### PR TITLE
Refactor to use API in visual mode

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
+#include <string.h>
+
 #include <rz_types.h>
 #include <rz_list.h>
 #include <rz_flag.h>
@@ -8,7 +10,7 @@
 #include <ht_uu.h>
 #include <rz_util/rz_graph_drawable.h>
 
-#include <string.h>
+#include "core_private.h"
 
 HEAPTYPE(ut64);
 
@@ -359,6 +361,58 @@ RZ_API ut64 rz_core_analysis_address(RzCore *core, ut64 addr) {
 		}
 	}
 	return types;
+}
+
+RZ_IPI int rz_core_analysis_set_reg(RzCore *core, const char *regname, ut64 val) {
+	int bits = (core->analysis->bits & RZ_SYS_BITS_64) ? 64 : 32;
+	RzRegItem *r = rz_reg_get(core->dbg->reg, regname, -1);
+	if (!r) {
+		int role = rz_reg_get_name_idx(regname);
+		if (role != -1) {
+			const char *alias = rz_reg_get_name(core->dbg->reg, role);
+			if (alias) {
+				r = rz_reg_get(core->dbg->reg, alias, -1);
+			}
+		}
+	}
+	if (!r) {
+		eprintf("ar: Unknown register '%s'\n", regname);
+		return -1;
+	}
+	rz_reg_set_value(core->dbg->reg, r, val);
+	rz_debug_reg_sync(core->dbg, RZ_REG_TYPE_ALL, true);
+	rz_core_debug_regs2flags(core, bits);
+	return 0;
+}
+
+RZ_IPI void rz_core_analysis_esil_init(RzCore *core) {
+	RzAnalysisEsil *esil = core->analysis->esil;
+	unsigned int addrsize = rz_config_get_i(core->config, "esil.addr.size");
+	int stacksize = rz_config_get_i(core->config, "esil.stack.depth");
+	int iotrap = rz_config_get_i(core->config, "esil.iotrap");
+	int romem = rz_config_get_i(core->config, "esil.romem");
+	int stats = rz_config_get_i(core->config, "esil.stats");
+	int noNULL = rz_config_get_i(core->config, "esil.noNULL");
+
+	rz_analysis_esil_free(esil);
+	// reinitialize
+	const char *pc = rz_reg_get_name(core->analysis->reg, RZ_REG_NAME_PC);
+	if (pc && rz_reg_getv(core->analysis->reg, pc) == 0LL) {
+		rz_core_analysis_set_reg(core, "PC", core->offset);
+	}
+	if (!(esil = core->analysis->esil = rz_analysis_esil_new(stacksize, iotrap, addrsize))) {
+		return;
+	}
+	rz_analysis_esil_setup(esil, core->analysis, romem, stats, noNULL); // setup io
+	esil->verbose = (int)rz_config_get_i(core->config, "esil.verbose");
+	const char *s = rz_config_get(core->config, "cmd.esil.intr");
+	if (s) {
+		char *my = strdup(s);
+		if (my) {
+			rz_config_set(core->config, "cmd.esil.intr", my);
+			free(my);
+		}
+	}
 }
 
 static bool blacklisted_word(char *name) {
@@ -6063,4 +6117,34 @@ RZ_API void rz_core_analysis_esil_graph(RzCore *core, const char *expr) {
 	}
 
 	rz_analysis_esil_dfg_free(edf);
+}
+
+RZ_IPI bool rz_core_analysis_var_rename(RzCore *core, const char *name, const char *newname) {
+	RzAnalysisOp *op = rz_core_analysis_op(core, core->offset, RZ_ANALYSIS_OP_MASK_BASIC);
+	if (!name) {
+		RzAnalysisVar *var = op ? rz_analysis_get_used_function_var(core->analysis, op->addr) : NULL;
+		if (var) {
+			name = var->name;
+		} else {
+			eprintf("Cannot find var @ 0x%08" PFMT64x "\n", core->offset);
+			rz_analysis_op_free(op);
+			return false;
+		}
+	}
+	RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(core->analysis, core->offset, -1);
+	if (fcn) {
+		RzAnalysisVar *v1 = rz_analysis_function_get_var_byname(fcn, name);
+		if (v1) {
+			rz_analysis_var_rename(v1, newname, true);
+		} else {
+			eprintf("Cant find var by name\n");
+			return false;
+		}
+	} else {
+		eprintf("afv: Cannot find function in 0x%08" PFMT64x "\n", core->offset);
+		rz_analysis_op_free(op);
+		return false;
+	}
+	rz_analysis_op_free(op);
+	return true;
 }

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -199,6 +199,38 @@ RZ_IPI void rz_core_debug_regs2flags(RzCore *core, int bits) {
 	}
 }
 
