### PR TITLE
cconfig.c: Refactor dup syscall sdb code into func

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -556,6 +556,13 @@ static void update_asmbits_options(RzCore *core, RzConfigNode *node) {
 	}
 }
 
+static void update_syscall_ns(RzCore *core) {
+	sdb_ns_unset(core->sdb, "syscall", NULL);
+	if (core->analysis->syscall->db) {
+		sdb_ns_set(core->sdb, "syscall", core->analysis->syscall->db);
+	}
+}
+
 static bool cb_asmarch(void *user, void *data) {
 	char asmparser[32];
 	RzCore *core = (RzCore *)user;
@@ -648,10 +655,7 @@ static bool cb_asmarch(void *user, void *data) {
 			//eprintf ("asm.arch: Cannot setup syscall '%s/%s' from '%s'\n",
 			//	node->value, asmos, RZ_LIBDIR"/rizin/"RZ_VERSION"/syscall");
 		}
-		sdb_ns_unset(core->sdb, "syscall", NULL);
-		if (core->analysis->syscall->db) {
-			sdb_ns_set(core->sdb, "syscall", core->analysis->syscall->db);
-		}
+		update_syscall_ns(core);
 	}
 	//if (!strcmp (node->value, "bf"))
 	//	rz_config_set (core->config, "dbg.backend", "bf");
@@ -780,10 +784,7 @@ static bool cb_asmbits(void *user, void *data) {
 			//eprintf ("asm.arch: Cannot setup syscall '%s/%s' from '%s'\n",
 			//	node->value, asmos, RZ_LIBDIR"/rizin/"RZ_VERSION"/syscall");
 		}
-		sdb_ns_unset(core->sdb, "syscall", NULL);
-		if (core->analysis->syscall->db) {
-			sdb_ns_set(core->sdb, "syscall", core->analysis->syscall->db);
-		}
+		update_syscall_ns(core);
 		__setsegoff(core->config, asmarch, core->analysis->bits);
 		if (core->dbg) {
 			rz_bp_use(core->dbg->bp, asmarch, core->analysis->bits);
@@ -946,10 +947,7 @@ static bool cb_asmos(void *user, void *data) {
 	if (asmarch) {
 		const char *asmcpu = rz_config_get(core->config, "asm.cpu");
 		rz_syscall_setup(core->analysis->syscall, asmarch->value, core->analysis->bits, asmcpu, node->value);
-		sdb_ns_unset(core->sdb, "syscall", NULL);
-		if (core->analysis->syscall->db) {
-			sdb_ns_set(core->sdb, "syscall", core->analysis->syscall->db);
-		}
+		update_syscall_ns(core);
 		__setsegoff(core->config, asmarch->value, asmbits);
 	}
 	rz_analysis_set_os(core->analysis, node->value);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr refactors the duplicate syscall sdb code in `cconfig.c` into a separate function.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
