### PR TITLE
Fixes for types serialization and deserialization

### DIFF
--- a/librz/analysis/serialize_analysis.c
+++ b/librz/analysis/serialize_analysis.c
@@ -2259,6 +2259,12 @@ RZ_API bool rz_serialize_analysis_load(RZ_NONNULL Sdb *db, RZ_NONNULL RzAnalysis
 	SUB("xrefs", rz_serialize_analysis_xrefs_load(subdb, analysis, res));
 
 	SUB("blocks", rz_serialize_analysis_blocks_load(subdb, analysis, diff_parser, res));
+
+	SUB("classes", rz_serialize_analysis_classes_load(subdb, analysis, res));
+	SUB("types", rz_serialize_analysis_types_load(subdb, analysis, res));
+	SUB("callables", rz_serialize_analysis_callables_load(subdb, analysis, res));
+	SUB("typelinks", rz_serialize_analysis_typelinks_load(subdb, analysis, res));
+
 	// All bbs have ref=1 now
 	SUB("functions", rz_serialize_analysis_functions_load(subdb, analysis, diff_parser, res));
 	SUB("noreturn", rz_serialize_analysis_function_noreturn_load(subdb, analysis, res));
@@ -2281,10 +2287,6 @@ RZ_API bool rz_serialize_analysis_load(RZ_NONNULL Sdb *db, RZ_NONNULL RzAnalysis
 
 	SUB("meta", rz_serialize_analysis_meta_load(subdb, analysis, res));
 	SUB("hints", rz_serialize_analysis_hints_load(subdb, analysis, res));
-	SUB("classes", rz_serialize_analysis_classes_load(subdb, analysis, res));
-	SUB("types", rz_serialize_analysis_types_load(subdb, analysis, res));
-	SUB("callables", rz_serialize_analysis_callables_load(subdb, analysis, res));
-	SUB("typelinks", rz_serialize_analysis_typelinks_load(subdb, analysis, res));
 	SUB("zigns", rz_serialize_analysis_sign_load(subdb, analysis, res));
 	SUB("imports", rz_serialize_analysis_imports_load(subdb, analysis, res));
 	SUB("pins", rz_serialize_analysis_pin_load(subdb, analysis, res));

--- a/librz/include/rz_project.h
+++ b/librz/include/rz_project.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-#define RZ_PROJECT_VERSION 4
+#define RZ_PROJECT_VERSION 5
 
 typedef Sdb RzProject;
 

--- a/librz/type/serialize_types.c
+++ b/librz/type/serialize_types.c
@@ -525,7 +525,7 @@ static void save_atomic_type(const RzTypeDB *typedb, Sdb *sdb, const RzBaseType 
 		rz_strbuf_setf(&key, "type.%s.typeclass", sname),
 		rz_type_typeclass_as_string(get_base_type_typeclass(type)), 0);
 
-	const char *typefmt = rz_type_format(typedb, sname);
+	const char *typefmt = rz_type_db_format_get(typedb, sname);
 	sdb_set(sdb,
 		rz_strbuf_setf(&key, "type.%s", sname),
 		typefmt, 0);

--- a/librz/type/type.c
+++ b/librz/type/type.c
@@ -253,14 +253,33 @@ RZ_API void rz_type_db_init(RzTypeDB *typedb, const char *dir_prefix, const char
 		RZ_LOG_DEBUG("types: loaded \"%s\"\n", dbpath);
 	}
 
-	// We do not load further if architecture or bits are not specified
-	if (!arch || bits <= 0) {
+	// We do not load further if bits are not specified
+	if (bits <= 0) {
+		return;
+	}
+
+	// Bits-specific types that are independent from architecture or OS
+	dbpath = sdb_fmt(RZ_JOIN_3_PATHS("%s", RZ_SDB_TYPES, "types-%d.sdb"),
+		dir_prefix, bits);
+	if (rz_type_db_load_sdb(typedb, dbpath)) {
+		RZ_LOG_DEBUG("types: loaded \"%s\"\n", dbpath);
+	}
+
+	// We do not load further if architecture is not specified
+	if (!arch) {
 		return;
 	}
 
 	// Architecture-specific types
 	dbpath = sdb_fmt(RZ_JOIN_3_PATHS("%s", RZ_SDB_TYPES, "types-%s.sdb"),
 		dir_prefix, arch);
+	if (rz_type_db_load_sdb(typedb, dbpath)) {
+		RZ_LOG_DEBUG("types: loaded \"%s\"\n", dbpath);
+	}
+
+	// Architecture- and bits-specific types
+	dbpath = sdb_fmt(RZ_JOIN_3_PATHS("%s", RZ_SDB_TYPES, "types-%s-%d.sdb"),
+		dir_prefix, arch, bits);
 	if (rz_type_db_load_sdb(typedb, dbpath)) {
 		RZ_LOG_DEBUG("types: loaded \"%s\"\n", dbpath);
 	}
@@ -272,18 +291,8 @@ RZ_API void rz_type_db_init(RzTypeDB *typedb, const char *dir_prefix, const char
 		if (rz_type_db_load_sdb(typedb, dbpath)) {
 			RZ_LOG_DEBUG("types: loaded \"%s\"\n", dbpath);
 		}
-		dbpath = sdb_fmt(RZ_JOIN_3_PATHS("%s", RZ_SDB_TYPES, "types-%d.sdb"),
-			dir_prefix, bits);
-		if (rz_type_db_load_sdb(typedb, dbpath)) {
-			RZ_LOG_DEBUG("types: loaded \"%s\"\n", dbpath);
-		}
 		dbpath = sdb_fmt(RZ_JOIN_3_PATHS("%s", RZ_SDB_TYPES, "types-%s-%d.sdb"),
 			dir_prefix, os, bits);
-		if (rz_type_db_load_sdb(typedb, dbpath)) {
-			RZ_LOG_DEBUG("types: loaded \"%s\"\n", dbpath);
-		}
-		dbpath = sdb_fmt(RZ_JOIN_3_PATHS("%s", RZ_SDB_TYPES, "types-%s-%d.sdb"),
-			dir_prefix, arch, bits);
 		if (rz_type_db_load_sdb(typedb, dbpath)) {
 			RZ_LOG_DEBUG("types: loaded \"%s\"\n", dbpath);
 		}

--- a/test/db/cmd/project
+++ b/test/db/cmd/project
@@ -376,5 +376,6 @@ Detailed project load info:
   project migrated from version 1 to 2.
   project migrated from version 2 to 3.
   project migrated from version 3 to 4.
+  project migrated from version 4 to 5.
 EOF
 RUN

--- a/test/unit/test_project_migrate.c
+++ b/test/unit/test_project_migrate.c
@@ -95,10 +95,11 @@ bool test_load_v1_noreturn() {
 	mu_assert_notnull(res, "result info new");
 	RzProjectErr err = rz_project_load_file(core, "prj/v1-noreturn.rzdb", true, res);
 	mu_assert_eq(err, RZ_PROJECT_ERR_SUCCESS, "project load err");
-	mu_assert_eq(rz_list_length(res), 3, "info");
+	mu_assert_eq(rz_list_length(res), 4, "info");
 	mu_assert_streq(rz_list_get_n(res, 0), "project migrated from version 1 to 2.", "info");
 	mu_assert_streq(rz_list_get_n(res, 1), "project migrated from version 2 to 3.", "info");
 	mu_assert_streq(rz_list_get_n(res, 2), "project migrated from version 3 to 4.", "info");
+	mu_assert_streq(rz_list_get_n(res, 3), "project migrated from version 4 to 5.", "info");
 
 	mu_assert_true(rz_analysis_noreturn_at_addr(core->analysis, 0x4242), "noreturn");
 	mu_assert_true(rz_analysis_noreturn_at_addr(core->analysis, 0x1337), "noreturn");
@@ -116,14 +117,39 @@ bool test_load_v1_noreturn_empty() {
 	mu_assert_notnull(res, "result info new");
 	RzProjectErr err = rz_project_load_file(core, "prj/v1-noreturn-empty.rzdb", true, res);
 	mu_assert_eq(err, RZ_PROJECT_ERR_SUCCESS, "project load err");
-	mu_assert_eq(rz_list_length(res), 3, "info");
+	mu_assert_eq(rz_list_length(res), 4, "info");
 	mu_assert_streq(rz_list_get_n(res, 0), "project migrated from version 1 to 2.", "info");
 	mu_assert_streq(rz_list_get_n(res, 1), "project migrated from version 2 to 3.", "info");
 	mu_assert_streq(rz_list_get_n(res, 2), "project migrated from version 3 to 4.", "info");
+	mu_assert_streq(rz_list_get_n(res, 3), "project migrated from version 4 to 5.", "info");
 
 	mu_assert_false(rz_analysis_noreturn_at_addr(core->analysis, 0x4242), "nono");
 	mu_assert_false(rz_analysis_noreturn_at_addr(core->analysis, 0x1337), "nono");
 	mu_assert_false(rz_analysis_noreturn_at_addr(core->analysis, 0x12345), "nono");
+
+	rz_serialize_result_info_free(res);
+
+	rz_core_free(core);
+	mu_end;
+}
+
+bool test_load_v1_unknown_type() {
+	RzCore *core = rz_core_new();
+	RzSerializeResultInfo *res = rz_serialize_result_info_new();
+	mu_assert_notnull(res, "result info new");
+	RzProjectErr err = rz_project_load_file(core, "prj/v1-noreturn.rzdb", true, res);
+	mu_assert_eq(err, RZ_PROJECT_ERR_SUCCESS, "project load err");
+	mu_assert_eq(rz_list_length(res), 4, "info");
+	mu_assert_streq(rz_list_get_n(res, 0), "project migrated from version 1 to 2.", "info");
+	mu_assert_streq(rz_list_get_n(res, 1), "project migrated from version 2 to 3.", "info");
+	mu_assert_streq(rz_list_get_n(res, 2), "project migrated from version 3 to 4.", "info");
+	mu_assert_streq(rz_list_get_n(res, 3), "project migrated from version 4 to 5.", "info");
+
+	mu_assert_true(rz_type_exists(core->analysis->typedb, "unknown_t"), "has unknown_t");
+	RzBaseType *unknown = rz_type_db_get_base_type(core->analysis->typedb, "unknown_t");
+	mu_assert_notnull(unknown, "has unknown_t");
+	mu_assert_eq(RZ_BASE_TYPE_KIND_ATOMIC, unknown->kind, "unknown_t is atomic");
+	mu_assert_eq(32, unknown->size, "unknown_t is 32-bit wide");
 
 	rz_serialize_result_info_free(res);
 
@@ -137,9 +163,10 @@ bool test_load_v2_typelink() {
 	mu_assert_notnull(res, "result info new");
 	RzProjectErr err = rz_project_load_file(core, "prj/v2-typelink-callables.rzdb", true, res);
 	mu_assert_eq(err, RZ_PROJECT_ERR_SUCCESS, "project load err");
-	mu_assert_eq(rz_list_length(res), 2, "info");
+	mu_assert_eq(rz_list_length(res), 3, "info");
 	mu_assert_streq(rz_list_get_n(res, 0), "project migrated from version 2 to 3.", "info");
 	mu_assert_streq(rz_list_get_n(res, 1), "project migrated from version 3 to 4.", "info");
+	mu_assert_streq(rz_list_get_n(res, 2), "project migrated from version 4 to 5.", "info");
 
 	mu_assert_true(rz_analysis_type_link_exists(core->analysis, 0x80484b0), "has typelink");
 	RzType *typelink = rz_analysis_type_link_at(core->analysis, 0x80484b0);
@@ -159,9 +186,10 @@ bool test_load_v2_callables() {
 	mu_assert_notnull(res, "result info new");
 	RzProjectErr err = rz_project_load_file(core, "prj/v2-typelink-callables.rzdb", true, res);
 	mu_assert_eq(err, RZ_PROJECT_ERR_SUCCESS, "project load err");
-	mu_assert_eq(rz_list_length(res), 2, "info");
+	mu_assert_eq(rz_list_length(res), 3, "info");
 	mu_assert_streq(rz_list_get_n(res, 0), "project migrated from version 2 to 3.", "info");
 	mu_assert_streq(rz_list_get_n(res, 1), "project migrated from version 3 to 4.", "info");
+	mu_assert_streq(rz_list_get_n(res, 2), "project migrated from version 4 to 5.", "info");
 
 	RzAnalysisFunction *fcn = rz_analysis_get_function_byname(core->analysis, "entry0");
 	mu_assert_notnull(fcn, "find \"entry0\" function");
@@ -194,6 +222,7 @@ int all_tests() {
 	mu_run_test(test_migrate_v2_v3);
 	mu_run_test(test_load_v1_noreturn);
 	mu_run_test(test_load_v1_noreturn_empty);
+	mu_run_test(test_load_v1_unknown_type);
 	mu_run_test(test_load_v2_callables);
 	mu_run_test(test_load_v2_typelink);
 	return tests_passed != tests_run;


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes three bugs:
1. Atomic type formats were saved as `type.bool=b bool bool` while it should be `type.bool=b`
2. Bit-specific types (`types-16.sdb` for example) were loaded only if `arch` was defined as well, we fix the order now.
3. Functions were loaded before types, which produced an error if function local variable used type defined in the `/core/analysis/types` project section.

**Test plan**

CI is green

**Closing issues**

Fixes https://github.com/rizinorg/rizin/issues/1560
