### PR TITLE
`rz_utf8_decode()`: Remove Java `\0` overlong special case by adding `mutf8` decoder

### DIFF
--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -73,6 +73,7 @@ RZ_API RZ_BORROW const char *rz_bin_string_type(int type) {
 	switch (type) {
 	case RZ_STRING_TYPE_ASCII: return "ascii";
 	case RZ_STRING_TYPE_UTF8: return "utf8";
+	case RZ_STRING_TYPE_MUTF8: return "mutf8";
 	case RZ_STRING_TYPE_WIDE_LE: return "utf16le";
 	case RZ_STRING_TYPE_WIDE32_LE: return "utf32le";
 	case RZ_STRING_TYPE_WIDE_BE: return "utf16be";

--- a/librz/bin/format/java/class_bin.c
+++ b/librz/bin/format/java/class_bin.c
@@ -1014,7 +1014,7 @@ RZ_API RZ_OWN RzList *rz_bin_java_class_strings(RZ_NONNULL RzBinJavaClass *bin) 
 			bstr->length = cpool->size;
 			bstr->size = cpool->size;
 			bstr->string = string;
-			bstr->type = RZ_STRING_TYPE_UTF8;
+			bstr->type = RZ_STRING_TYPE_MUTF8;
 			rz_list_append(list, bstr);
 		}
 	}

