### PR TITLE
Switch to `ubuntu:hirsute` for gcc-11 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,14 +359,12 @@ jobs:
     name: Build on gcc 11
     if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'gcc11') || contains(github.ref, 'release-') || github.ref == 'refs/heads/stable' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
-    container:
-        image: ubuntu:impish
-        options: --security-opt seccomp=unconfined
+    container: ubuntu:hirsute
     steps:
     - name: Set timezone to UTC
       run: ln -snf /usr/share/zoneinfo/UTC /etc/localtime && echo 'UTC' > /etc/timezone
     - name: Install tools
-      run: apt-get update && apt-get install --yes patch unzip git gcc make curl pkg-config libc6-i386 build-essential
+      run: apt-get update && apt-get install --yes patch unzip git gcc-11 make curl pkg-config libc6-i386 build-essential
     - name: Install python and other dependencies
       run: apt-get install --yes python3-wheel python3-setuptools python3-pip cabextract
     - name: Install meson and ninja
@@ -381,7 +379,7 @@ jobs:
       run: git clone https://github.com/rizinorg/rizin-testbins test/bins
       working-directory: rizin
     - name: Build with Meson + Ninja
-      run: meson --prefix=/usr -Dbuildtype=release build && ninja -C build
+      run: CC=gcc-11 meson --prefix=/usr -Dbuildtype=release build && ninja -C build
       working-directory: rizin
     - name: Install with Ninja
       run: ninja -C build install


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr switches to `ubuntu:hirsute` for the gcc-11 build so that `--security-opt seccomp=unconfined` can be removed allowing a local `docker build`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green. The gcc-11 build shows the same warnings as https://github.com/rizinorg/rizin/runs/3814566784 (#1802).

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
