### PR TITLE
Fix segfault in `rz-find` for multiple files

### DIFF
--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -38,7 +38,6 @@ typedef struct {
 
 static void rzfind_options_fini(RzfindOptions *ro) {
 	free(ro->buf);
-	rz_list_free(ro->keywords);
 }
 
 static void rzfind_options_init(RzfindOptions *ro) {
@@ -467,10 +466,12 @@ RZ_API int rz_main_rz_find(int argc, const char **argv) {
 
 		if (RZ_STR_ISEMPTY(file)) {
 			eprintf("Cannot open empty path\n");
+			rz_list_free(ro.keywords);
 			return 1;
 		}
 		rzfind_open(&ro, file);
 	}
+	rz_list_free(ro.keywords);
 	if (ro.json) {
 		printf("]\n");
 	}

--- a/test/db/tools/rz_find
+++ b/test/db/tools/rz_find
@@ -225,3 +225,22 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=rz-find multiple files
+FILE==
+CMDS=!rz-find -s README bins/arm/README bins/arm/README
+EXPECT=<<EOF
+File: bins/arm/README
+0x0
+File: bins/arm/README
+0x0
+EOF
+RUN
+
+NAME=rz-find recursive
+FILE==
+CMDS=!rz-find -q -s README bins/arm
+EXPECT=<<EOF
+0x0
+EOF
+RUN
+


### PR DESCRIPTION
# SQUASH ME

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Imported patches from radare2 for the crash in `rz-find` during the search in multiple files:
```
[i] ℤ rz-find -s rizin.re meson.build README.md                                                                                                                                                                                   18:01:17 
File: meson.build
File: README.md
zsh: segmentation fault (core dumped)  rz-find -s rizin.re meson.build README.md
```

**Test plan**

CI is green.
