### PR TITLE
[Debug] Let gdb attach regularly and reset reason after attach

### DIFF
--- a/librz/core/cio.c
+++ b/librz/core/cio.c
@@ -6,7 +6,6 @@
 
 RZ_API int rz_core_setup_debugger(RzCore *r, const char *debugbackend, bool attach) {
 	int pid, *p = NULL;
-	bool is_gdb = !strcmp(debugbackend, "gdb");
 	RzIODesc *fd = r->file ? rz_io_desc_get(r->io, r->file->fd) : NULL;
 
 	p = fd ? fd->data : NULL;
@@ -18,13 +17,11 @@ RZ_API int rz_core_setup_debugger(RzCore *r, const char *debugbackend, bool atta
 
 	rz_config_set(r->config, "io.ff", "true");
 	rz_config_set(r->config, "dbg.backend", debugbackend);
-	if (!is_gdb) {
-		pid = rz_io_desc_get_pid(fd);
-		rz_debug_select(r->dbg, pid, r->dbg->tid);
-		r->dbg->main_pid = pid;
-		if (attach) {
-			rz_core_debug_attach(r, pid);
-		}
+	pid = rz_io_desc_get_pid(fd);
+	rz_debug_select(r->dbg, pid, r->dbg->tid);
+	r->dbg->main_pid = pid;
+	if (attach) {
+		rz_core_debug_attach(r, pid);
 	}
 	//this makes to attach twice showing warnings in the output
 	//we get "resource busy" so it seems isn't an issue

--- a/librz/debug/debug.c
+++ b/librz/debug/debug.c
@@ -443,6 +443,7 @@ RZ_API int rz_debug_attach(RzDebug *dbg, int pid) {
 	if (dbg && dbg->cur && dbg->cur->attach) {
 		ret = dbg->cur->attach(dbg, pid);
 		if (ret != -1) {
+			dbg->reason.type = RZ_DEBUG_REASON_NONE; // after a successful attach, the process is not dead
 			rz_debug_select(dbg, pid, ret); //dbg->pid, dbg->tid);
 		}
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This fixes a regression from 56841703e1c5811508e797cbff93ae4974d3dc8e where remote gdb was broken in certain cases. The changes there are not wrong per se, but `rz_debug_is_dead()` was called before the attach happened, causing the stored reason to be set to `..._DEAD`, such that even after a successful attach, no debug commands would work because they check that variable:
```
florian-macbook:rizin florian$ rz -d gdb://florian-desktop:1337
WARNING: rz_file_exists: assertion '!RZ_STR_ISEMPTY(str)' failed (line 172)
= attach 4608 4608
 -- Follow the white rabbit
[0x00000000]> dc
Debugging is not enabled. Run ood?
[0x00000000]>
```

The same issue happened in rz-commodore

The fix here is to
* Always reset the debug reason after a successful attach
* Remove some gdb-specific hack, such that it attaches like any other plugin (it did work before without this because gdb has some auto-attach mechanism)

**Test plan**

Start a gdbserver, attach to it with rz and try `dc`