### PR TITLE
Fix some MSVC Warnings

### DIFF
--- a/librz/bin/dbginfo.c
+++ b/librz/bin/dbginfo.c
@@ -200,7 +200,7 @@ RZ_API const RzBinSourceLineSample *rz_bin_source_line_info_get_next(const RzBin
 RZ_API bool rz_bin_addr2line(RzBin *bin, ut64 addr, char *file, int len, int *line) {
 	rz_return_val_if_fail(bin, false);
 	if (!bin->cur || !bin->cur->o || !bin->cur->o->lines) {
-		return NULL;
+		return false;
 	}
 	const RzBinSourceLineSample *s = rz_bin_source_line_info_get_first_at(bin->cur->o->lines, addr);
 	if (!s || s->address != addr) {

--- a/librz/bin/format/elf/elf.c
+++ b/librz/bin/format/elf/elf.c
@@ -63,7 +63,7 @@
 #define COMPUTE_PLTGOT_POSITION(rel, pltgot_addr, n_initial_unused_entries) \
 	((rel->rva - pltgot_addr - n_initial_unused_entries * RZ_BIN_ELF_WORDSIZE) / RZ_BIN_ELF_WORDSIZE)
 
-#define GROWTH_FACTOR (1.5)
+#define GROWTH_FACTOR 2
 
 #define round_up(a) ((((a) + (4) - (1)) / (4)) * (4))
 

--- a/librz/bin/format/java/class_attribute.c
+++ b/librz/bin/format/java/class_attribute.c
@@ -86,7 +86,7 @@ bool java_attribute_set_code(ConstPool **pool, ut32 poolsize, Attribute *attr, R
 			free(ac->exceptions);
 			free(ac);
 			rz_warn_if_reached();
-			return NULL;
+			return false;
 		}
 
 		for (ut32 i = 0; i < ac->attributes_count; ++i) {

--- a/librz/bin/format/wasm/wasm.c
+++ b/librz/bin/format/wasm/wasm.c
@@ -150,7 +150,7 @@ static size_t consume_limits_r(RzBuffer *b, ut64 max, struct rz_bin_wasm_resizab
 	if (out->flags && (!(consume_u32_r(b, max, &out->maximum)))) {
 		return 0;
 	}
-	return (size_t)RZ_ABS(rz_buf_tell(b) - i);
+	return (size_t)(rz_buf_tell(b) - i);
 }
 
 // Utils

--- a/librz/bin/p/bin_luac.c
+++ b/librz/bin/p/bin_luac.c
@@ -33,7 +33,7 @@ static bool load_buffer(RzBinFile *bf, void **bin_obj, RzBuffer *buf, ut64 loada
 
 	if (major != 5) {
 		eprintf("currently support lua 5.x only\n");
-		return NULL;
+		return false;
 	}
 
 	switch (minor) {

--- a/librz/bin/p/bin_nso.c
+++ b/librz/bin/p/bin_nso.c
@@ -135,7 +135,7 @@ fail:
 }
 
 static bool load_buffer(RzBinFile *bf, void **bin_obj, RzBuffer *buf, ut64 loadaddr, Sdb *sdb) {
-	rz_return_val_if_fail(bf && buf, NULL);
+	rz_return_val_if_fail(bf && buf, false);
 	const ut64 la = bf->loadaddr;
 	ut64 sz = 0;
 	const ut8 *bytes = rz_buf_data(buf, &sz);

--- a/librz/bin/p/bin_wasm.c
+++ b/librz/bin/p/bin_wasm.c
@@ -25,7 +25,7 @@ static bool find_export(const ut32 *p, const RzBinWasmExportEntry *q) {
 }
 
 static bool load_buffer(RzBinFile *bf, void **bin_obj, RzBuffer *buf, ut64 loadaddr, Sdb *sdb) {
-	rz_return_val_if_fail(bf && buf && rz_buf_size(buf) != UT64_MAX, NULL);
+	rz_return_val_if_fail(bf && buf && rz_buf_size(buf) != UT64_MAX, false);
 
 	if (check_buffer(buf)) {
 		*bin_obj = rz_bin_wasm_init(bf, buf);

--- a/librz/io/io_desc.c
+++ b/librz/io/io_desc.c
@@ -379,7 +379,7 @@ static bool desc_fini_cb(void *user, void *data, ut32 id) {
 
 //closes all descs and frees all descs and io->files
 RZ_IPI bool rz_io_desc_fini(RzIO *io) {
-	rz_return_val_if_fail(io, NULL);
+	rz_return_val_if_fail(io, false);
 	if (io->files) {
 		rz_id_storage_foreach(io->files, desc_fini_cb, io);
 		rz_id_storage_free(io->files);


### PR DESCRIPTION
Fix #1048
Note that I set the `GROWTH_FACTOR` for arrays in ELF to 2, which is pretty much the standard.
I purposefully left the "unary minus operator applied to unsigned type, result still unsigned" ones because this behavior is well-defined and the code is correct.