### PR TITLE
Fix char array subscript warning

### DIFF
--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -1790,7 +1790,7 @@ static bool issymbol(char c) {
 static bool check_arg_name(RzPrint *print, char *p, ut64 func_addr) {
 	if (func_addr && print->exists_var) {
 		int z;
-		for (z = 0; p[z] && (isalpha(p[z]) || isdigit(p[z]) || p[z] == '_'); z++) {
+		for (z = 0; p[z] && (isalpha((int)p[z]) || isdigit((int)p[z]) || p[z] == '_'); z++) {
 			;
 		}
 		char tmp = p[z];

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -3619,7 +3619,7 @@ RZ_API RzList *rz_str_wrap(char *str, size_t width) {
 
 	do {
 		p++;
-		if (!*p || isspace(*p)) {
+		if (!*p || isspace((int)*p)) {
 			if (p != last_space + 1) {
 				if (p - start_line > width && first_space) {
 					rz_list_append(res, start_line);
@@ -3632,7 +3632,7 @@ RZ_API RzList *rz_str_wrap(char *str, size_t width) {
 		}
 	} while (*p);
 	p--;
-	while (p >= str && isspace(*p)) {
+	while (p >= str && isspace((int)*p)) {
 		*p = '\0';
 		p--;
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fix these warnings:
```
[118/1668] Compiling C object librz/util/msys-rz_util-0.3.0-git.dll.p/print.c.o
In file included from ../librz/include/rz_types_base.h:4,
                 from ../librz/include/rz_types.h:193,
                 from ../librz/include/rz_util/rz_print.h:4,
                 from ../librz/util/print.c:4:
../librz/util/print.c: In function ‘check_arg_name’:
../librz/util/print.c:1793:33: warning: array subscript has type ‘char’ [-Wchar-subscripts]
 1793 |   for (z = 0; p[z] && (isalpha(p[z]) || isdigit(p[z]) || p[z] == '_'); z++) {
      |                                ~^~~
../librz/util/print.c:1793:50: warning: array subscript has type ‘char’ [-Wchar-subscripts]
 1793 |   for (z = 0; p[z] && (isalpha(p[z]) || isdigit(p[z]) || p[z] == '_'); z++) {
      |                                                 ~^~~
[135/1668] Compiling C object librz/util/msys-rz_util-0.3.0-git.dll.p/str.c.o
In file included from ../librz/include/rz_types_base.h:4,
                 from ../librz/include/rz_types.h:193,
                 from ../librz/util/str.c:4:
../librz/util/str.c: In function ‘rz_str_wrap’:
../librz/util/str.c:3622:22: warning: array subscript has type ‘char’ [-Wchar-subscripts]
 3622 |   if (!*p || isspace(*p)) {
      |                      ^~
../librz/util/str.c:3635:29: warning: array subscript has type ‘char’ [-Wchar-subscripts]
 3635 |  while (p >= str && isspace(*p)) {
      |                             ^~
```

**Test plan**

CI is green