### PR TITLE
Simplify kill_word functions in dietline and fix META-D bug

### DIFF
--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -207,6 +207,15 @@ static int rz_line_readchar_utf8(ut8 *s, int slen) {
 
 #if __WINDOWS__
 static int rz_line_readchar_win(ut8 *s, int slen) { // this function handle the input in console mode
+	if (slen > 0 && rz_cons_readbuffer_readchar(s)) {
+		if (s[0] == '\x1b' && rz_cons_readbuffer_readchar(s + 1)) {
+			if (s[1] == '\x31' && rz_cons_readbuffer_readchar(s + 2)) {
+				return 3;
+			}
+			return 2;
+		}
+		return 1;
+	}
 	INPUT_RECORD irInBuf = { { 0 } };
 	BOOL ret, bCtrl = FALSE;
 	DWORD mode, out;

--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -34,10 +34,7 @@ static inline bool is_word_break_char(char ch, bool mode) {
 	if (mode == MAJOR_BREAK) {
 		return ch == ' ';
 	}
-	int len =
-		sizeof(word_break_characters) /
-		sizeof(word_break_characters[0]);
-	for (i = 0; i < len; i++) {
+	for (i = 0; i < RZ_ARRAY_SIZE(word_break_characters); i++) {
 		if (ch == word_break_characters[i]) {
 			return true;
 		}
@@ -46,98 +43,49 @@ static inline bool is_word_break_char(char ch, bool mode) {
 }
 
 /* https://www.gnu.org/software/bash/manual/html_node/Commands-For-Killing.html */
-static void backward_kill_word(void) {
+static void backward_kill_word(BreakMode mode) {
 	int i, len;
-	if (I.buffer.index > 0) {
-		for (i = I.buffer.index; i > 0 && is_word_break_char(I.buffer.data[i], MINOR_BREAK); i--) {
-			/* Move the cursor index back until we hit a non-word-break-character */
-		}
-		for (; i > 0 && !is_word_break_char(I.buffer.data[i], MINOR_BREAK); i--) {
-			/* Move the cursor index back until we hit a word-break-character */
-		}
-		if (i > 0) {
-			i++;
-		} else if (i < 0) {
-			i = 0;
-		}
-		if (I.buffer.index > I.buffer.length) {
-			I.buffer.length = I.buffer.index;
-		}
-		len = I.buffer.index - i + 1;
-		free(I.clipboard);
-		I.clipboard = rz_str_ndup(I.buffer.data + i, len);
-		rz_line_clipboard_push(I.clipboard);
-		memmove(I.buffer.data + i, I.buffer.data + I.buffer.index,
-			I.buffer.length - I.buffer.index + 1);
-		I.buffer.length = strlen(I.buffer.data);
-		I.buffer.index = i;
+	if (I.buffer.index <= 0) {
+		return;
 	}
-}
-
-static void backward_kill_Word(void) {
-	int i, len;
-	if (I.buffer.index > 0) {
-		for (i = I.buffer.index; i > 0 && is_word_break_char(I.buffer.data[i], MAJOR_BREAK); i--) {
-			/* Move the cursor index back until we hit a non-word-break-character */
-		}
-		for (; i > 0 && !is_word_break_char(I.buffer.data[i], MAJOR_BREAK); i--) {
-			/* Move the cursor index back until we hit a word-break-character */
-		}
-		if (i > 0) {
-			i++;
-		} else if (i < 0) {
-			i = 0;
-		}
-		if (I.buffer.index > I.buffer.length) {
-			I.buffer.length = I.buffer.index;
-		}
-		len = I.buffer.index - i + 1;
-		free(I.clipboard);
-		I.clipboard = rz_str_ndup(I.buffer.data + i, len);
-		rz_line_clipboard_push(I.clipboard);
-		memmove(I.buffer.data + i, I.buffer.data + I.buffer.index,
-			I.buffer.length - I.buffer.index + 1);
-		I.buffer.length = strlen(I.buffer.data);
-		I.buffer.index = i;
+	for (i = I.buffer.index; i > 0 && is_word_break_char(I.buffer.data[i], mode); i--) {
+		/* Move the cursor index back until we hit a non-word-break-character */
 	}
-}
-
-static void kill_word(void) {
-	int i, len;
-	for (i = I.buffer.index; i < I.buffer.length && is_word_break_char(I.buffer.data[i], MINOR_BREAK); i++) {
-		/* Move the cursor index forward until we hit a non-word-break-character */
+	for (; i > 0 && !is_word_break_char(I.buffer.data[i], mode); i--) {
+		/* Move the cursor index back until we hit a word-break-character */
 	}
-	for (; i < I.buffer.length && !is_word_break_char(I.buffer.data[i], MINOR_BREAK); i++) {
-		/* Move the cursor index forward we hit a word-break-character */
+	if (i > 0) {
+		i++;
+	} else if (i < 0) {
+		i = 0;
 	}
-	if (I.buffer.index >= I.buffer.length) {
+	if (I.buffer.index > I.buffer.length) {
 		I.buffer.length = I.buffer.index;
 	}
-	len = i - I.buffer.index + 1;
+	len = I.buffer.index - i;
+	free(I.clipboard);
+	I.clipboard = rz_str_ndup(I.buffer.data + i, len);
+	rz_line_clipboard_push(I.clipboard);
+	memmove(I.buffer.data + i, I.buffer.data + I.buffer.index,
+		I.buffer.length - I.buffer.index + 1);
+	I.buffer.length = strlen(I.buffer.data);
+	I.buffer.index = i;
+}
+
+static void kill_word(BreakMode mode) {
+	int i, len;
+	for (i = I.buffer.index; i < I.buffer.length && is_word_break_char(I.buffer.data[i], mode); i++) {
+		/* Move the cursor index forward until we hit a non-word-break-character */
+	}
+	for (; i < I.buffer.length && !is_word_break_char(I.buffer.data[i], mode); i++) {
+		/* Move the cursor index forward until we hit a word-break-character */
+	}
+	len = i - I.buffer.index;
 	free(I.clipboard);
 	I.clipboard = rz_str_ndup(I.buffer.data + I.buffer.index, len);
 	rz_line_clipboard_push(I.clipboard);
-	memmove(I.buffer.data + I.buffer.index, I.buffer.data + i, len);
-	I.buffer.length = strlen(I.buffer.data);
-}
-
-static void kill_Word(void) {
-	int i, len;
-	for (i = I.buffer.index; i < I.buffer.length && is_word_break_char(I.buffer.data[i], MAJOR_BREAK); i++) {
-		/* Move the cursor index forward until we hit a non-word-break-character */
-	}
-	for (; i < I.buffer.length && !is_word_break_char(I.buffer.data[i], MAJOR_BREAK); i++) {
-		/* Move the cursor index forward we hit a word-break-character */
-	}
-	if (I.buffer.index >= I.buffer.length) {
-		I.buffer.length = I.buffer.index;
-	}
-	len = i - I.buffer.index + 1;
-	free(I.clipboard);
-	I.clipboard = rz_str_ndup(I.buffer.data + I.buffer.index, len);
-	rz_line_clipboard_push(I.clipboard);
-	memmove(I.buffer.data + I.buffer.index, I.buffer.data + i, len);
-	I.buffer.length = strlen(I.buffer.data);
+	memmove(I.buffer.data + I.buffer.index, I.buffer.data + i, I.buffer.length - i + 1);
+	I.buffer.length -= len;
 }
 
 static void paste(void) {
@@ -1218,27 +1166,27 @@ static void __vi_mode(void) {
 				case 'i': {
 					char t = rz_cons_readchar();
 					if (t == 'w') { // diw
-						kill_word();
-						backward_kill_word();
+						kill_word(MINOR_BREAK);
+						backward_kill_word(MINOR_BREAK);
 					} else if (t == 'W') { // diW
-						kill_Word();
-						backward_kill_word();
+						kill_word(MAJOR_BREAK);
+						backward_kill_word(MINOR_BREAK);
 					}
 					if (I.hud) {
 						I.hud->vi = false;
 					}
 				} break;
 				case 'W':
-					kill_Word();
+					kill_word(MAJOR_BREAK);
 					break;
 				case 'w':
-					kill_word();
+					kill_word(MINOR_BREAK);
 					break;
 				case 'B':
-					backward_kill_Word();
+					backward_kill_word(MAJOR_BREAK);
 					break;
 				case 'b':
-					backward_kill_word();
+					backward_kill_word(MINOR_BREAK);
 					break;
 				case 'h':
 					__delete_prev_char();
@@ -1616,10 +1564,10 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 			yank_flag = enable_yank_pop ? 1 : 0;
 			break;
 		case 20: // ^t Kill from point to the end of the current word,
-			kill_word();
+			kill_word(MINOR_BREAK);
 			break;
 		case 15: // ^o kill backward
-			backward_kill_word();
+			backward_kill_word(MINOR_BREAK);
 			break;
 		case 14: // ^n
 			if (I.hud) {
@@ -1668,7 +1616,7 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 #endif
 			switch (buf[0]) {
 			case 127: // alt+bkspace
-				backward_kill_word();
+				backward_kill_word(MINOR_BREAK);
 				break;
 			case -1: // escape key, goto vi mode
 				if (I.enable_vi_mode) {
@@ -1701,7 +1649,7 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 				break;
 			case 'D':
 			case 'd':
-				kill_word();
+				kill_word(MINOR_BREAK);
 				break;
 			case 'F':
 			case 'f':

--- a/librz/cons/input.c
+++ b/librz/cons/input.c
@@ -577,6 +577,12 @@ static int __cons_readchar_w32(ut32 usec) {
 #endif
 
 RZ_API int rz_cons_readchar_timeout(ut32 usec) {
+	if (readbuffer_length > 0) {
+		int ch = *readbuffer;
+		readbuffer_length--;
+		memmove(readbuffer, readbuffer + 1, readbuffer_length);
+		return ch;
+	}
 #if __UNIX__
 	struct timeval tv;
 	fd_set fdset, errset;

--- a/librz/cons/input.c
+++ b/librz/cons/input.c
@@ -577,10 +577,8 @@ static int __cons_readchar_w32(ut32 usec) {
 #endif
 
 RZ_API int rz_cons_readchar_timeout(ut32 usec) {
-	if (readbuffer_length > 0) {
-		int ch = *readbuffer;
-		readbuffer_length--;
-		memmove(readbuffer, readbuffer + 1, readbuffer_length);
+	char ch;
+	if (rz_cons_readbuffer_readchar(&ch)) {
 		return ch;
 	}
 #if __UNIX__
@@ -627,13 +625,20 @@ RZ_API void rz_cons_switchbuf(bool active) {
 extern volatile sig_atomic_t sigwinchFlag;
 #endif
 
+RZ_API bool rz_cons_readbuffer_readchar(char *ch) {
+	if (readbuffer_length <= 0) {
+		return false;
+	}
+	*ch = *readbuffer;
+	readbuffer_length--;
+	memmove(readbuffer, readbuffer + 1, readbuffer_length);
+	return true;
+}
+
 RZ_API int rz_cons_readchar(void) {
-	char buf[2];
+	char buf[2], ch;
 	buf[0] = -1;
-	if (readbuffer_length > 0) {
-		int ch = *readbuffer;
-		readbuffer_length--;
-		memmove(readbuffer, readbuffer + 1, readbuffer_length);
+	if (rz_cons_readbuffer_readchar(&ch)) {
 		return ch;
 	}
 	rz_cons_set_raw(1);

--- a/librz/include/rz_cons.h
+++ b/librz/include/rz_cons.h
@@ -931,6 +931,7 @@ RZ_API void rz_cons_log_stub(const char *output, const char *funcname, const cha
 /* input */
 RZ_API int rz_cons_controlz(int ch);
 RZ_API int rz_cons_readchar(void);
+RZ_API bool rz_cons_readbuffer_readchar(char *ch);
 RZ_API bool rz_cons_readpush(const char *str, int len);
 RZ_API void rz_cons_readflush(void);
 RZ_API void rz_cons_switchbuf(bool active);

--- a/test/unit/test_cons.c
+++ b/test/unit/test_cons.c
@@ -284,12 +284,35 @@ bool test_line_multicompletion(void) {
 	mu_end;
 }
 
+bool test_line_kill_word(void) {
+	RzCons *cons = rz_cons_new();
+	// Make test reproducible everywhere
+	cons->force_columns = 80;
+	cons->force_rows = 23;
+	rz_line_free();
+	RzLine *line = rz_line_new();
+	line->ns_completion.run = multicompletion_run;
+	cons->line = line;
+
+	// write the string, then do ^b two times to move the index to 10, then ^d to delete the word under the cursor
+	const char instr[] = "pd 10@ hello\x1b\x62\x1b\x62\x1b\x64\n";
+	rz_cons_readpush(instr, sizeof(instr));
+	rz_line_readline();
+
+	mu_assert_eq(line->buffer.index, 3, "index is after 'pd '");
+	mu_assert_streq(line->buffer.data, "pd @ hello", "10 was deleted");
+
+	rz_cons_free();
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_rz_cons);
 	mu_run_test(test_cons_to_html);
 	mu_run_test(test_line_nocompletion);
 	mu_run_test(test_line_onecompletion);
 	mu_run_test(test_line_multicompletion);
+	mu_run_test(test_line_kill_word);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

* just use one kill_word/backward_kill_word function to reduce dupped
  code
* fix kill_word to correctly move buffer data
* add unit test for kill_word behaviour



**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Play with the shell interactively and try things like META-D, META-W, etc.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #767 