### PR TITLE
RzArch: Fix `clang-cl` and Coverity warnings

### DIFF
--- a/librz/analysis/arch_platform.c
+++ b/librz/analysis/arch_platform.c
@@ -57,7 +57,7 @@ RZ_API void rz_arch_platform_item_free(RzArchPlatformItem *item) {
 }
 
 static bool sdb_load_platform_profile(RZ_NONNULL RzArchPlatformTarget *t, RZ_NONNULL Sdb *sdb) {
-	rz_return_val_if_fail(t && sdb, NULL);
+	rz_return_val_if_fail(t && sdb, false);
 	SdbKv *kv;
 	SdbListIter *iter;
 	SdbList *l = sdb_foreach_list(sdb, false);
@@ -71,12 +71,12 @@ static bool sdb_load_platform_profile(RZ_NONNULL RzArchPlatformTarget *t, RZ_NON
 			argument_key = rz_str_newf("%s.address", item->name);
 			if (!argument_key) {
 				rz_arch_platform_item_free(item);
-				return NULL;
+				return false;
 			}
 			ut64 address = sdb_num_get(sdb, argument_key, NULL);
 			if (!address) {
 				rz_arch_platform_item_free(item);
-				return NULL;
+				return false;
 			}
 
 			argument_key = rz_str_newf("%s.comment", item->name);
@@ -91,7 +91,7 @@ static bool sdb_load_platform_profile(RZ_NONNULL RzArchPlatformTarget *t, RZ_NON
 }
 
 static bool sdb_load_arch_platform_by_path(RZ_NONNULL RzArchPlatformTarget *t, RZ_NONNULL const char *path) {
-	rz_return_val_if_fail(t && path, NULL);
+	rz_return_val_if_fail(t && path, false);
 	if (!path) {
 		return false;
 	}
@@ -112,7 +112,7 @@ static bool sdb_load_arch_platform_by_path(RZ_NONNULL RzArchPlatformTarget *t, R
  * \param path reference to path of the SDB file
  */
 RZ_API bool rz_arch_load_platform_sdb(RZ_NONNULL RzArchPlatformTarget *t, RZ_NONNULL const char *path) {
-	rz_return_val_if_fail(t && path, NULL);
+	rz_return_val_if_fail(t && path, false);
 	if (!path) {
 		return false;
 	}
@@ -136,7 +136,7 @@ RZ_API bool rz_arch_platform_init(RzArchPlatformTarget *t, RZ_NONNULL const char
 	if (!platform) {
 		return false;
 	}
-	rz_return_val_if_fail(arch && cpu && dir_prefix, NULL);
+	rz_return_val_if_fail(arch && cpu && dir_prefix, false);
 	char *path = rz_str_newf(RZ_JOIN_4_PATHS("%s", RZ_SDB, "asm/platforms", "%s-%s-%s.sdb"),
 		dir_prefix, arch, cpu, platform);
 	if (!path) {

--- a/librz/flag/flag.c
+++ b/librz/flag/flag.c
@@ -474,7 +474,7 @@ static RzFlagItem *evalFlag(RzFlag *f, RzFlagItem *item) {
 /* return true if flag.* exist at offset. Otherwise, false is returned.
  * For example (f, "sym", 3, 0x1000)*/
 RZ_API bool rz_flag_exist_at(RzFlag *f, const char *flag_prefix, ut16 fp_size, ut64 off) {
-	rz_return_val_if_fail(f && flag_prefix, NULL);
+	rz_return_val_if_fail(f && flag_prefix, false);
 	RzListIter *iter = NULL;
 	RzFlagItem *item = NULL;
 	const RzList *list = rz_flag_get_list(f, off);

--- a/librz/reg/profile.c
+++ b/librz/reg/profile.c
@@ -244,7 +244,7 @@ RZ_API bool rz_reg_set_profile_string(RzReg *reg, const char *str) {
 }
 
 RZ_API bool rz_reg_set_profile(RzReg *reg, const char *profile) {
-	rz_return_val_if_fail(reg && profile, NULL);
+	rz_return_val_if_fail(reg && profile, false);
 	char *base, *file;
 	char *str = rz_file_slurp(profile, NULL);
 	if (!str) {

--- a/librz/syscall/syscall.c
+++ b/librz/syscall/syscall.c
@@ -142,7 +142,7 @@ static inline bool sysregs_reload_needed(RzSyscall *s, const char *arch, int bit
 }
 
 static bool sdb_load_sysregs(RzSysregsDB *sysregdb, Sdb *sdb) {
-	rz_return_val_if_fail(sysregdb && sdb, NULL);
+	rz_return_val_if_fail(sysregdb && sdb, false);
 	RzSysregItem *sysregitem;
 	SdbKv *kv;
 	SdbListIter *iter;
@@ -155,12 +155,12 @@ static bool sdb_load_sysregs(RzSysregsDB *sysregdb, Sdb *sdb) {
 			argument_key = rz_str_newf("%s.address", name);
 
 			if (!argument_key) {
-				return NULL;
+				return false;
 			}
 			ut64 address = sdb_num_get(sdb, argument_key, NULL);
 			if (!address) {
 				rz_sysreg_item_free(sysregitem);
-				return NULL;
+				return false;
 			}
 
 			argument_key = rz_str_newf("%s.comment", name);

--- a/test/integration/test_cpu_platform_profiles.c
+++ b/test/integration/test_cpu_platform_profiles.c
@@ -47,6 +47,7 @@ bool test_cpu_profiles() {
 	RzSerializeResultInfo *res = rz_serialize_result_info_new();
 	mu_assert_notnull(res, "result info new");
 	err = rz_project_load_file(core, ".tmp/cpu_profile.rzdb", true, res);
+	rz_serialize_result_info_free(res);
 	mu_assert_eq(err, RZ_PROJECT_ERR_SUCCESS, "project load err");
 
 	// 7. Check the values again
@@ -101,6 +102,7 @@ bool test_platform_profiles() {
 	RzSerializeResultInfo *res = rz_serialize_result_info_new();
 	mu_assert_notnull(res, "result info new");
 	err = rz_project_load_file(core, ".tmp/cpu_platform.rzdb", true, res);
+	rz_serialize_result_info_free(res);
 	mu_assert_eq(err, RZ_PROJECT_ERR_SUCCESS, "project load err");
 
 	// 7. Check the values again


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes the following clang-cl warnings:

```
../librz/analysis/arch_platform.c(60): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'
../librz/analysis/arch_platform.c(74): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'
../librz/analysis/arch_platform.c(79): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'
../librz/analysis/arch_platform.c(94): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'
../librz/analysis/arch_platform.c(115): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'
../librz/analysis/arch_platform.c(139): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'

 ../librz/syscall/syscall.c(145): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'
../librz/syscall/syscall.c(158): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'
../librz/syscall/syscall.c(163): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'
../librz/flag/flag.c(477): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'
 ../librz/reg/profile.c(247): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'

```

**Test plan**

CI is green.

**Closing issues**
Partially addresses https://github.com/rizinorg/rizin/issues/1266
