### PR TITLE
Fix oob write for dwarf with abbrev with count 0 (Fix #2083)

### DIFF
--- a/test/db/formats/elf/crash
+++ b/test/db/formats/elf/crash
@@ -25,3 +25,11 @@ nth vaddr bind type lib name
 []
 EOF
 RUN
+
+NAME=ELF/Dwarf: abbrev empty
+FILE=bins/elf/dwarf_fuzzed_abbrev_empty
+CMDS=<<EOF
+aaa
+EOF
+EXPECT=
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

Fix #2083

**Detailed description**

This is described in #2083.