### PR TITLE
Remove the configuration variable `graph.web`

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3469,7 +3469,6 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETPREF("graph.font", "Courier", "Font for dot graphs");
 	SETBPREF("graph.offset", "false", "Show offsets in graphs");
 	SETBPREF("graph.bytes", "false", "Show opcode bytes in graphs");
-	SETBPREF("graph.web", "false", "Display graph in web browser (VV)");
 	SETI("graph.from", UT64_MAX, "Lower bound address when drawing global graphs");
 	SETI("graph.to", UT64_MAX, "Upper bound address when drawing global graphs");
 	SETI("graph.scroll", 5, "Scroll speed in ascii-art graph");

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -8258,11 +8258,12 @@ static void cmd_analysis_graph(RzCore *core, const char *input) {
 			rz_core_print_bb_custom(core, fcn);
 			break;
 		}
-		case 'w': // "agfw"
+		case 'w': { // "agfw"
 			char *cmdargs = rz_str_newf("agfd @ 0x%" PFMT64x, core->offset);
 			convert_dotcmd_to_image(core, cmdargs, input + 2);
 			free(cmdargs);
 			break;
+		}
 		default:
 			eprintf("Usage: see ag?\n");
 			break;
@@ -8504,11 +8505,12 @@ static void cmd_analysis_graph(RzCore *core, const char *input) {
 	case 'v': // "agv" alias for "agfv"
 		rz_core_cmdf(core, "agfv%s", input + 1);
 		break;
-	case 'w': // "agw"
+	case 'w': { // "agw"
 		char *cmdargs = rz_str_newf("agfd @ 0x%" PFMT64x, core->offset);
 		convert_dotcmd_to_image(core, cmdargs, input + 1);
 		free(cmdargs);
 		break;
+	}
 	default:
 		rz_core_cmd_help(core, help_msg_ag);
 		break;

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -548,7 +548,7 @@ static const char *help_msg_ag[] = {
 	"k", "", "SDB key-value",
 	"t", "", "Tiny ascii art",
 	"v", "", "Interactive ascii art",
-	"w", " [path]", "Write to path or display graph image (see graph.gv.format and graph.web)",
+	"w", " [path]", "Write to path or display graph image (see graph.gv.format)",
 	NULL
 };
 
@@ -8017,12 +8017,8 @@ RZ_API void rz_core_agraph_print(RzCore *core, int use_utf, const char *input) {
 		rz_cons_print("]\n");
 		break;
 	case 'w': { // "aggw"
-		if (rz_config_get_i(core->config, "graph.web")) {
-			rz_core_cmd0(core, "=H /graph/");
-		} else {
-			const char *filename = rz_str_trim_head_ro(input + 1);
-			convert_dotcmd_to_image(core, "aggd", filename);
-		}
+		const char *filename = rz_str_trim_head_ro(input + 1);
+		convert_dotcmd_to_image(core, "aggd", filename);
 		break;
 	}
 	default:
@@ -8263,13 +8259,9 @@ static void cmd_analysis_graph(RzCore *core, const char *input) {
 			break;
 		}
 		case 'w': // "agfw"
-			if (rz_config_get_i(core->config, "graph.web")) {
-				rz_core_cmd0(core, "=H /graph/");
-			} else {
-				char *cmdargs = rz_str_newf("agfd @ 0x%" PFMT64x, core->offset);
-				convert_dotcmd_to_image(core, cmdargs, input + 2);
-				free(cmdargs);
-			}
+			char *cmdargs = rz_str_newf("agfd @ 0x%" PFMT64x, core->offset);
+			convert_dotcmd_to_image(core, cmdargs, input + 2);
+			free(cmdargs);
 			break;
 		default:
 			eprintf("Usage: see ag?\n");
@@ -8513,13 +8505,9 @@ static void cmd_analysis_graph(RzCore *core, const char *input) {
 		rz_core_cmdf(core, "agfv%s", input + 1);
 		break;
 	case 'w': // "agw"
-		if (rz_config_get_i(core->config, "graph.web")) {
-			rz_core_cmd0(core, "=H /graph/");
-		} else {
-			char *cmdargs = rz_str_newf("agfd @ 0x%" PFMT64x, core->offset);
-			convert_dotcmd_to_image(core, cmdargs, input + 1);
-			free(cmdargs);
-		}
+		char *cmdargs = rz_str_newf("agfd @ 0x%" PFMT64x, core->offset);
+		convert_dotcmd_to_image(core, cmdargs, input + 1);
+		free(cmdargs);
 		break;
 	default:
 		rz_core_cmd_help(core, help_msg_ag);

--- a/librz/core/panels.c
+++ b/librz/core/panels.c
@@ -6435,11 +6435,7 @@ repeat:
 		}
 		break;
 	case ' ':
-		if (rz_config_get_b(core->config, "graph.web")) {
-			rz_core_cmd0(core, "agv $$");
-		} else {
-			__call_visual_graph(core);
-		}
+		__call_visual_graph(core);
 		break;
 	case ':':
 		rz_core_visual_prompt_input(core);
@@ -6659,11 +6655,7 @@ repeat:
 		}
 		break;
 	case 'V':
-		if (rz_config_get_b(core->config, "graph.web")) {
-			rz_core_cmd0(core, "agv $$");
-		} else {
-			__call_visual_graph(core);
-		}
+		__call_visual_graph(core);
 		break;
 	case ']':
 		if (__check_panel_type(cur, PANEL_CMD_HEXDUMP)) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

On https://github.com/rizinorg/rizin/pull/531#discussion_r571617045, it was discussed to remove `graph.web` which was the evar used to display graph in a web browser. 
This PR hopes to do exactly that.

**Test plan**

- [x] Merge when the CI is green and it's removed properly.

**Closing issues**

None