### PR TITLE
Remove all remaining SDB from Dwarf

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -1183,7 +1183,6 @@ static bool bin_dwarf(RzCore *core, RzBinFile *binfile, PJ *pj, int mode) {
 			}
 			rz_bin_dwarf_loc_free(loc_table);
 		}
-		rz_bin_dwarf_debug_info_free(info);
 		if (mode == RZ_MODE_PRINT) {
 			RzList *aranges = rz_bin_dwarf_parse_aranges(binfile);
 			if (aranges) {
@@ -1191,8 +1190,9 @@ static bool bin_dwarf(RzCore *core, RzBinFile *binfile, PJ *pj, int mode) {
 				rz_list_free(aranges);
 			}
 		}
-		RzList *lines = rz_bin_dwarf_parse_line(binfile,
+		RzList *lines = rz_bin_dwarf_parse_line(binfile, info,
 			RZ_BIN_DWARF_LINE_INFO_MASK_ROWS | (mode == RZ_MODE_PRINT ? RZ_BIN_DWARF_LINE_INFO_MASK_OPS : 0));
+		rz_bin_dwarf_debug_info_free(info);
 		if (lines) {
 			if (mode == RZ_MODE_PRINT) {
 				rz_core_bin_dwarf_print_lines(lines);

--- a/librz/include/rz_bin_dwarf.h
+++ b/librz/include/rz_bin_dwarf.h
@@ -761,6 +761,13 @@ typedef struct {
 	size_t capacity;
 	RzBinDwarfCompUnit *comp_units;
 	HtUP /*<ut64 offset, DwarfDie *die>*/ *lookup_table;
+
+	/**
+	 * Cache mapping from an offset in the debug_line section to a string
+	 * representing the DW_AT_comp_dir attribute of the compilation unit
+	 * that references this particular line information.
+	 */
+	HtUP /*<ut64, char *>*/ *line_info_offset_comp_dir;
 } RzBinDwarfDebugInfo;
 
 #define ABBREV_DECL_CAP 8
@@ -808,6 +815,7 @@ typedef struct rz_bin_dwarf_line_file_entry_t {
 } RzBinDwarfLineFileEntry;
 
 typedef struct {
+	ut64 offset; //< offset inside the debug_line section, for references from outside
 	ut64 unit_length;
 	ut16 version;
 	ut64 header_length;
@@ -931,14 +939,14 @@ RZ_API void rz_bin_dwarf_loc_free(HtUP /*<offset, RzBinDwarfLocList*>*/ *loc_tab
 RZ_API void rz_bin_dwarf_debug_info_free(RzBinDwarfDebugInfo *inf);
 RZ_API void rz_bin_dwarf_debug_abbrev_free(RzBinDwarfDebugAbbrev *da);
 
-RZ_API RzList *rz_bin_dwarf_parse_line(RzBinFile *binfile, RzBinDwarfLineInfoMask mask);
-RZ_API char *rz_bin_dwarf_line_header_get_full_file_path(Sdb *sdb_addrinfo, const RzBinDwarfLineHeader *header, ut64 file_index);
+RZ_API RzList *rz_bin_dwarf_parse_line(RzBinFile *binfile, RZ_NULLABLE RzBinDwarfDebugInfo *info, RzBinDwarfLineInfoMask mask);
+RZ_API char *rz_bin_dwarf_line_header_get_full_file_path(RZ_NULLABLE RzBinDwarfDebugInfo *info, const RzBinDwarfLineHeader *header, ut64 file_index);
 RZ_API ut64 rz_bin_dwarf_line_header_get_adj_opcode(const RzBinDwarfLineHeader *header, ut8 opcode);
 RZ_API ut64 rz_bin_dwarf_line_header_get_spec_op_advance_pc(const RzBinDwarfLineHeader *header, ut8 opcode);
 RZ_API st64 rz_bin_dwarf_line_header_get_spec_op_advance_line(const RzBinDwarfLineHeader *header, ut8 opcode);
 RZ_API void rz_bin_dwarf_line_header_reset_regs(const RzBinDwarfLineHeader *hdr, RzBinDwarfSMRegisters *regs);
 RZ_API bool rz_bin_dwarf_line_op_run(const RzBinDwarfLineHeader *hdr, RzBinDwarfSMRegisters *regs, RzBinDwarfLineOp *op,
-	RZ_NULLABLE RZ_OUT RzList /*<RzBinSourceRow>*/ *rows_out, RZ_DEPRECATE Sdb *sdb_addrinfo);
+	RZ_NULLABLE RZ_OUT RzList /*<RzBinSourceRow>*/ *rows_out, RZ_NULLABLE RzBinDwarfDebugInfo *info);
 RZ_API void rz_bin_dwarf_line_op_fini(RzBinDwarfLineOp *op);
 RZ_API void rz_bin_dwarf_line_info_free(RzBinDwarfLineInfo *li);
 

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -4256,7 +4256,6 @@ EXPECT=<<EOF
 [Source file]
 /home/landley/work/ab7/build/temp-armv6l/gcc-core/gcc/config/arm/ieee754-df.S
 /home/landley/work/ab7/build/temp-armv6l/gcc-core/gcc/config/arm/lib1funcs.asm
-/home/landley/work/ab7/build/temp-armv6l/build-gcc/gcc
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Dwarf line info (parsed from section `debug_line`) needs the compilation unit dirs which are present in the `debug_info` section in a relatively complicated way. The `debug_info` is usually parsed before lines so technically this information is available.
Before this PR, it was written as the single key `DW_AT_comp_dir` into the `sdb_addrline` sdb, which is absolutely not meant for this purpose but something entirely different, and of course with this, if you have multiple compilation units, which applies to any program larger than a hello world, you will only get the last parsed `DW_AT_comp_dir`, making almost all paths incorrect.
So instead, it is now parsed into a dedicated hashtable from the referred `debug_line` part offset to the respective `DW_AT_comp_dir` for this compilation unit, which is correct and fast, and also removes another dependency on this sdb for #843.

**Test plan**

Here is an example where the previous approach breaks (added as a unit test).
Before:
```
florian-macbook:rizin florian$ rz -Qc id test/bins/elf/dwarf4_multidir_comp_units
0x00001139	/home/florian/dev/dwarf-comp-units/some_subfolder/main.c	6
0x0000113d	/home/florian/dev/dwarf-comp-units/some_subfolder/main.c	7
0x0000115f	/home/florian/dev/dwarf-comp-units/some_subfolder/main.c	8
0x00001181	/home/florian/dev/dwarf-comp-units/some_subfolder/main.c	9
0x00001186	/home/florian/dev/dwarf-comp-units/some_subfolder/main.c	10
0x00001188	/home/florian/dev/dwarf-comp-units/some_subfolder/main.c	-
0x00001188	/home/florian/dev/dwarf-comp-units/some_subfolder/subfile.c	2
0x00001192	/home/florian/dev/dwarf-comp-units/some_subfolder/subfile.c	3
0x00001198	/home/florian/dev/dwarf-comp-units/some_subfolder/subfile.c	3
0x000011a1	/home/florian/dev/dwarf-comp-units/some_subfolder/subfile.c	3
0x000011a3	/home/florian/dev/dwarf-comp-units/some_subfolder/subfile.c	4
0x000011a5	/home/florian/dev/dwarf-comp-units/some_subfolder/subfile.c	-
```

After (these are the correct paths how I compiled this bin):
```
florian-macbook:rizin florian$ rz -Qc id test/bins/elf/dwarf4_multidir_comp_units
(...)
0x00001139	/home/florian/dev/dwarf-comp-units/main.c	6
0x0000113d	/home/florian/dev/dwarf-comp-units/main.c	7
0x0000115f	/home/florian/dev/dwarf-comp-units/main.c	8
0x00001181	/home/florian/dev/dwarf-comp-units/main.c	9
0x00001186	/home/florian/dev/dwarf-comp-units/main.c	10
0x00001188	/home/florian/dev/dwarf-comp-units/main.c	-
0x00001188	/home/florian/dev/dwarf-comp-units/some_subfolder/subfile.c	2
0x00001192	/home/florian/dev/dwarf-comp-units/some_subfolder/subfile.c	3
0x00001198	/home/florian/dev/dwarf-comp-units/some_subfolder/subfile.c	3
0x000011a1	/home/florian/dev/dwarf-comp-units/some_subfolder/subfile.c	3
0x000011a3	/home/florian/dev/dwarf-comp-units/some_subfolder/subfile.c	4
0x000011a5	/home/florian/dev/dwarf-comp-units/some_subfolder/subfile.c	-
```
