### PR TITLE
Fix crash in `rz_interpret_handler()`

### DIFF
--- a/librz/core/cmd_interpret.c
+++ b/librz/core/cmd_interpret.c
@@ -14,6 +14,9 @@ RZ_IPI RzCmdStatus rz_interpret_handler(RzCore *core, int argc, const char **arg
 		rz_cons_singleton()->is_html = 0;
 		char *cmd_output = rz_core_cmd_str(core, argv[1]);
 		rz_cons_singleton()->is_html = tmp_html;
+		if (!cmd_output) {
+			return RZ_CMD_STATUS_ERROR;
+		}
 		rz_core_cmd(core, cmd_output, 0);
 		free(cmd_output);
 		return RZ_CMD_STATUS_OK;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

If `rz_core_cmd_str()` fails, it returns `NULL`.

