### PR TITLE
Add dbg.create_new_console to toggle console creation ##debug

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -1447,6 +1447,13 @@ static bool cb_dbg_follow_child(void *user, void *data) {
 	return true;
 }
 
+static bool cb_dbg_create_new_console(void *user, void *data) {
+	RzCore *core = (RzCore*) user;
+	RzConfigNode *node = (RzConfigNode*) data;
+	core->dbg->create_new_console = node->i_value;
+	return true;
+}
+
 static bool cb_dbg_trace_continue(void *user, void *data) {
 	RzCore *core = (RzCore*)user;
 	RzConfigNode *node = (RzConfigNode*)data;
@@ -3338,6 +3345,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETCB ("dbg.args", "", &cb_dbg_args, "Set the args of the program to debug");
 	SETCB ("dbg.follow.child", "false", &cb_dbg_follow_child, "Continue tracing the child process on fork. By default the parent process is traced");
 	SETCB ("dbg.trace_continue", "true", &cb_dbg_trace_continue, "Trace every instruction between the initial PC position and the PC position at the end of continue's execution");
+	SETCB ("dbg.create_new_console", "true", &cb_dbg_create_new_console, "Create a new console window for the debugee on debug start");
 	/* debug */
 	SETCB ("dbg.status", "false", &cb_dbgstatus, "Set cmd.prompt to '.dr*' or '.dr*;drd;sr PC;pi 1;s-'");
 #if DEBUGGER

--- a/librz/include/rz_debug.h
+++ b/librz/include/rz_debug.h
@@ -268,6 +268,7 @@ typedef struct rz_debug_t {
 	int trace_aftersyscall; /* stop after the syscall (before if disabled) */
 	int trace_clone; /* stop on new threads */
 	int follow_child; /* On fork, trace the child */
+	bool create_new_console; /* Create a new console window for the debugee on debug start */
 	char *glob_libs; /* stop on lib load */
 	char *glob_unlibs; /* stop on lib unload */
 	bool consbreak; /* SIGINT handle for attached processes */


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**

Lets you run the debugee in the current console - will be useful for windows debug tests once text output regex is ready.

**Test plan**

Run `ood` and `dc` after setting `e dbg.create_new_console=false` and see that the output is printed to the current console.
