### PR TITLE
New API to get vector of RzIO maps

### DIFF
--- a/librz/bin/p/bin_coff.c
+++ b/librz/bin/p/bin_coff.c
@@ -490,7 +490,8 @@ static RzList *patch_relocs(RzBinFile *bf) {
 	if (nimports) {
 		void **it;
 		ut64 offset = 0;
-		rz_pvector_foreach (&io->maps, it) {
+		RzPVector *maps = rz_io_maps(io);
+		rz_pvector_foreach (maps, it) {
 			RzIOMap *map = *it;
 			if ((map->itv.addr + map->itv.size) > offset) {
 				offset = map->itv.addr + map->itv.size;

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -969,7 +969,8 @@ static RzList *patch_relocs(RzBinFile *bf) {
 	}
 
 	void **it;
-	rz_pvector_foreach (&io->maps, it) {
+	RzPVector *maps = rz_io_maps(io);
+	rz_pvector_foreach (maps, it) {
 		RzIOMap *map = *it;
 		if (map->itv.addr > offset) {
 			offset = map->itv.addr;

--- a/librz/bin/p/bin_mach0.c
+++ b/librz/bin/p/bin_mach0.c
@@ -624,7 +624,8 @@ static RzList *patch_relocs(RzBinFile *bf) {
 
 	ut64 offset = 0;
 	void **vit;
-	rz_pvector_foreach (&io->maps, vit) {
+	RzPVector *maps = rz_io_maps(io);
+	rz_pvector_foreach (maps, vit) {
 		RzIOMap *map = *vit;
 		if (map->itv.addr > offset) {
 			offset = map->itv.addr;

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -302,7 +302,8 @@ RZ_API ut64 rz_core_analysis_address(RzCore *core, ut64 addr) {
 		if (core->io) {
 			// sections
 			void **it;
-			rz_pvector_foreach (&core->io->maps, it) {
+			RzPVector *maps = rz_io_maps(core->io);
+			rz_pvector_foreach (maps, it) {
 				RzIOMap *s = *it;
 				if (addr >= s->itv.addr && addr < (s->itv.addr + s->itv.size)) {
 					// sections overlap, so we want to get the one with lower perms

--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -1566,7 +1566,8 @@ RZ_IPI void rz_core_io_file_open(RzCore *core, int fd) {
 RZ_IPI void rz_core_io_file_reopen(RzCore *core, int fd, int perms) {
 	if (rz_io_reopen(core->io, fd, perms, 644)) {
 		void **it;
-		rz_pvector_foreach_prev(&core->io->maps, it) {
+		RzPVector *maps = rz_io_maps(core->io);
+		rz_pvector_foreach_prev(maps, it) {
 			RzIOMap *map = *it;
 			if (map->fd == fd) {
 				map->perm |= RZ_PERM_WX;

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -7808,7 +7808,8 @@ static int compute_coverage(RzCore *core) {
 	cov += rz_meta_get_size(core->analysis, RZ_META_TYPE_DATA);
 	rz_list_foreach (core->analysis->fcns, iter, fcn) {
 		void **it;
-		rz_pvector_foreach (&core->io->maps, it) {
+		RzPVector *maps = rz_io_maps(core->io);
+		rz_pvector_foreach (maps, it) {
 			RzIOMap *map = *it;
 			if (map->perm & RZ_PERM_X) {
 				ut64 section_end = map->itv.addr + map->itv.size;
@@ -7825,7 +7826,8 @@ static int compute_coverage(RzCore *core) {
 static int compute_code(RzCore *core) {
 	int code = 0;
 	void **it;
-	rz_pvector_foreach (&core->io->maps, it) {
+	RzPVector *maps = rz_io_maps(core->io);
+	rz_pvector_foreach (maps, it) {
 		RzIOMap *map = *it;
 		if (map->perm & RZ_PERM_X) {
 			code += map->itv.size;

--- a/librz/core/cmd_search.c
+++ b/librz/core/cmd_search.c
@@ -634,7 +634,8 @@ RZ_API RzList *rz_core_get_boundaries_prot(RzCore *core, int perm, const char *m
 			int rwx = m ? m->perm : part->map->perm;
 #else
 		void **it;
-		rz_pvector_foreach (&core->io->maps, it) {
+		RzPVector *maps = rz_io_maps(core->io);
+		rz_pvector_foreach (maps, it) {
 			RzIOMap *map = *it;
 			ut64 from = rz_itv_begin(map->itv);
 			ut64 to = rz_itv_end(map->itv);
@@ -666,7 +667,8 @@ RZ_API RzList *rz_core_get_boundaries_prot(RzCore *core, int perm, const char *m
 		// bool only = (bool)(size_t)strstr (mode, ".only");
 
 		void **it;
-		rz_pvector_foreach (&core->io->maps, it) {
+		RzPVector *maps = rz_io_maps(core->io);
+		rz_pvector_foreach (maps, it) {
 			RzIOMap *map = *it;
 			ut64 from = rz_itv_begin(map->itv);
 			//ut64 to = rz_itv_end (map->itv);
@@ -754,7 +756,8 @@ RZ_API RzList *rz_core_get_boundaries_prot(RzCore *core, int perm, const char *m
 			if (from == UT64_MAX) {
 				int mask = 1;
 				void **it;
-				rz_pvector_foreach (&core->io->maps, it) {
+				RzPVector *maps = rz_io_maps(core->io);
+				rz_pvector_foreach (maps, it) {
 					RzIOMap *map = *it;
 					ut64 from = rz_itv_begin(map->itv);
 					ut64 size = rz_itv_size(map->itv);

--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -227,7 +227,8 @@ static void GH(get_brks)(RzCore *core, GHT *brk_start, GHT *brk_end) {
 		}
 	} else {
 		void **it;
-		rz_pvector_foreach (&core->io->maps, it) {
+		RzPVector *maps = rz_io_maps(core->io);
+		rz_pvector_foreach (maps, it) {
 			RzIOMap *map = *it;
 			if (map->name) {
 				if (strstr(map->name, "[heap]")) {
@@ -423,7 +424,8 @@ static bool GH(rz_resolve_main_arena)(RzCore *core, GHT *m_arena) {
 		}
 	} else {
 		void **it;
-		rz_pvector_foreach (&core->io->maps, it) {
+		RzPVector *maps = rz_io_maps(core->io);
+		rz_pvector_foreach (maps, it) {
 			RzIOMap *map = *it;
 			if (map->name && strstr(map->name, "arena")) {
 				libc_addr_sta = map->itv.addr;

--- a/librz/core/visual.c
+++ b/librz/core/visual.c
@@ -261,8 +261,9 @@ static bool __core_visual_gogo(RzCore *core, int ch) {
 	case 'g':
 		if (core->io->va) {
 			RzIOMap *map = rz_io_map_get(core->io, core->offset);
-			if (!map && !rz_pvector_empty(&core->io->maps)) {
-				map = rz_pvector_at(&core->io->maps, rz_pvector_len(&core->io->maps) - 1);
+			RzPVector *maps = rz_io_maps(core->io);
+			if (!map && !rz_pvector_empty(maps)) {
+				map = rz_pvector_at(maps, rz_pvector_len(maps) - 1);
 			}
 			if (map) {
 				rz_core_seek_and_save(core, rz_itv_begin(map->itv), true);
@@ -271,10 +272,11 @@ static bool __core_visual_gogo(RzCore *core, int ch) {
 			rz_core_seek_and_save(core, 0, true);
 		}
 		return true;
-	case 'G':
+	case 'G': {
 		map = rz_io_map_get(core->io, core->offset);
-		if (!map && !rz_pvector_empty(&core->io->maps)) {
-			map = rz_pvector_at(&core->io->maps, 0);
+		RzPVector *maps = rz_io_maps(core->io);
+		if (!map && !rz_pvector_empty(maps)) {
+			map = rz_pvector_at(maps, 0);
 		}
 		if (map) {
 			RzPrint *p = core->print;
@@ -287,6 +289,7 @@ static bool __core_visual_gogo(RzCore *core, int ch) {
 			rz_core_seek_and_save(core, rz_itv_end(map->itv) - (scr_rows - 2) * scols, true);
 		}
 		return true;
+	}
 	}
 	return false;
 }
@@ -3242,13 +3245,14 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 						if (s) {
 							entry = s->vaddr;
 						} else {
-							RzIOMap *map = rz_pvector_pop(&core->io->maps);
+							RzPVector *maps = rz_io_maps(core->io);
+							RzIOMap *map = rz_pvector_pop(maps);
 							if (map) {
 								entry = map->itv.addr;
 							} else {
 								entry = rz_config_get_i(core->config, "bin.baddr");
 							}
-							rz_pvector_push_front(&core->io->maps, map);
+							rz_pvector_push_front(maps, map);
 						}
 					}
 					if (entry != UT64_MAX) {

--- a/librz/include/rz_io.h
+++ b/librz/include/rz_io.h
@@ -272,6 +272,7 @@ RZ_API void rz_io_map_set_name(RzIOMap *map, const char *name);
 RZ_API void rz_io_map_del_name(RzIOMap *map);
 RZ_API RzList *rz_io_map_get_for_fd(RzIO *io, int fd);
 RZ_API bool rz_io_map_resize(RzIO *io, ut32 id, ut64 newsize);
+RZ_API RZ_BORROW RzPVector *rz_io_maps(RzIO *io);
 
 // next free address to place a map.. maybe just unify
 RZ_API ut64 rz_io_map_next_available(RzIO *io, ut64 addr, ut64 size, ut64 load_align);

--- a/librz/io/io_map.c
+++ b/librz/io/io_map.c
@@ -417,3 +417,13 @@ RZ_API ut64 rz_io_map_location(RzIO *io, ut64 size) {
 	}
 	return base;
 }
+
+/**
+ * \brief Returns the pointer to vector containing maps list
+ *
+ * \param io RzIO instance
+ */
+RZ_API RZ_BORROW RzPVector *rz_io_maps(RzIO *io) {
+	rz_return_val_if_fail(io, NULL);
+	return &io->maps;
+}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Since accessing `core->io->maps` directly is a bad practice, I introduce a new super-simple wrapper API to get the vector:

```c
RZ_API RZ_BORROW RzPVector *rz_io_maps(RzIO *io);
```

I follow the same logic as in https://github.com/rizinorg/rizin/pull/984

**Test plan**

CI is green
