### PR TITLE
Fix running into dead loop when integrating dwarf info for Free Pascal

### DIFF
--- a/librz/type/type.c
+++ b/librz/type/type.c
@@ -691,6 +691,9 @@ RZ_API ut64 rz_type_db_union_bitsize(const RzTypeDB *typedb, RZ_NONNULL RzBaseTy
 RZ_API ut64 rz_type_db_typedef_bitsize(const RzTypeDB *typedb, RZ_NONNULL RzBaseType *btype) {
 	rz_return_val_if_fail(typedb && btype && btype->kind == RZ_BASE_TYPE_KIND_TYPEDEF, 0);
 	rz_return_val_if_fail(btype->type, 0);
+	if (btype->type->kind == RZ_TYPE_KIND_IDENTIFIER && !strcmp(btype->type->identifier.name, btype->name)) {
+		return btype->size;
+	}
 	return rz_type_db_get_bitsize(typedb, btype->type);
 }
 

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -1780,8 +1780,8 @@ EXPECT=<<EOF
 |           0x00401991      66897df8       mov   word [mag], di
 |           0x00401995      668975f0       mov   word [szel], si
 |           0x00401999      b801000000     mov   eax, 1
-|           0x0040199e      bf01000000     mov   edi, 1
-|           0x004019a3      89c6           mov   esi, eax
+|           0x0040199e      bf01000000     mov   edi, 1                ; int64_t arg2
+|           0x004019a3      89c6           mov   esi, eax              ; int64_t arg_8h
 |           0x004019a5      e8b6a10200     call  sym.CRT____GOTOXY_TCRTCOORD_TCRTCOORD
 |           0x004019aa      66448b65f0     mov   r12w, word [szel]
 |           0x004019af      66c745ec0100   mov   word [i], 1


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

When integrating dwarf var type info into `typedb`, the `SmallInt` type of `Free Pascal` is recognized as `typedef`. But its base type and its type are the same, so this will leads to a dead loop when getting the `bit size` of that type.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The `function info integration freepascal` in `db/cmd/dwarf` is green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
