### PR TITLE
Reduce Coupling between RzCore and Tasks ##core

### DIFF
--- a/librz/cons/cons.c
+++ b/librz/cons/cons.c
@@ -829,7 +829,7 @@ RZ_API bool rz_cons_context_is_main(void) {
 
 RZ_API void rz_cons_context_break(RzConsContext *context) {
 	if (!context) {
-		return;
+		context = &rz_cons_context_default;
 	}
 	context->breaked = true;
 	if (context->event_interrupt) {

--- a/librz/core/cmd.c
+++ b/librz/core/cmd.c
@@ -6503,21 +6503,6 @@ RZ_API char *rz_core_cmd_str(RzCore *core, const char *cmd) {
 	return retstr;
 }
 
-/* run cmd in the main task synchronously */
-RZ_API int rz_core_cmd_task_sync(RzCore *core, const char *cmd, bool log) {
-	RzCoreTask *task = core->tasks.main_task;
-	char *s = strdup (cmd);
-	if (!s) {
-		return 0;
-	}
-	task->cmd = s;
-	task->cmd_log = log;
-	task->state = RZ_CORE_TASK_STATE_BEFORE_START;
-	int res = rz_core_task_run_sync (&core->tasks, task);
-	free (s);
-	return res;
-}
-
 RZ_IPI int rz_cmd_ox(void *data, const char *input) {
 	return rz_core_cmdf ((RzCore*)data, "s 0%s", input);
 }

--- a/librz/core/cmd.c
+++ b/librz/core/cmd.c
@@ -1668,7 +1668,7 @@ RZ_IPI int rz_cmd_tasks(void *data, const char *input) {
 			return 0;
 		}
 		if (input[1] == '*') {
-			rz_core_task_del_all_done (&core->tasks);
+			rz_core_task_del_all_done (core);
 		} else {
 			rz_core_task_del (&core->tasks, rz_num_math (core->num, input + 1));
 		}

--- a/librz/core/cmd_tasks.c
+++ b/librz/core/cmd_tasks.c
@@ -5,6 +5,10 @@
 #include "cmd_descs.h"
 
 static int task_enqueue(RzCore *core, const char *cmd, bool transient) {
+	if (rz_sandbox_enable (0)) {
+		eprintf ("This command is disabled in sandbox mode\n");
+		return -1;
+	}
 	RzCoreTask *task = rz_core_cmd_task_new (core, true, cmd);
 	if (!task) {
 		return -1;
@@ -33,6 +37,10 @@ static int task_output(RzCore *core, int tid) {
 }
 
 static int task_break(RzCore *core, int tid) {
+	if (rz_sandbox_enable (0)) {
+		eprintf ("This command is disabled in sandbox mode\n");
+		return -1;
+	}
 	if (!tid) {
 		return -1;
 	}
@@ -65,16 +73,28 @@ RZ_IPI RzCmdStatus rz_tasks_break_handler(RzCore *core, int argc, const char **a
 }
 
 RZ_IPI RzCmdStatus rz_tasks_delete_handler(RzCore *core, int argc, const char **argv) {
+	if (rz_sandbox_enable (0)) {
+		eprintf ("This command is disabled in sandbox mode\n");
+		return RZ_CMD_STATUS_ERROR;
+	}
 	int tid = rz_num_math (core->num, argv[1]);
 	return rz_core_task_del (&core->tasks, tid)? RZ_CMD_STATUS_OK: RZ_CMD_STATUS_ERROR;
 }
 
 RZ_IPI RzCmdStatus rz_tasks_delete_all_handler(RzCore *core, int argc, const char **argv) {
+	if (rz_sandbox_enable (0)) {
+		eprintf ("This command is disabled in sandbox mode\n");
+		return RZ_CMD_STATUS_ERROR;
+	}
 	rz_core_task_del_all_done (&core->tasks);
 	return RZ_CMD_STATUS_OK;
 }
 
 RZ_IPI RzCmdStatus rz_tasks_wait_handler(RzCore *core, int argc, const char **argv) {
+	if (rz_sandbox_enable (0)) {
+		eprintf ("This command is disabled in sandbox mode\n");
+		return RZ_CMD_STATUS_ERROR;
+	}
 	int tid = 0;
 	if (argc == 2) {
 		tid = rz_num_math (core->num, argv[1]);

--- a/librz/core/cmd_tasks.c
+++ b/librz/core/cmd_tasks.c
@@ -5,11 +5,7 @@
 #include "cmd_descs.h"
 
 static int task_enqueue(RzCore *core, const char *cmd, bool transient) {
-	if (rz_sandbox_enable (0)) {
-		eprintf ("This command is disabled in sandbox mode\n");
-		return -1;
-	}
-	RzCoreTask *task = rz_core_task_new (core, true, cmd, NULL, core);
+	RzCoreTask *task = rz_core_task_new (core, true, cmd);
 	if (!task) {
 		return -1;
 	}
@@ -36,10 +32,6 @@ static int task_output(RzCore *core, int tid) {
 }
 
 static int task_break(RzCore *core, int tid) {
-	if (rz_sandbox_enable (0)) {
-		eprintf ("This command is disabled in sandbox mode\n");
-		return -1;
-	}
 	if (tid) {
 		return -1;
 	}
@@ -72,28 +64,16 @@ RZ_IPI RzCmdStatus rz_tasks_break_handler(RzCore *core, int argc, const char **a
 }
 
 RZ_IPI RzCmdStatus rz_tasks_delete_handler(RzCore *core, int argc, const char **argv) {
-	if (rz_sandbox_enable (0)) {
-		eprintf ("This command is disabled in sandbox mode\n");
-		return RZ_CMD_STATUS_ERROR;
-	}
 	int tid = rz_num_math (core->num, argv[1]);
 	return rz_core_task_del (&core->tasks, tid)? RZ_CMD_STATUS_OK: RZ_CMD_STATUS_ERROR;
 }
 
 RZ_IPI RzCmdStatus rz_tasks_delete_all_handler(RzCore *core, int argc, const char **argv) {
-	if (rz_sandbox_enable (0)) {
-		eprintf ("This command is disabled in sandbox mode\n");
-		return RZ_CMD_STATUS_ERROR;
-	}
 	rz_core_task_del_all_done (&core->tasks);
 	return RZ_CMD_STATUS_OK;
 }
 
 RZ_IPI RzCmdStatus rz_tasks_wait_handler(RzCore *core, int argc, const char **argv) {
-	if (rz_sandbox_enable (0)) {
-		eprintf ("This command is disabled in sandbox mode\n");
-		return RZ_CMD_STATUS_ERROR;
-	}
 	int tid = 0;
 	if (argc == 2) {
 		tid = rz_num_math (core->num, argv[1]);

--- a/librz/core/cmd_tasks.c
+++ b/librz/core/cmd_tasks.c
@@ -9,7 +9,7 @@ static int task_enqueue(RzCore *core, const char *cmd, bool transient) {
 		eprintf ("This command is disabled in sandbox mode\n");
 		return -1;
 	}
-	RzCoreTask *task = rz_core_cmd_task_new (core, true, cmd);
+	RzCoreTask *task = rz_core_cmd_task_new (core, cmd);
 	if (!task) {
 		return -1;
 	}
@@ -42,6 +42,9 @@ static int task_break(RzCore *core, int tid) {
 		return -1;
 	}
 	if (!tid) {
+		return -1;
+	}
+	if (!rz_core_task_is_cmd (core, tid)) {
 		return -1;
 	}
 	rz_core_task_break (&core->tasks, tid);
@@ -78,6 +81,9 @@ RZ_IPI RzCmdStatus rz_tasks_delete_handler(RzCore *core, int argc, const char **
 		return RZ_CMD_STATUS_ERROR;
 	}
 	int tid = rz_num_math (core->num, argv[1]);
+	if (!rz_core_task_is_cmd (core, tid)) {
+		return -1;
+	}
 	return rz_core_task_del (&core->tasks, tid)? RZ_CMD_STATUS_OK: RZ_CMD_STATUS_ERROR;
 }
 
@@ -86,7 +92,7 @@ RZ_IPI RzCmdStatus rz_tasks_delete_all_handler(RzCore *core, int argc, const cha
 		eprintf ("This command is disabled in sandbox mode\n");
 		return RZ_CMD_STATUS_ERROR;
 	}
-	rz_core_task_del_all_done (&core->tasks);
+	rz_core_task_del_all_done (core);
 	return RZ_CMD_STATUS_OK;
 }
 
@@ -98,6 +104,9 @@ RZ_IPI RzCmdStatus rz_tasks_wait_handler(RzCore *core, int argc, const char **ar
 	int tid = 0;
 	if (argc == 2) {
 		tid = rz_num_math (core->num, argv[1]);
+	}
+	if (!rz_core_task_is_cmd (core, tid)) {
+		return -1;
 	}
 	rz_core_task_join (&core->tasks, core->tasks.current_task, tid ? tid : -1);
 	return RZ_CMD_STATUS_OK;

--- a/librz/core/cmd_tasks.c
+++ b/librz/core/cmd_tasks.c
@@ -82,7 +82,7 @@ RZ_IPI RzCmdStatus rz_tasks_delete_handler(RzCore *core, int argc, const char **
 	}
 	int tid = rz_num_math (core->num, argv[1]);
 	if (!rz_core_task_is_cmd (core, tid)) {
-		return -1;
+		return RZ_CMD_STATUS_ERROR;
 	}
 	return rz_core_task_del (&core->tasks, tid)? RZ_CMD_STATUS_OK: RZ_CMD_STATUS_ERROR;
 }
@@ -106,7 +106,7 @@ RZ_IPI RzCmdStatus rz_tasks_wait_handler(RzCore *core, int argc, const char **ar
 		tid = rz_num_math (core->num, argv[1]);
 	}
 	if (!rz_core_task_is_cmd (core, tid)) {
-		return -1;
+		return RZ_CMD_STATUS_ERROR;
 	}
 	rz_core_task_join (&core->tasks, core->tasks.current_task, tid ? tid : -1);
 	return RZ_CMD_STATUS_OK;

--- a/librz/core/cmd_tasks.c
+++ b/librz/core/cmd_tasks.c
@@ -5,7 +5,7 @@
 #include "cmd_descs.h"
 
 static int task_enqueue(RzCore *core, const char *cmd, bool transient) {
-	RzCoreTask *task = rz_core_task_new (core, true, cmd);
+	RzCoreTask *task = rz_core_cmd_task_new (core, true, cmd);
 	if (!task) {
 		return -1;
 	}
@@ -20,8 +20,9 @@ static int task_output(RzCore *core, int tid) {
 	}
 	RzCoreTask *task = rz_core_task_get_incref (&core->tasks, tid);
 	if (task) {
-		if (task->res) {
-			rz_cons_println (task->res);
+		const char *res = rz_core_cmd_task_get_result (task);
+		if (res) {
+			rz_cons_println (res);
 		}
 		rz_core_task_decref (task);
 	} else {
@@ -32,7 +33,7 @@ static int task_output(RzCore *core, int tid) {
 }
 
 static int task_break(RzCore *core, int tid) {
-	if (tid) {
+	if (!tid) {
 		return -1;
 	}
 	rz_core_task_break (&core->tasks, tid);

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -2464,7 +2464,7 @@ static void ev_iowrite_cb(RzEvent *ev, int type, void *user, void *data) {
 	}
 }
 
-RZ_IPI void rz_core_cmd_task_ctx_switch(RzCoreTask *next, void *user);
+RZ_IPI void rz_core_task_ctx_switch(RzCoreTask *next, void *user);
 RZ_IPI void rz_core_task_break_cb(RzCoreTask *task, void *user);
 
 RZ_API bool rz_core_init(RzCore *core) {
@@ -2511,7 +2511,7 @@ RZ_API bool rz_core_init(RzCore *core) {
 	core->print->use_comments = false;
 	core->rtr_n = 0;
 	core->blocksize_max = RZ_CORE_BLOCKSIZE_MAX;
-	rz_core_task_scheduler_init (&core->tasks, rz_core_cmd_task_ctx_switch, NULL, rz_core_task_break_cb, NULL);
+	rz_core_task_scheduler_init (&core->tasks, rz_core_task_ctx_switch, NULL, rz_core_task_break_cb, NULL);
 	core->watchers = rz_list_new ();
 	core->watchers->free = (RzListFree)rz_core_cmpwatch_free;
 	core->scriptstack = rz_list_new ();

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -2464,6 +2464,9 @@ static void ev_iowrite_cb(RzEvent *ev, int type, void *user, void *data) {
 	}
 }
 
+RZ_IPI void rz_core_cmd_task_ctx_switch(RzCoreTask *next, void *user);
+RZ_IPI void rz_core_task_break_cb(RzCoreTask *task, void *user);
+
 RZ_API bool rz_core_init(RzCore *core) {
 	core->blocksize = RZ_CORE_BLOCKSIZE;
 	core->block = (ut8 *)calloc (RZ_CORE_BLOCKSIZE + 1, 1);
@@ -2508,7 +2511,7 @@ RZ_API bool rz_core_init(RzCore *core) {
 	core->print->use_comments = false;
 	core->rtr_n = 0;
 	core->blocksize_max = RZ_CORE_BLOCKSIZE_MAX;
-	rz_core_task_scheduler_init (&core->tasks, core);
+	rz_core_task_scheduler_init (&core->tasks, rz_core_cmd_task_ctx_switch, NULL, rz_core_task_break_cb, NULL);
 	core->watchers = rz_list_new ();
 	core->watchers->free = (RzListFree)rz_core_cmpwatch_free;
 	core->scriptstack = rz_list_new ();

--- a/librz/core/task.c
+++ b/librz/core/task.c
@@ -324,7 +324,7 @@ static RzThreadFunctionRet task_run(RzCoreTask *task) {
 		goto nonstart;
 	}
 
-	task->runner (task->runner_user);
+	task->runner (sched, task->runner_user);
 
 	TASK_SIGSET_T old_sigset;
 nonstart:
@@ -587,10 +587,9 @@ static CmdTaskCtx *cmd_task_ctx_new(RzCore *core, bool create_cons, const char *
 	return ctx;
 }
 
-static void cmd_task_runner(void *user) {
+static void cmd_task_runner(RzCoreTaskScheduler *sched, void *user) {
 	CmdTaskCtx *ctx = user;
 	RzCore *core = ctx->core_ctx.core;
-	RzCoreTaskScheduler *sched = &core->tasks;
 	RzCoreTask *task = rz_core_task_self (sched);
 	char *res_str;
 	if (task == sched->main_task) {

--- a/librz/core/task.c
+++ b/librz/core/task.c
@@ -269,7 +269,7 @@ RZ_API void rz_core_task_decref (RzCoreTask *task) {
 	tasks_lock_leave (scheduler, &old_sigset);
 }
 
-RZ_API void rz_core_task_schedule(RzCoreTask *current, RTaskState next_state) {
+RZ_API void rz_core_task_schedule(RzCoreTask *current, RzTaskState next_state) {
 	RzCore *core = current->core;
 	RzCoreTaskScheduler *scheduler = &core->tasks;
 	bool stop = next_state != RZ_CORE_TASK_STATE_RUNNING;

--- a/librz/core/task.c
+++ b/librz/core/task.c
@@ -644,6 +644,7 @@ RZ_IPI void rz_core_cmd_task_ctx_switch(RzCoreTask *next, void *user) {
 		CoreTaskCtx *ctx = next->runner_user;
 		if (ctx->cons_context) {
 			rz_cons_context_load (ctx->cons_context);
+			return;
 		}
 	}
 	rz_cons_context_reset ();

--- a/librz/core/task.c
+++ b/librz/core/task.c
@@ -262,9 +262,6 @@ RZ_API void rz_core_task_schedule(RzCoreTask *current, RzTaskState next_state) {
 	tasks_lock_leave (sched, &old_sigset);
 
 	if (next) {
-		// TODO: this doesn't belong here:
-		rz_cons_context_reset ();
-
 		rz_th_lock_enter (next->dispatch_lock);
 		next->dispatched = true;
 		rz_th_lock_leave (next->dispatch_lock);

--- a/librz/core/task.c
+++ b/librz/core/task.c
@@ -2,18 +2,24 @@
 
 #include <rz_core.h>
 
-RZ_API void rz_core_task_scheduler_init (RzCoreTaskScheduler *tasks, RzCore *core) {
-	tasks->task_id_next = 0;
-	tasks->tasks = rz_list_newf ((RzListFree)rz_core_task_decref);
-	tasks->tasks_queue = rz_list_new ();
-	tasks->oneshot_queue = rz_list_newf (free);
-	tasks->oneshots_enqueued = 0;
-	tasks->lock = rz_th_lock_new (true);
-	tasks->tasks_running = 0;
-	tasks->oneshot_running = false;
-	tasks->main_task = rz_core_task_new (core, false, NULL);
-	rz_list_append (tasks->tasks, tasks->main_task);
-	tasks->current_task = NULL;
+RZ_API void rz_core_task_scheduler_init(RzCoreTaskScheduler *sched,
+		RzCoreTaskContextSwitch ctx_switch, void *ctx_switch_user,
+		RzCoreTaskBreak break_cb, void *break_cb_user) {
+	sched->ctx_switch = ctx_switch;
+	sched->ctx_switch_user = ctx_switch_user;
+	sched->break_cb = break_cb;
+	sched->break_cb_user = break_cb_user;
+	sched->task_id_next = 0;
+	sched->tasks = rz_list_newf ((RzListFree)rz_core_task_decref);
+	sched->tasks_queue = rz_list_new ();
+	sched->oneshot_queue = rz_list_newf (free);
+	sched->oneshots_enqueued = 0;
+	sched->lock = rz_th_lock_new (true);
+	sched->tasks_running = 0;
+	sched->oneshot_running = false;
+	sched->main_task = rz_core_task_new (sched, NULL, NULL, NULL);
+	rz_list_append (sched->tasks, sched->main_task);
+	sched->current_task = NULL;
 }
 
 RZ_API void rz_core_task_scheduler_fini (RzCoreTaskScheduler *tasks) {
@@ -55,70 +61,6 @@ typedef struct oneshot_t {
 	RzCoreTaskOneShot func;
 	void *user;
 } OneShot;
-
-RZ_API void rz_core_task_print (RzCore *core, RzCoreTask *task, int mode) {
-	switch (mode) {
-	case 'j':
-		{
-		rz_cons_printf ("{\"id\":%d,\"state\":\"", task->id);
-		switch (task->state) {
-		case RZ_CORE_TASK_STATE_BEFORE_START:
-			rz_cons_print ("before_start");
-			break;
-		case RZ_CORE_TASK_STATE_RUNNING:
-			rz_cons_print ("running");
-			break;
-		case RZ_CORE_TASK_STATE_SLEEPING:
-			rz_cons_print ("sleeping");
-			break;
-		case RZ_CORE_TASK_STATE_DONE:
-			rz_cons_print ("done");
-			break;
-		}
-		rz_cons_printf ("\",\"transient\":%s,\"cmd\":", task->transient ? "true" : "false");
-		if (task->cmd) {
-			rz_cons_printf ("\"%s\"}", task->cmd);
-		} else {
-			rz_cons_printf ("null}");
-		}
-		}
-		break;
-	default: {
-		const char *info = task->cmd;
-		if (task == core->tasks.main_task) {
-			info = "-- MAIN TASK --";
-		}
-		rz_cons_printf ("%3d %3s %12s  %s\n",
-					   task->id,
-					   task->transient ? "(t)" : "",
-					   rz_core_task_status (task),
-					   info ? info : "");
-		}
-		break;
-	}
-}
-
-RZ_API void rz_core_task_list(RzCore *core, int mode) {
-	RzListIter *iter;
-	RzCoreTask *task;
-	if (mode == 'j') {
-		rz_cons_printf ("[");
-	}
-	TASK_SIGSET_T old_sigset;
-	tasks_lock_enter (&core->tasks, &old_sigset);
-	rz_list_foreach (core->tasks.tasks, iter, task) {
-		rz_core_task_print (core, task, mode);
-		if (mode == 'j' && iter->n) {
-			rz_cons_printf (",");
-		}
-	}
-	if (mode == 'j') {
-		rz_cons_printf ("]\n");
-	} else {
-		rz_cons_printf ("--\ntotal running: %d\n", core->tasks.tasks_running);
-	}
-	tasks_lock_leave (&core->tasks, &old_sigset);
-}
 
 RZ_API int rz_core_task_running_tasks_count(RzCoreTaskScheduler *scheduler) {
 	RzListIter *iter;
@@ -197,26 +139,24 @@ static void task_free (RzCoreTask *task) {
 	if (!task) {
 		return;
 	}
-	free (task->cmd);
-	free (task->res);
+	if (task->runner_free) {
+		task->runner_free (task->runner_user);
+	}
 	rz_th_free (task->thread);
 	rz_th_sem_free (task->running_sem);
 	rz_th_cond_free (task->dispatch_cond);
 	rz_th_lock_free (task->dispatch_lock);
-	rz_cons_context_free (task->cons_context);
 	free (task);
 }
 
-RZ_API RzCoreTask *rz_core_task_new(RzCore *core, bool create_cons, const char *cmd) {
+RZ_API RzCoreTask *rz_core_task_new(RzCoreTaskScheduler *sched, RzCoreTaskRunner runner, RzCoreTaskRunnerFree runner_free, void *runner_user) {
 	RzCoreTask *task = RZ_NEW0 (RzCoreTask);
 	if (!task) {
 		goto fail;
 	}
 
+	task->sched = sched;
 	task->thread = NULL;
-	task->cmd = cmd ? strdup (cmd) : NULL;
-	task->cmd_log = false;
-	task->res = NULL;
 	task->running_sem = NULL;
 	task->dispatched = false;
 	task->dispatch_cond = rz_th_cond_new ();
@@ -224,20 +164,13 @@ RZ_API RzCoreTask *rz_core_task_new(RzCore *core, bool create_cons, const char *
 	if (!task->dispatch_cond || !task->dispatch_lock) {
 		goto fail;
 	}
-
-	if (create_cons) {
-		task->cons_context = rz_cons_context_new (rz_cons_singleton ()->context);
-		if (!task->cons_context) {
-			goto fail;
-		}
-		task->cons_context->cmd_depth = core->max_cmd_depth;
-	}
-
-	task->id = core->tasks.task_id_next++;
+	task->runner = runner;
+	task->runner_free = runner_free;
+	task->runner_user = runner_user;
+	task->id = sched->task_id_next++;
 	task->state = RZ_CORE_TASK_STATE_BEFORE_START;
 	task->refcount = 1;
 	task->transient = false;
-	task->core = core;
 	return task;
 
 fail:
@@ -250,9 +183,9 @@ RZ_API void rz_core_task_incref (RzCoreTask *task) {
 		return;
 	}
 	TASK_SIGSET_T old_sigset;
-	tasks_lock_enter (&task->core->tasks, &old_sigset);
+	tasks_lock_enter (task->sched, &old_sigset);
 	task->refcount++;
-	tasks_lock_leave (&task->core->tasks, &old_sigset);
+	tasks_lock_leave (task->sched, &old_sigset);
 }
 
 RZ_API void rz_core_task_decref (RzCoreTask *task) {
@@ -260,54 +193,53 @@ RZ_API void rz_core_task_decref (RzCoreTask *task) {
 		return;
 	}
 	TASK_SIGSET_T old_sigset;
-	RzCoreTaskScheduler *scheduler = &task->core->tasks;
-	tasks_lock_enter (scheduler, &old_sigset);
+	RzCoreTaskScheduler *sched = task->sched;
+	tasks_lock_enter (sched, &old_sigset);
 	task->refcount--;
 	if (task->refcount <= 0) {
 		task_free (task);
 	}
-	tasks_lock_leave (scheduler, &old_sigset);
+	tasks_lock_leave (sched, &old_sigset);
 }
 
 RZ_API void rz_core_task_schedule(RzCoreTask *current, RzTaskState next_state) {
-	RzCore *core = current->core;
-	RzCoreTaskScheduler *scheduler = &core->tasks;
+	RzCoreTaskScheduler *sched = current->sched;
 	bool stop = next_state != RZ_CORE_TASK_STATE_RUNNING;
 
-	if (scheduler->oneshot_running || (!stop && scheduler->tasks_running == 1 && scheduler->oneshots_enqueued == 0)) {
+	if (sched->oneshot_running || (!stop && sched->tasks_running == 1 && sched->oneshots_enqueued == 0)) {
 		return;
 	}
 
-	scheduler->current_task = NULL;
+	sched->current_task = NULL;
 
 	TASK_SIGSET_T old_sigset;
-	tasks_lock_enter (scheduler, &old_sigset);
+	tasks_lock_enter (sched, &old_sigset);
 
 	current->state = next_state;
 
 	if (stop) {
-		scheduler->tasks_running--;
+		sched->tasks_running--;
 	}
 
 	// oneshots always have priority.
 	// if there are any queued, run them immediately.
 	OneShot *oneshot;
-	while ((oneshot = rz_list_pop_head (scheduler->oneshot_queue))) {
-		scheduler->oneshots_enqueued--;
-		scheduler->oneshot_running = true;
+	while ((oneshot = rz_list_pop_head (sched->oneshot_queue))) {
+		sched->oneshots_enqueued--;
+		sched->oneshot_running = true;
 		oneshot->func (oneshot->user);
-		scheduler->oneshot_running = false;
+		sched->oneshot_running = false;
 		free (oneshot);
 	}
 
-	RzCoreTask *next = rz_list_pop_head (scheduler->tasks_queue);
+	RzCoreTask *next = rz_list_pop_head (sched->tasks_queue);
 
 	if (next && !stop) {
-		rz_list_append (scheduler->tasks_queue, current);
+		rz_list_append (sched->tasks_queue, current);
 		rz_th_lock_enter (current->dispatch_lock);
 	}
 
-	tasks_lock_leave (scheduler, &old_sigset);
+	tasks_lock_leave (sched, &old_sigset);
 
 	if (next) {
 		rz_cons_context_reset ();
@@ -325,37 +257,34 @@ RZ_API void rz_core_task_schedule(RzCoreTask *current, RzTaskState next_state) {
 	}
 
 	if (!stop) {
-		scheduler->current_task = current;
-		if (current->cons_context) {
-			rz_cons_context_load (current->cons_context);
-		} else {
-			rz_cons_context_reset ();
+		sched->current_task = current;
+		if (sched->ctx_switch) {
+			sched->ctx_switch (current, sched->ctx_switch_user);
 		}
 	}
 }
 
 static void task_wakeup(RzCoreTask *current) {
-	RzCore *core = current->core;
-	RzCoreTaskScheduler *scheduler = &core->tasks;
+	RzCoreTaskScheduler *sched = current->sched;
 
 	TASK_SIGSET_T old_sigset;
-	tasks_lock_enter (scheduler, &old_sigset);
+	tasks_lock_enter (sched, &old_sigset);
 
-	scheduler->tasks_running++;
+	sched->tasks_running++;
 	current->state = RZ_CORE_TASK_STATE_RUNNING;
 
 	// check if there are other tasks running
-	bool single = scheduler->tasks_running == 1 || scheduler->tasks_running == 0;
+	bool single = sched->tasks_running == 1 || sched->tasks_running == 0;
 
 	rz_th_lock_enter (current->dispatch_lock);
 
 	// if we are not the only task, we must wait until another task signals us.
 
 	if (!single) {
-		rz_list_append (scheduler->tasks_queue, current);
+		rz_list_append (sched->tasks_queue, current);
 	}
 
-	tasks_lock_leave (scheduler, &old_sigset);
+	tasks_lock_leave (sched, &old_sigset);
 
 	if (!single) {
 		while (!current->dispatched) {
@@ -366,12 +295,10 @@ static void task_wakeup(RzCoreTask *current) {
 
 	rz_th_lock_leave (current->dispatch_lock);
 
-	scheduler->current_task = current;
+	sched->current_task = current;
 
-	if (current->cons_context) {
-		rz_cons_context_load (current->cons_context);
-	} else {
-		rz_cons_context_reset ();
+	if (sched->ctx_switch) {
+		sched->ctx_switch (current, sched->ctx_switch_user);
 	}
 }
 
@@ -388,34 +315,20 @@ static void task_end(RzCoreTask *t) {
 }
 
 static RzThreadFunctionRet task_run(RzCoreTask *task) {
-	RzCore *core = task->core;
-	RzCoreTaskScheduler *scheduler = &task->core->tasks;
+	RzCoreTaskScheduler *sched = task->sched;
 
 	task_wakeup (task);
 
-	if (task->cons_context && task->cons_context->breaked) {
+	if (task->breaked) {
 		// breaked in RZ_CORE_TASK_STATE_BEFORE_START
 		goto nonstart;
 	}
 
-	char *res_str;
-	if (task == scheduler->main_task) {
-		rz_core_cmd (core, task->cmd, task->cmd_log);
-		res_str = NULL;
-	} else {
-		res_str = rz_core_cmd_str (core, task->cmd);
-	}
-
-	free (task->res);
-	task->res = res_str;
-
-	if (task != scheduler->main_task && rz_cons_default_context_is_interactive ()) {
-		eprintf ("\nTask %d finished\n", task->id);
-	}
+	task->runner (task->runner_user);
 
 	TASK_SIGSET_T old_sigset;
 nonstart:
-	tasks_lock_enter (scheduler, &old_sigset);
+	tasks_lock_enter (sched, &old_sigset);
 
 	task_end (task);
 
@@ -423,24 +336,20 @@ nonstart:
 		rz_th_sem_post (task->running_sem);
 	}
 
-	if (task->cons_context && task->cons_context->break_stack) {
-		rz_cons_context_break_pop (task->cons_context, false);
-	}
-
 	int ret = RZ_TH_STOP;
 	if (task->transient) {
 		RzCoreTask *ltask;
 		RzListIter *iter;
-		rz_list_foreach (scheduler->tasks, iter, ltask) {
+		rz_list_foreach (sched->tasks, iter, ltask) {
 			if (ltask == task) {
-				rz_list_delete (scheduler->tasks, iter);
+				rz_list_delete (sched->tasks, iter);
 				ret = RZ_TH_FREED;
 				break;
 			}
 		}
 	}
 
-	tasks_lock_leave (scheduler, &old_sigset);
+	tasks_lock_leave (sched, &old_sigset);
 	return ret;
 }
 
@@ -460,9 +369,6 @@ RZ_API void rz_core_task_enqueue(RzCoreTaskScheduler *scheduler, RzCoreTask *tas
 	}
 	if (task->running_sem) {
 		rz_th_sem_wait (task->running_sem);
-	}
-	if (task->cons_context) {
-		rz_cons_context_break_push (task->cons_context, NULL, NULL, false);
 	}
 	rz_list_append (scheduler->tasks, task);
 	task->thread = rz_th_new (task_run_thread, task, 0);
@@ -504,8 +410,6 @@ RZ_API void rz_core_task_sync_begin(RzCoreTaskScheduler *scheduler) {
 	TASK_SIGSET_T old_sigset;
 	tasks_lock_enter (scheduler, &old_sigset);
 	task->thread = NULL;
-	task->cmd = NULL;
-	task->cmd_log = false;
 	task->state = RZ_CORE_TASK_STATE_BEFORE_START;
 	tasks_lock_leave (scheduler, &old_sigset);
 	task_wakeup (task);
@@ -524,21 +428,6 @@ RZ_API void rz_core_task_sleep_begin(RzCoreTask *task) {
 
 RZ_API void rz_core_task_sleep_end(RzCoreTask *task) {
 	task_wakeup (task);
-}
-
-RZ_API const char *rz_core_task_status (RzCoreTask *task) {
-	switch (task->state) {
-	case RZ_CORE_TASK_STATE_RUNNING:
-		return "running";
-	case RZ_CORE_TASK_STATE_SLEEPING:
-		return "sleeping";
-	case RZ_CORE_TASK_STATE_DONE:
-		return "done";
-	case RZ_CORE_TASK_STATE_BEFORE_START:
-		return "before start";
-	default:
-		return "unknown";
-	}
 }
 
 RZ_API RzCoreTask *rz_core_task_self (RzCoreTaskScheduler *scheduler) {
@@ -567,6 +456,17 @@ RZ_API RzCoreTask *rz_core_task_get_incref(RzCoreTaskScheduler *scheduler, int i
 	return task;
 }
 
+/**
+ * break without locking, don't call directly and use public api instead!
+ */
+static void task_break(RzCoreTask *task) {
+	RzCoreTaskScheduler *sched = task->sched;
+	task->breaked = true;
+	if (sched->break_cb) {
+		sched->break_cb (task, sched->break_cb_user);
+	}
+}
+
 RZ_API void rz_core_task_break(RzCoreTaskScheduler *scheduler, int id) {
 	TASK_SIGSET_T old_sigset;
 	tasks_lock_enter (scheduler, &old_sigset);
@@ -575,9 +475,7 @@ RZ_API void rz_core_task_break(RzCoreTaskScheduler *scheduler, int id) {
 		tasks_lock_leave (scheduler, &old_sigset);
 		return;
 	}
-	if (task->cons_context) {
-		rz_cons_context_break (task->cons_context);
-	}
+	task_break (task);
 	tasks_lock_leave (scheduler, &old_sigset);
 }
 
@@ -588,7 +486,7 @@ RZ_API void rz_core_task_break_all(RzCoreTaskScheduler *scheduler) {
 	RzListIter *iter;
 	rz_list_foreach (scheduler->tasks, iter, task) {
 		if (task->state != RZ_CORE_TASK_STATE_DONE) {
-			rz_cons_context_break (task->cons_context);
+			task_break (task);
 		}
 	}
 	tasks_lock_leave (scheduler, &old_sigset);
@@ -627,3 +525,218 @@ RZ_API void rz_core_task_del_all_done (RzCoreTaskScheduler *scheduler) {
 		}
 	}
 }
+
+// above here is for agnostic RzTask api later
+// -------------------------------------------
+// below here is for RzCore-specific tasks
+
+/**
+ * Common base for all contexts of tasks in core.
+ * Must be the first member of every task context!
+ */
+typedef struct core_task_ctx_t {
+	RzCore *core;
+	RzConsContext *cons_context;
+} CoreTaskCtx;
+
+static bool core_task_ctx_init(CoreTaskCtx *ctx, RzCore *core, bool create_cons) {
+	ctx->core = core;
+	if (create_cons) {
+		ctx->cons_context = rz_cons_context_new (rz_cons_singleton ()->context);
+		if (!ctx->cons_context) {
+			return false;
+		}
+		ctx->cons_context->cmd_depth = core->max_cmd_depth;
+		rz_cons_context_break_push (ctx->cons_context, NULL, NULL, false);
+	} else {
+		ctx->cons_context = NULL;
+	}
+	return true;
+}
+
+static void core_task_ctx_fini(CoreTaskCtx *ctx) {
+	if (ctx->cons_context && ctx->cons_context->break_stack) {
+		rz_cons_context_break_pop (ctx->cons_context, false);
+	}
+	rz_cons_context_free (ctx->cons_context);
+}
+
+/**
+ * Context for (user-visible) command tasks
+ */
+typedef struct cmd_task_ctx_t {
+	CoreTaskCtx core_ctx;
+	char *cmd;
+	bool cmd_log;
+	char *res;
+} CmdTaskCtx;
+
+static CmdTaskCtx *cmd_task_ctx_new(RzCore *core, bool create_cons, const char *cmd) {
+	rz_return_val_if_fail (cmd, NULL);
+	CmdTaskCtx *ctx = RZ_NEW (CmdTaskCtx);
+	if (!ctx) {
+		return NULL;
+	}
+	if (!core_task_ctx_init (&ctx->core_ctx, core, create_cons)) {
+		free (ctx);
+		return NULL;
+	}
+	ctx->cmd = strdup (cmd);
+	ctx->cmd_log = false;
+	ctx->res = NULL;
+	return ctx;
+}
+
+static void cmd_task_runner(void *user) {
+	CmdTaskCtx *ctx = user;
+	RzCore *core = ctx->core_ctx.core;
+	RzCoreTaskScheduler *sched = &core->tasks;
+	RzCoreTask *task = rz_core_task_self (sched);
+	char *res_str;
+	if (task == sched->main_task) {
+		rz_core_cmd (core, ctx->cmd, ctx->cmd_log);
+		res_str = NULL;
+	} else {
+		res_str = rz_core_cmd_str (core, ctx->cmd);
+	}
+	ctx->res = res_str;
+
+	if (task != sched->main_task && rz_cons_default_context_is_interactive ()) {
+		eprintf ("\nTask %d finished\n", task->id);
+	}
+}
+
+static void cmd_task_free(void *user) {
+	if (!user) {
+		return;
+	}
+	CmdTaskCtx *ctx = user;
+	free (ctx->cmd);
+	free (ctx->res);
+	core_task_ctx_fini (&ctx->core_ctx);
+	free (ctx);
+}
+
+RZ_API RzCoreTask *rz_core_cmd_task_new(RzCore *core, bool create_cons, const char *cmd) {
+	CmdTaskCtx *ctx = cmd_task_ctx_new (core, create_cons, cmd);
+	if (!ctx) {
+		return NULL;
+	}
+	RzCoreTask *task = rz_core_task_new(&core->tasks, cmd_task_runner, cmd_task_free, ctx);
+	if (!task) {
+		cmd_task_free (ctx);
+		return NULL;
+	}
+	return task;
+}
+
+RZ_IPI void rz_core_cmd_task_ctx_switch(RzCoreTask *next, void *user) {
+	if (next->runner_user) {
+		CoreTaskCtx *ctx = next->runner_user;
+		if (ctx->cons_context) {
+			rz_cons_context_load (ctx->cons_context);
+		}
+	}
+	rz_cons_context_reset ();
+}
+
+RZ_IPI void rz_core_task_break_cb(RzCoreTask *task, void *user) {
+	CoreTaskCtx *ctx = task->runner_user;
+	rz_cons_context_break (ctx ? ctx->cons_context : NULL);
+}
+
+RZ_API const char *rz_core_task_status(RzCoreTask *task) {
+	switch (task->state) {
+	case RZ_CORE_TASK_STATE_RUNNING:
+		return "running";
+	case RZ_CORE_TASK_STATE_SLEEPING:
+		return "sleeping";
+	case RZ_CORE_TASK_STATE_DONE:
+		return "done";
+	case RZ_CORE_TASK_STATE_BEFORE_START:
+		return "before start";
+	default:
+		return "unknown";
+	}
+}
+
+RZ_API void rz_core_task_print(RzCore *core, RzCoreTask *task, int mode) {
+	if (task != core->tasks.main_task && task->runner != cmd_task_runner) {
+		// don't print tasks that are custom function-runners, which come from internal code.
+		// only main and command ones, which should be user-visible.
+		return;
+	}
+	const char *cmd;
+	if (task == core->tasks.main_task) {
+		cmd = "";
+	} else {
+		cmd = ((CmdTaskCtx *)task->runner_user)->cmd;
+	}
+	switch (mode) {
+	case 'j':
+		{
+		rz_cons_printf ("{\"id\":%d,\"state\":\"", task->id);
+		switch (task->state) {
+		case RZ_CORE_TASK_STATE_BEFORE_START:
+			rz_cons_print ("before_start");
+			break;
+		case RZ_CORE_TASK_STATE_RUNNING:
+			rz_cons_print ("running");
+			break;
+		case RZ_CORE_TASK_STATE_SLEEPING:
+			rz_cons_print ("sleeping");
+			break;
+		case RZ_CORE_TASK_STATE_DONE:
+			rz_cons_print ("done");
+			break;
+		}
+		rz_cons_printf ("\",\"transient\":%s,\"cmd\":", task->transient ? "true" : "false");
+		if (cmd) {
+			rz_cons_printf ("\"%s\"}", cmd);
+		} else {
+			rz_cons_printf ("null}");
+		}
+		break;
+	default: {
+		rz_cons_printf ("%3d %3s %12s  %s\n",
+					   task->id,
+					   task->transient ? "(t)" : "",
+					   rz_core_task_status (task),
+					   cmd ? cmd : "-- MAIN TASK --");
+		}
+		break;
+	}
+	}
+}
+
+RZ_API void rz_core_task_list(RzCore *core, int mode) {
+	RzListIter *iter;
+	RzCoreTask *task;
+	if (mode == 'j') {
+		rz_cons_printf ("[");
+	}
+	TASK_SIGSET_T old_sigset;
+	tasks_lock_enter (&core->tasks, &old_sigset);
+	rz_list_foreach (core->tasks.tasks, iter, task) {
+		rz_core_task_print (core, task, mode);
+		if (mode == 'j' && iter->n) {
+			rz_cons_printf (",");
+		}
+	}
+	if (mode == 'j') {
+		rz_cons_printf ("]\n");
+	} else {
+		rz_cons_printf ("--\ntotal running: %d\n", core->tasks.tasks_running);
+	}
+	tasks_lock_leave (&core->tasks, &old_sigset);
+}
+
+RZ_API const char *rz_core_cmd_task_get_result(RzCoreTask *task) {
+	// Check if this is really a command task
+	if (!task->runner_user || task->runner != cmd_task_runner) {
+		return NULL;
+	}
+	CmdTaskCtx *ctx = task->runner_user;
+	return ctx->res;
+}
+

--- a/librz/core/task.c
+++ b/librz/core/task.c
@@ -11,7 +11,7 @@ RZ_API void rz_core_task_scheduler_init (RzCoreTaskScheduler *tasks, RzCore *cor
 	tasks->lock = rz_th_lock_new (true);
 	tasks->tasks_running = 0;
 	tasks->oneshot_running = false;
-	tasks->main_task = rz_core_task_new (core, false, NULL, NULL, NULL);
+	tasks->main_task = rz_core_task_new (core, false, NULL);
 	rz_list_append (tasks->tasks, tasks->main_task);
 	tasks->current_task = NULL;
 }
@@ -207,7 +207,7 @@ static void task_free (RzCoreTask *task) {
 	free (task);
 }
 
-RZ_API RzCoreTask *rz_core_task_new(RzCore *core, bool create_cons, const char *cmd, RzCoreTaskCallback cb, void *user) {
+RZ_API RzCoreTask *rz_core_task_new(RzCore *core, bool create_cons, const char *cmd) {
 	RzCoreTask *task = RZ_NEW0 (RzCoreTask);
 	if (!task) {
 		goto fail;
@@ -238,9 +238,6 @@ RZ_API RzCoreTask *rz_core_task_new(RzCore *core, bool create_cons, const char *
 	task->refcount = 1;
 	task->transient = false;
 	task->core = core;
-	task->user = user;
-	task->cb = cb;
-
 	return task;
 
 fail:
@@ -421,10 +418,6 @@ nonstart:
 	tasks_lock_enter (scheduler, &old_sigset);
 
 	task_end (task);
-
-	if (task->cb) {
-		task->cb (task->user, task->res);
-	}
 
 	if (task->running_sem) {
 		rz_th_sem_post (task->running_sem);

--- a/librz/core/vmenus.c
+++ b/librz/core/vmenus.c
@@ -255,7 +255,7 @@ RZ_API bool rz_core_visual_esil(RzCore *core) {
 			if (rz_cons_fgets (cmd, sizeof (cmd), 0, NULL) < 0) {
 				cmd[0] = '\0';
 			}
-			rz_core_cmd_task_sync (core, cmd, 1);
+			rz_core_cmd0 (core, cmd);
 			rz_cons_set_raw (1);
 			rz_cons_show_cursor (false);
 			if (cmd[0]) {
@@ -2137,7 +2137,7 @@ RZ_API int rz_core_visual_trackflags(RzCore *core) {
 				*cmd = 0;
 			}
 			cmd[sizeof (cmd) - 1] = 0;
-			rz_core_cmd_task_sync (core, cmd, 1);
+			rz_core_cmd0 (core, cmd);
 			rz_cons_set_raw (1);
 			rz_cons_show_cursor (false);
 			if (*cmd) {

--- a/librz/core/vmenus_graph.c
+++ b/librz/core/vmenus_graph.c
@@ -388,7 +388,6 @@ RZ_API int rz_core_visual_view_graph(RzCore *core) {
 					cmd[0] = '\0';
 				}
 				rz_config_set (core->config, "scr.highlight", cmd);
-				//rz_core_cmd_task_sync (core, cmd, 1);
 				rz_cons_set_raw (1);
 				rz_cons_show_cursor (false);
 				rz_cons_clear ();
@@ -407,7 +406,6 @@ RZ_API int rz_core_visual_view_graph(RzCore *core) {
 				cmd[0] = '\0';
 			}
 			rz_core_cmd0 (core, cmd);
-			//rz_core_cmd_task_sync (core, cmd, 1);
 			rz_cons_set_raw (1);
 			rz_cons_show_cursor (false);
 			if (cmd[0]) {

--- a/librz/core/vmenus_zigns.c
+++ b/librz/core/vmenus_zigns.c
@@ -164,7 +164,7 @@ RZ_API int rz_core_visual_view_zigns(RzCore *core) {
 			if (rz_cons_fgets (cmd, sizeof (cmd), 0, NULL) < 0) {
 				cmd[0] = '\0';
 			}
-			rz_core_cmd_task_sync (core, cmd, 1);
+			rz_core_cmd0 (core, cmd);
 			rz_cons_set_raw (1);
 			rz_cons_show_cursor (false);
 			if (cmd[0]) {

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -210,7 +210,23 @@ typedef struct {
 
 RZ_API void rz_core_gadget_free (RzCoreGadget *g);
 
+typedef struct rz_core_task_t RzCoreTask;
+
+/**
+ * Scheduler-wide callback to switch any necessary context from cur to next.
+ */
+typedef void (*RzCoreTaskContextSwitch)(RzCoreTask *next, void *user);
+
+/**
+ * Scheduler-wide callback for breaking a task.
+ */
+typedef void (*RzCoreTaskBreak)(RzCoreTask *task, void *user);
+
 typedef struct rz_core_tasks_t {
+	RzCoreTaskContextSwitch ctx_switch;
+	void *ctx_switch_user;
+	RzCoreTaskBreak break_cb;
+	void *break_cb_user;
 	int task_id_next;
 	RzList *tasks;
 	RzList *tasks_queue;
@@ -385,7 +401,6 @@ RZ_API void rz_core_prompt_loop(RzCore *core);
 RZ_API ut64 rz_core_pava(RzCore *core, ut64 addr);
 RZ_API int rz_core_cmd(RzCore *core, const char *cmd, int log);
 RZ_API RzCmdStatus rz_core_cmd_newshell(RzCore *core, const char *cmd, int log);
-RZ_API int rz_core_cmd_task_sync(RzCore *core, const char *cmd, bool log);
 RZ_API char *rz_core_editor(const RzCore *core, const char *file, const char *str);
 RZ_API int rz_core_fgets(char *buf, int len, void *user);
 RZ_API RzFlagItem *rz_core_flag_get_by_spaces(RzFlag *f, ut64 off);
@@ -819,37 +834,48 @@ typedef enum {
 	RZ_CORE_TASK_STATE_DONE
 } RzTaskState;
 
-typedef struct rz_core_task_t {
+/**
+ * Main payload of a task, the function that should be executed asynchronously.
+ */
+typedef void (*RzCoreTaskRunner)(void *user);
+
+/**
+ * Task-specific callback to free/cleanup any runner-specific data.
+ */
+typedef void (*RzCoreTaskRunnerFree)(void *user);
+
+struct rz_core_task_t {
+	RzCoreTaskScheduler *sched;
 	int id;
 	RzTaskState state;
 	bool transient; // delete when finished
 	int refcount;
 	RzThreadSemaphore *running_sem;
-	RzCore *core;
 	bool dispatched;
 	RzThreadCond *dispatch_cond;
 	RzThreadLock *dispatch_lock;
 	RzThread *thread;
-	char *cmd;
-	char *res;
-	bool cmd_log;
-	RzConsContext *cons_context;
-} RzCoreTask;
+	bool breaked;
+
+	RzCoreTaskRunner runner; // will be NULL for main task
+	RzCoreTaskRunnerFree runner_free;
+	void *runner_user;
+};
 
 typedef void (*RzCoreTaskOneShot)(void *);
 
 RZ_API void rz_core_echo(RzCore *core, const char *msg);
 RZ_API RTable *rz_core_table(RzCore *core);
 
-RZ_API void rz_core_task_scheduler_init(RzCoreTaskScheduler *tasks, RzCore *core);
+RZ_API void rz_core_task_scheduler_init(RzCoreTaskScheduler *tasks,
+		RzCoreTaskContextSwitch ctx_switch, void *ctx_switch_user,
+		RzCoreTaskBreak break_cb, void *break_cb_user);
 RZ_API void rz_core_task_scheduler_fini(RzCoreTaskScheduler *tasks);
 RZ_API RzCoreTask *rz_core_task_get(RzCoreTaskScheduler *scheduler, int id);
 RZ_API RzCoreTask *rz_core_task_get_incref(RzCoreTaskScheduler *scheduler, int id);
-RZ_API void rz_core_task_print(RzCore *core, RzCoreTask *task, int mode);
-RZ_API void rz_core_task_list(RzCore *core, int mode);
 RZ_API int rz_core_task_running_tasks_count(RzCoreTaskScheduler *scheduler);
 RZ_API const char *rz_core_task_status(RzCoreTask *task);
-RZ_API RzCoreTask *rz_core_task_new(RzCore *core, bool create_cons, const char *cmd);
+RZ_API RzCoreTask *rz_core_task_new(RzCoreTaskScheduler *sched, RzCoreTaskRunner runner, RzCoreTaskRunnerFree runner_free, void *runner_user);
 RZ_API void rz_core_task_incref(RzCoreTask *task);
 RZ_API void rz_core_task_decref(RzCoreTask *task);
 RZ_API void rz_core_task_enqueue(RzCoreTaskScheduler *scheduler, RzCoreTask *task);
@@ -870,6 +896,12 @@ typedef void (*inRangeCb) (RzCore *core, ut64 from, ut64 to, int vsize,
 		int count, void *cb_user);
 RZ_API int rz_core_search_value_in_range (RzCore *core, RzInterval search_itv,
 		ut64 vmin, ut64 vmax, int vsize, inRangeCb cb, void *cb_user);
+
+// core-specific tasks
+RZ_API RzCoreTask *rz_core_cmd_task_new(RzCore *core, bool create_cons, const char *cmd);
+RZ_API void rz_core_task_print(RzCore *core, RzCoreTask *task, int mode);
+RZ_API void rz_core_task_list(RzCore *core, int mode);
+RZ_API const char *rz_core_cmd_task_get_result(RzCoreTask *task);
 
 RZ_API RzCoreAutocomplete *rz_core_autocomplete_add(RzCoreAutocomplete *parent, const char* cmd, int type, bool lock);
 RZ_API void rz_core_autocomplete_free(RzCoreAutocomplete *obj);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -812,8 +812,6 @@ RZ_API char *cmd_syscall_dostr(RzCore *core, st64 num, ut64 addr);
 
 /* tasks */
 
-typedef void (*RzCoreTaskCallback)(void *user, char *out);
-
 typedef enum {
 	RZ_CORE_TASK_STATE_BEFORE_START,
 	RZ_CORE_TASK_STATE_RUNNING,
@@ -827,7 +825,6 @@ typedef struct rz_core_task_t {
 	bool transient; // delete when finished
 	int refcount;
 	RzThreadSemaphore *running_sem;
-	void *user;
 	RzCore *core;
 	bool dispatched;
 	RzThreadCond *dispatch_cond;
@@ -837,7 +834,6 @@ typedef struct rz_core_task_t {
 	char *res;
 	bool cmd_log;
 	RzConsContext *cons_context;
-	RzCoreTaskCallback cb;
 } RzCoreTask;
 
 typedef void (*RzCoreTaskOneShot)(void *);
@@ -845,15 +841,15 @@ typedef void (*RzCoreTaskOneShot)(void *);
 RZ_API void rz_core_echo(RzCore *core, const char *msg);
 RZ_API RTable *rz_core_table(RzCore *core);
 
-RZ_API void rz_core_task_scheduler_init (RzCoreTaskScheduler *tasks, RzCore *core);
-RZ_API void rz_core_task_scheduler_fini (RzCoreTaskScheduler *tasks);
+RZ_API void rz_core_task_scheduler_init(RzCoreTaskScheduler *tasks, RzCore *core);
+RZ_API void rz_core_task_scheduler_fini(RzCoreTaskScheduler *tasks);
 RZ_API RzCoreTask *rz_core_task_get(RzCoreTaskScheduler *scheduler, int id);
 RZ_API RzCoreTask *rz_core_task_get_incref(RzCoreTaskScheduler *scheduler, int id);
 RZ_API void rz_core_task_print(RzCore *core, RzCoreTask *task, int mode);
 RZ_API void rz_core_task_list(RzCore *core, int mode);
 RZ_API int rz_core_task_running_tasks_count(RzCoreTaskScheduler *scheduler);
 RZ_API const char *rz_core_task_status(RzCoreTask *task);
-RZ_API RzCoreTask *rz_core_task_new(RzCore *core, bool create_cons, const char *cmd, RzCoreTaskCallback cb, void *user);
+RZ_API RzCoreTask *rz_core_task_new(RzCore *core, bool create_cons, const char *cmd);
 RZ_API void rz_core_task_incref(RzCoreTask *task);
 RZ_API void rz_core_task_decref(RzCoreTask *task);
 RZ_API void rz_core_task_enqueue(RzCoreTaskScheduler *scheduler, RzCoreTask *task);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -817,11 +817,11 @@ typedef enum {
 	RZ_CORE_TASK_STATE_RUNNING,
 	RZ_CORE_TASK_STATE_SLEEPING,
 	RZ_CORE_TASK_STATE_DONE
-} RTaskState;
+} RzTaskState;
 
 typedef struct rz_core_task_t {
 	int id;
-	RTaskState state;
+	RzTaskState state;
 	bool transient; // delete when finished
 	int refcount;
 	RzThreadSemaphore *running_sem;

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -871,7 +871,6 @@ RZ_API void rz_core_task_scheduler_init(RzCoreTaskScheduler *sched,
 		RzCoreTaskContextSwitch ctx_switch, void *ctx_switch_user,
 		RzCoreTaskBreak break_cb, void *break_cb_user);
 RZ_API void rz_core_task_scheduler_fini(RzCoreTaskScheduler *tasks);
-RZ_API RzCoreTask *rz_core_task_get(RzCoreTaskScheduler *scheduler, int id);
 RZ_API RzCoreTask *rz_core_task_get_incref(RzCoreTaskScheduler *scheduler, int id);
 RZ_API int rz_core_task_running_tasks_count(RzCoreTaskScheduler *scheduler);
 RZ_API const char *rz_core_task_status(RzCoreTask *task);
@@ -889,7 +888,6 @@ RZ_API void rz_core_task_sleep_end(RzCoreTask *task);
 RZ_API void rz_core_task_break(RzCoreTaskScheduler *scheduler, int id);
 RZ_API void rz_core_task_break_all(RzCoreTaskScheduler *scheduler);
 RZ_API int rz_core_task_del(RzCoreTaskScheduler *scheduler, int id);
-RZ_API void rz_core_task_del_all_done(RzCoreTaskScheduler *scheduler);
 RZ_API RzCoreTask *rz_core_task_self(RzCoreTaskScheduler *scheduler);
 RZ_API void rz_core_task_join(RzCoreTaskScheduler *scheduler, RzCoreTask *current, int id);
 typedef void (*inRangeCb) (RzCore *core, ut64 from, ut64 to, int vsize,
@@ -898,10 +896,15 @@ RZ_API int rz_core_search_value_in_range (RzCore *core, RzInterval search_itv,
 		ut64 vmin, ut64 vmax, int vsize, inRangeCb cb, void *cb_user);
 
 // core-specific tasks
-RZ_API RzCoreTask *rz_core_cmd_task_new(RzCore *core, bool create_cons, const char *cmd);
+RZ_API RzCoreTask *rz_core_cmd_task_new(RzCore *core, const char *cmd);
+RZ_API const char *rz_core_cmd_task_get_result(RzCoreTask *task);
+typedef void *(*RzCoreTaskFunction)(RzCore *core, void *user);
+RZ_API RzCoreTask *rz_core_function_task_new(RzCore *core, RzCoreTaskFunction fcn, void *fcn_user);
+RZ_API void *rz_core_function_task_get_result(RzCoreTask *task);
 RZ_API void rz_core_task_print(RzCore *core, RzCoreTask *task, int mode);
 RZ_API void rz_core_task_list(RzCore *core, int mode);
-RZ_API const char *rz_core_cmd_task_get_result(RzCoreTask *task);
+RZ_API bool rz_core_task_is_cmd(RzCore *core, int id);
+RZ_API void rz_core_task_del_all_done(RzCore *core);
 
 RZ_API RzCoreAutocomplete *rz_core_autocomplete_add(RzCoreAutocomplete *parent, const char* cmd, int type, bool lock);
 RZ_API void rz_core_autocomplete_free(RzCoreAutocomplete *obj);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -837,7 +837,7 @@ typedef enum {
 /**
  * Main payload of a task, the function that should be executed asynchronously.
  */
-typedef void (*RzCoreTaskRunner)(void *user);
+typedef void (*RzCoreTaskRunner)(RzCoreTaskScheduler *sched, void *user);
 
 /**
  * Task-specific callback to free/cleanup any runner-specific data.
@@ -867,7 +867,7 @@ typedef void (*RzCoreTaskOneShot)(void *);
 RZ_API void rz_core_echo(RzCore *core, const char *msg);
 RZ_API RTable *rz_core_table(RzCore *core);
 
-RZ_API void rz_core_task_scheduler_init(RzCoreTaskScheduler *tasks,
+RZ_API void rz_core_task_scheduler_init(RzCoreTaskScheduler *sched,
 		RzCoreTaskContextSwitch ctx_switch, void *ctx_switch_user,
 		RzCoreTaskBreak break_cb, void *break_cb_user);
 RZ_API void rz_core_task_scheduler_fini(RzCoreTaskScheduler *tasks);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -873,7 +873,6 @@ RZ_API void rz_core_task_scheduler_init(RzCoreTaskScheduler *sched,
 RZ_API void rz_core_task_scheduler_fini(RzCoreTaskScheduler *tasks);
 RZ_API RzCoreTask *rz_core_task_get_incref(RzCoreTaskScheduler *scheduler, int id);
 RZ_API int rz_core_task_running_tasks_count(RzCoreTaskScheduler *scheduler);
-RZ_API const char *rz_core_task_status(RzCoreTask *task);
 RZ_API RzCoreTask *rz_core_task_new(RzCoreTaskScheduler *sched, RzCoreTaskRunner runner, RzCoreTaskRunnerFree runner_free, void *runner_user);
 RZ_API void rz_core_task_incref(RzCoreTask *task);
 RZ_API void rz_core_task_decref(RzCoreTask *task);
@@ -901,7 +900,8 @@ RZ_API const char *rz_core_cmd_task_get_result(RzCoreTask *task);
 typedef void *(*RzCoreTaskFunction)(RzCore *core, void *user);
 RZ_API RzCoreTask *rz_core_function_task_new(RzCore *core, RzCoreTaskFunction fcn, void *fcn_user);
 RZ_API void *rz_core_function_task_get_result(RzCoreTask *task);
-RZ_API void rz_core_task_print(RzCore *core, RzCoreTask *task, int mode);
+RZ_API const char *rz_core_task_status(RzCoreTask *task);
+RZ_API void rz_core_task_print(RzCore *core, RzCoreTask *task, int mode, PJ *j);
 RZ_API void rz_core_task_list(RzCore *core, int mode);
 RZ_API bool rz_core_task_is_cmd(RzCore *core, int id);
 RZ_API void rz_core_task_del_all_done(RzCore *core);

--- a/test/db/cmd/cmd_task
+++ b/test/db/cmd/cmd_task
@@ -26,3 +26,15 @@ a task!
 
 EOF
 RUN
+
+NAME=&j
+FILE=-
+CMDS=<<EOF
+& ?e Hello\nfrom\na task!
+&& 1
+&j
+EOF
+EXPECT=<<EOF
+[{"id":0,"state":"running","transient":false},{"id":1,"state":"done","transient":false,"cmd":"?e Hello\\nfrom\\na task!"}]
+EOF
+RUN

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -23,6 +23,7 @@ if get_option('enable_tests')
     'ovf',
     'cmd',
     'core_cmd',
+    'core_task',
     'rzpipe',
     'cons',
     'contrbtree',

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -61,6 +61,7 @@ if get_option('enable_tests')
     'str',
     'strbuf',
     'table',
+    'task',
     'tree',
     'uleb128',
     'unum',

--- a/test/unit/test_core_task.c
+++ b/test/unit/test_core_task.c
@@ -1,0 +1,63 @@
+#include <rz_core.h>
+#include "minunit.h"
+
+static void *my_function(RzCore *core, void *user) {
+	size_t val = (size_t)user;
+	int i;
+	for (i = 0; i < 5; i++) {
+		rz_cons_printf ("%u, %d\n", (unsigned int)val, i);
+		rz_core_task_yield (&core->tasks);
+	}
+	return strdup (rz_cons_get_buffer ());
+}
+
+static bool test_core_task(void) {
+	RzCore *core = rz_core_new ();
+	rz_core_task_sync_begin (&core->tasks);
+
+	RzCoreTask *a = rz_core_cmd_task_new (core, "?e hello; ?e world; ?e from; ?e a; ?e task");
+	rz_core_task_enqueue (&core->tasks, a);
+
+	RzCoreTask *b = rz_core_function_task_new (core, my_function, (void *)(size_t)1337);
+	rz_core_task_enqueue (&core->tasks, b);
+
+	rz_cons_printf ("Hello\n");
+	rz_cons_printf ("this\n");
+	rz_cons_printf ("is\n");
+	rz_cons_printf ("the\n");
+	rz_cons_printf ("main\n");
+	rz_cons_printf ("task!\n");
+
+	rz_core_task_join (&core->tasks, rz_core_task_self (&core->tasks), a->id);
+	rz_core_task_join (&core->tasks, rz_core_task_self (&core->tasks), b->id);
+
+	void *fcn_result = rz_core_function_task_get_result (a);
+	mu_assert_null (fcn_result, "fcn result");
+	const char *cmd_result = rz_core_cmd_task_get_result (a);
+	mu_assert_streq (cmd_result, "hello\nworld\nfrom\na\ntask\n", "cmd result");
+
+	fcn_result = rz_core_function_task_get_result (b);
+	mu_assert_streq ((const char *)fcn_result, "1337, 0\n1337, 1\n1337, 2\n1337, 3\n1337, 4\n", "fcn result");
+	free (fcn_result);
+	cmd_result = rz_core_cmd_task_get_result (b);
+	mu_assert_null (cmd_result, "cmd result");
+
+	rz_core_task_del (&core->tasks, a->id);
+	rz_core_task_del (&core->tasks, b->id);
+
+	mu_assert_streq (rz_cons_get_buffer (), "Hello\nthis\nis\nthe\nmain\ntask!\n", "main buffer");
+
+	rz_core_task_sync_end (&core->tasks);
+	rz_core_free (core);
+	mu_end;
+}
+
+// This test is best served with helgrind
+static int all_tests(void) {
+	mu_run_test (test_core_task);
+	return tests_passed != tests_run;
+}
+
+int main(int argc, char **argv) {
+	return all_tests ();
+}

--- a/test/unit/test_task.c
+++ b/test/unit/test_task.c
@@ -1,0 +1,246 @@
+#include <rz_core.h>
+#include "minunit.h"
+
+typedef struct shared_ctx_t {
+	RzStrBuf log;
+	RzThreadLock *free_lock;
+} SharedCtx;
+
+typedef struct local_ctx_t {
+	SharedCtx *shared;
+	int id;
+	int freed;
+	unsigned int want_to_consume;
+	bool breaked;
+} LocalCtx;
+
+static void ctx_switch(RzCoreTask *next, void *user) {
+	SharedCtx *ctx = user;
+	LocalCtx *local_ctx = next->runner_user;
+	if (local_ctx) {
+		rz_strbuf_appendf (&ctx->log, "Context switch to %d\n", local_ctx->id);
+	} else {
+		rz_strbuf_appendf (&ctx->log, "Context switch to main\n");
+	}
+}
+
+static void task_break(RzCoreTask *task, void *user) {
+	LocalCtx *ctx = task->runner_user;
+	ctx->breaked = true;
+}
+
+static void runner(RzCoreTaskScheduler *sched, void *user) {
+	LocalCtx *ctx = user;
+	rz_strbuf_appendf (&ctx->shared->log, "Runner %d start\n", ctx->id);
+	while (ctx->want_to_consume) {
+		if (ctx->breaked) {
+			rz_strbuf_appendf (&ctx->shared->log, "Runner %d was breaked!\n", ctx->id);
+			break;
+		}
+		rz_strbuf_appendf (&ctx->shared->log, "Runner %d consume %u\n", ctx->id, ctx->want_to_consume);
+		ctx->want_to_consume--;
+		rz_core_task_yield (sched);
+	}
+	rz_strbuf_appendf (&ctx->shared->log, "Runner %d done\n", ctx->id);
+}
+
+static void local_ctx_free(void *user) {
+	LocalCtx *ctx = user;
+	SharedCtx *shared_ctx = ctx->shared;
+	rz_th_lock_enter (shared_ctx->free_lock);
+	ctx->freed++;
+	rz_th_lock_leave (shared_ctx->free_lock);
+}
+
+// Busy-wait for task threads to be started and in the queue
+static void wait_for_tasks_enqueued(RzCoreTaskScheduler *sched, size_t count) {
+	while (true) {
+		rz_th_lock_enter (sched->lock);
+		size_t queued = rz_list_length (sched->tasks_queue);
+		rz_th_lock_leave (sched->lock);
+		if (queued == count) {
+			break;
+		}
+		rz_sys_usleep (1000);
+	}
+}
+
+static bool test_task(void) {
+	SharedCtx shared_ctx = { 0 };
+	rz_strbuf_init (&shared_ctx.log);
+	shared_ctx.free_lock = rz_th_lock_new (false);
+
+	RzCoreTaskScheduler sched;
+	rz_core_task_scheduler_init (&sched, ctx_switch, &shared_ctx, task_break, &shared_ctx);
+	rz_core_task_sync_begin (&sched);
+
+	LocalCtx a_ctx = {
+		.shared = &shared_ctx,
+		.id = 1,
+		.want_to_consume = 3
+	};
+	RzCoreTask *a = rz_core_task_new (&sched, runner, local_ctx_free, &a_ctx);
+	int a_id = a->id;
+	rz_core_task_enqueue (&sched, a);
+	a = NULL; // ownership moved to the scheduler, don't touch anymore!
+	wait_for_tasks_enqueued (&sched, 1);
+
+	LocalCtx b_ctx = {
+		.shared = &shared_ctx,
+		.id = 2,
+		.want_to_consume = 3
+	};
+	RzCoreTask *b = rz_core_task_new (&sched, runner, local_ctx_free, &b_ctx);
+	b->transient = true;
+	int b_id = b->id;
+	rz_core_task_enqueue (&sched, b);
+	b = NULL; // ownership moved to the scheduler, don't touch anymore!
+	wait_for_tasks_enqueued (&sched, 2);
+
+	mu_assert_streq (rz_strbuf_get (&shared_ctx.log), "Context switch to main\n", "log");
+
+	// The scheduler uses very primitive round-robin scheduling, which is why it is completely deterministic
+	// after the queue has been filled and we can test it well.
+	// In case the scheduling scheme changes in the future, these tests are allowed to be changed for it.
+
+	rz_core_task_yield (&sched);
+	mu_assert_streq (rz_strbuf_get (&shared_ctx.log),
+			"Context switch to main\n"
+			"Context switch to 1\n"
+			"Runner 1 start\n"
+			"Runner 1 consume 3\n"
+			"Context switch to 2\n"
+			"Runner 2 start\n"
+			"Runner 2 consume 3\n"
+			"Context switch to main\n",
+			"log");
+	rz_core_task_break (&sched, b_id);
+
+	rz_th_lock_enter (shared_ctx.free_lock);
+	mu_assert_eq (a_ctx.freed, 0, "freed");
+	mu_assert_eq (b_ctx.freed, 0, "freed");
+	rz_th_lock_leave (shared_ctx.free_lock);
+
+	rz_core_task_yield (&sched);
+	mu_assert_streq (rz_strbuf_get (&shared_ctx.log),
+			"Context switch to main\n"
+			"Context switch to 1\n"
+			"Runner 1 start\n"
+			"Runner 1 consume 3\n"
+			"Context switch to 2\n"
+			"Runner 2 start\n"
+			"Runner 2 consume 3\n"
+			"Context switch to main\n"
+			"Context switch to 1\n"
+			"Runner 1 consume 2\n"
+			"Context switch to 2\n"
+			"Runner 2 was breaked!\n"
+			"Runner 2 done\n"
+			"Context switch to main\n",
+			"log");
+
+	rz_th_lock_enter (shared_ctx.free_lock);
+	mu_assert_eq (a_ctx.freed, 0, "freed");
+	mu_assert_eq (b_ctx.freed, 1, "freed"); // this one is transient and should now have been freed automatically
+	rz_th_lock_leave (shared_ctx.free_lock);
+
+	rz_core_task_yield (&sched);
+	mu_assert_streq (rz_strbuf_get (&shared_ctx.log),
+			"Context switch to main\n"
+			"Context switch to 1\n"
+			"Runner 1 start\n"
+			"Runner 1 consume 3\n"
+			"Context switch to 2\n"
+			"Runner 2 start\n"
+			"Runner 2 consume 3\n"
+			"Context switch to main\n"
+			"Context switch to 1\n"
+			"Runner 1 consume 2\n"
+			"Context switch to 2\n"
+			"Runner 2 was breaked!\n"
+			"Runner 2 done\n"
+			"Context switch to main\n"
+			"Context switch to 1\n"
+			"Runner 1 consume 1\n"
+			"Context switch to main\n",
+			"log");
+
+	rz_core_task_yield (&sched);
+	mu_assert_streq (rz_strbuf_get (&shared_ctx.log),
+			"Context switch to main\n"
+			"Context switch to 1\n"
+			"Runner 1 start\n"
+			"Runner 1 consume 3\n"
+			"Context switch to 2\n"
+			"Runner 2 start\n"
+			"Runner 2 consume 3\n"
+			"Context switch to main\n"
+			"Context switch to 1\n"
+			"Runner 1 consume 2\n"
+			"Context switch to 2\n"
+			"Runner 2 was breaked!\n"
+			"Runner 2 done\n"
+			"Context switch to main\n"
+			"Context switch to 1\n"
+			"Runner 1 consume 1\n"
+			"Context switch to main\n"
+			"Context switch to 1\n"
+			"Runner 1 done\n"
+			"Context switch to main\n",
+			"log");
+
+	// everything done now and no new logs should happen
+
+	rz_core_task_yield (&sched);
+	mu_assert_streq (rz_strbuf_get (&shared_ctx.log),
+			"Context switch to main\n"
+			"Context switch to 1\n"
+			"Runner 1 start\n"
+			"Runner 1 consume 3\n"
+			"Context switch to 2\n"
+			"Runner 2 start\n"
+			"Runner 2 consume 3\n"
+			"Context switch to main\n"
+			"Context switch to 1\n"
+			"Runner 1 consume 2\n"
+			"Context switch to 2\n"
+			"Runner 2 was breaked!\n"
+			"Runner 2 done\n"
+			"Context switch to main\n"
+			"Context switch to 1\n"
+			"Runner 1 consume 1\n"
+			"Context switch to main\n"
+			"Context switch to 1\n"
+			"Runner 1 done\n"
+			"Context switch to main\n",
+			"log");
+
+	rz_th_lock_enter (shared_ctx.free_lock);
+	mu_assert_eq (a_ctx.freed, 0, "freed"); // this one isn't transient so need to free it manually
+	mu_assert_eq (b_ctx.freed, 1, "freed");
+	rz_th_lock_leave (shared_ctx.free_lock);
+	rz_core_task_del (&sched, a_id);
+	rz_th_lock_enter (shared_ctx.free_lock);
+	mu_assert_eq (a_ctx.freed, 1, "freed");
+	mu_assert_eq (b_ctx.freed, 1, "freed");
+	rz_th_lock_leave (shared_ctx.free_lock);
+
+	rz_core_task_sync_end (&sched);
+	rz_core_task_join (&sched, NULL, -1);
+	rz_core_task_scheduler_fini (&sched);
+
+	rz_th_lock_free (shared_ctx.free_lock);
+	rz_strbuf_fini (&shared_ctx.log);
+
+	mu_end;
+}
+
+// This test is best served with helgrind
+static int all_tests(void) {
+	mu_run_test (test_task);
+	return tests_passed != tests_run;
+}
+
+int main(int argc, char **argv) {
+	return all_tests ();
+}


### PR DESCRIPTION
(More context in the comments)

This makes the low-level tasks code almost completely independent of RzCore. RzCore then puts a layer on top if the tasks to allow having a task-local cons context. This also introduces function tasks in addition to just command tasks.