### PR TITLE
Add a `?` in the help message of `a` to show that `ab?` exists

### DIFF
--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -12,7 +12,6 @@ static const char *help_msg_a[] = {
 	"aa", "[?]", "analyze all (fcns + bbs) (aa0 to avoid sub renaming)",
 	"a8", " [hexpairs]", "analyze bytes",
 	"ab", "[?] [addr]", "analyze block",
-	"abb", " [len]", "analyze N basic blocks in [len] (section.size by default)",
 	"ac", "[?]", "manage classes",
 	"aC", "[?]", "analyze function call",
 	"aCe", "[?]", "same as aC, but uses esil with abte to emulate the function",

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -11,7 +11,7 @@ static const char *help_msg_a[] = {
 	"a*", "", "same as afl*;ah*;ax*",
 	"aa", "[?]", "analyze all (fcns + bbs) (aa0 to avoid sub renaming)",
 	"a8", " [hexpairs]", "analyze bytes",
-	"ab", "[?] [b] [addr]", "analyze block at given address",
+	"ab", "[?] [addr]", "analyze block",
 	"abb", " [len]", "analyze N basic blocks in [len] (section.size by default)",
 	"ac", "[?]", "manage classes",
 	"aC", "[?]", "analyze function call",
@@ -89,7 +89,7 @@ static const char *help_msg_aar[] = {
 };
 
 static const char *help_msg_ab[] = {
-	"Usage:", "ab", "",
+	"Usage:", "ab", "analyze block",
 	"ab", " [addr]", "show basic block information at given address",
 	"ab.", "", "same as: ab $$",
 	"aba", " [addr]", "analyze esil accesses in basic block (see aea?)",

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -11,7 +11,7 @@ static const char *help_msg_a[] = {
 	"a*", "", "same as afl*;ah*;ax*",
 	"aa", "[?]", "analyze all (fcns + bbs) (aa0 to avoid sub renaming)",
 	"a8", " [hexpairs]", "analyze bytes",
-	"ab", "[b] [addr]", "analyze block at given address",
+	"ab", "[?] [b] [addr]", "analyze block at given address",
 	"abb", " [len]", "analyze N basic blocks in [len] (section.size by default)",
 	"ac", "[?]", "manage classes",
 	"aC", "[?]", "analyze function call",
@@ -97,7 +97,7 @@ static const char *help_msg_ab[] = {
 	"abj", " [addr]", "display basic block information in JSON",
 	"abl", "[,qj]", "list all basic blocks",
 	"abx", " [hexpair-bytes]", "analyze N bytes",
-	"abt[?]", " [addr] [num]", "find num paths from current offset to addr",
+	"abt", "[?] [addr] [num]", "find num paths from current offset to addr",
 	NULL
 };
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Recently, a person from the community pointed out that here was no 
indication that help for ab (`ab?`) exists under the help under `a?`. 
This commits adds a `?` to solve that.

Also tweaks `help_msg_ab` a bit.

**Test plan**
Do we need that `[b]` before `[addr]`on that line? I'm not sure. If not, we can remove that.
https://github.com/officialcjunior/rizin/blob/0a14c7e53e4b707d49a28215ebca15ae86dc2040/librz/core/cmd_analysis.c#L14

See if there's anything else that could be improved. 

**Closing issues**

None
