### PR TITLE
Fix Leaks in Types string conversions

### DIFF
--- a/librz/type/type.c
+++ b/librz/type/type.c
@@ -796,6 +796,16 @@ struct HelperBufs {
 	RzStrBuf *ptrbuf;
 };
 
+static void helper_bufs_init(struct HelperBufs *hbs) {
+	hbs->arraybuf = rz_strbuf_new("");
+	hbs->ptrbuf = rz_strbuf_new("");
+}
+
+static void helper_bufs_fini(struct HelperBufs *hbs) {
+	rz_strbuf_free(hbs->arraybuf);
+	rz_strbuf_free(hbs->ptrbuf);
+}
+
 static char *type_as_string(const RzTypeDB *typedb, RZ_NONNULL const RzType *type, RZ_NONNULL struct HelperBufs *bufs) {
 	rz_return_val_if_fail(typedb && type && bufs, NULL);
 
@@ -823,7 +833,7 @@ static char *type_as_string(const RzTypeDB *typedb, RZ_NONNULL const RzType *typ
 			rz_strbuf_append(buf, btype->name);
 		}
 		if (!rz_strbuf_is_empty(bufs->ptrbuf) || !rz_strbuf_is_empty(bufs->arraybuf)) {
-			rz_strbuf_appendf(buf, " %s%s", rz_strbuf_drain(bufs->ptrbuf), rz_strbuf_drain(bufs->arraybuf));
+			rz_strbuf_appendf(buf, " %s%s", rz_strbuf_get(bufs->ptrbuf), rz_strbuf_get(bufs->arraybuf));
 		}
 		break;
 	}
@@ -883,7 +893,7 @@ static char *type_as_string_decl(const RzTypeDB *typedb, RZ_NONNULL const RzType
 			free(btypestr);
 		}
 		if (!rz_strbuf_is_empty(bufs->ptrbuf) || !rz_strbuf_is_empty(bufs->arraybuf)) {
-			rz_strbuf_appendf(buf, " %s%s", rz_strbuf_drain(bufs->ptrbuf), rz_strbuf_drain(bufs->arraybuf));
+			rz_strbuf_appendf(buf, " %s%s", rz_strbuf_get(bufs->ptrbuf), rz_strbuf_get(bufs->arraybuf));
 		}
 		break;
 	}
@@ -962,7 +972,7 @@ static char *type_as_string_identifier_decl(const RzTypeDB *typedb, RZ_NONNULL c
 				rz_strbuf_append(buf, btype->name);
 			}
 		}
