### PR TITLE
Fix "directive argument is null" warnings in optimized asan build

### DIFF
--- a/librz/analysis/p/analysis_ppc_cs.c
+++ b/librz/analysis/p/analysis_ppc_cs.c
@@ -582,6 +582,18 @@ static void op_fillval(RzAnalysisOp *op, csh handle, cs_insn *insn) {
 	}
 }
 
+static char *shrink(char *op) {
+	if (!op) {
+		return NULL;
+	}
+	size_t len = strlen(op);
+	if (!len) {
+		return NULL;
+	}
+	op[len - 1] = 0;
+	return op;
+}
+
 static int analop(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask) {
 	static csh handle = 0;
 	static int omode = -1, obits = -1;
@@ -731,8 +743,10 @@ static int analop(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, in
 			break;
 		case PPC_INS_STWU:
 			op->type = RZ_ANALYSIS_OP_TYPE_STORE;
-			op1 = ARG(1);
-			op1[strlen(op1) - 1] = 0;
+			op1 = shrink(ARG(1));
+			if (!op1) {
+				break;
+			}
 			esilprintf(op, "%s,%s,=[4],%s=", ARG(0), op1, op1);
 			if (strstr(op1, "r1")) {
 				op->stackop = RZ_ANALYSIS_STACK_INC;
@@ -748,8 +762,10 @@ static int analop(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, in
 			break;
 		case PPC_INS_STBU:
 			op->type = RZ_ANALYSIS_OP_TYPE_STORE;
-			op1 = ARG(1);
-			op1[strlen(op1) - 1] = 0;
+			op1 = shrink(ARG(1));
+			if (!op1) {
+				break;
+			}
 			esilprintf(op, "%s,%s,=[1],%s=", ARG(0), op1, op1);
 			break;
 		case PPC_INS_STH:
@@ -758,8 +774,10 @@ static int analop(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, in
 			break;
 		case PPC_INS_STHU:
 			op->type = RZ_ANALYSIS_OP_TYPE_STORE;
-			op1 = ARG(1);
-			op1[strlen(op1) - 1] = 0;
+			op1 = shrink(ARG(1));
+			if (!op1) {
+				break;
+			}
 			esilprintf(op, "%s,%s,=[2],%s=", ARG(0), op1, op1);
 			break;
 		case PPC_INS_STD:
@@ -768,8 +786,10 @@ static int analop(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, in
 			break;
 		case PPC_INS_STDU:
 			op->type = RZ_ANALYSIS_OP_TYPE_STORE;
-			op1 = ARG(1);
-			op1[strlen(op1) - 1] = 0;
+			op1 = shrink(ARG(1));
+			if (!op1) {
+				break;
+			}
 			esilprintf(op, "%s,%s,=[8],%s=", ARG(0), op1, op1);
 			break;
 		case PPC_INS_LBZ:
@@ -779,8 +799,10 @@ static int analop(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, in
 		case PPC_INS_LBZU:
 		case PPC_INS_LBZUX:
 			op->type = RZ_ANALYSIS_OP_TYPE_LOAD;
-			op1 = ARG(1);
-			op1[strlen(op1) - 1] = 0;
+			op1 = shrink(ARG(1));
+			if (!op1) {
+				break;
+			}
 			esilprintf(op, "%s,[1],%s,=,%s=", op1, ARG(0), op1);
 			break;
 		case PPC_INS_LBZX:
@@ -795,8 +817,10 @@ static int analop(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, in
 		case PPC_INS_LDU:
 		case PPC_INS_LDUX:
 			op->type = RZ_ANALYSIS_OP_TYPE_LOAD;
-			op1 = ARG(1);
-			op1[strlen(op1) - 1] = 0;
+			op1 = shrink(ARG(1));
+			if (!op1) {
+				break;
+			}
 			esilprintf(op, "%s,[8],%s,=,%s=", op1, ARG(0), op1);
 			break;
 		case PPC_INS_LDX:
@@ -826,8 +850,10 @@ static int analop(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, in
 		case PPC_INS_LHZ:
 		case PPC_INS_LHZU:
 			op->type = RZ_ANALYSIS_OP_TYPE_LOAD;
-			op1 = ARG(1);
-			op1[strlen(op1) - 1] = 0;
+			op1 = shrink(ARG(1));
+			if (!op1) {
+				break;
+			}
 			esilprintf(op, "%s,[2],%s,=,%s=", op1, ARG(0), op1);
 			break;
 		case PPC_INS_LHBRX:
@@ -848,8 +874,10 @@ static int analop(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, in
 		case PPC_INS_LWZU:
 		case PPC_INS_LWZUX:
 			op->type = RZ_ANALYSIS_OP_TYPE_LOAD;
-			op1 = ARG(1);
-			op1[strlen(op1) - 1] = 0;
+			op1 = shrink(ARG(1));
+			if (!op1) {
+				break;
+			}
 			esilprintf(op, "%s,[4],%s,=,%s=", op1, ARG(0), op1);
 			break;
 		case PPC_INS_LWBRX:

--- a/librz/util/table.c
+++ b/librz/util/table.c
@@ -969,8 +969,8 @@ RZ_API bool rz_table_query(RzTable *t, const char *q) {
 		}
 		int col = rz_table_column_nth(t, columnName);
 		if (col == -1) {
-			if (columnName == NULL && strcmp(operation, "uniq")) {
-				eprintf("Invalid column name (%s) for (%s)\n", columnName, query);
+			if (columnName == NULL && strcmp(operation, "uniq")) { // TODO: What query triggers this?
+				eprintf("Column name is NULL for (%s)\n", query);
 			} else if (columnName) {
 				if (*columnName == '[') {
 					col = atoi(columnName + 1);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following warnings in the optimized asan build of #260 (https://github.com/rizinorg/rizin/runs/2012244885, View raw logs, search for "directive argument is null"):

```
2021-03-02T10:24:23.2790404Z In file included from /usr/include/stdio.h:867,
2021-03-02T10:24:23.2791518Z                  from ../librz/include/rz_types.h:248,
2021-03-02T10:24:23.2792432Z                  from ../librz/include/rz_util.h:6,
2021-03-02T10:24:23.2793388Z                  from ../librz/include/rz_util/rz_table.h:4,
2021-03-02T10:24:23.2794323Z                  from ../librz/util/table.c:3:
2021-03-02T10:24:23.2796396Z In function ‘fprintf’,
2021-03-02T10:24:23.2797456Z     inlined from ‘rz_table_query’ at ../librz/util/table.c:973:5:
2021-03-02T10:24:23.2798719Z /usr/include/x86_64-linux-gnu/bits/stdio2.h:100:10: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
2021-03-02T10:24:23.2800368Z   100 |   return __fprintf_chk (__stream, __USE_FORTIFY_LEVEL - 1, __fmt,
2021-03-02T10:24:23.2801211Z       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2021-03-02T10:24:23.2801730Z   101 |    __va_arg_pack ());
2021-03-02T10:24:23.2802194Z       |    ~~~~~~~~~~~~~~~~~
2021-03-02T10:24:23.2803228Z ../librz/util/table.c: In function ‘rz_table_query’:
2021-03-02T10:24:23.2804045Z ../librz/util/table.c:973:35: note: format string is defined here
2021-03-02T10:24:23.2805121Z   973 |     eprintf("Invalid column name (%s) for (%s)\n", columnName, query);
2021-03-02T10:24:23.2805997Z       |                                   ^~
```

```
2021-03-02T10:31:35.6117016Z In file included from ../librz/analysis/p/analysis_ppc_cs.c:3:
2021-03-02T10:31:35.6118419Z ../librz/analysis/p/analysis_ppc_cs.c: In function ‘analop’:
2021-03-02T10:31:35.6120245Z ../librz/include/rz_analysis.h:22:34: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
2021-03-02T10:31:35.6121993Z    22 | #define esilprintf(op, fmt, ...) rz_strbuf_setf(&op->esil, fmt, ##__VA_ARGS__)
2021-03-02T10:31:35.6122897Z       |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2021-03-02T10:31:35.6124071Z ../librz/analysis/p/analysis_ppc_cs.c:736:4: note: in expansion of macro ‘esilprintf’
2021-03-02T10:31:35.6125078Z   736 |    esilprintf(op, "%s,%s,=[4],%s=", ARG(0), op1, op1);
2021-03-02T10:31:35.6125767Z       |    ^~~~~~~~~~
2021-03-02T10:31:35.6129785Z ../librz/analysis/p/analysis_ppc_cs.c:736:23: note: format string is defined here
2021-03-02T10:31:35.6130751Z   736 |    esilprintf(op, "%s,%s,=[4],%s=", ARG(0), op1, op1);
2021-03-02T10:31:35.6132449Z       |                       ^~
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
