### PR TITLE
Enable MALLOC_OPTIONS=S on OpenBSD CI

### DIFF
--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -35,7 +35,7 @@ tasks:
         # https://todo.sr.ht/~sircmpwn/builds.sr.ht/274
         ln -s ${HOME}/rizin-testbins test/bins
         # Running the unit tests
-        ninja -C build test
+        MALLOC_OPTIONS=S ninja -C build test
     - test: |
         cd rizin
         export PATH=${HOME}/bin:/usr/local/bin:${PATH}
@@ -46,4 +46,4 @@ tasks:
         ln -s ${HOME}/rizin-testbins test/bins
         cd test
         # Running the unit tests
-        rz-test -L -o results.json
+        MALLOC_OPTIONS=S rz-test -L -o results.json


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This helps catch memory issues, similar to asan.
See also https://man.openbsd.org/malloc.3
In particular, `S` enables `CFGJ`.

For example:
```
-bash-5.0$ cat main.c

#include <stdlib.h>

int main() {
	char *buf = malloc(8);
	buf[8] = 42;
	free(buf);
	return 0;
}
-bash-5.0$ ./overflow
-bash-5.0$ MALLOC_OPTIONS=S ./overflow
overflow(40940) in free(): chunk canary corrupted 0xe068c5ba500 0x8@0x8
Abort trap (core dumped)
```