### PR TITLE
Fix rotating colors with `C` in visual mode

### DIFF
--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -2498,7 +2498,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 			}
 			break;
 		case 'C':
-			if (++color > 2) {
+			if (++color > 3) {
 				color = 0;
 			}
 			rz_config_set_i(core->config, "scr.color", color);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Try to press `C` key in visual mode. We have 3 color modes, not 2

**Test plan**

`C` in visual

## Third mode (16M)

![image](https://user-images.githubusercontent.com/203261/138254291-f17ab1f0-041f-475a-81ba-624774300b6b.png)

## Second mode (256 colors)
![image](https://user-images.githubusercontent.com/203261/138254505-33abb964-6057-4b82-a9e0-43d6c329fd79.png)

## First mode (16 colors)
![image](https://user-images.githubusercontent.com/203261/138254578-11a164da-dd6a-453b-bcd0-c82afa478fa7.png)

