### PR TITLE
RzIL Lifter for 6502

### DIFF
--- a/librz/analysis/p/analysis_6502.c
+++ b/librz/analysis/p/analysis_6502.c
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Florian Märkl <info@florianmaerkl.de>
 // SPDX-FileCopyrightText: 2019-2020 condret <condr3t@protonmail.com>
 // SPDX-FileCopyrightText: 2019-2020 riq <ricardoquesada@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
@@ -16,6 +17,7 @@
 #include <rz_asm.h>
 #include <rz_analysis.h>
 #include "../../asm/arch/snes/snes_op_table.h"
+#include "../../asm/arch/6502/6502_il.inc"
 
 enum {
 	_6502_FLAGS_C = (1 << 0),
@@ -28,7 +30,7 @@ enum {
 	_6502_FLAGS_BNZ = (_6502_FLAGS_B | _6502_FLAGS_Z | _6502_FLAGS_N),
 };
 
-static void _6502_analysis_update_flags(RzAnalysisOp *op, int flags) {
+static void _6502_analysis_esil_update_flags(RzAnalysisOp *op, int flags) {
 	/* FIXME: 9,$b instead of 8,$b to prevent the bug triggered by: A = 0 - 0xff - 1 */
 	if (flags & _6502_FLAGS_B) {
 		rz_strbuf_append(&op->esil, ",9,$b,C,:=");
@@ -45,114 +47,177 @@ static void _6502_analysis_update_flags(RzAnalysisOp *op, int flags) {
 }
 
 /* ORA, AND, EOR, ADC, STA, LDA, CMP and SBC share this pattern */
-static void _6502_analysis_esil_get_addr_pattern1(RzAnalysisOp *op, const ut8 *data, int len, char *addrbuf, int addrsize) {
+static void _6502_analysis_esil_get_addr_pattern1(RzAnalysisOp *op, const ut8 *data, size_t len,
+	RZ_NULLABLE char *esiladdr_out, int esiladdr_size,
+	_6502ILAddr *il_out) {
 	if (len < 1) {
 		return;
 	}
 	// turn off bits 5, 6 and 7
-	switch (data[0] & 0x1f) { // 0x1f = b00111111
+	ut16 imm = 0;
+	switch (data[0] & 0x1f) { // 0x1f = b00011111
 	case 0x09: // op #$ff
 		op->cycles = 2;
-		snprintf(addrbuf, addrsize, "0x%02x", (len > 1) ? data[1] : 0);
+		imm = len > 1 ? data[1] : 0;
+		if (esiladdr_out) {
+			snprintf(esiladdr_out, esiladdr_size, "0x%02x", (unsigned int)imm);
+		}
+		_6502_il_immediate(il_out, imm);
 		break;
 	case 0x05: // op $ff
 		op->cycles = 3;
-		snprintf(addrbuf, addrsize, "0x%02x", (len > 1) ? data[1] : 0);
+		imm = len > 1 ? data[1] : 0;
+		if (esiladdr_out) {
+			snprintf(esiladdr_out, esiladdr_size, "0x%02x", (unsigned int)imm);
+		}
+		_6502_il_addr_absolute(il_out, imm);
 		break;
 	case 0x15: // op $ff,x
 		op->cycles = 4;
-		snprintf(addrbuf, addrsize, "x,0x%02x,+", (len > 1) ? data[1] : 0);
+		imm = len > 1 ? data[1] : 0;
+		if (esiladdr_out) {
+			snprintf(esiladdr_out, esiladdr_size, "x,0x%02x,+", (unsigned int)imm);
+		}
+		_6502_il_addr_zero_page_reg(il_out, imm, "x");
 		break;
 	case 0x0d: // op $ffff
 		op->cycles = 4;
-		snprintf(addrbuf, addrsize, "0x%04x", (len > 2) ? (data[1] | data[2] << 8) : 0);
+		imm = (len > 2) ? ((ut16)data[1] | (ut16)data[2] << 8) : 0;
+		if (esiladdr_out) {
+			snprintf(esiladdr_out, esiladdr_size, "0x%04x", (unsigned int)imm);
+		}
+		_6502_il_addr_absolute(il_out, imm);
 		break;
 	case 0x1d: // op $ffff,x
 		// FIXME: Add 1 if page boundary is crossed.
 		op->cycles = 4;
-		snprintf(addrbuf, addrsize, "x,0x%04x,+", (len > 2) ? data[1] | data[2] << 8 : 0);
+		imm = (len > 2) ? ((ut16)data[1] | (ut16)data[2] << 8) : 0;
+		if (esiladdr_out) {
+			snprintf(esiladdr_out, esiladdr_size, "x,0x%04x,+", (unsigned int)imm);
+		}
+		_6502_il_addr_reg(il_out, imm, "x");
 		break;
 	case 0x19: // op $ffff,y
 		// FIXME: Add 1 if page boundary is crossed.
 		op->cycles = 4;
-		snprintf(addrbuf, addrsize, "y,0x%04x,+", (len > 2) ? data[1] | data[2] << 8 : 0);
+		imm = (len > 2) ? ((ut16)data[1] | (ut16)data[2] << 8) : 0;
+		if (esiladdr_out) {
+			snprintf(esiladdr_out, esiladdr_size, "y,0x%04x,+", (unsigned int)imm);
+		}
+		_6502_il_addr_reg(il_out, imm, "y");
 		break;
 	case 0x01: // op ($ff,x)
 		op->cycles = 6;
-		snprintf(addrbuf, addrsize, "x,0x%02x,+,[2]", (len > 1) ? data[1] : 0);
+		imm = data[1];
+		if (esiladdr_out) {
+			snprintf(esiladdr_out, esiladdr_size, "x,0x%02x,+,[2]", (unsigned int)imm);
+		}
+		_6502_il_addr_indirect_x(il_out, imm);
 		break;
 	case 0x11: // op ($ff),y
 		// FIXME: Add 1 if page boundary is crossed.
 		op->cycles = 5;
-		snprintf(addrbuf, addrsize, "y,0x%02x,[2],+", (len > 1) ? data[1] : 0);
+		imm = len > 1 ? data[1] : 0;
+		if (esiladdr_out) {
+			snprintf(esiladdr_out, esiladdr_size, "y,0x%02x,[2],+", (unsigned int)imm);
+		}
+		_6502_il_addr_indirect_y(il_out, imm);
 		break;
 	}
 }
 
 /* ASL, ROL, LSR, ROR, STX, LDX, DEC and INC share this pattern */
-static void _6502_analysis_esil_get_addr_pattern2(RzAnalysisOp *op, const ut8 *data, int len, char *addrbuf, int addrsize, char reg) {
+static void _6502_analysis_esil_get_addr_pattern2(RzAnalysisOp *op, const ut8 *data, size_t len,
+	char *addrbuf, int addrsize, const char *reg,
+	_6502ILAddr *il_out) {
 	// turn off bits 5, 6 and 7
 	if (len < 1) {
 		return;
 	}
+	ut16 imm = 0;
 	switch (data[0] & 0x1f) { // 0x1f = b00111111
 	case 0x02: // op #$ff
 		op->cycles = 2;
-		snprintf(addrbuf, addrsize, "0x%02x", (len > 1) ? data[1] : 0);
+		imm = (len > 1) ? data[1] : 0;
+		snprintf(addrbuf, addrsize, "0x%02x", (unsigned int)imm);
+		_6502_il_immediate(il_out, imm);
 		break;
 	case 0x0a: // op a
 		op->cycles = 2;
 		snprintf(addrbuf, addrsize, "a");
+		_6502_il_accumulator(il_out);
 		break;
 	case 0x06: // op $ff
 		op->cycles = 5;
-		snprintf(addrbuf, addrsize, "0x%02x", (len > 1) ? data[1] : 0);
+		imm = (len > 1) ? data[1] : 0;
+		snprintf(addrbuf, addrsize, "0x%02x", (unsigned int)imm);
+		_6502_il_addr_absolute(il_out, imm);
 		break;
-	case 0x16: // op $ff,x
+	case 0x16: // op $ff,x (or op $ff,y)
 		op->cycles = 6;
-		snprintf(addrbuf, addrsize, "%c,0x%02x,+", reg, (len > 1) ? data[1] : 0);
+		imm = (len > 1) ? data[1] : 0;
+		snprintf(addrbuf, addrsize, "%s,0x%02x,+", reg, imm);
+		_6502_il_addr_zero_page_reg(il_out, imm, reg);
 		break;
 	case 0x0e: // op $ffff
 		op->cycles = 6;
-		snprintf(addrbuf, addrsize, "0x%04x", (len > 2) ? data[1] | data[2] << 8 : 0);
+		imm = (len > 2) ? data[1] | data[2] << 8 : 0;
+		snprintf(addrbuf, addrsize, "0x%04x", imm);
+		_6502_il_addr_absolute(il_out, imm);
 		break;
-	case 0x1e: // op $ffff,x
+	case 0x1e: // op $ffff,x (or op $ffff,y)
 		op->cycles = 7;
-		snprintf(addrbuf, addrsize, "%c,0x%04x,+", reg, (len > 2) ? data[1] | data[2] << 8 : 0);
+		imm = (len > 2) ? data[1] | data[2] << 8 : 0;
+		snprintf(addrbuf, addrsize, "%s,0x%04x,+", reg, imm);
+		_6502_il_addr_reg(il_out, imm, reg);
 		break;
 	}
 }
 
 /* BIT, JMP, JMP(), STY, LDY, CPY, and CPX share this pattern */
-static void _6502_analysis_esil_get_addr_pattern3(RzAnalysisOp *op, const ut8 *data, int len, char *addrbuf, int addrsize, char reg) {
+static void _6502_analysis_esil_get_addr_pattern3(RzAnalysisOp *op, const ut8 *data, size_t len,
+	char *addrbuf, int addrsize, const char *reg,
+	_6502ILAddr *il_out) {
 	// turn off bits 5, 6 and 7
 	if (len < 1) {
 		return;
 	}
+	ut16 imm;
 	switch (data[0] & 0x1f) { // 0x1f = b00111111
 	case 0x00: // op #$ff
 		op->cycles = 2;
-		snprintf(addrbuf, addrsize, "0x%02x", (len > 1) ? data[1] : 0);
+		imm = (len > 1) ? data[1] : 0;
+		snprintf(addrbuf, addrsize, "0x%02x", imm);
+		_6502_il_immediate(il_out, imm);
 		break;
 	case 0x08: // op a
 		op->cycles = 2;
 		snprintf(addrbuf, addrsize, "a");
+		_6502_il_accumulator(il_out);
 		break;
 	case 0x04: // op $ff
 		op->cycles = 5;
-		snprintf(addrbuf, addrsize, "0x%02x", (len > 1) ? data[1] : 0);
+		imm = (len > 1) ? data[1] : 0;
+		snprintf(addrbuf, addrsize, "0x%02x", imm);
+		_6502_il_addr_absolute(il_out, imm);
 		break;
 	case 0x14: // op $ff,x
 		op->cycles = 6;
-		snprintf(addrbuf, addrsize, "%c,0x%02x,+", reg, (len > 1) ? data[1] : 0);
+		imm = (len > 1) ? data[1] : 0;
+		snprintf(addrbuf, addrsize, "%s,0x%02x,+", reg, imm);
+		_6502_il_addr_zero_page_reg(il_out, imm, reg);
 		break;
 	case 0x0c: // op $ffff
 		op->cycles = 6;
-		snprintf(addrbuf, addrsize, "0x%04x", (len > 2) ? data[1] | data[2] << 8 : 0);
+		imm = (len > 2) ? data[1] | data[2] << 8 : 0;
+		snprintf(addrbuf, addrsize, "0x%04x", imm);
+		_6502_il_addr_absolute(il_out, imm);
 		break;
 	case 0x1c: // op $ffff,x
 		op->cycles = 7;
-		snprintf(addrbuf, addrsize, "%c,0x%04x,+", reg, (len > 2) ? data[1] | data[2] << 8 : 0);
+		imm = (len > 2) ? data[1] | data[2] << 8 : 0;
+		snprintf(addrbuf, addrsize, "%s,0x%04x,+", reg, imm);
+		_6502_il_addr_reg(il_out, imm, reg);
 		break;
 	}
 }
@@ -207,7 +272,7 @@ static void _6502_analysis_esil_inc_reg(RzAnalysisOp *op, ut8 data0, char *sign)
 		break;
 	}
 	rz_strbuf_setf(&op->esil, "%s,%s%s=", reg, sign, sign);
-	_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+	_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
 }
 
 static void _6502_analysis_esil_mov(RzAnalysisOp *op, ut8 data0) {
@@ -246,7 +311,7 @@ static void _6502_analysis_esil_mov(RzAnalysisOp *op, ut8 data0) {
 
 	// don't update NZ on txs
 	if (data0 != 0x9a) {
-		_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
 	}
 }
 
@@ -266,7 +331,7 @@ static void _6502_analysis_esil_pop(RzAnalysisOp *op, ut8 data0) {
 	rz_strbuf_setf(&op->esil, "sp,++=,sp,0x100,+,[1],%s,=", reg);
 
 	if (data0 == 0x68) {
-		_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
 	}
 }
 
@@ -319,6 +384,7 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	op->type = RZ_ANALYSIS_OP_TYPE_UNK;
 	op->id = data[0];
 	rz_strbuf_init(&op->esil);
+	_6502ILAddr il_addr = { 0 };
 	switch (data[0]) {
 	case 0x02:
 	case 0x03:
@@ -441,6 +507,7 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		// PC was already incremented by one at this point. Needs to incremented once more
 		// New PC is Interrupt Vector: $fffe. (FIXME: Confirm this is valid for all 6502)
 		rz_strbuf_set(&op->esil, ",1,I,=,0,D,=,flags,0x10,|,0x100,sp,+,=[1],pc,1,+,0xfe,sp,+,=[2],3,sp,-=,0xfffe,[2],pc,=");
+		op->il_op = _6502_il_op_brk((ut16)addr);
 		break;
 
 	// FLAGS
@@ -455,13 +522,15 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		// FIXME: what opcode for this?
 		op->type = RZ_ANALYSIS_OP_TYPE_NOP;
 		_6502_analysis_esil_flags(op, data[0]);
+		op->il_op = _6502_il_op_flag(data[0]);
 		break;
 	// BIT
 	case 0x24: // bit $ff
 	case 0x2c: // bit $ffff
 		op->type = RZ_ANALYSIS_OP_TYPE_MOV;
-		_6502_analysis_esil_get_addr_pattern3(op, data, len, addrbuf, buffsize, 0);
+		_6502_analysis_esil_get_addr_pattern3(op, data, len, addrbuf, buffsize, NULL, &il_addr);
 		rz_strbuf_setf(&op->esil, "%s,[1],0x80,&,!,!,N,=,%s,[1],0x40,&,!,!,V,=,a,%s,[1],&,0xff,&,!,Z,=", addrbuf, addrbuf, addrbuf);
+		op->il_op = _6502_il_op_bit(&il_addr);
 		break;
 	// ADC
 	case 0x69: // adc #$ff
@@ -475,15 +544,16 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		// FIXME: update V
 		// FIXME: support BCD mode
 		op->type = RZ_ANALYSIS_OP_TYPE_ADD;
-		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize);
+		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize, &il_addr);
 		if (data[0] == 0x69) { // immediate mode
 			rz_strbuf_setf(&op->esil, "%s,a,+=,7,$c,C,a,+=,7,$c,|,C,:=", addrbuf);
 		} else {
 			rz_strbuf_setf(&op->esil, "%s,[1],a,+=,7,$c,C,a,+=,7,$c,|,C,:=", addrbuf);
 		}
-		_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
 		// fix Z
 		rz_strbuf_append(&op->esil, ",a,a,=,$z,Z,:=");
+		op->il_op = _6502_il_op_adc(&il_addr);
 		break;
 	// SBC
 	case 0xe9: // sbc #$ff
@@ -497,15 +567,16 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		// FIXME: update V
 		// FIXME: support BCD mode
 		op->type = RZ_ANALYSIS_OP_TYPE_SUB;
-		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize);
+		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize, &il_addr);
 		if (data[0] == 0xe9) { // immediate mode
 			rz_strbuf_setf(&op->esil, "C,!,%s,+,a,-=", addrbuf);
 		} else {
 			rz_strbuf_setf(&op->esil, "C,!,%s,[1],+,a,-=", addrbuf);
 		}
-		_6502_analysis_update_flags(op, _6502_FLAGS_BNZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_BNZ);
 		// fix Z and revert C
 		rz_strbuf_append(&op->esil, ",a,a,=,$z,Z,:=,C,!=");
+		op->il_op = _6502_il_op_sbc(&il_addr);
 		break;
 	// ORA
 	case 0x09: // ora #$ff
@@ -515,16 +586,19 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case 0x1d: // ora $ffff,x
 	case 0x19: // ora $ffff,y
 	case 0x01: // ora ($ff,x)
-	case 0x11: // ora ($ff),y
+	case 0x11: { // ora ($ff),y
 		op->type = RZ_ANALYSIS_OP_TYPE_OR;
-		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize);
-		if (data[0] == 0x09) { // immediate mode
+		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize, &il_addr);
+		bool is_immediate = data[0] == 0x09;
+		if (is_immediate) { // immediate mode
 			rz_strbuf_setf(&op->esil, "%s,a,|=", addrbuf);
 		} else {
 			rz_strbuf_setf(&op->esil, "%s,[1],a,|=", addrbuf);
 		}
-		_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
+		op->il_op = _6502_il_op_ora(&il_addr);
 		break;
+	}
 	// AND
 	case 0x29: // and #$ff
 	case 0x25: // and $ff
@@ -535,13 +609,15 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case 0x21: // and ($ff,x)
 	case 0x31: // and ($ff),y
 		op->type = RZ_ANALYSIS_OP_TYPE_AND;
-		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize);
-		if (data[0] == 0x29) { // immediate mode
+		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize, &il_addr);
+		bool is_immediate = data[0] == 0x29;
+		if (is_immediate) { // immediate mode
 			rz_strbuf_setf(&op->esil, "%s,a,&=", addrbuf);
 		} else {
 			rz_strbuf_setf(&op->esil, "%s,[1],a,&=", addrbuf);
 		}
-		_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
+		op->il_op = _6502_il_op_and(&il_addr);
 		break;
 	// EOR
 	case 0x49: // eor #$ff
@@ -553,13 +629,14 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case 0x41: // eor ($ff,x)
 	case 0x51: // eor ($ff),y
 		op->type = RZ_ANALYSIS_OP_TYPE_XOR;
-		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize);
+		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize, &il_addr);
 		if (data[0] == 0x49) { // immediate mode
 			rz_strbuf_setf(&op->esil, "%s,a,^=", addrbuf);
 		} else {
 			rz_strbuf_setf(&op->esil, "%s,[1],a,^=", addrbuf);
 		}
