### PR TITLE
Convert `dts` commands to newshell

### DIFF
--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -4276,7 +4276,6 @@ RZ_IPI RzCmdStatus rz_cmd_debug_start_trace_session_handler(RzCore *core, int ar
 	}
 	core->dbg->session = rz_debug_session_new();
 	rz_debug_add_checkpoint(core->dbg);
-
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/core/cmd_descs/cmd_debug.yaml
+++ b/librz/core/cmd_descs/cmd_debug.yaml
@@ -52,3 +52,30 @@ commands:
             args:
             - name: flag
               type: RZ_CMD_ARG_TYPE_FLAG
+  - name: dts
+    summary: Debug trace session commands
+    subcommands:
+    - name: dts+
+      summary: Start trace session
+      cname: cmd_debug_start_trace_session
+      args: []
+    - name: dts-
+      summary: Stop trace session
+      cname: cmd_debug_stop_trace_session
+      args: []
+    - name: dtst
+      cname: cmd_debug_save_trace_session
+      summary: Save trace sessions to disk
+      args:
+        - name: dir
+          type: RZ_CMD_ARG_TYPE_STRING
+    - name: dtsf
+      cname: cmd_debug_load_trace_session
+      summary: Load trace sessions to disk
+      args:
+        - name: dir
+          type: RZ_CMD_ARG_TYPE_STRING
+    - name: dtsm
+      cname: cmd_debug_list_trace_session_mmap
+      summary: List current memory map and hash
+      args: []

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -91,6 +91,8 @@ static const RzCmdDescArg cmd_debug_step_until_instr_regex_args[2];
 static const RzCmdDescArg cmd_debug_step_until_optype_args[2];
 static const RzCmdDescArg cmd_debug_step_until_esil_args[2];
 static const RzCmdDescArg cmd_debug_step_until_flag_args[2];
+static const RzCmdDescArg cmd_debug_save_trace_session_args[2];
+static const RzCmdDescArg cmd_debug_load_trace_session_args[2];
 static const RzCmdDescArg eval_getset_args[2];
 static const RzCmdDescArg eval_list_args[2];
 static const RzCmdDescArg eval_bool_invert_args[2];
