### PR TITLE
Meson: Escape paths on Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -160,8 +160,9 @@ rizin_libdir = get_option('libdir')
 rizin_incdir = get_option('includedir') / 'librz'
 rizin_datdir = get_option('datadir')
 if host_machine.system() == 'windows'
+  rizin_prefix = rizin_prefix / ''
   rizin_wwwroot = rizin_datdir / 'www'
-  rizin_sdb = rizin_datdir
+  rizin_sdb = rizin_datdir / ''
   rizin_zigns = rizin_datdir / 'zigns'
   rizin_themes = rizin_datdir / 'cons'
   rizin_fortunes = rizin_datdir / 'fortunes'


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Unescaped `\` were being put in `rz_userconf.h`
