### PR TITLE
Remove the extra spaces next to configuration variables on the fortunes

### DIFF
--- a/doc/fortunes.tips
+++ b/doc/fortunes.tips
@@ -28,7 +28,6 @@ Add comments using the ';' key in visual mode or the 'CC' command from the rizin
 Assemble opcodes with the 'a' and 'A' keys in visual mode, which are bindings to the 'wa' and 'wA' commands
 Find expanded AES keys in memory with '/ca'
 Find wide-char strings with the '/w <string>' command
-Enable ascii-art jump lines in disassembly by setting 'e asm.lines=true'. asm.lines.out and asm.linestyle may interest you as well
 Control the signal handlers of the child process with the 'dk' command
 Get a free shell with 'rz_gg -i exec -x'
 Interpret rizin scripts with '. <path-to-script>'. Similar to the bash source alias command.
@@ -42,11 +41,11 @@ Add colors to your screen with 'e scr.color=X' where 1 is 16 colors, 2 is 256 co
 Move the comments to the right changing their margin with asm.cmt.margin
 Execute a command on the visual prompt with cmd.vprompt
 Reduce the delta where flag resolving by address is used with cfg.delta
-Disable these messages with 'e cfg.fortunes = false' in your ~/.rizinrc
-Change your fortune types with 'e cfg.fortunes.file = fun,tips' in your ~/.rizinrc
-Show offsets in graphs with 'e graph.offset = true'
-Execute a command every time a breakpoint is hit with 'e cmd.bp = !my-program'
-Disassemble in intel syntax with 'e asm.syntax = intel'.
+Disable these messages with 'e cfg.fortunes=false' in your ~/.rizinrc
+Change your fortune types with 'e cfg.fortunes.file=fun,tips' in your ~/.rizinrc
+Show offsets in graphs with 'e graph.offset=true'
+Execute a command every time a breakpoint is hit with 'e cmd.bp=!my-program'
+Disassemble in intel syntax with 'e asm.syntax=intel'.
 Change the UID of the debugged process with child.uid (requires root)
 Enhance your graphs by increasing the size of the block and graph.depth eval variable.
 Control the height of the terminal on serial consoles with e scr.height
@@ -85,4 +84,4 @@ The more 'a' you add after 'aa' the more analysis steps are executed.
 Review all the subcommands of aa to see better ways to analyze your targets.
 Use /m to carve for known magic headers. speedup with search.
 You can use registers in math expressions. For example: 'wx 1234 @ esp - 2'
-For HTTP authentification 'e http.auth = 1', 'e http.authfile = <path>'
+For HTTP authentification 'e http.auth=1', 'e http.authfile=<path>'


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This removes the extra spaces next to configuration variables that was there on the fortunes inside `fortunes.tips`.
Also removed the line containing a fortune about `asm.linestyle`.

**Test plan**
None

**Closing issues**

As said on https://github.com/rizinorg/rizin/pull/357#issuecomment-760118879
