### PR TITLE
Wrap summaries when printing cmd help ##newshell

### DIFF
--- a/librz/core/cmd.c
+++ b/librz/core/cmd.c
@@ -7170,7 +7170,7 @@ RZ_API void rz_core_cmd_init(RzCore *core) {
 		{ "~", "grep", NULL, NULL, &grep_help, NULL, RZ_CMD_DESC_TYPE_FAKE },
 	};
 
-	core->rcmd = rz_cmd_new ();
+	core->rcmd = rz_cmd_new (!!core->cons);
 	core->rcmd->macro.user = core;
 	core->rcmd->macro.num = core->num;
 	core->rcmd->macro.cmd = core_cmd0_wrapper;

--- a/librz/core/cmd_api.c
+++ b/librz/core/cmd_api.c
@@ -28,7 +28,7 @@
 #define MAX_CHILDREN_SHOW 7
 
 #define MIN_SUMMARY_WIDTH 6
-#define MAX_RIGHT_ALIGHNMENT 15
+#define MAX_RIGHT_ALIGHNMENT 20
 
 static const RzCmdDescHelp not_defined_help = {
 	.usage = "Usage not defined",

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -226,6 +226,12 @@ typedef struct rz_cmd_t {
 	HtUP *ts_symbols_ht;
 	RzCmdDesc *root_cmd_desc;
 	HtPP *ht_cmds;
+	/**
+	 * True if a rz_cons_instance exists. When used from RzCore this is
+	 * commonly true. However, it can be used in tests to avoid access to
+	 * non-initialized RzCons.
+	 */
+	bool has_cons;
 } RzCmd;
 
 // TODO: remove this once transitioned to RzCmdDesc
@@ -282,7 +288,7 @@ RZ_API int rz_core_plugin_add(RzCmd *cmd, RzCorePlugin *plugin);
 RZ_API int rz_core_plugin_check(RzCmd *cmd, const char *a0);
 RZ_API int rz_core_plugin_fini(RzCmd *cmd);
 
-RZ_API RzCmd *rz_cmd_new(void);
+RZ_API RzCmd *rz_cmd_new(bool has_cons);
 RZ_API RzCmd *rz_cmd_free(RzCmd *cmd);
 RZ_API int rz_cmd_set_data(RzCmd *cmd, void *data);
 RZ_API int rz_cmd_add(RzCmd *cmd, const char *command, RzCmdCb callback);

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -196,6 +196,7 @@ RZ_API char *rz_str_from_ut64(ut64 val);
 RZ_API void rz_str_stripLine(char *str, const char *key);
 RZ_API char *rz_str_list_join(RzList *str, const char *sep);
 RZ_API char *rz_str_array_join(const char **a, size_t n, const char *sep);
+RZ_API RzList *rz_str_wrap(char *str, size_t width);
 
 RZ_API const char *rz_str_sep(const char *base, const char *sep);
 RZ_API const char *rz_str_rsep(const char *base, const char *p, const char *sep);

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -3582,6 +3582,55 @@ RZ_API const char *rz_str_str_xy(const char *s, const char *word, const char *pr
 	return d;
 }
 
+/**
+ * Wrap the input string according to the provided width, so that (if possible),
+ * each line fits in \p width characters. Words will not be split across
+ * multiple lines. Words are consecutive characters separated by one or more
+ * space. Spaces at the beginning of \p string will be maintained, trailing
+ * whitespaces at the end of each split line is removed.
+ *
+ * @param string a writable string, it will be modified by the function
+ * @param width the maximum size of each line. It will be respected only if
+ *              possible, as the function won't split words.
+ */
+RZ_API RzList *rz_str_wrap(char *str, size_t width) {
+	rz_return_val_if_fail (str, NULL);
+
+	RzList *res = rz_list_new ();
+	char *p, *start_line = str;
+	char *first_space = NULL, *last_space = NULL;
+
+	p = (char *)rz_str_trim_head_ro (str);
+	if (!*p) {
+		return res;
+	}
+
+	do{
+		p++;
+		if (!*p || isspace (*p)) {
+			if (p != last_space + 1) {
+				if (p - start_line > width && first_space) {
+					rz_list_append (res, start_line);
+					*first_space = '\0';
+					start_line = last_space ? last_space + 1 : p;
+				}
+				first_space = p;
+			}
+			last_space = p;
+		}
+	} while (*p);
+	p--;
+	while (p >= str && isspace (*p)) {
+		*p = '\0';
+		p--;
+	}
+	if (p > start_line) {
+		rz_list_append (res, start_line);
+	}
+
+	return res;
+}
+
 // version.c
 #include <rz_userconf.h>
 #include <rz_util.h>

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -164,6 +164,7 @@ bool test_cmd_descriptor_group(void) {
 		"| a  # a exec help\n"
 		"| ab # ab help\n";
 	mu_assert_streq (h, exp_h, "regular help for a is a_group_help");
+	rz_cmd_parsed_args_free (pa);
 	free (h);
 
 	rz_cmd_free (cmd);

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -83,7 +83,7 @@ static RzCmdStatus afl_argv_handler(RzCore *core, int argc, const char **argv) {
 }
 
 bool test_cmd_descriptor_argv(void) {
-	RzCmd *cmd = rz_cmd_new ();
+	RzCmd *cmd = rz_cmd_new (false);
 	RzCmdDesc *root = rz_cmd_get_root (cmd);
 	RzCmdDesc *cd = rz_cmd_desc_argv_new (cmd, root, "afl", afl_argv_handler, NULL);
 	mu_assert_notnull (cd, "cmddesc created");
@@ -97,7 +97,7 @@ bool test_cmd_descriptor_argv(void) {
 }
 
 bool test_cmd_descriptor_argv_nested(void) {
-	RzCmd *cmd = rz_cmd_new ();
+	RzCmd *cmd = rz_cmd_new (false);
 	RzCmdDesc *root = rz_cmd_get_root (cmd);
 	RzCmdDesc *af_cd = rz_cmd_desc_group_new (cmd, root, "af", NULL, NULL, NULL);
 	rz_cmd_desc_argv_new (cmd, root, "af2", NULL, NULL);
@@ -113,7 +113,7 @@ static int a_oldinput_cb(void *user, const char *input) {
 }
 
 bool test_cmd_descriptor_oldinput(void) {
-	RzCmd *cmd = rz_cmd_new ();
+	RzCmd *cmd = rz_cmd_new (false);
 	RzCmdDesc *root = rz_cmd_get_root (cmd);
 	RzCmdDesc *cd = rz_cmd_desc_oldinput_new (cmd, root, "a", a_oldinput_cb, NULL);
 	mu_assert_notnull (cd, "cmddesc created");
@@ -138,7 +138,7 @@ bool test_cmd_descriptor_group(void) {
 	const RzCmdDescHelp a_exec_help = { .summary = "a exec help" };
 	const RzCmdDescHelp a_group_help = { .summary = "a group help" };
 
-	RzCmd *cmd = rz_cmd_new ();
+	RzCmd *cmd = rz_cmd_new (false);
 	RzCmdDesc *root = rz_cmd_get_root (cmd);
 	RzCmdDesc *cd = rz_cmd_desc_group_new (cmd, root, "a", a_exec_cb, &a_exec_help, &a_group_help);
 	rz_cmd_desc_argv_new (cmd, cd, "ab", ab_cb, &ab_help);
@@ -188,7 +188,7 @@ static int w_handler(void *user, const char *input) {
 }
 
 bool test_cmd_descriptor_tree(void) {
-	RzCmd *cmd = rz_cmd_new ();
+	RzCmd *cmd = rz_cmd_new (false);
 	RzCmdDesc *root = rz_cmd_get_root (cmd);
 	RzCmdDesc *a_cd = rz_cmd_desc_group_new (cmd, root, "a", NULL, NULL, NULL);
 	rz_cmd_desc_argv_new (cmd, a_cd, "ap", ap_handler, NULL);
@@ -205,7 +205,7 @@ bool test_cmd_descriptor_tree(void) {
 }
 
 bool test_cmd_get_desc(void) {
-	RzCmd *cmd = rz_cmd_new ();
+	RzCmd *cmd = rz_cmd_new (false);
 	RzCmdDesc *root = rz_cmd_get_root (cmd);
 	RzCmdDesc *a_cd = rz_cmd_desc_group_new (cmd, root, "a", NULL, NULL, NULL);
 	RzCmdDesc *ap_cd = rz_cmd_desc_group_new (cmd, a_cd, "ap", ap_handler, NULL, NULL);
@@ -262,7 +262,7 @@ static int q_handler(void *user, const char *input) {
 }
 
 bool test_cmd_call_desc(void) {
-	RzCmd *cmd = rz_cmd_new ();
+	RzCmd *cmd = rz_cmd_new (false);
 	RzCmdDesc *root = rz_cmd_get_root (cmd);
 	RzCmdDesc *p_cd = rz_cmd_desc_group_new (cmd, root, "p", NULL, NULL, NULL);
 	rz_cmd_desc_argv_new (cmd, p_cd, "pd", pd_handler, NULL);
@@ -329,7 +329,7 @@ bool test_cmd_help(void) {
 		.details = NULL,
 	};
 
-	RzCmd *cmd = rz_cmd_new ();
+	RzCmd *cmd = rz_cmd_new (false);
 	RzCmdDesc *root = rz_cmd_get_root (cmd);
 	RzCmdDesc *p_cd = rz_cmd_desc_group_new (cmd, root, "p", NULL, NULL, &p_group_help);
 	rz_cmd_desc_argv_new (cmd, p_cd, "pd", pd_handler, &pd_help);
@@ -395,7 +395,7 @@ bool test_cmd_group_help(void) {
 		.details = NULL,
 	};
 
-	RzCmd *cmd = rz_cmd_new ();
+	RzCmd *cmd = rz_cmd_new (false);
 	RzCmdDesc *root = rz_cmd_get_root (cmd);
 	RzCmdDesc *p_cd = rz_cmd_desc_group_new (cmd, root, "p", p_handler_argv, &p_help, &p_group_help);
 	rz_cmd_desc_argv_new (cmd, p_cd, "pd", pd_handler, &pd_help);
@@ -417,7 +417,7 @@ bool test_cmd_group_help(void) {
 bool test_cmd_oldinput_help(void) {
 	rz_cons_new ();
 
-	RzCmd *cmd = rz_cmd_new ();
+	RzCmd *cmd = rz_cmd_new (true);
 	RzCmdDesc *root = rz_cmd_get_root (cmd);
 	RzCmdDesc *p_cd = rz_cmd_desc_group_new (cmd, root, "p", NULL, NULL, NULL);
 	rz_cmd_desc_argv_new (cmd, p_cd, "pd", pd_handler, NULL);
@@ -437,7 +437,7 @@ bool test_cmd_oldinput_help(void) {
 }
 
 bool test_remove_cmd(void) {
-	RzCmd *cmd = rz_cmd_new ();
+	RzCmd *cmd = rz_cmd_new (false);
 	RzCmdDesc *root = rz_cmd_get_root (cmd);
 	RzCmdDesc *x_cd = rz_cmd_desc_argv_new (cmd, root, "x", NULL, NULL);
 	RzCmdDesc *p_cd = rz_cmd_desc_group_new (cmd, root, "p", NULL, NULL, NULL);

--- a/test/unit/test_str.c
+++ b/test/unit/test_str.c
@@ -470,6 +470,87 @@ bool test_rz_str_str_xy(void) {
 	mu_end;
 }
 
+static bool test_rz_str_wrap(void) {
+	size_t i;
+	RzListIter *it;
+	const char *ts;
+	RStrBuf sb;
+	rz_strbuf_init (&sb);
+
+	char s1[] = "This is a very long string we would like to wrap at around X characters. It should not split words.";
+	RzList *l1 = rz_str_wrap (s1, 15);
+	mu_assert_eq (rz_list_length (l1), 7, "s1 should be split in 7");
+	const char *exp_s1[] = {
+		"This is a very",
+		"long string we",
+		"would like to",
+		"wrap at around",
+		"X characters.",
+		"It should not",
+		"split words.",
+	};
+	i = 0;
+	rz_list_foreach (l1, it, ts) {
+		rz_strbuf_setf (&sb, "%d-th string should be the same", i);
+		mu_assert_streq (ts, exp_s1[i++], rz_strbuf_get (&sb));
+	}
+	rz_list_free (l1);
+
+	char s2[] = "   This is a very long string we would     like to wrap at around X characters. It should not split words.   ";
+	RzList *l2 = rz_str_wrap (s2, 40);
+	mu_assert_eq (rz_list_length (l2), 3, "s2 should be split in 3");
+	const char *exp_s2[] = {
+		"   This is a very long string we would",
+		"like to wrap at around X characters. It",
+		"should not split words.",
+	};
+	i = 0;
+	rz_list_foreach (l2, it, ts) {
+		rz_strbuf_setf (&sb, "%d-th string should be the same", i);
+		mu_assert_streq (ts, exp_s2[i++], rz_strbuf_get (&sb));
+	}
+	rz_list_free (l2);
+
+	char s3[] = "    ";
+	RzList *l3 = rz_str_wrap (s3, 40);
+	mu_assert_eq (rz_list_length (l3), 0, "l3 should be empty");
+	rz_list_free (l3);
+
+	char s4[] = "  Hello  ";
+	RzList *l4 = rz_str_wrap (s4, 20);
+	mu_assert_eq (rz_list_length (l4), 1, "l4 should contained only one word");
+	mu_assert_streq (rz_list_get_n (l4, 0), "  Hello", "s4 Hello string is there");
+	rz_list_free (l4);
+
+	char s5[] = "Hello   World   Small   ";
+	RzList *l5 = rz_str_wrap (s5, 3);
+	mu_assert_eq (rz_list_length (l5), 3, "just three lines in s5, even if bigger");
+	mu_assert_streq (rz_list_get_n (l5, 0), "Hello", "s5 Hello string is there");
+	mu_assert_streq (rz_list_get_n (l5, 1), "World", "s5 World string is there");
+	mu_assert_streq (rz_list_get_n (l5, 2), "Small", "s5 World string is there");
+	rz_list_free (l5);
+
+	char s6[] = "Write value of given size";
+	RzList *l6 = rz_str_wrap (s6, 7);
+	mu_assert_eq (rz_list_length (l6), 5, "5 elements in s6");
+	const char *exp_s6[] = {
+		"Write",
+		"value",
+		"of",
+		"given",
+		"size",
+	};
+	i = 0;
+	rz_list_foreach (l6, it, ts) {
+		rz_strbuf_setf (&sb, "%d-th string should be the same", i);
+		mu_assert_streq (ts, exp_s6[i++], rz_strbuf_get (&sb));
+	}
+	rz_list_free (l6);
+
+	rz_strbuf_fini (&sb);
+	mu_end;
+}
+
 bool all_tests () {
 	mu_run_test (test_rz_str_newf);
 	mu_run_test (test_rz_str_replace_char_once);
@@ -500,6 +581,7 @@ bool all_tests () {
 	mu_run_test (test_rz_str_constpool);
 	mu_run_test (test_rz_str_format_msvc_argv);
 	mu_run_test (test_rz_str_str_xy);
+	mu_run_test (test_rz_str_wrap);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 **Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

We may have long summaries(or small screens :D) and if you run `?` in those cases the summaries would go to a new line and they would make it hard to understand the help. This PR tries to improve the situation by wrapping the summary and printing it aligned.

By the way, if you prefer I can split things so that you can review the `rz_str_wrap` API separately from its usages. As you prefer.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Additional info**
Before:
![image](https://user-images.githubusercontent.com/562321/95726508-50bbe780-0c79-11eb-92d5-c2500648404a.png)
After:
![image](https://user-images.githubusercontent.com/562321/95726554-5dd8d680-0c79-11eb-96f3-7e994af76c10.png)
![image](https://user-images.githubusercontent.com/562321/95726604-69c49880-0c79-11eb-9377-08891d24d15f.png)
