### PR TITLE
Add missing registers for dwarf reg mapping in x86

### DIFF
--- a/librz/analysis/dwarf_process.c
+++ b/librz/analysis/dwarf_process.c
@@ -861,7 +861,9 @@ static const char *map_dwarf_reg_to_x86_64_reg(ut64 reg_num, VariableLocationKin
 static const char *map_dwarf_reg_to_x86_reg(ut64 reg_num, VariableLocationKind *kind) {
 	*kind = LOCATION_REGISTER;
 	switch (reg_num) {
-	case 0: return "eax";
+	case 0:
+	case 8:
+		return "eax";
 	case 1: return "edx";
 	case 2: return "ecx";
 	case 3: return "ebx";
@@ -873,6 +875,15 @@ static const char *map_dwarf_reg_to_x86_reg(ut64 reg_num, VariableLocationKind *
 		return "ebp";
 	case 6: return "esi";
 	case 7: return "edi";
+	case 9: return "EFLAGS";
+	case 11: return "st0";
+	case 12: return "st1";
+	case 13: return "st2";
+	case 14: return "st3";
+	case 15: return "st4";
+	case 16: return "st5";
+	case 17: return "st6";
+	case 18: return "st7";
 	case 21: return "xmm0";
 	case 22: return "xmm1";
 	case 23: return "xmm2";
@@ -881,6 +892,20 @@ static const char *map_dwarf_reg_to_x86_reg(ut64 reg_num, VariableLocationKind *
 	case 26: return "xmm5";
 	case 27: return "xmm6";
 	case 28: return "xmm7";
+	case 29: return "mm0";
+	case 30: return "mm1";
+	case 31: return "mm2";
+	case 32: return "mm3";
+	case 33: return "mm4";
+	case 34: return "mm5";
+	case 35: return "mm6";
+	case 36: return "mm7";
+	case 40: return "es";
+	case 41: return "cs";
+	case 42: return "ss";
+	case 43: return "ds";
+	case 44: return "fs";
+	case 45: return "gs";
 	default:
 		rz_warn_if_reached();
 		*kind = LOCATION_UNKNOWN;

--- a/test/db/cmd/warnings
+++ b/test/db/cmd/warnings
@@ -1,0 +1,9 @@
+NAME=warning1 #missing regs for dwarf reg mapping in x86. issue #883
+FILE=bins/elf/find_x86-sok_gcc_m32_O2
+CMDS=<<EOF
+EOF
+EXPECT=<<EOF
+EOF
+EXPECT_ERR=<<EOF
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

According to https://01.org/sites/default/files/file_attach/intel386-psabi-1.0.pdf there are some registers missing in `map_dwarf_reg_to_x86_reg`.
![image](https://user-images.githubusercontent.com/37471354/118827304-d4644380-b8ee-11eb-8b64-4973d354b582.png)


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

No warnings in stderr.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

#883 
