### PR TITLE
Fix type name parsing in `tc` and `tcd`

### DIFF
--- a/librz/core/cmd_type.c
+++ b/librz/core/cmd_type.c
@@ -17,7 +17,7 @@ static void types_cc_print(RzCore *core, const char *cc, RzOutputMode mode) {
 	rz_return_if_fail(cc);
 	if (strchr(cc, '(')) {
 		if (!rz_analysis_cc_set(core->analysis, cc)) {
-			eprintf("Invalid syntax in cc signature.");
+			RZ_LOG_ERROR("Invalid syntax in cc signature.");
 		}
 	} else {
 		const char *ccname = rz_str_trim_head_ro(cc);
@@ -45,7 +45,7 @@ static RzCmdStatus types_enum_member_find(RzCore *core, const char *enum_name, c
 	ut64 value = rz_num_math(core->num, enum_value);
 	char *enum_member = rz_type_db_enum_member_by_val(core->analysis->typedb, enum_name, value);
 	if (!enum_member) {
-		eprintf("Cannot find matching enum member");
+		RZ_LOG_ERROR("Cannot find matching enum member");
 		return RZ_CMD_STATUS_ERROR;
 	}
 	rz_cons_println(enum_member);
@@ -58,7 +58,7 @@ static RzCmdStatus types_enum_member_find_all(RzCore *core, const char *enum_val
 	ut64 value = rz_num_math(core->num, enum_value);
 	RzList *matches = rz_type_db_find_enums_by_val(core->analysis->typedb, value);
 	if (!matches || rz_list_empty(matches)) {
-		eprintf("Cannot find matching enum member");
+		RZ_LOG_ERROR("Cannot find matching enum member");
 		return RZ_CMD_STATUS_ERROR;
 	}
 	RzListIter *iter;
@@ -70,25 +70,34 @@ static RzCmdStatus types_enum_member_find_all(RzCore *core, const char *enum_val
 	return RZ_CMD_STATUS_OK;
 }
 
-static bool print_type_c(RzCore *core, const char *ctype, bool multiline) {
-	const char *type = rz_str_trim_head_ro(ctype);
-	const char *name = type ? strchr(type, ' ') : NULL;
-	if (name && type) {
-		name++; // skip the ' ' (space)
-		if (rz_str_startswith(type, "struct")) {
-			rz_core_types_struct_print_c(core->analysis->typedb, name, multiline);
-		} else if (rz_str_startswith(type, "union")) {
-			rz_core_types_union_print_c(core->analysis->typedb, name, multiline);
-		} else if (rz_str_startswith(type, "enum")) {
-			rz_core_types_enum_print_c(core->analysis->typedb, name, multiline);
-		} else if (rz_str_startswith(type, "func")) {
-			rz_types_function_print(core->analysis->typedb, name, RZ_OUTPUT_MODE_STANDARD, NULL);
-		} else {
-			rz_core_types_typedef_print_c(core->analysis->typedb, name);
-		}
-		return true;
+static bool print_type_c(RzCore *core, const char *name, bool multiline) {
+	rz_return_val_if_fail(name, false);
+
+	RzBaseType *btype = rz_type_db_get_base_type(core->analysis->typedb, name);
+	if (!btype) {
+		return false;
 	}
-	return false;
+	switch (btype->kind) {
+	case RZ_BASE_TYPE_KIND_STRUCT:
+		rz_core_types_struct_print_c(core->analysis->typedb, btype, multiline);
+		break;
+	case RZ_BASE_TYPE_KIND_UNION:
+		rz_core_types_union_print_c(core->analysis->typedb, btype, multiline);
+		break;
+	case RZ_BASE_TYPE_KIND_ENUM:
+		rz_core_types_enum_print_c(core->analysis->typedb, btype, multiline);
+		break;
+	case RZ_BASE_TYPE_KIND_TYPEDEF:
+		rz_core_types_typedef_print_c(core->analysis->typedb, btype);
+		break;
+	case RZ_BASE_TYPE_KIND_ATOMIC:
+		rz_cons_println(name);
+		break;
+	default:
+		rz_warn_if_reached();
+		return false;
+	}
+	return true;
 }
 
 static void type_list_c_all(RzCore *core) {
@@ -116,7 +125,7 @@ static void type_list_c_all_nl(RzCore *core) {
 static RzCmdStatus type_format_print(RzCore *core, const char *type, ut64 address) {
 	char *fmt = rz_type_format(core->analysis->typedb, type);
 	if (RZ_STR_ISEMPTY(fmt)) {
-		eprintf("Cannot find type %s\n", type);
+		RZ_LOG_ERROR("Cannot find type %s\n", type);
 		free(fmt);
 		return RZ_CMD_STATUS_ERROR;
 	}
@@ -128,19 +137,19 @@ static RzCmdStatus type_format_print(RzCore *core, const char *type, ut64 addres
 static RzCmdStatus type_format_print_variable(RzCore *core, const char *type, const char *varname) {
 	char *fmt = rz_type_format(core->analysis->typedb, type);
 	if (RZ_STR_ISEMPTY(fmt)) {
-		eprintf("Cannot find type \"%s\"\n", type);
+		RZ_LOG_ERROR("Cannot find type \"%s\"\n", type);
 		free(fmt);
 		return RZ_CMD_STATUS_ERROR;
 	}
 	RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(core->analysis, core->offset, -1);
 	if (!fcn) {
-		eprintf("Cannot find function at the current offset\n");
+		RZ_LOG_ERROR("Cannot find function at the current offset\n");
 		free(fmt);
 		return RZ_CMD_STATUS_ERROR;
 	}
 	RzAnalysisVar *var = rz_analysis_function_get_var_byname(fcn, varname);
 	if (!var) {
-		eprintf("Cannot find variable \"%s\" in the current function\n", varname);
+		RZ_LOG_ERROR("Cannot find variable \"%s\" in the current function\n", varname);
 		free(fmt);
 		return RZ_CMD_STATUS_ERROR;
 	}
@@ -153,7 +162,7 @@ static RzCmdStatus type_format_print_variable(RzCore *core, const char *type, co
 static RzCmdStatus type_format_print_value(RzCore *core, const char *type, ut64 val) {
 	char *fmt = rz_type_format(core->analysis->typedb, type);
 	if (RZ_STR_ISEMPTY(fmt)) {
-		eprintf("Cannot find type %s\n", type);
+		RZ_LOG_ERROR("Cannot find type %s\n", type);
 		free(fmt);
 		return RZ_CMD_STATUS_ERROR;
 	}
@@ -165,7 +174,7 @@ static RzCmdStatus type_format_print_value(RzCore *core, const char *type, ut64 
 static RzCmdStatus type_format_print_hexstring(RzCore *core, const char *type, const char *hexpairs) {
 	char *fmt = rz_type_format(core->analysis->typedb, type);
 	if (RZ_STR_ISEMPTY(fmt)) {
-		eprintf("Cannot find type %s\n", type);
+		RZ_LOG_ERROR("Cannot find type %s\n", type);
 		free(fmt);
 		return RZ_CMD_STATUS_ERROR;
 	}
@@ -179,7 +188,7 @@ static void types_xrefs(RzCore *core, const char *typestr) {
 	RzType *type = rz_type_parse_string_single(core->analysis->typedb->parser, typestr, &error_msg);
 	if (!type || error_msg) {
 		if (error_msg) {
-			eprintf("%s", error_msg);
+			RZ_LOG_ERROR("%s", error_msg);
 			free(error_msg);
 		}
 		return;
@@ -218,7 +227,7 @@ static RzCmdStatus types_xrefs_function(RzCore *core, ut64 addr) {
 	RzListIter *iter;
 	RzAnalysisFunction *fcn = rz_analysis_get_function_at(core->analysis, addr);
 	if (!fcn) {
-		eprintf("Cannot find function at 0x%08" PFMT64x "\n", addr);
+		RZ_LOG_ERROR("Cannot find function at 0x%08" PFMT64x "\n", addr);
 		return RZ_CMD_STATUS_ERROR;
 	}
 	RzList *uniq = rz_analysis_types_from_fcn(core->analysis, fcn);
@@ -318,7 +327,7 @@ RZ_IPI RzCmdStatus rz_type_cc_del_all_handler(RzCore *core, int argc, const char
 RZ_IPI RzCmdStatus rz_type_list_c_handler(RzCore *core, int argc, const char **argv) {
 	if (argc > 1) {
 		if (!print_type_c(core, argv[1], true)) {
-			printf("Wrong type syntax");
+			RZ_LOG_ERROR("Type \"%s\" not found\n", argv[1]);
 			return RZ_CMD_STATUS_ERROR;
 		}
 	} else {
@@ -330,7 +339,7 @@ RZ_IPI RzCmdStatus rz_type_list_c_handler(RzCore *core, int argc, const char **a
 RZ_IPI RzCmdStatus rz_type_list_c_nl_handler(RzCore *core, int argc, const char **argv) {
 	if (argc > 1) {
 		if (!print_type_c(core, argv[1], false)) {
-			eprintf("Wrong type syntax");
+			RZ_LOG_ERROR("Type \"%s\" not found\n", argv[1]);
 			return RZ_CMD_STATUS_ERROR;
 		}
 	} else {
@@ -346,15 +355,18 @@ RZ_IPI RzCmdStatus rz_type_define_handler(RzCore *core, int argc, const char **a
 }
 
 RZ_IPI RzCmdStatus rz_type_list_enum_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
-	const char *enum_name = argc > 1 ? argv[1] : NULL;
-	// TODO: Reconsider the `te <enum_name> <member_value>` syntax change
-	const char *member_value = argc > 2 ? argv[2] : NULL;
-	if (enum_name) {
-		if (member_value) {
-			return types_enum_member_find(core, enum_name, member_value);
+	if (argc > 1) {
+		if (argc > 2) {
+			// TODO: Reconsider the `te <enum_name> <member_value>` syntax change
+			return types_enum_member_find(core, argv[1], argv[2]);
 		} else {
 			PJ *pj = (mode == RZ_OUTPUT_MODE_JSON) ? pj_new() : NULL;
-			rz_core_types_enum_print(core, enum_name, mode, pj);
+			RzBaseType *btype = rz_type_db_get_enum(core->analysis->typedb, argv[1]);
+			if (!btype) {
+				RZ_LOG_ERROR("Cannot find \"%s\" enum type\n", argv[1]);
+				return RZ_CMD_STATUS_ERROR;
+			}
+			rz_core_types_enum_print(core, btype, mode, pj);
 			if (mode == RZ_OUTPUT_MODE_JSON) {
 				rz_cons_println(pj_string(pj));
 				pj_free(pj);
@@ -375,7 +387,7 @@ RZ_IPI RzCmdStatus rz_type_enum_bitfield_handler(RzCore *core, int argc, const c
 	const char *enum_member = argc > 2 ? argv[2] : NULL;
 	int value = rz_type_db_enum_member_by_name(core->analysis->typedb, enum_name, enum_member);
 	if (value == -1) {
-		eprintf("Cannot find anything matching the specified bitfield");
+		RZ_LOG_ERROR("Cannot find anything matching the specified bitfield");
 		return RZ_CMD_STATUS_ERROR;
 	}
 	rz_cons_printf("0x%x\n", value);
@@ -384,7 +396,12 @@ RZ_IPI RzCmdStatus rz_type_enum_bitfield_handler(RzCore *core, int argc, const c
 
 RZ_IPI RzCmdStatus rz_type_enum_c_handler(RzCore *core, int argc, const char **argv) {
 	if (argc > 1) {
-		rz_core_types_enum_print_c(core->analysis->typedb, argv[1], true);
+		RzBaseType *btype = rz_type_db_get_enum(core->analysis->typedb, argv[1]);
+		if (!btype) {
+			RZ_LOG_ERROR("Cannot find \"%s\" enum type\n", argv[1]);
+			return RZ_CMD_STATUS_ERROR;
+		}
+		rz_core_types_enum_print_c(core->analysis->typedb, btype, true);
 	} else {
 		rz_core_types_enum_print_c_all(core->analysis->typedb, true);
 	}
@@ -393,7 +410,12 @@ RZ_IPI RzCmdStatus rz_type_enum_c_handler(RzCore *core, int argc, const char **a
 
 RZ_IPI RzCmdStatus rz_type_enum_c_nl_handler(RzCore *core, int argc, const char **argv) {
 	if (argc > 1) {
-		rz_core_types_enum_print_c(core->analysis->typedb, argv[1], false);
+		RzBaseType *btype = rz_type_db_get_enum(core->analysis->typedb, argv[1]);
+		if (!btype) {
+			RZ_LOG_ERROR("Cannot find \"%s\" enum type\n", argv[1]);
+			return RZ_CMD_STATUS_ERROR;
+		}
+		rz_core_types_enum_print_c(core->analysis->typedb, btype, false);
 	} else {
 		rz_core_types_enum_print_c_all(core->analysis->typedb, false);
 	}
@@ -409,7 +431,7 @@ RZ_IPI RzCmdStatus rz_type_list_function_handler(RzCore *core, int argc, const c
 	const char *function = argc > 1 ? argv[1] : NULL;
 	if (function) {
 		PJ *pj = (mode == RZ_OUTPUT_MODE_JSON) ? pj_new() : NULL;
-		rz_types_function_print(core->analysis->typedb, function, mode, pj);
+		rz_core_types_function_print(core->analysis->typedb, function, mode, pj);
 		if (mode == RZ_OUTPUT_MODE_JSON) {
 			rz_cons_println(pj_string(pj));
 			pj_free(pj);
@@ -433,13 +455,13 @@ RZ_IPI RzCmdStatus rz_type_function_del_all_handler(RzCore *core, int argc, cons
 RZ_IPI RzCmdStatus rz_type_function_cc_handler(RzCore *core, int argc, const char **argv) {
 	if (argc > 2) {
 		if (!rz_type_func_cc_set(core->analysis->typedb, argv[1], argv[2])) {
-			eprintf("Cannot set function \"%s\" calling convention \"%s\"\n", argv[1], argv[2]);
+			RZ_LOG_ERROR("Cannot set function \"%s\" calling convention \"%s\"\n", argv[1], argv[2]);
 			return RZ_CMD_STATUS_ERROR;
 		}
 	} else {
 		const char *cc = rz_type_func_cc(core->analysis->typedb, argv[1]);
 		if (!cc) {
-			eprintf("Cannot find function \"%s\" in types database\n", argv[1]);
+			RZ_LOG_ERROR("Cannot find function \"%s\" in types database\n", argv[1]);
 			return RZ_CMD_STATUS_ERROR;
 		}
 		rz_cons_println(cc);
@@ -550,13 +572,17 @@ RZ_IPI RzCmdStatus rz_type_print_hexstring_handler(RzCore *core, int argc, const
 }
 
 RZ_IPI RzCmdStatus rz_type_list_structure_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
-	const char *typename = argc > 1 ? argv[1] : NULL;
-	if (typename) {
+	if (argc > 1) {
 		if (mode == RZ_OUTPUT_MODE_STANDARD) {
-			rz_core_types_show_format(core, typename, mode);
+			rz_core_types_show_format(core, argv[1], mode);
 		} else {
 			PJ *pj = (mode == RZ_OUTPUT_MODE_JSON) ? pj_new() : NULL;
-			rz_core_types_struct_print(core, typename, mode, pj);
+			RzBaseType *btype = rz_type_db_get_struct(core->analysis->typedb, argv[1]);
+			if (!btype) {
+				RZ_LOG_ERROR("Cannot find \"%s\" struct type\n", argv[1]);
+				return RZ_CMD_STATUS_ERROR;
+			}
+			rz_core_types_struct_print(core, btype, mode, pj);
 			if (mode == RZ_OUTPUT_MODE_JSON) {
 				rz_cons_println(pj_string(pj));
 				pj_free(pj);
@@ -574,7 +600,12 @@ RZ_IPI RzCmdStatus rz_type_list_structure_handler(RzCore *core, int argc, const 
 
 RZ_IPI RzCmdStatus rz_type_structure_c_handler(RzCore *core, int argc, const char **argv) {
 	if (argc > 1) {
-		rz_core_types_struct_print_c(core->analysis->typedb, argv[1], true);
+		RzBaseType *btype = rz_type_db_get_struct(core->analysis->typedb, argv[1]);
+		if (!btype) {
+			RZ_LOG_ERROR("Cannot find \"%s\" struct type\n", argv[1]);
+			return RZ_CMD_STATUS_ERROR;
+		}
+		rz_core_types_struct_print_c(core->analysis->typedb, btype, true);
 	} else {
 		rz_core_types_struct_print_c_all(core->analysis->typedb, true);
 	}
@@ -583,7 +614,12 @@ RZ_IPI RzCmdStatus rz_type_structure_c_handler(RzCore *core, int argc, const cha
 
 RZ_IPI RzCmdStatus rz_type_structure_c_nl_handler(RzCore *core, int argc, const char **argv) {
 	if (argc > 1) {
-		rz_core_types_struct_print_c(core->analysis->typedb, argv[1], false);
+		RzBaseType *btype = rz_type_db_get_struct(core->analysis->typedb, argv[1]);
+		if (!btype) {
+			RZ_LOG_ERROR("Cannot find \"%s\" struct type\n", argv[1]);
+			return RZ_CMD_STATUS_ERROR;
+		}
+		rz_core_types_struct_print_c(core->analysis->typedb, btype, false);
 	} else {
 		rz_core_types_struct_print_c_all(core->analysis->typedb, false);
 	}
@@ -591,10 +627,14 @@ RZ_IPI RzCmdStatus rz_type_structure_c_nl_handler(RzCore *core, int argc, const 
 }
 
 RZ_IPI RzCmdStatus rz_type_list_typedef_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
-	const char *typename = argc > 1 ? argv[1] : NULL;
-	if (typename) {
+	if (argc > 1) {
 		PJ *pj = (mode == RZ_OUTPUT_MODE_JSON) ? pj_new() : NULL;
-		rz_core_types_typedef_print(core, typename, mode, pj);
+		RzBaseType *btype = rz_type_db_get_typedef(core->analysis->typedb, argv[1]);
+		if (!btype) {
+			RZ_LOG_ERROR("Cannot find \"%s\" typedef type\n", argv[1]);
+			return RZ_CMD_STATUS_ERROR;
+		}
+		rz_core_types_typedef_print(core, btype, mode, pj);
 		if (mode == RZ_OUTPUT_MODE_JSON) {
 			rz_cons_println(pj_string(pj));
 			pj_free(pj);
@@ -608,7 +648,12 @@ RZ_IPI RzCmdStatus rz_type_list_typedef_handler(RzCore *core, int argc, const ch
 RZ_IPI RzCmdStatus rz_type_typedef_c_handler(RzCore *core, int argc, const char **argv) {
 	RzTypeDB *typedb = core->analysis->typedb;
 	if (argc > 1) {
-		rz_core_types_typedef_print_c(typedb, argv[1]);
+		RzBaseType *btype = rz_type_db_get_typedef(core->analysis->typedb, argv[1]);
+		if (!btype) {
+			RZ_LOG_ERROR("Cannot find \"%s\" typedef type\n", argv[1]);
+			return RZ_CMD_STATUS_ERROR;
+		}
+		rz_core_types_typedef_print_c(typedb, btype);
 	} else {
 		rz_core_types_typedef_print_c_all(typedb);
 	}
@@ -616,13 +661,17 @@ RZ_IPI RzCmdStatus rz_type_typedef_c_handler(RzCore *core, int argc, const char 
 }
 
 RZ_IPI RzCmdStatus rz_type_list_union_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
-	const char *typename = argc > 1 ? argv[1] : NULL;
-	if (typename) {
+	if (argc > 1) {
 		if (mode == RZ_OUTPUT_MODE_STANDARD) {
-			rz_core_types_show_format(core, typename, mode);
+			rz_core_types_show_format(core, argv[1], mode);
 		} else {
 			PJ *pj = (mode == RZ_OUTPUT_MODE_JSON) ? pj_new() : NULL;
-			rz_core_types_union_print(core, typename, mode, pj);
+			RzBaseType *btype = rz_type_db_get_union(core->analysis->typedb, argv[1]);
+			if (!btype) {
+				RZ_LOG_ERROR("Cannot find \"%s\" union type\n", argv[1]);
+				return RZ_CMD_STATUS_ERROR;
+			}
+			rz_core_types_union_print(core, btype, mode, pj);
 			if (mode == RZ_OUTPUT_MODE_JSON) {
 				rz_cons_println(pj_string(pj));
 				pj_free(pj);
@@ -640,7 +689,12 @@ RZ_IPI RzCmdStatus rz_type_list_union_handler(RzCore *core, int argc, const char
 
 RZ_IPI RzCmdStatus rz_type_union_c_handler(RzCore *core, int argc, const char **argv) {
 	if (argc > 1) {
-		rz_core_types_union_print_c(core->analysis->typedb, argv[1], true);
+		RzBaseType *btype = rz_type_db_get_union(core->analysis->typedb, argv[1]);
+		if (!btype) {
+			RZ_LOG_ERROR("Cannot find \"%s\" union type\n", argv[1]);
+			return RZ_CMD_STATUS_ERROR;
+		}
+		rz_core_types_union_print_c(core->analysis->typedb, btype, true);
 	} else {
 		rz_core_types_union_print_c_all(core->analysis->typedb, true);
 	}
@@ -649,7 +703,12 @@ RZ_IPI RzCmdStatus rz_type_union_c_handler(RzCore *core, int argc, const char **
 
 RZ_IPI RzCmdStatus rz_type_union_c_nl_handler(RzCore *core, int argc, const char **argv) {
 	if (argc > 1) {
-		rz_core_types_union_print_c(core->analysis->typedb, argv[1], false);
+		RzBaseType *btype = rz_type_db_get_union(core->analysis->typedb, argv[1]);
+		if (!btype) {
+			RZ_LOG_ERROR("Cannot find \"%s\" union type\n", argv[1]);
+			return RZ_CMD_STATUS_ERROR;
+		}
+		rz_core_types_union_print_c(core->analysis->typedb, btype, false);
 	} else {
 		rz_core_types_union_print_c_all(core->analysis->typedb, false);
 	}

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -45,29 +45,29 @@ RZ_IPI void rz_core_analysis_function_until(RzCore *core, ut64 addr_end);
 RZ_IPI void rz_core_analysis_value_pointers(RzCore *core, RzOutputMode mode);
 
 /* ctypes.c */
-RZ_IPI void rz_core_types_calling_conventions_print(RzCore *core, RzOutputMode mode);
 // Enums
-RZ_IPI void rz_core_types_enum_print(RzCore *core, const char *enum_name, RzOutputMode mode, PJ *pj);
+RZ_IPI void rz_core_types_enum_print(RzCore *core, const RzBaseType *btype, RzOutputMode mode, PJ *pj);
 RZ_IPI void rz_core_types_enum_print_all(RzCore *core, RzOutputMode mode);
-RZ_IPI void rz_core_types_enum_print_c(RzTypeDB *typedb, const char *name, bool multiline);
+RZ_IPI void rz_core_types_enum_print_c(RzTypeDB *typedb, const RzBaseType *btype, bool multiline);
 RZ_IPI void rz_core_types_enum_print_c_all(RzTypeDB *typedb, bool multiline);
 // Unions
-RZ_IPI void rz_core_types_union_print(RzCore *core, const char *name, RzOutputMode mode, PJ *pj);
+RZ_IPI void rz_core_types_union_print(RzCore *core, const RzBaseType *btype, RzOutputMode mode, PJ *pj);
 RZ_IPI void rz_core_types_union_print_all(RzCore *core, RzOutputMode mode);
-RZ_IPI void rz_core_types_union_print_c(RzTypeDB *typedb, const char *name, bool multiline);
+RZ_IPI void rz_core_types_union_print_c(RzTypeDB *typedb, const RzBaseType *btype, bool multiline);
 RZ_IPI void rz_core_types_union_print_c_all(RzTypeDB *typedb, bool multiline);
 // Structs
-RZ_IPI void rz_core_types_struct_print(RzCore *core, const char *name, RzOutputMode mode, PJ *pj);
+RZ_IPI void rz_core_types_struct_print(RzCore *core, const RzBaseType *btype, RzOutputMode mode, PJ *pj);
 RZ_IPI void rz_core_types_struct_print_all(RzCore *core, RzOutputMode mode);
-RZ_IPI void rz_core_types_struct_print_c(RzTypeDB *typedb, const char *name, bool multiline);
+RZ_IPI void rz_core_types_struct_print_c(RzTypeDB *typedb, const RzBaseType *btype, bool multiline);
 RZ_IPI void rz_core_types_struct_print_c_all(RzTypeDB *typedb, bool multiline);
 // Typedefs
-RZ_IPI void rz_core_types_typedef_print(RzCore *core, const char *name, RzOutputMode mode, PJ *pj);
+RZ_IPI void rz_core_types_typedef_print(RzCore *core, const RzBaseType *btype, RzOutputMode mode, PJ *pj);
 RZ_IPI void rz_core_types_typedef_print_all(RzCore *core, RzOutputMode mode);
-RZ_IPI void rz_core_types_typedef_print_c(RzTypeDB *typedb, const char *name);
+RZ_IPI void rz_core_types_typedef_print_c(RzTypeDB *typedb, const RzBaseType *btype);
 RZ_IPI void rz_core_types_typedef_print_c_all(RzTypeDB *typedb);
 
-RZ_IPI void rz_types_function_print(RzTypeDB *typedb, const char *function, RzOutputMode mode, PJ *pj);
+RZ_IPI void rz_core_types_calling_conventions_print(RzCore *core, RzOutputMode mode);
+RZ_IPI void rz_core_types_function_print(RzTypeDB *typedb, const char *function, RzOutputMode mode, PJ *pj);
 RZ_IPI void rz_core_types_function_print_all(RzCore *core, RzOutputMode mode);
 RZ_IPI void rz_core_types_function_noreturn_print(RzCore *core, RzOutputMode mode);
 RZ_IPI void rz_core_types_show_format(RzCore *core, const char *name, RzOutputMode mode);

--- a/librz/core/ctypes.c
+++ b/librz/core/ctypes.c
@@ -65,9 +65,10 @@ RZ_IPI void rz_core_types_calling_conventions_print(RzCore *core, RzOutputMode m
 
 // Enums
 
-static void core_types_enum_print(RzCore *core, RzBaseType *btype, RzOutputMode mode, PJ *pj) {
+RZ_IPI void rz_core_types_enum_print(RzCore *core, const RzBaseType *btype, RzOutputMode mode, PJ *pj) {
 	rz_return_if_fail(core && btype);
 	rz_return_if_fail(btype->kind == RZ_BASE_TYPE_KIND_ENUM);
+
 	switch (mode) {
 	case RZ_OUTPUT_MODE_JSON: {
 		rz_return_if_fail(pj);
@@ -103,16 +104,6 @@ static void core_types_enum_print(RzCore *core, RzBaseType *btype, RzOutputMode 
 	}
 }
 
-RZ_IPI void rz_core_types_enum_print(RzCore *core, const char *name, RzOutputMode mode, PJ *pj) {
-	rz_return_if_fail(name);
-	RzTypeDB *typedb = core->analysis->typedb;
-	RzBaseType *btype = rz_type_db_get_enum(typedb, name);
-	if (!btype) {
-		return;
-	}
-	core_types_enum_print(core, btype, mode, pj);
-}
-
 RZ_IPI void rz_core_types_enum_print_all(RzCore *core, RzOutputMode mode) {
 	RzList *enumlist = rz_type_db_get_base_types_of_kind(core->analysis->typedb, RZ_BASE_TYPE_KIND_ENUM);
 	RzListIter *it;
@@ -122,7 +113,7 @@ RZ_IPI void rz_core_types_enum_print_all(RzCore *core, RzOutputMode mode) {
 	}
 	RzBaseType *btype;
 	rz_list_foreach (enumlist, it, btype) {
-		core_types_enum_print(core, btype, mode, pj);
+		rz_core_types_enum_print(core, btype, mode, pj);
 	}
 	rz_list_free(enumlist);
 	if (mode == RZ_OUTPUT_MODE_JSON) {
@@ -132,9 +123,10 @@ RZ_IPI void rz_core_types_enum_print_all(RzCore *core, RzOutputMode mode) {
 	}
 }
 
-static void core_types_enum_print_c(RzBaseType *btype, bool multiline) {
+RZ_IPI void rz_core_types_enum_print_c(RzTypeDB *typedb, const RzBaseType *btype, bool multiline) {
 	rz_return_if_fail(btype);
 	rz_return_if_fail(btype->kind == RZ_BASE_TYPE_KIND_ENUM);
+
 	char *separator;
 	if (!rz_vector_empty(&btype->enum_data.cases)) {
 		rz_cons_printf("enum %s {%s", btype->name, multiline ? "\n" : "");
@@ -150,29 +142,22 @@ static void core_types_enum_print_c(RzBaseType *btype, bool multiline) {
 	}
 }
 
-RZ_IPI void rz_core_types_enum_print_c(RzTypeDB *typedb, const char *name, bool multiline) {
-	RzBaseType *btype = rz_type_db_get_enum(typedb, name);
-	if (!btype) {
-		return;
-	}
-	core_types_enum_print_c(btype, multiline);
-}
-
 RZ_IPI void rz_core_types_enum_print_c_all(RzTypeDB *typedb, bool multiline) {
 	RzList *enumlist = rz_type_db_get_base_types_of_kind(typedb, RZ_BASE_TYPE_KIND_ENUM);
 	RzListIter *it;
 	RzBaseType *btype;
 	rz_list_foreach (enumlist, it, btype) {
-		core_types_enum_print_c(btype, multiline);
+		rz_core_types_enum_print_c(typedb, btype, multiline);
 	}
 	rz_list_free(enumlist);
 }
 
 // Unions
 
-static void core_types_union_print(RzCore *core, RzBaseType *btype, RzOutputMode mode, PJ *pj) {
+RZ_IPI void rz_core_types_union_print(RzCore *core, const RzBaseType *btype, RzOutputMode mode, PJ *pj) {
 	rz_return_if_fail(core && btype);
 	rz_return_if_fail(btype->kind == RZ_BASE_TYPE_KIND_UNION);
+
 	switch (mode) {
 	case RZ_OUTPUT_MODE_JSON: {
 		rz_return_if_fail(pj);
@@ -215,16 +200,6 @@ static void core_types_union_print(RzCore *core, RzBaseType *btype, RzOutputMode
 	}
 }
 
-RZ_IPI void rz_core_types_union_print(RzCore *core, const char *name, RzOutputMode mode, PJ *pj) {
-	rz_return_if_fail(name);
-	RzTypeDB *typedb = core->analysis->typedb;
-	RzBaseType *btype = rz_type_db_get_union(typedb, name);
-	if (!btype) {
-		return;
-	}
-	core_types_union_print(core, btype, mode, pj);
-}
-
 RZ_IPI void rz_core_types_union_print_all(RzCore *core, RzOutputMode mode) {
 	RzList *unionlist = rz_type_db_get_base_types_of_kind(core->analysis->typedb, RZ_BASE_TYPE_KIND_UNION);
 	RzListIter *it;
@@ -234,7 +209,7 @@ RZ_IPI void rz_core_types_union_print_all(RzCore *core, RzOutputMode mode) {
 	}
 	RzBaseType *btype;
 	rz_list_foreach (unionlist, it, btype) {
-		core_types_union_print(core, btype, mode, pj);
+		rz_core_types_union_print(core, btype, mode, pj);
 	}
 	rz_list_free(unionlist);
 	if (mode == RZ_OUTPUT_MODE_JSON) {
@@ -244,9 +219,10 @@ RZ_IPI void rz_core_types_union_print_all(RzCore *core, RzOutputMode mode) {
 	}
 }
 
-static void core_types_union_print_c(RzTypeDB *typedb, RzBaseType *btype, bool multiline) {
+RZ_IPI void rz_core_types_union_print_c(RzTypeDB *typedb, const RzBaseType *btype, bool multiline) {
 	rz_return_if_fail(btype);
 	rz_return_if_fail(btype->kind == RZ_BASE_TYPE_KIND_UNION);
+
 	char *separator;
 	if (!rz_vector_empty(&btype->enum_data.cases)) {
 		rz_cons_printf("union %s {%s", btype->name, multiline ? "\n" : "");
@@ -279,29 +255,22 @@ static void core_types_union_print_c(RzTypeDB *typedb, RzBaseType *btype, bool m
 	}
 }
 
-RZ_IPI void rz_core_types_union_print_c(RzTypeDB *typedb, const char *name, bool multiline) {
-	RzBaseType *btype = rz_type_db_get_union(typedb, name);
-	if (!btype) {
-		return;
-	}
-	core_types_union_print_c(typedb, btype, multiline);
-}
-
 RZ_IPI void rz_core_types_union_print_c_all(RzTypeDB *typedb, bool multiline) {
 	RzList *unionlist = rz_type_db_get_base_types_of_kind(typedb, RZ_BASE_TYPE_KIND_UNION);
 	RzListIter *it;
 	RzBaseType *btype;
 	rz_list_foreach (unionlist, it, btype) {
-		core_types_union_print_c(typedb, btype, multiline);
+		rz_core_types_union_print_c(typedb, btype, multiline);
 	}
 	rz_list_free(unionlist);
 }
 
 // Structures
 
-static void core_types_struct_print(RzCore *core, RzBaseType *btype, RzOutputMode mode, PJ *pj) {
+RZ_IPI void rz_core_types_struct_print(RzCore *core, const RzBaseType *btype, RzOutputMode mode, PJ *pj) {
 	rz_return_if_fail(core && btype);
 	rz_return_if_fail(btype->kind == RZ_BASE_TYPE_KIND_STRUCT);
+
 	switch (mode) {
 	case RZ_OUTPUT_MODE_JSON: {
 		rz_return_if_fail(pj);
@@ -345,16 +314,6 @@ static void core_types_struct_print(RzCore *core, RzBaseType *btype, RzOutputMod
 	}
 }
 
-RZ_IPI void rz_core_types_struct_print(RzCore *core, const char *name, RzOutputMode mode, PJ *pj) {
-	rz_return_if_fail(name);
-	RzTypeDB *typedb = core->analysis->typedb;
-	RzBaseType *btype = rz_type_db_get_struct(typedb, name);
-	if (!btype) {
-		return;
-	}
-	core_types_struct_print(core, btype, mode, pj);
-}
-
 RZ_IPI void rz_core_types_struct_print_all(RzCore *core, RzOutputMode mode) {
 	RzList *structlist = rz_type_db_get_base_types_of_kind(core->analysis->typedb, RZ_BASE_TYPE_KIND_STRUCT);
 	RzListIter *it;
@@ -364,7 +323,7 @@ RZ_IPI void rz_core_types_struct_print_all(RzCore *core, RzOutputMode mode) {
 	}
 	RzBaseType *btype;
 	rz_list_foreach (structlist, it, btype) {
-		core_types_struct_print(core, btype, mode, pj);
+		rz_core_types_struct_print(core, btype, mode, pj);
 	}
 	rz_list_free(structlist);
 	if (mode == RZ_OUTPUT_MODE_JSON) {
@@ -374,9 +333,10 @@ RZ_IPI void rz_core_types_struct_print_all(RzCore *core, RzOutputMode mode) {
 	}
 }
 
-static void core_types_struct_print_c(RzTypeDB *typedb, RzBaseType *btype, bool multiline) {
+RZ_IPI void rz_core_types_struct_print_c(RzTypeDB *typedb, const RzBaseType *btype, bool multiline) {
 	rz_return_if_fail(btype);
 	rz_return_if_fail(btype->kind == RZ_BASE_TYPE_KIND_STRUCT);
+
 	char *separator;
 	if (!rz_vector_empty(&btype->struct_data.members)) {
 		rz_cons_printf("struct %s {%s", btype->name, multiline ? "\n" : "");
@@ -410,30 +370,22 @@ static void core_types_struct_print_c(RzTypeDB *typedb, RzBaseType *btype, bool 
 	}
 }
 
-RZ_IPI void rz_core_types_struct_print_c(RzTypeDB *typedb, const char *name, bool multiline) {
-	rz_return_if_fail(name);
-	RzBaseType *btype = rz_type_db_get_struct(typedb, name);
-	if (!btype) {
-		return;
-	}
-	core_types_struct_print_c(typedb, btype, multiline);
-}
-
 RZ_IPI void rz_core_types_struct_print_c_all(RzTypeDB *typedb, bool multiline) {
 	RzList *structlist = rz_type_db_get_base_types_of_kind(typedb, RZ_BASE_TYPE_KIND_STRUCT);
 	RzListIter *it;
 	RzBaseType *btype;
 	rz_list_foreach (structlist, it, btype) {
-		core_types_struct_print_c(typedb, btype, multiline);
+		rz_core_types_struct_print_c(typedb, btype, multiline);
 	}
 	rz_list_free(structlist);
 }
 
 // Typedefs
 
-static void core_types_typedef_print(RzCore *core, RzBaseType *btype, RzOutputMode mode, PJ *pj) {
+RZ_IPI void rz_core_types_typedef_print(RzCore *core, const RzBaseType *btype, RzOutputMode mode, PJ *pj) {
 	rz_return_if_fail(core && btype);
 	rz_return_if_fail(btype->kind == RZ_BASE_TYPE_KIND_TYPEDEF);
+
 	char *typestr = rz_type_as_string(core->analysis->typedb, btype->type);
 	switch (mode) {
 	case RZ_OUTPUT_MODE_JSON: {
@@ -458,16 +410,6 @@ static void core_types_typedef_print(RzCore *core, RzBaseType *btype, RzOutputMo
 	free(typestr);
 }
 
-RZ_IPI void rz_core_types_typedef_print(RzCore *core, const char *name, RzOutputMode mode, PJ *pj) {
-	rz_return_if_fail(name);
-	RzTypeDB *typedb = core->analysis->typedb;
-	RzBaseType *btype = rz_type_db_get_typedef(typedb, name);
-	if (!btype) {
-		return;
-	}
-	core_types_typedef_print(core, btype, mode, pj);
-}
-
 RZ_IPI void rz_core_types_typedef_print_all(RzCore *core, RzOutputMode mode) {
 	RzList *typedeflist = rz_type_db_get_base_types_of_kind(core->analysis->typedb, RZ_BASE_TYPE_KIND_TYPEDEF);
 	RzListIter *it;
@@ -477,7 +419,7 @@ RZ_IPI void rz_core_types_typedef_print_all(RzCore *core, RzOutputMode mode) {
 	}
 	RzBaseType *btype;
 	rz_list_foreach (typedeflist, it, btype) {
-		core_types_typedef_print(core, btype, mode, pj);
+		rz_core_types_typedef_print(core, btype, mode, pj);
 	}
 	rz_list_free(typedeflist);
 	if (mode == RZ_OUTPUT_MODE_JSON) {
@@ -487,20 +429,13 @@ RZ_IPI void rz_core_types_typedef_print_all(RzCore *core, RzOutputMode mode) {
 	}
 }
 
-static void core_types_typedef_print_c(RzTypeDB *typedb, RzBaseType *btype) {
+RZ_IPI void rz_core_types_typedef_print_c(RzTypeDB *typedb, const RzBaseType *btype) {
 	rz_return_if_fail(btype);
 	rz_return_if_fail(btype->kind == RZ_BASE_TYPE_KIND_TYPEDEF);
+
 	char *typestr = rz_type_as_string(typedb, btype->type);
 	rz_cons_printf("typedef %s %s;\n", typestr, btype->name);
 	free(typestr);
-}
-
-RZ_IPI void rz_core_types_typedef_print_c(RzTypeDB *typedb, const char *typedef_name) {
-	RzBaseType *btype = rz_type_db_get_typedef(typedb, typedef_name);
-	if (!btype) {
-		return;
-	}
-	core_types_typedef_print_c(typedb, btype);
 }
 
 RZ_IPI void rz_core_types_typedef_print_c_all(RzTypeDB *typedb) {
@@ -508,14 +443,14 @@ RZ_IPI void rz_core_types_typedef_print_c_all(RzTypeDB *typedb) {
 	RzListIter *it;
 	RzBaseType *btype;
 	rz_list_foreach (typedeflist, it, btype) {
-		core_types_typedef_print_c(typedb, btype);
+		rz_core_types_typedef_print_c(typedb, btype);
 	}
 	rz_list_free(typedeflist);
 }
 
 // Function types
 
-RZ_IPI void rz_types_function_print(RzTypeDB *typedb, const char *function, RzOutputMode mode, PJ *pj) {
+RZ_IPI void rz_core_types_function_print(RzTypeDB *typedb, const char *function, RzOutputMode mode, PJ *pj) {
 	rz_return_if_fail(function);
 	RzCallable *callable = rz_type_func_get(typedb, function);
 	if (!callable) {
@@ -561,7 +496,7 @@ RZ_IPI void rz_core_types_function_print_all(RzCore *core, RzOutputMode mode) {
 	RzListIter *iter;
 	char *name;
 	rz_list_foreach (l, iter, name) {
-		rz_types_function_print(core->analysis->typedb, name, mode, pj);
+		rz_core_types_function_print(core->analysis->typedb, name, mode, pj);
 	}
 	rz_list_free(l);
 	if (mode == RZ_OUTPUT_MODE_JSON) {

--- a/test/db/cmd/cmd_tc
+++ b/test/db/cmd/cmd_tc
@@ -80,8 +80,8 @@ NAME=tc4
 FILE=bins/mach0/objc-employee
 CMDS=<<EOF
 .ic*
-tc "struct Employee"
-tc "struct NSString"
+tc Employee
+tc NSString
 EOF
 EXPECT=<<EOF
 struct Employee {
@@ -202,8 +202,8 @@ NAME=tc4 iOS14 arm64
 FILE=bins/mach0/objc-employee-ios14-arm64
 CMDS=<<EOF
 .ic*
-tc "struct Employee"
-tc "struct NSString"
+tc Employee
+tc NSString
 EOF
 EXPECT=<<EOF
 struct Employee {
@@ -323,8 +323,8 @@ NAME=tc4 iOS14 arm64e
 FILE=bins/mach0/objc-employee-ios14-arm64e
 CMDS=<<EOF
 .ic*
-tc "struct Employee"
-tc "struct NSString"
+tc Employee
+tc NSString
 EOF
 EXPECT=<<EOF
 struct Employee {

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -351,6 +351,7 @@ EXPECT_ERR=<<EOF
 Cannot find base type "xoo"
 Cannot find 'xoo' type
 Cannot find base type "xoo"
+ERROR: Cannot find "xoo" union type
 EOF
 RUN
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Changes the logic in many `t` commands, `tc` and `tcd` in particular to accept just the type name without the `struct` or `union` keyword required.

**Test plan**

```
e cfg.oldshell.autocompletion=false
td "struct blablafoo {};"
tc bla<TAB>
tcd bla<TAB>
tsc bla<TAB> # should show "blablafoo"
tuc bla<TAB> # should show nothing
```

**Closing issues**

Fixes #1607
