### PR TITLE
Reload File as r-x when loading a Project (Fix #266)

### DIFF
--- a/librz/analysis/reflines.c
+++ b/librz/analysis/reflines.c
@@ -150,7 +150,7 @@ do_skip:
 				}
 			}
 		}
-		if (!analysis->iob.is_valid_offset (analysis->iob.io, addr, 1)) {
+		if (!analysis->iob.is_valid_offset (analysis->iob.io, addr, RZ_PERM_X)) {
 			const int size = 4;
 			ptr += size;
 			addr += size;

--- a/librz/core/serialize_core.c
+++ b/librz/core/serialize_core.c
@@ -181,7 +181,7 @@ static FileRet try_load_file(RZ_NONNULL RzCore *core, const char *file, RZ_NULLA
 		return FILE_DOES_NOT_EXIST;
 	}
 
-	RzCoreFile *fh = rz_core_file_open (core, file, RZ_PERM_R, 0);
+	RzCoreFile *fh = rz_core_file_open (core, file, RZ_PERM_RX, 0);
 	if (!fh) {
 		SERIALIZE_ERR ("failed re-open file \"%s\" referenced by project", file);
 		return FILE_LOAD_FAIL;

--- a/test/db/cmd/project
+++ b/test/db/cmd/project
@@ -340,3 +340,26 @@ EXPECT=<<EOF
 0x080483d8                   50  push eax
 EOF
 RUN
+
+NAME=raw file permissions after reload
+FILE=bins/other/0x3
+CMDS=<<EOF
+e cfg.newshell=1
+om
+Ps .tmp_perms.rzdb
+o--
+?e --
+om
+?e --
+Po .tmp_perms.rzdb
+om
+rm .tmp_perms.rzdb
+EOF
+EXPECT=<<EOF
+ 1 fd: 3 +0x00000000 0x00000000 - 0x00000002 r-x 
+--
+--
+ 1 fd: 3 +0x00000000 0x00000000 - 0x00000002 r-x 
+EOF
+RUN
+


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**

The default perms when loading a file are `r-x`, as specified here:
https://github.com/rizinorg/rizin/blob/0dd48b62d3b1d1eb7734b6bed0f8917981e3ddd7/librz/main/rizin.c#L342
The simplified file-reloader in projects currently didn't replicate this but instead loaded as `r--` which doesn't make a big difference when the file goes through RzBin and is then mapped out with perms of the defined sections, but it stays the same for raw binaries like in the linked issue about z80.
Reflines are generated only for code marked as executable so they were missing there.

**Test plan**

see test and #266 

**Closing issues**

Fix #266
