### PR TITLE
Fix grep cmd when used with neg and begin `~!^`

### DIFF
--- a/librz/cons/grep.c
+++ b/librz/cons/grep.c
@@ -759,6 +759,9 @@ RZ_API int rz_cons_grep_line(char *buf, int len) {
 			}
 			if (grep->begin) {
 				hit = (p == in);
+				if (grep->neg) {
+					hit = !hit;
+				}
 			} else {
 				hit = !grep->neg;
 			}

--- a/test/db/cmd/feat_grep
+++ b/test/db/cmd/feat_grep
@@ -67,6 +67,20 @@ size     0x400
 EOF
 RUN
 
+NAME=grep neg begin
+FILE=malloc://1024
+CMDS=i~!^size
+EXPECT=<<EOF
+fd       3
+file     malloc://1024
+humansz  1K
+mode     rwx
+format   any
+iorw     true
+block    0x100
+EOF
+RUN
+
 NAME=grep end
 FILE=malloc://1024
 CMDS=i~0x400$


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This PR fixes grep when used with neg and begin.

```shell
[0x00000000]> Ll
c: C language extension (LGPL)
cpipe: rzpipe scripting in C (LGPL)
vala: Vala language extension (LGPL)
rust: Rust language extension (MIT)
zig: Zig language extension (MIT)
spp: SPP template programs (MIT)
pipe: Use #!pipe node script.js (LGPL)
lib: Load libs directly into rizin (LGPL)
[0x00000000]> Ll~^c
c: C language extension (LGPL)
cpipe: rzpipe scripting in C (LGPL)
[0x00000000]> Ll~!^c
vala: Vala language extension (LGPL)
rust: Rust language extension (MIT)
zig: Zig language extension (MIT)
spp: SPP template programs (MIT)
pipe: Use #!pipe node script.js (LGPL)
lib: Load libs directly into rizin (LGPL)
[0x00000000]>
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #1140
