### PR TITLE
Remove use of `sdb_fmt()` in PJ

### DIFF
--- a/librz/util/pj.c
+++ b/librz/util/pj.c
@@ -238,35 +238,40 @@ RZ_API PJ *pj_j(PJ *j, const char *k) {
 RZ_API PJ *pj_n(PJ *j, ut64 n) {
 	rz_return_val_if_fail(j, j);
 	pj_comma(j);
-	pj_raw(j, sdb_fmt("%" PFMT64u, n));
+	char s[64] = { 0 };
+	pj_raw(j, rz_strf(s, "%" PFMT64u, n));
 	return j;
 }
 
 RZ_API PJ *pj_N(PJ *j, st64 n) {
 	rz_return_val_if_fail(j, NULL);
 	pj_comma(j);
-	pj_raw(j, sdb_fmt("%" PFMT64d, n));
+	char s[64] = { 0 };
+	pj_raw(j, rz_strf(s, "%" PFMT64d, n));
 	return j;
 }
 
 RZ_API PJ *pj_f(PJ *j, float f) {
 	rz_return_val_if_fail(j, NULL);
 	pj_comma(j);
-	pj_raw(j, sdb_fmt("%f", f));
+	char s[64] = { 0 };
+	pj_raw(j, rz_strf(s, "%f", f));
 	return j;
 }
 
 RZ_API PJ *pj_d(PJ *j, double d) {
 	rz_return_val_if_fail(j, NULL);
 	pj_comma(j);
-	pj_raw(j, sdb_fmt("%lf", d));
+	char s[64] = { 0 };
+	pj_raw(j, rz_strf(s, "%lf", d));
 	return j;
 }
 
 RZ_API PJ *pj_i(PJ *j, int i) {
 	if (j) {
 		pj_comma(j);
-		pj_raw(j, sdb_fmt("%d", i));
+		char s[64] = { 0 };
+		pj_raw(j, rz_strf(s, "%d", i));
 	}
 	return j;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Started to remove `sdb_fmt()` use from the Rizin.

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/1168
