### PR TITLE
Disable unnecessary `io.cache=true` in tests

### DIFF
--- a/test/db/abi/languages/rust
+++ b/test/db/abi/languages/rust
@@ -12,7 +12,6 @@ RUN
 NAME=LANGUAGES : rust disasembly
 FILE=bins/abi_bins/elf/languages/rust/tree_traversal
 CMDS=<<EOF
-e io.cache=true
 pi 10
 EOF
 EXPECT=<<EOF

--- a/test/db/analysis/x86_64
+++ b/test/db/analysis/x86_64
@@ -2473,7 +2473,6 @@ e asm.arch=x86
 e asm.bytes=true
 e asm.bits=64
 e analysis.jmp.mid=false
-e io.cache=true
 wx b8210000c1ebfdbb2c000000000
 af
 afi
@@ -2536,7 +2535,6 @@ e asm.bits=64
 e analysis.nopskip=false
 e asm.bb.middle=true
 e analysis.jmp.mid=true
-e io.cache=true
 "(show_fcn bin; wx $0; af-*; af; afi; ?e; afb; ?e; pdr; ?e; agf; ?e; e asm.bb.middle=true; pdf; ?e; e asm.bb.middle=false; pdf)"
 .(show_fcn b8210000c1ebfdbb2c000000cc)
 ?e
@@ -2904,7 +2902,6 @@ CMDS=<<EOF
 e asm.arch=x86
 e asm.bytes=true
 e asm.bits=64
-e io.cache=true
 wx b821c10010ebf9
 s 3
 af; afi; ?e; afb; ?e; pdr; ?e; agf; ?e; pdf
@@ -3001,7 +2998,6 @@ CMDS=<<EOF
 e asm.arch=x86
 e asm.bytes=true
 e asm.bits=64
-e io.cache=true
 wx b821c10010ebf9
 s 0
 af; af-*
@@ -3058,7 +3054,6 @@ CMDS=<<EOF
 e asm.arch=x86
 e asm.bits=64
 e analysis.jmp.mid=true
-e io.cache=true
 e analysis.nopskip=false
 wx 0f1f440000b8210000c1ebfdbb2c000000ebf0
 af
@@ -3150,7 +3145,6 @@ e emu.write=true
 e asm.bytes=0
 e asm.cmt.col=20
 e asm.lines.bb=false
-e io.cache=true
 aeim
 s 0x00402aee
 pd 10~?int LoadStringA

--- a/test/db/cmd/cmd_aecb
+++ b/test/db/cmd/cmd_aecb
@@ -5,7 +5,6 @@ e asm.emu=true
 e asm.bits=64
 e asm.arch=x86
 e emu.write=true
-e io.cache=true
 s loc.main
 aei
 aeim
@@ -36,7 +35,6 @@ e asm.emu=true
 e asm.bits=64
 e asm.arch=x86
 e emu.write=true
-e io.cache=true
 s loc.main
 aei
 aeim

--- a/test/db/cmd/cmd_aesb
+++ b/test/db/cmd/cmd_aesb
@@ -5,7 +5,6 @@ e asm.emu=true
 e asm.bits=64
 e asm.arch=x86
 e emu.write=true
-e io.cache=true
 s loc.main
 aei
 aeim

