### PR TITLE
Rzshell: convert `o=` and `oa`

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -4331,6 +4331,11 @@ RZ_API int rz_core_bin_set_arch_bits(RzCore *r, const char *name, const char *ar
 	//set env if the binfile changed or we are dealing with xtr
 	if (curfile != binfile || binfile->curxtr) {
 		rz_core_bin_set_cur(r, binfile);
+		if (binfile->o && binfile->o->info) {
+			free(binfile->o->info->arch);
+			binfile->o->info->arch = strdup(arch);
+			binfile->o->info->bits = bits;
+		}
 		return rz_core_bin_apply_all_info(r, binfile);
 	}
 	return true;

--- a/librz/core/cmd/cmd_open.c
+++ b/librz/core/cmd/cmd_open.c
@@ -1065,57 +1065,6 @@ RZ_IPI int rz_cmd_open(void *data, const char *input) {
 	char **argv = NULL;
 
 	switch (*input) {
-	case 'a':
-		switch (input[1]) {
-		case '*': // "oa*"
-		{
-			RzListIter *iter;
-			RzBinFile *bf = NULL;
-			rz_list_foreach (core->bin->binfiles, iter, bf) {
-				if (bf && bf->o && bf->o->info) {
-					eprintf("oa %s %d %s\n", bf->o->info->arch, bf->o->info->bits, bf->file);
-				}
-			}
-			return 1;
-		}
-		case '?': // "oa?"
-		case ' ': // "oa "
-		{
-			int i;
-			char *ptr = strdup(input + 2);
-			const char *arch = NULL;
-			ut16 bits = 0;
-			const char *filename = NULL;
-			i = rz_str_word_set0(ptr);
-			if (i < 2) {
-				eprintf("Missing argument\n");
-				free(ptr);
-				return 0;
-			}
-			if (i == 3) {
-				filename = rz_str_word_get0(ptr, 2);
-			}
-			bits = rz_num_math(core->num, rz_str_word_get0(ptr, 1));
-			arch = rz_str_word_get0(ptr, 0);
-			rz_core_bin_set_arch_bits(core, filename, arch, bits);
-			RzBinFile *file = rz_bin_file_find_by_name(core->bin, filename);
-			if (!file) {
-				eprintf("Cannot find file %s\n", filename);
-				free(ptr);
-				return 0;
-			}
-			if (file->o && file->o->info) {
-				file->o->info->arch = strdup(arch);
-				file->o->info->bits = bits;
-				rz_core_bin_apply_all_info(core, file);
-			}
-			free(ptr);
-			return 1;
-		} break;
-		default:
-			eprintf("Usage: oa[-][arch] [bits] [filename]\n");
-			return 0;
-		}
 	case 'n': // "on"
 		if (input[1] == '*') {
 			rz_core_raw_file_print(core);
@@ -1581,4 +1530,13 @@ RZ_IPI RzCmdStatus rz_open_list_ascii_handler(RzCore *core, int argc, const char
 	rz_id_storage_foreach(core->io->files, init_desc_list_visual_cb, &data);
 	rz_id_storage_foreach(core->io->files, desc_list_visual_cb, &data);
 	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_open_arch_bits_handler(RzCore *core, int argc, const char **argv) {
+	const char *filename = argc > 3 ? argv[3] : NULL;
+	ut16 bits = rz_num_math(core->num, argv[2]);
+	const char *arch = argv[1];
+
+	int res = rz_core_bin_set_arch_bits(core, filename, arch, bits);
+	return res ? RZ_CMD_STATUS_OK : RZ_CMD_STATUS_ERROR;
 }

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -4833,6 +4833,14 @@ static const RzCmdDescHelp open_plugins_help = {
 	.args = open_plugins_args,
 };
 
+static const RzCmdDescArg open_list_ascii_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp open_list_ascii_help = {
+	.summary = "List opened files in ASCII-art bars",
+	.args = open_list_ascii_args,
+};
+
 static const RzCmdDescHelp cmd_print_help = {
 	.summary = "Print commands",
 };
@@ -8746,6 +8754,9 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *open_plugins_cd = rz_cmd_desc_argv_state_new(core->rcmd, cmd_open_cd, "oL", RZ_OUTPUT_MODE_TABLE | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET, rz_plugins_io_print_handler, &open_plugins_help);
 	rz_warn_if_fail(open_plugins_cd);
 	rz_cmd_desc_set_default_mode(open_plugins_cd, RZ_OUTPUT_MODE_TABLE);
+
+	RzCmdDesc *open_list_ascii_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_open_cd, "o=", rz_open_list_ascii_handler, &open_list_ascii_help);
+	rz_warn_if_fail(open_list_ascii_cd);
 
 	RzCmdDesc *cmd_print_cd = rz_cmd_desc_oldinput_new(core->rcmd, root_cd, "p", rz_cmd_print, &cmd_print_help);
 	rz_warn_if_fail(cmd_print_cd);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -212,6 +212,7 @@ static const RzCmdDescArg plugins_debug_print_args[2];
 static const RzCmdDescArg plugins_io_print_args[2];
 static const RzCmdDescArg open_close_args[2];
 static const RzCmdDescArg open_plugins_args[2];
+static const RzCmdDescArg open_arch_bits_args[4];
 static const RzCmdDescArg cmd_print_gadget_add_args[6];
 static const RzCmdDescArg cmd_print_gadget_move_args[6];
 static const RzCmdDescArg cmd_print_msg_digest_args[2];
@@ -4841,6 +4842,30 @@ static const RzCmdDescHelp open_list_ascii_help = {
 	.args = open_list_ascii_args,
 };
 
+static const RzCmdDescArg open_arch_bits_args[] = {
+	{
+		.name = "arch",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+
+	},
+	{
+		.name = "bits",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+
+	},
+	{
+		.name = "filename",
+		.type = RZ_CMD_ARG_TYPE_FILE,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp open_arch_bits_help = {
+	.summary = "Specify <arch> and <bits> for the file <filename> or the current one if none is specified",
+	.args = open_arch_bits_args,
+};
+
 static const RzCmdDescHelp cmd_print_help = {
 	.summary = "Print commands",
 };
@@ -8757,6 +8782,9 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *open_list_ascii_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_open_cd, "o=", rz_open_list_ascii_handler, &open_list_ascii_help);
 	rz_warn_if_fail(open_list_ascii_cd);
+
+	RzCmdDesc *open_arch_bits_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_open_cd, "oa", rz_open_arch_bits_handler, &open_arch_bits_help);
+	rz_warn_if_fail(open_arch_bits_cd);
 
 	RzCmdDesc *cmd_print_cd = rz_cmd_desc_oldinput_new(core->rcmd, root_cd, "p", rz_cmd_print, &cmd_print_help);
 	rz_warn_if_fail(cmd_print_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -374,6 +374,7 @@ RZ_IPI RzCmdStatus rz_open_close_handler(RzCore *core, int argc, const char **ar
 RZ_IPI RzCmdStatus rz_open_close_all_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_plugins_io_print_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_open_list_ascii_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_open_arch_bits_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI int rz_cmd_open(void *data, const char *input);
 RZ_IPI RzCmdStatus rz_cmd_print_gadget_add_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_print_gadget_print_as_rizin_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -373,6 +373,7 @@ RZ_IPI RzCmdStatus rz_plugins_parser_print_handler(RzCore *core, int argc, const
 RZ_IPI RzCmdStatus rz_open_close_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_open_close_all_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_plugins_io_print_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+RZ_IPI RzCmdStatus rz_open_list_ascii_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI int rz_cmd_open(void *data, const char *input);
 RZ_IPI RzCmdStatus rz_cmd_print_gadget_add_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_print_gadget_print_as_rizin_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_open.yaml
+++ b/librz/core/cmd_descs/cmd_open.yaml
@@ -27,3 +27,7 @@ commands:
       - RZ_OUTPUT_MODE_TABLE
       - RZ_OUTPUT_MODE_JSON
       - RZ_OUTPUT_MODE_QUIET
+  - name: o=
+    cname: open_list_ascii
+    summary: List opened files in ASCII-art bars
+    args: []

--- a/librz/core/cmd_descs/cmd_open.yaml
+++ b/librz/core/cmd_descs/cmd_open.yaml
@@ -31,3 +31,14 @@ commands:
     cname: open_list_ascii
     summary: List opened files in ASCII-art bars
     args: []
+  - name: oa
+    cname: open_arch_bits
+    summary: Specify <arch> and <bits> for the file <filename> or the current one if none is specified
+    args:
+      - name: arch
+        type: RZ_CMD_ARG_TYPE_STRING
+      - name: bits
+        type: RZ_CMD_ARG_TYPE_RZNUM
+      - name: filename
+        type: RZ_CMD_ARG_TYPE_FILE
+        optional: true

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -1004,7 +1004,6 @@ RZ_API void rz_bin_file_hash_free(RzBinFileHash *fhash);
 
 // binobject functions
 RZ_API int rz_bin_object_set_items(RzBinFile *binfile, RzBinObject *o);
-RZ_API bool rz_bin_object_delete(RzBin *bin, ut32 binfile_id);
 RZ_API ut64 rz_bin_object_addr_with_base(RzBinObject *o, ut64 addr);
 RZ_API ut64 rz_bin_object_get_vaddr(RzBinObject *o, ut64 paddr, ut64 vaddr);
 RZ_API const RzBinAddr *rz_bin_object_get_special_symbol(RzBinObject *o, RzBinSpecialSymbol sym);


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Try `oa`, it should work as before. Please note that `oa` is broken because e.g.
```
$ rizin -b 32 bins/mach0/fatmach0-3true
> oa x86 64
> oa x86 32
```
The first time you use `oa` it correctly switch to the 64bits sub-bin, the second time however things do not work well. I think fixing this properly without breaking many other things would require the famous "rzbin refactoring" with many unit tests... Completely out of scope for this small PR.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
