### PR TITLE
Fix crash after tracing an invalid opcode ##trace

### DIFF
--- a/librz/debug/debug.c
+++ b/librz/debug/debug.c
@@ -973,7 +973,7 @@ RZ_API int rz_debug_step(RzDebug *dbg, int steps) {
 			dbg->session->maxcnum++;
 			dbg->session->bp = 0;
 			if (!rz_debug_trace_ins_before (dbg)) {
-				eprintf ("trace_ins_before: failed");
+				eprintf ("trace_ins_before: failed\n");
 			}
 		}
 
@@ -989,7 +989,7 @@ RZ_API int rz_debug_step(RzDebug *dbg, int steps) {
 
 		if (dbg->session && dbg->recoil_mode == RZ_DBG_RECOIL_NONE) {
 			if (!rz_debug_trace_ins_after (dbg)) {
-				eprintf ("trace_ins_after: failed");
+				eprintf ("trace_ins_after: failed\n");
 			}
 			dbg->session->reasontype = dbg->reason.type;
 			dbg->session->bp = bp;

--- a/librz/debug/trace.c
+++ b/librz/debug/trace.c
@@ -108,6 +108,7 @@ RZ_API bool rz_debug_trace_ins_before(RzDebug *dbg) {
 }
 
 RZ_API bool rz_debug_trace_ins_after(RzDebug *dbg) {
+	rz_return_val_if_fail (dbg->cur_op, false);
 	RzListIter *it;
 	RzAnalysisValue *val;
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`rz_debug_trace_ins_before` fails when an instruction is invalid(according to `rz_analysis_op`) and sets `dbg->cur_op` to NULL. This lead to a segfault in `rz_debug_trace_ins_after` after stepping since it was trying to iterate over cur_op->access.
An invalid instruction won't be properly traced but debug will stop and an error will be printed for further investigation, the user will still be able to step over it backwards and forwards.

**Test plan**

This is a bit problematic to add a test to since it depends on an invalid instruction that won't crash the debugee and I am planning to add support for the unsupported instructions in another PR. You can test by tracing from debug start to main in Linux and you'll probably find some unsupported CET instruction: `ood`->`dts+`->`db main`->`dc`