### PR TITLE
Fix FreeBSD Build for removed KF_TYPE_CRYPTO

### DIFF
--- a/librz/debug/p/native/bsd/bsd_debug.c
+++ b/librz/debug/p/native/bsd/bsd_debug.c
@@ -494,7 +494,10 @@ RzList *bsd_desc_list(int pid) {
 		case KF_TYPE_PIPE: type = 'p'; break;
 		case KF_TYPE_FIFO: type = 'f'; break;
 		case KF_TYPE_KQUEUE: type = 'k'; break;
+#if __FreeBSD_version < 1300130
+		// removed in https://reviews.freebsd.org/D27302
 		case KF_TYPE_CRYPTO: type = 'c'; break;
+#endif
 		case KF_TYPE_MQUEUE: type = 'm'; break;
 		case KF_TYPE_SHM: type = 'h'; break;
 		case KF_TYPE_PTS: type = 't'; break;


### PR DESCRIPTION
**Detailed description**

For reference:
https://reviews.freebsd.org/D27302
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=251470
https://svnweb.freebsd.org/ports/head/devel/radare2/files/patch-libr_debug_p_native_bsd_bsd__debug.c?view=markup&pathrev=568227

**Test plan**

FreeBSD CI succeeds