### PR TITLE
Make cpu and in RzTypeTarget owned

### DIFF
--- a/librz/include/rz_type.h
+++ b/librz/include/rz_type.h
@@ -18,9 +18,9 @@ extern "C" {
 RZ_LIB_VERSION_HEADER(rz_type);
 
 typedef struct rz_type_target_t {
-	const char *cpu;
+	char *cpu;
 	int bits;
-	const char *os;
+	char *os;
 	bool big_endian;
 	const char *default_type;
 } RzTypeTarget;

--- a/librz/type/type.c
+++ b/librz/type/type.c
@@ -82,6 +82,8 @@ RZ_API void rz_type_db_free(RzTypeDB *typedb) {
 	ht_pp_free(typedb->types);
 	ht_pp_free(typedb->formats);
 	free((void *)typedb->target->default_type);
+	free(typedb->target->os);
+	free(typedb->target->cpu);
 	free(typedb->target);
 	free(typedb);
 }
@@ -156,7 +158,8 @@ RZ_API void rz_type_db_set_bits(RzTypeDB *typedb, int bits) {
  * \param os Operating system name to set
  */
 RZ_API void rz_type_db_set_os(RzTypeDB *typedb, const char *os) {
-	typedb->target->os = os;
+	free(typedb->target->os);
+	typedb->target->os = os ? strdup(os) : NULL;
 }
 
 /**
@@ -169,7 +172,8 @@ RZ_API void rz_type_db_set_os(RzTypeDB *typedb, const char *os) {
  * \param cpu Architecture name to set
  */
 RZ_API void rz_type_db_set_cpu(RzTypeDB *typedb, const char *cpu) {
-	typedb->target->cpu = cpu;
+	free(typedb->target->cpu);
+	typedb->target->cpu = cpu ? strdup(cpu) : NULL;
 }
 
 /**


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

```
florian-macbook:rizin florian$ build_asan/binrz/rizin/rizin -Qc "e asm.os=?; e asm.cpu="
eco: cannot open colorscheme profile (ayu)
ios
dos
darwin
linux
freebsd
openbsd
netbsd
windows
s110
none
=================================================================
==20168==ERROR: AddressSanitizer: heap-use-after-free on address 0x00010df12f90 at pc 0x00010a598b94 bp 0x00016b5d2580 sp 0x00016b5d2578
READ of size 1 at 0x00010df12f90 thread T0


    #0 0x10a598b90 in rz_type_db_init type.c:240
    #1 0x10a5992bc in rz_type_db_reload type.c:338
    #2 0x108097ac4 in rz_analysis_set_cpu analysis.c:329
    #3 0x10990ff88 in cb_analysis_cpu cconfig.c:293
    #4 0x10904bd60 in rz_config_set config.c:341
    #5 0x109913918 in cb_asmcpu cconfig.c:436
    #6 0x10904bd60 in rz_config_set config.c:341
    #7 0x1099c4214 in rz_eval_getset_handler cmd_eval.c:510
    #8 0x109b3017c in argv_call_cb cmd_api.c:691
    #9 0x109b245e4 in call_cd cmd_api.c:748
    #10 0x109b245c4 in call_cd cmd_api.c:744
    #11 0x109b241a8 in rz_cmd_call_parsed_args cmd_api.c:766
    #12 0x109ae9970 in handle_ts_arged_stmt_internal cmd.c:4460
    #13 0x109a9b7e4 in handle_ts_arged_stmt cmd.c:4408
    #14 0x109ae8960 in handle_ts_stmt cmd.c:5907
    #15 0x109ae7e20 in handle_ts_statements_internal cmd.c:5964
    #16 0x109a9b4e0 in handle_ts_statements cmd.c:5929
    #17 0x109aa504c in core_cmd_tsrzcmd cmd.c:6066
    #18 0x109a8da28 in rz_core_cmd_lines cmd.c:6193
    #19 0x104857ca4 in run_commands rizin.c:264
    #20 0x104855970 in rz_main_rizin rizin.c:1342
    #21 0x10482b1d4 in main rizin.c:57
    #22 0x18231d42c in start+0x0 (libdyld.dylib:arm64e+0x1842c)

0x00010df12f90 is located 0 bytes inside of 5-byte region [0x00010df12f90,0x00010df12f95)
freed by thread T0 here:
    #0 0x104ef32b4 in wrap_free+0x98 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x3f2b4)
    #1 0x10904b6d4 in rz_config_set config.c:307
    #2 0x1099c4214 in rz_eval_getset_handler cmd_eval.c:510
    #3 0x109b3017c in argv_call_cb cmd_api.c:691
    #4 0x109b245e4 in call_cd cmd_api.c:748
    #5 0x109b245c4 in call_cd cmd_api.c:744
    #6 0x109b241a8 in rz_cmd_call_parsed_args cmd_api.c:766
    #7 0x109ae9970 in handle_ts_arged_stmt_internal cmd.c:4460
    #8 0x109a9b7e4 in handle_ts_arged_stmt cmd.c:4408
    #9 0x109ae8960 in handle_ts_stmt cmd.c:5907
    #10 0x109ae7e20 in handle_ts_statements_internal cmd.c:5964
    #11 0x109a9b4e0 in handle_ts_statements cmd.c:5929
    #12 0x109aa504c in core_cmd_tsrzcmd cmd.c:6066
    #13 0x109a8da28 in rz_core_cmd_lines cmd.c:6193
    #14 0x104857ca4 in run_commands rizin.c:264
    #15 0x104855970 in rz_main_rizin rizin.c:1342
    #16 0x10482b1d4 in main rizin.c:57
    #17 0x18231d42c in start+0x0 (libdyld.dylib:arm64e+0x1842c)

previously allocated by thread T0 here:
    #0 0x104eee644 in wrap_strdup+0x1c4 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x3a644)
    #1 0x109049464 in rz_config_node_new config.c:13
    #2 0x10904bac0 in rz_config_set config.c:324
    #3 0x10904b0d4 in rz_config_set_cb config.c:171
    #4 0x1099078ec in rz_core_config_init cconfig.c:3062
    #5 0x109b3b8cc in rz_core_init core.c:2546
    #6 0x109b38034 in rz_core_new core.c:815
    #7 0x10484eb00 in rz_main_rizin rizin.c:411
    #8 0x10482b1d4 in main rizin.c:57
    #9 0x18231d42c in start+0x0 (libdyld.dylib:arm64e+0x1842c)

SUMMARY: AddressSanitizer: heap-use-after-free type.c:240 in rz_type_db_init
Shadow bytes around the buggy address:
  0x007021c025a0: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x007021c025b0: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x007021c025c0: fa fa fd fa fa fa fd fa fa fa fd fd fa fa fd fa
  0x007021c025d0: fa fa fd fd fa fa fd fa fa fa fd fa fa fa fd fd
  0x007021c025e0: fa fa fd fd fa fa fd fa fa fa 05 fa fa fa 07 fa
=>0x007021c025f0: fa fa[fd]fa fa fa 07 fa fa fa 00 05 fa fa 02 fa
  0x007021c02600: fa fa 00 05 fa fa 06 fa fa fa fd fa fa fa 00 07
  0x007021c02610: fa fa 03 fa fa fa 00 07 fa fa 02 fa fa fa 00 00
  0x007021c02620: fa fa 00 03 fa fa 00 00 fa fa 00 00 fa fa 00 03
  0x007021c02630: fa fa 00 00 fa fa 04 fa fa fa 00 07 fa fa 00 03
  0x007021c02640: fa fa 00 07 fa fa 00 05 fa fa 02 fa fa fa 00 05
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==20168==ABORTING
Abort trap: 6
```

It does not necessarily make sense to add a test for this since it is so implementation-defined.