### PR TITLE
Fixes for MSYS2 (MinGW, Cygwin) build

### DIFF
--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -603,7 +603,7 @@ typedef enum {
 	RZ_SYS_ARCH_RISCV
 } RzSysArch;
 
-#if HAVE_CLOCK_NANOSLEEP && CLOCK_MONOTONIC && (__linux__ || (__FreeBSD__ && __FreeBSD_version >= 1101000) || (__NetBSD__ && __NetBSD_Version__ >= 700000000))
+#if HAVE_CLOCK_NANOSLEEP && defined(CLOCK_MONOTONIC) && (__linux__ || (__FreeBSD__ && __FreeBSD_version >= 1101000) || (__NetBSD__ && __NetBSD_Version__ >= 700000000))
 #define HAS_CLOCK_NANOSLEEP 1
 #else
 #define HAS_CLOCK_NANOSLEEP 0

--- a/librz/include/rz_util/rz_sys.h
+++ b/librz/include/rz_util/rz_sys.h
@@ -132,11 +132,6 @@ RZ_API int rz_sys_open(const char *path, int perm, int mode);
 RZ_API FILE *rz_sys_fopen(const char *path, const char *mode);
 RZ_API int rz_sys_truncate_fd(int fd, ut64 length);
 RZ_API int rz_sys_truncate(const char *file, int sz);
-#if __WINDOWS__
-RZ_API HANDLE rz_sys_opendir(const char *path, WIN32_FIND_DATAW *entry);
-#else
-RZ_API DIR *rz_sys_opendir(const char *path);
-#endif
 RZ_API int rz_sys_cmdbg(const char *cmd);
 RZ_API int rz_sys_cmdf(const char *fmt, ...) RZ_PRINTF_CHECK(1, 2);
 RZ_API char *rz_sys_cmd_str(const char *cmd, const char *input, int *len);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Since `rz_sys_opendir()` is platform dependent and not used anywhere outside of `librz/util/sys.c` I removed it from the API and made `static` instead. There is already `rz_sys_dir()` already in the API.

**Test plan**

All green, compilation goes further on MSYS2

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/337
