### PR TITLE
Fix a grammatical error on the README ##docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Please have a look at [BUILDING.md][] for more information about building Rizin.
 
 We very much welcome any kind of contributions, from typos, to documentation, to
 refactoring, up to completely new features you may think of. Before
-contributing, we would like you to read the file [CONTRIBUTING.md][]. so that we
+contributing, we would like you to read the file [CONTRIBUTING.md][], so that we
 can all be on the same page.
 
 ## Tests


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
Under the title 'Contributing' on the README, the sentence 'Before contributing, we would like you to read the file CONTRIBUTING.md' ends just abruptly with a full stop. Here, I've replaced it with a comma so that it associates with the next sentence 'so that we can all be on the same page', which was also not capitalized.

**Test plan**

- [ ] Get it reviewed.

**Closing issues**
None
