### PR TITLE
Fix UAF in rz_bin_reset_strings()

### DIFF
--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -775,6 +775,8 @@ RZ_API RzList *rz_bin_reset_strings(RzBin *bin) {
 		rz_list_free(bf->o->strings);
 		bf->o->strings = NULL;
 	}
+	ht_up_free(bf->o->strings_db);
+	bf->o->strings_db = ht_up_new0();
 
 	bf->rawstr = bin->rawstr;
 	RzBinPlugin *plugin = rz_bin_file_cur_plugin(bf);

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -3008,12 +3008,112 @@ RUN
 
 NAME=iz (file x86)
 FILE=bins/elf/analysis/x86-helloworld-gcc
-CMDS=iz
+CMDS=<<EOF
+?e -- default --
+iz
+?e -- geq 12 --
+e bin.minstr=12
+iz
+?e -- geq 13 --
+e bin.minstr=13
+iz
+?e -- geq 0 --
+e bin.minstr=0
+iz
+?e -- leq 12 --
+e bin.maxstr=12
+iz
+?e -- leq 11 --
+e bin.maxstr=11
+iz
+?e -- no limit --
+e bin.maxstr=0
+iz
+EOF
 EXPECT=<<EOF
+-- default --
 [Strings]
 nth paddr      vaddr      len size section type  string
 -------------------------------------------------------
 0   0x000004b0 0x080484b0 12  13   .rodata ascii Hello world!
