### PR TITLE
Fix #1261 - remove unused libc function checkers

### DIFF
--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -86,10 +86,6 @@ typedef enum {
 #define RZ_PERM_ACCESS 32
 #define RZ_PERM_CREAT  64
 
-// HACK to fix capstone-android-mips build
-#undef mips
-#define mips mips
-
 #if defined(__powerpc) || defined(__powerpc__)
 #undef __POWERPC__
 #define __POWERPC__ 1
@@ -181,14 +177,6 @@ typedef int socklen_t;
 #define FUNC_ATTR_USED                  __attribute__((used))
 #define FUNC_ATTR_WARN_UNUSED_RESULT    __attribute__((warn_unused_result))
 #define FUNC_ATTR_ALWAYS_INLINE         __attribute__((always_inline))
-
-#ifdef __clang__
-// clang only
-#elif defined(__INTEL_COMPILER)
-// intel only
-#else
-// gcc only
-#endif
 #else
 #define FUNC_ATTR_MALLOC
 #define FUNC_ATTR_ALLOC_SIZE(x)

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -95,40 +95,9 @@ typedef enum {
 #define __POWERPC__ 1
 #endif
 
-#if __IPHONE_8_0 && defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
-#define LIBC_HAVE_SYSTEM 0
-#else
-#define LIBC_HAVE_SYSTEM 1
-#endif
-
-#if APPLE_SDK_IPHONEOS || APPLE_SDK_APPLETVOS || APPLE_SDK_WATCHOS || APPLE_SDK_APPLETVSIMULATOR || APPLE_SDK_WATCHSIMULATOR
-#define LIBC_HAVE_PTRACE 0
-#else
-#define LIBC_HAVE_PTRACE 1
-#endif
-
-#if HAVE_FORK
-#define LIBC_HAVE_FORK 1
-#else
-#define LIBC_HAVE_FORK 0
-#endif
-
 #if defined(__OpenBSD__)
 #include <sys/param.h>
 #undef MAXCOMLEN /* redefined in zipint.h */
-#endif
-
-/* release >= 5.9 */
-#if __OpenBSD__ && OpenBSD >= 201605
-#define LIBC_HAVE_PLEDGE 1
-#else
-#define LIBC_HAVE_PLEDGE 0
-#endif
-
-#if __sun
-#define LIBC_HAVE_PRIV_SET 1
-#else
-#define LIBC_HAVE_PRIV_SET 0
 #endif
 
 #ifdef __GNUC__

--- a/librz/include/rz_types_base.h
+++ b/librz/include/rz_types_base.h
@@ -219,8 +219,6 @@ typedef struct _utX {
 #endif
 
 #if APPLE_SDK_IPHONESIMULATOR
-#undef LIBC_HAVE_FORK
-#define LIBC_HAVE_FORK 0
 #undef DEBUGGER
 #define DEBUGGER 0
 #endif

--- a/librz/main/rz-agent.c
+++ b/librz/main/rz-agent.c
@@ -95,7 +95,7 @@ RZ_API int rz_main_rz_agent(int argc, const char **argv) {
 	memorystatus_control(MEMORYSTATUS_CMD_SET_JETSAM_TASK_LIMIT, getpid(), 256, NULL, 0);
 #endif
 	if (dodaemon) {
-#if LIBC_HAVE_FORK
+#if HAVE_FORK
 		int pid = rz_sys_fork();
 		if (pid > 0) {
 			printf("%d\n", pid);

--- a/librz/socket/run.c
+++ b/librz/socket/run.c
@@ -14,7 +14,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#if __APPLE__ && LIBC_HAVE_FORK
+#if __APPLE__ && HAVE_FORK
 #if !__POWERPC__
 #include <spawn.h>
 #endif
@@ -62,7 +62,7 @@
 #undef HAVE_PTY
 #define HAVE_PTY 0
 #else
-#define HAVE_PTY __UNIX__ && !__ANDROID__ && LIBC_HAVE_FORK && !__sun
+#define HAVE_PTY __UNIX__ && !__ANDROID__ && HAVE_FORK && !__sun
 #endif
 
 #if HAVE_PTY
@@ -1064,12 +1064,12 @@ RZ_API int rz_run_config_env(RzRunProfile *p) {
 
 // NOTE: return value is like in unix return code (0 = ok, 1 = not ok)
 RZ_API int rz_run_start(RzRunProfile *p) {
-#if LIBC_HAVE_FORK
+#if HAVE_EXECVE
 	if (p->_execve) {
 		exit(rz_sys_execv(p->_program, (char *const *)p->_args));
 	}
 #endif
-#if __APPLE__ && !__POWERPC__ && LIBC_HAVE_FORK
+#if __APPLE__ && !__POWERPC__ && HAVE_FORK
 	posix_spawnattr_t attr = { 0 };
 	pid_t pid = -1;
 	int ret;
@@ -1245,13 +1245,12 @@ RZ_API int rz_run_start(RzRunProfile *p) {
 				}
 			}
 			setsid();
-#if !LIBC_HAVE_FORK
+#if HAVE_EXECVE
 			exit(rz_sys_execv(p->_program, (char *const *)p->_args));
 #endif
 #endif
 		}
-// TODO: must be HAVE_EXECVE
-#if LIBC_HAVE_FORK
+#if HAVE_EXECVE
 		exit(rz_sys_execv(p->_program, (char *const *)p->_args));
 #endif
 	}

--- a/librz/socket/socket_proc.c
+++ b/librz/socket/socket_proc.c
@@ -15,7 +15,7 @@
 #define BUFFER_SIZE 4096
 
 RZ_API struct rz_socket_proc_t *rz_socket_proc_open(char *const argv[]) {
-#if __UNIX__ && LIBC_HAVE_FORK
+#if __UNIX__ && HAVE_FORK
 	RzSocketProc *sp = RZ_NEW(RzSocketProc);
 
 	if (!sp) {


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Migrated C preprocessor checks to the meson-provided checks.
- Removed unused checks.

**Test plan**

CI is green

Please be sure to check also locally. cc @devnexen @GustavoLCR @thestr4ng3r 

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/1261
