### PR TITLE
`rz_time_stamp_to_str`: Use 31-Dec-1969 epoch instead of hack

### DIFF
--- a/librz/util/time.c
+++ b/librz/util/time.c
@@ -55,21 +55,11 @@ RZ_API char *rz_time_stamp_to_str(ut32 timeStamp) {
 	rz_gmtime_r(&ts, &gmt_tm);
 	struct tm local_tm;
 	rz_localtime_r(&ts, &local_tm);
-#if __WINDOWS__ || __OpenBSD__
-	// Hack on Windows and OpenBSD so that mktime() returns proper values
-	// when the timestamp is close to 0.
-	bool advance_1_day = false;
 	if (gmt_tm.tm_mday == 1 && gmt_tm.tm_mon == 0 && gmt_tm.tm_year == 70) {
 		gmt_tm.tm_mday++;
-		advance_1_day = true;
-	}
-#endif
-	time_t gmt_time = mktime(&gmt_tm);
-#if __WINDOWS__ || __OpenBSD__
-	if (advance_1_day) {
 		local_tm.tm_mday++;
 	}
-#endif
+	time_t gmt_time = mktime(&gmt_tm);
 	time_t local_time = mktime(&local_tm);
 	bool err = gmt_time == -1 || local_time == -1;
 	long diff = (long)difftime(local_time, gmt_time);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr replaces the hack in `rz_time_stamp_to_str()` with counting the seconds since midnight 31 December 1969 if the timestamp is close to 0 (i.e. equivalent to a GMT time and date on 1 Jan 1970). This special epoch applies to all OSes.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
