### PR TITLE
Disable clang-cl -fno-common

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -133,6 +133,7 @@ if get_option('static_runtime')
 endif
 
 if cc.get_id() == 'clang-cl'
+  add_project_arguments('-fcommon', language: 'c')
   add_project_arguments('-D__STDC__=1', language: 'c')
   add_project_arguments('-D_CRT_DECLARE_NONSTDC_NAMES ', language: 'c')
   add_project_arguments('-D_CRT_SECURE_NO_WARNINGS', language: 'c')


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**

[Clang 11](https://releases.llvm.org/11.0.0/tools/clang/docs/ReleaseNotes.html#modified-compiler-flags) enabled -fno-common by default to make all globals used in multiple files behave as redefined static globals if they weren't defined as extern

> -fno-common has been enabled as the default for all targets. Therefore, C code that uses tentative definitions as definitions of a variable in multiple translation units will trigger multiple-definition linker errors. Generally, this occurs when the use of the extern keyword is neglected in the declaration of a variable in a header file. In some cases, no specific translation unit provides a definition of the variable. The previous behavior can be restored by specifying -fcommon.

This triggers a duplicate symbol error for all w32 functions that are used in multiple .c files. 

Reverting this flag seems to be a good solution for now since it's consistent with other compilers' behavior. I am not sure if we should access those functions through `dbg->user` instead of using global variables by adding it to [`W32DbgWInst`](https://github.com/rizinorg/rizin/blob/dev/shlr/w32dbg_wrap/include/w32dbg_wrap.h#L40). Setting them to `extern` will require redeclaring 1-21 function pointers in each .c file, only setting extern to the ones used outside of `debug_windows.c` may be error prone and `static` required this change - 2d9db900627140d9050eb3a0db6e33f00b86d214.

**Test plan**

See that appveyor clang-cl is green