### PR TITLE
Implement autocompletion for RZNUM arg types ##newshell

### DIFF
--- a/librz/core/cautocmpl.c
+++ b/librz/core/cautocmpl.c
@@ -155,6 +155,7 @@ static void autocmplt_cmd_arg_file(RzLineNSCompletionResult *res, const char *s,
 		}
 	}
 	rz_list_free (l);
+	free (basedir);
 	free (input);
 }
 
@@ -556,13 +557,10 @@ RZ_API RzLineNSCompletionResult *rz_core_autocomplete_newshell(RzCore *core, RzL
 
 	TSTree *tree = ts_parser_parse_string (parser, NULL, buf->data, buf->length);
 	TSNode root = ts_tree_root_node (tree);
-	RZ_LOG_DEBUG ("root = '%s'\n", ts_node_string (root));
-
 	TSNode node = ts_node_named_descendant_for_byte_range (root, buf->index - 1, buf->index);
 	if (ts_node_is_null (node)) {
 		goto err;
 	}
-	RZ_LOG_DEBUG ("cur_node = '%s'\n", ts_node_string (node));
 
 	// the autocompletion works in 2 steps:
 	// 1) it finds the proper type to autocomplete (sometimes it guesses)

--- a/librz/core/cautocmpl.c
+++ b/librz/core/cautocmpl.c
@@ -187,8 +187,50 @@ static bool offset_prompt_add_flag(RzFlagItem *fi, void *user) {
 	return true;
 }
 
-static void autocmplt_cmd_arg_num(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
+static void autocmplt_cmd_arg_fcn(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
+	RzListIter *iter;
+	RzAnalysisFunction *fcn;
+	rz_list_foreach (core->analysis->fcns, iter, fcn) {
+		char *name = rz_core_analysis_fcn_name (core, fcn);
+		if (!strncmp (name, s, len)) {
+			rz_line_ns_completion_result_add (res, name);
+		}
+		free (name);
+	}
+}
+
+static void autocmplt_cmd_arg_help_var(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
+	const char **vars = rz_core_get_help_vars (core);
+	while (*vars) {
+		if (!strncmp (*vars, s, len)) {
+			rz_line_ns_completion_result_add (res, *vars);
+		}
+		vars++;
+	}
+}
+
+static bool is_op_ch(char ch) {
+	return ch == '+' || ch == '-' || ch == '*' || ch == '/' || ch == '%' ||
+		ch == '>' || ch == '<';
+}
+
+static void autocmplt_cmd_arg_rznum(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
+	if (len > 0) {
+		// If the argument is composed of a complex expression with some
+		// operator, autocomplete only the last part
+		const char *p;
+		size_t plen;
+		for (p = s, plen = len; *p && plen > 0; p++, plen--) {
+			if (is_op_ch (*p)) {
+				res->start += p + 1 - s;
+				s = p + 1;
+				len = plen - 1;
+			}
+		}
+	}
+	autocmplt_cmd_arg_fcn (core, res, s, len);
 	rz_flag_foreach_prefix (core->flags, s, len, offset_prompt_add_flag, res);
+	autocmplt_cmd_arg_help_var (core, res, s, len);
 }
 
 static void autocmplt_cmd_arg_zign_space(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
@@ -204,18 +246,6 @@ static void autocmplt_cmd_arg_zign_space(RzCore *core, RzLineNSCompletionResult 
 
 	if (len == 0) {
 		rz_line_ns_completion_result_add (res, "*");
-	}
-}
-
-static void autocmplt_cmd_arg_fcn(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
-	RzListIter *iter;
-	RzAnalysisFunction *fcn;
-	rz_list_foreach (core->analysis->fcns, iter, fcn) {
-		char *name = rz_core_analysis_fcn_name (core, fcn);
-		if (!strncmp (name, s, len)) {
-			rz_line_ns_completion_result_add (res, name);
-		}
-		free (name);
 	}
 }
 
@@ -343,10 +373,8 @@ static size_t get_arg_number(TSNode arg) {
  * command \p cd . This is based on the type of argument a command may accept.
  */
 static void autocmplt_cmd_arg(RzCore *core, RzLineNSCompletionResult *res, const RzCmdDesc *cd, size_t i_arg, const char *s, size_t len) {
-	const RzCmdDescArg *arg = cd->help->args;
-	size_t i;
-	for (i = 0; i < i_arg && arg && arg->name; i++, arg++);
-	if (!arg || !arg->name) {
+	const RzCmdDescArg *arg = rz_cmd_desc_get_arg (core->rcmd, cd, i_arg);
+	if (!arg) {
 		return;
 	}
 
@@ -370,8 +398,8 @@ static void autocmplt_cmd_arg(RzCore *core, RzLineNSCompletionResult *res, const
 	case RZ_CMD_ARG_TYPE_MACRO:
 		autocmplt_cmd_arg_macro (core, res, s, len);
 		break;
-	case RZ_CMD_ARG_TYPE_NUM:
-		autocmplt_cmd_arg_num (core, res, s, len);
+	case RZ_CMD_ARG_TYPE_RZNUM:
+		autocmplt_cmd_arg_rznum (core, res, s, len);
 		break;
 	case RZ_CMD_ARG_TYPE_EVAL_KEY:
 		autocmplt_cmd_arg_eval_key (core, res, s, len);
@@ -408,10 +436,8 @@ static bool fill_autocmplt_data_cmdarg(struct autocmplt_data_t *ad, ut32 start, 
 
 	ad->i_arg = get_arg_number (node);
 
-	const RzCmdDescArg *arg = ad->cd->help->args;
-	size_t i;
-	for (i = 0; i < ad->i_arg && arg && arg->name; i++, arg++);
-	if (!arg || !arg->name) {
+	const RzCmdDescArg *arg = rz_cmd_desc_get_arg (core->rcmd, ad->cd, ad->i_arg);
+	if (!arg) {
 		return false;
 	}
 
@@ -515,7 +541,7 @@ RZ_API RzLineNSCompletionResult *rz_core_autocomplete_newshell(RzCore *core, RzL
 	if (prompt_type == RZ_LINE_PROMPT_OFFSET) {
 		res = rz_line_ns_completion_result_new (0, buf->length, NULL);
 		int n = strlen (buf->data);
-		autocmplt_cmd_arg_num (core, res, buf->data, n);
+		autocmplt_cmd_arg_rznum (core, res, buf->data, n);
 		return res;
 	} else if (prompt_type == RZ_LINE_PROMPT_FILE) {
 		res = rz_line_ns_completion_result_new (0, buf->length, NULL);

--- a/librz/core/cmd_api.c
+++ b/librz/core/cmd_api.c
@@ -1851,6 +1851,35 @@ RZ_API bool rz_cmd_desc_remove(RzCmd *cmd, RzCmdDesc *cd) {
 	return true;
 }
 
+/**
+ * \brief Get a reference to the i-th argument of a command descriptor.
+ *
+ * Get a reference to the i-th argument of a command. This function is useful
+ * to know which RzCmdDescArg an argument actually belongs to. In particular,
+ * it deals with arguments with special flags like \p RZ_CMD_ARG_FLAG_LAST or
+ * \p RZ_CMD_ARG_FLAG_ARRAY, where even if there is just one RzCmdDescArg,
+ * everything is considered as part of the same RzCmdDescArg.
+ */
+RZ_API const RzCmdDescArg *rz_cmd_desc_get_arg(RzCmd *cmd, const RzCmdDesc *cd, size_t i) {
+	const RzCmdDescArg *arg = cd->help->args;
+	size_t j = 0;
+	while (arg && arg->name) {
+		if (arg->type == RZ_CMD_ARG_TYPE_FAKE) {
+			arg++;
+			continue;
+		}
+		if (i == j) {
+			return arg;
+		}
+		if ((arg->flags & RZ_CMD_ARG_FLAG_LAST) || (arg->flags & RZ_CMD_ARG_FLAG_ARRAY)) {
+			return arg;
+		}
+		arg++;
+		j++;
+	}
+	return NULL;
+}
+
 static void cmd_foreach_cmdname(RzCmd *cmd, RzCmdDesc *cd, RzCmdForeachNameCb cb, void *user) {
 	if (!cd) {
 		return;

--- a/librz/core/cmd_help.c
+++ b/librz/core/cmd_help.c
@@ -412,6 +412,19 @@ enum {
 	RZ_AVATAR_CLIPPY,
 };
 
+/**
+ * \brief Returns all the $ variable names in a NULL-terminated array.
+ */
+RZ_API const char **rz_core_get_help_vars(RzCore *core) {
+	static const char *vars[] = {
+		"$$", "$$$", "$?", "$B", "$b", "$c", "$Cn", "$D", "$DB", "$DD", "$Dn",
+		"$e", "$f", "$F", "$Fb", "$FB", "$Fe", "$FE", "$Ff", "$Fi", "$FI", "$Fj",
+		"$fl", "$FS", "$Fs", "$FSS", "$j", "$Ja", "$l", "$M", "$m", "$MM", "$O",
+		"$o", "$p", "$P", "$r", "$s", "$S", "$SS", "$v", "$w", "$Xn", NULL
+	};
+	return vars;
+}
+
 RZ_API void rz_core_clippy(RzCore *core, const char *msg) {
 	int type = RZ_AVATAR_CLIPPY;
 	if (*msg == '+' || *msg == '3') {
@@ -831,12 +844,7 @@ RZ_IPI int rz_cmd_help(void *data, const char *input) {
 			rz_core_cmd_help (core, help_msg_question_v);
 		} else {
 			int i = 0;
-			const char *vars[] = {
-				"$$", "$$$", "$?", "$B", "$b", "$c", "$Cn", "$D", "$DB", "$DD", "$Dn",
-				"$e", "$f", "$F", "$Fb", "$FB", "$Fe", "$FE", "$Ff", "$Fi", "$FI", "$Fj",
-				"$fl", "$FS", "$Fs", "$FSS", "$j", "$Ja", "$l", "$M", "$m", "$MM", "$O",
-				"$o", "$p", "$P", "$r", "$s", "$S", "$SS", "$v", "$w", "$Xn", NULL
-			};
+			const char **vars = rz_core_get_help_vars (core);
 			const bool wideOffsets = rz_config_get_i (core->config, "scr.wideoff");
 			while (vars[i]) {
 				const char *pad = rz_str_pad (' ', 6 - strlen (vars[i]));

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -2754,6 +2754,7 @@ RZ_API void rz_core_fini(RzCore *c) {
 	sdb_free (c->sdb);
 	rz_parse_free (c->parser);
 	free (c->times);
+	rz_core_seek_free (c);
 }
 
 RZ_API void rz_core_free(RzCore *c) {

--- a/librz/core/seek.c
+++ b/librz/core/seek.c
@@ -388,7 +388,14 @@ RZ_API void rz_core_seek_reset(RzCore *core) {
 	rz_vector_fini (&core->seek_history.redos);
 	rz_vector_init (&core->seek_history.undos, sizeof (RzCoreSeekItem), NULL, NULL);
 	rz_vector_init (&core->seek_history.redos, sizeof (RzCoreSeekItem), NULL, NULL);
-	return;
+}
+
+/**
+ * Free seek history data
+ */
+RZ_API void rz_core_seek_free(RzCore *core) {
+	rz_vector_fini (&core->seek_history.undos);
+	rz_vector_fini (&core->seek_history.redos);
 }
 
 /**

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -488,6 +488,7 @@ RZ_API RzCmdDesc *rz_cmd_desc_get_exec(RzCmdDesc *cd);
 RZ_API bool rz_cmd_desc_has_handler(RzCmdDesc *cd);
 RZ_API bool rz_cmd_desc_remove(RzCmd *cmd, RzCmdDesc *cd);
 RZ_API void rz_cmd_foreach_cmdname(RzCmd *cmd, RzCmdForeachNameCb cb, void *user);
+RZ_API const RzCmdDescArg *rz_cmd_desc_get_arg(RzCmd *cmd, const RzCmdDesc *cd, size_t i);
 
 #define rz_cmd_desc_children_foreach(root, it_cd) rz_pvector_foreach (&root->children, it_cd)
 

--- a/librz/include/rz_cons.h
+++ b/librz/include/rz_cons.h
@@ -1057,6 +1057,7 @@ typedef struct rz_line_ns_completion_t RzLineNSCompletion;
  */
 typedef struct rz_line_ns_completion_result_t {
 	RzPVector options; ///< Vector of options that can be used for autocompletion
+	HtPP *options_ht; ///< Hash table to keep track of duplicated autocompletion suggestions
 	size_t start; ///< First byte that was considered for autocompletion. Everything before this will be left intact.
 	size_t end; ///< Last byte that was considered for autocompletion. Everything after this will be left intact.
 	const char *end_string; ///< String to place after the only option available is autocompleted. By default a space is used.

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -802,6 +802,7 @@ RZ_API char *rz_str_widget_list(void *user, RzList *list, int rows, int cur, Pri
 RZ_API PJ *rz_core_pj_new(RzCore *core);
 /* help */
 RZ_API void rz_core_cmd_help(const RzCore *core, const char * help[]);
+RZ_API const char **rz_core_get_help_vars(RzCore *core);
 
 /* analysis stats */
 

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -432,6 +432,7 @@ RZ_API bool rz_core_seek_save(RzCore *core);
 RZ_API bool rz_core_seek_undo(RzCore *core);
 RZ_API bool rz_core_seek_redo(RzCore *core);
 RZ_API void rz_core_seek_reset(RzCore *core);
+RZ_API void rz_core_seek_free(RzCore *core);
 RZ_API RzList *rz_core_seek_list(RzCore *core);
 RZ_API RzCoreSeekItem *rz_core_seek_peek(RzCore *core, int idx);
 RZ_API int rz_core_seek_base(RzCore *core, const char *hex, bool save);

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -766,6 +766,47 @@ bool test_arg_flags(void) {
 	mu_end;
 }
 
+bool test_get_arg(void) {
+	RzCmdDescArg z_args[] = {
+		{ .name = "a1", .type = RZ_CMD_ARG_TYPE_STRING },
+		{ .name = "a2", .type = RZ_CMD_ARG_TYPE_CMD, .flags = RZ_CMD_ARG_FLAG_LAST },
+		{ 0 }
+	};
+	RzCmdDescHelp z_help = { 0 };
+	z_help.summary = "z summary";
+	z_help.args = z_args;
+	RzCmdDescArg x_args[] = {
+		{ .name = "b1", .type = RZ_CMD_ARG_TYPE_STRING },
+		{ .name = "b2", .type = RZ_CMD_ARG_TYPE_STRING },
+		{ .name = "b3", .type = RZ_CMD_ARG_TYPE_STRING },
+		{ 0 }
+	};
+	RzCmdDescHelp x_help = { 0 };
+	x_help.summary = "x summary";
+	x_help.args = x_args;
+	RzCmd *cmd = rz_cmd_new (false);
+	RzCmdDesc *root = rz_cmd_get_root (cmd);
+	RzCmdDesc *z_cd = rz_cmd_desc_argv_new (cmd, root, "z", z_last_handler, &z_help);
+	RzCmdDesc *x_cd = rz_cmd_desc_argv_new (cmd, root, "x", x_array_handler, &x_help);
+
+	const RzCmdDescArg *a1 = rz_cmd_desc_get_arg (cmd, z_cd, 0);
+	mu_assert_streq (a1->name, "a1", "0th arg of z is a1");
+	const RzCmdDescArg *a2 = rz_cmd_desc_get_arg (cmd, z_cd, 1);
+	mu_assert_streq (a2->name, "a2", "1th arg of z is a2");
+	const RzCmdDescArg *an = rz_cmd_desc_get_arg (cmd, z_cd, 10);
+	mu_assert_streq (an->name, "a2", "10th arg of z is a2");
+
+	const RzCmdDescArg *b1 = rz_cmd_desc_get_arg (cmd, x_cd, 0);
+	mu_assert_streq (b1->name, "b1", "0th arg of x is b1");
+	const RzCmdDescArg *b2 = rz_cmd_desc_get_arg (cmd, x_cd, 1);
+	mu_assert_streq (b2->name, "b2", "1th arg of x is b2");
+	const RzCmdDescArg *bn = rz_cmd_desc_get_arg (cmd, x_cd, 10);
+	mu_assert_null (bn, "10th arg of x does not exist");
+
+	rz_cmd_free (cmd);
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test (test_parsed_args_noargs);
 	mu_run_test (test_parsed_args_onearg);
@@ -792,6 +833,7 @@ int all_tests() {
 	mu_run_test (test_double_quoted_arg_escaping);
 	mu_run_test (test_single_quoted_arg_escaping);
 	mu_run_test (test_arg_flags);
+	mu_run_test (test_get_arg);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

* Add rz_cmd_desc_get_arg API to get the right RzCmdDescArg reference 
* Extract rz_core_get_help_vars API to get vars names (?$)
* Implement seek autocompletion (it can autocomplete functions, flags and help vars. It works if you have a simple expression like `flag<tab>` but also if you do `flag1+sym.<tab>` or `flag1 + sym.<tab>`. Unfortunately, it autocompletes also if you do `flag1 sym.<tab>` which is not valid though :( Is this a big problem?)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Try `s` command and autocomplete here and there.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes https://github.com/rizinorg/rizin/issues/311
