### PR TITLE
Fix small mistake in `rz_list.h`

### DIFF
--- a/librz/include/rz_list.h
+++ b/librz/include/rz_list.h
@@ -39,7 +39,6 @@ typedef struct rz_oflist_t {
 	RFList *array; // statical readonly cache of linked list as a pointer array
 } ROFList;
 
-
 #ifdef RZ_API
 
 #define rz_list_foreach(list, it, pos) \

--- a/librz/include/rz_list.h
+++ b/librz/include/rz_list.h
@@ -4,6 +4,7 @@
 #include <rz_types.h>
 #include <rz_flist.h>
 #include <sdb.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -37,7 +38,7 @@ typedef struct rz_oflist_t {
 	ROFList_Parent super; // super class
 	RFList *array; // statical readonly cache of linked list as a pointer array
 } ROFList;
-#endif
+
 
 #ifdef RZ_API
 
@@ -116,4 +117,5 @@ RZ_API RZ_BORROW RzListIter *rz_list_find(RZ_NONNULL const RzList *list, const v
 }
 #endif
 
+#endif
 #endif


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

While trying to compile cutter against latest Rizin, the`rz_list.h` file showed an error. Digging a bit deeper seems that there is an erroneous `#endif` in the middle of the file. So I moved it to the bottom of the file like all other header files. Now Cutter compiles fine.

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
