### PR TITLE
Fix legend of `Vv` - visual menu mode

### DIFF
--- a/librz/core/vmenus.c
+++ b/librz/core/vmenus.c
@@ -2412,8 +2412,8 @@ static void rz_core_visual_analysis_refresh_column(RzCore *core, int colpos) {
 }
 
 static const char *help_fun_visual[] = {
-	"(a)", "analyze ", "(-)", "delete ", "(x)", "xrefs to", "(X)", "xrefs from  j/k next/prev\n",
-	"(r)", "rename ", "(c)", "calls ", "(d)", "definetab column (_) hud\n",
+	"(a)", "analyze ", "(-)", "delete ", "(x)", "xrefs to ", "(X)", "xrefs from ", "(j/k)", "next/prev\n",
+	"(r)", "rename ", "(c)", "calls ", "(d)", "define ", "(tab)", "column ", "(_)", "hud\n",
 	"(d)", "define ", "(v)", "vars ", "(?)", " help ", "(:)", "shell ", "(q)", "quit\n",
 	"(s)", "edit function signature.  \n\n",
 	NULL


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

See the legend of `Vv` mode after `aaa` is being run. Before it was misformatted.
