### PR TITLE
RzCmd: add some helper APIs for RzCmdStateOutput

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -426,8 +426,10 @@ static bool cb_asmcpu(void *user, void *data) {
 		update_asmcpu_options(core, node);
 		/* print verbose help instead of plain option listing */
 		RzCmdStateOutput state = { 0 };
-		state.mode = RZ_OUTPUT_MODE_STANDARD;
+		rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_STANDARD);
 		rz_core_asm_plugins_print(core, rz_config_get(core->config, "asm.arch"), &state);
+		rz_cmd_state_output_print(&state);
+		rz_cmd_state_output_fini(&state);
 		return 0;
 	}
 	rz_asm_set_cpu(core->rasm, node->value);
@@ -492,8 +494,10 @@ static bool cb_asmarch(void *user, void *data) {
 		if (strlen(node->value) > 1 && node->value[1] == '?') {
 			/* print more verbose help instead of plain option values */
 			RzCmdStateOutput state = { 0 };
-			state.mode = RZ_OUTPUT_MODE_STANDARD;
+			rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_STANDARD);
 			rz_core_asm_plugins_print(core, NULL, &state);
+			rz_cmd_state_output_print(&state);
+			rz_cmd_state_output_fini(&state);
 			return false;
 		} else {
 			print_node_options(node);
@@ -1470,9 +1474,11 @@ static bool cb_dbgbackend(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
 	RzCmdStateOutput state = { 0 };
-	state.mode = RZ_OUTPUT_MODE_QUIET;
+	rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_QUIET);
 	if (!strcmp(node->value, "?")) {
 		rz_core_debug_plugins_print(core, &state);
+		rz_cmd_state_output_print(&state);
+		rz_cmd_state_output_fini(&state);
 		return false;
 	}
 	if (!strcmp(node->value, "bf")) {

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -8748,14 +8748,12 @@ RZ_IPI int rz_cmd_analysis(void *data, const char *input) {
 				break;
 			}
 			RzCmdStateOutput state = { 0 };
-			state.mode = RZ_OUTPUT_MODE_JSON;
-			state.d.pj = pj_new();
-			if (!state.d.pj) {
+			if (!rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_JSON)) {
 				break;
 			}
 			rz_core_analysis_bb_info_print(core, bb, addr, &state);
-			rz_cons_println(pj_string(state.d.pj));
-			pj_free(state.d.pj);
+			rz_cmd_state_output_print(&state);
+			rz_cmd_state_output_fini(&state);
 			break;
 		}
 		case 0:
@@ -8771,8 +8769,12 @@ RZ_IPI int rz_cmd_analysis(void *data, const char *input) {
 				break;
 			}
 			RzCmdStateOutput state = { 0 };
-			state.mode = RZ_OUTPUT_MODE_LONG;
+			if (!rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_LONG)) {
+				break;
+			}
 			rz_core_analysis_bb_info_print(core, bb, addr, &state);
+			rz_cmd_state_output_print(&state);
+			rz_cmd_state_output_fini(&state);
 			break;
 		}
 		default:
@@ -8792,32 +8794,20 @@ RZ_IPI int rz_cmd_analysis(void *data, const char *input) {
 	case 'L': { // aL
 		RzCmdStateOutput state = { 0 };
 		switch (input[1]) {
-		case 'j': {
-			state.mode = RZ_OUTPUT_MODE_JSON;
-			state.d.pj = pj_new();
+		case 'j':
+			rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_JSON);
 			break;
-		}
-		case 'q': {
-			state.mode = RZ_OUTPUT_MODE_QUIET;
+		case 'q':
+			rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_JSON);
 			break;
-		}
-		default: {
-			state.mode = RZ_OUTPUT_MODE_STANDARD;
+		default:
+			rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_STANDARD);
 			break;
-		}
 		}
 		rz_core_asm_plugins_print(core, NULL, &state);
-		switch (state.mode) {
-		case RZ_OUTPUT_MODE_JSON: {
-			rz_cons_println(pj_string(state.d.pj));
-			rz_cons_flush();
-			pj_free(state.d.pj);
-			break;
-		}
-		default: {
-			break;
-		}
-		}
+		rz_cmd_state_output_print(&state);
+		rz_cmd_state_output_fini(&state);
+		rz_cons_flush();
 		break;
 	}
 	case 'o': cmd_analysis_opcode(core, input + 1); break; // "ao"

