### PR TITLE
Add RzIOMap return to rz_io_open_at()

### DIFF
--- a/librz/analysis/p/analysis_8051.c
+++ b/librz/analysis/p/analysis_8051.c
@@ -89,7 +89,7 @@ static void map_cpu_memory(RzAnalysis *analysis, int entry, ut32 addr, ut32 size
 	} else {
 		// allocate memory for address space
 		char *mstr = rz_str_newf("malloc://%d", size);
-		desc = analysis->iob.open_at(analysis->iob.io, mstr, RZ_PERM_RW, 0, addr);
+		desc = analysis->iob.open_at(analysis->iob.io, mstr, RZ_PERM_RW, 0, addr, NULL);
 		free(mstr);
 		// set 8051 address space as name of mapped memory
 		if (desc && analysis->iob.fd_get_name(analysis->iob.io, desc->fd)) {

--- a/librz/analysis/p/analysis_pic.c
+++ b/librz/analysis/p/analysis_pic.c
@@ -642,7 +642,7 @@ static RzIODesc *cpu_memory_map(RzIOBind *iob, RzIODesc *desc, ut32 addr,
 	if (desc && iob->fd_get_name(iob->io, desc->fd)) {
 		iob->fd_remap(iob->io, desc->fd, addr);
 	} else {
-		desc = iob->open_at(iob->io, mstr, RZ_PERM_RW, 0, addr);
+		desc = iob->open_at(iob->io, mstr, RZ_PERM_RW, 0, addr, NULL);
 	}
 	free(mstr);
 	return desc;

--- a/librz/bin/p/bin_coff.c
+++ b/librz/bin/p/bin_coff.c
@@ -499,14 +499,10 @@ static RzList *patch_relocs(RzBinFile *bf) {
 		m_vaddr = RZ_ROUND(offset, 16);
 		ut64 size = nimports * BYTES_PER_IMP_RELOC;
 		char *muri = rz_str_newf("malloc://%" PFMT64u, size);
-		RzIODesc *desc = b->iob.open_at(io, muri, RZ_PERM_R, 0664, m_vaddr);
+		RzIOMap *map;
+		RzIODesc *desc = b->iob.open_at(io, muri, RZ_PERM_R, 0664, m_vaddr, &map);
 		free(muri);
-		if (!desc) {
-			return NULL;
-		}
-
-		RzIOMap *map = b->iob.map_get(io, m_vaddr);
-		if (!map) {
+		if (!desc || !map) {
 			return NULL;
 		}
 		map->name = strdup(".imports.rz");

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -987,14 +987,10 @@ static RzList *patch_relocs(RzBinFile *bf) {
 	// reserve at least that space
 	size = bin->g_reloc_num * cdsz;
 	char *muri = rz_str_newf("malloc://%" PFMT64u, size);
-	RzIODesc *gotrzdesc = b->iob.open_at(io, muri, RZ_PERM_R, 0664, n_vaddr);
+	RzIOMap *gotrzmap;
+	RzIODesc *gotrzdesc = b->iob.open_at(io, muri, RZ_PERM_R, 0664, n_vaddr, &gotrzmap);
 	free(muri);
-	if (!gotrzdesc) {
-		return NULL;
-	}
-
-	RzIOMap *gotrzmap = b->iob.map_get(io, n_vaddr);
-	if (!gotrzmap) {
+	if (!gotrzdesc || !gotrzmap) {
 		return NULL;
 	}
 	gotrzmap->name = strdup(".got.rz");

--- a/librz/bin/p/bin_mach0.c
+++ b/librz/bin/p/bin_mach0.c
@@ -637,14 +637,10 @@ static RzList *patch_relocs(RzBinFile *bf) {
 	ut64 n_vaddr = g->itv.addr + g->itv.size;
 	ut64 size = num_ext_relocs * cdsz;
 	char *muri = rz_str_newf("malloc://%" PFMT64u, size);
-	gotrzdesc = b->iob.open_at(io, muri, RZ_PERM_R, 0664, n_vaddr);
+	RzIOMap *gotrzmap;
+	gotrzdesc = b->iob.open_at(io, muri, RZ_PERM_R, 0664, n_vaddr, &gotrzmap);
 	free(muri);
 	if (!gotrzdesc) {
-		goto beach;
-	}
-
-	RzIOMap *gotrzmap = b->iob.map_get(io, n_vaddr);
-	if (!gotrzmap) {
 		goto beach;
 	}
 	gotrzmap->name = strdup(".got.rz");

--- a/librz/core/cmd_open.c
+++ b/librz/core/cmd_open.c
@@ -1144,7 +1144,7 @@ RZ_IPI int rz_cmd_open(void *data, const char *input) {
 		if (!strcmp(ptr, "-")) {
 			ptr = "malloc://512";
 		}
-		if ((desc = rz_io_open_at(core->io, ptr, perms, 0644, addr))) {
+		if ((desc = rz_io_open_at(core->io, ptr, perms, 0644, addr, NULL))) {
 			fd = desc->fd;
 		}
 		if (fd == -1) {

--- a/librz/include/rz_io.h
+++ b/librz/include/rz_io.h
@@ -174,7 +174,7 @@ typedef bool (*RzIODescUse)(RzIO *io, int fd);
 typedef RzIODesc *(*RzIODescGet)(RzIO *io, int fd);
 typedef ut64 (*RzIODescSize)(RzIODesc *desc);
 typedef RzIODesc *(*RzIOOpen)(RzIO *io, const char *uri, int flags, int mode);
-typedef RzIODesc *(*RzIOOpenAt)(RzIO *io, const char *uri, int flags, int mode, ut64 at);
+typedef RzIODesc *(*RzIOOpenAt)(RzIO *io, const char *uri, int flags, int mode, ut64 at, RZ_NULLABLE RZ_OUT RzIOMap **map);
 typedef bool (*RzIOClose)(RzIO *io, int fd);
 typedef bool (*RzIOReadAt)(RzIO *io, ut64 addr, ut8 *buf, int len);
 typedef bool (*RzIOWriteAt)(RzIO *io, ut64 addr, const ut8 *buf, int len);
@@ -287,7 +287,7 @@ RZ_API RzIO *rz_io_new(void);
 RZ_API RzIO *rz_io_init(RzIO *io);
 RZ_API RzIODesc *rz_io_open_nomap(RzIO *io, const char *uri, int flags, int mode); //should return int
 RZ_API RzIODesc *rz_io_open(RzIO *io, const char *uri, int flags, int mode);
-RZ_API RzIODesc *rz_io_open_at(RzIO *io, const char *uri, int flags, int mode, ut64 at);
+RZ_API RzIODesc *rz_io_open_at(RzIO *io, const char *uri, int flags, int mode, ut64 at, RZ_NULLABLE RZ_OUT RzIOMap **map);
 RZ_API RzList *rz_io_open_many(RzIO *io, const char *uri, int flags, int mode);
 RZ_API RzIODesc *rz_io_open_buffer(RzIO *io, RzBuffer *b, int flags, int mode);
 RZ_API bool rz_io_close(RzIO *io);

--- a/librz/io/io.c
+++ b/librz/io/io.c
@@ -159,8 +159,18 @@ RZ_API RzIODesc *rz_io_open(RzIO *io, const char *uri, int perm, int mode) {
 	return desc;
 }
 
-/* opens a file and maps it to an offset specified by the "at"-parameter */
-RZ_API RzIODesc *rz_io_open_at(RzIO *io, const char *uri, int perm, int mode, ut64 at) {
+/**
+ * \brief Open a file and directly map it at the given offset
+ *
+ * This executes both rz_io_open_nomap() and rz_io_map_new() and returns their
+ * results without updating the skyline.
+ *
+ * \param uri file uri to open
+ * \param at where to map the file
+ * \param map optionally returns the created RzIOMap
+ * \return the opened RzIODesc of the file
+ * */
+RZ_API RzIODesc *rz_io_open_at(RzIO *io, const char *uri, int perm, int mode, ut64 at, RZ_NULLABLE RZ_OUT RzIOMap **map) {
 	rz_return_val_if_fail(io && uri, NULL);
 
 	RzIODesc *desc = rz_io_open_nomap(io, uri, perm, mode);
@@ -176,7 +186,10 @@ RZ_API RzIODesc *rz_io_open_at(RzIO *io, const char *uri, int perm, int mode, ut
 		size = UT64_MAX - at + 1;
 	}
 	// skyline not updated
-	rz_io_map_new(io, desc->fd, desc->perm, 0LL, at, size);
+	RzIOMap *m = rz_io_map_new(io, desc->fd, desc->perm, 0LL, at, size);
+	if (map) {
+		*map = m;
+	}
 	return desc;
 }
 

--- a/test/unit/test_buf.c
+++ b/test/unit/test_buf.c
@@ -205,7 +205,7 @@ bool test_rz_buf_io(void) {
 	char *tmpfile = rz_file_temp(NULL);
 	char *filename = rz_str_newf("file://%s", tmpfile);
 	free(tmpfile);
-	RzIODesc *desc = rz_io_open_at(io, filename, RZ_PERM_RW | RZ_PERM_CREAT, 0644, 0);
+	RzIODesc *desc = rz_io_open_at(io, filename, RZ_PERM_RW | RZ_PERM_CREAT, 0644, 0, NULL);
 	free(filename);
 	mu_assert_notnull(desc, "file should be opened for writing");
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`rz_io_open_at()` opens a new `RzIODesc` (returned) and creates an `RzIOMap` at the same time. Often it is necessary to also access the `RzIOMap` afterwards and usually code would then query it by address, which works reliably because of how io priority works, but it's kind of dirty, also because the `RzIOMap` pointer is directly available at the end of the function, so I added this additional return arg.

**Test plan**

all tests pass