### PR TITLE
Fix 'dr-' usage in the 'doc' command ##debug

### DIFF
--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -5287,10 +5287,10 @@ RZ_IPI int rz_cmd_debug(void *data, const char *input) {
 					rz_debug_detach (core->dbg, core->dbg->pid);
 				}
 			}
+			// Remove the target's registers from the flag list
+			rz_core_cmd0 (core, ".dr-");
 			// Reopen and rebase the original file
 			rz_core_cmd0 (core, "oo");
-			// Remove registers from the flag list
-			rz_core_cmd0 (core, "~dr-");
 			break;
 		case '?': // "do?"
 		default:


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**

Newshell detected the syntax error in `~dr-` and running `dr-` after closing the file meant that it didn't remove registers that were added from the target's register profile.

**Test plan**

See that `orig_rax`(or some other unique register that isn't available in the default register profile for the analyzed arch) is deleted after detaching from a gdb session using `doc`.