### PR TITLE
program header pase p_offset -> p_paddr

### DIFF
--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -236,7 +236,7 @@ static RzList *sections(RzBinFile *bf) {
 			ptr->add = false;
 			ptr->size = phdr[i].p_filesz;
 			ptr->vsize = phdr[i].p_memsz;
-			ptr->paddr = phdr[i].p_offset;
+			ptr->paddr = phdr[i].p_paddr;
 			ptr->vaddr = phdr[i].p_vaddr;
 			ptr->perm = phdr[i].p_flags;
 			ptr->is_segment = true;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
when I read the  souce code , I found  code 239 line ptr->paddr = phdr[i].p_offset  in file rizin/librz/bin/p/bin_elf.inc 239 . I modify the code to ptr->paddr = phdr[i].p_paddr . Should there use p_paddr more suitable ？

```
[0x00407f1c]> iSS
[Segments]

nth paddr          size vaddr         vsize perm name
―――――――――――――――――――――――――――――――――――――――――――――――――――――
0   0x00400040    0x1f8 0x00400040    0x1f8 -r-x PHDR
1   0x00400238     0x1c 0x00400238     0x1c -r-- INTERP
2   0x00400000  0x31d8c 0x00400000  0x31d8c -r-x LOAD0
3   0x00631e08   0x13e8 0x00631e08   0x4c90 -rw- LOAD1
4   0x00631e18    0x1e0 0x00631e18    0x1e0 -rw- DYNAMIC
5   0x00400254     0x20 0x00400254     0x20 -r-- NOTE
6   0x0042cc68    0xacc 0x0042cc68    0xacc -r-- GNU_EH_FRAME
7   0x00000000      0x0 0x00000000      0x0 -rw- GNU_STACK
8   0x00631e08    0x1f8 0x00631e08    0x1f8 -r-- GNU_RELRO
9   0x00000000     0x40 0x00400000     0x40 -rw- ehdr
```
and the readelf is 
```
$ readelf -lW 001.make.elf.x86_64

Elf 文件类型为 EXEC (可执行文件)
Entry point 0x407f1c
There are 9 program headers, starting at offset 64

程序头：
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
  PHDR           0x000040 0x0000000000400040 0x0000000000400040 0x0001f8 0x0001f8 R E 0x8
  INTERP         0x000238 0x0000000000400238 0x0000000000400238 0x00001c 0x00001c R   0x1
      [Requesting program interpreter: /lib64/ld-linux-x86-64.so.2]
  LOAD           0x000000 0x0000000000400000 0x0000000000400000 0x031d8c 0x031d8c R E 0x200000
  LOAD           0x031e08 0x0000000000631e08 0x0000000000631e08 0x0013e8 0x004c90 RW  0x200000
  DYNAMIC        0x031e18 0x0000000000631e18 0x0000000000631e18 0x0001e0 0x0001e0 RW  0x8
  NOTE           0x000254 0x0000000000400254 0x0000000000400254 0x000020 0x000020 R   0x4
  GNU_EH_FRAME   0x02cc68 0x000000000042cc68 0x000000000042cc68 0x000acc 0x000acc R   0x4
  GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RW  0x10
  GNU_RELRO      0x031e08 0x0000000000631e08 0x0000000000631e08 0x0001f8 0x0001f8 R   0x1

```
...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->
Using the file 001.make.elf.x86_64.zip as a test.


...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
