### PR TITLE
Add user pointer to RzDebug Plugins and refactor GDB to use it

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -679,7 +679,7 @@ static bool cb_asmbits(void *user, void *data) {
 		rz_debug_set_arch(core->dbg, core->analysis->cur->arch, bits);
 		bool load_from_debug = rz_config_get_b(core->config, "cfg.debug");
 		if (load_from_debug) {
-			if (core->dbg->h && core->dbg->h->reg_profile) {
+			if (core->dbg->cur && core->dbg->cur->reg_profile) {
 // XXX. that should depend on the plugin, not the host os
 #if __WINDOWS__
 #if !defined(_WIN64)
@@ -688,7 +688,7 @@ static bool cb_asmbits(void *user, void *data) {
 				core->dbg->bits = RZ_SYS_BITS_64;
 #endif
 #endif
-				char *rp = core->dbg->h->reg_profile(core->dbg);
+				char *rp = core->dbg->cur->reg_profile(core->dbg);
 				rz_reg_set_profile_string(core->dbg->reg, rp);
 				rz_reg_set_profile_string(core->analysis->reg, rp);
 				free(rp);

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -580,7 +580,7 @@ RZ_IPI void rz_core_debug_attach(RzCore *core, int pid) {
 		}
 	}
 	rz_debug_select(core->dbg, core->dbg->pid, core->dbg->tid);
-	rz_config_set_i(core->config, "dbg.swstep", (core->dbg->h && !core->dbg->h->canstep));
+	rz_config_set_i(core->config, "dbg.swstep", (core->dbg->cur && !core->dbg->cur->canstep));
 	rz_core_cmdf(core, "R! \"pid %d\"", core->dbg->pid);
 }
 
@@ -601,7 +601,7 @@ RZ_API RzCmdStatus rz_core_debug_plugin_print(RzDebug *dbg, RzDebugPlugin *plugi
 	}
 	case RZ_OUTPUT_MODE_STANDARD: {
 		rz_cons_printf("%d  %s  %s %s%s\n",
-			count, (plugin == dbg->h) ? "dbg" : "---",
+			count, (plugin == dbg->cur) ? "dbg" : "---",
 			plugin->name, spaces, plugin->license);
 		break;
 	}

--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -1187,7 +1187,7 @@ RZ_API RzCoreFile *rz_core_file_open(RzCore *r, const char *file, int flags, ut6
 	rz_list_append(r->files, fh);
 	if (rz_config_get_b(r->config, "cfg.debug")) {
 		bool swstep = true;
-		if (r->dbg->h && r->dbg->h->canstep) {
+		if (r->dbg->cur && r->dbg->cur->canstep) {
 			swstep = false;
 		}
 		rz_config_set_i(r->config, "dbg.swstep", swstep);

--- a/librz/core/cmd.c
+++ b/librz/core/cmd.c
@@ -3548,7 +3548,7 @@ RZ_API int rz_core_cmd_foreach3(RzCore *core, const char *cmd, char *each) { // 
 		}
 	} break;
 	case 'M':
-		if (dbg && dbg->h && dbg->maps) {
+		if (dbg && dbg->cur && dbg->maps) {
 			RzDebugMap *map;
 			rz_list_foreach (dbg->maps, iter, map) {
 				rz_core_seek(core, map->addr, true);
@@ -3559,10 +3559,10 @@ RZ_API int rz_core_cmd_foreach3(RzCore *core, const char *cmd, char *each) { // 
 		break;
 	case 't':
 		// iterate over all threads
-		if (dbg && dbg->h && dbg->h->threads) {
+		if (dbg && dbg->cur && dbg->cur->threads) {
 			int origpid = dbg->pid;
 			RzDebugPid *p;
-			list = dbg->h->threads(dbg, dbg->pid);
+			list = dbg->cur->threads(dbg, dbg->pid);
 			if (!list) {
 				return false;
 			}
@@ -3977,8 +3977,8 @@ RZ_API int rz_core_cmd_foreach(RzCore *core, const char *cmd, char *each) {
 	{
 		RzDebugPid *p;
 		int pid = core->dbg->pid;
-		if (core->dbg->h && core->dbg->h->pids) {
-			RzList *list = core->dbg->h->pids(core->dbg, RZ_MAX(0, pid));
+		if (core->dbg->cur && core->dbg->cur->pids) {
+			RzList *list = core->dbg->cur->pids(core->dbg, RZ_MAX(0, pid));
 			rz_list_foreach (list, iter, p) {
 				rz_cons_printf("# PID %d\n", p->pid);
 				rz_debug_select(core->dbg, p->pid, p->pid);
@@ -5886,7 +5886,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_dbgmap_stmt) {
 	TSNode command = ts_node_named_child(node, 0);
 	RzDebug *dbg = core->dbg;
 	RzCmdStatus res = RZ_CMD_STATUS_OK;
-	if (dbg && dbg->h && dbg->maps) {
+	if (dbg && dbg->cur && dbg->maps) {
 		RzDebugMap *map;
 		RzListIter *iter;
 		rz_list_foreach (dbg->maps, iter, map) {
@@ -5938,10 +5938,10 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_threads_stmt) {
 	TSNode command = ts_node_named_child(node, 0);
 	RzDebug *dbg = core->dbg;
 	RzCmdStatus res = RZ_CMD_STATUS_OK;
-	if (dbg && dbg->h && dbg->h->threads) {
+	if (dbg && dbg->cur && dbg->cur->threads) {
 		int origtid = dbg->tid;
 		RzDebugPid *p;
-		RzList *list = dbg->h->threads(dbg, dbg->pid);
+		RzList *list = dbg->cur->threads(dbg, dbg->pid);
 		if (!list) {
 			return RZ_CMD_STATUS_INVALID;
 		}

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -7991,8 +7991,8 @@ static int cmd_analysis_all(RzCore *core, const char *input) {
 			rz_core_task_yield(&core->tasks);
 			// Run pending analysis immediately after analysis
 			// Usefull when running commands with ";" or via rizin -c,-i
-			dh_orig = core->dbg->h
-				? strdup(core->dbg->h->name)
+			dh_orig = core->dbg->cur
+				? strdup(core->dbg->cur->name)
 				: strdup("esil");
 			if (core->io && core->io->desc && core->io->desc->plugin && !core->io->desc->plugin->isdbg) {
 				//use dh_origin if we are debugging

--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -5074,7 +5074,7 @@ RZ_IPI int rz_cmd_debug(void *data, const char *input) {
 		rz_core_debug_esil(core, input + 1);
 		break;
 	case 'g': // "dg"
-		if (core->dbg->h && core->dbg->h->gcore) {
+		if (core->dbg->cur && core->dbg->cur->gcore) {
 			if (core->dbg->pid == -1) {
 				eprintf("Not debugging, can't write core.\n");
 				break;
@@ -5084,7 +5084,7 @@ RZ_IPI int rz_cmd_debug(void *data, const char *input) {
 			rz_file_rm(corefile);
 			RzBuffer *dst = rz_buf_new_file(corefile, O_RDWR | O_CREAT, 0644);
 			if (dst) {
-				if (!core->dbg->h->gcore(core->dbg, dst)) {
+				if (!core->dbg->cur->gcore(core->dbg, dst)) {
 					eprintf("dg: coredump failed\n");
 				}
 				rz_buf_free(dst);
@@ -5149,8 +5149,8 @@ RZ_IPI int rz_cmd_debug(void *data, const char *input) {
 				core->dbg->session = NULL;
 			}
 			// Kill debugee and all child processes
-			if (core->dbg && core->dbg->h && core->dbg->h->pids && core->dbg->pid != -1) {
-				list = core->dbg->h->pids(core->dbg, core->dbg->pid);
+			if (core->dbg && core->dbg->cur && core->dbg->cur->pids && core->dbg->pid != -1) {
+				list = core->dbg->cur->pids(core->dbg, core->dbg->pid);
 				if (list) {
 					rz_list_foreach (list, iter, p) {
 						rz_debug_kill(core->dbg, p->pid, p->pid, SIGKILL);

--- a/librz/core/cmd_print.c
+++ b/librz/core/cmd_print.c
@@ -6786,8 +6786,8 @@ RZ_IPI int rz_cmd_print(void *data, const char *input) {
 			RzListIter *iter;
 			RzDebugPid *pid;
 			const char *arg = strchr(input, ' ');
-			RzList *pids = (core->dbg->h && core->dbg->h->pids)
-				? core->dbg->h->pids(core->dbg, 0)
+			RzList *pids = (core->dbg->cur && core->dbg->cur->pids)
+				? core->dbg->cur->pids(core->dbg, 0)
 				: NULL;
 			if (arg && *++arg) {
 				rz_list_foreach (pids, iter, pid) {

--- a/librz/core/panels.c
+++ b/librz/core/panels.c
@@ -3529,8 +3529,8 @@ int __symbols_cb(void *user) {
 
 int __program_cb(void *user) {
 	RzCore *core = (RzCore *)user;
-	char *dh_orig = core->dbg->h
-		? strdup(core->dbg->h->name)
+	char *dh_orig = core->dbg->cur
+		? strdup(core->dbg->cur->name)
 		: strdup("esil");
 	rz_core_analysis_all(core);
 	rz_core_analysis_everything(core, false, dh_orig);

--- a/librz/core/rtr.c
+++ b/librz/core/rtr.c
@@ -324,10 +324,10 @@ static int rz_core_rtr_gdb_cb(libgdbr_t *g, void *core_ptr, const char *cmd,
 			case 't':
 				switch (cmd[3]) {
 				case '\0': // dpt
-					if (!core->dbg->h->threads) {
+					if (!core->dbg->cur->threads) {
 						return -1;
 					}
-					if (!(list = core->dbg->h->threads(core->dbg, core->dbg->pid))) {
+					if (!(list = core->dbg->cur->threads(core->dbg, core->dbg->pid))) {
 						return -1;
 					}
 					memset(out_buf, 0, max_len);

--- a/librz/debug/ddesc.c
+++ b/librz/debug/ddesc.c
@@ -27,43 +27,43 @@ RZ_API void rz_debug_desc_free(RzDebugDesc *p) {
 }
 
 RZ_API int rz_debug_desc_open(RzDebug *dbg, const char *path) {
-	if (dbg && dbg->h && dbg->h->desc.open) {
-		return dbg->h->desc.open(path);
+	if (dbg && dbg->cur && dbg->cur->desc.open) {
+		return dbg->cur->desc.open(path);
 	}
 	return false;
 }
 
 RZ_API int rz_debug_desc_close(RzDebug *dbg, int fd) {
-	if (dbg && dbg->h && dbg->h->desc.close) {
-		return dbg->h->desc.close(fd);
+	if (dbg && dbg->cur && dbg->cur->desc.close) {
+		return dbg->cur->desc.close(fd);
 	}
 	return false;
 }
 
 RZ_API int rz_debug_desc_dup(RzDebug *dbg, int fd, int newfd) {
-	if (dbg && dbg->h && dbg->h->desc.dup) {
-		return dbg->h->desc.dup(fd, newfd);
+	if (dbg && dbg->cur && dbg->cur->desc.dup) {
+		return dbg->cur->desc.dup(fd, newfd);
 	}
 	return false;
 }
 
 RZ_API int rz_debug_desc_read(RzDebug *dbg, int fd, ut64 addr, int len) {
-	if (dbg && dbg->h && dbg->h->desc.read) {
-		return dbg->h->desc.read(fd, addr, len);
+	if (dbg && dbg->cur && dbg->cur->desc.read) {
+		return dbg->cur->desc.read(fd, addr, len);
 	}
 	return false;
 }
 
 RZ_API int rz_debug_desc_seek(RzDebug *dbg, int fd, ut64 addr) {
-	if (dbg && dbg->h && dbg->h->desc.seek) {
-		return dbg->h->desc.seek(fd, addr);
+	if (dbg && dbg->cur && dbg->cur->desc.seek) {
+		return dbg->cur->desc.seek(fd, addr);
 	}
 	return false;
 }
 
 RZ_API int rz_debug_desc_write(RzDebug *dbg, int fd, ut64 addr, int len) {
-	if (dbg && dbg->h && dbg->h->desc.write) {
-		return dbg->h->desc.write(fd, addr, len);
+	if (dbg && dbg->cur && dbg->cur->desc.write) {
+		return dbg->cur->desc.write(fd, addr, len);
 	}
 	return false;
 }
@@ -79,8 +79,8 @@ RZ_API int rz_debug_desc_list(RzDebug *dbg, int rad) {
 			dbg->cb_printf("TODO \n");
 		}
 	} else {
-		if (dbg && dbg->h && dbg->h->desc.list) {
-			list = dbg->h->desc.list(dbg->pid);
+		if (dbg && dbg->cur && dbg->cur->desc.list) {
+			list = dbg->cur->desc.list(dbg->pid);
 			rz_list_foreach (list, iter, p) {
 				dbg->cb_printf("%i 0x%" PFMT64x " %c%c%c %s\n", p->fd, p->off,
 					(p->perm & RZ_PERM_R) ? 'r' : '-',

--- a/librz/debug/debug.c
+++ b/librz/debug/debug.c
@@ -15,13 +15,13 @@ RZ_LIB_VERSION(rz_debug);
 #define DBG_BUF_SIZE 512
 
 RZ_API RzDebugInfo *rz_debug_info(RzDebug *dbg, const char *arg) {
-	if (!dbg || !dbg->h || !dbg->h->info) {
+	if (!dbg || !dbg->cur || !dbg->cur->info) {
 		return NULL;
 	}
 	if (dbg->pid < 0) {
 		return NULL;
 	}
-	return dbg->h->info(dbg, arg);
+	return dbg->cur->info(dbg, arg);
 }
 
 RZ_API void rz_debug_info_free(RzDebugInfo *rdi) {
@@ -47,8 +47,8 @@ RZ_API void rz_debug_bp_update(RzDebug *dbg) {
 }
 
 static int rz_debug_drx_at(RzDebug *dbg, ut64 addr) {
-	if (dbg && dbg->h && dbg->h->drx) {
-		return dbg->h->drx(dbg, 0, addr, 0, 0, 0, DRX_API_GET_BP);
+	if (dbg && dbg->cur && dbg->cur->drx) {
+		return dbg->cur->drx(dbg, 0, addr, 0, 0, 0, DRX_API_GET_BP);
 	}
 	return -1;
 }
@@ -383,7 +383,8 @@ RZ_API RzDebug *rz_debug_new(int hard) {
 	dbg->cb_printf = (void *)printf;
 	dbg->reg = rz_reg_new();
 	dbg->num = rz_num_new(rz_debug_num_callback, rz_debug_str_callback, dbg);
-	dbg->h = NULL;
+	dbg->cur = NULL;
+	dbg->plugin_data = NULL;
 	dbg->threads = NULL;
 	dbg->hitinfo = 1;
 	/* TODO: needs a redesign? */
@@ -439,8 +440,8 @@ RZ_API RzDebug *rz_debug_free(RzDebug *dbg) {
 
 RZ_API int rz_debug_attach(RzDebug *dbg, int pid) {
 	int ret = false;
-	if (dbg && dbg->h && dbg->h->attach) {
-		ret = dbg->h->attach(dbg, pid);
+	if (dbg && dbg->cur && dbg->cur->attach) {
+		ret = dbg->cur->attach(dbg, pid);
 		if (ret != -1) {
 			rz_debug_select(dbg, pid, ret); //dbg->pid, dbg->tid);
 		}
@@ -450,22 +451,22 @@ RZ_API int rz_debug_attach(RzDebug *dbg, int pid) {
 
 /* stop execution of child process */
 RZ_API int rz_debug_stop(RzDebug *dbg) {
-	if (dbg && dbg->h && dbg->h->stop) {
-		return dbg->h->stop(dbg);
+	if (dbg && dbg->cur && dbg->cur->stop) {
+		return dbg->cur->stop(dbg);
 	}
 	return false;
 }
 
 RZ_API bool rz_debug_set_arch(RzDebug *dbg, const char *arch, int bits) {
-	if (arch && dbg && dbg->h) {
+	if (arch && dbg && dbg->cur) {
 		switch (bits) {
 		case 27:
-			if (dbg->h->bits == 27) {
+			if (dbg->cur->bits == 27) {
 				dbg->bits = 27;
 			}
 			break;
 		case 32:
-			if (dbg->h->bits & RZ_SYS_BITS_32) {
+			if (dbg->cur->bits & RZ_SYS_BITS_32) {
 				dbg->bits = RZ_SYS_BITS_32;
 			}
 			break;
@@ -473,12 +474,12 @@ RZ_API bool rz_debug_set_arch(RzDebug *dbg, const char *arch, int bits) {
 			dbg->bits = RZ_SYS_BITS_64;
 			break;
 		}
-		if (!dbg->h->bits) {
-			dbg->bits = dbg->h->bits;
-		} else if (!(dbg->h->bits & dbg->bits)) {
-			dbg->bits = dbg->h->bits & RZ_SYS_BITS_64;
+		if (!dbg->cur->bits) {
+			dbg->bits = dbg->cur->bits;
+		} else if (!(dbg->cur->bits & dbg->bits)) {
+			dbg->bits = dbg->cur->bits & RZ_SYS_BITS_64;
 			if (!dbg->bits) {
-				dbg->bits = dbg->h->bits & RZ_SYS_BITS_32;
+				dbg->bits = dbg->cur->bits & RZ_SYS_BITS_32;
 			}
 			if (!dbg->bits) {
 				dbg->bits = RZ_SYS_BITS_32;
@@ -571,8 +572,8 @@ RZ_API int rz_debug_start(RzDebug *dbg, const char *cmd) {
 
 RZ_API int rz_debug_detach(RzDebug *dbg, int pid) {
 	int ret = 0;
-	if (dbg->h && dbg->h->detach) {
-		ret = dbg->h->detach(dbg, pid);
+	if (dbg->cur && dbg->cur->detach) {
+		ret = dbg->cur->detach(dbg, pid);
 		if (dbg->pid == pid) {
 			dbg->pid = -1;
 			dbg->tid = -1;
@@ -605,7 +606,7 @@ RZ_API bool rz_debug_select(RzDebug *dbg, int pid, int tid) {
 		return false;
 	}
 
-	if (dbg->h && dbg->h->select && !dbg->h->select(dbg, pid, tid)) {
+	if (dbg->cur && dbg->cur->select && !dbg->cur->select(dbg, pid, tid)) {
 		return false;
 	}
 
@@ -695,8 +696,8 @@ RZ_API RzDebugReasonType rz_debug_wait(RzDebug *dbg, RzBreakpointItem **bp) {
 	}
 
 	/* if our debugger plugin has wait */
-	if (dbg->h && dbg->h->wait) {
-		reason = dbg->h->wait(dbg, dbg->pid);
+	if (dbg->cur && dbg->cur->wait) {
+		reason = dbg->cur->wait(dbg, dbg->pid);
 		if (reason == RZ_DEBUG_REASON_DEAD) {
 			eprintf("\n==> Process finished\n\n");
 			RzEventDebugProcessFinished event = {
@@ -911,7 +912,7 @@ RZ_API int rz_debug_step_hard(RzDebug *dbg, RzBreakpointItem **pb) {
 		}
 	}
 
-	if (!dbg->h->step(dbg)) {
+	if (!dbg->cur->step(dbg)) {
 		return false;
 	}
 
@@ -951,7 +952,7 @@ RZ_API int rz_debug_step(RzDebug *dbg, int steps) {
 		steps = 1;
 	}
 
-	if (!dbg || !dbg->h) {
+	if (!dbg || !dbg->cur) {
 		return steps_taken;
 	}
 
@@ -1027,14 +1028,14 @@ RZ_API int rz_debug_step_over(RzDebug *dbg, int steps) {
 		steps = 1;
 	}
 
-	if (dbg->h && dbg->h->step_over) {
+	if (dbg->cur && dbg->cur->step_over) {
 		for (; steps_taken < steps; steps_taken++) {
 			if (dbg->session && dbg->recoil_mode == RZ_DBG_RECOIL_NONE) {
 				dbg->session->cnum++;
 				dbg->session->maxcnum++;
 				rz_debug_trace_ins_before(dbg);
 			}
-			if (!dbg->h->step_over(dbg)) {
+			if (!dbg->cur->step_over(dbg)) {
 				return steps_taken;
 			}
 			if (dbg->session && dbg->recoil_mode == RZ_DBG_RECOIL_NONE) {
@@ -1168,13 +1169,13 @@ repeat:
 		}
 		reason = dbg->session->reasontype;
 		bp = dbg->session->bp;
-	} else if (dbg->h && dbg->h->cont) {
+	} else if (dbg->cur && dbg->cur->cont) {
 		/* handle the stage-2 of breakpoints */
 		if (!rz_debug_recoil(dbg, RZ_DBG_RECOIL_CONTINUE)) {
 			return 0;
 		}
 		/* tell the inferior to go! */
-		ret = dbg->h->cont(dbg, dbg->pid, dbg->tid, sig);
+		ret = dbg->cur->cont(dbg, dbg->pid, dbg->tid, sig);
 		//XXX(jjd): why? //dbg->reason.signum = 0;
 		reason = rz_debug_wait(dbg, &bp);
 	} else {
@@ -1491,10 +1492,10 @@ static int show_syscall(RzDebug *dbg, const char *sysreg) {
 
 RZ_API int rz_debug_continue_syscalls(RzDebug *dbg, int *sc, int n_sc) {
 	int i, err, reg, ret = false;
-	if (!dbg || !dbg->h || rz_debug_is_dead(dbg)) {
+	if (!dbg || !dbg->cur || rz_debug_is_dead(dbg)) {
 		return false;
 	}
-	if (!dbg->h->contsc) {
+	if (!dbg->cur->contsc) {
 		/* user-level syscall tracing */
 		rz_debug_continue_until_optype(dbg, RZ_ANALYSIS_OP_TYPE_SWI, 0);
 		return show_syscall(dbg, "A0");
@@ -1522,7 +1523,7 @@ RZ_API int rz_debug_continue_syscalls(RzDebug *dbg, int *sc, int n_sc) {
 		 * return value after... */
 		rz_debug_step(dbg, 1);
 #endif
-		dbg->h->contsc(dbg, dbg->pid, 0); // TODO handle return value
+		dbg->cur->contsc(dbg, dbg->pid, 0); // TODO handle return value
 		// wait until continuation
 		reason = rz_debug_wait(dbg, NULL);
 		if (reason == RZ_DEBUG_REASON_DEAD || rz_debug_is_dead(dbg)) {
@@ -1567,8 +1568,8 @@ RZ_API int rz_debug_continue_syscall(RzDebug *dbg, int sc) {
 // TODO: remove from here? this is code injection!
 RZ_API int rz_debug_syscall(RzDebug *dbg, int num) {
 	bool ret = true;
-	if (dbg->h->contsc) {
-		ret = dbg->h->contsc(dbg, dbg->pid, num);
+	if (dbg->cur->contsc) {
+		ret = dbg->cur->contsc(dbg, dbg->pid, num);
 	}
 	eprintf("TODO: show syscall information\n");
 	/* rz_testc task? ala inject? */
@@ -1579,9 +1580,9 @@ RZ_API int rz_debug_kill(RzDebug *dbg, int pid, int tid, int sig) {
 	if (rz_debug_is_dead(dbg)) {
 		return false;
 	}
-	if (dbg->h && dbg->h->kill) {
+	if (dbg->cur && dbg->cur->kill) {
 		if (pid > 0) {
-			return dbg->h->kill(dbg, pid, tid, sig);
+			return dbg->cur->kill(dbg, pid, tid, sig);
 		}
 		return -1;
 	}
@@ -1590,40 +1591,40 @@ RZ_API int rz_debug_kill(RzDebug *dbg, int pid, int tid, int sig) {
 }
 
 RZ_API RzList *rz_debug_frames(RzDebug *dbg, ut64 at) {
-	if (dbg && dbg->h && dbg->h->frames) {
-		return dbg->h->frames(dbg, at);
+	if (dbg && dbg->cur && dbg->cur->frames) {
+		return dbg->cur->frames(dbg, at);
 	}
 	return NULL;
 }
 
 /* TODO: Implement fork and clone */
 RZ_API int rz_debug_child_fork(RzDebug *dbg) {
-	//if (dbg && dbg->h && dbg->h->frames)
-	//return dbg->h->frames (dbg);
+	//if (dbg && dbg->cur && dbg->cur->frames)
+	//return dbg->cur->frames (dbg);
 	return 0;
 }
 
 RZ_API int rz_debug_child_clone(RzDebug *dbg) {
-	//if (dbg && dbg->h && dbg->h->frames)
-	//return dbg->h->frames (dbg);
+	//if (dbg && dbg->cur && dbg->cur->frames)
+	//return dbg->cur->frames (dbg);
 	return 0;
 }
 
 RZ_API bool rz_debug_is_dead(RzDebug *dbg) {
-	if (!dbg->h) {
+	if (!dbg->cur) {
 		return false;
 	}
 	// workaround for debug.io.. should be generic
-	if (!strcmp(dbg->h->name, "io")) {
+	if (!strcmp(dbg->cur->name, "io")) {
 		return false;
 	}
-	bool is_dead = (dbg->pid == -1 && strncmp(dbg->h->name, "gdb", 3)) || (dbg->reason.type == RZ_DEBUG_REASON_DEAD);
-	if (dbg->pid > 0 && dbg->h && dbg->h->kill) {
-		is_dead = !dbg->h->kill(dbg, dbg->pid, false, 0);
+	bool is_dead = (dbg->pid == -1 && strncmp(dbg->cur->name, "gdb", 3)) || (dbg->reason.type == RZ_DEBUG_REASON_DEAD);
+	if (dbg->pid > 0 && dbg->cur && dbg->cur->kill) {
+		is_dead = !dbg->cur->kill(dbg, dbg->pid, false, 0);
 	}
 #if 0
-	if (!is_dead && dbg->h && dbg->h->kill) {
-		is_dead = !dbg->h->kill (dbg, dbg->pid, false, 0);
+	if (!is_dead && dbg->cur && dbg->cur->kill) {
+		is_dead = !dbg->cur->kill (dbg, dbg->pid, false, 0);
 	}
 #endif
 	if (is_dead) {
@@ -1633,28 +1634,28 @@ RZ_API bool rz_debug_is_dead(RzDebug *dbg) {
 }
 
 RZ_API int rz_debug_map_protect(RzDebug *dbg, ut64 addr, int size, int perms) {
-	if (dbg && dbg->h && dbg->h->map_protect) {
-		return dbg->h->map_protect(dbg, addr, size, perms);
+	if (dbg && dbg->cur && dbg->cur->map_protect) {
+		return dbg->cur->map_protect(dbg, addr, size, perms);
 	}
 	return false;
 }
 
 RZ_API void rz_debug_drx_list(RzDebug *dbg) {
-	if (dbg && dbg->h && dbg->h->drx) {
-		dbg->h->drx(dbg, 0, 0, 0, 0, 0, DRX_API_LIST);
+	if (dbg && dbg->cur && dbg->cur->drx) {
+		dbg->cur->drx(dbg, 0, 0, 0, 0, 0, DRX_API_LIST);
 	}
 }
 
 RZ_API int rz_debug_drx_set(RzDebug *dbg, int idx, ut64 addr, int len, int rwx, int g) {
-	if (dbg && dbg->h && dbg->h->drx) {
-		return dbg->h->drx(dbg, idx, addr, len, rwx, g, DRX_API_SET_BP);
+	if (dbg && dbg->cur && dbg->cur->drx) {
+		return dbg->cur->drx(dbg, idx, addr, len, rwx, g, DRX_API_SET_BP);
 	}
 	return false;
 }
 
 RZ_API int rz_debug_drx_unset(RzDebug *dbg, int idx) {
-	if (dbg && dbg->h && dbg->h->drx) {
-		return dbg->h->drx(dbg, idx, 0, -1, 0, 0, DRX_API_REMOVE_BP);
+	if (dbg && dbg->cur && dbg->cur->drx) {
+		return dbg->cur->drx(dbg, idx, 0, -1, 0, 0, DRX_API_REMOVE_BP);
 	}
 	return false;
 }

--- a/librz/debug/dmap.c
+++ b/librz/debug/dmap.c
@@ -299,13 +299,13 @@ RZ_API RzDebugMap *rz_debug_map_new(char *name, ut64 addr, ut64 addr_end, int pe
 }
 
 RZ_API RzList *rz_debug_modules_list(RzDebug *dbg) {
-	return (dbg && dbg->h && dbg->h->modules_get) ? dbg->h->modules_get(dbg) : NULL;
+	return (dbg && dbg->cur && dbg->cur->modules_get) ? dbg->cur->modules_get(dbg) : NULL;
 }
 
 RZ_API bool rz_debug_map_sync(RzDebug *dbg) {
 	bool ret = false;
-	if (dbg && dbg->h && dbg->h->map_get) {
-		RzList *newmaps = dbg->h->map_get(dbg);
+	if (dbg && dbg->cur && dbg->cur->map_get) {
+		RzList *newmaps = dbg->cur->map_get(dbg);
 		if (newmaps) {
 			rz_list_free(dbg->maps);
 			dbg->maps = newmaps;
@@ -317,8 +317,8 @@ RZ_API bool rz_debug_map_sync(RzDebug *dbg) {
 
 RZ_API RzDebugMap *rz_debug_map_alloc(RzDebug *dbg, ut64 addr, int size, bool thp) {
 	RzDebugMap *map = NULL;
-	if (dbg && dbg->h && dbg->h->map_alloc) {
-		map = dbg->h->map_alloc(dbg, addr, size, thp);
+	if (dbg && dbg->cur && dbg->cur->map_alloc) {
+		map = dbg->cur->map_alloc(dbg, addr, size, thp);
 	}
 	return map;
 }
@@ -326,8 +326,8 @@ RZ_API RzDebugMap *rz_debug_map_alloc(RzDebug *dbg, ut64 addr, int size, bool th
 RZ_API int rz_debug_map_dealloc(RzDebug *dbg, RzDebugMap *map) {
 	bool ret = false;
 	ut64 addr = map->addr;
-	if (dbg && dbg->h && dbg->h->map_dealloc) {
-		if (dbg->h->map_dealloc(dbg, addr, map->size)) {
+	if (dbg && dbg->cur && dbg->cur->map_dealloc) {
+		if (dbg->cur->map_dealloc(dbg, addr, map->size)) {
 			ret = true;
 		}
 	}

--- a/librz/debug/dreg.c
+++ b/librz/debug/dreg.c
@@ -8,7 +8,7 @@
 
 RZ_API int rz_debug_reg_sync(RzDebug *dbg, int type, int write) {
 	int i, n, size;
-	if (!dbg || !dbg->reg || !dbg->h) {
+	if (!dbg || !dbg->reg || !dbg->cur) {
 		return false;
 	}
 	// There's no point in syncing a dead target
@@ -16,10 +16,10 @@ RZ_API int rz_debug_reg_sync(RzDebug *dbg, int type, int write) {
 		return false;
 	}
 	// Check if the functions needed are available
-	if (write && !dbg->h->reg_write) {
+	if (write && !dbg->cur->reg_write) {
 		return false;
 	}
-	if (!write && !dbg->h->reg_read) {
+	if (!write && !dbg->cur->reg_read) {
 		return false;
 	}
 	// Sync all the types sequentially if asked
@@ -46,7 +46,7 @@ RZ_API int rz_debug_reg_sync(RzDebug *dbg, int type, int write) {
 	do {
 		if (write) {
 			ut8 *buf = rz_reg_get_bytes(dbg->reg, i, &size);
-			if (!buf || !dbg->h->reg_write(dbg, i, buf, size)) {
+			if (!buf || !dbg->cur->reg_write(dbg, i, buf, size)) {
 				if (i == RZ_REG_TYPE_GPR) {
 					eprintf("rz_debug_reg: error writing "
 						"registers %d to %d\n",
@@ -68,7 +68,7 @@ RZ_API int rz_debug_reg_sync(RzDebug *dbg, int type, int write) {
 					return false;
 				}
 				//we have already checked dbg->h and dbg->h->reg_read above
-				size = dbg->h->reg_read(dbg, i, buf, bufsize);
+				size = dbg->cur->reg_read(dbg, i, buf, bufsize);
 				// we need to check against zero because reg_read can return false
 				if (size > 0) {
 					rz_reg_set_bytes(dbg->reg, i, buf, size); //RZ_MIN (size, bufsize));

--- a/librz/debug/dsignal.c
+++ b/librz/debug/dsignal.c
@@ -162,8 +162,8 @@ RZ_API int rz_debug_signal_set(RzDebug *dbg, int num, ut64 addr) {
 
 /* TODO rename to _kill_ -> _signal_ */
 RZ_API RzList *rz_debug_kill_list(RzDebug *dbg) {
-	if (dbg->h->kill_list) {
-		return dbg->h->kill_list(dbg);
+	if (dbg->cur->kill_list) {
+		return dbg->cur->kill_list(dbg);
 	}
 	return NULL;
 }
@@ -172,8 +172,8 @@ RZ_API int rz_debug_kill_setup(RzDebug *dbg, int sig, int action) {
 	eprintf("TODO: set signal handlers of child\n");
 	// TODO: must inject code to call signal()
 #if 0
-	if (dbg->h->kill_setup)
-		return dbg->h->kill_setup (dbg, sig, action);
+	if (dbg->cur->kill_setup)
+		return dbg->cur->kill_setup (dbg, sig, action);
 #endif
 	// TODO: implement rz_debug_kill_setup
 	return false;

--- a/librz/debug/p/debug_esil.c
+++ b/librz/debug/p/debug_esil.c
@@ -45,7 +45,7 @@ static int __esil_step(RzDebug *dbg) {
 	return true;
 }
 
-static int __esil_init(RzDebug *dbg) {
+static bool __esil_init(RzDebug *dbg, void **user) {
 	dbg->tid = dbg->pid = 1;
 	// aeim
 	// aei

--- a/librz/debug/p/debug_gdb.c
+++ b/librz/debug/p/debug_gdb.c
@@ -15,86 +15,109 @@ typedef struct {
 #define UNSUPPORTED 0
 #define SUPPORTED   1
 
-static RzIOGdb **origriogdb = NULL;
-static libgdbr_t *desc = NULL;
-static ut8 *reg_buf = NULL;
-static int buf_size = 0;
-static int support_sw_bp = UNKNOWN;
-static int support_hw_bp = UNKNOWN;
+typedef struct rz_debug_gdb_ctx_t {
+	RzIOGdb **origrziogdb;
+	libgdbr_t *desc;
+	ut8 *reg_buf;
+	int buf_size;
+	int support_sw_bp;
+	int support_hw_bp;
+} RzDebugGdbCtx;
+
+static bool rz_debug_gdb_init(RzDebug *dbg, void **user) {
+	RzDebugGdbCtx *ctx = RZ_NEW0(RzDebugGdbCtx);
+	if (!ctx) {
+		return false;
+	}
+	ctx->support_sw_bp = UNKNOWN;
+	ctx->support_hw_bp = UNKNOWN;
+	*user = ctx;
+	return true;
+}
+
+static void rz_debug_gdb_fini(RzDebug *dbg, void *user) {
+	RzDebugGdbCtx *ctx = user;
+	free(ctx);
+}
 
 static int rz_debug_gdb_attach(RzDebug *dbg, int pid);
 static void check_connection(RzDebug *dbg) {
-	if (!desc) {
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
+	if (!ctx->desc) {
 		rz_debug_gdb_attach(dbg, -1);
 	}
 }
 
 static int rz_debug_gdb_step(RzDebug *dbg) {
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
 	check_connection(dbg);
-	if (!desc) {
+	if (!ctx->desc) {
 		return RZ_DEBUG_REASON_UNKNOWN;
 	}
-	gdbr_step(desc, dbg->tid);
+	gdbr_step(ctx->desc, dbg->tid);
 	return true;
 }
 
 static RzList *rz_debug_gdb_threads(RzDebug *dbg, int pid) {
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
 	RzList *list;
-	if ((list = gdbr_threads_list(desc, pid))) {
+	if ((list = gdbr_threads_list(ctx->desc, pid))) {
 		list->free = (RzListFree)&rz_debug_pid_free;
 	}
 	return list;
 }
 
 static RzList *rz_debug_gdb_pids(RzDebug *dbg, int pid) {
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
 	RzList *list;
-	if ((list = gdbr_pids_list(desc, pid))) {
+	if ((list = gdbr_pids_list(ctx->desc, pid))) {
 		list->free = (RzListFree)&rz_debug_pid_free;
 	}
 	return list;
 }
 
 static int rz_debug_gdb_reg_read(RzDebug *dbg, int type, ut8 *buf, int size) {
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
 	int copy_size;
 	int buflen = 0;
 	check_connection(dbg);
-	if (!desc) {
+	if (!ctx->desc) {
 		return RZ_DEBUG_REASON_UNKNOWN;
 	}
-	gdbr_read_registers(desc);
-	if (!desc || !desc->data) {
+	gdbr_read_registers(ctx->desc);
+	if (!ctx->desc || !ctx->desc->data) {
 		return -1;
 	}
 	// read the len of the current area
 	free(rz_reg_get_bytes(dbg->reg, type, &buflen));
-	if (size < desc->data_len) {
+	if (size < ctx->desc->data_len) {
 		eprintf("rz_debug_gdb_reg_read: small buffer %d vs %d\n",
-			(int)size, (int)desc->data_len);
+			(int)size, (int)ctx->desc->data_len);
 		//	return -1;
 	}
-	copy_size = RZ_MIN(desc->data_len, size);
-	buflen = RZ_MAX(desc->data_len, buflen);
-	if (reg_buf) {
+	copy_size = RZ_MIN(ctx->desc->data_len, size);
+	buflen = RZ_MAX(ctx->desc->data_len, buflen);
+	if (ctx->reg_buf) {
 		// if (buf_size < copy_size) { //desc->data_len) {
-		if (buflen > buf_size) { //copy_size) {
-			ut8 *new_buf = realloc(reg_buf, buflen);
+		if (buflen > ctx->buf_size) { //copy_size) {
+			ut8 *new_buf = realloc(ctx->reg_buf, buflen);
 			if (!new_buf) {
 				return -1;
 			}
-			reg_buf = new_buf;
-			buf_size = buflen;
+			ctx->reg_buf = new_buf;
+			ctx->buf_size = buflen;
 		}
 	} else {
-		reg_buf = calloc(buflen, 1);
-		if (!reg_buf) {
+		ctx->reg_buf = calloc(buflen, 1);
+		if (!ctx->reg_buf) {
 			return -1;
 		}
-		buf_size = buflen;
+		ctx->buf_size = buflen;
 	}
 	memset((void *)(volatile void *)buf, 0, size);
-	memcpy((void *)(volatile void *)buf, desc->data, RZ_MIN(copy_size, size));
-	memset((void *)(volatile void *)reg_buf, 0, buflen);
-	memcpy((void *)(volatile void *)reg_buf, desc->data, copy_size);
+	memcpy((void *)(volatile void *)buf, ctx->desc->data, RZ_MIN(copy_size, size));
+	memset((void *)(volatile void *)ctx->reg_buf, 0, buflen);
+	memcpy((void *)(volatile void *)ctx->reg_buf, ctx->desc->data, copy_size);
 #if 0
 	int i;
 	//for(i=0;i<168;i++) {
@@ -104,19 +127,20 @@ static int rz_debug_gdb_reg_read(RzDebug *dbg, int type, ut8 *buf, int size) {
 	}
 	printf("\n");
 #endif
-	return desc->data_len;
+	return ctx->desc->data_len;
 }
 
 static RzList *rz_debug_gdb_map_get(RzDebug *dbg) { //TODO
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
 	check_connection(dbg);
-	if (!desc || desc->pid <= 0) {
+	if (!ctx->desc || ctx->desc->pid <= 0) {
 		return NULL;
 	}
 	RzList *retlist = NULL;
-	if (desc->get_baddr) {
-		desc->get_baddr = false;
+	if (ctx->desc->get_baddr) {
+		ctx->desc->get_baddr = false;
 		ut64 baddr;
-		if ((baddr = gdbr_get_baddr(desc)) != UINT64_MAX) {
+		if ((baddr = gdbr_get_baddr(ctx->desc)) != UINT64_MAX) {
 			if (!(retlist = rz_list_new())) {
 				return NULL;
 			}
@@ -139,7 +163,7 @@ static RzList *rz_debug_gdb_map_get(RzDebug *dbg) { //TODO
 	// fstat info can get file size, but it doesn't work for /proc/pid/maps
 	ut64 buflen = 16384;
 	// If /proc/%d/maps is not valid for gdbserver, we return NULL, as of now
-	snprintf(path, sizeof(path) - 1, "/proc/%d/maps", desc->pid);
+	snprintf(path, sizeof(path) - 1, "/proc/%d/maps", ctx->desc->pid);
 
 #ifdef _MSC_VER
 #define GDB_FILE_OPEN_MODE (_S_IREAD | _S_IWRITE)
@@ -147,15 +171,15 @@ static RzList *rz_debug_gdb_map_get(RzDebug *dbg) { //TODO
 #define GDB_FILE_OPEN_MODE (S_IRUSR | S_IWUSR | S_IXUSR)
 #endif
 
-	if (gdbr_open_file(desc, path, O_RDONLY, GDB_FILE_OPEN_MODE) < 0) {
+	if (gdbr_open_file(ctx->desc, path, O_RDONLY, GDB_FILE_OPEN_MODE) < 0) {
 		return NULL;
 	}
 	if (!(buf = malloc(buflen))) {
-		gdbr_close_file(desc);
+		gdbr_close_file(ctx->desc);
 		return NULL;
 	}
-	if ((ret = gdbr_read_file(desc, buf, buflen - 1)) <= 0) {
-		gdbr_close_file(desc);
+	if ((ret = gdbr_read_file(ctx->desc, buf, buflen - 1)) <= 0) {
+		gdbr_close_file(ctx->desc);
 		free(buf);
 		return NULL;
 	}
@@ -170,12 +194,12 @@ static RzList *rz_debug_gdb_map_get(RzDebug *dbg) { //TODO
 	region1[0] = region2[0] = '0';
 	region1[1] = region2[1] = 'x';
 	if (!(ptr = strtok((char *)buf, "\n"))) {
-		gdbr_close_file(desc);
+		gdbr_close_file(ctx->desc);
 		free(buf);
 		return NULL;
 	}
 	if (!(retlist = rz_list_new())) {
-		gdbr_close_file(desc);
+		gdbr_close_file(ctx->desc);
 		free(buf);
 		return NULL;
 	}
@@ -196,7 +220,7 @@ static RzList *rz_debug_gdb_map_get(RzDebug *dbg) { //TODO
 		} else if (ret != 4) {
 			eprintf("%s: Unable to parse \"%s\"\nContent:\n%s\n",
 				__func__, path, buf);
-			gdbr_close_file(desc);
+			gdbr_close_file(ctx->desc);
 			free(buf);
 			rz_list_free(retlist);
 			return NULL;
@@ -236,7 +260,7 @@ static RzList *rz_debug_gdb_map_get(RzDebug *dbg) { //TODO
 		rz_list_append(retlist, map);
 		ptr = strtok(NULL, "\n");
 	}
-	gdbr_close_file(desc);
+	gdbr_close_file(ctx->desc);
 	free(buf);
 	return retlist;
 }
@@ -280,11 +304,12 @@ static RzList *rz_debug_gdb_modules_get(RzDebug *dbg) {
 }
 
 static int rz_debug_gdb_reg_write(RzDebug *dbg, int type, const ut8 *buf, int size) {
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
 	check_connection(dbg);
-	if (!desc) {
+	if (!ctx->desc) {
 		return RZ_DEBUG_REASON_UNKNOWN;
 	}
-	if (!reg_buf) {
+	if (!ctx->reg_buf) {
 		// we cannot write registers before we once read them
 		return -1;
 	}
@@ -304,13 +329,13 @@ static int rz_debug_gdb_reg_write(RzDebug *dbg, int type, const ut8 *buf, int si
 	// calling <g>
 	// so this workaround resizes the small register profile buffer
 	// to the whole set and fills the rest with 0
-	if (buf_size < buflen) {
-		ut8 *new_buf = realloc(reg_buf, buflen * sizeof(ut8));
+	if (ctx->buf_size < buflen) {
+		ut8 *new_buf = realloc(ctx->reg_buf, buflen * sizeof(ut8));
 		if (!new_buf) {
 			return -1;
 		}
-		reg_buf = new_buf;
-		memset(new_buf + buf_size, 0, buflen - buf_size);
+		ctx->reg_buf = new_buf;
+		memset(new_buf + ctx->buf_size, 0, buflen - ctx->buf_size);
 	}
 
 	RzRegItem *current = NULL;
@@ -318,56 +343,59 @@ static int rz_debug_gdb_reg_write(RzDebug *dbg, int type, const ut8 *buf, int si
 	// since this was the behaviour prior to the change.
 	RzRegArena *arena = dbg->reg->regset[type].arena;
 	for (;;) {
-		current = rz_reg_next_diff(dbg->reg, type, reg_buf, buflen, current, bits);
+		current = rz_reg_next_diff(dbg->reg, type, ctx->reg_buf, buflen, current, bits);
 		if (!current) {
 			break;
 		}
-		gdbr_write_reg(desc, current->name, (char *)arena->bytes + (current->offset / 8), current->size / 8);
+		gdbr_write_reg(ctx->desc, current->name, (char *)arena->bytes + (current->offset / 8), current->size / 8);
 	}
 	return true;
 }
 
 static int rz_debug_gdb_continue(RzDebug *dbg, int pid, int tid, int sig) {
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
 	check_connection(dbg);
-	if (!desc) {
+	if (!ctx->desc) {
 		return RZ_DEBUG_REASON_UNKNOWN;
 	}
-	gdbr_continue(desc, pid, -1, sig); // Continue all threads
-	if (desc->stop_reason.is_valid && desc->stop_reason.thread.present) {
+	gdbr_continue(ctx->desc, pid, -1, sig); // Continue all threads
+	if (ctx->desc->stop_reason.is_valid && ctx->desc->stop_reason.thread.present) {
 		//if (desc->tid != desc->stop_reason.thread.tid) {
 		//	eprintf ("thread id (%d) in reason differs from current thread id (%d)\n", dbg->pid, dbg->tid);
 		//}
-		desc->tid = desc->stop_reason.thread.tid;
+		ctx->desc->tid = ctx->desc->stop_reason.thread.tid;
 	}
-	return desc->tid;
+	return ctx->desc->tid;
 }
 
 static RzDebugReasonType rz_debug_gdb_wait(RzDebug *dbg, int pid) {
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
 	check_connection(dbg);
-	if (!desc) {
+	if (!ctx->desc) {
 		return RZ_DEBUG_REASON_UNKNOWN;
 	}
-	if (!desc->stop_reason.is_valid) {
-		if (gdbr_stop_reason(desc) < 0) {
+	if (!ctx->desc->stop_reason.is_valid) {
+		if (gdbr_stop_reason(ctx->desc) < 0) {
 			dbg->reason.type = RZ_DEBUG_REASON_UNKNOWN;
 			return RZ_DEBUG_REASON_UNKNOWN;
 		}
 	}
-	if (desc->stop_reason.thread.present) {
-		dbg->reason.tid = desc->stop_reason.thread.tid;
-		dbg->pid = desc->stop_reason.thread.pid;
-		dbg->tid = desc->stop_reason.thread.tid;
-		if (dbg->pid != desc->pid || dbg->tid != desc->tid) {
+	if (ctx->desc->stop_reason.thread.present) {
+		dbg->reason.tid = ctx->desc->stop_reason.thread.tid;
+		dbg->pid = ctx->desc->stop_reason.thread.pid;
+		dbg->tid = ctx->desc->stop_reason.thread.tid;
+		if (dbg->pid != ctx->desc->pid || dbg->tid != ctx->desc->tid) {
 			//eprintf ("= attach %d %d\n", dbg->pid, dbg->tid);
-			gdbr_select(desc, dbg->pid, dbg->tid);
+			gdbr_select(ctx->desc, dbg->pid, dbg->tid);
 		}
 	}
-	dbg->reason.signum = desc->stop_reason.signum;
-	dbg->reason.type = desc->stop_reason.reason;
-	return desc->stop_reason.reason;
+	dbg->reason.signum = ctx->desc->stop_reason.signum;
+	dbg->reason.type = ctx->desc->stop_reason.reason;
+	return ctx->desc->stop_reason.reason;
 }
 
 static int rz_debug_gdb_attach(RzDebug *dbg, int pid) {
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
 	RzIODesc *d = dbg->iob.io->desc;
 	// TODO: the core must update the dbg.swstep config var when this var is changed
 	dbg->swstep = false;
@@ -375,13 +403,13 @@ static int rz_debug_gdb_attach(RzDebug *dbg, int pid) {
 	if (d && d->plugin && d->plugin->name && d->data) {
 		if (!strcmp("gdb", d->plugin->name)) {
 			RzIOGdb *g = d->data;
-			origriogdb = (RzIOGdb **)&d->data; //TODO bit of a hack, please improve
-			support_sw_bp = UNKNOWN;
-			support_hw_bp = UNKNOWN;
-			desc = &g->desc;
+			ctx->origrziogdb = (RzIOGdb **)&d->data; //TODO bit of a hack, please improve
+			ctx->support_sw_bp = UNKNOWN;
+			ctx->support_hw_bp = UNKNOWN;
+			ctx->desc = &g->desc;
 			int arch = rz_sys_arch_id(dbg->arch);
 			int bits = dbg->analysis->bits;
-			gdbr_set_architecture(desc, arch, bits);
+			gdbr_set_architecture(ctx->desc, arch, bits);
 		} else {
 			eprintf("ERROR: Underlying IO descriptor is not a GDB one..\n");
 		}
@@ -390,44 +418,49 @@ static int rz_debug_gdb_attach(RzDebug *dbg, int pid) {
 }
 
 static int rz_debug_gdb_detach(RzDebug *dbg, int pid) {
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
 	int ret = 0;
 
-	if (pid <= 0 || !desc->stub_features.multiprocess) {
-		gdbr_detach(desc);
+	if (pid <= 0 || !ctx->desc->stub_features.multiprocess) {
+		gdbr_detach(ctx->desc);
 	}
-	ret = gdbr_detach_pid(desc, pid);
+	ret = gdbr_detach_pid(ctx->desc, pid);
 
 	if (dbg->pid == pid) {
-		desc = NULL;
+		ctx->desc = NULL;
 	}
 	return ret;
 }
 
 static const char *rz_debug_gdb_reg_profile(RzDebug *dbg) {
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
 	check_connection(dbg);
 	int arch = rz_sys_arch_id(dbg->arch);
 	int bits = dbg->analysis->bits;
 	// XXX This happens when rizin set dbg.backend before opening io_gdb
-	if (!desc) {
+	if (!ctx->desc) {
 		return gdbr_get_reg_profile(arch, bits);
 	}
-	if (!desc->target.valid) {
-		gdbr_set_architecture(desc, arch, bits);
+	if (!ctx->desc->target.valid) {
+		gdbr_set_architecture(ctx->desc, arch, bits);
 	}
-	if (desc->target.regprofile) {
-		return strdup(desc->target.regprofile);
+	if (ctx->desc->target.regprofile) {
+		return strdup(ctx->desc->target.regprofile);
 	}
 	return NULL;
 }
 
-static int rz_debug_gdb_set_reg_profile(const char *str) {
-	if (desc && str) {
-		return gdbr_set_reg_profile(desc, str);
+static int rz_debug_gdb_set_reg_profile(RzDebug *dbg, const char *str) {
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
+	if (ctx->desc && str) {
+		return gdbr_set_reg_profile(ctx->desc, str);
 	}
 	return false;
 }
 
 static int rz_debug_gdb_breakpoint(RzBreakpoint *bp, RzBreakpointItem *b, bool set) {
+	RzDebug *dbg = bp->user;
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
 	int ret = 0, bpsize;
 	if (!b) {
 		return false;
@@ -437,34 +470,34 @@ static int rz_debug_gdb_breakpoint(RzBreakpoint *bp, RzBreakpointItem *b, bool s
 	switch (b->perm) {
 	case RZ_BP_PROT_EXEC: {
 		if (set) {
-			ret = b->hw ? gdbr_set_hwbp(desc, b->addr, "", bpsize) : gdbr_set_bp(desc, b->addr, "", bpsize);
+			ret = b->hw ? gdbr_set_hwbp(ctx->desc, b->addr, "", bpsize) : gdbr_set_bp(ctx->desc, b->addr, "", bpsize);
 		} else {
-			ret = b->hw ? gdbr_remove_hwbp(desc, b->addr, bpsize) : gdbr_remove_bp(desc, b->addr, bpsize);
+			ret = b->hw ? gdbr_remove_hwbp(ctx->desc, b->addr, bpsize) : gdbr_remove_bp(ctx->desc, b->addr, bpsize);
 		}
 		break;
 	}
 	// TODO handle size (area of watch in upper layer and then bpsize. For the moment watches are set on exact on byte
 	case RZ_PERM_W: {
 		if (set) {
-			gdbr_set_hww(desc, b->addr, "", 1);
+			gdbr_set_hww(ctx->desc, b->addr, "", 1);
 		} else {
-			gdbr_remove_hww(desc, b->addr, 1);
+			gdbr_remove_hww(ctx->desc, b->addr, 1);
 		}
 		break;
 	}
 	case RZ_PERM_R: {
 		if (set) {
-			gdbr_set_hwr(desc, b->addr, "", 1);
+			gdbr_set_hwr(ctx->desc, b->addr, "", 1);
 		} else {
-			gdbr_remove_hwr(desc, b->addr, 1);
+			gdbr_remove_hwr(ctx->desc, b->addr, 1);
 		}
 		break;
 	}
 	case RZ_PERM_ACCESS: {
 		if (set) {
-			gdbr_set_hwa(desc, b->addr, "", 1);
+			gdbr_set_hwa(ctx->desc, b->addr, "", 1);
 		} else {
-			gdbr_remove_hwa(desc, b->addr, 1);
+			gdbr_remove_hwa(ctx->desc, b->addr, 1);
 		}
 		break;
 	}
@@ -473,9 +506,10 @@ static int rz_debug_gdb_breakpoint(RzBreakpoint *bp, RzBreakpointItem *b, bool s
 }
 
 static bool rz_debug_gdb_kill(RzDebug *dbg, int pid, int tid, int sig) {
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
 	// TODO kill based on pid and signal
 	if (sig != 0) {
-		if (gdbr_kill(desc) < 0) {
+		if (gdbr_kill(ctx->desc) < 0) {
 			return false;
 		}
 	}
@@ -483,15 +517,17 @@ static bool rz_debug_gdb_kill(RzDebug *dbg, int pid, int tid, int sig) {
 }
 
 static int rz_debug_gdb_select(RzDebug *dbg, int pid, int tid) {
-	if (!desc || !*origriogdb) {
-		desc = NULL; //TODO hacky fix, please improve. I would suggest using a **desc instead of a *desc, so it is automatically updated
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
+	if (!ctx->desc || !*ctx->origrziogdb) {
+		ctx->desc = NULL; //TODO hacky fix, please improve. I would suggest using a **desc instead of a *desc, so it is automatically updated
 		return false;
 	}
 
-	return gdbr_select(desc, pid, tid) >= 0;
+	return gdbr_select(ctx->desc, pid, tid) >= 0;
 }
 
 static RzDebugInfo *rz_debug_gdb_info(RzDebug *dbg, const char *arg) {
+	RzDebugGdbCtx *ctx = dbg->plugin_data;
 	RzDebugInfo *rdi;
 	if (!(rdi = RZ_NEW0(RzDebugInfo))) {
 		return NULL;
@@ -515,13 +551,13 @@ static RzDebugInfo *rz_debug_gdb_info(RzDebug *dbg, const char *arg) {
 	}
 	rdi->pid = dbg->pid;
 	rdi->tid = dbg->tid;
-	rdi->exe = gdbr_exec_file_read(desc, dbg->pid);
+	rdi->exe = gdbr_exec_file_read(ctx->desc, dbg->pid);
 	rdi->status = found ? th->status : RZ_DBG_PROC_STOP;
 	rdi->uid = found ? th->uid : -1;
 	rdi->gid = found ? th->gid : -1;
-	if (gdbr_stop_reason(desc) >= 0) {
-		eprintf("signal: %d\n", desc->stop_reason.signum);
-		rdi->signum = desc->stop_reason.signum;
+	if (gdbr_stop_reason(ctx->desc) >= 0) {
+		eprintf("signal: %d\n", ctx->desc->stop_reason.signum);
+		rdi->signum = ctx->desc->stop_reason.signum;
 	}
 	if (list_alloc) {
 		rz_list_free(th_list);
@@ -541,6 +577,8 @@ RzDebugPlugin rz_debug_plugin_gdb = {
 	.license = "LGPL3",
 	.arch = "x86,arm,sh,mips,avr,lm32,v850,ba2",
 	.bits = RZ_SYS_BITS_16 | RZ_SYS_BITS_32 | RZ_SYS_BITS_64,
+	.init = rz_debug_gdb_init,
+	.fini = rz_debug_gdb_fini,
 	.step = rz_debug_gdb_step,
 	.cont = rz_debug_gdb_continue,
 	.attach = &rz_debug_gdb_attach,

--- a/librz/debug/p/debug_native.c
+++ b/librz/debug/p/debug_native.c
@@ -1210,8 +1210,8 @@ static bool rz_debug_native_kill(RzDebug *dbg, int pid, int tid, int sig) {
 }
 
 struct rz_debug_desc_plugin_t rz_debug_desc_plugin_native;
-static int rz_debug_native_init(RzDebug *dbg) {
-	dbg->h->desc = rz_debug_desc_plugin_native;
+static bool rz_debug_native_init(RzDebug *dbg, void **user) {
+	dbg->cur->desc = rz_debug_desc_plugin_native;
 #if __WINDOWS__
 	return w32_init(dbg);
 #else

--- a/librz/debug/p/debug_winkd.c
+++ b/librz/debug/p/debug_winkd.c
@@ -141,7 +141,7 @@ static int rz_debug_winkd_breakpoint(RzBreakpoint *bp, RzBreakpointItem *b, bool
 	return winkd_bkpt(wctx, b->addr, set, b->hw, tag);
 }
 
-static int rz_debug_winkd_init(RzDebug *dbg) {
+static bool rz_debug_winkd_init(RzDebug *dbg, void **user) {
 	return true;
 }
 

--- a/librz/debug/p/native/linux/linux_coredump.c
+++ b/librz/debug/p/native/linux/linux_coredump.c
@@ -1033,8 +1033,8 @@ static int *get_unique_thread_id(RzDebug *dbg, int n_threads) {
 	int i = 0;
 	bool found = false;
 
-	if (dbg->h) {
-		list = dbg->h->threads(dbg, dbg->pid);
+	if (dbg->cur) {
+		list = dbg->cur->threads(dbg, dbg->pid);
 		if (!list) {
 			return NULL;
 		}

--- a/librz/debug/p/native/windows/windows_debug.c
+++ b/librz/debug/p/native/windows/windows_debug.c
@@ -35,11 +35,9 @@ bool setup_debug_privileges(bool b) {
 }
 
 int w32_init(RzDebug *dbg) {
-	W32DbgWInst *wrap = dbg->user;
-	if (!wrap) {
-		if (dbg->iob.io->w32dbg_wrap) {
-			dbg->user = (W32DbgWInst *)dbg->iob.io->w32dbg_wrap;
-		} else {
+	if (!dbg->user) {
+		dbg->user = dbg->iob.get_w32dbg_wrap(dbg->iob.io);
+		if (!dbg->user) {
 			return 0;
 		}
 	}

--- a/librz/debug/pid.c
+++ b/librz/debug/pid.c
@@ -24,8 +24,8 @@ RZ_API RzDebugPid *rz_debug_pid_free(RzDebugPid *pid) {
 }
 
 RZ_API RzList *rz_debug_pids(RzDebug *dbg, int pid) {
-	if (dbg && dbg->h && dbg->h->pids) {
-		return dbg->h->pids(dbg, pid);
+	if (dbg && dbg->cur && dbg->cur->pids) {
+		return dbg->cur->pids(dbg, pid);
 	}
 	return NULL;
 }
@@ -35,8 +35,8 @@ RZ_API int rz_debug_pid_list(RzDebug *dbg, int pid, char fmt) {
 	RzList *list;
 	RzListIter *iter;
 	RzDebugPid *p;
-	if (dbg && dbg->h && dbg->h->pids) {
-		list = dbg->h->pids(dbg, RZ_MAX(0, pid));
+	if (dbg && dbg->cur && dbg->cur->pids) {
+		list = dbg->cur->pids(dbg, RZ_MAX(0, pid));
 		if (!list) {
 			return false;
 		}
@@ -81,8 +81,8 @@ RZ_API int rz_debug_thread_list(RzDebug *dbg, int pid, char fmt) {
 	if (pid == -1) {
 		return false;
 	}
-	if (dbg && dbg->h && dbg->h->threads) {
-		list = dbg->h->threads(dbg, pid);
+	if (dbg && dbg->cur && dbg->cur->threads) {
+		list = dbg->cur->threads(dbg, pid);
 		if (!list) {
 			return false;
 		}

--- a/librz/include/rz_debug.h
+++ b/librz/include/rz_debug.h
@@ -287,14 +287,15 @@ typedef struct rz_debug_t {
 	RzList *q_regs;
 	const char *creg; // current register value
 	RzBreakpoint *bp;
-	void *user; // XXX(jjd): unused?? meant for caller's use??
+	RZ_DEPRECATE void *user; /// currently only used in windows-specific io_debug
 	char *snap_path;
 
 	/* io */
 	PrintfCallback cb_printf;
 	RzIOBind iob;
 
-	struct rz_debug_plugin_t *h;
+	struct rz_debug_plugin_t *cur;
+	void *plugin_data;
 	RzList *plugins;
 
 	bool pc_at_bp; /* after a breakpoint, is the pc at the bp? */
@@ -358,11 +359,12 @@ typedef struct rz_debug_plugin_t {
 	const char *license;
 	const char *author;
 	const char *version;
-	//const char **archs; // MUST BE DEPRECATED!!!!
 	ut32 bits;
 	const char *arch;
 	int canstep;
 	int keepio;
+	bool (*init)(RzDebug *dbg, void **user);
+	void (*fini)(RzDebug *debug, void *user);
 	/* life */
 	RzDebugInfo *(*info)(RzDebug *dbg, const char *arg);
 	int (*startv)(int argc, char **argv);
@@ -384,19 +386,18 @@ typedef struct rz_debug_plugin_t {
 	RzList *(*kill_list)(RzDebug *dbg);
 	int (*contsc)(RzDebug *dbg, int pid, int sc);
 	RzList *(*frames)(RzDebug *dbg, ut64 at);
-	RzBreakpointCallback breakpoint;
+	RzBreakpointCallback breakpoint; /// Callback to be used for RzBreakpoint. When called, RzBreakpoint.user points to the RzDebug.
 	// XXX: specify, pid, tid, or RzDebug ?
 	int (*reg_read)(RzDebug *dbg, int type, ut8 *buf, int size);
 	int (*reg_write)(RzDebug *dbg, int type, const ut8 *buf, int size); //XXX struct rz_regset_t regs);
 	char *(*reg_profile)(RzDebug *dbg);
-	int (*set_reg_profile)(const char *str);
+	int (*set_reg_profile)(RzDebug *dbg, const char *str);
 	/* memory */
 	RzList *(*map_get)(RzDebug *dbg);
 	RzList *(*modules_get)(RzDebug *dbg);
 	RzDebugMap *(*map_alloc)(RzDebug *dbg, ut64 addr, int size, bool thp);
 	int (*map_dealloc)(RzDebug *dbg, ut64 addr, int size);
 	int (*map_protect)(RzDebug *dbg, ut64 addr, int size, int perms);
-	int (*init)(RzDebug *dbg);
 	int (*drx)(RzDebug *dbg, int n, ut64 addr, int size, int rwx, int g, int api_type);
 	RzDebugDescPlugin desc;
 	// TODO: use RzList here

--- a/librz/include/rz_io.h
+++ b/librz/include/rz_io.h
@@ -29,6 +29,10 @@
 #endif
 #endif
 
+#if __WINDOWS__
+#include <w32dbg_wrap.h>
+#endif
+
 #if (defined(__GLIBC__) && defined(__linux__))
 typedef enum __ptrace_request rz_ptrace_request_t;
 typedef void *rz_ptrace_data_t;
@@ -81,7 +85,7 @@ typedef struct rz_io_t {
 	struct ptrace_wrap_instance_t *ptrace_wrap;
 #endif
 #if __WINDOWS__
-	struct w32dbg_wrap_instance_t *w32dbg_wrap;
+	struct w32dbg_wrap_instance_t *priv_w32dbg_wrap; ///< Do not access this directly, use rz_io_get_w32dbg_wrap() instead!
 #endif
 	char *args;
 	RzEvent *event;
@@ -217,6 +221,9 @@ typedef RzIOMap *(*RzIOMapAdd)(RzIO *io, int fd, int flags, ut64 delta, ut64 add
 typedef long (*RzIOPtraceFn)(RzIO *io, rz_ptrace_request_t request, pid_t pid, void *addr, rz_ptrace_data_t data);
 typedef void *(*RzIOPtraceFuncFn)(RzIO *io, void *(*func)(void *), void *user);
 #endif
+#if __WINDOWS__
+typedef struct w32dbg_wrap_instance_t *(*RzIOGetW32DbgWrap)(RzIO *io);
+#endif
 
 typedef struct rz_io_bind_t {
 	int init;
@@ -253,6 +260,9 @@ typedef struct rz_io_bind_t {
 #if HAVE_PTRACE
 	RzIOPtraceFn ptrace;
 	RzIOPtraceFuncFn ptrace_func;
+#endif
+#if __WINDOWS__
+	RzIOGetW32DbgWrap get_w32dbg_wrap;
 #endif
 } RzIOBind;
 
@@ -436,6 +446,10 @@ RZ_API bool rz_io_write_i(RzIO *io, ut64 addr, ut64 *val, int size, bool endian)
 RZ_API long rz_io_ptrace(RzIO *io, rz_ptrace_request_t request, pid_t pid, void *addr, rz_ptrace_data_t data);
 RZ_API pid_t rz_io_ptrace_fork(RzIO *io, void (*child_callback)(void *), void *child_callback_user);
 RZ_API void *rz_io_ptrace_func(RzIO *io, void *(*func)(void *), void *user);
+#endif
+
+#if __WINDOWS__
+RZ_API struct w32dbg_wrap_instance_t *rz_io_get_w32dbg_wrap(RzIO *io);
 #endif
 
 extern RzIOPlugin rz_io_plugin_procpid;

--- a/librz/io/p/io_debug.c
+++ b/librz/io/p/io_debug.c
@@ -121,9 +121,6 @@ static int fork_and_ptraceme(RzIO *io, int bits, const char *cmd) {
 		return -1;
 	}
 	setup_tokens();
-	if (!io->w32dbg_wrap) {
-		io->w32dbg_wrap = (struct w32dbg_wrap_instance_t *)w32dbg_wrap_new();
-	}
 	char *_cmd = io->args ? rz_str_appendf(strdup(cmd), " %s", io->args) : strdup(cmd);
 	char **argv = rz_str_argv(_cmd, NULL);
 	char *cmdline = NULL;
@@ -141,7 +138,7 @@ static int fork_and_ptraceme(RzIO *io, int bits, const char *cmd) {
 	flags |= core->dbg->create_new_console ? CREATE_NEW_CONSOLE : 0;
 	free(cmdline);
 	struct __createprocess_params p = { appname_, cmdline_, &pi, flags };
-	W32DbgWInst *wrap = (W32DbgWInst *)io->w32dbg_wrap;
+	W32DbgWInst *wrap = (W32DbgWInst *)rz_io_get_w32dbg_wrap(io);
 	wrap->params.type = W32_CALL_FUNC;
 	wrap->params.func.func = __createprocess_wrap;
 	wrap->params.func.user = &p;
@@ -187,8 +184,6 @@ static int fork_and_ptraceme(RzIO *io, int bits, const char *cmd) {
 err_fork:
 	eprintf("ERRFORK\n");
 	TerminateProcess(pi.hProcess, 1);
-	w32dbg_wrap_fini((W32DbgWInst *)io->w32dbg_wrap);
-	io->w32dbg_wrap = NULL;
 	CloseHandle(pi.hThread);
 	CloseHandle(pi.hProcess);
 	return -1;

--- a/librz/io/p/io_debug.c
+++ b/librz/io/p/io_debug.c
@@ -460,11 +460,11 @@ static bool __plugin_open(RzIO *io, const char *file, bool many) {
 #include <rz_core.h>
 static int get_pid_of(RzIO *io, const char *procname) {
 	RzCore *c = io->corebind.core;
-	if (c && c->dbg && c->dbg->h) {
+	if (c && c->dbg && c->dbg->cur) {
 		RzListIter *iter;
 		RzDebugPid *proc;
 		RzDebug *d = c->dbg;
-		RzList *pids = d->h->pids(d, 0);
+		RzList *pids = d->cur->pids(d, 0);
 		rz_list_foreach (pids, iter, proc) {
 			if (strstr(proc->path, procname)) {
 				eprintf("Matching PID %d %s\n", proc->pid, proc->path);

--- a/shlr/w32dbg_wrap/include/w32dbg_wrap.h
+++ b/shlr/w32dbg_wrap/include/w32dbg_wrap.h
@@ -47,6 +47,6 @@ typedef struct {
 
 W32DbgWInst *w32dbg_wrap_new(void);
 int w32dbg_wrap_wait_ret(W32DbgWInst *inst);
-void w32dbg_wrap_fini(W32DbgWInst *inst);
+void w32dbg_wrap_free(W32DbgWInst *inst);
 
 #endif

--- a/shlr/w32dbg_wrap/src/w32dbg_wrap.c
+++ b/shlr/w32dbg_wrap/src/w32dbg_wrap.c
@@ -55,7 +55,10 @@ W32DbgWInst *w32dbg_wrap_new(void) {
 	return inst;
 }
 
-void w32dbg_wrap_fini(W32DbgWInst *inst) {
+void w32dbg_wrap_free(W32DbgWInst *inst) {
+	if (!inst) {
+		return;
+	}
 	inst->params.type = W32_STOP;
 	ReleaseSemaphore(inst->request_sem, 1, NULL);
 	CloseHandle(inst->request_sem);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

* Renamed the current debug plugin in `RzDebug` from `h` to `cur` (like in `RzAsm` for example)
* Added a plugin context for debug plugins, naming/structure implemented as in #808
* Refactored remote gdb to use a local context instead of global vars

**Test plan**

This should be a pure refactoring without noticeable behavior changes. To test remote gdb, on one machine:
`gdbserver :1337 ./executable`
And on another (or the same):
`rz gdb://<hostname>:1337`
Then debug around. The behavior should be the same before and after these changes.
