### PR TITLE
[RzIL] Add Validator (Type-checker)

### DIFF
--- a/librz/il/il_export.c
+++ b/librz/il/il_export.c
@@ -163,16 +163,6 @@ static void il_opdmp_var(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
 	}
 }
 
-static void il_opdmp_unk(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
-	if (sb) {
-		rz_strbuf_append(sb, "unk");
-	} else {
-		pj_o(pj);
-		pj_ks(pj, "opcode", "unk");
-		pj_end(pj);
-	}
-}
-
 static void il_opdmp_ite(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
 	il_op_param_3("ite", op->op.ite, pure, condition, pure, x, pure, y);
 }
@@ -514,9 +504,6 @@ static void il_op_pure_resolve(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
 	case RZ_IL_OP_VAR:
 		il_opdmp_var(op, sb, pj);
 		return;
-	case RZ_IL_OP_UNK:
-		il_opdmp_unk(op, sb, pj);
-		return;
 	case RZ_IL_OP_ITE:
 		il_opdmp_ite(op, sb, pj);
 		return;
@@ -843,4 +830,82 @@ RZ_API void rz_il_event_json(RZ_NONNULL RzILEvent *evt, RZ_NONNULL PJ *pj) {
 	free(tmp0);
 	free(tmp1);
 	free(tmp2);
+}
+
+RZ_API RZ_NONNULL const char *rz_il_op_pure_code_stringify(RzILOpPureCode code) {
+	switch (code) {
+	case RZ_IL_OP_VAR:
+		return "var";
+	case RZ_IL_OP_ITE:
+		return "ite";
+	case RZ_IL_OP_LET:
+		return "let";
+	case RZ_IL_OP_B0:
+		return "b0";
+	case RZ_IL_OP_B1:
+		return "b1";
+	case RZ_IL_OP_INV:
+		return "inv";
+	case RZ_IL_OP_AND:
+		return "and";
+	case RZ_IL_OP_OR:
+		return "or";
+	case RZ_IL_OP_XOR:
+		return "xor";
+	case RZ_IL_OP_BITV:
+		return "bitv";
+	case RZ_IL_OP_MSB:
+		return "msb";
+	case RZ_IL_OP_LSB:
+		return "lsb";
+	case RZ_IL_OP_IS_ZERO:
+		return "is_zero";
+	case RZ_IL_OP_NEG:
+		return "neg";
+	case RZ_IL_OP_LOGNOT:
+		return "lognot";
+	case RZ_IL_OP_ADD:
+		return "add";
+	case RZ_IL_OP_SUB:
+		return "sub";
+	case RZ_IL_OP_MUL:
+		return "mul";
+	case RZ_IL_OP_DIV:
+		return "div";
+	case RZ_IL_OP_SDIV:
+		return "sdiv";
+	case RZ_IL_OP_MOD:
+		return "mod";
+	case RZ_IL_OP_SMOD:
+		return "smod";
+	case RZ_IL_OP_LOGAND:
+		return "logand";
+	case RZ_IL_OP_LOGOR:
+		return "logor";
+	case RZ_IL_OP_LOGXOR:
+		return "logxor";
+	case RZ_IL_OP_SHIFTR:
+		return "shiftr";
+	case RZ_IL_OP_SHIFTL:
+		return "shiftl";
+	case RZ_IL_OP_EQ:
+		return "eq";
+	case RZ_IL_OP_SLE:
+		return "sle";
+	case RZ_IL_OP_ULE:
+		return "ule";
+	case RZ_IL_OP_CAST:
+		return "cast";
+	case RZ_IL_OP_CONCAT:
+		return "concat";
+	case RZ_IL_OP_APPEND:
+		return "append";
+	case RZ_IL_OP_LOAD:
+		return "load";
+	case RZ_IL_OP_LOADW:
+		return "loadw";
+	case RZ_IL_OP_PURE_MAX:
+		break;
+	}
+	return "invalid";
 }

--- a/librz/il/il_export.c
+++ b/librz/il/il_export.c
@@ -340,10 +340,6 @@ static void il_opdmp_cast(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
 	}
 }
 
-static void il_opdmp_concat(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
-	il_op_unimplemented("concat");
-}
-
 static void il_opdmp_append(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
 	il_op_param_2("append", op->op.append, pure, high, pure, low);
 }
@@ -593,9 +589,6 @@ static void il_op_pure_resolve(RzILOpPure *op, RzStrBuf *sb, PJ *pj) {
 		return;
 	case RZ_IL_OP_CAST:
 		il_opdmp_cast(op, sb, pj);
-		return;
-	case RZ_IL_OP_CONCAT:
-		il_opdmp_concat(op, sb, pj);
 		return;
 	case RZ_IL_OP_APPEND:
 		il_opdmp_append(op, sb, pj);
@@ -896,8 +889,6 @@ RZ_API RZ_NONNULL const char *rz_il_op_pure_code_stringify(RzILOpPureCode code) 
 		return "ule";
 	case RZ_IL_OP_CAST:
 		return "cast";
-	case RZ_IL_OP_CONCAT:
-		return "concat";
 	case RZ_IL_OP_APPEND:
 		return "append";
 	case RZ_IL_OP_LOAD:
@@ -908,4 +899,14 @@ RZ_API RZ_NONNULL const char *rz_il_op_pure_code_stringify(RzILOpPureCode code) 
 		break;
 	}
 	return "invalid";
+}
+
+RZ_API char *rz_il_sort_pure_stringify(RzILSortPure sort) {
+	switch (sort.type) {
+	case RZ_IL_TYPE_PURE_BITVECTOR:
+		return rz_str_newf("bitvector:%u", (unsigned int)sort.props.bv.length);
+	case RZ_IL_TYPE_PURE_BOOL:
+		return strdup("bool");
+	}
+	return strdup("invalid");
 }

--- a/librz/il/il_export.c
+++ b/librz/il/il_export.c
@@ -825,6 +825,10 @@ RZ_API void rz_il_event_json(RZ_NONNULL RzILEvent *evt, RZ_NONNULL PJ *pj) {
 	free(tmp2);
 }
 
