### PR TITLE
Fix minunit -Wformat-overflow= warning by increasing msg buf size

### DIFF
--- a/test/unit/minunit.h
+++ b/test/unit/minunit.h
@@ -79,7 +79,7 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 #define mu_assert_true(actual, message) do { \
 		bool act__ = (actual); \
 		if (!(act__)) { \
-			char _meqstr[2048]; \
+			char _meqstr[5120]; \
 			sprintf (_meqstr, "%s: expected true, got false", (message)); \
 			mu_assert (_meqstr, false); \
 		} \
@@ -89,7 +89,7 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 	do { \
 		bool act__ = (actual); \
 		if ((act__)) { \
-			char _meqstr[2048]; \
+			char _meqstr[5120]; \
 			sprintf (_meqstr, "%s: expected false, got true", (message)); \
 			mu_assert (_meqstr, false); \
 		} \
@@ -99,14 +99,14 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 		ut64 act__ = (ut64)(actual); \
 		ut64 exp__ = (ut64)(expected); \
 		if ((exp__) != (act__)) { \
-			char _meqstr[2048]; \
+			char _meqstr[5120]; \
 			sprintf(_meqstr, "%s: expected %" PFMT64d ", got %" PFMT64d ".", (message), (ut64)(exp__), (ut64)(act__)); \
 			mu_assert(_meqstr, false); \
 		} \
 	} while(0)
 
 #define mu_assert_neq(actual, expected, message) do { \
-		char _meqstr[2048]; \
+		char _meqstr[5120]; \
 		ut64 act__ = (ut64)(actual); \
 		ut64 exp__ = (ut64)(expected); \
 		sprintf(_meqstr, "%s: expected not %" PFMT64d ", got %" PFMT64d ".", (message), (exp__), (act__)); \
@@ -114,7 +114,7 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 	} while(0)
 
 #define mu_assert_ptreq(actual, expected, message) do {	\
-		char _meqstr[2048]; \
+		char _meqstr[5120]; \
 		const void *act__ = (actual); \
 		const void *exp__ = (expected); \
 		sprintf (_meqstr, "%s: expected %p, got %p.", (message), (exp__), (act__)); \
@@ -122,7 +122,7 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 	} while (0)
 
 #define mu_assert_ptrneq(actual, expected, message) do { \
-		char _meqstr[2048]; \
+		char _meqstr[5120]; \
 		const void *act__ = (actual); \
 		const void *exp__ = (expected); \
 		sprintf (_meqstr, "%s: expected not %p, got %p.", (message), (exp__), (act__)); \
@@ -130,14 +130,14 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 	} while (0)
 
 #define mu_assert_null(actual, message) do {			\
-		char _meqstr[2048];					\
+		char _meqstr[5120];					\
 		const void *act__ = (actual); \
 		sprintf(_meqstr, "%s: expected to be NULL but it wasn't.", (message)); \
 		mu_assert(_meqstr, (act__) == NULL);		\
 	} while(0)
 
 #define mu_assert_notnull(actual, message) do {				\
-		char _meqstr[2048];					\
+		char _meqstr[5120];					\
 		const void *act__ = (actual); \
 		sprintf(_meqstr, "%s: expected to not be NULL but it was.", (message)); \
 		mu_assert(_meqstr, (act__) != NULL);			\
@@ -147,14 +147,14 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 		ut64 act__ = (ut64)(actual); \
 		ut64 exp__ = (ut64)(expected); \
 		if ((exp__) != (act__)) { \
-			char _meqstr[2048]; \
+			char _meqstr[5120]; \
 			sprintf(_meqstr, "%s: expected "fmt", got "fmt".", (message), (exp__), (act__)); \
 			mu_assert(_meqstr, false); \
 		} \
 	} while(0)
 
 #define mu_assert_streq(actual, expected, message) do { \
-		char _meqstr[2048]; \
+		char _meqstr[5120]; \
 		const char *act__ = (actual); \
 		const char *exp__ = (expected); \
 		sprintf(_meqstr, "%s: expected %s, got %s.", (message), (exp__), (act__)); \
@@ -168,7 +168,7 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 } while (0)
 
 #define mu_assert_nullable_streq(actual, expected, message) do { \
-		char _meqstr[2048]; \
+		char _meqstr[5120]; \
 		const char *act__ = (actual); \
 		const char *exp__ = (expected); \
 		sprintf(_meqstr, "%s: expected %s, got %s.", (message), (exp__ ? exp__ : "NULL"), (act__ ? act__ : "NULL")); \
@@ -176,7 +176,7 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 } while(0)
 
 #define mu_assert_memeq(actual, expected, len, message) do { \
-		char _meqstr[2048]; \
+		char _meqstr[5120]; \
 		const ut8 *act__ = (actual); \
 		const ut8 *exp__ = (expected); \
 		sprintf(_meqstr, "%s: expected ", message); \


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following warning (and its ilk) in #260 (https://github.com/rizinorg/rizin/runs/1687264032#step:12:2052 -- also search for `minunit.h`):

![dbgopt-minunit](https://user-images.githubusercontent.com/12002672/104478307-13ab1c80-55fd-11eb-9689-122987ed422a.PNG)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
