### PR TITLE
Convert aez (RzIL commands) to newshell

### DIFF
--- a/librz/core/cmd_descs/cmd_analysis.yaml
+++ b/librz/core/cmd_descs/cmd_analysis.yaml
@@ -3,6 +3,36 @@
 ---
 name: cmd_analysis
 commands:
+  - name: aez
+    summary: RzIL-based Emulation
+    cname: cmd_analysis_il
+    subcommands:
+      - name: aezi
+        summary: (Re)initialize the RzIL VM
+        cname: cmd_analysis_il_init
+        args: []
+      - name: aezv
+        summary: Show the current status of the RzIL VM
+        cname: cmd_analysis_il_state
+        args: []
+      - name: aezs
+        summary: Step a single instruction in the VM
+        cname: cmd_analysis_il_step
+        args: []
+      - name: aezse
+        summary: Step a single instruction in the VM and show events
+        cname: cmd_analysis_il_step_events
+        type: RZ_CMD_DESC_TYPE_ARGV_STATE
+        modes:
+          - RZ_OUTPUT_MODE_STANDARD
+          - RZ_OUTPUT_MODE_JSON
+        args: []
+    details:
+      - name: Examples
+        entries:
+          - text: "42aezs"
+            arg_str: ""
+            comment: Step 42 times in the VM
   - name: af
     summary: Analyze Functions commands
     cname: cmd_analysis_fcn

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -11,6 +11,7 @@ static const RzCmdDescDetail system_details[2];
 static const RzCmdDescDetail system_to_cons_details[2];
 static const RzCmdDescDetail hash_bang_details[2];
 static const RzCmdDescDetail pointer_details[2];
+static const RzCmdDescDetail cmd_analysis_il_details[2];
 static const RzCmdDescDetail analysis_reg_cond_details[4];
 static const RzCmdDescDetail ar_details[2];
 static const RzCmdDescDetail cmd_cmp_unified_details[2];
