### PR TITLE
Fix ASAN buffer overflow in `rz_buf_get_nstring()`

### DIFF
--- a/librz/util/buf.c
+++ b/librz/util/buf.c
@@ -556,7 +556,7 @@ RZ_API RZ_OWN RzBuffer *rz_buf_new_with_string(RZ_NONNULL const char *msg) {
 }
 
 /**
- * \brief Get a string whith a max length from the buffer
+ * \brief Get a string with a max length from the buffer
  * \param b RzBuffer pointer
  * \param addr The address of the string
  * \param size The max length authorized
@@ -572,8 +572,8 @@ RZ_API RZ_OWN char *rz_buf_get_nstring(RzBuffer *b, ut64 addr, size_t size) {
 	RzStrBuf *buf = rz_strbuf_new(NULL);
 
 	while (true) {
-		char tmp[GET_STRING_BUFFER_SIZE];
-		st64 r = rz_buf_read_at(b, addr, (ut8 *)tmp, sizeof(tmp));
+		char tmp[GET_STRING_BUFFER_SIZE + 1];
+		st64 r = rz_buf_read_at(b, addr, (ut8 *)tmp, sizeof(tmp) - 1);
 		if (r < 1) {
 			rz_strbuf_free(buf);
 			return NULL;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes the following ASAN complaints:
```
>>> MALLOC_PERTURB_=221 /home/runner/work/rizin/rizin/build/test/unit/test_buf
――――――――――――――――――――――――――――――――――――― ✀  ―――――――――――――――――――――――――――――――――――――
stderr:
=================================================================
==10755==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffddf104150 at pc 0x7feeec4a24d0 bp 0x7ffddf104080 sp 0x7ffddf104070
READ of size 1 at 0x7ffddf104150 thread T0
    #0 0x7feeec4a24cf in rz_str_nlen ../librz/util/str.c:1800
    #1 0x7feeec3e2a31 in rz_buf_get_nstring ../librz/util/buf.c:582
    #2 0x55d29c027dfe in test_rz_buf_get_string ../test/unit/test_buf.c:1078
    #3 0x55d29c02bcf8 in all_tests ../test/unit/test_buf.c:1290
    #4 0x7feeeaefa0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #5 0x55d29c00213d in _start (/home/runner/work/rizin/rizin/build/test/unit/test_buf+0x1913d)

Address 0x7ffddf104150 is located in stack of thread T0 at offset 64 in frame
    #0 0x7feeec3e295f in rz_buf_get_nstring ../librz/util/buf.c:569

  This frame has 1 object(s):
    [32, 64) 'tmp' (line 575) <== Memory access at offset 64 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow ../librz/util/str.c:1800 in rz_str_nlen
Shadow bytes around the buggy address:
  0x10003be187d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003be187e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003be187f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003be18800: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10003be18810: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x10003be18820: 00 00 f1 f1 f1 f1 00 00 00 00[f3]f3 f3 f3 00 00
  0x10003be18830: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1
  0x10003be18840: f1 f1 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x10003be18850: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x10003be18860: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x10003be18870: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==10755==ABORTING
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
>>> MALLOC_PERTURB_=122 /home/runner/work/rizin/rizin/build/test/unit/test_pdb
――――――――――――――――――――――――――――――――――――― ✀  ―――――――――――――――――――――――――――――――――――――
stderr:
../librz/include/rz_util/rz_buf.h:196:1: runtime error: store to misaligned address 0x603000001d04 for type 'long long unsigned int', which requires 8 byte alignment
0x603000001d04: note: pointer points here
  02 70 2f 44 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
              ^ 
=================================================================
==10832==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffeedf97c50 at pc 0x7f6af4ac94d0 bp 0x7ffeedf97b80 sp 0x7ffeedf97b70
READ of size 1 at 0x7ffeedf97c50 thread T0
    #0 0x7f6af4ac94cf in rz_str_nlen ../librz/util/str.c:1800
    #1 0x7f6af4a09a31 in rz_buf_get_nstring ../librz/util/buf.c:582
    #2 0x7f6af0c714b1 in parse_dbi_stream_ex_header ../librz/bin/pdb/dbi.c:100
    #3 0x7f6af0c714b1 in parse_dbi_stream ../librz/bin/pdb/dbi.c:159
    #4 0x7f6af0c77d13 in parse_streams ../librz/bin/pdb/pdb.c:57
    #5 0x7f6af0c77d13 in pdb7_parse ../librz/bin/pdb/pdb.c:262
    #6 0x7f6af0c77d13 in rz_bin_pdb_parse_from_buf ../librz/bin/pdb/pdb.c:324
    #7 0x5652566c86f6 in test_pdb_tpi_cpp ../test/unit/test_pdb.c:25
    #8 0x5652566eea97 in all_tests ../test/unit/test_pdb.c:921
    #9 0x5652566c67be in main ../test/unit/test_pdb.c:929
    #10 0x7f6aef1060b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #11 0x5652566c682d in _start (/home/runner/work/rizin/rizin/build/test/unit/test_pdb+0x2282d)

Address 0x7ffeedf97c50 is located in stack of thread T0 at offset 64 in frame
    #0 0x7f6af4a0995f in rz_buf_get_nstring ../librz/util/buf.c:569

  This frame has 1 object(s):
    [32, 64) 'tmp' (line 575) <== Memory access at offset 64 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow ../librz/util/str.c:1800 in rz_str_nlen
Shadow bytes around the buggy address:
  0x10005dbeaf30: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005dbeaf40: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005dbeaf50: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005dbeaf60: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005dbeaf70: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x10005dbeaf80: 00 00 f1 f1 f1 f1 00 00 00 00[f3]f3 f3 f3 00 00
  0x10005dbeaf90: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005dbeafa0: 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1
  0x10005dbeafb0: f1 f1 f8 f2 f8 f2 f8 f2 f8 f2 f8 f2 f8 f2 f8 f2
  0x10005dbeafc0: f8 f2 f8 f2 f8 f2 f8 f2 02 f2 02 f2 02 f2 02 f2
  0x10005dbeafd0: 02 f2 02 f2 02 f2 f8 f2 f8 f2 f8 f2 f8 f2 f8 f2
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==10832==ABORTING
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
```

**Test plan**

- CI is green
- `ninja -C build-asan test`
