### PR TITLE
Rename zign cfg vars and disable zign.match.types

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3275,12 +3275,12 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETI ("zign.maxsz", 500, "Maximum zignature length");
 	SETI ("zign.minsz", 16, "Minimum zignature length for matching");
 	SETI ("zign.mincc", 10, "Minimum cyclomatic complexity for matching");
-	SETBPREF ("zign.graph", "true", "Use graph metrics for matching");
-	SETBPREF ("zign.bytes", "true", "Use bytes patterns for matching");
-	SETBPREF ("zign.offset", "false", "Use original offset for matching");
-	SETBPREF ("zign.refs", "true", "Use references for matching");
-	SETBPREF ("zign.hash", "true", "Use Hash for matching");
-	SETBPREF ("zign.types", "true", "Use types for matching");
+	SETBPREF ("zign.match.graph", "true", "Use graph metrics for matching");
+	SETBPREF ("zign.match.bytes", "true", "Use bytes patterns for matching");
+	SETBPREF ("zign.match.offset", "false", "Use original offset for matching");
+	SETBPREF ("zign.match.refs", "true", "Use references for matching");
+	SETBPREF ("zign.match.hash", "true", "Use Hash for matching");
+	SETBPREF ("zign.match.types", "false", "Use types for matching");
 	SETBPREF ("zign.autoload", "false", "Autoload all zignatures located in " RZ_JOIN_2_PATHS ("~", RZ_HOME_ZIGNS));
 	SETPREF ("zign.diff.bthresh", "1.0", "Threshold for diffing zign bytes [0, 1] (see zc?)");
 	SETPREF ("zign.diff.gthresh", "1.0", "Threshold for diffing zign graphs [0, 1] (see zc?)");

