### PR TITLE
Fix redefinition of RzCoreConfigGet

### DIFF
--- a/librz/include/rz_bind.h
+++ b/librz/include/rz_bind.h
@@ -24,7 +24,6 @@ typedef void (*RzCoreSeekArchBits)(void *core, ut64 addr);
 typedef int (*RzCoreConfigGetI)(void *core, const char *key);
 typedef const char *(*RzCoreConfigGet)(void *core, const char *key);
 typedef ut64 (*RzCoreNumGet)(void *core, const char *str);
-typedef const char *(*RzCoreConfigGet)(void *core, const char *key);
 typedef const RzList *(*RzCoreFlagsGet)(void *core, ut64 offset);
 
 typedef struct rz_core_bind_t {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

resolves the following warning
```
../librz/include/rz_bind.h:27:23: warning: redefinition of typedef 'RzCoreConfigGet' is a C11 feature [-Wtypedef-redefinition]
typedef const char *(*RzCoreConfigGet)(void *core, const char *key);
                      ^
../librz/include/rz_bind.h:25:23: note: previous definition is here
typedef const char *(*RzCoreConfigGet)(void *core, const char *key);
                      ^
1 warning generated.
```