### PR TITLE
Demangle tcache and fastbin pointers automatically for glibc >= 2.32

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -2975,7 +2975,6 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETI("dbg.glibc.ma_offset", 0x1bb000, "Main_arena offset from his symbol");
 	SETI("dbg.glibc.fc_offset", 0x148, "First chunk offset from brk_start");
 #endif
-	SETBPREF("dbg.glibc.demangle", "false", "Demangle linked-lists pointers introduced in glibc 2.32");
 	SETI("dbg.glibc.fastbinmax", 10, "Upper bound on the number of fastbins printed");
 
 	SETBPREF("esil.prestep", "true", "Step before esil evaluation in `de` commands");

--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -877,11 +877,7 @@ static int GH(print_single_linked_list_bin)(RzCore *core, MallocState *main_aren
 			}
 		}
 		rz_io_read_at(core->io, next, (ut8 *)cnk, sizeof(GH(RzHeapChunk)));
-		if (core->dbg->glibc_version < 232) {
-			next = (!demangle) ? cnk->fd : PROTECT_PTR(next, cnk->fd);
-		} else {
-			next = PROTECT_PTR(next, cnk->fd);
-		}
+		next = GH(get_next_pointer)(core, next, cnk->fd);
 		rz_cons_printf("%s", next ? " -> " : "");
 		if (cnk->prev_size > size || ((cnk->size >> 3) << 3) > size) {
 			PRINTF_RA(" 0x%" PFMT64x, (ut64)next);
@@ -1029,13 +1025,7 @@ static void GH(tcache_print)(RzCore *core, GH(RTcache) * tcache, bool demangle) 
 					if (!r) {
 						break;
 					}
-					if (core->dbg->glibc_version < 232) {
-						tcache_tmp = (!demangle)
-							? read_le(&tcache_tmp)
-							: PROTECT_PTR(tcache_fd, read_le(&tcache_tmp));
-					} else {
-						tcache_tmp = PROTECT_PTR(tcache_fd, read_le(&tcache_tmp));
-					}
+					tcache_tmp = GH(get_next_pointer)(core, tcache_fd, read_le(&tcache_tmp));
 					rz_cons_printf("\n -> ");
 					GH(print_heap_chunk_simple)
 					(core, (ut64)(tcache_tmp - TC_HDR_SZ), NULL);

--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -1025,10 +1025,13 @@ static void GH(tcache_print)(RzCore *core, GH(RTcache) * tcache, bool demangle) 
 					if (!r) {
 						break;
 					}
-					tcache_tmp = (!demangle)
-						? read_le(&tcache_tmp)
-						: PROTECT_PTR(tcache_fd, read_le(&tcache_tmp));
-
+					if (core->dbg->glibc_version < 232) {
+						tcache_tmp = (!demangle)
+							? read_le(&tcache_tmp)
+							: PROTECT_PTR(tcache_fd, read_le(&tcache_tmp));
+					} else {
+						tcache_tmp = PROTECT_PTR(tcache_fd, read_le(&tcache_tmp));
+					}
 					rz_cons_printf("\n -> ");
 					GH(print_heap_chunk_simple)
 					(core, (ut64)(tcache_tmp - TC_HDR_SZ), NULL);

--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -877,7 +877,11 @@ static int GH(print_single_linked_list_bin)(RzCore *core, MallocState *main_aren
 			}
 		}
 		rz_io_read_at(core->io, next, (ut8 *)cnk, sizeof(GH(RzHeapChunk)));
-		next = (!demangle) ? cnk->fd : PROTECT_PTR(next, cnk->fd);
+		if (core->dbg->glibc_version < 232) {
+			next = (!demangle) ? cnk->fd : PROTECT_PTR(next, cnk->fd);
+		} else {
+			next = PROTECT_PTR(next, cnk->fd);
+		}
 		rz_cons_printf("%s", next ? " -> " : "");
 		if (cnk->prev_size > size || ((cnk->size >> 3) << 3) > size) {
 			PRINTF_RA(" 0x%" PFMT64x, (ut64)next);

--- a/test/db/archos/linux-x64/dbg_dmht
+++ b/test/db/archos/linux-x64/dbg_dmht
@@ -5,8 +5,6 @@ CMDS=<<EOF
 db 0x004011fa
 dc
 dmht~?0xffffffffffff
-e dbg.glibc.demangle=true
-dmht~?0xffffffffffff
 dmht~?Items: 7
 dc
 dmht~?Items: 6
@@ -14,7 +12,6 @@ dc
 dmht~?Items: 5
 EOF
 EXPECT=<<EOF
-2
 0
 1
 1


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
Since Glibc 2.32 the `fd` pointers of fast bins and tcache are by default protected. So Rizin should demangle these pointers by default. Currently, it relies on `dbg.glibc.demangle` to demangle which is by default set to false so the users get incorrect output. I think many users may not know that they have to change `dbg.glibc.demangle`  setting for correct output.  
This can be easily replicated by debugging a binary with Glibc version >= 2.32 (like arch which is shipping with 2.33 or by preloading it)   
This case is also discussed in [this thread](https://github.com/radareorg/radare2/issues/17915#issuecomment-729799640)

Here is an example: 
### Before:
#### Fastbin
<img width="488" alt="Screenshot 2021-05-06 at 2 06 01 PM" src="https://user-images.githubusercontent.com/56169176/117267724-33987180-ae74-11eb-9b63-d6b2386ef34d.png">

#### Tcache
<img width="763" alt="Screenshot 2021-05-06 at 2 05 39 PM" src="https://user-images.githubusercontent.com/56169176/117267673-27141900-ae74-11eb-82ff-a5d96a2226d6.png">

### After
#### Fastbin
<img width="478" alt="Screenshot 2021-05-06 at 2 06 51 PM" src="https://user-images.githubusercontent.com/56169176/117267851-532f9a00-ae74-11eb-8846-8313f6fd0c83.png">

#### Tcache
<img width="507" alt="Screenshot 2021-05-06 at 2 06 41 PM" src="https://user-images.githubusercontent.com/56169176/117267821-4ca12280-ae74-11eb-8620-48947e5186bd.png">







...

**Test plan**


...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
