### PR TITLE
Update missing copyrights

### DIFF
--- a/librz/bin/pdb/dbi.h
+++ b/librz/bin/pdb/dbi.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2014 inisider <inisider@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef DBI_H
 #define DBI_H
 

--- a/librz/bin/pdb/fpo.h
+++ b/librz/bin/pdb/fpo.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2014 inisider <inisider@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef FPO_H
 #define FPO_H
 

--- a/librz/bin/pdb/gdata.h
+++ b/librz/bin/pdb/gdata.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2014 inisider <inisider@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef GDATA_H
 #define GDATA_H
 

--- a/librz/bin/pdb/omap.h
+++ b/librz/bin/pdb/omap.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2014 inisider <inisider@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef OMAP_H
 #define OMAP_H
 

--- a/librz/bin/pdb/pdb_downloader.h
+++ b/librz/bin/pdb/pdb_downloader.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2014-2015 inisider <inisider@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef PDB_DOWNLOADER_H
 #define PDB_DOWNLOADER_H
 

--- a/librz/bin/pdb/stream_file.h
+++ b/librz/bin/pdb/stream_file.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2014 inisider <inisider@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef STREAM_FILE_H
 #define STREAM_FILE_H
 

--- a/librz/bin/pdb/stream_pe.h
+++ b/librz/bin/pdb/stream_pe.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2015 pancake <pancake@nopcode.org>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef PE_H
 #define PE_H
 

--- a/librz/bin/pdb/tpi.h
+++ b/librz/bin/pdb/tpi.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2014 inisider <inisider@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef TPI_H
 #define TPI_H
 

--- a/librz/bin/pdb/types.h
+++ b/librz/bin/pdb/types.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2014-2020 inisider <inisider@gmail.com>
+// SPDX-FileCopyrightText: 2020 HoundThe <cgkajm@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef PDB_TYPES_H
 #define PDB_TYPES_H
 

--- a/librz/core/cdwarf.c
+++ b/librz/core/cdwarf.c
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2021 thestr4ng3r <info@florianmaerkl.de>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include <rz_core.h>
 
 RZ_API void rz_core_bin_dwarf_print_abbrev_section(const RzBinDwarfDebugAbbrev *da) {

--- a/librz/util/asn1_oids.h
+++ b/librz/util/asn1_oids.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2017-2018 deroad <wargio@libero.it>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef OIDS_H
 #define OIDS_H
 

--- a/librz/util/x509.h
+++ b/librz/util/x509.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2017-2018 deroad <wargio@libero.it>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef RZ_X509_INTERNAL_H
 #define RZ_X509_INTERNAL_H
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

More fixes to improve the `reuse lint` score.
Added copyrights are based on the git history of Rizin and Radare2.

Was:
```
* Files with copyright information: 2765 / 3017
* Files with license information: 2766 / 3017
```
Now:
```
* Files with copyright information: 2777 / 3017
* Files with license information: 2778 / 3017
```

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/683