### PR TITLE
Fix memory corruption in disasm

### DIFF
--- a/librz/analysis/analysis.c
+++ b/librz/analysis/analysis.c
@@ -305,7 +305,9 @@ RZ_API void rz_analysis_set_cpu(RzAnalysis *analysis, const char *cpu) {
 
 RZ_API int rz_analysis_set_big_endian(RzAnalysis *analysis, int bigend) {
 	analysis->big_endian = bigend;
-	analysis->reg->big_endian = bigend;
+	if (analysis->reg) {
+		analysis->reg->big_endian = bigend;
+	}
 	return true;
 }
 

--- a/librz/analysis/esil_trace.c
+++ b/librz/analysis/esil_trace.c
@@ -53,7 +53,9 @@ RZ_API RzAnalysisEsilTrace *rz_analysis_esil_trace_new(RzAnalysisEsil *esil) {
 		if (!b) {
 			goto error;
 		}
-		memcpy(b->bytes, a->bytes, b->size);
+		if (b->bytes && a->bytes && b->size > 0) {
+			memcpy(b->bytes, a->bytes, b->size);
+		}
 		trace->arena[i] = b;
 	}
 	return trace;

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -456,32 +456,30 @@ RZ_API bool rz_core_bin_apply_config(RzCore *r, RzBinFile *binfile) {
 	rz_config_set(r->config, "file.type", info->rclass);
 	rz_config_set(r->config, "cfg.bigendian",
 		info->big_endian ? "true" : "false");
-	if (!info->rclass || strcmp(info->rclass, "fs")) {
-		if (info->lang) {
-			rz_config_set(r->config, "bin.lang", info->lang);
-		}
-		rz_config_set(r->config, "asm.os", info->os);
-		if (info->rclass && !strcmp(info->rclass, "pe")) {
-			rz_config_set(r->config, "analysis.cpp.abi", "msvc");
-		} else {
-			rz_config_set(r->config, "analysis.cpp.abi", "itanium");
-		}
-		rz_config_set(r->config, "asm.arch", info->arch);
-		if (info->cpu && *info->cpu) {
-			rz_config_set(r->config, "asm.cpu", info->cpu);
-		}
-		if (info->features && *info->features) {
-			rz_config_set(r->config, "asm.features", info->features);
-		}
-		rz_config_set(r->config, "analysis.arch", info->arch);
-		snprintf(str, RZ_FLAG_NAME_SIZE, "%i", info->bits);
-		rz_config_set(r->config, "asm.bits", str);
-		rz_config_set(r->config, "asm.dwarf",
-			(RZ_BIN_DBG_STRIPPED & info->dbg_info) ? "false" : "true");
-		v = rz_analysis_archinfo(r->analysis, RZ_ANALYSIS_ARCHINFO_ALIGN);
-		if (v != -1) {
-			rz_config_set_i(r->config, "asm.pcalign", v);
-		}
+	if (info->lang) {
+		rz_config_set(r->config, "bin.lang", info->lang);
+	}
+	rz_config_set(r->config, "asm.os", info->os);
+	if (info->rclass && !strcmp(info->rclass, "pe")) {
+		rz_config_set(r->config, "analysis.cpp.abi", "msvc");
+	} else {
+		rz_config_set(r->config, "analysis.cpp.abi", "itanium");
+	}
+	rz_config_set(r->config, "asm.arch", info->arch);
+	if (info->cpu && *info->cpu) {
+		rz_config_set(r->config, "asm.cpu", info->cpu);
+	}
+	if (info->features && *info->features) {
+		rz_config_set(r->config, "asm.features", info->features);
+	}
+	rz_config_set(r->config, "analysis.arch", info->arch);
+	snprintf(str, RZ_FLAG_NAME_SIZE, "%i", info->bits);
+	rz_config_set(r->config, "asm.bits", str);
+	rz_config_set(r->config, "asm.dwarf",
+		(RZ_BIN_DBG_STRIPPED & info->dbg_info) ? "false" : "true");
+	v = rz_analysis_archinfo(r->analysis, RZ_ANALYSIS_ARCHINFO_ALIGN);
+	if (v != -1) {
+		rz_config_set_i(r->config, "asm.pcalign", v);
 	}
 	rz_core_analysis_type_init(r);
 	rz_core_analysis_cc_init(r);

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -1484,15 +1484,15 @@ static void ds_atabs_option(RDisasmState *ds) {
 		return;
 	}
 	int bufasm_len = rz_strbuf_length(&ds->asmop.buf_asm);
-	int size = bufasm_len * (ds->atabs + 1) * 4;
+	int size = bufasm_len * (ds->atabs + 1) * 4 + 4;
 	if (size < 1 || size < bufasm_len) {
 		return;
 	}
-	b = malloc(size + 1);
 	if (ds->opstr) {
-		strcpy(b, ds->opstr);
+		size = strlen(ds->opstr) * (ds->atabs + 1) * 4 + 4;
+		b = rz_str_ndup(ds->opstr, size);
 	} else {
-		strcpy(b, rz_asm_op_get_asm(&ds->asmop));
+		b = rz_str_ndup(rz_asm_op_get_asm(&ds->asmop), size);
 	}
 	if (!b) {
 		return;


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

```
[i] ℤ rizin test-getopt-gnu.c-clang-x86-O0.o                                                                                                                                                                                      14:02:43 
Warning: run rizin with -e io.cache=true to fix relocations in disassembly
 -- Execute commands on a temporary offset by appending '@ offset' to your command.
[0x08000040]> aaa
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze function calls (aac)
[x] Analyze len bytes of instructions for references (aar)
[x] Check for vtables
[../librz/analysis/esil_trace.c:56:3: runtime error: null pointer passed as argument 1, which is declared to never be null
../librz/analysis/esil_trace.c:56:3: runtime error: null pointer passed as argument 2, which is declared to never be null
[x] Type matching analysis for all functions (aaft)
[x] Propagate noreturn information
[x] Use -AA or aaaa to perform additional experimental analysis.
[0x08000040]> s 0x800b000
[0x0800b000]> 
[0x0800b000]> pdf
=================================================================
==986224==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x612000272fd9 at pc 0x7f0da8896f79 bp 0x7ffe14177f50 sp 0x7ffe14177700
WRITE of size 283 at 0x612000272fd9 thread T0
    #0 0x7f0da8896f78  (/lib64/libasan.so.6+0x51f78)
    #1 0x7f0d9a4f077b in ds_atabs_option ../librz/core/disasm.c:1493
    #2 0x7f0d9a539b24 in rz_core_print_disasm ../librz/core/disasm.c:5292
    #3 0x7f0d9a3f8664 in rz_cmd_print ../librz/core/cmd_print.c:5600
    #4 0x7f0d9a47cec4 in call_cd ../librz/core/cmd_api.c:654
    #5 0x7f0d9a47cf7b in rz_cmd_call_parsed_args ../librz/core/cmd_api.c:669
    #6 0x7f0d9a450651 in handle_ts_arged_command_internal ../librz/core/cmd.c:4623
    #7 0x7f0d9a44fa30 in handle_ts_arged_command ../librz/core/cmd.c:4585
    #8 0x7f0d9a46c3a7 in handle_ts_command ../librz/core/cmd.c:6047
    #9 0x7f0d9a46da0f in handle_ts_commands_internal ../librz/core/cmd.c:6104
    #10 0x7f0d9a46cbd6 in handle_ts_commands ../librz/core/cmd.c:6069
    #11 0x7f0d9a46ed09 in core_cmd_tsr2cmd ../librz/core/cmd.c:6199
    #12 0x7f0d9a46f5d2 in rz_core_cmd ../librz/core/cmd.c:6246
    #13 0x7f0d9a4c0eca in rz_core_prompt_exec ../librz/core/core.c:2911
    #14 0x7f0d9a4be936 in rz_core_prompt_loop ../librz/core/core.c:2762
    #15 0x7f0da7c6e045 in rz_main_rizin ../librz/main/rizin.c:1362
    #16 0x401a5c in main ../binrz/rizin/rizin.c:55
    #17 0x7f0da70971e1 in __libc_start_main (/lib64/libc.so.6+0x281e1)
    #18 0x4011dd in _start (/home/akochkov/.local/bin/rizin+0x4011dd)

0x612000272fd9 is located 0 bytes to the right of 281-byte region [0x612000272ec0,0x612000272fd9)
allocated by thread T0 here:
    #0 0x7f0da88f03cf in __interceptor_malloc (/lib64/libasan.so.6+0xab3cf)
    #1 0x7f0d9a4f0668 in ds_atabs_option ../librz/core/disasm.c:1491
    #2 0x7f0d9a539b24 in rz_core_print_disasm ../librz/core/disasm.c:5292
    #3 0x7f0d9a3f8664 in rz_cmd_print ../librz/core/cmd_print.c:5600
    #4 0x7f0d9a47cec4 in call_cd ../librz/core/cmd_api.c:654
    #5 0x7f0d9a47cf7b in rz_cmd_call_parsed_args ../librz/core/cmd_api.c:669
    #6 0x7f0d9a450651 in handle_ts_arged_command_internal ../librz/core/cmd.c:4623
    #7 0x7f0d9a44fa30 in handle_ts_arged_command ../librz/core/cmd.c:4585
    #8 0x7f0d9a46c3a7 in handle_ts_command ../librz/core/cmd.c:6047
    #9 0x7f0d9a46da0f in handle_ts_commands_internal ../librz/core/cmd.c:6104
    #10 0x7f0d9a46cbd6 in handle_ts_commands ../librz/core/cmd.c:6069
    #11 0x7f0d9a46ed09 in core_cmd_tsr2cmd ../librz/core/cmd.c:6199
    #12 0x7f0d9a46f5d2 in rz_core_cmd ../librz/core/cmd.c:6246
    #13 0x7f0d9a4c0eca in rz_core_prompt_exec ../librz/core/core.c:2911
    #14 0x7f0d9a4be936 in rz_core_prompt_loop ../librz/core/core.c:2762
    #15 0x7f0da7c6e045 in rz_main_rizin ../librz/main/rizin.c:1362
    #16 0x401a5c in main ../binrz/rizin/rizin.c:55
    #17 0x7f0da70971e1 in __libc_start_main (/lib64/libc.so.6+0x281e1)

SUMMARY: AddressSanitizer: heap-buffer-overflow (/lib64/libasan.so.6+0x51f78) 
Shadow bytes around the buggy address:
  0x0c24800465a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c24800465b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c24800465c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c24800465d0: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c24800465e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c24800465f0: 00 00 00 00 00 00 00 00 00 00 00[01]fa fa fa fa
  0x0c2480046600: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c2480046610: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2480046620: fd fd fd fd fd fd fd fd fd fd fd fa fa fa fa fa
  0x0c2480046630: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c2480046640: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==986224==ABORTING
```

Caused memory corruption in `ds_atabs_option()` in `librz/core/disasm.c`.
Also fixed a couple minor UBSAN issues found during debugging.

[test-getopt-gnu.c-clang-x86-O0.o.zip](https://github.com/rizinorg/rizin/files/6106214/test-getopt-gnu.c-clang-x86-O0.o.zip)

**Test plan**

All green

