### PR TITLE
Refactor to use API instead of rz_core_cmd in hack.c

### DIFF
--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -1373,7 +1373,7 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 	static int gcomp_idx = 0;
 	static bool yank_flag = 0;
 	static int gcomp = 0;
-	signed char buf[10];
+	char buf[10];
 #if USE_UTF8
 	int utflen;
 #endif

--- a/librz/core/cio.c
+++ b/librz/core/cio.c
@@ -476,6 +476,15 @@ RZ_API int rz_core_is_valid_offset(RzCore *core, ut64 offset) {
 	return rz_io_is_valid_offset(core->io, offset, 0);
 }
 
+/**
+ * Writes the hexadecimal string at the given offset
+ *
+ * Returns the length of the written data.
+ *
+ * \param core RzCore reference
+ * \param addr Address to where to write
+ * \param pairs Data as the hexadecimal string
+ */
 RZ_API int rz_core_write_hexpair(RzCore *core, ut64 addr, const char *pairs) {
 	rz_return_val_if_fail(core && pairs, 0);
 	ut8 *buf = malloc(strlen(pairs) + 1);
@@ -505,4 +514,67 @@ RZ_API int rz_core_write_hexpair(RzCore *core, ut64 addr, const char *pairs) {
 	}
 	free(buf);
 	return len;
+}
+
+/**
+ * Assembles instructions and writes the resulting data at the given offset.
+ *
+ * Returns the length of the written data or -1 in case of error
+ *
+ * \param core RzCore reference
+ * \param addr Address to where to write
+ * \param instructions List of instructions to assemble as a string
+ * \param pretend Don't write but emit the sequence of `wx` commands
+ * \param pad Fit the instruction inside the current instruction, fill with nops to pad
+ */
+RZ_API int rz_core_write_assembly(RzCore *core, ut64 addr, const char *instructions, bool pretend, bool pad) {
+	int wseek = rz_config_get_i(core->config, "cfg.wseek");
+	rz_asm_set_pc(core->rasm, core->offset);
+	RzAsmCode *acode = rz_asm_massemble(core->rasm, instructions);
+	if (!acode) {
+		return -1;
+	}
+	if (pad) { // "wai"
+		RzAnalysisOp analop;
+		if (!rz_analysis_op(core->analysis, &analop, core->offset, core->block, core->blocksize, RZ_ANALYSIS_OP_MASK_BASIC)) {
+			eprintf("Invalid instruction?\n");
+			return -1;
+		}
+		if (analop.size < acode->len) {
+			eprintf("Doesnt fit\n");
+			rz_analysis_op_fini(&analop);
+			rz_asm_code_free(acode);
+			return -1;
+		}
+		rz_analysis_op_fini(&analop);
+		rz_core_hack(core, "nop");
+	}
+	if (acode->len > 0) {
+		char *hex = rz_asm_code_get_hex(acode);
+		if (pretend) {
+			rz_cons_printf("wx %s\n", hex);
+		} else {
+			if (!rz_core_write_at(core, core->offset, acode->bytes, acode->len)) {
+				eprintf("Failed to write %d bytes at 0x%" PFMT64x "address\n", acode->len, core->offset);
+				core->num->value = 1;
+				free(hex);
+				return -1;
+			} else {
+				if (rz_config_get_i(core->config, "scr.prompt")) {
+					eprintf("Written %d byte(s) (%s) = wx %s\n", acode->len, instructions, hex);
+				}
+				if (wseek) {
+					rz_core_seek_delta(core, acode->len, true);
+				}
+			}
+			rz_core_block_read(core);
+		}
+		free(hex);
+		return acode->len;
+	} else {
+		eprintf("Nothing to do.\n");
+		return 0;
+	}
+	rz_asm_code_free(acode);
+	return -1;
 }

