### PR TITLE
Use RZ_LOG_INFO instead of RZ_LOG_WARN for hash/gnu_hash sections

### DIFF
--- a/librz/bin/format/elf/elf_symbols.c
+++ b/librz/bin/format/elf/elf_symbols.c
@@ -377,7 +377,7 @@ Elf_(Word) Elf_(rz_bin_elf_get_number_of_dynamic_symbols)(RZ_NONNULL ELFOBJ *bin
 		return result;
 	}
 
-	RZ_LOG_WARN("Neither hash nor gnu_hash exist. Falling back to heuristics for deducing the number of dynamic symbols...\n");
+	RZ_LOG_INFO("Neither hash nor gnu_hash exist. Falling back to heuristics for deducing the number of dynamic symbols...\n");
 
 	result = get_number_of_symbols_from_section(bin);
 	if (result) {


### PR DESCRIPTION
Right now we don't correctly handle some ELF cases where the gnu_hash
section is ill-formed to allow the LD loader to skip it quickly (e.g.
when no symbols are defined in the binary). In such cases, we should not
bombard the user with warnings that may confuse them, considering the
situation has just improved compared to the last release.

However, we want in the future to properly count dynamic symbol entries
by using relocations. Until then though, the users don't want to see
warnings even for regular binaries.


Refer to #1592 