### PR TITLE
Make sure cmd_descs.h in the src dir does not cause double-compilation

### DIFF
--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -9,7 +9,6 @@
 #include <ctype.h>
 #include <limits.h>
 #include "core_private.h"
-#include "cmd_descs/cmd_descs.h"
 
 static int mousemode = 0;
 static int disMode = 0;

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -6,7 +6,6 @@
 #include <rz_core.h>
 #include <rz_debug.h>
 #include "core_private.h"
-#include "cmd_descs/cmd_descs.h"
 
 static bool is_x86_call(RzDebug *dbg, ut64 addr) {
 	ut8 buf[3];

--- a/librz/core/cmd.c
+++ b/librz/core/cmd.c
@@ -16,7 +16,7 @@
 #include <sys/utsname.h>
 #endif
 
-#include "cmd_descs/cmd_descs.h"
+#include <cmd_descs.h>
 
 #include <tree_sitter/api.h>
 TSLanguage *tree_sitter_rzcmd();

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -5,7 +5,7 @@
 // modify it manually. Look at cmd_descs.yaml if you want to update commands.
 //
 
-#include "cmd_descs.h"
+#include <cmd_descs.h>
 
 static const RzCmdDescDetail system_details[2];
 static const RzCmdDescDetail system_to_cons_details[2];

--- a/librz/core/cmd_descs/cmd_descs_generate.py
+++ b/librz/core/cmd_descs/cmd_descs_generate.py
@@ -15,7 +15,7 @@ CMDDESCS_C_TEMPLATE = """// SPDX-FileCopyrightText: 2021 RizinOrg <info@rizin.re
 // modify it manually. Look at cmd_descs.yaml if you want to update commands.
 //
 
-#include "cmd_descs.h"
+#include <cmd_descs.h>
 
 {helps_declarations}
 

--- a/librz/core/cmd_descs/meson.build
+++ b/librz/core/cmd_descs/meson.build
@@ -19,17 +19,17 @@ cmd_descs_yaml = files(
   'cmd_write.yaml',
   'cmd_zign.yaml',
 )
-cmd_descs_src_c = files('cmd_descs.c')
+cmd_descs_src_c = files('cmd_descs.c', 'cmd_descs.h')
 
 r = run_command(py3_exe, '-c', 'import yaml')
 if r.returncode() == 0
-  cmd_descs_c = custom_target(
-    'cmd_descs.c',
-    output: ['cmd_descs.c'],
-    input: [cmd_descs_generate_py, cmd_descs_yaml],
-    command: [py3_exe, cmd_descs_generate_py, '--output-dir', '@OUTDIR@', '--src-output-dir', meson.current_source_dir(), cmd_descs_yaml]
+  cmd_descs_ch = custom_target(
+    'cmd_descs.[ch]',
+    output: ['cmd_descs.c', 'cmd_descs.h'],
+    input: cmd_descs_yaml,
+    command: [py3_exe, cmd_descs_generate_py, '--output-dir', '@OUTDIR@', '--src-output-dir', meson.current_source_dir(), '@INPUT@']
   )
 else
   warning('PyYAML python module was not found, using cmd_descs.c/cmd_descs.h from source directory. Install PyYAML (either from your package manager or through pip) if you need to modify cmd_descs files.')
-  cmd_descs_c = cmd_descs_src_c
+  cmd_descs_ch = cmd_descs_src_c
 endif

--- a/librz/core/cmd_interpret.c
+++ b/librz/core/cmd_interpret.c
@@ -3,7 +3,7 @@
 
 #include <rz_cmd.h>
 #include <rz_core.h>
-#include "cmd_descs/cmd_descs.h"
+#include <cmd_descs.h>
 
 RZ_IPI RzCmdStatus rz_interpret_handler(RzCore *core, int argc, const char **argv) {
 	if (argc == 1) {

--- a/librz/core/cmd_tasks.c
+++ b/librz/core/cmd_tasks.c
@@ -3,7 +3,7 @@
 
 #include <rz_cmd.h>
 #include <rz_core.h>
-#include "cmd_descs/cmd_descs.h"
+#include <cmd_descs.h>
 
 static int task_enqueue(RzCore *core, const char *cmd, bool transient) {
 	RzCoreTask *task = rz_core_cmd_task_new(core, cmd, NULL, NULL);

--- a/librz/core/meson.build
+++ b/librz/core/meson.build
@@ -20,7 +20,7 @@ rz_core_sources = [
   'clang.c',
   'cparser.c',
   'cmd.c',
-  cmd_descs_c,
+  cmd_descs_ch,
   #'cmd_analysis.c',
   'cmd_api.c',
   #'cmd_cmp.c',
@@ -83,7 +83,7 @@ else
   rz_core_sources += 'windows_heap.c'
   rz_core_inc += ['../../shlr/heap/include/rz_windows']
 endif
-rz_core_inc = [platform_inc, include_directories(rz_core_inc)]
+rz_core_inc = [platform_inc, include_directories(rz_core_inc), 'cmd_descs']
 
 rz_core_deps = [
   rz_util_dep,

--- a/librz/core/panels.c
+++ b/librz/core/panels.c
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_core.h>
-#include "cmd_descs/cmd_descs.h"
 #include "core_private.h"
 
 #define PANEL_NUM_LIMIT 9

--- a/librz/core/visual.c
+++ b/librz/core/visual.c
@@ -4,7 +4,6 @@
 #include <rz_core.h>
 #include <rz_cons.h>
 #include "core_private.h"
-#include "cmd_descs/cmd_descs.h"
 
 #define NPF  5
 #define PIDX (RZ_ABS(core->printidx % NPF))


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
When changing a cmd_descs/*.yaml file and recompiling Rizin 2 times you
could notice that the second time some files were still recompiled, even
if everything should have been done just the first time. This was caused
by cmd_descs.h in the src directory being generated and updated by the
first compilation and then being used for the second one.


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Compile as usual.
Make sure `ninja -C build` returns `ninja: no work to do.`. Then change a simple string in e.g. `cmd_system.yaml`.

Run `ninja -C build` again. Files will be recompiled. 
Run again `ninja -C build`, without modifying any file. If the issue is fixed, it should return `ninja: no work to do`, otherwise you would see some files that are compiled by ninja.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