+RZ_IPI bool rz_core_debug_reg_set(RzCore *core, const char *regname, ut64 val, const char *strval) {
+	int bits = (core->dbg->bits & RZ_SYS_BITS_64) ? 64 : 32;
+	RzRegItem *r = rz_reg_get(core->dbg->reg, regname, -1);
+	if (!r) {
+		int role = rz_reg_get_name_idx(regname);
+		if (role != -1) {
+			const char *alias = rz_reg_get_name(core->dbg->reg, role);
+			if (alias) {
+				r = rz_reg_get(core->dbg->reg, alias, -1);
+			}
+		}
+	}
+	if (!r) {
+		eprintf("Unknown register '%s'\n", regname);
+		return false;
+	}
+
+	if (r->flags) {
+		if (strval) {
+			rz_reg_set_bvalue(core->dbg->reg, r, strval);
+		} else {
+			eprintf("String value cannot be NULL\n");
+			return false;
+		}
+	} else {
+		rz_reg_set_value(core->dbg->reg, r, val);
+	}
+	rz_debug_reg_sync(core->dbg, RZ_REG_TYPE_ALL, true);
+	rz_core_debug_regs2flags(core, bits);
+	return true;
+}
+
 RZ_IPI bool rz_core_debug_reg_list(RzCore *core, int type, int size, PJ *pj, int rad, const char *use_color) {
 	RzDebug *dbg = core->dbg;
 	int delta, cols, n = 0;
@@ -406,4 +438,76 @@ beach:
 		rz_cons_printf("\n");
 	}
 	return n != 0;
+}
+
+HEAPTYPE(ut64);
+
+static int regcmp(const void *a, const void *b) {
+	const ut64 *A = (const ut64 *)a;
+	const ut64 *B = (const ut64 *)b;
+	if (*A > *B) {
+		return 1;
+	}
+	if (*A == *B) {
+		return 0;
+	}
+	return -1;
+}
+
+static bool regcb(void *u, const ut64 k, const void *v) {
+	RzList *sorted = (RzList *)u;
+	ut64 *n = ut64_new(k);
+	rz_list_add_sorted(sorted, n, regcmp);
+	return true;
+}
+
+RZ_API void rz_core_debug_ri(RzCore *core, RzReg *reg, int mode) {
+	const RzList *list = rz_reg_get_list(reg, RZ_REG_TYPE_GPR);
+	RzListIter *iter;
+	RzRegItem *r;
+	HtUP *db = ht_up_new0();
+
+	rz_list_foreach (list, iter, r) {
+		if (r->size != core->rasm->bits) {
+			continue;
+		}
+		ut64 value = rz_reg_get_value(reg, r);
+		RzList *list = ht_up_find(db, value, NULL);
+		if (!list) {
+			list = rz_list_newf(NULL);
+			ht_up_update(db, value, list);
+		}
+		rz_list_append(list, r->name);
+	}
+
+	RzList *sorted = rz_list_newf(free);
+	ht_up_foreach(db, regcb, sorted);
+	ut64 *addr;
+	rz_list_foreach (sorted, iter, addr) {
+		int rwx = 0;
+		RzDebugMap *map = rz_debug_map_get(core->dbg, *addr);
+		if (map) {
+			rwx = map->perm;
+		}
+		rz_cons_printf(" %s  ", rz_str_rwx_i(rwx));
+
+		rz_cons_printf("0x%08" PFMT64x " ", *addr);
+		RzList *list = ht_up_find(db, *addr, NULL);
+		if (list) {
+			RzListIter *iter;
+			const char *r;
+			rz_cons_strcat(Color_YELLOW);
+			rz_list_foreach (list, iter, r) {
+				rz_cons_printf(" %s", r);
+			}
+			rz_cons_strcat(Color_RESET);
+			char *rrstr = rz_core_analysis_hasrefs(core, *addr, true);
+			if (rrstr && *rrstr && strchr(rrstr, 'R')) {
+				rz_cons_printf("    ;%s" Color_RESET, rrstr);
+			}
+			rz_cons_newline();
+		}
+	}
+	rz_list_free(sorted);
+	ht_up_free(db);
 }

