### PR TITLE
Refactor COFF Reloc Patching to use RzBinVirtualFile instead of IO Cache

### DIFF
--- a/librz/bin/format/coff/coff.h
+++ b/librz/bin/format/coff/coff.h
@@ -9,6 +9,7 @@
 #include <rz_lib.h>
 #include <rz_bin.h>
 #include <ht_up.h>
+#include <ht_uu.h>
 
 #define COFF_IS_BIG_ENDIAN    1
 #define COFF_IS_LITTLE_ENDIAN 0
@@ -28,15 +29,29 @@ struct rz_bin_coff_obj {
 	ut8 endian;
 	Sdb *kv;
 	bool verbose;
-	HtUP *sym_ht;
-	HtUP *imp_ht;
+	HtUP /*<symidx, RzBinSymbol>*/ *sym_ht;
+	HtUP /*<symidx, RzBinImport>*/ *imp_ht;
+	HtUU /*<symidx, ut64>*/ *imp_index; ///< locally-generated indices for imports, in particular for deterministically assigning reloc targets
 	ut64 *scn_va;
+	ut64 reloc_targets_map_base;
+	bool reloc_targets_map_base_calculated;
+	RzBuffer *buf_patched; ///< overlay over the original file with relocs patched
+	bool relocs_patched;
 };
 
-bool rz_coff_supported_arch(const ut8 *buf); /* Reads two bytes from buf. */
-struct rz_bin_coff_obj *rz_bin_coff_new_buf(RzBuffer *buf, bool verbose);
-void rz_bin_coff_free(struct rz_bin_coff_obj *obj);
-RzBinAddr *rz_coff_get_entry(struct rz_bin_coff_obj *obj);
-char *rz_coff_symbol_name(struct rz_bin_coff_obj *obj, void *ptr);
+RZ_API bool rz_coff_supported_arch(const ut8 *buf); /* Reads two bytes from buf. */
+RZ_API ut64 rz_coff_perms_from_section_flags(ut32 flags);
+RZ_API struct rz_bin_coff_obj *rz_bin_coff_new_buf(RzBuffer *buf, bool verbose);
+RZ_API void rz_bin_coff_free(struct rz_bin_coff_obj *obj);
+RZ_API RzBinAddr *rz_coff_get_entry(struct rz_bin_coff_obj *obj);
+RZ_API char *rz_coff_symbol_name(struct rz_bin_coff_obj *obj, void *ptr);
+
+RZ_API ut64 rz_coff_import_index_addr(struct rz_bin_coff_obj *obj, ut64 imp_index);
+RZ_API ut64 rz_coff_get_reloc_targets_map_base(struct rz_bin_coff_obj *obj);
+RZ_API RzList *rz_coff_get_relocs(struct rz_bin_coff_obj *bin);
+RZ_API ut64 rz_coff_get_reloc_targets_vfile_size(struct rz_bin_coff_obj *obj);
+RZ_API RZ_BORROW RzBuffer *rz_coff_get_patched_buf(struct rz_bin_coff_obj *bin);
+
+#define RZ_COFF_RELOC_TARGET_SIZE 8
 
 #endif /* COFF_H */

