### PR TITLE
Fix null-deref on failed g

### DIFF
--- a/librz/core/cmd/cmd_egg.c
+++ b/librz/core/cmd/cmd_egg.c
@@ -110,6 +110,9 @@ static RzEgg *rz_core_egg_setup(RzCore *core) {
 static RzCmdStatus rz_core_egg_compile_file(RzCore *core, const char *file) {
 	rz_return_val_if_fail(file, false);
 	RzEgg *egg = rz_core_egg_setup(core);
+	if (!egg) {
+		return RZ_CMD_STATUS_ERROR;
+	}
 	if (!rz_egg_load_file(egg, file)) {
 		RZ_LOG_ERROR("Cannot load file \"%s\"\n", file);
 		return RZ_CMD_STATUS_ERROR;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

```
florian-macbook:rizin florian$ rz -a 6502 =
WARNING: No calling convention defined for this file, analysis may be inaccurate.
[0x00000000]> g asdklf
ERROR: Cannot setup shellcode compiler for chosen configuration
Segmentation fault: 11
```

Hard to add a test for this since in theory 6502 and other archs might get support for this too later.