### PR TITLE
Fix #1276: invoke-virtual is now resolved

### DIFF
--- a/librz/asm/p/asm_dalvik.c
+++ b/librz/asm/p/asm_dalvik.c
@@ -19,7 +19,7 @@ static int dalvik_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	int size = dalvik_opcodes[i].len;
 	char str[1024], *strasm = NULL;
 	ut64 offset = 0;
-	char *flag_str;
+	char *flag_str = NULL;
 	a->dataalign = 2;
 
 	const char *buf_asm = NULL;

--- a/librz/bin/p/bin_dex.c
+++ b/librz/bin/p/bin_dex.c
@@ -181,7 +181,7 @@ static ut64 get_offset(RzBinFile *bf, int type, int index) {
 		return -1;
 	}
 	switch (type) {
-	case 'm': // strings
+	case 'm': // method
 		return rz_bin_dex_resolve_method_offset_by_idx(dex, index);
 	case 's': // strings
 		return (int)rz_bin_dex_resolve_string_offset_by_idx(dex, index);

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -2169,7 +2169,7 @@ static bool is_skippable_addr(RzCore *core, ut64 addr) {
 RZ_API int rz_core_analysis_fcn(RzCore *core, ut64 at, ut64 from, int reftype, int depth) {
 	if (from == UT64_MAX && is_skippable_addr(core, at)) {
 		if (core->analysis->verbose) {
-			eprintf("Message: Invalid address for function 0x%08" PFMT64x "\n", at);
+			RZ_LOG_WARN("invalid address for function 0x%08" PFMT64x "\n", at);
 		}
 		return 0;
 	}
@@ -2184,7 +2184,7 @@ RZ_API int rz_core_analysis_fcn(RzCore *core, ut64 at, ut64 from, int reftype, i
 	if (core->io->va) {
 		if (!rz_io_is_valid_offset(core->io, at, !core->analysis->opt.noncode)) {
 			if (core->analysis->verbose) {
-				eprintf("Warning: Address not mapped or not executable at 0x%08" PFMT64x "\n", at);
+				RZ_LOG_WARN("address not mapped or not executable at 0x%08" PFMT64x "\n", at);
 			}
 			return false;
 		}
@@ -2194,12 +2194,12 @@ RZ_API int rz_core_analysis_fcn(RzCore *core, ut64 at, ut64 from, int reftype, i
 	}
 
 	if ((from != UT64_MAX && !at) || at == UT64_MAX) {
-		eprintf("Invalid address from 0x%08" PFMT64x "\n", from);
+		RZ_LOG_WARN("invalid address from 0x%08" PFMT64x "\n", from);
 		return false;
 	}
 	if (depth < 0) {
 		if (core->analysis->verbose) {
-			eprintf("Warning: analysis depth reached\n");
+			RZ_LOG_WARN("analysis depth reached\n");
 		}
 		return false;
 	}

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -6042,6 +6042,19 @@ static void cmd_analysis_ucall_ref(RzCore *core, ut64 addr) {
 	}
 }
 
+static inline RzFlagItem *core_flag_get_at_as_ref_type(RzCore *core, RzAnalysisXRef *xrefi) {
+	switch (xrefi->type) {
+	case RZ_ANALYSIS_REF_TYPE_CALL:
+		return rz_flag_get_by_spaces(core->flags, xrefi->to, RZ_FLAGS_FS_SYMBOLS, RZ_FLAGS_FS_CLASSES, RZ_FLAGS_FS_FUNCTIONS, NULL);
+	case RZ_ANALYSIS_REF_TYPE_DATA:
+		return rz_flag_get_by_spaces(core->flags, xrefi->to, RZ_FLAGS_FS_STRINGS, RZ_FLAGS_FS_SYMBOLS, RZ_FLAGS_FS_IMPORTS, NULL);
+	case RZ_ANALYSIS_REF_TYPE_STRING:
+		return rz_flag_get_by_spaces(core->flags, xrefi->to, RZ_FLAGS_FS_STRINGS, NULL);
+	default:
+		return rz_flag_get_at(core->flags, xrefi->to, true);
+	}
+}
+
 #define var_ref_list(a, d, t) sdb_fmt("var.0x%" PFMT64x ".%d.%d.%s", \
 	a, 1, d, (t == 'R') ? "reads" : "writes");
 
@@ -6296,7 +6309,7 @@ static bool cmd_analysis_refs(RzCore *core, const char *input) {
 			if (fcn) {
 				RzList *xrefs = rz_analysis_function_get_xrefs_from(fcn);
 				rz_list_foreach (xrefs, iter, xrefi) {
-					RzFlagItem *f = rz_flag_get_at(core->flags, xrefi->to, true);
+					RzFlagItem *f = core_flag_get_at_as_ref_type(core, xrefi);
 					const char *name = f ? f->name : "";
 					if (pj) {
 						pj_o(pj);

--- a/test/db/analysis/dalvik
+++ b/test/db/analysis/dalvik
@@ -36,8 +36,8 @@ NAME=Dalvik resolve virtual methods called via invoke-virtual
 FILE=apk://bins/dex/org.radare.radare2installer.apk
 CMDS=e scr.prompt=false ; aaa ; axt @ sym.Lcom_ice_tar_TarEntry_.getUserName__Ljava_lang_String
 EXPECT=<<EOF
-entry0 0xc8ba [CALL] invoke-virtual {v1}, Lcom/ice/tar/TarEntry;.getUserName()Ljava/lang/String;
-entry0 0xc9e6 [CALL] invoke-virtual {v1}, Lcom/ice/tar/TarEntry;.getUserName()Ljava/lang/String;
-method.public.Lcom_ice_tar_TarEntry_.toString__Ljava_lang_String 0xf04a [CALL] invoke-virtual {v4}, Lcom/ice/tar/TarEntry;.getUserName()Ljava/lang/String;
+entry0 0xc8ba [CALL] invoke-virtual {v1}, Lcom/ice/tar/TarEntry;->getUserName()Ljava/lang/String;
+entry0 0xc9e6 [CALL] invoke-virtual {v1}, Lcom/ice/tar/TarEntry;->getUserName()Ljava/lang/String;
+method.public.Lcom_ice_tar_TarEntry_.toString__Ljava_lang_String 0xf04a [CALL] invoke-virtual {v4}, Lcom/ice/tar/TarEntry;->getUserName()Ljava/lang/String;
 EOF
 RUN

--- a/test/db/analysis/dalvik
+++ b/test/db/analysis/dalvik
@@ -23,8 +23,21 @@ NAME=Dalvik HelloWorld func xref
 FILE=bins/dex/HelloWorld.dex
 CMDS=aa; axt @sym.LHello_._init___V
 EXPECT=<<EOF
-sym.Ljava_lang_System_.out 0x24 [CALL] invoke-direct {}, LHello;.<init>()V
-sym.Ljava_lang_System_.out 0x3c [CALL] invoke-direct {}, LHello;.<init>()V
-entry0 0x26e [CALL] invoke-direct {v0}, LHello;.<init>()V
+sym.Ljava_lang_System_.out 0x24 [CALL] invoke-direct {}, LHello;-><init>()V
+sym.Ljava_lang_System_.out 0x3c [CALL] invoke-direct {}, LHello;-><init>()V
+entry0 0x26e [CALL] invoke-direct {v0}, LHello;-><init>()V
+method.public.LHello_.foo_I_V 0x298 [CALL] invoke-direct {v1}, Ljava/lang/StringBuilder;-><init>()V
+method.public.constructor.LWorld_._init___V; [03] -r-x section size 20 named code.World._init 0x2f4 [CALL] invoke-direct {v1}, Ljava/lang/Object;-><init>()V
+method.public.LWorld_.foo_I_V 0x320 [CALL] invoke-direct {v1}, Ljava/lang/StringBuilder;-><init>()V
+EOF
+RUN
+
+NAME=Dalvik resolve virtual methods called via invoke-virtual
+FILE=apk://bins/dex/org.radare.radare2installer.apk
+CMDS=e scr.prompt=false ; aaa ; axt @ sym.Lcom_ice_tar_TarEntry_.getUserName__Ljava_lang_String
+EXPECT=<<EOF
+entry0 0xc8ba [CALL] invoke-virtual {v1}, Lcom/ice/tar/TarEntry;.getUserName()Ljava/lang/String;
+entry0 0xc9e6 [CALL] invoke-virtual {v1}, Lcom/ice/tar/TarEntry;.getUserName()Ljava/lang/String;
+method.public.Lcom_ice_tar_TarEntry_.toString__Ljava_lang_String 0xf04a [CALL] invoke-virtual {v4}, Lcom/ice/tar/TarEntry;.getUserName()Ljava/lang/String;
 EOF
 RUN

--- a/test/db/formats/dex
+++ b/test/db/formats/dex
@@ -57,9 +57,9 @@ NAME=DEX dex38.dex invoke-polymorphic
 FILE=bins/dex/dex38.dex
 CMDS=pi 2 @0x00125e; pi 3 @0x0012da
 EXPECT=<<EOF
-invoke-polymorphic {v1, v2, v3}, Ljava/lang/invoke/MethodHandle;.invoke([Ljava/lang/Object;)Ljava/lang/Object;, (II)Ljava/lang/Object;
+invoke-polymorphic {v1, v2, v3}, Ljava/lang/invoke/MethodHandle;->invoke([Ljava/lang/Object;)Ljava/lang/Object;, (II)Ljava/lang/Object;
 move-result-object v1
-invoke-polymorphic {v0, v1, v2}, Ljava/lang/invoke/MethodHandle;.invoke([Ljava/lang/Object;)Ljava/lang/Object;, (Ljava/lang/String;I)Ljava/lang/Object;
+invoke-polymorphic {v0, v1, v2}, Ljava/lang/invoke/MethodHandle;->invoke([Ljava/lang/Object;)Ljava/lang/Object;, (Ljava/lang/String;I)Ljava/lang/Object;
 move-result-object v0
 return-object v0
 EOF
@@ -258,11 +258,11 @@ EXPECT=<<EOF
 iput v0, v1, LHello;->localVar I
 sput v0, LHello;->localVar2 I
 sget-object v0, Ljava/lang/System;->out Ljava/io/PrintStream;
-invoke-virtual {v0, v1}, Ljava/io/PrintStream;.println(Ljava/lang/String;)V
-invoke-virtual {v0, v1}, LHello;.foo(I)V
+invoke-virtual {v0, v1}, Ljava/io/PrintStream;->println(Ljava/lang/String;)V
+invoke-virtual {v0, v1}, LHello;->foo(I)V
 new-instance v0, LHello;
 new-instance v1, Ljava/lang/StringBuilder;
-invoke-direct {v1}, Ljava/lang/StringBuilder;.<init>()V
+invoke-direct {v1}, Ljava/lang/StringBuilder;-><init>()V
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fix #1276 

```
$ ninja -C build-noasan/ && build-noasan/binrz/rizin/rizin -Qc "aaa ; s sym.Lahmyth_mine_king_ahmyth_ConnectionManager_.sendReq__V ; axff~CALL" apk:///tmp/Ahmyth.apk
CALL 0x000411ce 0x00041934 sym.Lahmyth_mine_king_ahmyth_IOSocket_.getInstance__Lahmyth_mine_king_ahmyth_IOSocket
CALL 0x000411d6 0x0004194c sym.Lahmyth_mine_king_ahmyth_IOSocket_.getIoSocket__Lio_socket_client_Socket
CALL 0x000411ee 0x00040e40 sym.Lahmyth_mine_king_ahmyth_ConnectionManager_1_._init___V
CALL 0x000411f4 0x000453a8 sym.Lio_socket_emitter_Emitter_.on_Ljava_lang_String_Lio_socket_emitter_Emitter_Listener__Lio_socket_emitter_Emitter
CALL 0x00041206 0x00040e84 sym.Lahmyth_mine_king_ahmyth_ConnectionManager_2_._init___V
CALL 0x0004120c 0x000453a8 sym.Lio_socket_emitter_Emitter_.on_Ljava_lang_String_Lio_socket_emitter_Emitter_Listener__Lio_socket_emitter_Emitter
CALL 0x00041216 0x00044ce8 sym.Lio_socket_client_Socket_.connect__Lio_socket_client_Socket
```

a test has been added