### PR TITLE
Add command to print bins and arena info in JSON

### DIFF
--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -1673,6 +1673,10 @@ static int GH(print_bin_content)(RzCore *core, MallocState *main_arena, int bin_
 		rz_cons_printf(", bk=");
 		PRINTF_YA("0x%" PFMT64x, bk);
 		rz_cons_newline();
+	} else {
+		pj_kn(pj, "fd", fw);
+		pj_kn(pj, "bk", bk);
+		pj_ka(pj, "chunks");
 	}
 	GH(RzHeapChunk) *cnk = RZ_NEW0(GH(RzHeapChunk));
 
@@ -1695,7 +1699,9 @@ static int GH(print_bin_content)(RzCore *core, MallocState *main_arena, int bin_
 	}
 	free(cnk);
 	free(head);
-
+	if (pj) {
+		pj_end(pj);
+	}
 	return chunks_cnt;
 }
 
@@ -1715,13 +1721,11 @@ static void GH(print_unsortedbin_description)(RzCore *core, GHT m_arena, MallocS
 		pj_o(pj);
 		pj_kn(pj, "bin_num", 0);
 		pj_ks(pj, "bin_type", "unsorted");
-		pj_ka(pj, "chunks");
 	}
 	int chunk_cnt = GH(print_bin_content)(core, main_arena, 0, pj);
 	if (!pj) {
 		rz_cons_printf("Found %d chunks in unsorted bin\n", chunk_cnt);
 	} else {
-		pj_end(pj);
 		pj_end(pj);
 	}
 }