--- a/librz/core/cmd_write.c
+++ b/librz/core/cmd_write.c
@@ -1742,47 +1742,10 @@ RZ_IPI int rz_wa_handler_old(void *data, const char *input) {
 	case ' ':
 	case 'i':
 	case '*': {
-		const char *file = rz_str_trim_head_ro(input + 1);
-		RzAsmCode *acode;
-		rz_asm_set_pc(core->rasm, core->offset);
-		acode = rz_asm_massemble(core->rasm, file);
-		if (acode) {
-			if (input[0] == 'i') { // "wai"
-				RzAnalysisOp analop;
-				if (!rz_analysis_op(core->analysis, &analop, core->offset, core->block, core->blocksize, RZ_ANALYSIS_OP_MASK_BASIC)) {
-					eprintf("Invalid instruction?\n");
-					break;
-				}
-				if (analop.size < acode->len) {
-					eprintf("Doesnt fit\n");
-					rz_analysis_op_fini(&analop);
-					rz_asm_code_free(acode);
-					break;
-				}
-				rz_analysis_op_fini(&analop);
-				rz_core_cmd0(core, "wao nop");
-			}
-			if (acode->len > 0) {
-				char *hex = rz_asm_code_get_hex(acode);
-				if (input[0] == '*') {
-					rz_cons_printf("wx %s\n", hex);
-				} else {
-					if (!rz_core_write_at(core, core->offset, acode->bytes, acode->len)) {
-						cmd_write_fail(core);
-					} else {
-						if (rz_config_get_i(core->config, "scr.prompt")) {
-							eprintf("Written %d byte(s) (%s) = wx %s\n", acode->len, input + 1, hex);
-						}
-						WSEEK(core, acode->len);
-					}
-					rz_core_block_read(core);
-				}
-				free(hex);
-			} else {
-				eprintf("Nothing to do.\n");
-			}
-			rz_asm_code_free(acode);
-		}
+		bool pad = input[0] == 'i'; // "wai"
+		bool pretend = input[0] == '*'; // "wa*"
+		const char *instructions = rz_str_trim_head_ro(input + 1);
+		rz_core_write_assembly(core, core->offset, instructions, pretend, pad);
 	} break;
 	case 'f': // "waf"
 		if ((input[1] == ' ' || input[1] == '*')) {

--- a/librz/core/hack.c
+++ b/librz/core/hack.c
@@ -28,15 +28,15 @@ void rz_core_hack_help(const RzCore *core) {
 
 RZ_API bool rz_core_hack_dalvik(RzCore *core, const char *op, const RzAnalysisOp *analop) {
 	if (!strcmp(op, "nop")) {
-		rz_core_cmdf(core, "wx 0000");
+		rz_core_write_hexpair(core, core->offset, "0000");
 	} else if (!strcmp(op, "ret2")) {
-		rz_core_cmdf(core, "wx 12200f00"); // mov v0, 2;ret v0
+		rz_core_write_hexpair(core, core->offset, "12200f00"); // mov v0, 2;ret v0
 	} else if (!strcmp(op, "jinf")) {
-		rz_core_cmd0(core, "wx 2800\n");
+		rz_core_write_hexpair(core, core->offset, "2800");
 	} else if (!strcmp(op, "ret1")) {
-		rz_core_cmdf(core, "wx 12100f00"); // mov v0, 1;ret v0
+		rz_core_write_hexpair(core, core->offset, "12100f00"); // mov v0, 1;ret v0
 	} else if (!strcmp(op, "ret0")) {
-		rz_core_cmdf(core, "wx 12000f00"); // mov v0, 0;ret v0
+		rz_core_write_hexpair(core, core->offset, "12000f00"); // mov v0, 0;ret v0
 	} else {
 		eprintf("Unsupported operation '%s'\n", op);
 		return false;
@@ -46,16 +46,16 @@ RZ_API bool rz_core_hack_dalvik(RzCore *core, const char *op, const RzAnalysisOp
 
 RZ_API bool rz_core_hack_arm64(RzCore *core, const char *op, const RzAnalysisOp *analop) {
 	if (!strcmp(op, "nop")) {
-		rz_core_cmdf(core, "wx 1f2003d5");
+		rz_core_write_hexpair(core, core->offset, "1f2003d5");
 	} else if (!strcmp(op, "ret")) {
-		rz_core_cmdf(core, "wx c0035fd6t");
+		rz_core_write_hexpair(core, core->offset, "c0035fd6t");
 	} else if (!strcmp(op, "trap")) {
-		rz_core_cmdf(core, "wx 000020d4");
+		rz_core_write_hexpair(core, core->offset, "000020d4");
 	} else if (!strcmp(op, "jz")) {
 		eprintf("ARM jz hack not supported\n");
 		return false;
 	} else if (!strcmp(op, "jinf")) {
-		rz_core_cmdf(core, "wx 00000014");
+		rz_core_write_hexpair(core, core->offset, "00000014");
 	} else if (!strcmp(op, "jnz")) {
 		eprintf("ARM jnz hack not supported\n");
 		return false;
@@ -66,11 +66,11 @@ RZ_API bool rz_core_hack_arm64(RzCore *core, const char *op, const RzAnalysisOp 
 		eprintf("TODO: use jnz or jz\n");
 		return false;
 	} else if (!strcmp(op, "ret1")) {
-		rz_core_cmdf(core, "wa mov x0, 1,,ret");
+		rz_core_write_assembly(core, core->offset, "mov x0, 1,,ret", false, false);
 	} else if (!strcmp(op, "ret0")) {
-		rz_core_cmdf(core, "wa mov x0, 0,,ret");
+		rz_core_write_assembly(core, core->offset, "mov x0, 0,,ret", false, false);
 	} else if (!strcmp(op, "retn")) {
-		rz_core_cmdf(core, "wa mov x0, -1,,ret");
+		rz_core_write_assembly(core, core->offset, "mov x0, -1,,ret", false, false);
 	} else {
 		eprintf("Invalid operation '%s'\n", op);
 		return false;
@@ -101,24 +101,23 @@ RZ_API bool rz_core_hack_arm(RzCore *core, const char *op, const RzAnalysisOp *a
 			memcpy(str + i * 2, nopcode, nopsize * 2);
 		}
 		str[len * 2] = '\0';
-		rz_core_cmdf(core, "wx %s\n", str);
+		rz_core_write_hexpair(core, core->offset, str);
 		free(str);
 	} else if (!strcmp(op, "jinf")) {
-		rz_core_cmdf(core, "wx %s\n", (bits == 16) ? "fee7" : "feffffea");
+		rz_core_write_hexpair(core, core->offset, (bits == 16) ? "fee7" : "feffffea");
 	} else if (!strcmp(op, "trap")) {
-		const char *trapcode = (bits == 16) ? "bebe" : "fedeffe7";
-		rz_core_cmdf(core, "wx %s\n", trapcode);
+		rz_core_write_hexpair(core, core->offset, (bits == 16) ? "bebe" : "fedeffe7");
 	} else if (!strcmp(op, "jz")) {
 		if (bits == 16) {
 			switch (b[1]) {
 			case 0xb9: // CBNZ
-				rz_core_cmd0(core, "wx b1 @ $$+1\n"); //CBZ
+				rz_core_write_hexpair(core, core->offset + 1, "b1"); //CBZ
 				break;
 			case 0xbb: // CBNZ
-				rz_core_cmd0(core, "wx b3 @ $$+1\n"); //CBZ
+				rz_core_write_hexpair(core, core->offset + 1, "b3"); //CBZ
 				break;
 			case 0xd1: // BNE
-				rz_core_cmd0(core, "wx d0 @ $$+1\n"); //BEQ
+				rz_core_write_hexpair(core, core->offset + 1, "d0"); //BEQ
 				break;
 			default:
 				eprintf("Current opcode is not conditional\n");
@@ -132,13 +131,13 @@ RZ_API bool rz_core_hack_arm(RzCore *core, const char *op, const RzAnalysisOp *a
 		if (bits == 16) {
 			switch (b[1]) {
 			case 0xb1: // CBZ
-				rz_core_cmd0(core, "wx b9 @ $$+1\n"); //CBNZ
+				rz_core_write_hexpair(core, core->offset + 1, "b9"); //CBNZ
 				break;
 			case 0xb3: // CBZ
-				rz_core_cmd0(core, "wx bb @ $$+1\n"); //CBNZ
+				rz_core_write_hexpair(core, core->offset + 1, "bb"); //CBNZ
 				break;
 			case 0xd0: // BEQ
-				rz_core_cmd0(core, "wx d1 @ $$+1\n"); //BNE
+				rz_core_write_hexpair(core, core->offset + 1, "d1"); //BNE
 				break;
 			default:
 				eprintf("Current opcode is not conditional\n");
@@ -158,7 +157,7 @@ RZ_API bool rz_core_hack_arm(RzCore *core, const char *op, const RzAnalysisOp *a
 			case 0xb9: // CBNZ
 			case 0xbb: // CBNZ
 			case 0xd1: // BNE
-				rz_core_cmd0(core, "wx e0 @ $$+1\n"); //BEQ
+				rz_core_write_hexpair(core, core->offset + 1, "e0"); //BEQ
 				break;
 			default:
 				eprintf("Current opcode is not conditional\n");
@@ -173,21 +172,21 @@ RZ_API bool rz_core_hack_arm(RzCore *core, const char *op, const RzAnalysisOp *a
 		return false;
 	} else if (!strcmp(op, "ret1")) {
 		if (bits == 16) {
-			rz_core_cmd0(core, "wx 01207047\n"); // mov r0, 1; bx lr
+			rz_core_write_hexpair(core, core->offset, "01207047"); // mov r0, 1; bx lr
 		} else {
-			rz_core_cmd0(core, "wx 0100b0e31eff2fe1\n"); // movs r0, 1; bx lr
+			rz_core_write_hexpair(core, core->offset, "0100b0e31eff2fe1"); // movs r0, 1; bx lr
 		}
 	} else if (!strcmp(op, "ret0")) {
 		if (bits == 16) {
-			rz_core_cmd0(core, "wx 00207047\n"); // mov r0, 0; bx lr
+			rz_core_write_hexpair(core, core->offset, "00207047"); // mov r0, 0; bx lr
 		} else {
-			rz_core_cmd0(core, "wx 0000a0e31eff2fe1\n"); // movs r0, 0; bx lr
+			rz_core_write_hexpair(core, core->offset, "0000a0e31eff2fe1"); // movs r0, 0; bx lr
 		}
 	} else if (!strcmp(op, "retn")) {
 		if (bits == 16) {
-			rz_core_cmd0(core, "wx ff207047\n"); // mov r0, -1; bx lr
+			rz_core_write_hexpair(core, core->offset, "ff207047"); // mov r0, -1; bx lr
 		} else {
-			rz_core_cmd0(core, "wx ff00a0e31eff2fe1\n"); // movs r0, -1; bx lr
+			rz_core_write_hexpair(core, core->offset, "ff00a0e31eff2fe1"); // movs r0, -1; bx lr
 		}
 	} else {
 		eprintf("Invalid operation\n");
@@ -211,31 +210,31 @@ RZ_API bool rz_core_hack_x86(RzCore *core, const char *op, const RzAnalysisOp *a
 			memcpy(str + (i * 2), "90", 2);
 		}
 		str[size * 2] = '\0';
-		rz_core_cmdf(core, "wx %s\n", str);
+		rz_core_write_hexpair(core, core->offset, str);
 		free(str);
 	} else if (!strcmp(op, "trap")) {
-		rz_core_cmd0(core, "wx cc\n");
+		rz_core_write_hexpair(core, core->offset, "cc");
 	} else if (!strcmp(op, "jz")) {
 		if (b[0] == 0x75) {
-			rz_core_cmd0(core, "wx 74\n");
+			rz_core_write_hexpair(core, core->offset, "74");
 		} else {
 			eprintf("Current opcode is not conditional\n");
 			return false;
 		}
 	} else if (!strcmp(op, "jinf")) {
-		rz_core_cmd0(core, "wx ebfe\n");
+		rz_core_write_hexpair(core, core->offset, "ebfe");
 	} else if (!strcmp(op, "jnz")) {
 		if (b[0] == 0x74) {
-			rz_core_cmd0(core, "wx 75\n");
+			rz_core_write_hexpair(core, core->offset, "75");
 		} else {
 			eprintf("Current opcode is not conditional\n");
 			return false;
 		}
 	} else if (!strcmp(op, "nocj")) {
 		if (*b == 0xf) {
-			rz_core_cmd0(core, "wx 90e9");
+			rz_core_write_hexpair(core, core->offset, "90e9");
 		} else if (b[0] >= 0x70 && b[0] <= 0x7f) {
-			rz_core_cmd0(core, "wx eb");
+			rz_core_write_hexpair(core, core->offset, "eb");
 		} else {
 			eprintf("Current opcode is not conditional\n");
 			return false;
@@ -243,19 +242,23 @@ RZ_API bool rz_core_hack_x86(RzCore *core, const char *op, const RzAnalysisOp *a
 	} else if (!strcmp(op, "recj")) {
 		int is_near = (*b == 0xf);
 		if (b[0] < 0x80 && b[0] >= 0x70) { // short jmps: jo, jno, jb, jae, je, jne, jbe, ja, js, jns
-			rz_core_cmdf(core, "wx %x\n", (b[0] % 2) ? b[0] - 1 : b[0] + 1);
+			char *opcode = rz_str_newf("%x", (b[0] % 2) ? b[0] - 1 : b[0] + 1);
+			rz_core_write_hexpair(core, core->offset, opcode);
+			free(opcode);
 		} else if (is_near && b[1] < 0x90 && b[1] >= 0x80) { // near jmps: jo, jno, jb, jae, je, jne, jbe, ja, js, jns
-			rz_core_cmdf(core, "wx 0f%x\n", (b[1] % 2) ? b[1] - 1 : b[1] + 1);
+			char *opcode = rz_str_newf("0f%x", (b[1] % 2) ? b[1] - 1 : b[1] + 1);
+			rz_core_write_hexpair(core, core->offset, opcode);
+			free(opcode);
 		} else {
 			eprintf("Invalid conditional jump opcode\n");
 			return false;
 		}
 	} else if (!strcmp(op, "ret1")) {
-		rz_core_cmd0(core, "wx c20100\n");
+		rz_core_write_hexpair(core, core->offset, "c20100");
 	} else if (!strcmp(op, "ret0")) {
-		rz_core_cmd0(core, "wx c20000\n");
+		rz_core_write_hexpair(core, core->offset, "c20000");
 	} else if (!strcmp(op, "retn")) {
-		rz_core_cmd0(core, "wx c2ffff\n");
+		rz_core_write_hexpair(core, core->offset, "c2ffff");
 	} else {
 		eprintf("Invalid operation '%s'\n", op);
 		return false;

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -449,6 +449,7 @@ RZ_API int rz_core_block_read(RzCore *core);
 RZ_API int rz_core_block_size(RzCore *core, int bsize);
 RZ_API int rz_core_is_valid_offset(RzCore *core, ut64 offset);
 RZ_API int rz_core_write_hexpair(RzCore *core, ut64 addr, const char *pairs);
+RZ_API int rz_core_write_assembly(RzCore *core, ut64 addr, const char *instructions, bool pretend, bool pad);
 RZ_API int rz_core_shift_block(RzCore *core, ut64 addr, ut64 b_size, st64 dist);
 RZ_API void rz_core_autocomplete(RZ_NULLABLE RzCore *core, RzLineCompletion *completion, RzLineBuffer *buf, RzLinePromptType prompt_type);
 RZ_API RzLineNSCompletionResult *rz_core_autocomplete_newshell(RzCore *core, RzLineBuffer *buf, RzLinePromptType prompt_type);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Refactor `rz_core_cmd*()` calls to use proper API instead in `librz/core/hack.c` that writes a lot of hexpairs.
 Also introduced new `RZ_API int rz_core_write_assembly(RzCore *core, ut64 addr, const char *instructions, bool pretend, bool pad)` function to assemble and write instructions.

**Test plan**

CI is green
