### PR TITLE
Prevent FD_ZERO formatting from mangling by clang-format

### DIFF
--- a/librz/include/sflib/common/sftypes.h
+++ b/librz/include/sflib/common/sftypes.h
@@ -197,8 +197,7 @@ typedef struct
 		unsigned int __i; \
 		fd_set *__arr = (set); \
 		for (__i = 0; __i < sizeof(fd_set) / sizeof(fd_mask); ++__i) \
-			__FDS_BITS(__arr) \
-			[__i] = 0; \
+			(__FDS_BITS(__arr)[__i] = 0); \
 	} while (0)
 
 #define FD_SET(d, set)   (__FDS_BITS(set)[__FDELT(d)] |= FDMASK(d))

--- a/librz/include/sflib/common/sftypes.h
+++ b/librz/include/sflib/common/sftypes.h
@@ -196,8 +196,11 @@ typedef struct
 	do { \
 		unsigned int __i; \
 		fd_set *__arr = (set); \
-		for (__i = 0; __i < sizeof(fd_set) / sizeof(fd_mask); ++__i) \
-			(__FDS_BITS(__arr)[__i] = 0); \
+		for (__i = 0; __i < sizeof(fd_set) / sizeof(fd_mask); ++__i) { \
+			/* clang-format off */ \
+			__FDS_BITS(__arr)[__i] = 0; \
+			/* clang-format on */ \
+		} \
 	} while (0)
 
 #define FD_SET(d, set)   (__FDS_BITS(set)[__FDELT(d)] |= FDMASK(d))


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Both `clang-format-10` and `clang-format-11` cut the following statement into 2 lines https://github.com/rizinorg/rizin/blob/502e91aff7aa1d422f8a64489a17fa44a84602d7/librz/include/sflib/common/sftypes.h#L210 so this pr adds parentheses to prevent the cutting.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green. For some reason, changes to `librz/include/sflib/common/sftypes.h` do not trigger a meson rebuild.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
