### PR TITLE
Prevent rz_print_hexdump to get a negative size.

### DIFF
--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -679,6 +679,7 @@ RZ_API void rz_print_section(RzPrint *p, ut64 at) {
 }
 
 RZ_API void rz_print_hexdump(RzPrint *p, ut64 addr, const ut8 *buf, int len, int base, int step, size_t zoomsz) {
+	rz_return_if_fail(p && buf && len > 0);
 	PrintfCallback printfmt = (PrintfCallback)printf;
 #define print(x) printfmt("%s", x)
 	bool c = p ? (p->flags & RZ_PRINT_FLAGS_COLOR) : false;


### PR DESCRIPTION
This is just a small workaround for https://github.com/rizinorg/rizin/issues/759 but this does not solve the issue.

```
$ ./build/binrz/rizin/rizin -qc "wx e9bd ; Cd 190 1 @ 5 ; aa ; pd 3" -
WARNING: rz_print_hexdump: assertion 'p && buf && len > 0' failed (line 682)
┌ fcn.00000000 ();
│       ┌─< 0x00000000      e9bd000000     jmp   0xc2
        │   0x00000005 hex length=190 delta=0
0x00000005  0000 0000 0000 0000 0000 0000 0000 0000  ................
0x00000015  0000 0000 0000 0000 0000 0000 0000 0000  ................
0x00000025  0000 0000 0000 0000 0000 0000 0000 0000  ................
0x00000035  0000 0000 0000 0000 0000 0000 0000 0000  ................
0x00000045  0000 0000 0000 0000 0000 0000 0000 0000  ................
0x00000055  0000 0000 0000 0000 0000 0000 0000 0000  ................
0x00000065  0000 0000 0000 0000 0000 0000 0000 0000  ................
0x00000075  0000 0000 0000 0000 0000 0000 0000 0000  ................
0x00000085  0000 0000 0000 0000 0000 0000 0000 0000  ................
0x00000095  0000 0000 0000 0000 0000 0000 0000 0000  ................
0x000000a5  0000 0000 0000 0000 0000 0000 0000 0000  ................
0x000000b5  0000 0000 0000 0000 0000 0000 0000       ..............

│       │   ; CODE XREF from fcn.00000000 @ 
│       └─> 0x000000c2 hex length=190 delta=189

```