### PR TITLE
Make RzBinPlugin.patch_relocs local to RzBinFile

### DIFF
--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -709,8 +709,11 @@ static RzList *relocs_rbtree2list(RBNode *root) {
 
 RZ_API RBNode *rz_bin_patch_relocs(RzBin *bin) {
 	rz_return_val_if_fail(bin, NULL);
-	RzBinObject *o = rz_bin_cur_object(bin);
-	return o ? rz_bin_object_patch_relocs(bin, o) : NULL;
+	RzBinFile *bf = rz_bin_cur(bin);
+	if (!bf || !bf->o) {
+		return NULL;
+	}
+	return rz_bin_object_patch_relocs(bf, bf->o);
 }
 
 // return a list of <const RzBinReloc> that needs to be freed by the caller

--- a/librz/bin/bobj.c
+++ b/librz/bin/bobj.c
@@ -425,15 +425,15 @@ RZ_API int rz_bin_object_set_items(RzBinFile *bf, RzBinObject *o) {
 	return true;
 }
 
-RZ_IPI RBNode *rz_bin_object_patch_relocs(RzBin *bin, RzBinObject *o) {
-	rz_return_val_if_fail(bin && o, NULL);
+RZ_IPI RBNode *rz_bin_object_patch_relocs(RzBinFile *bf, RzBinObject *o) {
+	rz_return_val_if_fail(bf && o, NULL);
 
 	static bool first = true;
 	// rz_bin_object_set_items set o->relocs but there we don't have access
 	// to io so we need to be run from bin_relocs, free the previous reloc and get
 	// the patched ones
 	if (first && o->plugin && o->plugin->patch_relocs) {
-		RzList *tmp = o->plugin->patch_relocs(bin);
+		RzList *tmp = o->plugin->patch_relocs(bf);
 		first = false;
 		if (!tmp) {
 			return o->relocs;
@@ -442,7 +442,7 @@ RZ_IPI RBNode *rz_bin_object_patch_relocs(RzBin *bin, RzBinObject *o) {
 		REBASE_PADDR(o, tmp, RzBinReloc);
 		o->relocs = list2rbtree(tmp);
 		first = false;
-		bin->is_reloc_patched = true;
+		bf->rbin->is_reloc_patched = true;
 	}
 	return o->relocs;
 }

--- a/librz/bin/i/private.h
+++ b/librz/bin/i/private.h
@@ -26,7 +26,7 @@ RZ_IPI void rz_bin_object_filter_strings(RzBinObject *bo);
 RZ_IPI RzBinObject *rz_bin_object_new(RzBinFile *binfile, RzBinPlugin *plugin, ut64 baseaddr, ut64 loadaddr, ut64 offset, ut64 sz);
 RZ_IPI RzBinObject *rz_bin_object_get_cur(RzBin *bin);
 RZ_IPI RzBinObject *rz_bin_object_find_by_arch_bits(RzBinFile *binfile, const char *arch, int bits, const char *name);
-RZ_IPI RBNode *rz_bin_object_patch_relocs(RzBin *bin, RzBinObject *o);
+RZ_IPI RBNode *rz_bin_object_patch_relocs(RzBinFile *bf, RzBinObject *o);
 
 RZ_IPI const char *rz_bin_lang_tostring(int lang);
 RZ_IPI int rz_bin_lang_type(RzBinFile *binfile, const char *def, const char *sym);

--- a/librz/bin/p/bin_bflt.c
+++ b/librz/bin/p/bin_bflt.c
@@ -48,33 +48,22 @@ static int search_old_relocation(struct reloc_struct_t *reloc_table,
 	return -1;
 }
 
-static RzList *patch_relocs(RzBin *b) {
-	struct rz_bin_bflt_obj *bin = NULL;
-	RzList *list = NULL;
-	RzBinObject *obj;
-	int i = 0;
-	if (!b || !b->iob.io || !b->iob.io->desc) {
-		return NULL;
-	}
+static RzList *patch_relocs(RzBinFile *bf) {
+	RzBin *b = bf->rbin;
+	struct rz_bin_bflt_obj *bin = (struct rz_bin_bflt_obj *)bf->o->bin_obj;
 	if (!(b->iob.io->cached & RZ_PERM_W)) {
 		eprintf(
 			"Warning: please run rizin with -e io.cache=true to patch "
 			"relocations\n");
 		return NULL;
 	}
-
-	obj = rz_bin_cur_object(b);
-	if (!obj) {
-		return NULL;
-	}
-	bin = obj->bin_obj;
-	list = rz_list_newf((RzListFree)free);
+	RzList *list = rz_list_newf((RzListFree)free);
 	if (!list) {
 		return NULL;
 	}
 	if (bin->got_table) {
 		struct reloc_struct_t *got_table = bin->got_table;
-		for (i = 0; i < bin->n_got; i++) {
+		for (int i = 0; i < bin->n_got; i++) {
 			__patch_reloc(bin->b, got_table[i].addr_to_patch,
 				got_table[i].data_offset);
 			RzBinReloc *reloc = RZ_NEW0(RzBinReloc);
@@ -90,7 +79,7 @@ static RzList *patch_relocs(RzBin *b) {
 
 	if (bin->reloc_table) {
 		struct reloc_struct_t *reloc_table = bin->reloc_table;
-		for (i = 0; i < bin->hdr->reloc_count; i++) {
+		for (int i = 0; i < bin->hdr->reloc_count; i++) {
 			int found = search_old_relocation(reloc_table,
 				reloc_table[i].addr_to_patch,
 				bin->hdr->reloc_count);

--- a/librz/bin/p/bin_coff.c
+++ b/librz/bin/p/bin_coff.c
@@ -458,9 +458,10 @@ static RzList *relocs(RzBinFile *bf) {
 	return _relocs_list(bf->rbin, bin, false, UT64_MAX);
 }
 
-static RzList *patch_relocs(RzBin *b) {
-	rz_return_val_if_fail(b && b->iob.io && b->iob.io->desc, NULL);
-	RzBinObject *bo = rz_bin_cur_object(b);
+static RzList *patch_relocs(RzBinFile *bf) {
+	rz_return_val_if_fail(bf, NULL);
+	RzBin *b = bf->rbin;
+	RzBinObject *bo = bf->o;
 	RzIO *io = b->iob.io;
 	if (!bo || !bo->bin_obj) {
 		return NULL;

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -902,8 +902,9 @@ static void _patch_reloc(ut16 e_machine, RzIOBind *iob, RzBinElfReloc *rel, ut64
 	}
 }
 
-static RzList *patch_relocs(RzBin *b) {
-	rz_return_val_if_fail(b, NULL);
+static RzList *patch_relocs(RzBinFile *bf) {
+	rz_return_val_if_fail(bf, NULL);
+	RzBin *b = bf->rbin;
 	RzList *ret = NULL;
 	RzBinReloc *ptr = NULL;
 	RzIOMap *g = NULL;
@@ -913,10 +914,10 @@ static RzList *patch_relocs(RzBin *b) {
 	ut64 size, offset = 0;
 
 	RzIO *io = b->iob.io;
-	if (!io || !io->desc) {
+	if (!io) {
 		return NULL;
 	}
-	RzBinObject *obj = rz_bin_cur_object(b);
+	RzBinObject *obj = bf->o;
 	if (!obj) {
 		return NULL;
 	}

--- a/librz/bin/p/bin_mach0.c
+++ b/librz/bin/p/bin_mach0.c
@@ -574,26 +574,23 @@ static bool _patch_reloc(struct MACH0_(obj_t) * bin, RzIOBind *iob, struct reloc
 	return true;
 }
 
-static RzList *patch_relocs(RzBin *b) {
+static RzList *patch_relocs(RzBinFile *bf) {
+	rz_return_val_if_fail(bf, NULL);
+	RzBin *b = bf->rbin;
 	RzList *ret = NULL;
-	RzIO *io = NULL;
-	RzBinObject *obj = NULL;
-	struct MACH0_(obj_t) *bin = NULL;
 	RzIOMap *g = NULL;
 	HtUU *relocs_by_sym = NULL;
 	RzIODesc *gotrzdesc = NULL;
 
-	rz_return_val_if_fail(b, NULL);
-
-	io = b->iob.io;
-	if (!io || !io->desc) {
+	RzIO *io = b->iob.io;
+	if (!io) {
 		return NULL;
 	}
-	obj = rz_bin_cur_object(b);
+	RzBinObject *obj = bf->o;
 	if (!obj) {
 		return NULL;
 	}
-	bin = obj->bin_obj;
+	struct MACH0_(obj_t) *bin = obj->bin_obj;
 
 	RzSkipList *all_relocs = MACH0_(get_relocs)(bin);
 	if (!all_relocs) {

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -448,7 +448,7 @@ typedef struct rz_bin_plugin_t {
 	RzList /*<RzBinTrycatch>*/ *(*trycatch)(RzBinFile *bf);
 	RzList /*<RzBinClass>*/ *(*classes)(RzBinFile *bf);
 	RzList /*<RzBinMem>*/ *(*mem)(RzBinFile *bf);
-	RzList /*<RzBinReloc>*/ *(*patch_relocs)(RzBin *bin);
+	RzList /*<RzBinReloc>*/ *(*patch_relocs)(RzBinFile *bf);
 	RzList /*<RzBinMap>*/ *(*maps)(RzBinFile *bf);
 	RzList /*<RzBinFileHash>*/ *(*hashes)(RzBinFile *bf);
 	void (*header)(RzBinFile *bf);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The significant change is in `rz_bin.h`. The  `patch_relocs` function always operates locally for a single file/object. Plugins would take `rz_bin_cur_object()` before to get their object because there was no other way, but this is wrong.