### PR TITLE
Refactor to use API instead of rz_core_cmd

### DIFF
--- a/librz/analysis/analysis.c
+++ b/librz/analysis/analysis.c
@@ -152,7 +152,6 @@ RZ_API RzAnalysis *rz_analysis_free(RzAnalysis *a) {
 	if (!a) {
 		return NULL;
 	}
-	/* TODO: Free anals here */
 	rz_list_free(a->fcns);
 	ht_up_free(a->ht_addr_fun);
 	ht_pp_free(a->ht_name_fun);

--- a/librz/core/analysis_objc.c
+++ b/librz/core/analysis_objc.c
@@ -1,12 +1,15 @@
-/* rizin - LGPL - Copyright 2019-2020 - pancake */
+// SPDX-FileCopyrightText: 2019-2020 pancake
+// SPDX-License-Identifier: LGPL-3.0-only
 
-/* This code has been written by pancake which has been based on Alvaro's
+/* This code has been based on Alvaro's
  * rzpipe-python script which was based on FireEye script for IDA Pro.
  *
  * https://www.fireeye.com/blog/threat-research/2017/03/introduction_to_reve.html
  */
 
 #include <rz_core.h>
+
+#include "core_private.h"
 
 typedef struct {
 	RzCore *core;
@@ -76,11 +79,11 @@ static ut64 readQword(RzCoreObjc *objc, ut64 addr, bool *success) {
 
 static void objc_analyze(RzCore *core) {
 	const char *oldstr = rz_print_rowlog(core->print, "Analyzing code to find selref references");
-	rz_core_cmd0(core, "aar");
+	(void)rz_core_analysis_refs(core, "");
 	if (!strcmp("arm", rz_config_get(core->config, "asm.arch"))) {
 		const bool emu_lazy = rz_config_get_i(core->config, "emu.lazy");
 		rz_config_set_i(core->config, "emu.lazy", true);
-		rz_core_cmd0(core, "aae");
+		rz_core_analysis_esil_default(core);
 		rz_config_set_i(core->config, "emu.lazy", emu_lazy);
 	}
 	rz_print_rowlog_done(core->print, oldstr);

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -8337,36 +8337,7 @@ static int cmd_analysis_all(RzCore *core, const char *input) {
 			}
 			rz_core_analysis_esil(core, len, addr);
 		} else {
-			ut64 at = core->offset;
-			RzIOMap *map;
-			RzListIter *iter;
-			RzList *list = rz_core_get_boundaries_prot(core, -1, NULL, "analysis");
-			if (!list) {
-				break;
-			}
-			if (!strcmp("range", rz_config_get(core->config, "analysis.in"))) {
-				ut64 from = rz_config_get_i(core->config, "analysis.from");
-				ut64 to = rz_config_get_i(core->config, "analysis.to");
-				if (to > from) {
-					char *len = rz_str_newf(" 0x%" PFMT64x, to - from);
-					rz_core_seek(core, from, true);
-					rz_core_analysis_esil(core, len, NULL);
-					free(len);
-				} else {
-					eprintf("Assert: analysis.from > analysis.to\n");
-				}
-			} else {
-				rz_list_foreach (list, iter, map) {
-					if (map->perm & RZ_PERM_X) {
-						char *ss = rz_str_newf(" 0x%" PFMT64x, map->itv.size);
-						rz_core_seek(core, map->itv.addr, true);
-						rz_core_analysis_esil(core, ss, NULL);
-						free(ss);
-					}
-				}
-				rz_list_free(list);
-			}
-			rz_core_seek(core, at, true);
+			rz_core_analysis_esil_default(core);
 		}
 		break;
 	case 'r': // "aar"

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -19,6 +19,7 @@ RZ_IPI void rz_core_analysis_esil_step_over_untilexpr(RzCore *core, const char *
 RZ_IPI void rz_core_analysis_esil_references_all_functions(RzCore *core);
 RZ_IPI void rz_core_analysis_esil_emulate(RzCore *core, ut64 addr, ut64 until_addr, int off);
 RZ_IPI void rz_core_analysis_esil_emulate_bb(RzCore *core);
+RZ_IPI void rz_core_analysis_esil_default(RzCore *core);
 
 RZ_IPI bool rz_core_analysis_var_rename(RzCore *core, const char *name, const char *newname);
 RZ_IPI RzList *rz_core_analysis_calling_conventions(RzCore *core);

--- a/librz/core/libs.c
+++ b/librz/core/libs.c
@@ -133,7 +133,11 @@ RZ_API int rz_core_loadlibs(RzCore *core, int where, const char *path) {
 	char *file;
 	rz_list_foreach (files, iter, file) {
 		if (__isScriptFilename(file)) {
-			rz_core_cmdf(core, ". %s/%s", homeplugindir, file);
+			char *script_file = rz_str_newf("%s/%s", homeplugindir, file);
+			if (!rz_core_run_script(core, script_file)) {
+				eprintf("Cannot find script '%s'\n", script_file);
+			}
+			free(script_file);
 		}
 	}
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Refactor to use API instead of `rz_core_cmd*()` calls in Objective C analysis and plugins loading.

**Test plan**

CI is green
