### PR TITLE
Fix `-Warray-bounds` warnings in gcc-11 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,7 @@ jobs:
       run: git clone https://github.com/rizinorg/rizin-testbins test/bins
       working-directory: rizin
     - name: Build with Meson + Ninja
-      run: CC=gcc-11 meson --prefix=/usr -Dbuildtype=release build && ninja -C build
+      run: CC=gcc-11 meson --prefix=/usr -Dbuildtype=release --werror build && ninja -C build
       working-directory: rizin
     - name: Install with Ninja
       run: ninja -C build install

--- a/librz/core/task.c
+++ b/librz/core/task.c
@@ -709,7 +709,7 @@ RZ_API RzCoreTask *rz_core_function_task_new(RzCore *core, RzCoreTaskFunction fc
 	}
 	RzCoreTask *task = rz_core_task_new(&core->tasks, function_task_runner, function_task_free, ctx);
 	if (!task) {
-		cmd_task_free(ctx);
+		function_task_free(ctx);
 		return NULL;
 	}
 	return task;

--- a/librz/core/task.c
+++ b/librz/core/task.c
@@ -615,11 +615,10 @@ static void cmd_task_runner(RzCoreTaskScheduler *sched, void *user) {
 	}
 }
 
-static void cmd_task_free(void *user) {
-	if (!user) {
+static void cmd_task_free(CmdTaskCtx *ctx) {
+	if (!ctx) {
 		return;
 	}
-	CmdTaskCtx *ctx = user;
 	free(ctx->cmd);
 	free(ctx->res);
 	core_task_ctx_fini(&ctx->core_ctx);
@@ -635,7 +634,7 @@ RZ_API RzCoreTask *rz_core_cmd_task_new(RzCore *core, const char *cmd, RzCoreCmd
 	if (!ctx) {
 		return NULL;
 	}
-	RzCoreTask *task = rz_core_task_new(&core->tasks, cmd_task_runner, cmd_task_free, ctx);
+	RzCoreTask *task = rz_core_task_new(&core->tasks, cmd_task_runner, (RzCoreTaskRunnerFree)cmd_task_free, ctx);
 	if (!task) {
 		cmd_task_free(ctx);
 		return NULL;
@@ -689,11 +688,10 @@ static void function_task_runner(RzCoreTaskScheduler *sched, void *user) {
 	rz_cons_pop();
 }
 
-static void function_task_free(void *user) {
-	if (!user) {
+static void function_task_free(FunctionTaskCtx *ctx) {
+	if (!ctx) {
 		return;
 	}
-	FunctionTaskCtx *ctx = user;
 	core_task_ctx_fini(&ctx->core_ctx);
 	free(ctx);
 }
@@ -707,7 +705,8 @@ RZ_API RzCoreTask *rz_core_function_task_new(RzCore *core, RzCoreTaskFunction fc
 	if (!ctx) {
 		return NULL;
 	}
-	RzCoreTask *task = rz_core_task_new(&core->tasks, function_task_runner, function_task_free, ctx);
+	RzCoreTask *task = rz_core_task_new(&core->tasks, function_task_runner,
+		(RzCoreTaskRunnerFree)function_task_free, ctx);
 	if (!task) {
 		function_task_free(ctx);
 		return NULL;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes warnings of the following form in the gcc-11 build (https://github.com/rizinorg/rizin/runs/3840123684#step:9:1721):

![-Warray-bounds](https://user-images.githubusercontent.com/12002672/136791867-4c2140fb-2724-4128-8c54-024995578d04.PNG)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds, including the gcc-11 build, are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
