### PR TITLE
Track all related RzIOMaps and RzIODescs in RzCoreFile and other stories

### DIFF
--- a/librz/bin/bfile.c
+++ b/librz/bin/bfile.c
@@ -672,20 +672,14 @@ RZ_API bool rz_bin_file_set_cur_by_name(RzBin *bin, const char *name) {
 	return rz_bin_file_set_cur_binfile(bin, bf);
 }
 
-RZ_API bool rz_bin_file_deref(RzBin *bin, RzBinFile *a) {
-	rz_return_val_if_fail(bin && a, false);
-	if (!rz_bin_cur_object(bin)) {
-		return false;
-	}
-	bin->cur = NULL;
-	return true;
-}
-
 RZ_API void rz_bin_file_free(void /*RzBinFile*/ *_bf) {
 	if (!_bf) {
 		return;
 	}
 	RzBinFile *bf = _bf;
+	if (bf->rbin->cur == bf) {
+		bf->rbin->cur = NULL;
+	}
 	RzBinPlugin *plugin = rz_bin_file_cur_plugin(bf);
 	// Binary format objects are connected to the
 	// RzBinObject, so the plugin must destroy the

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -627,7 +627,7 @@ typedef struct {
 static bool findFile(void *user, void *data, ut32 id) {
 	FindFile *res = (FindFile *)user;
 	RzIODesc *desc = (RzIODesc *)data;
-	if (desc->perm && res->perm && !strcmp(desc->uri, res->uri)) {
+	if (desc->perm == res->perm && !strcmp(desc->uri, res->uri)) {
 		res->desc = desc;
 		return false;
 	}

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -2345,6 +2345,7 @@ static void ev_iowrite_cb(RzEvent *ev, int type, void *user, void *data) {
 
 RZ_IPI void rz_core_task_ctx_switch(RzCoreTask *next, void *user);
 RZ_IPI void rz_core_task_break_cb(RzCoreTask *task, void *user);
+RZ_IPI void rz_core_file_free(RzCoreFile *cf);
 
 RZ_API bool rz_core_init(RzCore *core) {
 	core->blocksize = RZ_CORE_BLOCKSIZE;

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -2343,6 +2343,19 @@ static void ev_iowrite_cb(RzEvent *ev, int type, void *user, void *data) {
 	}
 }
 
+RZ_IPI void rz_core_file_io_desc_closed(RzCore *core, RzIODesc *desc);
+RZ_IPI void rz_core_file_io_map_deleted(RzCore *core, RzIOMap *map);
+
+static void ev_iodescclose_cb(RzEvent *ev, int type, void *user, void *data) {
+	RzEventIODescClose *ioc = data;
+	rz_core_file_io_desc_closed(user, ioc->desc);
+}
+
+static void ev_iomapdel_cb(RzEvent *ev, int type, void *user, void *data) {
+	RzEventIOMapDel *iod = data;
+	rz_core_file_io_map_deleted(user, iod->map);
+}
+
 RZ_IPI void rz_core_task_ctx_switch(RzCoreTask *next, void *user);
 RZ_IPI void rz_core_task_break_cb(RzCoreTask *task, void *user);
 RZ_IPI void rz_core_file_free(RzCoreFile *cf);
@@ -2469,6 +2482,8 @@ RZ_API bool rz_core_init(RzCore *core) {
 	rz_bin_set_user_ptr(core->bin, core);
 	core->io = rz_io_new();
 	rz_event_hook(core->io->event, RZ_EVENT_IO_WRITE, ev_iowrite_cb, core);
+	rz_event_hook(core->io->event, RZ_EVENT_IO_DESC_CLOSE, ev_iodescclose_cb, core);
+	rz_event_hook(core->io->event, RZ_EVENT_IO_MAP_DEL, ev_iomapdel_cb, core);
 	core->io->ff = 1;
 	core->search = rz_search_new(RZ_SEARCH_KEYWORD);
 	core->flags = rz_flag_new();

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -849,7 +849,6 @@ RZ_API RzBinFile *rz_bin_file_find_by_name(RzBin *bin, const char *name);
 
 RZ_API bool rz_bin_file_set_cur_binfile(RzBin *bin, RzBinFile *bf);
 RZ_API bool rz_bin_file_set_cur_by_name(RzBin *bin, const char *name);
-RZ_API bool rz_bin_file_deref(RzBin *bin, RzBinFile *a);
 RZ_API bool rz_bin_file_set_cur_by_fd(RzBin *bin, ut32 bin_fd);
 RZ_API bool rz_bin_file_set_cur_by_id(RzBin *bin, ut32 bin_id);
 RZ_API bool rz_bin_file_set_cur_by_name(RzBin *bin, const char *name);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -136,6 +136,8 @@ typedef struct rz_core_file_t {
 	struct rz_core_t *core;
 	int dbg;
 	int fd;
+	RzPVector /*<RzIODesc>*/ extra_files; ///< additional files opened during mapping, for example for zeroed maps
+	RzPVector /*<RzIOMap>*/ maps; ///< all maps that have been created as a result of loading this file
 } RzCoreFile;
 
 typedef struct rz_core_times_t {

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -133,11 +133,9 @@ typedef struct rz_core_seek_undo_t {
 } RzCoreSeekItem;
 
 typedef struct rz_core_file_t {
+	struct rz_core_t *core;
 	int dbg;
 	int fd;
-	RzBinBind binb;
-	const struct rz_core_t *core;
-	ut8 alive;
 } RzCoreFile;
 
 typedef struct rz_core_times_t {
@@ -540,11 +538,10 @@ RZ_API int rz_core_file_set_by_name(RzCore *core, const char *name);
 RZ_API int rz_core_file_set_by_file(RzCore *core, RzCoreFile *cf);
 RZ_API int rz_core_setup_debugger(RzCore *r, const char *debugbackend, bool attach);
 
-RZ_API void rz_core_file_free(RzCoreFile *cf);
 RZ_API RzCoreFile *rz_core_file_open(RzCore *core, const char *file, int flags, ut64 loadaddr);
 RZ_API RzCoreFile *rz_core_file_open_many(RzCore *r, const char *file, int flags, ut64 loadaddr);
 RZ_API RzCoreFile *rz_core_file_get_by_fd(RzCore *core, int fd);
-RZ_API int rz_core_file_close(RzCore *core, RzCoreFile *fh);
+RZ_API void rz_core_file_close(RzCoreFile *fh);
 RZ_API bool rz_core_file_close_fd(RzCore *core, int fd);
 RZ_API bool rz_core_file_close_all_but(RzCore *core);
 RZ_API int rz_core_file_list(RzCore *core, int mode);

--- a/librz/include/rz_io.h
+++ b/librz/include/rz_io.h
@@ -168,6 +168,20 @@ typedef struct rz_io_desc_cache_t {
 	ut8 cdata[RZ_IO_DESC_CACHE_SIZE];
 } RzIODescCache;
 
+typedef struct rz_event_io_write_t {
+	ut64 addr;
+	const ut8 *buf;
+	int len;
+} RzEventIOWrite;
+
+typedef struct rz_event_io_desc_close_t {
+	RzIODesc *desc;
+} RzEventIODescClose;
+
+typedef struct rz_event_io_map_del_t {
+	RzIOMap *map;
+} RzEventIOMapDel;
+
 struct rz_io_bind_t;
 
 typedef bool (*RzIODescUse)(RzIO *io, int fd);

--- a/librz/include/rz_util/rz_event.h
+++ b/librz/include/rz_util/rz_event.h
@@ -39,6 +39,8 @@ typedef enum {
 	RZ_EVENT_CLASS_ATTR_RENAME, // RzEventClassAttrRename
 	RZ_EVENT_DEBUG_PROCESS_FINISHED, // RzEventDebugProcessFinished
 	RZ_EVENT_IO_WRITE, // RzEventIOWrite
+	RZ_EVENT_IO_DESC_CLOSE, // RzEventIODescClose
+	RZ_EVENT_IO_MAP_DEL, // RzEventIOMapDel
 	RZ_EVENT_MAX,
 } RzEventType;
 
@@ -76,12 +78,6 @@ typedef struct rz_event_class_attr_rename_t {
 typedef struct rz_event_debug_process_finished_t {
 	int pid;
 } RzEventDebugProcessFinished;
-
-typedef struct rz_event_io_write_t {
-	ut64 addr;
-	const ut8 *buf;
-	int len;
-} RzEventIOWrite;
 
 RZ_API RzEvent *rz_event_new(void *user);
 RZ_API void rz_event_free(RzEvent *ev);

--- a/librz/io/io.c
+++ b/librz/io/io.c
@@ -256,10 +256,9 @@ RZ_API int rz_io_close_all(RzIO *io) { // what about undo?
 		return false;
 	}
 	rz_io_desc_fini(io);
-	rz_io_map_fini(io);
+	rz_io_map_reset(io);
 	rz_list_free(io->plugins);
 	rz_io_desc_init(io);
-	rz_io_map_init(io);
 	rz_io_cache_fini(io);
 	rz_io_plugin_init(io);
 	return true;

--- a/librz/io/io_desc.c
+++ b/librz/io/io_desc.c
@@ -163,14 +163,15 @@ RZ_API RzIODesc *rz_io_desc_open_plugin(RzIO *io, RzIOPlugin *plugin, const char
 }
 
 RZ_API bool rz_io_desc_close(RzIODesc *desc) {
-	RzIO *io;
 	if (!desc || !desc->io || !desc->plugin) {
 		return false;
 	}
+	RzIO *io = desc->io;
+	RzEventIODescClose ev = { desc };
+	rz_event_send(io->event, RZ_EVENT_IO_DESC_CLOSE, &ev);
 	if (desc->plugin->close && desc->plugin->close(desc)) {
 		return false;
 	}
-	io = desc->io;
 	// remove entry from idstorage and free the desc-struct
 	rz_io_desc_del(io, desc->fd);
 	// remove all dead maps

--- a/librz/io/io_map.c
+++ b/librz/io/io_map.c
@@ -81,7 +81,8 @@ RZ_API bool rz_io_map_remap_fd(RzIO *io, int fd, ut64 addr) {
 	return retval;
 }
 
-static void _map_free(void *p) {
+/// Free-only. Be careful to only call this after sending RZ_EVENT_IO_MAP_DEL! (map_del does this)
+static void map_free(void *p) {
 	RzIOMap *map = (RzIOMap *)p;
 	if (map) {
 		free(map->name);
@@ -89,9 +90,18 @@ static void _map_free(void *p) {
 	}
 }
 
+/// Free the map, also sending the appropriate event.
+static void map_del(RzIO *io, RzIOMap *map) {
+	rz_return_if_fail(io && map);
+	RzEventIOMapDel ev = { map };
+	rz_event_send(io->event, RZ_EVENT_IO_MAP_DEL, &ev);
+	rz_id_pool_kick_id(io->map_ids, map->id);
+	map_free(map);
+}
+
 RZ_API void rz_io_map_init(RzIO *io) {
 	rz_return_if_fail(io);
-	rz_pvector_init(&io->maps, _map_free);
+	rz_pvector_init(&io->maps, map_free);
 	if (io->map_ids) {
 		rz_id_pool_free(io->map_ids);
 	}
@@ -175,6 +185,12 @@ RZ_API bool rz_io_map_is_mapped(RzIO *io, ut64 addr) {
 }
 
 RZ_API void rz_io_map_reset(RzIO *io) {
+	void **it;
+	rz_pvector_foreach (&io->maps, it) {
+		RzIOMap *map = *it;
+		RzEventIOMapDel ev = { map };
+		rz_event_send(io->event, RZ_EVENT_IO_MAP_DEL, &ev);
+	}
 	rz_io_map_fini(io);
 	rz_io_map_init(io);
 	io_map_calculate_skyline(io);
@@ -187,8 +203,7 @@ RZ_API bool rz_io_map_del(RzIO *io, ut32 id) {
 		RzIOMap *map = rz_pvector_at(&io->maps, i);
 		if (map->id == id) {
 			rz_pvector_remove_at(&io->maps, i);
-			_map_free(map);
-			rz_id_pool_kick_id(io->map_ids, id);
+			map_del(io, map);
 			io_map_calculate_skyline(io);
 			return true;
 		}
@@ -206,10 +221,8 @@ RZ_API bool rz_io_map_del_for_fd(RzIO *io, int fd) {
 		if (!map) {
 			rz_pvector_remove_at(&io->maps, i);
 		} else if (map->fd == fd) {
-			rz_id_pool_kick_id(io->map_ids, map->id);
-			//delete iter and map
 			rz_pvector_remove_at(&io->maps, i);
-			_map_free(map);
+			map_del(io, map);
 			ret = true;
 		} else {
 			i++;
@@ -297,9 +310,8 @@ RZ_API void rz_io_map_cleanup(RzIO *io) {
 			del = true;
 		} else if (!rz_io_desc_get(io, map->fd)) {
 			//delete map and iter if no desc exists for map->fd in io->files
-			rz_id_pool_kick_id(io->map_ids, map->id);
 			map = rz_pvector_remove_at(&io->maps, i);
-			_map_free(map);
+			map_del(io, map);
 			del = true;
 		} else {
 			i++;

--- a/librz/main/rz-bin.c
+++ b/librz/main/rz-bin.c
@@ -1045,7 +1045,7 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 			fd = rz_io_fd_get_current(core.io);
 			if (fd == -1) {
 				eprintf("rz_core: Cannot open file '%s'\n", file);
-				rz_core_file_free(fh);
+				rz_core_file_close(fh);
 				rz_core_fini(&core);
 				return 1;
 			}
@@ -1070,7 +1070,7 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 		//but we have yet the chance that this file is a fat binary
 		if (!bin->cur || !bin->cur->xtr_data) {
 			eprintf("rz-bin: Cannot open file\n");
-			rz_core_file_free(fh);
+			rz_core_file_close(fh);
 			rz_core_fini(&core);
 			return 1;
 		}
@@ -1099,7 +1099,7 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 				sdb_query(bin->cur->sdb, query);
 			}
 		}
-		rz_core_file_free(fh);
+		rz_core_file_close(fh);
 		rz_core_fini(&core);
 		return 0;
 	}
@@ -1198,7 +1198,7 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 	}
 	pj_free(pj);
 	rz_cons_flush();
-	rz_core_file_free(fh);
+	rz_core_file_close(fh);
 	rz_core_fini(&core);
 
 	return result;

--- a/test/db/formats/elf/core
+++ b/test/db/formats/elf/core
@@ -67,7 +67,7 @@ om
 EOF
 EXPECT=<<EOF
 21 fd: 3 +0x00001000 0x56621000 - 0x56621fff r-- fmap./home/florian/dev/crash/crash-linux-x86
-20 fd: 6 +0x00000000 0x56622000 - 0x56622fff r-- mmap./home/florian/dev/crash/crash-linux-x86
+20 fd: 10 +0x00000000 0x56622000 - 0x56622fff r-x mmap./home/florian/dev/crash/crash-linux-x86
 19 fd: 6 +0x00000000 0x56623000 - 0x56623fff r-- mmap./home/florian/dev/crash/crash-linux-x86
 18 fd: 3 +0x00002000 0x56624000 - 0x56624fff r-- fmap./home/florian/dev/crash/crash-linux-x86
 17 fd: 3 +0x00003000 0x56625000 - 0x56625fff r-- fmap./home/florian/dev/crash/crash-linux-x86
@@ -117,7 +117,7 @@ om
 EOF
 EXPECT=<<EOF
 22 fd: 3 +0x00002000 0x56149dfaf000 - 0x56149dfaffff r-- fmap./home/florian/dev/crash/crash-linux-x86_64
-21 fd: 9 +0x00000000 0x56149dfb0000 - 0x56149dfb0fff r-- mmap./home/florian/dev/crash/crash-linux-x86_64
+21 fd: 10 +0x00000000 0x56149dfb0000 - 0x56149dfb0fff r-x mmap./home/florian/dev/crash/crash-linux-x86_64
 20 fd: 9 +0x00000000 0x56149dfb1000 - 0x56149dfb1fff r-- mmap./home/florian/dev/crash/crash-linux-x86_64
 19 fd: 3 +0x00003000 0x56149dfb2000 - 0x56149dfb2fff r-- fmap./home/florian/dev/crash/crash-linux-x86_64
 18 fd: 3 +0x00004000 0x56149dfb3000 - 0x56149dfb3fff r-- fmap./home/florian/dev/crash/crash-linux-x86_64

--- a/test/db/formats/pe/hellocxx
+++ b/test/db/formats/pe/hellocxx
@@ -16,7 +16,7 @@ FILE=bins/pe/hellocxx-mingw32.exe
 CMDS=om
 EXPECT=<<EOF
  9 fd: 3 +0x00000400 0x00401000 - 0x00440bff r-x fmap..text
- 8 fd: 6 +0x00000000 0x00440c00 - 0x00440fff r-- mmap..text
+ 8 fd: 8 +0x00000000 0x00440c00 - 0x00440fff r-x mmap..text
  7 fd: 3 +0x00040000 0x00441000 - 0x004411ff r-- fmap..data
  6 fd: 7 +0x00000000 0x00441200 - 0x00441fff rw- mmap..data
  5 fd: 3 +0x00040200 0x00442000 - 0x00444bff r-- fmap..rdata

--- a/test/integration/test_open_analyse_save_load_project.c
+++ b/test/integration/test_open_analyse_save_load_project.c
@@ -44,15 +44,12 @@ bool test_open_analyse_save() {
 	mu_assert_eq(err, RZ_PROJECT_ERR_SUCCESS, "project save err");
 
 	// 5. Close the file
-	rz_core_file_free(file);
+	rz_core_file_close(file);
 	rz_core_free(core);
 
-	// 6. Open the file again
+	// 6. Create a new core
 	core = rz_core_new();
 	mu_assert_notnull(core, "new RzCore instance");
-	file = rz_core_file_open(core, fpath, RZ_PERM_R, loadaddr);
-	mu_assert_notnull(file, "open file");
-	rz_core_bin_load(core, fpath, loadaddr);
 
 	// 7. Load the previously saved project
 	RzSerializeResultInfo *res = rz_serialize_result_info_new();
@@ -69,7 +66,6 @@ bool test_open_analyse_save() {
 
 	// 10. Exit
 	rz_serialize_result_info_free(res);
-	rz_core_file_free(file);
 	rz_core_free(core);
 	mu_end;
 }

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -26,6 +26,7 @@ if get_option('enable_tests')
     'config',
     'cons',
     'contrbtree',
+    'core_bin',
     'core_cmd',
     'core_seek',
     'core_task',

--- a/test/unit/test_core_bin.c
+++ b/test/unit/test_core_bin.c
@@ -122,7 +122,7 @@ bool test_map_close(void) {
 	mu_assert_streq(bf->o->plugin->name, "mock", "binfile with mock plugin");
 
 	mu_assert_eq(rz_pvector_len(&core->io->maps), 3, "io maps count");
-	rz_core_file_close(core, f);
+	rz_core_file_close(f);
 
 	// TODO: this is broken
 #if 0

--- a/test/unit/test_core_bin.c
+++ b/test/unit/test_core_bin.c
@@ -110,37 +110,201 @@ bool test_map(void) {
 	mu_end;
 }
 
+/// test behavior after closing a single RzCoreFile
 bool test_map_close(void) {
 	RzCore *core = rz_core_new();
 	rz_bin_plugin_add(core->bin, &mock_plugin);
 	RzCoreFile *f = rz_core_file_open(core, "hex://424213374242", RZ_PERM_R, 0);
 	mu_assert_notnull(f, "load core file");
+	mu_assert_ptreq(core->file, f, "current file");
 	bool r = rz_core_bin_load(core, NULL, 0);
 	mu_assert_true(r, "core bin load");
 	RzBinFile *bf = rz_bin_file_find_by_fd(core->bin, f->fd);
 	mu_assert_notnull(bf, "binfile");
 	mu_assert_streq(bf->o->plugin->name, "mock", "binfile with mock plugin");
 
+	mu_assert_ptreq(core->file, f, "current file");
 	mu_assert_eq(rz_pvector_len(&core->io->maps), 3, "io maps count");
 	rz_core_file_close(f);
+	mu_assert_null(core->file, "closed current file");
 
-	// TODO: this is broken
-#if 0
+	// all maps related to the file, including zero-mmaps, should be closed
 	mu_assert_eq(rz_pvector_len(&core->io->maps), 0, "io maps count");
-#endif
 
-	// TODO: test reading, etc
+	ut8 buf[8];
+	r = rz_io_read_at(core->io, 0xfe, buf, sizeof(buf));
+	mu_assert_true(r, "io read");
+	mu_assert_memeq(buf, (const ut8 *)"\xff\xff\xff\xff\xff\xff\xff\xff", 8, "direct map read after close");
+	r = rz_io_read_at(core->io, 0x22e, buf, sizeof(buf));
+	mu_assert_true(r, "io read");
+	mu_assert_memeq(buf, (const ut8 *)"\xff\xff\xff\xff\xff\xff\xff\xff", 8, "direct map read with zeroes end after close");
 
 	rz_core_free(core);
 	mu_end;
 }
 
-// TODO: test closing one file, keeping another one open
-// TODO: test closing one file, keeping custom user-mappings open
+/// test behavior after closing an RzCoreFile when another one is present at the same time
+bool test_map_close_multiple(void) {
+	RzCore *core = rz_core_new();
+	rz_bin_plugin_add(core->bin, &mock_plugin);
+
+	RzCoreFile *f0 = rz_core_file_open(core, "hex://424213374242", RZ_PERM_R, 0);
+	mu_assert_notnull(f0, "load core file");
+	mu_assert_ptreq(core->file, f0, "current file");
+	bool r = rz_core_bin_load(core, NULL, 0);
+	mu_assert_true(r, "core bin load");
+
+	RzCoreFile *f1 = rz_core_file_open(core, "hex://c0ffeec0ffee", RZ_PERM_R, 0);
+	mu_assert_notnull(f1, "load another core file");
+	mu_assert_ptreq(core->file, f1, "current file");
+	r = rz_core_bin_load(core, NULL, 0);
+	mu_assert_true(r, "core bin load");
+
+	mu_assert_ptreq(core->file, f1, "current file");
+	mu_assert_eq(rz_list_length(core->files), 2, "core files count");
+	mu_assert_eq(rz_list_length(core->bin->binfiles), 2, "bin files count");
+	mu_assert_eq(rz_pvector_len(&core->io->maps), 6, "io maps count");
+
+	rz_core_file_close(f0);
+	mu_assert_ptreq(core->file, f1, "closed non-current file");
+	mu_assert_eq(rz_pvector_len(&f1->extra_files), 1, "other file still has its extra file refs");
+
+	// all maps related to the file, including zero-mmaps, should be closed
+	mu_assert_eq(rz_pvector_len(&core->io->maps), 3, "io maps count");
+
+	// f1 should still be alive and happy
+	ut8 buf[8];
+	r = rz_io_read_at(core->io, 0xfe, buf, sizeof(buf));
+	mu_assert_true(r, "io read");
+	mu_assert_memeq(buf, (const ut8 *)"\xff\xff\xee\xc0\xff\xff\xff\xff", 8, "direct map read");
+	r = rz_io_read_at(core->io, 0x22e, buf, sizeof(buf));
+	mu_assert_true(r, "io read");
+	mu_assert_memeq(buf, (const ut8 *)"\x00\x00\xff\xff\xff\xff\xff\xff", 8, "direct map read with zeroes end");
+
+	rz_core_free(core);
+	mu_end;
+}
+
+/// test behavior after closing an RzCoreFile when the underlying mappings have been changed manually
+bool test_map_close_manual_maps(void) {
+	RzCore *core = rz_core_new();
+	rz_bin_plugin_add(core->bin, &mock_plugin);
+	RzCoreFile *f = rz_core_file_open(core, "hex://424213374242", RZ_PERM_R, 0);
+	mu_assert_notnull(f, "load core file");
+	mu_assert_ptreq(core->file, f, "current file");
+	bool r = rz_core_bin_load(core, NULL, 0);
+	mu_assert_true(r, "core bin load");
+	RzBinFile *bf = rz_bin_file_find_by_fd(core->bin, f->fd);
+	mu_assert_notnull(bf, "binfile");
+	mu_assert_streq(bf->o->plugin->name, "mock", "binfile with mock plugin");
+
+	mu_assert_ptreq(core->file, f, "current file");
+	mu_assert_eq(rz_pvector_len(&core->io->maps), 3, "io maps count");
+
+	RzIOMap *map0 = rz_io_map_get(core->io, 0x100);
+	mu_assert_streq(map0->name, "fmap.direct map", "io map name");
+	mu_assert_eq(map0->delta, 2, "map delta");
+	mu_assert_eq(map0->itv.addr, 0x100, "map addr");
+	mu_assert_eq(map0->itv.size, 2, "map size");
+	mu_assert_eq(map0->perm, RZ_PERM_RX, "io map perm");
+
+	RzIOMap *map1 = rz_io_map_get(core->io, 0x200);
+	mu_assert_streq(map1->name, "fmap.direct map with zeroes", "io map name");
+	mu_assert_eq(map1->delta, 2, "map delta");
+	mu_assert_eq(map1->itv.addr, 0x200, "map addr");
+	mu_assert_eq(map1->itv.size, 2, "map size");
+	mu_assert_eq(map1->perm, RZ_PERM_R, "io map perm");
+
+	RzIOMap *map2 = rz_io_map_get(core->io, 0x202);
+	mu_assert_streq(map2->name, "mmap.direct map with zeroes", "io map name");
+	mu_assert_eq(map2->delta, 0, "map delta");
+	mu_assert_eq(map2->itv.addr, 0x202, "map addr");
+	mu_assert_eq(map2->itv.size, 0x2e, "map size");
+	mu_assert_eq(map2->perm, RZ_PERM_R, "io map perm");
+
+	mu_assert_eq(rz_pvector_len(&f->extra_files), 1, "tracked extra file for mmaps");
+	mu_assert_eq(rz_pvector_len(&f->maps), 3, "tracked maps count");
+	mu_assert_true(rz_pvector_contains(&f->maps, map0), "core file ref to map");
+	mu_assert_true(rz_pvector_contains(&f->maps, map1), "core file ref to map");
+	mu_assert_true(rz_pvector_contains(&f->maps, map2), "core file ref to map");
+
+	// manually delete some of the maps
+	rz_io_map_del(core->io, map1->id);
+	mu_assert_eq(rz_pvector_len(&f->extra_files), 1, "tracked extra file for mmaps");
+	mu_assert_eq(rz_pvector_len(&f->maps), 2, "tracked maps count");
+	mu_assert_true(rz_pvector_contains(&f->maps, map0), "core file ref to map");
+	mu_assert_true(rz_pvector_contains(&f->maps, map2), "core file ref to map");
+	rz_io_map_del(core->io, map2->id);
+	mu_assert_eq(rz_pvector_len(&f->extra_files), 1, "tracked extra file for mmaps");
+	mu_assert_eq(rz_pvector_len(&f->maps), 1, "tracked maps count");
+	mu_assert_true(rz_pvector_contains(&f->maps, map0), "core file ref to map");
+	// and add a new one, unrelated to the core file
+	RzIOMap *map3;
+	RzIODesc *mdesc = rz_io_open_at(core->io, "hex://c0ffee", 0644, RZ_PERM_R, 0x8000, &map3);
+	mu_assert_notnull(mdesc, "manual io file");
+	mu_assert_eq(map3->itv.addr, 0x8000, "manual map addr");
+	mu_assert_eq(rz_pvector_len(&core->io->maps), 2, "io maps count");
+
+	rz_core_file_close(f);
+	mu_assert_null(core->file, "closed current file");
+
+	// all maps related to the file, including zero-mmaps, should be closed, but not the ones we created manually
+	mu_assert_eq(rz_pvector_len(&core->io->maps), 1, "io maps count");
+	mu_assert_ptreq(rz_pvector_at(&core->io->maps, 0), map3, "remaining manual map");
+
+	ut8 buf[8];
+	r = rz_io_read_at(core->io, 0x8000, buf, sizeof(buf));
+	mu_assert_true(r, "io read");
+	mu_assert_memeq(buf, (const ut8 *)"\xc0\xff\xee\xff\xff\xff\xff\xff", 8, "untouched manual map");
+
+	rz_core_free(core);
+	mu_end;
+}
+
+/// test behavior after closing an RzCoreFile when the underlying fd has been closed manually
+bool test_map_close_manual_fd(void) {
+	RzCore *core = rz_core_new();
+	rz_bin_plugin_add(core->bin, &mock_plugin);
+	RzCoreFile *f = rz_core_file_open(core, "hex://424213374242", RZ_PERM_R, 0);
+	mu_assert_notnull(f, "load core file");
+	mu_assert_ptreq(core->file, f, "current file");
+	bool r = rz_core_bin_load(core, NULL, 0);
+	mu_assert_true(r, "core bin load");
+	RzBinFile *bf = rz_bin_file_find_by_fd(core->bin, f->fd);
+	mu_assert_notnull(bf, "binfile");
+	mu_assert_streq(bf->o->plugin->name, "mock", "binfile with mock plugin");
+
+	mu_assert_ptreq(core->file, f, "current file");
+	mu_assert_eq(rz_pvector_len(&core->io->maps), 3, "io maps count");
+
+	// manually close the low-level io fd
+	rz_io_fd_close(core->io, f->fd);
+	// io behavior: all maps directly from the fd are automatically closed with it
+	// The zero-mmapped one stays because core is the one who tracks it
+	mu_assert_eq(rz_pvector_len(&core->io->maps), 1, "io maps count");
+	RzIOMap *map = rz_pvector_at(&core->io->maps, 0);
+	mu_assert_streq(map->name, "mmap.direct map with zeroes", "io map name");
+	mu_assert_eq(map->delta, 0, "map delta");
+	mu_assert_eq(map->itv.addr, 0x202, "map addr");
+	mu_assert_eq(map->itv.size, 0x2e, "map size");
+	mu_assert_eq(map->perm, RZ_PERM_R, "io map perm");
+
+	rz_core_file_close(f);
+	mu_assert_null(core->file, "closed current file");
+
+	// now everything should be gone
+	mu_assert_eq(rz_pvector_len(&core->io->maps), 0, "io maps count");
+
+	rz_core_free(core);
+	mu_end;
+}
 
 bool all_tests() {
 	mu_run_test(test_map);
 	mu_run_test(test_map_close);
+	mu_run_test(test_map_close_multiple);
+	mu_run_test(test_map_close_manual_maps);
+	mu_run_test(test_map_close_manual_fd);
 	return tests_passed != tests_run;
 }
 

--- a/test/unit/test_core_bin.c
+++ b/test/unit/test_core_bin.c
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2021 Florian Märkl <info@florianmaerkl.de>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_core.h>
+#include "minunit.h"
+
+// --------------------------
+
+static bool check_buffer(RzBuffer *b) {
+	// match everything
+	return true;
+}
+
+static bool load_buffer(RzBinFile *bf, void **bin_obj, RzBuffer *buf, ut64 loadaddr, Sdb *sdb) {
+	return true;
+}
+
+static RzBinInfo *info(RzBinFile *bf) {
+	RzBinInfo *ret = RZ_NEW0(RzBinInfo);
+	if (!ret) {
+		return NULL;
+	}
+	ret->file = strdup(bf->file);
+	ret->has_va = 1;
+	return ret;
+}
+
+static RzList *maps(RzBinFile *bf) {
+	RzList *ret = rz_list_newf((RzListFree)rz_bin_map_free);
+
+	RzBinMap *map = RZ_NEW0(RzBinMap);
+	map->name = strdup("direct map");
+	map->paddr = 2;
+	map->vaddr = 0x100;
+	map->psize = 2;
+	map->vsize = 2;
+	map->perm = RZ_PERM_RX;
+	rz_list_push(ret, map);
+
+	map = RZ_NEW0(RzBinMap);
+	map->name = strdup("direct map with zeroes");
+	map->paddr = 2;
+	map->vaddr = 0x200;
+	map->psize = 2;
+	map->vsize = 0x30;
+	map->perm = RZ_PERM_R;
+	rz_list_push(ret, map);
+
+	return ret;
+}
+
+RzBinPlugin mock_plugin = {
+	.name = "mock",
+	.desc = "Testing Plugin",
+	.license = "LGPL3",
+	.load_buffer = load_buffer,
+	.check_buffer = check_buffer,
+	.maps = maps,
+	.info = info,
+};
+
+// --------------------------
+
+bool test_map(void) {
+	RzCore *core = rz_core_new();
+	rz_bin_plugin_add(core->bin, &mock_plugin);
+	RzCoreFile *f = rz_core_file_open(core, "hex://424213374242", RZ_PERM_R, 0);
+	mu_assert_notnull(f, "load core file");
+	bool r = rz_core_bin_load(core, NULL, 0);
+	mu_assert_true(r, "core bin load");
+	RzBinFile *bf = rz_bin_file_find_by_fd(core->bin, f->fd);
+	mu_assert_notnull(bf, "binfile");
+	mu_assert_streq(bf->o->plugin->name, "mock", "binfile with mock plugin");
+
+	mu_assert_eq(rz_pvector_len(&core->io->maps), 3, "io maps count");
+	RzIOMap *map = rz_pvector_at(&core->io->maps, 0);
+	mu_assert_streq(map->name, "mmap.direct map with zeroes", "io map name");
+	mu_assert_eq(map->delta, 0, "map delta");
+	mu_assert_eq(map->itv.addr, 0x202, "map addr");
+	mu_assert_eq(map->itv.size, 0x2e, "map size");
+	mu_assert_eq(map->perm, RZ_PERM_R, "io map perm");
+	map = rz_pvector_at(&core->io->maps, 1);
+	mu_assert_streq(map->name, "fmap.direct map with zeroes", "io map name");
+	mu_assert_eq(map->delta, 2, "map delta");
+	mu_assert_eq(map->itv.addr, 0x200, "map addr");
+	mu_assert_eq(map->itv.size, 2, "map size");
+	mu_assert_eq(map->perm, RZ_PERM_R, "io map perm");
+	map = rz_pvector_at(&core->io->maps, 2);
+	mu_assert_streq(map->name, "fmap.direct map", "io map name");
+	mu_assert_eq(map->delta, 2, "map delta");
+	mu_assert_eq(map->itv.addr, 0x100, "map addr");
+	mu_assert_eq(map->itv.size, 2, "map size");
+	mu_assert_eq(map->perm, RZ_PERM_RX, "io map perm");
+
+	ut8 buf[8];
+	r = rz_io_read_at(core->io, 0, buf, sizeof(buf));
+	mu_assert_true(r, "io read");
+	mu_assert_memeq(buf, (const ut8 *)"\xff\xff\xff\xff\xff\xff\xff\xff", 8, "unmapped read");
+	r = rz_io_read_at(core->io, 0xfe, buf, sizeof(buf));
+	mu_assert_true(r, "io read");
+	mu_assert_memeq(buf, (const ut8 *)"\xff\xff\x13\x37\xff\xff\xff\xff", 8, "direct map read");
+	r = rz_io_read_at(core->io, 0x1fe, buf, sizeof(buf));
+	mu_assert_true(r, "io read");
+	mu_assert_memeq(buf, (const ut8 *)"\xff\xff\x13\x37\x00\x00\x00\x00", 8, "direct map read with zeroes");
+	r = rz_io_read_at(core->io, 0x22e, buf, sizeof(buf));
+	mu_assert_true(r, "io read");
+	mu_assert_memeq(buf, (const ut8 *)"\x00\x00\xff\xff\xff\xff\xff\xff", 8, "direct map read with zeroes end");
+
+	rz_core_free(core);
+	mu_end;
+}
+
+bool test_map_close(void) {
+	RzCore *core = rz_core_new();
+	rz_bin_plugin_add(core->bin, &mock_plugin);
+	RzCoreFile *f = rz_core_file_open(core, "hex://424213374242", RZ_PERM_R, 0);
+	mu_assert_notnull(f, "load core file");
+	bool r = rz_core_bin_load(core, NULL, 0);
+	mu_assert_true(r, "core bin load");
+	RzBinFile *bf = rz_bin_file_find_by_fd(core->bin, f->fd);
+	mu_assert_notnull(bf, "binfile");
+	mu_assert_streq(bf->o->plugin->name, "mock", "binfile with mock plugin");
+
+	mu_assert_eq(rz_pvector_len(&core->io->maps), 3, "io maps count");
+	rz_core_file_close(core, f);
+
+	// TODO: this is broken
+#if 0
+	mu_assert_eq(rz_pvector_len(&core->io->maps), 0, "io maps count");
+#endif
+
+	// TODO: test reading, etc
+
+	rz_core_free(core);
+	mu_end;
+}
+
+// TODO: test closing one file, keeping another one open
+// TODO: test closing one file, keeping custom user-mappings open
+
+bool all_tests() {
+	mu_run_test(test_map);
+	mu_run_test(test_map_close);
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`RzCoreFile` is for tracking any low-level state in `RzIO` and `RzBin` together, for example to correctly tear down all associated maps of a file when it is closed, but keeping mappings from other sources open.
Previously, it failed hard at that. For example when you opened an ELF file that had some zero-mmaps as an `RzCoreFile`, then loaded all the bin maps from it, then called `rz_core_file_close()` on it again, you would expect the created mappings including the zero one to be cleaned up again, but this was not the case:
```
florian-macbook:rizin florian$ rz test/bins/elf/true
Warning: run rizin with -e io.cache=true to fix relocations in disassembly
 -- Move between your search hits in visual mode using the 'f' and 'F' keys
[0x00002110]> o
 3 * r-x 0x000087c0 test/bins/elf/true
 4 - rw- 0x00000198 null://408
[0x00002110]> om
 5 fd: 3 +0x00000000 0x00000000 - 0x00001167 r-- fmap.LOAD0
 4 fd: 3 +0x00002000 0x00002000 - 0x000050f0 r-x fmap.LOAD1
 3 fd: 3 +0x00006000 0x00006000 - 0x00007aff r-- fmap.LOAD2
 2 fd: 3 +0x00007c70 0x00008c70 - 0x0000907f r-- fmap.LOAD3
 1 fd: 4 +0x00000000 0x00009080 - 0x00009217 rw- mmap.LOAD3
[0x00002110]> o-3
[0x00002110]> o
 4 - rw- 0x00000198 null://408
[0x00002110]> om
 1 fd: 4 +0x00000000 0x00009080 - 0x00009217 rw- mmap.LOAD3
 ```
Here, `o-3` closes the core file as opposed to just the io file. If it was only the io file, this behavior would be correct but for the core file it's wrong.

Now the `RzCoreFile` tracks all additional files and maps that it creates during loading so they can be cleanly removed later again, and also without accidentally removing anything unrelated to that core file. The fact that the core file now holds pointers to IO maps and descs has the implication that when these low-level IO objects are deleted manually from elsewhere (which is possible and valid), then the core file must remove its references to them automatically, otherwise we will double-free.
This is why this also adds related events `RZ_EVENT_IO_DESC_CLOSE` and `RZ_EVENT_IO_MAP_DEL` so these cases can be tracked correctly.

In addition, 436871e8d6f1e48e5b26cadcacd97467bd2f18f1 removed a lot of old workarounds that were put on top of workarounds to avoid double-frees and stuff but were actually all not necessary if everything was handled right.
d26d25e35f5073dcaa88b30e0e4c446e5ae09abb also fixes a minor bug where the perms of zero-mappings were not set correctly.

**Test plan**

See the unit tests. I added tests for the new IO events, to make sure they are always emitted correctly so no free will be missed, and for the whole `RzCoreFile` stuff, making sure that it closes exactly what it should and does not double-free.