### PR TITLE
fill_args: Refactor out code that does closing brackets for optional args

### DIFF
--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -906,6 +906,13 @@ static void fill_wrapped_comment(RzCmd *cmd, RzStrBuf *sb, const char *comment, 
 	}
 }
 
+static void close_optionals(size_t *n_optionals, RzStrBuf *sb, size_t *len) {
+	for (; *n_optionals > 0; (*n_optionals)--) {
+		rz_strbuf_append(sb, "]");
+		(*len)++;
+	}
+}
+
 static size_t fill_args(RzStrBuf *sb, const RzCmdDesc *cd) {
 	const RzCmdDescArg *arg;
 	size_t n_optionals = 0;
@@ -915,10 +922,7 @@ static size_t fill_args(RzStrBuf *sb, const RzCmdDesc *cd) {
 		if (arg->type == RZ_CMD_ARG_TYPE_FAKE) {
 			if (!arg->optional) {
 				// Assume arg is a closing bracket
-				for (; n_optionals > 0; n_optionals--) {
-					rz_strbuf_append(sb, "]");
-					len++;
-				}
+				close_optionals(&n_optionals, sb, &len);
 			}
 			rz_strbuf_append(sb, arg->name);
 			len += strlen(arg->name);
@@ -956,10 +960,7 @@ static size_t fill_args(RzStrBuf *sb, const RzCmdDesc *cd) {
 			}
 		}
 	}
-	for (; n_optionals > 0; n_optionals--) {
-		rz_strbuf_append(sb, "]");
-		len++;
-	}
+	close_optionals(&n_optionals, sb, &len);
 	return len;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr just refactors out the code in `cmd_api.c`'s `fill_args()` that does the closing brackets for optional args.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
