### PR TITLE
Fix a typo in `afv` commands

### DIFF
--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -1288,7 +1288,7 @@ static int var_cmd(RzCore *core, const char *str) {
 				break;
 			}
 			int rw = (str[1] == 'g') ? RZ_ANALYSIS_VAR_ACCESS_TYPE_READ : RZ_ANALYSIS_VAR_ACCESS_TYPE_WRITE;
-			int ptr = *var->type == 's' ? idx - fcn->maxstack : idx;
+			int ptr = *var->kind == 's' ? idx - fcn->maxstack : idx;
 			RzAnalysisOp *op = rz_core_analysis_op(core, addr, 0);
 			const char *ireg = op ? op->ireg : NULL;
 			rz_analysis_var_set_access(var, ireg, addr, rw, ptr);

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -1288,7 +1288,7 @@ static int var_cmd(RzCore *core, const char *str) {
 				break;
 			}
 			int rw = (str[1] == 'g') ? RZ_ANALYSIS_VAR_ACCESS_TYPE_READ : RZ_ANALYSIS_VAR_ACCESS_TYPE_WRITE;
-			int ptr = *var->kind == 's' ? idx - fcn->maxstack : idx;
+			int ptr = var->kind == 's' ? idx - fcn->maxstack : idx;
 			RzAnalysisOp *op = rz_core_analysis_op(core, addr, 0);
 			const char *ireg = op ? op->ireg : NULL;
 			rz_analysis_var_set_access(var, ireg, addr, rw, ptr);


### PR DESCRIPTION
# SQUASH ME

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`var->type` is the full C type of the variable, here it should check for the `var->kind` where `s` means "stack, SP-based" (see `RzAnalysisVarKind`.

**Test plan**

CI is green
