### PR TITLE
core/agraph: reintroduce shift-tab to move to prev node

### DIFF
--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -4338,6 +4338,11 @@ RZ_API int rz_core_visual_graph(RzCore *core, RzAGraph *g, RzAnalysisFunction *_
 				agraph_toggle_callgraph(g);
 			}
 			break;
+		case 'Z':
+			if (okey == 27) { // shift-tab
+				agraph_prev_node(g);
+			}
+			break;
 		case 's':
 			if (!fcn) {
 				break;


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Shift-tab in Agraph mode was removed by mistake while removing folding from the graph.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

rizin -A /bin/ls ; VV ; <tab> / <shift-tab> should move to next/prev node in the graph.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closing https://github.com/rizinorg/rizin/issues/551
