### PR TITLE
Fix **environ symbol not found on FreeBSD

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -19,7 +19,7 @@ tasks:
         sudo python3 -m pip install 'git+https://github.com/rizinorg/rz-pipe#egg=rzpipe&subdirectory=python'
     - build: |
         cd rizin
-        meson --prefix=${HOME} build
+        meson -Db_lundef=false --prefix=${HOME} build
         ninja -C build
     - install: |
         cd rizin


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**

Trying to fix FreeBSD SourceHut CI according to this report https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1306#note_688915