### PR TITLE
For now, let's just ignore C0209 pylint error

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -60,7 +60,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=C0103,C0114,C0115,C0116,E0401,R0902
+disable=C0103,C0114,C0115,C0116,E0401,R0902,C0209
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
C0209: Formatting a regular string which could be a f-string
(consider-using-f-string)

Keep using regular format string formatting.