### PR TITLE
Support self-unhooking of RzEvent Callbacks

### DIFF
--- a/librz/include/rz_util/rz_event.h
+++ b/librz/include/rz_util/rz_event.h
@@ -16,6 +16,7 @@ typedef struct rz_event_t {
 	bool incall;
 	HtUP *callbacks;
 	RzVector all_callbacks;
+	RzVector /*<RzEventCallbackHandle>*/ pending_unhook; ///< while inside of a call and a handle is unhooked, the unhook is deferred and saved here
 	int next_handle;
 } RzEvent;
 

--- a/librz/util/event.c
+++ b/librz/util/event.c
@@ -27,6 +27,7 @@ RZ_API RzEvent *rz_event_new(void *user) {
 		goto err;
 	}
 	rz_vector_init(&ev->all_callbacks, sizeof(RzEventCallbackHook), NULL, NULL);
+	rz_vector_init(&ev->pending_unhook, sizeof(RzEventCallbackHandle), NULL, NULL);
 	return ev;
 err:
 	rz_event_free(ev);
@@ -37,8 +38,9 @@ RZ_API void rz_event_free(RzEvent *ev) {
 	if (!ev) {
 		return;
 	}
+	rz_vector_fini(&ev->pending_unhook);
 	ht_up_free(ev->callbacks);
-	rz_vector_clear(&ev->all_callbacks);
+	rz_vector_fini(&ev->all_callbacks);
 	free(ev);
 }
 
@@ -92,6 +94,12 @@ static bool del_hook(void *user, const ut64 k, const void *v) {
 
 RZ_API void rz_event_unhook(RzEvent *ev, RzEventCallbackHandle handle) {
 	rz_return_if_fail(ev);
+	if (ev->incall) {
+		// when inside a call (meaning rz_event_send currently iterates over the callback vectors),
+		// defer the unhook to after the rz_event_send is done.
+		rz_vector_push(&ev->pending_unhook, &handle);
+		return;
+	}
 	if (handle.type == RZ_EVENT_ALL) {
 		// try to delete it both from each list of callbacks and from
 		// the "all_callbacks" vector
@@ -116,12 +124,17 @@ RZ_API void rz_event_send(RzEvent *ev, int type, void *data) {
 	ev->incall = false;
 
 	RzVector *cbs = ht_up_find(ev->callbacks, (ut64)type, NULL);
-	if (!cbs) {
-		return;
+	if (cbs) {
+		ev->incall = true;
+		rz_vector_foreach(cbs, hook) {
+			hook->cb(ev, type, hook->user, data);
+		}
+		ev->incall = false;
 	}
-	ev->incall = true;
-	rz_vector_foreach(cbs, hook) {
-		hook->cb(ev, type, hook->user, data);
+
+	RzEventCallbackHandle *unhook_handle;
+	rz_vector_foreach(&ev->pending_unhook, unhook_handle) {
+		rz_event_unhook(ev, *unhook_handle);
 	}
-	ev->incall = false;
+	rz_vector_clear(&ev->pending_unhook);
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Previously, when calling `rz_event_unhook()` inside an event callback itself, it would mess up the internal callback vectors while they are still being iterated over. I solved this by deferring the actual unhooking to after the send is complete if necessary.

There is one implementation detail:
* When two callbacks A and B are registered for the same event and
* B is after A in the vector and
* A unhooks B
* then B will still be still be called with this single event one last time, happening after A's request for unhook.

This has the following implications:
Pro: the fact whether B will be called on this specific event does not depend on the order in which the callbacks have been registered.
Con: If the unhook out of A comes from deleting/freeing something that B accesses, B might uaf depending on how it is implemented.

Since it's not completely clear whether not calling B in this case is "better" than this behavior and preventing the B call would need additional logic (which however can easily be implemented), I decided to leave this open for now and not specify any behavior for it yet, until we find a case where it is relevant.

**Test plan**

see the added unit test