### PR TITLE
New RzJson to string API

### DIFF
--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -3451,25 +3451,8 @@ RZ_API RzTable *rz_core_table(RzCore *core) {
 /* Config helper function for PJ json encodings */
 RZ_API PJ *rz_core_pj_new(RzCore *core) {
 	const char *config_string_encoding = rz_config_get(core->config, "cfg.json.str");
-	const char *config_num_encoding = rz_config_get(core->config, "cfg.json.num");
-	PJEncodingNum number_encoding = PJ_ENCODING_NUM_DEFAULT;
-	PJEncodingStr string_encoding = PJ_ENCODING_STR_DEFAULT;
-
-	if (!strcmp("string", config_num_encoding)) {
-		number_encoding = PJ_ENCODING_NUM_STR;
-	} else if (!strcmp("hex", config_num_encoding)) {
-		number_encoding = PJ_ENCODING_NUM_HEX;
-	}
-
-	if (!strcmp("base64", config_string_encoding)) {
-		string_encoding = PJ_ENCODING_STR_BASE64;
-	} else if (!strcmp("hex", config_string_encoding)) {
-		string_encoding = PJ_ENCODING_STR_HEX;
-	} else if (!strcmp("array", config_string_encoding)) {
-		string_encoding = PJ_ENCODING_STR_ARRAY;
-	} else if (!strcmp("strip", config_string_encoding)) {
-		string_encoding = PJ_ENCODING_STR_STRIP;
-	}
-
+	const char *config_number_encoding = rz_config_get(core->config, "cfg.json.num");
+	PJEncodingStr string_encoding = pj_encoding_str_of_string(config_string_encoding);
+	PJEncodingNum number_encoding = pj_encoding_num_of_string(config_number_encoding);
 	return pj_new_with_encoding(string_encoding, number_encoding);
 }

--- a/librz/include/rz_util/pj.h
+++ b/librz/include/rz_util/pj.h
@@ -33,6 +33,10 @@ typedef struct pj_t {
 	PJEncodingNum num_encoding;
 } PJ;
 
+/* encoding */
+RZ_API PJEncodingStr pj_encoding_str_of_string(RZ_NONNULL const char *encoding);
+RZ_API PJEncodingNum pj_encoding_num_of_string(RZ_NONNULL const char *encoding);
+
 /* lifecycle */
 RZ_API PJ *pj_new(void);
 RZ_API PJ *pj_new_with_encoding(PJEncodingStr str_encoding, PJEncodingNum num_encoding);

--- a/librz/include/rz_util/rz_json.h
+++ b/librz/include/rz_util/rz_json.h
@@ -6,6 +6,7 @@
 #define RZ_JSON_H
 
 #include <rz_types.h>
+#include <rz_util/pj.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -62,6 +63,8 @@ RZ_API void rz_json_free(RzJson *js);
 RZ_API const RzJson *rz_json_get(const RzJson *json, const char *key); // get object's property by key
 RZ_API const RzJson *rz_json_item(const RzJson *json, size_t idx); // get array element by index
 RZ_API const RzJson *rz_json_get_path(const RzJson *json, const char *path); // reach into an object by (simple) JSON path like [0].methods[1].flags[0]
+RZ_API RZ_OWN char *rz_json_as_string(const RzJson *json); // shows the string representation of RzJson
+RZ_API RZ_OWN char *rz_json_as_string_with_encoding(const RzJson *json, PJEncodingStr str_encoding, PJEncodingNum num_encoding); // shows the string representation of RzJson with specified encoding
 
 #ifdef __cplusplus
 }

--- a/librz/util/json_parser.c
+++ b/librz/util/json_parser.c
@@ -7,6 +7,8 @@
 #include <rz_util/rz_utf8.h>
 #include <rz_util/rz_hex.h>
 #include <rz_util/rz_json.h>
+#include <rz_util/rz_assert.h>
+#include <rz_util/pj.h>
 
 #if 0
 // optional error printing
@@ -463,4 +465,108 @@ RZ_API const RzJson *rz_json_get_path(const RzJson *json, const char *path) {
 	}
 	// js == json means we've not done any access at all
 	return (js == json) ? NULL : js;
