### PR TITLE
Add Overlay Functionality to Sparse RzBuffer

### DIFF
--- a/librz/util/buf.c
+++ b/librz/util/buf.c
@@ -178,12 +178,23 @@ RZ_API RzBuffer *rz_buf_new_with_buf(RzBuffer *b) {
 	return rz_buf_new_with_bytes(tmp, sz);
 }
 
+/// create a new sparse RzBuffer where unpopulated bytes are filled with Oxff
 RZ_API RzBuffer *rz_buf_new_sparse(ut8 Oxff) {
 	RzBuffer *b = new_buffer(RZ_BUFFER_SPARSE, NULL);
 	if (b) {
 		b->Oxff_priv = Oxff;
 	}
 	return b;
+}
+
+/// create a new sparse RzBuffer where unpopulated bytes are taken as-is from b
+RZ_API RzBuffer *rz_buf_new_sparse_overlay(RzBuffer *b, RzBufferSparseWriteMode write_mode) {
+	rz_return_val_if_fail(b, NULL);
+	SparseInitConfig cfg = {
+		.base = b,
+		.write_mode = write_mode
+	};
+	return new_buffer(RZ_BUFFER_SPARSE, &cfg);
 }
 
 RZ_API RzBuffer *rz_buf_new(void) {
@@ -267,6 +278,12 @@ RZ_API bool rz_buf_set_bytes(RzBuffer *b, const ut8 *buf, ut64 length) {
 		return false;
 	}
 	return rz_buf_seek(b, 0, RZ_BUF_SET) >= 0;
+}
+
+/// Set the content that bytes read outside the buffer bounds should have
+RZ_API void rz_buf_set_overflow_byte(RzBuffer *b, ut8 Oxff) {
+	rz_return_if_fail(b);
+	b->Oxff_priv = Oxff;
 }
 
 RZ_API bool rz_buf_prepend_bytes(RzBuffer *b, const ut8 *buf, ut64 length) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

In addition to a sparse buffer on top of 0xff bytes, you can now have a sparse overlay on top of another buffer:
```diff
  RZ_API RzBuffer *rz_buf_new_sparse(ut8 Oxff);
+ RZ_API RzBuffer *rz_buf_new_sparse_overlay(RzBuffer *b, RzBufferSparseWriteMode write_mode);
```

The write mode determines whether, in a write, you want to write into the sparse buffer or through the sparse buffer into the base buffer.

This will be used for reloc patching, it will just be a sparse buffer on top of the io-based buffer with relocs written into the sparse overlay part in `RZ_BUF_SPARSE_WRITE_MODE_SPARSE` once, then it will be switched to `RZ_BUF_SPARSE_WRITE_MODE_THROUGH` so one can still write into the binary.

**Test plan**

unit tests