--- a/librz/bin/format/coff/coff_reloc.c
+++ b/librz/bin/format/coff/coff_reloc.c
@@ -1,0 +1,217 @@
+
+#include "coff.h"
+#include <rz_util.h>
+#include <ht_uu.h>
+
+/// base vaddr where to map the artificial reloc target vfile
+RZ_API ut64 rz_coff_get_reloc_targets_map_base(struct rz_bin_coff_obj *obj) {
+	rz_return_val_if_fail(obj, 0);
+	if (obj->reloc_targets_map_base_calculated) {
+		return obj->reloc_targets_map_base;
+	}
+	if (!obj->scn_va) {
+		return 0;
+	}
+	ut64 max = 0;
+	for (size_t i = 0; i < obj->hdr.f_nscns; i++) {
+		struct coff_scn_hdr *hdr = &obj->scn_hdrs[i];
+		ut64 val = obj->scn_va[i] + hdr->s_size;
+		if (val > max) {
+			max = val;
+		}
+	}
+	max += 8;
+	max += rz_num_align_delta(max, RZ_COFF_RELOC_TARGET_SIZE);
+	obj->reloc_targets_map_base = max;
+	obj->reloc_targets_map_base_calculated = true;
+	return obj->reloc_targets_map_base;
+}
+
+RZ_API ut64 rz_coff_import_index_addr(struct rz_bin_coff_obj *obj, ut64 imp_index) {
+	return rz_coff_get_reloc_targets_map_base(obj) + imp_index * RZ_COFF_RELOC_TARGET_SIZE;
+}
+
+typedef void (*RelocsForeachCb)(RZ_BORROW RzBinReloc *reloc, ut8 *patch_buf, size_t patch_buf_sz, void *user);
+
+static void relocs_foreach(struct rz_bin_coff_obj *bin, RelocsForeachCb cb, void *user) {
+	struct coff_reloc *rel;
+	for (size_t i = 0; i < bin->hdr.f_nscns; i++) {
+		if (!bin->scn_hdrs[i].s_nreloc) {
+			continue;
+		}
+		int len = 0, size = bin->scn_hdrs[i].s_nreloc * sizeof(struct coff_reloc);
+		if (size < 0) {
+			break;
+		}
+		rel = calloc(1, size + sizeof(struct coff_reloc));
+		if (!rel) {
+			break;
+		}
+		if (bin->scn_hdrs[i].s_relptr > bin->size ||
+			bin->scn_hdrs[i].s_relptr + size > bin->size) {
+			free(rel);
+			break;
+		}
+		len = rz_buf_read_at(bin->b, bin->scn_hdrs[i].s_relptr, (ut8 *)rel, size);
+		if (len != size) {
+			free(rel);
+			break;
+		}
+		for (size_t j = 0; j < bin->scn_hdrs[i].s_nreloc; j++) {
+			RzBinSymbol *symbol = (RzBinSymbol *)ht_up_find(bin->sym_ht, (ut64)rel[j].rz_symndx, NULL);
+			if (!symbol) {
+				continue;
+			}
+			RzBinReloc reloc = { 0 };
+
+			reloc.symbol = symbol;
+			reloc.paddr = bin->scn_hdrs[i].s_scnptr + rel[j].rz_vaddr;
+			if (bin->scn_va) {
+				reloc.vaddr = bin->scn_va[i] + rel[j].rz_vaddr;
+			}
+			reloc.type = rel[j].rz_type;
+
+			ut64 sym_vaddr = symbol->vaddr;
+			if (symbol->is_imported) {
+				reloc.import = (RzBinImport *)ht_up_find(bin->imp_ht, (ut64)rel[j].rz_symndx, NULL);
+				ut64 imp_idx = ht_uu_find(bin->imp_index, (ut64)rel[j].rz_symndx, NULL);
+				sym_vaddr = rz_coff_import_index_addr(bin, imp_idx);
+			}
+			reloc.target_vaddr = sym_vaddr;
+
+			size_t plen = 0;
+			ut8 patch_buf[8];
+			if (sym_vaddr) {
+				switch (bin->hdr.f_magic) {
+				case COFF_FILE_MACHINE_I386:
+					switch (rel[j].rz_type) {
+					case COFF_REL_I386_DIR32:
+						reloc.type = RZ_BIN_RELOC_32;
+						rz_write_le32(patch_buf, (ut32)sym_vaddr);
+						plen = 4;
+						break;
+					case COFF_REL_I386_REL32:
+						reloc.type = RZ_BIN_RELOC_32;
+						reloc.additive = 1;
+						ut64 data = rz_buf_read_le32_at(bin->b, reloc.paddr);
+						if (data == UT32_MAX) {
+							break;
+						}
+						reloc.addend = data;
+						data += sym_vaddr - reloc.vaddr - 4;
+						rz_write_le32(patch_buf, (st32)data);
+						plen = 4;
+						break;
+					}
+					break;
+				case COFF_FILE_MACHINE_AMD64:
+					switch (rel[j].rz_type) {
+					case COFF_REL_AMD64_REL32:
+						reloc.type = RZ_BIN_RELOC_32;
+						reloc.additive = 1;
+						ut64 data = rz_buf_read_le32_at(bin->b, reloc.paddr);
+						if (data == UT32_MAX) {
+							break;
+						}
+						reloc.addend = data;
+						data += sym_vaddr - reloc.vaddr - 4;
+						rz_write_le32(patch_buf, (st32)data);
+						plen = 4;
+						break;
+					}
+					break;
+				case COFF_FILE_MACHINE_ARMNT:
+					switch (rel[j].rz_type) {
+					case COFF_REL_ARM_BRANCH24T:
+					case COFF_REL_ARM_BLX23T:
+						reloc.type = RZ_BIN_RELOC_32;
+						ut16 hiword = rz_buf_read_le16_at(bin->b, reloc.paddr);
+						if (hiword == UT16_MAX) {
+							break;
+						}
+						ut16 loword = rz_buf_read_le16_at(bin->b, reloc.paddr + 2);
+						if (loword == UT16_MAX) {
+							break;
+						}
+						ut64 dst = sym_vaddr - reloc.vaddr - 4;
+						if (dst & 1) {
+							break;
+						}
+						loword |= (ut16)(dst >> 1) & 0x7ff;
+						hiword |= (ut16)(dst >> 12) & 0x7ff;
+						rz_write_le16(patch_buf, hiword);
+						rz_write_le16(patch_buf + 2, loword);
+						plen = 4;
+						break;
+					}
+					break;
+				case COFF_FILE_MACHINE_ARM64:
+					switch (rel[j].rz_type) {
+					case COFF_REL_ARM64_BRANCH26:
+						reloc.type = RZ_BIN_RELOC_32;
+						ut32 data = rz_buf_read_le32_at(bin->b, reloc.paddr);
+						if (data == UT32_MAX) {
+							break;
+						}
+						ut64 dst = sym_vaddr - reloc.vaddr;
+						data |= (ut32)((dst >> 2) & 0x3ffffffULL);
+						rz_write_le32(patch_buf, data);
+						plen = 4;
+						break;
+					}
+					break;
+				}
+			}
+			cb(&reloc, plen ? patch_buf : NULL, plen, user);
+		}
+		free(rel);
+	}
+}
+
+void get_relocs_list_cb(RZ_BORROW RzBinReloc *reloc, ut8 *patch_buf, size_t patch_buf_sz, void *user) {
+	RzList *r = user;
+	RzBinReloc *reloc_copy = RZ_NEW(RzBinReloc);
+	if (!reloc_copy) {
+		return;
+	}
+	memcpy(reloc_copy, reloc, sizeof(*reloc_copy));
+	rz_list_push(r, reloc_copy);
+}
+
+RZ_API RzList *rz_coff_get_relocs(struct rz_bin_coff_obj *bin) {
+	rz_return_val_if_fail(bin && bin->scn_hdrs, NULL);
+	RzList *r = rz_list_newf(free);
+	if (!r) {
+		return NULL;
+	}
+	relocs_foreach(bin, get_relocs_list_cb, r);
+	return r;
+}
+
+/// size of the artificial reloc target vfile
+RZ_API ut64 rz_coff_get_reloc_targets_vfile_size(struct rz_bin_coff_obj *obj) {
+	rz_return_val_if_fail(obj, 0);
+	ut64 count = obj->imp_index ? obj->imp_index->count : 0;
+	return count * RZ_COFF_RELOC_TARGET_SIZE;
+}
+
+static void patch_reloc_cb(RZ_BORROW RzBinReloc *reloc, ut8 *patch_buf, size_t patch_buf_sz, void *user) {
+	RzBuffer *buf = user;
+	if (patch_buf) {
+		rz_buf_write_at(buf, reloc->paddr, patch_buf, patch_buf_sz);
+	}
+}
+
+RZ_API RZ_BORROW RzBuffer *rz_coff_get_patched_buf(struct rz_bin_coff_obj *bin) {
+	rz_return_val_if_fail(bin, NULL);
+	if (bin->buf_patched) {
+		return bin->buf_patched;
+	}
+	bin->buf_patched = rz_buf_new_sparse_overlay(bin->b, RZ_BUF_SPARSE_WRITE_MODE_SPARSE);
+	if (!bin->buf_patched) {
+		return NULL;
+	}
+	relocs_foreach(bin, patch_reloc_cb, bin->buf_patched);
+	rz_buf_sparse_set_write_mode(bin->buf_patched, RZ_BUF_SPARSE_WRITE_MODE_THROUGH);
+	return bin->buf_patched;
+}