+}
+
+static void json_pj_recurse(const RzJson *json, PJ *pj) {
+	rz_return_if_fail(json && pj);
+	switch (json->type) {
+	case RZ_JSON_NULL: {
+		if (json->key) {
+			pj_knull(pj, json->key);
+		} else {
+			pj_null(pj);
+		}
+		break;
+	}
+	case RZ_JSON_OBJECT: {
+		if (json->key) {
+			pj_ko(pj, json->key);
+		} else {
+			pj_o(pj);
+		}
+		RzJson *baby;
+		for (baby = json->children.first; baby; baby = baby->next) {
+			json_pj_recurse(baby, pj);
+		}
+		pj_end(pj);
+		break;
+	}
+	case RZ_JSON_ARRAY: {
+		if (json->key) {
+			pj_ka(pj, json->key);
+		} else {
+			pj_a(pj);
+		}
+		RzJson *baby;
+		for (baby = json->children.first; baby; baby = baby->next) {
+			json_pj_recurse(baby, pj);
+		}
+		pj_end(pj);
+		break;
+	}
+	case RZ_JSON_STRING: {
+		if (json->key) {
+			pj_ks(pj, json->key, json->str_value);
+		} else {
+			pj_s(pj, json->str_value);
+		}
+		break;
+	}
+	case RZ_JSON_INTEGER: {
+		if (json->key) {
+			pj_ki(pj, json->key, json->num.u_value);
+		} else {
+			pj_i(pj, json->num.u_value);
+		}
+		break;
+	}
+	case RZ_JSON_DOUBLE: {
+		if (json->key) {
+			pj_kd(pj, json->key, json->num.dbl_value);
+		} else {
+			pj_d(pj, json->num.dbl_value);
+		}
+		break;
+	}
+	case RZ_JSON_BOOLEAN: {
+		if (json->key) {
+			pj_kb(pj, json->key, (bool)json->num.u_value);
+		} else {
+			pj_b(pj, (bool)json->num.u_value);
+		}
+	}
+	}
+}
+
+static void json_pj_handler(const RzJson *json, PJ *pj) {
+	if (json->type == RZ_JSON_OBJECT) {
+		pj_o(pj);
+	} else if (json->type == RZ_JSON_ARRAY) {
+		pj_a(pj);
+	}
+	RzJson *js;
+	for (js = json->children.first; js; js = js->next) {
+		json_pj_recurse(js, pj);
+	}
+	if (json->type == RZ_JSON_OBJECT || json->type == RZ_JSON_ARRAY) {
+		pj_end(pj);
+	}
+}
+
+RZ_API RZ_OWN char *rz_json_as_string(const RzJson *json) {
+	rz_return_val_if_fail(json, NULL);
+	rz_return_val_if_fail(json->type != RZ_JSON_NULL, NULL);
+	PJ *pj = pj_new();
+	json_pj_handler(json, pj);
+	char *str = pj_drain(pj);
+	return str;
+}
+
+RZ_API RZ_OWN char *rz_json_as_string_with_encoding(const RzJson *json, PJEncodingStr str_encoding, PJEncodingNum num_encoding) {
+	rz_return_val_if_fail(json, NULL);
+	rz_return_val_if_fail(json->type != RZ_JSON_NULL, NULL);
+	PJ *pj = pj_new_with_encoding(str_encoding, num_encoding);
+	json_pj_handler(json, pj);
+	char *str = pj_drain(pj);
+	return str;
 }

--- a/librz/util/pj.c
+++ b/librz/util/pj.c
@@ -22,6 +22,32 @@ static void pj_comma(PJ *j) {
 	j->is_key = false;
 }
 
