### PR TITLE
Fix compilation with Capstone v3

### DIFF
--- a/librz/analysis/p/analysis_arm_cs.c
+++ b/librz/analysis/p/analysis_arm_cs.c
@@ -3494,9 +3494,7 @@ jmp $$ + 4 + ( [delta] * 2 )
 	case ARM_INS_LDRT:
 		op->cycles = 4;
 		// 0x000082a8    28301be5     ldr r3, [fp, -0x28]
-#if CS_API_MAJOR > 3
-		op->scale = INSOP(1).mem.scale << INSOP(1).mem.lshift;
-#endif
+		op->scale = INSOP(1).mem.scale << LSHIFT(1);
 		op->ireg = cs_reg_name(handle, REGBASE(1));
 		op->disp = MEMDISP(1);
 		if (REGID(0) == ARM_REG_PC) {

--- a/librz/analysis/p/analysis_arm_cs.c
+++ b/librz/analysis/p/analysis_arm_cs.c
@@ -3494,7 +3494,9 @@ jmp $$ + 4 + ( [delta] * 2 )
 	case ARM_INS_LDRT:
 		op->cycles = 4;
 		// 0x000082a8    28301be5     ldr r3, [fp, -0x28]
+#if CS_API_MAJOR > 3
 		op->scale = INSOP(1).mem.scale << INSOP(1).mem.lshift;
+#endif
 		op->ireg = cs_reg_name(handle, REGBASE(1));
 		op->disp = MEMDISP(1);
 		if (REGID(0) == ARM_REG_PC) {
@@ -3777,7 +3779,9 @@ static void set_src_dst(RzAnalysisValue *val, RzReg *reg, csh *handle, cs_insn *
 			break;
 		case ARM_OP_MEM:
 			val->type = RZ_ANALYSIS_VAL_MEM;
+#if CS_API_MAJOR > 3
 			val->mul = armop.mem.scale << armop.mem.lshift;
+#endif
 			val->delta = armop.mem.disp;
 			break;
 		case ARM_OP_IMM:


### PR DESCRIPTION
# SQUASH ME

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fix the following error:
```
gcc -Ilibrz/analysis/librz_analysis.so.0.3.0-git.p -I. -I.. -I../librz/include -I../librz/analysis/arch/gb -I../librz/analysis/arch/hexagon -Isubprojects/sdb -I../subprojects/sdb -Isubprojects/sdb/src -I../subprojects/sdb/src -Ishlr -I../shlr -I../librz/asm/arch/include -I../librz/asm/arch -I../librz/asm/arch/h8300 -I../librz/asm/arch/hexagon -I../librz/asm/arch/msp430 -I../librz/asm/arch/rsp -I../librz/asm/arch/mcore -I../librz/asm/arch/v850 -I../librz/asm/arch/propeller -I../librz/asm/arch/ebc -I../librz/asm/arch/cr16 -I../librz/asm/arch/8051 -I../librz/asm/arch/v810 -I../librz/asm/arch/or1k -I../librz/bin/mangling -I../librz/bin/format -I../librz/type/parser -I../subprojects/capstone-3.0.5/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Werror -O3 --std=gnu99 -D_GNU_SOURCE -Werror=sizeof-pointer-memaccess -fvisibility=hidden -Wno-cpp -fPIC -DRZ_PLUGIN_INCORE=1 -MD -MQ librz/analysis/librz_analysis.so.0.3.0-git.p/p_analysis_arm_cs.c.o -MF librz/analysis/librz_analysis.so.0.3.0-git.p/p_analysis_arm_cs.c.o.d -o librz/analysis/librz_analysis.so.0.3.0-git.p/p_analysis_arm_cs.c.o -c ../librz/analysis/p/analysis_arm_cs.c
../librz/analysis/p/analysis_arm_cs.c: In function ‘anop32’:
../librz/analysis/p/analysis_arm_cs.c:3497:49: error: ‘arm_op_mem’ {aka ‘struct arm_op_mem’} has no member named ‘lshift’
 3497 |   op->scale = INSOP(1).mem.scale << INSOP(1).mem.lshift;
      |                                                 ^
../librz/analysis/p/analysis_arm_cs.c: In function ‘set_src_dst’:
../librz/analysis/p/analysis_arm_cs.c:3780:43: error: ‘arm_op_mem’ {aka ‘struct arm_op_mem’} has no member named ‘lshift’
 3780 |    val->mul = armop.mem.scale << armop.mem.lshift;
      |                                           ^
[972/1674] Compiling C object librz/analysis/librz_analysis.so.0.3.0-git.p/p_analysis_avr.c.o
[973/1674] Compiling C object librz/asm/librz_asm.so.0.3.0-git.p/arch_hexagon_hexagon_disas.c.o
ninja: build stopped: subcommand failed.
Error: Process completed with exit code 1.
```

**Test plan**

CI is green