### PR TITLE
Refactor to use API instead of rz_core_cmd

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -843,7 +843,7 @@ static int bin_info(RzCore *r, PJ *pj, int mode, ut64 laddr) {
 		rz_core_analysis_type_init(r);
 		rz_core_analysis_cc_init(r);
 		if (info->default_cc && rz_analysis_cc_exist(r->analysis, info->default_cc)) {
-			rz_core_cmdf(r, "e analysis.cc=%s", info->default_cc);
+			rz_config_set(r->config, "analysis.cc", info->default_cc);
 		}
 	} else if (IS_MODE_SIMPLE(mode)) {
 		rz_cons_printf("arch %s\n", info->arch);
@@ -2888,8 +2888,16 @@ static int bin_sections(RzCore *r, PJ *pj, int mode, ut64 laddr, int va, ut64 at
 					}
 				}
 				if (!loaded && !inDebugger) {
-					rz_core_cmdf(r, "on malloc://%d 0x%" PFMT64x " # bss\n",
-						section->vsize, addr);
+					char *ptr = rz_str_newf("malloc://%d", section->vsize);
+					if ((desc = rz_io_open_at(core->io, ptr, RZ_PERM_R, 0644, addr))) {
+						fd = desc->fd;
+					}
+					if (fd == -1) {
+						eprintf("Cannot open file '%'\n", ptr);
+					}
+					free(ptr);
+					core->num->value = fd;
+					rz_core_block_read(core);
 				}
 			}
 #endif

--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -5040,7 +5040,7 @@ RZ_IPI int rz_cmd_debug(void *data, const char *input) {
 			// Remove the target's registers from the flag list
 			rz_core_cmd0(core, ".dr-");
 			// Reopen and rebase the original file
-			rz_core_cmd0(core, "oo");
+			rz_core_io_file_open(core, core->io->desc->fd);
 			break;
 		case '?': // "do?"
 		default:


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Refactor `rz_core_cmd*()` calls to use proper API instead.

**Test plan**

CI is green
