### PR TITLE
Use RZ_LOG_INFO for Windows debug messages

### DIFF
--- a/librz/debug/p/debug_native.c
+++ b/librz/debug/p/debug_native.c
@@ -362,20 +362,20 @@ static RzDebugReasonType rz_debug_native_wait(RzDebug *dbg, int pid) {
 	} else if (reason == RZ_DEBUG_REASON_NEW_PID) {
 		if (r && r->thread) {
 			PTHREAD_ITEM item = r->thread;
-			rz_cons_printf("(%d) Created process %d (start @ %p) (teb @ %p)\n", item->pid, item->tid, item->lpStartAddress, item->lpThreadLocalBase);
+			RZ_LOG_INFO("(%d) Created process %d (start @ %p) (teb @ %p)\n", item->pid, item->tid, item->lpStartAddress, item->lpThreadLocalBase);
 			rz_cons_flush();
 		}
 	} else if (reason == RZ_DEBUG_REASON_NEW_TID) {
 		if (r && r->thread) {
 			PTHREAD_ITEM item = r->thread;
-			rz_cons_printf("(%d) Created thread %d (start @ %p) (teb @ %p)\n", item->pid, item->tid, item->lpStartAddress, item->lpThreadLocalBase);
+			RZ_LOG_INFO("(%d) Created thread %d (start @ %p) (teb @ %p)\n", item->pid, item->tid, item->lpStartAddress, item->lpThreadLocalBase);
 			rz_cons_flush();
 		}
 		restore_thread = true;
 	} else if (reason == RZ_DEBUG_REASON_EXIT_TID) {
 		PTHREAD_ITEM item = r->thread;
 		if (r && r->thread) {
-			rz_cons_printf("(%d) Finished thread %d Exit code %lu\n", (ut32)item->pid, (ut32)item->tid, item->dwExitCode);
+			RZ_LOG_INFO("(%d) Finished thread %d Exit code %lu\n", (ut32)item->pid, (ut32)item->tid, item->dwExitCode);
 			rz_cons_flush();
 		}
 		if (dbg->tid != orig_tid && item->tid != orig_tid) {
@@ -384,7 +384,7 @@ static RzDebugReasonType rz_debug_native_wait(RzDebug *dbg, int pid) {
 	} else if (reason == RZ_DEBUG_REASON_DEAD) {
 		if (r && r->thread) {
 			PTHREAD_ITEM item = r->thread;
-			rz_cons_printf("(%d) Finished process with exit code %lu\n", dbg->main_pid, item->dwExitCode);
+			RZ_LOG_INFO("(%d) Finished process with exit code %lu\n", dbg->main_pid, item->dwExitCode);
 			rz_cons_flush();
 		}
 		dbg->pid = -1;
@@ -392,7 +392,7 @@ static RzDebugReasonType rz_debug_native_wait(RzDebug *dbg, int pid) {
 	} else if (reason == RZ_DEBUG_REASON_USERSUSP && dbg->tid != orig_tid) {
 		if (r && r->thread) {
 			PTHREAD_ITEM item = r->thread;
-			rz_cons_printf("(%d) Created DebugBreak thread %d (start @ %p)\n", item->pid, item->tid, item->lpStartAddress);
+			RZ_LOG_INFO("(%d) Created DebugBreak thread %d (start @ %p)\n", item->pid, item->tid, item->lpStartAddress);
 			rz_cons_flush();
 		}
 		// DebugProcessBreak creates a new thread that will trigger a breakpoint. We record the


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

To not print those information messages by default:
```
[XX] C:\projects\rizin\test\db\archos\windows-x64\dbg_rebase var rebase
ANSICON=1 RZ_NOPLUGINS=1 rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -d -Qc 'aa
afv @ entry0
doc
afv @ entry0
' bins/pe/hello_world/hello_world_od64bit.exe
-- stdout
--- expected
+++ actual
@@ -1,3 +1,4 @@
+(4604) Created process 3832 (start @ 00007FF6203A1278) (teb @ 000000AC34BD0000)
 var int64_t var_20h @ rsp+0x48
 var int64_t var_8h @ rsp+0x68
 var int64_t var_10h @ rsp+0x70
-- stderr
Spawned new process with pid 4604, tid = 3832
bin.baddr 0x7ff6203a0000
Using 0x7ff6203a0000
asm.bits 64
[ ] Analyze all flags starting with sym. and entry0 (aa)[[x] Analyze all flags starting with sym. and entry0 (aa)
[**]                 C:\projects\rizin\test\db\asm\8051    13540 OK       922 BR        1 XX       17 FX
[XX] C:\projects\rizin\test\db\archos\windows-x64\dbg_rebase ref rebase
ANSICON=1 RZ_NOPLUGINS=1 rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -d -Qc 'aa
?v `axt main~entry0[1]`-`e bin.baddr`
doc
?v `axt main~entry0[1]`-`e bin.baddr`
' bins/pe/hello_world/hello_world_od64bit.exe
-- stdout
--- expected
+++ actual
@@ -1,2 +1,3 @@
+(3660) Created process 4788 (start @ 00007FF6203A1278) (teb @ 000000E0448C1000)
 0x1203
 0x1203
-- stderr
Spawned new process with pid 3660, tid = 4788
bin.baddr 0x7ff6203a0000
Using 0x7ff6203a0000
asm.bits 64
[ ] Analyze all flags starting with sym. and entry0 (aa)[[x] Analyze all flags starting with sym. and entry0 (aa)
[XX] C:\projects\rizin\test\db\archos\windows-x64\dbg_rebase flag rebase
ANSICON=1 RZ_NOPLUGINS=1 rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -d -Qc 'fs test
f testflag @ main+10
?v `f~testflag[0]`-`e bin.baddr`
doc
?v `f~testflag[0]`-`e bin.baddr`
' bins/pe/hello_world/hello_world_od64bit.exe
-- stdout
--- expected
+++ actual
@@ -1,2 +1,3 @@
+(5712) Created process 1048 (start @ 00007FF6203A1278) (teb @ 0000007CC7985000)
 0x100a
 0x100a
-- stderr
Spawned new process with pid 5712, tid = 1048
bin.baddr 0x7ff6203a0000
Using 0x7ff6203a0000
asm.bits 64
[XX] C:\projects\rizin\test\db\archos\windows-x64\dbg_rebase bp rebase
ANSICON=1 RZ_NOPLUGINS=1 rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -d -Qc 'db main
?v main-`db~main[0]`
doc
?v main-`db~main[0]`
' bins/pe/hello_world/hello_world_od64bit.exe
-- stdout
--- expected
+++ actual
@@ -1,2 +1,3 @@
+(2064) Created process 4836 (start @ 00007FF6203A1278) (teb @ 00000089F890F000)
 0x0
 0x0
-- stderr
Spawned new process with pid 2064, tid = 4836
bin.baddr 0x7ff6203a0000
Using 0x7ff6203a0000
asm.bits 64
[XX] C:\projects\rizin\test\db\archos\windows-x64\dbg_rebase function rebase
ANSICON=1 RZ_NOPLUGINS=1 rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -d -Qc '?v main-`e bin.baddr`
doc
?v main-`e bin.baddr`
' bins/pe/hello_world/hello_world_od64bit.exe
-- stdout
--- expected
+++ actual
@@ -1,2 +1,3 @@
+(1536) Created process 1968 (start @ 00007FF6203A1278) (teb @ 0000001B60D8D000)
 0x1000
 0x1000
-- stderr
Spawned new process with pid 1536, tid = 1968
bin.baddr 0x7ff6203a0000
Using 0x7ff6203a0000
asm.bits 64
```

**Test plan**

CI is green

**Closing issues**

See https://github.com/rizinorg/rizin/pull/1318#issuecomment-882453431
