### PR TITLE
Make meson.build work again with meson 0.55.3

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('rizin', 'c',
   version: 'v0.4.0-git',
   license: 'LGPL3',
-  meson_version: '>=0.55.0',
+  meson_version: '>=0.55.3',
   default_options: [
     'buildtype=debugoptimized',
     'b_vscrt=from_buildtype',
@@ -780,8 +780,12 @@ if cli_enabled
   )
 endif
 
-meson_dist_script = files('sys/meson_dist_script.py')
-meson.add_dist_script(meson_dist_script)
+dist_script = 'sys/meson_dist_script.py'
+if meson.version().version_compare('<0.57.0')
+  meson.add_dist_script(meson.source_root() / dist_script)
+else
+  meson.add_dist_script(files(dist_script))
+endif
 
 summary({
   'prefix': rizin_prefix,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr makes `meson.build` work again with Meson 0.55.3. The reason the required Meson version wasn't bumped higher is that a local machine encountered a performance regression when installing sdb files using Meson 0.57.2 and 0.60.2.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