--- a/librz/bin/format/java/class_const_pool.c
+++ b/librz/bin/format/java/class_const_pool.c
@@ -165,7 +165,7 @@ char *java_constant_pool_stringify(const ConstPool *cpool) {
 		if (!cpool->size) {
 			return NULL;
 		}
-		return rz_str_escape_utf8_for_json((const char *)cpool->buffer, cpool->size);
+		return rz_str_escape_mutf8_for_json((const char *)cpool->buffer, cpool->size);
 	}
 	case CONSTANT_POOL_LONG: {
 		st64 value = rz_read_be64(cpool->buffer);

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -2651,6 +2651,7 @@ static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzList *l
 
 			switch (string->type) {
 			case RZ_STRING_TYPE_UTF8:
+			case RZ_STRING_TYPE_MUTF8:
 			case RZ_STRING_TYPE_WIDE_LE:
 			case RZ_STRING_TYPE_WIDE32_LE:
 				block_list = rz_utf_block_list((const ut8 *)string->string, -1, NULL);
@@ -2704,6 +2705,7 @@ static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzList *l
 			RzStrBuf *buf = rz_strbuf_new(str);
 			switch (string->type) {
 			case RZ_STRING_TYPE_UTF8:
+			case RZ_STRING_TYPE_MUTF8:
 			case RZ_STRING_TYPE_WIDE_LE:
 			case RZ_STRING_TYPE_WIDE32_LE:
 				block_list = rz_utf_block_list((const ut8 *)string->string, -1, NULL);

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -161,6 +161,7 @@ enum {
 	RZ_STRING_TYPE_DETECT = '?',
 	RZ_STRING_TYPE_ASCII = 'a',
 	RZ_STRING_TYPE_UTF8 = 'u',
+	RZ_STRING_TYPE_MUTF8 = 'm', // modified utf8
 	RZ_STRING_TYPE_WIDE_LE = 'w', // utf16 / widechar string
 	RZ_STRING_TYPE_WIDE32_LE = 'W', // utf32
 	RZ_STRING_TYPE_WIDE_BE = 'x', // utf16-be / widechar string
@@ -765,7 +766,7 @@ typedef struct rz_bin_string_t {
 	ut32 ordinal;
 	ut32 size; // size of buffer containing the string in bytes
 	ut32 length; // length of string in chars
-	char type; // Ascii Wide cp850 utf8 base64 ...
+	char type; // Ascii Wide cp850 utf8 mutf8 base64 ...
 } RzBinString;
 
 typedef struct rz_bin_field_t {

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -194,6 +194,7 @@ RZ_API char *rz_str_utf16_decode(const ut8 *s, int len);
 RZ_API int rz_str_utf16_to_utf8(ut8 *dst, int len_dst, const ut8 *src, int len_src, int little_endian);
 RZ_API char *rz_str_utf16_encode(const char *s, int len);
 RZ_API char *rz_str_escape_utf8_for_json(const char *s, int len);
+RZ_API char *rz_str_escape_mutf8_for_json(const char *s, int len);
 RZ_API char *rz_str_home(const char *str);
 RZ_API char *rz_str_rz_prefix(const char *str);
 RZ_API size_t rz_str_nlen(const char *s, int n);

--- a/librz/include/rz_util/rz_utf8.h
+++ b/librz/include/rz_util/rz_utf8.h
@@ -13,6 +13,7 @@ typedef struct {
 typedef ut32 RzRune;
 RZ_API int rz_utf8_encode(ut8 *ptr, const RzRune ch);
 RZ_API int rz_utf8_decode(const ut8 *ptr, int ptrlen, RzRune *ch);
+RZ_API int rz_mutf8_decode(const ut8 *ptr, int ptrlen, RzRune *ch);
 RZ_API int rz_utf8_encode_str(const RzRune *str, ut8 *dst, const int dst_length);
 RZ_API int rz_utf8_size(const ut8 *ptr);
 RZ_API int rz_utf8_strlen(const ut8 *str);

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -1519,7 +1519,7 @@ RZ_API char *rz_str_escape_utf32be(const char *buf, int buf_size, bool show_asci
 	return rz_str_escape_utf(buf, buf_size, RZ_STRING_ENC_UTF32BE, show_asciidot, esc_bslash, false);
 }
 
-RZ_API char *rz_str_escape_utf8_for_json(const char *buf, int buf_size) {
+static char *escape_utf8_for_json(const char *buf, int buf_size, bool mutf8) {
 	char *new_buf, *q;
 	const char *p, *end;
 	RzRune ch;
@@ -1538,7 +1538,7 @@ RZ_API char *rz_str_escape_utf8_for_json(const char *buf, int buf_size) {
 	p = buf;
 	q = new_buf;
 	while (p < end) {
-		ch_bytes = rz_utf8_decode((ut8 *)p, end - p, &ch);
+		ch_bytes = mutf8 ? rz_mutf8_decode((ut8 *)p, end - p, &ch) : rz_utf8_decode((ut8 *)p, end - p, &ch);
 		if (ch_bytes == 1) {
 			switch (*p) {
 			case '\n':
@@ -1627,6 +1627,14 @@ RZ_API char *rz_str_escape_utf8_for_json(const char *buf, int buf_size) {
 	}
 	*q = '\0';
 	return new_buf;
+}
+
+RZ_API char *rz_str_escape_utf8_for_json(const char *buf, int buf_size) {
+	return escape_utf8_for_json(buf, buf_size, false);
+}
+
+RZ_API char *rz_str_escape_mutf8_for_json(const char *buf, int buf_size) {
+	return escape_utf8_for_json(buf, buf_size, true);
 }
 
 // http://daviddeley.com/autohotkey/parameters/parameters.htm#WINCRULES

--- a/librz/util/utf8.c
+++ b/librz/util/utf8.c
@@ -503,7 +503,7 @@ RZ_API int rz_utf8_decode(const ut8 *ptr, int ptrlen, RzRune *ch) {
 		if (ch) {
 			*ch = rune;
 		}
-		return rune < 0x80 && /* Java special case */ rune ? 0 : 2;
+		return rune < 0x80 ? 0 : 2;
 	} else if (ptrlen > 2 && (ptr[0] & 0xf0) == 0xe0 && (ptr[1] & 0xc0) == 0x80 && (ptr[2] & 0xc0) == 0x80) {
 		RzRune rune = (ptr[0] & 0xf) << 12 | (ptr[1] & 0x3f) << 6 | (ptr[2] & 0x3f);
 		if (ch) {
@@ -518,6 +518,17 @@ RZ_API int rz_utf8_decode(const ut8 *ptr, int ptrlen, RzRune *ch) {
 		return rune < 0x10000 ? 0 : 4;
 	}
 	return 0;
+}
+
+/* Convert an MUTF-8 buf into a unicode RzRune */
+RZ_API int rz_mutf8_decode(const ut8 *ptr, int ptrlen, RzRune *ch) {
+	if (ptrlen > 1 && ptr[0] == 0xc0 && ptr[1] == 0x80) {
+		if (ch) {
+			*ch = 0;
+		}
+		return 2;
+	}
+	return rz_utf8_decode(ptr, ptrlen, ch);
 }
 
 /* Convert a unicode RzRune into an UTF-8 buf */

--- a/test/db/formats/java
+++ b/test/db/formats/java
@@ -81,27 +81,27 @@ NAME=Check that strings are provided by Java class
 FILE=bins/java/HiKt.class
 CMDS=iz
 EXPECT=<<EOF
-nth paddr      vaddr      len size section             type string                                                                                                                                                                                                                                                                  
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-1   0x0000000a 0x0000000a 4   4    class.constant_pool utf8 HiKt
-3   0x00000014 0x00000014 16  16   class.constant_pool utf8 java/lang/Object
-5   0x0000002a 0x0000002a 4   4    class.constant_pool utf8 main
-6   0x00000031 0x00000031 22  22   class.constant_pool utf8 ([Ljava/lang/String;)V
-7   0x0000004a 0x0000004a 35  35   class.constant_pool utf8 Lorg/jetbrains/annotations/NotNull;
-8   0x00000070 0x00000070 4   4    class.constant_pool utf8 args
-10  0x0000007a 0x0000007a 30  30   class.constant_pool utf8 kotlin/jvm/internal/Intrinsics
-12  0x0000009e 0x0000009e 23  23   class.constant_pool utf8 checkParameterIsNotNull
-13  0x000000b8 0x000000b8 39  39   class.constant_pool utf8 (Ljava/lang/Object;Ljava/lang/String;)V
-16  0x000000ec 0x000000ec 19  19   class.constant_pool utf8 [Ljava/lang/String;
-17  0x00000102 0x00000102 17  17   class.constant_pool utf8 Lkotlin/Metadata;
-26  0x0000013d 0x0000013d 53  53   class.constant_pool utf8 \u0000\u0012\n\u0000\n\u0002\u0010\u0002\n\u0000\n\u0002\u0010\u0011\n\u0002\u0010\u000e\n\u0000\u001a\u0019\u0010\u0000\u001a\u00020\u00012\f\u0010\u0002\u001a\b\u0012\u0004\u0012\u00020\u00040\u0003¢\u0006\u0002\u0010\u0005 blocks=Basic Latin,Latin-1 Supplement
-29  0x0000017d 0x0000017d 5   5    class.constant_pool utf8 hi.kt
-30  0x00000185 0x00000185 4   4    class.constant_pool utf8 Code
-31  0x0000018c 0x0000018c 18  18   class.constant_pool utf8 LocalVariableTable
-32  0x000001a1 0x000001a1 15  15   class.constant_pool utf8 LineNumberTable
-33  0x000001b3 0x000001b3 36  36   class.constant_pool utf8 RuntimeInvisibleParameterAnnotations
-34  0x000001da 0x000001da 10  10   class.constant_pool utf8 SourceFile
-35  0x000001e7 0x000001e7 25  25   class.constant_pool utf8 RuntimeVisibleAnnotations
+nth paddr      vaddr      len size section             type  string                                                                                                                                                                                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+1   0x0000000a 0x0000000a 4   4    class.constant_pool mutf8 HiKt
+3   0x00000014 0x00000014 16  16   class.constant_pool mutf8 java/lang/Object
+5   0x0000002a 0x0000002a 4   4    class.constant_pool mutf8 main
+6   0x00000031 0x00000031 22  22   class.constant_pool mutf8 ([Ljava/lang/String;)V
+7   0x0000004a 0x0000004a 35  35   class.constant_pool mutf8 Lorg/jetbrains/annotations/NotNull;
+8   0x00000070 0x00000070 4   4    class.constant_pool mutf8 args
+10  0x0000007a 0x0000007a 30  30   class.constant_pool mutf8 kotlin/jvm/internal/Intrinsics
+12  0x0000009e 0x0000009e 23  23   class.constant_pool mutf8 checkParameterIsNotNull
+13  0x000000b8 0x000000b8 39  39   class.constant_pool mutf8 (Ljava/lang/Object;Ljava/lang/String;)V
+16  0x000000ec 0x000000ec 19  19   class.constant_pool mutf8 [Ljava/lang/String;
+17  0x00000102 0x00000102 17  17   class.constant_pool mutf8 Lkotlin/Metadata;
+26  0x0000013d 0x0000013d 53  53   class.constant_pool mutf8 \u0000\u0012\n\u0000\n\u0002\u0010\u0002\n\u0000\n\u0002\u0010\u0011\n\u0002\u0010\u000e\n\u0000\u001a\u0019\u0010\u0000\u001a\u00020\u00012\f\u0010\u0002\u001a\b\u0012\u0004\u0012\u00020\u00040\u0003¢\u0006\u0002\u0010\u0005 blocks=Basic Latin,Latin-1 Supplement
+29  0x0000017d 0x0000017d 5   5    class.constant_pool mutf8 hi.kt
+30  0x00000185 0x00000185 4   4    class.constant_pool mutf8 Code
+31  0x0000018c 0x0000018c 18  18   class.constant_pool mutf8 LocalVariableTable
+32  0x000001a1 0x000001a1 15  15   class.constant_pool mutf8 LineNumberTable
+33  0x000001b3 0x000001b3 36  36   class.constant_pool mutf8 RuntimeInvisibleParameterAnnotations
+34  0x000001da 0x000001da 10  10   class.constant_pool mutf8 SourceFile
+35  0x000001e7 0x000001e7 25  25   class.constant_pool mutf8 RuntimeVisibleAnnotations
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr declares the `\0` overlong encoding as invalid in `rz_utf8_decode()` and assigns the [`mutf8`](https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-4.html#jvms-4.4.7-300) string type for Java constant strings.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
