### PR TITLE
core/disasm: use bin section info instead of maps to show name/perm

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3074,7 +3074,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETBPREF("asm.section", "false", "Show section name before offset");
 	SETBPREF("asm.section.perm", "false", "Show section permissions in the disasm");
 	SETBPREF("asm.section.name", "true", "Show section name in the disasm");
-	SETI("asm.section.col", 20, "Columns width to show asm.section");
+	SETI("asm.section.col", 30, "Columns width to show asm.section");
 	SETCB("asm.sub.section", "false", &cb_asmsubsec, "Show offsets in disasm prefixed with section/map name");
 	SETCB("asm.pseudo", "false", &cb_asmpseudo, "Enable pseudo syntax");
 	SETBPREF("asm.size", "false", "Show size of opcodes in disassembly (pd)");

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -2657,13 +2657,20 @@ static void ds_print_lines_left(RDisasmState *ds) {
 	RzCore *core = ds->core;
 	if (ds->show_section) {
 		char *str = NULL;
-		if (ds->show_section_perm) {
-			// iosections must die, this should be rbin_section_get
-			RzIOMap *map = rz_io_map_get(core->io, ds->at);
-			str = strdup(map ? rz_str_rwx_i(map->perm) : "---");
+		if (ds->show_section_perm && core->bin && core->bin->cur) {
+			int va = rz_config_get_i(core->config, "io.va");
+			RzBinSection *sec = rz_bin_get_section_at(core->bin->cur->o, ds->at, va);
+			str = strdup(sec ? rz_str_rwx_i(sec->perm) : "---");
 		}
-		if (ds->show_section_name) {
-			str = rz_str_appendf(str, " %s", rz_core_get_section_name(core, ds->at));
+		if (ds->show_section_name && core->bin && core->bin->cur) {
+			int va = rz_config_get_i(core->config, "io.va");
+			RzBinSection *sec = rz_bin_get_section_at(core->bin->cur->o, ds->at, va);
+			if (sec) {
+				if (str) {
+					str = rz_str_append(str, " ");
+				}
+				str = rz_str_appendf(str, "%10.10s", sec->name);
+			}
 		}
 		char *sect = str ? str : strdup("");
 		printCol(ds, sect, ds->show_section_col, ds->color_reg);

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -2329,3 +2329,19 @@ and esp, 0xfffffff0
 and esp, 
 EOF
 RUN
+
+NAME=print section perm
+FILE=bins/elf/crackme0x05
+CMDS=<<EOF
+pd 1 @ 0x080483d2
+pd 1 @ 0x08049f24
+pd 1 @ 0x080483d2 @e:asm.section=true,asm.section.perm=true
+pd 1 @ 0x08049f24 @e:asm.section=true,asm.section.perm=true
+EOF
+EXPECT=<<EOF
+            0x080483d2      pop   esi
+            0x08049f24      .dword 0x00000010
+   r-x      .text           0x080483d2      pop   esi
+   rw-   .dynamic           0x08049f24      .dword 0x00000010
+EOF
+RUN


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Without this patch the disassembly would almost never print that a section is writable, because the info were taken from IO instead of Bin. Moreover, it increases a bit the size of the section part, if present, because otherwise even the common name `.text` is truncated.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
