### PR TITLE
Convert `fs` commands to rzshell

### DIFF
--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -74,6 +74,10 @@ static int rz_core_cmd_subst_i(RzCore *core, char *cmd, char *colon, bool *tmpse
 
 static bool lastcmd_repeat(RzCore *core, int next);
 
+static inline RzCmdStatus bool2status(bool val) {
+	return val ? RZ_CMD_STATUS_OK : RZ_CMD_STATUS_ERROR;
+}
+
 #include "cmd_block.c"
 #include "cmd_quit.c"
 #include "cmd_hash.c"

--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -5,10 +5,6 @@
 #include <stdbool.h>
 #include "rz_core.h"
 
-static RzCmdStatus bool2status(bool val) {
-	return val ? RZ_CMD_STATUS_OK : RZ_CMD_STATUS_ERROR;
-}
-
 static bool load_theme(RzCore *core, const char *path) {
 	if (!rz_file_exists(path)) {
 		return false;

--- a/librz/core/cmd/cmd_meta.c
+++ b/librz/core/cmd/cmd_meta.c
@@ -320,7 +320,7 @@ RZ_IPI RzCmdStatus rz_meta_space_handler(RzCore *core, int argc, const char **ar
 
 RZ_IPI RzCmdStatus rz_meta_space_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
 	RzSpaces *ms = &core->analysis->meta_spaces;
-	spaces_list(ms, state->mode);
+	rz_core_spaces_print(core, ms, state);
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/core/cmd/cmd_regs.c
+++ b/librz/core/cmd/cmd_regs.c
@@ -643,7 +643,7 @@ RZ_IPI RzCmdStatus rz_reg_flags_handler(RzCore *core, RzReg *reg, RzCmdRegSync s
 		}
 	}
 	if (!unset) {
-		rz_cons_print("fs+ " RZ_FLAGS_FS_REGISTERS "\n");
+		rz_cons_print("fss+ " RZ_FLAGS_FS_REGISTERS "\n");
 		bool failed;
 		SYNC_READ_LIST(ritems, failed);
 		if (failed) {
@@ -662,7 +662,7 @@ RZ_IPI RzCmdStatus rz_reg_flags_handler(RzCore *core, RzReg *reg, RzCmdRegSync s
 		}
 	}
 	if (!unset) {
-		rz_cons_print("fs-\n");
+		rz_cons_print("fss-\n");
 	}
 	rz_list_free(ritems);
 	return RZ_CMD_STATUS_OK;

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -291,6 +291,10 @@ static const RzCmdDescArg eval_readonly_args[2];
 static const RzCmdDescArg eval_spaces_args[2];
 static const RzCmdDescArg eval_type_args[2];
 static const RzCmdDescArg flag_describe_closest_args[2];
+static const RzCmdDescArg flag_space_add_args[2];
+static const RzCmdDescArg flag_space_remove_args[2];
+static const RzCmdDescArg flag_space_rename_args[2];
+static const RzCmdDescArg flag_space_stack_push_args[2];
 static const RzCmdDescArg flag_tag_add_args[3];
 static const RzCmdDescArg flag_tag_search_args[2];
 static const RzCmdDescArg flag_zone_add_args[2];
@@ -6438,6 +6442,108 @@ static const RzCmdDescHelp flag_describe_closest_help = {
 	.args = flag_describe_closest_args,
 };
 
+static const RzCmdDescHelp fs_help = {
+	.summary = "Manage flagspaces",
+};
+static const RzCmdDescArg flag_space_add_args[] = {
+	{
+		.name = "name",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp flag_space_add_help = {
+	.summary = "Add the flagspace",
+	.args = flag_space_add_args,
+};
+
+static const RzCmdDescArg flag_space_list_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp flag_space_list_help = {
+	.summary = "Display flagspaces",
+	.args = flag_space_list_args,
+};
+
+static const RzCmdDescArg flag_space_remove_args[] = {
+	{
+		.name = "name",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp flag_space_remove_help = {
+	.summary = "Remove the flagspace",
+	.args = flag_space_remove_args,
+};
+
+static const RzCmdDescArg flag_space_remove_all_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp flag_space_remove_all_help = {
+	.summary = "Remove all flagspaces",
+	.args = flag_space_remove_all_args,
+};
+
+static const RzCmdDescArg flag_space_move_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp flag_space_move_help = {
+	.summary = "Move the flags at the current address to the current flagspace",
+	.args = flag_space_move_args,
+};
+
+static const RzCmdDescArg flag_space_rename_args[] = {
+	{
+		.name = "newname",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp flag_space_rename_help = {
+	.summary = "Rename the flag space",
+	.args = flag_space_rename_args,
+};
+
+static const RzCmdDescHelp fss_help = {
+	.summary = "Manage the flagspace stack",
+};
+static const RzCmdDescArg flag_space_stack_push_args[] = {
+	{
+		.name = "name",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp flag_space_stack_push_help = {
+	.summary = "Push the flagspace to the stack",
+	.args = flag_space_stack_push_args,
+};
+
+static const RzCmdDescArg flag_space_stack_pop_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp flag_space_stack_pop_help = {
+	.summary = "Pop the flagspace from the stack",
+	.args = flag_space_stack_pop_args,
+};
+
+static const RzCmdDescArg flag_space_stack_list_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp flag_space_stack_list_help = {
+	.summary = "Display flagspace stack",
+	.args = flag_space_stack_list_args,
+};
+
 static const RzCmdDescHelp ft_help = {
 	.summary = "Flag tags",
 };
@@ -12060,6 +12166,36 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *flag_describe_closest_cd = rz_cmd_desc_argv_new(core->rcmd, fd_cd, "fdw", rz_flag_describe_closest_handler, &flag_describe_closest_help);
 	rz_warn_if_fail(flag_describe_closest_cd);
+
+	RzCmdDesc *fs_cd = rz_cmd_desc_group_new(core->rcmd, cmd_flag_cd, "fs", rz_flag_space_add_handler, &flag_space_add_help, &fs_help);
+	rz_warn_if_fail(fs_cd);
+	RzCmdDesc *flag_space_list_cd = rz_cmd_desc_argv_state_new(core->rcmd, fs_cd, "fsl", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET, rz_flag_space_list_handler, &flag_space_list_help);
+	rz_warn_if_fail(flag_space_list_cd);
+	rz_cmd_desc_set_default_mode(flag_space_list_cd, RZ_OUTPUT_MODE_STANDARD);
+
+	RzCmdDesc *flag_space_remove_cd = rz_cmd_desc_argv_new(core->rcmd, fs_cd, "fs-", rz_flag_space_remove_handler, &flag_space_remove_help);
+	rz_warn_if_fail(flag_space_remove_cd);
+
+	RzCmdDesc *flag_space_remove_all_cd = rz_cmd_desc_argv_new(core->rcmd, fs_cd, "fs-*", rz_flag_space_remove_all_handler, &flag_space_remove_all_help);
+	rz_warn_if_fail(flag_space_remove_all_cd);
+
+	RzCmdDesc *flag_space_move_cd = rz_cmd_desc_argv_new(core->rcmd, fs_cd, "fsm", rz_flag_space_move_handler, &flag_space_move_help);
+	rz_warn_if_fail(flag_space_move_cd);
+
+	RzCmdDesc *flag_space_rename_cd = rz_cmd_desc_argv_new(core->rcmd, fs_cd, "fsr", rz_flag_space_rename_handler, &flag_space_rename_help);
+	rz_warn_if_fail(flag_space_rename_cd);
+
+	RzCmdDesc *fss_cd = rz_cmd_desc_group_new(core->rcmd, fs_cd, "fss", NULL, NULL, &fss_help);
+	rz_warn_if_fail(fss_cd);
+	RzCmdDesc *flag_space_stack_push_cd = rz_cmd_desc_argv_new(core->rcmd, fss_cd, "fss+", rz_flag_space_stack_push_handler, &flag_space_stack_push_help);
+	rz_warn_if_fail(flag_space_stack_push_cd);
+
+	RzCmdDesc *flag_space_stack_pop_cd = rz_cmd_desc_argv_new(core->rcmd, fss_cd, "fss-", rz_flag_space_stack_pop_handler, &flag_space_stack_pop_help);
+	rz_warn_if_fail(flag_space_stack_pop_cd);
+
+	RzCmdDesc *flag_space_stack_list_cd = rz_cmd_desc_argv_state_new(core->rcmd, fss_cd, "fssl", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_flag_space_stack_list_handler, &flag_space_stack_list_help);
+	rz_warn_if_fail(flag_space_stack_list_cd);
+	rz_cmd_desc_set_default_mode(flag_space_stack_list_cd, RZ_OUTPUT_MODE_STANDARD);
 
 	RzCmdDesc *ft_cd = rz_cmd_desc_group_new(core->rcmd, cmd_flag_cd, "ft", rz_flag_tag_add_handler, &flag_tag_add_help, &ft_help);
 	rz_warn_if_fail(ft_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -453,6 +453,15 @@ RZ_IPI RzCmdStatus rz_eval_type_handler(RzCore *core, int argc, const char **arg
 RZ_IPI RzCmdStatus rz_flag_describe_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_flag_describe_at_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_flag_describe_closest_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_flag_space_add_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_flag_space_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+RZ_IPI RzCmdStatus rz_flag_space_remove_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_flag_space_remove_all_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_flag_space_move_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_flag_space_rename_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_flag_space_stack_push_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_flag_space_stack_pop_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_flag_space_stack_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_flag_tag_add_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_flag_tag_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_flag_tag_search_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_flag.yaml
+++ b/librz/core/cmd_descs/cmd_flag.yaml
@@ -30,6 +30,67 @@ commands:
         args:
           - name: string
             type: RZ_CMD_ARG_TYPE_STRING
+  - name: fs
+    summary: Manage flagspaces
+    subcommands:
+      - name: fs
+        cname: flag_space_add
+        summary: Add the flagspace
+        args:
+          - name: name
+            type: RZ_CMD_ARG_TYPE_STRING
+      - name: fsl
+        cname: flag_space_list
+        summary: Display flagspaces
+        type: RZ_CMD_DESC_TYPE_ARGV_STATE
+        default_mode: RZ_OUTPUT_MODE_STANDARD
+        modes:
+          - RZ_OUTPUT_MODE_STANDARD
+          - RZ_OUTPUT_MODE_JSON
+          - RZ_OUTPUT_MODE_QUIET
+        args: []
+      - name: fs-
+        cname: flag_space_remove
+        summary: Remove the flagspace
+        args:
+          - name: name
+            type: RZ_CMD_ARG_TYPE_STRING
+      - name: fs-*
+        cname: flag_space_remove_all
+        summary: Remove all flagspaces
+        args: []
+      - name: fsm
+        cname: flag_space_move
+        summary: Move the flags at the current address to the current flagspace
+        args: []
+      - name: fsr
+        cname: flag_space_rename
+        summary: Rename the flag space
+        args:
+          - name: newname
+            type: RZ_CMD_ARG_TYPE_STRING
+      - name: fss
+        summary: Manage the flagspace stack
+        subcommands:
+          - name: fss+
+            cname: flag_space_stack_push
+            summary: Push the flagspace to the stack
+            args:
+              - name: name
+                type: RZ_CMD_ARG_TYPE_STRING
+          - name: fss-
+            cname: flag_space_stack_pop
+            summary: Pop the flagspace from the stack
+            args: []
+          - name: fssl
+            cname: flag_space_stack_list
+            summary: Display flagspace stack
+            type: RZ_CMD_DESC_TYPE_ARGV_STATE
+            default_mode: RZ_OUTPUT_MODE_STANDARD
+            modes:
+              - RZ_OUTPUT_MODE_STANDARD
+              - RZ_OUTPUT_MODE_JSON
+            args: []
   - name: ft
     summary: Flag tags
     subcommands:

--- a/librz/core/cmeta.c
+++ b/librz/core/cmeta.c
@@ -6,6 +6,43 @@
 
 #include <rz_core.h>
 
+RZ_IPI void rz_core_spaces_print(RzCore *core, RzSpaces *spaces, RzCmdStateOutput *state) {
+	const RzSpace *cur = rz_spaces_current(spaces);
+	rz_cmd_state_output_array_start(state);
+	RzSpace *s;
+	PJ *pj = state->d.pj;
+	RzSpaceIter it;
+	rz_spaces_foreach(spaces, it, s) {
+		int count = rz_spaces_count(spaces, s->name);
+		switch (state->mode) {
+		case RZ_OUTPUT_MODE_JSON:
+			pj_o(pj);
+			pj_ks(pj, "name", s->name);
+			pj_ki(pj, "count", count);
+			pj_kb(pj, "selected", cur == s);
+			pj_end(pj);
+			break;
+		case RZ_OUTPUT_MODE_QUIET:
+			rz_cons_printf("%s\n", s->name);
+			break;
+		case RZ_OUTPUT_MODE_RIZIN:
+			rz_cons_printf("%s %s\n", spaces->name, s->name);
+			break;
+		case RZ_OUTPUT_MODE_STANDARD:
+			rz_cons_printf("%5d %c %s\n", count,
+				(!cur || cur == s) ? '*' : '.', s->name);
+			break;
+		default:
+			rz_warn_if_reached();
+			break;
+		}
+	}
+	rz_cmd_state_output_array_end(state);
+	if (state->mode == RZ_OUTPUT_MODE_RIZIN && rz_spaces_current(spaces)) {
+		rz_cons_printf("%s %s # current\n", spaces->name, rz_spaces_current_name(spaces));
+	}
+}
+
 static char *meta_string_escape(RzCore *core, RzAnalysisMetaItem *mi) {
 	char *esc_str = NULL;
 	RzStrEscOptions opt = { 0 };

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -911,7 +911,6 @@ static const char *rizin_argv[] = {
 	"f?", "f", "f.", "f*", "f-", "f--", "f+", "f=", "fa", "fb", "fc?", "fc", "fC", "fe-", "fe",
 	"ff", "fi", "fg", "fj",
 	"fl", "fla", "fm", "fn", "fnj", "fo", "fO", "fr", "fR", "fR?",
-	"fs?", "fs", "fs*", "fsj", "fs-", "fs+", "fs-.", "fsq", "fsm", "fss", "fss*", "fssj", "fsr",
 	"fV", "fx", "fq",
 	"g?", "g", "gw", "gc", "gl?", "gl", "gs", "gi", "gp", "ge", "gr", "gS",
 	"i?", "i", "ij", "iA", "ia", "ib", "ic", "icc", "iC",

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -52,6 +52,7 @@ RZ_IPI void rz_core_analysis_function_until(RzCore *core, ut64 addr_end);
 RZ_IPI void rz_core_analysis_value_pointers(RzCore *core, RzOutputMode mode);
 
 /* cmeta.c */
+RZ_IPI void rz_core_spaces_print(RzCore *core, RzSpaces *spaces, RzCmdStateOutput *state);
 RZ_IPI void rz_core_meta_print(RzCore *core, RzAnalysisMetaItem *d, ut64 start, ut64 size, bool show_full, RzCmdStateOutput *state);
 RZ_IPI void rz_core_meta_print_list_at(RzCore *core, ut64 addr, RzCmdStateOutput *state);
 RZ_IPI void rz_core_meta_print_list_all(RzCore *core, int type, RzCmdStateOutput *state);

--- a/test/db/abi/compilers/clang
+++ b/test/db/abi/compilers/clang
@@ -34,7 +34,7 @@ NAME=ELF_ABI : Clang m32 O0 flagspaces
 FILE=bins/abi_bins/elf/compilers/clang/echo_clang_m32_O0
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    87 * functions
@@ -45,7 +45,7 @@ NAME=ELF_ABI : Clang m32 O1 flagspaces
 FILE=bins/abi_bins/elf/compilers/clang/echo_clang_m32_O1
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    95 * functions
@@ -56,7 +56,7 @@ NAME=ELF_ABI : Clang m32 O2 flagspaces
 FILE=bins/abi_bins/elf/compilers/clang/echo_clang_m32_O2
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    50 * functions
@@ -67,7 +67,7 @@ NAME=ELF_ABI : Clang m32 O3 flagspaces
 FILE=bins/abi_bins/elf/compilers/clang/echo_clang_m32_O3
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    49 * functions
@@ -78,7 +78,7 @@ NAME=ELF_ABI : Clang m32 Of flagspaces
 FILE=bins/abi_bins/elf/compilers/clang/echo_clang_m32_Of
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    51 * functions
@@ -89,7 +89,7 @@ NAME=ELF_ABI : Clang m32 Os flagspaces
 FILE=bins/abi_bins/elf/compilers/clang/echo_clang_m32_Os
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    57 * functions

--- a/test/db/abi/compilers/clang_64
+++ b/test/db/abi/compilers/clang_64
@@ -35,7 +35,7 @@ NAME=ELF_ABI : Clang O0 flagspaces
 FILE=bins/abi_bins/elf/compilers/clang/echo_clang_O0
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    87 * functions
@@ -46,7 +46,7 @@ NAME=ELF_ABI : Clang O1 flagspaces
 FILE=bins/abi_bins/elf/compilers/clang/echo_clang_O1
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    95 * functions
@@ -57,7 +57,7 @@ NAME=ELF_ABI : Clang O2 flagspaces
 FILE=bins/abi_bins/elf/compilers/clang/echo_clang_O2
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    50 * functions
@@ -68,7 +68,7 @@ NAME=ELF_ABI : Clang O3 flagspaces
 FILE=bins/abi_bins/elf/compilers/clang/echo_clang_O3
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    49 * functions
@@ -79,7 +79,7 @@ NAME=ELF_ABI : Clang Of flagspaces
 FILE=bins/abi_bins/elf/compilers/clang/echo_clang_Of
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    51 * functions
@@ -90,7 +90,7 @@ NAME=ELF_ABI : Clang Os flagspaces
 FILE=bins/abi_bins/elf/compilers/clang/echo_clang_Os
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    87 * functions

--- a/test/db/abi/compilers/gcc
+++ b/test/db/abi/compilers/gcc
@@ -34,7 +34,7 @@ NAME=ELF_ABI : gcc m32 O0 flagspaces
 FILE=bins/abi_bins/elf/compilers/gcc/echo_gcc_m32_O0
 ARGS=-A
 CMDS=<<EOF
-fs~symbols$
+fsl~symbols$
 EOF
 EXPECT=<<EOF
   137 * symbols
@@ -45,7 +45,7 @@ NAME=ELF_ABI : gcc m32 O1 flagspaces
 FILE=bins/abi_bins/elf/compilers/gcc/echo_gcc_m32_O1
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    67 * functions
@@ -56,7 +56,7 @@ NAME=ELF_ABI : gcc m32 O2 flagspaces
 FILE=bins/abi_bins/elf/compilers/gcc/echo_gcc_m32_O2
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    51 * functions
@@ -67,7 +67,7 @@ NAME=ELF_ABI : gcc m32 O3 flagspaces
 FILE=bins/abi_bins/elf/compilers/gcc/echo_gcc_m32_O3
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    43 * functions
@@ -78,7 +78,7 @@ NAME=ELF_ABI : gcc m32 Of flagspaces
 FILE=bins/abi_bins/elf/compilers/gcc/echo_gcc_m32_Of
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    45 * functions
@@ -89,7 +89,7 @@ NAME=ELF_ABI : gcc m32 Os flagspaces
 FILE=bins/abi_bins/elf/compilers/gcc/echo_gcc_m32_Os
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    85 * functions

--- a/test/db/abi/compilers/gcc_64
+++ b/test/db/abi/compilers/gcc_64
@@ -35,7 +35,7 @@ NAME=ELF_ABI : gcc O0 flagspaces
 FILE=bins/abi_bins/elf/compilers/gcc/echo_gcc_O0
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    89 * functions
@@ -46,7 +46,7 @@ NAME=ELF_ABI : gcc O1 flagspaces
 FILE=bins/abi_bins/elf/compilers/gcc/echo_gcc_O1
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    68 * functions
@@ -57,7 +57,7 @@ NAME=ELF_ABI : gcc O2 flagspaces
 FILE=bins/abi_bins/elf/compilers/gcc/echo_gcc_O2
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    51 * functions
@@ -68,7 +68,7 @@ NAME=ELF_ABI : gcc O3 flagspaces
 FILE=bins/abi_bins/elf/compilers/gcc/echo_gcc_O3
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    44 * functions
@@ -79,7 +79,7 @@ NAME=ELF_ABI : gcc Of flagspaces
 FILE=bins/abi_bins/elf/compilers/gcc/echo_gcc_Of
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    45 * functions
@@ -90,7 +90,7 @@ NAME=ELF_ABI : gcc Os flagspaces
 FILE=bins/abi_bins/elf/compilers/gcc/echo_gcc_Os
 ARGS=-A
 CMDS=<<EOF
-fs~functions
+fsl~functions
 EOF
 EXPECT=<<EOF
    85 * functions

--- a/test/db/abi/compilers/pelles_c
+++ b/test/db/abi/compilers/pelles_c
@@ -13,7 +13,7 @@ NAME=ELF_ABI : Pelles C 32 flagspaces
 FILE=bins/abi_bins/pe/compilers/echo_32_pelleC.exe
 ARGS=-A
 CMDS=<<EOF
-fs
+fsl
 EOF
 EXPECT=<<EOF
     0 * classes
@@ -56,7 +56,7 @@ NAME=ELF_ABI : Pelles C 64 flagspaces
 FILE=bins/abi_bins/pe/compilers/echo_64_pelleC.exe
 ARGS=-A
 CMDS=<<EOF
-fs
+fsl
 EOF
 EXPECT=<<EOF
     0 * classes

--- a/test/db/abi/compilers/visual_studio
+++ b/test/db/abi/compilers/visual_studio
@@ -2,7 +2,7 @@ NAME=ELF_ABI : vs2008 debug flagspaces
 FILE=bins/abi_bins/pe/compilers/ooex_vs2008_dbg.exe
 ARGS=-A
 CMDS=<<EOF
-fs~relocs
+fsl~relocs
 EOF
 EXPECT=<<EOF
    60 * relocs
@@ -23,7 +23,7 @@ RUN
 NAME=ELF_ABI : vs2008 release flagspaces
 FILE=bins/abi_bins/pe/compilers/ooex_vs2008_release.exe
 CMDS=<<EOF
-fs~relocs
+fsl~relocs
 EOF
 EXPECT=<<EOF
    43 * relocs
@@ -45,7 +45,7 @@ NAME=ELF_ABI : vs2010 release flagspaces
 FILE=bins/abi_bins/pe/compilers/ooex_vs2010_release.exe
 ARGS=-A
 CMDS=<<EOF
-fs~relocs
+fsl~relocs
 EOF
 EXPECT=<<EOF
    43 * relocs
@@ -66,7 +66,7 @@ RUN
 NAME=ELF_ABI : vs2010 debug flagspaces
 FILE=bins/abi_bins/pe/compilers/ooex_vs2010_dbg.exe
 CMDS=<<EOF
-fs~relocs
+fsl~relocs
 EOF
 EXPECT=<<EOF
    59 * relocs

--- a/test/db/analysis/avr
+++ b/test/db/analysis/avr
@@ -101,7 +101,7 @@ ARGS=-e asm.cpu=ATTiny48
 CMDS=<<EOF
 aa
 pd 5 @ 0x0
-fs~reg
+fsl~reg
 EOF
 EXPECT=<<EOF
         ,=< 0x00000000  ~   jmp   entry0

--- a/test/db/cmd/cmd_ar
+++ b/test/db/cmd/cmd_ar
@@ -570,7 +570,7 @@ e asm.bits=64
 arf
 ?e --
 .arf
-fs
+fsl
 f
 ?e --
 arf-
@@ -580,7 +580,7 @@ arf rax
 arf- rax
 EOF
 EXPECT=<<EOF
-fs+ registers
+fss+ registers
 f rax @ 0x0
 f rbx @ 0x0
 f rcx @ 0x0
@@ -599,7 +599,7 @@ f rip @ 0x0
 f rbp @ 0x0
 f rflags @ 0x0
 f rsp @ 0x0
-fs-
+fss-
 --
     0 * classes
    18 * registers
@@ -644,9 +644,9 @@ f- rbp
 f- rflags
 f- rsp
 --------
-fs+ registers
+fss+ registers
 f rax @ 0x0
-fs-
+fss-
 --
 f- rax
 EOF

--- a/test/db/cmd/cmd_flags
+++ b/test/db/cmd/cmd_flags
@@ -55,7 +55,7 @@ NAME=1: fs *
 FILE=bins/elf/analysis/main
 CMDS=<<EOF
 fs *
-fs~?^*
+fsl~?^*
 EOF
 EXPECT=<<EOF
 0
@@ -66,7 +66,7 @@ NAME=2: fs *
 FILE=bins/elf/analysis/main
 CMDS=<<EOF
 fs *
-fs~?*
+fsl~?*
 EOF
 EXPECT=<<EOF
 8
@@ -94,44 +94,30 @@ NAME=fs test_flagspace
 FILE=bins/elf/analysis/main
 CMDS=<<EOF
 fs test_flagspace
-fs~?test_flagspace
+fsl~?test_flagspace
 EOF
 EXPECT=<<EOF
 1
 EOF
 RUN
 
-NAME=fs-test_flagspace
+NAME=fs- test_flagspace
 FILE=bins/elf/analysis/main
 CMDS=<<EOF
 fs test_flagspace
-fs-test_flagspace
-fs~?test_flagspace
+fs- test_flagspace
+fsl~?test_flagspace
 EOF
 EXPECT=<<EOF
 0
 EOF
 RUN
 
-NAME=fs-test_flagspace
+NAME=fs-* test_flagspace
 FILE=bins/elf/analysis/main
 CMDS=<<EOF
 fs-*
-fs~?0
-EOF
-EXPECT=<<EOF
-0
-EOF
-RUN
-
-NAME=fs-.
-FILE=malloc://1024
-CMDS=<<EOF
-fs test_flagspace
-fs test_bloh
-fs test_blah
-fs-.
-fs~?test_blah
+fsl~?0
 EOF
 EXPECT=<<EOF
 0
@@ -143,8 +129,8 @@ FILE=bins/elf/analysis/main
 CMDS=<<EOF
 fs-*
 fs test
-fsm str.Hello_World test
-fs
+fsm @ str.Hello_World
+fsl
 EOF
 EXPECT=<<EOF
     1 * test
@@ -156,9 +142,8 @@ FILE=bins/elf/analysis/main
 CMDS=<<EOF
 fs-*
 fs test
-fs test
 fsr test2
-fs
+fsl
 EOF
 EXPECT=<<EOF
     0 * test2

--- a/test/db/formats/elf/helloworld-gcc-elf
+++ b/test/db/formats/elf/helloworld-gcc-elf
@@ -249,7 +249,7 @@ RUN
 
 NAME=flags spaces
 FILE=bins/elf/analysis/x86-helloworld-gcc
-CMDS=fs
+CMDS=fsl
 EXPECT=<<EOF
     0 * classes
     3 * imports
@@ -265,7 +265,7 @@ RUN
 NAME=flags spaces after analysis
 FILE=bins/elf/analysis/x86-helloworld-gcc
 CMDS=<<EOF
-aa;fs *;fs
+aa;fsl
 afl~?
 EOF
 EXPECT=<<EOF
@@ -287,7 +287,7 @@ RUN
 
 NAME=flags spaces after analysis again
 FILE=bins/elf/analysis/x86-helloworld-gcc
-CMDS=s entry0+4; af;fs *;fs
+CMDS=s entry0+4; af;fsl
 EXPECT=<<EOF
     0 * classes
     1 * functions


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Port `fs` commands to the rzshell:
- `fs+` (flag space push to stack) was moved to `fss+` since it belongs to the flagspace stack
- `fs-` (flag space pop from stack) was moved to `fss-` since it belongs to the flagspace stack
- `fs` list commands were moved to `fsl` with standard, json, quiet outputs
- `fss` list commands were moved to `fssl` with standard and json outputs

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/1587
