### PR TITLE
Single vs double quotes windows

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -86,11 +86,11 @@ want this behaviour and you know what you are doing, you can still use
 
 ## Windows
 
-The building steps on Windows are the same as on *NIX systems, however you
-will have to run the following commands from the Visual Studio Developer
-shell (search for "x64 Native Tools Command Prompt for VS 2019" or similar).
-To install Meson on Windows, follow instructions
-[here](https://mesonbuild.com/Getting-meson.html).
+The building steps on Windows are the same as on *NIX systems, however you will
+have to run the following commands from the Command Prompt for Visual Studio
+(e.g. "x64 Native Tools Command Prompt for VS 2019" for 64bit builds, "x86
+Native Tools Command Prompt for VS 2019" for 32bit builds). To install Meson on
+Windows, follow instructions [here](https://mesonbuild.com/Getting-meson.html).
 
 ```
 $ meson --prefix=%CD%\rizin-install build

--- a/librz/core/cmd_api.c
+++ b/librz/core/cmd_api.c
@@ -34,10 +34,10 @@
 //       rizin-shell-parser grammar, except for ", ' and
 //       whitespaces, because we let cmd_substitution_arg create
 //       new arguments
-static const char *SPECIAL_CHARS_REGULAR = "@;~$#|`\"'()<>";
-static const char *SPECIAL_CHARS_REGULAR_SINGLE = "@;~$#|`\"'()<> ";
-static const char *SPECIAL_CHARS_PF = "@;~$#|`\"'<>";
-static const char *SPECIAL_CHARS_DOUBLE_QUOTED = "\"$()`";
+static const char *SPECIAL_CHARS_REGULAR = "@;~$#|`\"'()<>\\";
+static const char *SPECIAL_CHARS_REGULAR_SINGLE = "@;~$#|`\"'()<>\\ ";
+static const char *SPECIAL_CHARS_PF = "@;~$#|`\"'<>\\";
+static const char *SPECIAL_CHARS_DOUBLE_QUOTED = "\"$()`\\";
 static const char *SPECIAL_CHARS_SINGLE_QUOTED = "'";
 
 static const RzCmdDescHelp not_defined_help = {

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -1186,8 +1186,7 @@ RZ_API int rz_str_unescape(char *buf) {
 				}
 				esc_seq_len = 1 + num_digits;
 			} else {
-				eprintf ("Error: Unknown escape sequence.\n");
-				return 0; // -1?
+				continue;
 			}
 		}
 		memmove (buf + i + 1, buf + i + esc_seq_len, strlen (buf + i + esc_seq_len) + 1);

--- a/test/db/cmd/cmd_pf
+++ b/test/db/cmd/cmd_pf
@@ -880,7 +880,7 @@ RUN
 NAME=pf z, scr.strconv and str.escbslash
 FILE=-
 CMDS=<<EOF
-wz \x7fabc\\123\n
+wz \x7fabc\\\123\n
 (print strconv escbslash; e scr.strconv=$0; e str.escbslash=$1; pf z)
 .(print asciiesc false)
 .(print asciiesc true)

--- a/test/db/cmd/write
+++ b/test/db/cmd/write
@@ -439,7 +439,7 @@ NAME=wz esc seqs
 FILE=-
 CMDS=<<EOF
 e str.escbslash=true
-wz \a\b\t\n\v\f\r\e\\\x40\7\15\176
+wz \a\b\t\n\v\f\r\e\\\\\x40\7\15\176
 izz~0x0
 px 16~0x0
 EOF

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -133,7 +133,7 @@ RUN
 NAME=rz-asm #1167 5
 BROKEN=1
 FILE=-
-CMDS=!rz-asm -s att -a x86.as -b 64 'add $33, %rbx'
+CMDS=!rz-asm -s att -a x86.as -b 64 "add \\$33, %rbx"
 EXPECT=<<EOF
 4883c321
 EOF

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -131,9 +131,8 @@ EOF
 RUN
 
 NAME=rz-asm #1167 5
-BROKEN=1
 FILE=-
-CMDS=!rz-asm -s att -a x86.as -b 64 "add \\$33, %rbx"
+CMDS=!rz-asm -s att -a x86.as -b 64 "add $33, %rbx"
 EXPECT=<<EOF
 4883c321
 EOF

--- a/test/db/tools/rz_bin
+++ b/test/db/tools/rz_bin
@@ -1054,18 +1054,16 @@ EOF
 RUN
 
 NAME=rz-bin rust static type
-BROKEN=1
 FILE=-
-CMDS=!rz-bin -D rust '_ZN71_$LT$Test$u20$$u2b$$u20$$u27$static$u20$as$u20$foo..Bar$LT$Test$GT$$GT$3barE'
+CMDS=!rz-bin -D rust _ZN71_$LT$Test$u20$$u2b$$u20$$u27$static$u20$as$u20$foo..Bar$LT$Test$GT$$GT$3barE
 EXPECT=<<EOF
 <Test + 'static as foo::Bar<Test>>::bar
 EOF
 RUN
 
 NAME=rz-bin rust static type with hash
-BROKEN=1
 FILE=-
-CMDS=!rz-bin -D rust '_ZN96_$LT$core..fmt..Write..write_fmt..Adapter$LT$$u27$a$C$$u20$T$GT$$u20$as$u20$core..fmt..Write$GT$9write_str17he4f4768a2f446facE'
+CMDS=!rz-bin -D rust _ZN96_$LT$core..fmt..Write..write_fmt..Adapter$LT$$u27$a$C$$u20$T$GT$$u20$as$u20$core..fmt..Write$GT$9write_str17he4f4768a2f446facE
 EXPECT=<<EOF
 <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str::he4f4768a2f446fac
 EOF

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -645,6 +645,7 @@ bool test_arg_escaping(void) {
 	mu_assert_streq_free (rz_cmd_escape_arg ("hello\"world\"", RZ_CMD_ESCAPE_ONE_ARG), "hello\\\"world\\\"", "\" is escaped");
 	mu_assert_streq_free (rz_cmd_escape_arg ("hello>world", RZ_CMD_ESCAPE_ONE_ARG), "hello\\>world", "> is escaped");
 	mu_assert_streq_free (rz_cmd_escape_arg ("hello|world", RZ_CMD_ESCAPE_ONE_ARG), "hello\\|world", "| is escaped");
+	mu_assert_streq_free (rz_cmd_escape_arg ("hello\\world", RZ_CMD_ESCAPE_ONE_ARG), "hello\\\\world", "\\ is escaped");
 
 	mu_assert_streq_free (rz_cmd_unescape_arg ("hello", RZ_CMD_ESCAPE_ONE_ARG), "hello", "regular string remains the same");
 	mu_assert_streq_free (rz_cmd_unescape_arg ("hello\\ world", RZ_CMD_ESCAPE_ONE_ARG), "hello world", "spaces are unescaped");
@@ -653,6 +654,7 @@ bool test_arg_escaping(void) {
 	mu_assert_streq_free (rz_cmd_unescape_arg ("hello\\\"world\\\"", RZ_CMD_ESCAPE_ONE_ARG), "hello\"world\"", "\" is unescaped");
 	mu_assert_streq_free (rz_cmd_unescape_arg ("hello\\>world", RZ_CMD_ESCAPE_ONE_ARG), "hello>world", "> is unescaped");
 	mu_assert_streq_free (rz_cmd_unescape_arg ("hello\\|world", RZ_CMD_ESCAPE_ONE_ARG), "hello|world", "| is unescaped");
+	mu_assert_streq_free (rz_cmd_unescape_arg ("hello\\\\world", RZ_CMD_ESCAPE_ONE_ARG), "hello\\world", "\\ is unescaped");
 
 	mu_assert_streq_free (rz_cmd_escape_arg ("hello `world`", RZ_CMD_ESCAPE_MULTI_ARG), "hello \\`world\\`", "` is escaped");
 	mu_end;
@@ -668,6 +670,7 @@ bool test_double_quoted_arg_escaping(void) {
 	mu_assert_streq_free (rz_cmd_escape_arg ("hello@world", RZ_CMD_ESCAPE_DOUBLE_QUOTED_ARG), "hello@world", "@ is not escaped");
 	mu_assert_streq_free (rz_cmd_escape_arg ("hello $(world)", RZ_CMD_ESCAPE_DOUBLE_QUOTED_ARG), "hello \\$\\(world\\)", "$ is escaped");
 	mu_assert_streq_free (rz_cmd_escape_arg ("hello `world`", RZ_CMD_ESCAPE_DOUBLE_QUOTED_ARG), "hello \\`world\\`", "` is escaped");
+	mu_assert_streq_free (rz_cmd_escape_arg ("hello\\world", RZ_CMD_ESCAPE_DOUBLE_QUOTED_ARG), "hello\\\\world", "\\ is escaped");
 
 	mu_assert_streq_free (rz_cmd_unescape_arg ("hello", RZ_CMD_ESCAPE_DOUBLE_QUOTED_ARG), "hello", "regular string remains the same");
 	mu_assert_streq_free (rz_cmd_unescape_arg ("hello world", RZ_CMD_ESCAPE_DOUBLE_QUOTED_ARG), "hello world", "spaces are not escaped");
@@ -675,6 +678,8 @@ bool test_double_quoted_arg_escaping(void) {
 	mu_assert_streq_free (rz_cmd_unescape_arg ("hello\\'world\\'", RZ_CMD_ESCAPE_DOUBLE_QUOTED_ARG), "hello\\'world\\'", "' is not unescaped");
 	mu_assert_streq_free (rz_cmd_unescape_arg ("hello \\$\\(world\\)", RZ_CMD_ESCAPE_DOUBLE_QUOTED_ARG), "hello $(world)", "$ is unescaped");
 	mu_assert_streq_free (rz_cmd_unescape_arg ("hello \\`world\\`", RZ_CMD_ESCAPE_DOUBLE_QUOTED_ARG), "hello `world`", "` is unescaped");
+	mu_assert_streq_free (rz_cmd_unescape_arg ("hello\\\\world", RZ_CMD_ESCAPE_DOUBLE_QUOTED_ARG), "hello\\world", "\\ is unescaped");
+	mu_assert_streq_free (rz_cmd_unescape_arg ("hello\\y world", RZ_CMD_ESCAPE_DOUBLE_QUOTED_ARG), "hello\\y world", "\\y is not unescaped");
 	mu_end;
 }
 
@@ -686,6 +691,7 @@ bool test_single_quoted_arg_escaping(void) {
 	mu_assert_streq_free (rz_cmd_escape_arg ("hello|@>world", RZ_CMD_ESCAPE_SINGLE_QUOTED_ARG), "hello|@>world", "|@> are not escaped");
 	mu_assert_streq_free (rz_cmd_escape_arg ("hello $(world)", RZ_CMD_ESCAPE_SINGLE_QUOTED_ARG), "hello $(world)", "$ is not escaped");
 	mu_assert_streq_free (rz_cmd_escape_arg ("hello `world`", RZ_CMD_ESCAPE_SINGLE_QUOTED_ARG), "hello `world`", "` is not escaped");
+	mu_assert_streq_free (rz_cmd_escape_arg ("hello\\world", RZ_CMD_ESCAPE_SINGLE_QUOTED_ARG), "hello\\world", "\\ is not escaped");
 
 	mu_assert_streq_free (rz_cmd_unescape_arg ("hello", RZ_CMD_ESCAPE_SINGLE_QUOTED_ARG), "hello", "regular string remains the same");
 	mu_assert_streq_free (rz_cmd_unescape_arg ("hello world", RZ_CMD_ESCAPE_SINGLE_QUOTED_ARG), "hello world", "spaces are not escaped");
@@ -693,6 +699,7 @@ bool test_single_quoted_arg_escaping(void) {
 	mu_assert_streq_free (rz_cmd_unescape_arg ("hello\\'world\\'", RZ_CMD_ESCAPE_SINGLE_QUOTED_ARG), "hello'world'", "' is unescaped");
 	mu_assert_streq_free (rz_cmd_unescape_arg ("hello \\$\\(world\\)", RZ_CMD_ESCAPE_SINGLE_QUOTED_ARG), "hello \\$\\(world\\)", "$ is not unescaped");
 	mu_assert_streq_free (rz_cmd_unescape_arg ("hello \\`world\\`", RZ_CMD_ESCAPE_SINGLE_QUOTED_ARG), "hello \\`world\\`", "` is not unescaped");
+	mu_assert_streq_free (rz_cmd_unescape_arg ("hello\\\\world", RZ_CMD_ESCAPE_SINGLE_QUOTED_ARG), "hello\\\\world", "\\ is not escaped");
 	mu_end;
 }
 


### PR DESCRIPTION
@thestr4ng3r this should fix the recent issues in appveyor.
The double escape is required because one we actually want to pass `\` to the system shell (because everything after `!` is interpreted as a string to pass to `system(3)` and because the shell should not consider `$aaaa` as the variable named `aaaa`).

```
[XX] C:\projects\rizin\test\db\tools\rz_asm rz-asm #1167 5
ANSICON=1 RZ_NOPLUGINS=1 rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -Qc '!rz-asm -s att -a x86.as -b 64 'add $33, %rbx'' -
-- stdout
@@ -1 +0,0 @@
-4883c321
-- stderr
C:\Users\appveyor\AppData\Local\Temp\1\rz_A364.tmp: Assembler messages:
C:\Users\appveyor\AppData\Local\Temp\1\rz_A364.tmp:4: Error: junk at end of line, first unrecognized character is `9'
Error running: as  C:\Users\appveyor\AppData\Local\Temp\1\rz_A364.tmp -o C:\Users\appveyor\AppData\Local\Temp\1\rz_A365.tmpC:\Users\appveyor\AppData\Local\Temp\1\rz_A49F.tmp: Assembler messages:
C:\Users\appveyor\AppData\Local\Temp\1\rz_A49F.tmp:4: Error: junk at end of line, first unrecognized character is `9'
Error running: as  C:\Users\appveyor\AppData\Local\Temp\1\rz_A49F.tmp -o C:\Users\appveyor\AppData\Local\Temp\1\rz_A4A0.tmpC:\Users\appveyor\AppData\Local\Temp\1\rz_A5D9.tmp: Assembler messages:
C:\Users\appveyor\AppData\Local\Temp\1\rz_A5D9.tmp:4: Error: junk at end of line, first unrecognized character is `9'
Error running: as  C:\Users\appveyor\AppData\Local\Temp\1\rz_A5D9.tmp -o C:\Users\appveyor\AppData\Local\Temp\1\rz_A5DA.tmpCannot assemble ''add' at line 3
invalid
[**]    
[XX] C:\projects\rizin\test\db\formats\mangling\rust rust static type
ANSICON=1 RZ_NOPLUGINS=1 rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -Qc '!rz-bin -D rust '_ZN71_$LT$Test$u20$$u2b$$u20$$u27$static$u20$as$u20$foo..Bar$LT$Test$GT$$GT$3barE'' -
-- stdout
@@ -1 +1 @@
-<Test + 'static as foo::Bar<Test>>::bar
+'_ZN71_$LT$Test$u20$$u2b$$u20$$u27$static$u20$as$u20$foo..Bar$LT$Test$GT$$GT$3barE'
[XX] C:\projects\rizin\test\db\formats\mangling\rust rust static type with hash
ANSICON=1 RZ_NOPLUGINS=1 rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -Qc '!rz-bin -D rust '_ZN96_$LT$core..fmt..Write..write_fmt..Adapter$LT$$u27$a$C$$u20$T$GT$$u20$as$u20$core..fmt..Write$GT$9write_str17he4f4768a2f446facE'' -
-- stdout
@@ -1 +1 @@
-<core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str::he4f4768a2f446fac
+'_ZN96_$LT$core..fmt..Write..write_fmt..Adapter$LT$$u27$a$C$$u20$T$GT$$u20$as$u20$core..fmt..Write$GT$9write_str17he4f4768a2f446facE'
```