--- a/librz/core/cmd_zign.c
+++ b/librz/core/cmd_zign.c
@@ -779,14 +779,14 @@ static void search_add_to_types(RzCore *c, RzSignSearchMetrics *sm, RzSignType t
 
 static bool fill_search_metrics(RzSignSearchMetrics *sm, RzCore *c, void *user) {
 	unsigned int i = 0;
-	search_add_to_types (c, sm, RZ_SIGN_GRAPH, "zign.graph", &i);
-	search_add_to_types (c, sm, RZ_SIGN_OFFSET, "zign.offset", &i);
-	search_add_to_types (c, sm, RZ_SIGN_REFS, "zign.refs", &i);
-	search_add_to_types (c, sm, RZ_SIGN_BBHASH, "zign.hash", &i);
-	search_add_to_types (c, sm, RZ_SIGN_TYPES, "zign.types", &i);
+	search_add_to_types (c, sm, RZ_SIGN_GRAPH, "zign.match.graph", &i);
+	search_add_to_types (c, sm, RZ_SIGN_OFFSET, "zign.match.offset", &i);
+	search_add_to_types (c, sm, RZ_SIGN_REFS, "zign.match.refs", &i);
+	search_add_to_types (c, sm, RZ_SIGN_BBHASH, "zign.match.hash", &i);
+	search_add_to_types (c, sm, RZ_SIGN_TYPES, "zign.match.types", &i);
 #if 0
 	// untested
-	search_add_to_types(c, sm, RZ_SIGN_VARS, "zign.vars", &i);
+	search_add_to_types(c, sm, RZ_SIGN_VARS, "zign.match.vars", &i);
 #endif
 	sm->mincc = rz_config_get_i (c->config, "zign.mincc");
 	sm->analysis = c->analysis;
@@ -806,7 +806,7 @@ static bool search(RzCore *core, bool rad, bool only_func) {
 
 	struct ctxSearchCB bytes_search_ctx = { core, rad, 0, "bytes" };
 	const char *mode = rz_config_get (core->config, "search.in");
-	bool useBytes = rz_config_get_i (core->config, "zign.bytes");
+	bool useBytes = rz_config_get_i (core->config, "zign.match.bytes");
 	const char *zign_prefix = rz_config_get (core->config, "zign.prefix");
 	int maxsz = rz_config_get_i (core->config, "zign.maxsz");
 
@@ -949,11 +949,11 @@ static bool do_bestmatch_fcn(RzCore *core, const char *zigname, int count) {
 		return false;
 	}
 
-	if (!rz_config_get_i (core->config, "zign.bytes")) {
+	if (!rz_config_get_i (core->config, "zign.match.bytes")) {
 		rz_sign_bytes_free (it->bytes);
 		it->bytes = NULL;
 	}
-	if (!rz_config_get_i (core->config, "zign.graph")) {
+	if (!rz_config_get_i (core->config, "zign.match.graph")) {
 		rz_sign_graph_free (it->graph);
 		it->graph = NULL;
 	}
@@ -1014,7 +1014,7 @@ static bool do_bestmatch_sig(RzCore *core, int count) {
 		return false;
 	}
 
-	if (rz_config_get_i (core->config, "zign.bytes")) {
+	if (rz_config_get_i (core->config, "zign.match.bytes")) {
 		rz_sign_addto_item (core->analysis, item, fcn, RZ_SIGN_BYTES);
 		RzSignBytes *b = item->bytes;
 		int minsz = rz_config_get_i (core->config, "zign.minsz");
@@ -1024,7 +1024,7 @@ static bool do_bestmatch_sig(RzCore *core, int count) {
 			return false;
 		}
 	}
-	if (rz_config_get_i (core->config, "zign.graph")) {
+	if (rz_config_get_i (core->config, "zign.match.graph")) {
 		rz_sign_addto_item (core->analysis, item, fcn, RZ_SIGN_GRAPH);
 	}
 
@@ -1147,7 +1147,7 @@ static int cmdCheck(void *data, const char *input) {
 
 	const char *zign_prefix = rz_config_get (core->config, "zign.prefix");
 	int minsz = rz_config_get_i (core->config, "zign.minsz");
-	bool useBytes = rz_config_get_i (core->config, "zign.bytes");
+	bool useBytes = rz_config_get_i (core->config, "zign.match.bytes");
 
 	struct ctxSearchCB metsearch_ctx = { core, rad, 0, NULL };
 	RzSignSearchMetrics sm;

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -630,7 +630,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=z/ + zign.{bytes,graph}
+NAME=z/ + zign.match.{bytes,graph}
 FILE=bins/elf/analysis/zigs_stripped
 CMDS=<<EOF
 aa
@@ -639,14 +639,14 @@ za sym.print g cc=1 nbbs=1 edges=0 ebbs=1
 e zign.minsz = 0
 e zign.mincc = 0
 fs sign
-e zign.bytes = true
-e zign.graph = false
+e zign.match.bytes = true
+e zign.match.graph = false
 z/
 f~sign.bytes.sym.print?
 f~sign.graph.sym.print?
 f-*
-e zign.bytes = false
-e zign.graph = true
+e zign.match.bytes = false
+e zign.match.graph = true
 z/
 f~sign.bytes.sym.print?
 f~sign.graph.sym.print?
@@ -659,7 +659,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=zc + zign.{bytes,graph}
+NAME=zc + zign.match.{bytes,graph}
 FILE=bins/elf/analysis/zigs_stripped
 CMDS=<<EOF
 aa
@@ -668,14 +668,14 @@ za sym.print g cc=1 nbbs=1 edges=0 ebbs=1
 e zign.minsz = 0
 e zign.mincc = 0
 fs sign
-e zign.bytes = true
-e zign.graph = false
+e zign.match.bytes = true
+e zign.match.graph = false
 z. @ 0x400536
 f~sign.bytes.sym.print?
 f~sign.graph.sym.print?
 f-*
-e zign.bytes = false
-e zign.graph = true
+e zign.match.bytes = false
+e zign.match.graph = true
 z. @ 0x400536
 f~sign.bytes.sym.print?
 f~sign.graph.sym.print?
@@ -1774,7 +1774,7 @@ za main t func.sym.new_function_name.ret=int func.sym.new_function_name.args=2 f
 za main n sym.new_function_name
 s main
 af
-e zign.offset = true
+e zign.match.offset = true
 z.
 afs
 afn


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [rizin book](https://github.com/rizinorg/rizinbook) with the relevant information (https://github.com/rizinorg/book/pull/9)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
I think it would be better to organize matching mode vars to one subset. 
`zign.match.types` gives too much false positives and shouldn't be used by default (related #272) 

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
