### PR TITLE
Use cmd_descs_generate.py to update src dir and fallback if no PyYAML

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,20 @@
+name: "Mixed linter and checks"
+
+on:
+  push:
+  pull_request:
+  
+jobs:
+  cmd_descs_yaml_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install tools
+        run: sudo apt-get install yamllint python3-yaml
+      - name: Check YamlLint
+        run: |
+          yamllint -d "{rules: {line-length: {max: 120}}}" ./librz/core/cmd_descs.yaml
+      - name: Check sync between yaml and C/H files
+        run: |
+          ./librz/core/cmd_descs_generate.py --output-dir /tmp ./librz/core/cmd_descs.yaml
+          diff /tmp/cmd_descs.c ./librz/core/cmd_descs.c && diff /tmp/cmd_descs.h ./librz/core/cmd_descs.h

--- a/doc/newshell.md
+++ b/doc/newshell.md
@@ -132,12 +132,7 @@ static RzCmdStatus sky_handler(RzCore *core, int argc, const char **argv) {
 ```
 
 The YAML file is used at built-time (by meson only) to autogenerate two
-files: `cmd_descs.c` and `cmd_descs.h`. To make sure the Make build system
-still works, update the committed versions of these files with the following
-command:
-```
-$ ./librz/core/cmd_descs_generate.py --output-dir ./librz/core/ ./librz/core/cmd_descs.yaml
-```
+files: `cmd_descs.c` and `cmd_descs.h`.
 
 ## Where is the handler of command `x`?
 
@@ -158,12 +153,7 @@ Some examples:
 
 Find the command in
 [`librz/core/cmd_descs.yaml`](https://github.com/rizinorg/rizin/blob/9ce5003ca647cdfc181ac3c0f6206762ebb9e3e9/librz/core/cmd_descs.yaml),
-then fix/improve the `summary` and/or `description` fields. Once you have
-done that, make sure to test your changes are effective by compiling as usual
-and then run:
-```
-$ ./librz/core/cmd_descs_generate.py --output-dir ./librz/core/ ./librz/core/cmd_descs.yaml
-```
+then fix/improve the `summary` and/or `description` fields.
 
 ## How to show examples of a command or additional details
 

--- a/librz/core/cmd_descs_generate.py
+++ b/librz/core/cmd_descs_generate.py
@@ -508,6 +508,7 @@ def handler2decl(type, handler_name):
 
 
 parser = argparse.ArgumentParser(description='Generate .c/.h files from Command Descriptors YAML file.')
+parser.add_argument('--src-output-dir', type=str, required=False, help='Source output directory')
 parser.add_argument('--output-dir', type=str, required=False, help='Output directory')
 parser.add_argument('yaml_file', type=argparse.FileType("r"), help='Input YAML file containing all commands descriptions')
 
@@ -522,20 +523,18 @@ detail_decls = [detail2decl(cd) for cd in CmdDesc.c_details.values()]
 helps = [str(cd) for cd in root_cds]
 init_code = [createcd(cd) for cd in root_cds]
 
-cf = open(os.path.join(args.output_dir, 'cmd_descs.c'), 'w')
 cf_text = CMDDESCS_C_TEMPLATE.format(
     helps_declarations='\n'.join(detail_decls + arg_decls),
     helps='\n'.join(helps),
     init_code='\n'.join(init_code),
 )
-cf.write(cf_text)
-cf.close()
+open(os.path.join(args.output_dir, 'cmd_descs.c'), 'w').write(cf_text)
+open(os.path.join(args.src_output_dir, 'cmd_descs.c'), 'w').write(cf_text)
 
 handlers_decls = filter(lambda th: th[1] is not None, [(cd.type, cd.get_handler_cname()) for cd in CmdDesc.c_cds.values()])
 
-hf = open(os.path.join(args.output_dir, 'cmd_descs.h'), 'w')
 hf_text = CMDDESCS_H_TEMPLATE.format(
     handlers_declarations='\n'.join([handler2decl(t, h) for t, h in handlers_decls]),
 )
-hf.write(hf_text)
-hf.close()
+open(os.path.join(args.output_dir, 'cmd_descs.h'), 'w').write(hf_text)
+open(os.path.join(args.src_output_dir, 'cmd_descs.h'), 'w').write(hf_text)

--- a/librz/core/cmd_descs_generate.py
+++ b/librz/core/cmd_descs_generate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import os
@@ -509,7 +509,7 @@ def handler2decl(type, handler_name):
 
 parser = argparse.ArgumentParser(description='Generate .c/.h files from Command Descriptors YAML file.')
 parser.add_argument('--src-output-dir', type=str, required=False, help='Source output directory')
-parser.add_argument('--output-dir', type=str, required=False, help='Output directory')
+parser.add_argument('--output-dir', type=str, required=True, help='Output directory')
 parser.add_argument('yaml_file', type=argparse.FileType("r"), help='Input YAML file containing all commands descriptions')
 
 args = parser.parse_args()
@@ -529,7 +529,8 @@ cf_text = CMDDESCS_C_TEMPLATE.format(
     init_code='\n'.join(init_code),
 )
 open(os.path.join(args.output_dir, 'cmd_descs.c'), 'w').write(cf_text)
-open(os.path.join(args.src_output_dir, 'cmd_descs.c'), 'w').write(cf_text)
+if args.src_output_dir:
+    open(os.path.join(args.src_output_dir, 'cmd_descs.c'), 'w').write(cf_text)
 
 handlers_decls = filter(lambda th: th[1] is not None, [(cd.type, cd.get_handler_cname()) for cd in CmdDesc.c_cds.values()])
 
@@ -537,4 +538,5 @@ hf_text = CMDDESCS_H_TEMPLATE.format(
     handlers_declarations='\n'.join([handler2decl(t, h) for t, h in handlers_decls]),
 )
 open(os.path.join(args.output_dir, 'cmd_descs.h'), 'w').write(hf_text)
-open(os.path.join(args.src_output_dir, 'cmd_descs.h'), 'w').write(hf_text)
+if args.src_output_dir:
+    open(os.path.join(args.src_output_dir, 'cmd_descs.h'), 'w').write(hf_text)

--- a/librz/core/meson.build
+++ b/librz/core/meson.build
@@ -1,11 +1,19 @@
 cmd_descs_generate_py = files('cmd_descs_generate.py')
 cmd_descs_yaml = files('cmd_descs.yaml')
-cmd_descs_c = custom_target(
-  'cmd_descs.c',
-  output: ['cmd_descs.c', 'cmd_descs.h'],
-  input: [cmd_descs_generate_py, cmd_descs_yaml],
-  command: [py3_exe, cmd_descs_generate_py, '--output-dir', meson.current_build_dir(), cmd_descs_yaml]
-)
+cmd_descs_src_c = files('cmd_descs.c')
+
+r = run_command(py3_exe, '-c', 'import yaml')
+if r.returncode() == 0
+  cmd_descs_c = custom_target(
+    'cmd_descs.c',
+    output: ['cmd_descs.c'],
+    input: [cmd_descs_generate_py, cmd_descs_yaml],
+    command: [py3_exe, cmd_descs_generate_py, '--output-dir', '@OUTDIR@', '--src-output-dir', meson.current_source_dir(), cmd_descs_yaml]
+  )
+else
+  warning('PyYAML python module was not found, using cmd_descs.c/cmd_descs.h from source directory. Install PyYAML (either from your package manager or through pip) if you need to modify cmd_descs files.')
+  cmd_descs_c = cmd_descs_src_c
+endif
 
 rz_core_sources = [
   'anal_tp.c',


### PR DESCRIPTION
People with no PyYAML can still build everything, but they won't be able to update commands, of course. Also, the files in the src directory are automatically updated when you build with meson.

@thestr4ng3r I think this is a good tradeoff.