### PR TITLE
Refactor ELF PT_NOTE Parsing

### DIFF
--- a/librz/bin/format/elf/elf.h
+++ b/librz/bin/format/elf/elf.h
@@ -124,6 +124,38 @@ typedef struct rz_bin_elf_lib_t {
 	int last;
 } RzBinElfLib;
 
+/// A single file entry in a PT_NOTE of type NT_FILE
+typedef struct Elf_(rz_bin_elf_note_file_t) {
+	Elf_(Addr) start_vaddr;
+	Elf_(Addr) end_vaddr;
+	Elf_(Addr) file_off;
+	char *file;
+}
+RzBinElfNoteFile;
+
+/// A single PT_NOTE entry, parsed from an ElfW(Nhdr) and associated data.
+typedef struct Elf_(rz_bin_elf_note_t) {
+	Elf_(Word) type;
+	union {
+		struct {
+			size_t files_count;
+			RzBinElfNoteFile *files;
+		} file; //< for type == NT_FILE
+		struct {
+			size_t regstate_size;
+			ut8 *regstate;
+		} prstatus; //< for type = NT_PRSTATUS
+	};
+}
+RzBinElfNote;
+
+/// A single parsed PT_NOTE segment
+typedef struct Elf_(rz_bin_elf_note_segment_t) {
+	size_t notes_count;
+	RzBinElfNote *notes;
+}
+RzBinElfNoteSegment;
+
 struct Elf_(rz_bin_elf_obj_t) {
 	Elf_(Ehdr) ehdr;
 	Elf_(Phdr) * phdr;
@@ -138,6 +170,8 @@ struct Elf_(rz_bin_elf_obj_t) {
 	char *shstrtab;
 
 	RzBinElfDynamicInfo dyn_info;
+
+	RzList /*<RzBinElfNoteSegment>*/ *note_segments;
 
 	ut64 version_info[DT_VERSIONTAGNUM];
 
@@ -218,7 +252,7 @@ bool Elf_(rz_bin_elf_del_rpath)(RzBinFile *bf);
 bool Elf_(rz_bin_elf_is_executable)(ELFOBJ *bin);
 int Elf_(rz_bin_elf_has_relro)(struct Elf_(rz_bin_elf_obj_t) * bin);
 int Elf_(rz_bin_elf_has_nx)(struct Elf_(rz_bin_elf_obj_t) * bin);
-ut8 *Elf_(rz_bin_elf_grab_regstate)(struct Elf_(rz_bin_elf_obj_t) * bin, int *len);
+const ut8 *Elf_(rz_bin_elf_grab_regstate)(struct Elf_(rz_bin_elf_obj_t) * bin, size_t *size);
 RzList *Elf_(rz_bin_elf_get_maps)(ELFOBJ *bin);
 RzBinSymbol *Elf_(_r_bin_elf_convert_symbol)(struct Elf_(rz_bin_elf_obj_t) * bin,
 	struct rz_bin_elf_symbol_t *symbol,

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -41,11 +41,10 @@ static char *regstate(RzBinFile *bf) {
 		return NULL;
 	}
 
-	int len = 0;
-	ut8 *regs = Elf_(rz_bin_elf_grab_regstate)(obj, &len);
-	char *hexregs = (regs && len > 0) ? rz_hex_bin2strdup(regs, len) : NULL;
+	size_t sz = 0;
+	const ut8 *regs = Elf_(rz_bin_elf_grab_regstate)(obj, &sz);
+	char *hexregs = (regs && sz) ? rz_hex_bin2strdup(regs, sz) : NULL;
 
-	free(regs);
 	return hexregs;
 }
 

--- a/test/db/formats/elf/core
+++ b/test/db/formats/elf/core
@@ -59,3 +59,30 @@ EXPECT=<<EOF
         ,=< 0x7ffe70f68000      7f45           jg 0x7ffe70f68047
 EOF
 RUN
+
+NAME=core maps
+FILE=bins/elf/analysis/core.1159
+CMDS=<<EOF
+om
+EOF
+EXPECT=<<EOF
+18 fd: 3 +0x00001000 0x00400000 - 0x00400fff r-x /home/pancake/a.out
+17 fd: 3 +0x00002000 0x00600000 - 0x00600fff r-- /home/pancake/a.out
+16 fd: 3 +0x00003000 0x7f594847d000 - 0x7f594847dfff r-x /usr/lib/libc-2.22.so
+15 fd: 6 +0x00000000 0x7f594847e000 - 0x7f5948617fff r-x mmap.LOAD2
+14 fd: 5 +0x00000000 0x7f5948618000 - 0x7f5948817fff r-- /usr/lib/libc-2.22.so
+13 fd: 3 +0x00004000 0x7f5948818000 - 0x7f594881bfff r-- /usr/lib/libc-2.22.so
+12 fd: 3 +0x00008000 0x7f594881c000 - 0x7f594881dfff r-- /usr/lib/libc-2.22.so
+11 fd: 3 +0x0000a000 0x7f594881e000 - 0x7f5948821fff r-- fmap.LOAD6
+10 fd: 3 +0x0000e000 0x7f5948822000 - 0x7f5948822fff r-x /usr/lib/ld-2.22.so
+ 9 fd: 4 +0x00000000 0x7f5948823000 - 0x7f5948843fff r-x mmap.LOAD7
+ 8 fd: 3 +0x0000f000 0x7f5948a1e000 - 0x7f5948a20fff r-- fmap.LOAD8
+ 7 fd: 3 +0x00012000 0x7f5948a43000 - 0x7f5948a43fff r-- /usr/lib/ld-2.22.so
+ 6 fd: 3 +0x00013000 0x7f5948a44000 - 0x7f5948a44fff r-- /usr/lib/ld-2.22.so
+ 5 fd: 3 +0x00014000 0x7f5948a45000 - 0x7f5948a45fff r-- fmap.LOAD11
+ 4 fd: 3 +0x00015000 0x7ffe70de6000 - 0x7ffe70e07fff r-- [stack]
+ 3 fd: 3 +0x00037000 0x7ffe70f66000 - 0x7ffe70f67fff r-- fmap.LOAD13
+ 2 fd: 3 +0x00039000 0x7ffe70f68000 - 0x7ffe70f69fff r-x fmap.LOAD14
+ 1 fd: 3 +0x0003b000 0xffffffffff600000 - 0xffffffffff600fff r-x fmap.LOAD15
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This is about parsing `PT_NOTE` segment contents from core files (see for example https://www.gabriel.urdhr.fr/2015/05/29/core-file/)
Before, both `rz_bin_elf_grab_regstate()` and `get_nt_file_maps()`, would parse the segment on the fly (with a lot of code duplication) and return only the necessary information.
I will need to extract more fine-grained info from the regstate later so to avoid parsing it again, I refactored it to be parsed in the initial loading such that it is always available later.

**Test plan**

see the added test