### PR TITLE
[RzIL] Make bf emulation stateless

### DIFF
--- a/test/db/asm/bf
+++ b/test/db/asm/bf
@@ -1,3 +1,10 @@
 d "inc ptr" 3e 0 (set ptr (+ (var ptr) (bv 64 0x1)))
 d "dec ptr" 3c 0 (set ptr (- (var ptr) (bv 64 0x1)))
+d "inc [ptr]" 2b 0x0 (store 0 (var ptr) (+ (load 0 (var ptr)) (bv 8 0x1)))
+d "dec [ptr]" 2d 0x0 (store 0 (var ptr) (- (load 0 (var ptr)) (bv 8 0x1)))
 d "out [ptr]" 2e 0 (goto write)
+d "in [ptr]" 2c 0x0 (goto read)
+
+# These just jump to 0 because we have no context here:
+d "while [ptr]" 5b 0x0 (branch (! (is_zero (load 0 (var ptr)))) nop (jmp (bv 64 0x0)))
+d "loop" 5d 0x0 (branch (! (is_zero (load 0 (var ptr)))) (jmp (bv 64 0x0)) nop)

--- a/test/db/rzil/bf
+++ b/test/db/rzil/bf
@@ -86,8 +86,8 @@ opcode: inc [ptr]
 rzil: (store 0 (var ptr) (+ (load 0 (var ptr)) (bv 8 0x1)))
 {"opcode":"store","mem":0,"key":{"opcode":"var","value":"ptr"},"value":{"opcode":"+","x":{"opcode":"load","mem":0,"key":{"opcode":"var","value":"ptr"}},"y":{"opcode":"bitv","bits":"0x1","len":8}}}
 opcode: while [ptr]
-rzil: (branch (! (is_zero (load 0 (var ptr)))) nop (goto ]8))
-{"opcode":"branch","condition":{"opcode":"!","x":{"opcode":"is_zero","bv":{"opcode":"load","mem":0,"key":{"opcode":"var","value":"ptr"}}}},"true_eff":{"opcode":"nop"},"false_eff":{"opcode":"goto","label":"]8"}}
+rzil: (branch (! (is_zero (load 0 (var ptr)))) nop (jmp (bv 64 0x31)))
+{"opcode":"branch","condition":{"opcode":"!","x":{"opcode":"is_zero","bv":{"opcode":"load","mem":0,"key":{"opcode":"var","value":"ptr"}}}},"true_eff":{"opcode":"nop"},"false_eff":{"opcode":"jmp","dst":{"opcode":"bitv","bits":"0x31","len":64}}}
 opcode: inc ptr
 rzil: (set ptr (+ (var ptr) (bv 64 0x1)))
 {"opcode":"set","dst":"ptr","src":{"opcode":"+","x":{"opcode":"var","value":"ptr"},"y":{"opcode":"bitv","bits":"0x1","len":64}}}
@@ -98,8 +98,8 @@ opcode: dec [ptr]
 rzil: (store 0 (var ptr) (- (load 0 (var ptr)) (bv 8 0x1)))
 {"opcode":"store","mem":0,"key":{"opcode":"var","value":"ptr"},"value":{"opcode":"-","x":{"opcode":"load","mem":0,"key":{"opcode":"var","value":"ptr"}},"y":{"opcode":"bitv","bits":"0x1","len":8}}}
 opcode: loop
-rzil: (branch (! (is_zero (load 0 (var ptr)))) (goto [14) nop)
-{"opcode":"branch","condition":{"opcode":"!","x":{"opcode":"is_zero","bv":{"opcode":"load","mem":0,"key":{"opcode":"var","value":"ptr"}}}},"true_eff":{"opcode":"goto","label":"[14"},"false_eff":{"opcode":"nop"}}
+rzil: (branch (! (is_zero (load 0 (var ptr)))) (jmp (bv 64 0xf)) nop)
+{"opcode":"branch","condition":{"opcode":"!","x":{"opcode":"is_zero","bv":{"opcode":"load","mem":0,"key":{"opcode":"var","value":"ptr"}}}},"true_eff":{"opcode":"jmp","dst":{"opcode":"bitv","bits":"0xf","len":64}},"false_eff":{"opcode":"nop"}}
 opcode: out [ptr]
 rzil: (goto write)
 {"opcode":"goto","label":"write"}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Previously, bf IL lifting depended on a state `BfContext` built during emulation to track some labels for targets of `[` and `]`. This however also depended on disassembling in the exactly correct order, otherwise you get this:
![Bildschirmfoto 2022-01-16 um 13 36 40](https://user-images.githubusercontent.com/1460997/149660189-5939488b-a063-48f4-a94a-d0d2c82fe5d5.png)
or alternatively
![Bildschirmfoto 2022-01-16 um 13 37 19](https://user-images.githubusercontent.com/1460997/149660201-a5bb0e16-4895-4868-aec5-942059df7f44.png)

At the same time though it was also using just a regular search over the bytes at disassembly time to find matching brackets, so I extended this to work in both directions and thus it works without any state and in any order now.

An alternative to searching at disassembly time would be to implement the search in IL directly. But then we wouldn't be able to fill the `op->jump` value anymore.