### PR TITLE
newshell help: Start arg numbering from 1

### DIFF
--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -944,9 +944,9 @@ static size_t fill_args(RzStrBuf *sb, const RzCmdDesc *cd) {
 		}
 		if (arg->flags & RZ_CMD_ARG_FLAG_ARRAY) {
 			has_array = true;
-			rz_strbuf_appendf(sb, "<%s0>", arg->name);
+			rz_strbuf_appendf(sb, "<%s1>", arg->name);
 			len += strlen(arg->name) + 3;
-			rz_strbuf_appendf(sb, " [<%s1> ...]", arg->name);
+			rz_strbuf_appendf(sb, " [<%s2> ...]", arg->name);
 			len += strlen(arg->name) + 10;
 		} else if (arg->flags & RZ_CMD_ARG_FLAG_OPTION) {
 			rz_strbuf_appendf(sb, "-%s", arg->name);

--- a/test/db/cmd/cmd_help
+++ b/test/db/cmd/cmd_help
@@ -330,10 +330,10 @@ NAME=optional brackets
 FILE==
 CMDS=<<EOF
 ?~interpreter-name
-.?~macro-arg0
+.?~macro-arg
 EOF
 EXPECT=<<EOF
-| #![<interpreter-name> [<arg0> [<arg1> ...]]] # List all available interpreters / Run interpreter
-| .(<macro-name> [<macro-arg0> [<macro-arg1> ...]]) # Interpret output of macro
+| #![<interpreter-name> [<arg1> [<arg2> ...]]] # List all available interpreters / Run interpreter
+| .(<macro-name> [<macro-arg1> [<macro-arg2> ...]]) # Interpret output of macro
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Since the newshell help is mainly meant for human consumption, I think it's more natural to start argument numbering from 1 (and also you can then refer to the first argument as the first argument and not the zeroth argument). For examples online, see https://docs.python.org/3.10/library/functions.html#staticmethod and https://en.cppreference.com/w/cpp/language/list_initialization.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
