### PR TITLE
Fix which for subfile references

### DIFF
--- a/librz/core/cmd_descs/rzshell_which.py
+++ b/librz/core/cmd_descs/rzshell_which.py
@@ -23,6 +23,10 @@ def find_entry(commands, rzcommand):
             e = find_entry(c["subcommands"], rzcommand)
             if e is not None:
                 return e
+        if "subcommands" in c and isinstance(c["subcommands"], str):
+            # This cd is only a group pointing to another file,
+            # the handler cname will be fetched from there.
+            return None
 
         if c["name"] == rzcommand:
             return c


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Commands like `e` have two definitions:
```yml
# cmd_descs.yaml
  - name: e
    summary: List/get/set config evaluable vars
    subcommands: cmd_eval
```
```yml
# cmd_eval.yaml
  - name: e
    cname: eval_getset
    summary: Get/Set value of config variable <key>
# ...
```

Only the second one is of interest for `rzshell_which.py`. Which one was chosen previously depended on the order of `glob.glob(os.path.join(basedir, "*.yaml"))`.

**Test plan**

`sys/rzshell_which.py e` should show `C handler: rz_eval_getset_handler`. Whether it previously worked was a matter of luck. 
