### PR TITLE
Fix compiler warnings gnu/arc*.c syscall.c print.c debug_gdb.c

### DIFF
--- a/librz/asm/arch/arc/gnu/arc-dis.c
+++ b/librz/asm/arch/arc/gnu/arc-dis.c
@@ -86,8 +86,9 @@ typedef enum
 #define PUT_NEXT_WORD_IN(a)						\
   do									\
     {									\
-      if (is_limm == 1 && !NEXT_WORD (1))				\
+      if (is_limm == 1 && !NEXT_WORD (1)) {				\
 	mwerror (state, _("Illegal limm reference in last instruction!\n")); \
+      } \
       (a) = state->words[1];						\
     }									\
   while (0)
@@ -256,6 +257,11 @@ arc_sprintf (struct arcDisState *state, char *buf, const char *format, ...)
   va_list ap;
 
   va_start (ap, format);
+
+  if (!buf || !format) {
+    va_end (ap);
+    return;
+  }
 
   bp = buf;
   *bp = 0;

--- a/librz/asm/arch/arc/gnu/arcompact-dis.c
+++ b/librz/asm/arch/arc/gnu/arcompact-dis.c
@@ -99,8 +99,9 @@ static bfd_vma bfd_getm32_ac (unsigned int) ATTRIBUTE_UNUSED;
 #define FIELDS9_FLAG(word)     (((BITS(((signed int)(word)),0,5) << 6) | (BITS((word),6,11))) )
 
 #define PUT_NEXT_WORD_IN(a) {		\
-	if (is_limm==1 && !NEXT_WORD(1))       	\
-	  mwerror(state, "Illegal limm reference in last instruction!\n"); \
+          if (is_limm==1 && !NEXT_WORD(1)) { \
+            mwerror(state, "Illegal limm reference in last instruction!\n"); \
+          } \
           if (info->endian == BFD_ENDIAN_LITTLE) { \
             (a) = ((state->words[1] & 0xff00) | (state->words[1] & 0xff)) << 16; \
             (a) |= ((state->words[1] & 0xff0000) | (state->words[1] & 0xff000000)) >> 16;	\

--- a/librz/debug/p/debug_gdb.c
+++ b/librz/debug/p/debug_gdb.c
@@ -234,7 +234,7 @@ static RzList *rz_debug_gdb_map_get(RzDebug *dbg) { //TODO
 			snprintf(name, sizeof(name), "unk%d", unk++);
 		}
 		perm = 0;
-		for (i = 0; perms[i] && i < 5; i++) {
+		for (i = 0; i < 5 && perms[i]; i++) {
 			switch (perms[i]) {
 			case 'r': perm |= RZ_PERM_R; break;
 			case 'w': perm |= RZ_PERM_W; break;

--- a/librz/include/rz_syscall.h
+++ b/librz/include/rz_syscall.h
@@ -92,6 +92,7 @@ RZ_API RzSyscallItem *rz_syscall_item_new_from_string(const char *name, const ch
 RZ_API void rz_syscall_item_free(RzSyscallItem *si);
 
 RZ_API RzSyscall *rz_syscall_new(void);
+RZ_API void rz_sysregs_db_free(RzSysregsDB *sysregdb);
 RZ_API void rz_syscall_free(RzSyscall *ctx);
 RZ_API RzSyscall *rz_syscall_ref(RzSyscall *sc);
 RZ_API bool rz_syscall_setup(RzSyscall *s, const char *arch, int bits, const char *cpu, const char *os);

--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -1337,6 +1337,7 @@ RZ_API void rz_print_hexdiff(RzPrint *p, ut64 aa, const ut8 *_a, ut64 ba, const 
 }
 
 RZ_API void rz_print_bytes(RzPrint *p, const ut8 *buf, int len, const char *fmt) {
+	rz_return_if_fail(fmt);
 	int i;
 	if (p) {
 		for (i = 0; i < len; i++) {


### PR DESCRIPTION
# SQUASH ME

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Resolves the NULL format warnings and a leak in rz_syscall