### PR TITLE
Add missing copyright information

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -167,6 +167,10 @@ Files: librz/asm/arch/ppc/README
 Copyright: RadareOrg <pancake@nopcode.org>
 License: LGPL-3.0-only
 
+Files: librz/asm/arch/*/gnu/*
+Copyright: 1989-2021 Free Software Foundation, Inc.
+License: GPL-2.0-or-later
+
 Files: librz/bp/README
 Copyright: RadareOrg <pancake@nopcode.org>
 License: LGPL-3.0-only

--- a/librz/bin/format/mach0/mach064_is_kernelcache.c
+++ b/librz/bin/format/mach0/mach064_is_kernelcache.c
@@ -1,4 +1,7 @@
+// SPDX-FileCopyrightText: 2019-2020 Francesco Tamagni <mrmacete@protonmail.ch>
+// SPDX-FileCopyrightText: 2019 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
+
 #include "mach0_defines.h"
 
 static bool is_kernelcache_buffer(RzBuffer *b) {

--- a/librz/bin/format/objc/mach064_classes.c
+++ b/librz/bin/format/objc/mach064_classes.c
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2015-2020 inisider <inisider@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
+
 #define RZ_BIN_MACH064 1
 #include "mach0_classes.c"

--- a/librz/bin/format/xnu/rz_cf_dict.c
+++ b/librz/bin/format/xnu/rz_cf_dict.c
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2019 Francesco Tamagni <mrmacete@protonmail.ch>
 // SPDX-License-Identifier: LGPL-3.0-only
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <rz_util.h>

--- a/librz/crypto/des.c
+++ b/librz/crypto/des.c
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2015 seu <seu@panopticon.re>
 // SPDX-FileCopyrightText: 2015 condret <condret@runas-racer.com>
-// SPDX-FileCopyrightText: 2017 Giovanni <wargio@libero.it>
+// SPDX-FileCopyrightText: 2017 deroad <wargio@libero.it>
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_types.h>

--- a/librz/crypto/des.c
+++ b/librz/crypto/des.c
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2015 seu <seu@panopticon.re>
+// SPDX-FileCopyrightText: 2015 condret <condret@runas-racer.com>
+// SPDX-FileCopyrightText: 2017 Giovanni <wargio@libero.it>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include <rz_types.h>
 #include <rz_util.h>
 

--- a/shlr/gdb/src/arch.c
+++ b/shlr/gdb/src/arch.c
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2017 Srimanta Barua <srimanta.barua1@gmail.com>
+// SPDX-FileCopyrightText: 2018 Alyssa Milburn <noopwafel@gmail.com>
+// SPDX-FileCopyrightText: 2020 Zi Fan <zifan.tan@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include <rz_util.h>
 #include "arch.h"
 

--- a/shlr/gdb/src/common.c
+++ b/shlr/gdb/src/common.c
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2017-2019 Srimanta Barua <srimanta.barua1@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 /* Common functions for both client and server. Not part of the libgdbr interface */
 
 #include "libgdbr.h"

--- a/shlr/gdb/src/gdbserver/core.c
+++ b/shlr/gdb/src/gdbserver/core.c
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2017 Srimanta Barua <srimanta.barua1@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 // Notes and useful links:
 // This conversation (https://www.sourceware.org/ml/gdb/2009-02/msg00100.html) suggests GDB clients usually ignore error codes
 // Useful, but not to be blindly trusted - http://www.embecosm.com/appnotes/ean4/embecosm-howto-rsp-server-ean4-issue-2.html

--- a/shlr/qnx/include/arch.h
+++ b/shlr/qnx/include/arch.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2016 madprogrammer
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*! \file */
 #ifndef ARCH_H
 #define ARCH_H

--- a/shlr/qnx/include/core.h
+++ b/shlr/qnx/include/core.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2016 madprogrammer
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*! \file */
 #ifndef QNX_CORE_H
 #define QNX_CORE_H

--- a/shlr/qnx/include/libqnxr.h
+++ b/shlr/qnx/include/libqnxr.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2016 madprogrammer
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*! \file */
 #ifndef LIBQNXR_H
 #define LIBQNXR_H
@@ -29,7 +32,7 @@ typedef struct
 	st64 tid;
 } ptid_t;
 
-/*! 
+/*!
  * Core "object" that saves
  * the instance of the lib
  */

--- a/shlr/qnx/include/packet.h
+++ b/shlr/qnx/include/packet.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2016 madprogrammer
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*! \file */
 #ifndef PACKET_H
 #define PACKET_H

--- a/shlr/qnx/include/sigutil.h
+++ b/shlr/qnx/include/sigutil.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2016 madprogrammer
+// SPDX-License-Identifier: GPL-2.0-only
+
 #ifndef SIGNAL_H
 #define SIGNAL_H
 

--- a/shlr/qnx/include/utils.h
+++ b/shlr/qnx/include/utils.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2016 madprogrammer
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*! \file */
 #ifndef UTILS_H
 #define UTILS_H


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

More fixes to improve the `reuse lint` score.
Added copyrights are based on the git history of Rizin and Radare2.

Was:
```
* Files with copyright information: 2692 / 2973
* Files with license information: 2659 / 2973
```
Now:
```
* Files with copyright information: 2704 / 2972
* Files with license information: 2706 / 2972
```

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/683