### PR TITLE
Fix assert on base64 crypto final call without buf

### DIFF
--- a/librz/crypto/p/crypto_base64.c
+++ b/librz/crypto/p/crypto_base64.c
@@ -46,6 +46,9 @@ static bool update(RzCrypto *cry, const ut8 *buf, int len) {
 }
 
 static bool final(RzCrypto *cry, const ut8 *buf, int len) {
+	if (!buf) {
+		return true;
+	}
 	return update(cry, buf, len);
 }
 

--- a/test/db/tools/rz_hash
+++ b/test/db/tools/rz_hash
@@ -83,18 +83,21 @@ NAME=rz-hash -D base64 -s "YWRtaW4="
 FILE=-
 CMDS=!rz-hash -D base64 -s "YWRtaW4="
 EXPECT=admin
+EXPECT_ERR=
 RUN
 
 NAME=rz-hash -E base64 -s "admin"
 FILE=-
 CMDS=!rz-hash -E base64 -s "admin"
 EXPECT=YWRtaW4=
+EXPECT_ERR=
 RUN
 
 NAME=rz-hash -E base64 -x "61646d696e"
 FILE=-
 CMDS=!rz-hash -E base64 -x "61646d696e"
 EXPECT=YWRtaW4=
+EXPECT_ERR=
 RUN
 
 NAME=rz-hash -a md5 -x "61646d696e"


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fix for https://travis-ci.com/github/rizinorg/rizin/jobs/480056657#L2661
Calling with NULL buf is legal here to finalize the crypto without appending more data.

**Test plan**

see rz-test tests