### PR TITLE
Use PJ in `Lcj` and refactor to use API in panels ##json

### DIFF
--- a/librz/core/cmd_plugins.c
+++ b/librz/core/cmd_plugins.c
@@ -71,14 +71,20 @@ RZ_IPI int rz_cmd_plugins(void *data, const char *input) {
 		RzCorePlugin *cp;
 		switch (input[1]) {
 		case 'j': {
-			rz_cons_printf("[");
-			bool is_first_element = true;
-			rz_list_foreach (core->plugins, iter, cp) {
-				rz_cons_printf("%s{\"Name\":\"%s\",\"Description\":\"%s\"}",
-					is_first_element ? "" : ",", cp->name, cp->desc);
-				is_first_element = false;
+			PJ *pj = pj_new();
+			if (!pj) {
+				break;
 			}
-			rz_cons_printf("]\n");
+			pj_a(pj);
+			rz_list_foreach (core->plugins, iter, cp) {
+				pj_o(pj);
+				pj_ks(pj, "Name", cp->name);
+				pj_ks(pj, "Description", cp->desc);
+				pj_end(pj);
+			}
+			pj_end(pj);
+			rz_cons_println(pj_string(pj));
+			pj_free(pj);
 			break;
 		}
 		case 0:

--- a/librz/core/panels.c
+++ b/librz/core/panels.c
@@ -5972,7 +5972,7 @@ RZ_API bool rz_core_visual_panels_root(RzCore *core, RzPanelsRoot *panels_root) 
 	{
 		const char *l = rz_config_get(core->config, "scr.layout");
 		if (l && *l) {
-			rz_core_cmdf(core, "v %s", l);
+			rz_load_panels_layout(core, l);
 		}
 	}
 	RzPanels *panels = panels_root->panels[panels_root->cur_panels];

--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -22,3 +22,19 @@ x86.pseudo
 z80.pseudo
 EOF
 RUN
+
+NAME=List core plugins
+FILE=-
+CMDS=Lc
+EXPECT=<<EOF
+java: Suite of java commands, type `java` for more info
+EOF
+RUN
+
+NAME=List core plugins in JSON
+FILE=-
+CMDS=Lcj
+EXPECT=<<EOF
+[{"Name":"java","Description":"Suite of java commands, type `java` for more info"}]
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
This PR:
- Uses the PJ API for `Lcj`
- Replaces one instance of a `rz_core_cmdf` call to load a saved visual panel layout to use its API.

**Test plan**

- Check whether the test is representative enough. 
Since `Lcj` is sort of dependent what all plugins the user have installed, I had uninstalled all my other
plugins and added a test accordingly, even though if multiple plugins exist the JSON is valid.

![image](https://user-images.githubusercontent.com/29057155/114440299-9422ee80-9be7-11eb-9bf3-cad3169be010.png)


**Closing issues**

Related to #383 and #200 
