### PR TITLE
Fixed slow loop on fuzz bin

### DIFF
--- a/librz/bin/format/java/class_attribute.c
+++ b/librz/bin/format/java/class_attribute.c
@@ -102,6 +102,7 @@ bool java_attribute_set_code(ConstPool **pool, ut32 poolsize, Attribute *attr, R
 				ac->attributes[i] = attr;
 			} else {
 				java_attribute_free(attr);
+				break;
 			}
 		}
 	}

--- a/librz/bin/format/java/class_bin.c
+++ b/librz/bin/format/java/class_bin.c
@@ -179,6 +179,7 @@ static bool java_class_parse(RzBinJavaClass *bin, ut64 base, Sdb *kv, RzBuffer *
 				bin->attributes[i] = attr;
 			} else {
 				java_attribute_free(attr);
+				break;
 			}
 		}
 	}

--- a/librz/bin/format/java/class_field.c
+++ b/librz/bin/format/java/class_field.c
@@ -65,7 +65,8 @@ Field *java_field_new(ConstPool **pool, ut32 poolsize, RzBuffer *buf, ut64 offse
 		if (attr && java_attribute_resolve(pool, poolsize, attr, buf, false)) {
 			field->attributes[i] = attr;
 		} else {
-			free(attr);
+			java_attribute_free(attr);
+			break;
 		}
 	}
 	return field;

--- a/librz/bin/format/java/class_method.c
+++ b/librz/bin/format/java/class_method.c
@@ -71,7 +71,8 @@ Method *java_method_new(ConstPool **pool, ut32 poolsize, RzBuffer *buf, ut64 off
 		if (attr && java_attribute_resolve(pool, poolsize, attr, buf, is_oak)) {
 			method->attributes[i] = attr;
 		} else {
-			free(attr);
+			java_attribute_free(attr);
+			break;
 		}
 	}
 	return method;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The issue was that the binary was running in a loop where it was reading ut16 values `0xffffffff * 0xffffffff` times.