### PR TITLE
Fix for `dmha` command doesn't work properly

### DIFF
--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -191,7 +191,8 @@ RZ_API void rz_core_file_reopen_remote_debug(RzCore *core, char *uri, ut64 addr)
 		eprintf("No file open?\n");
 		return;
 	}
-
+	
+	core->dbg->main_arena_resolved = false;
 	RzList *old_sections = __save_old_sections(core);
 	ut64 old_base = core->bin->cur->o->baddr_shift;
 	int bits = core->rasm->bits;
@@ -258,7 +259,7 @@ RZ_API void rz_core_file_reopen_debug(RzCore *core, const char *args) {
 		rz_core_io_file_open(core, core->io->desc->fd);
 		return;
 	}
-
+	core->dbg->main_arena_resolved = false;
 	RzList *old_sections = __save_old_sections(core);
 	ut64 old_base = core->bin->cur->o->baddr_shift;
 	int bits = core->rasm->bits;

--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -191,7 +191,7 @@ RZ_API void rz_core_file_reopen_remote_debug(RzCore *core, char *uri, ut64 addr)
 		eprintf("No file open?\n");
 		return;
 	}
-	
+
 	core->dbg->main_arena_resolved = false;
 	RzList *old_sections = __save_old_sections(core);
 	ut64 old_base = core->bin->cur->o->baddr_shift;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

As stated in issue #679 the output of heap commands would be wrong after using `ood`. This was due to the fact that `core->dbg->main_arena_resolved` boolean value was still true after using `ood` but due to [ASLR](https://en.wikipedia.org/wiki/Address_space_layout_randomization) the location of main arena will change. 

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**
closes #679
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
