### PR TITLE
Add missing copyright information

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -135,6 +135,14 @@ Files: librz/magic/d/default/*
 Copyright: 1986, 1987, 1989, 1990, 1991, 1992, 1994, 1995 Ian F. Darwin
 License: BSD-2-Clause
 
+Files: librz/syscall/d/*
+Copyright: 2011 RadareOrg <pancake@nopcode.org>
+License: LGPL-3.0-only
+
+Files: librz/syscall/d2/*
+Copyright: 2018 RadareOrg <pancake@nopcode.org>
+License: LGPL-3.0-only
+
 Files: pkgcfg/*.pc.acr
 Copyright: 2009 RadareOrg <pancake@nopcode.org>
 License: LGPL-3.0-only

--- a/librz/asm/arch/arm/aarch64/aarch64-dis.h
+++ b/librz/asm/arch/arm/aarch64/aarch64-dis.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2012-2018 Free Software Foundation, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /* aarch64-dis.h -- Header file for aarch64-dis.c and aarch64-dis-2.c.
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Contributed by ARM Ltd.

--- a/librz/asm/arch/arm/aarch64/aarch64-opc.h
+++ b/librz/asm/arch/arm/aarch64/aarch64-opc.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2012-2018 Free Software Foundation, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /* aarch64-opc.h -- Header file for aarch64-opc.c and aarch64-opc-2.c.
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Contributed by ARM Ltd.

--- a/librz/asm/arch/arm/aarch64/aarch64-tbl.h
+++ b/librz/asm/arch/arm/aarch64/aarch64-tbl.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2012-2018 Free Software Foundation, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /* aarch64-tbl.h -- AArch64 opcode description table and instruction
    operand description table.
    Copyright (C) 2012-2018 Free Software Foundation, Inc.

--- a/librz/asm/arch/arm/aarch64/aarch64.h
+++ b/librz/asm/arch/arm/aarch64/aarch64.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2009-2018 Free Software Foundation, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /* AArch64 assembler/disassembler support.
 
    Copyright (C) 2009-2018 Free Software Foundation, Inc.

--- a/librz/asm/arch/arm/aarch64/sysdep.h
+++ b/librz/asm/arch/arm/aarch64/sysdep.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 1995-2018 Free Software Foundation, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /* Random host-dependent support code.
    Copyright (C) 1995-2018 Free Software Foundation, Inc.
    Written by Ken Raeburn.

--- a/librz/asm/arch/mcore/mcore.h
+++ b/librz/asm/arch/mcore/mcore.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2018-2020 deroad <wargio@libero.it>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef MCORE_H
 #define MCORE_H
 

--- a/librz/io/p/io_rzk_linux.c
+++ b/librz/io/p/io_rzk_linux.c
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2016 Rakholiya Jenish
+// SPDX-FileCopyrightText: 2016 NighterMan <jpenalbae@gmail.com>
+// SPDX-FileCopyrightText: 2017-2020 pancake <pancake@nopcode.org>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef __GNU__
 
 #include "io_rzk_linux.h"

--- a/librz/io/p/io_rzk_linux.h
+++ b/librz/io/p/io_rzk_linux.h
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2016 Rakholiya Jenish
+// SPDX-FileCopyrightText: 2016 NighterMan <jpenalbae@gmail.com>
+// SPDX-FileCopyrightText: 2017-2020 pancake <pancake@nopcode.org>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef __IO_RZK_LINUX_H__
 #define __IO_RZK_LINUX_H__
 

--- a/librz/io/p/io_rzk_windows.c
+++ b/librz/io/p/io_rzk_windows.c
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2016 skuater <skuater@hotmail.com>
+// SPDX-FileCopyrightText: 2016 Rakholiya Jenish
+// SPDX-FileCopyrightText: 2017 Jose Diaz <josediazplay@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include "io_rzk_windows.h"
 
 HANDLE gHandleDriver = NULL;

--- a/librz/io/p/io_rzk_windows.h
+++ b/librz/io/p/io_rzk_windows.h
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2016 skuater <skuater@hotmail.com>
+// SPDX-FileCopyrightText: 2016 Rakholiya Jenish
+// SPDX-FileCopyrightText: 2017 Jose Diaz <josediazplay@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef __IO_RZK_WINDOWS_H__
 #define __IO_RZK_WINDOWS_H__
 

--- a/librz/syscall/ioports.c
+++ b/librz/syscall/ioports.c
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2010-2020 pancake <pancake@nopcode.org>
+// SPDX-FileCopyrightText: 2016 Roman Valls Guimera <brainstorm@nopcode.org>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include "rz_syscall.h"
 
 RzSyscallPort sysport_x86[] = {

--- a/shlr/heap/include/rz_windows/windows_heap.h
+++ b/shlr/heap/include/rz_windows/windows_heap.h
@@ -1,10 +1,13 @@
+// SPDX-FileCopyrightText: 2019 GustavoLCR <gugulcr@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef WINDOWS_HEAP_H
 #define WINDOWS_HEAP_H
 
 #include <windows.h>
 #include <winternl.h>
 
-/* 
+/*
 	Defines most of heap related structures on Windows (some still missing)
 	Tested only on Windows 10 1809 x64
 	TODO:


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

More fixes to improve the `reuse lint` score.
Added copyrights are based on the git history of Rizin and Radare2.

Was:
```
* Files with copyright information: 2704 / 2972
* Files with license information: 2706 / 2972
```
Now:
```
* Files with copyright information: 2715 / 2972
* Files with license information: 2722 / 2972
```

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/683