### PR TITLE
Convert `rz_core_cmd*()` calls to API in vmenus

### DIFF
--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -6528,21 +6528,7 @@ static void cmd_analysis_hint(RzCore *core, const char *input) {
 		}
 		if (input[1] == ' ') {
 			// You can either specify immbase with letters, or numbers
-			int base;
-			if (rz_str_startswith(input + 2, "10u") || rz_str_startswith(input + 2, "du")) {
-				base = 11;
-			} else {
-				base = (input[2] == 's') ? 1 : (input[2] == 'b') ? 2
-					: (input[2] == 'p')                      ? 3
-					: (input[2] == 'o')                      ? 8
-					: (input[2] == 'd')                      ? 10
-					: (input[2] == 'h')                      ? 16
-					: (input[2] == 'i')                      ? 32
-										 : // ip address
-                                        (input[2] == 'S') ? 80
-									       : // syscall
-                                        (int)rz_num_math(core->num, input + 1);
-			}
+			int base = rz_num_base_of_string(core->num, input + 2);
 			rz_analysis_hint_set_immbase(core->analysis, core->offset, base);
 		} else if (input[1] != '?' && input[1] != '-') {
 			eprintf("|ERROR| Usage: ahi <base>\n");

--- a/librz/core/vmenus.c
+++ b/librz/core/vmenus.c
@@ -1749,10 +1749,8 @@ RZ_API int rz_core_visual_trackflags(RzCore *core) {
 				if (rz_cons_fgets(line, sizeof(line), 0, NULL) < 0) {
 					cmd[0] = '\0';
 				}
-				int res = snprintf(cmd, sizeof(cmd), "afr %s %s", line, fs2);
-				if (res < sizeof(cmd)) {
-					rz_core_cmd(core, cmd, 0);
-				}
+				ut64 addr = rz_num_math(core->num, line);
+				rz_core_analysis_function_add(core, fs2, addr, true);
 				rz_cons_set_raw(1);
 				rz_cons_show_cursor(false);
 			}
@@ -1769,8 +1767,8 @@ RZ_API int rz_core_visual_trackflags(RzCore *core) {
 		case '\r':
 		case '\n':
 			if (menu == 1) {
-				sprintf(cmd, "s %s", fs2);
-				rz_core_cmd(core, cmd, 0);
+				ut64 addr = rz_num_math(core->num, fs2);
+				rz_core_seek_and_save(core, addr, true);
 				return true;
 			}
 			rz_flag_space_set(core->flags, fs);
@@ -3116,7 +3114,8 @@ onemoretime:
 		rz_cons_show_cursor(true);
 		rz_line_set_prompt("immbase: ");
 		if (rz_cons_fgets(str, sizeof(str), 0, NULL) > 0) {
-			rz_core_cmdf(core, "ahi %s @ 0x%" PFMT64x, str, off);
+			int base = rz_num_base_of_string(core->num, str);
+			rz_analysis_hint_set_immbase(core->analysis, off, base);
 		}
 	} break;
 	case 'I': {

--- a/librz/include/rz_util/rz_num.h
+++ b/librz/include/rz_util/rz_num.h
@@ -97,6 +97,7 @@ RZ_API int rz_num_str_len(const char *str);
 RZ_API int rz_num_str_split(char *str);
 RZ_API RzList *rz_num_str_split_list(char *str);
 RZ_API void *rz_num_dup(ut64 n);
+RZ_API size_t rz_num_base_of_string(RNum *num, RZ_NONNULL const char *str);
 RZ_API double rz_num_cos(double a);
 RZ_API double rz_num_sin(double a);
 RZ_API double rz_num_get_float(RNum *num, const char *str);

--- a/librz/util/unum.c
+++ b/librz/util/unum.c
@@ -913,3 +913,49 @@ RZ_API double rz_num_cos(double a) {
 RZ_API double rz_num_sin(double a) {
 	return sin(a);
 }
+
+/**
+ * \brief Convert the base suffix to the numeric value
+ */
+RZ_API size_t rz_num_base_of_string(RNum *num, RZ_NONNULL const char *str) {
+	rz_return_val_if_fail(num && str, 10);
+	size_t base = 10;
+	if (rz_str_startswith(str, "10u") || rz_str_startswith(str, "du")) {
+		base = 11;
+	} else {
+		switch (str[0]) {
+		case 's':
+			base = 1;
+			break;
+		case 'b':
+			base = 2;
+			break;
+		case 'p':
+			base = 3;
+			break;
+		case 'o':
+			base = 8;
+			break;
+		case 'd':
+			base = 10;
+			break;
+		case 'h':
+			base = 16;
+			break;
+		case 'i':
+			base = 32;
+			break;
+		case 'q':
+			base = 64;
+			break;
+		case 'S':
+			// IPv4 address
+			base = 80;
+			break;
+		default:
+			// syscall
+			base = rz_num_math(num, str);
+		}
+	}
+	return base;
+}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Move number base parsing from `cmd_analysis.c` to RzNum, switch to use the API directly instead of the `s`, `afr`, and `ahi` commands.

**Test plan**

CI is green

**Closing issues**

Partially address https://github.com/rizinorg/rizin/issues/491