@@ -969,6 +970,50 @@ static const RzCmdDescHelp cmd_ox_help = {
 static const RzCmdDescHelp cmd_analysis_help = {
 	.summary = "Analysis commands",
 };
+static const RzCmdDescDetailEntry cmd_analysis_il_Examples_detail_entries[] = {
+	{ .text = "42aezs", .arg_str = "", .comment = "Step 42 times in the VM" },
+	{ 0 },
+};
+static const RzCmdDescDetail cmd_analysis_il_details[] = {
+	{ .name = "Examples", .entries = cmd_analysis_il_Examples_detail_entries },
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_analysis_il_help = {
+	.summary = "RzIL-based Emulation",
+	.details = cmd_analysis_il_details,
+};
+static const RzCmdDescArg cmd_analysis_il_init_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_analysis_il_init_help = {
+	.summary = "(Re)initialize the RzIL VM",
+	.args = cmd_analysis_il_init_args,
+};
+
+static const RzCmdDescArg cmd_analysis_il_state_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_analysis_il_state_help = {
+	.summary = "Show the current status of the RzIL VM",
+	.args = cmd_analysis_il_state_args,
+};
+
+static const RzCmdDescArg cmd_analysis_il_step_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_analysis_il_step_help = {
+	.summary = "Step a single instruction in the VM",
+	.args = cmd_analysis_il_step_args,
+};
+
+static const RzCmdDescArg cmd_analysis_il_step_events_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_analysis_il_step_events_help = {
+	.summary = "Step a single instruction in the VM and show events",
+	.args = cmd_analysis_il_step_events_args,
+};
+
 static const RzCmdDescHelp cmd_analysis_fcn_help = {
 	.summary = "Analyze Functions commands",
 };
@@ -9233,6 +9278,20 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *cmd_analysis_cd = rz_cmd_desc_oldinput_new(core->rcmd, root_cd, "a", rz_cmd_analysis, &cmd_analysis_help);
 	rz_warn_if_fail(cmd_analysis_cd);
+	RzCmdDesc *cmd_analysis_il_cd = rz_cmd_desc_group_new(core->rcmd, cmd_analysis_cd, "aez", NULL, NULL, &cmd_analysis_il_help);
+	rz_warn_if_fail(cmd_analysis_il_cd);
+	RzCmdDesc *cmd_analysis_il_init_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_analysis_il_cd, "aezi", rz_cmd_analysis_il_init_handler, &cmd_analysis_il_init_help);
+	rz_warn_if_fail(cmd_analysis_il_init_cd);
+
+	RzCmdDesc *cmd_analysis_il_state_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_analysis_il_cd, "aezv", rz_cmd_analysis_il_state_handler, &cmd_analysis_il_state_help);
+	rz_warn_if_fail(cmd_analysis_il_state_cd);
+
+	RzCmdDesc *cmd_analysis_il_step_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_analysis_il_cd, "aezs", rz_cmd_analysis_il_step_handler, &cmd_analysis_il_step_help);
+	rz_warn_if_fail(cmd_analysis_il_step_cd);
+
+	RzCmdDesc *cmd_analysis_il_step_events_cd = rz_cmd_desc_argv_state_new(core->rcmd, cmd_analysis_il_cd, "aezse", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_cmd_analysis_il_step_events_handler, &cmd_analysis_il_step_events_help);
+	rz_warn_if_fail(cmd_analysis_il_step_events_cd);
+
 	RzCmdDesc *cmd_analysis_fcn_cd = rz_cmd_desc_oldinput_new(core->rcmd, cmd_analysis_cd, "af", rz_cmd_analysis_fcn, &cmd_analysis_fcn_help);
 	rz_warn_if_fail(cmd_analysis_fcn_cd);
 	RzCmdDesc *afb_cd = rz_cmd_desc_group_state_new(core->rcmd, cmd_analysis_fcn_cd, "afb", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_TABLE, rz_analysis_function_blocks_list_handler, &analysis_function_blocks_list_help, &afb_help);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -51,6 +51,10 @@ RZ_IPI RzCmdStatus rz_cmd_help_search_handler(RzCore *core, int argc, const char
 RZ_IPI int rz_cmd_help(void *data, const char *input);
 RZ_IPI RzCmdStatus rz_push_escaped_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI int rz_cmd_ox(void *data, const char *input);
+RZ_IPI RzCmdStatus rz_cmd_analysis_il_init_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_analysis_il_state_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_analysis_il_step_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_analysis_il_step_events_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_analysis_function_blocks_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_analysis_function_blocks_add_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_analysis_function_blocks_del_handler(RzCore *core, int argc, const char **argv);

--- a/test/db/rzil/bf
+++ b/test/db/rzil/bf
@@ -7,7 +7,7 @@ e asm.bytes=true
 e analysis.arch=bf
 s 0
 aezi
-aezs 390
+390aezs
 EOF
 EXPECT=<<EOF
 Hello World!
@@ -38,7 +38,7 @@ ARGS=-b32
 CMDS=<<EOF
 s 0
 aezi
-aezs 906
+906aezs
 EOF
 EXPECT=<<EOF
 Hello World!
@@ -111,7 +111,7 @@ ARGS=-b32
 CMDS=<<EOF
 s 0
 aezi
-aezs 906
+906aezs
 EOF
 EXPECT=<<EOF
 Hello World!
@@ -127,7 +127,7 @@ e analysis.arch=bf
 e rzil.step.events.read=true
 s 0
 aezi
-aezse 390
+390aezse
 EOF
 EXPECT=<<EOF
 var_read(name: ptr, value: 0x0000000000000000)
@@ -1709,5 +1709,21 @@ var_read(name: ptr, value: 0x0000000000000002)
 mem_read(addr: 0x0000000000000002, value: 0x22)
 mem_write(addr: 0x0000000000000002, old: 0x22, new: 0x23)
 pc_write(old: 0x0000000000000011, new: 0x0000000000000012)
+EOF
+RUN
+
+NAME=aezsej
+FILE=bins/bf/hello-loops.bf
+ARGS=-b32
+CMDS=<<EOF
+e asm.arch=bf
+e analysis.arch=bf
+e rzil.step.events.read=true
+s 0
+aezi
+aezsej
+EOF
+EXPECT=<<EOF
+[{"type":"var_read","name":"ptr","value":"0x0000000000000000"},{"type":"var_read","name":"ptr","value":"0x0000000000000000"},{"type":"mem_read","address":"0x0000000000000000","value":"uninitialized memory"},{"type":"mem_write","address":"0x0000000000000000","old":"0x00","new":"0x01"},{"type":"pc_write","old":"0x0000000000000000","new":"0x0000000000000001"}]
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

I have removed the `aezs <n>` syntax to step n times with one call in favor of just typing `<n>aezs`. The downside is that `<n>aezsej` will not give valid json anymore since it appends multiple jsons, so in scripting it would have to be parsed individually. I personally think this is ok.

**Closing issues**

Paritially addresses #1533