### PR TITLE
Fix negative read on rz_print_hex_from_bin

### DIFF
--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -2098,7 +2098,7 @@ RZ_API void rz_print_hex_from_bin(RzPrint *p, char *bin_str) {
 	}
 	index--;
 	p->cb_printf("0x");
-	while (buf[index] == 0 && index > 0) {
+	while (index > 0 && !buf[index]) {
 		index--;
 	}
 	p->cb_printf("%" PFMT64x, buf[index]);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

the while is wrong, since it is accessing the memory before testing for the value.

