### PR TITLE
Refactoring analysis process in order to finish the next job like `constructor detection`

### DIFF
--- a/librz/analysis/class.c
+++ b/librz/analysis/class.c
@@ -499,6 +499,18 @@ static RzAnalysisClassErr rz_analysis_class_add_attr_unique(RzAnalysis *analysis
 // ---- METHODS ----
 // Format: addr,vtable_offset
 
+static int symbol_method_sort_by_addr(const void *x, const void *y) {
+	RzBinSymbol *a = (RzBinSymbol *)x;
+	RzBinSymbol *b = (RzBinSymbol *)y;
+	if (a->vaddr > b->vaddr) {
+		return 1;
+	}
+	if (a->vaddr < b->vaddr) {
+		return -1;
+	}
+	return 0;
+}
+
 static char *flagname_method(const char *class_name, const char *meth_name) {
 	if (rz_str_startswith(meth_name, "method.")) {
 		return rz_str_new(meth_name);
@@ -514,6 +526,7 @@ RZ_API void rz_analysis_class_method_fini(RzAnalysisMethod *meth) {
 RZ_API void rz_analysis_class_method_recover(RzAnalysis *analysis, RzBinClass *class, RzList *methods) {
 	RzListIter *iter_method;
 	RzBinSymbol *sym;
+	rz_list_sort(methods, &symbol_method_sort_by_addr);
 	rz_list_foreach (methods, iter_method, sym) {
 		if (!rz_analysis_class_method_exists(analysis, class->name, sym->name)) {
 			//detect constructor or destructor but not implemented

--- a/librz/analysis/rtti_itanium.c
+++ b/librz/analysis/rtti_itanium.c
@@ -785,7 +785,6 @@ static void recovery_apply_vtable(RVTableContext *context, const char *class_nam
 				meth.real_name = rz_str_new(exist_meth.real_name);
 				meth.vtable_offset = vmeth->vtable_offset;
 				meth.method_type = RZ_ANALYSIS_CLASS_METHOD_VIRTUAL;
-				rz_analysis_class_method_delete(context->analysis, class_name, exist_meth.name);
 				rz_analysis_class_method_fini(&exist_meth);
 			}
 		}

--- a/librz/analysis/rtti_itanium.c
+++ b/librz/analysis/rtti_itanium.c
@@ -769,9 +769,26 @@ static void recovery_apply_vtable(RVTableContext *context, const char *class_nam
 	RVTableMethodInfo *vmeth;
 	rz_vector_foreach(&vtable_info->methods, vmeth) {
 		RzAnalysisMethod meth;
-		meth.addr = vmeth->addr;
-		meth.vtable_offset = vmeth->vtable_offset;
-		meth.name = rz_str_newf("virtual_%" PFMT64d, meth.vtable_offset);
+		if (!rz_analysis_class_method_exists_by_addr(context->analysis, class_name, vmeth->addr)) {
+			meth.addr = vmeth->addr;
+			meth.vtable_offset = vmeth->vtable_offset;
+			RzAnalysisFunction *fcn = rz_analysis_get_function_at(context->analysis, vmeth->addr);
+			meth.name = fcn ? rz_str_new(fcn->name) : rz_str_newf("virtual_%" PFMT64d, meth.vtable_offset);
+			//Temporarily set as attr name
+			meth.real_name = fcn ? rz_str_new(fcn->name) : rz_str_newf("virtual_%" PFMT64d, meth.vtable_offset);
+			meth.method_type = RZ_ANALYSIS_CLASS_METHOD_VIRTUAL;
+		} else {
+			RzAnalysisMethod exist_meth;
+			if (rz_analysis_class_method_get_by_addr(context->analysis, class_name, vmeth->addr, &exist_meth) == RZ_ANALYSIS_CLASS_ERR_SUCCESS) {
+				meth.addr = vmeth->addr;
+				meth.name = rz_str_new(exist_meth.name);
+				meth.real_name = rz_str_new(exist_meth.real_name);
+				meth.vtable_offset = vmeth->vtable_offset;
+				meth.method_type = RZ_ANALYSIS_CLASS_METHOD_VIRTUAL;
+				rz_analysis_class_method_delete(context->analysis, class_name, exist_meth.name);
+				rz_analysis_class_method_fini(&exist_meth);
+			}
+		}
 		rz_analysis_class_method_set(context->analysis, class_name, &meth);
 		rz_analysis_class_method_fini(&meth);
 	}

--- a/librz/analysis/rtti_msvc.c
+++ b/librz/analysis/rtti_msvc.c
@@ -845,7 +845,6 @@ static void recovery_apply_vtable(RzAnalysis *analysis, const char *class_name, 
 				meth.real_name = rz_str_new(exist_meth.real_name);
 				meth.vtable_offset = vmeth->vtable_offset;
 				meth.method_type = RZ_ANALYSIS_CLASS_METHOD_VIRTUAL;
-				rz_analysis_class_method_delete(analysis, class_name, exist_meth.name);
 				rz_analysis_class_method_fini(&exist_meth);
 			}
 		}

--- a/librz/analysis/rtti_msvc.c
+++ b/librz/analysis/rtti_msvc.c
@@ -829,9 +829,26 @@ static void recovery_apply_vtable(RzAnalysis *analysis, const char *class_name, 
 	RVTableMethodInfo *vmeth;
 	rz_vector_foreach(&vtable_info->methods, vmeth) {
 		RzAnalysisMethod meth;
-		meth.addr = vmeth->addr;
-		meth.vtable_offset = vmeth->vtable_offset;
-		meth.name = rz_str_newf("virtual_%" PFMT64d, meth.vtable_offset);
+		if (!rz_analysis_class_method_exists_by_addr(analysis, class_name, vmeth->addr)) {
+			meth.addr = vmeth->addr;
+			meth.vtable_offset = vmeth->vtable_offset;
+			RzAnalysisFunction *fcn = rz_analysis_get_function_at(analysis, vmeth->addr);
+			meth.name = fcn ? rz_str_new(fcn->name) : rz_str_newf("virtual_%" PFMT64d, meth.vtable_offset);
+			//Temporarily set as attr name
+			meth.real_name = fcn ? rz_str_new(fcn->name) : rz_str_newf("virtual_%" PFMT64d, meth.vtable_offset);
+			meth.method_type = RZ_ANALYSIS_CLASS_METHOD_VIRTUAL;
+		} else {
+			RzAnalysisMethod exist_meth;
+			if (rz_analysis_class_method_get_by_addr(analysis, class_name, vmeth->addr, &exist_meth) == RZ_ANALYSIS_CLASS_ERR_SUCCESS) {
+				meth.addr = vmeth->addr;
+				meth.name = rz_str_new(exist_meth.name);
+				meth.real_name = rz_str_new(exist_meth.real_name);
+				meth.vtable_offset = vmeth->vtable_offset;
+				meth.method_type = RZ_ANALYSIS_CLASS_METHOD_VIRTUAL;
+				rz_analysis_class_method_delete(analysis, class_name, exist_meth.name);
+				rz_analysis_class_method_fini(&exist_meth);
+			}
+		}
 		rz_analysis_class_method_set(analysis, class_name, &meth);
 		rz_analysis_class_method_fini(&meth);
 	}

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -7062,8 +7062,8 @@ RZ_IPI bool rz_core_analysis_everything(RzCore *core, bool experimental, char *d
 		cmd_analysis_objc(core, true);
 	}
 	rz_core_task_yield(&core->tasks);
-	oldstr = rz_print_rowlog(core->print, "Check for vtables");
-	rz_analysis_rtti_recover_all(core->analysis);
+	oldstr = rz_print_rowlog(core->print, "Check for classes");
+	rz_analysis_class_recover_all(core->analysis);
 	rz_print_rowlog_done(core->print, oldstr);
 	rz_core_task_yield(&core->tasks);
 	rz_config_set_i(core->config, "analysis.calls", c);

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -8392,6 +8392,8 @@ static void cmd_analysis_class_method(RzCore *core, const char *input) {
 
 			RzAnalysisMethod meth;
 			meth.name = name_str;
+			meth.real_name = rz_str_new(name_str);
+			meth.method_type = RZ_ANALYSIS_CLASS_METHOD_DEFAULT;
 			meth.addr = rz_num_get(core->num, addr_str);
 			meth.vtable_offset = -1;
 			if (end) {

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1971,10 +1971,20 @@ RZ_API RzList *rz_analysis_preludes(RzAnalysis *analysis);
 RZ_API bool rz_analysis_is_prelude(RzAnalysis *analysis, const ut8 *data, int len);
 
 /* classes */
+typedef enum {
+	RZ_ANALYSIS_CLASS_METHOD_DEFAULT = 0,
+	RZ_ANALYSIS_CLASS_METHOD_VIRTUAL,
+	RZ_ANALYSIS_CLASS_METHOD_VIRTUAL_DESTRUCTOR,
+	RZ_ANALYSIS_CLASS_METHOD_DESTRUCTOR,
+	RZ_ANALYSIS_CLASS_METHOD_CONSTRUCTOR
+} RzAnalysisMethodType;
+
 typedef struct rz_analysis_method_t {
 	char *name;
+	char *real_name;
 	ut64 addr;
 	st64 vtable_offset; // >= 0 if method is virtual, else -1
+	RzAnalysisMethodType method_type;
 } RzAnalysisMethod;
 
 typedef struct rz_analysis_base_class_t {
@@ -1998,6 +2008,8 @@ typedef enum {
 	RZ_ANALYSIS_CLASS_ERR_OTHER
 } RzAnalysisClassErr;
 
+RZ_API void rz_analysis_class_recover_from_rzbin(RzAnalysis *analysis);
+RZ_API void rz_analysis_class_recover_all(RzAnalysis *analysis);
 RZ_API void rz_analysis_class_create(RzAnalysis *analysis, const char *name);
 RZ_API void rz_analysis_class_delete(RzAnalysis *analysis, const char *name);
 RZ_API bool rz_analysis_class_exists(RzAnalysis *analysis, const char *name);
@@ -2007,10 +2019,14 @@ RZ_API RzAnalysisClassErr rz_analysis_class_rename(RzAnalysis *analysis, const c
 
 RZ_API void rz_analysis_class_method_fini(RzAnalysisMethod *meth);
 RZ_API RzAnalysisClassErr rz_analysis_class_method_get(RzAnalysis *analysis, const char *class_name, const char *meth_name, RzAnalysisMethod *meth);
+RZ_API RzAnalysisClassErr rz_analysis_class_method_get_by_addr(RzAnalysis *analysis, const char *class_name, ut64 addr, RzAnalysisMethod *method);
 RZ_API RzVector /*<RzAnalysisMethod>*/ *rz_analysis_class_method_get_all(RzAnalysis *analysis, const char *class_name);
 RZ_API RzAnalysisClassErr rz_analysis_class_method_set(RzAnalysis *analysis, const char *class_name, RzAnalysisMethod *meth);
 RZ_API RzAnalysisClassErr rz_analysis_class_method_rename(RzAnalysis *analysis, const char *class_name, const char *old_meth_name, const char *new_meth_name);
 RZ_API RzAnalysisClassErr rz_analysis_class_method_delete(RzAnalysis *analysis, const char *class_name, const char *meth_name);
+RZ_API bool rz_analysis_class_method_exists(RzAnalysis *analysis, const char *class_name, const char *meth_name);
+RZ_API bool rz_analysis_class_method_exists_by_addr(RzAnalysis *analysis, const char *class_name, ut64 addr);
+RZ_API void rz_analysis_class_method_recover(RzAnalysis *analysis, RzBinClass *class, RzList *methods);
 
 RZ_API void rz_analysis_class_base_fini(RzAnalysisBaseClass *base);
 RZ_API RzAnalysisClassErr rz_analysis_class_base_get(RzAnalysis *analysis, const char *class_name, const char *base_id, RzAnalysisBaseClass *base);

--- a/test/db/cmd/bug_duplicate_vtables
+++ b/test/db/cmd/bug_duplicate_vtables
@@ -11,39 +11,75 @@ EOF
 EXPECT=<<EOF
 A
   (vtable at 0x400d28)
-  virtual_0 @ 0x400ac8 (vtable + 0x0)
-  virtual_8 @ 0x400af4 (vtable + 0x8)
+  A @ 0x400b36
+  greet @ 0x400ac8 (vtable + 0x0)
+  printValue @ 0x400af4 (vtable + 0x8)
 B: A
   (vtable at 0x400d08)
-  virtual_0 @ 0x400ac8 (vtable + 0x0)
-  virtual_8 @ 0x400b82 (vtable + 0x8)
+  B @ 0x400b4e
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
+  printValue @ 0x400b82 (vtable + 0x8)
 C: A
   (vtable at 0x400ce8)
-  virtual_0 @ 0x400ac8 (vtable + 0x0)
-  virtual_8 @ 0x400bf8 (vtable + 0x8)
+  C @ 0x400bc4
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
+  printValue @ 0x400bf8 (vtable + 0x8)
+std::basic_ostream_char__std::char_traits_char_____std::endl_char__std
+  char_traits<char> > @ 0x6012a8
+std::basic_ostream_char__std::char_traits_char_____std::operator____std
+  char_traits<char> > @ 0x601298
+std::ios_base::Init
+  Init @ 0x601278
+  ~Init @ 0x601290
+std::ostream
+  operator<< @ 0x6012a0
 A
   (vtable at 0x400d28)
-  virtual_0 @ 0x400ac8 (vtable + 0x0)
-  virtual_8 @ 0x400af4 (vtable + 0x8)
+  A @ 0x400b36
+  greet @ 0x400ac8 (vtable + 0x0)
+  printValue @ 0x400af4 (vtable + 0x8)
 B: A
   (vtable at 0x400d08)
-  virtual_0 @ 0x400ac8 (vtable + 0x0)
-  virtual_8 @ 0x400b82 (vtable + 0x8)
+  B @ 0x400b4e
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
+  printValue @ 0x400b82 (vtable + 0x8)
 C: A
   (vtable at 0x400ce8)
-  virtual_0 @ 0x400ac8 (vtable + 0x0)
-  virtual_8 @ 0x400bf8 (vtable + 0x8)
+  C @ 0x400bc4
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
+  printValue @ 0x400bf8 (vtable + 0x8)
+std::basic_ostream_char__std::char_traits_char_____std::endl_char__std
+  char_traits<char> > @ 0x6012a8
+std::basic_ostream_char__std::char_traits_char_____std::operator____std
+  char_traits<char> > @ 0x601298
+std::ios_base::Init
+  Init @ 0x601278
+  ~Init @ 0x601290
+std::ostream
+  operator<< @ 0x6012a0
 A
   (vtable at 0x400d28)
-  virtual_0 @ 0x400ac8 (vtable + 0x0)
-  virtual_8 @ 0x400af4 (vtable + 0x8)
+  A @ 0x400b36
+  greet @ 0x400ac8 (vtable + 0x0)
+  printValue @ 0x400af4 (vtable + 0x8)
 B: A
   (vtable at 0x400d08)
-  virtual_0 @ 0x400ac8 (vtable + 0x0)
-  virtual_8 @ 0x400b82 (vtable + 0x8)
+  B @ 0x400b4e
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
+  printValue @ 0x400b82 (vtable + 0x8)
 C: A
   (vtable at 0x400ce8)
-  virtual_0 @ 0x400ac8 (vtable + 0x0)
-  virtual_8 @ 0x400bf8 (vtable + 0x8)
+  C @ 0x400bc4
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
+  printValue @ 0x400bf8 (vtable + 0x8)
+std::basic_ostream_char__std::char_traits_char_____std::endl_char__std
+  char_traits<char> > @ 0x6012a8
+std::basic_ostream_char__std::char_traits_char_____std::operator____std
+  char_traits<char> > @ 0x601298
+std::ios_base::Init
+  Init @ 0x601278
+  ~Init @ 0x601290
+std::ostream
+  operator<< @ 0x6012a0
 EOF
 RUN

--- a/test/db/cmd/bug_duplicate_vtables
+++ b/test/db/cmd/bug_duplicate_vtables
@@ -11,19 +11,19 @@ EOF
 EXPECT=<<EOF
 A
   (vtable at 0x400d28)
-  A @ 0x400b36
   greet @ 0x400ac8 (vtable + 0x0)
   printValue @ 0x400af4 (vtable + 0x8)
+  A @ 0x400b36
 B: A
   (vtable at 0x400d08)
   B @ 0x400b4e
-  method.A.greet @ 0x400ac8 (vtable + 0x0)
   printValue @ 0x400b82 (vtable + 0x8)
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
 C: A
   (vtable at 0x400ce8)
   C @ 0x400bc4
-  method.A.greet @ 0x400ac8 (vtable + 0x0)
   printValue @ 0x400bf8 (vtable + 0x8)
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
 std::basic_ostream_char__std::char_traits_char_____std::endl_char__std
   char_traits<char> > @ 0x6012a8
 std::basic_ostream_char__std::char_traits_char_____std::operator____std
@@ -35,19 +35,19 @@ std::ostream
   operator<< @ 0x6012a0
 A
   (vtable at 0x400d28)
-  A @ 0x400b36
   greet @ 0x400ac8 (vtable + 0x0)
   printValue @ 0x400af4 (vtable + 0x8)
+  A @ 0x400b36
 B: A
   (vtable at 0x400d08)
   B @ 0x400b4e
-  method.A.greet @ 0x400ac8 (vtable + 0x0)
   printValue @ 0x400b82 (vtable + 0x8)
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
 C: A
   (vtable at 0x400ce8)
   C @ 0x400bc4
-  method.A.greet @ 0x400ac8 (vtable + 0x0)
   printValue @ 0x400bf8 (vtable + 0x8)
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
 std::basic_ostream_char__std::char_traits_char_____std::endl_char__std
   char_traits<char> > @ 0x6012a8
 std::basic_ostream_char__std::char_traits_char_____std::operator____std
@@ -59,19 +59,19 @@ std::ostream
   operator<< @ 0x6012a0
 A
   (vtable at 0x400d28)
-  A @ 0x400b36
   greet @ 0x400ac8 (vtable + 0x0)
   printValue @ 0x400af4 (vtable + 0x8)
+  A @ 0x400b36
 B: A
   (vtable at 0x400d08)
   B @ 0x400b4e
-  method.A.greet @ 0x400ac8 (vtable + 0x0)
   printValue @ 0x400b82 (vtable + 0x8)
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
 C: A
   (vtable at 0x400ce8)
   C @ 0x400bc4
-  method.A.greet @ 0x400ac8 (vtable + 0x0)
   printValue @ 0x400bf8 (vtable + 0x8)
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
 std::basic_ostream_char__std::char_traits_char_____std::endl_char__std
   char_traits<char> > @ 0x6012a8
 std::basic_ostream_char__std::char_traits_char_____std::operator____std

--- a/test/db/cmd/cmd_ac
+++ b/test/db/cmd/cmd_ac
@@ -31,7 +31,7 @@ Flatline
 Flatline=c
 -
 attr.Flatline.method=PrayerPosition
-attr.Flatline.method.PrayerPosition=4919,66
+attr.Flatline.method.PrayerPosition=4919,66,0,PrayerPosition
 attrtypes.Flatline=method
 0x00001337 0 method.Flatline.PrayerPosition
 EOF
@@ -70,8 +70,8 @@ Flatline
 Flatline=c
 -
 attr.Flatline.method=PrayerPosition,RemainIndoors
-attr.Flatline.method.PrayerPosition=4919,66
-attr.Flatline.method.RemainIndoors=3735928559,-1
+attr.Flatline.method.PrayerPosition=4919,66,0,PrayerPosition
+attr.Flatline.method.RemainIndoors=3735928559,-1,0,RemainIndoors
 attrtypes.Flatline=method
 0x00001337 0 method.Flatline.PrayerPosition
 0xdeadbeef 0 method.Flatline.RemainIndoors
@@ -81,7 +81,7 @@ Flatline
 Flatline=c
 -
 attr.Flatline.method=RemainIndoors
-attr.Flatline.method.RemainIndoors=3735928559,-1
+attr.Flatline.method.RemainIndoors=3735928559,-1,0,RemainIndoors
 attrtypes.Flatline=method
 0xdeadbeef 0 method.Flatline.RemainIndoors
 --
@@ -115,7 +115,7 @@ Flatline
 Flatline=c
 -
 attr.Flatline.method=PrayerPosition
-attr.Flatline.method.PrayerPosition=4919,66
+attr.Flatline.method.PrayerPosition=4919,66,0,PrayerPosition
 attrtypes.Flatline=method
 0x00001337 0 method.Flatline.PrayerPosition
 --
@@ -124,7 +124,7 @@ Flatline
 Flatline=c
 -
 attr.Flatline.method=Marigold
-attr.Flatline.method.Marigold=4919,66
+attr.Flatline.method.Marigold=4919,66,0,Marigold
 attrtypes.Flatline=method
 0x00001337 0 method.Flatline.Marigold
 EOF
@@ -182,7 +182,7 @@ PeripheryAlbum=c
 attr.Flatline.base=0
 attr.Flatline.base.0=PeripheryAlbum,0
 attr.Flatline.method=PrayerPosition
-attr.Flatline.method.PrayerPosition=4919,66
+attr.Flatline.method.PrayerPosition=4919,66,0,PrayerPosition
 attr.Flatline.vtable=0
 attr.Flatline.vtable.0=0x1337,0,0
 attr.PeripheryAlbum.base=0
@@ -202,7 +202,7 @@ PeripheryAlbum=c
 attr.Flatline.base=0
 attr.Flatline.base.0=PeripheryAlbum,0
 attr.Flatline.method=PrayerPosition
-attr.Flatline.method.PrayerPosition=4919,66
+attr.Flatline.method.PrayerPosition=4919,66,0,PrayerPosition
 attr.Flatline.vtable=0
 attr.Flatline.vtable.0=0x1337,0,0
 attrtypes.Flatline=base,method,vtable
@@ -219,7 +219,7 @@ PeripheryAlbum=c
 attr.Flatline.base=0
 attr.Flatline.base.0=PeripheryAlbum,0
 attr.Flatline.method=PrayerPosition
-attr.Flatline.method.PrayerPosition=4919,66
+attr.Flatline.method.PrayerPosition=4919,66,0,PrayerPosition
 attr.Flatline.vtable=0
 attr.Flatline.vtable.0=0x1337,0,0
 attrtypes.Flatline=base,method,vtable
@@ -415,7 +415,7 @@ attr.Deadwing.base.0=PorcupineTreeAlbum,8
 attr.PorcupineTreeAlbum.base=0
 attr.PorcupineTreeAlbum.base.0=Album,0
 attr.PorcupineTreeAlbum.method=Listen
-attr.PorcupineTreeAlbum.method.Listen=3735928559,-1
+attr.PorcupineTreeAlbum.method.Listen=3735928559,-1,0,Listen
 attr.PorcupineTreeAlbum.vtable=0
 attr.PorcupineTreeAlbum.vtable.0=0x1337,66,0
 attrtypes.Deadwing=base
@@ -437,7 +437,7 @@ attr.Deadwing.base.0=Masterpiece,8
 attr.Masterpiece.base=0
 attr.Masterpiece.base.0=Album,0
 attr.Masterpiece.method=Listen
-attr.Masterpiece.method.Listen=3735928559,-1
+attr.Masterpiece.method.Listen=3735928559,-1,0,Listen
 attr.Masterpiece.vtable=0
 attr.Masterpiece.vtable.0=0x1337,66,0
 attrtypes.Deadwing=base

--- a/test/db/cmd/cmd_acll
+++ b/test/db/cmd/cmd_acll
@@ -1,0 +1,33 @@
+NAME=acll list class detailed
+FILE=bins/elf/analysis/elf-virtualtable
+CMDS=<<EOF
+aaa
+acll
+EOF
+EXPECT=<<EOF
+A
+  (vtable at 0x400d28)
+  A @ 0x400b36
+  greet @ 0x400ac8 (vtable + 0x0)
+  printValue @ 0x400af4 (vtable + 0x8)
+B: A
+  (vtable at 0x400d08)
+  B @ 0x400b4e
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
+  printValue @ 0x400b82 (vtable + 0x8)
+C: A
+  (vtable at 0x400ce8)
+  C @ 0x400bc4
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
+  printValue @ 0x400bf8 (vtable + 0x8)
+std::basic_ostream_char__std::char_traits_char_____std::endl_char__std
+  char_traits<char> > @ 0x6012a8
+std::basic_ostream_char__std::char_traits_char_____std::operator____std
+  char_traits<char> > @ 0x601298
+std::ios_base::Init
+  Init @ 0x601278
+  ~Init @ 0x601290
+std::ostream
+  operator<< @ 0x6012a0
+EOF
+RUN

--- a/test/db/cmd/cmd_acll
+++ b/test/db/cmd/cmd_acll
@@ -7,19 +7,19 @@ EOF
 EXPECT=<<EOF
 A
   (vtable at 0x400d28)
-  A @ 0x400b36
   greet @ 0x400ac8 (vtable + 0x0)
   printValue @ 0x400af4 (vtable + 0x8)
+  A @ 0x400b36
 B: A
   (vtable at 0x400d08)
   B @ 0x400b4e
-  method.A.greet @ 0x400ac8 (vtable + 0x0)
   printValue @ 0x400b82 (vtable + 0x8)
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
 C: A
   (vtable at 0x400ce8)
   C @ 0x400bc4
-  method.A.greet @ 0x400ac8 (vtable + 0x0)
   printValue @ 0x400bf8 (vtable + 0x8)
+  method.A.greet @ 0x400ac8 (vtable + 0x0)
 std::basic_ostream_char__std::char_traits_char_____std::endl_char__std
   char_traits<char> > @ 0x6012a8
 std::basic_ostream_char__std::char_traits_char_____std::operator____std

--- a/test/db/cmd/cmd_fnj
+++ b/test/db/cmd/cmd_fnj
@@ -2,8 +2,8 @@ NAME=fnj shows demangled symbols
 FILE=bins/elf/demangle-test-cpp
 CMDS=<<EOF
 aaa
-fj~{253}
-fnj~{253}
+fj~{254}
+fnj~{254}
 EOF
 EXPECT=<<EOF
 {"name":"reloc.operator_delete_void","realname":"reloc.operator delete(void*)","size":8,"offset":16432}

--- a/test/unit/test_serialize_analysis.c
+++ b/test/unit/test_serialize_analysis.c
@@ -1133,8 +1133,8 @@ Sdb *classes_ref_db() {
 	sdb_set(attrs_db, "attr.Bright.base", "0", 0);
 	sdb_set(attrs_db, "attr.Aeropause.vtable", "0", 0);
 	sdb_set(attrs_db, "attr.Bright.base.0", "Aeropause,8", 0);
-	sdb_set(attrs_db, "attr.Aeropause.method.some_meth", "4919,42", 0);
-	sdb_set(attrs_db, "attr.Aeropause.method.some_other_meth", "4660,32", 0);
+	sdb_set(attrs_db, "attr.Aeropause.method.some_meth", "4919,42,0,some_meth", 0);
+	sdb_set(attrs_db, "attr.Aeropause.method.some_other_meth", "4660,32,0,some_other_meth", 0);
 	return db;
 }
 
@@ -1145,7 +1145,9 @@ bool test_analysis_classes_save() {
 	RzAnalysisMethod crystal = {
 		.name = strdup("some_meth"),
 		.addr = 0x1337,
-		.vtable_offset = 42
+		.vtable_offset = 42,
+		.method_type = RZ_ANALYSIS_CLASS_METHOD_DEFAULT,
+		.real_name = strdup("some_meth")
 	};
 	rz_analysis_class_method_set(analysis, "Aeropause", &crystal);
 	rz_analysis_class_method_fini(&crystal);
@@ -1153,7 +1155,9 @@ bool test_analysis_classes_save() {
 	RzAnalysisMethod meth = {
 		.name = strdup("some_other_meth"),
 		.addr = 0x1234,
-		.vtable_offset = 0x20
+		.vtable_offset = 0x20,
+		.method_type = RZ_ANALYSIS_CLASS_METHOD_DEFAULT,
+		.real_name = strdup("some_other_meth")
 	};
 	rz_analysis_class_method_set(analysis, "Aeropause", &meth);
 	rz_analysis_class_method_fini(&meth);
@@ -1637,7 +1641,7 @@ Sdb *analysis_ref_db() {
 	Sdb *class_attrs = sdb_ns(classes, "attrs", true);
 	sdb_set(class_attrs, "attrtypes.Aeropause", "method", 0);
 	sdb_set(class_attrs, "attr.Aeropause.method", "some_meth", 0);
-	sdb_set(class_attrs, "attr.Aeropause.method.some_meth", "4919,42", 0);
+	sdb_set(class_attrs, "attr.Aeropause.method.some_meth", "4919,42,0,some_meth", 0);
 
 	Sdb *types = sdb_ns(db, "types", true);
 	sdb_set(types, "badchar", "type", 0);
@@ -1698,7 +1702,9 @@ bool test_analysis_save() {
 	RzAnalysisMethod crystal = {
 		.name = strdup("some_meth"),
 		.addr = 0x1337,
-		.vtable_offset = 42
+		.vtable_offset = 42,
+		.method_type = RZ_ANALYSIS_CLASS_METHOD_DEFAULT,
+		.real_name = strdup("some_meth")
 	};
 	rz_analysis_class_method_set(analysis, "Aeropause", &crystal);
 	rz_analysis_class_method_fini(&crystal);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Currently, `check for vtables` is a separate task for analyzing classes. This is not good for analyzing other information about the classes, and in my humble opinion, it should be a sub-task of `check for classes`.
The output of the `acll` command should currently look like this, which includes other member functions of the class instead of just the virtual functions.
```
A
  (vtable at 0x400d28)
  method_A_A @ 0x400b36
  method_A_greet @ 0x400ac8 (vtable + 0x0)
  method_A_printValue @ 0x400af4 (vtable + 0x8)
B: A
  (vtable at 0x400d08)
  method_B_B_int @ 0x400b4e
  method_A_greet @ 0x400ac8 (vtable + 0x0)
  method_B_printValue @ 0x400b82 (vtable + 0x8)
C: A
  (vtable at 0x400ce8)
  method_C_C_int @ 0x400bc4
  method_A_greet @ 0x400ac8 (vtable + 0x0)
  method_C_printValue @ 0x400bf8 (vtable + 0x8)
std::basic_ostream_char__std::char_traits_char_____std::endl_char__std
  char_traits_char____std::basic_ostream_char__std::char_traits_char_____ @ 0x6012a8
std::basic_ostream_char__std::char_traits_char_____std::operator____std
  char_traits_char____std::basic_ostream_char__std::char_traits_char______char_const__ @ 0x601298
std::ios_base::Init
  Init__ @ 0x601278
  _Init__ @ 0x601290
std::ostream
  operator___int_ @ 0x601268
  operator___std::ostream______std::ostream___ @ 0x6012a0
```
One problem is that the function name of the class obtained from `rz-bin` contains `()~,`etc., such as `set_value(int, int)`, which causes the special symbols to be escaped to `_` after `rz_analysis_class_method_set`, which is hard to see in the output of `acll`, how can I just get its function name without other symbols?

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
