### PR TITLE
rz-diff - prevent double free of old pointer.

### DIFF
--- a/librz/main/rz-diff.c
+++ b/librz/main/rz-diff.c
@@ -2172,6 +2172,7 @@ static bool rz_diff_hex_visual(DiffContext *ctx) {
 			break;
 		}
 	}
+	canvas = hview.canvas;
 	console->event_data = NULL;
 	console->event_resize = NULL;
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The `canvas` declare at `1928` pointer is never updated when the resize event happen and this cause a double free/heap use after free.