### PR TITLE
Fix OOB read in UTF-8 length function

### DIFF
--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -2474,7 +2474,7 @@ RZ_API size_t rz_str_len_utf8_ansi(const char *str) {
 			i += chlen - 1;
 		} else if ((ch & 0xc0) != 0x80) { // utf8
 			len++;
-			if (rz_str_char_fullwidth(str + i, 4)) {
+			if (rz_str_char_fullwidth(str + i, chlen)) {
 				fullwidths++;
 			}
 		}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes the following problem (it requires 4 bytes in this particular case):
```
[i] ℤ rz-bin -g ea46f8188726aa47803a6d8c28cff8e9                                                                                                                                                                                  14:20:32 
=================================================================
==2421145==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020001b2b13 at pc 0x7fac6c3d4578 bp 0x7fff06ad9850 sp 0x7fff06ad9848
READ of size 1 at 0x6020001b2b13 thread T0
    #0 0x7fac6c3d4577 in rz_str_utf8_codepoint ../librz/util/str.c:2019
    #1 0x7fac6c3d47b8 in rz_str_char_fullwidth ../librz/util/str.c:2025
    #2 0x7fac6c3daa21 in rz_str_len_utf8_ansi ../librz/util/str.c:2477
    #3 0x7fac6c2ea165 in __table_adjust ../librz/util/table.c:53
    #4 0x7fac6c2eef38 in rz_table_tosimplestring ../librz/util/table.c:493
    #5 0x7fac61bebb07 in add_footer ../librz/core/cbin.c:373
    #6 0x7fac61c21643 in rz_core_bin_print ../librz/core/cbin.c:505
    #7 0x7fac6cfa9c6b in rz_main_rz_bin ../librz/main/rz-bin.c:1263
    #8 0x7fac6cd8cb74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
    #9 0x4010ad in _start (/home/akochkov/.local/bin/rz-bin+0x4010ad)

0x6020001b2b13 is located 0 bytes to the right of 3-byte region [0x6020001b2b10,0x6020001b2b13)
allocated by thread T0 here:
    #0 0x7fac6d0da967 in strdup (/lib64/libasan.so.6+0x59967)
    #1 0x7fac6c2ed565 in rz_table_add_rowf ../librz/util/table.c:296
    #2 0x7fac61c01857 in rz_core_bin_libs_print ../librz/core/cbin.c:2168
    #3 0x7fac61c21635 in rz_core_bin_print ../librz/core/cbin.c:505
    #4 0x7fac6cfa9c6b in rz_main_rz_bin ../librz/main/rz-bin.c:1263
    #5 0x7fac6cd8cb74 in __libc_start_main (/lib64/libc.so.6+0x27b74)

SUMMARY: AddressSanitizer: heap-buffer-overflow ../librz/util/str.c:2019 in rz_str_utf8_codepoint
Shadow bytes around the buggy address:
  0x0c048002e510: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x0c048002e520: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x0c048002e530: fa fa fd fa fa fa fd fd fa fa fd fa fa fa fd fa
  0x0c048002e540: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x0c048002e550: fa fa fd fa fa fa fd fa fa fa 00 00 fa fa 00 fa
=>0x0c048002e560: fa fa[03]fa fa fa 00 fa fa fa fa fa fa fa fa fa
  0x0c048002e570: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048002e580: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048002e590: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048002e5a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048002e5b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==2421145==ABORTING
```


**Test plan**

CI is green.
