### PR TITLE
rz-test: Use RZ_FREE instead of free in _result_info_free()-related code

### DIFF
--- a/binrz/rz-test/run.c
+++ b/binrz/rz-test/run.c
@@ -353,8 +353,8 @@ RZ_API void rz_test_asm_test_output_free(RzAsmTestOutput *out) {
 	if (!out) {
 		return;
 	}
-	free (out->disasm);
-	free (out->bytes);
+	RZ_FREE (out->disasm);
+	RZ_FREE (out->bytes);
 	free (out);
 }
 
@@ -485,9 +485,11 @@ RZ_API void rz_test_test_result_info_free(RzTestResultInfo *result) {
 		case RZ_TEST_TYPE_JSON:
 		case RZ_TEST_TYPE_FUZZ:
 			rz_subprocess_output_free (result->proc_out);
+			result->proc_out = NULL;
 			break;
 		case RZ_TEST_TYPE_ASM:
 			rz_test_asm_test_output_free (result->asm_out);
+			result->asm_out = NULL;
 			break;
 		}
 	}

--- a/librz/util/subprocess.c
+++ b/librz/util/subprocess.c
@@ -845,7 +845,7 @@ RZ_API void rz_subprocess_output_free(RzSubprocessOutput *out) {
 	if (!out) {
 		return;
 	}
-	free (out->out);
-	free (out->err);
+	RZ_FREE (out->out);
+	RZ_FREE (out->err);
 	free (out);
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr sets pointers of `_result_info_free()`-related code to NULL after freeing (using `RZ_FREE` or manually), intended as part of the effort to track down the following OpenBSD bug (https://builds.sr.ht/~xvilka/job/377421#task-test-636):

![openbsd-uaf](https://user-images.githubusercontent.com/12002672/103154798-19b79580-47d5-11eb-9ef9-fd355981ed51.PNG)

Cherry-picked from #260.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds, except maybe the OpenBSD build, are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
