### PR TITLE
Fix #1317 - Fix `dL handler` printing a warning

### DIFF
--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -4812,7 +4812,7 @@ RZ_IPI int rz_cmd_debug(void *data, const char *input) {
 			rz_config_set(core->config, "dbg.backend", backend);
 			// implicit by config.set rz_debug_use (core->dbg, str);
 			free(backend);
-			break;
+			return RZ_CMD_STATUS_OK;
 		}
 		case '?': {
 			rz_core_cmd_help(core, help_msg_dL);


### PR DESCRIPTION
Return immediately after setting the debug handler instead of continuing to the printing code

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Return immediately after setting the debug handler instead of continuing to the printing code

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tests pass

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Fixes #1317
