### PR TITLE
Fix double free in class_attribute.c

### DIFF
--- a/librz/bin/format/java/class_attribute.c
+++ b/librz/bin/format/java/class_attribute.c
@@ -243,6 +243,7 @@ bool java_attribute_set_localvariabletable(Attribute *attr, RzBuffer *buf) {
 				!rz_buf_read_be16(buf, &alvt->table[i].index)) {
 				free(alvt->table);
 				free(alvt);
+				return false;
 			}
 		}
 	}

--- a/librz/bin/format/java/class_attribute.c
+++ b/librz/bin/format/java/class_attribute.c
@@ -208,6 +208,7 @@ bool java_attribute_set_linenumbertable(Attribute *attr, RzBuffer *buf) {
 				!rz_buf_read_be16(buf, &alnt->table[i].line_number)) {
 				free(alnt->table);
 				free(alnt);
+				return false;
 			}
 		}
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
Due to recent changes in how rz_read_* works, 2 bugs (use-after-free) were introduced.