### PR TITLE
Fix the broken ASAN test by refactoring `is_cpu_valid()`

### DIFF
--- a/librz/analysis/arch_profile.c
+++ b/librz/analysis/arch_profile.c
@@ -158,12 +158,6 @@ static bool is_cpu_valid(char *cpu_dir, const char *cpu) {
 	char *filename = NULL;
 	char *cpu_name = NULL;
 	char *arch_cpu = NULL;
-	RzPVector *cpus = rz_pvector_new(NULL);
-	if (!cpus) {
-		rz_list_free(files);
-		return NULL;
-	}
-	rz_pvector_init(cpus, NULL);
 
 	rz_list_foreach (files, it, filename) {
 		if (!strcmp(filename, "..") || !strcmp(filename, "..")) {
@@ -173,20 +167,15 @@ static bool is_cpu_valid(char *cpu_dir, const char *cpu) {
 		if (!arch_cpu)
 			continue;
 		cpu_name = strchr(arch_cpu, '-');
-		rz_str_remove_char(cpu_name, '-');
-		rz_pvector_push(cpus, cpu_name);
-	}
-	rz_list_free(files);
-	free(arch_cpu);
-
-	void **ita;
-	rz_pvector_foreach (cpus, ita) {
-		if (!strcmp(*ita, cpu)) {
-			rz_pvector_free(cpus);
+		cpu_name[0] = '\0';
+		if (!strcmp(cpu_name + 1, cpu)) {
+			rz_list_free(files);
+			free(arch_cpu);
 			return true;
 		}
 	}
-	rz_pvector_free(cpus);
+	rz_list_free(files);
+	free(arch_cpu);
 	return false;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes the broken ASAN test by removing the use of `RzPVector`.  Also frees `arch_cpu`

**Test plan**

- [x] CI is green

**Closing issues**

None