### PR TITLE
Increase buffer to fix CID 365806.

### DIFF
--- a/librz/asm/arch/hexagon/hexagon.h
+++ b/librz/asm/arch/hexagon/hexagon.h
@@ -66,7 +66,7 @@ typedef enum {
 typedef struct {
 	bool first_insn;
 	bool last_insn;
-	char syntax_prefix[8]; // Package indicator
+	char syntax_prefix[16]; // Package indicator
 	char syntax_postfix[24]; // for ":endloop" string.
 } HexPktInfo;
 


### PR DESCRIPTION

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why. -> trivial
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Fixes CID 365806 found by Coverty. It simply increases the buffer from 8 -> 16

Cause of error: `strncpy` copied 8 bytes to a buffer of length 8  (`char syntax_prefix[8]`).
Even so the string copied to `char syntax_prefix[8]` was never longer than 7bytes, Coverty marks it as an error anyways. Since it could be potentially longer than 8 bytes and result in a not NULL terminated string.

This PR fixes it by simply increasing the buffer by 8 bytes. 

**Test plan**

Already present tests are enough.


**Closing issues**

None