### PR TITLE
commands: remove "comment" argument from `zi*` and `f*`

### DIFF
--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -190,7 +190,6 @@ static const RzCmdDescArg zign_space_select_args[2];
 static const RzCmdDescArg zign_space_delete_args[2];
 static const RzCmdDescArg zign_space_add_args[2];
 static const RzCmdDescArg zign_space_rename_args[2];
-static const RzCmdDescArg zign_info_args[2];
 static const RzCmdDescArg zign_info_range_args[3];
 
 static const RzCmdDescHelp cmd_system_help = {
@@ -3668,13 +3667,6 @@ static const RzCmdDescHelp zi_help = {
 	.summary = "Show zignatures matching information",
 };
 static const RzCmdDescArg zign_info_args[] = {
-	{
-		.name = "commens",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
-		.optional = true,
-
-	},
 	{ 0 },
 };
 static const RzCmdDescHelp zign_info_help = {

--- a/librz/core/cmd_descs/cmd_zign.yaml
+++ b/librz/core/cmd_descs/cmd_zign.yaml
@@ -275,10 +275,7 @@ commands:
       - name: zi
         cname: zign_info
         summary: Show zignatures matching information
-        args:
-          - name: commens
-            type: RZ_CMD_ARG_TYPE_STRING
-            optional: true
+        args: []
         modes:
           - RZ_OUTPUT_MODE_STANDARD
           - RZ_OUTPUT_MODE_JSON

--- a/librz/core/cmd_zign.c
+++ b/librz/core/cmd_zign.c
@@ -1519,8 +1519,6 @@ static RzCmdStatus zi_handler_common(RzCore *core, int mode, const char *pfx) {
 }
 
 RZ_IPI RzCmdStatus rz_zign_info_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
-	char *pfx;
-	RzCmdStatus res = RZ_CMD_STATUS_OK;
 	switch (mode) {
 	case RZ_OUTPUT_MODE_STANDARD:
 		return zi_handler_common(core, '\0', "");
@@ -1529,10 +1527,7 @@ RZ_IPI RzCmdStatus rz_zign_info_handler(RzCore *core, int argc, const char **arg
 	case RZ_OUTPUT_MODE_QUIET:
 		return zi_handler_common(core, 'q', "");
 	case RZ_OUTPUT_MODE_RIZIN:
-		pfx = argc > 1 ? rz_str_newf(" %s", argv[1]) : rz_str_new("");
-		res = zi_handler_common(core, '\0', pfx);
-		free(pfx);
-		return res;
+		return zi_handler_common(core, '*', "");
 	default:
 		return RZ_CMD_STATUS_ERROR;
 	}

--- a/librz/flag/flag.c
+++ b/librz/flag/flag.c
@@ -295,7 +295,6 @@ struct print_flag_t {
 	ut64 range_to;
 	RzSpace *fs;
 	bool real;
-	const char *pfx;
 };
 
 static bool print_flag_json(RzFlagItem *flag, void *user) {
@@ -347,9 +346,8 @@ static bool print_flag_rad(RzFlagItem *flag, void *user) {
 				flag->name, comment_b64 ? comment_b64 : "");
 		}
 	} else {
-		u->f->cb_printf("f %s %" PFMT64d " 0x%08" PFMT64x "%s%s %s\n",
+		u->f->cb_printf("f %s %" PFMT64d " 0x%08" PFMT64x " %s\n",
 			flag->name, flag->size, flag->offset,
-			u->pfx ? "+" : "", u->pfx ? u->pfx : "",
 			comment_b64 ? comment_b64 : "");
 	}
 
@@ -429,7 +427,6 @@ RZ_API void rz_flag_list(RzFlag *f, int rad, const char *pfx) {
 			.range_from = range_from,
 			.range_to = range_to,
 			.fs = NULL,
-			.pfx = pfx
 		};
 		rz_flag_foreach_space(f, rz_flag_space_cur(f), print_flag_rad, &u);
 		break;

--- a/test/db/cmd/cmd_flags
+++ b/test/db/cmd/cmd_flags
@@ -555,22 +555,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=flag prefix dump
-FILE=-
-CMDS=<<EOF
-f jiji=1
-f jojo=2
-f base=100
-.f*base
-?vi jiji
-?vi jojo
-EOF
-EXPECT=<<EOF
-101
-102
-EOF
-RUN
-
 NAME=rename flags from bin
 FILE=bins/elf/analysis/main
 CMDS=<<EOF

--- a/test/db/cmd/cmd_help
+++ b/test/db/cmd/cmd_help
@@ -250,10 +250,10 @@ CMDS=<<EOF
 ?* zi
 EOF
 EXPECT=<<EOF
-| zi [<commens>]       # Show zignatures matching information
-| zij [<commens>]      # Show zignatures matching information (JSON mode)
-| zi* [<commens>]      # Show zignatures matching information (rizin mode)
-| ziq [<commens>]      # Show zignatures matching information (quiet mode)
+| zi                   # Show zignatures matching information
+| zij                  # Show zignatures matching information (JSON mode)
+| zi*                  # Show zignatures matching information (rizin mode)
+| ziq                  # Show zignatures matching information (quiet mode)
 | zii <from> <to>      # Show zignatures matching information in range
 EOF
 RUN
@@ -264,7 +264,7 @@ CMDS=<<EOF
 ?*j zi
 EOF
 EXPECT=<<EOF
-{"zi":{"cmd":"zi","type":"argv_modes","args_str":" [<commens>]","args":[{"type":"string","name":"commens","is_last":true}],"description":"","summary":"Show zignatures matching information"},"zij":{"cmd":"zij","type":"argv_modes","args_str":" [<commens>]","args":[{"type":"string","name":"commens","is_last":true}],"description":"","summary":"Show zignatures matching information (JSON mode)"},"zi*":{"cmd":"zi*","type":"argv_modes","args_str":" [<commens>]","args":[{"type":"string","name":"commens","is_last":true}],"description":"","summary":"Show zignatures matching information (rizin mode)"},"ziq":{"cmd":"ziq","type":"argv_modes","args_str":" [<commens>]","args":[{"type":"string","name":"commens","is_last":true}],"description":"","summary":"Show zignatures matching information (quiet mode)"},"zii":{"cmd":"zii","type":"argv","args_str":" <from> <to>","args":[{"type":"number","name":"from","required":true},{"type":"number","name":"to","required":true}],"description":"","summary":"Show zignatures matching information in range"}}
+{"zi":{"cmd":"zi","type":"argv_modes","args_str":"","args":[],"description":"","summary":"Show zignatures matching information"},"zij":{"cmd":"zij","type":"argv_modes","args_str":"","args":[],"description":"","summary":"Show zignatures matching information (JSON mode)"},"zi*":{"cmd":"zi*","type":"argv_modes","args_str":"","args":[],"description":"","summary":"Show zignatures matching information (rizin mode)"},"ziq":{"cmd":"ziq","type":"argv_modes","args_str":"","args":[],"description":"","summary":"Show zignatures matching information (quiet mode)"},"zii":{"cmd":"zii","type":"argv","args_str":" <from> <to>","args":[{"type":"number","name":"from","required":true},{"type":"number","name":"to","required":true}],"description":"","summary":"Show zignatures matching information in range"}}
 EOF
 RUN
 
@@ -275,10 +275,10 @@ CMDS=<<EOF
 zi?*
 EOF
 EXPECT=<<EOF
-| zi [<commens>]       # Show zignatures matching information
-| zij [<commens>]      # Show zignatures matching information (JSON mode)
-| zi* [<commens>]      # Show zignatures matching information (rizin mode)
-| ziq [<commens>]      # Show zignatures matching information (quiet mode)
+| zi                   # Show zignatures matching information
+| zij                  # Show zignatures matching information (JSON mode)
+| zi*                  # Show zignatures matching information (rizin mode)
+| ziq                  # Show zignatures matching information (quiet mode)
 | zii <from> <to>      # Show zignatures matching information in range
 EOF
 RUN
@@ -289,7 +289,7 @@ CMDS=<<EOF
 zi?*j
 EOF
 EXPECT=<<EOF
-{"zi":{"cmd":"zi","type":"argv_modes","args_str":" [<commens>]","args":[{"type":"string","name":"commens","is_last":true}],"description":"","summary":"Show zignatures matching information"},"zij":{"cmd":"zij","type":"argv_modes","args_str":" [<commens>]","args":[{"type":"string","name":"commens","is_last":true}],"description":"","summary":"Show zignatures matching information (JSON mode)"},"zi*":{"cmd":"zi*","type":"argv_modes","args_str":" [<commens>]","args":[{"type":"string","name":"commens","is_last":true}],"description":"","summary":"Show zignatures matching information (rizin mode)"},"ziq":{"cmd":"ziq","type":"argv_modes","args_str":" [<commens>]","args":[{"type":"string","name":"commens","is_last":true}],"description":"","summary":"Show zignatures matching information (quiet mode)"},"zii":{"cmd":"zii","type":"argv","args_str":" <from> <to>","args":[{"type":"number","name":"from","required":true},{"type":"number","name":"to","required":true}],"description":"","summary":"Show zignatures matching information in range"}}
+{"zi":{"cmd":"zi","type":"argv_modes","args_str":"","args":[],"description":"","summary":"Show zignatures matching information"},"zij":{"cmd":"zij","type":"argv_modes","args_str":"","args":[],"description":"","summary":"Show zignatures matching information (JSON mode)"},"zi*":{"cmd":"zi*","type":"argv_modes","args_str":"","args":[],"description":"","summary":"Show zignatures matching information (rizin mode)"},"ziq":{"cmd":"ziq","type":"argv_modes","args_str":"","args":[],"description":"","summary":"Show zignatures matching information (quiet mode)"},"zii":{"cmd":"zii","type":"argv","args_str":" <from> <to>","args":[{"type":"number","name":"from","required":true},{"type":"number","name":"to","required":true}],"description":"","summary":"Show zignatures matching information in range"}}
 EOF
 RUN
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Both `zi*` and `f*` accepted a "comment" argument that was added while printing flags.

For example:
`pfx` was used while printing flags in rizin commands. For example, `f* hello` procuded:
```
f section..bss 4800 0x00022280+ hello
f section..gnu.build.attributes 1176 0x00025540+ hello
```
    
This was unused and wrong, because if there is already a comment for a flag, the resulting rizin command would be:
```
f hello 1 0x00000000+ hello base64:d29ybGQ=
```
    
Which would make the whole string "hello base64:d29ybGQ=" as a comment.
This commit just removes this feature of doubtful usefulness.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
