### PR TITLE
Update default libuv from 1.40.0 to 1.42.0

### DIFF
--- a/subprojects/libuv.wrap
+++ b/subprojects/libuv.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-directory = libuv-v1.40.0
+directory = libuv-v1.42.0
 
-source_url = https://github.com/rizinorg/fallback-repo/raw/main/libuv-v1.40.0.tar.gz
-source_filename = libuv-v1.40.0.tar.gz
-source_hash = 61a90db95bac00adec1cc5ddc767ebbcaabc70242bd1134a7a6b1fb1d498a194
-source_fallback_url = https://dist.libuv.org/dist/v1.40.0/libuv-v1.40.0.tar.gz
+source_url = https://github.com/rizinorg/fallback-repo/raw/main/libuv-v1.42.0.tar.gz
+source_filename = libuv-v1.42.0.tar.gz
+source_hash = 43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72
+source_fallback_url = https://dist.libuv.org/dist/v1.42.0/libuv-v1.42.0.tar.gz
 
-patch_directory = libuv-v1.40.0
+patch_directory = libuv-v1.42.0

--- a/subprojects/packagefiles/libuv-v1.42.0/meson.build
+++ b/subprojects/packagefiles/libuv-v1.42.0/meson.build
@@ -1,4 +1,4 @@
-project('libuv', 'c', version : '1.40.0', license : 'libuv', default_options: ['werror=false'])
+project('libuv', 'c', version : '1.42.0', license : 'libuv', default_options: ['werror=false'])
 
 cc = meson.get_compiler('c')
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

1.40.0 is very old version, new version has a few important Windows and BSD bugfixes:

## Changes since version 1.40.0:

* mailmap: update contact information for richardlau (Richard Lau)
* build: add asan checks (gengjiawen)
* unix: report bind error in uv_tcp_connect() (Ben Noordhuis)
* doc: uv_tcp_bind() never returns UV_EADDRINUSE (Ben Noordhuis)
* test: fix pump and tcp_write_batch benchmarks (Santiago Gimeno)
* doc: mark IBM i as Tier 2 support (Jesse Gorzinski)
* doc,poll: add notes (repeated cb & cancel pending cb) (Elad Nachmias)
* linux: fix `-Wincompatible-pointer-types` warning (Ben Noordhuis)
* linux: fix `-Wsign-compare` warning (Ben Noordhuis)
* android: add system call api guards (Ben Noordhuis)
* unix,win: harmonize uv_read_start() error handling (Ben Noordhuis)
* unix,win: more uv_read_start() argument validation (Ben Noordhuis)
* build: turn on `-fno-strict-aliasing` (Ben Noordhuis)
* stream: add uv_pipe and uv_socketpair to the API (Jameson Nash)
* unix,win: initialize timer `timeout` field (Ben Noordhuis)
* bsd-ifaddrs: improve comments (Darshan Sen)
* test: remove unnecessary uv_fs_stat() calls (Ben Noordhuis)
* fs: fix utime/futime timestamp rounding errors (Ben Noordhuis)
* test: ensure reliable floating point comparison (Jameson Nash)
* unix,fs: fix uv_fs_sendfile() (Santiago Gimeno)
* unix: fix uv_fs_stat when using statx (Simon Kadisch)
* linux,macos: fix uv_set_process_title regression (Momtchil Momtchev)
* doc: clarify UDP errors and recvmmsg (Ethel Weston)
* test-getaddrinfo: use example.invalid (Drew DeVault)
* Revert "build: fix android autotools build" (Bernardo Ramos)
* unix,fs: on DVS fs, statx returns EOPNOTSUPP (Mark Klein)
* win, fs: mkdir really return UV_EINVAL for invalid names (Nicholas Vavilov)
* tools: migrate tools/make_dist_html.py to python3 (Dominique Dumont)
* unix: fix uv_uptime() on linux (schamberg97)
* unix: check for partial copy_file_range support (Momtchil Momtchev)
* win: bump minimum supported version to windows 8 (Ben Noordhuis)
* poll,unix: ensure safety of rapid fd reuse (Bob Weinand)
* test: fix some warnings (Issam E. Maghni)
* unix: fix uv_uptime() regression (Santiago Gimeno)
* doc: fix versionadded metadata (cjihrig)
* test: fix 'incompatible pointer types' warnings (cjihrig)
* unix: check for EXDEV in uv__fs_sendfile() (Darshan Sen)

## Changes since version 1.41.0:

- win,tcp: make uv_close work more like unix
- cleanup,win: Remove _WIN32 guards on threadpool
- more errno mappings and fixes
- higher performance try-writes
- fix string encoding issue of uv_os_gethostname (note: MINGW-W64 upstream is broken on i686 due to https://sourceforge.net/p/mingw-w64/bugs/899/)
- zOS support
- Workarounds for a copy_file_range kernel bug
- Better support for TSan
- darwin: use RLIMIT_STACK for fsevents pthread

See more at:
- https://github.com/libuv/libuv/releases/tag/v1.42.0
- https://github.com/libuv/libuv/issues/3202
- https://github.com/libuv/libuv/releases/tag/v1.41.0

Please note, that this will require Windows 8 at least. On the other hand, the Windows 7 builds will be still possible with previous version.

**Test plan**

CI is green