### PR TITLE
Introduce new RzBinMap and refactor all Bin Plugins for it

### DIFF
--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -1363,6 +1363,14 @@ RZ_API const char *rz_bin_get_meth_flag_string(ut64 flag, bool compact) {
 	}
 }
 
+RZ_IPI void rz_bin_map_free(RzBinMap *map) {
+	if (!map) {
+		return;
+	}
+	free(map->name);
+	free(map);
+}
+
 RZ_IPI RzBinSection *rz_bin_section_new(const char *name) {
 	RzBinSection *s = RZ_NEW0(RzBinSection);
 	if (s) {

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -1394,7 +1394,7 @@ RZ_API RzList *rz_bin_maps_of_file_sections(RzBinFile *binfile) {
 	}
 	RzBinSection *sec;
 	RzListIter *it;
-	rz_list_foreach(sections, it, sec) {
+	rz_list_foreach (sections, it, sec) {
 		RzBinMap *map = RZ_NEW0(RzBinMap);
 		if (!map) {
 			goto hcf;

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -1459,7 +1459,6 @@ RZ_IPI void rz_bin_section_free(RzBinSection *bs) {
 	if (bs) {
 		free(bs->name);
 		free(bs->format);
-		free(bs->map_name);
 		free(bs);
 	}
 }

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -1390,7 +1390,7 @@ RZ_API RzList *rz_bin_maps_of_file_sections(RzBinFile *binfile) {
 	}
 	RzList *r = rz_list_newf((RzListFree)rz_bin_map_free);
 	if (!r) {
-		return NULL;
+		goto hcf;
 	}
 	RzBinSection *sec;
 	RzListIter *it;

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -1412,6 +1412,41 @@ hcf:
 	return r;
 }
 
+/**
+ * \brief Create a list of RzBinSection from RzBinMaps
+ *
+ * Some binary formats have a 1:1 correspondence of mapping and
+ * some of their RzBinSections, but also want to add some unmapped sections.
+ * In this case, they can implement their mapped sections in their maps callback,
+ * then in their sections callback use this function to create sections from them
+ * and add some additional ones.
+ * See also rz_bin_maps_of_file_sections() for the inverse, when no additional
+ * sections should be added.
+ * */
+RZ_API RzList *rz_bin_sections_of_maps(RzList /*<RzBinMap>*/ *maps) {
+	rz_return_val_if_fail(maps, NULL);
+	RzList *ret = rz_list_newf((RzListFree)rz_bin_section_free);
+	if (!ret) {
+		return NULL;
+	}
+	RzListIter *it;
+	RzBinMap *map;
+	rz_list_foreach (maps, it, map) {
+		RzBinSection *sec = RZ_NEW0(RzBinSection);
+		if (!sec) {
+			break;
+		}
+		sec->name = map->name ? strdup(map->name) : NULL;
+		sec->paddr = map->paddr;
+		sec->size = map->psize;
+		sec->vaddr = map->vaddr;
+		sec->vsize = map->vsize;
+		sec->perm = map->perm;
+		rz_list_append(ret, sec);
+	}
+	return ret;
+}
+
 RZ_IPI RzBinSection *rz_bin_section_new(const char *name) {
 	RzBinSection *s = RZ_NEW0(RzBinSection);
 	if (s) {

--- a/librz/bin/bobj.c
+++ b/librz/bin/bobj.c
@@ -38,6 +38,7 @@ static void object_delete_items(RzBinObject *o) {
 	rz_return_if_fail(o);
 	ht_up_free(o->addrzklassmethod);
 	rz_list_free(o->entries);
+	rz_list_free(o->maps);
 	rz_list_free(o->fields);
 	rz_list_free(o->imports);
 	rz_list_free(o->libs);
@@ -306,6 +307,12 @@ RZ_API int rz_bin_object_set_items(RzBinFile *bf, RzBinObject *o) {
 	if (p->entries) {
 		o->entries = p->entries(bf);
 		REBASE_PADDR(o, o->entries, RzBinAddr);
+	}
+	if (p->maps) {
+		o->maps = p->maps(bf);
+		if (o->maps) {
+			REBASE_PADDR(o, o->maps, RzBinMap);
+		}
 	}
 	if (p->fields) {
 		o->fields = p->fields(bf);

--- a/librz/bin/format/java/class_bin.c
+++ b/librz/bin/format/java/class_bin.c
@@ -1520,7 +1520,6 @@ static RzBinSection *new_section(const char *name, ut64 start, ut64 end, ut32 pe
 	section->size = end - start;
 	section->vsize = section->size;
 	section->perm = perm;
-	section->add = true;
 	return section;
 }
 

--- a/librz/bin/format/le/le.c
+++ b/librz/bin/format/le/le.c
@@ -281,7 +281,6 @@ static void __create_iter_sections(RzList *l, rz_bin_le_obj_t *bin, RzBinSection
 			s->vsize = data_size;
 			s->paddr = offset;
 			s->vaddr = vaddr;
-			s->add = true;
 			vaddr += data_size;
 			tot_size += data_size;
 			rz_list_append(l, s);
@@ -305,7 +304,6 @@ static void __create_iter_sections(RzList *l, rz_bin_le_obj_t *bin, RzBinSection
 		s->perm = sec->perm;
 		s->vsize = h->pagesize - tot_size;
 		s->vaddr = vaddr;
-		s->add = true;
 		rz_list_append(l, s);
 	}
 }
@@ -332,7 +330,6 @@ RzList *rz_bin_le_get_sections(rz_bin_le_obj_t *bin) {
 		sec->name = rz_str_newf("obj.%d", i + 1);
 		sec->vsize = entry->virtual_size;
 		sec->vaddr = entry->reloc_base_addr;
-		sec->add = true;
 		if (entry->flags & O_READABLE) {
 			sec->perm |= RZ_PERM_R;
 		}
@@ -396,7 +393,6 @@ RzList *rz_bin_le_get_sections(rz_bin_le_obj_t *bin) {
 			s->vaddr = sec->vaddr + page_size_sum;
 			s->perm = sec->perm;
 			s->size = page.size;
-			s->add = true;
 			s->bits = sec->bits;
 			rz_list_append(l, s);
 			page_size_sum += s->vsize;

--- a/librz/bin/format/luac/luac_bin.c
+++ b/librz/bin/format/luac/luac_bin.c
@@ -12,7 +12,6 @@ void luac_add_section(RzList *section_list, char *name, ut64 offset, ut32 size, 
 	bin_sec->name = rz_str_new(name);
 	bin_sec->vaddr = bin_sec->paddr = offset;
 	bin_sec->size = bin_sec->vsize = size;
-	bin_sec->add = true;
 	bin_sec->is_data = false;
 	bin_sec->bits = is_func ? sizeof(LUA_INSTRUCTION) * 8 : 8;
 	// bin_sec->has_strings = !is_func;

--- a/librz/bin/format/mach0/mach0.h
+++ b/librz/bin/format/mach0/mach0.h
@@ -183,9 +183,9 @@ struct MACH0_(obj_t) * MACH0_(new_buf)(RzBuffer *buf, struct MACH0_(opts_t) * op
 void *MACH0_(mach0_free)(struct MACH0_(obj_t) * bin);
 struct section_t *MACH0_(get_sections)(struct MACH0_(obj_t) * bin);
 char *MACH0_(section_type_to_string)(ut64 type);
-//RzList *MACH0_(get_segments)(struct MACH0_(obj_t) *bin);
 RzList *MACH0_(section_flag_to_rzlist)(ut64 flag);
-RzList *MACH0_(get_segments)(RzBinFile *bf); // struct MACH0_(obj_t) *bin);
+RzList *MACH0_(get_maps)(RzBinFile *bf);
+RzList *MACH0_(get_segments)(RzBinFile *bf);
 const struct symbol_t *MACH0_(get_symbols)(struct MACH0_(obj_t) * bin);
 const RzList *MACH0_(get_symbols_list)(struct MACH0_(obj_t) * bin);
 void MACH0_(pull_symbols)(struct MACH0_(obj_t) * mo, RzBinSymbolCallback cb, void *user);

--- a/librz/bin/format/mdmp/mdmp_pe.c
+++ b/librz/bin/format/mdmp/mdmp_pe.c
@@ -184,7 +184,6 @@ RzList *PE_(rz_bin_mdmp_pe_get_sections)(struct PE_(rz_bin_mdmp_pe_bin) * pe_bin
 		}
 		ptr->paddr = sections[i].paddr + pe_bin->paddr;
 		ptr->vaddr = sections[i].vaddr + ba;
-		ptr->add = false;
 		ptr->perm = 0;
 		if (RZ_BIN_PE_SCN_IS_EXECUTABLE(sections[i].perm)) {
 			ptr->perm |= RZ_PERM_X;

--- a/librz/bin/format/mz/mz.c
+++ b/librz/bin/format/mz/mz.c
@@ -142,7 +142,6 @@ RzList *rz_bin_mz_get_segments(const struct rz_bin_mz_obj_t *bin) {
 		section->vsize = section->size;
 		section->paddr = rz_bin_mz_la_to_pa(bin, section->vaddr);
 		section->perm = rz_str_rwx("rwx");
-		section->add = true;
 		section_number++;
 	}
 	section = rz_list_get_top(seg_list);

--- a/librz/bin/format/ne/ne.c
+++ b/librz/bin/format/ne/ne.c
@@ -75,7 +75,7 @@ RzList *rz_bin_ne_get_segments(rz_bin_ne_obj_t *bin) {
 	if (!bin) {
 		return NULL;
 	}
-	RzList *segments = rz_list_newf(free);
+	RzList *segments = rz_list_newf((RzListFree)rz_bin_section_free);
 	for (i = 0; i < bin->ne_header->SegCount; i++) {
 		RzBinSection *bs = RZ_NEW0(RzBinSection);
 		NE_image_segment_entry *se = &bin->segment_entries[i];

--- a/librz/bin/format/ne/ne.c
+++ b/librz/bin/format/ne/ne.c
@@ -76,6 +76,9 @@ RzList *rz_bin_ne_get_segments(rz_bin_ne_obj_t *bin) {
 		return NULL;
 	}
 	RzList *segments = rz_list_newf((RzListFree)rz_bin_section_free);
+	if (!segments) {
+		return NULL;
+	}
 	for (i = 0; i < bin->ne_header->SegCount; i++) {
 		RzBinSection *bs = RZ_NEW0(RzBinSection);
 		NE_image_segment_entry *se = &bin->segment_entries[i];

--- a/librz/bin/format/omf/omf.c
+++ b/librz/bin/format/omf/omf.c
@@ -765,7 +765,6 @@ int rz_bin_omf_send_sections(RzList *list, OMF_segment *section, rz_bin_omf_obj 
 		new->paddr = data->paddr;
 		new->vaddr = section->vaddr + data->offset + OMF_BASE_ADDR;
 		new->perm = RZ_PERM_RWX;
-		new->add = true;
 		rz_list_append(list, new);
 		data = data->next;
 	}

--- a/librz/bin/format/qnx/qnx.h
+++ b/librz/bin/format/qnx/qnx.h
@@ -89,6 +89,7 @@ RZ_PACKED(
 		lmf_header lmfh;
 		RzList *fixups;
 		RzList *sections;
+		RzList *maps;
 		lmf_rw_end rwend;
 	})
 QnxObj;

--- a/librz/bin/p/bin_art.c
+++ b/librz/bin/p/bin_art.c
@@ -205,16 +205,6 @@ static RzList *sections(RzBinFile *bf) {
 	return ret;
 }
 
-static RzList *maps(RzBinFile *bf) {
-	RzList *secs = sections(bf);
-	if (!secs) {
-		return NULL;
-	}
-	RzList *r = rz_bin_maps_of_sections(secs);
-	rz_list_free(secs);
-	return r;
-}
-
 RzBinPlugin rz_bin_plugin_art = {
 	.name = "art",
 	.desc = "Android Runtime",
@@ -224,7 +214,7 @@ RzBinPlugin rz_bin_plugin_art = {
 	.destroy = &destroy,
 	.check_buffer = &check_buffer,
 	.baddr = &baddr,
-	.maps = &maps,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.entries = entries,
 	.strings = &strings,

--- a/librz/bin/p/bin_art.c
+++ b/librz/bin/p/bin_art.c
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2021 Florian Märkl <info@florianmaerkl.de>
 // SPDX-FileCopyrightText: 2015-2018 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
@@ -166,7 +167,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->paddr = 0;
 	ptr->vaddr = art.image_base;
 	ptr->perm = RZ_PERM_R; // r--
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
@@ -178,7 +178,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->paddr = art.bitmap_offset;
 	ptr->vaddr = art.image_base + art.bitmap_offset;
 	ptr->perm = RZ_PERM_RX; // r-x
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
@@ -190,7 +189,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->size = art.oat_file_end - art.oat_file_begin;
 	ptr->vsize = ptr->size;
 	ptr->perm = RZ_PERM_RX; // r-x
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
@@ -202,10 +200,19 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->size = art.oat_data_end - art.oat_data_begin;
 	ptr->vsize = ptr->size;
 	ptr->perm = RZ_PERM_R; // r--
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 
 	return ret;
+}
+
+static RzList *maps(RzBinFile *bf) {
+	RzList *secs = sections(bf);
+	if (!secs) {
+		return NULL;
+	}
+	RzList *r = rz_bin_maps_of_sections(secs);
+	rz_list_free(secs);
+	return r;
 }
 
 RzBinPlugin rz_bin_plugin_art = {
@@ -217,6 +224,7 @@ RzBinPlugin rz_bin_plugin_art = {
 	.destroy = &destroy,
 	.check_buffer = &check_buffer,
 	.baddr = &baddr,
+	.maps = &maps,
 	.sections = &sections,
 	.entries = entries,
 	.strings = &strings,

--- a/librz/bin/p/bin_bios.c
+++ b/librz/bin/p/bin_bios.c
@@ -93,7 +93,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->paddr = rz_buf_size(bf->buf) - ptr->size;
 	ptr->vaddr = 0xf0000;
 	ptr->perm = RZ_PERM_RWX;
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 	// If image bigger than 128K - add one more section
 	if (bf->size >= 0x20000) {
@@ -105,10 +104,19 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->paddr = rz_buf_size(obj) - 2 * ptr->size;
 		ptr->vaddr = 0xe0000;
 		ptr->perm = RZ_PERM_RWX;
-		ptr->add = true;
 		rz_list_append(ret, ptr);
 	}
 	return ret;
+}
+
+static RzList *maps(RzBinFile *bf) {
+	RzList *secs = sections(bf);
+	if (!secs) {
+		return NULL;
+	}
+	RzList *r = rz_bin_maps_of_sections(secs);
+	rz_list_free(secs);
+	return r;
 }
 
 static RzList *entries(RzBinFile *bf) {
@@ -136,6 +144,7 @@ RzBinPlugin rz_bin_plugin_bios = {
 	.check_buffer = &check_buffer,
 	.baddr = &baddr,
 	.entries = entries,
+	.maps = maps,
 	.sections = sections,
 	.strings = &strings,
 	.info = &info,

--- a/librz/bin/p/bin_bios.c
+++ b/librz/bin/p/bin_bios.c
@@ -109,16 +109,6 @@ static RzList *sections(RzBinFile *bf) {
 	return ret;
 }
 
-static RzList *maps(RzBinFile *bf) {
-	RzList *secs = sections(bf);
-	if (!secs) {
-		return NULL;
-	}
-	RzList *r = rz_bin_maps_of_sections(secs);
-	rz_list_free(secs);
-	return r;
-}
-
 static RzList *entries(RzBinFile *bf) {
 	RzList *ret;
 	RzBinAddr *ptr = NULL;
@@ -144,7 +134,7 @@ RzBinPlugin rz_bin_plugin_bios = {
 	.check_buffer = &check_buffer,
 	.baddr = &baddr,
 	.entries = entries,
-	.maps = maps,
+	.maps = rz_bin_maps_of_file_sections,
 	.sections = sections,
 	.strings = &strings,
 	.info = &info,

--- a/librz/bin/p/bin_bootimg.c
+++ b/librz/bin/p/bin_bootimg.c
@@ -196,7 +196,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->paddr = 0;
 	ptr->vaddr = 0;
 	ptr->perm = RZ_PERM_R; // r--
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
@@ -208,7 +207,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->paddr = bi->page_size;
 	ptr->vaddr = bi->kernel_addr;
 	ptr->perm = RZ_PERM_R; // r--
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 
 	if (bi->ramdisk_size > 0) {
@@ -222,7 +220,6 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->paddr = ROUND_DOWN(base, bi->page_size);
 		ptr->vaddr = bi->ramdisk_addr;
 		ptr->perm = RZ_PERM_RX; // r-x
-		ptr->add = true;
 		rz_list_append(ret, ptr);
 	}
 
@@ -237,7 +234,6 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->paddr = ROUND_DOWN(base, bi->page_size);
 		ptr->vaddr = bi->second_addr;
 		ptr->perm = RZ_PERM_RX; // r-x
-		ptr->add = true;
 		rz_list_append(ret, ptr);
 	}
 
@@ -253,6 +249,7 @@ RzBinPlugin rz_bin_plugin_bootimg = {
 	.destroy = &destroy,
 	.check_buffer = &check_buffer,
 	.baddr = &baddr,
+	.maps = rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.entries = entries,
 	.strings = &strings,

--- a/librz/bin/p/bin_cgc.c
+++ b/librz/bin/p/bin_cgc.c
@@ -113,6 +113,7 @@ RzBinPlugin rz_bin_plugin_cgc = {
 	.boffset = &boffset,
 	.binsym = &binsym,
 	.entries = &entries,
+	.maps = &maps,
 	.sections = &sections,
 	.symbols = &symbols,
 	.minstrlen = 4,

--- a/librz/bin/p/bin_coff.c
+++ b/librz/bin/p/bin_coff.c
@@ -190,7 +190,6 @@ static RzList *sections(RzBinFile *bf) {
 		if (obj->scn_va) {
 			ptr->vaddr = obj->scn_va[i];
 		}
-		ptr->add = true;
 		ptr->perm = 0;
 		if (obj->scn_hdrs[i].s_flags & COFF_SCN_MEM_READ) {
 			ptr->perm |= RZ_PERM_R;
@@ -624,6 +623,7 @@ RzBinPlugin rz_bin_plugin_coff = {
 	.baddr = &baddr,
 	.binsym = &binsym,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.symbols = &symbols,
 	.imports = &imports,

--- a/librz/bin/p/bin_dol.c
+++ b/librz/bin/p/bin_dol.c
@@ -105,7 +105,6 @@ static RzList *sections(RzBinFile *bf) {
 		s->size = dol->text_size[i];
 		s->vsize = s->size;
 		s->perm = rz_str_rwx("r-x");
-		s->add = true;
 		rz_list_append(ret, s);
 	}
 	/* data sections */
@@ -120,7 +119,6 @@ static RzList *sections(RzBinFile *bf) {
 		s->size = dol->data_size[i];
 		s->vsize = s->size;
 		s->perm = rz_str_rwx("r--");
-		s->add = true;
 		rz_list_append(ret, s);
 	}
 	/* bss section */
@@ -131,7 +129,6 @@ static RzList *sections(RzBinFile *bf) {
 	s->size = dol->bss_size;
 	s->vsize = s->size;
 	s->perm = rz_str_rwx("rw-");
-	s->add = true;
 	rz_list_append(ret, s);
 
 	return ret;
@@ -178,6 +175,7 @@ RzBinPlugin rz_bin_plugin_dol = {
 	.baddr = &baddr,
 	.check_buffer = &check_buffer,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.info = &info,
 };

--- a/librz/bin/p/bin_elf.c
+++ b/librz/bin/p/bin_elf.c
@@ -145,6 +145,7 @@ RzBinPlugin rz_bin_plugin_elf = {
 	.boffset = &boffset,
 	.binsym = &binsym,
 	.entries = &entries,
+	.maps = &maps,
 	.sections = &sections,
 	.symbols = &symbols,
 	.minstrlen = 4,

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -302,7 +302,7 @@ static RzList *maps(RzBinFile *bf) {
 static RzList *sections(RzBinFile *bf) {
 	struct Elf_(rz_bin_elf_obj_t) *obj = (bf && bf->o) ? bf->o->bin_obj : NULL;
 	struct rz_bin_elf_section_t *section = NULL;
-	int i, num, found_load = 0;
+	int i, num;
 	Elf_(Phdr) *phdr = NULL;
 	RzBinSection *ptr = NULL;
 	RzList *ret = NULL;
@@ -343,7 +343,6 @@ static RzList *sections(RzBinFile *bf) {
 	ut16 mach = obj->ehdr.e_machine;
 	num = obj->ehdr.e_phnum;
 	phdr = obj->phdr;
-	ut64 core_sp = Elf_(rz_bin_elf_get_sp_val)(obj);
 	if (phdr) {
 		int n = 0;
 		for (i = 0; i < num; i++) {

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -192,6 +192,113 @@ static RzBinElfNoteFile *note_file_for_load_segment(struct Elf_(rz_bin_elf_obj_t
 	return NULL;
 }
 
+static ut32 section_perms_from_flags(ut32 flags) {
+	ut32 r = 0;
+	if (RZ_BIN_ELF_SCN_IS_EXECUTABLE(flags)) {
+		r |= RZ_PERM_X;
+	}
+	if (RZ_BIN_ELF_SCN_IS_WRITABLE(flags)) {
+		r |= RZ_PERM_W;
+	}
+	if (RZ_BIN_ELF_SCN_IS_READABLE(flags)) {
+		r |= RZ_PERM_R;
+	}
+	return r;
+}
+
+static RzList *maps(RzBinFile *bf) {
+	struct Elf_(rz_bin_elf_obj_t) *obj = (bf && bf->o) ? bf->o->bin_obj : NULL;
+	RzList *ret = NULL;
+	if (!obj || !(ret = rz_list_newf((RzListFree)rz_bin_map_free))) {
+		return NULL;
+	}
+	Elf_(Phdr) *phdr = obj->phdr;
+	if (phdr) {
+		ut64 core_sp = Elf_(rz_bin_elf_get_sp_val)(obj);
+		int n = 0;
+		for (size_t i = 0; i < obj->ehdr.e_phnum; i++) {
+			if (phdr[i].p_type != PT_LOAD) {
+				continue;
+			}
+			RzBinMap *map = RZ_NEW0(RzBinMap);
+			if (!map) {
+				break;
+			}
+			map->paddr = phdr[i].p_offset;
+			map->psize = phdr[i].p_filesz;
+			map->vsize = phdr[i].p_memsz;
+			map->vaddr = phdr[i].p_vaddr;
+			map->perm = phdr[i].p_flags | RZ_PERM_R;
+			// map names specific to core files...
+			if (core_sp != UT64_MAX && core_sp >= phdr[i].p_vaddr && core_sp < phdr[i].p_vaddr + phdr[i].p_memsz) {
+				map->name = strdup("[stack]");
+			} else {
+				RzBinElfNoteFile *nf = note_file_for_load_segment(obj, &phdr[i]);
+				if (nf && nf->file) {
+					map->name = strdup(nf->file);
+				}
+			}
+			// generic names
+			if (!map->name) {
+				map->name = rz_str_newf("LOAD%d", n);
+			}
+			n++;
+			rz_list_append(ret, map);
+		}
+	} else {
+		// Load sections if there is no PHDR
+		struct rz_bin_elf_section_t *sections = Elf_(rz_bin_elf_get_sections)(obj);
+		if (sections) {
+			for (size_t i = 0; !sections[i].last; i++) {
+				RzBinMap *map = RZ_NEW0(RzBinMap);
+				if (!map) {
+					break;
+				}
+				map->name = strdup(sections[i].name);
+				map->paddr = sections[i].offset;
+				map->psize = sections[i].type != SHT_NOBITS ? sections[i].size : 0;
+				map->vsize = sections[i].size;
+				map->vaddr = sections[i].rva;
+				map->perm = section_perms_from_flags(sections[i].flags);
+				rz_list_append(ret, map);
+			}
+		}
+	}
+
+	if (rz_list_empty(ret)) {
+		RzBinMap *map = RZ_NEW0(RzBinMap);
+		if (!map) {
+			return ret;
+		}
+		map->name = strdup("uphdr");
+		map->paddr = 0;
+		map->psize = bf->size;
+		map->vaddr = 0x10000;
+		map->vsize = bf->size;
+		map->perm = RZ_PERM_RWX;
+		rz_list_append(ret, map);
+	}
+
+	if (obj->ehdr.e_type == ET_REL) {
+		RzBinMap *map = RZ_NEW0(RzBinMap);
+		if (!map) {
+			return ret;
+		}
+		ut64 ehdr_size = sizeof(obj->ehdr);
+		if (bf->size < ehdr_size) {
+			ehdr_size = bf->size;
+		}
+		map->name = strdup("ehdr");
+		map->paddr = 0;
+		map->psize = ehdr_size;
+		map->vaddr = obj->baddr;
+		map->vsize = ehdr_size;
+		map->perm = RZ_PERM_RW;
+		rz_list_append(ret, map);
+	}
+	return ret;
+}
+
 static RzList *sections(RzBinFile *bf) {
 	struct Elf_(rz_bin_elf_obj_t) *obj = (bf && bf->o) ? bf->o->bin_obj : NULL;
 	struct rz_bin_elf_section_t *section = NULL;
@@ -227,17 +334,7 @@ static RzList *sections(RzBinFile *bf) {
 			ptr->vaddr = section[i].rva;
 			ptr->type = section[i].type;
 			ptr->flags = section[i].flags;
-			ptr->add = !obj->phdr; // Load sections if there is no PHDR
-			ptr->perm = 0;
-			if (RZ_BIN_ELF_SCN_IS_EXECUTABLE(section[i].flags)) {
-				ptr->perm |= RZ_PERM_X;
-			}
-			if (RZ_BIN_ELF_SCN_IS_WRITABLE(section[i].flags)) {
-				ptr->perm |= RZ_PERM_W;
-			}
-			if (RZ_BIN_ELF_SCN_IS_READABLE(section[i].flags)) {
-				ptr->perm |= RZ_PERM_R;
-			}
+			ptr->perm = section_perms_from_flags(section[i].flags);
 			rz_list_append(ret, ptr);
 		}
 	}
@@ -253,7 +350,6 @@ static RzList *sections(RzBinFile *bf) {
 			if (!(ptr = RZ_NEW0(RzBinSection))) {
 				return ret;
 			}
-			ptr->add = false;
 			ptr->size = phdr[i].p_filesz;
 			ptr->vsize = phdr[i].p_memsz;
 			ptr->paddr = phdr[i].p_offset;
@@ -267,16 +363,6 @@ static RzList *sections(RzBinFile *bf) {
 			case PT_LOAD: {
 				ptr->name = rz_str_newf("LOAD%d", n++);
 				ptr->perm |= RZ_PERM_R;
-				found_load = 1;
-				ptr->add = true;
-				if (core_sp != UT64_MAX && core_sp >= phdr[i].p_vaddr && core_sp < phdr[i].p_vaddr + phdr[i].p_memsz) {
-					ptr->map_name = strdup("[stack]");
-				} else {
-					RzBinElfNoteFile *nf = note_file_for_load_segment(obj, &phdr[i]);
-					if (nf && nf->file) {
-						ptr->map_name = strdup(nf->file);
-					}
-				}
 				break;
 			}
 			case PT_INTERP:
@@ -321,25 +407,6 @@ static RzList *sections(RzBinFile *bf) {
 		}
 	}
 
-	if (rz_list_empty(ret)) {
-		if (!bf->size) {
-			struct Elf_(rz_bin_elf_obj_t) *bin = bf->o->bin_obj;
-			bf->size = bin ? bin->size : 0x9999;
-		}
-		if (found_load == 0) {
-			if (!(ptr = RZ_NEW0(RzBinSection))) {
-				return ret;
-			}
-			ptr->name = strdup("uphdr");
-			ptr->size = bf->size;
-			ptr->vsize = bf->size;
-			ptr->paddr = 0;
-			ptr->vaddr = 0x10000;
-			ptr->add = true;
-			ptr->perm = RZ_PERM_RWX;
-			rz_list_append(ret, ptr);
-		}
-	}
 	// add entry for ehdr
 	ptr = RZ_NEW0(RzBinSection);
 	if (ptr) {
@@ -352,10 +419,6 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->vaddr = obj->baddr;
 		ptr->size = ehdr_size;
 		ptr->vsize = ehdr_size;
-		ptr->add = false;
-		if (obj->ehdr.e_type == ET_REL) {
-			ptr->add = true;
-		}
 		ptr->perm = RZ_PERM_RW;
 		ptr->is_segment = true;
 		rz_list_append(ret, ptr);

--- a/librz/bin/p/bin_elf64.c
+++ b/librz/bin/p/bin_elf64.c
@@ -139,6 +139,7 @@ RzBinPlugin rz_bin_plugin_elf64 = {
 	.boffset = &boffset,
 	.binsym = &binsym,
 	.entries = &entries,
+	.maps = &maps,
 	.sections = &sections,
 	.symbols = &symbols,
 	.imports = &imports,

--- a/librz/bin/p/bin_java.c
+++ b/librz/bin/p/bin_java.c
@@ -245,6 +245,7 @@ RzBinPlugin rz_bin_plugin_java = {
 	.baddr = &baddr,
 	.binsym = &binsym,
 	.entries = &entrypoints,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = sections,
 	.symbols = symbols,
 	.imports = &imports,

--- a/librz/bin/p/bin_le.c
+++ b/librz/bin/p/bin_le.c
@@ -102,16 +102,6 @@ static void header(RzBinFile *bf) {
 	p("Stack Size: 0x%04x\n", h->stacksize);
 }
 
-static RzList *maps(RzBinFile *bf) {
-	RzList *secs = rz_bin_le_get_sections(bf->o->bin_obj);
-	if (!secs) {
-		return NULL;
-	}
-	RzList *r = rz_bin_maps_of_sections(secs);
-	rz_list_free(secs);
-	return r;
-}
-
 static RzList *sections(RzBinFile *bf) {
 	return rz_bin_le_get_sections(bf->o->bin_obj);
 }
@@ -164,7 +154,7 @@ RzBinPlugin rz_bin_plugin_le = {
 	.destroy = &destroy,
 	.info = &info,
 	.header = &header,
-	.maps = &maps,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.entries = &entries,
 	.symbols = &symbols,

--- a/librz/bin/p/bin_le.c
+++ b/librz/bin/p/bin_le.c
@@ -102,6 +102,16 @@ static void header(RzBinFile *bf) {
 	p("Stack Size: 0x%04x\n", h->stacksize);
 }
 
+static RzList *maps(RzBinFile *bf) {
+	RzList *secs = rz_bin_le_get_sections(bf->o->bin_obj);
+	if (!secs) {
+		return NULL;
+	}
+	RzList *r = rz_bin_maps_of_sections(secs);
+	rz_list_free(secs);
+	return r;
+}
+
 static RzList *sections(RzBinFile *bf) {
 	return rz_bin_le_get_sections(bf->o->bin_obj);
 }
@@ -154,6 +164,7 @@ RzBinPlugin rz_bin_plugin_le = {
 	.destroy = &destroy,
 	.info = &info,
 	.header = &header,
+	.maps = &maps,
 	.sections = &sections,
 	.entries = &entries,
 	.symbols = &symbols,

--- a/librz/bin/p/bin_luac.c
+++ b/librz/bin/p/bin_luac.c
@@ -89,7 +89,7 @@ static RzList *sections(RzBinFile *bf) {
 		return NULL;
 	}
 
-	return bin_info_obj->section_list;
+	return rz_list_clone(bin_info_obj->section_list);
 }
 
 static RzList *symbols(RzBinFile *bf) {
@@ -137,6 +137,7 @@ RzBinPlugin rz_bin_plugin_luac = {
 	.check_buffer = &check_buffer,
 	.baddr = NULL,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.symbols = &symbols,
 	.info = &info,

--- a/librz/bin/p/bin_mach0.c
+++ b/librz/bin/p/bin_mach0.c
@@ -77,6 +77,10 @@ static ut64 baddr(RzBinFile *bf) {
 	return MACH0_(get_baddr)(bin);
 }
 
+static RzList *maps(RzBinFile *bf) {
+	return MACH0_(get_maps)(bf);
+}
+
 static RzList *sections(RzBinFile *bf) {
 	return MACH0_(get_segments)(bf);
 }
@@ -1159,6 +1163,7 @@ RzBinPlugin rz_bin_plugin_mach0 = {
 	.binsym = &binsym,
 	.entries = &entries,
 	.signature = &entitlements,
+	.maps = &maps,
 	.sections = &sections,
 	.symbols = &symbols,
 	.imports = &imports,

--- a/librz/bin/p/bin_mach064.c
+++ b/librz/bin/p/bin_mach064.c
@@ -298,6 +298,7 @@ RzBinPlugin rz_bin_plugin_mach064 = {
 	.baddr = &baddr,
 	.binsym = binsym,
 	.entries = &entries,
+	.maps = &maps,
 	.sections = &sections,
 	.signature = &entitlements,
 	.symbols = &symbols,

--- a/librz/bin/p/bin_mbn.c
+++ b/librz/bin/p/bin_mbn.c
@@ -122,7 +122,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->paddr = sb.paddr + 40;
 	ptr->vaddr = sb.vaddr;
 	ptr->perm = RZ_PERM_RX; // r-x
-	ptr->add = true;
 	ptr->has_strings = true;
 	rz_list_append(ret, ptr);
 
@@ -136,7 +135,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->vaddr = sb.sign_va;
 	ptr->perm = RZ_PERM_R; // r--
 	ptr->has_strings = true;
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 
 	if (sb.cert_sz && sb.cert_va > sb.vaddr) {
@@ -150,7 +148,6 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->vaddr = sb.cert_va;
 		ptr->perm = RZ_PERM_R; // r--
 		ptr->has_strings = true;
-		ptr->add = true;
 		rz_list_append(ret, ptr);
 	}
 	return ret;
@@ -194,6 +191,7 @@ RzBinPlugin rz_bin_plugin_mbn = {
 	.check_buffer = &check_buffer,
 	.baddr = &baddr,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.info = &info,
 };

--- a/librz/bin/p/bin_mdmp.c
+++ b/librz/bin/p/bin_mdmp.c
@@ -176,9 +176,50 @@ static bool load_buffer(RzBinFile *bf, void **bin_obj, RzBuffer *buf, ut64 loada
 	return false;
 }
 
-static RzList *sections(RzBinFile *bf) {
+static RzList *maps(RzBinFile *bf) {
+	struct rz_bin_mdmp_obj *obj = (struct rz_bin_mdmp_obj *)bf->o->bin_obj;
+	RzList *ret = rz_list_newf((RzListFree)rz_bin_map_free);
+	if (!ret) {
+		return NULL;
+	}
+
+	RzListIter *it;
 	struct minidump_memory_descriptor *memory;
+	rz_list_foreach (obj->streams.memories, it, memory) {
+		RzBinMap *map = RZ_NEW0(RzBinMap);
+		if (!map) {
+			return ret;
+		}
+		map->paddr = (memory->memory).rva;
+		map->psize = (memory->memory).data_size;
+		map->vaddr = memory->start_of_memory_range;
+		map->vsize = (memory->memory).data_size;
+		map->perm = rz_bin_mdmp_get_perm(obj, map->vaddr);
+		map->name = rz_str_newf("memory.0x%" PFMT64x, map->vaddr);
+		rz_list_append(ret, map);
+	}
+
+	ut64 index = obj->streams.memories64.base_rva;
 	struct minidump_memory_descriptor64 *memory64;
+	rz_list_foreach (obj->streams.memories64.memories, it, memory64) {
+		RzBinMap *map = RZ_NEW0(RzBinMap);
+		if (!map) {
+			return ret;
+		}
+		map->paddr = index;
+		map->psize = memory64->data_size;
+		map->vaddr = memory64->start_of_memory_range;
+		map->vsize = memory64->data_size;
+		map->perm = rz_bin_mdmp_get_perm(obj, map->vaddr);
+		map->name = rz_str_newf("memory64.0x%" PFMT64x, map->vaddr);
+		rz_list_append(ret, map);
+		index += memory64->data_size;
+	}
+
+	return ret;
+}
+
+static RzList *sections(RzBinFile *bf) {
 	struct minidump_module *module;
 	struct minidump_string *str;
 	struct rz_bin_mdmp_obj *obj;
@@ -187,54 +228,11 @@ static RzList *sections(RzBinFile *bf) {
 	RzList *ret, *pe_secs;
 	RzListIter *it, *it0;
 	RzBinSection *ptr;
-	ut64 index;
 
 	obj = (struct rz_bin_mdmp_obj *)bf->o->bin_obj;
 
-	if (!(ret = rz_list_newf(free))) {
+	if (!(ret = rz_list_newf((RzListFree)rz_bin_section_free))) {
 		return NULL;
-	}
-
-	/* TODO: Can't remove the memories from this section until get_vaddr is
-	** implemented correctly, currently it is never called!?!? Is it a
-	** relic? */
-	rz_list_foreach (obj->streams.memories, it, memory) {
-		if (!(ptr = RZ_NEW0(RzBinSection))) {
-			return ret;
-		}
-
-		ptr->name = strdup("Memory_Section");
-		ptr->paddr = (memory->memory).rva;
-		ptr->size = (memory->memory).data_size;
-		ptr->vaddr = memory->start_of_memory_range;
-		ptr->vsize = (memory->memory).data_size;
-		ptr->add = true;
-		ptr->has_strings = false;
-
-		ptr->perm = rz_bin_mdmp_get_perm(obj, ptr->vaddr);
-
-		rz_list_append(ret, ptr);
-	}
-
-	index = obj->streams.memories64.base_rva;
-	rz_list_foreach (obj->streams.memories64.memories, it, memory64) {
-		if (!(ptr = RZ_NEW0(RzBinSection))) {
-			return ret;
-		}
-
-		ptr->name = strdup("Memory_Section");
-		ptr->paddr = index;
-		ptr->size = memory64->data_size;
-		ptr->vaddr = memory64->start_of_memory_range;
-		ptr->vsize = memory64->data_size;
-		ptr->add = true;
-		ptr->has_strings = false;
-
-		ptr->perm = rz_bin_mdmp_get_perm(obj, ptr->vaddr);
-
-		rz_list_append(ret, ptr);
-
-		index += memory64->data_size;
 	}
 
 	// XXX: Never add here as they are covered above
@@ -269,7 +267,6 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->vsize = module->size_of_image;
 		ptr->paddr = rz_bin_mdmp_get_paddr(obj, ptr->vaddr);
 		ptr->size = module->size_of_image;
-		ptr->add = false;
 		ptr->has_strings = false;
 		/* As this is an encompassing section we will set the RWX to 0 */
 		ptr->perm = 0;
@@ -478,6 +475,7 @@ RzBinPlugin rz_bin_plugin_mdmp = {
 	.check_buffer = &check_buffer,
 	.mem = &mem,
 	.relocs = &relocs,
+	.maps = &maps,
 	.sections = &sections,
 	.symbols = &symbols,
 };

--- a/librz/bin/p/bin_menuet.c
+++ b/librz/bin/p/bin_menuet.c
@@ -131,7 +131,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->paddr = rz_read_ble32(buf + 12, false);
 	ptr->vaddr = ptr->paddr + baddr(bf);
 	ptr->perm = RZ_PERM_RX; // r-x
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 
 	if (MENUET_VERSION(buf)) {
@@ -147,7 +146,6 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->paddr = rz_read_ble32(buf + 40, false);
 		ptr->vaddr = ptr->paddr + baddr(bf);
 		ptr->perm = RZ_PERM_R; // r--
-		ptr->add = true;
 		rz_list_append(ret, ptr);
 	}
 
@@ -213,6 +211,7 @@ RzBinPlugin rz_bin_plugin_menuet = {
 	.check_buffer = &check_buffer,
 	.baddr = &baddr,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.info = &info,
 	.create = &create,

--- a/librz/bin/p/bin_mz.c
+++ b/librz/bin/p/bin_mz.c
@@ -141,6 +141,35 @@ static RzList *entries(RzBinFile *bf) {
 	return res;
 }
 
+static RzList *maps(RzBinFile *bf) {
+	RzList *r = rz_list_newf((RzListFree)rz_bin_map_free);
+	if (!r) {
+		return NULL;
+	}
+	RzList *segs = rz_bin_mz_get_segments(bf->o->bin_obj);
+	if (!segs) {
+		return r;
+	}
+	RzBinSection *seg;
+	RzListIter *it;
+	rz_list_foreach(segs, it, seg) {
+		RzBinMap *map = RZ_NEW0(RzBinMap);
+		if (!map) {
+			goto hcf;
+		}
+		map->name = seg->name ? strdup(seg->name) : NULL;
+		map->paddr = seg->paddr;
+		map->psize = seg->size;
+		map->vaddr = seg->vaddr;
+		map->vsize = seg->vsize;
+		map->perm = seg->perm;
+		rz_list_push(r, map);
+	}
+hcf:
+	rz_list_free(segs);
+	return r;
+}
+
 static RzList *sections(RzBinFile *bf) {
 	return rz_bin_mz_get_segments(bf->o->bin_obj);
 }
@@ -243,6 +272,7 @@ RzBinPlugin rz_bin_plugin_mz = {
 	.check_buffer = &check_buffer,
 	.binsym = &binsym,
 	.entries = &entries,
+	.maps = &maps,
 	.sections = &sections,
 	.info = &info,
 	.header = &header,

--- a/librz/bin/p/bin_mz.c
+++ b/librz/bin/p/bin_mz.c
@@ -141,16 +141,6 @@ static RzList *entries(RzBinFile *bf) {
 	return res;
 }
 
-static RzList *maps(RzBinFile *bf) {
-	RzList *segs = rz_bin_mz_get_segments(bf->o->bin_obj);
-	if (!segs) {
-		return NULL;
-	}
-	RzList *r = rz_bin_maps_of_sections(segs);
-	rz_list_free(segs);
-	return r;
-}
-
 static RzList *sections(RzBinFile *bf) {
 	return rz_bin_mz_get_segments(bf->o->bin_obj);
 }
@@ -253,7 +243,7 @@ RzBinPlugin rz_bin_plugin_mz = {
 	.check_buffer = &check_buffer,
 	.binsym = &binsym,
 	.entries = &entries,
-	.maps = &maps,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.info = &info,
 	.header = &header,

--- a/librz/bin/p/bin_mz.c
+++ b/librz/bin/p/bin_mz.c
@@ -142,30 +142,11 @@ static RzList *entries(RzBinFile *bf) {
 }
 
 static RzList *maps(RzBinFile *bf) {
-	RzList *r = rz_list_newf((RzListFree)rz_bin_map_free);
-	if (!r) {
-		return NULL;
-	}
 	RzList *segs = rz_bin_mz_get_segments(bf->o->bin_obj);
 	if (!segs) {
-		return r;
+		return NULL;
 	}
-	RzBinSection *seg;
-	RzListIter *it;
-	rz_list_foreach(segs, it, seg) {
-		RzBinMap *map = RZ_NEW0(RzBinMap);
-		if (!map) {
-			goto hcf;
-		}
-		map->name = seg->name ? strdup(seg->name) : NULL;
-		map->paddr = seg->paddr;
-		map->psize = seg->size;
-		map->vaddr = seg->vaddr;
-		map->vsize = seg->vsize;
-		map->perm = seg->perm;
-		rz_list_push(r, map);
-	}
-hcf:
+	RzList *r = rz_bin_maps_of_sections(segs);
 	rz_list_free(segs);
 	return r;
 }

--- a/librz/bin/p/bin_nes.c
+++ b/librz/bin/p/bin_nes.c
@@ -105,7 +105,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->vaddr = ROM_START_ADDRESS;
 	ptr->vsize = mirror ? ROM_MIRROR_ADDRESS - ROM_START_ADDRESS : ROM_SIZE; // make sure the ROM zero excess does not overlap the mirror
 	ptr->perm = RZ_PERM_RX;
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 	if (mirror) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
@@ -117,7 +116,6 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->vaddr = ROM_MIRROR_ADDRESS;
 		ptr->vsize = ROM_MIRROR_SIZE;
 		ptr->perm = RZ_PERM_RX;
-		ptr->add = true;
 		rz_list_append(ret, ptr);
 	}
 	return ret;
@@ -230,6 +228,7 @@ RzBinPlugin rz_bin_plugin_nes = {
 	.baddr = &baddr,
 	.check_buffer = &check_buffer,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = sections,
 	.symbols = &symbols,
 	.info = &info,

--- a/librz/bin/p/bin_nin3ds.c
+++ b/librz/bin/p/bin_nin3ds.c
@@ -55,7 +55,6 @@ static RzList *sections(RzBinFile *bf) {
 			sections[i]->paddr = loaded_header.sections[i].offset;
 			sections[i]->vaddr = loaded_header.sections[i].address;
 			sections[i]->perm = rz_str_rwx("rwx");
-			sections[i]->add = true;
 		}
 	}
 
@@ -135,6 +134,7 @@ RzBinPlugin rz_bin_plugin_nin3ds = {
 	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.info = &info,
 };

--- a/librz/bin/p/bin_ninds.c
+++ b/librz/bin/p/bin_ninds.c
@@ -44,7 +44,7 @@ static RzList *sections(RzBinFile *bf) {
 	RzList *ret = NULL;
 	RzBinSection *ptr9 = NULL, *ptr7 = NULL;
 
-	if (!(ret = rz_list_new())) {
+	if (!(ret = rz_list_newf((RzListFree)rz_bin_section_free))) {
 		return NULL;
 	}
 	if (!(ptr9 = RZ_NEW0(RzBinSection))) {
@@ -63,7 +63,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr9->paddr = loaded_header.arm9_rom_offset;
 	ptr9->vaddr = loaded_header.arm9_ram_address;
 	ptr9->perm = rz_str_rwx("rwx");
-	ptr9->add = true;
 	rz_list_append(ret, ptr9);
 
 	ptr7->name = strdup("arm7");
@@ -72,7 +71,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr7->paddr = loaded_header.arm7_rom_offset;
 	ptr7->vaddr = loaded_header.arm7_ram_address;
 	ptr7->perm = rz_str_rwx("rwx");
-	ptr7->add = true;
 	rz_list_append(ret, ptr7);
 
 	return ret;
@@ -136,6 +134,7 @@ RzBinPlugin rz_bin_plugin_ninds = {
 	.baddr = &baddr,
 	.boffset = &boffset,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.info = &info,
 };

--- a/librz/bin/p/bin_ningb.c
+++ b/librz/bin/p/bin_ningb.c
@@ -77,7 +77,6 @@ static RzList *sections(RzBinFile *bf) {
 		section->vaddr = i ? (i * 0x10000 - 0xc000) : 0;
 		section->size = section->vsize = 0x4000;
 		section->perm = rz_str_rwx("rx");
-		section->add = true;
 		rz_list_append(ret, section);
 	}
 	return ret;
@@ -257,6 +256,7 @@ RzBinPlugin rz_bin_plugin_ningb = {
 	.baddr = &baddr,
 	.binsym = &binsym,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.symbols = &symbols,
 	.info = &info,

--- a/librz/bin/p/bin_ningba.c
+++ b/librz/bin/p/bin_ningba.c
@@ -67,7 +67,7 @@ static RzList *sections(RzBinFile *bf) {
 	RzList *ret = NULL;
 	RzBinSection *s = RZ_NEW0(RzBinSection);
 	ut64 sz = rz_buf_size(bf->buf);
-	if (!(ret = rz_list_new())) {
+	if (!(ret = rz_list_newf((RzListFree)rz_bin_section_free))) {
 		free(s);
 		return NULL;
 	}
@@ -77,7 +77,6 @@ static RzList *sections(RzBinFile *bf) {
 	s->size = sz;
 	s->vsize = 0x2000000;
 	s->perm = RZ_PERM_RX;
-	s->add = true;
 
 	rz_list_append(ret, s);
 	return ret;
@@ -91,6 +90,7 @@ RzBinPlugin rz_bin_plugin_ningba = {
 	.check_buffer = &check_buffer,
 	.entries = &entries,
 	.info = &info,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 };
 

--- a/librz/bin/p/bin_ningba.c
+++ b/librz/bin/p/bin_ningba.c
@@ -66,6 +66,9 @@ static RzBinInfo *info(RzBinFile *bf) {
 static RzList *sections(RzBinFile *bf) {
 	RzList *ret = NULL;
 	RzBinSection *s = RZ_NEW0(RzBinSection);
+	if (!s) {
+		return NULL;
+	}
 	ut64 sz = rz_buf_size(bf->buf);
 	if (!(ret = rz_list_newf((RzListFree)rz_bin_section_free))) {
 		free(s);

--- a/librz/bin/p/bin_nro.c
+++ b/librz/bin/p/bin_nro.c
@@ -110,7 +110,7 @@ static RzList *maps(RzBinFile *bf) {
 		map->perm = RZ_PERM_R;
 		rz_list_append(ret, map);
 	} else {
-		eprintf("Invalid SIG0 address\n");
+		RZ_LOG_ERROR("Invalid SIG0 address\n");
 	}
 
 	// add text segment
@@ -185,7 +185,7 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->perm = RZ_PERM_R; // rw-
 		rz_list_append(ret, ptr);
 	} else {
-		eprintf("Invalid MOD0 address\n");
+		RZ_LOG_ERROR("Invalid MOD0 address\n");
 	}
 
 	RzList *mappies = maps(bf);

--- a/librz/bin/p/bin_nso.c
+++ b/librz/bin/p/bin_nso.c
@@ -174,19 +174,59 @@ static Sdb *get_sdb(RzBinFile *bf) {
 	return kv;
 }
 
+static RzList *maps(RzBinFile *bf) {
+	RzBuffer *b = bf->buf;
+	RzList *ret = rz_list_newf((RzListFree)rz_bin_map_free);
+	if (!ret) {
+		return NULL;
+	}
+
+	ut64 ba = baddr(bf);
+
+	RzBinMap *map = RZ_NEW0(RzBinMap);
+	if (!map) {
+		return ret;
+	}
+	map->name = strdup("text");
+	map->paddr = rz_buf_read_le32_at(b, NSO_OFF(text_memoffset));
+	map->vsize = map->psize = rz_buf_read_le32_at(b, NSO_OFF(text_size));
+	map->vaddr = rz_buf_read_le32_at(b, NSO_OFF(text_loc)) + ba;
+	map->perm = RZ_PERM_RX;
+	rz_list_append(ret, map);
+
+	// add ro segment
+	map = RZ_NEW0(RzBinMap);
+	if (!map) {
+		return ret;
+	}
+	map->name = strdup("ro");
+	map->paddr = rz_buf_read_le32_at(b, NSO_OFF(ro_memoffset));
+	map->vsize = map->psize = rz_buf_read_le32_at(b, NSO_OFF(ro_size));
+	map->vaddr = rz_buf_read_le32_at(b, NSO_OFF(ro_loc)) + ba;
+	map->perm = RZ_PERM_R;
+	rz_list_append(ret, map);
+
+	// add data segment
+	map = RZ_NEW0(RzBinMap);
+	if (!map) {
+		return ret;
+	}
+	map->name = strdup("data");
+	map->vsize = map->psize = rz_buf_read_le32_at(b, NSO_OFF(data_size));
+	map->paddr = rz_buf_read_le32_at(b, NSO_OFF(data_memoffset));
+	map->vaddr = rz_buf_read_le32_at(b, NSO_OFF(data_loc)) + ba;
+	map->perm = RZ_PERM_RW;
+	rz_list_append(ret, map);
+	return ret;
+}
+
 static RzList *sections(RzBinFile *bf) {
 	RzList *ret = NULL;
 	RzBinSection *ptr = NULL;
 	RzBuffer *b = bf->buf;
-	if (!bf->o->info) {
+	if (!(ret = rz_list_newf((RzListFree)rz_bin_section_free))) {
 		return NULL;
 	}
-	if (!(ret = rz_list_new())) {
-		return NULL;
-	}
-	ret->free = free;
-
-	ut64 ba = baddr(bf);
 
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
@@ -197,48 +237,17 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->paddr = 0;
 	ptr->vaddr = 0;
 	ptr->perm = RZ_PERM_R;
-	ptr->add = false;
 	rz_list_append(ret, ptr);
 
-	// add text segment
-	if (!(ptr = RZ_NEW0(RzBinSection))) {
-		return ret;
+	RzList *mappies = maps(bf);
+	if (mappies) {
+		RzList *msecs = rz_bin_sections_of_maps(mappies);
+		if (msecs) {
+			rz_list_join(ret, msecs);
+			rz_list_free(msecs);
+		}
+		rz_list_free(mappies);
 	}
-	ptr->name = strdup("text");
-	ptr->vsize = rz_buf_read_le32_at(b, NSO_OFF(text_size));
-	ptr->size = ptr->vsize;
-	ptr->paddr = rz_buf_read_le32_at(b, NSO_OFF(text_memoffset));
-	ptr->vaddr = rz_buf_read_le32_at(b, NSO_OFF(text_loc)) + ba;
-	ptr->perm = RZ_PERM_RX; // r-x
-	ptr->add = true;
-	rz_list_append(ret, ptr);
-
-	// add ro segment
-	if (!(ptr = RZ_NEW0(RzBinSection))) {
-		return ret;
-	}
-	ptr->name = strdup("ro");
-	ptr->vsize = rz_buf_read_le32_at(b, NSO_OFF(ro_size));
-	ptr->size = ptr->vsize;
-	ptr->paddr = rz_buf_read_le32_at(b, NSO_OFF(ro_memoffset));
-	ptr->vaddr = rz_buf_read_le32_at(b, NSO_OFF(ro_loc)) + ba;
-	ptr->perm = RZ_PERM_R; // r--
-	ptr->add = true;
-	rz_list_append(ret, ptr);
-
-	// add data segment
-	if (!(ptr = RZ_NEW0(RzBinSection))) {
-		return ret;
-	}
-	ptr->name = strdup("data");
-	ptr->vsize = rz_buf_read_le32_at(b, NSO_OFF(data_size));
-	ptr->size = ptr->vsize;
-	ptr->paddr = rz_buf_read_le32_at(b, NSO_OFF(data_memoffset));
-	ptr->vaddr = rz_buf_read_le32_at(b, NSO_OFF(data_loc)) + ba;
-	ptr->perm = RZ_PERM_RW;
-	ptr->add = true;
-	eprintf("BSS Size 0x%08" PFMT64x "\n", (ut64)rz_buf_read_le32_at(bf->buf, NSO_OFF(bss_size)));
-	rz_list_append(ret, ptr);
 	return ret;
 }
 
@@ -283,6 +292,7 @@ RzBinPlugin rz_bin_plugin_nso = {
 	.baddr = &baddr,
 	.binsym = &binsym,
 	.entries = &entries,
+	.maps = &maps,
 	.sections = &sections,
 	.get_sdb = &get_sdb,
 	.info = &info,

--- a/librz/bin/p/bin_omf.c
+++ b/librz/bin/p/bin_omf.c
@@ -165,6 +165,7 @@ RzBinPlugin rz_bin_plugin_omf = {
 	.check_buffer = &check_buffer,
 	.baddr = &baddr,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.symbols = &symbols,
 	.info = &info,

--- a/librz/bin/p/bin_p9.c
+++ b/librz/bin/p/bin_p9.c
@@ -71,7 +71,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->paddr = 8 * 4;
 	ptr->vaddr = ptr->paddr;
 	ptr->perm = RZ_PERM_RX; // r-x
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 	// add data segment
 	datasize = rz_buf_read_le32_at(bf->buf, 8);
@@ -85,7 +84,6 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->paddr = textsize + (8 * 4);
 		ptr->vaddr = ptr->paddr;
 		ptr->perm = RZ_PERM_RW;
-		ptr->add = true;
 		rz_list_append(ret, ptr);
 	}
 	// ignore bss or what
@@ -101,7 +99,6 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->paddr = datasize + textsize + (8 * 4);
 		ptr->vaddr = ptr->paddr;
 		ptr->perm = RZ_PERM_R; // r--
-		ptr->add = true;
 		rz_list_append(ret, ptr);
 	}
 	// add spsz segment
@@ -116,7 +113,6 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->paddr = symssize + datasize + textsize + (8 * 4);
 		ptr->vaddr = ptr->paddr;
 		ptr->perm = RZ_PERM_R; // r--
-		ptr->add = true;
 		rz_list_append(ret, ptr);
 	}
 	// add pcsz segment
@@ -131,7 +127,6 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->paddr = spszsize + symssize + datasize + textsize + (8 * 4);
 		ptr->vaddr = ptr->paddr;
 		ptr->perm = RZ_PERM_R; // r--
-		ptr->add = true;
 		rz_list_append(ret, ptr);
 	}
 	return ret;
@@ -230,6 +225,7 @@ RzBinPlugin rz_bin_plugin_p9 = {
 	.baddr = &baddr,
 	.binsym = &binsym,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.symbols = &symbols,
 	.imports = &imports,

--- a/librz/bin/p/bin_pe.c
+++ b/librz/bin/p/bin_pe.c
@@ -464,6 +464,7 @@ RzBinPlugin rz_bin_plugin_pe = {
 	.baddr = &baddr,
 	.binsym = &binsym,
 	.entries = &entries,
+	.maps = &maps,
 	.sections = &sections,
 	.signature = &signature,
 	.symbols = &symbols,

--- a/librz/bin/p/bin_pe.inc
+++ b/librz/bin/p/bin_pe.inc
@@ -121,6 +121,64 @@ static RzList *entries(RzBinFile *bf) {
 	return ret;
 }
 
+static ut32 perm_of_section_perm(ut64 perm) {
+	ut32 r = 0;
+	if (RZ_BIN_PE_SCN_IS_EXECUTABLE(perm)) {
+		r |= RZ_PERM_X;
+		r |= RZ_PERM_R; // implicit
+	}
+	if (RZ_BIN_PE_SCN_IS_WRITABLE(perm)) {
+		r |= RZ_PERM_W;
+	}
+	if (RZ_BIN_PE_SCN_IS_READABLE(perm)) {
+		r |= RZ_PERM_R;
+	}
+	if (RZ_BIN_PE_SCN_IS_SHAREABLE(perm)) {
+		r |= RZ_PERM_SHAR;
+	}
+	return r;
+}
+
+static RzList *maps(RzBinFile *bf) {
+	struct PE_(rz_bin_pe_obj_t) *bin = (struct PE_(rz_bin_pe_obj_t) *)bf->o->bin_obj;
+	struct rz_bin_pe_section_t *sections = NULL;
+	if (!bin || !(sections = bin->sections)) {
+		return NULL;
+	}
+	RzList *ret = rz_list_newf((RzListFree)rz_bin_map_free);
+	if (!ret) {
+		return NULL;
+	}
+	ut64 ba = baddr(bf);
+	PE_(rz_bin_pe_check_sections)
+	(bin, &sections);
+	for (size_t i = 0; !sections[i].last; i++) {
+		RzBinMap *map = RZ_NEW0(RzBinMap);
+		if (!map) {
+			break;
+		}
+		map->paddr = sections[i].paddr;
+		map->name = strdup(sections[i].name);
+		map->psize = sections[i].size;
+		if (map->psize > bin->size) {
+			if (sections[i].vsize < bin->size) {
+				map->psize = sections[i].vsize;
+			} else {
+				//hack give it page size
+				map->psize = 4096;
+			}
+		}
+		map->vsize = sections[i].vsize;
+		if (!map->vsize && map->psize) {
+			map->vsize = map->psize;
+		}
+		map->vaddr = sections[i].vaddr + ba;
+		map->perm = perm_of_section_perm(sections[i].perm);
+		rz_list_append(ret, map);
+	}
+	return ret;
+}
+
 static RzList *sections(RzBinFile *bf) {
 	RzList *ret = NULL;
 	RzBinSection *ptr = NULL;
@@ -141,44 +199,13 @@ static RzList *sections(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
 			break;
 		}
-		if (sections[i].name[0]) {
-			ptr->name = strdup((char *)sections[i].name);
-		} else {
-			ptr->name = strdup("");
-		}
+		ptr->name = strdup(sections[i].name);
 		ptr->size = sections[i].size;
-		if (ptr->size > bin->size) {
-			if (sections[i].vsize < bin->size) {
-				ptr->size = sections[i].vsize;
-			} else {
-				//hack give it page size
-				ptr->size = 4096;
-			}
-		}
 		ptr->vsize = sections[i].vsize;
-		if (!ptr->vsize && ptr->size) {
-			ptr->vsize = ptr->size;
-		}
 		ptr->flags = sections[i].flags;
 		ptr->paddr = sections[i].paddr;
 		ptr->vaddr = sections[i].vaddr + ba;
-
-		ptr->add = true;
-		ptr->perm = 0;
-		if (RZ_BIN_PE_SCN_IS_EXECUTABLE(sections[i].perm)) {
-			ptr->perm |= RZ_PERM_X;
-			ptr->perm |= RZ_PERM_R; // implicit
-		}
-		if (RZ_BIN_PE_SCN_IS_WRITABLE(sections[i].perm)) {
-			ptr->perm |= RZ_PERM_W;
-		}
-		if (RZ_BIN_PE_SCN_IS_READABLE(sections[i].perm)) {
-			ptr->perm |= RZ_PERM_R;
-		}
-		// this is causing may tests to fail because rx != srx
-		if (RZ_BIN_PE_SCN_IS_SHAREABLE(sections[i].perm)) {
-			ptr->perm |= RZ_PERM_SHAR;
-		}
+		ptr->perm = perm_of_section_perm(sections[i].perm);
 		if ((ptr->perm & RZ_PERM_RW) && !(ptr->perm & RZ_PERM_X) && ptr->size > 0) {
 			if (!strcmp(ptr->name, ".rsrc") ||
 				!strcmp(ptr->name, ".data") ||

--- a/librz/bin/p/bin_pe.inc
+++ b/librz/bin/p/bin_pe.inc
@@ -158,7 +158,7 @@ static RzList *maps(RzBinFile *bf) {
 			break;
 		}
 		map->paddr = sections[i].paddr;
-		map->name = strdup(sections[i].name);
+		map->name = strdup((char *)sections[i].name);
 		map->psize = sections[i].size;
 		if (map->psize > bin->size) {
 			if (sections[i].vsize < bin->size) {
@@ -199,7 +199,7 @@ static RzList *sections(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
 			break;
 		}
-		ptr->name = strdup(sections[i].name);
+		ptr->name = strdup((char *)sections[i].name);
 		ptr->size = sections[i].size;
 		ptr->vsize = sections[i].vsize;
 		ptr->flags = sections[i].flags;

--- a/librz/bin/p/bin_pe64.c
+++ b/librz/bin/p/bin_pe64.c
@@ -494,6 +494,7 @@ RzBinPlugin rz_bin_plugin_pe64 = {
 	.baddr = &baddr,
 	.binsym = &binsym,
 	.entries = &entries,
+	.maps = &maps,
 	.sections = &sections,
 	.symbols = &symbols,
 	.imports = &imports,

--- a/librz/bin/p/bin_pebble.c
+++ b/librz/bin/p/bin_pebble.c
@@ -108,7 +108,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->vsize = ptr->size = pai.num_reloc_entries * sizeof(ut32);
 	ptr->vaddr = ptr->paddr = pai.reloc_list_start;
 	ptr->perm = RZ_PERM_RW;
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 	if (ptr->vaddr < textsize) {
 		textsize = ptr->vaddr;
@@ -122,7 +121,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->vsize = ptr->size = 0;
 	ptr->vaddr = ptr->paddr = pai.sym_table_addr;
 	ptr->perm = RZ_PERM_R;
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 	if (ptr->vaddr < textsize) {
 		textsize = ptr->vaddr;
@@ -135,7 +133,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->vaddr = ptr->paddr = 0x80;
 	ptr->vsize = ptr->size = textsize - ptr->paddr;
 	ptr->perm = RZ_PERM_RWX;
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
@@ -145,7 +142,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->vsize = ptr->size = sizeof(PebbleAppInfo);
 	ptr->vaddr = ptr->paddr = 0;
 	ptr->perm = RZ_PERM_R;
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 
 	return ret;
@@ -194,6 +190,7 @@ RzBinPlugin rz_bin_plugin_pebble = {
 	.check_buffer = &check_buffer,
 	.baddr = &baddr,
 	.entries = entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = sections,
 	.strings = &strings,
 	.info = &info,

--- a/librz/bin/p/bin_prg.c
+++ b/librz/bin/p/bin_prg.c
@@ -52,7 +52,6 @@ static RzList *sections(RzBinFile *bf) {
 	section->vaddr = baddr(bf);
 	section->vsize = sz - 2;
 	section->perm = RZ_PERM_RWX;
-	section->add = true;
 	rz_list_append(ret, section);
 	return ret;
 }
@@ -80,6 +79,7 @@ RzBinPlugin rz_bin_plugin_prg = {
 	.baddr = baddr,
 	.check_buffer = check_buffer,
 	.entries = entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = sections,
 	.info = info,
 };

--- a/librz/bin/p/bin_psxexe.c
+++ b/librz/bin/p/bin_psxexe.c
@@ -74,7 +74,6 @@ static RzList *sections(RzBinFile *bf) {
 	sect->vaddr = psxheader.t_addr;
 	sect->vsize = psxheader.t_size;
 	sect->perm = RZ_PERM_RX;
-	sect->add = true;
 	sect->has_strings = true;
 
 	rz_list_append(ret, sect);
@@ -121,6 +120,7 @@ RzBinPlugin rz_bin_plugin_psxexe = {
 	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.info = &info,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.entries = &entries,
 	.strings = &strings,

--- a/librz/bin/p/bin_sfc.c
+++ b/librz/bin/p/bin_sfc.c
@@ -92,7 +92,6 @@ static void addrom(RzList *ret, const char *name, int i, ut64 paddr, ut64 vaddr,
 	ptr->vaddr = vaddr;
 	ptr->size = ptr->vsize = size;
 	ptr->perm = RZ_PERM_RX;
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 }
 
@@ -280,6 +279,7 @@ RzBinPlugin rz_bin_plugin_sfc = {
 	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = sections,
 	.symbols = &symbols,
 	.info = &info,

--- a/librz/bin/p/bin_smd.c
+++ b/librz/bin/p/bin_smd.c
@@ -265,7 +265,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->paddr = ptr->vaddr = 0;
 	ptr->size = ptr->vsize = 0x100;
 	ptr->perm = RZ_PERM_R;
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
@@ -275,7 +274,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->paddr = ptr->vaddr = 0x100;
 	ptr->size = ptr->vsize = sizeof(SMD_Header);
 	ptr->perm = RZ_PERM_R;
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
@@ -291,7 +289,6 @@ static RzList *sections(RzBinFile *bf) {
 	}
 	ptr->size = ptr->vsize = rz_buf_size(bf->buf) - ptr->paddr;
 	ptr->perm = RZ_PERM_RX;
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 	return ret;
 }
@@ -326,6 +323,7 @@ RzBinPlugin rz_bin_plugin_smd = {
 	.check_buffer = &check_buffer,
 	.baddr = &baddr,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.symbols = &symbols,
 	.info = &info,

--- a/librz/bin/p/bin_spc700.c
+++ b/librz/bin/p/bin_spc700.c
@@ -62,7 +62,6 @@ static RzList *sections(RzBinFile *bf) {
 	ptr->vaddr = 0x0;
 	ptr->vsize = RAM_SIZE;
 	ptr->perm = RZ_PERM_R;
-	ptr->add = true;
 	rz_list_append(ret, ptr);
 	return ret;
 }
@@ -87,6 +86,7 @@ RzBinPlugin rz_bin_plugin_spc700 = {
 	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.info = &info,
 };

--- a/librz/bin/p/bin_symbols.c
+++ b/librz/bin/p/bin_symbols.c
@@ -132,7 +132,6 @@ static RzBinSection *bin_section_from_section(RzCoreSymCacheElementSection *sect
 	s->vsize = s->size;
 	s->paddr = sect->paddr;
 	s->vaddr = sect->vaddr;
-	s->add = true;
 	s->perm = strstr(s->name, "TEXT") ? 5 : 4;
 	s->is_segment = false;
 	return s;
@@ -151,7 +150,6 @@ static RzBinSection *bin_section_from_segment(RzCoreSymCacheElementSegment *seg)
 	s->vsize = seg->vsize;
 	s->paddr = seg->paddr;
 	s->vaddr = seg->vaddr;
-	s->add = true;
 	s->perm = strstr(s->name, "TEXT") ? 5 : 4;
 	s->is_segment = true;
 	return s;
@@ -465,6 +463,7 @@ RzBinPlugin rz_bin_plugin_symbols = {
 	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.symbols = &symbols,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.size = &size,
 	.baddr = &baddr,

--- a/librz/bin/p/bin_te.c
+++ b/librz/bin/p/bin_te.c
@@ -95,7 +95,6 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->paddr = sections[i].paddr;
 		ptr->vaddr = sections[i].vaddr;
 		ptr->perm = 0;
-		ptr->add = true;
 		if (RZ_BIN_TE_SCN_IS_EXECUTABLE(sections[i].flags)) {
 			ptr->perm |= RZ_PERM_X;
 		}
@@ -161,6 +160,7 @@ RzBinPlugin rz_bin_plugin_te = {
 	.baddr = &baddr,
 	.binsym = &binsym,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.info = &info,
 	.minstrlen = 4,

--- a/librz/bin/p/bin_vsf.c
+++ b/librz/bin/p/bin_vsf.c
@@ -150,7 +150,7 @@ static RzList *sections(RzBinFile *bf) {
 		return NULL;
 	}
 	const int m_idx = vsf_obj->machine_idx;
-	// Radare doesn't support BANK switching.
+	// Rizin doesn't support BANK switching.
 	// But by adding the ROM sections first, and then the RAM
 	// it kind of simulate bank switching since users can remove existing sections
 	// and the RAM section won't overwrite the ROM since it was added last.
@@ -167,7 +167,6 @@ static RzList *sections(RzBinFile *bf) {
 			ptr->vaddr = 0xa000;
 			ptr->vsize = 1024 * 8; // BASIC size (8k)
 			ptr->perm = RZ_PERM_RX;
-			ptr->add = true;
 			rz_list_append(ret, ptr);
 
 			// KERNAL (0xe000 - 0xffff)
@@ -180,7 +179,6 @@ static RzList *sections(RzBinFile *bf) {
 			ptr->vaddr = 0xe000;
 			ptr->vsize = 1024 * 8; // KERNAL size (8k)
 			ptr->perm = RZ_PERM_RX;
-			ptr->add = true;
 			rz_list_append(ret, ptr);
 
 			// CHARGEN section ignored
@@ -196,7 +194,6 @@ static RzList *sections(RzBinFile *bf) {
 			ptr->vaddr = 0x4000;
 			ptr->vsize = 1024 * 28; // BASIC size (28k)
 			ptr->perm = RZ_PERM_RX;
-			ptr->add = true;
 			rz_list_append(ret, ptr);
 
 			// MONITOR (0xb000 - 0xbfff)
@@ -210,7 +207,6 @@ static RzList *sections(RzBinFile *bf) {
 			ptr->vaddr = 0xb000;
 			ptr->vsize = 1024 * 4; // BASIC size (4k)
 			ptr->perm = RZ_PERM_RX;
-			ptr->add = true;
 			rz_list_append(ret, ptr);
 
 			// EDITOR (0xc000 - 0xcfff)
@@ -223,7 +219,6 @@ static RzList *sections(RzBinFile *bf) {
 			ptr->vaddr = 0xc000;
 			ptr->vsize = 1024 * 4; // BASIC size (4k)
 			ptr->perm = RZ_PERM_RX;
-			ptr->add = true;
 			rz_list_append(ret, ptr);
 
 			// KERNAL (0xe000 - 0xffff)
@@ -236,7 +231,6 @@ static RzList *sections(RzBinFile *bf) {
 			ptr->vaddr = 0xe000;
 			ptr->vsize = 1024 * 8; // KERNAL size (8k)
 			ptr->perm = RZ_PERM_RX;
-			ptr->add = true;
 			rz_list_append(ret, ptr);
 
 			// CHARGEN section ignored
@@ -257,7 +251,6 @@ static RzList *sections(RzBinFile *bf) {
 			ptr->vaddr = 0x0;
 			ptr->vsize = size;
 			ptr->perm = RZ_PERM_RWX;
-			ptr->add = true;
 			rz_list_append(ret, ptr);
 		} else {
 			// RAM C128 (0x0000 - 0xffff): Bank 0
@@ -274,7 +267,6 @@ static RzList *sections(RzBinFile *bf) {
 			ptr->vaddr = 0x0;
 			ptr->vsize = size;
 			ptr->perm = RZ_PERM_RWX;
-			ptr->add = true;
 			rz_list_append(ret, ptr);
 
 			if (!(ptr = RZ_NEW0(RzBinSection))) {
@@ -286,7 +278,6 @@ static RzList *sections(RzBinFile *bf) {
 			ptr->vaddr = 0x0;
 			ptr->vsize = size;
 			ptr->perm = RZ_PERM_RWX;
-			ptr->add = true;
 			rz_list_append(ret, ptr);
 		}
 	}
@@ -549,6 +540,7 @@ RzBinPlugin rz_bin_plugin_vsf = {
 	.load_buffer = &load_buffer,
 	.check_buffer = &check_buffer,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = sections,
 	.symbols = &symbols,
 	.info = &info,

--- a/librz/bin/p/bin_wasm.c
+++ b/librz/bin/p/bin_wasm.c
@@ -112,7 +112,6 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->vsize = sec->payload_len;
 		ptr->vaddr = sec->offset;
 		ptr->paddr = sec->offset;
-		ptr->add = true;
 		// TODO permissions
 		ptr->perm = 0;
 		rz_list_append(ret, ptr);
@@ -336,6 +335,7 @@ RzBinPlugin rz_bin_plugin_wasm = {
 	.baddr = &baddr,
 	.binsym = &binsym,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.symbols = &symbols,
 	.imports = &imports,

--- a/librz/bin/p/bin_xbe.c
+++ b/librz/bin/p/bin_xbe.c
@@ -144,7 +144,6 @@ static RzList *sections(RzBinFile *bf) {
 		item->vaddr = sect[i].vaddr;
 		item->size = sect[i].size;
 		item->vsize = sect[i].vsize;
-		item->add = true;
 
 		item->perm = RZ_PERM_R;
 		if (sect[i].flags & SECT_FLAG_X) {
@@ -364,6 +363,7 @@ RzBinPlugin rz_bin_plugin_xbe = {
 	.baddr = &baddr,
 	.binsym = &binsym,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.symbols = &symbols,
 	.info = &info,

--- a/librz/bin/p/bin_xnu_kernelcache.c
+++ b/librz/bin/p/bin_xnu_kernelcache.c
@@ -1019,11 +1019,50 @@ static bool check_buffer(RzBuffer *b) {
 	return false;
 }
 
+static RzList *maps(RzBinFile *bf) {
+	RzBinObject *obj = bf ? bf->o : NULL;
+	if (!obj || !obj->bin_obj) {
+		return NULL;
+	}
+	RzList *ret = rz_list_newf((RzListFree)rz_bin_map_free);
+	if (!ret) {
+		return NULL;
+	}
+
+	RKernelCacheObj *kobj = (RKernelCacheObj *)obj->bin_obj;
+	ensure_kexts_initialized(kobj);
+
+	int nsegs = RZ_MIN(kobj->mach0->nsegs, 128);
+	int i;
+	for (i = 0; i < nsegs; i++) {
+		RzBinMap *map = RZ_NEW0(RzBinMap);
+		if (!map) {
+			break;
+		}
+		char segname[17];
+		struct MACH0_(segment_command) *seg = &kobj->mach0->segs[i];
+		rz_str_ncpy(segname, seg->segname, 17);
+		rz_str_filter(segname, -1);
+		map->name = rz_str_newf("%d.%s", i, segname);
+		map->paddr = seg->fileoff + bf->o->boffset;
+		map->psize = seg->vmsize;
+		map->vsize = seg->vmsize;
+		map->vaddr = seg->vmaddr;
+		if (!map->vaddr) {
+			map->vaddr = map->paddr;
+		}
+		map->perm = prot2perm(seg->initprot);
+		rz_list_append(ret, map);
+	}
+
+	return ret;
+}
+
 static RzList *sections(RzBinFile *bf) {
 	RzList *ret = NULL;
 	RzBinObject *obj = bf ? bf->o : NULL;
 
-	if (!obj || !obj->bin_obj || !(ret = rz_list_newf((RzListFree)free))) {
+	if (!obj || !obj->bin_obj || !(ret = rz_list_newf((RzListFree)rz_bin_section_free))) {
 		return NULL;
 	}
 
@@ -1068,7 +1107,6 @@ static RzList *sections(RzBinFile *bf) {
 		ptr->vsize = seg->vmsize;
 		ptr->paddr = seg->fileoff + bf->o->boffset;
 		ptr->vaddr = seg->vmaddr;
-		ptr->add = true;
 		ptr->is_segment = true;
 		if (!ptr->vaddr) {
 			ptr->vaddr = ptr->paddr;
@@ -2229,6 +2267,7 @@ RzBinPlugin rz_bin_plugin_xnu_kernelcache = {
 	.load_buffer = &load_buffer,
 	.entries = &entries,
 	.baddr = &baddr,
+	.maps = &maps,
 	.symbols = &symbols,
 	.sections = &sections,
 	.check_buffer = &check_buffer,

--- a/librz/bin/p/bin_z64.c
+++ b/librz/bin/p/bin_z64.c
@@ -119,7 +119,6 @@ static RzList *sections(RzBinFile *bf) {
 	text->paddr = N64_ROM_START;
 	text->vaddr = baddr(bf);
 	text->perm = RZ_PERM_RX;
-	text->add = true;
 	rz_list_append(ret, text);
 	return ret;
 }
@@ -157,6 +156,7 @@ RzBinPlugin rz_bin_plugin_z64 = {
 	.baddr = baddr,
 	.boffset = &boffset,
 	.entries = &entries,
+	.maps = &rz_bin_maps_of_file_sections,
 	.sections = &sections,
 	.info = &info
 };

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -354,6 +354,9 @@ RZ_API bool rz_core_bin_apply_info(RzCore *r, RzBinFile *binfile, ut32 mask) {
 	if (mask & RZ_CORE_BIN_ACC_ENTRIES) {
 		rz_core_bin_apply_entry(r, binfile, va);
 	}
+	if (mask & RZ_CORE_BIN_ACC_MAPS) {
+		rz_core_bin_apply_maps(r, binfile, va);
+	}
 	if (mask & RZ_CORE_BIN_ACC_SECTIONS) {
 		rz_core_bin_apply_sections(r, binfile, va);
 	}
@@ -696,7 +699,7 @@ static void add_map(RzCore *core, RzBinMap *map, ut64 addr, int fd) {
 	}
 
 	// then we map the part of the section that comes from the physical file
-	char *map_name = map->name ? strdup(map->name) : rz_str_newf("fmap.%d", fd);
+	char *map_name = map->name ? rz_str_newf("fmap.%s", map->name) : rz_str_newf("fmap.%d", fd);
 	if (!map_name) {
 		return;
 	}
@@ -746,6 +749,7 @@ RZ_API bool rz_core_bin_apply_maps(RzCore *core, RzBinFile *binfile, bool va) {
 		add_map(core, map, addr, binfile->fd);
 	}
 	rz_io_update(core->io);
+	return true;
 }
 
 /**

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -740,7 +740,7 @@ RZ_API bool rz_core_bin_apply_maps(RzCore *core, RzBinFile *binfile, bool va) {
 	RzListIter *it;
 	RzBinMap *map;
 	// reverse because of the way io handles maps
-	rz_list_foreach_prev (maps, it, map) {
+	rz_list_foreach_prev(maps, it, map) {
 		int va_map = va ? VA_TRUE : VA_FALSE;
 		if (va && !(map->perm & RZ_PERM_R)) {
 			va_map = VA_NOREBASE;
@@ -763,7 +763,6 @@ static void section_perms_str(char *dst, int perms) {
 	dst[3] = (perms & RZ_PERM_X) ? 'x' : '-';
 	dst[4] = '\0';
 }
-
 
 RZ_API bool rz_core_bin_apply_sections(RzCore *core, RzBinFile *binfile, bool va) {
 	rz_return_val_if_fail(core && binfile, NULL);

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -672,7 +672,7 @@ static bool io_create_mem_map(RzIO *io, RzBinMap *map, ut64 at) {
 	// update the io map's name to refer to the bin map
 	if (map->name) {
 		free(iomap->name);
-		iomap->name = !map->psize ? strdup(map->name) : rz_str_newf("mmap.%s", map->name);
+		iomap->name = rz_str_newf("mmap.%s", map->name);
 	}
 	return true;
 }

--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -964,7 +964,7 @@ RZ_API bool rz_core_bin_load(RzCore *r, const char *filenameuri, ut64 baddr) {
 					rz_config_set_i(r->config, "io.va", 0);
 				}
 				//workaround to map correctly malloc:// and raw binaries
-				if (rz_io_desc_is_dbg(desc) || (!obj->sections || !va)) {
+				if (rz_io_desc_is_dbg(desc) || (!obj->maps || !va)) {
 					rz_io_map_new(r->io, desc->fd, desc->perm, 0, laddr, rz_io_desc_size(desc));
 				}
 				RzBinInfo *info = obj->info;

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -585,6 +585,7 @@ typedef struct rz_bin_section_t {
 	bool is_data;
 	bool is_segment;
 	char *map_name; ///< name for the io map, only temporary while old RzBinMap has been removed and new does not exist yet
+	bool add;
 } RzBinSection;
 
 typedef struct rz_bin_class_t {
@@ -731,6 +732,7 @@ typedef struct rz_bin_bind_t {
 	ut32 visibility;
 } RzBinBind;
 
+RZ_IPI void rz_bin_map_free(RzBinMap *map);
 RZ_IPI RzBinSection *rz_bin_section_new(const char *name);
 RZ_IPI void rz_bin_section_free(RzBinSection *bs);
 RZ_API void rz_bin_info_free(RzBinInfo *rb);

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -733,7 +733,7 @@ typedef struct rz_bin_bind_t {
 } RzBinBind;
 
 RZ_API void rz_bin_map_free(RzBinMap *map);
-RZ_API RzList *rz_bin_maps_of_sections(RzList /*<RzBinSection>*/ *sections);
+RZ_API RzList *rz_bin_maps_of_file_sections(RzBinFile *binfile);
 RZ_IPI RzBinSection *rz_bin_section_new(const char *name);
 RZ_IPI void rz_bin_section_free(RzBinSection *bs);
 RZ_API void rz_bin_info_free(RzBinInfo *rb);

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -732,7 +732,8 @@ typedef struct rz_bin_bind_t {
 	ut32 visibility;
 } RzBinBind;
 
-RZ_IPI void rz_bin_map_free(RzBinMap *map);
+RZ_API void rz_bin_map_free(RzBinMap *map);
+RZ_API RzList *rz_bin_maps_of_sections(RzList /*<RzBinSection>*/ *sections);
 RZ_IPI RzBinSection *rz_bin_section_new(const char *name);
 RZ_IPI void rz_bin_section_free(RzBinSection *bs);
 RZ_API void rz_bin_info_free(RzBinInfo *rb);

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -734,6 +734,7 @@ typedef struct rz_bin_bind_t {
 
 RZ_API void rz_bin_map_free(RzBinMap *map);
 RZ_API RzList *rz_bin_maps_of_file_sections(RzBinFile *binfile);
+RZ_API RzList *rz_bin_sections_of_maps(RzList /*<RzBinMap>*/ *maps);
 RZ_IPI RzBinSection *rz_bin_section_new(const char *name);
 RZ_IPI void rz_bin_section_free(RzBinSection *bs);
 RZ_API void rz_bin_info_free(RzBinInfo *rb);

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -564,7 +564,7 @@ typedef struct rz_bin_map_t {
 	ut64 psize; ///< size of the data inside the file
 	ut64 vaddr; ///< address in the destination address space to map to
 	ut64 vsize; ///< size to map in the destination address space. If vsize > psize, excessive bytes are meant to be filled with 0
-	char *name;
+	RZ_NULLABLE char *name;
 	ut32 perm;
 } RzBinMap;
 

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -584,8 +584,6 @@ typedef struct rz_bin_section_t {
 	bool has_strings;
 	bool is_data;
 	bool is_segment;
-	char *map_name; ///< name for the io map, only temporary while old RzBinMap has been removed and new does not exist yet
-	bool add;
 } RzBinSection;
 
 typedef struct rz_bin_class_t {

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -772,7 +772,8 @@ RZ_API void rz_core_recover_vars(RzCore *core, RzAnalysisFunction *fcn, bool arg
 #define RZ_CORE_BIN_ACC_HASHES           0x10000000
 #define RZ_CORE_BIN_ACC_TRYCATCH         0x20000000
 #define RZ_CORE_BIN_ACC_SECTIONS_MAPPING 0x40000000
-#define RZ_CORE_BIN_ACC_ALL              0x504FFF
+#define RZ_CORE_BIN_ACC_MAPS             0x80000000
+#define RZ_CORE_BIN_ACC_ALL              0x80504FFF
 
 #define RZ_CORE_PRJ_FLAGS           0x0001
 #define RZ_CORE_PRJ_EVAL            0x0002

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -699,6 +699,7 @@ RZ_API bool rz_core_bin_raise(RzCore *core, ut32 bfid);
 
 RZ_API bool rz_core_bin_apply_strings(RzCore *r, RzBinFile *binfile);
 RZ_API bool rz_core_bin_apply_config(RzCore *r, RzBinFile *binfile);
+RZ_API bool rz_core_bin_apply_maps(RzCore *core, RzBinFile *binfile, bool va);
 RZ_API bool rz_core_bin_apply_main(RzCore *r, RzBinFile *binfile, bool va);
 RZ_API bool rz_core_bin_apply_dwarf(RzCore *core, RzBinFile *binfile);
 RZ_API bool rz_core_bin_apply_entry(RzCore *core, RzBinFile *binfile, bool va);

--- a/librz/include/rz_io.h
+++ b/librz/include/rz_io.h
@@ -152,7 +152,7 @@ typedef struct rz_io_map_t {
 	ut32 id;
 	RzInterval itv;
 	ut64 delta; // paddr = itv.addr + delta
-	char *name;
+	RZ_NULLABLE char *name;
 } RzIOMap;
 
 typedef struct rz_io_cache_t {

--- a/test/db/formats/coff
+++ b/test/db/formats/coff
@@ -95,14 +95,14 @@ pd 2
 EOF
 EXPECT=<<EOF
  9 fd: 3 +0x0000017c 0x00000000 - 0x000000ee --- fmap..drectve
- 8 fd: 3 +0x0000026b 0x000000f0 - 0x00000b9f r-- fmap..debug_S
- 7 fd: 3 +0x00000d1b 0x00000ba0 - 0x00000c13 r-- fmap..debug_T
- 6 fd: 3 +0x00000d8f 0x00000c20 - 0x00000c4c r-x fmap..text_mn
- 5 fd: 3 +0x00000dbc 0x00000c50 - 0x00000d23 r-- fmap..debug_S_1
- 4 fd: 3 +0x00000ec2 0x00000d30 - 0x00000d59 r-x fmap..text_mn_1
- 3 fd: 3 +0x00000eec 0x00000d60 - 0x00000e33 r-- fmap..debug_S_2
- 2 fd: 3 +0x00000ff2 0x00000e40 - 0x00000e43 r-- fmap..rtc_IMZ
- 1 fd: 3 +0x00001000 0x00000e50 - 0x00000e53 r-- fmap..rtc_TMZ
+ 8 fd: 3 +0x0000026b 0x000000f0 - 0x00000b9f r-- fmap..debug$S
+ 7 fd: 3 +0x00000d1b 0x00000ba0 - 0x00000c13 r-- fmap..debug$T
+ 6 fd: 3 +0x00000d8f 0x00000c20 - 0x00000c4c r-x fmap..text$mn
+ 5 fd: 3 +0x00000dbc 0x00000c50 - 0x00000d23 r-- fmap..debug$S
+ 4 fd: 3 +0x00000ec2 0x00000d30 - 0x00000d59 r-x fmap..text$mn
+ 3 fd: 3 +0x00000eec 0x00000d60 - 0x00000e33 r-- fmap..debug$S
+ 2 fd: 3 +0x00000ff2 0x00000e40 - 0x00000e43 r-- fmap..rtc$IMZ
+ 1 fd: 3 +0x00001000 0x00000e50 - 0x00000e53 r-- fmap..rtc$TMZ
 [Sections]
 
 nth paddr        size vaddr       vsize perm name

--- a/test/db/formats/dex
+++ b/test/db/formats/dex
@@ -151,7 +151,6 @@ CMDS=f
 EXPECT=<<EOF
 0x00000000 112 section.header
 0x00000000 1460 section.file
-0x00000000 1460 segment.file
 0x00000070 440 section.constpool
 0x00000160 0 sym.LHello.ifield_localVar:I
 0x00000168 0 sym.LHello.sfield_localVar2:I
@@ -167,7 +166,6 @@ EXPECT=<<EOF
 0x000001e8 1 class.LHello
 0x00000208 1 class.LWorld
 0x00000228 308 section.code
-0x00000228 308 segment.code
 0x00000238 20 sym.LHello.method._init___V
 0x00000238 1 method.public.constructor.LHello.LHello.method._init___V
 0x0000025c 1 entry0

--- a/test/db/formats/dmp/dmp
+++ b/test/db/formats/dmp/dmp
@@ -68,11 +68,11 @@ BITMAP_DUMP:
 EOF
 RUN
 
-NAME=: DMP BMP Page sections
+NAME=: DMP BMP Page maps
 FILE=bins/dmp/bmp.dmp
-CMDS=iS~?
+CMDS=om~?
 EXPECT=<<EOF
-21582
+21579
 EOF
 RUN
 

--- a/test/db/formats/elf/core
+++ b/test/db/formats/elf/core
@@ -66,27 +66,27 @@ CMDS=<<EOF
 om
 EOF
 EXPECT=<<EOF
-21 fd: 3 +0x00001000 0x56621000 - 0x56621fff r-- /home/florian/dev/crash/crash-linux-x86
+21 fd: 3 +0x00001000 0x56621000 - 0x56621fff r-- fmap./home/florian/dev/crash/crash-linux-x86
 20 fd: 6 +0x00000000 0x56622000 - 0x56622fff r-- /home/florian/dev/crash/crash-linux-x86
 19 fd: 6 +0x00000000 0x56623000 - 0x56623fff r-- /home/florian/dev/crash/crash-linux-x86
-18 fd: 3 +0x00002000 0x56624000 - 0x56624fff r-- /home/florian/dev/crash/crash-linux-x86
-17 fd: 3 +0x00003000 0x56625000 - 0x56625fff r-- /home/florian/dev/crash/crash-linux-x86
-16 fd: 3 +0x00004000 0xf7d50000 - 0xf7d50fff r-- /usr/lib32/libc-2.33.so
-15 fd: 9 +0x00000000 0xf7d51000 - 0xf7d6cfff r-- mmap.LOAD5
+18 fd: 3 +0x00002000 0x56624000 - 0x56624fff r-- fmap./home/florian/dev/crash/crash-linux-x86
+17 fd: 3 +0x00003000 0x56625000 - 0x56625fff r-- fmap./home/florian/dev/crash/crash-linux-x86
+16 fd: 3 +0x00004000 0xf7d50000 - 0xf7d50fff r-- fmap./usr/lib32/libc-2.33.so
+15 fd: 9 +0x00000000 0xf7d51000 - 0xf7d6cfff r-- mmap./usr/lib32/libc-2.33.so
 14 fd: 8 +0x00000000 0xf7d6d000 - 0xf7ec9fff r-x /usr/lib32/libc-2.33.so
 13 fd: 7 +0x00000000 0xf7eca000 - 0xf7f3bfff r-- /usr/lib32/libc-2.33.so
 12 fd: 6 +0x00000000 0xf7f3c000 - 0xf7f3cfff r-- /usr/lib32/libc-2.33.so
-11 fd: 3 +0x00005000 0xf7f3d000 - 0xf7f3efff r-- /usr/lib32/libc-2.33.so
-10 fd: 3 +0x00007000 0xf7f3f000 - 0xf7f40fff r-- /usr/lib32/libc-2.33.so
+11 fd: 3 +0x00005000 0xf7f3d000 - 0xf7f3efff r-- fmap./usr/lib32/libc-2.33.so
+10 fd: 3 +0x00007000 0xf7f3f000 - 0xf7f40fff r-- fmap./usr/lib32/libc-2.33.so
  9 fd: 3 +0x00009000 0xf7f41000 - 0xf7f49fff r-- fmap.LOAD11
  8 fd: 3 +0x00012000 0xf7f97000 - 0xf7f9afff r-- fmap.LOAD12
  7 fd: 3 +0x00016000 0xf7f9b000 - 0xf7f9cfff r-x fmap.LOAD13
- 6 fd: 3 +0x00018000 0xf7f9d000 - 0xf7f9dfff r-- /usr/lib32/ld-2.33.so
+ 6 fd: 3 +0x00018000 0xf7f9d000 - 0xf7f9dfff r-- fmap./usr/lib32/ld-2.33.so
  5 fd: 5 +0x00000000 0xf7f9e000 - 0xf7fbffff r-x /usr/lib32/ld-2.33.so
  4 fd: 4 +0x00000000 0xf7fc0000 - 0xf7fccfff r-- /usr/lib32/ld-2.33.so
- 3 fd: 3 +0x00019000 0xf7fcd000 - 0xf7fcefff r-- /usr/lib32/ld-2.33.so
- 2 fd: 3 +0x0001b000 0xf7fcf000 - 0xf7fcffff r-- /usr/lib32/ld-2.33.so
- 1 fd: 3 +0x0001c000 0xffb6b000 - 0xffb8bfff r-- [stack]
+ 3 fd: 3 +0x00019000 0xf7fcd000 - 0xf7fcefff r-- fmap./usr/lib32/ld-2.33.so
+ 2 fd: 3 +0x0001b000 0xf7fcf000 - 0xf7fcffff r-- fmap./usr/lib32/ld-2.33.so
+ 1 fd: 3 +0x0001c000 0xffb6b000 - 0xffb8bfff r-- fmap.[stack]
 EOF
 RUN
 
@@ -116,25 +116,25 @@ CMDS=<<EOF
 om
 EOF
 EXPECT=<<EOF
-22 fd: 3 +0x00002000 0x56149dfaf000 - 0x56149dfaffff r-- /home/florian/dev/crash/crash-linux-x86_64
+22 fd: 3 +0x00002000 0x56149dfaf000 - 0x56149dfaffff r-- fmap./home/florian/dev/crash/crash-linux-x86_64
 21 fd: 9 +0x00000000 0x56149dfb0000 - 0x56149dfb0fff r-- /home/florian/dev/crash/crash-linux-x86_64
 20 fd: 9 +0x00000000 0x56149dfb1000 - 0x56149dfb1fff r-- /home/florian/dev/crash/crash-linux-x86_64
-19 fd: 3 +0x00003000 0x56149dfb2000 - 0x56149dfb2fff r-- /home/florian/dev/crash/crash-linux-x86_64
-18 fd: 3 +0x00004000 0x56149dfb3000 - 0x56149dfb3fff r-- /home/florian/dev/crash/crash-linux-x86_64
+19 fd: 3 +0x00003000 0x56149dfb2000 - 0x56149dfb2fff r-- fmap./home/florian/dev/crash/crash-linux-x86_64
+18 fd: 3 +0x00004000 0x56149dfb3000 - 0x56149dfb3fff r-- fmap./home/florian/dev/crash/crash-linux-x86_64
 17 fd: 3 +0x00005000 0x7f582fa2e000 - 0x7f582fa2ffff r-- fmap.LOAD5
-16 fd: 3 +0x00007000 0x7f582fa30000 - 0x7f582fa30fff r-- /usr/lib/libc-2.33.so
-15 fd: 8 +0x00000000 0x7f582fa31000 - 0x7f582fa55fff r-- mmap.LOAD6
+16 fd: 3 +0x00007000 0x7f582fa30000 - 0x7f582fa30fff r-- fmap./usr/lib/libc-2.33.so
+15 fd: 8 +0x00000000 0x7f582fa31000 - 0x7f582fa55fff r-- mmap./usr/lib/libc-2.33.so
 14 fd: 7 +0x00000000 0x7f582fa56000 - 0x7f582fba1fff r-x /usr/lib/libc-2.33.so
 13 fd: 6 +0x00000000 0x7f582fba2000 - 0x7f582fbedfff r-- /usr/lib/libc-2.33.so
-12 fd: 3 +0x00008000 0x7f582fbee000 - 0x7f582fbf0fff r-- /usr/lib/libc-2.33.so
-11 fd: 3 +0x0000b000 0x7f582fbf1000 - 0x7f582fbf3fff r-- /usr/lib/libc-2.33.so
+12 fd: 3 +0x00008000 0x7f582fbee000 - 0x7f582fbf0fff r-- fmap./usr/lib/libc-2.33.so
+11 fd: 3 +0x0000b000 0x7f582fbf1000 - 0x7f582fbf3fff r-- fmap./usr/lib/libc-2.33.so
 10 fd: 3 +0x0000e000 0x7f582fbf4000 - 0x7f582fbfefff r-- fmap.LOAD11
- 9 fd: 3 +0x00019000 0x7f582fc4c000 - 0x7f582fc4cfff r-- /usr/lib/ld-2.33.so
+ 9 fd: 3 +0x00019000 0x7f582fc4c000 - 0x7f582fc4cfff r-- fmap./usr/lib/ld-2.33.so
  8 fd: 5 +0x00000000 0x7f582fc4d000 - 0x7f582fc70fff r-x /usr/lib/ld-2.33.so
  7 fd: 4 +0x00000000 0x7f582fc71000 - 0x7f582fc79fff r-- /usr/lib/ld-2.33.so
- 6 fd: 3 +0x0001a000 0x7f582fc7b000 - 0x7f582fc7cfff r-- /usr/lib/ld-2.33.so
- 5 fd: 3 +0x0001c000 0x7f582fc7d000 - 0x7f582fc7efff r-- /usr/lib/ld-2.33.so
- 4 fd: 3 +0x0001e000 0x7ffc8352d000 - 0x7ffc8354dfff r-- [stack]
+ 6 fd: 3 +0x0001a000 0x7f582fc7b000 - 0x7f582fc7cfff r-- fmap./usr/lib/ld-2.33.so
+ 5 fd: 3 +0x0001c000 0x7f582fc7d000 - 0x7f582fc7efff r-- fmap./usr/lib/ld-2.33.so
+ 4 fd: 3 +0x0001e000 0x7ffc8352d000 - 0x7ffc8354dfff r-- fmap.[stack]
  3 fd: 3 +0x0003f000 0x7ffc83558000 - 0x7ffc8355bfff r-- fmap.LOAD18
  2 fd: 3 +0x00043000 0x7ffc8355c000 - 0x7ffc8355dfff r-x fmap.LOAD19
  1 fd: 3 +0x00045000 0xffffffffff600000 - 0xffffffffff600fff r-x fmap.LOAD20
@@ -174,23 +174,23 @@ CMDS=<<EOF
 om
 EOF
 EXPECT=<<EOF
-17 fd: 3 +0x00001000 0x558ce37000 - 0x558ce37fff r-x /home/alarm/crash/crash-linux-arm64
-16 fd: 3 +0x00002000 0x558ce47000 - 0x558ce47fff r-- /home/alarm/crash/crash-linux-arm64
-15 fd: 3 +0x00003000 0x558ce48000 - 0x558ce48fff r-- /home/alarm/crash/crash-linux-arm64
-14 fd: 3 +0x00004000 0x7f8bd60000 - 0x7f8bd60fff r-x /usr/lib/libc-2.32.so
-13 fd: 6 +0x00000000 0x7f8bd61000 - 0x7f8bebafff r-x mmap.LOAD3
+17 fd: 3 +0x00001000 0x558ce37000 - 0x558ce37fff r-x fmap./home/alarm/crash/crash-linux-arm64
+16 fd: 3 +0x00002000 0x558ce47000 - 0x558ce47fff r-- fmap./home/alarm/crash/crash-linux-arm64
+15 fd: 3 +0x00003000 0x558ce48000 - 0x558ce48fff r-- fmap./home/alarm/crash/crash-linux-arm64
+14 fd: 3 +0x00004000 0x7f8bd60000 - 0x7f8bd60fff r-x fmap./usr/lib/libc-2.32.so
+13 fd: 6 +0x00000000 0x7f8bd61000 - 0x7f8bebafff r-x mmap./usr/lib/libc-2.32.so
 12 fd: 5 +0x00000000 0x7f8bebb000 - 0x7f8becafff r-- /usr/lib/libc-2.32.so
-11 fd: 3 +0x00005000 0x7f8becb000 - 0x7f8becdfff r-- /usr/lib/libc-2.32.so
-10 fd: 3 +0x00008000 0x7f8bece000 - 0x7f8bed0fff r-- /usr/lib/libc-2.32.so
+11 fd: 3 +0x00005000 0x7f8becb000 - 0x7f8becdfff r-- fmap./usr/lib/libc-2.32.so
+10 fd: 3 +0x00008000 0x7f8bece000 - 0x7f8bed0fff r-- fmap./usr/lib/libc-2.32.so
  9 fd: 3 +0x0000b000 0x7f8bed1000 - 0x7f8bed3fff r-- fmap.LOAD7
- 8 fd: 3 +0x0000e000 0x7f8bef8000 - 0x7f8bef8fff r-x /usr/lib/ld-2.32.so
- 7 fd: 4 +0x00000000 0x7f8bef9000 - 0x7f8bf19fff r-x mmap.LOAD8
+ 8 fd: 3 +0x0000e000 0x7f8bef8000 - 0x7f8bef8fff r-x fmap./usr/lib/ld-2.32.so
+ 7 fd: 4 +0x00000000 0x7f8bef9000 - 0x7f8bf19fff r-x mmap./usr/lib/ld-2.32.so
  6 fd: 3 +0x0000f000 0x7f8bf26000 - 0x7f8bf27fff r-- fmap.LOAD9
  5 fd: 3 +0x00011000 0x7f8bf28000 - 0x7f8bf28fff r-- fmap.LOAD10
  4 fd: 3 +0x00012000 0x7f8bf29000 - 0x7f8bf29fff r-x fmap.LOAD11
- 3 fd: 3 +0x00013000 0x7f8bf2a000 - 0x7f8bf2afff r-- /usr/lib/ld-2.32.so
- 2 fd: 3 +0x00014000 0x7f8bf2b000 - 0x7f8bf2cfff r-- /usr/lib/ld-2.32.so
- 1 fd: 3 +0x00016000 0x7ff5e96000 - 0x7ff5eb6fff r-- [stack]
+ 3 fd: 3 +0x00013000 0x7f8bf2a000 - 0x7f8bf2afff r-- fmap./usr/lib/ld-2.32.so
+ 2 fd: 3 +0x00014000 0x7f8bf2b000 - 0x7f8bf2cfff r-- fmap./usr/lib/ld-2.32.so
+ 1 fd: 3 +0x00016000 0x7ff5e96000 - 0x7ff5eb6fff r-- fmap.[stack]
 EOF
 RUN
 
@@ -280,25 +280,25 @@ CMDS=<<EOF
 om
 EOF
 EXPECT=<<EOF
-23 fd: 3 +0x00001000 0x00010000 - 0x00010fff r-x /home/pi/crash/crash-linux-arm32
-22 fd: 3 +0x00002000 0x00020000 - 0x00020fff r-- /home/pi/crash/crash-linux-arm32
-21 fd: 3 +0x00003000 0x00021000 - 0x00021fff r-- /home/pi/crash/crash-linux-arm32
-20 fd: 3 +0x00004000 0x76e49000 - 0x76e49fff r-x /usr/lib/arm-linux-gnueabihf/libc-2.28.so
-19 fd: 8 +0x00000000 0x76e4a000 - 0x76f80fff r-x mmap.LOAD3
+23 fd: 3 +0x00001000 0x00010000 - 0x00010fff r-x fmap./home/pi/crash/crash-linux-arm32
+22 fd: 3 +0x00002000 0x00020000 - 0x00020fff r-- fmap./home/pi/crash/crash-linux-arm32
+21 fd: 3 +0x00003000 0x00021000 - 0x00021fff r-- fmap./home/pi/crash/crash-linux-arm32
+20 fd: 3 +0x00004000 0x76e49000 - 0x76e49fff r-x fmap./usr/lib/arm-linux-gnueabihf/libc-2.28.so
+19 fd: 8 +0x00000000 0x76e4a000 - 0x76f80fff r-x mmap./usr/lib/arm-linux-gnueabihf/libc-2.28.so
 18 fd: 7 +0x00000000 0x76f81000 - 0x76f90fff r-- /usr/lib/arm-linux-gnueabihf/libc-2.28.so
-17 fd: 3 +0x00005000 0x76f91000 - 0x76f92fff r-- /usr/lib/arm-linux-gnueabihf/libc-2.28.so
-16 fd: 3 +0x00007000 0x76f93000 - 0x76f93fff r-- /usr/lib/arm-linux-gnueabihf/libc-2.28.so
+17 fd: 3 +0x00005000 0x76f91000 - 0x76f92fff r-- fmap./usr/lib/arm-linux-gnueabihf/libc-2.28.so
+16 fd: 3 +0x00007000 0x76f93000 - 0x76f93fff r-- fmap./usr/lib/arm-linux-gnueabihf/libc-2.28.so
 15 fd: 3 +0x00008000 0x76f94000 - 0x76f96fff r-- fmap.LOAD7
 14 fd: 6 +0x00000000 0x76f97000 - 0x76f9afff r-x /usr/lib/arm-linux-gnueabihf/libarmmem-v7l.so
 13 fd: 5 +0x00000000 0x76f9b000 - 0x76fa9fff r-- /usr/lib/arm-linux-gnueabihf/libarmmem-v7l.so
-12 fd: 3 +0x0000b000 0x76faa000 - 0x76faafff r-- /usr/lib/arm-linux-gnueabihf/libarmmem-v7l.so
-11 fd: 3 +0x0000c000 0x76fab000 - 0x76fabfff r-- /usr/lib/arm-linux-gnueabihf/libarmmem-v7l.so
-10 fd: 3 +0x0000d000 0x76fac000 - 0x76facfff r-x /usr/lib/arm-linux-gnueabihf/ld-2.28.so
- 9 fd: 4 +0x00000000 0x76fad000 - 0x76fcbfff r-x mmap.LOAD12
+12 fd: 3 +0x0000b000 0x76faa000 - 0x76faafff r-- fmap./usr/lib/arm-linux-gnueabihf/libarmmem-v7l.so
+11 fd: 3 +0x0000c000 0x76fab000 - 0x76fabfff r-- fmap./usr/lib/arm-linux-gnueabihf/libarmmem-v7l.so
+10 fd: 3 +0x0000d000 0x76fac000 - 0x76facfff r-x fmap./usr/lib/arm-linux-gnueabihf/ld-2.28.so
+ 9 fd: 4 +0x00000000 0x76fad000 - 0x76fcbfff r-x mmap./usr/lib/arm-linux-gnueabihf/ld-2.28.so
  8 fd: 3 +0x0000e000 0x76fda000 - 0x76fdbfff r-- fmap.LOAD13
- 7 fd: 3 +0x00010000 0x76fdc000 - 0x76fdcfff r-- /usr/lib/arm-linux-gnueabihf/ld-2.28.so
- 6 fd: 3 +0x00011000 0x76fdd000 - 0x76fddfff r-- /usr/lib/arm-linux-gnueabihf/ld-2.28.so
- 5 fd: 3 +0x00012000 0x7ea6c000 - 0x7ea8cfff r-- [stack]
+ 7 fd: 3 +0x00010000 0x76fdc000 - 0x76fdcfff r-- fmap./usr/lib/arm-linux-gnueabihf/ld-2.28.so
+ 6 fd: 3 +0x00011000 0x76fdd000 - 0x76fddfff r-- fmap./usr/lib/arm-linux-gnueabihf/ld-2.28.so
+ 5 fd: 3 +0x00012000 0x7ea6c000 - 0x7ea8cfff r-- fmap.[stack]
  4 fd: 3 +0x00033000 0x7eb68000 - 0x7eb68fff r-x fmap.LOAD17
  3 fd: 3 +0x00034000 0x7eb69000 - 0x7eb69fff r-- fmap.LOAD18
  2 fd: 3 +0x00035000 0x7eb6a000 - 0x7eb6afff r-x fmap.LOAD19

--- a/test/db/formats/elf/core
+++ b/test/db/formats/elf/core
@@ -67,23 +67,23 @@ om
 EOF
 EXPECT=<<EOF
 21 fd: 3 +0x00001000 0x56621000 - 0x56621fff r-- fmap./home/florian/dev/crash/crash-linux-x86
-20 fd: 6 +0x00000000 0x56622000 - 0x56622fff r-- /home/florian/dev/crash/crash-linux-x86
-19 fd: 6 +0x00000000 0x56623000 - 0x56623fff r-- /home/florian/dev/crash/crash-linux-x86
+20 fd: 6 +0x00000000 0x56622000 - 0x56622fff r-- mmap./home/florian/dev/crash/crash-linux-x86
+19 fd: 6 +0x00000000 0x56623000 - 0x56623fff r-- mmap./home/florian/dev/crash/crash-linux-x86
 18 fd: 3 +0x00002000 0x56624000 - 0x56624fff r-- fmap./home/florian/dev/crash/crash-linux-x86
 17 fd: 3 +0x00003000 0x56625000 - 0x56625fff r-- fmap./home/florian/dev/crash/crash-linux-x86
 16 fd: 3 +0x00004000 0xf7d50000 - 0xf7d50fff r-- fmap./usr/lib32/libc-2.33.so
 15 fd: 9 +0x00000000 0xf7d51000 - 0xf7d6cfff r-- mmap./usr/lib32/libc-2.33.so
-14 fd: 8 +0x00000000 0xf7d6d000 - 0xf7ec9fff r-x /usr/lib32/libc-2.33.so
-13 fd: 7 +0x00000000 0xf7eca000 - 0xf7f3bfff r-- /usr/lib32/libc-2.33.so
-12 fd: 6 +0x00000000 0xf7f3c000 - 0xf7f3cfff r-- /usr/lib32/libc-2.33.so
+14 fd: 8 +0x00000000 0xf7d6d000 - 0xf7ec9fff r-x mmap./usr/lib32/libc-2.33.so
+13 fd: 7 +0x00000000 0xf7eca000 - 0xf7f3bfff r-- mmap./usr/lib32/libc-2.33.so
+12 fd: 6 +0x00000000 0xf7f3c000 - 0xf7f3cfff r-- mmap./usr/lib32/libc-2.33.so
 11 fd: 3 +0x00005000 0xf7f3d000 - 0xf7f3efff r-- fmap./usr/lib32/libc-2.33.so
 10 fd: 3 +0x00007000 0xf7f3f000 - 0xf7f40fff r-- fmap./usr/lib32/libc-2.33.so
  9 fd: 3 +0x00009000 0xf7f41000 - 0xf7f49fff r-- fmap.LOAD11
  8 fd: 3 +0x00012000 0xf7f97000 - 0xf7f9afff r-- fmap.LOAD12
  7 fd: 3 +0x00016000 0xf7f9b000 - 0xf7f9cfff r-x fmap.LOAD13
  6 fd: 3 +0x00018000 0xf7f9d000 - 0xf7f9dfff r-- fmap./usr/lib32/ld-2.33.so
- 5 fd: 5 +0x00000000 0xf7f9e000 - 0xf7fbffff r-x /usr/lib32/ld-2.33.so
- 4 fd: 4 +0x00000000 0xf7fc0000 - 0xf7fccfff r-- /usr/lib32/ld-2.33.so
+ 5 fd: 5 +0x00000000 0xf7f9e000 - 0xf7fbffff r-x mmap./usr/lib32/ld-2.33.so
+ 4 fd: 4 +0x00000000 0xf7fc0000 - 0xf7fccfff r-- mmap./usr/lib32/ld-2.33.so
  3 fd: 3 +0x00019000 0xf7fcd000 - 0xf7fcefff r-- fmap./usr/lib32/ld-2.33.so
  2 fd: 3 +0x0001b000 0xf7fcf000 - 0xf7fcffff r-- fmap./usr/lib32/ld-2.33.so
  1 fd: 3 +0x0001c000 0xffb6b000 - 0xffb8bfff r-- fmap.[stack]
@@ -117,21 +117,21 @@ om
 EOF
 EXPECT=<<EOF
 22 fd: 3 +0x00002000 0x56149dfaf000 - 0x56149dfaffff r-- fmap./home/florian/dev/crash/crash-linux-x86_64
-21 fd: 9 +0x00000000 0x56149dfb0000 - 0x56149dfb0fff r-- /home/florian/dev/crash/crash-linux-x86_64
-20 fd: 9 +0x00000000 0x56149dfb1000 - 0x56149dfb1fff r-- /home/florian/dev/crash/crash-linux-x86_64
+21 fd: 9 +0x00000000 0x56149dfb0000 - 0x56149dfb0fff r-- mmap./home/florian/dev/crash/crash-linux-x86_64
+20 fd: 9 +0x00000000 0x56149dfb1000 - 0x56149dfb1fff r-- mmap./home/florian/dev/crash/crash-linux-x86_64
 19 fd: 3 +0x00003000 0x56149dfb2000 - 0x56149dfb2fff r-- fmap./home/florian/dev/crash/crash-linux-x86_64
 18 fd: 3 +0x00004000 0x56149dfb3000 - 0x56149dfb3fff r-- fmap./home/florian/dev/crash/crash-linux-x86_64
 17 fd: 3 +0x00005000 0x7f582fa2e000 - 0x7f582fa2ffff r-- fmap.LOAD5
 16 fd: 3 +0x00007000 0x7f582fa30000 - 0x7f582fa30fff r-- fmap./usr/lib/libc-2.33.so
 15 fd: 8 +0x00000000 0x7f582fa31000 - 0x7f582fa55fff r-- mmap./usr/lib/libc-2.33.so
-14 fd: 7 +0x00000000 0x7f582fa56000 - 0x7f582fba1fff r-x /usr/lib/libc-2.33.so
-13 fd: 6 +0x00000000 0x7f582fba2000 - 0x7f582fbedfff r-- /usr/lib/libc-2.33.so
+14 fd: 7 +0x00000000 0x7f582fa56000 - 0x7f582fba1fff r-x mmap./usr/lib/libc-2.33.so
+13 fd: 6 +0x00000000 0x7f582fba2000 - 0x7f582fbedfff r-- mmap./usr/lib/libc-2.33.so
 12 fd: 3 +0x00008000 0x7f582fbee000 - 0x7f582fbf0fff r-- fmap./usr/lib/libc-2.33.so
 11 fd: 3 +0x0000b000 0x7f582fbf1000 - 0x7f582fbf3fff r-- fmap./usr/lib/libc-2.33.so
 10 fd: 3 +0x0000e000 0x7f582fbf4000 - 0x7f582fbfefff r-- fmap.LOAD11
  9 fd: 3 +0x00019000 0x7f582fc4c000 - 0x7f582fc4cfff r-- fmap./usr/lib/ld-2.33.so
- 8 fd: 5 +0x00000000 0x7f582fc4d000 - 0x7f582fc70fff r-x /usr/lib/ld-2.33.so
- 7 fd: 4 +0x00000000 0x7f582fc71000 - 0x7f582fc79fff r-- /usr/lib/ld-2.33.so
+ 8 fd: 5 +0x00000000 0x7f582fc4d000 - 0x7f582fc70fff r-x mmap./usr/lib/ld-2.33.so
+ 7 fd: 4 +0x00000000 0x7f582fc71000 - 0x7f582fc79fff r-- mmap./usr/lib/ld-2.33.so
  6 fd: 3 +0x0001a000 0x7f582fc7b000 - 0x7f582fc7cfff r-- fmap./usr/lib/ld-2.33.so
  5 fd: 3 +0x0001c000 0x7f582fc7d000 - 0x7f582fc7efff r-- fmap./usr/lib/ld-2.33.so
  4 fd: 3 +0x0001e000 0x7ffc8352d000 - 0x7ffc8354dfff r-- fmap.[stack]
@@ -179,7 +179,7 @@ EXPECT=<<EOF
 15 fd: 3 +0x00003000 0x558ce48000 - 0x558ce48fff r-- fmap./home/alarm/crash/crash-linux-arm64
 14 fd: 3 +0x00004000 0x7f8bd60000 - 0x7f8bd60fff r-x fmap./usr/lib/libc-2.32.so
 13 fd: 6 +0x00000000 0x7f8bd61000 - 0x7f8bebafff r-x mmap./usr/lib/libc-2.32.so
-12 fd: 5 +0x00000000 0x7f8bebb000 - 0x7f8becafff r-- /usr/lib/libc-2.32.so
+12 fd: 5 +0x00000000 0x7f8bebb000 - 0x7f8becafff r-- mmap./usr/lib/libc-2.32.so
 11 fd: 3 +0x00005000 0x7f8becb000 - 0x7f8becdfff r-- fmap./usr/lib/libc-2.32.so
 10 fd: 3 +0x00008000 0x7f8bece000 - 0x7f8bed0fff r-- fmap./usr/lib/libc-2.32.so
  9 fd: 3 +0x0000b000 0x7f8bed1000 - 0x7f8bed3fff r-- fmap.LOAD7
@@ -285,12 +285,12 @@ EXPECT=<<EOF
 21 fd: 3 +0x00003000 0x00021000 - 0x00021fff r-- fmap./home/pi/crash/crash-linux-arm32
 20 fd: 3 +0x00004000 0x76e49000 - 0x76e49fff r-x fmap./usr/lib/arm-linux-gnueabihf/libc-2.28.so
 19 fd: 8 +0x00000000 0x76e4a000 - 0x76f80fff r-x mmap./usr/lib/arm-linux-gnueabihf/libc-2.28.so
-18 fd: 7 +0x00000000 0x76f81000 - 0x76f90fff r-- /usr/lib/arm-linux-gnueabihf/libc-2.28.so
+18 fd: 7 +0x00000000 0x76f81000 - 0x76f90fff r-- mmap./usr/lib/arm-linux-gnueabihf/libc-2.28.so
 17 fd: 3 +0x00005000 0x76f91000 - 0x76f92fff r-- fmap./usr/lib/arm-linux-gnueabihf/libc-2.28.so
 16 fd: 3 +0x00007000 0x76f93000 - 0x76f93fff r-- fmap./usr/lib/arm-linux-gnueabihf/libc-2.28.so
 15 fd: 3 +0x00008000 0x76f94000 - 0x76f96fff r-- fmap.LOAD7
-14 fd: 6 +0x00000000 0x76f97000 - 0x76f9afff r-x /usr/lib/arm-linux-gnueabihf/libarmmem-v7l.so
-13 fd: 5 +0x00000000 0x76f9b000 - 0x76fa9fff r-- /usr/lib/arm-linux-gnueabihf/libarmmem-v7l.so
+14 fd: 6 +0x00000000 0x76f97000 - 0x76f9afff r-x mmap./usr/lib/arm-linux-gnueabihf/libarmmem-v7l.so
+13 fd: 5 +0x00000000 0x76f9b000 - 0x76fa9fff r-- mmap./usr/lib/arm-linux-gnueabihf/libarmmem-v7l.so
 12 fd: 3 +0x0000b000 0x76faa000 - 0x76faafff r-- fmap./usr/lib/arm-linux-gnueabihf/libarmmem-v7l.so
 11 fd: 3 +0x0000c000 0x76fab000 - 0x76fabfff r-- fmap./usr/lib/arm-linux-gnueabihf/libarmmem-v7l.so
 10 fd: 3 +0x0000d000 0x76fac000 - 0x76facfff r-x fmap./usr/lib/arm-linux-gnueabihf/ld-2.28.so

--- a/test/db/formats/elf/sections
+++ b/test/db/formats/elf/sections
@@ -75,3 +75,21 @@ EXPECT=<<EOF
 ffffffffffffffffffff
 EOF
 RUN
+
+NAME=also map ehdr if ET_REL
+FILE=bins/elf/pngrutil_o
+CMDS=om
+EXPECT=<<EOF
+11 fd: 3 +0x00000034 0x08000034 - 0x080055c7 r-x fmap..text
+10 fd: 3 +0x00007328 0x08007328 - 0x0800852f --x fmap..rel.text
+ 9 fd: 3 +0x000055c8 0x080055c8 - 0x0800642b r-- fmap..rodata
+ 8 fd: 3 +0x00008530 0x08008530 - 0x0800858f --- fmap..rel.rodata
+ 7 fd: 3 +0x0000642c 0x0800642c - 0x08006461 --- fmap..comment
+ 6 fd: 3 +0x00006464 0x08006464 - 0x080068cb r-- fmap..eh_frame
+ 5 fd: 3 +0x00008590 0x08008590 - 0x0800869f --- fmap..rel.eh_frame
+ 4 fd: 3 +0x000086a0 0x080086a0 - 0x08008702 --- fmap..shstrtab
+ 3 fd: 3 +0x000068cc 0x080068cc - 0x08006e5b --- fmap..symtab
+ 2 fd: 3 +0x00006e5c 0x08006e5c - 0x08007325 --- fmap..strtab
+ 1 fd: 3 +0x00000000 0x08000000 - 0x08000033 r-- fmap.ehdr
+EOF
+RUN

--- a/test/db/formats/gba
+++ b/test/db/formats/gba
@@ -1,8 +1,21 @@
-NAME=GBA: 3D - S
+NAME=GBA: 3D - Maps
 FILE=bins/gba/3D.gba
 CMDS=om
 EXPECT=<<EOF
  2 fd: 3 +0x00000000 0x08000000 - 0x080105cb r-x fmap.ROM
  1 fd: 4 +0x00000000 0x080105cc - 0x09ffffff r-x mmap.ROM
+EOF
+RUN
+
+NAME=GBA: 3D - Sections
+FILE=bins/gba/3D.gba
+CMDS=iS
+EXPECT=<<EOF
+[Sections]
+
+nth paddr          size vaddr           vsize perm name
+-------------------------------------------------------
+0   0x00000000  0x105cc 0x08000000  0x2000000 -r-x ROM
+
 EOF
 RUN

--- a/test/db/formats/mdmp
+++ b/test/db/formats/mdmp
@@ -50,41 +50,32 @@ EXPECT=<<EOF
 
 nth paddr           size vaddr             vsize perm name
 ----------------------------------------------------------
-0   0x000043ac     0x648 0x0398f9b8        0x648 -r-- Memory_Section
-1   0x000049f4     0x100 0x77639dea        0x100 -r-- Memory_Section_1
-2   0x00004af4     0x9c8 0x032cf638        0x9c8 -r-- Memory_Section_2
-3   0x000054bc     0x798 0x0367f868        0x798 -r-- Memory_Section_3
-4   0x00005c54    0x2f28 0x000bd0d8       0x2f28 -r-- Memory_Section_4
-5   0x00008b7c      0xf8 0x03a7ff08         0xf8 -r-- Memory_Section_5
-6   0x00008c74     0x100 0x7776ad90        0x100 -r-- Memory_Section_6
-7   0x00008d74     0x100 0x7776bafa        0x100 -r-- Memory_Section_7
-8   0x00008e74     0x100 0x7776c06a        0x100 -r-- Memory_Section_8
-9   0x00000000   0xe3000 0xfffe0000      0xe3000 ---- C:_Windows_System32_calc.exe
-10  0x00000000  0x1aa000 0x77720000     0x1aa000 ---- C:_Windows_System32__tdll.dll
-11  0x00000000  0x11f000 0x77500000     0x11f000 ---- C:_Windows_System32_kernel32.dll
-12  0x00000000   0x6a000 0x7fefd4a0000   0x6a000 ---- C:_Windows_System32_KERNELBASE.dll
-13  0x00000000  0xd8a000 0x7fefeca0000  0xd8a000 ---- C:_Windows_System32_shell32.dll
-14  0x00000000   0x9f000 0x7fefdab0000   0x9f000 ---- C:_Windows_System32_msvcrt.dll
-15  0x00000000   0x71000 0x7fefd890000   0x71000 ---- C:_Windows_System32_shlwapi.dll
-16  0x00000000   0x67000 0x7fefdb50000   0x67000 ---- C:_Windows_System32_gdi32.dll
-17  0x00000000   0xfa000 0x77620000      0xfa000 ---- C:_Windows_System32_user32.dll
-18  0x00000000    0xe000 0x7fefdbc0000    0xe000 ---- C:_Windows_System32_lpk.dll
-19  0x00000000   0xca000 0x7fefe450000   0xca000 ---- C:_Windows_System32_usp10.dll
-20  0x00000000  0x203000 0x7fefea90000  0x203000 ---- C:_Windows_System32_ole32.dll
-21  0x00000000  0x12d000 0x7fefe8d0000  0x12d000 ---- C:_Windows_System32__pcrt4.dll
-22  0x00000000   0xdb000 0x7fefd9d0000   0xdb000 ---- C:_Windows_System32__dvapi32.dll
-23  0x00000000   0x1f000 0x7fefdff0000   0x1f000 ---- C:_Windows_System32_sechost.dll
-24  0x00000000   0xda000 0x7fefe520000   0xda000 ---- C:_Windows_System32_oleaut32.dll
-25  0x00000000   0x56000 0x7fefbb40000   0x56000 ---- C:_Windows_System32_uxtheme.dll
-26  0x00000000   0x3b000 0x7fefa140000   0x3b000 ---- C:_Windows_System32_winmm.dll
-27  0x00000000    0xc000 0x7fefc330000    0xc000 ---- C:_Windows_System32__ersion.dll
-28  0x00000000   0x2e000 0x7fefea00000   0x2e000 ---- C:_Windows_System32_imm32.dll
-29  0x00000000  0x109000 0x7fefe340000  0x109000 ---- C:_Windows_System32_msctf.dll
-30  0x00000000  0x161000 0x7fefb560000  0x161000 ---- C:_Windows_System32_WindowsCodecs.dll
-31  0x00000000   0x18000 0x7fefb710000   0x18000 ---- C:_Windows_System32_dwmapi.dll
-32  0x00000000    0xf000 0x7fefd2b0000    0xf000 ---- C:_Windows_System32_CRYPTBASE.dll
-33  0x00000000   0x99000 0x7fefddb0000   0x99000 ---- C:_Windows_System32_clbcatq.dll
-34  0x00000000   0x54000 0x7fef62b0000   0x54000 ---- C:_Windows_System32_oleacc.dll
+0   0x00000000   0xe3000 0xfffe0000      0xe3000 ---- C:_Windows_System32_calc.exe
+1   0x00000000  0x1aa000 0x77720000     0x1aa000 ---- C:_Windows_System32__tdll.dll
+2   0x00000000  0x11f000 0x77500000     0x11f000 ---- C:_Windows_System32_kernel32.dll
+3   0x00000000   0x6a000 0x7fefd4a0000   0x6a000 ---- C:_Windows_System32_KERNELBASE.dll
+4   0x00000000  0xd8a000 0x7fefeca0000  0xd8a000 ---- C:_Windows_System32_shell32.dll
+5   0x00000000   0x9f000 0x7fefdab0000   0x9f000 ---- C:_Windows_System32_msvcrt.dll
+6   0x00000000   0x71000 0x7fefd890000   0x71000 ---- C:_Windows_System32_shlwapi.dll
+7   0x00000000   0x67000 0x7fefdb50000   0x67000 ---- C:_Windows_System32_gdi32.dll
+8   0x00000000   0xfa000 0x77620000      0xfa000 ---- C:_Windows_System32_user32.dll
+9   0x00000000    0xe000 0x7fefdbc0000    0xe000 ---- C:_Windows_System32_lpk.dll
+10  0x00000000   0xca000 0x7fefe450000   0xca000 ---- C:_Windows_System32_usp10.dll
+11  0x00000000  0x203000 0x7fefea90000  0x203000 ---- C:_Windows_System32_ole32.dll
+12  0x00000000  0x12d000 0x7fefe8d0000  0x12d000 ---- C:_Windows_System32__pcrt4.dll
+13  0x00000000   0xdb000 0x7fefd9d0000   0xdb000 ---- C:_Windows_System32__dvapi32.dll
+14  0x00000000   0x1f000 0x7fefdff0000   0x1f000 ---- C:_Windows_System32_sechost.dll
+15  0x00000000   0xda000 0x7fefe520000   0xda000 ---- C:_Windows_System32_oleaut32.dll
+16  0x00000000   0x56000 0x7fefbb40000   0x56000 ---- C:_Windows_System32_uxtheme.dll
+17  0x00000000   0x3b000 0x7fefa140000   0x3b000 ---- C:_Windows_System32_winmm.dll
+18  0x00000000    0xc000 0x7fefc330000    0xc000 ---- C:_Windows_System32__ersion.dll
+19  0x00000000   0x2e000 0x7fefea00000   0x2e000 ---- C:_Windows_System32_imm32.dll
+20  0x00000000  0x109000 0x7fefe340000  0x109000 ---- C:_Windows_System32_msctf.dll
+21  0x00000000  0x161000 0x7fefb560000  0x161000 ---- C:_Windows_System32_WindowsCodecs.dll
+22  0x00000000   0x18000 0x7fefb710000   0x18000 ---- C:_Windows_System32_dwmapi.dll
+23  0x00000000    0xf000 0x7fefd2b0000    0xf000 ---- C:_Windows_System32_CRYPTBASE.dll
+24  0x00000000   0x99000 0x7fefddb0000   0x99000 ---- C:_Windows_System32_clbcatq.dll
+25  0x00000000   0x54000 0x7fef62b0000   0x54000 ---- C:_Windows_System32_oleacc.dll
 
 EOF
 RUN
@@ -93,15 +84,15 @@ NAME=mdmp maps
 FILE=bins/mdmp/calc.dmp
 CMDS=om
 EXPECT=<<EOF
- 9 fd: 3 +0x000043ac 0x0398f9b8 - 0x0398ffff r-- fmap.Memory_Section
- 8 fd: 3 +0x000049f4 0x77639dea - 0x77639ee9 r-- fmap.Memory_Section_1
- 7 fd: 3 +0x00004af4 0x032cf638 - 0x032cffff r-- fmap.Memory_Section_2
- 6 fd: 3 +0x000054bc 0x0367f868 - 0x0367ffff r-- fmap.Memory_Section_3
- 5 fd: 3 +0x00005c54 0x000bd0d8 - 0x000bffff r-- fmap.Memory_Section_4
- 4 fd: 3 +0x00008b7c 0x03a7ff08 - 0x03a7ffff r-- fmap.Memory_Section_5
- 3 fd: 3 +0x00008c74 0x7776ad90 - 0x7776ae8f r-- fmap.Memory_Section_6
- 2 fd: 3 +0x00008d74 0x7776bafa - 0x7776bbf9 r-- fmap.Memory_Section_7
- 1 fd: 3 +0x00008e74 0x7776c06a - 0x7776c169 r-- fmap.Memory_Section_8
+ 9 fd: 3 +0x000043ac 0x0398f9b8 - 0x0398ffff r-- fmap.memory.0x398f9b8
+ 8 fd: 3 +0x000049f4 0x77639dea - 0x77639ee9 r-- fmap.memory.0x77639dea
+ 7 fd: 3 +0x00004af4 0x032cf638 - 0x032cffff r-- fmap.memory.0x32cf638
+ 6 fd: 3 +0x000054bc 0x0367f868 - 0x0367ffff r-- fmap.memory.0x367f868
+ 5 fd: 3 +0x00005c54 0x000bd0d8 - 0x000bffff r-- fmap.memory.0xbd0d8
+ 4 fd: 3 +0x00008b7c 0x03a7ff08 - 0x03a7ffff r-- fmap.memory.0x3a7ff08
+ 3 fd: 3 +0x00008c74 0x7776ad90 - 0x7776ae8f r-- fmap.memory.0x7776ad90
+ 2 fd: 3 +0x00008d74 0x7776bafa - 0x7776bbf9 r-- fmap.memory.0x7776bafa
+ 1 fd: 3 +0x00008e74 0x7776c06a - 0x7776c169 r-- fmap.memory.0x7776c06a
 EOF
 RUN
 
@@ -109,59 +100,59 @@ NAME=mdmp memory64 maps
 FILE=bins/mdmp/hello64.dmp
 CMDS=om
 EXPECT=<<EOF
-53 fd: 3 +0x00002c8f 0x00010000 - 0x0001ffff r-- fmap.Memory_Section
-52 fd: 3 +0x00012c8f 0x00020000 - 0x0002ffff r-- fmap.Memory_Section_1
-51 fd: 3 +0x00022c8f 0x0022d000 - 0x0022ffff r-- fmap.Memory_Section_2
-50 fd: 3 +0x00025c8f 0x00230000 - 0x00233fff r-- fmap.Memory_Section_3
-49 fd: 3 +0x00029c8f 0x00240000 - 0x00240fff r-- fmap.Memory_Section_4
-48 fd: 3 +0x0002ac8f 0x00250000 - 0x00250fff r-- fmap.Memory_Section_5
-47 fd: 3 +0x0002bc8f 0x00260000 - 0x002c6fff r-- fmap.Memory_Section_6
-46 fd: 3 +0x00092c8f 0x00400000 - 0x00400fff r-- fmap.Memory_Section_7
-45 fd: 3 +0x00093c8f 0x00401000 - 0x00402fff r-x fmap.Memory_Section_8
-44 fd: 3 +0x00095c8f 0x00403000 - 0x00403fff r-- fmap.Memory_Section_9
-43 fd: 3 +0x00096c8f 0x00404000 - 0x00406fff r-- fmap.Memory_Section_10
-42 fd: 3 +0x00099c8f 0x00407000 - 0x00408fff r-- fmap.Memory_Section_11
-41 fd: 3 +0x0009bc8f 0x00409000 - 0x0040bfff --- fmap.Memory_Section_12
-40 fd: 3 +0x0009ec8f 0x0040c000 - 0x00424fff r-- fmap.Memory_Section_13
-39 fd: 3 +0x000b7c8f 0x00580000 - 0x00584fff r-- fmap.Memory_Section_14
-38 fd: 3 +0x000bcc8f 0x005e0000 - 0x005e6fff r-- fmap.Memory_Section_15
-37 fd: 3 +0x000c3c8f 0x77500000 - 0x77500fff r-- fmap.Memory_Section_16
-36 fd: 3 +0x000c4c8f 0x77501000 - 0x7759bfff r-x fmap.Memory_Section_17
-35 fd: 3 +0x0015fc8f 0x7759c000 - 0x77609fff r-- fmap.Memory_Section_18
-34 fd: 3 +0x001cdc8f 0x7760a000 - 0x7760bfff r-- fmap.Memory_Section_19
-33 fd: 3 +0x001cfc8f 0x7760c000 - 0x7761efff r-- fmap.Memory_Section_20
-32 fd: 3 +0x001e2c8f 0x77720000 - 0x77720fff r-- fmap.Memory_Section_21
-31 fd: 3 +0x001e3c8f 0x77721000 - 0x7781dfff r-x fmap.Memory_Section_22
-30 fd: 3 +0x002e0c8f 0x7781e000 - 0x7784cfff r-- fmap.Memory_Section_23
-29 fd: 3 +0x0030fc8f 0x7784d000 - 0x7784dfff r-- fmap.Memory_Section_24
-28 fd: 3 +0x00310c8f 0x7784e000 - 0x7784efff --- fmap.Memory_Section_25
-27 fd: 3 +0x00311c8f 0x7784f000 - 0x7784ffff r-- fmap.Memory_Section_26
-26 fd: 3 +0x00312c8f 0x77850000 - 0x77851fff --- fmap.Memory_Section_27
-25 fd: 3 +0x00314c8f 0x77852000 - 0x77852fff r-- fmap.Memory_Section_28
-24 fd: 3 +0x00315c8f 0x77853000 - 0x77855fff --- fmap.Memory_Section_29
-23 fd: 3 +0x00318c8f 0x77856000 - 0x77857fff r-- fmap.Memory_Section_30
-22 fd: 3 +0x0031ac8f 0x77858000 - 0x77858fff --- fmap.Memory_Section_31
-21 fd: 3 +0x0031bc8f 0x77859000 - 0x7785afff r-- fmap.Memory_Section_32
-20 fd: 3 +0x0031dc8f 0x7785b000 - 0x778c9fff r-- fmap.Memory_Section_33
-19 fd: 3 +0x0038cc8f 0x7efe0000 - 0x7efe4fff r-- fmap.Memory_Section_34
-18 fd: 3 +0x00391c8f 0x7ffe0000 - 0x7ffe0fff r-- fmap.Memory_Section_35
-17 fd: 3 +0x00392c8f 0x7fefd4a0000 - 0x7fefd4a0fff r-- fmap.Memory_Section_36
-16 fd: 3 +0x00393c8f 0x7fefd4a1000 - 0x7fefd4e9fff r-x fmap.Memory_Section_37
-15 fd: 3 +0x003dcc8f 0x7fefd4ea000 - 0x7fefd4fefff r-- fmap.Memory_Section_38
-14 fd: 3 +0x003f1c8f 0x7fefd4ff000 - 0x7fefd500fff r-- fmap.Memory_Section_39
-13 fd: 3 +0x003f3c8f 0x7fefd501000 - 0x7fefd509fff r-- fmap.Memory_Section_40
-12 fd: 3 +0x003fcc8f 0x7fefdab0000 - 0x7fefdab0fff r-- fmap.Memory_Section_41
-11 fd: 3 +0x003fdc8f 0x7fefdab1000 - 0x7fefdb29fff r-x fmap.Memory_Section_42
-10 fd: 3 +0x00476c8f 0x7fefdb2a000 - 0x7fefdb40fff r-- fmap.Memory_Section_43
- 9 fd: 3 +0x0048dc8f 0x7fefdb41000 - 0x7fefdb42fff r-- fmap.Memory_Section_44
- 8 fd: 3 +0x0048fc8f 0x7fefdb43000 - 0x7fefdb43fff --- fmap.Memory_Section_45
- 7 fd: 3 +0x00490c8f 0x7fefdb44000 - 0x7fefdb44fff r-- fmap.Memory_Section_46
- 6 fd: 3 +0x00491c8f 0x7fefdb45000 - 0x7fefdb46fff --- fmap.Memory_Section_47
- 5 fd: 3 +0x00493c8f 0x7fefdb47000 - 0x7fefdb4efff r-- fmap.Memory_Section_48
- 4 fd: 3 +0x0049bc8f 0x7feffa40000 - 0x7feffa40fff r-- fmap.Memory_Section_49
- 3 fd: 3 +0x0049cc8f 0x7fffffb0000 - 0x7fffffd2fff r-- fmap.Memory_Section_50
- 2 fd: 3 +0x004bfc8f 0x7fffffd7000 - 0x7fffffd7fff r-- fmap.Memory_Section_51
- 1 fd: 3 +0x004c0c8f 0x7fffffde000 - 0x7fffffdffff r-- fmap.Memory_Section_52
+53 fd: 3 +0x00002c8f 0x00010000 - 0x0001ffff r-- fmap.memory64.0x10000
+52 fd: 3 +0x00012c8f 0x00020000 - 0x0002ffff r-- fmap.memory64.0x20000
+51 fd: 3 +0x00022c8f 0x0022d000 - 0x0022ffff r-- fmap.memory64.0x22d000
+50 fd: 3 +0x00025c8f 0x00230000 - 0x00233fff r-- fmap.memory64.0x230000
+49 fd: 3 +0x00029c8f 0x00240000 - 0x00240fff r-- fmap.memory64.0x240000
+48 fd: 3 +0x0002ac8f 0x00250000 - 0x00250fff r-- fmap.memory64.0x250000
+47 fd: 3 +0x0002bc8f 0x00260000 - 0x002c6fff r-- fmap.memory64.0x260000
+46 fd: 3 +0x00092c8f 0x00400000 - 0x00400fff r-- fmap.memory64.0x400000
+45 fd: 3 +0x00093c8f 0x00401000 - 0x00402fff r-x fmap.memory64.0x401000
+44 fd: 3 +0x00095c8f 0x00403000 - 0x00403fff r-- fmap.memory64.0x403000
+43 fd: 3 +0x00096c8f 0x00404000 - 0x00406fff r-- fmap.memory64.0x404000
+42 fd: 3 +0x00099c8f 0x00407000 - 0x00408fff r-- fmap.memory64.0x407000
+41 fd: 3 +0x0009bc8f 0x00409000 - 0x0040bfff --- fmap.memory64.0x409000
+40 fd: 3 +0x0009ec8f 0x0040c000 - 0x00424fff r-- fmap.memory64.0x40c000
+39 fd: 3 +0x000b7c8f 0x00580000 - 0x00584fff r-- fmap.memory64.0x580000
+38 fd: 3 +0x000bcc8f 0x005e0000 - 0x005e6fff r-- fmap.memory64.0x5e0000
+37 fd: 3 +0x000c3c8f 0x77500000 - 0x77500fff r-- fmap.memory64.0x77500000
+36 fd: 3 +0x000c4c8f 0x77501000 - 0x7759bfff r-x fmap.memory64.0x77501000
+35 fd: 3 +0x0015fc8f 0x7759c000 - 0x77609fff r-- fmap.memory64.0x7759c000
+34 fd: 3 +0x001cdc8f 0x7760a000 - 0x7760bfff r-- fmap.memory64.0x7760a000
+33 fd: 3 +0x001cfc8f 0x7760c000 - 0x7761efff r-- fmap.memory64.0x7760c000
+32 fd: 3 +0x001e2c8f 0x77720000 - 0x77720fff r-- fmap.memory64.0x77720000
+31 fd: 3 +0x001e3c8f 0x77721000 - 0x7781dfff r-x fmap.memory64.0x77721000
+30 fd: 3 +0x002e0c8f 0x7781e000 - 0x7784cfff r-- fmap.memory64.0x7781e000
+29 fd: 3 +0x0030fc8f 0x7784d000 - 0x7784dfff r-- fmap.memory64.0x7784d000
+28 fd: 3 +0x00310c8f 0x7784e000 - 0x7784efff --- fmap.memory64.0x7784e000
+27 fd: 3 +0x00311c8f 0x7784f000 - 0x7784ffff r-- fmap.memory64.0x7784f000
+26 fd: 3 +0x00312c8f 0x77850000 - 0x77851fff --- fmap.memory64.0x77850000
+25 fd: 3 +0x00314c8f 0x77852000 - 0x77852fff r-- fmap.memory64.0x77852000
+24 fd: 3 +0x00315c8f 0x77853000 - 0x77855fff --- fmap.memory64.0x77853000
+23 fd: 3 +0x00318c8f 0x77856000 - 0x77857fff r-- fmap.memory64.0x77856000
+22 fd: 3 +0x0031ac8f 0x77858000 - 0x77858fff --- fmap.memory64.0x77858000
+21 fd: 3 +0x0031bc8f 0x77859000 - 0x7785afff r-- fmap.memory64.0x77859000
+20 fd: 3 +0x0031dc8f 0x7785b000 - 0x778c9fff r-- fmap.memory64.0x7785b000
+19 fd: 3 +0x0038cc8f 0x7efe0000 - 0x7efe4fff r-- fmap.memory64.0x7efe0000
+18 fd: 3 +0x00391c8f 0x7ffe0000 - 0x7ffe0fff r-- fmap.memory64.0x7ffe0000
+17 fd: 3 +0x00392c8f 0x7fefd4a0000 - 0x7fefd4a0fff r-- fmap.memory64.0x7fefd4a0000
+16 fd: 3 +0x00393c8f 0x7fefd4a1000 - 0x7fefd4e9fff r-x fmap.memory64.0x7fefd4a1000
+15 fd: 3 +0x003dcc8f 0x7fefd4ea000 - 0x7fefd4fefff r-- fmap.memory64.0x7fefd4ea000
+14 fd: 3 +0x003f1c8f 0x7fefd4ff000 - 0x7fefd500fff r-- fmap.memory64.0x7fefd4ff000
+13 fd: 3 +0x003f3c8f 0x7fefd501000 - 0x7fefd509fff r-- fmap.memory64.0x7fefd501000
+12 fd: 3 +0x003fcc8f 0x7fefdab0000 - 0x7fefdab0fff r-- fmap.memory64.0x7fefdab0000
+11 fd: 3 +0x003fdc8f 0x7fefdab1000 - 0x7fefdb29fff r-x fmap.memory64.0x7fefdab1000
+10 fd: 3 +0x00476c8f 0x7fefdb2a000 - 0x7fefdb40fff r-- fmap.memory64.0x7fefdb2a000
+ 9 fd: 3 +0x0048dc8f 0x7fefdb41000 - 0x7fefdb42fff r-- fmap.memory64.0x7fefdb41000
+ 8 fd: 3 +0x0048fc8f 0x7fefdb43000 - 0x7fefdb43fff --- fmap.memory64.0x7fefdb43000
+ 7 fd: 3 +0x00490c8f 0x7fefdb44000 - 0x7fefdb44fff r-- fmap.memory64.0x7fefdb44000
+ 6 fd: 3 +0x00491c8f 0x7fefdb45000 - 0x7fefdb46fff --- fmap.memory64.0x7fefdb45000
+ 5 fd: 3 +0x00493c8f 0x7fefdb47000 - 0x7fefdb4efff r-- fmap.memory64.0x7fefdb47000
+ 4 fd: 3 +0x0049bc8f 0x7feffa40000 - 0x7feffa40fff r-- fmap.memory64.0x7feffa40000
+ 3 fd: 3 +0x0049cc8f 0x7fffffb0000 - 0x7fffffd2fff r-- fmap.memory64.0x7fffffb0000
+ 2 fd: 3 +0x004bfc8f 0x7fffffd7000 - 0x7fffffd7fff r-- fmap.memory64.0x7fffffd7000
+ 1 fd: 3 +0x004c0c8f 0x7fffffde000 - 0x7fffffdffff r-- fmap.memory64.0x7fffffde000
 EOF
 RUN
 

--- a/test/db/formats/menuet
+++ b/test/db/formats/menuet
@@ -5,3 +5,13 @@ EXPECT=<<EOF
 1
 EOF
 RUN
+
+NAME=Menuet: maps
+FILE=bins/menuet/dosbox
+CMDS=om
+EXPECT=<<EOF
+ 3 fd: 3 +0x00000024 0x00000024 - 0x0011b023 r-x fmap.text
+ 2 fd: 3 +0x0dfde800 0x0dfde800 - 0xffb8000b r-- fmap.idata
+ 1 fd: 4 +0x00000000 0xffb8000c - 0xffb80817 r-- mmap.idata
+EOF
+RUN

--- a/test/db/formats/ne
+++ b/test/db/formats/ne
@@ -79,3 +79,20 @@ vaddr      paddr      type   name
 0x00000f5e 0x00000f5e SET_32 USER.SETTIMER
 EOF
 RUN
+
+NAME=NE Code
+FILE=bins/ne/anim8.exe
+CMDS=pi 10 @ sym.WNDPROC
+EXPECT=<<EOF
+mov ax, ds
+nop
+inc bp
+push bp
+mov bp, sp
+push ds
+mov ds, ax
+mov ax, 0x5c
+call 0x4d35
+push si
+EOF
+RUN

--- a/test/db/formats/nes
+++ b/test/db/formats/nes
@@ -13,3 +13,13 @@ EXPECT=<<EOF
 os       nes
 EOF
 RUN
+
+NAME=NES: Mapping
+FILE=bins/nes/Pong.nes
+CMDS=om
+EXPECT=<<EOF
+ 3 fd: 3 +0x00000010 0x00008000 - 0x0000bfff r-x fmap.ROM
+ 2 fd: 3 +0x00000010 0x0000c000 - 0x0000ffff r-x fmap.ROM_MIRROR
+ 1 fd: 4 +0x00000000 0x00010000 - 0x00013fff r-x mmap.ROM_MIRROR
+EOF
+RUN

--- a/test/db/formats/ninds
+++ b/test/db/formats/ninds
@@ -1,7 +1,16 @@
-NAME=NRO: Open/iI
+NAME=NDS: Open/iI
 FILE=bins/nds/bin
 CMDS=iI~?Nintendo
 EXPECT=<<EOF
 1
+EOF
+RUN
+
+NAME=NDS: Maps
+FILE=bins/nds/bin
+CMDS=om
+EXPECT=<<EOF
+ 2 fd: 3 +0x00000200 0x02000000 - 0x021b0863 r-x fmap.arm9
+ 1 fd: 3 +0x001b0c00 0x037f8000 - 0x03805b4f r-x fmap.arm7
 EOF
 RUN

--- a/test/db/formats/nro
+++ b/test/db/formats/nro
@@ -6,7 +6,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-
 NAME=nro sections
 FILE=bins/nro/appstore.nro
 ARGS=-e io.cache=true
@@ -22,6 +21,17 @@ nth paddr           size vaddr          vsize perm name
 3   0x001b4000   0x5a000 0x001b4000   0x5a000 -r-- ro
 4   0x0020e000    0xf000 0x0020e000    0xf000 -rw- data
 
+EOF
+RUN
+
+NAME=nro maps
+FILE=bins/nro/appstore.nro
+ARGS=-e io.cache=true
+CMDS=om
+EXPECT=<<EOF
+ 3 fd: 3 +0x00000000 0x00000000 - 0x001b3fff r-x fmap.text
+ 2 fd: 3 +0x001b4000 0x001b4000 - 0x0020dfff r-- fmap.ro
+ 1 fd: 3 +0x0020e000 0x0020e000 - 0x0021cfff r-- fmap.data
 EOF
 RUN
 

--- a/test/db/formats/nso
+++ b/test/db/formats/nso
@@ -24,6 +24,17 @@ nth paddr          size vaddr         vsize perm name
 EOF
 RUN
 
+NAME=nso maps
+FILE=bins/nso/application.nso
+ARGS=-e io.cache=true
+CMDS=om
+EXPECT=<<EOF
+ 3 fd: 3 +0x00000100 0x08000000 - 0x08020e17 r-x fmap.text
+ 2 fd: 3 +0x0001718f 0x08021000 - 0x0802eb0b r-- fmap.ro
+ 1 fd: 3 +0x0001f856 0x0802f000 - 0x08033217 r-- fmap.data
+EOF
+RUN
+
 NAME=nso entry
 FILE=bins/nso/application.nso
 ARGS=-e io.cache=true

--- a/test/db/formats/omf
+++ b/test/db/formats/omf
@@ -40,6 +40,15 @@ nth paddr       size vaddr       vsize perm name
 EOF
 RUN
 
+NAME=maps 16 bits omf
+FILE=bins/omf/hello_world
+CMDS=om
+EXPECT=<<EOF
+ 2 fd: 3 +0x00000073 0x00001000 - 0x00001012 r-x fmap.text_1
+ 1 fd: 3 +0x00000095 0x00001013 - 0x00001020 r-x fmap.data_1
+EOF
+RUN
+
 NAME=sections 16 bits omf - content
 FILE=bins/omf/hello_world
 CMDS=px 16 @ section.text_1; px 16 @ section.data_1
@@ -98,6 +107,15 @@ nth paddr       size vaddr       vsize perm name
 0   0x00000074  0x1d 0x00001000   0x1d -rwx .text_1
 1   0x000000a3   0xe 0x0000101d    0xe -rwx .data_1
 
+EOF
+RUN
+
+NAME=maps 32 bits omf
+FILE=bins/omf/hello_world32
+CMDS=om
+EXPECT=<<EOF
+ 2 fd: 3 +0x00000074 0x00001000 - 0x0000101c r-x fmap..text_1
+ 1 fd: 3 +0x000000a3 0x0000101d - 0x0000102a r-x fmap..data_1
 EOF
 RUN
 

--- a/test/db/formats/plan9
+++ b/test/db/formats/plan9
@@ -5,3 +5,28 @@ EXPECT=<<EOF
 1
 EOF
 RUN
+
+NAME=Plan9: maps
+FILE=bins/plan9/bin
+CMDS=om
+EXPECT=<<EOF
+ 4 fd: 3 +0x00000020 0x00000020 - 0x364a0720 r-x fmap.text
+ 3 fd: 5 +0x00000000 0x364a0721 - 0x364a0e21 r-x mmap.text
+ 2 fd: 3 +0x364a0721 0x364a0721 - 0x76d40c20 r-- fmap.data
+ 1 fd: 4 +0x00000000 0x76d40c21 - 0x76d41120 rw- mmap.data
+EOF
+RUN
+
+NAME=Plan9: sections
+FILE=bins/plan9/bin
+CMDS=iS
+EXPECT=<<EOF
+[Sections]
+
+nth paddr             size vaddr            vsize perm name
+-----------------------------------------------------------
+0   0x00000020  0x364a0701 0x00000020  0x364a0e02 -r-x text
+1   0x364a0721  0x408a0500 0x364a0721  0x408a0a00 -rw- data
+
+EOF
+RUN

--- a/test/db/formats/psx
+++ b/test/db/formats/psx
@@ -1,14 +1,28 @@
-NAME=DOL: sqrxz4 - open
-FILE=bins/psx/HITPSX.EXE
-CMDS=q!
-EXPECT=<<EOF
-EOF
-RUN
-
-NAME=DOL: sqrxz4 - iI
+NAME=psx: sqrxz4 - iI
 FILE=bins/psx/HITPSX.EXE
 CMDS=iI~?psx
 EXPECT=<<EOF
 1
+EOF
+RUN
+
+NAME=psx: sqrxz4 - sections
+FILE=bins/psx/HITPSX.EXE
+CMDS=iS
+EXPECT=<<EOF
+[Sections]
+
+nth paddr           size vaddr          vsize perm name
+-------------------------------------------------------
+0   0x00000800  0x180000 0x80010000  0x180000 -r-x TEXT
+
+EOF
+RUN
+
+NAME=psx: sqrxz4 - maps
+FILE=bins/psx/HITPSX.EXE
+CMDS=om
+EXPECT=<<EOF
+ 1 fd: 3 +0x00000800 0x80010000 - 0x8018ffff r-x fmap.TEXT
 EOF
 RUN

--- a/test/db/formats/pyc
+++ b/test/db/formats/pyc
@@ -109,6 +109,16 @@ free_object (0)
 EOF
 RUN
 
+NAME=pyc maps
+FILE=bins/pyc/py37.pyc
+CMDS=<<EOF
+om
+EOF
+EXPECT=<<EOF
+ 1 fd: 3 +0x00000000 0x00000000 - 0x00002be5 r-x 
+EOF
+RUN
+
 NAME=pyc entry
 FILE=bins/pyc/py37.pyc
 CMDS=<<EOF

--- a/test/db/formats/qnx
+++ b/test/db/formats/qnx
@@ -14,7 +14,6 @@ vaddr=0x0000021c paddr=0x0000021c haddr=-1 type=program
 EOF
 RUN
 
-
 NAME=sections of qnx
 FILE=bins/qnx/test.x
 CMDS=iS
@@ -26,6 +25,16 @@ nth paddr        size vaddr       vsize perm name
 0   0x00000044   0xf6 0x00000044   0xf6 ---- LMF_LOAD
 1   0x00000152  0x6c3 0x00000152  0x6c3 ---- LMF_LOAD
 
+EOF
+RUN
+
+NAME=maps of qnx
+FILE=bins/qnx/test.x
+CMDS=om
+EXPECT=<<EOF
+ 3 fd: 3 +0x00000000 0x00000000 - 0x00001481 r-x 
+ 2 fd: 3 +0x00000044 0x00000044 - 0x00000139 --- fmap.LMF_LOAD
+ 1 fd: 3 +0x00000152 0x00000152 - 0x00000814 --- fmap.LMF_LOAD
 EOF
 RUN
 

--- a/test/db/formats/smd
+++ b/test/db/formats/smd
@@ -126,6 +126,31 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=sega megadrive maps
+FILE=bins/smd/LiquidSpaceDodgerV3.bin
+CMDS=om
+EXPECT=<<EOF
+ 3 fd: 3 +0x00000000 0x00000000 - 0x000000ff r-- fmap.vtable
+ 2 fd: 3 +0x00000100 0x00000100 - 0x000001ff r-- fmap.header
+ 1 fd: 3 +0x00000200 0x00000200 - 0x000272f7 r-x fmap.text
+EOF
+RUN
+
+NAME=sega megadrive sections
+FILE=bins/smd/LiquidSpaceDodgerV3.bin
+CMDS=iS
+EXPECT=<<EOF
+[Sections]
+
+nth paddr          size vaddr         vsize perm name
+-----------------------------------------------------
+0   0x00000000    0x100 0x00000000    0x100 -r-- vtable
+1   0x00000100    0x100 0x00000100    0x100 -r-- header
+2   0x00000200  0x270f8 0x00000200  0x270f8 -r-x text
+
+EOF
+RUN
+
 NAME=smd strings
 FILE=malloc://256k
 CMDS=<<EOF

--- a/test/db/formats/sms
+++ b/test/db/formats/sms
@@ -5,3 +5,11 @@ EXPECT=<<EOF
 1
 EOF
 RUN
+
+NAME=SMS: maps
+FILE=bins/sms/demo.sms
+CMDS=om
+EXPECT=<<EOF
+ 1 fd: 3 +0x00000000 0x00000000 - 0x00007fff r-x 
+EOF
+RUN

--- a/test/db/formats/spc700
+++ b/test/db/formats/spc700
@@ -6,3 +6,26 @@ SPC700
 EOF
 EXPECT_ERR=
 RUN
+
+NAME=SPC700: sections
+FILE=bins/spc700/bin.spc
+CMDS=iS
+EXPECT=<<EOF
+[Sections]
+
+nth paddr          size vaddr         vsize perm name
+-----------------------------------------------------
+0   0x00000100  0x10000 0x00000000  0x10000 -r-- RAM
+
+EOF
+EXPECT_ERR=
+RUN
+
+NAME=SPC700: maps
+FILE=bins/spc700/bin.spc
+CMDS=om
+EXPECT=<<EOF
+ 1 fd: 3 +0x00000100 0x00000000 - 0x0000ffff r-- fmap.RAM
+EOF
+EXPECT_ERR=
+RUN

--- a/test/db/formats/vsf/rhps-norom
+++ b/test/db/formats/vsf/rhps-norom
@@ -18,7 +18,7 @@ NAME=VSF: Rocky Horror Picture Show- ROMs
 FILE=bins/vsf/c128-rhps-norom.vsf
 CMDS=om
 EXPECT=<<EOF
- 2 fd: 3 +0x0000008c 0x00000000 - 0x0000ffff r-x fmap.RAM_BANK_0
- 1 fd: 3 +0x0001008c 0x00000000 - 0x0000ffff r-x fmap.RAM_BANK_1
+ 2 fd: 3 +0x0000008c 0x00000000 - 0x0000ffff r-x fmap.RAM BANK 0
+ 1 fd: 3 +0x0001008c 0x00000000 - 0x0000ffff r-x fmap.RAM BANK 1
 EOF
 RUN

--- a/test/db/formats/vsf/rhps-rom
+++ b/test/db/formats/vsf/rhps-rom
@@ -22,7 +22,7 @@ EXPECT=<<EOF
  5 fd: 3 +0x000490a1 0x0000b000 - 0x0000bfff r-x fmap.MONITOR
  4 fd: 3 +0x0004a0a1 0x0000c000 - 0x0000cfff r-x fmap.EDITOR
  3 fd: 3 +0x000400a1 0x0000e000 - 0x0000ffff r-x fmap.KERNAL
- 2 fd: 3 +0x0000008c 0x00000000 - 0x0000ffff r-x fmap.RAM_BANK_0
- 1 fd: 3 +0x0001008c 0x00000000 - 0x0000ffff r-x fmap.RAM_BANK_1
+ 2 fd: 3 +0x0000008c 0x00000000 - 0x0000ffff r-x fmap.RAM BANK 0
+ 1 fd: 3 +0x0001008c 0x00000000 - 0x0000ffff r-x fmap.RAM BANK 1
 EOF
 RUN

--- a/test/db/formats/web_assembly
+++ b/test/db/formats/web_assembly
@@ -36,3 +36,15 @@ nth paddr        size vaddr       vsize perm name
 
 EOF
 RUN
+
+NAME=WASM: Wasm - maps
+FILE=bins/wasm/binary.wasm
+CMDS=om
+EXPECT=<<EOF
+ 5 fd: 3 +0x00000000 0x00000000 - 0x00000423 r-x 
+ 4 fd: 3 +0x0000000a 0x0000000a - 0x00000019 --- fmap.type
+ 3 fd: 3 +0x0000001d 0x0000001d - 0x00000048 --- fmap.function
+ 2 fd: 3 +0x0000004d 0x0000004d - 0x00000228 --- fmap.export
+ 1 fd: 3 +0x0000022d 0x0000022d - 0x00000422 --- fmap.code
+EOF
+RUN

--- a/test/db/formats/z64
+++ b/test/db/formats/z64
@@ -5,3 +5,24 @@ EXPECT=<<EOF
 1
 EOF
 RUN
+
+NAME=z64: sections
+FILE=bins/z64/demo.z64
+CMDS=iS
+EXPECT=<<EOF
+[Sections]
+
+nth paddr           size vaddr          vsize perm name
+-------------------------------------------------------
+0   0x00001000  0x13f000 0x80001000  0x13f000 -r-x text
+
+EOF
+RUN
+
+NAME=z64: maps
+FILE=bins/z64/demo.z64
+CMDS=om
+EXPECT=<<EOF
+ 1 fd: 3 +0x00001000 0x80001000 - 0x8013ffff r-x fmap.text
+EOF
+RUN

--- a/test/db/formats/zimg
+++ b/test/db/formats/zimg
@@ -5,3 +5,11 @@ EXPECT=<<EOF
 arch     arm
 EOF
 RUN
+
+NAME=zimg maps
+FILE=bins/zimg/arm32
+CMDS=om
+EXPECT=<<EOF
+ 1 fd: 3 +0x00000000 0x00000000 - 0x000003ff r-x 
+EOF
+RUN


### PR DESCRIPTION
**PLEASE SQUASH ME**

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This introduces the new `RzBinMap`, which is the source of information that a bin plugin gives for where to map which portions of the file. Previously this info was taken from `RzBinSection` (the `add` member meant which sections to map, which is now removed) but assuming that "sections" give the info for mapping is not really accurate for all formats (e.g. ELF) and results in some awkward sections emitted just for mapping some things.

So I went through every single bin plugin and updated it to now also implement the `maps` callback. Depending on how the format works, plugins have the following options for implementing this:
* Implement both `sections` and `maps` separately if they do not have much in common or `maps` is an easy to implement subset of `sections`.
* Implement `sections` and use `rz_bin_maps_of_file_sections()` as the `maps` callback, which just copies the section info to maps. This is useful when the format has a 1:1 correspondence between sections and mappings, so it doesn't have to be implemented twice.
* Implement `maps` and in `sections` pull in all maps using `rz_bin_sections_of_maps()` and add some more sections that should not be mapped. See docs of `rz_bin_sections_of_maps()` for more info about this.

Some notes on behavorial changes:

* ELF Core File Maps now also have `fmap.`/`mmap.` prefixes because they are now handled like any other mapping. Actually I think this is even better than before because you can see easier what is actually physical map and what is zeroed:
  old:
  ```
  21 fd: 3 +0x00001000 0x56621000 - 0x56621fff r-- /home/florian/dev/crash/crash-linux-x86
  20 fd: 6 +0x00000000 0x56622000 - 0x56622fff r-- /home/florian/dev/crash/crash-linux-x86
  ```

  new:
  ```
  21 fd: 3 +0x00001000 0x56621000 - 0x56621fff r-- fmap./home/florian/dev/crash/crash-linux-x86
  20 fd: 6 +0x00000000 0x56622000 - 0x56622fff r-- mmap./home/florian/dev/crash/crash-linux-x86
  ...
* Minidump maps are now called `memory.<addr>` or `memory64.<addr>` depending on the type instead of randomly numbering them:
  old:
  ```
  9 fd: 3 +0x000043ac 0x0398f9b8 - 0x0398ffff r-- fmap.Memory_Section
  8 fd: 3 +0x000049f4 0x77639dea - 0x77639ee9 r-- fmap.Memory_Section_1
  ```

  new:
  ```
  9 fd: 3 +0x000043ac 0x0398f9b8 - 0x0398ffff r-- fmap.memory.0x398f9b8
  8 fd: 3 +0x000049f4 0x77639dea - 0x77639ee9 r-- fmap.memory.0x77639dea
  ```


**Test plan**

run the tests

I have added tests whenever possible for each bin plugin where the concrete mapping functionality was not part of the test suite yet. For plugins that are too broken to add tests (xbe and sfc) or where we don't have testbins (kernelcache) I tested manually as good as possible. mbn is untested because I have no idea where to get such a bin but it's only using `rz_bin_maps_of_file_sections()` anyway so should be fine.