### PR TITLE
Fix CID 367529

### DIFF
--- a/librz/analysis/p/analysis_hexagon.c
+++ b/librz/analysis/p/analysis_hexagon.c
@@ -3,7 +3,7 @@
 
 // LLVM commit: 96e220e6886868d6663d966ecc396befffc355e7
 // LLVM commit date: 2022-01-05 11:01:52 +0000 (ISO 8601 format)
-// Date of code generation: 2022-01-05 11:54:26-05:00
+// Date of code generation: 2022-01-21 03:37:58-05:00
 //========================================
 // The following code is generated.
 // Do not edit. Repository of code generator:

--- a/librz/asm/arch/hexagon/hexagon.c
+++ b/librz/asm/arch/hexagon/hexagon.c
@@ -3,7 +3,7 @@
 
 // LLVM commit: 96e220e6886868d6663d966ecc396befffc355e7
 // LLVM commit date: 2022-01-05 11:01:52 +0000 (ISO 8601 format)
-// Date of code generation: 2022-01-05 11:54:26-05:00
+// Date of code generation: 2022-01-21 03:37:58-05:00
 //========================================
 // The following code is generated.
 // Do not edit. Repository of code generator:

--- a/librz/asm/arch/hexagon/hexagon.h
+++ b/librz/asm/arch/hexagon/hexagon.h
@@ -3,7 +3,7 @@
 
 // LLVM commit: 96e220e6886868d6663d966ecc396befffc355e7
 // LLVM commit date: 2022-01-05 11:01:52 +0000 (ISO 8601 format)
-// Date of code generation: 2022-01-05 11:54:26-05:00
+// Date of code generation: 2022-01-21 03:37:58-05:00
 //========================================
 // The following code is generated.
 // Do not edit. Repository of code generator:

--- a/librz/asm/arch/hexagon/hexagon_arch.c
+++ b/librz/asm/arch/hexagon/hexagon_arch.c
@@ -3,7 +3,7 @@
 
 // LLVM commit: 96e220e6886868d6663d966ecc396befffc355e7
 // LLVM commit date: 2022-01-05 11:01:52 +0000 (ISO 8601 format)
-// Date of code generation: 2022-01-05 11:54:26-05:00
+// Date of code generation: 2022-01-21 03:37:58-05:00
 //========================================
 // The following code is generated.
 // Do not edit. Repository of code generator:

--- a/librz/asm/arch/hexagon/hexagon_arch.h
+++ b/librz/asm/arch/hexagon/hexagon_arch.h
@@ -3,7 +3,7 @@
 
 // LLVM commit: 96e220e6886868d6663d966ecc396befffc355e7
 // LLVM commit date: 2022-01-05 11:01:52 +0000 (ISO 8601 format)
-// Date of code generation: 2022-01-05 11:54:26-05:00
+// Date of code generation: 2022-01-21 03:37:58-05:00
 //========================================
 // The following code is generated.
 // Do not edit. Repository of code generator:

--- a/librz/asm/arch/hexagon/hexagon_insn.h
+++ b/librz/asm/arch/hexagon/hexagon_insn.h
@@ -3,7 +3,7 @@
 
 // LLVM commit: 96e220e6886868d6663d966ecc396befffc355e7
 // LLVM commit date: 2022-01-05 11:01:52 +0000 (ISO 8601 format)
-// Date of code generation: 2022-01-05 11:54:26-05:00
+// Date of code generation: 2022-01-21 03:37:58-05:00
 //========================================
 // The following code is generated.
 // Do not edit. Repository of code generator:

--- a/librz/asm/p/asm_hexagon.c
+++ b/librz/asm/p/asm_hexagon.c
@@ -3,7 +3,7 @@
 
 // LLVM commit: 96e220e6886868d6663d966ecc396befffc355e7
 // LLVM commit date: 2022-01-05 11:01:52 +0000 (ISO 8601 format)
-// Date of code generation: 2022-01-05 11:54:26-05:00
+// Date of code generation: 2022-01-21 03:37:58-05:00
 //========================================
 // The following code is generated.
 // Do not edit. Repository of code generator:

--- a/test/db/asm/hexagon
+++ b/test/db/asm/hexagon
@@ -6,7 +6,7 @@ d "?   R0 = ##0x101" 20e00078 0x0
 d "?   R5 = add(clb(R31),#0xffffffff)" 05ff3f8c 0x0
 d "?   R4 = add(R19,##0x33)" 64c613b0 0x0
 
-d "?   nop" 00c0007f 0x10000000
+d "?   nop"  00c0007f 0x10000000
 d "?   R31 = add(R0,##0x2)" 5f4000b0 0x0
 
 d "?   P0 = tstbit(R6,#0); if (!P0.new) jump:t 0x14" 04e3c611 0xc


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This PR fixes CID 367529 and others which have the same problem. The ternary expression which evaluates to the same result is replaced with a single assignment.

```
hi->ana_op.type = hi->ana_op.prefix == RZ_ANALYSIS_OP_PREFIX_HWLOOP_END ? RZ_ANALYSIS_OP_TYPE_CJMP :
 RZ_ANALYSIS_OP_TYPE_CJMP;
```
becomes
```
hi->ana_op.type = RZ_ANALYSIS_OP_TYPE_CJMP;
```

**Test plan**

None

**Closing issues**

None