@@ -1521,6 +1523,61 @@ static const RzCmdDescArg cmd_debug_step_until_flag_args[] = {
 static const RzCmdDescHelp cmd_debug_step_until_flag_help = {
 	.summary = "Step until pc == <flag> matching name",
 	.args = cmd_debug_step_until_flag_args,
+};
+
+static const RzCmdDescHelp dts_help = {
+	.summary = "Debug trace session commands",
+};
+static const RzCmdDescArg cmd_debug_start_trace_session_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_debug_start_trace_session_help = {
+	.summary = "Start trace session",
+	.args = cmd_debug_start_trace_session_args,
+};
+
+static const RzCmdDescArg cmd_debug_stop_trace_session_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_debug_stop_trace_session_help = {
+	.summary = "Stop trace session",
+	.args = cmd_debug_stop_trace_session_args,
+};
+
+static const RzCmdDescArg cmd_debug_save_trace_session_args[] = {
+	{
+		.name = "dir",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_debug_save_trace_session_help = {
+	.summary = "Save trace sessions to disk",
+	.args = cmd_debug_save_trace_session_args,
+};
+
+static const RzCmdDescArg cmd_debug_load_trace_session_args[] = {
+	{
+		.name = "dir",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_debug_load_trace_session_help = {
+	.summary = "Load trace sessions to disk",
+	.args = cmd_debug_load_trace_session_args,
+};
+
+static const RzCmdDescArg cmd_debug_list_trace_session_mmap_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_debug_list_trace_session_mmap_help = {
+	.summary = "List current memory map and hash",
+	.args = cmd_debug_list_trace_session_mmap_args,
 };
 
 static const RzCmdDescHelp e_help = {
@@ -4227,6 +4284,23 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *cmd_debug_step_until_flag_cd = rz_cmd_desc_argv_new(core->rcmd, dsu_cd, "dsuf", rz_cmd_debug_step_until_flag_handler, &cmd_debug_step_until_flag_help);
 	rz_warn_if_fail(cmd_debug_step_until_flag_cd);
+
+	RzCmdDesc *dts_cd = rz_cmd_desc_group_new(core->rcmd, cmd_debug_step_cd, "dts", NULL, NULL, &dts_help);
+	rz_warn_if_fail(dts_cd);
+	RzCmdDesc *cmd_debug_start_trace_session_cd = rz_cmd_desc_argv_new(core->rcmd, dts_cd, "dts+", rz_cmd_debug_start_trace_session_handler, &cmd_debug_start_trace_session_help);
+	rz_warn_if_fail(cmd_debug_start_trace_session_cd);
+
+	RzCmdDesc *cmd_debug_stop_trace_session_cd = rz_cmd_desc_argv_new(core->rcmd, dts_cd, "dts-", rz_cmd_debug_stop_trace_session_handler, &cmd_debug_stop_trace_session_help);
+	rz_warn_if_fail(cmd_debug_stop_trace_session_cd);
+
+	RzCmdDesc *cmd_debug_save_trace_session_cd = rz_cmd_desc_argv_new(core->rcmd, dts_cd, "dtst", rz_cmd_debug_save_trace_session_handler, &cmd_debug_save_trace_session_help);
+	rz_warn_if_fail(cmd_debug_save_trace_session_cd);
+
+	RzCmdDesc *cmd_debug_load_trace_session_cd = rz_cmd_desc_argv_new(core->rcmd, dts_cd, "dtsf", rz_cmd_debug_load_trace_session_handler, &cmd_debug_load_trace_session_help);
+	rz_warn_if_fail(cmd_debug_load_trace_session_cd);
+
+	RzCmdDesc *cmd_debug_list_trace_session_mmap_cd = rz_cmd_desc_argv_new(core->rcmd, dts_cd, "dtsm", rz_cmd_debug_list_trace_session_mmap_handler, &cmd_debug_list_trace_session_mmap_help);
+	rz_warn_if_fail(cmd_debug_list_trace_session_mmap_cd);
 
 	RzCmdDesc *e_cd = rz_cmd_desc_group_new(core->rcmd, root_cd, "e", rz_eval_getset_handler, &eval_getset_help, &e_help);
 	rz_warn_if_fail(e_cd);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -4285,7 +4285,7 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *cmd_debug_step_until_flag_cd = rz_cmd_desc_argv_new(core->rcmd, dsu_cd, "dsuf", rz_cmd_debug_step_until_flag_handler, &cmd_debug_step_until_flag_help);
 	rz_warn_if_fail(cmd_debug_step_until_flag_cd);
 
-	RzCmdDesc *dts_cd = rz_cmd_desc_group_new(core->rcmd, cmd_debug_step_cd, "dts", NULL, NULL, &dts_help);
+	RzCmdDesc *dts_cd = rz_cmd_desc_group_new(core->rcmd, cmd_debug_cd, "dts", NULL, NULL, &dts_help);
 	rz_warn_if_fail(dts_cd);
 	RzCmdDesc *cmd_debug_start_trace_session_cd = rz_cmd_desc_argv_new(core->rcmd, dts_cd, "dts+", rz_cmd_debug_start_trace_session_handler, &cmd_debug_start_trace_session_help);
 	rz_warn_if_fail(cmd_debug_start_trace_session_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -105,6 +105,11 @@ RZ_IPI RzCmdStatus rz_cmd_debug_step_until_instr_regex_handler(RzCore *core, int
 RZ_IPI RzCmdStatus rz_cmd_debug_step_until_optype_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_step_until_esil_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_step_until_flag_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_start_trace_session_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_stop_trace_session_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_save_trace_session_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_load_trace_session_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_list_trace_session_mmap_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI int rz_cmd_debug_step(void *data, const char *input);
 RZ_IPI int rz_cmd_debug(void *data, const char *input);
 RZ_IPI RzCmdStatus rz_eval_getset_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -105,12 +105,12 @@ RZ_IPI RzCmdStatus rz_cmd_debug_step_until_instr_regex_handler(RzCore *core, int
 RZ_IPI RzCmdStatus rz_cmd_debug_step_until_optype_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_step_until_esil_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_step_until_flag_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI int rz_cmd_debug_step(void *data, const char *input);
 RZ_IPI RzCmdStatus rz_cmd_debug_start_trace_session_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_stop_trace_session_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_save_trace_session_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_load_trace_session_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_list_trace_session_mmap_handler(RzCore *core, int argc, const char **argv);
-RZ_IPI int rz_cmd_debug_step(void *data, const char *input);
 RZ_IPI int rz_cmd_debug(void *data, const char *input);
 RZ_IPI RzCmdStatus rz_eval_getset_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_eval_list_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);

--- a/test/db/archos/linux-x64/dbg_dts
+++ b/test/db/archos/linux-x64/dbg_dts
@@ -24,6 +24,7 @@ RUN
 NAME=stop trace session (dts-)
 FILE=bins/elf/analysis/calls_x64
 ARGS=-d -e dbg.bpsysign=true
+BROKEN=1
 CMDS=<<EOF
 dcu main
 dts+

--- a/test/db/archos/linux-x64/dbg_dts
+++ b/test/db/archos/linux-x64/dbg_dts
@@ -25,13 +25,22 @@ NAME=stop trace session (dts-)
 FILE=bins/elf/analysis/calls_x64
 ARGS=-d -e dbg.bpsysign=true
 CMDS=<<EOF
-db 0x0040057c
-dc
+dcu main
 dts+
+ds
+ds
+ds
+ds
 dts-
-dtst rizin
+ds
+ds
+dt
 EOF
 EXPECT=<<EOF
-No session started
+0x00400574 size=7 count=1 times=1 tag=0
+0x00400575 size=10 count=2 times=1 tag=0
+0x0040052f size=2 count=3 times=1 tag=0
+0x00400539 size=10 count=4 times=1 tag=0
+0x0040053c size=2 count=5 times=1 tag=0
 EOF
 RUN

--- a/test/db/archos/linux-x64/dbg_dts
+++ b/test/db/archos/linux-x64/dbg_dts
@@ -20,3 +20,18 @@ EXPECT=<<EOF
 0x00400565
 EOF
 RUN
+
+NAME=stop trace session (dts-)
+FILE=bins/elf/analysis/calls_x64
+ARGS=-d -e dbg.bpsysign=true
+CMDS=<<EOF
+db 0x0040057c
+dc
+dts+
+dts-
+dtst rizin
+EOF
+EXPECT=<<EOF
+No session started
+EOF
+RUN

--- a/test/db/archos/linux-x64/dbg_dts
+++ b/test/db/archos/linux-x64/dbg_dts
@@ -24,7 +24,6 @@ RUN
 NAME=stop trace session (dts-)
 FILE=bins/elf/analysis/calls_x64
 ARGS=-d -e dbg.bpsysign=true
-BROKEN=1
 CMDS=<<EOF
 dcu main
 dts+
@@ -34,14 +33,12 @@ ds
 ds
 dts-
 ds
-ds
-dt
+s
+dsb
+s
 EOF
 EXPECT=<<EOF
-0x00400574 size=7 count=1 times=1 tag=0
-0x00400575 size=10 count=2 times=1 tag=0
-0x0040052f size=2 count=3 times=1 tag=0
-0x00400539 size=10 count=4 times=1 tag=0
-0x0040053c size=2 count=5 times=1 tag=0
+0x40052f
+0x40052f
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Converts commands under `dts`: `dts+`, `dts-`, `dtst`, `dtsf`, `dtsm` commands to newshell.

**Test plan**

Everything except `dtsm` has unit tests now. I'm not sure whether we can add test
for this one as it prints a lot of information which is dependent on the machine.

```
[0x00400565]> dtsm
Reading 4096 byte(s) from 0x00600000...
Reading 8192 byte(s) from 0x7fae8e85f000...
Reading 12288 byte(s) from 0x7fae8ea22000...
Reading 45056 byte(s) from 0x7fae8ea25000...
Reading 8192 byte(s) from 0x7fae8ea71000...
Reading 135168 byte(s) from 0x7ffc033f4000...
/home/cjunior/Downloads/rz/rizin/test/bins/elf/analysis/calls_x64: 22706addda4447a4a46b9a173f7f30a40f7c6f4287f2bf1b89490dbf97665c70
unk0: 604c8c108fbd51a88eafa4c63e29b0536c65a4abb74ca64434550c61c3cb41d5
/usr/lib/libc-2.33.so: c028ab380aec5b54dcba7245776a82623c6fbfd4f5d39576500d4f249d7681aa
unk1: ca1861200cf6788937e8e6a31f1b082aec9145fcc0f7e417f3258e3c46339f86
/usr/lib/ld-2.33.so: 52a808c284ba793f87955d3d6a537e50a178ad6ad781c127e6cd94f2bec9e719
[stack]: 612eb34cdb4f709fb53ed885d8cc55d9009a0260e46a480fd1ec6ad0fc7acd58
```
See the name of the handler as well, I had went with 
`rz_cmd_debug_list_trace_session_mmap_handler` fearing that the name might get a bit long. 


Putting it as draft to see if the CI finds something out.
**Closing issues**

None