+/**
+ * Get a readable representation of \p code
+ * \return constant string, must not be freed
+ */
 RZ_API RZ_NONNULL const char *rz_il_op_pure_code_stringify(RzILOpPureCode code) {
 	switch (code) {
 	case RZ_IL_OP_VAR:
@@ -901,7 +905,11 @@ RZ_API RZ_NONNULL const char *rz_il_op_pure_code_stringify(RzILOpPureCode code) 
 	return "invalid";
 }
 
-RZ_API char *rz_il_sort_pure_stringify(RzILSortPure sort) {
+/**
+ * Get a readable representation of \p sort
+ * \return dynamically allocated string, to be freed by the caller
+ */
+RZ_API RZ_OWN char *rz_il_sort_pure_stringify(RzILSortPure sort) {
 	switch (sort.type) {
 	case RZ_IL_TYPE_PURE_BITVECTOR:
 		return rz_str_newf("bitvector:%u", (unsigned int)sort.props.bv.length);

--- a/librz/il/il_opcodes.c
+++ b/librz/il/il_opcodes.c
@@ -814,9 +814,6 @@ RZ_API RzILOpPure *rz_il_op_pure_dup(RZ_NONNULL RzILOpPure *op) {
 		r->op.cast.length = op->op.cast.length;
 		DUP_OP2(cast, fill, val);
 		break;
-	case RZ_IL_OP_CONCAT:
-		rz_warn_if_reached();
-		break;
 	case RZ_IL_OP_APPEND:
 		DUP_OP2(append, high, low);
 		break;
@@ -941,9 +938,6 @@ RZ_API void rz_il_op_pure_free(RZ_NULLABLE RzILOpPure *op) {
 		break;
 	case RZ_IL_OP_CAST:
 		rz_il_op_free_2(pure, cast, fill, val);
-		break;
-	case RZ_IL_OP_CONCAT:
-		rz_warn_if_reached();
 		break;
 	case RZ_IL_OP_APPEND:
 		rz_il_op_free_2(pure, append, high, low);

--- a/librz/il/il_opcodes.c
+++ b/librz/il/il_opcodes.c
@@ -58,15 +58,6 @@ RZ_API RZ_OWN RzILOpPure *rz_il_op_new_ite(RZ_NONNULL RzILOpPure *condition, RZ_
 }
 
 /**
- * \brief op structure for unknown
- */
-RZ_API RZ_OWN RzILOpPure *rz_il_op_new_unk() {
-	RzILOpPure *ret;
-	rz_il_op_new_0(Pure, RZ_IL_OP_UNK);
-	return ret;
-}
-
-/**
  *  \brief op structure for `var` ('a var -> 'a pure)
  *
  *  var v is the value of the variable v.
@@ -733,8 +724,6 @@ RZ_API RzILOpPure *rz_il_op_pure_dup(RZ_NONNULL RzILOpPure *op) {
 	case RZ_IL_OP_VAR:
 		r->op.var.v = op->op.var.v;
 		break;
-	case RZ_IL_OP_UNK:
-		break;
 	case RZ_IL_OP_ITE:
 		DUP_OP3(ite, condition, x, y);
 		break;
@@ -868,8 +857,6 @@ RZ_API void rz_il_op_pure_free(RZ_NULLABLE RzILOpPure *op) {
 	}
 	switch (op->code) {
 	case RZ_IL_OP_VAR:
-		break;
-	case RZ_IL_OP_UNK:
 		break;
 	case RZ_IL_OP_ITE:
 		rz_il_op_free_3(pure, ite, condition, x, y);

--- a/librz/il/il_validate.c
+++ b/librz/il/il_validate.c
@@ -21,6 +21,10 @@ static void var_kv_free(HtPPKv *kv) {
 	free(kv->value);
 }
 
+/**
+ * Create a new global context for validation
+ * Vars and mems can be added manually with rz_il_validate_global_context_add_* functions.
+ */
 RZ_API RzILValidateGlobalContext *rz_il_validate_global_context_new_empty(ut32 pc_len) {
 	RzILValidateGlobalContext *ctx = RZ_NEW0(RzILValidateGlobalContext);
 	if (!ctx) {
@@ -538,6 +542,14 @@ static bool validate_pure(VALIDATOR_PURE_ARGS) {
 	return validator(op, sort_out, report_builder, ctx, local_pure_var_stack);
 }
 
+/**
+ * Run validation (type-checking and other checks) on a pure expression and determine its sort.
+ * \p op the op to be checked. May be null, which will always be reported as invalid.
+ * \p ctx global context, defining available global vars and mems
+ * \p sort_out optionally returns the sort of the expression, if it is valid
+ * \p report_out optionally returns a readable report containing details about why the validation failed
+ * \return whether the given op is valid under \p ctx
+ */
 RZ_API bool rz_il_validate_pure(RZ_NULLABLE RzILOpPure *op, RZ_NONNULL RzILValidateGlobalContext *ctx,
 	RZ_NULLABLE RZ_OUT RzILSortPure *sort_out, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out) {
 	LocalContext local_ctx;
@@ -748,8 +760,17 @@ static bool validate_effect(VALIDATOR_EFFECT_ARGS) {
 	return validator(op, report_builder, ctx);
 }
 
-RZ_API bool rz_il_validate_effect(RZ_NULLABLE RzILOpEffect *op, RZ_OUT RZ_NULLABLE HtPP /* <const char *, RzILSortPure *> */ **local_var_sorts_out,
-	RZ_NONNULL RzILValidateGlobalContext *ctx, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out) {
+/**
+ * Run validation (type-checking and other checks) on an effect.
+ * \p op the op to be checked. May be null, which will always be reported as invalid.
+ * \p ctx global context, defining available global vars and mems
+ * \p local_var_sorts_out optionally returns a map of local variable names defined in the effect to their sorts
+ * \p report_out optionally returns a readable report containing details about why the validation failed
+ * \return whether the given op is valid under \p ctx
+ */
+RZ_API bool rz_il_validate_effect(RZ_NULLABLE RzILOpEffect *op, RZ_NONNULL RzILValidateGlobalContext *ctx,
+	RZ_NULLABLE RZ_OUT HtPP /* <const char *, RzILSortPure *> */ **local_var_sorts_out,
+	RZ_NULLABLE RZ_OUT RzILValidateReport *report_out) {
 	LocalContext local_ctx;
 	if (!local_context_init(&local_ctx, ctx)) {
 		if (report_out) {

--- a/librz/il/il_validate.c
+++ b/librz/il/il_validate.c
@@ -3,43 +3,86 @@
 
 #include <rz_il/rz_il_validate.h>
 
-struct rz_il_validate_context_t {
+/////////////////////////////////////////////////////////
+// ---------------------- context -----------------------
+
+/**
+ * Global (immutable) context
+ */
+struct rz_il_validate_global_context_t {
 	HtPP /*<const char *, RzILSortPure *>*/ *global_vars;
-}; /* RzILValidateContext */
+}; /* RzILValidateGlobalContext */
 
 static void var_kv_free(HtPPKv *kv) {
 	free(kv->key);
 	free(kv->value);
 }
 
-/**
- * Create a new context for IL validation based on the global vars and mems in \p vm
- */
-RZ_API RzILValidateContext *rz_il_validate_context_new_from_vm(RzILVM *vm) {
-	RzILValidateContext *ctx = RZ_NEW0(RzILValidateContext);
+RZ_API RzILValidateGlobalContext *rz_il_validate_global_context_new_empty() {
+	RzILValidateGlobalContext *ctx = RZ_NEW0(RzILValidateGlobalContext);
 	if (!ctx) {
 		return NULL;
 	}
 	ctx->global_vars = ht_pp_new(NULL, var_kv_free, NULL);
-	return NULL;
+	return ctx;
 }
 
-RZ_API void rz_il_validate_context_free(RzILValidateContext *ctx) {
+/**
+ * Create a new context for IL validation based on the global vars and mems in \p vm
+ */
+RZ_API RzILValidateGlobalContext *rz_il_validate_global_context_new_from_vm(RzILVM *vm) {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+	// TODO: add global vars
+	return ctx;
+}
+
+RZ_API void rz_il_validate_global_context_free(RzILValidateGlobalContext *ctx) {
+	ht_pp_free(ctx->global_vars);
 	if (!ctx) {
 		return;
 	}
 }
 
 typedef struct {
+	const RzILValidateGlobalContext *global_ctx;
 	HtPP /*<const char *, RzILSortPure *>*/ *local_vars;
 } LocalContext;
+
+static bool local_context_init(LocalContext *ctx, RzILValidateGlobalContext *global_ctx) {
+	ctx->global_ctx = global_ctx;
+	ctx->local_vars = ht_pp_new(NULL, var_kv_free, NULL);
+	if (!ctx->local_vars) {
+		return false;
+	}
+	return true;
+}
+
+static void local_context_fini(LocalContext *ctx) {
+	ht_pp_free(ctx->local_vars);
+}
 
 /////////////////////////////////////////////////////////
 // ------------------------ pure ------------------------
 
-static bool validate_pure(RZ_NULLABLE RzILOpPure *op, RZ_NONNULL RzILSortPure *sort_out, RZ_NONNULL RzStrBuf *report_builder);
+/**
+ * Linked list (stack) of let-bound vars
+ *
+ * While descending, new var definitions are pushed, thus shadowing other vars
+ * of the same name when searching from the head.
+ */
+typedef struct local_pure_var_t {
+	const char *name;
+	RzILSortPure sort;
+	struct local_pure_var_t *next;
+} LocalPureVar;
 
-#define VALIDATOR_PURE_ARGS RZ_NULLABLE RzILOpPure *op, RZ_NONNULL RzILSortPure *sort_out, RZ_NONNULL RzStrBuf *report_builder
+#define VALIDATOR_PURE_ARGS \
+	RZ_NULLABLE RzILOpPure *op, \
+		RZ_NONNULL RzILSortPure *sort_out, \
+		RZ_NONNULL RzStrBuf *report_builder, \
+		RZ_NONNULL const LocalContext *ctx, \
+		RZ_NULLABLE LocalPureVar *local_pure_var_stack
+static bool validate_pure(VALIDATOR_PURE_ARGS);
 typedef bool (*ValidatePureFn)(VALIDATOR_PURE_ARGS);
 #define VALIDATOR_PURE_NAME(op) validate_pure_##op
 #define VALIDATOR_PURE(op)      static bool VALIDATOR_PURE_NAME(op)(VALIDATOR_PURE_ARGS)
@@ -50,10 +93,40 @@ typedef bool (*ValidatePureFn)(VALIDATOR_PURE_ARGS);
 			return false; \
 		} \
 	} while (0)
+#define VALIDATOR_DESCEND(op, sort) \
+	do { \
+		if (!validate_pure(op, sort, report_builder, ctx, local_pure_var_stack)) { \
+			return false; \
+		} \
+	} while (0)
 
 VALIDATOR_PURE(invalid) {
 	rz_strbuf_appendf(report_builder, "Unimplemented validation for op of type %d.\n", (int)op->code);
 	return false;
+}
+
+VALIDATOR_PURE(var) {
+	RzILOpArgsVar *args = &op->op.var;
+	VALIDATOR_ASSERT(args->v, "Var name of var op is NULL.\n");
+	switch (args->kind) {
+	case RZ_IL_VAR_KIND_GLOBAL:
+		return false; // TODO
+	case RZ_IL_VAR_KIND_LOCAL:
+		return false; // TODO
+	case RZ_IL_VAR_KIND_LOCAL_PURE: {
+		for (LocalPureVar *loc = local_pure_var_stack; loc; loc = loc->next) {
+			if (!strcmp(loc->name, args->v)) {
+				*sort_out = loc->sort;
+				return true;
+			}
+		}
+		VALIDATOR_ASSERT(false, "Local pure variable \"%s\" unbound at var op.\n", args->v);
+		return false;
+	}
+	default:
+		VALIDATOR_ASSERT(false, "Var op has invalid kind.\n");
+	}
+	return true;
 }
 
 VALIDATOR_PURE(bool_const) {
@@ -77,14 +150,10 @@ VALIDATOR_PURE(bitv_binop) {
 	VALIDATOR_ASSERT(x, "Left operand of %s op is NULL.\n", rz_il_op_pure_code_stringify(op->code));
 	VALIDATOR_ASSERT(y, "Right operand of %s op is NULL.\n", rz_il_op_pure_code_stringify(op->code));
 	RzILSortPure sx;
-	if (!validate_pure(x, &sx, report_builder)) {
-		return false;
-	}
+	VALIDATOR_DESCEND(x, &sx);
 	VALIDATOR_ASSERT(sx.type == RZ_IL_TYPE_PURE_BITVECTOR, "Left operand of %s op is not a bitvector.\n", rz_il_op_pure_code_stringify(op->code));
 	RzILSortPure sy;
-	if (!validate_pure(y, &sy, report_builder)) {
-		return false;
-	}
+	VALIDATOR_DESCEND(y, &sy);
 	VALIDATOR_ASSERT(sy.type == RZ_IL_TYPE_PURE_BITVECTOR, "Right operand of %s op is not a bitvector.\n", rz_il_op_pure_code_stringify(op->code));
 	VALIDATOR_ASSERT(sx.props.bv.length == sy.props.bv.length, "Operand sizes of %s op do not agree: %u vs. %u.\n",
 		rz_il_op_pure_code_stringify(op->code), (unsigned int)sx.props.bv.length, (unsigned int)sy.props.bv.length);
@@ -92,10 +161,25 @@ VALIDATOR_PURE(bitv_binop) {
 	return true;
 }
 
+VALIDATOR_PURE(let) {
+	RzILOpArgsLet *args = &op->op.let;
+	VALIDATOR_ASSERT(args->name, "Var name of let op is NULL.\n");
+	VALIDATOR_ASSERT(args->exp, "Expression of let op is NULL.\n");
+	VALIDATOR_ASSERT(args->body, "Body of let op is NULL.\n");
+	RzILSortPure sort;
+	VALIDATOR_DESCEND(args->exp, &sort);
+	LocalPureVar var = {
+		.name = args->name,
+		.sort = sort,
+		.next = local_pure_var_stack
+	};
+	return validate_pure(args->body, sort_out, report_builder, ctx, &var);
+}
+
 static ValidatePureFn validate_pure_table[RZ_IL_OP_PURE_MAX] = {
-	[RZ_IL_OP_VAR] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_VAR] = VALIDATOR_PURE_NAME(var),
 	[RZ_IL_OP_ITE] = VALIDATOR_PURE_NAME(invalid),
-	[RZ_IL_OP_LET] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_LET] = VALIDATOR_PURE_NAME(let),
 	[RZ_IL_OP_B0] = VALIDATOR_PURE_NAME(bool_const),
 	[RZ_IL_OP_B1] = VALIDATOR_PURE_NAME(bool_const),
 	[RZ_IL_OP_INV] = VALIDATOR_PURE_NAME(invalid),
@@ -130,24 +214,33 @@ static ValidatePureFn validate_pure_table[RZ_IL_OP_PURE_MAX] = {
 	[RZ_IL_OP_LOADW] = VALIDATOR_PURE_NAME(invalid)
 };
 
-static bool validate_pure(RZ_NULLABLE RzILOpPure *op, RZ_NONNULL RzILSortPure *sort_out, RZ_NONNULL RzStrBuf *report_builder) {
+static bool validate_pure(VALIDATOR_PURE_ARGS) {
 	if (!op) {
 		rz_strbuf_appendf(report_builder, "Encountered NULL for pure op.\n");
 		return false;
 	}
 	ValidatePureFn validator = validate_pure_table[op->code];
 	rz_return_val_if_fail(validator, false);
-	return validator(op, sort_out, report_builder);
+	return validator(op, sort_out, report_builder, ctx, local_pure_var_stack);
 }
 
 /////////////////////////////////////////////////////////
 // ----------------------- effect -----------------------
 
-RZ_API bool rz_il_validate_pure(RZ_NULLABLE RzILOpPure *op, RZ_NULLABLE RZ_OUT RzILSortPure *sort_out, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out) {
+RZ_API bool rz_il_validate_pure(RZ_NULLABLE RzILOpPure *op, RZ_NONNULL RzILValidateGlobalContext *ctx,
+	RZ_NULLABLE RZ_OUT RzILSortPure *sort_out, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out) {
+	LocalContext local_ctx;
+	if (!local_context_init(&local_ctx, ctx)) {
+		if (report_out) {
+			*report_out = NULL;
+		}
+		return false;
+	}
 	RzStrBuf report_builder;
 	rz_strbuf_init(&report_builder);
 	RzILSortPure sort = { 0 };
-	bool valid = validate_pure(op, &sort, &report_builder);
+	bool valid = validate_pure(op, &sort, &report_builder, &local_ctx, NULL);
+	local_context_fini(&local_ctx);
 	if (sort_out) {
 		*sort_out = sort;
 	}

--- a/librz/il/il_validate.c
+++ b/librz/il/il_validate.c
@@ -21,6 +21,10 @@ static void var_kv_free(HtPPKv *kv) {
 	free(kv->value);
 }
 
+static void var_kv_unown_free(HtPPKv *kv) {
+	free(kv->key);
+}
+
 /**
  * Create a new global context for validation
  * Vars and mems can be added manually with rz_il_validate_global_context_add_* functions.
@@ -117,7 +121,7 @@ static bool local_context_init(LocalContext *ctx, const RzILValidateGlobalContex
 	if (!ctx->local_vars_known) {
 		return false;
 	}
-	ctx->local_vars_available = ht_pp_new(NULL, NULL, NULL);
+	ctx->local_vars_available = ht_pp_new(NULL, var_kv_unown_free, NULL);
 	if (!ctx->local_vars_available) {
 		ht_pp_free(ctx->local_vars_known);
 		return false;

--- a/librz/il/il_validate.c
+++ b/librz/il/il_validate.c
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2022 Florian Märkl <info@florianmaerkl.de>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_il/rz_il_validate.h>
+
+struct rz_il_validate_context_t {
+	HtPP /*<const char *, RzILSortPure *>*/ *global_vars;
+}; /* RzILValidateContext */
+
+static void var_kv_free(HtPPKv *kv) {
+	free(kv->key);
+	free(kv->value);
+}
+
+/**
+ * Create a new context for IL validation based on the global vars and mems in \p vm
+ */
+RZ_API RzILValidateContext *rz_il_validate_context_new_from_vm(RzILVM *vm) {
+	RzILValidateContext *ctx = RZ_NEW0(RzILValidateContext);
+	if (!ctx) {
+		return NULL;
+	}
+	ctx->global_vars = ht_pp_new(NULL, var_kv_free, NULL);
+	return NULL;
+}
+
+RZ_API void rz_il_validate_context_free(RzILValidateContext *ctx) {
+	if (!ctx) {
+		return;
+	}
+}
+
+typedef struct {
+	HtPP /*<const char *, RzILSortPure *>*/ *local_vars;
+} LocalContext;
+
+/////////////////////////////////////////////////////////
+// ------------------------ pure ------------------------
+
+static bool validate_pure(RZ_NULLABLE RzILOpPure *op, RZ_NONNULL RzILSortPure *sort_out, RZ_NONNULL RzStrBuf *report_builder);
+
+#define VALIDATOR_PURE_ARGS RZ_NULLABLE RzILOpPure *op, RZ_NONNULL RzILSortPure *sort_out, RZ_NONNULL RzStrBuf *report_builder
+typedef bool (*ValidatePureFn)(VALIDATOR_PURE_ARGS);
+#define VALIDATOR_PURE_NAME(op) validate_pure_##op
+#define VALIDATOR_PURE(op)      static bool VALIDATOR_PURE_NAME(op)(VALIDATOR_PURE_ARGS)
+#define VALIDATOR_ASSERT(condition, ...) \
+	do { \
+		if (!(condition)) { \
+			rz_strbuf_appendf(report_builder, __VA_ARGS__); \
+			return false; \
+		} \
+	} while (0)
+
+VALIDATOR_PURE(invalid) {
+	rz_strbuf_appendf(report_builder, "Unimplemented validation for op of type %d.\n", (int)op->code);
+	return false;
+}
+
+VALIDATOR_PURE(bool_const) {
+	*sort_out = rz_il_sort_pure_bool();
+	return true;
+}
+
+VALIDATOR_PURE(bitv) {
+	RzBitVector *bv = op->op.bitv.value;
+	if (!bv) {
+		rz_strbuf_appendf(report_builder, "Bitvector in constant bitvector op is NULL.\n");
+		return false;
+	}
+	*sort_out = rz_il_sort_pure_bv(rz_bv_len(bv));
+	return true;
+}
+
+VALIDATOR_PURE(bitv_binop) {
+	RzILOpPure *x = op->op.add.x; // just add is fine, all ops in here use the same struct
+	RzILOpPure *y = op->op.add.y;
+	VALIDATOR_ASSERT(x, "Left operand of %s op is NULL.\n", rz_il_op_pure_code_stringify(op->code));
+	VALIDATOR_ASSERT(y, "Right operand of %s op is NULL.\n", rz_il_op_pure_code_stringify(op->code));
+	RzILSortPure sx;
+	if (!validate_pure(x, &sx, report_builder)) {
+		return false;
+	}
+	VALIDATOR_ASSERT(sx.type == RZ_IL_TYPE_PURE_BITVECTOR, "Left operand of %s op is not a bitvector.\n", rz_il_op_pure_code_stringify(op->code));
+	RzILSortPure sy;
+	if (!validate_pure(y, &sy, report_builder)) {
+		return false;
+	}
+	VALIDATOR_ASSERT(sy.type == RZ_IL_TYPE_PURE_BITVECTOR, "Right operand of %s op is not a bitvector.\n", rz_il_op_pure_code_stringify(op->code));
+	VALIDATOR_ASSERT(sx.props.bv.length == sy.props.bv.length, "Operand sizes of %s op do not agree: %u vs. %u.\n",
+		rz_il_op_pure_code_stringify(op->code), (unsigned int)sx.props.bv.length, (unsigned int)sy.props.bv.length);
+	*sort_out = sx;
+	return true;
+}
+
+static ValidatePureFn validate_pure_table[RZ_IL_OP_PURE_MAX] = {
+	[RZ_IL_OP_VAR] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_ITE] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_LET] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_B0] = VALIDATOR_PURE_NAME(bool_const),
+	[RZ_IL_OP_B1] = VALIDATOR_PURE_NAME(bool_const),
+	[RZ_IL_OP_INV] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_AND] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_OR] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_XOR] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_BITV] = VALIDATOR_PURE_NAME(bitv),
+	[RZ_IL_OP_MSB] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_LSB] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_IS_ZERO] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_NEG] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_LOGNOT] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_ADD] = VALIDATOR_PURE_NAME(bitv_binop),
+	[RZ_IL_OP_SUB] = VALIDATOR_PURE_NAME(bitv_binop),
+	[RZ_IL_OP_MUL] = VALIDATOR_PURE_NAME(bitv_binop),
+	[RZ_IL_OP_DIV] = VALIDATOR_PURE_NAME(bitv_binop),
+	[RZ_IL_OP_MOD] = VALIDATOR_PURE_NAME(bitv_binop),
+	[RZ_IL_OP_SDIV] = VALIDATOR_PURE_NAME(bitv_binop),
+	[RZ_IL_OP_SMOD] = VALIDATOR_PURE_NAME(bitv_binop),
+	[RZ_IL_OP_LOGAND] = VALIDATOR_PURE_NAME(bitv_binop),
+	[RZ_IL_OP_LOGOR] = VALIDATOR_PURE_NAME(bitv_binop),
+	[RZ_IL_OP_LOGXOR] = VALIDATOR_PURE_NAME(bitv_binop),
+	[RZ_IL_OP_SHIFTR] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_SHIFTL] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_EQ] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_SLE] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_ULE] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_CAST] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_CONCAT] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_APPEND] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_LOAD] = VALIDATOR_PURE_NAME(invalid),
+	[RZ_IL_OP_LOADW] = VALIDATOR_PURE_NAME(invalid)
+};
+
+static bool validate_pure(RZ_NULLABLE RzILOpPure *op, RZ_NONNULL RzILSortPure *sort_out, RZ_NONNULL RzStrBuf *report_builder) {
+	if (!op) {
+		rz_strbuf_appendf(report_builder, "Encountered NULL for pure op.\n");
+		return false;
+	}
+	ValidatePureFn validator = validate_pure_table[op->code];
+	rz_return_val_if_fail(validator, false);
+	return validator(op, sort_out, report_builder);
+}
+
+/////////////////////////////////////////////////////////
+// ----------------------- effect -----------------------
+
+RZ_API bool rz_il_validate_pure(RZ_NULLABLE RzILOpPure *op, RZ_NULLABLE RZ_OUT RzILSortPure *sort_out, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out) {
+	RzStrBuf report_builder;
+	rz_strbuf_init(&report_builder);
+	RzILSortPure sort = { 0 };
+	bool valid = validate_pure(op, &sort, &report_builder);
+	if (sort_out) {
+		*sort_out = sort;
+	}
+	if (report_out) {
+		*report_out = rz_strbuf_is_empty(&report_builder) ? NULL : rz_str_trim_tail(rz_strbuf_drain_nofree(&report_builder));
+	}
+	rz_strbuf_fini(&report_builder);
+	return valid;
+}
+
+RZ_API bool rz_il_validate_effect(RZ_NULLABLE RzILOpEffect *op, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out) {
+	return false;
+}

