### PR TITLE
Add API calls of Windows Heap for Cutter

### DIFF
--- a/librz/core/cheap.c
+++ b/librz/core/cheap.c
@@ -3,20 +3,30 @@
 
 /* API calls of windows heap for Cutter */
 #if __WINDOWS__
-RZ_API RzList *rz_heap_windows_blocks_list(RzCore *core) {
+/**
+ * \brief Get a list of heap blocks (Windows heap)
+ * \param core RzCore Pointer
+ * \return RzList of RzWindowsHeapBlock structs
+ */
+RZ_API RZ_OWN RzList *rz_heap_windows_blocks_list(RzCore *core) {
 	return rz_heap_blocks_list(core);
 }
 
-RZ_API RzList *rz_heap_windows_heap_list(RzCore *core) {
+/**
+ * \brief Get a list of heaps (Windows heap)
+ * \param core RzCore Pointer
+ * \return RzList of RzWindowsHeapInfo structs
+ */
+RZ_API RZ_OWN RzList *rz_heap_windows_heap_list(RzCore *core) {
 	return rz_heap_list(core);
 }
 #else
 
-RZ_API RzList *rz_heap_windows_blocks_list(RzCore *core) {
+RZ_API RZ_OWN RzList *rz_heap_windows_blocks_list(RzCore *core) {
 	return NULL;
 }
 
-RZ_API RzList *rz_heap_windows_heap_list(RzCore *core) {
+RZ_API RZ_OWN RzList *rz_heap_windows_heap_list(RzCore *core) {
 	return NULL;
 }
 

--- a/librz/core/cheap.c
+++ b/librz/core/cheap.c
@@ -1,0 +1,23 @@
+#include <rz_core.h>
+#include "core_private.h"
+
+/* API calls of windows heap for Cutter */
+#if __WINDOWS__
+RZ_API RzList *rz_heap_windows_blocks_list(RzCore *core) {
+	return rz_heap_blocks_list(core);
+}
+
+RZ_API RzList *rz_heap_windows_heap_list(RzCore *core) {
+	return rz_heap_list(core);
+}
+#else
+
+RZ_API RzList *rz_heap_windows_blocks_list(RzCore *core) {
+	return NULL;
+}
+
+RZ_API RzList *rz_heap_windows_heap_list(RzCore *core) {
+	return NULL;
+}
+
+#endif

--- a/librz/core/cmd_debug.c
+++ b/librz/core/cmd_debug.c
@@ -1715,9 +1715,6 @@ RZ_IPI int rz_cmd_debug_heap_jemalloc(void *data, const char *input) {
 }
 
 #include "linux_heap_glibc.c"
-#if __WINDOWS__
-#include "windows_heap.c"
-#endif
 
 static void foreach_reg_set_or_clear(RzCore *core, bool set) {
 	RzReg *reg = rz_config_get_b(core->config, "cfg.debug")

--- a/librz/core/cmd_windows_heap.c
+++ b/librz/core/cmd_windows_heap.c
@@ -36,3 +36,21 @@ RZ_IPI RzCmdStatus rz_cmd_debug_process_heap_block_handler(RzCore *core, int arg
 	NOT_SUPPORTED_ERROR_MESSAGE;
 }
 #endif
+
+/* API calls for Cutter */
+
+RZ_API RzList *rz_heap_windows_blocks_list(RzCore *core) {
+#if __WINDOWS__
+	return rz_heap_blocks_list(core);
+#else
+	return NULL;
+#endif
+}
+
+RZ_API RzList *rz_heap_windows_heap_list(RzCore *core) {
+#if __WINDOWS__
+	return rz_heap_list(core);
+#else
+	return NULL;
+#endif
+}

--- a/librz/core/cmd_windows_heap.c
+++ b/librz/core/cmd_windows_heap.c
@@ -39,18 +39,20 @@ RZ_IPI RzCmdStatus rz_cmd_debug_process_heap_block_handler(RzCore *core, int arg
 
 /* API calls for Cutter */
 
-RZ_API RzList *rz_heap_windows_blocks_list(RzCore *core) {
 #if __WINDOWS__
+RZ_API RzList *rz_heap_windows_blocks_list(RzCore *core) {
 	return rz_heap_blocks_list(core);
-#else
-	return NULL;
-#endif
 }
 
 RZ_API RzList *rz_heap_windows_heap_list(RzCore *core) {
-#if __WINDOWS__
 	return rz_heap_list(core);
-#else
-	return NULL;
-#endif
 }
+#else
+RZ_API RzList *rz_heap_windows_blocks_list(RzCore *core) {
+	return NULL;
+}
+
+RZ_API RzList *rz_heap_windows_heap_list(RzCore *core) {
+	return NULL;
+}
+#endif

--- a/librz/core/cmd_windows_heap.c
+++ b/librz/core/cmd_windows_heap.c
@@ -1,25 +1,27 @@
 #include <rz_core.h>
+#include "core_private.h"
+
 #define NOT_SUPPORTED_ERROR_MESSAGE \
 	eprintf("Windows heap parsing is not supported on this platform\n"); \
 	return RZ_CMD_STATUS_ERROR;
 
 #if __WINDOWS__
 RZ_IPI RzCmdStatus rz_cmd_debug_process_heaps_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
-	w32_list_heaps(core, mode);
+	rz_heap_list_w32(core, mode);
 	return RZ_CMD_STATUS_OK;
 }
 
 RZ_IPI RzCmdStatus rz_cmd_debug_process_heap_block_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
 	if (argc == 2) {
-		cmd_debug_map_heap_block_win(core, argv[1], mode, false);
+		rz_heap_debug_block_win(core, argv[1], mode, false);
 	} else {
-		cmd_debug_map_heap_block_win(core, NULL, mode, false);
+		rz_heap_debug_block_win(core, NULL, mode, false);
 	}
 	return RZ_CMD_STATUS_OK;
 }
 
 RZ_IPI RzCmdStatus rz_cmd_debug_heap_block_flag_handler(RzCore *core, int argc, const char **argv) {
-	cmd_debug_map_heap_block_win(core, NULL, RZ_OUTPUT_MODE_STANDARD, true);
+	rz_heap_debug_block_win(core, NULL, RZ_OUTPUT_MODE_STANDARD, true);
 	return RZ_CMD_STATUS_OK;
 }
 
@@ -34,25 +36,5 @@ RZ_IPI RzCmdStatus rz_cmd_debug_process_heaps_handler(RzCore *core, int argc, co
 
 RZ_IPI RzCmdStatus rz_cmd_debug_process_heap_block_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
 	NOT_SUPPORTED_ERROR_MESSAGE;
-}
-#endif
-
-/* API calls for Cutter */
-
-#if __WINDOWS__
-RZ_API RzList *rz_heap_windows_blocks_list(RzCore *core) {
-	return rz_heap_blocks_list(core);
-}
-
-RZ_API RzList *rz_heap_windows_heap_list(RzCore *core) {
-	return rz_heap_list(core);
-}
-#else
-RZ_API RzList *rz_heap_windows_blocks_list(RzCore *core) {
-	return NULL;
-}
-
-RZ_API RzList *rz_heap_windows_heap_list(RzCore *core) {
-	return NULL;
 }
 #endif

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -131,4 +131,13 @@ RZ_IPI void rz_core_flag_describe(RzCore *core, ut64 addr, bool strict_offset, R
 /* cmd_debug.c */
 RZ_IPI void rz_core_dbg_follow_seek_register(RzCore *core);
 RZ_IPI void rz_core_static_debug_stop(void *u);
+
+#if __WINDOWS__
+/* windows_heap.c */
+RZ_IPI RzList *rz_heap_blocks_list(RzCore *core);
+RZ_IPI RzList *rz_heap_list(RzCore *core);
+RZ_IPI void rz_heap_debug_block_win(RzCore *core, const char *addr, RzOutputMode mode, bool flag);
+RZ_IPI void rz_heap_list_w32(RzCore *core, RzOutputMode mode);
+#endif
+
 #endif

--- a/librz/core/meson.build
+++ b/librz/core/meson.build
@@ -14,6 +14,7 @@ rz_core_sources = [
   'cdebug.c',
   'cdwarf.c',
   'chash.c',
+  'cheap.c',
   'cio.c',
   'cil.c',
   'clang.c',

--- a/librz/core/windows_heap.c
+++ b/librz/core/windows_heap.c
@@ -1378,3 +1378,103 @@ static void cmd_debug_map_heap_block_win(RzCore *core, const char *addr, RzOutpu
 	rz_table_free(tbl);
 	pj_free(pj);
 }
+
+static RzList *rz_heap_blocks_list(RzCore *core) {
+	initialize_windows_ntdll_query_api_functions();
+	DWORD pid = core->dbg->pid;
+	PDEBUG_BUFFER db;
+	RzList *blocks_list = rz_list_newf(free);
+	if (__is_windows_ten()) {
+		db = GetHeapBlocks(pid, core->dbg);
+	} else {
+		db = InitHeapInfo(core->dbg, PDI_HEAPS | PDI_HEAP_BLOCKS);
+	}
+	if (!db) {
+		eprintf("Couldn't get heap info.\n");
+		return blocks_list;
+	}
+
+	PHeapInformation heapInfo = db->HeapInformation;
+	CHECK_INFO(heapInfo);
+	HeapBlock *block = malloc(sizeof(HeapBlock));
+	for (int i = 0; i < heapInfo->count; i++) {
+		bool go = true;
+		char *type;
+		if (GetFirstHeapBlock(&heapInfo->heaps[i], block) & go) {
+			do {
+				type = get_type(block->dwFlags);
+				if (!type) {
+					type = "";
+				}
+				ut64 granularity = block->extraInfo ? block->extraInfo->granularity : heapInfo->heaps[i].Granularity;
+				ut64 address = (ut64)block->dwAddress - granularity;
+				ut64 unusedBytes = block->extraInfo ? block->extraInfo->unusedBytes : 0;
+
+				// add blocks to list
+				RzWindowsHeapBlock *heap_block = RZ_NEW0(RzWindowsHeapBlock);
+				if (!heap_block) {
+					rz_list_free(blocks_list);
+					RtlDestroyQueryDebugBuffer(db);
+					return NULL;
+				}
+				heap_block->headerAddress = address;
+				heap_block->userAddress = (ut64)block->dwAddress;
+				heap_block->size = block->dwSize;
+				strcpy(heap_block->type, type);
+				heap_block->unusedBytes = unusedBytes;
+
+				rz_list_append(blocks_list, heap_block);
+			} while (GetNextHeapBlock(&heapInfo->heaps[i], block));
+		}
+		if (!(db->InfoClassMask & PDI_HEAP_BLOCKS)) {
+			// RtlDestroyQueryDebugBuffer wont free this for some reason
+			free_extra_info(&heapInfo->heaps[i]);
+			RZ_FREE(heapInfo->heaps[i].Blocks);
+		}
+	}
+	RtlDestroyQueryDebugBuffer(db);
+	return blocks_list;
+}
+
+static RzList *rz_heap_list(RzCore *core) {
+	initialize_windows_ntdll_query_api_functions();
+	ULONG pid = core->dbg->pid;
+	PDEBUG_BUFFER db = InitHeapInfo(core->dbg, PDI_HEAPS | PDI_HEAP_BLOCKS);
+	if (!db) {
+		if (__is_windows_ten()) {
+			db = GetHeapBlocks(pid, core->dbg);
+		}
+		if (!db) {
+			eprintf("Couldn't get heap info.\n");
+			return NULL;
+		}
+	}
+
+	RzList *heaps_list = rz_list_new(free);
+	PHeapInformation heapInfo = db->HeapInformation;
+	CHECK_INFO(heapInfo);
+	for (int i = 0; i < heapInfo->count; i++) {
+		DEBUG_HEAP_INFORMATION heap = heapInfo->heaps[i];
+		// add heaps to list
+		RzWindowsHeapInfo *rzHeapInfo = RZ_NEW0(RzWindowsHeapInfo);
+		if (!rzHeapInfo) {
+			rz_list_free(heaps_list);
+			RtlDestroyQueryDebugBuffer(db);
+			return NULL;
+		}
+		rzHeapInfo->base = heap.Base;
+		rzHeapInfo->blockCount = heap.BlockCount;
+		rzHeapInfo->allocated = heap.Allocated;
+		rzHeapInfo->committed = heap.Committed;
+
+		rz_list_append(heaps_list, rzHeapInfo);
+
+		if (!(db->InfoClassMask & PDI_HEAP_BLOCKS)) {
+			free_extra_info(&heap);
+			RZ_FREE(heap.Blocks);
+		}
+	}
+
+	RtlDestroyQueryDebugBuffer(db);
+	return heaps_list;
+}

--- a/librz/core/windows_heap.c
+++ b/librz/core/windows_heap.c
@@ -1422,6 +1422,7 @@ static RzList *rz_heap_blocks_list(RzCore *core) {
 				heap_block->size = block->dwSize;
 				strcpy(heap_block->type, type);
 				heap_block->unusedBytes = unusedBytes;
+				heap_block->granularity = granularity;
 
 				rz_list_append(blocks_list, heap_block);
 			} while (GetNextHeapBlock(&heapInfo->heaps[i], block));

--- a/librz/core/windows_heap.c
+++ b/librz/core/windows_heap.c
@@ -1214,7 +1214,7 @@ static RzTable *__new_heapblock_tbl(void) {
 	return tbl;
 }
 
-static void w32_list_heaps(RzCore *core, RzOutputMode mode) {
+RZ_IPI void rz_heap_list_w32(RzCore *core, RzOutputMode mode) {
 	initialize_windows_ntdll_query_api_functions();
 	ULONG pid = core->dbg->pid;
 	PDEBUG_BUFFER db = InitHeapInfo(core->dbg, PDI_HEAPS | PDI_HEAP_BLOCKS);
@@ -1347,7 +1347,7 @@ static void w32_list_heaps_blocks(RzCore *core, RzOutputMode mode, bool flag) {
 	RtlDestroyQueryDebugBuffer(db);
 }
 
-static void cmd_debug_map_heap_block_win(RzCore *core, const char *addr, RzOutputMode mode, bool flag) {
+RZ_IPI void rz_heap_debug_block_win(RzCore *core, const char *addr, RzOutputMode mode, bool flag) {
 	initialize_windows_ntdll_query_api_functions();
 	ut64 off = 0;
 	if (!addr) {
@@ -1389,7 +1389,7 @@ static void cmd_debug_map_heap_block_win(RzCore *core, const char *addr, RzOutpu
 	pj_free(pj);
 }
 
-static RzList *rz_heap_blocks_list(RzCore *core) {
+RZ_IPI RzList *rz_heap_blocks_list(RzCore *core) {
 	initialize_windows_ntdll_query_api_functions();
 	DWORD pid = core->dbg->pid;
 	PDEBUG_BUFFER db;
@@ -1447,7 +1447,7 @@ static RzList *rz_heap_blocks_list(RzCore *core) {
 	return blocks_list;
 }
 
-static RzList *rz_heap_list(RzCore *core) {
+RZ_IPI RzList *rz_heap_list(RzCore *core) {
 	initialize_windows_ntdll_query_api_functions();
 	ULONG pid = core->dbg->pid;
 	PDEBUG_BUFFER db = InitHeapInfo(core->dbg, PDI_HEAPS | PDI_HEAP_BLOCKS);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -31,7 +31,8 @@
 #include <rz_crypto.h>
 #include <rz_bind.h>
 #include <rz_util/rz_annotated_code.h>
-#include "rz_heap_glibc.h"
+#include <rz_heap_glibc.h>
+#include <rz_windows_heap.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -785,6 +786,10 @@ RZ_API RzHeapBin *rz_heap_fastbin_content(RzCore *core, MallocState *arena, int 
 RZ_API MallocState *rz_heap_get_arena(RzCore *core, ut64 m_state);
 RZ_API RzList *rz_heap_tcache_content(RzCore *core, ut64 arena_base);
 RZ_API bool rz_heap_write_chunk(RzCore *core, RzHeapChunkSimple *chunk_simple);
+
+/* cmd_windows_heap.c */
+RZ_API RzList *rz_heap_windows_blocks_list(RzCore *core);
+RZ_API RzList *rz_heap_windows_heap_list(RzCore *core);
 
 // XXX dupe from rz_bin.h
 /* bin.c */

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -788,8 +788,8 @@ RZ_API RzList *rz_heap_tcache_content(RzCore *core, ut64 arena_base);
 RZ_API bool rz_heap_write_chunk(RzCore *core, RzHeapChunkSimple *chunk_simple);
 
 /* cmd_windows_heap.c */
-RZ_API RzList *rz_heap_windows_blocks_list(RzCore *core);
-RZ_API RzList *rz_heap_windows_heap_list(RzCore *core);
+RZ_API RZ_OWN RzList *rz_heap_windows_blocks_list(RzCore *core);
+RZ_API RZ_OWN RzList *rz_heap_windows_heap_list(RzCore *core);
 
 // XXX dupe from rz_bin.h
 /* bin.c */

--- a/librz/include/rz_windows_heap.h
+++ b/librz/include/rz_windows_heap.h
@@ -1,0 +1,28 @@
+#ifndef RZ_WINDOWS_HEAP_H
+#define RZ_WINDOWS_HEAP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct rz_heap_block {
+	ut64 userAddress;
+	ut64 headerAddress;
+	ut64 granularity;
+	ut64 unusedBytes;
+	char type[100];
+	ut64 size;
+} RzWindowsHeapBlock;
+
+typedef struct rz_heap_info {
+	ut64 base;
+	ut64 blockCount;
+	ut64 allocated;
+	ut64 committed;
+} RzWindowsHeapInfo;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //

--- a/librz/meson.build
+++ b/librz/meson.build
@@ -366,6 +366,7 @@ include_files =[
   'include/rz_type.h',
   'include/rz_util.h',
   'include/rz_vector.h',
+  'include/rz_windows_heap.h',
   'include/rz_skyline.h',
 ]
 install_headers(include_files, install_dir: rizin_incdir)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Added two API calls, one gets the data related to `dmwb` command and one for `dmw` command. 
Will mark this ready for review once the Cutter part looks satisfactory. 

**Test plan**

Use the Cutter Widget and see if it works fine

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