+-- geq 12 --
+[Strings]
+nth paddr      vaddr      len size section type  string
+-------------------------------------------------------
+0   0x000004b0 0x080484b0 12  13   .rodata ascii Hello world!
+-- geq 13 --
+[Strings]
+nth paddr vaddr len size section type string
+--------------------------------------------
+-- geq 0 --
+[Strings]
+nth paddr      vaddr      len size section type  string
+-------------------------------------------------------
+0   0x000004b0 0x080484b0 12  13   .rodata ascii Hello world!
+-- leq 12 --
+[Strings]
+nth paddr      vaddr      len size section type  string
+-------------------------------------------------------
+0   0x000004b0 0x080484b0 12  13   .rodata ascii Hello world!
+-- leq 11 --
+[Strings]
+nth paddr vaddr len size section type string
+--------------------------------------------
+-- no limit --
+[Strings]
+nth paddr      vaddr      len size section type  string
+-------------------------------------------------------
+0   0x000004b0 0x080484b0 12  13   .rodata ascii Hello world!
+EOF
+RUN
+
+NAME=iz (__cfstring)
+FILE=bins/mach0/hello-objc-osx
+CMDS=<<EOF
+?e -- default --
+iz
+?e -- geq 12 --
+e bin.minstr=12
+iz
+?e -- leq 13 --
+e bin.maxstr=12
+iz
+EOF
+EXPECT=<<EOF
+-- default --
+[Strings]
+nth paddr       vaddr       len size section            type  string
+--------------------------------------------------------------------
+0   0x00000d58  0x100000d58 9   10   2.__TEXT.__cstring ascii sayHello:
+1   0x00000d62  0x100000d62 4   5    2.__TEXT.__cstring ascii init
+2   0x00000d67  0x100000d67 5   6    2.__TEXT.__cstring ascii alloc
+3   0x00000d6d  0x100000d6d 5   6    2.__TEXT.__cstring ascii Hahha
+4   0x00000d73  0x100000d73 12  13   2.__TEXT.__cstring ascii Hello World 
+5   0x00000d86  0x100000d86 9   10   2.__TEXT.__cstring ascii callMeNot
+6   0x00000d90  0x100000d90 7   8    2.__TEXT.__cstring ascii v16@0:8
+7   0x00000d98  0x100000d98 9   10   2.__TEXT.__cstring ascii sayHello2
+8   0x00000da2  0x100000da2 10  11   2.__TEXT.__cstring ascii v20@0:8i16
+9   0x00000dad  0x100000dad 11  12   2.__TEXT.__cstring ascii sayHello3::
+10  0x00000db9  0x100000db9 13  14   2.__TEXT.__cstring ascii v24@0:8i16i20
+11  0x00000dc7  0x100000dc7 8   9    2.__TEXT.__cstring ascii sayLong:
+12  0x00000dd0  0x100000dd0 10  11   2.__TEXT.__cstring ascii v24@0:8Q16
+13  0x00000ddb  0x100000ddb 7   8    2.__TEXT.__cstring ascii @16@0:8
+14  0x00000de3  0x100000de3 4   5    2.__TEXT.__cstring ascii Test
+3   0x100001058 0x100001058 5   6                       ascii cstr.Hahha
+4   0x100001078 0x100001078 12  13                      ascii cstr.Hello World 
+-- geq 12 --
+[Strings]
+nth paddr       vaddr       len size section            type  string
+--------------------------------------------------------------------
+0   0x00000d73  0x100000d73 12  13   2.__TEXT.__cstring ascii Hello World 
+1   0x00000db9  0x100000db9 13  14   2.__TEXT.__cstring ascii v24@0:8i16i20
+0   0x100001078 0x100001078 12  13                      ascii cstr.Hello World 
+-- leq 13 --
+[Strings]
+nth paddr       vaddr       len size section            type  string
+--------------------------------------------------------------------
+0   0x00000d73  0x100000d73 12  13   2.__TEXT.__cstring ascii Hello World 
+0   0x100001078 0x100001078 12  13                      ascii cstr.Hello World 
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The `strings_db` leaked pointers to strings freed above:
```
florian-macbook:airplay florian$ ~/dev/rizin/build/binrz/rizin/rizin -e bin.minstr=0 AirPlayXPCHelper
=================================================================
==65255==ERROR: AddressSanitizer: heap-use-after-free on address 0x000112212f74 at pc 0x0001076270c0 bp 0x00016d020d40 sp 0x00016d020d38
READ of size 1 at 0x000112212f74 thread T0
    #0 0x1076270bc in rz_bin_file_get_strings bfile.c:820
    #1 0x1075fff7c in rz_bin_reset_strings bin.c:785
    #2 0x107ef9280 in cb_binminstr cconfig.c:2518
    #3 0x1075deb48 in rz_config_set config.c:566
    #4 0x1075dfe08 in __evalString config.c:687
    #5 0x1075dfc5c in rz_config_eval config.c:731
    #6 0x102e07578 in rz_main_rizin rizin.c:1194
    #7 0x102ddf1cc in main rizin.c:55
    #8 0x19af65f30 in start+0x0 (libdyld.dylib:arm64e+0x16f30)

0x000112212f74 is located 36 bytes inside of 40-byte region [0x000112212f50,0x000112212f78)
freed by thread T0 here:
    #0 0x10369bba8 in wrap_free+0x98 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x3fba8)
    #1 0x1075f9354 in rz_bin_string_free bin.c:213
    #2 0x10324b71c in rz_list_delete list.c:108
    #3 0x10324b4f8 in rz_list_purge list.c:74
    #4 0x10324b784 in rz_list_free list.c:84
    #5 0x1075ffcac in rz_bin_reset_strings bin.c:775
    #6 0x107ef9280 in cb_binminstr cconfig.c:2518
    #7 0x1075deb48 in rz_config_set config.c:566
    #8 0x1075dfe08 in __evalString config.c:687
    #9 0x1075dfc5c in rz_config_eval config.c:731
    #10 0x102e07578 in rz_main_rizin rizin.c:1194
    #11 0x102ddf1cc in main rizin.c:55
    #12 0x19af65f30 in start+0x0 (libdyld.dylib:arm64e+0x16f30)

previously allocated by thread T0 here:
    #0 0x10369be38 in wrap_calloc+0x9c (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x3fe38)
    #1 0x10762b9bc in string_scan_range bfile.c:299
    #2 0x107627d90 in get_strings_range bfile.c:431
    #3 0x107626a64 in rz_bin_file_get_strings bfile.c:787
    #4 0x10762fca8 in rz_bin_object_set_items bobj.c:367
    #5 0x10762dfbc in rz_bin_object_new bobj.c:175
    #6 0x107622d80 in rz_bin_file_object_new_from_xtr_data bfile.c:483
    #7 0x107623e74 in rz_bin_file_find_by_arch_bits bfile.c:556
    #8 0x107edabf8 in rz_core_bin_set_arch_bits cbin.c:4297
    #9 0x10814e6f4 in rz_core_bin_load cfile.c:992
    #10 0x102e062c8 in rz_main_rizin rizin.c:1091
    #11 0x102ddf1cc in main rizin.c:55
    #12 0x19af65f30 in start+0x0 (libdyld.dylib:arm64e+0x16f30)

SUMMARY: AddressSanitizer: heap-use-after-free bfile.c:820 in rz_bin_file_get_strings
Shadow bytes around the buggy address:
  0x007022462590: fa fa fd fd fd fd fd fd fa fa fd fd fd fd fd fa
  0x0070224625a0: fa fa fd fd fd fd fd fd fa fa fd fd fd fd fd fa
  0x0070224625b0: fa fa fd fd fd fd fd fd fa fa fd fd fd fd fd fa
  0x0070224625c0: fa fa fd fd fd fd fd fa fa fa fd fd fd fd fd fd
  0x0070224625d0: fa fa fd fd fd fd fd fd fa fa fd fd fd fd fd fd
=>0x0070224625e0: fa fa fd fd fd fd fd fd fa fa fd fd fd fd[fd]fa
  0x0070224625f0: fa fa fd fd fd fd fd fa fa fa fd fd fd fd fd fa
  0x007022462600: fa fa fd fd fd fd fd fd fa fa fd fd fd fd fd fa
  0x007022462610: fa fa fd fd fd fd fd fd fa fa fd fd fd fd fd fa
  0x007022462620: fa fa fd fd fd fd fd fa fa fa fd fd fd fd fd fa
  0x007022462630: fa fa fd fd fd fd fd fa fa fa fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==65255==ABORTING
Abort trap: 6
```

**Test plan**

Run the added `__cfstring` test, optionally with asan or valgrind.