### PR TITLE
Extract common API to generate different types of graphs/outputs ##breaking

### DIFF
--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -3669,6 +3669,7 @@ RZ_API void rz_agraph_print(RzAGraph *g) {
 }
 
 RZ_API void rz_agraph_print_json(RzAGraph *g, PJ *pj) {
+	// TODO: add extra_json_info(RzAGraph *g, RzANode *an, PJ *pj) argument
 	RzList *nodes = g->graph->nodes, *neighbours = NULL;
 	RzListIter *it, *itt;
 	RzGraphNode *node = NULL, *neighbour = NULL;

--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -4302,20 +4302,18 @@ RZ_API int rz_core_visual_graph(RzCore *core, RzAGraph *g, RzAnalysisFunction *_
 			break;
 		case '>':
 			if (fcn && rz_cons_yesno('y', "Compute function callgraph? (Y/n)")) {
-				rz_core_agraph_reset(core);
-				rz_core_cmd0(core, ".agc* @$FB;.axfg @$FB;aggi");
+				rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_FUNCCALL, RZ_AGRAPH_OUTPUT_MODE_INTERACTIVE, NULL);
 			}
 			break;
 		case '<':
-			// rz_core_visual_refs (core, true, false);
 			if (fcn) {
-				rz_core_agraph_reset(core);
-				rz_core_cmd0(core, ".axtg $FB;aggi");
+				rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_XREFS, RZ_AGRAPH_OUTPUT_MODE_INTERACTIVE, NULL);
 			}
 			break;
 		case 'G':
 			rz_core_agraph_reset(core);
-			rz_core_cmd0(core, ".dtg*;aggi");
+			rz_core_cmd0(core, ".dtg*");
+			rz_core_agraph_print_interactive(core);
 			break;
 		case 'V':
 			if (fcn) {

--- a/librz/core/cagraph.c
+++ b/librz/core/cagraph.c
@@ -107,6 +107,10 @@ RZ_IPI void rz_core_agraph_print_interactive(RzCore *core) {
 	}
 }
 
+RZ_IPI void rz_core_agraph_print_write(RzCore *core, const char *filename) {
+	rz_convert_dotcmd_to_image(core, "aggd", filename);
+}
+
 static void agraph_print_node_dot(RzANode *n, void *user) {
 	char *label = strdup(n->body);
 	//label = rz_str_replace (label, "\n", "\\l", 1);

--- a/librz/core/cagraph.c
+++ b/librz/core/cagraph.c
@@ -510,7 +510,7 @@ static bool core_agraph_bb_handle(RzCore *core, RzAGraphOutputMode mode, const c
 		return false;
 	default:
 		rz_core_agraph_bb_create(core, core->offset);
-		return true;;
+		return true;
 	}
 }
 
@@ -561,7 +561,7 @@ RZ_IPI void rz_core_agraph_print_type(RzCore *core, RzAGraphType type, RzAGraphO
 		break;
 	}
 
