### PR TITLE
Add missing copyrights

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -35,6 +35,10 @@ Files: .gitignore
 Copyright: 2021 RizinOrg <info@rizin.re>
 License: LGPL-3.0-only
 
+Files: **/.gitignore
+Copyright: 2021 RizinOrg <info@rizin.re>
+License: LGPL-3.0-only
+
 Files: .pylintrc
 Copyright: 2021 RizinOrg <info@rizin.re>
 License: LGPL-3.0-only
@@ -47,6 +51,10 @@ Files: *.md
 Copyright: 2021 RizinOrg <info@rizin.re>
 License: LGPL-3.0-only
 
+Files: *.in
+Copyright: 2021 RizinOrg <info@rizin.re>
+License: LGPL-3.0-only
+
 Files: **/meson.build
 Copyright: 2021 RizinOrg <info@rizin.re>
 License: LGPL-3.0-only
@@ -56,6 +64,10 @@ Copyright: 2021 RizinOrg <info@rizin.re>
 License: LGPL-3.0-only
 
 Files: meson_options.txt
+Copyright: 2021 RizinOrg <info@rizin.re>
+License: LGPL-3.0-only
+
+Files: **/meson_options.txt
 Copyright: 2021 RizinOrg <info@rizin.re>
 License: LGPL-3.0-only
 

--- a/librz/bin/format/le/le.h
+++ b/librz/bin/format/le/le.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2019 GustavoLCR <gugulcr@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef LE_H
 #define LE_H
 #include <rz_bin.h>

--- a/librz/bin/format/le/le_specs.h
+++ b/librz/bin/format/le/le_specs.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2019 GustavoLCR <gugulcr@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef LE_SPECS_H
 #define LE_SPECS_H
 #include <rz_types.h>

--- a/librz/bin/format/mach0/coresymbolication.h
+++ b/librz/bin/format/mach0/coresymbolication.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2020 mrmacete <mrmacete@protonmail.ch>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include <rz_bin.h>
 #include <rz_types.h>
 

--- a/librz/bin/format/mach0/coresymbolication.h
+++ b/librz/bin/format/mach0/coresymbolication.h
@@ -4,8 +4,8 @@
 #include <rz_bin.h>
 #include <rz_types.h>
 
