### PR TITLE
[RzIL] Make cast work as in BAP

### DIFF
--- a/librz/il/rzil_export.c
+++ b/librz/il/rzil_export.c
@@ -315,14 +315,17 @@ static void il_opdmp_cast(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
 	if (sb) {
 		rz_strbuf_append(sb, "cast(val:");
 		il_op_pure_resolve(opx->val, sb, pj);
-		rz_strbuf_appendf(sb, ", length:%u, shift:%d)", opx->length, opx->shift);
+		rz_strbuf_appendf(sb, ", length:%u, fill:", opx->length);
+		il_op_pure_resolve(opx->fill, sb, pj);
+		rz_strbuf_append(sb, ")");
 	} else {
 		pj_o(pj);
 		pj_ks(pj, "opcode", "cast");
 		pj_k(pj, "value");
 		il_op_pure_resolve(opx->val, sb, pj);
 		pj_kn(pj, "length", opx->length);
-		pj_kN(pj, "shift", opx->shift);
+		pj_k(pj, "fill");
+		il_op_pure_resolve(opx->fill, sb, pj);
 		pj_end(pj);
 	}
 }

--- a/librz/il/rzil_opcodes.c
+++ b/librz/il/rzil_opcodes.c
@@ -308,10 +308,10 @@ RZ_API RZ_OWN RzILOpBool *rz_il_op_new_sle(RZ_NONNULL RzILOpBitVector *x, RZ_NON
 /**
  *  \brief op structure for casting bitv
  */
-RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_cast(ut32 length, int shift, RZ_NONNULL RzILOpBitVector *val) {
+RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_cast(ut32 length, RZ_NONNULL RzILOpBool *fill, RZ_NONNULL RzILOpBitVector *val) {
 	rz_return_val_if_fail(length > 0 && val, NULL);
 	RzILOpBitVector *ret;
-	rz_il_op_new_3(BitVector, RZIL_OP_CAST, RzILOpArgsCast, cast, length, shift, val);
+	rz_il_op_new_3(BitVector, RZIL_OP_CAST, RzILOpArgsCast, cast, length, fill, val);
 	return ret;
 }
 

--- a/librz/include/rz_il/rzil_opcodes.h
+++ b/librz/include/rz_il/rzil_opcodes.h
@@ -134,8 +134,8 @@ typedef struct rz_il_op_args_cmp_t RzILOpArgsUle;
  *  \brief op structure for casting bitv
  */
 typedef struct rz_il_op_args_cast_t {
-	ut32 length; ///< new bits lenght
-	int shift; ///< shift old bits (positive is << and >> negative)
+	ut32 length; ///< new bits length
+	RzILOpBool *fill; ///< If m = size val - length > 0 then m fill-bits are prepended to the most significant part of the vector.
 	RzILOpBitVector *val; ///< value to cast
 } RzILOpArgsCast;
 
@@ -459,7 +459,7 @@ RZ_API RZ_OWN RzILOpBool *rz_il_op_new_non_zero(RZ_NONNULL RzILOpPure *bv);
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_eq(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_ule(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_sle(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
-RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_cast(ut32 length, int shift, RZ_NONNULL RzILOpBitVector *val);
+RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_cast(ut32 length, RZ_NONNULL RzILOpBool *fill, RZ_NONNULL RzILOpBitVector *val);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_neg(RZ_NONNULL RzILOpBitVector *value);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_log_not(RZ_NONNULL RzILOpBitVector *value);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_add(RZ_NONNULL RzILOpBitVector *x, RZ_NONNULL RzILOpBitVector *y);

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -344,7 +344,7 @@ RZ_API bool rz_bv_set_all(RZ_NONNULL RzBitVector *bv, bool b) {
 	rz_return_val_if_fail(bv, false);
 
 	if (bv->len <= 64) {
-		bv->bits.small_u = b ? UT64_MAX : 0;
+		bv->bits.small_u = b ? (UT64_MAX & ((1ull << bv->len) - 1)) : 0;
 		return b;
 	}
 

--- a/test/unit/test_il_vm.c
+++ b/test/unit/test_il_vm.c
@@ -168,6 +168,49 @@ static bool test_rzil_vm_root_evaluation() {
 	mu_end;
 }
 
+static bool test_rzil_vm_op_cast() {
+	RzILVM *vm = rz_il_vm_new(0, 8, false);
+
+	// 8 -> 8
+	RzILOpPure *op = rz_il_op_new_cast(8, rz_il_op_new_b0(), rz_il_op_new_bitv_from_ut64(8, 0x42));
+	RzBitVector *r = rz_il_evaluate_bitv(vm, op);
+	rz_il_op_pure_free(op);
+	mu_assert_notnull(r, "eval");
+	mu_assert_eq(rz_bv_len(r), 8, "eval length");
+	mu_assert_eq(rz_bv_to_ut64(r), 0x42, "eval val");
+	rz_bv_free(r);
+
+	// 8 -> 4
+	op = rz_il_op_new_cast(4, rz_il_op_new_b0(), rz_il_op_new_bitv_from_ut64(8, 0x42));
+	r = rz_il_evaluate_bitv(vm, op);
+	rz_il_op_pure_free(op);
+	mu_assert_notnull(r, "eval");
+	mu_assert_eq(rz_bv_len(r), 4, "eval length");
+	mu_assert_eq(rz_bv_to_ut64(r), 0x2, "eval val");
+	rz_bv_free(r);
+
+	// 8 -> 16 (false)
+	op = rz_il_op_new_cast(13, rz_il_op_new_b0(), rz_il_op_new_bitv_from_ut64(8, 0x42));
+	r = rz_il_evaluate_bitv(vm, op);
+	rz_il_op_pure_free(op);
+	mu_assert_notnull(r, "eval");
+	mu_assert_eq(rz_bv_len(r), 13, "eval length");
+	mu_assert_eq(rz_bv_to_ut64(r), 0x42, "eval val");
+	rz_bv_free(r);
+
+	// 8 -> 16 (true)
+	op = rz_il_op_new_cast(13, rz_il_op_new_b1(), rz_il_op_new_bitv_from_ut64(8, 0x42));
+	r = rz_il_evaluate_bitv(vm, op);
+	rz_il_op_pure_free(op);
+	mu_assert_notnull(r, "eval");
+	mu_assert_eq(rz_bv_len(r), 13, "eval length");
+	mu_assert_eq(rz_bv_to_ut64(r), 0x1f42, "eval val");
+	rz_bv_free(r);
+
+	rz_il_vm_free(vm);
+	mu_end;
+}
+
 static bool test_rzil_vm_op_set() {
 	RzILVM *vm = rz_il_vm_new(0, 8, false);
 
@@ -386,6 +429,7 @@ bool all_tests() {
 	mu_run_test(test_rzil_vm_basic_operation);
 	mu_run_test(test_rzil_vm_operation);
 	mu_run_test(test_rzil_vm_root_evaluation);
+	mu_run_test(test_rzil_vm_op_cast);
 	mu_run_test(test_rzil_vm_op_set);
 	mu_run_test(test_rzil_vm_op_jmp);
 	mu_run_test(test_rzil_vm_op_goto_addr);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

See http://binaryanalysisplatform.github.io/bap/api/master/bap-core-theory/Bap_core_theory/Theory/module-type-Basic/index.html#val-cast

> val cast : 'a Bitv.t Value.sort -> bool -> 'b bitv -> 'a bitv
>
> cast s b x casts x to sort s filling with b.
> If m = size s - size (sort b) > 0 then m bits b are prepended to the most significant part of the vector.
> Otherwise, if m <= 0, i.e., it is a narrowing cast, then the value of b doesn't affect the result of evaluation.

There is no shifting involved.

The cast is needed in particular for zero- and sign-extension.

**Test plan**

unit tests