### PR TITLE
[FLIRT] Extract info from parsed structure and Fix #1314

### DIFF
--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -8668,7 +8668,7 @@ static const RzCmdDescArg zign_flirt_create_args[] = {
 	{ 0 },
 };
 static const RzCmdDescHelp zign_flirt_create_help = {
-	.summary = "Create a FLIRT file (.pac or .sig)",
+	.summary = "Create a FLIRT file (.pat or .sig)",
 	.args = zign_flirt_create_args,
 };
 
@@ -8681,7 +8681,7 @@ static const RzCmdDescArg zign_flirt_dump_args[] = {
 	{ 0 },
 };
 static const RzCmdDescHelp zign_flirt_dump_help = {
-	.summary = "Open a FLIRT file (.pac or .sig) and dumps its contents",
+	.summary = "Open a FLIRT file (.pat or .sig) and dumps its contents",
 	.args = zign_flirt_dump_args,
 };
 
@@ -8694,7 +8694,7 @@ static const RzCmdDescArg zign_flirt_scan_args[] = {
 	{ 0 },
 };
 static const RzCmdDescHelp zign_flirt_scan_help = {
-	.summary = "Open a FLIRT file (.pac or .sig) and tries to apply the signatures to the loaded binary",
+	.summary = "Open a FLIRT file (.pat or .sig) and tries to apply the signatures to the loaded binary",
 	.args = zign_flirt_scan_args,
 };
 

--- a/librz/core/cmd_descs/cmd_zign.yaml
+++ b/librz/core/cmd_descs/cmd_zign.yaml
@@ -187,19 +187,19 @@ commands:
     subcommands:
       - name: zfc
         cname: zign_flirt_create
-        summary: Create a FLIRT file (.pac or .sig)
+        summary: Create a FLIRT file (.pat or .sig)
         args:
           - name: filename
             type: RZ_CMD_ARG_TYPE_FILE
       - name: zfd
         cname: zign_flirt_dump
-        summary: Open a FLIRT file (.pac or .sig) and dumps its contents
+        summary: Open a FLIRT file (.pat or .sig) and dumps its contents
         args:
           - name: filename
             type: RZ_CMD_ARG_TYPE_FILE
       - name: zfs
         cname: zign_flirt_scan
-        summary: Open a FLIRT file (.pac or .sig) and tries to apply the signatures to the loaded binary
+        summary: Open a FLIRT file (.pat or .sig) and tries to apply the signatures to the loaded binary
         args:
           - name: filename
             type: RZ_CMD_ARG_TYPE_FILE

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -1114,6 +1114,7 @@ RZ_API void rz_core_analysis_propagate_noreturn(RzCore *core, ut64 addr);
 RZ_API bool rz_core_flirt_dump_file(RZ_NONNULL const char *flirt_file);
 RZ_API bool rz_core_flirt_create_file(RZ_NONNULL RzCore *core, RZ_NONNULL const char *output_file, RZ_NULLABLE ut32 *written_nodes);
 RZ_API bool rz_core_flirt_convert_file(RZ_NONNULL RzCore *core, RZ_NONNULL const char *input_file, RZ_NONNULL const char *ouput_file);
+RZ_API const char *rz_core_flirt_arch_from_id(ut8 arch);
 RZ_API ut8 rz_core_flirt_arch_from_name(RZ_NONNULL const char *arch);
 RZ_API ut32 rz_core_flirt_file_from_option_list(RZ_NONNULL const char *file_list);
 RZ_API ut16 rz_core_flirt_os_from_option_list(RZ_NONNULL const char *os_list);

--- a/librz/include/rz_flirt.h
+++ b/librz/include/rz_flirt.h
@@ -186,9 +186,35 @@ enum rz_flirt_node_optimization_t {
 	RZ_FLIRT_NODE_OPTIMIZE_MAX, ///< optimize the tree structure and drops the tail bytes
 };
 
