### PR TITLE
Fix Coverity issues on parse/parse_*.c

### DIFF
--- a/librz/parse/p/parse_common.c
+++ b/librz/parse/p/parse_common.c
@@ -174,8 +174,9 @@ static bool rz_pseudo_convert(const RzPseudoConfig *config, const char *assembly
 	char *result = rz_strbuf_get(sb);
 	for (int i = 0; i < config->replace_length; ++i) {
 		rp = &config->replace[i];
-		rz_str_replace(result, rp->expected, rp->replace, rp->flag);
+		result = rz_str_replace(result, rp->expected, rp->replace, rp->flag);
 	}
+	sb->ptr = result;
 
 	rz_list_free(tokens);
 	return true;

--- a/librz/parse/p/parse_common.c
+++ b/librz/parse/p/parse_common.c
@@ -171,12 +171,13 @@ static bool rz_pseudo_convert(const RzPseudoConfig *config, const char *assembly
 		rz_strbuf_append_n(sb, gr->grammar + i, p - i);
 	}
 
-	char *result = rz_strbuf_get(sb);
+	char *result = rz_strbuf_drain_nofree(sb);
 	for (int i = 0; i < config->replace_length; ++i) {
 		rp = &config->replace[i];
 		result = rz_str_replace(result, rp->expected, rp->replace, rp->flag);
 	}
-	sb->ptr = result;
+	rz_strbuf_set(sb, result);
+	free(result);
 
 	rz_list_free(tokens);
 	return true;

--- a/librz/parse/p/parse_m68k_pseudo.c
+++ b/librz/parse/p/parse_m68k_pseudo.c
@@ -90,10 +90,10 @@ static bool parse(RzParse *parse, const char *assembly, RzStrBuf *sb) {
 		rz_strbuf_setf(sb, "asm(\"%s\")", assembly);
 		return true;
 	}
-	rz_str_replace(copy, ".l", "", 0);
-	rz_str_replace(copy, ".w", "", 0);
-	rz_str_replace(copy, ".d", "", 0);
-	rz_str_replace(copy, ".b", "", 0);
+	copy = rz_str_replace(copy, ".l", "", 0);
+	copy = rz_str_replace(copy, ".w", "", 0);
+	copy = rz_str_replace(copy, ".d", "", 0);
+	copy = rz_str_replace(copy, ".b", "", 0);
 	bool res = rz_pseudo_convert(&m68k_config, copy, sb);
 	free(copy);
 	return res;

--- a/librz/parse/p/parse_riscv_pseudo.c
+++ b/librz/parse/p/parse_riscv_pseudo.c
@@ -211,7 +211,7 @@ static bool parse(RzParse *p, const char *data, RzStrBuf *sb) {
 		char *s = strdup(str);
 		s = rz_str_replace(s, "+ -", "- ", 1);
 		s = rz_str_replace(s, "- -", "+ ", 1);
-		strcpy(str, s);
+		rz_strf(str, "%s", s);
 		free(s);
 	}
 	free(buf);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- COV 353912
- COV 353908
- COV 353909
- COV 353910
- COV 353911