### PR TITLE
Remove `cmd_print_pwn` and other easter eggs

### DIFF
--- a/librz/core/cmd_print.c
+++ b/librz/core/cmd_print.c
@@ -2415,10 +2415,6 @@ RZ_API void rz_core_print_cmp(RzCore *core, ut64 from, ut64 to) {
 	free(b);
 }
 
-static void cmd_print_pwn(const RzCore *core) {
-	rz_cons_printf("easter egg license has expired\n");
-}
-
 static int cmd_print_pxA(RzCore *core, int len, const char *input) {
 	RzConsPrintablePalette *pal = &core->cons->context->pal;
 	int show_offset = true;
@@ -4891,9 +4887,7 @@ RZ_IPI int rz_cmd_print(void *data, const char *input) {
 	block = core->block;
 	switch (*input) {
 	case 'w': // "pw"
-		if (input[1] == 'n') {
-			cmd_print_pwn(core);
-		} else if (input[1] == 'd') {
+		if (input[1] == 'd') { // "pwd"
 			char *cwd = rz_sys_getdir();
 			if (cwd) {
 				rz_cons_println(cwd);
@@ -6827,9 +6821,6 @@ RZ_IPI int rz_cmd_print(void *data, const char *input) {
 			core->offset = offset0;
 			rz_cons_printf("\n");
 		}
-		break;
-	case 'n': // easter
-		eprintf("easter egg license has expired\n");
 		break;
 	case 't': // "pt"
 		switch (input[1]) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Removes all instances of 'easter eggs' or lines talking about it. `cmd_print_pwn()` was a function printing just that.

**Test plan**
- [x] CI builds green

**Closing issues**

None
