### PR TITLE
Refactor `rz_cons_pal_list()` to return an `RzList`

### DIFF
--- a/librz/cons/pal.c
+++ b/librz/cons/pal.c
@@ -521,7 +521,7 @@ RZ_API void rz_cons_pal_show(void) {
 typedef struct {
 	int val;
 	const char *str;
-} RAttrStr;
+} RzAttrStr;
 
 RZ_API RzList *rz_cons_pal_list(int rad, const char *arg) {
 	char *name = NULL, *current, **color;
@@ -571,7 +571,7 @@ RZ_API RzList *rz_cons_pal_list(int rad, const char *arg) {
 				rz_str_append(name, rz_str_newf(" rgb:%02x%02x%02x", rcolor->r2, rcolor->g2, rcolor->b2));
 			}
 			if (rcolor->attr) {
-				const RAttrStr attrs[] = {
+				const RzAttrStr attrs[] = {
 					{ RZ_CONS_ATTR_BOLD, "bold" },
 					{ RZ_CONS_ATTR_DIM, "dim" },
 					{ RZ_CONS_ATTR_ITALIC, "italic" },

--- a/librz/cons/pal.c
+++ b/librz/cons/pal.c
@@ -526,18 +526,22 @@ typedef struct {
 RZ_API void rz_cons_pal_list(int rad, const char *arg) {
 	char *name, **color;
 	const char *hasnext;
+	PJ *pj = pj_new();
 	int i;
 	if (rad == 'j') {
-		rz_cons_print("{");
+		pj_o(pj);
 	}
 	for (i = 0; keys[i].name; i++) {
 		RzColor *rcolor = RZCOLOR_AT(i);
 		color = COLOR_AT(i);
 		switch (rad) {
 		case 'j':
-			hasnext = (keys[i + 1].name) ? "," : "";
-			rz_cons_printf("\"%s\":[%d,%d,%d]%s",
-				keys[i].name, rcolor->r, rcolor->g, rcolor->b, hasnext);
+			pj_k(pj, keys[i].name);
+			pj_a(pj);
+			pj_n(pj, rcolor->r);
+			pj_n(pj, rcolor->g);
+			pj_n(pj, rcolor->b);
+			pj_end(pj);
 			break;
 		case 'c': {
 			const char *prefix = rz_str_trim_head_ro(arg);
@@ -599,7 +603,9 @@ RZ_API void rz_cons_pal_list(int rad, const char *arg) {
 		}
 	}
 	if (rad == 'j') {
-		rz_cons_print("}\n");
+		pj_end(pj);
+		rz_cons_println(pj_string(pj));
+		pj_free(pj);
 	}
 }
 

--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -105,6 +105,19 @@ static void list_themes_in_path(RzList *list, const char *path) {
 	rz_list_free(files);
 }
 
+static void print_cons_pal_list(int rad, const char *arg) {
+	RzList *lst = rz_cons_pal_list(rad, arg);
+	char *items = NULL;
+	RzListIter *it;
+	rz_list_foreach (lst, it, items) {
+		if (rad == 1) {
+			eprintf("%s \n", items);
+		} else {
+			eprintf("%s", items);
+		}
+	}
+}
+
 RZ_API char *rz_core_theme_get(RzCore *core) {
 	return core->curtheme;
 }
@@ -163,13 +176,13 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_list_handler(RzCore *core, int argc, const 
 	}
 	switch (mode) {
 	case RZ_OUTPUT_MODE_RIZIN:
-		rz_cons_pal_list(1, NULL);
+		print_cons_pal_list(1, NULL);
 		break;
 	case RZ_OUTPUT_MODE_JSON:
-		rz_cons_pal_list('j', NULL);
+		print_cons_pal_list('j', NULL);
 		break;
 	case RZ_OUTPUT_MODE_STANDARD:
-		rz_cons_pal_list(0, NULL);
+		print_cons_pal_list(0, NULL);
 		break;
 	default:
 		return RZ_CMD_STATUS_ERROR;
@@ -178,7 +191,7 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_list_handler(RzCore *core, int argc, const 
 }
 
 RZ_IPI RzCmdStatus rz_cmd_eval_color_display_palette_css_handler(RzCore *core, int argc, const char **argv) {
-	rz_cons_pal_list('c', argv[1]);
+	print_cons_pal_list('c', argv[1]);
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -105,17 +105,18 @@ static void list_themes_in_path(RzList *list, const char *path) {
 	rz_list_free(files);
 }
 
-static void print_cons_pal_list(int rad, const char *arg) {
-	RzList *lst = rz_cons_pal_list(rad, arg);
+static void print_cons_pal_list(RzOutputMode mode, const char *arg) {
+	RzList *lst = rz_cons_pal_list(mode, arg);
 	char *items = NULL;
 	RzListIter *it;
 	rz_list_foreach (lst, it, items) {
-		if (rad == 1) {
-			eprintf("%s \n", items);
+		if (mode == RZ_OUTPUT_MODE_RIZIN) {
+			rz_cons_printf("%s \n", items);
 		} else {
-			eprintf("%s", items);
+			rz_cons_printf("%s", items);
 		}
 	}
+	rz_list_free(lst);
 }
 
 RZ_API char *rz_core_theme_get(RzCore *core) {
@@ -174,24 +175,12 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_list_handler(RzCore *core, int argc, const 
 		eprintf("(%s)(%sCOLOR" Color_RESET ")\n", argv[1], color);
 		return RZ_CMD_STATUS_OK;
 	}
-	switch (mode) {
-	case RZ_OUTPUT_MODE_RIZIN:
-		print_cons_pal_list(1, NULL);
-		break;
-	case RZ_OUTPUT_MODE_JSON:
-		print_cons_pal_list('j', NULL);
-		break;
-	case RZ_OUTPUT_MODE_STANDARD:
-		print_cons_pal_list(0, NULL);
-		break;
-	default:
-		return RZ_CMD_STATUS_ERROR;
-	};
+	print_cons_pal_list(mode, NULL);
 	return RZ_CMD_STATUS_OK;
 }
 
 RZ_IPI RzCmdStatus rz_cmd_eval_color_display_palette_css_handler(RzCore *core, int argc, const char **argv) {
-	print_cons_pal_list('c', argv[1]);
+	print_cons_pal_list(RZ_OUTPUT_MODE_LONG, argv[1]);
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/include/rz_cons.h
+++ b/librz/include/rz_cons.h
@@ -950,7 +950,7 @@ RZ_API const char *rz_cons_pal_get_name(int index);
 RZ_API int rz_cons_pal_len(void);
 RZ_API int rz_cons_rgb_parse(const char *p, ut8 *r, ut8 *g, ut8 *b, ut8 *a);
 RZ_API char *rz_cons_rgb_tostring(ut8 r, ut8 g, ut8 b);
-RZ_API void rz_cons_pal_list(int rad, const char *arg);
+RZ_API RzList *rz_cons_pal_list(int rad, const char *arg);
 RZ_API void rz_cons_pal_show(void);
 RZ_API int rz_cons_get_size(int *rows);
 RZ_API bool rz_cons_isatty(void);

--- a/librz/include/rz_cons.h
+++ b/librz/include/rz_cons.h
@@ -950,7 +950,7 @@ RZ_API const char *rz_cons_pal_get_name(int index);
 RZ_API int rz_cons_pal_len(void);
 RZ_API int rz_cons_rgb_parse(const char *p, ut8 *r, ut8 *g, ut8 *b, ut8 *a);
 RZ_API char *rz_cons_rgb_tostring(ut8 r, ut8 g, ut8 b);
-RZ_API RzList *rz_cons_pal_list(int rad, const char *arg);
+RZ_API RZ_OWN RzList *rz_cons_pal_list(RzOutputMode mode, const char *prefix);
 RZ_API void rz_cons_pal_show(void);
 RZ_API int rz_cons_get_size(int *rows);
 RZ_API bool rz_cons_isatty(void);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The linked issue suggests to
```
Refactor the APIs like rz_cons_pal_list() to return the RzList instead, 
and introduce a separate function to print this RzList depending on the 
separate modes using RzOutputMode enum as well.
```
This is an early, draft PR and so far, I've just appended the `char *` (which was getting printed) to the `RzList` in each iteration. Feel free to suggest
other ideas.

Things to do:
* Currently, the PJ is printed inside `rz_cons_pal_list()` itself. Need to see if it can be moved with introducing `RzCmdStateOutput` or something else.
* Add the Doxygen doc for the API
* Looks like the inline grep `~` is broken on this PR

**Test plan**
`ec*` has a test, tests for `ecj` can also maybe be added.

**Closing issues**

Closes #1676
