### PR TITLE
Add Integration Test for RzBinVirtualFiles without RzCore

### DIFF
--- a/librz/bin/bobj.c
+++ b/librz/bin/bobj.c
@@ -580,6 +580,21 @@ RZ_API RzBinSymbol *rz_bin_object_get_symbol_of_import(RzBinObject *o, RzBinImpo
 	return ht_pp_find(o->import_name_symbols, imp->name, NULL);
 }
 
+RZ_API RzBinVirtualFile *rz_bin_object_get_virtual_file(RzBinObject *o, const char *name) {
+	rz_return_val_if_fail(o && name, NULL);
+	if (!o->vfiles) {
+		return NULL;
+	}
+	RzListIter *it;
+	RzBinVirtualFile *vf;
+	rz_list_foreach (o->vfiles, it, vf) {
+		if (!strcmp(vf->name, name)) {
+			return vf;
+		}
+	}
+	return NULL;
+}
+
 RZ_IPI RzBinObject *rz_bin_object_get_cur(RzBin *bin) {
 	rz_return_val_if_fail(bin && bin->cur, NULL);
 	return bin->cur->o;

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -944,6 +944,7 @@ RZ_API ut64 rz_bin_object_get_vaddr(RzBinObject *o, ut64 paddr, ut64 vaddr);
 RZ_API RzBinAddr *rz_bin_object_get_special_symbol(RzBinObject *o, RzBinSpecialSymbol sym);
 RZ_API RzBinRelocStorage *rz_bin_object_patch_relocs(RzBinFile *bf, RzBinObject *o);
 RZ_API RzBinSymbol *rz_bin_object_get_symbol_of_import(RzBinObject *o, RzBinImport *imp);
+RZ_API RzBinVirtualFile *rz_bin_object_get_virtual_file(RzBinObject *o, const char *name);
 RZ_API void rz_bin_mem_free(void *data);
 
 // demangle functions

--- a/test/integration/meson.build
+++ b/test/integration/meson.build
@@ -3,6 +3,7 @@ if get_option('enable_tests')
 
   tests = [
     'open_analyse_save_load_project',
+    'bin_vfiles'
   ]
 
   unit_test_env = environment()

--- a/test/integration/test_bin_vfiles.c
+++ b/test/integration/test_bin_vfiles.c
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2021 Florian Märkl <info@florianmaerkl.de>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_bin.h>
+
+#include "../unit/minunit.h"
+
+/// Test using RzBin without RzCore and extract some data from a vfiile
+bool test_bin_vfiles() {
+	// 1. Open the file as RzBuffer
+	RzBuffer *buf = rz_buf_new_file("bins/elf/ls", O_RDONLY, 0644);
+	mu_assert_notnull(buf, "open file");
+
+	// 2. Load the buffer into RzBin
+	RzBin *bin = rz_bin_new();
+	RzBinOptions opts = { 0 };
+	opts.filename = "<internal>";
+	opts.obj_opts.patch_relocs = true;
+	RzBinFile *bf = rz_bin_open_buf(bin, buf, &opts);
+	mu_assert_notnull(bf, "load bin file");
+
+	// 2. Extract the reloc-patched buffer
+	mu_assert_notnull(bf->o, "object");
+	mu_assert_notnull(bf->o->vfiles, "vfiles");
+	RzBinVirtualFile *patched = rz_bin_object_get_virtual_file(bf->o, "patched");
+	mu_assert_notnull(patched, "patched vfile");
+
+	// 3. Find an interesting reloc by an import name
+	mu_assert_notnull(bf->o->relocs, "relocs");
+	RzBinReloc *reloc = NULL;
+	for (size_t i = 0; i < bf->o->relocs->relocs_count; i++) {
+		RzBinReloc *r = bf->o->relocs->relocs[i];
+		if (!r->import) {
+			continue;
+		}
+		if (!strcmp(r->import->name, "isatty")) {
+			reloc = r;
+			break;
+		}
+	}
+	mu_assert_notnull(reloc, "found reloc by name");
+	mu_assert_eq(reloc->paddr, 0x00020ce8, "reloc paddr");
+	mu_assert_eq(reloc->vaddr, 0x00021ce8, "reloc vaddr");
+	mu_assert_neq(reloc->target_vaddr, 0, "target not 0");
+	mu_assert_neq(reloc->target_vaddr, UT64_MAX, "target not UT64_MAX");
+
+	// 4. Check the contents of the original buf and the vfile against the data in the reloc
+	ut64 val = rz_buf_read_le64_at(buf, reloc->paddr);
+	mu_assert_eq(val, 0, "original buf has nothing patched");
+	val = rz_buf_read_le64_at(patched->buf, reloc->paddr);
+	mu_assert_eq(val, reloc->target_vaddr, "read patched target from vfile");
+
+	// 5. Exit
+	rz_bin_free(bin);
+	mu_end;
+}
+
+int all_tests() {
+	mu_run_test(test_bin_vfiles);
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The vfiles may be consumed even when RzCore is not present.