### PR TITLE
Fix gcc 9.2.0 kind of x86_64 jumptables

### DIFF
--- a/test/db/analysis/x86_64
+++ b/test/db/analysis/x86_64
@@ -3236,6 +3236,31 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=gcc_9.2.0_64 switch/case flags
+FILE=bins/elf/dectest64
+CMDS=<<EOF
+aaa
+f~switch
+f~case.
+EOF
+EXPECT=<<EOF
+0x004011fd 1 switch.0x004011fd
+0x0040138d 1 switch.0x0040138d
+0x0040120a 1 case.0x4011fd.0
+0x0040121b 1 case.0x4011fd.1
+0x0040122c 1 case.0x4011fd.2
+0x0040123d 1 case.0x4011fd.3
+0x0040124e 1 case.0x4011fd.4
+0x00401270 1 case.default.0x4011fd
+0x00401398 1 case.0x40138d.0
+0x004013a9 1 case.0x40138d.1
+0x004013ba 1 case.0x40138d.2
+0x004013cb 1 case.0x40138d.3
+0x004013dc 1 case.0x40138d.4
+0x004013fe 1 case.default.0x40138d
+EOF
+RUN
+
 NAME=clang_3.8_64 switch/case flags
 FILE=bins/jmptbl/test_clang_3.8_64.out
 CMDS=<<EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

When analyzing a jumptable from a preceding `mov reg, [reg * scale + disp]`, the entry size of `4` was hardcoded here, breaking for example 64bit ones. This is sort of a regression out of #418. Before that, `analysis->bits >> 3` was used in the if branch that this one with the `4` was merged with.

But I think `analysis->bits >> 3` is also not ideal here and the size should be taken from the mov instruction instead. There are two candidates for this: the "scale" or the size of the actual value moved (dword/qword). I went for the scale here because of how `try_walkthrough_jmptbl()` iterates through the table by adding the size.

**Test plan**

See the added test case. Before the change, it only analyzed a single case instead of 5.
