### PR TITLE
Use RPATH when the prefix is not the standard /usr

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -38,11 +38,12 @@ $ ninja -C build # or `meson compile -C build`
 $ sudo ninja -C build install # or `meson install -C build`
 ```
 
-As not all systems look for libraries in `/usr/local` subdirectories, you may
-have to set `LD_LIBRARY_PATH` to the proper path (e.g. `/usr/local/lib64` or
-`/usr/local/lib`). Otherwise, if you don't want to change your `LD_LIBRARY_PATH`
-you can use `meson -Dlocal=true build` in the first step to use `RPATH` and make
-sure the rizin binary can find its libraries by itself.
+NOTE: when `--prefix=/usr` is not used, meson will set `RPATH` to ensure that
+libraries can be found on the system without having to deal with
+`LD_LIBRARY_PATH` or ld settings. This is done to ensure a simple
+installation process out-of-the-box, but if you don't want this behaviour and
+you know what you are doing, you can still use `-Dlocal=disabled` to avoid
+using `RPATH`.
 
 ### Build system-wide, in `/usr`
 
@@ -57,8 +58,9 @@ $ ninja -C build
 $ sudo ninja -C build install
 ```
 
-This kind of installation usually does not require any change to
-`LD_LIBRARY_PATH` and it should work out of the box.
+This kind of installation is not recommended if your system provides Rizin as
+a package or if you don't want to mess with software provided by your
+distribution.
 
 
 ### Build user-wide, in `~/.local`
@@ -74,10 +76,13 @@ $ ninja -C build install
 ```
 
 The `install` step will install rizin in `~/.local/bin`, so make sure to add it
-to your `PATH` variable. As most systems don't look for libraries in
-`~/.local/lib`/`~/.local/lib64`, you will have to set `LD_LIBRARY_PATH`
-accordingly or, if you prefer, use `meson -Dlocal=true --prefix=~/.local build`
-instead of just `meson --prefix=~/.local build`.
+to your `PATH` variable (e.g. `export PATH=$PATH:~/.local/bin`).
+
+NOTE: meson will set `RPATH` to ensure that libraries can be found on the
+system without having to deal with `LD_LIBRARY_PATH` or ld settings. This is
+done to ensure a simple installation process out-of-the-box, but if you don't
+want this behaviour and you know what you are doing, you can still use
+`-Dlocal=disabled` to avoid using `RPATH`.
 
 ## Windows
 
@@ -85,17 +90,16 @@ The building steps on Windows are the same as on *NIX systems, however you will
 have to run the following commands from the Visual Studio Developer Powershell
 (on Visual Studio Community 2019 you can find it under Tools > Command Line >
 Developer Powershell). To install Meson on Windows, follow instructions
-[here](https://mesonbuild.com/Getting-meson.html). We also suggest to compile
-Rizin statically, to avoid dealing with libraries when running the Rizin
-binaries.
+[here](https://mesonbuild.com/Getting-meson.html).
 
 ```
-$ meson --prefix=$PWD\rizin-install --default-library=static -Dstatic_runtime=true build
+$ meson --prefix=%CD%\rizin-install build
 $ ninja -C build
 $ ninja -C build install
 ```
 
-You can run rizin from `$PWD\rizin-install\bin`.
+You can run rizin from `%CD%\rizin-install\bin`. If you don't specify any
+`--prefix`, meson will install rizin directly under `C:\`.
 
 ## Build with ASAN/UBSAN
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,6 @@ Usage: rizin [-ACdfLMnNqStuvwzX] [-P patch] [-p prj] [-a arch] [-b bits] [-i fil
              [-s addr] [-B baddr] [-m maddr] [-c cmd] [-e k=v] file|pid|-|--|=
 ```
 
-NOTE: You may have to add `LD_LIBRARY_PATH=/usr/local/lib64` or
-`LD_LIBRARY_PATH=/usr/local/lib` based on your system to make sure rizin will
-find the installed libraries.
-
 Please have a look at [BUILDING.md][] for more information about building Rizin.
 
 # Contributing

--- a/meson.build
+++ b/meson.build
@@ -562,9 +562,17 @@ if get_option('b_sanitize').contains('undefined')
   pkgcfg_sanitize_libs += ' -lubsan'
 endif
 
+use_rpath = false
+if host_machine.system() != 'windows' and get_option('default_library') == 'shared'
+  if get_option('local').enabled() or (get_option('local').auto() and get_option('prefix') != '/usr')
+    use_rpath = true
+  endif
+endif
+
 rpath_exe = ''
 rpath_lib = ''
-if get_option('local') and get_option('default_library') == 'shared'
+if use_rpath
+  message('RPATH will be used to link libraries and executables')
   rpath_exe = '$ORIGIN/../' + get_option('libdir')
   rpath_lib = '$ORIGIN'
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,6 @@
 option('cli', type: 'feature', value: 'auto', description: 'Build CLI programs (“auto” means they will be built when not a subproject)')
 option('static_runtime', type: 'boolean', value: false)
-option('local', type: 'boolean', value: false, description: 'Adds support for local/side-by-side installation (sets rpath if needed)')
+option('local', type: 'feature', value: 'auto', description: 'Adds support for local/side-by-side installation (sets rpath if needed)')
 option('blob', type: 'boolean', value: false, description: 'Compile just one binary which dispatch to the right handlers based on the name used to call it')
 
 # For Windows


### PR DESCRIPTION
This is to make it easier for people to install rizin without dealing
with LD_LIBRARY_PATH, while at the same time avoiding RPATH when things
are installed in the system-wide path (for most systems, at least). In
any case, people can disable this behaviour by using `-Dlocal=disabled`.