### PR TITLE
Add platform profiles' `.comment` value as a comment where it's used

### DIFF
--- a/librz/analysis/arch_platform.c
+++ b/librz/analysis/arch_platform.c
@@ -105,6 +105,18 @@ static bool sdb_load_arch_platform_by_path(RZ_NONNULL RzArchPlatformTarget *t, R
 	return result;
 }
 
+RZ_API const char *rz_arch_platform_add_comments_references(RzArchPlatformTarget *t, ut64 port) {
+	rz_return_val_if_fail(t, NULL);
+	if (!t->platforms) {
+		return NULL;
+	}
+	RzArchPlatformItem *item = ht_up_find(t->platforms, port, NULL);
+	if (item) {
+		return item->comment;
+	}
+	return NULL;
+}
+
 /**
  * \brief Loads the contents of the Platform Profile to the RzArchPlatformTarget
  *

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -3437,6 +3437,12 @@ static void ds_print_sysregs(RDisasmState *ds) {
 			// TODO: add register description description
 			ds->has_description = true;
 		}
+		sr = rz_arch_platform_add_comments_references(core->analysis->platform_target, ds->analop.dereferenced_mmio_address);
+		if (sr) {
+			CMT_ALIGN;
+			ds_comment(ds, true, "; MMIO %s - %s", sr, "");
+			ds->has_description = true;
+		}
 	} break;
 	}
 }
@@ -4017,6 +4023,7 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 			ut64 num = rz_read_ble(msg, core->print->big_endian, refptr * 8);
 			st64 n = (st64)num;
 			st32 n32 = (st32)(n & UT32_MAX);
+			ds->analop.dereferenced_mmio_address = num;
 			if (ds->analop.type == RZ_ANALYSIS_OP_TYPE_LEA) {
 				char str[128] = { 0 };
 				f = rz_flag_get_i(core->flags, refaddr);

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -843,6 +843,7 @@ typedef struct rz_analysis_op_t {
 	st64 stackptr; /* stack pointer */
 	int refptr; /* if (0) ptr = "reference" else ptr = "load memory of refptr bytes" */
 	ut64 mmio_address; // mmio address
+	ut64 dereferenced_mmio_address; // dereferenced mmio address
 	RzAnalysisValue *src[3];
 	RzAnalysisValue *dst;
 	RzList *access; /* RzAnalysisValue access information */

--- a/librz/include/rz_arch.h
+++ b/librz/include/rz_arch.h
@@ -58,6 +58,7 @@ RZ_API void rz_arch_platform_item_free(RzArchPlatformItem *item);
 RZ_API bool rz_arch_load_platform_sdb(RZ_NONNULL RzArchPlatformTarget *t, RZ_NONNULL const char *path);
 RZ_API bool rz_arch_platform_init(RzArchPlatformTarget *t, RZ_NONNULL const char *arch, RZ_NONNULL const char *cpu,
 	const char *platform, RZ_NONNULL const char *platforms_dir);
+RZ_API const char *rz_arch_platform_add_comments_references(RzArchPlatformTarget *t, ut64 port);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The objective of this PR is to make Rizin show the `.comment` value of the ports from the platform profiles 
at the places where they are used, i.e, accessed through load and store instructions.

Firstly, I've made an API which returns the `.comment` when the address of the port is passed to it.
Then, I've made a variable `analop.dereferenced_mmio_address` inside `RDisasmState` to house the de referenced
memory address.

**Test plan**

Testing

The way I initially thought I could test this was to get an instruction that loads or stores something to a port that's defined in some of the profiles that we already have. Therefore, I wrote the following code:

```c
void c_entry() {
    int *ptr = (int*)0x7e215048;
    *(unsigned long volatile *)0x7e215048 = 0xdeadbeef;
    return ;
}
```

And compiled it for `arm926ej-s`:

```
 arm-none-eabi-gcc -c -mcpu=arm926ej-s test.c -lc -o test.o
 arm-none-eabi-as -mcpu=arm926ej-s startup.s -o startup.o
 arm-none-eabi-ld -T test.ld test.o startup.o -o test.elf
 arm-none-eabi-objcopy -O binary test.elf test.bin
```

Which provided the following disassembly:

```asm
            ;-- c_entry:                                                                                                               
            0x00010040      str   fp, [sp, -4]!                                                                                        
            0x00010044      add   fp, sp, 0                                                                                            
            0x00010048      sub   sp, sp, 0xc                                                                                          
            0x0001004c      ldr   r3, [0x00010070]                     ; [0x10070:4]=0x7e215048                                        
            0x00010050      str   r3, [fp, -8]                         ; 8                                                             
            0x00010054      ldr   r3, [0x00010070]                     ; [0x10070:4]=0x7e215048                                        
            0x00010058      mov   r2, 5                                                                                                
            0x0001005c      str   r2, [r3]                                                                                             
            0x00010060      mov   r0, r0                                                                                               
            0x00010064      add   sp, fp, 0                                                                                            
            0x00010068      pop   {fp}                                                                                                 
            0x0001006c      bx    lr                                                                                                   
            0x00010070      invalid    
```
 
Here, we can see that`0x00010070` is not where the actual defined port is- it's at`0x7e215048`- read by the four bytes at `0x00010070`. I've stored that value at `ds->analop.dereferenced_mmio_address` when it's generated so that I can pass it to an API which returns the comment that can be added.

```bash
┌ sym.c_entry (int32_t arg1);                                                                                                          
│           ; var int32_t var_8h @ fp-0x8                                                                                              
│           ; arg int32_t arg1 @ r0                                                                                                    
│           0x00010040      str   fp, [sp, -4]!                                                                                        
│           0x00010044      add   fp, sp, 0                                                                                            
│           0x00010048      sub   sp, sp, 0xc                                                                                          
│           0x0001004c      ldr   r3, [0x00010070]                     ; [0x10070:4]=0x7e215048 AUX_MU_IIR_REG ; MMIO Mini UART Interrupt Identify
│           0x00010050      str   r3, [var_8h]                         ; 8                                                             
│           0x00010054      ldr   r3, [0x00010070]                     ; [0x10070:4]=0x7e215048 AUX_MU_IIR_REG ; MMIO Mini UART Interrupt  Identify
│           0x00010058      mov   r2, 5                                                                                                
│           0x0001005c      str   r2, [r3]                                                                                             
│           0x00010060      mov   r0, r0                               ; arg1                                                          
│           0x00010064      add   sp, fp, 0                                                                                            
│           0x00010068      pop   {fp}                                                                                                 
└           0x0001006c      bx    lr                                                                                                   
            ; DATA XREFS from sym.c_entry @ 0x1004c, 0x10054                                                                           
            0x00010070      cdpvc p0, 2, c5, c1, c8, 2                                                                                 
            0x00010074      invalid                                                                                                    
            0x00010078      invalid
```

**Closing issues**

Closes #1671
