### PR TITLE
Honor value_add when estimating dyldcache slide ##bin

### DIFF
--- a/librz/bin/p/bin_dyldcache.c
+++ b/librz/bin/p/bin_dyldcache.c
@@ -442,7 +442,7 @@ static ut32 dumb_ctzll(ut64 x) {
 	return result;
 }
 
-static ut64 estimate_slide(RzBinFile *bf, RDyldCache *cache, ut64 value_mask) {
+static ut64 estimate_slide(RzBinFile *bf, RDyldCache *cache, ut64 value_mask, ut64 value_add) {
 	ut64 slide = 0;
 	ut64 *classlist = malloc(64);
 	if (!classlist) {
@@ -504,10 +504,11 @@ static ut64 estimate_slide(RzBinFile *bf, RDyldCache *cache, ut64 value_mask) {
 		ut64 data_tail = data_addr & 0xfff;
 		ut64 data_tail_end = (data_addr + sections[data_idx].size) & 0xfff;
 		for (i = 0; i < n_classes; i++) {
-			ut64 cl_tail = classlist[i] & 0xfff;
+			ut64 cl_addr = (classlist[i] & value_mask) + value_add;
+			ut64 cl_tail = cl_addr & 0xfff;
 			if (cl_tail >= data_tail && cl_tail < data_tail_end) {
 				ut64 off = cl_tail - data_tail;
-				slide = ((classlist[i] - off) & value_mask) - (data_addr & value_mask);
+				slide = ((cl_addr - off) & value_mask) - (data_addr & value_mask);
 				found_sample = true;
 				break;
 			}
@@ -586,7 +587,7 @@ static RDyldRebaseInfo *get_rebase_info(RzBinFile *bf, RDyldCache *cache, ut64 s
 		rebase_info->page_size = slide_info.page_size;
 		rebase_info->one_page_buf = one_page_buf;
 		if (slide == UT64_MAX) {
-			rebase_info->slide = estimate_slide(bf, cache, 0x7ffffffffffffULL);
+			rebase_info->slide = estimate_slide(bf, cache, 0x7ffffffffffffULL, 0);
 			if (rebase_info->slide) {
 				eprintf("dyldcache is slid: 0x%" PFMT64x "\n", rebase_info->slide);
 			}
@@ -663,7 +664,7 @@ static RDyldRebaseInfo *get_rebase_info(RzBinFile *bf, RDyldCache *cache, ut64 s
 		rebase_info->page_size = slide_info.page_size;
 		rebase_info->one_page_buf = one_page_buf;
 		if (slide == UT64_MAX) {
-			rebase_info->slide = estimate_slide(bf, cache, rebase_info->value_mask);
+			rebase_info->slide = estimate_slide(bf, cache, rebase_info->value_mask, rebase_info->value_add);
 			if (rebase_info->slide) {
 				eprintf("dyldcache is slid: 0x%" PFMT64x "\n", rebase_info->slide);
 			}
@@ -734,7 +735,7 @@ static RDyldRebaseInfo *get_rebase_info(RzBinFile *bf, RDyldCache *cache, ut64 s
 		rebase_info->entries = tmp_buf_2;
 		rebase_info->entries_size = slide_info.entries_size;
 		if (slide == UT64_MAX) {
-			rebase_info->slide = estimate_slide(bf, cache, UT64_MAX);
+			rebase_info->slide = estimate_slide(bf, cache, UT64_MAX, 0);
 			if (rebase_info->slide) {
 				eprintf("dyldcache is slid: 0x%" PFMT64x "\n", rebase_info->slide);
 			}
@@ -1974,6 +1975,7 @@ static void header(RzBinFile *bf) {
 					pj_kn(pj, "page_extras_count", info2->page_extras_count);
 					pj_kn(pj, "delta_mask", info2->delta_mask);
 					pj_kn(pj, "value_mask", info2->value_mask);
+					pj_kn(pj, "value_add", info2->value_add);
 					pj_kn(pj, "delta_shift", info2->delta_shift);
 					pj_kn(pj, "page_size", info2->page_size);
 				} else if (version == 1) {

--- a/librz/bin/p/bin_dyldcache.c
+++ b/librz/bin/p/bin_dyldcache.c
@@ -2028,7 +2028,7 @@ static void header(RzBinFile *bf) {
 	}
 
 	pj_end(pj);
-	p("%s", pj_string(pj));
+	p("%s\n", pj_string(pj));
 
 beach:
 	pj_free(pj);

--- a/test/db/formats/dyldcache
+++ b/test/db/formats/dyldcache
@@ -4,6 +4,7 @@ CMDS=<<EOF
 i
 is
 iS
+iH
 om
 pi 4@sym._what_is_cool
 EOF
@@ -60,6 +61,7 @@ nth paddr       size vaddr        vsize perm name
 3   0x00008fa0  0x18 0x180008fa0   0x18 -r-x lib_libb-1.0.dylib.0.__TEXT.__text
 4   0x00008fb8  0x48 0x180008fb8   0x48 -r-x lib_libb-1.0.dylib.1.__TEXT.__unwind_info
 
+{"header":{"magic":"dyld_v1   arm64","mappingOffset":320,"mappingCount":3,"imagesOffset":656,"imagesCount":2,"dyldBaseAddress":0,"codeSignatureOffset":196608,"codeSignatureSize":16384,"slideInfoOffset":0,"slideInfoSize":0,"localSymbolsOffset":0,"localSymbolsSize":0,"uuid":"857bce1a017e34649909d58ee21cf8dc","cacheType":"production","branchPoolsOffset":0,"branchPoolsCount":0,"accelerateInfoAddr":0,"accelerateInfoSize":0,"imagesTextOffset":720,"imagesTextCount":2},"slideInfo":[{"start":98304,"end":114688,"version":2,"slide":0,"page_starts_count":4,"page_extras_count":0,"delta_mask":72056494526300160,"value_mask":18374687579183251455,"value_add":0,"delta_shift":38,"page_size":4096}],"images":[{"uuid":"ccbf29d455693a1592314e14d41a542a","address":6442455040,"textSegmentSize":16384,"path":"/usr/lib/liba-1.0.dylib","name":"liba-1.0.dylib"},{"uuid":"60d2f3d644a2391087503a56a3d8ff07","address":6442471424,"textSegmentSize":16384,"path":"/usr/lib/libb-1.0.dylib","name":"libb-1.0.dylib"}]}
  3 fd: 3 +0x00000000 0x180000000 - 0x180017fff r-x fmap.cache_map.0
  2 fd: 3 +0x00018000 0x182018000 - 0x18201bfff r-- fmap.cache_map.1
  1 fd: 3 +0x0001c000 0x18401c000 - 0x18402ffff r-- fmap.cache_map.2
@@ -78,6 +80,7 @@ o bins/dyldcache/dyld_shared_cache_arm64-macOS
 i
 is
 iS
+iH
 om
 pi 4@sym._what_is_cool
 EOF
@@ -131,6 +134,7 @@ nth paddr       size vaddr        vsize perm name
 1   0x00004fa8   0x6 0x180004fa8    0x6 -r-x lib_liba-1.0.dylib.1.__TEXT.__cstring
 2   0x00004fb0  0x50 0x180004fb0   0x50 -r-x lib_liba-1.0.dylib.2.__TEXT.__unwind_info
 
+{"header":{"magic":"dyld_v1   arm64","mappingOffset":320,"mappingCount":3,"imagesOffset":656,"imagesCount":2,"dyldBaseAddress":0,"codeSignatureOffset":196608,"codeSignatureSize":16384,"slideInfoOffset":0,"slideInfoSize":0,"localSymbolsOffset":0,"localSymbolsSize":0,"uuid":"857bce1a017e34649909d58ee21cf8dc","cacheType":"production","branchPoolsOffset":0,"branchPoolsCount":0,"accelerateInfoAddr":0,"accelerateInfoSize":0,"imagesTextOffset":720,"imagesTextCount":2},"slideInfo":[{"start":98304,"end":114688,"version":2,"slide":0,"page_starts_count":4,"page_extras_count":0,"delta_mask":72056494526300160,"value_mask":18374687579183251455,"value_add":0,"delta_shift":38,"page_size":4096}],"images":[{"uuid":"ccbf29d455693a1592314e14d41a542a","address":6442455040,"textSegmentSize":16384,"path":"/usr/lib/liba-1.0.dylib","name":"liba-1.0.dylib"},{"uuid":"60d2f3d644a2391087503a56a3d8ff07","address":6442471424,"textSegmentSize":16384,"path":"/usr/lib/libb-1.0.dylib","name":"libb-1.0.dylib"}]}
  3 fd: 3 +0x00000000 0x180000000 - 0x180017fff r-x fmap.cache_map.0
  2 fd: 3 +0x00018000 0x182018000 - 0x18201bfff r-- fmap.cache_map.1
  1 fd: 3 +0x0001c000 0x18401c000 - 0x18402ffff r-- fmap.cache_map.2


### PR DESCRIPTION
macOS caches have `value_add` set to a non-zero value, and
`estimate_slide` wasn't taking it into account resultin in a wrong side
estimation.