### PR TITLE
Do not recurse on empty intervals ##io

### DIFF
--- a/librz/io/io_map.c
+++ b/librz/io/io_map.c
@@ -340,6 +340,9 @@ RZ_API ut64 rz_io_map_next_available(RzIO* io, ut64 addr, ut64 size, ut64 load_a
 	void **it;
 	rz_pvector_foreach (&io->maps, it) {
 		RzIOMap *map = *it;
+		if (!rz_itv_size (map->itv)) {
+			break;
+		}
 		ut64 to = rz_itv_end (map->itv);
 		next_addr = RZ_MAX (next_addr, to + (load_align - (to % load_align)) % load_align);
 		// XXX - This does not handle when file overflow 0xFFFFFFFF000 -> 0x00000FFF


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

In https://github.com/rizinorg/rizin/commit/7316b71619a8025e076f6462a6141badb40b8628 I have removed the condition to have maps of at least 1 byte, to allow to create an empty file and then resize it with mmap while still seeing the map with `om` while you resize. This caused a problem in some fuzzed bin, because a recursion was never terminated (see https://github.com/rizinorg/rizin/runs/1640406367#step:19:16).

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Fuzz tests should be green.
