### PR TITLE
Fix OOB write in `rz_str_unescape()` if last char is `\`

### DIFF
--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -1211,6 +1211,9 @@ RZ_API int rz_str_unescape(char *buf) {
 			buf[i] = (ch << 4) + ch2;
 			esc_seq_len = 4;
 			break;
+		case '\0':
+			buf[i] = '\0';
+			return i;
 		default:
 			if (IS_OCTAL(buf[i + 1])) {
 				int num_digits = 1;

--- a/test/db/cmd/cmd_fuzzed
+++ b/test/db/cmd/cmd_fuzzed
@@ -47,3 +47,13 @@ EOF
 EXPECT=<<EOF
 EOF
 RUN
+
+NAME=Escaping crash
+FILE==
+CMDS=<<EOF
+e scr.null=true
+\
+EOF
+EXPECT=<<EOF
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Fixes crash if command is only a `\`

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Test pass

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None