### PR TITLE
Re-design the way `?` and `??` are used in rzshell

### DIFF
--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -5203,6 +5203,7 @@ static const RzCmdDescArg type_args[] = {
 };
 static const RzCmdDescHelp type_help = {
 	.summary = "List all types / Show type information",
+	.description = "When <type> is provided, the pf-format for the given type is provided, otherwise all types are listed.",
 	.args = type_args,
 };
 

--- a/librz/core/cmd_descs/cmd_type.yaml
+++ b/librz/core/cmd_descs/cmd_type.yaml
@@ -14,6 +14,9 @@ commands:
       - name: type
         type: RZ_CMD_ARG_TYPE_ANY_TYPE
         optional: true
+    description: >
+      When <type> is provided, the pf-format for the given type is provided,
+      otherwise all types are listed.
   - name: t-
     cname: type_del
     summary: Remove the type

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -367,14 +367,6 @@ bool test_cmd_help(void) {
 	free(h);
 	rz_cmd_parsed_args_free(a);
 
-	const char *pd_help_exp = "Usage: pd <num>   # pd summary\n";
-	a = rz_cmd_parsed_args_newcmd("pd?");
-	h = rz_cmd_get_help(cmd, a, false);
-	mu_assert_notnull(h, "help is not null");
-	mu_assert_streq(h, pd_help_exp, "wrong help for pd?");
-	free(h);
-	rz_cmd_parsed_args_free(a);
-
 	const char *pd_long_help_exp = "Usage: pd <num>   # pd summary\n"
 				       "\n"
 				       "pd long description\n"
@@ -385,6 +377,13 @@ bool test_cmd_help(void) {
 	h = rz_cmd_get_help(cmd, a, false);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, pd_long_help_exp, "wrong help for pd??");
+	free(h);
+	rz_cmd_parsed_args_free(a);
+
+	a = rz_cmd_parsed_args_newcmd("pd?");
+	h = rz_cmd_get_help(cmd, a, false);
+	mu_assert_notnull(h, "help is not null");
+	mu_assert_streq(h, pd_long_help_exp, "wrong help for pd?");
 	free(h);
 	rz_cmd_parsed_args_free(a);
 
@@ -459,6 +458,72 @@ bool test_cmd_oldinput_help(void) {
 	mu_end;
 }
 
+bool test_cmd_group_exec_help(void) {
+	const RzCmdDescHelp p_help = {
+		.summary = "p summary",
+		.usage = "p-usage",
+		.description = "This is p-command description",
+		.details = NULL,
+		.args = fake_args,
+	};
+
+	const RzCmdDescHelp p_group_help = {
+		.usage = "p-usage",
+		.summary = "p group-summary",
+		.args_str = NULL,
+		.description = NULL,
+		.details = NULL,
+	};
+
+	const RzCmdDescHelp pd_help = {
+		.summary = "pd summary",
+		.usage = NULL,
+		.args_str = " <num>",
+		.description = "pd long description",
+		.details = NULL,
+		.args = fake_args,
+	};
+
+	RzCmd *cmd = rz_cmd_new(false);
+	RzCmdDesc *root = rz_cmd_get_root(cmd);
+	RzCmdDesc *p_cd = rz_cmd_desc_group_new(cmd, root, "p", p_handler_argv, &p_help, &p_group_help);
+	rz_cmd_desc_argv_new(cmd, p_cd, "pd", pd_handler, &pd_help);
+
+	const char *p_group_help_exp = "Usage: p-usage   # p group-summary\n"
+				       "| p        # p summary\n"
+				       "| pd <num> # pd summary\n";
+	RzCmdParsedArgs *a = rz_cmd_parsed_args_newcmd("p?");
+	char *h = rz_cmd_get_help(cmd, a, false);
+	mu_assert_notnull(h, "help is not null");
+	mu_assert_streq(h, p_group_help_exp, "wrong help for p?");
+	free(h);
+	rz_cmd_parsed_args_free(a);
+
+	const char *p_help_exp = "Usage: p-usage   # p summary\n"
+				 "\n"
+				 "This is p-command description\n";
+	a = rz_cmd_parsed_args_newcmd("p??");
+	h = rz_cmd_get_help(cmd, a, false);
+	mu_assert_notnull(h, "help is not null");
+	mu_assert_streq(h, p_help_exp, "wrong help for p??");
+	free(h);
+	rz_cmd_parsed_args_free(a);
+
+	const char *pd_help_exp = "Usage: pd <num>   # pd summary\n"
+				  "\n"
+				  "pd long description\n";
+	a = rz_cmd_parsed_args_newcmd("pd?");
+	char *h1 = rz_cmd_get_help(cmd, a, false);
+	rz_cmd_parsed_args_free(a);
+	a = rz_cmd_parsed_args_newcmd("pd??");
+	char *h2 = rz_cmd_get_help(cmd, a, false);
+	rz_cmd_parsed_args_free(a);
+	mu_assert_streq(h1, h2, "pd? should be the same as pd?? because it is a terminal command");
+	mu_assert_streq(h1, pd_help_exp, "pd?/pd?? should print full help");
+
+	rz_cmd_free(cmd);
+	mu_end;
+}
 bool test_remove_cmd(void) {
 	RzCmd *cmd = rz_cmd_new(false);
 	RzCmdDesc *root = rz_cmd_get_root(cmd);
@@ -537,19 +602,25 @@ bool test_cmd_argv_modes(void) {
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("?");
 	char *h = rz_cmd_get_help(cmd, pa, false);
-	char *exp_h = "Usage: [.][times][cmd][~grep][@[@iter]addr!size][|>pipe] ; ...\n"
+	char *exp_h = "Usage: [.][times][cmd][~grep][@[@iter]addr][|>pipe] ; ...\n"
 		      "| z[jqJ] # z summary\n";
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the help");
 	free(h);
 	rz_cmd_parsed_args_free(pa);
 
-	pa = rz_cmd_parsed_args_newcmd("z?");
-	h = rz_cmd_get_help(cmd, pa, false);
 	exp_h = "Usage: z[jqJ]   # z summary\n"
 		"| z       # z summary\n"
 		"| zj      # z summary (JSON mode)\n"
 		"| zq      # z summary (quiet mode)\n"
 		"| zJ      # z summary (verbose JSON mode)\n";
+	pa = rz_cmd_parsed_args_newcmd("z?");
+	h = rz_cmd_get_help(cmd, pa, false);
+	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the sub help");
+	free(h);
+	rz_cmd_parsed_args_free(pa);
+
+	pa = rz_cmd_parsed_args_newcmd("z??");
+	h = rz_cmd_get_help(cmd, pa, false);
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the sub help");
 	free(h);
 	rz_cmd_parsed_args_free(pa);
@@ -586,7 +657,7 @@ bool test_cmd_argv_state(void) {
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("?");
 	char *h = rz_cmd_get_help(cmd, pa, false);
-	char *exp_h = "Usage: [.][times][cmd][~grep][@[@iter]addr!size][|>pipe] ; ...\n"
+	char *exp_h = "Usage: [.][times][cmd][~grep][@[@iter]addr][|>pipe] ; ...\n"
 		      "| z[jqJ] # group summary\n";
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the help");
 	free(h);
@@ -634,7 +705,7 @@ bool test_cmd_group_argv_modes(void) {
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("?");
 	char *h = rz_cmd_get_help(cmd, pa, false);
-	char *exp_h = "Usage: [.][times][cmd][~grep][@[@iter]addr!size][|>pipe] ; ...\n"
+	char *exp_h = "Usage: [.][times][cmd][~grep][@[@iter]addr][|>pipe] ; ...\n"
 		      "| z[jqd] # z group summary\n";
 	mu_assert_streq(h, exp_h, "zd is considered in the help");
 	free(h);
@@ -1229,6 +1300,7 @@ int all_tests() {
 	mu_run_test(test_cmd_help);
 	mu_run_test(test_cmd_group_help);
 	mu_run_test(test_cmd_oldinput_help);
+	mu_run_test(test_cmd_group_exec_help);
 	mu_run_test(test_remove_cmd);
 	mu_run_test(test_cmd_args);
 	mu_run_test(test_cmd_argv_modes);


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

* `<cmd>?` allows to list the sub-commands of <cmd>. If <cmd> has no
  sub-commands, the full help of <cmd> is printed instead.
* `<cmd>??` allows to always list the full help of <cmd>. Useful when
  <cmd> is both the name of a group and a command itself.
* output modes are only listed as part of the full help and not
  considered as sub-commands.
* fix a bug where `<cmd><mode>?` was just printing the list of
  sub-commands of <cmd> instead of the full help of <cmd><mode>.


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Use `?`, then try `?` and `??` on already converted commands. In particular, look for commands that have also a description and some examples, like `wB`, `w6`, `t`, `%`, `e` and few others. Please notice how before it was impossible to get the list of sub-modes for commands like `z` that is both the name of a sub-tree and of a command.

Please test it a bit to check it makes sense.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #https://github.com/rizinorg/rizin/issues/657
