### PR TITLE
Fix #1032 - Wrong use of wcstombs

### DIFF
--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -3510,17 +3510,16 @@ err_r_str_mb_to_wc:
 
 RZ_API char *rz_str_wc_to_mb_l(const wchar_t *buf, int len) {
 	char *res_buf = NULL;
-	bool fail = true;
 	size_t sz;
 
 	if (!buf || len <= 0) {
 		return NULL;
 	}
-	sz = wcstombs(NULL, buf, len);
+	sz = wcstombs(NULL, buf, 0);
 	if (sz == (size_t)-1) {
 		goto err_r_str_wc_to_mb;
 	}
-	res_buf = (char *)calloc(1, (sz + 1) * sizeof(char));
+	res_buf = RZ_NEWS0(char, sz + 1);
 	if (!res_buf) {
 		goto err_r_str_wc_to_mb;
 	}
@@ -3528,12 +3527,11 @@ RZ_API char *rz_str_wc_to_mb_l(const wchar_t *buf, int len) {
 	if (sz == (size_t)-1) {
 		goto err_r_str_wc_to_mb;
 	}
-	fail = false;
-err_r_str_wc_to_mb:
-	if (fail) {
-		RZ_FREE(res_buf);
-	}
 	return res_buf;
+
+err_r_str_wc_to_mb:
+	free(res_buf);
+	return NULL;
 }
 
 RZ_API char *rz_str_wc_to_mb(const wchar_t *buf) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Tries to fix:
```
../librz/util/str.c: In function ‘rz_str_wc_to_mb_l’:
../librz/util/str.c:3519:7: warning: argument 1 is null but the corresponding size argument 3 range is [1, 2147483647] [-Wnonnull]
 3519 |  sz = wcstombs(NULL, buf, len);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../librz/include/rz_types.h:250,
                 from ../librz/util/str.c:4:
/usr/include/stdlib.h:937:15: note: in a call to function ‘wcstombs’ declared with attribute ‘write_only (1, 3)’
  937 | extern size_t wcstombs (char *__restrict __s,
      |               ^~~~~~~~

```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
