### PR TITLE
Avoid using pcache when emulating functions.

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -125,8 +125,6 @@ static char *getFunctionNamePrefix(RzCore *core, ut64 off, const char *name) {
 	return strdup(name);
 }
 
-static RzCore *mycore = NULL;
-
 // XXX: copypaste from analysis/data.c
 #define MINLEN 1
 static int is_string(const ut8 *buf, int size, int *len) {
@@ -5363,12 +5361,13 @@ static ut64 ntarget = UT64_MAX;
 
 // TODO differentiate endian-aware mem_read with other reads; move ntarget handling to another function
 static int esilbreak_mem_read(RzAnalysisEsil *esil, ut64 addr, ut8 *buf, int len) {
+	RzCore *core = esil->analysis->coreb.core;
 	ut8 str[128];
 	if (addr != UT64_MAX) {
 		esilbreak_last_read = addr;
 	}
 	handle_var_stack_access(esil, addr, RZ_ANALYSIS_VAR_ACCESS_TYPE_READ, len);
-	if (myvalid(mycore->io, addr) && rz_io_read_at(mycore->io, addr, (ut8 *)buf, len)) {
+	if (myvalid(core->io, addr) && rz_io_read_at(core->io, addr, (ut8 *)buf, len)) {
 		ut64 refptr;
 		bool trace = true;
 		switch (len) {
@@ -5383,22 +5382,22 @@ static int esilbreak_mem_read(RzAnalysisEsil *esil, ut64 addr, ut8 *buf, int len
 			break;
 		default:
 			trace = false;
-			rz_io_read_at(mycore->io, addr, (ut8 *)buf, len);
+			rz_io_read_at(core->io, addr, (ut8 *)buf, len);
 			break;
 		}
 		// TODO incorrect
 		bool validRef = false;
-		if (trace && myvalid(mycore->io, refptr)) {
+		if (trace && myvalid(core->io, refptr)) {
 			if (ntarget == UT64_MAX || ntarget == refptr) {
 				str[0] = 0;
-				if (rz_io_read_at(mycore->io, refptr, str, sizeof(str)) < 1) {
+				if (rz_io_read_at(core->io, refptr, str, sizeof(str)) < 1) {
 					//eprintf ("Invalid read\n");
 					str[0] = 0;
 					validRef = false;
 				} else {
-					rz_analysis_xrefs_set(mycore->analysis, esil->address, refptr, RZ_ANALYSIS_REF_TYPE_DATA);
+					rz_analysis_xrefs_set(core->analysis, esil->address, refptr, RZ_ANALYSIS_REF_TYPE_DATA);
 					str[sizeof(str) - 1] = 0;
-					add_string_ref(mycore, esil->address, refptr);
+					add_string_ref(core, esil->address, refptr);
 					esilbreak_last_data = UT64_MAX;
 					validRef = true;
 				}
@@ -5407,7 +5406,7 @@ static int esilbreak_mem_read(RzAnalysisEsil *esil, ut64 addr, ut8 *buf, int len
 
 		/** resolve ptr */
 		if (ntarget == UT64_MAX || ntarget == addr || (ntarget == UT64_MAX && !validRef)) {
-			rz_analysis_xrefs_set(mycore->analysis, esil->address, addr, RZ_ANALYSIS_REF_TYPE_DATA);
+			rz_analysis_xrefs_set(core->analysis, esil->address, addr, RZ_ANALYSIS_REF_TYPE_DATA);
 		}
 	}
 	return 0; // fallback
@@ -5660,7 +5659,6 @@ RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *tar
 	ut64 end = 0LL;
 	ut64 cur;
 
-	mycore = core;
 	if (!strcmp(str, "?")) {
 		eprintf("Usage: aae[f] [len] [addr] - analyze refs in function, section or len bytes with esil\n");
 		eprintf("  aae $SS @ $S             - analyze the whole section\n");
@@ -5947,7 +5945,7 @@ RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *tar
 					break;
 				}
 				if ((target && dst == ntarget) || !target) {
-					if (dst > 0xffff && op.src[1] && (dst & 0xffff) == (op.src[1]->imm & 0xffff) && myvalid(mycore->io, dst)) {
+					if (dst > 0xffff && op.src[1] && (dst & 0xffff) == (op.src[1]->imm & 0xffff) && myvalid(core->io, dst)) {
 						RzFlagItem *f;
 						char *str;
 						if (CHECKREF(dst) || CHECKREF(cur)) {
@@ -5957,7 +5955,7 @@ RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *tar
 							}
 							if ((f = rz_core_flag_get_by_spaces(core->flags, dst))) {
 								rz_meta_set_string(core->analysis, RZ_META_TYPE_COMMENT, cur, f->name);
-							} else if ((str = is_string_at(mycore, dst, NULL))) {
+							} else if ((str = is_string_at(core, dst, NULL))) {
 								char *str2 = sdb_fmt("esilref: '%s'", str);
 								// HACK avoid format string inside string used later as format
 								// string crashes disasm inside agf under some conditions.
@@ -5974,7 +5972,7 @@ RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *tar
 		case RZ_ANALYSIS_OP_TYPE_LOAD: {
 			ut64 dst = esilbreak_last_read;
 			if (dst != UT64_MAX && CHECKREF(dst)) {
-				if (myvalid(mycore->io, dst)) {
+				if (myvalid(core->io, dst)) {
 					rz_analysis_xrefs_set(core->analysis, cur, dst, RZ_ANALYSIS_REF_TYPE_DATA);
 					if (cfg_analysis_strings) {
 						add_string_ref(core, op.addr, dst);
@@ -5983,7 +5981,7 @@ RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *tar
 			}
 			dst = esilbreak_last_data;
 			if (dst != UT64_MAX && CHECKREF(dst)) {
-				if (myvalid(mycore->io, dst)) {
+				if (myvalid(core->io, dst)) {
 					rz_analysis_xrefs_set(core->analysis, cur, dst, RZ_ANALYSIS_REF_TYPE_DATA);
 					if (cfg_analysis_strings) {
 						add_string_ref(core, op.addr, dst);
@@ -6135,7 +6133,6 @@ RZ_API int rz_core_search_value_in_range(RzCore *core, RzInterval search_itv, ut
 	bool vinfun = rz_config_get_b(core->config, "analysis.vinfun");
 	bool vinfunr = rz_config_get_b(core->config, "analysis.vinfunrange");
 	bool analyze_strings = rz_config_get_b(core->config, "analysis.strings");
-	mycore = core;
 	ut8 buf[4096];
 	ut64 v64, value = 0, size;
 	ut64 from = search_itv.addr, to = rz_itv_end(search_itv);
@@ -6242,7 +6239,7 @@ RZ_API int rz_core_search_value_in_range(RzCore *core, RzInterval search_itv, ut
 				if (isValidMatch) {
 					cb(core, addr, value, vsize, cb_user);
 					if (analyze_strings && stringAt(core, addr)) {
-						add_string_ref(mycore, addr, value);
+						add_string_ref(core, addr, value);
 					}
 					hitctr++;
 				}

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -742,7 +742,7 @@ RZ_IPI void rz_core_analysis_esil_init_mem(RzCore *core, const char *name, ut64 
 	v = sdb_itoa(esil->stack_fd, val, 10);
 	sdb_set(core->sdb, "aeim.fd", v, 0);
 
-	rz_config_set_i(core->config, "io.va", true);
+	rz_config_set_b(core->config, "io.va", true);
 	if (pattern && *pattern) {
 		switch (*pattern) {
 		case '0':
@@ -7089,13 +7089,13 @@ RZ_API bool rz_core_analysis_everything(RzCore *core, bool experimental, char *d
 	if (!rz_str_startswith(rz_config_get(core->config, "asm.arch"), "x86")) {
 		rz_core_analysis_value_pointers(core, RZ_OUTPUT_MODE_STANDARD);
 		rz_core_task_yield(&core->tasks);
-		bool ioCache = rz_config_get_i(core->config, "io.pcache");
-		rz_config_set_i(core->config, "io.pcache", 1);
+		bool pcache = rz_config_get_b(core->config, "io.pcache");
+		rz_config_set_b(core->config, "io.pcache", false);
 		oldstr = rz_print_rowlog(core->print, "Emulate functions to find computed references (aaef)");
 		rz_core_analysis_esil_references_all_functions(core);
 		rz_print_rowlog_done(core->print, oldstr);
 		rz_core_task_yield(&core->tasks);
-		rz_config_set_i(core->config, "io.pcache", ioCache);
+		rz_config_set_b(core->config, "io.pcache", pcache);
 		if (rz_cons_is_breaked()) {
 			return false;
 		}
@@ -7269,13 +7269,12 @@ RZ_IPI bool rz_core_analysis_types_propagation(RzCore *core) {
 		eprintf("TOFIX: aaft can't run in debugger mode.\n");
 		return false;
 	}
-	const char *io_cache_key = "io.pcache.write";
 	RzConfigHold *hold = rz_config_hold_new(core->config);
-	rz_config_hold_i(hold, "io.va", io_cache_key, NULL);
-	bool io_cache = rz_config_get_i(core->config, io_cache_key);
+	rz_config_hold_i(hold, "io.va", "io.pcache.write", NULL);
+	bool io_cache = rz_config_get_b(core->config, "io.pcache.write");
 	if (!io_cache) {
 		// XXX. we shouldnt need this, but it breaks 'rizin -c aaa -w ls'
-		rz_config_set_i(core->config, io_cache_key, true);
+		rz_config_set_b(core->config, "io.pcache.write", true);
 	}
 	const bool delete_regs = !rz_flag_space_count(core->flags, RZ_FLAGS_FS_REGISTERS);
 	seek = core->offset;

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -1622,14 +1622,14 @@ static bool cb_iopcache(void *user, void *data) {
 	RzConfigNode *node = (RzConfigNode *)data;
 	if ((bool)node->i_value) {
 		if (core) {
-			rz_config_set_i(core->config, "io.pcache.read", true);
-			rz_config_set_i(core->config, "io.pcache.write", true);
+			rz_config_set_b(core->config, "io.pcache.read", true);
+			rz_config_set_b(core->config, "io.pcache.write", true);
 		}
 	} else {
 		if (core && core->io) {
 			rz_io_desc_cache_fini_all(core->io);
-			rz_config_set_i(core->config, "io.pcache.read", false);
-			rz_config_set_i(core->config, "io.pcache.write", false);
+			rz_config_set_b(core->config, "io.pcache.read", false);
+			rz_config_set_b(core->config, "io.pcache.write", false);
 		}
 	}
 	return true;
@@ -1647,7 +1647,7 @@ static bool cb_iopcacheread(void *user, void *data) {
 			core->io->p_cache &= 2;
 			if (!(core->io->p_cache & 2)) {
 				rz_io_desc_cache_fini_all(core->io);
-				rz_config_set_i(core->config, "io.pcache", false);
+				rz_config_set_b(core->config, "io.pcache", false);
 			}
 		}
 	}
@@ -1666,7 +1666,7 @@ static bool cb_iopcachewrite(void *user, void *data) {
 			core->io->p_cache &= 1;
 			if (!(core->io->p_cache & 1)) {
 				rz_io_desc_cache_fini_all(core->io);
-				rz_config_set_i(core->config, "io.pcache", false);
+				rz_config_set_b(core->config, "io.pcache", false);
 			}
 		}
 	}

--- a/test/db/analysis/arm
+++ b/test/db/analysis/arm
@@ -1078,3 +1078,14 @@ EXPECT=<<EOF
 size: 20
 EOF
 RUN
+
+NAME=aaef xrefs without pcache
+FILE=bins/arm/elf/hello_world
+CMDS=<<EOF
+aaa
+axt @ str.Hello_world
+EOF
+EXPECT=<<EOF
+main 0x512 [DATA] add r3, pc
+EOF
+RUN


### PR DESCRIPTION
# SQUASH ME

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

when we emulate asm, we fail to read due pcache being enabled on aaa

**Test plan**

Added simple test