### PR TITLE
Refactor to use API in Visual mode

### DIFF
--- a/librz/core/Makefile
+++ b/librz/core/Makefile
@@ -7,7 +7,7 @@ RZ_DEPS+=rz_debug rz_hash rz_bin rz_lang rz_io rz_analysis rz_parse rz_bp rz_egg
 RZ_DEPS+=rz_reg rz_search rz_syscall rz_socket rz_magic rz_crypto
 
 OBJS=core.o cmd.o cfile.o cconfig.o visual.o cio.o yank.o libs.o agraph.o
-OBJS+=fortune.o hack.o vasm.o cbin.o rtr.o cmd_api.o cmd_descs.o
+OBJS+=fortune.o hack.o vasm.o cbin.o rtr.o cmd_api.o cmd_descs.o cdebug.o
 OBJS+=carg.o canalysis.o cautocmpl.o project.o gdiff.o casm.o disasm.o cplugin.o
 OBJS+=vmenus.o vmenus_graph.o vmenus_zigns.o zdiff.o
 OBJS+=task.o panels.o vmarks.o analysis_tp.o analysis_objc.o blaze.o

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_core.h>
+#include <rz_debug.h>
+
+RZ_API bool rz_core_debug_step_one(RzCore *core, int times) {
+	if (rz_config_get_i(core->config, "cfg.debug")) {
+		rz_reg_arena_swap(core->dbg->reg, true);
+		// sync registers for BSD PT_STEP/PT_CONT
+		rz_debug_reg_sync(core->dbg, RZ_REG_TYPE_GPR, false);
+		ut64 pc = rz_debug_reg_get(core->dbg, "PC");
+		rz_debug_trace_pc(core->dbg, pc);
+		if (!rz_debug_step(core->dbg, times)) {
+			eprintf("Step failed\n");
+			core->break_loop = true;
+			return false;
+		}
+	} else {
+		int i = 0;
+		do {
+			rz_core_esil_step(core, UT64_MAX, NULL, NULL, false);
+			rz_core_cmd0(core, ".ar*");
+			i++;
+		} while (i < times);
+	}
+	return true;
+}

--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -4472,20 +4472,7 @@ static int cmd_debug_step(RzCore *core, const char *input) {
 	switch (input[1]) {
 	case 0: // "ds"
 	case ' ':
-		if (rz_config_get_i(core->config, "cfg.debug")) {
-			rz_reg_arena_swap(core->dbg->reg, true);
-			// sync registers for BSD PT_STEP/PT_CONT
-			// XXX(jjd): is this necessary?
-			rz_debug_reg_sync(core->dbg, RZ_REG_TYPE_GPR, false);
-			ut64 pc = rz_debug_reg_get(core->dbg, "PC");
-			rz_debug_trace_pc(core->dbg, pc);
-			if (!rz_debug_step(core->dbg, times)) {
-				eprintf("Step failed\n");
-				core->break_loop = true;
-			}
-		} else {
-			rz_core_cmdf(core, "%daes", RZ_MAX(1, times));
-		}
+		rz_core_debug_step_one(core, times);
 		break;
 	case 'i': // "dsi"
 		if (input[2] == ' ') {

--- a/librz/core/cmd_eval.c
+++ b/librz/core/cmd_eval.c
@@ -214,7 +214,7 @@ RZ_API RzList *rz_core_list_themes(RzCore *core) {
 	return list;
 }
 
-static void nextpal(RzCore *core, int mode) {
+RZ_IPI void rz_core_theme_nextpal(RzCore *core, int mode) {
 	// TODO: use rz_core_list_themes() here instead of rewalking all the time
 	RzList *files = NULL;
 	RzListIter *iter;
@@ -292,14 +292,14 @@ done:
 	free(path);
 	if (getNext) {
 		RZ_FREE(curtheme);
-		nextpal(core, mode);
+		rz_core_theme_nextpal(core, mode);
 		return;
 	}
 	if (mode == 'l' && !curtheme && !rz_list_empty(files)) {
-		//nextpal (core, mode);
+		//rz_core_theme_nextpal (core, mode);
 	} else if (mode == 'n' || mode == 'p') {
 		if (curtheme) {
-			rz_core_cmdf(core, "eco %s", curtheme);
+			cmd_load_theme(core, curtheme);
 		}
 	}
 	rz_list_free(files);
@@ -337,7 +337,7 @@ RZ_IPI int rz_eval_color(void *data, const char *input) {
 		break;
 	case 'o': // "eco"
 		if (input[1] == 'j') {
-			nextpal(core, 'j');
+			rz_core_theme_nextpal(core, 'j');
 		} else if (input[1] == ' ') {
 			cmd_load_theme(core, input + 2);
 		} else if (input[1] == 'o') {
@@ -388,10 +388,10 @@ RZ_IPI int rz_eval_color(void *data, const char *input) {
 		rz_cons_pal_random();
 		break;
 	case 'n': // "ecn"
-		nextpal(core, 'n');
+		rz_core_theme_nextpal(core, 'n');
 		break;
 	case 'p': // "ecp"
-		nextpal(core, 'p');
+		rz_core_theme_nextpal(core, 'p');
 		break;
 	case 'H': { // "ecH"
 		char *color_code = NULL;

--- a/librz/core/meson.build
+++ b/librz/core/meson.build
@@ -25,6 +25,7 @@ rz_core_sources = [
   'cautocmpl.c',
   'cbin.c',
   'cconfig.c',
+  'cdebug.c',
   'cio.c',
   'cmd.c',
   cmd_descs_c,

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -384,6 +384,7 @@ typedef int (*RzCoreSearchCallback)(RzCore *core, ut64 from, ut8 *buf, int len);
 //#define rz_core_ncast(x) (RzCore*)(size_t)(x)
 RZ_API RzList *rz_core_list_themes(RzCore *core);
 RZ_API char *rz_core_get_theme(void);
+RZ_API void rz_core_theme_nextpal(RzCore *core, int mode);
 RZ_API const char *rz_core_get_section_name(RzCore *core, ut64 addr);
 RZ_API RzCons *rz_core_get_cons(RzCore *core);
 RZ_API RzBin *rz_core_get_bin(RzCore *core);
@@ -535,6 +536,9 @@ RZ_API ut8 *rz_core_transform_op(RzCore *core, const char *arg, char op);
 RZ_API int rz_core_set_file_by_fd(RzCore *core, ut64 bin_fd);
 RZ_API int rz_core_set_file_by_name(RzBin *bin, const char *name);
 RZ_API ut32 rz_core_file_cur_fd(RzCore *core);
+
+/* cdebug.c */
+RZ_API bool rz_core_debug_step_one(RzCore *core, int times);
 
 RZ_API void rz_core_debug_rr(RzCore *core, RzReg *reg, int mode);
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ x I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Refactor Visual mode to use API instead of `rz_core_cmd*` functions in some cases - themes palette navigation and some of the debugging commands - debug step and ESIL emulation step.

**Test plan**

Go into Visual mode, e.g. `Vp` and try to press `s` in both debug and ESIL modes.


**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/382
