### PR TITLE
enable flushing for oldinput_get_help

### DIFF
--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -1234,6 +1234,9 @@ static char *oldinput_get_help(RzCmd *cmd, RzCmdDesc *cd, RzCmdParsedArgs *a) {
 
 	char *res = NULL;
 	rz_cons_push();
+	// rz_cons_push disables flushing, which is going to be a problem if a help menu is
+	// displayed.
+	rz_cons_set_flush(true);
 	RzCmdStatus status = rz_cmd_call_parsed_args(cmd, a);
 	if (status == RZ_CMD_STATUS_OK) {
 		rz_cons_filter();


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

When executing `V?`, a new console context is created with `noflush` set to `true`. When `noflush` is set, `rz_cons_flush` has no effect, so the following code from `visual_help` does not manage to output a prompt to the screen before waiting for user input.

```c
rz_core_visual_append_help(q, "Visual Help", help_visual);
rz_cons_printf("%s", rz_strbuf_get(q));
rz_cons_flush();
switch (rz_cons_readchar()) {
```

Flushing could be enabled in `visual_help`, but it seems like this could be necessary for other `oldinput_get_help` cases so I enabled it there.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Run `V?` and the help menu should be displayed.

![demo](https://user-images.githubusercontent.com/17961/139602281-e1d21763-80dd-45ff-835b-bfef3ce2dce6.gif)

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #1892 