-	switch(mode) {
+	switch (mode) {
 	case RZ_AGRAPH_OUTPUT_MODE_ASCII:
 		rz_core_agraph_print_ascii(core);
 		break;

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -2633,7 +2633,6 @@ RZ_API void rz_core_analysis_callgraph(RzCore *core, ut64 addr, int fmt) {
 	bool refgraph = rz_config_get_i(core->config, "graph.refs");
 	RzListIter *iter, *iter2;
 	int usenames = rz_config_get_i(core->config, "graph.json.usenames");
-	;
 	RzAnalysisFunction *fcni;
 	RzAnalysisRef *fcnr;
 	PJ *pj = NULL;

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -529,7 +529,6 @@ static const char *help_msg_ag[] = {
 	"agA", "[format]", "Global data references graph",
 	"agc", "[format]", "Function callgraph",
 	"agC", "[format]", "Global callgraph",
-	"agd", "[format] [fcn addr]", "Diff graph",
 	"agf", "[format]", "Basic blocks function graph",
 	"agi", "[format]", "Imports graph",
 	"agr", "[format]", "References graph",
@@ -5655,13 +5654,15 @@ static void cmd_analysis_esil(RzCore *core, const char *input) {
 		case 'v': {
 			char *oprompt = strdup(rz_config_get(core->config, "cmd.gprompt"));
 			rz_config_set(core->config, "cmd.gprompt", "pi 1");
-			rz_core_cmd0(core, ".aeg*;aggv");
+			rz_core_cmd0(core, ".aeg*");
+			rz_core_agraph_print_interactive(core);
 			rz_config_set(core->config, "cmd.gprompt", oprompt);
 			free(oprompt);
 			break;
 		}
 		case '\0':
-			rz_core_cmd0(core, ".aeg*;agg");
+			rz_core_cmd0(core, ".aeg*");
+			rz_core_agraph_print_interactive(core);
 			break;
 		case ' ':
 			rz_core_analysis_esil_graph(core, input + 2);
@@ -8214,53 +8215,6 @@ static void cmd_analysis_graph(RzCore *core, const char *input) {
 			break;
 		}
 		break;
-	case 'd': { // "agd"
-		int diff_opt = RZ_CORE_ANALYSIS_GRAPHBODY | RZ_CORE_ANALYSIS_GRAPHDIFF;
-		switch (input[1]) {
-		case 'j': { // "agdj"
-			ut64 addr = input[2] ? rz_num_math(core->num, input + 2) : core->offset;
-			rz_core_gdiff_fcn(core, addr, core->offset);
-			rz_core_analysis_graph(core, addr, diff_opt | RZ_CORE_ANALYSIS_JSON);
-			break;
-		}
-		case 'J': { // "agdJ"
-			ut64 addr = input[2] ? rz_num_math(core->num, input + 2) : core->offset;
-			rz_core_gdiff_fcn(core, addr, core->offset);
-			rz_core_analysis_graph(core, addr, diff_opt | RZ_CORE_ANALYSIS_JSON | RZ_CORE_ANALYSIS_JSON_FORMAT_DISASM);
-			break;
-		}
-		case '*': { // "agd*"
-			ut64 addr = input[2] ? rz_num_math(core->num, input + 2) : core->offset;
-			rz_core_gdiff_fcn(core, addr, core->offset);
-			rz_core_analysis_graph(core, addr, diff_opt | RZ_CORE_ANALYSIS_STAR);
-			break;
-		}
-		case ' ': // "agd "
-		case 0:
-		case 't': // "agdt"
-		case 'k': // "agdk"
-		case 'v': // "agdv"
-		case 'g': { // "agdg"
-			ut64 addr = input[2] ? rz_num_math(core->num, input + 2) : core->offset;
-			rz_core_agraph_reset(core);
-			rz_core_cmdf(core, ".agd* @ %" PFMT64u "; agg%s;", addr, input + 1);
-			break;
-		}
-		case 'd': { // "agdd"
-			ut64 addr = input[2] ? rz_num_math(core->num, input + 2) : core->offset;
-			rz_core_gdiff_fcn(core, addr, core->offset);
-			rz_core_analysis_graph(core, addr, diff_opt);
-			break;
-		}
-		case 'w': { // "agdw"
-			char *cmdargs = rz_str_newf("agdd 0x%" PFMT64x, core->offset);
-			convert_dotcmd_to_image(core, cmdargs, input + 2);
-			free(cmdargs);
-			break;
-		}
-		}
-		break;
-	}
 	case 'v': // "agv" alias for "agfv"
 		rz_core_cmdf(core, "agfv%s", input + 1);
 		break;

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -8096,13 +8096,13 @@ static void cmd_analysis_graph(RzCore *core, const char *input) {
 		}
 		break;
 	case 'j': // "agj" alias for agfj
-		rz_core_cmdf(core, "agfj%s", input + 1);
+		rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_BB, RZ_AGRAPH_OUTPUT_MODE_JSON, NULL);
 		break;
 	case 'J': // "agJ" alias for agfJ
-		rz_core_cmdf(core, "agfJ%s", input + 1);
+		rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_BB, RZ_AGRAPH_OUTPUT_MODE_JSON_FORMAT, NULL);
 		break;
 	case 'k': // "agk" alias for agfk
-		rz_core_cmdf(core, "agfk%s", input + 1);
+		rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_BB, RZ_AGRAPH_OUTPUT_MODE_SDB, NULL);
 		break;
 	case 'l': // "agl"
 		rz_core_analysis_graph(core, rz_num_math(core->num, input + 1), RZ_CORE_ANALYSIS_GRAPHLINES);
@@ -8178,14 +8178,11 @@ static void cmd_analysis_graph(RzCore *core, const char *input) {
 		}
 		break;
 	case 'v': // "agv" alias for "agfv"
-		rz_core_cmdf(core, "agfv%s", input + 1);
+		rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_BB, RZ_AGRAPH_OUTPUT_MODE_INTERACTIVE, NULL);
 		break;
-	case 'w': { // "agw"
-		char *cmdargs = rz_str_newf("agfd @ 0x%" PFMT64x, core->offset);
-		rz_convert_dotcmd_to_image(core, cmdargs, input + 1);
-		free(cmdargs);
+	case 'w':
+		rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_BB, RZ_AGRAPH_OUTPUT_MODE_WRITE, rz_str_trim_head_ro(input + 2));
 		break;
-	}
 	default:
 		rz_core_cmd_help(core, help_msg_ag);
 		break;

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -5650,38 +5650,40 @@ static void cmd_analysis_esil(RzCore *core, const char *input) {
 		break;
 	case 'g': // "aeg"
 		switch (input[1]) {
-		case 'i':
-		case 'v': {
-			char *oprompt = strdup(rz_config_get(core->config, "cmd.gprompt"));
-			rz_config_set(core->config, "cmd.gprompt", "pi 1");
-			rz_core_cmd0(core, ".aeg*");
-			rz_core_agraph_print_interactive(core);
-			rz_config_set(core->config, "cmd.gprompt", oprompt);
-			free(oprompt);
-			break;
-		}
-		case '\0':
-			rz_core_cmd0(core, ".aeg*");
-			rz_core_agraph_print_interactive(core);
-			break;
+		case 0:
 		case ' ':
-			rz_core_analysis_esil_graph(core, input + 2);
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_ESIL, RZ_AGRAPH_OUTPUT_MODE_ASCII, rz_str_trim_head_ro(input + 2));
 			break;
-		case '*': {
-			RzAnalysisOp *aop = rz_core_analysis_op(core, core->offset, RZ_ANALYSIS_OP_MASK_ESIL);
-			if (aop) {
-				const char *esilstr = rz_strbuf_get(&aop->esil);
-				if (RZ_STR_ISNOTEMPTY(esilstr)) {
-					rz_core_analysis_esil_graph(core, esilstr);
-				}
-			}
+		case '*':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_ESIL, RZ_AGRAPH_OUTPUT_MODE_RIZIN, NULL);
 			break;
-		}
+		case 'd':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_ESIL, RZ_AGRAPH_OUTPUT_MODE_DOT, NULL);
+			break;
+		case 'g':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_ESIL, RZ_AGRAPH_OUTPUT_MODE_GML, NULL);
+			break;
+		case 'j':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_ESIL, RZ_AGRAPH_OUTPUT_MODE_JSON, NULL);
+			break;
+		case 'J':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_ESIL, RZ_AGRAPH_OUTPUT_MODE_JSON_FORMAT, NULL);
+			break;
+		case 'k':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_ESIL, RZ_AGRAPH_OUTPUT_MODE_SDB, NULL);
+			break;
+		case 't':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_ESIL, RZ_AGRAPH_OUTPUT_MODE_TINY, NULL);
+			break;
+		case 'v':
+		case 'i':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_ESIL, RZ_AGRAPH_OUTPUT_MODE_INTERACTIVE, NULL);
+			break;
+		case 'w':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_ESIL, RZ_AGRAPH_OUTPUT_MODE_WRITE, rz_str_trim_head_ro(input + 2));
+			break;
 		default:
-			rz_cons_printf("Usage: aeg[iv*]\n");
-			rz_cons_printf(" aeg  analyze current instruction as an esil graph\n");
-			rz_cons_printf(" aeg* analyze current instruction as an esil graph\n");
-			rz_cons_printf(" aegv and launch the visual interactive mode (.aeg*;aggv == aegv)\n");
+			eprintf("See ag?\n:w");
 			break;
 		}
 		break;

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -7513,10 +7513,6 @@ static bool convert_dot_str_to_image(RzCore *core, char *str, const char *save_p
 	return convert_dot_to_image(core, "a.dot", save_path);
 }
 
