### PR TITLE
Detect `shm_open()` function with Meson

### DIFF
--- a/librz/include/rz_userconf.h.in
+++ b/librz/include/rz_userconf.h.in
@@ -23,6 +23,7 @@
 #define HAVE_OPENPTY                @HAVE_OPENPTY@
 #define HAVE_FORKPTY                @HAVE_FORKPTY@
 #define HAVE_LOGIN_TTY              @HAVE_LOGIN_TTY@
+#define HAVE_SHM_OPEN               @HAVE_SHM_OPEN@
 #define HAVE_LIB_MAGIC              @HAVE_LIB_MAGIC@
 #define USE_LIB_MAGIC               @USE_LIB_MAGIC@
 #define HAVE_LIB_XXHASH             @HAVE_LIB_XXHASH@

--- a/librz/io/meson.build
+++ b/librz/io/meson.build
@@ -49,7 +49,6 @@ if host_machine.system() == 'windows'
   ]
 endif
 
-
 rz_io_deps = [
   bochs_dep,
   gdb_dep,
@@ -58,6 +57,7 @@ rz_io_deps = [
   libzip_dep,
   ar_dep,
   pth,
+  lrt,
   rz_util_dep,
   rz_socket_dep,
   rz_hash_dep,

--- a/meson.build
+++ b/meson.build
@@ -348,6 +348,11 @@ if not cc.has_function('clock_gettime', prefix: '#include <time.h>') and cc.has_
   lrt = cc.find_library('rt', required: true, static: is_static_build)
 endif
 
+have_lrt = not ['windows', 'darwin', 'openbsd', 'android'].contains(host_machine.system())
+if have_lrt and lrt == []
+  lrt = cc.find_library('rt', required: true, static: is_static_build)
+endif
+
 code = '#include <unistd.h>\nextern char **environ;\nint main() { char **env = environ; }'
 have_environ = cc.links(code, name: 'have extern char **environ')
 userconf.set10('HAVE_ENVIRON', have_environ)
@@ -375,6 +380,7 @@ foreach item : [
     ['nice', '#include <unistd.h>', []],
     ['copyfile', '#include <copyfile.h>', []],
     ['strlcpy', '#include <string.h>', []],
+    ['shm_open', '#include <sys/mman.h>', [lrt]],
     ['openpty', '', [utl]],
     ['forkpty', '', [utl]],
     ['login_tty', '', [utl]],


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Before it was disabled completely

**Test plan**

Run the following Python script:

```py
#!/usr/bin/env python3

import rzpipe
from multiprocessing import shared_memory

FILENAME="/bin/ls"

with open(FILENAME, "rb") as f:
    data = f.read()
    shm_a = shared_memory.SharedMemory(create=True, size=len(data))
    print("Copying %s..." % FILENAME)
    shm_a.buf[:] = data[:]
    print("Copied %s succesfully" % FILENAME)

    print(shm_a.buf[:5])
    print(shm_a.name)

    print("Opening Rizin...")
    rzp = rzpipe.open("shm://{0:s}".format(shm_a.name))
    rzp.cmd("aa")
    print(rzp.cmd("afl"))
    print(rzp.cmdj("ij"))
    rzp.quit()
    shm_a.close()
    shm_a.unlink()
```
Should output something like this:
```
[i] ℤ LD_PRELOAD=/lib64/libasan.so.6 ./shared_memory.py                                                     20:20:52
Copying /bin/ls...
Copied /bin/ls succesfully
<memory at 0x7f40fba79b80>
psm_15b6e947
Opening Rizin...
Connected to shared memory "psm_15b6e947" (0xf3437adb)
- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0x00000000  ffff ffff ffff ffff ffff ffff ffff ffff  ................


{'core': {'file': 'shm://psm_15b6e947', 'fd': 3, 'size': 4294967295, 'humansz': '4.0G', 'iorw': False, 'mode': 'r-x',
'block': 256, 'format': 'any'}}
~/rizin/tests
[i] ℤ  ./shared_memory.py                                                     20:25:03
Copying /bin/ls...
Copied /bin/ls succesfully
<memory at 0x7f38bc3f4b80>
psm_be8dd05d
Opening Rizin...
Connected to shared memory "psm_be8dd05d" (0x21da57aa)
- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0x00006b10  f30f 1efa 31ed 4989 d15e 4889 e248 83e4  ....1.I..^H..H..

0x00006b10    1 46           entry0
0x0000fcc0   53 1345 -> 1287 sym._obstack_newchunk
0x0000fca0   23 35705 -> 370  sym._obstack_begin_1
0x000106e0    8 55   -> 45   sym._obstack_allocated_p
0x0000fc80    1 21           sym._obstack_begin
0x000107b0    3 38           sym._obstack_memory_used
0x00010720   12 47678 -> 124  sym._obstack_free
0x000046c0    1 11           sym.imp.__ctype_toupper_loc
0x000046d0    1 11           sym.imp.getenv
0x000046e0    1 11           sym.imp.cap_to_text
0x000046f0    1 11           sym.imp.sigprocmask
0x00004700    1 11           sym.imp.__snprintf_chk
0x00004710    1 11           sym.imp.raise
0x00004720    1 11           sym.imp.free
0x00004730    1 11           sym.imp.abort
0x00004740    1 11           sym.imp.__errno_location
0x00004750    1 11           sym.imp.strncmp
0x00004760    1 11           sym.imp.localtime_r
0x00004770    1 11           sym.imp._exit
0x00004780    1 11           sym.imp.strcpy
0x00004790    1 11           sym.imp.__fpending
0x000047a0    1 11           sym.imp.isatty
0x000047b0    1 11           sym.imp.sigaction
0x000047c0    1 11           sym.imp.iswcntrl
0x000047d0    1 11           sym.imp.wcswidth
0x000047e0    1 11           sym.imp.localeconv
0x000047f0    1 11           sym.imp.mbstowcs
0x00004800    1 11           sym.imp.readlink
0x00004810    1 11           sym.imp.clock_gettime
0x00004820    1 11           sym.imp.setenv
0x00004830    1 11           sym.imp.textdomain
0x00004840    1 11           sym.imp.fclose
0x00004850    1 11           sym.imp.opendir
0x00004860    1 11           sym.imp.getpwuid
0x00004870    1 11           sym.imp.bindtextdomain
0x00004880    1 11           sym.imp.dcgettext
0x00004890    1 11           sym.imp.__ctype_get_mb_cur_max
0x000048a0    1 11           sym.imp.strlen
0x000048b0    1 11           sym.imp.__stack_chk_fail
0x000048c0    1 11           sym.imp.getopt_long
0x000048d0    1 11           sym.imp.mbrtowc
0x000048e0    1 11           sym.imp.freecon
0x000048f0    1 11           sym.imp.strchr
0x00004900    1 11           sym.imp.getgrgid
0x00004910    1 11           sym.imp.snprintf
0x00004920    1 11           sym.imp.__overflow
0x00004930    1 11           sym.imp.strrchr
0x00004940    1 11           sym.imp.gmtime_r
0x00004950    1 11           sym.imp.lseek
0x00004960    1 11           sym.imp.__assert_fail
0x00004970    1 11           sym.imp.fnmatch
0x00004980    1 11           sym.imp.memset
0x00004990    1 11           sym.imp.ioctl
0x000049a0    1 11           sym.imp.getcwd
0x000049b0    1 11           sym.imp.closedir
0x000049c0    1 11           sym.imp.lstat
0x000049d0    1 11           sym.imp.memcmp
0x000049e0    1 11           sym.imp._setjmp
0x000049f0    1 11           sym.imp.fputs_unlocked
0x00004a00    1 11           sym.imp.calloc
0x00004a10    1 11           sym.imp.strcmp
0x00004a20    1 11           sym.imp.signal
0x00004a30    1 11           sym.imp.dirfd
0x00004a40    1 11           sym.imp.fputc_unlocked
0x00004a50    1 11           sym.imp.__memcpy_chk
0x00004a60    1 11           sym.imp.sigemptyset
0x00004a70    1 11           sym.imp.memcpy
0x00004a80    1 11           sym.imp.tzset
0x00004a90    1 11           sym.imp.fileno
0x00004aa0    1 11           sym.imp.tcgetpgrp
0x00004ab0    1 11           sym.imp.readdir
0x00004ac0    1 11           sym.imp.wcwidth
0x00004ad0    1 11           sym.imp.malloc
0x00004ae0    1 11           sym.imp.fflush
0x00004af0    1 11           sym.imp.nl_langinfo
0x00004b00    1 11           sym.imp.strcoll
0x00004b10    1 11           sym.imp.mktime
0x00004b20    1 11           sym.imp.__freading
0x00004b30    1 11           sym.imp.fwrite_unlocked
0x00004b40    1 11           sym.imp.realloc
0x00004b50    1 11           sym.imp.stpncpy
0x00004b60    1 11           sym.imp.setlocale
0x00004b70    1 11           sym.imp.__printf_chk
0x00004b80    1 11           sym.imp.statx
0x00004b90    1 11           sym.imp.timegm
0x00004ba0    1 11           sym.imp.strftime
0x00004bb0    1 11           sym.imp.mempcpy
0x00004bc0    1 11           sym.imp.memmove
0x00004bd0    1 11           sym.imp.error
0x00004be0    1 11           sym.imp.fseeko
0x00004bf0    1 11           sym.imp.cap_get_file
0x00004c00    1 11           sym.imp.strtoumax
0x00004c10    1 11           sym.imp.unsetenv
0x00004c20    1 11           sym.imp.cap_free
0x00004c30    1 11           sym.imp.__cxa_atexit
0x00004c40    1 11           sym.imp.wcstombs
0x00004c50    1 11           sym.imp.getxattr
0x00004c60    1 11           sym.imp.gethostname
0x00004c70    1 11           sym.imp.sigismember
0x00004c80    1 11           sym.imp.exit
0x00004c90    1 11           sym.imp.fwrite
0x00004ca0    1 11           sym.imp.__fprintf_chk
0x00004cb0    1 11           sym.imp.getfilecon
0x00004cc0    1 11           sym.imp.fflush_unlocked
0x00004cd0    1 11           sym.imp.mbsinit
0x00004ce0    1 11           sym.imp.lgetfilecon
0x00004cf0    1 11           sym.imp.iswprint
0x00004d00    1 11           sym.imp.__cxa_finalize
0x00004d10    1 11           sym.imp.sigaddset
0x00004d20    1 11           sym.imp.__ctype_tolower_loc
0x00004d30    1 11           sym.imp.__ctype_b_loc
0x00004d40    1 11           sym.imp.__sprintf_chk
0x00004d80  353 7568 -> 7531 main
0x00006bf0    5 137  -> 60   entry.init0
0x00006bb0    5 57   -> 54   entry.fini0
0x00006b40    4 41   -> 34   fcn.00006b40

{'core': {'file': 'shm://psm_be8dd05d', 'fd': 3, 'size': 4294967295, 'humansz': '4.0G', 'iorw': False, 'mode': 'r-x',
'block': 256, 'format': 'elf64'}, 'bin': {'arch': 'x86', 'baddr': 0, 'binsz': 140034, 'bintype': 'elf', 'bits': 64, 'c
lass': 'ELF64', 'endian': 'LE', 'intrp': '/lib64/ld-linux-x86-64.so.2', 'laddr': 0, 'lang': 'c', 'machine': 'AMD x86-6
4 architecture', 'maxopsz': 16, 'minopsz': 1, 'os': 'linux', 'pcalign': 0, 'relro': 'full', 'rpath': 'NONE', 'subsys':
 'linux', 'stripped': True, 'crypto': False, 'havecode': True, 'va': True, 'sanitiz': False, 'static': False, 'linenum
': False, 'lsyms': False, 'canary': True, 'PIE': True, 'RELROCS': False, 'NX': True}}
~/rizin/tests
```


**Closing issues**
