### PR TITLE
Use rz_analysis_get_address_bits() in pxr and fix asserts

### DIFF
--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -6496,7 +6496,7 @@ RZ_IPI int rz_cmd_print(void *data, const char *input) {
 		case 'r': // "pxr"
 			if (l) {
 				int mode = input[2];
-				int wordsize = core->analysis->bits / 8;
+				int wordsize = rz_analysis_get_address_bits(core->analysis) / 8;
 				if (mode == '?') {
 					eprintf("Usage: pxr[1248][*,jq] [length]\n");
 					break;

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -1897,7 +1897,8 @@ RZ_API char *rz_core_analysis_hasrefs_to_depth(RzCore *core, ut64 value, PJ *pj,
 		}
 	}
 	ut64 type = rz_core_analysis_address(core, value);
-	RzBinSection *sect = value ? rz_bin_get_section_at(rz_bin_cur_object(core->bin), value, true) : NULL;
+	RzBinObject *obj = rz_bin_cur_object(core->bin);
+	RzBinSection *sect = value && obj ? rz_bin_get_section_at(obj, value, true) : NULL;
 	if (!((type & RZ_ANALYSIS_ADDR_TYPE_HEAP) || (type & RZ_ANALYSIS_ADDR_TYPE_STACK))) {
 		// Do not repeat "stack" or "heap" words unnecessarily.
 		if (sect && sect->name[0]) {

--- a/test/db/cmd/cmd_px
+++ b/test/db/cmd/cmd_px
@@ -68,6 +68,23 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=pxr addr size != bits
+FILE=malloc://0x2000
+CMDS=<<EOF
+e asm.arch=6502
+w Hello @ 0x1234
+wx 3412 @ 2
+pxr 8 @ 0
+EOF
+EXPECT=<<EOF
+0x00000000 0000  ..
+0x00000002 3412  4. R W X 'pha' Hello
+0x00000004 0000  ..
+0x00000006 0000  ..
+EOF
+EXPECT_ERR=
+RUN
+
 NAME=px 10
 FILE=malloc://1024
 CMDS=wx 90909090909090909090 ; px 10


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

avr and 6502 use 16bit addresses but have their bits set to 8. pxr should use 16.

**Test plan**

`rz -a 6502 -Qc pxr` should show 2-byte entries
