### PR TITLE
Fix rpath on MacOS, broken by moving binaries for signing

### DIFF
--- a/binrz/rizin/macos_sign.sh
+++ b/binrz/rizin/macos_sign.sh
@@ -4,13 +4,5 @@
 
 ENTITLEMENT="$1"
 SRC="$2"
-if [ "$#" -ne 2 ]; then
-        DST="$3"
 
-        rm -f "${DST}"
-        cp -a "${SRC}" "${DST}"
-else
-        DST="${MESON_INSTALL_DESTDIR_PREFIX}/${SRC}"
-fi
-
-codesign --entitlements "${ENTITLEMENT}" --force -s - "${DST}"
+codesign --entitlements "${ENTITLEMENT}" --force -s - "${SRC}"

--- a/binrz/rizin/meson.build
+++ b/binrz/rizin/meson.build
@@ -1,18 +1,4 @@
-rizin_link_args = []
-rizin_link_depends = []
-rizin_name = 'rizin'
-rizin_exe_name = rizin_name
-if host_machine.system() == 'darwin'
-  # NOTE: we do not sign the binary with a certificate for now, so no need for this.
-  #       However keep this in mind if/when we will sign rizin binary
-  # rizin_link_args += ['-Wl,-sectcreate,__TEXT,__info_plist,' + join_paths(meson.current_source_dir(), 'Info.plist')]
-  # rizin_link_args += ['-Wl,-framework,Security']
-  # rizin_link_args += ['-Wl,-framework,CoreFoundation']
-  # rizin_link_depends += 'Info.plist'
-  rizin_exe_name += '-unsigned'
-endif
-
-rizin_exe = executable(rizin_exe_name, 'rizin.c',
+rizin_exe = executable('rizin', 'rizin.c',
   include_directories: [platform_inc],
   dependencies: [
     rz_util_dep,
@@ -37,11 +23,9 @@ rizin_exe = executable(rizin_exe_name, 'rizin.c',
     rz_crypto_dep,
     rz_magic_dep
   ],
-  install: rizin_exe_name == rizin_name,
+  install: true,
   install_rpath: rpath_exe,
   implicit_include_directories: false,
-  link_args: rizin_link_args,
-  link_depends: rizin_link_depends,
 )
 
 if host_machine.system() == 'darwin'
@@ -49,23 +33,21 @@ if host_machine.system() == 'darwin'
   # entitlements
   entitlements = files('rizin_macos.xml')
   macos_sign_sh = meson.current_source_dir() / 'macos_sign.sh'
-  custom_target(rizin_name,
+  custom_target('rizin-signing',
     build_by_default: true,
     build_always_stale: true,
     command: [
       macos_sign_sh,
       entitlements,
       rizin_exe.full_path(),
-      meson.current_build_dir() / rizin_name,
     ],
     depends: rizin_exe,
-    output: rizin_name,
-    install: true,
-    install_dir: get_option('bindir'),
+    output: 'rizin-signing',
+    install: false,
   )
 
   meson.add_install_script(meson.current_source_dir() / 'macos_sign.sh',
     entitlements,
-    get_option('bindir') / rizin_name,
+    rizin_prefix / rizin_bindir / 'rizin',
   )
 endif

--- a/meson.build
+++ b/meson.build
@@ -155,6 +155,7 @@ endif
 library_cflags = ['-DRZ_PLUGIN_INCORE=1']
 
 rizin_prefix = get_option('prefix')
+rizin_bindir = get_option('bindir')
 rizin_libdir = get_option('libdir')
 rizin_incdir = get_option('includedir') / 'librz'
 rizin_datdir = get_option('datadir')
@@ -712,6 +713,7 @@ endif
 
 summary({
   'prefix': rizin_prefix,
+  'bindir': rizin_bindir,
   'libdir': rizin_libdir,
   'includedir': rizin_incdir,
   'datadir': rizin_datdir,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

I've noticed that the installed rizin binary was not correctly linked to the libraries. This was due to the signing stuff I recently added and somehow meson was not able anymore to replace `@rpath` with the right path. This avoids copying rizin binary  and just sign the original one, fixing the rpath issue.


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
