### PR TITLE
Travis CI: wait for more than 10 min

### DIFF
--- a/travis-script
+++ b/travis-script
@@ -32,7 +32,7 @@ if [ "${COVERAGE}" == "1" ] ; then
 	OPTS="${OPTS} -Db_coverage=true"
 fi
 
-meson --prefix=${TRAVIS_BUILD_DIR}/install ${OPTS} build || exit 1
+travis_wait meson --prefix=${TRAVIS_BUILD_DIR}/install ${OPTS} build || exit 1
 ninja -C build || exit 1
 ninja -C build install || exit 1
 export PKG_CONFIG_PATH=$(pwd)/build/meson-private:${PKG_CONFIG_PATH}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Currently Travis CI job on PPC worker stalls during the `meson build` stage, I guess because of the fetching subprojects.
Trying to check if waiting more will fix the problem

```
+meson --prefix=/home/travis/build/rizinorg/rizin/install -Duse_webui=true build

No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.

Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received

The build has been terminated
````
https://travis-ci.com/github/rizinorg/rizin/jobs/486181160#L236

**Test plan**

Travis CI PPC builds and runs tests fine.
