### PR TITLE
Fix #1145 - when no operation is defined, use sha256

### DIFF
--- a/librz/main/rz-hash.c
+++ b/librz/main/rz-hash.c
@@ -367,6 +367,11 @@ static void rz_hash_parse_cmdline(int argc, const char **argv, RzHashContext *ct
 		return;
 	}
 
+	if (!ctx->algorithm) {
+		rz_hash_ctx_set_str(ctx, algorithm, "sha256");
+		rz_hash_ctx_set_op(ctx, RZ_HASH_OP_HASH);
+	}
+
 	if (!ctx->input && !strcmp(argv[argc - 1], "-")) {
 		ctx->use_stdin = true;
 	} else {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

I forgot to set the default operation as sha256 when i rewrote rz-hash