### PR TITLE
Fix some memleaks in unit tests

### DIFF
--- a/librz/analysis/analysis.c
+++ b/librz/analysis/analysis.c
@@ -172,6 +172,7 @@ RZ_API RzAnalysis *rz_analysis_free(RzAnalysis *a) {
 
 	plugin_fini(a);
 
+	rz_analysis_rzil_cleanup(a, a->rzil);
 	rz_list_free(a->fcns);
 	ht_up_free(a->ht_addr_fun);
 	ht_pp_free(a->ht_name_fun);

--- a/librz/analysis/p/analysis_bf.c
+++ b/librz/analysis/p/analysis_bf.c
@@ -35,14 +35,14 @@ static void bf_syscall_read(RzILVM *vm, RzILOp *op) {
 	ut8 c = getc(stdin);
 	RzILBitVector *bv = rz_il_bv_new_from_ut32(BF_ALIGN_SIZE, c);
 
-	RzILVal *ptr_val = rz_il_dup_value(rz_il_hash_find_val_by_name(vm, "ptr"));
+	RzILVal *ptr_val = rz_il_value_dup(rz_il_hash_find_val_by_name(vm, "ptr"));
 
 	rz_il_vm_mem_store(vm, 0, ptr_val->data.bv, bv);
-	rz_il_free_value(ptr_val);
+	rz_il_value_free(ptr_val);
 }
 
 static void bf_syscall_write(RzILVM *vm, RzILOp *op) {
-	RzILVal *ptr_val = rz_il_dup_value(rz_il_hash_find_val_by_name(vm, "ptr"));
+	RzILVal *ptr_val = rz_il_value_dup(rz_il_hash_find_val_by_name(vm, "ptr"));
 
 	RzILBitVector *bv = rz_il_vm_mem_load(vm, 0, ptr_val->data.bv);
 	if (!bv) {
@@ -51,7 +51,7 @@ static void bf_syscall_write(RzILVM *vm, RzILOp *op) {
 	}
 	ut32 c = rz_il_bv_to_ut32(bv);
 
-	rz_il_free_value(ptr_val);
+	rz_il_value_free(ptr_val);
 	rz_il_bv_free(bv);
 
 	putchar(c);

--- a/librz/asm/asm.c
+++ b/librz/asm/asm.c
@@ -252,6 +252,7 @@ RZ_API void rz_asm_free(RzAsm *a) {
 	}
 	rz_syscall_free(a->syscall);
 	free(a->cpu);
+	free(a->features);
 	sdb_free(a->pair);
 	ht_pp_free(a->flags);
 	a->pair = NULL;

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -145,6 +145,7 @@ RZ_API void rz_bin_info_free(RzBinInfo *rb) {
 	free(rb->cpu);
 	free(rb->machine);
 	free(rb->os);
+	free(rb->features);
 	free(rb->subsystem);
 	free(rb->default_cc);
 	free(rb->rpath);

--- a/librz/cons/line.c
+++ b/librz/cons/line.c
@@ -23,7 +23,7 @@ RZ_API RzLine *rz_line_new(void) {
 	I.contents = NULL;
 	I.enable_vi_mode = false;
 	I.clipboard = NULL;
-	I.kill_ring = rz_list_newf(NULL);
+	I.kill_ring = rz_list_newf(free);
 	I.kill_ring_ptr = -1;
 #if __WINDOWS__
 	I.vtmode = rz_cons_detect_vt_mode();

--- a/librz/core/cio.c
+++ b/librz/core/cio.c
@@ -777,11 +777,13 @@ RZ_API bool rz_core_write_string_at(RzCore *core, ut64 addr, const char *s) {
 	int len = rz_str_unescape(str);
 	if (!rz_core_write_at(core, addr, (const ut8 *)str, len)) {
 		RZ_LOG_ERROR("Could not write '%s' at %" PFMT64x "\n", s, addr);
+		free(str);
 		return false;
 	}
 	if (rz_config_get_i(core->config, "cfg.wseek")) {
 		rz_core_seek_delta(core, len, true);
 	}
+	free(str);
 	return true;
 }
 

--- a/librz/core/yank.c
+++ b/librz/core/yank.c
@@ -179,10 +179,9 @@ RZ_API bool rz_core_yank_paste(RzCore *core, ut64 addr, ut64 len) {
 		return false;
 	}
 	rz_buf_read_at(core->yank_buf, 0, buf, len);
-	if (!rz_core_write_at(core, addr, buf, len)) {
-		return false;
-	}
-	return true;
+	bool res = rz_core_write_at(core, addr, buf, len);
+	free(buf);
+	return res;
 }
 
 /* \brief Yanks data from the current offset to the specified offset

--- a/librz/il/definitions/bool.c
+++ b/librz/il/definitions/bool.c
@@ -8,7 +8,7 @@
  * \param true_or_false bool, set bool as true or false
  * \return bool RzILBool, pointer to bool value
  */
-RZ_API RzILBool *rz_il_new_bool(bool true_or_false) {
+RZ_API RzILBool *rz_il_bool_new(bool true_or_false) {
 	RzILBool *ret = RZ_NEW0(RzILBool);
 	if (!ret) {
 		return NULL;
@@ -26,7 +26,7 @@ RZ_API RzILBool *rz_il_new_bool(bool true_or_false) {
 RZ_API RzILBool *rz_il_bool_and(RZ_NONNULL RzILBool *a, RZ_NONNULL RzILBool *b) {
 	rz_return_val_if_fail(a && b, NULL);
 	bool result = a->b && b->b;
-	RzILBool *ret = rz_il_new_bool(result);
+	RzILBool *ret = rz_il_bool_new(result);
 	return ret;
 }
 
@@ -39,7 +39,7 @@ RZ_API RzILBool *rz_il_bool_and(RZ_NONNULL RzILBool *a, RZ_NONNULL RzILBool *b) 
 RZ_API RzILBool *rz_il_bool_or(RZ_NONNULL RzILBool *a, RZ_NONNULL RzILBool *b) {
 	rz_return_val_if_fail(a && b, NULL);
 	bool result = a->b || b->b;
-	RzILBool *ret = rz_il_new_bool(result);
+	RzILBool *ret = rz_il_bool_new(result);
 	return ret;
 }
 
@@ -52,7 +52,7 @@ RZ_API RzILBool *rz_il_bool_or(RZ_NONNULL RzILBool *a, RZ_NONNULL RzILBool *b) {
 RZ_API RzILBool *rz_il_bool_xor(RZ_NONNULL RzILBool *a, RZ_NONNULL RzILBool *b) {
 	rz_return_val_if_fail(a && b, NULL);
 	bool result = a->b != b->b;
-	return rz_il_new_bool(result);
+	return rz_il_bool_new(result);
 }
 
 /**
@@ -63,7 +63,7 @@ RZ_API RzILBool *rz_il_bool_xor(RZ_NONNULL RzILBool *a, RZ_NONNULL RzILBool *b) 
 RZ_API RzILBool *rz_il_bool_not(RZ_NONNULL RzILBool *a) {
 	rz_return_val_if_fail(a, NULL);
 	bool result = !a->b;
-	RzILBool *ret = rz_il_new_bool(result);
+	RzILBool *ret = rz_il_bool_new(result);
 	return ret;
 }
 
@@ -71,7 +71,7 @@ RZ_API RzILBool *rz_il_bool_not(RZ_NONNULL RzILBool *a) {
  * Free RzILBool instance
  * \param bool_var RzILBool, pointer to the bool instance
  */
-RZ_API void rz_il_free_bool(RzILBool *bool_var) {
+RZ_API void rz_il_bool_free(RzILBool *bool_var) {
 	if (!bool_var) {
 		return;
 	}

--- a/librz/il/definitions/effect.c
+++ b/librz/il/definitions/effect.c
@@ -7,7 +7,7 @@
  * Create a data effect
  * \return Data effect instance
  */
-RZ_API RzILDataEffect *rz_il_effect_new_data(void) {
+RZ_API RzILDataEffect *rz_il_effect_data_new(void) {
 	RzILDataEffect *ret;
 	ret = RZ_NEW0(RzILDataEffect);
 	if (!ret) {
@@ -23,7 +23,7 @@ RZ_API RzILDataEffect *rz_il_effect_new_data(void) {
  * Create a control effect
  * \return Control effect
  */
-RZ_API RzILCtrlEffect *rz_il_effect_new_ctrl(void) {
+RZ_API RzILCtrlEffect *rz_il_effect_ctrl_new(void) {
 	RzILCtrlEffect *ret;
 	ret = RZ_NEW0(RzILCtrlEffect);
 	if (!ret) {
@@ -73,7 +73,7 @@ RZ_API RzILEffect *rz_il_wrap_data_effect(RzILDataEffect *eff) {
  * Free a control effect
  * \param eff control effect to be free
  */
-RZ_API void rz_il_effect_free_ctrl(RzILCtrlEffect *eff) {
+RZ_API void rz_il_effect_ctrl_free(RzILCtrlEffect *eff) {
 	if (!eff) {
 		return;
 	}
@@ -84,7 +84,7 @@ RZ_API void rz_il_effect_free_ctrl(RzILCtrlEffect *eff) {
  * Free a data effect
  * \param eff data effect to be free
  */
-RZ_API void rz_il_effect_free_data(RzILDataEffect *eff) {
+RZ_API void rz_il_effect_data_free(RzILDataEffect *eff) {
 	if (!eff) {
 		return;
 	}
@@ -102,10 +102,10 @@ RZ_API RzILEffect *rz_il_effect_new(EFFECT_TYPE type) {
 	// can only be data or ctrl
 	switch (type) {
 	case EFFECT_TYPE_CTRL:
-		ret = rz_il_wrap_ctrl_effect(rz_il_effect_new_ctrl());
+		ret = rz_il_wrap_ctrl_effect(rz_il_effect_ctrl_new());
 		break;
 	case EFFECT_TYPE_DATA:
-		ret = rz_il_wrap_data_effect(rz_il_effect_new_data());
+		ret = rz_il_wrap_data_effect(rz_il_effect_data_new());
 		break;
 	case EFFECT_TYPE_NON:
 		ret = RZ_NEW0(RzILEffect);
@@ -136,11 +136,11 @@ RZ_API void rz_il_effect_free(RzILEffect *effect) {
 	EFFECT_TYPE type = effect->effect_type;
 	switch (type) {
 	case EFFECT_TYPE_CTRL:
-		rz_il_effect_free_ctrl(effect->ctrl_eff);
+		rz_il_effect_ctrl_free(effect->ctrl_eff);
 		effect->ctrl_eff = NULL;
 		break;
 	case EFFECT_TYPE_DATA:
-		rz_il_effect_free_data(effect->data_eff);
+		rz_il_effect_data_free(effect->data_eff);
 		effect->data_eff = NULL;
 		break;
 	case EFFECT_TYPE_NON:
@@ -202,7 +202,7 @@ RZ_API RZ_OWN char *rz_il_effect_as_string(RzILEffect *effect) {
  * \param type Label type
  * \return Pointer to label
  */
-RZ_API RzILEffectLabel *rz_il_effect_new_label(RZ_NONNULL const char *name, EFFECT_LABEL_TYPE type) {
+RZ_API RzILEffectLabel *rz_il_effect_label_new(RZ_NONNULL const char *name, EFFECT_LABEL_TYPE type) {
 	RzILEffectLabel *lbl = RZ_NEW0(RzILEffectLabel);
 	if (!lbl) {
 		return NULL;

--- a/librz/il/definitions/mem.c
+++ b/librz/il/definitions/mem.c
@@ -13,7 +13,7 @@ static void free_bv_key_value(HtPPKv *kv) {
  * \param min_unit_size, minimal size of a data unit of current arch
  * \return RzILMem*
  */
-RZ_API RzILMem *rz_il_new_mem(ut32 min_unit_size) {
+RZ_API RzILMem *rz_il_mem_new(ut32 min_unit_size) {
 	RzILMem *ret = RZ_NEW0(RzILMem);
 	if (!ret) {
 		return NULL;
@@ -38,7 +38,7 @@ RZ_API RzILMem *rz_il_new_mem(ut32 min_unit_size) {
  * Free a Mem
  * \param mem memory to be free
  */
-RZ_API void rz_il_free_mem(RzILMem *mem) {
+RZ_API void rz_il_mem_free(RzILMem *mem) {
 	if (!mem) {
 		return;
 	}

--- a/librz/il/definitions/value.c
+++ b/librz/il/definitions/value.c
@@ -7,7 +7,7 @@
  * New an empty value
  * \return val RzILVal, pointer to this value
  */
-RZ_API RzILVal *rz_il_new_value(void) {
+RZ_API RzILVal *rz_il_value_new(void) {
 	RzILVal *ret;
 	ret = RZ_NEW0(RzILVal);
 	if (!ret) {
@@ -22,12 +22,12 @@ RZ_API RzILVal *rz_il_new_value(void) {
  * \param val RzILVal, pointer to the value you want to dump
  * \return dump RzILVal, pointer to the dumped value
  */
-RZ_API RzILVal *rz_il_dup_value(RzILVal *val) {
-	RzILVal *ret = rz_il_new_value();
+RZ_API RzILVal *rz_il_value_dup(RzILVal *val) {
+	RzILVal *ret = rz_il_value_new();
 	ret->type = val->type;
 
 	if (ret->type == RZIL_VAR_TYPE_BOOL) {
-		ret->data.b = rz_il_new_bool(val->data.b->b);
+		ret->data.b = rz_il_bool_new(val->data.b->b);
 	}
 
 	if (ret->type == RZIL_VAR_TYPE_BV) {
@@ -46,7 +46,7 @@ RZ_API RzILVal *rz_il_dup_value(RzILVal *val) {
  * Free a RzILVal value
  * \param val RzILVal, pointer to the RzILVal instance
  */
-RZ_API void rz_il_free_value(RzILVal *val) {
+RZ_API void rz_il_value_free(RzILVal *val) {
 	if (!val) {
 		return;
 	}
@@ -54,7 +54,7 @@ RZ_API void rz_il_free_value(RzILVal *val) {
 	RZIL_VAR_TYPE type = val->type;
 	switch (type) {
 	case RZIL_VAR_TYPE_BOOL:
-		rz_il_free_bool(val->data.b);
+		rz_il_bool_free(val->data.b);
 		break;
 	case RZIL_VAR_TYPE_BV:
 		rz_il_bv_free(val->data.bv);

--- a/librz/il/rzil_vm.c
+++ b/librz/il/rzil_vm.c
@@ -37,7 +37,7 @@ RZ_API RzILVal *rz_il_vm_create_value(RZ_NONNULL RzILVM *vm, RZ_NONNULL RZIL_VAR
 		return NULL;
 	}
 
-	RzILVal *val = rz_il_new_value();
+	RzILVal *val = rz_il_value_new();
 	val->type = type;
 
 	rz_il_add_to_bag(vm->vm_global_value_set, val);
@@ -78,7 +78,7 @@ RZ_API RzILVal *rz_il_vm_fortify_val(RzILVM *vm, RzILVal *val) {
  * \return val RzILVal, pointer to the fortified value
  */
 RZ_API RzILVal *rz_il_vm_fortify_bitv(RzILVM *vm, RzILBitVector *bitv) {
-	RzILVal *val = rz_il_new_value();
+	RzILVal *val = rz_il_value_new();
 	if (!val) {
 		return NULL;
 	}
@@ -96,7 +96,7 @@ RZ_API RzILVal *rz_il_vm_fortify_bitv(RzILVM *vm, RzILBitVector *bitv) {
  * \return val RzILVal, pointer to the fortified value
  */
 RZ_API RzILVal *rz_il_vm_fortify_bool(RzILVM *vm, RzILBool *b) {
-	RzILVal *val = rz_il_new_value();
+	RzILVal *val = rz_il_value_new();
 	if (!val) {
 		return NULL;
 	}
@@ -228,7 +228,7 @@ RZ_API RzILEffectLabel *rz_il_vm_create_label(RzILVM *vm, RZ_NONNULL const char 
 	rz_return_val_if_fail(name, NULL);
 	HtPP *lbl_table = vm->vm_global_label_table;
 
-	RzILEffectLabel *lbl = rz_il_effect_new_label(name, EFFECT_LABEL_ADDR);
+	RzILEffectLabel *lbl = rz_il_effect_label_new(name, EFFECT_LABEL_ADDR);
 	lbl->addr = rz_il_bv_dup(addr);
 	ht_pp_insert(lbl_table, name, lbl);
 
@@ -245,7 +245,7 @@ RZ_API RzILEffectLabel *rz_il_vm_create_label_lazy(RzILVM *vm, RZ_NONNULL const 
 	rz_return_val_if_fail(name, NULL);
 	HtPP *lbl_table = vm->vm_global_label_table;
 
-	RzILEffectLabel *lbl = rz_il_effect_new_label(name, EFFECT_LABEL_ADDR);
+	RzILEffectLabel *lbl = rz_il_effect_label_new(name, EFFECT_LABEL_ADDR);
 	lbl->addr = NULL;
 	ht_pp_insert(lbl_table, name, lbl);
 
@@ -303,21 +303,20 @@ RZ_API RzPVector *rz_il_make_oplist(int num, ...) {
 
 // WARN : convertion breaks the original data
 static RzILBool *bitv_to_bool(RzILBitVector *bitv) {
-	RzILBool *result;
-	result = rz_il_new_bool(!rz_il_bv_is_zero_vector(bitv));
+	RzILBool *result = rz_il_bool_new(!rz_il_bv_is_zero_vector(bitv));
 	rz_il_bv_free(bitv);
 	return result;
 }
 
 static RzILVal *bitv_to_val(RzILBitVector *bitv) {
-	RzILVal *ret = rz_il_new_value();
+	RzILVal *ret = rz_il_value_new();
 	ret->type = RZIL_VAR_TYPE_BV;
 	ret->data.bv = bitv;
 	return ret;
 }
 
 static RzILVal *bool_to_val(RzILBool *b) {
-	RzILVal *ret = rz_il_new_value();
+	RzILVal *ret = rz_il_value_new();
 	ret->type = RZIL_VAR_TYPE_BOOL;
 	ret->data.b = b;
 	return ret;
@@ -477,9 +476,17 @@ RZ_API RzILEffect *rz_il_evaluate_effect(RzILVM *vm, RzILOp *op, RzILOpArgType *
 	case RZIL_OP_ARG_EFF:
 		return result;
 	case RZIL_OP_ARG_BITV:
+		rz_il_bv_free(result);
+		break;
 	case RZIL_OP_ARG_BOOL:
+		rz_il_bool_free(result);
+		break;
 	case RZIL_OP_ARG_VAL:
+		rz_il_value_free(result);
+		break;
 	case RZIL_OP_ARG_MEM:
+		rz_il_mem_free(result);
+		break;
 	default:
 		RZ_LOG_ERROR("RzIL : Expected Effect\n");
 		break;

--- a/librz/il/theory_bitv.c
+++ b/librz/il/theory_bitv.c
@@ -7,7 +7,7 @@
 void *rz_il_handler_msb(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
 	RzILOpMsb *op_msb = op->op.msb;
 	RzILBitVector *bv = rz_il_evaluate_bitv(vm, op_msb->bv, type);
-	RzILBool *result = rz_il_new_bool(rz_il_bv_msb(bv));
+	RzILBool *result = rz_il_bool_new(rz_il_bv_msb(bv));
 	rz_il_bv_free(bv);
 
 	*type = RZIL_OP_ARG_BOOL;
@@ -17,7 +17,7 @@ void *rz_il_handler_msb(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
 void *rz_il_handler_lsb(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
 	RzILOpLsb *op_lsb = op->op.lsb;
 	RzILBitVector *bv = rz_il_evaluate_bitv(vm, op_lsb->bv, type);
-	RzILBool *result = rz_il_new_bool(rz_il_bv_lsb(bv));
+	RzILBool *result = rz_il_bool_new(rz_il_bv_lsb(bv));
 	rz_il_bv_free(bv);
 
 	*type = RZIL_OP_ARG_BOOL;
@@ -51,7 +51,7 @@ void *rz_il_handler_sle(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
 
 	RzILBitVector *x = rz_il_evaluate_bitv(vm, op_sle->x, type);
 	RzILBitVector *y = rz_il_evaluate_bitv(vm, op_sle->y, type);
-	RzILBool *result = rz_il_new_bool(rz_il_bv_sle(x, y));
+	RzILBool *result = rz_il_bool_new(rz_il_bv_sle(x, y));
 
 	rz_il_bv_free(x);
 	rz_il_bv_free(y);
@@ -65,7 +65,7 @@ void *rz_il_handler_ule(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
 
 	RzILBitVector *x = rz_il_evaluate_bitv(vm, op_ule->x, type);
 	RzILBitVector *y = rz_il_evaluate_bitv(vm, op_ule->y, type);
-	RzILBool *result = rz_il_new_bool(rz_il_bv_ule(x, y));
+	RzILBool *result = rz_il_bool_new(rz_il_bv_ule(x, y));
 
 	rz_il_bv_free(x);
 	rz_il_bv_free(y);
@@ -185,7 +185,7 @@ void *rz_il_handler_shiftl(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
 
 	rz_il_bv_free(shift);
 	rz_il_bv_free(bv);
-	rz_il_free_bool(fill_bit);
+	rz_il_bool_free(fill_bit);
 
 	*type = RZIL_OP_ARG_BOOL;
 	return result;
@@ -204,7 +204,7 @@ void *rz_il_handler_shiftr(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
 
 	rz_il_bv_free(shift);
 	rz_il_bv_free(bv);
-	rz_il_free_bool(fill_bit);
+	rz_il_bool_free(fill_bit);
 
 	*type = RZIL_OP_ARG_BITV;
 	return result;

--- a/librz/il/theory_bool.c
+++ b/librz/il/theory_bool.c
@@ -5,13 +5,13 @@
 #include <rz_il/rzil_vm.h>
 
 void *rz_il_handler_b0(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
-	RzILBool *ret = rz_il_new_bool(false);
+	RzILBool *ret = rz_il_bool_new(false);
 	*type = RZIL_OP_ARG_BOOL;
 	return ret;
 }
 
 void *rz_il_handler_b1(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
-	RzILBool *ret = rz_il_new_bool(true);
+	RzILBool *ret = rz_il_bool_new(true);
 	*type = RZIL_OP_ARG_BOOL;
 	return ret;
 }
@@ -22,8 +22,8 @@ void *rz_il_handler_and_(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
 	RzILBool *y = rz_il_evaluate_bool(vm, op_and_->y, type);
 
 	RzILBool *result = rz_il_bool_and(x, y);
-	rz_il_free_bool(x);
-	rz_il_free_bool(y);
+	rz_il_bool_free(x);
+	rz_il_bool_free(y);
 
 	*type = RZIL_OP_ARG_BOOL;
 	return result;
@@ -35,8 +35,8 @@ void *rz_il_handler_or_(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
 	RzILBool *y = rz_il_evaluate_bool(vm, op_or_->y, type);
 
 	RzILBool *result = rz_il_bool_or(x, y);
-	rz_il_free_bool(x);
-	rz_il_free_bool(y);
+	rz_il_bool_free(x);
+	rz_il_bool_free(y);
 
 	*type = RZIL_OP_ARG_BOOL;
 	return result;
@@ -46,7 +46,7 @@ void *rz_il_handler_inv(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
 	RzILOpInv *op_inv = op->op.inv;
 	RzILBool *x = rz_il_evaluate_bool(vm, op_inv->x, type);
 	RzILBool *result = rz_il_bool_not(x);
-	rz_il_free_bool(x);
+	rz_il_bool_free(x);
 
 	return result;
 }

--- a/librz/il/theory_effect.c
+++ b/librz/il/theory_effect.c
@@ -85,12 +85,12 @@ void *rz_il_handler_goto(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
 
 	RzILEffectLabel *label = rz_il_vm_find_label_by_name(vm, lname);
 	if (label->type == EFFECT_LABEL_SYSCALL) {
-		rz_il_effect_free_ctrl(eff->ctrl_eff);
+		rz_il_effect_ctrl_free(eff->ctrl_eff);
 		eff->notation = EFFECT_NOTATION_GOTO_SYS;
 		// WARN : HACK to call hook
 		eff->ctrl_eff = (void *)op;
 	} else if (label->type == EFFECT_LABEL_HOOK) {
-		rz_il_effect_free_ctrl(eff->ctrl_eff);
+		rz_il_effect_ctrl_free(eff->ctrl_eff);
 		eff->notation = EFFECT_NOTATION_GOTO_HOOK;
 		// WARN : HACK to call
 		eff->ctrl_eff = (void *)op;
@@ -139,8 +139,7 @@ void *rz_il_handler_branch(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
 		// false branch
 		ret = (op_branch->false_eff == NULL) ? rz_il_effect_new(EFFECT_TYPE_NON) : rz_il_evaluate_effect(vm, op_branch->false_eff, type);
 	}
-
-	rz_il_free_bool(condition);
+	rz_il_bool_free(condition);
 
 	if (ret) {
 		*type = RZIL_OP_ARG_EFF;

--- a/librz/il/theory_init.c
+++ b/librz/il/theory_init.c
@@ -16,21 +16,21 @@ void *rz_il_handler_ite(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
 	} else {
 		ret = rz_il_evaluate_val(vm, op_ite->y, type); // false branch
 	}
-
+	rz_il_bool_free(condition);
 	return ret;
 }
 
 void *rz_il_handler_var(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
 	RzILOpVar *var_op = op->op.var;
 	RzILVal *val = rz_il_hash_find_val_by_name(vm, var_op->v);
-	val = rz_il_dup_value(val);
+	val = rz_il_value_dup(val);
 
 	*type = RZIL_OP_ARG_VAL;
 	return val;
 }
 
 void *rz_il_handler_unk(RzILVM *vm, RzILOp *op, RzILOpArgType *type) {
-	RzILVal *val = rz_il_new_value(); // has UNK
+	RzILVal *val = rz_il_value_new(); // has UNK
 	*type = RZIL_OP_ARG_VAL;
 	return val;
 }

--- a/librz/il/vm_layer.c
+++ b/librz/il/vm_layer.c
@@ -42,7 +42,7 @@ RZ_API bool rz_il_vm_init(RzILVM *vm, ut64 start_addr, int addr_size, int data_s
 		return false;
 	}
 
-	vm->vm_global_value_set = rz_il_new_bag(RZ_IL_VM_MAX_VAL, (RzILBagFreeFunc)rz_il_free_value);
+	vm->vm_global_value_set = rz_il_new_bag(RZ_IL_VM_MAX_VAL, (RzILBagFreeFunc)rz_il_value_free);
 	if (!vm->vm_global_value_set) {
 		RZ_LOG_ERROR("[VM INIT FAILED] : value bag\n");
 		rz_il_vm_fini(vm);
@@ -167,7 +167,7 @@ RZ_API void rz_il_vm_fini(RzILVM *vm) {
 
 	if (vm->mems) {
 		for (int i = 0; i < vm->mem_count; ++i) {
-			rz_il_free_mem(vm->mems[i]);
+			rz_il_mem_free(vm->mems[i]);
 		}
 		free(vm->mems);
 	}
@@ -184,6 +184,31 @@ RZ_API void rz_il_vm_fini(RzILVM *vm) {
 		free(vm->op_handler_table);
 	}
 	rz_il_bv_free(vm->pc);
+}
+
+/**
+ * Create a new empty VM
+ * \param vm RzILVM, pointer to an empty VM
+ * \param start_addr ut64, initiation pc address
+ * \param addr_size int, size of the address in VM
+ * \param data_size int, size of the minimal data unit in VM
+ */
+RZ_API RzILVM *rz_il_vm_new(ut64 start_addr, int addr_size, int data_size) {
+	RzILVM *vm = RZ_NEW0(RzILVM);
+	if (!vm) {
+		return NULL;
+	}
+	rz_il_vm_init(vm, start_addr, addr_size, data_size);
+	return vm;
+}
+
+/**
+ * Close, clean and free vm
+ * \param vm RzILVM* pointer to VM
+ */
+RZ_API void rz_il_vm_free(RzILVM *vm) {
+	rz_il_vm_fini(vm);
+	free(vm);
 }
 
 /**
@@ -221,7 +246,7 @@ RZ_API void rz_il_free_bv_addr(RzILBitVector *addr) {
  * \return Mem memory, return a pointer to the newly created memory
  */
 RZ_API RzILMem *rz_il_vm_add_mem(RzILVM *vm, ut32 min_unit_size) {
-	RzILMem *mem = rz_il_new_mem(min_unit_size);
+	RzILMem *mem = rz_il_mem_new(min_unit_size);
 	vm->mems[vm->mem_count] = mem;
 	vm->mem_count += 1;
 	return mem;

--- a/librz/include/rz_il/definitions/bool.h
+++ b/librz/include/rz_il/definitions/bool.h
@@ -16,12 +16,12 @@ struct bool_t {
 };
 typedef struct bool_t RzILBool;
 
-RZ_API RzILBool *rz_il_new_bool(bool true_or_false);
+RZ_API RzILBool *rz_il_bool_new(bool true_or_false);
 RZ_API RzILBool *rz_il_bool_and(RzILBool *a, RzILBool *b);
 RZ_API RzILBool *rz_il_bool_or(RzILBool *a, RzILBool *b);
 RZ_API RzILBool *rz_il_bool_xor(RzILBool *a, RzILBool *b);
 RZ_API RzILBool *rz_il_bool_not(RzILBool *a);
-RZ_API void rz_il_free_bool(RzILBool *bool_var);
+RZ_API void rz_il_bool_free(RzILBool *bool_var);
 
 #ifdef __cplusplus
 }

--- a/librz/include/rz_il/definitions/effect.h
+++ b/librz/include/rz_il/definitions/effect.h
@@ -79,14 +79,14 @@ struct rzil_effect_union_t {
 // a chain of effects
 // should use something like rz_vector / rz_list
 RZ_API RzILEffect *rz_il_effect_new(EFFECT_TYPE type);
-RZ_API RzILDataEffect *rz_il_effect_new_data(void);
-RZ_API RzILCtrlEffect *rz_il_effect_new_ctrl(void);
+RZ_API RzILDataEffect *rz_il_effect_data_new(void);
+RZ_API RzILCtrlEffect *rz_il_effect_ctrl_new(void);
 RZ_API RzILEffect *rz_il_wrap_ctrl_effect(RzILCtrlEffect *eff);
 RZ_API RzILEffect *rz_il_wrap_data_effect(RzILDataEffect *eff);
-RZ_API RzILEffectLabel *rz_il_effect_new_label(const char *name, EFFECT_LABEL_TYPE type);
+RZ_API RzILEffectLabel *rz_il_effect_label_new(const char *name, EFFECT_LABEL_TYPE type);
 RZ_API void rz_il_effect_free(RzILEffect *effect);
-RZ_API void rz_il_effect_free_ctrl(RzILCtrlEffect *eff);
-RZ_API void rz_il_effect_free_data(RzILDataEffect *eff);
+RZ_API void rz_il_effect_ctrl_free(RzILCtrlEffect *eff);
+RZ_API void rz_il_effect_data_free(RzILDataEffect *eff);
 RZ_API char *rz_il_effect_as_string(RzILEffect *effect);
 
 #ifdef __cplusplus

--- a/librz/include/rz_il/definitions/mem.h
+++ b/librz/include/rz_il/definitions/mem.h
@@ -15,8 +15,8 @@ struct rzil_mem_t {
 };
 typedef struct rzil_mem_t RzILMem;
 
-RZ_API RzILMem *rz_il_new_mem(ut32 min_unit_size);
-RZ_API void rz_il_free_mem(RzILMem *mem);
+RZ_API RzILMem *rz_il_mem_new(ut32 min_unit_size);
+RZ_API void rz_il_mem_free(RzILMem *mem);
 RZ_API RzILMem *rz_il_mem_store(RzILMem *mem, RzILBitVector *key, RzILBitVector *value);
 RZ_API RzILBitVector *rz_il_mem_load(RzILMem *mem, RzILBitVector *key);
 

--- a/librz/include/rz_il/definitions/value.h
+++ b/librz/include/rz_il/definitions/value.h
@@ -34,9 +34,9 @@ typedef enum {
 	RZIL_TEMP_EMPTY
 } RZIL_TEMP_TYPE;
 
-RZ_API RzILVal *rz_il_new_value(void);
-RZ_API RzILVal *rz_il_dup_value(RzILVal *val);
-RZ_API void rz_il_free_value(RzILVal *val);
+RZ_API RzILVal *rz_il_value_new(void);
+RZ_API RzILVal *rz_il_value_dup(RzILVal *val);
+RZ_API void rz_il_value_free(RzILVal *val);
 
 #ifdef __cplusplus
 }

--- a/librz/include/rz_il/vm_layer.h
+++ b/librz/include/rz_il/vm_layer.h
@@ -10,6 +10,8 @@ extern "C" {
 #endif
 
 // VM high level operations
+RZ_API RzILVM *rz_il_vm_new(ut64 start_addr, int addr_size, int data_size);
+RZ_API void rz_il_vm_free(RzILVM *vm);
 RZ_API bool rz_il_vm_init(RzILVM *vm, ut64 start_addr, int addr_size, int data_size);
 RZ_API void rz_il_vm_fini(RzILVM *vm);
 RZ_API void rz_il_vm_step(RzILVM *vm, RzILOp *root);

--- a/librz/util/buf.c
+++ b/librz/util/buf.c
@@ -189,23 +189,24 @@ static bool buf_move_back(RZ_NONNULL RzBuffer *b, ut64 addr, ut64 length) {
 		return false;
 	}
 
+	bool res = false;
 	st64 tmp_length = rz_buf_read_at(b, addr, tmp, size - addr);
 	if (tmp_length < 0) {
-		free(tmp);
-		return false;
+		goto err;
 	}
 
 	if (!rz_buf_resize(b, size + length)) {
-		free(tmp);
-		return false;
+		goto err;
 	}
 
 	if (rz_buf_write_at(b, addr + length, tmp, tmp_length) < 0) {
-		free(tmp);
-		return false;
+		goto err;
 	}
 
-	return true;
+	res = true;
+err:
+	free(tmp);
+	return res;
 }
 
 static ut8 *get_whole_buf(RzBuffer *b, ut64 *size) {

--- a/librz/util/buf_sparse.c
+++ b/librz/util/buf_sparse.c
@@ -128,6 +128,9 @@ static bool buf_sparse_init(RzBuffer *b, const void *user) {
 	if (user) {
 		SparseInitConfig *cfg = (void *)user;
 		priv->base = cfg->base;
+		if (priv->base) {
+			rz_buf_ref(priv->base);
+		}
 		priv->write_mode = cfg->write_mode;
 	} else {
 		priv->write_mode = RZ_BUF_SPARSE_WRITE_MODE_SPARSE;
@@ -141,6 +144,7 @@ static bool buf_sparse_init(RzBuffer *b, const void *user) {
 static bool buf_sparse_fini(RzBuffer *b) {
 	struct buf_sparse_priv *priv = get_priv_sparse(b);
 	rz_vector_fini(&priv->chunks);
+	rz_buf_free(priv->base);
 	RZ_FREE(b->priv);
 	return true;
 }

--- a/librz/util/table.c
+++ b/librz/util/table.c
@@ -869,11 +869,6 @@ static int __resolveOperation(const char *op) {
 	return -1;
 }
 
-static void __table_column_free(void *_col) {
-	RzTableColumn *col = (RzTableColumn *)_col;
-	free(col);
-}
-
 RZ_API void rz_table_columns(RzTable *t, RzList *col_names) {
 	// 1 bool per OLD column to indicate whether it should be freed (masked out)
 	bool *free_cols = malloc(sizeof(bool) * rz_list_length(t->cols));
@@ -974,7 +969,7 @@ RZ_API void rz_table_filter_columns(RzTable *t, RzList *list) {
 	const char *col;
 	RzListIter *iter;
 	RzList *cols = t->cols;
-	t->cols = rz_list_newf(__table_column_free);
+	t->cols = rz_list_newf(rz_table_column_free);
 	rz_list_foreach (list, iter, col) {
 		int ncol = rz_table_column_nth(t, col);
 		if (ncol != -1) {

--- a/test/unit/test_bin.c
+++ b/test/unit/test_bin.c
@@ -69,7 +69,7 @@ bool test_rz_bin(void) {
 		i++;
 	}
 
-	const RzList *hashes = rz_bin_file_compute_hashes(bin, bf, UT64_MAX);
+	RzList *hashes = rz_bin_file_compute_hashes(bin, bf, UT64_MAX);
 	mu_assert_eq(rz_list_length(hashes), 5, "rz_bin_file_get_hashes");
 	const char *hash_names[] = { "md5", "sha1", "sha256", "crc32", "entropy" };
 	const char *hash_hexes[] = { "99327411dd72a11d7198b54298648adf", "f2bf1c7758c7b1e22bdea1d7681882783b658705", "3aed9a3821134a2ab1d69cb455e5e9d80bb651a1c97af04cdba4f3bb0adaa37b", "cf8cb28a", "3.484857" };
@@ -80,6 +80,7 @@ bool test_rz_bin(void) {
 		mu_assert_streq(hash->hex, hash_hexes[i], "hash digest is wrong");
 		i++;
 	}
+	rz_list_free(hashes);
 
 	rz_bin_free(bin);
 	rz_io_free(io);

--- a/test/unit/test_buf.c
+++ b/test/unit/test_buf.c
@@ -975,6 +975,7 @@ bool test_rz_buf_sparse_overlay_size(void) {
 	mu_assert_eq(rz_buf_size(b), 0x204, "buf sz");
 
 	rz_buf_free(b);
+	rz_buf_free(base);
 	mu_end;
 }
 

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -520,6 +520,8 @@ bool test_cmd_group_exec_help(void) {
 	rz_cmd_parsed_args_free(a);
 	mu_assert_streq(h1, h2, "pd? should be the same as pd?? because it is a terminal command");
 	mu_assert_streq(h1, pd_help_exp, "pd?/pd?? should print full help");
+	free(h1);
+	free(h2);
 
 	rz_cmd_free(cmd);
 	mu_end;

--- a/test/unit/test_config.c
+++ b/test/unit/test_config.c
@@ -25,6 +25,7 @@ bool test_config() {
 	what = rz_config_get_b(cfg, "true.or.false");
 	mu_assert_eq(what, false, "Boolean variable (toggle)");
 
+	rz_config_free(cfg);
 	mu_end;
 }
 
@@ -47,6 +48,7 @@ bool test_config_lock() {
 	bool what = rz_config_get_b(cfg, "true.or.false");
 	mu_assert_false(what, "Boolean variable (locked)");
 
+	rz_config_free(cfg);
 	mu_end;
 }
 

--- a/test/unit/test_id_storage.c
+++ b/test/unit/test_id_storage.c
@@ -14,6 +14,7 @@ static bool test_rz_id_storage_toomany(void) {
 	mu_assert_true(r, "id1");
 	r = rz_id_storage_add(ids, "ccc", &id2);
 	mu_assert_false(r, "id2");
+	rz_id_storage_free(ids);
 	mu_end;
 }
 
@@ -23,6 +24,7 @@ static bool test_rz_id_storage_wrong(void) {
 	RzIDStorage *ids = rz_id_storage_new(20, 10);
 	r = rz_id_storage_add(ids, "aaa", &id0);
 	mu_assert_false(r, "id0");
+	rz_id_storage_free(ids);
 	mu_end;
 }
 

--- a/test/unit/test_il_definitions.c
+++ b/test/unit/test_il_definitions.c
@@ -117,43 +117,54 @@ bool test_rzil_bv_logic(void) {
 	result = rz_il_bv_and(x, y);
 	mu_assert("and x y", is_equal_bv(result, and));
 	rz_il_bv_free(result);
+	rz_il_bv_free(and);
 
 	result = rz_il_bv_or(x, y);
 	mu_assert("or x y", is_equal_bv(result, or));
 	rz_il_bv_free(result);
+	rz_il_bv_free(or);
 
 	result = rz_il_bv_xor(x, y);
 	mu_assert("xor x y", is_equal_bv(result, xor));
 	rz_il_bv_free(result);
+	rz_il_bv_free(xor);
 
 	result = rz_il_bv_not(x);
 	mu_assert("not x", is_equal_bv(result, not ));
 	rz_il_bv_free(result);
+	rz_il_bv_free(not );
 
 	result = rz_il_bv_neg(x);
 	mu_assert("neg x", is_equal_bv(result, neg));
 	rz_il_bv_free(result);
+	rz_il_bv_free(neg);
 
 	result = rz_il_bv_dup(y);
 	rz_il_bv_lshift(result, 3);
 	mu_assert("left shift y", is_equal_bv(result, ls));
 	rz_il_bv_free(result);
+	rz_il_bv_free(ls);
 
 	result = rz_il_bv_dup(y);
 	rz_il_bv_lshift_fill(result, 3, true);
 	mu_assert("left shift y filling 1", is_equal_bv(result, ls_fill));
 	rz_il_bv_free(result);
+	rz_il_bv_free(ls_fill);
 
 	result = rz_il_bv_dup(y);
 	rz_il_bv_rshift(result, 3);
 	mu_assert("right shift y", is_equal_bv(result, rs));
 	rz_il_bv_free(result);
+	rz_il_bv_free(rs);
 
 	result = rz_il_bv_dup(y);
 	rz_il_bv_rshift_fill(result, 3, true);
 	mu_assert("right shift y", is_equal_bv(result, rs_fill));
 	rz_il_bv_free(result);
+	rz_il_bv_free(rs_fill);
 
+	rz_il_bv_free(x);
+	rz_il_bv_free(y);
 	mu_end;
 }
 
@@ -300,23 +311,25 @@ bool test_rzil_bv_operation(void) {
 bool test_rzil_bv_cast(void) {
 	ut32 normal, shadow;
 	normal = 2021;
-	shadow = rz_il_bv_to_ut32(rz_il_bv_new_from_ut32(32, normal));
+	RzILBitVector *bv = rz_il_bv_new_from_ut32(32, normal);
+	shadow = rz_il_bv_to_ut32(bv);
+	rz_il_bv_free(bv);
 
 	mu_assert("cast bv<->ut32", normal == shadow);
 	mu_end;
 }
 
 bool test_rzil_bool_init(void) {
-	RzILBool *b = rz_il_new_bool(true);
+	RzILBool *b = rz_il_bool_new(true);
 	mu_assert_notnull(b, "New RzILBool");
 	mu_assert_eq(b->b, true, "bool is true");
-	rz_il_free_bool(b);
+	rz_il_bool_free(b);
 	mu_end;
 }
 
 bool test_rzil_bool_logic(void) {
-	RzILBool *t = rz_il_new_bool(true);
-	RzILBool *f = rz_il_new_bool(false);
+	RzILBool *t = rz_il_bool_new(true);
+	RzILBool *f = rz_il_bool_new(false);
 	RzILBool *result;
 
 	// and
@@ -325,15 +338,15 @@ bool test_rzil_bool_logic(void) {
 	// t and f => false
 	result = rz_il_bool_and(t, t);
 	mu_assert("true and true", is_equal_bool(result, t));
-	rz_il_free_bool(result);
+	rz_il_bool_free(result);
 
 	result = rz_il_bool_and(t, f);
 	mu_assert("true and false", is_equal_bool(result, f));
-	rz_il_free_bool(result);
+	rz_il_bool_free(result);
 
 	result = rz_il_bool_and(f, f);
 	mu_assert("false and false", is_equal_bool(result, f));
-	rz_il_free_bool(result);
+	rz_il_bool_free(result);
 
 	// or
 	// t or t => true
@@ -341,26 +354,26 @@ bool test_rzil_bool_logic(void) {
 	// f or f => false
 	result = rz_il_bool_or(t, t);
 	mu_assert("true or true", is_equal_bool(result, t));
-	rz_il_free_bool(result);
+	rz_il_bool_free(result);
 
 	result = rz_il_bool_or(t, f);
 	mu_assert("true or false", is_equal_bool(result, t));
-	rz_il_free_bool(result);
+	rz_il_bool_free(result);
 
 	result = rz_il_bool_or(f, f);
 	mu_assert("false or false", is_equal_bool(result, f));
-	rz_il_free_bool(result);
+	rz_il_bool_free(result);
 
 	// not
 	// not t => false
 	// not f => true
 	result = rz_il_bool_not(t);
 	mu_assert("not true", is_equal_bool(result, f));
-	rz_il_free_bool(result);
+	rz_il_bool_free(result);
 
 	result = rz_il_bool_not(f);
 	mu_assert("not false", is_equal_bool(result, t));
-	rz_il_free_bool(result);
+	rz_il_bool_free(result);
 
 	// xor
 	// t xor t => false
@@ -368,23 +381,23 @@ bool test_rzil_bool_logic(void) {
 	// t xor f => true
 	result = rz_il_bool_xor(t, t);
 	mu_assert("t xor t", is_equal_bool(result, f));
-	rz_il_free_bool(result);
+	rz_il_bool_free(result);
 
 	result = rz_il_bool_xor(f, f);
 	mu_assert("f xor f", is_equal_bool(result, f));
-	rz_il_free_bool(result);
+	rz_il_bool_free(result);
 
 	result = rz_il_bool_xor(t, f);
 	mu_assert("t xor f", is_equal_bool(result, t));
-	rz_il_free_bool(result);
+	rz_il_bool_free(result);
 
-	rz_il_free_bool(t);
-	rz_il_free_bool(f);
+	rz_il_bool_free(t);
+	rz_il_bool_free(f);
 	mu_end;
 }
 
 static bool test_rzil_mem() {
-	RzILMem *mem = rz_il_new_mem(8);
+	RzILMem *mem = rz_il_mem_new(8);
 	mu_assert_notnull(mem, "Create mem");
 
 	RzILBitVector *addr = rz_il_bv_new_from_ut32(16, 121);
@@ -399,6 +412,12 @@ static bool test_rzil_mem() {
 
 	RzILBitVector *data = rz_il_mem_load(mem, addr);
 	mu_assert("Load correct data", is_equal_bv(data, valid_data));
+	rz_il_bv_free(data);
+
+	rz_il_bv_free(valid_data);
+	rz_il_bv_free(invalid_data);
+	rz_il_bv_free(addr);
+	rz_il_mem_free(mem);
 
 	mu_end;
 }
@@ -411,12 +430,13 @@ static bool test_rzil_effect() {
 	mu_assert_null(general_effect->next_eff, "Empty doesn't have next effect");
 	mu_assert_null(general_effect->ctrl_eff, "Empty doesn't include control effect");
 	mu_assert_null(general_effect->data_eff, "Empty doesn't include data effect");
+	rz_il_effect_free(general_effect);
 
-	RzILCtrlEffect *c_eff = rz_il_effect_new_ctrl();
+	RzILCtrlEffect *c_eff = rz_il_effect_ctrl_new();
 	mu_assert_notnull(c_eff, "Create empty control effect");
 	mu_assert_null(c_eff->pc, "Empty control effect have no next pc info");
 
-	RzILDataEffect *d_eff = rz_il_effect_new_data();
+	RzILDataEffect *d_eff = rz_il_effect_data_new();
 	mu_assert_notnull(d_eff, "Create empty data effect");
 	mu_assert_null(d_eff->var_name, "Empty data effect doesn't have variable name");
 
@@ -425,10 +445,12 @@ static bool test_rzil_effect() {
 	data_effect = rz_il_wrap_data_effect(d_eff);
 	mu_assert_eq(data_effect->effect_type, EFFECT_TYPE_DATA, "Wrap data effect");
 	mu_assert_eq(data_effect->data_eff, d_eff, "Get data effect from general one");
+	rz_il_effect_free(data_effect);
 
 	contrl_effect = rz_il_wrap_ctrl_effect(c_eff);
 	mu_assert_eq(contrl_effect->effect_type, EFFECT_TYPE_CTRL, "Wrap control effect");
 	mu_assert_eq(contrl_effect->ctrl_eff, c_eff, "Get control effect from general one");
+	rz_il_effect_free(contrl_effect);
 
 	mu_end;
 }

--- a/test/unit/test_il_vm.c
+++ b/test/unit/test_il_vm.c
@@ -6,18 +6,14 @@
 #include "minunit.h"
 
 static bool test_rzil_vm_init() {
-	RzILVM *vm = RZ_NEW0(RzILVM);
-	mu_assert_notnull(vm, "Create VM");
-	rz_il_vm_init(vm, 0, 8, 8);
+	RzILVM *vm = rz_il_vm_new(0, 8, 8);
 	mu_assert_eq(vm->addr_size, 8, "VM Init");
-	rz_il_vm_fini(vm);
+	rz_il_vm_free(vm);
 	mu_end;
 }
 
 static bool test_rzil_vm_basic_operation() {
-	RzILVM *vm = RZ_NEW0(RzILVM);
-	mu_assert_notnull(vm, "Create vm");
-	rz_il_vm_init(vm, 0, 8, 16);
+	RzILVM *vm = rz_il_vm_new(0, 8, 16);
 
 	// 1. create variables
 	RzILVar *var_r1 = rz_il_vm_create_variable(vm, "r1");
@@ -102,13 +98,12 @@ static bool test_rzil_vm_basic_operation() {
 	mu_assert_true(is_equal_bv, "Update lazy label successfully");
 
 	rz_il_bv_free(addr);
-	rz_il_vm_fini(vm);
+	rz_il_vm_free(vm);
 	mu_end;
 }
 
 static bool test_rzil_vm_operation() {
-	RzILVM *vm = RZ_NEW0(RzILVM);
-	rz_il_vm_init(vm, 0, 8, 16);
+	RzILVM *vm = rz_il_vm_new(0, 8, 16);
 
 	// 1. create register r0 and r1
 	rz_il_vm_add_reg(vm, "r0", 8);
@@ -133,13 +128,12 @@ static bool test_rzil_vm_operation() {
 	is_zero = rz_il_bv_is_zero_vector(r1->data.bv);
 	mu_assert("Init r1 as all zero bitvector", is_zero);
 
-	rz_il_vm_fini(vm);
+	rz_il_vm_free(vm);
 	mu_end;
 }
 
 static bool test_rzil_vm_root_evaluation() {
-	RzILVM *vm = RZ_NEW0(RzILVM);
-	rz_il_vm_init(vm, 0, 8, 16);
+	RzILVM *vm = rz_il_vm_new(0, 8, 16);
 
 	RzILOp *ite_root = rz_il_new_op(RZIL_OP_ITE);
 	RzILOp *add = rz_il_new_op(RZIL_OP_ADD);
@@ -167,14 +161,14 @@ static bool test_rzil_vm_root_evaluation() {
 	RzILBool *condition = rz_il_evaluate_bool(vm, ite_root->op.ite->condition, &type_checker);
 	mu_assert_eq(type_checker, RZIL_OP_ARG_BOOL, "Evaluate a bool expression");
 	mu_assert_eq(condition->b, true, "Correctly convert bitv to bool");
-	rz_il_free_bool(condition);
+	rz_il_bool_free(condition);
 
 	// Evaluate the whole ite expression
 	RzILVal *ite_val = rz_il_evaluate_val(vm, ite_root, &type_checker);
 	mu_assert_eq(type_checker, RZIL_OP_ARG_VAL, "Correctly get a RzILVal");
 	mu_assert_eq(ite_val->type, RZIL_VAR_TYPE_BOOL, "Return a Bool Val");
 	mu_assert_eq(ite_val->data.b->b, true, "Return a True");
-	rz_il_free_value(ite_val);
+	rz_il_value_free(ite_val);
 
 	// Catch error
 	RzILOp *branch_root = rz_il_new_op(RZIL_OP_BRANCH);
@@ -190,8 +184,11 @@ static bool test_rzil_vm_root_evaluation() {
 	RzILEffect *eff = rz_il_evaluate_effect(vm, branch_root, &type_checker);
 	mu_assert_null(eff, "Error happens");
 	mu_assert_eq(type_checker, RZIL_OP_ARG_BOOL, "you cannot convert bool type to effect, such an error will be detected");
+	rz_il_effect_free(eff);
 
 	rz_il_free_op(ite_root);
+	rz_il_free_op(true_val);
+	rz_il_free_op(false_val);
 	rz_il_free_op(add);
 	rz_il_free_op(arg1);
 	rz_il_free_op(arg2);
@@ -199,7 +196,7 @@ static bool test_rzil_vm_root_evaluation() {
 	rz_il_free_op(branch_true);
 	rz_il_free_op(branch_false);
 	rz_il_free_op(branch_cond);
-	rz_il_vm_fini(vm);
+	rz_il_vm_free(vm);
 	mu_end;
 }
 

--- a/test/unit/test_io.c
+++ b/test/unit/test_io.c
@@ -349,6 +349,7 @@ bool test_rz_io_default(void) {
 	close(fd);
 	mu_assert_memeq(buf, (ut8 *)"FEDCBA0987654321", 0x10, "data has been correctly written at 0x50");
 	rz_file_rm(filename);
+	free(filename);
 	mu_end;
 }
 

--- a/test/unit/test_json.c
+++ b/test/unit/test_json.c
@@ -1005,7 +1005,7 @@ static int check_expected_58(RzJson *j) {
 		"\"str5\":\"\\\\?text\\\\?\",\"str\\t6\\\\\":\"text\\ntext\\ttext\","
 		"\"obj\":{\"KEY\":\"VAL\",\"obj\":{\"KEY\":\"VAL\"}}}";
 	char *jsonstr = rz_json_as_string(j);
-	mu_assert_streq(jsonstr, json_str, "RzJson as string");
+	mu_assert_streq_free(jsonstr, json_str, "RzJson as string");
 	return MU_PASSED;
 }
 

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -26,6 +26,7 @@ bool test_rz_scan_strings_detect_ascii(void) {
 
 	rz_detected_string_free(s);
 	rz_list_free(str_list);
+	rz_buf_free(buf);
 
 	mu_end;
 }
@@ -45,6 +46,7 @@ bool test_rz_scan_strings_detect_utf8(void) {
 
 	rz_detected_string_free(s);
 	rz_list_free(str_list);
+	rz_buf_free(buf);
 
 	mu_end;
 }
@@ -71,6 +73,7 @@ bool test_rz_scan_strings_detect_utf16_le(void) {
 
 	rz_detected_string_free(s);
 	rz_list_free(str_list);
+	rz_buf_free(buf);
 
 	mu_end;
 }
@@ -97,6 +100,7 @@ bool test_rz_scan_strings_detect_utf16_le_special_chars(void) {
 
 	rz_detected_string_free(s);
 	rz_list_free(str_list);
+	rz_buf_free(buf);
 
 	mu_end;
 }
@@ -123,6 +127,7 @@ bool test_rz_scan_strings_detect_utf16_be(void) {
 
 	rz_detected_string_free(s);
 	rz_list_free(str_list);
+	rz_buf_free(buf);
 
 	mu_end;
 }
@@ -152,6 +157,7 @@ bool test_rz_scan_strings_detect_utf32_le(void) {
 
 	rz_detected_string_free(s);
 	rz_list_free(str_list);
+	rz_buf_free(buf);
 
 	mu_end;
 }
@@ -181,6 +187,7 @@ bool test_rz_scan_strings_detect_utf32_be(void) {
 
 	rz_detected_string_free(s);
 	rz_list_free(str_list);
+	rz_buf_free(buf);
 
 	mu_end;
 }
@@ -206,6 +213,7 @@ bool test_rz_scan_strings_utf16_be(void) {
 
 	rz_detected_string_free(s);
 	rz_list_free(str_list);
+	rz_buf_free(buf);
 
 	mu_end;
 }

--- a/test/unit/test_table.c
+++ b/test/unit/test_table.c
@@ -325,7 +325,8 @@ bool test_rz_table_columns() {
 bool test_rz_table_transpose() {
 	RzTable *t = __table_test_data1();
 	rz_table_add_row(t, "d", "100", NULL);
-	char *table = rz_table_tostring(rz_table_transpose(t));
+	RzTable *transpose = rz_table_transpose(t);
+	char *table = rz_table_tostring(transpose);
 	mu_assert_streq(table,
 		"Name  Value1 Value2 Value3 Value4 \n"
 		"----------------------------------\n"
@@ -333,6 +334,8 @@ bool test_rz_table_transpose() {
 		"code  97     98     99     100\n",
 		"rz_table_transpose");
 	free(table);
+	rz_table_free(transpose);
+	rz_table_free(t);
 	mu_end;
 }
 
@@ -351,6 +354,7 @@ bool test_rz_table_add_row_columnsf() {
 		"e     10\n",
 		"rz_table_transpose");
 	free(table);
+	rz_table_free(t);
 	mu_end;
 }
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Just fixing leaks detected by running unit tests. Ideally unit tests, at least, should be leak-free. There is still a lot to do for that though.
Bonus fix: adjust RzIL APIs to respect the usual naming convention e.g. `rz_il_bv_free` instead of `rz_il_free_bv`, etc.
