### PR TITLE
RzCore ESIL initialization code deduplication

### DIFF
--- a/librz/core/cio.c
+++ b/librz/core/cio.c
@@ -33,12 +33,15 @@ RZ_API int rz_core_setup_debugger(RzCore *r, const char *debugbackend, bool atta
 	{
 		const char *bep = rz_config_get(r->config, "dbg.bep");
 		if (bep) {
+			ut64 address = 0;
 			if (!strcmp(bep, "loader")) {
 				/* do nothing here */
 			} else if (!strcmp(bep, "entry")) {
-				rz_core_cmd(r, "dcu entry0", 0);
+				address = rz_num_math(r->num, "entry0");
+				rz_core_debug_continue_until(r, address, address);
 			} else {
-				rz_core_cmdf(r, "dcu %s", bep);
+				address = rz_num_math(r->num, bep);
+				rz_core_debug_continue_until(r, address, address);
 			}
 		}
 	}

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -5212,7 +5212,7 @@ static void cmd_analysis_esil(RzCore *core, const char *input) {
 			core->analysis->esil = NULL;
 			break;
 		case 0: // "aei"
-			rz_core_analysis_esil_init(core);
+			rz_core_analysis_esil_reinit(core);
 			break;
 		}
 		break;

--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -3875,7 +3875,7 @@ static void rz_core_debug_esil(RzCore *core, const char *input) {
 		if (rz_debug_esil_watch_empty(core->dbg)) {
 			eprintf("Error: no esil watchpoints defined\n");
 		} else {
-			rz_core_analysis_esil_init(core);
+			rz_core_analysis_esil_reinit(core);
 			rz_debug_esil_prestep(core->dbg, rz_config_get_i(core->config, "esil.prestep"));
 			rz_debug_esil_continue(core->dbg);
 		}
@@ -3883,7 +3883,7 @@ static void rz_core_debug_esil(RzCore *core, const char *input) {
 	case 's': // "des"
 		if (input[1] == 'u' && input[2] == ' ') { // "desu"
 			ut64 addr, naddr, fin = rz_num_math(core->num, input + 2);
-			rz_core_analysis_esil_init(core);
+			rz_core_analysis_esil_reinit(core);
 			addr = rz_debug_reg_get(core->dbg, "PC");
 			while (addr != fin) {
 				rz_debug_esil_prestep(core->dbg, rz_config_get_i(core->config, "esil.prestep"));
@@ -3898,7 +3898,7 @@ static void rz_core_debug_esil(RzCore *core, const char *input) {
 		} else if (input[1] == '?' || !input[1]) {
 			rz_core_cmd_help(core, help_msg_des);
 		} else {
-			rz_core_analysis_esil_init(core);
+			rz_core_analysis_esil_reinit(core);
 			rz_debug_esil_prestep(core->dbg, rz_config_get_i(core->config, "esil.prestep"));
 			// continue
 			rz_debug_esil_step(core->dbg, rz_num_math(core->num, input + 1));
@@ -4557,18 +4557,7 @@ RZ_IPI int rz_cmd_debug(void *data, const char *input) {
 			}
 			break;
 		case 'e': // "dte"
-			if (!core->analysis->esil) {
-				int stacksize = rz_config_get_i(core->config, "esil.stack.depth");
-				int romem = rz_config_get_i(core->config, "esil.romem");
-				int stats = rz_config_get_i(core->config, "esil.stats");
-				int iotrap = rz_config_get_i(core->config, "esil.iotrap");
-				int nonull = rz_config_get_i(core->config, "esil.nonull");
-				unsigned int addrsize = rz_config_get_i(core->config, "esil.addr.size");
-				if (!(core->analysis->esil = rz_analysis_esil_new(stacksize, iotrap, addrsize))) {
-					return 0;
-				}
-				rz_analysis_esil_setup(core->analysis->esil, core->analysis, romem, stats, nonull);
-			}
+			rz_core_analysis_esil_init(core);
 			switch (input[2]) {
 			case 0: // "dte"
 				rz_analysis_esil_trace_list(core->analysis->esil);

--- a/librz/core/cmd_search.c
+++ b/librz/core/cmd_search.c
@@ -1599,7 +1599,7 @@ static void do_esil_search(RzCore *core, struct search_parameters *param, const 
 	}
 	if (!core->analysis->esil) {
 		// initialize esil vm
-		rz_core_analysis_esil_init(core);
+		rz_core_analysis_esil_reinit(core);
 		if (!core->analysis->esil) {
 			eprintf("Cannot initialize the ESIL vm\n");
 			return;

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -9,6 +9,7 @@ RZ_IPI int rz_output_mode_to_char(RzOutputMode mode);
 
 RZ_IPI int rz_core_analysis_set_reg(RzCore *core, const char *regname, ut64 val);
 RZ_IPI void rz_core_analysis_esil_init(RzCore *core);
+RZ_IPI void rz_core_analysis_esil_reinit(RzCore *core);
 RZ_IPI void rz_core_analysis_esil_init_mem_del(RzCore *core, const char *name, ut64 addr, ut32 size);
 RZ_IPI void rz_core_analysis_esil_init_mem(RzCore *core, const char *name, ut64 addr, ut32 size);
 RZ_IPI void rz_core_analysis_esil_init_mem_p(RzCore *core);

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -6517,7 +6517,7 @@ RZ_API int rz_core_disasm_pde(RzCore *core, int nb_opcodes, int mode) {
 		pj_a(pj);
 	}
 	if (!core->analysis->esil) {
-		rz_core_analysis_esil_init(core);
+		rz_core_analysis_esil_reinit(core);
 		if (!rz_config_get_b(core->config, "cfg.debug")) {
 			rz_core_analysis_esil_init_mem(core, NULL, UT64_MAX, UT32_MAX);
 		}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

There were two places that initialized ESIL VM but a bit differently. Main difference was the freeing previous ESIL instance and setting `PC` register. So I called this variant `rz_core_analysis_esil_reinit()` and the one without resetting ESIL - `rz_core_analysis_esil_init()` and updated corresponding calls.

Also removed last `rz_core_cmd*()` occurences in `librz/core/cio.c`.

**Test plan**

CI is green
