### PR TITLE
Fixes for old Debian (Wheezy, Jessie)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
       run: make install
       working-directory: rizin
     - name: Install test dependencies
-      run: python3 -m pip install --user 'git+https://github.com/rizinorg/rizin-rzpipe#egg=rzpipe&subdirectory=python'
+      run: python3 -m pip install --user 'git+https://github.com/rizinorg/rz-pipe#egg=rz-pipe&subdirectory=python'
     - name: Run tests
       # FIXME: debug tests fail on debian for now, let's ignore all tests for the moment
       run: cd test && make || exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,7 @@ jobs:
             container:
                 - debian:wheezy
                 - debian:jessie
+                - debian:stretch
 
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
@@ -300,7 +301,6 @@ jobs:
     - name: Fix containers (Wheezy)
       if: matrix.container == 'debian:wheezy'
       run: |
-          sed -i '/deb http:\/\/deb.debian.org\/debian wheezy-updates main/d' /etc/apt/sources.list
           echo "deb http://archive.debian.org/debian wheezy main" > /etc/apt/sources.list
           echo "deb http://archive.debian.org/debian-security wheezy/updates main" >> /etc/apt/sources.list
           echo "Acquire::Check-Valid-Until no;" > /etc/apt/apt.conf.d/99no-check-valid-until

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,6 +332,11 @@ jobs:
     - name: Install with make
       run: make install
       working-directory: rizin
+    - name: Run unit tests
+      run: cd test && make unit_tests
+      working-directory: rizin
+      env:
+        PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig
     - name: Install test dependencies
       run: python3 -m pip install --user 'git+https://github.com/rizinorg/rz-pipe#egg=rz-pipe&subdirectory=python'
     - name: Run tests

--- a/librz/cons/pal.c
+++ b/librz/cons/pal.c
@@ -72,10 +72,10 @@ static struct {
 	{ "graph.current", rz_offsetof (RzConsPrintablePalette, graph_current), rz_offsetof (RzConsPalette, graph_current) },
 	{ "graph.traced", rz_offsetof (RzConsPrintablePalette, graph_traced), rz_offsetof (RzConsPalette, graph_traced) },
 
-        { "graph.diff.unknown", rz_offsetof (RzConsPrintablePalette, graph_diff_unknown), rz_offsetof (RzConsPalette, graph_diff_unknown) },
-        { "graph.diff.new", rz_offsetof (RzConsPrintablePalette, graph_diff_new), rz_offsetof (RzConsPalette, graph_diff_new) },
-        { "graph.diff.match", rz_offsetof (RzConsPrintablePalette, graph_diff_match), rz_offsetof (RzConsPalette, graph_diff_match) },
-        { "graph.diff.unmatch", rz_offsetof (RzConsPrintablePalette, graph_diff_unmatch), rz_offsetof (RzConsPalette, graph_diff_unmatch) },
+	{ "graph.diff.unknown", rz_offsetof (RzConsPrintablePalette, graph_diff_unknown), rz_offsetof (RzConsPalette, graph_diff_unknown) },
+	{ "graph.diff.new", rz_offsetof (RzConsPrintablePalette, graph_diff_new), rz_offsetof (RzConsPalette, graph_diff_new) },
+	{ "graph.diff.match", rz_offsetof (RzConsPrintablePalette, graph_diff_match), rz_offsetof (RzConsPalette, graph_diff_match) },
+	{ "graph.diff.unmatch", rz_offsetof (RzConsPrintablePalette, graph_diff_unmatch), rz_offsetof (RzConsPalette, graph_diff_unmatch) },
 
 	{ "gui.cflow", rz_offsetof (RzConsPrintablePalette, gui_cflow), rz_offsetof (RzConsPalette, gui_cflow) },
 	{ "gui.dataoffset", rz_offsetof (RzConsPrintablePalette, gui_dataoffset), rz_offsetof (RzConsPalette, gui_dataoffset) },

--- a/librz/include/rz_cons.h
+++ b/librz/include/rz_cons.h
@@ -638,7 +638,7 @@ typedef struct rz_cons_t {
 #define Color_BBLUE      "\x1b[94m"
 #define Color_BBGBLUE    "\x1b[104m"
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || (defined(__GNUC__) && __GNUC__ < 5)
 #define RZCOLOR(a, r, g, b, bgr, bgg, bgb, id16) {0, a, r, g, b, bgr, bgg, bgb, id16}
 #else
 #define RZCOLOR(a, r, g, b, bgr, bgg, bgb, id16) (RzColor) {0, a, r, g, b, bgr, bgg, bgb, id16}

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -395,7 +395,9 @@ static inline void *rz_new_copy(int size, void *data) {
 #define typeof(arg) __typeof__(arg)
 #endif
 
-#if 1
+// There is a bug of using "offsetof()" in the structure
+// initialization in GCC < 5.0 versions
+#if !(defined(__GNUC__) && __GNUC__ < 5)
 #define rz_offsetof(type, member) offsetof(type, member)
 #else
 #if __SDB_WINDOWS__


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Compiling Rizin for Debian Wheezy and Jessie became problematic, there are some annoying GCC bugs in it: https://github.com/rizinorg/rizin/pull/322#issuecomment-755969176
```
make[3]: Entering directory `/__w/rizin/rizin/rizin/librz/cons'
...
gcc -c -std=gnu99 -MD   -fPIC -g -Wall -D__UNIX__=1 -I/__w/rizin/rizin/rizin/librz -I/__w/rizin/rizin/rizin/librz/include -I/__w/rizin/rizin/rizin/librz/../shlr/sdb/src -fvisibility=hidden -o pal.o pal.c
pal.c:99:2: error: initializer element is not constant
pal.c:99:2: error: (near initialization for 'colors[0].rcolor')
make[3]: *** [pal.o] Error 1
make[3]: Leaving directory `/__w/rizin/rizin/rizin/librz/cons'
make[2]: Leaving directory `/__w/rizin/rizin/rizin/librz'
make[2]: *** [cons] Error 2
make[1]: Leaving directory `/__w/rizin/rizin/rizin/librz'
```

**Test plan**

All green.