### PR TITLE
Fix manual RzBinFile deletion in bin_raw_strings()

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -1648,6 +1648,9 @@ static bool bin_raw_strings(RzCore *r, PJ *pj, int mode, int va) {
 		return false;
 	}
 	if (!bf) {
+		// TODO: manually creating an RzBinFile like this is a hack and abuse of RzBin API
+		// If we don't want to use an RzBinFile for searching strings, the raw strings search
+		// should be refactored out of bin.
 		bf = RZ_NEW0(RzBinFile);
 		if (!bf) {
 			return false;
@@ -1674,9 +1677,8 @@ static bool bin_raw_strings(RzCore *r, PJ *pj, int mode, int va) {
 	rz_list_free(l);
 	if (new_bf) {
 		rz_buf_free(bf->buf);
-		bf->buf = NULL;
-		bf->id = -1;
-		rz_bin_file_delete(r->bin, bf);
+		free(bf->file);
+		free(bf);
 	}
 	return true;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

To fix the assert: https://travis-ci.com/github/rizinorg/rizin/jobs/503938513
What is done in this function is bad, it's manually crafting an `RzBinFile` object to make the string search work. In that case `rz_bin_file_delete()` will be confused because the file isn't really part of bin and instead it has to be cleaned up manually too. To be refactored.