### PR TITLE
Refactor to use API in debug commands

### DIFF
--- a/librz/core/cmd_meta.c
+++ b/librz/core/cmd_meta.c
@@ -416,9 +416,7 @@ static int cmd_meta_comment(RzCore *core, const char *input) {
 		const char *comment = rz_meta_get_string(core->analysis, RZ_META_TYPE_COMMENT, addr);
 		out = rz_core_editor(core, NULL, comment);
 		if (out) {
-			//rz_meta_set (core->analysis->meta, RZ_META_TYPE_COMMENT, addr, 0, out);
-			rz_core_cmdf(core, "CC-@0x%08" PFMT64x, addr);
-			//rz_meta_del (core->analysis->meta, input[0], addr, addr+1);
+			rz_meta_del(core->analysis, RZ_META_TYPE_COMMENT, addr, 1);
 			rz_meta_set_string(core->analysis,
 				RZ_META_TYPE_COMMENT, addr, out);
 			free(out);
@@ -655,9 +653,7 @@ static int cmd_meta_others(RzCore *core, const char *input) {
 		const char *comment = rz_meta_get_string(core->analysis, RZ_META_TYPE_COMMENT, addr);
 		out = rz_core_editor(core, NULL, comment);
 		if (out) {
-			//rz_meta_set (core->analysis->meta, RZ_META_TYPE_COMMENT, addr, 0, out);
-			rz_core_cmdf(core, "CC-@0x%08" PFMT64x, addr);
-			//rz_meta_del (core->analysis->meta, input[0], addr, addr+1);
+			rz_meta_del(core->analysis, RZ_META_TYPE_COMMENT, addr, 1);
 			rz_meta_set_string(core->analysis, RZ_META_TYPE_COMMENT, addr, out);
 			free(out);
 		}

--- a/librz/core/cmd_open.c
+++ b/librz/core/cmd_open.c
@@ -1094,7 +1094,7 @@ RZ_API void rz_core_file_reopen_remote_debug(RzCore *core, char *uri, ut64 addr)
 		__rebase_everything(core, old_sections, old_base);
 	}
 	rz_list_free(old_sections);
-	rz_core_cmd0(core, "sr PC");
+	rz_core_seek_to_register(core, "PC", false);
 }
 
 RZ_API void rz_core_file_reopen_debug(RzCore *core, const char *args) {
@@ -1144,7 +1144,7 @@ RZ_API void rz_core_file_reopen_debug(RzCore *core, const char *args) {
 		__rebase_everything(core, old_sections, old_base);
 	}
 	rz_list_free(old_sections);
-	rz_core_cmd0(core, "sr PC");
+	rz_core_seek_to_register(core, "PC", false);
 	free(bin_abspath);
 	free(escaped_path);
 	free(binpath);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Switch to use API instead of `rz_core_cmd*()` calls in `librz/core/cmd_debug.c` - all `d*` commands

**Test plan**

- Debug commands that involve ESIL - e.g. `des` and `desu` should behave as before
- `dcf` should behave as before
- `dc` command should behave as before
- `ds` commands should behave as before
- All tests should be green
