### PR TITLE
Fix Global Variable UAF after deleting flag manually

### DIFF
--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -748,7 +748,6 @@ typedef struct rz_analysis_var_global_t {
 	ut64 addr; ///< address of the global variable
 	RzType *type; ///< type of the variable
 	RzVector /*<RzTypeConstraint>*/ constraints;
-	RZ_BORROW RzFlagItem *flag_item; ///< flag corresponding to the global variable
 	RZ_BORROW RzAnalysis *analysis; ///< analysis pertaining to this global variable
 } RzAnalysisVarGlobal;
 
@@ -1642,6 +1641,7 @@ RZ_API void rz_analysis_fcn_vars_add_types(RzAnalysis *analysis, RZ_NONNULL RzAn
 RZ_API RZ_OWN RzAnalysisVarGlobal *rz_analysis_var_global_new(RZ_NONNULL const char *name, ut64 addr);
 RZ_API RZ_OWN bool rz_analysis_var_global_add(RzAnalysis *analysis, RZ_NONNULL RzAnalysisVarGlobal *global_var);
 RZ_API void rz_analysis_var_global_free(RzAnalysisVarGlobal *glob);
+RZ_API RZ_NULLABLE RzFlagItem *rz_analysis_var_global_get_flag_item(RzAnalysisVarGlobal *glob);
 RZ_API bool rz_analysis_var_global_delete(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL RzAnalysisVarGlobal *glob);
 RZ_API bool rz_analysis_var_global_delete_byname(RzAnalysis *analysis, RZ_NONNULL const char *name);
 RZ_API bool rz_analysis_var_global_delete_byaddr_at(RzAnalysis *analysis, ut64 addr);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -71,6 +71,7 @@ RZ_LIB_VERSION_HEADER(rz_core);
 #define RZ_FLAGS_FS_MMIO_REGISTERS          "registers.mmio"
 #define RZ_FLAGS_FS_MMIO_REGISTERS_EXTENDED "registers.extended"
 #define RZ_FLAGS_FS_PLATFORM_PORTS          "platform.ports"
+#define RZ_FLAGS_FS_GLOBALS                 "globals"
 
 #define RZ_GRAPH_FORMAT_NO     0
 #define RZ_GRAPH_FORMAT_GMLFCN 1

--- a/test/unit/test_analysis_global_var.c
+++ b/test/unit/test_analysis_global_var.c
@@ -13,7 +13,6 @@ bool test_rz_analysis_global_var() {
 	mu_assert_notnull(glob, "create a global variable");
 	mu_assert_streq(glob->name, "foo", "global var name");
 	mu_assert_eq(glob->addr, 0x1337, "global var address");
-	mu_assert_null(glob->flag_item, "global var flag_item");
 	mu_assert_null(glob->analysis, "global var analysis");
 	RzTypeParser *parser = rz_type_parser_new();
 	mu_assert_notnull(parser, "create type parser");
@@ -22,10 +21,16 @@ bool test_rz_analysis_global_var() {
 	mu_assert_notnull(typ, "parsed type");
 	rz_analysis_var_global_set_type(glob, typ);
 	mu_assert_streq(glob->type->identifier.name, "int", "global var type");
+	RzFlagItem *flag = rz_analysis_var_global_get_flag_item(glob);
+	mu_assert_null(flag, "no flag yet");
 
 	bool added = rz_analysis_var_global_add(analysis, glob);
 	mu_assert_true(added, "add global var");
-	mu_assert_notnull(glob->flag_item, "flag_item null");
+	flag = rz_analysis_var_global_get_flag_item(glob);
+	mu_assert_notnull(flag, "global var flag_item");
+	mu_assert_eq(flag->offset, glob->addr, "flag item addr");
+	mu_assert_streq(flag->name, "foo", "flag item name");
+	mu_assert_streq(flag->space->name, RZ_FLAGS_FS_GLOBALS, "flag space");
 
 	glob = NULL;
 	glob = rz_analysis_var_global_get_byaddr_at(analysis, 0x1337);
@@ -57,7 +62,9 @@ bool test_rz_analysis_global_var() {
 	glob = rz_analysis_var_global_get_byname(analysis, "bar");
 	mu_assert_notnull(glob, "get global var by addr");
 	mu_assert_streq(glob->name, "bar", "global var name");
-	mu_assert_streq(glob->flag_item->name, "bar", "global flag_item name");
+	mu_assert_streq(flag->name, "bar", "global flag_item name");
+	RzFlagItem *flag2 = rz_analysis_var_global_get_flag_item(glob);
+	mu_assert_ptreq(flag2, flag, "still same flag");
 
 	bool deleted = rz_analysis_var_global_delete_byaddr_at(analysis, 0x1337);
 	mu_assert_true(deleted, "delete global var");
@@ -72,7 +79,6 @@ bool test_rz_analysis_global_var() {
 	mu_assert_notnull(glob, "create a global variable");
 	mu_assert_streq(glob->name, "foo", "global var name");
 	mu_assert_eq(glob->addr, 0x1337, "global var address");
-	mu_assert_null(glob->flag_item, "global var flag_item");
 	mu_assert_null(glob->analysis, "global var flags");
 	errmsg = NULL;
 	typ = rz_type_parse_string_single(parser, "int", &errmsg);
@@ -82,7 +88,6 @@ bool test_rz_analysis_global_var() {
 
 	added = rz_analysis_var_global_add(analysis, glob);
 	mu_assert_true(added, "add global var");
-	mu_assert_notnull(glob->flag_item, "flag_item null");
 
 	glob = NULL;
 	glob = rz_analysis_var_global_get_byaddr_at(analysis, 0x1337);
@@ -102,7 +107,6 @@ bool test_rz_analysis_global_var() {
 	mu_assert_notnull(glob, "create a global variable");
 	mu_assert_streq(glob->name, "bar", "global var name");
 	mu_assert_eq(glob->addr, 0x114514, "global var address");
-	mu_assert_null(glob->flag_item, "global var flag_item");
 	mu_assert_null(glob->analysis, "global var flags");
 	typ = rz_type_parse_string_single(parser, "int", &errmsg);
 	mu_assert_notnull(typ, "parsed type");
@@ -111,7 +115,10 @@ bool test_rz_analysis_global_var() {
 
 	added = rz_analysis_var_global_add(analysis, glob);
 	mu_assert_true(added, "add global var");
-	mu_assert_notnull(glob->flag_item, "flag_item null");
+	flag = rz_analysis_var_global_get_flag_item(glob);
+	mu_assert_notnull(flag, "global var flag_item");
+	mu_assert_eq(flag->offset, glob->addr, "flag item addr");
+	mu_assert_streq(flag->name, "bar", "flag item name");
 
 	glob = NULL;
 	glob = rz_analysis_var_global_get_byname(analysis, "bar");
@@ -130,8 +137,108 @@ bool test_rz_analysis_global_var() {
 	mu_end;
 }
 
+bool test_flag_confusion_space_name() {
+	RzCore *core = rz_core_new();
+	RzAnalysis *analysis = core->analysis;
+
+	rz_flag_space_set(core->flags, "mire");
+	RzAnalysisVarGlobal *glob = rz_analysis_var_global_new("foo", 0x1337);
+	RzTypeParser *parser = rz_type_parser_new();
+	mu_assert_notnull(parser, "create type parser");
+	RzType *typ = rz_type_parse_string_single(parser, "int", NULL);
+	rz_analysis_var_global_set_type(glob, typ);
+	rz_analysis_var_global_add(analysis, glob);
+	RzFlagItem *fi = rz_analysis_var_global_get_flag_item(glob);
+	mu_assert_notnull(fi, "global var flag_item");
+	mu_assert_eq(fi->offset, glob->addr, "flag item addr");
+	mu_assert_streq(fi->name, "foo", "flag item name");
+	mu_assert_streq(fi->space->name, RZ_FLAGS_FS_GLOBALS, "flag space");
+
+	rz_flag_space_set(core->flags, "ulu-mulu");
+	RzFlagItem *fii = rz_analysis_var_global_get_flag_item(glob);
+	mu_assert_ptreq(fii, fi, "unaffected by space change");
+
+	rz_flag_rename(core->flags, fi, "bar");
+	fi = rz_analysis_var_global_get_flag_item(glob);
+	mu_assert_null(fi, "flag lost");
+
+	rz_type_parser_free(parser);
+	rz_core_free(core);
+	mu_end;
+}
+
+bool test_flag_confusion_addr() {
+	RzCore *core = rz_core_new();
+	RzAnalysis *analysis = core->analysis;
+
+	RzAnalysisVarGlobal *glob = rz_analysis_var_global_new("foo", 0x1337);
+	RzTypeParser *parser = rz_type_parser_new();
+	mu_assert_notnull(parser, "create type parser");
+	RzType *typ = rz_type_parse_string_single(parser, "int", NULL);
+	rz_analysis_var_global_set_type(glob, typ);
+	rz_analysis_var_global_add(analysis, glob);
+	RzFlagItem *fi = rz_analysis_var_global_get_flag_item(glob);
+
+	rz_flag_set(core->flags, fi->name, 0x31337, fi->size);
+	fi = rz_analysis_var_global_get_flag_item(glob);
+	mu_assert_null(fi, "flag lost");
+
+	rz_type_parser_free(parser);
+	rz_core_free(core);
+	mu_end;
+}
+
+bool test_flag_confusion_delete() {
+	RzCore *core = rz_core_new();
+	RzAnalysis *analysis = core->analysis;
+
+	RzAnalysisVarGlobal *glob = rz_analysis_var_global_new("foo", 0x1337);
+	RzTypeParser *parser = rz_type_parser_new();
+	mu_assert_notnull(parser, "create type parser");
+	RzType *typ = rz_type_parse_string_single(parser, "int", NULL);
+	rz_analysis_var_global_set_type(glob, typ);
+	rz_analysis_var_global_add(analysis, glob);
+	RzFlagItem *fi = rz_analysis_var_global_get_flag_item(glob);
+
+	rz_flag_unset(core->flags, fi);
+	fi = rz_analysis_var_global_get_flag_item(glob);
+	mu_assert_null(fi, "flag lost");
+
+	rz_analysis_var_global_rename(analysis, "foo", "bar");
+	mu_assert_streq(glob->name, "bar", "rename without flag");
+	mu_assert_eq(glob->addr, 0x1337, "addr");
+
+	glob = NULL;
+	glob = rz_analysis_var_global_get_byaddr_at(analysis, 0x1337);
+	mu_assert_notnull(glob, "get global var by addr");
+	mu_assert_streq(glob->name, "bar", "global var name");
+	mu_assert_eq(glob->addr, 0x1337, "global var address");
+	mu_assert_streq(glob->type->identifier.name, "int", "global var type");
+
+	glob = NULL;
+	glob = rz_analysis_var_global_get_byname(analysis, "bar");
+	mu_assert_notnull(glob, "get global var by addr");
+	mu_assert_streq(glob->name, "bar", "global var name");
+	mu_assert_eq(glob->addr, 0x1337, "global var address");
+	mu_assert_streq(glob->type->identifier.name, "int", "global var type");
+
+	glob = NULL;
+	glob = rz_analysis_var_global_get_byaddr_in(analysis, 0x1339); // test RBTree
+	mu_assert_notnull(glob, "get global var by addr");
+	mu_assert_streq(glob->name, "bar", "global var name");
+	mu_assert_eq(glob->addr, 0x1337, "global var address");
+	mu_assert_streq(glob->type->identifier.name, "int", "global var type");
+
+	rz_type_parser_free(parser);
+	rz_core_free(core);
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test(test_rz_analysis_global_var);
+	mu_run_test(test_flag_confusion_space_name);
+	mu_run_test(test_flag_confusion_addr);
+	mu_run_test(test_flag_confusion_delete);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The reference to the flag in `RzAnalysisVarGlobal` is dangerous:
```
florian-macbook:rizin florian$ build_asan/binrz/rizin/rizin -Qc "avga test 0x100 int; f- test; avgn test tost"
=================================================================
==33231==ERROR: AddressSanitizer: heap-use-after-free on address 0x00011ed39600 at pc 0x0001046a0a18 bp 0x00016b8c7290 sp 0x00016b8c7288
READ of size 8 at 0x00011ed39600 thread T0
    #0 0x1046a0a14 in update_flag_item_name flag.c:166
    #1 0x1046a1350 in rz_flag_rename flag.c:772
    #2 0x107e959dc in rz_analysis_var_global_rename var_global.c:270
    #3 0x1096fe4ac in rz_analysis_global_variable_rename_handler cmd_analysis.c:8153
    #4 0x10984c15c in argv_call_cb cmd_api.c:691
    #5 0x1098405c4 in call_cd cmd_api.c:748
    #6 0x109840188 in rz_cmd_call_parsed_args cmd_api.c:766
    #7 0x109805950 in handle_ts_arged_stmt_internal cmd.c:4460
    #8 0x1097b77c4 in handle_ts_arged_stmt cmd.c:4408
    #9 0x109804940 in handle_ts_stmt cmd.c:5907
    #10 0x109803e00 in handle_ts_statements_internal cmd.c:5964
    #11 0x1097b74c0 in handle_ts_statements cmd.c:5929
    #12 0x1097c102c in core_cmd_tsrzcmd cmd.c:6066
    #13 0x1097a9a08 in rz_core_cmd_lines cmd.c:6193
    #14 0x104563ca4 in run_commands rizin.c:264
    #15 0x104561970 in rz_main_rizin rizin.c:1342
    #16 0x1045371d4 in main rizin.c:57
    #17 0x18231d42c in start+0x0 (libdyld.dylib:arm64e+0x1842c)

0x00011ed39600 is located 0 bytes inside of 72-byte region [0x00011ed39600,0x00011ed39648)
freed by thread T0 here:
    #0 0x104f0b2b4 in wrap_free+0x98 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x3f2b4)
    #1 0x10469c01c in rz_flag_item_free flag.c:269
    #2 0x10469b1d4 in ht_free_flag flag.c:186
    #3 0x104b6ef68 in freefn ht_inc.c:45
    #4 0x104b6f37c in ht_pp_delete ht_inc.c:341
    #5 0x1046a1458 in rz_flag_unset flag.c:782
    #6 0x1046a20bc in rz_flag_unset_name flag.c:828
    #7 0x1096b5398 in rz_cmd_flag cmd_flag.c:1069
    #8 0x109840698 in call_cd cmd_api.c:751
    #9 0x109840188 in rz_cmd_call_parsed_args cmd_api.c:766
    #10 0x109805950 in handle_ts_arged_stmt_internal cmd.c:4460
    #11 0x1097b77c4 in handle_ts_arged_stmt cmd.c:4408
    #12 0x109804940 in handle_ts_stmt cmd.c:5907
    #13 0x109803e00 in handle_ts_statements_internal cmd.c:5964
    #14 0x1097b74c0 in handle_ts_statements cmd.c:5929
    #15 0x1097c102c in core_cmd_tsrzcmd cmd.c:6066
    #16 0x1097a9a08 in rz_core_cmd_lines cmd.c:6193
    #17 0x104563ca4 in run_commands rizin.c:264
    #18 0x104561970 in rz_main_rizin rizin.c:1342
    #19 0x1045371d4 in main rizin.c:57
    #20 0x18231d42c in start+0x0 (libdyld.dylib:arm64e+0x1842c)

previously allocated by thread T0 here:
    #0 0x104f0b544 in wrap_calloc+0x9c (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x3f544)
    #1 0x1046a0644 in rz_flag_set flag.c:721
    #2 0x107e947e0 in rz_analysis_var_global_add var_global.c:67
    #3 0x1096fe16c in rz_analysis_global_variable_add_handler cmd_analysis.c:8125
    #4 0x10984c15c in argv_call_cb cmd_api.c:691
    #5 0x1098405c4 in call_cd cmd_api.c:748
    #6 0x109840188 in rz_cmd_call_parsed_args cmd_api.c:766
    #7 0x109805950 in handle_ts_arged_stmt_internal cmd.c:4460
    #8 0x1097b77c4 in handle_ts_arged_stmt cmd.c:4408
    #9 0x109804940 in handle_ts_stmt cmd.c:5907
    #10 0x109803e00 in handle_ts_statements_internal cmd.c:5964
    #11 0x1097b74c0 in handle_ts_statements cmd.c:5929
    #12 0x1097c102c in core_cmd_tsrzcmd cmd.c:6066
    #13 0x1097a9a08 in rz_core_cmd_lines cmd.c:6193
    #14 0x104563ca4 in run_commands rizin.c:264
    #15 0x104561970 in rz_main_rizin rizin.c:1342
    #16 0x1045371d4 in main rizin.c:57
    #17 0x18231d42c in start+0x0 (libdyld.dylib:arm64e+0x1842c)

SUMMARY: AddressSanitizer: heap-use-after-free flag.c:166 in update_flag_item_name
Shadow bytes around the buggy address:
  0x007023dc7270: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x007023dc7280: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x007023dc7290: fd fd fa fa fa fa fd fd fd fd fd fd fd fd fd fd
  0x007023dc72a0: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fa fa
  0x007023dc72b0: fa fa fd fd fd fd fd fd fd fd fd fd fa fa fa fa
=>0x007023dc72c0:[fd]fd fd fd fd fd fd fd fd fa fa fa fa fa fd fd
  0x007023dc72d0: fd fd fd fd fd fd fd fd fa fa fa fa fd fd fd fd
  0x007023dc72e0: fd fd fd fd fd fd fa fa fa fa fd fd fd fd fd fd
  0x007023dc72f0: fd fd fd fd fa fa fa fa fd fd fd fd fd fd fd fd
  0x007023dc7300: fd fd fa fa fa fa fd fd fd fd fd fd fd fd fd fd
  0x007023dc7310: fa fa fa fa 00 00 00 00 00 00 00 00 00 00 fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==33231==ABORTING
Abort trap: 6
```

Since there are no events or anything similar to detect when the flag was deleted manually, the only way is to re-query it every time. I have added an API to encapsulate this.

**Test plan**

`rizin -Qc "avga test 0x100 int; f- test; avgn test tost"` and the added unit tests