### PR TITLE
Refactor to use API in visual and ASCII graph modes

### DIFF
--- a/librz/core/cmd_seek.c
+++ b/librz/core/cmd_seek.c
@@ -62,15 +62,15 @@ static void printPadded(RzCore *core, int pad) {
 	free(fmt);
 }
 
-static bool seek_to_register(RzCore *core, const char *input, bool is_silent) {
+RZ_IPI bool rz_core_seek_to_register(RzCore *core, const char *regname, bool is_silent) {
 	ut64 off;
 	if (core->bin->is_debugger) {
-		off = rz_debug_reg_get(core->dbg, input);
+		off = rz_debug_reg_get(core->dbg, regname);
 		return rz_core_seek_opt(core, off, true, !is_silent);
 	} else {
 		RzReg *orig = core->dbg->reg;
 		core->dbg->reg = core->analysis->reg;
-		off = rz_debug_reg_get(core->dbg, input);
+		off = rz_debug_reg_get(core->dbg, regname);
 		core->dbg->reg = orig;
 		return rz_core_seek_opt(core, off, true, !is_silent);
 	}
@@ -271,7 +271,7 @@ RZ_IPI int rz_cmd_seek(void *data, const char *input) {
 	switch (*input) {
 	case 'r': // "sr"
 		if (input[1] && input[2]) {
-			seek_to_register(core, input + 2, silent);
+			rz_core_seek_to_register(core, input + 2, silent);
 		} else {
 			eprintf("|Usage| 'sr PC' seek to program counter register\n");
 		}
@@ -772,5 +772,5 @@ RZ_IPI RzCmdStatus rz_seek_opcode_handler(RzCore *core, int argc, const char **a
 }
 
 RZ_IPI RzCmdStatus rz_seek_register_handler(RzCore *core, int argc, const char **argv) {
-	return bool2cmdstatus(seek_to_register(core, argv[1], false));
+	return bool2cmdstatus(rz_core_seek_to_register(core, argv[1], false));
 }

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -13,9 +13,15 @@ RZ_IPI bool rz_core_debug_reg_set(RzCore *core, const char *regname, ut64 val, c
 RZ_IPI bool rz_core_debug_reg_list(RzCore *core, int type, int size, PJ *pj, int rad, const char *use_color);
 RZ_IPI void rz_core_debug_regs2flags(RzCore *core, int bits);
 RZ_IPI void rz_core_regs2flags(RzCore *core);
+RZ_IPI void rz_core_debug_single_step_in(RzCore *core);
+RZ_IPI void rz_core_debug_single_step_over(RzCore *core);
 RZ_IPI void rz_core_debug_breakpoint_toggle(RzCore *core, ut64 addr);
 RZ_IPI void rz_core_debug_continue(RzCore *core);
 
 /* cmd_eval.c */
 RZ_IPI bool rz_core_load_theme(RzCore *core, const char *name);
+
+/* cmd_seek.c */
+
+RZ_IPI bool rz_core_seek_to_register(RzCore *core, const char *input, bool is_silent);
 #endif

--- a/librz/core/panels.c
+++ b/librz/core/panels.c
@@ -5485,7 +5485,7 @@ void __set_breakpoints_on_cursor(RzCore *core, RzPanel *panel) {
 		return;
 	}
 	if (__check_panel_type(panel, PANEL_CMD_DISASSEMBLY)) {
-		rz_core_cmdf(core, "dbs 0x%08" PFMT64x, core->offset + core->print->cur);
+		rz_core_debug_breakpoint_toggle(core, core->offset + core->print->cur);
 		panel->view->refresh = true;
 	}
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Refactor the Visual and ASCII graph modes to use the API instead of `rz_core_cmd*()` calls.

**Test plan**

All green, try debugging features in both visual and ASCII graph modes.

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/382 and https://github.com/rizinorg/rizin/issues/384