### PR TITLE
Add Exclusions to RzConfig Loading

### DIFF
--- a/librz/config/serialize_config.c
+++ b/librz/config/serialize_config.c
@@ -23,17 +23,40 @@ RZ_API void rz_serialize_config_save(RZ_NONNULL Sdb *db, RZ_NONNULL RzConfig *co
 	}
 }
 
+typedef struct load_config_ctx_t {
+	RzConfig *config;
+	HtPP *exclude;
+} LoadConfigCtx;
+
 static bool load_config_cb(void *user, const char *k, const char *v) {
-	RzConfig *config = user;
-	RzConfigNode *node = rz_config_node_get (config, k);
+	LoadConfigCtx *ctx = user;
+	if (ctx->exclude && ht_pp_find_kv (ctx->exclude, k, NULL)) {
+		return true;
+	}
+	RzConfigNode *node = rz_config_node_get (ctx->config, k);
 	if (!node) {
 		return 1;
 	}
-	rz_config_set (config, k, v);
+	rz_config_set (ctx->config, k, v);
 	return 1;
 }
 
-RZ_API bool rz_serialize_config_load(RZ_NONNULL Sdb *db, RZ_NONNULL RzConfig *config, RZ_NULLABLE RzSerializeResultInfo *res) {
-	sdb_foreach (db, load_config_cb, config);
+/**
+ * @param exclude NULL-terminated array of keys to not load from the sdb.
+ */
+RZ_API bool rz_serialize_config_load(RZ_NONNULL Sdb *db, RZ_NONNULL RzConfig *config,
+		RZ_NULLABLE const char * const *exclude, RZ_NULLABLE RzSerializeResultInfo *res) {
+	LoadConfigCtx ctx = { config, NULL };
+	if (exclude) {
+		ctx.exclude = ht_pp_new (NULL, NULL, NULL);
+		if (!ctx.exclude) {
+			return false;
+		}
+		for (; *exclude; exclude++) {
+			ht_pp_insert (ctx.exclude, *exclude, NULL);
+		}
+	}
+	sdb_foreach (db, load_config_cb, &ctx);
+	ht_pp_free (ctx.exclude);
 	return true;
 }

--- a/librz/core/serialize_core.c
+++ b/librz/core/serialize_core.c
@@ -39,6 +39,12 @@ RZ_API void rz_serialize_core_save(RZ_NONNULL Sdb *db, RZ_NONNULL RzCore *core, 
 	sdb_set (db, "blocksize", buf, 0);
 }
 
+static const char * const config_exclude[] = {
+	"scr.interactive", // especially relevant for Cutter since it needs this to be false
+	"scr.color",
+	NULL
+};
+
 RZ_API bool rz_serialize_core_load(RZ_NONNULL Sdb *db, RZ_NONNULL RzCore *core, bool load_bin_io,
 		RZ_NULLABLE const char *prj_file, RZ_NULLABLE RzSerializeResultInfo *res) {
 	Sdb *subdb;
@@ -48,7 +54,7 @@ RZ_API bool rz_serialize_core_load(RZ_NONNULL Sdb *db, RZ_NONNULL RzCore *core, 
 	if (load_bin_io) {
 		SUB ("file", file_load (subdb, core, prj_file, res));
 	}
-	SUB ("config", rz_serialize_config_load (subdb, core->config, res));
+	SUB ("config", rz_serialize_config_load (subdb, core->config, config_exclude, res));
 	SUB ("flags", rz_serialize_flag_load (subdb, core->flags, res));
 	SUB ("analysis", rz_serialize_analysis_load (subdb, core->analysis, res));
 

--- a/librz/include/rz_config.h
+++ b/librz/include/rz_config.h
@@ -118,7 +118,8 @@ static inline bool rz_config_node_is_str(RzConfigNode *node) {
 /* serialize */
 
 RZ_API void rz_serialize_config_save(RZ_NONNULL Sdb *db, RZ_NONNULL RzConfig *config);
-RZ_API bool rz_serialize_config_load(RZ_NONNULL Sdb *db, RZ_NONNULL RzConfig *config, RZ_NULLABLE RzSerializeResultInfo *res);
+RZ_API bool rz_serialize_config_load(RZ_NONNULL Sdb *db, RZ_NONNULL RzConfig *config,
+		RZ_NULLABLE const char * const *exclude, RZ_NULLABLE RzSerializeResultInfo *res);
 #endif
 
 #ifdef __cplusplus

--- a/test/unit/test_serialize_config.c
+++ b/test/unit/test_serialize_config.c
@@ -38,7 +38,7 @@ bool test_config_load() {
 
 	Sdb *db = ref_db ();
 	sdb_set (db, "sneaky", "not part of config", 0);
-	bool loaded = rz_serialize_config_load (db, config, NULL);
+	bool loaded = rz_serialize_config_load (db, config, NULL, NULL);
 	sdb_free (db);
 	mu_assert ("load success", loaded);
 
@@ -50,9 +50,35 @@ bool test_config_load() {
 	mu_end;
 }
 
+bool test_config_load_exclude() {
+	static const char * const exclude[] = {
+		"somestring",
+		"someint",
+		NULL
+	};
+	RzConfig *config = rz_config_new (NULL);
+	rz_config_set (config, "somestring", "someoldvalue");
+	rz_config_set_i (config, "someint", 123);
+	rz_config_set_i (config, "somebiggerint", 0);
+	rz_config_lock (config, true);
+
+	Sdb *db = ref_db ();
+	bool loaded = rz_serialize_config_load (db, config, exclude, NULL);
+	sdb_free (db);
+	mu_assert ("load success", loaded);
+
+	mu_assert_eq (rz_list_length (config->nodes), 3, "count after load");
+	mu_assert_streq (rz_config_get (config, "somestring"), "someoldvalue", "excluded config string");
+	mu_assert_eq_fmt (rz_config_get_i (config, "someint"), (ut64)123, "excluded config int", "%"PFMT64u);
+	mu_assert_eq_fmt (rz_config_get_i (config, "somebiggerint"), (ut64)0x1337, "loaded config bigger int", "0x%"PFMT64x);
+	rz_config_free (config);
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test (test_config_save);
 	mu_run_test (test_config_load);
+	mu_run_test (test_config_load_exclude);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**

More exclusions should follow, but these are the two most important ones for Cutter.
For example Cutter needs `scr.interactive` to be set to false, otherwise you will get some weird behavior in a few places.
But for command line rizin, you also don't want everything to be loaded. Also here, when you load a project that was created in Cutter or any other environment where `scr.interactive` was false or `scr.color` was set to something else, you don't suddenly want your shell to change but keep your local settings.

The solution here is to just exclude certain config vars when loading.