### PR TITLE
Allow users to decide how their tables look

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3257,6 +3257,10 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETPREF("prj.file", "", "Path of the currently opened project");
 	SETBPREF("prj.compress", "false", "Compress the project file while saving");
 
+	/* table */
+	SETPREF("table.style", "standard", "Style of showing tables (values: standard, fancy, JSON, CSV");
+	SETBPREF("table.header", "true", "Show the header column titles when showing table");
+
 	/* cfg */
 	SETBPREF("cfg.plugins", "true", "Load plugins at startup");
 	SETCB("time.fmt", "%Y-%m-%d %H:%M:%S %z", &cb_cfgdatefmt, "Date format (%Y-%m-%d %H:%M:%S %z)");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Currently, there is no way for the user to configure how their table will be printed/shown. It would be nice to allow the user to decide the printing style and whether to print headers or not.

Need help in figuring out how to use the config within the `rz_table_new` function. Maybe I could use a `RzCoreBind`. Would like to hear some suggestions.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Add integration tests.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None.
