### PR TITLE
Remove globals in RzCons input handling

### DIFF
--- a/librz/cons/cons.c
+++ b/librz/cons/cons.c
@@ -580,6 +580,8 @@ RZ_API RzCons *rz_cons_new(void) {
 	I.break_lines = false;
 	I.lines = 0;
 
+	I.input = RZ_NEW0(RzConsInputContext);
+	I.input->bufactive = true;
 	I.context = &rz_cons_context_default;
 	cons_context_init(I.context, NULL);
 
@@ -638,6 +640,8 @@ RZ_API RzCons *rz_cons_free(void) {
 		rz_line_free();
 		I.line = NULL;
 	}
+	RZ_FREE(I.input->readbuffer);
+	RZ_FREE(I.input);
 	RZ_FREE(I.context->buffer);
 	RZ_FREE(I.break_word);
 	cons_context_deinit(I.context);

--- a/librz/cons/input.c
+++ b/librz/cons/input.c
@@ -9,30 +9,6 @@
 
 #define I rz_cons_singleton()
 
-// TODO: Support binary, use RzBuffer and remove globals
-static char *readbuffer = NULL;
-static int readbuffer_length = 0;
-static bool bufactive = true;
-
-#if 0
-//__UNIX__
-#include <poll.h>
-static int __is_fd_ready(int fd) {
-	fd_set rfds;
-	struct timeval tv;
-	if (fd==-1)
-		return 0;
-	FD_ZERO (&rfds);
-	FD_SET (fd, &rfds);
-	tv.tv_sec = 0;
-	tv.tv_usec = 1;
-	if (select (1, &rfds, NULL, NULL, &tv) == -1)
-		return 0;
-	return 1;
-	return !FD_ISSET (0, &rfds);
-}
-#endif
-
 RZ_API int rz_cons_controlz(int ch) {
 #if __UNIX__
 	if (ch == 0x1a) {
@@ -605,23 +581,23 @@ RZ_API int rz_cons_readchar_timeout(ut32 usec) {
 }
 
 RZ_API bool rz_cons_readpush(const char *str, int len) {
-	char *res = (len + readbuffer_length > 0) ? realloc(readbuffer, len + readbuffer_length) : NULL;
+	char *res = (len + I->input->readbuffer_length > 0) ? realloc(I->input->readbuffer, len + I->input->readbuffer_length) : NULL;
 	if (res) {
-		readbuffer = res;
-		memmove(readbuffer + readbuffer_length, str, len);
-		readbuffer_length += len;
+		I->input->readbuffer = res;
+		memmove(I->input->readbuffer + I->input->readbuffer_length, str, len);
+		I->input->readbuffer_length += len;
 		return true;
 	}
 	return false;
 }
 
 RZ_API void rz_cons_readflush(void) {
-	RZ_FREE(readbuffer);
-	readbuffer_length = 0;
+	RZ_FREE(I->input->readbuffer);
+	I->input->readbuffer_length = 0;
 }
 
 RZ_API void rz_cons_switchbuf(bool active) {
-	bufactive = active;
+	I->input->bufactive = active;
 }
 
 #if !__WINDOWS__
@@ -629,12 +605,12 @@ extern volatile sig_atomic_t sigwinchFlag;
 #endif
 
 RZ_API bool rz_cons_readbuffer_readchar(char *ch) {
-	if (readbuffer_length <= 0) {
+	if (I->input->readbuffer_length <= 0) {
 		return false;
 	}
-	*ch = *readbuffer;
-	readbuffer_length--;
-	memmove(readbuffer, readbuffer + 1, readbuffer_length);
+	*ch = *I->input->readbuffer;
+	I->input->readbuffer_length--;
+	memmove(I->input->readbuffer, I->input->readbuffer + 1, I->input->readbuffer_length);
 	return true;
 }
 
@@ -678,7 +654,7 @@ RZ_API int rz_cons_readchar(void) {
 	if (ret != 1) {
 		return -1;
 	}
-	if (bufactive) {
+	if (I->input->bufactive) {
 		rz_cons_set_raw(0);
 	}
 	return rz_cons_controlz(buf[0]);

--- a/librz/include/rz_cons.h
+++ b/librz/include/rz_cons.h
@@ -459,6 +459,12 @@ typedef enum {
 	RZ_VIRT_TERM_MODE_COMPLETE, ///< All the sequences goes through VT (Windows Terminal, mintty, all OSs)
 } RzVirtTermMode;
 
+typedef struct rz_cons_input_context_t {
+	size_t readbuffer_length;
+	char *readbuffer;
+	bool bufactive;
+} RzConsInputContext;
+
 typedef struct rz_cons_context_t {
 	RzConsGrep grep;
 	RzStack *cons_stack;
@@ -492,6 +498,7 @@ typedef struct rz_cons_context_t {
 
 typedef struct rz_cons_t {
 	RzConsContext *context;
+	RzConsInputContext *input;
 	char *lastline;
 	bool is_html;
 	bool was_html;
@@ -565,17 +572,6 @@ typedef struct rz_cons_t {
 	bool show_vals; // show which section in Vv
 	// TODO: move into instance? + avoid unnecessary copies
 } RzCons;
-
-// XXX THIS MUST BE A SINGLETON AND WRAPPED INTO RzCons */
-/* XXX : global variables? or a struct with a singleton? */
-//extern FILE *stdin_fd;
-//extern FILE *rz_cons_stdin_fd;
-//extern int rz_cons_stdout_fd;
-//extern int rz_cons_stdout_file;
-//extern char *rz_cons_filterline;
-//extern char *rz_cons_teefile;
-// not needed anymoar
-//extern int (*rz_cons_user_fgets)(char *buf, int len);
 
 #define RZ_CONS_KEY_F1  0xf1
 #define RZ_CONS_KEY_F2  0xf2
@@ -793,19 +789,6 @@ typedef struct rz_cons_canvas_line_style_t {
 } RzCanvasLineStyle;
 
 // UTF-8 symbols indexes
-// XXX. merge with RUNE/RUNECODE/RUNECODESTR
-#if 0
-#define LINE_VERT   0
-#define LINE_CROSS  1
-#define LINE_HORIZ  2
-#define LINE_UP     3
-#define CORNER_BR   4
-#define CORNER_BL   5
-#define CORNER_TL   6
-#define CORNER_TR   7
-#define ARROW_RIGHT 8
-#define ARROW_LEFT  9
-#else
 #define LINE_VERT   0
 #define LINE_CROSS  1
 #define LINE_HORIZ  2
@@ -816,7 +799,6 @@ typedef struct rz_cons_canvas_line_style_t {
 #define CORNER_TR   6
 #define ARROW_RIGHT 8
 #define ARROW_LEFT  9
-#endif
 
 #ifdef RZ_API
 RZ_API RzConsCanvas *rz_cons_canvas_new(int w, int h);


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Just remove the global state from the input handling. Singleton is still here but this patch makes the refactoring a bit easier.

**Test plan**

Ci is green, try to test different modes

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/276
