### PR TITLE
Use portable Format for Graph Metrics in Zignatures

### DIFF
--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -51,7 +51,7 @@ RZ_API char *rz_str_sanitize_sdb_key(const char *s);
 RZ_API const char *rz_str_casestr(const char *a, const char *b);
 RZ_API const char *rz_str_firstbut(const char *s, char ch, const char *but);
 RZ_API const char *rz_str_lastbut(const char *s, char ch, const char *but);
-RZ_API int rz_str_split(char *str, char ch);
+RZ_API size_t rz_str_split(char *str, char ch);
 RZ_API RzList *rz_str_split_list(char *str, const char *c, int n);
 RZ_API RzList *rz_str_split_duplist(const char *str, const char *c, bool trim);
 RZ_API RzList *rz_str_split_duplist_n(const char *str, const char *c, int n, bool trim);
@@ -102,6 +102,9 @@ RZ_API int rz_str_char_count(const char *string, char ch);
 RZ_API char *rz_str_word_get0set(char *stra, int stralen, int idx, const char *newstr, int *newlen);
 RZ_API int rz_str_word_set0(char *str);
 RZ_API int rz_str_word_set0_stack(char *str);
+static inline const char *rz_str_word_get_next0(const char *str) {
+	return str + strlen(str) + 1;
+}
 RZ_API const char *rz_str_word_get0(const char *str, int idx);
 RZ_API char *rz_str_word_get_first(const char *string);
 RZ_API void rz_str_trim(char *str);

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -328,9 +328,9 @@ RZ_API int rz_str_delta(char *p, char a, char b) {
  * Replaces all instances of \p ch in \p str with a NULL byte and it returns
  * the number of split strings.
  */
-RZ_API int rz_str_split(char *str, char ch) {
+RZ_API size_t rz_str_split(char *str, char ch) {
 	rz_return_val_if_fail(str, 0);
-	int i;
+	size_t i;
 	char *p;
 	for (i = 1, p = str; *p; p++) {
 		if (*p == ch) {
@@ -524,10 +524,10 @@ RZ_API const char *rz_str_word_get0(const char *str, int idx) {
 	int i;
 	const char *ptr = str;
 	if (!ptr || idx < 0 /* prevent crashes with negative index */) {
-		return (char *)nullstr;
+		return nullstr;
 	}
 	for (i = 0; i != idx; i++) {
-		ptr += strlen(ptr) + 1;
+		ptr = rz_str_word_get_next0(ptr);
 	}
 	return ptr;
 }

--- a/test/unit/test_serialize_analysis.c
+++ b/test/unit/test_serialize_analysis.c
@@ -1434,7 +1434,7 @@ Sdb *sign_ref_db() {
 	sdb_set(spaces, "name", "zs", 0);
 	Sdb *spaces_spaces = sdb_ns(spaces, "spaces", true);
 	sdb_set(spaces_spaces, "koridai", "s", 0);
-	sdb_set(db, "zign|*|sym.mahboi", "|s:4|b:deadbeef|m:c0ffee42|o:4919|g:7b0000000b0000000c0000000d0000002a000000|r:gwonam,link|x:king,ganon|v:r16,s42,b13|t:func.sym.mahboi.ret=char *,func.sym.mahboi.args=2,func.sym.mahboi.arg.0=\"int,arg0\",func.sym.mahboi.arg.1=\"uint32_t,die\"|c:This peace is what all true warriors strive for|n:sym.Mah.Boi|h:7bfa1358c427e26bc03c2384f41de7be6ebc01958a57e9a6deda5bdba9768851", 0);
+	sdb_set(db, "zign|*|sym.mahboi", "|s:4|b:deadbeef|m:c0ffee42|o:4919|g:123,11,12,13,42|r:gwonam,link|x:king,ganon|v:r16,s42,b13|t:func.sym.mahboi.ret=char *,func.sym.mahboi.args=2,func.sym.mahboi.arg.0=\"int,arg0\",func.sym.mahboi.arg.1=\"uint32_t,die\"|c:This peace is what all true warriors strive for|n:sym.Mah.Boi|h:7bfa1358c427e26bc03c2384f41de7be6ebc01958a57e9a6deda5bdba9768851", 0);
 	sdb_set(db, "zign|koridai|sym.boring", "|c:gee it sure is boring around here", 0);
 	return db;
 }

--- a/test/unit/test_str.c
+++ b/test/unit/test_str.c
@@ -149,7 +149,7 @@ bool test_rz_str_case(void) {
 
 bool test_rz_str_split(void) {
 	char *hi = strdup("hello world");
-	int r = rz_str_split(hi, ' ');
+	size_t r = rz_str_split(hi, ' ');
 	mu_assert_eq(r, 2, "split on space");
 	char *hello = hi;
 	char *world = hi + 6;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Old: `g:7b0000000b0000000c0000000d0000002a000000`
New: `g:123,11,12,13,42`

**Test plan**

See projects unit tests

**Closing issues**

For #279 but not closing