### PR TITLE
#undef `_WIN32_WINNT` and `NTDDI_VERSION` before redefining them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,7 @@ jobs:
   build-centos7:
     name: Build on CentOS 7
     runs-on: ubuntu-latest
+    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'centos') || contains(github.ref, 'release-') || github.ref == 'refs/heads/stable' || github.event_name == 'schedule'
     container: centos:7
     steps:
     - name: Install tools
@@ -284,6 +285,7 @@ jobs:
 
   build-debian:
     name: Build on old Debian ${{ matrix.container }}
+    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'debian') || contains(github.ref, 'release-') || github.ref == 'refs/heads/stable' || github.event_name == 'schedule'
     strategy:
         matrix:
             container:
@@ -355,6 +357,7 @@ jobs:
 
   build-static:
     name: Build static
+    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'static') || contains(github.ref, 'release-') || github.ref == 'refs/heads/stable' || github.event_name == 'schedule'
     runs-on: ubuntu-20.04
     container:
         image: alpine:edge
@@ -405,6 +408,7 @@ jobs:
 
   create-tarball:
     name: Create source tarball
+    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'extras') || contains(github.ref, 'release-') || github.ref == 'refs/heads/stable'
     runs-on: ubuntu-latest
     outputs:
         version: ${{ steps.extract_version.outputs.version }}
@@ -435,6 +439,7 @@ jobs:
 
   test-tarball:
     name: Test source tarball
+    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'extras') || contains(github.ref, 'release-') || github.ref == 'refs/heads/stable'
     runs-on: ubuntu-latest
     needs: [create-tarball]
     steps:
@@ -465,6 +470,7 @@ jobs:
   build-osx-pkg:
     name: Build OSX package
     runs-on: macos-latest
+    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'osx') || ((contains(github.ref, 'release-') || github.ref == 'refs/heads/stable') && github.event_name == 'push') || github.event_name == 'schedule'
     needs: [build-and-test]
     steps:
     - uses: actions/checkout@v2
@@ -485,6 +491,7 @@ jobs:
   build-windows:
     name: Build Windows zip/installer ${{ matrix.name }}
     runs-on: windows-latest
+    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'windows') || (github.event_name == 'push' && (contains(github.ref, 'release-') || github.ref == 'refs/heads/stable'))
     needs: [build-and-test]
     strategy:
       fail-fast: false
@@ -543,6 +550,7 @@ jobs:
   build-android:
     name: Build Android ${{ matrix.name }} package
     runs-on: ubuntu-latest
+    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'android') || ((contains(github.ref, 'release-') || github.ref == 'refs/heads/stable') && github.event_name == 'push') || github.event_name == 'schedule'
     needs: [build-and-test]
     strategy:
       fail-fast: false
@@ -569,6 +577,7 @@ jobs:
 
 #  build-extras:
 #    name: Build rizin extras and rzpipe
+#    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'extras') || contains(github.ref, 'release-') || github.event_name == 'schedule'
 #    needs: [test-tarball]
 #    runs-on: ubuntu-latest
 #    env:
@@ -609,6 +618,7 @@ jobs:
 
   build-rzpipe:
     name: Build rizin rzpipe
+    if: contains(github.head_ref, 'dist') || contains(github.ref, 'release-') || github.ref == 'refs/heads/stable' || github.event_name == 'schedule'
     needs: [test-tarball]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,6 @@ jobs:
   build-centos7:
     name: Build on CentOS 7
     runs-on: ubuntu-latest
-    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'centos') || contains(github.ref, 'release-') || github.ref == 'refs/heads/stable' || github.event_name == 'schedule'
     container: centos:7
     steps:
     - name: Install tools
@@ -285,7 +284,6 @@ jobs:
 
   build-debian:
     name: Build on old Debian ${{ matrix.container }}
-    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'debian') || contains(github.ref, 'release-') || github.ref == 'refs/heads/stable' || github.event_name == 'schedule'
     strategy:
         matrix:
             container:
@@ -357,7 +355,6 @@ jobs:
 
   build-static:
     name: Build static
-    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'static') || contains(github.ref, 'release-') || github.ref == 'refs/heads/stable' || github.event_name == 'schedule'
     runs-on: ubuntu-20.04
     container:
         image: alpine:edge
@@ -408,7 +405,6 @@ jobs:
 
   create-tarball:
     name: Create source tarball
-    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'extras') || contains(github.ref, 'release-') || github.ref == 'refs/heads/stable'
     runs-on: ubuntu-latest
     outputs:
         version: ${{ steps.extract_version.outputs.version }}
@@ -439,7 +435,6 @@ jobs:
 
   test-tarball:
     name: Test source tarball
-    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'extras') || contains(github.ref, 'release-') || github.ref == 'refs/heads/stable'
     runs-on: ubuntu-latest
     needs: [create-tarball]
     steps:
@@ -470,7 +465,6 @@ jobs:
   build-osx-pkg:
     name: Build OSX package
     runs-on: macos-latest
