### PR TITLE
Fix non-Xcode Clang Build on macOS

### DIFF
--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -95,7 +95,7 @@ typedef enum {
 #define __POWERPC__ 1
 #endif
 
-#if __IPHONE_8_0 && TARGET_OS_IPHONE
+#if __IPHONE_8_0 && defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
 #define LIBC_HAVE_SYSTEM 0
 #else
 #define LIBC_HAVE_SYSTEM 1


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Custom built clang on macOS by default (or at least from MacPorts) builds with `-Werror,-Wundef-prefix=TARGET_OS_`:
```
In file included from ../librz/util/base85.c:35:
../librz/include/rz_types.h:98:21: error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGET_OS_]
#if __IPHONE_8_0 && TARGET_OS_IPHONE
                    ^
```