### PR TITLE
ACCESS_CMP: Prevent compiler from assuming expression signedness

### DIFF
--- a/librz/analysis/var.c
+++ b/librz/analysis/var.c
@@ -6,7 +6,7 @@
 #include <rz_core.h>
 #include <rz_list.h>
 
-#define ACCESS_CMP(x, y) ((x) - ((RzAnalysisVarAccess *)y)->offset)
+#define ACCESS_CMP(x, y) ((st64)((ut64)(x) - (ut64)((RzAnalysisVarAccess *)y)->offset))
 
 RZ_API bool rz_analysis_var_display(RzAnalysis *analysis, RzAnalysisVar *var) {
 	char *fmt = rz_type_format (analysis->sdb_types, var->type);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following failure in #260 (https://github.com/rizinorg/rizin/runs/1617745700#step:15:87). It's cherry-picked from b48c93f1e4bc736752ef31be8d54494e3f0d0dbc since it can affect optimized builds outside #260:

![test_analysis_var-fail](https://user-images.githubusercontent.com/12002672/103277577-55847200-4a04-11eb-97c6-d9443f58910b.PNG)

Apparently, it's currently only relevant because of optimization and the following line in the unit tests. Not sure why you'd want to relocate a function to the higher half of memory tbh:
https://github.com/rizinorg/rizin/blob/cf5334773037b0403d5a9603305499d0ec42780a/test/unit/test_analysis_var.c#L165

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
