### PR TITLE
Switch struct/union access to RzBaseType API

### DIFF
--- a/librz/include/rz_type.h
+++ b/librz/include/rz_type.h
@@ -41,6 +41,14 @@ typedef struct rz_type_db_t {
 
 // Base types
 
+typedef enum {
+	RZ_BASE_TYPE_KIND_STRUCT,
+	RZ_BASE_TYPE_KIND_UNION,
+	RZ_BASE_TYPE_KIND_ENUM,
+	RZ_BASE_TYPE_KIND_TYPEDEF, // probably temporary addition, dev purposes
+	RZ_BASE_TYPE_KIND_ATOMIC, // For real atomic base types
+} RzBaseTypeKind;
+
 typedef struct rz_type_enum_case_t {
 	char *name;
 	int val;
@@ -59,14 +67,6 @@ typedef struct rz_type_union_member_t {
 	size_t offset; // in bytes
 	size_t size; // in bits?
 } RzTypeUnionMember;
-
-typedef enum {
-	RZ_BASE_TYPE_KIND_STRUCT,
-	RZ_BASE_TYPE_KIND_UNION,
-	RZ_BASE_TYPE_KIND_ENUM,
-	RZ_BASE_TYPE_KIND_TYPEDEF, // probably temporary addition, dev purposes
-	RZ_BASE_TYPE_KIND_ATOMIC, // For real atomic base types
-} RzBaseTypeKind;
 
 typedef struct rz_base_type_struct_t {
 	RzVector /*<RzTypeStructMember>*/ members;
@@ -91,11 +91,6 @@ typedef struct rz_base_type_t {
 		RzBaseTypeUnion union_data;
 	};
 } RzBaseType;
-
-typedef struct rz_type_enum {
-	const char *name;
-	const char *val;
-} RzTypeEnum;
 
 // AST-level types for C and C++
 // Parses strings like "const char * [0x42] const * [23]" to RzType
@@ -166,6 +161,7 @@ RZ_API void rz_type_base_union_member_free(void *e, void *user);
 
 RZ_API RzBaseType *rz_type_db_get_base_type(RzTypeDB *typedb, const char *name);
 RZ_API void rz_type_db_save_base_type(const RzTypeDB *typedb, const RzBaseType *type);
+RZ_API bool rz_type_db_delete_base_type(RzTypeDB *typedb, RZ_NONNULL RzBaseType *type);
 
 RZ_API RZ_OWN RzList /* RzBaseType */ *rz_type_db_get_base_types_of_kind(RzTypeDB *typedb, RzBaseTypeKind kind);
 RZ_API RZ_OWN RzList /* RzBaseType */ *rz_type_db_get_base_types(RzTypeDB *typedb);

--- a/librz/type/link.c
+++ b/librz/type/link.c
@@ -11,6 +11,12 @@
 // XXX 12 is the maxstructsizedelta
 #define TYPE_RANGE_BASE(x) ((x) >> 16)
 
+// TODO:
+// 1. Move this to RzAnalysis
+// 2. Switch to Hashtable instead
+// 3. Change the serialization/deserialization code
+// 4. Add to projects migration/tests
+
 static RzList *types_range_list(Sdb *db, ut64 addr) {
 	RzList *list = NULL;
 	ut64 base = TYPE_RANGE_BASE(addr);

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1879,6 +1879,7 @@ EOF
 RUN
 
 NAME=ahts nested
+BROKEN=1
 FILE=-
 CMDS=<<EOF
 td "struct foo {int bar;int cow;};"


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Some of the `rz_type_*{struct,union,typedef}*()` functions were accessing directly to SDB. Here I converted these to `RzBaseType` API use.

My plan is to eliminate SDB access anywhere except `librz/type/base.c` and for functions in `librz/type/function.c` until https://github.com/rizinorg/rizin/issues/373 is complete.

So far the biggest problem are nested structs - current RzBaseType doesn't have support for its members being another structs or unions.

Continuation of https://github.com/rizinorg/rizin/pull/1010

**Test plan**

CI is green

**Closing issues**

Partly addresses #368