-RZ_IPI void rz_core_agraph_print_write(RzCore *core, const char *filename) {
-	rz_convert_dotcmd_to_image(core, "aggd", filename);
-}
-
 static void cmd_agraph_node(RzCore *core, const char *input) {
 	switch (*input) {
 	case ' ': { // "agn"

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -7595,7 +7595,7 @@ RZ_API void rz_core_agraph_print(RzCore *core, int use_utf, const char *input) {
 	}
 	switch (*input) {
 	case 0:
-		rz_core_agraph_print_custom(core);
+		rz_core_agraph_print_ascii(core);
 		break;
 	case 't': // "aggt" - tiny graph
 		rz_core_agraph_print_tiny(core);
@@ -7884,141 +7884,251 @@ static void cmd_analysis_graph(RzCore *core, const char *input) {
 		cmd_agraph_edge(core, input + 1);
 		break;
 	case 'g': // "agg"
-		rz_core_agraph_print(core, -1, input + 1);
+		switch (input[1]) {
+		case 0:
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_CUSTOM, RZ_AGRAPH_OUTPUT_MODE_ASCII, NULL);
+			break;
+		case '*':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_CUSTOM, RZ_AGRAPH_OUTPUT_MODE_RIZIN, NULL);
+			break;
+		case 'd':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_CUSTOM, RZ_AGRAPH_OUTPUT_MODE_DOT, NULL);
+			break;
+		case 'g':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_CUSTOM, RZ_AGRAPH_OUTPUT_MODE_GML, NULL);
+			break;
+		case 'j':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_CUSTOM, RZ_AGRAPH_OUTPUT_MODE_JSON, NULL);
+			break;
+		case 'k':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_CUSTOM, RZ_AGRAPH_OUTPUT_MODE_SDB, NULL);
+			break;
+		case 't':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_CUSTOM, RZ_AGRAPH_OUTPUT_MODE_TINY, NULL);
+			break;
+		case 'v':
+		case 'i':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_CUSTOM, RZ_AGRAPH_OUTPUT_MODE_INTERACTIVE, NULL);
+			break;
+		case 'w':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_CUSTOM, RZ_AGRAPH_OUTPUT_MODE_WRITE, rz_str_trim_head_ro(input + 2));
+			break;
+		default:
+			eprintf("See ag?\n:w");
+			break;
+		}
 		break;
 	case 's': // "ags"
 		rz_core_analysis_graph(core, rz_num_math(core->num, input + 1), 0);
 		break;
 	case 'C': // "agC"
 		switch (input[1]) {
-		case 'v': // "agCv"
-		case 't': // "agCt"
-		case 'k': // "agCk"
-		case 'w': // "agCw"
-		case ' ': // "agC "
-		case 0: {
-			core->graph->is_callgraph = true;
-			rz_core_agraph_reset(core);
-			rz_core_cmdf(core, ".agC*;");
-			rz_core_agraph_print(core, -1, input + 1);
-			core->graph->is_callgraph = false;
+		case 0:
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBCALL, RZ_AGRAPH_OUTPUT_MODE_ASCII, NULL);
 			break;
-		}
-		case 'J': // "agCJ"
-		case 'j': // "agCj"
-			rz_core_analysis_callgraph(core, UT64_MAX, RZ_GRAPH_FORMAT_JSON);
+		case '*':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBCALL, RZ_AGRAPH_OUTPUT_MODE_RIZIN, NULL);
 			break;
-		case 'g': // "agCg"
-			rz_core_analysis_callgraph(core, UT64_MAX, RZ_GRAPH_FORMAT_GML);
+		case 'd':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBCALL, RZ_AGRAPH_OUTPUT_MODE_DOT, NULL);
 			break;
-		case 'd': // "agCd"
-			rz_core_analysis_callgraph(core, UT64_MAX, RZ_GRAPH_FORMAT_DOT);
+		case 'g':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBCALL, RZ_AGRAPH_OUTPUT_MODE_GML, NULL);
 			break;
-		case '*': // "agC*"
-			rz_core_analysis_callgraph(core, UT64_MAX, RZ_GRAPH_FORMAT_CMD);
+		case 'j':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBCALL, RZ_AGRAPH_OUTPUT_MODE_JSON, NULL);
+			break;
+		case 'k':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBCALL, RZ_AGRAPH_OUTPUT_MODE_SDB, NULL);
+			break;
+		case 't':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBCALL, RZ_AGRAPH_OUTPUT_MODE_TINY, NULL);
+			break;
+		case 'v':
+		case 'i':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBCALL, RZ_AGRAPH_OUTPUT_MODE_INTERACTIVE, NULL);
+			break;
+		case 'w':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBCALL, RZ_AGRAPH_OUTPUT_MODE_WRITE, rz_str_trim_head_ro(input + 2));
 			break;
 		default:
-			eprintf("Usage: see ag?\n");
+			eprintf("See ag?\n:w");
 			break;
 		}
 		break;
 	case 'r': // "agr" references graph
 		switch (input[1]) {
-		case '*': { // "agr*"
-			rz_core_analysis_coderefs(core, core->offset);
-		} break;
-		default: {
-			core->graph->is_callgraph = true;
-			rz_core_agraph_reset(core);
-			rz_core_cmdf(core, ".agr* @ %" PFMT64u ";", core->offset);
-			rz_core_agraph_print(core, -1, input + 1);
-			core->graph->is_callgraph = false;
+		case 0:
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_REFS, RZ_AGRAPH_OUTPUT_MODE_ASCII, NULL);
 			break;
-		}
+		case '*':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_REFS, RZ_AGRAPH_OUTPUT_MODE_RIZIN, NULL);
+			break;
+		case 'd':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_REFS, RZ_AGRAPH_OUTPUT_MODE_DOT, NULL);
+			break;
+		case 'g':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_REFS, RZ_AGRAPH_OUTPUT_MODE_GML, NULL);
+			break;
+		case 'j':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_REFS, RZ_AGRAPH_OUTPUT_MODE_JSON, NULL);
+			break;
+		case 'k':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_REFS, RZ_AGRAPH_OUTPUT_MODE_SDB, NULL);
+			break;
+		case 't':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_REFS, RZ_AGRAPH_OUTPUT_MODE_TINY, NULL);
+			break;
+		case 'v':
+		case 'i':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_REFS, RZ_AGRAPH_OUTPUT_MODE_INTERACTIVE, NULL);
+			break;
+		case 'w':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_REFS, RZ_AGRAPH_OUTPUT_MODE_WRITE, rz_str_trim_head_ro(input + 2));
+			break;
+		default:
+			eprintf("See ag?\n:w");
+			break;
 		}
 		break;
 	case 'R': // "agR" global refs
 		switch (input[1]) {
-		case '*': { // "agR*"
-			ut64 from = rz_config_get_i(core->config, "graph.from");
-			ut64 to = rz_config_get_i(core->config, "graph.to");
-			RzListIter *it;
-			RzAnalysisFunction *fcn;
-			rz_list_foreach (core->analysis->fcns, it, fcn) {
-				if ((from == UT64_MAX && to == UT64_MAX) || RZ_BETWEEN(from, fcn->addr, to)) {
-					rz_core_analysis_coderefs(core, fcn->addr);
-				}
-			}
+		case 0:
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBREFS, RZ_AGRAPH_OUTPUT_MODE_ASCII, NULL);
 			break;
-		}
-		default: {
-			core->graph->is_callgraph = true;
-			rz_core_agraph_reset(core);
-			rz_core_cmdf(core, ".agR*;");
-			rz_core_agraph_print(core, -1, input + 1);
-			core->graph->is_callgraph = false;
+		case '*':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBREFS, RZ_AGRAPH_OUTPUT_MODE_RIZIN, NULL);
 			break;