--- a/librz/bin/meson.build
+++ b/librz/bin/meson.build
@@ -75,6 +75,7 @@ rz_bin_sources = [
 
   'format/bflt/bflt.c',
   'format/coff/coff.c',
+  'format/coff/coff_reloc.c',
   'format/dex/dex.c',
   'format/dmp/dmp64.c',
   'format/elf/elf.c',

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -809,6 +809,7 @@ RZ_API void rz_bin_virtual_file_free(RzBinVirtualFile *vfile);
 RZ_API void rz_bin_map_free(RzBinMap *map);
 RZ_API RzList *rz_bin_maps_of_file_sections(RzBinFile *binfile);
 RZ_API RzList *rz_bin_sections_of_maps(RzList /*<RzBinMap>*/ *maps);
+RZ_API ut64 rz_bin_find_free_base_addr(RzList /*<RzBinMap>*/ *maps, ut64 align);
 RZ_IPI RzBinSection *rz_bin_section_new(const char *name);
 RZ_IPI void rz_bin_section_free(RzBinSection *bs);
 RZ_API RZ_OWN char *rz_bin_section_type_to_string(RzBin *bin, int type);

--- a/test/db/formats/coff
+++ b/test/db/formats/coff
@@ -8,32 +8,32 @@ EXPECT=<<EOF
 [Imports]
 nth vaddr      bind type lib name
 ---------------------------------
-0   ---------- NONE FUNC     __TIFFmalloc
-1   ---------- NONE FUNC     __TIFFrealloc
-2   ---------- NONE FUNC     __TIFFmemset
-3   ---------- NONE FUNC     __TIFFmemcpy
-4   ---------- NONE FUNC     __TIFFfree
-5   ---------- NONE FUNC     _TIFFFindField
-6   ---------- NONE FUNC     _TIFFFieldWithTag
-7   ---------- NONE FUNC     _TIFFReadDirectory
-8   ---------- NONE FUNC     _TIFFErrorExt
-9   ---------- NONE FUNC     _TIFFWarningExt
-10  ---------- NONE FUNC     _TIFFSwabShort
-11  ---------- NONE FUNC     _TIFFSwabLong
-12  ---------- NONE FUNC     _TIFFSwabLong8
-13  ---------- NONE FUNC     __TIFFGetFields
-14  ---------- NONE FUNC     __TIFFGetExifFields
-15  ---------- NONE FUNC     __TIFFSetupFields
-16  ---------- NONE FUNC     __TIFFFillStriles
-17  ---------- NONE FUNC     __TIFFNoPostDecode
-18  ---------- NONE FUNC     __TIFFSwab16BitData
-19  ---------- NONE FUNC     __TIFFSwab24BitData
-20  ---------- NONE FUNC     __TIFFSwab32BitData
-21  ---------- NONE FUNC     __TIFFSwab64BitData
-22  ---------- NONE FUNC     _TIFFSetCompressionScheme
-23  ---------- NONE FUNC     __TIFFDataSize
-24  ---------- NONE FUNC     __TIFFCheckMalloc
-25  ---------- NONE UNK      __fltused
+0   0x0000b690 NONE FUNC     __TIFFmalloc
+1   0x0000b698 NONE FUNC     __TIFFrealloc
+2   0x0000b6a0 NONE FUNC     __TIFFmemset
+3   0x0000b6a8 NONE FUNC     __TIFFmemcpy
+4   0x0000b6b0 NONE FUNC     __TIFFfree
+5   0x0000b6b8 NONE FUNC     _TIFFFindField
+6   0x0000b6c0 NONE FUNC     _TIFFFieldWithTag
+7   0x0000b6c8 NONE FUNC     _TIFFReadDirectory
+8   0x0000b6d0 NONE FUNC     _TIFFErrorExt
+9   0x0000b6d8 NONE FUNC     _TIFFWarningExt
+10  0x0000b6e0 NONE FUNC     _TIFFSwabShort
+11  0x0000b6e8 NONE FUNC     _TIFFSwabLong
+12  0x0000b6f0 NONE FUNC     _TIFFSwabLong8
+13  0x0000b6f8 NONE FUNC     __TIFFGetFields
+14  0x0000b700 NONE FUNC     __TIFFGetExifFields
+15  0x0000b708 NONE FUNC     __TIFFSetupFields
+16  0x0000b710 NONE FUNC     __TIFFFillStriles
+17  0x0000b718 NONE FUNC     __TIFFNoPostDecode
+18  0x0000b720 NONE FUNC     __TIFFSwab16BitData
+19  0x0000b728 NONE FUNC     __TIFFSwab24BitData
+20  0x0000b730 NONE FUNC     __TIFFSwab32BitData
+21  0x0000b738 NONE FUNC     __TIFFSwab64BitData
+22  0x0000b740 NONE FUNC     _TIFFSetCompressionScheme
+23  0x0000b748 NONE FUNC     __TIFFDataSize
+24  0x0000b750 NONE FUNC     __TIFFCheckMalloc
+25  0x0000b758 NONE UNK      __fltused
 
 [Sections]
 
@@ -58,25 +58,26 @@ NAME=tiny coff
 FILE=bins/coff/coff.obj
 CMDS=om;is;ir
 EXPECT=<<EOF
- 2 fd: 3 +0x00000064 0x00000000 - 0x00000026 r-x fmap..text
+ 3 fd: 5 +0x00000000 0x00000058 - 0x00000067 r-- vmap.reloc-targets
+ 2 fd: 4 +0x00000064 0x00000000 - 0x00000026 r-x vmap..text
  1 fd: 3 +0x0000008b 0x00000030 - 0x0000004b r-- fmap..data
 [Symbols]
 
 nth paddr      vaddr      bind   type size lib name
 ---------------------------------------------------
-0   ---------- ---------- NONE   UNK  4        imp.MessageBoxA
-0   ---------- ---------- NONE   UNK  4        imp.ExitProcess
+0   ---------- 0x00000058 NONE   UNK  4        imp.MessageBoxA
+0   ---------- 0x00000060 NONE   UNK  4        imp.ExitProcess
 0   0x00000064 0x00000000 LOCAL  SECT 4        .text
 0   0x00000064 0x00000000 GLOBAL FUNC 4        main
 0   0x0000008b 0x00000030 LOCAL  SECT 4        .data
 [Relocations]
 
-vaddr      paddr      type   name
----------------------------------
-0x00000009 0x0000006d ADD_32 .data
-0x00000010 0x00000074 ADD_32 .data
-0x0000001c 0x00000080 ADD_32 MessageBoxA
-0x00000023 0x00000087 ADD_32 ExitProcess
+vaddr      paddr      target     type   name
+--------------------------------------------
+0x00000009 0x0000006d 0x00000030 ADD_32 .data
+0x00000010 0x00000074 0x00000030 ADD_32 .data + 0x0000000f
+0x0000001c 0x00000080 0x00000058 ADD_32 MessageBoxA
+0x00000023 0x00000087 0x00000060 ADD_32 ExitProcess
 
 
 4 relocations
@@ -94,15 +95,16 @@ s sym.__1FooBar__QAE_XZ
 pd 2
 EOF
 EXPECT=<<EOF
+10 fd: 5 +0x00000000 0x00000e60 - 0x00000e6f r-- vmap.reloc-targets
  9 fd: 3 +0x0000017c 0x00000000 - 0x000000ee --- fmap..drectve
  8 fd: 3 +0x0000026b 0x000000f0 - 0x00000b9f r-- fmap..debug$S
  7 fd: 3 +0x00000d1b 0x00000ba0 - 0x00000c13 r-- fmap..debug$T
  6 fd: 3 +0x00000d8f 0x00000c20 - 0x00000c4c r-x fmap..text$mn
- 5 fd: 3 +0x00000dbc 0x00000c50 - 0x00000d23 r-- fmap..debug$S
+ 5 fd: 4 +0x00000dbc 0x00000c50 - 0x00000d23 r-- vmap..debug$S
  4 fd: 3 +0x00000ec2 0x00000d30 - 0x00000d59 r-x fmap..text$mn
- 3 fd: 3 +0x00000eec 0x00000d60 - 0x00000e33 r-- fmap..debug$S
- 2 fd: 3 +0x00000ff2 0x00000e40 - 0x00000e43 r-- fmap..rtc$IMZ
- 1 fd: 3 +0x00001000 0x00000e50 - 0x00000e53 r-- fmap..rtc$TMZ
+ 3 fd: 4 +0x00000eec 0x00000d60 - 0x00000e33 r-- vmap..debug$S
+ 2 fd: 4 +0x00000ff2 0x00000e40 - 0x00000e43 r-- vmap..rtc$IMZ
+ 1 fd: 4 +0x00001000 0x00000e50 - 0x00000e53 r-- vmap..rtc$TMZ
 [Sections]
 
 nth paddr        size vaddr       vsize perm name
@@ -132,22 +134,21 @@ nth paddr      vaddr      bind   type size lib name
 0   0x00000eec 0x00000d60 LOCAL  SECT 4        .debug$S
 0   0x00000d8f 0x00000c20 GLOBAL FUNC 4        ??0FooBar@@QAE@XZ
 0   0x00000ec2 0x00000d30 GLOBAL FUNC 4        ??1FooBar@@QAE@XZ
-0   ---------- ---------- NONE   FUNC 4        imp.__RTC_InitBase
-0   ---------- ---------- NONE   FUNC 4        imp.__RTC_Shutdown
+0   ---------- 0x00000e60 NONE   FUNC 4        imp.__RTC_InitBase
+0   ---------- 0x00000e68 NONE   FUNC 4        imp.__RTC_Shutdown
 0   0x00000ff2 0x00000e40 LOCAL  SECT 4        .rtc$IMZ
 0   0x00000ff2 0x00000e40 LOCAL  UNK  4        __RTC_InitBase.rtc$IMZ
 0   0x00001000 0x00000e50 LOCAL  SECT 4        .rtc$TMZ
 0   0x00001000 0x00000e50 LOCAL  UNK  4        __RTC_Shutdown.rtc$TMZ
             ;-- section..text_mn_1:
-            ;-- .text$mn:
             ;-- ??1FooBar@@QAE@XZ:
-            0x00000d30      55             push  ebp                   ; [05] -r-x section size 42 named .text_mn_1
+            ;-- .text$mn:
+            0x00000d30      55             push  ebp                   ; RELOC TARGET 10 ??1FooBar@@QAE@XZ @ 0x00000d30 ; [05] -r-x section size 42 named .text_mn_1
             0x00000d31      8bec           mov   ebp, esp
 EOF
 RUN
 
 NAME=patched reloc x86
-ARGS=-e io.cache=1
 FILE=bins/coff/tif_dir.obj
 CMDS=<<EOF
 e asm.bytes=true
@@ -160,15 +161,14 @@ EOF
 EXPECT=<<EOF
 |           0x00008dbd      e80e000000     call  sym._TIFFVGetField    ; RELOC 32 _TIFFVGetField @ 0x00008dd0
 sym._TIFFGetField 0x8dbd [CALL] call sym._TIFFVGetField
-|           0x00008dde      e8ad280000     call  sym.imp._TIFFFindField; RELOC 32 _TIFFFindField
+|           0x00008dde      e8d5280000     call  sym.imp._TIFFFindField; RELOC 32 _TIFFFindField
             ; CALL XREF from sym._TIFFVGetField @ 0x8dde
             ;-- _TIFFFindField:
-            0x0000b690      .dword 0x00000000                          ; RELOC TARGET 32 _TIFFFindField
+            0x0000b6b8      .dword 0x00000000                          ; RELOC TARGET 32 _TIFFFindField
 EOF
 RUN
 
 NAME=patching REL32 amd64
-ARGS=-e io.cache=1
 FILE=bins/coff/coff.obj
 CMDS=<<EOF
 e asm.bytes=true


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This is similar to my previous prs that refactor abuse of io.cache in bin plugins to use RzBinVirtualFiles instead. In particular, this is most similar to elf reloc patching from https://github.com/rizinorg/rizin/pull/1079

**Test plan**

The existing tests target this quite well already. Changes come mostly from now different ordering of imports and the fact that relocs are also patched when `io.cache=false`.