### PR TITLE
Check for .git in meson without Python and also for non-dir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,8 +55,8 @@ version_commit = '0'
 
 gittip = ''
 
-git_dir_exists = run_command(py3_exe, '-c', '__import__("sys").exit(0 if __import__("os").path.isdir(".git") else 1)')
-if git_exe.found() and git_dir_exists.returncode() == 0
+fs = import('fs')
+if git_exe.found() and fs.exists('.git')
   # Get gittip
   git_rev_parse = run_command(py3_exe, git_exe_repo_py, git_exe, repo, 'rev-parse', 'HEAD')
   if git_rev_parse.returncode() == 0


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

When using `git worktree`, `.git` is not a directory but a file, so this check would fail and make some tests fail. `git rev-parse` still works in that case:
<img width="400" alt="Bildschirmfoto 2021-06-11 um 21 51 42" src="https://user-images.githubusercontent.com/1460997/121741774-40f1ed00-caff-11eb-8bb2-ce414762fa30.png">


This `fs` module is available since meson 0.53 and we require 0.55 so we can use it.