### PR TITLE
Refactor to use API in print commands

### DIFF
--- a/librz/core/cmd_meta.c
+++ b/librz/core/cmd_meta.c
@@ -218,6 +218,13 @@ static bool print_addrinfo(void *user, const char *k, const char *v) {
 	return true;
 }
 
+RZ_IPI void rz_core_meta_comment_add(RzCore *core, const char *comment, ut64 addr) {
+	const char *oldcomment = rz_meta_get_string(core->analysis, RZ_META_TYPE_COMMENT, addr);
+	if (!oldcomment || (oldcomment && !strstr(oldcomment, comment))) {
+		rz_meta_set_string(core->analysis, RZ_META_TYPE_COMMENT, addr, comment);
+	}
+}
+
 static int cmd_meta_add_fileline(Sdb *s, char *fileline, ut64 offset) {
 	char aoffset[64];
 	char *aoffsetptr = sdb_itoa(offset, aoffset, 16);
@@ -461,26 +468,23 @@ static int cmd_meta_comment(RzCore *core, const char *input) {
 	case 'u': // "CCu"
 		//
 		{
-			char *newcomment;
+			char *comment;
 			const char *arg = input + 2;
 			while (*arg && *arg == ' ')
 				arg++;
 			if (!strncmp(arg, "base64:", 7)) {
 				char *s = (char *)sdb_decode(arg + 7, NULL);
 				if (s) {
-					newcomment = s;
+					comment = s;
 				} else {
-					newcomment = NULL;
+					comment = NULL;
 				}
 			} else {
-				newcomment = strdup(arg);
+				comment = strdup(arg);
 			}
-			if (newcomment) {
-				const char *comment = rz_meta_get_string(core->analysis, RZ_META_TYPE_COMMENT, addr);
-				if (!comment || (comment && !strstr(comment, newcomment))) {
-					rz_meta_set_string(core->analysis, RZ_META_TYPE_COMMENT, addr, newcomment);
-				}
-				free(newcomment);
+			if (comment) {
+				rz_core_meta_comment_add(core, comment, addr);
+				free(comment);
 			}
 		}
 		break;

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -48,4 +48,7 @@ RZ_IPI bool rz_core_seek_to_register(RzCore *core, const char *input, bool is_si
 RZ_IPI int rz_core_seek_opcode_forward(RzCore *core, int n, bool silent);
 RZ_IPI int rz_core_seek_opcode_forward(RzCore *core, int n, bool silent);
 RZ_IPI int rz_core_seek_opcode(RzCore *core, int numinstr, bool silent);
+
+/* cmd_meta.c */
+RZ_IPI void rz_core_meta_comment_add(RzCore *core, const char *comment, ut64 addr);
 #endif


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Refactor to use an API instead of `rz_core_cmd*()` calls in some of the print commands. Note, that we might want to rethink some of these printing commands in the future since they don't really make sense.

**Test plan**

- All green.
- Try to run `pxt` commands in various scenarious