### PR TITLE
Fix: Conditional jumps are treated as data xrefs if analysis.jmp.cref=false

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4154,11 +4154,22 @@ RZ_API int rz_core_analysis_search(RzCore *core, ut64 from, ut64 to, ut64 ref, i
 	return count;
 }
 
+/**
+ * \brief Validate the reference. If virtual addressing is enabled, we allow only references to virtual addresses in order to reduce
+ * the number of false positives. In debugger mode (\p cfg_debug = true), the reference must point to a mapped memory region.
+ *
+ * \param core The Rizin core.
+ * \param at Address of the reference.
+ * \param xref_to Address at which the reference points to.
+ * \param type The suspected reference type.
+ * \param pj The print json struct which stores the reference if \p rad = 'j'.
+ * \param rad Usually the last character in a command. Set to 'j' if \p pj should be filled with the reference (if valid). 
+ * \param cfg_debug True if debugger mode is enabled. False otherwise.
+ * \param cfg_analysis_strings True if a string search should be started at \p xref_to. False otherwise.
+ * \return true If the reference, as given to the function, is valid.
+ * \return false If the reference, as given to the function, is not valid.
+ */
 static bool found_xref(RzCore *core, ut64 at, ut64 xref_to, RzAnalysisXRefType type, PJ *pj, int rad, int cfg_debug, bool cfg_analysis_strings) {
-	// Validate the reference. If virtual addressing is enabled, we
-	// allow only references to virtual addresses in order to reduce
-	// the number of false positives. In debugger mode, the reference
-	// must point to a mapped memory region.
 	if (type == RZ_ANALYSIS_REF_TYPE_NULL) {
 		return false;
 	}

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4294,7 +4294,7 @@ RZ_API int rz_core_analysis_search_xrefs(RzCore *core, ut64 from, ut64 to, PJ *p
 			if (ret <= 0 || i > bsz) {
 				break;
 			}
-			if (op.type == RZ_ANALYSIS_OP_TYPE_CJMP && rz_config_get_b(core->config, "analysis.jmp.cref")) {
+			if (op.type == RZ_ANALYSIS_OP_TYPE_CJMP && !rz_config_get_b(core->config, "analysis.jmp.cref")) {
 				break;
 			}
 			// find references

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4283,6 +4283,9 @@ RZ_API int rz_core_analysis_search_xrefs(RzCore *core, ut64 from, ut64 to, PJ *p
 			if (ret <= 0 || i > bsz) {
 				break;
 			}
+			if (op.type == RZ_ANALYSIS_OP_TYPE_CJMP && rz_config_get_b(core->config, "analysis.jmp.cref")) {
+				break;
+			}
 			// find references
 			if ((st64)op.val > asm_sub_varmin && op.val != UT64_MAX && op.val != UT32_MAX) {
 				if (found_xref(core, op.addr, op.val, RZ_ANALYSIS_REF_TYPE_DATA, pj, rad, cfg_debug, cfg_analysis_strings)) {
@@ -4308,8 +4311,7 @@ RZ_API int rz_core_analysis_search_xrefs(RzCore *core, ut64 from, ut64 to, PJ *p
 				}
 				break;
 			case RZ_ANALYSIS_OP_TYPE_CJMP:
-				if (rz_config_get_b(core->config, "analysis.jmp.cref") &&
-					found_xref(core, op.addr, op.jump, RZ_ANALYSIS_REF_TYPE_CODE, pj, rad, cfg_debug, cfg_analysis_strings)) {
+				if (found_xref(core, op.addr, op.jump, RZ_ANALYSIS_REF_TYPE_CODE, pj, rad, cfg_debug, cfg_analysis_strings)) {
 					count++;
 				}
 				break;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

If `aar` analyses an instruction with an conditional jump and `analysis.jmp.cref = false` it is treated as a data reference.

With this fix the condition `analysis.jmp.cref` is checked before any reference analysis is done. 


**Test plan**

Since my only architecture I am really fluent in is Hexagon I can only provide a test for this. There is a test in this [PR](https://github.com/rizinorg/rizin/pull/1614) which failed before https://github.com/rizinorg/rizin/pull/1614/commits/9dd5ec4c173600348817cbecadbadfcb19b0907f.

On [this branch](https://github.com/Rot127/rizin/tree/Hexagon) the following commands show that the fix is working:

```
> rizin test/bins/elf/analysis/hexagon-hello-loop
[0x00005000]> e analysis.jmp.cref=false
[0x00005000]> s sym.main
[0x00005110]> af
[0x00005110]> aar
[0x00005110]> afx
c 0x00005124 -> 0x00005128 ? jump 0x5128
d 0x00005130 -> 0x00005154 ? if (P0) jump:nt 0x5154     <------ Correct jump, but incorrect reference type.
c 0x00005134 -> 0x00005138 [     jump 0x5138
C 0x00005138 -> 0x000050e0 [     call sym.pHello
C 0x0000513c -> 0x000050f8 [     call sym.pWorld
c 0x00005140 -> 0x00005144 [     jump 0x5144
c 0x00005150 -> 0x00005128 ? jump 0x5128
```

After applying the fix:

```
> rizin test/bins/elf/analysis/hexagon-hello-loop
[0x00005000]> e analysis.jmp.cref=false
[0x00005000]> s sym.main
[0x00005110]> af
[0x00005110]> aar
[0x00005110]> afx
c 0x00005124 -> 0x00005128 ? jump 0x5128
c 0x00005134 -> 0x00005138 [     jump 0x5138
C 0x00005138 -> 0x000050e0 [     call sym.pHello
C 0x0000513c -> 0x000050f8 [     call sym.pWorld
c 0x00005140 -> 0x00005144 [     jump 0x5144
c 0x00005150 -> 0x00005128 ? jump 0x5128
```
