### PR TITLE
Enable `rz_core_debug_sync_bits()` only on Windows

### DIFF
--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -586,6 +586,7 @@ RZ_API void rz_core_debug_ri(RzCore *core, RzReg *reg, int mode) {
 }
 
 RZ_IPI void rz_core_debug_sync_bits(RzCore *core) {
+#if __WINDOWS__
 	if (rz_config_get_b(core->config, "cfg.debug")) {
 		switch (core->dbg->bits) {
 		case RZ_SYS_BITS_8:
@@ -602,6 +603,7 @@ RZ_IPI void rz_core_debug_sync_bits(RzCore *core) {
 			break;
 		}
 	}
+#endif
 }
 
 RZ_IPI void rz_core_debug_single_step_in(RzCore *core) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr is a quick hack to make asan green (by preventing [this error](https://github.com/rizinorg/rizin/runs/4330615495?check_suite_focus=true#step:16:123) due to 53a76946310fd247cd6c4166b61064c383adef1f) until someone figures out why apparently `asm.bits` cannot be set repeatedly.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
