### PR TITLE
core: retrieve parents details when not available

### DIFF
--- a/librz/core/cmd_api.c
+++ b/librz/core/cmd_api.c
@@ -968,10 +968,22 @@ static char *argv_modes_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
 	return rz_strbuf_drain(sb);
 }
 
+const RzCmdDescDetail *get_cd_details(RzCmdDesc *cd) {
+	do {
+		if (cd->help->details) {
+			return cd->help->details;
+		}
+		cd = cd->parent;
+	} while (cd);
+	return NULL;
+}
+
 static void fill_details(RzCmd *cmd, RzCmdDesc *cd, RzStrBuf *sb, bool use_color) {
-	if (!cd->help->details) {
+	const RzCmdDescDetail *detail_it = get_cd_details(cd);
+	if (!detail_it) {
 		return;
 	}
+
 	const char *pal_help_color = "",
 		   *pal_input_color = "",
 		   *pal_label_color = "",
@@ -986,7 +998,6 @@ static void fill_details(RzCmd *cmd, RzCmdDesc *cd, RzStrBuf *sb, bool use_color
 		pal_reset = cons->context->pal.reset;
 	}
 
-	const RzCmdDescDetail *detail_it = cd->help->details;
 	while (detail_it->name) {
 		if (!RZ_STR_ISEMPTY(detail_it->name)) {
 			rz_strbuf_appendf(sb, "\n%s%s:%s\n", pal_label_color, detail_it->name, pal_reset);

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -848,6 +848,40 @@ bool test_get_arg(void) {
 	mu_end;
 }
 
+bool test_parent_details(void) {
+	const RzCmdDescDetailEntry z_help_examples[] = {
+		{ .text = "z", .comment = "comment" },
+		{ 0 },
+	};
+	const RzCmdDescDetail z_help_details[] = {
+		{ .name = "Examples", .entries = z_help_examples },
+		{ 0 },
+	};
+
+	RzCmdDescHelp z_group_help = { 0 };
+	z_group_help.summary = "z summary";
+	z_group_help.details = z_help_details;
+	RzCmdDescArg zx_args[] = {
+		{ 0 }
+	};
+	RzCmdDescHelp zx_help = { 0 };
+	zx_help.summary = "x summary";
+	zx_help.args = zx_args;
+	RzCmd *cmd = rz_cmd_new(false, false);
+	RzCmdDesc *root = rz_cmd_get_root(cmd);
+	RzCmdDesc *z_cd = rz_cmd_desc_group_new(cmd, root, "z", NULL, NULL, &z_group_help);
+	rz_cmd_desc_argv_new(cmd, z_cd, "zx", x_array_handler, &zx_help);
+
+	RzCmdParsedArgs *args = rz_cmd_parsed_args_new("zx??", 0, NULL);
+	char *h = rz_cmd_get_help(cmd, args, false);
+	mu_assert_strcontains(h, "Examples", "zx help should include examples from parent z");
+	mu_assert_strcontains(h, "comment", "zx help should include examples from parent z");
+	free(h);
+
+	rz_cmd_free(cmd);
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test(test_parsed_args_noargs);
 	mu_run_test(test_parsed_args_onearg);
@@ -876,6 +910,7 @@ int all_tests() {
 	mu_run_test(test_single_quoted_arg_escaping);
 	mu_run_test(test_arg_flags);
 	mu_run_test(test_get_arg);
+	mu_run_test(test_parent_details);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Some commands might be very similar and it would be a waste of memory and developers time having to repeat the same things for multiple commands. For example, see `wv8`, `wv1`, `wv2`, etc. They do exactly the same thing, so apart from the different description, you could easily provide the same examples showing all usecases, instead of having to repeat the same things 4 times.

This PR solves the problem by retrieving the parent group details in case the current command descriptor does not have any details available.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #81 