### PR TITLE
Add IL lifting testing to rz-test 

### DIFF
--- a/binrz/rz-test/rz-test.c
+++ b/binrz/rz-test/rz-test.c
@@ -735,6 +735,27 @@ static void print_result_diff(RzTestRunConfig *config, RzTestResultInfo *result)
 			}
 		}
 		// TODO: assembly
+		if (result->test->asm_test->il) {
+			const char *expect = result->test->asm_test->il;
+			const char *actual = result->asm_out->il;
+			const char *report = result->asm_out->il_report;
+			bool il_printed = false;
+			const char *hdr = "-- IL\n";
+			if (expect && actual && strcmp(actual, expect)) {
+				printf("%s", hdr);
+				il_printed = true;
+				print_diff(actual, expect, NULL);
+			}
+			if (report) {
+				if (!il_printed) {
+					printf("%s", hdr);
+					if (actual) {
+						printf("%s\n", actual);
+					}
+				}
+				printf(Color_RED "%s" Color_RESET "\n", report);
+			}
+		}
 		break;
 	case RZ_TEST_TYPE_JSON:
 		break;

--- a/binrz/rz-test/rz_test.h
+++ b/binrz/rz-test/rz_test.h
@@ -99,9 +99,10 @@ typedef struct rz_test_asm_test_t {
 	int bits;
 	int mode;
 	ut64 offset;
-	char *disasm;
-	ut8 *bytes;
+	RZ_NONNULL char *disasm;
+	RZ_NONNULL ut8 *bytes;
 	size_t bytes_size;
+	RZ_NULLABLE char *il;
 } RzAsmTest;
 
 typedef struct rz_test_json_test_t {
@@ -149,8 +150,12 @@ typedef struct rz_test_asm_test_output_t {
 	char *disasm;
 	ut8 *bytes;
 	size_t bytes_size;
+	char *il;
+	char *il_report;
+	bool il_failed;
 	bool as_timeout;
 	bool disas_timeout;
+	bool il_timeout;
 } RzAsmTestOutput;
 
 typedef enum rz_test_test_result_t {

--- a/librz/analysis/op.c
+++ b/librz/analysis/op.c
@@ -53,10 +53,8 @@ RZ_API bool rz_analysis_op_fini(RzAnalysisOp *op) {
 	rz_analysis_switch_op_free(op->switch_op);
 	op->switch_op = NULL;
 	RZ_FREE(op->mnemonic);
-	if (op->rzil_op) {
-		rz_il_op_effect_free(op->rzil_op->op);
-		RZ_FREE(op->rzil_op);
-	}
+	rz_il_op_effect_free(op->il_op);
+	op->il_op = NULL;
 	return true;
 }
 

--- a/librz/analysis/p/analysis_bf.c
+++ b/librz/analysis/p/analysis_bf.c
@@ -304,17 +304,11 @@ static int bf_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *b
 
 	BfContext *ctx = analysis->rzil->user;
 	RzILVM *vm = analysis->rzil->vm;
-	RzILOpEffect *ilop = NULL;
-	op->rzil_op = RZ_NEW0(RzAnalysisRzilOp);
-	if (!op->rzil_op) {
-		RZ_LOG_ERROR("Fail to init rzil op\n");
-		return -1;
-	}
 	ut64 dst = 0LL;
 
 	switch (buf[0]) {
 	case '[':
-		ilop = bf_llimit(vm, ctx, op->id, addr);
+		op->il_op = bf_llimit(vm, ctx, op->id, addr);
 		op->type = RZ_ANALYSIS_OP_TYPE_CJMP;
 		op->fail = addr + 1;
 		buf = rz_mem_dup((void *)buf, len);
@@ -361,31 +355,31 @@ static int bf_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *b
 		free((ut8 *)buf);
 		break;
 	case ']':
-		ilop = bf_rlimit(vm, ctx, op->id, addr);
+		op->il_op = bf_rlimit(vm, ctx, op->id, addr);
 		op->type = RZ_ANALYSIS_OP_TYPE_UJMP;
 		break;
 	case '>':
 		op->type = RZ_ANALYSIS_OP_TYPE_ADD;
-		ilop = bf_right_arrow(vm, op->id);
+		op->il_op = bf_right_arrow(vm, op->id);
 		break;
 	case '<':
 		op->type = RZ_ANALYSIS_OP_TYPE_SUB;
-		ilop = bf_left_arrow(vm, op->id);
+		op->il_op = bf_left_arrow(vm, op->id);
 		break;
 	case '+':
 		op->type = RZ_ANALYSIS_OP_TYPE_ADD;
-		ilop = bf_inc(vm, op->id);
+		op->il_op = bf_inc(vm, op->id);
 		break;
 	case '-':
 		op->type = RZ_ANALYSIS_OP_TYPE_SUB;
-		ilop = bf_dec(vm, op->id);
+		op->il_op = bf_dec(vm, op->id);
 		break;
 	case '.':
-		ilop = bf_out(vm, op->id);
+		op->il_op = bf_out(vm, op->id);
 		op->type = RZ_ANALYSIS_OP_TYPE_STORE;
 		break;
 	case ',':
-		ilop = bf_in(vm, op->id);
+		op->il_op = bf_in(vm, op->id);
 		op->type = RZ_ANALYSIS_OP_TYPE_LOAD;
 		break;
 	case 0x00:
@@ -394,11 +388,8 @@ static int bf_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *b
 		break;
 	default:
 		op->type = RZ_ANALYSIS_OP_TYPE_NOP;
-		ilop = rz_il_op_new_nop();
+		op->il_op = rz_il_op_new_nop();
 		break;
-	}
-	if (ilop) {
-		op->rzil_op->op = ilop;
 	}
 	ctx->op_count++;
 	return op->size;

--- a/librz/analysis/rzil/rzil.c
+++ b/librz/analysis/rzil/rzil.c
@@ -119,7 +119,7 @@ RZ_API bool rz_analysis_rzil_setup(RzAnalysis *analysis) {
 	return true;
 }
 
-static void rz_analysis_rzil_parse_root(RzAnalysis *analysis, RzAnalysisRzil *rzil, RzAnalysisRzilOp *ops) {
+static void rz_analysis_rzil_parse_root(RzAnalysis *analysis, RzAnalysisRzil *rzil, RzAnalysisLiftedILOp ops) {
 	rz_return_if_fail(analysis && rzil);
 
 	// IL disabled
@@ -169,5 +169,5 @@ RZ_API void rz_analysis_rzil_collect_info(RzAnalysis *analysis, RzAnalysisRzil *
 
 	// Parse and emulate IL opcode, and collect `trace` and `stats` info
 	// Use new op struct for parsing
-	rz_analysis_rzil_parse_root(analysis, rzil, op->rzil_op);
+	rz_analysis_rzil_parse_root(analysis, rzil, op->il_op);
 }

--- a/librz/analysis/rzil/rzil_stats.c
+++ b/librz/analysis/rzil/rzil_stats.c
@@ -26,6 +26,6 @@
  * \param analysis RzAnalysis
  * \param op  a general IL op structure (Designed for switching between different implementations of IL op struct)
  */
-RZ_API void rz_analysis_rzil_record_stats(RzAnalysis *analysis, RzAnalysisRzil *rzil, RzAnalysisRzilOp *op) {
+RZ_API void rz_analysis_rzil_record_stats(RzAnalysis *analysis, RzAnalysisRzil *rzil, RzAnalysisLiftedILOp op) {
 	// ready for rewriting this file
 }

--- a/librz/analysis/rzil/rzil_trace.c
+++ b/librz/analysis/rzil/rzil_trace.c
@@ -91,6 +91,6 @@ RZ_API void rz_analysis_rzil_trace_free(RzAnalysisEsilTrace *trace) {
  * \param rzil IL instance
  * \param op RzAnalysisRzilOp, a general IL op structure (Designed for switching between different implementations of IL op struct)
  */
-RZ_API void rz_analysis_rzil_trace_op(RzAnalysis *analysis, RZ_NONNULL RzAnalysisRzil *rzil, RZ_NONNULL RzAnalysisRzilOp *op) {
+RZ_API void rz_analysis_rzil_trace_op(RzAnalysis *analysis, RZ_NONNULL RzAnalysisRzil *rzil, RZ_NONNULL RzAnalysisLiftedILOp op) {
 	// TODO : rewrite this file when migrate to new op structure
 }

--- a/librz/core/cil.c
+++ b/librz/core/cil.c
@@ -631,7 +631,7 @@ RZ_IPI void rz_core_rzil_step(RzCore *core) {
 	// analysis current data to trigger rzil_set_op_code
 	(void)rz_io_read_at_mapped(core->io, addr, code, sizeof(code));
 	int size = rz_analysis_op(analysis, &op, addr, code, sizeof(code), RZ_ANALYSIS_OP_MASK_ESIL | RZ_ANALYSIS_OP_MASK_HINT);
-	RzILOpEffect *ilop = op.rzil_op ? op.rzil_op->op : NULL;
+	RzILOpEffect *ilop = op.il_op;
 
 	if (ilop) {
 		rz_il_vm_step(vm, ilop, size > 0 ? size : 1);

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -1006,13 +1006,9 @@ static void core_analysis_bytes(RzCore *core, const ut8 *buf, int len, int nops,
 			if (jesil && *jesil) {
 				pj_ks(pj, "esil", jesil);
 			}
-			if (op.rzil_op) {
-				if (op.rzil_op->op) {
-					pj_k(pj, "rzil");
-					rz_il_op_effect_json(op.rzil_op->op, pj);
-				} else {
-					pj_knull(pj, "rzil");
-				}
+			if (op.il_op) {
+				pj_k(pj, "rzil");
+				rz_il_op_effect_json(op.il_op, pj);
 			}
 			pj_kb(pj, "sign", op.sign);
 			pj_kn(pj, "prefix", op.prefix);
@@ -1190,9 +1186,9 @@ static void core_analysis_bytes(RzCore *core, const ut8 *buf, int len, int nops,
 			} else if (RZ_STR_ISNOTEMPTY(esilstr)) {
 				printline("esil", "%s\n", esilstr);
 			}
-			if (op.rzil_op && op.rzil_op->op) {
+			if (op.il_op) {
 				RzStrBuf *sbil = rz_strbuf_new("");
-				rz_il_op_effect_stringify(op.rzil_op->op, sbil);
+				rz_il_op_effect_stringify(op.il_op, sbil);
 				printline("rzil", "%s\n", rz_strbuf_get(sbil));
 				rz_strbuf_free(sbil);
 			}

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -810,9 +810,7 @@ typedef enum rz_analysis_data_type_t {
 	RZ_ANALYSIS_DATATYPE_FLOAT,
 } RzAnalysisDataType;
 
-typedef struct rz_analysis_rzil_op_t {
-	RzILOpEffect *op;
-} RzAnalysisRzilOp;
+typedef RzILOpEffect *RzAnalysisLiftedILOp;
 
 typedef struct rz_analysis_op_t {
 	char *mnemonic; /* mnemonic.. it actually contains the args too, we should replace rasm with this */
@@ -847,7 +845,7 @@ typedef struct rz_analysis_op_t {
 	RzList *access; /* RzAnalysisValue access information */
 	RzStrBuf esil;
 	RzStrBuf opex;
-	RzAnalysisRzilOp *rzil_op;
+	RzAnalysisLiftedILOp il_op;
 	const char *reg; /* destination register */
 	const char *ireg; /* register used for indirect memory computation*/
 	int scale;
@@ -1577,12 +1575,12 @@ RZ_API bool rz_analysis_rzil_set_pc(RzAnalysisRzil *rzil, ut64 addr);
 RZ_API bool rz_analysis_rzil_setup(RzAnalysis *analysis);
 RZ_API void rz_analysis_rzil_cleanup(RzAnalysis *analysis);
 RZ_API void rz_analysis_set_rzil_op(RzAnalysisRzil *rzil, ut64 addr, RzPVector *oplist);
-RZ_API void rz_analysis_rzil_record_stats(RzAnalysis *analysis, RzAnalysisRzil *rzil, RzAnalysisRzilOp *op);
+RZ_API void rz_analysis_rzil_record_stats(RzAnalysis *analysis, RzAnalysisRzil *rzil, RzAnalysisLiftedILOp op);
 
 /* trace */
 RZ_API RzAnalysisRzilTrace *rz_analysis_rzil_trace_new(RzAnalysis *analysis, RzAnalysisRzil *rzil);
 RZ_API void rz_analysis_rzil_trace_free(RzAnalysisRzilTrace *trace);
-RZ_API void rz_analysis_rzil_trace_op(RzAnalysis *analysis, RzAnalysisRzil *rzil, RzAnalysisRzilOp *op);
+RZ_API void rz_analysis_rzil_trace_op(RzAnalysis *analysis, RzAnalysisRzil *rzil, RzAnalysisLiftedILOp op);
 RZ_API void rz_analysis_rzil_collect_info(RzAnalysis *analysis, RzAnalysisRzil *rzil, RzAnalysisOp *op, bool use_new);
 
 RZ_API bool rz_analysis_add_device_peripheral_map(RzBinObject *o, RzAnalysis *analysis);

--- a/librz/main/meson.build
+++ b/librz/main/meson.build
@@ -22,6 +22,7 @@ rz_main_deps = [
   rz_cons_dep,
   rz_hash_dep,
   rz_crypto_dep,
+  rz_il_dep,
   rz_io_dep,
   rz_reg_dep,
   rz_bp_dep,

--- a/test/README.md
+++ b/test/README.md
@@ -58,7 +58,7 @@ A test can have one of the following results:
 Tests for the assembly and disassembly (in `db/asm/*`) have a different format:
 General format:
 ```
-type "assembly" opcode [offset]
+type "assembly" opcode [offset] [IL]
 ```
 where type can be any of:
 * **a** meaning "assemble"
@@ -78,6 +78,21 @@ d "ret" c3
 a "nop" 90 # Assembly is correct
 dB "nopppp" 90 # Disassembly test is broken
 ```
+
+#### IL
+
+To also test lifting an instruction to RzIL, you can append the readable IL
+representation like so:
+```
+d "inc ptr" 3e 0 set(v:ptr, x:add(x:var(v:ptr), y:bitv(bits:0x0000000000000001, len:64)))
+```
+
+This means that rz-test will also perform the lifting from bytes to RzIL,
+run the validation pass on the result and compare it against the given string.
+
+In this case, passing an offset is mandatory, otherwise the argument would be ambiguous.
+
+#### General hints
 
 You can merge lines:
 ```

--- a/test/db/asm/bf
+++ b/test/db/asm/bf
@@ -1,0 +1,3 @@
+d "inc ptr" 3e 0 set(v:ptr, x:add(x:var(v:ptr), y:bitv(bits:0x0000000000000001, len:64)))
+d "dec ptr" 3c 0 set(v:ptr, x:sub(x:var(v:ptr), y:bitv(bits:0x0000000000000001, len:64)))
+d "out [ptr]" 2e 0 goto(lbl:write)

--- a/test/db/asm/hexagon
+++ b/test/db/asm/hexagon
@@ -6,7 +6,7 @@ d "?   R0 = ##0x101" 20e00078 0x0
 d "?   R5 = add(clb(R31),#0xffffffff)" 05ff3f8c 0x0
 d "?   R4 = add(R19,##0x33)" 64c613b0 0x0
 
-d "?   nop"  00c0007f 0x10000000 0x0
+d "?   nop" 00c0007f 0x10000000
 d "?   R31 = add(R0,##0x2)" 5f4000b0 0x0
 
 d "?   P0 = tstbit(R6,#0); if (!P0.new) jump:t 0x14" 04e3c611 0xc

--- a/test/db/asm/x86_16
+++ b/test/db/asm/x86_16
@@ -6,7 +6,7 @@ a "jne 0x14" 7512
 a "jnz 0x94" 660f858d000000
 a "jnz -0x94" 660f8565ffffff
 a "jno -0x34" 71ca
-dB "jmp 0xfec50" e95bec f000:fff2
+dB "jmp 0xfec50" e95bec
 d "jmp 0x1fec50" e95bec 0x001ffff2
 a "mov al, [0xbeef]" a0efbe
 a "mov ax, [0xbeef]" a1efbe

--- a/test/db/cmd/cmd_system
+++ b/test/db/cmd/cmd_system
@@ -62,3 +62,18 @@ EXPECT=<<EOF
 test
 EOF
 RUN
+
+NAME=! return
+FILE=
+CMDS=<<EOF
+!true
+?v $?
+!false
+?v $?
+EOF
+EXPECT=<<EOF
+0x0
+0x1
+EOF
+EXPECT_ERR=
+RUN

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -129,33 +129,27 @@ RUN
 NAME=rz-asm #1900 (detect syntax error - case 1)
 FILE==
 CMDS=!rz-asm -a x86 -b 32 "mov hello, eax"
-EXPECT=<<EOF
-EOF
+EXPECT=
 EXPECT_ERR=<<EOF
 Cannot assemble 'mov hello, eax' at line 3
-invalid
 EOF
 RUN
 
 NAME=rz-asm #1900 (detect syntax error - case 2)
 FILE==
 CMDS=!rz-asm -a x86 -b 32 "mov 33, eax"
-EXPECT=<<EOF
-EOF
+EXPECT=
 EXPECT_ERR=<<EOF
 Cannot assemble 'mov 33, eax' at line 3
-invalid
 EOF
 RUN
 
 NAME=rz-asm #1900 (detect syntax error - case 3)
 FILE==
 CMDS=!rz-asm -a x86 -b 32 "mov eax, hello"
-EXPECT=<<EOF
-EOF
+EXPECT=
 EXPECT_ERR=<<EOF
 Cannot assemble 'mov eax, hello' at line 3
-invalid
 EOF
 RUN
 
@@ -165,7 +159,6 @@ CMDS=!rz-asm -a x86 -b 32 "mov eax, 0x1122334455"
 EXPECT=
 EXPECT_ERR=<<EOF
 Cannot assemble 'mov eax, 0x1122334455' at line 3
-invalid
 EOF
 RUN
 
@@ -178,9 +171,7 @@ EOF
 EXPECT=
 EXPECT_ERR=<<EOF
 Cannot assemble 'mov rax, 0x112233445566778899' at line 3
-invalid
 Cannot assemble 'mov eax, 0x1122334455' at line 3
-invalid
 EOF
 RUN
 
@@ -570,5 +561,32 @@ BROKEN=1
 CMDS=!rz-asm -a arm.as -b 64 "sub sp, sp, 16"
 EXPECT=<<EOF
 ff4300d1
+EOF
+RUN
+
+NAME=rz-asm RzIL
+FILE=
+CMDS=<<EOF
+!rz-asm -a bf -I 3e
+?v $?
+EOF
+EXPECT=<<EOF
+set(v:ptr, x:add(x:var(v:ptr), y:bitv(bits:0x0000000000000001, len:64)))
+0x0
+EOF
+EXPECT_ERR=
+RUN
+
+NAME=rz-asm RzIL failure
+FILE=
+CMDS=<<EOF
+!rz-asm -a bf -I 00
+?v $?
+EOF
+EXPECT=<<EOF
+0x1
+EOF
+EXPECT_ERR=<<EOF
+Invalid instruction of lifting not implemented.
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This adds a convenient way to write manual tests for individual instruction lifting, as part of our regular asm tests, e.g.:
```
d "inc ptr" 3e 0 set(v:ptr, x:add(x:var(v:ptr), y:bitv(bits:0x0000000000000001, len:64)))
```
This compares the lifted IL against the given string, but also runs the full validation pass to detect any errors:
![Bildschirmfoto 2022-01-10 um 17 13 12](https://user-images.githubusercontent.com/1460997/148800678-9e049451-c89a-4902-a95e-d5f2abd974f3.png)

The idea is that every instruction for which we implement lifting will come with such a test, so we can make sure the code is always valid.

As a bonus, this also adds IL output to `rz-asm`:
```
$ rz-asm -a bf -I 3e
set(v:ptr, x:add(x:var(v:ptr), y:bitv(bits:0x0000000000000001, len:64)))
```

**Test plan**

```
rz-test -i test/db/asm/bf
```
