### PR TITLE
Define rizin_exe also when using blob feature

### DIFF
--- a/binrz/blob/meson.build
+++ b/binrz/blob/meson.build
@@ -1,4 +1,4 @@
-executable('rizin', 'main.c',
+rizin_exe = executable('rizin', 'main.c',
   include_directories: [platform_inc],
   dependencies: [
     rz_main_dep,

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -1,12 +1,12 @@
-test_conf_data = configuration_data()
-test_conf_data.set_quoted('RIZIN_BUILD_PATH', rizin_exe.full_path())
-test_config_h = configure_file(
-  input: 'test_config.h.in',
-  output: 'test_config.h',
-  configuration: test_conf_data,
-)
-
 if get_option('enable_tests')
+  test_conf_data = configuration_data()
+  test_conf_data.set_quoted('RIZIN_BUILD_PATH', rizin_exe.full_path())
+  test_config_h = configure_file(
+    input: 'test_config.h.in',
+    output: 'test_config.h',
+    configuration: test_conf_data,
+  )
+
   subdir('auxiliary')
 
   tests = [


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Unit tests need the path of the rizin executable to properly run in some
cases, thus define rizin_exe variable both in regular build and when
rizin is built with -Dblob=true.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Just check the android build.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
