### PR TITLE
Fix Double Free in Cs without a Bin File

### DIFF
--- a/librz/core/cmeta.c
+++ b/librz/core/cmeta.c
@@ -417,7 +417,7 @@ static bool meta_string_guess_add(RzCore *core, ut64 addr, size_t limit, char **
 	}
 	*ds = rz_list_first(str_list);
 	rz_list_free(str_list);
-	rz_str_ncpy(*((char **)name), (*ds)->string, limit);
+	rz_str_ncpy(name, (*ds)->string, limit);
 	name[limit] = '\0';
 	*name_out = name;
 	return true;

--- a/test/db/cmd/cmd_meta
+++ b/test/db/cmd/cmd_meta
@@ -107,6 +107,18 @@ hello
 EOF
 RUN
 
+NAME=Cs
+FILE==
+CMDS=<<EOF
+w "Friendly Conversation"
+Cs
+C
+EOF
+EXPECT=<<EOF
+0x00000000 ascii[22] "Friendly Conversation"
+EOF
+RUN
+
 NAME=Cs without bin
 FILE==
 CMDS=<<EOF

--- a/test/db/cmd/cmd_meta
+++ b/test/db/cmd/cmd_meta
@@ -106,3 +106,42 @@ hello
 0x0000000a CCu "hello"
 EOF
 RUN
+
+NAME=Cs without bin
+FILE==
+CMDS=<<EOF
+ob-*
+w "Friendly Conversation"
+Cs
+# Right now, this does nothing. We just check that it doesn't crash.
+# Later, it will be nice if it also actually detects the string.
+C
+EOF
+EXPECT=
+RUN
+
+NAME=Cs8 without bin
+FILE==
+CMDS=<<EOF
+ob-*
+w "Friendly Conversation"
+Cs8
+C
+EOF
+EXPECT=<<EOF
+0x00000000 utf8[22] "Friendly Conversation"
+EOF
+RUN
+
+NAME=Csb without bin
+FILE==
+CMDS=<<EOF
+ob-*
+w "Friendly Conversation"
+Csb
+C
+EOF
+EXPECT=<<EOF
+0x00000000 ascii[22] "Friendly Conversation"
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

In practice, this happens for example when remote-debugging:

```
florian@florian-gentoo ~/dev/rizin $ valgrind rz =
==8851== Memcheck, a memory error detector
==8851== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==8851== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==8851== Command: rz =
==8851==
o -- You can redefine descriptive commands in the hud file and using the 'V_' command.
[0x00000000]> ob-*
[0x00000000]> Cs
==8851== Invalid free() / delete / delete[] / realloc()
==8851==    at 0x4851E40: free (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==8851==    by 0x61D85C3: rz_core_meta_string_add (cmeta.c:463)
==8851==    by 0x627D98F: rz_meta_string_handler (cmd_meta.c:434)
==8851==    by 0x62C2617: argv_call_cb (cmd_api.c:693)
==8851==    by 0x62C294F: call_cd (cmd_api.c:752)
==8851==    by 0x62C293B: call_cd (cmd_api.c:748)
==8851==    by 0x62C2A33: rz_cmd_call_parsed_args (cmd_api.c:770)
==8851==    by 0x62B6107: handle_ts_arged_stmt_internal (cmd.c:3985)
==8851==    by 0x62B5C4B: handle_ts_arged_stmt (cmd.c:3933)
==8851==    by 0x62BE683: handle_ts_stmt (cmd.c:5435)
==8851==    by 0x62BEABF: handle_ts_statements_internal (cmd.c:5492)
==8851==    by 0x62BE85F: handle_ts_statements (cmd.c:5457)
==8851==  Address 0x7f90ac0 is 0 bytes inside a block of size 257 free'd
==8851==    at 0x4851E40: free (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==8851==    by 0x61D8283: meta_string_guess_add (cmeta.c:396)
==8851==    by 0x61D8503: rz_core_meta_string_add (cmeta.c:448)
==8851==    by 0x627D98F: rz_meta_string_handler (cmd_meta.c:434)
==8851==    by 0x62C2617: argv_call_cb (cmd_api.c:693)
==8851==    by 0x62C294F: call_cd (cmd_api.c:752)
==8851==    by 0x62C293B: call_cd (cmd_api.c:748)
==8851==    by 0x62C2A33: rz_cmd_call_parsed_args (cmd_api.c:770)
==8851==    by 0x62B6107: handle_ts_arged_stmt_internal (cmd.c:3985)
==8851==    by 0x62B5C4B: handle_ts_arged_stmt (cmd.c:3933)
==8851==    by 0x62BE683: handle_ts_stmt (cmd.c:5435)
==8851==    by 0x62BEABF: handle_ts_statements_internal (cmd.c:5492)
==8851==  Block was alloc'd at
==8851==    at 0x484F3C8: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==8851==    by 0x61D821B: meta_string_guess_add (cmeta.c:389)
==8851==    by 0x61D8503: rz_core_meta_string_add (cmeta.c:448)
==8851==    by 0x627D98F: rz_meta_string_handler (cmd_meta.c:434)
==8851==    by 0x62C2617: argv_call_cb (cmd_api.c:693)
==8851==    by 0x62C294F: call_cd (cmd_api.c:752)
==8851==    by 0x62C293B: call_cd (cmd_api.c:748)
==8851==    by 0x62C2A33: rz_cmd_call_parsed_args (cmd_api.c:770)
==8851==    by 0x62B6107: handle_ts_arged_stmt_internal (cmd.c:3985)
==8851==    by 0x62B5C4B: handle_ts_arged_stmt (cmd.c:3933)
==8851==    by 0x62BE683: handle_ts_stmt (cmd.c:5435)
==8851==    by 0x62BEABF: handle_ts_statements_internal (cmd.c:5492)
==8851==
```
