### PR TITLE
Fix dup [?25l esc seq in cmd_visual test

### DIFF
--- a/librz/core/visual.c
+++ b/librz/core/visual.c
@@ -4009,7 +4009,6 @@ RZ_API int rz_core_visual(RzCore *core, const char *input) {
 			printfmtSingle[2] = debugstr;
 		}
 #endif
-		rz_cons_show_cursor(false);
 		rz_cons_enable_mouse(rz_config_get_b(core->config, "scr.wheel"));
 		core->cons->event_resize = NULL; // avoid running old event with new data
 		core->cons->event_data = core;

--- a/test/db/cmd/cmd_visual
+++ b/test/db/cmd/cmd_visual
@@ -89,7 +89,7 @@ e scr.rows=12
 ?e
 EOF
 EXPECT=<<EOF
-[?25l[?25l[0;0H[0m[0x00005ae0 [Xadvc]0 11% 192 bins/elf/ls]> xc @ entry0                          
+[?25l[0;0H[0m[0x00005ae0 [Xadvc]0 11% 192 bins/elf/ls]> xc @ entry0                          
 - offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF  comment  
 0x00005ae0  f30f 1efa 31ed 4989 d15e 4889 e248 83e4  ....1.I..^H..H..  ; entry0 
 0x00005af0  f050 544c 8d05 660c 0100 488d 0def 0b01  .PTL..f...H.....           


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the duplicate `[?25l` escape sequence found in the "initial Visual view" `cmd_visual` test.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
