### PR TITLE
Use python3 to use encoding= in open() function

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,7 +61,7 @@ init:
 # Required software for building
 install:
   # Update environment variables
-  - ps: $env:RZ_VERSION = ( python sys\\version.py )
+  - ps: $env:RZ_VERSION = (& (Join-Path $env:PYTHON python.exe) sys\\version.py )
   - ps: $env:DIST_FOLDER = "rizin-$env:builder-$env:RZ_VERSION"
   - ps: $env:ARTIFACT_ZIP = "$env:DIST_FOLDER.zip"
   # Download required packages


### PR DESCRIPTION
```
[00:00:28] At line:1 char:21
[00:00:28] + $env:RZ_VERSION = ( python sys\\version.py )
[00:00:28] +                     ~~~~~~~~~~~~~~~~~~~~~~
[00:00:28]     + CategoryInfo          : NotSpecified: (Traceback (most recent call last)::String) [], RemoteException
[00:00:28]     + FullyQualifiedErrorId : NativeCommandError
[00:00:28]  
[00:00:28]   File "sys\\version.py", line 15, in <module>
[00:00:28]     with open(meson_file, "r", encoding="utf8") as f:
[00:00:28] TypeError: 'encoding' is an invalid keyword argument for this function

```