### PR TITLE
Fix -Wstringop-truncation warnings in optimized asan build in rizin code

### DIFF
--- a/librz/bin/format/elf/elf.c
+++ b/librz/bin/format/elf/elf.c
@@ -2895,7 +2895,7 @@ RzBinElfLib *Elf_(rz_bin_elf_get_libs)(ELFOBJ *bin) {
 			free(ret);
 			return NULL;
 		}
-		strncpy(ret[k].name, bin->strtab + val, ELF_STRING_LENGTH);
+		strncpy(ret[k].name, bin->strtab + val, ELF_STRING_LENGTH - 1);
 		ret[k].name[ELF_STRING_LENGTH - 1] = '\0';
 		ret[k].last = 0;
 		if (ret[k].name[0]) {

--- a/librz/bin/format/mach0/mach0.c
+++ b/librz/bin/format/mach0/mach0.c
@@ -3615,7 +3615,7 @@ struct lib_t *MACH0_(get_libs)(struct MACH0_(obj_t) * bin) {
 	}
 	for (i = 0; i < bin->nlibs; i++) {
 		sdb_set(bin->kv, sdb_fmt("libs.%d.name", i), bin->libs[i], 0);
-		strncpy(libs[i].name, bin->libs[i], RZ_BIN_MACH0_STRING_LENGTH);
+		strncpy(libs[i].name, bin->libs[i], RZ_BIN_MACH0_STRING_LENGTH - 1);
 		libs[i].name[RZ_BIN_MACH0_STRING_LENGTH - 1] = '\0';
 		libs[i].last = 0;
 	}

--- a/librz/debug/p/native/linux/linux_coredump.c
+++ b/librz/debug/p/native/linux/linux_coredump.c
@@ -96,14 +96,14 @@ static prpsinfo_t *linux_get_prpsinfo(RzDebug *dbg, proc_per_process_t *proc_dat
 		goto error;
 	}
 	basename = rz_file_basename(pfname);
-	strncpy(p->pr_fname, basename, sizeof(p->pr_fname));
+	strncpy(p->pr_fname, basename, sizeof(p->pr_fname) - 1);
 	p->pr_fname[sizeof(p->pr_fname) - 1] = 0;
 	ppsargs = prpsinfo_get_psargs(buffer, (int)len);
 	if (!ppsargs) {
 		goto error;
 	}
 
-	strncpy(p->pr_psargs, ppsargs, sizeof(p->pr_psargs));
+	strncpy(p->pr_psargs, ppsargs, sizeof(p->pr_psargs) - 1);
 	p->pr_psargs[sizeof(p->pr_psargs) - 1] = 0;
 	free(buffer);
 	free(ppsargs);

--- a/shlr/winkd/iob_pipe.c
+++ b/shlr/winkd/iob_pipe.c
@@ -73,7 +73,7 @@ static void *iob_pipe_open(const char *path) {
 	memset(&sa, 0, sizeof(struct sockaddr_un));
 
 	sa.sun_family = AF_UNIX;
-	strncpy(sa.sun_path, path, sizeof(sa.sun_path));
+	strncpy(sa.sun_path, path, sizeof(sa.sun_path) - 1);
 	sa.sun_path[sizeof(sa.sun_path) - 1] = 0;
 	if (connect(sock, (struct sockaddr *)&sa, sizeof(struct sockaddr_un)) == -1) {
 		perror("connect");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes warnings of the following form in the optimized asan build of #260 in rizin code (https://github.com/rizinorg/rizin/runs/2031121204, View raw logs, search for "-Wstringop-truncation" ignoring the capstone code):

```
2021-03-04T12:52:02.6893560Z In file included from /usr/include/string.h:495,
2021-03-04T12:52:02.6894069Z                  from ../shlr/winkd/iob_pipe.c:4:
2021-03-04T12:52:02.6895383Z In function ‘strncpy’,
2021-03-04T12:52:02.6896113Z     inlined from ‘iob_pipe_open’ at ../shlr/winkd/iob_pipe.c:75:2:
2021-03-04T12:52:02.6897385Z /usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ specified bound 108 equals destination size [-Wstringop-truncation]
2021-03-04T12:52:02.6898430Z   106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
2021-03-04T12:52:02.6899110Z       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