--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -1809,78 +1809,6 @@ static int cmd_debug_map(RzCore *core, const char *input) {
 #include "windows_heap.c"
 #endif
 
-HEAPTYPE(ut64);
-
-static int regcmp(const void *a, const void *b) {
-	const ut64 *A = (const ut64 *)a;
-	const ut64 *B = (const ut64 *)b;
-	if (*A > *B) {
-		return 1;
-	}
-	if (*A == *B) {
-		return 0;
-	}
-	return -1;
-}
-
-static bool regcb(void *u, const ut64 k, const void *v) {
-	RzList *sorted = (RzList *)u;
-	ut64 *n = ut64_new(k);
-	rz_list_add_sorted(sorted, n, regcmp);
-	return true;
-}
-
-RZ_API void rz_core_debug_ri(RzCore *core, RzReg *reg, int mode) {
-	const RzList *list = rz_reg_get_list(reg, RZ_REG_TYPE_GPR);
-	RzListIter *iter;
-	RzRegItem *r;
-	HtUP *db = ht_up_new0();
-
-	rz_list_foreach (list, iter, r) {
-		if (r->size != core->rasm->bits) {
-			continue;
-		}
-		ut64 value = rz_reg_get_value(reg, r);
-		RzList *list = ht_up_find(db, value, NULL);
-		if (!list) {
-			list = rz_list_newf(NULL);
-			ht_up_update(db, value, list);
-		}
-		rz_list_append(list, r->name);
-	}
-
-	RzList *sorted = rz_list_newf(free);
-	ht_up_foreach(db, regcb, sorted);
-	ut64 *addr;
-	rz_list_foreach (sorted, iter, addr) {
-		int rwx = 0;
-		RzDebugMap *map = rz_debug_map_get(core->dbg, *addr);
-		if (map) {
-			rwx = map->perm;
-		}
-		rz_cons_printf(" %s  ", rz_str_rwx_i(rwx));
-
-		rz_cons_printf("0x%08" PFMT64x " ", *addr);
-		RzList *list = ht_up_find(db, *addr, NULL);
-		if (list) {
-			RzListIter *iter;
-			const char *r;
-			rz_cons_strcat(Color_YELLOW);
-			rz_list_foreach (list, iter, r) {
-				rz_cons_printf(" %s", r);
-			}
-			rz_cons_strcat(Color_RESET);
-			char *rrstr = rz_core_analysis_hasrefs(core, *addr, true);
-			if (rrstr && *rrstr && strchr(rrstr, 'R')) {
-				rz_cons_printf("    ;%s" Color_RESET, rrstr);
-			}
-			rz_cons_newline();
-		}
-	}
-	rz_list_free(sorted);
-	ht_up_free(db);
-}
-
 static void foreach_reg_set_or_clear(RzCore *core, bool set) {
 	RzReg *reg = rz_config_get_i(core->config, "cfg.debug")
 		? core->dbg->reg
@@ -2899,35 +2827,11 @@ static void cmd_debug_reg(RzCore *core, const char *str) {
 		arg = strchr(str + 1, '=');
 		if (arg) {
 			*arg = 0;
-			char *string = rz_str_trim_dup(str + 1);
-			const char *regname = rz_reg_get_name(core->dbg->reg, rz_reg_get_name_idx(string));
-			if (!regname) {
-				regname = string;
-			}
-			r = rz_reg_get(core->dbg->reg, regname, -1); //RZ_REG_TYPE_GPR);
-			if (r) {
-				if (r->flags) {
-					rz_cons_printf("0x%08" PFMT64x " ->",
-						rz_reg_get_value(core->dbg->reg, r));
-					rz_reg_set_bvalue(core->dbg->reg, r, arg + 1);
-					rz_debug_reg_sync(core->dbg, RZ_REG_TYPE_ALL, true);
-					rz_cons_printf("0x%08" PFMT64x "\n",
-						rz_reg_get_value(core->dbg->reg, r));
-				} else {
-					rz_cons_printf("0x%08" PFMT64x " ->",
-						rz_reg_get_value(core->dbg->reg, r));
-					rz_reg_set_value(core->dbg->reg, r,
-						rz_num_math(core->num, arg + 1));
-					rz_debug_reg_sync(core->dbg, RZ_REG_TYPE_ALL, true);
-					rz_cons_printf("0x%08" PFMT64x "\n",
-						rz_reg_get_value(core->dbg->reg, r));
-				}
-			} else {
-				eprintf("unknown register '%s'\n", string);
-			}
-			free(string);
-			// update flags here
-			rz_core_debug_regs2flags(core, bits);
+			char *ostr = rz_str_trim_dup(str + 1);
+			char *regname = rz_str_trim_nc(ostr);
+			ut64 regval = rz_num_math(core->num, arg + 1);
+			rz_core_debug_reg_set(core, regname, regval, ostr);
+			free(ostr);
 			return;
 		}
 

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -6,6 +6,10 @@
 
 RZ_IPI int rz_core_analysis_set_reg(RzCore *core, const char *regname, ut64 val);
 RZ_IPI void rz_core_analysis_esil_init(RzCore *core);
+RZ_IPI bool rz_core_analysis_var_rename(RzCore *core, const char *name, const char *newname);
+
+/* cdebug.c */
+RZ_IPI bool rz_core_debug_reg_set(RzCore *core, const char *regname, ut64 val, const char *strval);
 RZ_IPI bool rz_core_debug_reg_list(RzCore *core, int type, int size, PJ *pj, int rad, const char *use_color);
 RZ_IPI void rz_core_debug_regs2flags(RzCore *core, int bits);
 RZ_IPI void rz_core_regs2flags(RzCore *core);

--- a/librz/core/visual.c
+++ b/librz/core/visual.c
@@ -1325,7 +1325,7 @@ static void addComment(RzCore *core, ut64 addr) {
 	if (rz_cons_fgets(buf, sizeof(buf), 0, NULL) < 0) {
 		buf[0] = '\0';
 	}
-	rz_core_cmdf(core, "\"CC %s\"@0x%08" PFMT64x, buf, addr);
+	rz_meta_set_string(core->analysis, RZ_META_TYPE_COMMENT, addr, buf);
 	rz_core_visual_showcursor(core, false);
 	rz_cons_set_raw(true);
 }
@@ -2524,9 +2524,9 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 			break;
 		case '$':
 			if (core->print->cur_enabled) {
-				rz_core_cmdf(core, "dr PC=$$+%d", core->print->cur);
+				rz_core_debug_reg_set(core, "PC", core->offset + core->print->cur, NULL);
 			} else {
-				rz_core_cmd0(core, "dr PC=$$");
+				rz_core_debug_reg_set(core, "PC", core->offset, NULL);
 			}
 			break;
 		case '@':
@@ -2572,11 +2572,16 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 				if (!strcmp(n, "-")) {
 					rz_flag_unset_off(core->flags, core->offset + core->print->cur);
 				} else if (*n == '.') {
-					if (n[1] == '-') {
-						//unset
-						rz_core_cmdf(core, "f.-%s@0x%" PFMT64x, n + 1, core->offset + min);
+					RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(core->analysis, core->offset + min, 0);
+					if (fcn) {
+						if (n[1] == '-') {
+							// Unset the local label (flag)
+							rz_analysis_function_delete_label(fcn, n + 1);
+						} else {
+							rz_analysis_function_set_label(fcn, n + 1, core->offset + min);
+						}
 					} else {
-						rz_core_cmdf(core, "f.%s@0x%" PFMT64x, n + 1, core->offset + min);
+						eprintf("Cannot find function at 0x%08" PFMT64x "\n", core->offset + min);
 					}
 				} else if (*n == '-') {
 					if (*n) {
@@ -2587,15 +2592,13 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 						range = 1;
 					}
 					if (*n) {
-						rz_flag_set(core->flags, n,
-							core->offset + min, range);
+						rz_flag_set(core->flags, n, core->offset + min, range);
 					}
 				}
 			}
 			rz_cons_enable_mouse(mouse_state && rz_config_get_b(core->config, "scr.wheel"));
-		}
 			rz_core_visual_showcursor(core, false);
-			break;
+		} break;
 		case ',':
 			visual_comma(core);
 			break;
@@ -2771,25 +2774,21 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 			visual_refresh(core);
 			break;
 		case ' ':
-		case 'V':
-			if (rz_config_get_b(core->config, "graph.web")) {
-				rz_core_cmd0(core, "agv $$");
-			} else {
-				RzAnalysisFunction *fun = rz_analysis_get_fcn_in(core->analysis, core->offset, RZ_ANALYSIS_FCN_TYPE_NULL);
-				int ocolor = rz_config_get_i(core->config, "scr.color");
-				if (!fun) {
-					rz_cons_message("Not in a function. Type 'df' to define it here");
-					break;
-				} else if (rz_list_empty(fun->bbs)) {
-					rz_cons_message("No basic blocks in this function. You may want to use 'afb+'.");
-					break;
-				}
-				reset_print_cur(core->print);
-				eprintf("\rRendering graph...");
-				rz_core_visual_graph(core, NULL, NULL, true);
-				rz_config_set_i(core->config, "scr.color", ocolor);
+		case 'V': {
+			RzAnalysisFunction *fun = rz_analysis_get_fcn_in(core->analysis, core->offset, RZ_ANALYSIS_FCN_TYPE_NULL);
+			int ocolor = rz_config_get_i(core->config, "scr.color");
+			if (!fun) {
+				rz_cons_message("Not in a function. Type 'df' to define it here");
+				break;
+			} else if (rz_list_empty(fun->bbs)) {
+				rz_cons_message("No basic blocks in this function. You may want to use 'afb+'.");
+				break;
 			}
-			break;
+			reset_print_cur(core->print);
+			eprintf("\rRendering graph...");
+			rz_core_visual_graph(core, NULL, NULL, true);
+			rz_config_set_i(core->config, "scr.color", ocolor);
+		} break;
 		case 'v':
 			rz_core_visual_analysis(core, NULL);
 			break;
@@ -3109,7 +3108,8 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 					if (core->seltab) {
 						const char *creg = core->dbg->creg;
 						if (creg) {
-							rz_core_cmdf(core, "dr %s = %s-1\n", creg, creg);
+							ut64 cregval = rz_debug_reg_get(core->dbg, creg);
+							rz_core_debug_reg_set(core, creg, cregval - 1, NULL);
 						}
 					} else {
 						int w = rz_config_get_i(core->config, "hex.cols");
@@ -3137,7 +3137,8 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 					if (core->seltab) {
 						const char *creg = core->dbg->creg;
 						if (creg) {
-							rz_core_cmdf(core, "dr %s = %s+1\n", creg, creg);
+							ut64 cregval = rz_debug_reg_get(core->dbg, creg);
+							rz_core_debug_reg_set(core, creg, cregval + 1, NULL);
 						}
 					} else {
 						int w = rz_config_get_i(core->config, "hex.cols");
@@ -3167,7 +3168,8 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 						const char *creg = core->dbg->creg;
 						if (creg) {
 							int delta = core->rasm->bits / 8;
-							rz_core_cmdf(core, "dr %s = %s-%d\n", creg, creg, delta);
+							ut64 cregval = rz_debug_reg_get(core->dbg, creg);
+							rz_core_debug_reg_set(core, creg, cregval - delta, NULL);
 						}
 					} else {
 						int w = rz_config_get_i(core->config, "hex.cols");
@@ -3203,7 +3205,8 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 						const char *creg = core->dbg->creg;
 						if (creg) {
 							int delta = core->rasm->bits / 8;
-							rz_core_cmdf(core, "dr %s = %s+%d\n", creg, creg, delta);
+							ut64 cregval = rz_debug_reg_get(core->dbg, creg);
+							rz_core_debug_reg_set(core, creg, cregval + delta, NULL);
 						}
 					} else {
 						int w = rz_config_get_i(core->config, "hex.cols");
@@ -3211,7 +3214,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 							rz_config_get_i(core->config, "stack.size") + w);
 					}
 				} else {
-					rz_core_cmdf(core, "dr PC=0x%08" PFMT64x, core->offset + core->print->cur);
+					rz_core_debug_reg_set(core, "PC", core->offset + core->print->cur, NULL);
 				}
 			} else if (!autoblocksize) {
 				rz_core_block_size(core, core->blocksize + cols);

--- a/librz/core/vmenus.c
+++ b/librz/core/vmenus.c
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
+#include <string.h>
+
 #include <rz_core.h>
 #include <rz_util.h>
-#include <string.h>
+
+#include "core_private.h"
 
 #define MAX_FORMAT 3
 
@@ -1229,7 +1232,8 @@ RZ_API int rz_core_visual_classes(RzCore *core) {
 		case 'p':
 			if (mode == 'm' && mur) {
 				rz_core_seek(core, mur->vaddr, true);
-				rz_core_cmd0(core, "af;pdf~..");
+				rz_core_analysis_function_add(core, NULL, core->offset, false);
+				rz_core_cmd0(core, "pdf~..");
 			}
 			break;
 		case 'm': // methods
@@ -1745,8 +1749,7 @@ RZ_API int rz_core_visual_view_rop(RzCore *core) {
 			rz_line_set_prompt("comment: ");
 			const char *line = rz_line_readline();
 			if (line && *line) {
-				// XXX code injection bug here
-				rz_core_cmdf(core, "CC %s @ 0x%08" PFMT64x, line, addr + delta);
+				rz_meta_set_string(core->analysis, RZ_META_TYPE_COMMENT, addr + delta, line);
 			}
 		} break;
 		case '.':
@@ -2229,7 +2232,7 @@ RZ_API int rz_core_visual_comments(RzCore *core) {
 		case ' ':
 		case '\r':
 		case '\n':
-			rz_core_cmdf(core, "s 0x%" PFMT64x, from);
+			rz_core_seek_and_save(core, from, true);
 			RZ_FREE(p);
 			return true;
 		case 'Q':
@@ -2517,7 +2520,7 @@ static void variable_rename(RzCore *core, ut64 addr, int vindex, const char *nam
 	rz_list_foreach (list, iter, var) {
 		if (i == vindex) {
 			rz_core_seek(core, addr, false);
-			rz_core_cmd_strf(core, "afvn %s %s", name, var->name);
+			rz_core_analysis_var_rename(core, name, var->name);
 			rz_core_seek(core, a_tmp, false);
 			break;
 		}
@@ -2881,7 +2884,7 @@ RZ_API void rz_core_visual_debugtraces(RzCore *core, const char *input) {
 			rz_core_cmdf(core, ".dte %d", i);
 		}
 		rz_core_cmd0(core, "x 64@r:SP");
-		rz_core_cmd0(core, "dri");
+		rz_core_debug_ri(core, core->dbg->reg, 0);
 		// limit by rows here
 		//int rows = rz_cons_get_size (NULL);
 		rz_core_cmdf(core, "dtd %d", delta);
@@ -3045,7 +3048,12 @@ RZ_API void rz_core_visual_analysis(RzCore *core, const char *input) {
 		case 'a':
 			switch (level) {
 			case 0:
-				rz_core_cmd0(core, "af-$$;af"); // reanalize
+				// Remove the old function information
+				rz_core_analysis_undefine(core, core->offset);
+				rz_analysis_fcn_del_locs(core->analysis, core->offset);
+				rz_analysis_fcn_del(core->analysis, core->offset);
+				// Reanalyze and create function from scratch
+				rz_core_analysis_function_add(core, NULL, core->offset, false);
 				break;
 			case 1: {
 				eprintf("Select variable source ('r'egister, 's'tackptr or 'b'aseptr): ");
@@ -3127,7 +3135,10 @@ RZ_API void rz_core_visual_analysis(RzCore *core, const char *input) {
 		case '-':
 			switch (level) {
 			case 0:
-				rz_core_cmdf(core, "af- 0x%" PFMT64x, addr);
+				// Remove the old function information
+				rz_core_analysis_undefine(core, addr);
+				rz_analysis_fcn_del_locs(core->analysis, addr);
+				rz_analysis_fcn_del(core->analysis, addr);
 				break;
 			}
 			break;
@@ -3701,7 +3712,8 @@ onemoretime:
 			rz_analysis_function_resize(fcn, core->offset - fcn->addr);
 		}
 		rz_cons_break_push(NULL, NULL);
-		rz_core_cmdf(core, "af @ 0x%08" PFMT64x, off); // required for thumb autodetection
+		// required for thumb autodetection
+		rz_core_analysis_function_add(core, NULL, off, false);
 		rz_cons_break_pop();
 	} break;
 	case 'v': {

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -546,6 +546,7 @@ RZ_API ut32 rz_core_file_cur_fd(RzCore *core);
 RZ_API bool rz_core_debug_step_one(RzCore *core, int times);
 RZ_API bool rz_core_debug_continue_until(RzCore *core, ut64 addr, ut64 to);
 
+RZ_API void rz_core_debug_ri(RzCore *core, RzReg *reg, int mode);
 RZ_API void rz_core_debug_rr(RzCore *core, RzReg *reg, int mode);
 RZ_API void rz_core_debug_set_register_flags(RzCore *core);
 RZ_API void rz_core_debug_clear_register_flags(RzCore *core);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Refactor to use the API directy instead of calling `rz_core_cmd()` for some actions in the Visual Menus (`Vv` mode).

**Test plan**

- Try to add and remove the functions in this mode, also to navigate debug traces.
- Try to run Rizin in debug mode `rizin -d /bin/ls` then enter Visual mode, show the registers, scroll a bit and press `$` to set PC to the selected address
- Try to add comment
- Try to add/remove local flags (labels)

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/491