### PR TITLE
RzShell: add autocompletion for @@ iterator operators, @@., @@=, etc.

### DIFF
--- a/librz/core/cautocmpl.c
+++ b/librz/core/cautocmpl.c
@@ -15,7 +15,7 @@ enum autocmplt_type_t {
 	AUTOCMPLT_UNKNOWN = 0, ///< Unknown, nothing will be autocompleted
 	AUTOCMPLT_CMD_ID, ///< A command identifier (aka command name) needs to be autocompleted
 	AUTOCMPLT_CMD_ARG, ///< The argument of an arged_stmt (see grammar.js) needs to be autocompleted
-	AUTOCMPLT_TMP_STMT, ///< A temporary modifier operator like `@ `, `@a:`, `@v:`, etc.
+	AUTOCMPLT_AT_STMT, ///< A temporary modifier operator like `@ `, `@a:`, `@v:` or a iter operator like `@@.`, `@@`, `@@i`, etc.
 	AUTOCMPLT_RZNUM, ///< A expression that can be parsed by RzNum (e.g. "flag+3")
 	AUTOCMPLT_ARCH, ///< An architecture supported by Rizin (e.g. x86, arm, etc.)
 	AUTOCMPLT_BITS, ///< A bits value supported by the currently selected architecture (e asm.bits=?)
@@ -23,6 +23,8 @@ enum autocmplt_type_t {
 	AUTOCMPLT_FLAG_SPACE, ///< A flag space needs to be autocompleted
 	AUTOCMPLT_REG, ///< A cpu register needs to be autocompleted
 	AUTOCMPLT_EVAL_FULL, ///< A name=value of a evaluable variable (e.g. `e` command)
+	AUTOCMPLT_FLAG, ///< A flag item needs to be autocompleted
+	AUTOCMPLT_FUNCTION, ///< A function name needs to be autocompleted
 };
 
 /**
@@ -118,7 +120,7 @@ static void autocmplt_cmdidentifier(RzCore *core, RzLineNSCompletionResult *res,
 	rz_cmd_foreach_cmdname(core->rcmd, NULL, do_autocmplt_cmdidentifier, &u);
 }
 
-static void autocmplt_tmp_stmt(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
+static void autocmplt_at_stmt(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
 	const char *stmts[] = {
 		"@ ",
 		"@!",
@@ -136,6 +138,33 @@ static void autocmplt_tmp_stmt(RzCore *core, RzLineNSCompletionResult *res, cons
 		"@s:",
 		"@v:",
 		"@x:",
+		"@@.",
+		"@@=",
+		"@@@=",
+		"@@",
+		"@@c:",
+		"@@@c:",
+		"@@C",
+		"@@C:",
+		"@@dbt",
+		"@@dbtb",
+		"@@dbts",
+		"@@t",
+		"@@b",
+		"@@i",
+		"@@ii",
+		"@@iS",
+		"@@iSS",
+		"@@is",
+		"@@iz",
+		"@@f",
+		"@@f:",
+		"@@F",
+		"@@F:",
+		"@@om",
+		"@@dm",
+		"@@r",
+		"@@s:",
 		NULL,
 	};
 	const char **stmt;
@@ -308,6 +337,7 @@ static void autocmplt_cmd_arg_flag(RzCore *core, RzLineNSCompletionResult *res, 
 			rz_line_ns_completion_result_add(res, flag);
 		}
 	}
+	rz_list_free(list);
 }
 
 static bool offset_prompt_add_flag(RzFlagItem *fi, void *user) {
@@ -693,10 +723,11 @@ static bool fill_autocmplt_data_cmdarg(struct autocmplt_data_t *ad, ut32 start, 
 }
 
 /**
- * Fill the \p ad structure with all the data required to autocomplete a tmp stmt (@, @(, @a:, etc.)
+ * Fill the \p ad structure with all the data required to autocomplete a tmp
+ * stmt (@, @(, @a:, etc.) or a iter stmt (@@, @@., @@i, etc.)
  */
-static bool fill_autocmplt_data_tmp_stmt(struct autocmplt_data_t *ad, ut32 start, ut32 end) {
-	return fill_autocmplt_data(ad, AUTOCMPLT_TMP_STMT, start, end);
+static bool fill_autocmplt_data_at_stmt(struct autocmplt_data_t *ad, ut32 start, ut32 end) {
+	return fill_autocmplt_data(ad, AUTOCMPLT_AT_STMT, start, end);
 }
 
 static bool find_autocmplt_type_newcmd_or_arg(struct autocmplt_data_t *ad, RzCore *core, RzLineBuffer *buf) {
@@ -731,43 +762,98 @@ static bool is_arg_identifier_in_tmp_stmt(TSNode node) {
 		return false;
 	}
 	const char *node_type = ts_node_type(node);
-	return rz_str_startswith(node_type, "tmp_") && rz_str_endswith(node_type, "_stmt");
+	bool is_iter_or_tmp = rz_str_startswith(node_type, "tmp_") || rz_str_startswith(node_type, "iter_");
+	return is_iter_or_tmp && rz_str_endswith(node_type, "_stmt");
 }
 
-static bool find_autocmplt_type_tmp_stmt(struct autocmplt_data_t *ad, RzCore *core, RzLineBuffer *buf) {
+static bool find_autocmplt_type_at_stmt(struct autocmplt_data_t *ad, RzCore *core, RzLineBuffer *buf) {
 	bool res = false;
-	if (buf->index > 0 && buf->data[buf->index - 1] == '@') {
+	if (buf->index > 1 && buf->data[buf->index - 1] == '@' && buf->data[buf->index - 2] == '@') {
+		struct guess_data_t *g = guess_next_autocmplt_token(core, buf, "=a", 1);
+		if (g) {
+			ut32 node_start = ts_node_start_byte(g->node);
+			ut32 node_end = ts_node_end_byte(g->node);
+			ut32 start = node_start - 3;
+			if (buf->index > 2 && buf->data[buf->index - 3] == '@') {
+				start--;
+				node_start--;
+			}
+			if (is_arg_identifier_in_tmp_stmt(g->node) && node_start > 3) {
+				res = fill_autocmplt_data_at_stmt(ad, start, node_end - 2);
+			}
+			guess_data_free(g);
+		}
+	} else if (buf->index > 0 && buf->data[buf->index - 1] == '@') {
 		struct guess_data_t *g = guess_next_autocmplt_token(core, buf, " a", 1);
 		if (g) {
 			ut32 node_start = ts_node_start_byte(g->node);
 			ut32 node_end = ts_node_end_byte(g->node);
-			if (is_arg_identifier_in_tmp_stmt(g->node)) {
-				res = fill_autocmplt_data_tmp_stmt(ad, node_start, node_end - 1);
+			if (is_arg_identifier_in_tmp_stmt(g->node) && node_start > 2) {
+				res = fill_autocmplt_data_at_stmt(ad, node_start - 2, node_end - 2);
 			}
 			guess_data_free(g);
 		}
-		if (res) {
-			return res;
-		}
 	}
-	if (buf->index > 1 && buf->data[buf->index - 2] == '@') {
+	if (res) {
+		return res;
+	}
+
+	char *start_iter = buf->data + buf->index;
+	char *p = start_iter;
+	// 4 is the longest @@ iter command (see @@dbta)
+	// We don't care to look for the @@ pattern before that point, because it
+	// wouldn't be a valid command anyway
+	char *maximum_search = buf->index > 4 ? start_iter - 4 : start_iter;
+	while (p > buf->data + 2 && p > maximum_search && !(*(p - 1) == '@' && *(p - 2) == '@') && *p != ' ') {
+		p--;
+	}
+	if (p > buf->data + 2 && p > maximum_search && p + 4 - buf->data < RZ_LINE_BUFSIZE && *(p - 3) == '@' && *p != ' ') {
+		// This handles the case <cmd> @@@c<TAB>
+		int idx = buf->index;
+		buf->index = p - buf->data + 1;
+		char last_char = buf->data[buf->index - 1];
+		buf->data[buf->index - 1] = '=';
+		struct guess_data_t *g = guess_next_autocmplt_token(core, buf, "a", 0);
+		buf->data[buf->index - 1] = last_char;
+		buf->index = idx;
+		if (g) {
+			if (is_arg_identifier_in_tmp_stmt(g->node)) {
+				res = fill_autocmplt_data_at_stmt(ad, p - buf->data - 3, buf->index);
+			}
+			guess_data_free(g);
+		}
+	} else if (p > buf->data + 2 && p > maximum_search && p + 4 - buf->data < RZ_LINE_BUFSIZE && *p != ' ') {
+		// This handles the cases <cmd> @@d<TAB> and similar
+		int idx = buf->index;
+		buf->index = p - buf->data + 1;
+		char last_char = buf->data[buf->index - 1];
+		buf->data[buf->index - 1] = 'd';
+		struct guess_data_t *g = guess_next_autocmplt_token(core, buf, "bta", 2);
+		buf->data[buf->index - 1] = last_char;
+		buf->index = idx;
+		if (g) {
+			const char *node_type = ts_node_type(g->node);
+			if (!strcmp(node_type, "iter_dbta_stmt")) {
+				res = fill_autocmplt_data_at_stmt(ad, p - buf->data - 2, buf->index);
+			}
+			guess_data_free(g);
+		}
+	} else if (buf->index > 1 && buf->data[buf->index - 2] == '@') {
+		// This handles the cases <cmd> @v<TAB> and similar
 		struct guess_data_t *g = guess_next_autocmplt_token(core, buf, ":a", 1);
 		if (g) {
 			ut32 node_start = ts_node_start_byte(g->node);
 			ut32 node_end = ts_node_end_byte(g->node);
 			if (is_arg_identifier_in_tmp_stmt(g->node) && node_start > 3 && node_end > 2) {
-				res = fill_autocmplt_data_tmp_stmt(ad, node_start - 3, node_end - 2);
+				res = fill_autocmplt_data_at_stmt(ad, node_start - 3, node_end - 2);
 			}
 			guess_data_free(g);
-		}
-		if (res) {
-			return res;
 		}
 	}
 	return res;
 }
 
-static bool find_autocmplt_type_tmp_stmt_op(struct autocmplt_data_t *ad, RzCore *core, RzLineBuffer *buf,
+static bool find_autocmplt_type_at_stmt_op(struct autocmplt_data_t *ad, RzCore *core, RzLineBuffer *buf,
 	const char *tmp_op, const char *newtext, enum autocmplt_type_t ad_type) {
 	bool res = false;
 	struct guess_data_t *g = guess_next_autocmplt_token(core, buf, newtext, 0);
@@ -877,23 +963,33 @@ static bool find_autocmplt_type(struct autocmplt_data_t *ad, RzCore *core, TSNod
 	} else if (find_autocmplt_type_quoted_arg(ad, core, buf, "'", "single_quoted_arg")) {
 		ad->res->end_string = "' ";
 		return true;
-	} else if (find_autocmplt_type_tmp_stmt_op(ad, core, buf, "tmp_seek_stmt", "a", AUTOCMPLT_RZNUM)) {
+	} else if (find_autocmplt_type_at_stmt_op(ad, core, buf, "tmp_seek_stmt", "a", AUTOCMPLT_RZNUM)) {
 		return true;
-	} else if (find_autocmplt_type_tmp_stmt_op(ad, core, buf, "tmp_fromto_stmt", "a b)", AUTOCMPLT_RZNUM)) {
+	} else if (find_autocmplt_type_at_stmt_op(ad, core, buf, "tmp_fromto_stmt", "a b)", AUTOCMPLT_RZNUM)) {
 		return true;
-	} else if (find_autocmplt_type_tmp_stmt_op(ad, core, buf, "tmp_arch_stmt", "a", AUTOCMPLT_ARCH)) {
+	} else if (find_autocmplt_type_at_stmt_op(ad, core, buf, "tmp_arch_stmt", "a", AUTOCMPLT_ARCH)) {
 		return true;
-	} else if (find_autocmplt_type_tmp_stmt_op(ad, core, buf, "tmp_bits_stmt", "1", AUTOCMPLT_BITS)) {
+	} else if (find_autocmplt_type_at_stmt_op(ad, core, buf, "tmp_bits_stmt", "1", AUTOCMPLT_BITS)) {
 		return true;
-	} else if (find_autocmplt_type_tmp_stmt_op(ad, core, buf, "tmp_file_stmt", "a", AUTOCMPLT_FILE)) {
+	} else if (find_autocmplt_type_at_stmt_op(ad, core, buf, "tmp_file_stmt", "a", AUTOCMPLT_FILE)) {
 		return true;
-	} else if (find_autocmplt_type_tmp_stmt_op(ad, core, buf, "tmp_fs_stmt", "a", AUTOCMPLT_FLAG_SPACE)) {
+	} else if (find_autocmplt_type_at_stmt_op(ad, core, buf, "tmp_fs_stmt", "a", AUTOCMPLT_FLAG_SPACE)) {
 		return true;
-	} else if (find_autocmplt_type_tmp_stmt_op(ad, core, buf, "tmp_reg_stmt", "a", AUTOCMPLT_REG)) {
+	} else if (find_autocmplt_type_at_stmt_op(ad, core, buf, "tmp_reg_stmt", "a", AUTOCMPLT_REG)) {
 		return true;
-	} else if (find_autocmplt_type_tmp_stmt_op(ad, core, buf, "tmp_eval_stmt", "a", AUTOCMPLT_EVAL_FULL)) {
+	} else if (find_autocmplt_type_at_stmt_op(ad, core, buf, "tmp_eval_stmt", "a", AUTOCMPLT_EVAL_FULL)) {
 		return true;
-	} else if (find_autocmplt_type_tmp_stmt(ad, core, buf)) {
+	} else if (find_autocmplt_type_at_stmt_op(ad, core, buf, "iter_offsets_stmt", "a", AUTOCMPLT_RZNUM)) {
+		return true;
+	} else if (find_autocmplt_type_at_stmt_op(ad, core, buf, "iter_offsetssizes_stmt", "a", AUTOCMPLT_RZNUM)) {
+		return true;
+	} else if (find_autocmplt_type_at_stmt_op(ad, core, buf, "iter_file_lines_stmt", "a", AUTOCMPLT_FILE)) {
+		return true;
+	} else if (find_autocmplt_type_at_stmt_op(ad, core, buf, "iter_flags_stmt", "a", AUTOCMPLT_FLAG)) {
+		return true;
+	} else if (find_autocmplt_type_at_stmt_op(ad, core, buf, "iter_function_stmt", "a", AUTOCMPLT_FUNCTION)) {
+		return true;
+	} else if (find_autocmplt_type_at_stmt(ad, core, buf)) {
 		return true;
 	}
 	return false;
@@ -927,8 +1023,12 @@ RZ_API RzLineNSCompletionResult *rz_core_autocomplete_rzshell(RzCore *core, RzLi
 	if (ts_node_is_null(node)) {
 		goto err;
 	}
-	RZ_LOG_DEBUG("autocomplete_rzshell root = '%s'\n", ts_node_string(root));
-	RZ_LOG_DEBUG("autocomplete_rzshell node = '%s'\n", ts_node_string(node));
+	char *root_string = ts_node_string(root);
+	char *node_string = ts_node_string(node);
+	RZ_LOG_DEBUG("autocomplete_rzshell root = '%s'\n", root_string);
+	RZ_LOG_DEBUG("autocomplete_rzshell node = '%s'\n", node_string);
+	free(node_string);
+	free(root_string);
 
 	// the autocompletion works in 2 steps:
 	// 1) it finds the proper type to autocomplete (sometimes it guesses)
@@ -943,8 +1043,8 @@ RZ_API RzLineNSCompletionResult *rz_core_autocomplete_rzshell(RzCore *core, RzLi
 		case AUTOCMPLT_CMD_ARG:
 			autocmplt_cmd_arg(core, ad.res, ad.cd, ad.i_arg, buf->data + ad.res->start, ad.res->end - ad.res->start);
 			break;
-		case AUTOCMPLT_TMP_STMT:
-			autocmplt_tmp_stmt(core, ad.res, buf->data + ad.res->start, ad.res->end - ad.res->start);
+		case AUTOCMPLT_AT_STMT:
+			autocmplt_at_stmt(core, ad.res, buf->data + ad.res->start, ad.res->end - ad.res->start);
 			break;
 		case AUTOCMPLT_RZNUM:
 			autocmplt_cmd_arg_rznum(core, ad.res, buf->data + ad.res->start, ad.res->end - ad.res->start);
@@ -966,6 +1066,12 @@ RZ_API RzLineNSCompletionResult *rz_core_autocomplete_rzshell(RzCore *core, RzLi
 			break;
 		case AUTOCMPLT_EVAL_FULL:
 			autocmplt_cmd_arg_eval_full(core, ad.res, buf->data + ad.res->start, ad.res->end - ad.res->start);
+			break;
+		case AUTOCMPLT_FLAG:
+			autocmplt_cmd_arg_flag(core, ad.res, buf->data + ad.res->start, ad.res->end - ad.res->start);
+			break;
+		case AUTOCMPLT_FUNCTION:
+			autocmplt_cmd_arg_fcn(core, ad.res, buf->data + ad.res->start, ad.res->end - ad.res->start);
 			break;
 		default:
 			break;

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -7205,6 +7205,7 @@ static const RzCmdDescDetailEntry iterators_empty_detail_entries[] = {
 	{ .text = "<cmd> @@t", .arg_str = "", .comment = "Run <cmd> over all threads" },
 	{ .text = "<cmd> @@b", .arg_str = "", .comment = "Run <cmd> over all basic blocks of the current function" },
 	{ .text = "<cmd> @@i", .arg_str = "", .comment = "Run <cmd> over all instructions of the current basic block" },
+	{ .text = "<cmd> @@ii", .arg_str = "", .comment = "Run <cmd> over all imports" },
 	{ .text = "<cmd> @@iS", .arg_str = "", .comment = "Run <cmd> over all sections" },
 	{ .text = "<cmd> @@iSS", .arg_str = "", .comment = "Run <cmd> over all segments" },
 	{ .text = "<cmd> @@is", .arg_str = "", .comment = "Run <cmd> over all symbols" },

--- a/librz/core/cmd_descs/cmd_descs.yaml
+++ b/librz/core/cmd_descs/cmd_descs.yaml
@@ -156,7 +156,7 @@ commands:
     args:
       - name: search_cmd
         type: RZ_CMD_ARG_TYPE_STRING
-        flags: ''
+        flags: ""
         optional: true
     modes:
       - RZ_OUTPUT_MODE_STANDARD
@@ -376,6 +376,9 @@ commands:
           - text: "<cmd> @@i"
             arg_str: ""
             comment: "Run <cmd> over all instructions of the current basic block"
+          - text: "<cmd> @@ii"
+            arg_str: ""
+            comment: "Run <cmd> over all imports"
           - text: "<cmd> @@iS"
             arg_str: ""
             comment: "Run <cmd> over all sections"
@@ -598,7 +601,8 @@ commands:
         entries:
           - text: aflt
             arg_str: ":addr/cols/name/nbbs:nbbs/sort/dec:nbbs/gt/1:nbbs/lt/10:fancy"
-            comment: Show only the address, name and number of basic blocks of the identified functions
+            comment:
+              Show only the address, name and number of basic blocks of the identified functions
               with more than 1 block but less than 10, sorted decrementally by number of blocks.
   - name: shell
     summary: Common shell commands

--- a/librz/core/cmd_descs/cmd_open.yaml
+++ b/librz/core/cmd_descs/cmd_open.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2021 RizinOrg <info@rizin.re>
+# SPDX-License-Identifier: LGPL-3.0-only
+---
+name: cmd_open
+commands:
+  - name: o
+    cname: open
+    summary: Open <file> and map it at <addr> with the specified permissions <perm>
+    args:
+      - name: file
+        type: RZ_CMD_ARG_TYPE_FILE
+      - name: addr
+        type: RZ_CMD_ARG_TYPE_RZNUM
+        optional: true
+      - name: perm
+        type: RZ_CMD_ARG_TYPE_STRING
+        optional: true
+  - name: ol
+    cname: open_list
+    summary: List opened files
+    type: RZ_CMD_DESC_TYPE_ARGV_STATE
+    default_mode: RZ_OUTPUT_MODE_TABLE
+    modes:
+      - RZ_OUTPUT_MODE_TABLE
+      - RZ_OUTPUT_MODE_JSON
+    args: []
+  - name: o-
+    cname: open_close
+    summary: Close file descriptor
+    args:
+      - name: file_descriptor
+        type: RZ_CMD_ARG_TYPE_NUM

--- a/test/db/cmd/cmd_repeats
+++ b/test/db/cmd/cmd_repeats
@@ -4,7 +4,7 @@ CMDS=<<EOF
 @@?~?
 EOF
 EXPECT=<<EOF
-22
+23
 EOF
 RUN
 

--- a/test/unit/test_autocmplt.c
+++ b/test/unit/test_autocmplt.c
@@ -452,10 +452,9 @@ static bool test_autocmplt_tmp_operators(void) {
 	RzLineNSCompletionResult *r = rz_core_autocomplete_rzshell(core, buf, RZ_LINE_PROMPT_DEFAULT);
 
 	mu_assert_notnull(r, "r should not be null");
-	// TODO: WHY the +1????
-	mu_assert_eq(r->start, strlen("pd @ "), "should autocomplete the @ operator");
-	mu_assert_eq(r->end, buf->length + 1, "should autocomplete ending at end of buffer");
-	mu_assert_eq(rz_pvector_len(&r->options), 16, "there are 16 @ operators (see @?)");
+	mu_assert_eq(r->start, strlen("pd "), "should autocomplete the @ operator");
+	mu_assert_eq(r->end, buf->length, "should autocomplete ending at end of buffer");
+
 	const char *tmp_ops[] = {
 		"@ ",
 		"@!",
@@ -473,7 +472,35 @@ static bool test_autocmplt_tmp_operators(void) {
 		"@s:",
 		"@v:",
 		"@x:",
+		"@@.",
+		"@@=",
+		"@@@=",
+		"@@",
+		"@@c:",
+		"@@@c:",
+		"@@C",
+		"@@C:",
+		"@@dbt",
+		"@@dbtb",
+		"@@dbts",
+		"@@t",
+		"@@b",
+		"@@i",
+		"@@ii",
+		"@@iS",
+		"@@iSS",
+		"@@is",
+		"@@iz",
+		"@@f",
+		"@@f:",
+		"@@F",
+		"@@F:",
+		"@@om",
+		"@@dm",
+		"@@r",
+		"@@s:",
 	};
+	mu_assert_eq(rz_pvector_len(&r->options), RZ_ARRAY_SIZE(tmp_ops), "there are all @/@@/@@ operators (see @?, @@?)");
 	int i;
 	for (i = 0; i < RZ_ARRAY_SIZE(tmp_ops); i++) {
 		char msg[100];


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Finish autocompletion for @@ operators.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Enter the rizin shell and try things such as:
* `pd 1 @<TAB>`
* `pd 1 @@<TAB>`
* `pd 1 @@@<TAB>`
* `pd 1 @i<TAB>`
* `pd 1 @@i<TAB>`
* `pd 1 @@f<TAB>`
* `pd 1 @@f:<TAB>`
* `pd 1 @@.<TAB>`
* `pd 1 @@F:<TAB>`

autocompletion should properly work when using `cfg.oldshell.autocompletion=false`.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #1808 
