### PR TITLE
CID 315924: Out-of-bounds access (OVERRUN)

### DIFF
--- a/librz/util/file.c
+++ b/librz/util/file.c
@@ -197,7 +197,7 @@ RZ_API bool rz_file_is_abspath(const char *file) {
 
 RZ_API char *rz_file_abspath_rel(const char *cwd, const char *file) {
 	char *ret = NULL;
-	if (!file || !strcmp(file, ".") || !strcmp(file, "./")) {
+	if (RZ_STR_ISEMPTY(file) || !strcmp(file, ".") || !strcmp(file, "./")) {
 		return strdup(cwd);
 	}
 	if (strstr(file, "://")) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

rz_file_abspath_rel checks for null pointer but not for empty string, which is wrong.