### PR TITLE
Fix some null derefs in Windows Debugger

### DIFF
--- a/librz/debug/p/native/windows/windows_debug.c
+++ b/librz/debug/p/native/windows/windows_debug.c
@@ -1295,7 +1295,7 @@ static void w32_info_user(RzDebug *dbg, RzDebugInfo *rdi) {
 	SID_NAME_USE snu = { 0 };
 	W32DbgWInst *wrap = dbg->plugin_data;
 
-	if (!wrap->pi.hProcess) {
+	if (!wrap || !wrap->pi.hProcess) {
 		return;
 	}
 	if (!OpenProcessToken(wrap->pi.hProcess, TOKEN_QUERY, &h_tok)) {
@@ -1344,6 +1344,9 @@ err_w32_info_user:
 
 static void w32_info_exe(RzDebug *dbg, RzDebugInfo *rdi) {
 	W32DbgWInst *wrap = dbg->plugin_data;
+	if (!wrap) {
+		return;
+	}
 	rdi->exe = resolve_path(wrap->pi.hProcess, NULL);
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

When `dc` is running in a background task (as it does in cutter) and the process is stopped from another task, there may be a race condition where the `wrap` pointer is already null in these places.

This complements https://github.com/rizinorg/cutter/pull/2783 on rizin side. The changes here are not strictly necessary for cutter though.