### PR TITLE
Initialize retctx,ctx before freeing the inner elements

### DIFF
--- a/librz/analysis/var.c
+++ b/librz/analysis/var.c
@@ -1103,13 +1103,15 @@ RZ_API void rz_analysis_extract_rarg(RzAnalysis *analysis, RzAnalysisOp *op, RzA
 RZ_API void rz_analysis_extract_vars(RzAnalysis *analysis, RzAnalysisFunction *fcn, RzAnalysisOp *op) {
 	rz_return_if_fail(analysis && fcn && op);
 
-	const char *BP = analysis->reg->name[RZ_REG_NAME_BP];
-	const char *SP = analysis->reg->name[RZ_REG_NAME_SP];
+	const char *BP = rz_reg_get_name(analysis->reg, RZ_REG_NAME_BP);
+	const char *SP = rz_reg_get_name(analysis->reg, RZ_REG_NAME_SP);
 	if (BP) {
 		extract_arg(analysis, fcn, op, BP, "+", RZ_ANALYSIS_VAR_KIND_BPV);
 		extract_arg(analysis, fcn, op, BP, "-", RZ_ANALYSIS_VAR_KIND_BPV);
 	}
-	extract_arg(analysis, fcn, op, SP, "+", RZ_ANALYSIS_VAR_KIND_SPV);
+	if (SP) {
+		extract_arg(analysis, fcn, op, SP, "+", RZ_ANALYSIS_VAR_KIND_SPV);
+	}
 }
 
 static RzList *var_generate_list(RzAnalysis *a, RzAnalysisFunction *fcn, int kind) {

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -5371,6 +5371,9 @@ RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *tar
 		rz_core_analysis_esil_init_mem(core, NULL, UT64_MAX, UT32_MAX);
 	}
 	const char *spname = rz_reg_get_name(core->analysis->reg, RZ_REG_NAME_SP);
+	if (!spname) {
+		goto out_pop_regs;
+	}
 	EsilBreakCtx ctx = {
 		&op,
 		fcn,


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

In rz_core_analysis_type_match retctx structure was initialized on the
stack only after a "goto out_function", where a field of that structure
was freed. When the goto path is taken, the field is not properly
initialized and it cause cause a crash of Rizin or have other effects.

Fixes: CVE-2021-4022

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #2015 
