### PR TITLE
bin/format/mach0: check for int overflow before allocating segments

### DIFF
--- a/librz/bin/format/mach0/coresymbolication.c
+++ b/librz/bin/format/mach0/coresymbolication.c
@@ -183,7 +183,16 @@ RzCoreSymCacheElement *rz_coresym_cache_element_new(RzBinFile *bf, RzBuffer *buf
 
 	ut64 page_zero_size = 0;
 	size_t page_zero_idx = 0;
+
 	if (UT32_MUL_OVFCHK(hdr->n_segments, sizeof(RzCoreSymCacheElementSegment))) {
+		goto beach;
+	} else if (UT32_MUL_OVFCHK(hdr->n_segments, sizeof(RzCoreSymCacheElementSection))) {
+		goto beach;
+	} else if (UT32_MUL_OVFCHK(hdr->n_symbols, sizeof(RzCoreSymCacheElementSymbol))) {
+		goto beach;
+	} else if (UT32_MUL_OVFCHK(hdr->n_lined_symbols, sizeof(RzCoreSymCacheElementLinedSymbol))) {
+		goto beach;
+	} else if (UT32_MUL_OVFCHK(hdr->n_line_info, sizeof(RzCoreSymCacheElementLineInfo))) {
 		goto beach;
 	}
 	if (hdr->n_segments > 0) {

--- a/librz/bin/format/mach0/coresymbolication.c
+++ b/librz/bin/format/mach0/coresymbolication.c
@@ -183,6 +183,9 @@ RzCoreSymCacheElement *rz_coresym_cache_element_new(RzBinFile *bf, RzBuffer *buf
 
 	ut64 page_zero_size = 0;
 	size_t page_zero_idx = 0;
+	if (UT32_MUL_OVFCHK(hdr->n_segments, sizeof(RzCoreSymCacheElementSegment))) {
+		goto beach;
+	}
 	if (hdr->n_segments > 0) {
 		result->segments = RZ_NEWS0(RzCoreSymCacheElementSegment, hdr->n_segments);
 		if (!result->segments) {

--- a/librz/bin/format/mach0/coresymbolication.c
+++ b/librz/bin/format/mach0/coresymbolication.c
@@ -186,7 +186,7 @@ RzCoreSymCacheElement *rz_coresym_cache_element_new(RzBinFile *bf, RzBuffer *buf
 
 	if (UT32_MUL_OVFCHK(hdr->n_segments, sizeof(RzCoreSymCacheElementSegment))) {
 		goto beach;
-	} else if (UT32_MUL_OVFCHK(hdr->n_segments, sizeof(RzCoreSymCacheElementSection))) {
+	} else if (UT32_MUL_OVFCHK(hdr->n_sections, sizeof(RzCoreSymCacheElementSection))) {
 		goto beach;
 	} else if (UT32_MUL_OVFCHK(hdr->n_symbols, sizeof(RzCoreSymCacheElementSymbol))) {
 		goto beach;


### PR DESCRIPTION
**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

`./builddir/binrz/rizin/rizin ./test/bins/fuzzed/bfb0fadddc16434236518fd17aebf32b` when rizin is compiled with asan should not produce any asan crash.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

It should fix the issue with the fuzzed binary found on dev.

