### PR TITLE
libzip: use conf_data not zipconf_data in meson.build for HAVE_SHARED

### DIFF
--- a/subprojects/packagefiles/libzip-1.7.3/meson.build
+++ b/subprojects/packagefiles/libzip-1.7.3/meson.build
@@ -102,7 +102,7 @@ if is_big_endian
   conf_data.set10('WORDS_BIGENDIAN', is_big_endian)
 endif
 if get_option('default_library') == 'shared'
-  zipconf_data.set('HAVE_SHARED', true)
+  conf_data.set10('HAVE_SHARED', true)
 endif
 conf_data.set('CMAKE_PROJECT_NAME', 'libzip')
 conf_data.set('CMAKE_PROJECT_VERSION', meson.project_version())


### PR DESCRIPTION
**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

HAVE_SHARED is in libzip/config.h, not in zipconf.h, so use conf_data instead of the wrong zipconf_data. Anyway, that line should almost never be used because when libzip subproject is used, it should be compiled statically unless someone changes stuff manually. However, it seems that somehow someone was able to trigger that line by using a dirty build dir.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
