### PR TITLE
New string information API

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -4517,3 +4517,81 @@ RZ_API char *rz_core_bin_method_flags_str(ut64 flags, int mode) {
 out:
 	return rz_strbuf_drain(buf);
 }
+
+static RzCoreStringKind get_string_kind(const ut8 *buf, ut64 len) {
+	rz_return_val_if_fail(buf && len, RZ_CORE_STRING_KIND_UNKNOWN);
+	ut64 needle = 0;
+	ut64 rc, i;
+	RzCoreStringKind str_kind = RZ_CORE_STRING_KIND_UNKNOWN;
+
+	while (needle < len) {
+		rc = rz_utf8_decode(buf + needle, len - needle, NULL);
+		if (!rc) {
+			needle++;
+			continue;
+		}
+		if (needle + rc + 2 < len &&
+			buf[needle + rc + 0] == 0x00 &&
+			buf[needle + rc + 1] == 0x00 &&
+			buf[needle + rc + 2] == 0x00) {
+			str_kind = RZ_CORE_STRING_KIND_WIDE16;
+		} else {
+			str_kind = RZ_CORE_STRING_KIND_ASCII;
+		}
+		for (i = 0; needle < len; i += rc) {
+			RzRune r;
+			if (str_kind == RZ_CORE_STRING_KIND_WIDE16) {
+				if (needle + 1 < len) {
+					r = buf[needle + 1] << 8 | buf[needle];
+					rc = 2;
+				} else {
+					break;
+				}
+			} else {
+				rc = rz_utf8_decode(buf + needle, len - needle, &r);
+				if (rc > 1) {
+					str_kind = RZ_CORE_STRING_KIND_UTF8;
+				}
+			}
+			/*Invalid sequence detected*/
+			if (!rc) {
+				needle++;
+				break;
+			}
+			needle += rc;
+		}
+	}
+	return str_kind;
+}
+
+/**
+ * \brief Returns the information about string given the offset and legnth
+ *
+ * \param core RzCore instance
+ * \param block Pointer to the string
+ * \param len Length of the string
+ * \param type A type of the string to override autodetection
+ */
+RZ_OWN RZ_API RzCoreString *rz_core_string_information(RzCore *core, const char *block, ut32 len, RzCoreStringKind kind) {
+	rz_return_val_if_fail(core && block && len, NULL);
+	RzCoreString *cstring = RZ_NEW0(RzCoreString);
+	if (!cstring) {
+		return NULL;
+	}
+	const char *section_name = rz_core_get_section_name(core, core->offset);
+	if (section_name && strlen(section_name) < 1) {
+		section_name = "unknown";
+	}
+	cstring->section_name = section_name;
+	cstring->string = block;
+	cstring->offset = core->offset;
+	cstring->size = len;
+	if (kind != RZ_CORE_STRING_KIND_UNKNOWN) {
+		cstring->kind = kind;
+	} else {
+		cstring->kind = get_string_kind((const ut8 *)block, len);
+	}
+	// FIXME: Add proper length calculation (see functions in librz/util/str.c)
+	cstring->length = cstring->size;
+	return cstring;
+}

--- a/librz/core/cmd_print.c
+++ b/librz/core/cmd_print.c
@@ -1261,54 +1261,6 @@ err:
 	rz_config_set_i(core->config, "hex.cols", hex_cols);
 }
 
