### PR TITLE
Migrating types command to the newshell

### DIFF
--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -111,6 +111,8 @@ static const RzCmdDescArg type_list_c_nl_args[2];
 static const RzCmdDescArg type_cc_list_args[2];
 static const RzCmdDescArg type_cc_del_args[2];
 static const RzCmdDescArg type_define_args[2];
+static const RzCmdDescArg type_list_function_args[2];
+static const RzCmdDescArg type_function_c_args[2];
 static const RzCmdDescArg type_kuery_args[2];
 static const RzCmdDescArg type_list_noreturn_args[2];
 static const RzCmdDescArg type_noreturn_del_args[2];
@@ -2068,6 +2070,39 @@ static const RzCmdDescHelp type_define_help = {
 	.args = type_define_args,
 };
 
+static const RzCmdDescHelp tf_help = {
+	.summary = "List loaded functions definitions",
+};
+static const RzCmdDescArg type_list_function_args[] = {
+	{
+		.name = "type",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_list_function_help = {
+	.summary = "List loaded function definitions / Show function signature",
+	.args = type_list_function_args,
+};
+
+static const RzCmdDescArg type_function_c_args[] = {
+	{
+		.name = "type",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_function_c_help = {
+	.summary = "Show function definition in the C output format",
+	.args = type_function_c_args,
+};
+
 static const RzCmdDescArg type_kuery_args[] = {
 	{
 		.name = "type",
@@ -3702,6 +3737,11 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *type_define_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_type_cd, "td", rz_type_define_handler, &type_define_help);
 	rz_warn_if_fail(type_define_cd);
+
+	RzCmdDesc *tf_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "tf", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_SDB, rz_type_list_function_handler, &type_list_function_help, &tf_help);
+	rz_warn_if_fail(tf_cd);
+	RzCmdDesc *type_function_c_cd = rz_cmd_desc_argv_modes_new(core->rcmd, tf_cd, "tfc", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_type_function_c_handler, &type_function_c_help);
+	rz_warn_if_fail(type_function_c_cd);
 
 	RzCmdDesc *type_kuery_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_type_cd, "tk", rz_type_kuery_handler, &type_kuery_help);
 	rz_warn_if_fail(type_kuery_cd);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -111,6 +111,11 @@ static const RzCmdDescArg type_list_c_nl_args[2];
 static const RzCmdDescArg type_cc_list_args[2];
 static const RzCmdDescArg type_cc_del_args[2];
 static const RzCmdDescArg type_define_args[2];
+static const RzCmdDescArg type_list_enum_args[3];
+static const RzCmdDescArg type_enum_bitfield_args[3];
+static const RzCmdDescArg type_enum_c_args[2];
+static const RzCmdDescArg type_enum_c_nl_args[2];
+static const RzCmdDescArg type_enum_find_args[2];
 static const RzCmdDescArg type_list_function_args[2];
 static const RzCmdDescArg type_function_c_args[2];
 static const RzCmdDescArg type_kuery_args[2];
@@ -2070,6 +2075,93 @@ static const RzCmdDescHelp type_define_help = {
 	.args = type_define_args,
 };
 
+static const RzCmdDescHelp te_help = {
+	.summary = "List loaded enums",
+};
+static const RzCmdDescArg type_list_enum_args[] = {
+	{
+		.name = "enum",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.optional = true,
+
+	},
+	{
+		.name = "value",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_list_enum_help = {
+	.summary = "List loaded enums / Show enum member",
+	.args = type_list_enum_args,
+};
+
+static const RzCmdDescArg type_enum_bitfield_args[] = {
+	{
+		.name = "enum",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+
+	},
+	{
+		.name = "field",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_enum_bitfield_help = {
+	.summary = "Show enum bitfield",
+	.args = type_enum_bitfield_args,
+};
+
+static const RzCmdDescArg type_enum_c_args[] = {
+	{
+		.name = "enum",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_enum_c_help = {
+	.summary = "Show enum in the C output format",
+	.args = type_enum_c_args,
+};
+
+static const RzCmdDescArg type_enum_c_nl_args[] = {
+	{
+		.name = "enum",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_enum_c_nl_help = {
+	.summary = "Show enum in the C output format without newlines",
+	.args = type_enum_c_nl_args,
+};
+
+static const RzCmdDescArg type_enum_find_args[] = {
+	{
+		.name = "value",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_enum_find_help = {
+	.summary = "Find enum and member by the member value",
+	.args = type_enum_find_args,
+};
+
 static const RzCmdDescHelp tf_help = {
 	.summary = "List loaded functions definitions",
 };
@@ -3737,6 +3829,20 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *type_define_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_type_cd, "td", rz_type_define_handler, &type_define_help);
 	rz_warn_if_fail(type_define_cd);
+
+	RzCmdDesc *te_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "te", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_SDB, rz_type_list_enum_handler, &type_list_enum_help, &te_help);
+	rz_warn_if_fail(te_cd);
+	RzCmdDesc *type_enum_bitfield_cd = rz_cmd_desc_argv_new(core->rcmd, te_cd, "teb", rz_type_enum_bitfield_handler, &type_enum_bitfield_help);
+	rz_warn_if_fail(type_enum_bitfield_cd);
+
+	RzCmdDesc *type_enum_c_cd = rz_cmd_desc_argv_new(core->rcmd, te_cd, "tec", rz_type_enum_c_handler, &type_enum_c_help);
+	rz_warn_if_fail(type_enum_c_cd);
+
+	RzCmdDesc *type_enum_c_nl_cd = rz_cmd_desc_argv_new(core->rcmd, te_cd, "ted", rz_type_enum_c_nl_handler, &type_enum_c_nl_help);
+	rz_warn_if_fail(type_enum_c_nl_cd);
+
+	RzCmdDesc *type_enum_find_cd = rz_cmd_desc_argv_new(core->rcmd, te_cd, "tef", rz_type_enum_find_handler, &type_enum_find_help);
+	rz_warn_if_fail(type_enum_find_cd);
 
 	RzCmdDesc *tf_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "tf", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_SDB, rz_type_list_function_handler, &type_list_function_help, &tf_help);
 	rz_warn_if_fail(tf_cd);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -117,7 +117,6 @@ static const RzCmdDescArg type_enum_c_args[2];
 static const RzCmdDescArg type_enum_c_nl_args[2];
 static const RzCmdDescArg type_enum_find_args[2];
 static const RzCmdDescArg type_list_function_args[2];
-static const RzCmdDescArg type_function_c_args[2];
 static const RzCmdDescArg type_kuery_args[2];
 static const RzCmdDescArg type_list_noreturn_args[2];
 static const RzCmdDescArg type_noreturn_del_args[2];
@@ -2183,21 +2182,6 @@ static const RzCmdDescHelp type_list_function_help = {
 	.args = type_list_function_args,
 };
 
-static const RzCmdDescArg type_function_c_args[] = {
-	{
-		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
-		.optional = true,
-
-	},
-	{ 0 },
-};
-static const RzCmdDescHelp type_function_c_help = {
-	.summary = "Show function definition in the C output format",
-	.args = type_function_c_args,
-};
-
 static const RzCmdDescArg type_kuery_args[] = {
 	{
 		.name = "type",
@@ -3893,8 +3877,6 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *tf_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "tf", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_SDB, rz_type_list_function_handler, &type_list_function_help, &tf_help);
 	rz_warn_if_fail(tf_cd);
-	RzCmdDesc *type_function_c_cd = rz_cmd_desc_argv_modes_new(core->rcmd, tf_cd, "tfc", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_type_function_c_handler, &type_function_c_help);
-	rz_warn_if_fail(type_function_c_cd);
 
 	RzCmdDesc *type_kuery_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_type_cd, "tk", rz_type_kuery_handler, &type_kuery_help);
 	rz_warn_if_fail(type_kuery_cd);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -121,6 +121,9 @@ static const RzCmdDescArg type_function_c_args[2];
 static const RzCmdDescArg type_kuery_args[2];
 static const RzCmdDescArg type_list_noreturn_args[2];
 static const RzCmdDescArg type_noreturn_del_args[2];
+static const RzCmdDescArg type_open_file_args[2];
+static const RzCmdDescArg type_open_editor_args[2];
+static const RzCmdDescArg type_open_sdb_args[2];
 static const RzCmdDescArg type_list_typedef_args[2];
 static const RzCmdDescArg type_typedef_c_args[2];
 static const RzCmdDescArg type_list_union_args[2];
@@ -2250,6 +2253,50 @@ static const RzCmdDescHelp type_noreturn_del_all_help = {
 	.args = type_noreturn_del_all_args,
 };
 
+static const RzCmdDescHelp to_help = {
+	.summary = "Open C header file and load types from it",
+};
+static const RzCmdDescArg type_open_file_args[] = {
+	{
+		.name = "file",
+		.type = RZ_CMD_ARG_TYPE_FILE,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_open_file_help = {
+	.summary = "Open C header file and load types from it",
+	.args = type_open_file_args,
+};
+
+static const RzCmdDescArg type_open_editor_args[] = {
+	{
+		.name = "type",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_open_editor_help = {
+	.summary = "Open cfg.editor to edit types",
+	.args = type_open_editor_args,
+};
+
+static const RzCmdDescArg type_open_sdb_args[] = {
+	{
+		.name = "file",
+		.type = RZ_CMD_ARG_TYPE_FILE,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_open_sdb_help = {
+	.summary = "Open SDB file and load types from it",
+	.args = type_open_sdb_args,
+};
+
 static const RzCmdDescHelp tt_help = {
 	.summary = "List loaded typedefs",
 };
@@ -3859,6 +3906,14 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *type_noreturn_del_all_cd = rz_cmd_desc_argv_new(core->rcmd, tn_cd, "tn-*", rz_type_noreturn_del_all_handler, &type_noreturn_del_all_help);
 	rz_warn_if_fail(type_noreturn_del_all_cd);
+
+	RzCmdDesc *to_cd = rz_cmd_desc_group_new(core->rcmd, cmd_type_cd, "to", rz_type_open_file_handler, &type_open_file_help, &to_help);
+	rz_warn_if_fail(to_cd);
+	RzCmdDesc *type_open_editor_cd = rz_cmd_desc_argv_new(core->rcmd, to_cd, "toe", rz_type_open_editor_handler, &type_open_editor_help);
+	rz_warn_if_fail(type_open_editor_cd);
+
+	RzCmdDesc *type_open_sdb_cd = rz_cmd_desc_argv_new(core->rcmd, to_cd, "tos", rz_type_open_sdb_handler, &type_open_sdb_help);
+	rz_warn_if_fail(type_open_sdb_cd);
 
 	RzCmdDesc *tt_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "tt", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_type_list_typedef_handler, &type_list_typedef_help, &tt_help);
 	rz_warn_if_fail(tt_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -167,6 +167,9 @@ RZ_IPI RzCmdStatus rz_type_kuery_handler(RzCore *core, int argc, const char **ar
 RZ_IPI RzCmdStatus rz_type_list_noreturn_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI RzCmdStatus rz_type_noreturn_del_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_noreturn_del_all_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_open_file_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_open_editor_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_open_sdb_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_list_typedef_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI RzCmdStatus rz_type_typedef_c_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_list_union_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -156,6 +156,11 @@ RZ_IPI RzCmdStatus rz_type_cc_list_handler(RzCore *core, int argc, const char **
 RZ_IPI RzCmdStatus rz_type_cc_del_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_cc_del_all_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_define_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_list_enum_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
+RZ_IPI RzCmdStatus rz_type_enum_bitfield_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_enum_c_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_enum_c_nl_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_enum_find_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_list_function_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI RzCmdStatus rz_type_function_c_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI RzCmdStatus rz_type_kuery_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -156,6 +156,8 @@ RZ_IPI RzCmdStatus rz_type_cc_list_handler(RzCore *core, int argc, const char **
 RZ_IPI RzCmdStatus rz_type_cc_del_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_cc_del_all_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_define_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_list_function_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
+RZ_IPI RzCmdStatus rz_type_function_c_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI RzCmdStatus rz_type_kuery_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_list_noreturn_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI RzCmdStatus rz_type_noreturn_del_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -162,7 +162,6 @@ RZ_IPI RzCmdStatus rz_type_enum_c_handler(RzCore *core, int argc, const char **a
 RZ_IPI RzCmdStatus rz_type_enum_c_nl_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_enum_find_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_list_function_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
-RZ_IPI RzCmdStatus rz_type_function_c_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI RzCmdStatus rz_type_kuery_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_list_noreturn_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI RzCmdStatus rz_type_noreturn_del_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_type.yaml
+++ b/librz/core/cmd_descs/cmd_type.yaml
@@ -109,16 +109,6 @@ commands:
           - name: type
             type: RZ_CMD_ARG_TYPE_STRING
             optional: true
-      - name: tfc
-        cname: type_function_c
-        summary: Show function definition in the C output format
-        modes:
-          - RZ_OUTPUT_MODE_STANDARD
-          - RZ_OUTPUT_MODE_JSON
-        args:
-          - name: type
-            type: RZ_CMD_ARG_TYPE_STRING
-            optional: true
   - name: tk
     cname: type_kuery
     summary: Perform SDB query on types database

--- a/librz/core/cmd_descs/cmd_type.yaml
+++ b/librz/core/cmd_descs/cmd_type.yaml
@@ -50,6 +50,51 @@ commands:
     args:
       - name: type
         type: RZ_CMD_ARG_TYPE_STRING
+  - name: te
+    summary: List loaded enums
+    subcommands:
+      - name: te
+        cname: type_list_enum
+        summary: List loaded enums / Show enum member
+        modes:
+          - RZ_OUTPUT_MODE_STANDARD
+          - RZ_OUTPUT_MODE_JSON
+          - RZ_OUTPUT_MODE_SDB
+        args:
+          - name: enum
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+          - name: value
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+      - name: teb
+        cname: type_enum_bitfield
+        summary: Show enum bitfield
+        args:
+          - name: enum
+            type: RZ_CMD_ARG_TYPE_STRING
+          - name: field
+            type: RZ_CMD_ARG_TYPE_STRING
+      - name: tec
+        cname: type_enum_c
+        summary: Show enum in the C output format
+        args:
+          - name: enum
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+      - name: ted
+        cname: type_enum_c_nl
+        summary: Show enum in the C output format without newlines
+        args:
+          - name: enum
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+      - name: tef
+        cname: type_enum_find
+        summary: Find enum and member by the member value
+        args:
+          - name: value
+            type: RZ_CMD_ARG_TYPE_STRING
   - name: tf
     summary: List loaded functions definitions
     subcommands:

--- a/librz/core/cmd_descs/cmd_type.yaml
+++ b/librz/core/cmd_descs/cmd_type.yaml
@@ -50,6 +50,30 @@ commands:
     args:
       - name: type
         type: RZ_CMD_ARG_TYPE_STRING
+  - name: tf
+    summary: List loaded functions definitions
+    subcommands:
+      - name: tf
+        cname: type_list_function
+        summary: List loaded function definitions / Show function signature
+        modes:
+          - RZ_OUTPUT_MODE_STANDARD
+          - RZ_OUTPUT_MODE_JSON
+          - RZ_OUTPUT_MODE_SDB
+        args:
+          - name: type
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+      - name: tfc
+        cname: type_function_c
+        summary: Show function definition in the C output format
+        modes:
+          - RZ_OUTPUT_MODE_STANDARD
+          - RZ_OUTPUT_MODE_JSON
+        args:
+          - name: type
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
   - name: tk
     cname: type_kuery
     summary: Perform SDB query on types database

--- a/librz/core/cmd_descs/cmd_type.yaml
+++ b/librz/core/cmd_descs/cmd_type.yaml
@@ -150,6 +150,28 @@ commands:
         cname: type_noreturn_del_all
         summary: Remove all noreturn references
         args: []
+  - name: to
+    summary: Open C header file and load types from it
+    subcommands:
+      - name: to
+        cname: type_open_file
+        summary: Open C header file and load types from it
+        args:
+          - name: file
+            type: RZ_CMD_ARG_TYPE_FILE
+      - name: toe
+        cname: type_open_editor
+        summary: Open cfg.editor to edit types
+        args:
+          - name: type
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+      - name: tos
+        cname: type_open_sdb
+        summary: Open SDB file and load types from it
+        args:
+          - name: file
+            type: RZ_CMD_ARG_TYPE_FILE
   - name: tt
     summary: List loaded typedefs
     subcommands:

--- a/librz/core/cmd_type.c
+++ b/librz/core/cmd_type.c
@@ -26,7 +26,6 @@ static const char *help_msg_t[] = {
 	"to", " <path>", "Load types from C header file",
 	"toe", " [type.name]", "Open cfg.editor to edit types",
 	"tos", " <path>", "Load types from parsed Sdb database",
-	"touch", " <file>", "Create or update timestamp in file",
 	"tp", "  <type> [addr|varname]", "cast data at <address> to <type> and print it (XXX: type can contain spaces)",
 	"tpv", " <type> @ [value]", "Show offset formatted for given type",
 	"tpx", " <type> <hexpairs>", "Show value for type with specified byte sequence (XXX: type can contain spaces)",
@@ -71,7 +70,6 @@ static const char *help_msg_to[] = {
 	"to", " -", "Open cfg.editor to load types",
 	"to", " <path>", "Load types from C header file",
 	"tos", " <path>", "Load types from parsed Sdb database",
-	"touch", " <file>", "Create or update timestamp in file",
 	NULL
 };
 
@@ -1535,14 +1533,6 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 		}
 		if (input[1] == ' ') {
 			types_open_file(core, input + 2);
-		} else if (input[1] == 'u') {
-			// "tou" "touch"
-			char *arg = strchr(input, ' ');
-			if (arg) {
-				rz_file_touch(arg + 1);
-			} else {
-				eprintf("Usage: touch [filename]");
-			}
 		} else if (input[1] == 's') { // "tos"
 			types_open_sdb(core, input + 3);
 		} else if (input[1] == 'e') { // "toe"

--- a/librz/include/rz_util/rz_ctypes.h
+++ b/librz/include/rz_util/rz_ctypes.h
@@ -22,6 +22,7 @@ RZ_API int rz_type_set(Sdb *TDB, ut64 at, const char *field, ut64 val);
 RZ_API void rz_type_del(Sdb *TDB, const char *name);
 RZ_API int rz_type_kind(Sdb *TDB, const char *name);
 RZ_API char *rz_type_enum_member(Sdb *TDB, const char *name, const char *member, ut64 val);
+RZ_API RzList *rz_type_enum_find_member(Sdb *TDB, ut64 val);
 RZ_API char *rz_type_enum_getbitfield(Sdb *TDB, const char *name, ut64 val);
 RZ_API RzList *rz_type_get_enum(Sdb *TDB, const char *name);
 RZ_API ut64 rz_type_get_bitsize(Sdb *TDB, const char *type);

--- a/librz/util/utype.c
+++ b/librz/util/utype.c
@@ -88,6 +88,29 @@ RZ_API char *rz_type_enum_member(Sdb *TDB, const char *name, const char *member,
 	return sdb_get(TDB, q, 0);
 }
 
+RZ_API RzList *rz_type_enum_find_member(Sdb *TDB, ut64 val) {
+	SdbKv *kv;
+	SdbListIter *iter;
+	SdbList *l = sdb_foreach_list(TDB, true);
+	RzList *res = rz_list_new();
+	ls_foreach (l, iter, kv) {
+		if (!strcmp(sdbkv_value(kv), "enum")) {
+			const char *name = sdbkv_key(kv);
+			if (name) {
+				const char *q = sdb_fmt("enum.%s.0x%" PFMT64x, name, val);
+				char *member = sdb_get(TDB, q, 0);
+				if (member) {
+					char *pair = rz_str_newf("%s.%s", name, member);
+					rz_list_append(res, pair);
+					free(member);
+				}
+			}
+		}
+	}
+	ls_free(l);
+	return res;
+}
+
 RZ_API char *rz_type_enum_getbitfield(Sdb *TDB, const char *name, ut64 val) {
 	char *q, *ret = NULL;
 	const char *res;

--- a/test/db/cmd/cmd_tc
+++ b/test/db/cmd/cmd_tc
@@ -286,11 +286,11 @@ struct Employee {
 EOF
 RUN
 
-NAME=test cmd tfc
+NAME=test cmd tf
 FILE=bins/mach0/objc-employee
 CMDS=<<EOF
-tfc main
-tfc entry0
+tf main
+tf entry0
 EOF
 EXPECT=<<EOF
 int main (int argc, char ** argv, char ** envp);

--- a/test/db/cmd/shell
+++ b/test/db/cmd/shell
@@ -7,16 +7,3 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=touch
-FILE=--
-CMDS=<<EOF
-rm .foo.touch
-ls .foo.touch
-touch .foo.touch
-ls .foo.touch
-rm .foo.touch
-EOF
-EXPECT=<<EOF
-        .foo.touch  
-EOF
-RUN

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -318,8 +318,7 @@ EOF
 EXPECT=<<EOF
 {"name":"FOO","values":{"A":1,"B":256,"C":255,"D":4,"E":5}}
 {"name":"BAR","values":{"G":2048,"Z":238,"P":4,"E":5}}
-{"name":"BAR","values":{"G":2048,"Z":238,"P":4,"E":5}}
-{"name":"FOO","values":{"A":1,"B":256,"C":255,"D":4,"E":5}}
+[{"name":"BAR","values":{"G":2048,"Z":238,"P":4,"E":5}},{"name":"FOO","values":{"A":1,"B":256,"C":255,"D":4,"E":5}}]
 EOF
 RUN
 

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -333,46 +333,62 @@ tek BAR
 tek
 EOF
 EXPECT=<<EOF
-enum.FOO.0xff=C
+enum.FOO.0x100=B
 enum.FOO.0x1=A
 enum.FOO.0x4=D
 enum.FOO.0x5=E
-enum.FOO=A,B,C,D,E
-enum.FOO.0x100=B
+enum.FOO.0xff=C
 enum.FOO.A=0x1
 enum.FOO.B=0x100
 enum.FOO.C=0xff
 enum.FOO.D=0x4
 enum.FOO.E=0x5
-enum.BAR.0x5=E
+enum.FOO=A,B,C,D,E
 enum.BAR.0x4=P
+enum.BAR.0x5=E
 enum.BAR.0x800=G
 enum.BAR.0xee=Z
-enum.BAR=G,Z,P,E
-enum.BAR.G=0x800
 enum.BAR.E=0x5
+enum.BAR.G=0x800
 enum.BAR.P=0x4
 enum.BAR.Z=0xee
-enum.BAR.0x5=E
+enum.BAR=G,Z,P,E
 enum.BAR.0x4=P
+enum.BAR.0x5=E
 enum.BAR.0x800=G
 enum.BAR.0xee=Z
-enum.BAR=G,Z,P,E
-enum.BAR.G=0x800
 enum.BAR.E=0x5
+enum.BAR.G=0x800
 enum.BAR.P=0x4
 enum.BAR.Z=0xee
-enum.FOO.0xff=C
+enum.BAR=G,Z,P,E
+enum.FOO.0x100=B
 enum.FOO.0x1=A
 enum.FOO.0x4=D
 enum.FOO.0x5=E
-enum.FOO=A,B,C,D,E
-enum.FOO.0x100=B
+enum.FOO.0xff=C
 enum.FOO.A=0x1
 enum.FOO.B=0x100
 enum.FOO.C=0xff
 enum.FOO.D=0x4
 enum.FOO.E=0x5
+enum.FOO=A,B,C,D,E
+EOF
+RUN
+
+NAME=tf and tfk
+FILE=-
+CMDS=<<EOF
+tf write
+tfk write
+EOF
+EXPECT=<<EOF
+ssize_t write (int fd, const char * ptr, size_t nbytes);
+func.write.arg.0=int,fd
+func.write.arg.1=const char *,ptr
+func.write.arg.2=size_t,nbytes
+func.write.args=3
+func.write.ret=ssize_t
 EOF
 RUN
 

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -198,7 +198,7 @@ RUN
 NAME=t-enum
 FILE=-
 CMDS=<<EOF
-td enum pe_machine { IMAGE_FILE_MACHINE_IA64=0x200, IMAGE_FILE_MACHINE_I386=0x14c };
+td "enum pe_machine { IMAGE_FILE_MACHINE_IA64=0x200, IMAGE_FILE_MACHINE_I386=0x14c };"
 te~?pe_machine
 t-pe_machine
 te~?pe_machine
@@ -256,7 +256,7 @@ RUN
 NAME=t-*
 FILE=-
 CMDS=<<EOF
-td enum pe_machine { IMAGE_FILE_MACHINE_IA64=0x200, IMAGE_FILE_MACHINE_I386=0x14c };
+td "enum pe_machine { IMAGE_FILE_MACHINE_IA64=0x200, IMAGE_FILE_MACHINE_I386=0x14c };"
 t-*
 t
 EOF
@@ -267,7 +267,7 @@ RUN
 NAME=teb
 FILE=-
 CMDS=<<EOF
-td enum pe_machine { IMAGE_FILE_MACHINE_IA64=0x200, IMAGE_FILE_MACHINE_I386=0x14c };
+td "enum pe_machine { IMAGE_FILE_MACHINE_IA64=0x200, IMAGE_FILE_MACHINE_I386=0x14c };"
 teb pe_machine IMAGE_FILE_MACHINE_I386
 EOF
 EXPECT=<<EOF
@@ -278,7 +278,7 @@ RUN
 NAME=te
 FILE=-
 CMDS=<<EOF
-td enum pe_machine { IMAGE_FILE_MACHINE_IA64=0x200, IMAGE_FILE_MACHINE_I386=0x14c };
+td "enum pe_machine { IMAGE_FILE_MACHINE_IA64=0x200, IMAGE_FILE_MACHINE_I386=0x14c };"
 te pe_machine 0x14c
 EOF
 EXPECT=<<EOF
@@ -286,10 +286,100 @@ IMAGE_FILE_MACHINE_I386
 EOF
 RUN
 
+NAME=tef
+FILE=-
+CMDS=<<EOF
+td "enum FOO { A=1, B=0x100, C=0xFF, D=4, E=5 };"
+td "enum BAR { G=0x800, Z=0xEE, P=4, E=5 };"
+tef 0x800
+tef 0x100
+tef 4
+tef 0x5
+EOF
+EXPECT=<<EOF
+BAR.G
+FOO.B
+BAR.P
+FOO.D
+BAR.E
+FOO.E
+EOF
+RUN
+
+NAME=tej
+FILE=-
+CMDS=<<EOF
+td "enum FOO { A=1, B=0x100, C=0xFF, D=4, E=5 };"
+td "enum BAR { G=0x800, Z=0xEE, P=4, E=5 };"
+tej FOO
+tej BAR
+tej
+EOF
+EXPECT=<<EOF
+{"name":"FOO","values":{"A":1,"B":256,"C":255,"D":4,"E":5}}
+{"name":"BAR","values":{"G":2048,"Z":238,"P":4,"E":5}}
+{"name":"BAR","values":{"G":2048,"Z":238,"P":4,"E":5}}
+{"name":"FOO","values":{"A":1,"B":256,"C":255,"D":4,"E":5}}
+EOF
+RUN
+
+NAME=tek
+FILE=-
+CMDS=<<EOF
+td "enum FOO { A=1, B=0x100, C=0xFF, D=4, E=5 };"
+td "enum BAR { G=0x800, Z=0xEE, P=4, E=5 };"
+tek FOO
+tek BAR
+tek
+EOF
+EXPECT=<<EOF
+enum.FOO.0xff=C
+enum.FOO.0x1=A
+enum.FOO.0x4=D
+enum.FOO.0x5=E
+enum.FOO=A,B,C,D,E
+enum.FOO.0x100=B
+enum.FOO.A=0x1
+enum.FOO.B=0x100
+enum.FOO.C=0xff
+enum.FOO.D=0x4
+enum.FOO.E=0x5
+enum.BAR.0x5=E
+enum.BAR.0x4=P
+enum.BAR.0x800=G
+enum.BAR.0xee=Z
+enum.BAR=G,Z,P,E
+enum.BAR.G=0x800
+enum.BAR.E=0x5
+enum.BAR.P=0x4
+enum.BAR.Z=0xee
+enum.BAR.0x5=E
+enum.BAR.0x4=P
+enum.BAR.0x800=G
+enum.BAR.0xee=Z
+enum.BAR=G,Z,P,E
+enum.BAR.G=0x800
+enum.BAR.E=0x5
+enum.BAR.P=0x4
+enum.BAR.Z=0xee
+enum.FOO.0xff=C
+enum.FOO.0x1=A
+enum.FOO.0x4=D
+enum.FOO.0x5=E
+enum.FOO=A,B,C,D,E
+enum.FOO.0x100=B
+enum.FOO.A=0x1
+enum.FOO.B=0x100
+enum.FOO.C=0xff
+enum.FOO.D=0x4
+enum.FOO.E=0x5
+EOF
+RUN
+
 NAME=tt
 FILE=-
 CMDS=<<EOF
-td typedef char FILE_NAME;
+td "typedef char FILE_NAME;"
 tt FILE_NAME
 td "typedef bool FLAG;"
 tt FLAG
@@ -899,6 +989,17 @@ enum Foo {
 	COW = 1,
 	BAR = 2
 };
+EOF
+RUN
+
+NAME=ted test
+FILE=-
+CMDS=<<EOF
+td "enum Foo {COW=1,BAR=2};"
+ted Foo
+EOF
+EXPECT=<<EOF
+enum Foo {COW = 1, BAR = 2};
 EOF
 RUN
 


### PR DESCRIPTION
# **DO NOT SQUASH**

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Migrating `t` commands to the newshell and fixes along the way.
- Removed `touch` command
- Added `tek` command to print enum contents in the SDB format
- Added `tef` command to search for the matching enums by the value (necessary for https://github.com/rizinorg/rizin/issues/697)
- Removed `tfc` command and now `tf` behaves as one - it prints the function types in C format
- Moved old `tf` command to `tfk` to print SDB format

For example, lets define two enums:
```
td "enum BLA { A = 1, B = 0x80, C = 2 };"
td "enum FOO { G = 2, B = 0x90, P = 3254543};"
```
If you run `tef 2` it will show:
```
BLA.C
FOO.G
```
If you run `tef 1` it will show:
```
BLA.A
```

**Test plan**

All green
