### PR TITLE
Make Strings in RzAnalysisPlugin const char * ##analysis

### DIFF
--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1303,12 +1303,12 @@ typedef int (*RzAnalysisEsilLoopCB)(RzAnalysisEsil *esil, RzAnalysisOp *op);
 typedef int (*RzAnalysisEsilTrapCB)(RzAnalysisEsil *esil, int trap_type, int trap_code);
 
 typedef struct rz_analysis_plugin_t {
-	char *name;
-	char *desc;
-	char *license;
-	char *arch;
-	char *author;
-	char *version;
+	const char *name;
+	const char *desc;
+	const char *license;
+	const char *arch;
+	const char *author;
+	const char *version;
 	int bits;
 	int esil; // can do esil or not
 	int fileformat_type;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**

This is mostly important for C++ where otherwise you get things like this:
```
[13/22] Building CXX object CMakeFiles/analysis_ghidra.dir/src/analysis_ghidra.cpp.o
../src/analysis_ghidra.cpp:3273:16: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
 3273 |  /* .name = */ "ghidra",
      |                ^~~~~~~~
../src/analysis_ghidra.cpp:3274:16: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
 3274 |  /* .desc = */ "SLEIGH Disassembler from Ghidra",
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/analysis_ghidra.cpp:3275:19: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
 3275 |  /* .license = */ "GPL3",
      |                   ^~~~~~
../src/analysis_ghidra.cpp:3276:16: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
 3276 |  /* .arch = */ "sleigh",
      |                ^~~~~~~~
../src/analysis_ghidra.cpp:3277:18: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
 3277 |  /* .author = */ "FXTi",
      |                  ^~~~~~
```

**Test plan**

all plugins still build without warnings