### PR TITLE
Parse comments in types definitions

### DIFF
--- a/librz/core/ctypes.c
+++ b/librz/core/ctypes.c
@@ -431,7 +431,12 @@ RZ_IPI RZ_OWN char *rz_core_types_typedef_as_c(RzTypeDB *typedb, const RzBaseTyp
 		rz_strbuf_free(buf);
 		return NULL;
 	}
-	rz_strbuf_appendf(buf, "typedef %s %s;\n", typestr, btype->name);
+	// Typedef of the callable is a special case
+	if (rz_type_is_callable_ptr_nested(btype->type)) {
+		rz_strbuf_appendf(buf, "typedef %s;\n", typestr);
+	} else {
+		rz_strbuf_appendf(buf, "typedef %s %s;\n", typestr, btype->name);
+	}
 	free(typestr);
 	return rz_strbuf_drain(buf);
 }

--- a/librz/type/base.c
+++ b/librz/type/base.c
@@ -214,9 +214,14 @@ RZ_API RZ_OWN char *rz_type_db_base_type_as_string(const RzTypeDB *typedb, RZ_NO
 		break;
 	}
 	case RZ_BASE_TYPE_KIND_TYPEDEF: {
-		char *ttype = rz_type_as_string(typedb, type->type);
-		rz_strbuf_appendf(buf, "typedef %s %s;", ttype, type->name);
-		free(ttype);
+		char *typestr = rz_type_as_string(typedb, type->type);
+		// Typedef of the callable is a special case
+		if (rz_type_is_callable_ptr_nested(type->type)) {
+			rz_strbuf_appendf(buf, "typedef %s;", typestr);
+		} else {
+			rz_strbuf_appendf(buf, "typedef %s %s;", typestr, type->name);
+		}
+		free(typestr);
 		break;
 	}
 	case RZ_BASE_TYPE_KIND_ATOMIC:

