### PR TITLE
Fixed build warning

### DIFF
--- a/test/integration/test_bin_vfiles.c
+++ b/test/integration/test_bin_vfiles.c
@@ -45,7 +45,7 @@ bool test_bin_vfiles() {
 	mu_assert_neq(reloc->target_vaddr, UT64_MAX, "target not UT64_MAX");
 
 	// 4. Check the contents of the original buf and the vfile against the data in the reloc
-	ut64 val;
+	ut64 val = 1;
 	mu_assert_true(rz_buf_read_le64_at(buf, reloc->paddr, &val), "failed to read");
 
 	mu_assert_eq(val, 0, "original buf has nothing patched");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes just a simple warning on the test

```
../test/integration/test_bin_vfiles.c: In function ‘test_bin_vfiles’:
../test/integration/../unit/minunit.h:138:25: warning: ‘val’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  138 |                         snprintf(_meqstr, MU_BUF_SIZE, "%s: expected %" PFMT64d ", got %" PFMT64d ".", (message), (ut64)(exp__), (ut64)(act__)); \
      |                         ^~~~~~~~
../test/integration/test_bin_vfiles.c:48:14: note: ‘val’ was declared here
   48 |         ut64 val;
```