### PR TITLE
Use get_reg_profile instead of set in ppc plugins

### DIFF
--- a/librz/analysis/p/analysis_ppc_cs.c
+++ b/librz/analysis/p/analysis_ppc_cs.c
@@ -207,7 +207,7 @@ static void opex(RzStrBuf *buf, csh handle, cs_insn *insn) {
 #define ARG(n)     getarg2(&gop, n, "")
 #define ARG2(n, m) getarg2(&gop, n, m)
 
-static bool set_reg_profile(RzAnalysis *analysis) {
+static char *get_reg_profile(RzAnalysis *analysis) {
 	const char *p = NULL;
 	if (analysis->bits == 32) {
 		p =
@@ -411,7 +411,7 @@ static bool set_reg_profile(RzAnalysis *analysis) {
 			"gpr	dbat3u .32 484 0\n"
 			"gpr	mask   .64 488 0\n"; //not a real register used on complex functions
 	}
-	return rz_reg_set_profile_string(analysis->reg, p);
+	return strdup(p);
 }
 
 static int analop_vle(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len) {
@@ -1312,7 +1312,7 @@ RzAnalysisPlugin rz_analysis_plugin_ppc_cs = {
 	.archinfo = archinfo,
 	.preludes = analysis_preludes,
 	.op = &analop,
-	.set_reg_profile = &set_reg_profile,
+	.get_reg_profile = &get_reg_profile,
 };
 
 #ifndef RZ_PLUGIN_INCORE

--- a/librz/analysis/p/analysis_ppc_gnu.c
+++ b/librz/analysis/p/analysis_ppc_gnu.c
@@ -79,7 +79,7 @@ static int ppc_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *
 	return op->size;
 }
 
-static bool set_reg_profile(RzAnalysis *analysis) {
+static char *get_reg_profile(RzAnalysis *analysis) {
 	const char *p =
 		"=PC	srr0\n"
 		"=SR	srr1\n" // status register
@@ -134,7 +134,7 @@ static bool set_reg_profile(RzAnalysis *analysis) {
 		"gpr	ctr	.32	148	0\n"
 		"gpr	mq	.32	152	0\n"
 		"gpr	vrsave	.32	156	0\n";
-	return rz_reg_set_profile_string(analysis->reg, p);
+	return strdup(p);
 }
 
 static int archinfo(RzAnalysis *analysis, int q) {
@@ -149,7 +149,7 @@ RzAnalysisPlugin rz_analysis_plugin_ppc_gnu = {
 	.archinfo = archinfo,
 	.bits = 32 | 64,
 	.op = &ppc_op,
-	.set_reg_profile = &set_reg_profile,
+	.get_reg_profile = &get_reg_profile,
 };
 
 #ifndef RZ_PLUGIN_INCORE


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`set_reg_profile` is deprecated and causes weird warning output on a ppc host.

**Test plan**

`rz -a ppc -Qc ar` and `rz -a ppc.gnu ar` should show registers.