--- a/librz/type/format.c
+++ b/librz/type/format.c
@@ -3013,10 +3013,14 @@ static bool type_to_format_pair(const RzTypeDB *typedb, RzStrBuf *format, RzStrB
 		return type_to_format_pair(typedb, format, fields, identifier, type->array.type);
 	} else if (type->kind == RZ_TYPE_KIND_POINTER) {
 		// We can't print anything useful for function type pointer
-		if (rz_type_is_callable_ptr(type)) {
+		if (rz_type_is_callable_ptr_nested(type)) {
 			// Thus we consider this is just a `void *` pointer
 			rz_strbuf_append(format, "p");
-			rz_strbuf_appendf(fields, "%s ", type->callable->name);
+			const char *name = rz_type_identifier(type);
+			// Callables are allowed to have empty names
+			if (name) {
+				rz_strbuf_appendf(fields, "%s ", name);
+			}
 		} else {
 			rz_strbuf_append(format, "*");
 			return type_to_format_pair(typedb, format, fields, identifier, type->pointer.type);
@@ -3025,7 +3029,10 @@ static bool type_to_format_pair(const RzTypeDB *typedb, RzStrBuf *format, RzStrB
 		// We can't print anything useful for function type
 		// Thus we consider this is just a `void *` pointer
 		rz_strbuf_append(format, "p");
-		rz_strbuf_appendf(fields, "%s ", type->callable->name);
+		// Callables are allowed to have empty names
+		if (type->callable->name) {
+			rz_strbuf_appendf(fields, "%s ", type->callable->name);
+		}
 	}
 	return true;
 }

--- a/librz/type/parser/types_parser.c
+++ b/librz/type/parser/types_parser.c
@@ -388,6 +388,11 @@ int parse_struct_node(CParserState *state, TSNode node, const char *text, Parser
 		TSNode child = ts_node_named_child(struct_body, i);
 		const char *node_type = ts_node_type(child);
 
+		// Skip comments
+		if (!strcmp(node_type, "comment")) {
+			continue;
+		}
+
 		// Parse the type qualifier first (if present)
 		// FIXME: There could be multiple different type qualifiers in one declaration
 		bool is_const = false;
@@ -448,8 +453,9 @@ int parse_struct_node(CParserState *state, TSNode node, const char *text, Parser
 		// Thus it has the additional node after the declarator
 		TSNode bitfield_clause = ts_node_next_named_sibling(field_declarator);
 		if (!ts_node_is_null(bitfield_clause)) {
+			const char *bfnode_type = ts_node_type(field_type);
 			// As per C standard bitfields are defined only for atomic types, particularly "int"
-			if (strcmp(ts_node_type(field_type), "primitive_type")) {
+			if (strcmp(bfnode_type, "primitive_type") && strcmp(bfnode_type, "type_identifier")) {
 				parser_error(state, "ERROR: Struct bitfield cannot contain non-primitive bitfield!\n");
 				node_malformed_error(state, child, text, "struct field");
 				result = -1;
@@ -672,6 +678,11 @@ int parse_union_node(CParserState *state, TSNode node, const char *text, ParserT
 		TSNode child = ts_node_named_child(union_body, i);
 		const char *node_type = ts_node_type(child);
 
+		// Skip comments
+		if (!strcmp(node_type, "comment")) {
+			continue;
+		}
+
 		// Parse the type qualifier first (if present)
 		// FIXME: There could be multiple different type qualifiers in one declaration
 		bool is_const = false;
@@ -731,8 +742,9 @@ int parse_union_node(CParserState *state, TSNode node, const char *text, ParserT
 		// Thus it has the additional node after the declarator
 		TSNode bitfield_clause = ts_node_next_named_sibling(field_declarator);
 		if (!ts_node_is_null(bitfield_clause)) {
+			const char *bfnode_type = ts_node_type(field_type);
 			// As per C standard bitfields are defined only for atomic types, particularly "int"
-			if (strcmp(ts_node_type(field_type), "primitive_type")) {
+			if (strcmp(bfnode_type, "primitive_type") && strcmp(bfnode_type, "type_identifier")) {
 				parser_error(state, "ERROR: Union bitfield cannot contain non-primitive bitfield!\n");
 				node_malformed_error(state, child, text, "union field");
 				result = -1;
@@ -948,6 +960,12 @@ int parse_enum_node(CParserState *state, TSNode node, const char *text, ParserTy
 		parser_debug(state, "enum: processing %d field...\n", i);
 		TSNode child = ts_node_named_child(enum_body, i);
 		const char *node_type = ts_node_type(child);
+
+		// Skip comments
+		if (!strcmp(node_type, "comment")) {
+			continue;
+		}
+
 		// Every field should have (field_declaration) AST clause
 		if (strcmp(node_type, "enumerator")) {
 			parser_error(state, "ERROR: Enum member AST should contain (enumerator) node!\n");

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -355,6 +355,41 @@ ERROR: Cannot find "xoo" union type
 EOF
 RUN
 
+NAME=td with comments
+FILE==
+CMDS=<<EOF
+td "typedef /* fff */ unsigned int uint; // ggg "
+td "union bla { uint b; /* qwe */ };"
+td "struct foo { uint b; /* qwe */ char *foo[5]; };"
+td "enum bar { A = 0, /* qwe */ B, G, /* ewq */ }"
+tu bla
+tuc bla
+ts foo
+tsc foo
+te bar
+tec bar
+EOF
+EXPECT=<<EOF
+pf i b
+union bla {
+	uint b;
+};
+pf i[5]*c b foo
+struct foo {
+	uint b;
+	char *foo[5];
+};
+A = 0x0
+B = 0x1
+G = 0x2
+enum bar {
+	A = 0,
+	B = 1,
+	G = 2
+};
+EOF
+RUN
+
 NAME=typedef
 FILE==
 CMDS=<<EOF
@@ -364,6 +399,21 @@ t~?Abracadabra
 EOF
 EXPECT=<<EOF
 0
+EOF
+RUN
+
+NAME=typedef function
+FILE==
+CMDS=<<EOF
+td "typedef uint8_t ( *bla)(const char *bla, void *foo);"
+tt bla
+ttc bla
+tf bla
+EOF
+EXPECT=<<EOF
+bla = uint8_t (*bla)(const char *bla, void *foo)
+typedef uint8_t (*bla)(const char *bla, void *foo);
+uint8_t bla(const char *bla, void *foo);
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Allows to parse the structures, unions, enums, typedefs with the comments inside their body.
Also allowed printing the format of the function pointers without the name

**Test plan**

```
$ rizin
[0x00000000]> to ./behemoth.h
[0x00000000]> t EFI_DECOMPRESS_GET_INFO
pf p EFI_DECOMPRESS_GET_INFO
[0x00000000]> tf EFI_DECOMPRESS_GET_INFO
EFI_STATUS EFI_DECOMPRESS_GET_INFO(EFI_DECOMPRESS_PROTOCOL *This, void *Source, UINT32 SourceSize, UINT32 *DestinationSize, UINT32 *ScratchSize);
[0x00000000]> tt EFI_DECOMPRESS_GET_INFO
EFI_DECOMPRESS_GET_INFO = EFI_STATUS (*EFI_DECOMPRESS_GET_INFO)(EFI_DECOMPRESS_PROTOCOL *This, void *Source, UINT32 SourceSize, UINT32 *DestinationSize, UINT32 *ScratchSize)
[0x00000000]> ttc EFI_DECOMPRESS_GET_INFO
typedef EFI_STATUS (*EFI_DECOMPRESS_GET_INFO)(EFI_DECOMPRESS_PROTOCOL *This, void *Source, UINT32 SourceSize, UINT32 *DestinationSize, UINT32 *ScratchSize);
[0x00000000]> tt EFI_PEI_INSTALL_PPI
EFI_PEI_INSTALL_PPI = EFI_STATUS (*EFI_PEI_INSTALL_PPI)(PEFI_PEI_SERVICES *PeiServices, EFI_PEI_PPI_DESCRIPTOR *PpiList)
```

**Closing issues**

Fixes https://github.com/rizinorg/rizin/issues/1662