-		rz_strbuf_appendf(buf, " %s%s%s", rz_strbuf_drain(bufs->ptrbuf), identifier, rz_strbuf_drain(bufs->arraybuf));
+		rz_strbuf_appendf(buf, " %s%s%s", rz_strbuf_get(bufs->ptrbuf), identifier, rz_strbuf_get(bufs->arraybuf));
 		break;
 	}
 	case RZ_TYPE_KIND_POINTER: {
@@ -1008,10 +1018,11 @@ static char *type_as_string_identifier_decl(const RzTypeDB *typedb, RZ_NONNULL c
  */
 RZ_API RZ_OWN char *rz_type_as_string(const RzTypeDB *typedb, RZ_NONNULL const RzType *type) {
 	rz_return_val_if_fail(typedb && type, NULL);
-	RzStrBuf *arraybuf = rz_strbuf_new("");
-	RzStrBuf *ptrbuf = rz_strbuf_new("");
-	struct HelperBufs bufs = { arraybuf, ptrbuf };
-	return type_as_string(typedb, type, &bufs);
+	struct HelperBufs bufs;
+	helper_bufs_init(&bufs);
+	char *r = type_as_string(typedb, type, &bufs);
+	helper_bufs_fini(&bufs);
+	return r;
 }
 
 /**
@@ -1022,10 +1033,11 @@ RZ_API RZ_OWN char *rz_type_as_string(const RzTypeDB *typedb, RZ_NONNULL const R
  */
 RZ_API RZ_OWN char *rz_type_declaration_as_string(const RzTypeDB *typedb, RZ_NONNULL const RzType *type) {
 	rz_return_val_if_fail(typedb && type, NULL);
-	RzStrBuf *arraybuf = rz_strbuf_new("");
-	RzStrBuf *ptrbuf = rz_strbuf_new("");
-	struct HelperBufs bufs = { arraybuf, ptrbuf };
-	return type_as_string_decl(typedb, type, &bufs);
+	struct HelperBufs bufs;
+	helper_bufs_init(&bufs);
+	char *r = type_as_string_decl(typedb, type, &bufs);
+	helper_bufs_fini(&bufs);
+	return r;
 }
 
 /**
@@ -1036,10 +1048,11 @@ RZ_API RZ_OWN char *rz_type_declaration_as_string(const RzTypeDB *typedb, RZ_NON
  */
 RZ_API RZ_OWN char *rz_type_identifier_declaration_as_string(const RzTypeDB *typedb, RZ_NONNULL const RzType *type, RZ_NONNULL const char *identifier) {
 	rz_return_val_if_fail(typedb && type, NULL);
-	RzStrBuf *arraybuf = rz_strbuf_new("");
-	RzStrBuf *ptrbuf = rz_strbuf_new("");
-	struct HelperBufs bufs = { arraybuf, ptrbuf };
-	return type_as_string_identifier_decl(typedb, type, identifier, &bufs);
+	struct HelperBufs bufs;
+	helper_bufs_init(&bufs);
+	char *r = type_as_string_identifier_decl(typedb, type, identifier, &bufs);
+	helper_bufs_fini(&bufs);
+	return r;
 }
 
 /**

--- a/test/unit/test_type.c
+++ b/test/unit/test_type.c
@@ -603,11 +603,11 @@ static bool test_struct_func_types(void) {
 	RzCallableArg *arg;
 	arg = *rz_pvector_index_ptr(call->args, 0);
 	mu_assert_streq(arg->name, "a", "argument \"a\"");
-	mu_assert_streq(rz_type_as_string(typedb, arg->type), "int", "argument \"a\" type");
+	mu_assert_streq_free(rz_type_as_string(typedb, arg->type), "int", "argument \"a\" type");
 
 	arg = *rz_pvector_index_ptr(call->args, 1);
 	mu_assert_streq(arg->name, "b", "argument \"b\"");
-	mu_assert_streq(rz_type_as_string(typedb, arg->type), "const char *", "argument \"b\" type");
+	mu_assert_streq_free(rz_type_as_string(typedb, arg->type), "const char *", "argument \"b\" type");
 
 	rz_type_free(ttype);
 
@@ -635,15 +635,15 @@ static bool test_struct_func_types(void) {
 	mu_assert_eq(RZ_TYPE_KIND_CALLABLE, member->type->pointer.type->pointer.type->kind, "not function pointer's pointer");
 
 	call = member->type->pointer.type->pointer.type->callable;
-	mu_assert_streq(rz_type_as_string(typedb, call->ret), "wchar_t", "function return type");
+	mu_assert_streq_free(rz_type_as_string(typedb, call->ret), "wchar_t", "function return type");
 
 	arg = *rz_pvector_index_ptr(call->args, 0);
 	mu_assert_streq(arg->name, "a", "argument \"a\"");
-	mu_assert_streq(rz_type_as_string(typedb, arg->type), "int", "argument \"a\" type");
+	mu_assert_streq_free(rz_type_as_string(typedb, arg->type), "int", "argument \"a\" type");
 
 	arg = *rz_pvector_index_ptr(call->args, 1);
 	mu_assert_streq(arg->name, "b", "argument \"b\"");
-	mu_assert_streq(rz_type_as_string(typedb, arg->type), "const char *", "argument \"b\" type");
+	mu_assert_streq_free(rz_type_as_string(typedb, arg->type), "const char *", "argument \"b\" type");
 
 	rz_type_free(ttype);
 	rz_type_db_free(typedb);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Before: [leaks-old.log](https://github.com/rizinorg/rizin/files/7177718/leaks-old.log)
```
==3753== LEAK SUMMARY:
==3753==    definitely lost: 3,141 bytes in 129 blocks
==3753==    indirectly lost: 871 bytes in 21 blocks
==3753==      possibly lost: 0 bytes in 0 blocks
==3753==    still reachable: 31 bytes in 1 blocks
==3753==         suppressed: 0 bytes in 0 blocks
```

After: [leaks-new.log](https://github.com/rizinorg/rizin/files/7177722/leaks-new.log)
```
==3896== LEAK SUMMARY:
==3896==    definitely lost: 1,304 bytes in 34 blocks
==3896==    indirectly lost: 871 bytes in 21 blocks
==3896==      possibly lost: 0 bytes in 0 blocks
==3896==    still reachable: 31 bytes in 1 blocks
==3896==         suppressed: 0 bytes in 0 blocks
```

Still a few things to fix but this is a start.