### PR TITLE
Remove appending Section Index to Name in COFF Plugin

### DIFF
--- a/librz/bin/p/bin_coff.c
+++ b/librz/bin/p/bin_coff.c
@@ -167,53 +167,41 @@ static RzList *entries(RzBinFile *bf) {
 }
 
 static RzList *sections(RzBinFile *bf) {
-	char *tmp = NULL;
-	size_t i;
-	RzBinSection *ptr = NULL;
 	struct rz_bin_coff_obj *obj = (struct rz_bin_coff_obj *)bf->o->bin_obj;
-
 	RzList *ret = rz_list_newf((RzListFree)rz_bin_section_free);
 	if (!ret) {
 		return NULL;
 	}
-	if (obj && obj->scn_hdrs) {
-		for (i = 0; i < obj->hdr.f_nscns; i++) {
-			tmp = rz_coff_symbol_name(obj, &obj->scn_hdrs[i]);
-			if (!tmp) {
-				rz_list_free(ret);
-				return NULL;
-			}
-			//IO does not like sections with the same name append idx
-			//since it will update it
-			ptr = RZ_NEW0(RzBinSection);
-			if (!ptr) {
-				free(tmp);
-				return ret;
-			}
-			ptr->name = rz_str_newf("%s-%zu", tmp, i);
-			free(tmp);
-			if (strstr(ptr->name, "data")) {
-				ptr->is_data = true;
-			}
-			ptr->size = obj->scn_hdrs[i].s_size;
-			ptr->vsize = obj->scn_hdrs[i].s_size;
-			ptr->paddr = obj->scn_hdrs[i].s_scnptr;
-			if (obj->scn_va) {
-				ptr->vaddr = obj->scn_va[i];
-			}
-			ptr->add = true;
-			ptr->perm = 0;
-			if (obj->scn_hdrs[i].s_flags & COFF_SCN_MEM_READ) {
-				ptr->perm |= RZ_PERM_R;
-			}
-			if (obj->scn_hdrs[i].s_flags & COFF_SCN_MEM_WRITE) {
-				ptr->perm |= RZ_PERM_W;
-			}
-			if (obj->scn_hdrs[i].s_flags & COFF_SCN_MEM_EXECUTE) {
-				ptr->perm |= RZ_PERM_X;
-			}
-			rz_list_append(ret, ptr);
+	if (!obj || !obj->scn_hdrs) {
+		return ret;
+	}
+	for (size_t i = 0; i < obj->hdr.f_nscns; i++) {
+		RzBinSection *ptr = RZ_NEW0(RzBinSection);
+		if (!ptr) {
+			return ret;
 		}
+		ptr->name = rz_coff_symbol_name(obj, &obj->scn_hdrs[i]);
+		if (ptr->name && strstr(ptr->name, "data")) {
+			ptr->is_data = true;
+		}
+		ptr->size = obj->scn_hdrs[i].s_size;
+		ptr->vsize = obj->scn_hdrs[i].s_size;
+		ptr->paddr = obj->scn_hdrs[i].s_scnptr;
+		if (obj->scn_va) {
+			ptr->vaddr = obj->scn_va[i];
+		}
+		ptr->add = true;
+		ptr->perm = 0;
+		if (obj->scn_hdrs[i].s_flags & COFF_SCN_MEM_READ) {
+			ptr->perm |= RZ_PERM_R;
+		}
+		if (obj->scn_hdrs[i].s_flags & COFF_SCN_MEM_WRITE) {
+			ptr->perm |= RZ_PERM_W;
+		}
+		if (obj->scn_hdrs[i].s_flags & COFF_SCN_MEM_EXECUTE) {
+			ptr->perm |= RZ_PERM_X;
+		}
+		rz_list_append(ret, ptr);
 	}
 	return ret;
 }

--- a/test/db/formats/coff
+++ b/test/db/formats/coff
@@ -39,17 +39,17 @@ nth vaddr      bind type lib name
 
 nth paddr         size vaddr        vsize perm name
 ---------------------------------------------------
-0   0x000001cc    0x2f 0x00000000    0x2f ---- .drectve-0
-1   0x000001fb  0x8670 0x00000030  0x8670 -r-- .debug_S-1
-2   0x0000ad73    0x70 0x000086a0    0x70 -r-- .debug_T-2
-3   0x0000ade3   0x625 0x00008710   0x625 -rw- .data-3
-4   0x0000b408    0x54 0x00008d40    0x54 -r-- .rdata-4
-5   0x00000000     0x8 0x00008da0     0x8 -rw- .bss-5
-6   0x0000b45c  0x2895 0x00008db0  0x2895 -r-x .text_mn-6
-7   0x0000e967     0x8 0x0000b650     0x8 -r-- .rdata-7
-8   0x0000e96f     0x4 0x0000b660     0x4 -r-- .rdata-8
-9   0x0000e973     0x8 0x0000b670     0x8 -r-- .rdata-9
-10  0x0000e97b     0x4 0x0000b680     0x4 -r-- .rdata-10
+0   0x000001cc    0x2f 0x00000000    0x2f ---- .drectve
+1   0x000001fb  0x8670 0x00000030  0x8670 -r-- .debug_S
+2   0x0000ad73    0x70 0x000086a0    0x70 -r-- .debug_T
+3   0x0000ade3   0x625 0x00008710   0x625 -rw- .data
+4   0x0000b408    0x54 0x00008d40    0x54 -r-- .rdata
+5   0x00000000     0x8 0x00008da0     0x8 -rw- .bss
+6   0x0000b45c  0x2895 0x00008db0  0x2895 -r-x .text_mn
+7   0x0000e967     0x8 0x0000b650     0x8 -r-- .rdata_1
+8   0x0000e96f     0x4 0x0000b660     0x4 -r-- .rdata_2
+9   0x0000e973     0x8 0x0000b670     0x8 -r-- .rdata_3
+10  0x0000e97b     0x4 0x0000b680     0x4 -r-- .rdata_4
 
 EOF
 RUN
@@ -58,8 +58,8 @@ NAME=tiny coff
 FILE=bins/coff/coff.obj
 CMDS=om;is;ir
 EXPECT=<<EOF
- 2 fd: 3 +0x00000064 0x00000000 - 0x00000026 r-x fmap..text-0
- 1 fd: 3 +0x0000008b 0x00000030 - 0x0000004b r-- fmap..data-1
+ 2 fd: 3 +0x00000064 0x00000000 - 0x00000026 r-x fmap..text
+ 1 fd: 3 +0x0000008b 0x00000030 - 0x0000004b r-- fmap..data
 [Symbols]
 
 nth paddr      vaddr      bind   type size lib name
@@ -88,26 +88,60 @@ FILE=bins/coff/coff2.obj
 CMDS=<<EOF
 e asm.bytes=true
 om
-is~text
+iS
+is
 s sym.__1FooBar__QAE_XZ
 pd 2
 EOF
 EXPECT=<<EOF
- 9 fd: 3 +0x0000017c 0x00000000 - 0x000000ee --- fmap..drectve-0
- 8 fd: 3 +0x0000026b 0x000000f0 - 0x00000b9f r-- fmap..debug_S-1
- 7 fd: 3 +0x00000d1b 0x00000ba0 - 0x00000c13 r-- fmap..debug_T-2
- 6 fd: 3 +0x00000d8f 0x00000c20 - 0x00000c4c r-x fmap..text_mn-3
- 5 fd: 3 +0x00000dbc 0x00000c50 - 0x00000d23 r-- fmap..debug_S-4
- 4 fd: 3 +0x00000ec2 0x00000d30 - 0x00000d59 r-x fmap..text_mn-5
- 3 fd: 3 +0x00000eec 0x00000d60 - 0x00000e33 r-- fmap..debug_S-6
- 2 fd: 3 +0x00000ff2 0x00000e40 - 0x00000e43 r-- fmap..rtc_IMZ-7
- 1 fd: 3 +0x00001000 0x00000e50 - 0x00000e53 r-- fmap..rtc_TMZ-8
+ 9 fd: 3 +0x0000017c 0x00000000 - 0x000000ee --- fmap..drectve
+ 8 fd: 3 +0x0000026b 0x000000f0 - 0x00000b9f r-- fmap..debug_S
+ 7 fd: 3 +0x00000d1b 0x00000ba0 - 0x00000c13 r-- fmap..debug_T
+ 6 fd: 3 +0x00000d8f 0x00000c20 - 0x00000c4c r-x fmap..text_mn
+ 5 fd: 3 +0x00000dbc 0x00000c50 - 0x00000d23 r-- fmap..debug_S_1
+ 4 fd: 3 +0x00000ec2 0x00000d30 - 0x00000d59 r-x fmap..text_mn_1
+ 3 fd: 3 +0x00000eec 0x00000d60 - 0x00000e33 r-- fmap..debug_S_2
+ 2 fd: 3 +0x00000ff2 0x00000e40 - 0x00000e43 r-- fmap..rtc_IMZ
+ 1 fd: 3 +0x00001000 0x00000e50 - 0x00000e53 r-- fmap..rtc_TMZ
+[Sections]
+
+nth paddr        size vaddr       vsize perm name
+-------------------------------------------------
+0   0x0000017c   0xef 0x00000000   0xef ---- .drectve
+1   0x0000026b  0xab0 0x000000f0  0xab0 -r-- .debug_S
+2   0x00000d1b   0x74 0x00000ba0   0x74 -r-- .debug_T
+3   0x00000d8f   0x2d 0x00000c20   0x2d -r-x .text_mn
+4   0x00000dbc   0xd4 0x00000c50   0xd4 -r-- .debug_S_1
+5   0x00000ec2   0x2a 0x00000d30   0x2a -r-x .text_mn_1
+6   0x00000eec   0xd4 0x00000d60   0xd4 -r-- .debug_S_2
+7   0x00000ff2    0x4 0x00000e40    0x4 -r-- .rtc_IMZ
+8   0x00001000    0x4 0x00000e50    0x4 -r-- .rtc_TMZ
+
+[Symbols]
+
+nth paddr      vaddr      bind   type size lib name
+---------------------------------------------------
+0   ---------- ---------- LOCAL  ABS  4        @comp.id-0x01055e97
+0   ---------- ---------- LOCAL  ABS  4        @feat.00-0x80000191
+0   0x0000017c 0x00000000 LOCAL  SECT 4        .drectve
+0   0x0000026b 0x000000f0 LOCAL  SECT 4        .debug$S
+0   0x00000d1b 0x00000ba0 LOCAL  SECT 4        .debug$T
 0   0x00000d8f 0x00000c20 LOCAL  SECT 4        .text$mn
+0   0x00000dbc 0x00000c50 LOCAL  SECT 4        .debug$S
 0   0x00000ec2 0x00000d30 LOCAL  SECT 4        .text$mn
-            ;-- section..text_mn_5:
+0   0x00000eec 0x00000d60 LOCAL  SECT 4        .debug$S
+0   0x00000d8f 0x00000c20 GLOBAL FUNC 4        ??0FooBar@@QAE@XZ
+0   0x00000ec2 0x00000d30 GLOBAL FUNC 4        ??1FooBar@@QAE@XZ
+0   ---------- ---------- NONE   FUNC 4        imp.__RTC_InitBase
+0   ---------- ---------- NONE   FUNC 4        imp.__RTC_Shutdown
+0   0x00000ff2 0x00000e40 LOCAL  SECT 4        .rtc$IMZ
+0   0x00000ff2 0x00000e40 LOCAL  UNK  4        __RTC_InitBase.rtc$IMZ
+0   0x00001000 0x00000e50 LOCAL  SECT 4        .rtc$TMZ
+0   0x00001000 0x00000e50 LOCAL  UNK  4        __RTC_Shutdown.rtc$TMZ
+            ;-- section..text_mn_1:
             ;-- .text$mn:
             ;-- ??1FooBar@@QAE@XZ:
-            0x00000d30      55             push  ebp                   ; [05] -r-x section size 42 named .text_mn-5
+            0x00000d30      55             push  ebp                   ; [05] -r-x section size 42 named .text_mn_1
             0x00000d31      8bec           mov   ebp, esp
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Since 32a53fc86f98e07ade5115cd74aa280853136308, section names in coff got their index appended like this, on the plugin side:
```
[0x00000c20]> iS
[Sections]

nth paddr        size vaddr       vsize perm name
―――――――――――――――――――――――――――――――――――――――――――――――――
0   0x0000017c   0xef 0x00000000   0xef ---- .drectve-0
1   0x0000026b  0xab0 0x000000f0  0xab0 -r-- .debug_S-1
2   0x00000d1b   0x74 0x00000ba0   0x74 -r-- .debug_T-2
3   0x00000d8f   0x2d 0x00000c20   0x2d -r-x .text_mn-3
4   0x00000dbc   0xd4 0x00000c50   0xd4 -r-- .debug_S-4
5   0x00000ec2   0x2a 0x00000d30   0x2a -r-x .text_mn-5
6   0x00000eec   0xd4 0x00000d60   0xd4 -r-- .debug_S-6
7   0x00000ff2    0x4 0x00000e40    0x4 -r-- .rtc_IMZ-7
8   0x00001000    0x4 0x00000e50    0x4 -r-- .rtc_TMZ-8

[0x00000c20]> om
 9 fd: 3 +0x0000017c 0x00000000 - 0x000000ee --- fmap..drectve-0
 8 fd: 3 +0x0000026b 0x000000f0 - 0x00000b9f r-- fmap..debug_S-1
 7 fd: 3 +0x00000d1b 0x00000ba0 - 0x00000c13 r-- fmap..debug_T-2
 6 fd: 3 +0x00000d8f 0x00000c20 - 0x00000c4c r-x fmap..text_mn-3
 5 fd: 3 +0x00000dbc 0x00000c50 - 0x00000d23 r-- fmap..debug_S-4
 4 fd: 3 +0x00000ec2 0x00000d30 - 0x00000d59 r-x fmap..text_mn-5
 3 fd: 3 +0x00000eec 0x00000d60 - 0x00000e33 r-- fmap..debug_S-6
 2 fd: 3 +0x00000ff2 0x00000e40 - 0x00000e43 r-- fmap..rtc_IMZ-7
 1 fd: 3 +0x00001000 0x00000e50 - 0x00000e53 r-- fmap..rtc_TMZ-8
```

This doesn't really have anything to do with what the commit fixed back then. In fact, duplicated names from a plugin get automatically suffixed, which results in this after removing it:

```
[0x00000c20]> iS
[Sections]

nth paddr        size vaddr       vsize perm name
―――――――――――――――――――――――――――――――――――――――――――――――――
0   0x0000017c   0xef 0x00000000   0xef ---- .drectve
1   0x0000026b  0xab0 0x000000f0  0xab0 -r-- .debug_S
2   0x00000d1b   0x74 0x00000ba0   0x74 -r-- .debug_T
3   0x00000d8f   0x2d 0x00000c20   0x2d -r-x .text_mn
4   0x00000dbc   0xd4 0x00000c50   0xd4 -r-- .debug_S_1
5   0x00000ec2   0x2a 0x00000d30   0x2a -r-x .text_mn_1
6   0x00000eec   0xd4 0x00000d60   0xd4 -r-- .debug_S_2
7   0x00000ff2    0x4 0x00000e40    0x4 -r-- .rtc_IMZ
8   0x00001000    0x4 0x00000e50    0x4 -r-- .rtc_TMZ

[0x00000c20]> om
 9 fd: 3 +0x0000017c 0x00000000 - 0x000000ee --- fmap..drectve
 8 fd: 3 +0x0000026b 0x000000f0 - 0x00000b9f r-- fmap..debug_S
 7 fd: 3 +0x00000d1b 0x00000ba0 - 0x00000c13 r-- fmap..debug_T
 6 fd: 3 +0x00000d8f 0x00000c20 - 0x00000c4c r-x fmap..text_mn
 5 fd: 3 +0x00000dbc 0x00000c50 - 0x00000d23 r-- fmap..debug_S_1
 4 fd: 3 +0x00000ec2 0x00000d30 - 0x00000d59 r-x fmap..text_mn_1
 3 fd: 3 +0x00000eec 0x00000d60 - 0x00000e33 r-- fmap..debug_S_2
 2 fd: 3 +0x00000ff2 0x00000e40 - 0x00000e43 r-- fmap..rtc_IMZ
 1 fd: 3 +0x00001000 0x00000e50 - 0x00000e53 r-- fmap..rtc_TMZ
```

**Test plan**

I've extended the relevant test a bit to make sure the fixes done by the mentioned commit still work. The `bins/coff/coff2.obj` is the exact same file as in the issue linked by the commit.
