### PR TITLE
Fix Visual Commenting (Fix #1999)

### DIFF
--- a/librz/core/cmd/cmd_meta.c
+++ b/librz/core/cmd/cmd_meta.c
@@ -161,34 +161,6 @@ static bool meta_set_flag(RzCore *core, RzAnalysisMetaType mtype, ut64 addr, ut6
 	return rz_meta_set(core->analysis, mtype, addr, size, flag ? flag : str);
 }
 
-static void meta_comment_append(RzCore *core, const char *newcomment, RzAnalysisMetaType mtype, ut64 addr) {
-	const char *comment = rz_meta_get_string(core->analysis, mtype, addr);
-	char *nc = strdup(newcomment);
-	rz_str_unescape(nc);
-	if (comment) {
-		char *text = rz_str_newf("%s %s", comment, nc);
-		if (text) {
-			rz_meta_set_string(core->analysis, mtype, addr, text);
-			free(text);
-		} else {
-			rz_sys_perror("malloc");
-		}
-	} else {
-		rz_meta_set_string(core->analysis, mtype, addr, nc);
-	}
-	free(nc);
-}
-
-static void meta_editor(RzCore *core, RzAnalysisMetaType mtype, ut64 addr) {
-	const char *comment = rz_meta_get_string(core->analysis, mtype, addr);
-	char *out = rz_core_editor(core, NULL, comment);
-	if (out) {
-		rz_meta_del(core->analysis, mtype, addr, 1);
-		rz_meta_set_string(core->analysis, mtype, addr, out);
-		free(out);
-	}
-}
-
 static void meta_remove_all(RzCore *core, RzAnalysisMetaType mtype) {
 	rz_meta_del(core->analysis, mtype, 0, UT64_MAX);
 }
@@ -222,7 +194,7 @@ RZ_IPI RzCmdStatus rz_meta_remove_all_handler(RzCore *core, int argc, const char
 }
 
 RZ_IPI RzCmdStatus rz_comment_handler(RzCore *core, int argc, const char **argv) {
-	meta_comment_append(core, argv[1], RZ_META_TYPE_COMMENT, core->offset);
+	rz_core_meta_append(core, argv[1], RZ_META_TYPE_COMMENT, core->offset);
 	return RZ_CMD_STATUS_OK;
 }
 
@@ -240,7 +212,7 @@ RZ_IPI RzCmdStatus rz_comment_at_handler(RzCore *core, int argc, const char **ar
 }
 
 RZ_IPI RzCmdStatus rz_comment_append_handler(RzCore *core, int argc, const char **argv) {
-	meta_comment_append(core, argv[1], RZ_META_TYPE_COMMENT, core->offset);
+	rz_core_meta_append(core, argv[1], RZ_META_TYPE_COMMENT, core->offset);
 	return RZ_CMD_STATUS_OK;
 }
 
@@ -283,7 +255,7 @@ RZ_IPI RzCmdStatus rz_comment_filelink_handler(RzCore *core, int argc, const cha
 }
 
 RZ_IPI RzCmdStatus rz_comment_editor_handler(RzCore *core, int argc, const char **argv) {
-	meta_editor(core, RZ_META_TYPE_COMMENT, core->offset);
+	rz_core_meta_editor(core, RZ_META_TYPE_COMMENT, core->offset);
 	return RZ_CMD_STATUS_OK;
 }
 
@@ -720,6 +692,6 @@ RZ_IPI RzCmdStatus rz_meta_type_remove_all_handler(RzCore *core, int argc, const
 }
 
 RZ_IPI RzCmdStatus rz_meta_type_editor_handler(RzCore *core, int argc, const char **argv) {
-	meta_editor(core, RZ_META_TYPE_VARTYPE, core->offset);
+	rz_core_meta_editor(core, RZ_META_TYPE_VARTYPE, core->offset);
 	return RZ_CMD_STATUS_OK;
 }

--- a/librz/core/cmeta.c
+++ b/librz/core/cmeta.c
@@ -330,3 +330,31 @@ RZ_IPI void rz_core_meta_print_list_in_function(RzCore *core, RzAnalysisMetaType
 	print_meta_list(core, type, addr, state);
 	rz_cmd_state_output_array_end(state);
 }
+
+RZ_IPI void rz_core_meta_append(RzCore *core, const char *newcomment, RzAnalysisMetaType mtype, ut64 addr) {
+	const char *comment = rz_meta_get_string(core->analysis, mtype, addr);
+	char *nc = strdup(newcomment);
+	rz_str_unescape(nc);
+	if (comment) {
+		char *text = rz_str_newf("%s %s", comment, nc);
+		if (text) {
+			rz_meta_set_string(core->analysis, mtype, addr, text);
+			free(text);
+		} else {
+			rz_sys_perror("malloc");
+		}
+	} else {
+		rz_meta_set_string(core->analysis, mtype, addr, nc);
+	}
+	free(nc);
+}
+
+RZ_IPI void rz_core_meta_editor(RzCore *core, RzAnalysisMetaType mtype, ut64 addr) {
+	const char *comment = rz_meta_get_string(core->analysis, mtype, addr);
+	char *out = rz_core_editor(core, NULL, comment);
+	if (out) {
+		rz_meta_del(core->analysis, mtype, addr, 1);
+		rz_meta_set_string(core->analysis, mtype, addr, out);
+		free(out);
+	}
+}

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -55,6 +55,8 @@ RZ_IPI void rz_core_meta_print(RzCore *core, RzAnalysisMetaItem *d, ut64 start, 
 RZ_IPI void rz_core_meta_print_list_at(RzCore *core, ut64 addr, RzCmdStateOutput *state);
 RZ_IPI void rz_core_meta_print_list_all(RzCore *core, int type, RzCmdStateOutput *state);
 RZ_IPI void rz_core_meta_print_list_in_function(RzCore *core, int type, ut64 addr, RzCmdStateOutput *state);
+RZ_IPI void rz_core_meta_append(RzCore *core, const char *newcomment, RzAnalysisMetaType mtype, ut64 addr);
+RZ_IPI void rz_core_meta_editor(RzCore *core, RzAnalysisMetaType mtype, ut64 addr);
 
 /* ctypes.c */
 // Enums


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This was broken from newshell conversion. But it's better to use C for this anyway.

**Test plan**

Append:
* `Vp` (navigate to disassembly)
* `;`
* enter some comment
* Enter
* The comment should be appended at the addr (to any existing comment)

Delete:
 * `Vp` (navigate to disassembly)
 * `;`
 * `-`
 * Enter
 * Comment should be deleted

Editor:
 * `Vp` (navigate to disassembly)
 * `!`
 * Editor should open and saving should update the comment

All of this should also work when adding a comment for an xref:
 * `Vp` (navigate to disassembly)
 * Navigate to the destination of an xref
 * `x`
 * `;`
 * repeat the cases above

**Closing issues**

Fix #1999