### PR TITLE
Download submodules in appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,7 @@ skip_tags: true
 branches:
   only:
     - dev
+    - /.*-windows-.*/
 
 # Environment variables
 environment:
@@ -64,6 +65,8 @@ init:
 
 # Required software for building
 install:
+  # Download submodules
+  - ps: git submodule update --init --recursive
   # Update environment variables
   - ps: $env:RZ_VERSION = ( python sys\\version.py )
   - ps: $env:DIST_FOLDER = "rizin-$env:builder-$env:RZ_VERSION"


### PR DESCRIPTION
It should fix https://ci.appveyor.com/project/rizinorg/rizin/builds/36726589 hopefully. Also, I hope to enable appveyor for PR that has "windows" in the name.