### PR TITLE
Stop Parsing NE Relocs when outside of the Buffer

### DIFF
--- a/librz/bin/format/ne/ne.c
+++ b/librz/bin/format/ne/ne.c
@@ -435,6 +435,7 @@ RzList *rz_bin_ne_get_relocs(rz_bin_ne_obj_t *bin) {
 		return NULL;
 	}
 
+	ut64 bufsz = rz_buf_size(bin->buf);
 	RzListIter *it;
 	RzBinSection *seg;
 	int index = -1;
@@ -444,12 +445,15 @@ RzList *rz_bin_ne_get_relocs(rz_bin_ne_obj_t *bin) {
 			continue;
 		}
 		ut32 off, start = off = seg->paddr + seg->size;
+		if ((ut64)off + 2 > bufsz) {
+			continue;
+		}
 		ut16 length = rz_buf_read_le16_at(bin->buf, off);
 		if (!length) {
 			continue;
 		}
 		off += 2;
-		while (off < start + length * sizeof(NE_image_reloc_item)) {
+		while (off < start + length * sizeof(NE_image_reloc_item) && off + sizeof(NE_image_reloc_item) <= bufsz) {
 			RzBinReloc *reloc = RZ_NEW0(RzBinReloc);
 			if (!reloc) {
 				return NULL;

--- a/test/db/formats/pe/exe2pe
+++ b/test/db/formats/pe/exe2pe
@@ -1,6 +1,13 @@
-NAME=PE: corkami exe2pe.exe - open
+NAME=PE: corkami exe2pe.exe - open and don't parse oob relocs
 FILE=bins/pe/exe2pe.exe
-CMDS=q!
+CMDS=ir
 EXPECT=<<EOF
+[Relocations]
+
+vaddr paddr type name
+---------------------
+
+
+0 relocations
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The binary in question apparently is https://github.com/corkami/pocs/blob/master/PE/exe2pe.asm which is intentionally broken. The ne parser would read the number of relocs from outside the file and thus attempt to parse 0xffff relocs per segment.

**Test plan**

see the updated test