### PR TITLE
Add test for pointers inside structures

### DIFF
--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1197,6 +1197,33 @@ struct with_array {
 EOF
 RUN
 
+NAME=tsl test with pointers
+FILE==
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+td "struct foo { void *v1; void *v2; };"
+tsl foo
+e asm.bits=32
+td "struct foo { void *v1; void *v2; };"
+tsl foo
+e asm.bits=16
+td "struct foo { void *v1; void *v2; };"
+tsl foo
+EOF
+EXPECT=<<EOF
+struct foo:
+	v1: void * (size = 8, offset = 0)
+	v2: void * (size = 8, offset = 8)
+struct foo:
+	v1: void * (size = 4, offset = 0)
+	v2: void * (size = 4, offset = 4)
+struct foo:
+	v1: void * (size = 2, offset = 0)
+	v2: void * (size = 2, offset = 2)
+EOF
+RUN
+
 NAME=tec test
 FILE==
 CMDS=<<EOF


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Now Rizin supports the pointer size calculation based on the current value of `asm.arch`, `asm.bits`, `asm.os`.
Thus adding the test for https://github.com/rizinorg/rizin/issues/312

**Test plan**

CI is green

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/312
