### PR TITLE
Move TSLanguage initialization into new rz_core_cmd_new API

### DIFF
--- a/librz/core/cmd.c
+++ b/librz/core/cmd.c
@@ -5622,17 +5622,22 @@ struct ts_data_symbol_map map_ts_symbols[] = {
 	{ NULL, NULL },
 };
 
-static void ts_symbols_init(RzCmd *cmd) {
-	if (cmd->language) {
-		return;
+/**
+ * \brief Create an instance of RzCmd for the Rizin language
+ */
+RZ_API RzCmd *rz_core_cmd_new(bool has_cons) {
+	RzCmd *res = rz_cmd_new(has_cons);
+	if (!res) {
+		return NULL;
 	}
+
 	TSLanguage *lang = tree_sitter_rzcmd();
-	cmd->language = lang;
-	cmd->ts_symbols_ht = ht_up_new0();
+	res->language = lang;
+	res->ts_symbols_ht = ht_up_new0();
 	struct ts_data_symbol_map *entry = map_ts_stmt_handlers;
 	while (entry->name) {
 		TSSymbol symbol = ts_language_symbol_for_name(lang, entry->name, strlen(entry->name), true);
-		ht_up_insert(cmd->ts_symbols_ht, symbol, entry->data);
+		ht_up_insert(res->ts_symbols_ht, symbol, entry->data);
 		entry++;
 	}
 
@@ -5642,11 +5647,10 @@ static void ts_symbols_init(RzCmd *cmd) {
 		*sym_ptr = ts_language_symbol_for_name(lang, entry->name, strlen(entry->name), true);
 		entry++;
 	}
+	return res;
 }
 
 static RzCmdStatus core_cmd_tsrzcmd(RzCore *core, const char *cstr, bool split_lines, bool log) {
-	ts_symbols_init(core->rcmd);
-
 	TSParser *parser = ts_parser_new();
 	bool language_ok = ts_parser_set_language(parser, (TSLanguage *)core->rcmd->language);
 	rz_return_val_if_fail(language_ok, RZ_CMD_STATUS_INVALID);
@@ -6135,7 +6139,7 @@ RZ_API void rz_core_cmd_init(RzCore *core) {
 		{ "z", "zignatures", rz_cmd_zign },
 	};
 
-	core->rcmd = rz_cmd_new(!!core->cons);
+	core->rcmd = rz_core_cmd_new(!!core->cons);
 	core->rcmd->macro.user = core;
 	core->rcmd->macro.num = core->num;
 	core->rcmd->macro.cmd = core_cmd0_wrapper;

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -630,6 +630,7 @@ RZ_API bool rz_core_yank_file_all(RzCore *core, const char *filename);
 
 RZ_API void rz_core_loadlibs_init(RzCore *core);
 RZ_API int rz_core_loadlibs(RzCore *core, int where, const char *path);
+RZ_API RzCmd *rz_core_cmd_new(bool has_cons);
 RZ_API int rz_core_cmd_buffer(RzCore *core, const char *buf);
 RZ_API int rz_core_cmdf(RzCore *core, const char *fmt, ...) RZ_PRINTF_CHECK(2, 3);
 RZ_API int rz_core_cmd0(RzCore *core, const char *cmd);

--- a/test/unit/test_autocmplt.c
+++ b/test/unit/test_autocmplt.c
@@ -58,7 +58,7 @@ static RzCore *fake_core_new(void) {
 	mu_assert_notnull(cf, "file should be opened");
 	rz_core_bin_load(core, "bins/elf/hello_world", 0);
 	rz_cmd_free(core->rcmd);
-	RzCmd *cmd = rz_cmd_new(true);
+	RzCmd *cmd = rz_core_cmd_new(true);
 	mu_assert_notnull(cmd, "cmd should be created");
 	RzCmdDesc *root = rz_cmd_get_root(cmd);
 	mu_assert_notnull(root, "root should be present");

--- a/test/unit/test_core_cmd.c
+++ b/test/unit/test_core_cmd.c
@@ -71,7 +71,7 @@ static RzCmdStatus cmd_last_opt_handler(RzCore *core, int argc, const char **arg
 static RzCore *fake_core_new(void) {
 	RzCore *core = rz_core_new();
 	rz_cmd_free(core->rcmd);
-	core->rcmd = rz_cmd_new(true);
+	core->rcmd = rz_core_cmd_new(true);
 	core->rcmd->data = core;
 	RzCmdDesc *root = rz_cmd_get_root(core->rcmd);
 	rz_cmd_desc_argv_new(core->rcmd, root, "string", string_handler, &string_help);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Before this patch the RzCmd->language (used mainly as cache) was initialized on demand while executing the first command. This PR creates a new API `rz_core_cmd_new` that creates a new RzCmd through `rz_cmd_new` and then sets the ->language field according to the rizin grammar. Then, when RzCore creates core->rcmd, it uses `rz_core_cmd_new` instead of the plain `rz_cmd_new`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #1797 
