### PR TITLE
Make Tiny C Compiler `configure` script executable again

### DIFF
--- a/.github/workflows/tcc.yml
+++ b/.github/workflows/tcc.yml
@@ -24,6 +24,7 @@ jobs:
           git clone https://repo.or.cz/tinycc.git
           cd tinycc
           git checkout mob
+          chmod +x ./configure
 
     - name: Compiling and installing TinyCC
       working-directory: tinycc


### PR DESCRIPTION

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

configure had the exec bit removed with
https://repo.or.cz/tinycc.git/commit/1ed4b6ba1a66a9836d325f0eb9c753d45518fb94,
so this commit makes sure it has it again so we can test tcc build.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

TCC build should be green again

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
