### PR TITLE
Fix overlapped memcpy in sparse RzBuffer

### DIFF
--- a/librz/util/buf_sparse.c
+++ b/librz/util/buf_sparse.c
@@ -98,7 +98,7 @@ static st64 sparse_write(SparsePriv *priv, ut64 addr, const ut8 *data, ut64 len)
 	c->data = newbuf;
 	c->to = newto;
 	memcpy(c->data + (addr - c->from), data, len);
-	if (in_end_chunk) {
+	if (in_end_chunk && in_end_chunk != c) {
 		memcpy(c->data + (addr - c->from) + len,
 			in_end_chunk->data + (addr + len - in_end_chunk->from),
 			in_end_chunk->to - (addr + len) + 1);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

```
florian@florian-gentoo ~/dev/rizin $ valgrind --leak-check=full build/test/unit/test_buf
==5428== Memcheck, a memory error detector
==5428== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==5428== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==5428== Command: build/test/unit/test_buf
==5428==
Jamie Seed: 1640694369
test_rz_buf_file OK
test_rz_buf_bytes OK
test_rz_buf_mmap OK
test_rz_buf_with_buf OK
test_rz_buf_slice OK
test_rz_buf_io_fd OK
test_rz_buf_io OK
==5428== Source and destination overlap in memcpy(0x4d99e86, 0x4d99e86, 6)
==5428==    at 0x4856F7C: memcpy (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==5428==    by 0x48BD5BB: sparse_write (buf_sparse.c:102)
==5428==    by 0x48BDF43: buf_sparse_write (buf_sparse.c:260)
==5428==    by 0x48BF84B: buf_write (buf.c:69)
==5428==    by 0x48C1C3B: rz_buf_write (buf.c:1186)
==5428==    by 0x48C1D03: rz_buf_write_at (buf.c:1211)
==5428==    by 0x48C198B: rz_buf_insert_bytes (buf.c:1096)
==5428==    by 0x10B5C7: test_buf (test_buf.c:72)
==5428==    by 0x10D75B: test_rz_buf_sparse_common (test_buf.c:291)
==5428==    by 0x121F63: all_tests (test_buf.c:1319)
==5428==    by 0x122A0F: main (test_buf.c:1348)
==5428==
test_rz_buf_sparse_common OK
test_rz_buf_sparse_split OK
test_rz_buf_sparse_write_inside OK
test_rz_buf_sparse_write_start_exact OK
test_rz_buf_sparse_write_end_exact OK
test_rz_buf_sparse_write_beyond OK
test_rz_buf_sparse_write_into OK
test_rz_buf_sparse_write_bridge OK
test_rz_buf_sparse_write_bridge_exact OK
test_rz_buf_sparse_write_bridge_over_outside OK
test_rz_buf_sparse_write_bridge_over_inside OK
test_rz_buf_sparse_resize OK
test_rz_buf_sparse_fuzz OK
test_rz_buf_sparse_overlay OK
test_rz_buf_sparse_populated_in OK
test_rz_buf_sparse_size OK
test_rz_buf_sparse_overlay_size OK
test_rz_buf_bytes_steal OK
test_rz_buf_format OK
test_rz_buf_get_string OK
test_rz_buf_get_string_nothing OK
test_rz_buf_get_nstring OK
test_rz_buf_slice_too_big OK
test_rz_buf_with_methods OK
test_rz_buf_whole_buf OK
test_rz_buf_whole_buf_alloc OK
==5428==
==5428== HEAP SUMMARY:
==5428==     in use at exit: 0 bytes in 0 blocks
==5428==   total heap usage: 21,538 allocs, 21,538 frees, 12,384,479 bytes allocated
==5428==
==5428== All heap blocks were freed -- no leaks are possible
==5428==
==5428== For lists of detected and suppressed errors, rerun with: -s
==5428== ERROR SUMMARY: 9386 errors from 1 contexts (suppressed: 0 from 0)
```

**Test plan**

The sparse buffer is tested quite hard and even fuzzed, so this should be fine.