### PR TITLE
Expose section type and flag to string API

### DIFF
--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -1442,6 +1442,42 @@ RZ_IPI void rz_bin_section_free(RzBinSection *bs) {
 	}
 }
 
+/**
+ * \brief Converts the RzBinSection type to the string representation
+ *
+ * Some binary formats have a function interface called "section_type_to_string"
+ * The returned string type name is different between formats
+ *
+ * \param bin RzBin instance
+ * \param type A type field of the RzBinSection (differs between formats)
+ * */
+RZ_API RZ_OWN char *rz_bin_section_type_to_string(RzBin *bin, int type) {
+	RzBinFile *a = rz_bin_cur(bin);
+	RzBinPlugin *plugin = rz_bin_file_cur_plugin(a);
+	if (plugin && plugin->section_type_to_string) {
+		return plugin->section_type_to_string(type);
+	}
+	return NULL;
+}
+
+/**
+ * \brief Converts the RzBinSection flags to a list of string representations
+ *
+ * Some binary formats have a function interface called "section_flag_to_rzlist"
+ * The returned string flag names are different between formats
+ *
+ * \param bin RzBin instance
+ * \param flag A flag field of the RzBinSection (differs between formats)
+ * */
+RZ_API RZ_OWN RzList *rz_bin_section_flag_to_list(RzBin *bin, ut64 flag) {
+	RzBinFile *a = rz_bin_cur(bin);
+	RzBinPlugin *plugin = rz_bin_file_cur_plugin(a);
+	if (plugin && plugin->section_flag_to_rzlist) {
+		return plugin->section_flag_to_rzlist(flag);
+	}
+	return NULL;
+}
+
 RZ_API RzBinFile *rz_bin_file_at(RzBin *bin, ut64 at) {
 	RzListIter *it, *it2;
 	RzBinFile *bf;

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -2833,24 +2833,6 @@ static int bin_map_sections_to_segments(RzBin *bin, PJ *pj, int mode) {
 	return true;
 }
 
-static char *section_type_to_string(RzBin *bin, int type) {
-	RzBinFile *a = rz_bin_cur(bin);
-	RzBinPlugin *plugin = rz_bin_file_cur_plugin(a);
-	if (plugin && plugin->section_type_to_string) {
-		return plugin->section_type_to_string(type);
-	}
-	return NULL;
-}
-
-static RzList *section_flag_to_rzlist(RzBin *bin, ut64 flag) {
-	RzBinFile *a = rz_bin_cur(bin);
-	RzBinPlugin *plugin = rz_bin_file_cur_plugin(a);
-	if (plugin && plugin->section_flag_to_rzlist) {
-		return plugin->section_flag_to_rzlist(flag);
-	}
-	return NULL;
-}
-
 static int bin_sections(RzCore *r, PJ *pj, int mode, ut64 laddr, int va, ut64 at, const char *name, const char *chksum, bool print_segments) {
 	RzBinSection *section;
 	RzBinInfo *info = NULL;
@@ -3036,14 +3018,14 @@ static int bin_sections(RzCore *r, PJ *pj, int mode, ut64 laddr, int va, ut64 at
 				free(data);
 			}
 			if (!print_segments && plugin_type_support) {
-				char *section_type = section_type_to_string(r->bin, section->type);
+				char *section_type = rz_bin_section_type_to_string(r->bin, section->type);
 				if (section_type) {
 					pj_ks(pj, "type", section_type);
 				}
 				free(section_type);
 			}
 			if (!print_segments && plugin_flags_support) {
-				RzList *flags = section_flag_to_rzlist(r->bin, section->flags);
+				RzList *flags = rz_bin_section_flag_to_list(r->bin, section->flags);
 				char *pos;
 				if (flags) {
 					pj_ka(pj, "flags");
@@ -3107,12 +3089,12 @@ static int bin_sections(RzCore *r, PJ *pj, int mode, ut64 laddr, int va, ut64 at
 			rz_list_append(row_list, strdup(section_name));
 
 			if (!print_segments && plugin_type_support) {
-				char *section_type = section_type_to_string(r->bin, section->type);
+				char *section_type = rz_bin_section_type_to_string(r->bin, section->type);
 				rz_list_append(row_list, section_type);
 			}
 
 			if (!print_segments && plugin_flags_support) {
-				RzList *section_flags = section_flag_to_rzlist(r->bin, section->flags);
+				RzList *section_flags = rz_bin_section_flag_to_list(r->bin, section->flags);
 				char *section_flags_str = rz_str_list_join(section_flags, ",");
 				rz_list_append(row_list, section_flags_str);
 				rz_list_free(section_flags);

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -758,6 +758,8 @@ RZ_API RzList *rz_bin_maps_of_file_sections(RzBinFile *binfile);
 RZ_API RzList *rz_bin_sections_of_maps(RzList /*<RzBinMap>*/ *maps);
 RZ_IPI RzBinSection *rz_bin_section_new(const char *name);
 RZ_IPI void rz_bin_section_free(RzBinSection *bs);
+RZ_API RZ_OWN char *rz_bin_section_type_to_string(RzBin *bin, int type);
+RZ_API RZ_OWN RzList *rz_bin_section_flag_to_list(RzBin *bin, ut64 flag);
 RZ_API void rz_bin_info_free(RzBinInfo *rb);
 RZ_API void rz_bin_import_free(RzBinImport *imp);
 RZ_API void rz_bin_symbol_free(RzBinSymbol *sym);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Rizin already had functions to convert section type and flags to strings, but they were marked as `static` which is problematic for users of the API who is bound to decode the numeric fields on their own. This change exposes it as two new APIs of `RzBin`:
```c
RZ_API RZ_OWN char *rz_bin_section_type_to_string(RzBin *bin, int type);
RZ_API RZ_OWN RzList *rz_bin_section_flag_to_list(RzBin *bin, ut64 flag);
```

**Test plan**

CI is green
