### PR TITLE
Replace naked rz_sys_system/write/read/freopen calls with their wrapped counterparts

### DIFF
--- a/binrz/preload/librz2.c
+++ b/binrz/preload/librz2.c
@@ -66,9 +66,9 @@ void alloc_console(void) {
 	coninfo.dwSize.Y = 4096;
 	SetConsoleScreenBufferSize (hStdin, coninfo.dwSize);
 
-	freopen ("conin$", "r", stdin);
-	freopen ("conout$", "w", stdout);
-	freopen ("conout$", "w", stderr);
+	rz_xfreopen ("conin$", "r", stdin);
+	rz_xfreopen ("conout$", "w", stdout);
+	rz_xfreopen ("conout$", "w", stderr);
 }
 
 static void start_rz(void) {

--- a/binrz/rizin/rizin.c
+++ b/binrz/rizin/rizin.c
@@ -4,27 +4,27 @@
 #include <rz_util.h>
 
 static void rz_cmd(int in, int out, const char *cmd) {
-	write (out, cmd, strlen (cmd) + 1);
-	write (out, "\n", 1);
+	rz_xwrite (out, cmd, strlen (cmd) + 1);
+	rz_xwrite (out, "\n", 1);
 	int bufsz = (1024 * 64);
 	unsigned char *buf = malloc (bufsz);
 	if (!buf) {
 		return;
 	}
 	while (1) {
-		read (in, buf, bufsz);
+		rz_xread (in, buf, bufsz);
 		buf[bufsz - 1] = '\0';
 		int len = strlen ((const char *)buf);
 		if (len < 1) {
 			break;
 		}
-		write (1, buf, len);
+		rz_xwrite (1, buf, len);
 		if (len != bufsz) {
 			break;
 		}
 	}
 	free (buf);
-	write (1, "\n", 1);
+	rz_xwrite (1, "\n", 1);
 }
 
 static int rz_main_rzpipe(int argc, const char **argv) {

--- a/librz/analysis/p/analysis_x86_cs.c
+++ b/librz/analysis/p/analysis_x86_cs.c
@@ -3287,7 +3287,7 @@ static int x86_int_0x80(RzAnalysisEsil *esil, int interrupt) {
 	case 3:
 		{
 			char *dst = calloc (1, (size_t)edx);
-			(void)read ((ut32)ebx, dst, (size_t)edx);
+			rz_xread ((ut32)ebx, dst, (size_t)edx);
 			rz_analysis_esil_mem_write (esil, ecx, (ut8 *)dst, (int)edx);
 			free (dst);
 			return true;
@@ -3296,7 +3296,7 @@ static int x86_int_0x80(RzAnalysisEsil *esil, int interrupt) {
 		{
 			char *src = malloc ((size_t)edx);
 			rz_analysis_esil_mem_read (esil, ecx, (ut8 *)src, (int)edx);
-			write ((ut32)ebx, src, (size_t)edx);
+			rz_xwrite ((ut32)ebx, src, (size_t)edx);
 			free (src);
 			return true;
 		}

--- a/librz/asm/p/asm_x86_nasm.c
+++ b/librz/asm/p/asm_x86_nasm.c
@@ -23,7 +23,7 @@ static int assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
 
 	char *asm_buf = rz_str_newf ("[BITS %i]\nORG 0x%"PFMT64x"\n%s\n", a->bits, a->pc, buf);
 	if (asm_buf) {
-		(void)write (ifd, asm_buf, strlen (asm_buf));
+		rz_xwrite (ifd, asm_buf, strlen (asm_buf));
 		free (asm_buf);
 	}
 

--- a/librz/cons/cons.c
+++ b/librz/cons/cons.c
@@ -1570,13 +1570,13 @@ RZ_API void rz_cons_set_raw(bool is_raw) {
 #elif __WINDOWS__
 	if (is_raw) {
 		if (I.term_xterm) {
-			rz_sys_system ("stty raw -echo");
+			rz_sys_system_ ("stty raw -echo");
 		} else {
 			SetConsoleMode (h, I.term_raw);
 		}
 	} else {
 		if (I.term_xterm) {
-			rz_sys_system ("stty -raw echo");
+			rz_sys_system_ ("stty -raw echo");
 		} else {
 			SetConsoleMode (h, I.term_buf);
 		}

--- a/librz/cons/cons.c
+++ b/librz/cons/cons.c
@@ -1570,13 +1570,13 @@ RZ_API void rz_cons_set_raw(bool is_raw) {
 #elif __WINDOWS__
 	if (is_raw) {
 		if (I.term_xterm) {
-			rz_sys_system_ ("stty raw -echo");
+			rz_sys_xsystem ("stty raw -echo");
 		} else {
 			SetConsoleMode (h, I.term_raw);
 		}
 	} else {
 		if (I.term_xterm) {
-			rz_sys_system_ ("stty -raw echo");
+			rz_sys_xsystem ("stty -raw echo");
 		} else {
 			SetConsoleMode (h, I.term_buf);
 		}

--- a/librz/cons/cons.c
+++ b/librz/cons/cons.c
@@ -135,19 +135,19 @@ static void __break_signal(int sig) {
 static inline void __cons_write_ll(const char *buf, int len) {
 #if __WINDOWS__
 	if (I.vtmode) {
-		(void) write (I.fdout, buf, len);
+		rz_xwrite (I.fdout, buf, len);
 	} else {
 		if (I.fdout == 1) {
 			rz_cons_w32_print (buf, len, false);
 		} else {
-			(void) write (I.fdout, buf, len);
+			rz_xwrite (I.fdout, buf, len);
 		}
 	}
 #else
 	if (I.fdout < 1) {
 		I.fdout = 1;
 	}
-	(void) write (I.fdout, buf, len);
+	rz_xwrite (I.fdout, buf, len);
 #endif
 }
 
@@ -1364,13 +1364,13 @@ static bool __xterm_get_size(void) {
 		return false;
 	}
 	int rows, columns;
-	(void)write (I.fdout, "\x1b[999;999H", sizeof ("\x1b[999;999H"));
+	rz_xwrite (I.fdout, "\x1b[999;999H", sizeof ("\x1b[999;999H"));
 	rows = __xterm_get_cur_pos (&columns);
 	if (rows) {
 		I.rows = rows;
 		I.columns = columns;
 	} // otherwise reuse previous values
-	(void)write (I.fdout, RZ_CONS_CURSOR_RESTORE, sizeof (RZ_CONS_CURSOR_RESTORE));
+	rz_xwrite (I.fdout, RZ_CONS_CURSOR_RESTORE, sizeof (RZ_CONS_CURSOR_RESTORE));
 	return true;
 }
 
@@ -1518,7 +1518,7 @@ RZ_API void rz_cons_show_cursor(int cursor) {
 #if __WINDOWS__
 	if (I.vtmode) {
 #endif
-		(void) write (1, cursor ? "\x1b[?25h" : "\x1b[?25l", 6);
+		rz_xwrite (1, cursor ? "\x1b[?25h" : "\x1b[?25l", 6);
 #if __WINDOWS__
 	} else {
 		static HANDLE hStdout = NULL;
@@ -1699,7 +1699,7 @@ RZ_API void rz_cons_zero(void) {
 	if (I.line) {
 		I.line->zerosep = true;
 	}
-	(void)write (1, "", 1);
+	rz_xwrite (1, "", 1);
 }
 
 RZ_API void rz_cons_highlight(const char *word) {
@@ -1939,6 +1939,6 @@ RZ_API void rz_cons_cmd_help(const char *help[], bool use_color) {
 
 RZ_API void rz_cons_clear_buffer(void) {
 	if (I.vtmode) {
-		(void)write (1, "\x1b" "c\x1b[3J", 6);
+		rz_xwrite (1, "\x1b" "c\x1b[3J", 6);
 	}
 }

--- a/librz/cons/cutf8.c
+++ b/librz/cons/cutf8.c
@@ -224,13 +224,13 @@ RZ_API bool rz_cons_is_utf8(void) {
 		close (fd);
 		return false;
 	}
-	write (1, "\xc3\x89\xc3\xa9", 4);
+	rz_xwrite (1, "\xc3\x89\xc3\xa9", 4);
 	if (cursor_position (fd, &row2, &col2)) {
 		close (fd);
 		return false;
 	}
 	close (fd);
-	write (1, "\r    \r", 6);
+	rz_xwrite (1, "\r    \r", 6);
 	return ((col2-col)==2);
 #endif
 	return ret;

--- a/librz/cons/output.c
+++ b/librz/cons/output.c
@@ -14,7 +14,7 @@ static void __fill_tail(int cols, int lines) {
 		lines--;
 		white[cols] = '\n';
 		while (lines-- > 0) {
-			write (1, white, cols);
+			rz_xwrite (1, white, cols);
 		}
 	}
 }
@@ -29,7 +29,7 @@ RZ_API void rz_cons_w32_clear(void) {
 		return;
 	}
 	if (I->is_wine == 1) {
-		write (1, "\033[0;0H\033[0m\033[2J", 6 + 4 + 4);
+		rz_xwrite (1, "\033[0;0H\033[0m\033[2J", 6 + 4 + 4);
 	}
 	if (!hStdout) {
 		hStdout = GetStdHandle (STD_OUTPUT_HANDLE);
@@ -59,7 +59,7 @@ RZ_API void rz_cons_w32_gotoxy(int fd, int x, int y) {
 		return;
 	}
 	if (I->is_wine == 1) {
-		write (fd, "\x1b[0;0H", 6);
+		rz_xwrite (fd, "\x1b[0;0H", 6);
 	}
 	if (!*hConsole) {
 		*hConsole = GetStdHandle (fd == 1 ? STD_OUTPUT_HANDLE : STD_ERROR_HANDLE);
@@ -150,7 +150,7 @@ static int rz_cons_w32_hprint(DWORD hdl, const char *ptr, int len, bool vmode) {
 			}
 			if (ll > 0) {
 				raw_ll = bytes_utf8len (str, ll);
-				write (fd, str, raw_ll);
+				rz_xwrite (fd, str, raw_ll);
 				linelen += ll;
 			}
 			esc = 0;
@@ -160,10 +160,10 @@ static int rz_cons_w32_hprint(DWORD hdl, const char *ptr, int len, bool vmode) {
 				char white[1024];
 				if (wlen > 0 && wlen < sizeof (white)) {
 					memset (white, ' ', sizeof (white));
-					write (fd, white, wlen-1);
+					rz_xwrite (fd, white, wlen-1);
 				}
 			}
-			write (fd, "\n\r", 2);
+			rz_xwrite (fd, "\n\r", 2);
 			// reset colors for next line
 			SetConsoleTextAttribute (hConsole, 1 | 2 | 4 | 8);
 			linelen = 0;
@@ -181,10 +181,10 @@ static int rz_cons_w32_hprint(DWORD hdl, const char *ptr, int len, bool vmode) {
 					//wlen = 5;
 					if (wlen > 0) {
 						memset (white, ' ', sizeof (white));
-						write (fd, white, wlen);
+						rz_xwrite (fd, white, wlen);
 					}
 				}
-				write (fd, "\n\r", 2);
+				rz_xwrite (fd, "\n\r", 2);
 				//write (fd, "\r\n", 2);
 				//lines--;
 				linelen = 0;
@@ -201,7 +201,7 @@ static int rz_cons_w32_hprint(DWORD hdl, const char *ptr, int len, bool vmode) {
 			}
 			if (ll > 0) {
 				raw_ll = bytes_utf8len (str, ll);
-				write (fd, str, raw_ll);
+				rz_xwrite (fd, str, raw_ll);
 				linelen += ll;
 			}
 			esc = 1;
@@ -387,14 +387,14 @@ static int rz_cons_w32_hprint(DWORD hdl, const char *ptr, int len, bool vmode) {
 		if (wlen > 0) {
 			char white[1024];
 			memset (white, ' ', sizeof (white));
-			write (fd, white, wlen);
+			rz_xwrite (fd, white, wlen);
 		}
 		/* fill tail */
 		__fill_tail (cols, lines);
 	} else {
 		int ll = (size_t)(ptr - str);
 		if (ll > 0) {
-			write (fd, str, ll);
+			rz_xwrite (fd, str, ll);
 			linelen += ll;
 		}
 	}

--- a/librz/core/cmd.c
+++ b/librz/core/cmd.c
@@ -1523,7 +1523,7 @@ RZ_IPI int rz_cmd_resize(void *data, const char *input) {
 		}
 		break;
 	case 'e':
-		write (1, Color_RESET_TERMINAL, strlen (Color_RESET_TERMINAL));
+		rz_xwrite (1, Color_RESET_TERMINAL, strlen (Color_RESET_TERMINAL));
 		return true;
 	case '?': // "r?"
 	default:

--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -5275,7 +5275,7 @@ RZ_IPI int rz_cmd_debug(void *data, const char *input) {
 				setRarunProfileString (core, input + 3);
 			} else {
 				// TODO use the api
-				rz_sys_system ("rz_run -h");
+				rz_sys_system_ ("rz_run -h");
 			}
 			break;
 		case 'o': // "doo" : reopen in debug mode

--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -5275,7 +5275,7 @@ RZ_IPI int rz_cmd_debug(void *data, const char *input) {
 				setRarunProfileString (core, input + 3);
 			} else {
 				// TODO use the api
-				rz_sys_system_ ("rz_run -h");
+				rz_sys_xsystem ("rz_run -h");
 			}
 			break;
 		case 'o': // "doo" : reopen in debug mode

--- a/librz/core/panels.c
+++ b/librz/core/panels.c
@@ -3309,7 +3309,7 @@ int __rz_shell_cb(void *user) {
 int __system_shell_cb(void *user) {
 	rz_cons_set_raw (0);
 	rz_cons_flush ();
-	rz_sys_system_ ("$SHELL");
+	rz_sys_xsystem ("$SHELL");
 	return 0;
 }
 

--- a/librz/core/panels.c
+++ b/librz/core/panels.c
@@ -3309,7 +3309,7 @@ int __rz_shell_cb(void *user) {
 int __system_shell_cb(void *user) {
 	rz_cons_set_raw (0);
 	rz_cons_flush ();
-	rz_sys_system ("$SHELL");
+	rz_sys_system_ ("$SHELL");
 	return 0;
 }
 

--- a/librz/debug/p/debug_native.c
+++ b/librz/debug/p/debug_native.c
@@ -991,7 +991,7 @@ static RzList *rz_debug_native_map_get (RzDebug *dbg) {
 	char path[1024];
 	/* TODO: On solaris parse /proc/%d/map */
 	snprintf (path, sizeof(path) - 1, "pmap %d >&2", ps.tid);
-	rz_sys_system_ (path);
+	rz_sys_xsystem (path);
 #else
 	RzDebugMap *map;
 	int i, perm, unk = 0;

--- a/librz/debug/p/debug_native.c
+++ b/librz/debug/p/debug_native.c
@@ -991,7 +991,7 @@ static RzList *rz_debug_native_map_get (RzDebug *dbg) {
 	char path[1024];
 	/* TODO: On solaris parse /proc/%d/map */
 	snprintf (path, sizeof(path) - 1, "pmap %d >&2", ps.tid);
-	rz_sys_system (path);
+	rz_sys_system_ (path);
 #else
 	RzDebugMap *map;
 	int i, perm, unk = 0;

--- a/librz/debug/p/native/darwin.c
+++ b/librz/debug/p/native/darwin.c
@@ -6,7 +6,7 @@ int pids_cmdline(int pid, char *cmdline) {
         fd = open(cmdline, O_RDONLY);
         cmdline[0] = '\0';
         if (fd != -1) {
-                read(fd, cmdline, 1024);
+                rz_xread (fd, cmdline, 1024);
                 cmdline[1024] = '\0';
                 close(fd);
         }

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -675,6 +675,10 @@ static inline void rz_run_call10(void *fcn, void *arg1, void *arg2, void *arg3, 
 		(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
 }
 
+#define RZ_V_NOT(op, fail_ret) \
+	if ((op) == (fail_ret)) \
+		eprintf (#op" at %s:%d failed: %s\n", __FILE__, __LINE__, strerror (errno))
+
 #ifndef container_of
 # ifdef _MSC_VER
 #  define container_of(ptr, type, member) ((type *)((char *)(ptr) - offsetof(type, member)))

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -678,6 +678,9 @@ static inline void rz_run_call10(void *fcn, void *arg1, void *arg2, void *arg3, 
 #define RZ_V_NOT(op, fail_ret) \
 	if ((op) == (fail_ret)) \
 		eprintf (#op" at %s:%d failed: %s\n", __FILE__, __LINE__, strerror (errno))
+#define rz_xwrite(fd, buf, count) RZ_V_NOT (write (fd, buf, count), -1)
+#define rz_xread(fd, buf, count) RZ_V_NOT (read (fd, buf, count), -1)
+#define rz_xfreopen(pathname, mode, stream) RZ_V_NOT (freopen (pathname, mode, stream), NULL)
 
 #ifndef container_of
 # ifdef _MSC_VER

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -677,7 +677,7 @@ static inline void rz_run_call10(void *fcn, void *arg1, void *arg2, void *arg3, 
 
 #define RZ_V_NOT(op, fail_ret) \
 	if ((op) == (fail_ret)) \
-		eprintf (#op" at %s:%d failed: %s\n", __FILE__, __LINE__, strerror (errno))
+		RZ_LOG_WARN (#op" at %s:%d failed: %s\n", __FILE__, __LINE__, strerror (errno))
 #define rz_xwrite(fd, buf, count) RZ_V_NOT (write (fd, buf, count), -1)
 #define rz_xread(fd, buf, count) RZ_V_NOT (read (fd, buf, count), -1)
 #define rz_xfreopen(pathname, mode, stream) RZ_V_NOT (freopen (pathname, mode, stream), NULL)

--- a/librz/include/rz_util/rz_sys.h
+++ b/librz/include/rz_util/rz_sys.h
@@ -79,6 +79,7 @@ RZ_API int rz_sys_system(const char *command);
 #else
 #define rz_sys_system system
 #endif
+#define rz_sys_system_(cmd) RZ_V_NOT (rz_sys_system (cmd), -1)
 
 RZ_API int rz_sys_crash_handler(const char *cmd);
 RZ_API const char *rz_sys_arch_str(int arch);

--- a/librz/include/rz_util/rz_sys.h
+++ b/librz/include/rz_util/rz_sys.h
@@ -79,7 +79,7 @@ RZ_API int rz_sys_system(const char *command);
 #else
 #define rz_sys_system system
 #endif
-#define rz_sys_system_(cmd) RZ_V_NOT (rz_sys_system (cmd), -1)
+#define rz_sys_xsystem(cmd) RZ_V_NOT (rz_sys_system (cmd), -1)
 
 RZ_API int rz_sys_crash_handler(const char *cmd);
 RZ_API const char *rz_sys_arch_str(int arch);

--- a/librz/lang/lang.c
+++ b/librz/lang/lang.c
@@ -275,7 +275,7 @@ RZ_API int rz_lang_prompt(RzLang *lang) {
 		strncpy (buf, p, sizeof (buf) - 1);
 		if (*buf == '!') {
 			if (buf[1]) {
-				rz_sys_system_ (buf + 1);
+				rz_sys_xsystem (buf + 1);
 			} else {
 				char *foo, *code = NULL;
 				do {

--- a/librz/lang/lang.c
+++ b/librz/lang/lang.c
@@ -275,7 +275,7 @@ RZ_API int rz_lang_prompt(RzLang *lang) {
 		strncpy (buf, p, sizeof (buf) - 1);
 		if (*buf == '!') {
 			if (buf[1]) {
-				rz_sys_system (buf + 1);
+				rz_sys_system_ (buf + 1);
 			} else {
 				char *foo, *code = NULL;
 				do {

--- a/librz/lang/p/pipe.c
+++ b/librz/lang/p/pipe.c
@@ -164,7 +164,7 @@ static int lang_pipe_run(RzLang *lang, const char *code, int len) {
 		perror ("pipe run");
 	} else if (!child) {
 		/* children */
-		rz_sys_system (code);
+		rz_sys_system_ (code);
 		(void) write (input[1], "", 1);
 		rz_sys_pipe_close (input[0]);
 		rz_sys_pipe_close (input[1]);

--- a/librz/lang/p/pipe.c
+++ b/librz/lang/p/pipe.c
@@ -164,7 +164,7 @@ static int lang_pipe_run(RzLang *lang, const char *code, int len) {
 		perror ("pipe run");
 	} else if (!child) {
 		/* children */
-		rz_sys_system_ (code);
+		rz_sys_xsystem (code);
 		(void) write (input[1], "", 1);
 		rz_sys_pipe_close (input[0]);
 		rz_sys_pipe_close (input[1]);

--- a/librz/lang/p/pipe.c
+++ b/librz/lang/p/pipe.c
@@ -165,7 +165,7 @@ static int lang_pipe_run(RzLang *lang, const char *code, int len) {
 	} else if (!child) {
 		/* children */
 		rz_sys_xsystem (code);
-		(void) write (input[1], "", 1);
+		rz_xwrite (input[1], "", 1);
 		rz_sys_pipe_close (input[0]);
 		rz_sys_pipe_close (input[1]);
 		rz_sys_pipe_close (output[0]);
@@ -199,11 +199,11 @@ static int lang_pipe_run(RzLang *lang, const char *code, int len) {
 			res = lang->cmd_str ((RzCore*)lang->user, buf);
 			//eprintf ("%d %s\n", ret, buf);
 			if (res) {
-				(void) write (input[1], res, strlen (res) + 1);
+				rz_xwrite (input[1], res, strlen (res) + 1);
 				free (res);
 			} else {
 				eprintf ("rz_lang_pipe: NULL reply for (%s)\n", buf);
-				(void) write (input[1], "", 1); // NULL byte
+				rz_xwrite (input[1], "", 1); // NULL byte
 			}
 		}
 		rz_cons_break_pop ();

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -872,9 +872,9 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 		rz_cons_set_raw (false);
 #if __UNIX__
 		// TODO: keep flags :?
-		(void)freopen ("/dev/tty", "rb", stdin);
-		(void)freopen ("/dev/tty", "w", stdout);
-		(void)freopen ("/dev/tty", "w", stderr);
+		rz_xfreopen ("/dev/tty", "rb", stdin);
+		rz_xfreopen ("/dev/tty", "w", stdout);
+		rz_xfreopen ("/dev/tty", "w", stderr);
 #else
 		eprintf ("Cannot reopen stdin without UNIX\n");
 		free (buf);

--- a/librz/main/rz_diff.c
+++ b/librz/main/rz_diff.c
@@ -386,15 +386,15 @@ static int bcb(RzDiff *d, void *user, RzDiffOp *op) {
 	// we append data
 	if (op->b_len <= 246) {
 		ut8 data = op->b_len;
-		(void) write (1, &data, 1);
+		rz_xwrite (1, &data, 1);
 	} else if (op->b_len <= USHRT_MAX) {
 		USLen = (ut16) op->b_len;
 		ut8 data = 247;
-		(void) write (1, &data, 1);
+		rz_xwrite (1, &data, 1);
 		print_bytes (&USLen, sizeof (USLen), true);
 	} else if (op->b_len <= INT_MAX) {
 		ut8 data = 248;
-		(void) write (1, &data, 1);
+		rz_xwrite (1, &data, 1);
 		ILen = (int) op->b_len;
 		print_bytes (&ILen, sizeof (ILen), true);
 	} else {
@@ -1255,7 +1255,7 @@ RZ_API int rz_main_rz_diff(int argc, const char **argv) {
 			pj_ka (ro.pj, "changes");
 		}
 		if (ro.diffmode == 'B') {
-			(void) write (1, "\xd1\xff\xd1\xff\x04", 5);
+			rz_xwrite (1, "\xd1\xff\xd1\xff\x04", 5);
 		}
 		if (ro.diffmode == 'U') {
 			char *res = rz_diff_buffers_unified (d, bufa, (int)sza, bufb, (int)szb);
@@ -1266,7 +1266,7 @@ RZ_API int rz_main_rz_diff(int argc, const char **argv) {
 		} else if (ro.diffmode == 'B') {
 			rz_diff_set_callback (d, &bcb, &ro);
 			rz_diff_buffers (d, bufa, (ut32)sza, bufb, (ut32)szb);
-			(void) write (1, "\x00", 1);
+			rz_xwrite (1, "\x00", 1);
 		} else {
 			rz_diff_set_callback (d, &cb, &ro); // (void *)(size_t)diffmode);
 			rz_diff_buffers (d, bufa, (ut32)sza, bufb, (ut32)szb);

--- a/librz/main/rz_find.c
+++ b/librz/main/rz_find.c
@@ -184,7 +184,7 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 
 	if (ro->identify) {
 		char *cmd = rz_str_newf ("rizin -e search.show=false -e search.maxhits=1 -nqcpm \"%s\"", efile);
-		rz_sys_system (cmd);
+		rz_sys_system_ (cmd);
 		free (cmd);
 		free (efile);
 		return 0;

--- a/librz/main/rz_find.c
+++ b/librz/main/rz_find.c
@@ -184,7 +184,7 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 
 	if (ro->identify) {
 		char *cmd = rz_str_newf ("rizin -e search.show=false -e search.maxhits=1 -nqcpm \"%s\"", efile);
-		rz_sys_system_ (cmd);
+		rz_sys_xsystem (cmd);
 		free (cmd);
 		free (efile);
 		return 0;

--- a/librz/main/rz_hash.c
+++ b/librz/main/rz_hash.c
@@ -410,7 +410,7 @@ static int encrypt_or_decrypt_file(const char *algo, int direction, const char *
 				int result_size = 0;
 				ut8 *result = rz_crypto_get_output (cry, &result_size);
 				if (result) {
-					(void)write (1, result, result_size);
+					rz_xwrite (1, result, result_size);
 					free (result);
 				}
 				free (buf);

--- a/librz/main/rz_run.c
+++ b/librz/main/rz_run.c
@@ -11,7 +11,7 @@ static void fwd(int sig) {
 
 static void rz_run_tty(void) {
 	/* TODO: Implement in native code */
-	rz_sys_system ("tty");
+	rz_sys_system_ ("tty");
 	close (1);
 	dup2 (2, 1);
 	rz_sys_signal (SIGINT, fwd);

--- a/librz/main/rz_run.c
+++ b/librz/main/rz_run.c
@@ -11,7 +11,7 @@ static void fwd(int sig) {
 
 static void rz_run_tty(void) {
 	/* TODO: Implement in native code */
-	rz_sys_system_ ("tty");
+	rz_sys_xsystem ("tty");
 	close (1);
 	dup2 (2, 1);
 	rz_sys_signal (SIGINT, fwd);

--- a/librz/socket/rzpipe.c
+++ b/librz/socket/rzpipe.c
@@ -300,7 +300,7 @@ RZ_API RzPipe *rzpipe_open(const char *cmd) {
 				eprintf ("return code %d for %s\n", rc, cmd);
 			}
 			// trigger the blocking read
-			write (1, "\xff", 1);
+			rz_xwrite (1, "\xff", 1);
 			rz_sys_pipe_close (rzp->output[1]);
 			close (0);
 			close (1);

--- a/librz/util/file.c
+++ b/librz/util/file.c
@@ -917,7 +917,7 @@ static RzMmap *file_mmap(RzMmap *m) {
 		return NULL;
 	}
 	lseek (m->fd, (off_t)0, SEEK_SET);
-	read (m->fd, m->buf, m->len);
+	rz_xread (m->fd, m->buf, m->len);
 	return m;
 }
 #endif

--- a/librz/util/subprocess.c
+++ b/librz/util/subprocess.c
@@ -410,7 +410,7 @@ static void subprocess_unlock(void) {
 
 static void handle_sigchld(int sig) {
 	ut8 b = 1;
-	write (sigchld_pipe[1], &b, 1);
+	rz_xwrite (sigchld_pipe[1], &b, 1);
 }
 
 static RzThreadFunctionRet sigchld_th(RzThread *th) {
@@ -456,7 +456,7 @@ static RzThreadFunctionRet sigchld_th(RzThread *th) {
 				proc->ret = -1;
 			}
 			ut8 r = 0;
-			write (proc->killpipe[1], &r, 1);
+			rz_xwrite (proc->killpipe[1], &r, 1);
 			subprocess_unlock ();
 		}
 	}
@@ -493,7 +493,7 @@ RZ_API bool rz_subprocess_init(void) {
 RZ_API void rz_subprocess_fini(void) {
 	rz_sys_signal (SIGCHLD, SIG_IGN);
 	ut8 b = 0;
-	write (sigchld_pipe[1], &b, 1);
+	rz_xwrite (sigchld_pipe[1], &b, 1);
 	rz_sys_pipe_close (sigchld_pipe [1]);
 	rz_th_wait (sigchld_thread);
 	rz_sys_pipe_close (sigchld_pipe [0]);
@@ -791,7 +791,7 @@ RZ_API void rz_subprocess_kill(RzSubprocess *proc) {
 }
 
 RZ_API void rz_subprocess_stdin_write(RzSubprocess *proc, const ut8 *buf, size_t buf_size) {
-	write (proc->stdin_fd, buf, buf_size);
+	rz_xwrite (proc->stdin_fd, buf, buf_size);
 	rz_sys_pipe_close (proc->stdin_fd);
 	proc->stdin_fd = -1;
 }

--- a/test/unit/test_buf.c
+++ b/test/unit/test_buf.c
@@ -109,7 +109,7 @@ bool test_rz_buf_file(void) {
 	// Prepare file
 	int fd = rz_file_mkstemp ("", &filename);
 	mu_assert_neq ((ut64)fd, (ut64)-1, "mkstemp failed...");
-	write (fd, content, length);
+	rz_xwrite (fd, content, length);
 	close (fd);
 
 	b = rz_buf_new_file (filename, O_RDWR, 0);
@@ -152,7 +152,7 @@ bool test_rz_buf_mmap(void) {
 	// Prepare file
 	int fd = rz_file_mkstemp ("", &filename);
 	mu_assert_neq ((long long)fd, -1LL, "mkstemp failed...");
-	write (fd, content, length);
+	rz_xwrite (fd, content, length);
 	close (fd);
 
 	b = rz_buf_new_mmap (filename, O_RDWR, 0);

--- a/test/unit/test_io.c
+++ b/test/unit/test_io.c
@@ -266,7 +266,7 @@ bool test_rz_io_default(void) {
 
 	char *filename = rz_file_temp (NULL);
 	int fd = open(filename, O_RDWR | O_CREAT, 0644);
-	write (fd, "1234567890ABCDEF", 0x10);
+	rz_xwrite (fd, "1234567890ABCDEF", 0x10);
 	close (fd);
 
 	char *filename_io = rz_str_newf ("file://%s", filename);
@@ -297,7 +297,7 @@ bool test_rz_io_default(void) {
 	free (filename_io);
 
 	fd = open(filename, O_RDONLY, 0644);
-	read (fd, buf, 0x10);
+	rz_xread (fd, buf, 0x10);
 	close (fd);
 	mu_assert_memeq (buf, (ut8 *)"FEDCBA0987654321", 0x10, "data has been correctly written at 0x50");
 	rz_file_rm (filename);

--- a/test/unit/test_util.c
+++ b/test/unit/test_util.c
@@ -134,7 +134,7 @@ bool test_file_slurp(void) {
 
 	f = open (test_file, O_WRONLY, S_IRWXU);
 	mu_assert_neq (f, -1, "cannot reopen empty file");
-	write (f, some_words, strlen (some_words));
+	rz_xwrite (f, some_words, strlen (some_words));
 	close (f);
 
 	content = rz_file_slurp (test_file, &s);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes warnings like the following in #260 (https://github.com/rizinorg/rizin/pull/260/checks?check_run_id=1708037157#step:12:904 -- also search for `-Wunused-result`):

![Wunused-result](https://user-images.githubusercontent.com/12002672/104929688-2cda1180-59df-11eb-8182-d9c33951e9dd.PNG)

It does so by wrapping the calls with a return value check, that on failure basically just prints the equivalent of `perror` to stderr and continues.

There have been discussions about this in https://github.com/rizinorg/rizin/pull/260#pullrequestreview-569946799 and https://github.com/rizinorg/rizin/pull/260#pullrequestreview-570101832. As a side note, the bash command for the mass renaming of `write`/`read`/`freopen` was:

```sh
REGEX="^\([[:blank:]][[:blank:]]*\)\((void)[[:blank:]]*\)\?\(write\|read\|freopen\)[[:blank:]]*(" bash -c 'git grep -l "$REGEX" -- '*.c' | xargs -n 1 sed -i "s/$REGEX/\1rz_x\3 (/"'
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds should be green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
