### PR TITLE
Delete ESIL stack memory after type propagation

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -6336,6 +6336,7 @@ RZ_IPI bool rz_core_analysis_types_propagation(RzCore *core) {
 	}
 	rz_core_seek(core, seek, true);
 	rz_reg_arena_pop(core->analysis->reg);
+	rz_core_analysis_esil_init_mem_del(core, NULL, UT64_MAX, UT32_MAX);
 	rz_config_hold_restore(hold);
 	rz_config_hold_free(hold);
 	free(saved_arena);

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -8130,3 +8130,24 @@ fun2
 ["fun1","fun2"]
 EOF
 RUN
+
+NAME=no ESIL memory in aaft
+FILE=bins/elf/back1
+CMDS=<<EOF
+aa
+s main
+oml
+aaft
+oml
+EOF
+EXPECT=<<EOF
+ 1 fd: 4 +0x00000000 0x00201020 - 0x00201087 r-- vmap.reloc-targets
+ 2 fd: 3 +0x00000000 0x00000000 - 0x000009af r-x fmap.LOAD0
+ 3 fd: 5 +0x00000000 0x00201010 - 0x00201017 rw- mmap.LOAD1
+ 4 fd: 6 +0x00000d98 0x00200d98 - 0x0020100f r-- vmap.LOAD1
+ 1 fd: 4 +0x00000000 0x00201020 - 0x00201087 r-- vmap.reloc-targets
+ 2 fd: 3 +0x00000000 0x00000000 - 0x000009af r-x fmap.LOAD0
+ 3 fd: 5 +0x00000000 0x00201010 - 0x00201017 rw- mmap.LOAD1
+ 4 fd: 6 +0x00000d98 0x00200d98 - 0x0020100f r-- vmap.LOAD1
+EOF
+RUN


### PR DESCRIPTION
 **Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

```
$ rizin /bin/ls
[0x00006b10]> oml
 1 fd: 4 +0x00000000 0x00023548 - 0x00023f3f r-- vmap.reloc-targets
 2 fd: 3 +0x00000000 0x00000000 - 0x0000352f r-- fmap.LOAD0
 3 fd: 3 +0x00004000 0x00004000 - 0x00017130 r-x fmap.LOAD1
 4 fd: 3 +0x00018000 0x00018000 - 0x0001f4c7 r-- fmap.LOAD2
 5 fd: 5 +0x00000000 0x00022278 - 0x0002353f rw- mmap.LOAD3
 6 fd: 6 +0x0001ff70 0x00020f70 - 0x00022277 r-- vmap.LOAD3
[0x00006b10]> aaa
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze function calls (aac)
[x] Analyze len bytes of instructions for references (aar)
[x] Check for classes
[x] Type matching analysis for all functions (aaft)
[x] Propagate noreturn information
[x] Use -AA or aaaa to perform additional experimental analysis.
[x] Applied 0 FLIRT signatures via sigdb
[0x00006b10]> oml
 1 fd: 4 +0x00000000 0x00023548 - 0x00023f3f r-- vmap.reloc-targets
 2 fd: 3 +0x00000000 0x00000000 - 0x0000352f r-- fmap.LOAD0
 3 fd: 3 +0x00004000 0x00004000 - 0x00017130 r-x fmap.LOAD1
 4 fd: 3 +0x00018000 0x00018000 - 0x0001f4c7 r-- fmap.LOAD2
 5 fd: 5 +0x00000000 0x00022278 - 0x0002353f rw- mmap.LOAD3
 6 fd: 6 +0x0001ff70 0x00020f70 - 0x00022277 r-- vmap.LOAD3
```

No ` 7 fd: 7 +0x00000000 0x00100000 - 0x001effff rw- mem.0x100000_0xf0000` should be present.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #2179 