### PR TITLE
Use `RZ_CMD_STATUS_ERROR` in `pt` commands

### DIFF
--- a/librz/core/cmd_print.c
+++ b/librz/core/cmd_print.c
@@ -1591,6 +1591,7 @@ RZ_IPI RzCmdStatus rz_cmd_print_timestamp_unix_handler(RzCore *core, int argc, c
 		eprintf("Please change the block size to a value greater than and a multiple of %zu. For example, "
 			"run `b %zu`\n",
 			sizeof(ut32), sizeof(ut32));
+		return RZ_CMD_STATUS_ERROR;
 	}
 	if (len % sizeof(ut32)) {
 		len = len - (len % sizeof(ut32));
@@ -1618,6 +1619,7 @@ RZ_IPI RzCmdStatus rz_cmd_print_timestamp_dos_handler(RzCore *core, int argc, co
 		eprintf("Please change the block size to a value greater than and a multiple of %zu. For example, "
 			"run `b %zu`\n",
 			sizeof(ut32), sizeof(ut32));
+		return RZ_CMD_STATUS_ERROR;
 	}
 	if (len % sizeof(ut32)) {
 		len = len - (len % sizeof(ut32));
@@ -1636,6 +1638,7 @@ RZ_IPI RzCmdStatus rz_cmd_print_timestamp_hfs_handler(RzCore *core, int argc, co
 		eprintf("Please change the block size to a value greater than and a multiple of %zu. For example, "
 			"run `b %zu`\n",
 			sizeof(ut32), sizeof(ut32));
+		return RZ_CMD_STATUS_ERROR;
 	}
 	if (len % sizeof(ut32)) {
 		len = len - (len % sizeof(ut32));
@@ -1654,6 +1657,7 @@ RZ_IPI RzCmdStatus rz_cmd_print_timestamp_ntfs_handler(RzCore *core, int argc, c
 		eprintf("Please change the block size to a value greater than and a multiple of %zu. For example, "
 			"run `b %zu`\n",
 			sizeof(ut64), sizeof(ut64));
+		return RZ_CMD_STATUS_ERROR;
 	}
 	if (len % sizeof(ut64)) {
 		len = len - (len % sizeof(ut64));


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Return `RZ_CMD_STATUS_ERROR` in `pt` commands when the blocksize isn't adequate.

**Test plan**

CI is green.

**Closing issues**

None.