--- a/librz/core/cmd_hash.c
+++ b/librz/core/cmd_hash.c
@@ -45,7 +45,7 @@ static int cmd_hash_bang(RzCore *core, const char *input) {
 	int ac;
 	char **av = rz_str_argv(input + 1, &ac);
 	RzCmdStateOutput state = { 0 };
-	state.mode = RZ_OUTPUT_MODE_STANDARD;
+	rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_STANDARD);
 	if (ac > 0) {
 		RzLangPlugin *p = rz_lang_get_by_name(core->lang, av[0]);
 		if (p) {
@@ -77,6 +77,8 @@ static int cmd_hash_bang(RzCore *core, const char *input) {
 	} else {
 		rz_core_lang_plugins_print(core->lang, &state);
 	}
+	rz_cmd_state_output_print(&state);
+	rz_cmd_state_output_fini(&state);
 	rz_str_argv_free(av);
 	return true;
 }
@@ -106,10 +108,12 @@ RZ_IPI int rz_cmd_hash(void *data, const char *input) {
 }
 
 RZ_IPI RzCmdStatus rz_hash_bang_handler(RzCore *core, int argc, const char **argv) {
-	RzCmdStateOutput state = { 0 };
-	state.mode = RZ_OUTPUT_MODE_STANDARD;
 	if (argc == 1) {
+		RzCmdStateOutput state = { 0 };
+		rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_STANDARD);
 		rz_core_lang_plugins_print(core->lang, &state);
+		rz_cmd_state_output_print(&state);
+		rz_cmd_state_output_fini(&state);
 	} else {
 		RzLangPlugin *p = rz_lang_get_by_name(core->lang, argv[1]);
 		if (!p) {

--- a/librz/core/cmd_info.c
+++ b/librz/core/cmd_info.c
@@ -763,19 +763,15 @@ RZ_IPI int rz_cmd_info(void *data, const char *input) {
 			RzCmdStateOutput state = { 0 };
 			char *ptr = strchr(input, ' ');
 			switch (input[1]) {
-			case 'j': {
-				state.mode = RZ_OUTPUT_MODE_JSON;
-				state.d.pj = pj_new();
+			case 'j':
+				rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_JSON);
 				break;
-			}
-			case 'q': {
-				state.mode = RZ_OUTPUT_MODE_QUIET;
+			case 'q':
+				rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_QUIET);
 				break;
-			}
-			default: {
-				state.mode = RZ_OUTPUT_MODE_STANDARD;
+			default:
+				rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_STANDARD);
 				break;
-			}
 			}
 			if (ptr && ptr[1]) {
 				const char *plugin_name = ptr + 1;
@@ -785,17 +781,9 @@ RZ_IPI int rz_cmd_info(void *data, const char *input) {
 				rz_bin_list_plugin(core->bin, plugin_name, pj, 0);
 			} else {
 				rz_core_bin_plugins_print(core->bin, &state);
-				switch (state.mode) {
-				case RZ_OUTPUT_MODE_JSON: {
-					rz_cons_print(pj_string(state.d.pj));
-					rz_cons_flush();
-					pj_free(state.d.pj);
-					break;
-				}
-				default: {
-					break;
-				}
-				}
+				rz_cmd_state_output_print(&state);
+				rz_cmd_state_output_fini(&state);
+				rz_cons_flush();
 			}
 			newline = false;
 			goto done;

--- a/librz/core/cmd_linux_heap_glibc.c
+++ b/librz/core/cmd_linux_heap_glibc.c
@@ -29,8 +29,18 @@ RZ_IPI RzCmdStatus rz_cmd_heap_chunk_print_handler(RzCore *core, int argc, const
 RZ_IPI RzCmdStatus rz_cmd_heap_chunks_graph_handler(RzCore *core, int argc, const char **argv) {
 	// RZ_OUTPUT_MODE_LONG_JSON mode workaround for graph
 	RzCmdStateOutput state = { 0 };
-	state.mode = RZ_OUTPUT_MODE_LONG_JSON;
-	call_handler(rz_cmd_heap_chunks_print_handler, argc, argv, &state);
+	if (!rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_LONG)) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+	RzCmdStatus res;
+	if (core->rasm->bits == 64) {
+		res = rz_cmd_heap_chunks_print_handler_64(core, argc, argv, &state);
+	} else {
+		res = rz_cmd_heap_chunks_print_handler_32(core, argc, argv, &state);
+	}
+	rz_cmd_state_output_print(&state);
+	rz_cmd_state_output_fini(&state);
+	return res;
 }
 
 RZ_IPI RzCmdStatus rz_cmd_heap_info_print_handler(RzCore *core, int argc, const char **argv) {

--- a/librz/core/cmd_open.c
+++ b/librz/core/cmd_open.c
@@ -179,7 +179,10 @@ static void cmd_open_bin(RzCore *core, const char *input) {
 	switch (input[1]) {
 	case 'L': // "obL"
 		state.mode = RZ_OUTPUT_MODE_STANDARD;
+		rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_STANDARD);
 		rz_core_bin_plugins_print(core->bin, &state);
+		rz_cmd_state_output_print(&state);
+		rz_cmd_state_output_fini(&state);
 		break;
 	case '\0': // "ob"
 	case 'q': // "obj"
@@ -1323,22 +1326,13 @@ RZ_IPI int rz_cmd_open(void *data, const char *input) {
 			break;
 		}
 		if (input[1] == 'j') {
-			state.mode = RZ_OUTPUT_MODE_JSON;
-			state.d.pj = pj_new();
+			rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_JSON);
 		} else {
-			state.mode = RZ_OUTPUT_MODE_STANDARD;
+			rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_STANDARD);
 		}
 		rz_core_io_plugins_print(core->io, &state);
-		switch (state.mode) {
-		case RZ_OUTPUT_MODE_JSON: {
-			rz_cons_println(pj_string(state.d.pj));
-			pj_free(state.d.pj);
-			break;
-		}
-		default: {
-			break;
-		}
-		}
+		rz_cmd_state_output_print(&state);
+		rz_cmd_state_output_fini(&state);
 		break;
 	}
 	case 'i': // "oi"

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -561,6 +561,10 @@ RZ_API char *rz_cmd_unescape_arg(const char *arg, RzCmdEscape escape);
 RZ_API void rz_cmd_state_output_array_start(RzCmdStateOutput *state);
 RZ_API void rz_cmd_state_output_array_end(RzCmdStateOutput *state);
 RZ_API void rz_cmd_state_output_set_columnsf(RzCmdStateOutput *state, const char *fmt, ...);
+RZ_API bool rz_cmd_state_output_init(RZ_NONNULL RzCmdStateOutput *state, RzOutputMode mode);
+RZ_API void rz_cmd_state_output_fini(RZ_NONNULL RzCmdStateOutput *state);
+RZ_API void rz_cmd_state_output_free(RZ_NONNULL RzCmdStateOutput *state);
+RZ_API void rz_cmd_state_output_print(RZ_NONNULL RzCmdStateOutput *state);
 
 #define rz_cmd_parsed_args_foreach_arg(args, i, arg) for ((i) = 1; (i) < (args->argc) && ((arg) = (args)->argv[i]); (i)++)
 

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -504,9 +504,11 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 			free(debugbackend);
 			debugbackend = strdup(opt.arg);
 			RzCmdStateOutput state = { 0 };
-			state.mode = RZ_OUTPUT_MODE_QUIET;
+			rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_QUIET);
 			if (!strcmp(opt.arg, "?")) {
 				rz_core_debug_plugins_print(r, &state);
+				rz_cmd_state_output_print(&state);
+				rz_cmd_state_output_fini(&state);
 				rz_cons_flush();
 				LISTS_FREE();
 				return 0;
@@ -726,8 +728,10 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 		if (quietLeak) {
 			exit(0);
 		}
-		state.mode = RZ_OUTPUT_MODE_STANDARD;
+		rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_STANDARD);
 		rz_core_io_plugins_print(r->io, &state);
