### PR TITLE
Fix potential buffer overflow in rc2

### DIFF
--- a/librz/crypto/p/crypto_rc2.c
+++ b/librz/crypto/p/crypto_rc2.c
@@ -188,8 +188,8 @@ static void rc2_crypt(struct rc2_state *state, const ut8 *inbuf, ut8 *outbuf, in
 		}
 	}
 
-	if (idx % 8) {
-		while (idx % 8) {
+	if (idx % 8 && idx < BLOCK_SIZE) {
+		while (idx % 8 && idx < BLOCK_SIZE) {
 			data_block[idx++] = 0;
 		}
 		rc2_crypt8(state, (const ut8 *)data_block, (ut8 *)crypted_block);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Resolves the following warning

```
In function ‘rc2_crypt’,
    inlined from ‘update’ at ../librz/crypto/p/crypto_rc2.c:230:3:
../librz/crypto/p/crypto_rc2.c:193:43: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  193 |                         data_block[idx++] = 0;
      |                         ~~~~~~~~~~~~~~~~~~^~~
../librz/crypto/p/crypto_rc2.c: In function ‘update’:
../librz/crypto/p/crypto_rc2.c:173:14: note: at offset 8 into destination object ‘data_block’ of size 8
  173 |         char data_block[BLOCK_SIZE] = { 0 };
      |              ^~~~~~~~~~
```