### PR TITLE
Rewrite Sparse RzBuffer for Efficient Reading

### DIFF
--- a/librz/include/rz_vector.h
+++ b/librz/include/rz_vector.h
@@ -101,6 +101,12 @@ RZ_API void *rz_vector_assign_at(RzVector *vec, size_t index, void *elem);
 // It is the caller's responsibility to free potential resources associated with the element.
 RZ_API void rz_vector_remove_at(RzVector *vec, size_t index, void *into);
 
+/**
+ * remove all elements in the given range and write the contents to into (must be appropriately large).
+ * It is the caller's responsibility to free potential resources associated with the elements.
+ */
+RZ_API void rz_vector_remove_range(RzVector *vec, size_t index, size_t count, void *into);
+
 // insert the value of size vec->elem_size at x at the given index.
 // x is a pointer to the actual data to assign!
 RZ_API void *rz_vector_insert(RzVector *vec, size_t index, void *x);

--- a/librz/util/buf.c
+++ b/librz/util/buf.c
@@ -659,10 +659,6 @@ RZ_API RzBuffer *rz_buf_ref(RzBuffer *b) {
 	return b;
 }
 
-RZ_API RzList *rz_buf_nonempty_list(RzBuffer *b) {
-	return b->methods->nonempty_list ? b->methods->nonempty_list(b) : NULL;
-}
-
 RZ_API st64 rz_buf_uleb128(RzBuffer *b, ut64 *v) {
 	ut8 c = 0xff;
 	ut64 s = 0, sum = 0, l = 0;

--- a/librz/util/vector.c
+++ b/librz/util/vector.c
@@ -144,7 +144,7 @@ RZ_API void rz_vector_remove_range(RzVector *vec, size_t index, size_t count, vo
 	}
 	vec->len -= count;
 	if (index < vec->len) {
-		memmove(p, (char *)p + vec->elem_size * count, vec->elem_size * (vec->len - index + count));
+		memmove(p, (char *)p + vec->elem_size * count, vec->elem_size * (vec->len - index));
 	}
 }
 

--- a/librz/util/vector.c
+++ b/librz/util/vector.c
@@ -136,6 +136,18 @@ RZ_API void rz_vector_remove_at(RzVector *vec, size_t index, void *into) {
 	}
 }
 
