### PR TITLE
Introduce `rz_core_gadget_print()` API to print visual gadgets

### DIFF
--- a/librz/core/cmd_print.c
+++ b/librz/core/cmd_print.c
@@ -1426,11 +1426,22 @@ static void cmd_print_fromage(RzCore *core, const char *input, const ut8 *data, 
 	}
 }
 
+/**
+ * \brief Frees a visual print gadget
+ *
+ * \param g reference to RzCoreGadget
+ */
 RZ_API void rz_core_gadget_free(RzCoreGadget *g) {
 	free(g->cmd);
 	free(g);
 }
 
+/**
+ * \brief Prints or displays the print gadgets while in
+ * visual mode
+ *
+ * \param core reference to RzCore
+ */
 RZ_API void rz_core_gadget_print(RzCore *core) {
 	RzCoreGadget *g;
 	RzListIter *iter;

--- a/librz/core/cmd_print.c
+++ b/librz/core/cmd_print.c
@@ -1431,6 +1431,18 @@ RZ_API void rz_core_gadget_free(RzCoreGadget *g) {
 	free(g);
 }
 
+RZ_API void rz_core_gadget_print(RzCore *core) {
+	RzCoreGadget *g;
+	RzListIter *iter;
+	rz_list_foreach (core->gadgets, iter, g) {
+		char *res = rz_core_cmd_str(core, g->cmd);
+		if (res) {
+			rz_cons_strcat_at(res, g->x, g->y, g->w, g->h);
+			free(res);
+		}
+	}
+}
+
 static const char *help_msg_pg[] = {
 	"Usage: pg[-]", "[asm|hex]", "print (dis)assembled",
 	"pg", " [x y w h cmd]", "add a new gadget",
@@ -1509,15 +1521,7 @@ static void cmd_print_gadget(RzCore *core, const char *_input) {
 		rz_list_free(args);
 		free(input);
 	} else if (!*_input) { // "pg"
-		RzCoreGadget *g;
-		RzListIter *iter;
-		rz_list_foreach (core->gadgets, iter, g) {
-			char *res = rz_core_cmd_str(core, g->cmd);
-			if (res) {
-				rz_cons_strcat_at(res, g->x, g->y, g->w, g->h);
-				free(res);
-			}
-		}
+		rz_core_gadget_print(core);
 	} else {
 		rz_core_cmd_help(core, help_msg_pg);
 	}

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -2809,7 +2809,7 @@ RZ_API int rz_core_prompt(RzCore *r, int sync) {
 	free(r->cmdqueue);
 	r->cmdqueue = strdup(line);
 	if (r->scr_gadgets && *line && *line != 'q') {
-		rz_core_cmd0(r, "pg");
+		rz_core_gadget_print(r);
 	}
 	r->num->value = r->rc;
 	return true;

--- a/librz/core/panels.c
+++ b/librz/core/panels.c
@@ -4749,7 +4749,7 @@ void __panels_refresh(RzCore *core) {
 	}
 	rz_cons_canvas_print(can);
 	if (core->scr_gadgets) {
-		rz_core_cmd0(core, "pg");
+		rz_core_gadget_print(core);
 	}
 	rz_cons_flush();
 	if (rz_cons_singleton()->fps) {

--- a/librz/core/visual.c
+++ b/librz/core/visual.c
@@ -3858,7 +3858,7 @@ static void visual_refresh(RzCore *core) {
 		rz_cons_reset();
 	}
 	if (core->scr_gadgets) {
-		rz_core_cmd0(core, "pg");
+		rz_core_gadget_print(core);
 		rz_cons_flush();
 	}
 	core->cons->blankline = false;

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -396,6 +396,9 @@ typedef int (*RzCoreSearchCallback)(RzCore *core, ut64 from, ut8 *buf, int len);
 #ifdef RZ_API
 RZ_API int rz_core_bind(RzCore *core, RzCoreBind *bnd);
 
+/**
+ * \brief APIs to handle Visual Gadgets
+ */
 RZ_API void rz_core_gadget_free(RzCoreGadget *g);
 RZ_API void rz_core_gadget_print(RzCore *core);
 

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -397,6 +397,7 @@ typedef int (*RzCoreSearchCallback)(RzCore *core, ut64 from, ut8 *buf, int len);
 RZ_API int rz_core_bind(RzCore *core, RzCoreBind *bnd);
 
 RZ_API void rz_core_gadget_free(RzCoreGadget *g);
+RZ_API void rz_core_gadget_print(RzCore *core);
 
 RZ_API bool rz_core_plugin_init(RzCore *core);
 RZ_API bool rz_core_plugin_add(RzCore *core, RzCorePlugin *plugin);

--- a/test/db/cmd/cmd_visual
+++ b/test/db/cmd/cmd_visual
@@ -103,3 +103,25 @@ EXPECT=<<EOF
 0x00005b70  ffe0 660f 1f44 0000 c30f 1f80 0000 0000  ..f..D..........           [?25h[0m[2J[0;0H
 EOF
 RUN
+
+NAME=pg command print gadgets
+FILE=bins/elf/ls
+CMDS=<<EOF
+pg 6 6 35 35 il
+e scr.gadgets=1
+e scr.interactive=true
+e scr.columns=10
+e scr.rows=1
+< q; V
+?e
+EOF
+EXPECT=<<EOF
+[?25l[0;0H[0m[0x00005ae[0J[0m[s[6;0H[Link[7;0Hlibcap.[0m
+[8;0Hlibc.so[0m
+[9;0H[0m
+[10;0H2 libra[0m
+[11;0H[0m
+[12;0H[Linked[0m
+[0m[u[?25h[0m[2J[0;0H
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Introduced `rz_core_gadget_print()` for the command `pg` which displays the gadgets on the screen and used it everywhere `rz_core_cmd` call to `pg` was called. 

**Test plan**

Added a test at `test/db/cmd/cmd_visual`. Here's a screenshot of `pg 10 10 10 10 ddr` in action.
![Screenshot_2021-05-12_00-03-27](https://user-images.githubusercontent.com/29057155/117868067-c55e0f80-b2b6-11eb-97a7-0a5bd484f856.png)


**Closing issues**

Related to #382 
