### PR TITLE
Remove some exit() calls from librz/

### DIFF
--- a/librz/crypto/p/crypto_serpent_algo.c
+++ b/librz/crypto/p/crypto_serpent_algo.c
@@ -1,4 +1,5 @@
 #include "crypto_serpent_algo.h"
+#include <rz_util/rz_assert.h>
 
 static const ut8 S[][16] = {
 	{ 3, 8, 15, 1, 10, 6, 5, 11, 14, 13, 4, 2, 7, 0, 9, 12 }, /* S0: */
@@ -64,10 +65,7 @@ static inline ut8 apply_sbox_inv(int si, ut8 x) {
 }
 
 static inline ut8 get_bit(int i, ut32 input) {
-	if (i >= 32) {
-		eprintf("Wrong bit asked");
-		exit(1);
-	}
+	rz_return_val_if_fail(i < 32, 0);
 	return (input >> i) & 1;
 }
 
@@ -91,10 +89,7 @@ void apply_FP(ut32 in[DW_BY_BLOCK], ut32 out[DW_BY_BLOCK]) {
 
 void serpent_keyschedule(struct serpent_state st,
 	ut32 subkeys[NB_SUBKEYS * DW_BY_BLOCK]) {
-	if ((st.key_size != 128) && (st.key_size != 192) && (st.key_size != 256)) {
-		eprintf("Invalid key size");
-		exit(1);
-	}
+	rz_return_if_fail((st.key_size == 128) || (st.key_size == 192) || (st.key_size == 256));
 
 	ut32 tmpkeys[DW_BY_BLOCK * NB_SUBKEYS + DW_BY_USERKEY] = { 0 };
 	const ut32 phi = 0x9e3779b9;

--- a/librz/egg/egg_lang.c
+++ b/librz/egg/egg_lang.c
@@ -1049,7 +1049,8 @@ static void rcc_next(RzEgg *egg) {
 		if (!strcmp(str, "while")) {
 			char var[128];
 			if (egg->lang.lastctxdelta >= 0) {
-				exit(eprintf("ERROR: Unsupported while syntax\n"));
+				eprintf("ERROR: Unsupported while syntax\n");
+				return;
 			}
 			sprintf(var, "__begin_%d_%d_%d\n", egg->lang.nfunctions, CTX, egg->lang.nestedi[CTX - 1]);
 			e->while_end(egg, var); // get_frame_label (1));
@@ -1292,9 +1293,10 @@ RZ_API int rz_egg_lang_parsechar(RzEgg *egg, char c) {
 	}
 	if (egg->lang.slurp) {
 		if (egg->lang.slurp != '"' && c == egg->lang.slurpin) { // only happend when (...(...)...)
-			exit(eprintf(
+			eprintf(
 				"%s:%d Nesting of expressions not yet supported\n",
-				egg->lang.file, egg->lang.line));
+				egg->lang.file, egg->lang.line);
+			return -1;
 		}
 		if (c == egg->lang.slurp && egg->lang.oc != '\\') { // close egg->lang.slurp
 			egg->lang.elem[egg->lang.elem_n] = '\0';

--- a/librz/egg/rlcc/rlcc.c
+++ b/librz/egg/rlcc/rlcc.c
@@ -191,7 +191,7 @@ int main(int argc, char **argv) {
 	if (err != NULL) {
 		mpc_err_print(err);
 		mpc_err_delete(err);
-		exit(1);
+		return -1;
 	}
 
 #if 1


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Reported by Fedora packagers:
```
rizin.x86_64: W: shared-lib-calls-exit /usr/lib64/librz_core.so.0.1.2 exit@GLIBC_2.2.5
rizin.x86_64: W: shared-lib-calls-exit /usr/lib64/librz_crypto.so.0.1.2 exit@GLIBC_2.2.5
rizin.x86_64: W: shared-lib-calls-exit /usr/lib64/librz_egg.so.0.1.2 exit@GLIBC_2.2.5
rizin.x86_64: W: shared-lib-calls-exit /usr/lib64/librz_main.so.0.1.2 exit@GLIBC_2.2.5
rizin.x86_64: W: shared-lib-calls-exit /usr/lib64/librz_socket.so.0.1.2 exit@GLIBC_2.2.5
Libraries should not called exit… Unless it's a false positive, seems like an upstream bug.
```

I removed some of the `exit()` calls in `librz/crypto` and `librz/egg`. The ones in `librz/core`, `librz/socket`, and `librz/main` are trickier.

Ideally, there should be no `exit()` calls at all in **ANY** of `librz/` files.

**Test plan**

CI is green.

**Leftovers**
```
[i] ℤ rg "[ \t]+exit\(" librz                                                                                                                                                                                                     13:16:39 
librz/socket/socket.c
228:                    exit(1);
231:            exit(0);

librz/socket/run.c
354:            exit(code);
718:    exit(0);
777:            exit(0);
1052:                   exit(0);
1069:           exit(rz_sys_execv(p->_program, (char *const *)p->_args));
1116:           exit(ret);
1130:                           exit(1);
1140:                           exit(0);
1156:                                   exit(0);
1169:                   exit(ret);
1171:                   exit(rz_sys_system(p->_system));
1177:                   exit(rz_sys_system(p->_system));
1235:                           exit(1);
1244:                                   exit(0);
1249:                   exit(rz_sys_execv(p->_program, (char *const *)p->_args));
1255:           exit(rz_sys_execv(p->_program, (char *const *)p->_args));

librz/util/sys.c
198:            exit(status);
416:    exit(rz_sys_system(cmd));
642:            exit(ret);
795:    exit(0);
981:            exit(ret);
1027:           exit(0);
1779:   exit(1);

librz/main/rizin.c
714:                    exit(0);
1440:           exit(ret);

librz/socket/socket_proc.c
43:             exit(1);

librz/socket/rzpipe.c
309:            exit(rc);

librz/io/p/io_debug.c
222:            exit(MAGIC_EXIT);
382:            exit(1);
388:            exit(1);
394:    exit(1);

librz/core/rtr.c
150:    exit(0);

librz/core/cmd_quit.c
54:                     exit(0);

librz/asm/arch/arm/gnu/arm-dis.c
48:#define abort() exit(1)
```