### PR TITLE
Process noreturn functions also for relocations

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -6688,6 +6688,127 @@ RZ_IPI char *rz_core_analysis_function_signature(RzCore *core, RzOutputMode mode
 	return signature;
 }
 
+static RzAnalysisBlock *find_block_at_xref_addr(RzCore *core, ut64 addr) {
+	RzList *blocks = rz_analysis_get_blocks_in(core->analysis, addr);
+	if (!blocks) {
+		return NULL;
+	}
+	RzAnalysisBlock *block = NULL;
+	RzListIter *bit;
+	RzAnalysisBlock *block_cur;
+	rz_list_foreach (blocks, bit, block_cur) {
+		if (rz_analysis_block_op_starts_at(block_cur, addr)) {
+			block = block_cur;
+			break;
+		}
+	}
+	if (block) {
+		rz_analysis_block_ref(block);
+	}
+	rz_list_free(blocks);
+	return block;
+}
+
+static void relocation_function_process_noreturn(RzCore *core, RzAnalysisBlock *b, RzList *todo, ut64 opsize, ut64 reladdr, ut64 addr) {
+	rz_analysis_noreturn_add(core->analysis, NULL, reladdr);
+	// Chop the block
+	rz_analysis_block_chop_noreturn(b, addr + opsize);
+	// Add a potential noreturn function to the future analysis
+	RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(core->analysis, addr, RZ_ANALYSIS_FCN_TYPE_NULL);
+	if (fcn) {
+		rz_list_append(todo, fcn);
+	}
+}
+
+static void relocation_noreturn_process(RzCore *core, RzList *noretl, RzList *todo, RzAnalysisBlock *b, RzBinReloc *rel, ut64 opsize, ut64 addr) {
+	RzListIter *iter3;
+	char *noret;
+	if (rel->import) {
+		rz_list_foreach (noretl, iter3, noret) {
+			if (!strcmp(rel->import->name, noret)) {
+				relocation_function_process_noreturn(core, b, todo, opsize, rel->vaddr, addr);
+			}
+		}
+	} else if (rel->symbol) {
+		rz_list_foreach (noretl, iter3, noret) {
+			if (!strcmp(rel->symbol->name, noret)) {
+				relocation_function_process_noreturn(core, b, todo, opsize, rel->symbol->vaddr, addr);
+			}
+		}
+	}
+}
+
+#define CALL_BUF_SIZE 32
+
+struct core_noretl {
+	RzCore *core;
+	RzList *noretl;
+	RzList *todo;
+};
+
+static bool process_reference_noreturn_cb(void *u, const ut64 k, const void *v) {
+	RzCore *core = ((struct core_noretl *)u)->core;
+	RzList *noretl = ((struct core_noretl *)u)->noretl;
+	RzList *todo = ((struct core_noretl *)u)->todo;
+	RzAnalysisRef *ref = (RzAnalysisRef *)v;
+	if (ref->type == RZ_ANALYSIS_REF_TYPE_CALL || ref->type == RZ_ANALYSIS_REF_TYPE_CODE) {
+		// At first we check if there are any relocations that override the call address
+		// Note, that the relocation overrides only the part of the instruction
+		ut64 addr = k;
+		ut8 buf[CALL_BUF_SIZE] = { 0 };
+		RzAnalysisOp op = { 0 };
+		if (core->analysis->iob.read_at(core->analysis->iob.io, addr, buf, CALL_BUF_SIZE)) {
+			if (rz_analysis_op(core->analysis, &op, addr, buf, core->blocksize, 0)) {
+				RzBinReloc *rel = rz_core_getreloc(core, addr, op.size);
+				if (rel) {
+					// Find the block that has an instruction at exactly the reference addr
+					RzAnalysisBlock *block = find_block_at_xref_addr(core, addr);
+					if (!block) {
+						return true;
+					}
+					relocation_noreturn_process(core, noretl, todo, block, rel, op.size, addr);
+				}
+			}
+		} else {
+			eprintf("Fail to load %d bytes of data at 0x%08" PFMT64x "\n", CALL_BUF_SIZE, addr);
+		}
+	}
+	return true;
+}
+
+static bool process_refs_cb(void *u, const ut64 k, const void *v) {
+	HtUP *ht = (HtUP *)v;
+	ht_up_foreach(ht, process_reference_noreturn_cb, u);
+	return true;
+}
+
+RZ_API void rz_core_analysis_propagate_noreturn_relocs(RzCore *core, ut64 addr) {
+	// Processing every reference calls rz_analysis_op() which sometimes changes the
+	// state of `asm.bits` variable, thus we save it to restore after the processing
+	// is finished.
+	int bits1 = core->analysis->bits;
+	int bits2 = core->rasm->bits;
+	// find known noreturn functions to propagate
+	RzList *noretl = rz_types_function_noreturn(core->analysis->sdb_types);
+	// List of the potentially noreturn functions
+	RzList *todo = rz_list_new();
+	struct core_noretl u = { core, noretl, todo };
+	ht_up_foreach(core->analysis->dict_xrefs, process_refs_cb, &u);
+	rz_list_free(noretl);
+	core->analysis->bits = bits1;
+	core->rasm->bits = bits2;
+	// For every function in todo list analyze if it's potentially noreturn
+	RzListIter *iter;
+	RzAnalysisFunction *fcn;
+	rz_list_foreach (todo, iter, fcn) {
+		if (fcn->addr && analyze_noreturn_function(core, fcn)) {
+			fcn->is_noreturn = true;
+			rz_analysis_noreturn_add(core->analysis, NULL, fcn->addr);
+		}
+	}
+	rz_list_free(todo);
+}
+
 RZ_API void rz_core_analysis_propagate_noreturn(RzCore *core, ut64 addr) {
 	RzList *todo = rz_list_newf(free);
 	if (!todo) {
@@ -6710,6 +6831,10 @@ RZ_API void rz_core_analysis_propagate_noreturn(RzCore *core, ut64 addr) {
 		}
 	}
 
+	// At first we propagate all noreturn functions that are imports or symbols
+	// via the relocations
+	rz_core_analysis_propagate_noreturn_relocs(core, addr);
+
 	// find known noreturn functions to propagate
 	RzListIter *iter;
 	RzAnalysisFunction *f;
@@ -6719,7 +6844,6 @@ RZ_API void rz_core_analysis_propagate_noreturn(RzCore *core, ut64 addr) {
 			rz_list_append(todo, n);
 		}
 	}
