### PR TITLE
Refactor VA Calculation, binsyms and Import Resolving

### DIFF
--- a/librz/bin/bfile.c
+++ b/librz/bin/bfile.c
@@ -49,7 +49,7 @@ static void print_string(RzBinFile *bf, RzBinString *string, int raw, PJ *pj) {
 	}
 	section_name = s ? s->name : "";
 	type_string = rz_bin_string_type(string->type);
-	vaddr = addr = rz_bin_get_vaddr(bin, string->paddr, string->vaddr);
+	vaddr = addr = bf->o ? rz_bin_object_get_vaddr(bf->o, string->paddr, string->vaddr) : UT64_MAX;
 
 	// If raw string dump mode, use printf to dump directly to stdout.
 	//  PrintfCallback temp = io->cb_printf;
@@ -1015,17 +1015,6 @@ RZ_API RzBinField *rz_bin_file_add_field(RzBinFile *binfile, const char *classna
 	//TODO: add_field into class
 	//eprintf ("TODO add field: %s \n", name);
 	return NULL;
-}
-
-// XXX this api name makes no sense
-/* returns vaddr, rebased with the baseaddr of binfile, if va is enabled for
- * bin, paddr otherwise */
-RZ_API ut64 rz_bin_file_get_vaddr(RzBinFile *bf, ut64 paddr, ut64 vaddr) {
-	rz_return_val_if_fail(bf && bf->o, paddr);
-	if (bf->o->info && bf->o->info->has_va) {
-		return rz_bin_object_addr_with_base(bf->o, vaddr);
-	}
-	return paddr;
 }
 
 RZ_API RzList *rz_bin_file_get_trycatch(RzBinFile *bf) {

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -1251,29 +1251,6 @@ RZ_API RzList * /*<RzBinClass>*/ rz_bin_get_classes(RzBin *bin) {
 	return o ? o->classes : NULL;
 }
 
-/* returns vaddr, rebased with the baseaddr of bin, if va is enabled for bin,
- * paddr otherwise */
-RZ_API ut64 rz_bin_get_vaddr(RzBin *bin, ut64 paddr, ut64 vaddr) {
-	rz_return_val_if_fail(bin && paddr != UT64_MAX, UT64_MAX);
-
-	if (!bin->cur) {
-		return paddr;
-	}
-	/* hack to realign thumb symbols */
-	if (bin->cur->o && bin->cur->o->info && bin->cur->o->info->arch) {
-		if (bin->cur->o->info->bits == 16) {
-			RzBinSection *s = rz_bin_get_section_at(bin->cur->o, paddr, false);
-			// autodetect thumb
-			if (s && (s->perm & RZ_PERM_X) && strstr(s->name, "text")) {
-				if (!strcmp(bin->cur->o->info->arch, "arm") && (vaddr & 1)) {
-					vaddr = (vaddr >> 1) << 1;
-				}
-			}
-		}
-	}
-	return rz_bin_file_get_vaddr(bin->cur, paddr, vaddr);
-}
-
 RZ_API ut64 rz_bin_get_size(RzBin *bin) {
 	rz_return_val_if_fail(bin, UT64_MAX);
 	RzBinObject *o = rz_bin_cur_object(bin);

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -656,15 +656,6 @@ RZ_API void rz_bin_set_baddr(RzBin *bin, ut64 baddr) {
 	// maybe in RzBinFile.rebase() ?
 }
 
-RZ_API RzBinAddr *rz_bin_get_sym(RzBin *bin, int sym) {
-	rz_return_val_if_fail(bin, NULL);
-	RzBinObject *o = rz_bin_cur_object(bin);
-	if (sym < 0 || sym >= RZ_BIN_SYM_LAST) {
-		return NULL;
-	}
-	return o ? o->binsym[sym] : NULL;
-}
-
 // XXX: those accessors are redundant
 RZ_API RzList *rz_bin_get_entries(RzBin *bin) {
 	rz_return_val_if_fail(bin, NULL);

--- a/librz/bin/bobj.c
+++ b/librz/bin/bobj.c
@@ -52,7 +52,7 @@ static void object_delete_items(RzBinObject *o) {
 	rz_bin_source_line_info_free(o->lines);
 	sdb_free(o->kv);
 	rz_list_free(o->mem);
-	for (i = 0; i < RZ_BIN_SYM_LAST; i++) {
+	for (i = 0; i < RZ_BIN_SPECIAL_SYMBOL_LAST; i++) {
 		free(o->binsym[i]);
 	}
 }
@@ -298,7 +298,7 @@ RZ_API int rz_bin_object_set_items(RzBinFile *bf, RzBinObject *o) {
 	}
 	// XXX this is expensive because is O(n^n)
 	if (p->binsym) {
-		for (i = 0; i < RZ_BIN_SYM_LAST; i++) {
+		for (i = 0; i < RZ_BIN_SPECIAL_SYMBOL_LAST; i++) {
 			o->binsym[i] = p->binsym(bf, i);
 			if (o->binsym[i]) {
 				o->binsym[i]->paddr += o->loadaddr;
@@ -553,4 +553,12 @@ RZ_API ut64 rz_bin_object_get_vaddr(RzBinObject *o, ut64 paddr, ut64 vaddr) {
 		return rz_bin_object_addr_with_base(o, vaddr);
 	}
 	return paddr;
+}
+
+RZ_API RzBinAddr *rz_bin_object_get_special_symbol(RzBinObject *o, RzBinSpecialSymbol sym) {
+	rz_return_val_if_fail(o, NULL);
+	if (sym < 0 || sym >= RZ_BIN_SPECIAL_SYMBOL_LAST) {
+		return NULL;
+	}
+	return o ? o->binsym[sym] : NULL;
 }

--- a/librz/bin/format/java/class_bin.c
+++ b/librz/bin/format/java/class_bin.c
@@ -763,7 +763,7 @@ RZ_API void rz_bin_java_class_as_source_code(RzBinJavaClass *bin, RzStrBuf *sb) 
 	rz_strbuf_append(sb, "}\n");
 }
 
-RZ_API RzBinAddr *rz_bin_java_class_resolve_symbol(RzBinJavaClass *bin, int resolve) {
+RZ_API RzBinAddr *rz_bin_java_class_resolve_symbol(RzBinJavaClass *bin, RzBinSpecialSymbol resolve) {
 	rz_return_val_if_fail(bin, NULL);
 
 	RzBinAddr *ret = RZ_NEW0(RzBinAddr);
@@ -785,12 +785,12 @@ RZ_API RzBinAddr *rz_bin_java_class_resolve_symbol(RzBinJavaClass *bin, int reso
 				continue;
 			}
 
-			if (resolve == RZ_BIN_SYM_ENTRY || resolve == RZ_BIN_SYM_INIT) {
+			if (resolve == RZ_BIN_SPECIAL_SYMBOL_ENTRY || resolve == RZ_BIN_SPECIAL_SYMBOL_INIT) {
 				if (strcmp(name, "<init>") != 0 && strcmp(name, "<clinit>") != 0) {
 					free(name);
 					continue;
 				}
-			} else if (resolve == RZ_BIN_SYM_MAIN) {
+			} else if (resolve == RZ_BIN_SPECIAL_SYMBOL_MAIN) {
 				if (strcmp(name, "main") != 0) {
 					free(name);
 					continue;

--- a/librz/bin/format/java/class_bin.h
+++ b/librz/bin/format/java/class_bin.h
@@ -77,7 +77,7 @@ RZ_API char *rz_bin_java_class_const_pool_resolve_index(RzBinJavaClass *bin, st3
 
 /* used in bin_java.c and core_java.c */
 RZ_API void rz_bin_java_class_as_source_code(RzBinJavaClass *bin, RzStrBuf *sb);
-RZ_API RzBinAddr *rz_bin_java_class_resolve_symbol(RzBinJavaClass *bin, int resolve);
+RZ_API RzBinAddr *rz_bin_java_class_resolve_symbol(RzBinJavaClass *bin, RzBinSpecialSymbol resolve);
 RZ_API RzList *rz_bin_java_class_strings(RzBinJavaClass *bin);
 RZ_API RzList *rz_bin_java_class_entrypoints(RzBinJavaClass *bin);
 RZ_API RzList *rz_bin_java_class_methods_as_symbols(RzBinJavaClass *bin);

--- a/librz/bin/p/bin_art.c
+++ b/librz/bin/p/bin_art.c
@@ -118,7 +118,6 @@ static RzBinInfo *info(RzBinFile *bf) {
 	ret->machine = strdup("arm");
 	ret->arch = strdup("arm");
 	ret->has_va = 1;
-	ret->has_lit = true;
 	ret->has_pi = ao->art.compile_pic;
 	ret->bits = 16; // 32? 64?
 	ret->big_endian = 0;

--- a/librz/bin/p/bin_avr.c
+++ b/librz/bin/p/bin_avr.c
@@ -86,7 +86,6 @@ static RzBinInfo *info(RzBinFile *bf) {
 		bi->machine = strdup("ATmel");
 		bi->os = strdup("avr");
 		bi->has_va = 0; // 1;
-		bi->has_lit = false;
 		bi->arch = strdup("avr");
 		bi->bits = 8;
 	}

--- a/librz/bin/p/bin_coff.c
+++ b/librz/bin/p/bin_coff.c
@@ -39,7 +39,7 @@ static ut64 baddr(RzBinFile *bf) {
 	return 0;
 }
 
-static RzBinAddr *binsym(RzBinFile *bf, int sym) {
+static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol sym) {
 	return NULL;
 }
 

--- a/librz/bin/p/bin_coff.c
+++ b/librz/bin/p/bin_coff.c
@@ -528,7 +528,6 @@ static RzBinInfo *info(RzBinFile *bf) {
 	ret->big_endian = obj->endian;
 	ret->has_va = true;
 	ret->dbg_info = 0;
-	ret->has_lit = true;
 
 	if (rz_coff_is_stripped(obj)) {
 		ret->dbg_info |= RZ_BIN_DBG_STRIPPED;

--- a/librz/bin/p/bin_dex.c
+++ b/librz/bin/p/bin_dex.c
@@ -753,7 +753,6 @@ static RzBinInfo *info(RzBinFile *bf) {
 	ret->file = bf->file ? strdup(bf->file) : NULL;
 	ret->type = strdup("DEX CLASS");
 	ret->has_va = true;
-	ret->has_lit = true;
 	ret->bclass = rz_bin_dex_get_version(bf->o->bin_obj);
 	ret->rclass = strdup("class");
 	ret->os = strdup("linux");

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -118,23 +118,25 @@ static ut64 boffset(RzBinFile *bf) {
 	return Elf_(rz_bin_elf_get_boffset)(bf->o->bin_obj);
 }
 
-static RzBinAddr *binsym(RzBinFile *bf, int sym) {
+static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol sym) {
 	struct Elf_(rz_bin_elf_obj_t) *obj = bf->o->bin_obj;
 	RzBinAddr *ret = NULL;
 	ut64 addr = 0LL;
 
 	switch (sym) {
-	case RZ_BIN_SYM_ENTRY:
+	case RZ_BIN_SPECIAL_SYMBOL_ENTRY:
 		addr = Elf_(rz_bin_elf_get_entry_offset)(bf->o->bin_obj);
 		break;
-	case RZ_BIN_SYM_MAIN:
+	case RZ_BIN_SPECIAL_SYMBOL_MAIN:
 		addr = Elf_(rz_bin_elf_get_main_offset)(bf->o->bin_obj);
 		break;
-	case RZ_BIN_SYM_INIT:
+	case RZ_BIN_SPECIAL_SYMBOL_INIT:
 		addr = Elf_(rz_bin_elf_get_init_offset)(bf->o->bin_obj);
 		break;
-	case RZ_BIN_SYM_FINI:
+	case RZ_BIN_SPECIAL_SYMBOL_FINI:
 		addr = Elf_(rz_bin_elf_get_fini_offset)(bf->o->bin_obj);
+		break;
+	default:
 		break;
 	}
 	if (addr && addr != UT64_MAX && (ret = RZ_NEW0(RzBinAddr))) {

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -1112,7 +1112,6 @@ static RzBinInfo *info(RzBinFile *bf) {
 	}
 	ret->type = str;
 	ret->has_pi = (strstr(str, "DYN")) ? 1 : 0;
-	ret->has_lit = true;
 	ret->has_sanitizers = has_sanitizers(bf);
 	if (!(str = Elf_(rz_bin_elf_get_elf_class)(obj))) {
 		free(ret);

--- a/librz/bin/p/bin_java.c
+++ b/librz/bin/p/bin_java.c
@@ -171,7 +171,7 @@ static RzList *libs(RzBinFile *bf) {
 	return rz_bin_java_class_as_libraries(jclass);
 }
 
-static RzBinAddr *binsym(RzBinFile *bf, int sym) {
+static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol sym) {
 	RzBinJavaClass *jclass = rz_bin_file_get_java_class(bf);
 	if (!jclass) {
 		return NULL;

--- a/librz/bin/p/bin_mach0.c
+++ b/librz/bin/p/bin_mach0.c
@@ -518,7 +518,6 @@ static RzBinInfo *info(RzBinFile *bf) {
 	ret->subsystem = strdup("darwin");
 	ret->arch = strdup(MACH0_(get_cputype)(bf->o->bin_obj));
 	ret->machine = MACH0_(get_cpusubtype)(bf->o->bin_obj);
-	ret->has_lit = true;
 	ret->type = MACH0_(get_filetype)(bf->o->bin_obj);
 	ret->big_endian = MACH0_(is_big_endian)(bf->o->bin_obj);
 	ret->bits = 32;

--- a/librz/bin/p/bin_mach0.c
+++ b/librz/bin/p/bin_mach0.c
@@ -1113,11 +1113,11 @@ static RzBuffer *create(RzBin *bin, const ut8 *code, int clen, const ut8 *data, 
 	return buf;
 }
 
-static RzBinAddr *binsym(RzBinFile *bf, int sym) {
+static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol sym) {
 	ut64 addr;
 	RzBinAddr *ret = NULL;
 	switch (sym) {
-	case RZ_BIN_SYM_MAIN:
+	case RZ_BIN_SPECIAL_SYMBOL_MAIN:
 		addr = MACH0_(get_main)(bf->o->bin_obj);
 		if (addr == UT64_MAX || !(ret = RZ_NEW0(RzBinAddr))) {
 			return NULL;
@@ -1127,6 +1127,8 @@ static RzBinAddr *binsym(RzBinFile *bf, int sym) {
 		ret->vaddr = ((addr >> 1) << 1);
 		//}
 		ret->paddr = ret->vaddr;
+		break;
+	default:
 		break;
 	}
 	return ret;

--- a/librz/bin/p/bin_mach064.c
+++ b/librz/bin/p/bin_mach064.c
@@ -270,16 +270,18 @@ static RzBuffer *create(RzBin *bin, const ut8 *code, int codelen, const ut8 *dat
 	return buf;
 }
 
-static RzBinAddr *binsym(RzBinFile *bf, int sym) {
+static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol sym) {
 	ut64 addr;
 	RzBinAddr *ret = NULL;
 	switch (sym) {
-	case RZ_BIN_SYM_MAIN:
+	case RZ_BIN_SPECIAL_SYMBOL_MAIN:
 		addr = MACH0_(get_main)(bf->o->bin_obj);
 		if (!addr || !(ret = RZ_NEW0(RzBinAddr))) {
 			return NULL;
 		}
 		ret->paddr = ret->vaddr = addr;
+		break;
+	default:
 		break;
 	}
 	return ret;

--- a/librz/bin/p/bin_mdmp.c
+++ b/librz/bin/p/bin_mdmp.c
@@ -65,9 +65,6 @@ static RzBinInfo *info(RzBinFile *bf) {
 	ret->rpath = strdup("NONE");
 	ret->type = strdup("MDMP (MiniDump crash report data)");
 
-	// FIXME: Needed to fix issue with PLT resolving. Can we get away with setting this for all children bins?
-	ret->has_lit = true;
-
 	sdb_set(bf->sdb, "mdmp.flags", sdb_fmt("0x%08" PFMT64x, obj->hdr->flags), 0);
 	sdb_num_set(bf->sdb, "mdmp.streams", obj->hdr->number_of_streams, 0);
 

--- a/librz/bin/p/bin_mz.c
+++ b/librz/bin/p/bin_mz.c
@@ -114,12 +114,14 @@ static void destroy(RzBinFile *bf) {
 	rz_bin_mz_free((struct rz_bin_mz_obj_t *)bf->o->bin_obj);
 }
 
-static RzBinAddr *binsym(RzBinFile *bf, int type) {
+static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol type) {
 	RzBinAddr *mzaddr = NULL;
 	if (bf && bf->o && bf->o->bin_obj) {
 		switch (type) {
-		case RZ_BIN_SYM_MAIN:
+		case RZ_BIN_SPECIAL_SYMBOL_MAIN:
 			mzaddr = rz_bin_mz_get_main_vaddr(bf->o->bin_obj);
+			break;
+		default:
 			break;
 		}
 	}

--- a/librz/bin/p/bin_ningb.c
+++ b/librz/bin/p/bin_ningb.c
@@ -24,8 +24,8 @@ static ut64 baddr(RzBinFile *bf) {
 	return 0LL;
 }
 
-static RzBinAddr *binsym(RzBinFile *bf, int type) {
-	if (type == RZ_BIN_SYM_MAIN && bf && bf->buf) {
+static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol type) {
+	if (type == RZ_BIN_SPECIAL_SYMBOL_MAIN && bf && bf->buf) {
 		ut8 init_jmp[4];
 		RzBinAddr *ret = RZ_NEW0(RzBinAddr);
 		if (!ret) {

--- a/librz/bin/p/bin_nro.c
+++ b/librz/bin/p/bin_nro.c
@@ -243,7 +243,6 @@ static RzBinInfo *info(RzBinFile *bf) {
 	}
 	ret->bits = 64;
 	ret->has_va = true;
-	ret->has_lit = true;
 	ret->big_endian = false;
 	ret->dbg_info = 0;
 	ret->dbg_info = 0;

--- a/librz/bin/p/bin_nro.c
+++ b/librz/bin/p/bin_nro.c
@@ -54,7 +54,7 @@ static bool load_buffer(RzBinFile *bf, void **bin_obj, RzBuffer *b, ut64 loadadd
 	return true;
 }
 
-static RzBinAddr *binsym(RzBinFile *bf, int type) {
+static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol type) {
 	return NULL; // TODO
 }
 

--- a/librz/bin/p/bin_nso.c
+++ b/librz/bin/p/bin_nso.c
@@ -267,7 +267,6 @@ static RzBinInfo *info(RzBinFile *bf) {
 	ret->type = strdup("EXEC (executable file)");
 	ret->bits = 64;
 	ret->has_va = true;
-	ret->has_lit = true;
 	ret->big_endian = false;
 	ret->dbg_info = 0;
 	return ret;

--- a/librz/bin/p/bin_nso.c
+++ b/librz/bin/p/bin_nso.c
@@ -142,7 +142,7 @@ static bool load_buffer(RzBinFile *bf, void **bin_obj, RzBuffer *buf, ut64 loada
 	return load_bytes(bf, bin_obj, bytes, sz, la, bf->sdb);
 }
 
-static RzBinAddr *binsym(RzBinFile *bf, int type) {
+static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol type) {
 	return NULL; // TODO
 }
 

--- a/librz/bin/p/bin_omf.c
+++ b/librz/bin/p/bin_omf.c
@@ -146,7 +146,6 @@ static RzBinInfo *info(RzBinFile *bf) {
 	ret->arch = strdup("x86");
 	ret->big_endian = false;
 	ret->has_va = true;
-	ret->has_lit = true;
 	ret->bits = rz_bin_omf_get_bits(bf->o->bin_obj);
 	ret->dbg_info = 0;
 	ret->has_nx = false;

--- a/librz/bin/p/bin_p9.c
+++ b/librz/bin/p/bin_p9.c
@@ -24,7 +24,7 @@ static ut64 baddr(RzBinFile *bf) {
 	return 0x1000000; // XXX
 }
 
-static RzBinAddr *binsym(RzBinFile *bf, int type) {
+static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol type) {
 	return NULL; // TODO
 }
 

--- a/librz/bin/p/bin_pe.inc
+++ b/librz/bin/p/bin_pe.inc
@@ -40,13 +40,15 @@ static ut64 baddr(RzBinFile *bf) {
 	return PE_(rz_bin_pe_get_image_base)(bf->o->bin_obj);
 }
 
-static RzBinAddr *binsym(RzBinFile *bf, int type) {
+static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol type) {
 	struct rz_bin_pe_addr_t *peaddr = NULL;
 	RzBinAddr *ret = NULL;
 	if (bf && bf->o && bf->o->bin_obj) {
 		switch (type) {
-		case RZ_BIN_SYM_MAIN:
+		case RZ_BIN_SPECIAL_SYMBOL_MAIN:
 			peaddr = PE_(rz_bin_pe_get_main_vaddr)(bf->o->bin_obj);
+			break;
+		default:
 			break;
 		}
 	}

--- a/librz/bin/p/bin_pe.inc
+++ b/librz/bin/p/bin_pe.inc
@@ -477,7 +477,6 @@ static RzBinInfo *info(RzBinFile *bf) {
 	ret->bits = PE_(rz_bin_pe_get_bits)(bf->o->bin_obj);
 	ret->big_endian = PE_(rz_bin_pe_is_big_endian)(bf->o->bin_obj);
 	ret->dbg_info = 0;
-	ret->has_lit = true;
 	ret->has_canary = has_canary(bf);
 	ret->has_nx = haschr(bf, IMAGE_DLL_CHARACTERISTICS_NX_COMPAT);
 	ret->has_pi = haschr(bf, IMAGE_DLL_CHARACTERISTICS_DYNAMIC_BASE);

--- a/librz/bin/p/bin_te.c
+++ b/librz/bin/p/bin_te.c
@@ -39,14 +39,16 @@ static ut64 baddr(RzBinFile *bf) {
 	return rz_bin_te_get_image_base(bf->o->bin_obj);
 }
 
-static RzBinAddr *binsym(RzBinFile *bf, int type) {
+static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol type) {
 	RzBinAddr *ret = NULL;
 	switch (type) {
-	case RZ_BIN_SYM_MAIN:
+	case RZ_BIN_SPECIAL_SYMBOL_MAIN:
 		if (!(ret = RZ_NEW(RzBinAddr))) {
 			return NULL;
 		}
 		ret->paddr = ret->vaddr = rz_bin_te_get_main_paddr(bf->o->bin_obj);
+		break;
+	default:
 		break;
 	}
 	return ret;

--- a/librz/bin/p/bin_wasm.c
+++ b/librz/bin/p/bin_wasm.c
@@ -42,7 +42,7 @@ static ut64 baddr(RzBinFile *bf) {
 	return 0;
 }
 
-static RzBinAddr *binsym(RzBinFile *bf, int type) {
+static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol type) {
 	return NULL; // TODO
 }
 

--- a/librz/bin/p/bin_xbe.c
+++ b/librz/bin/p/bin_xbe.c
@@ -53,8 +53,8 @@ static void destroy(RzBinFile *bf) {
 	RZ_FREE(bf->o->bin_obj);
 }
 
-static RzBinAddr *binsym(RzBinFile *bf, int type) {
-	if (!bf || !bf->buf || type != RZ_BIN_SYM_MAIN) {
+static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol type) {
+	if (!bf || !bf->buf || type != RZ_BIN_SPECIAL_SYMBOL_MAIN) {
 		return NULL;
 	}
 	rz_bin_xbe_obj_t *obj = bf->o->bin_obj;

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4799,7 +4799,7 @@ RZ_API int rz_core_analysis_all(RzCore *core) {
 	RzBinFile *bf = core->bin->cur;
 	RzBinObject *o = bf ? bf->o : NULL;
 	/* Symbols (Imports are already analyzed by rz_bin on init) */
-	if ((list = rz_bin_get_symbols(core->bin)) != NULL) {
+	if (o && (list = o->symbols) != NULL) {
 		rz_list_foreach (list, iter, symbol) {
 			if (rz_cons_is_breaked()) {
 				break;
@@ -4816,7 +4816,7 @@ RZ_API int rz_core_analysis_all(RzCore *core) {
 	}
 	rz_core_task_yield(&core->tasks);
 	/* Main */
-	if ((binmain = rz_bin_get_sym(core->bin, RZ_BIN_SYM_MAIN))) {
+	if (o && (binmain = rz_bin_object_get_special_symbol(o, RZ_BIN_SPECIAL_SYMBOL_MAIN))) {
 		if (binmain->paddr != UT64_MAX) {
 			ut64 addr = rz_bin_object_get_vaddr(o, binmain->paddr, binmain->vaddr);
 			rz_core_analysis_fcn(core, addr, -1, RZ_ANALYSIS_REF_TYPE_NULL, depth - 1);

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -2946,8 +2946,9 @@ RZ_API RzGraph *rz_core_analysis_importxrefs(RzCore *core) {
 		return NULL;
 	}
 	rz_list_foreach (obj->imports, iter, imp) {
-		ut64 addr = rz_core_bin_impaddr(core->bin, va, imp->name);
-		if (addr) {
+		RzBinSymbol *sym = rz_bin_object_get_symbol_of_import(obj, imp);
+		ut64 addr = sym ? (va ? rz_bin_object_get_vaddr(obj, sym->paddr, sym->vaddr) : sym->paddr) : UT64_MAX;
+		if (addr && addr != UT64_MAX) {
 			add_single_addr_xrefs(core, addr, graph);
 		} else {
 			rz_graph_add_node_info(graph, imp->name, NULL, 0);

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4795,6 +4795,9 @@ RZ_API int rz_core_analysis_all(RzCore *core) {
 	rz_core_task_yield(&core->tasks);
 
 	rz_cons_break_push(NULL, NULL);
+
+	RzBinFile *bf = core->bin->cur;
+	RzBinObject *o = bf ? bf->o : NULL;
 	/* Symbols (Imports are already analyzed by rz_bin on init) */
 	if ((list = rz_bin_get_symbols(core->bin)) != NULL) {
 		rz_list_foreach (list, iter, symbol) {
@@ -4806,8 +4809,7 @@ RZ_API int rz_core_analysis_all(RzCore *core) {
 				continue;
 			}
 			if (isValidSymbol(symbol)) {
-				ut64 addr = rz_bin_get_vaddr(core->bin, symbol->paddr,
-					symbol->vaddr);
+				ut64 addr = rz_bin_object_get_vaddr(o, symbol->paddr, symbol->vaddr);
 				rz_core_analysis_fcn(core, addr, -1, RZ_ANALYSIS_REF_TYPE_NULL, depth - 1);
 			}
 		}
@@ -4816,7 +4818,7 @@ RZ_API int rz_core_analysis_all(RzCore *core) {
 	/* Main */
 	if ((binmain = rz_bin_get_sym(core->bin, RZ_BIN_SYM_MAIN))) {
 		if (binmain->paddr != UT64_MAX) {
-			ut64 addr = rz_bin_get_vaddr(core->bin, binmain->paddr, binmain->vaddr);
+			ut64 addr = rz_bin_object_get_vaddr(o, binmain->paddr, binmain->vaddr);
 			rz_core_analysis_fcn(core, addr, -1, RZ_ANALYSIS_REF_TYPE_NULL, depth - 1);
 		}
 	}
@@ -4826,7 +4828,7 @@ RZ_API int rz_core_analysis_all(RzCore *core) {
 			if (entry->paddr == UT64_MAX) {
 				continue;
 			}
-			ut64 addr = rz_bin_get_vaddr(core->bin, entry->paddr, entry->vaddr);
+			ut64 addr = rz_bin_object_get_vaddr(o, entry->paddr, entry->vaddr);
 			rz_core_analysis_fcn(core, addr, -1, RZ_ANALYSIS_REF_TYPE_NULL, depth - 1);
 		}
 	}

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -2933,9 +2933,7 @@ static void add_single_addr_xrefs(RzCore *core, ut64 addr, RzGraph *graph) {
 }
 
 RZ_API RzGraph *rz_core_analysis_importxrefs(RzCore *core) {
-	RzBinInfo *info = rz_bin_get_info(core->bin);
 	RzBinObject *obj = rz_bin_cur_object(core->bin);
-	bool lit = info ? info->has_lit : false;
 	bool va = core->io->va || core->bin->is_debugger;
 
 	RzListIter *iter;
@@ -2948,7 +2946,7 @@ RZ_API RzGraph *rz_core_analysis_importxrefs(RzCore *core) {
 		return NULL;
 	}
 	rz_list_foreach (obj->imports, iter, imp) {
-		ut64 addr = lit ? rz_core_bin_impaddr(core->bin, va, imp->name) : 0;
+		ut64 addr = rz_core_bin_impaddr(core->bin, va, imp->name);
 		if (addr) {
 			add_single_addr_xrefs(core, addr, graph);
 		} else {

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -2226,7 +2226,6 @@ static int bin_imports(RzCore *r, PJ *pj, int mode, int va, const char *name) {
 	rz_return_val_if_fail(table, false);
 	RzBinImport *import;
 	RzListIter *iter;
-	bool lit = info ? info->has_lit : false;
 	int i = 0;
 
 	if (!info) {
@@ -2256,7 +2255,7 @@ static int bin_imports(RzCore *r, PJ *pj, int mode, int va, const char *name) {
 		}
 		char *symname = import->name ? strdup(import->name) : NULL;
 		char *libname = import->libname ? strdup(import->libname) : NULL;
-		ut64 addr = lit ? rz_core_bin_impaddr(r->bin, va, symname) : 0;
+		ut64 addr = rz_core_bin_impaddr(r->bin, va, symname);
 		if (bin_demangle) {
 			char *dname = rz_bin_demangle(r->bin->cur, NULL, symname, addr, keep_lib);
 			if (dname) {

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -484,7 +484,7 @@ RZ_API bool rz_core_bin_apply_main(RzCore *r, RzBinFile *binfile, bool va) {
 	if (!o) {
 		return false;
 	}
-	RzBinAddr *binmain = o->binsym[RZ_BIN_SYM_MAIN];
+	RzBinAddr *binmain = rz_bin_object_get_special_symbol(o, RZ_BIN_SPECIAL_SYMBOL_MAIN);
 	if (!binmain) {
 		return false;
 	}
@@ -1805,7 +1805,7 @@ static int bin_main(RzCore *r, RzBinFile *binfile, PJ *pj, int mode, int va) {
 	if (!o) {
 		return false;
 	}
-	RzBinAddr *binmain = o->binsym[RZ_BIN_SYM_MAIN];
+	RzBinAddr *binmain = rz_bin_object_get_special_symbol(o, RZ_BIN_SPECIAL_SYMBOL_MAIN);
 	if (!binmain) {
 		return false;
 	}

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -126,13 +126,13 @@ RZ_LIB_VERSION_HEADER(rz_bin);
 #define RZ_BIN_TYPE_SPECIAL_SYM_STR "SPCL"
 #define RZ_BIN_TYPE_UNKNOWN_STR     "UNK"
 
-enum {
-	RZ_BIN_SYM_ENTRY,
-	RZ_BIN_SYM_INIT,
-	RZ_BIN_SYM_MAIN,
-	RZ_BIN_SYM_FINI,
-	RZ_BIN_SYM_LAST
-};
+typedef enum {
+	RZ_BIN_SPECIAL_SYMBOL_ENTRY,
+	RZ_BIN_SPECIAL_SYMBOL_INIT,
+	RZ_BIN_SPECIAL_SYMBOL_MAIN,
+	RZ_BIN_SPECIAL_SYMBOL_FINI,
+	RZ_BIN_SPECIAL_SYMBOL_LAST
+} RzBinSpecialSymbol;
 
 // name mangling types
 // TODO: Rename to RZ_BIN_LANG_
@@ -267,7 +267,7 @@ typedef struct rz_bin_object_t {
 	RzList /*<BinMap*/ *maps;
 	char *regstate;
 	RzBinInfo *info;
-	RzBinAddr *binsym[RZ_BIN_SYM_LAST];
+	RzBinAddr *binsym[RZ_BIN_SPECIAL_SYMBOL_LAST];
 	struct rz_bin_plugin_t *plugin;
 	int lang;
 	Sdb *kv;
@@ -515,7 +515,7 @@ typedef struct rz_bin_plugin_t {
 	bool (*check_buffer)(RzBuffer *buf);
 	ut64 (*baddr)(RzBinFile *bf);
 	ut64 (*boffset)(RzBinFile *bf);
-	RzBinAddr *(*binsym)(RzBinFile *bf, int num);
+	RzBinAddr *(*binsym)(RzBinFile *bf, RzBinSpecialSymbol num);
 	RzList /*<RzBinAddr>*/ *(*entries)(RzBinFile *bf);
 	RzList /*<RzBinSection>*/ *(*sections)(RzBinFile *bf);
 	RZ_OWN RzBinSourceLineInfo *(*lines)(RzBinFile *bf); //< only called once on load, ownership is transferred to the caller
@@ -781,7 +781,6 @@ RZ_API RzBinInfo *rz_bin_get_info(RzBin *bin);
 RZ_API void rz_bin_set_baddr(RzBin *bin, ut64 baddr);
 RZ_API ut64 rz_bin_get_laddr(RzBin *bin);
 RZ_API ut64 rz_bin_get_size(RzBin *bin);
-RZ_API RzBinAddr *rz_bin_get_sym(RzBin *bin, int sym);
 RZ_API RzList *rz_bin_raw_strings(RzBinFile *a, int min);
 RZ_API RzList *rz_bin_dump_strings(RzBinFile *a, int min, int raw);
 
@@ -857,6 +856,7 @@ RZ_API int rz_bin_object_set_items(RzBinFile *binfile, RzBinObject *o);
 RZ_API bool rz_bin_object_delete(RzBin *bin, ut32 binfile_id);
 RZ_API ut64 rz_bin_object_addr_with_base(RzBinObject *o, ut64 addr);
 RZ_API ut64 rz_bin_object_get_vaddr(RzBinObject *o, ut64 paddr, ut64 vaddr);
+RZ_API RzBinAddr *rz_bin_object_get_special_symbol(RzBinObject *o, RzBinSpecialSymbol sym);
 RZ_API RBNode *rz_bin_object_patch_relocs(RzBinFile *bf, RzBinObject *o);
 RZ_API void rz_bin_mem_free(void *data);
 

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -801,8 +801,6 @@ RZ_API RZ_DEPRECATE RzList *rz_bin_reset_strings(RzBin *bin);
 RZ_API RZ_DEPRECATE int rz_bin_is_string(RzBin *bin, ut64 va);
 RZ_API RZ_DEPRECATE int rz_bin_is_big_endian(RzBin *bin);
 RZ_API RZ_DEPRECATE int rz_bin_is_static(RzBin *bin);
-RZ_API RZ_DEPRECATE ut64 rz_bin_get_vaddr(RzBin *bin, ut64 paddr, ut64 vaddr);
-RZ_API ut64 rz_bin_file_get_vaddr(RzBinFile *bf, ut64 paddr, ut64 vaddr);
 
 RZ_API int rz_bin_load_languages(RzBinFile *binfile);
 RZ_API RzBinFile *rz_bin_cur(RzBin *bin);
@@ -858,6 +856,7 @@ RZ_API void rz_bin_file_hash_free(RzBinFileHash *fhash);
 RZ_API int rz_bin_object_set_items(RzBinFile *binfile, RzBinObject *o);
 RZ_API bool rz_bin_object_delete(RzBin *bin, ut32 binfile_id);
 RZ_API ut64 rz_bin_object_addr_with_base(RzBinObject *o, ut64 addr);
+RZ_API ut64 rz_bin_object_get_vaddr(RzBinObject *o, ut64 paddr, ut64 vaddr);
 RZ_API RBNode *rz_bin_object_patch_relocs(RzBinFile *bf, RzBinObject *o);
 RZ_API void rz_bin_mem_free(void *data);
 

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -252,6 +252,11 @@ typedef struct rz_bin_object_t {
 	RzList /*<RzBinSection>*/ *sections;
 	RzList /*<RzBinImport>*/ *imports;
 	RzList /*<RzBinSymbol>*/ *symbols;
+	/**
+	 * \brief Acceleration structure for fast access of the symbol for a given import.
+	 * This associates the name of every symbol where is_imported == true to the symbol itself.
+	 */
+	HtPP /*<const char *, RzBinSymbol>*/ *import_name_symbols; // currently only used for imports, but could be extended to all symbols if needed.
 	RzList /*<??>*/ *entries;
 	RzList /*<??>*/ *fields;
 	RzList /*<??>*/ *libs;
@@ -857,6 +862,7 @@ RZ_API ut64 rz_bin_object_addr_with_base(RzBinObject *o, ut64 addr);
 RZ_API ut64 rz_bin_object_get_vaddr(RzBinObject *o, ut64 paddr, ut64 vaddr);
 RZ_API RzBinAddr *rz_bin_object_get_special_symbol(RzBinObject *o, RzBinSpecialSymbol sym);
 RZ_API RBNode *rz_bin_object_patch_relocs(RzBinFile *bf, RzBinObject *o);
+RZ_API RzBinSymbol *rz_bin_object_get_symbol_of_import(RzBinObject *o, RzBinImport *imp);
 RZ_API void rz_bin_mem_free(void *data);
 
 // demangle functions

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -231,7 +231,6 @@ typedef struct rz_bin_info_t {
 	int has_crypto;
 	int has_nx;
 	int big_endian;
-	bool has_lit;
 	char *actual_checksum;
 	char *claimed_checksum;
 	int pe_overlay;

--- a/test/db/formats/elf/crash
+++ b/test/db/formats/elf/crash
@@ -23,8 +23,8 @@ EXPECT=<<EOF
 [Imports]
 nth vaddr      bind type lib name
 ---------------------------------
-0   0x00000000 NONE NONE     
+0   ---------- NONE NONE     
 
-[{"ordinal":0,"name":"","plt":0}]
+[{"ordinal":0,"name":""}]
 EOF
 RUN

--- a/test/db/formats/java
+++ b/test/db/formats/java
@@ -712,9 +712,9 @@ EXPECT=<<EOF
 [Imports]
 nth vaddr      bind type  lib name
 ----------------------------------
-1   0x00000000 NONE METH      java.lang.Object.<init>
-3   0x00000000 NONE FIELD     java.lang.System.out
-5   0x00000000 NONE METH      java.io.PrintStream.println
+1   ---------- NONE METH      java.lang.Object.<init>
+3   ---------- NONE FIELD     java.lang.System.out
+5   ---------- NONE METH      java.io.PrintStream.println
 
 EOF
 RUN
@@ -727,15 +727,15 @@ EXPECT=<<EOF
 [Imports]
 nth vaddr      bind type  lib name
 ----------------------------------
-8   0x00000000 NONE METH      java.lang.Object.<init>
-16  0x00000000 NONE FIELD     java.lang.System.out
-26  0x00000000 NONE METH      java.lang.StringBuilder.<init>
-29  0x00000000 NONE METH      java.lang.StringBuilder.append
-33  0x00000000 NONE METH      java.lang.StringBuilder.toString
-37  0x00000000 NONE METH      java.io.PrintStream.println
-46  0x00000000 NONE METH      java.lang.String.<init>
-55  0x00000000 NONE METH      java.lang.Integer.valueOf
-61  0x00000000 NONE METH      TestVariableSwitchUp.TestMultipleVariable
+8   ---------- NONE METH      java.lang.Object.<init>
+16  ---------- NONE FIELD     java.lang.System.out
+26  ---------- NONE METH      java.lang.StringBuilder.<init>
+29  ---------- NONE METH      java.lang.StringBuilder.append
+33  ---------- NONE METH      java.lang.StringBuilder.toString
+37  ---------- NONE METH      java.io.PrintStream.println
+46  ---------- NONE METH      java.lang.String.<init>
+55  ---------- NONE METH      java.lang.Integer.valueOf
+61  ---------- NONE METH      TestVariableSwitchUp.TestMultipleVariable
 
 EOF
 RUN
@@ -760,15 +760,15 @@ EXPECT=<<EOF
 [Imports]
 nth vaddr      bind type  lib name
 ----------------------------------
-1   0x00000000 NONE METH      java.lang.Object.<init>
-2   0x00000000 NONE FIELD     Hello.who
-3   0x00000000 NONE FIELD     java.lang.System.out
-5   0x00000000 NONE METH      java.lang.StringBuilder.<init>
-7   0x00000000 NONE METH      java.lang.StringBuilder.append
-8   0x00000000 NONE METH      java.lang.StringBuilder.toString
-9   0x00000000 NONE METH      java.io.PrintStream.println
-12  0x00000000 NONE METH      Hello.<init>
-13  0x00000000 NONE METH      Hello.say
+1   ---------- NONE METH      java.lang.Object.<init>
+2   ---------- NONE FIELD     Hello.who
+3   ---------- NONE FIELD     java.lang.System.out
+5   ---------- NONE METH      java.lang.StringBuilder.<init>
+7   ---------- NONE METH      java.lang.StringBuilder.append
+8   ---------- NONE METH      java.lang.StringBuilder.toString
+9   ---------- NONE METH      java.io.PrintStream.println
+12  ---------- NONE METH      Hello.<init>
+13  ---------- NONE METH      Hello.say
 
 EOF
 RUN
@@ -781,7 +781,7 @@ EXPECT=<<EOF
 [Imports]
 nth vaddr      bind type lib name
 ---------------------------------
-15  0x00000000 NONE METH     kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull
+15  ---------- NONE METH     kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull
 
 EOF
 RUN
@@ -794,8 +794,8 @@ EXPECT=<<EOF
 [Imports]
 nth vaddr      bind type  lib name
 ----------------------------------
-7   0x00000000 NONE FIELD     java.lang.System.out
-8   0x00000000 NONE METH      java.io.PrintStream.println
+7   ---------- NONE FIELD     java.lang.System.out
+8   ---------- NONE METH      java.io.PrintStream.println
 
 EOF
 RUN
@@ -808,17 +808,17 @@ EXPECT=<<EOF
 [Imports]
 nth vaddr      bind type lib name
 ---------------------------------
-1   0x00000000 NONE METH     java.lang.Object.<init>
-3   0x00000000 NONE METH     java.lang.StringBuilder.<init>
-4   0x00000000 NONE METH     java.lang.StringBuilder.append
-6   0x00000000 NONE METH     java.lang.StringBuilder.toString
-7   0x00000000 NONE METH     java.lang.Runtime.getRuntime
-8   0x00000000 NONE METH     java.lang.Runtime.exec
-11  0x00000000 NONE METH     java.lang.Process.getInputStream
-12  0x00000000 NONE METH     java.io.InputStreamReader.<init>
-13  0x00000000 NONE METH     java.io.BufferedReader.<init>
-14  0x00000000 NONE METH     java.io.BufferedReader.readLine
-15  0x00000000 NONE METH     java.lang.String.trim
+1   ---------- NONE METH     java.lang.Object.<init>
+3   ---------- NONE METH     java.lang.StringBuilder.<init>
+4   ---------- NONE METH     java.lang.StringBuilder.append
+6   ---------- NONE METH     java.lang.StringBuilder.toString
+7   ---------- NONE METH     java.lang.Runtime.getRuntime
+8   ---------- NONE METH     java.lang.Runtime.exec
+11  ---------- NONE METH     java.lang.Process.getInputStream
+12  ---------- NONE METH     java.io.InputStreamReader.<init>
+13  ---------- NONE METH     java.io.BufferedReader.<init>
+14  ---------- NONE METH     java.io.BufferedReader.readLine
+15  ---------- NONE METH     java.lang.String.trim
 
 EOF
 RUN
@@ -831,90 +831,90 @@ EXPECT=<<EOF
 [Imports]
 nth vaddr      bind type  lib name
 ----------------------------------
-1   0x00000000 NONE METH      org.radare2.installer.MainActivity.download
-2   0x00000000 NONE FIELD     org.radare2.installer.MainActivity.handler
-3   0x00000000 NONE FIELD     org.radare2.installer.MainActivity.thread
-4   0x00000000 NONE FIELD     org.radare2.installer.MainActivity.outputView
-5   0x00000000 NONE FIELD     org.radare2.installer.MainActivity.remoteRunButton
-6   0x00000000 NONE METH      org.radare2.installer.MainActivity.checkForRadare
-7   0x00000000 NONE FIELD     org.radare2.installer.MainActivity.http_url_default
-8   0x00000000 NONE METH      org.radare2.installer.MainActivity.output
-9   0x00000000 NONE FIELD     org.radare2.installer.MainActivity.mUtils
-10  0x00000000 NONE METH      android.app.Activity.<init>
-12  0x00000000 NONE METH      android.os.Handler.<init>
-15  0x00000000 NONE METH      org.radare2.installer.MainActivity$2.<init>
-16  0x00000000 NONE FIELD     org.radare2.installer.MainActivity.onLocalRunButtonClick
-18  0x00000000 NONE METH      org.radare2.installer.MainActivity$3.<init>
-19  0x00000000 NONE FIELD     org.radare2.installer.MainActivity.onRemoteRunButtonClick
-20  0x00000000 NONE METH      android.app.Activity.onCreate
-23  0x00000000 NONE METH      org.radare2.installer.MainActivity.setContentView
-25  0x00000000 NONE METH      org.radare2.installer.MainActivity.getApplicationContext
-26  0x00000000 NONE METH      org.radare2.installer.Utils.<init>
-29  0x00000000 NONE METH      org.radare2.installer.MainActivity.findViewById
-34  0x00000000 NONE METH      org.radare2.installer.Utils.GetPref
-36  0x00000000 NONE METH      java.lang.String.equals
-37  0x00000000 NONE METH      android.widget.CheckBox.setChecked
-45  0x00000000 NONE METH      android.widget.Button.setOnClickListener
-47  0x00000000 NONE FIELD     org.radare2.installer.MainActivity.localRunButton
-49  0x00000000 NONE METH      org.radare2.installer.Utils.isInternetAvailable
-50  0x00000000 NONE METH      android.preference.PreferenceManager.getDefaultSharedPreferences
-53  0x00000000 NONE METH      org.radare2.installer.MainActivity$1.<init>
-54  0x00000000 NONE METH      java.lang.Thread.<init>
-55  0x00000000 NONE METH      java.lang.Thread.start
-58  0x00000000 NONE IMETH     android.view.Menu.add
-59  0x00000000 NONE METH      android.app.Activity.onCreateOptionsMenu
-60  0x00000000 NONE IMETH     android.view.MenuItem.getItemId
-63  0x00000000 NONE METH      android.content.Intent.<init>
-65  0x00000000 NONE METH      android.content.Intent.setFlags
-66  0x00000000 NONE METH      org.radare2.installer.MainActivity.startActivity
-69  0x00000000 NONE METH      java.io.File.<init>
-70  0x00000000 NONE METH      java.io.File.exists
-72  0x00000000 NONE METH      org.radare2.installer.MainActivity$4.<init>
-73  0x00000000 NONE METH      android.os.Handler.post
-76  0x00000000 NONE METH      java.io.FileInputStream.<init>
-77  0x00000000 NONE METH      java.util.zip.GZIPInputStream.<init>
-78  0x00000000 NONE METH      java.lang.String.lastIndexOf
-79  0x00000000 NONE METH      java.lang.String.substring
-82  0x00000000 NONE METH      java.lang.StringBuilder.<init>
-83  0x00000000 NONE METH      java.lang.StringBuilder.append
-85  0x00000000 NONE METH      java.lang.StringBuilder.toString
-87  0x00000000 NONE METH      java.io.FileOutputStream.<init>
-88  0x00000000 NONE METH      java.util.zip.GZIPInputStream.read
-89  0x00000000 NONE METH      java.io.OutputStream.write
-90  0x00000000 NONE METH      java.util.zip.GZIPInputStream.close
-91  0x00000000 NONE METH      java.io.OutputStream.close
-93  0x00000000 NONE METH      com.ice.tar.TarArchive.<init>
-94  0x00000000 NONE METH      com.ice.tar.TarArchive.extractContents
-95  0x00000000 NONE METH      com.ice.tar.TarArchive.closeArchive
-96  0x00000000 NONE METH      java.io.File.delete
-98  0x00000000 NONE METH      org.radare2.installer.MainActivity$5.<init>
-100 0x00000000 NONE METH      java.net.URL.<init>
-101 0x00000000 NONE METH      java.net.URL.openConnection
-104 0x00000000 NONE METH      java.net.HttpURLConnection.setRequestMethod
-105 0x00000000 NONE METH      java.net.HttpURLConnection.setInstanceFollowRedirects
-106 0x00000000 NONE METH      java.net.HttpURLConnection.getRequestProperties
-107 0x00000000 NONE METH      java.net.HttpURLConnection.connect
-108 0x00000000 NONE METH      java.net.HttpURLConnection.getContentLength
-110 0x00000000 NONE METH      java.lang.StringBuilder.append
-113 0x00000000 NONE METH      java.net.HttpURLConnection.getHeaderField
-114 0x00000000 NONE METH      org.radare2.installer.Utils.StorePref
-115 0x00000000 NONE METH      java.net.HttpURLConnection.getInputStream
-117 0x00000000 NONE METH      java.io.InputStream.read
-118 0x00000000 NONE METH      java.io.FileOutputStream.write
-121 0x00000000 NONE METH      org.radare2.installer.MainActivity.resetButtons
-123 0x00000000 NONE METH      java.io.FileOutputStream.close
-124 0x00000000 NONE METH      java.io.InputStream.close
-125 0x00000000 NONE METH      java.net.HttpURLConnection.disconnect
-127 0x00000000 NONE METH      java.lang.Exception.printStackTrace
-128 0x00000000 NONE METH      android.app.Activity.onResume
-131 0x00000000 NONE IMETH     android.content.SharedPreferences.getString
-132 0x00000000 NONE METH      java.lang.Integer.parseInt
-134 0x00000000 NONE IMETH     android.content.SharedPreferences.getBoolean
-137 0x00000000 NONE METH      org.radare2.installer.MainActivity.getSystemService
-140 0x00000000 NONE METH      android.app.PendingIntent.getService
-141 0x00000000 NONE METH      android.app.AlarmManager.cancel
-142 0x00000000 NONE METH      android.os.SystemClock.elapsedRealtime
-143 0x00000000 NONE METH      android.app.AlarmManager.setInexactRepeating
+1   ---------- NONE METH      org.radare2.installer.MainActivity.download
+2   ---------- NONE FIELD     org.radare2.installer.MainActivity.handler
+3   ---------- NONE FIELD     org.radare2.installer.MainActivity.thread
+4   ---------- NONE FIELD     org.radare2.installer.MainActivity.outputView
+5   ---------- NONE FIELD     org.radare2.installer.MainActivity.remoteRunButton
+6   ---------- NONE METH      org.radare2.installer.MainActivity.checkForRadare
+7   ---------- NONE FIELD     org.radare2.installer.MainActivity.http_url_default
+8   ---------- NONE METH      org.radare2.installer.MainActivity.output
+9   ---------- NONE FIELD     org.radare2.installer.MainActivity.mUtils
+10  ---------- NONE METH      android.app.Activity.<init>
+12  ---------- NONE METH      android.os.Handler.<init>
+15  ---------- NONE METH      org.radare2.installer.MainActivity$2.<init>
+16  ---------- NONE FIELD     org.radare2.installer.MainActivity.onLocalRunButtonClick
+18  ---------- NONE METH      org.radare2.installer.MainActivity$3.<init>
+19  ---------- NONE FIELD     org.radare2.installer.MainActivity.onRemoteRunButtonClick
+20  ---------- NONE METH      android.app.Activity.onCreate
+23  ---------- NONE METH      org.radare2.installer.MainActivity.setContentView
+25  ---------- NONE METH      org.radare2.installer.MainActivity.getApplicationContext
+26  ---------- NONE METH      org.radare2.installer.Utils.<init>
+29  ---------- NONE METH      org.radare2.installer.MainActivity.findViewById
+34  ---------- NONE METH      org.radare2.installer.Utils.GetPref
+36  ---------- NONE METH      java.lang.String.equals
+37  ---------- NONE METH      android.widget.CheckBox.setChecked
+45  ---------- NONE METH      android.widget.Button.setOnClickListener
+47  ---------- NONE FIELD     org.radare2.installer.MainActivity.localRunButton
+49  ---------- NONE METH      org.radare2.installer.Utils.isInternetAvailable
+50  ---------- NONE METH      android.preference.PreferenceManager.getDefaultSharedPreferences
+53  ---------- NONE METH      org.radare2.installer.MainActivity$1.<init>
+54  ---------- NONE METH      java.lang.Thread.<init>
+55  ---------- NONE METH      java.lang.Thread.start
+58  ---------- NONE IMETH     android.view.Menu.add
+59  ---------- NONE METH      android.app.Activity.onCreateOptionsMenu
+60  ---------- NONE IMETH     android.view.MenuItem.getItemId
+63  ---------- NONE METH      android.content.Intent.<init>
+65  ---------- NONE METH      android.content.Intent.setFlags
+66  ---------- NONE METH      org.radare2.installer.MainActivity.startActivity
+69  ---------- NONE METH      java.io.File.<init>
+70  ---------- NONE METH      java.io.File.exists
+72  ---------- NONE METH      org.radare2.installer.MainActivity$4.<init>
+73  ---------- NONE METH      android.os.Handler.post
+76  ---------- NONE METH      java.io.FileInputStream.<init>
+77  ---------- NONE METH      java.util.zip.GZIPInputStream.<init>
+78  ---------- NONE METH      java.lang.String.lastIndexOf
+79  ---------- NONE METH      java.lang.String.substring
+82  ---------- NONE METH      java.lang.StringBuilder.<init>
+83  ---------- NONE METH      java.lang.StringBuilder.append
+85  ---------- NONE METH      java.lang.StringBuilder.toString
+87  ---------- NONE METH      java.io.FileOutputStream.<init>
+88  ---------- NONE METH      java.util.zip.GZIPInputStream.read
+89  ---------- NONE METH      java.io.OutputStream.write
+90  ---------- NONE METH      java.util.zip.GZIPInputStream.close
+91  ---------- NONE METH      java.io.OutputStream.close
+93  ---------- NONE METH      com.ice.tar.TarArchive.<init>
+94  ---------- NONE METH      com.ice.tar.TarArchive.extractContents
+95  ---------- NONE METH      com.ice.tar.TarArchive.closeArchive
+96  ---------- NONE METH      java.io.File.delete
+98  ---------- NONE METH      org.radare2.installer.MainActivity$5.<init>
+100 ---------- NONE METH      java.net.URL.<init>
+101 ---------- NONE METH      java.net.URL.openConnection
+104 ---------- NONE METH      java.net.HttpURLConnection.setRequestMethod
+105 ---------- NONE METH      java.net.HttpURLConnection.setInstanceFollowRedirects
+106 ---------- NONE METH      java.net.HttpURLConnection.getRequestProperties
+107 ---------- NONE METH      java.net.HttpURLConnection.connect
+108 ---------- NONE METH      java.net.HttpURLConnection.getContentLength
+110 ---------- NONE METH      java.lang.StringBuilder.append
+113 ---------- NONE METH      java.net.HttpURLConnection.getHeaderField
+114 ---------- NONE METH      org.radare2.installer.Utils.StorePref
+115 ---------- NONE METH      java.net.HttpURLConnection.getInputStream
+117 ---------- NONE METH      java.io.InputStream.read
+118 ---------- NONE METH      java.io.FileOutputStream.write
+121 ---------- NONE METH      org.radare2.installer.MainActivity.resetButtons
+123 ---------- NONE METH      java.io.FileOutputStream.close
+124 ---------- NONE METH      java.io.InputStream.close
+125 ---------- NONE METH      java.net.HttpURLConnection.disconnect
+127 ---------- NONE METH      java.lang.Exception.printStackTrace
+128 ---------- NONE METH      android.app.Activity.onResume
+131 ---------- NONE IMETH     android.content.SharedPreferences.getString
+132 ---------- NONE METH      java.lang.Integer.parseInt
+134 ---------- NONE IMETH     android.content.SharedPreferences.getBoolean
+137 ---------- NONE METH      org.radare2.installer.MainActivity.getSystemService
+140 ---------- NONE METH      android.app.PendingIntent.getService
+141 ---------- NONE METH      android.app.AlarmManager.cancel
+142 ---------- NONE METH      android.os.SystemClock.elapsedRealtime
+143 ---------- NONE METH      android.app.AlarmManager.setInexactRepeating
 
 EOF
 RUN
@@ -927,19 +927,19 @@ EXPECT=<<EOF
 [Imports]
 nth vaddr      bind type  lib name
 ----------------------------------
-1   0x00000000 NONE METH      java.lang.Object.<init>
-2   0x00000000 NONE FIELD     java.lang.System.out
-4   0x00000000 NONE METH      java.io.PrintStream.println
-8   0x00000000 NONE METH      java.io.FileReader.<init>
-9   0x00000000 NONE METH      java.io.BufferedReader.<init>
-10  0x00000000 NONE METH      java.io.BufferedReader.readLine
-12  0x00000000 NONE METH      java.lang.StringBuilder.<init>
-14  0x00000000 NONE METH      java.lang.StringBuilder.append
-15  0x00000000 NONE METH      java.lang.StringBuilder.toString
-16  0x00000000 NONE METH      java.io.BufferedReader.close
-18  0x00000000 NONE FIELD     java.lang.System.err
-21  0x00000000 NONE METH      java.io.PrintStream.format
-22  0x00000000 NONE METH      java.lang.Exception.printStackTrace
+1   ---------- NONE METH      java.lang.Object.<init>
+2   ---------- NONE FIELD     java.lang.System.out
+4   ---------- NONE METH      java.io.PrintStream.println
+8   ---------- NONE METH      java.io.FileReader.<init>
+9   ---------- NONE METH      java.io.BufferedReader.<init>
+10  ---------- NONE METH      java.io.BufferedReader.readLine
+12  ---------- NONE METH      java.lang.StringBuilder.<init>
+14  ---------- NONE METH      java.lang.StringBuilder.append
+15  ---------- NONE METH      java.lang.StringBuilder.toString
+16  ---------- NONE METH      java.io.BufferedReader.close
+18  ---------- NONE FIELD     java.lang.System.err
+21  ---------- NONE METH      java.io.PrintStream.format
+22  ---------- NONE METH      java.lang.Exception.printStackTrace
 
 EOF
 RUN
@@ -964,28 +964,28 @@ EXPECT=<<EOF
 [Imports]
 nth vaddr      bind type  lib name
 ----------------------------------
-13  0x00000000 NONE METH      groovy.lang.Script.<init>
-17  0x00000000 NONE METH      test.$getCallSiteArray
-22  0x00000000 NONE METH      groovy.lang.Script.<init>
-35  0x00000000 NONE IMETH     org.codehaus.groovy.runtime.callsite.CallSite.call
-55  0x00000000 NONE IMETH     org.codehaus.groovy.runtime.callsite.CallSite.callConstructor
-61  0x00000000 NONE METH      org.codehaus.groovy.runtime.ScriptBytecodeAdapter.createMap
-67  0x00000000 NONE IMETH     org.codehaus.groovy.runtime.callsite.CallSite.call
-71  0x00000000 NONE IMETH     org.codehaus.groovy.runtime.callsite.CallSite.callCurrent
-79  0x00000000 NONE IMETH     org.codehaus.groovy.runtime.callsite.CallSite.callGetProperty
-92  0x00000000 NONE IMETH     org.codehaus.groovy.runtime.callsite.CallSite.call
-100 0x00000000 NONE METH      java.lang.Object.getClass
-104 0x00000000 NONE METH      org.codehaus.groovy.runtime.ScriptBytecodeAdapter.initMetaClass
-106 0x00000000 NONE FIELD     test.$staticClassInfo
-112 0x00000000 NONE METH      org.codehaus.groovy.reflection.ClassInfo.getClassInfo
-115 0x00000000 NONE METH      org.codehaus.groovy.reflection.ClassInfo.getMetaClass
-147 0x00000000 NONE METH      test.$createCallSiteArray_1
-152 0x00000000 NONE METH      org.codehaus.groovy.runtime.callsite.CallSiteArray.<init>
-154 0x00000000 NONE FIELD     test.$callSiteArray
-159 0x00000000 NONE METH      java.lang.ref.SoftReference.get
-161 0x00000000 NONE METH      test.$createCallSiteArray
-164 0x00000000 NONE METH      java.lang.ref.SoftReference.<init>
-168 0x00000000 NONE FIELD     org.codehaus.groovy.runtime.callsite.CallSiteArray.array
+13  ---------- NONE METH      groovy.lang.Script.<init>
+17  ---------- NONE METH      test.$getCallSiteArray
+22  ---------- NONE METH      groovy.lang.Script.<init>
+35  ---------- NONE IMETH     org.codehaus.groovy.runtime.callsite.CallSite.call
+55  ---------- NONE IMETH     org.codehaus.groovy.runtime.callsite.CallSite.callConstructor
+61  ---------- NONE METH      org.codehaus.groovy.runtime.ScriptBytecodeAdapter.createMap
+67  ---------- NONE IMETH     org.codehaus.groovy.runtime.callsite.CallSite.call
+71  ---------- NONE IMETH     org.codehaus.groovy.runtime.callsite.CallSite.callCurrent
+79  ---------- NONE IMETH     org.codehaus.groovy.runtime.callsite.CallSite.callGetProperty
+92  ---------- NONE IMETH     org.codehaus.groovy.runtime.callsite.CallSite.call
+100 ---------- NONE METH      java.lang.Object.getClass
+104 ---------- NONE METH      org.codehaus.groovy.runtime.ScriptBytecodeAdapter.initMetaClass
+106 ---------- NONE FIELD     test.$staticClassInfo
+112 ---------- NONE METH      org.codehaus.groovy.reflection.ClassInfo.getClassInfo
+115 ---------- NONE METH      org.codehaus.groovy.reflection.ClassInfo.getMetaClass
+147 ---------- NONE METH      test.$createCallSiteArray_1
+152 ---------- NONE METH      org.codehaus.groovy.runtime.callsite.CallSiteArray.<init>
+154 ---------- NONE FIELD     test.$callSiteArray
+159 ---------- NONE METH      java.lang.ref.SoftReference.get
+161 ---------- NONE METH      test.$createCallSiteArray
+164 ---------- NONE METH      java.lang.ref.SoftReference.<init>
+168 ---------- NONE FIELD     org.codehaus.groovy.runtime.callsite.CallSiteArray.array
 
 EOF
 RUN
@@ -998,27 +998,27 @@ EXPECT=<<EOF
 [Imports]
 nth vaddr      bind   type  lib name
 ------------------------------------
-2   0x00000000 NONE   METH      TryWithResources.<init>
-3   0x00000000 NONE   METH      java.lang.RuntimeException.<init>
-4   0x00000000 NONE   FIELD     java.lang.System.out
-6   0x00000000 NONE   METH      java.lang.StringBuilder.<init>
-8   0x00000000 NONE   METH      java.lang.StringBuilder.append
-9   0x00000000 NONE   METH      java.lang.StringBuilder.append
-10  0x00000000 NONE   METH      java.lang.StringBuilder.toString
-11  0x00000000 NONE   METH      java.io.PrintStream.println
-12  0x00000000 NONE   FIELD     TryWithResources.i
-14  0x00000000 NONE   METH      java.io.PrintStream.println
-15  0x00000000 NONE   FIELD     TryWithResources.$
-17  0x00000000 GLOBAL FUNC      TryWithResources.main
-19  0x00000000 NONE   METH      TryWithResources.$
-20  0x00000000 NONE   METH      java.io.PrintStream.println
-21  0x00000000 NONE   METH      TryWithResources.$
-22  0x00000000 NONE   METH      TryWithResources.close
-24  0x00000000 NONE   METH      java.lang.Throwable.addSuppressed
-25  0x00000000 NONE   METH      TryWithResources.$
-26  0x00000000 NONE   IMETH     java.lang.AutoCloseable.close
-27  0x00000000 NONE   METH      java.lang.Throwable.printStackTrace
-0   0x00000000 WEAK   IFACE     java.lang.AutoCloseable.*
+2   ---------- NONE   METH      TryWithResources.<init>
+3   ---------- NONE   METH      java.lang.RuntimeException.<init>
+4   ---------- NONE   FIELD     java.lang.System.out
+6   ---------- NONE   METH      java.lang.StringBuilder.<init>
+8   ---------- NONE   METH      java.lang.StringBuilder.append
+9   ---------- NONE   METH      java.lang.StringBuilder.append
+10  ---------- NONE   METH      java.lang.StringBuilder.toString
+11  ---------- NONE   METH      java.io.PrintStream.println
+12  ---------- NONE   FIELD     TryWithResources.i
+14  ---------- NONE   METH      java.io.PrintStream.println
+15  ---------- NONE   FIELD     TryWithResources.$
+17  ---------- GLOBAL FUNC      TryWithResources.main
+19  ---------- NONE   METH      TryWithResources.$
+20  ---------- NONE   METH      java.io.PrintStream.println
+21  ---------- NONE   METH      TryWithResources.$
+22  ---------- NONE   METH      TryWithResources.close
+24  ---------- NONE   METH      java.lang.Throwable.addSuppressed
+25  ---------- NONE   METH      TryWithResources.$
+26  ---------- NONE   IMETH     java.lang.AutoCloseable.close
+27  ---------- NONE   METH      java.lang.Throwable.printStackTrace
+0   ---------- WEAK   IFACE     java.lang.AutoCloseable.*
 
 EOF
 RUN

--- a/test/db/formats/ne
+++ b/test/db/formats/ne
@@ -34,10 +34,10 @@ EXPECT=<<EOF
 [Imports]
 nth vaddr      bind type lib name
 ---------------------------------
-1   0x00000000 NONE NONE     KERNEL
-2   0x00000000 NONE NONE     USER
-3   0x00000000 NONE NONE     GDI
-4   0x00000000 NONE NONE     WIN87EM
+1   ---------- NONE NONE     KERNEL
+2   ---------- NONE NONE     USER
+3   ---------- NONE NONE     GDI
+4   ---------- NONE NONE     WIN87EM
 
 EOF
 RUN

--- a/test/db/formats/pe/imports_tinyW7
+++ b/test/db/formats/pe/imports_tinyW7
@@ -24,7 +24,7 @@ vaddr      paddr      type   name
 [Imports]
 nth  vaddr      bind type lib      name
 ---------------------------------------
-284  0x00000000 NONE FUNC kernel32 FindAtomW
+284  ---------- NONE FUNC kernel32 FindAtomW
 1268 0x00401034 NONE FUNC msvcrt   Ordinal_1268
 
 EOF

--- a/test/db/tools/rz_bin
+++ b/test/db/tools/rz_bin
@@ -326,7 +326,7 @@ EXPECT=<<EOF
 nth vaddr      bind type lib name
 ---------------------------------
 0   0x00001f94 NONE FUNC     exit
-1   0x00000000 NONE FUNC     dyld_stub_binder
+1   ---------- NONE FUNC     dyld_stub_binder
 
 EOF
 RUN
@@ -339,7 +339,7 @@ EXPECT=<<EOF
 nth vaddr      bind type lib name
 ---------------------------------
 0   0x00001f94 NONE FUNC     exit
-1   0x00000000 NONE FUNC     dyld_stub_binder
+1   ---------- NONE FUNC     dyld_stub_binder
 
 EOF
 RUN


### PR DESCRIPTION
**DO NOT SQUASH**

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The commits can be looked at separately.
* The first unclutters some of the of the virtual address calculation and it is now centered around the `RzBinObject`-local `rz_bin_object_get_vaddr()` function.
* The second converts binsym to use an actual enum type `RzBinSpecialSymbol` everywhere instead of int and also makes it `RzBinObject`-local.
* The third just removes `has_lit`
* The fourth removes an old hack where **GLOBAL** (!!!) sdb of "symbol name -> addr" was used during iterating over imports to resolve their addresses from their name. The same info is now available in a smaller hashtable in `RzBinObject`.

**Test plan**

This is quite well-covered by integration tests