### PR TITLE
Port `g` (egg/shellcode) commands to the rzshell

### DIFF
--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -85,12 +85,12 @@ static bool lastcmd_repeat(RzCore *core, int next);
 #include "cmd_project.c"
 #include "cmd_write.c"
 #include "cmd_cmp.c"
+#include "cmd_egg.c"
 #include "cmd_eval.c"
 #include "cmd_interpret.c"
 #include "cmd_analysis.c"
 #include "cmd_open.c"
 #include "cmd_type.c"
-#include "cmd_egg.c"
 #include "cmd_info.c"
 #include "cmd_meta.c"
 #include "cmd_macro.c"
@@ -6129,7 +6129,6 @@ RZ_API void rz_core_cmd_init(RzCore *core) {
 		{ "c", "compare memory", rz_cmd_cmp },
 		{ "d", "debugger operations", rz_cmd_debug },
 		{ "f", "get/set flags", rz_cmd_flag },
-		{ "g", "egg manipulation", rz_cmd_egg },
 		{ "k", "perform sdb query", rz_cmd_kuery },
 		{ "ls", "list files and directories", rz_cmd_ls },
 		{ "m", "make directory and move files", rz_cmd_m },

--- a/librz/core/cmd/cmd_egg.c
+++ b/librz/core/cmd/cmd_egg.c
@@ -1,29 +1,21 @@
 // SPDX-FileCopyrightText: 2009-2018 pancake <pancake@nopcode.org>
+// SPDX-FileCopyrightText: 2021 Anton Kochkov <anton.kochkov@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include "rz_cons.h"
-#include "rz_core.h"
-#include "rz_egg.h"
+#include <rz_core.h>
+#include <rz_egg.h>
 
-static const char *help_msg_g[] = {
-	"Usage:", "g[wcilper] [arg]", "Go compile shellcodes",
-	"g", " ", "Compile the shellcode",
-	"g", " foo.r", "Compile rz_egg source file",
-	"gw", "", "Compile and write",
-	"gc", " cmd=/bin/ls", "Set config option for shellcodes and encoders",
-	"gc", "", "List all config options",
-	"gl", "[?]", "List plugins (shellcodes, encoders)",
-	"gs", " name args", "Compile syscall name(args)",
-	"gi", " [type]", "Define the shellcode type",
-	"gp", " padding", "Define padding for command",
-	"ge", " [encoder] [key]", "Specify an encoder and a key",
-	"gr", "", "Reset rz_egg",
-	"gS", "", "Show the current configuration",
-	"EVAL VARS:", "", "asm.arch, asm.bits, asm.os",
+static const char *RzEggConfigOptions[] = {
+	"egg.shellcode",
+	"egg.encoder",
+	"egg.padding",
+	"key",
+	"cmd",
+	"suid",
 	NULL
 };
 
-static void cmd_egg_option(RzEgg *egg, const char *key, const char *input) {
+static void egg_option(RzEgg *egg, const char *key, const char *input) {
 	if (!*input) {
 		return;
 	}
@@ -53,38 +45,7 @@ static void showBuffer(RzBuffer *b) {
 	}
 }
 
-#if 0
-static int compileShellcode(RzEgg *egg, const char *input){
-	int i = 0;
-	RzBuffer *b;
-	if (!rz_egg_shellcode (egg, input)) {
-		eprintf ("Unknown shellcode '%s'\n", input);
-		return 1;
-	}
-	if (!rz_egg_assemble (egg)) {
-		eprintf ("rz_egg_assemble : invalid assembly\n");
-		rz_egg_reset (egg);
-		return 1;
-	}
-	if (!egg->bin) {
-		egg->bin = rz_buf_new ();
-	}
-	if (!(b = rz_egg_get_bin (egg))) {
-		eprintf ("rz_egg_get_bin: invalid egg :(\n");
-		rz_egg_reset (egg);
-		return 1;
-	}
-	rz_egg_finalize (egg);
-	for (i = 0; i < b->length; i++) {
-		rz_cons_printf ("%02x", b->buf[i]);
-	}
-	rz_cons_newline ();
-	rz_egg_reset (egg);
-	return 0;
-}
-#endif
-
-static int cmd_egg_compile(RzEgg *egg) {
+static bool rz_core_egg_compile(RzEgg *egg) {
 	RzBuffer *b;
 	int ret = false;
 	char *p = rz_egg_option_get(egg, "egg.shellcode");
@@ -120,8 +81,6 @@ static int cmd_egg_compile(RzEgg *egg) {
 		showBuffer(b);
 		ret = true;
 	}
-	// we do not own this buffer!!
-	// rz_buf_free (b);
 	rz_egg_option_set(egg, "egg.shellcode", "");
 	rz_egg_option_set(egg, "egg.padding", "");
 	rz_egg_option_set(egg, "egg.encoder", "");
@@ -131,166 +90,182 @@ static int cmd_egg_compile(RzEgg *egg) {
 	return ret;
 }
 
-RZ_IPI int rz_cmd_egg(void *data, const char *input) {
-	RzCore *core = (RzCore *)data;
+static RzEgg *rz_core_egg_setup(RzCore *core) {
 	RzEgg *egg = core->egg;
-	char *oa, *p;
-	rz_egg_setup(egg,
-		rz_config_get(core->config, "asm.arch"),
-		core->rasm->bits, 0,
-		rz_config_get(core->config, "asm.os")); // XXX
-	switch (*input) {
-	case 's': // "gs"
-		// TODO: pass args to rz_core_syscall without vararg
-		if (input[1] == ' ') {
-			RzBuffer *buf = NULL;
-			const char *ooaa = input + 2;
-			while (IS_WHITESPACE(*ooaa) && *ooaa)
-				ooaa++;
-			oa = strdup(ooaa);
-			p = strchr(oa + 1, ' ');
-			if (p) {
-				*p = 0;
-				buf = rz_core_syscall(core, oa, p + 1);
-			} else {
-				buf = rz_core_syscall(core, oa, "");
-			}
-			free(oa);
-			if (buf) {
-				showBuffer(buf);
-			}
-			egg->lang.nsyscalls = 0;
-		} else {
-			eprintf("Usage: gs [syscallname] [parameters]\n");
-		}
-		break;
-	case ' ': // "g "
-		if (input[1] && input[2]) {
-			rz_egg_load(egg, input + 2, 0);
-			if (!cmd_egg_compile(egg)) {
-				eprintf("Cannot compile '%s'\n", input + 2);
-			}
-		} else {
-			eprintf("wat\n");
-		}
-		break;
-	case '\0': // "g"
-		if (!cmd_egg_compile(egg)) {
-			eprintf("Cannot compile\n");
-		}
-		break;
-	case 'p': // "gp"
-		if (input[1] == ' ') {
-			if (input[0] && input[2]) {
-				rz_egg_option_set(egg, "egg.padding", input + 2);
-			}
-		} else {
-			eprintf("Usage: gp [padding]\n");
-		}
-		break;
-	case 'e': // "ge"
-		if (input[1] == ' ') {
-			const char *encoder = input + 2;
-			while (IS_WHITESPACE(*encoder) && *encoder) {
-				encoder++;
-			}
+	const char *arch = rz_config_get(core->config, "asm.arch");
+	const char *os = rz_config_get(core->config, "asm.os");
+	int bits = rz_config_get_i(core->config, "asm.bits");
 
-			oa = strdup(encoder);
-			p = strchr(oa + 1, ' ');
+	if (!rz_egg_setup(egg, arch, bits, 0, os)) {
+		RZ_LOG_ERROR("Cannot setup shellcode compiler for chosen configuration");
+		return NULL;
+	}
+	return egg;
+}
 
-			if (p) {
-				*p = 0;
-				rz_egg_option_set(egg, "key", p + 1);
-				rz_egg_option_set(egg, "egg.encoder", oa);
-			} else {
-				eprintf("Usage: ge [encoder] [key]\n");
+RZ_IPI RzCmdStatus rz_egg_compile_handler(RzCore *core, int argc, const char **argv) {
+	RzEgg *egg = rz_core_egg_setup(core);
+	if (!egg) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+	if (argc > 1) {
+		rz_egg_load(egg, argv[1], 0);
+	}
+	if (!rz_core_egg_compile(egg)) {
+		RZ_LOG_ERROR("Cannot compile the shellcode");
+		return RZ_CMD_STATUS_ERROR;
+	}
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_egg_config_handler(RzCore *core, int argc, const char **argv) {
+	RzEgg *egg = rz_core_egg_setup(core);
+	if (!egg) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+	if (argc > 1) {
+		// Set the config option
+		RzList *l = rz_str_split_duplist_n(argv[1], "=", 1, false);
+		if (!l) {
+			return RZ_CMD_STATUS_ERROR;
+		}
+		size_t llen = rz_list_length(l);
+		if (!llen) {
+			return RZ_CMD_STATUS_ERROR;
+		}
+		char *key = rz_list_get_n(l, 0);
+		if (RZ_STR_ISEMPTY(key)) {
+			RZ_LOG_ERROR("No config option name specified");
+			rz_list_free(l);
+			return RZ_CMD_STATUS_ERROR;
+		}
+		// If there is value specified - set it, if not - just show the value
+		if (llen == 1) {
+			// No value
+			char *o = rz_egg_option_get(egg, key);
+			if (!o) {
+				RZ_LOG_ERROR("No such config option exists");
+				rz_list_free(l);
+				return RZ_CMD_STATUS_ERROR;
 			}
-			free(oa);
-		} else {
-			eprintf("Usage: ge [encoder] [key]\n");
-		}
-		break;
-	case 'i': // "gi"
-		if (input[1] == ' ') {
-			if (input[0] && input[2]) {
-				rz_egg_option_set(egg, "egg.shellcode", input + 2);
-			} else {
-				eprintf("Usage: gi [shellcode-type]\n");
+			rz_cons_print(o);
+			free(o);
+		} else if (llen == 2) {
+			char *value = rz_list_get_n(l, 1);
+			if (RZ_STR_ISEMPTY(value)) {
+				RZ_LOG_ERROR("No config option value  specified");
+				rz_list_free(l);
+				return RZ_CMD_STATUS_ERROR;
 			}
-		} else {
-			eprintf("Usage: gi [shellcode-type]\n");
+			rz_egg_option_set(egg, key, value);
 		}
-		break;
-	case 'l': // "gl"
-	{
-		RzListIter *iter;
-		RzEggPlugin *p;
-		rz_list_foreach (egg->plugins, iter, p) {
-			rz_cons_printf("%s  %6s : %s\n",
-				(p->type == RZ_EGG_PLUGIN_SHELLCODE) ? "shc" : "enc", p->name, p->desc);
-		}
-	} break;
-	case 'S': // "gS"
-	{
-		static const char *configList[] = {
-			"egg.shellcode",
-			"egg.encoder",
-			"egg.padding",
-			"key",
-			"cmd",
-			"suid",
-			NULL
-		};
-		rz_cons_printf("Configuration options\n");
-		int i;
-		for (i = 0; configList[i]; i++) {
-			const char *p = configList[i];
+		rz_list_free(l);
+	} else {
+		// List all available config options and their values
+		size_t i;
+		for (i = 0; RzEggConfigOptions[i]; i++) {
+			const char *p = RzEggConfigOptions[i];
 			if (rz_egg_option_get(egg, p)) {
 				rz_cons_printf("%s : %s\n", p, rz_egg_option_get(egg, p));
 			} else {
 				rz_cons_printf("%s : %s\n", p, "");
 			}
 		}
-		rz_cons_printf("\nTarget options\n");
-		rz_cons_printf("arch : %s\n", core->analysis->cpu);
-		rz_cons_printf("os   : %s\n", core->analysis->os);
-		rz_cons_printf("bits : %d\n", core->analysis->bits);
-	} break;
-	case 'r': // "gr"
-		cmd_egg_option(egg, "egg.padding", "");
-		cmd_egg_option(egg, "egg.shellcode", "");
-		cmd_egg_option(egg, "egg.encoder", "");
-		break;
-	case 'c': // "gc"
-		// list, get, set egg options
-		switch (input[1]) {
-		case ' ':
-			oa = strdup(input + 2);
-			p = strchr(oa, '=');
-			if (p) {
-				*p = 0;
-				rz_egg_option_set(egg, oa, p + 1);
-			} else {
-				char *o = rz_egg_option_get(egg, oa);
-				if (o) {
-					rz_cons_print(o);
-					free(o);
-				}
-			}
-			free(oa);
-			break;
-		case '\0':
-			// rz_pair_list (egg->pair,NULL);
-			eprintf("TODO: list options\n");
-			break;
-		default:
-			eprintf("Usage: gc [k=v]\n");
-			break;
-		}
-		break;
-	case '?':
-		rz_core_cmd_help(core, help_msg_g);
-		break;
 	}
-	return true;
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_egg_list_plugins_handler(RzCore *core, int argc, const char **argv) {
+	RzEgg *egg = rz_core_egg_setup(core);
+	if (!egg) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+	RzListIter *iter;
+	RzEggPlugin *p;
+	rz_list_foreach (egg->plugins, iter, p) {
+		rz_cons_printf("%s  %6s : %s\n",
+			(p->type == RZ_EGG_PLUGIN_SHELLCODE) ? "shc" : "enc", p->name, p->desc);
+	}
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_egg_syscall_handler(RzCore *core, int argc, const char **argv) {
+	RzEgg *egg = rz_core_egg_setup(core);
+	if (!egg) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+	RzBuffer *buf = NULL;
+	if (argc > 2) {
+		// With syscall parameters specified
+		buf = rz_core_syscall(core, argv[1], argv[2]);
+	} else {
+		// Without any parameters
+		buf = rz_core_syscall(core, argv[1], "");
+	}
+	if (buf) {
+		showBuffer(buf);
+	}
+	egg->lang.nsyscalls = 0;
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_egg_type_handler(RzCore *core, int argc, const char **argv) {
+	RzEgg *egg = rz_core_egg_setup(core);
+	if (!egg) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_egg_option_set(egg, "egg.shellcode", argv[1]);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_egg_padding_handler(RzCore *core, int argc, const char **argv) {
+	RzEgg *egg = rz_core_egg_setup(core);
+	if (!egg) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_egg_option_set(egg, "egg.padding", argv[1]);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_egg_encoder_handler(RzCore *core, int argc, const char **argv) {
+	RzEgg *egg = rz_core_egg_setup(core);
+	if (!egg) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_egg_option_set(egg, "key", argv[2]);
+	rz_egg_option_set(egg, "egg.encoder", argv[1]);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_egg_reset_handler(RzCore *core, int argc, const char **argv) {
+	RzEgg *egg = rz_core_egg_setup(core);
+	if (!egg) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+	egg_option(egg, "egg.padding", "");
+	egg_option(egg, "egg.shellcode", "");
+	egg_option(egg, "egg.encoder", "");
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_egg_show_config_handler(RzCore *core, int argc, const char **argv) {
+	RzEgg *egg = rz_core_egg_setup(core);
+	if (!egg) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_cons_printf("Configuration options\n");
+	int i;
+	for (i = 0; RzEggConfigOptions[i]; i++) {
+		const char *p = RzEggConfigOptions[i];
+		if (rz_egg_option_get(egg, p)) {
+			rz_cons_printf("%s : %s\n", p, rz_egg_option_get(egg, p));
+		} else {
+			rz_cons_printf("%s : %s\n", p, "");
+		}
+	}
+	rz_cons_printf("\nTarget options\n");
+	rz_cons_printf("arch : %s\n", core->analysis->cpu);
+	rz_cons_printf("os   : %s\n", core->analysis->os);
+	rz_cons_printf("bits : %d\n", core->analysis->bits);
+	return RZ_CMD_STATUS_OK;
 }

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -16,6 +16,7 @@ static const RzCmdDescDetail cmd_debug_add_cond_bp_details[2];
 static const RzCmdDescDetail cmd_debug_add_watchpoint_details[2];
 static const RzCmdDescDetail eval_getset_details[2];
 static const RzCmdDescDetail env_details[3];
+static const RzCmdDescDetail egg_config_details[2];
 static const RzCmdDescDetail history_list_or_exec_details[2];
 static const RzCmdDescDetail wB_details[2];
 static const RzCmdDescDetail wv_details[2];
@@ -190,6 +191,12 @@ static const RzCmdDescArg eval_readonly_args[2];
 static const RzCmdDescArg eval_spaces_args[2];
 static const RzCmdDescArg eval_type_args[2];
 static const RzCmdDescArg env_args[3];
+static const RzCmdDescArg egg_compile_args[2];
+static const RzCmdDescArg egg_config_args[2];
+static const RzCmdDescArg egg_syscall_args[3];
+static const RzCmdDescArg egg_type_args[2];
+static const RzCmdDescArg egg_padding_args[2];
+static const RzCmdDescArg egg_encoder_args[3];
 static const RzCmdDescArg history_list_or_exec_args[2];
 static const RzCmdDescArg cmd_info_class_as_source_args[2];
 static const RzCmdDescArg cmd_info_class_fields_args[2];
@@ -4105,8 +4112,138 @@ static const RzCmdDescHelp cmd_flag_help = {
 	.summary = "Manage flags",
 };
 
-static const RzCmdDescHelp cmd_egg_help = {
+static const RzCmdDescHelp g_help = {
 	.summary = "Generate shellcodes with rz_egg",
+};
+static const RzCmdDescArg egg_compile_args[] = {
+	{
+		.name = "file",
+		.type = RZ_CMD_ARG_TYPE_FILE,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp egg_compile_help = {
+	.summary = "Compile the shellcode",
+	.args = egg_compile_args,
+};
+
+static const RzCmdDescDetailEntry egg_config_Examples_detail_entries[] = {
+	{ .text = "gc", .arg_str = " egg.encoder", .comment = "Show current value of config variable `egg.encoder`" },
+	{ .text = "gc", .arg_str = " egg.encoder=xor", .comment = "Set config variable `egg.encoder` to `xor`" },
+	{ 0 },
+};
+static const RzCmdDescDetail egg_config_details[] = {
+	{ .name = "Examples", .entries = egg_config_Examples_detail_entries },
+	{ 0 },
+};
+static const RzCmdDescArg egg_config_args[] = {
+	{
+		.name = "key=value",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_ARRAY,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp egg_config_help = {
+	.summary = "Get/Set config option for shellcode / List all config options",
+	.args_str = " <key>[=<val>] [<key>[=<val>] ...]]",
+	.details = egg_config_details,
+	.args = egg_config_args,
+};
+
+static const RzCmdDescArg egg_list_plugins_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp egg_list_plugins_help = {
+	.summary = "List shellcode and encoder plugins",
+	.args = egg_list_plugins_args,
+};
+
+static const RzCmdDescArg egg_syscall_args[] = {
+	{
+		.name = "name",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+
+	},
+	{
+		.name = "args",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_ARRAY,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp egg_syscall_help = {
+	.summary = "Compile syscall \"name(args)\"",
+	.args = egg_syscall_args,
+};
+
+static const RzCmdDescArg egg_type_args[] = {
+	{
+		.name = "type",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp egg_type_help = {
+	.summary = "Define the shellcode type",
+	.args = egg_type_args,
+};
+
+static const RzCmdDescArg egg_padding_args[] = {
+	{
+		.name = "padding",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp egg_padding_help = {
+	.summary = "Define padding for command",
+	.args = egg_padding_args,
+};
+
+static const RzCmdDescArg egg_encoder_args[] = {
+	{
+		.name = "encoder",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+
+	},
+	{
+		.name = "key",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp egg_encoder_help = {
+	.summary = "Specify an encoder and a key",
+	.args = egg_encoder_args,
+};
+
+static const RzCmdDescArg egg_reset_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp egg_reset_help = {
+	.summary = "Reset the shellcode configuration",
+	.args = egg_reset_args,
+};
+
+static const RzCmdDescArg egg_show_config_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp egg_show_config_help = {
+	.summary = "Show the current configuration",
+	.args = egg_show_config_args,
 };
 
 static const RzCmdDescHelp H_help = {
@@ -8217,8 +8354,31 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *cmd_flag_cd = rz_cmd_desc_oldinput_new(core->rcmd, root_cd, "f", rz_cmd_flag, &cmd_flag_help);
 	rz_warn_if_fail(cmd_flag_cd);
 
-	RzCmdDesc *cmd_egg_cd = rz_cmd_desc_oldinput_new(core->rcmd, root_cd, "g", rz_cmd_egg, &cmd_egg_help);
-	rz_warn_if_fail(cmd_egg_cd);
+	RzCmdDesc *g_cd = rz_cmd_desc_group_new(core->rcmd, root_cd, "g", rz_egg_compile_handler, &egg_compile_help, &g_help);
+	rz_warn_if_fail(g_cd);
+	RzCmdDesc *egg_config_cd = rz_cmd_desc_argv_new(core->rcmd, g_cd, "gc", rz_egg_config_handler, &egg_config_help);
+	rz_warn_if_fail(egg_config_cd);
+
+	RzCmdDesc *egg_list_plugins_cd = rz_cmd_desc_argv_new(core->rcmd, g_cd, "gl", rz_egg_list_plugins_handler, &egg_list_plugins_help);
+	rz_warn_if_fail(egg_list_plugins_cd);
+
+	RzCmdDesc *egg_syscall_cd = rz_cmd_desc_argv_new(core->rcmd, g_cd, "gs", rz_egg_syscall_handler, &egg_syscall_help);
+	rz_warn_if_fail(egg_syscall_cd);
+
+	RzCmdDesc *egg_type_cd = rz_cmd_desc_argv_new(core->rcmd, g_cd, "gi", rz_egg_type_handler, &egg_type_help);
+	rz_warn_if_fail(egg_type_cd);
+
+	RzCmdDesc *egg_padding_cd = rz_cmd_desc_argv_new(core->rcmd, g_cd, "gp", rz_egg_padding_handler, &egg_padding_help);
+	rz_warn_if_fail(egg_padding_cd);
+
+	RzCmdDesc *egg_encoder_cd = rz_cmd_desc_argv_new(core->rcmd, g_cd, "ge", rz_egg_encoder_handler, &egg_encoder_help);
+	rz_warn_if_fail(egg_encoder_cd);
+
+	RzCmdDesc *egg_reset_cd = rz_cmd_desc_argv_new(core->rcmd, g_cd, "gr", rz_egg_reset_handler, &egg_reset_help);
+	rz_warn_if_fail(egg_reset_cd);
+
+	RzCmdDesc *egg_show_config_cd = rz_cmd_desc_argv_new(core->rcmd, g_cd, "gS", rz_egg_show_config_handler, &egg_show_config_help);
+	rz_warn_if_fail(egg_show_config_cd);
 
 	RzCmdDesc *H_cd = rz_cmd_desc_group_new(core->rcmd, root_cd, "H", rz_history_list_or_exec_handler, &history_list_or_exec_help, &H_help);
 	rz_warn_if_fail(H_cd);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -4172,7 +4172,7 @@ static const RzCmdDescArg egg_syscall_args[] = {
 	{
 		.name = "args",
 		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_ARRAY,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
 		.optional = true,
 
 	},

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -304,7 +304,15 @@ RZ_IPI RzCmdStatus rz_eval_type_handler(RzCore *core, int argc, const char **arg
 RZ_IPI RzCmdStatus rz_env_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_exit_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI int rz_cmd_flag(void *data, const char *input);
-RZ_IPI int rz_cmd_egg(void *data, const char *input);
+RZ_IPI RzCmdStatus rz_egg_compile_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_egg_config_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_egg_list_plugins_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_egg_syscall_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_egg_type_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_egg_padding_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_egg_encoder_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_egg_reset_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_egg_show_config_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_history_list_or_exec_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_history_clear_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_history_save_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_descs.yaml
+++ b/librz/core/cmd_descs/cmd_descs.yaml
@@ -208,9 +208,8 @@ commands:
     summary: Manage flags
     type: RZ_CMD_DESC_TYPE_OLDINPUT
   - name: g
-    cname: cmd_egg
     summary: Generate shellcodes with rz_egg
-    type: RZ_CMD_DESC_TYPE_OLDINPUT
+    subcommands: cmd_egg
   - name: H
     summary: Rizin history commands.
     subcommands: cmd_history

--- a/librz/core/cmd_descs/cmd_egg.yaml
+++ b/librz/core/cmd_descs/cmd_egg.yaml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2021 RizinOrg <info@rizin.re>
+# SPDX-License-Identifier: LGPL-3.0-only
+---
+name: cmd_egg
+commands:
+  - name: g
+    cname: egg_compile
+    summary: Compile the shellcode
+    args:
+      - name: file
+        type: RZ_CMD_ARG_TYPE_FILE
+        optional: true
+  - name: gc
+    cname: egg_config
+    summary: Get/Set config option for shellcode / List all config options
+    args_str: " <key>[=<val>] [<key>[=<val>] ...]]"
+    args:
+      - name: key=value
+        type: RZ_CMD_ARG_TYPE_STRING
+        flags: RZ_CMD_ARG_FLAG_ARRAY
+        optional: true
+    details:
+      - name: Examples
+        entries:
+          - text: gc
+            arg_str: " egg.encoder"
+            comment: "Show current value of config variable `egg.encoder`"
+          - text: gc
+            arg_str: " egg.encoder=xor"
+            comment: "Set config variable `egg.encoder` to `xor`"
+  - name: gl
+    cname: egg_list_plugins
+    summary: List shellcode and encoder plugins
+    args: []
+  - name: gs
+    cname: egg_syscall
+    summary: Compile syscall "name(args)"
+    args:
+      - name: name
+        type: RZ_CMD_ARG_TYPE_STRING
+      - name: args
+        type: RZ_CMD_ARG_TYPE_STRING
+        flags: RZ_CMD_ARG_FLAG_ARRAY
+        optional: true
+  - name: gi
+    cname: egg_type
+    summary: Define the shellcode type
+    args:
+      - name: type
+        type: RZ_CMD_ARG_TYPE_STRING
+  - name: gp
+    cname: egg_padding
+    summary: Define padding for command
+    args:
+      - name: padding
+        type: RZ_CMD_ARG_TYPE_RZNUM
+  - name: ge
+    cname: egg_encoder
+    summary: Specify an encoder and a key
+    args:
+      - name: encoder
+        type: RZ_CMD_ARG_TYPE_STRING
+      - name: key
+        type: RZ_CMD_ARG_TYPE_STRING
+  - name: gr
+    cname: egg_reset
+    summary: Reset the shellcode configuration
+    args: []
+  - name: gS
+    cname: egg_show_config
+    args: []
+    summary: Show the current configuration

--- a/librz/core/cmd_descs/cmd_egg.yaml
+++ b/librz/core/cmd_descs/cmd_egg.yaml
@@ -40,7 +40,6 @@ commands:
         type: RZ_CMD_ARG_TYPE_STRING
       - name: args
         type: RZ_CMD_ARG_TYPE_STRING
-        flags: RZ_CMD_ARG_FLAG_ARRAY
         optional: true
   - name: gi
     cname: egg_type

--- a/librz/core/cmd_descs/meson.build
+++ b/librz/core/cmd_descs/meson.build
@@ -4,6 +4,7 @@ cmd_descs_yaml = files(
   'cmd_block.yaml',
   'cmd_debug.yaml',
   'cmd_descs.yaml',
+  'cmd_egg.yaml',
   'cmd_eval.yaml',
   'cmd_heap_glibc.yaml',
   'cmd_history.yaml',

--- a/librz/egg/egg.c
+++ b/librz/egg/egg.c
@@ -121,13 +121,11 @@ RZ_API void rz_egg_reset(RzEgg *egg) {
 	rz_list_purge(egg->patches);
 }
 
-RZ_API int rz_egg_setup(RzEgg *egg, const char *arch, int bits, int endian, const char *os) {
+RZ_API bool rz_egg_setup(RzEgg *egg, const char *arch, int bits, int endian, const char *os) {
 	const char *asmcpu = NULL; // TODO
 	egg->remit = NULL;
 
 	egg->os = os ? rz_str_hash(os) : RZ_EGG_OS_DEFAULT;
-	//eprintf ("%s -> %x (linux=%x) (darwin=%x)\n", os, egg->os, RZ_EGG_OS_LINUX, RZ_EGG_OS_DARWIN);
-	// TODO: setup egg->arch for all archs
 	if (!strcmp(arch, "x86")) {
 		egg->arch = RZ_SYS_ARCH_X86;
 		switch (bits) {
@@ -159,8 +157,10 @@ RZ_API int rz_egg_setup(RzEgg *egg, const char *arch, int bits, int endian, cons
 		egg->remit = &emit_trace;
 		egg->bits = bits;
 		egg->endian = endian;
+	} else {
+		return false;
 	}
-	return 0;
+	return true;
 }
 
 RZ_API int rz_egg_include(RzEgg *egg, const char *file, int format) {

--- a/librz/egg/egg.c
+++ b/librz/egg/egg.c
@@ -25,6 +25,22 @@ void egg_patch_free(void *p) {
 	free(ep);
 }
 
+RZ_API const char *rz_egg_os_as_string(int os) {
+	switch (os) {
+	case RZ_EGG_OS_LINUX: return "linux";
+	case RZ_EGG_OS_OSX: return "osx";
+	case RZ_EGG_OS_DARWIN: return "darwin";
+	case RZ_EGG_OS_WATCHOS: return "watchos";
+	case RZ_EGG_OS_IOS: return "ios";
+	case RZ_EGG_OS_MACOS: return "macos";
+	case RZ_EGG_OS_W32: return "win32";
+	case RZ_EGG_OS_WINDOWS: return "windows";
+	case RZ_EGG_OS_BEOS: return "beos";
+	case RZ_EGG_OS_FREEBSD: return "freebsd";
+	default: return "linux";
+	}
+}
+
 RZ_API RzEgg *rz_egg_new(void) {
 	int i;
 	RzEgg *egg = RZ_NEW0(RzEgg);
@@ -76,7 +92,6 @@ beach:
 RZ_API int rz_egg_add(RzEgg *a, RzEggPlugin *foo) {
 	RzListIter *iter;
 	RzAsmPlugin *h;
-	// TODO: cache foo->name length and use memcmp instead of strcmp
 	if (!foo->name) {
 		return false;
 	}
@@ -94,24 +109,24 @@ RZ_API char *rz_egg_to_string(RzEgg *egg) {
 }
 
 RZ_API void rz_egg_free(RzEgg *egg) {
-	if (egg) {
-		rz_buf_free(egg->src);
-		rz_buf_free(egg->buf);
-		rz_buf_free(egg->bin);
-		rz_list_free(egg->list);
-		rz_asm_free(egg->rasm);
-		rz_syscall_free(egg->syscall);
-		sdb_free(egg->db);
-		rz_list_free(egg->plugins);
-		rz_list_free(egg->patches);
-		rz_egg_lang_free(egg);
-		free(egg);
+	if (!egg) {
+		return;
 	}
+	rz_buf_free(egg->src);
+	rz_buf_free(egg->buf);
+	rz_buf_free(egg->bin);
+	rz_list_free(egg->list);
+	rz_asm_free(egg->rasm);
+	rz_syscall_free(egg->syscall);
+	sdb_free(egg->db);
+	rz_list_free(egg->plugins);
+	rz_list_free(egg->patches);
+	rz_egg_lang_free(egg);
+	free(egg);
 }
 
 RZ_API void rz_egg_reset(RzEgg *egg) {
 	rz_egg_lang_include_init(egg);
-	// TODO: use rz_list_purge instead of free/new here
 	rz_buf_free(egg->src);
 	rz_buf_free(egg->buf);
 	rz_buf_free(egg->bin);
@@ -185,6 +200,7 @@ RZ_API int rz_egg_include(RzEgg *egg, const char *file, int format) {
 }
 
 RZ_API void rz_egg_load(RzEgg *egg, const char *code, int format) {
+	rz_return_if_fail(code);
 	switch (format) {
 	case 'a': // assembly
 		rz_buf_append_bytes(egg->buf, (const ut8 *)code, strlen(code));
@@ -193,6 +209,47 @@ RZ_API void rz_egg_load(RzEgg *egg, const char *code, int format) {
 		rz_buf_append_bytes(egg->src, (const ut8 *)code, strlen(code));
 		break;
 	}
+}
+
+RZ_API bool rz_egg_load_file(RzEgg *egg, const char *file) {
+	rz_return_val_if_fail(file, false);
+	// We have to reset the RzEgg state first
+	rz_egg_reset(egg);
+	if (rz_str_endswith(file, ".c")) {
+		char *fileSanitized = strdup(file);
+		rz_str_sanitize(fileSanitized);
+		const char *arch = rz_sys_arch_str(egg->arch);
+		const char *os = rz_egg_os_as_string(egg->os);
+		char *textFile = rz_egg_Cfile_parser(fileSanitized, arch, os, egg->bits);
+		if (!textFile) {
+			RZ_LOG_ERROR("Failure while parsing '%s'\n", fileSanitized);
+			free(fileSanitized);
+			return false;
+		}
+		size_t l;
+		char *buf = rz_file_slurp(textFile, &l);
+		if (buf && l > 0) {
+			rz_egg_raw(egg, (const ut8 *)buf, (int)l);
+		} else {
+			RZ_LOG_ERROR("Error loading '%s'\n", textFile);
+		}
+		rz_file_rm(textFile);
+		free(fileSanitized);
+		free(textFile);
+		free(buf);
+	} else {
+		int fmt;
+		if (rz_str_endswith(file, ".s") || rz_str_endswith(file, ".asm")) {
+			fmt = 'a';
+		} else {
+			fmt = 0;
+		}
+		if (!rz_egg_include(egg, file, fmt)) {
+			RZ_LOG_ERROR("Cannot open '%s'\n", file);
+			return false;
+		}
+	}
+	return true;
 }
 
 RZ_API void rz_egg_syscall(RzEgg *egg, const char *arg, ...) {

--- a/librz/include/rz_egg.h
+++ b/librz/include/rz_egg.h
@@ -184,6 +184,7 @@ typedef struct rz_egg_emit_t {
 RZ_API RzEgg *rz_egg_new(void);
 RZ_API void rz_egg_lang_init(RzEgg *egg);
 RZ_API void rz_egg_lang_free(RzEgg *egg);
+RZ_API const char *rz_egg_os_as_string(int os);
 RZ_API char *rz_egg_to_string(RzEgg *egg);
 RZ_API void rz_egg_free(RzEgg *egg);
 RZ_API int rz_egg_add(RzEgg *a, RzEggPlugin *foo);
@@ -191,6 +192,7 @@ RZ_API void rz_egg_reset(RzEgg *egg);
 RZ_API bool rz_egg_setup(RzEgg *egg, const char *arch, int bits, int endian, const char *os);
 RZ_API int rz_egg_include(RzEgg *egg, const char *file, int format);
 RZ_API void rz_egg_load(RzEgg *egg, const char *code, int format);
+RZ_API bool rz_egg_load_file(RzEgg *egg, const char *file);
 RZ_API void rz_egg_syscall(RzEgg *egg, const char *arg, ...) RZ_PRINTF_CHECK(2, 3);
 RZ_API void rz_egg_alloc(RzEgg *egg, int n);
 RZ_API void rz_egg_label(RzEgg *egg, const char *name);

--- a/librz/include/rz_egg.h
+++ b/librz/include/rz_egg.h
@@ -188,7 +188,7 @@ RZ_API char *rz_egg_to_string(RzEgg *egg);
 RZ_API void rz_egg_free(RzEgg *egg);
 RZ_API int rz_egg_add(RzEgg *a, RzEggPlugin *foo);
 RZ_API void rz_egg_reset(RzEgg *egg);
-RZ_API int rz_egg_setup(RzEgg *egg, const char *arch, int bits, int endian, const char *os);
+RZ_API bool rz_egg_setup(RzEgg *egg, const char *arch, int bits, int endian, const char *os);
 RZ_API int rz_egg_include(RzEgg *egg, const char *file, int format);
 RZ_API void rz_egg_load(RzEgg *egg, const char *code, int format);
 RZ_API void rz_egg_syscall(RzEgg *egg, const char *arg, ...) RZ_PRINTF_CHECK(2, 3);

--- a/librz/main/rz-gg.c
+++ b/librz/main/rz-gg.c
@@ -374,37 +374,9 @@ RZ_API int rz_main_rz_gg(int argc, const char **argv) {
 				}
 				rz_egg_load(egg, buf, 0);
 			}
-		} else if (strstr(file, ".c")) {
-			char *fileSanitized = strdup(file);
-			rz_str_sanitize(fileSanitized);
-			char *textFile = rz_egg_Cfile_parser(fileSanitized, arch, os, bits);
-
-			if (!textFile) {
-				eprintf("Failure while parsing '%s'\n", fileSanitized);
-				goto fail;
-			}
-
-			size_t l;
-			char *buf = rz_file_slurp(textFile, &l);
-			if (buf && l > 0) {
-				rz_egg_raw(egg, (const ut8 *)buf, (int)l);
-			} else {
-				eprintf("Error loading '%s'\n", textFile);
-			}
-
-			rz_file_rm(textFile);
-			free(fileSanitized);
-			free(textFile);
-			free(buf);
 		} else {
-			if (strstr(file, ".s") || strstr(file, ".asm")) {
-				fmt = 'a';
-			} else {
-				fmt = 0;
-			}
-			if (!rz_egg_include(egg, file, fmt)) {
-				eprintf("Cannot open '%s'\n", file);
-				goto fail;
+			if (!rz_egg_load_file(egg, file)) {
+				eprintf("Cannot load file \"%s\"\n", file);
 			}
 		}
 	}

--- a/test/db/cmd/cmd_egg
+++ b/test/db/cmd/cmd_egg
@@ -1,0 +1,73 @@
+NAME=gc - get/set config option
+FILE==
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+e asm.os=linux
+gc
+gi exec
+gc
+EOF
+EXPECT=<<EOF
+egg.shellcode : 
+egg.encoder : 
+egg.padding : 
+key : 
+cmd : 
+suid : 
+egg.shellcode : exec
+egg.encoder : 
+egg.padding : 
+key : 
+cmd : 
+suid : 
+EOF
+RUN
+
+NAME=gl - list plugins
+FILE==
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+e asm.os=linux
+gl
+EOF
+EXPECT=<<EOF
+shc    exec : execute cmd=/bin/sh suid=false
+enc     xor : xor encoder for shellcode
+EOF
+RUN
+
+NAME=g - compile the shellcode
+FILE==
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+e asm.os=linux
+gi exec
+g
+gr
+e asm.bits=64
+gi exec
+g
+EOF
+EXPECT=<<EOF
+31c050682f2f7368682f62696e89e3505389e199b00bcd80
+31c048bbd19d9691d08c97ff48f7db53545f995257545eb03b0f05
+EOF
+RUN
+
+NAME=g - compile the shellcode from file
+BROKEN=1
+FILE==
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+e asm.os=linux
+g bins/other/rz-gg/simple_cmp.r
+EOF
+EXPECT=<<EOF
+5589e581ec80000000c745086869210ac7450c6e000000c74510000000008d4508898504000000c7450501000000c745060200000055583b45060f8f5a0000006a04546a018b1c248b8c24040000008b942408000000b804000000cd8083c40c6a008b1c24b801000000cd8083c40481c4800000005dc3
+EOF
+RUN
+


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Migrate `g` (egg/shellcode) commands to the rzshell
- Removed `gw`, since it was mentioned in the help but not implemented
- Made `gc` (set egg options) behave like `e` command

**Test plan**

CI is green

Partially addresses #1342