### PR TITLE
Fixes for Windows input when `e scr.vtmode=1` 

### DIFF
--- a/librz/cons/input.c
+++ b/librz/cons/input.c
@@ -573,9 +573,6 @@ static int __cons_readchar_w32(ut32 usec) {
 				resizeWin();
 			}
 		}
-		if (I->vtmode != 2 && !I->term_xterm) {
-			FlushConsoleInputBuffer(h);
-		}
 	} while (ch == 0);
 	SetConsoleMode(h, mode);
 	return ch;

--- a/librz/cons/input.c
+++ b/librz/cons/input.c
@@ -504,7 +504,7 @@ static int __cons_readchar_w32(ut32 usec) {
 
 			if (irInBuf.EventType == KEY_EVENT) {
 				if (irInBuf.Event.KeyEvent.bKeyDown) {
-					bCtrl = irInBuf.Event.KeyEvent.dwControlKeyState & 8;
+					bCtrl = irInBuf.Event.KeyEvent.dwControlKeyState & LEFT_CTRL_PRESSED;
 					if (irInBuf.Event.KeyEvent.uChar.UnicodeChar) {
 						char *tmp = rz_utf16_to_utf8_l(&irInBuf.Event.KeyEvent.uChar.UnicodeChar, 1);
 						if (tmp) {

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -2203,10 +2203,10 @@ static bool scr_vtmode(void *user, void *data) {
 	GetConsoleMode(input, &mode);
 	if (node->i_value == 2) {
 		SetConsoleMode(input, mode & ENABLE_VIRTUAL_TERMINAL_INPUT);
-		rz_cons_singleton()->term_raw = ENABLE_VIRTUAL_TERMINAL_INPUT;
+		rz_cons_singleton()->term_raw |= ENABLE_VIRTUAL_TERMINAL_INPUT;
 	} else {
 		SetConsoleMode(input, mode & ~ENABLE_VIRTUAL_TERMINAL_INPUT);
-		rz_cons_singleton()->term_raw = 0;
+		rz_cons_singleton()->term_raw &= ~ENABLE_VIRTUAL_TERMINAL_INPUT;
 	}
 	HANDLE streams[] = { GetStdHandle(STD_OUTPUT_HANDLE), GetStdHandle(STD_ERROR_HANDLE) };
 	int i;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Manually tested

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None
