### PR TITLE
Filter stdout warning in luac test

### DIFF
--- a/librz/bin/format/luac/luac_bin.c
+++ b/librz/bin/format/luac/luac_bin.c
@@ -136,7 +136,10 @@ static void free_rz_symbol(RzBinSymbol *symbol) {
 }
 
 LuacBinInfo *luac_build_info(LuaProto *proto) {
-	rz_return_val_if_fail(proto, NULL);
+	if (proto == NULL) {
+		eprintf("Warning : No proto for building info\n");
+		return NULL;
+	}
 
 	LuacBinInfo *ret = RZ_NEW0(LuacBinInfo);
 	if (!ret) {

--- a/librz/bin/format/luac/luac_common.c
+++ b/librz/bin/format/luac/luac_common.c
@@ -164,7 +164,9 @@ void lua_free_upvalue_entry(LuaUpvalueEntry *entry) {
 }
 
 void lua_free_proto_entry(LuaProto *proto) {
-	rz_return_if_fail(proto);
+	if (proto == NULL) {
+		return;
+	}
 
 	/* free constants entries */
 	rz_list_free(proto->const_entries);

--- a/test/db/formats/luac/luac
+++ b/test/db/formats/luac/luac
@@ -136,9 +136,14 @@ EXPECT=<<EOF
 EOF
 RUN
 
+# Fix build warning
+# see https://travis-ci.com/github/rizinorg/rizin/jobs/492588616
 NAME=LUAC: broken file
 FILE=bins/luac/random.luac
 CMDS=<<EOF
+EOF
+REGEXP_FILTER_OUT=<<EOF
+Nothing
 EOF
 EXPECT=<<EOF
 EOF

--- a/test/db/formats/luac/luac
+++ b/test/db/formats/luac/luac
@@ -136,14 +136,10 @@ EXPECT=<<EOF
 EOF
 RUN
 
-# Fix build warning
 # see https://travis-ci.com/github/rizinorg/rizin/jobs/492588616
 NAME=LUAC: broken file
 FILE=bins/luac/random.luac
 CMDS=<<EOF
-EOF
-REGEXP_FILTER_OUT=<<EOF
-Nothing
 EOF
 EXPECT=<<EOF
 EOF


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

see https://travis-ci.com/github/rizinorg/rizin/jobs/492588616

This pr filters the stdout for ARMv8

**Addtional**
These warnings should be sent to stderr, but they were sent to stdout on ARMv8