### PR TITLE
Fix assert in anj for address

### DIFF
--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -1169,7 +1169,6 @@ static int cmd_an(RzCore *core, bool use_json, const char *name) {
 				rz_cons_printf ("0x%" PFMT64x "\n", tgt_addr);
 			} else {
 				pj_o (pj);
-				pj_ks (pj, "name", name);
 				pj_ks (pj, "type", "address");
 				pj_kn (pj, "offset", tgt_addr);
 				pj_end (pj);

--- a/test/db/cmd/cmd_an
+++ b/test/db/cmd/cmd_an
@@ -32,3 +32,22 @@ EXPECT=<<EOF
 renamed_strlen
 EOF
 RUN
+
+NAME=an address
+FILE=bins/elf/crackme0x05
+CMDS=<<EOF
+s 0x0804840d
+an
+anj
+an jumptarget
+an
+anj
+EOF
+EXPECT=<<EOF
+0x8048411
+[{"type":"address","offset":134513681}]
+jumptarget
+[{"name":"jumptarget","realname":"jumptarget","type":"flag","offset":134513681}]
+EOF
+EXPECT_ERR=
+RUN


### PR DESCRIPTION
This fixes quite a lot of spam in Cutter. Note that in this else branch, `name` is always guaranteed to be null so the line makes no sense at all there.