### PR TITLE
Gitignore all capstones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,7 @@ peda-session-*
 /.vs
 .cache/
 test/.tmp/*
-subprojects/capstone-bundled/
+subprojects/capstone-*/
 subprojects/libuv-*/
 subprojects/libzip-*/
 subprojects/lz4-*/


### PR DESCRIPTION
I need to use `capstone-next` for arm64e (latest macOS stuff)