### PR TITLE
Refactor some parts of vmenus to use more API ##refactor

### DIFF
--- a/librz/core/cautocmpl.c
+++ b/librz/core/cautocmpl.c
@@ -201,7 +201,7 @@ static void autocmplt_cmd_arg_fcn(RzCore *core, RzLineNSCompletionResult *res, c
 }
 
 static void autocmplt_cmd_arg_help_var(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
-	const char **vars = rz_core_get_help_vars(core);
+	const char **vars = rz_core_help_vars_get(core);
 	while (*vars) {
 		if (!strncmp(*vars, s, len)) {
 			rz_line_ns_completion_result_add(res, *vars);

--- a/librz/core/cmd_help.c
+++ b/librz/core/cmd_help.c
@@ -416,7 +416,7 @@ enum {
 /**
  * \brief Returns all the $ variable names in a NULL-terminated array.
  */
-RZ_API const char **rz_core_get_help_vars(RzCore *core) {
+RZ_API const char **rz_core_help_vars_get(RzCore *core) {
 	static const char *vars[] = {
 		"$$", "$$$", "$?", "$B", "$b", "$c", "$Cn", "$D", "$DB", "$DD", "$Dn",
 		"$e", "$f", "$F", "$Fb", "$FB", "$Fe", "$FE", "$Ff", "$Fi", "$FI", "$Fj",
@@ -428,7 +428,7 @@ RZ_API const char **rz_core_get_help_vars(RzCore *core) {
 
 RZ_API void rz_core_help_vars_print(RzCore *core) {
 	int i = 0;
-	const char **vars = rz_core_get_help_vars(core);
+	const char **vars = rz_core_help_vars_get(core);
 	const bool wideOffsets = rz_config_get_i(core->config, "scr.wideoff");
 	while (vars[i]) {
 		const char *pad = rz_str_pad(' ', 6 - strlen(vars[i]));

--- a/librz/core/cmd_help.c
+++ b/librz/core/cmd_help.c
@@ -426,6 +426,21 @@ RZ_API const char **rz_core_get_help_vars(RzCore *core) {
 	return vars;
 }
 
+RZ_API void rz_core_eval_variables_print(RzCore *core) {
+	int i = 0;
+	const char **vars = rz_core_get_help_vars(core);
+	const bool wideOffsets = rz_config_get_i(core->config, "scr.wideoff");
+	while (vars[i]) {
+		const char *pad = rz_str_pad(' ', 6 - strlen(vars[i]));
+		if (wideOffsets) {
+			eprintf("%s %s 0x%016" PFMT64x "\n", vars[i], pad, rz_num_math(core->num, vars[i]));
+		} else {
+			eprintf("%s %s 0x%08" PFMT64x "\n", vars[i], pad, rz_num_math(core->num, vars[i]));
+		}
+		i++;
+	}
+}
+
 RZ_API void rz_core_clippy(RzCore *core, const char *msg) {
 	int type = RZ_AVATAR_CLIPPY;
 	if (*msg == '+' || *msg == '3') {
@@ -841,18 +856,7 @@ RZ_IPI int rz_cmd_help(void *data, const char *input) {
 		if (input[1] == '?') {
 			rz_core_cmd_help(core, help_msg_question_v);
 		} else {
-			int i = 0;
-			const char **vars = rz_core_get_help_vars(core);
-			const bool wideOffsets = rz_config_get_i(core->config, "scr.wideoff");
-			while (vars[i]) {
-				const char *pad = rz_str_pad(' ', 6 - strlen(vars[i]));
-				if (wideOffsets) {
-					eprintf("%s %s 0x%016" PFMT64x "\n", vars[i], pad, rz_num_math(core->num, vars[i]));
-				} else {
-					eprintf("%s %s 0x%08" PFMT64x "\n", vars[i], pad, rz_num_math(core->num, vars[i]));
-				}
-				i++;
-			}
+			rz_core_eval_variables_print(core);
 		}
 		return true;
 	case 'V': // "?V"

--- a/librz/core/cmd_help.c
+++ b/librz/core/cmd_help.c
@@ -426,7 +426,7 @@ RZ_API const char **rz_core_get_help_vars(RzCore *core) {
 	return vars;
 }
 
-RZ_API void rz_core_eval_variables_print(RzCore *core) {
+RZ_API void rz_core_help_vars_print(RzCore *core) {
 	int i = 0;
 	const char **vars = rz_core_get_help_vars(core);
 	const bool wideOffsets = rz_config_get_i(core->config, "scr.wideoff");
@@ -856,7 +856,7 @@ RZ_IPI int rz_cmd_help(void *data, const char *input) {
 		if (input[1] == '?') {
 			rz_core_cmd_help(core, help_msg_question_v);
 		} else {
-			rz_core_eval_variables_print(core);
+			rz_core_help_vars_print(core);
 		}
 		return true;
 	case 'V': // "?V"

--- a/librz/core/vmenus.c
+++ b/librz/core/vmenus.c
@@ -2434,7 +2434,7 @@ RZ_API void rz_core_visual_config(RzCore *core) {
 			option = _option;
 			break;
 		case '$':
-			rz_core_cmd0(core, "?$");
+			rz_core_eval_variables_print(core);
 			rz_cons_any_key(NULL);
 			break;
 		case '*':
@@ -3109,7 +3109,7 @@ RZ_API void rz_core_visual_analysis(RzCore *core, const char *input) {
 			delta = 0;
 			break;
 		case 'R':
-			rz_core_cmd0(core, "ecn");
+			rz_core_theme_nextpal(core, 'n');
 			break;
 		case 'p':
 			printMode++;
@@ -3884,11 +3884,11 @@ RZ_API void rz_core_visual_colors(RzCore *core) {
 			opt++;
 			break;
 		case 'l':
-			rz_core_cmd0(core, "ecn");
+			rz_core_theme_nextpal(core, 'n');
 			oopt = -1;
 			break;
 		case 'h':
-			rz_core_cmd0(core, "ecp");
+			rz_core_theme_nextpal(core, 'p');
 			oopt = -1;
 			break;
 		case 'K':

--- a/librz/core/vmenus.c
+++ b/librz/core/vmenus.c
@@ -2434,7 +2434,7 @@ RZ_API void rz_core_visual_config(RzCore *core) {
 			option = _option;
 			break;
 		case '$':
-			rz_core_eval_variables_print(core);
+			rz_core_help_vars_print(core);
 			rz_cons_any_key(NULL);
 			break;
 		case '*':

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -453,7 +453,7 @@ RZ_API void rz_core_autocomplete(RZ_NULLABLE RzCore *core, RzLineCompletion *com
 RZ_API RzLineNSCompletionResult *rz_core_autocomplete_newshell(RzCore *core, RzLineBuffer *buf, RzLinePromptType prompt_type);
 RZ_API void rz_core_print_scrollbar(RzCore *core);
 RZ_API void rz_core_print_scrollbar_bottom(RzCore *core);
-RZ_API void rz_core_eval_variables_print(RzCore *core);
+RZ_API void rz_core_help_vars_print(RzCore *core);
 RZ_API void rz_core_visual_prompt_input(RzCore *core);
 RZ_API void rz_core_visual_toggle_hints(RzCore *core);
 RZ_API void rz_core_visual_toggle_decompiler_disasm(RzCore *core, bool for_graph, bool reset);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -819,7 +819,7 @@ RZ_API char *rz_str_widget_list(void *user, RzList *list, int rows, int cur, Pri
 RZ_API PJ *rz_core_pj_new(RzCore *core);
 /* help */
 RZ_API void rz_core_cmd_help(const RzCore *core, const char *help[]);
-RZ_API const char **rz_core_get_help_vars(RzCore *core);
+RZ_API const char **rz_core_help_vars_get(RzCore *core);
 
 /* analysis stats */
 

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -453,6 +453,7 @@ RZ_API void rz_core_autocomplete(RZ_NULLABLE RzCore *core, RzLineCompletion *com
 RZ_API RzLineNSCompletionResult *rz_core_autocomplete_newshell(RzCore *core, RzLineBuffer *buf, RzLinePromptType prompt_type);
 RZ_API void rz_core_print_scrollbar(RzCore *core);
 RZ_API void rz_core_print_scrollbar_bottom(RzCore *core);
+RZ_API void rz_core_eval_variables_print(RzCore *core);
 RZ_API void rz_core_visual_prompt_input(RzCore *core);
 RZ_API void rz_core_visual_toggle_hints(RzCore *core);
 RZ_API void rz_core_visual_toggle_decompiler_disasm(RzCore *core, bool for_graph, bool reset);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This commit replaces all instances where `ecn` and `ecp`
were called using `rz_core_cmd0 `, with their corresponding APIs.

Also created a new API `rz_core_help_vars_print` to handle
the command `?$`

Renames `rz_core_get_help_vars` -> ` rz_core_help_vars_get`

**Test plan**

- [x]  Make sure that `rz_core_help_vars_print()` works and is put in the right place.

**Closing issues**

Related to #491
