### PR TITLE
rz_cons_printf_list: fix potential busy loop (#18970)

### DIFF
--- a/librz/cons/cons.c
+++ b/librz/cons/cons.c
@@ -1145,17 +1145,16 @@ RZ_API void rz_cons_printf_list(const char *format, va_list ap) {
 	if (strchr(format, '%')) {
 		if (palloc(MOAR + strlen(format) * 20)) {
 		club:
-			size = I.context->buffer_sz - I.context->buffer_len - 1; /* remaining space in I.context->buffer */
+			size = I.context->buffer_sz - I.context->buffer_len; /* remaining space in I.context->buffer */
 			written = vsnprintf(I.context->buffer + I.context->buffer_len, size, format, ap3);
 			if (written >= size) { /* not all bytes were written */
-				if (palloc(written)) {
+				if (palloc(written + 1)) { /* + 1 byte for \0 termination */
 					va_end(ap3);
 					va_copy(ap3, ap2);
 					goto club;
 				}
 			}
 			I.context->buffer_len += written;
-			I.context->buffer[I.context->buffer_len] = 0;
 		}
 	} else {
 		rz_cons_strcat(format);


### PR DESCRIPTION
In case the string to be written by `vsnprintf` including `\0`
termination equals to the length of the buffer, the code enters in a
busy loop. The original code seems to assume, that `vsnprintf` won't
terminate the string with `\0` character which it does.

The [documentation of `vsnprintf`
states](https://en.cppreference.com/w/c/io/vfprintf):

> `int vsnprintf( char *restrict buffer, size_t bufsz, const
> char *restrict format, va_list vlist );`
>
> Writes the results to a character string buffer. At most bufsz - 1
> characters are written. The resulting character string will be
> terminated with a null character, unless bufsz is zero. If bufsz is
> zero, nothing is written and buffer may be a null pointer, [...]

This means that the `size` variable should be set to the total
available length of the buffer, not `length - 1`. Furthermore on the
return value the manual writes:

> however the return value (number of bytes that would be written not
> including the null terminator) is still calculated and returned.

This means that the `written` size returned doesn't count the
terminating `\0` in the length, so the value of `written` can be at
most `size - 1` before truncating the output. In other words a string
having`size = written + 1` would fit exactly in the buffer.

Also as `vsnprintf` will write the terminating `\0` there is no need
to explicitly do that.

Backport radare2 fix 8ef090c0176b28fb3ed9ce735dd1b3e4a38de096.

See https://github.com/radareorg/radare2/pull/18970