+RZ_API void rz_vector_remove_range(RzVector *vec, size_t index, size_t count, void *into) {
+	rz_return_if_fail(vec && index + count <= vec->len);
+	void *p = rz_vector_index_ptr(vec, index);
+	if (into) {
+		memcpy(into, p, count * vec->elem_size);
+	}
+	vec->len -= count;
+	if (index < vec->len) {
+		memmove(p, (char *)p + vec->elem_size * count, vec->elem_size * (vec->len - index + count));
+	}
+}
+
 RZ_API void *rz_vector_insert(RzVector *vec, size_t index, void *x) {
 	rz_return_val_if_fail(vec && index <= vec->len, NULL);
 	if (vec->len >= vec->capacity) {

--- a/test/unit/test_io_ihex.c
+++ b/test/unit/test_io_ihex.c
@@ -60,7 +60,6 @@ bool test_rz_io_ihex_write(void) {
 	io->Oxff = 0xff;
 	RzIODesc *desc = rz_io_open_nomap(io, uri, RZ_PERM_RW, 0);
 	mu_assert_notnull(desc, "open");
-	eprintf("uri: %s\n", uri);
 
 	// simple write contained entirely within one source chunk
 	bool r = rz_io_write_at(io, 0x10101, (const ut8 *)"Ulu", 3);
@@ -119,11 +118,23 @@ bool test_rz_io_ihex_write(void) {
 
 	rz_io_free(io);
 
-	// TODO: test this when it works, currently it's producing unsorted garbage with overlaps, even if reloading works
+	const char *file_expect =
+		":08FFF800303132333435363765\n"
+		":020000040001F9\n"
+		":1001000021556c750121470136007efe09d24d75df\n"
+		":100110006c75017eb7c20001ff5f16002148557261\n"
+		":040120005368616B54\n"
+		":070300004B72757368616B1D\n"
+		":020000040002F8\n"
+		":1000fe00546172726f6b4623965778239eda3f01d6\n"
+		":02010E00B2CA73\n"
+		":100110003F0156702B5E712B722B732146013421E7\n"
+		":020000040004F6\n"
+		":070000004172656369626F44\n"
+		":00000001FF\n";
 	char *res = rz_file_slurp(filename, NULL);
-	printf("\nres ===========\n");
-	printf("%s\n", res);
-	printf("===============\n");
+	rz_str_remove_char(res, '\r');
+	mu_assert_streq(res, file_expect, "written ihex file");
 	free(res);
 
 	// reopen and check reads again
@@ -170,7 +181,6 @@ bool test_rz_io_ihex_resize_bigger(void) {
 	io->ff = true;
 	io->Oxff = 0xff;
 	RzIODesc *desc = rz_io_open_nomap(io, uri, RZ_PERM_RW, 0);
-	eprintf("uri: %s\n", uri);
 	mu_assert_notnull(desc, "open");
 
 	mu_assert_eq(rz_io_desc_size(desc), 0x20120, "desc size");
@@ -193,11 +203,19 @@ bool test_rz_io_ihex_resize_bigger(void) {
 
 	rz_io_free(io);
 
-	// TODO: test this when it works, currently it's producing unsorted garbage with overlaps, even if reloading works
+	const char *file_expect =
+		":020000040001F9\n"
+		":10010000214601360121470136007EFE09D2190140\n"
+		":100110002146017EB7C20001FF5F16002148011988\n"
+		":020000040002F8\n"
+		":10010000194E79234623965778239EDA3F01B2CAC7\n"
+		":100110003F0156702B5E712B722B732146013421E7\n"
+		":07100000486F736850616B3B\n"
+		":01FFFF00FF02\n"
+		":00000001FF\n";
 	char *res = rz_file_slurp(filename, NULL);
-	printf("\nres ===========\n");
-	printf("%s\n", res);
-	printf("===============\n");
+	rz_str_remove_char(res, '\r');
+	mu_assert_streq(res, file_expect, "written ihex file");
 	free(res);
 
 	// reopen and check again
@@ -226,7 +244,6 @@ bool test_rz_io_ihex_resize_smaller(void) {
 	io->ff = true;
 	io->Oxff = 0xff;
 	RzIODesc *desc = rz_io_open_nomap(io, uri, RZ_PERM_RW, 0);
-	eprintf("uri: %s\n", uri);
 	mu_assert_notnull(desc, "open");
 
 	mu_assert_eq(rz_io_desc_size(desc), 0x20120, "desc size");
@@ -241,11 +258,16 @@ bool test_rz_io_ihex_resize_smaller(void) {
 
 	rz_io_free(io);
 
-	// TODO: test this when it works, currently it's producing unsorted garbage with overlaps, even if reloading works
+	const char *file_expect =
+		":020000040001F9\n"
+		":10010000214601360121470136007EFE09D2190140\n"
+		":100110002146017EB7C20001FF5F16002148011988\n"
+		":020000040002F8\n"
+		":08010000194E7923462396579E\n"
+		":00000001FF\n";
 	char *res = rz_file_slurp(filename, NULL);
-	printf("\nres ===========\n");
-	printf("%s\n", res);
-	printf("===============\n");
+	rz_str_remove_char(res, '\r');
+	mu_assert_streq(res, file_expect, "written ihex file");
 	free(res);
 
 	// reopen and check again

--- a/test/unit/test_vector.c
+++ b/test/unit/test_vector.c
@@ -247,6 +247,31 @@ static bool test_vector_remove_at(void) {
 	mu_end;
 }
 
+static bool test_vector_remove_range(void) {
+	RzVector v;
+	init_test_vector(&v, 5, 0, NULL, NULL);
+
+	ut32 e[3];
+	rz_vector_remove_range(&v, 2, 2, e);
+	mu_assert_eq(e[0], 2, "rz_vector_remove_at => into");
+	mu_assert_eq(e[1], 3, "rz_vector_remove_at => into");
+	mu_assert_eq(v.len, 3UL, "rz_vector_remove_at => len");
+
+	mu_assert_eq(((ut32 *)v.a)[0], 0, "rz_vector_remove_at => remaining elements");
+	mu_assert_eq(((ut32 *)v.a)[1], 1, "rz_vector_remove_at => remaining elements");
+	mu_assert_eq(((ut32 *)v.a)[2], 4, "rz_vector_remove_at => remaining elements");
+
+	rz_vector_remove_range(&v, 0, 3, e);
+	mu_assert_eq(e[0], 0, "rz_vector_remove_at (end) => into");
+	mu_assert_eq(e[1], 1, "rz_vector_remove_at (end) => into");
+	mu_assert_eq(e[2], 4, "rz_vector_remove_at (end) => into");
+	mu_assert_eq(v.len, 0UL, "rz_vector_remove_at (end) => len");
+
+	rz_vector_fini(&v);
+
+	mu_end;
+}
+
 static bool test_vector_insert(void) {
 	RzVector v;
 
@@ -1212,6 +1237,7 @@ static int all_tests(void) {
 	mu_run_test(test_vector_clone);
 	mu_run_test(test_vector_empty);
 	mu_run_test(test_vector_remove_at);
+	mu_run_test(test_vector_remove_range);
 	mu_run_test(test_vector_insert);
 	mu_run_test(test_vector_insert_range);
 	mu_run_test(test_vector_pop);

--- a/test/unit/test_vector.c
+++ b/test/unit/test_vector.c
@@ -649,7 +649,7 @@ static bool test_vector_foreach(void) {
 	mu_end;
 }
 
-static bool test_vector_lower_bound(void) {
+static bool test_vector_bounds(void) {
 	RzVector v;
 	rz_vector_init(&v, sizeof(st64), NULL, NULL);
 	st64 a[] = { 0, 2, 4, 6, 8 };
@@ -659,14 +659,33 @@ static bool test_vector_lower_bound(void) {
 #define CMP(x, y) x - (*(st64 *)y)
 	rz_vector_lower_bound(&v, 3, l, CMP);
 	mu_assert_eq(l, 2, "lower_bound");
+	rz_vector_upper_bound(&v, 3, l, CMP);
+	mu_assert_eq(l, 2, "upper_bound");
+
+	rz_vector_lower_bound(&v, 4, l, CMP);
+	mu_assert_eq(l, 2, "lower_bound");
+	rz_vector_upper_bound(&v, 4, l, CMP);
+	mu_assert_eq(l, 3, "upper_bound");
+
 	rz_vector_lower_bound(&v, -1, l, CMP);
 	mu_assert_eq(l, 0, "lower_bound");
+	rz_vector_upper_bound(&v, -1, l, CMP);
+	mu_assert_eq(l, 0, "upper_bound");
+
 	rz_vector_lower_bound(&v, 0, l, CMP);
 	mu_assert_eq(l, 0, "lower_bound");
+	rz_vector_upper_bound(&v, 0, l, CMP);
+	mu_assert_eq(l, 1, "upper_bound");
+
 	rz_vector_lower_bound(&v, 2, l, CMP);
 	mu_assert_eq(l, 1, "lower_bound");
+	rz_vector_upper_bound(&v, 2, l, CMP);
+	mu_assert_eq(l, 2, "upper_bound");
+
 	rz_vector_lower_bound(&v, 42, l, CMP);
 	mu_assert_eq(l, 5, "lower_bound");
+	rz_vector_upper_bound(&v, 42, l, CMP);
+	mu_assert_eq(l, 5, "upper_bound");
 #undef CMP
 	rz_vector_clear(&v);
 	mu_end;
@@ -1203,7 +1222,7 @@ static int all_tests(void) {
 	mu_run_test(test_vector_shrink);
 	mu_run_test(test_vector_flush);
 	mu_run_test(test_vector_foreach);
-	mu_run_test(test_vector_lower_bound);
+	mu_run_test(test_vector_bounds);
 
 	mu_run_test(test_pvector_init);
 	mu_run_test(test_pvector_new);


### PR DESCRIPTION
 **DO NOT SQUASH**

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The Sparse RzBuffer, until now only used in ihex, will be used for relocs patching. Before this, it was an unordered linked list of data chunks, so reading from it would require linearly iterating through them and finding the right chunk, which is of course quite bad for performance. Moreover, these chunks could overlap in some cases, causing weird results in ihex.

The new implementation is a sorted flat vector of chunks that never overlap and as soon as two chunks would touch, they will be merged. That means read access is O(log n) with very few indirection. Writing is more expensive if writes happen in the middle because the new chunk has to be inserted in between.
An alternative would have been to use an `RBTree` but I think memory efficiency and read performance is more important here.

This also fixes a small bug regarding writing data spanning more than 2 16bit pages in ihex. This bug was present before too but only harder to hit because chunks were never merged.

**Test plan**

unit tests. There are tests for the sparse buf, including fuzzing ones and for ihex.