### PR TITLE
Refactor APIs related to themes and remove global variables from `cmd_eval`

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -364,7 +364,7 @@ static bool cb_scrrainbow(void *user, void *data) {
 		rz_cons_pal_random();
 	} else {
 		core->print->flags &= (~RZ_PRINT_FLAGS_RAINBOW);
-		rz_core_theme_load(core, rz_core_theme_get());
+		rz_core_theme_load(core, rz_core_theme_get(core));
 	}
 	rz_print_set_flags(core->print, core->print->flags);
 	return true;

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -364,7 +364,7 @@ static bool cb_scrrainbow(void *user, void *data) {
 		rz_cons_pal_random();
 	} else {
 		core->print->flags &= (~RZ_PRINT_FLAGS_RAINBOW);
-		rz_core_load_theme(core, rz_core_get_theme());
+		rz_core_theme_load(core, rz_core_theme_get());
 	}
 	rz_print_set_flags(core->print, core->print->flags);
 	return true;

--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -241,7 +241,7 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_load_theme_handler(RzCore *core, int argc, 
 		return bool2status(rz_core_load_theme(core, argv[1]));
 	}
 	switch (mode) {
-	case RZ_OUTPUT_MODE_JSON:
+	case RZ_OUTPUT_MODE_JSON: {
 		PJ *pj = pj_new();
 		if (!pj) {
 			break;
@@ -255,6 +255,7 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_load_theme_handler(RzCore *core, int argc, 
 		rz_cons_println(pj_string(pj));
 		pj_free(pj);
 		break;
+	}
 	case RZ_OUTPUT_MODE_QUIET:
 		themes_list = rz_core_list_themes(core);
 		rz_list_foreach (themes_list, th_iter, th) {

--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -61,7 +61,7 @@ static bool pal_seek(RzCore *core, RzConsPalSeekMode mode, const char *file, RzL
 	return true;
 }
 
-RZ_API bool rz_core_load_theme(RzCore *core, const char *name) {
+RZ_API bool rz_core_theme_load(RzCore *core, const char *name) {
 	bool failed = false;
 	char *path;
 	if (!name || !*name) {
@@ -110,11 +110,11 @@ static void list_themes_in_path(RzList *list, const char *path) {
 	rz_list_free(files);
 }
 
-RZ_API char *rz_core_get_theme(void) {
+RZ_API char *rz_core_theme_get(void) {
 	return curtheme;
 }
 
-RZ_API RZ_OWN RzList *rz_core_list_themes(RzCore *core) {
+RZ_API RZ_OWN RzList *rz_core_theme_list(RzCore *core) {
 	RzList *list = rz_list_newf(free);
 	getNext = false;
 	char *tmp = strdup("default");
@@ -137,7 +137,7 @@ RZ_API RZ_OWN RzList *rz_core_list_themes(RzCore *core) {
 RZ_IPI void rz_core_theme_nextpal(RzCore *core, RzConsPalSeekMode mode) {
 	RzListIter *iter;
 	const char *fn;
-	RzList *files = rz_core_list_themes(core);
+	RzList *files = rz_core_theme_list(core);
 
 	rz_list_foreach (files, iter, fn) {
 		if (*fn && *fn != '.') {
@@ -149,7 +149,7 @@ RZ_IPI void rz_core_theme_nextpal(RzCore *core, RzConsPalSeekMode mode) {
 	rz_list_free(files);
 	files = NULL;
 done:
-	rz_core_load_theme(core, curtheme);
+	rz_core_theme_load(core, curtheme);
 	rz_list_free(files);
 }
 
@@ -227,13 +227,13 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_load_theme_handler(RzCore *core, int argc, 
 	RzListIter *th_iter;
 	const char *th;
 	if (argc == 2) {
-		return bool2status(rz_core_load_theme(core, argv[1]));
+		return bool2status(rz_core_theme_load(core, argv[1]));
 	}
 	switch (state->mode) {
 	case RZ_OUTPUT_MODE_JSON: {
 		PJ *pj = state->d.pj;
 		pj_a(pj);
-		themes_list = rz_core_list_themes(core);
+		themes_list = rz_core_theme_list(core);
 		if (!themes_list) {
 			return RZ_CMD_STATUS_ERROR;
 		}
@@ -244,7 +244,7 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_load_theme_handler(RzCore *core, int argc, 
 		break;
 	}
 	case RZ_OUTPUT_MODE_QUIET:
-		themes_list = rz_core_list_themes(core);
+		themes_list = rz_core_theme_list(core);
 		if (!themes_list) {
 			return RZ_CMD_STATUS_ERROR;
 		}
@@ -254,7 +254,7 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_load_theme_handler(RzCore *core, int argc, 
 		rz_list_free(themes_list);
 		break;
 	default:
-		themes_list = rz_core_list_themes(core);
+		themes_list = rz_core_theme_list(core);
 		if (!themes_list) {
 			return RZ_CMD_STATUS_ERROR;
 		}
@@ -271,12 +271,12 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_load_theme_handler(RzCore *core, int argc, 
 }
 
 RZ_IPI RzCmdStatus rz_cmd_eval_color_list_current_theme_handler(RzCore *core, int argc, const char **argv) {
-	rz_cons_println(rz_core_get_theme());
+	rz_cons_println(rz_core_theme_get());
 	return RZ_CMD_STATUS_OK;
 }
 
 RZ_IPI RzCmdStatus rz_cmd_eval_color_list_reload_current_handler(RzCore *core, int argc, const char **argv) {
-	rz_core_load_theme(core, rz_core_get_theme());
+	rz_core_theme_load(core, rz_core_theme_get());
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -93,10 +93,6 @@ RZ_API bool rz_core_theme_load(RzCore *core, const char *name) {
 	return !failed;
 }
 
-static int cmpthemes(const void *a, const void *b) {
-	return (int)strcmp(a, b);
-}
-
 static void list_themes_in_path(RzList *list, const char *path) {
 	RzListIter *iter;
 	const char *fn;
@@ -128,7 +124,7 @@ RZ_API RZ_OWN RzList *rz_core_theme_list(RzCore *core) {
 		list_themes_in_path(list, path);
 		RZ_FREE(path);
 	}
-	rz_list_sort(list, cmpthemes);
+	rz_list_sort(list, (RzListComparator)strcmp);
 	return list;
 }
 

--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -93,6 +93,10 @@ RZ_API bool rz_core_theme_load(RzCore *core, const char *name) {
 	return !failed;
 }
 
+static int cmpthemes(const void *a, const void *b) {
+	return (int)strcmp(a, b);
+}
+
 static void list_themes_in_path(RzList *list, const char *path) {
 	RzListIter *iter;
 	const char *fn;
@@ -124,7 +128,7 @@ RZ_API RZ_OWN RzList *rz_core_theme_list(RzCore *core) {
 		list_themes_in_path(list, path);
 		RZ_FREE(path);
 	}
-
+	rz_list_sort(list, cmpthemes);
 	return list;
 }
 

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -8446,7 +8446,7 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *cmd_eval_color_set_colorful_palette_cd = rz_cmd_desc_argv_new(core->rcmd, ec_cd, "ecs", rz_cmd_eval_color_set_colorful_palette_handler, &cmd_eval_color_set_colorful_palette_help);
 	rz_warn_if_fail(cmd_eval_color_set_colorful_palette_cd);
 
-	RzCmdDesc *eco_cd = rz_cmd_desc_group_modes_new(core->rcmd, ec_cd, "eco", RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET, rz_cmd_eval_color_load_theme_handler, &cmd_eval_color_load_theme_help, &eco_help);
+	RzCmdDesc *eco_cd = rz_cmd_desc_group_state_new(core->rcmd, ec_cd, "eco", RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET, rz_cmd_eval_color_load_theme_handler, &cmd_eval_color_load_theme_help, &eco_help);
 	rz_warn_if_fail(eco_cd);
 	RzCmdDesc *cmd_eval_color_list_current_theme_cd = rz_cmd_desc_argv_new(core->rcmd, eco_cd, "eco.", rz_cmd_eval_color_list_current_theme_handler, &cmd_eval_color_list_current_theme_help);
 	rz_warn_if_fail(cmd_eval_color_list_current_theme_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -291,7 +291,7 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_highlight_remove_all_handler(RzCore *core, 
 RZ_IPI RzCmdStatus rz_cmd_eval_color_highlight_remove_current_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_eval_color_set_random_palette_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_eval_color_set_colorful_palette_handler(RzCore *core, int argc, const char **argv);
-RZ_IPI RzCmdStatus rz_cmd_eval_color_load_theme_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
+RZ_IPI RzCmdStatus rz_cmd_eval_color_load_theme_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_cmd_eval_color_list_current_theme_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_eval_color_list_reload_current_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_eval_color_load_previous_theme_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_eval.yaml
+++ b/librz/core/cmd_descs/cmd_eval.yaml
@@ -133,6 +133,7 @@ commands:
           - name: eco
             summary: List the available themes
             cname: cmd_eval_color_load_theme
+            type: RZ_CMD_DESC_TYPE_ARGV_STATE
             args:
               - name: theme
                 type: RZ_CMD_ARG_TYPE_STRING

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -2374,6 +2374,7 @@ RZ_API bool rz_core_init(RzCore *core) {
 	rz_core_seek_reset(core);
 	core->lastsearch = NULL;
 	core->cmdfilter = NULL;
+	core->curtheme = "default";
 	core->switch_file_view = 0;
 	core->cmdremote = 0;
 	core->incomment = false;

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -1377,7 +1377,7 @@ static void autocomplete_theme(RzCore *core, RzLineCompletion *completion, const
 	int len = strlen(str);
 	char *theme;
 	RzListIter *iter;
-	RzList *themes = rz_core_list_themes(core);
+	RzList *themes = rz_core_theme_list(core);
 	rz_list_foreach (themes, iter, theme) {
 		if (!len || !strncmp(str, theme, len)) {
 			rz_line_completion_push(completion, theme);

--- a/librz/core/tui/panels.c
+++ b/librz/core/tui/panels.c
@@ -3217,7 +3217,7 @@ int __settings_colors_cb(void *user) {
 	RzPanelsMenuItem *parent = menu->history[menu->depth - 1];
 	RzPanelsMenuItem *child = parent->sub[parent->selectedIndex];
 	rz_str_ansi_filter(child->name, NULL, NULL, -1);
-	rz_core_load_theme(core, child->name);
+	rz_core_theme_load(core, child->name);
 	int i;
 	for (i = 1; i < menu->depth; i++) {
 		RzPanel *p = menu->history[i]->p;
@@ -5333,7 +5333,7 @@ RZ_API void rz_save_panels_layout(RzCore *core, const char *oname) {
 }
 
 void __load_config_menu(RzCore *core) {
-	RzList *themes_list = rz_core_list_themes(core);
+	RzList *themes_list = rz_core_theme_list(core);
 	RzListIter *th_iter;
 	char *th;
 	int i = 0;

--- a/librz/core/tui/vmenus.c
+++ b/librz/core/tui/vmenus.c
@@ -3537,7 +3537,7 @@ RZ_API void rz_core_visual_colors(RzCore *core) {
 		}
 		rz_cons_rgb_str(cstr, sizeof(cstr), &rcolor);
 		char *esc = strchr(cstr + 1, '\x1b');
-		char *curtheme = rz_core_get_theme();
+		char *curtheme = rz_core_theme_get();
 
 		rz_cons_printf("# Use '.' to randomize current color and ':' to randomize palette\n");
 		rz_cons_printf("# Press '" Color_RED "rR" Color_GREEN "gG" Color_BLUE "bB" Color_RESET

--- a/librz/core/tui/vmenus.c
+++ b/librz/core/tui/vmenus.c
@@ -3537,7 +3537,7 @@ RZ_API void rz_core_visual_colors(RzCore *core) {
 		}
 		rz_cons_rgb_str(cstr, sizeof(cstr), &rcolor);
 		char *esc = strchr(cstr + 1, '\x1b');
-		char *curtheme = rz_core_theme_get();
+		char *curtheme = rz_core_theme_get(core);
 
 		rz_cons_printf("# Use '.' to randomize current color and ':' to randomize palette\n");
 		rz_cons_printf("# Press '" Color_RED "rR" Color_GREEN "gG" Color_BLUE "bB" Color_RESET

--- a/librz/include/rz_cons.h
+++ b/librz/include/rz_cons.h
@@ -465,6 +465,11 @@ typedef struct rz_cons_input_context_t {
 	bool bufactive;
 } RzConsInputContext;
 
+typedef enum {
+	RZ_CONS_PAL_SEEK_PREVIOUS,
+	RZ_CONS_PAL_SEEK_NEXT,
+} RzConsPalSeekMode;
+
 typedef struct rz_cons_context_t {
 	RzConsGrep grep;
 	RzStack *cons_stack;

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -418,7 +418,7 @@ RZ_API bool rz_core_plugin_fini(RzCore *core);
 RZ_API RzList *rz_core_list_themes(RzCore *core);
 RZ_API char *rz_core_get_theme(void);
 RZ_API bool rz_core_load_theme(RzCore *core, const char *name);
-RZ_API void rz_core_theme_nextpal(RzCore *core, int mode);
+RZ_API void rz_core_theme_nextpal(RzCore *core, RzConsPalSeekMode mode);
 RZ_API const char *rz_core_get_section_name(RzCore *core, ut64 addr);
 RZ_API RzCons *rz_core_get_cons(RzCore *core);
 RZ_API RzBin *rz_core_get_bin(RzCore *core);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -415,9 +415,9 @@ RZ_API bool rz_core_plugin_add(RzCore *core, RzCorePlugin *plugin);
 RZ_API bool rz_core_plugin_fini(RzCore *core);
 
 //#define rz_core_ncast(x) (RzCore*)(size_t)(x)
-RZ_API RzList *rz_core_list_themes(RzCore *core);
-RZ_API char *rz_core_get_theme(void);
-RZ_API bool rz_core_load_theme(RzCore *core, const char *name);
+RZ_API RzList *rz_core_theme_list(RzCore *core);
+RZ_API char *rz_core_theme_get(void);
+RZ_API bool rz_core_theme_load(RzCore *core, const char *name);
 RZ_API void rz_core_theme_nextpal(RzCore *core, RzConsPalSeekMode mode);
 RZ_API const char *rz_core_get_section_name(RzCore *core, ut64 addr);
 RZ_API RzCons *rz_core_get_cons(RzCore *core);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -342,6 +342,7 @@ struct rz_core_t {
 	char *cmdremote;
 	char *lastsearch;
 	char *cmdfilter;
+	char *curtheme;
 	bool break_loop;
 	bool binat;
 	bool fixedbits; // will be true when using @b:
@@ -416,7 +417,7 @@ RZ_API bool rz_core_plugin_fini(RzCore *core);
 
 //#define rz_core_ncast(x) (RzCore*)(size_t)(x)
 RZ_API RzList *rz_core_theme_list(RzCore *core);
-RZ_API char *rz_core_theme_get(void);
+RZ_API char *rz_core_theme_get(RzCore *core);
 RZ_API bool rz_core_theme_load(RzCore *core, const char *name);
 RZ_API void rz_core_theme_nextpal(RzCore *core, RzConsPalSeekMode mode);
 RZ_API const char *rz_core_get_section_name(RzCore *core, ut64 addr);

--- a/test/db/cmd/cmd_ec
+++ b/test/db/cmd/cmd_ec
@@ -312,3 +312,29 @@ ecHi rgb:00007f @ 0x00000000
 [{"offset":0,"type":"ecHi","color":"#00007f"}]
 EOF
 RUN
+
+NAME=Test ecp and ecn- load previous and next theme
+FILE==
+CMDS=<<EOF
+eco xvilka
+eco.
+ecp
+eco.
+ecn
+EOF
+EXPECT=<<EOF
+xvilka
+tango
+xvilka
+EOF
+RUN
+
+NAME=Test ecoj- list themes in JSON
+FILE==
+CMDS=<<EOF
+ecoj
+EOF
+EXPECT=<<EOF
+["default","cutter","pink","zenburn","defragger","xvilka","tango","monokai","rasta","cga","smyck","matrix","consonance","twilight","white","bold","ogray","basic","lima","behelit","dark","darkda","sepia","white2","onedark","ayu","bright","focus","gb","gentoo","solarized"]
+EOF
+RUN

--- a/test/db/cmd/cmd_ec
+++ b/test/db/cmd/cmd_ec
@@ -316,16 +316,17 @@ RUN
 NAME=Test ecp and ecn- load previous and next theme
 FILE==
 CMDS=<<EOF
-eco xvilka
+eco zenburn
 eco.
 ecp
 eco.
 ecn
+eco.
 EOF
 EXPECT=<<EOF
-xvilka
-tango
-xvilka
+zenburn
+gentoo
+zenburn
 EOF
 RUN
 
@@ -335,6 +336,6 @@ CMDS=<<EOF
 ecoj
 EOF
 EXPECT=<<EOF
-["default","cutter","pink","zenburn","defragger","xvilka","tango","monokai","rasta","cga","smyck","matrix","consonance","twilight","white","bold","ogray","basic","lima","behelit","dark","darkda","sepia","white2","onedark","ayu","bright","focus","gb","gentoo","solarized"]
+["default","gentoo","zenburn","gb","behelit","lima","dark","ogray","basic","matrix","darkda","rasta","bright","onedark","cga","ayu","bold","cutter","smyck","twilight","tango","monokai","sepia","pink","consonance","defragger","white2","solarized","white","focus","xvilka"]
 EOF
 RUN

--- a/test/db/cmd/cmd_ec
+++ b/test/db/cmd/cmd_ec
@@ -316,7 +316,7 @@ RUN
 NAME=Test ecp and ecn- load previous and next theme
 FILE==
 CMDS=<<EOF
-eco zenburn
+eco sepia
 eco.
 ecp
 eco.
@@ -324,9 +324,9 @@ ecn
 eco.
 EOF
 EXPECT=<<EOF
-zenburn
-gentoo
-zenburn
+sepia
+rasta
+sepia
 EOF
 RUN
 
@@ -336,6 +336,6 @@ CMDS=<<EOF
 ecoj
 EOF
 EXPECT=<<EOF
-["default","gentoo","zenburn","gb","behelit","lima","dark","ogray","basic","matrix","darkda","rasta","bright","onedark","cga","ayu","bold","cutter","smyck","twilight","tango","monokai","sepia","pink","consonance","defragger","white2","solarized","white","focus","xvilka"]
+["ayu","basic","behelit","bold","bright","cga","consonance","cutter","dark","darkda","default","defragger","focus","gb","gentoo","lima","matrix","monokai","ogray","onedark","pink","rasta","sepia","smyck","solarized","tango","twilight","white","white2","xvilka","zenburn"]
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Current status:
* Refactored `rz_core_theme_nextpal()` to use `rz_core_list_themes()`
* Used PJ for `ecoj`
*  Added tests for `ecp`, `ecn` and `ecoj`
* Remove all global values from `cmd_eval.c`.
      - Added `curtheme` into `RzCore` which points to the current name of the theme.
* Sorts the themes according to the name so that it shows up the same way on all platforms.
* This part from the linked issue: `In function rz_eval_color() for the JSON mode it's better to use the better name like rz_core_themes_print() and use also rz_core_list_themes() API and RzOutputMode enum`
* Renames the APIs related to the themes to follow a standard nomenclature.
```
RZ_API RzList *rz_core_theme_list(RzCore *core);
RZ_API char *rz_core_theme_get(void);
RZ_API bool rz_core_theme_load(RzCore *core, const char *name);
RZ_API void rz_core_theme_nextpal(RzCore *core, RzConsPalSeekMode mode);
```


**Test plan**

- [x] CI passes

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Partially address #1676
