### PR TITLE
Refactor loading of the PE headers

### DIFF
--- a/librz/bin/format/mdmp/mdmp.c
+++ b/librz/bin/format/mdmp/mdmp.c
@@ -1219,8 +1219,12 @@ static bool rz_bin_mdmp_patch_pe_headers(RzBuffer *pe_buf) {
 	Pe64_image_dos_header dos_hdr;
 	Pe64_image_nt_headers nt_hdr;
 
-	Pe64_read_dos_header(pe_buf, &dos_hdr);
-	Pe64_read_nt_headers(pe_buf, dos_hdr.e_lfanew, &nt_hdr);
+	if (!Pe64_read_dos_header(pe_buf, &dos_hdr)) {
+		return false;
+	}
+	if (!Pe64_read_nt_headers(pe_buf, dos_hdr.e_lfanew, &nt_hdr)) {
+		return false;
+	}
 
 	/* Patch RawData in headers */
 	ut64 sect_hdrs_off = dos_hdr.e_lfanew + 4 + sizeof(Pe64_image_file_header) + nt_hdr.file_header.SizeOfOptionalHeader;

--- a/librz/bin/format/pe/pe.h
+++ b/librz/bin/format/pe/pe.h
@@ -152,7 +152,7 @@ struct PE_(rz_bin_pe_obj_t) {
 	ut64 delay_import_directory_offset;
 
 	int import_directory_size;
-	int size;
+	ut64 size;
 	int num_sections;
 	int endian;
 	bool verbose;

--- a/librz/bin/format/pe/pe_misc.c
+++ b/librz/bin/format/pe/pe_misc.c
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2021 08A <08A@riseup.net>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include "pe.h"
+
+bool rz_bin_pe_buffer_read_le8(RzBuffer *buf, ut64 *offset, ut8 *result) {
+	rz_return_val_if_fail(buf && offset && result, false);
+	if (!rz_buf_read8_at(buf, *offset, result)) {
+		return false;
+	}
+	*offset += 1;
+	return true;
+}
+
+bool rz_bin_pe_buffer_read_le16(RzBuffer *buf, ut64 *offset, ut16 *result) {
+	rz_return_val_if_fail(buf && offset && result, false);
+	if (!rz_buf_read_le16_at(buf, *offset, result)) {
+		return false;
+	}
+	*offset += 2;
+	return true;
+}
+
+bool rz_bin_pe_buffer_read_le32(RzBuffer *buf, ut64 *offset, ut32 *result) {
+	rz_return_val_if_fail(buf && offset && result, false);
+	if (!rz_buf_read_le32_at(buf, *offset, result)) {
+		return false;
+	}
+	*offset += 4;
+	return true;
+}
+
+bool rz_bin_pe_buffer_read_le64(RzBuffer *buf, ut64 *offset, ut64 *result) {
+	rz_return_val_if_fail(buf && offset && result, false);
+	if (!rz_buf_read_le64_at(buf, *offset, result)) {
+		return false;
+	}
+	*offset += 8;
+	return true;
+}

--- a/librz/bin/format/pe/pe_specs.h
+++ b/librz/bin/format/pe/pe_specs.h
@@ -786,14 +786,19 @@ typedef struct {
 	PE64_SCOPE_RECORD ScopeRecord[];
 } PE64_SCOPE_TABLE;
 
-int Pe32_read_dos_header(RzBuffer *b, Pe32_image_dos_header *header);
-int Pe32_read_nt_headers(RzBuffer *b, ut64 addr, Pe32_image_nt_headers *headers);
-int Pe32_read_image_section_header(RzBuffer *b, ut64 addr, Pe32_image_section_header *section_header);
+bool rz_bin_pe_buffer_read_le8(RzBuffer *buf, ut64 *offset, ut8 *result);
+bool rz_bin_pe_buffer_read_le16(RzBuffer *buf, ut64 *offset, ut16 *result);
+bool rz_bin_pe_buffer_read_le32(RzBuffer *buf, ut64 *offset, ut32 *result);
+bool rz_bin_pe_buffer_read_le64(RzBuffer *buf, ut64 *offset, ut64 *result);
+
+bool Pe32_read_dos_header(RzBuffer *buf, Pe32_image_dos_header *header);
+bool Pe32_read_nt_headers(RzBuffer *buf, ut64 addr, Pe32_image_nt_headers *headers);
+bool Pe32_read_image_section_header(RzBuffer *b, ut64 addr, Pe32_image_section_header *section_header);
 void Pe32_write_image_section_header(RzBuffer *b, ut64 addr, Pe32_image_section_header *section_header);
 
-int Pe64_read_dos_header(RzBuffer *b, Pe64_image_dos_header *header);
-int Pe64_read_nt_headers(RzBuffer *b, ut64 addr, Pe64_image_nt_headers *headers);
-int Pe64_read_image_section_header(RzBuffer *b, ut64 addr, Pe64_image_section_header *section_header);
+bool Pe64_read_dos_header(RzBuffer *buf, Pe64_image_dos_header *header);
+bool Pe64_read_nt_headers(RzBuffer *buf, ut64 addr, Pe64_image_nt_headers *headers);
+bool Pe64_read_image_section_header(RzBuffer *b, ut64 addr, Pe64_image_section_header *section_header);
 void Pe64_write_image_section_header(RzBuffer *b, ut64 addr, Pe64_image_section_header *section_header);
 
 #endif

--- a/librz/bin/meson.build
+++ b/librz/bin/meson.build
@@ -137,6 +137,7 @@ rz_bin_sources = [
   'format/pe/pe.c',
   'format/pe/pe64.c',
   'format/pe/pemixed.c',
+  'format/pe/pe_misc.c',
   'format/pyc/marshal.c',
   'format/pyc/pyc.c',
   'format/pyc/pyc_magic.c',


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

If we open PE file through `shm://` it loads all headers from seek value 0, without incrementing that seek automatically for every value. Used the same approach as in ELF

See https://github.com/rizinorg/rizin/pull/1761

**Test plan**

CI is green