### PR TITLE
Tests, Fixes and Simplifications for ihex and Sparse RzBuffer

### DIFF
--- a/librz/include/rz_util/rz_buf.h
+++ b/librz/include/rz_util/rz_buf.h
@@ -50,11 +50,9 @@ struct rz_buf_t {
 
 // XXX: this should not be public
 typedef struct rz_buf_cache_t {
-	ut64 from;
-	ut64 to;
-	int size;
-	ut8 *data;
-	int written;
+	ut64 from; ///< inclusive
+	ut64 to; ///< exclusive, may overlap to 0
+	ut8 *data; ///< size == to - from
 } RzBufferSparse;
 
 /* constructors */

--- a/librz/io/p/io_ihex.c
+++ b/librz/io/p/io_ihex.c
@@ -344,7 +344,7 @@ static bool ihex_write(RzIODesc *desc, Rihex *rih) {
 		ut16 addh0 = rbs->from >> 16;
 		ut16 addh1 = (rbs->to - 1) >> 16;
 		ut16 tsiz = 0;
-		if (rbs->size == 0) {
+		if (rbs->from == rbs->to) {
 			continue;
 		}
 
@@ -381,7 +381,7 @@ static bool ihex_write(RzIODesc *desc, Rihex *rih) {
 			}
 		}
 		//00 records (remaining data)
-		if (fwblock(out, rbs->data + tsiz, (addh1 << 16) | addl0, rbs->size - tsiz)) {
+		if (fwblock(out, rbs->data + tsiz, (addh1 << 16) | addl0, (rbs->to - rbs->from) - tsiz)) {
 			eprintf("ihex:fwblock error\n");
 			rz_list_free(nonempty);
 			fclose(out);
@@ -392,7 +392,6 @@ static bool ihex_write(RzIODesc *desc, Rihex *rih) {
 	rz_list_free(nonempty);
 	fprintf(out, ":00000001FF\n");
 	fclose(out);
-	out = NULL;
 	return true;
 }
 

--- a/librz/io/p/io_ihex.c
+++ b/librz/io/p/io_ihex.c
@@ -41,86 +41,29 @@ typedef struct {
 	RzBuffer *rbuf;
 } Rihex;
 
-static int fw04b(FILE *fd, ut16 eaddr);
-static int fwblock(FILE *fd, ut8 *b, ut32 start_addr, ut16 size);
+static bool ihex_write(RzIODesc *desc, Rihex *rih);
 
 static int __write(RzIO *io, RzIODesc *fd, const ut8 *buf, int count) {
-	const char *pathname;
-	FILE *out;
-	Rihex *rih;
-	RzBufferSparse *rbs;
-	RzListIter *iter;
-
 	if (!fd || !fd->data || (fd->perm & RZ_PERM_W) == 0 || count <= 0) {
 		return -1;
 	}
-	rih = fd->data;
-	pathname = fd->name + 7;
-	out = rz_sys_fopen(pathname, "w");
-	if (!out) {
-		eprintf("Cannot open '%s' for writing\n", pathname);
-		return -1;
-	}
+	Rihex *rih = fd->data;
 	/* mem write */
 	if (rz_buf_write_at(rih->rbuf, io->off, buf, count) != count) {
 		eprintf("ihex:write(): sparse write failed\n");
-		fclose(out);
 		return -1;
 	}
 	rz_buf_seek(rih->rbuf, count, RZ_BUF_CUR);
+	if (!ihex_write(fd, rih)) {
+		return -1;
+	}
+	return count;
+}
 
-	/* disk write : process each sparse chunk */
-	//TODO : sort addresses + check overlap?
-	RzList *nonempty = rz_buf_nonempty_list(rih->rbuf);
-	rz_list_foreach (nonempty, iter, rbs) {
-		ut16 addl0 = rbs->from & 0xffff;
-		ut16 addh0 = rbs->from >> 16;
-		ut16 addh1 = rbs->to >> 16;
-		ut16 tsiz = 0;
-		if (rbs->size == 0) {
-			continue;
-		}
-
-		if (addh0 != addh1) {
-			//we cross a 64k boundary, so write in two steps
-			//04 record (ext address)
-			if (fw04b(out, addh0) < 0) {
-				eprintf("ihex:write: file error\n");
-				rz_list_free(nonempty);
-				fclose(out);
-				return -1;
-			}
-			//00 records (data)
-			tsiz = -addl0;
-			addl0 = 0;
-			if (fwblock(out, rbs->data, rbs->from, tsiz)) {
-				eprintf("ihex:fwblock error\n");
-				rz_list_free(nonempty);
-				fclose(out);
-				return -1;
-			}
-		}
-		//04 record (ext address)
-		if (fw04b(out, addh1) < 0) {
-			eprintf("ihex:write: file error\n");
-			rz_list_free(nonempty);
-			fclose(out);
-			return -1;
-		}
-		//00 records (remaining data)
-		if (fwblock(out, rbs->data + tsiz, (addh1 << 16) | addl0, rbs->size - tsiz)) {
-			eprintf("ihex:fwblock error\n");
-			rz_list_free(nonempty);
-			fclose(out);
-			return -1;
-		}
-	} //list_foreach
-
-	rz_list_free(nonempty);
-	fprintf(out, ":00000001FF\n");
-	fclose(out);
-	out = NULL;
-	return 0;
+//fw04b : write 04 record (extended address); ret <0 if error
+static int fw04b(FILE *fd, ut16 eaddr) {
+	ut8 cks = 0 - (6 + (eaddr >> 8) + (eaddr & 0xff));
+	return fprintf(fd, ":02000004%04X%02X\n", eaddr, cks);
 }
 
 //write contiguous block of data to file; ret 0 if ok
@@ -177,12 +120,6 @@ static int fwblock(FILE *fd, ut8 *b, ut32 start_addr, ut16 size) {
 		return -1;
 	}
 	return 0;
-}
-
-//fw04b : write 04 record (extended address); ret <0 if error
-static int fw04b(FILE *fd, ut16 eaddr) {
-	ut8 cks = 0 - (6 + (eaddr >> 8) + (eaddr & 0xff));
-	return fprintf(fd, ":02000004%04X%02X\n", eaddr, cks);
 }
 
 static int __read(RzIO *io, RzIODesc *fd, ut8 *buf, int count) {
@@ -389,6 +326,76 @@ fail:
 	return false;
 }
 
+static bool ihex_write(RzIODesc *desc, Rihex *rih) {
+	const char *pathname = desc->name + 7;
+	FILE *out = rz_sys_fopen(pathname, "w");
+	if (!out) {
+		eprintf("Cannot open '%s' for writing\n", pathname);
+		return false;
+	}
+	RzBufferSparse *rbs;
+	RzListIter *iter;
+	/* disk write : process each sparse chunk */
+	//TODO : sort addresses + check overlap?
+	RzList *nonempty = rz_buf_nonempty_list(rih->rbuf);
+	ut64 addh_cur = 0;
+	rz_list_foreach (nonempty, iter, rbs) {
+		ut16 addl0 = rbs->from & 0xffff;
+		ut16 addh0 = rbs->from >> 16;
+		ut16 addh1 = (rbs->to - 1) >> 16;
+		ut16 tsiz = 0;
+		if (rbs->size == 0) {
+			continue;
+		}
+
+		if (addh0 != addh1) {
+			//we cross a 64k boundary, so write in two steps
+			if (addh0 != addh_cur) {
+				addh_cur = addh0;
+				//04 record (ext address)
+				if (fw04b(out, addh0) < 0) {
+					eprintf("ihex:write: file error\n");
+					rz_list_free(nonempty);
+					fclose(out);
+					return false;
+				}
+			}
+			//00 records (data)
+			tsiz = -addl0;
+			addl0 = 0;
+			if (fwblock(out, rbs->data, rbs->from, tsiz)) {
+				eprintf("ihex:fwblock error\n");
+				rz_list_free(nonempty);
+				fclose(out);
+				return false;
+			}
+		}
+		if (addh1 != addh_cur) {
+			addh_cur = addh1;
+			//04 record (ext address)
+			if (fw04b(out, addh1) < 0) {
+				eprintf("ihex:write: file error\n");
+				rz_list_free(nonempty);
+				fclose(out);
+				return false;
+			}
+		}
+		//00 records (remaining data)
+		if (fwblock(out, rbs->data + tsiz, (addh1 << 16) | addl0, rbs->size - tsiz)) {
+			eprintf("ihex:fwblock error\n");
+			rz_list_free(nonempty);
+			fclose(out);
+			return false;
+		}
+	} //list_foreach
+
+	rz_list_free(nonempty);
+	fprintf(out, ":00000001FF\n");
+	fclose(out);
+	out = NULL;
+	return true;
+}
+
 static RzIODesc *__open(RzIO *io, const char *pathname, int rw, int mode) {
 	Rihex *mal = NULL;
 	char *str = NULL;
@@ -427,10 +434,13 @@ static bool __resize(RzIO *io, RzIODesc *fd, ut64 size) {
 		return false;
 	}
 	Rihex *rih = fd->data;
-	if (rih) {
-		return rz_buf_resize(rih->rbuf, size);
+	if (!rih) {
+		return false;
 	}
-	return false;
+	if (!rz_buf_resize(rih->rbuf, size)) {
+		return false;
+	}
+	return ihex_write(fd, rih);
 }
 
 RzIOPlugin rz_io_plugin_ihex = {

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -51,6 +51,7 @@ if get_option('enable_tests')
     'idstorage',
     'intervaltree',
     'io',
+    'io_ihex',
     'json',
     'list',
     'ovf',

--- a/test/unit/test_io_ihex.c
+++ b/test/unit/test_io_ihex.c
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: 2021 Florian Märkl <info@florianmaerkl.de>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_io.h>
+#include "minunit.h"
+
+static const char *ihex_sample =
+	":020000021000EC\r\n"
+	":10010000214601360121470136007EFE09D2190140\r\n"
+	":100110002146017EB7C20001FF5F16002148011988\r\n"
+	":020000022000DC\r\n"
+	":10010000194E79234623965778239EDA3F01B2CAC7\r\n"
+	":100110003F0156702B5E712B722B732146013421E7\r\n"
+	":00000001FF\r\n";
+
+char *create_sample_file(const char *prefix) {
+	char *filename = rz_file_temp(prefix);
+	int fd = open(filename, O_RDWR | O_CREAT, 0644);
+	rz_xwrite(fd, ihex_sample, strlen(ihex_sample));
+	close(fd);
+	return filename;
+}
+
+bool test_rz_io_ihex_read(void) {
+	RzIO *io = rz_io_new();
+	io->ff = true;
+	io->Oxff = 0xff;
+
+	char *filename = create_sample_file("ihex0");
+	char *uri = rz_str_newf("ihex://%s", filename);
+	rz_io_open_nomap(io, uri, RZ_PERM_R, 0);
+	free(uri);
+
+	ut8 buf[8];
+	bool r = rz_io_read_at(io, 0, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\xff\xff\xff\xff\xff\xff\xff\xff", sizeof(buf), "read");
+	r = rz_io_read_at(io, 0x10100, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\x21\x46\x01\x36\x01\x21\x47\x01", sizeof(buf), "read");
+	r = rz_io_read_at(io, 0x1010e, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\x19\x01\x21\x46\x01\x7e\xb7\xc2", sizeof(buf), "read");
+	r = rz_io_read_at(io, 0x200fe, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\xff\xff\x19\x4e\x79\x23\x46\x23", sizeof(buf), "read");
+
+	rz_io_free(io);
+	rz_file_rm(filename);
+	free(filename);
+	mu_end;
+}
+
+bool test_rz_io_ihex_write(void) {
+	char *filename = create_sample_file("ihex1");
+	char *uri = rz_str_newf("ihex://%s", filename);
+
+	RzIO *io = rz_io_new();
+	io->ff = true;
+	io->Oxff = 0xff;
+	RzIODesc *desc = rz_io_open_nomap(io, uri, RZ_PERM_RW, 0);
+	mu_assert_notnull(desc, "open");
+	eprintf("uri: %s\n", uri);
+
+	// simple write contained entirely within one source chunk
+	bool r = rz_io_write_at(io, 0x10101, (const ut8 *)"Ulu", 3);
+	mu_assert_true(r, "write success");
+	ut8 buf[8];
+	r = rz_io_read_at(io, 0x10100, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\x21Ulu\x01\x21\x47\x01", sizeof(buf), "read");
+
+	// write crossing source chunk boundaries
+	r = rz_io_write_at(io, 0x1010e, (const ut8 *)"Mulu", 4);
+	mu_assert_true(r, "write success");
+	r = rz_io_read_at(io, 0x1010d, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\xd2Mulu\x01\x7e\xb7", sizeof(buf), "read");
+
+	// write beyond source chunk boundaries
+	r = rz_io_write_at(io, 0x1011e, (const ut8 *)"UrShak", 6);
+	mu_assert_true(r, "write success");
+	r = rz_io_read_at(io, 0x1011d, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\x48UrShak\xff", sizeof(buf), "read");
+
+	// write before and into source chunk boundaries
+	r = rz_io_write_at(io, 0x200fe, (const ut8 *)"Tarrok", 6);
+	mu_assert_true(r, "write success");
+	r = rz_io_read_at(io, 0x200fd, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\xffTarrok\x46", sizeof(buf), "read");
+
+	// write outside any chunks
+	r = rz_io_write_at(io, 0x10300, (const ut8 *)"Krushak", 7);
+	mu_assert_true(r, "write success");
+	r = rz_io_read_at(io, 0x102ff, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\xffKrushak", sizeof(buf), "read");
+
+	// write that ends exactly at an extended addr boundary
+	r = rz_io_write_at(io, 0xfff8, (const ut8 *)"01234567", 8);
+	mu_assert_true(r, "write success");
+	r = rz_io_read_at(io, 0xfff8, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"01234567", sizeof(buf), "read");
+
+	// write far out in the open space
+	mu_assert_eq(rz_io_desc_size(desc), 0x20120, "desc size");
+	r = rz_io_write_at(io, 0x40000, (const ut8 *)"Arecibo", 7);
+	mu_assert_true(r, "write success");
+	// writing outside also resizes
+	mu_assert_eq(rz_io_desc_size(desc), 0x40007, "desc size");
+	r = rz_io_read_at(io, 0x3ffff, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\xff"
+					  "Arecibo",
+		sizeof(buf), "read");
+
+	rz_io_free(io);
+
+	// TODO: test this when it works, currently it's producing unsorted garbage with overlaps, even if reloading works
+	char *res = rz_file_slurp(filename, NULL);
+	printf("\nres ===========\n");
+	printf("%s\n", res);
+	printf("===============\n");
+	free(res);
+
+	// reopen and check reads again
+	io = rz_io_new();
+	io->ff = true;
+	io->Oxff = 0xff;
+	rz_io_open_nomap(io, uri, RZ_PERM_R, 0);
+	r = rz_io_read_at(io, 0x10100, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\x21Ulu\x01\x21\x47\x01", sizeof(buf), "read");
+	r = rz_io_read_at(io, 0x1010d, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\xd2Mulu\x01\x7e\xb7", sizeof(buf), "read");
+	r = rz_io_read_at(io, 0x1011d, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\x48UrShak\xff", sizeof(buf), "read");
+	r = rz_io_read_at(io, 0x200fd, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\xffTarrok\x46", sizeof(buf), "read");
+	r = rz_io_read_at(io, 0x102ff, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\xffKrushak", sizeof(buf), "read");
+	r = rz_io_read_at(io, 0xfff8, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"01234567", sizeof(buf), "read");
+	r = rz_io_read_at(io, 0x3ffff, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\xff"
+					  "Arecibo",
+		sizeof(buf), "read");
+	rz_io_free(io);
+
+	rz_file_rm(filename);
+	free(filename);
+	free(uri);
+	mu_end;
+}
+
+bool test_rz_io_ihex_resize_bigger(void) {
+	char *filename = create_sample_file("ihex2");
+	char *uri = rz_str_newf("ihex://%s", filename);
+
+	RzIO *io = rz_io_new();
+	io->ff = true;
+	io->Oxff = 0xff;
+	RzIODesc *desc = rz_io_open_nomap(io, uri, RZ_PERM_RW, 0);
+	eprintf("uri: %s\n", uri);
+	mu_assert_notnull(desc, "open");
+
+	mu_assert_eq(rz_io_desc_size(desc), 0x20120, "desc size");
+	bool r = rz_io_desc_resize(desc, 0x30000);
+	mu_assert_true(r, "resized");
+	mu_assert_eq(rz_io_desc_size(desc), 0x30000, "desc size");
+
+	// Resizing to something bigger will write a single 0xff at the end since the size is
+	// defined as the address after the last populated byte.
+	// This behavior is debatable, but Intel Hex doesn't really have any notion of size so
+	// it can actually make sense.
+
+	// write in new space
+	r = rz_io_write_at(io, 0x21000, (const ut8 *)"HoshPak", 7);
+	mu_assert_true(r, "write success");
+	ut8 buf[8];
+	r = rz_io_read_at(io, 0x20fff, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\xffHoshPak", sizeof(buf), "read");
+
+	rz_io_free(io);
+
+	// TODO: test this when it works, currently it's producing unsorted garbage with overlaps, even if reloading works
+	char *res = rz_file_slurp(filename, NULL);
+	printf("\nres ===========\n");
+	printf("%s\n", res);
+	printf("===============\n");
+	free(res);
+
+	// reopen and check again
+	io = rz_io_new();
+	io->ff = true;
+	io->Oxff = 0xff;
+	desc = rz_io_open_nomap(io, uri, RZ_PERM_R, 0);
+	mu_assert_notnull(desc, "reopen");
+	mu_assert_eq(rz_io_desc_size(desc), 0x30000, "desc size");
+	r = rz_io_read_at(io, 0x20fff, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\xffHoshPak", sizeof(buf), "read");
+	rz_io_free(io);
+
+	rz_file_rm(filename);
+	free(filename);
+	free(uri);
+	mu_end;
+}
+
+bool test_rz_io_ihex_resize_smaller(void) {
+	char *filename = create_sample_file("ihex3");
+	char *uri = rz_str_newf("ihex://%s", filename);
+
+	RzIO *io = rz_io_new();
+	io->ff = true;
+	io->Oxff = 0xff;
+	RzIODesc *desc = rz_io_open_nomap(io, uri, RZ_PERM_RW, 0);
+	eprintf("uri: %s\n", uri);
+	mu_assert_notnull(desc, "open");
+
+	mu_assert_eq(rz_io_desc_size(desc), 0x20120, "desc size");
+	bool r = rz_io_desc_resize(desc, 0x20108);
+	mu_assert_true(r, "resized");
+	mu_assert_eq(rz_io_desc_size(desc), 0x20108, "desc size");
+
+	ut8 buf[8];
+	r = rz_io_read_at(io, 0x20104, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\x46\x23\x96\x57\xff\xff\xff\xff", sizeof(buf), "read");
+
+	rz_io_free(io);
+
+	// TODO: test this when it works, currently it's producing unsorted garbage with overlaps, even if reloading works
+	char *res = rz_file_slurp(filename, NULL);
+	printf("\nres ===========\n");
+	printf("%s\n", res);
+	printf("===============\n");
+	free(res);
+
+	// reopen and check again
+	io = rz_io_new();
+	io->ff = true;
+	io->Oxff = 0xff;
+	desc = rz_io_open_nomap(io, uri, RZ_PERM_R, 0);
+	mu_assert_notnull(desc, "reopen");
+	mu_assert_eq(rz_io_desc_size(desc), 0x20108, "desc size");
+	r = rz_io_read_at(io, 0x20104, buf, sizeof(buf));
+	mu_assert_true(r, "read success");
+	mu_assert_memeq(buf, (const ut8 *)"\x46\x23\x96\x57\xff\xff\xff\xff", sizeof(buf), "read");
+	rz_io_free(io);
+
+	rz_file_rm(filename);
+	free(filename);
+	free(uri);
+	mu_end;
+}
+
+bool all_tests(void) {
+	mu_run_test(test_rz_io_ihex_read);
+	mu_run_test(test_rz_io_ihex_write);
+	mu_run_test(test_rz_io_ihex_resize_bigger);
+	mu_run_test(test_rz_io_ihex_resize_smaller);
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests)


### PR DESCRIPTION
**DO NOT SQUASH**

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This primarily adds tests for ihex and then some simplifications to sparse `RzBuffer`, which ihex is the only user of (soon to be more) so current sparse buffer use-cases are well-tested and we won't get any regressions there.

The tests intentionally still leave exact the outcoming ihex file contents open, because they contain overlaps and are thus somewhat broken. Since I will introduce some major changes to the sparse buffers that will also make fixing this a lot easier, this should be done after that. But as written above, the primary point is not to introduce regressions.

There is also a little fix in here, namely the change from `ut16 addh1 = rbs->to >> 16;` to `ut16 addh1 = (rbs->to - 1) >> 16;`. This prevents a write failure when a chunk ends at exactly an extended address boundary.

**Test plan**

unit tests