### PR TITLE
Pyc plugin segment fault fix and add tests

### DIFF
--- a/librz/analysis/analysis.c
+++ b/librz/analysis/analysis.c
@@ -144,14 +144,10 @@ RZ_API RzAnalysis *rz_analysis_new(void) {
 
 RZ_API void plugin_fini(RzAnalysis *analysis) {
 	RzAnalysisPlugin *p = analysis->cur;
-	if (p && p->fini) {
-		if (p->fini(analysis->plugin_data)) {
-			analysis->plugin_data = NULL;
-			return;
-		} else {
-			RZ_LOG_ERROR("analysis plugin '%s' failed to terminate.\n", p->name);
-		}
+	if (p && p->fini && !p->fini(analysis->plugin_data)) {
+		RZ_LOG_ERROR("analysis plugin '%s' failed to terminate.\n", p->name);
 	}
+        analysis->plugin_data = NULL;
 }
 
 void __block_free_rb(RBNode *node, void *user);

--- a/librz/analysis/analysis.c
+++ b/librz/analysis/analysis.c
@@ -144,8 +144,13 @@ RZ_API RzAnalysis *rz_analysis_new(void) {
 
 RZ_API void plugin_fini(RzAnalysis *analysis) {
 	RzAnalysisPlugin *p = analysis->cur;
-	if (p && p->fini && !p->fini(analysis->plugin_data)) {
-		RZ_LOG_ERROR("analysis plugin '%s' failed to terminate.\n", p->name);
+	if (p && p->fini) {
+		if (p->fini(analysis->plugin_data)){
+			analysis->plugin_data = NULL;
+			return;
+		} else {
+                        RZ_LOG_ERROR("analysis plugin '%s' failed to terminate.\n", p->name);
+		}
 	}
 }
 

--- a/librz/analysis/analysis.c
+++ b/librz/analysis/analysis.c
@@ -147,7 +147,7 @@ RZ_API void plugin_fini(RzAnalysis *analysis) {
 	if (p && p->fini && !p->fini(analysis->plugin_data)) {
 		RZ_LOG_ERROR("analysis plugin '%s' failed to terminate.\n", p->name);
 	}
-        analysis->plugin_data = NULL;
+	analysis->plugin_data = NULL;
 }
 
 void __block_free_rb(RBNode *node, void *user);

--- a/librz/analysis/analysis.c
+++ b/librz/analysis/analysis.c
@@ -145,11 +145,11 @@ RZ_API RzAnalysis *rz_analysis_new(void) {
 RZ_API void plugin_fini(RzAnalysis *analysis) {
 	RzAnalysisPlugin *p = analysis->cur;
 	if (p && p->fini) {
-		if (p->fini(analysis->plugin_data)){
+		if (p->fini(analysis->plugin_data)) {
 			analysis->plugin_data = NULL;
 			return;
 		} else {
-                        RZ_LOG_ERROR("analysis plugin '%s' failed to terminate.\n", p->name);
+			RZ_LOG_ERROR("analysis plugin '%s' failed to terminate.\n", p->name);
 		}
 	}
 }

--- a/librz/analysis/p/analysis_pyc.c
+++ b/librz/analysis/p/analysis_pyc.c
@@ -128,9 +128,6 @@ analysis_end:
 }
 
 static bool finish(void *user) {
-	if (user == NULL) {
-		return true;
-	}
 	pyc_opcodes *ops = (user);
 	free_opcode(ops);
 	return true;

--- a/librz/analysis/p/analysis_pyc.c
+++ b/librz/analysis/p/analysis_pyc.c
@@ -128,7 +128,9 @@ analysis_end:
 }
 
 static bool finish(void *user) {
-	rz_return_val_if_fail(user, false);
+	if (user == NULL) {
+		return true;
+	}
 	pyc_opcodes *ops = (user);
 	free_opcode(ops);
 	return true;

--- a/librz/asm/arch/pyc/opcode.c
+++ b/librz/asm/arch/pyc/opcode.c
@@ -127,6 +127,9 @@ static version_opcode version_op[] = {
 };
 
 bool pyc_opcodes_equal(pyc_opcodes *op, const char *version) {
+	if (version == NULL){
+		return NULL;
+	}
 	version_opcode *vop = version_op;
 
 	while (vop->version) {
@@ -142,11 +145,10 @@ bool pyc_opcodes_equal(pyc_opcodes *op, const char *version) {
 }
 
 pyc_opcodes *get_opcode_by_version(char *version) {
+        if (version == NULL){
+                return NULL;
+        }
 	version_opcode *vop = version_op;
-	if (version == NULL){
-		eprintf("[x]Require Python Version Info. Please Use rizin instead of rz-asm\n");
-		return NULL;
-	}
 
 	while (vop->version) {
 		if (!strcmp(vop->version, version)) {

--- a/librz/asm/arch/pyc/opcode.c
+++ b/librz/asm/arch/pyc/opcode.c
@@ -127,7 +127,7 @@ static version_opcode version_op[] = {
 };
 
 bool pyc_opcodes_equal(pyc_opcodes *op, const char *version) {
-	if (version == NULL){
+	if (version == NULL) {
 		return NULL;
 	}
 	version_opcode *vop = version_op;
@@ -145,9 +145,9 @@ bool pyc_opcodes_equal(pyc_opcodes *op, const char *version) {
 }
 
 pyc_opcodes *get_opcode_by_version(char *version) {
-        if (version == NULL){
-                return NULL;
-        }
+	if (version == NULL) {
+		return NULL;
+	}
 	version_opcode *vop = version_op;
 
 	while (vop->version) {

--- a/librz/asm/arch/pyc/opcode.c
+++ b/librz/asm/arch/pyc/opcode.c
@@ -195,11 +195,13 @@ pyc_opcodes *new_pyc_opcodes() {
 void free_opcode(pyc_opcodes *opcodes) {
 	size_t i;
 	for (i = 0; i < 256; i++) {
-		free(opcodes->opcodes[i].op_name);
+		if (opcodes->opcodes && opcodes->opcodes[i].op_name) {
+                        free(opcodes->opcodes[i].op_name);
+                }
 	}
 	free(opcodes->opcodes);
 	rz_list_free(opcodes->opcode_arg_fmt);
-	free(opcodes);
+	// free(opcodes);
 }
 
 void add_arg_fmt(pyc_opcodes *ret, char *op_name, const char *(*formatter)(ut32 oparg)) {

--- a/librz/asm/arch/pyc/opcode.c
+++ b/librz/asm/arch/pyc/opcode.c
@@ -127,8 +127,8 @@ static version_opcode version_op[] = {
 };
 
 bool pyc_opcodes_equal(pyc_opcodes *op, const char *version) {
-	if (version == NULL) {
-		return NULL;
+	if (version == NULL || op == NULL) {
+		return false;
 	}
 	version_opcode *vop = version_op;
 
@@ -194,14 +194,19 @@ pyc_opcodes *new_pyc_opcodes() {
 
 void free_opcode(pyc_opcodes *opcodes) {
 	size_t i;
+	if (opcodes == NULL || opcodes->opcodes == NULL){
+		return;
+	}
 	for (i = 0; i < 256; i++) {
-		if (opcodes->opcodes && opcodes->opcodes[i].op_name) {
+		if (opcodes->opcodes[i].op_name) {
                         free(opcodes->opcodes[i].op_name);
                 }
 	}
 	free(opcodes->opcodes);
-	rz_list_free(opcodes->opcode_arg_fmt);
-	// free(opcodes);
+	if (opcodes->opcode_arg_fmt){
+                rz_list_free(opcodes->opcode_arg_fmt);
+        }
+	free(opcodes);
 }
 
 void add_arg_fmt(pyc_opcodes *ret, char *op_name, const char *(*formatter)(ut32 oparg)) {

--- a/librz/asm/arch/pyc/opcode.c
+++ b/librz/asm/arch/pyc/opcode.c
@@ -143,6 +143,10 @@ bool pyc_opcodes_equal(pyc_opcodes *op, const char *version) {
 
 pyc_opcodes *get_opcode_by_version(char *version) {
 	version_opcode *vop = version_op;
+	if (version == NULL){
+		eprintf("[x]Require Python Version Info. Please Use rizin instead of rz-asm\n");
+		return NULL;
+	}
 
 	while (vop->version) {
 		if (!strcmp(vop->version, version)) {

--- a/librz/asm/arch/pyc/opcode.c
+++ b/librz/asm/arch/pyc/opcode.c
@@ -194,18 +194,18 @@ pyc_opcodes *new_pyc_opcodes() {
 
 void free_opcode(pyc_opcodes *opcodes) {
 	size_t i;
-	if (opcodes == NULL || opcodes->opcodes == NULL){
+	if (opcodes == NULL || opcodes->opcodes == NULL) {
 		return;
 	}
 	for (i = 0; i < 256; i++) {
 		if (opcodes->opcodes[i].op_name) {
-                        free(opcodes->opcodes[i].op_name);
-                }
+			free(opcodes->opcodes[i].op_name);
+		}
 	}
 	free(opcodes->opcodes);
-	if (opcodes->opcode_arg_fmt){
-                rz_list_free(opcodes->opcode_arg_fmt);
-        }
+	if (opcodes->opcode_arg_fmt) {
+		rz_list_free(opcodes->opcode_arg_fmt);
+	}
 	free(opcodes);
 }
 

--- a/librz/asm/p/asm_pyc.c
+++ b/librz/asm/p/asm_pyc.c
@@ -36,14 +36,14 @@ static int disassemble(RzAsm *a, RzAsmOp *opstruct, const ut8 *buf, int len) {
 	if (!opcodes_cache || !pyc_opcodes_equal(opcodes_cache, a->cpu)) {
 		opcodes_cache = get_opcode_by_version(a->cpu);
 		if (opcodes_cache == NULL){
-			opstruct->size = len;
+			eprintf("[x]Require Info from code object, use rizin instead\n");
 			return len;
 		}
 		opcodes_cache->bits = a->bits;
 	}
 	int r = rz_pyc_disasm(opstruct, buf, cobjs, interned_table, pc, opcodes_cache);
 	opstruct->size = r;
-	return r;
+        return r;
 }
 
 static bool finish(void *user) {

--- a/librz/asm/p/asm_pyc.c
+++ b/librz/asm/p/asm_pyc.c
@@ -25,17 +25,17 @@ static int disassemble(RzAsm *a, RzAsmOp *opstruct, const ut8 *buf, int len) {
 		}
 	}
 
-        RzList *cobjs = NULL;
-        RzList *interned_table = NULL;
+	RzList *cobjs = NULL;
+	RzList *interned_table = NULL;
 
-        if (shared){
+	if (shared) {
 		cobjs = rz_list_get_n(shared, 0);
 		interned_table = rz_list_get_n(shared, 1);
 	}
 
 	if (!opcodes_cache || !pyc_opcodes_equal(opcodes_cache, a->cpu)) {
 		opcodes_cache = get_opcode_by_version(a->cpu);
-		if (opcodes_cache == NULL){
+		if (opcodes_cache == NULL) {
 			eprintf("[x]Require Info from code object, use rizin instead\n");
 			return len;
 		}
@@ -43,7 +43,7 @@ static int disassemble(RzAsm *a, RzAsmOp *opstruct, const ut8 *buf, int len) {
 	}
 	int r = rz_pyc_disasm(opstruct, buf, cobjs, interned_table, pc, opcodes_cache);
 	opstruct->size = r;
-        return r;
+	return r;
 }
 
 static bool finish(void *user) {

--- a/librz/asm/p/asm_pyc.c
+++ b/librz/asm/p/asm_pyc.c
@@ -24,10 +24,21 @@ static int disassemble(RzAsm *a, RzAsmOp *opstruct, const ut8 *buf, int len) {
 			shared = bin->cur->o->bin_obj;
 		}
 	}
-	RzList *cobjs = rz_list_get_n(shared, 0);
-	RzList *interned_table = rz_list_get_n(shared, 1);
+
+        RzList *cobjs = NULL;
+        RzList *interned_table = NULL;
+
+        if (shared){
+		cobjs = rz_list_get_n(shared, 0);
+		interned_table = rz_list_get_n(shared, 1);
+	}
+
 	if (!opcodes_cache || !pyc_opcodes_equal(opcodes_cache, a->cpu)) {
 		opcodes_cache = get_opcode_by_version(a->cpu);
+		if (opcodes_cache == NULL){
+			opstruct->size = len;
+			return len;
+		}
 		opcodes_cache->bits = a->bits;
 	}
 	int r = rz_pyc_disasm(opstruct, buf, cobjs, interned_table, pc, opcodes_cache);

--- a/test/db/formats/pyc
+++ b/test/db/formats/pyc
@@ -1,0 +1,82 @@
+NAME=pyc load version39
+FILE=bins/py39.pyc
+CMDS=iI~machine
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=pyc load version38
+FILE=bins/py38.pyc
+CMDS=iI~machine
+EXPECT=<<EOF
+machine  Python v3.8.0 VM (rev 5d714034866ce1e9f89dc141fe4cc0b50cf20a8e)
+EOF
+RUN
+
+NAME=pyc load version37
+FILE=bins/py37.pyc
+CMDS=iI~machine
+EXPECT=<<EOF
+machine  Python v3.7.0 VM (rev ae1f6af15f3e4110616801e235873e47fd7d1977)
+EOF
+RUN
+
+NAME=pyc load version36
+FILE=bins/py36.pyc
+CMDS=iI~machine
+EXPECT=<<EOF
+machine  Python v3.6.0 VM (rev 5c4568a05a0a62b5947c55f68f9f2ecfb90a4f12)
+EOF
+RUN
+
+NAME=pyc symbols
+FILE=bins/py37.pyc
+CMDS=is~?Human
+EXPECT=<<EOF
+9
+EOF
+RUN
+
+NAME=pyc sections
+FILE=bins/py37.pyc
+CMDS=iS~Bat
+EXPECT=<<EOF
+30  0x00001f0d   0x2a 0x00001f0d   0x2a ---- module_.Bat
+31  0x00001f5f    0xa 0x00001f5f    0xa ---- module_.Bat.__init
+32  0x00001fca    0x8 0x00001fca    0x8 ---- module_.Bat.say
+33  0x00002037    0x4 0x00002037    0x4 ---- module_.Bat.sonar
+34  0x00002103   0x1c 0x00002103   0x1c ---- module_.Batman
+35  0x00002143   0x44 0x00002143   0x44 ---- module_.Batman.__init
+36  0x00002235    0x4 0x00002235    0x4 ---- module_.Batman.sing
+EOF
+RUN
+
+NAME=pyc entry
+FILE=bins/py37.pyc
+CMDS=ie~program
+EXPECT=<<EOF
+vaddr=0x0000002a paddr=0x0000002a haddr=-1 type=program
+EOF
+RUN
+
+NAME=pyc disasm
+FILE=bins/py37.pyc
+CMDS=pd 10
+EXPECT=<<EOF
+            ;-- entry0:
+            ;-- section.module:
+            ;-- <module>:
+            0x0000002a      LOAD_CONST Multiline strings can be written
+    using three "s, and are often used
+    as documentation. ; [00] ---- section size 3218 named module
+            0x0000002c      STORE_NAME             __doc__
+            0x0000002e      LOAD_CONST                True
+        ,=< 0x00000030      JUMP_IF_FALSE_OR_POP                  10
+        |   0x00000032      LOAD_CONST               False
+        `-> 0x00000034      POP_TOP
+            0x00000036      LOAD_CONST               False
+        ,=< 0x00000038      JUMP_IF_TRUE_OR_POP                  18
+        |   0x0000003a      LOAD_CONST                True
+        `-> 0x0000003c      POP_TOP
+EOF
+RUN

--- a/test/db/formats/pyc
+++ b/test/db/formats/pyc
@@ -1,45 +1,57 @@
 NAME=pyc load version39
-FILE=bins/py39.pyc
-CMDS=iI~machine
+FILE=bins/pyc/py39.pyc
+CMDS=<<EOF
+iI~machine
+EOF
 EXPECT=<<EOF
 EOF
 RUN
 
 NAME=pyc load version38
-FILE=bins/py38.pyc
-CMDS=iI~machine
+FILE=bins/pyc/py38.pyc
+CMDS=<<EOF
+iI~machine
+EOF
 EXPECT=<<EOF
 machine  Python v3.8.0 VM (rev 5d714034866ce1e9f89dc141fe4cc0b50cf20a8e)
 EOF
 RUN
 
 NAME=pyc load version37
-FILE=bins/py37.pyc
-CMDS=iI~machine
+FILE=bins/pyc/py37.pyc
+CMDS=<<EOF
+iI~machine
+EOF
 EXPECT=<<EOF
 machine  Python v3.7.0 VM (rev ae1f6af15f3e4110616801e235873e47fd7d1977)
 EOF
 RUN
 
 NAME=pyc load version36
-FILE=bins/py36.pyc
-CMDS=iI~machine
+FILE=bins/pyc/py36.pyc
+CMDS=<<EOF
+iI~machine
+EOF
 EXPECT=<<EOF
 machine  Python v3.6.0 VM (rev 5c4568a05a0a62b5947c55f68f9f2ecfb90a4f12)
 EOF
 RUN
 
 NAME=pyc symbols
-FILE=bins/py37.pyc
-CMDS=is~?Human
+FILE=bins/pyc/py37.pyc
+CMDS=<<EOF
+is~?Human
+EOF
 EXPECT=<<EOF
 9
 EOF
 RUN
 
 NAME=pyc sections
-FILE=bins/py37.pyc
-CMDS=iS~Bat
+FILE=bins/pyc/py37.pyc
+CMDS=<<EOF
+iS~Bat
+EOF
 EXPECT=<<EOF
 30  0x00001f0d   0x2a 0x00001f0d   0x2a ---- module_.Bat
 31  0x00001f5f    0xa 0x00001f5f    0xa ---- module_.Bat.__init
@@ -52,16 +64,20 @@ EOF
 RUN
 
 NAME=pyc entry
-FILE=bins/py37.pyc
-CMDS=ie~program
+FILE=bins/pyc/py37.pyc
+CMDS=<<EOF
+ie~program
+EOF
 EXPECT=<<EOF
 vaddr=0x0000002a paddr=0x0000002a haddr=-1 type=program
 EOF
 RUN
 
 NAME=pyc disasm
-FILE=bins/py37.pyc
-CMDS=pd 10
+FILE=bins/pyc/py37.pyc
+CMDS=<<EOF
+pd 10
+EOF
 EXPECT=<<EOF
             ;-- entry0:
             ;-- section.module:

--- a/test/db/formats/pyc
+++ b/test/db/formats/pyc
@@ -37,6 +37,16 @@ machine  Python v3.6.0 VM (rev 5c4568a05a0a62b5947c55f68f9f2ecfb90a4f12)
 EOF
 RUN
 
+NAME=pyc load version27
+FILE=bins/pyc/py27.pyc
+CMDS=<<EOF
+iI~machine
+EOF
+EXPECT=<<EOF
+machine  Python 2.7a2+ VM (rev edfed0e32cedf3b84c6e999052486a750a3f5bee)
+EOF
+RUN
+
 NAME=pyc symbols
 FILE=bins/pyc/py37.pyc
 CMDS=<<EOF
@@ -94,5 +104,62 @@ EXPECT=<<EOF
         ,=< 0x00000038      JUMP_IF_TRUE_OR_POP                  18
         |   0x0000003a      LOAD_CONST                True
         `-> 0x0000003c      POP_TOP
+EOF
+RUN
+
+NAME=pyc symbols for pyc2.7
+FILE=bins/pyc/py27.pyc
+CMDS=<<EOF
+is~hello_world
+EOF
+EXPECT=<<EOF
+1   0x00000052 0x00000052 NONE FUNC 9        <module>.hello_world
+EOF
+RUN
+
+NAME=pyc disasm for 2.7
+FILE=bins/pyc/py27.pyc
+CMDS=<<EOF
+pd 10
+EOF
+EXPECT=<<EOF
+            ;-- entry0:
+            ;-- section.module:
+            ;-- <module>:
+            0x0000001e      LOAD_CONSTCodeObject(hello_world) from hello.py ; [00] ---- section size 25 named module
+            0x00000021      MAKE_FUNCTION
+            0x00000024      STORE_NAME         hello_world
+            0x00000027      LOAD_CONST             'world'
+            0x0000002a      PRINT_ITEM
+            0x0000002b      PRINT_NEWLINE
+            0x0000002c      LOAD_NAME         hello_world
+            0x0000002f      CALL_FUNCTION0 positional, 0 named
+            0x00000032      POP_TOP
+            0x00000033      LOAD_CONST                None
+EOF
+RUN
+
+NAME=pyc function
+FILE=bins/pyc/py27.pyc
+CMDS=<<EOF
+aa
+e scr.utf8=false
+pdf
+EOF
+EXPECT=<<EOF
+            ;-- section.module:
+            ;-- <module>:
+/ entry0 ();
+|           0x0000001e      LOAD_CONSTCodeObject(hello_world) from hello.py ; [00] ---- section size 25 named module
+|           0x00000021      MAKE_FUNCTION
+|           0x00000024      STORE_NAME         hello_world
+|           0x00000027      LOAD_CONST             'world'
+|           0x0000002a      PRINT_ITEM
+|           0x0000002b      PRINT_NEWLINE
+|           0x0000002c      LOAD_NAME         hello_world
+|           0x0000002f      CALL_FUNCTION0 positional, 0 named
+|           0x00000032      POP_TOP
+|           0x00000033      LOAD_CONST                None
+\           0x00000036      RETURN_VALUE
 EOF
 RUN

--- a/test/db/formats/pyc
+++ b/test/db/formats/pyc
@@ -15,6 +15,12 @@ EOF
 EXPECT=<<EOF
 machine  Python v3.8.0 VM (rev 5d714034866ce1e9f89dc141fe4cc0b50cf20a8e)
 EOF
+REGEXP_FILTER_ERR=<<EOF
+free_object\ \(0\)
+EOF
+EXPECT_ERR=<<EOF
+free_object (0)
+EOF
 RUN
 
 NAME=pyc load version37
@@ -24,6 +30,12 @@ iI~machine
 EOF
 EXPECT=<<EOF
 machine  Python v3.7.0 VM (rev ae1f6af15f3e4110616801e235873e47fd7d1977)
+EOF
+REGEXP_FILTER_ERR=<<EOF
+free_object\ \(0\)
+EOF
+EXPECT_ERR=<<EOF
+free_object (0)
 EOF
 RUN
 
@@ -35,6 +47,12 @@ EOF
 EXPECT=<<EOF
 machine  Python v3.6.0 VM (rev 5c4568a05a0a62b5947c55f68f9f2ecfb90a4f12)
 EOF
+REGEXP_FILTER_ERR=<<EOF
+free_object\ \(0\)
+EOF
+EXPECT_ERR=<<EOF
+free_object (0)
+EOF
 RUN
 
 NAME=pyc load version27
@@ -45,6 +63,12 @@ EOF
 EXPECT=<<EOF
 machine  Python 2.7a2+ VM (rev edfed0e32cedf3b84c6e999052486a750a3f5bee)
 EOF
+REGEXP_FILTER_ERR=<<EOF
+free_object\ \(0\)
+EOF
+EXPECT_ERR=<<EOF
+free_object (0)
+EOF
 RUN
 
 NAME=pyc symbols
@@ -54,6 +78,12 @@ is~?Human
 EOF
 EXPECT=<<EOF
 9
+EOF
+REGEXP_FILTER_ERR=<<EOF
+free_object\ \(0\)
+EOF
+EXPECT_ERR=<<EOF
+free_object (0)
 EOF
 RUN
 
@@ -71,6 +101,12 @@ EXPECT=<<EOF
 35  0x00002143   0x44 0x00002143   0x44 ---- module_.Batman.__init
 36  0x00002235    0x4 0x00002235    0x4 ---- module_.Batman.sing
 EOF
+REGEXP_FILTER_ERR=<<EOF
+free_object\ \(0\)
+EOF
+EXPECT_ERR=<<EOF
+free_object (0)
+EOF
 RUN
 
 NAME=pyc entry
@@ -80,6 +116,12 @@ ie~program
 EOF
 EXPECT=<<EOF
 vaddr=0x0000002a paddr=0x0000002a haddr=-1 type=program
+EOF
+REGEXP_FILTER_ERR=<<EOF
+free_object\ \(0\)
+EOF
+EXPECT_ERR=<<EOF
+free_object (0)
 EOF
 RUN
 
@@ -105,6 +147,12 @@ EXPECT=<<EOF
         |   0x0000003a      LOAD_CONST                True
         `-> 0x0000003c      POP_TOP
 EOF
+REGEXP_FILTER_ERR=<<EOF
+free_object\ \(0\)
+EOF
+EXPECT_ERR=<<EOF
+free_object (0)
+EOF
 RUN
 
 NAME=pyc symbols for pyc2.7
@@ -114,6 +162,12 @@ is~hello_world
 EOF
 EXPECT=<<EOF
 1   0x00000052 0x00000052 NONE FUNC 9        <module>.hello_world
+EOF
+REGEXP_FILTER_ERR=<<EOF
+free_object\ \(0\)
+EOF
+EXPECT_ERR=<<EOF
+free_object (0)
 EOF
 RUN
 
@@ -136,6 +190,12 @@ EXPECT=<<EOF
             0x0000002f      CALL_FUNCTION0 positional, 0 named
             0x00000032      POP_TOP
             0x00000033      LOAD_CONST                None
+EOF
+REGEXP_FILTER_ERR=<<EOF
+free_object\ \(0\)
+EOF
+EXPECT_ERR=<<EOF
+free_object (0)
 EOF
 RUN
 
@@ -161,5 +221,11 @@ EXPECT=<<EOF
 |           0x00000032      POP_TOP
 |           0x00000033      LOAD_CONST                None
 \           0x00000036      RETURN_VALUE
+EOF
+REGEXP_FILTER_ERR=<<EOF
+free_object\ \(0\)
+EOF
+EXPECT_ERR=<<EOF
+free_object (0)
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This pr may close issue#803. The pyc asm plugin requires version info from `RzAsm a->cpu` (which is set in its bin plugin bin_pyc.c), but rz-asm don't have the concept about rz-bin's info, this value will be a NULL pointer. So this pr patches `get_opcode_by_version` and `get_opcodes_equal` in `asm/arch/pyc/opcode.c` to prevent segment fault.

Also, I added some command tests for pyc plugin

**Test plan**

No crash when run `rz-asm -a pyc -d 0x0000006a`

**Closing issues**

closes #803 #805 

**Addtional Info**
Originally I wanted to set a default version to solve this problem. But due to `rz_pyc_disasm` requires more than just version info from other plugins. I just simply put a NULL pointer check and error message there. The similar problem may occur in other formats whose opcodes are different from various versions. Maybe `rz-asm` can add a command line option to specify version in the future ?
