### PR TITLE
UTF-16 be, UTF-32 be support

### DIFF
--- a/librz/bin/bfile.c
+++ b/librz/bin/bfile.c
@@ -6,11 +6,8 @@
 #include <rz_bin.h>
 #include <rz_msg_digest.h>
 #include <rz_util/rz_log.h>
+#include <rz_util/rz_str_search.h>
 #include "i/private.h"
-
-// maybe too big sometimes? 2KB of stack eaten here..
-#define RZ_STRING_SCAN_BUFFER_SIZE 2048
-#define RZ_STRING_MAX_UNI_BLOCKS   4
 
 static RzBinClass *__getClass(RzBinFile *bf, const char *name) {
 	rz_return_val_if_fail(bf && bf->o && bf->o->classes_ht && name, NULL);
@@ -112,34 +109,21 @@ static void print_string(RzBinFile *bf, RzBinString *string, int raw, PJ *pj) {
 
 static int string_scan_range(RzList *list, RzBinFile *bf, int min,
 	const ut64 from, const ut64 to, int type, int raw, RzBinSection *section) {
-	RzBin *bin = bf->rbin;
-	ut8 tmp[RZ_STRING_SCAN_BUFFER_SIZE];
-	ut64 str_start, needle = from;
-	int count = 0, i, rc, runes;
-	int str_type = RZ_STRING_TYPE_DETECT;
 
-	// if list is null it means its gonna dump
 	rz_return_val_if_fail(bf, -1);
 
-	if (type == -1) {
-		type = RZ_STRING_TYPE_DETECT;
-	}
-	if (from == to) {
+	RzListIter *it;
+	RzBinString *bs;
+	RzBinSection *s = NULL;
+
+	RzList *str_list = rz_list_new();
+
+	int count = rz_scan_strings(str_list, bf->buf, from, to, min, type);
+	if (count <= 0) {
+		rz_list_free(str_list);
 		return 0;
 	}
-	if (from > to) {
-		eprintf("Invalid range to find strings 0x%" PFMT64x " .. 0x%" PFMT64x "\n", from, to);
-		return -1;
-	}
-	int len = to - from;
-	ut8 *buf = calloc(len, 1);
-	if (!buf || !min) {
-		free(buf);
-		return -1;
-	}
-	st64 vdelta = 0, pdelta = 0;
-	RzBinSection *s = NULL;
-	bool ascii_only = false;
+
 	PJ *pj = NULL;
 	if (bf->strmode == RZ_MODE_JSON && !list) {
 		pj = pj_new();
@@ -147,220 +131,48 @@ static int string_scan_range(RzList *list, RzBinFile *bf, int min,
 			pj_a(pj);
 		}
 	}
-	rz_buf_read_at(bf->buf, from, buf, len);
-	// may oobread
-	while (needle < to) {
-		if (bin && bin->consb.is_breaked) {
-			if (bin->consb.is_breaked()) {
-				break;
+
+	rz_list_foreach (str_list, it, bs) {
+		if (!s) {
+			if (section) {
+				s = section;
+			} else if (bf->o) {
+				s = rz_bin_get_section_at(bf->o, bs->paddr, false);
 			}
 		}
-		rc = rz_utf8_decode(buf + needle - from, to - needle, NULL);
-		if (!rc) {
-			needle++;
-			continue;
+
+		if (s) {
+			bs->vaddr = bs->paddr - s->paddr + s->vaddr;
 		}
-		if (type == RZ_STRING_TYPE_DETECT) {
-			char *w = (char *)buf + needle + rc - from;
-			if ((to - needle) > 5 + rc) {
-				bool is_wide32 = (needle + rc + 2 < to) && (!w[0] && !w[1] && !w[2] && w[3] && !w[4]);
-				if (is_wide32) {
-					str_type = RZ_STRING_TYPE_WIDE32;
-				} else {
-					bool is_wide = needle + rc + 4 < to && !w[0] && w[1] && !w[2] && w[3] && !w[4];
-					str_type = is_wide ? RZ_STRING_TYPE_WIDE : RZ_STRING_TYPE_ASCII;
-				}
-			} else {
-				str_type = RZ_STRING_TYPE_ASCII;
+
+		if (list) {
+			if (bf->o) {
+				ht_up_insert(bf->o->strings_db, bs->vaddr, bs);
 			}
-		} else if (type == RZ_STRING_TYPE_UTF8) {
-			str_type = RZ_STRING_TYPE_ASCII; // initial assumption
+			rz_list_append(list, bs);
 		} else {
-			str_type = type;
-		}
-		runes = 0;
-		str_start = needle;
-
-		/* Eat a whole C string */
-		for (i = 0; i < sizeof(tmp) - 4 && needle < to; i += rc) {
-			RzRune r = { 0 };
-
-			if (str_type == RZ_STRING_TYPE_WIDE32) {
-				rc = rz_utf32le_decode(buf + needle - from, to - needle, &r);
-				if (rc) {
-					rc = 4;
-				}
-			} else if (str_type == RZ_STRING_TYPE_WIDE) {
-				rc = rz_utf16le_decode(buf + needle - from, to - needle, &r);
-				if (rc == 1) {
-					rc = 2;
-				}
-			} else {
-				rc = rz_utf8_decode(buf + needle - from, to - needle, &r);
-				if (rc > 1) {
-					str_type = RZ_STRING_TYPE_UTF8;
-				}
-			}
-
-			/* Invalid sequence detected */
-			if (!rc || (ascii_only && r > 0x7f)) {
-				needle++;
-				break;
-			}
-
-			needle += rc;
-
-			if (rz_isprint(r) && r != '\\') {
-				if (str_type == RZ_STRING_TYPE_WIDE32) {
-					if (r == 0xff) {
-						r = 0;
-					}
-				}
-				rc = rz_utf8_encode(tmp + i, r);
-				runes++;
-				/* Print the escape code */
-			} else if (r && r < 0x100 && strchr("\b\v\f\n\r\t\a\033\\", (char)r)) {
-				if ((i + 32) < sizeof(tmp) && r < 93) {
-					tmp[i + 0] = '\\';
-					tmp[i + 1] = "       abtnvfr             e  "
-						     "                              "
-						     "                              "
-						     "  \\"[r];
-				} else {
-					// string too long
-					break;
-				}
-				rc = 2;
-				runes++;
-			} else {
-				/* \0 marks the end of C-strings */
-				break;
-			}
+			print_string(bf, bs, raw, pj);
+			rz_bin_string_free(bs);
 		}
 
-		tmp[i++] = '\0';
-
-		if (runes < min && runes >= 2 && str_type == RZ_STRING_TYPE_ASCII && needle < to) {
-			// back up past the \0 to the last char just in case it starts a wide string
-			needle -= 2;
+		if (from == 0 && to == bf->size) {
+			/* force lookup section at the next one */
+			s = NULL;
 		}
-		if (runes >= min) {
-			// reduce false positives
-			int j, num_blocks, *block_list;
-			int *freq_list = NULL, expected_ascii, actual_ascii, num_chars;
-			if (str_type == RZ_STRING_TYPE_ASCII) {
-				for (j = 0; j < i; j++) {
-					char ch = tmp[j];
-					if (ch != '\n' && ch != '\r' && ch != '\t') {
-						if (!IS_PRINTABLE(tmp[j])) {
-							continue;
-						}
-					}
-				}
-			}
-			switch (str_type) {
-			case RZ_STRING_TYPE_UTF8:
-			case RZ_STRING_TYPE_WIDE:
-			case RZ_STRING_TYPE_WIDE32:
-				num_blocks = 0;
-				block_list = rz_utf_block_list((const ut8 *)tmp, i - 1,
-					str_type == RZ_STRING_TYPE_WIDE ? &freq_list : NULL);
-				if (block_list) {
-					for (j = 0; block_list[j] != -1; j++) {
-						num_blocks++;
-					}
-				}
-				if (freq_list) {
-					num_chars = 0;
-					actual_ascii = 0;
-					for (j = 0; freq_list[j] != -1; j++) {
-						num_chars += freq_list[j];
-						if (!block_list[j]) { // ASCII
-							actual_ascii = freq_list[j];
-						}
-					}
-					free(freq_list);
-					expected_ascii = num_blocks ? num_chars / num_blocks : 0;
-					if (actual_ascii > expected_ascii) {
-						ascii_only = true;
-						needle = str_start;
-						free(block_list);
-						continue;
-					}
-				}
-				free(block_list);
-				if (num_blocks > RZ_STRING_MAX_UNI_BLOCKS) {
-					continue;
-				}
-			}
-			RzBinString *bs = RZ_NEW0(RzBinString);
-			if (!bs) {
-				break;
-			}
-			bs->type = str_type;
-			bs->length = runes;
-			bs->size = needle - str_start;
-			bs->ordinal = count++;
-			// TODO: move into adjust_offset
-			switch (str_type) {
-			case RZ_STRING_TYPE_WIDE:
-				if (str_start - from > 1) {
-					const ut8 *p = buf + str_start - 2 - from;
-					if (p[0] == 0xff && p[1] == 0xfe) {
-						str_start -= 2; // \xff\xfe
-					}
-				}
-				break;
-			case RZ_STRING_TYPE_WIDE32:
-				if (str_start - from > 3) {
-					const ut8 *p = buf + str_start - 4 - from;
-					if (p[0] == 0xff && p[1] == 0xfe) {
-						str_start -= 4; // \xff\xfe\x00\x00
-					}
-				}
-				break;
-			}
-			if (!s) {
-				if (section) {
-					s = section;
-				} else if (bf->o) {
-					s = rz_bin_get_section_at(bf->o, str_start, false);
-				}
-				if (s) {
-					vdelta = s->vaddr;
-					pdelta = s->paddr;
-				}
-			}
-			bs->paddr = str_start;
-			bs->vaddr = str_start - pdelta + vdelta;
-			bs->string = rz_str_ndup((const char *)tmp, i);
-			if (list) {
-				rz_list_append(list, bs);
-				if (bf->o) {
-					ht_up_insert(bf->o->strings_db, bs->vaddr, bs);
-				}
-			} else {
-				print_string(bf, bs, raw, pj);
-				rz_bin_string_free(bs);
-			}
-			if (from == 0 && to == bf->size) {
-				/* force lookup section at the next one */
-				s = NULL;
-			}
-		}
-		ascii_only = false;
 	}
-	free(buf);
+
 	if (pj) {
 		pj_end(pj);
-		if (bin) {
-			RzIO *io = bin->iob.io;
+		if (bf->rbin) {
+			RzIO *io = bf->rbin->iob.io;
 			if (io) {
 				io->cb_printf("%s", pj_string(pj));
 			}
 		}
 		pj_free(pj);
 	}
+
+	rz_list_free(str_list);
 	return count;
 }
 

--- a/librz/bin/bfile.c
+++ b/librz/bin/bfile.c
@@ -236,7 +236,11 @@ static void get_strings_range(RzBinFile *bf, RzList *list, int min, int raw, ut6
 		type = RZ_STRING_TYPE_WIDE;
 	} else if (!strcmp(enc, "utf32le")) {
 		type = RZ_STRING_TYPE_WIDE32;
-	} else { // TODO utf16be, utf32be
+	} else if (!strcmp(enc, "utf16be")) {
+		type = RZ_STRING_TYPE_WIDE_BE;
+	} else if (!strcmp(enc, "utf32be")) {
+		type = RZ_STRING_TYPE_WIDE32_BE;
+	} else {
 		eprintf("ERROR: encoding %s not supported\n", enc);
 		return;
 	}

--- a/librz/bin/bfile.c
+++ b/librz/bin/bfile.c
@@ -162,7 +162,8 @@ static int string_scan_range(RzList *list, RzBinFile *bf, int min,
 	RzUtilStrScanOptions scan_opt = {
 		.buf_size = 2048,
 		.max_uni_blocks = 4,
-		.min_str_length = min
+		.min_str_length = min,
+		.prefer_big_endian = false
 	};
 
 	int count = rz_scan_strings(bf->buf, str_list, &scan_opt, from, to, type);

--- a/librz/bin/bfile.c
+++ b/librz/bin/bfile.c
@@ -165,7 +165,7 @@ static int string_scan_range(RzList *list, RzBinFile *bf, int min,
 		.min_str_length = min
 	};
 
-	int count = rz_scan_strings(&scan_opt, str_list, bf->buf, from, to, type);
+	int count = rz_scan_strings(bf->buf, str_list, &scan_opt, from, to, type);
 	if (count <= 0) {
 		rz_list_free(str_list);
 		return 0;

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -71,11 +71,13 @@ RZ_API RzBinXtrData *rz_bin_xtrdata_new(RzBuffer *buf, ut64 offset, ut64 size, u
 
 RZ_API const char *rz_bin_string_type(int type) {
 	switch (type) {
-	case 'a': return "ascii";
-	case 'u': return "utf8";
-	case 'w': return "utf16le";
-	case 'W': return "utf32le";
-	case 'b': return "base64";
+	case RZ_STRING_TYPE_ASCII: return "ascii";
+	case RZ_STRING_TYPE_UTF8: return "utf8";
+	case RZ_STRING_TYPE_WIDE: return "utf16le";
+	case RZ_STRING_TYPE_WIDE32: return "utf32le";
+	case RZ_STRING_TYPE_WIDE_BE: return "utf16be";
+	case RZ_STRING_TYPE_WIDE32_BE: return "utf32be";
+	case RZ_STRING_TYPE_BASE64: return "base64";
 	}
 	return "ascii"; // XXX
 }

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -69,12 +69,12 @@ RZ_API RzBinXtrData *rz_bin_xtrdata_new(RzBuffer *buf, ut64 offset, ut64 size, u
 	return data;
 }
 
-RZ_API const char *rz_bin_string_type(int type) {
+RZ_API RZ_BORROW const char *rz_bin_string_type(int type) {
 	switch (type) {
 	case RZ_STRING_TYPE_ASCII: return "ascii";
 	case RZ_STRING_TYPE_UTF8: return "utf8";
-	case RZ_STRING_TYPE_WIDE: return "utf16le";
-	case RZ_STRING_TYPE_WIDE32: return "utf32le";
+	case RZ_STRING_TYPE_WIDE_LE: return "utf16le";
+	case RZ_STRING_TYPE_WIDE32_LE: return "utf32le";
 	case RZ_STRING_TYPE_WIDE_BE: return "utf16be";
 	case RZ_STRING_TYPE_WIDE32_BE: return "utf32be";
 	case RZ_STRING_TYPE_BASE64: return "base64";

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -2651,8 +2651,8 @@ static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzList *l
 
 			switch (string->type) {
 			case RZ_STRING_TYPE_UTF8:
-			case RZ_STRING_TYPE_WIDE:
-			case RZ_STRING_TYPE_WIDE32:
+			case RZ_STRING_TYPE_WIDE_LE:
+			case RZ_STRING_TYPE_WIDE32_LE:
 				block_list = rz_utf_block_list((const ut8 *)string->string, -1, NULL);
 				if (block_list) {
 					if (block_list[0] == 0 && block_list[1] == -1) {
@@ -2704,8 +2704,8 @@ static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzList *l
 			RzStrBuf *buf = rz_strbuf_new(str);
 			switch (string->type) {
 			case RZ_STRING_TYPE_UTF8:
-			case RZ_STRING_TYPE_WIDE:
-			case RZ_STRING_TYPE_WIDE32:
+			case RZ_STRING_TYPE_WIDE_LE:
+			case RZ_STRING_TYPE_WIDE32_LE:
 				block_list = rz_utf_block_list((const ut8 *)string->string, -1, NULL);
 				if (block_list) {
 					if (block_list[0] == 0 && block_list[1] == -1) {

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -935,7 +935,7 @@ RZ_API bool rz_bin_use_arch(RzBin *bin, const char *arch, int bits, const char *
 RZ_API RzBuffer *rz_bin_create(RzBin *bin, const char *plugin_name, const ut8 *code, int codelen, const ut8 *data, int datalen, RzBinArchOptions *opt);
 RZ_API RzBuffer *rz_bin_package(RzBin *bin, const char *type, const char *file, RzList *files);
 
-RZ_API RZ_OWN const char *rz_bin_string_type(int type);
+RZ_API RZ_BORROW const char *rz_bin_string_type(int type);
 RZ_API const char *rz_bin_entry_type_string(int etype);
 
 RZ_API bool rz_bin_file_object_new_from_xtr_data(RzBin *bin, RzBinFile *bf, RzBinObjectLoadOptions *opts, RzBinXtrData *data);

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -161,8 +161,8 @@ enum {
 	RZ_STRING_TYPE_DETECT = '?',
 	RZ_STRING_TYPE_ASCII = 'a',
 	RZ_STRING_TYPE_UTF8 = 'u',
-	RZ_STRING_TYPE_WIDE = 'w', // utf16 / widechar string
-	RZ_STRING_TYPE_WIDE32 = 'W', // utf32
+	RZ_STRING_TYPE_WIDE_LE = 'w', // utf16 / widechar string
+	RZ_STRING_TYPE_WIDE32_LE = 'W', // utf32
 	RZ_STRING_TYPE_WIDE_BE = 'x', // utf16-be / widechar string
 	RZ_STRING_TYPE_WIDE32_BE = 'X', // utf32-be
 	RZ_STRING_TYPE_BASE64 = 'b',
@@ -935,7 +935,7 @@ RZ_API bool rz_bin_use_arch(RzBin *bin, const char *arch, int bits, const char *
 RZ_API RzBuffer *rz_bin_create(RzBin *bin, const char *plugin_name, const ut8 *code, int codelen, const ut8 *data, int datalen, RzBinArchOptions *opt);
 RZ_API RzBuffer *rz_bin_package(RzBin *bin, const char *type, const char *file, RzList *files);
 
-RZ_API const char *rz_bin_string_type(int type);
+RZ_API RZ_OWN const char *rz_bin_string_type(int type);
 RZ_API const char *rz_bin_entry_type_string(int etype);
 
 RZ_API bool rz_bin_file_object_new_from_xtr_data(RzBin *bin, RzBinFile *bf, RzBinObjectLoadOptions *opts, RzBinXtrData *data);

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -163,6 +163,8 @@ enum {
 	RZ_STRING_TYPE_UTF8 = 'u',
 	RZ_STRING_TYPE_WIDE = 'w', // utf16 / widechar string
 	RZ_STRING_TYPE_WIDE32 = 'W', // utf32
+	RZ_STRING_TYPE_WIDE_BE = 'x', // utf16-be / widechar string
+	RZ_STRING_TYPE_WIDE32_BE = 'X', // utf32-be
 	RZ_STRING_TYPE_BASE64 = 'b',
 };
 

--- a/librz/include/rz_util.h
+++ b/librz/include/rz_util.h
@@ -61,6 +61,7 @@ int gettimeofday(struct timeval *p, void *tz);
 #include "rz_util/rz_str.h"
 #include "rz_util/rz_ascii_table.h"
 #include "rz_util/rz_strbuf.h"
+#include "rz_util/rz_str_search.h"
 #include "rz_util/rz_strpool.h"
 #include "rz_util/rz_str_constpool.h"
 #include "rz_util/rz_sys.h"

--- a/librz/include/rz_util/rz_str_search.h
+++ b/librz/include/rz_util/rz_str_search.h
@@ -1,0 +1,17 @@
+#ifndef RZ_STR_SEARCH_H
+#define RZ_STR_SEARCH_H
+
+#include <rz_bin.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+RZ_API int rz_scan_strings(RzList *list, RzBuffer *buf_to_scan,
+	const ut64 from, const ut64 to, int min_str_length, int type);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RZ_STR_SEARCH_H

--- a/librz/include/rz_util/rz_str_search.h
+++ b/librz/include/rz_util/rz_str_search.h
@@ -30,23 +30,8 @@ typedef struct {
 	size_t min_str_length; ///< Minimum string length
 } RzUtilStrScanOptions;
 
-/**
- * Free a RzDetectedString
- */
 RZ_API void rz_detected_string_free(RzDetectedString *str);
 
-/**
- * \brief Look for strings in an RzBuffer.
- * \param buf_to_scan Pointer to a RzBuffer to scan
- * \param list Pointer to a list that will be populated with the found strings
- * \param opt Pointer to a RzUtilStrScanOptions that specifies search parameters
- * \param from Minimum address to scan
- * \param to Maximum address to scan
- * \param type Type of strings to search
- * \return Number of strings found
- *
- * Used to look for strings in a give RzBuffer. The function can also automatically detect string types.
- */
 RZ_API int rz_scan_strings(RzBuffer *buf_to_scan, RzList *list, const RzUtilStrScanOptions *opt,
 	const ut64 from, const ut64 to, RzStrEnc type);
 

--- a/librz/include/rz_util/rz_str_search.h
+++ b/librz/include/rz_util/rz_str_search.h
@@ -37,9 +37,9 @@ RZ_API void rz_detected_string_free(RzDetectedString *str);
 
 /**
  * \brief Look for strings in an RzBuffer.
- * \param opt Pointer to a RzUtilStrScanOptions that specifies search parameters
- * \param list Pointer to a list that will be populated with the found strings
  * \param buf_to_scan Pointer to a RzBuffer to scan
+ * \param list Pointer to a list that will be populated with the found strings
+ * \param opt Pointer to a RzUtilStrScanOptions that specifies search parameters
  * \param from Minimum address to scan
  * \param to Maximum address to scan
  * \param type Type of strings to search
@@ -47,8 +47,8 @@ RZ_API void rz_detected_string_free(RzDetectedString *str);
  *
  * Used to look for strings in a give RzBuffer. The function can also automatically detect string types.
  */
-RZ_API int rz_scan_strings(const RzUtilStrScanOptions *opt, RzList *list,
-	RzBuffer *buf_to_scan, const ut64 from, const ut64 to, RzStrEnc type);
+RZ_API int rz_scan_strings(RzBuffer *buf_to_scan, RzList *list, const RzUtilStrScanOptions *opt,
+	const ut64 from, const ut64 to, RzStrEnc type);
 
 #ifdef __cplusplus
 }

--- a/librz/include/rz_util/rz_str_search.h
+++ b/librz/include/rz_util/rz_str_search.h
@@ -28,6 +28,7 @@ typedef struct {
 	size_t buf_size; ///< Maximum size of a detected string
 	size_t max_uni_blocks; ///< Maximum number of unicode blocks
 	size_t min_str_length; ///< Minimum string length
+	bool prefer_big_endian; //< True if the preferred endianess for UTF strings is big-endian
 } RzUtilStrScanOptions;
 
 RZ_API void rz_detected_string_free(RzDetectedString *str);

--- a/librz/include/rz_util/rz_str_search.h
+++ b/librz/include/rz_util/rz_str_search.h
@@ -1,14 +1,54 @@
 #ifndef RZ_STR_SEARCH_H
 #define RZ_STR_SEARCH_H
 
-#include <rz_bin.h>
+#include <rz_util/rz_str.h>
+#include <rz_util/rz_assert.h>
+#include <rz_util/rz_buf.h>
+#include <rz_list.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-RZ_API int rz_scan_strings(RzList *list, RzBuffer *buf_to_scan,
-	const ut64 from, const ut64 to, int min_str_length, int type);
+/**
+ * Represent a detected string.
+ */
+typedef struct {
+	char *string; ///< Pointer to the string
+	ut64 addr; ///< Address of the string in the RzBuffer
+	ut32 size; ///< Size of buffer containing the string in bytes
+	ut32 length; ///< Length of string in chars
+	RzStrEnc type; ///< String type
+} RzDetectedString;
+
+/**
+ * Defines the search parameters for rz_scan_strings
+ */
+typedef struct {
+	size_t buf_size; ///< Maximum size of a detected string
+	size_t max_uni_blocks; ///< Maximum number of unicode blocks
+	size_t min_str_length; ///< Minimum string length
+} RzUtilStrScanOptions;
+
+/**
+ * Free a RzDetectedString
+ */
+RZ_API void rz_detected_string_free(RzDetectedString *str);
+
+/**
+ * \brief Look for strings in an RzBuffer.
+ * \param opt Pointer to a RzUtilStrScanOptions that specifies search parameters
+ * \param list Pointer to a list that will be populated with the found strings
+ * \param buf_to_scan Pointer to a RzBuffer to scan
+ * \param from Minimum address to scan
+ * \param to Maximum address to scan
+ * \param type Type of strings to search
+ * \return Number of strings found
+ *
+ * Used to look for strings in a give RzBuffer. The function can also automatically detect string types.
+ */
+RZ_API int rz_scan_strings(const RzUtilStrScanOptions *opt, RzList *list,
+	RzBuffer *buf_to_scan, const ut64 from, const ut64 to, RzStrEnc type);
 
 #ifdef __cplusplus
 }

--- a/librz/include/rz_util/rz_utf32.h
+++ b/librz/include/rz_util/rz_utf32.h
@@ -6,6 +6,6 @@
 
 RZ_API int rz_utf32_decode(const ut8 *ptr, int ptrlen, RzRune *ch, bool bigendian);
 RZ_API int rz_utf32le_decode(const ut8 *ptr, int ptrlen, RzRune *ch);
-RZ_API int rz_utf32le_decode(const ut8 *ptr, int ptrlen, RzRune *ch);
+RZ_API int rz_utf32be_decode(const ut8 *ptr, int ptrlen, RzRune *ch);
 
 #endif //  RZ_UTF32_H

--- a/librz/meson.build
+++ b/librz/meson.build
@@ -414,6 +414,7 @@ rz_util_files = [
   'include/rz_util/rz_stack.h',
   'include/rz_util/rz_str.h',
   'include/rz_util/rz_str_constpool.h',
+  'include/rz_util/rz_str_search.h',
   'include/rz_util/rz_str_util.h',
   'include/rz_util/rz_strbuf.h',
   'include/rz_util/rz_strpool.h',

--- a/librz/util/meson.build
+++ b/librz/util/meson.build
@@ -50,6 +50,7 @@ rz_util_sources = [
   'stack.c',
   'str.c',
   'str_constpool.c',
+  'str_search.c',
   'str_trim.c',
   'strbuf.c',
   'strpool.c',

--- a/librz/util/str_search.c
+++ b/librz/util/str_search.c
@@ -112,7 +112,7 @@ static ut64 adjust_offset(RzStrEnc str_type, ut8 *buf, const ut64 str_start) {
 	return 0;
 }
 
-RZ_API int rz_scan_strings(const RzUtilStrScanOptions *opt, RzList *list, RzBuffer *buf_to_scan,
+RZ_API int rz_scan_strings(RzBuffer *buf_to_scan, RzList *list, const RzUtilStrScanOptions *opt,
 	const ut64 from, const ut64 to, RzStrEnc type) {
 
 	rz_return_val_if_fail(opt, -1);

--- a/librz/util/str_search.c
+++ b/librz/util/str_search.c
@@ -330,10 +330,14 @@ RZ_API int rz_scan_strings(RzBuffer *buf_to_scan, RzList *list, const RzUtilStrS
 					} else if (!ds_le) {
 						to_add = ds_be;
 						needle_offset = ds_be->size;
-					} else {
+					} else if (!opt->prefer_big_endian) {
 						to_add = ds_le;
 						to_delete = ds_be;
 						needle_offset = ds_le->size + 3;
+					} else {
+						to_add = ds_be;
+						to_delete = ds_le;
+						needle_offset = ds_le->size;
 					}
 
 					count++;
@@ -362,10 +366,14 @@ RZ_API int rz_scan_strings(RzBuffer *buf_to_scan, RzList *list, const RzUtilStrS
 					} else if (!ds_le) {
 						to_add = ds_be;
 						needle_offset = ds_be->size;
-					} else {
+					} else if (!opt->prefer_big_endian) {
 						to_add = ds_le;
 						to_delete = ds_be;
 						needle_offset = ds_le->size + 1;
+					} else {
+						to_add = ds_be;
+						to_delete = ds_le;
+						needle_offset = ds_le->size;
 					}
 
 					count++;

--- a/librz/util/str_search.c
+++ b/librz/util/str_search.c
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2021 borzacchiello <lucaborza@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include <rz_util/rz_str_search.h>
 #include <rz_util/rz_utf8.h>
 #include <rz_util/rz_utf16.h>

--- a/librz/util/str_search.c
+++ b/librz/util/str_search.c
@@ -144,6 +144,7 @@ RZ_API int rz_scan_strings(RzBuffer *buf_to_scan, RzList *list, const RzUtilStrS
 	rz_buf_read_at(buf_to_scan, from, buf, len);
 	// may oobread
 	while (needle < to) {
+		ut64 original_needle = needle;
 		bool is_wide_be_str = false;
 
 		char ch = *(buf + needle - from);
@@ -272,6 +273,7 @@ RZ_API int rz_scan_strings(RzBuffer *buf_to_scan, RzList *list, const RzUtilStrS
 		if (runes >= opt->min_str_length) {
 			FalsePositiveResult false_positive_result = reduce_false_positives(opt, tmp, i - 1, str_type);
 			if (false_positive_result == SKIP_STRING) {
+				needle = original_needle + 1;
 				continue;
 			} else if (false_positive_result == RETRY_ASCII) {
 				ascii_only = true;
@@ -293,6 +295,8 @@ RZ_API int rz_scan_strings(RzBuffer *buf_to_scan, RzList *list, const RzUtilStrS
 			ds->addr = str_start;
 			ds->string = rz_str_ndup((const char *)tmp, i);
 			rz_list_append(list, ds);
+		} else {
+			needle = original_needle + 1;
 		}
 		ascii_only = false;
 	}

--- a/librz/util/str_search.c
+++ b/librz/util/str_search.c
@@ -1,0 +1,219 @@
+#include <rz_bin.h>
+#include <rz_util/rz_assert.h>
+
+// maybe too big sometimes? 2KB of stack eaten here..
+#define RZ_STRING_SCAN_BUFFER_SIZE 2048
+#define RZ_STRING_MAX_UNI_BLOCKS   4
+
+RZ_API int rz_scan_strings(RzList *list, RzBuffer *buf_to_scan,
+	const ut64 from, const ut64 to, int min_str_length, int type) {
+
+	ut8 tmp[RZ_STRING_SCAN_BUFFER_SIZE];
+	ut64 str_start, needle = from;
+	int count = 0, i, rc, runes;
+	int str_type = RZ_STRING_TYPE_DETECT;
+
+	// list cannot be NULL
+	rz_return_val_if_fail(list, -1);
+
+	// buf_to_scan cannot be NULL
+	rz_return_val_if_fail(buf_to_scan, -1);
+
+	if (type == -1) {
+		type = RZ_STRING_TYPE_DETECT;
+	}
+	if (from == to) {
+		return 0;
+	}
+	if (from > to) {
+		eprintf("Invalid range to find strings 0x%" PFMT64x " .. 0x%" PFMT64x "\n", from, to);
+		return -1;
+	}
+	int len = to - from;
+	ut8 *buf = calloc(len, 1);
+	if (!buf || !min_str_length) {
+		free(buf);
+		return -1;
+	}
+
+	bool ascii_only = false;
+
+	rz_buf_read_at(buf_to_scan, from, buf, len);
+	// may oobread
+	while (needle < to) {
+		rc = rz_utf8_decode(buf + needle - from, to - needle, NULL);
+		if (!rc) {
+			needle++;
+			continue;
+		}
+
+		if (type == RZ_STRING_TYPE_DETECT) {
+			char *w = (char *)buf + needle + rc - from;
+			if ((to - needle) > 5 + rc) {
+				bool is_wide32 = (needle + rc + 2 < to) && (!w[0] && !w[1] && !w[2] && w[3] && !w[4]);
+				if (is_wide32) {
+					str_type = RZ_STRING_TYPE_WIDE32;
+				} else {
+					bool is_wide = needle + rc + 4 < to && !w[0] && w[1] && !w[2] && w[3] && !w[4];
+					str_type = is_wide ? RZ_STRING_TYPE_WIDE : RZ_STRING_TYPE_ASCII;
+				}
+			} else {
+				str_type = RZ_STRING_TYPE_ASCII;
+			}
+		} else if (type == RZ_STRING_TYPE_UTF8) {
+			str_type = RZ_STRING_TYPE_ASCII; // initial assumption
+		} else {
+			str_type = type;
+		}
+		runes = 0;
+		str_start = needle;
+
+		/* Eat a whole C string */
+		for (i = 0; i < sizeof(tmp) - 4 && needle < to; i += rc) {
+			RzRune r = { 0 };
+
+			if (str_type == RZ_STRING_TYPE_WIDE32) {
+				rc = rz_utf32le_decode(buf + needle - from, to - needle, &r);
+				if (rc) {
+					rc = 4;
+				}
+			} else if (str_type == RZ_STRING_TYPE_WIDE) {
+				rc = rz_utf16le_decode(buf + needle - from, to - needle, &r);
+				if (rc == 1) {
+					rc = 2;
+				}
+			} else {
+				rc = rz_utf8_decode(buf + needle - from, to - needle, &r);
+				if (rc > 1) {
+					str_type = RZ_STRING_TYPE_UTF8;
+				}
+			}
+
+			/* Invalid sequence detected */
+			if (!rc || (ascii_only && r > 0x7f)) {
+				needle++;
+				break;
+			}
+
+			needle += rc;
+
+			if (rz_isprint(r) && r != '\\') {
+				if (str_type == RZ_STRING_TYPE_WIDE32) {
+					if (r == 0xff) {
+						r = 0;
+					}
+				}
+				rc = rz_utf8_encode(tmp + i, r);
+				runes++;
+				/* Print the escape code */
+			} else if (r && r < 0x100 && strchr("\b\v\f\n\r\t\a\033\\", (char)r)) {
+				if ((i + 32) < sizeof(tmp) && r < 93) {
+					tmp[i + 0] = '\\';
+					tmp[i + 1] = "       abtnvfr             e  "
+						     "                              "
+						     "                              "
+						     "  \\"[r];
+				} else {
+					// string too long
+					break;
+				}
+				rc = 2;
+				runes++;
+			} else {
+				/* \0 marks the end of C-strings */
+				break;
+			}
+		}
+
+		tmp[i++] = '\0';
+
+		if (runes < min_str_length && runes >= 2 && str_type == RZ_STRING_TYPE_ASCII && needle < to) {
+			// back up past the \0 to the last char just in case it starts a wide string
+			needle -= 2;
+		}
+		if (runes >= min_str_length) {
+			// reduce false positives
+			int j, num_blocks, *block_list;
+			int *freq_list = NULL, expected_ascii, actual_ascii, num_chars;
+			if (str_type == RZ_STRING_TYPE_ASCII) {
+				for (j = 0; j < i; j++) {
+					char ch = tmp[j];
+					if (ch != '\n' && ch != '\r' && ch != '\t') {
+						if (!IS_PRINTABLE(tmp[j])) {
+							continue;
+						}
+					}
+				}
+			}
+			switch (str_type) {
+			case RZ_STRING_TYPE_UTF8:
+			case RZ_STRING_TYPE_WIDE:
+			case RZ_STRING_TYPE_WIDE32:
+				num_blocks = 0;
+				block_list = rz_utf_block_list((const ut8 *)tmp, i - 1,
+					str_type == RZ_STRING_TYPE_WIDE ? &freq_list : NULL);
+				if (block_list) {
+					for (j = 0; block_list[j] != -1; j++) {
+						num_blocks++;
+					}
+				}
+				if (freq_list) {
+					num_chars = 0;
+					actual_ascii = 0;
+					for (j = 0; freq_list[j] != -1; j++) {
+						num_chars += freq_list[j];
+						if (!block_list[j]) { // ASCII
+							actual_ascii = freq_list[j];
+						}
+					}
+					free(freq_list);
+					expected_ascii = num_blocks ? num_chars / num_blocks : 0;
+					if (actual_ascii > expected_ascii) {
+						ascii_only = true;
+						needle = str_start;
+						free(block_list);
+						continue;
+					}
+				}
+				free(block_list);
+				if (num_blocks > RZ_STRING_MAX_UNI_BLOCKS) {
+					continue;
+				}
+			}
+			RzBinString *bs = RZ_NEW0(RzBinString);
+			if (!bs) {
+				break;
+			}
+			bs->type = str_type;
+			bs->length = runes;
+			bs->size = needle - str_start;
+			bs->ordinal = count++;
+			// TODO: move into adjust_offset
+			switch (str_type) {
+			case RZ_STRING_TYPE_WIDE:
+				if (str_start - from > 1) {
+					const ut8 *p = buf + str_start - 2 - from;
+					if (p[0] == 0xff && p[1] == 0xfe) {
+						str_start -= 2; // \xff\xfe
+					}
+				}
+				break;
+			case RZ_STRING_TYPE_WIDE32:
+				if (str_start - from > 3) {
+					const ut8 *p = buf + str_start - 4 - from;
+					if (p[0] == 0xff && p[1] == 0xfe) {
+						str_start -= 4; // \xff\xfe\x00\x00
+					}
+				}
+				break;
+			}
+			bs->paddr = str_start;
+			bs->vaddr = str_start;
+			bs->string = rz_str_ndup((const char *)tmp, i);
+			rz_list_append(list, bs);
+		}
+		ascii_only = false;
+	}
+	free(buf);
+	return count;
+}

--- a/librz/util/str_search.c
+++ b/librz/util/str_search.c
@@ -150,9 +150,9 @@ RZ_API int rz_scan_strings(RzBuffer *buf_to_scan, RzList *list, const RzUtilStrS
 		char ch = *(buf + needle - from);
 		if (ch == 0 && type == RZ_STRING_ENC_GUESS) {
 			char *w = (char *)buf + needle + 1 - from;
-			if ((to - needle) > 5 + 1) {
-				bool is_wide32_be = !w[0] && !w[1] && w[2] && !w[3] && !w[4];
-				bool is_wide_be = w[0] && !w[1] && w[2] && !w[3] && w[4];
+			if ((to - needle) > 6 + 1) {
+				bool is_wide32_be = !w[0] && !w[1] && w[2] && !w[3] && !w[4] && !w[5];
+				bool is_wide_be = w[0] && !w[1] && w[2] && !w[3] && w[4] && !w[5];
 				if (is_wide32_be) {
 					is_wide_be_str = true;
 					str_type = RZ_STRING_ENC_UTF32BE;

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -4504,7 +4504,6 @@ wz k\0i\0abcdefgh
 (izenc enc; e bin.str.enc=$0; iz:quiet)
 .(izenc guess)
 .(izenc utf8)
-.(izenc utf16le)
 o-*
 rm .tmp/strenc-bin
 EOF
@@ -4512,7 +4511,6 @@ EXPECT=<<EOF
 0   0x000004b0 0x080484b0 12  13   .rodata ascii Hello world!
 0   0x000004b4 0x080484b4 8   9    .rodata ascii abcdefgh
 0   0x000004b4 0x080484b4 8   9    .rodata ascii abcdefgh
-0   0x000004b0 0x080484b0 6   13   .rodata utf16le ki扡摣晥桧 blocks=Basic Latin,CJK Unified Ideographs
 EOF
 RUN
 
@@ -4704,9 +4702,9 @@ RUN
 NAME=regression for #9370
 FILE=bins/elf/analysis/hello-arm32
 ARGS=-m 0x10000
-CMDS=izz~Hello
+CMDS=izz~Hello[1,2,3,4,5,6,7,8]
 EXPECT=<<EOF
-6   0x00000200 0x00010200 11  12   .rodata         ascii   Hello World
+0x00000200 0x00010200 11 12 .rodata ascii Hello World
 EOF
 RUN
 
@@ -5276,12 +5274,12 @@ RUN
 
 NAME=ascii substring detection (#14499)
 FILE=bins/pe/Reborn_Stub-strings.exe
-CMDS=izz~pomf
+CMDS=izz~pomf[1,2,3,4,5,6,7,8]
 EXPECT=<<EOF
-7154 0x00087f8a 0x00489d8a 26  53   .text   utf16le http://pomf.cat/upload.php
-7159 0x000880dd 0x00489edd 19  39   .text   utf16le https://a.pomf.cat/
-7322 0x00089bed 0x0048b9ed 26  53   .text   utf16le http://pomf.cat/upload.php
-7323 0x00089c22 0x0048ba22 19  40   .text   utf16le https://a.pomf.cat/
+0x00087f8a 0x00489d8a 26 53 .text utf16le http://pomf.cat/upload.php
+0x000880dd 0x00489edd 19 39 .text utf16le https://a.pomf.cat/
+0x00089bed 0x0048b9ed 26 53 .text utf16le http://pomf.cat/upload.php
+0x00089c22 0x0048ba22 19 40 .text utf16le https://a.pomf.cat/
 EOF
 RUN
 

--- a/test/db/formats/mdmp
+++ b/test/db/formats/mdmp
@@ -340,11 +340,49 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=mdmp 32bit - strings count
+NAME=mdmp 32bit - strings
 FILE=bins/mdmp/hello.dmp
-CMDS=iz~?
+CMDS=<<EOF
+iz~0x0043cf24[1,2,3,4,5,6,7,8]
+iz~0x0043cf2e[1,2,3,4,5,6,7,8]
+iz~0x0043cf38[1,2,3,4,5,6,7,8]
+iz~0x00447247[1,2,3,4,5,6,7,8]
+iz~0x0044726b[1,2,3,4,5,6,7,8]
+iz~0x00447291[1,2,3,4,5,6,7,8]
+iz~0x004472ac[1,2,3,4,5,6,7,8]
+iz~0x0048acc8[1,2,3,4,5,6,7,8]
+iz~0x0048b004[1,2,3,4,5,6,7,8]
+iz~0x00168c38[1,2,3,4,5,6,7,8]
+iz~0x00168f80[1,2,3,4,5,6,7,8]
+iz~0x00128c38[1,2,3,4,5,6,7,8]
+iz~0x00128fa8[1,2,3,4,5,6,7,8]
+iz~0x000cdc38[1,2,3,4,5,6,7,8]
+iz~0x000cdf84[1,2,3,4,5,6,7,8]
+iz~0x00299106[1,2,3,4,5,6,7,8]
+iz~0x001adff0[1,2,3,4,5,6,7,8]
+iz~0x0033641a[1,2,3,4,5,6,7,8]
+iz~0x00337f88[1,2,3,4,5,6,7,8]
+EOF
 EXPECT=<<EOF
-10276
+0x0043cf24 0x77820352 4 10 C:_Windows_System32__tdll.dll utf16le Alpc
+0x0043cf2e 0x7782035c 4 10 C:_Windows_System32__tdll.dll utf16le Pool
+0x0043cf38 0x77820366 5 12 C:_Windows_System32__tdll.dll utf16le Timer
+0x00447247 0x7782a675 35 36 C:_Windows_System32__tdll.dll ascii RtlFindActivationContextSectionGuid
+0x0044726b 0x7782a699 37 38 C:_Windows_System32__tdll.dll ascii RtlFindActivationContextSectionString
+0x00447291 0x7782a6bf 26 27 C:_Windows_System32__tdll.dll ascii RtlFindCharInUnicodeString
+0x004472ac 0x7782a6da 16 17 C:_Windows_System32__tdll.dll ascii RtlFindClearBits
+0x0048acc8 0x7786e0f6 15 32 C:_Windows_System32__tdll.dll utf16le VS_VERSION_INFO
+0x0048b004 0x7786e432 11 24 C:_Windows_System32__tdll.dll utf16le VarFileInfo
+0x00168c38 0x7500d066 15 32 C:_Windows_System32_wow64.dll utf16le VS_VERSION_INFO
+0x00168f80 0x7500d3ae 11 24 C:_Windows_System32_wow64.dll utf16le VarFileInfo
+0x00128c38 0x74fc9066 15 32 C:_Windows_System32_wow64win.dll utf16le VS_VERSION_INFO
+0x00128fa8 0x74fc93d6 11 24 C:_Windows_System32_wow64win.dll utf16le VarFileInfo
+0x000cdc38 0x74f66066 15 32 C:_Windows_System32_wow64cpu.dll utf16le VS_VERSION_INFO
+0x000cdf84 0x74f663b2 11 24 C:_Windows_System32_wow64cpu.dll utf16le VarFileInfo
+0x00299106 0x77087534 11 12 C:_Windows_SysWOW64_kernel32.dll ascii _vfprintf_l
+0x001adff0 0x75d9341e 11 24 C:_Windows_SysWOW64_KERNELBASE.dll utf16le VarFileInfo
+0x0033641a 0x77415848 39 40 C:_Windows_SysWOW64_msvcrt.dll ascii Assertion failed:
+0x00337f88 0x774173b6 11 24 C:_Windows_SysWOW64_msvcrt.dll utf16le VarFileInfo
 EOF
 RUN
 
@@ -469,11 +507,43 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=mdmp 64bit - strings count
+NAME=mdmp 64bit - strings
 FILE=bins/mdmp/hello64.dmp
-CMDS=iz~?
+CMDS=<<EOF
+iz~0x002e2fe1[1,2,3,4,5,6,7,8]
+iz~0x002e2feb[1,2,3,4,5,6,7,8]
+iz~0x002e2ff5[1,2,3,4,5,6,7,8]
+iz~0x00330d85[1,2,3,4,5,6,7,8]
+iz~0x003310c1[1,2,3,4,5,6,7,8]
+iz~0x00161a37[1,2,3,4,5,6,7,8]
+iz~0x00161c7f[1,2,3,4,5,6,7,8]
+iz~0x00161dbf[1,2,3,4,5,6,7,8]
+iz~0x001d9d45[1,2,3,4,5,6,7,8]
+iz~0x001da0a5[1,2,3,4,5,6,7,8]
+iz~0x003fad45[1,2,3,4,5,6,7,8]
+iz~0x003fb0ad[1,2,3,4,5,6,7,8]
+iz~0x00480857[1,2,3,4,5,6,7,8]
+iz~0x004808c7[1,2,3,4,5,6,7,8]
+iz~0x00499cf5[1,2,3,4,5,6,7,8]
+iz~0x0049a045[1,2,3,4,5,6,7,8]
+EOF
 EXPECT=<<EOF
-22900
+0x002e2fe1 0x77820352 4 10 C:_Windows_System32__tdll.dll utf16le Alpc
+0x002e2feb 0x7782035c 4 10 C:_Windows_System32__tdll.dll utf16le Pool
+0x002e2ff5 0x77820366 5 12 C:_Windows_System32__tdll.dll utf16le Timer
+0x00330d85 0x7786e0f6 15 32 C:_Windows_System32__tdll.dll utf16le VS_VERSION_INFO
+0x003310c1 0x7786e432 11 24 C:_Windows_System32__tdll.dll utf16le VarFileInfo
+0x00161a37 0x7759dda8 7 16 C:_Windows_System32_kernel32.dll utf16le win.ini
+0x00161c7f 0x7759dff0 20 42 C:_Windows_System32_kernel32.dll utf16le \Classes\Wow6432Node
+0x00161dbf 0x7759e130 45 92 C:_Windows_System32_kernel32.dll utf16le \REGISTRY\USER\*\SOFTWARE\Classes\Wow6432Node
+0x001d9d45 0x776160b6 15 32 C:_Windows_System32_kernel32.dll utf16le VS_VERSION_INFO
+0x001da0a5 0x77616416 11 24 C:_Windows_System32_kernel32.dll utf16le VarFileInfo
+0x003fad45 0x7fefd5080b6 15 32 C:_Windows_System32_KERNELBASE.dll utf16le VS_VERSION_INFO
+0x003fb0ad 0x7fefd50841e 11 24 C:_Windows_System32_KERNELBASE.dll utf16le VarFileInfo
+0x00480857 0x7fefdb33bc8 4 10 C:_Windows_System32_msvcrt.dll utf16le PATH
+0x004808c7 0x7fefdb33c38 10 22 C:_Windows_System32_msvcrt.dll utf16le SystemRoot
+0x00499cf5 0x7fefdb4d066 15 32 C:_Windows_System32_msvcrt.dll utf16le VS_VERSION_INFO
+0x0049a045 0x7fefdb4d3b6 11 24 C:_Windows_System32_msvcrt.dll utf16le VarFileInfo
 EOF
 RUN
 

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -86,6 +86,7 @@ if get_option('enable_tests')
     'stack',
     'str',
     'strbuf',
+    'str_search',
     'subprocess',
     'table',
     'task',

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -155,7 +155,7 @@ bool test_rz_scan_strings_utf16_be(void) {
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 
 	RzList *str_list = rz_list_new();
-	int n = rz_scan_strings(buf, str_list, &g_opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_UTF16BE);
+	int n = rz_scan_strings(buf, str_list, &g_opt, 16, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_UTF16BE);
 	mu_assert_eq(n, 1, "rz_scan_strings utf16be, number of strings");
 
 	RzDetectedString *s = rz_list_get_n(str_list, 0);

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -13,7 +13,7 @@ bool test_rz_scan_strings_detect_ascii(void) {
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 
 	RzList *str_list = rz_list_new();
-	int n = rz_scan_strings(&g_opt, str_list, buf, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
+	int n = rz_scan_strings(buf, str_list, &g_opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
 	mu_assert_eq(n, 1, "rz_scan_strings ascii, number of strings");
 
 	RzDetectedString *s = rz_list_get_n(str_list, 0);
@@ -32,7 +32,7 @@ bool test_rz_scan_strings_detect_utf8(void) {
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 
 	RzList *str_list = rz_list_new();
-	int n = rz_scan_strings(&g_opt, str_list, buf, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
+	int n = rz_scan_strings(buf, str_list, &g_opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
 	mu_assert_eq(n, 1, "rz_scan_strings utf8, number of strings");
 
 	RzDetectedString *s = rz_list_get_n(str_list, 0);
@@ -56,7 +56,7 @@ bool test_rz_scan_strings_detect_utf16_le(void) {
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 
 	RzList *str_list = rz_list_new();
-	int n = rz_scan_strings(&g_opt, str_list, buf, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
+	int n = rz_scan_strings(buf, str_list, &g_opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
 	mu_assert_eq(n, 1, "rz_scan_strings utf16le, number of strings");
 
 	RzDetectedString *s = rz_list_get_n(str_list, 0);
@@ -80,7 +80,7 @@ bool test_rz_scan_strings_detect_utf16_be(void) {
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 
 	RzList *str_list = rz_list_new();
-	int n = rz_scan_strings(&g_opt, str_list, buf, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
+	int n = rz_scan_strings(buf, str_list, &g_opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
 	mu_assert_eq(n, 1, "rz_scan_strings utf16be, number of strings");
 
 	RzDetectedString *s = rz_list_get_n(str_list, 0);
@@ -107,7 +107,7 @@ bool test_rz_scan_strings_detect_utf32_le(void) {
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 
 	RzList *str_list = rz_list_new();
-	int n = rz_scan_strings(&g_opt, str_list, buf, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
+	int n = rz_scan_strings(buf, str_list, &g_opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
 	mu_assert_eq(n, 1, "rz_scan_strings utf32le, number of strings");
 
 	RzDetectedString *s = rz_list_get_n(str_list, 0);
@@ -134,7 +134,7 @@ bool test_rz_scan_strings_detect_utf32_be(void) {
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 
 	RzList *str_list = rz_list_new();
-	int n = rz_scan_strings(&g_opt, str_list, buf, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
+	int n = rz_scan_strings(buf, str_list, &g_opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
 	mu_assert_eq(n, 1, "rz_scan_strings utf32be, number of strings");
 
 	RzDetectedString *s = rz_list_get_n(str_list, 0);
@@ -155,7 +155,7 @@ bool test_rz_scan_strings_utf16_be(void) {
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 
 	RzList *str_list = rz_list_new();
-	int n = rz_scan_strings(&g_opt, str_list, buf, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_UTF16BE);
+	int n = rz_scan_strings(buf, str_list, &g_opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_UTF16BE);
 	mu_assert_eq(n, 1, "rz_scan_strings utf16be, number of strings");
 
 	RzDetectedString *s = rz_list_get_n(str_list, 0);

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -1,0 +1,186 @@
+
+#include <rz_util.h>
+#include "minunit.h"
+
+static RzUtilStrScanOptions g_opt = {
+	.buf_size = 2048,
+	.max_uni_blocks = 4,
+	.min_str_length = 4
+};
+
+bool test_rz_scan_strings_detect_ascii(void) {
+	static const unsigned char str[] = "\xff\xff\xffI am an ASCII string\xff\xff";
+	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
+
+	RzList *str_list = rz_list_new();
+	int n = rz_scan_strings(&g_opt, str_list, buf, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
+	mu_assert_eq(n, 1, "rz_scan_strings ascii, number of strings");
+
+	RzDetectedString *s = rz_list_get_n(str_list, 0);
+	mu_assert_streq(s->string, "I am an ASCII string", "rz_scan_strings ascii, different string");
+	mu_assert_eq(s->addr, 3, "rz_scan_strings ascii, address");
+	mu_assert_eq(s->type, RZ_STRING_ENC_LATIN1, "rz_scan_strings ascii, string type");
+
+	rz_detected_string_free(s);
+	rz_list_free(str_list);
+
+	mu_end;
+}
+
+bool test_rz_scan_strings_detect_utf8(void) {
+	static const unsigned char str[] = "\xff\xff\xff\xffI am a \xc3\x99TF-8 string\xff\xff\xff\xff";
+	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
+
+	RzList *str_list = rz_list_new();
+	int n = rz_scan_strings(&g_opt, str_list, buf, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
+	mu_assert_eq(n, 1, "rz_scan_strings utf8, number of strings");
+
+	RzDetectedString *s = rz_list_get_n(str_list, 0);
+	mu_assert_streq(s->string, "I am a \xc3\x99TF-8 string", "rz_scan_strings utf8, different string");
+	mu_assert_eq(s->addr, 4, "rz_scan_strings utf8, address");
+	mu_assert_eq(s->type, RZ_STRING_ENC_UTF8, "rz_scan_strings utf8, string type");
+
+	rz_detected_string_free(s);
+	rz_list_free(str_list);
+
+	mu_end;
+}
+
+bool test_rz_scan_strings_detect_utf16_le(void) {
+	static const unsigned char str[] =
+		"\xff\xff\xff\x49\x00\x20\x00\x61\x00\x6d\x00\x20\x00\x61"
+		"\x00\x20\x00\x55\x00\x54\x00\x46\x00\x2d\x00\x31\x00\x36"
+		"\x00\x6c\x00\x65\x00\x20\x00\x73\x00\x74\x00\x72\x00\x69"
+		"\x00\x6e\x00\x67\x00\x00\xff\xff";
+
+	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
+
+	RzList *str_list = rz_list_new();
+	int n = rz_scan_strings(&g_opt, str_list, buf, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
+	mu_assert_eq(n, 1, "rz_scan_strings utf16le, number of strings");
+
+	RzDetectedString *s = rz_list_get_n(str_list, 0);
+	mu_assert_streq(s->string, "I am a UTF-16le string", "rz_scan_strings utf16le, different string");
+	mu_assert_eq(s->addr, 3, "rz_scan_strings utf16le, address");
+	mu_assert_eq(s->type, RZ_STRING_ENC_UTF16LE, "rz_scan_strings utf16le, string type");
+
+	rz_detected_string_free(s);
+	rz_list_free(str_list);
+
+	mu_end;
+}
+
+bool test_rz_scan_strings_detect_utf16_be(void) {
+	static const unsigned char str[] =
+		"\xff\xff\xff\x00\x49\x00\x20\x00\x61\x00\x6d\x00\x20\x00\x61"
+		"\x00\x20\x00\x55\x00\x54\x00\x46\x00\x2d\x00\x31\x00\x36\x00"
+		"\x62\x00\x65\x00\x20\x00\x73\x00\x74\x00\x72\x00\x69\x00\x6e"
+		"\x00\x67\xff\xff\xff\xff";
+
+	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
+
+	RzList *str_list = rz_list_new();
+	int n = rz_scan_strings(&g_opt, str_list, buf, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
+	mu_assert_eq(n, 1, "rz_scan_strings utf16be, number of strings");
+
+	RzDetectedString *s = rz_list_get_n(str_list, 0);
+	mu_assert_streq(s->string, "I am a UTF-16be string", "rz_scan_strings utf16be, different string");
+	mu_assert_eq(s->addr, 3, "rz_scan_strings utf16be, address");
+	mu_assert_eq(s->type, RZ_STRING_ENC_UTF16BE, "rz_scan_strings utf16be, string type");
+
+	rz_detected_string_free(s);
+	rz_list_free(str_list);
+
+	mu_end;
+}
+
+bool test_rz_scan_strings_detect_utf32_le(void) {
+	static const unsigned char str[] =
+		"\xff\xff\x49\x00\x00\x00\x20\x00\x00\x00\x61\x00\x00\x00\x6d"
+		"\x00\x00\x00\x20\x00\x00\x00\x61\x00\x00\x00\x20\x00\x00\x00"
+		"\x55\x00\x00\x00\x54\x00\x00\x00\x46\x00\x00\x00\x2d\x00\x00"
+		"\x00\x33\x00\x00\x00\x32\x00\x00\x00\x6c\x00\x00\x00\x65\x00"
+		"\x00\x00\x20\x00\x00\x00\x73\x00\x00\x00\x74\x00\x00\x00\x72"
+		"\x00\x00\x00\x69\x00\x00\x00\x6e\x00\x00\x00\x67\x00\x00\x00"
+		"\xff\xff\xff\xff\xff\xff\xff\xff";
+
+	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
+
+	RzList *str_list = rz_list_new();
+	int n = rz_scan_strings(&g_opt, str_list, buf, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
+	mu_assert_eq(n, 1, "rz_scan_strings utf32le, number of strings");
+
+	RzDetectedString *s = rz_list_get_n(str_list, 0);
+	mu_assert_streq(s->string, "I am a UTF-32le string", "rz_scan_strings utf32le, different string");
+	mu_assert_eq(s->addr, 2, "rz_scan_strings utf32le, address");
+	mu_assert_eq(s->type, RZ_STRING_ENC_UTF32LE, "rz_scan_strings utf32le, string type");
+
+	rz_detected_string_free(s);
+	rz_list_free(str_list);
+
+	mu_end;
+}
+
+bool test_rz_scan_strings_detect_utf32_be(void) {
+	static const unsigned char str[] =
+		"\xff\xff\x00\x00\x00\x49\x00\x00\x00\x20\x00\x00\x00\x61\x00"
+		"\x00\x00\x6d\x00\x00\x00\x20\x00\x00\x00\x61\x00\x00\x00\x20"
+		"\x00\x00\x00\x55\x00\x00\x00\x54\x00\x00\x00\x46\x00\x00\x00"
+		"\x2d\x00\x00\x00\x33\x00\x00\x00\x32\x00\x00\x00\x62\x00\x00"
+		"\x00\x65\x00\x00\x00\x20\x00\x00\x00\x73\x00\x00\x00\x74\x00"
+		"\x00\x00\x72\x00\x00\x00\x69\x00\x00\x00\x6e\x00\x00\x00\x67"
+		"\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff";
+
+	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
+
+	RzList *str_list = rz_list_new();
+	int n = rz_scan_strings(&g_opt, str_list, buf, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
+	mu_assert_eq(n, 1, "rz_scan_strings utf32be, number of strings");
+
+	RzDetectedString *s = rz_list_get_n(str_list, 0);
+	mu_assert_streq(s->string, "I am a UTF-32be string", "rz_scan_strings utf32be, different string");
+	mu_assert_eq(s->addr, 2, "rz_scan_strings utf32be, address");
+	mu_assert_eq(s->type, RZ_STRING_ENC_UTF32BE, "rz_scan_strings utf32be, string type");
+
+	rz_detected_string_free(s);
+	rz_list_free(str_list);
+
+	mu_end;
+}
+
+bool test_rz_scan_strings_utf16_be(void) {
+	static const unsigned char str[] =
+		"\xff\xfftorre, alfiere\xff\xff\x04\x41\x04\x3b\x04\x3e\x04\x3d\x00\x2c\x00\x20\x04\x3b\x04\x30\x04\x34\x04\x4c\x04\x4f";
+
+	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
+
+	RzList *str_list = rz_list_new();
+	int n = rz_scan_strings(&g_opt, str_list, buf, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_UTF16BE);
+	mu_assert_eq(n, 1, "rz_scan_strings utf16be, number of strings");
+
+	RzDetectedString *s = rz_list_get_n(str_list, 0);
+
+	mu_assert_streq(s->string, "\xd1\x81\xd0\xbb\xd0\xbe\xd0\xbd\x2c\x20\xd0\xbb\xd0\xb0\xd0\xb4\xd1\x8c\xd1\x8f",
+		"rz_scan_strings utf16be, different string");
+	mu_assert_eq(s->addr, 18, "rz_scan_strings utf16be, address");
+	mu_assert_eq(s->type, RZ_STRING_ENC_UTF16BE, "rz_scan_strings utf16be, string type");
+
+	rz_detected_string_free(s);
+	rz_list_free(str_list);
+
+	mu_end;
+}
+
+bool all_tests() {
+	mu_run_test(test_rz_scan_strings_detect_ascii);
+	mu_run_test(test_rz_scan_strings_detect_utf8);
+	mu_run_test(test_rz_scan_strings_detect_utf16_le);
+	mu_run_test(test_rz_scan_strings_detect_utf16_be);
+	mu_run_test(test_rz_scan_strings_detect_utf32_le);
+	mu_run_test(test_rz_scan_strings_detect_utf32_be);
+
+	mu_run_test(test_rz_scan_strings_utf16_be);
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests)

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -1,4 +1,7 @@
 
+// SPDX-FileCopyrightText: 2021 borzacchiello <lucaborza@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include <rz_util.h>
 #include "minunit.h"
 

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -1,4 +1,3 @@
-
 // SPDX-FileCopyrightText: 2021 borzacchiello <lucaborza@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -150,7 +150,7 @@ bool test_rz_scan_strings_detect_utf32_be(void) {
 
 bool test_rz_scan_strings_utf16_be(void) {
 	static const unsigned char str[] =
-		"\xff\xfftorre, alfiere\xff\xff\x04\x41\x04\x3b\x04\x3e\x04\x3d\x00\x2c\x00\x20\x04\x3b\x04\x30\x04\x34\x04\x4c\x04\x4f";
+		"\xff\xfftorre, alfiere\xff\x00\x04\x41\x04\x3b\x04\x3e\x04\x3d\x00\x2c\x00\x20\x04\x3b\x04\x30\x04\x34\x04\x4c\x04\x4f";
 
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 
@@ -160,9 +160,9 @@ bool test_rz_scan_strings_utf16_be(void) {
 
 	RzDetectedString *s = rz_list_get_n(str_list, 0);
 
+	mu_assert_eq(s->addr, 18, "rz_scan_strings utf16be, address");
 	mu_assert_streq(s->string, "\xd1\x81\xd0\xbb\xd0\xbe\xd0\xbd\x2c\x20\xd0\xbb\xd0\xb0\xd0\xb4\xd1\x8c\xd1\x8f",
 		"rz_scan_strings utf16be, different string");
-	mu_assert_eq(s->addr, 18, "rz_scan_strings utf16be, address");
 	mu_assert_eq(s->type, RZ_STRING_ENC_UTF16BE, "rz_scan_strings utf16be, string type");
 
 	rz_detected_string_free(s);

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -178,9 +178,9 @@ bool all_tests() {
 	mu_run_test(test_rz_scan_strings_detect_ascii);
 	mu_run_test(test_rz_scan_strings_detect_utf8);
 	mu_run_test(test_rz_scan_strings_detect_utf16_le);
-	mu_run_test(test_rz_scan_strings_detect_utf16_be);
+	// mu_run_test(test_rz_scan_strings_detect_utf16_be);
 	mu_run_test(test_rz_scan_strings_detect_utf32_le);
-	mu_run_test(test_rz_scan_strings_detect_utf32_be);
+	// mu_run_test(test_rz_scan_strings_detect_utf32_be);
 
 	mu_run_test(test_rz_scan_strings_utf16_be);
 	return tests_passed != tests_run;

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -7,7 +7,8 @@
 static RzUtilStrScanOptions g_opt = {
 	.buf_size = 2048,
 	.max_uni_blocks = 4,
-	.min_str_length = 4
+	.min_str_length = 4,
+	.prefer_big_endian = false
 };
 
 bool test_rz_scan_strings_detect_ascii(void) {
@@ -58,6 +59,8 @@ bool test_rz_scan_strings_detect_utf16_le(void) {
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 
 	RzList *str_list = rz_list_new();
+
+	g_opt.prefer_big_endian = false;
 	int n = rz_scan_strings(buf, str_list, &g_opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
 	mu_assert_eq(n, 1, "rz_scan_strings utf16le, number of strings");
 
@@ -82,6 +85,8 @@ bool test_rz_scan_strings_detect_utf16_be(void) {
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 
 	RzList *str_list = rz_list_new();
+
+	g_opt.prefer_big_endian = true;
 	int n = rz_scan_strings(buf, str_list, &g_opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
 	mu_assert_eq(n, 1, "rz_scan_strings utf16be, number of strings");
 
@@ -109,6 +114,8 @@ bool test_rz_scan_strings_detect_utf32_le(void) {
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 
 	RzList *str_list = rz_list_new();
+
+	g_opt.prefer_big_endian = false;
 	int n = rz_scan_strings(buf, str_list, &g_opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
 	mu_assert_eq(n, 1, "rz_scan_strings utf32le, number of strings");
 
@@ -136,6 +143,8 @@ bool test_rz_scan_strings_detect_utf32_be(void) {
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 
 	RzList *str_list = rz_list_new();
+
+	g_opt.prefer_big_endian = true;
 	int n = rz_scan_strings(buf, str_list, &g_opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_GUESS);
 	mu_assert_eq(n, 1, "rz_scan_strings utf32be, number of strings");
 
@@ -157,6 +166,8 @@ bool test_rz_scan_strings_utf16_be(void) {
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 
 	RzList *str_list = rz_list_new();
+
+	g_opt.prefer_big_endian = true;
 	int n = rz_scan_strings(buf, str_list, &g_opt, 16, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_UTF16BE);
 	mu_assert_eq(n, 1, "rz_scan_strings utf16be, number of strings");
 
@@ -177,9 +188,9 @@ bool all_tests() {
 	mu_run_test(test_rz_scan_strings_detect_ascii);
 	mu_run_test(test_rz_scan_strings_detect_utf8);
 	mu_run_test(test_rz_scan_strings_detect_utf16_le);
-	// mu_run_test(test_rz_scan_strings_detect_utf16_be);
+	mu_run_test(test_rz_scan_strings_detect_utf16_be);
 	mu_run_test(test_rz_scan_strings_detect_utf32_le);
-	// mu_run_test(test_rz_scan_strings_detect_utf32_be);
+	mu_run_test(test_rz_scan_strings_detect_utf32_be);
 
 	mu_run_test(test_rz_scan_strings_utf16_be);
 	return tests_passed != tests_run;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

Hi! I'm trying to become more comfortable with the code trying to solve some issues. I'm sorry if I'm doing something wrong!

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This PR:
-  refactor `string_scan_range` of `librz/bin/bfile.c` by moving the string searching logic  to the file `librz/util/str_search.c` (as suggested in #1052).
- adds support for the detection of UTF-16 BE and UTF-32 BE strings.

---

The introduced public API due to refactoring is the following:
```C
RZ_API int rz_scan_strings(RzList *list, RzBuffer *buf_to_scan,
	const ut64 from, const ut64 to, int min_str_length, int type);
```
it looks for strings in the `RzBuffer buf_to_scan`, filling the `RzList list`.
`string_scan_range` now uses this API. Unfortunately, it is possibly slower than the previous version, since it always allocates a list that is passed to `rz_scan_strings`. Ofc I can revert these modifications.

---

`UTF-16 BE` and `UTF-32 BE` detection heuristic should be very similar to the one for `UTF-16 LE` and `UTF-32 LE`. It simply checks the following pattern for the first 6 bytes of the string:
UTF-32 BE: 00 00 00 _XX_ 00 00
UTF-16 BE: 00 _XX_ 00 _XX_ 00 _XX_ 

where _XX_ is a byte != 0

---
I did not add (yet) big-endian strings [here](https://github.com/rizinorg/rizin/blob/413c8e2ad789e863fda2a9825680868c4f37ec74/librz/util/str_search.c#L187) since I am not sure that `rz_utf_block_list` would work with big-endian UTF strings.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

I did not add any tests yet. I'm just using [this file](https://github.com/rizinorg/rizin/files/7060773/encodings.zip) to perform some preliminary tests, running:
`rz-bin -zz /path/to/encodings`

output before this commit:
```
[Strings]
nth paddr      vaddr      len size section type    string
―――――――――――――――――――――――――――――――――――――――――――――――――――――――――
0   0x00000000 0x00000000 20  21           ascii   i am an ascii string
1   0x00000020 0x00000020 19  21           utf8    i am a ÙTF-8 string blocks=Basic Latin,Latin-1 Supplement
2   0x00000040 0x00000040 22  46           utf16le i am a UTF-16le string
3   0x00000071 0x00000071 21  43           utf16le i am a UTF-16be strin
4   0x000000a0 0x000000a0 22  92           utf32le i am a UTF-32le string
5   0x00000103 0x00000103 21  88           utf32le i am a UTF-32be strin
```

output after this commit:
```
[Strings]
nth paddr      vaddr      len size section type    string                                                    
―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
0   0x00000000 0x00000000 20  21           ascii   i am an ascii string
1   0x00000020 0x00000020 19  21           utf8    i am a ÙTF-8 string blocks=Basic Latin,Latin-1 Supplement
2   0x00000040 0x00000040 22  46           utf16le i am a UTF-16le string
3   0x00000070 0x00000070 22  46           utf16be i am a UTF-16be string
4   0x000000a0 0x000000a0 22  92           utf32le i am a UTF-32le string
5   0x00000100 0x00000100 22  92           utf32be i am a UTF-32be string
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #1052
