### PR TITLE
Detect `copyfile()` with Meson

### DIFF
--- a/librz/util/file.c
+++ b/librz/util/file.c
@@ -14,12 +14,7 @@
 #include <sys/mman.h>
 #include <limits.h>
 #endif
-#if __APPLE__ && __MAC_10_5
-#define HAVE_COPYFILE_H 1
-#else
-#define HAVE_COPYFILE_H 0
-#endif
-#if HAVE_COPYFILE_H
+#if HAVE_COPYFILE
 #include <copyfile.h>
 #endif
 #if _MSC_VER
@@ -1155,7 +1150,7 @@ RZ_API char *rz_file_tmpdir(void) {
 RZ_API bool rz_file_copy(const char *src, const char *dst) {
 	/* TODO: implement in C */
 	/* TODO: Use NO_CACHE for iOS dyldcache copying */
-#if HAVE_COPYFILE_H
+#if HAVE_COPYFILE
 	return copyfile(src, dst, 0, COPYFILE_DATA | COPYFILE_XATTR) != -1;
 #elif __WINDOWS__
 	PTCHAR s = rz_sys_conv_utf8_to_win(src);

--- a/meson.build
+++ b/meson.build
@@ -371,6 +371,7 @@ foreach item : [
     ['system', '#include <stdlib.h>', []],
     ['fork', '#include <unistd.h>', []],
     ['nice', '#include <unistd.h>', []],
+    ['copyfile', '#include <copyfile.h>', []],
     ['strlcpy', '#include <string.h>', []],
     ['openpty', '', [utl]],
     ['forkpty', '', [utl]],


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Before it was like that:
```c
#if __APPLE__ && __MAC_10_5
#define HAVE_COPYFILE_H 1
#else
#define HAVE_COPYFILE_H 0
#endif
```
Now we detect the presence of `copyfile()` function that requires `#include <copyfile.h>` using Meson.

**Test plan**

CI is green.