### PR TITLE
Remove an old, unused help for the command `pi` ##refactor

### DIFF
--- a/librz/core/cmd_print.c
+++ b/librz/core/cmd_print.c
@@ -5168,10 +5168,6 @@ RZ_IPI int rz_cmd_print(void *data, const char *input) {
 				rz_core_disasm_pdi(core, 0, l, 0);
 			}
 			break;
-		case '?': // "pi?"
-			rz_cons_printf("|Usage: p[iI][df] [len]   print N instructions/bytes"
-				       "(f=func) (see pi? and pdi)\n");
-			break;
 		default:
 			if (l) {
 				rz_core_print_disasm_instructions(core, l, 0);
@@ -5181,7 +5177,6 @@ RZ_IPI int rz_cmd_print(void *data, const char *input) {
 	case 'i': // "pi"
 		switch (input[1]) {
 		case '?':
-			// rz_cons_printf ("|Usage: pi[defj] [num]\n");
 			rz_core_cmd_help(core, help_msg_pi);
 			break;
 		case 'u': // "piu" disasm until ret/jmp . todo: accept arg to specify type


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
There is an old, unused help for the command `pi` in `cmd_print.c`. This patch removes that.
The particular case is never triggered as `pi` is handled in another switch. And over there, a proper  
`rz_core_cmd_help` is already present.

**Test plan**
See if there's anything more can be done to make it better.

**Closing issues**

None.
