### PR TITLE
Remove duplicate definitions of `esilprintf` ##analysis

### DIFF
--- a/librz/analysis/p/analysis_arm_cs.c
+++ b/librz/analysis/p/analysis_arm_cs.c
@@ -10,8 +10,6 @@
 #include <rz_util/rz_assert.h>
 #include "./analysis_arm_hacks.inc"
 
-#define esilprintf(op, fmt, ...) rz_strbuf_setf(&op->esil, fmt, ##__VA_ARGS__)
-
 /* arm64 */
 #define IMM64(x)   (ut64)(insn->detail->arm64.operands[x].imm)
 #define INSOP64(x) insn->detail->arm64.operands[x]

--- a/librz/analysis/p/analysis_sparc_cs.c
+++ b/librz/analysis/p/analysis_sparc_cs.c
@@ -10,7 +10,6 @@
 #error Old Capstone not supported
 #endif
 
-#define esilprintf(op, fmt, ...) rz_strbuf_setf(&op->esil, fmt, ##__VA_ARGS__)
 #define INSOP(n)                 insn->detail->sparc.operands[n]
 #define INSCC                    insn->detail->sparc.cc
 

--- a/librz/analysis/p/analysis_sparc_cs.c
+++ b/librz/analysis/p/analysis_sparc_cs.c
@@ -10,8 +10,8 @@
 #error Old Capstone not supported
 #endif
 
-#define INSOP(n)                 insn->detail->sparc.operands[n]
-#define INSCC                    insn->detail->sparc.cc
+#define INSOP(n) insn->detail->sparc.operands[n]
+#define INSCC    insn->detail->sparc.cc
 
 static void opex(RzStrBuf *buf, csh handle, cs_insn *insn) {
 	int i;

--- a/librz/analysis/p/analysis_sysz.c
+++ b/librz/analysis/p/analysis_sysz.c
@@ -11,8 +11,7 @@
 #error Old Capstone not supported
 #endif
 
-#define esilprintf(op, fmt, ...) rz_strbuf_setf(&op->esil, fmt, ##__VA_ARGS__)
-#define INSOP(n)                 insn->detail->sysz.operands[n]
+#define INSOP(n) insn->detail->sysz.operands[n]
 
 static void opex(RzStrBuf *buf, csh handle, cs_insn *insn) {
 	int i;

--- a/librz/analysis/p/analysis_x86_cs.c
+++ b/librz/analysis/p/analysis_x86_cs.c
@@ -31,7 +31,6 @@ call = 4
 #error Old Capstone not supported
 #endif
 
-#define esilprintf(op, fmt, ...) rz_strbuf_setf(&op->esil, fmt, ##__VA_ARGS__)
 #define opexprintf(op, fmt, ...) rz_strbuf_setf(&op->opex, fmt, ##__VA_ARGS__)
 #define INSOP(n)                 insn->detail->x86.operands[n]
 #define INSOPS                   insn->detail->x86.op_count

--- a/librz/analysis/p/analysis_xcore_cs.c
+++ b/librz/analysis/p/analysis_xcore_cs.c
@@ -10,8 +10,7 @@
 #error Old Capstone not supported
 #endif
 
-#define esilprintf(op, fmt, ...) rz_strbuf_setf(&op->esil, fmt, ##__VA_ARGS__)
-#define INSOP(n)                 insn->detail->xcore.operands[n]
+#define INSOP(n) insn->detail->xcore.operands[n]
 
 static void opex(RzStrBuf *buf, csh handle, cs_insn *insn) {
 	int i;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`esilprintf` is defined in rz_analysis.h, but was redefined and used in many files related to analysis of different
architectures. This patch removes all those duplicate definitions.

**Test plan**

CI passes with no complaints.

**Closing issues**

None