-    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'osx') || ((contains(github.ref, 'release-') || github.ref == 'refs/heads/stable') && github.event_name == 'push') || github.event_name == 'schedule'
     needs: [build-and-test]
     steps:
     - uses: actions/checkout@v2
@@ -491,7 +485,6 @@ jobs:
   build-windows:
     name: Build Windows zip/installer ${{ matrix.name }}
     runs-on: windows-latest
-    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'windows') || (github.event_name == 'push' && (contains(github.ref, 'release-') || github.ref == 'refs/heads/stable'))
     needs: [build-and-test]
     strategy:
       fail-fast: false
@@ -550,7 +543,6 @@ jobs:
   build-android:
     name: Build Android ${{ matrix.name }} package
     runs-on: ubuntu-latest
-    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'android') || ((contains(github.ref, 'release-') || github.ref == 'refs/heads/stable') && github.event_name == 'push') || github.event_name == 'schedule'
     needs: [build-and-test]
     strategy:
       fail-fast: false
@@ -577,7 +569,6 @@ jobs:
 
 #  build-extras:
 #    name: Build rizin extras and rzpipe
-#    if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'extras') || contains(github.ref, 'release-') || github.event_name == 'schedule'
 #    needs: [test-tarball]
 #    runs-on: ubuntu-latest
 #    env:
@@ -618,7 +609,6 @@ jobs:
 
   build-rzpipe:
     name: Build rizin rzpipe
-    if: contains(github.head_ref, 'dist') || contains(github.ref, 'release-') || github.ref == 'refs/heads/stable' || github.event_name == 'schedule'
     needs: [test-tarball]
     runs-on: ubuntu-latest
     env:

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -139,7 +139,6 @@ typedef enum {
 #ifdef _MSC_VER
 #ifdef NTDDI_WIN10_TH2
 /* Avoid using Developer Preview and default to Windows 10/Windows Server 2016 */
-#define WINVER 0x0A00
 #define _WIN32_WINNT  _WIN32_WINNT_WIN10
 #define NTDDI_VERSION NTDDI_WIN10
 #endif

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -140,6 +140,8 @@ typedef enum {
 #include <sdkddkver.h>
 #ifdef NTDDI_WIN10_TH2
 /* Avoid using Developer Preview and default to Windows 10/Windows Server 2016 */
+#undef _WIN32_WINNT
+#undef NTDDI_VERSION
 #define _WIN32_WINNT  _WIN32_WINNT_WIN10
 #define NTDDI_VERSION NTDDI_WIN10
 #endif

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -137,12 +137,12 @@ typedef enum {
 #endif
 #if __WINDOWS__ || _WIN32
 #ifdef _MSC_VER
-#include <sdkddkver.h>
 #ifdef NTDDI_WIN10_TH2
 /* Avoid using Developer Preview and default to Windows 10/Windows Server 2016 */
 #define _WIN32_WINNT  _WIN32_WINNT_WIN10
 #define NTDDI_VERSION NTDDI_WIN10
 #endif
+#include <sdkddkver.h>
 /* Must be included before windows.h */
 #include <winsock2.h>
 #include <ws2tcpip.h>

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -139,6 +139,7 @@ typedef enum {
 #ifdef _MSC_VER
 #ifdef NTDDI_WIN10_TH2
 /* Avoid using Developer Preview and default to Windows 10/Windows Server 2016 */
+#define WINVER 0x0A00
 #define _WIN32_WINNT  _WIN32_WINNT_WIN10
 #define NTDDI_VERSION NTDDI_WIN10
 #endif

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -137,12 +137,12 @@ typedef enum {
 #endif
 #if __WINDOWS__ || _WIN32
 #ifdef _MSC_VER
+#include <sdkddkver.h>
 #ifdef NTDDI_WIN10_TH2
 /* Avoid using Developer Preview and default to Windows 10/Windows Server 2016 */
 #define _WIN32_WINNT  _WIN32_WINNT_WIN10
 #define NTDDI_VERSION NTDDI_WIN10
 #endif
-#include <sdkddkver.h>
 /* Must be included before windows.h */
 #include <winsock2.h>
 #include <ws2tcpip.h>


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes (a ton of) warnings of the following form:

(https://ci.appveyor.com/project/rizinorg/rizin/builds/40730197/job/xju9vp275yedbr7b#L5095)
![_WIN32_WINNT](https://user-images.githubusercontent.com/12002672/132972318-a2ac8464-85a8-4ac0-9da0-05794611d414.PNG)

~~https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-150 says that one needs to set `_WIN32_WINNT` _before_ including `sdkddkver.h` (I presume this is also true for `NTDDI_VERSION`), and there's an example in https://gcc.gnu.org/onlinedocs/gcc-11.2.0/cpp/Object-like-Macros.html that has the following note: "Notice that `BUFSIZE` was not defined when `TABLESIZE` was defined.".~~

I want to argue the above but the original code checks for `NTDDI_WIN10_TH2` which is defined in ... `sdkddkver.h`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The warnings are gone from the Windows builds. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
