### PR TITLE
Fix crash with `es` without args

### DIFF
--- a/librz/core/cmd_eval.c
+++ b/librz/core/cmd_eval.c
@@ -753,7 +753,8 @@ RZ_IPI RzCmdStatus rz_eval_readonly_handler(RzCore *core, int argc, const char *
 }
 
 RZ_IPI RzCmdStatus rz_eval_spaces_handler(RzCore *core, int argc, const char **argv) {
-	rz_config_list(core->config, argv[1], 's');
+	const char *arg = argc > 1 ? argv[1] : "";
+	rz_config_list(core->config, arg, 's');
 	return RZ_CMD_STATUS_OK;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Same as #434
