### PR TITLE
Fix REL relocations in ARM binaries

### DIFF
--- a/librz/bin/bobj.c
+++ b/librz/bin/bobj.c
@@ -24,6 +24,8 @@ RZ_API ut64 rz_bin_reloc_size(RzBinReloc *reloc) {
 		return 8;
 	case RZ_BIN_RELOC_16:
 		return 16;
+	case RZ_BIN_RELOC_24:
+		return 24;
 	case RZ_BIN_RELOC_32:
 		return 32;
 	case RZ_BIN_RELOC_64:

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -895,12 +895,11 @@ static void patch_reloc(struct Elf_(rz_bin_elf_obj_t) * obj, RzBinElfReloc *rel,
 		break;
 	case EM_ARM:
 		val = S + A;
-		if (rel->mode == DT_REL) {
+		if (!rel->sym && rel->mode == DT_REL) {
 			rz_buf_read_at(obj->buf_patched, patch_addr, buf, 4);
-			val += rz_read_le32(buf);
+			val += obj->big_endian ? rz_read_be32(buf) : rz_read_le32(buf);
 		}
-		rz_write_le32(buf, val);
-		rz_buf_write_at(obj->buf_patched, patch_addr, buf, 4);
+		rz_buf_write_ble32_at(obj->buf_patched, patch_addr, val, obj->big_endian);
 		break;
 	case EM_AARCH64:
 		val = S + A;
@@ -1145,8 +1144,32 @@ static RzBinReloc *reloc_convert(ELFOBJ *bin, RzBinElfReloc *rel, ut64 GOT) {
 		case RZ_ARM_SBREL32: ADD(32, -B);
 		case RZ_ARM_GLOB_DAT: ADD(32, 0);
 		case RZ_ARM_JUMP_SLOT: ADD(32, 0);
+		case RZ_ARM_COPY: ADD(32, 0); // copy symbol at runtime
 		case RZ_ARM_RELATIVE: ADD(32, B);
 		case RZ_ARM_GOTOFF: ADD(32, -GOT);
+		case RZ_ARM_GOTPC: ADD(32, GOT - P);
+		case RZ_ARM_CALL: ADD(24, -P);
+		case RZ_ARM_JUMP24: ADD(24, -P);
+		case RZ_ARM_THM_JUMP24: ADD(24, -P);
+		case RZ_ARM_PREL31: ADD(32, -P);
+		case RZ_ARM_MOVW_PREL_NC: ADD(16, -P);
+		case RZ_ARM_MOVT_PREL: ADD(32, -P);
+		case RZ_ARM_THM_MOVW_PREL_NC: ADD(16, -P);
+		case RZ_ARM_REL32_NOI: ADD(32, -P);
+		case RZ_ARM_ABS32_NOI: ADD(32, 0);
+		case RZ_ARM_ALU_PC_G0_NC: ADD(32, -P);
+		case RZ_ARM_ALU_PC_G0: ADD(32, -P);
+		case RZ_ARM_ALU_PC_G1_NC: ADD(32, -P);
+		case RZ_ARM_ALU_PC_G1: ADD(32, -P);
+		case RZ_ARM_ALU_PC_G2: ADD(32, -P);
+		case RZ_ARM_LDR_PC_G1: ADD(32, -P);
+		case RZ_ARM_LDR_PC_G2: ADD(32, -P);
+		case RZ_ARM_LDRS_PC_G0: ADD(32, -P);
+		case RZ_ARM_LDRS_PC_G1: ADD(32, -P);
+		case RZ_ARM_LDRS_PC_G2: ADD(32, -P);
+		case RZ_ARM_LDC_PC_G0: ADD(32, -P);
+		case RZ_ARM_LDC_PC_G1: ADD(32, -P);
+		case RZ_ARM_LDC_PC_G2: ADD(32, -P);
 		default: ADD(32, GOT); break; // reg relocations
 		}
 		break;

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -895,6 +895,10 @@ static void patch_reloc(struct Elf_(rz_bin_elf_obj_t) * obj, RzBinElfReloc *rel,
 		break;
 	case EM_ARM:
 		val = S + A;
+		if (rel->mode == DT_REL) {
+			rz_buf_read_at(obj->buf_patched, patch_addr, buf, 4);
+			val += rz_read_le32(buf);
+		}
 		rz_write_le32(buf, val);
 		rz_buf_write_at(obj->buf_patched, patch_addr, buf, 4);
 		break;

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -1082,6 +1082,7 @@ static ut8 bin_reloc_size(RzBinReloc *reloc) {
 	switch (reloc->type) {
 		CASE(8);
 		CASE(16);
+		CASE(24);
 		CASE(32);
 		CASE(64);
 	}
@@ -1825,6 +1826,7 @@ static const char *bin_reloc_type_name(RzBinReloc *reloc) {
 	switch (reloc->type) {
 		CASE(8);
 		CASE(16);
+		CASE(24);
 		CASE(32);
 		CASE(64);
 	}

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -188,6 +188,7 @@ enum {
 typedef enum {
 	RZ_BIN_RELOC_8 = 8,
 	RZ_BIN_RELOC_16 = 16,
+	RZ_BIN_RELOC_24 = 24,
 	RZ_BIN_RELOC_32 = 32,
 	RZ_BIN_RELOC_64 = 64
 } RzBinRelocType;

--- a/test/db/formats/elf/elf-relarm
+++ b/test/db/formats/elf/elf-relarm
@@ -23,7 +23,69 @@ vaddr      paddr      type   name
 EOF
 RUN
 
-NAME=ELF: arm sh relocs
+NAME=ELF: arm relocs 1
+FILE=bins/elf/r2pay-arm32.so
+CMDS=<<EOF
+ir~?
+# ARM_RELATIVE
+s 0xb58c0
+pf bbbb
+pd 1
+# ARM_ABS32
+s 0xb58c4
+pf bbbb
+pd 1
+# ARM_ABS32
+s 0xb58d8
+pf bbbb
+pd 1
+# ARM_GLOB_DAT
+s 0xb5dbc
+pf bbbb
+pd 1
+# ARM_JUMP_SLOT
+s 0xb5e08
+pf bbbb
+pd 1
+EOF
+EXPECT=<<EOF
+427
+0x000b58c0 = 0x24
+0x000b58c1 = 0x45
+0x000b58c2 = 0x00
+0x000b58c3 = 0x00
+            ;-- section..fini_array:
+            ;-- segment.LOAD1:
+            0x000b58c0      .dword 0x00004524 ; entry0 ; entry.fini0 ; section..text; RELOC 32  ; [14] -rw- section size 4 named .fini_array
+0x000b58c4 = 0x60
+0x000b58c5 = 0x45
+0x000b58c6 = 0x00
+0x000b58c7 = 0x00
+            ;-- section..init_array:
+            ;-- .datadiv_decode1794556967687044894:
+            0x000b58c4      .dword 0x00004560 ; reloc.target..datadiv_decode1794556967687044894 ; sym..datadiv_decode1794556967687044894; RELOC 32 .datadiv_decode1794556967687044894 @ 0x00004560 ; [15] -rw- section size 364 named .init_array
+0x000b58d8 = 0x44
+0x000b58d9 = 0x8b
+0x000b58da = 0x09
+0x000b58db = 0x00
+            ;-- .datadiv_decode668687990735969933:
+            0x000b58d8      .dword 0x00098b44 ; reloc.target..datadiv_decode668687990735969933 ; sym..datadiv_decode668687990735969933; RELOC 32 .datadiv_decode668687990735969933 @ 0x00098b44
+0x000b5dbc = 0x24
+0x000b5dbd = 0x35
+0x000b5dbe = 0x14
+0x000b5dbf = 0x00
+            ;-- x.10:
+            0x000b5dbc      .dword 0x00143524 ; reloc.target.x.10 ; obj.x.10; RELOC 32 x.10 @ 0x00143524
+0x000b5e08 = 0xb4
+0x000b5e09 = 0x37
+0x000b5e0a = 0x14
+0x000b5e0b = 0x00
+            ;-- __cxa_atexit:
+            0x000b5e08      .dword 0x001437b4 ; reloc.target.__cxa_atexit; RELOC 32 __cxa_atexit
+EOF
+RUN
+
+NAME=ELF: arm relocs 2
 FILE=bins/elf/r2pay-arm32.so
 CMDS=<<EOF
 ir~?

--- a/test/db/formats/elf/elf-relarm
+++ b/test/db/formats/elf/elf-relarm
@@ -23,9 +23,6 @@ vaddr      paddr      type   name
 EOF
 RUN
 
-# IMPORTANT: patched relocs at 0x000b58d0 and 0x000b58d4 are WRONG! They should point to some init0 and init1, like in the 64bit variant.
-# This test exists to check the others around, and whether these two are patched at all
-# If the patching is fixed, the expected result can be updated.
 NAME=ELF: arm sh relocs
 FILE=bins/elf/r2pay-arm32.so
 CMDS=<<EOF
@@ -42,8 +39,8 @@ EXPECT=<<EOF
             0x000b58c8      .dword 0x00004570 ; reloc.target..datadiv_decode12875440098136793118 ; sym..datadiv_decode12875440098136793118; RELOC 32 .datadiv_decode12875440098136793118 @ 0x00004570
             ;-- .datadiv_decode11893604691534341392:
             0x000b58cc      .dword 0x00098028 ; reloc.target..datadiv_decode11893604691534341392 ; sym..datadiv_decode11893604691534341392; RELOC 32 .datadiv_decode11893604691534341392 @ 0x00098028
-            0x000b58d0      .dword 0x00000000                          ; RELOC 32 
-            0x000b58d4      .dword 0x00000000                          ; RELOC 32 
+            0x000b58d0      .dword 0x00008115 ; entry.init0            ; RELOC 32 
+            0x000b58d4      .dword 0x00055049 ; entry.init1            ; RELOC 32 
             ;-- .datadiv_decode668687990735969933:
             0x000b58d8      .dword 0x00098b44 ; reloc.target..datadiv_decode668687990735969933 ; sym..datadiv_decode668687990735969933; RELOC 32 .datadiv_decode668687990735969933 @ 0x00098b44
             ;-- .datadiv_decode16868916699024037624:
@@ -78,5 +75,25 @@ EXPECT=<<EOF
             0x00126548      .qword 0x00000000000f22e8 ; sym..datadiv_decode3655886617018729963
             0x00126550      .qword 0x00000000000f22ec ; sym..datadiv_decode16406252260792032531
             0x00126558      .qword 0x00000000000f22f0 ; sym..datadiv_decode13403071575248320347
+EOF
+RUN
+
+NAME=ELF: R_ARM_RELATIVE patch reloc
+FILE=bins/arm/elf/hello_world
+CMDS=<<EOF
+pxw 4 @ 0x00010f08
+pxw 4 @ 0x00010f0c
+pxw 4 @ 0x00011020
+pxw 4 @ 0x00011030
+pxw 4 @ 0x00011034
+pxw 4 @ 0x00011040
+EOF
+EXPECT=<<EOF
+0x00010f08  0x00000509                                   ....
+0x00010f0c  0x000004c9                                   ....
+0x00011020  0x00000565                                   e...
+0x00011030  0x00000525                                   %...
+0x00011034  0x0000050d                                   ....
+0x00011040  0x00011040                                   @...
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This PR should fix #2052. Prior to this fix, `Elf32_Rel` relocations in ARM binaries did not take the addend from the binary.

I did not add any tests yet. Let me know if the fix seems reasonable, and I will add some tests.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The R_ARM_RELATIVE relocations in the binary posted in #2052 are now resolved to the correct values. For example, for the relocation at 0x3004:
```
[0x00000754]> pd 1 @ 0x3004
            0x00003004      .dword 0x0000196b                          ; RELOC 32 
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #2052
