### PR TITLE
Fix use of unsafe `localtime()` and portable `gmtime_r()`

### DIFF
--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -124,11 +124,6 @@ typedef enum {
 #define strcasecmp  stricmp
 #define strncasecmp strnicmp
 #define __WINDOWS__ 1
-
-#include <time.h>
-static inline struct tm *gmtime_r(const time_t *t, struct tm *r) {
-	return (gmtime_s(r, t)) ? NULL : r;
-}
 #endif
 
 #if defined(EMSCRIPTEN) || defined(__linux__) || defined(__APPLE__) || defined(__GNU__) || defined(__ANDROID__) || defined(__QNX__) || defined(__sun) || defined(__HAIKU__)

--- a/librz/include/rz_util/rz_time.h
+++ b/librz/include/rz_util/rz_time.h
@@ -27,6 +27,7 @@ RZ_API char *rz_time_to_string(ut64 ts);
 RZ_API char *rz_asctime_r(const struct tm *tm, char *buf);
 RZ_API char *rz_ctime_r(const time_t *timer, char *buf);
 RZ_API struct tm *rz_localtime_r(const time_t *time, struct tm *res);
+RZ_API struct tm *rz_gmtime_r(const time_t *time, struct tm *res);
 
 #define RZ_TIME_PROFILE_ENABLED 0
 

--- a/librz/magic/mdump.c
+++ b/librz/magic/mdump.c
@@ -201,7 +201,7 @@ const char *file_fmttime(ut32 v, int local, char *pp) {
 		if (now == (time_t)0) {
 			struct tm *tm1;
 			(void)time(&now);
-			tm1 = localtime(&now);
+			tm1 = rz_localtime_r(&now, &timestruct);
 			if (!tm1)
 				return "*Invalid time*";
 			daylight = tm1->tm_isdst;
@@ -210,7 +210,7 @@ const char *file_fmttime(ut32 v, int local, char *pp) {
 #endif /* HAVE_DAYLIGHT */
 		if (daylight)
 			t += 3600;
-		tm = gmtime_r(&t, &timestruct);
+		tm = rz_gmtime_r(&t, &timestruct);
 		if (!tm)
 			return "*Invalid time*";
 		rz_asctime_r(tm, pp);

--- a/librz/type/format.c
+++ b/librz/type/format.c
@@ -507,7 +507,7 @@ static void rz_type_format_time(RzStrBuf *outbuf, int endian, int mode,
 		if (!timestr) {
 			return;
 		}
-		rz_asctime_r(gmtime_r((time_t *)&addr, &timestruct), timestr);
+		rz_asctime_r(rz_gmtime_r((time_t *)&addr, &timestruct), timestr);
 		*(timestr + 24) = '\0';
 		if (!SEEVALUE && !ISQUIET) {
 			rz_strbuf_appendf(outbuf, "0x%08" PFMT64x " = ", seeki + ((elem >= 0) ? elem * 4 : 0));
@@ -520,7 +520,7 @@ static void rz_type_format_time(RzStrBuf *outbuf, int endian, int mode,
 			}
 			while (size--) {
 				updateAddr(buf + i, size - i, endian, &addr, NULL);
-				rz_asctime_r(gmtime_r((time_t *)&addr, &timestruct), timestr);
+				rz_asctime_r(rz_gmtime_r((time_t *)&addr, &timestruct), timestr);
 				*(timestr + 24) = '\0';
 				if (elem == -1 || elem == 0) {
 					rz_strbuf_appendf(outbuf, "%s", timestr);
@@ -546,7 +546,7 @@ static void rz_type_format_time(RzStrBuf *outbuf, int endian, int mode,
 		if (!timestr) {
 			return;
 		}
-		rz_asctime_r(gmtime_r((time_t *)&addr, &timestruct), timestr);
+		rz_asctime_r(rz_gmtime_r((time_t *)&addr, &timestruct), timestr);
 		*(timestr + 24) = '\0';
 		if (size == -1) {
 			rz_strbuf_appendf(outbuf, "\"%s\"", timestr);
@@ -554,7 +554,7 @@ static void rz_type_format_time(RzStrBuf *outbuf, int endian, int mode,
 			rz_strbuf_append(outbuf, "[ ");
 			while (size--) {
 				updateAddr(buf + i, size - i, endian, &addr, NULL);
-				rz_asctime_r(gmtime_r((time_t *)&addr, &timestruct), timestr);
+				rz_asctime_r(rz_gmtime_r((time_t *)&addr, &timestruct), timestr);
 				*(timestr + 24) = '\0';
 				if (elem == -1 || elem == 0) {
 					rz_strbuf_appendf(outbuf, "\"%s\"", timestr);

--- a/librz/util/time.c
+++ b/librz/util/time.c
@@ -51,8 +51,9 @@ RZ_API char *rz_time_stamp_to_str(ut32 timeStamp) {
 #ifdef _MSC_VER
 	time_t rawtime;
 	struct tm *tminfo;
+	struct tm tmptm;
 	rawtime = (time_t)timeStamp;
-	tminfo = localtime(&rawtime);
+	tminfo = rz_localtime_r(&rawtime, &tmptm);
 	//tminfo = gmtime (&rawtime);
 	return rz_str_trim_dup(asctime(tminfo));
 #else
@@ -206,6 +207,15 @@ RZ_API struct tm *rz_localtime_r(const time_t *time, struct tm *res) {
 	return err ? NULL : res;
 #else
 	return localtime_r(time, res);
+#endif
+}
+
+RZ_API struct tm *rz_gmtime_r(const time_t *time, struct tm *res) {
+#if __WINDOWS__
+	errno_t err = gmtime_s(res, time);
+	return err ? NULL : res;
+#else
+	return gmtime_r(time, res);
 #endif
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Some code was using thread-unsafe `localtime()`, some code was using non-portable `gmtime_r()`. I created own portable `rz_gmtime_r()` in analogy to existing `rz_localtime_r()` and used it instead. Also removed unnecessary inline function from the header.

**Test plan**

CI is green.

**Closing issues**

Might be related to https://github.com/rizinorg/rizin/issues/982#issuecomment-890772705
