### PR TITLE
Check pty.h functions presence in Meson

### DIFF
--- a/librz/include/rz_userconf.h.in
+++ b/librz/include/rz_userconf.h.in
@@ -20,6 +20,9 @@
 #define HAVE_SYSTEM                 @HAVE_SYSTEM@
 #define HAVE_PIPE2                  @HAVE_PIPE2@
 #define HAVE_ENVIRON                @HAVE_ENVIRON@
+#define HAVE_OPENPTY                @HAVE_OPENPTY@
+#define HAVE_FORKPTY                @HAVE_FORKPTY@
+#define HAVE_LOGIN_TTY              @HAVE_LOGIN_TTY@
 #define HAVE_LIB_MAGIC              @HAVE_LIB_MAGIC@
 #define USE_LIB_MAGIC               @USE_LIB_MAGIC@
 #define HAVE_LIB_XXHASH             @HAVE_LIB_XXHASH@

--- a/librz/socket/run.c
+++ b/librz/socket/run.c
@@ -32,6 +32,17 @@
 #include <mach-o/nlist.h>
 #endif
 
+#if HAVE_OPENPTY && HAVE_FORKPTY && HAVE_LOGIN_TTY
+#if defined(__APPLE__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <util.h>
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
+#include <libutil.h>
+#else
+#include <pty.h>
+#include <utmp.h>
+#endif
+#endif
+
 #if __UNIX__
 #include <sys/ioctl.h>
 #include <sys/resource.h>
@@ -42,17 +53,12 @@
 #endif
 #if __linux__ && !__ANDROID__
 #include <sys/personality.h>
-#include <pty.h>
-#include <utmp.h>
 #endif
-#if defined(__APPLE__) || defined(__NetBSD__) || defined(__OpenBSD__)
-#include <util.h>
-#elif defined(__FreeBSD__) || defined(__DragonFly__)
+#if defined(__FreeBSD__) || defined(__DragonFly__)
 #if HAVE_DECL_PROCCTL_ASLR_CTL
 #include <sys/procctl.h>
 #endif
 #include <sys/sysctl.h>
-#include <libutil.h>
 #endif
 #endif
 #ifdef _MSC_VER
@@ -61,14 +67,7 @@
 #define pid_t int
 #endif
 
-#if EMSCRIPTEN
-#undef HAVE_PTY
-#define HAVE_PTY 0
-#else
-#define HAVE_PTY __UNIX__ && !__ANDROID__ && HAVE_FORK && !__sun
-#endif
-
-#if HAVE_PTY
+#if HAVE_OPENPTY && HAVE_FORKPTY && HAVE_LOGIN_TTY
 static int (*dyn_openpty)(int *amaster, int *aslave, char *name, struct termios *termp, struct winsize *winp) = NULL;
 static int (*dyn_login_tty)(int fd) = NULL;
 static id_t (*dyn_forkpty)(int *amaster, char *name, struct termios *termp, struct winsize *winp) = NULL;
