### PR TITLE
Fix #1137 - avoid use after free

### DIFF
--- a/librz/bin/format/pyc/marshal.c
+++ b/librz/bin/format/pyc/marshal.c
@@ -1170,6 +1170,7 @@ static bool extract_sections_symbols(pyc_object *obj, RzList *sections, RzList *
 	if (!rz_list_append(sections, section)) {
 		goto fail;
 	}
+	section = NULL;
 	// start building symbol
 	symbol->name = strdup(prefix);
 	//symbol->bind;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`section` gets added to the list but then the `goto fail` is taken later, which frees the memory, thus use after free.
