### PR TITLE
Detect presence of extern char **environ

### DIFF
--- a/librz/include/rz_userconf.h.in
+++ b/librz/include/rz_userconf.h.in
@@ -18,6 +18,7 @@
 #define HAVE_EXECL                  @HAVE_EXECL@
 #define HAVE_SYSTEM                 @HAVE_SYSTEM@
 #define HAVE_PIPE2                  @HAVE_PIPE2@
+#define HAVE_ENVIRON                @HAVE_ENVIRON@
 #define HAVE_LIB_MAGIC              @HAVE_LIB_MAGIC@
 #define USE_LIB_MAGIC               @USE_LIB_MAGIC@
 #define HAVE_LIB_XXHASH             @HAVE_LIB_XXHASH@

--- a/librz/util/subprocess.c
+++ b/librz/util/subprocess.c
@@ -603,7 +603,6 @@ RZ_API void rz_subprocess_fini(void) {
 	rz_th_lock_free(subprocs_mutex);
 }
 
-extern char **environ;
 static char **create_child_env(const char *envvars[], const char *envvals[], size_t env_size) {
 	char **ep;
 	size_t new_env_size = env_size, size = 0;
@@ -612,6 +611,7 @@ static char **create_child_env(const char *envvars[], const char *envvals[], siz
 		positions[i] = SIZE_MAX;
 	}
 
+	char **environ = rz_sys_get_environ();
 	for (ep = environ; *ep; ep++, size++) {
 		size_t j;
 
@@ -764,7 +764,7 @@ RZ_API RzSubprocess *rz_subprocess_start_opt(RzSubprocessOpt *opt) {
 		}
 
 		// Use the previously created environment
-		environ = child_env;
+		rz_sys_set_environ(child_env);
 
 		rz_sys_execvp(opt->file, argv);
 		perror("exec");

--- a/librz/util/sys.c
+++ b/librz/util/sys.c
@@ -1247,7 +1247,7 @@ RZ_API char *rz_sys_pid_to_path(int pid) {
 RZ_API void rz_sys_env_init(void) {
 	char **envp = rz_sys_get_environ();
 	if (envp) {
-		rz_sys_set_environ(envp);
+		env = envp;
 	}
 }
 
@@ -1266,6 +1266,9 @@ RZ_API char **rz_sys_get_environ(void) {
 
 RZ_API void rz_sys_set_environ(char **e) {
 	env = e;
+#if HAVE_ENVIRON
+	environ = e;
+#endif
 }
 
 RZ_API char *rz_sys_whoami(char *buf) {

--- a/librz/util/sys.c
+++ b/librz/util/sys.c
@@ -43,11 +43,6 @@ static char **env = NULL;
 #endif
 #if __APPLE__
 #include <errno.h>
-#ifdef __MAC_10_8
-#define HAVE_ENVIRON 1
-#else
-#define HAVE_ENVIRON 0
-#endif
 
 #if HAVE_ENVIRON
 #include <execinfo.h>

--- a/meson.build
+++ b/meson.build
@@ -331,6 +331,11 @@ if not cc.has_function('clock_gettime', prefix: '#include <time.h>') and cc.has_
   lrt = cc.find_library('rt', required: true, static: is_static_build)
 endif
 
+code = '#include <unistd.h>\nextern char **environ;\nint main() { char **env = environ; }'
+have_environ = cc.links(code, name: 'have extern char **environ')
+userconf.set10('HAVE_ENVIRON', have_environ)
+message('HAVE_ENVIRON: @0@'.format(have_environ))
+
 foreach item : [
     ['arc4random_uniform', '#include <stdlib.h>', []],
     ['explicit_bzero', '#include <string.h>', []],


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Detecting if the platform has `extern char **environ` variable.

**Test plan**

All green, look for `HAVE_ENVIRON` in the logs.

**Closing issues**

Closes #952 
