### PR TITLE
Implement rz_subprocess_start_opt API to choose pipes

### DIFF
--- a/binrz/rz-test/run.c
+++ b/binrz/rz-test/run.c
@@ -8,13 +8,13 @@ static RzSubprocessOutput *subprocess_runner(const char *file, const char *args[
 	if (!proc) {
 		return NULL;
 	}
-	bool timeout = !rz_subprocess_wait(proc, timeout_ms);
-	if (timeout) {
+	RzSubprocessWaitReason r = rz_subprocess_wait(proc, timeout_ms);
+	if (r == RZ_SUBPROCESS_TIMEDOUT) {
 		rz_subprocess_kill(proc);
 	}
 	RzSubprocessOutput *out = rz_subprocess_drain(proc);
 	if (out) {
-		out->timeout = timeout;
+		out->timeout = r == RZ_SUBPROCESS_TIMEDOUT;
 	}
 	rz_subprocess_free(proc);
 	return out;
@@ -280,7 +280,7 @@ RZ_API RzAsmTestOutput *rz_test_run_asm_test(RzTestRunConfig *config, RzAsmTest 
 	if (test->mode & RZ_ASM_TEST_MODE_ASSEMBLE) {
 		rz_pvector_push(&args, test->disasm);
 		RzSubprocess *proc = rz_subprocess_start(config->rz_asm_cmd, args.v.a, rz_pvector_len(&args), NULL, NULL, 0);
-		if (!rz_subprocess_wait(proc, config->timeout_ms)) {
+		if (rz_subprocess_wait(proc, config->timeout_ms) == RZ_SUBPROCESS_TIMEDOUT) {
 			rz_subprocess_kill(proc);
 			out->as_timeout = true;
 			goto rip;
@@ -314,7 +314,7 @@ RZ_API RzAsmTestOutput *rz_test_run_asm_test(RzTestRunConfig *config, RzAsmTest 
 		rz_pvector_push(&args, "-d");
 		rz_pvector_push(&args, hex);
 		RzSubprocess *proc = rz_subprocess_start(config->rz_asm_cmd, args.v.a, rz_pvector_len(&args), NULL, NULL, 0);
-		if (!rz_subprocess_wait(proc, config->timeout_ms)) {
+		if (rz_subprocess_wait(proc, config->timeout_ms) == RZ_SUBPROCESS_TIMEDOUT) {
 			rz_subprocess_kill(proc);
 			out->disas_timeout = true;
 			goto ship;

--- a/librz/include/rz_util/rz_subprocess.h
+++ b/librz/include/rz_util/rz_subprocess.h
@@ -3,12 +3,49 @@
 #ifndef RZ_UTIL_SUBPROCESS_H
 #define RZ_UTIL_SUBPROCESS_H
 
+/**
+ * Enum used to determine how pipes should be created, if at all, in the
+ * subprocess.
+ */
+typedef enum rz_process_pipe_t {
+	///< No pipe should be created. It can be used for stdin, stdout and stderr.
+	RZ_PROCESS_PIPE_NONE,
+	///< A new pipe should be created. It can be used for stdin, stdout and stderr.
+	RZ_PROCESS_PIPE_CREATE,
+	///< Re-use the same pipe as stdout. It can be used for stderr only.
+	RZ_PROCESS_PIPE_STDOUT,
+} RzSubprocessPipe;
+
 typedef struct rz_process_output_t {
 	char *out; // stdout
 	char *err; // stderr
 	int ret; // exit code of the process
 	bool timeout;
 } RzSubprocessOutput;
+
+/**
+ * Specify how the new subprocess should be created.
+ */
+typedef struct rz_subprocess_opt_t {
+	///< Name of the executable to run. It is searched also in PATH
+	const char *file;
+	///< Arguments to pass to the subprocess. These are just the arguments and do not include the program name (aka argv[0])
+	const char **args;
+	///< Number of arguments in \p args array
+	size_t args_size;
+	///< Names of environment variables that subprocess should have differently from parent
+	const char **envvars;
+	///< Values of environment variables that subprocess should have differently from parent
+	const char **envvals;
+	///< Number of elements contained in both \p envvars and \p envvals
+	size_t env_size;
+	///< Specify how to deal with subprocess stdin
+	RzSubprocessPipe stdin_pipe;
+	///< Specify how to deal with subprocess stdout
+	RzSubprocessPipe stdout_pipe;
+	///< Specify how to deal with subprocess stderr
+	RzSubprocessPipe stderr_pipe;
+} RzSubprocessOpt;
 
 typedef struct rz_subprocess_t RzSubprocess;
 
@@ -17,6 +54,7 @@ RZ_API void rz_subprocess_fini(void);
 RZ_API RzSubprocess *rz_subprocess_start(
 	const char *file, const char *args[], size_t args_size,
 	const char *envvars[], const char *envvals[], size_t env_size);
+RZ_API RzSubprocess *rz_subprocess_start_opt(RzSubprocessOpt *opt);
 RZ_API void rz_subprocess_free(RzSubprocess *proc);
 RZ_API bool rz_subprocess_wait(RzSubprocess *proc, ut64 timeout_ms);
 RZ_API void rz_subprocess_kill(RzSubprocess *proc);

--- a/librz/include/rz_util/rz_subprocess.h
+++ b/librz/include/rz_util/rz_subprocess.h
@@ -7,14 +7,27 @@
  * Enum used to determine how pipes should be created, if at all, in the
  * subprocess.
  */
-typedef enum rz_process_pipe_t {
+typedef enum rz_subprocess_pipe_create_t {
 	///< No pipe should be created. It can be used for stdin, stdout and stderr.
-	RZ_PROCESS_PIPE_NONE,
+	RZ_SUBPROCESS_PIPE_NONE,
 	///< A new pipe should be created. It can be used for stdin, stdout and stderr.
-	RZ_PROCESS_PIPE_CREATE,
+	RZ_SUBPROCESS_PIPE_CREATE,
 	///< Re-use the same pipe as stdout. It can be used for stderr only.
-	RZ_PROCESS_PIPE_STDOUT,
-} RzSubprocessPipe;
+	RZ_SUBPROCESS_PIPE_STDOUT,
+} RzSubprocessPipeCreate;
+
+/**
+ * Values passed to rz_subprocess API to mention stdin, stdout, stderr or a combination of those
+ */
+#define RZ_SUBPROCESS_STDIN  (1 << 0)
+#define RZ_SUBPROCESS_STDOUT (1 << 1)
+#define RZ_SUBPROCESS_STDERR (1 << 2)
+
+typedef enum rz_process_wait_reason_t {
+	RZ_SUBPROCESS_DEAD,
+	RZ_SUBPROCESS_TIMEDOUT,
+	RZ_SUBPROCESS_BYTESREAD,
+} RzSubprocessWaitReason;
 
 typedef struct rz_process_output_t {
 	char *out; // stdout
@@ -40,11 +53,11 @@ typedef struct rz_subprocess_opt_t {
 	///< Number of elements contained in both \p envvars and \p envvals
 	size_t env_size;
 	///< Specify how to deal with subprocess stdin
-	RzSubprocessPipe stdin_pipe;
+	RzSubprocessPipeCreate stdin_pipe;
 	///< Specify how to deal with subprocess stdout
-	RzSubprocessPipe stdout_pipe;
+	RzSubprocessPipeCreate stdout_pipe;
 	///< Specify how to deal with subprocess stderr
-	RzSubprocessPipe stderr_pipe;
+	RzSubprocessPipeCreate stderr_pipe;
 } RzSubprocessOpt;
 
 typedef struct rz_subprocess_t RzSubprocess;
@@ -56,12 +69,14 @@ RZ_API RzSubprocess *rz_subprocess_start(
 	const char *envvars[], const char *envvals[], size_t env_size);
 RZ_API RzSubprocess *rz_subprocess_start_opt(RzSubprocessOpt *opt);
 RZ_API void rz_subprocess_free(RzSubprocess *proc);
-RZ_API bool rz_subprocess_wait(RzSubprocess *proc, ut64 timeout_ms);
+RZ_API RzSubprocessWaitReason rz_subprocess_wait(RzSubprocess *proc, ut64 timeout_ms);
 RZ_API void rz_subprocess_kill(RzSubprocess *proc);
 RZ_API int rz_subprocess_ret(RzSubprocess *proc);
 RZ_API char *rz_subprocess_out(RzSubprocess *proc);
 RZ_API char *rz_subprocess_err(RzSubprocess *proc);
-RZ_API void rz_subprocess_stdin_write(RzSubprocess *proc, const ut8 *buf, size_t buf_size);
+RZ_API ssize_t rz_subprocess_stdin_write(RzSubprocess *proc, const ut8 *buf, size_t buf_size);
+RZ_API RzStrBuf *rz_subprocess_stdout_read(RzSubprocess *proc, size_t n, ut64 timeout_ms);
+RZ_API RzStrBuf *rz_subprocess_stdout_readline(RzSubprocess *proc, ut64 timeout_ms);
 RZ_API RzSubprocessOutput *rz_subprocess_drain(RzSubprocess *proc);
 RZ_API void rz_subprocess_output_free(RzSubprocessOutput *out);
 

--- a/librz/util/subprocess.c
+++ b/librz/util/subprocess.c
@@ -1,6 +1,8 @@
 #include <rz_cons.h>
 #include <rz_util.h>
 
+#define BUFFER_SIZE 0x500
+
 #if __WINDOWS__
 struct rz_subprocess_t {
 	HANDLE stdin_write;
@@ -274,8 +276,8 @@ static RzSubprocessWaitReason subprocess_wait(RzSubprocess *proc, ut64 timeout_m
 		timeout_us_abs = rz_time_now_mono() + timeout_ms * RZ_USEC_PER_MSEC;
 	}
 
-	char stdout_buf[0x500 + 1];
-	char stderr_buf[0x500 + 1];
+	char stdout_buf[BUFFER_SIZE + 1];
+	char stderr_buf[BUFFER_SIZE + 1];
 	bool stdout_enabled = (pipe_fd & RZ_SUBPROCESS_STDOUT) && proc->stdout_read;
 	bool stderr_enabled = (pipe_fd & RZ_SUBPROCESS_STDERR) && proc->stderr_read && proc->stderr_read != proc->stdout_read;
 	bool stdout_eof = false;
@@ -814,7 +816,7 @@ error:
 }
 
 static size_t read_to_strbuf(RzStrBuf *sb, int fd, bool *fd_eof, size_t n_bytes) {
-	char buf[0x500];
+	char buf[BUFFER_SIZE];
 	size_t to_read = sizeof(buf);
 	if (n_bytes && to_read > n_bytes) {
 		to_read = n_bytes;

--- a/test/unit/auxiliary/meson.build
+++ b/test/unit/auxiliary/meson.build
@@ -2,6 +2,7 @@ files = [
   'subprocess-helloworld',
   'subprocess-stdin',
   'subprocess-multiargs',
+  'subprocess-interactive',
 ]
 
 foreach file : files

--- a/test/unit/auxiliary/subprocess-interactive.c
+++ b/test/unit/auxiliary/subprocess-interactive.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+	int a, b, c, d;
+	scanf("%d", &a);
+	scanf("%d", &b);
+	srand(0xcafecafe);
+	c = rand();
+	printf("%d\n", c);
+	fflush(stdout);
+	scanf("%d", &d);
+	if (a + b + c == d) {
+		printf("Right\n");
+	} else {
+		printf("Wrong\n");
+	}
+	return 0;
+}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

So far the `RzSubprocess` API always created pipes for stdin/stdout/stderr, but this is not always desirables as in some cases a program may want to directly work with the terminal (e.g. `vim`). As we want to use subprocess API to implement pipe and `!` commands, I'm adding this API so that I can specify when I want pipes and when not.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Windows still needs to be implemented.