+typedef enum rz_flirt_file_type_t {
+	RZ_FLIRT_FILE_TYPE_UNKNOWN = 0, ///< unknown type
+	RZ_FLIRT_FILE_TYPE_SIG, ///< `.sig` compressed pattern file
+	RZ_FLIRT_FILE_TYPE_PAT, ///< `.pat` text format pattern file
+} RzFlirtFileType;
+
+typedef struct rz_flirt_sig_info_t {
+	ut8 version; ///< FLIRT sig version
+	ut8 architecture; ///< FLIRT sig architecture/processor id
+	ut32 n_modules; ///< FLIRT sig total number of modules/signatures contained
+	char *name; ///< FLIRT sig name
+} RzFlirtSigInfo;
+
+typedef struct rz_flirt_pat_info_t {
+	ut32 n_modules; ///< FLIRT pat total number of modules/signatures contained
+} RzFlirtPatInfo;
+
+typedef struct rz_flirt_info_t {
+	RzFlirtFileType type; ///< Flirt file type
+	union {
+		RzFlirtSigInfo sig; ///< Sig info
+		RzFlirtPatInfo pat; ///< Pat info
+	} u;
+} RzFlirtInfo;
+
 RZ_API ut32 rz_sign_flirt_node_count_nodes(RZ_NONNULL const RzFlirtNode *node);
 RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_node_new(RZ_NONNULL RzAnalysis *analysis, ut32 optimization);
 RZ_API void rz_sign_flirt_node_free(RZ_NULLABLE RzFlirtNode *node);
+RZ_API void rz_sign_flirt_info_fini(RZ_NULLABLE RzFlirtInfo *info);
 
 RZ_API void rz_sign_flirt_apply(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL const char *flirt_file, ut8 expected_arch);
 
@@ -202,10 +228,10 @@ typedef struct rz_flirt_compressed_options_t {
 	const char *libname;
 } RzFlirtCompressedOptions;
 
-RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_compressed_pattern_from_buffer(RZ_NONNULL RzBuffer *flirt_buf, ut8 expected_arch);
+RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_compressed_pattern_from_buffer(RZ_NONNULL RzBuffer *flirt_buf, ut8 expected_arch, RZ_NULLABLE RzFlirtInfo *info);
 RZ_API bool rz_sign_flirt_write_compressed_pattern_to_buffer(RZ_NONNULL const RzFlirtNode *node, RZ_NONNULL RzBuffer *buffer, RzFlirtCompressedOptions *options);
 
-RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_string_pattern_from_buffer(RZ_NONNULL RzBuffer *flirt_buf, ut32 optimization);
+RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_string_pattern_from_buffer(RZ_NONNULL RzBuffer *flirt_buf, ut32 optimization, RZ_NULLABLE RzFlirtInfo *info);
 RZ_API bool rz_sign_flirt_write_string_pattern_to_buffer(RZ_NONNULL const RzFlirtNode *node, RZ_NONNULL RzBuffer *buffer);
 
 #ifdef __cplusplus

