### PR TITLE
[RzIL] Remove vector-oplists in favor of seq

### DIFF
--- a/librz/analysis/op.c
+++ b/librz/analysis/op.c
@@ -54,8 +54,7 @@ RZ_API bool rz_analysis_op_fini(RzAnalysisOp *op) {
 	op->switch_op = NULL;
 	RZ_FREE(op->mnemonic);
 	if (op->rzil_op) {
-		// TODO free root_node once it is implemented
-		rz_pvector_free(op->rzil_op->ops);
+		rz_il_op_effect_free(op->rzil_op->op);
 		RZ_FREE(op->rzil_op);
 	}
 	return true;

--- a/librz/core/cil.c
+++ b/librz/core/cil.c
@@ -636,8 +636,6 @@ RZ_IPI void rz_core_analysis_rzil_vm_status(RzCore *core, const char *var_name, 
 
 // step a list of ct_opcode at a given address
 RZ_IPI void rz_core_rzil_step(RzCore *core) {
-	RzPVector *oplist;
-
 	if (!core->analysis || !core->analysis->rzil) {
 		RZ_LOG_ERROR("RzIL: Run 'aezi' first to initialize the VM\n");
 		return;
@@ -662,10 +660,10 @@ RZ_IPI void rz_core_rzil_step(RzCore *core) {
 	// analysis current data to trigger rzil_set_op_code
 	(void)rz_io_read_at_mapped(core->io, addr, code, sizeof(code));
 	int size = rz_analysis_op(analysis, &op, addr, code, sizeof(code), RZ_ANALYSIS_OP_MASK_ESIL | RZ_ANALYSIS_OP_MASK_HINT);
-	oplist = op.rzil_op ? op.rzil_op->ops : NULL;
+	RzILOpEffect *ilop = op.rzil_op ? op.rzil_op->op : NULL;
 
-	if (oplist) {
-		rz_il_vm_list_step(vm, oplist, size > 0 ? size : 1);
+	if (ilop) {
+		rz_il_vm_list_step(vm, ilop, size > 0 ? size : 1);
 	} else {
 		RZ_LOG_ERROR("RzIL: invalid instruction detected or reach the end of code at address 0x%08" PFMT64x "\n", addr);
 	}

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -1052,9 +1052,9 @@ static void core_analysis_bytes(RzCore *core, const ut8 *buf, int len, int nops,
 				pj_ks(pj, "esil", jesil);
 			}
 			if (op.rzil_op) {
-				if (op.rzil_op->ops) {
+				if (op.rzil_op->op) {
 					pj_k(pj, "rzil");
-					rz_il_oplist_json(op.rzil_op->ops, pj);
+					rz_il_op_effect_json(op.rzil_op->op, pj);
 				} else {
 					pj_knull(pj, "rzil");
 				}
@@ -1235,15 +1235,11 @@ static void core_analysis_bytes(RzCore *core, const ut8 *buf, int len, int nops,
 			} else if (RZ_STR_ISNOTEMPTY(esilstr)) {
 				printline("esil", "%s\n", esilstr);
 			}
-			if (op.rzil_op) {
-				if (op.rzil_op->ops) {
-					RzStrBuf *sbil = rz_strbuf_new("");
-					rz_il_oplist_stringify(op.rzil_op->ops, sbil);
-					printline("rzil", "%s\n", rz_strbuf_get(sbil));
-					rz_strbuf_free(sbil);
-				} else {
-					printline_noarg("rzil", "[]");
-				}
+			if (op.rzil_op && op.rzil_op->op) {
+				RzStrBuf *sbil = rz_strbuf_new("");
+				rz_il_op_effect_stringify(op.rzil_op->op, sbil);
+				printline("rzil", "%s\n", rz_strbuf_get(sbil));
+				rz_strbuf_free(sbil);
 			}
 			if (hint && hint->jump != UT64_MAX) {
 				op.jump = hint->jump;

--- a/librz/il/definitions/mem.c
+++ b/librz/il/definitions/mem.c
@@ -120,9 +120,9 @@ static RzBitVector *read_n_bits(RzBuffer *buf, ut32 n_bits, RzBitVector *key, bo
 	// we ignore bad reads. RzBuffer fills up with its "overflow byte" on failure.
 	rz_buf_read_at(buf, address, data, n_bytes);
 	if (big_endian) {
-		value = rz_bv_new_from_bytes_be(data, 0, n_bits);
+		rz_bv_set_from_bytes_be(value, data, 0, n_bits);
 	} else {
-		value = rz_bv_new_from_bytes_le(data, 0, n_bits);
+		rz_bv_set_from_bytes_le(value, data, 0, n_bits);
 	}
 	free(data);
 	return value;

--- a/librz/il/rzil_export.c
+++ b/librz/il/rzil_export.c
@@ -665,45 +665,6 @@ RZ_API void rz_il_op_effect_json(RZ_NONNULL RzILOpEffect *op, RZ_NONNULL PJ *pj)
 	il_op_effect_resolve(op, NULL, pj);
 }
 
-/**
- * Generates the string representation of the IL statements
- * \param op_list RzPVector*, array of IL statements
- * \param sb RzStrBuf*, a pointer to the string buffer
- */
-RZ_API void rz_il_oplist_stringify(RZ_NONNULL RzPVector *op_list, RZ_NONNULL RzStrBuf *sb) {
-	rz_return_if_fail(op_list && sb);
-
-	ut32 i = 0;
-	void **iter;
-	rz_strbuf_append(sb, "[");
-	rz_pvector_foreach (op_list, iter) {
-		RzILOpEffect *ilop = *iter;
-		if (i > 0) {
-			rz_strbuf_append(sb, ", ");
-		}
-		rz_il_op_effect_stringify(ilop, sb);
-		i++;
-	}
-	rz_strbuf_append(sb, "]");
-}
-
-/**
- * Generates the JSON representation of the IL statements
- * \param code RzPVector*, array of IL statements
- * \param pj PJ*, a pointer to the JSON buffer
- */
-RZ_API void rz_il_oplist_json(RZ_NONNULL RzPVector *op_list, RZ_NONNULL PJ *pj) {
-	rz_return_if_fail(op_list && pj);
-
-	pj_a(pj);
-	void **iter;
-	rz_pvector_foreach (op_list, iter) {
-		RzILOpEffect *ilop = *iter;
-		rz_il_op_effect_json(ilop, pj);
-	}
-	pj_end(pj);
-}
-
 RZ_API void rz_il_event_stringify(RZ_NONNULL RzILEvent *evt, RZ_NONNULL RzStrBuf *sb) {
 	rz_return_if_fail(evt && sb);
 	char *tmp0 = NULL, *tmp1 = NULL, *tmp2 = NULL;

--- a/librz/il/rzil_vm.c
+++ b/librz/il/rzil_vm.c
@@ -386,27 +386,6 @@ RZ_API RZ_BORROW RzILEffectLabel *rz_il_vm_update_label(RZ_NONNULL RzILVM *vm, R
 	return lbl;
 }
 
-/**
- * Make a core theory opcode vector
- * \param num int, number of total opcodes
- * \param ... op RzILOp, op will be pushed to vector one by one
- * \return oplist RzPVector*, pointer to the opcode
- */
-RZ_API RZ_OWN RzPVector *rz_il_make_oplist(ut32 num, ...) {
-	va_list args;
-	RzILOpEffect *cur_op;
-	RzPVector *oplist = rz_pvector_new((RzPVectorFree)rz_il_op_effect_free);
-
-	va_start(args, num);
-	for (ut32 i = 0; i < num; ++i) {
-		cur_op = va_arg(args, RzILOpEffect *);
-		rz_pvector_push(oplist, cur_op);
-	}
-	va_end(args);
-
-	return oplist;
-}
-
 static void *eval_pure(RZ_NONNULL RzILVM *vm, RZ_NONNULL RzILOpPure *op, RZ_NONNULL RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 	RzILOpPureHandler handler = vm->op_handler_pure_table[op->code];

--- a/librz/il/rzil_vm.c
+++ b/librz/il/rzil_vm.c
@@ -387,17 +387,6 @@ RZ_API RZ_BORROW RzILEffectLabel *rz_il_vm_update_label(RZ_NONNULL RzILVM *vm, R
 }
 
 /**
- * Store an opcode list to address
- * \param vm RzILVM, pointer to VM
- * \param addr RzBitVector, address of this opcode list
- * \param oplist RzPVector of RzILOp, core theory opcodes
- */
-RZ_API void rz_il_vm_store_opcodes_to_addr(RZ_NONNULL RzILVM *vm, RZ_NONNULL RzBitVector *addr, RZ_NONNULL RzPVector *oplist) {
-	rz_return_if_fail(vm && addr && oplist);
-	ht_pp_insert(vm->ct_opcodes, addr, oplist);
-}
-
-/**
  * Make a core theory opcode vector
  * \param num int, number of total opcodes
  * \param ... op RzILOp, op will be pushed to vector one by one

--- a/librz/il/vm_layer.c
+++ b/librz/il/vm_layer.c
@@ -400,20 +400,12 @@ RZ_API void rz_il_vm_event_add(RzILVM *vm, RzILEvent *evt) {
  * \param op_list, a list of op roots.
  * \param op_size, how much the pc value has to increate of.
  */
-RZ_API bool rz_il_vm_list_step(RzILVM *vm, RzPVector *op_list, ut32 op_size) {
-	rz_return_val_if_fail(vm && op_list, false);
+RZ_API bool rz_il_vm_list_step(RzILVM *vm, RzILOpEffect *op, ut32 op_size) {
+	rz_return_val_if_fail(vm && op, false);
 
 	rz_list_purge(vm->events);
 
-	bool succ = true;
-	void **iter;
-	rz_pvector_foreach (op_list, iter) {
-		RzILOpEffect *root = *iter;
-		if (!rz_il_evaluate_effect(vm, root)) {
-			succ = false;
-			break;
-		}
-	}
+	bool succ = rz_il_evaluate_effect(vm, op);
 
 	RzBitVector *step = rz_bv_new_from_ut64(vm->pc->len, op_size);
 	RzBitVector *next_pc = rz_bv_add(vm->pc, step, NULL);

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -807,9 +807,8 @@ typedef enum rz_analysis_data_type_t {
 	RZ_ANALYSIS_DATATYPE_FLOAT,
 } RzAnalysisDataType;
 
-// For switchting to AST-like approach in the future
 typedef struct rz_analysis_rzil_op_t {
-	RzPVector *ops;
+	RzILOpEffect *op;
 } RzAnalysisRzilOp;
 
 typedef struct rz_analysis_op_t {

--- a/librz/include/rz_il/rzil_opcodes.h
+++ b/librz/include/rz_il/rzil_opcodes.h
@@ -524,6 +524,7 @@ RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_let(RZ_NONNULL const char *var, RZ_NONN
 RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_jmp(RZ_NONNULL RzILOpBitVector *dst);
 RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_goto(RZ_NONNULL const char *label);
 RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_seq(RZ_NONNULL RzILOpEffect *x, RZ_NONNULL RzILOpEffect *y);
+RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_seqn(ut32 n, ...);
 RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_blk(RZ_NONNULL RzILOpEffect *data_effect, RZ_NONNULL RzILOpEffect *ctrl_effect);
 RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_repeat(RZ_NONNULL RzILOpBool *condition, RZ_NONNULL RzILOpEffect *data_effect);
 RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_branch(RZ_NONNULL RzILOpBool *condition, RZ_NULLABLE RzILOpEffect *true_effect, RZ_NULLABLE RzILOpEffect *false_effect);

--- a/librz/include/rz_il/rzil_vm.h
+++ b/librz/include/rz_il/rzil_vm.h
@@ -53,7 +53,6 @@ struct rz_il_vm_t {
 	HtPP *vm_local_bind_table; ///< Hashtable to record relationships between local var and val
 	HtPP *vm_global_label_table; ///< Hashtable to maintain the label and address
 	HtPP *vm_local_label_table; ///< Hashtable to maintain the label and address
-	HtPP *ct_opcodes; ///< Hashtable to maintain address and opcodes
 	RzBitVector *pc; ///< Program Counter of VM
 	RzILOpPureHandler *op_handler_pure_table; ///< Array of Handler, handler can be indexed by opcode
 	RzILOpEffectHandler *op_handler_effect_table; ///< Array of Handler, handler can be indexed by opcode
@@ -96,7 +95,6 @@ RZ_API void rz_il_vm_add_reg(RZ_NONNULL RzILVM *vm, RZ_NONNULL const char *name,
 RZ_API void rz_il_vm_add_bit_reg(RZ_NONNULL RzILVM *vm, RZ_NONNULL const char *name, bool value);
 
 // VM store and load core theory opcodes
-RZ_API void rz_il_vm_store_opcodes_to_addr(RZ_NONNULL RzILVM *vm, RZ_NONNULL RzBitVector *addr, RZ_NONNULL RzPVector *oplist);
 RZ_API RZ_OWN RzPVector *rz_il_make_oplist(ut32 num, ...);
 #define rz_il_make_nop_list() rz_il_make_oplist(0, NULL)
 

--- a/librz/include/rz_il/rzil_vm.h
+++ b/librz/include/rz_il/rzil_vm.h
@@ -94,17 +94,11 @@ RZ_API RZ_BORROW RzILVal *rz_il_vm_fortify_bool(RZ_NONNULL RzILVM *vm, bool val)
 RZ_API void rz_il_vm_add_reg(RZ_NONNULL RzILVM *vm, RZ_NONNULL const char *name, ut32 length);
 RZ_API void rz_il_vm_add_bit_reg(RZ_NONNULL RzILVM *vm, RZ_NONNULL const char *name, bool value);
 
-// VM store and load core theory opcodes
-RZ_API RZ_OWN RzPVector *rz_il_make_oplist(ut32 num, ...);
-#define rz_il_make_nop_list() rz_il_make_oplist(0, NULL)
-
 RZ_API void rz_il_op_pure_stringify(RZ_NONNULL RzILOpPure *op, RZ_NONNULL RzStrBuf *sb);
 RZ_API void rz_il_op_effect_stringify(RZ_NONNULL RzILOpEffect *op, RZ_NONNULL RzStrBuf *sb);
-RZ_API void rz_il_oplist_stringify(RZ_NONNULL RzPVector *oplist, RZ_NONNULL RzStrBuf *sb);
 
 RZ_API void rz_il_op_pure_json(RZ_NONNULL RzILOpPure *op, RZ_NONNULL PJ *pj);
 RZ_API void rz_il_op_effect_json(RZ_NONNULL RzILOpEffect *op, RZ_NONNULL PJ *pj);
-RZ_API void rz_il_oplist_json(RZ_NONNULL RzPVector *oplist, RZ_NONNULL PJ *pj);
 
 RZ_API void rz_il_event_stringify(RZ_NONNULL RzILEvent *evt, RZ_NONNULL RzStrBuf *sb);
 RZ_API void rz_il_event_json(RZ_NONNULL RzILEvent *evt, RZ_NONNULL PJ *pj);

--- a/librz/include/rz_il/vm_layer.h
+++ b/librz/include/rz_il/vm_layer.h
@@ -17,7 +17,7 @@ RZ_API bool rz_il_vm_init(RzILVM *vm, ut64 start_addr, ut32 addr_size, bool big_
 RZ_API void rz_il_vm_fini(RzILVM *vm);
 RZ_API void rz_il_vm_add_mem(RzILVM *vm, RzILMemIndex index, RZ_OWN RzILMem *mem);
 RZ_API RzILMem *rz_il_vm_get_mem(RzILVM *vm, RzILMemIndex index);
-RZ_API bool rz_il_vm_list_step(RzILVM *vm, RzPVector *op_list, ut32 op_size);
+RZ_API bool rz_il_vm_list_step(RzILVM *vm, RzILOpEffect *op, ut32 op_size);
 
 // VM Event operations
 RZ_API void rz_il_vm_event_add(RzILVM *vm, RzILEvent *evt);

--- a/test/db/rzil/bf
+++ b/test/db/rzil/bf
@@ -78,29 +78,29 @@ aoj @ 0x6a ~{.rzil}
 EOF
 EXPECT=<<EOF
 opcode: inc [ptr]
-rzil: [store(mem:0, key:var(v:ptr), value:add(x:load(mem:0, key:var(v:ptr)), y:bitv(bits:0x01, len:8)))]
-[{"opcode":"store","mem":0,"key":{"opcode":"var","value":"ptr"},"value":{"opcode":"add","x":{"opcode":"load","mem":0,"key":{"opcode":"var","value":"ptr"}},"y":{"opcode":"bitv","bits":"0x01","len":8}}}]
+rzil: store(mem:0, key:var(v:ptr), value:add(x:load(mem:0, key:var(v:ptr)), y:bitv(bits:0x01, len:8)))
+{"opcode":"store","mem":0,"key":{"opcode":"var","value":"ptr"},"value":{"opcode":"add","x":{"opcode":"load","mem":0,"key":{"opcode":"var","value":"ptr"}},"y":{"opcode":"bitv","bits":"0x01","len":8}}}
 opcode: while [ptr]
-rzil: [branch(condition:inv(x:is_zero(bv:load(mem:0, key:var(v:ptr)))), true_eff:nop(), false_eff:goto(lbl:]8))]
-[{"opcode":"branch","condition":{"opcode":"inv","x":{"opcode":"is_zero","bv":{"opcode":"load","mem":0,"key":{"opcode":"var","value":"ptr"}}}},"true_eff":{"opcode":"nop"},"false_eff":{"opcode":"goto","label":"]8"}}]
+rzil: branch(condition:inv(x:is_zero(bv:load(mem:0, key:var(v:ptr)))), true_eff:nop(), false_eff:goto(lbl:]8))
+{"opcode":"branch","condition":{"opcode":"inv","x":{"opcode":"is_zero","bv":{"opcode":"load","mem":0,"key":{"opcode":"var","value":"ptr"}}}},"true_eff":{"opcode":"nop"},"false_eff":{"opcode":"goto","label":"]8"}}
 opcode: inc ptr
-rzil: [set(v:ptr, x:add(x:var(v:ptr), y:bitv(bits:0x0000000000000001, len:64)))]
-[{"opcode":"set","dst":"ptr","src":{"opcode":"add","x":{"opcode":"var","value":"ptr"},"y":{"opcode":"bitv","bits":"0x0000000000000001","len":64}}}]
+rzil: set(v:ptr, x:add(x:var(v:ptr), y:bitv(bits:0x0000000000000001, len:64)))
+{"opcode":"set","dst":"ptr","src":{"opcode":"add","x":{"opcode":"var","value":"ptr"},"y":{"opcode":"bitv","bits":"0x0000000000000001","len":64}}}
 opcode: dec ptr
-rzil: [set(v:ptr, x:sub(x:var(v:ptr), y:bitv(bits:0x0000000000000001, len:64)))]
-[{"opcode":"set","dst":"ptr","src":{"opcode":"sub","x":{"opcode":"var","value":"ptr"},"y":{"opcode":"bitv","bits":"0x0000000000000001","len":64}}}]
+rzil: set(v:ptr, x:sub(x:var(v:ptr), y:bitv(bits:0x0000000000000001, len:64)))
+{"opcode":"set","dst":"ptr","src":{"opcode":"sub","x":{"opcode":"var","value":"ptr"},"y":{"opcode":"bitv","bits":"0x0000000000000001","len":64}}}
 opcode: dec [ptr]
-rzil: [store(mem:0, key:var(v:ptr), value:sub(x:load(mem:0, key:var(v:ptr)), y:bitv(bits:0x01, len:8)))]
-[{"opcode":"store","mem":0,"key":{"opcode":"var","value":"ptr"},"value":{"opcode":"sub","x":{"opcode":"load","mem":0,"key":{"opcode":"var","value":"ptr"}},"y":{"opcode":"bitv","bits":"0x01","len":8}}}]
+rzil: store(mem:0, key:var(v:ptr), value:sub(x:load(mem:0, key:var(v:ptr)), y:bitv(bits:0x01, len:8)))
+{"opcode":"store","mem":0,"key":{"opcode":"var","value":"ptr"},"value":{"opcode":"sub","x":{"opcode":"load","mem":0,"key":{"opcode":"var","value":"ptr"}},"y":{"opcode":"bitv","bits":"0x01","len":8}}}
 opcode: loop
-rzil: [branch(condition:inv(x:is_zero(bv:load(mem:0, key:var(v:ptr)))), true_eff:goto(lbl:[14), false_eff:nop())]
-[{"opcode":"branch","condition":{"opcode":"inv","x":{"opcode":"is_zero","bv":{"opcode":"load","mem":0,"key":{"opcode":"var","value":"ptr"}}}},"true_eff":{"opcode":"goto","label":"[14"},"false_eff":{"opcode":"nop"}}]
+rzil: branch(condition:inv(x:is_zero(bv:load(mem:0, key:var(v:ptr)))), true_eff:goto(lbl:[14), false_eff:nop())
+{"opcode":"branch","condition":{"opcode":"inv","x":{"opcode":"is_zero","bv":{"opcode":"load","mem":0,"key":{"opcode":"var","value":"ptr"}}}},"true_eff":{"opcode":"goto","label":"[14"},"false_eff":{"opcode":"nop"}}
 opcode: out [ptr]
-rzil: [goto(lbl:write)]
-[{"opcode":"goto","label":"write"}]
+rzil: goto(lbl:write)
+{"opcode":"goto","label":"write"}
 opcode: nop
-rzil: []
-null
+rzil: nop()
+{"opcode":"nop"}
 EOF
 RUN
 

--- a/test/unit/test_il_definitions.c
+++ b/test/unit/test_il_definitions.c
@@ -91,6 +91,7 @@ static bool test_rzil_mem_load() {
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
 	rz_buf_set_overflow_byte(buf, 0xaa);
 	RzILMem *mem = rz_il_mem_new(buf, 16);
+	rz_buf_free(buf); // buf is refcounted
 	mu_assert_notnull(mem, "Create mem");
 
 	// valid read
@@ -125,6 +126,7 @@ static bool test_rzil_mem_store() {
 	ut8 data[] = { 0x0, 0x0, 0x0, 0x0, 0x0, 0x42, 0x0, 0x0 };
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
 	RzILMem *mem = rz_il_mem_new(buf, 16);
+	rz_buf_free(buf); // buf is refcounted
 	mu_assert_notnull(mem, "Create mem");
 
 	RzBitVector *addr = rz_bv_new_from_ut64(16, 1);
@@ -163,6 +165,7 @@ static bool test_rzil_mem_loadw() {
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
 	rz_buf_set_overflow_byte(buf, 0xaa);
 	RzILMem *mem = rz_il_mem_new(buf, 16);
+	rz_buf_free(buf); // buf is refcounted
 	mu_assert_notnull(mem, "Create mem");
 
 	// valid read (le)
@@ -179,12 +182,14 @@ static bool test_rzil_mem_loadw() {
 	mu_assert_eq(rz_bv_len(val), 16, "loadw size");
 	mu_assert_eq(rz_bv_to_ut64(val), 0x1337, "loadw val");
 	rz_bv_free(val);
+	rz_bv_free(addr);
 
 	// invalid key size
-	rz_bv_free(addr);
 	addr = rz_bv_new_from_ut64(8, 1);
 	val = rz_il_mem_loadw(mem, addr, 16, false);
+	rz_bv_free(addr);
 	mu_assert_null(val, "invalid key size");
+	rz_bv_free(val);
 
 	// valid read (overflow)
 	addr = rz_bv_new_from_ut64(16, 100);
@@ -203,6 +208,7 @@ static bool test_rzil_mem_storew() {
 	ut8 data[] = { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
 	RzILMem *mem = rz_il_mem_new(buf, 32);
+	rz_buf_free(buf); // buf is refcounted
 	mu_assert_notnull(mem, "Create mem");
 
 	// valid write (le)


### PR DESCRIPTION
# Do not squash!

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The root type of a lifted op is now simply a single RzILOpEffect, which
can be for example a chain of seq ops. This is in line with what BAP
uses.
For convenient creation of sequences, `rz_il_op_new_seqn(ut32 n, ...)`
is a drop-in replacement for `rz_il_make_oplist(ut32 n, ...)`.

**Test plan**

see unit tests.
