### PR TITLE
Refactor types commands to use API

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -6520,6 +6520,20 @@ static bool cc_print(void *p, const char *k, const char *v) {
 	return true;
 }
 
+RZ_IPI RzList *rz_core_analysis_calling_conventions(RzCore *core) {
+	RzList *ccl = rz_list_new();
+	SdbKv *kv;
+	SdbListIter *iter;
+	SdbList *l = sdb_foreach_list(core->analysis->sdb_cc, true);
+	ls_foreach (l, iter, kv) {
+		if (!strcmp(sdbkv_value(kv), "cc")) {
+			rz_list_append(ccl, strdup(sdbkv_key(kv)));
+		}
+	}
+	ls_free(l);
+	return ccl;
+}
+
 RZ_IPI void rz_core_analysis_calling_conventions_print(RzCore *core) {
 	sdb_foreach(core->analysis->sdb_cc, cc_print, NULL);
 }

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -3356,7 +3356,7 @@ static int cmd_analysis_fcn(RzCore *core, const char *input) {
 			break;
 		}
 		case 'k': // "afck"
-			rz_core_kuery_print(core, "k analysis/cc/*");
+			rz_core_kuery_print(core, "analysis/cc/*");
 			break;
 		case 'l': // "afcl" list all function Calling conventions.
 			rz_core_analysis_calling_conventions_print(core);

--- a/librz/core/cmd_flag.c
+++ b/librz/core/cmd_flag.c
@@ -262,18 +262,18 @@ static void __flag_graph(RzCore *core, const char *input, int mode) {
 	rz_list_free(flags);
 }
 
