### PR TITLE
Fix args comments are missing in pd command

### DIFF
--- a/librz/analysis/fcn.c
+++ b/librz/analysis/fcn.c
@@ -2422,7 +2422,6 @@ RZ_API RZ_OWN RzCallable *rz_analysis_function_derive_type(RzAnalysis *analysis,
 	rz_pvector_foreach (args, it) {
 		RzAnalysisVar *var = *it;
 		if (!var) {
-			eprintf("missing arg var\n");
 			// TODO: maybe create a stub void arg here?
 			continue;
 		}

--- a/librz/core/analysis_tp.c
+++ b/librz/core/analysis_tp.c
@@ -338,8 +338,26 @@ static void type_match(RzCore *core, char *fcn_name, ut64 addr, ut64 baddr, cons
 			const char *typestr = rz_str_new(rz_list_get_n(types, pos++));
 			type = rz_type_parse_string_single(typedb->parser, typestr, NULL);
 		} else {
-			type = rz_type_func_args_type(typedb, fcn_name, arg_num);
-			name = rz_type_func_args_name(typedb, fcn_name, arg_num);
+			RzCallable *callable = rz_type_func_get(typedb, fcn_name);
+			if (!callable) {
+				RzAnalysisFunction *fcn = rz_analysis_get_function_byname(analysis, fcn_name);
+				if (!fcn) {
+					continue;
+				}
+				callable = rz_analysis_function_derive_type(analysis, fcn);
+				if (!callable) {
+					continue;
+				}
+			}
+			if (arg_num >= rz_pvector_len(callable->args)) {
+				continue;
+			}
+			RzCallableArg *arg = *rz_pvector_index_ptr(callable->args, arg_num);
+			if (!arg) {
+				continue;
+			}
+			type = arg->type;
+			name = arg->name;
 		}
 		if (!type && !userfnc) {
 			continue;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

For predefined function types we call `rz_type_func_get` to get `RzCallable` from hashtable, but for "free-standing" functions, they are not added into `typedb`. So we can call `rz_analysis_function_derive_type` to create a new one that derives types from `RzAnalysisVar`. This will fix 3 failing tests in `db/analysis/x86_64`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
