### PR TITLE
Fix Ada and FreePascal detection tests (broken)

### DIFF
--- a/test/db/abi/languages/ada
+++ b/test/db/abi/languages/ada
@@ -1,11 +1,21 @@
 NAME=LANGUAGES : ada detection
 FILE=bins/abi_bins/elf/languages/ada/ada_test
 CMDS=<<EOF
-iI~compiler,lang
+iI~compiler
 EOF
 EXPECT=<<EOF
 compiler GCC: (GNU) 6.2.1 20160916 (Red Hat 6.2.1-2) GCC: (GNU) 6.3.1 20161221 (Red Hat 6.3.1-1)
-lang     c
+EOF
+RUN
+
+NAME=LANGUAGES : ada detection
+FILE=bins/abi_bins/elf/languages/ada/ada_test
+BROKEN=1
+CMDS=<<EOF
+iI~lang
+EOF
+EXPECT=<<EOF
+lang     ada
 EOF
 RUN
 

--- a/test/db/abi/languages/freepascal
+++ b/test/db/abi/languages/freepascal
@@ -1,10 +1,11 @@
 NAME=LANGUAGES : freepascal detection
 FILE=bins/abi_bins/elf/languages/freepascal/pick_random
+BROKEN=1
 CMDS=<<EOF
-iI~compiler,lang
+iI~lang
 EOF
 EXPECT=<<EOF
-lang     c
+lang     freepascal
 EOF
 RUN
 


### PR DESCRIPTION
Fix Ada and FreePascal detection tests these tests are currently broken so I've marked then BROKEN=1

This is part of #878