### PR TITLE
Force python3 when running sys/version.py

### DIFF
--- a/dist/osx/build_osx_package.sh
+++ b/dist/osx/build_osx_package.sh
@@ -2,7 +2,7 @@
 #
 # Script to create a OSX .pkg file to install Rizin
 
-VERSION=$(./sys/version.py)
+VERSION=$(python3 ./sys/version.py)
 RIZINDIR=$(pwd)
 RIZININSTALL=/tmp/rizin-install
 OSXPKGDIR=/tmp/osxpkgtmp


### PR DESCRIPTION
It should fix https://github.com/rizinorg/rizin/runs/3465534930?check_suite_focus=true 