### PR TITLE
rz_core_debug_sync_bits: Set `asm.bits` only if necessary

### DIFF
--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -588,27 +588,8 @@ RZ_API void rz_core_debug_ri(RzCore *core, RzReg *reg, int mode) {
 RZ_IPI void rz_core_debug_sync_bits(RzCore *core) {
 	if (rz_config_get_b(core->config, "cfg.debug")) {
 		ut64 asm_bits = rz_config_get_i(core->config, "asm.bits");
-		switch (core->dbg->bits) {
-		case RZ_SYS_BITS_8:
-			if (asm_bits != 8) {
-				rz_config_set_i(core->config, "asm.bits", 8);
-			}
-			break;
-		case RZ_SYS_BITS_16:
-			if (asm_bits != 16) {
-				rz_config_set_i(core->config, "asm.bits", 16);
-			}
-			break;
-		case RZ_SYS_BITS_32:
-			if (asm_bits != 32) {
-				rz_config_set_i(core->config, "asm.bits", 32);
-			}
-			break;
-		case RZ_SYS_BITS_64:
-			if (asm_bits != 64) {
-				rz_config_set_i(core->config, "asm.bits", 64);
-			}
-			break;
+		if (asm_bits != core->dbg->bits * 8) {
+			rz_config_set_i(core->config, "asm.bits", core->dbg->bits * 8);
 		}
 	}
 }

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -587,18 +587,27 @@ RZ_API void rz_core_debug_ri(RzCore *core, RzReg *reg, int mode) {
 
 RZ_IPI void rz_core_debug_sync_bits(RzCore *core) {
 	if (rz_config_get_b(core->config, "cfg.debug")) {
+		ut64 asm_bits = rz_config_get_i(core->config, "asm.bits");
 		switch (core->dbg->bits) {
 		case RZ_SYS_BITS_8:
-			rz_config_set_i(core->config, "asm.bits", 8);
+			if (asm_bits != 8) {
+				rz_config_set_i(core->config, "asm.bits", 8);
+			}
 			break;
 		case RZ_SYS_BITS_16:
-			rz_config_set_i(core->config, "asm.bits", 16);
+			if (asm_bits != 16) {
+				rz_config_set_i(core->config, "asm.bits", 16);
+			}
 			break;
 		case RZ_SYS_BITS_32:
-			rz_config_set_i(core->config, "asm.bits", 32);
+			if (asm_bits != 32) {
+				rz_config_set_i(core->config, "asm.bits", 32);
+			}
 			break;
 		case RZ_SYS_BITS_64:
-			rz_config_set_i(core->config, "asm.bits", 64);
+			if (asm_bits != 64) {
+				rz_config_set_i(core->config, "asm.bits", 64);
+			}
 			break;
 		}
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr makes `rz_core_debug_sync_bits()` set `asm.bits` only if it needs to change. As a nice side effect, it makes the asan build green, i.e. it prevents [this error](https://github.com/rizinorg/rizin/runs/4330615495?check_suite_focus=true#step:16:123) due to 53a76946310fd247cd6c4166b61064c383adef1f.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
