### PR TITLE
Fix `RzILOpNot` name for use in bindings

### DIFF
--- a/librz/il/rzil_opcodes.c
+++ b/librz/il/rzil_opcodes.c
@@ -62,7 +62,7 @@ RZ_API RzILOp *rz_il_new_op(RzILOPCode code) {
 		ret->op.neg = (RzILOpNeg *)RZ_NEW0(RzILOpNeg);
 		break;
 	case RZIL_OP_NOT:
-		ret->op.not = (RzILOpNot *)RZ_NEW0(RzILOpNot);
+		ret->op.not_ = (RzILOpNot *)RZ_NEW0(RzILOpNot);
 		break;
 	case RZIL_OP_ADD:
 	case RZIL_OP_SUB:

--- a/librz/il/theory_bitv.c
+++ b/librz/il/theory_bitv.c
@@ -36,7 +36,7 @@ void *rz_il_handler_neg(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
 }
 
 void *rz_il_handler_not(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
-	RzILOpNot *op_not = op->op.not ;
+	RzILOpNot *op_not = op->op.not_;
 
 	RzILBitVector *bv = rz_il_evaluate_bitv(vm, op_not->bv, type);
 	RzILBitVector *result = rz_il_bv_not(bv);

--- a/librz/include/rz_il/rzil_opcodes.h
+++ b/librz/include/rz_il/rzil_opcodes.h
@@ -409,7 +409,7 @@ typedef union {
 	RzILOpUle *ule;
 	RzILOpSle *sle;
 	RzILOpNeg *neg;
-	RzILOpNot * not ;
+	RzILOpNot *not_;
 	RzILOpAdd *add;
 	RzILOpSub *sub;
 	RzILOpMul *mul;


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fix to avoid `not` name directly - it's problematic for some FFI bindings.

**Test plan**

CI is green.