### PR TITLE
Remove slow and almost unused Source File Reading from Debug Info

### DIFF
--- a/test/db/tools/rz_bin
+++ b/test/db/tools/rz_bin
@@ -1056,7 +1056,7 @@ NAME=rz-bin -dj
 FILE=bins/elf/analysis/dwarftest
 CMDS=!rz-bin -dj ${RZ_FILE}
 EXPECT=<<EOF
-{"dwarf":[[{"name":"CC","file":"dwarftest.c","line_num":4,"addr":4195629},{"name":"CL","file":"dwarftest.c","line_num":4,"line":"","addr":4195629}],[{"name":"CC","file":"dwarftest.c","line_num":7,"addr":4195637},{"name":"CL","file":"dwarftest.c","line_num":7,"line":"","addr":4195637}],[{"name":"CC","file":"dwarftest.c","line_num":8,"addr":4195646},{"name":"CL","file":"dwarftest.c","line_num":8,"line":"","addr":4195646}],[{"name":"CC","file":"dwarftest.c","line_num":7,"addr":4195656},{"name":"CL","file":"dwarftest.c","line_num":7,"line":"","addr":4195656}],[{"name":"CC","file":"dwarftest.c","line_num":7,"addr":4195660},{"name":"CL","file":"dwarftest.c","line_num":7,"line":"","addr":4195660}],[{"name":"CC","file":"dwarftest.c","line_num":11,"addr":4195666},{"name":"CL","file":"dwarftest.c","line_num":11,"line":"","addr":4195666}],[{"name":"CC","file":"dwarftest.c","line_num":12,"addr":4195671},{"name":"CL","file":"dwarftest.c","line_num":12,"line":"","addr":4195671}],[{"name":"CC","file":"dwarftest.c","line_num":0,"addr":4195673},{"name":"CL","file":"dwarftest.c","line_num":0,"line":"","addr":4195673}]]}
+{"dwarf":[[{"file":"dwarftest.c","line":4,"addr":4195629}],[{"file":"dwarftest.c","line":7,"addr":4195637}],[{"file":"dwarftest.c","line":8,"addr":4195646}],[{"file":"dwarftest.c","line":7,"addr":4195656}],[{"file":"dwarftest.c","line":7,"addr":4195660}],[{"file":"dwarftest.c","line":11,"addr":4195666}],[{"file":"dwarftest.c","line":12,"addr":4195671}],[{"file":"dwarftest.c","line":0,"addr":4195673}]]}
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

When you loaded a binary with dwarf info, rizin would attempt to slurp every single source file at load time, however:
* This may be undesired if it is an untrusted binary because the binary can tell rizin any file paths it wants and rizin will read them from the host
*  It was only used in the `rz_cons_printf("\"CC %s:%d\"@0x%" PFMT64x "\n"...` code path which is not covered by tests, so it's probably irrelevant and in the json where I think it's also irrelevant.

Even worse, if loading for a file failed (which is basically always the case if you don't have the source), it would re-attempt to read the file on every single line number+column sample, whose number in the same ballpark as the number of instructions in the entire binary, creating a huge bottleneck.

Little comparison:
Before:
```
florian-macbook:rizin florian$ time rz-test -j1 test/db/cmd/dwarf
Running from /Users/florian/dev/rizin/test
Loaded 9 tests.
[9/9]                       9 OK         0 BR        0 XX        0 FX
Finished in 36 seconds.

real	0m36.465s
user	0m8.416s
sys	0m1.195s
```

After:
```
florian-macbook:rizin florian$ time rz-test -j1 test/db/cmd/dwarf
Running from /Users/florian/dev/rizin/test
Loaded 9 tests.
[9/9]                       9 OK         0 BR        0 XX        0 FX
Finished in 8 seconds.

real	0m8.047s
user	0m7.934s
sys	0m0.099s
```
Though this is not necessarily represantative since macOS has horribly slow io. I would expect the difference to be a bit less on Linux.

Also I can load the binary from #676 in about 1m instead of 2m30s but there is still more room for optimization.