### PR TITLE
Remember project file after save and add Ps without args

### DIFF
--- a/librz/core/cmd_descs.c
+++ b/librz/core/cmd_descs.c
@@ -568,7 +568,7 @@ static const RzCmdDescHelp P_help = {
 	.summary = "Project management",
 };
 static const RzCmdDescArg project_save_args[] = {
-	{ .name = "project.rzdb", .type = RZ_CMD_ARG_TYPE_FILE, },
+	{ .name = "project.rzdb", .type = RZ_CMD_ARG_TYPE_FILE, .optional = true, },
 	{ 0 },
 };
 static const RzCmdDescHelp project_save_help = {

--- a/librz/core/cmd_descs.yaml
+++ b/librz/core/cmd_descs.yaml
@@ -482,6 +482,7 @@
       args:
         - name: project.rzdb
           type: RZ_CMD_ARG_TYPE_FILE
+          optional: true
     - name: Po
       cname: project_open
       summary: Open a project

--- a/librz/core/cmd_project.c
+++ b/librz/core/cmd_project.c
@@ -3,9 +3,20 @@
 #include <rz_project.h>
 
 RZ_IPI RzCmdStatus rz_project_save_handler(RzCore *core, int argc, const char **argv) {
-	RzProjectErr err = rz_project_save_file (core, argv[1]);
+	const char *file;
+	if (argc == 1) {
+		file = rz_config_get (core->config, "prj.file");
+		if (!file || !*file) {
+			eprintf ("There is no project file associated with the current session yet.\n"
+				"Specify the file explitily as Ps <file.rzdb> or set it manually with e prj.file.\n");
+			return RZ_CMD_STATUS_ERROR;
+		}
+	} else { // argc == 2 checked by the shell
+		file = argv[1];
+	}
+	RzProjectErr err = rz_project_save_file (core, file);
 	if (err != RZ_PROJECT_ERR_SUCCESS) {
-		eprintf ("Failed to save project: %s\n", rz_project_err_message (err));
+		eprintf ("Failed to save project: %s to file %s\n", file, rz_project_err_message (err));
 	}
 	return RZ_CMD_STATUS_OK;
 }

--- a/librz/core/cmd_project.c
+++ b/librz/core/cmd_project.c
@@ -6,9 +6,9 @@ RZ_IPI RzCmdStatus rz_project_save_handler(RzCore *core, int argc, const char **
 	const char *file;
 	if (argc == 1) {
 		file = rz_config_get (core->config, "prj.file");
-		if (!file || !*file) {
+		if (RZ_STR_ISEMPTY (file)) {
 			eprintf ("There is no project file associated with the current session yet.\n"
-				"Specify the file explitily as Ps <file.rzdb> or set it manually with e prj.file.\n");
+				"Specify the file explitily as `Ps <file.rzdb>` or set it manually with `e prj.file=<project-path>`.\n");
 			return RZ_CMD_STATUS_ERROR;
 		}
 	} else { // argc == 2 checked by the shell
@@ -16,7 +16,7 @@ RZ_IPI RzCmdStatus rz_project_save_handler(RzCore *core, int argc, const char **
 	}
 	RzProjectErr err = rz_project_save_file (core, file);
 	if (err != RZ_PROJECT_ERR_SUCCESS) {
-		eprintf ("Failed to save project: %s to file %s\n", file, rz_project_err_message (err));
+		eprintf ("Failed to save project to file %s: %s\n", file, rz_project_err_message (err));
 	}
 	return RZ_CMD_STATUS_OK;
 }

--- a/librz/core/project.c
+++ b/librz/core/project.c
@@ -51,6 +51,9 @@ RZ_API RzProjectErr rz_project_save_file(RzCore *core, const char *file) {
 		err = RZ_PROJECT_ERR_FILE;
 	}
 	sdb_free (prj);
+	if (err == RZ_PROJECT_ERR_SUCCESS) {
+		rz_config_set (core->config, "prj.file", file);
+	}
 	return err;
 }
 

--- a/test/db/cmd/project
+++ b/test/db/cmd/project
@@ -307,3 +307,28 @@ EXPECT=<<EOF
 0x00000100    1 48           windowpane
 EOF
 RUN
+
+NAME=remember saved project file during session
+FILE=bins/elf/crackme0x05
+CMDS=<<EOF
+e cfg.newshell=1
+Ps .tmp_remember.rzdb
+e prj.file
+f cashews @ 0x080483d8
+Ps
+o--
+e prj.file=
+e prj.file
+Po .tmp_remember.rzdb
+e prj.file
+rm .tmp_remember.rzdb
+pdi 1 @ 0x080483d8
+EOF
+EXPECT=<<EOF
+.tmp_remember.rzdb
+
+.tmp_remember.rzdb
+0x080483d8   cashews:
+0x080483d8                   50  push eax
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**

After saving a project explicitly using `Ps file.rzdb` you can just type `Ps` to save to the same file again.

**Test plan**

run the tests