### PR TITLE
Fix malformed Mach-O export table parsing

### DIFF
--- a/librz/bin/format/mach0/mach0.c
+++ b/librz/bin/format/mach0/mach0.c
@@ -2715,12 +2715,12 @@ static int walk_exports(struct MACH0_(obj_t) * bin, RExportsIterator iterator, v
 			RZ_FREE(next);
 			goto beach;
 		}
-		next->node = tr + trie;
-		if (next->node >= end) {
+		if (tr + (ut64)trie >= (ut64)end) {
 			eprintf("malformed export trie\n");
 			RZ_FREE(next);
 			goto beach;
 		}
+		next->node = tr + trie;
 		{
 			// avoid loops
 			RzListIter *it;

--- a/librz/bin/format/mach0/mach0.c
+++ b/librz/bin/format/mach0/mach0.c
@@ -2715,7 +2715,7 @@ static int walk_exports(struct MACH0_(obj_t) * bin, RExportsIterator iterator, v
 			RZ_FREE(next);
 			goto beach;
 		}
-		if (tr + (ut64)trie >= (ut64)end) {
+		if (UT64_ADD_OVFCHK(tr, (ut64)trie) || tr + (ut64)trie >= (ut64)end) {
 			eprintf("malformed export trie\n");
 			RZ_FREE(next);
 			goto beach;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Note, while technically this wasn't an error it was still triggering the ASAN runtime exception due to the memory regions boundary checks even during the index arithmetic. Thus to perform the corresponding check we convert pointers to the `ut64` type first.

```
[XX] /Users/runner/work/rizin/rizin/test/bins/fuzzed <fuzz> /Users/runner/work/rizin/rizin/test/bins/fuzzed/48735003f0e19e5bdeff1402840cd0b3
RZ_NOPLUGINS=1 rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -Qc aaa /Users/runner/work/rizin/rizin/test/bins/fuzzed/48735003f0e19e5bdeff1402840cd0b3
-- stdout

-- stderr

-- exit status: -1
[**]    /Users/runner/work/rizin/rizin/test/bins/fuzzed      522 OK         0 BR        1 XX        0 FX
```

**Test plan**

CI is green