### PR TITLE
8051: Make Jump Targets in Higher Banks stay inside their Bank

### DIFF
--- a/librz/analysis/p/analysis_8051.c
+++ b/librz/analysis/p/analysis_8051.c
@@ -1218,22 +1218,22 @@ static int i8051_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		op->stackop = RZ_ANALYSIS_STACK_INC;
 		op->stackptr = 2;
 		if (arg1 == A_ADDR11) {
-			op->jump = arg_addr11(addr + op->size, buf);
+			op->jump = arg_addr11(addr, addr + op->size, buf);
 			op->fail = addr + op->size;
 		} else if (arg1 == A_ADDR16) {
-			op->jump = 0x100 * buf[1] + buf[2];
+			op->jump = apply_bank(addr, 0x100 * buf[1] + buf[2]);
 			op->fail = addr + op->size;
 		}
 		break;
 	case OP_JMP:
 		if (arg1 == A_ADDR11) {
-			op->jump = arg_addr11(addr + op->size, buf);
+			op->jump = arg_addr11(addr, addr + op->size, buf);
 			op->fail = addr + op->size;
 		} else if (arg1 == A_ADDR16) {
-			op->jump = 0x100 * buf[1] + buf[2];
+			op->jump = apply_bank(addr, 0x100 * buf[1] + buf[2]);
 			op->fail = addr + op->size;
 		} else if (arg1 == A_OFFSET) {
-			op->jump = arg_offset(addr + op->size, buf[1]);
+			op->jump = arg_offset(addr, addr + op->size, buf[1]);
 			op->fail = addr + op->size;
 		}
 		break;
@@ -1246,7 +1246,7 @@ static int i8051_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case OP_JB:
 	case OP_JBC:
 	case OP_JNB:
-		op->jump = arg_offset(addr + op->size, buf[op->size - 1]);
+		op->jump = arg_offset(addr, addr + op->size, buf[op->size - 1]);
 		op->fail = addr + op->size;
 	}
 

