### PR TITLE
Removed junk on screen in visual mode with two columns

### DIFF
--- a/librz/core/visual.c
+++ b/librz/core/visual.c
@@ -3777,12 +3777,13 @@ static void visual_refresh(RzCore *core) {
 			if (split_w > w) {
 				// do not show column contents
 			} else {
+				rz_cons_clear();
 				rz_cons_printf("[cmd.cprompt=%s]\n", vi);
 				if (oseek != UT64_MAX) {
 					rz_core_seek(core, oseek, true);
 				}
 				rz_core_cmd0(core, vi);
-				rz_cons_column(split_w);
+				rz_cons_column(split_w + 1);
 				if (!strncmp(vi, "p=", 2) && core->print->cur_enabled) {
 					oseek = core->offset;
 					core->print->cur_enabled = false;

--- a/librz/core/visual.c
+++ b/librz/core/visual.c
@@ -3771,26 +3771,22 @@ static void visual_refresh(RzCore *core) {
 	if (vsplit) {
 		// XXX: slow
 		core->cons->blankline = false;
-		{
-			int hex_cols = rz_config_get_i(core->config, "hex.cols");
-			int split_w = 12 + 4 + hex_cols + (hex_cols * 3);
-			if (split_w > w) {
-				// do not show column contents
+		if (split_w > w) {
+			// do not show column contents
+		} else {
+			rz_cons_clear();
+			rz_cons_printf("[cmd.cprompt=%s]\n", vi);
+			if (oseek != UT64_MAX) {
+				rz_core_seek(core, oseek, true);
+			}
+			rz_core_cmd0(core, vi);
+			rz_cons_column(split_w + 1);
+			if (!strncmp(vi, "p=", 2) && core->print->cur_enabled) {
+				oseek = core->offset;
+				core->print->cur_enabled = false;
+				rz_core_seek(core, core->num->value, true);
 			} else {
-				rz_cons_clear();
-				rz_cons_printf("[cmd.cprompt=%s]\n", vi);
-				if (oseek != UT64_MAX) {
-					rz_core_seek(core, oseek, true);
-				}
-				rz_core_cmd0(core, vi);
-				rz_cons_column(split_w + 1);
-				if (!strncmp(vi, "p=", 2) && core->print->cur_enabled) {
-					oseek = core->offset;
-					core->print->cur_enabled = false;
-					rz_core_seek(core, core->num->value, true);
-				} else {
-					oseek = UT64_MAX;
-				}
+				oseek = UT64_MAX;
 			}
 		}
 		rz_cons_gotoxy(0, 0);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

I forced a screen refresh when painting two columns in visual mode, fixing #1717.
I also added a 1 char space between the two columns.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

As in #1717, type
```
[0x00006b10]> Vp
```
Then press "|" key to set the second column
It will ask for the value to `cmd.cprompt`, type `px`
Now there is no more junk on the right column.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #1717