@@ -1745,11 +1749,9 @@ static void GH(print_smallbin_description)(RzCore *core, GHT m_arena, MallocStat
 			pj_o(pj);
 			pj_kn(pj, "bin_num", bin_num);
 			pj_ks(pj, "bin_type", "small");
-			pj_ka(pj, "chunks");
 		}
 		int chunk_found = GH(print_bin_content)(core, main_arena, bin_num, pj);
 		if (pj) {
-			pj_end(pj);
 			pj_end(pj);
 		}
 		if (chunk_found > 0) {
@@ -1781,11 +1783,9 @@ static void GH(print_largebin_description)(RzCore *core, GHT m_arena, MallocStat
 			pj_o(pj);
 			pj_kn(pj, "bin_num", bin_num);
 			pj_ks(pj, "bin_type", "large");
-			pj_ka(pj, "chunks");
 		}
 		int chunk_found = GH(print_bin_content)(core, main_arena, bin_num, pj);
 		if (pj) {
-			pj_end(pj);
 			pj_end(pj);
 		}
 		if (chunk_found > 0) {

--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -2025,9 +2025,19 @@ static int GH(cmd_dbg_map_heap_glibc)(RzCore *core, const char *input) {
 		if (!GH(rz_resolve_main_arena)(core, &m_arena)) {
 			break;
 		}
-		if (!GH(update_main_arena)(core, m_arena, main_arena)) {
+		if (core->offset != core->prompt_offset) {
+			m_state = core->offset;
+		} else {
+			m_state = m_arena;
+		}
+		if (!GH(is_arena)(core, m_arena, m_state)) {
+			PRINT_RA("This address is not part of the arenas\n");
 			break;
 		}
+		if (!GH(update_main_arena)(core, m_state, main_arena)) {
+			break;
+		}
+
 		input += 1;
 		bool json = false;
 		if (input[0] == 'j') { // dmhdj
@@ -2051,9 +2061,8 @@ static int GH(cmd_dbg_map_heap_glibc)(RzCore *core, const char *input) {
 				break;
 			}
 		}
-
 		GH(print_main_arena_bins)
-		(core, m_arena, main_arena, global_max_fast, bin_format, json);
+		(core, m_state, main_arena, global_max_fast, bin_format, json);
 		break;
 	case 'f': // "dmhf"
 		if (GH(rz_resolve_main_arena)(core, &m_arena)) {

--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -71,7 +71,7 @@ static inline GHT GH(align_address_to_size)(ut64 addr, ut64 align) {
 }
 
 static inline GHT GH(get_next_pointer)(RzCore *core, GHT pos, GHT next) {
-	return (core->dbg->glibc_version < 232) ? next : PROTECT_PTR(pos, next);
+	return (core->dbg->glibc_version < 232) ? next : (GHT)((pos >> 12) ^ next);
 }
 
 static GHT GH(get_main_arena_with_symbol)(RzCore *core, RzDebugMap *map) {
@@ -761,16 +761,12 @@ static int GH(print_double_linked_list_bin)(RzCore *core, MallocState *main_aren
 		initial_brk = (brk_start >> 12) << 12;
 	}
 
-	switch (num_bin) {
-	case 0:
+	if (num_bin == 0) {
 		PRINT_GA("  double linked list unsorted bin {\n");
-		break;
-	case 1 ... NSMALLBINS - 1:
+	} else if (num_bin >= 1 && num_bin <= NSMALLBINS - 1) {
 		PRINT_GA("  double linked list small bin {\n");
-		break;
-	case NSMALLBINS ... NBINS - 2:
+	} else if (num_bin >= NSMALLBINS && num_bin <= NBINS - 2) {
 		PRINT_GA("  double linked list large bin {\n");
-		break;
 	}
 
 	if (!graph || graph == 1) {

--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -592,11 +592,14 @@ void GH(print_heap_chunk_simple)(RzCore *core, GHT chunk, const char *status, PJ
 		rz_cons_printf(")");
 	} else {
 		pj_o(pj);
+		pj_kn(pj, "prev_size", cnk->prev_size);
 		pj_kn(pj, "addr", chunk);
 		pj_kn(pj, "size", (ut64)cnk->size & ~(NON_MAIN_ARENA | IS_MMAPPED | PREV_INUSE));
 		pj_kn(pj, "non_main_arena", cnk->size & NON_MAIN_ARENA);
 		pj_kn(pj, "mmapped", cnk->size & IS_MMAPPED);
 		pj_kn(pj, "prev_inuse", cnk->size & PREV_INUSE);
+		pj_kn(pj, "fd", cnk->fd);
+		pj_kn(pj, "bk", cnk->bk);
 		pj_end(pj);
 	}
 	free(cnk);

--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -1578,7 +1578,7 @@ void GH(print_malloc_states)(RzCore *core, GHT m_arena, MallocState *main_arena,
 		pj_kn(pj, "last_rem", main_arena->GH(last_remainder));
 		pj_kn(pj, "top", main_arena->GH(top));
 		pj_kn(pj, "next", main_arena->GH(next));
-                pj_ks(pj, "type", "main");
+		pj_ks(pj, "type", "main");
 		pj_ks(pj, "state", "used");
 		pj_end(pj);
 	}
@@ -1611,11 +1611,11 @@ void GH(print_malloc_states)(RzCore *core, GHT m_arena, MallocState *main_arena,
 				pj_kn(pj, "top", ta->GH(top));
 				pj_kn(pj, "next", ta->GH(next));
 				pj_ks(pj, "type", "thread");
-                                if (ta->attached_threads) {
-                                        pj_ks(pj, "state", "used");
-                                } else {
-                                        pj_ks(pj, "state", "free");
-                                }
+				if (ta->attached_threads) {
+					pj_ks(pj, "state", "used");
+				} else {
+					pj_ks(pj, "state", "free");
+				}
 				pj_end(pj);
 			}
 		}

--- a/librz/include/rz_heap_glibc.h
+++ b/librz/include/rz_heap_glibc.h
@@ -49,7 +49,6 @@ RZ_LIB_VERSION_HEADER(rz_heap_glibc);
 
 // Introduced with glibc 2.32
 
-
 #define largebin_index_32(size) \
 	(((((ut32)(size)) >> 6) <= 38) ? 56 + (((ut32)(size)) >> 6) : ((((ut32)(size)) >> 9) <= 20) ? 91 + (((ut32)(size)) >> 9) \
 			: ((((ut32)(size)) >> 12) <= 10)                                            ? 110 + (((ut32)(size)) >> 12) \

--- a/librz/include/rz_heap_glibc.h
+++ b/librz/include/rz_heap_glibc.h
@@ -48,8 +48,7 @@ RZ_LIB_VERSION_HEADER(rz_heap_glibc);
 #define TC_SZ_64  0x10
 
 // Introduced with glibc 2.32
-#define PROTECT_PTR(pos, ptr) \
-	((__typeof(ptr))((((size_t)pos) >> 12) ^ ((size_t)ptr)))
+
 
 #define largebin_index_32(size) \
 	(((((ut32)(size)) >> 6) <= 38) ? 56 + (((ut32)(size)) >> 6) : ((((ut32)(size)) >> 9) <= 20) ? 91 + (((ut32)(size)) >> 9) \


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Adding a command `dmhdj`  to retrieve information about the bins in JSON format. This will be useful when I implement heap viewer for Cutter.
### TODO:
- Fix tcache in `dmhd` different arenas
- Add more information in JSON commands as required 

#### More info in `dmha` command
<img width="939" alt="Screenshot 2021-05-30 at 9 33 37 PM" src="https://user-images.githubusercontent.com/56169176/120111220-ba4c2000-c18e-11eb-9710-4980d189c4c3.png">

#### `dmhaj` 
<img width="764" alt="Screenshot 2021-05-30 at 9 49 19 PM" src="https://user-images.githubusercontent.com/56169176/120111773-e8326400-c190-11eb-89e8-9e247fc28563.png">


#### `dmhdj`
<img width="770" alt="Screenshot 2021-05-30 at 8 58 29 PM" src="https://user-images.githubusercontent.com/56169176/120110093-da2d1500-c189-11eb-8a30-72d7dee6225a.png">


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
