### PR TITLE
Fix #1864: Find `main()` of Fedora 35 x86_64 `/bin/ls`

### DIFF
--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -308,6 +308,10 @@ static ut64 get_main_offset_linux_64_pie(ELFOBJ *bin, ut64 entry, ut8 *buf) {
 	if (buf[0] == 0xf3 && buf[1] == 0x0f && buf[2] == 0x1e && buf[3] == 0xfa) {
 		// Change begin offset if binary starts with 'endbr64'
 		bo = 33;
+		// double xor for init and fini
+		if (!memcmp(buf + 19, "\x45\x31\xc0\x31\xc9", 5)) {
+			bo = 24;
+		}
 	}
 	if (buf[bo] == 0x48) {
 		ut8 ch = buf[bo + 1];

--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -1877,7 +1877,7 @@ ut64 Elf_(rz_bin_elf_get_init_offset)(RZ_NONNULL ELFOBJ *bin) {
 ut64 Elf_(rz_bin_elf_get_main_offset)(RZ_NONNULL ELFOBJ *bin) {
 	rz_return_val_if_fail(bin, UT64_MAX);
 
-	ut8 buf[256];
+	ut8 buf[256] = { 0 };
 	ut64 entry = Elf_(rz_bin_elf_get_entry_offset)(bin);
 	ut64 main_addr;
 

--- a/test/db/formats/elf/main
+++ b/test/db/formats/elf/main
@@ -158,3 +158,11 @@ vaddr      paddr
 
 EOF
 RUN
+
+NAME=main fedora 35 x86_64 ls (#1864)
+FILE=bins/elf/analysis/fedora_35_x86_64bit_ls
+CMDS=?v main
+EXPECT=<<EOF
+0x4d80
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr finds the `main()` of a Fedora 35 x86_64 binary when both `*init` and `*fini` are NULL.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #1864.
