### PR TITLE
Remove yank test where we alloc 2 GB of ram for no reason

### DIFF
--- a/test/db/cmd/feat_yank
+++ b/test/db/cmd/feat_yank
@@ -48,17 +48,6 @@ ok
 EOF
 RUN
 
-NAME=yank-segfault4
-FILE==
-CMDS=<<EOF
-y 1000000000
-?e ok
-EOF
-EXPECT=<<EOF
-ok
-EOF
-RUN
-
 NAME=yank-doublefree
 FILE==
 CMDS=<<EOF


### PR DESCRIPTION
Yank allocs 1GB via malloc(size) and then allocs another GB via RzBuffer

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This test yank 1000000000 bytes (~953 MB) and allocs ~2GB of ram killing the CI