### PR TITLE
Use `offsetof` with Clang

### DIFF
--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -365,7 +365,7 @@ static inline void *rz_new_copy(int size, void *data) {
 
 // There is a bug of using "offsetof()" in the structure
 // initialization in GCC < 5.0 versions
-#if !(defined(__GNUC__) && __GNUC__ < 5)
+#if !(defined(__GNUC__) && __GNUC__ < 5) || defined(__clang__)
 #define rz_offsetof(type, member) offsetof(type, member)
 #else
 #if __SDB_WINDOWS__


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr cherry-picks the fix for the following error of #1910:

![bin_nro-UB](https://user-images.githubusercontent.com/12002672/139694704-1c2b6810-cd9c-447c-902c-dd2bef0aacfb.PNG)
(https://github.com/rizinorg/rizin/runs/4058905317?check_suite_focus=true#step:16:49)

It appears that Clang 11 declares `__GNUC__` to be 4 even though it has an `offsetof` that appears to be working just fine.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
