### PR TITLE
analysis: fix size of element put in vector in get_delta_jmptbl_info

### DIFF
--- a/librz/analysis/jmptbl.c
+++ b/librz/analysis/jmptbl.c
@@ -284,7 +284,7 @@ RZ_API bool rz_analysis_get_delta_jmptbl_info(RZ_NONNULL RzAnalysis *analysis, R
 	rz_return_val_if_fail(analysis && fcn && params, false);
 	bool isValid = false;
 	bool foundCmp = false;
-	int i;
+	ut64 i;
 
 	RzAnalysisOp tmp_aop = { 0 };
 	if (lea_address > jmp_address) {


### PR DESCRIPTION
 **Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The vector has sizeof(ut64), but `i` was int.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #1691 
