### PR TITLE
analysis_arm_cs.c: Fix -Wmaybe-uninitialized warning in optimized capstone-v3 build

### DIFF
--- a/librz/analysis/p/analysis_arm_cs.c
+++ b/librz/analysis/p/analysis_arm_cs.c
@@ -3737,8 +3737,8 @@ static void op_fillval(RzAnalysis *analysis, RzAnalysisOp *op, csh handle, cs_in
 	case RZ_ANALYSIS_OP_TYPE_ROR:
 	case RZ_ANALYSIS_OP_TYPE_ROL:
 	case RZ_ANALYSIS_OP_TYPE_CAST:
-#if CS_API_MAJOR > 3
 		for (i = 1; i < count; i++) {
+#if CS_API_MAJOR > 3
 			if (bits == 64) {
 				cs_arm64_op arm64op = INSOP64(i);
 				if (arm64op.access == CS_AC_WRITE) {
@@ -3751,9 +3751,9 @@ static void op_fillval(RzAnalysis *analysis, RzAnalysisOp *op, csh handle, cs_in
 					continue;
 				}
 			}
+#endif
 			break;
 		}
-#endif
 		for (j = 0; j < 3; j++, i++) {
 			set_src_dst(op->src[j], analysis->reg, &handle, insn, i, bits);
 		}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following warning in the `capstone-v3` build of #260 (https://github.com/rizinorg/rizin/runs/2065028270#step:12:1323):

![analysis_arm_cs_maybe_uninitialized](https://user-images.githubusercontent.com/12002672/110465176-0eef7a00-810f-11eb-9389-f705e2ac741f.PNG)

This is basically a mechanical blindfix which practically initializes `i` to 1, but since we don't run tests on `capstone-v3` I'm not sure whether it's worth going deeper on this.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
