### PR TITLE
Add rz_num_align_delta()

### DIFF
--- a/librz/include/rz_util/rz_num.h
+++ b/librz/include/rz_util/rz_num.h
@@ -103,6 +103,21 @@ static inline st64 rz_num_abs(st64 num) {
 	return num < 0 ? -num : num;
 }
 
+/**
+ * \brief Padding to align v to the next alignment-boundary.
+ * \return the least `d` such that `(v + d) % alignment == 0`.
+ */
+static inline ut64 rz_num_align_delta(ut64 v, ut64 alignment) {
+	if (!alignment) {
+		return 0;
+	}
+	ut64 excess = v % alignment;
+	if (!excess) {
+		return 0;
+	}
+	return alignment - excess;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/unit/test_unum.c
+++ b/test/unit/test_unum.c
@@ -129,6 +129,20 @@ bool test_rz_num_str_split_list() {
 	mu_end;
 }
 
+bool test_rz_num_align_delta() {
+	ut64 d = rz_num_align_delta(0, 8);
+	mu_assert_eq(d, 0, "align delta");
+	d = rz_num_align_delta(3, 8);
+	mu_assert_eq(d, 5, "align delta");
+	d = rz_num_align_delta(0x10, 8);
+	mu_assert_eq(d, 0, "align delta");
+	d = rz_num_align_delta(0x11, 8);
+	mu_assert_eq(d, 7, "align delta");
+	d = rz_num_align_delta(0x42, 0);
+	mu_assert_eq(d, 0, "align delta");
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_rz_num_units);
 	mu_run_test(test_rz_num_minmax_swap_i);
@@ -137,6 +151,7 @@ bool all_tests() {
 	mu_run_test(test_rz_num_str_len);
 	mu_run_test(test_rz_num_str_split);
 	mu_run_test(test_rz_num_str_split_list);
+	mu_run_test(test_rz_num_align_delta);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Pulled from #796:

```c
/**
 * \brief Padding to align v to the next alignment-boundary.
 * \return the least `d` such that `(v + d) % alignment == 0`.
 */
static inline ut64 rz_num_align_delta(ut64 v, ut64 alignment)
```
**Test plan**

unit tests