### PR TITLE
[RzIL] Add rz_il_op_pure_dup() and rz_il_op_new_(unsigned|signed)()

### DIFF
--- a/librz/il/rzil_opcodes.c
+++ b/librz/il/rzil_opcodes.c
@@ -673,6 +673,159 @@ RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_storew(RzILMemIndex mem, RZ_NONNULL RzI
 #undef rz_il_op_new_2
 #undef rz_il_op_new_3
 
+RZ_API RzILOpPure *rz_il_op_pure_dup(RZ_NULLABLE RzILOpPure *op) {
+	rz_return_val_if_fail(op, NULL);
+	RzILOpPure *r = RZ_NEW0(RzILOpPure);
+	if (!r) {
+		return NULL;
+	}
+#define DUP_OP1(arg, m0) \
+	do { \
+		r->op.arg.m0 = rz_il_op_pure_dup(op->op.arg.m0); \
+		if (!r->op.arg.m0) { \
+			return NULL; \
+		} \
+	} while (0);
+#define DUP_OP2(arg, m0, m1) \
+	do { \
+		r->op.arg.m0 = rz_il_op_pure_dup(op->op.arg.m0); \
+		r->op.arg.m1 = rz_il_op_pure_dup(op->op.arg.m1); \
+		if (!r->op.arg.m0 || !r->op.arg.m1) { \
+			rz_il_op_pure_free(r->op.arg.m0); \
+			rz_il_op_pure_free(r->op.arg.m1); \
+			return NULL; \
+		} \
+	} while (0);
+#define DUP_OP3(arg, m0, m1, m2) \
+	do { \
+		r->op.arg.m0 = rz_il_op_pure_dup(op->op.arg.m0); \
+		r->op.arg.m1 = rz_il_op_pure_dup(op->op.arg.m1); \
+		r->op.arg.m2 = rz_il_op_pure_dup(op->op.arg.m2); \
+		if (!r->op.arg.m0 || !r->op.arg.m1 || !r->op.arg.m2) { \
+			rz_il_op_pure_free(r->op.arg.m0); \
+			rz_il_op_pure_free(r->op.arg.m1); \
+			rz_il_op_pure_free(r->op.arg.m2); \
+			return NULL; \
+		} \
+	} while (0);
+	r->code = op->code;
+	switch (op->code) {
+	case RZIL_OP_VAR:
+		r->op.var.v = op->op.var.v;
+		break;
+	case RZIL_OP_UNK:
+		break;
+	case RZIL_OP_ITE:
+		DUP_OP3(ite, condition, x, y);
+		break;
+	case RZIL_OP_B0:
+		break;
+	case RZIL_OP_B1:
+		break;
+	case RZIL_OP_INV:
+		DUP_OP1(boolinv, x);
+		break;
+	case RZIL_OP_AND:
+		DUP_OP2(booland, x, y);
+		break;
+	case RZIL_OP_OR:
+		DUP_OP2(boolor, x, y);
+		break;
+	case RZIL_OP_XOR:
+		DUP_OP2(boolxor, x, y);
+		break;
+	case RZIL_OP_BITV:
+		r->op.bitv.value = rz_bv_dup(op->op.bitv.value);
+		break;
+	case RZIL_OP_MSB:
+		DUP_OP1(msb, bv);
+		break;
+	case RZIL_OP_LSB:
+		DUP_OP1(lsb, bv);
+		break;
+	case RZIL_OP_IS_ZERO:
+		DUP_OP1(is_zero, bv);
+		break;
+	case RZIL_OP_NEG:
+		DUP_OP1(neg, bv);
+		break;
+	case RZIL_OP_LOGNOT:
+		DUP_OP1(lognot, bv);
+		break;
+	case RZIL_OP_ADD:
+		DUP_OP2(add, x, y);
+		break;
+	case RZIL_OP_SUB:
+		DUP_OP2(sub, x, y);
+		break;
+	case RZIL_OP_MUL:
+		DUP_OP2(mul, x, y);
+		break;
+	case RZIL_OP_DIV:
+		DUP_OP2(div, x, y);
+		break;
+	case RZIL_OP_SDIV:
+		DUP_OP2(sdiv, x, y);
+		break;
+	case RZIL_OP_MOD:
+		DUP_OP2(mod, x, y);
+		break;
+	case RZIL_OP_SMOD:
+		DUP_OP2(smod, x, y);
+		break;
+	case RZIL_OP_LOGAND:
+		DUP_OP2(logand, x, y);
+		break;
+	case RZIL_OP_LOGOR:
+		DUP_OP2(logor, x, y);
+		break;
+	case RZIL_OP_LOGXOR:
+		DUP_OP2(logxor, x, y);
+		break;
+	case RZIL_OP_SHIFTR:
+		DUP_OP2(shiftr, x, y);
+		break;
+	case RZIL_OP_SHIFTL:
+		DUP_OP2(shiftl, x, y);
+		break;
+	case RZIL_OP_EQ:
+		DUP_OP2(eq, x, y);
+		break;
+	case RZIL_OP_SLE:
+		DUP_OP2(sle, x, y);
+		break;
+	case RZIL_OP_ULE:
+		DUP_OP2(ule, x, y);
+		break;
+	case RZIL_OP_CAST:
+		r->op.cast.length = op->op.cast.length;
+		DUP_OP2(cast, fill, val);
+		break;
+	case RZIL_OP_CONCAT:
+		rz_warn_if_reached();
+		break;
+	case RZIL_OP_APPEND:
+		DUP_OP2(append, x, y);
+		break;
+	case RZIL_OP_LOAD:
+		r->op.load.mem = op->op.load.mem;
+		DUP_OP1(load, key);
+		break;
+	case RZIL_OP_LOADW:
+		r->op.loadw.mem = op->op.loadw.mem;
+		r->op.loadw.n_bits = op->op.loadw.n_bits;
+		DUP_OP1(loadw, key);
+		break;
+	default:
+		rz_warn_if_reached();
+		break;
+	}
+#undef DUP_OP
+#undef DUP_OP2
+#undef DUP_OP3
+	return r;
+}
+
 #define rz_il_op_free_1(sort, s, v0) \
 	rz_il_op_##sort##_free(op->op.s.v0);
 

--- a/librz/il/rzil_opcodes.c
+++ b/librz/il/rzil_opcodes.c
@@ -289,6 +289,26 @@ RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_cast(ut32 length, RZ_NONNULL RzILOpB
 }
 
 /**
+ * \brief Extend val to length bits, filling up with zeroes
+ *
+ * For length > val->len, this fits the general notion of zero extension.
+ */
+RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_unsigned(ut32 length, RZ_NONNULL RzILOpBitVector *val) {
+	rz_return_val_if_fail(length && val, NULL);
+	return rz_il_op_new_cast(length, rz_il_op_new_b0(), val);
+}
+
+/**
+ * \brief Extend val to length bits, filling up with val's most significant bit
+ *
+ * For length > val->len, this fits the general notion of sign extension.
+ */
+RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_signed(ut32 length, RZ_NONNULL RzILOpBitVector *val) {
+	rz_return_val_if_fail(length && val, NULL);
+	return rz_il_op_new_cast(length, rz_il_op_new_msb(rz_il_op_pure_dup(val)), val);
+}
+
+/**
  *  \brief op structure for `neg` ('s bitv -> 's bitv)
  *
  *  neg x is two-complement unary minus
@@ -673,7 +693,10 @@ RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_storew(RzILMemIndex mem, RZ_NONNULL RzI
 #undef rz_il_op_new_2
 #undef rz_il_op_new_3
 
-RZ_API RzILOpPure *rz_il_op_pure_dup(RZ_NULLABLE RzILOpPure *op) {
+/**
+ * Duplicate the given op recursively, for example to reuse it multiple times in another op.
+ */
+RZ_API RzILOpPure *rz_il_op_pure_dup(RZ_NONNULL RzILOpPure *op) {
 	rz_return_val_if_fail(op, NULL);
 	RzILOpPure *r = RZ_NEW0(RzILOpPure);
 	if (!r) {

--- a/librz/include/rz_il/rzil_opcodes.h
+++ b/librz/include/rz_il/rzil_opcodes.h
@@ -439,6 +439,7 @@ struct rz_il_op_pure_t {
 };
 
 RZ_API void rz_il_op_pure_free(RZ_NULLABLE RzILOpPure *op);
+RZ_API RzILOpPure *rz_il_op_pure_dup(RZ_NULLABLE RzILOpPure *op);
 
 RZ_API RZ_OWN RzILOpPure *rz_il_op_new_ite(RZ_NONNULL RzILOpPure *condition, RZ_NULLABLE RzILOpPure *x, RZ_NULLABLE RzILOpPure *y);
 RZ_API RZ_OWN RzILOpPure *rz_il_op_new_unk();

--- a/librz/include/rz_il/rzil_opcodes.h
+++ b/librz/include/rz_il/rzil_opcodes.h
@@ -439,7 +439,7 @@ struct rz_il_op_pure_t {
 };
 
 RZ_API void rz_il_op_pure_free(RZ_NULLABLE RzILOpPure *op);
-RZ_API RzILOpPure *rz_il_op_pure_dup(RZ_NULLABLE RzILOpPure *op);
+RZ_API RzILOpPure *rz_il_op_pure_dup(RZ_NONNULL RzILOpPure *op);
 
 RZ_API RZ_OWN RzILOpPure *rz_il_op_new_ite(RZ_NONNULL RzILOpPure *condition, RZ_NULLABLE RzILOpPure *x, RZ_NULLABLE RzILOpPure *y);
 RZ_API RZ_OWN RzILOpPure *rz_il_op_new_unk();
@@ -461,6 +461,8 @@ RZ_API RZ_OWN RzILOpBool *rz_il_op_new_eq(RZ_NONNULL RzILOpPure *x, RZ_NONNULL R
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_ule(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_sle(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_cast(ut32 length, RZ_NONNULL RzILOpBool *fill, RZ_NONNULL RzILOpBitVector *val);
+RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_unsigned(ut32 length, RZ_NONNULL RzILOpBitVector *val); // "zero extension"
+RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_signed(ut32 length, RZ_NONNULL RzILOpBitVector *val); // "sign extension"
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_neg(RZ_NONNULL RzILOpBitVector *value);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_log_not(RZ_NONNULL RzILOpBitVector *value);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_add(RZ_NONNULL RzILOpBitVector *x, RZ_NONNULL RzILOpBitVector *y);

--- a/test/unit/test_il_vm.c
+++ b/test/unit/test_il_vm.c
@@ -189,7 +189,7 @@ static bool test_rzil_vm_op_cast() {
 	mu_assert_eq(rz_bv_to_ut64(r), 0x2, "eval val");
 	rz_bv_free(r);
 
-	// 8 -> 16 (false)
+	// 8 -> 13 (false)
 	op = rz_il_op_new_cast(13, rz_il_op_new_b0(), rz_il_op_new_bitv_from_ut64(8, 0x42));
 	r = rz_il_evaluate_bitv(vm, op);
 	rz_il_op_pure_free(op);
@@ -198,13 +198,63 @@ static bool test_rzil_vm_op_cast() {
 	mu_assert_eq(rz_bv_to_ut64(r), 0x42, "eval val");
 	rz_bv_free(r);
 
-	// 8 -> 16 (true)
+	// 8 -> 13 (true)
 	op = rz_il_op_new_cast(13, rz_il_op_new_b1(), rz_il_op_new_bitv_from_ut64(8, 0x42));
 	r = rz_il_evaluate_bitv(vm, op);
 	rz_il_op_pure_free(op);
 	mu_assert_notnull(r, "eval");
 	mu_assert_eq(rz_bv_len(r), 13, "eval length");
 	mu_assert_eq(rz_bv_to_ut64(r), 0x1f42, "eval val");
+	rz_bv_free(r);
+
+	rz_il_vm_free(vm);
+	mu_end;
+}
+
+static bool test_rzil_vm_op_unsigned() {
+	RzILVM *vm = rz_il_vm_new(0, 8, false);
+
+	// msb not set, filled with 0
+	RzILOpPure *op = rz_il_op_new_unsigned(13, rz_il_op_new_bitv_from_ut64(8, 0x42));
+	RzBitVector *r = rz_il_evaluate_bitv(vm, op);
+	rz_il_op_pure_free(op);
+	mu_assert_notnull(r, "eval");
+	mu_assert_eq(rz_bv_len(r), 13, "eval length");
+	mu_assert_eq(rz_bv_to_ut64(r), 0x42, "eval val");
+	rz_bv_free(r);
+
+	// msb set, still filled with 0
+	op = rz_il_op_new_unsigned(13, rz_il_op_new_bitv_from_ut64(8, 0xf2));
+	r = rz_il_evaluate_bitv(vm, op);
+	rz_il_op_pure_free(op);
+	mu_assert_notnull(r, "eval");
+	mu_assert_eq(rz_bv_len(r), 13, "eval length");
+	mu_assert_eq(rz_bv_to_ut64(r), 0xf2, "eval val");
+	rz_bv_free(r);
+
+	rz_il_vm_free(vm);
+	mu_end;
+}
+
+static bool test_rzil_vm_op_signed() {
+	RzILVM *vm = rz_il_vm_new(0, 8, false);
+
+	// msb not set, filled with 0
+	RzILOpPure *op = rz_il_op_new_signed(13, rz_il_op_new_bitv_from_ut64(8, 0x42));
+	RzBitVector *r = rz_il_evaluate_bitv(vm, op);
+	rz_il_op_pure_free(op);
+	mu_assert_notnull(r, "eval");
+	mu_assert_eq(rz_bv_len(r), 13, "eval length");
+	mu_assert_eq(rz_bv_to_ut64(r), 0x42, "eval val");
+	rz_bv_free(r);
+
+	// msb set, filled with 1
+	op = rz_il_op_new_signed(13, rz_il_op_new_bitv_from_ut64(8, 0xf2));
+	r = rz_il_evaluate_bitv(vm, op);
+	rz_il_op_pure_free(op);
+	mu_assert_notnull(r, "eval");
+	mu_assert_eq(rz_bv_len(r), 13, "eval length");
+	mu_assert_eq(rz_bv_to_ut64(r), 0x1ff2, "eval val");
 	rz_bv_free(r);
 
 	rz_il_vm_free(vm);
@@ -430,6 +480,8 @@ bool all_tests() {
 	mu_run_test(test_rzil_vm_operation);
 	mu_run_test(test_rzil_vm_root_evaluation);
 	mu_run_test(test_rzil_vm_op_cast);
+	mu_run_test(test_rzil_vm_op_unsigned);
+	mu_run_test(test_rzil_vm_op_signed);
 	mu_run_test(test_rzil_vm_op_set);
 	mu_run_test(test_rzil_vm_op_jmp);
 	mu_run_test(test_rzil_vm_op_goto_addr);


### PR DESCRIPTION
# Do not squash

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This adds dup-ing pure ops and unsigned/signed, which is pretty much zero/sign extension and uses the dup.
http://binaryanalysisplatform.github.io/bap/api/master/bap-core-theory/Bap_core_theory/Theory/module-type-Basic/index.html#val-signed

**Test plan**

added unit tests