### PR TITLE
Fix dex & java coverity

### DIFF
--- a/librz/bin/format/dex/dex.c
+++ b/librz/bin/format/dex/dex.c
@@ -1313,6 +1313,7 @@ RZ_API RZ_OWN RzList /*<RzBinImport*>*/ *rz_bin_dex_imports(RZ_NONNULL RzBinDex 
 
 		char *object = dex_resolve_type_id(dex, field_id->class_idx);
 		if (!object) {
+			free(import);
 			break;
 		}
 		rz_str_replace_char(object, ';', 0);

--- a/librz/bin/format/java/class_attribute.c
+++ b/librz/bin/format/java/class_attribute.c
@@ -429,15 +429,20 @@ bool java_attribute_set_module(Attribute *attr, RzBuffer *buf) {
 	return true;
 
 java_attribute_set_module_bad:
-	rz_warn_if_reached();
-	for (ut32 i = 0; i < am->exports_count; ++i) {
-		free(am->exports[i].to_indices);
+	if (am->exports) {
+		for (ut32 i = 0; i < am->exports_count; ++i) {
+			free(am->exports[i].to_indices);
+		}
 	}
-	for (ut32 i = 0; i < am->opens_count; ++i) {
-		free(am->opens[i].to_indices);
+	if (am->opens) {
+		for (ut32 i = 0; i < am->opens_count; ++i) {
+			free(am->opens[i].to_indices);
+		}
 	}
-	for (ut32 i = 0; i < am->provides_count; ++i) {
-		free(am->provides[i].with_indices);
+	if (am->provides) {
+		for (ut32 i = 0; i < am->provides_count; ++i) {
+			free(am->provides[i].with_indices);
+		}
 	}
 	free(am->uses_index);
 	free(am->exports);

--- a/librz/bin/format/java/class_attribute.c
+++ b/librz/bin/format/java/class_attribute.c
@@ -385,8 +385,8 @@ bool java_attribute_set_module(Attribute *attr, RzBuffer *buf) {
 	}
 
 	if (am->uses_count > 0) {
-		am->uses_index = RZ_NEWS0(ut16, am->uses_count);
-		if (!am->uses_index) {
+		tmp16 = RZ_NEWS0(ut16, am->uses_count);
+		if (!tmp16) {
 			goto java_attribute_set_module_bad;
 		}
 		am->uses_index = tmp16;

--- a/librz/bin/format/java/class_bin.c
+++ b/librz/bin/format/java/class_bin.c
@@ -1213,7 +1213,7 @@ RZ_API RZ_OWN RzList *rz_bin_java_class_fields_as_symbols(RZ_NONNULL RzBinJavaCl
 			RzBinSymbol *symbol = rz_bin_symbol_new(NULL, field->offset, field->offset);
 			if (!symbol) {
 				rz_warn_if_reached();
-				free(sym);
+				free(field_name);
 				continue;
 			}
 			symbol->classname = rz_bin_java_class_name(bin);

--- a/librz/bin/mangling/java.c
+++ b/librz/bin/mangling/java.c
@@ -272,7 +272,7 @@ RZ_API RZ_OWN char *rz_bin_demangle_java(RZ_NULLABLE const char *mangled) {
 	}
 	rz_str_trim(name);
 	// removes any obvious class like java.lang.String
-	rz_str_replace(name, "java/lang/", "", 1);
+	name = rz_str_replace(name, "java/lang/", "", 1);
 
 	if ((arguments = strchr(name, '(')) && (return_type = strchr(arguments, ')'))) {
 		return demangle_method(name, arguments, return_type);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- CID 355574: Resource leak (RESOURCE_LEAK)
- CID 355575: Use after free (USE_AFTER_FREE)
- CID 354859: Dereference after null check (FORWARD_NULL)
- CID 354871: Dereference after null check (FORWARD_NULL)
- CID 354878: Dereference after null check (FORWARD_NULL)
- CID 354867: Explicit null dereferenced (FORWARD_NULL)
- CID 355572: Dereference after null check (FORWARD_NULL)
- CID 355576: Use after free (USE_AFTER_FREE) 
