### PR TITLE
Fix minor leak in `rizin -v` execution path

### DIFF
--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -628,11 +628,13 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 			if (quiet) {
 				printf("%s\n", RZ_VERSION);
 				LISTS_FREE();
+				RZ_FREE(debugbackend);
 				free(customRarunProfile);
 				return 0;
 			} else {
 				rz_main_version_verify(0);
 				LISTS_FREE();
+				RZ_FREE(debugbackend);
 				free(customRarunProfile);
 				return rz_main_version_print("rizin");
 			}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Noticed the problem when accidentally called `rizin -v` from the ASAN build.

```
[i] ℤ rizin -v                                                                                                                                                                                                                    12:13:19 
rizin 0.3.0-git @ linux-x86-64
commit: c4c4789dc13f1ee1ba82b18736c82b26fb44356a, build: 2021-05-21__12:04:48

=================================================================
==358936==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 7 byte(s) in 1 object(s) allocated from:
    #0 0x7f02adec4967 in strdup (/lib64/libasan.so.6+0x59967)
    #1 0x7f02ad41ceab in rz_main_rizin ../librz/main/rizin.c:440
    #2 0x7f02ac898b74 in __libc_start_main (/lib64/libc.so.6+0x27b74)

SUMMARY: AddressSanitizer: 7 byte(s) leaked in 1 allocation(s).
```

**Test plan**

CI is green