--- a/librz/il/il_vm.c
+++ b/librz/il/il_vm.c
@@ -148,6 +148,13 @@ RZ_API void rz_il_vm_free(RzILVM *vm) {
 }
 
 /**
+ * Get the number of bits of the program counter bitvector
+ */
+RZ_API ut32 rz_il_vm_get_pc_len(RzILVM *vm) {
+	return rz_bv_len(vm->pc);
+}
+
+/**
  * Add a memory to VM at the given index.
  * Ownership of the memory is transferred to the VM.
  */

--- a/librz/il/il_vm_eval.c
+++ b/librz/il/il_vm_eval.c
@@ -12,7 +12,6 @@
 void *rz_il_handler_ite(RzILVM *vm, RzILOpPure *op, RzILTypePure *type);
 void *rz_il_handler_var(RzILVM *vm, RzILOpPure *op, RzILTypePure *type);
 void *rz_il_handler_let(RzILVM *vm, RzILOpPure *op, RzILTypePure *type);
-void *rz_il_handler_unk(RzILVM *vm, RzILOpPure *op, RzILTypePure *type);
 
 void *rz_il_handler_bitv(RzILVM *vm, RzILOpPure *op, RzILTypePure *type);
 void *rz_il_handler_msb(RzILVM *vm, RzILOpPure *op, RzILTypePure *type);
