### PR TITLE
Fix +/- in visual cursor mode

### DIFF
--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -3080,9 +3080,9 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 					}
 				} else {
 					if (core->print->ocur == -1) {
-						sprintf(buf, "wos 01 @ $$+%i!1", core->print->cur);
+						sprintf(buf, "wos 01 @ $$+%i @!1", core->print->cur);
 					} else {
-						sprintf(buf, "wos 01 @ $$+%i!%i", core->print->cur < core->print->ocur ? core->print->cur : core->print->ocur,
+						sprintf(buf, "wos 01 @ $$+%i @!%i", core->print->cur < core->print->ocur ? core->print->cur : core->print->ocur,
 							RZ_ABS(core->print->ocur - core->print->cur) + 1);
 					}
 					rz_core_cmd(core, buf, 0);
@@ -3109,9 +3109,9 @@ RZ_API int rz_core_visual_cmd(RzCore *core, const char *arg) {
 					}
 				} else {
 					if (core->print->ocur == -1) {
-						sprintf(buf, "woa 01 @ $$+%i!1", core->print->cur);
+						sprintf(buf, "woa 01 @ $$+%i @!1", core->print->cur);
 					} else {
-						sprintf(buf, "woa 01 @ $$+%i!%i", core->print->cur < core->print->ocur ? core->print->cur : core->print->ocur,
+						sprintf(buf, "woa 01 @ $$+%i @!%i", core->print->cur < core->print->ocur ? core->print->cur : core->print->ocur,
 							RZ_ABS(core->print->ocur - core->print->cur) + 1);
 					}
 					rz_core_cmd(core, buf, 0);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Syntax has changed: @! with space temporarily sets the blocksize.
Otherwise the entire block would always be changed.

**Test plan**

* `rz =`
* `Vc`
* press `+`/`-` to edit the selected byte
  * only the selected byte should change, not the entire block