### PR TITLE
Fix external AppVeyor tests that are XX

### DIFF
--- a/test/db/cmd/cmd_pa
+++ b/test/db/cmd/cmd_pa
@@ -26,3 +26,11 @@ ffd0
 1021
 EOF
 RUN
+
+NAME=att pa
+FILE=--
+CMDS=pa add $33, %rbx @a:x86.as:64 @e:asm.syntax=att
+EXPECT=<<EOF
+4883c321
+EOF
+RUN

--- a/test/db/formats/mangling/rust
+++ b/test/db/formats/mangling/rust
@@ -24,7 +24,7 @@ RUN
 
 NAME=rust static type
 FILE=-
-CMDS=!rz-bin -D rust '_ZN71_$LT$Test$u20$$u2b$$u20$$u27$static$u20$as$u20$foo..Bar$LT$Test$GT$$GT$3barE'
+CMDS=iD rust _ZN71_$LT$Test$u20$$u2b$$u20$$u27$static$u20$as$u20$foo..Bar$LT$Test$GT$$GT$3barE
 EXPECT=<<EOF
 <Test + 'static as foo::Bar<Test>>::bar
 EOF
@@ -32,7 +32,7 @@ RUN
 
 NAME=rust static type with hash
 FILE=-
-CMDS=!rz-bin -D rust '_ZN96_$LT$core..fmt..Write..write_fmt..Adapter$LT$$u27$a$C$$u20$T$GT$$u20$as$u20$core..fmt..Write$GT$9write_str17he4f4768a2f446facE'
+CMDS=iD rust _ZN96_$LT$core..fmt..Write..write_fmt..Adapter$LT$$u27$a$C$$u20$T$GT$$u20$as$u20$core..fmt..Write$GT$9write_str17he4f4768a2f446facE
 EXPECT=<<EOF
 <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str::he4f4768a2f446fac
 EOF

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -131,6 +131,7 @@ EOF
 RUN
 
 NAME=rz-asm #1167 5
+BROKEN=1
 FILE=-
 CMDS=!rz-asm -s att -a x86.as -b 64 'add $33, %rbx'
 EXPECT=<<EOF

--- a/test/db/tools/rz_bin
+++ b/test/db/tools/rz_bin
@@ -1052,3 +1052,21 @@ EXPECT_ERR=<<EOF
 Cannot open empty path
 EOF
 RUN
+
+NAME=rz-bin rust static type
+BROKEN=1
+FILE=-
+CMDS=!rz-bin -D rust '_ZN71_$LT$Test$u20$$u2b$$u20$$u27$static$u20$as$u20$foo..Bar$LT$Test$GT$$GT$3barE'
+EXPECT=<<EOF
+<Test + 'static as foo::Bar<Test>>::bar
+EOF
+RUN
+
+NAME=rz-bin rust static type with hash
+BROKEN=1
+FILE=-
+CMDS=!rz-bin -D rust '_ZN96_$LT$core..fmt..Write..write_fmt..Adapter$LT$$u27$a$C$$u20$T$GT$$u20$as$u20$core..fmt..Write$GT$9write_str17he4f4768a2f446facE'
+EXPECT=<<EOF
+<core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str::he4f4768a2f446fac
+EOF
+RUN


### PR DESCRIPTION
 This is the same pr as #180 but with the branch name renamed from `fix-external-xx-windows` to `windows-fix-external-xx`.