### PR TITLE
build: Fix dependencies names which are called libmagic and libxxhash

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -240,7 +240,14 @@ config_h = configure_file(
 )
 
 # handle magic library
-sys_magic = cc.find_library('magic', required: get_option('use_sys_magic'), static: is_static_build)
+sys_magic_opt = get_option('use_sys_magic')
+sys_magic = disabler()
+if sys_magic_opt.enabled() or sys_magic_opt.auto()
+  sys_magic = dependency('libmagic', required: false, static: is_static_build)
+  if not sys_magic.found()
+    sys_magic = cc.find_library('magic', required: sys_magic_opt, static: is_static_build)
+  endif
+endif
 
 # handle xxhash library
 r = run_command(py3_exe, check_meson_subproject_py, 'xxhash')
@@ -250,12 +257,12 @@ endif
 
 sys_xxhash_opt = get_option('use_sys_xxhash')
 if sys_xxhash_opt.enabled() or sys_xxhash_opt.auto()
-  xxhash_dep = dependency('xxhash', required: false, static: is_static_build)
+  xxhash_dep = dependency('libxxhash', required: false, static: is_static_build)
   if not xxhash_dep.found()
     xxhash_dep = cc.find_library('xxhash', required: sys_xxhash_opt, static: is_static_build)
   endif
 endif
-if sys_xxhash_opt.auto() or sys_xxhash_opt.disabled()
+if (sys_xxhash_opt.auto() and not xxhash_dep.found()) or sys_xxhash_opt.disabled()
   xxhash_proj = subproject('xxhash', default_options: ['default_library=static'])
   xxhash_dep = xxhash_proj.get_variable('xxhash_dep')
 endif


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The .pc files are called libxxhash.pc and libmagic.pc, thus use the correct names.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Build rizin with various options for `-Duse_sys_xxhash` and `-Duse_sys_magic`. I tried it a bit with containers having only the library or library + .pc file and with different values of enabled/disabled/auto.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Fix https://github.com/rizinorg/rizin/issues/2013
