### PR TITLE
Check for plugin ESIL support before running ESIL code in `aaa`.

### DIFF
--- a/librz/analysis/p/analysis_riscv.c
+++ b/librz/analysis/p/analysis_riscv.c
@@ -907,6 +907,7 @@ RzAnalysisPlugin rz_analysis_plugin_riscv = {
 	.bits = 32 | 64,
 	.op = &riscv_op,
 	.get_reg_profile = &get_reg_profile,
+	.esil = true,
 };
 
 #ifndef RZ_PLUGIN_INCORE

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -6631,6 +6631,7 @@ RZ_API bool rz_core_analysis_everything(RzCore *core, bool experimental, char *d
 	bool didAap = false;
 	ut64 curseek = core->offset;
 	bool cfg_debug = rz_config_get_b(core->config, "cfg.debug");
+	bool plugin_supports_esil = core->analysis->cur->esil;
 	const char *oldstr = NULL;
 	if (rz_str_startswith(rz_config_get(core->config, "bin.lang"), "go")) {
 		oldstr = rz_print_rowlog(core->print, "Find function and symbol names from golang binaries (aang)");
@@ -6703,7 +6704,9 @@ RZ_API bool rz_core_analysis_everything(RzCore *core, bool experimental, char *d
 		bool pcache = rz_config_get_b(core->config, "io.pcache");
 		rz_config_set_b(core->config, "io.pcache", false);
 		oldstr = rz_print_rowlog(core->print, "Emulate functions to find computed references (aaef)");
-		rz_core_analysis_esil_references_all_functions(core);
+		if (plugin_supports_esil) {
+			rz_core_analysis_esil_references_all_functions(core);
+		}
 		rz_print_rowlog_done(core->print, oldstr);
 		rz_core_task_yield(&core->tasks);
 		rz_config_set_b(core->config, "io.pcache", pcache);
@@ -6742,11 +6745,12 @@ RZ_API bool rz_core_analysis_everything(RzCore *core, bool experimental, char *d
 		rz_print_rowlog_done(core->print, oldstr);
 		rz_core_task_yield(&core->tasks);
 	}
-
-	oldstr = rz_print_rowlog(core->print, "Type matching analysis for all functions (aaft)");
-	rz_core_analysis_types_propagation(core);
-	rz_print_rowlog_done(core->print, oldstr);
-	rz_core_task_yield(&core->tasks);
+	if (plugin_supports_esil) {
+		oldstr = rz_print_rowlog(core->print, "Type matching analysis for all functions (aaft)");
+		rz_core_analysis_types_propagation(core);
+		rz_print_rowlog_done(core->print, oldstr);
+		rz_core_task_yield(&core->tasks);
+	}
 
 	oldstr = rz_print_rowlog(core->print, "Propagate noreturn information");
 	rz_core_analysis_propagate_noreturn(core, UT64_MAX);

--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -430,7 +430,7 @@ _dAe  32 64      ppc         BSD     Capstone PowerPC disassembler (by pancake)
 _dA_  32 64      ppc.gnu     GPL3    PowerPC
 _dA_  32         propeller   LGPL3   propeller disassembly plugin
 _dA_  8 16       pyc         LGPL3   PYC disassemble plugin
-_dA_  32 64      riscv       GPL     RISC-V
+_dAe  32 64      riscv       GPL     RISC-V
 _dAe  32         rsp         LGPL3   Reality Signal Processor
 _dAe  32         sh          GPL3    SuperH-4 CPU
 _dA_  8 16       snes        LGPL3   SuperNES CPU


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The `aaa` command runs ESIL analysis although the analysis plugin not necessarily supports it. This PR checks for ESIL support before functions are executed which use ESIL code.


**Test plan**

Fixes this issue: https://github.com/rizinorg/rizin/pull/1614#issuecomment-980184657

**Closing issues**

None

**Documentation statement**

Function in question was already documented.