--- a/librz/asm/arch/8051/8051_disas.c
+++ b/librz/asm/arch/8051/8051_disas.c
@@ -95,13 +95,13 @@ static char *rz_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 		case 2:
 			if (len > 1) {
 				if (arg1 == A_OFFSET) {
-					disasm = rz_str_newf(name, arg_offset(pc, pc + 2, buf[1]));
+					disasm = rz_str_newf(name, (unsigned int)arg_offset(pc, pc + 2, buf[1]));
 				} else if (arg1 == A_ADDR11) {
-					disasm = rz_str_newf(name, arg_addr11(pc, pc + 2, buf));
+					disasm = rz_str_newf(name, (unsigned int)arg_addr11(pc, pc + 2, buf));
 				} else if ((arg1 == A_RI) || (arg1 == A_RN)) {
 					// op @Ri, arg; op Rn, arg
 					if (arg2 == A_OFFSET) {
-						disasm = rz_str_newf(name, buf[0] & mask, arg_offset(pc, pc + 2, buf[1]));
+						disasm = rz_str_newf(name, buf[0] & mask, (unsigned int)arg_offset(pc, pc + 2, buf[1]));
 					} else {
 						disasm = rz_str_newf(name, buf[0] & mask, buf[1]);
 					}
@@ -127,25 +127,25 @@ static char *rz_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 		case 3:
 			if (len > 2) {
 				if (arg1 == A_ADDR16) {
-					disasm = rz_str_newf(name, apply_bank(pc, 0x100 * buf[1] + buf[2]));
+					disasm = rz_str_newf(name, (unsigned int)apply_bank(pc, 0x100 * buf[1] + buf[2]));
 				} else if (arg1 == A_IMM16) {
 					disasm = rz_str_newf(name, 0x100 * buf[1] + buf[2]);
 				} else if (arg2 == A_OFFSET) {
 					if (mask != A_NONE) {
 						// @Ri, immediate, offset; Rn, immediate, offset
-						disasm = rz_str_newf(name, buf[0] & mask, buf[1], arg_offset(pc, pc + 3, buf[1]));
+						disasm = rz_str_newf(name, buf[0] & mask, buf[1], (unsigned int)arg_offset(pc, pc + 3, buf[1]));
 					} else if (arg1 == A_BIT) {
 						// bit, offset
-						disasm = rz_str_newf(name, arg_bit(buf[1]), buf[1] & 0x07, arg_offset(pc, pc + 3, buf[2]));
+						disasm = rz_str_newf(name, arg_bit(buf[1]), buf[1] & 0x07, (unsigned int)arg_offset(pc, pc + 3, buf[2]));
 						val1 = buf[1];
 					} else {
 						// direct, offset; a, immediate, offset
-						disasm = rz_str_newf(name, buf[1], apply_bank(pc, arg_offset(pc, pc + 3, buf[2])));
+						disasm = rz_str_newf(name, buf[1], (unsigned int)arg_offset(pc, pc + 3, buf[2]));
 						val1 = buf[1];
 					}
 				} else if (arg3 == A_OFFSET) {
 					// @Ri/Rn, direct, offset
-					disasm = rz_str_newf(name, buf[0] & mask, buf[1], arg_offset(pc, pc + 3, buf[2]));
+					disasm = rz_str_newf(name, buf[0] & mask, buf[1], (unsigned int)arg_offset(pc, pc + 3, buf[2]));
 					val2 = buf[1];
 				} else if (arg1 == A_DIRECT && arg2 == A_DIRECT) {
 					// op direct, direct has src and dest swapped

--- a/librz/asm/arch/8051/8051_disas.c
+++ b/librz/asm/arch/8051/8051_disas.c
@@ -95,13 +95,13 @@ static char *rz_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 		case 2:
 			if (len > 1) {
 				if (arg1 == A_OFFSET) {
-					disasm = rz_str_newf(name, arg_offset(pc + 2, buf[1]));
+					disasm = rz_str_newf(name, arg_offset(pc, pc + 2, buf[1]));
 				} else if (arg1 == A_ADDR11) {
-					disasm = rz_str_newf(name, arg_addr11(pc + 2, buf));
+					disasm = rz_str_newf(name, arg_addr11(pc, pc + 2, buf));
 				} else if ((arg1 == A_RI) || (arg1 == A_RN)) {
 					// op @Ri, arg; op Rn, arg
 					if (arg2 == A_OFFSET) {
-						disasm = rz_str_newf(name, buf[0] & mask, arg_offset(pc + 2, buf[1]));
+						disasm = rz_str_newf(name, buf[0] & mask, arg_offset(pc, pc + 2, buf[1]));
 					} else {
 						disasm = rz_str_newf(name, buf[0] & mask, buf[1]);
 					}
@@ -126,26 +126,26 @@ static char *rz_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 			break;
 		case 3:
 			if (len > 2) {
-				if ((arg1 == A_ADDR16) || (arg1 == A_IMM16)) {
-					disasm = rz_str_newf(name, 0x100 * buf[1] + buf[2]);
+				if (arg1 == A_ADDR16) {
+					disasm = rz_str_newf(name, apply_bank(pc, 0x100 * buf[1] + buf[2]));
 				} else if (arg1 == A_IMM16) {
 					disasm = rz_str_newf(name, 0x100 * buf[1] + buf[2]);
 				} else if (arg2 == A_OFFSET) {
 					if (mask != A_NONE) {
 						// @Ri, immediate, offset; Rn, immediate, offset
-						disasm = rz_str_newf(name, buf[0] & mask, buf[1], arg_offset(pc + 3, buf[1]));
+						disasm = rz_str_newf(name, buf[0] & mask, buf[1], arg_offset(pc, pc + 3, buf[1]));
 					} else if (arg1 == A_BIT) {
 						// bit, offset
-						disasm = rz_str_newf(name, arg_bit(buf[1]), buf[1] & 0x07, arg_offset(pc + 3, buf[2]));
+						disasm = rz_str_newf(name, arg_bit(buf[1]), buf[1] & 0x07, arg_offset(pc, pc + 3, buf[2]));
 						val1 = buf[1];
 					} else {
 						// direct, offset; a, immediate, offset
-						disasm = rz_str_newf(name, buf[1], arg_offset(pc + 3, buf[2]));
+						disasm = rz_str_newf(name, buf[1], apply_bank(pc, arg_offset(pc, pc + 3, buf[2])));
 						val1 = buf[1];
 					}
 				} else if (arg3 == A_OFFSET) {
 					// @Ri/Rn, direct, offset
-					disasm = rz_str_newf(name, buf[0] & mask, buf[1], arg_offset(pc + 3, buf[2]));
+					disasm = rz_str_newf(name, buf[0] & mask, buf[1], arg_offset(pc, pc + 3, buf[2]));
 					val2 = buf[1];
 				} else if (arg1 == A_DIRECT && arg2 == A_DIRECT) {
 					// op direct, direct has src and dest swapped

--- a/librz/asm/arch/8051/8051_ops.h
+++ b/librz/asm/arch/8051/8051_ops.h
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2021 Florian Märkl <info@florianmaerkl.de>
 // SPDX-FileCopyrightText: 2015-2016 pancake <pancake@nopcode.org>
 // SPDX-FileCopyrightText: 2015-2016 condret <condr3t@protonmail.com>
 // SPDX-FileCopyrightText: 2015-2016 riq <ricardoquesada@gmail.com>
@@ -9,17 +10,22 @@
 
 #include <rz_types.h>
 
-static inline ut16 arg_offset(ut16 pc, ut8 offset) {
-	if (offset < 0x80) {
-		return pc + offset;
-	}
-	offset = 0 - offset;
-	return pc - offset;
+/// Construct an address with the higher bits from ref (determining the bank) and the lower from addr (offset in the bank)
+static inline ut64 apply_bank(ut64 ref, ut16 addr) {
+	return (ref & ~0xffff) | (ut64)addr;
 }
 
-static inline ut16 arg_addr11(ut16 pc, const ut8 *buf) {
+static inline ut64 arg_offset(ut64 bank, ut16 pc, ut8 offset) {
+	if (offset < 0x80) {
+		return apply_bank(bank, pc + offset);
+	}
+	offset = 0 - offset;
+	return apply_bank(bank, pc - offset);
+}
+
+static inline ut64 arg_addr11(ut64 bank, ut16 pc, const ut8 *buf) {
 	// ADDR11 is replacing lower 11 bits of (pre-incremented) PC
-	return (pc & 0xf800) + ((buf[0] & 0xe0) << 3) + buf[1];
+	return apply_bank(bank, (pc & 0xf800) + ((buf[0] & 0xe0) << 3) + buf[1]);
 }
 
 static inline ut8 arg_bit(ut8 bit_addr) {

--- a/test/db/analysis/8051
+++ b/test/db/analysis/8051
@@ -202,3 +202,165 @@ EXPECT=<<EOF
 jump: 0x00001216
 EOF
 RUN
+
+NAME=8051: [ACALL addr11] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx f123 ; pi 1 ; ao 1~jump
+EXPECT=<<EOF
+acall 0x11723
+jump: 0x00011723
+EOF
+RUN
+
+NAME=8051: [AJMP addr11] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx e123 ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+ajmp 0x11723
+jump: 0x00011723
+EOF
+RUN
+
+NAME=8051: [CJNE a,imm,offs] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx b4ab13 ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+cjne a, #0xab, 0x11216
+jump: 0x00011216
+EOF
+RUN
+
+NAME=8051: [CJNE a,dir,offs] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx b56018 ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+cjne a, 0x60, 0x1121b
+jump: 0x0001121b
+EOF
+RUN
+
+NAME=8051: [CJNE @r1,imm,offs] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx b72432 ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+cjne @r1, #0x24, 0x11235
+jump: 0x00011235
+EOF
+RUN
+
+NAME=8051: [CJNE r7,imm,offs] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx bf0205 ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+cjne r7, #0x02, 0x11208
+jump: 0x00011208
+EOF
+RUN
+
+NAME=8051: [DJNZ dir,offs] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx d54088 ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+djnz 0x40, 0x1118b
+jump: 0x0001118b
+EOF
+RUN
+
+NAME=8051: [DJNZ r0,offs] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx d8fc ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+djnz r0, 0x111fe
+jump: 0x000111fe
+EOF
+RUN
+
+NAME=8051: [JB bit,offs] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx 207d03 ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+jb 0x2f.5, 0x11206
+jump: 0x00011206
+EOF
+RUN
+
+NAME=8051: [JBC bit,offs] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx 101508 ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+jbc 0x22.5, 0x1120b
+jump: 0x0001120b
+EOF
+RUN
+
+NAME=8051: [JC offs] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx 4003 ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+jc 0x11205
+jump: 0x00011205
+EOF
+RUN
+
+NAME=8051: [JNB bit,offs] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx 305108 ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+jnb 0x2a.1, 0x1120b
+jump: 0x0001120b
+EOF
+RUN
+
+NAME=8051: [JNC offs] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx 5007 ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+jnc 0x11209
+jump: 0x00011209
+EOF
+RUN
+
+NAME=8051: [JNZ offs] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx 7013 ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+jnz 0x11215
+jump: 0x00011215
+EOF
+RUN
+
+NAME=8051: [JZ offs] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx 6015 ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+jz 0x11217
+jump: 0x00011217
+EOF
+RUN
+
+NAME=8051: [LCALL add16] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx 12b6cf ; pi 1 ; ao 1~jump
+EXPECT=<<EOF
+lcall 0x1b6cf
+jump: 0x0001b6cf
+EOF
+RUN
+
+NAME=8051: [LJMP addr16] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx 022c0d ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+ljmp 0x12c0d
+jump: 0x00012c0d
+EOF
+RUN
+
+NAME=8051: [SJMP offs] - bank jump check
+FILE=malloc://0x20000
+CMDS=e asm.arch=8051 ; s 0x11200 ; wx 8014 ; pi 1 ; ao 1~^jump
+EXPECT=<<EOF
+sjmp 0x11216
+jump: 0x00011216
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

8051 can only address 16bits so we take the higher ones from the address of the instruction itself so code can be relocated as long as it is aligned to 0x10000.

Practical use: when needing more code than one 16bit space can hold, 8051 can do bankswitching between multiple 16bit banks. Mapping all of these banks can be done in rizin by just mapping them one after each other. In such a case, you need the above behavior so higher banks than 0 have their jump targets correct.