-static char get_string_type(const ut8 *buf, ut64 len) {
-	ut64 needle = 0;
-	int rc, i;
-	char str_type = 0;
-
-	if (!buf) {
-		return '?';
-	}
-	while (needle < len) {
-		rc = rz_utf8_decode(buf + needle, len - needle, NULL);
-		if (!rc) {
-			needle++;
-			continue;
-		}
-		if (needle + rc + 2 < len &&
-			buf[needle + rc + 0] == 0x00 &&
-			buf[needle + rc + 1] == 0x00 &&
-			buf[needle + rc + 2] == 0x00) {
-			str_type = 'w';
-		} else {
-			str_type = 'a';
-		}
-		for (i = 0; needle < len; i += rc) {
-			RzRune r;
-			if (str_type == 'w') {
-				if (needle + 1 < len) {
-					r = buf[needle + 1] << 8 | buf[needle];
-					rc = 2;
-				} else {
-					break;
-				}
-			} else {
-				rc = rz_utf8_decode(buf + needle, len - needle, &r);
-				if (rc > 1) {
-					str_type = 'u';
-				}
-			}
-			/*Invalid sequence detected*/
-			if (!rc) {
-				needle++;
-				break;
-			}
-			needle += rc;
-		}
-	}
-	return str_type;
-}
-
 static void cmd_print_eq_dict(RzCore *core, const ut8 *block, int bsz) {
 	int i;
 	int min = -1;
@@ -4595,25 +4547,40 @@ static inline int cmd_pxb_k(const ut8 *buffer, int x) {
 	return buffer[3 - x] << (8 * x);
 }
 
-static void print_json_string(RzCore *core, const char *block, int len, const char *type) {
-	const char *section_name = rz_core_get_section_name(core, core->offset);
-	if (section_name && strlen(section_name) < 1) {
-		section_name = "unknown";
-	} else {
-		// cleaning useless spaces in section name in json data.
-		section_name = rz_str_trim_head_ro(section_name);
-		char *p;
-		for (p = (char *)section_name; *p && *p != ' '; p++) {
-		}
-		*p = '\0';
+static void print_json_string(RzCore *core, const char *block, ut32 len, RzCoreStringKind kind) {
+	RzCoreString *cstring = rz_core_string_information(core, block, len, kind);
+	if (!cstring) {
+		return;
 	}
-	if (!type) {
-		switch (get_string_type(core->block, len)) {
-		case 'w': type = "wide"; break;
-		case 'a': type = "ascii"; break;
-		case 'u': type = "utf"; break;
-		default: type = "unknown"; break;
-		}
+	// cleaning useless spaces in section name in json data.
+	char *section_name = strdup(rz_str_trim_head_ro(cstring->section_name));
+	char *p;
+	for (p = (char *)section_name; *p && *p != ' '; p++) {
+	}
+	*p = '\0';
+	char *kindstr;
+	switch (cstring->kind) {
+	case RZ_CORE_STRING_KIND_ASCII:
+		kindstr = "ascii";
+		break;
+	case RZ_CORE_STRING_KIND_WIDE16: // No UTF/Unicode encoding
+		kindstr = "wide16";
+		break;
+	case RZ_CORE_STRING_KIND_WIDE32: // NO UTF/Unicode encoding
+		kindstr = "wide32";
+		break;
+	case RZ_CORE_STRING_KIND_UTF8:
+		kindstr = "utf8";
+		break;
+	case RZ_CORE_STRING_KIND_UTF16:
+		kindstr = "utf16";
+		break;
+	case RZ_CORE_STRING_KIND_UTF32:
+		kindstr = "utf32";
+		break;
+	default:
+		kindstr = "unknown";
+		break;
 	}
 	PJ *pj = rz_core_pj_new(core);
 	if (!pj) {
@@ -4622,18 +4589,20 @@ static void print_json_string(RzCore *core, const char *block, int len, const ch
 	pj_o(pj);
 	pj_k(pj, "string");
 	// TODO: add pj_kd for data to pass key(string) and value(data,len) instead of pj_ks which null terminates
-	char *str = rz_str_utf16_encode(block, len); // XXX just block + len should be fine, pj takes care of this
+	char *str = rz_str_utf16_encode(cstring->string, cstring->size); // XXX just block + len should be fine, pj takes care of this
 	pj_raw(pj, "\"");
 	pj_raw(pj, str);
 	free(str);
 	pj_raw(pj, "\"");
-	pj_kn(pj, "offset", core->offset);
+	pj_kn(pj, "offset", cstring->offset);
 	pj_ks(pj, "section", section_name);
-	pj_ki(pj, "length", len);
-	pj_ks(pj, "type", type);
+	pj_ki(pj, "length", cstring->length);
+	pj_ks(pj, "type", kindstr);
 	pj_end(pj);
 	rz_cons_println(pj_string(pj));
 	pj_free(pj);
+	free(section_name);
+	free(cstring);
 }
 
 static char *__op_refs(RzCore *core, RzAnalysisOp *op, int n) {
@@ -5770,7 +5739,7 @@ RZ_IPI int rz_cmd_print(void *data, const char *input) {
 					len = rz_num_math(core->num, input + 3);
 					len = RZ_MIN(len, core->blocksize);
 				}
-				print_json_string(core, (const char *)core->block, len, NULL);
+				print_json_string(core, (const char *)core->block, len, RZ_CORE_STRING_KIND_UNKNOWN);
 			}
 			break;
 		case 'i': // "psi"
@@ -5867,7 +5836,7 @@ RZ_IPI int rz_cmd_print(void *data, const char *input) {
 					}
 					s[j] = '\0';
 					if (input[2] == 'j') { // pszj
-						print_json_string(core, (const char *)s, j, NULL);
+						print_json_string(core, (const char *)s, j, RZ_CORE_STRING_KIND_UNKNOWN);
 					} else {
 						rz_cons_println(s);
 					}
@@ -5881,7 +5850,7 @@ RZ_IPI int rz_cmd_print(void *data, const char *input) {
 				// TODO: add support for 2-4 byte length pascal strings
 				if (mylen < core->blocksize) {
 					if (input[2] == 'j') { // pspj
-						print_json_string(core, (const char *)core->block + 1, mylen, NULL);
+						print_json_string(core, (const char *)core->block + 1, mylen, RZ_CORE_STRING_KIND_UNKNOWN);
 					} else {
 						rz_print_string(core->print, core->offset,
 							core->block + 1, mylen, RZ_PRINT_STRING_ZEROEND);
@@ -5895,7 +5864,7 @@ RZ_IPI int rz_cmd_print(void *data, const char *input) {
 		case 'w': // "psw"
 			if (l > 0) {
 				if (input[2] == 'j') { // pswj
-					print_json_string(core, (const char *)core->block, len, "wide");
+					print_json_string(core, (const char *)core->block, len, RZ_CORE_STRING_KIND_WIDE16);
 				} else {
 					rz_print_string(core->print, core->offset, core->block, len,
 						RZ_PRINT_STRING_WIDE | RZ_PRINT_STRING_ZEROEND);
@@ -5905,7 +5874,7 @@ RZ_IPI int rz_cmd_print(void *data, const char *input) {
 		case 'W': // "psW"
 			if (l > 0) {
 				if (input[2] == 'j') { // psWj
-					print_json_string(core, (const char *)core->block, len, "wide32");
+					print_json_string(core, (const char *)core->block, len, RZ_CORE_STRING_KIND_WIDE32);
 				} else {
 					rz_print_string(core->print, core->offset, core->block, len,
 						RZ_PRINT_STRING_WIDE32 | RZ_PRINT_STRING_ZEROEND);
@@ -5933,7 +5902,7 @@ RZ_IPI int rz_cmd_print(void *data, const char *input) {
 					json = input[3] == 'j'; // "psuzj"
 				}
 				if (json) { // psuj
-					print_json_string(core, (const char *)core->block, len, "utf16");
+					print_json_string(core, (const char *)core->block, len, RZ_CORE_STRING_KIND_UTF16);
 				} else {
 					char *str = rz_str_utf16_encode((const char *)core->block, len);
 					rz_cons_println(str);
@@ -5974,7 +5943,7 @@ RZ_IPI int rz_cmd_print(void *data, const char *input) {
 						rz_core_cmdf(core, "ps%c @ 0x%" PFMT32x, json ? 'j' : ' ', *((ut32 *)core->block + 2));
 					}
 				} else if (json) {
-					print_json_string(core, (const char *)core->block + 1, len, NULL);
+					print_json_string(core, (const char *)core->block + 1, len, RZ_CORE_STRING_KIND_UNKNOWN);
 				} else {
 					rz_print_string(core->print, core->offset, core->block + 1,
 						len, RZ_PRINT_STRING_ZEROEND);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -802,6 +802,45 @@ RZ_API char *rz_core_bin_method_build_flag_name(RzBinClass *cls, RzBinSymbol *me
 RZ_API char *rz_core_bin_method_flags_str(ut64 flags, int mode);
 RZ_API bool rz_core_pdb_info(RzCore *core, const char *file, PJ *pj, int mode);
 
+typedef enum {
+	RZ_CORE_STRING_KIND_UNKNOWN,
+	RZ_CORE_STRING_KIND_ASCII,
+	RZ_CORE_STRING_KIND_WIDE16, // No UTF/Unicode encoding
+	RZ_CORE_STRING_KIND_WIDE32, // NO UTF/Unicode encoding
+	RZ_CORE_STRING_KIND_UTF8,
+	RZ_CORE_STRING_KIND_UTF16,
+	RZ_CORE_STRING_KIND_UTF32,
+} RzCoreStringKind;
+
+/**
+ * \brief A structure to hold information about string - type, size, and location
+ */
+typedef struct rz_core_string_t {
+	/**
+	 * The pointer to the string data itself.
+	 */
+	const char *string;
+	ut64 offset;
+	/**
+	 * Size of buffer containing the string in bytes.
+	 */
+	ut32 size;
+	/**
+	 * Length of string in chars.
+	 */
+	ut32 length;
+	/**
+	 * A string kind - ASCII, Wide, or various Unicode types.
+	 */
+	RzCoreStringKind kind;
+	/**
+	 * A section name that contains the string.
+	 */
+	const char *section_name;
+} RzCoreString;
+
+RZ_API RZ_OWN RzCoreString *rz_core_string_information(RzCore *core, const char *block, ut32 len, RzCoreStringKind kind);
+
 /* rtr */
 RZ_API int rz_core_rtr_cmds(RzCore *core, const char *port);
 RZ_API char *rz_core_rtr_cmds_query(RzCore *core, const char *host, const char *port, const char *cmd);

--- a/test/db/cmd/cmd_ps
+++ b/test/db/cmd/cmd_ps
@@ -50,17 +50,6 @@ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
 EOF
 RUN
 
-NAME=psj ascii (#9064)
-FILE==
-CMDS=<<EOF
-"wz ...\"..����..."
-psj 13
-EOF
-EXPECT=<<EOF
-{"string":"...\"..\u00ef\u00bf\u00bd\u00ef\u00bf\u00bd\u00ef","offset":0,"section":"unknown","length":13,"type":"utf"}
-EOF
-RUN
-
 NAME=psx escapes newlines (#10037)
 FILE==
 CMDS=<<EOF

--- a/test/db/cmd/cmd_psj
+++ b/test/db/cmd/cmd_psj
@@ -9,28 +9,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=psj utf
-FILE=malloc://128
-CMDS=<<EOF
-wx e9bb91e5aea2
-psj 6
-EOF
-EXPECT=<<EOF
-{"string":"\u00e9\u00bb\u0091\u00e5\u00ae\u00a2","offset":0,"section":"unknown","length":6,"type":"utf"}
-EOF
-RUN
-
-NAME=psj wide
-FILE=bins/elf/analysis/x86-helloworld-gcc
-CMDS=<<EOF
-s 0x08049600
-psj 4
-EOF
-EXPECT=<<EOF
-{"string":"\u000b\u0000\u0000\u0000","offset":134518272,"section":".dynamic","length":4,"type":"wide"}
-EOF
-RUN
-
 NAME=psj ascii 2
 FILE=bins/elf/analysis/hello-android-arm
 CMDS=<<EOF
@@ -41,3 +19,37 @@ EXPECT=<<EOF
 {"string":"Hello World","offset":33624,"section":".rodata","length":11,"type":"ascii"}
 EOF
 RUN
+
+NAME=psj utf8
+FILE=malloc://128
+CMDS=<<EOF
+wx e9bb91e5aea2
+psj 6
+EOF
+EXPECT=<<EOF
+{"string":"\u00e9\u00bb\u0091\u00e5\u00ae\u00a2","offset":0,"section":"unknown","length":6,"type":"utf8"}
+EOF
+RUN
+
+NAME=psj utf8 (#9064)
+FILE==
+CMDS=<<EOF
+"wz ...\"..����..."
+psj 13
+EOF
+EXPECT=<<EOF
+{"string":"...\"..\u00ef\u00bf\u00bd\u00ef\u00bf\u00bd\u00ef","offset":0,"section":"unknown","length":13,"type":"utf8"}
+EOF
+RUN
+
+NAME=psj wide16
+FILE=bins/elf/analysis/x86-helloworld-gcc
+CMDS=<<EOF
+s 0x08049600
+psj 4
+EOF
+EXPECT=<<EOF
+{"string":"\u000b\u0000\u0000\u0000","offset":134518272,"section":".dynamic","length":4,"type":"wide16"}
+EOF
+RUN
+


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Currently the only way to get information about string was running a corresponding `ps` command. This introduces new function
```c
RZ_OWN RZ_API RzCoreString *rz_core_string_information(RzCore *core, const char *block, ut32 len, RzCoreStringKind kind)
```
It returns the result in form of this structure:
```c
typedef struct rz_core_string_t {
	const char *string;
	ut64 offset;
	ut32 size; // size of buffer containing the string in bytes
	ut32 length; // length of string in chars
	RzCoreStringKind kind; // Ascii Wide cp850 utf8 base64 ...
	const char *section_name;
} RzCoreString;
```

The corresponding `ps` commands switched to use this new API.
The underlying logic lacks some of the stuff - UTF32 detection, etc.
In the future there could be more connection between this and `librz/util/str.c` functions, also with `RzBinString` and `iz` commands.

**Test plan**

CI is green
