### PR TITLE
Make rz_cons_rgb_str* take const RzColor *

### DIFF
--- a/librz/cons/rgb.c
+++ b/librz/cons/rgb.c
@@ -287,7 +287,7 @@ static void rz_cons_rgb_gen(RzConsColorMode mode, char *outstr, size_t sz, ut8 a
 }
 
 /* Return the computed color string for the specified color in the specified mode */
-RZ_API char *rz_cons_rgb_str_mode(RzConsColorMode mode, char *outstr, size_t sz, RzColor *rcolor) {
+RZ_API char *rz_cons_rgb_str_mode(RzConsColorMode mode, char *outstr, size_t sz, const RzColor *rcolor) {
 	if (!rcolor) {
 		return NULL;
 	}
@@ -313,7 +313,7 @@ RZ_API char *rz_cons_rgb_str_mode(RzConsColorMode mode, char *outstr, size_t sz,
 }
 
 /* Return the computed color string for the specified color */
-RZ_API char *rz_cons_rgb_str(char *outstr, size_t sz, RzColor *rcolor) {
+RZ_API char *rz_cons_rgb_str(char *outstr, size_t sz, const RzColor *rcolor) {
 	return rz_cons_rgb_str_mode(rz_cons_singleton()->context->color_mode, outstr, sz, rcolor);
 }
 

--- a/librz/include/rz_cons.h
+++ b/librz/include/rz_cons.h
@@ -977,10 +977,9 @@ RZ_API int rz_cons_grep_line(char *buf, int len); // must be static
 RZ_API void rz_cons_grepbuf(void);
 
 RZ_API void rz_cons_rgb(ut8 r, ut8 g, ut8 b, ut8 a);
-RZ_API void rz_cons_rgb_fgbg(ut8 r, ut8 g, ut8 b, ut8 R, ut8 G, ut8 B);
 RZ_API void rz_cons_rgb_init(void);
-RZ_API char *rz_cons_rgb_str_mode(RzConsColorMode mode, char *outstr, size_t sz, RzColor *rcolor);
-RZ_API char *rz_cons_rgb_str(char *outstr, size_t sz, RzColor *rcolor);
+RZ_API char *rz_cons_rgb_str_mode(RzConsColorMode mode, char *outstr, size_t sz, const RzColor *rcolor);
+RZ_API char *rz_cons_rgb_str(char *outstr, size_t sz, const RzColor *rcolor);
 RZ_API char *rz_cons_rgb_str_off(char *outstr, size_t sz, ut64 off);
 RZ_API void rz_cons_color(int fg, int r, int g, int b);
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Also remove leftover rz_cons_rgb_fgbg() declaration