### PR TITLE
[FLIRT] Enforce arch match on sig, zfs output n of matches and added pac support & tests

### DIFF
--- a/librz/core/cmd/cmd_zign.c
+++ b/librz/core/cmd/cmd_zign.c
@@ -558,7 +558,7 @@ static int cmdFlirt(void *data, const char *input) {
 		RzListIter *iter;
 		RzList *files = rz_file_globsearch(input + 2, depth);
 		rz_list_foreach (files, iter, file) {
-			rz_sign_flirt_apply(core->analysis, file);
+			rz_sign_flirt_apply(core->analysis, file, NULL);
 		}
 		rz_list_free(files);
 		break;
@@ -1423,14 +1423,21 @@ RZ_IPI RzCmdStatus rz_zign_flirt_dump_handler(RzCore *core, int argc, const char
 }
 
 RZ_IPI RzCmdStatus rz_zign_flirt_scan_handler(RzCore *core, int argc, const char **argv) {
+	int new, old;
 	int depth = rz_config_get_i(core->config, "dir.depth");
-	char *file;
-	RzListIter *iter;
+	const char *arch = rz_config_get(core->config, "asm.arch");
+	char *file = NULL;
+	RzListIter *iter = NULL;
 	RzList *files = rz_file_globsearch(argv[1], depth);
+
+	old = rz_flag_count(core->flags, "flirt");
 	rz_list_foreach (files, iter, file) {
-		rz_sign_flirt_apply(core->analysis, file);
+		rz_sign_flirt_apply(core->analysis, file, arch);
 	}
 	rz_list_free(files);
+	new = rz_flag_count(core->flags, "flirt");
+
+	rz_cons_printf("Found %d FLIRT signatures via %s\n", new - old, argv[1]);
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/include/rz_flirt.h
+++ b/librz/include/rz_flirt.h
@@ -41,14 +41,14 @@ extern "C" {
 #define RZ_FLIRT_SIG_ARCH_SPARC     23 // SPARC
 #define RZ_FLIRT_SIG_ARCH_ALPHA     24 // DEC Alpha
 #define RZ_FLIRT_SIG_ARCH_HPPA      25 // Hewlett-Packard PA-RISC
-#define RZ_FLIRT_SIG_ARCH_H8500     26 // Hitachi H8/500
-#define RZ_FLIRT_SIG_ARCH_TRICORE   27 // Tasking Tricore
+#define RZ_FLIRT_SIG_ARCH_H8500     26 // Renesas (formerly Hitachi) H8/500
+#define RZ_FLIRT_SIG_ARCH_TRICORE   27 // Tricore
 #define RZ_FLIRT_SIG_ARCH_DSP56K    28 // Motorola DSP5600x
 #define RZ_FLIRT_SIG_ARCH_C166      29 // Siemens C166 family
 #define RZ_FLIRT_SIG_ARCH_ST20      30 // SGS-Thomson ST20
 #define RZ_FLIRT_SIG_ARCH_IA64      31 // Intel Itanium IA64
 #define RZ_FLIRT_SIG_ARCH_I960      32 // Intel 960
-#define RZ_FLIRT_SIG_ARCH_F2MC      33 // Fujistu F2MC-16
+#define RZ_FLIRT_SIG_ARCH_F2MC      33 // Fujitsu F2MC-16
 #define RZ_FLIRT_SIG_ARCH_TMS320C54 34 // Texas Instruments TMS320C54xx
 #define RZ_FLIRT_SIG_ARCH_TMS320C55 35 // Texas Instruments TMS320C55xx
 #define RZ_FLIRT_SIG_ARCH_TRIMEDIA  36 // Trimedia

--- a/librz/include/rz_flirt.h
+++ b/librz/include/rz_flirt.h
@@ -15,6 +15,69 @@ extern "C" {
 
 #define RZ_FLIRT_NAME_MAX 1024
 
+#define RZ_FLIRT_SIG_ARCH_386       0 // Intel 80x86
+#define RZ_FLIRT_SIG_ARCH_Z80       1 // 8085, Z80
+#define RZ_FLIRT_SIG_ARCH_I860      2 // Intel 860
+#define RZ_FLIRT_SIG_ARCH_8051      3 // 8051
+#define RZ_FLIRT_SIG_ARCH_TMS       4 // Texas Instruments TMS320C5x
+#define RZ_FLIRT_SIG_ARCH_6502      5 // 6502
+#define RZ_FLIRT_SIG_ARCH_PDP       6 // PDP11
+#define RZ_FLIRT_SIG_ARCH_68K       7 // Motoroal 680x0
+#define RZ_FLIRT_SIG_ARCH_JAVA      8 // Java
+#define RZ_FLIRT_SIG_ARCH_6800      9 // Motorola 68xx
+#define RZ_FLIRT_SIG_ARCH_ST7       10 // SGS-Thomson ST7
+#define RZ_FLIRT_SIG_ARCH_MC6812    11 // Motorola 68HC12
+#define RZ_FLIRT_SIG_ARCH_MIPS      12 // MIPS
+#define RZ_FLIRT_SIG_ARCH_ARM       13 // Advanced RISC Machines
+#define RZ_FLIRT_SIG_ARCH_TMSC6     14 // Texas Instruments TMS320C6x
+#define RZ_FLIRT_SIG_ARCH_PPC       15 // PowerPC
+#define RZ_FLIRT_SIG_ARCH_80196     16 // Intel 80196
+#define RZ_FLIRT_SIG_ARCH_Z8        17 // Z8
+#define RZ_FLIRT_SIG_ARCH_SH        18 // Renesas (formerly Hitachi) SuperH
+#define RZ_FLIRT_SIG_ARCH_NET       19 // Microsoft Visual Studio.Net
+#define RZ_FLIRT_SIG_ARCH_AVR       20 // Atmel 8-bit RISC processor(s)
+#define RZ_FLIRT_SIG_ARCH_H8        21 // Hitachi H8/300, H8/2000
+#define RZ_FLIRT_SIG_ARCH_PIC       22 // Microchip's PIC
+#define RZ_FLIRT_SIG_ARCH_SPARC     23 // SPARC
+#define RZ_FLIRT_SIG_ARCH_ALPHA     24 // DEC Alpha
+#define RZ_FLIRT_SIG_ARCH_HPPA      25 // Hewlett-Packard PA-RISC
+#define RZ_FLIRT_SIG_ARCH_H8500     26 // Hitachi H8/500
+#define RZ_FLIRT_SIG_ARCH_TRICORE   27 // Tasking Tricore
+#define RZ_FLIRT_SIG_ARCH_DSP56K    28 // Motorola DSP5600x
+#define RZ_FLIRT_SIG_ARCH_C166      29 // Siemens C166 family
+#define RZ_FLIRT_SIG_ARCH_ST20      30 // SGS-Thomson ST20
+#define RZ_FLIRT_SIG_ARCH_IA64      31 // Intel Itanium IA64
+#define RZ_FLIRT_SIG_ARCH_I960      32 // Intel 960
+#define RZ_FLIRT_SIG_ARCH_F2MC      33 // Fujistu F2MC-16
+#define RZ_FLIRT_SIG_ARCH_TMS320C54 34 // Texas Instruments TMS320C54xx
+#define RZ_FLIRT_SIG_ARCH_TMS320C55 35 // Texas Instruments TMS320C55xx
+#define RZ_FLIRT_SIG_ARCH_TRIMEDIA  36 // Trimedia
+#define RZ_FLIRT_SIG_ARCH_M32R      37 // Mitsubishi 32bit RISC
+#define RZ_FLIRT_SIG_ARCH_NEC_78K0  38 // NEC 78K0
+#define RZ_FLIRT_SIG_ARCH_NEC_78K0S 39 // NEC 78K0S
+#define RZ_FLIRT_SIG_ARCH_M740      40 // Mitsubishi 8bit
+#define RZ_FLIRT_SIG_ARCH_M7700     41 // Mitsubishi 16bit
+#define RZ_FLIRT_SIG_ARCH_ST9       42 // ST9+
+#define RZ_FLIRT_SIG_ARCH_FR        43 // Fujitsu FR Family
+#define RZ_FLIRT_SIG_ARCH_MC6816    44 // Motorola 68HC16
+#define RZ_FLIRT_SIG_ARCH_M7900     45 // Mitsubishi 7900
+#define RZ_FLIRT_SIG_ARCH_TMS320C3  46 // Texas Instruments TMS320C3
+#define RZ_FLIRT_SIG_ARCH_KR1878    47 // Angstrem KR1878
+#define RZ_FLIRT_SIG_ARCH_AD218X    48 // Analog Devices ADSP 218X
+#define RZ_FLIRT_SIG_ARCH_OAKDSP    49 // Atmel OAK DSP
+#define RZ_FLIRT_SIG_ARCH_TLCS900   50 // Toshiba TLCS-900
+#define RZ_FLIRT_SIG_ARCH_C39       51 // Rockwell C39
+#define RZ_FLIRT_SIG_ARCH_CR16      52 // NSC CR16
+#define RZ_FLIRT_SIG_ARCH_MN102L00  53 // Panasonic MN10200
+#define RZ_FLIRT_SIG_ARCH_TMS320C1X 54 // Texas Instruments TMS320C1x
+#define RZ_FLIRT_SIG_ARCH_NEC_V850X 55 // NEC V850 and V850ES/E1/E2
+#define RZ_FLIRT_SIG_ARCH_SCR_ADPT  56 // Processor module adapter for processor modules written in scripting languages
+#define RZ_FLIRT_SIG_ARCH_EBC       57 // EFI Bytecode
+#define RZ_FLIRT_SIG_ARCH_MSP430    58 // Texas Instruments MSP430
+#define RZ_FLIRT_SIG_ARCH_SPU       59 // Cell Broadband Engine Synergistic Processor Unit
+#define RZ_FLIRT_SIG_ARCH_DALVIK    60 // Android Dalvik Virtual Machine
+#define RZ_FLIRT_SIG_ARCH_ANY       UT32_MAX
+
 typedef struct RzFlirtTailByte {
 	ut16 offset; // from pattern_size + crc_length
 	ut8 value;
@@ -33,7 +96,7 @@ typedef struct RzFlirtModule {
 	ut32 crc16; // crc16 of the module after the pattern bytes
 	// until but not including the first variant byte
 	// this is a custom crc16
-	ut16 length; // total length of the module, should be < 0x8000
+	ut32 length; // total length of the module
 	RzList *public_functions;
 	RzList *tail_bytes;
 	RzList *referenced_functions;
@@ -45,13 +108,15 @@ typedef struct RzFlirtNode {
 	ut32 length; // length of the pattern
 	ut64 variant_mask; // this is the mask that will define variant bytes in ut8 *pattern_bytes
 	ut8 *pattern_bytes; // holds the pattern bytes of the signature
-	ut8 *variant_bool_array; // bool array, if true, byte in pattern_bytes is a variant byte
+	ut8 *pattern_mask; // bool array, if true, byte in pattern_bytes is a variant byte
 } RzFlirtNode;
 
-RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_buffer(RZ_NONNULL RzBuffer *buffer);
+RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_compressed_buffer(RZ_NONNULL RzBuffer *flirt_buf, ut32 expected_arch);
+RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_string_buffer(RZ_NONNULL RzBuffer *flirt_buf);
 RZ_API void rz_sign_flirt_node_free(RZ_NULLABLE RzFlirtNode *node);
 RZ_API ut8 rz_sign_flirt_get_version(RZ_NONNULL RzBuffer *buffer);
-RZ_API void rz_sign_flirt_apply(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL const char *flirt_file);
+RZ_API ut32 rz_sign_flirt_id_from_name(RZ_NONNULL const char *arch);
+RZ_API void rz_sign_flirt_apply(RzAnalysis *analysis, const char *flirt_file, const char *arch);
 
 #ifdef __cplusplus
 }

--- a/librz/signature/flirt.c
+++ b/librz/signature/flirt.c
@@ -358,9 +358,18 @@ RZ_API void rz_sign_flirt_node_free(RZ_NULLABLE RzFlirtNode *node) {
 	free(node);
 }
 
-/* Returns true if b matches the pattern in node. */
-/* Returns false otherwise. */
-static int is_pattern_matching(ut32 p_size, const ut8 *pattern, const ut8 *mask, const ut8 *b, ut32 b_size) {
+/**
+ * \brief Checks if a pattern does match the buffer data
+ *
+ * \param p_size   The pattern size
+ * \param pattern  The pattern to check agains
+ * \param mask     The pattern mask
+ * \param b        Buffer to check
+ * \param b_size   Size of the buffer to check
+ *
+ * \return True if pattern does match, false otherwise.
+ */
+static bool is_pattern_matching(ut32 p_size, const ut8 *pattern, const ut8 *mask, const ut8 *b, ut32 b_size) {
 	if (b_size < p_size) {
 		return false;
 	}
@@ -372,10 +381,18 @@ static int is_pattern_matching(ut32 p_size, const ut8 *pattern, const ut8 *mask,
 	return true;
 }
 
+/**
+ * \brief Checks if the module matches the buffer and renames the matched functions
+ *
+ * \param analysis  The RzAnalysis struct from where to fetch and modify the functions
+ * \param module    The FLIRT module to match against the buffer
+ * \param b         Buffer to check
+ * \param address   Function address
+ * \param buf_size  Size of the buffer to check
+ *
+ * \return True if pattern does match, false otherwise.
+ */
 static int module_match_buffer(RzAnalysis *analysis, const RzFlirtModule *module, ut8 *b, ut64 address, ut32 buf_size) {
-	/* Returns true if module matches b, according to the signatures infos.
-	 * Return false otherwise.
-	 * The buffer starts from the first byte after the pattern */
 	RzFlirtFunction *flirt_func;
 	RzAnalysisFunction *next_module_function;
 	RzListIter *tail_byte_it, *flirt_func_it;
@@ -393,8 +410,6 @@ static int module_match_buffer(RzAnalysis *analysis, const RzFlirtModule *module
 			}
 		}
 	}
-
-	// TODO referenced functions
 
 	rz_list_foreach (module->public_functions, flirt_func_it, flirt_func) {
 		// Once the first module function is found, we need to go through the module->public_functions
@@ -484,9 +499,14 @@ static int node_match_buffer(RzAnalysis *analysis, const RzFlirtNode *node, ut8 
 	return false;
 }
 
-/* Tries to find matching functions between the signature infos in root_node
- * and the analyzed functions in analysis
- * Returns false on error. */
+/**
+ * \brief Tries to find matching functions between the signature infos in root_node and the analyzed functions in analysis
+ *
+ * \param analysis   The analysis
+ * \param root_node  The root node
+ *
+ * \return False on error, otherwise true
+ */
 static bool node_match_functions(RzAnalysis *analysis, const RzFlirtNode *root_node) {
 	bool ret = true;
 
@@ -530,8 +550,8 @@ static bool node_match_functions(RzAnalysis *analysis, const RzFlirtNode *root_n
 }
 
 static ut8 read_module_tail_bytes(RzFlirtModule *module, ParseStatus *b) {
-	/*parses a module tail bytes*/
-	/*returns false on parsing error*/
+	/* parses a module tail bytes */
+	/* returns false on parsing error */
 	int i;
 	ut8 number_of_tail_bytes;
 	RzFlirtTailByte *tail_byte = NULL;
@@ -583,8 +603,8 @@ err_exit:
 }
 
 static ut8 read_module_referenced_functions(RzFlirtModule *module, ParseStatus *b) {
-	/*parses a module referenced functions*/
-	/*returns false on parsing error*/
+	/* parses a module referenced functions */
+	/* returns false on parsing error */
 	int i, j;
 	ut8 number_of_referenced_functions;
 	ut32 ref_function_name_length;
@@ -658,7 +678,7 @@ err_exit:
 
 static ut8 read_module_public_functions(RzFlirtModule *module, ParseStatus *b, ut8 *flags) {
 	/* Reads and set the public functions names and offsets associated within a module */
-	/*returns false on parsing error*/
+	/* returns false on parsing error */
 	int i;
 	ut16 offset = 0;
 	ut8 current_byte;
@@ -739,8 +759,8 @@ err_exit:
 }
 
 static ut8 parse_leaf(ParseStatus *b, RzFlirtNode *node) {
-	/*parses a signature leaf: modules with same leading pattern*/
-	/*returns false on parsing error*/
+	/* parses a signature leaf: modules with same leading pattern */
+	/* returns false on parsing error */
 	ut8 flags, crc_length;
 	ut16 crc16;
 	RzFlirtModule *module = NULL;
@@ -827,9 +847,9 @@ static ut8 read_node_length(RzFlirtNode *node, ParseStatus *b) {
 }
 
 static ut8 read_node_variant_mask(RzFlirtNode *node, ParseStatus *b) {
-	/*Reads and sets a node's variant bytes mask. This mask is then used to*/
-	/*read the non-variant bytes following.*/
-	/*returns false on parsing error*/
+	/* Reads and sets a node's variant bytes mask. This mask is then used to */
+	/* read the non-variant bytes following. */
+	/* returns false on parsing error */
 	if (node->length < 0x10) {
 		node->variant_mask = read_max_2_bytes(b);
 		if (is_status_err_or_eof(b)) {
@@ -851,8 +871,8 @@ static ut8 read_node_variant_mask(RzFlirtNode *node, ParseStatus *b) {
 }
 
 static bool read_node_bytes(RzFlirtNode *node, ParseStatus *b) {
-	/*Reads the node bytes, and also sets the variant bytes in pattern_mask*/
-	/*returns false on parsing error*/
+	/* Reads the node bytes, and also sets the variant bytes in pattern_mask */
+	/* returns false on parsing error */
 	int i;
 	ut64 current_mask_bit = 0;
 	if ((int)node->length < 0) {
@@ -880,8 +900,8 @@ static bool read_node_bytes(RzFlirtNode *node, ParseStatus *b) {
 }
 
 static ut8 parse_tree(ParseStatus *b, RzFlirtNode *root_node) {
-	/*parse a signature pattern tree or sub-tree*/
-	/*returns false on parsing error*/
+	/* parse a signature pattern tree or sub-tree */
+	/* returns false on parsing error */
 	RzFlirtNode *node = NULL;
 	int i, tree_nodes = read_multiple_bytes(b); // confirmed it's not read_byte(), XXX could it be read_max_2_bytes() ???
 	if (is_status_err_or_eof(b)) {

--- a/librz/signature/flirt.c
+++ b/librz/signature/flirt.c
@@ -106,69 +106,6 @@
 
 #define DEBUG 0
 
-/*arch flags*/
-#define IDASIG__ARCH__386       0 // Intel 80x86
-#define IDASIG__ARCH__Z80       1 // 8085, Z80
-#define IDASIG__ARCH__I860      2 // Intel 860
-#define IDASIG__ARCH__8051      3 // 8051
-#define IDASIG__ARCH__TMS       4 // Texas Instruments TMS320C5x
-#define IDASIG__ARCH__6502      5 // 6502
-#define IDASIG__ARCH__PDP       6 // PDP11
-#define IDASIG__ARCH__68K       7 // Motoroal 680x0
-#define IDASIG__ARCH__JAVA      8 // Java
-#define IDASIG__ARCH__6800      9 // Motorola 68xx
-#define IDASIG__ARCH__ST7       10 // SGS-Thomson ST7
-#define IDASIG__ARCH__MC6812    11 // Motorola 68HC12
-#define IDASIG__ARCH__MIPS      12 // MIPS
-#define IDASIG__ARCH__ARM       13 // Advanced RISC Machines
-#define IDASIG__ARCH__TMSC6     14 // Texas Instruments TMS320C6x
-#define IDASIG__ARCH__PPC       15 // PowerPC
-#define IDASIG__ARCH__80196     16 // Intel 80196
-#define IDASIG__ARCH__Z8        17 // Z8
-#define IDASIG__ARCH__SH        18 // Renesas (formerly Hitachi) SuperH
-#define IDASIG__ARCH__NET       19 // Microsoft Visual Studio.Net
-#define IDASIG__ARCH__AVR       20 // Atmel 8-bit RISC processor(s)
-#define IDASIG__ARCH__H8        21 // Hitachi H8/300, H8/2000
-#define IDASIG__ARCH__PIC       22 // Microchip's PIC
-#define IDASIG__ARCH__SPARC     23 // SPARC
-#define IDASIG__ARCH__ALPHA     24 // DEC Alpha
-#define IDASIG__ARCH__HPPA      25 // Hewlett-Packard PA-RISC
-#define IDASIG__ARCH__H8500     26 // Hitachi H8/500
-#define IDASIG__ARCH__TRICORE   27 // Tasking Tricore
-#define IDASIG__ARCH__DSP56K    28 // Motorola DSP5600x
-#define IDASIG__ARCH__C166      29 // Siemens C166 family
-#define IDASIG__ARCH__ST20      30 // SGS-Thomson ST20
-#define IDASIG__ARCH__IA64      31 // Intel Itanium IA64
-#define IDASIG__ARCH__I960      32 // Intel 960
-#define IDASIG__ARCH__F2MC      33 // Fujistu F2MC-16
-#define IDASIG__ARCH__TMS320C54 34 // Texas Instruments TMS320C54xx
-#define IDASIG__ARCH__TMS320C55 35 // Texas Instruments TMS320C55xx
-#define IDASIG__ARCH__TRIMEDIA  36 // Trimedia
-#define IDASIG__ARCH__M32R      37 // Mitsubishi 32bit RISC
-#define IDASIG__ARCH__NEC_78K0  38 // NEC 78K0
-#define IDASIG__ARCH__NEC_78K0S 39 // NEC 78K0S
-#define IDASIG__ARCH__M740      40 // Mitsubishi 8bit
-#define IDASIG__ARCH__M7700     41 // Mitsubishi 16bit
-#define IDASIG__ARCH__ST9       42 // ST9+
-#define IDASIG__ARCH__FR        43 // Fujitsu FR Family
-#define IDASIG__ARCH__MC6816    44 // Motorola 68HC16
-#define IDASIG__ARCH__M7900     45 // Mitsubishi 7900
-#define IDASIG__ARCH__TMS320C3  46 // Texas Instruments TMS320C3
-#define IDASIG__ARCH__KR1878    47 // Angstrem KR1878
-#define IDASIG__ARCH__AD218X    48 // Analog Devices ADSP 218X
-#define IDASIG__ARCH__OAKDSP    49 // Atmel OAK DSP
-#define IDASIG__ARCH__TLCS900   50 // Toshiba TLCS-900
-#define IDASIG__ARCH__C39       51 // Rockwell C39
-#define IDASIG__ARCH__CR16      52 // NSC CR16
-#define IDASIG__ARCH__MN102L00  53 // Panasonic MN10200
-#define IDASIG__ARCH__TMS320C1X 54 // Texas Instruments TMS320C1x
-#define IDASIG__ARCH__NEC_V850X 55 // NEC V850 and V850ES/E1/E2
-#define IDASIG__ARCH__SCR_ADPT  56 // Processor module adapter for processor modules written in scripting languages
-#define IDASIG__ARCH__EBC       57 // EFI Bytecode
-#define IDASIG__ARCH__MSP430    58 // Texas Instruments MSP430
-#define IDASIG__ARCH__SPU       59 // Cell Broadband Engine Synergistic Processor Unit
-#define IDASIG__ARCH__DALVIK    60 // Android Dalvik Virtual Machine
-
 /*file_types flags*/
 #define IDASIG__FILE__DOS_EXE_OLD 0x00000001
 #define IDASIG__FILE__DOS_COM_OLD 0x00000002
@@ -268,6 +205,32 @@ typedef struct parse_status_t {
 	bool error;
 	ut8 version;
 } ParseStatus;
+
+typedef struct arch_id_t {
+	const char *name;
+	ut32 id;
+} ArchId;
+
+const ArchId arch_id_map[18] = {
+	{ "6502", RZ_FLIRT_SIG_ARCH_6502 },
+	{ "arm", RZ_FLIRT_SIG_ARCH_ARM },
+	{ "avr", RZ_FLIRT_SIG_ARCH_AVR },
+	{ "cr16", RZ_FLIRT_SIG_ARCH_CR16 },
+	{ "dalvik", RZ_FLIRT_SIG_ARCH_DALVIK },
+	{ "ebc", RZ_FLIRT_SIG_ARCH_EBC },
+	{ "h8300", RZ_FLIRT_SIG_ARCH_H8 },
+	{ "hppa", RZ_FLIRT_SIG_ARCH_HPPA },
+	{ "java", RZ_FLIRT_SIG_ARCH_JAVA },
+	{ "mips", RZ_FLIRT_SIG_ARCH_MIPS },
+	{ "msp430", RZ_FLIRT_SIG_ARCH_MSP430 },
+	{ "pic", RZ_FLIRT_SIG_ARCH_PIC },
+	{ "ppc", RZ_FLIRT_SIG_ARCH_PPC },
+	{ "sh", RZ_FLIRT_SIG_ARCH_SH },
+	{ "sparc", RZ_FLIRT_SIG_ARCH_SPARC },
+	{ "tricore", RZ_FLIRT_SIG_ARCH_TRICORE },
+	{ "x86", RZ_FLIRT_SIG_ARCH_386 },
+	{ "z80", RZ_FLIRT_SIG_ARCH_Z80 }
+};
 
 #define is_status_err_or_eof(p) (p->eof || p->error)
 
@@ -369,7 +332,7 @@ static ut32 read_multiple_bytes(ParseStatus *b) {
 	return read_word(b);
 }
 
-static void module_free(RzFlirtModule *module) {
+void module_free(RzFlirtModule *module) {
 	if (!module) {
 		return;
 	}
@@ -388,15 +351,28 @@ RZ_API void rz_sign_flirt_node_free(RZ_NULLABLE RzFlirtNode *node) {
 	if (!node) {
 		return;
 	}
-	free(node->variant_bool_array);
+	free(node->pattern_mask);
 	free(node->pattern_bytes);
 	rz_list_free(node->module_list);
 	rz_list_free(node->child_list);
 	free(node);
 }
 
-static int module_match_buffer(RzAnalysis *analysis, const RzFlirtModule *module,
-	ut8 *b, ut64 address, ut32 buf_size) {
+/* Returns true if b matches the pattern in node. */
+/* Returns false otherwise. */
+static int is_pattern_matching(ut32 p_size, const ut8 *pattern, const ut8 *mask, const ut8 *b, ut32 b_size) {
+	if (b_size < p_size) {
+		return false;
+	}
+	for (ut32 i = 0; i < p_size; i++) {
+		if (!mask[i] && pattern[i] != b[i]) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static int module_match_buffer(RzAnalysis *analysis, const RzFlirtModule *module, ut8 *b, ut64 address, ut32 buf_size) {
 	/* Returns true if module matches b, according to the signatures infos.
 	 * Return false otherwise.
 	 * The buffer starts from the first byte after the pattern */
@@ -484,29 +460,12 @@ static int module_match_buffer(RzAnalysis *analysis, const RzFlirtModule *module
 	return true;
 }
 
-/* Returns true if b matches the pattern in node. */
-/* Returns false otherwise. */
-static int node_pattern_match(const RzFlirtNode *node, ut8 *b, int buf_size) {
-	int i;
-	if (buf_size < node->length) {
-		return false;
-	}
-	for (i = 0; i < node->length; i++) {
-		if (!node->variant_bool_array[i]) {
-			if (i < node->length && node->pattern_bytes[i] != b[i]) {
-				return false;
-			}
-		}
-	}
-	return true;
-}
-
 static int node_match_buffer(RzAnalysis *analysis, const RzFlirtNode *node, ut8 *b, ut64 address, ut32 buf_size, ut32 buf_idx) {
 	RzListIter *node_child_it, *module_it;
 	RzFlirtNode *child;
 	RzFlirtModule *module;
 
-	if (node_pattern_match(node, b + buf_idx, buf_size - buf_idx)) {
+	if (is_pattern_matching(node->length, node->pattern_bytes, node->pattern_mask, b + buf_idx, buf_size - buf_idx)) {
 		if (node->child_list) {
 			rz_list_foreach (node->child_list, node_child_it, child) {
 				if (node_match_buffer(analysis, child, b, address, buf_size, buf_idx + node->length)) {
@@ -892,7 +851,7 @@ static ut8 read_node_variant_mask(RzFlirtNode *node, ParseStatus *b) {
 }
 
 static bool read_node_bytes(RzFlirtNode *node, ParseStatus *b) {
-	/*Reads the node bytes, and also sets the variant bytes in variant_bool_array*/
+	/*Reads the node bytes, and also sets the variant bytes in pattern_mask*/
 	/*returns false on parsing error*/
 	int i;
 	ut64 current_mask_bit = 0;
@@ -903,11 +862,11 @@ static bool read_node_bytes(RzFlirtNode *node, ParseStatus *b) {
 	if (!(node->pattern_bytes = malloc(node->length))) {
 		return false;
 	}
-	if (!(node->variant_bool_array = malloc(node->length))) {
+	if (!(node->pattern_mask = malloc(node->length))) {
 		return false;
 	}
 	for (i = 0; i < node->length; i++, current_mask_bit >>= 1) {
-		node->variant_bool_array[i] = (bool)(node->variant_mask & current_mask_bit);
+		node->pattern_mask[i] = (bool)(node->variant_mask & current_mask_bit);
 		if (node->variant_mask & current_mask_bit) {
 			node->pattern_bytes[i] = 0x00;
 		} else {
@@ -1181,11 +1140,15 @@ static int parse_v10_header(RzBuffer *buf, idasig_v10_t *header) {
 
 /**
  * \brief Parses the RzBuffer containing a FLIRT structure and returns an RzFlirtNode
+ * 
+ * Parses the RzBuffer containing a FLIRT structure and returns an RzFlirtNode if expected_arch
+ * matches the id or RZ_FLIRT_SIG_ARCH_ANY is set.
  *
- * \param  flirt_buf The buffer to read
- * \return           Parsed FLIRT node
+ * \param  flirt_buf     The buffer to read
+ * \param  expected_arch The expected arch to be used for the buffer
+ * \return               Parsed FLIRT node
  */
-RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_buffer(RZ_NONNULL RzBuffer *flirt_buf) {
+RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_compressed_buffer(RZ_NONNULL RzBuffer *flirt_buf, ut32 expected_arch) {
 	rz_return_val_if_fail(flirt_buf, NULL);
 
 	ut8 *name = NULL;
@@ -1215,6 +1178,10 @@ RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_buffer(RZ_NONNULL RzBuffer *flirt
 	}
 
 	parse_v5_header(flirt_buf, header);
+
+	if (expected_arch != RZ_FLIRT_SIG_ARCH_ANY && header->arch != expected_arch) {
+		goto exit;
+	}
 
 	if (ps.version >= 6) {
 		if (!(v6_v7 = RZ_NEW0(idasig_v6_v7_t))) {
@@ -1344,22 +1311,61 @@ exit:
 }
 
 /**
+ * \brief Returns the FLIRT arch id from a given arch name
+ * Returns RZ_FLIRT_SIG_ARCH_ANY if name is not found.
+ *
+ * \param  arch The arch to convert to id 
+ * \return      The FLIRT arch id.
+ */
+RZ_API ut32 rz_sign_flirt_id_from_name(RZ_NONNULL const char *arch) {
+	rz_return_val_if_fail(RZ_STR_ISNOTEMPTY(arch), RZ_FLIRT_SIG_ARCH_ANY);
+
+	for (ut32 i = 0; i < RZ_ARRAY_SIZE(arch_id_map); ++i) {
+		if (!strcmp(arch, arch_id_map[i].name)) {
+			return arch_id_map[i].id;
+		}
+	}
+
+	return RZ_FLIRT_SIG_ARCH_ANY;
+}
+
+/**
  * \brief Parses the FLIRT file and applies the signatures
  *
  * \param analysis    The RzAnalysis structure 
  * \param flirt_file  The FLIRT file to parse
  */
-RZ_API void rz_sign_flirt_apply(RzAnalysis *analysis, const char *flirt_file) {
+RZ_API void rz_sign_flirt_apply(RzAnalysis *analysis, const char *flirt_file, const char *arch) {
 	rz_return_if_fail(analysis && RZ_STR_ISNOTEMPTY(flirt_file));
 	RzBuffer *flirt_buf = NULL;
 	RzFlirtNode *node = NULL;
+	ut32 id = RZ_FLIRT_SIG_ARCH_ANY;
+
+	const char *extension = rz_str_lchr(flirt_file, '.');
+	if (RZ_STR_ISEMPTY(extension) || (strcmp(extension, ".sig") != 0 && strcmp(extension, ".pac") != 0)) {
+		RZ_LOG_ERROR("FLIRT: unknown extension '%s'\n", extension);
+		return;
+	}
 
 	if (!(flirt_buf = rz_buf_new_slurp(flirt_file))) {
 		RZ_LOG_ERROR("FLIRT: Can't open %s\n", flirt_file);
 		return;
 	}
 
-	node = rz_sign_flirt_parse_buffer(flirt_buf);
+	if (RZ_STR_ISNOTEMPTY(arch)) {
+		ut32 id = rz_sign_flirt_id_from_name(arch);
+		if (id == RZ_FLIRT_SIG_ARCH_ANY) {
+			RZ_LOG_ERROR("FLIRT: unknown arch %s\n", arch);
+			return;
+		}
+	}
+
+	if (!strcmp(extension, ".pac")) {
+		node = rz_sign_flirt_parse_string_buffer(flirt_buf);
+	} else {
+		node = rz_sign_flirt_parse_compressed_buffer(flirt_buf, id);
+	}
+
 	rz_buf_free(flirt_buf);
 	if (node) {
 		if (!node_match_functions(analysis, node)) {

--- a/librz/signature/meson.build
+++ b/librz/signature/meson.build
@@ -1,5 +1,6 @@
 rz_sign_sources = [
    'flirt.c',
+   'pac.c',
    'zignature.c',
    'sign.c',
 ]

--- a/librz/signature/pac.c
+++ b/librz/signature/pac.c
@@ -29,7 +29,7 @@
  *    ^------- Function size (min 2 bytes, but can be bigger)
  * 
  * :0000@ Curl_gethostname
- * |   ||                `--- Symbol name
+ * |   ||     `-------------- Symbol name
  * |   |`-------------------- If set, then is local symbol
  * |   `--------------------- Symbol offset and type (: -> public)
  * `------------------------- Symbol type (: -> public, ^ -> reference)
@@ -48,6 +48,8 @@
 #else
 #define pac_dbg(...)
 #endif
+
+#define PAC_LINE_BUFFER_SIZE 1024
 
 extern void module_free(RzFlirtModule *module);
 
@@ -343,7 +345,7 @@ err:
  */
 RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_string_buffer(RZ_NONNULL RzBuffer *flirt_buf) {
 	rz_return_val_if_fail(flirt_buf, NULL);
-	char buffer[1024];
+	char buffer[PAC_LINE_BUFFER_SIZE];
 	const char *buffer_end = buffer + sizeof(buffer);
 	ut32 line_num = 1;
 	char *newline = NULL;

--- a/librz/signature/pac.c
+++ b/librz/signature/pac.c
@@ -1,0 +1,369 @@
+// SPDX-FileCopyrightText: 2021 RizinOrg <info@rizin.re>
+// SPDX-FileCopyrightText: 2021 deroad <wargio@libero.it>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_flirt.h>
+#include <rz_util.h>
+
+#if 0
+#define pac_dbg(...) eprintf(__VA_ARGS__)
+#else
+#define pac_dbg(...)
+#endif
+
+extern void module_free(RzFlirtModule *module);
+
+static inline ut8 decode_byte(char b) {
+	if (b >= '0' && b <= '9') {
+		return b - '0';
+	} else if (b >= 'A' && b <= 'F') {
+		return (b - 'A') + 10;
+	}
+	return (b - 'a') + 10;
+}
+
+static inline ut8 parse_byte(char high, char low) {
+	ut8 value = decode_byte(high) << 4;
+	return value | decode_byte(low);
+}
+
+static bool flirt_pat_parse_pattern_mask(const char *in_pattern, ut8 **out_bytes, ut8 **out_mask, ut32 *out_size) {
+	size_t length = 0;
+	ut8 *bytes = NULL, *mask = NULL;
+
+	if (RZ_STR_ISEMPTY(in_pattern)) {
+		return false;
+	}
+
+	length = strlen(in_pattern);
+	if (length & 1) {
+		return false;
+	}
+
+	ut32 n_bytes = length >> 1;
+
+	bytes = RZ_NEWS(ut8, n_bytes);
+	if (!bytes) {
+		RZ_LOG_ERROR("FLIRT: cannot allocate child bytes\n");
+		return false;
+	}
+
+	mask = RZ_NEWS(ut8, n_bytes);
+	if (!mask) {
+		RZ_LOG_ERROR("FLIRT: cannot allocate child mask\n");
+		goto err;
+	}
+
+	//eprintf("pattern: ");
+	for (ut32 i = 0; i < n_bytes; ++i) {
+		ut32 p = i << 1;
+		char high = in_pattern[p];
+		char low = in_pattern[p + 1];
+		if (IS_HEXCHAR(high) && IS_HEXCHAR(low)) {
+			bytes[i] = parse_byte(high, low);
+			mask[i] = 0;
+			//eprintf("%02X(%c%c) ", bytes[i], high, low);
+		} else if (high == '.' && low == '.') {
+			bytes[i] = 0;
+			mask[i] = 1;
+			//eprintf("..");
+		} else {
+			goto err;
+		}
+	}
+	//eprintf("\n");
+
+	*out_bytes = bytes;
+	*out_mask = mask;
+	*out_size = n_bytes;
+	return true;
+
+err:
+	free(mask);
+	free(bytes);
+	return false;
+}
+
+/**
+ * Expects one of these line formats and lines may end with '\r'
+ * 
+ * 4154554889FD534889F3C60700E8........C6441DFF004189C485C07515BE2E 07 FAEE 003B :0000@ Curl_gethostname ^000E gethostname ^0027 strchr ........4885C07403C600004489E05B5D415CC3
+ * 31C04885D2741F488D4417FF4839C77610EB1D0F1F4400004883E8014839C777 13 9867 0033 :0000 Curl_memrchr 
+ * # some comment line
+ * ---
+ * 
+ * The '---' are the pat file terminator
+ * Some files may contain comments using hashtag (#) as prefix
+ */
+static bool flirt_pat_parse_line(RzFlirtNode *root, RzStrBuf *sb, ut32 line_num) {
+	RzFlirtNode *child = NULL;
+	RzFlirtModule *module = NULL;
+	char *tmp_tok = NULL;
+
+	int line_len = rz_strbuf_length(sb);
+	char *line = rz_strbuf_get(sb);
+	if (RZ_STR_ISEMPTY(line) || line_len < 1) {
+		RZ_LOG_WARN("FLIRT: line %u is empty\n", line_num);
+		return true;
+	} else if (!strncmp(line, "---", strlen("---"))) {
+		return false;
+	} else if (line[0] == '#') {
+		return true;
+	}
+
+	if (line[line_len - 1] == '\r') {
+		line_len--;
+		line[line_len] = 0;
+		if (*line || line_len < 1) {
+			RZ_LOG_WARN("FLIRT: line %u is empty\n", line_num);
+			return true;
+		}
+	}
+
+	RzList *tokens = rz_str_split_list(line, " ", 0);
+	if (rz_list_empty(tokens)) {
+		RZ_LOG_ERROR("FLIRT: cannot tokenize line %u\n", line_num);
+		goto err;
+	}
+
+	child = RZ_NEW0(RzFlirtNode);
+	if (!child) {
+		RZ_LOG_ERROR("FLIRT: cannot allocate child node\n");
+		goto err;
+	}
+
+	child->module_list = rz_list_newf((RzListFree)module_free);
+	if (!child->module_list) {
+		RZ_LOG_ERROR("FLIRT: cannot allocate child module list\n");
+		goto err;
+	}
+
+	module = RZ_NEW0(RzFlirtModule);
+	if (!module || !rz_list_append(child->module_list, module)) {
+		free(module);
+		RZ_LOG_ERROR("FLIRT: cannot allocate or append child module\n");
+		goto err;
+	}
+
+	module->public_functions = rz_list_newf((RzListFree)free);
+	if (!module->public_functions) {
+		RZ_LOG_ERROR("FLIRT: cannot allocate child module public function list\n");
+		goto err;
+	}
+
+	module->referenced_functions = rz_list_newf((RzListFree)free);
+	if (!module->public_functions) {
+		RZ_LOG_ERROR("FLIRT: cannot allocate child module referenced function list\n");
+		goto err;
+	}
+
+	// Pattern with mask
+	// 4154554889FD534889F3C60700E8........C6441DFF004189C485C07515BE2E
+	// 31C04885D2741F488D4417FF4839C77610EB1D0F1F4400004883E8014839C777
+	tmp_tok = (char *)rz_list_pop_head(tokens);
+	if (!flirt_pat_parse_pattern_mask(tmp_tok, &child->pattern_bytes, &child->pattern_mask, &child->length)) {
+		RZ_LOG_ERROR("FLIRT: invalid pattern with mask (%s) at line %u\n", tmp_tok, line_num);
+		goto err;
+	}
+	pac_dbg("pattern: %s\n", tmp_tok);
+
+	// CRC16 length
+	// [...] 07
+	// [...] 13
+	tmp_tok = (char *)rz_list_pop_head(tokens);
+	if (tmp_tok && strlen(tmp_tok) == 2 && IS_HEXCHAR(tmp_tok[0]) && IS_HEXCHAR(tmp_tok[1])) {
+		module->crc_length = parse_byte(tmp_tok[0], tmp_tok[1]);
+	} else {
+		RZ_LOG_ERROR("FLIRT: invalid crc16 length (%s) at line %u\n", tmp_tok, line_num);
+		goto err;
+	}
+	pac_dbg("crc16 length: %s\n", tmp_tok);
+
+	// CRC16 value
+	// [...] FAEE
+	// [...] 9867
+	tmp_tok = (char *)rz_list_pop_head(tokens);
+	if (tmp_tok && strlen(tmp_tok) == 4 &&
+		IS_HEXCHAR(tmp_tok[0]) && IS_HEXCHAR(tmp_tok[1]) &&
+		IS_HEXCHAR(tmp_tok[2]) && IS_HEXCHAR(tmp_tok[3])) {
+		module->crc16 = parse_byte(tmp_tok[0], tmp_tok[1]) << 8;
+		module->crc16 |= parse_byte(tmp_tok[2], tmp_tok[3]);
+	} else {
+		RZ_LOG_ERROR("FLIRT: invalid crc16 value (%s) at line %u\n", tmp_tok, line_num);
+		goto err;
+	}
+	pac_dbg("crc16: %s\n", tmp_tok);
+
+	// function size (min 2 bytes, but can be bigger)
+	// [...] 003B
+	// [...] 0033
+	tmp_tok = (char *)rz_list_pop_head(tokens);
+	if (!tmp_tok || strlen(tmp_tok) < 4 || !(module->length = strtol(tmp_tok, NULL, 16))) {
+		RZ_LOG_ERROR("FLIRT: invalid function size (%s) at line %u\n", tmp_tok, line_num);
+		goto err;
+	}
+	pac_dbg("function size: %s\n", tmp_tok);
+
+	// symbols
+	// :0000@ Curl_gethostname ^000E gethostname ^0027 strchr
+	// :0000 Curl_memrchr
+	while ((tmp_tok = (char *)rz_list_pop_head(tokens)) && RZ_STR_ISNOTEMPTY(tmp_tok)) {
+		RzList *to_append = NULL;
+		ut32 len_tok = strlen(tmp_tok);
+		ut32 offset = 0;
+		bool is_local = false;
+		if (len_tok > 0 && !(len_tok & 1) && (IS_HEXCHAR(tmp_tok[0]) || tmp_tok[0] == '.')) {
+			// it's trailer bytes
+			break;
+		}
+
+		if (len_tok >= 6 && tmp_tok[0] == ':' && tmp_tok[len_tok - 1] == '@') {
+			// :0000@ -> local function (handling it as public)
+			tmp_tok[len_tok - 1] = 0;
+			offset = strtol(tmp_tok + 1, NULL, 16);
+			is_local = true;
+			to_append = module->public_functions;
+			tmp_tok[len_tok - 1] = '@';
+		} else if (len_tok >= 5 && tmp_tok[0] == ':') {
+			// :0000 -> public function
+			offset = strtol(tmp_tok + 1, NULL, 16);
+			to_append = module->public_functions;
+		} else if (len_tok == 5 && tmp_tok[0] == '^') {
+			// ^0000 -> reference function
+			offset = strtol(tmp_tok + 1, NULL, 16);
+			to_append = module->referenced_functions;
+		} else {
+			RZ_LOG_ERROR("FLIRT: invalid symbol offset (%.10s len %u) at line %u\n", tmp_tok, len_tok, line_num);
+			goto err;
+		}
+
+		tmp_tok = (char *)rz_list_pop_head(tokens);
+		if (RZ_STR_ISEMPTY(tmp_tok)) {
+			RZ_LOG_ERROR("FLIRT: empty symbol name at line %u\n", line_num);
+			goto err;
+		}
+		len_tok = strlen(tmp_tok);
+
+		RzFlirtFunction *function = RZ_NEW0(RzFlirtFunction);
+		if (!function || !rz_list_append(to_append, function)) {
+			free(function);
+			RZ_LOG_ERROR("FLIRT: cannot allocate or append RzFlirtFunction\n");
+			goto err;
+		}
+		function->is_local = is_local;
+		function->offset = offset;
+		strncpy(function->name, tmp_tok, RZ_MIN(len_tok, RZ_FLIRT_NAME_MAX - 1));
+		pac_dbg("%s function: %04x %s\n", to_append == module->referenced_functions ? "ref" : function->is_local ? ("loc" : "pub"), offset, tmp_tok);
+	}
+
+	if (RZ_STR_ISNOTEMPTY(tmp_tok) && (IS_HEXCHAR(tmp_tok[0]) || tmp_tok[0] == '.')) {
+		size_t len_tok = strlen(tmp_tok);
+
+		module->tail_bytes = rz_list_newf((RzListFree)free);
+		if (!module->public_functions) {
+			RZ_LOG_ERROR("FLIRT: cannot allocate child module tail bytes list\n");
+			goto err;
+		}
+
+		for (ut32 i = 0, o = 0; i < len_tok; i += 2, o++) {
+			if (tmp_tok[i] == '.' && tmp_tok[i + 1] == '.') {
+				continue;
+			} else if (!IS_HEXCHAR(tmp_tok[i]) || !IS_HEXCHAR(tmp_tok[i + 1])) {
+				RZ_LOG_ERROR("FLIRT: expecting tail byte at line %u but got (%s)\n", line_num, tmp_tok + i);
+				goto err;
+			}
+			ut8 byte = parse_byte(tmp_tok[i], tmp_tok[i + 1]);
+
+			RzFlirtTailByte *tail = RZ_NEW0(RzFlirtTailByte);
+			if (!tail || !rz_list_append(module->tail_bytes, tail)) {
+				free(tail);
+				RZ_LOG_ERROR("FLIRT: cannot allocate or append RzFlirtTailByte\n");
+				goto err;
+			}
+
+			tail->offset = o;
+			tail->value = byte;
+		}
+		pac_dbg("tail: %s\n", tmp_tok);
+	}
+
+	rz_list_free(tokens);
+	if (!rz_list_append(root->child_list, child)) {
+		RZ_LOG_ERROR("FLIRT: cannot append child to root\n");
+		goto err;
+	}
+
+	return true;
+
+err:
+	rz_sign_flirt_node_free(child);
+	rz_list_free(tokens);
+	return false;
+}
+
+/**
+ * \brief Parses the RzBuffer containing a FLIRT signature in string format and returns an RzFlirtNode
+ * 
+ * \param  flirt_buf     The buffer to read
+ * \return               Parsed FLIRT node
+ */
+RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_string_buffer(RZ_NONNULL RzBuffer *flirt_buf) {
+	rz_return_val_if_fail(flirt_buf, NULL);
+	char buffer[1024];
+	const char *buffer_end = buffer + sizeof(buffer);
+	ut32 line_num = 1;
+	char *newline = NULL;
+	st64 read = 0;
+	RzFlirtNode *root = NULL;
+	RzStrBuf *line = NULL;
+
+	root = RZ_NEW0(RzFlirtNode);
+	if (!root) {
+		RZ_LOG_ERROR("FLIRT: cannot allocate root node\n");
+		return NULL;
+	}
+	root->child_list = rz_list_newf((RzListFree)rz_sign_flirt_node_free);
+
+	line = rz_strbuf_new("");
+	if (!line) {
+		rz_sign_flirt_node_free(root);
+		RZ_LOG_ERROR("FLIRT: cannot allocate line buffer\n");
+		return NULL;
+	}
+
+	do {
+		if (newline) {
+			char *p = newline + 1;
+			pac_dbg("%05u: %s\n", line_num, rz_strbuf_get(line));
+			bool parsed = flirt_pat_parse_line(root, line, line_num);
+			rz_strbuf_fini(line);
+			rz_strbuf_init(line);
+			if (!parsed) {
+				break;
+			}
+			line_num++;
+			if (p < buffer_end && *p) {
+				if ((newline = strchr(p, '\n'))) {
+					newline[0] = 0;
+				}
+				rz_strbuf_append(line, p);
+			}
+			continue;
+		}
+		memset(buffer, 0, sizeof(buffer));
+		if ((read = rz_buf_read(flirt_buf, (ut8 *)buffer, sizeof(buffer) - 1)) < 1) {
+			break;
+		}
+		if ((newline = strchr(buffer, '\n'))) {
+			newline[0] = 0;
+		}
+		rz_strbuf_append(line, buffer);
+	} while (true);
+
+	if (rz_strbuf_length(line) > 0) {
+		flirt_pat_parse_line(root, line, line_num);
+	}
+
+	rz_strbuf_free(line);
+	return root;
+}

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -692,6 +692,7 @@ NAME=aa ; zfs libc-v7.sig
 FILE=bins/elf/analysis/pid_stripped
 CMDS=aa ; zfs bins/other/sigs/libc-v7.sig
 EXPECT=<<EOF
+Found 1 FLIRT signatures via bins/other/sigs/libc-v7.sig
 EOF
 RUN
 
@@ -709,6 +710,7 @@ ARGS=-ecfg.oldshell=false
 FILE=bins/elf/analysis/pid_stripped
 CMDS=s 0x4e2420 ; af ; s 0x4e25c7 ; af ; zfs bins/other/sigs/libc-v7.sig ; afl ~4e2420
 EXPECT=<<EOF
+Found 1 FLIRT signatures via bins/other/sigs/libc-v7.sig
 0x004e2420   40 664          flirt.__libc_start_main
 EOF
 RUN
@@ -724,6 +726,7 @@ zfs bins/other/sigs/libc-v7.sig
 afl~4e2420
 EOF
 EXPECT=<<EOF
+Found 1 FLIRT signatures via bins/other/sigs/libc-v7.sig
 0x004e2420   40 664          flirt.__libc_start_main
 EOF
 RUN
@@ -732,6 +735,7 @@ NAME=aa ; zfs libc-v10.sig
 FILE=bins/elf/analysis/pid_stripped
 CMDS=aa ; zfs bins/other/sigs/libc-v10.sig
 EXPECT=<<EOF
+Found 1 FLIRT signatures via bins/other/sigs/libc-v10.sig
 EOF
 RUN
 
@@ -749,6 +753,7 @@ ARGS=-ecfg.oldshell=false
 FILE=bins/elf/analysis/pid_stripped
 CMDS=s 0x4e2420 ; af ; s 0x4e25c7 ; af ; zfs bins/other/sigs/libc-v10.sig ; afl ~4e2420
 EXPECT=<<EOF
+Found 1 FLIRT signatures via bins/other/sigs/libc-v10.sig
 0x004e2420   40 664          flirt.__libc_start_main
 EOF
 RUN
@@ -764,6 +769,7 @@ zfs bins/other/sigs/libc-v10.sig
 afl~4e2420
 EOF
 EXPECT=<<EOF
+Found 1 FLIRT signatures via bins/other/sigs/libc-v10.sig
 0x004e2420   40 664          flirt.__libc_start_main
 EOF
 RUN
@@ -1778,5 +1784,37 @@ EOF
 EXPECT=<<EOF
 int sym.new_function_name(int NEWARGC, char ** NEWARGV);
 sym.new_function_name
+EOF
+RUN
+
+NAME=FLIRT apply pac signature
+FILE=bins/flirt/elf-x86/curl-example
+CMDS=<<EOF
+aaa
+zfs bins/flirt/elf-x86/libcurl.a.pac
+EOF
+EXPECT=<<EOF
+Found 207 FLIRT signatures via bins/flirt/elf-x86/libcurl.a.pac
+EOF
+RUN
+
+NAME=FLIRT apply pac signature
+FILE=bins/flirt/elf-x86/curl-example
+CMDS=<<EOF
+aaa
+zfs bins/flirt/elf-x86/libcurl.a.sig
+EOF
+EXPECT=<<EOF
+Found 206 FLIRT signatures via bins/flirt/elf-x86/libcurl.a.sig
+EOF
+RUN
+
+NAME=FLIRT dump pac signature
+FILE==
+CMDS=<<EOF
+zfd bins/flirt/elf-x86/libcurl.a.pac~?
+EOF
+EXPECT=<<EOF
+166
 EOF
 RUN

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -49,6 +49,7 @@ if get_option('enable_tests')
     'event',
     'file',
     'flags',
+    'flirt',
     'glob',
     'graph',
     'hash',

--- a/test/unit/test_flirt.c
+++ b/test/unit/test_flirt.c
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2021 RizinOrg <info@rizin.re>
+// SPDX-FileCopyrightText: 2021 deroad <wargio@libero.it>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <math.h>
+#include <rz_flirt.h>
+#include <rz_util.h>
+#include "minunit.h"
+
+#define test_flirt_pat_run(name) mu_run_test(test_flirt_pat_##name)
+#define test_flirt_pat_def(name, n_childs, string) \
+	bool test_flirt_pat_##name(void) { \
+		RzFlirtNode *node = NULL; \
+		RzBuffer *buffer = rz_buf_new_with_string(string); \
+		mu_assert_notnull(buffer, "buffer is not null (" #name ")"); \
+		node = rz_sign_flirt_parse_string_buffer(buffer); \
+		mu_assert_notnull(node, "node is not null (" #name ")"); \
+		mu_assert_eq(rz_list_length(node->child_list), n_childs, "node contains one child (" #name ")"); \
+		rz_sign_flirt_node_free(node); \
+		mu_end; \
+	}
+
+test_flirt_pat_def(parse_signature, 1,
+	"31C04885D2741F488D4417FF4839C77610EB1D0F1F4400004883E8014839C777 13 9867 0033 :0000 Curl_memrchr \n"
+	"---\n");
+
+test_flirt_pat_def(parse_comment, 0,
+	"#some comment here\n"
+	"---\n");
+
+test_flirt_pat_def(parse_trailer, 1,
+	"4154554889FD534889F3C60700E8........C6441DFF004189C485C07515BE2E 07 FAEE 003B :0000 Curl_gethostname ^000E gethostname ^0027 strchr ........4885C07403C600004489E05B5D415CC3\n"
+	"---\n");
+
+test_flirt_pat_def(parse_large_function, 1,
+	"3c14a918d430e77901b6ed5ffc95ba75102562772b73fb79c65537a5765f9018 ff 3041 2989a :0000 foo\n"
+	"---\n");
+
+test_flirt_pat_def(parse_large_offset, 1,
+	"3c14a918d430e77901b6ed5ffc95ba75102562772b73fb79c65537a5765f9018 ff 3041 2989a :0000 ecp_nistz256_precomputed :25100 ecp_nistz256_mul_by_2 :251a0 ecp_nistz256_div_by_2 :25280 ecp_nistz256_mul_by_3 :25380 ecp_nistz256_add :25420 ecp_nistz256_sub :254c0 ecp_nistz256_neg :25560 ecp_nistz256_ord_mul_mont :258e0 ecp_nistz256_ord_sqr_mont :26300 ecp_nistz256_to_mont :26340 ecp_nistz256_mul_mont :26640 ecp_nistz256_sqr_mont :26ce0 ecp_nistz256_from_mont :26e00 ecp_nistz256_scatter_w5 :26e60 ecp_nistz256_gather_w5 :26fc0 ecp_nistz256_scatter_w7 :27000 ecp_nistz256_gather_w7 :272a0 ecp_nistz256_avx2_gather_w7 :27580 ecp_nistz256_point_double :278c0 ecp_nistz256_point_add :28020 ecp_nistz256_point_add_affine\n"
+	"---\n");
+
+test_flirt_pat_def(parse_multiline, 5,
+	"31C083FF7F77114863FF488D05........0FB6043883E008C30F1F8000000000 0D 8C27 0149 :0000 Curl_isspace :0020 Curl_isdigit :0040 Curl_isalnum :0060 Curl_isxdigit :0080 Curl_isgraph :00B0 Curl_isprint :00D0 Curl_isalpha :00F0 Curl_isupper :0110 Curl_islower :0130 Curl_iscntrl ........0FB6043883E004C30F1F800000000031C083FF7F77114863FF488D05........0FB6043883E007C30F1F800000000031C083FF7F77114863FF488D05........0FB6043883E044C30F1F800000000083FF7F771B83FF2074164863FF488D05........0FB6043883E05FC30F1F400031C0C366662E0F1F840000000000669031C083FF7F77114863FF488D05........0FB6043883E05FC30F1F800000000031C083FF7F77114863FF488D05........0FB6043883E003C30F1F800000000031C083FF7F77114863FF488D05........0FB6043883E001C30F1F800000000031C083FF7F77114863FF488D05........0FB6043883E002C30F1F800000000031C083FF7F77114863FF488D05........0FB6043883E020C3\n"
+	"0FB707C366662E0F1F840000000000908B07C366662E0F1F8400000000006690 08 DB34 0028 :0000 Curl_read16_le :0010 Curl_read32_le :0020 Curl_read16_be \n"
+	"41564531F641554989FD41545589F5534889D30F1F4400004889DA89EE4C89EF 01 3E9B 006C :0000 Curl_get_line ^0021 fgets ^0031 strlen ........4989C44885C074334889C7E8........4885C0740841807C04FF0A740E41BE01000000EBCE660F1F4400004584F6740B4531F6EBBE660F1F4400005B4C89E05D415C415D415EC3\n"
+	"4154554889FD534889F3C60700E8........C6441DFF004189C485C07515BE2E 07 FAEE 003B :0000 Curl_gethostname ^000E gethostname ^0027 strchr ........4885C07403C600004489E05B5D415CC3\n"
+	"31C04885D2741F488D4417FF4839C77610EB1D0F1F4400004883E8014839C777 13 9867 0033 :0000 Curl_memrchr \n"
+	"---\n");
+
+int all_tests() {
+	test_flirt_pat_run(parse_signature);
+	test_flirt_pat_run(parse_comment);
+	test_flirt_pat_run(parse_trailer);
+	test_flirt_pat_run(parse_large_function);
+	test_flirt_pat_run(parse_large_offset);
+	test_flirt_pat_run(parse_multiline);
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests)


### PR DESCRIPTION
Tests

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Support `.pac` FLIRT format
- Output number of matches when `zfs` is called
- Enforces the arch type when calling `zfs` with a `.sig` FLIRT file

**Test plan**

Green tests

**Closing issues**

Related to #817 request
