### PR TITLE
core/cmd_debug: fix OOB read when running 'dcu'

### DIFF
--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -4184,7 +4184,7 @@ RZ_IPI int rz_debug_continue_oldhandler(void *data, const char *input) {
 	case 'u': // "dcu"
 		if (input[1] == '?') {
 			rz_core_cmd_help(core, help_msg_dcu);
-		} else if (input[1] == '.') {
+		} else if (input[1] == '.' || input[1] == '\0') {
 			cmd_dcu(core, "cu $$");
 		} else {
 			char *tmpinp = rz_str_newf("cu %s", input + 2);


### PR DESCRIPTION
 **Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

OOB read because `cmd_dcu`  always looks for the argument. This will be really fixed once `dcu` is converted to newshell, but in the meantime...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
