### PR TITLE
Remove Newlisp and ES6 (Babel) support for RzLang

### DIFF
--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -602,20 +602,8 @@ RZ_API bool rz_core_run_script(RzCore *core, const char *file) {
 					lang_run_file(core, core->lang, cmd);
 					free(cmd);
 					ret = 1;
-				} else if (!strcmp(ext, "lsp")) {
-					char *cmd = cmdstr("newlisp -n");
-					rz_lang_use(core->lang, "pipe");
-					lang_run_file(core, core->lang, cmd);
-					free(cmd);
-					ret = 1;
 				} else if (!strcmp(ext, "go")) {
 					char *cmd = cmdstr("go run");
-					rz_lang_use(core->lang, "pipe");
-					lang_run_file(core, core->lang, cmd);
-					free(cmd);
-					ret = 1;
-				} else if (!strcmp(ext, "es6")) {
-					char *cmd = cmdstr("babel-node");
 					rz_lang_use(core->lang, "pipe");
 					lang_run_file(core, core->lang, cmd);
 					free(cmd);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Newlisp is dead. In fact, it's probably make sense to support Scheme (.scm) scripting instead
- ES6 doesn't need Babel nowadays, it's supported by the mainline Node.js

**Test plan**

CI is green