-		_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
+		op->il_op = _6502_il_op_eor(&il_addr);
 		break;
 	// ASL
 	case 0x0a: // asl a
@@ -568,13 +645,14 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case 0x0e: // asl $ffff
 	case 0x1e: // asl $ffff,x
 		op->type = RZ_ANALYSIS_OP_TYPE_SHL;
+		_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, "x", &il_addr);
 		if (data[0] == 0x0a) {
 			rz_strbuf_set(&op->esil, "1,a,<<=,7,$c,C,:=,a,a,=");
 		} else {
-			_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, 'x');
 			rz_strbuf_setf(&op->esil, "1,%s,[1],<<,%s,=[1],7,$c,C,:=", addrbuf, addrbuf);
 		}
-		_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
+		op->il_op = _6502_il_op_asl(&il_addr);
 		break;
 	// LSR
 	case 0x4a: // lsr a
@@ -583,13 +661,14 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case 0x4e: // lsr $ffff
 	case 0x5e: // lsr $ffff,x
 		op->type = RZ_ANALYSIS_OP_TYPE_SHR;
+		_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, "x", &il_addr);
 		if (data[0] == 0x4a) {
 			rz_strbuf_set(&op->esil, "1,a,&,C,=,1,a,>>=");
 		} else {
-			_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, 'x');
 			rz_strbuf_setf(&op->esil, "1,%s,[1],&,C,=,1,%s,[1],>>,%s,=[1]", addrbuf, addrbuf, addrbuf);
 		}
-		_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
+		op->il_op = _6502_il_op_lsr(&il_addr);
 		break;
 	// ROL
 	case 0x2a: // rol a
@@ -598,13 +677,14 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case 0x2e: // rol $ffff
 	case 0x3e: // rol $ffff,x
 		op->type = RZ_ANALYSIS_OP_TYPE_ROL;
+		_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, "x", &il_addr);
 		if (data[0] == 0x2a) {
 			rz_strbuf_set(&op->esil, "1,a,<<,C,|,a,=,7,$c,C,:=,a,a,=");
 		} else {
-			_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, 'x');
 			rz_strbuf_setf(&op->esil, "1,%s,[1],<<,C,|,%s,=[1],7,$c,C,:=", addrbuf, addrbuf);
 		}
-		_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
+		op->il_op = _6502_il_op_rol(&il_addr);
 		break;
 	// ROR
 	case 0x6a: // ror a
@@ -615,13 +695,14 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		// uses N as temporary to hold C value. but in fact,
 		// it is not temporary since in all ROR ops, N will have the value of C
 		op->type = RZ_ANALYSIS_OP_TYPE_ROR;
+		_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, "x", &il_addr);
 		if (data[0] == 0x6a) {
 			rz_strbuf_set(&op->esil, "C,N,=,1,a,&,C,=,1,a,>>,7,N,<<,|,a,=");
 		} else {
-			_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, 'x');
 			rz_strbuf_setf(&op->esil, "C,N,=,1,%s,[1],&,C,=,1,%s,[1],>>,7,N,<<,|,%s,=[1]", addrbuf, addrbuf, addrbuf);
 		}
-		_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
+		op->il_op = _6502_il_op_ror(&il_addr);
 		break;
 	// INC
 	case 0xe6: // inc $ff
@@ -629,9 +710,10 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case 0xee: // inc $ffff
 	case 0xfe: // inc $ffff,x
 		op->type = RZ_ANALYSIS_OP_TYPE_STORE;
-		_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, 'x');
+		_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, "x", &il_addr);
 		rz_strbuf_setf(&op->esil, "%s,++=[1]", addrbuf);
-		_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
+		op->il_op = _6502_il_op_inc(&il_addr, true);
 		break;
 	// DEC
 	case 0xc6: // dec $ff
@@ -639,9 +721,10 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case 0xce: // dec $ffff
 	case 0xde: // dec $ffff,x
 		op->type = RZ_ANALYSIS_OP_TYPE_STORE;
-		_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, 'x');
+		_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, "x", &il_addr);
 		rz_strbuf_setf(&op->esil, "%s,--=[1]", addrbuf);
-		_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
+		op->il_op = _6502_il_op_inc(&il_addr, false);
 		break;
 	// INX, INY
 	case 0xe8: // inx
@@ -649,6 +732,7 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		op->cycles = 2;
 		op->type = RZ_ANALYSIS_OP_TYPE_STORE;
 		_6502_analysis_esil_inc_reg(op, data[0], "+");
+		op->il_op = _6502_il_op_inc_reg(data[0] == 0xe8 ? "x" : "y", true);
 		break;
 	// DEX, DEY
 	case 0xca: // dex
@@ -656,6 +740,7 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		op->cycles = 2;
 		op->type = RZ_ANALYSIS_OP_TYPE_STORE;
 		_6502_analysis_esil_inc_reg(op, data[0], "-");
+		op->il_op = _6502_il_op_inc_reg(data[0] == 0xca ? "x" : "y", false);
 		break;
 	// CMP
 	case 0xc9: // cmp #$ff
@@ -667,45 +752,48 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case 0xc1: // cmp ($ff,x)
 	case 0xd1: // cmp ($ff),y
 		op->type = RZ_ANALYSIS_OP_TYPE_CMP;
-		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize);
+		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize, &il_addr);
 		if (data[0] == 0xc9) { // immediate mode
 			rz_strbuf_setf(&op->esil, "%s,a,==", addrbuf);
 		} else {
 			rz_strbuf_setf(&op->esil, "%s,[1],a,==", addrbuf);
 		}
-		_6502_analysis_update_flags(op, _6502_FLAGS_BNZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_BNZ);
 		// invert C, since C=1 when A-M >= 0
 		rz_strbuf_append(&op->esil, ",C,!,C,=");
+		op->il_op = _6502_il_op_cmp("a", &il_addr);
 		break;
 	// CPX
 	case 0xe0: // cpx #$ff
 	case 0xe4: // cpx $ff
 	case 0xec: // cpx $ffff
 		op->type = RZ_ANALYSIS_OP_TYPE_CMP;
-		_6502_analysis_esil_get_addr_pattern3(op, data, len, addrbuf, buffsize, 0);
+		_6502_analysis_esil_get_addr_pattern3(op, data, len, addrbuf, buffsize, NULL, &il_addr);
 		if (data[0] == 0xe0) { // immediate mode
 			rz_strbuf_setf(&op->esil, "%s,x,==", addrbuf);
 		} else {
 			rz_strbuf_setf(&op->esil, "%s,[1],x,==", addrbuf);
 		}
-		_6502_analysis_update_flags(op, _6502_FLAGS_BNZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_BNZ);
 		// invert C, since C=1 when A-M >= 0
 		rz_strbuf_append(&op->esil, ",C,!,C,=");
+		op->il_op = _6502_il_op_cmp("x", &il_addr);
 		break;
 	// CPY
 	case 0xc0: // cpy #$ff
 	case 0xc4: // cpy $ff
 	case 0xcc: // cpy $ffff
 		op->type = RZ_ANALYSIS_OP_TYPE_CMP;
-		_6502_analysis_esil_get_addr_pattern3(op, data, len, addrbuf, buffsize, 0);
+		_6502_analysis_esil_get_addr_pattern3(op, data, len, addrbuf, buffsize, NULL, &il_addr);
 		if (data[0] == 0xc0) { // immediate mode
 			rz_strbuf_setf(&op->esil, "%s,y,==", addrbuf);
 		} else {
 			rz_strbuf_setf(&op->esil, "%s,[1],y,==", addrbuf);
 		}
-		_6502_analysis_update_flags(op, _6502_FLAGS_BNZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_BNZ);
 		// invert C, since C=1 when A-M >= 0
 		rz_strbuf_append(&op->esil, ",C,!,C,=");
+		op->il_op = _6502_il_op_cmp("y", &il_addr);
 		break;
 	// BRANCHES
 	case 0x10: // bpl $ffff
@@ -734,6 +822,7 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		// FIXME: add a type of conditional
 		// op->cond = RZ_TYPE_COND_LE;
 		_6502_analysis_esil_ccall(op, data[0]);
+		op->il_op = _6502_il_op_branch(data[0], op->jump);
 		break;
 	// JSR
 	case 0x20: // jsr $ffff
@@ -746,6 +835,7 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		// control to the following address
 		// stack is on page one and sp is an 8-bit reg: operations must be done like: sp + 0x100
 		rz_strbuf_setf(&op->esil, "1,pc,-,0xff,sp,+,=[2],0x%04" PFMT64x ",pc,=,2,sp,-=", op->jump);
+		op->il_op = _6502_il_op_jsr(op->jump, addr);
 		break;
 	// JMP
 	case 0x4c: // jmp $ffff
@@ -753,14 +843,16 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		op->type = RZ_ANALYSIS_OP_TYPE_JMP;
 		op->jump = (len > 2) ? data[1] | data[2] << 8 : 0;
 		rz_strbuf_setf(&op->esil, "0x%04" PFMT64x ",pc,=", op->jump);
+		op->il_op = _6502_il_op_jmp(op->jump, false);
 		break;
-	case 0x6c: // jmp ($ffff)
+	case 0x6c: { // jmp ($ffff)
 		op->cycles = 5;
 		op->type = RZ_ANALYSIS_OP_TYPE_UJMP;
-		// FIXME: how to read memory?
-		// op->jump = data[1] | data[2] << 8;
-		rz_strbuf_setf(&op->esil, "0x%04x,[2],pc,=", len > 2 ? data[1] | data[2] << 8 : 0);
+		ut16 imm = len > 2 ? data[1] | data[2] << 8 : 0;
+		rz_strbuf_setf(&op->esil, "0x%04x,[2],pc,=", imm);
+		op->il_op = _6502_il_op_jmp(imm, true);
 		break;
+	}
 	// RTS
 	case 0x60: // rts
 		op->eob = true;
@@ -771,6 +863,7 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		// Operation:  PC from Stack, PC + 1 -> PC
 		// stack is on page one and sp is an 8-bit reg: operations must be done like: sp + 0x100
 		rz_strbuf_set(&op->esil, "0x101,sp,+,[2],pc,=,pc,++=,2,sp,+=");
+		op->il_op = _6502_il_op_rts();
 		break;
 	// RTI
 	case 0x40: // rti
@@ -782,11 +875,13 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		// Operation: P from Stack, PC from Stack
 		// stack is on page one and sp is an 8-bit reg: operations must be done like: sp + 0x100
 		rz_strbuf_set(&op->esil, "0x101,sp,+,[1],flags,=,0x102,sp,+,[2],pc,=,3,sp,+=");
+		op->il_op = _6502_il_op_rti();
 		break;
 	// NOP
 	case 0xea: // nop
 		op->type = RZ_ANALYSIS_OP_TYPE_NOP;
 		op->cycles = 2;
+		op->il_op = rz_il_op_new_nop();
 		break;
 	// LDA
 	case 0xa9: // lda #$ff
@@ -798,13 +893,14 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case 0xa1: // lda ($ff,x)
 	case 0xb1: // lda ($ff),y
 		op->type = RZ_ANALYSIS_OP_TYPE_LOAD;
-		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize);
-		if (data[0] == 0xa9) { // immediate mode
+		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize, &il_addr);
+		if (data[0] == 0xa9) {
 			rz_strbuf_setf(&op->esil, "%s,a,=", addrbuf);
 		} else {
 			rz_strbuf_setf(&op->esil, "%s,[1],a,=", addrbuf);
 		}
-		_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
+		op->il_op = _6502_il_op_ld("a", &il_addr);
 		break;
 	// LDX
 	case 0xa2: // ldx #$ff
@@ -813,13 +909,14 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case 0xae: // ldx $ffff
 	case 0xbe: // ldx $ffff,y
 		op->type = RZ_ANALYSIS_OP_TYPE_LOAD;
-		_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, 'y');
+		_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, "y", &il_addr);
 		if (data[0] == 0xa2) { // immediate mode
 			rz_strbuf_setf(&op->esil, "%s,x,=", addrbuf);
 		} else {
 			rz_strbuf_setf(&op->esil, "%s,[1],x,=", addrbuf);
 		}
-		_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
+		op->il_op = _6502_il_op_ld("x", &il_addr);
 		break;
 	// LDY
 	case 0xa0: // ldy #$ff
@@ -828,13 +925,14 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case 0xac: // ldy $ffff
 	case 0xbc: // ldy $ffff,x
 		op->type = RZ_ANALYSIS_OP_TYPE_LOAD;
-		_6502_analysis_esil_get_addr_pattern3(op, data, len, addrbuf, buffsize, 'x');
+		_6502_analysis_esil_get_addr_pattern3(op, data, len, addrbuf, buffsize, "x", &il_addr);
 		if (data[0] == 0xa0) { // immediate mode
 			rz_strbuf_setf(&op->esil, "%s,y,=", addrbuf);
 		} else {
 			rz_strbuf_setf(&op->esil, "%s,[1],y,=", addrbuf);
 		}
