### PR TITLE
Add forward-search in shell (#571)

### DIFF
--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -1509,7 +1509,9 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 			break;
 		case 19: // ^S -- forward-search
 			if (gcomp) {
-				gcomp_idx--;
+				if (gcomp_idx > 0) {
+					gcomp_idx--;
+				}
 				gcomp_is_rev = false;
 			} else {
 				__move_cursor_left();
@@ -2000,17 +2002,12 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 						if (i == 0) {
 							if (gcomp_is_rev) {
 								gcomp_idx--;
-							} else {
-								gcomp_idx++;
 							}
 						}
 					}
 				}
-				if (gcomp_is_rev) {
-					printf("\r (reverse-i-search (%s)): %s\r", I.buffer.data, gcomp_line);
-				} else {
-					printf("\r (forward-i-search (%s)): %s\r", I.buffer.data, gcomp_line);
-				}
+				const char *prompt = gcomp_is_rev ? "reverse-i-search" : "forward-i-search";
+				printf("\r (%s (%s)): %s\r", prompt, I.buffer.data, gcomp_line);
 			} else {
 				__print_prompt();
 			}

--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -1332,6 +1332,7 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 	static int gcomp_idx = 0;
 	static bool yank_flag = 0;
 	static int gcomp = 0;
+	static int gcomp_is_rev = true;
 	char buf[10];
 #if USE_UTF8
 	int utflen;
@@ -1499,15 +1500,17 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 			}
 			fflush(stdout);
 			break;
-		case 18: // ^R -- autocompletion
+		case 18: // ^R -- reverse-search
 			if (gcomp) {
 				gcomp_idx++;
 			}
+			gcomp_is_rev = true;
 			gcomp = 1;
 			break;
-		case 19: // ^S -- backspace
+		case 19: // ^S -- forward-search
 			if (gcomp) {
-				gcomp--;
+				gcomp_idx--;
+				gcomp_is_rev = false;
 			} else {
 				__move_cursor_left();
 			}
@@ -1995,11 +1998,19 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 							}
 						}
 						if (i == 0) {
-							gcomp_idx--;
+							if (gcomp_is_rev) {
+								gcomp_idx--;
+							} else {
+								gcomp_idx++;
+							}
 						}
 					}
 				}
-				printf("\r (reverse-i-search (%s)): %s\r", I.buffer.data, gcomp_line);
+				if (gcomp_is_rev) {
+					printf("\r (reverse-i-search (%s)): %s\r", I.buffer.data, gcomp_line);
+				} else {
+					printf("\r (forward-i-search (%s)): %s\r", I.buffer.data, gcomp_line);
+				}
 			} else {
 				__print_prompt();
 			}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The PR adds a forward-search to the rizin shell, allowing selecting the history skipped using the backward search (Ctrl-R).

I added it to `Ctrl-G` since `Ctrl-S` was already mapped to [_backspace_](https://github.com/rizinorg/rizin/blob/41b4da831eef5bcaeb980415b64f26df366d8045/librz/cons/dietline.c#L1508) command. I choose `Ctrl-G` only because isn't mapped and `G` is close to `R` on the keyboard, but maybe `Ctrl-S` can be remapped instead. Let me know what you prefer, and I will modify the commit accordingly!

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

If I run the commands:
```
[0x000bfe24]> aa
[0x000bfe24]> ab
[0x000bfe24]> ac
[0x000bfe24]> ad
```
And I hit `Ctrl-R`, I write `a`, and I hit `Ctrl-R` two times, I get:
```
(reverse-i-search (a)): ab
```
Using the _forward-search_ I can go back to the skipped commands. E.g., hitting `Ctrl-G` one time I get:
```
(forward-i-search (a)): ac
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #571 
