### PR TITLE
Check for null pointer in class_bin.c

### DIFF
--- a/librz/bin/format/java/class_bin.c
+++ b/librz/bin/format/java/class_bin.c
@@ -1494,13 +1494,16 @@ RZ_API RZ_OWN RzList *rz_bin_java_class_const_pool_as_imports(RZ_NONNULL RzBinJa
 				continue;
 			}
 
+			char *object = java_class_constant_pool_stringify_at(bin, class_name_index);
+			if (!object) {
+				break;
+			}
+
 			RzBinImport *import = RZ_NEW0(RzBinImport);
 			if (!import) {
 				rz_warn_if_reached();
 				continue;
 			}
-
-			char *object = java_class_constant_pool_stringify_at(bin, class_name_index);
 
 			char *class_name = (char *)rz_str_rchr(object, NULL, '/');
 			if (class_name) {

--- a/librz/bin/format/java/class_bin.c
+++ b/librz/bin/format/java/class_bin.c
@@ -1496,7 +1496,7 @@ RZ_API RZ_OWN RzList *rz_bin_java_class_const_pool_as_imports(RZ_NONNULL RzBinJa
 
 			char *object = java_class_constant_pool_stringify_at(bin, class_name_index);
 			if (!object) {
-				break;
+				continue;
 			}
 
 			RzBinImport *import = RZ_NEW0(RzBinImport);


### PR DESCRIPTION

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

fixes the null pointer returned `java_class_constant_pool_stringify_at` which crashes strdup