### PR TITLE
Add types autocompletion

### DIFF
--- a/librz/core/cautocmpl.c
+++ b/librz/core/cautocmpl.c
@@ -6,6 +6,8 @@
 #include <rz_cons.h>
 #include <rz_cmd.h>
 
+#include "core_private.h"
+
 /**
  * Describe what needs to be autocompleted.
  */
@@ -212,6 +214,66 @@ static void autocmplt_cmd_arg_fcn(RzCore *core, RzLineNSCompletionResult *res, c
 		}
 		free(name);
 	}
+}
+
+static void autocmplt_cmd_arg_enum_type(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
+	char *item;
+	RzListIter *iter;
+	RzList *list = rz_types_enums(core->analysis->sdb_types);
+	rz_list_foreach (list, iter, item) {
+		if (!strncmp(item, s, len)) {
+			rz_line_ns_completion_result_add(res, item);
+		}
+	}
+	rz_list_free(list);
+}
+
+static void autocmplt_cmd_arg_struct_type(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
+	char *item;
+	RzListIter *iter;
+	RzList *list = rz_types_structs(core->analysis->sdb_types);
+	rz_list_foreach (list, iter, item) {
+		if (!strncmp(item, s, len)) {
+			rz_line_ns_completion_result_add(res, item);
+		}
+	}
+	rz_list_free(list);
+}
+
+static void autocmplt_cmd_arg_union_type(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
+	char *item;
+	RzListIter *iter;
+	RzList *list = rz_types_unions(core->analysis->sdb_types);
+	rz_list_foreach (list, iter, item) {
+		if (!strncmp(item, s, len)) {
+			rz_line_ns_completion_result_add(res, item);
+		}
+	}
+	rz_list_free(list);
+}
+
+static void autocmplt_cmd_arg_alias_type(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
+	char *item;
+	RzListIter *iter;
+	RzList *list = rz_types_typedefs(core->analysis->sdb_types);
+	rz_list_foreach (list, iter, item) {
+		if (!strncmp(item, s, len)) {
+			rz_line_ns_completion_result_add(res, item);
+		}
+	}
+	rz_list_free(list);
+}
+
+static void autocmplt_cmd_arg_any_type(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
+	char *item;
+	RzListIter *iter;
+	RzList *list = rz_types_all(core->analysis->sdb_types);
+	rz_list_foreach (list, iter, item) {
+		if (!strncmp(item, s, len)) {
+			rz_line_ns_completion_result_add(res, item);
+		}
+	}
+	rz_list_free(list);
 }
 
 static void autocmplt_cmd_arg_help_var(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
@@ -443,6 +505,21 @@ static void autocmplt_cmd_arg(RzCore *core, RzLineNSCompletionResult *res, const
 		break;
 	case RZ_CMD_ARG_TYPE_FLAG:
 		autocmplt_cmd_arg_flag(core, res, s, len);
+		break;
+	case RZ_CMD_ARG_TYPE_ENUM_TYPE:
+		autocmplt_cmd_arg_enum_type(core, res, s, len);
+		break;
+	case RZ_CMD_ARG_TYPE_STRUCT_TYPE:
+		autocmplt_cmd_arg_struct_type(core, res, s, len);
+		break;
+	case RZ_CMD_ARG_TYPE_UNION_TYPE:
+		autocmplt_cmd_arg_union_type(core, res, s, len);
+		break;
+	case RZ_CMD_ARG_TYPE_ALIAS_TYPE:
+		autocmplt_cmd_arg_alias_type(core, res, s, len);
+		break;
+	case RZ_CMD_ARG_TYPE_ANY_TYPE:
+		autocmplt_cmd_arg_any_type(core, res, s, len);
 		break;
 	default:
 		break;

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -2007,8 +2007,7 @@ static const RzCmdDescHelp t_help = {
 static const RzCmdDescArg type_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_ANY_TYPE,
 		.optional = true,
 
 	},
@@ -2022,8 +2021,7 @@ static const RzCmdDescHelp type_help = {
 static const RzCmdDescArg type_del_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_ANY_TYPE,
 
 	},
 	{ 0 },
@@ -2047,8 +2045,7 @@ static const RzCmdDescHelp tc_help = {
 static const RzCmdDescArg type_list_c_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_ANY_TYPE,
 		.optional = true,
 
 	},
@@ -2062,8 +2059,7 @@ static const RzCmdDescHelp type_list_c_help = {
 static const RzCmdDescArg type_list_c_nl_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_ANY_TYPE,
 		.optional = true,
 
 	},
@@ -2134,7 +2130,7 @@ static const RzCmdDescHelp te_help = {
 static const RzCmdDescArg type_list_enum_args[] = {
 	{
 		.name = "enum",
-		.type = RZ_CMD_ARG_TYPE_STRING,
+		.type = RZ_CMD_ARG_TYPE_ENUM_TYPE,
 		.optional = true,
 
 	},
@@ -2155,7 +2151,7 @@ static const RzCmdDescHelp type_list_enum_help = {
 static const RzCmdDescArg type_enum_bitfield_args[] = {
 	{
 		.name = "enum",
-		.type = RZ_CMD_ARG_TYPE_STRING,
+		.type = RZ_CMD_ARG_TYPE_ENUM_TYPE,
 
 	},
 	{
@@ -2174,8 +2170,7 @@ static const RzCmdDescHelp type_enum_bitfield_help = {
 static const RzCmdDescArg type_enum_c_args[] = {
 	{
 		.name = "enum",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_ENUM_TYPE,
 		.optional = true,
 
 	},
@@ -2189,8 +2184,7 @@ static const RzCmdDescHelp type_enum_c_help = {
 static const RzCmdDescArg type_enum_c_nl_args[] = {
 	{
 		.name = "enum",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_ENUM_TYPE,
 		.optional = true,
 
 	},
@@ -2398,7 +2392,7 @@ static const RzCmdDescHelp tp_help = {
 static const RzCmdDescArg type_print_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
+		.type = RZ_CMD_ARG_TYPE_ANY_TYPE,
 
 	},
 	{
@@ -2418,7 +2412,7 @@ static const RzCmdDescHelp type_print_help = {
 static const RzCmdDescArg type_print_value_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
+		.type = RZ_CMD_ARG_TYPE_ANY_TYPE,
 
 	},
 	{
@@ -2438,7 +2432,7 @@ static const RzCmdDescHelp type_print_value_help = {
 static const RzCmdDescArg type_print_hexstring_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
+		.type = RZ_CMD_ARG_TYPE_ANY_TYPE,
 
 	},
 	{
@@ -2460,45 +2454,42 @@ static const RzCmdDescHelp ts_help = {
 static const RzCmdDescArg type_list_structure_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_STRUCT_TYPE,
 		.optional = true,
 
 	},
 	{ 0 },
 };
 static const RzCmdDescHelp type_list_structure_help = {
-	.summary = "List loaded unions / Show pf format string for given union",
+	.summary = "List loaded structures / Show pf format string for given structure",
 	.args = type_list_structure_args,
 };
 
 static const RzCmdDescArg type_structure_c_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_STRUCT_TYPE,
 		.optional = true,
 
 	},
 	{ 0 },
 };
 static const RzCmdDescHelp type_structure_c_help = {
-	.summary = "Show union in the C output format with newlines",
+	.summary = "Show structure in the C output format with newlines",
 	.args = type_structure_c_args,
 };
 
 static const RzCmdDescArg type_structure_c_nl_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_STRUCT_TYPE,
 		.optional = true,
 
 	},
 	{ 0 },
 };
 static const RzCmdDescHelp type_structure_c_nl_help = {
-	.summary = "Show union in the C output format without newlines",
+	.summary = "Show structure in the C output format without newlines",
 	.args = type_structure_c_nl_args,
 };
 
@@ -2508,8 +2499,7 @@ static const RzCmdDescHelp tt_help = {
 static const RzCmdDescArg type_list_typedef_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_ALIAS_TYPE,
 		.optional = true,
 
 	},
@@ -2523,8 +2513,7 @@ static const RzCmdDescHelp type_list_typedef_help = {
 static const RzCmdDescArg type_typedef_c_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_ALIAS_TYPE,
 		.optional = true,
 
 	},
@@ -2541,8 +2530,7 @@ static const RzCmdDescHelp tu_help = {
 static const RzCmdDescArg type_list_union_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_UNION_TYPE,
 		.optional = true,
 
 	},
@@ -2556,8 +2544,7 @@ static const RzCmdDescHelp type_list_union_help = {
 static const RzCmdDescArg type_union_c_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_UNION_TYPE,
 		.optional = true,
 
 	},
@@ -2571,8 +2558,7 @@ static const RzCmdDescHelp type_union_c_help = {
 static const RzCmdDescArg type_union_c_nl_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_UNION_TYPE,
 		.optional = true,
 
 	},
@@ -2589,8 +2575,7 @@ static const RzCmdDescHelp tx_help = {
 static const RzCmdDescArg type_xrefs_list_args[] = {
 	{
 		.name = "type",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_ANY_TYPE,
 		.optional = true,
 
 	},

--- a/librz/core/cmd_descs/cmd_type.yaml
+++ b/librz/core/cmd_descs/cmd_type.yaml
@@ -12,14 +12,14 @@ commands:
       - RZ_OUTPUT_MODE_JSON
     args:
       - name: type
-        type: RZ_CMD_ARG_TYPE_STRING
+        type: RZ_CMD_ARG_TYPE_ANY_TYPE
         optional: true
   - name: t-
     cname: type_del
     summary: Remove the type
     args:
       - name: type
-        type: RZ_CMD_ARG_TYPE_STRING
+        type: RZ_CMD_ARG_TYPE_ANY_TYPE
   - name: t-*
     cname: type_del_all
     summary: Remove all types
@@ -32,14 +32,14 @@ commands:
         summary: List loaded types in C format with newlines
         args:
           - name: type
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_ANY_TYPE
             optional: true
       - name: tcd
         cname: type_list_c_nl
         summary: List loaded types in C format without newlines
         args:
           - name: type
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_ANY_TYPE
             optional: true
       - name: tcc
         summary: Manage calling convention types
@@ -85,7 +85,7 @@ commands:
           - RZ_OUTPUT_MODE_SDB
         args:
           - name: enum
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_ENUM_TYPE
             optional: true
           - name: value
             type: RZ_CMD_ARG_TYPE_STRING
@@ -95,7 +95,7 @@ commands:
         summary: Show enum bitfield
         args:
           - name: enum
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_ENUM_TYPE
           - name: field
             type: RZ_CMD_ARG_TYPE_STRING
       - name: tec
@@ -103,14 +103,14 @@ commands:
         summary: Show enum in the C output format
         args:
           - name: enum
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_ENUM_TYPE
             optional: true
       - name: ted
         cname: type_enum_c_nl
         summary: Show enum in the C output format without newlines
         args:
           - name: enum
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_ENUM_TYPE
             optional: true
       - name: tef
         cname: type_enum_find
@@ -228,7 +228,7 @@ commands:
         summary: Print formatted type casted to the address or variable
         args:
           - name: type
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_ANY_TYPE
           - name: address
             type: RZ_CMD_ARG_TYPE_STRING
             optional: true
@@ -237,7 +237,7 @@ commands:
         summary: Print formatted type casted to the value
         args:
           - name: type
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_ANY_TYPE
           - name: value
             type: RZ_CMD_ARG_TYPE_STRING
             optional: true
@@ -246,7 +246,7 @@ commands:
         summary: Print formatted type casted to the hexadecimal sequence
         args:
           - name: type
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_ANY_TYPE
           - name: hexpairs
             type: RZ_CMD_ARG_TYPE_STRING
   - name: ts
@@ -254,28 +254,28 @@ commands:
     subcommands:
       - name: ts
         cname: type_list_structure
-        summary: List loaded unions / Show pf format string for given union
+        summary: List loaded structures / Show pf format string for given structure
         modes:
           - RZ_OUTPUT_MODE_STANDARD
           - RZ_OUTPUT_MODE_RIZIN
           - RZ_OUTPUT_MODE_JSON
         args:
           - name: type
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_STRUCT_TYPE
             optional: true
       - name: tsc
         cname: type_structure_c
-        summary: Show union in the C output format with newlines
+        summary: Show structure in the C output format with newlines
         args:
           - name: type
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_STRUCT_TYPE
             optional: true
       - name: tsd
         cname: type_structure_c_nl
-        summary: Show union in the C output format without newlines
+        summary: Show structure in the C output format without newlines
         args:
           - name: type
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_STRUCT_TYPE
             optional: true
   - name: tt
     summary: List loaded typedefs
@@ -288,14 +288,14 @@ commands:
           - RZ_OUTPUT_MODE_JSON
         args:
           - name: type
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_ALIAS_TYPE
             optional: true
       - name: ttc
         cname: type_typedef_c
         summary: Show typedef in the C output format
         args:
           - name: type
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_ALIAS_TYPE
             optional: true
   - name: tu
     summary: List loaded unions
@@ -309,21 +309,21 @@ commands:
           - RZ_OUTPUT_MODE_JSON
         args:
           - name: type
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_UNION_TYPE
             optional: true
       - name: tuc
         cname: type_union_c
         summary: Show union in the C output format with newlines
         args:
           - name: type
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_UNION_TYPE
             optional: true
       - name: tud
         cname: type_union_c_nl
         summary: Show union in the C output format without newlines
         args:
           - name: type
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_UNION_TYPE
             optional: true
   - name: tx
     summary: Type xrefs
@@ -333,7 +333,7 @@ commands:
         summary: List functions using the type
         args:
           - name: type
-            type: RZ_CMD_ARG_TYPE_STRING
+            type: RZ_CMD_ARG_TYPE_ANY_TYPE
             optional: true
       - name: txf
         cname: type_xrefs_function

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -54,7 +54,10 @@ RZ_IPI void rz_types_enum_print_c(Sdb *TDB, const char *arg, bool multiline);
 RZ_IPI bool rz_core_types_typedef_info(RzCore *core, const char *name);
 RZ_IPI void rz_types_typedef_print_c(Sdb *TDB, const char *typedef_name);
 RZ_IPI void rz_core_list_loaded_typedefs(RzCore *core, RzOutputMode mode);
+RZ_IPI RzList *rz_types_typedefs(Sdb *TDB);
 
+RZ_IPI RzList *rz_types_unions(Sdb *TDB);
+RZ_IPI RzList *rz_types_structs(Sdb *TDB);
 // Structured types JSON
 RZ_IPI void rz_types_structured_print_json(Sdb *TDB, SdbList *l);
 RZ_IPI void rz_types_union_print_json(Sdb *TDB);
@@ -79,7 +82,7 @@ RZ_IPI void rz_core_types_link_print_all(RzCore *core, RzOutputMode mode);
 RZ_IPI void rz_core_types_link(RzCore *core, const char *type, ut64 addr);
 RZ_IPI void rz_core_types_link_show(RzCore *core, ut64 addr);
 RZ_IPI void rz_core_types_print_all(RzCore *core, RzOutputMode mode);
-
+RZ_IPI RzList *rz_types_all(Sdb *TDB);
 RZ_IPI void rz_types_define(RzCore *core, const char *type);
 RZ_IPI void rz_types_open_file(RzCore *core, const char *path);
 RZ_IPI void rz_types_open_editor(RzCore *core, const char *typename);

--- a/librz/core/ctypes.c
+++ b/librz/core/ctypes.c
@@ -371,7 +371,25 @@ RZ_IPI void rz_types_struct_print_c(Sdb *TDB, const char *name, bool multiline) 
 	ls_free(l);
 }
 
+RZ_IPI RzList *rz_types_unions(Sdb *TDB) {
+	SdbList *sl = sdb_foreach_list_filter_user(TDB, sdb_if_union_cb, true, TDB);
+	RzList *l = rz_list_of_sdblist(sl);
+	ls_free(sl);
+	return l;
+}
+
+RZ_IPI RzList *rz_types_structs(Sdb *TDB) {
+	SdbList *sl = sdb_foreach_list_filter_user(TDB, sdb_if_struct_cb, true, TDB);
+	RzList *l = rz_list_of_sdblist(sl);
+	ls_free(sl);
+	return l;
+}
+
 // Typedefs
+
+static bool sdb_if_typedef_cb(void *p, const char *k, const char *v) {
+	return !strncmp(v, "typedef", strlen("typedef") + 1);
+}
 
 RZ_IPI bool rz_core_types_typedef_info(RzCore *core, const char *name) {
 	const char *istypedef;
@@ -461,6 +479,13 @@ RZ_IPI void rz_types_typedef_print_c(Sdb *TDB, const char *typedef_name) {
 	}
 	free(name);
 	ls_free(l);
+}
+
+RZ_IPI RzList *rz_types_typedefs(Sdb *TDB) {
+	SdbList *sl = sdb_foreach_list_filter_user(TDB, sdb_if_typedef_cb, true, TDB);
+	RzList *l = rz_list_of_sdblist(sl);
+	ls_free(sl);
+	return l;
 }
 
 // Function types
@@ -1055,6 +1080,17 @@ RZ_IPI void rz_core_types_print_all(RzCore *core, RzOutputMode mode) {
 		break;
 	}
 	ls_free(l);
+}
+
+static bool sdb_if_c_type_cb(void *p, const char *k, const char *v) {
+	return sdb_if_union_cb(p, k, v) || sdb_if_struct_cb(p, k, v) || sdb_if_type_cb(p, k, v);
+}
+
+RZ_IPI RzList *rz_types_all(Sdb *TDB) {
+	SdbList *sl = sdb_foreach_list_filter_user(TDB, sdb_if_c_type_cb, true, TDB);
+	RzList *l = rz_list_of_sdblist(sl);
+	ls_free(sl);
+	return l;
 }
 
 RZ_IPI void rz_types_define(RzCore *core, const char *type) {

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -51,6 +51,12 @@ typedef enum rz_cmd_arg_type_t {
 	RZ_CMD_ARG_TYPE_EVAL_FULL, ///< Argument is the name+(optional)value of a evaluable variable (e.g. `e` command)
 	RZ_CMD_ARG_TYPE_FCN_VAR, ///< Argument is the name of a function variable/argument
 	RZ_CMD_ARG_TYPE_FLAG, ///< Argument is a rizin flag
+	RZ_CMD_ARG_TYPE_ENUM_TYPE, ///< Argument is a C enum type name
+	RZ_CMD_ARG_TYPE_STRUCT_TYPE, ///< Argument is a C struct type name
+	RZ_CMD_ARG_TYPE_UNION_TYPE, ///< Argument is a C union type name
+	RZ_CMD_ARG_TYPE_ALIAS_TYPE, ///< Argument is a C typedef (alias) name
+	RZ_CMD_ARG_TYPE_CLASS_TYPE, ///< Argument is a C++/etc class name
+	RZ_CMD_ARG_TYPE_ANY_TYPE, ///< Argument is the any of the C or C++ type name
 } RzCmdArgType;
 
 /**

--- a/librz/include/rz_list.h
+++ b/librz/include/rz_list.h
@@ -110,6 +110,7 @@ RZ_API void *rz_list_pop_head(RzList *list);
 RZ_API void rz_list_reverse(RzList *list);
 RZ_API RzList *rz_list_clone(const RzList *list);
 RZ_API char *rz_list_to_str(RzList *list, char ch);
+RZ_API RzList *rz_list_of_sdblist(SdbList *sl);
 
 /* hashlike api */
 RZ_API RzListIter *rz_list_contains(const RzList *list, const void *p);

--- a/librz/util/list.c
+++ b/librz/util/list.c
@@ -627,3 +627,13 @@ RZ_API char *rz_list_to_str(RzList *list, char ch) {
 	}
 	return rz_strbuf_drain(buf);
 }
+
+RZ_API RzList *rz_list_of_sdblist(SdbList *sl) {
+	RzList *l = rz_list_newf(free);
+	SdbKv *kv;
+	SdbListIter *iter;
+	ls_foreach (sl, iter, kv) {
+		rz_list_append(l, strdup(sdbkv_key(kv)));
+	}
+	return l;
+}


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Following the `t` commands conversion to the newshell, adding autocompletion support for C enums, C typedefs, C unions, and C structs.

**Test plan**

Try the autocompletion feature in `te`, `ts`, `tu`, `tt`, `t`, and `tp` commands.
