### PR TITLE
Removed unused is_java_lang

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -3593,18 +3593,6 @@ static void classdump_java(RzCore *r, RzBinClass *c) {
 	rz_cons_printf("}\n\n");
 }
 
-static inline bool is_java_lang(RzBinFile *bf) {
-	if (!bf || !bf->o) {
-		return false;
-	} else if (bf->o->lang == RZ_BIN_NM_JAVA) {
-		return true;
-	} else if (!bf->o->info || !bf->o->info->lang) {
-		return false;
-	}
-	const char *lang = bf->o->info->lang;
-	return strstr(lang, "dalvik") || strstr(lang, "java") || strstr(lang, "kotlin");
-}
-
 static void bin_class_print_rizin(RzCore *r, RzBinClass *c, ut64 at_min) {
 	RzListIter *iter2;
 	RzBinFile *bf = rz_bin_cur(r->bin);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes a warning on *BSD systems