-static void spaces_list(RzSpaces *sp, int mode) {
+static void spaces_list(RzSpaces *sp, RzOutputMode mode) {
 	RzSpaceIter it;
 	RzSpace *s;
 	const RzSpace *cur = rz_spaces_current(sp);
 	PJ *pj = NULL;
-	if (mode == 'j') {
+	if (mode == RZ_OUTPUT_MODE_JSON) {
 		pj = pj_new();
 		pj_a(pj);
 	}
 	rz_spaces_foreach(sp, it, s) {
 		int count = rz_spaces_count(sp, s->name);
-		if (mode == 'j') {
+		if (mode == RZ_OUTPUT_MODE_JSON) {
 			pj_o(pj);
 			pj_ks(pj, "name", s->name);
 			pj_ki(pj, "count", count);
@@ -288,10 +288,10 @@ static void spaces_list(RzSpaces *sp, int mode) {
 				s->name);
 		}
 	}
-	if (mode == '*' && rz_spaces_current(sp)) {
+	if (mode == RZ_OUTPUT_MODE_RIZIN && rz_spaces_current(sp)) {
 		rz_cons_printf("%s %s # current\n", sp->name, rz_spaces_current_name(sp));
 	}
-	if (mode == 'j') {
+	if (mode == RZ_OUTPUT_MODE_JSON) {
 		pj_end(pj);
 		rz_cons_printf("%s\n", pj_string(pj));
 		pj_free(pj);
@@ -302,7 +302,6 @@ RZ_IPI void rz_core_flag_describe(RzCore *core, ut64 addr, bool strict_offset, R
 	RzFlagItem *f = rz_flag_get_at(core->flags, addr, !strict_offset);
 	if (f) {
 		if (f->offset != addr) {
-			// if input contains 'j' print json
 			if (mode == RZ_OUTPUT_MODE_JSON) {
 				PJ *pj = pj_new();
 				pj_o(pj);
@@ -1254,13 +1253,17 @@ rep:
 			}
 		} break;
 		case 'j':
-		case '\0':
-		case '*':
-		case 'q':
-			spaces_list(&core->flags->spaces, input[1]);
+			spaces_list(&core->flags->spaces, RZ_OUTPUT_MODE_JSON);
 			break;
+		case '*':
+			spaces_list(&core->flags->spaces, RZ_OUTPUT_MODE_RIZIN);
+			break;
+		case 'q':
+			spaces_list(&core->flags->spaces, RZ_OUTPUT_MODE_QUIET);
+			break;
+		case '\0':
 		default:
-			spaces_list(&core->flags->spaces, 0);
+			spaces_list(&core->flags->spaces, RZ_OUTPUT_MODE_STANDARD);
 			break;
 		}
 		break;

--- a/librz/core/cmd_type.c
+++ b/librz/core/cmd_type.c
@@ -193,12 +193,10 @@ static void __core_cmd_tcc(RzCore *core, const char *input) {
 		}
 		break;
 	case 0:
-		rz_core_cmd0(core, "afcl");
+		rz_core_analysis_calling_conventions_print(core);
 		break;
 	case 'j': {
-		char *ccs = rz_core_cmd_strf(core, "afcl");
-		rz_str_trim(ccs);
-		RzList *list = rz_str_split_list(ccs, "\n", 0);
+		RzList *list = rz_core_analysis_calling_conventions(core);
 		RzListIter *iter;
 		const char *cc;
 		PJ *pj = pj_new();
@@ -213,12 +211,9 @@ static void __core_cmd_tcc(RzCore *core, const char *input) {
 		rz_cons_printf("%s\n", pj_string(pj));
 		pj_free(pj);
 		rz_list_free(list);
-		free(ccs);
 	} break;
 	case 'l': {
-		char *ccs = rz_core_cmd_strf(core, "afcl");
-		rz_str_trim(ccs);
-		RzList *list = rz_str_split_list(ccs, "\n", 0);
+		RzList *list = rz_core_analysis_calling_conventions(core);
 		RzListIter *iter;
 		const char *cc;
 		rz_list_foreach (list, iter, cc) {
@@ -227,12 +222,9 @@ static void __core_cmd_tcc(RzCore *core, const char *input) {
 			free(ccexpr);
 		}
 		rz_list_free(list);
-		free(ccs);
 	} break;
 	case '*': {
-		char *ccs = rz_core_cmd_strf(core, "afcl");
-		rz_str_trim(ccs);
-		RzList *list = rz_str_split_list(ccs, "\n", 0);
+		RzList *list = rz_core_analysis_calling_conventions(core);
 		RzListIter *iter;
 		const char *cc;
 		rz_list_foreach (list, iter, cc) {
@@ -241,7 +233,6 @@ static void __core_cmd_tcc(RzCore *core, const char *input) {
 			free(ccexpr);
 		}
 		rz_list_free(list);
-		free(ccs);
 	} break;
 	case 'k':
 		rz_core_cmd0(core, "afck");

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -70,4 +70,7 @@ RZ_IPI int rz_core_seek_opcode(RzCore *core, int numinstr, bool silent);
 
 /* cmd_meta.c */
 RZ_IPI void rz_core_meta_comment_add(RzCore *core, const char *comment, ut64 addr);
+
+/* cmd_flag.c */
+RZ_IPI void rz_core_flag_describe(RzCore *core, ut64 addr, bool strict_offset, RzOutputMode mode);
 #endif

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -17,6 +17,7 @@ RZ_IPI void rz_core_analysis_esil_step_over_until(RzCore *core, ut64 addr);
 RZ_IPI void rz_core_analysis_esil_step_over_untilexpr(RzCore *core, const char *expr);
 RZ_IPI void rz_core_analysis_esil_references_all_functions(RzCore *core);
 RZ_IPI bool rz_core_analysis_var_rename(RzCore *core, const char *name, const char *newname);
+RZ_IPI RzList *rz_core_analysis_calling_conventions(RzCore *core);
 RZ_IPI void rz_core_analysis_calling_conventions_print(RzCore *core);
 RZ_IPI char *rz_core_analysis_function_signature(RzCore *core, RzOutputMode mode, char *fcn_name);
 RZ_IPI bool rz_core_analysis_everything(RzCore *core, bool experimental, char *dh_orig);

--- a/librz/core/visual.c
+++ b/librz/core/visual.c
@@ -1359,7 +1359,7 @@ repeat:
 		int h, w = rz_cons_get_size(&h);
 		bool asm_bytes = rz_config_get_b(core->config, "asm.bytes");
 		rz_config_set_b(core->config, "asm.bytes", false);
-		rz_core_cmd0(core, "fd");
+		rz_core_flag_describe(core, core->offset, false, RZ_OUTPUT_MODE_STANDARD);
 
 		int maxcount = 9;
 		int rows, cols = rz_cons_get_size(&rows);
@@ -3235,7 +3235,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 				ut64 addr = rz_debug_reg_get(core->dbg, "PC");
 				if (addr && addr != UT64_MAX) {
 					rz_core_seek_and_save(core, addr, true);
-					rz_core_cmdf(core, "ar `arn PC`=0x%" PFMT64x, addr);
+					rz_core_analysis_set_reg(core, "PC", addr);
 				} else {
 					ut64 entry = rz_num_get(core->num, "entry0");
 					if (!entry || entry == UT64_MAX) {
@@ -3614,7 +3614,7 @@ RZ_API void rz_core_print_scrollbar(RzCore *core) {
 
 	int scrollbar = rz_config_get_i(core->config, "scr.scrollbar");
 	if (scrollbar == 2) {
-		// already handled by rz_core_cmd("zf:") in visual.c
+		// already handled by rz_core_cmd("fz:") in visual.c
 		return;
 	}
 	if (scrollbar > 2) {
@@ -3798,11 +3798,6 @@ static void visual_refresh(RzCore *core) {
 	vi = rz_config_get(core->config, "cmd.vprompt");
 	if (vi && *vi) {
 		rz_core_cmd0(core, vi);
-#if 0
-		char *output = rz_core_cmd_str (core, vi);
-		rz_cons_strcat_at (output, 10, 5, 20, 20);
-		free (output);
-#endif
 	}
 	rz_core_visual_title(core, color);
 	vcmd = rz_config_get(core->config, "cmd.visual");

--- a/test/db/cmd/cmd_tcc
+++ b/test/db/cmd/cmd_tcc
@@ -34,17 +34,17 @@ tccl
 tcc*
 EOF
 EXPECT=<<EOF
-["rax r13.swift (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4) r12;","rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);","rax amd64syscall (rdi, rsi, rdx, r10, r8, r9);","rax ms (rcx, rdx, r8, r9, stack);","rdi reg (rdi, rsi, rdx, rcx);"]
-rax r13.swift (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4) r12;
+["rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);","rax amd64syscall (rdi, rsi, rdx, r10, r8, r9);","rax ms (rcx, rdx, r8, r9, stack);","rdi reg (rdi, rsi, rdx, rcx);","rax r13.swift (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4) r12;"]
 rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
 rax amd64syscall (rdi, rsi, rdx, r10, r8, r9);
 rax ms (rcx, rdx, r8, r9, stack);
 rdi reg (rdi, rsi, rdx, rcx);
-tfc rax r13.swift (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4) r12;
+rax r13.swift (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4) r12;
 tfc rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
 tfc rax amd64syscall (rdi, rsi, rdx, r10, r8, r9);
 tfc rax ms (rcx, rdx, r8, r9, stack);
 tfc rdi reg (rdi, rsi, rdx, rcx);
+tfc rax r13.swift (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4) r12;
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Refactor to use proper API instead of the `rc_core_cmd*()` calls in Visual mode and some of the Types commands.
Also:
- Fixed the bug when running `afck`
- Refactored to use `RzOutputMode` enum instead of the `int`/`char` as the output mode in some flag commands.

**Test plan**

CI is green
