### PR TITLE
Remove an empty and useless Makefile in `librz/lang` ##lang

### DIFF
--- a/librz/lang/p/Makefile
+++ b/librz/lang/p/Makefile
@@ -1,3 +1,0 @@
-all:
-
-clean:


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
`librz/lang/p/Makefile` is useless and is not used anywhere, as you can learn from  [here](https://github.com/rizinorg/rizin/blob/dev/librz/lang/lang.c#L8-L17). This commit removes that file.


**Test plan**

- [ ] Merge when green

**Closing issues**

None