### PR TITLE
libzip.wrap: add fallback url

### DIFF
--- a/subprojects/libzip.wrap
+++ b/subprojects/libzip.wrap
@@ -1,6 +1,7 @@
 [wrap-file]
 directory = libzip-1.7.3
 source_url = https://libzip.org/download/libzip-1.7.3.tar.gz
+source_fallback_url = https://github.com/nih-at/libzip/releases/download/v1.7.3/libzip-1.7.3.tar.gz
 source_filename = libzip-1.7.3.tar.gz
 source_hash = 0e2276c550c5a310d4ebf3a2c3dfc43fb3b4602a072ff625842ad4f3238cb9cc
 patch_directory = libzip-1.7.3


### PR DESCRIPTION
CI fails since libzip.org is down. The same file is available in the github project's releases, so add this URL as a fallback to libzip.wrap