### PR TITLE
Use x64 when building windows binaries in ci.yml

### DIFF
--- a/.github/vsdevenv.ps1
+++ b/.github/vsdevenv.ps1
@@ -1,7 +1,9 @@
 $installationPath = vswhere.exe -latest -property installationPath
-if ($installationPath -and (test-path "$installationPath\Common7\Tools\vsdevcmd.bat")) {
-  & "${env:COMSPEC}" /s /c "`"$installationPath\Common7\Tools\vsdevcmd.bat`" -no_logo && set" | foreach-object {
-    $name, $value = $_ -split '=', 2
-    set-content env:\"$name" $value
-  }
+if (-not $installationPath -or -not (test-path "$installationPath\VC\Auxiliary\Build\vcvars64.bat")) {
+  throw "vcvars64.bat file not found"
 }
+& "${env:COMSPEC}" /s /c "`"$installationPath\VC\Auxiliary\Build\vcvars64.bat`" > nul 2>&1 && set" | . { process {
+  if ($_ -match '^([^=]+)=(.*)') {
+    [System.Environment]::SetEnvironmentVariable($matches[1], $matches[2])
+  }
+}}

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -81,10 +81,10 @@ instead of just `meson --prefix=~/.local build`.
 
 ## Windows
 
-The building steps on Windows are the same as on *NIX systems, however you will
-have to run the following commands from the Visual Studio Developer Powershell
-(on Visual Studio Community 2019 you can find it under Tools > Command Line >
-Developer Powershell). To install Meson on Windows, follow instructions
+The building steps on Windows are the same as on *NIX systems, however you
+will have to run the following commands from the Visual Studio Developer
+shell (search for "x64 Native Tools Command Prompt for VS 2019" or similar).
+To install Meson on Windows, follow instructions
 [here](https://mesonbuild.com/Getting-meson.html). We also suggest to compile
 Rizin statically, to avoid dealing with libraries when running the Rizin
 binaries.


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

In radare2 we noticed that ci.yml was building 32bit binaries. That's because I made a mistake and it was taking variables for the x86 environment. This PR should fix it and also the documentation, to suggest using the x64 environment.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
Fix https://github.com/rizinorg/rizin/issues/112