### PR TITLE
Add and test rz_array_*_bound()

### DIFF
--- a/librz/bin/dbginfo.c
+++ b/librz/bin/dbginfo.c
@@ -152,20 +152,14 @@ RZ_API const RzBinSourceLineSample *rz_bin_source_line_info_get_first_at(const R
 	if (!sli->samples_count) {
 		return NULL;
 	}
-	// binary search
-	size_t l = 0;
-	size_t h = sli->samples_count;
-	while (l < h - 1) {
-		size_t m = l + ((h - l) >> 1);
-		if (addr < sli->samples[m].address) {
-			h = m;
-		} else {
-			l = m;
-		}
-	}
-	if (l >= sli->samples_count) {
+	size_t l;
+#define CMP(x, y) (x > y.address ? 1 : (x < y.address ? -1 : 0))
+	rz_array_upper_bound(sli->samples, sli->samples_count, addr, l, CMP);
+#undef CMP
+	if (!l) {
 		return NULL;
 	}
+	l--;
 	RzBinSourceLineSample *r = &sli->samples[l];
 	if (r->address > addr || rz_bin_source_line_sample_is_closing(r)) {
 		return NULL;

--- a/librz/include/rz_vector.h
+++ b/librz/include/rz_vector.h
@@ -328,16 +328,51 @@ static inline void **rz_pvector_flush(RzPVector *vec) {
 	} while (0)
 
 /*
+ * \brief Find the index of the least element greater than the upper bound x using binary search
+ * example:
+ *
+ * st64 a[] = { 0, 2, 4, 6, 8 };
+ * size_t index;
+ * #define CMP(x, y) x - y
+ * rz_pvector_lower_bound (v, 2, index, CMP);
+ * // index == 2 (contains value 4)
+ */
+#define rz_array_upper_bound(array, len, x, i, cmp) \
+	do { \
+		size_t h = len, m; \
+		for (i = 0; i < h;) { \
+			m = i + ((h - i) >> 1); \
+			if (cmp((x), ((array)[m])) < 0) { \
+				h = m; \
+			} else { \
+				i = m + 1; \
+			} \
+		} \
+	} while (0)
+
+/*
  * example:
  *
  * RzPVector *v = ...; // contains {(void*)0, (void*)2, (void*)4, (void*)6, (void*)8};
  * size_t index;
  * #define CMP(x, y) x - y
- * rz_pvector_lower_bound (v, (void *)3, index, CMP);
- * // index == 2
+ * rz_pvector_lower_bound (v, (void *)2, index, CMP);
+ * // index == 1
  */
 #define rz_pvector_lower_bound(vec, x, i, cmp) \
 	rz_array_lower_bound((void **)(vec)->v.a, (vec)->v.len, x, i, cmp)
+
+/*
+ * example:
+ *
+ * RzPVector *v = ...; // contains {(void*)0, (void*)2, (void*)4, (void*)6, (void*)8};
+ * size_t index;
+ * #define CMP(x, y) x - y
+ * rz_pvector_upper_bound (v, (void *)2, index, CMP);
+ * // index == 2
+ */
+#define rz_pvector_upper_bound(vec, x, i, cmp) \
+	rz_array_upper_bound((void **)(vec)->v.a, (vec)->v.len, x, i, cmp)
 
 #ifdef __cplusplus
 }

--- a/librz/include/rz_vector.h
+++ b/librz/include/rz_vector.h
@@ -305,6 +305,29 @@ static inline void **rz_pvector_flush(RzPVector *vec) {
 	for (it = ((vec)->v.len == 0 ? NULL : (void **)(vec)->v.a + (vec)->v.len - 1); it != NULL && it != (void **)(vec)->v.a - 1; it--)
 
 /*
+ * \brief Find the index of the least element greater than or equal to the lower bound x using binary search
+ * example:
+ *
+ * st64 a[] = { 0, 2, 4, 6, 8 };
+ * size_t index;
+ * #define CMP(x, y) x - y
+ * rz_pvector_lower_bound (v, 3, index, CMP);
+ * // index == 2 (contains value 4)
+ */
+#define rz_array_lower_bound(array, len, x, i, cmp) \
+	do { \
+		size_t h = len, m; \
+		for (i = 0; i < h;) { \
+			m = i + ((h - i) >> 1); \
+			if (cmp((x), ((array)[m])) > 0) { \
+				i = m + 1; \
+			} else { \
+				h = m; \
+			} \
+		} \
+	} while (0)
+
+/*
  * example:
  *
  * RzPVector *v = ...; // contains {(void*)0, (void*)2, (void*)4, (void*)6, (void*)8};
@@ -314,17 +337,7 @@ static inline void **rz_pvector_flush(RzPVector *vec) {
  * // index == 2
  */
 #define rz_pvector_lower_bound(vec, x, i, cmp) \
-	do { \
-		size_t h = (vec)->v.len, m; \
-		for (i = 0; i < h;) { \
-			m = i + ((h - i) >> 1); \
-			if ((cmp((x), ((void **)(vec)->v.a)[m])) > 0) { \
-				i = m + 1; \
-			} else { \
-				h = m; \
-			} \
-		} \
-	} while (0)
+	rz_array_lower_bound((void **)(vec)->v.a, (vec)->v.len, x, i, cmp)
 
 #ifdef __cplusplus
 }

--- a/test/unit/test_vector.c
+++ b/test/unit/test_vector.c
@@ -1138,7 +1138,7 @@ static size_t lower_bound_slow(st64 *a, size_t count, st64 v) {
 }
 
 static size_t upper_bound_slow(st64 *a, size_t count, st64 v) {
-	size_t i;;
+	size_t i;
 	for (i = 0; i < count; i++) {
 		if (a[i] > v) {
 			break;

--- a/test/unit/test_vector.c
+++ b/test/unit/test_vector.c
@@ -401,8 +401,6 @@ static bool test_vector_pop(void) {
 	mu_assert_eq(e, 0, "rz_vector_pop (last) into");
 	mu_assert_eq(v.len, 0UL, "rz_vector_pop (last) => len");
 
-	rz_vector_pop(&v, &e);
-
 	rz_vector_clear(&v);
 
 	mu_end;
@@ -611,6 +609,7 @@ static bool test_vector_flush(void) {
 	for (size_t i = 0; i < 5; i++) {
 		mu_assert_eq(r[i], i, "flushed contents");
 	}
+	free(r);
 	mu_end;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The semantics correspond to for example `std::lower_bound` and `std::upper_bound` in C++.
We had these operations on vectors, but not on raw arrays before. Also upper bound was missing on pvector. 

**Test plan**

unit tests