### PR TITLE
Make Tests use x86.as only on x86 Host

### DIFF
--- a/test/db/archos/linux-x64/asm_x64_as
+++ b/test/db/archos/linux-x64/asm_x64_as
@@ -1,6 +1,5 @@
 NAME=rz-asm #1167 3
 FILE=-
-# BROKEN=1
 CMDS=!rz-asm -s att -a x86.as -b 64 "test %rbx, %rax"
 EXPECT=<<EOF
 4885d8
@@ -9,7 +8,6 @@ RUN
 
 NAME=rz-asm #1167 4
 FILE=-
-# BROKEN=1
 CMDS=!rz-asm -s intel -a x86.as -b 64 "test rax, rbx"
 EXPECT=<<EOF
 4885d8
@@ -17,7 +15,6 @@ EOF
 RUN
 
 NAME=rz-asm #1167 5
-# BROKEN=1
 FILE=-
 CMDS=!rz-asm -s att -a x86.as -b 64 'add $33, %rbx'
 EXPECT=<<EOF

--- a/test/db/archos/linux-x64/asm_x64_as
+++ b/test/db/archos/linux-x64/asm_x64_as
@@ -1,0 +1,50 @@
+NAME=rz-asm #1167 3
+FILE=-
+# BROKEN=1
+CMDS=!rz-asm -s att -a x86.as -b 64 "test %rbx, %rax"
+EXPECT=<<EOF
+4885d8
+EOF
+RUN
+
+NAME=rz-asm #1167 4
+FILE=-
+# BROKEN=1
+CMDS=!rz-asm -s intel -a x86.as -b 64 "test rax, rbx"
+EXPECT=<<EOF
+4885d8
+EOF
+RUN
+
+NAME=rz-asm #1167 5
+# BROKEN=1
+FILE=-
+CMDS=!rz-asm -s att -a x86.as -b 64 'add $33, %rbx'
+EXPECT=<<EOF
+4883c321
+EOF
+RUN
+
+NAME=rz-asm #1167 6
+FILE=-
+CMDS=!rz-asm -s intel -a x86.as -b 64 "add rbx, 33"
+EXPECT=<<EOF
+4883c321
+EOF
+RUN
+
+NAME=rz-asm -s att -a x86.as -b 64 movq %rdx, %rax
+FILE=-
+CMDS=!rz-asm -s att -a x86.as -b 64 "movq %rdx, %rax"
+EXPECT=<<EOF
+4889d0
+EOF
+RUN
+
+NAME=att pa
+FILE=--
+CMDS=pa add $33, %rbx @a:x86.as:64 @e:asm.syntax=att
+EXPECT=<<EOF
+4883c321
+EOF
+RUN

--- a/test/db/cmd/cmd_pa
+++ b/test/db/cmd/cmd_pa
@@ -26,11 +26,3 @@ ffd0
 1021
 EOF
 RUN
-
-NAME=att pa
-FILE=--
-CMDS=pa add $33, %rbx @a:x86.as:64 @e:asm.syntax=att
-EXPECT=<<EOF
-4883c321
-EOF
-RUN

--- a/test/db/esil/x86_32
+++ b/test/db/esil/x86_32
@@ -2369,11 +2369,8 @@ CMDS=<<EOF
 # Common parts
 #
 e asm.arch=x86
-?== x86 `e asm.arch`
-?!e asm.assembler=x86.as
-??e asm.assembler=x86.nz
 e asm.bits=32
-wa bsf eax, ebx
+wx 0fbcc3 # bsf eax, ebx
 #
 # BSF: test ZF
 #
@@ -2417,9 +2414,8 @@ CMDS=<<EOF
 # Common parts
 #
 e asm.arch=x86
-e asm.assembler=x86.as
 e asm.bits=32
-wa bsr eax, ebx
+wx 0fbdc3 # bsr eax, ebx
 #
 # BSR: test ZF
 #

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -112,41 +112,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=rz-asm #1167 3
-FILE=-
-BROKEN=1
-CMDS=!rz-asm -s att -a x86.as -b 64 "test %rbx, %rax"
-EXPECT=<<EOF
-4885d8
-EOF
-RUN
-
-NAME=rz-asm #1167 4
-FILE=-
-BROKEN=1
-CMDS=!rz-asm -s intel -a x86.as -b 64 "test rax, rbx"
-EXPECT=<<EOF
-4885d8
-EOF
-RUN
-
-NAME=rz-asm #1167 5
-BROKEN=1
-FILE=-
-CMDS=!rz-asm -s att -a x86.as -b 64 'add $33, %rbx'
-EXPECT=<<EOF
-4883c321
-EOF
-RUN
-
-NAME=rz-asm #1167 6
-FILE=-
-CMDS=!rz-asm -s intel -a x86.as -b 64 "add rbx, 33"
-EXPECT=<<EOF
-4883c321
-EOF
-RUN
-
 NAME=rz-asm #1900
 FILE=-
 CMDS=<<EOF
@@ -304,14 +269,6 @@ FILE=-
 CMDS=!rz-asm -a x86 -b16 -B "xor al, 0x34";ps
 EXPECT=<<EOF
 44
-EOF
-RUN
-
-NAME=rz-asm -s att -a x86.as -b 64 movq %rdx, %rax
-FILE=-
-CMDS=!rz-asm -s att -a x86.as -b 64 "movq %rdx, %rax"
-EXPECT=<<EOF
-4889d0
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

x86.as depends an the `as` executable to be available, which usually on non-x86 isn't. I rewrote tests that didn't explicitly test this plugin to not use it and moved the others to archos.

**Test plan**

run tests on e.g. arm
