### PR TITLE
Port `ft` commands to the rzshell

### DIFF
--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -279,6 +279,8 @@ static const RzCmdDescArg eval_editor_args[2];
 static const RzCmdDescArg eval_readonly_args[2];
 static const RzCmdDescArg eval_spaces_args[2];
 static const RzCmdDescArg eval_type_args[2];
+static const RzCmdDescArg flag_tag_add_args[3];
+static const RzCmdDescArg flag_tag_search_args[2];
 static const RzCmdDescArg egg_compile_args[2];
 static const RzCmdDescArg egg_config_args[2];
 static const RzCmdDescArg egg_syscall_args[3];
@@ -6066,6 +6068,49 @@ static const RzCmdDescHelp eval_type_help = {
 static const RzCmdDescHelp cmd_flag_help = {
 	.summary = "Manage flags",
 };
+static const RzCmdDescHelp ft_help = {
+	.summary = "Flag tags",
+};
+static const RzCmdDescArg flag_tag_add_args[] = {
+	{
+		.name = "tag",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+
+	},
+	{
+		.name = "words",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp flag_tag_add_help = {
+	.summary = "Set a list of words for the given tag",
+	.args = flag_tag_add_args,
+};
+
+static const RzCmdDescArg flag_tag_list_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp flag_tag_list_help = {
+	.summary = "List all flag tags",
+	.args = flag_tag_list_args,
+};
+
+static const RzCmdDescArg flag_tag_search_args[] = {
+	{
+		.name = "tag",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp flag_tag_search_help = {
+	.summary = "Find all matching flag names for the given tag",
+	.args = flag_tag_search_args,
+};
 
 static const RzCmdDescHelp g_help = {
 	.summary = "Generate shellcodes with rz_egg",
@@ -11177,6 +11222,14 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *cmd_flag_cd = rz_cmd_desc_oldinput_new(core->rcmd, root_cd, "f", rz_cmd_flag, &cmd_flag_help);
 	rz_warn_if_fail(cmd_flag_cd);
+	RzCmdDesc *ft_cd = rz_cmd_desc_group_new(core->rcmd, cmd_flag_cd, "ft", rz_flag_tag_add_handler, &flag_tag_add_help, &ft_help);
+	rz_warn_if_fail(ft_cd);
+	RzCmdDesc *flag_tag_list_cd = rz_cmd_desc_argv_state_new(core->rcmd, ft_cd, "ftl", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_LONG | RZ_OUTPUT_MODE_JSON, rz_flag_tag_list_handler, &flag_tag_list_help);
+	rz_warn_if_fail(flag_tag_list_cd);
+	rz_cmd_desc_set_default_mode(flag_tag_list_cd, RZ_OUTPUT_MODE_STANDARD);
+
+	RzCmdDesc *flag_tag_search_cd = rz_cmd_desc_argv_new(core->rcmd, ft_cd, "ftn", rz_flag_tag_search_handler, &flag_tag_search_help);
+	rz_warn_if_fail(flag_tag_search_cd);
 
 	RzCmdDesc *g_cd = rz_cmd_desc_group_new(core->rcmd, root_cd, "g", rz_egg_compile_handler, &egg_compile_help, &g_help);
 	rz_warn_if_fail(g_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -433,6 +433,9 @@ RZ_IPI RzCmdStatus rz_eval_editor_handler(RzCore *core, int argc, const char **a
 RZ_IPI RzCmdStatus rz_eval_readonly_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_eval_spaces_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_eval_type_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_flag_tag_add_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_flag_tag_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+RZ_IPI RzCmdStatus rz_flag_tag_search_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI int rz_cmd_flag(void *data, const char *input);
 RZ_IPI RzCmdStatus rz_egg_compile_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_egg_config_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_descs.yaml
+++ b/librz/core/cmd_descs/cmd_descs.yaml
@@ -216,6 +216,7 @@ commands:
     cname: cmd_flag
     summary: Manage flags
     type: RZ_CMD_DESC_TYPE_OLDINPUT
+    subcommands: cmd_flag
   - name: g
     summary: Generate shellcodes with rz_egg
     subcommands: cmd_egg

--- a/librz/core/cmd_descs/cmd_flag.yaml
+++ b/librz/core/cmd_descs/cmd_flag.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2022 RizinOrg <info@rizin.re>
+# SPDX-License-Identifier: LGPL-3.0-only
+---
+name: cmd_flag
+commands:
+  - name: ft
+    summary: Flag tags
+    subcommands:
+      - name: ft
+        cname: flag_tag_add
+        summary: Set a list of words for the given tag
+        args:
+          - name: tag
+            type: RZ_CMD_ARG_TYPE_STRING
+          - name: words
+            type: RZ_CMD_ARG_TYPE_STRING
+      - name: ftl
+        cname: flag_tag_list
+        summary: List all flag tags
+        type: RZ_CMD_DESC_TYPE_ARGV_STATE
+        default_mode: RZ_OUTPUT_MODE_STANDARD
+        modes:
+          - RZ_OUTPUT_MODE_STANDARD
+          - RZ_OUTPUT_MODE_LONG
+          - RZ_OUTPUT_MODE_JSON
+        args: []
+      - name: ftn
+        cname: flag_tag_search
+        summary: Find all matching flag names for the given tag
+        args:
+          - name: tag
+            type: RZ_CMD_ARG_TYPE_STRING
+

--- a/librz/core/cmd_descs/meson.build
+++ b/librz/core/cmd_descs/meson.build
@@ -7,6 +7,7 @@ cmd_descs_yaml = files(
   'cmd_descs.yaml',
   'cmd_egg.yaml',
   'cmd_eval.yaml',
+  'cmd_flag.yaml',
   'cmd_heap_glibc.yaml',
   'cmd_history.yaml',
   'cmd_info.yaml',

--- a/librz/flag/tags.c
+++ b/librz/flag/tags.c
@@ -10,13 +10,8 @@ RZ_API RzList *rz_flag_tags_set(RzFlag *f, const char *name, const char *words) 
 	return NULL;
 }
 
-RZ_API RzList *rz_flag_tags_list(RzFlag *f, const char *name) {
+RZ_API RzList *rz_flag_tags_list(RzFlag *f) {
 	rz_return_val_if_fail(f, NULL);
-	if (name) {
-		const char *k = sdb_fmt("tag.%s", name);
-		char *words = sdb_get(f->tags, k, NULL);
-		return rz_str_split_list(words, " ", 0);
-	}
 	RzList *res = rz_list_newf(free);
 	SdbList *o = sdb_foreach_list(f->tags, false);
 	SdbListIter *iter;
@@ -56,7 +51,7 @@ static bool iter_glob_flag(RzFlagItem *fi, void *user) {
 	return true;
 }
 
-RZ_API RzList *rz_flag_tags_get(RzFlag *f, const char *name) {
+RZ_API RzList /* <RzFlagItem */ *rz_flag_tags_get(RzFlag *f, const char *name) {
 	rz_return_val_if_fail(f && name, NULL);
 	const char *k = sdb_fmt("tag.%s", name);
 	RzList *res = rz_list_newf(NULL);

--- a/librz/flag/tags.c
+++ b/librz/flag/tags.c
@@ -51,7 +51,7 @@ static bool iter_glob_flag(RzFlagItem *fi, void *user) {
 	return true;
 }
 
-RZ_API RzList /* <RzFlagItem */ *rz_flag_tags_get(RzFlag *f, const char *name) {
+RZ_API RzList /* <RzFlagItem> */ *rz_flag_tags_get(RzFlag *f, const char *name) {
 	rz_return_val_if_fail(f && name, NULL);
 	const char *k = sdb_fmt("tag.%s", name);
 	RzList *res = rz_list_newf(NULL);

--- a/librz/include/rz_flag.h
+++ b/librz/include/rz_flag.h
@@ -173,7 +173,7 @@ static inline bool rz_flag_space_is_empty(RzFlag *f) {
 #define rz_flag_space_foreach(f, it, s) rz_spaces_foreach(&(f)->spaces, (it), (s))
 
 /* tags */
-RZ_API RzList *rz_flag_tags_list(RzFlag *f, const char *name);
+RZ_API RzList *rz_flag_tags_list(RzFlag *f);
 RZ_API RzList *rz_flag_tags_set(RzFlag *f, const char *name, const char *words);
 RZ_API void rz_flag_tags_reset(RzFlag *f, const char *name);
 RZ_API RzList *rz_flag_tags_get(RzFlag *f, const char *name);

--- a/test/db/cmd/cmd_flags
+++ b/test/db/cmd/cmd_flags
@@ -650,3 +650,60 @@ EXPECT=<<EOF
 0x00000064 1 base64:NotB64
 EOF
 RUN
+
+NAME=ft
+FILE=bins/elf/analysis/main
+CMDS=<<EOF
+ftl
+ftlj
+ftll
+ft bla "foo goo moo"
+f foo
+s main
+f goo
+ftl~bla
+ftll
+ftn bla
+EOF
+EXPECT=<<EOF
+fs
+env
+string
+threads
+network
+dylib
+alloc
+time
+process
+stdout
+["fs":[],"env":[],"string":[],"threads":[],"network":[],"dylib":[],"alloc":[],"time":[],"process":[],"stdout":[]]
+fs:
+env:
+string:
+threads:
+network:
+dylib:
+alloc:
+time:
+process:
+stdout:
+bla
+fs:
+dylib:
+process:
+stdout:
+network:
+alloc:
+env:
+string:
+time:
+bla:
+0x00400410  foo
+0x00400506  goo
+threads:
+0x00400410  foo
+0x00400506  goo
+EOF
+RUN
+
+


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Port `ft` (flag tags) command to the rzshell
- Removed `ftw` and it's implemented in `ftl`
- `ftl` command to list flag tags (and the result of their match) in standard, long and JSON modes (removed `*` aka RIZIN command mode)
- `ft bla "foo moo goo"` to add new tag

**Test plan**

CI is green