### PR TITLE
RzShell: convert wh command to shell/which

### DIFF
--- a/librz/core/cmd/cmd_shell.c
+++ b/librz/core/cmd/cmd_shell.c
@@ -215,3 +215,14 @@ RZ_IPI RzCmdStatus rz_cmd_shell_clear_handler(RzCore *core, int argc, const char
 	rz_cons_clear00();
 	return RZ_CMD_STATUS_OK;
 }
+
+RZ_IPI RzCmdStatus rz_cmd_shell_which_handler(RzCore *core, int argc, const char **argv) {
+	char *solved = rz_file_path(argv[1]);
+	if (!solved) {
+		RZ_LOG_ERROR("Could not get the full path of '%s'\n", argv[1]);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_cons_println(solved);
+	free(solved);
+	return RZ_CMD_STATUS_OK;
+}

--- a/librz/core/cmd/cmd_shell.c
+++ b/librz/core/cmd/cmd_shell.c
@@ -215,7 +215,7 @@ RZ_IPI RzCmdStatus rz_cmd_shell_clear_handler(RzCore *core, int argc, const char
 	rz_cons_clear00();
 	return RZ_CMD_STATUS_OK;
 }
-
+// which
 RZ_IPI RzCmdStatus rz_cmd_shell_which_handler(RzCore *core, int argc, const char **argv) {
 	char *solved = rz_file_path(argv[1]);
 	if (!solved) {

--- a/librz/core/cmd/cmd_shell.c
+++ b/librz/core/cmd/cmd_shell.c
@@ -215,6 +215,7 @@ RZ_IPI RzCmdStatus rz_cmd_shell_clear_handler(RzCore *core, int argc, const char
 	rz_cons_clear00();
 	return RZ_CMD_STATUS_OK;
 }
+
 // which
 RZ_IPI RzCmdStatus rz_cmd_shell_which_handler(RzCore *core, int argc, const char **argv) {
 	char *solved = rz_file_path(argv[1]);

--- a/librz/core/cmd/cmd_write.c
+++ b/librz/core/cmd/cmd_write.c
@@ -1110,20 +1110,6 @@ RZ_IPI int rz_w6_handler_old(void *data, const char *input) {
 	return 0;
 }
 
-RZ_IPI int rz_wh_handler_old(void *data, const char *input) {
-	char *p = strchr(input, ' ');
-	if (p) {
-		while (*p == ' ')
-			p++;
-		p = rz_file_path(p);
-		if (p) {
-			rz_cons_println(p);
-			free(p);
-		}
-	}
-	return 0;
-}
-
 RZ_IPI int rz_we_handler_old(void *data, const char *input) {
 	RzCore *core = (RzCore *)data;
 	ut64 addr = 0, len = 0, b_size = 0;
@@ -1946,9 +1932,6 @@ RZ_IPI int rz_cmd_write(void *data, const char *input) {
 		break;
 	case '6': // "w6"
 		rz_w6_handler_old(core, input + 1);
-		break;
-	case 'h': // "wh"
-		rz_wh_handler_old(core, input + 1);
 		break;
 	case 'e': // "we"
 		rz_we_handler_old(core, input + 1);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -5,7 +5,7 @@
 // modify it manually. Look at cmd_descs.yaml if you want to update commands.
 //
 
-#include <cmd_descs.h>
+# include <cmd_descs.h>
 
 static const RzCmdDescDetail system_details[2];
 static const RzCmdDescDetail system_to_cons_details[2];
@@ -342,6 +342,7 @@ static const RzCmdDescArg cmd_shell_cat_args[2];
 static const RzCmdDescArg cmd_shell_mv_args[3];
 static const RzCmdDescArg cmd_shell_mkdir_args[3];
 static const RzCmdDescArg cmd_shell_sort_args[2];
+static const RzCmdDescArg cmd_shell_which_args[2];
 
 static const RzCmdDescHelp escl__help = {
 	.summary = "Run given commands as in system(3) or shows command history",
@@ -6564,10 +6565,6 @@ static const RzCmdDescHelp write_base64_encode_help = {
 	.args = write_base64_encode_args,
 };
 
-static const RzCmdDescHelp wh_handler_old_help = {
-	.summary = "whereis/which shell command",
-};
-
 static const RzCmdDescHelp we_handler_old_help = {
 	.summary = "Extend write operations (insert bytes instead of replacing)",
 };
@@ -7546,6 +7543,7 @@ static const RzCmdDescHelp specifiers_help = {
 
 static const RzCmdDescHelp shell_help = {
 	.summary = "Common shell commands",
+	.sort_subcommands = true,
 };
 static const RzCmdDescDetailEntry cmd_shell_env_Examples_detail_entries[] = {
 	{ .text = "%", .arg_str = NULL, .comment = "List all environment variables" },
@@ -7811,6 +7809,20 @@ static const RzCmdDescArg cmd_shell_cls_args[] = {
 static const RzCmdDescHelp cmd_shell_cls_help = {
 	.summary = "clear",
 	.args = cmd_shell_cls_args,
+};
+
+static const RzCmdDescArg cmd_shell_which_args[] = {
+	{
+		.name = "command",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_shell_which_help = {
+	.summary = "Which shell command",
+	.args = cmd_shell_which_args,
 };
 
 RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
@@ -9240,9 +9252,6 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *write_base64_encode_cd = rz_cmd_desc_argv_new(core->rcmd, w6_cd, "w6e", rz_write_base64_encode_handler, &write_base64_encode_help);
 	rz_warn_if_fail(write_base64_encode_cd);
 
-	RzCmdDesc *wh_handler_old_cd = rz_cmd_desc_oldinput_new(core->rcmd, w_cd, "wh", rz_wh_handler_old, &wh_handler_old_help);
-	rz_warn_if_fail(wh_handler_old_cd);
-
 	RzCmdDesc *we_handler_old_cd = rz_cmd_desc_oldinput_new(core->rcmd, w_cd, "we", rz_we_handler_old, &we_handler_old_help);
 	rz_warn_if_fail(we_handler_old_cd);
 
@@ -9474,5 +9483,8 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *cmd_shell_cls_cd = rz_cmd_desc_argv_new(core->rcmd, shell_cd, "cls", rz_cmd_shell_clear_handler, &cmd_shell_cls_help);
 	rz_warn_if_fail(cmd_shell_cls_cd);
+
+	RzCmdDesc *cmd_shell_which_cd = rz_cmd_desc_argv_new(core->rcmd, shell_cd, "which", rz_cmd_shell_which_handler, &cmd_shell_which_help);
+	rz_warn_if_fail(cmd_shell_which_cd);
 	rz_cmd_batch_end(core->rcmd);
 }

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -5,7 +5,7 @@
 // modify it manually. Look at cmd_descs.yaml if you want to update commands.
 //
 
-# include <cmd_descs.h>
+#include <cmd_descs.h>
 
 static const RzCmdDescDetail system_details[2];
 static const RzCmdDescDetail system_to_cons_details[2];

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -5,9 +5,9 @@
 // modify it manually. Look at cmd_descs.yaml if you want to update commands.
 //
 
-# include <rz_cmd.h>
-# include <rz_core.h>
-# include <rz_util.h>
+#include <rz_cmd.h>
+#include <rz_core.h>
+#include <rz_util.h>
 
 // Command handlers, manually defined somewhere else
 RZ_IPI RzCmdStatus rz_system_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -5,9 +5,9 @@
 // modify it manually. Look at cmd_descs.yaml if you want to update commands.
 //
 
-#include <rz_cmd.h>
-#include <rz_core.h>
-#include <rz_util.h>
+# include <rz_cmd.h>
+# include <rz_core.h>
+# include <rz_util.h>
 
 // Command handlers, manually defined somewhere else
 RZ_IPI RzCmdStatus rz_system_handler(RzCore *core, int argc, const char **argv);
@@ -494,7 +494,6 @@ RZ_IPI RzCmdStatus rz_write_8_inc_handler(RzCore *core, int argc, const char **a
 RZ_IPI RzCmdStatus rz_write_8_dec_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_write_base64_decode_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_write_base64_encode_handler(RzCore *core, int argc, const char **argv);
-RZ_IPI int rz_wh_handler_old(void *data, const char *input);
 RZ_IPI int rz_we_handler_old(void *data, const char *input);
 RZ_IPI int rz_wu_handler_old(void *data, const char *input);
 RZ_IPI RzCmdStatus rz_write_random_handler(RzCore *core, int argc, const char **argv);
@@ -569,6 +568,7 @@ RZ_IPI RzCmdStatus rz_cmd_shell_pwd_handler(RzCore *core, int argc, const char *
 RZ_IPI RzCmdStatus rz_cmd_shell_sort_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_shell_clear_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_shell_clear_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_shell_which_handler(RzCore *core, int argc, const char **argv);
 
 // Main function that initialize the entire commands tree
 RZ_IPI void rzshell_cmddescs_init(RzCore *core);

--- a/librz/core/cmd_descs/cmd_descs.yaml
+++ b/librz/core/cmd_descs/cmd_descs.yaml
@@ -607,4 +607,5 @@ commands:
               with more than 1 block but less than 10, sorted decrementally by number of blocks.
   - name: shell
     summary: Common shell commands
+    sort_subcommands: true
     subcommands: cmd_shell

--- a/librz/core/cmd_descs/cmd_descs_generate.py
+++ b/librz/core/cmd_descs/cmd_descs_generate.py
@@ -182,8 +182,7 @@ class Arg:
         if self.type == "RZ_CMD_ARG_TYPE_CHOICES":
             return self.cd.cname + "_" + compute_cname(self.name) + "_choices"
 
-        raise Exception(
-            "_get_choices_cname should be called on ARG_TYPE_CHOICES only")
+        raise Exception("_get_choices_cname should be called on ARG_TYPE_CHOICES only")
 
     def _get_union(self):
         if self.type == "RZ_CMD_ARG_TYPE_CHOICES":
@@ -411,8 +410,7 @@ class CmdDesc:
 
     def _validate(self, c):
         if c.keys():
-            print("Command %s has unrecognized properties: %s." %
-                  (self.name, c.keys()))
+            print("Command %s has unrecognized properties: %s." % (self.name, c.keys()))
             sys.exit(1)
 
         if self.type not in CD_VALID_TYPES:
@@ -448,8 +446,7 @@ class CmdDesc:
             sys.exit(1)
 
         if self.cname in CmdDesc.c_cds:
-            print("Another command already has the same cname as %s" %
-                  (self.cname,))
+            print("Another command already has the same cname as %s" % (self.cname,))
             sys.exit(1)
 
         if (
@@ -490,8 +487,7 @@ class CmdDesc:
             out += "\n".join([d.get_cstructure() for d in self.details])
             out += DESC_HELP_DETAILS_TEMPLATE.format(
                 cname=CmdDesc.get_detail_cname(self),
-                details=",\n".join([str(d)
-                                    for d in self.details] + ["\t{ 0 },"]),
+                details=",\n".join([str(d) for d in self.details] + ["\t{ 0 },"]),
             )
             details_cname = CmdDesc.get_detail_cname(self)
         elif self.details_alias is not None:
@@ -499,8 +495,7 @@ class CmdDesc:
 
         if self.args is not None:
             out += "\n".join(
-                [a.get_cstructure()
-                 for a in self.args if a.get_cstructure() != ""]
+                [a.get_cstructure() for a in self.args if a.get_cstructure() != ""]
             )
             out += DESC_HELP_ARGS_TEMPLATE.format(
                 cname=CmdDesc.get_arg_cname(self),
@@ -518,8 +513,7 @@ class CmdDesc:
             else ""
         )
         args_str = (
-            DESC_HELP_TEMPLATE_ARGS_STR.format(
-                args_str=strornull(self.args_str))
+            DESC_HELP_TEMPLATE_ARGS_STR.format(args_str=strornull(self.args_str))
             if self.args_str is not None
             else ""
         )
@@ -530,7 +524,8 @@ class CmdDesc:
         )
         sort_subcommands = (
             DESC_HELP_TEMPLATE_SORT_SUBCOMMANDS.format(
-                sort_subcommands="true" if self.sort_subcommands else "false")
+                sort_subcommands="true" if self.sort_subcommands else "false"
+            )
             if self.sort_subcommands is not None
             else ""
         )
@@ -627,17 +622,14 @@ def createcd_typegroup(cd):
             cname=cd.cname,
             parent_cname=cd.parent.cname,
             name=strornull(cd.name),
-            handler_cname=(
-                cd.exec_cd and cd.exec_cd.get_handler_cname()) or "NULL",
-            help_cname_ref=(cd.exec_cd and "&" +
-                            cd.exec_cd.get_help_cname()) or "NULL",
+            handler_cname=(cd.exec_cd and cd.exec_cd.get_handler_cname()) or "NULL",
+            help_cname_ref=(cd.exec_cd and "&" + cd.exec_cd.get_help_cname()) or "NULL",
             group_help_cname=cd.get_help_cname(),
         )
         subcommands = (
             cd.exec_cd and cd.subcommands and cd.subcommands[1:]
         ) or cd.subcommands
-        formatted_string += "\n".join([createcd(child)
-                                       for child in subcommands or []])
+        formatted_string += "\n".join([createcd(child) for child in subcommands or []])
 
     return formatted_string
 
@@ -756,8 +748,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument(
     "--src-output-dir", type=str, required=False, help="Source output directory"
 )
-parser.add_argument("--output-dir", type=str,
-                    required=True, help="Output directory")
+parser.add_argument("--output-dir", type=str, required=True, help="Output directory")
 parser.add_argument(
     "yaml_files",
     type=argparse.FileType("r"),
@@ -797,8 +788,7 @@ handlers_decls = filter(
 )
 
 hf_text = CMDDESCS_H_TEMPLATE.format(
-    handlers_declarations="\n".join(
-        [handler2decl(t, h) for t, h in handlers_decls]),
+    handlers_declarations="\n".join([handler2decl(t, h) for t, h in handlers_decls]),
 )
 with open(os.path.join(args.output_dir, "cmd_descs.h"), "w", encoding="utf8") as f:
     f.write(hf_text)

--- a/librz/core/cmd_descs/cmd_shell.yaml
+++ b/librz/core/cmd_descs/cmd_shell.yaml
@@ -159,3 +159,9 @@ commands:
     cname: cmd_shell_cls
     handler: cmd_shell_clear
     args: []
+  - name: which
+    cname: cmd_shell_which
+    summary: Which shell command
+    args:
+      - name: command
+        type: RZ_CMD_ARG_TYPE_STRING

--- a/librz/core/cmd_descs/cmd_write.yaml
+++ b/librz/core/cmd_descs/cmd_write.yaml
@@ -259,10 +259,6 @@ commands:
           - text: w6e
             arg_str: " 48656c6c6f576f726c64"
             comment: Write the string "SGVsbG9Xb3JsZAo=" (without quotes) at current offset.
-  - name: wh
-    cname: wh_handler_old
-    summary: whereis/which shell command
-    type: RZ_CMD_DESC_TYPE_OLDINPUT
   - name: we
     cname: we_handler_old
     summary: Extend write operations (insert bytes instead of replacing)

--- a/test/db/cmd/cmd_w
+++ b/test/db/cmd/cmd_w
@@ -66,10 +66,10 @@ ESIz
 EOF
 RUN
 
-NAME=wh
+NAME=which
 FILE==
 CMDS=<<EOF
-wh rizin~?
+which rizin~?
 EOF
 EXPECT=<<EOF
 1


### PR DESCRIPTION
Moved `wh` to `which` under the `shell` group.
Also, make `shell` group automatically sorted.