-#ifndef _INCLUDE_R_BIN_CORESYMBOLICATION_H
-#define _INCLUDE_R_BIN_CORESYMBOLICATION_H
+#ifndef _INCLUDE_RZ_BIN_CORESYMBOLICATION_H
+#define _INCLUDE_RZ_BIN_CORESYMBOLICATION_H
 
 typedef struct rz_coresym_cache_element_hdr_t {
 	ut32 version;

--- a/librz/bin/format/mach0/fatmach0.h
+++ b/librz/bin/format/mach0/fatmach0.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2010-2013 nibble <nibble.ds@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include <rz_types.h>
 #include "mach0_specs.h"
 

--- a/librz/bin/format/mach0/fatmach0.h
+++ b/librz/bin/format/mach0/fatmach0.h
@@ -4,8 +4,8 @@
 #include <rz_types.h>
 #include "mach0_specs.h"
 
-#ifndef _INCLUDE_R_BIN_FATMACH0_H_
-#define _INCLUDE_R_BIN_FATMACH0_H_
+#ifndef _INCLUDE_RZ_BIN_FATMACH0_H_
+#define _INCLUDE_RZ_BIN_FATMACH0_H_
 
 struct rz_bin_fatmach0_obj_t {
 	const char *file;

--- a/librz/bin/format/mach0/mach0.h
+++ b/librz/bin/format/mach0/mach0.h
@@ -6,8 +6,8 @@
 #include <rz_types.h>
 #include "mach0_specs.h"
 
-#ifndef _INCLUDE_R_BIN_MACH0_H_
-#define _INCLUDE_R_BIN_MACH0_H_
+#ifndef _INCLUDE_RZ_BIN_MACH0_H_
+#define _INCLUDE_RZ_BIN_MACH0_H_
 
 // 20% faster loading times for macho if enabled
 #define FEATURE_SYMLIST 0

--- a/librz/bin/format/mach0/mach0.h
+++ b/librz/bin/format/mach0/mach0.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2010-2020 nibble <nibble.ds@gmail.com>
+// SPDX-FileCopyrightText: 2010-2020 pancake <pancake@nopcode.org>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include <rz_bin.h>
 #include <rz_types.h>
 #include "mach0_specs.h"

--- a/librz/bin/format/mach0/mach0_specs.h
+++ b/librz/bin/format/mach0/mach0_specs.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2010-2020 nibble <nibble.ds@gmail.com>
+// SPDX-FileCopyrightText: 2010-2020 pancake <pancake@nopcode.org>
+// SPDX-License-Identifier: LGPL-3.0-only
 
 #ifndef _INCLUDE_R_BIN_MACH0_SPECS_H_
 #define _INCLUDE_R_BIN_MACH0_SPECS_H_

--- a/librz/bin/format/mach0/mach0_specs.h
+++ b/librz/bin/format/mach0/mach0_specs.h
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: 2010-2020 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef _INCLUDE_R_BIN_MACH0_SPECS_H_
-#define _INCLUDE_R_BIN_MACH0_SPECS_H_
+#ifndef _INCLUDE_RZ_BIN_MACH0_SPECS_H_
+#define _INCLUDE_RZ_BIN_MACH0_SPECS_H_
 
 typedef int integer_t;
 

--- a/librz/bin/format/ne/ne.h
+++ b/librz/bin/format/ne/ne.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2019 GustavoLCR <gugulcr@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef NE_H
 #define NE_H
 #include <rz_types.h>

--- a/librz/bin/format/ne/ne_specs.h
+++ b/librz/bin/format/ne/ne_specs.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2019 GustavoLCR <gugulcr@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef NE_SPECS_H
 #define NE_SPECS_H
 

--- a/librz/bin/format/nin/gba.h
+++ b/librz/bin/format/nin/gba.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2014 condret <condr3t@protonmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include <rz_types.h>
 
 const ut8 lic_gba[] = {

--- a/librz/bin/format/nin/n3ds.h
+++ b/librz/bin/format/nin/n3ds.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2016 Alberto Ortega
+// SPDX-License-Identifier: LGPL-3.0-only
 
 /*
 https://www.3dbrew.org/wiki/FIRM

--- a/librz/bin/format/nin/nds.h
+++ b/librz/bin/format/nin/nds.h
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2014 Alberto Ortega
+// SPDX-License-Identifier: LGPL-3.0-only
 
 /*
 http://dsibrew.org/wiki/NDS_Format

--- a/librz/bin/format/nin/nin.h
+++ b/librz/bin/format/nin/nin.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2013-2017 condret <condr3t@protonmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include <rz_types.h>
 #include <string.h>
 

--- a/librz/bin/format/objc/mach064_classes.h
+++ b/librz/bin/format/objc/mach064_classes.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2015 inisider <inisider@gmail.com>
+// SPDX-FileCopyrightText: 2018-2019 Francesco Tamagni <mrmacete@protonmail.ch>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef MACH064_CLASSES
 #define MACH064_CLASSES
 

--- a/librz/bin/format/objc/mach0_classes.h
+++ b/librz/bin/format/objc/mach0_classes.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2015 inisider <inisider@gmail.com>
+// SPDX-FileCopyrightText: 2018-2019 Francesco Tamagni <mrmacete@protonmail.ch>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include <rz_bin.h>
 
 #include "mach0/mach0_specs.h"

--- a/librz/bin/format/omf/omf.h
+++ b/librz/bin/format/omf/omf.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2015 ampotos <mercie_i@epitech.eu>
+// SPDX-FileCopyrightText: 2015-2019 pancake <pancake@nopcode.org>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef OMF_H_
 #define OMF_H_
 

--- a/librz/bin/format/omf/omf_specs.h
+++ b/librz/bin/format/omf/omf_specs.h
@@ -1,7 +1,11 @@
+// SPDX-FileCopyrightText: 2015 ampotos <mercie_i@epitech.eu>
+// SPDX-FileCopyrightText: 2015-2019 pancake <pancake@nopcode.org>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef OMF_SPECS_H_
 #define OMF_SPECS_H_
 
-// additionnal informations : http://pierrelib.pagesperso-orange.fr/exec_formats/OMF_v1.1.pdf
+// additional information : http://pierrelib.pagesperso-orange.fr/exec_formats/OMF_v1.1.pdf
 
 // record type
 #define OMF_THEADR    0x80 // Translator Header Record

--- a/librz/bin/format/pe/dotnet.c
+++ b/librz/bin/format/pe/dotnet.c
@@ -1,23 +1,7 @@
 // SPDX-FileCopyrightText: 2015. The YARA Authors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/*
-Forked by pancake in 2017
-
-Copyright (c) 2015. The YARA Authors. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+/* Forked by pancake in 2017 */
 
 #define _GNU_SOURCE
 

--- a/librz/bin/format/pe/dotnet.h
+++ b/librz/bin/format/pe/dotnet.h
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2015. The YARA Authors. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/* Forked by pancake in 2017 */
+
 #ifndef YR_DOTNET_H
 #define YR_DOTNET_H
 

--- a/librz/bin/format/pe/pe.h
+++ b/librz/bin/format/pe/pe.h
@@ -8,8 +8,8 @@
 
 #include "pe_specs.h"
 
-#ifndef _INCLUDE_R_BIN_PE_H_
-#define _INCLUDE_R_BIN_PE_H_
+#ifndef _INCLUDE_RZ_BIN_PE_H_
+#define _INCLUDE_RZ_BIN_PE_H_
 
 #define RZ_BIN_PE_SCN_IS_SHAREABLE(x)  x &PE_IMAGE_SCN_MEM_SHARED
 #define RZ_BIN_PE_SCN_IS_EXECUTABLE(x) x &PE_IMAGE_SCN_MEM_EXECUTE

--- a/librz/bin/format/pe/pemixed.h
+++ b/librz/bin/format/pe/pemixed.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2018 JohnPeng47 <johnpeng47@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include <rz_types.h>
 #include "pe.h"
 

--- a/librz/bin/format/pe/pemixed.h
+++ b/librz/bin/format/pe/pemixed.h
@@ -8,8 +8,8 @@
 #define SUB_BIN_NATIVE 1
 #define SUB_BIN_NET    2
 
-#ifndef _INCLUDE_R_BIN_PEMIXED_H_
-#define _INCLUDE_R_BIN_PEMIXED_H_
+#ifndef _INCLUDE_RZ_BIN_PEMIXED_H_
+#define _INCLUDE_RZ_BIN_PEMIXED_H_
 
 struct rz_bin_pemixed_obj_t {
 	const char *file;

--- a/librz/bin/format/psxexe/psxexe.h
+++ b/librz/bin/format/psxexe/psxexe.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2015 Dax <trogu.davide@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef PSXEXE_H
 #define PSXEXE_H
 

--- a/librz/bin/format/te/te.h
+++ b/librz/bin/format/te/te.h
@@ -7,8 +7,8 @@
 #include <rz_lib.h>
 #include <rz_bin.h>
 
-#ifndef _INCLUDE_R_BIN_TE_H_
-#define _INCLUDE_R_BIN_TE_H_
+#ifndef _INCLUDE_RZ_BIN_TE_H_
+#define _INCLUDE_RZ_BIN_TE_H_
 
 #define RZ_BIN_TE_SCN_IS_SHAREABLE(x)  x &TE_IMAGE_SCN_MEM_SHARED
 #define RZ_BIN_TE_SCN_IS_EXECUTABLE(x) x &TE_IMAGE_SCN_MEM_EXECUTE

--- a/librz/bin/format/te/te_specs.h
+++ b/librz/bin/format/te/te_specs.h
@@ -11,8 +11,8 @@
 #define TE_DWord ut64
 #define TE_VWord ut32
 
-#ifndef _INCLUDE_R_BIN_TE_SPECS_H_
-#define _INCLUDE_R_BIN_TE_SPECS_H_
+#ifndef _INCLUDE_RZ_BIN_TE_SPECS_H_
+#define _INCLUDE_RZ_BIN_TE_SPECS_H_
 
 #define TE_NAME_LENGTH   256
 #define TE_STRING_LENGTH 256

--- a/librz/bin/format/xbe/xbe.h
+++ b/librz/bin/format/xbe/xbe.h
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2014 LemonBoy <thatlemon@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef _INCLUDE_XBE_H_
+#define _INCLUDE_XBE_H_
 
 #define XBE_MAGIC 0x48454258
 
@@ -71,3 +76,5 @@ typedef struct {
 	int kt_key;
 	int ep_key;
 } rz_bin_xbe_obj_t;
+
+#endif

--- a/librz/bin/format/zimg/zimg.h
+++ b/librz/bin/format/zimg/zimg.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2009-2015 ninjahacker <wardjm@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef ZIMG_H
 #define ZIMG_H
 

--- a/librz/bin/p/bin_xbe.c
+++ b/librz/bin/p/bin_xbe.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2014-2019 thatlemon@gmail.com <thatlemon@gmail.com>
+// SPDX-FileCopyrightText: 2014-2019 LemonBoy <thatlemon@gmail.com>
 // SPDX-FileCopyrightText: 2014-2019 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 

--- a/librz/debug/debug.c
+++ b/librz/debug/debug.c
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2009-2018 pancake <pancake@nopcode.org>
 // SPDX-FileCopyrightText: 2009-2018 jduck <github.jdrake@qoop.org>
-// SPDX-FileCopyrightText: 2009-2018 TheLemonMan <thatlemon@gmail.com>
+// SPDX-FileCopyrightText: 2009-2018 LemonBoy <thatlemon@gmail.com>
 // SPDX-FileCopyrightText: 2009-2018 saucec0de
 // SPDX-License-Identifier: LGPL-3.0-only
 

--- a/librz/debug/p/bfvm.h
+++ b/librz/debug/p/bfvm.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2008-2011 pancake <pancake@nopcode.org>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef _R_BFVM_INCLUDE_
 #define _R_BFVM_INCLUDE_
 

--- a/librz/debug/p/debug_winkd.c
+++ b/librz/debug/p/debug_winkd.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2014-2017 The Lemon Man
+// SPDX-FileCopyrightText: 2014-2017 LemonBoy
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_debug.h>

--- a/librz/io/p/io_winkd.c
+++ b/librz/io/p/io_winkd.c
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: 2014-2017 The Lemon Man
+// SPDX-FileCopyrightText: 2014-2017 LemonBoy
 // SPDX-License-Identifier: LGPL-3.0-only
 
-// Copyright (c) 2014-2017, The Lemon Man, All rights reserved. LGPLv3
+// Copyright (c) 2014-2017, LemonBoy, All rights reserved. LGPLv3
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/librz/search/regexp.c
+++ b/librz/search/regexp.c
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2008-2020 pancake <pancake@nopcode.org>
-// SPDX-FileCopyrightText: 2008-2020 TheLemonMan <thatlemon@gmail.com>
+// SPDX-FileCopyrightText: 2008-2020 LemonBoy <thatlemon@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include "rz_search.h"

--- a/librz/util/utf8.c
+++ b/librz/util/utf8.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2014-2018 thelemon <thatlemon@gmail.com>
+// SPDX-FileCopyrightText: 2014-2018 LemonBoy <thatlemon@gmail.com>
 // SPDX-FileCopyrightText: 2014-2018 kazarmy <kazarmy@gmail.com>
 // SPDX-FileCopyrightText: 2014-2018 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only

--- a/shlr/winkd/iob_pipe.c
+++ b/shlr/winkd/iob_pipe.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2014-2017 The Lemon Man <thatlemon@gmail.com>
+// SPDX-FileCopyrightText: 2014-2017 LemonBoy <thatlemon@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 #include <fcntl.h>
 #include <stdio.h>

--- a/shlr/winkd/kd.c
+++ b/shlr/winkd/kd.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2014-2017 The Lemon Man <thatlemon@gmail.com>
+// SPDX-FileCopyrightText: 2014-2017 LemonBoy <thatlemon@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 #include <stdio.h>
 #include <stdlib.h>

--- a/shlr/winkd/kd.h
+++ b/shlr/winkd/kd.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2014-2017 The Lemon Man <thatlemon@gmail.com>
+// SPDX-FileCopyrightText: 2014-2017 LemonBoy <thatlemon@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #ifndef KD_H

--- a/shlr/winkd/transport.c
+++ b/shlr/winkd/transport.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2014-2017 The Lemon Man <thatlemon@gmail.com>
+// SPDX-FileCopyrightText: 2014-2017 LemonBoy <thatlemon@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_util.h>

--- a/shlr/winkd/transport.h
+++ b/shlr/winkd/transport.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2014-2017 The Lemon Man <thatlemon@gmail.com>
+// SPDX-FileCopyrightText: 2014-2017 LemonBoy <thatlemon@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #ifndef _TRANSPORT_H_

--- a/shlr/winkd/winkd.c
+++ b/shlr/winkd/winkd.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2014-2017 The Lemon Man <thatlemon@gmail.com>
+// SPDX-FileCopyrightText: 2014-2017 LemonBoy <thatlemon@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 #include <stdio.h>
 #include <stdarg.h>

--- a/shlr/winkd/winkd.h
+++ b/shlr/winkd/winkd.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2014-2017 The Lemon Man <thatlemon@gmail.com>
+// SPDX-FileCopyrightText: 2014-2017 LemonBoy <thatlemon@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #ifndef _winkd_H_

--- a/test/unit/test_inflate_deflate.c
+++ b/test/unit/test_inflate_deflate.c
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2021 Dhruv Maroo <dhruvmaru007@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include <rz_util.h>
 #include "minunit.h"
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

More fixes to improve the reuse lint score.
Added copyrights are based on the git history of Rizin and Radare2.

Also fixed the name of https://github.com/LemonBoy everywhere to be the same.

Was:
```
* Files with copyright information: 3072 / 3114
* Files with license information: 3072 / 3114
```

Now:
```
* Files with copyright information: 3099 / 3114
* Files with license information: 3099 / 3114
```

**Test plan**

CI is green

**Closing issues**

Partially addresses #683
