### PR TITLE
core/cmd_descs: add support for default_mode

### DIFF
--- a/librz/core/cmd_descs/cmd_descs.yaml
+++ b/librz/core/cmd_descs/cmd_descs.yaml
@@ -22,6 +22,8 @@
 #   modes: >
 #     same as RzCmdDesc.modes. When present the type is automatically set to
 #     ARGV_MODES.
+#   default_mode: >
+#     same as RzCmdDesc.default_mode.
 #   details: >
 #     an array of RzCmdDescDetail or a string referencing an already existing
 #     RzCmdDescDetail array

--- a/librz/core/cmd_descs/cmd_descs_generate.py
+++ b/librz/core/cmd_descs/cmd_descs_generate.py
@@ -819,10 +819,12 @@ cf_text = CMDDESCS_C_TEMPLATE.format(
     helps="\n".join(helps),
     init_code="\n".join(init_code),
 )
-with open(os.path.join(args.output_dir, "cmd_descs.c"), "w") as f:
+with open(os.path.join(args.output_dir, "cmd_descs.c"), "w", encoding="utf8") as f:
     f.write(cf_text)
 if args.src_output_dir:
-    with open(os.path.join(args.src_output_dir, "cmd_descs.c"), "w") as f:
+    with open(
+        os.path.join(args.src_output_dir, "cmd_descs.c"), "w", encoding="utf8"
+    ) as f:
         f.write(cf_text)
 
 handlers_decls = filter(
@@ -833,8 +835,10 @@ handlers_decls = filter(
 hf_text = CMDDESCS_H_TEMPLATE.format(
     handlers_declarations="\n".join([handler2decl(t, h) for t, h in handlers_decls]),
 )
-with open(os.path.join(args.output_dir, "cmd_descs.h"), "w") as f:
+with open(os.path.join(args.output_dir, "cmd_descs.h"), "w", encoding="utf8") as f:
     f.write(hf_text)
 if args.src_output_dir:
-    with open(os.path.join(args.src_output_dir, "cmd_descs.h"), "w") as f:
+    with open(
+        os.path.join(args.src_output_dir, "cmd_descs.h"), "w", encoding="utf8"
+    ) as f:
         f.write(hf_text)

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -434,12 +434,14 @@ typedef struct rz_cmd_desc_t {
 		struct {
 			RzCmdArgvModesCb cb;
 			int modes; ///< A combination of RzOutputMode values
+			RzOutputMode default_mode; ///< Make one of the modes the default one, used even when the special suffix is not specified.
 			int min_argc;
 			int max_argc;
 		} argv_modes_data;
 		struct {
 			RzCmdArgvStateCb cb;
 			int modes; ///< A combination of RzOutputMode values
+			RzOutputMode default_mode; ///< Make one of the modes the default one, used even when the special suffix is not specified.
 			int min_argc;
 			int max_argc;
 		} argv_state_data;
@@ -536,6 +538,7 @@ RZ_API RzCmdDesc *rz_cmd_desc_oldinput_new(RzCmd *cmd, RzCmdDesc *parent, const 
 RZ_API RzCmdDesc *rz_cmd_desc_fake_new(RzCmd *cmd, RzCmdDesc *parent, const char *name, const RzCmdDescHelp *help);
 RZ_API RzCmdDesc *rz_cmd_desc_parent(RzCmdDesc *cd);
 RZ_API RzCmdDesc *rz_cmd_desc_get_exec(RzCmdDesc *cd);
+RZ_API bool rz_cmd_desc_set_default_mode(RzCmdDesc *cd, RzOutputMode mode);
 RZ_API bool rz_cmd_desc_has_handler(const RzCmdDesc *cd);
 RZ_API bool rz_cmd_desc_remove(RzCmd *cmd, RzCmdDesc *cd);
 RZ_API void rz_cmd_foreach_cmdname(RzCmd *cmd, RzCmdDesc *begin, RzCmdForeachNameCb cb, void *user);

--- a/sys/check_meson_subproject.py
+++ b/sys/check_meson_subproject.py
@@ -18,7 +18,7 @@ meson_root = os.environ["MESON_SOURCE_ROOT"]
 subproject_filename = os.path.join(meson_root, "subprojects", subproject + ".wrap")
 
 try:
-    with open(subproject_filename, "r") as f:
+    with open(subproject_filename, "r", encoding="utf8") as f:
 
         is_wrap_git = False
         revision = None
@@ -43,7 +43,9 @@ try:
             subproject_dir = os.path.join(meson_root, "subprojects", directory)
             subproject_git_dir = os.path.join(subproject_dir, ".git")
             if os.path.isdir(subproject_dir) and os.path.isdir(subproject_git_dir):
-                with open(os.path.join(subproject_git_dir, "HEAD"), "r") as f:
+                with open(
+                    os.path.join(subproject_git_dir, "HEAD"), "r", encoding="utf8"
+                ) as f:
                     head = f.read().strip()
                 if head != revision:
                     sys.exit(1)

--- a/sys/create_tags_rz.py
+++ b/sys/create_tags_rz.py
@@ -9,6 +9,6 @@ import os
 from sys import argv
 
 for fname in argv[1:]:
-    with open(fname) as f:
+    with open(fname, encoding="utf8") as f:
         text = " ".join(f.read().splitlines())
     print("ft %s %s" % (os.path.basename(fname), text))

--- a/sys/syscall_preprocessing.py
+++ b/sys/syscall_preprocessing.py
@@ -8,8 +8,8 @@
 import re
 import sys
 
-with open(sys.argv[1]) as inf:
-    with open(sys.argv[2], "w") as outf:
+with open(sys.argv[1], encoding="utf8") as inf:
+    with open(sys.argv[2], "w", encoding="utf8") as outf:
         for line in inf:
             if not line.startswith("_") and "=" in line:
                 arr = re.split("=|,", line)

--- a/sys/version.py
+++ b/sys/version.py
@@ -12,7 +12,7 @@ meson_file = "meson.build"
 if len(sys.argv) > 1:
     meson_file = os.path.join(sys.argv[1], meson_file)
 
-with open(meson_file, "r") as f:
+with open(meson_file, "r", encoding="utf8") as f:
     # Read only first 10 lines of the meson file, looking for 'version: ' string
     for i in range(10):
         fields = [x.strip() for x in f.readline().strip().split(":")]

--- a/test/unit/legacy_unit/syscall/openbsd-gen.py
+++ b/test/unit/legacy_unit/syscall/openbsd-gen.py
@@ -5,7 +5,7 @@
 import copy
 import sys
 
-with open("/usr/include/sys/syscall.h", "r") as f:
+with open("/usr/include/sys/syscall.h", "r", encoding="utf8") as f:
     rec = {"name": None, "args": None}
     recs = {}
 
@@ -37,7 +37,7 @@ with open("/usr/include/sys/syscall.h", "r") as f:
 
             recs[int(callnum)] = copy.copy(rec)
             rec = {"name": None, "args": None}
-with open("openbsd.c", "w") as out:
+with open("openbsd.c", "w", encoding="utf8") as out:
     out.write('#include "r_syscall.h"\n\n/* syscall-openbsd */\n')
     out.write("RSyscallItem syscalls_openbsd_x86[] = {\n")
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Some commands might have one of the output modes as default one. If
that's the case, RzCmd should be aware of that so that it can
initializes everything needed for that default mode.

For example, if command `c` supports TABLE, JSON and QUIET and you want
to have `c`(with no suffix) print the TABLE mode, the parser would have
to initialize the RzTable data structures anyway, so it must be aware of
it.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Unit tests.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
