### PR TITLE
Fix a crash during variables type propagation

### DIFF
--- a/librz/core/analysis_tp.c
+++ b/librz/core/analysis_tp.c
@@ -927,8 +927,11 @@ RZ_API void rz_core_analysis_type_match(RzCore *core, RzAnalysisFunction *fcn, H
 		}
 	}
 	// Type propagation for register based args
+	// We clone variables vector since `var_type_set()` function can remove
+	// overlapping vars depending on the type
+	RzPVector *cloned_vars = (RzPVector *)rz_vector_clone((RzVector *)&fcn->vars);
 	void **vit;
-	rz_pvector_foreach (&fcn->vars, vit) {
+	rz_pvector_foreach (cloned_vars, vit) {
 		RzAnalysisVar *rvar = *vit;
 		if (rvar->kind == RZ_ANALYSIS_VAR_KIND_REG) {
 			RzAnalysisVar *lvar = rz_analysis_var_get_dst_var(rvar);
@@ -946,6 +949,7 @@ RZ_API void rz_core_analysis_type_match(RzCore *core, RzAnalysisFunction *fcn, H
 			}
 		}
 	}
+	rz_pvector_free(cloned_vars);
 out_function:
 	free(retctx.ret_reg);
 	ht_up_free(op_cache);

--- a/librz/include/rz_vector.h
+++ b/librz/include/rz_vector.h
@@ -67,6 +67,9 @@ RZ_API void rz_vector_fini(RzVector *vec);
 // frees the vector and calls vec->free on every element if set.
 RZ_API void rz_vector_free(RzVector *vec);
 
+// the dst vector will have the same capacity as src.
+RZ_API bool rz_vector_copy(RzVector *dst, RzVector *src);
+
 // the returned vector will have the same capacity as vec.
 RZ_API RzVector *rz_vector_clone(RzVector *vec);
 

--- a/librz/util/vector.c
+++ b/librz/util/vector.c
@@ -79,7 +79,7 @@ RZ_API void rz_vector_free(RzVector *vec) {
 	}
 }
 
-static bool vector_clone(RzVector *dst, RzVector *src) {
+RZ_API bool rz_vector_copy(RzVector *dst, RzVector *src) {
 	rz_return_val_if_fail(dst && src, false);
 	dst->capacity = src->capacity;
 	dst->len = src->len;
@@ -104,7 +104,7 @@ RZ_API RzVector *rz_vector_clone(RzVector *vec) {
 	if (!ret) {
 		return NULL;
 	}
-	if (!vector_clone(ret, vec)) {
+	if (!rz_vector_copy(ret, vec)) {
 		free(ret);
 		return NULL;
 	}

--- a/test/db/analysis/x86_64
+++ b/test/db/analysis/x86_64
@@ -3972,3 +3972,54 @@ EXPECT=<<EOF
 }
 EOF
 RUN
+
+NAME=x86_64 int64_t variable overlapping removal
+FILE=bins/elf/arch-x86_64-ls
+CMDS=<<EOF
+s 0x10270
+af
+afv
+aaft
+afv
+EOF
+EXPECT=<<EOF
+void fcn.00010270(int64_t arg1, int64_t arg2, int64_t arg3, int64_t arg4, int64_t arg5);
+var int64_t var_10h_2 @ rsp+0x10
+var int64_t var_8h @ rsp+0x18
+var int64_t var_10h @ rsp+0x20
+var int64_t var_18h @ rsp+0x28
+var int64_t var_20h @ rsp+0x30
+var int64_t var_30h @ rsp+0x40
+var int64_t var_34h @ rsp+0x44
+var int64_t var_38h @ rsp+0x48
+var int64_t var_40h @ rsp+0x50
+var int64_t var_48h @ rsp+0x58
+var int64_t var_4ch @ rsp+0x5c
+var int64_t var_4eh @ rsp+0x5e
+var int64_t var_50h @ rsp+0x60
+var int64_t var_88h @ rsp+0x98
+arg int64_t arg5 @ r8
+arg int64_t arg4 @ rcx
+arg int64_t arg3 @ rdx
+arg int64_t arg2 @ rsi
+arg int64_t arg1 @ rdi
+void fcn.00010270(int64_t arg1, int64_t arg2, const char **s, int64_t arg4, int64_t arg5);
+var const char * var_10h_2 @ rsp+0x10
+var void ** s1 @ rsp+0x18
+var uint64_t var_10h @ rsp+0x20
+var int64_t var_18h @ rsp+0x28
+var int64_t var_20h @ rsp+0x30
+var uint64_t var_30h @ rsp+0x40
+var int64_t var_34h @ rsp+0x44
+var int64_t var_38h @ rsp+0x48
+var int64_t var_40h @ rsp+0x50
+var const char ** var_48h @ rsp+0x58
+var int64_t var_50h @ rsp+0x60
+var int64_t var_88h @ rsp+0x98
+arg int64_t arg5 @ r8
+arg int64_t arg4 @ rcx
+arg const char ** s @ rdx
+arg int64_t arg2 @ rsi
+arg int64_t arg1 @ rdi
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Clone the variables vector before retyping it, since retyping might trigger overlapping var deletion in case of the new type is big enough to overshadow the next variables.

**Test plan**

CI is green