### PR TITLE
Remove unused variables: `file.location` and `dbg.libc.dbglib`

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -2988,7 +2988,6 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETI ("dbg.glibc.fc_offset", 0x148, "First chunk offset from brk_start");
 #endif
 	SETBPREF ("dbg.glibc.demangle", "false", "Demangle linked-lists pointers introduced in glibc 2.32");
-	SETPREF ("dbg.libc.dbglib", "", "Set libc debug library file");
 
 	SETBPREF ("esil.prestep", "true", "Step before esil evaluation in `de` commands");
 	SETPREF ("esil.fillstack", "", "Initialize ESIL stack with (random, debrujn, sequence, zeros, ...)");
@@ -3678,7 +3677,6 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETPREF ("file.type", "", "Type of current file");
 	SETI ("file.loadalign", 1024, "Alignment of load addresses");
 	SETI ("file.openmany", 1, "Maximum number of files opened at once");
-	SETPREF ("file.location", "", "Is the file 'local', 'remote', or 'memory'");
 	/* magic */
 	SETI ("magic.depth", 100, "Recursivity depth in magic description strings");
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**
Variables `file.location` and `dbg.libc.dbglib` were not used anywhere. This Pull Request removes them.

**Test plan**

- [x] Merge when all tests are green.

**Closing issues**

None
