### PR TITLE
Fix #807 - Don't use `cmd.prompt` to update register flags

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -1154,9 +1154,6 @@ static bool cb_cfgdebug(void *user, void *data) {
 		const char *dbgbackend = rz_config_get(core->config, "dbg.backend");
 		core->bin->is_debugger = true;
 		rz_debug_use(core->dbg, dbgbackend);
-		if (!strcmp(rz_config_get(core->config, "cmd.prompt"), "")) {
-			rz_config_set(core->config, "cmd.prompt", ".dr*");
-		}
 		if (!strcmp(dbgbackend, "bf")) {
 			rz_config_set(core->config, "asm.arch", "bf");
 		}
@@ -1452,20 +1449,6 @@ static bool cb_dbg_args(void *user, void *data) {
 		core->io->args = NULL;
 	} else {
 		core->io->args = strdup(node->value);
-	}
-	return true;
-}
-
-static bool cb_dbgstatus(void *user, void *data) {
-	RzCore *r = (RzCore *)user;
-	RzConfigNode *node = (RzConfigNode *)data;
-	if (rz_config_get_i(r->config, "cfg.debug")) {
-		if (node->i_value) {
-			rz_config_set(r->config, "cmd.prompt",
-				".dr*; drd; sr PC;pi 1;s-");
-		} else {
-			rz_config_set(r->config, "cmd.prompt", ".dr*");
-		}
 	}
 	return true;
 }
@@ -3400,7 +3383,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETCB("dbg.trace_continue", "true", &cb_dbg_trace_continue, "Trace every instruction between the initial PC position and the PC position at the end of continue's execution");
 	SETCB("dbg.create_new_console", "true", &cb_dbg_create_new_console, "Create a new console window for the debugee on debug start");
 	/* debug */
-	SETCB("dbg.status", "false", &cb_dbgstatus, "Set cmd.prompt to '.dr*' or '.dr*;drd;sr PC;pi 1;shu'");
+	SETBPREF("dbg.status", "false", "Set cmd.prompt to '.dr*' or '.dr*;drd;sr PC;pi 1;shu'");
 #if DEBUGGER
 	SETCB("dbg.backend", "native", &cb_dbgbackend, "Select the debugger backend");
 #else

--- a/librz/core/cio.c
+++ b/librz/core/cio.c
@@ -8,7 +8,6 @@ RZ_API int rz_core_setup_debugger(RzCore *r, const char *debugbackend, bool atta
 	int pid, *p = NULL;
 	bool is_gdb = !strcmp(debugbackend, "gdb");
 	RzIODesc *fd = r->file ? rz_io_desc_get(r->io, r->file->fd) : NULL;
-	const char *prompt = NULL;
 
 	p = fd ? fd->data : NULL;
 	rz_config_set_i(r->config, "cfg.debug", 1);

--- a/librz/core/cio.c
+++ b/librz/core/cio.c
@@ -48,17 +48,6 @@ RZ_API int rz_core_setup_debugger(RzCore *r, const char *debugbackend, bool atta
 	}
 	rz_core_seek_to_register(r, "PC", false);
 
-	/* set the prompt if it's not been set already by the callbacks */
-	prompt = rz_config_get(r->config, "cmd.prompt");
-	if (prompt && !strcmp(prompt, "")) {
-		if (rz_config_get_i(r->config, "dbg.status")) {
-			rz_config_set(r->config, "cmd.prompt", ".dr*;drd;sr PC;pi 1;shu");
-		} else {
-			rz_config_set(r->config, "cmd.prompt", ".dr*");
-		}
-	}
-	rz_config_set(r->config, "cmd.vprompt", ".dr*");
-	rz_config_set(r->config, "cmd.gprompt", ".dr*");
 	return true;
 }
 

--- a/librz/core/cmd_analysis.c
+++ b/librz/core/cmd_analysis.c
@@ -4137,9 +4137,10 @@ RZ_API int rz_core_esil_step_back(RzCore *core) {
 	RzAnalysisEsil *esil = core->analysis->esil;
 	if (esil->trace->idx > 0) {
 		rz_analysis_esil_trace_restore(esil, esil->trace->idx - 1);
+		rz_core_regs2flags(core);
 		return 1;
 	}
-	return -1;
+	return 0;
 }
 
 RZ_API bool rz_core_esil_continue_back(RzCore *core) {
@@ -4174,6 +4175,8 @@ RZ_API bool rz_core_esil_continue_back(RzCore *core) {
 
 	// Return to the nearest breakpoint or jump back to the first index if a breakpoint wasn't found
 	rz_analysis_esil_trace_restore(esil, idx);
+
+	rz_core_regs2flags(core);
 
 	return true;
 }

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -8,6 +8,7 @@
 #if __UNIX__
 #include <signal.h>
 #endif
+#include "core_private.h"
 
 #define DB core->sdb
 
@@ -2670,6 +2671,9 @@ RZ_API void rz_core_free(RzCore *c) {
 RZ_API void rz_core_prompt_loop(RzCore *r) {
 	int ret;
 	do {
+		if (rz_config_get_b(r->config, "dbg.status")) {
+			rz_core_debug_print_status(r);
+		}
 		int err = rz_core_prompt(r, false);
 		if (err < 1) {
 			// handle ^D

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -115,6 +115,7 @@ RZ_IPI void rz_core_debug_single_step_over(RzCore *core);
 RZ_IPI void rz_core_debug_breakpoint_toggle(RzCore *core, ut64 addr);
 RZ_IPI void rz_core_debug_continue(RzCore *core);
 RZ_IPI void rz_core_debug_attach(RzCore *core, int pid);
+RZ_IPI void rz_core_debug_print_status(RzCore *core);
 
 /* cfile.c */
 RZ_IPI void rz_core_io_file_open(RzCore *core, int fd);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Use `rz_core_debug_regs2flags()` APIs instead and add `rz_core_debug_print_status()` IPI

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tests pass

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Fixes #807
