### PR TITLE
RzCore: do not compress projects by default

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3152,7 +3152,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 
 	/* prj */
 	SETPREF("prj.file", "", "Path of the currently opened project");
-	SETBPREF("prj.compress", "true", "Compress the project file while saving");
+	SETBPREF("prj.compress", "false", "Compress the project file while saving");
 
 	/* cfg */
 	SETBPREF("cfg.plugins", "true", "Load plugins at startup");


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

By keeping projects in their text representation by default, we ensure
that project files can be more easily put in a version control system,
diffed, merged, etc.


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

I tried to save a project in both modes, re-open it with different values of prj.compress.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #1555 
