### PR TITLE
Mark the test for `pg` as broken ##test

### DIFF
--- a/test/db/cmd/cmd_visual
+++ b/test/db/cmd/cmd_visual
@@ -106,6 +106,7 @@ RUN
 
 NAME=pg command print gadgets
 FILE=bins/elf/ls
+BROKEN=1
 CMDS=<<EOF
 pg 6 6 35 35 il
 e scr.gadgets=1


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Mark the test for `pg` (print visual gadgets) as broken for now, as the test failed the Appveyor's Windows CI.

**Test plan**

...

**Closing issues**

None