-		_6502_analysis_update_flags(op, _6502_FLAGS_NZ);
+		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
+		op->il_op = _6502_il_op_ld("y", &il_addr);
 		break;
 	// STA
 	case 0x85: // sta $ff
@@ -845,24 +943,27 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case 0x81: // sta ($ff,x)
 	case 0x91: // sta ($ff),y
 		op->type = RZ_ANALYSIS_OP_TYPE_STORE;
-		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize);
+		_6502_analysis_esil_get_addr_pattern1(op, data, len, addrbuf, buffsize, &il_addr);
 		rz_strbuf_setf(&op->esil, "a,%s,=[1]", addrbuf);
+		op->il_op = _6502_il_op_st("a", &il_addr);
 		break;
 	// STX
 	case 0x86: // stx $ff
 	case 0x96: // stx $ff,y
 	case 0x8e: // stx $ffff
 		op->type = RZ_ANALYSIS_OP_TYPE_STORE;
-		_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, 'y');
+		_6502_analysis_esil_get_addr_pattern2(op, data, len, addrbuf, buffsize, "y", &il_addr);
 		rz_strbuf_setf(&op->esil, "x,%s,=[1]", addrbuf);
+		op->il_op = _6502_il_op_st("x", &il_addr);
 		break;
 	// STY
 	case 0x84: // sty $ff
 	case 0x94: // sty $ff,x
 	case 0x8c: // sty $ffff
 		op->type = RZ_ANALYSIS_OP_TYPE_STORE;
-		_6502_analysis_esil_get_addr_pattern3(op, data, len, addrbuf, buffsize, 'x');
+		_6502_analysis_esil_get_addr_pattern3(op, data, len, addrbuf, buffsize, "x", &il_addr);
 		rz_strbuf_setf(&op->esil, "y,%s,=[1]", addrbuf);
+		op->il_op = _6502_il_op_st("y", &il_addr);
 		break;
 	// PHP/PHA
 	case 0x08: // php
@@ -872,6 +973,11 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		op->stackop = RZ_ANALYSIS_STACK_INC;
 		op->stackptr = 1;
 		_6502_analysis_esil_push(op, data[0]);
+		if (data[0] == 0x08) {
+			op->il_op = _6502_il_op_php();
+		} else {
+			op->il_op = _6502_il_op_pha();
+		}
 		break;
 	// PLP,PLA
 	case 0x28: // plp
@@ -881,6 +987,11 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		op->stackop = RZ_ANALYSIS_STACK_INC;
 		op->stackptr = -1;
 		_6502_analysis_esil_pop(op, data[0]);
+		if (data[0] == 0x28) {
+			op->il_op = _6502_il_op_plp();
+		} else {
+			op->il_op = _6502_il_op_pla();
+		}
 		break;
 	// TAX,TYA,...
 	case 0xaa: // tax
@@ -890,6 +1001,10 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		op->type = RZ_ANALYSIS_OP_TYPE_MOV;
 		op->cycles = 2;
 		_6502_analysis_esil_mov(op, data[0]);
+		op->il_op = _6502_il_op_transfer(
+			data[0] == 0xaa ? "x" : (data[0] == 0xa8 ? "y" : "a"),
+			data[0] == 0x8a ? "x" : (data[0] == 0x98 ? "y" : "a"),
+			true);
 		break;
 	case 0x9a: // txs
 		op->type = RZ_ANALYSIS_OP_TYPE_MOV;
@@ -898,12 +1013,14 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		// FIXME: should I get register X a place it here?
 		// op->stackptr = get_register_x();
 		_6502_analysis_esil_mov(op, data[0]);
+		op->il_op = _6502_il_op_transfer("sp", "x", false);
 		break;
 	case 0xba: // tsx
 		op->type = RZ_ANALYSIS_OP_TYPE_MOV;
 		op->cycles = 2;
 		op->stackop = RZ_ANALYSIS_STACK_GET;
 		_6502_analysis_esil_mov(op, data[0]);
+		op->il_op = _6502_il_op_transfer("x", "sp", true);
 		break;
 	}
 	return op->size;
@@ -954,6 +1071,32 @@ static int address_bits(RzAnalysis *analysis, int bits) {
 	return 16;
 }
 
