### PR TITLE
[RzIL] Flatten out all RzILOpArgs* structs

### DIFF
--- a/librz/il/rzil_export.c
+++ b/librz/il/rzil_export.c
@@ -98,13 +98,13 @@ static void il_op_effect_resolve(RzILOpEffect *op, RzStrBuf *sb, PJ *pj);
 	do { \
 		if (sb) { \
 			rz_strbuf_append(sb, name "(" #v0 ":"); \
-			il_op_pure_resolve(opx->v0, sb, pj); \
+			il_op_pure_resolve(opx.v0, sb, pj); \
 			rz_strbuf_append(sb, ")"); \
 		} else { \
 			pj_o(pj); \
 			pj_ks(pj, "opcode", name); \
 			pj_k(pj, #v0); \
-			il_op_pure_resolve(opx->v0, sb, pj); \
+			il_op_pure_resolve(opx.v0, sb, pj); \
 			pj_end(pj); \
 		} \
 	} while (0)
@@ -113,17 +113,17 @@ static void il_op_effect_resolve(RzILOpEffect *op, RzStrBuf *sb, PJ *pj);
 	do { \
 		if (sb) { \
 			rz_strbuf_append(sb, name "(" #v0 ":"); \
-			il_op_##sort0##_resolve(opx->v0, sb, pj); \
+			il_op_##sort0##_resolve(opx.v0, sb, pj); \
 			rz_strbuf_append(sb, ", " #v1 ":"); \
-			il_op_##sort1##_resolve(opx->v1, sb, pj); \
+			il_op_##sort1##_resolve(opx.v1, sb, pj); \
 			rz_strbuf_append(sb, ")"); \
 		} else { \
 			pj_o(pj); \
 			pj_ks(pj, "opcode", name); \
 			pj_k(pj, #v0); \
-			il_op_##sort0##_resolve(opx->v0, sb, pj); \
+			il_op_##sort0##_resolve(opx.v0, sb, pj); \
 			pj_k(pj, #v1); \
-			il_op_##sort1##_resolve(opx->v1, sb, pj); \
+			il_op_##sort1##_resolve(opx.v1, sb, pj); \
 			pj_end(pj); \
 		} \
 	} while (0)
@@ -132,27 +132,27 @@ static void il_op_effect_resolve(RzILOpEffect *op, RzStrBuf *sb, PJ *pj);
 	do { \
 		if (sb) { \
 			rz_strbuf_append(sb, name "(" #v0 ":"); \
-			il_op_##sort0##_resolve(opx->v0, sb, pj); \
+			il_op_##sort0##_resolve(opx.v0, sb, pj); \
 			rz_strbuf_append(sb, ", " #v1 ":"); \
-			il_op_##sort1##_resolve(opx->v1, sb, pj); \
+			il_op_##sort1##_resolve(opx.v1, sb, pj); \
 			rz_strbuf_append(sb, ", " #v2 ":"); \
-			il_op_##sort2##_resolve(opx->v2, sb, pj); \
+			il_op_##sort2##_resolve(opx.v2, sb, pj); \
 			rz_strbuf_append(sb, ")"); \
 		} else { \
 			pj_o(pj); \
 			pj_ks(pj, "opcode", name); \
 			pj_k(pj, #v0); \
-			il_op_##sort0##_resolve(opx->v0, sb, pj); \
+			il_op_##sort0##_resolve(opx.v0, sb, pj); \
 			pj_k(pj, #v1); \
-			il_op_##sort1##_resolve(opx->v1, sb, pj); \
+			il_op_##sort1##_resolve(opx.v1, sb, pj); \
 			pj_k(pj, #v2); \
-			il_op_##sort2##_resolve(opx->v2, sb, pj); \
+			il_op_##sort2##_resolve(opx.v2, sb, pj); \
 			pj_end(pj); \
 		} \
 	} while (0)
 
 static void il_opdmp_var(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
-	RzILOpArgsVar *opx = op->op.var;
+	RzILOpArgsVar *opx = &op->op.var;
 	if (sb) {
 		rz_strbuf_appendf(sb, "var(v:%s)", opx->v);
 	} else {
@@ -216,7 +216,7 @@ static void il_opdmp_bool_xor(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
 }
 
 static void il_opdmp_bitv(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
-	RzILOpArgsBv *opx = op->op.bitv;
+	RzILOpArgsBv *opx = &op->op.bitv;
 	char *num = rz_bv_as_hex_string(opx->value);
 	if (sb) {
 		rz_strbuf_appendf(sb, "bitv(bits:%s, len:%u)", num, opx->value->len);
@@ -311,7 +311,7 @@ static void il_opdmp_ule(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
 }
 
 static void il_opdmp_cast(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
-	RzILOpArgsCast *opx = op->op.cast;
+	RzILOpArgsCast *opx = &op->op.cast;
 	if (sb) {
 		rz_strbuf_append(sb, "cast(val:");
 		il_op_pure_resolve(opx->val, sb, pj);
@@ -339,7 +339,7 @@ static void il_opdmp_append(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
 }
 
 static void il_opdmp_load(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
-	RzILOpArgsLoad *opx = op->op.load;
+	RzILOpArgsLoad *opx = &op->op.load;
 	if (sb) {
 		rz_strbuf_appendf(sb, "load(mem:%u, key:", (unsigned int)opx->mem);
 		il_op_pure_resolve(opx->key, sb, pj);
@@ -355,7 +355,7 @@ static void il_opdmp_load(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
 }
 
 static void il_opdmp_store(RzILOpEffect *op, RzStrBuf *sb, PJ *pj) {
-	RzILOpArgsStore *opx = op->op.store;
+	RzILOpArgsStore *opx = &op->op.store;
 
 	if (sb) {
 		rz_strbuf_appendf(sb, "store(mem:%u, key:", (unsigned int)opx->mem);
@@ -380,7 +380,7 @@ static void il_opdmp_nop(RzILOpEffect *op, RzStrBuf *sb, PJ *pj) {
 }
 
 static void il_opdmp_set(RzILOpEffect *op, RzStrBuf *sb, PJ *pj) {
-	RzILOpArgsSet *opx = op->op.set;
+	RzILOpArgsSet *opx = &op->op.set;
 	if (sb) {
 		rz_strbuf_appendf(sb, "set(v:%s, x:", opx->v);
 		il_op_pure_resolve(opx->x, sb, pj);
@@ -396,7 +396,7 @@ static void il_opdmp_set(RzILOpEffect *op, RzStrBuf *sb, PJ *pj) {
 }
 
 static void il_opdmp_let(RzILOpEffect *op, RzStrBuf *sb, PJ *pj) {
-	RzILOpArgsLet *opx = op->op.let;
+	RzILOpArgsLet *opx = &op->op.let;
 	if (sb) {
 		rz_strbuf_appendf(sb, "let(v:%s, x:", opx->v);
 		il_op_pure_resolve(opx->x, sb, pj);
@@ -417,7 +417,7 @@ static void il_opdmp_jmp(RzILOpEffect *op, RzStrBuf *sb, PJ *pj) {
 }
 
 static void il_opdmp_goto(RzILOpEffect *op, RzStrBuf *sb, PJ *pj) {
-	RzILOpArgsGoto *opx = op->op.goto_;
+	RzILOpArgsGoto *opx = &op->op.goto_;
 	if (sb) {
 		rz_strbuf_appendf(sb, "goto(lbl:%s)", opx->lbl);
 	} else {

--- a/librz/il/rzil_opcodes.c
+++ b/librz/il/rzil_opcodes.c
@@ -18,13 +18,8 @@
 		if (!ret) { \
 			return NULL; \
 		} \
-		ret->op.s = RZ_NEW0(t); \
-		if (!ret->op.s) { \
-			free(ret); \
-			return NULL; \
-		} \
 		ret->code = id; \
-		ret->op.s->v0 = v0; \
+		ret->op.s.v0 = v0; \
 	} while (0)
 
 #define rz_il_op_new_2(sort, id, t, s, v0, v1) \
@@ -33,14 +28,9 @@
 		if (!ret) { \
 			return NULL; \
 		} \
-		ret->op.s = RZ_NEW0(t); \
-		if (!ret->op.s) { \
-			free(ret); \
-			return NULL; \
-		} \
 		ret->code = id; \
-		ret->op.s->v0 = v0; \
-		ret->op.s->v1 = v1; \
+		ret->op.s.v0 = v0; \
+		ret->op.s.v1 = v1; \
 	} while (0)
 
 #define rz_il_op_new_3(sort, id, t, s, v0, v1, v2) \
@@ -49,15 +39,10 @@
 		if (!ret) { \
 			return NULL; \
 		} \
-		ret->op.s = RZ_NEW0(t); \
-		if (!ret->op.s) { \
-			free(ret); \
-			return NULL; \
-		} \
 		ret->code = id; \
-		ret->op.s->v0 = v0; \
-		ret->op.s->v1 = v1; \
-		ret->op.s->v2 = v2; \
+		ret->op.s.v0 = v0; \
+		ret->op.s.v1 = v1; \
+		ret->op.s.v2 = v2; \
 	} while (0)
 
 /**
@@ -194,14 +179,8 @@ RZ_API RZ_OWN RzILOpBool *rz_il_op_new_bitv_from_ut64(ut32 length, ut64 number) 
 		rz_bv_free(value);
 		return NULL;
 	}
-	ret->op.bitv = RZ_NEW0(RzILOpArgsBv);
-	if (!ret->op.bitv) {
-		rz_bv_free(value);
-		free(ret);
-		return NULL;
-	}
 	ret->code = RZIL_OP_BITV;
-	ret->op.bitv->value = value;
+	ret->op.bitv.value = value;
 	return ret;
 }
 
@@ -220,14 +199,8 @@ RZ_API RZ_OWN RzILOpBool *rz_il_op_new_bitv_from_st64(ut32 length, st64 number) 
 		rz_bv_free(value);
 		return NULL;
 	}
-	ret->op.bitv = RZ_NEW0(RzILOpArgsBv);
-	if (!ret->op.bitv) {
-		rz_bv_free(value);
-		free(ret);
-		return NULL;
-	}
 	ret->code = RZIL_OP_BITV;
-	ret->op.bitv->value = value;
+	ret->op.bitv.value = value;
 	return ret;
 }
 
@@ -585,7 +558,7 @@ RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_seqn(ut32 n, ...) {
 		if (i == n - 1) {
 			// last one
 			if (prev_seq) {
-				prev_seq->op.seq->y = cur_op;
+				prev_seq->op.seq.y = cur_op;
 			} else {
 				// n == 1, no need for seq at all
 				root = cur_op;
@@ -596,18 +569,13 @@ RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_seqn(ut32 n, ...) {
 		if (!seq) {
 			break;
 		}
-		seq->op.seq = RZ_NEW0(RzILOpArgsSeq);
-		if (!seq->op.seq) {
-			free(seq);
-			break;
-		}
 		seq->code = RZIL_OP_SEQ;
-		seq->op.seq->x = cur_op;
+		seq->op.seq.x = cur_op;
 		if (prev_seq) {
 			// not the first one
 			// We let the seq recurse in the second op because that
 			// can enable tail call elimination in the evaluation.
-			prev_seq->op.seq->y = seq;
+			prev_seq->op.seq.y = seq;
 		} else {
 			// first one
 			root = seq;
@@ -705,22 +673,17 @@ RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_storew(RzILMemIndex mem, RZ_NONNULL RzI
 #undef rz_il_op_new_2
 #undef rz_il_op_new_3
 
-#define rz_il_op_free_0(s) free(op->op.s)
-
 #define rz_il_op_free_1(sort, s, v0) \
-	rz_il_op_##sort##_free(op->op.s->v0); \
-	free(op->op.s)
+	rz_il_op_##sort##_free(op->op.s.v0);
 
 #define rz_il_op_free_2(sort, s, v0, v1) \
-	rz_il_op_##sort##_free(op->op.s->v0); \
-	rz_il_op_##sort##_free(op->op.s->v1); \
-	free(op->op.s)
+	rz_il_op_##sort##_free(op->op.s.v0); \
+	rz_il_op_##sort##_free(op->op.s.v1);
 
 #define rz_il_op_free_3(sort, s, v0, v1, v2) \
-	rz_il_op_##sort##_free(op->op.s->v0); \
-	rz_il_op_##sort##_free(op->op.s->v1); \
-	rz_il_op_##sort##_free(op->op.s->v2); \
-	free(op->op.s)
+	rz_il_op_##sort##_free(op->op.s.v0); \
+	rz_il_op_##sort##_free(op->op.s.v1); \
+	rz_il_op_##sort##_free(op->op.s.v2);
 
 RZ_API void rz_il_op_pure_free(RZ_NULLABLE RzILOpPure *op) {
 	if (!op) {
@@ -728,17 +691,14 @@ RZ_API void rz_il_op_pure_free(RZ_NULLABLE RzILOpPure *op) {
 	}
 	switch (op->code) {
 	case RZIL_OP_VAR:
-		rz_il_op_free_0(var);
 		break;
 	case RZIL_OP_UNK:
-		// nothing to free
 		break;
 	case RZIL_OP_ITE:
 		rz_il_op_free_3(pure, ite, condition, x, y);
 		break;
 	case RZIL_OP_B0:
 	case RZIL_OP_B1:
-		// nothing to free
 		break;
 	case RZIL_OP_INV:
 		rz_il_op_free_1(pure, boolinv, x);
@@ -750,8 +710,7 @@ RZ_API void rz_il_op_pure_free(RZ_NULLABLE RzILOpPure *op) {
 		rz_il_op_free_2(pure, boolxor, x, y);
 		break;
 	case RZIL_OP_BITV:
-		rz_bv_free(op->op.bitv->value);
-		rz_il_op_free_0(bitv);
+		rz_bv_free(op->op.bitv.value);
 		break;
 	case RZIL_OP_MSB:
 		rz_il_op_free_1(pure, msb, bv);
@@ -848,7 +807,6 @@ RZ_API void rz_il_op_effect_free(RZ_NULLABLE RzILOpEffect *op) {
 		rz_il_op_free_2(pure, storew, key, value);
 		break;
 	case RZIL_OP_NOP:
-		// nothing to free
 		break;
 	case RZIL_OP_SET:
 		rz_il_op_free_1(pure, set, x);
@@ -860,7 +818,6 @@ RZ_API void rz_il_op_effect_free(RZ_NULLABLE RzILOpEffect *op) {
 		rz_il_op_free_1(pure, jmp, dst);
 		break;
 	case RZIL_OP_GOTO:
-		rz_il_op_free_0(goto_);
 		break;
 	case RZIL_OP_SEQ:
 		rz_il_op_free_2(effect, seq, x, y);
@@ -869,11 +826,11 @@ RZ_API void rz_il_op_effect_free(RZ_NULLABLE RzILOpEffect *op) {
 		rz_il_op_free_2(effect, blk, data_eff, ctrl_eff);
 		break;
 	case RZIL_OP_REPEAT:
-		rz_il_op_pure_free(op->op.repeat->condition);
+		rz_il_op_pure_free(op->op.repeat.condition);
 		rz_il_op_free_1(effect, repeat, data_eff);
 		break;
 	case RZIL_OP_BRANCH:
-		rz_il_op_pure_free(op->op.repeat->condition);
+		rz_il_op_pure_free(op->op.repeat.condition);
 		rz_il_op_free_2(effect, branch, true_eff, false_eff);
 		break;
 	default:

--- a/librz/il/theory_bitv.c
+++ b/librz/il/theory_bitv.c
@@ -8,7 +8,7 @@
 void *rz_il_handler_msb(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsMsb *op_msb = op->op.msb;
+	RzILOpArgsMsb *op_msb = &op->op.msb;
 	RzBitVector *bv = rz_il_evaluate_bitv(vm, op_msb->bv);
 	RzILBool *result = bv ? rz_il_bool_new(rz_bv_msb(bv)) : NULL;
 	rz_bv_free(bv);
@@ -20,7 +20,7 @@ void *rz_il_handler_msb(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 void *rz_il_handler_lsb(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsLsb *op_lsb = op->op.lsb;
+	RzILOpArgsLsb *op_lsb = &op->op.lsb;
 	RzBitVector *bv = rz_il_evaluate_bitv(vm, op_lsb->bv);
 	RzILBool *result = bv ? rz_il_bool_new(rz_bv_lsb(bv)) : NULL;
 	rz_bv_free(bv);
@@ -32,7 +32,7 @@ void *rz_il_handler_lsb(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 void *rz_il_handler_is_zero(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsLsb *op_lsb = op->op.lsb;
+	RzILOpArgsLsb *op_lsb = &op->op.lsb;
 	RzBitVector *bv = rz_il_evaluate_bitv(vm, op_lsb->bv);
 	RzILBool *result = bv ? rz_il_bool_new(rz_bv_is_zero_vector(bv)) : NULL;
 	rz_bv_free(bv);
@@ -44,7 +44,7 @@ void *rz_il_handler_is_zero(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type)
 void *rz_il_handler_neg(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsNeg *neg = op->op.neg;
+	RzILOpArgsNeg *neg = &op->op.neg;
 
 	RzBitVector *bv_arg = rz_il_evaluate_bitv(vm, neg->bv);
 	RzBitVector *bv_result = bv_arg ? rz_bv_neg(bv_arg) : NULL;
@@ -57,7 +57,7 @@ void *rz_il_handler_neg(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 void *rz_il_handler_logical_not(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsLogNot *op_not = op->op.lognot;
+	RzILOpArgsLogNot *op_not = &op->op.lognot;
 
 	RzBitVector *bv = rz_il_evaluate_bitv(vm, op_not->bv);
 	RzBitVector *result = bv ? rz_bv_not(bv) : NULL;
@@ -70,7 +70,7 @@ void *rz_il_handler_logical_not(RzILVM *vm, RzILOpBitVector *op, RzILPureType *t
 void *rz_il_handler_eq(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsSle *op_sle = op->op.sle;
+	RzILOpArgsSle *op_sle = &op->op.sle;
 
 	RzBitVector *x = rz_il_evaluate_bitv(vm, op_sle->x);
 	RzBitVector *y = rz_il_evaluate_bitv(vm, op_sle->y);
@@ -85,7 +85,7 @@ void *rz_il_handler_eq(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 void *rz_il_handler_sle(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsSle *op_sle = op->op.sle;
+	RzILOpArgsSle *op_sle = &op->op.sle;
 
 	RzBitVector *x = rz_il_evaluate_bitv(vm, op_sle->x);
 	RzBitVector *y = rz_il_evaluate_bitv(vm, op_sle->y);
@@ -100,7 +100,7 @@ void *rz_il_handler_sle(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 void *rz_il_handler_ule(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsUle *op_ule = op->op.ule;
+	RzILOpArgsUle *op_ule = &op->op.ule;
 
 	RzBitVector *x = rz_il_evaluate_bitv(vm, op_ule->x);
 	RzBitVector *y = rz_il_evaluate_bitv(vm, op_ule->y);
@@ -115,7 +115,7 @@ void *rz_il_handler_ule(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 void *rz_il_handler_add(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsAdd *op_add = op->op.add;
+	RzILOpArgsAdd *op_add = &op->op.add;
 
 	RzBitVector *x = rz_il_evaluate_bitv(vm, op_add->x);
 	RzBitVector *y = rz_il_evaluate_bitv(vm, op_add->y);
@@ -131,7 +131,7 @@ void *rz_il_handler_add(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 void *rz_il_handler_append(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsAppend *op_append = op->op.append;
+	RzILOpArgsAppend *op_append = &op->op.append;
 
 	RzBitVector *x = rz_il_evaluate_bitv(vm, op_append->x);
 	RzBitVector *y = rz_il_evaluate_bitv(vm, op_append->y);
@@ -146,7 +146,7 @@ void *rz_il_handler_append(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) 
 void *rz_il_handler_logical_and(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsAdd *op_add = op->op.add;
+	RzILOpArgsAdd *op_add = &op->op.add;
 
 	RzBitVector *x = rz_il_evaluate_bitv(vm, op_add->x);
 	RzBitVector *y = rz_il_evaluate_bitv(vm, op_add->y);
@@ -161,7 +161,7 @@ void *rz_il_handler_logical_and(RzILVM *vm, RzILOpBitVector *op, RzILPureType *t
 void *rz_il_handler_logical_or(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsAdd *op_add = op->op.add;
+	RzILOpArgsAdd *op_add = &op->op.add;
 
 	RzBitVector *x = rz_il_evaluate_bitv(vm, op_add->x);
 	RzBitVector *y = rz_il_evaluate_bitv(vm, op_add->y);
@@ -176,7 +176,7 @@ void *rz_il_handler_logical_or(RzILVM *vm, RzILOpBitVector *op, RzILPureType *ty
 void *rz_il_handler_logical_xor(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsAdd *op_add = op->op.add;
+	RzILOpArgsAdd *op_add = &op->op.add;
 
 	RzBitVector *x = rz_il_evaluate_bitv(vm, op_add->x);
 	RzBitVector *y = rz_il_evaluate_bitv(vm, op_add->y);
@@ -191,7 +191,7 @@ void *rz_il_handler_logical_xor(RzILVM *vm, RzILOpBitVector *op, RzILPureType *t
 void *rz_il_handler_sub(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsSub *op_sub = op->op.sub;
+	RzILOpArgsSub *op_sub = &op->op.sub;
 
 	RzBitVector *x = rz_il_evaluate_bitv(vm, op_sub->x);
 	RzBitVector *y = rz_il_evaluate_bitv(vm, op_sub->y);
@@ -206,7 +206,7 @@ void *rz_il_handler_sub(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 void *rz_il_handler_mul(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsMul *op_mul = op->op.mul;
+	RzILOpArgsMul *op_mul = &op->op.mul;
 
 	RzBitVector *x = rz_il_evaluate_bitv(vm, op_mul->x);
 	RzBitVector *y = rz_il_evaluate_bitv(vm, op_mul->y);
@@ -222,7 +222,7 @@ void *rz_il_handler_mul(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 void *rz_il_handler_div(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsDiv *op_div = op->op.div;
+	RzILOpArgsDiv *op_div = &op->op.div;
 
 	RzBitVector *x = rz_il_evaluate_bitv(vm, op_div->x);
 	RzBitVector *y = rz_il_evaluate_bitv(vm, op_div->y);
@@ -247,7 +247,7 @@ void *rz_il_handler_div(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 void *rz_il_handler_sdiv(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsSdiv *op_sdiv = op->op.sdiv;
+	RzILOpArgsSdiv *op_sdiv = &op->op.sdiv;
 
 	RzBitVector *x = rz_il_evaluate_bitv(vm, op_sdiv->x);
 	RzBitVector *y = rz_il_evaluate_bitv(vm, op_sdiv->y);
@@ -262,7 +262,7 @@ void *rz_il_handler_sdiv(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 void *rz_il_handler_mod(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsMod *op_mod = op->op.mod;
+	RzILOpArgsMod *op_mod = &op->op.mod;
 
 	RzBitVector *x = rz_il_evaluate_bitv(vm, op_mod->x);
 	RzBitVector *y = rz_il_evaluate_bitv(vm, op_mod->y);
@@ -277,7 +277,7 @@ void *rz_il_handler_mod(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 void *rz_il_handler_smod(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsSmod *op_smod = op->op.smod;
+	RzILOpArgsSmod *op_smod = &op->op.smod;
 
 	RzBitVector *x = rz_il_evaluate_bitv(vm, op_smod->x);
 	RzBitVector *y = rz_il_evaluate_bitv(vm, op_smod->y);
@@ -292,7 +292,7 @@ void *rz_il_handler_smod(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 void *rz_il_handler_shiftl(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsShiftLeft *op_shiftl = op->op.shiftl;
+	RzILOpArgsShiftLeft *op_shiftl = &op->op.shiftl;
 
 	RzBitVector *bv = rz_il_evaluate_bitv(vm, op_shiftl->x);
 	RzBitVector *shift = rz_il_evaluate_bitv(vm, op_shiftl->y);
@@ -314,7 +314,7 @@ void *rz_il_handler_shiftl(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) 
 void *rz_il_handler_shiftr(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsShiftRight *op_shr = op->op.shiftr;
+	RzILOpArgsShiftRight *op_shr = &op->op.shiftr;
 
 	RzBitVector *bv = rz_il_evaluate_bitv(vm, op_shr->x);
 	RzBitVector *shift = rz_il_evaluate_bitv(vm, op_shr->y);
@@ -336,7 +336,7 @@ void *rz_il_handler_shiftr(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) 
 
 void *rz_il_handler_bitv(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
-	RzILOpArgsBv *op_bitv = op->op.bitv;
+	RzILOpArgsBv *op_bitv = &op->op.bitv;
 
 	RzBitVector *bv = rz_bv_dup(op_bitv->value);
 
@@ -347,7 +347,7 @@ void *rz_il_handler_bitv(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 void *rz_il_handler_cast(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsCast *op_cast = op->op.cast;
+	RzILOpArgsCast *op_cast = &op->op.cast;
 	RzILBool *fill = rz_il_evaluate_bool(vm, op_cast->fill);
 	if (!fill) {
 		return NULL;

--- a/librz/il/theory_bool.c
+++ b/librz/il/theory_bool.c
@@ -29,7 +29,7 @@ void *rz_il_handler_bool_true(RzILVM *vm, RzILOpBool *op, RzILPureType *type) {
 void *rz_il_handler_bool_and(RzILVM *vm, RzILOpBool *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsBoolAnd *op_and = op->op.booland;
+	RzILOpArgsBoolAnd *op_and = &op->op.booland;
 	RzILBool *x = rz_il_evaluate_bool(vm, op_and->x);
 	RzILBool *y = rz_il_evaluate_bool(vm, op_and->y);
 
@@ -44,7 +44,7 @@ void *rz_il_handler_bool_and(RzILVM *vm, RzILOpBool *op, RzILPureType *type) {
 void *rz_il_handler_bool_or(RzILVM *vm, RzILOpBool *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsBoolOr *op_or = op->op.boolor;
+	RzILOpArgsBoolOr *op_or = &op->op.boolor;
 	RzILBool *x = rz_il_evaluate_bool(vm, op_or->x);
 	RzILBool *y = rz_il_evaluate_bool(vm, op_or->y);
 
@@ -59,7 +59,7 @@ void *rz_il_handler_bool_or(RzILVM *vm, RzILOpBool *op, RzILPureType *type) {
 void *rz_il_handler_bool_xor(RzILVM *vm, RzILOpBool *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsBoolXor *op_xor = op->op.boolxor;
+	RzILOpArgsBoolXor *op_xor = &op->op.boolxor;
 	RzILBool *x = rz_il_evaluate_bool(vm, op_xor->x);
 	RzILBool *y = rz_il_evaluate_bool(vm, op_xor->y);
 
@@ -77,7 +77,7 @@ void *rz_il_handler_bool_xor(RzILVM *vm, RzILOpBool *op, RzILPureType *type) {
 void *rz_il_handler_bool_inv(RzILVM *vm, RzILOpBool *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsBoolInv *op_inv = op->op.boolinv;
+	RzILOpArgsBoolInv *op_inv = &op->op.boolinv;
 	RzILBool *x = rz_il_evaluate_bool(vm, op_inv->x);
 	RzILBool *result = x ? rz_il_bool_not(x) : NULL;
 	rz_il_bool_free(x);

--- a/librz/il/theory_effect.c
+++ b/librz/il/theory_effect.c
@@ -105,7 +105,7 @@ bool rz_il_handler_nop(RzILVM *vm, RzILOpEffect *op) {
 
 bool rz_il_handler_set(RzILVM *vm, RzILOpEffect *op) {
 	rz_return_val_if_fail(vm && op, false);
-	RzILOpArgsSet *set_op = op->op.set;
+	RzILOpArgsSet *set_op = &op->op.set;
 	RzILVal *val = rz_il_evaluate_val(vm, set_op->x);
 	if (!val) {
 		return false;
@@ -116,7 +116,7 @@ bool rz_il_handler_set(RzILVM *vm, RzILOpEffect *op) {
 
 bool rz_il_handler_let(RzILVM *vm, RzILOpEffect *op) {
 	rz_return_val_if_fail(vm && op, false);
-	RzILOpArgsLet *let_op = op->op.let;
+	RzILOpArgsLet *let_op = &op->op.let;
 	RzILVal *val = rz_il_evaluate_val(vm, let_op->x);
 	if (!val) {
 		return false;
@@ -133,7 +133,7 @@ static void perform_jump(RzILVM *vm, RZ_OWN RzBitVector *dst) {
 
 bool rz_il_handler_jmp(RzILVM *vm, RzILOpEffect *op) {
 	rz_return_val_if_fail(vm && op, false);
-	RzBitVector *dst = rz_il_evaluate_bitv(vm, op->op.jmp->dst);
+	RzBitVector *dst = rz_il_evaluate_bitv(vm, op->op.jmp.dst);
 	if (!dst) {
 		return false;
 	}
@@ -143,7 +143,7 @@ bool rz_il_handler_jmp(RzILVM *vm, RzILOpEffect *op) {
 
 bool rz_il_handler_goto(RzILVM *vm, RzILOpEffect *op) {
 	rz_return_val_if_fail(vm && op, false);
-	RzILOpArgsGoto *op_goto = op->op.goto_;
+	RzILOpArgsGoto *op_goto = &op->op.goto_;
 	const char *lname = op_goto->lbl;
 	RzILEffectLabel *label = rz_il_vm_find_label_by_name(vm, lname);
 	if (!label) {
@@ -160,14 +160,14 @@ bool rz_il_handler_goto(RzILVM *vm, RzILOpEffect *op) {
 
 bool rz_il_handler_seq(RzILVM *vm, RzILOpEffect *op) {
 	rz_return_val_if_fail(vm && op, false);
-	RzILOpArgsSeq *op_seq = op->op.seq;
+	RzILOpArgsSeq *op_seq = &op->op.seq;
 	return rz_il_evaluate_effect(vm, op_seq->x) && rz_il_evaluate_effect(vm, op_seq->y);
 }
 
 bool rz_il_handler_branch(RzILVM *vm, RzILOpEffect *op) {
 	rz_return_val_if_fail(vm && op, false);
 
-	RzILOpArgsBranch *op_branch = op->op.branch;
+	RzILOpArgsBranch *op_branch = &op->op.branch;
 
 	RzILBool *condition = rz_il_evaluate_bool(vm, op_branch->condition);
 	if (!condition) {

--- a/librz/il/theory_init.c
+++ b/librz/il/theory_init.c
@@ -24,7 +24,7 @@ static RzILEvent *il_event_new_read_from_name(RzILVM *vm, const char *name, RzIL
 void *rz_il_handler_ite(RzILVM *vm, RzILOpPure *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 
-	RzILOpArgsIte *op_ite = op->op.ite;
+	RzILOpArgsIte *op_ite = &op->op.ite;
 
 	RzILBool *condition = rz_il_evaluate_bool(vm, op_ite->condition);
 	if (!condition) {
@@ -44,7 +44,7 @@ void *rz_il_handler_var(RzILVM *vm, RzILOpPure *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 	bool is_local = false;
 
-	RzILOpArgsVar *var_op = op->op.var;
+	RzILOpArgsVar *var_op = &op->op.var;
 	RzILVal *val = rz_il_hash_find_val_by_name(vm, var_op->v);
 	if (!val) {
 		val = rz_il_hash_find_local_val_by_name(vm, var_op->v);

--- a/librz/il/theory_mem.c
+++ b/librz/il/theory_mem.c
@@ -8,7 +8,7 @@
 
 void *rz_il_handler_load(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
-	RzILOpArgsLoad *op_load = op->op.load;
+	RzILOpArgsLoad *op_load = &op->op.load;
 
 	RzBitVector *addr = rz_il_evaluate_bitv(vm, op_load->key);
 	if (!addr) {
@@ -23,7 +23,7 @@ void *rz_il_handler_load(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 bool rz_il_handler_store(RzILVM *vm, RzILOpEffect *op) {
 	rz_return_val_if_fail(vm && op, NULL);
 
-	RzILOpArgsStore *op_store = op->op.store;
+	RzILOpArgsStore *op_store = &op->op.store;
 
 	RzBitVector *addr = rz_il_evaluate_bitv(vm, op_store->key);
 	RzBitVector *value = rz_il_evaluate_bitv(vm, op_store->value);
@@ -41,7 +41,7 @@ bool rz_il_handler_store(RzILVM *vm, RzILOpEffect *op) {
 
 void *rz_il_handler_loadw(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
-	RzILOpArgsLoadW *op_loadw = op->op.loadw;
+	RzILOpArgsLoadW *op_loadw = &op->op.loadw;
 
 	RzBitVector *addr = rz_il_evaluate_bitv(vm, op_loadw->key);
 	if (!addr) {
@@ -56,7 +56,7 @@ void *rz_il_handler_loadw(RzILVM *vm, RzILOpBitVector *op, RzILPureType *type) {
 bool rz_il_handler_storew(RzILVM *vm, RzILOpEffect *op) {
 	rz_return_val_if_fail(vm && op, NULL);
 
-	RzILOpArgsStoreW *op_storew = op->op.storew;
+	RzILOpArgsStoreW *op_storew = &op->op.storew;
 
 	RzBitVector *addr = rz_il_evaluate_bitv(vm, op_storew->key);
 	RzBitVector *value = rz_il_evaluate_bitv(vm, op_storew->value);

--- a/librz/include/rz_il/rzil_opcodes.h
+++ b/librz/include/rz_il/rzil_opcodes.h
@@ -401,40 +401,40 @@ typedef enum {
 struct rz_il_op_pure_t {
 	RzILOpPureCode code;
 	union {
-		RzILOpArgsIte *ite;
-		RzILOpArgsVar *var;
+		RzILOpArgsIte ite;
+		RzILOpArgsVar var;
 
-		RzILOpArgsBoolAnd *booland;
-		RzILOpArgsBoolOr *boolor;
-		RzILOpArgsBoolXor *boolxor;
-		RzILOpArgsBoolInv *boolinv;
+		RzILOpArgsBoolAnd booland;
+		RzILOpArgsBoolOr boolor;
+		RzILOpArgsBoolXor boolxor;
+		RzILOpArgsBoolInv boolinv;
 
-		RzILOpArgsBv *bitv;
-		RzILOpArgsMsb *msb;
-		RzILOpArgsLsb *lsb;
-		RzILOpArgsIsZero *is_zero;
-		RzILOpArgsEq *eq;
-		RzILOpArgsUle *ule;
-		RzILOpArgsSle *sle;
-		RzILOpArgsCast *cast;
-		RzILOpArgsNeg *neg;
-		RzILOpArgsLogNot *lognot;
-		RzILOpArgsAdd *add;
-		RzILOpArgsSub *sub;
-		RzILOpArgsMul *mul;
-		RzILOpArgsDiv *div;
-		RzILOpArgsSdiv *sdiv;
-		RzILOpArgsSmod *smod;
-		RzILOpArgsMod *mod;
-		RzILOpArgsLogand *logand;
-		RzILOpArgsLogor *logor;
-		RzILOpArgsLogxor *logxor;
-		RzILOpArgsShiftLeft *shiftl;
-		RzILOpArgsShiftRight *shiftr;
-		RzILOpArgsAppend *append;
+		RzILOpArgsBv bitv;
+		RzILOpArgsMsb msb;
+		RzILOpArgsLsb lsb;
+		RzILOpArgsIsZero is_zero;
+		RzILOpArgsEq eq;
+		RzILOpArgsUle ule;
+		RzILOpArgsSle sle;
+		RzILOpArgsCast cast;
+		RzILOpArgsNeg neg;
+		RzILOpArgsLogNot lognot;
+		RzILOpArgsAdd add;
+		RzILOpArgsSub sub;
+		RzILOpArgsMul mul;
+		RzILOpArgsDiv div;
+		RzILOpArgsSdiv sdiv;
+		RzILOpArgsSmod smod;
+		RzILOpArgsMod mod;
+		RzILOpArgsLogand logand;
+		RzILOpArgsLogor logor;
+		RzILOpArgsLogxor logxor;
+		RzILOpArgsShiftLeft shiftl;
+		RzILOpArgsShiftRight shiftr;
+		RzILOpArgsAppend append;
 
-		RzILOpArgsLoad *load;
-		RzILOpArgsLoadW *loadw;
+		RzILOpArgsLoad load;
+		RzILOpArgsLoadW loadw;
 	} op;
 };
 
@@ -502,17 +502,17 @@ typedef enum {
 struct rz_il_op_effect_t {
 	RzILOpEffectCode code;
 	union {
-		RzILOpArgsSet *set;
-		RzILOpArgsLet *let;
-		RzILOpArgsJmp *jmp;
-		RzILOpArgsGoto *goto_;
-		RzILOpArgsSeq *seq;
-		RzILOpArgsBlk *blk;
-		RzILOpArgsRepeat *repeat;
-		RzILOpArgsBranch *branch;
+		RzILOpArgsSet set;
+		RzILOpArgsLet let;
+		RzILOpArgsJmp jmp;
+		RzILOpArgsGoto goto_;
+		RzILOpArgsSeq seq;
+		RzILOpArgsBlk blk;
+		RzILOpArgsRepeat repeat;
+		RzILOpArgsBranch branch;
 
-		RzILOpArgsStore *store;
-		RzILOpArgsStoreW *storew;
+		RzILOpArgsStore store;
+		RzILOpArgsStoreW storew;
 	} op;
 };
 

--- a/test/unit/test_il_definitions.c
+++ b/test/unit/test_il_definitions.c
@@ -261,8 +261,8 @@ static bool test_rzil_seqn() {
 	s = rz_il_op_new_seqn(2, e0, e1);
 	mu_assert_notnull(s, "seqn 2");
 	mu_assert_eq(s->code, RZIL_OP_SEQ, "seqn 2 seq");
-	mu_assert_ptreq(s->op.seq->x, e0, "seqn 2 first");
-	mu_assert_ptreq(s->op.seq->y, e1, "seqn 2 second");
+	mu_assert_ptreq(s->op.seq.x, e0, "seqn 2 first");
+	mu_assert_ptreq(s->op.seq.y, e1, "seqn 2 second");
 	rz_il_op_effect_free(s);
 
 	// n = 3 ==> nested seq with recursion in the second op:
@@ -273,10 +273,10 @@ static bool test_rzil_seqn() {
 	s = rz_il_op_new_seqn(3, e0, e1, e2);
 	mu_assert_notnull(s, "seqn 3");
 	mu_assert_eq(s->code, RZIL_OP_SEQ, "seqn 3 seq");
-	mu_assert_ptreq(s->op.seq->x, e0, "seqn 3 first");
-	mu_assert_eq(s->op.seq->y->code, RZIL_OP_SEQ, "seqn 3 second seq");
-	mu_assert_ptreq(s->op.seq->y->op.seq->x, e1, "seqn 3 second");
-	mu_assert_ptreq(s->op.seq->y->op.seq->y, e2, "seqn 3 third");
+	mu_assert_ptreq(s->op.seq.x, e0, "seqn 3 first");
+	mu_assert_eq(s->op.seq.y->code, RZIL_OP_SEQ, "seqn 3 second seq");
+	mu_assert_ptreq(s->op.seq.y->op.seq.x, e1, "seqn 3 second");
+	mu_assert_ptreq(s->op.seq.y->op.seq.y, e2, "seqn 3 third");
 	rz_il_op_effect_free(s);
 
 	// n = 4 ==> nested seq with recursion in the second op and no confusion:
@@ -288,12 +288,12 @@ static bool test_rzil_seqn() {
 	s = rz_il_op_new_seqn(4, e0, e1, e2, e3);
 	mu_assert_notnull(s, "seqn 4");
 	mu_assert_eq(s->code, RZIL_OP_SEQ, "seqn 4 seq");
-	mu_assert_ptreq(s->op.seq->x, e0, "seqn 4 first");
-	mu_assert_eq(s->op.seq->y->code, RZIL_OP_SEQ, "seqn 4 second seq");
-	mu_assert_ptreq(s->op.seq->y->op.seq->x, e1, "seqn 4 second");
-	mu_assert_eq(s->op.seq->y->op.seq->y->code, RZIL_OP_SEQ, "seqn 4 third seq");
-	mu_assert_ptreq(s->op.seq->y->op.seq->y->op.seq->x, e2, "seqn 4 third");
-	mu_assert_ptreq(s->op.seq->y->op.seq->y->op.seq->y, e3, "seqn 4 fourth");
+	mu_assert_ptreq(s->op.seq.x, e0, "seqn 4 first");
+	mu_assert_eq(s->op.seq.y->code, RZIL_OP_SEQ, "seqn 4 second seq");
+	mu_assert_ptreq(s->op.seq.y->op.seq.x, e1, "seqn 4 second");
+	mu_assert_eq(s->op.seq.y->op.seq.y->code, RZIL_OP_SEQ, "seqn 4 third seq");
+	mu_assert_ptreq(s->op.seq.y->op.seq.y->op.seq.x, e2, "seqn 4 third");
+	mu_assert_ptreq(s->op.seq.y->op.seq.y->op.seq.y, e3, "seqn 4 fourth");
 	rz_il_op_effect_free(s);
 
 	mu_end;

--- a/test/unit/test_il_vm.c
+++ b/test/unit/test_il_vm.c
@@ -152,7 +152,7 @@ static bool test_rzil_vm_root_evaluation() {
 	RzILOpBitVector *ite_root = rz_il_op_new_ite(condition, true_val, false_val);
 
 	// Partially evaluate `condition` only
-	RzILBool *condition_res = rz_il_evaluate_bool(vm, ite_root->op.ite->condition);
+	RzILBool *condition_res = rz_il_evaluate_bool(vm, ite_root->op.ite.condition);
 	mu_assert_notnull(condition_res, "boolean eval success");
 	mu_assert_eq(condition_res->b, true, "Evaluate boolean condition");
 	rz_il_bool_free(condition_res);


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This reduces heap usage and indirection.
