### PR TITLE
Search up to the last byte in a block.

### DIFF
--- a/librz/core/casm.c
+++ b/librz/core/casm.c
@@ -251,7 +251,7 @@ RZ_API RzList *rz_core_asm_strsearch(RzCore *core, const char *input, ut64 from,
 		idx = 0, matchcount = 0;
 		while (addrbytes * (idx + 1) <= core->blocksize) {
 			ut64 addr = at + idx;
-			if (addr >= to) {
+			if (addr > to) {
 				break;
 			}
 			rz_asm_set_pc(core->rasm, addr);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`rz_core_asm_strsearch` does not search until the very last address in a block.
This becomes a problem since the last address in a block can still hold an instruction which matches the search.

This pull requests fixes the address bounds check.

**Example:**

 Consider the following search test:

```
FILE=bins/elf/analysis/hexagon-hello-loop

/ai 0xfffffff8
```

Without the fix it will find the following instructions:
```
0x0000342c   # 4: ? if (!R23) memh(P3++#-0x8) = R11.h 
0x0000342e   # 4: ? if (!R7) memw(P3++#-0x8) = R11 
0x00005128   # 4: ? R2 = memw(R30+##-0x8) 
0x00005144   # 4: ? R2 = memw(R30+##-0x8) 
0x0000514c   # 4: ? memw(R30+##-0x8) = R2 
0x0000564c   # 4: ? R2 = memw(R0+##-0x8) 
0x00005654   # 4: ? if (R17.new) P0 = add(R16,##-0x8) 
0x00005740   # 4: ? R17 = and(R2,##-0x8) 
0x00005840   # 4: ? R4 = add(R2,##-0x8) 
0x00005970   # 4: ? if (R2.new) P2 = add(R2,##-0x8) 
0x000059d0   # 4: ? R1 = and(R1,##-0x8) 
0x00006394   # 4: ? R4 = and(R4,##-0x8) 
0x000063f8   # 4: ? R4 = and(R4,##-0x8) 
0x0000641c   # 4: ? R4 = and(R4,##-0x8) 
0x00006510   # 4: ? R4 = and(R4,##-0x8) 
0x00006534   # 4: ? R4 = and(R4,##-0x8) 
0x00007134   # 4: ? R3 = mux(P0,#-0x8,#-0x8) 
0x00007b4e   # 4: ? R0 = add(R2,##-0x8) 
0x00007eae   # 4: ? R0 = add(R2,##-0x8) 
0x00007ee0   # 4: ? R17 = add(R17,##-0x8) 
0x00008484   # 4: ? R2 = add(R16,add(R2,##-0x8)) 
0x0000848c   # 4: ? R2 = add(R2,##-0x8) 
0x00008598   # 4: ? memd(R2+##-0x8) = R1:0 
0x000087b8   # 4: ? memd(R3+##-0x8) = R1:0 
0x00009b64   # 4: ? R2 = memw(R18+##-0x8) 
0x00000aac   # 4: ? immext(##0x1c00) 
0x00000ab4   # 4: ? immext(##0x1c00) 
0x00000b44   # 4: ? immext(##0x1c00) 
0x00005170   # 4: ? immext(##0x1c00) 
0x00005178   # 4: ? immext(##0x1c00) 
0x00005180   # 4: ? immext(##0x1c00)
```

If the fix is applied it will find two more instructions, which are located directly at the block boundary.

```diff
' bins/elf/analysis/hexagon-hello-loop
-- stdout
--- expected
+++ actual
@@ -25,7 +25,6 @@
 0x00005840   # 4: ? R4 = add(R2,##-0x8) 
 0x00005970   # 4: ? if (R2.new) P2 = add(R2,##-0x8) 
 0x000059d0   # 4: ? R1 = and(R1,##-0x8) 
+0x00005d00   # 4: ? if (R2.new) P0 = add(R2,##-0x8) 
 0x00006394   # 4: ? R4 = and(R4,##-0x8) 
 0x000063f8   # 4: ? R4 = and(R4,##-0x8) 
 0x0000641c   # 4: ? R4 = and(R4,##-0x8) 
@@ -37,7 +36,6 @@
 0x00007ee0   # 4: ? R17 = add(R17,##-0x8) 
 0x00008484   # 4: ? R2 = add(R16,add(R2,##-0x8)) 
 0x0000848c   # 4: ? R2 = add(R2,##-0x8) 
+0x00008500   # 4: ? memd(R2+##-0x8) = R1:0 
 0x00008598   # 4: ? memd(R2+##-0x8) = R1:0 
 0x000087b8   # 4: ? memd(R3+##-0x8) = R1:0 
 0x00009b64   # 4: ? R2 = memw(R18+##-0x8)
```

**Test plan**

The tests in the updated Hexagon plugin ([Pull request](https://github.com/rizinorg/rizin/pull/1614)) will cover this case (That's also where the examples from.).
So waiting for its test cases to be merged is probably the best way.

**Closing issues**

None
