### PR TITLE
Add Alpine CI job with SourceHut

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -1,0 +1,49 @@
+image: alpine/latest
+packages:
+    - meson
+    - pkgconf
+    - make
+    - gcc
+    - cabextract
+    - wget
+    - python3
+    - linux-headers
+sources:
+    - https://github.com/rizinorg/rizin
+    - https://github.com/rizinorg/rizin-testbins
+tasks:
+    - skip: echo "${GITHUB_REF}" | grep -E '^refs/(heads/(dev|stable|alpine-.+|dist-.+)|tags/.+)$' || complete-build
+    - rzpipe: |
+        sudo python3 -m ensurepip
+        sudo python3 -m pip install 'git+https://github.com/rizinorg/rz-pipe#egg=rzpipe&subdirectory=python'
+    - build: |
+        cd rizin
+        meson --prefix=${HOME} build
+        ninja -C build
+    - install: |
+        cd rizin
+        export PATH=${HOME}/bin:${PATH}
+        export LD_LIBRARY_PATH=${HOME}/lib:${HOME}/lib64:${LD_LIBRARY_PATH}
+        export PKG_CONFIG_PATH=${HOME}/lib/pkgconfig:${PKG_CONFIG_PATH}
+        ninja -C build install
+    - unittest: |
+        cd rizin
+        export PATH=${HOME}/bin:${PATH}
+        export LD_LIBRARY_PATH=${HOME}/lib:${HOME}/lib64:${LD_LIBRARY_PATH}
+        export PKG_CONFIG_PATH=${HOME}/lib/pkgconfig:${PKG_CONFIG_PATH}
+        # Workaround until the feature request is solved
+        # https://todo.sr.ht/~sircmpwn/builds.sr.ht/274
+        ln -s ${HOME}/rizin-testbins test/bins
+        # Running the unit tests
+        ninja -C build test
+    - test: |
+        cd rizin
+        export PATH=${HOME}/bin:${PATH}
+        export LD_LIBRARY_PATH=${HOME}/lib:${HOME}/lib64:${LD_LIBRARY_PATH}
+        export PKG_CONFIG_PATH=${HOME}/lib/pkgconfig:${PKG_CONFIG_PATH}
+        # Workaround until the feature request is solved
+        # https://todo.sr.ht/~sircmpwn/builds.sr.ht/274
+        ln -s ${HOME}/rizin-testbins test/bins
+        # Running the test suite
+        cd test
+        rz-test -L -o results.json


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Alpine linux built around Musl and is widely used as a Docker/Podman container base.

**Test plan**

CI is green

Might be helpful for solving https://github.com/rizinorg/rizin/issues/982

```
../librz/util/thread.c: In function 'rz_th_setaffinity':
../librz/util/thread.c:138:26: warning: passing argument 1 of 'sched_setaffinity' makes integer from pointer without a cast [-Wint-conversion]
  138 |  if (sched_setaffinity(th->tid, sizeof(c), &c) != 0) {
      |                        ~~^~~~~
      |                          |
      |                          pthread_t {aka struct __pthread *}
In file included from /usr/include/pthread.h:30,
                 from ../librz/include/rz_th.h:24,
                 from ../librz/util/thread.c:4:
/usr/include/sched.h:91:23: note: expected 'pid_t' {aka 'int'} but argument is of type 'pthread_t' {aka 'struct __pthread *'}
   91 | int sched_setaffinity(pid_t, size_t, const cpu_set_t *);
      |                       ^~~~~
[1167/1725] Compiling C object librz/util/librz_util.so.0.4.0-git.p/strpool.c.o
[1168/1725] Compiling C object librz/util/librz_util.so.0.4.0-git.p/strbuf.c.o
[1169/1725] Compiling C object librz/util/librz_util.so.0.4.0-git.p/str_trim.c.o
../librz/util/sys.c: In function 'rz_sys_backtrace':
../librz/util/sys.c:303:2: warning: #warning TODO: rz_sys_bt : unimplemented [-Wcpp]
  303 | #warning TODO: rz_sys_bt : unimplemented
      |  ^~~~~~~
```

From `src/shed/affinity.c` from musl:
```c
int sched_setaffinity(pid_t tid, size_t size, const cpu_set_t *set)
{
	return syscall(SYS_sched_setaffinity, tid, size, set);
}

int pthread_setaffinity_np(pthread_t td, size_t size, const cpu_set_t *set)
{
	return syscall(SYS_sched_setaffinity, td->tid, size, set);
}
```