### PR TITLE
Add rz_strf() Macro

### DIFF
--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -19,6 +19,25 @@ typedef enum {
 	RZ_STRING_ENC_GUESS = 'g',
 } RzStrEnc;
 
+/**
+ * \brief Convenience macro for local temporary strings
+ * \param buf Target buffer, **must** be an array type, not a pointer.
+ *
+ * This eases the common pattern where a stack-allocated string of a fixed
+ * size is created and filled with `snprintf()` to be used as a temporary string.
+ *
+ * Example:
+ *
+ *     char k[32];
+ *     char v[32];
+ *     sdb_set(db, rz_strf(k, "key.%d", 42), rz_strf(v, "val.%d", 123));
+ */
+#define rz_strf(buf, ...) ( \
+	snprintf(buf, sizeof(buf), __VA_ARGS__) < 0 \
+		? rz_assert_log(RZ_LOGLVL_FATAL, "rz_strf error while using snprintf"), NULL \
+		: buf \
+)
+
 typedef int (*RzStrRangeCallback)(void *, int);
 
 #define RZ_STR_ISEMPTY(x)    (!(x) || !*(x))

--- a/meson.build
+++ b/meson.build
@@ -120,6 +120,11 @@ elif cc.has_argument('--std=c99')
   add_project_arguments('--std=c99', language: ['c', 'cpp'])
 endif
 
+# Sanitize correct usage of rz_strf()
+if cc.has_argument('-Werror=sizeof-pointer-memaccess')
+  add_global_arguments('-Werror=sizeof-pointer-memaccess', language: ['c', 'cpp'])
+endif
+
 if cc.get_id() == 'clang-cl'
   add_project_arguments('-fcommon', language: 'c')
   add_project_arguments('-D__STDC__=1', language: 'c')

--- a/test/unit/test_str.c
+++ b/test/unit/test_str.c
@@ -612,6 +612,22 @@ bool test_rz_str_encoded_json(void) {
 	mu_end;
 }
 
+bool test_rz_strf(void) {
+#if 1
+	char *illegle = NULL;
+	rz_strf(illegle, "this should trigger gcc's -Werror=sizeof-pointer-memaccess");
+#endif
+	char bufa[0x100];
+	char bufb[0x100];
+	char *resa = rz_strf(bufa, "Hello");
+	char *resb = rz_strf(bufb, "World %d", 42);
+	mu_assert_ptreq(resa, bufa, "rz_strf ptr");
+	mu_assert_streq(resa, "Hello", "rz_strf string");
+	mu_assert_ptreq(resb, bufb, "rz_strf ptr");
+	mu_assert_streq(resb, "World 42", "rz_strf string");
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_rz_str_newf);
 	mu_run_test(test_rz_str_replace_char_once);
@@ -646,6 +662,7 @@ bool all_tests() {
 	mu_run_test(test_rz_str_str_xy);
 	mu_run_test(test_rz_str_wrap);
 	mu_run_test(test_rz_str_encoded_json);
+	mu_run_test(test_rz_strf);
 	return tests_passed != tests_run;
 }
 

--- a/test/unit/test_str.c
+++ b/test/unit/test_str.c
@@ -613,7 +613,7 @@ bool test_rz_str_encoded_json(void) {
 }
 
 bool test_rz_strf(void) {
-#if 1
+#if 0
 	char *illegle = NULL;
 	rz_strf(illegle, "this should trigger gcc's -Werror=sizeof-pointer-memaccess");
 #endif


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Convenience macro for local temporary strings
\param buf Target buffer, **must** be an array type, not a pointer.

This eases the common pattern where a stack-allocated string of a fixed
size is created and filled with `snprintf()` to be used as a temporary string.
 
Example:
```c
char k[32];
char v[32];
sdb_set(db, rz_strf(k, "key.%d", 42), rz_strf(v, "val.%d", 123));
```


**Test plan**

see unit tests