-		}
+		case 'd':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBREFS, RZ_AGRAPH_OUTPUT_MODE_DOT, NULL);
+			break;
+		case 'g':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBREFS, RZ_AGRAPH_OUTPUT_MODE_GML, NULL);
+			break;
+		case 'j':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBREFS, RZ_AGRAPH_OUTPUT_MODE_JSON, NULL);
+			break;
+		case 'k':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBREFS, RZ_AGRAPH_OUTPUT_MODE_SDB, NULL);
+			break;
+		case 't':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBREFS, RZ_AGRAPH_OUTPUT_MODE_TINY, NULL);
+			break;
+		case 'v':
+		case 'i':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBREFS, RZ_AGRAPH_OUTPUT_MODE_INTERACTIVE, NULL);
+			break;
+		case 'w':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBREFS, RZ_AGRAPH_OUTPUT_MODE_WRITE, rz_str_trim_head_ro(input + 2));
+			break;
+		default:
+			eprintf("See ag?\n:w");
+			break;
 		}
 		break;
 	case 'x': { // "agx" cross refs
-		RzGraph *graph = rz_core_analysis_codexrefs(core, core->offset);
-		if (!graph) {
-			eprintf("Couldn't create graph");
+		switch (input[1]) {
+		case 0:
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_XREFS, RZ_AGRAPH_OUTPUT_MODE_ASCII, NULL);
+			break;
+		case '*':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_XREFS, RZ_AGRAPH_OUTPUT_MODE_RIZIN, NULL);
+			break;
+		case 'd':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_XREFS, RZ_AGRAPH_OUTPUT_MODE_DOT, NULL);
+			break;
+		case 'g':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_XREFS, RZ_AGRAPH_OUTPUT_MODE_GML, NULL);
+			break;
+		case 'j':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_XREFS, RZ_AGRAPH_OUTPUT_MODE_JSON, NULL);
+			break;
+		case 'k':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_XREFS, RZ_AGRAPH_OUTPUT_MODE_SDB, NULL);
+			break;
+		case 't':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_XREFS, RZ_AGRAPH_OUTPUT_MODE_TINY, NULL);
+			break;
+		case 'v':
+		case 'i':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_XREFS, RZ_AGRAPH_OUTPUT_MODE_INTERACTIVE, NULL);
+			break;
+		case 'w':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_XREFS, RZ_AGRAPH_OUTPUT_MODE_WRITE, rz_str_trim_head_ro(input + 2));
+			break;
+		default:
+			eprintf("See ag?\n:w");
 			break;
 		}
-		rz_core_graph_print(core, graph, -1, true, input + 1);
-		rz_graph_free(graph);
 		break;
 	}
-	case 'i': { // "agi" import graph
-		RzGraph *graph = rz_core_analysis_importxrefs(core);
-		if (!graph) {
-			eprintf("Couldn't create graph");
+	case 'i': // "agi" import graph
+		switch (input[1]) {
+		case 0:
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_IMPORTS, RZ_AGRAPH_OUTPUT_MODE_ASCII, NULL);
+			break;
+		case '*':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_IMPORTS, RZ_AGRAPH_OUTPUT_MODE_RIZIN, NULL);
+			break;
+		case 'd':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_IMPORTS, RZ_AGRAPH_OUTPUT_MODE_DOT, NULL);
+			break;
+		case 'g':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_IMPORTS, RZ_AGRAPH_OUTPUT_MODE_GML, NULL);
+			break;
+		case 'j':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_IMPORTS, RZ_AGRAPH_OUTPUT_MODE_JSON, NULL);
+			break;
+		case 'k':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_IMPORTS, RZ_AGRAPH_OUTPUT_MODE_SDB, NULL);
+			break;
+		case 't':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_IMPORTS, RZ_AGRAPH_OUTPUT_MODE_TINY, NULL);
+			break;
+		case 'v':
+		case 'i':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_IMPORTS, RZ_AGRAPH_OUTPUT_MODE_INTERACTIVE, NULL);
+			break;
+		case 'w':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_IMPORTS, RZ_AGRAPH_OUTPUT_MODE_WRITE, rz_str_trim_head_ro(input + 2));
+			break;
+		default:
+			eprintf("See ag?\n:w");
 			break;
 		}
-		rz_core_graph_print(core, graph, -1, true, input + 1);
-		rz_graph_free(graph);
 		break;
-	}
 	case 'c': // "agc"
 		switch (input[1]) {
-		case 'v': // "agcv"
-		case 't': // "agct"
-		case 'k': // "agck"
-		case 'w': // "agcw"
-		case ' ': { // "agc "
-			core->graph->is_callgraph = true;
-			rz_core_agraph_reset(core);
-			rz_core_cmdf(core, ".agc* @ %" PFMT64u "; agg%s;", core->offset, input + 1);
-			core->graph->is_callgraph = false;
+		case 0:
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_FUNCCALL, RZ_AGRAPH_OUTPUT_MODE_ASCII, NULL);
 			break;
-		}
-		case 0: // "agc "
-			core->graph->is_callgraph = true;
-			rz_core_agraph_reset(core);
-			rz_core_cmd0(core, ".agc* $$; agg;");
-			core->graph->is_callgraph = false;
+		case '*':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_FUNCCALL, RZ_AGRAPH_OUTPUT_MODE_RIZIN, NULL);
 			break;
-		case 'g': { // "agg"
-			rz_core_analysis_callgraph(core, core->offset, RZ_GRAPH_FORMAT_GMLFCN);
+		case 'd':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_FUNCCALL, RZ_AGRAPH_OUTPUT_MODE_DOT, NULL);
 			break;
-		}
-		case 'd': { // "aggd"
-			rz_core_analysis_callgraph(core, core->offset, RZ_GRAPH_FORMAT_DOT);
+		case 'g':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_FUNCCALL, RZ_AGRAPH_OUTPUT_MODE_GML, NULL);
 			break;
-		}
-		case 'J': // "aggJ"
-		case 'j': { // "aggj"
-			rz_core_analysis_callgraph(core, core->offset, RZ_GRAPH_FORMAT_JSON);
+		case 'j':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_FUNCCALL, RZ_AGRAPH_OUTPUT_MODE_JSON, NULL);
 			break;
-		}
-		case '*': { // "agg*"
-			rz_core_analysis_callgraph(core, core->offset, RZ_GRAPH_FORMAT_CMD);
+		case 'k':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_FUNCCALL, RZ_AGRAPH_OUTPUT_MODE_SDB, NULL);
 			break;
-		}
+		case 't':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_FUNCCALL, RZ_AGRAPH_OUTPUT_MODE_TINY, NULL);
+			break;
+		case 'v':
+		case 'i':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_FUNCCALL, RZ_AGRAPH_OUTPUT_MODE_INTERACTIVE, NULL);
+			break;
+		case 'w':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_FUNCCALL, RZ_AGRAPH_OUTPUT_MODE_WRITE, rz_str_trim_head_ro(input + 2));
+			break;
 		default:
-			eprintf("Usage: see ag?\n");
+			eprintf("See ag?\n:w");
 			break;
 		}
 		break;
