### PR TITLE
Fix clang `-Wabsolute-value` warning + Trigger linux clang build on `clang` in branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             compiler: clang
             run_tests: true
             meson_options: -Dbuildtype=release
-            enabled: ${{ github.event_name != 'pull_request' && needs.changes.outputs.edited == 'true' }}
+            enabled: ${{ (github.event_name != 'pull_request' || contains(github.head_ref, 'clang')) && needs.changes.outputs.edited == 'true' }}
             timeout: 45
             allow_failure: false
           - name: linux-meson-gcc-tests

--- a/librz/include/rz_util/rz_hex.h
+++ b/librz/include/rz_util/rz_hex.h
@@ -9,7 +9,7 @@ RZ_API int rz_hex_pair2bin(const char *arg);
 RZ_API int rz_hex_str2binmask(const char *in, ut8 *out, ut8 *mask);
 RZ_API int rz_hex_str2bin(const char *in, ut8 *out);
 RZ_API int rz_hex_bin2str(const ut8 *in, int len, char *out);
-RZ_API void rz_hex_ut2st_str(const ut64 in, RZ_INOUT char *out, const int len);
+RZ_API void rz_hex_ut2st_str(const ut32 in, RZ_INOUT char *out, const int len);
 RZ_API char *rz_hex_bin2strdup(const ut8 *in, int len);
 RZ_API bool rz_hex_to_byte(ut8 *val, ut8 c);
 RZ_API int rz_hex_str_is_valid(const char *s);

--- a/librz/util/hex.c
+++ b/librz/util/hex.c
@@ -394,8 +394,8 @@ RZ_API int rz_hex_bin2str(const ut8 *in, int len, char *out) {
 }
 
 /**
- * \brief Takes an unsigned integer and returns the signed integer in hex format as string.
- * E.g.: 0xffffffffffffffff -> "-0x1"
+ * \brief Takes an unsigned 32bit integer with MSB set to 1 and returns the signed integer in hex format as string.
+ * E.g.: 0xffffffff -> "-0x1"
  *
  * \param in The integer to convert to the signed string.
  * \param out The buffer to write the signed hex string to.
@@ -403,12 +403,12 @@ RZ_API int rz_hex_bin2str(const ut8 *in, int len, char *out) {
  * \return char* The signed integer as hex string.
  */
 RZ_API void rz_hex_ut2st_str(const ut64 in, RZ_INOUT char *out, const int len) {
-	if (len < 20) {
-		RZ_LOG_FATAL("Output buffer too small for 64bit value.\n");
+	char tmp[12];
+	if (len < RZ_ARRAY_SIZE(tmp)) {
+		RZ_LOG_FATAL("Output buffer too small for negative 32bit value.\n");
 	}
-	char tmp[20];
-	sprintf(tmp, "-0x%" PFMT32x, ~(ut32)in + 1);
-	memcpy(out, tmp, 20);
+	snprintf(tmp, RZ_ARRAY_SIZE(tmp), "-0x%" PFMT32x, ~(ut32)in + 1);
+	memcpy(out, tmp, RZ_ARRAY_SIZE(tmp));
 	return;
 }
 

--- a/librz/util/hex.c
+++ b/librz/util/hex.c
@@ -407,7 +407,7 @@ RZ_API void rz_hex_ut2st_str(const ut64 in, RZ_INOUT char *out, const int len) {
 		RZ_LOG_FATAL("Output buffer too small for 64bit value.\n");
 	}
 	char tmp[20];
-	sprintf(tmp, "-0x%" PFMT64x, llabs((st64)in));
+	sprintf(tmp, "-0x%" PFMT32x, ~(ut32)in + 1);
 	memcpy(out, tmp, 20);
 	return;
 }

--- a/librz/util/hex.c
+++ b/librz/util/hex.c
@@ -404,11 +404,11 @@ RZ_API int rz_hex_bin2str(const ut8 *in, int len, char *out) {
  */
 RZ_API void rz_hex_ut2st_str(const ut64 in, RZ_INOUT char *out, const int len) {
 	char tmp[12];
-	if (len < RZ_ARRAY_SIZE(tmp)) {
+	if (len < sizeof(tmp)) {
 		RZ_LOG_FATAL("Output buffer too small for negative 32bit value.\n");
 	}
-	snprintf(tmp, RZ_ARRAY_SIZE(tmp), "-0x%" PFMT32x, ~(ut32)in + 1);
-	memcpy(out, tmp, RZ_ARRAY_SIZE(tmp));
+	snprintf(tmp, sizeof(tmp), "-0x%" PFMT32x, ~(ut32)in + 1);
+	memcpy(out, tmp, sizeof(tmp));
 	return;
 }
 

--- a/librz/util/hex.c
+++ b/librz/util/hex.c
@@ -402,12 +402,12 @@ RZ_API int rz_hex_bin2str(const ut8 *in, int len, char *out) {
  * \param len Length of the out buffer.
  * \return char* The signed integer as hex string.
  */
-RZ_API void rz_hex_ut2st_str(const ut64 in, RZ_INOUT char *out, const int len) {
+RZ_API void rz_hex_ut2st_str(const ut32 in, RZ_INOUT char *out, const int len) {
 	char tmp[12];
 	if (len < sizeof(tmp)) {
 		RZ_LOG_FATAL("Output buffer too small for negative 32bit value.\n");
 	}
-	snprintf(tmp, sizeof(tmp), "-0x%" PFMT32x, ~(ut32)in + 1);
+	snprintf(tmp, sizeof(tmp), "-0x%" PFMT32x, ~in + 1);
 	memcpy(out, tmp, sizeof(tmp));
 	return;
 }

--- a/librz/util/hex.c
+++ b/librz/util/hex.c
@@ -407,7 +407,7 @@ RZ_API void rz_hex_ut2st_str(const ut64 in, RZ_INOUT char *out, const int len) {
 		RZ_LOG_FATAL("Output buffer too small for 64bit value.\n");
 	}
 	char tmp[20];
-	sprintf(tmp, "-0x%x", abs((st64)in));
+	sprintf(tmp, "-0x%" PFMT64x, llabs((st64)in));
 	memcpy(out, tmp, 20);
 	return;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following warning on the `linux-meson-clang-tests` build:

![llabs](https://user-images.githubusercontent.com/12002672/143728957-4756b961-ecaf-486a-b898-fc296de9f5d6.PNG)
(https://github.com/rizinorg/rizin/runs/4342000656?check_suite_focus=true#step:12:553)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green. The `linux-meson-clang-tests` build runs on this pr. The above warning is no longer emitted.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
