### PR TITLE
Rename the macro RBININFO to RZBININFO in cmd_info.c ##refactor

### DIFF
--- a/librz/core/cmd_info.c
+++ b/librz/core/cmd_info.c
@@ -503,7 +503,7 @@ RZ_IPI int rz_cmd_info(void *data, const char *input) {
 			ut64 baddr = rz_config_get_i(core->config, "bin.baddr");
 			rz_core_bin_load(core, fn, baddr);
 		} break;
-#define RBININFO(n, x, y) \
+#define RZBININFO(n, x, y) \
 	if (is_array) { \
 		pj_k(pj, n); \
 	} \
@@ -523,9 +523,9 @@ RZ_IPI int rz_cmd_info(void *data, const char *input) {
 			if (input[1] == 'j' && input[2] == '.') {
 				mode = RZ_MODE_JSON;
 				INIT_PJ();
-				RBININFO("exports", RZ_CORE_BIN_ACC_EXPORTS, input + 2);
+				RZBININFO("exports", RZ_CORE_BIN_ACC_EXPORTS, input + 2);
 			} else {
-				RBININFO("exports", RZ_CORE_BIN_ACC_EXPORTS, input + 1);
+				RZBININFO("exports", RZ_CORE_BIN_ACC_EXPORTS, input + 1);
 			}
 			while (*(++input))
 				;
@@ -598,7 +598,7 @@ RZ_IPI int rz_cmd_info(void *data, const char *input) {
 			rz_list_free(old_hashes);
 		} break;
 		case 'Z': // "iZ"
-			RBININFO("size", RZ_CORE_BIN_ACC_SIZE, NULL);
+			RZBININFO("size", RZ_CORE_BIN_ACC_SIZE, NULL);
 			break;
 		case 'O': // "iO"
 			switch (input[1]) {
@@ -613,9 +613,9 @@ RZ_IPI int rz_cmd_info(void *data, const char *input) {
 		case 'S': // "iS"
 			//we comes from ia or iS
 			if ((input[1] == 'm' && input[2] == 'z') || !input[1]) {
-				RBININFO("sections", RZ_CORE_BIN_ACC_SECTIONS, NULL);
+				RZBININFO("sections", RZ_CORE_BIN_ACC_SECTIONS, NULL);
 			} else if (input[1] == 'S' && !input[2]) { // "iSS"
-				RBININFO("segments", RZ_CORE_BIN_ACC_SEGMENTS, NULL);
+				RZBININFO("segments", RZ_CORE_BIN_ACC_SEGMENTS, NULL);
 			} else { //iS/iSS entropy,sha1
 				const char *name = "sections";
 				int action = RZ_CORE_BIN_ACC_SECTIONS;
@@ -641,7 +641,7 @@ RZ_IPI int rz_cmd_info(void *data, const char *input) {
 						param_shift++;
 					}
 				}
-				RBININFO(name, action, input + 1 + param_shift);
+				RZBININFO(name, action, input + 1 + param_shift);
 			}
 			//we move input until get '\0'
 			while (*(++input))
@@ -652,14 +652,14 @@ RZ_IPI int rz_cmd_info(void *data, const char *input) {
 			break;
 		case 'H': // "iH"
 			if (input[1] == 'H') { // "iHH"
-				RBININFO("header", RZ_CORE_BIN_ACC_HEADER, NULL);
+				RZBININFO("header", RZ_CORE_BIN_ACC_HEADER, NULL);
 				break;
 			}
 		case 'h': // "ih"
-			RBININFO("fields", RZ_CORE_BIN_ACC_FIELDS, NULL);
+			RZBININFO("fields", RZ_CORE_BIN_ACC_FIELDS, NULL);
 			break;
 		case 'l': { // "il"
-			RBININFO("libs", RZ_CORE_BIN_ACC_LIBS, NULL);
+			RZBININFO("libs", RZ_CORE_BIN_ACC_LIBS, NULL);
 			break;
 		}
 		case 'L': { // "iL"
@@ -683,15 +683,15 @@ RZ_IPI int rz_cmd_info(void *data, const char *input) {
 			if (input[1] == 'j' && input[2] == '.') {
 				mode = RZ_MODE_JSON;
 				INIT_PJ();
-				RBININFO("symbols", RZ_CORE_BIN_ACC_SYMBOLS, input + 2);
+				RZBININFO("symbols", RZ_CORE_BIN_ACC_SYMBOLS, input + 2);
 			} else if (input[1] == 'q' && input[2] == 'q') {
 				mode = RZ_MODE_SIMPLEST;
-				RBININFO("symbols", RZ_CORE_BIN_ACC_SYMBOLS, input + 1);
+				RZBININFO("symbols", RZ_CORE_BIN_ACC_SYMBOLS, input + 1);
 			} else if (input[1] == 'q' && input[2] == '.') {
 				mode = RZ_MODE_SIMPLE;
-				RBININFO("symbols", RZ_CORE_BIN_ACC_SYMBOLS, input + 2);
+				RZBININFO("symbols", RZ_CORE_BIN_ACC_SYMBOLS, input + 2);
 			} else {
-				RBININFO("symbols", RZ_CORE_BIN_ACC_SYMBOLS, input + 1);
+				RZBININFO("symbols", RZ_CORE_BIN_ACC_SYMBOLS, input + 1);
 			}
 			while (*(++input))
 				;
@@ -699,13 +699,13 @@ RZ_IPI int rz_cmd_info(void *data, const char *input) {
 			break;
 		}
 		case 'R': // "iR"
-			RBININFO("resources", RZ_CORE_BIN_ACC_RESOURCES, NULL);
+			RZBININFO("resources", RZ_CORE_BIN_ACC_RESOURCES, NULL);
 			break;
 		case 'r': // "ir"
-			RBININFO("relocs", RZ_CORE_BIN_ACC_RELOCS, NULL);
+			RZBININFO("relocs", RZ_CORE_BIN_ACC_RELOCS, NULL);
 			break;
 		case 'X': // "iX"
-			RBININFO("source", RZ_CORE_BIN_ACC_SOURCE, NULL);
+			RZBININFO("source", RZ_CORE_BIN_ACC_SOURCE, NULL);
 			break;
 		case 'd': // "id"
 			if (input[1] == 'p') { // "idp"
@@ -819,39 +819,39 @@ RZ_IPI int rz_cmd_info(void *data, const char *input) {
 				rz_core_cmd_help(core, help_msg_id);
 				input++;
 			} else { // "id"
-				RBININFO("dwarf", RZ_CORE_BIN_ACC_DWARF, NULL);
+				RZBININFO("dwarf", RZ_CORE_BIN_ACC_DWARF, NULL);
 			}
 			break;
 		case 'i': { // "ii"
-			RBININFO("imports", RZ_CORE_BIN_ACC_IMPORTS, NULL);
+			RZBININFO("imports", RZ_CORE_BIN_ACC_IMPORTS, NULL);
 			break;
 		}
 		case 'I': // "iI"
-			RBININFO("info", RZ_CORE_BIN_ACC_INFO, NULL);
+			RZBININFO("info", RZ_CORE_BIN_ACC_INFO, NULL);
 			break;
 		case 'e': // "ie"
 			if (input[1] == 'e') {
-				RBININFO("initfini", RZ_CORE_BIN_ACC_INITFINI, NULL);
+				RZBININFO("initfini", RZ_CORE_BIN_ACC_INITFINI, NULL);
 				input++;
 			} else {
-				RBININFO("entries", RZ_CORE_BIN_ACC_ENTRIES, NULL);
+				RZBININFO("entries", RZ_CORE_BIN_ACC_ENTRIES, NULL);
 			}
 			break;
 		case 'M': // "iM"
-			RBININFO("main", RZ_CORE_BIN_ACC_MAIN, NULL);
+			RZBININFO("main", RZ_CORE_BIN_ACC_MAIN, NULL);
 			break;
 		case 'm': // "im"
-			RBININFO("memory", RZ_CORE_BIN_ACC_MEM, NULL);
+			RZBININFO("memory", RZ_CORE_BIN_ACC_MEM, NULL);
 			break;
 		case 'w': // "iw"
-			RBININFO("trycatch", RZ_CORE_BIN_ACC_TRYCATCH, NULL);
+			RZBININFO("trycatch", RZ_CORE_BIN_ACC_TRYCATCH, NULL);
 			break;
 		case 'V': // "iV"
-			RBININFO("versioninfo", RZ_CORE_BIN_ACC_VERSIONINFO, NULL);
+			RZBININFO("versioninfo", RZ_CORE_BIN_ACC_VERSIONINFO, NULL);
 			break;
 		case 'T': // "iT"
 		case 'C': // "iC" // rz-bin -C create // should be deprecated and just use iT (or find a better name)
-			RBININFO("signature", RZ_CORE_BIN_ACC_SIGNATURE, NULL);
+			RZBININFO("signature", RZ_CORE_BIN_ACC_SIGNATURE, NULL);
 			break;
 		case 'z': // "iz"
 			if (input[1] == '-') { //iz-
@@ -908,7 +908,7 @@ RZ_IPI int rz_cmd_info(void *data, const char *input) {
 					}
 					goto done;
 				}
-				RBININFO("strings", RZ_CORE_BIN_ACC_RAW_STRINGS, NULL);
+				RZBININFO("strings", RZ_CORE_BIN_ACC_RAW_STRINGS, NULL);
 			} else {
 				RzBinObject *obj = rz_bin_cur_object(core->bin);
 				if (input[1] == 'q') {
@@ -918,7 +918,7 @@ RZ_IPI int rz_cmd_info(void *data, const char *input) {
 					input++;
 				}
 				if (obj) {
-					RBININFO("strings", RZ_CORE_BIN_ACC_STRINGS, NULL);
+					RZBININFO("strings", RZ_CORE_BIN_ACC_STRINGS, NULL);
 				}
 			}
 			break;
@@ -1064,20 +1064,20 @@ RZ_IPI int rz_cmd_info(void *data, const char *input) {
 						if (input[2] == '*') {
 							mode |= RZ_MODE_RIZINCMD;
 						}
-						RBININFO("classes", RZ_CORE_BIN_ACC_CLASSES, NULL);
+						RZBININFO("classes", RZ_CORE_BIN_ACC_CLASSES, NULL);
 						input = " ";
 					} else { // "icq"
 						if (input[2] == 'j') {
 							mode |= RZ_MODE_JSON; // default mode is RZ_MODE_SIMPLE
 						}
-						RBININFO("classes", RZ_CORE_BIN_ACC_CLASSES, NULL);
+						RZBININFO("classes", RZ_CORE_BIN_ACC_CLASSES, NULL);
 					}
 					goto done;
 				}
 			} else { // "ic"
 				RzBinObject *obj = rz_bin_cur_object(core->bin);
 				if (obj && obj->classes) {
-					RBININFO("classes", RZ_CORE_BIN_ACC_CLASSES, NULL);
+					RZBININFO("classes", RZ_CORE_BIN_ACC_CLASSES, NULL);
 				}
 			}
 			break;

--- a/librz/core/cmd_info.c
+++ b/librz/core/cmd_info.c
@@ -1065,7 +1065,6 @@ RZ_IPI int rz_cmd_info(void *data, const char *input) {
 							mode |= RZ_MODE_RIZINCMD;
 						}
 						RZBININFO("classes", RZ_CORE_BIN_ACC_CLASSES, NULL);
-						input = " ";
 					} else { // "icq"
 						if (input[2] == 'j') {
 							mode |= RZ_MODE_JSON; // default mode is RZ_MODE_SIMPLE


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

In `cmd_info.c`, there was a marco named `RBININFO` which basically just helps
while handling cases of `i` command with `rz_core_bin_info`.
This commit renames RBININFO to RZBININFO.

**Test plan**

Merge when green.

**Closing issues**

None