### PR TITLE
Add test for aae when non-fcn-start bb is first

### DIFF
--- a/test/db/analysis/x86_32
+++ b/test/db/analysis/x86_32
@@ -3442,3 +3442,50 @@ EXPECT=<<EOF
 \           0x08048059      int   0x80
 EOF
 RUN
+
+NAME=tiny1 aae non-start-bb first
+FILE=bins/elf/analysis/tiny1
+CMDS=<<EOF
+e io.cache=true
+$orig_end=?e `omt va_end/cols~[0]:3`
+omr 1 `omt size/cols~[0]:3`+2
+s `$orig_end`
+wa jmp entry0
+aF
+aae
+agf
+?e
+afl
+EOF
+EXPECT=<<EOF
+[0x0804805b]>  # fcn.0804805b ();
+.----.
+|    |
+|.-------------------------------------------.
+||  0x8048054                                |
+|| ; CODE XREF from fcn.0804805b @ 0x804805b |
+|| ;-- entry0:                               |
+|| ; '*'                                     |
+|| ; 42                                      |
+|| mov bl, 0x2a                              |
+|| xor eax, eax                              |
+|| inc eax                                   |
+|| ;-- syscall.exit:                         |
+|| int 0x80                                  |
+|`-------------------------------------------'
+|    v
+|    |
+|    '----------.
+|               |
+|           .---------------------.
+|           |  0x804805b          |
+|           | 9: fcn.0804805b (); |
+|           | jmp entry0          |
+|           `---------------------'
+|               v
+|               |
+`---------------'
+
+0x0804805b    2 9            fcn.0804805b
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr tests `aae` when a non-function-start basic block is first. It complements #634.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
