### PR TITLE
Migrating types command to the newshell 

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -2579,7 +2579,7 @@ static bool cb_analysis_roregs(RzCore *core, RzConfigNode *node) {
 static bool cb_analysissyscc(RzCore *core, RzConfigNode *node) {
 	if (core && core->analysis) {
 		if (!strcmp(node->value, "?")) {
-			rz_core_analysis_calling_conventions_print(core);
+			rz_core_types_calling_conventions_print(core, RZ_OUTPUT_MODE_STANDARD);
 			return false;
 		}
 		rz_analysis_set_syscc_default(core->analysis, node->value);
@@ -2590,7 +2590,7 @@ static bool cb_analysissyscc(RzCore *core, RzConfigNode *node) {
 static bool cb_analysiscc(RzCore *core, RzConfigNode *node) {
 	if (core && core->analysis) {
 		if (!strcmp(node->value, "?")) {
-			rz_core_analysis_calling_conventions_print(core);
+			rz_core_types_calling_conventions_print(core, RZ_OUTPUT_MODE_STANDARD);
 			return false;
 		}
 		rz_analysis_set_cc_default(core->analysis, node->value);

--- a/librz/core/cmd.c
+++ b/librz/core/cmd.c
@@ -83,11 +83,6 @@ static RzCmdDescriptor *cmd_descriptor(const char *cmd, const char *help[]) {
 
 static int rz_core_cmd_subst_i(RzCore *core, char *cmd, char *colon, bool *tmpseek);
 
-static int bb_cmpaddr(const void *_a, const void *_b) {
-	const RzAnalysisBlock *a = _a, *b = _b;
-	return a->addr > b->addr ? 1 : (a->addr < b->addr ? -1 : 0);
-}
-
 static void cmd_debug_reg(RzCore *core, const char *str);
 static bool lastcmd_repeat(RzCore *core, int next);
 

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -3073,7 +3073,7 @@ RZ_IPI int rz_cmd_analysis_fcn(void *data, const char *input) {
 			rz_core_kuery_print(core, "analysis/cc/*");
 			break;
 		case 'l': // "afcl" list all function Calling conventions.
-			rz_core_analysis_calling_conventions_print(core);
+			rz_core_types_calling_conventions_print(core, RZ_OUTPUT_MODE_STANDARD);
 			break;
 		case 'o': { // "afco"
 			char *dbpath = rz_str_trim_dup(input + 2);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -129,6 +129,9 @@ static const RzCmdDescArg type_open_sdb_args[2];
 static const RzCmdDescArg type_print_args[3];
 static const RzCmdDescArg type_print_value_args[3];
 static const RzCmdDescArg type_print_hexstring_args[3];
+static const RzCmdDescArg type_list_structure_args[2];
+static const RzCmdDescArg type_structure_c_args[2];
+static const RzCmdDescArg type_structure_c_nl_args[2];
 static const RzCmdDescArg type_list_typedef_args[2];
 static const RzCmdDescArg type_typedef_c_args[2];
 static const RzCmdDescArg type_list_union_args[2];
@@ -2409,6 +2412,54 @@ static const RzCmdDescHelp type_print_hexstring_help = {
 	.args = type_print_hexstring_args,
 };
 
+static const RzCmdDescHelp ts_help = {
+	.summary = "List loaded structures",
+};
+static const RzCmdDescArg type_list_structure_args[] = {
+	{
+		.name = "type",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_list_structure_help = {
+	.summary = "List loaded unions / Show pf format string for given union",
+	.args = type_list_structure_args,
+};
+
+static const RzCmdDescArg type_structure_c_args[] = {
+	{
+		.name = "type",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_structure_c_help = {
+	.summary = "Show union in the C output format with newlines",
+	.args = type_structure_c_args,
+};
+
+static const RzCmdDescArg type_structure_c_nl_args[] = {
+	{
+		.name = "type",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_structure_c_nl_help = {
+	.summary = "Show union in the C output format without newlines",
+	.args = type_structure_c_nl_args,
+};
+
 static const RzCmdDescHelp tt_help = {
 	.summary = "List loaded typedefs",
 };
@@ -4044,6 +4095,14 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *type_print_hexstring_cd = rz_cmd_desc_argv_new(core->rcmd, tp_cd, "tpx", rz_type_print_hexstring_handler, &type_print_hexstring_help);
 	rz_warn_if_fail(type_print_hexstring_cd);
+
+	RzCmdDesc *ts_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "ts", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON, rz_type_list_structure_handler, &type_list_structure_help, &ts_help);
+	rz_warn_if_fail(ts_cd);
+	RzCmdDesc *type_structure_c_cd = rz_cmd_desc_argv_new(core->rcmd, ts_cd, "tsc", rz_type_structure_c_handler, &type_structure_c_help);
+	rz_warn_if_fail(type_structure_c_cd);
+
+	RzCmdDesc *type_structure_c_nl_cd = rz_cmd_desc_argv_new(core->rcmd, ts_cd, "tsd", rz_type_structure_c_nl_handler, &type_structure_c_nl_help);
+	rz_warn_if_fail(type_structure_c_nl_cd);
 
 	RzCmdDesc *tt_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "tt", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_type_list_typedef_handler, &type_list_typedef_help, &tt_help);
 	rz_warn_if_fail(tt_cd);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -118,6 +118,9 @@ static const RzCmdDescArg type_enum_c_nl_args[2];
 static const RzCmdDescArg type_enum_find_args[2];
 static const RzCmdDescArg type_list_function_args[2];
 static const RzCmdDescArg type_kuery_args[2];
+static const RzCmdDescArg type_link_args[3];
+static const RzCmdDescArg type_link_show_args[2];
+static const RzCmdDescArg type_link_del_args[2];
 static const RzCmdDescArg type_list_noreturn_args[2];
 static const RzCmdDescArg type_noreturn_del_args[2];
 static const RzCmdDescArg type_open_file_args[2];
@@ -2197,6 +2200,66 @@ static const RzCmdDescHelp type_kuery_help = {
 	.args = type_kuery_args,
 };
 
+static const RzCmdDescHelp tl_help = {
+	.summary = "Manage type links to the address",
+};
+static const RzCmdDescArg type_link_args[] = {
+	{
+		.name = "typename",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.optional = true,
+
+	},
+	{
+		.name = "address",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_link_help = {
+	.summary = "List all type links / Add a type link",
+	.args = type_link_args,
+};
+
+static const RzCmdDescArg type_link_show_args[] = {
+	{
+		.name = "address",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_link_show_help = {
+	.summary = "Show the type link",
+	.args = type_link_show_args,
+};
+
+static const RzCmdDescArg type_link_del_args[] = {
+	{
+		.name = "address",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_link_del_help = {
+	.summary = "Remove the type link",
+	.args = type_link_del_args,
+};
+
+static const RzCmdDescArg type_link_del_all_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp type_link_del_all_help = {
+	.summary = "Remove all type links",
+	.args = type_link_del_all_args,
+};
+
 static const RzCmdDescHelp tn_help = {
 	.summary = "Manage noreturn function attributes and marks",
 };
@@ -3881,6 +3944,17 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *type_kuery_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_type_cd, "tk", rz_type_kuery_handler, &type_kuery_help);
 	rz_warn_if_fail(type_kuery_cd);
+
+	RzCmdDesc *tl_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "tl", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_SDB | RZ_OUTPUT_MODE_LONG, rz_type_link_handler, &type_link_help, &tl_help);
+	rz_warn_if_fail(tl_cd);
+	RzCmdDesc *type_link_show_cd = rz_cmd_desc_argv_new(core->rcmd, tl_cd, "tls", rz_type_link_show_handler, &type_link_show_help);
+	rz_warn_if_fail(type_link_show_cd);
+
+	RzCmdDesc *type_link_del_cd = rz_cmd_desc_argv_new(core->rcmd, tl_cd, "tl-", rz_type_link_del_handler, &type_link_del_help);
+	rz_warn_if_fail(type_link_del_cd);
+
+	RzCmdDesc *type_link_del_all_cd = rz_cmd_desc_argv_new(core->rcmd, tl_cd, "tl-*", rz_type_link_del_all_handler, &type_link_del_all_help);
+	rz_warn_if_fail(type_link_del_all_cd);
 
 	RzCmdDesc *tn_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "tn", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN, rz_type_list_noreturn_handler, &type_list_noreturn_help, &tn_help);
 	rz_warn_if_fail(tn_cd);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -126,6 +126,9 @@ static const RzCmdDescArg type_noreturn_del_args[2];
 static const RzCmdDescArg type_open_file_args[2];
 static const RzCmdDescArg type_open_editor_args[2];
 static const RzCmdDescArg type_open_sdb_args[2];
+static const RzCmdDescArg type_print_args[3];
+static const RzCmdDescArg type_print_value_args[3];
+static const RzCmdDescArg type_print_hexstring_args[3];
 static const RzCmdDescArg type_list_typedef_args[2];
 static const RzCmdDescArg type_typedef_c_args[2];
 static const RzCmdDescArg type_list_union_args[2];
@@ -2344,6 +2347,68 @@ static const RzCmdDescHelp type_open_sdb_help = {
 	.args = type_open_sdb_args,
 };
 
+static const RzCmdDescHelp tp_help = {
+	.summary = "Print formatted type casted to the address",
+};
+static const RzCmdDescArg type_print_args[] = {
+	{
+		.name = "type",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+
+	},
+	{
+		.name = "address",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_print_help = {
+	.summary = "Print formatted type casted to the address or variable",
+	.args = type_print_args,
+};
+
+static const RzCmdDescArg type_print_value_args[] = {
+	{
+		.name = "type",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+
+	},
+	{
+		.name = "value",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_print_value_help = {
+	.summary = "Print formatted type casted to the value",
+	.args = type_print_value_args,
+};
+
+static const RzCmdDescArg type_print_hexstring_args[] = {
+	{
+		.name = "type",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+
+	},
+	{
+		.name = "hexpairs",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_print_hexstring_help = {
+	.summary = "Print formatted type casted to the hexadecimal sequence",
+	.args = type_print_hexstring_args,
+};
+
 static const RzCmdDescHelp tt_help = {
 	.summary = "List loaded typedefs",
 };
@@ -3971,6 +4036,14 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *type_open_sdb_cd = rz_cmd_desc_argv_new(core->rcmd, to_cd, "tos", rz_type_open_sdb_handler, &type_open_sdb_help);
 	rz_warn_if_fail(type_open_sdb_cd);
+
+	RzCmdDesc *tp_cd = rz_cmd_desc_group_new(core->rcmd, cmd_type_cd, "tp", rz_type_print_handler, &type_print_help, &tp_help);
+	rz_warn_if_fail(tp_cd);
+	RzCmdDesc *type_print_value_cd = rz_cmd_desc_argv_new(core->rcmd, tp_cd, "tpv", rz_type_print_value_handler, &type_print_value_help);
+	rz_warn_if_fail(type_print_value_cd);
+
+	RzCmdDesc *type_print_hexstring_cd = rz_cmd_desc_argv_new(core->rcmd, tp_cd, "tpx", rz_type_print_hexstring_handler, &type_print_hexstring_help);
+	rz_warn_if_fail(type_print_hexstring_cd);
 
 	RzCmdDesc *tt_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "tt", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_type_list_typedef_handler, &type_list_typedef_help, &tt_help);
 	rz_warn_if_fail(tt_cd);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -106,6 +106,8 @@ static const RzCmdDescArg seek_prev_args[2];
 static const RzCmdDescArg seek_opcode_args[2];
 static const RzCmdDescArg seek_register_args[2];
 static const RzCmdDescArg sleep_args[2];
+static const RzCmdDescArg type_args[2];
+static const RzCmdDescArg type_del_args[2];
 static const RzCmdDescArg type_list_c_args[2];
 static const RzCmdDescArg type_list_c_nl_args[2];
 static const RzCmdDescArg type_cc_list_args[2];
@@ -1998,9 +2000,46 @@ static const RzCmdDescHelp sleep_help = {
 	.args = sleep_args,
 };
 
-static const RzCmdDescHelp cmd_type_help = {
+static const RzCmdDescHelp t_help = {
 	.summary = "Types, noreturn, signatures, C parser and more",
 };
+static const RzCmdDescArg type_args[] = {
+	{
+		.name = "type",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_help = {
+	.summary = "List all types / Show type information",
+	.args = type_args,
+};
+
+static const RzCmdDescArg type_del_args[] = {
+	{
+		.name = "type",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_del_help = {
+	.summary = "Remove the type",
+	.args = type_del_args,
+};
+
+static const RzCmdDescArg type_del_all_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp type_del_all_help = {
+	.summary = "Remove all types",
+	.args = type_del_all_args,
+};
+
 static const RzCmdDescHelp tc_help = {
 	.summary = "List loaded types in C format",
 };
@@ -4074,9 +4113,15 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *sleep_cd = rz_cmd_desc_argv_new(core->rcmd, s_cd, "sleep", rz_sleep_handler, &sleep_help);
 	rz_warn_if_fail(sleep_cd);
 
-	RzCmdDesc *cmd_type_cd = rz_cmd_desc_oldinput_new(core->rcmd, root_cd, "t", rz_cmd_type, &cmd_type_help);
-	rz_warn_if_fail(cmd_type_cd);
-	RzCmdDesc *tc_cd = rz_cmd_desc_group_new(core->rcmd, cmd_type_cd, "tc", rz_type_list_c_handler, &type_list_c_help, &tc_help);
+	RzCmdDesc *t_cd = rz_cmd_desc_group_modes_new(core->rcmd, root_cd, "t", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON, rz_type_handler, &type_help, &t_help);
+	rz_warn_if_fail(t_cd);
+	RzCmdDesc *type_del_cd = rz_cmd_desc_argv_new(core->rcmd, t_cd, "t-", rz_type_del_handler, &type_del_help);
+	rz_warn_if_fail(type_del_cd);
+
+	RzCmdDesc *type_del_all_cd = rz_cmd_desc_argv_new(core->rcmd, t_cd, "t-*", rz_type_del_all_handler, &type_del_all_help);
+	rz_warn_if_fail(type_del_all_cd);
+
+	RzCmdDesc *tc_cd = rz_cmd_desc_group_new(core->rcmd, t_cd, "tc", rz_type_list_c_handler, &type_list_c_help, &tc_help);
 	rz_warn_if_fail(tc_cd);
 	RzCmdDesc *type_list_c_nl_cd = rz_cmd_desc_argv_new(core->rcmd, tc_cd, "tcd", rz_type_list_c_nl_handler, &type_list_c_nl_help);
 	rz_warn_if_fail(type_list_c_nl_cd);
@@ -4089,10 +4134,10 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *type_cc_del_all_cd = rz_cmd_desc_argv_new(core->rcmd, tcc_cd, "tcc-*", rz_type_cc_del_all_handler, &type_cc_del_all_help);
 	rz_warn_if_fail(type_cc_del_all_cd);
 
-	RzCmdDesc *type_define_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_type_cd, "td", rz_type_define_handler, &type_define_help);
+	RzCmdDesc *type_define_cd = rz_cmd_desc_argv_new(core->rcmd, t_cd, "td", rz_type_define_handler, &type_define_help);
 	rz_warn_if_fail(type_define_cd);
 
-	RzCmdDesc *te_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "te", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_SDB, rz_type_list_enum_handler, &type_list_enum_help, &te_help);
+	RzCmdDesc *te_cd = rz_cmd_desc_group_modes_new(core->rcmd, t_cd, "te", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_SDB, rz_type_list_enum_handler, &type_list_enum_help, &te_help);
 	rz_warn_if_fail(te_cd);
 	RzCmdDesc *type_enum_bitfield_cd = rz_cmd_desc_argv_new(core->rcmd, te_cd, "teb", rz_type_enum_bitfield_handler, &type_enum_bitfield_help);
 	rz_warn_if_fail(type_enum_bitfield_cd);
@@ -4106,13 +4151,13 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *type_enum_find_cd = rz_cmd_desc_argv_new(core->rcmd, te_cd, "tef", rz_type_enum_find_handler, &type_enum_find_help);
 	rz_warn_if_fail(type_enum_find_cd);
 
-	RzCmdDesc *tf_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "tf", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_SDB, rz_type_list_function_handler, &type_list_function_help, &tf_help);
+	RzCmdDesc *tf_cd = rz_cmd_desc_group_modes_new(core->rcmd, t_cd, "tf", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_SDB, rz_type_list_function_handler, &type_list_function_help, &tf_help);
 	rz_warn_if_fail(tf_cd);
 
-	RzCmdDesc *type_kuery_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_type_cd, "tk", rz_type_kuery_handler, &type_kuery_help);
+	RzCmdDesc *type_kuery_cd = rz_cmd_desc_argv_new(core->rcmd, t_cd, "tk", rz_type_kuery_handler, &type_kuery_help);
 	rz_warn_if_fail(type_kuery_cd);
 
-	RzCmdDesc *tl_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "tl", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_SDB | RZ_OUTPUT_MODE_LONG, rz_type_link_handler, &type_link_help, &tl_help);
+	RzCmdDesc *tl_cd = rz_cmd_desc_group_modes_new(core->rcmd, t_cd, "tl", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_SDB | RZ_OUTPUT_MODE_LONG, rz_type_link_handler, &type_link_help, &tl_help);
 	rz_warn_if_fail(tl_cd);
 	RzCmdDesc *type_link_show_cd = rz_cmd_desc_argv_new(core->rcmd, tl_cd, "tls", rz_type_link_show_handler, &type_link_show_help);
 	rz_warn_if_fail(type_link_show_cd);
@@ -4123,7 +4168,7 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *type_link_del_all_cd = rz_cmd_desc_argv_new(core->rcmd, tl_cd, "tl-*", rz_type_link_del_all_handler, &type_link_del_all_help);
 	rz_warn_if_fail(type_link_del_all_cd);
 
-	RzCmdDesc *tn_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "tn", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN, rz_type_list_noreturn_handler, &type_list_noreturn_help, &tn_help);
+	RzCmdDesc *tn_cd = rz_cmd_desc_group_modes_new(core->rcmd, t_cd, "tn", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN, rz_type_list_noreturn_handler, &type_list_noreturn_help, &tn_help);
 	rz_warn_if_fail(tn_cd);
 	RzCmdDesc *type_noreturn_del_cd = rz_cmd_desc_argv_new(core->rcmd, tn_cd, "tn-", rz_type_noreturn_del_handler, &type_noreturn_del_help);
 	rz_warn_if_fail(type_noreturn_del_cd);
@@ -4131,7 +4176,7 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *type_noreturn_del_all_cd = rz_cmd_desc_argv_new(core->rcmd, tn_cd, "tn-*", rz_type_noreturn_del_all_handler, &type_noreturn_del_all_help);
 	rz_warn_if_fail(type_noreturn_del_all_cd);
 
-	RzCmdDesc *to_cd = rz_cmd_desc_group_new(core->rcmd, cmd_type_cd, "to", rz_type_open_file_handler, &type_open_file_help, &to_help);
+	RzCmdDesc *to_cd = rz_cmd_desc_group_new(core->rcmd, t_cd, "to", rz_type_open_file_handler, &type_open_file_help, &to_help);
 	rz_warn_if_fail(to_cd);
 	RzCmdDesc *type_open_editor_cd = rz_cmd_desc_argv_new(core->rcmd, to_cd, "toe", rz_type_open_editor_handler, &type_open_editor_help);
 	rz_warn_if_fail(type_open_editor_cd);
@@ -4139,7 +4184,7 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *type_open_sdb_cd = rz_cmd_desc_argv_new(core->rcmd, to_cd, "tos", rz_type_open_sdb_handler, &type_open_sdb_help);
 	rz_warn_if_fail(type_open_sdb_cd);
 
-	RzCmdDesc *tp_cd = rz_cmd_desc_group_new(core->rcmd, cmd_type_cd, "tp", rz_type_print_handler, &type_print_help, &tp_help);
+	RzCmdDesc *tp_cd = rz_cmd_desc_group_new(core->rcmd, t_cd, "tp", rz_type_print_handler, &type_print_help, &tp_help);
 	rz_warn_if_fail(tp_cd);
 	RzCmdDesc *type_print_value_cd = rz_cmd_desc_argv_new(core->rcmd, tp_cd, "tpv", rz_type_print_value_handler, &type_print_value_help);
 	rz_warn_if_fail(type_print_value_cd);
@@ -4147,7 +4192,7 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *type_print_hexstring_cd = rz_cmd_desc_argv_new(core->rcmd, tp_cd, "tpx", rz_type_print_hexstring_handler, &type_print_hexstring_help);
 	rz_warn_if_fail(type_print_hexstring_cd);
 
-	RzCmdDesc *ts_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "ts", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON, rz_type_list_structure_handler, &type_list_structure_help, &ts_help);
+	RzCmdDesc *ts_cd = rz_cmd_desc_group_modes_new(core->rcmd, t_cd, "ts", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON, rz_type_list_structure_handler, &type_list_structure_help, &ts_help);
 	rz_warn_if_fail(ts_cd);
 	RzCmdDesc *type_structure_c_cd = rz_cmd_desc_argv_new(core->rcmd, ts_cd, "tsc", rz_type_structure_c_handler, &type_structure_c_help);
 	rz_warn_if_fail(type_structure_c_cd);
@@ -4155,12 +4200,12 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *type_structure_c_nl_cd = rz_cmd_desc_argv_new(core->rcmd, ts_cd, "tsd", rz_type_structure_c_nl_handler, &type_structure_c_nl_help);
 	rz_warn_if_fail(type_structure_c_nl_cd);
 
-	RzCmdDesc *tt_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "tt", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_type_list_typedef_handler, &type_list_typedef_help, &tt_help);
+	RzCmdDesc *tt_cd = rz_cmd_desc_group_modes_new(core->rcmd, t_cd, "tt", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_type_list_typedef_handler, &type_list_typedef_help, &tt_help);
 	rz_warn_if_fail(tt_cd);
 	RzCmdDesc *type_typedef_c_cd = rz_cmd_desc_argv_new(core->rcmd, tt_cd, "ttc", rz_type_typedef_c_handler, &type_typedef_c_help);
 	rz_warn_if_fail(type_typedef_c_cd);
 
-	RzCmdDesc *tu_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_type_cd, "tu", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON, rz_type_list_union_handler, &type_list_union_help, &tu_help);
+	RzCmdDesc *tu_cd = rz_cmd_desc_group_modes_new(core->rcmd, t_cd, "tu", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON, rz_type_list_union_handler, &type_list_union_help, &tu_help);
 	rz_warn_if_fail(tu_cd);
 	RzCmdDesc *type_union_c_cd = rz_cmd_desc_argv_new(core->rcmd, tu_cd, "tuc", rz_type_union_c_handler, &type_union_c_help);
 	rz_warn_if_fail(type_union_c_cd);
@@ -4168,7 +4213,7 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *type_union_c_nl_cd = rz_cmd_desc_argv_new(core->rcmd, tu_cd, "tud", rz_type_union_c_nl_handler, &type_union_c_nl_help);
 	rz_warn_if_fail(type_union_c_nl_cd);
 
-	RzCmdDesc *tx_cd = rz_cmd_desc_group_new(core->rcmd, cmd_type_cd, "tx", rz_type_xrefs_list_handler, &type_xrefs_list_help, &tx_help);
+	RzCmdDesc *tx_cd = rz_cmd_desc_group_new(core->rcmd, t_cd, "tx", rz_type_xrefs_list_handler, &type_xrefs_list_help, &tx_help);
 	rz_warn_if_fail(tx_cd);
 	RzCmdDesc *type_xrefs_function_cd = rz_cmd_desc_argv_new(core->rcmd, tx_cd, "txf", rz_type_xrefs_function_handler, &type_xrefs_function_help);
 	rz_warn_if_fail(type_xrefs_function_cd);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -137,6 +137,8 @@ static const RzCmdDescArg type_typedef_c_args[2];
 static const RzCmdDescArg type_list_union_args[2];
 static const RzCmdDescArg type_union_c_args[2];
 static const RzCmdDescArg type_union_c_nl_args[2];
+static const RzCmdDescArg type_xrefs_list_args[2];
+static const RzCmdDescArg type_xrefs_function_args[2];
 static const RzCmdDescArg uniq_args[2];
 static const RzCmdDescArg uname_args[2];
 static const RzCmdDescArg write_args[2];
@@ -2541,6 +2543,55 @@ static const RzCmdDescHelp type_union_c_nl_help = {
 	.args = type_union_c_nl_args,
 };
 
+static const RzCmdDescHelp tx_help = {
+	.summary = "Type xrefs",
+};
+static const RzCmdDescArg type_xrefs_list_args[] = {
+	{
+		.name = "type",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_xrefs_list_help = {
+	.summary = "List functions using the type",
+	.args = type_xrefs_list_args,
+};
+
+static const RzCmdDescArg type_xrefs_function_args[] = {
+	{
+		.name = "address",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp type_xrefs_function_help = {
+	.summary = "List all types used in the function",
+	.args = type_xrefs_function_args,
+};
+
+static const RzCmdDescArg type_xrefs_graph_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp type_xrefs_graph_help = {
+	.summary = "Render the type xrefs graph",
+	.args = type_xrefs_graph_args,
+};
+
+static const RzCmdDescArg type_xrefs_list_all_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp type_xrefs_list_all_help = {
+	.summary = "List all types used by any function",
+	.args = type_xrefs_list_all_args,
+};
+
 static const RzCmdDescArg uniq_args[] = {
 	{
 		.name = "filename",
@@ -4116,6 +4167,17 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *type_union_c_nl_cd = rz_cmd_desc_argv_new(core->rcmd, tu_cd, "tud", rz_type_union_c_nl_handler, &type_union_c_nl_help);
 	rz_warn_if_fail(type_union_c_nl_cd);
+
+	RzCmdDesc *tx_cd = rz_cmd_desc_group_new(core->rcmd, cmd_type_cd, "tx", rz_type_xrefs_list_handler, &type_xrefs_list_help, &tx_help);
+	rz_warn_if_fail(tx_cd);
+	RzCmdDesc *type_xrefs_function_cd = rz_cmd_desc_argv_new(core->rcmd, tx_cd, "txf", rz_type_xrefs_function_handler, &type_xrefs_function_help);
+	rz_warn_if_fail(type_xrefs_function_cd);
+
+	RzCmdDesc *type_xrefs_graph_cd = rz_cmd_desc_argv_new(core->rcmd, tx_cd, "txg", rz_type_xrefs_graph_handler, &type_xrefs_graph_help);
+	rz_warn_if_fail(type_xrefs_graph_cd);
+
+	RzCmdDesc *type_xrefs_list_all_cd = rz_cmd_desc_argv_new(core->rcmd, tx_cd, "txl", rz_type_xrefs_list_all_handler, &type_xrefs_list_all_help);
+	rz_warn_if_fail(type_xrefs_list_all_cd);
 
 	RzCmdDesc *uniq_cd = rz_cmd_desc_argv_new(core->rcmd, root_cd, "uniq", rz_uniq_handler, &uniq_help);
 	rz_warn_if_fail(uniq_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -176,6 +176,9 @@ RZ_IPI RzCmdStatus rz_type_open_sdb_handler(RzCore *core, int argc, const char *
 RZ_IPI RzCmdStatus rz_type_print_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_print_value_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_print_hexstring_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_list_structure_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
+RZ_IPI RzCmdStatus rz_type_structure_c_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_structure_c_nl_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_list_typedef_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI RzCmdStatus rz_type_typedef_c_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_list_union_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -163,6 +163,10 @@ RZ_IPI RzCmdStatus rz_type_enum_c_nl_handler(RzCore *core, int argc, const char 
 RZ_IPI RzCmdStatus rz_type_enum_find_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_list_function_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI RzCmdStatus rz_type_kuery_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_link_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
+RZ_IPI RzCmdStatus rz_type_link_show_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_link_del_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_link_del_all_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_list_noreturn_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI RzCmdStatus rz_type_noreturn_del_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_noreturn_del_all_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -173,6 +173,9 @@ RZ_IPI RzCmdStatus rz_type_noreturn_del_all_handler(RzCore *core, int argc, cons
 RZ_IPI RzCmdStatus rz_type_open_file_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_open_editor_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_open_sdb_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_print_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_print_value_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_print_hexstring_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_list_typedef_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI RzCmdStatus rz_type_typedef_c_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_list_union_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -150,6 +150,9 @@ RZ_IPI RzCmdStatus rz_seek_prev_handler(RzCore *core, int argc, const char **arg
 RZ_IPI RzCmdStatus rz_seek_opcode_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_seek_register_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_sleep_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
+RZ_IPI RzCmdStatus rz_type_del_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_del_all_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_list_c_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_list_c_nl_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_cc_list_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
@@ -188,7 +191,6 @@ RZ_IPI RzCmdStatus rz_type_xrefs_list_handler(RzCore *core, int argc, const char
 RZ_IPI RzCmdStatus rz_type_xrefs_function_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_xrefs_graph_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_xrefs_list_all_handler(RzCore *core, int argc, const char **argv);
-RZ_IPI int rz_cmd_type(void *data, const char *input);
 RZ_IPI RzCmdStatus rz_uniq_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_uname_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI int rz_cmd_visual(void *data, const char *input);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -184,6 +184,10 @@ RZ_IPI RzCmdStatus rz_type_typedef_c_handler(RzCore *core, int argc, const char 
 RZ_IPI RzCmdStatus rz_type_list_union_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI RzCmdStatus rz_type_union_c_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_type_union_c_nl_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_xrefs_list_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_xrefs_function_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_xrefs_graph_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_type_xrefs_list_all_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI int rz_cmd_type(void *data, const char *input);
 RZ_IPI RzCmdStatus rz_uniq_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_uname_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_descs.yaml
+++ b/librz/core/cmd_descs/cmd_descs.yaml
@@ -254,10 +254,8 @@ commands:
     summary: Seek commands
     subcommands: cmd_seek
   - name: t
-    cname: cmd_type
     summary: Types, noreturn, signatures, C parser and more
     subcommands: cmd_type
-    type: RZ_CMD_DESC_TYPE_OLDINPUT
   - name: uniq
     cname: uniq
     summary: List uniq strings in file

--- a/librz/core/cmd_descs/cmd_type.yaml
+++ b/librz/core/cmd_descs/cmd_type.yaml
@@ -197,6 +197,35 @@ commands:
         args:
           - name: file
             type: RZ_CMD_ARG_TYPE_FILE
+  - name: tp
+    summary: Print formatted type casted to the address
+    subcommands:
+      - name: tp
+        cname: type_print
+        summary: Print formatted type casted to the address or variable
+        args:
+          - name: type
+            type: RZ_CMD_ARG_TYPE_STRING
+          - name: address
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+      - name: tpv
+        cname: type_print_value
+        summary: Print formatted type casted to the value
+        args:
+          - name: type
+            type: RZ_CMD_ARG_TYPE_STRING
+          - name: value
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+      - name: tpx
+        cname: type_print_hexstring
+        summary: Print formatted type casted to the hexadecimal sequence
+        args:
+          - name: type
+            type: RZ_CMD_ARG_TYPE_STRING
+          - name: hexpairs
+            type: RZ_CMD_ARG_TYPE_STRING
   - name: tt
     summary: List loaded typedefs
     subcommands:

--- a/librz/core/cmd_descs/cmd_type.yaml
+++ b/librz/core/cmd_descs/cmd_type.yaml
@@ -116,6 +116,41 @@ commands:
       - name: type
         type: RZ_CMD_ARG_TYPE_STRING
         optional: true
+  - name: tl
+    summary: Manage type links to the address
+    subcommands:
+      - name: tl
+        cname: type_link
+        summary: List all type links / Add a type link
+        modes:
+          - RZ_OUTPUT_MODE_STANDARD
+          - RZ_OUTPUT_MODE_RIZIN
+          - RZ_OUTPUT_MODE_JSON
+          - RZ_OUTPUT_MODE_SDB
+          - RZ_OUTPUT_MODE_LONG
+        args:
+          - name: typename
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+          - name: address
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+      - name: tls
+        cname: type_link_show
+        summary: Show the type link
+        args:
+          - name: address
+            type: RZ_CMD_ARG_TYPE_STRING
+      - name: tl-
+        cname: type_link_del
+        summary: Remove the type link
+        args:
+          - name: address
+            type: RZ_CMD_ARG_TYPE_STRING
+      - name: tl-*
+        cname: type_link_del_all
+        summary: Remove all type links
+        args: []
   - name: tn
     summary: Manage noreturn function attributes and marks
     subcommands:

--- a/librz/core/cmd_descs/cmd_type.yaml
+++ b/librz/core/cmd_descs/cmd_type.yaml
@@ -226,6 +226,34 @@ commands:
             type: RZ_CMD_ARG_TYPE_STRING
           - name: hexpairs
             type: RZ_CMD_ARG_TYPE_STRING
+  - name: ts
+    summary: List loaded structures
+    subcommands:
+      - name: ts
+        cname: type_list_structure
+        summary: List loaded unions / Show pf format string for given union
+        modes:
+          - RZ_OUTPUT_MODE_STANDARD
+          - RZ_OUTPUT_MODE_RIZIN
+          - RZ_OUTPUT_MODE_JSON
+        args:
+          - name: type
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+      - name: tsc
+        cname: type_structure_c
+        summary: Show union in the C output format with newlines
+        args:
+          - name: type
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+      - name: tsd
+        cname: type_structure_c_nl
+        summary: Show union in the C output format without newlines
+        args:
+          - name: type
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
   - name: tt
     summary: List loaded typedefs
     subcommands:

--- a/librz/core/cmd_descs/cmd_type.yaml
+++ b/librz/core/cmd_descs/cmd_type.yaml
@@ -1,6 +1,27 @@
 ---
 name: cmd_type
 commands:
+  - name: t
+    cname: type
+    summary: List all types / Show type information
+    modes:
+      - RZ_OUTPUT_MODE_STANDARD
+      - RZ_OUTPUT_MODE_RIZIN
+      - RZ_OUTPUT_MODE_JSON
+    args:
+      - name: type
+        type: RZ_CMD_ARG_TYPE_STRING
+        optional: true
+  - name: t-
+    cname: type_del
+    summary: Remove the type
+    args:
+      - name: type
+        type: RZ_CMD_ARG_TYPE_STRING
+  - name: t-*
+    cname: type_del_all
+    summary: Remove all types
+    args: []
   - name: tc
     summary: List loaded types in C format
     subcommands:

--- a/librz/core/cmd_descs/cmd_type.yaml
+++ b/librz/core/cmd_descs/cmd_type.yaml
@@ -302,3 +302,28 @@ commands:
           - name: type
             type: RZ_CMD_ARG_TYPE_STRING
             optional: true
+  - name: tx
+    summary: Type xrefs
+    subcommands:
+      - name: tx
+        cname: type_xrefs_list
+        summary: List functions using the type
+        args:
+          - name: type
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+      - name: txf
+        cname: type_xrefs_function
+        summary: List all types used in the function
+        args:
+          - name: address
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+      - name: txg
+        cname: type_xrefs_graph
+        summary: Render the type xrefs graph
+        args: []
+      - name: txl
+        cname: type_xrefs_list_all
+        summary: List all types used by any function
+        args: []

--- a/librz/core/cmd_type.c
+++ b/librz/core/cmd_type.c
@@ -7,6 +7,264 @@
 #include <sdb.h>
 #include "core_private.h"
 
+// Calling conventions
+
+static void types_cc_print(RzCore *core, const char *cc, RzOutputMode mode) {
+	rz_return_if_fail(cc);
+	if (strchr(cc, '(')) {
+		if (!rz_analysis_cc_set(core->analysis, cc)) {
+			eprintf("Invalid syntax in cc signature.");
+		}
+	} else {
+		const char *ccname = rz_str_trim_head_ro(cc);
+		char *result = rz_analysis_cc_get(core->analysis, ccname);
+		if (result) {
+			if (mode == RZ_OUTPUT_MODE_JSON) {
+				PJ *pj = rz_core_pj_new(core);
+				pj_a(pj);
+				pj_ks(pj, "cc", result);
+				pj_end(pj);
+				rz_cons_println(pj_string(pj));
+				pj_free(pj);
+			} else {
+				rz_cons_printf("%s\n", result);
+			}
+			free(result);
+		}
+	}
+}
+
+// Enums
+
+static RzCmdStatus types_enum_member_find(RzCore *core, const char *enum_name, const char *enum_value) {
+	rz_return_val_if_fail(enum_name || enum_value, RZ_CMD_STATUS_ERROR);
+	Sdb *TDB = core->analysis->sdb_types;
+	ut64 value = rz_num_math(core->num, enum_value);
+	char *enum_member = rz_type_enum_member(TDB, enum_name, NULL, value);
+	if (!enum_member) {
+		eprintf("Cannot find matching enum member");
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_cons_println(enum_member);
+	free(enum_member);
+	return RZ_CMD_STATUS_OK;
+}
+
+static RzCmdStatus types_enum_member_find_all(RzCore *core, const char *enum_value) {
+	rz_return_val_if_fail(enum_value, RZ_CMD_STATUS_ERROR);
+	Sdb *TDB = core->analysis->sdb_types;
+	ut64 value = rz_num_math(core->num, enum_value);
+	RzList *matches = rz_type_enum_find_member(TDB, value);
+	if (!matches || rz_list_empty(matches)) {
+		eprintf("Cannot find matching enum member");
+		return RZ_CMD_STATUS_ERROR;
+	}
+	RzListIter *iter;
+	char *match;
+	rz_list_foreach (matches, iter, match) {
+		rz_cons_println(match);
+	}
+	rz_list_free(matches);
+	return RZ_CMD_STATUS_OK;
+}
+
+static bool print_type_c(RzCore *core, const char *ctype) {
+	Sdb *TDB = core->analysis->sdb_types;
+	const char *type = rz_str_trim_head_ro(ctype);
+	const char *name = type ? strchr(type, '.') : NULL;
+	if (name && type) {
+		name++; // skip the '.'
+		if (rz_str_startswith(type, "struct")) {
+			rz_types_struct_print_c(TDB, name, true);
+		} else if (rz_str_startswith(type, "union")) {
+			rz_types_union_print_c(TDB, name, true);
+		} else if (rz_str_startswith(type, "enum")) {
+			rz_types_enum_print_c(TDB, name, true);
+		} else if (rz_str_startswith(type, "typedef")) {
+			rz_types_typedef_print_c(TDB, name);
+		} else if (rz_str_startswith(type, "func")) {
+			rz_types_function_print(TDB, name, RZ_OUTPUT_MODE_STANDARD, NULL);
+		}
+		return true;
+	}
+	return false;
+}
+
+static void type_list_c_all(RzCore *core) {
+	Sdb *TDB = core->analysis->sdb_types;
+	// List all unions in the C format with newlines
+	rz_types_union_print_c(TDB, NULL, true);
+	// List all structures in the C format with newlines
+	rz_types_struct_print_c(TDB, NULL, true);
+	// List all typedefs in the C format with newlines
+	rz_types_typedef_print_c(TDB, NULL);
+	// List all enums in the C format with newlines
+	rz_types_enum_print_c(TDB, NULL, true);
+}
+
+static void type_list_c_all_nl(RzCore *core) {
+	Sdb *TDB = core->analysis->sdb_types;
+	// List all unions in the C format without newlines
+	rz_types_union_print_c(TDB, NULL, false);
+	// List all structures in the C format without newlines
+	rz_types_struct_print_c(TDB, NULL, false);
+	// List all typedefs in the C format without newlines
+	rz_types_typedef_print_c(TDB, NULL);
+	// List all enums in the C format without newlines
+	rz_types_enum_print_c(TDB, NULL, false);
+}
+
+static RzCmdStatus type_format_print(RzCore *core, const char *type, ut64 address) {
+	Sdb *TDB = core->analysis->sdb_types;
+	char *fmt = rz_type_format(TDB, type);
+	if (RZ_STR_ISEMPTY(fmt)) {
+		eprintf("Cannot find type %s\n", type);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_core_cmdf(core, "pf %s @ 0x%08" PFMT64x "\n", fmt, address);
+	return RZ_CMD_STATUS_OK;
+}
+
+static RzCmdStatus type_format_print_variable(RzCore *core, const char *type, const char *varname) {
+	Sdb *TDB = core->analysis->sdb_types;
+	char *fmt = rz_type_format(TDB, type);
+	if (RZ_STR_ISEMPTY(fmt)) {
+		eprintf("Cannot find type \"%s\"\n", type);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(core->analysis, core->offset, -1);
+	if (!fcn) {
+		eprintf("Cannot find function at the current offset\n");
+		return RZ_CMD_STATUS_ERROR;
+	}
+	RzAnalysisVar *var = rz_analysis_function_get_var_byname(fcn, varname);
+	if (!var) {
+		eprintf("Cannot find variable \"%s\" in the current function\n", varname);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	ut64 addr = rz_analysis_var_addr(var);
+	rz_core_cmdf(core, "pf %s @ 0x%08" PFMT64x "\n", fmt, addr);
+	return RZ_CMD_STATUS_OK;
+}
+
+static RzCmdStatus type_format_print_value(RzCore *core, const char *type, ut64 val) {
+	Sdb *TDB = core->analysis->sdb_types;
+	char *fmt = rz_type_format(TDB, type);
+	if (RZ_STR_ISEMPTY(fmt)) {
+		eprintf("Cannot find type %s\n", type);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_core_cmdf(core, "pf %s @v:0x%08" PFMT64x "\n", fmt, val);
+	return RZ_CMD_STATUS_OK;
+}
+
+static RzCmdStatus type_format_print_hexstring(RzCore *core, const char *type, const char *hexpairs) {
+	Sdb *TDB = core->analysis->sdb_types;
+	char *fmt = rz_type_format(TDB, type);
+	if (RZ_STR_ISEMPTY(fmt)) {
+		eprintf("Cannot find type %s\n", type);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_core_cmdf(core, "pf %s @x:%s", fmt, hexpairs);
+	return RZ_CMD_STATUS_OK;
+}
+
+static void type_define(RzCore *core, const char *type) {
+	// Add trailing semicolon to force the valid C syntax
+	// It allows us to skip the trailing semicolon in the input
+	// to reduce the unnecessary typing
+	char *tmp = rz_str_newf("%s;", type);
+	if (!tmp) {
+		return;
+	}
+	char *error_msg = NULL;
+	char *out = rz_parse_c_string(core->analysis, tmp, &error_msg);
+	free(tmp);
+	if (out) {
+		rz_analysis_save_parsed_type(core->analysis, out);
+		free(out);
+	}
+	if (error_msg) {
+		eprintf("%s", error_msg);
+		free(error_msg);
+	}
+}
+
+static void types_open_file(RzCore *core, const char *path) {
+	const char *dir = rz_config_get(core->config, "dir.types");
+	char *homefile = NULL;
+	if (*path == '~') {
+		if (path[1] && path[2]) {
+			homefile = rz_str_home(path + 2);
+			path = homefile;
+		}
+	}
+	if (!strcmp(path, "-")) {
+		char *tmp = rz_core_editor(core, "*.h", "");
+		if (tmp) {
+			char *error_msg = NULL;
+			char *out = rz_parse_c_string(core->analysis, tmp, &error_msg);
+			if (out) {
+				rz_analysis_save_parsed_type(core->analysis, out);
+				free(out);
+			}
+			if (error_msg) {
+				fprintf(stderr, "%s", error_msg);
+				free(error_msg);
+			}
+			free(tmp);
+		}
+	} else {
+		char *error_msg = NULL;
+		char *out = rz_parse_c_file(core->analysis, path, dir, &error_msg);
+		if (out) {
+			rz_analysis_save_parsed_type(core->analysis, out);
+			free(out);
+		}
+		if (error_msg) {
+			fprintf(stderr, "%s", error_msg);
+			free(error_msg);
+		}
+	}
+	free(homefile);
+}
+
+static void types_open_editor(RzCore *core, const char *typename) {
+	Sdb *TDB = core->analysis->sdb_types;
+	char *str = rz_core_cmd_strf(core, "tc %s", typename ? typename : "");
+	char *tmp = rz_core_editor(core, "*.h", str);
+	if (tmp) {
+		char *error_msg = NULL;
+		char *out = rz_parse_c_string(core->analysis, tmp, &error_msg);
+		if (out) {
+			// remove previous types and save new edited types
+			sdb_reset(TDB);
+			rz_parse_c_reset(core->parser);
+			rz_analysis_save_parsed_type(core->analysis, out);
+			free(out);
+		}
+		if (error_msg) {
+			eprintf("%s\n", error_msg);
+			free(error_msg);
+		}
+		free(tmp);
+	}
+	free(str);
+}
+
+static void types_open_sdb(RzCore *core, const char *path) {
+	Sdb *TDB = core->analysis->sdb_types;
+	if (rz_file_exists(path)) {
+		Sdb *db_tmp = sdb_new(0, path, 0);
+		sdb_merge(TDB, db_tmp);
+		sdb_close(db_tmp);
+		sdb_free(db_tmp);
+	}
+}
+
+// =============================================================================
+//                             DEPRECATED
+
 static const char *help_msg_t[] = {
 	"Usage: t", "", "# cparse types commands",
 	"t", "", "List all loaded types",
@@ -175,368 +433,6 @@ static const char *help_msg_tu[] = {
 	NULL
 };
 
-static void kv_lines_print_sorted(char *kv_lines) {
-	RzListIter *iter;
-	char *k;
-	RzList *list = rz_str_split_duplist(kv_lines, "\n", true);
-	rz_list_sort(list, (RzListComparator)strcmp);
-	rz_list_foreach (list, iter, k) {
-		if (RZ_STR_ISNOTEMPTY(k)) {
-			rz_cons_println(k);
-		}
-	}
-	rz_list_free(list);
-}
-
-static void types_cc_print_all(RzCore *core, RzOutputMode mode) {
-	switch (mode) {
-	case RZ_OUTPUT_MODE_STANDARD: {
-		rz_core_analysis_calling_conventions_print(core);
-	} break;
-	case RZ_OUTPUT_MODE_JSON: {
-		RzList *list = rz_core_analysis_calling_conventions(core);
-		RzListIter *iter;
-		const char *cc;
-		PJ *pj = rz_core_pj_new(core);
-		pj_a(pj);
-		rz_list_foreach (list, iter, cc) {
-			char *ccexpr = rz_analysis_cc_get(core->analysis, cc);
-			// TODO: expose this as an object, not just an array of strings
-			pj_s(pj, ccexpr);
-			free(ccexpr);
-		}
-		pj_end(pj);
-		rz_cons_printf("%s\n", pj_string(pj));
-		pj_free(pj);
-		rz_list_free(list);
-	} break;
-	case RZ_OUTPUT_MODE_LONG: {
-		RzList *list = rz_core_analysis_calling_conventions(core);
-		RzListIter *iter;
-		const char *cc;
-		rz_list_foreach (list, iter, cc) {
-			char *ccexpr = rz_analysis_cc_get(core->analysis, cc);
-			rz_cons_printf("%s\n", ccexpr);
-			free(ccexpr);
-		}
-		rz_list_free(list);
-	} break;
-	case RZ_OUTPUT_MODE_RIZIN: {
-		RzList *list = rz_core_analysis_calling_conventions(core);
-		RzListIter *iter;
-		const char *cc;
-		rz_list_foreach (list, iter, cc) {
-			char *ccexpr = rz_analysis_cc_get(core->analysis, cc);
-			rz_cons_printf("tcc \"%s\"\n", ccexpr);
-			free(ccexpr);
-		}
-		rz_list_free(list);
-	} break;
-	case RZ_OUTPUT_MODE_SDB:
-		rz_core_kuery_print(core, "analysis/cc/*");
-		break;
-	default:
-		rz_warn_if_reached();
-		break;
-	}
-}
-
-static void types_cc_print(RzCore *core, const char *cc, RzOutputMode mode) {
-	rz_return_if_fail(cc);
-	if (strchr(cc, '(')) {
-		if (!rz_analysis_cc_set(core->analysis, cc)) {
-			eprintf("Invalid syntax in cc signature.");
-		}
-	} else {
-		const char *ccname = rz_str_trim_head_ro(cc);
-		char *result = rz_analysis_cc_get(core->analysis, ccname);
-		if (result) {
-			if (mode == RZ_OUTPUT_MODE_JSON) {
-				PJ *pj = rz_core_pj_new(core);
-				pj_a(pj);
-				pj_ks(pj, "cc", result);
-				pj_end(pj);
-				rz_cons_println(pj_string(pj));
-				pj_free(pj);
-			} else {
-				rz_cons_printf("%s\n", result);
-			}
-			free(result);
-		}
-	}
-}
-
-static void types_enum_print(RzCore *core, const char *enum_name, RzOutputMode mode, PJ *pj) {
-	rz_return_if_fail(enum_name);
-	Sdb *TDB = core->analysis->sdb_types;
-	switch (mode) {
-	case RZ_OUTPUT_MODE_JSON: {
-		rz_return_if_fail(pj);
-		RTypeEnum *member;
-		RzListIter *iter;
-		RzList *list = rz_type_get_enum(TDB, enum_name);
-		pj_o(pj);
-		if (list && !rz_list_empty(list)) {
-			pj_ks(pj, "name", enum_name);
-			pj_k(pj, "values");
-			pj_o(pj);
-			rz_list_foreach (list, iter, member) {
-				pj_kn(pj, member->name, rz_num_math(NULL, member->val));
-			}
-			pj_end(pj);
-		}
-		pj_end(pj);
-		rz_list_free(list);
-		break;
-	}
-	case RZ_OUTPUT_MODE_STANDARD: {
-		RzList *list = rz_type_get_enum(TDB, enum_name);
-		RzListIter *iter;
-		RTypeEnum *member;
-		rz_list_foreach (list, iter, member) {
-			rz_cons_printf("%s = %s\n", member->name, member->val);
-		}
-		rz_list_free(list);
-		break;
-	}
-	case RZ_OUTPUT_MODE_QUIET:
-		rz_cons_println(enum_name);
-		break;
-	case RZ_OUTPUT_MODE_SDB: {
-		char *keys = sdb_querys(TDB, NULL, -1, sdb_fmt("~~enum.%s", enum_name));
-		if (keys) {
-			kv_lines_print_sorted(keys);
-			free(keys);
-		}
-		break;
-	}
-	default:
-		break;
-	}
-}
-
-static void types_enum_print_all(RzCore *core, RzOutputMode mode) {
-	Sdb *TDB = core->analysis->sdb_types;
-	SdbKv *kv;
-	SdbListIter *iter;
-	PJ *pj = (mode == RZ_OUTPUT_MODE_JSON) ? rz_core_pj_new(core) : NULL;
-	SdbList *l = sdb_foreach_list(TDB, true);
-	if (mode == RZ_OUTPUT_MODE_JSON) {
-		pj_a(pj);
-	}
-	ls_foreach (l, iter, kv) {
-		if (!strcmp(sdbkv_value(kv), "enum")) {
-			const char *name = sdbkv_key(kv);
-			types_enum_print(core, name, mode, pj);
-		}
-	}
-	ls_free(l);
-	if (mode == RZ_OUTPUT_MODE_JSON) {
-		pj_end(pj);
-		rz_cons_println(pj_string(pj));
-		pj_free(pj);
-	}
-}
-
-static RzCmdStatus types_enum_member_find(RzCore *core, const char *enum_name, const char *enum_value) {
-	rz_return_val_if_fail(enum_name || enum_value, RZ_CMD_STATUS_ERROR);
-	Sdb *TDB = core->analysis->sdb_types;
-	ut64 value = rz_num_math(core->num, enum_value);
-	char *enum_member = rz_type_enum_member(TDB, enum_name, NULL, value);
-	if (!enum_member) {
-		eprintf("Cannot find matching enum member");
-		return RZ_CMD_STATUS_ERROR;
-	}
-	rz_cons_println(enum_member);
-	free(enum_member);
-	return RZ_CMD_STATUS_OK;
-}
-
-static RzCmdStatus types_enum_member_find_all(RzCore *core, const char *enum_value) {
-	rz_return_val_if_fail(enum_value, RZ_CMD_STATUS_ERROR);
-	Sdb *TDB = core->analysis->sdb_types;
-	ut64 value = rz_num_math(core->num, enum_value);
-	RzList *matches = rz_type_enum_find_member(TDB, value);
-	if (!matches || rz_list_empty(matches)) {
-		eprintf("Cannot find matching enum member");
-		return RZ_CMD_STATUS_ERROR;
-	}
-	RzListIter *iter;
-	char *match;
-	rz_list_foreach (matches, iter, match) {
-		rz_cons_println(match);
-	}
-	rz_list_free(matches);
-	return RZ_CMD_STATUS_OK;
-}
-
-static void types_function_print(RzCore *core, const char *function, RzOutputMode mode, PJ *pj) {
-	rz_return_if_fail(function);
-	Sdb *TDB = core->analysis->sdb_types;
-	char *res = sdb_querys(TDB, NULL, -1, sdb_fmt("func.%s.args", function));
-	int i, args = sdb_num_get(TDB, sdb_fmt("func.%s.args", function), 0);
-	const char *ret = sdb_const_get(TDB, sdb_fmt("func.%s.ret", function), 0);
-	if (!ret) {
-		ret = "void";
-	}
-	switch (mode) {
-	case RZ_OUTPUT_MODE_JSON: {
-		rz_return_if_fail(pj);
-		pj_o(pj);
-		pj_ks(pj, "name", function);
-		pj_ks(pj, "ret", ret);
-		pj_k(pj, "args");
-		pj_a(pj);
-		for (i = 0; i < args; i++) {
-			char *type = sdb_get(TDB, sdb_fmt("func.%s.arg.%d", function, i), 0);
-			if (!type) {
-				continue;
-			}
-			char *name = strchr(type, ',');
-			if (name) {
-				*name++ = 0;
-			}
-			pj_o(pj);
-			pj_ks(pj, "type", type);
-			if (name) {
-				pj_ks(pj, "name", name);
-			} else {
-				pj_ks(pj, "name", "(null)");
-			}
-			pj_end(pj);
-		}
-		pj_end(pj);
-		pj_end(pj);
-	} break;
-	case RZ_OUTPUT_MODE_SDB: {
-		char *keys = sdb_querys(TDB, NULL, -1, sdb_fmt("~~func.%s", function));
-		if (keys) {
-			kv_lines_print_sorted(keys);
-			free(keys);
-		}
-	} break;
-	default: {
-		rz_cons_printf("%s %s (", ret, function);
-		for (i = 0; i < args; i++) {
-			char *type = sdb_get(TDB, sdb_fmt("func.%s.arg.%d", function, i), 0);
-			char *name = strchr(type, ',');
-			if (name) {
-				*name++ = 0;
-			}
-			rz_cons_printf("%s%s %s", i == 0 ? "" : ", ", type, name);
-		}
-		rz_cons_printf(");\n");
-	} break;
-	}
-	free(res);
-}
-
-static void types_function_print_all(RzCore *core, RzOutputMode mode) {
-	Sdb *TDB = core->analysis->sdb_types;
-	SdbKv *kv;
-	SdbListIter *iter;
-	PJ *pj = (mode == RZ_OUTPUT_MODE_JSON) ? rz_core_pj_new(core) : NULL;
-	SdbList *l = sdb_foreach_list(TDB, true);
-	if (mode == RZ_OUTPUT_MODE_JSON) {
-		pj_a(pj);
-	}
-	ls_foreach (l, iter, kv) {
-		if (!strcmp(sdbkv_value(kv), "func")) {
-			const char *name = sdbkv_key(kv);
-			types_function_print(core, name, mode, pj);
-		}
-	}
-	ls_free(l);
-	if (mode == RZ_OUTPUT_MODE_JSON) {
-		pj_end(pj);
-		rz_cons_println(pj_string(pj));
-		pj_free(pj);
-	}
-}
-
-static void types_link_print(RzCore *core, const char *type, ut64 addr, RzOutputMode mode) {
-	rz_return_if_fail(type);
-	switch (mode) {
-	case RZ_OUTPUT_MODE_JSON: {
-		PJ *pj = pj_new();
-		if (!pj) {
-			return;
-		}
-		pj_o(pj);
-		char *saddr = rz_str_newf("0x%" PFMT64x, addr);
-		pj_ks(pj, saddr, type);
-		pj_end(pj);
-		rz_cons_println(pj_string(pj));
-		pj_free(pj);
-		free(saddr);
-		break;
-	}
-	case RZ_OUTPUT_MODE_STANDARD:
-		rz_cons_printf("0x%" PFMT64x " = %s\n", addr, type);
-		break;
-	case RZ_OUTPUT_MODE_RIZIN:
-		rz_cons_printf("tl %s 0x%" PFMT64x "\n", type, addr);
-		break;
-	case RZ_OUTPUT_MODE_LONG: {
-		char *fmt = rz_type_format(core->analysis->sdb_types, type);
-		if (!fmt) {
-			eprintf("Can't fint type %s", type);
-		}
-		rz_cons_printf("(%s)\n", type);
-		rz_core_cmdf(core, "pf %s @ 0x%" PFMT64x "\n", fmt, addr);
-		break;
-	}
-	default:
-		rz_warn_if_reached();
-		break;
-	}
-}
-
-static void types_link_print_all(RzCore *core, RzOutputMode mode) {
-	Sdb *TDB = core->analysis->sdb_types;
-	SdbKv *kv;
-	SdbListIter *iter;
-	SdbList *l = sdb_foreach_list(TDB, true);
-	ls_foreach (l, iter, kv) {
-		if (!strcmp(sdbkv_value(kv), "link")) {
-			const char *name = sdbkv_key(kv);
-			ut64 addr = rz_num_math(core->num, sdbkv_value(kv) + strlen("link."));
-			types_link_print(core, name, addr, mode);
-		}
-	}
-	ls_free(l);
-}
-
-static void types_link(RzCore *core, const char *type, ut64 addr) {
-	Sdb *TDB = core->analysis->sdb_types;
-	char *tmp = sdb_get(TDB, type, 0);
-	if (tmp && *tmp) {
-		rz_type_set_link(TDB, type, addr);
-		RzList *fcns = rz_analysis_get_functions_in(core->analysis, core->offset);
-		if (rz_list_length(fcns) > 1) {
-			eprintf("Multiple functions found in here.\n");
-		} else if (rz_list_length(fcns) == 1) {
-			RzAnalysisFunction *fcn = rz_list_first(fcns);
-			rz_core_link_stroff(core, fcn);
-		} else {
-			eprintf("Cannot find any function here\n");
-		}
-		rz_list_free(fcns);
-		free(tmp);
-	} else {
-		eprintf("unknown type %s\n", type);
-	}
-}
-
-static void types_link_show(RzCore *core, ut64 addr) {
-	Sdb *TDB = core->analysis->sdb_types;
-	const char *query = sdb_fmt("link.%08" PFMT64x, addr);
-	const char *link = sdb_const_get(TDB, query, 0);
-	if (link) {
-		types_link_print(core, link, addr, RZ_OUTPUT_MODE_LONG);
-	}
-}
-
 static void __core_cmd_tcc(RzCore *core, const char *input) {
 	switch (*input) {
 	case '?':
@@ -550,62 +446,23 @@ static void __core_cmd_tcc(RzCore *core, const char *input) {
 		}
 		break;
 	case 0:
-		types_cc_print_all(core, RZ_OUTPUT_MODE_STANDARD);
+		rz_core_types_calling_conventions_print(core, RZ_OUTPUT_MODE_STANDARD);
 		break;
 	case 'j':
-		types_cc_print_all(core, RZ_OUTPUT_MODE_JSON);
+		rz_core_types_calling_conventions_print(core, RZ_OUTPUT_MODE_JSON);
 		break;
 	case 'l':
-		types_cc_print_all(core, RZ_OUTPUT_MODE_LONG);
+		rz_core_types_calling_conventions_print(core, RZ_OUTPUT_MODE_LONG);
 		break;
 	case '*':
-		types_cc_print_all(core, RZ_OUTPUT_MODE_RIZIN);
+		rz_core_types_calling_conventions_print(core, RZ_OUTPUT_MODE_RIZIN);
 		break;
 	case 'k':
-		types_cc_print_all(core, RZ_OUTPUT_MODE_SDB);
+		rz_core_types_calling_conventions_print(core, RZ_OUTPUT_MODE_SDB);
 		break;
 	case ' ':
 		types_cc_print(core, input + 1, RZ_OUTPUT_MODE_STANDARD);
 		break;
-	}
-}
-
-static void type_show_format(RzCore *core, const char *name, RzOutputMode mode) {
-	const char *isenum = sdb_const_get(core->analysis->sdb_types, name, 0);
-	if (isenum && !strcmp(isenum, "enum")) {
-		eprintf("IS ENUM\n");
-	} else {
-		char *fmt = rz_type_format(core->analysis->sdb_types, name);
-		if (fmt) {
-			rz_str_trim(fmt);
-			switch (mode) {
-			case RZ_OUTPUT_MODE_JSON: {
-				PJ *pj = rz_core_pj_new(core);
-				if (!pj) {
-					return;
-				}
-				pj_o(pj);
-				pj_ks(pj, "name", name);
-				pj_ks(pj, "format", fmt);
-				pj_end(pj);
-				rz_cons_printf("%s", pj_string(pj));
-				pj_free(pj);
-			} break;
-			case RZ_OUTPUT_MODE_RIZIN: {
-				rz_cons_printf("pf.%s %s\n", name, fmt);
-			} break;
-			case RZ_OUTPUT_MODE_STANDARD: {
-				// FIXME: Not really a standard format
-				// We should think about better representation by default here
-				rz_cons_printf("pf %s\n", fmt);
-			} break;
-			default:
-				break;
-			}
-			free(fmt);
-		} else {
-			eprintf("Cannot find '%s' type\n", name);
-		}
 	}
 }
 
@@ -623,7 +480,7 @@ static void cmd_type_noreturn(RzCore *core, const char *input) {
 	switch (input[0]) {
 	case '-': // "tn-"
 		if (input[1] == '*') {
-			RzList *noretl = rz_core_analysis_noreturn(core);
+			RzList *noretl = rz_types_function_noreturn(core->analysis->sdb_types);
 			RzListIter *iter;
 			char *name;
 			rz_list_foreach (noretl, iter, name) {
@@ -663,13 +520,13 @@ static void cmd_type_noreturn(RzCore *core, const char *input) {
 		break;
 	case '*':
 	case 'r': // "tn*"
-		rz_core_analysis_noreturn_print(core, RZ_OUTPUT_MODE_RIZIN);
+		rz_core_types_function_noreturn_print(core, RZ_OUTPUT_MODE_RIZIN);
 		break;
 	case 'j': // "tnj"
-		rz_core_analysis_noreturn_print(core, RZ_OUTPUT_MODE_JSON);
+		rz_core_types_function_noreturn_print(core, RZ_OUTPUT_MODE_JSON);
 		break;
 	case 0: // "tn"
-		rz_core_analysis_noreturn_print(core, RZ_OUTPUT_MODE_STANDARD);
+		rz_core_types_function_noreturn_print(core, RZ_OUTPUT_MODE_STANDARD);
 		break;
 	default:
 	case '?':
@@ -678,766 +535,18 @@ static void cmd_type_noreturn(RzCore *core, const char *input) {
 	}
 }
 
-static Sdb *TDB_ = NULL; // HACK
-
-static bool stdifstruct(void *user, const char *k, const char *v) {
-	rz_return_val_if_fail(TDB_, false);
-	if (!strcmp(v, "struct") && !rz_str_startswith(k, "typedef")) {
-		return true;
-	}
-	if (!strcmp(v, "typedef")) {
-		const char *typedef_key = sdb_fmt("typedef.%s", k);
-		const char *type = sdb_const_get(TDB_, typedef_key, NULL);
-		if (type && rz_str_startswith(type, "struct")) {
-			return true;
-		}
-	}
-	return false;
-}
-
-/*!
- * \brief print the data types details in JSON format
- * \param TDB pointer to the sdb for types
- * \param filter a callback function for the filtering
- * \return 1 if success, 0 if failure
- */
-static int print_struct_union_list_json(Sdb *TDB, SdbForeachCallback filter) {
-	PJ *pj = pj_new();
-	if (!pj) {
-		return 0;
-	}
-	SdbList *l = sdb_foreach_list_filter(TDB, filter, true);
-	SdbListIter *it;
-	SdbKv *kv;
-
-	pj_a(pj); // [
-	ls_foreach (l, it, kv) {
-		const char *k = sdbkv_key(kv);
-		if (!k || !*k) {
-			continue;
-		}
-		pj_o(pj); // {
-		pj_ks(pj, "type", k); // key value pair of string and string
-		pj_end(pj); // }
-	}
-	pj_end(pj); // ]
-
-	rz_cons_println(pj_string(pj));
-	pj_free(pj);
-	ls_free(l);
-	return 1;
-}
-
-static void print_struct_union_in_c_format(Sdb *TDB, SdbForeachCallback filter, const char *arg, bool multiline) {
-	char *name = NULL;
-	SdbKv *kv;
-	SdbListIter *iter;
-	SdbList *l = sdb_foreach_list_filter(TDB, filter, true);
-	const char *space = "";
-	bool match = false;
-
-	ls_foreach (l, iter, kv) {
-		if (name && !strcmp(sdbkv_value(kv), name)) {
-			continue;
-		}
-		free(name);
-		int n;
-		name = strdup(sdbkv_key(kv));
-		if (name && (arg && *arg)) {
-			if (!strcmp(arg, name)) {
-				match = true;
-			} else {
-				continue;
-			}
-		}
-		rz_cons_printf("%s %s {%s", sdbkv_value(kv), name, multiline ? "\n" : "");
-		char *p, *var = rz_str_newf("%s.%s", sdbkv_value(kv), name);
-		for (n = 0; (p = sdb_array_get(TDB, var, n, NULL)); n++) {
-			char *var2 = rz_str_newf("%s.%s", var, p);
-			if (var2) {
-				char *val = sdb_array_get(TDB, var2, 0, NULL);
-				if (val) {
-					char *arr = sdb_array_get(TDB, var2, 2, NULL);
-					int arrnum = atoi(arr);
-					free(arr);
-					if (multiline) {
-						rz_cons_printf("\t%s", val);
-						if (p && p[0] != '\0') {
-							rz_cons_printf("%s%s", strstr(val, " *") ? "" : " ", p);
-							if (arrnum) {
-								rz_cons_printf("[%d]", arrnum);
-							}
-						}
-						rz_cons_println(";");
-					} else {
-						rz_cons_printf("%s%s %s", space, val, p);
-						if (arrnum) {
-							rz_cons_printf("[%d]", arrnum);
-						}
-						rz_cons_print(";");
-						space = " ";
-					}
-					free(val);
-				}
-				free(var2);
-			}
-			free(p);
-		}
-		free(var);
-		rz_cons_println("};");
-		space = "";
-		if (match) {
-			break;
-		}
-	}
-	free(name);
-	ls_free(l);
-}
-
-static void print_enum_in_c_format(Sdb *TDB, const char *arg, bool multiline) {
-	char *name = NULL;
-	SdbKv *kv;
-	SdbListIter *iter;
-	SdbList *l = sdb_foreach_list(TDB, true);
-	const char *separator = "";
-	bool match = false;
-	ls_foreach (l, iter, kv) {
-		if (!strcmp(sdbkv_value(kv), "enum")) {
-			if (!name || strcmp(sdbkv_value(kv), name)) {
-				free(name);
-				name = strdup(sdbkv_key(kv));
-				if (name && (arg && *arg)) {
-					if (!strcmp(arg, name)) {
-						match = true;
-					} else {
-						continue;
-					}
-				}
-				rz_cons_printf("%s %s {%s", sdbkv_value(kv), name, multiline ? "\n" : "");
-				{
-					RzList *list = rz_type_get_enum(TDB, name);
-					if (list && !rz_list_empty(list)) {
-						RzListIter *iter;
-						RTypeEnum *member;
-						separator = multiline ? "\t" : "";
-						rz_list_foreach (list, iter, member) {
-							rz_cons_printf("%s%s = %" PFMT64u, separator, member->name, rz_num_math(NULL, member->val));
-							separator = multiline ? ",\n\t" : ", ";
-						}
-					}
-					rz_list_free(list);
-				}
-				rz_cons_println(multiline ? "\n};" : "};");
-				if (match) {
-					break;
-				}
-			}
-		}
-	}
-	free(name);
-	ls_free(l);
-}
-
-static bool printkey_cb(void *user, const char *k, const char *v) {
-	rz_cons_println(k);
-	return true;
-}
-
-static bool stdifunion(void *p, const char *k, const char *v) {
-	return !strncmp(v, "union", strlen("union") + 1);
-}
-
-static bool stdiftype(void *p, const char *k, const char *v) {
-	return !strncmp(v, "type", strlen("type") + 1);
-}
-
-static bool print_typelist_r_cb(void *p, const char *k, const char *v) {
-	rz_cons_printf("tk %s=%s\n", k, v);
-	return true;
-}
-
-static bool print_type_c(RzCore *core, const char *ctype) {
-	Sdb *TDB = core->analysis->sdb_types;
-	const char *type = rz_str_trim_head_ro(ctype);
-	const char *name = type ? strchr(type, '.') : NULL;
-	if (name && type) {
-		name++; // skip the '.'
-		if (rz_str_startswith(type, "struct")) {
-			print_struct_union_in_c_format(TDB, stdifstruct, name, true);
-		} else if (rz_str_startswith(type, "union")) {
-			print_struct_union_in_c_format(TDB, stdifunion, name, true);
-		} else if (rz_str_startswith(type, "enum")) {
-			print_enum_in_c_format(TDB, name, true);
-		} else if (rz_str_startswith(type, "typedef")) {
-			rz_core_list_typename_alias_c(core, name);
-		} else if (rz_str_startswith(type, "func")) {
-			types_function_print(core, name, RZ_OUTPUT_MODE_STANDARD, NULL);
-		}
-		return true;
-	}
-	return false;
-}
-
-static bool print_typelist_json_cb(void *p, const char *k, const char *v) {
-	RzCore *core = (RzCore *)p;
-	PJ *pj = pj_new();
-	pj_o(pj);
-	Sdb *sdb = core->analysis->sdb_types;
-	char *sizecmd = rz_str_newf("type.%s.size", k);
-	char *size_s = sdb_querys(sdb, NULL, -1, sizecmd);
-	char *formatcmd = rz_str_newf("type.%s", k);
-	char *format_s = sdb_querys(sdb, NULL, -1, formatcmd);
-	rz_str_trim(format_s);
-	pj_ks(pj, "type", k);
-	pj_ki(pj, "size", size_s ? atoi(size_s) : -1);
-	pj_ks(pj, "format", format_s);
-	pj_end(pj);
-	rz_cons_printf("%s", pj_string(pj));
-	pj_free(pj);
-	free(size_s);
-	free(format_s);
-	free(sizecmd);
-	free(formatcmd);
-	return true;
-}
-
-static void print_keys(Sdb *TDB, RzCore *core, SdbForeachCallback filter, SdbForeachCallback printfn_cb, bool json) {
-	SdbList *l = sdb_foreach_list_filter(TDB, filter, true);
-	SdbListIter *it;
-	SdbKv *kv;
-	const char *comma = "";
-
-	if (json) {
-		rz_cons_printf("[");
-	}
-	ls_foreach (l, it, kv) {
-		const char *k = sdbkv_key(kv);
-		if (!k || !*k) {
-			continue;
-		}
-		if (json) {
-			rz_cons_printf("%s", comma);
-			comma = ",";
-		}
-		printfn_cb(core, sdbkv_key(kv), sdbkv_value(kv));
-	}
-	if (json) {
-		rz_cons_printf("]\n");
-	}
-	ls_free(l);
-}
-
 static void typesList(RzCore *core, int mode) {
 	switch (mode) {
 	case 1:
 	case '*':
-		print_keys(core->analysis->sdb_types, core, NULL, print_typelist_r_cb, false);
+		rz_core_types_print_all(core, RZ_OUTPUT_MODE_RIZIN);
 		break;
 	case 'j':
-		print_keys(core->analysis->sdb_types, core, stdiftype, print_typelist_json_cb, true);
+		rz_core_types_print_all(core, RZ_OUTPUT_MODE_JSON);
 		break;
 	default:
-		print_keys(core->analysis->sdb_types, core, stdiftype, printkey_cb, false);
+		rz_core_types_print_all(core, RZ_OUTPUT_MODE_STANDARD);
 		break;
-	}
-}
-
-static void set_offset_hint(RzCore *core, RzAnalysisOp *op, const char *type, ut64 laddr, ut64 at, int offimm) {
-	char *res = rz_type_get_struct_memb(core->analysis->sdb_types, type, offimm);
-	const char *cmt = ((offimm == 0) && res) ? res : type;
-	if (offimm > 0) {
-		// set hint only if link is present
-		char *query = sdb_fmt("link.%08" PFMT64x, laddr);
-		if (res && sdb_const_get(core->analysis->sdb_types, query, 0)) {
-			rz_analysis_hint_set_offset(core->analysis, at, res);
-		}
-	} else if (cmt && rz_analysis_op_ismemref(op->type)) {
-		rz_meta_set_string(core->analysis, RZ_META_TYPE_VARTYPE, at, cmt);
-	}
-}
-
-static bool typedef_info(RzCore *core, const char *name) {
-	const char *istypedef;
-	Sdb *TDB = core->analysis->sdb_types;
-	istypedef = sdb_const_get(TDB, name, 0);
-	if (istypedef && !strncmp(istypedef, "typedef", 7)) {
-		const char *q = sdb_fmt("typedef.%s", name);
-		const char *res = sdb_const_get(TDB, q, 0);
-		if (res) {
-			rz_cons_println(res);
-		} else {
-			return false;
-		}
-	} else {
-		eprintf("This is not an typedef\n");
-		return false;
-	}
-	return true;
-}
-
-RZ_API void rz_core_list_loaded_typedefs(RzCore *core, RzOutputMode mode) {
-	PJ *pj = NULL;
-	Sdb *TDB = core->analysis->sdb_types;
-	if (mode == RZ_OUTPUT_MODE_JSON) {
-		pj = rz_core_pj_new(core);
-		if (!pj) {
-			return;
-		}
-		pj_o(pj);
-	}
-	char *name = NULL;
-	SdbKv *kv;
-	SdbListIter *iter;
-	SdbList *l = sdb_foreach_list(TDB, true);
-	ls_foreach (l, iter, kv) {
-		if (!strcmp(sdbkv_value(kv), "typedef")) {
-			if (!name || strcmp(sdbkv_value(kv), name)) {
-				free(name);
-				name = strdup(sdbkv_key(kv));
-				if (mode == RZ_OUTPUT_MODE_STANDARD) {
-					rz_cons_println(name);
-				} else {
-					const char *q = sdb_fmt("typedef.%s", name);
-					const char *res = sdb_const_get(TDB, q, 0);
-					pj_ks(pj, name, res);
-				}
-			}
-		}
-	}
-	if (mode == RZ_OUTPUT_MODE_JSON) {
-		pj_end(pj);
-		rz_cons_println(pj_string(pj));
-		pj_free(pj);
-	}
-	free(name);
-	ls_free(l);
-}
-
-RZ_API void rz_core_list_typename_alias_c(RzCore *core, const char *typedef_name) {
-	char *name = NULL;
-	SdbKv *kv;
-	SdbListIter *iter;
-	Sdb *TDB = core->analysis->sdb_types;
-	SdbList *l = sdb_foreach_list(TDB, true);
-	bool match = false;
-	ls_foreach (l, iter, kv) {
-		if (!strcmp(sdbkv_value(kv), "typedef")) {
-			if (!name || strcmp(sdbkv_value(kv), name)) {
-				free(name);
-				name = strdup(sdbkv_key(kv));
-				if (name && (typedef_name && *typedef_name)) {
-					if (!strcmp(typedef_name, name)) {
-						match = true;
-					} else {
-						continue;
-					}
-				}
-				const char *q = sdb_fmt("typedef.%s", name);
-				const char *res = sdb_const_get(TDB, q, 0);
-				if (res) {
-					rz_cons_printf("%s %s %s;\n", sdbkv_value(kv), res, name);
-				}
-				if (match) {
-					break;
-				}
-			}
-		}
-	}
-	free(name);
-	ls_free(l);
-}
-
-RZ_API int rz_core_get_stacksz(RzCore *core, ut64 from, ut64 to) {
-	int stack = 0, maxstack = 0;
-	ut64 at = from;
-
-	if (from >= to) {
-		return 0;
-	}
-	const int mininstrsz = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE);
-	const int minopcode = RZ_MAX(1, mininstrsz);
-	while (at < to) {
-		RzAnalysisOp *op = rz_core_analysis_op(core, at, RZ_ANALYSIS_OP_MASK_BASIC);
-		if (!op || op->size <= 0) {
-			at += minopcode;
-			continue;
-		}
-		if ((op->stackop == RZ_ANALYSIS_STACK_INC) && RZ_ABS(op->stackptr) < 8096) {
-			stack += op->stackptr;
-			if (stack > maxstack) {
-				maxstack = stack;
-			}
-		}
-		at += op->size;
-		rz_analysis_op_free(op);
-	}
-	return maxstack;
-}
-
-static void set_retval(RzCore *core, ut64 at) {
-	RzAnalysis *analysis = core->analysis;
-	RzAnalysisHint *hint = rz_analysis_hint_get(analysis, at);
-	RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(analysis, at, 0);
-
-	if (!hint || !fcn || !fcn->name) {
-		goto beach;
-	}
-	if (hint->ret == UT64_MAX) {
-		goto beach;
-	}
-	const char *cc = rz_analysis_cc_func(core->analysis, fcn->name);
-	const char *regname = rz_analysis_cc_ret(analysis, cc);
-	if (regname) {
-		RzRegItem *reg = rz_reg_get(analysis->reg, regname, -1);
-		if (reg) {
-			rz_reg_set_value(analysis->reg, reg, hint->ret);
-		}
-	}
-beach:
-	rz_analysis_hint_free(hint);
-	return;
-}
-
-RZ_API void rz_core_link_stroff(RzCore *core, RzAnalysisFunction *fcn) {
-	RzAnalysisBlock *bb;
-	RzListIter *it;
-	RzAnalysisOp aop = { 0 };
-	bool ioCache = rz_config_get_i(core->config, "io.cache");
-	bool stack_set = false;
-	bool resolved = false;
-	const char *varpfx;
-	int dbg_follow = rz_config_get_i(core->config, "dbg.follow");
-	Sdb *TDB = core->analysis->sdb_types;
-	RzAnalysisEsil *esil;
-	int iotrap = rz_config_get_i(core->config, "esil.iotrap");
-	int stacksize = rz_config_get_i(core->config, "esil.stack.depth");
-	unsigned int addrsize = rz_config_get_i(core->config, "esil.addr.size");
-	const char *pc_name = rz_reg_get_name(core->analysis->reg, RZ_REG_NAME_PC);
-	const char *sp_name = rz_reg_get_name(core->analysis->reg, RZ_REG_NAME_SP);
-	RzRegItem *pc = rz_reg_get(core->analysis->reg, pc_name, -1);
-
-	if (!fcn) {
-		return;
-	}
-	if (!(esil = rz_analysis_esil_new(stacksize, iotrap, addrsize))) {
-		return;
-	}
-	rz_analysis_esil_setup(esil, core->analysis, 0, 0, 0);
-	int i, ret, bsize = RZ_MAX(64, core->blocksize);
-	const int mininstrsz = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE);
-	const int maxinstrsz = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_MAX_OP_SIZE);
-	const int minopcode = RZ_MAX(1, mininstrsz);
-	ut8 *buf = malloc(bsize);
-	if (!buf) {
-		free(buf);
-		rz_analysis_esil_free(esil);
-		return;
-	}
-	rz_reg_arena_push(core->analysis->reg);
-	rz_debug_reg_sync(core->dbg, RZ_REG_TYPE_ALL, true);
-	ut64 spval = rz_reg_getv(esil->analysis->reg, sp_name);
-	if (spval) {
-		// reset stack pointer to initial value
-		RzRegItem *sp = rz_reg_get(esil->analysis->reg, sp_name, -1);
-		ut64 curpc = rz_reg_getv(esil->analysis->reg, pc_name);
-		int stacksz = rz_core_get_stacksz(core, fcn->addr, curpc);
-		if (stacksz > 0) {
-			rz_reg_arena_zero(esil->analysis->reg); // clear prev reg values
-			rz_reg_set_value(esil->analysis->reg, sp, spval + stacksz);
-		}
-	} else {
-		// initialize stack
-		rz_core_analysis_esil_init_mem(core, NULL, UT64_MAX, UT32_MAX);
-		stack_set = true;
-	}
-	rz_config_set_i(core->config, "io.cache", 1);
-	rz_config_set_i(core->config, "dbg.follow", 0);
-	ut64 oldoff = core->offset;
-	rz_cons_break_push(NULL, NULL);
-	// TODO: The algorithm can be more accurate if blocks are followed by their jmp/fail, not just by address
-	rz_list_sort(fcn->bbs, bb_cmpaddr);
-	rz_list_foreach (fcn->bbs, it, bb) {
-		ut64 at = bb->addr;
-		ut64 to = bb->addr + bb->size;
-		rz_reg_set_value(esil->analysis->reg, pc, at);
-		for (i = 0; at < to; i++) {
-			if (rz_cons_is_breaked()) {
-				goto beach;
-			}
-			if (at < bb->addr) {
-				break;
-			}
-			if (i >= (bsize - maxinstrsz)) {
-				i = 0;
-			}
-			if (!i) {
-				rz_io_read_at(core->io, at, buf, bsize);
-			}
-			ret = rz_analysis_op(core->analysis, &aop, at, buf + i, bsize - i, RZ_ANALYSIS_OP_MASK_VAL);
-			if (ret <= 0) {
-				i += minopcode;
-				at += minopcode;
-				rz_analysis_op_fini(&aop);
-				continue;
-			}
-			i += ret - 1;
-			at += ret;
-			int index = 0;
-			if (aop.ireg) {
-				index = rz_reg_getv(esil->analysis->reg, aop.ireg) * aop.scale;
-			}
-			int j, src_imm = -1, dst_imm = -1;
-			ut64 src_addr = UT64_MAX;
-			ut64 dst_addr = UT64_MAX;
-			for (j = 0; j < 3; j++) {
-				if (aop.src[j] && aop.src[j]->reg && aop.src[j]->reg->name) {
-					src_addr = rz_reg_getv(esil->analysis->reg, aop.src[j]->reg->name) + index;
-					src_imm = aop.src[j]->delta;
-				}
-			}
-			if (aop.dst && aop.dst->reg && aop.dst->reg->name) {
-				dst_addr = rz_reg_getv(esil->analysis->reg, aop.dst->reg->name) + index;
-				dst_imm = aop.dst->delta;
-			}
-			RzAnalysisVar *var = rz_analysis_get_used_function_var(core->analysis, aop.addr);
-			if (false) { // src_addr != UT64_MAX || dst_addr != UT64_MAX) {
-				//  if (src_addr == UT64_MAX && dst_addr == UT64_MAX) {
-				rz_analysis_op_fini(&aop);
-				continue;
-			}
-			char *slink = rz_type_link_at(TDB, src_addr);
-			char *vlink = rz_type_link_at(TDB, src_addr + src_imm);
-			char *dlink = rz_type_link_at(TDB, dst_addr);
-			//TODO: Handle register based arg for struct offset propgation
-			if (vlink && var && var->kind != 'r') {
-				if (rz_type_kind(TDB, vlink) == RZ_TYPE_UNION) {
-					varpfx = "union";
-				} else {
-					varpfx = "struct";
-				}
-				// if a var addr matches with struct , change it's type and name
-				// var int local_e0h --> var struct foo
-				if (strcmp(var->name, vlink) && !resolved) {
-					resolved = true;
-					rz_analysis_var_set_type(var, varpfx);
-					rz_analysis_var_rename(var, vlink, false);
-				}
-			} else if (slink) {
-				set_offset_hint(core, &aop, slink, src_addr, at - ret, src_imm);
-			} else if (dlink) {
-				set_offset_hint(core, &aop, dlink, dst_addr, at - ret, dst_imm);
-			}
-			if (rz_analysis_op_nonlinear(aop.type)) {
-				rz_reg_set_value(esil->analysis->reg, pc, at);
-				set_retval(core, at - ret);
-			} else {
-				rz_core_esil_step(core, UT64_MAX, NULL, NULL, false);
-			}
-			free(dlink);
-			free(vlink);
-			free(slink);
-			rz_analysis_op_fini(&aop);
-		}
-	}
-beach:
-	rz_io_cache_reset(core->io, core->io->cached); // drop cache writes
-	rz_config_set_i(core->config, "io.cache", ioCache);
-	rz_config_set_i(core->config, "dbg.follow", dbg_follow);
-	if (stack_set) {
-		rz_core_analysis_esil_init_mem_del(core, NULL, UT64_MAX, UT32_MAX);
-	}
-	rz_core_seek(core, oldoff, true);
-	rz_analysis_esil_free(esil);
-	rz_reg_arena_pop(core->analysis->reg);
-	rz_core_regs2flags(core);
-	rz_cons_break_pop();
-	free(buf);
-}
-
-static void print_all_format(RzCore *core, Sdb *TDB, SdbForeachCallback sdbcb) {
-	SdbList *l = sdb_foreach_list_filter(TDB, sdbcb, true);
-	SdbListIter *it;
-	SdbKv *kv;
-	ls_foreach (l, it, kv) {
-		type_show_format(core, sdbkv_key(kv), RZ_OUTPUT_MODE_RIZIN);
-	}
-	ls_free(l);
-}
-
-static void print_all_struct_format(RzCore *core, Sdb *TDB) {
-	print_all_format(core, TDB, stdifstruct);
-}
-
-static void print_all_union_format(RzCore *core, Sdb *TDB) {
-	print_all_format(core, TDB, stdifunion);
-}
-
-static void type_list_c_all(RzCore *core) {
-	Sdb *TDB = core->analysis->sdb_types;
-	//types_function_print_all(core, RZ_OUTPUT_MODE_STANDARD);
-	// List all unions in the C format with newlines
-	print_struct_union_in_c_format(TDB, stdifunion, NULL, true);
-	// List all structures in the C format with newlines
-	rz_core_cmd0(core, "tsc");
-	// List all typedefs in the C format with newlines
-	rz_core_list_typename_alias_c(core, NULL);
-	// List all enums in the C format with newlines
-	print_enum_in_c_format(TDB, NULL, true);
-}
-
-static void type_list_c_all_nl(RzCore *core) {
-	Sdb *TDB = core->analysis->sdb_types;
-	print_struct_union_in_c_format(TDB, stdifunion, NULL, false);
-	rz_core_cmd0(core, "tsd");
-	rz_core_list_typename_alias_c(core, NULL);
-	print_enum_in_c_format(TDB, NULL, false);
-}
-
-static RzCmdStatus type_format_print(RzCore *core, const char *type, ut64 address) {
-	Sdb *TDB = core->analysis->sdb_types;
-	char *fmt = rz_type_format(TDB, type);
-	if (!fmt || !*fmt) {
-		eprintf("Cannot find type %s\n", type);
-		return RZ_CMD_STATUS_ERROR;
-	}
-	rz_core_cmdf(core, "pf %s @ 0x%08" PFMT64x "\n", fmt, address);
-	return RZ_CMD_STATUS_OK;
-}
-
-static RzCmdStatus type_format_print_variable(RzCore *core, const char *type, const char *varname) {
-	Sdb *TDB = core->analysis->sdb_types;
-	char *fmt = rz_type_format(TDB, type);
-	if (!fmt || !*fmt) {
-		eprintf("Cannot find type \"%s\"\n", type);
-		return RZ_CMD_STATUS_ERROR;
-	}
-	RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(core->analysis, core->offset, -1);
-	if (!fcn) {
-		eprintf("Cannot find function at the current offset\n");
-		return RZ_CMD_STATUS_ERROR;
-	}
-	RzAnalysisVar *var = rz_analysis_function_get_var_byname(fcn, varname);
-	if (!var) {
-		eprintf("Cannot find variable \"%s\" in the current function\n", varname);
-		return RZ_CMD_STATUS_ERROR;
-	}
-	ut64 addr = rz_analysis_var_addr(var);
-	rz_core_cmdf(core, "pf %s @ 0x%08" PFMT64x "\n", fmt, addr);
-	return RZ_CMD_STATUS_OK;
-}
-
-static RzCmdStatus type_format_print_value(RzCore *core, const char *type, ut64 val) {
-	Sdb *TDB = core->analysis->sdb_types;
-	char *fmt = rz_type_format(TDB, type);
-	if (!fmt || !*fmt) {
-		eprintf("Cannot find type %s\n", type);
-		return RZ_CMD_STATUS_ERROR;
-	}
-	rz_core_cmdf(core, "pf %s @v:0x%08" PFMT64x "\n", fmt, val);
-	return RZ_CMD_STATUS_OK;
-}
-
-static RzCmdStatus type_format_print_hexstring(RzCore *core, const char *type, const char *hexpairs) {
-	Sdb *TDB = core->analysis->sdb_types;
-	char *fmt = rz_type_format(TDB, type);
-	if (!fmt && !*fmt) {
-		eprintf("Cannot find type %s\n", type);
-		return RZ_CMD_STATUS_ERROR;
-	}
-	rz_core_cmdf(core, "pf %s @x:%s", fmt, hexpairs);
-	return RZ_CMD_STATUS_OK;
-}
-
-static void type_define(RzCore *core, const char *type) {
-	// Add trailing semicolon to force the valid C syntax
-	// It allows us to skip the trailing semicolon in the input
-	// to reduce the unnecessary typing
-	char *tmp = rz_str_newf("%s;", type);
-	if (!tmp) {
-		return;
-	}
-	char *error_msg = NULL;
-	char *out = rz_parse_c_string(core->analysis, tmp, &error_msg);
-	free(tmp);
-	if (out) {
-		rz_analysis_save_parsed_type(core->analysis, out);
-		free(out);
-	}
-	if (error_msg) {
-		eprintf("%s", error_msg);
-		free(error_msg);
-	}
-}
-
-static void types_open_file(RzCore *core, const char *path) {
-	const char *dir = rz_config_get(core->config, "dir.types");
-	char *homefile = NULL;
-	if (*path == '~') {
-		if (path[1] && path[2]) {
-			homefile = rz_str_home(path + 2);
-			path = homefile;
-		}
-	}
-	if (!strcmp(path, "-")) {
-		char *tmp = rz_core_editor(core, "*.h", "");
-		if (tmp) {
-			char *error_msg = NULL;
-			char *out = rz_parse_c_string(core->analysis, tmp, &error_msg);
-			if (out) {
-				rz_analysis_save_parsed_type(core->analysis, out);
-				free(out);
-			}
-			if (error_msg) {
-				fprintf(stderr, "%s", error_msg);
-				free(error_msg);
-			}
-			free(tmp);
-		}
-	} else {
-		char *error_msg = NULL;
-		char *out = rz_parse_c_file(core->analysis, path, dir, &error_msg);
-		if (out) {
-			rz_analysis_save_parsed_type(core->analysis, out);
-			free(out);
-		}
-		if (error_msg) {
-			fprintf(stderr, "%s", error_msg);
-			free(error_msg);
-		}
-	}
-	free(homefile);
-}
-
-static void types_open_editor(RzCore *core, const char *typename) {
-	Sdb *TDB = core->analysis->sdb_types;
-	char *str = rz_core_cmd_strf(core, "tc %s", typename ? typename : "");
-	char *tmp = rz_core_editor(core, "*.h", str);
-	if (tmp) {
-		char *error_msg = NULL;
-		char *out = rz_parse_c_string(core->analysis, tmp, &error_msg);
-		if (out) {
-			// remove previous types and save new edited types
-			sdb_reset(TDB);
-			rz_parse_c_reset(core->parser);
-			rz_analysis_save_parsed_type(core->analysis, out);
-			free(out);
-		}
-		if (error_msg) {
-			eprintf("%s\n", error_msg);
-			free(error_msg);
-		}
-		free(tmp);
-	}
-	free(str);
-}
-
-static void types_open_sdb(RzCore *core, const char *path) {
-	Sdb *TDB = core->analysis->sdb_types;
-	if (rz_file_exists(path)) {
-		Sdb *db_tmp = sdb_new(0, path, 0);
-		sdb_merge(TDB, db_tmp);
-		sdb_close(db_tmp);
-		sdb_free(db_tmp);
 	}
 }
 
@@ -1445,7 +554,6 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 	RzCore *core = (RzCore *)data;
 	Sdb *TDB = core->analysis->sdb_types;
 	char *res;
-	TDB_ = TDB; // HACK
 
 	switch (input[0]) {
 	case 'n': // "tn"
@@ -1459,30 +567,30 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 			break;
 		case '*':
 			if (input[2] == ' ') {
-				type_show_format(core, rz_str_trim_head_ro(input + 2), RZ_OUTPUT_MODE_RIZIN);
+				rz_core_types_show_format(core, rz_str_trim_head_ro(input + 2), RZ_OUTPUT_MODE_RIZIN);
 			} else {
-				print_all_union_format(core, TDB);
+				rz_core_types_union_print_format_all(core, TDB);
 			}
 			break;
 		case 'j': // "tuj"
 			if (input[2]) {
-				type_show_format(core, rz_str_trim_head_ro(input + 2), RZ_OUTPUT_MODE_JSON);
+				rz_core_types_show_format(core, rz_str_trim_head_ro(input + 2), RZ_OUTPUT_MODE_JSON);
 				rz_cons_newline();
 			} else {
-				print_struct_union_list_json(TDB, stdifunion);
+				rz_types_union_print_json(TDB);
 			}
 			break;
 		case 'c': // "tuc"
-			print_struct_union_in_c_format(TDB, stdifunion, rz_str_trim_head_ro(input + 2), true);
+			rz_types_union_print_c(TDB, rz_str_trim_head_ro(input + 2), true);
 			break;
 		case 'd': // "tud"
-			print_struct_union_in_c_format(TDB, stdifunion, rz_str_trim_head_ro(input + 2), false);
+			rz_types_union_print_c(TDB, rz_str_trim_head_ro(input + 2), false);
 			break;
 		case ' ': // "tu "
-			type_show_format(core, rz_str_trim_head_ro(input + 1), RZ_OUTPUT_MODE_STANDARD);
+			rz_core_types_show_format(core, rz_str_trim_head_ro(input + 1), RZ_OUTPUT_MODE_STANDARD);
 			break;
 		case 0:
-			print_keys(TDB, core, stdifunion, printkey_cb, false);
+			rz_types_union_print_sdb(TDB);
 			break;
 		}
 	} break;
@@ -1527,13 +635,13 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 			break;
 		case '*':
 			if (input[2] == ' ') {
-				type_show_format(core, rz_str_trim_head_ro(input + 2), RZ_OUTPUT_MODE_RIZIN);
+				rz_core_types_show_format(core, rz_str_trim_head_ro(input + 1), RZ_OUTPUT_MODE_RIZIN);
 			} else {
-				print_all_struct_format(core, TDB);
+				rz_core_types_struct_print_format_all(core, TDB);
 			}
 			break;
 		case ' ':
-			type_show_format(core, rz_str_trim_head_ro(input + 1), RZ_OUTPUT_MODE_STANDARD);
+			rz_core_types_show_format(core, rz_str_trim_head_ro(input + 1), RZ_OUTPUT_MODE_STANDARD);
 			break;
 		case 's':
 			if (input[2] == ' ') {
@@ -1543,21 +651,21 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 			}
 			break;
 		case 0:
-			print_keys(TDB, core, stdifstruct, printkey_cb, false);
+			rz_types_struct_print_sdb(TDB);
 			break;
 		case 'c': // "tsc"
-			print_struct_union_in_c_format(TDB, stdifstruct, rz_str_trim_head_ro(input + 2), true);
+			rz_types_struct_print_c(TDB, rz_str_trim_head_ro(input + 2), true);
 			break;
 		case 'd': // "tsd"
-			print_struct_union_in_c_format(TDB, stdifstruct, rz_str_trim_head_ro(input + 2), false);
+			rz_types_struct_print_c(TDB, rz_str_trim_head_ro(input + 2), false);
 			break;
 		case 'j': // "tsj"
 			// TODO: current output is a bit poor, will be good to improve
 			if (input[2]) {
-				type_show_format(core, rz_str_trim_head_ro(input + 2), RZ_OUTPUT_MODE_JSON);
+				rz_core_types_show_format(core, rz_str_trim_head_ro(input + 2), RZ_OUTPUT_MODE_JSON);
 				rz_cons_newline();
 			} else {
-				print_struct_union_list_json(TDB, stdifstruct);
+				rz_types_struct_print_json(TDB);
 			}
 			break;
 		}
@@ -1582,13 +690,13 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 			break;
 		case 'j': // "tej"
 			if (input[2] == 0) { // "tej"
-				types_enum_print_all(core, RZ_OUTPUT_MODE_JSON);
+				rz_core_types_enum_print_all(core, RZ_OUTPUT_MODE_JSON);
 			} else { // "tej ENUM"
 				if (member_value) {
 					types_enum_member_find(core, name, member_value);
 				} else {
 					PJ *pj = rz_core_pj_new(core);
-					types_enum_print(core, name, RZ_OUTPUT_MODE_JSON, pj);
+					rz_core_types_enum_print(core, name, RZ_OUTPUT_MODE_JSON, pj);
 					pj_end(pj);
 					rz_cons_println(pj_string(pj));
 					pj_free(pj);
@@ -1597,19 +705,19 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 			break;
 		case 'k': // "tek"
 			if (input[2] == 0) { // "tek"
-				types_enum_print_all(core, RZ_OUTPUT_MODE_SDB);
+				rz_core_types_enum_print_all(core, RZ_OUTPUT_MODE_SDB);
 			} else { // "tek ENUM"
-				types_enum_print(core, name, RZ_OUTPUT_MODE_SDB, NULL);
+				rz_core_types_enum_print(core, name, RZ_OUTPUT_MODE_SDB, NULL);
 			}
 			break;
 		case 'b': // "teb"
 			res = rz_type_enum_member(TDB, name, member_value, 0);
 			break;
 		case 'c': // "tec"
-			print_enum_in_c_format(TDB, rz_str_trim_head_ro(input + 2), true);
+			rz_types_enum_print_c(TDB, rz_str_trim_head_ro(input + 2), true);
 			break;
 		case 'd': // "ted"
-			print_enum_in_c_format(TDB, rz_str_trim_head_ro(input + 2), false);
+			rz_types_enum_print_c(TDB, rz_str_trim_head_ro(input + 2), false);
 			break;
 		case 'f': // "tef"
 			if (member_value) {
@@ -1620,11 +728,11 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 			if (member_value) {
 				types_enum_member_find(core, name, member_value);
 			} else {
-				types_enum_print(core, name, RZ_OUTPUT_MODE_STANDARD, NULL);
+				rz_core_types_enum_print(core, name, RZ_OUTPUT_MODE_STANDARD, NULL);
 			}
 			break;
 		case '\0': {
-			types_enum_print_all(core, RZ_OUTPUT_MODE_QUIET);
+			rz_core_types_enum_print_all(core, RZ_OUTPUT_MODE_QUIET);
 		} break;
 		}
 		free(name);
@@ -1635,7 +743,7 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 		}
 	} break;
 	case ' ':
-		type_show_format(core, input + 1, RZ_OUTPUT_MODE_STANDARD);
+		rz_core_types_show_format(core, input + 1, RZ_OUTPUT_MODE_STANDARD);
 		break;
 	// t* - list all types in 'pf' syntax
 	case 'j': // "tj"
@@ -1787,14 +895,14 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 				}
 			}
 			rz_str_trim(type);
-			types_link(core, type, addr);
+			rz_core_types_link(core, type, addr);
 			free(type);
 			break;
 		}
 		case 's': {
 			char *ptr = rz_str_trim_dup(input + 2);
 			ut64 addr = rz_num_math(core->num, ptr);
-			types_link_show(core, addr);
+			rz_core_types_link_show(core, addr);
 			free(ptr);
 			break;
 		}
@@ -1812,16 +920,16 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 			}
 			break;
 		case '*':
-			types_link_print_all(core, RZ_OUTPUT_MODE_RIZIN);
+			rz_core_types_link_print_all(core, RZ_OUTPUT_MODE_RIZIN);
 			break;
 		case 'l':
-			types_link_print_all(core, RZ_OUTPUT_MODE_LONG);
+			rz_core_types_link_print_all(core, RZ_OUTPUT_MODE_LONG);
 			break;
 		case 'j':
-			types_link_print_all(core, RZ_OUTPUT_MODE_JSON);
+			rz_core_types_link_print_all(core, RZ_OUTPUT_MODE_JSON);
 			break;
 		case '\0':
-			types_link_print_all(core, RZ_OUTPUT_MODE_STANDARD);
+			rz_core_types_link_print_all(core, RZ_OUTPUT_MODE_STANDARD);
 			break;
 		}
 		break;
@@ -1886,31 +994,31 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 	case 'f': // "tf"
 		switch (input[1]) {
 		case 0: // "tf"
-			types_function_print_all(core, RZ_OUTPUT_MODE_STANDARD);
+			rz_core_types_function_print_all(core, RZ_OUTPUT_MODE_STANDARD);
 			break;
 		case 'k': // "tfk"
 			if (input[2] == ' ') {
 				const char *name = rz_str_trim_head_ro(input + 3);
-				types_function_print(core, name, RZ_OUTPUT_MODE_SDB, NULL);
+				rz_types_function_print(TDB, name, RZ_OUTPUT_MODE_SDB, NULL);
 			} else {
-				types_function_print_all(core, RZ_OUTPUT_MODE_SDB);
+				rz_core_types_function_print_all(core, RZ_OUTPUT_MODE_SDB);
 			}
 			break;
 		case 'j': // "tfj"
 			if (input[2] == ' ') {
 				const char *name = rz_str_trim_head_ro(input + 2);
 				PJ *pj = rz_core_pj_new(core);
-				types_function_print(core, name, RZ_OUTPUT_MODE_JSON, pj);
+				rz_types_function_print(TDB, name, RZ_OUTPUT_MODE_JSON, pj);
 				pj_end(pj);
 				rz_cons_println(pj_string(pj));
 				pj_free(pj);
 			} else {
-				types_function_print_all(core, RZ_OUTPUT_MODE_JSON);
+				rz_core_types_function_print_all(core, RZ_OUTPUT_MODE_JSON);
 			}
 			break;
 		case ' ': {
 			const char *name = rz_str_trim_head_ro(input + 2);
-			types_function_print(core, name, RZ_OUTPUT_MODE_SDB, NULL);
+			rz_types_function_print(TDB, name, RZ_OUTPUT_MODE_SDB, NULL);
 			break;
 		}
 		default:
@@ -1926,7 +1034,7 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 			break;
 		}
 		if (input[1] == 'c') { // "ttc"
-			rz_core_list_typename_alias_c(core, input + 2);
+			rz_types_typedef_print_c(TDB, input + 2);
 			break;
 		}
 		if (input[1] == '?') { // "tt?"
@@ -1938,7 +1046,7 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 			break;
 		}
 		char *s = strdup(input + 2);
-		typedef_info(core, s);
+		rz_core_types_typedef_info(core, s);
 		free(s);
 	} break;
 	case '?':
@@ -1948,12 +1056,15 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 	return true;
 }
 
+// =============================================================================
+//                        END    DEPRECATED
+
 RZ_IPI RzCmdStatus rz_type_cc_list_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
 	const char *cc = argc > 1 ? argv[1] : NULL;
 	if (cc) {
 		types_cc_print(core, cc, mode);
 	} else {
-		types_cc_print_all(core, mode);
+		rz_core_types_calling_conventions_print(core, mode);
 	}
 	return RZ_CMD_STATUS_OK;
 }
@@ -2002,7 +1113,7 @@ RZ_IPI RzCmdStatus rz_type_list_enum_handler(RzCore *core, int argc, const char 
 			return types_enum_member_find(core, enum_name, member_value);
 		} else {
 			PJ *pj = (mode == RZ_OUTPUT_MODE_JSON) ? rz_core_pj_new(core) : NULL;
-			types_enum_print(core, enum_name, mode, pj);
+			rz_core_types_enum_print(core, enum_name, mode, pj);
 			if (mode == RZ_OUTPUT_MODE_JSON) {
 				rz_cons_println(pj_string(pj));
 				pj_free(pj);
@@ -2013,7 +1124,7 @@ RZ_IPI RzCmdStatus rz_type_list_enum_handler(RzCore *core, int argc, const char 
 		if (mode == RZ_OUTPUT_MODE_STANDARD) {
 			mode = RZ_OUTPUT_MODE_QUIET;
 		}
-		types_enum_print_all(core, mode);
+		rz_core_types_enum_print_all(core, mode);
 	}
 	return RZ_CMD_STATUS_OK;
 }
@@ -2035,14 +1146,14 @@ RZ_IPI RzCmdStatus rz_type_enum_bitfield_handler(RzCore *core, int argc, const c
 RZ_IPI RzCmdStatus rz_type_enum_c_handler(RzCore *core, int argc, const char **argv) {
 	const char *enum_name = argc > 1 ? argv[1] : NULL;
 	Sdb *TDB = core->analysis->sdb_types;
-	print_enum_in_c_format(TDB, enum_name, true);
+	rz_types_enum_print_c(TDB, enum_name, true);
 	return RZ_CMD_STATUS_OK;
 }
 
 RZ_IPI RzCmdStatus rz_type_enum_c_nl_handler(RzCore *core, int argc, const char **argv) {
 	const char *enum_name = argc > 1 ? argv[1] : NULL;
 	Sdb *TDB = core->analysis->sdb_types;
-	print_enum_in_c_format(TDB, enum_name, false);
+	rz_types_enum_print_c(TDB, enum_name, false);
 	return RZ_CMD_STATUS_OK;
 }
 
@@ -2055,13 +1166,13 @@ RZ_IPI RzCmdStatus rz_type_list_function_handler(RzCore *core, int argc, const c
 	const char *function = argc > 1 ? argv[1] : NULL;
 	if (function) {
 		PJ *pj = (mode == RZ_OUTPUT_MODE_JSON) ? rz_core_pj_new(core) : NULL;
-		types_function_print(core, function, mode, pj);
+		rz_types_function_print(core->analysis->sdb_types, function, mode, pj);
 		if (mode == RZ_OUTPUT_MODE_JSON) {
 			rz_cons_println(pj_string(pj));
 			pj_free(pj);
 		}
 	} else {
-		types_function_print_all(core, mode);
+		rz_core_types_function_print_all(core, mode);
 	}
 	return RZ_CMD_STATUS_OK;
 }
@@ -2088,16 +1199,16 @@ RZ_IPI RzCmdStatus rz_type_link_handler(RzCore *core, int argc, const char **arg
 	const char *name = argc > 1 ? argv[1] : NULL;
 	ut64 addr = argc > 2 ? rz_num_math(core->num, argv[2]) : core->offset;
 	if (name) {
-		types_link(core, name, addr);
+		rz_core_types_link(core, name, addr);
 	} else {
-		types_link_print_all(core, mode);
+		rz_core_types_link_print_all(core, mode);
 	}
 	return RZ_CMD_STATUS_OK;
 }
 
 RZ_IPI RzCmdStatus rz_type_link_show_handler(RzCore *core, int argc, const char **argv) {
 	ut64 addr = rz_num_math(core->num, argv[1]);
-	types_link_show(core, addr);
+	rz_core_types_link_show(core, addr);
 	return RZ_CMD_STATUS_OK;
 }
 
@@ -2124,7 +1235,7 @@ RZ_IPI RzCmdStatus rz_type_list_noreturn_handler(RzCore *core, int argc, const c
 			rz_analysis_noreturn_add(core->analysis, name, UT64_MAX);
 		}
 	} else {
-		rz_core_analysis_noreturn_print(core, mode);
+		rz_core_types_function_noreturn_print(core, mode);
 	}
 	return RZ_CMD_STATUS_OK;
 }
@@ -2137,7 +1248,7 @@ RZ_IPI RzCmdStatus rz_type_noreturn_del_handler(RzCore *core, int argc, const ch
 }
 
 RZ_IPI RzCmdStatus rz_type_noreturn_del_all_handler(RzCore *core, int argc, const char **argv) {
-	RzList *noretl = rz_core_analysis_noreturn(core);
+	RzList *noretl = rz_types_function_noreturn(core->analysis->sdb_types);
 	RzListIter *iter;
 	char *name;
 	rz_list_foreach (noretl, iter, name) {
@@ -2190,14 +1301,14 @@ RZ_IPI RzCmdStatus rz_type_list_structure_handler(RzCore *core, int argc, const 
 	const char *typename = argc > 1 ? argv[1] : NULL;
 	Sdb *TDB = core->analysis->sdb_types;
 	if (typename) {
-		type_show_format(core, typename, mode);
+		rz_core_types_show_format(core, typename, mode);
 	} else {
 		if (mode == RZ_OUTPUT_MODE_RIZIN) {
-			print_all_struct_format(core, TDB);
+			rz_core_types_struct_print_format_all(core, TDB);
 		} else if (mode == RZ_OUTPUT_MODE_JSON) {
-			print_struct_union_list_json(TDB, stdifstruct);
+			rz_types_struct_print_json(TDB);
 		} else {
-			print_keys(TDB, core, stdifstruct, printkey_cb, false);
+			rz_types_struct_print_sdb(TDB);
 		}
 	}
 	return RZ_CMD_STATUS_OK;
@@ -2206,21 +1317,21 @@ RZ_IPI RzCmdStatus rz_type_list_structure_handler(RzCore *core, int argc, const 
 RZ_IPI RzCmdStatus rz_type_structure_c_handler(RzCore *core, int argc, const char **argv) {
 	const char *typename = argc > 1 ? argv[1] : NULL;
 	Sdb *TDB = core->analysis->sdb_types;
-	print_struct_union_in_c_format(TDB, stdifstruct, typename, true);
+	rz_types_struct_print_c(TDB, typename, true);
 	return RZ_CMD_STATUS_OK;
 }
 
 RZ_IPI RzCmdStatus rz_type_structure_c_nl_handler(RzCore *core, int argc, const char **argv) {
 	const char *typename = argc > 1 ? argv[1] : NULL;
 	Sdb *TDB = core->analysis->sdb_types;
-	print_struct_union_in_c_format(TDB, stdifstruct, typename, false);
+	rz_types_struct_print_c(TDB, typename, false);
 	return RZ_CMD_STATUS_OK;
 }
 
 RZ_IPI RzCmdStatus rz_type_list_typedef_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
 	const char *typename = argc > 1 ? argv[1] : NULL;
 	if (typename) {
-		if (!typedef_info(core, typename)) {
+		if (!rz_core_types_typedef_info(core, typename)) {
 			eprintf("Can't find typedef");
 			return RZ_CMD_STATUS_ERROR;
 		}
@@ -2232,11 +1343,12 @@ RZ_IPI RzCmdStatus rz_type_list_typedef_handler(RzCore *core, int argc, const ch
 
 RZ_IPI RzCmdStatus rz_type_typedef_c_handler(RzCore *core, int argc, const char **argv) {
 	const char *typename = argc > 1 ? argv[1] : NULL;
+	Sdb *TDB = core->analysis->sdb_types;
 	if (!typename) {
-		rz_core_list_typename_alias_c(core, NULL);
+		rz_types_typedef_print_c(TDB, NULL);
 		return RZ_CMD_STATUS_OK;
 	}
-	rz_core_list_typename_alias_c(core, typename);
+	rz_types_typedef_print_c(TDB, typename);
 	return RZ_CMD_STATUS_OK;
 }
 
@@ -2244,14 +1356,14 @@ RZ_IPI RzCmdStatus rz_type_list_union_handler(RzCore *core, int argc, const char
 	const char *typename = argc > 1 ? argv[1] : NULL;
 	Sdb *TDB = core->analysis->sdb_types;
 	if (typename) {
-		type_show_format(core, typename, mode);
+		rz_core_types_show_format(core, typename, mode);
 	} else {
 		if (mode == RZ_OUTPUT_MODE_RIZIN) {
-			print_all_union_format(core, TDB);
+			rz_core_types_union_print_format_all(core, TDB);
 		} else if (mode == RZ_OUTPUT_MODE_JSON) {
-			print_struct_union_list_json(TDB, stdifunion);
+			rz_types_union_print_json(TDB);
 		} else {
-			print_keys(TDB, core, stdifunion, printkey_cb, false);
+			rz_types_union_print_sdb(TDB);
 		}
 	}
 	return RZ_CMD_STATUS_OK;
@@ -2260,13 +1372,13 @@ RZ_IPI RzCmdStatus rz_type_list_union_handler(RzCore *core, int argc, const char
 RZ_IPI RzCmdStatus rz_type_union_c_handler(RzCore *core, int argc, const char **argv) {
 	const char *typename = argc > 1 ? argv[1] : NULL;
 	Sdb *TDB = core->analysis->sdb_types;
-	print_struct_union_in_c_format(TDB, stdifunion, typename, true);
+	rz_types_union_print_c(TDB, typename, true);
 	return RZ_CMD_STATUS_OK;
 }
 
 RZ_IPI RzCmdStatus rz_type_union_c_nl_handler(RzCore *core, int argc, const char **argv) {
 	const char *typename = argc > 1 ? argv[1] : NULL;
 	Sdb *TDB = core->analysis->sdb_types;
-	print_struct_union_in_c_format(TDB, stdifunion, typename, false);
+	rz_types_union_print_c(TDB, typename, false);
 	return RZ_CMD_STATUS_OK;
 }

--- a/librz/core/cmd_type.c
+++ b/librz/core/cmd_type.c
@@ -620,7 +620,7 @@ static void cmd_type_noreturn(RzCore *core, const char *input) {
 	}
 }
 
-static void typesList(RzCore *core, int mode) {
+static void types_list(RzCore *core, int mode) {
 	switch (mode) {
 	case 1:
 	case '*':
@@ -834,7 +834,7 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 	case 'j': // "tj"
 	case '*': // "t*"
 	case 0: // "t"
-		typesList(core, input[0]);
+		types_list(core, input[0]);
 		break;
 	case 'o': // "to"
 		if (input[1] == '?') {
@@ -1087,6 +1087,27 @@ RZ_IPI int rz_cmd_type(void *data, const char *input) {
 
 // =============================================================================
 //                        END    DEPRECATED
+
+RZ_IPI RzCmdStatus rz_type_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
+	const char *type = argc > 1 ? argv[1] : NULL;
+	if (type) {
+		rz_core_types_show_format(core, type, mode);
+	} else {
+		rz_core_types_print_all(core, mode);
+	}
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_type_del_handler(RzCore *core, int argc, const char **argv) {
+	rz_analysis_remove_parsed_type(core->analysis, argv[1]);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_type_del_all_handler(RzCore *core, int argc, const char **argv) {
+	sdb_reset(core->analysis->sdb_types);
+	rz_parse_c_reset(core->parser);
+	return RZ_CMD_STATUS_OK;
+}
 
 RZ_IPI RzCmdStatus rz_type_cc_list_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
 	const char *cc = argc > 1 ? argv[1] : NULL;
@@ -1436,4 +1457,3 @@ RZ_IPI RzCmdStatus rz_type_xrefs_list_all_handler(RzCore *core, int argc, const 
 	types_xrefs_all(core);
 	return RZ_CMD_STATUS_OK;
 }
-

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -77,6 +77,11 @@ RZ_IPI void rz_core_types_link(RzCore *core, const char *type, ut64 addr);
 RZ_IPI void rz_core_types_link_show(RzCore *core, ut64 addr);
 RZ_IPI void rz_core_types_print_all(RzCore *core, RzOutputMode mode);
 
+RZ_IPI void rz_types_define(RzCore *core, const char *type);
+RZ_IPI void rz_types_open_file(RzCore *core, const char *path);
+RZ_IPI void rz_types_open_editor(RzCore *core, const char *typename);
+RZ_IPI void rz_types_open_sdb(RzCore *core, const char *path);
+
 /* agraph.c */
 RZ_IPI void rz_core_agraph_add_node(RzCore *core, const char *title, const char *body, int color);
 RZ_IPI void rz_core_agraph_del_node(RzCore *core, const char *title);

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -71,7 +71,7 @@ RZ_IPI void rz_core_types_show_format(RzCore *core, const char *name, RzOutputMo
 RZ_IPI void rz_core_types_struct_print_format_all(RzCore *core, Sdb *TDB);
 RZ_IPI void rz_core_types_union_print_format_all(RzCore *core, Sdb *TDB);
 RZ_IPI RzList *rz_types_links(Sdb *db);
-RZ_IPI void rz_core_types_link_print(RzCore *core, const char *type, ut64 addr, RzOutputMode mode);
+RZ_IPI void rz_core_types_link_print(RzCore *core, const char *type, ut64 addr, RzOutputMode mode, PJ *pj);
 RZ_IPI void rz_core_types_link_print_all(RzCore *core, RzOutputMode mode);
 RZ_IPI void rz_core_types_link(RzCore *core, const char *type, ut64 addr);
 RZ_IPI void rz_core_types_link_show(RzCore *core, ut64 addr);

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -7,6 +7,9 @@
 RZ_IPI void rz_core_kuery_print(RzCore *core, const char *k);
 RZ_IPI int rz_output_mode_to_char(RzOutputMode mode);
 
+RZ_IPI int bb_cmpaddr(const void *_a, const void *_b);
+RZ_IPI int fcn_cmpaddr(const void *_a, const void *_b);
+
 RZ_IPI int rz_core_analysis_set_reg(RzCore *core, const char *regname, ut64 val);
 RZ_IPI void rz_core_analysis_esil_init(RzCore *core);
 RZ_IPI void rz_core_analysis_esil_reinit(RzCore *core);
@@ -23,8 +26,6 @@ RZ_IPI void rz_core_analysis_esil_emulate_bb(RzCore *core);
 RZ_IPI void rz_core_analysis_esil_default(RzCore *core);
 
 RZ_IPI bool rz_core_analysis_var_rename(RzCore *core, const char *name, const char *newname);
-RZ_IPI RzList *rz_core_analysis_calling_conventions(RzCore *core);
-RZ_IPI void rz_core_analysis_calling_conventions_print(RzCore *core);
 RZ_IPI char *rz_core_analysis_function_signature(RzCore *core, RzOutputMode mode, char *fcn_name);
 RZ_IPI bool rz_core_analysis_everything(RzCore *core, bool experimental, char *dh_orig);
 RZ_IPI bool rz_core_analysis_function_delete_var(RzCore *core, RzAnalysisFunction *fcn, RzAnalysisVarKind kind, const char *id);
@@ -39,9 +40,44 @@ RZ_IPI void rz_core_analysis_bbs_info_print(RzCore *core, RzAnalysisFunction *fc
 RZ_IPI void rz_core_analysis_bb_info_print(RzCore *core, RzAnalysisBlock *bb, ut64 addr, RzOutputMode mode);
 RZ_IPI void rz_core_analysis_function_until(RzCore *core, ut64 addr_end);
 RZ_IPI void rz_core_analysis_value_pointers(RzCore *core, RzOutputMode mode);
-RZ_IPI RzList *rz_core_analysis_noreturn(RzCore *core);
-RZ_IPI void rz_core_analysis_noreturn_print(RzCore *core, RzOutputMode mode);
 
+/* ctypes.c */
+RZ_IPI RzList *rz_types_calling_conventions(Sdb *db);
+RZ_IPI void rz_core_types_calling_conventions_print(RzCore *core, RzOutputMode mode);
+RZ_IPI RzList *rz_types_enums(Sdb *db);
+RZ_IPI void rz_core_types_enum_print(RzCore *core, const char *enum_name, RzOutputMode mode, PJ *pj);
+RZ_IPI void rz_core_types_enum_print_all(RzCore *core, RzOutputMode mode);
+RZ_IPI void rz_types_enum_print_c(Sdb *TDB, const char *arg, bool multiline);
+RZ_IPI bool rz_core_types_typedef_info(RzCore *core, const char *name);
+RZ_IPI void rz_types_typedef_print_c(Sdb *TDB, const char *typedef_name);
+RZ_IPI void rz_core_list_loaded_typedefs(RzCore *core, RzOutputMode mode);
+
+// Structured types JSON
+RZ_IPI void rz_types_structured_print_json(Sdb *TDB, SdbList *l);
+RZ_IPI void rz_types_union_print_json(Sdb *TDB);
+RZ_IPI void rz_types_struct_print_json(Sdb *TDB);
+// Structured types SDB
+RZ_IPI void rz_types_structured_print_sdb(Sdb *TDB, SdbList *l);
+RZ_IPI void rz_types_union_print_sdb(Sdb *TDB);
+RZ_IPI void rz_types_struct_print_sdb(Sdb *TDB);
+// Structured types C format
+RZ_IPI void rz_types_union_print_c(Sdb *TDB, const char *name, bool multiline);
+RZ_IPI void rz_types_struct_print_c(Sdb *TDB, const char *name, bool multiline);
+RZ_IPI void rz_types_function_print(Sdb *TDB, const char *function, RzOutputMode mode, PJ *pj);
+RZ_IPI void rz_core_types_function_print_all(RzCore *core, RzOutputMode mode);
+RZ_IPI RzList *rz_types_function_noreturn(Sdb *db);
+RZ_IPI void rz_core_types_function_noreturn_print(RzCore *core, RzOutputMode mode);
+RZ_IPI void rz_core_types_show_format(RzCore *core, const char *name, RzOutputMode mode);
+RZ_IPI void rz_core_types_struct_print_format_all(RzCore *core, Sdb *TDB);
+RZ_IPI void rz_core_types_union_print_format_all(RzCore *core, Sdb *TDB);
+RZ_IPI RzList *rz_types_links(Sdb *db);
+RZ_IPI void rz_core_types_link_print(RzCore *core, const char *type, ut64 addr, RzOutputMode mode);
+RZ_IPI void rz_core_types_link_print_all(RzCore *core, RzOutputMode mode);
+RZ_IPI void rz_core_types_link(RzCore *core, const char *type, ut64 addr);
+RZ_IPI void rz_core_types_link_show(RzCore *core, ut64 addr);
+RZ_IPI void rz_core_types_print_all(RzCore *core, RzOutputMode mode);
+
+/* agraph.c */
 RZ_IPI void rz_core_agraph_add_node(RzCore *core, const char *title, const char *body, int color);
 RZ_IPI void rz_core_agraph_del_node(RzCore *core, const char *title);
 RZ_IPI void rz_core_agraph_add_edge(RzCore *core, const char *un, const char *vn);

--- a/librz/core/ctypes.c
+++ b/librz/core/ctypes.c
@@ -1035,6 +1035,9 @@ RZ_IPI void rz_core_types_print_all(RzCore *core, RzOutputMode mode) {
 		}
 		break;
 	case RZ_OUTPUT_MODE_RIZIN:
+		// This is a special case, we don't filter anything
+		ls_free(l);
+		l = sdb_foreach_list(TDB, true);
 		ls_foreach (l, it, kv) {
 			rz_cons_printf("tk %s=%s\n", sdbkv_key(kv), sdbkv_value(kv));
 		}

--- a/librz/core/ctypes.c
+++ b/librz/core/ctypes.c
@@ -1,0 +1,1047 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <string.h>
+
+#include <rz_types.h>
+#include <rz_list.h>
+#include <rz_core.h>
+
+#include "core_private.h"
+
+static void kv_lines_print_sorted(char *kv_lines) {
+	RzListIter *iter;
+	char *k;
+	RzList *list = rz_str_split_duplist(kv_lines, "\n", true);
+	rz_list_sort(list, (RzListComparator)strcmp);
+	rz_list_foreach (list, iter, k) {
+		if (RZ_STR_ISNOTEMPTY(k)) {
+			rz_cons_println(k);
+		}
+	}
+	rz_list_free(list);
+}
+
+// Calling conventions
+
+RZ_IPI RzList *rz_types_calling_conventions(Sdb *db) {
+	RzList *ccl = rz_list_new();
+	SdbKv *kv;
+	SdbListIter *iter;
+	SdbList *l = sdb_foreach_list(db, true);
+	ls_foreach (l, iter, kv) {
+		if (!strcmp(sdbkv_value(kv), "cc")) {
+			rz_list_append(ccl, strdup(sdbkv_key(kv)));
+		}
+	}
+	ls_free(l);
+	return ccl;
+}
+
+RZ_IPI void rz_core_types_calling_conventions_print(RzCore *core, RzOutputMode mode) {
+	RzList *list = rz_types_calling_conventions(core->analysis->sdb_cc);
+	RzListIter *iter;
+	const char *cc;
+	switch (mode) {
+	case RZ_OUTPUT_MODE_STANDARD: {
+		rz_list_foreach (list, iter, cc) {
+			rz_cons_println(cc);
+		}
+	} break;
+	case RZ_OUTPUT_MODE_JSON: {
+		PJ *pj = rz_core_pj_new(core);
+		pj_a(pj);
+		rz_list_foreach (list, iter, cc) {
+			char *ccexpr = rz_analysis_cc_get(core->analysis, cc);
+			// TODO: expose this as an object, not just an array of strings
+			pj_s(pj, ccexpr);
+			free(ccexpr);
+		}
+		pj_end(pj);
+		rz_cons_printf("%s\n", pj_string(pj));
+		pj_free(pj);
+	} break;
+	case RZ_OUTPUT_MODE_LONG: {
+		rz_list_foreach (list, iter, cc) {
+			char *ccexpr = rz_analysis_cc_get(core->analysis, cc);
+			rz_cons_printf("%s\n", ccexpr);
+			free(ccexpr);
+		}
+	} break;
+	case RZ_OUTPUT_MODE_RIZIN: {
+		rz_list_foreach (list, iter, cc) {
+			char *ccexpr = rz_analysis_cc_get(core->analysis, cc);
+			rz_cons_printf("tcc \"%s\"\n", ccexpr);
+			free(ccexpr);
+		}
+	} break;
+	case RZ_OUTPUT_MODE_SDB:
+		rz_core_kuery_print(core, "analysis/cc/*");
+		break;
+	default:
+		rz_warn_if_reached();
+		break;
+	}
+	rz_list_free(list);
+}
+
+// Enums
+
+RZ_IPI RzList *rz_types_enums(Sdb *db) {
+	RzList *ccl = rz_list_new();
+	SdbKv *kv;
+	SdbListIter *iter;
+	SdbList *l = sdb_foreach_list(db, true);
+	ls_foreach (l, iter, kv) {
+		if (!strcmp(sdbkv_value(kv), "enum")) {
+			rz_list_append(ccl, strdup(sdbkv_key(kv)));
+		}
+	}
+	ls_free(l);
+	return ccl;
+}
+
+RZ_IPI void rz_core_types_enum_print(RzCore *core, const char *enum_name, RzOutputMode mode, PJ *pj) {
+	rz_return_if_fail(enum_name);
+	Sdb *TDB = core->analysis->sdb_types;
+	switch (mode) {
+	case RZ_OUTPUT_MODE_JSON: {
+		rz_return_if_fail(pj);
+		RTypeEnum *member;
+		RzListIter *iter;
+		RzList *list = rz_type_get_enum(TDB, enum_name);
+		pj_o(pj);
+		if (list && !rz_list_empty(list)) {
+			pj_ks(pj, "name", enum_name);
+			pj_k(pj, "values");
+			pj_o(pj);
+			rz_list_foreach (list, iter, member) {
+				pj_kn(pj, member->name, rz_num_math(NULL, member->val));
+			}
+			pj_end(pj);
+		}
+		pj_end(pj);
+		rz_list_free(list);
+		break;
+	}
+	case RZ_OUTPUT_MODE_STANDARD: {
+		RzList *list = rz_type_get_enum(TDB, enum_name);
+		RzListIter *iter;
+		RTypeEnum *member;
+		rz_list_foreach (list, iter, member) {
+			rz_cons_printf("%s = %s\n", member->name, member->val);
+		}
+		rz_list_free(list);
+		break;
+	}
+	case RZ_OUTPUT_MODE_QUIET:
+		rz_cons_println(enum_name);
+		break;
+	case RZ_OUTPUT_MODE_SDB: {
+		char *keys = sdb_querys(TDB, NULL, -1, sdb_fmt("~~enum.%s", enum_name));
+		if (keys) {
+			kv_lines_print_sorted(keys);
+			free(keys);
+		}
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+RZ_IPI void rz_core_types_enum_print_all(RzCore *core, RzOutputMode mode) {
+	Sdb *TDB = core->analysis->sdb_types;
+	RzList *enumlist = rz_types_enums(TDB);
+	RzListIter *it;
+	char *e;
+	PJ *pj = (mode == RZ_OUTPUT_MODE_JSON) ? rz_core_pj_new(core) : NULL;
+	if (mode == RZ_OUTPUT_MODE_JSON) {
+		pj_a(pj);
+	}
+	rz_list_foreach (enumlist, it, e) {
+		rz_core_types_enum_print(core, e, mode, pj);
+	}
+	rz_list_free(enumlist);
+	if (mode == RZ_OUTPUT_MODE_JSON) {
+		pj_end(pj);
+		rz_cons_println(pj_string(pj));
+		pj_free(pj);
+	}
+}
+
+RZ_IPI void rz_types_enum_print_c(Sdb *TDB, const char *arg, bool multiline) {
+	char *name = NULL;
+	SdbKv *kv;
+	SdbListIter *iter;
+	SdbList *l = sdb_foreach_list(TDB, true);
+	const char *separator = "";
+	bool match = false;
+	ls_foreach (l, iter, kv) {
+		if (!strcmp(sdbkv_value(kv), "enum")) {
+			if (!name || strcmp(sdbkv_value(kv), name)) {
+				free(name);
+				name = strdup(sdbkv_key(kv));
+				if (name && (arg && *arg)) {
+					if (!strcmp(arg, name)) {
+						match = true;
+					} else {
+						continue;
+					}
+				}
+				rz_cons_printf("%s %s {%s", sdbkv_value(kv), name, multiline ? "\n" : "");
+				{
+					RzList *list = rz_type_get_enum(TDB, name);
+					if (list && !rz_list_empty(list)) {
+						RzListIter *iter;
+						RTypeEnum *member;
+						separator = multiline ? "\t" : "";
+						rz_list_foreach (list, iter, member) {
+							rz_cons_printf("%s%s = %" PFMT64u, separator, member->name, rz_num_math(NULL, member->val));
+							separator = multiline ? ",\n\t" : ", ";
+						}
+					}
+					rz_list_free(list);
+				}
+				rz_cons_println(multiline ? "\n};" : "};");
+				if (match) {
+					break;
+				}
+			}
+		}
+	}
+	free(name);
+	ls_free(l);
+}
+
+// Structured types (structures and unions)
+
+static bool sdb_if_union_cb(void *p, const char *k, const char *v) {
+	return !strncmp(v, "union", strlen("union") + 1);
+}
+
+static bool sdb_if_struct_cb(void *user, const char *k, const char *v) {
+	rz_return_val_if_fail(user, false);
+	Sdb *TDB = (Sdb *)user;
+	if (!strcmp(v, "struct") && !rz_str_startswith(k, "typedef")) {
+		return true;
+	}
+	if (!strcmp(v, "typedef")) {
+		const char *typedef_key = sdb_fmt("typedef.%s", k);
+		const char *type = sdb_const_get(TDB, typedef_key, NULL);
+		if (type && rz_str_startswith(type, "struct")) {
+			return true;
+		}
+	}
+	return false;
+}
+
+RZ_IPI void rz_types_structured_print_json(Sdb *TDB, SdbList *l) {
+	SdbKv *kv;
+	SdbListIter *it;
+	PJ *pj = pj_new();
+	if (!pj) {
+		return;
+	}
+
+	pj_a(pj); // [
+	ls_foreach (l, it, kv) {
+		const char *k = sdbkv_key(kv);
+		if (!k || !*k) {
+			continue;
+		}
+		pj_o(pj); // {
+		pj_ks(pj, "type", k); // key value pair of string and string
+		pj_end(pj); // }
+	}
+	pj_end(pj); // ]
+
+	rz_cons_println(pj_string(pj));
+	pj_free(pj);
+}
+
+RZ_IPI void rz_types_union_print_json(Sdb *TDB) {
+	SdbList *l = sdb_foreach_list_filter(TDB, sdb_if_union_cb, true);
+	rz_types_structured_print_json(TDB, l);
+	ls_free(l);
+}
+
+RZ_IPI void rz_types_struct_print_json(Sdb *TDB) {
+	SdbList *l = sdb_foreach_list_filter_user(TDB, sdb_if_struct_cb, true, TDB);
+	rz_types_structured_print_json(TDB, l);
+	ls_free(l);
+}
+
+RZ_IPI void rz_types_structured_print_sdb(Sdb *TDB, SdbList *l) {
+	SdbKv *kv;
+	SdbListIter *it;
+	ls_foreach (l, it, kv) {
+		rz_cons_println(sdbkv_key(kv));
+	}
+}
+
+RZ_IPI void rz_types_union_print_sdb(Sdb *TDB) {
+	SdbList *l = sdb_foreach_list_filter(TDB, sdb_if_union_cb, true);
+	rz_types_structured_print_sdb(TDB, l);
+	ls_free(l);
+}
+
+RZ_IPI void rz_types_struct_print_sdb(Sdb *TDB) {
+	SdbList *l = sdb_foreach_list_filter_user(TDB, sdb_if_struct_cb, true, TDB);
+	rz_types_structured_print_sdb(TDB, l);
+	ls_free(l);
+}
+
+RZ_IPI void rz_types_structured_print_c(Sdb *TDB, SdbList *l, const char *arg, bool multiline) {
+	char *name = NULL;
+	SdbKv *kv;
+	SdbListIter *iter;
+	const char *space = "";
+	bool match = false;
+
+	ls_foreach (l, iter, kv) {
+		if (name && !strcmp(sdbkv_value(kv), name)) {
+			continue;
+		}
+		free(name);
+		int n;
+		name = strdup(sdbkv_key(kv));
+		if (name && (arg && *arg)) {
+			if (!strcmp(arg, name)) {
+				match = true;
+			} else {
+				continue;
+			}
+		}
+		rz_cons_printf("%s %s {%s", sdbkv_value(kv), name, multiline ? "\n" : "");
+		char *p, *var = rz_str_newf("%s.%s", sdbkv_value(kv), name);
+		for (n = 0; (p = sdb_array_get(TDB, var, n, NULL)); n++) {
+			char *var2 = rz_str_newf("%s.%s", var, p);
+			if (var2) {
+				char *val = sdb_array_get(TDB, var2, 0, NULL);
+				if (val) {
+					char *arr = sdb_array_get(TDB, var2, 2, NULL);
+					int arrnum = atoi(arr);
+					free(arr);
+					if (multiline) {
+						rz_cons_printf("\t%s", val);
+						if (p && p[0] != '\0') {
+							rz_cons_printf("%s%s", strstr(val, " *") ? "" : " ", p);
+							if (arrnum) {
+								rz_cons_printf("[%d]", arrnum);
+							}
+						}
+						rz_cons_println(";");
+					} else {
+						rz_cons_printf("%s%s %s", space, val, p);
+						if (arrnum) {
+							rz_cons_printf("[%d]", arrnum);
+						}
+						rz_cons_print(";");
+						space = " ";
+					}
+					free(val);
+				}
+				free(var2);
+			}
+			free(p);
+		}
+		free(var);
+		rz_cons_println("};");
+		space = "";
+		if (match) {
+			break;
+		}
+	}
+	free(name);
+}
+
+RZ_IPI void rz_types_union_print_c(Sdb *TDB, const char *name, bool multiline) {
+	SdbList *l = sdb_foreach_list_filter(TDB, sdb_if_union_cb, true);
+	rz_types_structured_print_c(TDB, l, name, multiline);
+	ls_free(l);
+}
+
+RZ_IPI void rz_types_struct_print_c(Sdb *TDB, const char *name, bool multiline) {
+	SdbList *l = sdb_foreach_list_filter_user(TDB, sdb_if_struct_cb, true, TDB);
+	rz_types_structured_print_c(TDB, l, name, multiline);
+	ls_free(l);
+}
+
+// Typedefs
+
+RZ_IPI bool rz_core_types_typedef_info(RzCore *core, const char *name) {
+	const char *istypedef;
+	Sdb *TDB = core->analysis->sdb_types;
+	istypedef = sdb_const_get(TDB, name, 0);
+	if (istypedef && !strncmp(istypedef, "typedef", 7)) {
+		const char *q = sdb_fmt("typedef.%s", name);
+		const char *res = sdb_const_get(TDB, q, 0);
+		if (res) {
+			rz_cons_println(res);
+		} else {
+			return false;
+		}
+	} else {
+		eprintf("This is not an typedef\n");
+		return false;
+	}
+	return true;
+}
+
+RZ_IPI void rz_core_list_loaded_typedefs(RzCore *core, RzOutputMode mode) {
+	PJ *pj = NULL;
+	Sdb *TDB = core->analysis->sdb_types;
+	if (mode == RZ_OUTPUT_MODE_JSON) {
+		pj = rz_core_pj_new(core);
+		if (!pj) {
+			return;
+		}
+		pj_o(pj);
+	}
+	char *name = NULL;
+	SdbKv *kv;
+	SdbListIter *iter;
+	SdbList *l = sdb_foreach_list(TDB, true);
+	ls_foreach (l, iter, kv) {
+		if (!strcmp(sdbkv_value(kv), "typedef")) {
+			if (!name || strcmp(sdbkv_value(kv), name)) {
+				free(name);
+				name = strdup(sdbkv_key(kv));
+				if (mode == RZ_OUTPUT_MODE_STANDARD) {
+					rz_cons_println(name);
+				} else {
+					const char *q = sdb_fmt("typedef.%s", name);
+					const char *res = sdb_const_get(TDB, q, 0);
+					pj_ks(pj, name, res);
+				}
+			}
+		}
+	}
+	if (mode == RZ_OUTPUT_MODE_JSON) {
+		pj_end(pj);
+		rz_cons_println(pj_string(pj));
+		pj_free(pj);
+	}
+	free(name);
+	ls_free(l);
+}
+
+RZ_IPI void rz_types_typedef_print_c(Sdb *TDB, const char *typedef_name) {
+	char *name = NULL;
+	SdbKv *kv;
+	SdbListIter *iter;
+	SdbList *l = sdb_foreach_list(TDB, true);
+	bool match = false;
+	ls_foreach (l, iter, kv) {
+		if (!strcmp(sdbkv_value(kv), "typedef")) {
+			if (!name || strcmp(sdbkv_value(kv), name)) {
+				free(name);
+				name = strdup(sdbkv_key(kv));
+				if (name && (typedef_name && *typedef_name)) {
+					if (!strcmp(typedef_name, name)) {
+						match = true;
+					} else {
+						continue;
+					}
+				}
+				const char *q = sdb_fmt("typedef.%s", name);
+				const char *res = sdb_const_get(TDB, q, 0);
+				if (res) {
+					rz_cons_printf("%s %s %s;\n", sdbkv_value(kv), res, name);
+				}
+				if (match) {
+					break;
+				}
+			}
+		}
+	}
+	free(name);
+	ls_free(l);
+}
+
+// Function types
+
+RZ_IPI void rz_types_function_print(Sdb *TDB, const char *function, RzOutputMode mode, PJ *pj) {
+	rz_return_if_fail(function);
+	char *res = sdb_querys(TDB, NULL, -1, sdb_fmt("func.%s.args", function));
+	int i, args = sdb_num_get(TDB, sdb_fmt("func.%s.args", function), 0);
+	const char *ret = sdb_const_get(TDB, sdb_fmt("func.%s.ret", function), 0);
+	if (!ret) {
+		ret = "void";
+	}
+	switch (mode) {
+	case RZ_OUTPUT_MODE_JSON: {
+		rz_return_if_fail(pj);
+		pj_o(pj);
+		pj_ks(pj, "name", function);
+		pj_ks(pj, "ret", ret);
+		pj_k(pj, "args");
+		pj_a(pj);
+		for (i = 0; i < args; i++) {
+			char *type = sdb_get(TDB, sdb_fmt("func.%s.arg.%d", function, i), 0);
+			if (!type) {
+				continue;
+			}
+			char *name = strchr(type, ',');
+			if (name) {
+				*name++ = 0;
+			}
+			pj_o(pj);
+			pj_ks(pj, "type", type);
+			if (name) {
+				pj_ks(pj, "name", name);
+			} else {
+				pj_ks(pj, "name", "(null)");
+			}
+			pj_end(pj);
+		}
+		pj_end(pj);
+		pj_end(pj);
+	} break;
+	case RZ_OUTPUT_MODE_SDB: {
+		char *keys = sdb_querys(TDB, NULL, -1, sdb_fmt("~~func.%s", function));
+		if (keys) {
+			kv_lines_print_sorted(keys);
+			free(keys);
+		}
+	} break;
+	default: {
+		rz_cons_printf("%s %s (", ret, function);
+		for (i = 0; i < args; i++) {
+			char *type = sdb_get(TDB, sdb_fmt("func.%s.arg.%d", function, i), 0);
+			char *name = strchr(type, ',');
+			if (name) {
+				*name++ = 0;
+			}
+			rz_cons_printf("%s%s %s", i == 0 ? "" : ", ", type, name);
+		}
+		rz_cons_printf(");\n");
+	} break;
+	}
+	free(res);
+}
+
+RZ_IPI void rz_core_types_function_print_all(RzCore *core, RzOutputMode mode) {
+	Sdb *TDB = core->analysis->sdb_types;
+	SdbKv *kv;
+	SdbListIter *iter;
+	PJ *pj = (mode == RZ_OUTPUT_MODE_JSON) ? rz_core_pj_new(core) : NULL;
+	SdbList *l = sdb_foreach_list(TDB, true);
+	if (mode == RZ_OUTPUT_MODE_JSON) {
+		pj_a(pj);
+	}
+	ls_foreach (l, iter, kv) {
+		if (!strcmp(sdbkv_value(kv), "func")) {
+			const char *name = sdbkv_key(kv);
+			rz_types_function_print(TDB, name, mode, pj);
+		}
+	}
+	ls_free(l);
+	if (mode == RZ_OUTPUT_MODE_JSON) {
+		pj_end(pj);
+		rz_cons_println(pj_string(pj));
+		pj_free(pj);
+	}
+}
+
+// Noreturn function attributes
+
+static bool nonreturn_print_rizin(void *p, const char *k, const char *v) {
+	RzCore *core = (RzCore *)p;
+	if (!strncmp(v, "func", strlen("func") + 1)) {
+		char *query = sdb_fmt("func.%s.noreturn", k);
+		if (sdb_bool_get(core->analysis->sdb_types, query, NULL)) {
+			rz_cons_printf("tnn %s\n", k);
+		}
+	}
+	if (!strncmp(k, "addr.", 5)) {
+		rz_cons_printf("tna 0x%s %s\n", k + 5, v);
+	}
+	return true;
+}
+
+static bool nonreturn_print(RzCore *core, RzList *noretl) {
+	RzListIter *it;
+	char *s;
+	rz_list_foreach (noretl, it, s) {
+		rz_cons_println(s);
+	}
+	return true;
+}
+
+static bool nonreturn_print_json(RzCore *core, RzList *noretl) {
+	RzListIter *it;
+	char *s;
+	PJ *pj = rz_core_pj_new(core);
+	pj_a(pj);
+	rz_list_foreach (noretl, it, s) {
+		pj_k(pj, s);
+	}
+	pj_end(pj);
+	rz_cons_println(pj_string(pj));
+	pj_free(pj);
+	return true;
+}
+
+RZ_IPI RzList *rz_types_function_noreturn(Sdb *db) {
+	RzList *noretl = rz_list_new();
+	SdbKv *kv;
+	SdbListIter *iter;
+	SdbList *l = sdb_foreach_list(db, true);
+	ls_foreach (l, iter, kv) {
+		const char *k = sdbkv_key(kv);
+		if (!strncmp(k, "func.", 5) && strstr(k, ".noreturn")) {
+			char *s = strdup(k + 5);
+			char *d = strchr(s, '.');
+			if (d) {
+				*d = 0;
+			}
+			rz_list_append(noretl, strdup(s));
+			free(s);
+		}
+		if (!strncmp(k, "addr.", 5)) {
+			char *off;
+			if (!(off = strdup(k + 5))) {
+				break;
+			}
+			char *ptr = strstr(off, ".noreturn");
+			if (ptr) {
+				*ptr = 0;
+				char *addr = rz_str_newf("0x%s", off);
+				rz_list_append(noretl, addr);
+			}
+			free(off);
+		}
+	}
+	ls_free(l);
+	return noretl;
+}
+
+RZ_IPI void rz_core_types_function_noreturn_print(RzCore *core, RzOutputMode mode) {
+	Sdb *TDB = core->analysis->sdb_types;
+	RzList *noretl = rz_types_function_noreturn(TDB);
+	switch (mode) {
+	case RZ_OUTPUT_MODE_RIZIN:
+		sdb_foreach(TDB, nonreturn_print_rizin, core);
+		break;
+	case RZ_OUTPUT_MODE_JSON:
+		nonreturn_print_json(core, noretl);
+		break;
+	default:
+		nonreturn_print(core, noretl);
+		break;
+	}
+}
+
+// Type formatting
+
+RZ_IPI void rz_core_types_show_format(RzCore *core, const char *name, RzOutputMode mode) {
+	const char *isenum = sdb_const_get(core->analysis->sdb_types, name, 0);
+	if (isenum && !strcmp(isenum, "enum")) {
+		eprintf("IS ENUM\n");
+	} else {
+		char *fmt = rz_type_format(core->analysis->sdb_types, name);
+		if (fmt) {
+			rz_str_trim(fmt);
+			switch (mode) {
+			case RZ_OUTPUT_MODE_JSON: {
+				PJ *pj = rz_core_pj_new(core);
+				if (!pj) {
+					return;
+				}
+				pj_o(pj);
+				pj_ks(pj, "name", name);
+				pj_ks(pj, "format", fmt);
+				pj_end(pj);
+				rz_cons_printf("%s", pj_string(pj));
+				pj_free(pj);
+			} break;
+			case RZ_OUTPUT_MODE_RIZIN: {
+				rz_cons_printf("pf.%s %s\n", name, fmt);
+			} break;
+			case RZ_OUTPUT_MODE_STANDARD: {
+				// FIXME: Not really a standard format
+				// We should think about better representation by default here
+				rz_cons_printf("pf %s\n", fmt);
+			} break;
+			default:
+				break;
+			}
+			free(fmt);
+		} else {
+			eprintf("Cannot find '%s' type\n", name);
+		}
+	}
+}
+
+static void print_all_format(RzCore *core, Sdb *TDB, SdbForeachCallback sdbcb) {
+	SdbList *l = sdb_foreach_list(TDB, true);
+	SdbListIter *it;
+	SdbKv *kv;
+	ls_foreach (l, it, kv) {
+		if (sdbcb(TDB, sdbkv_key(kv), sdbkv_value(kv))) {
+			rz_core_types_show_format(core, sdbkv_key(kv), RZ_OUTPUT_MODE_RIZIN);
+		}
+	}
+	ls_free(l);
+}
+
+RZ_IPI void rz_core_types_struct_print_format_all(RzCore *core, Sdb *TDB) {
+	print_all_format(core, TDB, sdb_if_struct_cb);
+}
+
+RZ_IPI void rz_core_types_union_print_format_all(RzCore *core, Sdb *TDB) {
+	print_all_format(core, TDB, sdb_if_union_cb);
+}
+
+// Type links
+
+RZ_IPI RzList *rz_types_links(Sdb *db) {
+	RzList *ccl = rz_list_new();
+	SdbKv *kv;
+	SdbListIter *iter;
+	SdbList *l = sdb_foreach_list(db, true);
+	ls_foreach (l, iter, kv) {
+		if (!strcmp(sdbkv_value(kv), "link")) {
+			rz_list_append(ccl, strdup(sdbkv_key(kv)));
+		}
+	}
+	ls_free(l);
+	return ccl;
+}
+
+static void set_retval(RzCore *core, ut64 at) {
+	RzAnalysis *analysis = core->analysis;
+	RzAnalysisHint *hint = rz_analysis_hint_get(analysis, at);
+	RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(analysis, at, 0);
+
+	if (!hint || !fcn || !fcn->name) {
+		goto beach;
+	}
+	if (hint->ret == UT64_MAX) {
+		goto beach;
+	}
+	const char *cc = rz_analysis_cc_func(core->analysis, fcn->name);
+	const char *regname = rz_analysis_cc_ret(analysis, cc);
+	if (regname) {
+		RzRegItem *reg = rz_reg_get(analysis->reg, regname, -1);
+		if (reg) {
+			rz_reg_set_value(analysis->reg, reg, hint->ret);
+		}
+	}
+beach:
+	rz_analysis_hint_free(hint);
+	return;
+}
+
+static void set_offset_hint(RzCore *core, RzAnalysisOp *op, const char *type, ut64 laddr, ut64 at, int offimm) {
+	char *res = rz_type_get_struct_memb(core->analysis->sdb_types, type, offimm);
+	const char *cmt = ((offimm == 0) && res) ? res : type;
+	if (offimm > 0) {
+		// set hint only if link is present
+		char *query = sdb_fmt("link.%08" PFMT64x, laddr);
+		if (res && sdb_const_get(core->analysis->sdb_types, query, 0)) {
+			rz_analysis_hint_set_offset(core->analysis, at, res);
+		}
+	} else if (cmt && rz_analysis_op_ismemref(op->type)) {
+		rz_meta_set_string(core->analysis, RZ_META_TYPE_VARTYPE, at, cmt);
+	}
+}
+
+RZ_API void rz_core_link_stroff(RzCore *core, RzAnalysisFunction *fcn) {
+	RzAnalysisBlock *bb;
+	RzListIter *it;
+	RzAnalysisOp aop = { 0 };
+	bool ioCache = rz_config_get_i(core->config, "io.cache");
+	bool stack_set = false;
+	bool resolved = false;
+	const char *varpfx;
+	int dbg_follow = rz_config_get_i(core->config, "dbg.follow");
+	Sdb *TDB = core->analysis->sdb_types;
+	RzAnalysisEsil *esil;
+	int iotrap = rz_config_get_i(core->config, "esil.iotrap");
+	int stacksize = rz_config_get_i(core->config, "esil.stack.depth");
+	unsigned int addrsize = rz_config_get_i(core->config, "esil.addr.size");
+	const char *pc_name = rz_reg_get_name(core->analysis->reg, RZ_REG_NAME_PC);
+	const char *sp_name = rz_reg_get_name(core->analysis->reg, RZ_REG_NAME_SP);
+	RzRegItem *pc = rz_reg_get(core->analysis->reg, pc_name, -1);
+
+	if (!fcn) {
+		return;
+	}
+	if (!(esil = rz_analysis_esil_new(stacksize, iotrap, addrsize))) {
+		return;
+	}
+	rz_analysis_esil_setup(esil, core->analysis, 0, 0, 0);
+	int i, ret, bsize = RZ_MAX(64, core->blocksize);
+	const int mininstrsz = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE);
+	const int maxinstrsz = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_MAX_OP_SIZE);
+	const int minopcode = RZ_MAX(1, mininstrsz);
+	ut8 *buf = malloc(bsize);
+	if (!buf) {
+		free(buf);
+		rz_analysis_esil_free(esil);
+		return;
+	}
+	rz_reg_arena_push(core->analysis->reg);
+	rz_debug_reg_sync(core->dbg, RZ_REG_TYPE_ALL, true);
+	ut64 spval = rz_reg_getv(esil->analysis->reg, sp_name);
+	if (spval) {
+		// reset stack pointer to initial value
+		RzRegItem *sp = rz_reg_get(esil->analysis->reg, sp_name, -1);
+		ut64 curpc = rz_reg_getv(esil->analysis->reg, pc_name);
+		int stacksz = rz_core_get_stacksz(core, fcn->addr, curpc);
+		if (stacksz > 0) {
+			rz_reg_arena_zero(esil->analysis->reg); // clear prev reg values
+			rz_reg_set_value(esil->analysis->reg, sp, spval + stacksz);
+		}
+	} else {
+		// initialize stack
+		rz_core_analysis_esil_init_mem(core, NULL, UT64_MAX, UT32_MAX);
+		stack_set = true;
+	}
+	rz_config_set_i(core->config, "io.cache", 1);
+	rz_config_set_i(core->config, "dbg.follow", 0);
+	ut64 oldoff = core->offset;
+	rz_cons_break_push(NULL, NULL);
+	// TODO: The algorithm can be more accurate if blocks are followed by their jmp/fail, not just by address
+	rz_list_sort(fcn->bbs, bb_cmpaddr);
+	rz_list_foreach (fcn->bbs, it, bb) {
+		ut64 at = bb->addr;
+		ut64 to = bb->addr + bb->size;
+		rz_reg_set_value(esil->analysis->reg, pc, at);
+		for (i = 0; at < to; i++) {
+			if (rz_cons_is_breaked()) {
+				goto beach;
+			}
+			if (at < bb->addr) {
+				break;
+			}
+			if (i >= (bsize - maxinstrsz)) {
+				i = 0;
+			}
+			if (!i) {
+				rz_io_read_at(core->io, at, buf, bsize);
+			}
+			ret = rz_analysis_op(core->analysis, &aop, at, buf + i, bsize - i, RZ_ANALYSIS_OP_MASK_VAL);
+			if (ret <= 0) {
+				i += minopcode;
+				at += minopcode;
+				rz_analysis_op_fini(&aop);
+				continue;
+			}
+			i += ret - 1;
+			at += ret;
+			int index = 0;
+			if (aop.ireg) {
+				index = rz_reg_getv(esil->analysis->reg, aop.ireg) * aop.scale;
+			}
+			int j, src_imm = -1, dst_imm = -1;
+			ut64 src_addr = UT64_MAX;
+			ut64 dst_addr = UT64_MAX;
+			for (j = 0; j < 3; j++) {
+				if (aop.src[j] && aop.src[j]->reg && aop.src[j]->reg->name) {
+					src_addr = rz_reg_getv(esil->analysis->reg, aop.src[j]->reg->name) + index;
+					src_imm = aop.src[j]->delta;
+				}
+			}
+			if (aop.dst && aop.dst->reg && aop.dst->reg->name) {
+				dst_addr = rz_reg_getv(esil->analysis->reg, aop.dst->reg->name) + index;
+				dst_imm = aop.dst->delta;
+			}
+			RzAnalysisVar *var = rz_analysis_get_used_function_var(core->analysis, aop.addr);
+			if (false) { // src_addr != UT64_MAX || dst_addr != UT64_MAX) {
+				//  if (src_addr == UT64_MAX && dst_addr == UT64_MAX) {
+				rz_analysis_op_fini(&aop);
+				continue;
+			}
+			char *slink = rz_type_link_at(TDB, src_addr);
+			char *vlink = rz_type_link_at(TDB, src_addr + src_imm);
+			char *dlink = rz_type_link_at(TDB, dst_addr);
+			//TODO: Handle register based arg for struct offset propgation
+			if (vlink && var && var->kind != 'r') {
+				if (rz_type_kind(TDB, vlink) == RZ_TYPE_UNION) {
+					varpfx = "union";
+				} else {
+					varpfx = "struct";
+				}
+				// if a var addr matches with struct , change it's type and name
+				// var int local_e0h --> var struct foo
+				if (strcmp(var->name, vlink) && !resolved) {
+					resolved = true;
+					rz_analysis_var_set_type(var, varpfx);
+					rz_analysis_var_rename(var, vlink, false);
+				}
+			} else if (slink) {
+				set_offset_hint(core, &aop, slink, src_addr, at - ret, src_imm);
+			} else if (dlink) {
+				set_offset_hint(core, &aop, dlink, dst_addr, at - ret, dst_imm);
+			}
+			if (rz_analysis_op_nonlinear(aop.type)) {
+				rz_reg_set_value(esil->analysis->reg, pc, at);
+				set_retval(core, at - ret);
+			} else {
+				rz_core_esil_step(core, UT64_MAX, NULL, NULL, false);
+			}
+			free(dlink);
+			free(vlink);
+			free(slink);
+			rz_analysis_op_fini(&aop);
+		}
+	}
+beach:
+	rz_io_cache_reset(core->io, core->io->cached); // drop cache writes
+	rz_config_set_i(core->config, "io.cache", ioCache);
+	rz_config_set_i(core->config, "dbg.follow", dbg_follow);
+	if (stack_set) {
+		rz_core_analysis_esil_init_mem_del(core, NULL, UT64_MAX, UT32_MAX);
+	}
+	rz_core_seek(core, oldoff, true);
+	rz_analysis_esil_free(esil);
+	rz_reg_arena_pop(core->analysis->reg);
+	rz_core_regs2flags(core);
+	rz_cons_break_pop();
+	free(buf);
+}
+
+RZ_IPI void rz_core_types_link_print(RzCore *core, const char *type, ut64 addr, RzOutputMode mode) {
+	rz_return_if_fail(type);
+	switch (mode) {
+	case RZ_OUTPUT_MODE_JSON: {
+		PJ *pj = rz_core_pj_new(core);
+		if (!pj) {
+			return;
+		}
+		pj_o(pj);
+		char *saddr = rz_str_newf("0x%" PFMT64x, addr);
+		pj_ks(pj, saddr, type);
+		pj_end(pj);
+		rz_cons_println(pj_string(pj));
+		pj_free(pj);
+		free(saddr);
+		break;
+	}
+	case RZ_OUTPUT_MODE_STANDARD:
+		rz_cons_printf("0x%08" PFMT64x " = %s\n", addr, type);
+		break;
+	case RZ_OUTPUT_MODE_RIZIN:
+		rz_cons_printf("tl %s 0x%" PFMT64x "\n", type, addr);
+		break;
+	case RZ_OUTPUT_MODE_LONG: {
+		char *fmt = rz_type_format(core->analysis->sdb_types, type);
+		if (!fmt) {
+			eprintf("Can't fint type %s", type);
+		}
+		rz_cons_printf("(%s)\n", type);
+		rz_core_cmdf(core, "pf %s @ 0x%" PFMT64x "\n", fmt, addr);
+		break;
+	}
+	default:
+		rz_warn_if_reached();
+		break;
+	}
+}
+
+RZ_IPI void rz_core_types_link_print_all(RzCore *core, RzOutputMode mode) {
+	Sdb *TDB = core->analysis->sdb_types;
+	SdbKv *kv;
+	SdbListIter *iter;
+	SdbList *l = sdb_foreach_list(TDB, true);
+	ls_foreach (l, iter, kv) {
+		if (!strncmp(sdbkv_key(kv), "link.", strlen("link."))) {
+			const char *name = sdbkv_value(kv);
+			char *saddr = rz_str_newf("0x%s", sdbkv_key(kv) + strlen("link."));
+			ut64 addr = rz_num_math(core->num, saddr);
+			rz_core_types_link_print(core, name, addr, mode);
+			free(saddr);
+		}
+	}
+	ls_free(l);
+}
+
+RZ_IPI void rz_core_types_link(RzCore *core, const char *type, ut64 addr) {
+	Sdb *TDB = core->analysis->sdb_types;
+	char *tmp = sdb_get(TDB, type, 0);
+	if (RZ_STR_ISEMPTY(tmp)) {
+		eprintf("unknown type %s\n", type);
+		free(tmp);
+		return;
+	}
+	rz_type_set_link(TDB, type, addr);
+	RzList *fcns = rz_analysis_get_functions_in(core->analysis, core->offset);
+	if (rz_list_length(fcns) > 1) {
+		eprintf("Multiple functions found in here.\n");
+	} else if (rz_list_length(fcns) == 1) {
+		RzAnalysisFunction *fcn = rz_list_first(fcns);
+		rz_core_link_stroff(core, fcn);
+	}
+	rz_list_free(fcns);
+	free(tmp);
+}
+
+RZ_IPI void rz_core_types_link_show(RzCore *core, ut64 addr) {
+	Sdb *TDB = core->analysis->sdb_types;
+	const char *query = sdb_fmt("link.%08" PFMT64x, addr);
+	const char *link = sdb_const_get(TDB, query, 0);
+	if (link) {
+		rz_core_types_link_print(core, link, addr, RZ_OUTPUT_MODE_LONG);
+	}
+}
+
+// Everything
+
+static bool sdb_if_type_cb(void *p, const char *k, const char *v) {
+	return !strncmp(v, "type", strlen("type") + 1);
+}
+
+RZ_IPI void rz_core_types_print_all(RzCore *core, RzOutputMode mode) {
+	SdbListIter *it;
+	SdbKv *kv;
+	Sdb *TDB = core->analysis->sdb_types;
+	SdbList *l = sdb_foreach_list_filter(TDB, sdb_if_type_cb, true);
+	switch (mode) {
+	case RZ_OUTPUT_MODE_JSON: {
+		PJ *pj = rz_core_pj_new(core);
+		if (!pj) {
+			return;
+		}
+		pj_a(pj);
+		// TODO: Make it more efficient
+		ls_foreach (l, it, kv) {
+			pj_o(pj);
+			const char *k = sdbkv_key(kv);
+			char *sizecmd = rz_str_newf("type.%s.size", k);
+			char *size_s = sdb_querys(TDB, NULL, -1, sizecmd);
+			char *formatcmd = rz_str_newf("type.%s", k);
+			char *format_s = sdb_querys(TDB, NULL, -1, formatcmd);
+			rz_str_trim(format_s);
+			pj_ks(pj, "type", k);
+			pj_ki(pj, "size", size_s ? atoi(size_s) : -1);
+			pj_ks(pj, "format", format_s);
+			free(size_s);
+			free(format_s);
+			free(sizecmd);
+			free(formatcmd);
+			pj_end(pj);
+		}
+		pj_end(pj);
+		rz_cons_println(pj_string(pj));
+		pj_free(pj);
+		break;
+	}
+	case RZ_OUTPUT_MODE_STANDARD:
+		ls_foreach (l, it, kv) {
+			rz_cons_println(sdbkv_key(kv));
+		}
+		break;
+	case RZ_OUTPUT_MODE_RIZIN:
+		ls_foreach (l, it, kv) {
+			rz_cons_printf("tk %s=%s\n", sdbkv_key(kv), sdbkv_value(kv));
+		}
+		break;
+	default:
+		rz_warn_if_reached();
+		break;
+	}
+	ls_free(l);
+}

--- a/librz/core/meson.build
+++ b/librz/core/meson.build
@@ -6,6 +6,7 @@ rz_core_sources = [
   'casm.c',
   'cagraph.c',
   'canalysis.c',
+  'ctypes.c',
   'carg.c',
   'cautocmpl.c',
   'cbin.c',

--- a/librz/core/vmenus.c
+++ b/librz/core/vmenus.c
@@ -669,7 +669,7 @@ RZ_API int rz_core_visual_types(RzCore *core) {
 		}
 		if (!strcmp(opts[h_opt], "cc")) {
 			// XXX TODO: make this work (select with cursor, to delete, or add a new one with 'i', etc)
-			rz_core_cmdf(core, "tfcl");
+			rz_core_types_calling_conventions_print(core, RZ_OUTPUT_MODE_STANDARD);
 		} else {
 			vt.t_idx = option;
 			vt.t_ctr = 0;
@@ -704,7 +704,7 @@ RZ_API int rz_core_visual_types(RzCore *core) {
 		case 'o': {
 			char *file = prompt("Filename: ", NULL);
 			if (file) {
-				rz_core_cmdf(core, "\"to %s\"", file);
+				rz_types_open_file(core, file);
 				free(file);
 			}
 		} break;
@@ -755,15 +755,15 @@ RZ_API int rz_core_visual_types(RzCore *core) {
 		case 'a': {
 			txt = prompt("add C type: ", NULL);
 			if (txt) {
-				rz_core_cmdf(core, "td \"%s\"", txt);
+				rz_types_define(core, txt);
 				free(txt);
 			}
 		} break;
 		case 'd':
-			rz_core_cmdf(core, "t- %s", vt.curname);
+			rz_analysis_remove_parsed_type(core->analysis, vt.curname);
 			break;
 		case '-':
-			rz_core_cmd0(core, "to -");
+			rz_types_open_editor(core, NULL);
 			break;
 		case ' ':
 		case '\r':

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -617,9 +617,8 @@ RZ_API char *rz_core_disassemble_bytes(RzCore *core, ut64 addr, int b);
 RZ_API RzList *rz_core_get_func_args(RzCore *core, const char *func_name);
 RZ_API void rz_core_print_func_args(RzCore *core);
 RZ_API char *resolve_fcn_name(RzAnalysis *analysis, const char *func_name);
-RZ_API int rz_core_get_stacksz(RzCore *core, ut64 from, ut64 to);
 
-/* analysis.c */
+/* canalysis.c */
 RZ_API RzAnalysisOp *rz_core_analysis_op(RzCore *core, ut64 addr, int mask);
 RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *addr);
 RZ_API void rz_core_analysis_fcn_merge(RzCore *core, ut64 addr, ut64 addr2);
@@ -665,6 +664,7 @@ RZ_API RzList *rz_core_analysis_cycles(RzCore *core, int ccl);
 RZ_API RzList *rz_core_analysis_fcn_get_calls(RzCore *core, RzAnalysisFunction *fcn); // get all calls from a function
 RZ_API void rz_cmd_analysis_blocks(RzCore *core, const char *input);
 RZ_API void rz_cmd_analysis_calls(RzCore *core, const char *input, bool printCommands, bool importsOnly);
+RZ_API int rz_core_get_stacksz(RzCore *core, ut64 from, ut64 to);
 
 /*tp.c*/
 RZ_API void rz_core_analysis_type_match(RzCore *core, RzAnalysisFunction *fcn);
@@ -860,9 +860,6 @@ typedef struct {
 typedef struct {
 	RzCoreAnalStatsItem *block;
 } RzCoreAnalStats;
-
-RZ_API void rz_core_list_typename_alias_c(RzCore *core, const char *typedef_name);
-RZ_API void rz_core_list_loaded_typedefs(RzCore *core, RzOutputMode mode);
 
 RZ_API char *rz_core_analysis_hasrefs(RzCore *core, ut64 value, int mode);
 RZ_API char *rz_core_analysis_get_comments(RzCore *core, ut64 addr);

--- a/librz/include/rz_util/rz_ctypes.h
+++ b/librz/include/rz_util/rz_ctypes.h
@@ -31,6 +31,7 @@ RZ_API char *rz_type_get_struct_memb(Sdb *TDB, const char *type, int offset);
 RZ_API char *rz_type_link_at(Sdb *TDB, ut64 addr);
 RZ_API int rz_type_set_link(Sdb *TDB, const char *val, ut64 addr);
 RZ_API int rz_type_unlink(Sdb *TDB, ut64 addr);
+RZ_API int rz_type_unlink_all(Sdb *TDB);
 RZ_API int rz_type_link_offset(Sdb *TDB, const char *val, ut64 addr);
 RZ_API char *rz_type_format(Sdb *TDB, const char *t);
 

--- a/librz/util/utype.c
+++ b/librz/util/utype.c
@@ -397,6 +397,19 @@ RZ_API int rz_type_unlink(Sdb *TDB, ut64 addr) {
 	return true;
 }
 
+static bool sdbdeletelink(void *p, const char *k, const char *v) {
+	Sdb *TDB = (Sdb *)p;
+	if (!strncmp(k, "link.", strlen("link."))) {
+		rz_type_del(TDB, k);
+	}
+	return true;
+}
+
+RZ_API int rz_type_unlink_all(Sdb *TDB) {
+	sdb_foreach(TDB, sdbdeletelink, TDB);
+	return true;
+}
+
 static char *fmt_struct_union(Sdb *TDB, char *var, bool is_typedef) {
 	// assumes var list is sorted by offset.. should do more checks here
 	char *p = NULL, *vars = NULL, var2[132], *fmt = NULL;

--- a/test/db/cmd/cmd_afcl
+++ b/test/db/cmd/cmd_afcl
@@ -7,11 +7,11 @@ e asm.bits=64
 afcl
 EOF
 EXPECT=<<EOF
-swift
 amd64
 amd64syscall
 ms
 reg
+swift
 EOF
 RUN
 
@@ -72,8 +72,8 @@ e asm.bits=64
 afcl
 EOF
 EXPECT=<<EOF
-reg
 arm64
+reg
 swift
 EOF
 RUN
@@ -145,9 +145,9 @@ e asm.bits=32
 afcl
 EOF
 EXPECT=<<EOF
-reg
 n32
 o32
+reg
 EOF
 RUN
 
@@ -156,8 +156,8 @@ FILE=bins/elf/libc.so.0
 ARGS=-a mips -b 64
 CMDS=afcl
 EXPECT=<<EOF
-reg
 n32
 o32
+reg
 EOF
 RUN

--- a/test/db/cmd/cmd_ara
+++ b/test/db/cmd/cmd_ara
@@ -90,17 +90,17 @@ tcc `arcc`
 afcl
 EOF
 EXPECT=<<EOF
-swift
 amd64
 amd64syscall
 ms
 reg
+swift
 r0 reg(r0, r1, r2, r3)
 rdi reg(rdi, rsi, rdx, rcx)
-swift
 amd64
 amd64syscall
 ms
 reg
+swift
 EOF
 RUN

--- a/test/db/cmd/cmd_tcc
+++ b/test/db/cmd/cmd_tcc
@@ -6,11 +6,11 @@ tcc-*
 tcc
 EOF
 EXPECT=<<EOF
-swift
 amd64
 amd64syscall
 ms
 reg
+swift
 EOF
 RUN
 
@@ -18,11 +18,11 @@ NAME=tcc
 FILE=bins/elf/ls
 CMDS=tcc
 EXPECT=<<EOF
-swift
 amd64
 amd64syscall
 ms
 reg
+swift
 EOF
 RUN
 

--- a/test/db/cmd/noreturn
+++ b/test/db/cmd/noreturn
@@ -117,7 +117,7 @@ CMDS=<<EOF
 e asm.arch=x86
 e asm.bits=32
 "wa call 0x10;ret"
-tna 0x10
+tn 0x10
 af
 pif
 EOF

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -91,9 +91,9 @@ RUN
 
 NAME=List type links
 CMDS=<<EOF
-tl int = 0x4
+tl int 0x4
 w test @ 0x10
-tl char * = 0x10
+tl "char *" 0x10
 tl
 EOF
 EXPECT=<<EOF
@@ -106,9 +106,9 @@ NAME=List readable type links
 CMDS=<<EOF
 tl int
 wB -1
-tl int = 0x8
+tl int 0x8
 w test @ 0x10
-tl char * = 0x10
+tl "char *" 0x10
 tll
 EOF
 EXPECT=<<EOF
@@ -130,7 +130,7 @@ e asm.lines.bb=false
 aa
 s sym.Java_com_app_ndh_NDHActivity_print
 to bins/headers/jni.h
-tl JNINativeInterface = 0x464c457f
+tl JNINativeInterface 0x464c457f
 pdf~JNINativeInterface
 pdr~JNI?
 EOF
@@ -799,7 +799,7 @@ e asm.comments=false
 td "struct bar {int a ; int b; int c;}"
 wx 48C7C058190000488B5004488B4808483B500448BBEFBEADDE00000000488958089090C3
 af
-tl bar = 0x1958
+tl bar 0x1958
 ?e
 pdf~bar.
 EOF
@@ -821,7 +821,7 @@ e asm.bits=64
 e asm.comments=false
 td "struct bar {int a ; int b; int c;}"
 wx 48C7C058190000488B5004488B4808483B500448BBEFBEADDE00000000488958089090C3
-tl bar = 0x1958
+tl bar 0x1958
 af
 aat @ fcn.00000000
 ?e
@@ -847,8 +847,8 @@ e asm.flags=false
 td "struct bar {int x; int y; int z;};"
 td "struct foo {int a; int b; int c;};"
 wx 48C7C000010000488B5008488B480448C7C000020000488B5008488B48049090C3
-tl bar = 0x200
-tl foo = 0x100
+tl bar 0x200
+tl foo 0x100
 af
 aat
 pdf
@@ -874,7 +874,7 @@ e asm.bytes=true
 aa
 s main
 td "struct Books {char  title[50];char  author[50]; char  subject[100];};"
-tl Books = 0x00177f18
+tl Books 0x00177f18
 ?e
 pdf~Books
 EOF
@@ -899,7 +899,7 @@ aa
 td "struct Test { int a; int  b; char *c;};"
 s main
 ahr 0x00000597 @ 0x00000592
-tl Test = 0x00002020
+tl Test 0x00002020
 s 0x000005a8
 ?e
 pd 3
@@ -921,7 +921,7 @@ td "union Books {char  title[50];char  author[50]; char  subject[100];};"
 tu
 tu Books
 s main
-tl Books = 0x00177f88
+tl Books 0x00177f88
 afv~Books
 s 0x000006d2
 pd 1

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1760,9 +1760,9 @@ txf main
 ?e =
 txf fcn.00011b90
 ?e =
-txt size_t
+tx size_t
 ?e =
-txt size_t *
+tx "size_t *"
 EOF
 EXPECT=<<EOF
 int

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -195,12 +195,12 @@ Cannot find 'int' type
 EOF
 RUN
 
-NAME=t-enum
+NAME=t- enum
 FILE=-
 CMDS=<<EOF
 td "enum pe_machine { IMAGE_FILE_MACHINE_IA64=0x200, IMAGE_FILE_MACHINE_I386=0x14c };"
 te~?pe_machine
-t-pe_machine
+t- pe_machine
 te~?pe_machine
 EOF
 EXPECT=<<EOF
@@ -209,12 +209,12 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=t-struct
+NAME=t- struct
 FILE=-
 CMDS=<<EOF
 t-*
 td "struct three_elements{int x; char y; float z;}"
-t-three_elements
+t- three_elements
 ts~?
 EOF
 EXPECT=<<EOF
@@ -222,12 +222,12 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=t-union
+NAME=t- union
 FILE=-
 CMDS=<<EOF
 td "union xoo{int x; int y; int z;}"
-tk*~union
-t-xoo
+tk *~union
+t- xoo
 EOF
 EXPECT=<<EOF
 union.xoo=x,y,z
@@ -245,7 +245,7 @@ NAME=typedef
 FILE=-
 CMDS=<<EOF
 td "typedef int Abracadabra"
-t-Abracadabra
+t- Abracadabra
 t~?Abracadabra
 EOF
 EXPECT=<<EOF

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1669,18 +1669,15 @@ RUN
 NAME=tn common
 FILE=bins/pe/pe.exe
 CMDS=<<EOF
-tna 8
-tnn 8
+tn 8
 tn
 tn- 0x8
-tn- 8
 tn
 tn-*
 tn
 EOF
 EXPECT=<<EOF
 0x8
-8
 ExitProcess
 ExitThread
 FatalExit

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -551,22 +551,6 @@ tk a=b
 EOF
 RUN
 
-NAME=tp
-FILE=-
-CMDS=<<EOF
-td "struct person { int age; char name[10]; }"
-s 4
-w Carlos
-s 0
-wx 13
-tp person @ 0x0
-EOF
-EXPECT=<<EOF
-  age : 0x00000000 = 19
- name : 0x00000004 = "Carlos"
-EOF
-RUN
-
 NAME=unions
 FILE=-
 CMDS=<<EOF
@@ -689,6 +673,142 @@ teb Foo COW
 EOF
 EXPECT=<<EOF
 0x1
+EOF
+RUN
+
+NAME=tp
+FILE=-
+CMDS=<<EOF
+td "struct person { int age; char name[10]; }"
+s 14
+w Carlos
+s 10
+wx 13
+tp person @ 10
+tp person 10
+EOF
+EXPECT=<<EOF
+  age : 0x0000000a = 19
+ name : 0x0000000e = "Carlos"
+  age : 0x0000000a = 19
+ name : 0x0000000e = "Carlos"
+EOF
+RUN
+
+NAME=tpv
+FILE=-
+CMDS=<<EOF
+td "struct s16ui { uint16_t a_u; int16_t b_i; uint16_t c_u; int16_t d_i;}"
+td "struct s16iu { int16_t a_i; uint16_t b_u; int16_t c_i; uint16_t d_u;}"
+td "struct s32ui { uint32_t e_u; int16_t f_i;}"
+td "struct s32iu { int32_t e_i; uint16_t f_u;}"
+e asm.bits=16
+e cfg.bigendian=true
+tpv s16ui 0xcafebabecafebabe
+tpv s16iu 0xcafebabecafebabe
+tpv s32ui 0xcafebabecafebabe
+tpv s32iu 0xcafebabecafebabe
+e cfg.bigendian=false
+tpv s16ui 0xcafebabecafebabe
+tpv s16iu 0xcafebabecafebabe
+tpv s32ui 0xcafebabecafebabe
+tpv s32iu 0xcafebabecafebabe
+e asm.bits=32
+e cfg.bigendian=true
+tpv s16ui 0xcafebabecafebabe
+tpv s16iu 0xcafebabecafebabe
+tpv s32ui 0xcafebabecafebabe
+tpv s32iu 0xcafebabecafebabe
+e cfg.bigendian=false
+tpv s16ui 0xcafebabecafebabe
+tpv s16iu 0xcafebabecafebabe
+tpv s32ui 0xcafebabecafebabe
+tpv s32iu 0xcafebabecafebabe
+e asm.bits=64
+e cfg.bigendian=true
+tpv s16ui 0xcafebabecafebabe
+tpv s16iu 0xcafebabecafebabe
+tpv s32ui 0xcafebabecafebabe
+tpv s32iu 0xcafebabecafebabe
+e cfg.bigendian=false
+tpv s16ui 0xcafebabecafebabe
+tpv s16iu 0xcafebabecafebabe
+tpv s32ui 0xcafebabecafebabe
+tpv s32iu 0xcafebabecafebabe
+EOF
+EXPECT=<<EOF
+ a_u : 0x00000000 = 0xbabe
+ b_i : 0x00000002 = 0x0000
+ c_u : 0x00000004 = 0x0000
+ d_i : 0x00000006 = 0x0000
+ a_i : 0x00000000 = 0xbabe
+ b_u : 0x00000002 = 0x0000
+ c_i : 0x00000004 = 0x0000
+ d_u : 0x00000006 = 0x0000
+ e_u : 0x00000000 = 3133014016
+ f_i : 0x00000004 = 0x0000
+ e_i : 0x00000000 = 3133014016
+ f_u : 0x00000004 = 0x0000
+ a_u : 0x00000000 = 0xbabe
+ b_i : 0x00000002 = 0x0000
+ c_u : 0x00000004 = 0x0000
+ d_i : 0x00000006 = 0x0000
+ a_i : 0x00000000 = 0xbabe
+ b_u : 0x00000002 = 0x0000
+ c_i : 0x00000004 = 0x0000
+ d_u : 0x00000006 = 0x0000
+ e_u : 0x00000000 = 47806
+ f_i : 0x00000004 = 0x0000
+ e_i : 0x00000000 = 47806
+ f_u : 0x00000004 = 0x0000
+ a_u : 0x00000000 = 0xcafe
+ b_i : 0x00000002 = 0xbabe
+ c_u : 0x00000004 = 0x0000
+ d_i : 0x00000006 = 0x0000
+ a_i : 0x00000000 = 0xcafe
+ b_u : 0x00000002 = 0xbabe
+ c_i : 0x00000004 = 0x0000
+ d_u : 0x00000006 = 0x0000
+ e_u : 0x00000000 = 3405691582
+ f_i : 0x00000004 = 0x0000
+ e_i : 0x00000000 = 3405691582
+ f_u : 0x00000004 = 0x0000
+ a_u : 0x00000000 = 0xbabe
+ b_i : 0x00000002 = 0xcafe
+ c_u : 0x00000004 = 0x0000
+ d_i : 0x00000006 = 0x0000
+ a_i : 0x00000000 = 0xbabe
+ b_u : 0x00000002 = 0xcafe
+ c_i : 0x00000004 = 0x0000
+ d_u : 0x00000006 = 0x0000
+ e_u : 0x00000000 = 3405691582
+ f_i : 0x00000004 = 0x0000
+ e_i : 0x00000000 = 3405691582
+ f_u : 0x00000004 = 0x0000
+ a_u : 0x00000000 = 0xcafe
+ b_i : 0x00000002 = 0xbabe
+ c_u : 0x00000004 = 0xcafe
+ d_i : 0x00000006 = 0xbabe
+ a_i : 0x00000000 = 0xcafe
+ b_u : 0x00000002 = 0xbabe
+ c_i : 0x00000004 = 0xcafe
+ d_u : 0x00000006 = 0xbabe
+ e_u : 0x00000000 = 3405691582
+ f_i : 0x00000004 = 0xcafe
+ e_i : 0x00000000 = 3405691582
+ f_u : 0x00000004 = 0xcafe
+ a_u : 0x00000000 = 0xbabe
+ b_i : 0x00000002 = 0xcafe
+ c_u : 0x00000004 = 0xbabe
+ d_i : 0x00000006 = 0xcafe
+ a_i : 0x00000000 = 0xbabe
+ b_u : 0x00000002 = 0xcafe
+ c_i : 0x00000004 = 0xbabe
+ d_u : 0x00000006 = 0xcafe
+ e_u : 0x00000000 = 3405691582
+ f_i : 0x00000004 = 0xbabe
+ e_i : 0x00000000 = 3405691582
+ f_u : 0x00000004 = 0xbabe
 EOF
 RUN
 


### PR DESCRIPTION
# **DO NOT SQUASH**

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Migrating `t` commands to the newshell and fixes along the way.
- Migrated `tl` command, changed the syntax from `tl [typename] = [address]` to `tl [typename [address]]`
- Removed `tllj` command
- Migrated `tp` commands
- Migrated `tx` commands, removed `txt` to `tx` command alias
- Migrated all `t` commands
- Removed `tnn` command and `tna` (alias for `tn`)
- Refactored code to provide slightly better API, temporarily marked it as `RZ_IPI` in `librz/core/ctypes.c` as a preparation for the RzTypes module extraction.
- Substituted `rz_core_cmd*()` calls to any `t` sub-command with the proper API.

**Test plan**

All green