--- a/test/db/cmd/cmd_graph
+++ b/test/db/cmd/cmd_graph
@@ -313,10 +313,10 @@ NAME=super mario block (#8788)
 FILE=bins/elf/analysis/hello-android-mips
 CMDS=<<EOF
 e emu.str=true
+e io.cache=true
 s 0x0008049c
 af+ 0x0008049c super_mario_fix
 afb+ 0x0008049c 0x0008049c 8
-e io.cache=true
 wx c2a2c2a2c2a2 @ 0x80510
 e bin.str.enc=utf8
 agf

--- a/test/db/cmd/cmd_pd2
+++ b/test/db/cmd/cmd_pd2
@@ -333,9 +333,9 @@ NAME=esil func cmt refline
 FILE=bins/elf/ls
 CMDS=<<EOF
 e asm.bytes=true
-e io.cache=true
 e asm.emu=true
 e asm.types=0
+e io.cache=true
 wx 7d0a7f08eb00 @ 0x5b02
 pd 4 @ 0x5b02
 EOF
@@ -353,7 +353,6 @@ CMDS=<<EOF
 e asm.bytes=true
 e asm.arch=x86
 e asm.bits=64
-e io.cache=true
 wx 488b4608
 td "struct ms { char b[8]; int member1; int member2; };"
 aht ms.member1

--- a/test/db/cmd/cmd_pdr
+++ b/test/db/cmd/cmd_pdr
@@ -60,7 +60,6 @@ e asm.arch=x86
 e asm.bits=64
 e analysis.nopskip=false
 e analysis.jmp.mid=true
-e io.cache=true
 wx 0f1f440000b8210000c1ebfdbb2c000000ebf0
 af
 e asm.bb.middle=true

--- a/test/db/cmd/cmd_w
+++ b/test/db/cmd/cmd_w
@@ -117,8 +117,8 @@ RUN
 
 NAME=wc
 FILE==
-ARGS=-e io.cache=true
 CMDS=<<EOF
+e io.cache=true
 wx 010203
 wc
 wx 555555 @ 2

--- a/test/db/cmd/midbb
+++ b/test/db/cmd/midbb
@@ -89,7 +89,6 @@ e asm.arch=x86
 e asm.bits=64
 e analysis.nopskip=false
 e analysis.jmp.mid=true
-e io.cache=true
 wx 0f1f440000b8210000c1ebfdbb2c000000ebf0
 af
 ?e
@@ -528,7 +527,6 @@ e asm.arch=x86
 e asm.bits=64
 e analysis.nopskip=false
 e analysis.jmp.mid=true
-e io.cache=true
 wx 0f1f440000b8210000c1ebfdbb2c000000ebf0
 af
 e asm.bb.middle=true
@@ -563,7 +561,6 @@ e asm.arch=x86
 e asm.bits=64
 e analysis.nopskip=false
 e analysis.jmp.mid=true
-e io.cache=true
 wx 0f1f440000b8210000c1ebfdbb2c000000ebf0
 af
 e asm.bb.middle=true

--- a/test/db/cmd/write
+++ b/test/db/cmd/write
@@ -103,7 +103,7 @@ RUN
 # wao : modify operation of current opcode
 NAME=wao nop (x86)
 FILE=malloc://1024
-ARGS=-a x86 -b 64 -e io.cache=1
+ARGS=-a x86 -b 64
 CMDS=<<EOF
 wx 31ed4989d15e4889e24883e4f0
 pi 5
@@ -125,7 +125,7 @@ RUN
 # wao : modify operation of current opcode
 NAME=wao trap (x86)
 FILE=malloc://1024
-ARGS=-a x86 -b 64 -e io.cache=1
+ARGS=-a x86 -b 64
 CMDS=<<EOF
 wx 31ed4989d15e4889e24883e4f0
 pi 5
@@ -147,7 +147,7 @@ RUN
 # wao : modify operation of current opcode, on ARM
 NAME=wao nop (arm)
 FILE=malloc://1024
-ARGS=-a arm -b 32 -e io.cache=1
+ARGS=-a arm -b 32
 CMDS=<<EOF
 wx 24c09fe500b0a0e304109de40d20a0e1
 pi 4
@@ -168,7 +168,7 @@ RUN
 # wao : modify operation of current opcode, on ARM
 NAME=wao trap (arm)
 FILE=malloc://1024
-ARGS=-a arm -b 32 -e io.cache=1
+ARGS=-a arm -b 32
 CMDS=<<EOF
 wx 24c09fe500b0a0e304109de40d20a0e1
 pi 4
@@ -308,7 +308,6 @@ CMDS=<<EOF
 mkdir .tmp
 cp -f bins/pe/b.exe .tmp/.b.exe.orig
 cp -f bins/pe/b.exe .tmp/.b.exe.new
-e io.cache=true
 o+ .tmp/.b.exe.new
 wx ff
 wci

--- a/test/db/esil/arm_16
+++ b/test/db/esil/arm_16
@@ -1,9 +1,9 @@
 NAME=adr emulation
 FILE=malloc://0x200
 CMDS=<<EOF
-e io.cache=true
 e asm.arch=arm
 e asm.bits=16
+e io.cache=true
 s 0x0008735c
 wx 30a1
 w rizin_emulation\x00 @ 0x87420
@@ -21,7 +21,6 @@ RUN
 NAME=clz
 FILE=malloc://0x200
 CMDS=<<EOF
-e io.cache=true
 e asm.arch=arm
 e asm.bits=16
 wa clz r0, r1
@@ -46,10 +45,10 @@ RUN
 NAME=addw emulation
 FILE=malloc://0x200
 CMDS=<<EOF
-e io.cache=true
 e asm.arch=arm
 e asm.bits=16
-s 0x00088a1c 
+e io.cache=true
+s 0x00088a1c
 wx 0ff26c71
 w addw_emulation\x00 @ 0x8918c
 aei

--- a/test/db/esil/esil
+++ b/test/db/esil/esil
@@ -119,7 +119,6 @@ ARGS=-a mips
 CMDS=<<EOF
 e cfg.bigendian=false
 aeim
-e io.cache=true
 "ae 0x69686766,0x00100000,=[4]"
 psz @0x00100000
 EOF
@@ -134,7 +133,6 @@ ARGS=-a mips
 CMDS=<<EOF
 e cfg.bigendian=true
 aeim
-e io.cache=true
 "ae 0x69686766,0x00100000,=[4]"
 psz @0x00100000
 EOF
@@ -149,7 +147,6 @@ BROKEN=1
 CMDS=<<EOF
 e cfg.bigendian=true
 aeim
-e io.cache=true
 "ae 0x69686766,0x00100000,=[4]"
 psz @0x00100000
 EOF
@@ -164,7 +161,6 @@ ARGS=-a arm -b 32
 CMDS=<<EOF
 e cfg.bigendian=true
 aeim
-e io.cache=true
 ar r0=0x00100000
 ar r1=0x69686766
 "ae r1,1,r0,=[*]"
@@ -181,7 +177,6 @@ ARGS=-a arm -b 64
 CMDS=<<EOF
 e cfg.bigendian=true
 aeim
-e io.cache=true
 ar x0=0x00100000
 ar x1=0x69686766
 "ae x1,1,x0,=[*]"
@@ -198,7 +193,6 @@ ARGS=-a arm -b 32
 CMDS=<<EOF
 e cfg.bigendian=false
 aeim
-e io.cache=true
 ar r0=0x00100000
 ar r1=0x69686766
 "ae r1,1,r0,=[*]"
@@ -215,7 +209,6 @@ ARGS=-a arm -b 64
 CMDS=<<EOF
 e cfg.bigendian=false
 aeim
-e io.cache=true
 ar x0=0x00100000
 ar x1=0x69686766
 "ae x1,1,x0,=[*]"
@@ -232,7 +225,6 @@ ARGS=-a arm -b 64
 CMDS=<<EOF
 e cfg.bigendian=false
 aeim
-e io.cache=true
 ar x0=0x00100000
 ar x1=0x69686766
 "ae x1,0xffffffff,x0,=[*]"
@@ -292,7 +284,7 @@ RUN
 NAME=rep stosq
 FILE=bins/elf/analysis/x64-rep-stosq
 CMDS=<<EOF
-e io.cache=1
+e io.cache=true
 aei
 aeip
 3aes
@@ -314,7 +306,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=signext 8 32 64 
+NAME=signext 8 32 64
 FILE==
 CMDS="ae 8,0x80,~,8,0x70,~,32,0x80000000,~,64,0x80000000,~"
 EXPECT=<<EOF

--- a/test/db/esil/x86_32
+++ b/test/db/esil/x86_32
@@ -1205,7 +1205,6 @@ FILE=bins/other/tmctf_re100
 ARGS=-a x86 -b 32
 CMDS=<<EOF
 e io.va=true
-e io.cache=true
 s 0x278
 aei
 aeim
@@ -2337,7 +2336,6 @@ FILE==
 CMDS=<<EOF
 e asm.arch=x86
 e asm.bits=32
-e io.cache=true
 wx 0fab0424
 pdj 1~{}
 EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Now that binary loading uses virtual files, some of the `io.cache=true` calls in our tests are unnecessary. Remove them.

**Test plan**

CI is green