### PR TITLE
Added support for regex in test output ##test

### DIFF
--- a/binrz/rz-test/run.c
+++ b/binrz/rz-test/run.c
@@ -170,11 +170,13 @@ RZ_API bool rz_test_check_cmd_test(RzSubprocessOutput *out, RzCmdTest *test) {
 		return false;
 	}
 	const char *expect_out = test->expect.value;
-	if (expect_out && strcmp (out->out, expect_out) != 0) {
+	const bool regex_out = test->regex_out.value;
+	if (expect_out && ((!regex_out && strcmp (expect_out, out->out)) || (regex_out && 1 != rz_regex_match (expect_out, "en", out->out)))) {
 		return false;
 	}
 	const char *expect_err = test->expect_err.value;
-	if (expect_err && strcmp (out->err, expect_err) != 0) {
+	const bool regex_err = test->regex_err.value;
+	if (expect_err && ((!regex_err && strcmp (expect_err, out->err)) || (regex_err && 1 != rz_regex_match (expect_err, "en", out->err)))) {
 		return false;
 	}
 	return true;

--- a/binrz/rz-test/run.c
+++ b/binrz/rz-test/run.c
@@ -165,18 +165,30 @@ RZ_API RzSubprocessOutput *rz_test_run_cmd_test(RzTestRunConfig *config, RzCmdTe
 	return out;
 }
 
+RZ_API bool rz_test_cmp_cmd_output(const char *output, const char *expect, const char *regexp) {
+	if (regexp) {
+		RzList *matches = rz_regex_get_match_list (regexp, "en", output);
+		const char *match = rz_list_to_str (matches, '\0');
+		bool equal = (0 == strcmp (expect, match));
+		rz_list_free (matches);
+		RZ_FREE (match);
+		return equal;
+	}
+	return (0 == strcmp (expect, output));
+}
+
 RZ_API bool rz_test_check_cmd_test(RzSubprocessOutput *out, RzCmdTest *test) {
 	if (!out || out->ret != 0 || !out->out || !out->err || out->timeout) {
 		return false;
 	}
 	const char *expect_out = test->expect.value;
-	const bool regex_out = test->regex_out.value;
-	if (expect_out && ((!regex_out && strcmp (expect_out, out->out)) || (regex_out && 1 != rz_regex_match (expect_out, "en", out->out)))) {
+	const char *regexp_out = test->regexp_out.value;
+	if (expect_out && !rz_test_cmp_cmd_output (out->out, expect_out, regexp_out)) {
 		return false;
 	}
 	const char *expect_err = test->expect_err.value;
-	const bool regex_err = test->regex_err.value;
-	if (expect_err && ((!regex_err && strcmp (expect_err, out->err)) || (regex_err && 1 != rz_regex_match (expect_err, "en", out->err)))) {
+	const char *regexp_err = test->regexp_err.value;
+	if (expect_err && !rz_test_cmp_cmd_output (out->err, expect_err, regexp_err)) {
 		return false;
 	}
 	return true;

--- a/binrz/rz-test/rz-test.c
+++ b/binrz/rz-test/rz-test.c
@@ -682,13 +682,16 @@ static void print_result_diff(RzTestRunConfig *config, RzTestResultInfo *result)
 	case RZ_TEST_TYPE_CMD: {
 		rz_test_run_cmd_test (config, result->test->cmd_test, print_runner, NULL);
 		const char *expect = result->test->cmd_test->expect.value;
-		if (expect && strcmp (result->proc_out->out, expect)) {
+		const char *out = result->proc_out->out;
+		const bool regex_out = result->test->cmd_test->regex_out.value;
+		if (expect && ((!regex_out && strcmp (expect, out)) || (regex_out && 1 != rz_regex_match (expect, "en", out)))) {
 			printf ("-- stdout\n");
-			print_diff (result->proc_out->out, expect, false);
+			print_diff (out, expect, false);
 		}
 		expect = result->test->cmd_test->expect_err.value;
 		const char *err = result->proc_out->err;
-		if (expect && strcmp (err, expect)) {
+		const bool regex_err = result->test->cmd_test->regex_err.value;
+		if (expect && ((!regex_err && strcmp (expect, err)) || (regex_err && 1 != rz_regex_match (expect, "en", err)))) {
 			printf ("-- stderr\n");
 			print_diff (err, expect, false);
 		} else if (*err) {

--- a/binrz/rz-test/rz_test.h
+++ b/binrz/rz-test/rz_test.h
@@ -53,9 +53,9 @@ typedef struct rz_test_cmd_test_t {
 	RzCmdTestStringRecord cmds;
 	RzCmdTestStringRecord expect;
 	RzCmdTestStringRecord expect_err;
+	RzCmdTestStringRecord regexp_out;
+	RzCmdTestStringRecord regexp_err;
 	RzCmdTestBoolRecord broken;
-	RzCmdTestBoolRecord regex_out;
-	RzCmdTestBoolRecord regex_err;
 	RzCmdTestNumRecord timeout;
 	ut64 run_line;
 	bool load_plugins;
@@ -71,9 +71,9 @@ typedef struct rz_test_cmd_test_t {
 	macro_str ("CMDS", cmds) \
 	macro_str ("EXPECT", expect) \
 	macro_str ("EXPECT_ERR", expect_err) \
-	macro_bool ("BROKEN", broken) \
-	macro_bool ("REGEX_OUT", regex_out) \
-	macro_bool ("REGEX_ERR", regex_err)
+	macro_str ("REGEXP_OUT", regexp_out) \
+	macro_str ("REGEXP_ERR", regexp_err) \
+	macro_bool ("BROKEN", broken)
 
 typedef enum rz_test_asm_test_mode_t {
 	RZ_ASM_TEST_MODE_ASSEMBLE = 1,
@@ -184,6 +184,7 @@ typedef RzSubprocessOutput *(*RzTestCmdRunner)(const char *file, const char *arg
 
 RZ_API RzSubprocessOutput *rz_test_run_cmd_test(RzTestRunConfig *config, RzCmdTest *test, RzTestCmdRunner runner, void *user);
 RZ_API bool rz_test_check_cmd_test(RzSubprocessOutput *out, RzCmdTest *test);
+RZ_API bool rz_test_cmp_cmd_output(const char *output, const char *expect, const char *regexp);
 RZ_API bool rz_test_check_jq_available(void);
 RZ_API RzSubprocessOutput *rz_test_run_json_test(RzTestRunConfig *config, RzJsonTest *test, RzTestCmdRunner runner, void *user);
 RZ_API bool rz_test_check_json_test(RzSubprocessOutput *out, RzJsonTest *test);

--- a/binrz/rz-test/rz_test.h
+++ b/binrz/rz-test/rz_test.h
@@ -54,6 +54,8 @@ typedef struct rz_test_cmd_test_t {
 	RzCmdTestStringRecord expect;
 	RzCmdTestStringRecord expect_err;
 	RzCmdTestBoolRecord broken;
+	RzCmdTestBoolRecord regex_out;
+	RzCmdTestBoolRecord regex_err;
 	RzCmdTestNumRecord timeout;
 	ut64 run_line;
 	bool load_plugins;
@@ -69,7 +71,9 @@ typedef struct rz_test_cmd_test_t {
 	macro_str ("CMDS", cmds) \
 	macro_str ("EXPECT", expect) \
 	macro_str ("EXPECT_ERR", expect_err) \
-	macro_bool ("BROKEN", broken)
+	macro_bool ("BROKEN", broken) \
+	macro_bool ("REGEX_OUT", regex_out) \
+	macro_bool ("REGEX_ERR", regex_err)
 
 typedef enum rz_test_asm_test_mode_t {
 	RZ_ASM_TEST_MODE_ASSEMBLE = 1,

--- a/librz/include/rz_regex.h
+++ b/librz/include/rz_regex.h
@@ -2,6 +2,7 @@
 #define	RZ_REGEX_H
 
 #include <rz_types.h>
+#include <rz_list.h>
 #include <sys/types.h>
 
 typedef struct rz_regex_t {
@@ -57,9 +58,10 @@ typedef struct rz_regmatch_t {
 #define	RZ_REGEX_LARGE		01000	/* force large representation */
 #define	RZ_REGEX_BACKR		02000	/* force use of backref code */
 
-RZ_API RzRegex *rz_regex_new (const char *pattern, const char *cflags);
-RZ_API int rz_regex_run (const char *pattern, const char *flags, const char *text);
-RZ_API int rz_regex_match (const char *pattern, const char *flags, const char *text);
+RZ_API RzRegex *rz_regex_new(const char *pattern, const char *cflags);
+RZ_API int rz_regex_run(const char *pattern, const char *flags, const char *text);
+RZ_API int rz_regex_match(const char *pattern, const char *flags, const char *text);
+RZ_API RzList *rz_regex_get_match_list(const char *pattern, const char *flags, const char *text);
 RZ_API int rz_regex_flags(const char *flags);
 RZ_API int rz_regex_comp(RzRegex*, const char *, int);
 RZ_API size_t rz_regex_error(int, const RzRegex*, char *, size_t);
@@ -68,7 +70,7 @@ RZ_API size_t rz_regex_error(int, const RzRegex*, char *, size_t);
  * a dummy argument name is added.
  */
 RZ_API bool rz_regex_check(const RzRegex *rr, const char *str);
-RZ_API int rz_regex_exec(const RzRegex *, const char *, size_t, RzRegexMatch __pmatch[], int);
+RZ_API int rz_regex_exec(const RzRegex *preg, const char *string, size_t nmatch, RzRegexMatch __pmatch[], int eflags);
 RZ_API void rz_regex_free(RzRegex *);
 RZ_API void rz_regex_fini(RzRegex *);
 

--- a/test/db/archos/linux-x64/dbg_oo
+++ b/test/db/archos/linux-x64/dbg_oo
@@ -95,3 +95,13 @@ Hello world!
 EOF
 RUN
 
+NAME=ood check for ptrace errors
+FILE=bins/elf/analysis/x86-helloworld-gcc
+CMDS=<<EOF
+ood
+EOF
+REGEXP_ERR=([a-zA-Z-]+\s+)
+EXPECT_ERR=<<EOF
+Process with PID attach File -helloworld-gcc  reopened in read-write mode
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**

REGEXP_OUT/ERR is used to apply regex on the program's stdout/stderr which will then be compared with EXPECT/_ERR.

**Test plan**

Check that tests that use regex pass.