### PR TITLE
Fix afs command not working on user defined retval and args

### DIFF
--- a/librz/analysis/d/types-macos.sdb.txt
+++ b/librz/analysis/d/types-macos.sdb.txt
@@ -1,6 +1,40 @@
 sigset_t=typedef
 typedef.sigset_t=uint32_t
 
+__idtype=enum
+enum.__idtype=P_ALL,P_GID,P_PGID
+enum.__idtype.P_ALL=0x0
+enum.__idtype.P_GID=0x1
+enum.__idtype.P_PGID=0x2
+
+idtype_t=typedef
+typedef.idtype_t=enum __idtype
+
+fd_mask=typedef
+typedef.fd_mask=int32_t
+
+_fd_set=struct
+struct._fd_set=fds_bits
+struct._fd_set.fds_bits=fd_mask,0,32
+
+fd_set=typedef
+typedef.fd_set=struct _fd_set
+
+__siginfo_t=struct
+struct.__siginfo_t=si_signo,si_errno,si_code,si_pid,si_uid,si_status,si_addr,si_value,si_band
+struct.__siginfo_t.si_signo=int,0,0
+struct.__siginfo_t.si_errno=int,4,0
+struct.__siginfo_t.si_code=int,8,0
+struct.__siginfo_t.si_pid=pid_t,12,0
+struct.__siginfo_t.si_uid=uid_t,16,0
+struct.__siginfo_t.si_status=int,20,0
+struct.__siginfo_t.si_addr=void*,24,0
+struct.__siginfo_t.si_value=union sigval,28,0
+struct.__siginfo_t.si_band=int,36,0
+
+siginfo_t=typedef
+typedef.siginfo_t=struct __siginfo_t
+
 sigaction=struct
 struct.sigaction=__sigaction_u,sa_mask,sa_flags
 struct.sigaction.__sigaction_u=void*,0,0

--- a/librz/analysis/var.c
+++ b/librz/analysis/var.c
@@ -219,6 +219,7 @@ RZ_API void rz_analysis_function_delete_all_vars(RzAnalysisFunction *fcn) {
 		var_free(*it);
 	}
 	rz_pvector_clear(&fcn->vars);
+	fcn->argnum = 0;
 }
 
 RZ_API void rz_analysis_function_delete_unused_vars(RzAnalysisFunction *fcn) {

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -9145,6 +9145,7 @@ RZ_IPI RzCmdStatus rz_analysis_function_signature_type_handler(RzCore *core, int
 		eprintf("Cannot find type %s\n", argv[1]);
 		return RZ_CMD_STATUS_ERROR;
 	}
+	fcn->ret_type = ret_type;
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -245,6 +245,7 @@ typedef struct rz_analysis_function_t {
 	HtUP /*<ut64, char *>*/ *labels;
 	HtPP /*<char *, ut64 *>*/ *label_addrs;
 	RzPVector vars;
+	RzType *ret_type;
 	HtUP /*<st64, RzPVector<RzAnalysisVar *>>*/ *inst_vars; // offset of instructions => the variables they access
 	ut64 reg_save_area; // size of stack area pre-reserved for saving registers
 	st64 bp_off; // offset of bp inside owned stack frame

--- a/librz/type/type.c
+++ b/librz/type/type.c
@@ -769,7 +769,6 @@ static char *type_as_string(const RzTypeDB *typedb, RZ_NONNULL const RzType *typ
 		// Here it can be any of the RzBaseType
 		RzBaseType *btype = rz_type_db_get_base_type(typedb, type->identifier.name);
 		if (!btype) {
-			eprintf("cannot find base type \"%s\"\n", type->identifier.name);
 			return NULL;
 		}
 		if (type->identifier.is_const) {
@@ -823,7 +822,6 @@ static char *type_as_string_decl(const RzTypeDB *typedb, RZ_NONNULL const RzType
 		// Here it can be any of the RzBaseType
 		RzBaseType *btype = rz_type_db_get_base_type(typedb, type->identifier.name);
 		if (!btype) {
-			eprintf("cannot find base type \"%s\"\n", type->identifier.name);
 			return NULL;
 		}
 		const char *btypestr = btype->kind == RZ_BASE_TYPE_KIND_TYPEDEF ? btype->name : rz_type_db_base_type_as_string(typedb, btype);
@@ -879,7 +877,6 @@ static char *type_as_string_identifier_decl(const RzTypeDB *typedb, RZ_NONNULL c
 		// Here it can be any of the RzBaseType
 		RzBaseType *btype = rz_type_db_get_base_type(typedb, type->identifier.name);
 		if (!btype) {
-			eprintf("cannot find base type \"%s\"\n", type->identifier.name);
 			return NULL;
 		}
 		// If the structure/union is anonymous, then we put declaration inline,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

When users using the `afs` command to define function signature to what they want, we don't have a field that holds a function's retval information. For the args, we should make it accord with the user's thought. When the current args vector length is less than the user required or it is empty, we should add the args. Otherwise, we should remove them.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Fix `afs fcnname with dots` in `db/cmd/types`.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
