### PR TITLE
io: silence warning on openbsd

### DIFF
--- a/librz/include/rz_io.h
+++ b/librz/include/rz_io.h
@@ -42,7 +42,7 @@ typedef void *rz_ptrace_data_t;
 typedef int rz_ptrace_request_t;
 typedef void *rz_ptrace_data_t;
 #define RZ_PTRACE_NODATA NULL
-#elif __APPLE__
+#elif __APPLE__ || __OpenBSD__
 typedef int rz_ptrace_request_t;
 typedef int rz_ptrace_data_t;
 #define RZ_PTRACE_NODATA 0


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)

Fixes the following warning:
```
../librz/io/io.c:653:36: warning: incompatible pointer to integer conversion passing 'rz_ptrace_data_t' (aka 'void *') to parameter of type 'int' [-Wint-conversion]
        return ptrace(request, pid, addr, data);
                                          ^~~~
/usr/include/sys/ptrace.h:132:57: note: passing argument to parameter '_data' here
int     ptrace(int _request, pid_t _pid, caddr_t _addr, int _data);
                                                            ^
1 warning generated.
[450/1682] Compiling C object librz/io/librz_io.so.0.3.0-git.p/p_io_ptrace.c.o[K
../librz/io/p/io_ptrace.c:134:12: warning: cast to 'rz_ptrace_data_t' (aka 'void *') from smaller integer type 'ptrace_word' (aka 'int') [-Wint-to-void-pointer-cast]
                int rc = debug_write_raw(io, pid, at++, buf[x]); //((ut32*)(at)), buf[x]);
                         ^
../librz/io/p/io_ptrace.c:57:92: note: expanded from macro 'debug_write_raw'
#define debug_write_raw(io, x, y, z) rz_io_ptrace((io), PTRACE_POKEDATA, (x), (void *)(y), (rz_ptrace_data_t)(z))
                                                                                           ^
../librz/io/p/io_ptrace.c:142:7: warning: cast to 'rz_ptrace_data_t' (aka 'void *') from smaller integer type 'ptrace_word' (aka 'int') [-Wint-to-void-pointer-cast]
                if (debug_write_raw(io, pid, (void *)at, lr)) {
                    ^
../librz/io/p/io_ptrace.c:57:92: note: expanded from macro 'debug_write_raw'
#define debug_write_raw(io, x, y, z) rz_io_ptrace((io), PTRACE_POKEDATA, (x), (void *)(y), (rz_ptrace_data_t)(z))
                                                                                           ^
../librz/io/p/io_ptrace.c:202:61: warning: incompatible integer to pointer conversion passing 'int' to parameter of type 'rz_ptrace_data_t' (aka 'void *') [-Wint-conversion]
        return rz_io_ptrace(io, PT_GET_PROCESS_STATE, pid, &state, len) != -1;
                                                                   ^~~
../librz/include/rz_io.h:450:105: note: passing argument to parameter 'data' here
RZ_API long rz_io_ptrace(RzIO *io, rz_ptrace_request_t request, pid_t pid, void *addr, rz_ptrace_data_t data);
                                                                                                        ^
3 warnings generated.
```