+		rz_cmd_state_output_print(&state);
+		rz_cmd_state_output_fini(&state);
 		rz_cons_flush();
 		LISTS_FREE();
 		free(pfile);

--- a/librz/main/rz-asm.c
+++ b/librz/main/rz-asm.c
@@ -531,25 +531,11 @@ RZ_API int rz_main_rz_asm(int argc, const char *argv[]) {
 		case 'L': {
 			RzCore *core = rz_core_new();
 			RzCmdStateOutput state = { 0 };
-			if (as->json) {
-				state.mode = RZ_OUTPUT_MODE_JSON;
-				state.d.pj = pj_new();
-			} else {
-				state.mode = RZ_OUTPUT_MODE_STANDARD;
-			}
+			rz_cmd_state_output_init(&state, as->json ? RZ_OUTPUT_MODE_JSON : RZ_OUTPUT_MODE_STANDARD);
 			rz_core_asm_plugins_print(core, opt.argv[opt.ind], &state);
-			switch (state.mode) {
-			case RZ_OUTPUT_MODE_JSON: {
-				rz_cons_println(pj_string(state.d.pj));
-				rz_cons_flush();
-				pj_free(state.d.pj);
-				break;
-			}
-			default: {
-				rz_cons_flush();
-				break;
-			}
-			}
+			rz_cmd_state_output_print(&state);
+			rz_cmd_state_output_fini(&state);
+			rz_cons_flush();
 			free(core);
 			ret = 1;
 			goto beach;

--- a/librz/main/rz-bin.c
+++ b/librz/main/rz-bin.c
@@ -492,31 +492,21 @@ static void __listPlugins(RzBin *bin, const char *plugin_name, PJ *pj, int rad) 
 	RzCmdStateOutput state = { 0 };
 	if (rad == RZ_MODE_JSON) {
 		format = 'j';
-		state.mode = RZ_OUTPUT_MODE_JSON;
-		state.d.pj = pj_new();
+		rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_JSON);
 	} else if (rad) {
 		format = 'q';
-		state.mode = RZ_OUTPUT_MODE_QUIET;
+		rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_QUIET);
 	} else {
-		state.mode = RZ_OUTPUT_MODE_STANDARD;
+		rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_STANDARD);
 	}
 	bin->cb_printf = (PrintfCallback)printf;
 	if (plugin_name) {
 		rz_bin_list_plugin(bin, plugin_name, pj, format);
 	} else {
 		rz_core_bin_plugins_print(bin, &state);
-		switch (state.mode) {
-		case RZ_OUTPUT_MODE_JSON: {
-			rz_cons_print(pj_string(state.d.pj));
-			rz_cons_flush();
-			pj_free(state.d.pj);
-			break;
-		}
-		default: {
-			rz_cons_flush();
-			break;
-		}
-		}
+		rz_cmd_state_output_print(&state);
+		rz_cmd_state_output_fini(&state);
+		rz_cons_flush();
 	}
 }
 

