### PR TITLE
Refactor `rz_arch_profile_add_flag_every_io` to not let it depend on RzCore

### DIFF
--- a/librz/analysis/arch_profile.c
+++ b/librz/analysis/arch_profile.c
@@ -199,13 +199,14 @@ RZ_API bool rz_arch_profiles_init(RzArchTarget *t, const char *cpu, const char *
 	char *path = rz_str_newf(RZ_JOIN_4_PATHS("%s", RZ_SDB, "asm/cpus", "%s-%s.sdb"),
 		dir_prefix, arch, cpu);
 	if (!path || !arch) {
+		free(path);
 		return false;
 	}
 	char *cpu_dir = rz_str_newf(RZ_JOIN_3_PATHS("%s", RZ_SDB, "asm/cpus"), dir_prefix);
 	if (!is_cpu_valid(cpu_dir, cpu)) {
 		if (!strcmp(arch, "avr")) {
 			free(path);
-			path = rz_str_newf(RZ_JOIN_4_PATHS("%s", RZ_SDB, "asm/cpus", "avr-ATmega8.sdb"), dir_prefix);
+			path = rz_str_newf("%s" RZ_SYS_DIR RZ_SDB RZ_SYS_DIR "asm" RZ_SYS_DIR "cpus" RZ_SYS_DIR "avr-ATmega8.sdb", dir_prefix);
 		}
 	}
 	if (!rz_arch_load_profile_sdb(t, path)) {

--- a/librz/analysis/arch_profile.c
+++ b/librz/analysis/arch_profile.c
@@ -198,16 +198,14 @@ RZ_API bool rz_arch_profiles_init(RzArchTarget *t, const char *cpu, const char *
 	}
 	char *path = rz_str_newf(RZ_JOIN_4_PATHS("%s", RZ_SDB, "asm/cpus", "%s-%s.sdb"),
 		dir_prefix, arch, cpu);
-	if (!path) {
+	if (!path || !arch) {
 		return false;
 	}
 	char *cpu_dir = rz_str_newf(RZ_JOIN_3_PATHS("%s", RZ_SDB, "asm/cpus"), dir_prefix);
 	if (!is_cpu_valid(cpu_dir, cpu)) {
-		if (arch) {
-			if (!strcmp(arch, "avr")) {
-				free(path);
-				path = rz_str_newf(RZ_JOIN_4_PATHS("%s", RZ_SDB, "asm/cpus", "avr-ATmega8.sdb"), dir_prefix);
-			}
+		if (!strcmp(arch, "avr")) {
+			free(path);
+			path = rz_str_newf(RZ_JOIN_4_PATHS("%s", RZ_SDB, "asm/cpus", "avr-ATmega8.sdb"), dir_prefix);
 		}
 	}
 	if (!rz_type_db_load_arch_profile_sdb(t, path)) {

--- a/librz/analysis/arch_profile.c
+++ b/librz/analysis/arch_profile.c
@@ -156,17 +156,21 @@ static bool is_cpu_valid(char *cpu_dir, const char *cpu) {
 	}
 	RzListIter *it;
 	char *filename = NULL;
-	char *cpu_name = NULL;
 	char *arch_cpu = NULL;
 
 	rz_list_foreach (files, it, filename) {
+		char *cpu_name = NULL;
 		if (!strcmp(filename, "..") || !strcmp(filename, "..")) {
 			continue;
 		}
 		arch_cpu = rz_str_ndup(filename, strlen(filename) - 4);
-		if (!arch_cpu)
+		if (!arch_cpu) {
 			continue;
+		}
 		cpu_name = strchr(arch_cpu, '-');
+		if (!cpu_name) {
+			continue;
+		}
 		cpu_name[0] = '\0';
 		if (!strcmp(cpu_name + 1, cpu)) {
 			rz_list_free(files);
@@ -201,6 +205,7 @@ RZ_API bool rz_arch_profiles_init(RzArchTarget *t, const char *cpu, const char *
 	if (!is_cpu_valid(cpu_dir, cpu)) {
 		if (arch) {
 			if (!strcmp(arch, "avr")) {
+				free(path);
 				path = rz_str_newf(RZ_JOIN_4_PATHS("%s", RZ_SDB, "asm/cpus", "avr-ATmega8.sdb"), dir_prefix);
 			}
 		}

--- a/librz/analysis/arch_profile.c
+++ b/librz/analysis/arch_profile.c
@@ -142,7 +142,7 @@ static bool sdb_load_arch_profile_by_path(RZ_NONNULL RzArchTarget *t, const char
  * \param t reference to RzArchTarget
  * \param path reference to path of the SDB file
  */
-RZ_API bool rz_type_db_load_arch_profile_sdb(RzArchTarget *t, const char *path) {
+RZ_API bool rz_arch_load_profile_sdb(RzArchTarget *t, const char *path) {
 	if (!rz_file_exists(path)) {
 		return false;
 	}
@@ -208,7 +208,7 @@ RZ_API bool rz_arch_profiles_init(RzArchTarget *t, const char *cpu, const char *
 			path = rz_str_newf(RZ_JOIN_4_PATHS("%s", RZ_SDB, "asm/cpus", "avr-ATmega8.sdb"), dir_prefix);
 		}
 	}
-	if (!rz_type_db_load_arch_profile_sdb(t, path)) {
+	if (!rz_arch_load_profile_sdb(t, path)) {
 		sdb_free(t->db);
 		t->db = NULL;
 	}

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -6450,7 +6450,7 @@ RZ_API void rz_core_analysis_flag_every_function(RzCore *core) {
 
 static bool add_mmio_flag_cb(void *user, const ut64 addr, const void *v) {
 	const char *name = v;
-	RzFlag *flags = user;
+	RzFlag *flags = (RzFlag *)user;
 	rz_flag_space_push(flags, RZ_FLAGS_FS_MMIO_REGISTERS);
 	rz_flag_set(flags, name, addr, 1);
 	rz_flag_space_pop(flags);
@@ -6459,7 +6459,7 @@ static bool add_mmio_flag_cb(void *user, const ut64 addr, const void *v) {
 
 static bool add_mmio_extended_flag_cb(void *user, const ut64 addr, const void *v) {
 	const char *name = v;
-	RzFlag *flags = user;
+	RzFlag *flags = (RzFlag *)user;
 	rz_flag_space_push(flags, RZ_FLAGS_FS_MMIO_REGISTERS_EXTENDED);
 	rz_flag_set(flags, name, addr, 1);
 	rz_flag_space_pop(flags);

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -6450,27 +6450,32 @@ RZ_API void rz_core_analysis_flag_every_function(RzCore *core) {
 
 static bool add_mmio_flag_cb(void *user, const ut64 addr, const void *v) {
 	const char *name = v;
-	RzCore *core = user;
-	rz_flag_space_push(core->flags, RZ_FLAGS_FS_MMIO_REGISTERS);
-	rz_flag_set(core->flags, name, addr, 1);
-	rz_flag_space_pop(core->flags);
+	RzFlag *flags = user;
+	rz_flag_space_push(flags, RZ_FLAGS_FS_MMIO_REGISTERS);
+	rz_flag_set(flags, name, addr, 1);
+	rz_flag_space_pop(flags);
 	return true;
 }
 
 static bool add_mmio_extended_flag_cb(void *user, const ut64 addr, const void *v) {
 	const char *name = v;
-	RzCore *core = user;
-	rz_flag_space_push(core->flags, RZ_FLAGS_FS_MMIO_REGISTERS_EXTENDED);
-	rz_flag_set(core->flags, name, addr, 1);
-	rz_flag_space_pop(core->flags);
+	RzFlag *flags = user;
+	rz_flag_space_push(flags, RZ_FLAGS_FS_MMIO_REGISTERS_EXTENDED);
+	rz_flag_set(flags, name, addr, 1);
+	rz_flag_space_pop(flags);
 	return true;
 }
 
-RZ_API void rz_arch_profile_add_flag_every_io(RzCore *core) {
-	rz_flag_unset_all_in_space(core->flags, RZ_FLAGS_FS_MMIO_REGISTERS);
-	rz_flag_unset_all_in_space(core->flags, RZ_FLAGS_FS_MMIO_REGISTERS_EXTENDED);
-	ht_up_foreach(core->analysis->arch_target->profile->registers_mmio, add_mmio_flag_cb, core);
-	ht_up_foreach(core->analysis->arch_target->profile->registers_extended, add_mmio_extended_flag_cb, core);
+/**
+ * \brief Adds the IO and extended IO registers from the CPU profiles as flags
+ * \param profile reference to RzArchProfile 
+ * \param flags reference to RzFlag 
+ */
+RZ_API void rz_arch_profile_add_flag_every_io(RzArchProfile *profile, RzFlag *flags) {
+	rz_flag_unset_all_in_space(flags, RZ_FLAGS_FS_MMIO_REGISTERS);
+	rz_flag_unset_all_in_space(flags, RZ_FLAGS_FS_MMIO_REGISTERS_EXTENDED);
+	ht_up_foreach(profile->registers_mmio, add_mmio_flag_cb, flags);
+	ht_up_foreach(profile->registers_extended, add_mmio_extended_flag_cb, flags);
 }
 
 /* TODO: move into rz_analysis_function_rename (); */

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -613,7 +613,9 @@ static bool cb_asmarch(void *user, void *data) {
 
 	const char *dir_prefix = rz_config_get(core->config, "dir.prefix");
 	rz_sysreg_set_arch(core->analysis->syscall, node->value, dir_prefix);
-	rz_arch_profiles_init(core->analysis->arch_target, asmcpu->value, rz_config_get(core->config, "asm.arch"), dir_prefix);
+	if (asmcpu) {
+		rz_arch_profiles_init(core->analysis->arch_target, asmcpu->value, node->value, dir_prefix);
+	}
 
 	return true;
 }

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -7986,7 +7986,7 @@ static int cmd_analysis_all(RzCore *core, const char *input) {
 			rz_cons_break_push(NULL, NULL);
 			rz_cons_break_timeout(rz_config_get_i(core->config, "analysis.timeout"));
 			rz_core_analysis_all(core);
-			rz_arch_profile_add_flag_every_io(core);
+			rz_arch_profile_add_flag_every_io(core->analysis->arch_target->profile, core->flags);
 			rz_print_rowlog_done(core->print, oldstr);
 			rz_core_task_yield(&core->tasks);
 			// Run pending analysis immediately after analysis

--- a/librz/include/rz_arch.h
+++ b/librz/include/rz_arch.h
@@ -38,7 +38,7 @@ RZ_API void rz_arch_profile_free(RzArchProfile *profile);
 RZ_API void rz_arch_target_free(RzArchTarget *target);
 RZ_API bool rz_arch_profiles_init(RzArchTarget *c, const char *cpu, const char *arch, const char *dir_prefix);
 RZ_API void rz_arch_profile_add_flag_every_io(RzArchProfile *profile, RzFlag *flags);
-RZ_API bool rz_type_db_load_arch_profile_sdb(RzArchTarget *t, const char *path);
+RZ_API bool rz_arch_load_profile_sdb(RzArchTarget *t, const char *path);
 
 #ifdef __cplusplus
 }

--- a/librz/include/rz_arch.h
+++ b/librz/include/rz_arch.h
@@ -4,15 +4,12 @@
 #ifndef RZ_ARCH_H
 #define RZ_ARCH_H
 
-#include <rz_types.h>
-#include <rz_util.h>
+#include <rz_flag.h>
 #include <sdb.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-struct rz_core_t;
 
 typedef struct rz_arch_profile_t {
 	ut64 rom_size;
@@ -40,7 +37,8 @@ RZ_API RZ_OWN RzArchTarget *rz_arch_target_new();
 RZ_API void rz_arch_profile_free(RzArchProfile *profile);
 RZ_API void rz_arch_target_free(RzArchTarget *target);
 RZ_API bool rz_arch_profiles_init(RzArchTarget *c, const char *cpu, const char *arch, const char *dir_prefix);
-RZ_API void rz_arch_profile_add_flag_every_io(struct rz_core_t *core);
+RZ_API void rz_arch_profile_add_flag_every_io(RzArchProfile *profile, RzFlag *flags);
+RZ_API bool rz_type_db_load_arch_profile_sdb(RzArchTarget *t, const char *path);
 
 #ifdef __cplusplus
 }

--- a/librz/include/rz_syscall.h
+++ b/librz/include/rz_syscall.h
@@ -103,7 +103,7 @@ RZ_API int rz_syscall_get_swi(RzSyscall *s);
 
 RZ_API const char *rz_sysreg_get(RzSyscall *s, const char *type, ut64 num);
 RZ_API bool rz_sysreg_set_arch(RzSyscall *s, const char *arch, const char *dir_prefix);
-RZ_API bool rz_type_db_load_sysregs_sdb(RzSysregsDB *sysregdb, const char *path);
+RZ_API bool rz_sysreg_load_sdb(RzSysregsDB *sysregdb, const char *path);
 RZ_API RzSysregsDB *rz_sysregs_db_new();
 RZ_API RZ_OWN RzSysregItem *rz_sysreg_item_new(RZ_NULLABLE const char *name);
 RZ_API void rz_sysreg_item_free(RzSysregItem *sysregitem);

--- a/librz/syscall/syscall.c
+++ b/librz/syscall/syscall.c
@@ -177,7 +177,7 @@ static bool sdb_load_by_path(RZ_NONNULL RzSysregsDB *sysregdb, const char *path)
  * \param s reference to RzSysregDB
  * \param path reference to path of the SDB file
  */
-RZ_API bool rz_type_db_load_sysregs_sdb(RzSysregsDB *sysregdb, const char *path) {
+RZ_API bool rz_sysreg_load_sdb(RzSysregsDB *sysregdb, const char *path) {
 	if (!rz_file_exists(path)) {
 		return false;
 	}
@@ -198,7 +198,7 @@ RZ_API bool rz_sysreg_set_arch(RzSyscall *s, const char *arch, const char *dir_p
 
 	s->srdb = rz_sysregs_db_new();
 	if (path) {
-		if (!rz_type_db_load_sysregs_sdb(s->srdb, path)) {
+		if (!rz_sysreg_load_sdb(s->srdb, path)) {
 			s->srdb = NULL;
 			return false;
 		}
@@ -255,7 +255,7 @@ RZ_API bool rz_syscall_setup(RzSyscall *s, const char *arch, int bits, const cha
 		char *dbName = rz_str_newf(RZ_JOIN_2_PATHS("reg", "%s-%s-%d"),
 			arch, cpu, bits);
 		if (dbName) {
-			if (!rz_type_db_load_sysregs_sdb(s->srdb, dbName)) {
+			if (!rz_sysreg_load_sdb(s->srdb, dbName)) {
 				s->srdb = NULL;
 			}
 			free(dbName);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`rz_arch_profile_add_flag_every_io` didn't actually need `RzCore` as one of its arguments. It just needed `RzArchProfile` for the hashtables and `RzFlag`,  so that the flags can be added. That is what has been done here. 

**Test plan**

- [ ] CI is green

**Closing issues**

None
