### PR TITLE
Fix meta escape for EBCDIC encodings

### DIFF
--- a/librz/core/cmeta.c
+++ b/librz/core/cmeta.c
@@ -20,6 +20,11 @@ static char *meta_string_escape(RzCore *core, RzAnalysisMetaItem *mi) {
 		// All strings that are put into the metadata are already converted
 		esc_str = rz_str_escape_utf8(mi->str, &opt);
 		break;
+	case RZ_STRING_ENC_IBM037:
+	case RZ_STRING_ENC_IBM290:
+	case RZ_STRING_ENC_EBCDIC_UK:
+	case RZ_STRING_ENC_EBCDIC_US:
+	case RZ_STRING_ENC_EBCDIC_ES:
 	case RZ_STRING_ENC_8BIT:
 		esc_str = rz_str_escape_8bit(mi->str, false, &opt);
 		break;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes the failing meta escaping test:
```
[XX] db/cmd/metadata Cs ascii/8bit
RZ_NOPLUGINS=1 rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -Qc 'Csb @ 0x1400160a0
Csl~gate
Csl~ANSI
' bins/pe/testapp-msvc64.exe
-- stdout
--- expected
+++ actual
@@ -1,3 +1,27 @@
 0x1400160a0 8bit[18] "latin1 gate: \xce\xbb\xab\xce"
 0x1400160b8 ascii[50] "  -- in ConEmu, run `chcp 28591` to see the gate."
 0x140016000 ascii[19] "\tANSI\esc: \e[33m\r\n"
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
+WARNING: (../librz/core/cmeta.c:27):meta_string_escape: code should not be reached
```

**Test plan**

CI is green.