@@ -8036,35 +8146,71 @@ static void cmd_analysis_graph(RzCore *core, const char *input) {
 		break;
 	case 'a': // "aga"
 		switch (input[1]) {
-		case '*': {
-			rz_core_analysis_datarefs(core, core->offset);
+		case 0:
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_DATA, RZ_AGRAPH_OUTPUT_MODE_ASCII, NULL);
 			break;
-		}
+		case '*':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_DATA, RZ_AGRAPH_OUTPUT_MODE_RIZIN, NULL);
+			break;
+		case 'd':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_DATA, RZ_AGRAPH_OUTPUT_MODE_DOT, NULL);
+			break;
+		case 'g':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_DATA, RZ_AGRAPH_OUTPUT_MODE_GML, NULL);
+			break;
+		case 'j':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_DATA, RZ_AGRAPH_OUTPUT_MODE_JSON, NULL);
+			break;
+		case 'k':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_DATA, RZ_AGRAPH_OUTPUT_MODE_SDB, NULL);
+			break;
+		case 't':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_DATA, RZ_AGRAPH_OUTPUT_MODE_TINY, NULL);
+			break;
+		case 'v':
+		case 'i':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_DATA, RZ_AGRAPH_OUTPUT_MODE_INTERACTIVE, NULL);
+			break;
+		case 'w':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_DATA, RZ_AGRAPH_OUTPUT_MODE_WRITE, rz_str_trim_head_ro(input + 2));
+			break;
 		default:
-			rz_core_agraph_reset(core);
-			rz_core_cmdf(core, ".aga* @ %" PFMT64u ";", core->offset);
-			rz_core_agraph_print(core, -1, input + 1);
+			eprintf("See ag?\n:w");
 			break;
 		}
 		break;
 	case 'A': // "agA" global data refs
 		switch (input[1]) {
-		case '*': {
-			ut64 from = rz_config_get_i(core->config, "graph.from");
-			ut64 to = rz_config_get_i(core->config, "graph.to");
-			RzListIter *it;
-			RzAnalysisFunction *fcn;
-			rz_list_foreach (core->analysis->fcns, it, fcn) {
-				if ((from == UT64_MAX && to == UT64_MAX) || RZ_BETWEEN(from, fcn->addr, to)) {
-					rz_core_analysis_datarefs(core, fcn->addr);
-				}
-			}
+		case 0:
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBDATA, RZ_AGRAPH_OUTPUT_MODE_ASCII, NULL);
 			break;
-		}
+		case '*':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBDATA, RZ_AGRAPH_OUTPUT_MODE_RIZIN, NULL);
+			break;
+		case 'd':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBDATA, RZ_AGRAPH_OUTPUT_MODE_DOT, NULL);
+			break;
+		case 'g':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBDATA, RZ_AGRAPH_OUTPUT_MODE_GML, NULL);
+			break;
+		case 'j':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBDATA, RZ_AGRAPH_OUTPUT_MODE_JSON, NULL);
+			break;
+		case 'k':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBDATA, RZ_AGRAPH_OUTPUT_MODE_SDB, NULL);
+			break;
+		case 't':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBDATA, RZ_AGRAPH_OUTPUT_MODE_TINY, NULL);
+			break;
+		case 'v':
+		case 'i':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBDATA, RZ_AGRAPH_OUTPUT_MODE_INTERACTIVE, NULL);
+			break;
+		case 'w':
+			rz_core_agraph_print_type(core, RZ_AGRAPH_TYPE_GLOBDATA, RZ_AGRAPH_OUTPUT_MODE_WRITE, rz_str_trim_head_ro(input + 2));
+			break;
 		default:
-			rz_core_agraph_reset(core);
-			rz_core_cmdf(core, ".agA*;");
-			rz_core_agraph_print(core, -1, input + 1);
+			eprintf("See ag?\n:w");
 			break;
 		}
 		break;

