### PR TITLE
Refactor to use API in analysis

### DIFF
--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -15,6 +15,7 @@ RZ_IPI void rz_core_analysis_esil_init_regs(RzCore *core);
 RZ_IPI void rz_core_analysis_esil_step_over(RzCore *core);
 RZ_IPI void rz_core_analysis_esil_step_over_until(RzCore *core, ut64 addr);
 RZ_IPI void rz_core_analysis_esil_step_over_untilexpr(RzCore *core, const char *expr);
+RZ_IPI void rz_core_analysis_esil_references_all_functions(RzCore *core);
 RZ_IPI bool rz_core_analysis_var_rename(RzCore *core, const char *name, const char *newname);
 RZ_IPI void rz_core_analysis_calling_conventions_print(RzCore *core);
 RZ_IPI char *rz_core_analysis_function_signature(RzCore *core, RzOutputMode mode, char *fcn_name);
@@ -22,6 +23,7 @@ RZ_IPI bool rz_core_analysis_everything(RzCore *core, bool experimental, char *d
 RZ_IPI bool rz_core_analysis_function_delete_var(RzCore *core, RzAnalysisFunction *fcn, RzAnalysisVarKind kind, const char *id);
 RZ_IPI char *rz_core_analysis_var_display(RzCore *core, RzAnalysisVar *var, bool add_name);
 RZ_IPI char *rz_core_analysis_all_vars_display(RzCore *core, RzAnalysisFunction *fcn, bool add_name);
+RZ_IPI bool rz_core_analysis_types_propagation(RzCore *core);
 RZ_IPI char *rz_core_analysis_function_get_signature(RzCore *core, ut64 addr);
 RZ_IPI bool rz_core_analysis_function_set_signature(RzCore *core, ut64 addr, const char *newsig);
 RZ_IPI void rz_core_analysis_function_signature_editor(RzCore *core, ut64 addr);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Refactor to use proper API instead of `rz_core_cmd*()` calls to invoke Rizin commands in the analysis module (`librz/core/canalysis.c`)

**Test plan**

- CI is green