-
 	while (!rz_list_empty(todo)) {
 		ut64 *paddr = (ut64 *)rz_list_pop(todo);
 		ut64 noret_addr = *paddr;
@@ -6743,23 +6867,7 @@ RZ_API void rz_core_analysis_propagate_noreturn(RzCore *core, ut64 addr) {
 			}
 
 			// Find the block that has an instruction at exactly the xref addr
-			RzList *blocks = rz_analysis_get_blocks_in(core->analysis, call_addr);
-			if (!blocks) {
-				continue;
-			}
-			RzAnalysisBlock *block = NULL;
-			RzListIter *bit;
-			RzAnalysisBlock *block_cur;
-			rz_list_foreach (blocks, bit, block_cur) {
-				if (rz_analysis_block_op_starts_at(block_cur, call_addr)) {
-					block = block_cur;
-					break;
-				}
-			}
-			if (block) {
-				rz_analysis_block_ref(block);
-			}
-			rz_list_free(blocks);
+			RzAnalysisBlock *block = find_block_at_xref_addr(core, call_addr);
 			if (!block) {
 				continue;
 			}

--- a/test/db/analysis/noreturn
+++ b/test/db/analysis/noreturn
@@ -14,3 +14,27 @@ true
 EOF
 RUN
 
+NAME=noreturn exit (relocation)
+FILE=bins/elf/analysis/filetime.c-clang-x64-O0.o
+CMDS=<<EOF
+aaa
+s sym.showVersion
+afi~size[1]
+afi~noreturn[1]
+s sym.showHelp
+afi~size[1]
+afi~noreturn[1]
+s sym.main
+afi~size[1]
+afi~noreturn[1]
+EOF
+EXPECT=<<EOF
+38
+true
+89
+true
+1202
+false
+EOF
+RUN
+


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

There are some binaries that call noreturn functions e.g. `exit` only after processing relocations. Disassembly shows these functions just fine, but during the analysis noreturn propagation stage they are not processed properly.

**Test plan**

```
[i] ℤ rizin filetime.c-clang-x64-O0.o                                                                                                                                                                                             18:38:51 
Warning: run rizin with -e io.cache=true to fix relocations in disassembly
 -- Use scr.accel to browse the file faster!
[0x08000040]> aaa
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze function calls (aac)
[x] Analyze len bytes of instructions for references (aar)
[x] Check for vtables
[x] Type matching analysis for all functions (aaft)
[x] Propagate noreturn information
[x] Use -AA or aaaa to perform additional experimental analysis.
[0x08000040]> s sym.showVersion 
[0x08000610]> pdf
            ; CALL XREF from sym.main @ 0x80000b0
╭ sym.showVersion ();
│           0x08000610      push  rbp
│           0x08000611      mov   rbp, rsp
│           0x08000614      mov   edi, 1
│           0x08000619      movabs rsi, 0                              ; RELOC 64 .rodata.str1.1 @ 0x08000636 + 0xd1
│           0x08000623      mov   eax, 0x11d                           ; 285
│           0x08000628      mov   edx, eax
│           0x0800062a      call  sym.Vwrite
│           0x0800062f      xor   edi, edi
╰           0x08000631      call  exit                                 ; RELOC 32 exit
[0x08000610]> tn
0x8000555
0x8000632
_Exit
__assert_fail
__cxa_throw
__libc_init
__libc_start_main
__stack_chk_fail
__uClibc_main
_exit
abort
err
errc
errx
exit
```

Before the patch it didn't stop at `0x08000631      call  exit                                 ; RELOC 32 exit` function since the call target before the relocation is `0`.

[filetime.c-clang-x64-O0.o.zip](https://github.com/rizinorg/rizin/files/6107906/filetime.c-clang-x64-O0.o.zip)

