### PR TITLE
Check if Core Plugin implements call before calling

### DIFF
--- a/librz/core/cmd_api.c
+++ b/librz/core/cmd_api.c
@@ -435,7 +435,7 @@ RZ_API int rz_cmd_call(RzCmd *cmd, const char *input) {
 			}
 		}
 		rz_list_foreach (cmd->plist, iter, cp) {
-			if (cp->call(cmd->data, input)) {
+			if (cp->call && cp->call(cmd->data, input)) {
 				free(nstr);
 				return true;
 			}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

When a core plugin does not implement `call`, this would call NULL on any command if `cfg.newshell=false`. I noticed this in Cutter while having https://git.sr.ht/~thestr4ng3r/rz-commodore/tree/master/item/src/core_commodore.c#L172 loaded, which purely uses newshell commands and does not have this function.

**Test plan**

If you really want to test this, install the plugin above, then:
```
[0x00000000]> e cfg.newshell=false
[0x00000000]> djkf
Segmentation fault (core dumped)
```