@@ -66,7 +65,6 @@ bool rz_il_handler_effect_unimplemented(RzILVM *vm, RzILOpEffect *op);
 
 RZ_IPI RzILOpPureHandler rz_il_op_handler_pure_table_default[RZ_IL_OP_PURE_MAX] = {
 	[RZ_IL_OP_VAR] = rz_il_handler_var,
-	[RZ_IL_OP_UNK] = rz_il_handler_unk,
 	[RZ_IL_OP_ITE] = rz_il_handler_ite,
 	[RZ_IL_OP_LET] = rz_il_handler_let,
 	[RZ_IL_OP_B0] = rz_il_handler_bool_false,

--- a/librz/il/il_vm_eval.c
+++ b/librz/il/il_vm_eval.c
@@ -95,7 +95,6 @@ RZ_IPI RzILOpPureHandler rz_il_op_handler_pure_table_default[RZ_IL_OP_PURE_MAX] 
 	[RZ_IL_OP_SLE] = rz_il_handler_sle,
 	[RZ_IL_OP_ULE] = rz_il_handler_ule,
 	[RZ_IL_OP_CAST] = rz_il_handler_cast,
-	[RZ_IL_OP_CONCAT] = rz_il_handler_pure_unimplemented,
 	[RZ_IL_OP_APPEND] = rz_il_handler_append,
 	[RZ_IL_OP_LOAD] = rz_il_handler_load,
 	[RZ_IL_OP_LOADW] = rz_il_handler_loadw,

--- a/librz/il/meson.build
+++ b/librz/il/meson.build
@@ -13,6 +13,7 @@ rz_il_sources = [
    'il_export.c',
    'il_events.c',
    'il_reg.c',
+   'il_validate.c',
    'il_vm.c',
    'il_vm_eval.c',
 ]

--- a/librz/il/theory_init.c
+++ b/librz/il/theory_init.c
@@ -81,11 +81,6 @@ void *rz_il_handler_let(RzILVM *vm, RzILOpPure *op, RzILTypePure *type) {
 	return r;
 }
 
-void *rz_il_handler_unk(RzILVM *vm, RzILOpPure *op, RzILTypePure *type) {
-	rz_return_val_if_fail(vm && op && type, NULL);
-	return NULL;
-}
-
 void *rz_il_handler_pure_unimplemented(RzILVM *vm, RzILOpPure *op, RzILTypePure *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 	RZ_LOG_ERROR("RzIL: unimplemented op handler (%d).\n", (int)op->code);

--- a/librz/include/meson.build
+++ b/librz/include/meson.build
@@ -130,6 +130,7 @@ rz_il_files = [
   'rz_il/rz_il_opcodes.h',
   'rz_il/rz_il_events.h',
   'rz_il/rz_il_reg.h',
+  'rz_il/rz_il_validate.h',
   'rz_il/rz_il_vm.h'
 ]
 install_headers(rz_il_files, install_dir: join_paths(rizin_incdir, 'rz_il'))

--- a/librz/include/rz_il.h
+++ b/librz/include/rz_il.h
@@ -1,6 +1,7 @@
 #ifndef RZ_IL_H
 #define RZ_IL_H
 
+#include <rz_il/rz_il_validate.h>
 #include <rz_il/rz_il_vm.h>
 #include <rz_il/rz_il_opcodes.h>
 #include <rz_il/rz_il_reg.h>

--- a/librz/include/rz_il/definitions/sort.h
+++ b/librz/include/rz_il/definitions/sort.h
@@ -59,7 +59,7 @@ static inline RzILSortPure rz_il_sort_pure_bv(ut32 length) {
 	return r;
 }
 
-RZ_API char *rz_il_sort_pure_stringify(RzILSortPure sort);
+RZ_API RZ_OWN char *rz_il_sort_pure_stringify(RzILSortPure sort);
 
 #ifdef __cplusplus
 }

--- a/librz/include/rz_il/definitions/sort.h
+++ b/librz/include/rz_il/definitions/sort.h
@@ -59,6 +59,8 @@ static inline RzILSortPure rz_il_sort_pure_bv(ut32 length) {
 	return r;
 }
 
+RZ_API char *rz_il_sort_pure_stringify(RzILSortPure sort);
+
 #ifdef __cplusplus
 }
 #endif

--- a/librz/include/rz_il/rz_il_events.h
+++ b/librz/include/rz_il/rz_il_events.h
@@ -72,6 +72,10 @@ RZ_API RZ_OWN RzILEvent *rz_il_event_mem_write_new(RZ_NONNULL const RzBitVector 
 RZ_API RZ_OWN RzILEvent *rz_il_event_var_write_new(RZ_NONNULL const char *name, RZ_NULLABLE const RzBitVector *old_v, RZ_NONNULL const RzBitVector *new_v);
 RZ_API void rz_il_event_free(RZ_NULLABLE RzILEvent *evt);
 
+// Printing/Export
+RZ_API void rz_il_event_stringify(RZ_NONNULL RzILEvent *evt, RZ_NONNULL RzStrBuf *sb);
+RZ_API void rz_il_event_json(RZ_NONNULL RzILEvent *evt, RZ_NONNULL PJ *pj);
+
 #ifdef __cplusplus
 }
 #endif

