### PR TITLE
RzCons: add rz_cons_get_buffer_dup helper API

### DIFF
--- a/librz/cons/cons.c
+++ b/librz/cons/cons.c
@@ -777,9 +777,20 @@ RZ_API void rz_cons_reset(void) {
 	CTX(pageable) = true;
 }
 
+/**
+ * \brief Return the current RzCons buffer
+ */
 RZ_API const char *rz_cons_get_buffer(void) {
 	//check len otherwise it will return trash
 	return I.context->buffer_len ? I.context->buffer : NULL;
+}
+
+/**
+ * \brief Return a newly allocated buffer containing what's currently in RzCons buffer
+ */
+RZ_API char *rz_cons_get_buffer_dup(void) {
+	const char *s = rz_cons_get_buffer();
+	return s ? strdup(s) : NULL;
 }
 
 RZ_API int rz_cons_get_buffer_len(void) {

--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -4059,7 +4059,7 @@ static char *get_graph_string(RzCore *core, RzAGraph *g) {
 	rz_config_set_i(core->config, "scr.color", 0);
 	rz_config_set_i(core->config, "scr.utf8", 0);
 	rz_core_visual_graph(core, g, NULL, false);
-	char *s = strdup(rz_cons_get_buffer());
+	char *s = rz_cons_get_buffer_dup();
 	rz_cons_reset();
 	rz_config_set_i(core->config, "scr.color", c);
 	rz_config_set_i(core->config, "scr.utf8", u);

--- a/librz/core/cmd.c
+++ b/librz/core/cmd.c
@@ -3765,10 +3765,7 @@ RZ_API int rz_core_cmd_foreach(RzCore *core, const char *cmd, char *each) {
 					rz_core_seek(core, fcn->addr, true);
 					rz_cons_push();
 					rz_core_cmd(core, cmd, 0);
-					buf = (char *)rz_cons_get_buffer();
-					if (buf) {
-						buf = strdup(buf);
-					}
+					buf = rz_cons_get_buffer_dup();
 					rz_cons_pop();
 					rz_cons_strcat(buf);
 					free(buf);
@@ -3961,12 +3958,10 @@ RZ_API int rz_core_cmd_foreach(RzCore *core, const char *cmd, char *each) {
 					}
 
 					char *buf = NULL;
-					const char *tmp = NULL;
 					rz_core_seek(core, flag->offset, true);
 					rz_cons_push();
 					rz_core_cmd(core, cmd, 0);
-					tmp = rz_cons_get_buffer();
-					buf = tmp ? strdup(tmp) : NULL;
+					buf = rz_cons_get_buffer_dup();
 					rz_cons_pop();
 					rz_cons_strcat(buf);
 					free(buf);

--- a/librz/core/cmd_api.c
+++ b/librz/core/cmd_api.c
@@ -1146,14 +1146,16 @@ static char *oldinput_get_help(RzCmd *cmd, RzCmdDesc *cd, RzCmdParsedArgs *a) {
 		return NULL;
 	}
 
-	const char *s = NULL;
+	char *res = NULL;
 	rz_cons_push();
 	RzCmdStatus status = rz_cmd_call_parsed_args(cmd, a);
 	if (status == RZ_CMD_STATUS_OK) {
 		rz_cons_filter();
-		s = rz_cons_get_buffer();
+		res = rz_cons_get_buffer_dup();
 	}
-	char *res = strdup(s ? s : "");
+	if (!res) {
+		res = strdup("");
+	}
 	rz_cons_pop();
 	return res;
 }

--- a/librz/debug/p/debug_io.c
+++ b/librz/debug/p/debug_io.c
@@ -80,12 +80,12 @@ static char *__io_reg_profile(RzDebug *dbg) {
 	if (drp) {
 		return drp;
 	}
-	const char *buf = rz_cons_get_buffer();
-	if (buf && *buf) {
-		char *ret = strdup(buf);
+	char *buf = rz_cons_get_buffer_dup();
+	if (RZ_STR_ISNOTEMPTY(buf)) {
 		rz_cons_pop();
-		return ret;
+		return buf;
 	}
+	free(buf);
 	rz_cons_pop();
 	return rz_analysis_get_reg_profile(dbg->analysis);
 }
@@ -94,12 +94,13 @@ static char *__io_reg_profile(RzDebug *dbg) {
 static int __reg_read(RzDebug *dbg, int type, ut8 *buf, int size) {
 	char *dr8 = dbg->iob.system(dbg->iob.io, "dr8");
 	if (!dr8) {
-		const char *fb = rz_cons_get_buffer();
-		if (!fb || !*fb) {
+		char *fb = rz_cons_get_buffer_dup();
+		if (RZ_STR_ISEMPTY(fb)) {
+			free(fb);
 			eprintf("debug.io: Failed to get dr8 from io\n");
 			return -1;
 		}
-		dr8 = strdup(fb);
+		dr8 = fb;
 		rz_cons_reset();
 	}
 	ut8 *bregs = calloc(1, strlen(dr8));

--- a/librz/include/rz_cons.h
+++ b/librz/include/rz_cons.h
@@ -975,6 +975,7 @@ RZ_API char *rz_cons_hud_string(const char *s);
 RZ_API char *rz_cons_hud_file(const char *f);
 
 RZ_API const char *rz_cons_get_buffer(void);
+RZ_API RZ_OWN char *rz_cons_get_buffer_dup(void);
 RZ_API int rz_cons_get_buffer_len(void);
 RZ_API void rz_cons_grep_help(void);
 RZ_API void rz_cons_grep_parsecmd(char *cmd, const char *quotestr);

--- a/test/unit/test_annotated_code.c
+++ b/test/unit/test_annotated_code.c
@@ -301,7 +301,7 @@ static bool test_rz_core_annotated_code_print_json(void) {
 	rz_cons_new();
 	rz_cons_push();
 	rz_core_annotated_code_print_json(code);
-	actual = strdup(rz_cons_get_buffer());
+	actual = rz_cons_get_buffer_dup();
 	rz_cons_pop();
 	mu_assert_streq(actual, expected, "pdgj OUTPUT DOES NOT MATCH");
 
@@ -320,7 +320,7 @@ static bool test_rz_core_annotated_code_print_json_context_annotations(void) {
 	rz_cons_new();
 	rz_cons_push();
 	rz_core_annotated_code_print_json(code);
-	char *actual = strdup(rz_cons_get_buffer());
+	char *actual = rz_cons_get_buffer_dup();
 	rz_cons_pop();
 	mu_assert_streq(actual, expected, "rz_core_annotated_code_print_json() output doesn't match with the expected output");
 	free(actual);
@@ -341,7 +341,7 @@ static bool test_rz_core_annotated_code_print(void) {
 	rz_cons_new();
 	rz_cons_push();
 	rz_core_annotated_code_print(code, NULL);
-	actual = strdup(rz_cons_get_buffer());
+	actual = rz_cons_get_buffer_dup();
 	rz_cons_pop();
 	mu_assert_streq(actual, expected_first, "pdg OUTPUT DOES NOT MATCH");
 	rz_cons_pop();
@@ -356,7 +356,7 @@ static bool test_rz_core_annotated_code_print(void) {
 				"                  |}\n";
 	rz_core_annotated_code_print(code, offsets);
 	free(actual);
-	actual = strdup(rz_cons_get_buffer());
+	actual = rz_cons_get_buffer_dup();
 	rz_cons_pop();
 	mu_assert_streq(actual, expected_second, "pdgo OUTPUT DOES NOT MATCH");
 	rz_cons_pop();
@@ -376,7 +376,7 @@ static bool test_rz_core_annotated_code_print_comment_cmds(void) {
 	rz_cons_new();
 	rz_cons_push();
 	rz_core_annotated_code_print_comment_cmds(code);
-	actual = strdup(rz_cons_get_buffer());
+	actual = rz_cons_get_buffer_dup();
 	rz_cons_pop();
 	mu_assert_streq(actual, expected, "pdg* OUTPUT DOES NOT MATCH");
 

--- a/test/unit/test_core_task.c
+++ b/test/unit/test_core_task.c
@@ -11,7 +11,7 @@ static void *my_function(RzCore *core, void *user) {
 		rz_cons_printf("%u, %d\n", (unsigned int)val, i);
 		rz_core_task_yield(&core->tasks);
 	}
-	return strdup(rz_cons_get_buffer());
+	return rz_cons_get_buffer_dup();
 }
 
 static bool test_core_task(void) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Provide helper function to avoid doing the usual get_buffer + strdup.