### PR TITLE
core/serialize_core: exclude restoring of scr.prompt

### DIFF
--- a/librz/core/serialize_core.c
+++ b/librz/core/serialize_core.c
@@ -58,6 +58,7 @@ static const char *const config_exclude[] = {
 	"scr.color.ops",
 	"scr.color.pipe",
 	"scr.interactive", // especially relevant for Cutter since it needs this to be false
+	"scr.prompt", // especially relevant for rzpipe, otherwise loading a project might break the pipe
 	"scr.rainbow",
 	"scr.utf8",
 	"scr.utf8.curvy",

--- a/test/db/cmd/cmd_pipe
+++ b/test/db/cmd/cmd_pipe
@@ -33,3 +33,16 @@ Disassembly of entry0:
 
 EOF
 RUN
+
+NAME=rzpipe load project
+FILE=--
+CMDS=<<EOF
+?q `env~?^ASAN=1$`
+?+ env LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.5
+!python3 -c 'import rzpipe;rz=rzpipe.open("--");rz.cmd("Po bins/other/ls.rzdb");print(rz.cmd("?v custom_main"))'
+EOF
+EXPECT=<<EOF
+0x4070
+
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Restoring scr.prompt might break rz-pipe if you open a project from
within rz-pipe. Exclude scr.prompt so that it is not set to true in such
cases.


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

See https://github.com/rizinorg/rz-pipe/issues/25#issuecomment-890897178

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

https://github.com/rizinorg/rz-pipe/issues/25
