### PR TITLE
`pj_(k)r`: Use `ut8` instead of `unsigned char`

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -2851,7 +2851,7 @@ RZ_API bool rz_core_file_info_print(RzCore *core, RzBinFile *binfile, RzCmdState
 		if (rz_str_is_utf8(filename)) {
 			pj_ks(state->d.pj, file_tag, filename);
 		} else {
-			pj_kr(state->d.pj, file_tag, (unsigned char *)filename, strlen(filename));
+			pj_kr(state->d.pj, file_tag, (const ut8 *)filename, strlen(filename));
 		}
 		if (desc) {
 			ut64 fsz = rz_io_desc_size(desc);

--- a/librz/include/rz_util/rz_pj.h
+++ b/librz/include/rz_util/rz_pj.h
@@ -61,11 +61,11 @@ RZ_API PJ *pj_kb(PJ *j, const char *k, bool v);
 /* named "null" */
 RZ_API PJ *pj_null(PJ *j);
 
-/* append all uchars in v as signed ints (?) */
-RZ_API PJ *pj_r(PJ *j, const unsigned char *v, size_t v_len);
+/* array with first v_len bytes of v */
+RZ_API PJ *pj_r(PJ *j, const ut8 *v, size_t v_len);
 
 /* named entry with pj_r */
-RZ_API PJ *pj_kr(PJ *j, const char *k, const unsigned char *v, size_t v_len);
+RZ_API PJ *pj_kr(PJ *j, const char *k, const ut8 *v, size_t v_len);
 
 /* string, escaped for json */
 RZ_API PJ *pj_s(PJ *j, const char *k);

--- a/librz/util/pj.c
+++ b/librz/util/pj.c
@@ -208,7 +208,7 @@ RZ_API PJ *pj_s(PJ *j, const char *k) {
 	return j;
 }
 
-RZ_API PJ *pj_r(PJ *j, const unsigned char *v, size_t v_len) {
+RZ_API PJ *pj_r(PJ *j, const ut8 *v, size_t v_len) {
 	rz_return_val_if_fail(j && v, j);
 	size_t i;
 	pj_a(j);
@@ -219,7 +219,7 @@ RZ_API PJ *pj_r(PJ *j, const unsigned char *v, size_t v_len) {
 	return j;
 }
 
-RZ_API PJ *pj_kr(PJ *j, const char *k, const unsigned char *v, size_t v_len) {
+RZ_API PJ *pj_kr(PJ *j, const char *k, const ut8 *v, size_t v_len) {
 	rz_return_val_if_fail(j && k && v, j);
 	pj_k(j, k);
 	pj_r(j, v, v_len);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr justs replaces the use of `unsigned char` in the `pj_(k)r` functions with the shorter `ut8`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
