### PR TITLE
Resolve minor bug in `rz_type_db_base_type_as_string`

### DIFF
--- a/librz/type/base.c
+++ b/librz/type/base.c
@@ -207,7 +207,7 @@ RZ_API RZ_OWN char *rz_type_db_base_type_as_string(const RzTypeDB *typedb, RZ_NO
 		RzTypeUnionMember *memb;
 		rz_vector_foreach(&type->union_data.members, memb) {
 			char *declaration = rz_type_identifier_declaration_as_string(typedb, memb->type, memb->name);
-			rz_strbuf_appendf(buf, "%s; ", declaration);
+			rz_strbuf_appendf(buf, "%s %s; ", declaration, memb->name);
 			free(declaration);
 		}
 		rz_strbuf_append(buf, " }");

--- a/librz/type/base.c
+++ b/librz/type/base.c
@@ -187,7 +187,7 @@ RZ_API RZ_OWN char *rz_type_db_base_type_as_string(const RzTypeDB *typedb, RZ_NO
 		RzTypeStructMember *memb;
 		rz_vector_foreach(&type->struct_data.members, memb) {
 			char *declaration = rz_type_identifier_declaration_as_string(typedb, memb->type, memb->name);
-			rz_strbuf_appendf(buf, "%s; ", declaration);
+			rz_strbuf_appendf(buf, "%s %s; ", declaration, memb->name);
 			free(declaration);
 		}
 		rz_strbuf_append(buf, " }");

--- a/test/unit/test_type.c
+++ b/test/unit/test_type.c
@@ -88,7 +88,7 @@ static bool test_types_get_base_type_struct(void) {
 	mu_assert_eq(member->offset, 4, "Incorrect offset for struct member");
 	mu_assert_true(rz_type_atomic_str_eq(typedb, member->type, "int32_t"), "Incorrect type for struct member");
 	mu_assert_streq(member->name, "cow", "Incorrect name for struct member");
-
+	mu_assert_streq(rz_type_db_base_type_as_string(typedb, base), "struct kappa { int32_t bar; int32_t cow;  }", "Incorrect conversion of struct to string");
 	rz_type_db_free(typedb);
 	mu_end;
 }

--- a/test/unit/test_type.c
+++ b/test/unit/test_type.c
@@ -88,7 +88,9 @@ static bool test_types_get_base_type_struct(void) {
 	mu_assert_eq(member->offset, 4, "Incorrect offset for struct member");
 	mu_assert_true(rz_type_atomic_str_eq(typedb, member->type, "int32_t"), "Incorrect type for struct member");
 	mu_assert_streq(member->name, "cow", "Incorrect name for struct member");
+
 	mu_assert_streq(rz_type_db_base_type_as_string(typedb, base), "struct kappa { int32_t bar; int32_t cow;  }", "Incorrect conversion of struct to string");
+
 	rz_type_db_free(typedb);
 	mu_end;
 }
@@ -118,6 +120,8 @@ static bool test_types_get_base_type_union(void) {
 	member = rz_vector_index_ptr(&base->union_data.members, 1);
 	mu_assert_true(rz_type_atomic_str_eq(typedb, member->type, "int32_t"), "Incorrect type for union member");
 	mu_assert_streq(member->name, "cow", "Incorrect name for union member");
+
+	mu_assert_streq(rz_type_db_base_type_as_string(typedb, base), "union kappa { int32_t bar; int32_t cow;  }", "Incorrect conversion of union to string");
 
 	rz_type_db_free(typedb);
 	mu_end;

--- a/test/unit/test_type.c
+++ b/test/unit/test_type.c
@@ -11,13 +11,11 @@
 static void setup_sdb_for_struct(Sdb *res) {
 	// td "struct kappa {int bar;int cow;};"
 	sdb_set(res, "kappa", "struct", 0);
-
 	sdb_set(res, "struct.kappa", "bar,cow", 0);
 	sdb_set(res, "struct.kappa.bar", "int32_t,0,0", 0);
 	sdb_set(res, "struct.kappa.cow", "int32_t,4,0", 0);
 
 	sdb_set(res, "lappa", "struct", 0);
-
 	sdb_set(res, "struct.lappa", "bar,cow", 0);
 	sdb_set(res, "struct.lappa.bar", "int32_t,0,0", 0);
 	sdb_set(res, "struct.lappa.cow", "struct kappa,4,0", 0);
@@ -29,6 +27,11 @@ static void setup_sdb_for_union(Sdb *res) {
 	sdb_set(res, "union.kappa", "bar,cow", 0);
 	sdb_set(res, "union.kappa.bar", "int32_t,0,0", 0);
 	sdb_set(res, "union.kappa.cow", "int32_t,0,0", 0);
+
+	sdb_set(res, "lappa", "union", 0);
+	sdb_set(res, "union.lappa", "bar,cow", 0);
+	sdb_set(res, "union.lappa.bar", "int32_t,0,0", 0);
+	sdb_set(res, "union.lappa.cow", "union kappa,0,0", 0);
 }
 
 static void setup_sdb_for_enum(Sdb *res) {
@@ -136,6 +139,12 @@ static bool test_types_get_base_type_union(void) {
 	mu_assert_streq(member->name, "cow", "Incorrect name for union member");
 
 	mu_assert_streq(rz_type_db_base_type_as_string(typedb, base), "union kappa { int32_t bar; int32_t cow;  }", "Incorrect conversion of union to string");
+
+	RzBaseType *base2 = rz_type_db_get_base_type(typedb, "lappa");
+	mu_assert_notnull(base2, "Couldn't create get base type of union \"lappa\"");
+	mu_assert_eq(RZ_BASE_TYPE_KIND_UNION, base2->kind, "Wrong base type");
+	mu_assert_streq(base2->name, "lappa", "type name");
+	mu_assert_streq(rz_type_db_base_type_as_string(typedb, base2), "union lappa { int32_t bar; union kappa cow;  }", "Incorrect conversion of union to string");
 
 	rz_type_db_free(typedb);
 	mu_end;

--- a/test/unit/test_type.c
+++ b/test/unit/test_type.c
@@ -11,9 +11,16 @@
 static void setup_sdb_for_struct(Sdb *res) {
 	// td "struct kappa {int bar;int cow;};"
 	sdb_set(res, "kappa", "struct", 0);
+
 	sdb_set(res, "struct.kappa", "bar,cow", 0);
 	sdb_set(res, "struct.kappa.bar", "int32_t,0,0", 0);
 	sdb_set(res, "struct.kappa.cow", "int32_t,4,0", 0);
+
+	sdb_set(res, "lappa", "struct", 0);
+
+	sdb_set(res, "struct.lappa", "bar,cow", 0);
+	sdb_set(res, "struct.lappa.bar", "int32_t,0,0", 0);
+	sdb_set(res, "struct.lappa.cow", "struct kappa,4,0", 0);
 }
 
 static void setup_sdb_for_union(Sdb *res) {
@@ -90,6 +97,13 @@ static bool test_types_get_base_type_struct(void) {
 	mu_assert_streq(member->name, "cow", "Incorrect name for struct member");
 
 	mu_assert_streq(rz_type_db_base_type_as_string(typedb, base), "struct kappa { int32_t bar; int32_t cow;  }", "Incorrect conversion of struct to string");
+
+	RzBaseType *base2 = rz_type_db_get_base_type(typedb, "lappa");
+	mu_assert_notnull(base2, "Couldn't create get base type of struct \"lappa\"");
+
+	mu_assert_eq(RZ_BASE_TYPE_KIND_STRUCT, base2->kind, "Wrong base type");
+	mu_assert_streq(base2->name, "lappa", "type name");
+	mu_assert_streq(rz_type_db_base_type_as_string(typedb, base2), "struct lappa { int32_t bar; struct kappa cow;  }", "Incorrect conversion of struct to string");
 
 	rz_type_db_free(typedb);
 	mu_end;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
On my quest to fix types in  Cutter I saw that `rz_type_db_base_type_as_string` is not returning the name of the member of structs.
Old output:
```
struct foo { int; int;  }
```

New output
```
struct foo { int a; int b;  }
```

Should I add some new lines too??
The output will be like
```
struct foo { 
int a; 
int b; 
}
```
Also I am thinking of adding a semi colon at the end so the output can be parsed back more easily.