### PR TITLE
Enforce c99/gnu99 on libdemangle

### DIFF
--- a/subprojects/libdemangle.wrap
+++ b/subprojects/libdemangle.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/rizinorg/rz-libdemangle.git
-revision = d0844115a8d66ba8c23510e8e1484afe7363be39
+revision = 23398b4f3f6a97f89ba0a3c543ba276a670a151f


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes the following error

```
../subprojects/libdemangle/src/demangler_util.c: In function 'dem_str_replace_char':
../subprojects/libdemangle/src/demangler_util.c:25:2: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
  for (size_t i = 0; i < size; ++i) {
  ^
../subprojects/libdemangle/src/demangler_util.c:25:2: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
```