### PR TITLE
Revert OpenBSD `buildtype` back to `debugoptimized` and remove its `MALLOC_OPTIONS=S`

### DIFF
--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -36,7 +36,7 @@ tasks:
         # https://todo.sr.ht/~sircmpwn/builds.sr.ht/274
         ln -s ${HOME}/rizin-testbins test/bins
         # Running the unit tests
-        MALLOC_OPTIONS=S ninja -C build test
+        ninja -C build test
     - test: |
         cd rizin
         export PATH=${HOME}/bin:/usr/local/bin:${PATH}
@@ -47,4 +47,4 @@ tasks:
         ln -s ${HOME}/rizin-testbins test/bins
         cd test
         # Running the unit tests
-        MALLOC_OPTIONS=S rz-test -L -o results.json
+        rz-test -L -o results.json

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -19,7 +19,7 @@ tasks:
         /usr/local/bin/python3 -m pip install --user 'git+https://github.com/rizinorg/rz-pipe#egg=rzpipe&subdirectory=python'
     - build: |
         cd rizin
-        meson --buildtype=debug --prefix=${HOME} build # buildtype temporarily set to debug to examine rare rz-test crash core dumps
+        meson --prefix=${HOME} build
         ninja -C build
     - install: |
         cd rizin


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

#1818 might have fixed whatever was causing the UAFs in the OpenBSD build so this pr reverts its `buildtype` back to `debugoptimized` and removes its `MALLOC_OPTIONS=S`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
