### PR TITLE
Load all files in `.a`

### DIFF
--- a/librz/bin/bfile.c
+++ b/librz/bin/bfile.c
@@ -499,10 +499,9 @@ RZ_API bool rz_bin_file_delete(RzBin *bin, RzBinFile *bf) {
 }
 
 RZ_API RzBinFile *rz_bin_file_find_by_fd(RzBin *bin, ut32 bin_fd) {
+	rz_return_val_if_fail(bin, NULL);
 	RzListIter *iter;
 	RzBinFile *bf;
-
-	rz_return_val_if_fail(bin, NULL);
 
 	rz_list_foreach (bin->binfiles, iter, bf) {
 		if (bf->fd == bin_fd) {

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -776,6 +776,7 @@ RZ_API bool rz_core_bin_apply_entry(RzCore *core, RzBinFile *binfile, bool va) {
 
 static RzIODesc *find_reusable_file(RzIO *io, RzCoreFile *cf, const char *uri, int perm) {
 	rz_return_val_if_fail(io && uri, NULL);
+
 	if (!cf) {
 		// valid case, but then we can't reuse anything
 		return NULL;
@@ -866,9 +867,9 @@ static void add_map(RzCore *core, RZ_NULLABLE RzCoreFile *cf, RzBinFile *bf, RzB
 			if (!desc) {
 				free(uri);
 				return;
-			}
-			if (cf) {
-				rz_pvector_push(&cf->extra_files, desc);
+			} else if (cf && !rz_pvector_push(&cf->extra_files, desc)) {
+				free(uri);
+				return;
 			}
 		}
 		free(uri);

--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -917,6 +917,8 @@ static bool map_multi_dex(RzCore *core, RzIODesc *desc, ut32 id) {
 }
 
 RZ_API bool rz_core_bin_load(RZ_NONNULL RzCore *r, RZ_NULLABLE const char *filenameuri, ut64 baddr) {
+	rz_return_val_if_fail(r, false);
+
 	RzCoreFile *cf = rz_core_file_cur(r);
 	RzIODesc *desc = cf ? rz_io_desc_get(r->io, cf->fd) : NULL;
 	ut64 laddr = rz_config_get_i(r->config, "bin.laddr");
@@ -927,16 +929,14 @@ RZ_API bool rz_core_bin_load(RZ_NONNULL RzCore *r, RZ_NULLABLE const char *filen
 	if (!cf) {
 		return false;
 	}
-	// NULL deref guard
-	if (desc) {
-		is_io_load = desc && desc->plugin;
-		if (!filenameuri || !*filenameuri) {
-			filenameuri = desc->name;
-		}
+
+	is_io_load = desc && desc->plugin;
+	if (desc && RZ_STR_ISEMPTY(filenameuri)) {
+		filenameuri = desc->name;
 	}
 
-	if (!filenameuri) {
-		eprintf("rz_core_bin_load: no file specified\n");
+	if (RZ_STR_ISEMPTY(filenameuri)) {
+		RZ_LOG_ERROR("rz_core_bin_load: no file specified\n");
 		return false;
 	}
 
@@ -1021,9 +1021,9 @@ RZ_API bool rz_core_bin_load(RZ_NONNULL RzCore *r, RZ_NULLABLE const char *filen
 			rz_io_map_new(r->io, desc->fd, desc->perm, 0, laddr, rz_io_desc_size(desc));
 		}
 		if (binfile) {
-			rz_core_bin_set_arch_bits(r, binfile->file,
-				rz_config_get(r->config, "asm.arch"),
-				rz_config_get_i(r->config, "asm.bits"));
+			ut16 bits = rz_config_get_i(r->config, "asm.bits");
+			const char *arch = rz_config_get(r->config, "asm.arch");
+			rz_core_bin_set_arch_bits(r, binfile->file, arch, bits);
 		}
 	}
 	if (desc && rz_config_get_i(r->config, "io.exec")) {
@@ -1082,59 +1082,68 @@ RZ_API bool rz_core_bin_load(RZ_NONNULL RzCore *r, RZ_NULLABLE const char *filen
 		// Setting the right arch and bits, so regstate will be shown correctly
 		if (plugin->info) {
 			RzBinInfo *inf = plugin->info(binfile);
-			eprintf("Setting up coredump arch-bits to: %s-%d\n", inf->arch, inf->bits);
+			RZ_LOG_INFO("Setting up coredump arch-bits to: %s-%d\n", inf->arch, inf->bits);
 			rz_config_set(r->config, "asm.arch", inf->arch);
 			rz_config_set_i(r->config, "asm.bits", inf->bits);
 			rz_bin_info_free(inf);
 		}
 		if (binfile->o->regstate) {
 			if (rz_reg_arena_set_bytes(r->analysis->reg, binfile->o->regstate)) {
-				eprintf("Setting up coredump: Problem while setting the registers\n");
+				RZ_LOG_WARN("Setting up coredump: Problem while setting the registers\n");
 			} else {
-				eprintf("Setting up coredump: Registers have been set\n");
+				RZ_LOG_INFO("Setting up coredump: Registers have been set\n");
 			}
 		}
 	}
 	return true;
 }
 
-RZ_API bool rz_core_file_open_many(RZ_NONNULL RzCore *r, RZ_NULLABLE const char *file, int perm, ut64 loadaddr) {
-	const bool openmany = rz_config_get_i(r->config, "file.openmany");
-	int opened_count = 0;
-	RzListIter *fd_iter, *iter2;
-	RzIODesc *desc;
-
+/**
+ * \brief Open the file as a compilation of files
+ * 
+ * Calls rz_io_open_many and maps all the file descriptors to an RzCoreFile
+ */
+RZ_API RZ_BORROW RzCoreFile *rz_core_file_open_many(RZ_NONNULL RzCore *r, RZ_NULLABLE const char *file, int perm, ut64 loadaddr) {
 	RzList *list_fds = rz_io_open_many(r->io, file, perm, 0644);
 
-	if (!list_fds || rz_list_length(list_fds) == 0) {
+	if (rz_list_empty(list_fds)) {
 		rz_list_free(list_fds);
-		return false;
+		return NULL;
 	}
 
-	rz_list_foreach_safe (list_fds, fd_iter, iter2, desc) {
-		opened_count++;
-		if (openmany && opened_count > 1) {
-			// XXX - Open Many should limit the number of files
-			// loaded in io plugin area this needs to be more premptive
-			// like down in the io plugin layer.
-			// start closing down descriptors
-			rz_list_delete(list_fds, fd_iter);
+	RzListIter *it = NULL;
+	RzIODesc *desc = NULL;
+	RzIODesc *first = NULL;
+	rz_list_foreach (list_fds, it, desc) {
+		if (!rz_io_desc_add(r->io, desc)) {
+			rz_io_desc_free(desc);
+			continue;
+		} else if (!first) {
+			first = desc;
+		}
+
+		RzCoreFile *fh = core_file_new(r, desc->fd);
+		if (!fh) {
 			continue;
 		}
-		RzCoreFile *fh = RZ_NEW0(RzCoreFile);
-		if (fh) {
-			fh->core = r;
-			fh->fd = desc->fd;
-			r->file = fh;
-			rz_list_append(r->files, fh);
-			rz_core_bin_load(r, desc->name, loadaddr);
+		r->file = fh;
+		rz_list_append(r->files, fh);
+		if (!rz_core_bin_load(r, desc->name, loadaddr)) {
+			RZ_LOG_ERROR("failed to load %s\n", desc->name);
 		}
 	}
-	return true;
+
+	rz_list_free(list_fds);
+	return rz_list_first(r->files);
 }
 
-/* loadaddr is rizin -m (mapaddr) */
-RZ_API RzCoreFile *rz_core_file_open(RzCore *r, const char *file, int flags, ut64 loadaddr) {
+/**
+ * \brief Tries to open the file as is, otherwise tries as is a compilation of files
+ * 
+ * Calls rz_io_open_nomap but if it fails, then tries with rz_core_file_open_many;
+ * Also, loadaddr is rizin -m (mapaddr)
+ */
+RZ_API RZ_BORROW RzCoreFile *rz_core_file_open(RZ_NONNULL RzCore *r, RZ_NONNULL const char *file, int flags, ut64 loadaddr) {
 	rz_return_val_if_fail(r && file, NULL);
 	ut64 prev = rz_time_now_mono();
 	const bool openmany = rz_config_get_i(r->config, "file.openmany");
@@ -1153,9 +1162,10 @@ RZ_API RzCoreFile *rz_core_file_open(RzCore *r, const char *file, int flags, ut6
 		goto beach;
 	}
 	if (!fd && openmany) {
-		if (!rz_core_file_open_many(r, file, flags, loadaddr)) {
+		if (!(fh = rz_core_file_open_many(r, file, flags, loadaddr))) {
 			goto beach;
 		}
+		fd = rz_io_desc_get(r->io, fh->fd);
 	}
 	if (!fd) {
 		if (flags & RZ_PERM_W) {
@@ -1173,10 +1183,12 @@ RZ_API RzCoreFile *rz_core_file_open(RzCore *r, const char *file, int flags, ut6
 		goto beach;
 	}
 
-	fh = core_file_new(r, fd->fd);
 	if (!fh) {
-		eprintf("core/file.c: rz_core_open failed to allocate RzCoreFile.\n");
-		goto beach;
+		fh = core_file_new(r, fd->fd);
+		if (!fh) {
+			RZ_LOG_ERROR("rz_core_file_open: failed to allocate RzCoreFile.\n");
+			goto beach;
+		}
 	}
 	{
 		const char *cp = rz_config_get(r->config, "cmd.open");
@@ -1191,7 +1203,9 @@ RZ_API RzCoreFile *rz_core_file_open(RzCore *r, const char *file, int flags, ut6
 	r->file = fh;
 	rz_io_use_fd(r->io, fd->fd);
 
-	rz_list_append(r->files, fh);
+	if (!rz_list_find_ptr(r->files, fh)) {
+		rz_list_append(r->files, fh);
+	}
 	if (rz_config_get_b(r->config, "cfg.debug")) {
 		bool swstep = true;
 		if (r->dbg->cur && r->dbg->cur->canstep) {

--- a/librz/core/cmd_open.c
+++ b/librz/core/cmd_open.c
@@ -4,6 +4,7 @@
 #include <rz_bin.h>
 #include <rz_debug.h>
 #include <rz_core.h>
+#include <rz_io.h>
 
 static const char *help_msg_o[] = {
 	"Usage: o", "[com- ] [file] ([offset])", "",
@@ -29,6 +30,7 @@ static const char *help_msg_o[] = {
 	"oo", "[?+bcdnm]", "reopen current file (see oo?) (reload in rw or debugger)",
 	"op", "[r|n|p|fd]", "select priorized file by fd (see ob), opn/opp/opr = next/previous/rotate",
 	"oq", "", "list all open files",
+	"ou", "[fd]", "select fd to use",
 	"ox", " fd fdx", "exchange the descs of fd and fdx and keep the mapping",
 	NULL
 };
@@ -1362,18 +1364,20 @@ RZ_IPI int rz_cmd_open(void *data, const char *input) {
 		RzListIter *iter = NULL;
 		RzCoreFile *f;
 		core->switch_file_view = 0;
-		int num = atoi(input + 2);
-
+		const char *snum = rz_str_trim_head_ro(input + 2);
+		int num = rz_num_math(NULL, snum);
 		rz_list_foreach (core->files, iter, f) {
 			if (f->fd == num) {
 				core->file = f;
+				rz_io_use_fd(core->io, num);
+				RzBinFile *bf = rz_bin_file_find_by_fd(core->bin, num);
+				if (bf) {
+					rz_core_bin_raise(core, bf->id);
+					rz_core_block_read(core);
+					rz_cons_printf("switched to fd %d %s\n", num, bf->file);
+				}
+				break;
 			}
-		}
-		rz_io_use_fd(core->io, num);
-		RzBinFile *bf = rz_bin_file_find_by_fd(core->bin, num);
-		if (bf) {
-			rz_core_bin_raise(core, bf->id);
-			rz_core_block_read(core);
 		}
 		break;
 	}

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -558,8 +558,8 @@ RZ_API int rz_core_file_set_by_name(RzCore *core, const char *name);
 RZ_API int rz_core_file_set_by_file(RzCore *core, RzCoreFile *cf);
 RZ_API int rz_core_setup_debugger(RzCore *r, const char *debugbackend, bool attach);
 
-RZ_API RzCoreFile *rz_core_file_open(RzCore *core, const char *file, int flags, ut64 loadaddr);
-RZ_API bool rz_core_file_open_many(RZ_NONNULL RzCore *r, RZ_NULLABLE const char *file, int perm, ut64 loadaddr);
+RZ_API RZ_BORROW RzCoreFile *rz_core_file_open(RZ_NONNULL RzCore *core, RZ_NONNULL const char *file, int flags, ut64 loadaddr);
+RZ_API RZ_BORROW RzCoreFile *rz_core_file_open_many(RZ_NONNULL RzCore *r, RZ_NULLABLE const char *file, int perm, ut64 loadaddr);
 RZ_API RzCoreFile *rz_core_file_get_by_fd(RzCore *core, int fd);
 RZ_API void rz_core_file_close(RzCoreFile *fh);
 RZ_API bool rz_core_file_close_fd(RzCore *core, int fd);

--- a/librz/io/p/io_ar.c
+++ b/librz/io/p/io_ar.c
@@ -10,6 +10,49 @@ static bool rz_io_ar_plugin_open(RzIO *io, const char *file, bool many) {
 	return !strncmp("ar://", file, 5) || !strncmp("lib://", file, 6);
 }
 
+static RzList *rz_io_ar_open_many(RzIO *io, const char *file, int perm, int mode) {
+	const char *arname = strstr(file, "://");
+	if (!arname) {
+		return NULL;
+	}
+	arname += 3;
+
+	RzList *all = ar_open_all(arname, rz_sys_open_perms(perm));
+	if (!all) {
+		RZ_LOG_ERROR("ar: cannot open all .o files in '%s'\n", file);
+		return NULL;
+	}
+
+	RzList *list_fds = rz_list_new();
+	if (!list_fds) {
+		rz_list_free(all);
+		return NULL;
+	}
+
+	RzArFp *arfp;
+	RzListIter *it;
+
+	rz_list_foreach (all, it, arfp) {
+		char *uri_name = rz_str_newf("%s//%s", file, arfp->name);
+		RzIODesc *desc = rz_io_desc_new(io, &rz_io_plugin_ar, uri_name, perm, mode, arfp);
+		free(uri_name);
+		if (!desc) {
+			rz_list_free(all);
+			rz_list_free(list_fds);
+			return NULL;
+		}
+		desc->name = strdup(arfp->name);
+		if (!rz_list_append(list_fds, desc)) {
+			rz_list_free(all);
+			rz_list_free(list_fds);
+			return NULL;
+		}
+		it->data = NULL;
+	}
+	rz_list_free(all);
+	return list_fds;
+}
+
 static RzIODesc *rz_io_ar_open(RzIO *io, const char *file, int perm, int mode) {
 	rz_return_val_if_fail(io && file, NULL);
 	RzIODesc *res = NULL;
@@ -22,11 +65,13 @@ static RzIODesc *rz_io_ar_open(RzIO *io, const char *file, int perm, int mode) {
 		goto err;
 	}
 	arname += 3;
+
 	char *filename = strstr(arname, "//");
-	if (filename) {
-		*filename = 0;
-		filename += 2;
+	if (!filename) {
+		goto err;
 	}
+	*filename = 0;
+	filename += 2;
 
 	RzArFp *arf = ar_open_file(arname, rz_sys_open_perms(perm), filename);
 	if (!arf) {
@@ -40,11 +85,6 @@ static RzIODesc *rz_io_ar_open(RzIO *io, const char *file, int perm, int mode) {
 err:
 	free(uri);
 	return res;
-}
-
-static RzList *rz_io_ar_open_many(RzIO *io, const char *file, int rw, int mode) {
-	eprintf("Not implemented\n");
-	return NULL;
 }
 
 static ut64 rz_io_ar_lseek(RzIO *io, RzIODesc *fd, ut64 offset, int whence) {
@@ -87,13 +127,16 @@ static int rz_io_ar_close(RzIODesc *fd) {
 	if (!fd || !fd->data) {
 		return -1;
 	}
-	return ar_close((RzArFp *)fd->data);
+	ar_close((RzArFp *)fd->data);
+	fd->data = NULL;
+	return 0;
 }
 
 RzIOPlugin rz_io_plugin_ar = {
 	.name = "ar",
 	.desc = "Open ar/lib files",
 	.license = "LGPL3",
+	.author = "xarkes",
 	.uris = "ar://,lib://",
 	.open = rz_io_ar_open,
 	.open_many = rz_io_ar_open_many,

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -1458,6 +1458,7 @@ beach:
 	rz_cons_set_raw(0);
 	rz_cons_free();
 	LISTS_FREE();
+	free(debugbackend);
 	RZ_FREE(pfile);
 	return ret;
 }

--- a/shlr/ar/ar.h
+++ b/shlr/ar/ar.h
@@ -2,19 +2,21 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 #ifndef _AR_H
 #define _AR_H
+#include <rz_util.h>
 
 typedef struct RZARFP {
 	char *name;
 	ut64 start;
 	ut64 end;
 	RzBuffer *buf;
-	ut32 *refcount;
+	bool shared_buf;
 } RzArFp;
 
 /* Offset passed is always the real io->off of the inspected file,
  * the functions automatically translate it to relative offset within the archive */
 RZ_API RzArFp *ar_open_file(const char *arname, int perm, const char *filename);
-RZ_API int ar_close(RzArFp *f);
+RZ_API RzList *ar_open_all(const char *arname, int perm);
+RZ_API void ar_close(RzArFp *f);
 RZ_API int ar_read_at(RzArFp *f, ut64 off, void *buf, int count);
 RZ_API int ar_write_at(RzArFp *f, ut64 off, void *buf, int count);
 #endif // _AR_H

--- a/test/db/formats/ar
+++ b/test/db/formats/ar
@@ -57,3 +57,224 @@ EXPECT=<<EOF
 0x00000000  6c6f 6e67 7370 6163 650a ffff ffff ffff  longspace.......
 EOF
 RUN
+
+NAME=ar load many
+FILE=ar://bins/ar/libgdbr.a
+CMDS=o ; is ; ou 5 ; is ; ou 10 ; is
+EXPECT=<<EOF
+ 3 * r-x 0x000036c0 ar://bins/ar/libgdbr.a//libgdbr.o
+ 4 - r-x 0x000048d8 ar://bins/ar/libgdbr.a//packet.o
+ 5 - r-x 0x00004388 ar://bins/ar/libgdbr.a//arch.o
+ 6 - r-x 0x000042e0 ar://bins/ar/libgdbr.a//common.o
+ 7 - r-x 0x00003008 ar://bins/ar/libgdbr.a//utils.o
+ 8 - r-x 0x00008b10 ar://bins/ar/libgdbr.a//core.o
+ 9 - r-x 0x00006e30 ar://bins/ar/libgdbr.a//xml.o
+10 - r-x 0x0001b898 ar://bins/ar/libgdbr.a//core.o
+11 - r-x 0x00013b38 ar://bins/ar/libgdbr.a//responses.o
+12 - r-x 0x000008b8 vfile://0/reloc-targets
+13 - r-x 0x000036c0 vfile://0/patched
+14 - r-x 0x00000aa8 vfile://1/reloc-targets
+15 - r-x 0x000048d8 vfile://1/patched
+16 - r-x 0x00000110 vfile://2/reloc-targets
+17 - r-x 0x00004388 vfile://2/patched
+18 - r-x 0x00000a80 vfile://3/reloc-targets
+19 - r-x 0x000042e0 vfile://3/patched
+20 - r-x 0x00000608 vfile://4/reloc-targets
+21 - r-x 0x00003008 vfile://4/patched
+22 - r-x 0x000015c8 vfile://5/reloc-targets
+23 - r-x 0x00008b10 vfile://5/patched
+24 - r-x 0x00000f80 vfile://6/reloc-targets
+25 - r-x 0x00006e30 vfile://6/patched
+26 - r-x 0x00005330 vfile://7/reloc-targets
+27 - r-x 0x0001b898 vfile://7/patched
+28 - rw- 0x00000028 null://40
+29 - r-x 0x00003ff0 vfile://8/reloc-targets
+30 - r-x 0x00013b38 vfile://8/patched
+31 - r-x 0x000008b8 vfile://9/reloc-targets
+32 - r-x 0x000036c0 vfile://9/patched
+nth paddr      vaddr      bind   type   size lib name                      
+---------------------------------------------------------------------------
+1   ---------- 0x00000000 LOCAL  FILE   0        libgdbr.c
+2   0x00000040 0x08000040 LOCAL  SECT   0        .text
+3   0x00000444 0x08000444 LOCAL  SECT   0        .data
+4   0x00000444 0x08000444 LOCAL  SECT   0        .bss
+5   0x00000450 0x08000450 LOCAL  SECT   0        .rodata
+6   0x000004b0 0x080004b0 LOCAL  OBJ    22       __func__.6092
+7   0x000004c6 0x080004c6 LOCAL  SECT   0        .debug_info
+8   0x00000a5f 0x08000a5f LOCAL  SECT   0        .debug_abbrev
+9   0x00000b41 0x08000b41 LOCAL  SECT   0        .debug_aranges
+10  0x00000b71 0x08000b71 LOCAL  SECT   0        .debug_line
+11  0x00000cd7 0x08000cd7 LOCAL  SECT   0        .debug_str
+12  0x00001217 0x08001217 LOCAL  SECT   0        .note.GNU-stack
+13  0x00001218 0x08001218 LOCAL  SECT   0        .eh_frame
+14  0x000011fc 0x080011fc LOCAL  SECT   0        .comment
+15  0x00000040 0x08000040 GLOBAL FUNC   484      gdbr_init
+21  0x00000224 0x08000224 GLOBAL FUNC   452      gdbr_set_architecture
+32  0x000003e8 0x080003e8 GLOBAL FUNC   92       gdbr_cleanup
+16  0x00000000 0x08000000 GLOBAL NOTYPE 16       imp._GLOBAL_OFFSET_TABLE_
+17  0x00000000 0x08000000 GLOBAL NOTYPE 16       imp.memset
+18  0x00000000 0x08000000 GLOBAL NOTYPE 16       imp.calloc
+19  0x00000000 0x08000000 GLOBAL NOTYPE 16       imp.free
+20  0x00000000 0x08000000 GLOBAL NOTYPE 16       imp.r_socket_new
+22  0x00000000 0x08000000 GLOBAL NOTYPE 16       imp.strcmp
+23  0x00000000 0x08000000 GLOBAL NOTYPE 16       imp.gdb_regs_mips
+24  0x00000000 0x08000000 GLOBAL NOTYPE 16       imp.gdb_regs_lm32
+25  0x00000000 0x08000000 GLOBAL NOTYPE 16       imp.gdb_regs_avr
+26  0x00000000 0x08000000 GLOBAL NOTYPE 16       imp.gdb_regs_x86_32
+27  0x00000000 0x08000000 GLOBAL NOTYPE 16       imp.gdb_regs_x86_64
+28  0x00000000 0x08000000 GLOBAL NOTYPE 16       imp.stderr
+29  0x00000000 0x08000000 GLOBAL NOTYPE 16       imp.fprintf
+30  0x00000000 0x08000000 GLOBAL NOTYPE 16       imp.gdb_regs_arm32
+31  0x00000000 0x08000000 GLOBAL NOTYPE 16       imp.gdb_regs_aarch64
+switched to fd 5 arch.o
+nth paddr      vaddr      bind   type size lib name             
+----------------------------------------------------------------
+1   ---------- 0x00000000 LOCAL  FILE 0        arch.c
+2   0x00000040 0x00000040 LOCAL  SECT 0        .text
+3   0x00000040 0x00000040 LOCAL  SECT 0        .data
+4   0x000036b0 0x000036b0 LOCAL  SECT 0        .bss
+5   0x000036b0 0x000036b0 LOCAL  SECT 0        .debug_info
+6   0x00003781 0x00003781 LOCAL  SECT 0        .debug_abbrev
+7   0x00003805 0x00003805 LOCAL  SECT 0        .debug_aranges
+8   0x00003825 0x00003825 LOCAL  SECT 0        .debug_line
+9   0x0000387b 0x0000387b LOCAL  SECT 0        .debug_str
+10  0x00003985 0x00003985 LOCAL  SECT 0        .note.GNU-stack
+11  0x0000396a 0x0000396a LOCAL  SECT 0        .comment
+12  0x00000040 0x00000040 GLOBAL OBJ  1200     gdb_regs_x86_64
+13  0x00000500 0x00000500 GLOBAL OBJ  816      gdb_regs_x86_32
+14  0x00000840 0x00000840 GLOBAL OBJ  1296     gdb_regs_arm32
+15  0x00000d60 0x00000d60 GLOBAL OBJ  3312     gdb_regs_aarch64
+16  0x00001a60 0x00001a60 GLOBAL OBJ  1920     gdb_regs_lm32
+17  0x000021e0 0x000021e0 GLOBAL OBJ  3552     gdb_regs_mips
+18  0x00002fc0 0x00002fc0 GLOBAL OBJ  1776     gdb_regs_avr
+switched to fd 10 core.o
+nth paddr      vaddr      bind   type   size lib name                        
+-----------------------------------------------------------------------------
+1   ---------- 0x00000000 LOCAL  FILE   0        core.c
+2   0x00000040 0x00000040 LOCAL  SECT   0        .text
+3   0x00003c3c 0x00003c3c LOCAL  SECT   0        .data
+4   0x00003c40 0x00003c40 LOCAL  SECT   0        .bss
+5   0x00000040 0x00000040 LOCAL  FUNC   276      set_interface_attribs
+6   0x00003c40 0x00003c40 LOCAL  OBJ    32       reg_cache
+7   0x00000154 0x00000154 LOCAL  FUNC   96       reg_cache_init
+8   0x00003c40 0x00003c40 LOCAL  SECT   0        .rodata
+9   0x000001b4 0x000001b4 LOCAL  FUNC   177      gdbr_connect_lldb
+10  0x00000f87 0x00000f87 LOCAL  FUNC   157      gdbr_read_registers_lldb
+11  0x00004080 0x00004080 LOCAL  OBJ    17       __func__.10461
+12  0x00003c3c 0x00003c3c LOCAL  OBJ    4        P.10515
+13  0x00003c60 0x00003c60 LOCAL  OBJ    8        cur_desc
+14  0x000021cb 0x000021cb LOCAL  FUNC   57       _sigint_handler
+15  0x00004098 0x00004098 LOCAL  OBJ    15       __func__.10626
+16  0x000040a8 0x000040a8 LOCAL  OBJ    15       __func__.10638
+17  0x000040c0 0x000040c0 LOCAL  OBJ    16       __func__.10645
+18  0x000040d0 0x000040d0 LOCAL  SECT   0        .debug_info
+19  0x00007b54 0x00007b54 LOCAL  SECT   0        .debug_abbrev
+20  0x00007cdd 0x00007cdd LOCAL  SECT   0        .debug_aranges
+21  0x00007d0d 0x00007d0d LOCAL  SECT   0        .debug_line
+22  0x00008339 0x00008339 LOCAL  SECT   0        .debug_str
+23  0x0000a1b2 0x0000a1b2 LOCAL  SECT   0        .note.GNU-stack
+24  0x0000a1b8 0x0000a1b8 LOCAL  SECT   0        .eh_frame
+25  0x0000a197 0x0000a197 LOCAL  SECT   0        .comment
+38  0x00000265 0x00000265 GLOBAL FUNC   1105     gdbr_connect
+48  0x00000879 0x00000879 GLOBAL FUNC   390      gdbr_check_vcont
+49  0x0000073e 0x0000073e GLOBAL FUNC   315      gdbr_select
+51  0x000006b6 0x000006b6 GLOBAL FUNC   136      gdbr_disconnect
+56  0x000009ff 0x000009ff GLOBAL FUNC   79       gdbr_stop_reason
+58  0x00000a4e 0x00000a4e GLOBAL FUNC   167      gdbr_check_extended_mode
+59  0x00000af5 0x00000af5 GLOBAL FUNC   298      gdbr_attach
+62  0x00000c1f 0x00000c1f GLOBAL FUNC   95       gdbr_detach
+63  0x00000c7e 0x00000c7e GLOBAL FUNC   313      gdbr_detach_pid
+64  0x00000db7 0x00000db7 GLOBAL FUNC   144      gdbr_kill
+65  0x00000e47 0x00000e47 GLOBAL FUNC   320      gdbr_kill_pid
+68  0x00001024 0x00001024 GLOBAL FUNC   314      gdbr_read_registers
+70  0x0000115e 0x0000115e GLOBAL FUNC   954      gdbr_read_memory
+75  0x00001518 0x00001518 GLOBAL FUNC   709      gdbr_write_memory
+78  0x000017dd 0x000017dd GLOBAL FUNC   149      gdbr_step
+79  0x00002204 0x00002204 GLOBAL FUNC   870      send_vcont
+80  0x00001872 0x00001872 GLOBAL FUNC   309      gdbr_continue
+82  0x000019a7 0x000019a7 GLOBAL FUNC   251      gdbr_write_bin_registers
+84  0x00001aa2 0x00001aa2 GLOBAL FUNC   365      gdbr_write_register
+86  0x00001c0f 0x00001c0f GLOBAL FUNC   395      gdbr_write_reg
+87  0x00001d9a 0x00001d9a GLOBAL FUNC   970      gdbr_write_registers
+92  0x00002164 0x00002164 GLOBAL FUNC   103      test_command
+97  0x0000256a 0x0000256a GLOBAL FUNC   426      set_bp
+99  0x00002714 0x00002714 GLOBAL FUNC   47       gdbr_set_bp
+100 0x00002743 0x00002743 GLOBAL FUNC   47       gdbr_set_hwbp
+101 0x00002772 0x00002772 GLOBAL FUNC   42       gdbr_remove_bp
+102 0x000027c6 0x000027c6 GLOBAL FUNC   419      remove_bp
+103 0x0000279c 0x0000279c GLOBAL FUNC   42       gdbr_remove_hwbp
+105 0x00002969 0x00002969 GLOBAL FUNC   453      gdbr_open_file
+107 0x00002b2e 0x00002b2e GLOBAL FUNC   496      gdbr_read_file
+109 0x00002d1e 0x00002d1e GLOBAL FUNC   249      gdbr_close_file
+111 0x00002e17 0x00002e17 GLOBAL FUNC   14       gdbr_invalidate_reg_cache
+112 0x00002e25 0x00002e25 GLOBAL FUNC   729      gdbr_send_qRcmd
+115 0x000030fe 0x000030fe GLOBAL FUNC   655      gdbr_exec_file_read
+117 0x0000338d 0x0000338d GLOBAL FUNC   467      gdbr_is_thread_dead
+118 0x00003560 0x00003560 GLOBAL FUNC   842      gdbr_threads_list
+124 0x000038aa 0x000038aa GLOBAL FUNC   912      gdbr_get_baddr
+26  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp._GLOBAL_OFFSET_TABLE_
+27  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.memset
+28  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.tcgetattr
+29  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.cfsetospeed
+30  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.cfsetispeed
+31  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.tcsetattr
+32  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.__stack_chk_fail
+33  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.malloc
+34  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.gdbr_read_target_xml
+35  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.send_msg
+36  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.read_packet
+37  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.send_ack
+39  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.r_strbuf_init
+40  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.getenv
+41  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.strtoul
+42  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.snprintf
+43  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.r_socket_connect_serial
+44  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.r_socket_connect
+45  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_qSupported
+46  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.strncmp
+47  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_qC
+50  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.strcmp
+52  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.r_socket_close
+53  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.free
+54  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.write_thread_id
+55  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.strtok
+57  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_stop_reason
+60  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.calloc
+61  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_attach
+66  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_lldb_read_reg
+67  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.memcpy
+69  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_g
+71  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.stderr
+72  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.fprintf
+73  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_m
+74  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.memmove
+76  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.pack_hex
+77  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_M
+81  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.strncpy
+83  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_G
+85  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_P
+88  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.strlen
+89  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.strchr
+90  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.strcpy
+91  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.hex2char
+93  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.hexdump
+94  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.r_socket_write
+95  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.signal
+96  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_cont
+98  0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_setbp
+104 0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_removebp
+106 0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_vFile_open
+108 0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_vFile_pread
+110 0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.handle_vFile_close
+113 0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.__ctype_b_loc
+114 0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.unpack_hex
+116 0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.r_str_append
+119 0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.r_list_new
+120 0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.read_thread_id
+121 0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.strdup
+122 0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.r_list_free
+123 0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.r_list_append
+125 0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.r_str_startswith
+126 0x00000000 0x00000000 GLOBAL NOTYPE 16       imp.strtoull
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This will load all the `*.o` files embedded inside an `.a` file

I will keep this here, but i will postpone the completion of the PR