### PR TITLE
Always Upload Test Results in GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
       env:
         ASAN_OPTIONS: ${{ matrix.asan_options }}
     - name: Upload test results
-      if: matrix.run_tests && matrix.enabled
+      if: always() && matrix.run_tests && matrix.enabled
       uses: actions/upload-artifact@v2
       with:
         name: test-results-${{ matrix.name }}
@@ -385,6 +385,7 @@ jobs:
         rz-test -L -o results.json || true
       working-directory: rizin
     - name: Upload test results
+      if: always()
       uses: actions/upload-artifact@v2
       with:
         name: test-results-static


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Apparently GitHub Action's notion of propositional logic is a bit strange.
If a previous step fails, then a following one with `if: matrix.run_tests && matrix.enabled` does not run but with `if: always() && matrix.run_tests && matrix.enabled` it does.

See for example: https://github.com/rizinorg/rizin/runs/2792046944
vs: https://github.com/rizinorg/rizin/runs/2795764719