### PR TITLE
Allow referring to structs/unions without specifiers

### DIFF
--- a/librz/type/parser/types_parser.c
+++ b/librz/type/parser/types_parser.c
@@ -186,6 +186,18 @@ int parse_sole_type_name(CParserState *state, TSNode node, const char *text, Par
 		free(real_type);
 		return 0;
 	}
+	// Before resorting to create a new forward type, check if there is some union or struct with the same name already.
+	// This will e.g. catch cases like referring to `struct MyStruct` by just `MyStruct`.
+	if ((*tpair = c_parser_get_structure_type(state, real_type))) {
+		parser_debug(state, "Fetched type as struct: \"%s\"\n", real_type);
+		free(real_type);
+		return 0;
+	}
+	if ((*tpair = c_parser_get_union_type(state, real_type))) {
+		parser_debug(state, "Fetched type as union: \"%s\"\n", real_type);
+		free(real_type);
+		return 0;
+	}
 	// If not - we form both RzType and RzBaseType to store in the Types database
 	// as a forward-looking definition
 	*tpair = c_parser_new_primitive_type(state, real_type, is_const);

--- a/test/unit/test_type.c
+++ b/test/unit/test_type.c
@@ -499,7 +499,7 @@ static bool test_struct_identifier_without_specifier(void) {
 	int r = rz_type_parse_string(typedb, "struct bla { int a; };", &error_msg);
 	mu_assert_eq(r, 0, "parse struct definition");
 
-	// After definin a struct `struct bla` we also want to be able to refer to
+	// After defining a struct `struct bla` we also want to be able to refer to
 	// it by just `bla` rather than `struct bla`
 
 	RzType *ttype = rz_type_parse_string_single(typedb->parser, "bla *", &error_msg);
@@ -527,7 +527,7 @@ static bool test_union_identifier_without_specifier(void) {
 	int r = rz_type_parse_string(typedb, "union bla { int a; };", &error_msg);
 	mu_assert_eq(r, 0, "parse union definition");
 
-	// After definin a union `union bla` we also want to be able to refer to
+	// After defining a union `union bla` we also want to be able to refer to
 	// it by just `bla` rather than `union bla`
 
 	RzType *ttype = rz_type_parse_string_single(typedb->parser, "bla *", &error_msg);

--- a/test/unit/test_type.c
+++ b/test/unit/test_type.c
@@ -488,6 +488,62 @@ static bool test_struct_func_types(void) {
 	mu_end;
 }
 
+static bool test_struct_identifier_without_specifier(void) {
+	RzTypeDB *typedb = rz_type_db_new();
+	mu_assert_notnull(typedb, "Couldn't create new RzTypeDB");
+	mu_assert_notnull(typedb->types, "Couldn't create new types hashtable");
+	const char *dir_prefix = rz_sys_prefix(NULL);
+	rz_type_db_init(typedb, dir_prefix, "x86", 64, "linux");
+
+	char *error_msg = NULL;
+	int r = rz_type_parse_string(typedb, "struct bla { int a; };", &error_msg);
+	mu_assert_eq(r, 0, "parse struct definition");
+
+	// After definin a struct `struct bla` we also want to be able to refer to
+	// it by just `bla` rather than `struct bla`
+
+	RzType *ttype = rz_type_parse_string_single(typedb->parser, "bla *", &error_msg);
+	mu_assert_notnull(ttype, "type parse successfull");
+	mu_assert_eq(ttype->kind, RZ_TYPE_KIND_POINTER, "is pointer");
+	mu_assert_notnull(ttype->pointer.type, "pointed type");
+	mu_assert_eq(ttype->pointer.type->kind, RZ_TYPE_KIND_IDENTIFIER, "pointing to identifier");
+	mu_assert_false(ttype->pointer.type->identifier.is_const, "identifier not const");
+	mu_assert_streq(ttype->pointer.type->identifier.name, "bla", "bla struct");
+
+	rz_type_free(ttype);
+
+	rz_type_db_free(typedb);
+	mu_end;
+}
+
+static bool test_union_identifier_without_specifier(void) {
+	RzTypeDB *typedb = rz_type_db_new();
+	mu_assert_notnull(typedb, "Couldn't create new RzTypeDB");
+	mu_assert_notnull(typedb->types, "Couldn't create new types hashtable");
+	const char *dir_prefix = rz_sys_prefix(NULL);
+	rz_type_db_init(typedb, dir_prefix, "x86", 64, "linux");
+
+	char *error_msg = NULL;
+	int r = rz_type_parse_string(typedb, "union bla { int a; };", &error_msg);
+	mu_assert_eq(r, 0, "parse union definition");
+
+	// After definin a union `union bla` we also want to be able to refer to
+	// it by just `bla` rather than `union bla`
+
+	RzType *ttype = rz_type_parse_string_single(typedb->parser, "bla *", &error_msg);
+	mu_assert_notnull(ttype, "type parse successfull");
+	mu_assert_eq(ttype->kind, RZ_TYPE_KIND_POINTER, "is pointer");
+	mu_assert_notnull(ttype->pointer.type, "pointed type");
+	mu_assert_eq(ttype->pointer.type->kind, RZ_TYPE_KIND_IDENTIFIER, "pointing to identifier");
+	mu_assert_false(ttype->pointer.type->identifier.is_const, "identifier not const");
+	mu_assert_streq(ttype->pointer.type->identifier.name, "bla", "bla union");
+
+	rz_type_free(ttype);
+
+	rz_type_db_free(typedb);
+	mu_end;
+}
+
 /* references */
 typedef struct {
 	const char *name;
@@ -536,6 +592,8 @@ int all_tests() {
 	mu_run_test(test_const_types);
 	mu_run_test(test_array_types);
 	mu_run_test(test_struct_func_types);
+	mu_run_test(test_struct_identifier_without_specifier);
+	mu_run_test(test_union_identifier_without_specifier);
 	mu_run_test(test_references);
 	return tests_passed != tests_run;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Used for example in rz-ghidra tests: https://github.com/rizinorg/rz-ghidra/blob/40ea3766d1bb283e255e31b9e7c3a61885dd3cb0/test/db/extras/ghidra#L2007

**Test plan**

See unit tests

Or:
Load some struct like `struct Stuff { int a; };`
Assign it to a variable like `afvb var_name "Stuff *"` as opposed to `afvb var_name "struct Stuff *"`
