### PR TITLE
Remove note about rz alias.

### DIFF
--- a/man/rizin.1
+++ b/man/rizin.1
@@ -24,8 +24,6 @@
 .Sh DESCRIPTION
 rizin is a commandline hexadecimal editor.
 .Pp
-"rz" is the alias program name for rizin.
-.Pp
 This manpage is not updated yet. Feel free to contribute.
 .Pp
 The options are:


### PR DESCRIPTION
 Just removes the reference to the `rz` alias we've decided not to use.