### PR TITLE
8051_ass.c: Remove never-executed break

### DIFF
--- a/librz/asm/arch/8051/8051_ass.c
+++ b/librz/asm/arch/8051/8051_ass.c
@@ -534,7 +534,6 @@ static bool mnem_add(char const *const *arg, ut16 pc, ut8 **out) {
 		return false;
 	}
 	switch (arg[1][0]) {
-		break;
 	case '@':
 	case '[':
 		return singlearg_register(0x26, arg[1], out);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

According to https://en.cppreference.com/w/c/language/switch, statements in a `switch` that are not part of a `case` or `default` are not executed. This pr removes an occurrence.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
