### PR TITLE
Complete "acvf" command to better look up function address on vtable offset

### DIFF
--- a/librz/analysis/class.c
+++ b/librz/analysis/class.c
@@ -1338,7 +1338,7 @@ static void list_all_functions_at_vtable_offset(RzAnalysis *analysis, const char
 	}
 
 	rz_vector_foreach(vtables, vtable) {
-		if (vtable->size < offset + function_ptr_size) {
+		if (vtable->size < offset + function_ptr_size || offset % function_ptr_size) {
 			continue;
 		}
 

--- a/librz/analysis/rtti_itanium.c
+++ b/librz/analysis/rtti_itanium.c
@@ -762,7 +762,14 @@ static void recovery_apply_vtable(RVTableContext *context, const char *class_nam
 		return;
 	}
 
-	RzAnalysisVTable vtable = { .id = NULL, .offset = 0, .size = 0, .addr = vtable_info->saddr };
+	ut64 startAddress = vtable_info->saddr;
+	RVTableInfo *vtablet = rz_analysis_vtable_parse_at(context, startAddress);
+	ut64 size = 0;
+	if (vtablet) {
+		size = rz_analysis_vtable_info_get_size(context, vtablet);
+	}
+
+	RzAnalysisVTable vtable = { .id = NULL, .offset = 0, .size = size, .addr = vtable_info->saddr };
 	rz_analysis_class_vtable_set(context->analysis, class_name, &vtable);
 	rz_analysis_class_vtable_fini(&vtable);
 

--- a/librz/analysis/rtti_itanium.c
+++ b/librz/analysis/rtti_itanium.c
@@ -762,12 +762,8 @@ static void recovery_apply_vtable(RVTableContext *context, const char *class_nam
 		return;
 	}
 
-	ut64 startAddress = vtable_info->saddr;
-	RVTableInfo *vtablet = rz_analysis_vtable_parse_at(context, startAddress);
 	ut64 size = 0;
-	if (vtablet) {
-		size = rz_analysis_vtable_info_get_size(context, vtablet);
-	}
+	size = rz_analysis_vtable_info_get_size(context, vtable_info);
 
 	RzAnalysisVTable vtable = { .id = NULL, .offset = 0, .size = size, .addr = vtable_info->saddr };
 	rz_analysis_class_vtable_set(context->analysis, class_name, &vtable);

--- a/librz/analysis/rtti_itanium.c
+++ b/librz/analysis/rtti_itanium.c
@@ -762,8 +762,7 @@ static void recovery_apply_vtable(RVTableContext *context, const char *class_nam
 		return;
 	}
 
-	ut64 size = 0;
-	size = rz_analysis_vtable_info_get_size(context, vtable_info);
+	ut64 size = rz_analysis_vtable_info_get_size(context, vtable_info);
 
 	RzAnalysisVTable vtable = { .id = NULL, .offset = 0, .size = size, .addr = vtable_info->saddr };
 	rz_analysis_class_vtable_set(context->analysis, class_name, &vtable);

--- a/librz/analysis/rtti_msvc.c
+++ b/librz/analysis/rtti_msvc.c
@@ -821,12 +821,8 @@ static void recovery_apply_vtable(RzAnalysis *analysis, const char *class_name, 
 
 	RVTableContext context;
 	rz_analysis_vtable_begin(analysis, &context);
-	ut64 startAddress = vtable_info->saddr;
-	RVTableInfo *vtablet = rz_analysis_vtable_parse_at(&context, startAddress);
 	ut64 size = 0;
-	if (vtablet) {
-		size = rz_analysis_vtable_info_get_size(&context, vtablet);
-	}
+	size = rz_analysis_vtable_info_get_size(&context, vtable_info);
 
 	RzAnalysisVTable vtable;
 	vtable.size = size;

--- a/librz/analysis/rtti_msvc.c
+++ b/librz/analysis/rtti_msvc.c
@@ -819,9 +819,7 @@ static void recovery_apply_vtable(RVTableContext *context, const char *class_nam
 		return;
 	}
 
-	rz_analysis_vtable_begin(context->analysis, context);
-	ut64 size = 0;
-	size = rz_analysis_vtable_info_get_size(context, vtable_info);
+	ut64 size = rz_analysis_vtable_info_get_size(context, vtable_info);
 
 	RzAnalysisVTable vtable;
 	vtable.size = size;

--- a/librz/analysis/rtti_msvc.c
+++ b/librz/analysis/rtti_msvc.c
@@ -819,7 +819,17 @@ static void recovery_apply_vtable(RzAnalysis *analysis, const char *class_name, 
 		return;
 	}
 
+	RVTableContext context;
+	rz_analysis_vtable_begin(analysis, &context);
+	ut64 startAddress = vtable_info->saddr;
+	RVTableInfo *vtablet = rz_analysis_vtable_parse_at(&context, startAddress);
+	ut64 size = 0;
+	if (vtablet) {
+		size = rz_analysis_vtable_info_get_size(&context, vtablet);
+	}
+
 	RzAnalysisVTable vtable;
+	vtable.size = size;
 	vtable.id = NULL;
 	vtable.offset = 0;
 	vtable.addr = vtable_info->saddr;

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -8510,7 +8510,7 @@ static void cmd_analysis_class_vtable(RzCore *core, const char *input) {
 			*end = '\0';
 			end++;
 		}
-		ut64 offset_arg = rz_num_get(core->num, cstr); 
+		ut64 offset_arg = rz_num_get(core->num, cstr);
 		char *class_arg = NULL;
 		if (end) {
 			class_arg = (char *)rz_str_trim_head_ro(end);

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -8502,7 +8502,7 @@ static void cmd_analysis_class_vtable(RzCore *core, const char *input) {
 			return;
 		}
 		char *cstr = strdup(str);
-		if (!cstr) {
+		if (!cstr || !isdigit(cstr[0])) {
 			break;
 		}
 		char *end = strchr(cstr, ' ');
@@ -8510,7 +8510,7 @@ static void cmd_analysis_class_vtable(RzCore *core, const char *input) {
 			*end = '\0';
 			end++;
 		}
-		ut64 offset_arg = rz_num_get(core->num, cstr); // Should I allow negative offset?
+		ut64 offset_arg = rz_num_get(core->num, cstr); 
 		char *class_arg = NULL;
 		if (end) {
 			class_arg = (char *)rz_str_trim_head_ro(end);

--- a/test/db/cmd/cmd_ac
+++ b/test/db/cmd/cmd_ac
@@ -578,6 +578,8 @@ acvf 0
 acvf 0x8 A
 acvf 0x0 C
 acvf 0x10 ABC
+acvf -10
+acvf abc
 EOF
 EXPECT=<<EOF
 Function address: 0x00400ac8, in A vtable 0
@@ -596,6 +598,8 @@ acvf 0 A
 acvf 0x8 B
 acvf 0x10 C
 acvf 0x18 ABC
+acvf -20
+acvf abc
 EOF
 EXPECT=<<EOF
 Function address: 0x100005f1c, in A vtable 0

--- a/test/db/cmd/cmd_ac
+++ b/test/db/cmd/cmd_ac
@@ -569,3 +569,41 @@ EXPECT=<<EOF
 [{"name":"InAbsentia","bases":[{"id":"0","name":"Album","offset":0}],"vtables":[{"id":"0","addr":4268452,"offset":0}],"methods":[{"name":"virtual_0","addr":4198536,"type":"VIRTUAL","vtable_offset":0},{"name":"virtual_4","addr":4198579,"type":"VIRTUAL","vtable_offset":4}]},{"name":"type_info","bases":[],"vtables":[{"id":"0","addr":4268540,"offset":0}],"methods":[{"name":"virtual_0","addr":4198710,"type":"VIRTUAL","vtable_offset":0}]},{"name":"Album","bases":[],"vtables":[{"id":"0","addr":4268388,"offset":0}],"methods":[{"name":"virtual_0","addr":4198493,"type":"VIRTUAL","vtable_offset":0},{"name":"virtual_4","addr":4198567,"type":"VIRTUAL","vtable_offset":4}]}]
 EOF
 RUN
+
+NAME=acvf2
+FILE=bins/elf/analysis/elf-virtualtable
+CMDS=<<EOF
+aaa
+acvf 0
+acvf 0x8 A
+acvf 0x0 C
+acvf 0x10 ABC
+EOF
+EXPECT=<<EOF
+Function address: 0x00400ac8, in A vtable 0
+Function address: 0x00400ac8, in B vtable 0
+Function address: 0x00400ac8, in C vtable 0
+Function address: 0x00400af4, in A vtable 0
+Function address: 0x00400ac8, in C vtable 0
+EOF
+RUN
+
+NAME=acvf3
+FILE=bins/mach0/TestRTTI-arm64
+CMDS=<<EOF
+aaa
+acvf 0 A
+acvf 0x8 B
+acvf 0x10 C
+acvf 0x18 ABC
+EOF
+EXPECT=<<EOF
+Function address: 0x100005f1c, in A vtable 0
+Function address: 0x100005fe0, in B vtable 0
+Function address: 0x100005f44, in B vtable 1
+Function address: 0x100005fe0, in B vtable 2
+Function address: 0x100005f44, in B vtable 3
+Function address: 0x1000060a0, in C vtable 1
+Function address: 0x1000060a0, in C vtable 3
+EOF
+RUN


### PR DESCRIPTION
…v, and show function names

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
As mentioned in [#414](https://github.com/rizinorg/rizin/issues/414), the command that takes the offset and looks up the actual destination is implemented as `acvf`, and the general usage is shown in [#16157](https://github.com/radareorg/radare2/pull/16157) of [`r2`](https://github.com/radareorg/radare2). 

The question is: after I consulted the `?` page, I thought it works if:
```s
# (testcase has class `Base` and `Derive:Base`, and virtual functions for each)
$ rizin ~/vtabletest
...
[0x000010a0]> aaa
...
[0x000010a0]> av

Vtable Found at 0x00003d70
0x00003d70 : method.Base.f
0x00003d78 : method.Derive.g
0x00003d80 : method.Base.h


Vtable Found at 0x00003d98
0x00003d98 : method.Base.f
0x00003da0 : method.Base.g
0x00003da8 : method.Base.h

[0x000010a0]> acl
Base
Derive: Base
[0x000010a0]> acvf 0 Base
[0x000010a0]>
```
While not, because in [#16157](https://github.com/radareorg/radare2/pull/16157) of [`r2`](https://github.com/radareorg/radare2), we should use `acv` command before `acvf` to add vtable address/offset/size to the class.

In my view, it's better for `acvf` to work right after `aaa`, and after analysing I found it invalid due to getting wrong `size` of `vtable` in `rz_analysis_class_vtable_get()`, so I add another `size` obtaining gadget partly from `rz_analysis_vtable_search()`. 

And I add function names in output in `list_all_functions_at_vtable_offset()`, hope it will help.

**Test plan**
It used to be like what I mentioned, after this modification:
```s
$ rizin rizin-testbins/elf/analysis/elf-virtualtable
...
[0x004008e0]> aaa
...
[0x004008e0]> acvf 0
Function address: 0x00400ac8, in A vtable 0
Function address: 0x00400ac8, in B vtable 0
Function address: 0x00400ac8, in C vtable 0
[0x004008e0]> q

$ rizin ../rizin-testbins/mach0/TestRTTI-arm64
...
[0x10000612c]> aaa
...
[0x10000612c]> acvf 0
Function address: 0x100005f1c, in A vtable 0
Function address: 0x100005f94, in B vtable 0
Function address: 0x100005fbc, in B vtable 1
Function address: 0x100005f94, in B vtable 2
Function address: 0x100005fbc, in B vtable 3
Function address: 0x10000602c, in C vtable 0
Function address: 0x100005f1c, in C vtable 1
Function address: 0x10000602c, in C vtable 2
Function address: 0x100005f1c, in C vtable 3
Function address: 0x100005f94, in D vtable 0
Function address: 0x10000602c, in D vtable 1
Function address: 0x100005fbc, in D vtable 2
[0x10000612c]> acvf 0x8 D
Function address: 0x1000060c4, in D vtable 0
Function address: 0x1000060ec, in D vtable 1
Function address: 0x100006054, in D vtable 2
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
