### PR TITLE
Fix external AppVeyor tests that are XX

### DIFF
--- a/test/db/cmd/cmd_pa
+++ b/test/db/cmd/cmd_pa
@@ -26,3 +26,11 @@ ffd0
 1021
 EOF
 RUN
+
+NAME=att pa
+FILE=--
+CMDS=pa add $33, %rbx @a:x86.as:64 @e:asm.syntax=att
+EXPECT=<<EOF
+4883c321
+EOF
+RUN

--- a/test/db/formats/mangling/rust
+++ b/test/db/formats/mangling/rust
@@ -24,7 +24,7 @@ RUN
 
 NAME=rust static type
 FILE=-
-CMDS=!rz-bin -D rust '_ZN71_$LT$Test$u20$$u2b$$u20$$u27$static$u20$as$u20$foo..Bar$LT$Test$GT$$GT$3barE'
+CMDS=iD rust _ZN71_$LT$Test$u20$$u2b$$u20$$u27$static$u20$as$u20$foo..Bar$LT$Test$GT$$GT$3barE
 EXPECT=<<EOF
 <Test + 'static as foo::Bar<Test>>::bar
 EOF
@@ -32,7 +32,7 @@ RUN
 
 NAME=rust static type with hash
 FILE=-
-CMDS=!rz-bin -D rust '_ZN96_$LT$core..fmt..Write..write_fmt..Adapter$LT$$u27$a$C$$u20$T$GT$$u20$as$u20$core..fmt..Write$GT$9write_str17he4f4768a2f446facE'
+CMDS=iD rust _ZN96_$LT$core..fmt..Write..write_fmt..Adapter$LT$$u27$a$C$$u20$T$GT$$u20$as$u20$core..fmt..Write$GT$9write_str17he4f4768a2f446facE
 EXPECT=<<EOF
 <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str::he4f4768a2f446fac
 EOF

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -131,6 +131,7 @@ EOF
 RUN
 
 NAME=rz-asm #1167 5
+BROKEN=1
 FILE=-
 CMDS=!rz-asm -s att -a x86.as -b 64 'add $33, %rbx'
 EXPECT=<<EOF

--- a/test/db/tools/rz_bin
+++ b/test/db/tools/rz_bin
@@ -1052,3 +1052,21 @@ EXPECT_ERR=<<EOF
 Cannot open empty path
 EOF
 RUN
+
+NAME=rz-bin rust static type
+BROKEN=1
+FILE=-
+CMDS=!rz-bin -D rust '_ZN71_$LT$Test$u20$$u2b$$u20$$u27$static$u20$as$u20$foo..Bar$LT$Test$GT$$GT$3barE'
+EXPECT=<<EOF
+<Test + 'static as foo::Bar<Test>>::bar
+EOF
+RUN
+
+NAME=rz-bin rust static type with hash
+BROKEN=1
+FILE=-
+CMDS=!rz-bin -D rust '_ZN96_$LT$core..fmt..Write..write_fmt..Adapter$LT$$u27$a$C$$u20$T$GT$$u20$as$u20$core..fmt..Write$GT$9write_str17he4f4768a2f446facE'
+EXPECT=<<EOF
+<core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str::he4f4768a2f446fac
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The pr fixes the XX AppVeyor tests by rewriting them using internal commands and marking the external version as broken. Also moved the broken `rz-bin` tests into `tools/rz_bin`.

@ret2libc I'd be happy to fix #110 so that it works with this pr. AppVeyor should be green asap though, since it is a pain to check the AppVeyor logs to see whether there is additional redness.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green, including AppVeyor.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
