### PR TITLE
Restore previous fd after tmp change statements (e.g. @x:, etc.)

### DIFF
--- a/librz/core/cmd.c
+++ b/librz/core/cmd.c
@@ -5132,6 +5132,7 @@ static bool handle_tmp_desc(struct tsr2cmd_state *state, TSNode command, const u
 	int pamode = !core->io->va;
 	RzCmdStatus res = RZ_CMD_STATUS_INVALID, o_fixedblock = core->fixedblock;
 	RzBuffer *b = rz_buf_new_with_bytes (buf, sz);
+	int cur_fd = rz_io_fd_get_current (core->io);
 	RzIODesc *d = rz_io_open_buffer (core->io, b, RZ_PERM_RWX, 0);
 	if (!d) {
 		eprintf ("Cannot open io buffer\n");
@@ -5154,6 +5155,7 @@ static bool handle_tmp_desc(struct tsr2cmd_state *state, TSNode command, const u
 	}
 	rz_io_desc_close (d);
 	rz_core_block_size (core, obsz);
+	rz_io_use_fd (core->io, cur_fd);
 
 out_buf:
 	rz_buf_free (b);

--- a/test/db/archos/linux-x64/dbg
+++ b/test/db/archos/linux-x64/dbg
@@ -8,3 +8,19 @@ pop esi
 mov ecx, esp
 EOF
 RUN
+
+NAME=restore fd
+FILE=bins/elf/analysis/pie
+ARGS=-d
+CMDS=<<EOF
+s main
+p8 8
+p8 8 @v:0xdeadbeef
+p8 8
+EOF
+EXPECT=<<EOF
+5589e5cc5dc36690
+efbeadde5dc36690
+5589e5cc5dc36690
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The added tests explains the problem. While debugging, temporary changes like `@x:`, `@v:`, etc. were not switching back to the previous file descriptor, so the user could not see the original file after using one of those `@` commands.