### PR TITLE
Fix `-Wunused-function` warning on Mac

### DIFF
--- a/librz/debug/p/debug_native.c
+++ b/librz/debug/p/debug_native.c
@@ -91,7 +91,7 @@ RZ_API RzList *rz_w32_dbg_maps(RzDebug *);
 /* begin of debugger code */
 #if DEBUGGER
 
-#if !__WINDOWS__ && !(__linux__ && !defined(WAIT_ON_ALL_CHILDREN))
+#if !__WINDOWS__ && !(__linux__ && !defined(WAIT_ON_ALL_CHILDREN)) && !__APPLE__
 static int rz_debug_handle_signals(RzDebug *dbg) {
 #if __KFBSD__ || __NetBSD__
 	return bsd_handle_signals(dbg);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following warning:

![rz_debug_handle_signals](https://user-images.githubusercontent.com/12002672/144734583-89912383-2587-44ec-a75c-75db9cec18af.PNG)
(https://github.com/rizinorg/rizin/runs/4418574514?check_suite_focus=true#step:12:1531)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green. The above warning does not appear.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
