### PR TITLE
Add missing copyright

### DIFF
--- a/librz/asm/arch/cr16/cr16_disas.h
+++ b/librz/asm/arch/cr16/cr16_disas.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2014 Fedor Sakharov <fedor.sakharov@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef RZ_CR16_DISASM_H
 #define RZ_CR16_DISASM_H
 

--- a/librz/asm/arch/dcpu16/dcpu16.h
+++ b/librz/asm/arch/dcpu16/dcpu16.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2012 pancake <pancake@nopcode.org>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef _INCLUDE_DCPU16_H_
 #define _INCLUDE_DCPU16_H_
 

--- a/librz/asm/arch/ebc/ebc_disas.h
+++ b/librz/asm/arch/ebc/ebc_disas.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2013-2015 Fedor Sakharov <fedor.sakharov@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef RZ_EBC_DISAS_H
 #define RZ_EBC_DISAS_H
 

--- a/librz/asm/arch/h8300/h8300_disas.h
+++ b/librz/asm/arch/h8300/h8300_disas.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2014 Fedor Sakharov <fedor.sakharov@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef RZ_H8300_DISAS_H
 #define RZ_H8300_DISAS_H
 

--- a/librz/asm/arch/mcs96/mcs96.h
+++ b/librz/asm/arch/mcs96/mcs96.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2015-2019 condret <condr3t@protonmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include <rz_util.h>
 #include <rz_types.h>
 

--- a/librz/asm/arch/msp430/msp430_disas.h
+++ b/librz/asm/arch/msp430/msp430_disas.h
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2014 Fedor Sakharov <fedor.sakharov@gmail.com>
+// SPDX-FileCopyrightText: 2015 Mauro Matteo Cascella <mauromatteo.cascella@gmail.com>
+// SPDX-FileCopyrightText: 2016 Mitchell Johnson <ehntoo@gmail.com>
+// SPDX-FileCopyrightText: 2018 Neven Sajko <nsajko@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef MSP430_DISAS_H
 #define MSP430_DISAS_H
 

--- a/librz/asm/arch/propeller/propeller_disas.h
+++ b/librz/asm/arch/propeller/propeller_disas.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2014 Fedor Sakharov <fedor.sakharov@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef PROPELLER_DISAS_H
 #define PROPELLER_DISAS_H
 

--- a/librz/asm/arch/tms320/c55x_plus/c55plus.h
+++ b/librz/asm/arch/tms320/c55x_plus/c55plus.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2013-2021 th0rpe <josediazfer@yahoo.es>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef C55PLUS_H
 #define C55PLUS_H
 

--- a/librz/asm/arch/tms320/c55x_plus/decode.h
+++ b/librz/asm/arch/tms320/c55x_plus/decode.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2013-2021 th0rpe <josediazfer@yahoo.es>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef DECODE_H
 #define DECODE_H
 

--- a/librz/asm/arch/tms320/c55x_plus/decode_funcs.h
+++ b/librz/asm/arch/tms320/c55x_plus/decode_funcs.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2013-2021 th0rpe <josediazfer@yahoo.es>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef DECODE_FUNCS_H
 #define DECODE_FUNCS_H
 

--- a/librz/asm/arch/tms320/c55x_plus/hashtable.h
+++ b/librz/asm/arch/tms320/c55x_plus/hashtable.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2013-2021 th0rpe <josediazfer@yahoo.es>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef HASHTABLE_H
 #define HASHTABLE_H
 

--- a/librz/asm/arch/tms320/c55x_plus/hashvector.h
+++ b/librz/asm/arch/tms320/c55x_plus/hashvector.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2013-2021 th0rpe <josediazfer@yahoo.es>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef HASHVECTOR_H
 #define HASHVECTOR_H
 

--- a/librz/asm/arch/tms320/c55x_plus/ins.h
+++ b/librz/asm/arch/tms320/c55x_plus/ins.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2013-2021 th0rpe <josediazfer@yahoo.es>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef INS_H
 #define INS_H
 

--- a/librz/asm/arch/tms320/c55x_plus/utils.h
+++ b/librz/asm/arch/tms320/c55x_plus/utils.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2013-2021 th0rpe <josediazfer@yahoo.es>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef UUTILS_H
 #define UUTILS_H
 

--- a/librz/asm/arch/tms320/scripts/c55x_gen_tbl.pl
+++ b/librz/asm/arch/tms320/scripts/c55x_gen_tbl.pl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2014 Ilya V. Matveychikov <i.matveychikov@milabs.ru>
+# SPDX-License-Identifier: LGPL-3.0-only
+
 use Data::Dumper;
 
 #

--- a/librz/asm/arch/tms320/tms320_dasm.h
+++ b/librz/asm/arch/tms320/tms320_dasm.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2014 Ilya V. Matveychikov <i.matveychikov@milabs.ru>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef __TMS320_DASM_H__
 #define __TMS320_DASM_H__
 

--- a/librz/asm/arch/tms320/tms320_p.h
+++ b/librz/asm/arch/tms320/tms320_p.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2014 Ilya V. Matveychikov <i.matveychikov@milabs.ru>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef __TMS320_P_H__
 #define __TMS320_P_H__
 

--- a/librz/asm/arch/v810/v810_disas.h
+++ b/librz/asm/arch/v810/v810_disas.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2015 danielps
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef RZ_V810_DISASM_H
 #define RZ_V810_DISASM_H
 

--- a/librz/asm/arch/v850/v850_disas.h
+++ b/librz/asm/arch/v850/v850_disas.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2014-2018 Fedor Sakharov <fedor.sakharov@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef RZ_V850_DISASM_H
 #define RZ_V850_DISASM_H
 

--- a/librz/asm/arch/xap/dis.h
+++ b/librz/asm/arch/xap/dis.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2007 sorbo
+// SPDX-FileCopyrightText: 2010-2019 pancake <pancake@nopcode.org>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef _INCLUDE_XAP_DIS_H_
 #define _INCLUDE_XAP_DIS_H_
 

--- a/librz/asm/p/asm_arm_hacks.inc
+++ b/librz/asm/p/asm_arm_hacks.inc
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2020 phakeobj
+// SPDX-License-Identifier: LGPL-3.0-only
+
 static char *hack_handle_dp_imm(ut32 insn) {
 	char *buf_asm = NULL;
 	char *mnemonic = NULL;

--- a/librz/bin/format/coff/coff_reloc.c
+++ b/librz/bin/format/coff/coff_reloc.c
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2021 Florian Märkl <info@florianmaerkl.de>
+// SPDX-License-Identifier: LGPL-3.0-only
 
 #include "coff.h"
 #include <rz_util.h>


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

More fixes to improve the `reuse lint` score.
Added copyrights are based on the git history of Rizin and Radare2.

Was:
```
* Files with copyright information: 3051 / 3114
* Files with license information: 3051 / 3114
```
Now:
```
* Files with copyright information: 3073 / 3114
* Files with license information: 3073 / 3114
```

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/683