### PR TITLE
RzJson: support simple JSON paths

### DIFF
--- a/librz/include/rz_util/rz_json.h
+++ b/librz/include/rz_util/rz_json.h
@@ -61,6 +61,7 @@ RZ_API void rz_json_free(RzJson *js);
 
 RZ_API const RzJson *rz_json_get(const RzJson *json, const char *key); // get object's property by key
 RZ_API const RzJson *rz_json_item(const RzJson *json, size_t idx); // get array element by index
+RZ_API const RzJson *rz_json_get_path(const RzJson *json, const char *path); // reach into an object by (simple) JSON path like [0].methods[1].flags[0]
 
 #ifdef __cplusplus
 }

--- a/librz/util/json_parser.c
+++ b/librz/util/json_parser.c
@@ -442,8 +442,9 @@ RZ_API const RzJson *rz_json_get_path(const RzJson *json, const char *path) {
 		case '.':
 			key = path;
 			for (keysize = 0; key[keysize]; ++keysize) {
-				if (strchr(".[", key[keysize]))
+				if (strchr(".[", key[keysize])) {
 					break;
+				}
 			}
 			if (keysize == 0) {
 				RZ_JSON_REPORT_ERROR("JSON path: expected key", path - 1);

--- a/test/unit/test_json.c
+++ b/test/unit/test_json.c
@@ -967,6 +967,34 @@ static int check_expected_48(RzJson *j) {
 	return MU_PASSED;
 }
 
+static int check_expected_57(RzJson *j) {
+	const RzJson *nonexist = rz_json_get_path(j, "[0].nonexist");
+	mu_assert_null(nonexist, "nonexisting object null");
+
+	// try a few invalid paths
+	mu_assert_null(rz_json_get_path(j, "[].things[0].path"), "invalid path [].things[0].path");
+	mu_assert_null(rz_json_get_path(j, "[0].things[0]."), "invalid path [0].things[0].");
+	mu_assert_null(rz_json_get_path(j, "[0].things[0]."), "invalid path [0].things[0].");
+
+	static const char *paths[] = {
+		"[0].things[0].path",
+		"[0].things[1].path",
+		"[0].things[2].path",
+		"[1].things[0].path",
+		"[1].things[0].child.path",
+		"[1].things[1].path",
+		"[1].things[1].child.path",
+	};
+	for (int i = 1; i < sizeof(paths) / sizeof(paths[0]); i++) {
+		const char *path = paths[i];
+		const RzJson *found = rz_json_get_path(j, path);
+		mu_assert_notnull(found, path);
+		mu_assert_eq(found->type, RZ_JSON_STRING, "type is string");
+		mu_assert_streq(found->str_value, path, "correct object found");
+	}
+	return MU_PASSED;
+}
+
 JsonTest tests[] = {
 	{ // 0
 		"    {\n      \"some-int\": 195,\n      \"array1\": [ 3, 5.1, -7, \"nin"
@@ -1179,7 +1207,24 @@ JsonTest tests[] = {
 		NULL },
 	{ // 56
 		"{\"hello\":42,/*stuff*/,\"invalid\":123}\n",
-		NULL }
+		NULL },
+	{ // 57
+		"["
+		"{\"things\": ["
+		"    {\"path\": \"[0].things[0].path\"},"
+		"    {\"path\": \"[0].things[1].path\"},"
+		"    {\"path\": \"[0].things[2].path\"}"
+		"]},"
+		"{\"things\": ["
+		"    {\"path\": \"[1].things[0].path\","
+		"      \"child\": {\"path\": \"[1].things[0].child.path\"}"
+		"    },"
+		"    {\"path\": \"[1].things[1].path\","
+		"      \"child\": {\"path\": \"[1].things[1].child.path\"}"
+		"    }"
+		"]}"
+		"]",
+		check_expected_57 },
 };
 
 static int test_json(int test_number, char *input, int (*check)(RzJson *j)) {


### PR DESCRIPTION
add rz_json_get_path, which allows querying by paths like `[0].sub.children[0].thing`


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Support simple JSON paths like the one above. Could be extended to support fancy things like `things[*].whatever`, but I don't know if this is needed and what the idiomatic API for this would look like in rizin land.

**Test plan**

Tests were added in `test_json.c`so:
ninja test

**Closing issues**

closes #1108 
