### PR TITLE
Use source_fallback_url when failing

### DIFF
--- a/subprojects/libuv.wrap
+++ b/subprojects/libuv.wrap
@@ -1,8 +1,9 @@
 [wrap-file]
 directory = libuv-v1.40.0
 
-source_url = https://dist.libuv.org/dist/v1.40.0/libuv-v1.40.0.tar.gz
+source_url = https://github.com/rizinorg/fallback-repo/raw/main/libuv-v1.40.0.tar.gz
 source_filename = libuv-v1.40.0.tar.gz
 source_hash = 61a90db95bac00adec1cc5ddc767ebbcaabc70242bd1134a7a6b1fb1d498a194
+source_fallback_url = https://dist.libuv.org/dist/v1.40.0/libuv-v1.40.0.tar.gz
 
 patch_directory = libuv-v1.40.0

--- a/subprojects/lz4.wrap
+++ b/subprojects/lz4.wrap
@@ -4,3 +4,4 @@ source_url = https://github.com/lz4/lz4/archive/v1.9.3.tar.gz
 source_filename = lz4-1.9.3.tgz
 source_hash = 030644df4611007ff7dc962d981f390361e6c97a34e5cbc393ddfbe019ffe2c1
 patch_directory = lz4-1.9.3
+source_fallback_url = https://github.com/rizinorg/fallback-repo/raw/main/lz4-1.9.3.tgz

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,6 +1,7 @@
 [wrap-file]
 directory = zlib-1.2.11
-source_url = https://zlib.net/fossils/zlib-1.2.11.tar.gz
+source_url = https://github.com/rizinorg/fallback-repo/raw/main/zlib-1.2.11.tar.gz
 source_filename = zlib-1.2.11.tar.gz
 source_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
 patch_directory = zlib-1.2.11
+source_fallback_url = https://zlib.net/fossils/zlib-1.2.11.tar.gz


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Too many failures due resources not being available, therefore before is better to use github CDN then the real resource as fallback