+static bool il_6502_init(RzAnalysis *analysis) {
+	rz_return_val_if_fail(analysis && analysis->rzil, false);
+	RzAnalysisRzil *rzil = analysis->rzil;
+	if (rzil->inited) {
+		RZ_LOG_ERROR("RzIL: 6502: already initialized\n");
+		return true;
+	}
+	RzILVM *vm = rzil->vm;
+	if (!rz_il_vm_init(rzil->vm, 0, 16, 8)) {
+		RZ_LOG_ERROR("RzIL: 6502: failed to initialize VM\n");
+		return false;
+	}
+
+	rz_il_vm_add_mem(vm, 0, rz_il_mem_new(rzil->io_buf, 16));
+
+	return true;
+}
+
+static bool il_6502_fini(RzAnalysis *analysis) {
+	rz_return_val_if_fail(analysis && analysis->rzil, false);
+	RzAnalysisRzil *rzil = analysis->rzil;
+	rzil->user = NULL;
+	rzil->inited = false;
+	return true;
+}
+
 RzAnalysisPlugin rz_analysis_plugin_6502 = {
 	.name = "6502",
 	.desc = "6502/NES analysis plugin",
@@ -966,6 +1109,8 @@ RzAnalysisPlugin rz_analysis_plugin_6502 = {
 	.esil = true,
 	.esil_init = esil_6502_init,
 	.esil_fini = esil_6502_fini,
+	.rzil_init = il_6502_init,
+	.rzil_fini = il_6502_fini
 };
 
 #ifndef RZ_PLUGIN_INCORE

--- a/librz/asm/arch/6502/6502_il.inc
+++ b/librz/asm/arch/6502/6502_il.inc
@@ -1,0 +1,586 @@
+// SPDX-FileCopyrightText: 2022 Florian Märkl <info@florianmaerkl.de>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+/**
+ * \file
+ * 6502 Lifting to be included from analysis_6502.c and plugged directly into the decoding logic.
+ */
+// clang-format off
+
+#include <rz_il.h>
+
+typedef enum {
+	_6502_ADDR_KIND_ADDR,
+	_6502_ADDR_KIND_IMMEDIATE,
+	_6502_ADDR_KIND_ACCUMULATOR
+} _6502AddrKind;
+
+typedef struct {
+	_6502AddrKind kind;
+	RzILOpBitVector *addr; ///< either the addr, or the immediate value if immedate, or NULL if accumulator
+} _6502ILAddr;
+
+#include <rz_il/rz_il_opbuilder_begin.h>
+
+// Different common addressing modes, producing a pure value to be used for the actual instruction
+// They receive the raw 1 or 2-byte value that follows the opcode byte.
+// https://www.masswerk.at/6502/6502_instruction_set.html#description
+
+/**
+ * op a
+ */
+static void _6502_il_accumulator(_6502ILAddr *out) {
+	out->kind = _6502_ADDR_KIND_ACCUMULATOR;
+	out->addr = VARG("a");
+}
+
+/**
+ * op #$ff
+ */
+static void _6502_il_immediate(_6502ILAddr *out, ut16 imm) {
+	out->kind = _6502_ADDR_KIND_IMMEDIATE;
+	out->addr = U8(imm);
+}
+
+/**
+ * op $ff
+ * op $ffff
+ */
+static void _6502_il_addr_absolute(_6502ILAddr *out, ut16 imm) {
+	out->kind = _6502_ADDR_KIND_ADDR;
+	out->addr = U16(imm);
+}
+
+/**
+ * op $ff,x
+ * op $ff,y
+ */
+static void _6502_il_addr_zero_page_reg(_6502ILAddr *out, ut16 imm, const char *reg) {
+	out->kind = _6502_ADDR_KIND_ADDR;
+	out->addr = UNSIGNED(16, ADD(U8(imm), VARG(reg)));
+}
+
+/**
+ * op $ffff,x
+ * op $ffff,y
+ */
+static void _6502_il_addr_reg(_6502ILAddr *out, ut16 imm, const char *reg) {
+	out->kind = _6502_ADDR_KIND_ADDR;
+	out->addr = ADD(U16(imm), UNSIGNED(16, VARG(reg)));
+}
+
+/**
+ * op ($ff,x)
+ */
+static void _6502_il_addr_indirect_x(_6502ILAddr *out, ut16 imm) {
+	out->kind = _6502_ADDR_KIND_ADDR;
+	RzILOpPure *zp = ADD(U8(imm), VARG("x"));
+	out->addr = APPEND(
+		LOAD(UNSIGNED(16, ADD(DUP(zp), U8(1)))),
+		LOAD(UNSIGNED(16, zp))
+	);
+}
+
+/**
+ * op ($ff),y
+ */
+static void _6502_il_addr_indirect_y(_6502ILAddr *out, ut16 imm) {
+	out->kind = _6502_ADDR_KIND_ADDR;
+	RzILOpPure *zp = U8(imm);
+	RzILOpPure *base = APPEND(
+		LOAD(UNSIGNED(16, ADD(DUP(zp), U8(1)))),
+		LOAD(UNSIGNED(16, zp))
+	);
+	out->addr = ADD(base, UNSIGNED(16, VARG("y")));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Flags and stack handling
+
+static RzILOpEffect *update_flags_nz(RzILOpPure *val) {
+	return SEQ2(
+		SETG("Z", IS_ZERO(val)),
+		SETG("N", MSB(DUP(val)))
+	);
+}
+
+static RzILOpBitVector *status_byte(bool b) {
+	RzILOpBitVector *r = LOGOR(
+		ITE(VARG("N"), U8(0x80), U8(0)),
+		LOGOR(ITE(VARG("V"), U8(0x40), U8(0)),
+		LOGOR(ITE(VARG("D"), U8(0x08), U8(0)),
+		LOGOR(ITE(VARG("I"), U8(0x04), U8(0)),
+		LOGOR(ITE(VARG("Z"), U8(0x02), U8(0)),
+		ITE(VARG("C"), U8(0x01), U8(0)))))));
+	return b ? LOGOR(r, U8(0x20)) : r;
+}
+
+static RzILOpEffect *status_byte_apply(RzILOpBitVector *sb) {
+	return SEQ(6,
+		SETG("N", MSB(sb)),
+		SETG("V", INV(IS_ZERO(LOGAND(DUP(sb), U8(0x40))))),
+		SETG("D", INV(IS_ZERO(LOGAND(DUP(sb), U8(0x08))))),
+		SETG("I", INV(IS_ZERO(LOGAND(DUP(sb), U8(0x04))))),
+		SETG("Z", INV(IS_ZERO(LOGAND(DUP(sb), U8(0x02))))),
+		SETG("C", LSB(DUP(sb)))
+	);
+}
+
+static RzILOpEffect *stack_push(RzILOpBitVector *v) {
+	return SEQ2(
+		SETG("sp", SUB(VARG("sp"), U8(1))),
+		STORE(APPEND(U8(1), VARG("sp")), v));
+}
+
+static RzILOpEffect *stack_pop(const char *varname) {
+	return SEQ2(
+		SETL(varname, LOAD(APPEND(U8(1), VARG("sp")))),
+		SETG("sp", ADD(VARG("sp"), U8(1))));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// The ops themselves, taking a value aquired from one of the functions above,
+// and (if possible) the information whether this is an immediate value or
+// an address to dereference.
+
+static RzILOpBitVector *do_load(_6502ILAddr *addr) {
+	switch (addr->kind) {
+	case _6502_ADDR_KIND_ADDR:
+		return LOAD(addr->addr);
+	case _6502_ADDR_KIND_IMMEDIATE:
+		return addr->addr;
+	case _6502_ADDR_KIND_ACCUMULATOR:
+		return VARG("a");
+	default:
+		rz_warn_if_reached();
+		return NULL;
+	}
+}
+
+/**
+ * Dup addr->addr, for when both do_load and do_store should be used,
+ * because it is moved, not copied.
+ */
+static _6502ILAddr *dup_addr(_6502ILAddr *addr) {
+	if (addr->addr) {
+		addr->addr = DUP(addr->addr);
+	}
+	return addr;
+}
+
+static RzILOpEffect *do_store(_6502ILAddr *addr, RzILOpBitVector *v) {
+	switch (addr->kind) {
+	case _6502_ADDR_KIND_ADDR:
+		return STORE(addr->addr, v);
+	case _6502_ADDR_KIND_ACCUMULATOR:
+		return SETG("a", v);
+	default:
+		// can't store to immediate
+		rz_warn_if_reached();
+		return NULL;
+	}
+}
+
+/**
+ * lda
+ * ldx
+ * ldy
+ */
+static RzILOpEffect *_6502_il_op_ld(const char *reg, _6502ILAddr *addr) {
+	RzILOpBitVector *v = do_load(addr);
+	return SEQ2(
+		SETG(reg, v),
+		update_flags_nz(VARG(reg))
+	);
+}
+
+/**
+ * sta
+ * stx
+ * sty
+ */
+static RzILOpEffect *_6502_il_op_st(const char *reg, _6502ILAddr *addr) {
+	return do_store(addr, VARG(reg));
+}
+
+/**
+ * and
+ */
+static RzILOpEffect *_6502_il_op_and(_6502ILAddr *addr) {
+	RzILOpBitVector *v = do_load(addr);
+	return SEQ2(
+		SETG("a", LOGAND(VARG("a"), v)),
+		update_flags_nz(VARG("a"))
+	);
+}
+
+/**
+ * ora
+ */
+static RzILOpEffect *_6502_il_op_ora(_6502ILAddr *addr) {
+	RzILOpBitVector *v = do_load(addr);
+	return SEQ2(
+		SETG("a", LOGOR(VARG("a"), v)),
+		update_flags_nz(VARG("a"))
+	);
+}
+
+/**
+ * eor
+ */
+static RzILOpEffect *_6502_il_op_eor(_6502ILAddr *addr) {
+	RzILOpBitVector *v = do_load(addr);
+	return SEQ2(
+		SETG("a", LOGXOR(VARG("a"), v)),
+		update_flags_nz(VARG("a"))
+	);
+}
+
+/**
+ * adc
+ */
+static RzILOpEffect *_6502_il_op_adc(_6502ILAddr *addr) {
+	// TODO: bcd if D
+	return SEQ(6,
+		SETL("src", do_load(addr)),
+		SETL("res", ADD(
+			ITE(VARG("C"), U8(1), U8(0)),
+			ADD(VARG("a"), VARL("src")))),
+		update_flags_nz(VARL("res")),
+		SETG("C", ITE(VARG("C"), ULE(VARL("res"), VARG("a")), ULT(VARL("res"), VARG("a")))),
+		SETG("V",
+			AND(
+				INV(XOR(MSB(VARG("a")), MSB(VARL("src")))),
+				XOR(MSB(VARG("a")), MSB(VARL("res"))))),
+		SETG("a", VARL("res")));
+}
+
+/**
+ * sbc
+ */
+static RzILOpEffect *_6502_il_op_sbc(_6502ILAddr *addr) {
+	// TODO: bcd if D
+	return SEQ(7,
+		SETL("src", do_load(addr)),
+		SETL("res", SUB(
+			UNSIGNED(9, VARG("a")),
+			SUB(UNSIGNED(9, VARL("src")),
+				ITE(VARG("C"), UN(9, 0), UN(9, 1))))),
+		SETG("C", INV(MSB(VARL("res")))),
+		SETL("res8", UNSIGNED(8, VARL("res"))),
+		update_flags_nz(VARL("res8")),
+		SETG("V",
+			AND(
+				XOR(MSB(VARG("a")), MSB(VARL("res"))),
+				XOR(MSB(VARG("a")), MSB(VARL("src"))))),
+		SETG("a", VARL("res8")));
+}
+
+/**
+ * asl
+ */
+static RzILOpEffect *_6502_il_op_asl(_6502ILAddr *addr) {
+	RzILOpEffect *load = SETL("tmp", do_load(addr));
+	return SEQ(5,
+		load,
+		SETG("C", MSB(VARL("tmp"))),
+		SETL("tmp", SHIFTL0(VARL("tmp"), UN(3, 1))),
+		do_store(dup_addr(addr), VARL("tmp")),
+		update_flags_nz(VARL("tmp"))
+	);
+}
+
+/**
+ * lsr
+ */
+static RzILOpEffect *_6502_il_op_lsr(_6502ILAddr *addr) {
+	RzILOpEffect *load = SETL("tmp", do_load(addr));
+	return SEQ(5,
+		load,
+		SETG("C", LSB(VARL("tmp"))),
+		SETL("tmp", SHIFTR0(VARL("tmp"), UN(3, 1))),
+		do_store(dup_addr(addr), VARL("tmp")),
+		SETG("Z", IS_ZERO(VARL("tmp"))),
+		SETG("N", IL_FALSE)
+	);
+}
+
+typedef enum {
+	_6502_BRANCH_ON_PLUS = 0x10,
+	_6502_BRANCH_ON_MINUS = 0x30,
+	_6502_BRANCH_ON_OVERFLOW_CLEAR = 0x50,
+	_6502_BRANCH_ON_OVERFLOW_SET = 0x70,
+	_6502_BRANCH_ON_CARRY_CLEAR = 0x90,
+	_6502_BRANCH_ON_CARRY_SET = 0xb0,
+	_6502_BRANCH_ON_NOT_EQUAL = 0xd0,
+	_6502_BRANCH_ON_EQUAL = 0xf0
+} _6502BranchCond;
+
+
+/**
+ * bpl
+ * bmi
+ * bvc
+ * bvs
+ * bcc
+ * bcs
+ * bne
+ * beq
+ */
+static RzILOpEffect *_6502_il_op_branch(_6502BranchCond cond, ut16 target) {
+	RzILOpBool *c;
+	switch (cond) {
+	case _6502_BRANCH_ON_PLUS:
+		c = INV(VARG("N"));
+		break;
+	case _6502_BRANCH_ON_MINUS:
+		c = VARG("N");
+		break;
+	case _6502_BRANCH_ON_OVERFLOW_CLEAR:
+		c = INV(VARG("V"));
+		break;
+	case _6502_BRANCH_ON_OVERFLOW_SET:
+		c = VARG("V");
+		break;
+	case _6502_BRANCH_ON_CARRY_CLEAR:
+		c = INV(VARG("C"));
+		break;
+	case _6502_BRANCH_ON_CARRY_SET:
+		c = VARG("C");
+		break;
+	case _6502_BRANCH_ON_NOT_EQUAL:
+		c = INV(VARG("Z"));
+		break;
+	case _6502_BRANCH_ON_EQUAL:
+		c = VARG("Z");
+		break;
+	default:
+		rz_warn_if_reached();
+		return NULL;
+	}
+	return BRANCH(c, JMP(U16(target)), NOP);
+}
+
+/**
+ * jmp
+ */
+static RzILOpEffect *_6502_il_op_jmp(ut16 target, bool indir) {
+	RzILOpBitVector *addr = U16(target);
+	return JMP(indir ? LOADW(16, addr) : addr);
+}
+
+/**
+ * brk
+ */
+static RzILOpEffect *_6502_il_op_brk(ut16 offset) {
+	offset += 2;
+	return SEQ(6,
+		stack_push(U8((ut8)(offset >> 8))),
+		stack_push(U8((ut8)offset)),
+		stack_push(status_byte(true)),
+		SETG("D", IL_FALSE),
+		SETG("I", IL_TRUE),
+		JMP(LOADW(16, U16(0xfffe)))
+	);
+}
+
+/**
+ * jsr
+ */
+static RzILOpEffect *_6502_il_op_jsr(ut16 target, ut64 offset) {
+	offset += 2; // yes, this is **inside** the jsr.
+	return SEQ(3,
+		stack_push(U8((ut8)(offset >> 8))),
+		stack_push(U8((ut8)offset)),
+		JMP(U16(target)));
+}
+
+/**
+ * rti
+ */
+static RzILOpEffect *_6502_il_op_rti() {
+	return SEQ(3,
+		stack_pop("sr"),
+		status_byte_apply(VARL("sr")),
+		stack_pop("pcl"),
+		stack_pop("pch"),
+		JMP(APPEND(VARL("pch"), VARL("pcl"))));
+}
+
+/**
+ * rts
+ */
+static RzILOpEffect *_6502_il_op_rts() {
+	return SEQ(3,
+		stack_pop("pcl"),
+		stack_pop("pch"),
+		JMP(ADD(APPEND(VARL("pch"), VARL("pcl")), U16(1))));
+}
+
+/**
+ * bit
+ */
+static RzILOpEffect *_6502_il_op_bit(_6502ILAddr *addr) {
+	return SEQ(4,
+		SETL("tmp", do_load(addr)),
+		SETG("N", MSB(VARL("tmp"))),
+		SETG("V", MSB(UNSIGNED(7, VARL("tmp")))),
+		SETG("Z", IS_ZERO(LOGAND(VARL("tmp"), VARG("a"))))
+	);
+}
+
+typedef enum {
+	_6502_FLAG_OP_SET_I = 0x78,
+	_6502_FLAG_OP_CLEAR_I = 0x58,
+	_6502_FLAG_OP_SET_C = 0x38,
+	_6502_FLAG_OP_CLEAR_C = 0x18,
+	_6502_FLAG_OP_SET_D = 0xf8,
+	_6502_FLAG_OP_CLEAR_D = 0xd8,
+	_6502_FLAG_OP_CLEAR_V = 0xb8
+} _6502FlagOp;
+
+/**
+ * sei
+ * cli
+ * sec
+ * clc
+ * sed
+ * cld
+ * clv
+ */
+static RzILOpEffect *_6502_il_op_flag(_6502FlagOp op) {
+	switch (op) {
+	case _6502_FLAG_OP_SET_I:
+		return SETG("I", IL_TRUE);
+	case _6502_FLAG_OP_CLEAR_I:
+		return SETG("I", IL_FALSE);
+	case _6502_FLAG_OP_SET_C:
+		return SETG("C", IL_TRUE);
+	case _6502_FLAG_OP_CLEAR_C:
+		return SETG("C", IL_FALSE);
+	case _6502_FLAG_OP_SET_D:
+		return SETG("D", IL_TRUE);
+	case _6502_FLAG_OP_CLEAR_D:
+		return SETG("D", IL_FALSE);
+	case _6502_FLAG_OP_CLEAR_V:
+		return SETG("V", IL_FALSE);
+	default:
+		rz_warn_if_reached();
+		return NULL;
+	}
+}
+
+/**
+ * cmp
+ * cpx
+ * cpy
+ */
+static RzILOpEffect *_6502_il_op_cmp(const char *reg, _6502ILAddr *addr) {
+	return SEQ(3,
+		SETL("tmp", SUB(UNSIGNED(9, VARG(reg)), UNSIGNED(9, do_load(addr)))),
+		SETG("C", INV(MSB(VARL("tmp")))),
+		update_flags_nz(UNSIGNED(8, VARL("tmp")))
+	);
+}
+
+/**
+ * inx
+ * iny
+ * dex
+ * dey
+ */
+static RzILOpEffect *_6502_il_op_inc_reg(const char *reg, bool inc) {
+	RzILOpBitVector *v = inc ? ADD(VARG(reg), U8(1)) : SUB(VARG(reg), U8(1));
+	return SEQ2(
+		SETG(reg, v),
+		update_flags_nz(UNSIGNED(8, VARG(reg)))
+	);
+}
+
+/**
+ * inc
+ * dec
+ */
+static RzILOpEffect *_6502_il_op_inc(_6502ILAddr *addr, bool inc) {
+	RzILOpBitVector *v = inc ? ADD(do_load(addr), U8(1)) : SUB(do_load(addr), U8(1));
+	return SEQ(3,
+		SETL("tmp", v),
+		do_store(dup_addr(addr), VARL("tmp")),
+		update_flags_nz(VARL("tmp"))
+	);
+}
+
+/**
+ * pha
+ */
+static RzILOpEffect *_6502_il_op_pha() {
+	return stack_push(VARG("a"));
+}
+
+/**
+ * php
+ */
+static RzILOpEffect *_6502_il_op_php() {
+	return stack_push(status_byte(true));
+}
+
+/**
+ * pla
+ */
+static RzILOpEffect *_6502_il_op_pla() {
+	return SEQ(3,
+		stack_pop("tmp"),
+		SETG("a", VARL("tmp")),
+		update_flags_nz(VARL("tmp")));
+}
+
+/**
+ * plp
+ */
+static RzILOpEffect *_6502_il_op_plp() {
+	return SEQ2(
+		stack_pop("tmp"),
+		status_byte_apply(VARL("tmp")));
+}
+
+/**
+ * rol
+ */
+static RzILOpEffect *_6502_il_op_rol(_6502ILAddr *addr) {
+	RzILOpEffect *load = SETL("tmp", do_load(addr));
+	return SEQ(5,
+		load,
+		SETL("res", LOGOR(SHIFTL0(VARL("tmp"), UN(3, 1)), ITE(VARG("C"), U8(1), U8(0)))),
+		SETG("C", MSB(VARL("tmp"))),
+		do_store(dup_addr(addr), VARL("res")),
+		update_flags_nz(VARL("res")));
+}
+
+/**
+ * ror
+ */
+static RzILOpEffect *_6502_il_op_ror(_6502ILAddr *addr) {
+	RzILOpEffect *load = SETL("tmp", do_load(addr));
+	return SEQ(5,
+		load,
+		SETL("res", LOGOR(SHIFTR0(VARL("tmp"), UN(3, 1)), ITE(VARG("C"), U8(0x80), U8(0)))),
+		SETG("C", LSB(VARL("tmp"))),
+		do_store(dup_addr(addr), VARL("res")),
+		update_flags_nz(VARL("res")));
+}
+
+/**
+ * tax
+ * tay
+ * tsx
+ * txa
+ * txs
+ * tya
+ */
+static RzILOpEffect *_6502_il_op_transfer(const char *dst, const char *src, bool update_flags) {
+	RzILOpEffect *tf = SETG(dst, VARG(src));
+	return update_flags ? SEQ2(tf, update_flags_nz(VARG(dst))) : tf;
+}
+
+#include <rz_il/rz_il_opbuilder_end.h>
+// clang-format on

--- a/librz/il/definitions/variable.c
+++ b/librz/il/definitions/variable.c
@@ -174,3 +174,19 @@ RZ_API RZ_BORROW RzILVal *rz_il_var_set_get_value(RzILVarSet *vs, const char *na
 	rz_return_val_if_fail(vs && name, NULL);
 	return ht_pp_find(vs->contents, name, NULL);
 }
+
+/**
+ * Get a readable string representation of \p kind
+ */
+const char *rz_il_var_kind_name(RzILVarKind kind) {
+	switch (kind) {
+	case RZ_IL_VAR_KIND_GLOBAL:
+		return "global";
+	case RZ_IL_VAR_KIND_LOCAL:
+		return "local";
+	case RZ_IL_VAR_KIND_LOCAL_PURE:
+		return "local pure";
+	default:
+		return "invalid";
+	}
+}

--- a/librz/il/il_opcodes.c
+++ b/librz/il/il_opcodes.c
@@ -280,6 +280,26 @@ RZ_API RZ_OWN RzILOpBool *rz_il_op_new_sle(RZ_NONNULL RzILOpBitVector *x, RZ_NON
 }
 
 /**
+ * unsigned strict less than
+ */
+RZ_API RZ_OWN RzILOpBool *rz_il_op_new_ult(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y) {
+	rz_return_val_if_fail(x && y, NULL);
+	return rz_il_op_new_bool_and(
+		rz_il_op_new_ule(x, y),
+		rz_il_op_new_bool_inv(rz_il_op_new_eq(rz_il_op_pure_dup(x), rz_il_op_pure_dup(y))));
+}
+
+/**
+ * signed strict less than
+ */
+RZ_API RZ_OWN RzILOpBool *rz_il_op_new_slt(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y) {
+	rz_return_val_if_fail(x && y, NULL);
+	return rz_il_op_new_bool_and(
+		rz_il_op_new_sle(x, y),
+		rz_il_op_new_bool_inv(rz_il_op_new_eq(rz_il_op_pure_dup(x), rz_il_op_pure_dup(y))));
+}
+
+/**
  *  \brief op structure for casting bitv
  */
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_cast(ut32 length, RZ_NONNULL RzILOpBool *fill, RZ_NONNULL RzILOpBitVector *val) {
@@ -723,6 +743,7 @@ RZ_API RzILOpPure *rz_il_op_pure_dup(RZ_NONNULL RzILOpPure *op) {
 	switch (op->code) {
 	case RZ_IL_OP_VAR:
 		r->op.var.v = op->op.var.v;
+		r->op.var.kind = op->op.var.kind;
 		break;
 	case RZ_IL_OP_ITE:
 		DUP_OP3(ite, condition, x, y);

--- a/librz/il/il_vm_eval.c
+++ b/librz/il/il_vm_eval.c
@@ -312,7 +312,7 @@ RZ_API RZ_NULLABLE RZ_OWN RzILVal *rz_il_evaluate_val(RZ_NONNULL RzILVM *vm, RZ_
 	case RZ_IL_TYPE_PURE_BITVECTOR:
 		return rz_il_value_new_bitv(res);
 	default:
-		RZ_LOG_ERROR("RzIL: type error: expected bitvector, got %s\n", pure_type_name(type));
+		RZ_LOG_ERROR("RzIL: type error: got %s\n", pure_type_name(type));
 		return NULL;
 	}
 }

--- a/librz/il/theory_init.c
+++ b/librz/il/theory_init.c
@@ -45,6 +45,8 @@ void *rz_il_handler_var(RzILVM *vm, RzILOpPure *op, RzILTypePure *type) {
 	RzILOpArgsVar *var_op = &op->op.var;
 	RzILVal *val = rz_il_vm_get_var_value(vm, var_op->kind, var_op->v);
 	if (!val) {
+		RZ_LOG_ERROR("RzIL: reading value of variable \"%s\" of kind %s failed.\n",
+			var_op->v, rz_il_var_kind_name(var_op->kind));
 		return NULL;
 	}
 

--- a/librz/include/meson.build
+++ b/librz/include/meson.build
@@ -128,6 +128,8 @@ install_headers(rz_il_definitions_files, install_dir: join_paths(rizin_incdir, '
 
 rz_il_files = [
   'rz_il/rz_il_opcodes.h',
+  'rz_il/rz_il_opbuilder_begin.h',
+  'rz_il/rz_il_opbuilder_end.h',
   'rz_il/rz_il_events.h',
   'rz_il/rz_il_reg.h',
   'rz_il/rz_il_validate.h',

--- a/librz/include/rz_il/definitions/variable.h
+++ b/librz/include/rz_il/definitions/variable.h
@@ -49,6 +49,8 @@ typedef enum {
 	RZ_IL_VAR_KIND_LOCAL_PURE ///< local pure var, bound only by let expressions, scope is limited to the let's pure body, thus it's immutable.
 } RzILVarKind;
 
+const char *rz_il_var_kind_name(RzILVarKind kind);
+
 #ifdef __cplusplus
 }
 #endif

--- a/librz/include/rz_il/rz_il_opbuilder_begin.h
+++ b/librz/include/rz_il/rz_il_opbuilder_begin.h
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2021 Florian Märkl <info@florianmaerkl.de>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+/**
+ * \file
+ * \brief Syntax Macros for RzIL Lifting
+ *
+ * This header introduces a number of short macros for conveniently building RzIL
+ * expressions without having to type out `rz_il_op_new_...`.
+ *
+ * It is intended to be used like this, for example when lifting IL from an architecture:
+ *
+ *     #include <rz_il/rz_il_opbuilder_begin.h>
+ *
+ *     RzILOpEffect *lift_my_op() {
+ *         return SEQ(3,
+ *             SETG("a", U8(42)),
+ *             SETG("x", U8(123)),
+ *             STORE(0xcafe, VARG("a")));
+ *     }
+ *
+ *     #include <rz_il/rz_il_opbuilder_end.h>
+ *
+ * Because of their short nature, these macros may conflict with other code. As such,
+ * it should never be included in any public headers, and should be closed by an
+ * `#include <rz_il/rz_il_opbuilder_end.h>` when not needed anymore, which `#undef`s
+ * everything again.
+ *
+ * Consequently, when editing this file, always make sure to keep `rz_il_opbuilder_end.h`
+ * in sync!
+ */
+
+#ifndef RZ_IL_OPBUILDER_BEGIN_H
+#define RZ_IL_OPBUILDER_BEGIN_H
+
+#include "rz_il_opcodes.h"
+
+#define ITE(c, t, f) rz_il_op_new_ite(c, t, f)
+
+#define UN(l, val) rz_il_op_new_bitv_from_ut64(l, val)
+#define U8(val)    UN(8, val)
+#define U16(val)   UN(16, val)
+#define U32(val)   UN(32, val)
+#define U64(val)   UN(64, val)
+
+#define SN(l, val) rz_il_op_new_bitv_from_st64(l, val)
+#define S8(val)    SN(8, val)
+#define S16(val)   SN(16, val)
+#define S32(val)   SN(32, val)
+#define S64(val)   SN(64, val)
+
+#define IL_FALSE  rz_il_op_new_b0()
+#define IL_TRUE   rz_il_op_new_b1()
+#define INV(x)    rz_il_op_new_bool_inv(x)
+#define XOR(x, y) rz_il_op_new_bool_xor(x, y)
+#define AND(x, y) rz_il_op_new_bool_and(x, y)
+
+#define ADD(x, y)        rz_il_op_new_add(x, y)
+#define SUB(x, y)        rz_il_op_new_sub(x, y)
+#define SHIFTL0(v, dist) rz_il_op_new_shiftl(IL_FALSE, v, dist)
+#define SHIFTR0(v, dist) rz_il_op_new_shiftr(IL_FALSE, v, dist)
+#define LOGAND(x, y)     rz_il_op_new_log_and(x, y)
+#define LOGOR(x, y)      rz_il_op_new_log_or(x, y)
+#define LOGXOR(x, y)     rz_il_op_new_log_xor(x, y)
+
+#define IS_ZERO(x) rz_il_op_new_is_zero(x)
+#define MSB(x)     rz_il_op_new_msb(x)
+#define LSB(x)     rz_il_op_new_lsb(x)
+#define ULT(x, y)  rz_il_op_new_ult(x, y)
+#define ULE(x, y)  rz_il_op_new_ule(x, y)
+
+#define LOAD(addr)       rz_il_op_new_load(0, addr)
+#define LOADW(n, addr)   rz_il_op_new_loadw(0, addr, n)
+#define STORE(addr, val) rz_il_op_new_store(0, addr, val)
+
+#define VARG(name)    rz_il_op_new_var(name, RZ_IL_VAR_KIND_GLOBAL)
+#define VARL(name)    rz_il_op_new_var(name, RZ_IL_VAR_KIND_LOCAL)
+#define VARLP(name)   rz_il_op_new_var(name, RZ_IL_VAR_KIND_LOCAL_PURE)
+#define SETG(name, v) rz_il_op_new_set(name, false, v)
+#define SETL(name, v) rz_il_op_new_set(name, true, v)
+
+#define UNSIGNED(n, x)    rz_il_op_new_unsigned(n, x)
+#define APPEND(high, low) rz_il_op_new_append(high, low)
+#define DUP(op)           rz_il_op_pure_dup(op)
+
+#define SEQ(n, ...)     rz_il_op_new_seqn(n, __VA_ARGS__)
+#define SEQ2(e0, e1)    rz_il_op_new_seq(e0, e1)
+#define NOP             rz_il_op_new_nop()
+#define BRANCH(c, t, f) rz_il_op_new_branch(c, t, f)
+#define JMP(tgt)        rz_il_op_new_jmp(tgt)
+
+#endif

--- a/librz/include/rz_il/rz_il_opbuilder_end.h
+++ b/librz/include/rz_il/rz_il_opbuilder_end.h
@@ -1,0 +1,60 @@
+
+#ifndef RZ_IL_OPBUILDER_BEGIN_H
+#error rz_il_opbuilder_end.h included without rz_il_opbuilder_begin.h before
+#endif
+
+#undef ITE
+
+#undef UN
+#undef U8
+#undef U16
+#undef U32
+#undef U64
+
+#undef SN
+#undef S8
+#undef S16
+#undef S32
+#undef S64
+
+#undef IL_FALSE
+#undef IL_TRUE
+#undef INV
+#undef XOR
+#undef AND
+
+#undef ADD
+#undef SUB
+#undef SHIFTL0
+#undef SHIFTR0
+#undef LOGAND
+#undef LOGOR
+#undef LOGXOR
+
+#undef IS_ZERO
+#undef MSB
+#undef LSB
+#undef ULT
+#undef ULE
+
+#undef LOAD
+#undef LOADW
+#undef STORE
+
+#undef VARG
+#undef VARL
+#undef VARLP
+#undef SETG
+#undef SETL
+
+#undef UNSIGNED
+#undef APPEND
+#undef DUP
+
+#undef SEQ
+#undef SEQ2
+#undef NOP
+#undef BRANCH
+#undef JMP
+
+#undef RZ_IL_OPBUILDER_BEGIN_H

--- a/librz/include/rz_il/rz_il_opcodes.h
+++ b/librz/include/rz_il/rz_il_opcodes.h
@@ -459,6 +459,8 @@ RZ_API RZ_OWN RzILOpBool *rz_il_op_new_non_zero(RZ_NONNULL RzILOpPure *bv);
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_eq(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_ule(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_sle(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
+RZ_API RZ_OWN RzILOpBool *rz_il_op_new_ult(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
+RZ_API RZ_OWN RzILOpBool *rz_il_op_new_slt(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_cast(ut32 length, RZ_NONNULL RzILOpBool *fill, RZ_NONNULL RzILOpBitVector *val);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_unsigned(ut32 length, RZ_NONNULL RzILOpBitVector *val); // "zero extension"
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_signed(ut32 length, RZ_NONNULL RzILOpBitVector *val); // "sign extension"

--- a/test/db/asm/6502
+++ b/test/db/asm/6502
@@ -1,151 +1,151 @@
-d "adc #0x42" 6942 0x0
-d "adc 0x42" 6542 0x0
-d "adc 0x42,x" 7542 0x0
-d "adc 0xcafe" 6dfeca 0x0
-d "adc 0xcafe,x" 7dfeca 0x0
-d "adc 0xcafe,y" 79feca 0x0
-d "adc (0x42,x)" 6142 0x0
-d "adc (0x42),y" 7142 0x0
-d "and #0x42" 2942 0x0
-d "and 0x42" 2542 0x0
-d "and 0x42,x" 3542 0x0
-d "and 0xcafe" 2dfeca 0x0
-d "and 0xcafe,x" 3dfeca 0x0
-d "and 0xcafe,y" 39feca 0x0
-d "and (0x42,x)" 2142 0x0
-d "and (0x42),y" 3142 0x0
-d "asl a" 0a 0x0
-d "asl 0x42" 0642 0x0
-d "asl 0x42,x" 1642 0x0
-d "asl 0xcafe" 0efeca 0x0
-d "asl 0xcafe,x" 1efeca 0x0
-d "bcc 0x02e4" 90d0 0x312
-d "bcs 0x02e4" b0d0 0x312
-d "beq 0x02e4" f0d0 0x312
-d "bit 0x42" 2442 0x0
-d "bit 0xcafe" 2cfeca 0x0
-d "bmi 0x02e4" 30d0 0x312
-d "bne 0x02e4" d0d0 0x312
-d "bpl 0x02e4" 10d0 0x312
-d "brk" 00 0x0
-d "bvc 0x02e4" 50d0 0x312
-d "bvs 0x02e4" 70d0 0x312
-d "clc" 18 0x0
-d "cld" d8 0x0
-d "cli" 58 0x0
-d "clv" b8 0x0
-d "cmp #0x42" c942 0x0
-d "cmp 0x42" c542 0x0
-d "cmp 0x42,x" d542 0x0
-d "cmp 0xcafe" cdfeca 0x0
-d "cmp 0xcafe,x" ddfeca 0x0
-d "cmp 0xcafe,y" d9feca 0x0
-d "cmp (0x42,x)" c142 0x0
-d "cmp (0x42),y" d142 0x0
-d "cpx #0x42" e042 0x0
-d "cpx 0x42" e442 0x0
-d "cpx 0xcafe" ecfeca 0x0
-d "cpy #0x42" c042 0x0
-d "cpy 0x42" c442 0x0
-d "cpy 0xcafe" ccfeca 0x0
-d "dec 0x42" c642 0x0
-d "dec 0x42,x" d642 0x0
-d "dec 0xcafe" cefeca 0x0
-d "dec 0xcafe,x" defeca 0x0
-d "dex" ca 0x0
-d "dey" 88 0x0
-d "eor #0x42" 4942 0x0
-d "eor 0x42" 4542 0x0
-d "eor 0x42,x" 5542 0x0
-d "eor 0xcafe" 4dfeca 0x0
-d "eor 0xcafe,x" 5dfeca 0x0
-d "eor 0xcafe,y" 59feca 0x0
-d "eor (0x42,x)" 4142 0x0
-d "eor (0x42),y" 5142 0x0
-d "inc 0x42" e642 0x0
-d "inc 0x42,x" f642 0x0
-d "inc 0xcafe" eefeca 0x0
-d "inc 0xcafe,x" fefeca 0x0
-d "inx" e8 0x0
-d "iny" c8 0x0
-d "jmp 0xcafe" 4cfeca 0x0
-d "jmp (0xcafe)" 6cfeca 0x0
-d "jsr 0xcafe" 20feca 0x0
-d "lda #0x42" a942 0x0
-d "lda 0x42" a542 0x0
-d "lda 0x42,x" b542 0x0
-d "lda 0xcafe" adfeca 0x0
-d "lda 0xcafe,x" bdfeca 0x0
-d "lda 0xcafe,y" b9feca 0x0
-d "lda (0x42,x)" a142 0x0
-d "lda (0x42),y" b142 0x0
-d "ldx #0x42" a242 0x0
-d "ldx 0x42" a642 0x0
-d "ldx 0x42,y" b642 0x0
-d "ldx 0xcafe" aefeca 0x0
-d "ldx 0xcafe,y" befeca 0x0
-d "ldy #0x42" a042 0x0
-d "ldy 0x42" a442 0x0
-d "ldy 0x42,x" b442 0x0
-d "ldy 0xcafe" acfeca 0x0
-d "ldy 0xcafe,x" bcfeca 0x0
-d "lsr a" 4a 0x0
-d "lsr 0x42" 4642 0x0
-d "lsr 0x42,x" 5642 0x0
-d "lsr 0xcafe" 4efeca 0x0
-d "lsr 0xcafe,x" 5efeca 0x0
-d "nop" ea 0x0
-d "ora #0x42" 0942 0x0
-d "ora 0x42" 0542 0x0
-d "ora 0x42,x" 1542 0x0
-d "ora 0xcafe" 0dfeca 0x0
-d "ora 0xcafe,x" 1dfeca 0x0
-d "ora 0xcafe,y" 19feca 0x0
-d "ora (0x42,x)" 0142 0x0
-d "ora (0x42),y" 1142 0x0
-d "pha" 48 0x0
-d "php" 08 0x0
-d "pla" 68 0x0
-d "plp" 28 0x0
-d "rol a" 2a 0x0
-d "rol 0x42" 2642 0x0
-d "rol 0x42,x" 3642 0x0
-d "rol 0xcafe" 2efeca 0x0
-d "rol 0xcafe,x" 3efeca 0x0
-d "ror a" 6a 0x0
-d "ror 0x42" 6642 0x0
-d "ror 0x42,x" 7642 0x0
-d "ror 0xcafe" 6efeca 0x0
-d "ror 0xcafe,x" 7efeca 0x0
-d "rti" 40 0x0
-d "rts" 60 0x0
-d "sbc #0x42" e942 0x0
-d "sbc 0x42" e542 0x0
-d "sbc 0x42,x" f542 0x0
-d "sbc 0xcafe" edfeca 0x0
-d "sbc 0xcafe,x" fdfeca 0x0
-d "sbc 0xcafe,y" f9feca 0x0
-d "sbc (0x42,x)" e142 0x0
-d "sbc (0x42),y" f142 0x0
-d "sec" 38 0x0
-d "sed" f8 0x0
-d "sei" 78 0x0
-d "sta 0x42" 8542 0x0
-d "sta 0x42,x" 9542 0x0
-d "sta 0xcafe" 8dfeca 0x0
-d "sta 0xcafe,x" 9dfeca 0x0
-d "sta 0xcafe,y" 99feca 0x0
-d "sta (0x42,x)" 8142 0x0
-d "sta (0x42),y" 9142 0x0
-d "stx 0x42" 8642 0x0
-d "stx 0x42,y" 9642 0x0
-d "stx 0xcafe" 8efeca 0x0
-d "sty 0x42" 8442 0x0
-d "sty 0x42,x" 9442 0x0
-d "sty 0xcafe" 8cfeca 0x0
-d "tax" aa 0x0
-d "tay" a8 0x0
-d "tsx" ba 0x0
-d "txa" 8a 0x0
-d "txs" 9a 0x0
-d "tya" 98 0x0
+d "adc #0x42" 6942 0x0 (seq (set src (bv 8 0x42)) (seq (set res (+ (ite (var C) (bv 8 0x1) (bv 8 0x0)) (+ (var a) (var src)))) (seq (seq (set Z (is_zero (var res))) (set N (msb (var res)))) (seq (set C (ite (var C) (ule (var res) (var a)) (&& (ule (var res) (var a)) (! (== (var res) (var a)))))) (seq (set V (&& (! (^^ (msb (var a)) (msb (var src)))) (^^ (msb (var a)) (msb (var res))))) (set a (var res)))))))
+d "adc 0x42" 6542 0x0 (seq (set src (load 0 (bv 16 0x42))) (seq (set res (+ (ite (var C) (bv 8 0x1) (bv 8 0x0)) (+ (var a) (var src)))) (seq (seq (set Z (is_zero (var res))) (set N (msb (var res)))) (seq (set C (ite (var C) (ule (var res) (var a)) (&& (ule (var res) (var a)) (! (== (var res) (var a)))))) (seq (set V (&& (! (^^ (msb (var a)) (msb (var src)))) (^^ (msb (var a)) (msb (var res))))) (set a (var res)))))))
+d "adc 0x42,x" 7542 0x0 (seq (set src (load 0 (cast 16 false (+ (bv 8 0x42) (var x))))) (seq (set res (+ (ite (var C) (bv 8 0x1) (bv 8 0x0)) (+ (var a) (var src)))) (seq (seq (set Z (is_zero (var res))) (set N (msb (var res)))) (seq (set C (ite (var C) (ule (var res) (var a)) (&& (ule (var res) (var a)) (! (== (var res) (var a)))))) (seq (set V (&& (! (^^ (msb (var a)) (msb (var src)))) (^^ (msb (var a)) (msb (var res))))) (set a (var res)))))))
+d "adc 0xcafe" 6dfeca 0x0 (seq (set src (load 0 (bv 16 0xcafe))) (seq (set res (+ (ite (var C) (bv 8 0x1) (bv 8 0x0)) (+ (var a) (var src)))) (seq (seq (set Z (is_zero (var res))) (set N (msb (var res)))) (seq (set C (ite (var C) (ule (var res) (var a)) (&& (ule (var res) (var a)) (! (== (var res) (var a)))))) (seq (set V (&& (! (^^ (msb (var a)) (msb (var src)))) (^^ (msb (var a)) (msb (var res))))) (set a (var res)))))))
+d "adc 0xcafe,x" 7dfeca 0x0 (seq (set src (load 0 (+ (bv 16 0xcafe) (cast 16 false (var x))))) (seq (set res (+ (ite (var C) (bv 8 0x1) (bv 8 0x0)) (+ (var a) (var src)))) (seq (seq (set Z (is_zero (var res))) (set N (msb (var res)))) (seq (set C (ite (var C) (ule (var res) (var a)) (&& (ule (var res) (var a)) (! (== (var res) (var a)))))) (seq (set V (&& (! (^^ (msb (var a)) (msb (var src)))) (^^ (msb (var a)) (msb (var res))))) (set a (var res)))))))
+d "adc 0xcafe,y" 79feca 0x0 (seq (set src (load 0 (+ (bv 16 0xcafe) (cast 16 false (var y))))) (seq (set res (+ (ite (var C) (bv 8 0x1) (bv 8 0x0)) (+ (var a) (var src)))) (seq (seq (set Z (is_zero (var res))) (set N (msb (var res)))) (seq (set C (ite (var C) (ule (var res) (var a)) (&& (ule (var res) (var a)) (! (== (var res) (var a)))))) (seq (set V (&& (! (^^ (msb (var a)) (msb (var src)))) (^^ (msb (var a)) (msb (var res))))) (set a (var res)))))))
+d "adc (0x42,x)" 6142 0x0 (seq (set src (load 0 (append (load 0 (cast 16 false (+ (+ (bv 8 0x42) (var x)) (bv 8 0x1)))) (load 0 (cast 16 false (+ (bv 8 0x42) (var x))))))) (seq (set res (+ (ite (var C) (bv 8 0x1) (bv 8 0x0)) (+ (var a) (var src)))) (seq (seq (set Z (is_zero (var res))) (set N (msb (var res)))) (seq (set C (ite (var C) (ule (var res) (var a)) (&& (ule (var res) (var a)) (! (== (var res) (var a)))))) (seq (set V (&& (! (^^ (msb (var a)) (msb (var src)))) (^^ (msb (var a)) (msb (var res))))) (set a (var res)))))))
+d "adc (0x42),y" 7142 0x0 (seq (set src (load 0 (+ (append (load 0 (cast 16 false (+ (bv 8 0x42) (bv 8 0x1)))) (load 0 (cast 16 false (bv 8 0x42)))) (cast 16 false (var y))))) (seq (set res (+ (ite (var C) (bv 8 0x1) (bv 8 0x0)) (+ (var a) (var src)))) (seq (seq (set Z (is_zero (var res))) (set N (msb (var res)))) (seq (set C (ite (var C) (ule (var res) (var a)) (&& (ule (var res) (var a)) (! (== (var res) (var a)))))) (seq (set V (&& (! (^^ (msb (var a)) (msb (var src)))) (^^ (msb (var a)) (msb (var res))))) (set a (var res)))))))
+d "and #0x42" 2942 0x0 (seq (set a (& (var a) (bv 8 0x42))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "and 0x42" 2542 0x0 (seq (set a (& (var a) (load 0 (bv 16 0x42)))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "and 0x42,x" 3542 0x0 (seq (set a (& (var a) (load 0 (cast 16 false (+ (bv 8 0x42) (var x)))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "and 0xcafe" 2dfeca 0x0 (seq (set a (& (var a) (load 0 (bv 16 0xcafe)))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "and 0xcafe,x" 3dfeca 0x0 (seq (set a (& (var a) (load 0 (+ (bv 16 0xcafe) (cast 16 false (var x)))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "and 0xcafe,y" 39feca 0x0 (seq (set a (& (var a) (load 0 (+ (bv 16 0xcafe) (cast 16 false (var y)))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "and (0x42,x)" 2142 0x0 (seq (set a (& (var a) (load 0 (append (load 0 (cast 16 false (+ (+ (bv 8 0x42) (var x)) (bv 8 0x1)))) (load 0 (cast 16 false (+ (bv 8 0x42) (var x)))))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "and (0x42),y" 3142 0x0 (seq (set a (& (var a) (load 0 (+ (append (load 0 (cast 16 false (+ (bv 8 0x42) (bv 8 0x1)))) (load 0 (cast 16 false (bv 8 0x42)))) (cast 16 false (var y)))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "asl a" 0a 0x0 (seq (set tmp (var a)) (seq (set C (msb (var tmp))) (seq (set tmp (<< (var tmp) (bv 3 0x1) false)) (seq (set a (var tmp)) (seq (set Z (is_zero (var tmp))) (set N (msb (var tmp))))))))
+d "asl 0x42" 0642 0x0 (seq (set tmp (load 0 (bv 16 0x42))) (seq (set C (msb (var tmp))) (seq (set tmp (<< (var tmp) (bv 3 0x1) false)) (seq (store 0 (bv 16 0x42) (var tmp)) (seq (set Z (is_zero (var tmp))) (set N (msb (var tmp))))))))
+d "asl 0x42,x" 1642 0x0 (seq (set tmp (load 0 (cast 16 false (+ (bv 8 0x42) (var x))))) (seq (set C (msb (var tmp))) (seq (set tmp (<< (var tmp) (bv 3 0x1) false)) (seq (store 0 (cast 16 false (+ (bv 8 0x42) (var x))) (var tmp)) (seq (set Z (is_zero (var tmp))) (set N (msb (var tmp))))))))
+d "asl 0xcafe" 0efeca 0x0 (seq (set tmp (load 0 (bv 16 0xcafe))) (seq (set C (msb (var tmp))) (seq (set tmp (<< (var tmp) (bv 3 0x1) false)) (seq (store 0 (bv 16 0xcafe) (var tmp)) (seq (set Z (is_zero (var tmp))) (set N (msb (var tmp))))))))
+d "asl 0xcafe,x" 1efeca 0x0 (seq (set tmp (load 0 (+ (bv 16 0xcafe) (cast 16 false (var x))))) (seq (set C (msb (var tmp))) (seq (set tmp (<< (var tmp) (bv 3 0x1) false)) (seq (store 0 (+ (bv 16 0xcafe) (cast 16 false (var x))) (var tmp)) (seq (set Z (is_zero (var tmp))) (set N (msb (var tmp))))))))
+d "bcc 0x02e4" 90d0 0x312 (branch (! (var C)) (jmp (bv 16 0x2e4)) nop)
+d "bcs 0x02e4" b0d0 0x312 (branch (var C) (jmp (bv 16 0x2e4)) nop)
+d "beq 0x02e4" f0d0 0x312 (branch (var Z) (jmp (bv 16 0x2e4)) nop)
+d "bit 0x42" 2442 0x0 (seq (set tmp (load 0 (bv 16 0x42))) (seq (set N (msb (var tmp))) (seq (set V (msb (cast 7 false (var tmp)))) (set Z (is_zero (& (var tmp) (var a)))))))
+d "bit 0xcafe" 2cfeca 0x0 (seq (set tmp (load 0 (bv 16 0xcafe))) (seq (set N (msb (var tmp))) (seq (set V (msb (cast 7 false (var tmp)))) (set Z (is_zero (& (var tmp) (var a)))))))
+d "bmi 0x02e4" 30d0 0x312 (branch (var N) (jmp (bv 16 0x2e4)) nop)
+d "bne 0x02e4" d0d0 0x312 (branch (! (var Z)) (jmp (bv 16 0x2e4)) nop)
+d "bpl 0x02e4" 10d0 0x312 (branch (! (var N)) (jmp (bv 16 0x2e4)) nop)
+d "brk" 00 0x2040 (seq (seq (set sp (- (var sp) (bv 8 0x1))) (store 0 (append (bv 8 0x1) (var sp)) (bv 8 0x20))) (seq (seq (set sp (- (var sp) (bv 8 0x1))) (store 0 (append (bv 8 0x1) (var sp)) (bv 8 0x42))) (seq (seq (set sp (- (var sp) (bv 8 0x1))) (store 0 (append (bv 8 0x1) (var sp)) (| (| (ite (var N) (bv 8 0x80) (bv 8 0x0)) (| (ite (var V) (bv 8 0x40) (bv 8 0x0)) (| (ite (var D) (bv 8 0x8) (bv 8 0x0)) (| (ite (var I) (bv 8 0x4) (bv 8 0x0)) (| (ite (var Z) (bv 8 0x2) (bv 8 0x0)) (ite (var C) (bv 8 0x1) (bv 8 0x0))))))) (bv 8 0x20)))) (seq (set D false) (seq (set I true) (jmp (loadw 0 16 (bv 16 0xfffe))))))))
+d "bvc 0x02e4" 50d0 0x312 (branch (! (var V)) (jmp (bv 16 0x2e4)) nop)
+d "bvs 0x02e4" 70d0 0x312 (branch (var V) (jmp (bv 16 0x2e4)) nop)
+d "clc" 18 0x0 (set C false)
+d "cld" d8 0x0 (set D false)
+d "cli" 58 0x0 (set I false)
+d "clv" b8 0x0 (set V false)
+d "cmp #0x42" c942 0x0 (seq (set tmp (- (cast 9 false (var a)) (cast 9 false (bv 8 0x42)))) (seq (set C (! (msb (var tmp)))) (seq (set Z (is_zero (cast 8 false (var tmp)))) (set N (msb (cast 8 false (var tmp)))))))
+d "cmp 0x42" c542 0x0 (seq (set tmp (- (cast 9 false (var a)) (cast 9 false (load 0 (bv 16 0x42))))) (seq (set C (! (msb (var tmp)))) (seq (set Z (is_zero (cast 8 false (var tmp)))) (set N (msb (cast 8 false (var tmp)))))))
+d "cmp 0x42,x" d542 0x0 (seq (set tmp (- (cast 9 false (var a)) (cast 9 false (load 0 (cast 16 false (+ (bv 8 0x42) (var x))))))) (seq (set C (! (msb (var tmp)))) (seq (set Z (is_zero (cast 8 false (var tmp)))) (set N (msb (cast 8 false (var tmp)))))))
+d "cmp 0xcafe" cdfeca 0x0 (seq (set tmp (- (cast 9 false (var a)) (cast 9 false (load 0 (bv 16 0xcafe))))) (seq (set C (! (msb (var tmp)))) (seq (set Z (is_zero (cast 8 false (var tmp)))) (set N (msb (cast 8 false (var tmp)))))))
+d "cmp 0xcafe,x" ddfeca 0x0 (seq (set tmp (- (cast 9 false (var a)) (cast 9 false (load 0 (+ (bv 16 0xcafe) (cast 16 false (var x))))))) (seq (set C (! (msb (var tmp)))) (seq (set Z (is_zero (cast 8 false (var tmp)))) (set N (msb (cast 8 false (var tmp)))))))
+d "cmp 0xcafe,y" d9feca 0x0 (seq (set tmp (- (cast 9 false (var a)) (cast 9 false (load 0 (+ (bv 16 0xcafe) (cast 16 false (var y))))))) (seq (set C (! (msb (var tmp)))) (seq (set Z (is_zero (cast 8 false (var tmp)))) (set N (msb (cast 8 false (var tmp)))))))
+d "cmp (0x42,x)" c142 0x0 (seq (set tmp (- (cast 9 false (var a)) (cast 9 false (load 0 (append (load 0 (cast 16 false (+ (+ (bv 8 0x42) (var x)) (bv 8 0x1)))) (load 0 (cast 16 false (+ (bv 8 0x42) (var x))))))))) (seq (set C (! (msb (var tmp)))) (seq (set Z (is_zero (cast 8 false (var tmp)))) (set N (msb (cast 8 false (var tmp)))))))
+d "cmp (0x42),y" d142 0x0 (seq (set tmp (- (cast 9 false (var a)) (cast 9 false (load 0 (+ (append (load 0 (cast 16 false (+ (bv 8 0x42) (bv 8 0x1)))) (load 0 (cast 16 false (bv 8 0x42)))) (cast 16 false (var y))))))) (seq (set C (! (msb (var tmp)))) (seq (set Z (is_zero (cast 8 false (var tmp)))) (set N (msb (cast 8 false (var tmp)))))))
+d "cpx #0x42" e042 0x0 (seq (set tmp (- (cast 9 false (var x)) (cast 9 false (bv 8 0x42)))) (seq (set C (! (msb (var tmp)))) (seq (set Z (is_zero (cast 8 false (var tmp)))) (set N (msb (cast 8 false (var tmp)))))))
+d "cpx 0x42" e442 0x0 (seq (set tmp (- (cast 9 false (var x)) (cast 9 false (load 0 (bv 16 0x42))))) (seq (set C (! (msb (var tmp)))) (seq (set Z (is_zero (cast 8 false (var tmp)))) (set N (msb (cast 8 false (var tmp)))))))
+d "cpx 0xcafe" ecfeca 0x0 (seq (set tmp (- (cast 9 false (var x)) (cast 9 false (load 0 (bv 16 0xcafe))))) (seq (set C (! (msb (var tmp)))) (seq (set Z (is_zero (cast 8 false (var tmp)))) (set N (msb (cast 8 false (var tmp)))))))
+d "cpy #0x42" c042 0x0 (seq (set tmp (- (cast 9 false (var y)) (cast 9 false (bv 8 0x42)))) (seq (set C (! (msb (var tmp)))) (seq (set Z (is_zero (cast 8 false (var tmp)))) (set N (msb (cast 8 false (var tmp)))))))
+d "cpy 0x42" c442 0x0 (seq (set tmp (- (cast 9 false (var y)) (cast 9 false (load 0 (bv 16 0x42))))) (seq (set C (! (msb (var tmp)))) (seq (set Z (is_zero (cast 8 false (var tmp)))) (set N (msb (cast 8 false (var tmp)))))))
+d "cpy 0xcafe" ccfeca 0x0 (seq (set tmp (- (cast 9 false (var y)) (cast 9 false (load 0 (bv 16 0xcafe))))) (seq (set C (! (msb (var tmp)))) (seq (set Z (is_zero (cast 8 false (var tmp)))) (set N (msb (cast 8 false (var tmp)))))))
+d "dec 0x42" c642 0x0 (seq (set tmp (- (load 0 (bv 16 0x42)) (bv 8 0x1))) (seq (store 0 (bv 16 0x42) (var tmp)) (seq (set Z (is_zero (var tmp))) (set N (msb (var tmp))))))
+d "dec 0x42,x" d642 0x0 (seq (set tmp (- (load 0 (cast 16 false (+ (bv 8 0x42) (var x)))) (bv 8 0x1))) (seq (store 0 (cast 16 false (+ (bv 8 0x42) (var x))) (var tmp)) (seq (set Z (is_zero (var tmp))) (set N (msb (var tmp))))))
+d "dec 0xcafe" cefeca 0x0 (seq (set tmp (- (load 0 (bv 16 0xcafe)) (bv 8 0x1))) (seq (store 0 (bv 16 0xcafe) (var tmp)) (seq (set Z (is_zero (var tmp))) (set N (msb (var tmp))))))
+d "dec 0xcafe,x" defeca 0x0 (seq (set tmp (- (load 0 (+ (bv 16 0xcafe) (cast 16 false (var x)))) (bv 8 0x1))) (seq (store 0 (+ (bv 16 0xcafe) (cast 16 false (var x))) (var tmp)) (seq (set Z (is_zero (var tmp))) (set N (msb (var tmp))))))
+d "dex" ca 0x0 (seq (set x (- (var x) (bv 8 0x1))) (seq (set Z (is_zero (cast 8 false (var x)))) (set N (msb (cast 8 false (var x))))))
+d "dey" 88 0x0 (seq (set y (- (var y) (bv 8 0x1))) (seq (set Z (is_zero (cast 8 false (var y)))) (set N (msb (cast 8 false (var y))))))
+d "eor #0x42" 4942 0x0 (seq (set a (^ (var a) (bv 8 0x42))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "eor 0x42" 4542 0x0 (seq (set a (^ (var a) (load 0 (bv 16 0x42)))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "eor 0x42,x" 5542 0x0 (seq (set a (^ (var a) (load 0 (cast 16 false (+ (bv 8 0x42) (var x)))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "eor 0xcafe" 4dfeca 0x0 (seq (set a (^ (var a) (load 0 (bv 16 0xcafe)))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "eor 0xcafe,x" 5dfeca 0x0 (seq (set a (^ (var a) (load 0 (+ (bv 16 0xcafe) (cast 16 false (var x)))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "eor 0xcafe,y" 59feca 0x0 (seq (set a (^ (var a) (load 0 (+ (bv 16 0xcafe) (cast 16 false (var y)))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "eor (0x42,x)" 4142 0x0 (seq (set a (^ (var a) (load 0 (append (load 0 (cast 16 false (+ (+ (bv 8 0x42) (var x)) (bv 8 0x1)))) (load 0 (cast 16 false (+ (bv 8 0x42) (var x)))))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "eor (0x42),y" 5142 0x0 (seq (set a (^ (var a) (load 0 (+ (append (load 0 (cast 16 false (+ (bv 8 0x42) (bv 8 0x1)))) (load 0 (cast 16 false (bv 8 0x42)))) (cast 16 false (var y)))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "inc 0x42" e642 0x0 (seq (set tmp (+ (load 0 (bv 16 0x42)) (bv 8 0x1))) (seq (store 0 (bv 16 0x42) (var tmp)) (seq (set Z (is_zero (var tmp))) (set N (msb (var tmp))))))
+d "inc 0x42,x" f642 0x0 (seq (set tmp (+ (load 0 (cast 16 false (+ (bv 8 0x42) (var x)))) (bv 8 0x1))) (seq (store 0 (cast 16 false (+ (bv 8 0x42) (var x))) (var tmp)) (seq (set Z (is_zero (var tmp))) (set N (msb (var tmp))))))
+d "inc 0xcafe" eefeca 0x0 (seq (set tmp (+ (load 0 (bv 16 0xcafe)) (bv 8 0x1))) (seq (store 0 (bv 16 0xcafe) (var tmp)) (seq (set Z (is_zero (var tmp))) (set N (msb (var tmp))))))
+d "inc 0xcafe,x" fefeca 0x0 (seq (set tmp (+ (load 0 (+ (bv 16 0xcafe) (cast 16 false (var x)))) (bv 8 0x1))) (seq (store 0 (+ (bv 16 0xcafe) (cast 16 false (var x))) (var tmp)) (seq (set Z (is_zero (var tmp))) (set N (msb (var tmp))))))
+d "inx" e8 0x0 (seq (set x (+ (var x) (bv 8 0x1))) (seq (set Z (is_zero (cast 8 false (var x)))) (set N (msb (cast 8 false (var x))))))
+d "iny" c8 0x0 (seq (set y (+ (var y) (bv 8 0x1))) (seq (set Z (is_zero (cast 8 false (var y)))) (set N (msb (cast 8 false (var y))))))
+d "jmp 0xcafe" 4cfeca 0x0 (jmp (bv 16 0xcafe))
+d "jmp (0xcafe)" 6cfeca 0x0 (jmp (loadw 0 16 (bv 16 0xcafe)))
+d "jsr 0xcafe" 20feca 0x3240 (seq (seq (set sp (- (var sp) (bv 8 0x1))) (store 0 (append (bv 8 0x1) (var sp)) (bv 8 0x32))) (seq (seq (set sp (- (var sp) (bv 8 0x1))) (store 0 (append (bv 8 0x1) (var sp)) (bv 8 0x42))) (jmp (bv 16 0xcafe))))
+d "lda #0x42" a942 0x0 (seq (set a (bv 8 0x42)) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "lda 0x42" a542 0x0 (seq (set a (load 0 (bv 16 0x42))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "lda 0x42,x" b542 0x0 (seq (set a (load 0 (cast 16 false (+ (bv 8 0x42) (var x))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "lda 0xcafe" adfeca 0x0 (seq (set a (load 0 (bv 16 0xcafe))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "lda 0xcafe,x" bdfeca 0x0 (seq (set a (load 0 (+ (bv 16 0xcafe) (cast 16 false (var x))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "lda 0xcafe,y" b9feca 0x0 (seq (set a (load 0 (+ (bv 16 0xcafe) (cast 16 false (var y))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "lda (0x42,x)" a142 0x0 (seq (set a (load 0 (append (load 0 (cast 16 false (+ (+ (bv 8 0x42) (var x)) (bv 8 0x1)))) (load 0 (cast 16 false (+ (bv 8 0x42) (var x))))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "lda (0x42),y" b142 0x0 (seq (set a (load 0 (+ (append (load 0 (cast 16 false (+ (bv 8 0x42) (bv 8 0x1)))) (load 0 (cast 16 false (bv 8 0x42)))) (cast 16 false (var y))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "ldx #0x42" a242 0x0 (seq (set x (bv 8 0x42)) (seq (set Z (is_zero (var x))) (set N (msb (var x)))))
+d "ldx 0x42" a642 0x0 (seq (set x (load 0 (bv 16 0x42))) (seq (set Z (is_zero (var x))) (set N (msb (var x)))))
+d "ldx 0x42,y" b642 0x0 (seq (set x (load 0 (cast 16 false (+ (bv 8 0x42) (var y))))) (seq (set Z (is_zero (var x))) (set N (msb (var x)))))
+d "ldx 0xcafe" aefeca 0x0 (seq (set x (load 0 (bv 16 0xcafe))) (seq (set Z (is_zero (var x))) (set N (msb (var x)))))
+d "ldx 0xcafe,y" befeca 0x0 (seq (set x (load 0 (+ (bv 16 0xcafe) (cast 16 false (var y))))) (seq (set Z (is_zero (var x))) (set N (msb (var x)))))
+d "ldy #0x42" a042 0x0 (seq (set y (bv 8 0x42)) (seq (set Z (is_zero (var y))) (set N (msb (var y)))))
+d "ldy 0x42" a442 0x0 (seq (set y (load 0 (bv 16 0x42))) (seq (set Z (is_zero (var y))) (set N (msb (var y)))))
+d "ldy 0x42,x" b442 0x0 (seq (set y (load 0 (cast 16 false (+ (bv 8 0x42) (var x))))) (seq (set Z (is_zero (var y))) (set N (msb (var y)))))
+d "ldy 0xcafe" acfeca 0x0 (seq (set y (load 0 (bv 16 0xcafe))) (seq (set Z (is_zero (var y))) (set N (msb (var y)))))
+d "ldy 0xcafe,x" bcfeca 0x0 (seq (set y (load 0 (+ (bv 16 0xcafe) (cast 16 false (var x))))) (seq (set Z (is_zero (var y))) (set N (msb (var y)))))
+d "lsr a" 4a 0x0 (seq (set tmp (var a)) (seq (set C (lsb (var tmp))) (seq (set tmp (>> (var tmp) (bv 3 0x1) false)) (seq (set a (var tmp)) (set Z (is_zero (var tmp)))))))
+d "lsr 0x42" 4642 0x0 (seq (set tmp (load 0 (bv 16 0x42))) (seq (set C (lsb (var tmp))) (seq (set tmp (>> (var tmp) (bv 3 0x1) false)) (seq (store 0 (bv 16 0x42) (var tmp)) (set Z (is_zero (var tmp)))))))
+d "lsr 0x42,x" 5642 0x0 (seq (set tmp (load 0 (cast 16 false (+ (bv 8 0x42) (var x))))) (seq (set C (lsb (var tmp))) (seq (set tmp (>> (var tmp) (bv 3 0x1) false)) (seq (store 0 (cast 16 false (+ (bv 8 0x42) (var x))) (var tmp)) (set Z (is_zero (var tmp)))))))
+d "lsr 0xcafe" 4efeca 0x0 (seq (set tmp (load 0 (bv 16 0xcafe))) (seq (set C (lsb (var tmp))) (seq (set tmp (>> (var tmp) (bv 3 0x1) false)) (seq (store 0 (bv 16 0xcafe) (var tmp)) (set Z (is_zero (var tmp)))))))
+d "lsr 0xcafe,x" 5efeca 0x0 (seq (set tmp (load 0 (+ (bv 16 0xcafe) (cast 16 false (var x))))) (seq (set C (lsb (var tmp))) (seq (set tmp (>> (var tmp) (bv 3 0x1) false)) (seq (store 0 (+ (bv 16 0xcafe) (cast 16 false (var x))) (var tmp)) (set Z (is_zero (var tmp)))))))
+d "nop" ea 0x0 nop
+d "ora #0x42" 0942 0x0 (seq (set a (| (var a) (bv 8 0x42))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "ora 0x42" 0542 0x0 (seq (set a (| (var a) (load 0 (bv 16 0x42)))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "ora 0x42,x" 1542 0x0 (seq (set a (| (var a) (load 0 (cast 16 false (+ (bv 8 0x42) (var x)))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "ora 0xcafe" 0dfeca 0x0 (seq (set a (| (var a) (load 0 (bv 16 0xcafe)))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "ora 0xcafe,x" 1dfeca 0x0 (seq (set a (| (var a) (load 0 (+ (bv 16 0xcafe) (cast 16 false (var x)))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "ora 0xcafe,y" 19feca 0x0 (seq (set a (| (var a) (load 0 (+ (bv 16 0xcafe) (cast 16 false (var y)))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "ora (0x42,x)" 0142 0x0 (seq (set a (| (var a) (load 0 (append (load 0 (cast 16 false (+ (+ (bv 8 0x42) (var x)) (bv 8 0x1)))) (load 0 (cast 16 false (+ (bv 8 0x42) (var x)))))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "ora (0x42),y" 1142 0x0 (seq (set a (| (var a) (load 0 (+ (append (load 0 (cast 16 false (+ (bv 8 0x42) (bv 8 0x1)))) (load 0 (cast 16 false (bv 8 0x42)))) (cast 16 false (var y)))))) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "pha" 48 0x0 (seq (set sp (- (var sp) (bv 8 0x1))) (store 0 (append (bv 8 0x1) (var sp)) (var a)))
+d "php" 08 0x0 (seq (set sp (- (var sp) (bv 8 0x1))) (store 0 (append (bv 8 0x1) (var sp)) (| (| (ite (var N) (bv 8 0x80) (bv 8 0x0)) (| (ite (var V) (bv 8 0x40) (bv 8 0x0)) (| (ite (var D) (bv 8 0x8) (bv 8 0x0)) (| (ite (var I) (bv 8 0x4) (bv 8 0x0)) (| (ite (var Z) (bv 8 0x2) (bv 8 0x0)) (ite (var C) (bv 8 0x1) (bv 8 0x0))))))) (bv 8 0x20))))
+d "pla" 68 0x0 (seq (seq (set tmp (load 0 (append (bv 8 0x1) (var sp)))) (set sp (+ (var sp) (bv 8 0x1)))) (seq (set a (var tmp)) (seq (set Z (is_zero (var tmp))) (set N (msb (var tmp))))))
+d "plp" 28 0x0 (seq (seq (set tmp (load 0 (append (bv 8 0x1) (var sp)))) (set sp (+ (var sp) (bv 8 0x1)))) (seq (set N (msb (var tmp))) (seq (set V (! (is_zero (& (var tmp) (bv 8 0x40))))) (seq (set D (! (is_zero (& (var tmp) (bv 8 0x8))))) (seq (set I (! (is_zero (& (var tmp) (bv 8 0x4))))) (seq (set Z (! (is_zero (& (var tmp) (bv 8 0x2))))) (set C (lsb (var tmp)))))))))
+d "rol a" 2a 0x0 (seq (set tmp (var a)) (seq (set res (| (<< (var tmp) (bv 3 0x1) false) (ite (var C) (bv 8 0x1) (bv 8 0x0)))) (seq (set C (msb (var tmp))) (seq (set a (var res)) (seq (set Z (is_zero (var res))) (set N (msb (var res))))))))
+d "rol 0x42" 2642 0x0 (seq (set tmp (load 0 (bv 16 0x42))) (seq (set res (| (<< (var tmp) (bv 3 0x1) false) (ite (var C) (bv 8 0x1) (bv 8 0x0)))) (seq (set C (msb (var tmp))) (seq (store 0 (bv 16 0x42) (var res)) (seq (set Z (is_zero (var res))) (set N (msb (var res))))))))
+d "rol 0x42,x" 3642 0x0 (seq (set tmp (load 0 (cast 16 false (+ (bv 8 0x42) (var x))))) (seq (set res (| (<< (var tmp) (bv 3 0x1) false) (ite (var C) (bv 8 0x1) (bv 8 0x0)))) (seq (set C (msb (var tmp))) (seq (store 0 (cast 16 false (+ (bv 8 0x42) (var x))) (var res)) (seq (set Z (is_zero (var res))) (set N (msb (var res))))))))
+d "rol 0xcafe" 2efeca 0x0 (seq (set tmp (load 0 (bv 16 0xcafe))) (seq (set res (| (<< (var tmp) (bv 3 0x1) false) (ite (var C) (bv 8 0x1) (bv 8 0x0)))) (seq (set C (msb (var tmp))) (seq (store 0 (bv 16 0xcafe) (var res)) (seq (set Z (is_zero (var res))) (set N (msb (var res))))))))
+d "rol 0xcafe,x" 3efeca 0x0 (seq (set tmp (load 0 (+ (bv 16 0xcafe) (cast 16 false (var x))))) (seq (set res (| (<< (var tmp) (bv 3 0x1) false) (ite (var C) (bv 8 0x1) (bv 8 0x0)))) (seq (set C (msb (var tmp))) (seq (store 0 (+ (bv 16 0xcafe) (cast 16 false (var x))) (var res)) (seq (set Z (is_zero (var res))) (set N (msb (var res))))))))
+d "ror a" 6a 0x0 (seq (set tmp (var a)) (seq (set res (| (>> (var tmp) (bv 3 0x1) false) (ite (var C) (bv 8 0x80) (bv 8 0x0)))) (seq (set C (lsb (var tmp))) (seq (set a (var res)) (seq (set Z (is_zero (var res))) (set N (msb (var res))))))))
+d "ror 0x42" 6642 0x0 (seq (set tmp (load 0 (bv 16 0x42))) (seq (set res (| (>> (var tmp) (bv 3 0x1) false) (ite (var C) (bv 8 0x80) (bv 8 0x0)))) (seq (set C (lsb (var tmp))) (seq (store 0 (bv 16 0x42) (var res)) (seq (set Z (is_zero (var res))) (set N (msb (var res))))))))
+d "ror 0x42,x" 7642 0x0 (seq (set tmp (load 0 (cast 16 false (+ (bv 8 0x42) (var x))))) (seq (set res (| (>> (var tmp) (bv 3 0x1) false) (ite (var C) (bv 8 0x80) (bv 8 0x0)))) (seq (set C (lsb (var tmp))) (seq (store 0 (cast 16 false (+ (bv 8 0x42) (var x))) (var res)) (seq (set Z (is_zero (var res))) (set N (msb (var res))))))))
+d "ror 0xcafe" 6efeca 0x0 (seq (set tmp (load 0 (bv 16 0xcafe))) (seq (set res (| (>> (var tmp) (bv 3 0x1) false) (ite (var C) (bv 8 0x80) (bv 8 0x0)))) (seq (set C (lsb (var tmp))) (seq (store 0 (bv 16 0xcafe) (var res)) (seq (set Z (is_zero (var res))) (set N (msb (var res))))))))
+d "ror 0xcafe,x" 7efeca 0x0 (seq (set tmp (load 0 (+ (bv 16 0xcafe) (cast 16 false (var x))))) (seq (set res (| (>> (var tmp) (bv 3 0x1) false) (ite (var C) (bv 8 0x80) (bv 8 0x0)))) (seq (set C (lsb (var tmp))) (seq (store 0 (+ (bv 16 0xcafe) (cast 16 false (var x))) (var res)) (seq (set Z (is_zero (var res))) (set N (msb (var res))))))))
+d "rti" 40 0x0 (seq (seq (set sr (load 0 (append (bv 8 0x1) (var sp)))) (set sp (+ (var sp) (bv 8 0x1)))) (seq (seq (set N (msb (var sr))) (seq (set V (! (is_zero (& (var sr) (bv 8 0x40))))) (seq (set D (! (is_zero (& (var sr) (bv 8 0x8))))) (seq (set I (! (is_zero (& (var sr) (bv 8 0x4))))) (seq (set Z (! (is_zero (& (var sr) (bv 8 0x2))))) (set C (lsb (var sr)))))))) (seq (set pcl (load 0 (append (bv 8 0x1) (var sp)))) (set sp (+ (var sp) (bv 8 0x1))))))
+d "rts" 60 0x0 (seq (seq (set pcl (load 0 (append (bv 8 0x1) (var sp)))) (set sp (+ (var sp) (bv 8 0x1)))) (seq (seq (set pch (load 0 (append (bv 8 0x1) (var sp)))) (set sp (+ (var sp) (bv 8 0x1)))) (jmp (+ (append (var pch) (var pcl)) (bv 16 0x1)))))
+d "sbc #0x42" e942 0x0 (seq (set src (bv 8 0x42)) (seq (set res (- (cast 9 false (var a)) (- (cast 9 false (var src)) (ite (var C) (bv 9 0x0) (bv 9 0x1))))) (seq (set C (! (msb (var res)))) (seq (set res8 (cast 8 false (var res))) (seq (seq (set Z (is_zero (var res8))) (set N (msb (var res8)))) (seq (set V (&& (^^ (msb (var a)) (msb (var res))) (^^ (msb (var a)) (msb (var src))))) (set a (var res8))))))))
+d "sbc 0x42" e542 0x0 (seq (set src (load 0 (bv 16 0x42))) (seq (set res (- (cast 9 false (var a)) (- (cast 9 false (var src)) (ite (var C) (bv 9 0x0) (bv 9 0x1))))) (seq (set C (! (msb (var res)))) (seq (set res8 (cast 8 false (var res))) (seq (seq (set Z (is_zero (var res8))) (set N (msb (var res8)))) (seq (set V (&& (^^ (msb (var a)) (msb (var res))) (^^ (msb (var a)) (msb (var src))))) (set a (var res8))))))))
+d "sbc 0x42,x" f542 0x0 (seq (set src (load 0 (cast 16 false (+ (bv 8 0x42) (var x))))) (seq (set res (- (cast 9 false (var a)) (- (cast 9 false (var src)) (ite (var C) (bv 9 0x0) (bv 9 0x1))))) (seq (set C (! (msb (var res)))) (seq (set res8 (cast 8 false (var res))) (seq (seq (set Z (is_zero (var res8))) (set N (msb (var res8)))) (seq (set V (&& (^^ (msb (var a)) (msb (var res))) (^^ (msb (var a)) (msb (var src))))) (set a (var res8))))))))
+d "sbc 0xcafe" edfeca 0x0 (seq (set src (load 0 (bv 16 0xcafe))) (seq (set res (- (cast 9 false (var a)) (- (cast 9 false (var src)) (ite (var C) (bv 9 0x0) (bv 9 0x1))))) (seq (set C (! (msb (var res)))) (seq (set res8 (cast 8 false (var res))) (seq (seq (set Z (is_zero (var res8))) (set N (msb (var res8)))) (seq (set V (&& (^^ (msb (var a)) (msb (var res))) (^^ (msb (var a)) (msb (var src))))) (set a (var res8))))))))
+d "sbc 0xcafe,x" fdfeca 0x0 (seq (set src (load 0 (+ (bv 16 0xcafe) (cast 16 false (var x))))) (seq (set res (- (cast 9 false (var a)) (- (cast 9 false (var src)) (ite (var C) (bv 9 0x0) (bv 9 0x1))))) (seq (set C (! (msb (var res)))) (seq (set res8 (cast 8 false (var res))) (seq (seq (set Z (is_zero (var res8))) (set N (msb (var res8)))) (seq (set V (&& (^^ (msb (var a)) (msb (var res))) (^^ (msb (var a)) (msb (var src))))) (set a (var res8))))))))
+d "sbc 0xcafe,y" f9feca 0x0 (seq (set src (load 0 (+ (bv 16 0xcafe) (cast 16 false (var y))))) (seq (set res (- (cast 9 false (var a)) (- (cast 9 false (var src)) (ite (var C) (bv 9 0x0) (bv 9 0x1))))) (seq (set C (! (msb (var res)))) (seq (set res8 (cast 8 false (var res))) (seq (seq (set Z (is_zero (var res8))) (set N (msb (var res8)))) (seq (set V (&& (^^ (msb (var a)) (msb (var res))) (^^ (msb (var a)) (msb (var src))))) (set a (var res8))))))))
+d "sbc (0x42,x)" e142 0x0 (seq (set src (load 0 (append (load 0 (cast 16 false (+ (+ (bv 8 0x42) (var x)) (bv 8 0x1)))) (load 0 (cast 16 false (+ (bv 8 0x42) (var x))))))) (seq (set res (- (cast 9 false (var a)) (- (cast 9 false (var src)) (ite (var C) (bv 9 0x0) (bv 9 0x1))))) (seq (set C (! (msb (var res)))) (seq (set res8 (cast 8 false (var res))) (seq (seq (set Z (is_zero (var res8))) (set N (msb (var res8)))) (seq (set V (&& (^^ (msb (var a)) (msb (var res))) (^^ (msb (var a)) (msb (var src))))) (set a (var res8))))))))
+d "sbc (0x42),y" f142 0x0 (seq (set src (load 0 (+ (append (load 0 (cast 16 false (+ (bv 8 0x42) (bv 8 0x1)))) (load 0 (cast 16 false (bv 8 0x42)))) (cast 16 false (var y))))) (seq (set res (- (cast 9 false (var a)) (- (cast 9 false (var src)) (ite (var C) (bv 9 0x0) (bv 9 0x1))))) (seq (set C (! (msb (var res)))) (seq (set res8 (cast 8 false (var res))) (seq (seq (set Z (is_zero (var res8))) (set N (msb (var res8)))) (seq (set V (&& (^^ (msb (var a)) (msb (var res))) (^^ (msb (var a)) (msb (var src))))) (set a (var res8))))))))
+d "sec" 38 0x0 (set C true)
+d "sed" f8 0x0 (set D true)
+d "sei" 78 0x0 (set I true)
+d "sta 0x42" 8542 0x0 (store 0 (bv 16 0x42) (var a))
+d "sta 0x42,x" 9542 0x0 (store 0 (cast 16 false (+ (bv 8 0x42) (var x))) (var a))
+d "sta 0xcafe" 8dfeca 0x0 (store 0 (bv 16 0xcafe) (var a))
+d "sta 0xcafe,x" 9dfeca 0x0 (store 0 (+ (bv 16 0xcafe) (cast 16 false (var x))) (var a))
+d "sta 0xcafe,y" 99feca 0x0 (store 0 (+ (bv 16 0xcafe) (cast 16 false (var y))) (var a))
+d "sta (0x42,x)" 8142 0x0 (store 0 (append (load 0 (cast 16 false (+ (+ (bv 8 0x42) (var x)) (bv 8 0x1)))) (load 0 (cast 16 false (+ (bv 8 0x42) (var x))))) (var a))
+d "sta (0x42),y" 9142 0x0 (store 0 (+ (append (load 0 (cast 16 false (+ (bv 8 0x42) (bv 8 0x1)))) (load 0 (cast 16 false (bv 8 0x42)))) (cast 16 false (var y))) (var a))
+d "stx 0x42" 8642 0x0 (store 0 (bv 16 0x42) (var x))
+d "stx 0x42,y" 9642 0x0 (store 0 (cast 16 false (+ (bv 8 0x42) (var y))) (var x))
+d "stx 0xcafe" 8efeca 0x0 (store 0 (bv 16 0xcafe) (var x))
+d "sty 0x42" 8442 0x0 (store 0 (bv 16 0x42) (var y))
+d "sty 0x42,x" 9442 0x0 (store 0 (cast 16 false (+ (bv 8 0x42) (var x))) (var y))
+d "sty 0xcafe" 8cfeca 0x0 (store 0 (bv 16 0xcafe) (var y))
+d "tax" aa 0x0 (seq (set x (var a)) (seq (set Z (is_zero (var x))) (set N (msb (var x)))))
+d "tay" a8 0x0 (seq (set y (var a)) (seq (set Z (is_zero (var y))) (set N (msb (var y)))))
+d "tsx" ba 0x0 (seq (set x (var sp)) (seq (set Z (is_zero (var x))) (set N (msb (var x)))))
+d "txa" 8a 0x0 (seq (set a (var x)) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))
+d "txs" 9a 0x0 (set sp (var x))
+d "tya" 98 0x0 (seq (set a (var y)) (seq (set Z (is_zero (var a))) (set N (msb (var a)))))

--- a/test/db/rzil/6502
+++ b/test/db/rzil/6502
@@ -1,0 +1,247 @@
+NAME=6502 addr imm
+FILE=malloc://0x10000
+ARGS=-a 6502
+CMDS=<<EOF
+wx a942
+aezi
+aezs
+ar a
+EOF
+EXPECT=<<EOF
+a = 0x00000042
+EOF
+RUN
+
+NAME=6502 addr deref zero page
+FILE=malloc://0x10000
+ARGS=-a 6502
+CMDS=<<EOF
+wx a530
+wx 42 @ 0x30
+aezi
+aezs
+ar a
+EOF
+EXPECT=<<EOF
+a = 0x00000042
+EOF
+RUN
+
+NAME=6502 addr deref
+FILE=malloc://0x10000
+ARGS=-a 6502
+CMDS=<<EOF
+wx ad3402
+wx 42 @ 0x234
+aezi
+aezs
+ar a
+EOF
+EXPECT=<<EOF
+a = 0x00000042
+EOF
+RUN
+
+NAME=6502 addr zero page x
+FILE=malloc://0x10000
+ARGS=-a 6502
+CMDS=<<EOF
+wx b5f0
+wx 42 @ 0xf3
+aezi
+ar x=0x3
+aezs
+ar a
+EOF
+EXPECT=<<EOF
+a = 0x00000042
+EOF
+RUN
+
+NAME=6502 addr zero page x, overflow
+FILE=malloc://0x10000
+ARGS=-a 6502
+CMDS=<<EOF
+wx b5f0
+wx 42 @ 0x03
+aezi
+ar x=0x13
+aezs
+ar a
+EOF
+EXPECT=<<EOF
+a = 0x00000042
+EOF
+RUN
+
+NAME=6502 addr (indirect,x)
+FILE=malloc://0x10000
+ARGS=-a 6502
+CMDS=<<EOF
+wx a143
+wx abcd @ 0x50
+wx 8a @ 0xcdab
+aezi
+ar x=0xd
+aezs
+ar a
+EOF
+EXPECT=<<EOF
+a = 0x0000008a
+EOF
+RUN
+
+NAME=6502 addr (indirect,x), +x overflow
+FILE=malloc://0x10000
+ARGS=-a 6502
+CMDS=<<EOF
+wx a143
+wx abcd @ 0x33
+wx 8a @ 0xcdab
+aezi
+ar x=0xf0
+aezs
+ar a
+EOF
+EXPECT=<<EOF
+a = 0x0000008a
+EOF
+RUN
+
+NAME=6502 addr (indirect,x), +1 overflow
+FILE=malloc://0x10000
+ARGS=-a 6502
+CMDS=<<EOF
+s 1
+wx a143
+wx ab @ 0xff
+wx cd @ 0x00
+wx 8a @ 0xcdab
+aezi
+ar x=0xbc
+aezs
+ar a
+EOF
+EXPECT=<<EOF
+a = 0x0000008a
+EOF
+RUN
+
+NAME=6502 addr (indirect),y
+FILE=malloc://0x10000
+ARGS=-a 6502
+CMDS=<<EOF
+wx b150
+wx abcd @ 0x50
+wx 8a @ 0xceaa
+aezi
+ar y=0xff
+aezs
+ar a
+EOF
+EXPECT=<<EOF
+a = 0x0000008a
+EOF
+RUN
+
+NAME=6502 addr (indirect),y, +1 overflow
+FILE=malloc://0x10000
+ARGS=-a 6502
+CMDS=<<EOF
+s 1
+wx b1ff
+wx ab @ 0xff
+wx cd @ 0x00
+wx 8a @ 0xceaa
+aezi
+ar y=0xff
+aezs
+ar a
+EOF
+EXPECT=<<EOF
+a = 0x0000008a
+EOF
+RUN
+
+NAME=6502 lda flags
+FILE=malloc://0x10000
+ARGS=-a 6502
+CMDS=<<EOF
+aezi
+wx a934 # lda #0x34
+pi 1
+aezs
+ar 1
+ara0
+wx a900 # lda #0x00
+pi 1
+aezs
+ar 1
+ara0
+wx a980 # lda #0x80
+pi 1
+aezs
+ar 1
+EOF
+EXPECT=<<EOF
+lda #0x34
+C = 0x00000000
+Z = 0x00000000
+I = 0x00000000
+D = 0x00000000
+V = 0x00000000
+N = 0x00000000
+lda #0x00
+C = 0x00000000
+Z = 0x00000001
+I = 0x00000000
+D = 0x00000000
+V = 0x00000000
+N = 0x00000000
+lda #0x80
+C = 0x00000000
+Z = 0x00000000
+I = 0x00000000
+D = 0x00000000
+V = 0x00000000
+N = 0x00000001
+EOF
+RUN
+
+NAME=6502 jmp
+FILE=malloc://0x10000
+ARGS=-a 6502
+CMDS=<<EOF
+s 0x1234
+wx 4cfeca @ 0x1234 # jmp 0xcafe
+pi 1
+aezi
+aezs
+ar
+EOF
+EXPECT=<<EOF
+jmp 0xcafe
+a = 0x00000000
+x = 0x00000000
+y = 0x00000000
+flags = 0x00000000
+sp = 0x00000000
+pc = 0x0000cafe
+EOF
+RUN
+
+NAME=6502 crackme.prg decrypt
+FILE=bins/prg/crackme.prg
+ARGS=-a 6502 -F prg
+TIMEOUT=4
+CMDS=<<EOF
+s 0x84c
+e io.cache=1
+aezi
+aezsu 0x84f
+ps @ 0x91b
+EOF
+EXPECT=<<EOF
+HELLO FROM RZIL
+EOF
+RUN


### PR DESCRIPTION
# Do not squash

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This adds RzIL lifting for all legal 6502 ops, except the special bcd modes of `adc` and `sbc` for now. The lifting of every one of these ops is covered by an asm test, making sure all IL is valid. Some manual execution tests are available too, including one that runs a simple real-world xor-"decryption" loop.
The lifting has not been tested against traces yet, so minor mistakes in the semantics are currently expected.

In addition, this also brings the IL opbuilder, which is just a header introducing some macros for writing lifting code with nice syntax.

**Test plan**

see the added tests