--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -654,7 +654,8 @@ static void dot_trace_traverse(RzCore *core, RTree *t, int fmt) {
 
 	if (fmt == 'i') {
 		rz_core_agraph_reset(core);
-		rz_core_cmd0(core, ".dtg*;aggi");
+		rz_core_cmd0(core, ".dtg*");
+		rz_core_agraph_print_interactive(core);
 		return;
 	}
 	aux_data.graph = rz_graph_new();

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -871,7 +871,7 @@ static const char *rizin_argv[] = {
 	"afvs?", "afvs", "afvs*", "afvsj", "afvs-", "afvsg", "afvss",
 	"afv*", "afvR", "afvW", "afva", "afvd", "afvn", "afvt", "afv-", "af*", "afx",
 	"aF",
-	"ag?", "ag", "aga", "agA", "agc", "agC", "agd", "agf", "agi", "agr", "agR", "agx", "agg", "ag-",
+	"ag?", "ag", "aga", "agA", "agc", "agC", "agf", "agi", "agr", "agR", "agx", "agg", "ag-",
 	"agn?", "agn", "agn-", "age?", "age", "age-",
 	"agl", "agfl",
 	"ah?", "ah", "ah.", "ah-", "ah*", "aha", "ahb", "ahc", "ahe", "ahf", "ahh", "ahi?", "ahi", "ahj", "aho",

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -23,6 +23,7 @@ typedef enum {
 	RZ_AGRAPH_OUTPUT_MODE_DOT,
 	RZ_AGRAPH_OUTPUT_MODE_GML,
 	RZ_AGRAPH_OUTPUT_MODE_JSON,
+	RZ_AGRAPH_OUTPUT_MODE_JSON_FORMAT,
 	RZ_AGRAPH_OUTPUT_MODE_SDB,
 	RZ_AGRAPH_OUTPUT_MODE_TINY,
 	RZ_AGRAPH_OUTPUT_MODE_INTERACTIVE,
@@ -77,4 +78,6 @@ RZ_IPI int rz_core_seek_opcode(RzCore *core, int numinstr, bool silent);
 
 /* cmd_meta.c */
 RZ_IPI void rz_core_meta_comment_add(RzCore *core, const char *comment, ut64 addr);
+
+RZ_IPI bool rz_convert_dotcmd_to_image(RzCore *core, char *rz_cmd, const char *save_path);
 #endif

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -4,6 +4,31 @@
 #include <rz_types.h>
 #include <rz_core.h>
 
+typedef enum {
+	RZ_AGRAPH_TYPE_DATA,
+	RZ_AGRAPH_TYPE_GLOBDATA,
+	RZ_AGRAPH_TYPE_FUNCCALL,
+	RZ_AGRAPH_TYPE_GLOBCALL,
+	RZ_AGRAPH_TYPE_BB,
+	RZ_AGRAPH_TYPE_IMPORTS,
+	RZ_AGRAPH_TYPE_REFS,
+	RZ_AGRAPH_TYPE_GLOBREFS,
+	RZ_AGRAPH_TYPE_XREFS,
+	RZ_AGRAPH_TYPE_CUSTOM,
+} RzAGraphType;
+
+typedef enum {
+	RZ_AGRAPH_OUTPUT_MODE_ASCII,
+	RZ_AGRAPH_OUTPUT_MODE_RIZIN,
+	RZ_AGRAPH_OUTPUT_MODE_DOT,
+	RZ_AGRAPH_OUTPUT_MODE_GML,
+	RZ_AGRAPH_OUTPUT_MODE_JSON,
+	RZ_AGRAPH_OUTPUT_MODE_SDB,
+	RZ_AGRAPH_OUTPUT_MODE_TINY,
+	RZ_AGRAPH_OUTPUT_MODE_INTERACTIVE,
+	RZ_AGRAPH_OUTPUT_MODE_WRITE,
+} RzAGraphOutputMode;
+
 RZ_IPI int rz_core_analysis_set_reg(RzCore *core, const char *regname, ut64 val);
 RZ_IPI void rz_core_analysis_esil_init(RzCore *core);
 RZ_IPI void rz_core_analysis_esil_init_mem_del(RzCore *core, const char *name, ut64 addr, ut32 size);
@@ -19,7 +44,7 @@ RZ_IPI void rz_core_agraph_del_node(RzCore *core, const char *title);
 RZ_IPI void rz_core_agraph_add_edge(RzCore *core, const char *un, const char *vn);
 RZ_IPI void rz_core_agraph_del_edge(RzCore *core, const char *un, const char *vn);
 RZ_IPI void rz_core_agraph_reset(RzCore *core);
-RZ_IPI void rz_core_agraph_print_custom(RzCore *core);
+RZ_IPI void rz_core_agraph_print_ascii(RzCore *core);
 RZ_IPI void rz_core_agraph_print_tiny(RzCore *core);
 RZ_IPI void rz_core_agraph_print_sdb(RzCore *core);
 RZ_IPI void rz_core_agraph_print_interactive(RzCore *core);
@@ -28,6 +53,7 @@ RZ_IPI void rz_core_agraph_print_rizin(RzCore *core);
 RZ_IPI void rz_core_agraph_print_json(RzCore *core);
 RZ_IPI void rz_core_agraph_print_gml(RzCore *core);
 RZ_IPI void rz_core_agraph_print_write(RzCore *core, const char *filename);
+RZ_IPI void rz_core_agraph_print_type(RzCore *core, RzAGraphType type, RzAGraphOutputMode mode, const char *extra);
 
 /* cdebug.c */
 RZ_IPI bool rz_core_debug_reg_set(RzCore *core, const char *regname, ut64 val, const char *strval);

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -15,6 +15,7 @@ typedef enum {
 	RZ_AGRAPH_TYPE_GLOBREFS,
 	RZ_AGRAPH_TYPE_XREFS,
 	RZ_AGRAPH_TYPE_CUSTOM,
+	RZ_AGRAPH_TYPE_ESIL,
 } RzAGraphType;
 
 typedef enum {

--- a/shlr/rizin-shell-parser/grammar.js
+++ b/shlr/rizin-shell-parser/grammar.js
@@ -351,7 +351,7 @@ module.exports = grammar({
 
     last_command_identifier: ($) => choice(".", "..."),
     interpret_arg: ($) => $._any_command,
-    system_identifier: ($) => /![\*!-=]*/,
+    system_identifier: ($) => /![\-=!\*]*/,
     question_mark_identifier: ($) => "?",
 
     repeat_command: ($) =>

--- a/shlr/rizin-shell-parser/src/grammar.json
+++ b/shlr/rizin-shell-parser/src/grammar.json
@@ -2739,7 +2739,7 @@
     },
     "system_identifier": {
       "type": "PATTERN",
-      "value": "![\\*!-=]*"
+      "value": "![\\-=!\\*]*"
     },
     "question_mark_identifier": {
       "type": "STRING",

--- a/shlr/rizin-shell-parser/src/parser.c
+++ b/shlr/rizin-shell-parser/src/parser.c
@@ -3935,7 +3935,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 248:
       ACCEPT_TOKEN(sym_system_identifier);
-      if (('!' <= lookahead && lookahead <= '=')) ADVANCE(248);
+      if (lookahead == '!' ||
+          lookahead == '*' ||
+          lookahead == '-' ||
+          lookahead == '=') ADVANCE(248);
       END_STATE();
     case 249:
       ACCEPT_TOKEN(sym_question_mark_identifier);

--- a/test/db/cmd/cmd_ag
+++ b/test/db/cmd/cmd_ag
@@ -5,7 +5,7 @@ aa 2> /dev/null
 agcj
 EOF
 EXPECT=<<EOF
-[{"name":"entry0","size":42,"imports":["reloc.__libc_start_main"]}]
+{"nodes":[{"id":0,"title":"entry0","body":"","out_nodes":[1]},{"id":1,"title":"reloc.__libc_start_main","body":"","out_nodes":[]}]}
 EOF
 RUN
 
@@ -16,33 +16,33 @@ aa 2> /dev/null
 agi*
 EOF
 EXPECT=<<EOF
-agn "sym.imp.free"
-agn "0x0000083f"
-agn "_ITM_deregisterTMCloneTable"
-agn "sym.imp.strcpy"
-agn "0x00000814"
-agn "sym.imp.puts"
-agn "0x00000833"
-agn "sym.imp.strlen"
-agn "0x000007cf"
-agn "0x000007de"
-agn "__libc_start_main"
-agn "__gmon_start__"
-agn "sym.imp.malloc"
-agn "0x000007f6"
-agn "sym.imp.strcat"
-agn "0x00000827"
-agn "_ITM_registerTMCloneTable"
-agn "section..plt.got"
-agn "0x0000077e"
-age "0x0000083f" "sym.imp.free"
+agn "sym.imp.free" base64:
+agn "__gmon_start__" base64:
+agn "0x00000814" base64:
+agn "0x00000833" base64:
+agn "__libc_start_main" base64:
+agn "0x0000077e" base64:
+agn "0x0000083f" base64:
+agn "sym.imp.malloc" base64:
+agn "0x000007de" base64:
+agn "0x000007cf" base64:
+agn "sym.imp.strlen" base64:
+agn "0x00000827" base64:
+agn "section..plt.got" base64:
+agn "0x000007f6" base64:
+agn "sym.imp.strcat" base64:
+agn "sym.imp.puts" base64:
+agn "sym.imp.strcpy" base64:
+agn "_ITM_registerTMCloneTable" base64:
+agn "_ITM_deregisterTMCloneTable" base64:
 age "0x00000814" "sym.imp.strcpy"
 age "0x00000833" "sym.imp.puts"
-age "0x000007cf" "sym.imp.strlen"
-age "0x000007de" "sym.imp.strlen"
-age "0x000007f6" "sym.imp.malloc"
-age "0x00000827" "sym.imp.strcat"
 age "0x0000077e" "section..plt.got"
+age "0x0000083f" "sym.imp.free"
+age "0x000007de" "sym.imp.strlen"
+age "0x000007cf" "sym.imp.strlen"
+age "0x00000827" "sym.imp.strcat"
+age "0x000007f6" "sym.imp.malloc"
 EOF
 RUN
 
@@ -54,8 +54,8 @@ aa 2> /dev/null
 agx* @ main
 EOF
 EXPECT=<<EOF
-agn "main"
-agn "0x000006bd"
+agn "main" base64:
+agn "0x000006bd" base64:
 age "0x000006bd" "main"
 EOF
 RUN
@@ -85,35 +85,35 @@ digraph code {
 rankdir=LR;
 outputorder=edgesfirst
 graph [bgcolor=azure];
-edge [arrowhead=normal, color="#3030c0" style=bold weight=2 ];
-node [fillcolor=white, style=filled shape=box fontsize="8" fontname="Courier"];
-0 [URL="sym.imp.free", color="lightgray", label="sym.imp.free"]
-1 [URL="0x0000083f", color="lightgray", label="0x0000083f"]
-1 -> 0
-2 [URL="_ITM_deregisterTMCloneTable", color="lightgray", label="_ITM_deregisterTMCloneTable"]
-3 [URL="sym.imp.strcpy", color="lightgray", label="sym.imp.strcpy"]
-4 [URL="0x00000814", color="lightgray", label="0x00000814"]
-4 -> 3
-5 [URL="sym.imp.puts", color="lightgray", label="sym.imp.puts"]
-6 [URL="0x00000833", color="lightgray", label="0x00000833"]
-6 -> 5
-7 [URL="sym.imp.strlen", color="lightgray", label="sym.imp.strlen"]
-8 [URL="0x000007cf", color="lightgray", label="0x000007cf"]
-8 -> 7
-9 [URL="0x000007de", color="lightgray", label="0x000007de"]
-9 -> 7
-10 [URL="__libc_start_main", color="lightgray", label="__libc_start_main"]
-11 [URL="__gmon_start__", color="lightgray", label="__gmon_start__"]
-12 [URL="sym.imp.malloc", color="lightgray", label="sym.imp.malloc"]
-13 [URL="0x000007f6", color="lightgray", label="0x000007f6"]
-13 -> 12
-14 [URL="sym.imp.strcat", color="lightgray", label="sym.imp.strcat"]
-15 [URL="0x00000827", color="lightgray", label="0x00000827"]
-15 -> 14
-16 [URL="_ITM_registerTMCloneTable", color="lightgray", label="_ITM_registerTMCloneTable"]
-17 [URL="section..plt.got", color="lightgray", label="section..plt.got"]
-18 [URL="0x0000077e", color="lightgray", label="0x0000077e"]
-18 -> 17
+edge [arrowhead=normal, color="#3030c0" style=bold weight=2];
+node [fillcolor=white, style=filled shape=box fontname="Courier" fontsize="8"];
+"sym.imp.free" [URL="sym.imp.free", color="lightgray", label="sym.imp.free"]
+"__gmon_start__" [URL="__gmon_start__", color="lightgray", label="__gmon_start__"]
+"0x00000814" [URL="0x00000814", color="lightgray", label="0x00000814"]
+"0x00000833" [URL="0x00000833", color="lightgray", label="0x00000833"]
+"__libc_start_main" [URL="__libc_start_main", color="lightgray", label="__libc_start_main"]
+"0x0000077e" [URL="0x0000077e", color="lightgray", label="0x0000077e"]
+"0x0000083f" [URL="0x0000083f", color="lightgray", label="0x0000083f"]
+"sym.imp.malloc" [URL="sym.imp.malloc", color="lightgray", label="sym.imp.malloc"]
+"0x000007de" [URL="0x000007de", color="lightgray", label="0x000007de"]
+"0x000007cf" [URL="0x000007cf", color="lightgray", label="0x000007cf"]
+"sym.imp.strlen" [URL="sym.imp.strlen", color="lightgray", label="sym.imp.strlen"]
+"0x00000827" [URL="0x00000827", color="lightgray", label="0x00000827"]
+"section..plt.got" [URL="section..plt.got", color="lightgray", label="section..plt.got"]
+"0x000007f6" [URL="0x000007f6", color="lightgray", label="0x000007f6"]
+"sym.imp.strcat" [URL="sym.imp.strcat", color="lightgray", label="sym.imp.strcat"]
+"sym.imp.puts" [URL="sym.imp.puts", color="lightgray", label="sym.imp.puts"]
+"sym.imp.strcpy" [URL="sym.imp.strcpy", color="lightgray", label="sym.imp.strcpy"]
+"_ITM_registerTMCloneTable" [URL="_ITM_registerTMCloneTable", color="lightgray", label="_ITM_registerTMCloneTable"]
+"_ITM_deregisterTMCloneTable" [URL="_ITM_deregisterTMCloneTable", color="lightgray", label="_ITM_deregisterTMCloneTable"]
+"0x00000814" -> "sym.imp.strcpy"
+"0x00000833" -> "sym.imp.puts"
+"0x0000077e" -> "section..plt.got"
+"0x0000083f" -> "sym.imp.free"
+"0x000007de" -> "sym.imp.strlen"
+"0x000007cf" -> "sym.imp.strlen"
+"0x00000827" -> "sym.imp.strcat"
+"0x000007f6" -> "sym.imp.malloc"
 }
 graph
 [
@@ -125,52 +125,52 @@ directed 1
     label  "sym.imp.free"
   ]
   node [
-    id  1
-    label  "0x0000083f"
-  ]
-  node [
-    id  2
-    label  "_ITM_deregisterTMCloneTable"
-  ]
-  node [
-    id  3
-    label  "sym.imp.strcpy"
+    id  11
+    label  "__gmon_start__"
   ]
   node [
     id  4
     label  "0x00000814"
   ]
   node [
-    id  5
-    label  "sym.imp.puts"
-  ]
-  node [
     id  6
     label  "0x00000833"
-  ]
-  node [
-    id  7
-    label  "sym.imp.strlen"
-  ]
-  node [
-    id  8
-    label  "0x000007cf"
-  ]
-  node [
-    id  9
-    label  "0x000007de"
   ]
   node [
     id  10
     label  "__libc_start_main"
   ]
   node [
-    id  11
-    label  "__gmon_start__"
+    id  18
+    label  "0x0000077e"
+  ]
+  node [
+    id  1
+    label  "0x0000083f"
   ]
   node [
     id  12
     label  "sym.imp.malloc"
+  ]
+  node [
+    id  9
+    label  "0x000007de"
+  ]
+  node [
+    id  8
+    label  "0x000007cf"
+  ]
+  node [
+    id  7
+    label  "sym.imp.strlen"
+  ]
+  node [
+    id  15
+    label  "0x00000827"
+  ]
+  node [
+    id  17
+    label  "section..plt.got"
   ]
   node [
     id  13
@@ -181,24 +181,20 @@ directed 1
     label  "sym.imp.strcat"
   ]
   node [
-    id  15
-    label  "0x00000827"
+    id  5
+    label  "sym.imp.puts"
+  ]
+  node [
+    id  3
+    label  "sym.imp.strcpy"
   ]
   node [
     id  16
     label  "_ITM_registerTMCloneTable"
   ]
   node [
-    id  17
-    label  "section..plt.got"
-  ]
-  node [
-    id  18
-    label  "0x0000077e"
-  ]
-  edge [
-    source  1
-    target  0
+    id  2
+    label  "_ITM_deregisterTMCloneTable"
   ]
   edge [
     source  4
@@ -209,27 +205,31 @@ directed 1
     target  5
   ]
   edge [
-    source  8
-    target  7
+    source  18
+    target  17
+  ]
+  edge [
+    source  1
+    target  0
   ]
   edge [
     source  9
     target  7
   ]
   edge [
-    source  13
-    target  12
+    source  8
+    target  7
   ]
   edge [
     source  15
     target  14
   ]
   edge [
-    source  18
-    target  17
+    source  13
+    target  12
   ]
 ]
-{"nodes":[{"id":0,"title":"sym.imp.free","offset":1584,"out_nodes":[]},{"id":1,"title":"0x0000083f","offset":2111,"out_nodes":[0]},{"id":2,"title":"_ITM_deregisterTMCloneTable","offset":0,"out_nodes":[]},{"id":3,"title":"sym.imp.strcpy","offset":1600,"out_nodes":[]},{"id":4,"title":"0x00000814","offset":2068,"out_nodes":[3]},{"id":5,"title":"sym.imp.puts","offset":1616,"out_nodes":[]},{"id":6,"title":"0x00000833","offset":2099,"out_nodes":[5]},{"id":7,"title":"sym.imp.strlen","offset":1632,"out_nodes":[]},{"id":8,"title":"0x000007cf","offset":1999,"out_nodes":[7]},{"id":9,"title":"0x000007de","offset":2014,"out_nodes":[7]},{"id":10,"title":"__libc_start_main","offset":0,"out_nodes":[]},{"id":11,"title":"__gmon_start__","offset":0,"out_nodes":[]},{"id":12,"title":"sym.imp.malloc","offset":1648,"out_nodes":[]},{"id":13,"title":"0x000007f6","offset":2038,"out_nodes":[12]},{"id":14,"title":"sym.imp.strcat","offset":1664,"out_nodes":[]},{"id":15,"title":"0x00000827","offset":2087,"out_nodes":[14]},{"id":16,"title":"_ITM_registerTMCloneTable","offset":0,"out_nodes":[]},{"id":17,"title":"section..plt.got","offset":1680,"out_nodes":[]},{"id":18,"title":"0x0000077e","offset":1918,"out_nodes":[17]}]}
+{"nodes":[{"id":0,"title":"sym.imp.free","body":"","out_nodes":[]},{"id":1,"title":"0x0000083f","body":"","out_nodes":[0]},{"id":2,"title":"_ITM_deregisterTMCloneTable","body":"","out_nodes":[]},{"id":3,"title":"sym.imp.strcpy","body":"","out_nodes":[]},{"id":4,"title":"0x00000814","body":"","out_nodes":[3]},{"id":5,"title":"sym.imp.puts","body":"","out_nodes":[]},{"id":6,"title":"0x00000833","body":"","out_nodes":[5]},{"id":7,"title":"sym.imp.strlen","body":"","out_nodes":[]},{"id":8,"title":"0x000007cf","body":"","out_nodes":[7]},{"id":9,"title":"0x000007de","body":"","out_nodes":[7]},{"id":10,"title":"__libc_start_main","body":"","out_nodes":[]},{"id":11,"title":"__gmon_start__","body":"","out_nodes":[]},{"id":12,"title":"sym.imp.malloc","body":"","out_nodes":[]},{"id":13,"title":"0x000007f6","body":"","out_nodes":[12]},{"id":14,"title":"sym.imp.strcat","body":"","out_nodes":[]},{"id":15,"title":"0x00000827","body":"","out_nodes":[14]},{"id":16,"title":"_ITM_registerTMCloneTable","body":"","out_nodes":[]},{"id":17,"title":"section..plt.got","body":"","out_nodes":[]},{"id":18,"title":"0x0000077e","body":"","out_nodes":[17]}]}
 agraph.color_box=G1swbQ==
 agraph.delta_x=0x8a
 agraph.delta_y=0x1

--- a/test/db/cmd/cmd_agC
+++ b/test/db/cmd/cmd_agC
@@ -2,10 +2,10 @@ NAME=agCj entry0 imports libc_start_main
 FILE=bins/elf/true
 CMDS=<<EOF
 aaa 2> /dev/null
-agCj~{0}
+agCj~{nodes[0]}
 EOF
 EXPECT=<<EOF
-{"name":"entry0","size":46,"imports":["reloc.__libc_start_main"]}
+{"id":0,"title":"entry0","body":"","out_nodes":[1]}
 EOF
 RUN
 
@@ -13,11 +13,11 @@ NAME=agCd entry0 imports libc_start_main
 FILE=bins/elf/true
 CMDS=<<EOF
 aaa 2> /dev/null
-agCd~2110
+agCd~entry0
 EOF
 EXPECT=<<EOF
-  "0x00002110" [label="entry0" URL="entry0/0x00002110"];
-  "0x00002110" -> "0x00008f30" [color="#61afef" URL="reloc.__libc_start_main/0x00008f30"];
+"entry0" [URL="entry0", color="lightgray", label="entry0"]
+"entry0" -> "reloc.__libc_start_main"
 EOF
 RUN
 
@@ -28,7 +28,7 @@ aaa 2> /dev/null
 agCd~label="main"
 EOF
 EXPECT=<<EOF
-  "0x00002050" [label="main" URL="main/0x00002050"];
+"main" [URL="main", color="lightgray", label="main"]
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Extract a common API to print graphs (`ag` commands) as needed. Few things to consider about this:
- unfortunately existing code did slightly different things for different types of graph/output so when possible i tried to refactor these differences and just use one single code to output a graph in different modes. What this means is that some commands now might output slightly different output. For example, `agc`/`agC` in json mode printed:
```
[
  {
    "name": "entry0",
    "size": 46,
    "imports": [
      "reloc.__libc_start_main"
    ]
  }
]
```
while now it prints:
```
{
  "nodes": [
    {
      "id": 0,
      "title": "entry0",
      "body": "",
      "out_nodes": [
        1
      ]
    },
    {
      "id": 1,
      "title": "reloc.__libc_start_main",
      "body": "",
      "out_nodes": [
        
      ]
    }
  ]
}
```
which is the common format.
- Only `agf` commands/subcommands was not refactored for now, because it involves a lot of changes, so right now `agf` is kinda of a special case, because it uses completely different code to print a graph and to write it in different formats.


Probably Cutter needs to be fixed for the `agc`/`agC` (and maybe other) cases, while `agf` would still work.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