--- a/librz/include/rz_il/rz_il_opcodes.h
+++ b/librz/include/rz_il/rz_il_opcodes.h
@@ -347,7 +347,6 @@ typedef struct rz_il_op_args_storew_t {
 typedef enum {
 	// Init
 	RZ_IL_OP_VAR,
-	RZ_IL_OP_UNK,
 	RZ_IL_OP_ITE,
 	RZ_IL_OP_LET,
 
@@ -447,7 +446,6 @@ RZ_API void rz_il_op_pure_free(RZ_NULLABLE RzILOpPure *op);
 RZ_API RzILOpPure *rz_il_op_pure_dup(RZ_NONNULL RzILOpPure *op);
 
 RZ_API RZ_OWN RzILOpPure *rz_il_op_new_ite(RZ_NONNULL RzILOpPure *condition, RZ_NULLABLE RzILOpPure *x, RZ_NULLABLE RzILOpPure *y);
-RZ_API RZ_OWN RzILOpPure *rz_il_op_new_unk();
 RZ_API RZ_OWN RzILOpPure *rz_il_op_new_var(RZ_NONNULL const char *var, RzILVarKind kind);
 RZ_API RZ_OWN RzILOpPure *rz_il_op_new_let(RZ_NONNULL const char *name, RZ_NONNULL RzILOpPure *exp, RZ_NONNULL RzILOpPure *body);
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_b0();
@@ -537,6 +535,15 @@ RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_branch(RZ_NONNULL RzILOpBool *condition
 
 RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_store(RzILMemIndex mem, RZ_NONNULL RzILOpBitVector *key, RZ_NONNULL RzILOpBitVector *value);
 RZ_API RZ_OWN RzILOpEffect *rz_il_op_new_storew(RzILMemIndex mem, RZ_NONNULL RzILOpBitVector *key, RZ_NONNULL RzILOpBitVector *value);
+
+// Printing/Export
+RZ_API RZ_NONNULL const char *rz_il_op_pure_code_stringify(RzILOpPureCode code);
+
+RZ_API void rz_il_op_pure_stringify(RZ_NONNULL RzILOpPure *op, RZ_NONNULL RzStrBuf *sb);
+RZ_API void rz_il_op_effect_stringify(RZ_NONNULL RzILOpEffect *op, RZ_NONNULL RzStrBuf *sb);
+
+RZ_API void rz_il_op_pure_json(RZ_NONNULL RzILOpPure *op, RZ_NONNULL PJ *pj);
+RZ_API void rz_il_op_effect_json(RZ_NONNULL RzILOpEffect *op, RZ_NONNULL PJ *pj);
 
 #ifdef __cplusplus
 }

--- a/librz/include/rz_il/rz_il_opcodes.h
+++ b/librz/include/rz_il/rz_il_opcodes.h
@@ -67,22 +67,18 @@ typedef struct rz_il_op_args_un_bv_b_t RzILOpArgsLsb;
 typedef struct rz_il_op_args_un_bv_b_t RzILOpArgsIsZero;
 
 /**
- *  \brief op structure for `neg` ('s bitv -> 's bitv)
- *
- *  neg x is two-complement unary minus
+ * op structure for
+ * `not` ('s bitv -> 's bitv)
+ *   not x is one-complement negation.
+ * `neg` ('s bitv -> 's bitv)
+ *   neg x is two-complement unary minus
  */
-typedef struct rz_il_op_args_neg_t {
+struct rz_il_op_args_bv_unop_t {
 	RzILOpBitVector *bv; ///< unary operand
-} RzILOpArgsNeg;
+};
 
-/**
- *  \brief op structure for `not` ('s bitv -> 's bitv)
- *
- *  not x is one-complement negation.
- */
-typedef struct rz_il_op_args_logical_not_t {
-	RzILOpBitVector *bv; ///< unary operand
-} RzILOpArgsLogNot;
+typedef struct rz_il_op_args_bv_unop_t RzILOpArgsLogNot;
+typedef struct rz_il_op_args_bv_unop_t RzILOpArgsNeg;
 
 /**
  *  \brief op structure for two-operand algorithm and logical operations ('s bitv -> 's bitv -> 's bitv)
@@ -381,7 +377,6 @@ typedef enum {
 	RZ_IL_OP_SLE,
 	RZ_IL_OP_ULE,
 	RZ_IL_OP_CAST,
-	RZ_IL_OP_CONCAT,
 	RZ_IL_OP_APPEND,
 	// ...
 

--- a/librz/include/rz_il/rz_il_validate.h
+++ b/librz/include/rz_il/rz_il_validate.h
@@ -17,11 +17,13 @@ extern "C" {
 
 typedef char *RzILValidateReport;
 
-typedef struct rz_il_validate_context_t RzILValidateContext;
+typedef struct rz_il_validate_global_context_t RzILValidateGlobalContext;
 
-RZ_API RzILValidateContext *rz_il_validate_context_new_from_vm(RzILVM *vm);
-RZ_API void rz_il_validate_context_free(RzILValidateContext *ctx);
-RZ_API bool rz_il_validate_pure(RZ_NULLABLE RzILOpPure *op, RZ_NULLABLE RZ_OUT RzILSortPure *sort_out, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out);
+RZ_API RzILValidateGlobalContext *rz_il_validate_global_context_new_empty();
+RZ_API RzILValidateGlobalContext *rz_il_validate_global_context_new_from_vm(RzILVM *vm);
+RZ_API void rz_il_validate_global_context_free(RzILValidateGlobalContext *ctx);
+RZ_API bool rz_il_validate_pure(RZ_NULLABLE RzILOpPure *op, RZ_NONNULL RzILValidateGlobalContext *ctx,
+	RZ_NULLABLE RZ_OUT RzILSortPure *sort_out, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out);
 RZ_API bool rz_il_validate_effect(RZ_NULLABLE RzILOpEffect *op, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out);
 
 #ifdef __cplusplus

--- a/librz/include/rz_il/rz_il_validate.h
+++ b/librz/include/rz_il/rz_il_validate.h
@@ -20,6 +20,8 @@ typedef char *RzILValidateReport;
 typedef struct rz_il_validate_global_context_t RzILValidateGlobalContext;
 
 RZ_API RzILValidateGlobalContext *rz_il_validate_global_context_new_empty();
+RZ_API void rz_il_validate_global_context_add_var(RzILValidateGlobalContext *ctx, const char *name, RzILSortPure sort);
+RZ_API void rz_il_validate_global_context_add_mem(RzILValidateGlobalContext *ctx, RzILMemIndex idx, ut32 key_len, ut32 val_len);
 RZ_API RzILValidateGlobalContext *rz_il_validate_global_context_new_from_vm(RzILVM *vm);
 RZ_API void rz_il_validate_global_context_free(RzILValidateGlobalContext *ctx);
 RZ_API bool rz_il_validate_pure(RZ_NULLABLE RzILOpPure *op, RZ_NONNULL RzILValidateGlobalContext *ctx,

--- a/librz/include/rz_il/rz_il_validate.h
+++ b/librz/include/rz_il/rz_il_validate.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2022 Florian Märkl <info@florianmaerkl.de>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef RZ_IL_VALIDATE_H
+#define RZ_IL_VALIDATE_H
+
+#include <rz_il/rz_il_vm.h>
+
+/**
+ * \file
+ * \brief Validation/Type Checking of RzIL Code
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef char *RzILValidateReport;
+
+typedef struct rz_il_validate_context_t RzILValidateContext;
+
+RZ_API RzILValidateContext *rz_il_validate_context_new_from_vm(RzILVM *vm);
+RZ_API void rz_il_validate_context_free(RzILValidateContext *ctx);
+RZ_API bool rz_il_validate_pure(RZ_NULLABLE RzILOpPure *op, RZ_NULLABLE RZ_OUT RzILSortPure *sort_out, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out);
+RZ_API bool rz_il_validate_effect(RZ_NULLABLE RzILOpEffect *op, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RZ_IL_VALIDATE_H

--- a/librz/include/rz_il/rz_il_validate.h
+++ b/librz/include/rz_il/rz_il_validate.h
@@ -17,6 +17,14 @@ extern "C" {
 
 typedef char *RzILValidateReport;
 
+/**
+ * Global context for validation, defining:
+ *  * all global variables with their sorts
+ *  * all mems with their key and value lengths
+ * Validation can only be performes when this context is known,
+ * as for example the type of a var op referring to a global var
+ * depends on this.
+ */
 typedef struct rz_il_validate_global_context_t RzILValidateGlobalContext;
 
 RZ_API RzILValidateGlobalContext *rz_il_validate_global_context_new_empty(ut32 pc_len);
@@ -26,8 +34,9 @@ RZ_API RzILValidateGlobalContext *rz_il_validate_global_context_new_from_vm(RZ_N
 RZ_API void rz_il_validate_global_context_free(RzILValidateGlobalContext *ctx);
 RZ_API bool rz_il_validate_pure(RZ_NULLABLE RzILOpPure *op, RZ_NONNULL RzILValidateGlobalContext *ctx,
 	RZ_NULLABLE RZ_OUT RzILSortPure *sort_out, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out);
-RZ_API bool rz_il_validate_effect(RZ_NULLABLE RzILOpEffect *op, RZ_OUT RZ_NULLABLE HtPP /* <const char *, RzILSortPure *> */ **local_var_sorts_out,
-	RZ_NONNULL RzILValidateGlobalContext *ctx, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out);
+RZ_API bool rz_il_validate_effect(RZ_NULLABLE RzILOpEffect *op, RZ_NONNULL RzILValidateGlobalContext *ctx,
+	RZ_NULLABLE RZ_OUT HtPP /* <const char *, RzILSortPure *> */ **local_var_sorts_out,
+	RZ_NULLABLE RZ_OUT RzILValidateReport *report_out);
 
 #ifdef __cplusplus
 }

--- a/librz/include/rz_il/rz_il_validate.h
+++ b/librz/include/rz_il/rz_il_validate.h
@@ -19,14 +19,15 @@ typedef char *RzILValidateReport;
 
 typedef struct rz_il_validate_global_context_t RzILValidateGlobalContext;
 
-RZ_API RzILValidateGlobalContext *rz_il_validate_global_context_new_empty();
+RZ_API RzILValidateGlobalContext *rz_il_validate_global_context_new_empty(ut32 pc_len);
 RZ_API void rz_il_validate_global_context_add_var(RzILValidateGlobalContext *ctx, const char *name, RzILSortPure sort);
 RZ_API void rz_il_validate_global_context_add_mem(RzILValidateGlobalContext *ctx, RzILMemIndex idx, ut32 key_len, ut32 val_len);
-RZ_API RzILValidateGlobalContext *rz_il_validate_global_context_new_from_vm(RzILVM *vm);
+RZ_API RzILValidateGlobalContext *rz_il_validate_global_context_new_from_vm(RZ_NONNULL RzILVM *vm);
 RZ_API void rz_il_validate_global_context_free(RzILValidateGlobalContext *ctx);
 RZ_API bool rz_il_validate_pure(RZ_NULLABLE RzILOpPure *op, RZ_NONNULL RzILValidateGlobalContext *ctx,
 	RZ_NULLABLE RZ_OUT RzILSortPure *sort_out, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out);
-RZ_API bool rz_il_validate_effect(RZ_NULLABLE RzILOpEffect *op, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out);
+RZ_API bool rz_il_validate_effect(RZ_NULLABLE RzILOpEffect *op, RZ_OUT RZ_NULLABLE HtPP /* <const char *, RzILSortPure *> */ **local_var_sorts_out,
+	RZ_NONNULL RzILValidateGlobalContext *ctx, RZ_NULLABLE RZ_OUT RzILValidateReport *report_out);
 
 #ifdef __cplusplus
 }

--- a/librz/include/rz_il/rz_il_validate.h
+++ b/librz/include/rz_il/rz_il_validate.h
@@ -28,7 +28,7 @@ typedef char *RzILValidateReport;
 typedef struct rz_il_validate_global_context_t RzILValidateGlobalContext;
 
 RZ_API RzILValidateGlobalContext *rz_il_validate_global_context_new_empty(ut32 pc_len);
-RZ_API void rz_il_validate_global_context_add_var(RzILValidateGlobalContext *ctx, const char *name, RzILSortPure sort);
+RZ_API void rz_il_validate_global_context_add_var(RzILValidateGlobalContext *ctx, RZ_NONNULL const char *name, RzILSortPure sort);
 RZ_API void rz_il_validate_global_context_add_mem(RzILValidateGlobalContext *ctx, RzILMemIndex idx, ut32 key_len, ut32 val_len);
 RZ_API RzILValidateGlobalContext *rz_il_validate_global_context_new_from_vm(RZ_NONNULL RzILVM *vm);
 RZ_API void rz_il_validate_global_context_free(RzILValidateGlobalContext *ctx);

--- a/librz/include/rz_il/rz_il_vm.h
+++ b/librz/include/rz_il/rz_il_vm.h
@@ -88,16 +88,6 @@ RZ_API RZ_BORROW RzILVar *rz_il_vm_get_var(RZ_NONNULL RzILVM *vm, RzILVarKind ki
 RZ_API RZ_OWN RzPVector /* <RzILVar> */ *rz_il_vm_get_all_vars(RZ_NONNULL RzILVM *vm, RzILVarKind kind);
 RZ_API RZ_BORROW RzILVal *rz_il_vm_get_var_value(RZ_NONNULL RzILVM *vm, RzILVarKind kind, const char *name);
 
-// Printing/Export
-RZ_API void rz_il_op_pure_stringify(RZ_NONNULL RzILOpPure *op, RZ_NONNULL RzStrBuf *sb);
-RZ_API void rz_il_op_effect_stringify(RZ_NONNULL RzILOpEffect *op, RZ_NONNULL RzStrBuf *sb);
-
-RZ_API void rz_il_op_pure_json(RZ_NONNULL RzILOpPure *op, RZ_NONNULL PJ *pj);
-RZ_API void rz_il_op_effect_json(RZ_NONNULL RzILOpEffect *op, RZ_NONNULL PJ *pj);
-
-RZ_API void rz_il_event_stringify(RZ_NONNULL RzILEvent *evt, RZ_NONNULL RzStrBuf *sb);
-RZ_API void rz_il_event_json(RZ_NONNULL RzILEvent *evt, RZ_NONNULL PJ *pj);
-
 // Evaluation (Emulation)
 RZ_API RZ_NULLABLE RZ_OWN RzBitVector *rz_il_evaluate_bitv(RZ_NONNULL RzILVM *vm, RZ_NONNULL RzILOpBitVector *op);
 RZ_API RZ_NULLABLE RZ_OWN RzILBool *rz_il_evaluate_bool(RZ_NONNULL RzILVM *vm, RZ_NONNULL RzILOpBool *op);

--- a/librz/include/rz_il/rz_il_vm.h
+++ b/librz/include/rz_il/rz_il_vm.h
@@ -58,6 +58,8 @@ RZ_API void rz_il_vm_free(RzILVM *vm);
 RZ_API bool rz_il_vm_init(RzILVM *vm, ut64 start_addr, ut32 addr_size, bool big_endian);
 RZ_API void rz_il_vm_fini(RzILVM *vm);
 
+RZ_API ut32 rz_il_vm_get_pc_len(RzILVM *vm);
+
 // VM Event operations
 RZ_API void rz_il_vm_event_add(RzILVM *vm, RzILEvent *evt);
 

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -155,7 +155,7 @@ RZ_API char *rz_str_trim_lines(char *str);
 RZ_API void rz_str_trim_head(char *str);
 RZ_API const char *rz_str_trim_head_ro(const char *str);
 RZ_API const char *rz_str_trim_head_wp(const char *str);
-RZ_API char *rz_str_trim_tail(char *str);
+RZ_API RZ_BORROW char *rz_str_trim_tail(RZ_NONNULL char *str);
 RZ_API ut32 rz_str_hash(const char *str);
 RZ_API ut64 rz_str_hash64(const char *str);
 RZ_API char *rz_str_trim_nc(char *str);

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -155,7 +155,7 @@ RZ_API char *rz_str_trim_lines(char *str);
 RZ_API void rz_str_trim_head(char *str);
 RZ_API const char *rz_str_trim_head_ro(const char *str);
 RZ_API const char *rz_str_trim_head_wp(const char *str);
-RZ_API void rz_str_trim_tail(char *str);
+RZ_API char *rz_str_trim_tail(char *str);
 RZ_API ut32 rz_str_hash(const char *str);
 RZ_API ut64 rz_str_hash64(const char *str);
 RZ_API char *rz_str_trim_nc(char *str);

--- a/librz/util/str_trim.c
+++ b/librz/util/str_trim.c
@@ -113,7 +113,7 @@ RZ_API void rz_str_trim_head(char *str) {
  * Remove whitespace chars from the tail of the string, replacing them with null bytes. The string is changed in-place.
  * \return the string itself
  */
-RZ_API char *rz_str_trim_tail(char *str) {
+RZ_API RZ_BORROW char *rz_str_trim_tail(RZ_NONNULL char *str) {
 	rz_return_val_if_fail(str, str);
 	size_t length = strlen(str);
 	while (length-- > 0) {

--- a/librz/util/str_trim.c
+++ b/librz/util/str_trim.c
@@ -109,10 +109,12 @@ RZ_API void rz_str_trim_head(char *str) {
 	}
 }
 
-// Remove whitespace chars from the tail of the string, replacing them with
-// null bytes. The string is changed in-place.
-RZ_API void rz_str_trim_tail(char *str) {
-	rz_return_if_fail(str);
+/**
+ * Remove whitespace chars from the tail of the string, replacing them with null bytes. The string is changed in-place.
+ * \return the string itself
+ */
+RZ_API char *rz_str_trim_tail(char *str) {
+	rz_return_val_if_fail(str, str);
 	size_t length = strlen(str);
 	while (length-- > 0) {
 		if (IS_WHITECHAR(str[length])) {
@@ -121,6 +123,7 @@ RZ_API void rz_str_trim_tail(char *str) {
 			break;
 		}
 	}
+	return str;
 }
 
 // Removes spaces from the head of the string, and zeros out whitespaces from

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -63,6 +63,7 @@ if get_option('enable_tests')
     'inflate_deflate',
     'il_definitions',
     'il_reg',
+    'il_validate',
     'il_vm',
     'intervaltree',
     'io',

--- a/test/unit/test_il_definitions.c
+++ b/test/unit/test_il_definitions.c
@@ -9,7 +9,7 @@ static bool is_equal_bool(RzILBool *x, RzILBool *y) {
 	return x->b == y->b;
 }
 
-bool test_rzil_bool_init(void) {
+bool test_il_bool_init(void) {
 	RzILBool *b = rz_il_bool_new(true);
 	mu_assert_notnull(b, "New RzILBool");
 	mu_assert_eq(b->b, true, "bool is true");
@@ -17,7 +17,7 @@ bool test_rzil_bool_init(void) {
 	mu_end;
 }
 
-bool test_rzil_bool_logic(void) {
+bool test_il_bool_logic(void) {
 	RzILBool *t = rz_il_bool_new(true);
 	RzILBool *f = rz_il_bool_new(false);
 	RzILBool *result;
@@ -86,7 +86,7 @@ bool test_rzil_bool_logic(void) {
 	mu_end;
 }
 
-static bool test_rzil_mem_load() {
+static bool test_il_mem_load() {
 	ut8 data[] = { 0x0, 0x0, 0x0, 0x0, 0x0, 0x42, 0x0, 0x0 };
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
 	rz_buf_set_overflow_byte(buf, 0xaa);
@@ -122,7 +122,7 @@ static bool test_rzil_mem_load() {
 	mu_end;
 }
 
-static bool test_rzil_mem_store() {
+static bool test_il_mem_store() {
 	ut8 data[] = { 0x0, 0x0, 0x0, 0x0, 0x0, 0x42, 0x0, 0x0 };
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
 	RzILMem *mem = rz_il_mem_new(buf, 16);
@@ -160,7 +160,7 @@ static bool test_rzil_mem_store() {
 	mu_end;
 }
 
-static bool test_rzil_mem_loadw() {
+static bool test_il_mem_loadw() {
 	ut8 data[] = { 0x0, 0x0, 0x0, 0x0, 0x13, 0x37, 0x0, 0x0 };
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
 	rz_buf_set_overflow_byte(buf, 0xaa);
@@ -204,7 +204,7 @@ static bool test_rzil_mem_loadw() {
 	mu_end;
 }
 
-static bool test_rzil_mem_storew() {
+static bool test_il_mem_storew() {
 	ut8 data[] = { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
 	RzILMem *mem = rz_il_mem_new(buf, 32);
@@ -240,7 +240,7 @@ static bool test_rzil_mem_storew() {
 	mu_end;
 }
 
-static bool test_rzil_seqn() {
+static bool test_il_seqn() {
 	// n = 0 ==> just a nop
 	RzILOpEffect *s = rz_il_op_new_seqn(0);
 	mu_assert_notnull(s, "seqn 0");
@@ -299,14 +299,29 @@ static bool test_rzil_seqn() {
 	mu_end;
 }
 
+static bool test_il_sort_pure_eq() {
+	bool r = rz_il_sort_pure_eq(rz_il_sort_pure_bool(), rz_il_sort_pure_bool());
+	mu_assert_true(r, "sort eq");
+	r = rz_il_sort_pure_eq(rz_il_sort_pure_bv(32), rz_il_sort_pure_bv(32));
+	mu_assert_true(r, "sort eq");
+	r = rz_il_sort_pure_eq(rz_il_sort_pure_bv(32), rz_il_sort_pure_bv(31));
+	mu_assert_false(r, "sort eq");
+	r = rz_il_sort_pure_eq(rz_il_sort_pure_bool(), rz_il_sort_pure_bv(32));
+	mu_assert_false(r, "sort eq");
+	r = rz_il_sort_pure_eq(rz_il_sort_pure_bv(32), rz_il_sort_pure_bool());
+	mu_assert_false(r, "sort eq");
+	mu_end;
+}
+
 bool all_tests() {
-	mu_run_test(test_rzil_bool_init);
-	mu_run_test(test_rzil_bool_logic);
-	mu_run_test(test_rzil_mem_load);
-	mu_run_test(test_rzil_mem_store);
-	mu_run_test(test_rzil_mem_loadw);
-	mu_run_test(test_rzil_mem_storew);
-	mu_run_test(test_rzil_seqn);
+	mu_run_test(test_il_bool_init);
+	mu_run_test(test_il_bool_logic);
+	mu_run_test(test_il_mem_load);
+	mu_run_test(test_il_mem_store);
+	mu_run_test(test_il_mem_loadw);
+	mu_run_test(test_il_mem_storew);
+	mu_run_test(test_il_seqn);
+	mu_run_test(test_il_sort_pure_eq);
 	return tests_passed != tests_run;
 }
 

--- a/test/unit/test_il_validate.c
+++ b/test/unit/test_il_validate.c
@@ -45,43 +45,36 @@ static bool test_il_validate_pure_bitv() {
 	mu_end;
 }
 
-static bool test_il_validate_pure_bitv_binop() {
+static bool test_il_validate_pure_ite() {
 	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
 
-	RzILOpPure *op = rz_il_op_new_add(
-		rz_il_op_new_bitv_from_ut64(64, 123),
-		rz_il_op_new_bitv_from_ut64(64, 456));
+	RzILOpPure *op = rz_il_op_new_ite(rz_il_op_new_b0(), rz_il_op_new_bitv_from_ut64(32, 0), rz_il_op_new_bitv_from_ut64(32, 0));
 	RzILSortPure sort;
 	RzILValidateReport report;
 	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
 	mu_assert_true(val, "valid");
-	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(64)), "sort");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(32)), "sort");
 	mu_assert_null(report, "no report");
 	rz_il_op_pure_free(op);
 
-	op = rz_il_op_new_add(
-		rz_il_op_new_bitv_from_ut64(63, 123),
-		rz_il_op_new_bitv_from_ut64(64, 456));
+	op = rz_il_op_new_ite(rz_il_op_new_b0(), rz_il_op_new_b0(), rz_il_op_new_b1());
 	val = rz_il_validate_pure(op, ctx, &sort, &report);
-	mu_assert_false(val, "invalid");
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bool()), "sort");
+	mu_assert_null(report, "no report");
 	rz_il_op_pure_free(op);
-	mu_assert_streq_free(report, "Operand sizes of add op do not agree: 63 vs. 64.", "report");
 
-	op = rz_il_op_new_add(
-		rz_il_op_new_b0(),
-		rz_il_op_new_bitv_from_ut64(64, 456));
+	op = rz_il_op_new_ite(rz_il_op_new_bitv_from_ut64(12, 0), rz_il_op_new_bitv_from_ut64(32, 0), rz_il_op_new_bitv_from_ut64(32, 0));
 	val = rz_il_validate_pure(op, ctx, &sort, &report);
-	mu_assert_false(val, "invalid");
+	mu_assert_false(val, "valid");
+	mu_assert_streq_free(report, "Condition of ite op is not boolean.", "report");
 	rz_il_op_pure_free(op);
-	mu_assert_streq_free(report, "Left operand of add op is not a bitvector.", "report");
 
-	op = rz_il_op_new_add(
-		rz_il_op_new_bitv_from_ut64(64, 456),
-		rz_il_op_new_b0());
+	op = rz_il_op_new_ite(rz_il_op_new_b0(), rz_il_op_new_bitv_from_ut64(32, 0), rz_il_op_new_bitv_from_ut64(31, 0));
 	val = rz_il_validate_pure(op, ctx, &sort, &report);
-	mu_assert_false(val, "invalid");
+	mu_assert_false(val, "valid");
+	mu_assert_streq_free(report, "Types of ite branches do not agree: bitvector:32 vs. bitvector:31.", "report");
 	rz_il_op_pure_free(op);
-	mu_assert_streq_free(report, "Right operand of add op is not a bitvector.", "report");
 
 	rz_il_validate_global_context_free(ctx);
 	mu_end;
@@ -162,11 +155,410 @@ static bool test_il_validate_pure_let() {
 	mu_end;
 }
 
+static bool test_il_validate_pure_var() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+	rz_il_validate_global_context_add_var(ctx, "y", rz_il_sort_pure_bv(42));
+
+	RzILOpPure *op = rz_il_op_new_var("y", RZ_IL_VAR_KIND_GLOBAL);
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(42)), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_var("x", RZ_IL_VAR_KIND_GLOBAL);
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	mu_assert_streq_free(report, "Global variable \"x\" referenced by var op does not exist.", "report");
+	rz_il_op_pure_free(op);
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_validate_pure_inv() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+
+	RzILOpPure *op = rz_il_op_new_bool_inv(rz_il_op_new_b0());
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bool()), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_bool_inv(rz_il_op_new_bitv_from_ut64(32, 0));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Operand of boolean inv op is not boolean.", "report");
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_validate_pure_bool_binop() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+
+	RzILOpPure *op = rz_il_op_new_bool_and(
+		rz_il_op_new_b0(),
+		rz_il_op_new_b1());
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bool()), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_bool_and(
+		rz_il_op_new_b0(),
+		rz_il_op_new_bitv_from_ut64(64, 456));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Right operand of and op is not bool.", "report");
+
+	op = rz_il_op_new_bool_and(
+		rz_il_op_new_bitv_from_ut64(64, 456),
+		rz_il_op_new_b0());
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Left operand of and op is not bool.", "report");
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_validate_pure_bitv_binop() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+
+	RzILOpPure *op = rz_il_op_new_add(
+		rz_il_op_new_bitv_from_ut64(64, 123),
+		rz_il_op_new_bitv_from_ut64(64, 456));
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(64)), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_add(
+		rz_il_op_new_bitv_from_ut64(63, 123),
+		rz_il_op_new_bitv_from_ut64(64, 456));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Operand sizes of add op do not agree: 63 vs. 64.", "report");
+
+	op = rz_il_op_new_add(
+		rz_il_op_new_b0(),
+		rz_il_op_new_bitv_from_ut64(64, 456));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Left operand of add op is not a bitvector.", "report");
+
+	op = rz_il_op_new_add(
+		rz_il_op_new_bitv_from_ut64(64, 456),
+		rz_il_op_new_b0());
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Right operand of add op is not a bitvector.", "report");
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_validate_pure_bitv_bool_unop() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+
+	RzILOpPure *op = rz_il_op_new_msb(rz_il_op_new_bitv_from_ut64(64, 123));
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bool()), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_msb(rz_il_op_new_b0());
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Operand of msb op is not a bitvector.", "report");
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_validate_pure_bitv_unop() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+
+	RzILOpPure *op = rz_il_op_new_log_not(rz_il_op_new_bitv_from_ut64(64, 123));
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(64)), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_log_not(rz_il_op_new_b0());
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Operand of lognot op is not a bitvector.", "report");
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_validate_pure_shift() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+
+	RzILOpPure *op = rz_il_op_new_shiftl(rz_il_op_new_b0(),
+		rz_il_op_new_bitv_from_ut64(64, 123), rz_il_op_new_bitv_from_ut64(32, 32));
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(64)), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_shiftl(rz_il_op_new_bitv_from_ut64(8, 0),
+		rz_il_op_new_bitv_from_ut64(64, 123), rz_il_op_new_bitv_from_ut64(32, 32));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Fill operand of shiftl op is not bool.", "report");
+
+	op = rz_il_op_new_shiftl(rz_il_op_new_b0(),
+		rz_il_op_new_b0(), rz_il_op_new_bitv_from_ut64(32, 32));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Value operand of shiftl op is not a bitvector.", "report");
+
+	op = rz_il_op_new_shiftl(rz_il_op_new_b0(),
+		rz_il_op_new_bitv_from_ut64(32, 32), rz_il_op_new_b0());
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Distance operand of shiftl op is not a bitvector.", "report");
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_validate_pure_cmp() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+
+	RzILOpPure *op = rz_il_op_new_eq(
+		rz_il_op_new_bitv_from_ut64(64, 123),
+		rz_il_op_new_bitv_from_ut64(64, 456));
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bool()), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_eq(
+		rz_il_op_new_bitv_from_ut64(63, 123),
+		rz_il_op_new_bitv_from_ut64(64, 456));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Operand sizes of eq op do not agree: 63 vs. 64.", "report");
+
+	op = rz_il_op_new_eq(
+		rz_il_op_new_b0(),
+		rz_il_op_new_bitv_from_ut64(64, 456));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Left operand of eq op is not a bitvector.", "report");
+
+	op = rz_il_op_new_eq(
+		rz_il_op_new_bitv_from_ut64(64, 456),
+		rz_il_op_new_b0());
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Right operand of eq op is not a bitvector.", "report");
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_validate_pure_cast() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+
+	RzILOpPure *op = rz_il_op_new_cast(13,
+		rz_il_op_new_b0(),
+		rz_il_op_new_bitv_from_ut64(64, 456));
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(13)), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_cast(13,
+		rz_il_op_new_b0(),
+		rz_il_op_new_bitv_from_ut64(64, 456));
+	op->op.cast.length = 0;
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Length of cast op is 0.", "report");
+
+	op = rz_il_op_new_cast(13,
+		rz_il_op_new_bitv_from_ut64(12, 0),
+		rz_il_op_new_bitv_from_ut64(64, 456));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Fill operand of cast op is not bool.", "report");
+
+	op = rz_il_op_new_cast(13,
+		rz_il_op_new_b0(),
+		rz_il_op_new_b0());
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Value operand of cast op is not a bitvector.", "report");
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_validate_pure_append() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+
+	RzILOpPure *op = rz_il_op_new_append(
+		rz_il_op_new_bitv_from_ut64(64, 123),
+		rz_il_op_new_bitv_from_ut64(41, 456));
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(64 + 41)), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_append(
+		rz_il_op_new_b0(),
+		rz_il_op_new_bitv_from_ut64(64, 456));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "High operand of append op is not a bitvector.", "report");
+
+	op = rz_il_op_new_append(
+		rz_il_op_new_bitv_from_ut64(64, 456),
+		rz_il_op_new_b0());
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Low operand of append op is not a bitvector.", "report");
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_validate_pure_load() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+	rz_il_validate_global_context_add_mem(ctx, 1, 16, 9);
+
+	RzILOpPure *op = rz_il_op_new_load(1, rz_il_op_new_bitv_from_ut64(16, 123));
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(9)), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_load(1, rz_il_op_new_bitv_from_ut64(9, 123));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Length of key operand (9) of load op is not equal to key length 16 of mem 1.", "report");
+
+	op = rz_il_op_new_load(0, rz_il_op_new_bitv_from_ut64(16, 123));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Mem 0 referenced by load op does not exist.", "report");
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_validate_pure_loadw() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+	rz_il_validate_global_context_add_mem(ctx, 1, 16, 9);
+
+	RzILOpPure *op = rz_il_op_new_loadw(1, rz_il_op_new_bitv_from_ut64(16, 123), 32);
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(32)), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_loadw(1, rz_il_op_new_bitv_from_ut64(9, 123), 32);
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Length of key operand (9) of loadw op is not equal to key length 16 of mem 1.", "report");
+
+	op = rz_il_op_new_loadw(0, rz_il_op_new_bitv_from_ut64(16, 123), 32);
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Mem 0 referenced by loadw op does not exist.", "report");
+
+	op = rz_il_op_new_loadw(1, rz_il_op_new_bitv_from_ut64(16, 123), 32);
+	op->op.loadw.n_bits = 0;
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Length of loadw op is 0.", "report");
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_il_validate_pure_bitv);
 	mu_run_test(test_il_validate_pure_bool);
-	mu_run_test(test_il_validate_pure_bitv_binop);
+	mu_run_test(test_il_validate_pure_ite);
 	mu_run_test(test_il_validate_pure_let);
+	mu_run_test(test_il_validate_pure_var);
+	mu_run_test(test_il_validate_pure_inv);
+	mu_run_test(test_il_validate_pure_bool_binop);
+	mu_run_test(test_il_validate_pure_bitv_binop);
+	mu_run_test(test_il_validate_pure_bitv_bool_unop);
+	mu_run_test(test_il_validate_pure_bitv_unop);
+	mu_run_test(test_il_validate_pure_shift);
+	mu_run_test(test_il_validate_pure_cmp);
+	mu_run_test(test_il_validate_pure_cast);
+	mu_run_test(test_il_validate_pure_append);
+	mu_run_test(test_il_validate_pure_load);
+	mu_run_test(test_il_validate_pure_loadw);
 	return tests_passed != tests_run;
 }
 

--- a/test/unit/test_il_validate.c
+++ b/test/unit/test_il_validate.c
@@ -187,7 +187,7 @@ static bool test_il_validate_pure_var() {
 	val = rz_il_validate_effect(eop, ctx, NULL, &report);
 	mu_assert_true(val, "valid");
 	mu_assert_null(report, "no report");
-	rz_il_op_pure_free(op);
+	rz_il_op_effect_free(eop);
 
 	op = rz_il_op_new_var("x", RZ_IL_VAR_KIND_GLOBAL);
 	val = rz_il_validate_pure(op, ctx, &sort, &report);
@@ -207,7 +207,7 @@ static bool test_il_validate_pure_var() {
 	val = rz_il_validate_effect(eop, ctx, NULL, &report);
 	mu_assert_false(val, "invalid");
 	mu_assert_streq_free(report, "Length of dst operand (23) of jmp op is not equal to pc length 24.", "report");
-	rz_il_op_pure_free(op);
+	rz_il_op_effect_free(eop);
 
 	rz_il_validate_global_context_free(ctx);
 	mu_end;

--- a/test/unit/test_il_validate.c
+++ b/test/unit/test_il_validate.c
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2022 Florian Märkl <info@florianmaerkl.de>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_il.h>
+#include <rz_util.h>
+#include "minunit.h"
+
+static bool test_il_validate() {
+	RzILOpPure *op = rz_il_op_new_add(
+		rz_il_op_new_bitv_from_ut64(64, 123),
+		rz_il_op_new_bitv_from_ut64(64, 456));
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(64)), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_add(
+		rz_il_op_new_bitv_from_ut64(63, 123),
+		rz_il_op_new_bitv_from_ut64(64, 456));
+	val = rz_il_validate_pure(op, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Operand sizes of add op do not agree: 63 vs. 64.", "report");
+
+	mu_end;
+}
+
+bool all_tests() {
+	mu_run_test(test_il_validate);
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests)

--- a/test/unit/test_il_validate.c
+++ b/test/unit/test_il_validate.c
@@ -5,13 +5,55 @@
 #include <rz_util.h>
 #include "minunit.h"
 
-static bool test_il_validate() {
+static bool test_il_validate_pure_bool() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+
+	RzILOpPure *op = rz_il_op_new_b0();
+	RzILSortPure sort = rz_il_sort_pure_bv(0xffff);
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bool()), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_b1();
+	sort = rz_il_sort_pure_bv(0xffff);
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bool()), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_validate_pure_bitv() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+
+	RzILOpPure *op = rz_il_op_new_bitv_from_ut64(42, 123);
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(42)), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_validate_pure_bitv_binop() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+
 	RzILOpPure *op = rz_il_op_new_add(
 		rz_il_op_new_bitv_from_ut64(64, 123),
 		rz_il_op_new_bitv_from_ut64(64, 456));
 	RzILSortPure sort;
 	RzILValidateReport report;
-	bool val = rz_il_validate_pure(op, &sort, &report);
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
 	mu_assert_true(val, "valid");
 	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(64)), "sort");
 	mu_assert_null(report, "no report");
@@ -20,16 +62,111 @@ static bool test_il_validate() {
 	op = rz_il_op_new_add(
 		rz_il_op_new_bitv_from_ut64(63, 123),
 		rz_il_op_new_bitv_from_ut64(64, 456));
-	val = rz_il_validate_pure(op, &sort, &report);
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
 	mu_assert_false(val, "invalid");
 	rz_il_op_pure_free(op);
 	mu_assert_streq_free(report, "Operand sizes of add op do not agree: 63 vs. 64.", "report");
 
+	op = rz_il_op_new_add(
+		rz_il_op_new_b0(),
+		rz_il_op_new_bitv_from_ut64(64, 456));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Left operand of add op is not a bitvector.", "report");
+
+	op = rz_il_op_new_add(
+		rz_il_op_new_bitv_from_ut64(64, 456),
+		rz_il_op_new_b0());
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "invalid");
+	rz_il_op_pure_free(op);
+	mu_assert_streq_free(report, "Right operand of add op is not a bitvector.", "report");
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_validate_pure_let() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty();
+
+	// body type
+	RzILOpPure *op = rz_il_op_new_let(
+		"x", rz_il_op_new_b0(),
+		rz_il_op_new_bitv_from_ut64(64, 456));
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(64)), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	// bound
+	op = rz_il_op_new_let(
+		"x", rz_il_op_new_b0(),
+		rz_il_op_new_var("x", RZ_IL_VAR_KIND_LOCAL_PURE));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bool()), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	// shadowing
+	op = rz_il_op_new_let(
+		"x", rz_il_op_new_b0(),
+		rz_il_op_new_let(
+			"y", rz_il_op_new_bitv_from_ut64(32, 123),
+			rz_il_op_new_let(
+				"x", rz_il_op_new_bitv_from_ut64(42, 321),
+				rz_il_op_new_var("x", RZ_IL_VAR_KIND_LOCAL_PURE))));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(42)), "sort");
+	mu_assert_null(report, "no report");
+	free(report);
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_let(
+		"x", rz_il_op_new_b0(),
+		rz_il_op_new_let(
+			"y", rz_il_op_new_bitv_from_ut64(32, 123),
+			rz_il_op_new_let(
+				"x", rz_il_op_new_bitv_from_ut64(42, 321),
+				rz_il_op_new_var("y", RZ_IL_VAR_KIND_LOCAL_PURE))));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_bv(32)), "sort");
+	mu_assert_null(report, "no report");
+	free(report);
+	rz_il_op_pure_free(op);
+
+	// invalid cases
+	op = rz_il_op_new_let(
+		"x", rz_il_op_new_b0(),
+		rz_il_op_new_var("x", RZ_IL_VAR_KIND_LOCAL));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "valid");
+	free(report);
+	rz_il_op_pure_free(op);
+
+	op = rz_il_op_new_let(
+		"x", rz_il_op_new_b0(),
+		rz_il_op_new_var("x", RZ_IL_VAR_KIND_GLOBAL));
+	val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_false(val, "valid");
+	free(report);
+	rz_il_op_pure_free(op);
+
+	rz_il_validate_global_context_free(ctx);
 	mu_end;
 }
 
 bool all_tests() {
-	mu_run_test(test_il_validate);
+	mu_run_test(test_il_validate_pure_bitv);
+	mu_run_test(test_il_validate_pure_bool);
+	mu_run_test(test_il_validate_pure_bitv_binop);
+	mu_run_test(test_il_validate_pure_let);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Well-typed programs cannot go wrong.
  -- Robin Milner

This adds the IL validator, which performs static type-checking of both pure and effect ops among other checks. In particular, assuming the validator is correctly implemented, if it considers an op to be valid under some context, evaluating the op in the vm will never yield a runtime error, that is, an error where the vm itself errors, not an expected error state of the code being executed.
In our case, this includes for example:
* Any kind of type error: Conditions not being bool, bitvector sizes not matching, ...
* Variables not being available when they are accessed
* Using local variables with multiple different types in a single effect
* etc.

Any code that we lift must obey these rules. Thus, any analysis can rely on it.
The plan for this is to use the validator primarily in testing, development of lifters and for IL code coming from the outside.
If our lifting code is covered well enough by tests using the validator, we can omit the validation at runtime.

The only ops that do not have well-defined validation yet are `blk` and `goto` since their semantics, in particular regarding label handling are still a bit vague.
This also removes the `concat` and `unk` ops since they are unimplemented and not needed.

**Test plan**

See the unit tests.