+RZ_API PJEncodingStr pj_encoding_str_of_string(RZ_NONNULL const char *encoding) {
+	rz_return_val_if_fail(encoding, PJ_ENCODING_STR_DEFAULT);
+	PJEncodingStr string_encoding = PJ_ENCODING_STR_DEFAULT;
+	if (!strcmp("base64", encoding)) {
+		string_encoding = PJ_ENCODING_STR_BASE64;
+	} else if (!strcmp("hex", encoding)) {
+		string_encoding = PJ_ENCODING_STR_HEX;
+	} else if (!strcmp("array", encoding)) {
+		string_encoding = PJ_ENCODING_STR_ARRAY;
+	} else if (!strcmp("strip", encoding)) {
+		string_encoding = PJ_ENCODING_STR_STRIP;
+	}
+	return string_encoding;
+}
+
+RZ_API PJEncodingNum pj_encoding_num_of_string(RZ_NONNULL const char *encoding) {
+	rz_return_val_if_fail(encoding, PJ_ENCODING_NUM_DEFAULT);
+	PJEncodingNum number_encoding = PJ_ENCODING_NUM_DEFAULT;
+	if (!strcmp("string", encoding)) {
+		number_encoding = PJ_ENCODING_NUM_STR;
+	} else if (!strcmp("hex", encoding)) {
+		number_encoding = PJ_ENCODING_NUM_HEX;
+	}
+	return number_encoding;
+}
+
 RZ_API PJ *pj_new(void) {
 	PJ *j = RZ_NEW0(PJ);
 	if (j) {

--- a/test/unit/test_json.c
+++ b/test/unit/test_json.c
@@ -995,6 +995,20 @@ static int check_expected_57(RzJson *j) {
 	return MU_PASSED;
 }
 
+static int check_expected_58(RzJson *j) {
+	char *json_str =
+		"{\"some-int\":195,\"array1\":[3,5.100000,-7,\"nine\",true,false,\"last\"],"
+		"\"array2\":[\"/*\",\"*/\"],\"some-bool\":true,\"other-bool\":false,"
+		"\"some-dbl\":-0.000100,\"some-null\":null,\"hello\":\"world!\","
+		"\"str1\":\"//\",\"str2\":\"\\\\\","
+		"\"str3\":\"text /*text*/ text\",\"str4\":\"\\\\text\\\\\","
+		"\"str5\":\"\\\\?text\\\\?\",\"str\\t6\\\\\":\"text\\ntext\\ttext\","
+		"\"obj\":{\"KEY\":\"VAL\",\"obj\":{\"KEY\":\"VAL\"}}}";
+	char *jsonstr = rz_json_as_string(j);
+	mu_assert_streq(jsonstr, json_str, "RzJson as string");
+	return MU_PASSED;
+}
+
 JsonTest tests[] = {
 	{ // 0
 		"    {\n      \"some-int\": 195,\n      \"array1\": [ 3, 5.1, -7, \"nin"
@@ -1225,6 +1239,18 @@ JsonTest tests[] = {
 		"]}"
 		"]",
 		check_expected_57 },
+	{ // 58
+		"    {\n      \"some-int\": 195,\n      \"array1\": [ 3, 5.1, -7, \"nin"
+		"e\", /*11,*/ true, false, \"last\" ],\n      \"array2\":[\"/*\",\"*/\""
+		"],\n      \"some-bool\": true,\n      \"other-bool\": false,\n      \""
+		"some-dbl\": -1e-4,\n      \"some-null\": null,\n      \"hello\": \"wor"
+		"ld!\",\n      \"str1\": \"//\",\n      \"str2\": \"\\\\\",\n      \"st"
+		"r3\": \"text /*text*/ text\",\n      \"str4\": \"\\\\text\\\\\",\n    "
+		"  \"str5\": \"\\?text\\?\",\n      \"str\\t6\\\\\": \"text\\ntext\\tte"
+		"xt\",\n      //\"other\":"
+		" \"/OTHER/\",\n      \"obj\": {\"KEY\":\"VAL\", \"obj\":{\"KEY\":\"VAL"
+		"\"}}\n    }\n",
+		check_expected_58 },
 };
 
 static int test_json(int test_number, char *input, int (*check)(RzJson *j)) {


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

An extract from https://github.com/rizinorg/rizin/pull/1118

- Added a new API `RZ_API RZ_OWN char *rz_json_as_string(const RzJson *json);` to convert `RzJson` to `char *` using the PJ API
- Added a new API `RZ_API RZ_OWN char *rz_json_as_string_with_encoding(const RzJson *json, PJEncodingStr str_encoding, PJEncodingNum num_encoding);` to convert `RzJson` to `char *` using the PJ API with encoding

By the way, note, that we might also need to cleanup/refactor the `librz/util/json_indent.c` in the future.

**Test plan**

CI is green
