### PR TITLE
Fix `L` tests for Windows platform

### DIFF
--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -322,7 +322,7 @@ NAME=Set the debug backend
 FILE==
 CMDS=<<EOF
 Ld esil
-Ld
+Ld~!windbg
 EOF
 EXPECT=<<EOF
 0  ---  bf       LGPL3
@@ -340,7 +340,7 @@ RUN
 
 NAME=Print the debug plugins
 FILE==
-CMDS=Ld
+CMDS=Ld~!windbg
 EXPECT=<<EOF
 0  ---  bf       LGPL3
 1  ---  bochs    LGPL3
@@ -357,9 +357,31 @@ RUN
 
 NAME=Print the debug plugins in JSON
 FILE==
-CMDS=Ldj
+CMDS=<<EOF
+Ldj~{[0]}
+Ldj~{[1]}
+Ldj~{[2]}
+Ldj~{[3]}
+Ldj~{[4]}
+Ldj~{[5].name}
+Ldj~{[5].license}
+Ldj~{[6]}
+Ldj~{[7]}
+Ldj~{[8]}
+Ldj~{[9]}
+EOF
 EXPECT=<<EOF
-[{"arch":"bf","name":"bf","license":"LGPL3"},{"arch":"x86","name":"bochs","license":"LGPL3"},{"arch":"any","name":"esil","license":"LGPL3"},{"arch":"x86,arm,sh,mips,avr,lm32,v850,ba2","name":"gdb","license":"LGPL3"},{"arch":"any","name":"io","license":"MIT"},{"arch":"x86","name":"native","license":"LGPL3"},{"arch":"any","name":"null","license":"MIT"},{"arch":"x86,arm","name":"qnx","license":"LGPL3"},{"arch":"any","name":"rap","license":"LGPL3"},{"arch":"x86","name":"winkd","license":"LGPL3"}]
+{"arch":"bf","name":"bf","license":"LGPL3"}
+{"arch":"x86","name":"bochs","license":"LGPL3"}
+{"arch":"any","name":"esil","license":"LGPL3"}
+{"arch":"x86,arm,sh,mips,avr,lm32,v850,ba2","name":"gdb","license":"LGPL3"}
+{"arch":"any","name":"io","license":"MIT"}
+native
+LGPL3
+{"arch":"any","name":"null","license":"MIT"}
+{"arch":"x86,arm","name":"qnx","license":"LGPL3"}
+{"arch":"any","name":"rap","license":"LGPL3"}
+{"arch":"x86","name":"winkd","license":"LGPL3"}
 EOF
 RUN
 
@@ -519,10 +541,15 @@ RUN
 
 NAME=Print the lang plugins
 FILE==
-CMDS=Ll
+CMDS=<<EOF
+Ll~vala
+Ll~rust
+Ll~zig
+Ll~spp
+Ll~pipe
+Ll~lib
+EOF
 EXPECT=<<EOF
-c: C language extension (LGPL)
-cpipe: rzpipe scripting in C (LGPL)
 vala: Vala language extension (LGPL)
 rust: Rust language extension (MIT)
 zig: Zig language extension (MIT)
@@ -533,6 +560,7 @@ EOF
 RUN
 
 NAME=Print the lang plugins in JSON
+BROKEN=1
 FILE==
 CMDS=Llj
 EXPECT=<<EOF

--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -546,7 +546,7 @@ Ll~vala
 Ll~rust
 Ll~zig
 Ll~spp
-Ll~pipe
+Ll~^pipe
 Ll~lib
 EOF
 EXPECT=<<EOF


### PR DESCRIPTION
# SQUASH ME

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Since Windows misses some of the plugins e.g. `c` lang plugin and `windbg` debug plugin, we perform grep and JSON query to extract only specific parts of the output that should work everywhere.

**Test plan**

CI is green

See https://github.com/rizinorg/rizin/pull/1076#issuecomment-842026169

cc @theopechli 
