### PR TITLE
Fix adding comments in visual mode using `;`

### DIFF
--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -3271,7 +3271,7 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 			rz_cons_flush();
 			rz_cons_set_raw(false);
 			rz_line_set_prompt("comment: ");
-			strcpy(buf, "\"CC ");
+			strcpy(buf, "CC ");
 			i = strlen(buf);
 			if (rz_cons_fgets(buf + i, sizeof(buf) - i, 0, NULL) > 0) {
 				ut64 addr, orig;
@@ -3280,35 +3280,25 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 					addr += core->print->cur;
 					rz_core_seek(core, addr, true);
 				}
-				if (!strcmp(buf + i, "-")) {
-					strcpy(buf, "CC-");
-				} else {
-					switch (buf[i]) {
-					case '-':
-						memcpy(buf, "\"CC-\x00", 5);
-						break;
-					case '!':
-						memcpy(buf, "\"CC!\x00", 5);
-						break;
-					default:
-						memcpy(buf, "\"CC ", 4);
-						break;
-					}
-					strcat(buf, "\"");
+				switch (buf[i]) {
+				case '-':
+					memcpy(buf, "CC-", 3);
+					break;
+				case '!':
+					memcpy(buf, "CC!", 3);
+					break;
 				}
-				if (buf[3] == ' ') {
-					// have to escape any quotes.
+				if (buf[2] == ' ') {
+					// have to escape any semicolons
 					int j, len = strlen(buf);
 					char *duped = strdup(buf);
-					for (i = 4, j = 4; i < len; i++, j++) {
+					for (i = 3, j = 3; i < len; i++, j++) {
 						char c = duped[i];
-						if (c == '"' && i != (len - 1)) {
+						if (c == ';') {
 							buf[j] = '\\';
 							j++;
-							buf[j] = '"';
-						} else {
-							buf[j] = c;
 						}
+						buf[j] = c;
 					}
 					free(duped);
 				}


### PR DESCRIPTION

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

  * No need to escape quotes, users can do it themselves by using `\"`
    wherever needed
  * Instead, it is necessary to escape semicolons (`;`) since they would
    terminate the comment command, which is not good

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Green CI.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #1999.
