### PR TITLE
Fix minor leak in union parsing

### DIFF
--- a/librz/type/parser/types_parser.c
+++ b/librz/type/parser/types_parser.c
@@ -631,19 +631,21 @@ int parse_union_node(CParserState *state, TSNode node, const char *text, ParserT
 				parser_debug(state, "Union \"%s\" was forward-defined before\n", name);
 				if (!(*tpair = c_parser_new_union_naked_type(state, name))) {
 					parser_error(state, "Cannot create \"%s\" naked union type in the context\n", name);
-					return -1;
+					result = -1;
+					goto unexit;
 				}
-				return 0;
+				goto unexit;
 			}
 			// We still could create the "forward looking union declaration"
 			// The parser then can augment the definition
 			if (!(*tpair = c_parser_new_union_forward_definition(state, name))) {
 				parser_error(state, "Cannot create \"%s\" forward union definition in the context\n", name);
-				return -1;
+				result = -1;
+				goto unexit;
 			}
-			return 0;
+			goto unexit;
 		} else {
-			return 0;
+			goto unexit;
 		}
 	}
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Freeing `name` allocated at the early stages of the union types parsing.

**Test plan**

CI is green