### PR TITLE
Make rz_strbuf_slice() truncate on excessive len

### DIFF
--- a/librz/include/rz_util/rz_strbuf.h
+++ b/librz/include/rz_util/rz_strbuf.h
@@ -16,7 +16,7 @@ typedef struct {
 #define RZ_STRBUF_SAFEGET(sb) (rz_strbuf_get(sb) ? rz_strbuf_get(sb) : "")
 RZ_API RzStrBuf *rz_strbuf_new(const char *s);
 RZ_API const char *rz_strbuf_set(RzStrBuf *sb, const char *s); // return = the string or NULL on fail
-RZ_API bool rz_strbuf_slice(RzStrBuf *sb, int from, int len);
+RZ_API bool rz_strbuf_slice(RzStrBuf *sb, size_t from, size_t len);
 RZ_API bool rz_strbuf_setbin(RzStrBuf *sb, const ut8 *s, size_t len);
 RZ_API ut8 *rz_strbuf_getbin(RzStrBuf *sb, int *len);
 RZ_API const char *rz_strbuf_setf(RzStrBuf *sb, const char *fmt, ...) RZ_PRINTF_CHECK(2, 3); // return = the string or NULL on fail

--- a/librz/util/strbuf.c
+++ b/librz/util/strbuf.c
@@ -110,36 +110,29 @@ RZ_API bool rz_strbuf_setbin(RzStrBuf *sb, const ut8 *s, size_t l) {
 /**
  * \brief Cuts the current string into a substring
  *
+ * Only to be used on strings, not binary buffers.
+ * If `len > sb->len - from`, then the resulting size will be truncated appropriately.
+ *
  * \param sb    RzStrBuf to use
  * \param from  Begin index from where to cut
  * \param len   Length of the substring to cut
  *
  * \return      false when fails to to cut the current buffer into a substring
  */
-RZ_API bool rz_strbuf_slice(RZ_NONNULL RzStrBuf *sb, int from, int len) {
+RZ_API bool rz_strbuf_slice(RZ_NONNULL RzStrBuf *sb, size_t from, size_t len) {
 	rz_return_val_if_fail(sb && from >= 0 && len >= 0, false);
-	if (from < 0 && len >= sb->len) {
-		return false;
+	if (from >= sb->len) {
+		// trying to cut outside the buf
+		return !sb->len && !from; // but it's fine if both are 0
 	}
 	char *s = rz_strbuf_get(sb);
-	if (!from) {
-		sb->len = len;
-		sb->ptrlen = len + 1;
-		s[len] = 0;
-		return true;
+	len = RZ_MIN(sb->len - from, len);
+	if (from) {
+		memmove(s, s + from, len);
 	}
-	const char *fr = rz_str_ansi_chrn(s, from + 1);
-	const char *to = rz_str_ansi_chrn(s, from + len + 1);
-	char *r = rz_str_newlen(fr, to - fr);
-	rz_strbuf_fini(sb);
-	rz_strbuf_init(sb);
-	if (from >= len) {
-		rz_strbuf_set(sb, "");
-		free(r);
-		return false;
-	}
-	rz_strbuf_set(sb, r);
-	free(r);
+	sb->len = len;
+	sb->ptrlen = len + 1;
+	s[len] = 0;
 	return true;
 }
 

--- a/test/unit/test_strbuf.c
+++ b/test/unit/test_strbuf.c
@@ -6,10 +6,20 @@
 
 bool test_rz_strbuf_slice(void) {
 	RzStrBuf *sa = rz_strbuf_new("foo,bar,cow");
-	rz_strbuf_slice(sa, 2, 4); // should be from/to instead of from/len ?
-	char *a = rz_strbuf_drain(sa);
-	mu_assert_streq(a, "o,ba", "slicing fails");
-	free(a);
+	rz_strbuf_slice(sa, 2, 4);
+	mu_assert_streq_free(rz_strbuf_drain(sa), "o,ba", "from + len");
+
+	sa = rz_strbuf_new("Restore our vision of natural progression");
+	rz_strbuf_slice(sa, 0, 18);
+	mu_assert_streq_free(rz_strbuf_drain(sa), "Restore our vision", "len");
+
+	sa = rz_strbuf_new("Drift with the ebb and flow");
+	rz_strbuf_slice(sa, 15, 9001);
+	mu_assert_streq_free(rz_strbuf_drain(sa), "ebb and flow", "from + escessive len");
+
+	sa = rz_strbuf_new("Intuition speak to me");
+	rz_strbuf_slice(sa, 0, 9001);
+	mu_assert_streq_free(rz_strbuf_drain(sa), "Intuition speak to me", "escessive len");
 
 	mu_end;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

It is often useful to get a slice of some maximum len, also accepting
smaller results if the source is not large enough.
This also makes the function always operate on byte indices. Before,
it was inconsistently skipping ansi codes sometimes.
This also fixes potential oob writes in panels.c:

```
==13670== Memcheck, a memory error detector
==13670== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==13670== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==13670== Command: build/binrz/rizin/rizin /home/florian/dev/rizin/test/bins/elf/crackme0x00b
==13670== Parent PID: 2158
==13670== 
==13670== Invalid write of size 1
==13670==    at 0x48FC548: rz_strbuf_slice (strbuf.c:128)
==13670==    by 0x6311E3F: __update_panel_title (panels.c:1125)
==13670==    by 0x631200F: __default_panel_print (panels.c:1146)
==13670==    by 0x6311377: __panel_print (panels.c:982)
==13670==    by 0x631F67F: __panels_refresh (panels.c:4675)
==13670==    by 0x6312E3F: __panels_layout_refresh (panels.c:1371)
==13670==    by 0x632530B: __panels_process (panels.c:6346)
==13670==    by 0x632425B: rz_core_visual_panels_root (panels.c:6019)
==13670==    by 0x62DA243: rz_cmd_panels (cmd.c:1083)
==13670==    by 0x62EFDB7: call_cd (cmd_api.c:755)
==13670==    by 0x62EFE57: rz_cmd_call_parsed_args (cmd_api.c:770)
==13670==    by 0x62E3527: handle_ts_arged_stmt_internal (cmd.c:3984)
==13670==  Address 0x6a74ff0 is 16 bytes after a block of size 64 alloc'd
==13670==    at 0x4854224: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==13670==    by 0x48FBE23: rz_strbuf_new (strbuf.c:9)
==13670==    by 0x6311C6B: __update_panel_title (panels.c:1107)
==13670==    by 0x631200F: __default_panel_print (panels.c:1146)
==13670==    by 0x6311377: __panel_print (panels.c:982)
==13670==    by 0x631F67F: __panels_refresh (panels.c:4675)
==13670==    by 0x6312E3F: __panels_layout_refresh (panels.c:1371)
==13670==    by 0x632530B: __panels_process (panels.c:6346)
==13670==    by 0x632425B: rz_core_visual_panels_root (panels.c:6019)
==13670==    by 0x62DA243: rz_cmd_panels (cmd.c:1083)
==13670==    by 0x62EFDB7: call_cd (cmd_api.c:755)
==13670==    by 0x62EFE57: rz_cmd_call_parsed_args (cmd_api.c:770)
```

**Test plan**

Run the tests
`v`, then tab around, press `m`, etc.
