### PR TITLE
Add extern "C" to rz_assert.h

### DIFF
--- a/librz/include/rz_util/rz_assert.h
+++ b/librz/include/rz_util/rz_assert.h
@@ -3,6 +3,10 @@
 
 #include "rz_log.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define RZ_STATIC_ASSERT(x) \
 	switch (0) { \
 	case 0: \
@@ -143,5 +147,9 @@ RZ_API void rz_assert_log(RLogLevel level, const char *fmt, ...) RZ_PRINTF_CHECK
 	} while (0)
 
 #endif // RZ_CHECKS_LEVEL
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Otherwise C++ projects fail:
```
Undefined symbols for architecture arm64:
  "rz_assert_log(rz_log_level, char const*, ...)", referenced from:
      rz_vector_empty(rz_vector_t const*) in RizinLoadImage.cpp.o
      rz_vector_empty(rz_vector_t const*) in RizinTypeFactory.cpp.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```