### PR TITLE
Refactor RzBinFile Deletion API and add Events + other stuff

### DIFF
--- a/librz/bin/bobj.c
+++ b/librz/bin/bobj.c
@@ -592,22 +592,6 @@ RZ_IPI RzBinObject *rz_bin_object_find_by_arch_bits(RzBinFile *bf, const char *a
 	return NULL;
 }
 
-RZ_API bool rz_bin_object_delete(RzBin *bin, ut32 bf_id) {
-	rz_return_val_if_fail(bin, false);
-
-	bool res = false;
-	RzBinFile *bf = rz_bin_file_find_by_id(bin, bf_id);
-	if (bf) {
-		if (bin->cur == bf) {
-			bin->cur = NULL;
-		}
-		if (!bf->o) {
-			rz_list_delete_data(bin->binfiles, bf);
-		}
-	}
-	return res;
-}
-
 RZ_IPI void rz_bin_object_filter_strings(RzBinObject *bo) {
 	rz_return_if_fail(bo && bo->strings);
 

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -307,11 +307,11 @@ RZ_API bool rz_core_bin_load_structs(RzCore *core, const char *file) {
 		return false;
 	}
 	RzBinOptions opt = { 0 };
-	if (!rz_bin_open(core->bin, file, &opt)) {
+	RzBinFile *bf = rz_bin_open(core->bin, file, &opt);
+	if (!bf) {
 		eprintf("Cannot open bin '%s'\n", file);
 		return false;
 	}
-	RzBinFile *bf = rz_bin_cur(core->bin);
 	if (!bf) {
 		eprintf("Cannot open bin '%s'\n", file);
 		return false;

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -317,7 +317,7 @@ RZ_API bool rz_core_bin_load_structs(RzCore *core, const char *file) {
 		return false;
 	}
 	rz_core_bin_export_info(core, RZ_MODE_SET);
-	rz_bin_file_delete(core->bin, bf->id);
+	rz_bin_file_delete(core->bin, bf);
 	return true;
 }
 
@@ -1676,7 +1676,7 @@ static bool bin_raw_strings(RzCore *r, PJ *pj, int mode, int va) {
 		rz_buf_free(bf->buf);
 		bf->buf = NULL;
 		bf->id = -1;
-		rz_bin_file_free(bf);
+		rz_bin_file_delete(r->bin, bf);
 	}
 	return true;
 }
@@ -4325,12 +4325,9 @@ RZ_API bool rz_core_bin_raise(RzCore *core, ut32 bfid) {
 	return bf && rz_core_bin_apply_all_info(core, bf) && rz_core_block_read(core);
 }
 
-RZ_API bool rz_core_bin_delete(RzCore *core, ut32 bf_id) {
-	if (bf_id == UT32_MAX) {
-		return false;
-	}
-	rz_bin_file_delete(core->bin, bf_id);
-	RzBinFile *bf = rz_bin_file_at(core->bin, core->offset);
+RZ_API bool rz_core_bin_delete(RzCore *core, RzBinFile *bf) {
+	rz_bin_file_delete(core->bin, bf);
+	bf = rz_bin_file_at(core->bin, core->offset);
 	if (bf) {
 		rz_io_use_fd(core->io, bf->fd);
 	}

--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -374,7 +374,7 @@ RZ_API int rz_core_file_reopen(RzCore *core, const char *args, int perm, int loa
 		bool had_rbin_info = false;
 
 		if (ofile && bf) {
-			if (rz_bin_file_delete(core->bin, bf->id)) {
+			if (rz_bin_file_delete(core->bin, bf)) {
 				had_rbin_info = true;
 			}
 		}

--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -1421,7 +1421,8 @@ static bool get_bin_info(RzCore *core, const char *file, ut64 baseaddr, PJ *pj, 
 	opt.sz = rz_io_fd_size(core->io, fd);
 	opt.baseaddr = baseaddr;
 	RzBinFile *obf = rz_bin_cur(core->bin);
-	if (!rz_bin_open_io(core->bin, &opt)) {
+	RzBinFile *bf = rz_bin_open_io(core->bin, &opt);
+	if (!bf) {
 		rz_io_fd_close(core->io, fd);
 		return false;
 	}
@@ -1436,7 +1437,6 @@ static bool get_bin_info(RzCore *core, const char *file, ut64 baseaddr, PJ *pj, 
 	} else {
 		rz_core_bin_info(core, action, pj, mode, 1, filter, NULL);
 	}
-	RzBinFile *bf = rz_bin_cur(core->bin);
 	rz_bin_file_delete(core->bin, bf->id);
 	rz_bin_file_set_cur_binfile(core->bin, obf);
 	rz_io_fd_close(core->io, fd);

--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -1437,7 +1437,7 @@ static bool get_bin_info(RzCore *core, const char *file, ut64 baseaddr, PJ *pj, 
 	} else {
 		rz_core_bin_info(core, action, pj, mode, 1, filter, NULL);
 	}
-	rz_bin_file_delete(core->bin, bf->id);
+	rz_bin_file_delete(core->bin, bf);
 	rz_bin_file_set_cur_binfile(core->bin, obf);
 	rz_io_fd_close(core->io, fd);
 	return true;

--- a/librz/core/cmd_info.c
+++ b/librz/core/cmd_info.c
@@ -318,17 +318,21 @@ static bool is_equal_file_hashes(RzList *lfile_hashes, RzList *rfile_hashes, boo
 	return true;
 }
 
-static int __r_core_bin_reload(RzCore *r, const char *file, ut64 baseaddr) {
-	int result = 0;
+static bool __r_core_bin_reload(RzCore *r, const char *file, ut64 baseaddr) {
 	RzCoreFile *cf = rz_core_file_cur(r);
-	if (cf) {
-		RzBinFile *bf = rz_bin_file_find_by_fd(r->bin, cf->fd);
-		if (bf) {
-			result = rz_bin_reload(r->bin, bf->id, baseaddr);
-		}
+	if (!cf) {
+		return false;
 	}
-	rz_core_bin_apply_all_info(r, rz_bin_cur(r->bin));
-	return result;
+	RzBinFile *obf = rz_bin_file_find_by_fd(r->bin, cf->fd);
+	if (!obf) {
+		return false;
+	}
+	RzBinFile *nbf = rz_bin_reload(r->bin, obf, baseaddr);
+	if (!nbf) {
+		return false;
+	}
+	rz_core_bin_apply_all_info(r, nbf);
+	return true;
 }
 
 static bool isKnownPackage(const char *cn) {

--- a/librz/core/cmd_open.c
+++ b/librz/core/cmd_open.c
@@ -341,11 +341,7 @@ static void cmd_open_bin(RzCore *core, const char *input) {
 			}
 			id = (*value && rz_is_valid_input_num_value(core->num, value)) ? rz_get_input_num_value(core->num, value) : UT32_MAX;
 			RzBinFile *bf = rz_bin_file_find_by_id(core->bin, id);
-			if (!bf) {
-				eprintf("Invalid binid\n");
-				break;
-			}
-			if (!rz_core_bin_delete(core, bf->id)) {
+			if (!bf || !rz_core_bin_delete(core, bf)) {
 				eprintf("Cannot find an RzBinFile associated with that id.\n");
 			}
 		}

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -2332,6 +2332,7 @@ static void ev_iowrite_cb(RzEvent *ev, int type, void *user, void *data) {
 
 RZ_IPI void rz_core_file_io_desc_closed(RzCore *core, RzIODesc *desc);
 RZ_IPI void rz_core_file_io_map_deleted(RzCore *core, RzIOMap *map);
+RZ_IPI void rz_core_file_bin_file_deleted(RzCore *core, RzBinFile *bf);
 
 static void ev_iodescclose_cb(RzEvent *ev, int type, void *user, void *data) {
 	RzEventIODescClose *ioc = data;
@@ -2341,6 +2342,11 @@ static void ev_iodescclose_cb(RzEvent *ev, int type, void *user, void *data) {
 static void ev_iomapdel_cb(RzEvent *ev, int type, void *user, void *data) {
 	RzEventIOMapDel *iod = data;
 	rz_core_file_io_map_deleted(user, iod->map);
+}
+
+static void ev_binfiledel_cb(RzEvent *ev, int type, void *user, void *data) {
+	RzEventBinFileDel *bev = data;
+	rz_core_file_bin_file_deleted(user, bev->bf);
 }
 
 RZ_IPI void rz_core_task_ctx_switch(RzCoreTask *next, void *user);
@@ -2463,6 +2469,7 @@ RZ_API bool rz_core_init(RzCore *core) {
 	/// XXX shouhld be using coreb
 	rz_parse_set_user_ptr(core->parser, core);
 	core->bin = rz_bin_new();
+	rz_event_hook(core->bin->event, RZ_EVENT_BIN_FILE_DEL, ev_binfiledel_cb, core);
 	rz_cons_bind(&core->bin->consb);
 	// XXX we shuold use RzConsBind instead of this hardcoded pointer
 	core->bin->cb_printf = (PrintfCallback)rz_cons_printf;

--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -48,8 +48,8 @@ static GHT GH(get_va_symbol)(RzCore *core, const char *path, const char *sym_nam
 
 	RzBinOptions opt;
 	rz_bin_options_init(&opt, -1, 0, 0, false);
-	bool res = rz_bin_open(bin, path, &opt);
-	if (!res) {
+	RzBinFile *libc_bf = rz_bin_open(bin, path, &opt);
+	if (!libc_bf) {
 		return vaddr;
 	}
 
@@ -61,8 +61,7 @@ static GHT GH(get_va_symbol)(RzCore *core, const char *path, const char *sym_nam
 		}
 	}
 
-	RzBinFile *libc_bf = rz_bin_cur(bin);
-	rz_bin_file_delete(bin, libc_bf->id);
+	rz_bin_file_delete(bin, libc_bf);
 	rz_bin_file_set_cur_binfile(bin, current_bf);
 	return vaddr;
 }

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -320,6 +320,7 @@ struct rz_bin_t {
 	RZ_DEPRECATE RzBinFile *cur; ///< never use this in new code! Get a file from the binfiles list or track it yourself.
 	int narch;
 	void *user;
+	RzEvent *event;
 	/* preconfigured values */
 	int debase64;
 	int minstrlen;
@@ -783,6 +784,10 @@ typedef struct rz_bin_options_t {
 	const char *filename;
 } RzBinOptions;
 
+typedef struct rz_event_bin_file_del_t {
+	RzBinFile *bf;
+} RzEventBinFileDel;
+
 RZ_API RzBinImport *rz_bin_import_clone(RzBinImport *o);
 RZ_API const char *rz_bin_symbol_name(RzBinSymbol *s);
 typedef void (*RzBinSymbolCallback)(RzBinObject *obj, RzBinSymbol *symbol);
@@ -853,10 +858,6 @@ RZ_API const char *rz_bin_entry_type_string(int etype);
 
 RZ_API bool rz_bin_file_object_new_from_xtr_data(RzBin *bin, RzBinFile *bf, ut64 baseaddr, ut64 loadaddr, RzBinXtrData *data);
 
-// RzBinFile lifecycle
-// RZ_IPI RzBinFile *rz_bin_file_new(RzBin *bin, const char *file, ut64 file_sz, int rawstr, int fd, const char *xtrname, Sdb *sdb, bool steal_ptr);
-RZ_API bool rz_bin_file_close(RzBin *bin, int bd);
-RZ_API void rz_bin_file_free(void /*RzBinFile*/ *bf_);
 // RzBinFile.get
 RZ_API RzBinFile *rz_bin_file_at(RzBin *bin, ut64 addr);
 RZ_API RzBinFile *rz_bin_file_find_by_object_id(RzBin *bin, ut32 binobj_id);
@@ -879,7 +880,7 @@ RZ_API bool rz_bin_file_set_cur_by_fd(RzBin *bin, ut32 bin_fd);
 RZ_API bool rz_bin_file_set_cur_by_id(RzBin *bin, ut32 bin_id);
 RZ_API bool rz_bin_file_set_cur_by_name(RzBin *bin, const char *name);
 RZ_API ut64 rz_bin_file_delete_all(RzBin *bin);
-RZ_API bool rz_bin_file_delete(RzBin *bin, ut32 bin_id);
+RZ_API bool rz_bin_file_delete(RzBin *bin, RzBinFile *bf);
 RZ_API RzList *rz_bin_file_compute_hashes(RzBin *bin, ut64 limit);
 RZ_API RzList *rz_bin_file_set_hashes(RzBin *bin, RzList *new_hashes);
 RZ_API RzBinPlugin *rz_bin_file_cur_plugin(RzBinFile *binfile);

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -275,7 +275,7 @@ typedef struct rz_bin_object_t {
 	RzBinAddr *binsym[RZ_BIN_SPECIAL_SYMBOL_LAST];
 	struct rz_bin_plugin_t *plugin;
 	int lang;
-	Sdb *kv;
+	RZ_DEPRECATE Sdb *kv; ///< deprecated, put info in C structures instead of this
 	HtUP *addrzklassmethod;
 	void *bin_obj; // internal pointer used by formats
 } RzBinObject;
@@ -301,8 +301,8 @@ struct rz_bin_file_t {
 	struct rz_bin_xtr_plugin_t *curxtr;
 	// struct rz_bin_plugin_t *curplugin; // use o->plugin
 	RzList *xtr_data;
-	Sdb *sdb;
-	Sdb *sdb_info;
+	RZ_DEPRECATE Sdb *sdb; ///< deprecated, put info in C structures instead of this
+	RZ_DEPRECATE Sdb *sdb_info; ///< deprecated, put info in C structures instead of this
 	struct rz_bin_t *rbin;
 }; // RzBinFile
 
@@ -317,7 +317,7 @@ typedef struct rz_bin_file_options_t {
 
 struct rz_bin_t {
 	const char *file;
-	RzBinFile *cur; // TODO: deprecate
+	RZ_DEPRECATE RzBinFile *cur; ///< never use this in new code! Get a file from the binfiles list or track it yourself.
 	int narch;
 	void *user;
 	/* preconfigured values */
@@ -326,7 +326,7 @@ struct rz_bin_t {
 	int maxstrlen; //< <= 0 means no limit
 	ut64 maxstrbuf;
 	int rawstr;
-	Sdb *sdb;
+	RZ_DEPRECATE Sdb *sdb;
 	RzIDStorage *ids;
 	RzList /*<RzBinPlugin>*/ *plugins;
 	RzList /*<RzBinXtrPlugin>*/ *binxtrs;
@@ -512,7 +512,7 @@ typedef struct rz_bin_plugin_t {
 	char *license;
 	int (*init)(void *user);
 	int (*fini)(void *user);
-	Sdb *(*get_sdb)(RzBinFile *obj);
+	RZ_DEPRECATE Sdb *(*get_sdb)(RzBinFile *obj); ///< deprecated, put info in C structures instead of this
 	bool (*load_buffer)(RzBinFile *bf, void **bin_obj, RzBuffer *buf, ut64 loadaddr, Sdb *sdb);
 	ut64 (*size)(RzBinFile *bin);
 	void (*destroy)(RzBinFile *bf);

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -794,10 +794,10 @@ RZ_API void rz_bin_arch_options_init(RzBinArchOptions *opt, const char *arch, in
 // open/close/reload functions
 RZ_API RzBin *rz_bin_new(void);
 RZ_API void rz_bin_free(RzBin *bin);
-RZ_API bool rz_bin_open(RzBin *bin, const char *file, RzBinOptions *opt);
-RZ_API bool rz_bin_open_io(RzBin *bin, RzBinOptions *opt);
-RZ_API bool rz_bin_open_buf(RzBin *bin, RzBuffer *buf, RzBinOptions *opt);
-RZ_API bool rz_bin_reload(RzBin *bin, ut32 bf_id, ut64 baseaddr);
+RZ_API RzBinFile *rz_bin_open(RzBin *bin, const char *file, RzBinOptions *opt);
+RZ_API RzBinFile *rz_bin_open_io(RzBin *bin, RzBinOptions *opt);
+RZ_API RzBinFile *rz_bin_open_buf(RzBin *bin, RzBuffer *buf, RzBinOptions *opt);
+RZ_API RzBinFile *rz_bin_reload(RzBin *bin, RzBinFile *bf, ut64 baseaddr);
 
 // plugins/bind functions
 RZ_API void rz_bin_bind(RzBin *b, RzBinBind *bnd);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -718,7 +718,7 @@ RZ_API bool rz_core_bin_load(RzCore *core, const char *file, ut64 baseaddr);
 RZ_API int rz_core_bin_rebase(RzCore *core, ut64 baddr);
 RZ_API void rz_core_bin_export_info(RzCore *core, int mode);
 RZ_API int rz_core_bin_list(RzCore *core, int mode);
-RZ_API bool rz_core_bin_delete(RzCore *core, ut32 binfile_idx);
+RZ_API bool rz_core_bin_delete(RzCore *core, RzBinFile *bf);
 RZ_API ut64 rz_core_bin_impaddr(RzBin *bin, int va, const char *name);
 
 RZ_API void rz_core_bin_print_source_line_sample(RzCore *core, const RzBinSourceLineSample *s, RzOutputMode mode, PJ *pj);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -136,6 +136,7 @@ typedef struct rz_core_file_t {
 	struct rz_core_t *core;
 	int dbg;
 	int fd;
+	RzPVector /*<RzBinFile>*/ binfiles; ///< all bin files that have been created for this core file
 	RzPVector /*<RzIODesc>*/ extra_files; ///< additional files opened during mapping, for example for zeroed maps
 	RzPVector /*<RzIOMap>*/ maps; ///< all maps that have been created as a result of loading this file
 } RzCoreFile;

--- a/librz/include/rz_util/rz_event.h
+++ b/librz/include/rz_util/rz_event.h
@@ -41,6 +41,7 @@ typedef enum {
 	RZ_EVENT_IO_WRITE, // RzEventIOWrite
 	RZ_EVENT_IO_DESC_CLOSE, // RzEventIODescClose
 	RZ_EVENT_IO_MAP_DEL, // RzEventIOMapDel
+	RZ_EVENT_BIN_FILE_DEL, // RzEventBinFileDel
 	RZ_EVENT_MAX,
 } RzEventType;
 

--- a/test/db/cmd/cmd_open
+++ b/test/db/cmd/cmd_open
@@ -109,7 +109,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=o -
+NAME=o =
 FILE=malloc://1024
 CMDS=<<EOF
 e file.nowarn=true
@@ -410,11 +410,21 @@ RUN
 NAME=o-*
 FILE==
 CMDS=<<EOF
-o -
+e asm.arch=x86
+e asm.bits=64
+o =
+o~?
+ob
+?e --
 o-*
 o~?
+ob
 EOF
 EXPECT=<<EOF
+2
+0 3 x86-64 ba:0x00000000 sz:512 malloc://512
+1 4 x86-64 ba:0x00000000 sz:512 malloc://512
+--
 0
 EOF
 RUN
@@ -422,24 +432,31 @@ RUN
 NAME=o-3
 FILE==
 CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
 o =
 o-3
 o~?
+ob
 EOF
 EXPECT=<<EOF
 1
+1 4 x86-64 ba:0x00000000 sz:512 malloc://512
 EOF
 RUN
 
 NAME=oc
 FILE=bins/elf/true32
 CMDS=<<EOF
+ob~?
 i
 oc =
 ?e --
+ob~?
 i
 EOF
 EXPECT=<<EOF
+1
 fd       3
 file     bins/elf/true32
 size     0x560c
@@ -480,6 +497,7 @@ stripped true
 subsys   linux
 va       true
 --
+1
 fd       3
 file     malloc://512
 size     0x200

--- a/test/unit/test_bin.c
+++ b/test/unit/test_bin.c
@@ -13,11 +13,11 @@ bool test_rz_bin(void) {
 	rz_io_bind(io, &bin->iob);
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/elf/ioli/crackme0x00", &opt);
-	mu_assert("crackme0x00 binary could not be opened", res);
+	RzBinFile *bf = rz_bin_open(bin, "bins/elf/ioli/crackme0x00", &opt);
+	mu_assert_notnull(bf, "crackme0x00 binary could not be opened");
+	mu_assert_notnull(bf->o, "bin object");
 
-	RzList *sections = rz_bin_get_sections(bin);
-	// XXX this is wrong, because its returning the sections and the segments, we need another api here
+	RzList *sections = bf->o->sections;
 	mu_assert_eq(rz_list_length(sections), 39, "rz_bin_get_sections");
 
 	rz_bin_free(bin);

--- a/test/unit/test_bin.c
+++ b/test/unit/test_bin.c
@@ -1,11 +1,10 @@
+// SPDX-FileCopyrightText: 2021 Florian Märkl <info@florianmaerkl.de>
 // SPDX-FileCopyrightText: 2019 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_util.h>
 #include "minunit.h"
 #include <rz_bin.h>
-
-//TODO test rz_str_chop_path
 
 bool test_rz_bin(void) {
 	RzBin *bin = rz_bin_new();
@@ -93,9 +92,116 @@ bool test_rz_bin_reloc_storage(void) {
 	mu_end;
 }
 
+typedef struct {
+	RzList /*<RzBinFile>*/ *expect; /// things whose delete events are expected now
+	bool failed_unexpected;
+} DelTracker;
+
+static void event_file_del_cb(RzEvent *ev, int type, void *user, void *data) {
+	DelTracker *tracker = user;
+	if (type != RZ_EVENT_BIN_FILE_DEL) {
+		tracker->failed_unexpected = true;
+		return;
+	}
+	RzEventBinFileDel *bev = data;
+	RzListIter *it = rz_list_find_ptr(tracker->expect, bev->bf);
+	if (!it) {
+		tracker->failed_unexpected = true;
+		return;
+	}
+	rz_list_delete(tracker->expect, it);
+}
+
+bool test_rz_bin_file_delete(void) {
+	RzIO *io = rz_io_new();
+	RzBin *bin = rz_bin_new();
+	rz_io_bind(io, &bin->iob);
+
+	DelTracker tracker = {
+		.expect = rz_list_new(),
+		.failed_unexpected = false
+	};
+	rz_event_hook(bin->event, RZ_EVENT_BIN_FILE_DEL, event_file_del_cb, &tracker);
+
+	RzBinOptions opt = { 0 };
+	RzBinFile *f0 = rz_bin_open(bin, "hex://42424242424242", &opt);
+	mu_assert_notnull(f0, "open file");
+
+	RzBinFile *f1 = rz_bin_open(bin, "malloc://1024", &opt);
+	mu_assert_notnull(f1, "open file");
+	mu_assert_ptrneq(f1, f0, "unique files");
+
+	mu_assert_eq(rz_list_length(bin->binfiles), 2, "files count");
+	mu_assert_true(rz_list_contains(bin->binfiles, f0), "f0 in list");
+	mu_assert_true(rz_list_contains(bin->binfiles, f1), "f1 in list");
+
+	mu_assert_false(tracker.failed_unexpected, "unexpected del event");
+	rz_list_push(tracker.expect, f0);
+	rz_bin_file_delete(bin, f0);
+	mu_assert_false(tracker.failed_unexpected, "unexpected del event");
+	mu_assert_true(rz_list_empty(tracker.expect), "missing del event");
+
+	mu_assert_eq(rz_list_length(bin->binfiles), 1, "files count");
+	mu_assert_true(rz_list_contains(bin->binfiles, f1), "f1 in list");
+
+	rz_bin_free(bin);
+	rz_io_free(io);
+
+	// free should not send del events for remaining files
+	mu_assert_true(rz_list_empty(tracker.expect), "missing del event");
+	mu_assert_false(tracker.failed_unexpected, "unexpected del event");
+
+	rz_list_free(tracker.expect);
+	mu_end;
+}
+
+bool test_rz_bin_file_delete_all(void) {
+	RzIO *io = rz_io_new();
+	RzBin *bin = rz_bin_new();
+	rz_io_bind(io, &bin->iob);
+
+	DelTracker tracker = {
+		.expect = rz_list_new(),
+		.failed_unexpected = false
+	};
+	rz_event_hook(bin->event, RZ_EVENT_BIN_FILE_DEL, event_file_del_cb, &tracker);
+
+	RzBinOptions opt = { 0 };
+	RzBinFile *f0 = rz_bin_open(bin, "hex://42424242424242", &opt);
+	mu_assert_notnull(f0, "open file");
+
+	RzBinFile *f1 = rz_bin_open(bin, "malloc://1024", &opt);
+	mu_assert_notnull(f1, "open file");
+	mu_assert_ptrneq(f1, f0, "unique files");
+
+	mu_assert_eq(rz_list_length(bin->binfiles), 2, "files count");
+	mu_assert_true(rz_list_contains(bin->binfiles, f0), "f0 in list");
+	mu_assert_true(rz_list_contains(bin->binfiles, f1), "f1 in list");
+
+	mu_assert_false(tracker.failed_unexpected, "unexpected del event");
+	rz_list_push(tracker.expect, f0);
+	rz_list_push(tracker.expect, f1);
+	rz_bin_file_delete_all(bin);
+	mu_assert_false(tracker.failed_unexpected, "unexpected del event");
+	mu_assert_true(rz_list_empty(tracker.expect), "missing del event");
+
+	mu_assert_eq(rz_list_length(bin->binfiles), 0, "files count");
+
+	rz_bin_free(bin);
+	rz_io_free(io);
+
+	mu_assert_true(rz_list_empty(tracker.expect), "missing del event");
+	mu_assert_false(tracker.failed_unexpected, "unexpected del event");
+
+	rz_list_free(tracker.expect);
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_rz_bin);
 	mu_run_test(test_rz_bin_reloc_storage);
+	mu_run_test(test_rz_bin_file_delete);
+	mu_run_test(test_rz_bin_file_delete_all);
 	return tests_passed != tests_run;
 }
 

--- a/test/unit/test_dwarf.c
+++ b/test/unit/test_dwarf.c
@@ -82,8 +82,8 @@ bool test_dwarf3_c_basic(void) { // this should work for dwarf2 aswell
 	rz_io_bind(io, &bin->iob);
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/elf/dwarf3_c.elf", &opt);
-	mu_assert("couldn't open file", res);
+	RzBinFile *bf = rz_bin_open(bin, "bins/elf/dwarf3_c.elf", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 
 	RzBinDwarfDebugAbbrev *da = NULL;
 	// mode = 0, calls
@@ -197,8 +197,8 @@ bool test_dwarf3_cpp_basic(void) { // this should work for dwarf2 aswell
 	rz_io_bind(io, &bin->iob);
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/elf/dwarf3_cpp.elf", &opt);
-	mu_assert("couldn't open file", res);
+	RzBinFile *bf = rz_bin_open(bin, "bins/elf/dwarf3_cpp.elf", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 
 	// this is probably ugly, but I didn't know how to
 	// tell core  what bin to open so I did it myself
@@ -588,8 +588,8 @@ bool test_dwarf3_cpp_many_comp_units(void) {
 	rz_io_bind(io, &bin->iob);
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/elf/dwarf3_many_comp_units.elf", &opt);
-	mu_assert("couldn't open file", res);
+	RzBinFile *bf = rz_bin_open(bin, "bins/elf/dwarf3_many_comp_units.elf", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 
 	RzBinDwarfDebugAbbrev *da = NULL;
 	// mode = 0, calls
@@ -694,8 +694,8 @@ bool test_dwarf_cpp_empty_line_info(void) { // this should work for dwarf2 aswel
 	rz_io_bind(io, &bin->iob);
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/pe/hello_world_not_stripped.exe", &opt);
-	mu_assert("couldn't open file", res);
+	RzBinFile *bf = rz_bin_open(bin, "bins/pe/hello_world_not_stripped.exe", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 
 	RzBinDwarfDebugAbbrev *da = NULL;
 	// mode = 0, calls
@@ -753,8 +753,8 @@ bool test_dwarf2_cpp_many_comp_units(void) {
 	rz_io_bind(io, &bin->iob);
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/elf/dwarf2_many_comp_units.elf", &opt);
-	mu_assert("couldn't open file", res);
+	RzBinFile *bf = rz_bin_open(bin, "bins/elf/dwarf2_many_comp_units.elf", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 
 	RzBinDwarfDebugAbbrev *da = NULL;
 	// mode = 0, calls
@@ -860,8 +860,8 @@ bool test_dwarf4_cpp_many_comp_units(void) {
 	rz_io_bind(io, &bin->iob);
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/elf/dwarf4_many_comp_units.elf", &opt);
-	mu_assert("couldn't open file", res);
+	RzBinFile *bf = rz_bin_open(bin, "bins/elf/dwarf4_many_comp_units.elf", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 
 	// TODO add abbrev checks
 
@@ -960,8 +960,8 @@ bool test_dwarf4_multidir_comp_units(void) {
 	rz_io_bind(io, &bin->iob);
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/elf/dwarf4_multidir_comp_units", &opt);
-	mu_assert("couldn't open file", res);
+	RzBinFile *bf = rz_bin_open(bin, "bins/elf/dwarf4_multidir_comp_units", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 
 	RzBinDwarfDebugAbbrev *da = rz_bin_dwarf_parse_abbrev(bin->cur);
 	mu_assert_notnull(da, "abbrevs");
@@ -1003,8 +1003,8 @@ bool test_big_endian_dwarf2(void) {
 	rz_io_bind(io, &bin->iob);
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/elf/ppc64_sudoku_dwarf", &opt);
-	mu_assert("couldn't open file", res);
+	RzBinFile *bf = rz_bin_open(bin, "bins/elf/ppc64_sudoku_dwarf", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 
 	RzBinDwarfLineInfo *li = rz_bin_dwarf_parse_line(bin->cur, NULL, RZ_BIN_DWARF_LINE_INFO_MASK_OPS | RZ_BIN_DWARF_LINE_INFO_MASK_LINES);
 	mu_assert_notnull(li, "line info");
@@ -1502,8 +1502,8 @@ bool test_dwarf3_aranges(void) {
 	rz_io_bind(io, &bin->iob);
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/elf/dwarf3_many_comp_units.elf", &opt);
-	mu_assert("couldn't open file", res);
+	RzBinFile *bf = rz_bin_open(bin, "bins/elf/dwarf3_many_comp_units.elf", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 
 	RzList *aranges = rz_bin_dwarf_parse_aranges(bin->cur);
 	mu_assert_eq(rz_list_length(aranges), 2, "arange sets count");

--- a/test/unit/test_dwarf_info.c
+++ b/test/unit/test_dwarf_info.c
@@ -57,8 +57,8 @@ bool test_dwarf3_c(void) {
 	rz_io_bind(io, &bin->iob);
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/elf/dwarf3_c.elf", &opt);
-	mu_assert("dwarf3_c.elf binary could not be opened", res);
+	RzBinFile *bf = rz_bin_open(bin, "bins/elf/dwarf3_c.elf", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 
 	RzBinDwarfDebugAbbrev *da = rz_bin_dwarf_parse_abbrev(bin->cur);
 	mu_assert_eq(da->count, 7, "Incorrect number of abbreviation");
@@ -120,8 +120,8 @@ bool test_dwarf4_cpp_multiple_modules(void) {
 	rz_io_bind(io, &bin->iob);
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/elf/dwarf4_many_comp_units.elf", &opt);
-	mu_assert("dwarf4_many_comp_units.elf binary could not be opened", res);
+	RzBinFile *bf = rz_bin_open(bin, "bins/elf/dwarf4_many_comp_units.elf", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 
 	RzBinDwarfDebugAbbrev *da = rz_bin_dwarf_parse_abbrev(bin->cur);
 	mu_assert_eq(da->count, 37, "Incorrect number of abbreviation");
@@ -330,8 +330,8 @@ bool test_dwarf2_big_endian(void) {
 	rz_io_bind(io, &bin->iob);
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/elf/ppc64_sudoku_dwarf", &opt);
-	mu_assert("dwarf4_many_comp_units.elf binary could not be opened", res);
+	RzBinFile *bf = rz_bin_open(bin, "bins/elf/ppc64_sudoku_dwarf", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 
 	RzBinDwarfDebugAbbrev *da = rz_bin_dwarf_parse_abbrev(bin->cur);
 	mu_assert_eq(da->count, 108, "Incorrect number of abbreviation");

--- a/test/unit/test_dwarf_integration.c
+++ b/test/unit/test_dwarf_integration.c
@@ -21,11 +21,11 @@ static bool test_parse_dwarf_types(void) {
 	rz_io_bind(io, &bin->iob);
 	analysis->binb.demangle = rz_bin_demangle;
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/pe/vista-glass.exe", &opt);
+	RzBinFile *bf = rz_bin_open(bin, "bins/pe/vista-glass.exe", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 	// TODO fix, how to correctly promote binary info to the RzAnalysis in unit tests?
 	analysis->cpu = strdup("x86");
 	analysis->bits = 32;
-	mu_assert("pe/vista-glass.exe binary could not be opened", res);
 	RzBinDwarfDebugAbbrev *abbrevs = rz_bin_dwarf_parse_abbrev(bin->cur);
 	mu_assert_notnull(abbrevs, "Couldn't parse Abbreviations");
 	RzBinDwarfDebugInfo *info = rz_bin_dwarf_parse_info(bin->cur, abbrevs);
@@ -87,11 +87,11 @@ static bool test_dwarf_function_parsing_cpp(void) {
 	analysis->binb.demangle = rz_bin_demangle;
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/elf/dwarf4_many_comp_units.elf", &opt);
+	RzBinFile *bf = rz_bin_open(bin, "bins/elf/dwarf4_many_comp_units.elf", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 	// TODO fix, how to correctly promote binary info to the RzAnalysis in unit tests?
 	analysis->cpu = strdup("x86");
 	analysis->bits = 64;
-	mu_assert("elf/dwarf4_many_comp_units.elf binary could not be opened", res);
 	RzBinDwarfDebugAbbrev *abbrevs = rz_bin_dwarf_parse_abbrev(bin->cur);
 	mu_assert_notnull(abbrevs, "Couldn't parse Abbreviations");
 	RzBinDwarfDebugInfo *info = rz_bin_dwarf_parse_info(bin->cur, abbrevs);
@@ -142,11 +142,11 @@ static bool test_dwarf_function_parsing_go(void) {
 	analysis->binb.demangle = rz_bin_demangle;
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/elf/dwarf_go_tree", &opt);
+	RzBinFile *bf = rz_bin_open(bin, "bins/elf/dwarf_go_tree", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 	// TODO fix, how to correctly promote binary info to the RzAnalysis in unit tests?
 	analysis->cpu = strdup("x86");
 	analysis->bits = 64;
-	mu_assert("bins/elf/dwarf_go_tree", res);
 	RzBinDwarfDebugAbbrev *abbrevs = rz_bin_dwarf_parse_abbrev(bin->cur);
 	mu_assert_notnull(abbrevs, "Couldn't parse Abbreviations");
 	RzBinDwarfDebugInfo *info = rz_bin_dwarf_parse_info(bin->cur, abbrevs);
@@ -195,11 +195,11 @@ static bool test_dwarf_function_parsing_rust(void) {
 	analysis->binb.demangle = rz_bin_demangle;
 
 	RzBinOptions opt = { 0 };
-	bool res = rz_bin_open(bin, "bins/elf/dwarf_rust_bubble", &opt);
+	RzBinFile *bf = rz_bin_open(bin, "bins/elf/dwarf_rust_bubble", &opt);
+	mu_assert_notnull(bf, "couldn't open file");
 	// TODO fix, how to correctly promote binary info to the RzAnalysis in unit tests?
 	analysis->cpu = strdup("x86");
 	analysis->bits = 64;
-	mu_assert("bins/elf/dwarf_rust_bubble", res);
 	RzBinDwarfDebugAbbrev *abbrevs = rz_bin_dwarf_parse_abbrev(bin->cur);
 	mu_assert_notnull(abbrevs, "Couldn't parse Abbreviations");
 	RzBinDwarfDebugInfo *info = rz_bin_dwarf_parse_info(bin->cur, abbrevs);

--- a/test/unit/test_io.c
+++ b/test/unit/test_io.c
@@ -352,11 +352,12 @@ typedef struct {
 } CloseTracker;
 
 static void event_desc_close_cb(RzEvent *ev, int type, void *user, void *data) {
+	CloseTracker *tracker = user;
 	if (type != RZ_EVENT_IO_DESC_CLOSE) {
+		tracker->failed_unexpected = true;
 		return;
 	}
 	RzEventIODescClose *iev = data;
-	CloseTracker *tracker = user;
 	RzListIter *it = rz_list_find_ptr(tracker->expect, iev->desc);
 	if (!it) {
 		tracker->failed_unexpected = true;
@@ -420,11 +421,12 @@ bool test_rz_io_event_desc_close(void) {
 }
 
 static void event_map_del_cb(RzEvent *ev, int type, void *user, void *data) {
+	CloseTracker *tracker = user;
 	if (type != RZ_EVENT_IO_MAP_DEL) {
+		tracker->failed_unexpected = true;
 		return;
 	}
 	RzEventIOMapDel *iev = data;
-	CloseTracker *tracker = user;
 	RzListIter *it = rz_list_find_ptr(tracker->expect, iev->map);
 	if (!it) {
 		tracker->failed_unexpected = true;


### PR DESCRIPTION
**DO NOT SQUASH**

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This comes out of #1079. I would like to keep it as a draft for a while to be able to still change things if I notice that it's necessary. But feel free to review nonetheless! It's almost finished.

This contains multiple changes:

* Before, you would often see this pattern:
    ```c
    rz_bin_open(bin, "some file", ...);
    RzBinFile *bf = rz_bin_cur(bin);
    // do stuff with bf
    ```
    This relies on the newly opened file to be the current one afterwards but it is also kind of nonsense because the `rz_bin_open()` already knows the pointer so I changed it to just return it (`NULL` means failure):
    ```
    RzBinFile *bf = rz_bin_open(bin, "some file", ...);
    // do stuff with bf
    ```
* `rz_bin_file_delete()` now take an `RzBinFile *` instead of its id. This eliminates several roundtrips where for example the user entered an id, core would fetch the `RzBinFile *bf` for it, then call `rz_bin_file_delete(bf->id)`, then `rz_bin_file_delete()` would fetch the `RzBinFile *` again, etc.
* `RZ_EVENT_BIN_FILE_DEL` has been added for detecting file deletion
* `RzCoreFile` now also tracks `RzBinFile`s like in #1091 and they are closed when the core file is closed. Before, they leaked.

**Test plan**

unit tests