### PR TITLE
Fixed OOB read in mach0.c

### DIFF
--- a/librz/bin/format/mach0/mach0.c
+++ b/librz/bin/format/mach0/mach0.c
@@ -3070,7 +3070,7 @@ const struct symbol_t *MACH0_(get_symbols)(struct MACH0_(obj_t) * bin) {
 			}
 		}
 
-		for (i = 0; i < bin->nsymtab; i++) {
+		for (i = 0; i < bin->nsymtab && i < symbols_count; i++) {
 			struct MACH0_(nlist) *st = &bin->symtab[i];
 			if (st->n_type & N_STAB) {
 				continue;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Out of bound read in `mach0.c`