@@ -291,7 +290,7 @@ static void setASLR(RzRunProfile *r, int enabled) {
 
 #if __APPLE__ && !__POWERPC__
 #else
-#if HAVE_PTY
+#if HAVE_OPENPTY && HAVE_FORKPTY && HAVE_LOGIN_TTY
 static void restore_saved_fd(int saved, bool restore, int fd) {
 	if (saved == -1) {
 		return;
@@ -304,7 +303,7 @@ static void restore_saved_fd(int saved, bool restore, int fd) {
 #endif
 
 static int handle_redirection_proc(const char *cmd, bool in, bool out, bool err) {
-#if HAVE_PTY
+#if HAVE_OPENPTY && HAVE_FORKPTY && HAVE_LOGIN_TTY
 	if (!dyn_forkpty) {
 		// No forkpty api found, maybe we should fallback to just fork without any pty allocated
 		return -1;
@@ -678,7 +677,7 @@ RZ_API const char *rz_run_help(void) {
 	       "# nice=5\n";
 }
 
-#if HAVE_PTY
+#if HAVE_OPENPTY && HAVE_FORKPTY && HAVE_LOGIN_TTY
 static int fd_forward(int in_fd, int out_fd, char **buff) {
 	int size = 0;
 
@@ -729,7 +728,7 @@ static RzThreadFunctionRet exit_process(RzThread *th) {
 #endif
 
 static int redirect_socket_to_pty(RzSocket *sock) {
-#if HAVE_PTY
+#if HAVE_OPENPTY && HAVE_FORKPTY && HAVE_LOGIN_TTY
 	// directly duplicating the fds using dup2() creates problems
 	// in case of interactive applications
 	int fdm, fds;
@@ -809,7 +808,7 @@ static int redirect_socket_to_pty(RzSocket *sock) {
 RZ_API int rz_run_config_env(RzRunProfile *p) {
 	int ret;
 
-#if HAVE_PTY
+#if HAVE_OPENPTY && HAVE_FORKPTY && HAVE_LOGIN_TTY
 	dyn_init();
 #endif
 

--- a/meson.build
+++ b/meson.build
@@ -371,6 +371,9 @@ foreach item : [
     ['system', '#include <stdlib.h>', []],
     ['fork', '#include <unistd.h>', []],
     ['nice', '#include <unistd.h>', []],
+    ['openpty', '', [utl]],
+    ['forkpty', '', [utl]],
+    ['login_tty', '', [utl]],
     ['pipe2', '#define _GNU_SOURCE\n#include <fcntl.h>\n#include <unistd.h>', []]
   ]
   func = item[0]

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -69,6 +69,7 @@ if get_option('enable_tests')
     'queue',
     'rbtree',
     'reg',
+    'run',
     'rz_test',
     'rzpipe',
     'serialize_analysis',

--- a/test/unit/test_run.c
+++ b/test/unit/test_run.c
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2021 Anton Kochkov <anton.kochkov@gmail.com
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_util.h>
+#include <rz_socket.h>
+#include "minunit.h"
+
+static char tmp_path[1000];
+static const char *runprofile =
+	"program=%s\n"
+	"arg1=argument1\n"
+	"arg2=argument2\n"
+	"arg3=argument3\n"
+	"setenv=FOO=BAR\n"
+	"timeout=3\n"
+	"stdout=foo.txt\n";
+
+const char *get_auxiliary_path(const char *s) {
+	char *p = rz_sys_pid_to_path(rz_sys_getpid());
+	char *pp = (char *)rz_str_lchr(p, RZ_SYS_DIR[0]);
+	if (pp) {
+		*pp = '\0';
+	}
+	snprintf(tmp_path, sizeof(tmp_path), "%s%s%s%s%s", p, RZ_SYS_DIR, "auxiliary", RZ_SYS_DIR, s);
+	free(p);
+	return tmp_path;
+}
+
+bool test_rz_run_profile_parse(void) {
+	RzRunProfile *rp = rz_run_new(NULL);
+	mu_assert_notnull(rp, "create new run profile");
+
+	const char *exe_path = get_auxiliary_path("subprocess-multiargs");
+	char *profile = rz_str_newf(runprofile, exe_path);
+	bool res = rz_run_parse(rp, profile);
+	mu_assert_true(res, "parse run profile");
+
+	rz_run_free(rp);
+	mu_end;
+}
+
+bool test_rz_run_profile(void) {
+	RzRunProfile *rp = rz_run_new(NULL);
+	mu_assert_notnull(rp, "create new run profile");
+
+	const char *exe_path = get_auxiliary_path("subprocess-multiargs");
+	char *profile = rz_str_newf(runprofile, exe_path);
+	bool res = rz_run_parse(rp, profile);
+	mu_assert_true(res, "parse run profile");
+
+	int exitcode = rz_run_start(rp);
+	mu_assert_eq(exitcode, 0, "run success");
+
+	rz_run_free(rp);
+	mu_end;
+}
+
+int all_tests() {
+	mu_run_test(test_rz_run_profile_parse);
+	mu_run_test(test_rz_run_profile);
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Do not use `HAVE_PTY` define logic and check the `openpty()`, `forkpty()` and `login_tty()` dynamically using Meson.

Note , that `librz/socket/run.c` is a bit of a mess, but refactoring it more is out of the scope of this PR.

https://man7.org/linux/man-pages/man3/openpty.3.html

**Test plan**

CI is green