### PR TITLE
Add gdbserver tests ##test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,9 @@ jobs:
     - name: Install test dependencies
       if: matrix.run_tests && matrix.enabled
       run: pip3 install --user "file://$GITHUB_WORKSPACE/test/rz-pipe#egg=rzpipe&subdirectory=python"
+    - name: Install gdbserver dependency
+      if: matrix.run_tests && matrix.enabled && (matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04')
+      run: sudo apt-get --assume-yes install gdbserver
     - name: Install clang
       if: matrix.compiler == 'clang' && matrix.os == 'ubuntu-latest' && matrix.enabled
       run: sudo apt-get --assume-yes install clang

--- a/test/db/archos/linux-x64/dbg_gdbserver
+++ b/test/db/archos/linux-x64/dbg_gdbserver
@@ -1,0 +1,16 @@
+NAME=gdbserver connect
+FILE=bins/elf/analysis/calls_x64
+CMDS=<<EOF
+!scripts/gdbserver.py --port 12346 --binary bins/elf/analysis/calls_x64
+oodf gdb://127.0.0.1:12346
+db main
+ds
+dc
+doc
+!killall gdbserver
+EOF
+REGEXP_FILTER_ERR=([A-Za-z=:\n]+\s)
+EXPECT_ERR=<<EOF
+= attach = attach hit breakpoint at: gdbserver: no process found
+EOF
+RUN

--- a/test/db/archos/linux-x64/dbg_gdbserver
+++ b/test/db/archos/linux-x64/dbg_gdbserver
@@ -4,7 +4,6 @@ CMDS=<<EOF
 !scripts/gdbserver.py --port 12346 --binary bins/elf/analysis/calls_x64
 oodf gdb://127.0.0.1:12346
 db main
-ds
 dc
 doc
 !killall gdbserver

--- a/test/db/archos/linux-x64/dbg_gdbserver
+++ b/test/db/archos/linux-x64/dbg_gdbserver
@@ -1,15 +1,14 @@
-NAME=gdbserver connect
-FILE=bins/elf/analysis/calls_x64
+NAME=gdbserver continue
+FILE=bins/elf/analysis/pie
 CMDS=<<EOF
-!scripts/gdbserver.py --port 12346 --binary bins/elf/analysis/calls_x64
+!scripts/gdbserver.py --port 12346 --binary bins/elf/analysis/pie
 oodf gdb://127.0.0.1:12346
 db main
 dc
+?v main-`s`+1
 doc
-!killall gdbserver
 EOF
-REGEXP_FILTER_ERR=([A-Za-z=:\n]+\s)
-EXPECT_ERR=<<EOF
-= attach = attach hit breakpoint at: gdbserver: no process found
+EXPECT=<<EOF
+0x0
 EOF
 RUN

--- a/test/db/archos/linux-x64/dbg_gdbserver_rebase
+++ b/test/db/archos/linux-x64/dbg_gdbserver_rebase
@@ -1,0 +1,88 @@
+NAME=function rebase
+FILE=bins/elf/analysis/pie
+CMDS=<<EOF
+!scripts/gdbserver.py --port 12341 --binary bins/elf/analysis/pie
+oodf gdb://127.0.0.1:12341
+?v main-`dmm~pie[0]`
+doc
+?v main-`dmm~pie[0]`
+EOF
+EXPECT=<<EOF
+0x5c5
+0x5c5
+EOF
+RUN
+
+NAME=bp rebase
+FILE=bins/elf/analysis/pie
+CMDS=<<EOF
+!scripts/gdbserver.py --port 12342 --binary bins/elf/analysis/pie
+oodf gdb://127.0.0.1:12342
+aa
+db main
+?v main-`db~main[0]`
+doc
+?v main-`db~main[0]`
+EOF
+EXPECT=<<EOF
+0x0
+0x0
+EOF
+RUN
+
+NAME=ref rebase
+FILE=bins/elf/hello_world
+CMDS=<<EOF
+!scripts/gdbserver.py --port 12343 --binary bins/elf/hello_world
+oodf gdb://127.0.0.1:12343
+aa
+?v `axt main~entry0[1]`-`e bin.baddr`
+doc
+?v `axt main~entry0[1]`-`e bin.baddr`
+EOF
+EXPECT=<<EOF
+0x6bd
+0x6bd
+EOF
+RUN
+
+NAME=flag rebase
+FILE=bins/elf/analysis/pie
+CMDS=<<EOF
+!scripts/gdbserver.py --port 12345 --binary bins/elf/analysis/pie
+oodf gdb://127.0.0.1:12345
+fs test
+f testflag @ main+10
+?v `f~testflag[0]`-`e bin.baddr`
+doc
+?v `f~testflag[0]`-`e bin.baddr`
+EOF
+EXPECT=<<EOF
+0x5cf
+0x5cf
+EOF
+RUN
+
+NAME=var rebase
+FILE=bins/elf/hello_world
+CMDS=<<EOF
+aa
+!scripts/gdbserver.py --port 12344 --binary bins/elf/hello_world
+oodf gdb://127.0.0.1:12344
+afv @ main
+doc
+afv @ main
+EOF
+EXPECT=<<EOF
+var int64_t var_20h @ rbp-0x20
+var int64_t var_1ch @ rbp-0x1c
+var int64_t var_18h @ rbp-0x18
+var int64_t var_10h @ rbp-0x10
+var int64_t var_8h @ rbp-0x8
+var int64_t var_20h @ rbp-0x20
+var int64_t var_1ch @ rbp-0x1c
+var int64_t var_18h @ rbp-0x18
+var int64_t var_10h @ rbp-0x10
+var int64_t var_8h @ rbp-0x8
+EOF
+RUN

--- a/test/scripts/gdbserver.py
+++ b/test/scripts/gdbserver.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+r"""
+This script launches gdbserver in a subprocess and waits until it's ready to receive
+a new connection since it's not possible to know if gdbserver is ready to connect
+to with `oodf` after executing it as a background task using `& !gdbserver ...`.
+Example usage in a test:
+
+  !scripts/gdbserver.py --port PORT --binary bins/elf/analysis/calls_x64
+
+It's important to note that PORT has to be unique for each test since all tests
+run in parallel and may attempt to open the same port at the same time.
+
+"""
+
+import argparse
+import subprocess
+import os
+
+def execute(cmd):
+    popen = subprocess.Popen(cmd, stderr=subprocess.PIPE, universal_newlines=True)
+    for stderr_line in iter(popen.stderr.readline, ""):
+        yield stderr_line
+
+def main():
+    parser = argparse.ArgumentParser(description=
+            "Run gdbserver in a new process with the given arguments and exit "
+            "once gdbserver is ready for new connections")
+    parser.add_argument('--host', default='127.0.0.1')
+    parser.add_argument('--port', default='1234')
+    parser.add_argument('--binary', default='')
+    parser.add_argument('--output', default=False, action='store_true',
+            help='print stdout output from gdbserver')
+    args = parser.parse_args()
+
+    while True:
+        for output in execute(["gdbserver", "{}:{}".format(args.host, args.port), args.binary]):
+            if args.output:
+                print(output)
+            # Exit once gdbserver is ready for connections
+            if "Listening on port" in output:
+                exit(0)
+            # gdbserver might fail to start if the port is taken
+            if "Can't bind address" in output:
+                print(output)
+                exit(1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Initial test support for gdbserver. 
I added `test/scripts/gdbserver.py` since it's not possible to know if gdbserver is ready to connect to with `oodf` after executing gdbserver as a background task using `& !gdbserver ...`. We can expand on this script in the future to verify the packets we send to the server with gdbserver's `--remote-debug`.

Since tests run in parallel each test has to have a unique gdbserver port. I only documented it in the script itself since it doesn't really fit into the README.

**Test plan**

Green CI