### PR TITLE
Refactor to use API in Visual mode

### DIFF
--- a/librz/config/config.c
+++ b/librz/config/config.c
@@ -348,6 +348,7 @@ RZ_API ut64 rz_config_get_i(RzConfig *cfg, const char *name) {
 		if (node->i_value || !strcmp(node->value, "false")) {
 			return node->i_value;
 		}
+		// TODO: Remove it once the switch to `rz_config_get_b()` is complete
 		if (!strcmp(node->value, "true")) {
 			return 1;
 		}

--- a/librz/config/config.c
+++ b/librz/config/config.c
@@ -146,7 +146,7 @@ RZ_API void rz_config_list(RzConfig *cfg, const char *str, int rad) {
 	bool json = false;
 	bool isFirst = false;
 
-	if (!IS_NULLSTR(str)) {
+	if (RZ_STR_ISNOTEMPTY(str)) {
 		str = rz_str_trim_head_ro(str);
 		len = strlen(str);
 		if (len > 0 && str[0] == 'j') {
@@ -424,7 +424,7 @@ RZ_API RzConfigNode *rz_config_set_b(RzConfig *cfg, const char *name, bool value
 	ut64 oi = 0;
 
 	rz_return_val_if_fail(cfg && cfg->ht, NULL);
-	rz_return_val_if_fail(!IS_NULLSTR(name), NULL);
+	rz_return_val_if_fail(RZ_STR_ISNOTEMPTY(name), NULL);
 
 	node = rz_config_node_get(cfg, name);
 	if (node) {
@@ -492,7 +492,7 @@ RZ_API RzConfigNode *rz_config_set(RzConfig *cfg, const char *name, const char *
 	ut64 oi;
 
 	rz_return_val_if_fail(cfg && cfg->ht, NULL);
-	rz_return_val_if_fail(!IS_NULLSTR(name), NULL);
+	rz_return_val_if_fail(RZ_STR_ISNOTEMPTY(name), NULL);
 
 	node = rz_config_node_get(cfg, name);
 	if (node) {

--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -4505,21 +4505,7 @@ RZ_API int rz_core_visual_graph(RzCore *core, RzAGraph *g, RzAnalysisFunction *_
 				g->need_reload_nodes = true;
 			}
 			// TODO: toggle shortcut hotkeys
-			if (rz_config_get_b(core->config, "asm.hint.call")) {
-				rz_config_toggle(core->config, "asm.hint.call");
-				rz_config_set_b(core->config, "asm.hint.jmp", true);
-			} else if (rz_config_get_b(core->config, "asm.hint.jmp")) {
-				rz_config_toggle(core->config, "asm.hint.jmp");
-				rz_config_set_b(core->config, "asm.hint.emu", true);
-			} else if (rz_config_get_b(core->config, "asm.hint.emu")) {
-				rz_config_toggle(core->config, "asm.hint.emu");
-				rz_config_set_b(core->config, "asm.hint.lea", true);
-			} else if (rz_config_get_b(core->config, "asm.hint.lea")) {
-				rz_config_toggle(core->config, "asm.hint.lea");
-				rz_config_set_b(core->config, "asm.hint.call", true);
-			} else {
-				rz_config_set_b(core->config, "asm.hint.call", true);
-			}
+			rz_core_visual_toggle_hints(core);
 			break;
 		case '$':
 			rz_core_cmd(core, "dr PC=$$", 0);

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -4,6 +4,45 @@
 #include <rz_debug.h>
 #include "core_private.h"
 
+static bool is_x86_call(RzDebug *dbg, ut64 addr) {
+	ut8 buf[3];
+	ut8 *op = buf;
+	(void)dbg->iob.read_at(dbg->iob.io, addr, buf, RZ_ARRAY_SIZE(buf));
+	switch (buf[0]) { /* Segment override prefixes */
+	case 0x65:
+	case 0x64:
+	case 0x26:
+	case 0x3e:
+	case 0x36:
+	case 0x2e:
+		op++;
+	}
+	if (op[0] == 0xe8) {
+		return true;
+	}
+	if (op[0] == 0xff /* bits 4-5 (from right) of next byte must be 01 */
+		&& (op[1] & 0x30) == 0x10) {
+		return true;
+	}
+	/* ... */
+	return false;
+}
+
+static bool is_x86_ret(RzDebug *dbg, ut64 addr) {
+	ut8 buf[1];
+	(void)dbg->iob.read_at(dbg->iob.io, addr, buf, RZ_ARRAY_SIZE(buf));
+	switch (buf[0]) {
+	case 0xc3:
+	case 0xcb:
+	case 0xc2:
+	case 0xca:
+		return true;
+	default:
+		return false;
+	}
+	/* Possibly incomplete with regard to instruction prefixes */
+}
+
 RZ_API bool rz_core_debug_step_one(RzCore *core, int times) {
 	if (rz_config_get_i(core->config, "cfg.debug")) {
 		rz_reg_arena_swap(core->dbg->reg, true);
@@ -27,6 +66,90 @@ RZ_API bool rz_core_debug_step_one(RzCore *core, int times) {
 	return true;
 }
 
+RZ_API bool rz_core_debug_continue_until(RzCore *core, ut64 addr, ut64 to) {
+	ut64 pc;
+	if (!strcmp(core->dbg->btalgo, "trace") && core->dbg->arch && !strcmp(core->dbg->arch, "x86") && core->dbg->bits == 4) {
+		unsigned long steps = 0;
+		long level = 0;
+		const char *pc_name = core->dbg->reg->name[RZ_REG_NAME_PC];
+		ut64 prev_pc = UT64_MAX;
+		bool prev_call = false;
+		bool prev_ret = false;
+		const char *sp_name = core->dbg->reg->name[RZ_REG_NAME_SP];
+		ut64 old_sp, cur_sp;
+		rz_cons_break_push(NULL, NULL);
+		rz_list_free(core->dbg->call_frames);
+		core->dbg->call_frames = rz_list_new();
+		core->dbg->call_frames->free = free;
+		rz_debug_reg_sync(core->dbg, RZ_REG_TYPE_GPR, false);
+		old_sp = rz_debug_reg_get(core->dbg, sp_name);
+		while (true) {
+			rz_debug_reg_sync(core->dbg, RZ_REG_TYPE_GPR, false);
+			pc = rz_debug_reg_get(core->dbg, pc_name);
+			if (prev_call) {
+				ut32 ret_addr;
+				RzDebugFrame *frame = RZ_NEW0(RzDebugFrame);
+				cur_sp = rz_debug_reg_get(core->dbg, sp_name);
+				(void)core->dbg->iob.read_at(core->dbg->iob.io, cur_sp, (ut8 *)&ret_addr,
+					sizeof(ret_addr));
+				frame->addr = ret_addr;
+				frame->size = old_sp - cur_sp;
+				frame->sp = cur_sp;
+				frame->bp = old_sp;
+				rz_list_prepend(core->dbg->call_frames, frame);
+				eprintf("%ld Call from 0x%08" PFMT64x " to 0x%08" PFMT64x " ret 0x%08" PFMT32x "\n",
+					level, prev_pc, pc, ret_addr);
+				level++;
+				old_sp = cur_sp;
+				prev_call = false;
+			} else if (prev_ret) {
+				RzDebugFrame *head = rz_list_get_bottom(core->dbg->call_frames);
+				if (head && head->addr != pc) {
+					eprintf("*");
+				} else {
+					rz_list_pop_head(core->dbg->call_frames);
+					eprintf("%ld", level);
+					level--;
+				}
+				eprintf(" Ret from 0x%08" PFMT64x " to 0x%08" PFMT64x "\n",
+					prev_pc, pc);
+				prev_ret = false;
+			}
+			if (steps % 500 == 0 || pc == addr) {
+				eprintf("At 0x%08" PFMT64x " after %lu steps\n", pc, steps);
+			}
+			if (rz_cons_is_breaked() || rz_debug_is_dead(core->dbg) || pc == addr) {
+				break;
+			}
+			if (is_x86_call(core->dbg, pc)) {
+				prev_pc = pc;
+				prev_call = true;
+			} else if (is_x86_ret(core->dbg, pc)) {
+				prev_pc = pc;
+				prev_ret = true;
+			}
+			rz_debug_step(core->dbg, 1);
+			steps++;
+		}
+		rz_cons_break_pop();
+		return true;
+	}
+	eprintf("Continue until 0x%08" PFMT64x " using %d bpsize\n", addr, core->dbg->bpsize);
+	rz_reg_arena_swap(core->dbg->reg, true);
+	if (rz_bp_add_sw(core->dbg->bp, addr, core->dbg->bpsize, RZ_BP_PROT_EXEC)) {
+		if (rz_debug_is_dead(core->dbg)) {
+			eprintf("Cannot continue, run ood?\n");
+		} else {
+			rz_debug_continue(core->dbg);
+		}
+		rz_bp_del(core->dbg->bp, addr);
+	} else {
+		eprintf("Cannot set breakpoint of size %d at 0x%08" PFMT64x "\n",
+			core->dbg->bpsize, addr);
+		return false;
+	}
+	return true;
+}
 static void regs_to_flags(RzCore *core, int size) {
 	const RzList *l = rz_reg_get_list(core->dbg->reg, RZ_REG_TYPE_GPR);
 	RzListIter *iter;

--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -4119,45 +4119,6 @@ static void rz_core_debug_kill(RzCore *core, const char *input) {
 	}
 }
 
-static bool is_x86_call(RzDebug *dbg, ut64 addr) {
-	ut8 buf[3];
-	ut8 *op = buf;
-	(void)dbg->iob.read_at(dbg->iob.io, addr, buf, RZ_ARRAY_SIZE(buf));
-	switch (buf[0]) { /* Segment override prefixes */
-	case 0x65:
-	case 0x64:
-	case 0x26:
-	case 0x3e:
-	case 0x36:
-	case 0x2e:
-		op++;
-	}
-	if (op[0] == 0xe8) {
-		return true;
-	}
-	if (op[0] == 0xff /* bits 4-5 (from right) of next byte must be 01 */
-		&& (op[1] & 0x30) == 0x10) {
-		return true;
-	}
-	/* ... */
-	return false;
-}
-
-static bool is_x86_ret(RzDebug *dbg, ut64 addr) {
-	ut8 buf[1];
-	(void)dbg->iob.read_at(dbg->iob.io, addr, buf, RZ_ARRAY_SIZE(buf));
-	switch (buf[0]) {
-	case 0xc3:
-	case 0xcb:
-	case 0xc2:
-	case 0xca:
-		return true;
-	default:
-		return false;
-	}
-	/* Possibly incomplete with regard to instruction prefixes */
-}
-
 static bool cmd_dcu(RzCore *core, const char *input) {
 	const char *ptr = NULL;
 	ut64 from, to, pc;
@@ -4216,86 +4177,7 @@ static bool cmd_dcu(RzCore *core, const char *input) {
 		} while (pc < from || pc > to);
 		rz_cons_break_pop();
 	} else {
-		ut64 addr = from;
-		if (!strcmp(core->dbg->btalgo, "trace") && core->dbg->arch && !strcmp(core->dbg->arch, "x86") && core->dbg->bits == 4) {
-			unsigned long steps = 0;
-			long level = 0;
-			const char *pc_name = core->dbg->reg->name[RZ_REG_NAME_PC];
-			ut64 prev_pc = UT64_MAX;
-			bool prev_call = false;
-			bool prev_ret = false;
-			const char *sp_name = core->dbg->reg->name[RZ_REG_NAME_SP];
-			ut64 old_sp, cur_sp;
-			rz_cons_break_push(NULL, NULL);
-			rz_list_free(core->dbg->call_frames);
-			core->dbg->call_frames = rz_list_new();
-			core->dbg->call_frames->free = free;
-			rz_debug_reg_sync(core->dbg, RZ_REG_TYPE_GPR, false);
-			old_sp = rz_debug_reg_get(core->dbg, sp_name);
-			while (true) {
-				rz_debug_reg_sync(core->dbg, RZ_REG_TYPE_GPR, false);
-				pc = rz_debug_reg_get(core->dbg, pc_name);
-				if (prev_call) {
-					ut32 ret_addr;
-					RzDebugFrame *frame = RZ_NEW0(RzDebugFrame);
-					cur_sp = rz_debug_reg_get(core->dbg, sp_name);
-					(void)core->dbg->iob.read_at(core->dbg->iob.io, cur_sp, (ut8 *)&ret_addr,
-						sizeof(ret_addr));
-					frame->addr = ret_addr;
-					frame->size = old_sp - cur_sp;
-					frame->sp = cur_sp;
-					frame->bp = old_sp;
-					rz_list_prepend(core->dbg->call_frames, frame);
-					eprintf("%ld Call from 0x%08" PFMT64x " to 0x%08" PFMT64x " ret 0x%08" PFMT32x "\n",
-						level, prev_pc, pc, ret_addr);
-					level++;
-					old_sp = cur_sp;
-					prev_call = false;
-				} else if (prev_ret) {
-					RzDebugFrame *head = rz_list_get_bottom(core->dbg->call_frames);
-					if (head && head->addr != pc) {
-						eprintf("*");
-					} else {
-						rz_list_pop_head(core->dbg->call_frames);
-						eprintf("%ld", level);
-						level--;
-					}
-					eprintf(" Ret from 0x%08" PFMT64x " to 0x%08" PFMT64x "\n",
-						prev_pc, pc);
-					prev_ret = false;
-				}
-				if (steps % 500 == 0 || pc == addr) {
-					eprintf("At 0x%08" PFMT64x " after %lu steps\n", pc, steps);
-				}
-				if (rz_cons_is_breaked() || rz_debug_is_dead(core->dbg) || pc == addr) {
-					break;
-				}
-				if (is_x86_call(core->dbg, pc)) {
-					prev_pc = pc;
-					prev_call = true;
-				} else if (is_x86_ret(core->dbg, pc)) {
-					prev_pc = pc;
-					prev_ret = true;
-				}
-				rz_debug_step(core->dbg, 1);
-				steps++;
-			}
-			rz_cons_break_pop();
-			return true;
-		}
-		eprintf("Continue until 0x%08" PFMT64x " using %d bpsize\n", addr, core->dbg->bpsize);
-		rz_reg_arena_swap(core->dbg->reg, true);
-		if (rz_bp_add_sw(core->dbg->bp, addr, core->dbg->bpsize, RZ_BP_PROT_EXEC)) {
-			if (rz_debug_is_dead(core->dbg)) {
-				eprintf("Cannot continue, run ood?\n");
-			} else {
-				rz_debug_continue(core->dbg);
-			}
-			rz_bp_del(core->dbg->bp, addr);
-		} else {
-			eprintf("Cannot set breakpoint of size %d at 0x%08" PFMT64x "\n",
-				core->dbg->bpsize, addr);
-		}
+		return rz_core_debug_continue_until(core, from, to);
 	}
 	return true;
 }

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -637,89 +637,89 @@ static RDisasmState *ds_init(RzCore *core) {
 	ds->color_func_var_addr = P(func_var_addr)
 	    : Color_CYAN;
 
-	ds->immstr = rz_config_get_i(core->config, "asm.imm.str");
-	ds->immtrim = rz_config_get_i(core->config, "asm.imm.trim");
-	ds->use_esil = rz_config_get_i(core->config, "asm.esil");
-	ds->pre_emu = rz_config_get_i(core->config, "emu.pre");
-	ds->show_flgoff = rz_config_get_i(core->config, "asm.flags.offset");
-	ds->show_nodup = rz_config_get_i(core->config, "asm.nodup");
+	ds->immstr = rz_config_get_b(core->config, "asm.imm.str");
+	ds->immtrim = rz_config_get_b(core->config, "asm.imm.trim");
+	ds->use_esil = rz_config_get_b(core->config, "asm.esil");
+	ds->pre_emu = rz_config_get_b(core->config, "emu.pre");
+	ds->show_flgoff = rz_config_get_b(core->config, "asm.flags.offset");
+	ds->show_nodup = rz_config_get_b(core->config, "asm.nodup");
 	{
 		const char *ah = rz_config_get(core->config, "asm.highlight");
 		ds->asm_highlight = (ah && *ah) ? rz_num_math(core->num, ah) : UT64_MAX;
 	}
-	ds->asm_analysis = rz_config_get_i(core->config, "asm.analysis");
+	ds->asm_analysis = rz_config_get_b(core->config, "asm.analysis");
 	ds->show_color = rz_config_get_i(core->config, "scr.color");
-	ds->show_color_bytes = rz_config_get_i(core->config, "scr.color.bytes"); // maybe rename to asm.color.bytes
-	ds->show_color_args = rz_config_get_i(core->config, "scr.color.args");
-	ds->colorop = rz_config_get_i(core->config, "scr.color.ops"); // XXX confusing name // asm.color.inst (mnemonic + operands) ?
-	ds->show_utf8 = rz_config_get_i(core->config, "scr.utf8");
-	ds->acase = rz_config_get_i(core->config, "asm.ucase");
-	ds->capitalize = rz_config_get_i(core->config, "asm.capitalize");
+	ds->show_color_bytes = rz_config_get_b(core->config, "scr.color.bytes"); // maybe rename to asm.color.bytes
+	ds->show_color_args = rz_config_get_b(core->config, "scr.color.args");
+	ds->colorop = rz_config_get_b(core->config, "scr.color.ops"); // XXX confusing name // asm.color.inst (mnemonic + operands) ?
+	ds->show_utf8 = rz_config_get_b(core->config, "scr.utf8");
+	ds->acase = rz_config_get_b(core->config, "asm.ucase");
+	ds->capitalize = rz_config_get_b(core->config, "asm.capitalize");
 	ds->atabs = rz_config_get_i(core->config, "asm.tabs");
-	ds->atabsonce = rz_config_get_i(core->config, "asm.tabs.once");
+	ds->atabsonce = rz_config_get_b(core->config, "asm.tabs.once");
 	ds->atabsoff = rz_config_get_i(core->config, "asm.tabs.off");
 	ds->midflags = rz_config_get_i(core->config, "asm.flags.middle");
-	ds->midbb = rz_config_get_i(core->config, "asm.bb.middle");
-	ds->midcursor = rz_config_get_i(core->config, "asm.midcursor");
-	ds->decode = rz_config_get_i(core->config, "asm.decode");
-	core->parser->pseudo = ds->pseudo = rz_config_get_i(core->config, "asm.pseudo");
+	ds->midbb = rz_config_get_b(core->config, "asm.bb.middle");
+	ds->midcursor = rz_config_get_b(core->config, "asm.midcursor");
+	ds->decode = rz_config_get_b(core->config, "asm.decode");
+	core->parser->pseudo = ds->pseudo = rz_config_get_b(core->config, "asm.pseudo");
 	if (ds->pseudo) {
 		ds->atabs = 0;
 	}
-	ds->subnames = rz_config_get_i(core->config, "asm.sub.names");
+	ds->subnames = rz_config_get_b(core->config, "asm.sub.names");
 	ds->interactive = rz_cons_is_interactive();
-	ds->subjmp = rz_config_get_i(core->config, "asm.sub.jmp");
-	ds->subvar = rz_config_get_i(core->config, "asm.sub.var");
-	core->parser->subrel = rz_config_get_i(core->config, "asm.sub.rel");
-	core->parser->subreg = rz_config_get_i(core->config, "asm.sub.reg");
-	core->parser->localvar_only = rz_config_get_i(core->config, "asm.sub.varonly");
+	ds->subjmp = rz_config_get_b(core->config, "asm.sub.jmp");
+	ds->subvar = rz_config_get_b(core->config, "asm.sub.var");
+	core->parser->subrel = rz_config_get_b(core->config, "asm.sub.rel");
+	core->parser->subreg = rz_config_get_b(core->config, "asm.sub.reg");
+	core->parser->localvar_only = rz_config_get_b(core->config, "asm.sub.varonly");
 	core->parser->retleave_asm = NULL;
-	ds->show_fcnsig = rz_config_get_i(core->config, "asm.fcnsig");
-	ds->show_vars = rz_config_get_i(core->config, "asm.var");
+	ds->show_fcnsig = rz_config_get_b(core->config, "asm.fcnsig");
+	ds->show_vars = rz_config_get_b(core->config, "asm.var");
 	ds->show_varsum = rz_config_get_i(core->config, "asm.var.summary");
-	ds->show_varaccess = rz_config_get_i(core->config, "asm.var.access");
+	ds->show_varaccess = rz_config_get_b(core->config, "asm.var.access");
 	ds->maxrefs = rz_config_get_i(core->config, "asm.xrefs.max");
 	ds->maxflags = rz_config_get_i(core->config, "asm.flags.limit");
 	ds->flags_inline = rz_config_get_i(core->config, "asm.flags.inline");
 	ds->asm_types = rz_config_get_i(core->config, "asm.types");
 	ds->foldxrefs = rz_config_get_i(core->config, "asm.xrefs.fold");
-	ds->show_lines = rz_config_get_i(core->config, "asm.lines");
-	ds->show_lines_bb = ds->show_lines ? rz_config_get_i(core->config, "asm.lines.bb") : false;
-	ds->linesright = rz_config_get_i(core->config, "asm.lines.right");
-	ds->show_indent = rz_config_get_i(core->config, "asm.indent");
+	ds->show_lines = rz_config_get_b(core->config, "asm.lines");
+	ds->show_lines_bb = ds->show_lines ? rz_config_get_b(core->config, "asm.lines.bb") : false;
+	ds->linesright = rz_config_get_b(core->config, "asm.lines.right");
+	ds->show_indent = rz_config_get_b(core->config, "asm.indent");
 	ds->indent_space = rz_config_get_i(core->config, "asm.indentspace");
 	ds->tracespace = rz_config_get_i(core->config, "asm.tracespace");
 	ds->cyclespace = rz_config_get_i(core->config, "asm.cyclespace");
-	ds->show_dwarf = rz_config_get_i(core->config, "asm.dwarf");
-	ds->dwarfFile = rz_config_get_i(ds->core->config, "asm.dwarf.file");
-	ds->dwarfAbspath = rz_config_get_i(ds->core->config, "asm.dwarf.abspath");
-	ds->show_lines_call = ds->show_lines ? rz_config_get_i(core->config, "asm.lines.call") : false;
-	ds->show_lines_ret = ds->show_lines ? rz_config_get_i(core->config, "asm.lines.ret") : false;
-	ds->show_size = rz_config_get_i(core->config, "asm.size");
-	ds->show_trace = rz_config_get_i(core->config, "asm.trace");
+	ds->show_dwarf = rz_config_get_b(core->config, "asm.dwarf");
+	ds->dwarfFile = rz_config_get_b(ds->core->config, "asm.dwarf.file");
+	ds->dwarfAbspath = rz_config_get_b(ds->core->config, "asm.dwarf.abspath");
+	ds->show_lines_call = ds->show_lines ? rz_config_get_b(core->config, "asm.lines.call") : false;
+	ds->show_lines_ret = ds->show_lines ? rz_config_get_b(core->config, "asm.lines.ret") : false;
+	ds->show_size = rz_config_get_b(core->config, "asm.size");
+	ds->show_trace = rz_config_get_b(core->config, "asm.trace");
 	ds->linesout = rz_config_get_i(core->config, "asm.lines.out");
 	ds->adistrick = rz_config_get_i(core->config, "asm.middle"); // TODO: find better name
-	ds->asm_demangle = rz_config_get_i(core->config, "asm.demangle");
-	ds->asm_describe = rz_config_get_i(core->config, "asm.describe");
-	ds->show_offset = rz_config_get_i(core->config, "asm.offset");
-	ds->show_offdec = rz_config_get_i(core->config, "asm.decoff");
-	ds->show_bbline = rz_config_get_i(core->config, "asm.bb.line");
-	ds->show_section = rz_config_get_i(core->config, "asm.section");
+	ds->asm_demangle = rz_config_get_b(core->config, "asm.demangle");
+	ds->asm_describe = rz_config_get_b(core->config, "asm.describe");
+	ds->show_offset = rz_config_get_b(core->config, "asm.offset");
+	ds->show_offdec = rz_config_get_b(core->config, "asm.decoff");
+	ds->show_bbline = rz_config_get_b(core->config, "asm.bb.line");
+	ds->show_section = rz_config_get_b(core->config, "asm.section");
 	ds->show_section_col = rz_config_get_i(core->config, "asm.section.col");
-	ds->show_section_perm = rz_config_get_i(core->config, "asm.section.perm");
-	ds->show_section_name = rz_config_get_i(core->config, "asm.section.name");
-	ds->show_symbols = rz_config_get_i(core->config, "asm.symbol");
+	ds->show_section_perm = rz_config_get_b(core->config, "asm.section.perm");
+	ds->show_section_name = rz_config_get_b(core->config, "asm.section.name");
+	ds->show_symbols = rz_config_get_b(core->config, "asm.symbol");
 	ds->show_symbols_col = rz_config_get_i(core->config, "asm.symbol.col");
-	ds->asm_instr = rz_config_get_i(core->config, "asm.instr");
-	ds->show_emu = rz_config_get_i(core->config, "asm.emu");
-	ds->show_emu_str = rz_config_get_i(core->config, "emu.str");
-	ds->show_emu_stroff = rz_config_get_i(core->config, "emu.str.off");
-	ds->show_emu_strinv = rz_config_get_i(core->config, "emu.str.inv");
-	ds->show_emu_strflag = rz_config_get_i(core->config, "emu.str.flag");
-	ds->show_emu_strlea = rz_config_get_i(core->config, "emu.str.lea");
-	ds->show_emu_write = rz_config_get_i(core->config, "emu.write");
-	ds->show_emu_ssa = rz_config_get_i(core->config, "emu.ssa");
-	ds->show_emu_stack = rz_config_get_i(core->config, "emu.stack");
+	ds->asm_instr = rz_config_get_b(core->config, "asm.instr");
+	ds->show_emu = rz_config_get_b(core->config, "asm.emu");
+	ds->show_emu_str = rz_config_get_b(core->config, "emu.str");
+	ds->show_emu_stroff = rz_config_get_b(core->config, "emu.str.off");
+	ds->show_emu_strinv = rz_config_get_b(core->config, "emu.str.inv");
+	ds->show_emu_strflag = rz_config_get_b(core->config, "emu.str.flag");
+	ds->show_emu_strlea = rz_config_get_b(core->config, "emu.str.lea");
+	ds->show_emu_write = rz_config_get_b(core->config, "emu.write");
+	ds->show_emu_ssa = rz_config_get_b(core->config, "emu.ssa");
+	ds->show_emu_stack = rz_config_get_b(core->config, "emu.stack");
 	ds->stackFd = -1;
 	if (ds->show_emu_stack) {
 		// TODO: initialize fake stack in here
@@ -739,42 +739,42 @@ static RDisasmState *ds_init(RzCore *core) {
 		}
 	}
 	ds->stackptr = core->analysis->stackptr;
-	ds->show_offseg = rz_config_get_i(core->config, "asm.segoff");
-	ds->show_flags = rz_config_get_i(core->config, "asm.flags");
-	ds->show_bytes = rz_config_get_i(core->config, "asm.bytes");
-	ds->show_bytes_right = rz_config_get_i(core->config, "asm.bytes.right");
-	ds->show_optype = rz_config_get_i(core->config, "asm.optype");
+	ds->show_offseg = rz_config_get_b(core->config, "asm.segoff");
+	ds->show_flags = rz_config_get_b(core->config, "asm.flags");
+	ds->show_bytes = rz_config_get_b(core->config, "asm.bytes");
+	ds->show_bytes_right = rz_config_get_b(core->config, "asm.bytes.right");
+	ds->show_optype = rz_config_get_b(core->config, "asm.optype");
 	ds->asm_meta = rz_config_get_i(core->config, "asm.meta");
 	ds->asm_xrefs_code = rz_config_get_i(core->config, "asm.xrefs.code");
-	ds->show_reloff = rz_config_get_i(core->config, "asm.reloff");
-	ds->show_reloff_flags = rz_config_get_i(core->config, "asm.reloff.flags");
-	ds->show_lines_fcn = ds->show_lines ? rz_config_get_i(core->config, "asm.lines.fcn") : false;
-	ds->show_comments = rz_config_get_i(core->config, "asm.comments");
-	ds->show_usercomments = rz_config_get_i(core->config, "asm.usercomments");
-	ds->asm_hint_jmp = rz_config_get_i(core->config, "asm.hint.jmp");
-	ds->asm_hint_call = rz_config_get_i(core->config, "asm.hint.call");
-	ds->asm_hint_call_indirect = rz_config_get_i(core->config, "asm.hint.call.indirect");
-	ds->asm_hint_lea = rz_config_get_i(core->config, "asm.hint.lea");
-	ds->asm_hint_emu = rz_config_get_i(core->config, "asm.hint.emu");
-	ds->asm_hint_cdiv = rz_config_get_i(core->config, "asm.hint.cdiv");
+	ds->show_reloff = rz_config_get_b(core->config, "asm.reloff");
+	ds->show_reloff_flags = rz_config_get_b(core->config, "asm.reloff.flags");
+	ds->show_lines_fcn = ds->show_lines ? rz_config_get_b(core->config, "asm.lines.fcn") : false;
+	ds->show_comments = rz_config_get_b(core->config, "asm.comments");
+	ds->show_usercomments = rz_config_get_b(core->config, "asm.usercomments");
+	ds->asm_hint_jmp = rz_config_get_b(core->config, "asm.hint.jmp");
+	ds->asm_hint_call = rz_config_get_b(core->config, "asm.hint.call");
+	ds->asm_hint_call_indirect = rz_config_get_b(core->config, "asm.hint.call.indirect");
+	ds->asm_hint_lea = rz_config_get_b(core->config, "asm.hint.lea");
+	ds->asm_hint_emu = rz_config_get_b(core->config, "asm.hint.emu");
+	ds->asm_hint_cdiv = rz_config_get_b(core->config, "asm.hint.cdiv");
 	ds->asm_hint_pos = rz_config_get_i(core->config, "asm.hint.pos");
-	ds->asm_hints = rz_config_get_i(core->config, "asm.hints");
-	ds->show_slow = rz_config_get_i(core->config, "asm.slow");
-	ds->show_refptr = rz_config_get_i(core->config, "asm.refptr");
-	ds->show_calls = rz_config_get_i(core->config, "asm.calls");
-	ds->show_family = rz_config_get_i(core->config, "asm.family");
+	ds->asm_hints = rz_config_get_b(core->config, "asm.hints");
+	ds->show_slow = rz_config_get_b(core->config, "asm.slow");
+	ds->show_refptr = rz_config_get_b(core->config, "asm.refptr");
+	ds->show_calls = rz_config_get_b(core->config, "asm.calls");
+	ds->show_family = rz_config_get_b(core->config, "asm.family");
 	ds->cmtcol = rz_config_get_i(core->config, "asm.cmt.col");
-	ds->show_cmtesil = rz_config_get_i(core->config, "asm.cmt.esil");
-	ds->show_cmtflgrefs = rz_config_get_i(core->config, "asm.cmt.flgrefs");
-	ds->show_cycles = rz_config_get_i(core->config, "asm.cycles");
-	ds->show_stackptr = rz_config_get_i(core->config, "asm.stackptr");
-	ds->show_xrefs = rz_config_get_i(core->config, "asm.xrefs");
-	ds->show_cmtrefs = rz_config_get_i(core->config, "asm.cmt.refs");
+	ds->show_cmtesil = rz_config_get_b(core->config, "asm.cmt.esil");
+	ds->show_cmtflgrefs = rz_config_get_b(core->config, "asm.cmt.flgrefs");
+	ds->show_cycles = rz_config_get_b(core->config, "asm.cycles");
+	ds->show_stackptr = rz_config_get_b(core->config, "asm.stackptr");
+	ds->show_xrefs = rz_config_get_b(core->config, "asm.xrefs");
+	ds->show_cmtrefs = rz_config_get_b(core->config, "asm.cmt.refs");
 	ds->show_cmtoff = rz_config_get(core->config, "asm.cmt.off");
 	if (!ds->show_cmtoff) {
 		ds->show_cmtoff = "nodup";
 	}
-	ds->show_functions = rz_config_get_i(core->config, "asm.functions");
+	ds->show_functions = rz_config_get_b(core->config, "asm.functions");
 	ds->nbytes = rz_config_get_i(core->config, "asm.nbytes");
 	ds->show_asciidot = !strcmp(core->print->strconv_mode, "asciidot");
 	const char *strenc_str = rz_config_get(core->config, "bin.str.enc");
@@ -800,11 +800,11 @@ static RDisasmState *ds_init(RzCore *core) {
 	ds->nb = 0;
 	ds->flagspace_ports = rz_flag_space_get(core->flags, "ports");
 	ds->lbytes = rz_config_get_i(core->config, "asm.lbytes");
-	ds->show_comment_right_default = rz_config_get_i(core->config, "asm.cmt.right");
+	ds->show_comment_right_default = rz_config_get_b(core->config, "asm.cmt.right");
 	ds->show_comment_right = ds->show_comment_right_default;
-	ds->show_flag_in_bytes = rz_config_get_i(core->config, "asm.flags.inbytes");
-	ds->show_marks = rz_config_get_i(core->config, "asm.marks");
-	ds->show_noisy_comments = rz_config_get_i(core->config, "asm.noisy");
+	ds->show_flag_in_bytes = rz_config_get_b(core->config, "asm.flags.inbytes");
+	ds->show_marks = rz_config_get_b(core->config, "asm.marks");
+	ds->show_noisy_comments = rz_config_get_b(core->config, "asm.noisy");
 	ds->pre = DS_PRE_NONE;
 	ds->ocomment = NULL;
 	ds->linesopts = 0;
@@ -818,8 +818,8 @@ static RDisasmState *ds_init(RzCore *core) {
 	ds->esil_regstate = NULL;
 	ds->esil_likely = false;
 
-	ds->showpayloads = rz_config_get_i(ds->core->config, "asm.payloads");
-	ds->showrelocs = rz_config_get_i(core->config, "bin.relocs");
+	ds->showpayloads = rz_config_get_b(ds->core->config, "asm.payloads");
+	ds->showrelocs = rz_config_get_b(core->config, "bin.relocs");
 	ds->min_ref_addr = rz_config_get_i(core->config, "asm.sub.varmin");
 
 	if (ds->show_flag_in_bytes) {
@@ -860,7 +860,7 @@ static RDisasmState *ds_init(RzCore *core) {
 	} else {
 		ds->cursor = -1;
 	}
-	if (rz_config_get_i(core->config, "asm.lines.wide")) {
+	if (rz_config_get_b(core->config, "asm.lines.wide")) {
 		ds->linesopts |= RZ_ANALYSIS_REFLINE_TYPE_WIDE;
 	}
 	if (core->cons->vline) {
@@ -1040,8 +1040,8 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 		ds->opstr = strdup(rz_asm_op_get_asm(&ds->asmop));
 	}
 	/* initialize */
-	core->parser->subrel = rz_config_get_i(core->config, "asm.sub.rel");
-	core->parser->subreg = rz_config_get_i(core->config, "asm.sub.reg");
+	core->parser->subrel = rz_config_get_b(core->config, "asm.sub.rel");
+	core->parser->subreg = rz_config_get_b(core->config, "asm.sub.reg");
 	core->parser->subrel_addr = 0;
 	if (core->parser->subrel && (ds->analop.type == RZ_ANALYSIS_OP_TYPE_LEA || ds->analop.type == RZ_ANALYSIS_OP_TYPE_MOV || ds->analop.type == RZ_ANALYSIS_OP_TYPE_CMP) && ds->analop.ptr != UT64_MAX) {
 		core->parser->subrel_addr = ds->analop.ptr;
@@ -1236,7 +1236,7 @@ static void ds_begin_line(RDisasmState *ds) {
 
 static void ds_newline(RDisasmState *ds) {
 	if (ds->pj) {
-		const bool is_html = rz_config_get_i(ds->core->config, "scr.html");
+		const bool is_html = rz_config_get_b(ds->core->config, "scr.html");
 		if (is_html) {
 			char *s = rz_cons_html_filter(rz_cons_get_buffer(), NULL);
 			pj_s(ds->pj, s);
@@ -1800,10 +1800,10 @@ static void ds_show_functions(RDisasmState *ds) {
 	if (!ds->show_functions) {
 		return;
 	}
-	bool demangle = rz_config_get_i(core->config, "bin.demangle");
-	bool keep_lib = rz_config_get_i(core->config, "bin.demangle.libs");
+	bool demangle = rz_config_get_b(core->config, "bin.demangle");
+	bool keep_lib = rz_config_get_b(core->config, "bin.demangle.libs");
 	bool showSig = ds->show_fcnsig && ds->show_calls;
-	bool call = rz_config_get_i(core->config, "asm.calls");
+	bool call = rz_config_get_b(core->config, "asm.calls");
 	const char *lang = demangle ? rz_config_get(core->config, "bin.lang") : NULL;
 	f = rz_analysis_get_function_at(core->analysis, ds->at);
 	if (!f) {
@@ -2238,7 +2238,7 @@ static void ds_show_flags(RDisasmState *ds) {
 	int count = 0;
 	bool outline = !ds->flags_inline;
 	const char *comma = "";
-	bool keep_lib = rz_config_get_i(core->config, "bin.demangle.libs");
+	bool keep_lib = rz_config_get_b(core->config, "bin.demangle.libs");
 	bool docolon = true;
 	int nth = 0;
 	rz_list_foreach (uniqlist, iter, flag) {
@@ -2872,7 +2872,7 @@ static bool ds_print_data_type(RDisasmState *ds, const ut8 *buf, int ib, int siz
 	}
 	// adjust alignment
 	ut64 n = rz_read_ble(buf, core->print->big_endian, size * 8);
-	if (rz_config_get_i(core->config, "asm.marks")) {
+	if (rz_config_get_b(core->config, "asm.marks")) {
 		rz_cons_printf("  ");
 		int q = core->print->cur_enabled &&
 			ds->cursor >= ds->index &&
@@ -4154,8 +4154,8 @@ static void ds_print_relocs(RDisasmState *ds) {
 	}
 	RzCore *core = ds->core;
 	const char *lang = rz_config_get(core->config, "bin.lang");
-	bool demangle = rz_config_get_i(core->config, "asm.demangle");
-	bool keep_lib = rz_config_get_i(core->config, "bin.demangle.libs");
+	bool demangle = rz_config_get_b(core->config, "asm.demangle");
+	bool keep_lib = rz_config_get_b(core->config, "bin.demangle.libs");
 	RzBinReloc *rel = rz_core_getreloc(core, ds->at, ds->analop.size);
 	if (rel) {
 		int cstrlen = 0;
@@ -4559,7 +4559,7 @@ static void mipsTweak(RDisasmState *ds) {
 	RzCore *core = ds->core;
 	const char *asm_arch = rz_config_get(core->config, "asm.arch");
 	if (asm_arch && *asm_arch && strstr(asm_arch, "mips")) {
-		if (rz_config_get_i(core->config, "analysis.gpfixed")) {
+		if (rz_config_get_b(core->config, "analysis.gpfixed")) {
 			ut64 gp = rz_config_get_i(core->config, "analysis.gp");
 			rz_reg_setv(core->analysis->reg, "gp", gp);
 		}
@@ -4773,8 +4773,8 @@ beach:
 }
 
 static void ds_print_calls_hints(RDisasmState *ds) {
-	int emu = rz_config_get_i(ds->core->config, "asm.emu");
-	int emuwrite = rz_config_get_i(ds->core->config, "emu.write");
+	bool emu = rz_config_get_b(ds->core->config, "asm.emu");
+	bool emuwrite = rz_config_get_b(ds->core->config, "emu.write");
 	if (emu && emuwrite) {
 		// this is done by ESIL
 		return;
@@ -5150,7 +5150,7 @@ RZ_API int rz_core_print_disasm(RzPrint *p, RzCore *core, ut64 addr, ut8 *buf, i
 toro:
 	// uhm... is this necessary? imho can be removed
 	rz_asm_set_pc(core->rasm, rz_core_pava(core, ds->addr + idx));
-	core->cons->vline = rz_config_get_i(core->config, "scr.utf8") ? (rz_config_get_i(core->config, "scr.utf8.curvy") ? rz_vline_uc : rz_vline_u) : rz_vline_a;
+	core->cons->vline = rz_config_get_b(core->config, "scr.utf8") ? (rz_config_get_b(core->config, "scr.utf8.curvy") ? rz_vline_uc : rz_vline_u) : rz_vline_a;
 
 	if (core->print->cur_enabled) {
 		// TODO: support in-the-middle-of-instruction too
@@ -6241,16 +6241,16 @@ RZ_API int rz_core_print_disasm_all(RzCore *core, ut64 addr, int l, int len, int
 }
 
 RZ_API int rz_core_disasm_pdi_with_buf(RzCore *core, ut64 address, ut8 *buf, ut32 nb_opcodes, ut32 nb_bytes, int fmt) {
-	bool show_offset = rz_config_get_i(core->config, "asm.offset");
-	bool show_bytes = rz_config_get_i(core->config, "asm.bytes");
-	int decode = rz_config_get_i(core->config, "asm.decode");
-	int subnames = rz_config_get_i(core->config, "asm.sub.names");
+	bool show_offset = rz_config_get_b(core->config, "asm.offset");
+	bool show_bytes = rz_config_get_b(core->config, "asm.bytes");
+	bool decode = rz_config_get_b(core->config, "asm.decode");
+	bool subnames = rz_config_get_b(core->config, "asm.sub.names");
 	int show_color = rz_config_get_i(core->config, "scr.color");
-	bool asm_ucase = rz_config_get_i(core->config, "asm.ucase");
-	bool asm_instr = rz_config_get_i(core->config, "asm.instr");
-	int esil = rz_config_get_i(core->config, "asm.esil");
-	int flags = rz_config_get_i(core->config, "asm.flags");
-	bool asm_immtrim = rz_config_get_i(core->config, "asm.imm.trim");
+	bool asm_ucase = rz_config_get_b(core->config, "asm.ucase");
+	bool asm_instr = rz_config_get_b(core->config, "asm.instr");
+	bool esil = rz_config_get_b(core->config, "asm.esil");
+	bool flags = rz_config_get_b(core->config, "asm.flags");
+	bool asm_immtrim = rz_config_get_b(core->config, "asm.imm.trim");
 	int i = 0, j, ret, err = 0;
 	ut64 old_offset = core->offset;
 	RzAsmOp asmop;
@@ -6275,8 +6275,8 @@ RZ_API int rz_core_disasm_pdi_with_buf(RzCore *core, ut64 address, ut8 *buf, ut3
 	rz_cons_break_push(NULL, NULL);
 	rz_core_seek(core, address, false);
 	int midflags = rz_config_get_i(core->config, "asm.flags.middle");
-	int midbb = rz_config_get_i(core->config, "asm.bb.middle");
-	bool asmmarks = rz_config_get_i(core->config, "asm.marks");
+	bool midbb = rz_config_get_b(core->config, "asm.bb.middle");
+	bool asmmarks = rz_config_get_b(core->config, "asm.marks");
 	rz_config_set_i(core->config, "asm.marks", false);
 	i = 0;
 	j = 0;
@@ -6524,7 +6524,7 @@ RZ_API int rz_core_disasm_pde(RzCore *core, int nb_opcodes, int mode) {
 	}
 	if (!core->analysis->esil) {
 		rz_core_cmd0(core, "aei");
-		if (!rz_config_get_i(core->config, "cfg.debug")) {
+		if (!rz_config_get_b(core->config, "cfg.debug")) {
 			rz_core_cmd0(core, "aeim");
 		}
 	}

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -2584,7 +2584,7 @@ static void ds_control_flow_comments(RDisasmState *ds) {
 		if (ds->asm_analysis) {
 			switch (ds->analop.type) {
 			case RZ_ANALYSIS_OP_TYPE_CALL:
-				rz_core_cmdf(ds->core, "af @ 0x%" PFMT64x, ds->analop.jump);
+				rz_core_analysis_function_add(ds->core, NULL, ds->analop.jump, false);
 				break;
 			}
 		}

--- a/librz/core/panels.c
+++ b/librz/core/panels.c
@@ -3398,7 +3398,7 @@ int __step_over_cb(void *user) {
 
 int __io_cache_on_cb(void *user) {
 	RzCore *core = (RzCore *)user;
-	rz_config_set_i(core->config, "io.cache", 1);
+	rz_config_set_b(core->config, "io.cache", true);
 	(void)__show_status(core, "io.cache is on");
 	__set_mode(core, PANEL_MODE_DEFAULT);
 	return 0;
@@ -3406,7 +3406,7 @@ int __io_cache_on_cb(void *user) {
 
 int __io_cache_off_cb(void *user) {
 	RzCore *core = (RzCore *)user;
-	rz_config_set_i(core->config, "io.cache", 0);
+	rz_config_set_b(core->config, "io.cache", false);
 	(void)__show_status(core, "io.cache is off");
 	__set_mode(core, PANEL_MODE_DEFAULT);
 	return 0;
@@ -4669,7 +4669,7 @@ void __panels_refresh(RzCore *core) {
 	RzStrBuf *title = rz_strbuf_new(" ");
 	bool utf8 = rz_config_get_i(core->config, "scr.utf8");
 	if (firstRun) {
-		rz_config_set_i(core->config, "scr.utf8", 0);
+		rz_config_set_b(core->config, "scr.utf8", false);
 	}
 
 	__refresh_core_offset(core);
@@ -4753,7 +4753,7 @@ void __panels_refresh(RzCore *core) {
 
 	if (firstRun) {
 		firstRun = false;
-		rz_config_set_i(core->config, "scr.utf8", utf8);
+		rz_config_set_b(core->config, "scr.utf8", utf8);
 		RzPanel *cur = __get_cur_panel(core->panels);
 		cur->view->refresh = true;
 		__panels_refresh(core);
@@ -4809,7 +4809,7 @@ void __panel_single_step_in(RzCore *core) {
 
 void __panel_single_step_over(RzCore *core) {
 	bool io_cache = rz_config_get_i(core->config, "io.cache");
-	rz_config_set_i(core->config, "io.cache", false);
+	rz_config_set_b(core->config, "io.cache", false);
 	if (rz_config_get_i(core->config, "cfg.debug")) {
 		rz_core_cmd(core, "dso", 0);
 		rz_core_debug_regs2flags(core, 0);
@@ -4817,7 +4817,7 @@ void __panel_single_step_over(RzCore *core) {
 		rz_core_cmd(core, "aeso", 0);
 		rz_core_regs2flags(core);
 	}
-	rz_config_set_i(core->config, "io.cache", io_cache);
+	rz_config_set_b(core->config, "io.cache", io_cache);
 }
 
 void __panel_breakpoint(RzCore *core) {
@@ -5501,7 +5501,7 @@ void __set_breakpoints_on_cursor(RzCore *core, RzPanel *panel) {
 void __insert_value(RzCore *core) {
 	if (!rz_config_get_i(core->config, "io.cache")) {
 		if (__show_status_yesno(core, 1, "Insert is not available because io.cache is off. Turn on now?(Y/n)")) {
-			rz_config_set_i(core->config, "io.cache", 1);
+			rz_config_set_b(core->config, "io.cache", true);
 			(void)__show_status(core, "io.cache is on and insert is available now.");
 		} else {
 			(void)__show_status(core, "You can always turn on io.cache in Menu->Edit->io.cache");
@@ -6462,26 +6462,26 @@ repeat:
 	case 'r':
 		// TODO: toggle shortcut hotkeys
 		if (rz_config_get_i(core->config, "asm.hint.call")) {
-			rz_core_cmd0(core, "e!asm.hint.call");
-			rz_core_cmd0(core, "e asm.hint.jmp=true");
+			rz_config_toggle(core->config, "asm.hint.call");
+			rz_config_set_b(core->config, "asm.hint.jmp", true);
 		} else if (rz_config_get_i(core->config, "asm.hint.jmp")) {
-			rz_core_cmd0(core, "e!asm.hint.jmp");
-			rz_core_cmd0(core, "e asm.hint.emu=true");
+			rz_config_toggle(core->config, "asm.hint.jmp");
+			rz_config_set_b(core->config, "asm.hint.emu", true);
 		} else if (rz_config_get_i(core->config, "asm.hint.emu")) {
-			rz_core_cmd0(core, "e!asm.hint.emu");
-			rz_core_cmd0(core, "e asm.hint.lea=true");
+			rz_config_toggle(core->config, "asm.hint.emu");
+			rz_config_set_b(core->config, "asm.hint.lea", true);
 		} else if (rz_config_get_i(core->config, "asm.hint.lea")) {
-			rz_core_cmd0(core, "e!asm.hint.lea");
-			rz_core_cmd0(core, "e asm.hint.call=true");
+			rz_config_toggle(core->config, "asm.hint.lea");
+			rz_config_set_b(core->config, "asm.hint.call", true);
 		} else {
-			rz_core_cmd0(core, "e asm.hint.call=true");
+			rz_config_set_b(core->config, "asm.hint.call", true);
 		}
 		break;
 	case 'R':
 		if (rz_config_get_i(core->config, "scr.randpal")) {
 			rz_cons_pal_random();
 		} else {
-			rz_core_cmd0(core, "ecn");
+			rz_core_theme_nextpal(core, 'n');
 		}
 		__do_panels_refresh(core);
 		break;

--- a/librz/core/panels.c
+++ b/librz/core/panels.c
@@ -3971,7 +3971,7 @@ void __print_disassembly_cb(void *user, void *p) {
 	ut64 o_offset = core->offset;
 	core->offset = panel->model->addr;
 	rz_core_seek(core, panel->model->addr, true);
-	if (rz_config_get_i(core->config, "cfg.debug")) {
+	if (rz_config_get_b(core->config, "cfg.debug")) {
 		rz_core_debug_regs2flags(core, 0);
 	}
 	cmdstr = __handle_cmd_str_cache(core, panel, false);
@@ -4667,7 +4667,7 @@ void __panels_refresh(RzCore *core) {
 		return;
 	}
 	RzStrBuf *title = rz_strbuf_new(" ");
-	bool utf8 = rz_config_get_i(core->config, "scr.utf8");
+	bool utf8 = rz_config_get_b(core->config, "scr.utf8");
 	if (firstRun) {
 		rz_config_set_b(core->config, "scr.utf8", false);
 	}
@@ -4798,7 +4798,7 @@ void __do_panels_refreshOneShot(RzCore *core) {
 }
 
 void __panel_single_step_in(RzCore *core) {
-	if (rz_config_get_i(core->config, "cfg.debug")) {
+	if (rz_config_get_b(core->config, "cfg.debug")) {
 		rz_core_cmd(core, "ds", 0);
 		rz_core_debug_regs2flags(core, 0);
 	} else {
@@ -4808,9 +4808,9 @@ void __panel_single_step_in(RzCore *core) {
 }
 
 void __panel_single_step_over(RzCore *core) {
-	bool io_cache = rz_config_get_i(core->config, "io.cache");
+	bool io_cache = rz_config_get_b(core->config, "io.cache");
 	rz_config_set_b(core->config, "io.cache", false);
-	if (rz_config_get_i(core->config, "cfg.debug")) {
+	if (rz_config_get_b(core->config, "cfg.debug")) {
 		rz_core_cmd(core, "dso", 0);
 		rz_core_debug_regs2flags(core, 0);
 	} else {
@@ -4920,7 +4920,7 @@ void __init_almighty_db(RzCore *core) {
 	sdb_ptr_set(db, "Search strings in the whole bin", &__search_strings_bin_create, 0);
 	sdb_ptr_set(db, "Create New", &__create_panel_input, 0);
 	sdb_ptr_set(db, "Change Command of Current Panel", &__replace_current_panel_input, 0);
-	if (rz_config_get_i(core->config, "cfg.debug")) {
+	if (rz_config_get_b(core->config, "cfg.debug")) {
 		sdb_ptr_set(db, "Put Breakpoints", &__put_breakpoints_cb, 0);
 		sdb_ptr_set(db, "Continue", &__continue_almighty_cb, 0);
 		sdb_ptr_set(db, "Step", &__step_almighty_cb, 0);
@@ -5023,7 +5023,7 @@ bool __init(RzCore *core, RzPanels *panels, int w, int h) {
 	panels->panel = NULL;
 	panels->n_panels = 0;
 	panels->columnWidth = 80;
-	if (rz_config_get_i(core->config, "cfg.debug")) {
+	if (rz_config_get_b(core->config, "cfg.debug")) {
 		panels->layout = PANEL_LAYOUT_DEFAULT_DYNAMIC;
 	} else {
 		panels->layout = PANEL_LAYOUT_DEFAULT_STATIC;
@@ -5489,7 +5489,7 @@ void __toggle_help(RzCore *core) {
 }
 
 void __set_breakpoints_on_cursor(RzCore *core, RzPanel *panel) {
-	if (!rz_config_get_i(core->config, "cfg.debug")) {
+	if (!rz_config_get_b(core->config, "cfg.debug")) {
 		return;
 	}
 	if (__check_panel_type(panel, PANEL_CMD_DISASSEMBLY)) {
@@ -5499,7 +5499,7 @@ void __set_breakpoints_on_cursor(RzCore *core, RzPanel *panel) {
 }
 
 void __insert_value(RzCore *core) {
-	if (!rz_config_get_i(core->config, "io.cache")) {
+	if (!rz_config_get_b(core->config, "io.cache")) {
 		if (__show_status_yesno(core, 1, "Insert is not available because io.cache is off. Turn on now?(Y/n)")) {
 			rz_config_set_b(core->config, "io.cache", true);
 			(void)__show_status(core, "io.cache is on and insert is available now.");
@@ -5948,8 +5948,8 @@ void __redo_seek(RzCore *core) {
 }
 
 void __rotate_asmemu(RzCore *core, RzPanel *p) {
-	const bool isEmuStr = rz_config_get_i(core->config, "emu.str");
-	const bool isEmu = rz_config_get_i(core->config, "asm.emu");
+	const bool isEmuStr = rz_config_get_b(core->config, "emu.str");
+	const bool isEmu = rz_config_get_b(core->config, "asm.emu");
 	if (isEmu) {
 		if (isEmuStr) {
 			rz_config_set(core->config, "emu.str", "false");
@@ -6120,10 +6120,10 @@ void __handle_tab_next(RzCore *core) {
 }
 
 void __handle_print_rotate(RzCore *core) {
-	if (rz_config_get_i(core->config, "asm.pseudo")) {
+	if (rz_config_get_b(core->config, "asm.pseudo")) {
 		rz_config_toggle(core->config, "asm.pseudo");
 		rz_config_toggle(core->config, "asm.esil");
-	} else if (rz_config_get_i(core->config, "asm.esil")) {
+	} else if (rz_config_get_b(core->config, "asm.esil")) {
 		rz_config_toggle(core->config, "asm.esil");
 	} else {
 		rz_config_toggle(core->config, "asm.pseudo");
@@ -6324,7 +6324,7 @@ void __panels_process(RzCore *core, RzPanels *panels) {
 
 	rz_cons_enable_mouse(false);
 repeat:
-	rz_cons_enable_mouse(rz_config_get_i(core->config, "scr.wheel"));
+	rz_cons_enable_mouse(rz_config_get_b(core->config, "scr.wheel"));
 	core->panels = panels;
 	core->cons->event_resize = NULL; // avoid running old event with new data
 	core->cons->event_data = core;
@@ -6437,7 +6437,7 @@ repeat:
 		}
 		break;
 	case ' ':
-		if (rz_config_get_i(core->config, "graph.web")) {
+		if (rz_config_get_b(core->config, "graph.web")) {
 			rz_core_cmd0(core, "agv $$");
 		} else {
 			__call_visual_graph(core);
@@ -6461,16 +6461,16 @@ repeat:
 	} break;
 	case 'r':
 		// TODO: toggle shortcut hotkeys
-		if (rz_config_get_i(core->config, "asm.hint.call")) {
+		if (rz_config_get_b(core->config, "asm.hint.call")) {
 			rz_config_toggle(core->config, "asm.hint.call");
 			rz_config_set_b(core->config, "asm.hint.jmp", true);
-		} else if (rz_config_get_i(core->config, "asm.hint.jmp")) {
+		} else if (rz_config_get_b(core->config, "asm.hint.jmp")) {
 			rz_config_toggle(core->config, "asm.hint.jmp");
 			rz_config_set_b(core->config, "asm.hint.emu", true);
-		} else if (rz_config_get_i(core->config, "asm.hint.emu")) {
+		} else if (rz_config_get_b(core->config, "asm.hint.emu")) {
 			rz_config_toggle(core->config, "asm.hint.emu");
 			rz_config_set_b(core->config, "asm.hint.lea", true);
-		} else if (rz_config_get_i(core->config, "asm.hint.lea")) {
+		} else if (rz_config_get_b(core->config, "asm.hint.lea")) {
 			rz_config_toggle(core->config, "asm.hint.lea");
 			rz_config_set_b(core->config, "asm.hint.call", true);
 		} else {
@@ -6478,7 +6478,7 @@ repeat:
 		}
 		break;
 	case 'R':
-		if (rz_config_get_i(core->config, "scr.randpal")) {
+		if (rz_config_get_b(core->config, "scr.randpal")) {
 			rz_cons_pal_random();
 		} else {
 			rz_core_theme_nextpal(core, 'n');
@@ -6675,7 +6675,7 @@ repeat:
 		}
 		break;
 	case 'V':
-		if (rz_config_get_i(core->config, "graph.web")) {
+		if (rz_config_get_b(core->config, "graph.web")) {
 			rz_core_cmd0(core, "agv $$");
 		} else {
 			__call_visual_graph(core);

--- a/librz/core/panels.c
+++ b/librz/core/panels.c
@@ -6461,21 +6461,7 @@ repeat:
 	} break;
 	case 'r':
 		// TODO: toggle shortcut hotkeys
-		if (rz_config_get_b(core->config, "asm.hint.call")) {
-			rz_config_toggle(core->config, "asm.hint.call");
-			rz_config_set_b(core->config, "asm.hint.jmp", true);
-		} else if (rz_config_get_b(core->config, "asm.hint.jmp")) {
-			rz_config_toggle(core->config, "asm.hint.jmp");
-			rz_config_set_b(core->config, "asm.hint.emu", true);
-		} else if (rz_config_get_b(core->config, "asm.hint.emu")) {
-			rz_config_toggle(core->config, "asm.hint.emu");
-			rz_config_set_b(core->config, "asm.hint.lea", true);
-		} else if (rz_config_get_b(core->config, "asm.hint.lea")) {
-			rz_config_toggle(core->config, "asm.hint.lea");
-			rz_config_set_b(core->config, "asm.hint.call", true);
-		} else {
-			rz_config_set_b(core->config, "asm.hint.call", true);
-		}
+		rz_core_visual_toggle_hints(core);
 		break;
 	case 'R':
 		if (rz_config_get_b(core->config, "scr.randpal")) {

--- a/librz/core/visual.c
+++ b/librz/core/visual.c
@@ -101,6 +101,24 @@ RZ_API void rz_core_visual_applyHexMode(RzCore *core, int hexMode) {
 	}
 }
 
+RZ_API void rz_core_visual_toggle_hints(RzCore *core) {
+	if (rz_config_get_b(core->config, "asm.hint.call")) {
+		rz_config_toggle(core->config, "asm.hint.call");
+		rz_config_set_b(core->config, "asm.hint.jmp", true);
+	} else if (rz_config_get_b(core->config, "asm.hint.jmp")) {
+		rz_config_toggle(core->config, "asm.hint.jmp");
+		rz_config_set_b(core->config, "asm.hint.emu", true);
+	} else if (rz_config_get_b(core->config, "asm.hint.emu")) {
+		rz_config_toggle(core->config, "asm.hint.emu");
+		rz_config_set_b(core->config, "asm.hint.lea", true);
+	} else if (rz_config_get_b(core->config, "asm.hint.lea")) {
+		rz_config_toggle(core->config, "asm.hint.lea");
+		rz_config_set_b(core->config, "asm.hint.call", true);
+	} else {
+		rz_config_set_b(core->config, "asm.hint.call", true);
+	}
+}
+
 RZ_API void rz_core_visual_toggle_decompiler_disasm(RzCore *core, bool for_graph, bool reset) {
 	static RzConfigHold *hold = NULL; // should be a tab-specific var
 	if (hold) {
@@ -2748,21 +2766,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 			break;
 		case 'r':
 			// TODO: toggle shortcut hotkeys
-			if (rz_config_get_b(core->config, "asm.hint.call")) {
-				rz_config_toggle(core->config, "asm.hint.call");
-				rz_config_set_b(core->config, "asm.hint.jmp", true);
-			} else if (rz_config_get_b(core->config, "asm.hint.jmp")) {
-				rz_config_toggle(core->config, "asm.hint.jmp");
-				rz_config_set_b(core->config, "asm.hint.emu", true);
-			} else if (rz_config_get_b(core->config, "asm.hint.emu")) {
-				rz_config_toggle(core->config, "asm.hint.emu");
-				rz_config_set_b(core->config, "asm.hint.lea", true);
-			} else if (rz_config_get_b(core->config, "asm.hint.lea")) {
-				rz_config_toggle(core->config, "asm.hint.lea");
-				rz_config_set_b(core->config, "asm.hint.call", true);
-			} else {
-				rz_config_set_b(core->config, "asm.hint.call", true);
-			}
+			rz_core_visual_toggle_hints(core);
 			visual_refresh(core);
 			break;
 		case ' ':

--- a/librz/core/visual.c
+++ b/librz/core/visual.c
@@ -298,7 +298,7 @@ static const char *help_msg_visual[] = {
 	"=", "set cmd.vprompt (top row)",
 	"|", "set cmd.cprompt (right column)",
 	".", "seek to program counter",
-	"#", "toggle decompiler comments in disasm (see pdd* from r2dec)",
+	"#", "toggle decompiler comments in disasm (see pdd* from jsdec)",
 	"\\", "toggle visual split mode",
 	"\"", "toggle the column mode (uses pC..)",
 	"/", "in cursor mode search in current block",

--- a/librz/core/visual.c
+++ b/librz/core/visual.c
@@ -774,7 +774,7 @@ static void visual_single_step_in(RzCore *core) {
 
 static void __core_visual_step_over(RzCore *core) {
 	bool io_cache = rz_config_get_i(core->config, "io.cache");
-	rz_config_set_i(core->config, "io.cache", false);
+	rz_config_set_b(core->config, "io.cache", false);
 	if (rz_config_get_i(core->config, "cfg.debug")) {
 		if (core->print->cur_enabled) {
 			rz_core_cmd(core, "dcr", 0);
@@ -787,7 +787,7 @@ static void __core_visual_step_over(RzCore *core) {
 		rz_core_cmd(core, "aeso", 0);
 		rz_core_regs2flags(core);
 	}
-	rz_config_set_i(core->config, "io.cache", io_cache);
+	rz_config_set_b(core->config, "io.cache", io_cache);
 }
 
 static void visual_breakpoint(RzCore *core) {
@@ -1381,7 +1381,7 @@ repeat:
 	} else {
 		int h, w = rz_cons_get_size(&h);
 		bool asm_bytes = rz_config_get_i(core->config, "asm.bytes");
-		rz_config_set_i(core->config, "asm.bytes", false);
+		rz_config_set_b(core->config, "asm.bytes", false);
 		rz_core_cmd0(core, "fd");
 
 		int maxcount = 9;
@@ -1498,7 +1498,7 @@ repeat:
 			free(dis);
 			dis = NULL;
 		}
-		rz_config_set_i(core->config, "asm.bytes", asm_bytes);
+		rz_config_set_b(core->config, "asm.bytes", asm_bytes);
 	}
 	rz_cons_flush();
 	rz_cons_enable_mouse(rz_config_get_i(core->config, "scr.wheel"));
@@ -2749,19 +2749,19 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 		case 'r':
 			// TODO: toggle shortcut hotkeys
 			if (rz_config_get_i(core->config, "asm.hint.call")) {
-				rz_core_cmd0(core, "e!asm.hint.call");
-				rz_core_cmd0(core, "e asm.hint.jmp=true");
+				rz_config_toggle(core->config, "asm.hint.call");
+				rz_config_set_b(core->config, "asm.hint.jmp", true);
 			} else if (rz_config_get_i(core->config, "asm.hint.jmp")) {
-				rz_core_cmd0(core, "e!asm.hint.jmp");
-				rz_core_cmd0(core, "e asm.hint.emu=true");
+				rz_config_toggle(core->config, "asm.hint.jmp");
+				rz_config_set_b(core->config, "asm.hint.emu", true);
 			} else if (rz_config_get_i(core->config, "asm.hint.emu")) {
-				rz_core_cmd0(core, "e!asm.hint.emu");
-				rz_core_cmd0(core, "e asm.hint.lea=true");
+				rz_config_toggle(core->config, "asm.hint.emu");
+				rz_config_set_b(core->config, "asm.hint.lea", true);
 			} else if (rz_config_get_i(core->config, "asm.hint.lea")) {
-				rz_core_cmd0(core, "e!asm.hint.lea");
-				rz_core_cmd0(core, "e asm.hint.call=true");
+				rz_config_toggle(core->config, "asm.hint.lea");
+				rz_config_set_b(core->config, "asm.hint.call", true);
 			} else {
-				rz_core_cmd0(core, "e asm.hint.call=true");
+				rz_config_set_b(core->config, "asm.hint.call", true);
 			}
 			visual_refresh(core);
 			break;
@@ -3606,9 +3606,9 @@ static int visual_responsive(RzCore *core) {
 	int h, w = rz_cons_get_size(&h);
 	if (rz_config_get_i(core->config, "scr.responsive")) {
 		if (w < 110) {
-			rz_config_set_i(core->config, "asm.cmt.right", 0);
+			rz_config_set_b(core->config, "asm.cmt.right", false);
 		} else {
-			rz_config_set_i(core->config, "asm.cmt.right", 1);
+			rz_config_set_b(core->config, "asm.cmt.right", true);
 		}
 		if (w < 68) {
 			rz_config_set_i(core->config, "hex.cols", (int)(w / 5.2));
@@ -3616,9 +3616,9 @@ static int visual_responsive(RzCore *core) {
 			rz_config_set_i(core->config, "hex.cols", 16);
 		}
 		if (w < 25) {
-			rz_config_set_i(core->config, "asm.offset", 0);
+			rz_config_set_b(core->config, "asm.offset", false);
 		} else {
-			rz_config_set_i(core->config, "asm.offset", 1);
+			rz_config_set_b(core->config, "asm.offset", true);
 		}
 		if (w > 80) {
 			rz_config_set_i(core->config, "asm.lines.width", 14);
@@ -3629,9 +3629,9 @@ static int visual_responsive(RzCore *core) {
 		}
 		if (w < 70) {
 			rz_config_set_i(core->config, "asm.lines.width", 1);
-			rz_config_set_i(core->config, "asm.bytes", 0);
+			rz_config_set_b(core->config, "asm.bytes", false);
 		} else {
-			rz_config_set_i(core->config, "asm.bytes", 1);
+			rz_config_set_b(core->config, "asm.bytes", true);
 		}
 	}
 	return w;

--- a/librz/core/visual.c
+++ b/librz/core/visual.c
@@ -205,10 +205,10 @@ static void prevPrintCommand(void) {
 
 static const char *stackPrintCommand(RzCore *core) {
 	if (current0format == 0) {
-		if (rz_config_get_i(core->config, "dbg.slow")) {
+		if (rz_config_get_b(core->config, "dbg.slow")) {
 			return "pxr";
 		}
-		if (rz_config_get_i(core->config, "stack.bytes")) {
+		if (rz_config_get_b(core->config, "stack.bytes")) {
 			return "px";
 		}
 		switch (core->rasm->bits) {
@@ -377,8 +377,8 @@ static void rotateAsmBits(RzCore *core) {
 }
 
 static const char *rotateAsmemu(RzCore *core) {
-	const bool isEmuStr = rz_config_get_i(core->config, "emu.str");
-	const bool isEmu = rz_config_get_i(core->config, "asm.emu");
+	const bool isEmuStr = rz_config_get_b(core->config, "emu.str");
+	const bool isEmu = rz_config_get_b(core->config, "asm.emu");
 	if (isEmu) {
 		if (isEmuStr) {
 			rz_config_set(core->config, "emu.str", "false");
@@ -394,7 +394,7 @@ static const char *rotateAsmemu(RzCore *core) {
 RZ_API void rz_core_visual_showcursor(RzCore *core, int x) {
 	if (core && core->vmode) {
 		rz_cons_show_cursor(x);
-		rz_cons_enable_mouse(rz_config_get_i(core->config, "scr.wheel"));
+		rz_cons_enable_mouse(rz_config_get_b(core->config, "scr.wheel"));
 	} else {
 		rz_cons_enable_mouse(false);
 	}
@@ -720,7 +720,7 @@ RZ_API void rz_core_visual_prompt_input(RzCore *core) {
 
 	rz_cons_show_cursor(false);
 	core->vmode = true;
-	rz_cons_enable_mouse(mouse_state && rz_config_get_i(core->config, "scr.wheel"));
+	rz_cons_enable_mouse(mouse_state && rz_config_get_b(core->config, "scr.wheel"));
 	rz_cons_show_cursor(true);
 }
 
@@ -745,7 +745,7 @@ RZ_API int rz_core_visual_prompt(RzCore *core) {
 		rz_cons_echo(NULL);
 		rz_cons_flush();
 		ret = true;
-		if (rz_config_get_i(core->config, "cfg.debug")) {
+		if (rz_config_get_b(core->config, "cfg.debug")) {
 			rz_core_debug_regs2flags(core, 0);
 		}
 	} else {
@@ -758,7 +758,7 @@ RZ_API int rz_core_visual_prompt(RzCore *core) {
 }
 
 static void visual_single_step_in(RzCore *core) {
-	if (rz_config_get_i(core->config, "cfg.debug")) {
+	if (rz_config_get_b(core->config, "cfg.debug")) {
 		if (core->print->cur_enabled) {
 			rz_core_debug_continue_until(core, core->offset, core->offset + core->print->cur);
 			core->print->cur_enabled = 0;
@@ -773,9 +773,9 @@ static void visual_single_step_in(RzCore *core) {
 }
 
 static void __core_visual_step_over(RzCore *core) {
-	bool io_cache = rz_config_get_i(core->config, "io.cache");
+	bool io_cache = rz_config_get_b(core->config, "io.cache");
 	rz_config_set_b(core->config, "io.cache", false);
-	if (rz_config_get_i(core->config, "cfg.debug")) {
+	if (rz_config_get_b(core->config, "cfg.debug")) {
 		if (core->print->cur_enabled) {
 			rz_core_cmd(core, "dcr", 0);
 			core->print->cur_enabled = 0;
@@ -795,7 +795,7 @@ static void visual_breakpoint(RzCore *core) {
 }
 
 static void visual_continue(RzCore *core) {
-	if (rz_config_get_i(core->config, "cfg.debug")) {
+	if (rz_config_get_b(core->config, "cfg.debug")) {
 		rz_core_cmd(core, "dc", 0);
 	} else {
 		rz_core_cmd(core, "aec", 0);
@@ -1380,7 +1380,7 @@ repeat:
 		rz_cons_printf("\n\n(no %srefs)\n", xref ? "x" : "");
 	} else {
 		int h, w = rz_cons_get_size(&h);
-		bool asm_bytes = rz_config_get_i(core->config, "asm.bytes");
+		bool asm_bytes = rz_config_get_b(core->config, "asm.bytes");
 		rz_config_set_b(core->config, "asm.bytes", false);
 		rz_core_cmd0(core, "fd");
 
@@ -1501,7 +1501,7 @@ repeat:
 		rz_config_set_b(core->config, "asm.bytes", asm_bytes);
 	}
 	rz_cons_flush();
-	rz_cons_enable_mouse(rz_config_get_i(core->config, "scr.wheel"));
+	rz_cons_enable_mouse(rz_config_get_b(core->config, "scr.wheel"));
 	ch = rz_cons_readchar();
 	ch = rz_cons_arrow_to_hjkl(ch);
 	if (ch == ':') {
@@ -1670,7 +1670,7 @@ static void visual_comma(RzCore *core) {
 	}
 beach:
 	free(comment);
-	rz_cons_enable_mouse(mouse_state && rz_config_get_i(core->config, "scr.wheel"));
+	rz_cons_enable_mouse(mouse_state && rz_config_get_b(core->config, "scr.wheel"));
 }
 
 static bool isDisasmPrint(int mode) {
@@ -2239,7 +2239,7 @@ static int numbuf_pull(void) {
 }
 
 static bool canWrite(RzCore *core, ut64 addr) {
-	if (rz_config_get_i(core->config, "io.cache")) {
+	if (rz_config_get_b(core->config, "io.cache")) {
 		return true;
 	}
 	RzIOMap *map = rz_io_map_get(core->io, addr);
@@ -2306,7 +2306,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 	if (isNumber(core, ch)) {
 		// only in disasm and debug prints..
 		if (isDisasmPrint(core->printidx)) {
-			if (rz_config_get_i(core->config, "asm.hints") && (rz_config_get_i(core->config, "asm.hint.jmp") || rz_config_get_i(core->config, "asm.hint.lea") || rz_config_get_i(core->config, "asm.hint.emu") || rz_config_get_i(core->config, "asm.hint.call"))) {
+			if (rz_config_get_b(core->config, "asm.hints") && (rz_config_get_b(core->config, "asm.hint.jmp") || rz_config_get_b(core->config, "asm.hint.lea") || rz_config_get_b(core->config, "asm.hint.emu") || rz_config_get_b(core->config, "asm.hint.call"))) {
 				rz_core_visual_jump(core, ch);
 			} else {
 				numbuf_append(ch);
@@ -2327,7 +2327,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 		case 0x0d: // "enter" "\\n" "newline"
 		{
 			RzAnalysisOp *op;
-			int wheel = rz_config_get_i(core->config, "scr.wheel");
+			bool wheel = rz_config_get_b(core->config, "scr.wheel");
 			if (wheel) {
 				rz_cons_enable_mouse(true);
 			}
@@ -2418,7 +2418,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 				buf[0] = '\0';
 			}
 			strcat(buf, "\"");
-			int wheel = rz_config_get_i(core->config, "scr.wheel");
+			bool wheel = rz_config_get_b(core->config, "scr.wheel");
 			if (wheel) {
 				rz_cons_enable_mouse(true);
 			}
@@ -2489,7 +2489,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 			core->print->cur_enabled = oce;
 			core->print->cur = occ;
 			core->print->ocur = oco;
-			if (rz_config_get_i(core->config, "scr.wheel")) {
+			if (rz_config_get_b(core->config, "scr.wheel")) {
 				rz_cons_enable_mouse(true);
 			}
 		} break;
@@ -2529,7 +2529,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 			int distance = numbuf_pull();
 			rz_core_visual_define(core, arg + 1, distance - 1);
 			rz_core_visual_showcursor(core, false);
-			rz_cons_enable_mouse(mouse_state && rz_config_get_i(core->config, "scr.wheel"));
+			rz_cons_enable_mouse(mouse_state && rz_config_get_b(core->config, "scr.wheel"));
 		} break;
 		case 'D':
 			setdiff(core);
@@ -2573,7 +2573,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 					}
 				}
 			}
-			rz_cons_enable_mouse(mouse_state && rz_config_get_i(core->config, "scr.wheel"));
+			rz_cons_enable_mouse(mouse_state && rz_config_get_b(core->config, "scr.wheel"));
 		}
 			rz_core_visual_showcursor(core, false);
 			break;
@@ -2720,7 +2720,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 			rz_core_seek(core, oaddr, true);
 		} break;
 		case 'R':
-			if (rz_config_get_i(core->config, "scr.randpal")) {
+			if (rz_config_get_b(core->config, "scr.randpal")) {
 				rz_cons_pal_random();
 			} else {
 				rz_core_theme_nextpal(core, 'n');
@@ -2748,16 +2748,16 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 			break;
 		case 'r':
 			// TODO: toggle shortcut hotkeys
-			if (rz_config_get_i(core->config, "asm.hint.call")) {
+			if (rz_config_get_b(core->config, "asm.hint.call")) {
 				rz_config_toggle(core->config, "asm.hint.call");
 				rz_config_set_b(core->config, "asm.hint.jmp", true);
-			} else if (rz_config_get_i(core->config, "asm.hint.jmp")) {
+			} else if (rz_config_get_b(core->config, "asm.hint.jmp")) {
 				rz_config_toggle(core->config, "asm.hint.jmp");
 				rz_config_set_b(core->config, "asm.hint.emu", true);
-			} else if (rz_config_get_i(core->config, "asm.hint.emu")) {
+			} else if (rz_config_get_b(core->config, "asm.hint.emu")) {
 				rz_config_toggle(core->config, "asm.hint.emu");
 				rz_config_set_b(core->config, "asm.hint.lea", true);
-			} else if (rz_config_get_i(core->config, "asm.hint.lea")) {
+			} else if (rz_config_get_b(core->config, "asm.hint.lea")) {
 				rz_config_toggle(core->config, "asm.hint.lea");
 				rz_config_set_b(core->config, "asm.hint.call", true);
 			} else {
@@ -2767,7 +2767,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 			break;
 		case ' ':
 		case 'V':
-			if (rz_config_get_i(core->config, "graph.web")) {
+			if (rz_config_get_b(core->config, "graph.web")) {
 				rz_core_cmd0(core, "agv $$");
 			} else {
 				RzAnalysisFunction *fun = rz_analysis_get_fcn_in(core->analysis, core->offset, RZ_ANALYSIS_FCN_TYPE_NULL);
@@ -2835,7 +2835,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 					cursor_nextrow(core, false);
 				}
 			} else {
-				if (rz_config_get_i(core->config, "scr.wheel.nkey")) {
+				if (rz_config_get_b(core->config, "scr.wheel.nkey")) {
 					int i, distance = numbuf_pull();
 					if (distance < 1) {
 						distance = 1;
@@ -2911,7 +2911,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 					cursor_prevrow(core, false);
 				}
 			} else {
-				if (rz_config_get_i(core->config, "scr.wheel.nkey")) {
+				if (rz_config_get_b(core->config, "scr.wheel.nkey")) {
 					int i, distance = numbuf_pull();
 					if (distance < 1) {
 						distance = 1;
@@ -3387,7 +3387,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 }
 
 RZ_API void rz_core_visual_title(RzCore *core, int color) {
-	bool showDelta = rz_config_get_i(core->config, "scr.slow");
+	bool showDelta = rz_config_get_b(core->config, "scr.slow");
 	static ut64 oldpc = 0;
 	const char *BEGIN = core->cons->context->pal.prompt;
 	const char *filename;
@@ -3434,7 +3434,7 @@ RZ_API void rz_core_visual_title(RzCore *core, int color) {
 	if (rz_config_get_i(core->config, "scr.scrollbar") == 2) {
 		rz_core_cmd(core, "fz:", 0);
 	}
-	if (rz_config_get_i(core->config, "cfg.debug")) {
+	if (rz_config_get_b(core->config, "cfg.debug")) {
 		ut64 curpc = rz_debug_reg_get(core->dbg, "PC");
 		if (curpc && curpc != UT64_MAX && curpc != oldpc) {
 			// check dbg.follow here
@@ -3604,7 +3604,7 @@ RZ_API void rz_core_visual_title(RzCore *core, int color) {
 
 static int visual_responsive(RzCore *core) {
 	int h, w = rz_cons_get_size(&h);
-	if (rz_config_get_i(core->config, "scr.responsive")) {
+	if (rz_config_get_b(core->config, "scr.responsive")) {
 		if (w < 110) {
 			rz_config_set_b(core->config, "asm.cmt.right", false);
 		} else {
@@ -3657,10 +3657,10 @@ RZ_API void rz_core_print_scrollbar(RzCore *core) {
 	}
 	ut64 from = 0;
 	ut64 to = UT64_MAX;
-	if (rz_config_get_i(core->config, "cfg.debug")) {
+	if (rz_config_get_b(core->config, "cfg.debug")) {
 		from = rz_num_math(core->num, "$D");
 		to = rz_num_math(core->num, "$D+$DD");
-	} else if (rz_config_get_i(core->config, "io.va")) {
+	} else if (rz_config_get_b(core->config, "io.va")) {
 		from = rz_num_math(core->num, "$S");
 		to = rz_num_math(core->num, "$S+$SS");
 	} else {
@@ -3714,10 +3714,10 @@ RZ_API void rz_core_print_scrollbar_bottom(RzCore *core) {
 	}
 	ut64 from = 0;
 	ut64 to = UT64_MAX;
-	if (rz_config_get_i(core->config, "cfg.debug")) {
+	if (rz_config_get_b(core->config, "cfg.debug")) {
 		from = rz_num_math(core->num, "$D");
 		to = rz_num_math(core->num, "$D+$DD");
-	} else if (rz_config_get_i(core->config, "io.va")) {
+	} else if (rz_config_get_b(core->config, "io.va")) {
 		from = rz_num_math(core->num, "$S");
 		to = rz_num_math(core->num, "$S+$SS");
 	} else {
@@ -3916,7 +3916,7 @@ RZ_API void rz_core_visual_disasm_up(RzCore *core, int *cols) {
 
 RZ_API void rz_core_visual_disasm_down(RzCore *core, RzAsmOp *op, int *cols) {
 	int midflags = rz_config_get_i(core->config, "asm.flags.middle");
-	const bool midbb = rz_config_get_i(core->config, "asm.bb.middle");
+	const bool midbb = rz_config_get_b(core->config, "asm.bb.middle");
 	op->size = 1;
 	rz_asm_set_pc(core->rasm, core->offset);
 	*cols = rz_asm_disassemble(core->rasm,
@@ -4013,11 +4013,11 @@ RZ_API int rz_core_visual(RzCore *core, const char *input) {
 		skip = fix_cursor(core);
 		rz_cons_show_cursor(false);
 		rz_cons_set_raw(1);
-		const int ref = rz_config_get_i(core->config, "dbg.slow");
+		const int ref = rz_config_get_b(core->config, "dbg.slow");
 #if 1
 		// This is why multiple debug views dont work
 		if (core->printidx == RZ_CORE_VISUAL_MODE_DB) {
-			const int pxa = rz_config_get_i(core->config, "stack.anotated"); // stack.anotated
+			const bool pxa = rz_config_get_b(core->config, "stack.anotated"); // stack.anotated
 			const char *reg = rz_config_get(core->config, "stack.reg");
 			const int size = rz_config_get_i(core->config, "stack.size");
 			const int delta = rz_config_get_i(core->config, "stack.delta");
@@ -4045,7 +4045,7 @@ RZ_API int rz_core_visual(RzCore *core, const char *input) {
 		}
 #endif
 		rz_cons_show_cursor(false);
-		rz_cons_enable_mouse(rz_config_get_i(core->config, "scr.wheel"));
+		rz_cons_enable_mouse(rz_config_get_b(core->config, "scr.wheel"));
 		core->cons->event_resize = NULL; // avoid running old event with new data
 		core->cons->event_data = core;
 		core->cons->event_resize = (RzConsEvent)visual_refresh_oneshot;
@@ -4054,7 +4054,7 @@ RZ_API int rz_core_visual(RzCore *core, const char *input) {
 		if (color) {
 			flags |= RZ_PRINT_FLAGS_COLOR;
 		}
-		debug = rz_config_get_i(core->config, "cfg.debug");
+		debug = rz_config_get_b(core->config, "cfg.debug");
 		flags |= RZ_PRINT_FLAGS_ADDRMOD | RZ_PRINT_FLAGS_HEADER;
 		rz_print_set_flags(core->print, flags);
 		scrseek = rz_num_math(core->num,

--- a/librz/core/vmenus.c
+++ b/librz/core/vmenus.c
@@ -471,10 +471,10 @@ RZ_API bool rz_core_visual_bit_editor(RzCore *core) {
 			}
 		} break;
 		case 'R':
-			if (rz_config_get_i(core->config, "scr.randpal")) {
-				rz_core_cmd0(core, "ecr");
+			if (rz_config_get_b(core->config, "scr.randpal")) {
+				rz_cons_pal_random();
 			} else {
-				rz_core_cmd0(core, "ecn");
+				rz_core_theme_nextpal(core, 'n');
 			}
 			break;
 		case '+':
@@ -3127,7 +3127,7 @@ RZ_API void rz_core_visual_analysis(RzCore *core, const char *input) {
 		case '-':
 			switch (level) {
 			case 0:
-				rz_core_cmdf(core, "af-0x%" PFMT64x, addr);
+				rz_core_cmdf(core, "af- 0x%" PFMT64x, addr);
 				break;
 			}
 			break;
@@ -3138,7 +3138,7 @@ RZ_API void rz_core_visual_analysis(RzCore *core, const char *input) {
 			rz_core_visual_refs(core, true, true);
 			break;
 		case 's':
-			rz_core_cmdf(core, "afs!@0x%08" PFMT64x, addr);
+			rz_core_cmdf(core, "afs! @ 0x%08" PFMT64x, addr);
 			break;
 		case 'c':
 			level = 2;

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1659,6 +1659,8 @@ RZ_API void rz_analysis_fcn_vars_cache_fini(RzAnalysisFcnVarsCache *cache);
 RZ_API char *rz_analysis_fcn_format_sig(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL RzAnalysisFunction *fcn, RZ_NULLABLE char *fcn_name,
 	RZ_NULLABLE RzAnalysisFcnVarsCache *reuse_cache, RZ_NULLABLE const char *fcn_name_pre, RZ_NULLABLE const char *fcn_name_post);
 
+RZ_API void rz_analysis_fcn_vars_add_types(RzAnalysis *analysis, RzAnalysisFunction *fcn);
+
 /* project */
 RZ_API bool rz_analysis_xrefs_init(RzAnalysis *analysis);
 

--- a/librz/include/rz_config.h
+++ b/librz/include/rz_config.h
@@ -79,6 +79,7 @@ RZ_API void rz_config_lock(RzConfig *cfg, int l);
 RZ_API bool rz_config_eval(RzConfig *cfg, const char *str, bool many);
 RZ_API void rz_config_bump(RzConfig *cfg, const char *key);
 RZ_API RzConfigNode *rz_config_set_i(RzConfig *cfg, const char *name, const ut64 i);
+RZ_API RzConfigNode *rz_config_set_b(RzConfig *cfg, const char *name, bool value);
 RZ_API RzConfigNode *rz_config_set_cb(RzConfig *cfg, const char *name, const char *value, bool (*callback)(void *user, void *data));
 RZ_API RzConfigNode *rz_config_set_i_cb(RzConfig *cfg, const char *name, int ivalue, bool (*callback)(void *user, void *data));
 RZ_API RzConfigNode *rz_config_set(RzConfig *cfg, const char *name, const char *value);

--- a/librz/include/rz_config.h
+++ b/librz/include/rz_config.h
@@ -85,6 +85,7 @@ RZ_API RzConfigNode *rz_config_set_i_cb(RzConfig *cfg, const char *name, int iva
 RZ_API RzConfigNode *rz_config_set(RzConfig *cfg, const char *name, const char *value);
 RZ_API bool rz_config_rm(RzConfig *cfg, const char *name);
 RZ_API ut64 rz_config_get_i(RzConfig *cfg, const char *name);
+RZ_API bool rz_config_get_b(RzConfig *cfg, const char *name);
 RZ_API const char *rz_config_get(RzConfig *cfg, const char *name);
 RZ_API const char *rz_config_desc(RzConfig *cfg, const char *name, const char *desc);
 RZ_API const char *rz_config_node_desc(RzConfigNode *node, const char *desc);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -512,6 +512,8 @@ RZ_API bool rz_core_serve(RzCore *core, RzIODesc *fd);
 RZ_API int rz_core_file_reopen(RzCore *core, const char *args, int perm, int binload);
 RZ_API void rz_core_file_reopen_debug(RzCore *core, const char *args);
 RZ_API void rz_core_file_reopen_remote_debug(RzCore *core, char *uri, ut64 addr);
+RZ_API bool rz_core_file_resize(RzCore *core, ut64 newsize);
+RZ_API bool rz_core_file_resize_delta(RzCore *core, st64 delta);
 RZ_API RzCoreFile *rz_core_file_find_by_fd(RzCore *core, ut64 fd);
 RZ_API RzCoreFile *rz_core_file_find_by_name(RzCore *core, const char *name);
 RZ_API RzCoreFile *rz_core_file_cur(RzCore *r);
@@ -540,6 +542,7 @@ RZ_API ut32 rz_core_file_cur_fd(RzCore *core);
 
 /* cdebug.c */
 RZ_API bool rz_core_debug_step_one(RzCore *core, int times);
+RZ_API bool rz_core_debug_continue_until(RzCore *core, ut64 addr, ut64 to);
 
 RZ_API void rz_core_debug_rr(RzCore *core, RzReg *reg, int mode);
 RZ_API void rz_core_debug_set_register_flags(RzCore *core);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -454,6 +454,7 @@ RZ_API RzLineNSCompletionResult *rz_core_autocomplete_newshell(RzCore *core, RzL
 RZ_API void rz_core_print_scrollbar(RzCore *core);
 RZ_API void rz_core_print_scrollbar_bottom(RzCore *core);
 RZ_API void rz_core_visual_prompt_input(RzCore *core);
+RZ_API void rz_core_visual_toggle_hints(RzCore *core);
 RZ_API void rz_core_visual_toggle_decompiler_disasm(RzCore *core, bool for_graph, bool reset);
 RZ_API void rz_core_visual_applyDisMode(RzCore *core, int disMode);
 RZ_API void rz_core_visual_applyHexMode(RzCore *core, int hexMode);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -619,6 +619,9 @@ RZ_API bool rz_core_esil_cmd(RzAnalysisEsil *esil, const char *cmd, ut64 a1, ut6
 RZ_API int rz_core_esil_step(RzCore *core, ut64 until_addr, const char *until_expr, ut64 *prev_addr, bool stepOver);
 RZ_API int rz_core_esil_step_back(RzCore *core);
 RZ_API ut64 rz_core_analysis_get_bbaddr(RzCore *core, ut64 addr);
+RZ_API void rz_core_analysis_flag_every_function(RzCore *core);
+RZ_API bool rz_core_analysis_function_rename(RzCore *core, ut64 addr, const char *_name);
+RZ_API bool rz_core_analysis_function_add(RzCore *core, const char *name, ut64 addr, bool analyze_recursively);
 RZ_API int rz_core_analysis_fcn(RzCore *core, ut64 at, ut64 from, int reftype, int depth);
 RZ_API char *rz_core_analysis_fcn_autoname(RzCore *core, ut64 addr, int dump, int mode);
 RZ_API void rz_core_analysis_autoname_all_fcns(RzCore *core);

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -23,6 +23,7 @@ if get_option('enable_tests')
     'bitmap',
     'buf',
     'cmd',
+    'config',
     'cons',
     'contrbtree',
     'core_cmd',

--- a/test/unit/test_config.c
+++ b/test/unit/test_config.c
@@ -1,0 +1,56 @@
+#include <rz_config.h>
+#include "minunit.h"
+
+bool test_config() {
+	RzConfig *cfg = rz_config_new(NULL);
+
+	// string variables
+	rz_config_set(cfg, "foo.bar", "bla");
+	const char *bla = rz_config_get(cfg, "foo.bar");
+	mu_assert_streq(bla, "bla", "String variable");
+
+	// integer variables
+	rz_config_set_i(cfg, "universe.question", 42);
+	int answer = rz_config_get_i(cfg, "universe.question");
+	mu_assert_eq(answer, 42, "Integer variable");
+
+	// boolean variables
+	rz_config_set_b(cfg, "true.or.false", true);
+	bool what = rz_config_get_b(cfg, "true.or.false");
+	mu_assert_eq(what, true, "Boolean variable");
+	rz_config_toggle(cfg, "true.or.false");
+	what = rz_config_get_b(cfg, "true.or.false");
+	mu_assert_eq(what, false, "Boolean variable (toggle)");
+
+	mu_end;
+}
+
+bool test_config_lock() {
+	RzConfig *cfg = rz_config_new(NULL);
+	cfg->lock = 1;
+
+	// string variables
+	rz_config_set(cfg, "foo.bar", "bla");
+	const char *bla = rz_config_get(cfg, "foo.bar");
+	mu_assert_null(bla, "String variable (locked)");
+
+	// integer variables
+	rz_config_set_i(cfg, "universe.question", 42);
+	int answer = rz_config_get_i(cfg, "universe.question");
+	mu_assert_neq(answer, 42, "Integer variable (locked)");
+
+	// boolean variables
+	rz_config_set_b(cfg, "true.or.false", true);
+	bool what = rz_config_get_b(cfg, "true.or.false");
+	mu_assert_false(what, "Boolean variable (locked)");
+
+	mu_end;
+}
+
+bool all_tests() {
+	mu_run_test(test_config);
+	mu_run_test(test_config_lock);
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests)


### PR DESCRIPTION
**DO NOT SQUASH**

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Refactor Visual mode to use API instead of `rz_core_cmd*` functions in some cases - debug continue until and resizing commands.

Also introduced new API calls for better understanding what config variables are bool and check it more granularly:
- `rz_config_get_b(RzConfig *cfg, const char *name)`
- `rz_config_set_b(RzConfig *cfg, const char *name, bool value)`

To reduce unnecessary `rz_core_cmdf()` calls in visual browse also switched `af` calls to the newly introduced `RZ_API bool rz_core_analysis_function_add()`.

**Test plan**

Go into Visual mode, e.g. `Vp` and try to press `s` or F8  in both debug and ESIL modes. Also try `g` key.
Also try to resize the file by pressing `r` (-1 byte) and `R` (+1 byte).

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/382