### PR TITLE
Implement il_opdmp_append and fix windows warnings

### DIFF
--- a/librz/il/definitions/bitvector.c
+++ b/librz/il/definitions/bitvector.c
@@ -975,13 +975,13 @@ RZ_API bool rz_il_bv_lsb(RZ_NONNULL RzILBitVector *bv) {
  * \return ret bool, return true if bv is a zero bitvector, false if not
  */
 RZ_API bool rz_il_bv_is_zero_vector(RZ_NONNULL RzILBitVector *x) {
-	rz_return_val_if_fail(x, NULL);
+	rz_return_val_if_fail(x, false);
 
 	if (x->len <= 64) {
 		return x->bits.small_u == 0;
 	}
 
-	rz_return_val_if_fail(x->bits.large_a, NULL);
+	rz_return_val_if_fail(x->bits.large_a, false);
 
 	for (ut32 i = 0; i < x->_elem_len; ++i) {
 		if (x->bits.large_a[i] != 0) {
@@ -998,9 +998,9 @@ RZ_API bool rz_il_bv_is_zero_vector(RZ_NONNULL RzILBitVector *x) {
  * \return ret bool, return true if x <= y, else return false
  */
 RZ_API bool rz_il_bv_ule(RZ_NONNULL RzILBitVector *x, RZ_NONNULL RzILBitVector *y) {
-	rz_return_val_if_fail(x && y, NULL);
+	rz_return_val_if_fail(x && y, false);
 	// x > y ? return false : return true
-	return bv_unsigned_cmp(x, y) > 0 ? false : true;
+	return bv_unsigned_cmp(x, y) <= 0;
 }
 
 /**
@@ -1010,9 +1010,9 @@ RZ_API bool rz_il_bv_ule(RZ_NONNULL RzILBitVector *x, RZ_NONNULL RzILBitVector *
  * \return ret bool, return true if x <= y, else return false
  */
 RZ_API bool rz_il_bv_sle(RZ_NONNULL RzILBitVector *x, RZ_NONNULL RzILBitVector *y) {
-	rz_return_val_if_fail(x && y, NULL);
-	int x_msb = rz_il_bv_msb(x);
-	int y_msb = rz_il_bv_msb(y);
+	rz_return_val_if_fail(x && y, false);
+	bool x_msb = rz_il_bv_msb(x);
+	bool y_msb = rz_il_bv_msb(y);
 
 	if (x_msb && y_msb) {
 		return !rz_il_bv_ule(x, y);
@@ -1025,7 +1025,7 @@ RZ_API bool rz_il_bv_sle(RZ_NONNULL RzILBitVector *x, RZ_NONNULL RzILBitVector *
 	// if x_msb set, y_msb unset => x < y
 	// if x_msb unset, y_msb set => x > y
 	// x != y when reaches here
-	return x_msb ? true : false;
+	return x_msb;
 }
 
 /**

--- a/librz/il/rzil_export.c
+++ b/librz/il/rzil_export.c
@@ -312,7 +312,7 @@ static void il_opdmp_concat(RzILOp *op, RzStrBuf *sb, PJ *pj) {
 }
 
 static void il_opdmp_append(RzILOp *op, RzStrBuf *sb, PJ *pj) {
-	il_op_unimplemented("append");
+	il_op_param_2("append", op->op.append, x, y);
 }
 
 static void il_opdmp_load(RzILOp *op, RzStrBuf *sb, PJ *pj) {
@@ -426,89 +426,131 @@ static void il_op_resolve(RzILOp *op, RzStrBuf *sb, PJ *pj) {
 	}
 	switch (op->code) {
 	case RZIL_OP_VAR:
-		return il_opdmp_var(op, sb, pj);
+		il_opdmp_var(op, sb, pj);
+		return;
 	case RZIL_OP_UNK:
-		return il_opdmp_unk(op, sb, pj);
+		il_opdmp_unk(op, sb, pj);
+		return;
 	case RZIL_OP_ITE:
-		return il_opdmp_ite(op, sb, pj);
+		il_opdmp_ite(op, sb, pj);
+		return;
 	case RZIL_OP_B0:
-		return il_opdmp_bool_false(op, sb, pj);
+		il_opdmp_bool_false(op, sb, pj);
+		return;
 	case RZIL_OP_B1:
-		return il_opdmp_bool_true(op, sb, pj);
+		il_opdmp_bool_true(op, sb, pj);
+		return;
 	case RZIL_OP_INV:
-		return il_opdmp_bool_inv(op, sb, pj);
+		il_opdmp_bool_inv(op, sb, pj);
+		return;
 	case RZIL_OP_AND:
-		return il_opdmp_bool_and(op, sb, pj);
+		il_opdmp_bool_and(op, sb, pj);
+		return;
 	case RZIL_OP_OR:
-		return il_opdmp_bool_or(op, sb, pj);
+		il_opdmp_bool_or(op, sb, pj);
+		return;
 	case RZIL_OP_XOR:
-		return il_opdmp_bool_xor(op, sb, pj);
+		il_opdmp_bool_xor(op, sb, pj);
+		return;
 	case RZIL_OP_BITV:
-		return il_opdmp_bitv(op, sb, pj);
+		il_opdmp_bitv(op, sb, pj);
+		return;
 	case RZIL_OP_MSB:
-		return il_opdmp_msb(op, sb, pj);
+		il_opdmp_msb(op, sb, pj);
+		return;
 	case RZIL_OP_LSB:
-		return il_opdmp_lsb(op, sb, pj);
+		il_opdmp_lsb(op, sb, pj);
+		return;
 	case RZIL_OP_NEG:
-		return il_opdmp_neg(op, sb, pj);
+		il_opdmp_neg(op, sb, pj);
+		return;
 	case RZIL_OP_LOGNOT:
-		return il_opdmp_lognot(op, sb, pj);
+		il_opdmp_lognot(op, sb, pj);
+		return;
 	case RZIL_OP_ADD:
-		return il_opdmp_add(op, sb, pj);
+		il_opdmp_add(op, sb, pj);
+		return;
 	case RZIL_OP_SUB:
-		return il_opdmp_sub(op, sb, pj);
+		il_opdmp_sub(op, sb, pj);
+		return;
 	case RZIL_OP_MUL:
-		return il_opdmp_mul(op, sb, pj);
+		il_opdmp_mul(op, sb, pj);
+		return;
 	case RZIL_OP_DIV:
-		return il_opdmp_div(op, sb, pj);
+		il_opdmp_div(op, sb, pj);
+		return;
 	case RZIL_OP_SDIV:
-		return il_opdmp_sdiv(op, sb, pj);
+		il_opdmp_sdiv(op, sb, pj);
+		return;
 	case RZIL_OP_MOD:
-		return il_opdmp_mod(op, sb, pj);
+		il_opdmp_mod(op, sb, pj);
+		return;
 	case RZIL_OP_SMOD:
-		return il_opdmp_smod(op, sb, pj);
+		il_opdmp_smod(op, sb, pj);
+		return;
 	case RZIL_OP_LOGAND:
-		return il_opdmp_logand(op, sb, pj);
+		il_opdmp_logand(op, sb, pj);
+		return;
 	case RZIL_OP_LOGOR:
-		return il_opdmp_logor(op, sb, pj);
+		il_opdmp_logor(op, sb, pj);
+		return;
 	case RZIL_OP_LOGXOR:
-		return il_opdmp_logxor(op, sb, pj);
+		il_opdmp_logxor(op, sb, pj);
+		return;
 	case RZIL_OP_SHIFTR:
-		return il_opdmp_shiftr(op, sb, pj);
+		il_opdmp_shiftr(op, sb, pj);
+		return;
 	case RZIL_OP_SHIFTL:
-		return il_opdmp_shiftl(op, sb, pj);
+		il_opdmp_shiftl(op, sb, pj);
+		return;
 	case RZIL_OP_SLE:
-		return il_opdmp_sle(op, sb, pj);
+		il_opdmp_sle(op, sb, pj);
+		return;
 	case RZIL_OP_ULE:
-		return il_opdmp_ule(op, sb, pj);
+		il_opdmp_ule(op, sb, pj);
+		return;
 	case RZIL_OP_CAST:
-		return il_opdmp_cast(op, sb, pj);
+		il_opdmp_cast(op, sb, pj);
+		return;
 	case RZIL_OP_CONCAT:
-		return il_opdmp_concat(op, sb, pj);
+		il_opdmp_concat(op, sb, pj);
+		return;
 	case RZIL_OP_APPEND:
-		return il_opdmp_append(op, sb, pj);
+		il_opdmp_append(op, sb, pj);
+		return;
 	case RZIL_OP_LOAD:
-		return il_opdmp_load(op, sb, pj);
+		il_opdmp_load(op, sb, pj);
+		return;
 	case RZIL_OP_STORE:
-		return il_opdmp_store(op, sb, pj);
+		il_opdmp_store(op, sb, pj);
+		return;
 	case RZIL_OP_PERFORM:
-		return il_opdmp_perform(op, sb, pj);
+		il_opdmp_perform(op, sb, pj);
+		return;
 	case RZIL_OP_SET:
-		return il_opdmp_set(op, sb, pj);
+		il_opdmp_set(op, sb, pj);
+		return;
 	case RZIL_OP_JMP:
-		return il_opdmp_jmp(op, sb, pj);
+		il_opdmp_jmp(op, sb, pj);
+		return;
 	case RZIL_OP_GOTO:
-		return il_opdmp_goto(op, sb, pj);
+		il_opdmp_goto(op, sb, pj);
+		return;
 	case RZIL_OP_SEQ:
-		return il_opdmp_seq(op, sb, pj);
+		il_opdmp_seq(op, sb, pj);
+		return;
 	case RZIL_OP_BLK:
-		return il_opdmp_blk(op, sb, pj);
+		il_opdmp_blk(op, sb, pj);
+		return;
 	case RZIL_OP_REPEAT:
-		return il_opdmp_repeat(op, sb, pj);
+		il_opdmp_repeat(op, sb, pj);
+		return;
 	case RZIL_OP_BRANCH:
-		return il_opdmp_branch(op, sb, pj);
+		il_opdmp_branch(op, sb, pj);
+		return;
 	case RZIL_OP_INVALID:
-		return il_opdmp_invalid(op, sb, pj);
+		il_opdmp_invalid(op, sb, pj);
+		return;
 	default:
 		rz_warn_if_reached();
 		if (sb) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Implements `il_opdmp_append` which was not implemented in the PR https://github.com/rizinorg/rizin/commit/dfb69003669b6ddcf514340c24e4124c4b0b0550
- Fixes the following warnings:
```
D:/a/rizin/rizin/librz/il/definitions/bitvector.c(978): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'
D:/a/rizin/rizin/librz/il/definitions/bitvector.c(984): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'
D:/a/rizin/rizin/librz/il/definitions/bitvector.c(1001): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'
D:/a/rizin/rizin/librz/il/definitions/bitvector.c(1013): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'
D:/a/rizin/rizin/librz/il/rzil_export.c(429): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(431): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(433): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(435): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(437): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(439): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(441): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(443): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(445): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(447): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(449): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(451): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(453): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(455): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(457): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(459): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(461): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(463): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(465): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(467): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(469): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(471): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(473): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(475): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(477): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(479): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(481): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(483): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(485): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(487): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(489): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(491): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(493): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(495): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(497): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(499): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(501): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(503): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(505): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(507): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(509): warning C4098: 'il_op_resolve': 'void' function returning a value
D:/a/rizin/rizin/librz/il/rzil_export.c(511): warning C4098: 'il_op_resolve': 'void' function returning a value
```