--- a/librz/main/rz-sign.c
+++ b/librz/main/rz-sign.c
@@ -182,7 +182,7 @@ RZ_API int rz_main_rz_sign(int argc, const char **argv) {
 			rz_cons_printf("rz-sign: written %u signatures to %s.\n", n_nodes, output_file);
 		}
 	} else {
-		// convert a flirt file from .pac to .sig or viceversa
+		// convert a flirt file from .pat to .sig or viceversa
 		if (!rz_core_flirt_convert_file(core, input_file, output_file)) {
 			ret = -1;
 		} else if (!quiet) {

--- a/librz/signature/flirt.c
+++ b/librz/signature/flirt.c
@@ -308,6 +308,21 @@ RZ_API void rz_sign_flirt_node_free(RZ_NULLABLE RzFlirtNode *node) {
 }
 
 /**
+ * \brief Frees an RzFlirtInfo struct elements without freeing the pointer
+ *
+ * \param RzFlirtInfo  The RzFlirtInfo elements to be freed
+ */
+RZ_API void rz_sign_flirt_info_fini(RZ_NULLABLE RzFlirtInfo *info) {
+	if (!info) {
+		return;
+	}
+	if (info->type == RZ_FLIRT_FILE_TYPE_SIG) {
+		free(info->u.sig.name);
+	}
+	memset(info, 0, sizeof(RzFlirtInfo));
+}
+
+/**
  * \brief Checks if a pattern does match the buffer data
  *
  * \param p_size   The pattern size
@@ -1012,9 +1027,10 @@ exit:
  *
  * \param  flirt_buf     The buffer to read
  * \param  expected_arch The expected arch to be used for the buffer
+ * \param  info          Pointer to a RzFlirtInfo that can be used to get info about the sig file
  * \return               Parsed FLIRT node
  */
-RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_compressed_pattern_from_buffer(RZ_NONNULL RzBuffer *flirt_buf, ut8 expected_arch) {
+RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_compressed_pattern_from_buffer(RZ_NONNULL RzBuffer *flirt_buf, ut8 expected_arch, RZ_NULLABLE RzFlirtInfo *info) {
 	rz_return_val_if_fail(flirt_buf && expected_arch <= RZ_FLIRT_SIG_ARCH_ANY, NULL);
 
 	ut8 *name = NULL;
@@ -1139,6 +1155,15 @@ RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_compressed_pattern_from_buffer(RZ
 		free(node);
 	}
 
+	if (info && ret) {
+		info->type = RZ_FLIRT_FILE_TYPE_SIG;
+		info->u.sig.version = rz_sign_flirt_node_count_nodes(ret);
+		info->u.sig.architecture = header->arch;
+		info->u.sig.n_modules = ps.version;
+		info->u.sig.name = (char *)name;
+		name = NULL;
+	}
+
 exit:
 	free(buf);
 	rz_buf_free(rz_buf);
@@ -1178,9 +1203,9 @@ RZ_API void rz_sign_flirt_apply(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL cons
 	}
 
 	if (!strcmp(extension, ".pat")) {
-		node = rz_sign_flirt_parse_string_pattern_from_buffer(flirt_buf, RZ_FLIRT_NODE_OPTIMIZE_MAX);
+		node = rz_sign_flirt_parse_string_pattern_from_buffer(flirt_buf, RZ_FLIRT_NODE_OPTIMIZE_MAX, NULL);
 	} else {
-		node = rz_sign_flirt_parse_compressed_pattern_from_buffer(flirt_buf, expected_arch);
+		node = rz_sign_flirt_parse_compressed_pattern_from_buffer(flirt_buf, expected_arch, NULL);
 	}
 
 	rz_buf_free(flirt_buf);

--- a/librz/signature/pat.c
+++ b/librz/signature/pat.c
@@ -350,9 +350,10 @@ err:
  *
  * \param  flirt_buf     The buffer to read
  * \param  optimization  Optimization to apply after creation of the flatten nodes.
+ * \param  info          Pointer to a RzFlirtInfo that can be used to get info about the pat file
  * \return               Parsed FLIRT node
  */
-RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_string_pattern_from_buffer(RZ_NONNULL RzBuffer *flirt_buf, ut32 optimization) {
+RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_string_pattern_from_buffer(RZ_NONNULL RzBuffer *flirt_buf, ut32 optimization, RZ_NULLABLE RzFlirtInfo *info) {
 	rz_return_val_if_fail(flirt_buf, NULL);
 
 	if (optimization > RZ_FLIRT_NODE_OPTIMIZE_MAX) {
@@ -428,6 +429,11 @@ RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_string_pattern_from_buffer(RZ_NON
 	} else if (!flirt_node_optimize(root)) {
 		rz_sign_flirt_node_free(root);
 		return NULL;
+	}
+
+	if (info) {
+		info->type = RZ_FLIRT_FILE_TYPE_PAT;
+		info->u.pat.n_modules = rz_sign_flirt_node_count_nodes(root);
 	}
 
 	return root;

--- a/test/db/cmd/cmd_aaF
+++ b/test/db/cmd/cmd_aaF
@@ -21,7 +21,7 @@ afl~printf
 EOF
 EXPECT=<<EOF
 0x00409c70   18 516  -> 514  flirt.printf
-0x0046fc50    7 516  -> 342  flirt.printf
+0x0046fc50    7 516  -> 342  flirt.printf_1
 EOF
 RUN
 
@@ -36,6 +36,6 @@ EOF
 EXPECT=<<EOF
 Applying elf/x86/64/match.sig signature file
 0x00409c70   18 516  -> 514  flirt.printf
-0x0046fc50    7 516  -> 342  flirt.printf
+0x0046fc50    7 516  -> 342  flirt.printf_1
 EOF
 RUN

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -700,6 +700,10 @@ NAME=zfd libc-v7.sig
 FILE=bins/elf/analysis/pid_stripped
 CMDS=zfd bins/other/sigs/libc-v7.sig
 EXPECT=<<EOF
+SIG format
+Signature:    , 7 modules
+Version:      1
+Architecture: 0 (x86)
 41564155B8........4154554D89C4534889CD4D89CD4881EC900000004885C0:
  0. 16 D2A2 0298 0000:__libc_start_main
 EOF
@@ -739,10 +743,14 @@ Found 1 FLIRT signatures via bins/other/sigs/libc-v10.sig
 EOF
 RUN
 
-NAME=zfd libc-v10.sig
+NAME=zfd libc-v10.sig (malformed v10)
 FILE=bins/elf/analysis/pid_stripped
 CMDS=zfd bins/other/sigs/libc-v10.sig
 EXPECT=<<EOF
+SIG format
+Signature:    FLIRT v10, 10 modules
+Version:      1
+Architecture: 0 (x86)
 41564155B8........4154554D89C4534889CD4D89CD4881EC900000004885C0:
  0. 16 D2A2 0298 0000:__libc_start_main
 EOF
@@ -1815,6 +1823,6 @@ CMDS=<<EOF
 zfd bins/flirt/elf-x86/libcurl.a.pat~?
 EOF
 EXPECT=<<EOF
-207
+209
 EOF
 RUN

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -792,6 +792,7 @@ EOF
 EXPECT=<<EOF
 0x004004d1 86 flirt.__malloc_assert.constprop.13
 0x00400527 35 flirt.__gconv_release_step.part.1
+0x0040054a 79 flirt.length_mismatch
 0x00400b70 613 flirt.get_common_indeces.constprop.1
 0x00400de0 1657 flirt.__libc_start_main
 0x00401460 385 flirt.__libc_check_standard_fds
@@ -819,6 +820,7 @@ EXPECT=<<EOF
 0x0040ea50 288 flirt.__new_exitfn
 0x0040ec70 250 flirt.__cxa_atexit
 0x0040f430 542 flirt.__correctly_grouped_prefixmb
+0x0040f650 192 flirt.___asprintf
 0x0040f710 368 flirt.locked_vfxprintf
 0x0040f880 784 flirt.__fxprintf
 0x0040fe20 33103 flirt._IO_fflush
@@ -852,6 +854,7 @@ EXPECT=<<EOF
 0x0042b6b0 1022 flirt.__memcmp_sse2
 0x00447cf0 1568 flirt.handle_amd
 0x00448310 37 flirt.__cache_sysconf
+0x00448380 9 flirt.__wmemcpy
 0x004491d0 80 flirt.__get_child_max
 0x004492c0 288 flirt.__libc_open64
 0x004493e0 160 flirt.__open64_nocancel
@@ -914,7 +917,7 @@ EXPECT=<<EOF
 0x0045f800 13172 flirt._IO_vfprintf_internal
 0x00462b80 976 flirt.hack_digit
 0x00465a50 11033 flirt.___printf_fp
-0x00468470 192 flirt.___asprintf
+0x00468470 192 flirt.___asprintf_1
 0x00468530 11072 flirt._i18n_number_rewrite
 0x0046b070 13435 flirt._IO_vfwprintf
 0x0046e540 1929 flirt.__parse_one_specmb
@@ -939,7 +942,8 @@ EXPECT=<<EOF
 0x00472480 102 flirt.__strtok_r
 0x00472cc0 218 flirt.__argz_create_sep
 0x00472da0 183 flirt.__argz_add_sep
-0x00473890 9 flirt.__wmemcpy
+0x00473890 9 flirt.__wmemcpy_2
+0x004738a0 9 flirt.__wmemcpy_1
 0x00473ab0 480 flirt.__wcrtomb
 0x00473c90 806 flirt.__wcsrtombs
 0x00473fc0 32 flirt.__wcschrnul
@@ -979,7 +983,7 @@ EXPECT=<<EOF
 0x0047f5c0 240 flirt._dl_add_to_slotinfo
 0x0047f6b0 416 flirt._dl_get_origin
 0x0047f850 197 flirt._dl_scope_free
-0x00480690 48 flirt.length_mismatch
+0x00480690 48 flirt.length_mismatch_1
 0x004806c0 210 flirt._dl_exception_create
 0x004807a0 729 flirt._dl_exception_create_format
 0x00480a80 38 flirt._dl_exception_free
@@ -1002,7 +1006,8 @@ EXPECT=<<EOF
 0x004832a0 1378 flirt.__mpn_impn_mul_n
 0x00483810 431 flirt.__mpn_impn_sqr_n_basecase
 0x004839c0 1262 flirt.__mpn_impn_sqr_n
-0x00483f50 173 flirt.__mpn_sub_n
+0x00483f50 173 flirt.__mpn_sub_n_1
+0x00484000 235 flirt.__mpn_addmul_1
 0x004840f0 144 flirt.__mpn_extract_double
 0x00484180 185 flirt.__mpn_extract_long_double
 0x00484240 286 flirt.__mpn_extract_float128
@@ -1024,7 +1029,8 @@ EXPECT=<<EOF
 0x00487960 101 flirt._dl_tlsdesc_resolve_hold_fixup
 0x004879d0 25 flirt._dl_unmap
 0x00487cf0 83 flirt._dl_addr_inside_object
-0x00487e00 235 flirt.__mpn_addmul_1
+0x00487d50 173 flirt.__mpn_sub_n
+0x00487e00 235 flirt.__mpn_addmul_1_1
 0x004895d0 877 flirt._dl_init
 0x00489940 1806 flirt._dl_check_map_versions
 0x0048fa10 478 flirt.__dl_iterate_phdr

--- a/test/db/tools/rz_sign
+++ b/test/db/tools/rz_sign
@@ -18,6 +18,10 @@ NAME=FLIRT dump libc-v7.sig
 FILE==
 CMDS=!rz-sign -d bins/other/sigs/libc-v7.sig
 EXPECT=<<EOF
+SIG format
+Signature:    , 7 modules
+Version:      1
+Architecture: 0 (x86)
 41564155B8........4154554D89C4534889CD4D89CD4881EC900000004885C0:
  0. 16 D2A2 0298 0000:__libc_start_main
 EOF
@@ -27,6 +31,10 @@ NAME=FLIRT dump libc-v10.sig
 FILE==
 CMDS=!rz-sign -d bins/other/sigs/libc-v10.sig
 EXPECT=<<EOF
+SIG format
+Signature:    FLIRT v10, 10 modules
+Version:      1
+Architecture: 0 (x86)
 41564155B8........4154554D89C4534889CD4D89CD4881EC900000004885C0:
  0. 16 D2A2 0298 0000:__libc_start_main
 EOF

--- a/test/unit/test_flirt.c
+++ b/test/unit/test_flirt.c
@@ -13,7 +13,7 @@
 		RzFlirtNode *node = NULL; \
 		RzBuffer *buffer = rz_buf_new_with_string(string); \
 		mu_assert_notnull(buffer, "buffer is not null (" #name ")"); \
-		node = rz_sign_flirt_parse_string_pattern_from_buffer(buffer, RZ_FLIRT_NODE_OPTIMIZE_NONE); \
+		node = rz_sign_flirt_parse_string_pattern_from_buffer(buffer, RZ_FLIRT_NODE_OPTIMIZE_NONE, NULL); \
 		mu_assert_notnull(node, "node is not null (" #name ")"); \
 		mu_assert_eq(rz_list_length(node->child_list), n_childs, "node contains one child (" #name ")"); \
 		rz_sign_flirt_node_free(node); \


### PR DESCRIPTION
# do NOT squash

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Allows to extract (and print via dump cmd) informations related to FLIRT files.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Fix #1314 by verifying that the function was never declared before. 