### PR TITLE
intervaltree.c: Check for NULL before using `container_of`

### DIFF
--- a/librz/util/intervaltree.c
+++ b/librz/util/intervaltree.c
@@ -4,7 +4,7 @@
 #include <rz_util/rz_intervaltree.h>
 #include <rz_util/rz_assert.h>
 
-#define unwrap(rbnode) container_of(rbnode, RzIntervalNode, node)
+#define unwrap(rbnode) ((rbnode) ? container_of(rbnode, RzIntervalNode, node) : NULL)
 
 static void node_max(RBNode *node) {
 	RzIntervalNode *intervalnode = unwrap(node);
@@ -140,7 +140,7 @@ RZ_API bool rz_interval_tree_delete(RzIntervalTree *tree, RzIntervalNode *node, 
 	RBNode *root = &tree->root->node;
 	RBIter path_cache = { 0 };
 	bool r = rz_rbtree_aug_delete(&root, node, cmp_exact_node, &path_cache, interval_node_free, free ? tree->free : NULL, node_max);
-	tree->root = root ? unwrap(root) : NULL;
+	tree->root = unwrap(root);
 	return r;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr cherry-picks the fix from #1910 for UBs of the following form in `intervaltree.c`:

![interval-tree c-UB](https://user-images.githubusercontent.com/12002672/140280027-66612479-2c3f-4541-900e-f644af7afcdb.PNG)
(https://github.com/rizinorg/rizin/runs/4068068778?check_suite_focus=true#step:16:93)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
