### PR TITLE
Add support for `sltu` and `sgtu` instructions for RISC-V's ESIL #emu

### DIFF
--- a/librz/analysis/p/analysis_riscv.c
+++ b/librz/analysis/p/analysis_riscv.c
@@ -550,11 +550,11 @@ static int riscv_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 			esilprintf (op, "%s,%s,!=,%s,=", ARG (2), ARG (1), ARG (0));
 		} else if (!strncmp (name, "sle", 3)) {
 			esilprintf (op, "%s,%s,<=,%s,=", ARG (2), ARG (1), ARG (0));
-		} else if (!strncmp (name, "slt", 3)) {
+		} else if (!strncmp (name, "slt", 3) || !strcmp (name, "sltu")) {
 			esilprintf (op, "%s,%s,<,%s,=", ARG (2), ARG (1), ARG (0));
 		} else if (!strncmp (name, "sge", 3)) {
 			esilprintf (op, "%s,%s,>=,%s,=", ARG (2), ARG (1), ARG (0));
-		} else if (!strncmp (name, "sgt", 3)) {
+		} else if (!strncmp (name, "sgt", 3) || !strcmp (name, "sgtu")) {
 			esilprintf (op, "%s,%s,>,%s,=", ARG (2), ARG (1), ARG (0));
 		}
 		// debug


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
Add support for `sltu` and `sgtu` instructions for RISC-V's ESIL, which are basically just unsigned-versions of `stl` and `sgtu`.

**Test plan**
I do not know how to add tests for this, at the moment. Would like directions as I'm currently learning more about it from the [previous tests](https://github.com/rizinorg/rizin/blob/dev/test/db/esil/riscv_64#L33-L53).

**Closing issues**

None