### PR TITLE
sys/clang-format.py: Require clang-format 11

### DIFF
--- a/sys/clang-format.py
+++ b/sys/clang-format.py
@@ -2,7 +2,17 @@
 
 import glob
 import os
+import shutil
+import subprocess
 import sys
+
+binary = "clang-format-11"
+if not shutil.which(binary):
+    binary = "clang-format"
+    verstr = subprocess.run([binary, "--version"], capture_output=True).stdout
+    if not b"version 11." in verstr:
+        sys.stderr.write("ERROR: clang-format 11 required\n")
+        sys.exit(1)
 
 dirlist = [
     "binrz",
@@ -51,7 +61,7 @@ try:
             print("Processing pattern: {0}".format(pat))
             for filename in glob.iglob(d + "/**/" + pat, recursive=True):
                 if not skip(filename):
-                    CMD = "clang-format -style=file -i {0}".format(filename)
+                    CMD = "{0} -style=file -i {1}".format(binary, filename)
                     print(CMD)
                     os.system(CMD)
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr makes `sys/clang.format.py` check whether clang-format is version 11. Ubuntu 20.04 installs clang-format 10 by default which formats code differently even with the same `.clang-format`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
