### PR TITLE
Fixes for macOS 10.5/ppc64

### DIFF
--- a/binrz/rizin/macos_sign.sh
+++ b/binrz/rizin/macos_sign.sh
@@ -13,4 +13,16 @@ if [ "$IS_INSTALL" = "true" ] ; then
     SRC="${MESON_INSTALL_DESTDIR_PREFIX}/${SRC}"
 fi
 
+# The --entitlements arg was only added in Mac OS X 10.6 Snow Leopard / Xcode 3.2 / security_systemkeychain-36515.
+# Moreover, our build system adds load mach-o load commands that the ancient codesign does not recognize either so let's skip it.
+# uname -r is
+#   9.<something> for 10.5
+#   10.<something> for 10.6
+#   ...
+OSVER=$(uname -r)
+if [ "${OSVER%%.*}" -lt 10 ]; then
+	echo "Detected Mac OS X < 10.6, skipping codesign."
+	exit 0
+fi
+
 codesign --entitlements "${ENTITLEMENT}" --force -s - "${SRC}"

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -214,7 +214,7 @@ RZ_API char *rz_str_escape_utf8_for_json(const char *s, int len);
 RZ_API char *rz_str_escape_mutf8_for_json(const char *s, int len);
 RZ_API char *rz_str_home(const char *str);
 RZ_API char *rz_str_rz_prefix(const char *str);
-RZ_API size_t rz_str_nlen(const char *s, int n);
+RZ_API size_t rz_str_nlen(const char *s, size_t n);
 RZ_API size_t rz_str_nlen_w(const char *s, int n);
 RZ_API size_t rz_wstr_clen(const char *s);
 RZ_API char *rz_str_prepend(char *ptr, const char *string);

--- a/librz/type/type.c
+++ b/librz/type/type.c
@@ -1078,7 +1078,7 @@ static char *type_as_pretty_string(const RzTypeDB *typedb, const RzType *type, c
 		}
 	}
 
