### PR TITLE
Fix symbols collision due to visibility not being used on subprojects

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -148,7 +148,7 @@ endif
 
 if get_option('default_library') == 'shared'
   if cc.has_argument('-fvisibility=hidden')
-    add_project_arguments('-fvisibility=hidden', language: 'c')
+    add_global_arguments('-fvisibility=hidden', language: 'c')
   endif
 endif
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Various zlib (and possibly others) symbols were wrongly made global, thus exported in rz_util and other libs. In particular, I found out that `inflate` and others were used as soon as rz_util was loaded by `ld`. This ofc caused problems all around, resulting in a crash in libmagic (though that was probably just a coincidence).

This PR should fix the problem by making sure `-fvisibility=hidden` is used everywhere, even in subprojects.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Check `inflate` symbols in `rz_util.so`.
```
$ nm ~/.local/lib64/librz_util.so | grep infl
0000000000099100 t inflate
000000000009b710 t inflateCodesUsed
000000000009b320 t inflateCopy
00000000000bd320 r inflate_copyright
000000000009ae10 t inflateEnd
000000000009c810 t inflate_fast
000000000009ae70 t inflateGetDictionary
000000000009afd0 t inflateGetHeader
0000000000099050 t inflateInit_
0000000000098f60 t inflateInit2_
000000000009b680 t inflateMark
0000000000099060 t inflatePrime
0000000000098e40 t inflateReset
0000000000098ea0 t inflateReset2
0000000000098d50 t inflateResetKeep
000000000009af20 t inflateSetDictionary
0000000000098d00 t inflateStateCheck
000000000009b040 t inflateSync
000000000009b2c0 t inflateSyncPoint
000000000009b780 t inflate_table
000000000009b5b0 t inflateUndermine
000000000009b610 t inflateValidate
000000000007b550 T rz_inflate
```

This should be the correct output, with `t` (which means those symbols are local, not global). Before this PR, those symbols were `T`, that is globals.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes https://github.com/rizinorg/rizin/issues/1017

To be honest, the magic files might still be incompatible, but at least they do not make rizin segfault!