--- a/test/unit/legacy_unit/debug/main.c
+++ b/test/unit/legacy_unit/debug/main.c
@@ -13,11 +13,13 @@ int main(int argc, char **argv) {
 	struct rz_io_t *io;
 	struct rz_debug_t *dbg = NULL;
 	RzCmdStateOutput state = { 0 };
-	state.mode = RZ_OUTPUT_MODE_STANDARD;
+	rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_STANDARD);
 
 	io = rz_io_new();
 	printf("Supported IO pluggins:\n");
 	rz_core_io_plugins_print(io, &state);
+	rz_cmd_state_output_print(&state);
+	rz_cmd_state_output_fini(&state);
 
 	fd = rz_io_open_nomap(io, "dbg:///bin/ls", 0, 0);
 	if (!fd) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Some helper functions to deal with `RzCmdStateOutput` structure. Init/fini/free/print. Plus, I added some unit tests to do what I'm essentially doing in the `i` PR. The only thing I don't like too much is that you have to write different code based on whether you want to just print multiple tables one after the other or you want to *combine* json output (which is done for example by `ia`, where it takes the json output of some other commands and show them as a bigger more  complex json object).

I don't see a solution around that though. So what I'm doing in the `i` PR is to just do 
```
if (state->mode != JSON) { 
   rz_cmd_state_output_print(&state);
   rz_cmd_state_output_fini(&state);
   rz_cmd_state_output_init(&state, state->mode);
} else {
   pj_o(state.d.pj, "bin");
}
```

It's not the best thing, but it's the only way I can think of right now to combine the json output. Because essentially the json output behaves differently than other outputs: said differently, `ia` is exactly equal to `ie`+`iE`+`ii`+... , but `iaj` is not equal to `iej`+`iEj`+`iij`+..., rather `iaj` is a combination of those json, so i must special-handle it.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
