### PR TITLE
Refactor to use more API in various commands and improve code quality

### DIFF
--- a/binrz/preload/librz2.c
+++ b/binrz/preload/librz2.c
@@ -32,7 +32,7 @@ static void sigusr1(int s) {
 
 static void sigusr2(int s) {
 	(void)openself();
-	rz_core_cmd0(core, "=H&");
+	rz_equal_H_handler_old(core, "&");
 }
 
 static void _libwrap_init() __attribute__((constructor));
@@ -47,7 +47,7 @@ static void _libwrap_init(void) {
 	core = rz_core_new();
 	rz_core_loadlibs(core, RZ_CORE_LOADLIBS_ALL, NULL);
 	if (web) {
-		rz_core_cmd0(core, "=H&");
+		rz_equal_H_handler_old(core, "&");
 		rz_sys_setenv("RZ_RUN_WEB", NULL);
 		free(web);
 	}

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -460,7 +460,7 @@ static bool cb_scrrainbow(void *user, void *data) {
 		rz_cons_pal_random();
 	} else {
 		core->print->flags &= (~RZ_PRINT_FLAGS_RAINBOW);
-		rz_core_cmd0(core, "ecoo");
+		rz_core_load_theme(core, rz_core_get_theme());
 	}
 	rz_print_set_flags(core->print, core->print->flags);
 	return true;

--- a/librz/core/cmd.c
+++ b/librz/core/cmd.c
@@ -748,7 +748,7 @@ RZ_API bool rz_core_run_script(RzCore *core, const char *file) {
 		char *absfile = rz_file_abspath(file);
 		rz_config_set(core->config, "http.index", absfile);
 		free(absfile);
-		rz_core_cmdf(core, "=H");
+		rz_equal_H_handler_old(core, "");
 		rz_config_set(core->config, "http.index", httpIndex);
 		free(httpIndex);
 		ret = true;

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -4846,6 +4846,7 @@ static void __core_analysis_appcall(RzCore *core, const char *input) {
 
 	rz_reg_setv(core->analysis->reg, "PC", core->offset);
 	rz_core_esil_step(core, 0, NULL, NULL, false);
+	rz_core_regs2flags(core);
 
 	rz_reg_setv(core->analysis->reg, "SP", sp);
 	free(inp);

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -4845,7 +4845,7 @@ static void __core_analysis_appcall(RzCore *core, const char *input) {
 	rz_reg_setv(core->analysis->reg, "SP", 0);
 
 	rz_reg_setv(core->analysis->reg, "PC", core->offset);
-	rz_core_cmd0(core, "aesu 0");
+	rz_core_esil_step(core, 0, NULL, NULL, false);
 
 	rz_reg_setv(core->analysis->reg, "SP", sp);
 	free(inp);

--- a/librz/core/cmd_flag.c
+++ b/librz/core/cmd_flag.c
@@ -103,6 +103,18 @@ static const char *help_msg_fz[] = {
 	NULL
 };
 
+static const char *help_msg_ft[] = {
+	"Usage: ft", "[?ln] [k] [v ...]", " # Flag tags",
+	"ft", " tag strcpy strlen ...", "set words for the 'string' tag",
+	"ft", " tag", "get offsets of all matching flags",
+	"ft", "", "list all tags",
+	"ftn", " tag", "get matching flagnames fot given tag",
+	"ftw", "", "flag tags within this file",
+	"ftj", "", "list all flagtags in JSON format",
+	"ft*", "", "list all flagtags in rizin commands",
+	NULL
+};
+
 static bool listFlag(RzFlagItem *flag, void *user) {
 	rz_list_append(user, flag);
 	return true;
@@ -523,14 +535,7 @@ static void cmd_flag_tags(RzCore *core, const char *input) {
 		return;
 	}
 	if (mode == '?') {
-		eprintf("Usage: ft[?ln] [k] [v ...]\n");
-		eprintf(" ft tag strcpy strlen ... # set words for the 'string' tag\n");
-		eprintf(" ft tag                   # get offsets of all matching flags\n");
-		eprintf(" ft                       # list all tags\n");
-		eprintf(" ftn tag                  # get matching flagnames fot given tag\n");
-		eprintf(" ftw                      # flag tags within this file\n");
-		eprintf(" ftj                      # list all flagtags in JSON format\n");
-		eprintf(" ft*                      # list all flagtags in rizin commands\n");
+		rz_core_cmd_help(core, help_msg_ft);
 		free(inp);
 		return;
 	}
@@ -546,7 +551,7 @@ static void cmd_flag_tags(RzCore *core, const char *input) {
 		free(inp);
 		return;
 	}
-	if (mode == '*') {
+	if (mode == '*') { // "ft*"
 		RzListIter *iter;
 		const char *tag;
 		RzList *list = rz_flag_tags_list(core->flags, NULL);

--- a/librz/core/panels.c
+++ b/librz/core/panels.c
@@ -5997,7 +5997,7 @@ RZ_API bool rz_core_visual_panels_root(RzCore *core, RzPanelsRoot *panels_root) 
 	}
 	rz_cons_enable_mouse(false);
 	if (fromVisual) {
-		rz_core_cmdf(core, "V");
+		rz_core_visual(core, "");
 	}
 	return true;
 }

--- a/librz/core/vmenus.c
+++ b/librz/core/vmenus.c
@@ -1707,7 +1707,7 @@ RZ_API int rz_core_visual_view_rop(RzCore *core) {
 			rz_cons_show_cursor(false);
 			break;
 		case 'y':
-			rz_core_cmdf(core, "yfx %s", chainstr);
+			rz_core_yank_hexpair(core, chainstr);
 			break;
 		case 'o': {
 			rz_line_set_prompt("offset: ");

--- a/librz/util/print_code.c
+++ b/librz/util/print_code.c
@@ -240,8 +240,7 @@ RZ_API void rz_print_code(RzPrint *p, ut64 addr, const ut8 *buf, int len, char l
 			rz_print_cursor(p, i, 1, 0);
 		}
 		pj_end(pj);
-		p->cb_printf(pj_string(pj));
-		p->cb_printf("\n");
+		p->cb_printf("%s\n", pj_string(pj));
 		pj_free(pj);
 	} break;
 	case 'P':

--- a/librz/util/print_code.c
+++ b/librz/util/print_code.c
@@ -231,15 +231,19 @@ RZ_API void rz_print_code(RzPrint *p, ut64 addr, const ut8 *buf, int len, char l
 		}
 		p->cb_printf(" }\n");
 		break;
-	case 'j': // "pcj"
-		p->cb_printf("[");
+	case 'j': { // "pcj"
+		PJ *pj = pj_new();
+		pj_a(pj);
 		for (i = 0; !rz_print_is_interrupted() && i < len; i++) {
 			rz_print_cursor(p, i, 1, 1);
-			p->cb_printf("%d%s", buf[i], (i + 1 < len) ? "," : "");
+			pj_i(pj, buf[i]);
 			rz_print_cursor(p, i, 1, 0);
 		}
-		p->cb_printf("]\n");
-		break;
+		pj_end(pj);
+		p->cb_printf(pj_string(pj));
+		p->cb_printf("\n");
+		pj_free(pj);
+	} break;
 	case 'P':
 	case 'p': // "pcp" "pcP"
 		p->cb_printf("import struct\nbuf = struct.pack (\"%dB\", *[", len);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This PR brings some `rz_core_cmd0` replacements across the codebase and a little bit of code quality improvements.
* Use `rz_core_cmd_help` for `ft`
`ft?` had just been `eprintf`-ing the help messages.

* Handle all the cases of `=H&` and `=H`  calls.
Used `rz_equal_H_handler_old()` for that. Needs a bit of review on that as well as one case where I refactored a call to `aesu`

* Used PJ in `pcj`
  
**Test plan**

* Use PJ in `pcj`
`pcj` has tests. So, if that succeeds, that one will be in good spirits.


**Closing issues**

Partially related with #491 
