### PR TITLE
java: Fix bytecode->type warning

### DIFF
--- a/librz/asm/arch/java/jvm.c
+++ b/librz/asm/arch/java/jvm.c
@@ -1443,7 +1443,7 @@ static bool decode_instruction(JavaVM *jvm, Bytecode *bytecode) {
 		jvm->current++;
 		return true;
 	}
-	if (!bytecode->type) {
+	if (!bytecode->type[0]) {
 		bytecode->atype = RZ_ANALYSIS_OP_TYPE_UNK;
 	}
 	bytecode->opcode = byte;

--- a/librz/asm/arch/java/jvm.c
+++ b/librz/asm/arch/java/jvm.c
@@ -1443,7 +1443,7 @@ static bool decode_instruction(JavaVM *jvm, Bytecode *bytecode) {
 		jvm->current++;
 		return true;
 	}
-	if (!bytecode->type[0]) {
+	if (!bytecode->atype) {
 		bytecode->atype = RZ_ANALYSIS_OP_TYPE_UNK;
 	}
 	bytecode->opcode = byte;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following warning, spotted on the FreeBSD build (https://builds.sr.ht/~xvilka/job/465412#task-build):

![java-bytecode-type](https://user-images.githubusercontent.com/12002672/111894862-46ccba80-8a49-11eb-8860-1d22d9a3c74f.PNG)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds should be green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