-	if (strnlen(pointer_str, 1) != 0 || identifier || strnlen(array_str, 1) != 0) {
+	if (rz_str_nlen(pointer_str, 1) != 0 || identifier || rz_str_nlen(array_str, 1) != 0) {
 		rz_strbuf_append(buf, " "); // add space only if the type is pointer or an array or has an identifier
 	}
 	rz_strbuf_appendf(buf, "%s%s%s", pointer_str ? pointer_str : "", identifier ? identifier : "", array_str ? array_str : "");

--- a/librz/util/buf.c
+++ b/librz/util/buf.c
@@ -579,7 +579,7 @@ RZ_API RZ_OWN char *rz_buf_get_nstring(RzBuffer *b, ut64 addr, size_t size) {
 			return NULL;
 		}
 
-		size_t count = strnlen(tmp, r);
+		size_t count = rz_str_nlen(tmp, r);
 		rz_strbuf_append_n(buf, tmp, count);
 
 		if (count > size) {

--- a/librz/util/file.c
+++ b/librz/util/file.c
@@ -224,10 +224,14 @@ RZ_API char *rz_file_abspath_rel(const char *cwd, const char *file) {
 		ret = strdup(file);
 	}
 #if __UNIX__
-	char *abspath = realpath(ret, NULL);
+	char rp[PATH_MAX] = { 0 };
+	char *abspath = realpath(ret, rp); // second arg == NULL is only an extension
 	if (abspath) {
-		free(ret);
-		ret = abspath;
+		abspath = strdup(abspath);
+		if (abspath) {
+			free(ret);
+			ret = abspath;
+		}
 	}
 #endif
 	return ret;

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -1794,14 +1794,13 @@ RZ_API size_t rz_str_ansi_len(const char *str) {
 	return rz_str_ansi_nlen(str, 0);
 }
 
-RZ_API size_t rz_str_nlen(const char *str, int n) {
+RZ_API size_t rz_str_nlen(const char *str, size_t n) {
+	rz_return_val_if_fail(str, 0);
 	size_t len = 0;
-	if (str) {
-		while (*str && n > 0) {
-			len++;
-			str++;
-			n--;
-		}
+	while (*str && n) {
+		len++;
+		str++;
+		n--;
 	}
 	return len;
 }

--- a/librz/util/sys.c
+++ b/librz/util/sys.c
@@ -44,7 +44,7 @@ static char **env = NULL;
 #if __APPLE__
 #include <errno.h>
 
-#if HAVE_ENVIRON
+#if HAVE_ENVIRON || __APPLE__
 #include <execinfo.h>
 #endif
 // iOS don't have this we can't hardcode
@@ -1259,7 +1259,9 @@ RZ_API char **rz_sys_get_environ(void) {
 
 RZ_API void rz_sys_set_environ(char **e) {
 	env = e;
-#if HAVE_ENVIRON
+#if __APPLE__ && !HAVE_ENVIRON
+	*_NSGetEnviron() = e;
+#elif HAVE_ENVIRON
 	environ = e;
 #endif
 }

--- a/librz/util/thread.c
+++ b/librz/util/thread.c
@@ -75,7 +75,7 @@ RZ_API bool rz_th_setname(RzThread *th, const char *name) {
 		eprintf("Failed to set thread name\n");
 		return false;
 	}
-#elif __APPLE__
+#elif __APPLE__ && defined(MAC_OS_X_VERSION_10_6)
 	if (pthread_setname_np(name) != 0) {
 		eprintf("Failed to set thread name\n");
 		return false;
@@ -101,7 +101,7 @@ RZ_API bool rz_th_setname(RzThread *th, const char *name) {
 
 RZ_API bool rz_th_getname(RzThread *th, char *name, size_t len) {
 #if defined(HAVE_PTHREAD_NP) && HAVE_PTHREAD_NP
-#if __linux__ || __NetBSD__ || __APPLE__ || __sun
+#if __linux__ || __NetBSD__ || (__APPLE__ && defined(MAC_OS_X_VERSION_10_6)) || __sun
 	if (pthread_getname_np(th->tid, name, len) != 0) {
 		eprintf("Failed to get thread name\n");
 		return false;

--- a/meson.build
+++ b/meson.build
@@ -378,8 +378,17 @@ if have_lrt and not lrt.found()
   lrt = cc.find_library('rt', required: true, static: is_static_build)
 endif
 
-code = '#include <unistd.h>\nextern char **environ;\nint main() { char **env = environ; }'
-have_environ = cc.links(code, name: 'have extern char **environ')
+if host_machine.system() == 'darwin'
+  # On older Mac OS X versions (at least Lion and older), environ is only available when compiling an executable,
+  # but we will use is primarily in shared libs. Unfortunately, cc.links() only checks for executable compiling,
+  # so this does not help us.
+  # But in fact, even the environ(7) man page on macOS 11.6 still claims that environ is not avaliable for
+  # shared libs (even though it seems to work) and suggests using _NSGetEnviron(), so let's just do this always.
+  have_environ = false
+else
+  code = '#include <unistd.h>\nextern char **environ;\nint main() { char **env = environ; }'
+  have_environ = cc.links(code, name: 'have extern char **environ')
+endif
 userconf.set10('HAVE_ENVIRON', have_environ)
 message('HAVE_ENVIRON: @0@'.format(have_environ))
 

--- a/subprojects/packagefiles/libzip-1.7.3/meson.build
+++ b/subprojects/packagefiles/libzip-1.7.3/meson.build
@@ -50,13 +50,18 @@ else
 endif
 
 underscore_functions = ['close', 'dup', 'fdopen', 'fileno', 'setmode', 'snprintf', 'strdup', 'stricmp', 'strtoi64', 'strtoui64', 'umask', 'unlink']
-functions = ['arc4random', 'clonefile', 'explicit_bzero', 'explicit_memset', 'fileno', 'fseeko', 'ftello', 'getprogname', 'localtime_r', 'mkstemp', 'setmode', 'snprintf', 'strdup', 'stricmp', 'strtoll', 'strtoull']
+functions = ['clonefile', 'explicit_bzero', 'explicit_memset', 'fileno', 'fseeko', 'ftello', 'getprogname', 'localtime_r', 'mkstemp', 'setmode', 'snprintf', 'strdup', 'stricmp', 'strtoll', 'strtoull']
 headers = ['stdbool.h', 'strings.h', 'unistd.h', 'dirent.h', 'fts.h', 'ndir.h', 'sys/dir.h', 'sys/ndir.h', 'sys/attr.h']
 types = ['off_t', 'size_t']
 # special case because clang-cl finds strcasecmp but has problem while linking
 if cc.get_id() != 'clang-cl' and cc.has_function('strcasecmp')
   conf_data.set10('HAVE_STRCASECMP', true)
   have_strcasecmp = true
+endif
+# both arc4random_buf and arc4random are needed if any
+if cc.has_function('arc4random_buf') and cc.has_function('arc4random')
+  conf_data.set10('HAVE_ARC4RANDOM', true)
+  have_arc4random = true
 endif
 foreach fcn : functions
   if cc.has_function(fcn) or cc.has_function(fcn, prefix: '#include <stdio.h>')

--- a/subprojects/sdb.wrap
+++ b/subprojects/sdb.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/rizinorg/sdb.git
-revision = db7edd4a96a89b6749b677a85d7fa4ee2c6fbbb9
+revision = 6b405914220c5b0afddc89d192066d9b02cc4ce8

--- a/test/unit/test_str.c
+++ b/test/unit/test_str.c
@@ -655,9 +655,6 @@ bool test_rz_str_nlen(void) {
 	mu_assert_eq(rz_str_nlen("A", 0), 0, "0 n should give 0");
 	mu_assert_eq(rz_str_nlen("A", 1), 1, "1 n should give 1");
 	mu_assert_eq(rz_str_nlen("A", 2), 1, "1 n should give 1 for 'A'");
-	mu_assert_eq(rz_str_nlen("A", -100), 0, "-100 n should give 0 for 'A'");
-	mu_assert_eq(rz_str_nlen("", -100), 0, "-100 n should give 0 for ''");
-	mu_assert_eq(rz_str_nlen(NULL, -100), 0, "-100 n should give 0 for NULL");
 	mu_end;
 }
 


### PR DESCRIPTION
**DO NOT SQUASH**

Same as #1641, but with harder ci testing.

There are more issues, but this at least fixes the build with `-Ddebugger=false` on Leopard/ppc.

Tested on:
- [x] 10.5/ppc
- [x] 10.5/x86
- [x] 10.6/x86
- [x] 11.6/arm64