### PR TITLE
Fix RzCore typedef redefinition in rz_arch.h

### DIFF
--- a/librz/include/rz_arch.h
+++ b/librz/include/rz_arch.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-typedef struct rz_core_t RzCore;
+struct rz_core_t;
 
 typedef struct rz_arch_profile_t {
 	ut64 rom_size;
@@ -40,7 +40,7 @@ RZ_API RZ_OWN RzArchTarget *rz_arch_target_new();
 RZ_API void rz_arch_profile_free(RzArchProfile *profile);
 RZ_API void rz_arch_target_free(RzArchTarget *target);
 RZ_API bool rz_arch_profiles_init(RzArchTarget *c, const char *cpu, const char *arch, const char *dir_prefix);
-RZ_API void rz_arch_profile_add_flag_every_io(RzCore *core);
+RZ_API void rz_arch_profile_add_flag_every_io(struct rz_core_t *core);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes this warning for `Apple clang version 12.0.5 (clang-1205.0.22.9)
Target: arm64-apple-darwin20.5.0`:
![Bildschirmfoto 2021-06-13 um 14 20 48](https://user-images.githubusercontent.com/1460997/121807027-aacedb80-cc52-11eb-8624-69305d281bc8.png)
