### PR TITLE
Do not escape strings during the search

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -2577,6 +2577,8 @@ static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzList *l
 			}
 		}
 
+		char *escaped_string = rz_str_escape_utf8_keep_printable(string->string, false, true);
+
 		switch (state->mode) {
 		case RZ_OUTPUT_MODE_JSON: {
 			int *block_list;
@@ -2589,7 +2591,7 @@ static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzList *l
 			pj_ks(state->d.pj, "section", section_name);
 			pj_ks(state->d.pj, "type", type_string);
 			// data itself may be encoded so use pj_ks
-			pj_ks(state->d.pj, "string", string->string);
+			pj_ks(state->d.pj, "string", escaped_string);
 
 			switch (string->type) {
 			case RZ_STRING_TYPE_UTF8:
@@ -2620,7 +2622,7 @@ static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzList *l
 		}
 		case RZ_OUTPUT_MODE_TABLE: {
 			int *block_list;
-			char *str = string->string;
+			char *str = escaped_string;
 			char *no_dbl_bslash_str = NULL;
 			if (!core->print->esc_bslash) {
 				char *ptr;
@@ -2680,15 +2682,16 @@ static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzList *l
 		}
 		case RZ_OUTPUT_MODE_QUIET:
 			rz_cons_printf("0x%" PFMT64x " %d %d %s\n", vaddr,
-				string->size, string->length, string->string);
+				string->size, string->length, escaped_string);
 			break;
 		case RZ_OUTPUT_MODE_QUIETEST:
-			rz_cons_printf("%s\n", string->string);
+			rz_cons_printf("%s\n", escaped_string);
 			break;
 		default:
 			rz_warn_if_reached();
 			break;
 		}
+		free(escaped_string);
 	}
 	RZ_FREE(b64.string);
 	rz_cmd_state_output_array_end(state);

--- a/librz/util/str_search.c
+++ b/librz/util/str_search.c
@@ -181,16 +181,11 @@ static RzDetectedString *process_one_string(const ut8 *buf, const ut64 from, ut6
 			runes++;
 		} else if (r && r < 0x100 && strchr("\b\v\f\n\r\t\a\033\\", (char)r)) {
 			if ((i + 32) < opt->buf_size && r < 93) {
-				tmp[i + 0] = '\\';
-				tmp[i + 1] = "       abtnvfr             e  "
-					     "                              "
-					     "                              "
-					     "  \\"[r];
+				rc = rz_utf8_encode(tmp + i, r);
 			} else {
 				// string too long
 				break;
 			}
-			rc = 2;
 			runes++;
 		} else {
 			/* \0 marks the end of C-strings */

--- a/test/unit/test_bin.c
+++ b/test/unit/test_bin.c
@@ -54,12 +54,12 @@ bool test_rz_bin(void) {
 	const RzList *strings = rz_bin_object_get_strings(obj);
 	mu_assert_eq(rz_list_length(strings), 5, "rz_bin_object_get_strings");
 	const char *exp_strings[] = {
-		"IOLI Crackme Level 0x00\\n",
+		"IOLI Crackme Level 0x00\n",
 		"Password: ",
 		// "%s", // This is not automatically recognized because too short
 		"250382",
-		"Invalid Password!\\n",
-		"Password OK :)\\n",
+		"Invalid Password!\n",
+		"Password OK :)\n",
 	};
 	RzBinString *s;
 	int i = 0;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Do not escape special characters during the string search process, only on printing (`iz` commands)

**Test plan**

CI is green

**Closing issues**

Required for https://github.com/rizinorg/rizin/pull/1752
