### PR TITLE
Remove hacky Overlap Check in Core IO Mapping from Bin

### DIFF
--- a/librz/bin/p/bin_nes.c
+++ b/librz/bin/p/bin_nes.c
@@ -101,13 +101,13 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->name = strdup("ROM");
 	ptr->paddr = INES_HDR_SIZE;
 	ptr->size = ihdr.prg_page_count_16k * PRG_PAGE_SIZE;
+	bool mirror = ROM_START_ADDRESS + ptr->size <= ROM_MIRROR_ADDRESS; // not a 256bit ROM, mapper 0 mirrors the complete ROM in this case
 	ptr->vaddr = ROM_START_ADDRESS;
-	ptr->vsize = ROM_SIZE;
+	ptr->vsize = mirror ? ROM_MIRROR_ADDRESS - ROM_START_ADDRESS : ROM_SIZE; // make sure the ROM zero excess does not overlap the mirror
 	ptr->perm = RZ_PERM_RX;
 	ptr->add = true;
 	rz_list_append(ret, ptr);
-	if (ROM_START_ADDRESS + ptr->size <= ROM_MIRROR_ADDRESS) {
-		// not a 256bit ROM, mapper 0 mirrors the complete ROM in this case
+	if (mirror) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
 			return ret;
 		}

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -656,10 +656,7 @@ static bool io_create_mem_map(RzIO *io, RzBinSection *sec, ut64 at) {
 	RzIOMap *iomap = NULL;
 	RzIODesc *desc = findReusableFile(io, uri, sec->perm);
 	if (desc) {
-		iomap = rz_io_map_get(io, at);
-		if (!iomap && gap) {
-			iomap = rz_io_map_add_batch(io, desc->fd, desc->perm, 0LL, at, gap);
-		}
+		iomap = rz_io_map_add_batch(io, desc->fd, desc->perm, 0LL, at, gap);
 		reused = true;
 	}
 	if (!desc) {


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
This affects sections where `vsize > psize` in which case you get two mappings, one `fmap.<name>` (or none if `psize == 0`) and `mmap.<name>` with 0s.
The check here is for when an `mmap.` one is about to be created. Before, it was skipped if there was another map with a **lower priority** that contained the vaddr (only the **start address**) of the new mmap, however **only** if there has been a "reusable" file found, meaning another `mmap` file of exactly the same size, which is present in `test/db/cmd/bug_3788` but extremely rare and specific, so this change should not change anything for almost all files.

That means:
* The previous behavior would still overlap the .text section with 0s in this example, iff .bss has higher prio:
    ```
    [.bss                         ]
                     [.text                           ]
    ```

* The current behavior's overlaps are more or less unnoticeable if .text has higher prio than .bss. This is not the case for example in `eofarch.c-gcc-arm-O3.o` in the linked issue. In any case, we can not rely on this prio for object files since they are a special case anyway where there are no segments and we fall back to mapping sections, which are actually not meant to be mapped, so priority probably doesn't have much meaning there. (priority is taken from the order they appear in the binary, earlier is higher prio). So #815 is valid and should be fixed insided the elf plugin imo.


**Test plan**

The only relevant case I am aware of is `test/db/cmd/bug_3788`, which fails without the changes in `bin_nes.c`.

