### PR TITLE
Split afvx to two commands - one for variables and one for function arguments

### DIFF
--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -905,8 +905,9 @@ static void list_vars(RzCore *core, RzAnalysisFunction *fcn, PJ *pj, int type, c
 	if (name && *name) {
 		var = rz_analysis_function_get_var_byname(fcn, name);
 		if (var) {
-			if (var->isarg == vlt || vlt == IS_ARG_AND_VAR)
+			if (var->isarg == vlt || vlt == IS_ARG_AND_VAR) {
 				var_accesses_list(fcn, var, pj, access_type, var->name);
+			}
 		}
 	} else {
 		rz_list_foreach (list, iter, var) {

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -911,8 +911,9 @@ static void list_vars(RzCore *core, RzAnalysisFunction *fcn, PJ *pj, int type, c
 		}
 	} else {
 		rz_list_foreach (list, iter, var) {
-			if (var->isarg == vlt || vlt == IS_ARG_AND_VAR)
+			if (var->isarg == vlt || vlt == IS_ARG_AND_VAR) {
 				var_accesses_list(fcn, var, pj, access_type, var->name);
+			}
 		}
 	}
 	if (pj) {

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -851,7 +851,13 @@ static void var_accesses_list(RzAnalysisFunction *fcn, RzAnalysisVar *var, PJ *p
 	}
 }
 
-static void list_vars(RzCore *core, RzAnalysisFunction *fcn, PJ *pj, int type, const char *name) {
+typedef enum {
+	IS_VAR = 0,
+	IS_ARG,
+	IS_ARG_AND_VAR
+} RzVarListType;
+
+static void list_vars(RzCore *core, RzAnalysisFunction *fcn, PJ *pj, int type, const char *name, RzVarListType vlt) {
 	RzAnalysisVar *var = NULL;
 	RzListIter *iter;
 	RzList *list = rz_analysis_var_all_list(core->analysis, fcn);
@@ -899,11 +905,13 @@ static void list_vars(RzCore *core, RzAnalysisFunction *fcn, PJ *pj, int type, c
 	if (name && *name) {
 		var = rz_analysis_function_get_var_byname(fcn, name);
 		if (var) {
-			var_accesses_list(fcn, var, pj, access_type, var->name);
+			if (var->isarg == vlt || vlt == IS_ARG_AND_VAR)
+				var_accesses_list(fcn, var, pj, access_type, var->name);
 		}
 	} else {
 		rz_list_foreach (list, iter, var) {
-			var_accesses_list(fcn, var, pj, access_type, var->name);
+			if (var->isarg == vlt || vlt == IS_ARG_AND_VAR)
+				var_accesses_list(fcn, var, pj, access_type, var->name);
 		}
 	}
 	if (pj) {
@@ -925,13 +933,13 @@ static void cmd_afvx(RzCore *core, RzAnalysisFunction *fcn, bool json) {
 		} else {
 			rz_cons_printf("afvR\n");
 		}
-		list_vars(core, fcn, pj, 'R', NULL);
+		list_vars(core, fcn, pj, 'R', NULL, IS_ARG_AND_VAR);
 		if (json) {
 			pj_k(pj, "writes");
 		} else {
 			rz_cons_printf("afvW\n");
 		}
-		list_vars(core, fcn, pj, 'W', NULL);
+		list_vars(core, fcn, pj, 'W', NULL, IS_ARG_AND_VAR);
 		if (json) {
 			pj_end(pj);
 			char *j = pj_drain(pj);
@@ -1145,7 +1153,7 @@ static int var_cmd(RzCore *core, const char *str) {
 					return false;
 				}
 			}
-			list_vars(core, fcn, pj, str[0], name);
+			list_vars(core, fcn, pj, str[0], name, IS_ARG_AND_VAR);
 			if (str[1] == 'j') {
 				pj_end(pj);
 				rz_cons_println(pj_string(pj));
@@ -9576,7 +9584,7 @@ RZ_IPI RzCmdStatus rz_analysis_function_vars_type_handler(RzCore *core, int argc
 	return RZ_CMD_STATUS_OK;
 }
 
-RZ_IPI RzCmdStatus rz_analysis_function_vars_xrefs_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
+RZ_IPI RzCmdStatus rz_analysis_function_args_and_vars_xrefs_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode, bool use_args, bool use_vars) {
 	RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(core->analysis, core->offset, -1);
 	if (!fcn) {
 		eprintf("Cannot find function in 0x%08" PFMT64x "\n", core->offset);
@@ -9590,13 +9598,23 @@ RZ_IPI RzCmdStatus rz_analysis_function_vars_xrefs_handler(RzCore *core, int arg
 	} else {
 		rz_cons_printf("afvR\n");
 	}
-	list_vars(core, fcn, pj, 'R', argv[1]);
+	if (use_args) {
+		list_vars(core, fcn, pj, 'R', argv[1], IS_ARG);
+	}
+	if (use_vars) {
+		list_vars(core, fcn, pj, 'R', argv[1], IS_VAR);
+	}
 	if (mode == RZ_OUTPUT_MODE_JSON) {
 		pj_k(pj, "writes");
 	} else {
 		rz_cons_printf("afvW\n");
 	}
-	list_vars(core, fcn, pj, 'W', argv[1]);
+	if (use_args) {
+		list_vars(core, fcn, pj, 'W', argv[1], IS_ARG);
+	}
+	if (use_vars) {
+		list_vars(core, fcn, pj, 'W', argv[1], IS_VAR);
+	}
 	if (mode == RZ_OUTPUT_MODE_JSON) {
 		pj_end(pj);
 		char *j = pj_drain(pj);
@@ -9604,6 +9622,18 @@ RZ_IPI RzCmdStatus rz_analysis_function_vars_xrefs_handler(RzCore *core, int arg
 		free(j);
 	}
 	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_analysis_function_vars_xrefs_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
+	return rz_analysis_function_args_and_vars_xrefs_handler(core, argc, argv, mode, true, true);
+}
+
+RZ_IPI RzCmdStatus rz_analysis_function_vars_xrefs_args_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
+	return rz_analysis_function_args_and_vars_xrefs_handler(core, argc, argv, mode, true, false);
+}
+
+RZ_IPI RzCmdStatus rz_analysis_function_vars_xrefs_vars_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
+	return rz_analysis_function_args_and_vars_xrefs_handler(core, argc, argv, mode, false, true);
 }
 
 static RzCmdStatus analysis_function_vars_kind_list(RzCore *core, RzAnalysisFunction *fcn, RzAnalysisVarKind kind, RzOutputMode mode) {

--- a/librz/core/cmd_descs/cmd_analysis.yaml
+++ b/librz/core/cmd_descs/cmd_analysis.yaml
@@ -225,15 +225,38 @@ commands:
               - name: type
                 type: RZ_CMD_ARG_TYPE_STRING
           - name: afvx
-            cname: analysis_function_vars_xrefs
-            summary: Show function variable xrefs (same as afvR+afvW)
-            modes:
-              - RZ_OUTPUT_MODE_STANDARD
-              - RZ_OUTPUT_MODE_JSON
-            args:
-              - name: varname
-                type: RZ_CMD_ARG_TYPE_FCN_VAR
-                optional: true
+            summary: Show argument/variable xrefs in a function
+            subcommands:
+              - name: afvx
+                cname: analysis_function_vars_xrefs
+                summary: Show function variable xrefs (same as afvR+afvW)
+                modes:
+                  - RZ_OUTPUT_MODE_STANDARD
+                  - RZ_OUTPUT_MODE_JSON
+                args:
+                  - name: varname
+                    type: RZ_CMD_ARG_TYPE_FCN_VAR
+                    optional: true
+              - name: afvxa
+                cname: analysis_function_vars_xrefs_args
+                summary: Show function argument xrefs
+                modes:
+                  - RZ_OUTPUT_MODE_STANDARD
+                  - RZ_OUTPUT_MODE_JSON
+                args:
+                  - name: varname
+                    type: RZ_CMD_ARG_TYPE_FCN_VAR
+                    optional: true
+              - name: afvxv
+                cname: analysis_function_vars_xrefs_vars
+                summary: Show function local variable xrefs
+                modes:
+                  - RZ_OUTPUT_MODE_STANDARD
+                  - RZ_OUTPUT_MODE_JSON
+                args:
+                  - name: varname
+                    type: RZ_CMD_ARG_TYPE_FCN_VAR
+                    optional: true
           - name: afvb
             summary: Manipulate BP based arguments/locals
             subcommands:

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -70,6 +70,8 @@ static const RzCmdDescArg analysis_function_vars_reads_args[2];
 static const RzCmdDescArg analysis_function_vars_writes_args[2];
 static const RzCmdDescArg analysis_function_vars_type_args[3];
 static const RzCmdDescArg analysis_function_vars_xrefs_args[2];
+static const RzCmdDescArg analysis_function_vars_xrefs_args_args[2];
+static const RzCmdDescArg analysis_function_vars_xrefs_vars_args[2];
 static const RzCmdDescArg analysis_function_vars_bp_args[4];
 static const RzCmdDescArg analysis_function_vars_bp_del_args[2];
 static const RzCmdDescArg analysis_function_vars_bp_getref_args[3];
@@ -1127,6 +1129,9 @@ static const RzCmdDescHelp analysis_function_vars_type_help = {
 	.args = analysis_function_vars_type_args,
 };
 
+static const RzCmdDescHelp afvx_help = {
+	.summary = "Show argument/variable xrefs in a function",
+};
 static const RzCmdDescArg analysis_function_vars_xrefs_args[] = {
 	{
 		.name = "varname",
@@ -4101,13 +4106,12 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *analysis_function_vars_type_cd = rz_cmd_desc_argv_new(core->rcmd, afv_cd, "afvt", rz_analysis_function_vars_type_handler, &analysis_function_vars_type_help);
 	rz_warn_if_fail(analysis_function_vars_type_cd);
 
-	RzCmdDesc *analysis_function_vars_xrefs_cd = rz_cmd_desc_argv_modes_new(core->rcmd, afv_cd, "afvx", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_function_vars_xrefs_handler, &analysis_function_vars_xrefs_help);
-	rz_warn_if_fail(analysis_function_vars_xrefs_cd);
-
-	RzCmdDesc *analysis_function_vars_xrefs_args_cd = rz_cmd_desc_argv_modes_new(core->rcmd, afv_cd, "afvxa", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_function_vars_xrefs_args_handler, &analysis_function_vars_xrefs_args_help);
+	RzCmdDesc *afvx_cd = rz_cmd_desc_group_modes_new(core->rcmd, afv_cd, "afvx", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_function_vars_xrefs_handler, &analysis_function_vars_xrefs_help, &afvx_help);
+	rz_warn_if_fail(afvx_cd);
+	RzCmdDesc *analysis_function_vars_xrefs_args_cd = rz_cmd_desc_argv_modes_new(core->rcmd, afvx_cd, "afvxa", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_function_vars_xrefs_args_handler, &analysis_function_vars_xrefs_args_help);
 	rz_warn_if_fail(analysis_function_vars_xrefs_args_cd);
 
-	RzCmdDesc *analysis_function_vars_xrefs_vars_cd = rz_cmd_desc_argv_modes_new(core->rcmd, afv_cd, "afvxv", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_function_vars_xrefs_vars_handler, &analysis_function_vars_xrefs_vars_help);
+	RzCmdDesc *analysis_function_vars_xrefs_vars_cd = rz_cmd_desc_argv_modes_new(core->rcmd, afvx_cd, "afvxv", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_function_vars_xrefs_vars_handler, &analysis_function_vars_xrefs_vars_help);
 	rz_warn_if_fail(analysis_function_vars_xrefs_vars_cd);
 
 	RzCmdDesc *afvb_cd = rz_cmd_desc_group_modes_new(core->rcmd, afv_cd, "afvb", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON, rz_analysis_function_vars_bp_handler, &analysis_function_vars_bp_help, &afvb_help);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -1141,6 +1141,34 @@ static const RzCmdDescHelp analysis_function_vars_xrefs_help = {
 	.args = analysis_function_vars_xrefs_args,
 };
 
+static const RzCmdDescArg analysis_function_vars_xrefs_args_args[] = {
+	{
+		.name = "varname",
+		.type = RZ_CMD_ARG_TYPE_FCN_VAR,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_function_vars_xrefs_args_help = {
+	.summary = "Show function argument xrefs",
+	.args = analysis_function_vars_xrefs_args_args,
+};
+
+static const RzCmdDescArg analysis_function_vars_xrefs_vars_args[] = {
+	{
+		.name = "varname",
+		.type = RZ_CMD_ARG_TYPE_FCN_VAR,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_function_vars_xrefs_vars_help = {
+	.summary = "Show function local variable xrefs",
+	.args = analysis_function_vars_xrefs_vars_args,
+};
+
 static const RzCmdDescHelp afvb_help = {
 	.summary = "Manipulate BP based arguments/locals",
 };
@@ -4075,6 +4103,12 @@ RZ_IPI void newshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *analysis_function_vars_xrefs_cd = rz_cmd_desc_argv_modes_new(core->rcmd, afv_cd, "afvx", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_function_vars_xrefs_handler, &analysis_function_vars_xrefs_help);
 	rz_warn_if_fail(analysis_function_vars_xrefs_cd);
+
+	RzCmdDesc *analysis_function_vars_xrefs_args_cd = rz_cmd_desc_argv_modes_new(core->rcmd, afv_cd, "afvxa", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_function_vars_xrefs_args_handler, &analysis_function_vars_xrefs_args_help);
+	rz_warn_if_fail(analysis_function_vars_xrefs_args_cd);
+
+	RzCmdDesc *analysis_function_vars_xrefs_vars_cd = rz_cmd_desc_argv_modes_new(core->rcmd, afv_cd, "afvxv", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_function_vars_xrefs_vars_handler, &analysis_function_vars_xrefs_vars_help);
+	rz_warn_if_fail(analysis_function_vars_xrefs_vars_cd);
 
 	RzCmdDesc *afvb_cd = rz_cmd_desc_group_modes_new(core->rcmd, afv_cd, "afvb", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON, rz_analysis_function_vars_bp_handler, &analysis_function_vars_bp_help, &afvb_help);
 	rz_warn_if_fail(afvb_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -79,6 +79,8 @@ RZ_IPI RzCmdStatus rz_analysis_function_vars_reads_handler(RzCore *core, int arg
 RZ_IPI RzCmdStatus rz_analysis_function_vars_writes_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_analysis_function_vars_type_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_analysis_function_vars_xrefs_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
+RZ_IPI RzCmdStatus rz_analysis_function_vars_xrefs_args_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
+RZ_IPI RzCmdStatus rz_analysis_function_vars_xrefs_vars_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI RzCmdStatus rz_analysis_function_vars_bp_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI RzCmdStatus rz_analysis_function_vars_bp_del_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_analysis_function_vars_bp_getref_handler(RzCore *core, int argc, const char **argv);

--- a/test/db/analysis/vars
+++ b/test/db/analysis/vars
@@ -105,6 +105,186 @@ R 0x1000010f0  movzx eax, word [var_2eh]
 EOF
 RUN
 
+NAME=afvxa
+FILE=bins/elf/ls.odd
+CMDS=<<EOF
+af
+afv=
+afvxv
+EOF
+EXPECT=<<EOF
+* arg3
+R 0x5312  mov r9, rdx
+afvR
+afvW
+EOF
+RUN
+
+NAME=afvxa2
+FILE=bins/mach0/mac-ls
+CMDS=<<EOF
+af
+afv=
+afvxa
+EOF
+EXPECT=<<EOF
+* argv
+R 0x10000106c  mov rbx, rsi
+* argc
+R 0x10000106f  mov r14d, edi
+* var_640h
+R 0x100001072  lea rax, [var_640h]
+* var_648h
+R 0x100001617  lea rbx, [var_648h]
+R 0x100001691  lea rsi, [var_648h]
+W 0x100001079  mov qword [var_648h], rax
+* var_654h
+R 0x100001784  cmp dword [var_654h], 0
+W 0x100001137  mov dword [var_654h], 0
+W 0x100001315  mov dword [var_654h], 1
+* var_650h
+R 0x10000173c  or ebx, dword [var_650h]
+R 0x100001807  cmp dword [var_650h], 0
+R 0x10000181c  cmp dword [var_650h], 0
+W 0x10000114c  mov dword [var_650h], 0
+W 0x1000014f2  mov dword [var_650h], 1
+* var_64ch
+R 0x100001736  mov ebx, dword [var_64ch]
+R 0x1000017dd  cmp dword [var_64ch], 0
+R 0x1000017f2  cmp dword [var_64ch], 0
+W 0x100001156  mov dword [var_64ch], 0
+W 0x1000012d8  mov dword [var_64ch], 1
+* var_658h
+R 0x1000017d4  cmp dword [var_658h], 0
+W 0x100001160  mov dword [var_658h], 0
+W 0x1000014ce  mov dword [var_658h], 1
+* var_660h
+R 0x1000018f1  mov rax, qword [var_660h]
+W 0x100001597  mov qword [var_660h], rcx
+* var_664h
+R 0x10000190b  mov edi, dword [var_664h]
+W 0x1000015a3  mov dword [var_664h], eax
+* var_670h
+R 0x100001911  mov rsi, qword [var_670h]
+W 0x1000015ad  mov qword [var_670h], rax
+* var_34h
+R 0x10000179e  lea rdi, [var_34h]
+* var_440h
+R 0x1000015f8  lea rdi, [var_440h]
+* var_30h
+R 0x1000010d6  lea rdx, [var_30h]
+* var_2eh
+R 0x1000010f0  movzx eax, word [var_2eh]
+afvR
+      argv  0x10000106c
+      argc  0x10000106f
+afvW
+      argv
+      argc
+EOF
+RUN
+
+NAME=afvxv
+FILE=bins/elf/ls.odd
+CMDS=<<EOF
+af
+afv=
+afvxv
+EOF
+EXPECT=<<EOF
+* arg3
+R 0x5312  mov r9, rdx
+afvR
+afvW
+EOF
+RUN
+
+NAME=afvxv2
+FILE=bins/mach0/mac-ls
+CMDS=<<EOF
+af
+afv=
+afvxv
+EOF
+EXPECT=<<EOF
+* argv
+R 0x10000106c  mov rbx, rsi
+* argc
+R 0x10000106f  mov r14d, edi
+* var_640h
+R 0x100001072  lea rax, [var_640h]
+* var_648h
+R 0x100001617  lea rbx, [var_648h]
+R 0x100001691  lea rsi, [var_648h]
+W 0x100001079  mov qword [var_648h], rax
+* var_654h
+R 0x100001784  cmp dword [var_654h], 0
+W 0x100001137  mov dword [var_654h], 0
+W 0x100001315  mov dword [var_654h], 1
+* var_650h
+R 0x10000173c  or ebx, dword [var_650h]
+R 0x100001807  cmp dword [var_650h], 0
+R 0x10000181c  cmp dword [var_650h], 0
+W 0x10000114c  mov dword [var_650h], 0
+W 0x1000014f2  mov dword [var_650h], 1
+* var_64ch
+R 0x100001736  mov ebx, dword [var_64ch]
+R 0x1000017dd  cmp dword [var_64ch], 0
+R 0x1000017f2  cmp dword [var_64ch], 0
+W 0x100001156  mov dword [var_64ch], 0
+W 0x1000012d8  mov dword [var_64ch], 1
+* var_658h
+R 0x1000017d4  cmp dword [var_658h], 0
+W 0x100001160  mov dword [var_658h], 0
+W 0x1000014ce  mov dword [var_658h], 1
+* var_660h
+R 0x1000018f1  mov rax, qword [var_660h]
+W 0x100001597  mov qword [var_660h], rcx
+* var_664h
+R 0x10000190b  mov edi, dword [var_664h]
+W 0x1000015a3  mov dword [var_664h], eax
+* var_670h
+R 0x100001911  mov rsi, qword [var_670h]
+W 0x1000015ad  mov qword [var_670h], rax
+* var_34h
+R 0x10000179e  lea rdi, [var_34h]
+* var_440h
+R 0x1000015f8  lea rdi, [var_440h]
+* var_30h
+R 0x1000010d6  lea rdx, [var_30h]
+* var_2eh
+R 0x1000010f0  movzx eax, word [var_2eh]
+afvR
+  var_640h  0x100001072
+  var_648h  0x100001617,0x100001691
+  var_654h  0x100001784
+  var_650h  0x10000173c,0x100001807,0x10000181c
+  var_64ch  0x100001736,0x1000017dd,0x1000017f2
+  var_658h  0x1000017d4
+  var_660h  0x1000018f1
+  var_664h  0x10000190b
+  var_670h  0x100001911
+   var_34h  0x10000179e
+  var_440h  0x1000015f8
+   var_30h  0x1000010d6
+   var_2eh  0x1000010f0
+afvW
+  var_640h
+  var_648h  0x100001079
+  var_654h  0x100001137,0x100001315
+  var_650h  0x10000114c,0x1000014f2
+  var_64ch  0x100001156,0x1000012d8
+  var_658h  0x100001160,0x1000014ce
+  var_660h  0x100001597
+  var_664h  0x1000015a3
+  var_670h  0x1000015ad
+   var_34h
+  var_440h
+   var_30h
+   var_2eh
+EOF
+RUN
+
 NAME=Detect register args used only by callee
 FILE=-
 CMDS=<<EOF


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This PR splits `afvx` command in two:
- `afvxa` will show only arguments
- `afvxv` will show only local variables
- `afvx` will show both

**Test plan**

Try `afvxa` and `afvxv`

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/332

cc @no1rr