### PR TITLE
Fix installing bitvector headers

### DIFF
--- a/librz/meson.build
+++ b/librz/meson.build
@@ -399,6 +399,7 @@ rz_util_files = [
   'include/rz_util/rz_base91.h',
   'include/rz_util/rz_big.h',
   'include/rz_util/rz_bitmap.h',
+  'include/rz_util/rz_bitvector.h',
   'include/rz_util/rz_buf.h',
   'include/rz_util/rz_debruijn.h',
   'include/rz_util/rz_event.h',


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

After https://github.com/rizinorg/rizin/commit/648c267bc794940a87d592532f8f67f07c9846bb it was forgotten to be added in the installation target in meson.

**Test plan**

CI is green