### PR TITLE
Add more Config Vars to Project Load Exclusions

### DIFF
--- a/librz/core/serialize_core.c
+++ b/librz/core/serialize_core.c
@@ -49,6 +49,8 @@ static const char *const config_exclude[] = {
 	"dir.tmp",
 	"dir.types",
 	"dir.zigns",
+	"http.root",
+	"pdb.symstore",
 	"scr.color",
 	"scr.color.args",
 	"scr.color.bytes",

--- a/librz/core/serialize_core.c
+++ b/librz/core/serialize_core.c
@@ -39,8 +39,27 @@ RZ_API void rz_serialize_core_save(RZ_NONNULL Sdb *db, RZ_NONNULL RzCore *core, 
 }
 
 static const char *const config_exclude[] = {
-	"scr.interactive", // especially relevant for Cutter since it needs this to be false
+	"dir.home",
+	"dir.libs",
+	"dir.magic",
+	"dir.plugins",
+	"dir.prefix",
+	"dir.projects",
+	"dir.source",
+	"dir.tmp",
+	"dir.types",
+	"dir.zigns",
 	"scr.color",
+	"scr.color.args",
+	"scr.color.bytes",
+	"scr.color.grep",
+	"scr.color.ops",
+	"scr.color.pipe",
+	"scr.interactive", // especially relevant for Cutter since it needs this to be false
+	"scr.rainbow",
+	"scr.utf8",
+	"scr.utf8.curvy",
+	"ghidra.sleighhome", // also important for Cutter
 	NULL
 };
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This prevents certain config vars from the project creator's host to be loaded into the loader's session where they don't make sense anymore, especially file paths.
Necessary for Cutter.

This will eventually be replaced by a better solution than this exclusion list.

**Test plan**

Save a project on one host and load it on another. Color schemes may be wrong and `ghidra.sleighhome` will be incorrect among others.