### PR TITLE
 Revert OpenBSD `buildtype` back to `debugoptimized`

### DIFF
--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -21,7 +21,7 @@ tasks:
         cd rizin
         # Workaround to avoid running rz-pipe shm:// test due to memory constraints.
         rm -f test/db/archos/not-windows-any/cmd_pipe
-        meson --buildtype=debug --prefix=${HOME} build # buildtype temporarily set to debug to examine rare rz-test crash core dumps
+        meson --prefix=${HOME} build
         ninja -C build
     - install: |
         cd rizin
@@ -38,7 +38,7 @@ tasks:
         # https://todo.sr.ht/~sircmpwn/builds.sr.ht/274
         ln -s ${HOME}/rizin-testbins test/bins
         # Running the unit tests
-        MALLOC_OPTIONS=S ninja -C build test
+        ninja -C build test
     - test: |
         cd rizin
         export PATH=${HOME}/bin:/usr/local/bin:${PATH}
@@ -49,4 +49,4 @@ tasks:
         ln -s ${HOME}/rizin-testbins test/bins
         cd test
         # Running the unit tests
-        MALLOC_OPTIONS=S rz-test -L -o results.json
+        rz-test -L -o results.json

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -38,7 +38,7 @@ tasks:
         # https://todo.sr.ht/~sircmpwn/builds.sr.ht/274
         ln -s ${HOME}/rizin-testbins test/bins
         # Running the unit tests
-        ninja -C build test
+        MALLOC_OPTIONS=S ninja -C build test
     - test: |
         cd rizin
         export PATH=${HOME}/bin:/usr/local/bin:${PATH}
@@ -49,4 +49,4 @@ tasks:
         ln -s ${HOME}/rizin-testbins test/bins
         cd test
         # Running the unit tests
-        rz-test -L -o results.json
+        MALLOC_OPTIONS=S rz-test -L -o results.json


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

After #1910 we might as well see whether the OpenBSD UAFs are still there on an optimized build.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The OpenBSD build is green, and remains green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
