### PR TITLE
Fix agraph.c calloc warning

### DIFF
--- a/librz/include/rz_agraph.h
+++ b/librz/include/rz_agraph.h
@@ -84,7 +84,7 @@ typedef struct rz_ascii_graph_t {
 	RzList *back_edges;
 	RzList *long_edges;
 	struct layer_t *layers;
-	int n_layers;
+	unsigned int n_layers;
 	RzList *dists; /* RzList<struct dist_t> */
 	RzList *edges; /* RzList<AEdge> */
 	RzAGraphHits ghits;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following warning in #260 (https://github.com/rizinorg/rizin/runs/1770565347#step:12:1244):

![agraph-calloc-warning](https://user-images.githubusercontent.com/12002672/105987125-cc328f00-60d8-11eb-808c-4b22001a7362.PNG)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
