### PR TITLE
Fix thumb/arm breakpoint confusion on Linux/arm32

### DIFF
--- a/librz/bp/bp.c
+++ b/librz/bp/bp.c
@@ -25,7 +25,6 @@ static void rz_bp_item_free(RzBreakpointItem *b) {
  */
 RZ_API RzBreakpoint *rz_bp_new(RZ_BORROW RZ_NONNULL RzBreakpointContext *ctx) {
 	int i;
-	RzBreakpointPlugin *static_plugin;
 	RzBreakpoint *bp = RZ_NEW0(RzBreakpoint);
 	if (!bp) {
 		return NULL;
@@ -40,10 +39,7 @@ RZ_API RzBreakpoint *rz_bp_new(RZ_BORROW RZ_NONNULL RzBreakpointContext *ctx) {
 	bp->plugins = rz_list_newf((RzListFree)free);
 	bp->nhwbps = 0;
 	for (i = 0; bp_static_plugins[i]; i++) {
-		static_plugin = RZ_NEW(RzBreakpointPlugin);
-		memcpy(static_plugin, bp_static_plugins[i],
-			sizeof(RzBreakpointPlugin));
-		rz_bp_plugin_add(bp, static_plugin);
+		rz_bp_plugin_add(bp, bp_static_plugins[i]);
 	}
 	memset(&bp->iob, 0, sizeof(bp->iob));
 	return bp;

--- a/librz/bp/bp_io.c
+++ b/librz/bp/bp_io.c
@@ -39,8 +39,8 @@ RZ_API bool rz_bp_restore_except(RzBreakpoint *bp, bool set, ut64 addr) {
 	RzListIter *iter;
 	RzBreakpointItem *b;
 
-	if (set && bp->bpinmaps) {
-		bp->corebind.syncDebugMaps(bp->corebind.core);
+	if (set && bp->bpinmaps && bp->ctx.maps_sync) {
+		bp->ctx.maps_sync(bp->ctx.user);
 	}
 
 	rz_list_foreach (bp->bps, iter, b) {

--- a/librz/bp/bp_plugin.c
+++ b/librz/bp/bp_plugin.c
@@ -39,9 +39,12 @@ RZ_API int rz_bp_plugin_add(RzBreakpoint *bp, RzBreakpointPlugin *foo) {
 	return true;
 }
 
-RZ_API int rz_bp_use(RzBreakpoint *bp, const char *name, int bits) {
+/**
+ * Switch to the registered breakpoint plugin called \p name
+ */
+RZ_API int rz_bp_use(RZ_NONNULL RzBreakpoint *bp, RZ_NONNULL const char *name) {
+	rz_return_val_if_fail(bp && name, false);
 	RzListIter *iter;
-	bp->bits = bits;
 	RzBreakpointPlugin *h;
 	rz_list_foreach (bp->plugins, iter, h) {
 		if (!strcmp(h->name, name)) {

--- a/librz/bp/bp_plugin.c
+++ b/librz/bp/bp_plugin.c
@@ -21,21 +21,23 @@ RZ_API int rz_bp_plugin_del(RzBreakpoint *bp, const char *name) {
 	return false;
 }
 
-RZ_API int rz_bp_plugin_add(RzBreakpoint *bp, RzBreakpointPlugin *foo) {
+RZ_API bool rz_bp_plugin_add(RzBreakpoint *bp, RZ_BORROW RZ_NONNULL RzBreakpointPlugin *plugin) {
+	rz_return_val_if_fail(bp && plugin, false);
 	RzListIter *iter;
 	RzBreakpointPlugin *h;
-	if (!bp) {
-		eprintf("Cannot add plugin because dbg->bp is null and/or plugin is null\n");
-		return false;
-	}
 	/* avoid dupped plugins */
 	rz_list_foreach (bp->bps, iter, h) {
-		if (!strcmp(h->name, foo->name)) {
+		if (!strcmp(h->name, plugin->name)) {
 			return false;
 		}
 	}
+	RzBreakpointPlugin *dup = RZ_NEW(RzBreakpointPlugin);
+	if (!dup) {
+		return false;
+	}
+	memcpy(dup, plugin, sizeof(RzBreakpointPlugin));
 	bp->nbps++;
-	rz_list_append(bp->plugins, foo);
+	rz_list_append(bp->plugins, dup);
 	return true;
 }
 

--- a/librz/bp/bp_traptrace.c
+++ b/librz/bp/bp_traptrace.c
@@ -103,7 +103,7 @@ RZ_API int rz_bp_traptrace_add(RzBreakpoint *bp, ut64 from, ut64 to) {
 	// TODO: check return value
 	bp->iob.read_at(bp->iob.io, from, buf, len);
 	memset(bits, 0x00, bitlen);
-	rz_bp_get_bytes(bp, trap, len, bp->endian, 0);
+	rz_bp_get_bytes(bp, from, trap, len);
 
 	trace = RZ_NEW(RzBreakpointTrace);
 	if (!trace) {

--- a/librz/bp/bp_watch.c
+++ b/librz/bp/bp_watch.c
@@ -20,7 +20,7 @@ RZ_API RzBreakpointItem *rz_bp_watch_add(RzBreakpoint *bp, ut64 addr, int size, 
 		return NULL;
 	}
 	b = rz_bp_item_new(bp);
-	b->addr = addr + bp->delta;
+	b->addr = addr;
 	b->size = size;
 	b->enabled = true;
 	b->perm = perm;

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -652,13 +652,6 @@ static bool cb_asmarch(void *user, void *data) {
 	return true;
 }
 
-static bool cb_dbgbpsize(void *user, void *data) {
-	RzCore *core = (RzCore *)user;
-	RzConfigNode *node = (RzConfigNode *)data;
-	core->dbg->bpsize = node->i_value;
-	return true;
-}
-
 static bool cb_dbgbtdepth(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
@@ -726,7 +719,6 @@ static bool cb_asmbits(void *user, void *data) {
 		__setsegoff(core->config, asmarch, core->analysis->bits);
 		if (core->dbg) {
 			rz_bp_use(core->dbg->bp, asmarch);
-			rz_config_set_i(core->config, "dbg.bpsize", rz_bp_size(core->dbg->bp, core->analysis->bits));
 		}
 		/* set pcalign */
 		int v = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_ALIGN);
@@ -3453,12 +3445,6 @@ RZ_API int rz_core_config_init(RzCore *core) {
 
 	rz_config_set_getter(cfg, "dbg.swstep", (RzConfigCallback)__dbg_swstep_getter);
 
-// TODO: This should be specified at first by the debug backend when attaching
-#if __arm__ || __mips__
-	SETICB("dbg.bpsize", 4, &cb_dbgbpsize, "Size of software breakpoints");
-#else
-	SETICB("dbg.bpsize", 1, &cb_dbgbpsize, "Size of software breakpoints");
-#endif
 	SETBPREF("dbg.bpsysign", "false", "Ignore system breakpoints");
 	SETICB("dbg.btdepth", 128, &cb_dbgbtdepth, "Depth of backtrace");
 	SETCB("dbg.trace", "false", &cb_trace, "Trace program execution (see asm.trace)");

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -725,8 +725,8 @@ static bool cb_asmbits(void *user, void *data) {
 		update_syscall_ns(core);
 		__setsegoff(core->config, asmarch, core->analysis->bits);
 		if (core->dbg) {
-			rz_bp_use(core->dbg->bp, asmarch, core->analysis->bits);
-			rz_config_set_i(core->config, "dbg.bpsize", rz_bp_size(core->dbg->bp));
+			rz_bp_use(core->dbg->bp, asmarch);
+			rz_config_set_i(core->config, "dbg.bpsize", rz_bp_size(core->dbg->bp, core->analysis->bits));
 		}
 		/* set pcalign */
 		int v = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_ALIGN);

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -164,19 +164,18 @@ RZ_API bool rz_core_debug_continue_until(RzCore *core, ut64 addr, ut64 to) {
 		rz_cons_break_pop();
 		return true;
 	}
-	eprintf("Continue until 0x%08" PFMT64x " using %d bpsize\n", addr, core->dbg->bpsize);
+	RZ_LOG_ERROR("Continue until 0x%08" PFMT64x "\n", addr);
 	rz_reg_arena_swap(core->dbg->reg, true);
-	if (rz_bp_add_sw(core->dbg->bp, addr, core->dbg->bpsize, RZ_PERM_X)) {
+	if (rz_bp_add_sw(core->dbg->bp, addr, 0, RZ_PERM_X)) {
 		if (rz_debug_is_dead(core->dbg)) {
-			eprintf("Cannot continue, run ood?\n");
+			RZ_LOG_ERROR("Cannot continue, run ood?\n");
 		} else {
 			rz_debug_continue(core->dbg);
 			rz_core_reg_update_flags(core);
 		}
 		rz_bp_del(core->dbg->bp, addr);
 	} else {
-		eprintf("Cannot set breakpoint of size %d at 0x%08" PFMT64x "\n",
-			core->dbg->bpsize, addr);
+		RZ_LOG_ERROR("Cannot set breakpoint for continuing until 0x%08" PFMT64x "\n", addr);
 		return false;
 	}
 	return true;

--- a/librz/core/cmd/cmd_debug.c
+++ b/librz/core/cmd/cmd_debug.c
@@ -3564,7 +3564,7 @@ RZ_IPI RzCmdStatus rz_cmd_debug_bp_plugin_handler(RzCore *core, int argc, const 
 	if (argc == 1) {
 		rz_bp_plugin_list(core->dbg->bp);
 	} else if (argc == 2) {
-		if (!rz_bp_use(core->dbg->bp, argv[1], core->analysis->bits)) {
+		if (!rz_bp_use(core->dbg->bp, argv[1])) {
 			RZ_LOG_ERROR("Failed to set breakpoint plugin handler to %s\n", argv[1]);
 			return RZ_CMD_STATUS_ERROR;
 		}

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -2291,6 +2291,13 @@ static void bp_maps_sync(void *user) {
 	}
 }
 
+static int bp_bits_at(ut64 addr, void *user) {
+	RzCore *core = user;
+	int r = 0;
+	rz_core_arch_bits_at(core, addr, &r, NULL);
+	return r ? r : core->analysis->bits;
+}
+
 static void ev_iowrite_cb(RzEvent *ev, int type, void *user, void *data) {
 	RzCore *core = user;
 	RzEventIOWrite *iow = data;
@@ -2501,7 +2508,8 @@ RZ_API bool rz_core_init(RzCore *core) {
 	RzBreakpointContext bp_ctx = {
 		.user = core,
 		.is_mapped = bp_is_mapped,
-		.maps_sync = bp_maps_sync
+		.maps_sync = bp_maps_sync,
+		.bits_at = bp_bits_at
 	};
 	core->dbg = rz_debug_new(&bp_ctx);
 
@@ -2534,7 +2542,7 @@ RZ_API bool rz_core_init(RzCore *core) {
 		}
 	}
 	rz_config_set(core->config, "asm.arch", RZ_SYS_ARCH);
-	rz_bp_use(core->dbg->bp, RZ_SYS_ARCH, core->analysis->bits);
+	rz_bp_use(core->dbg->bp, RZ_SYS_ARCH);
 	update_sdb(core);
 	{
 		char *a = rz_path_system(RZ_FLAGS);

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -273,36 +273,6 @@ static ut64 numget(RzCore *core, const char *k) {
 	return rz_num_math(core->num, k);
 }
 
-static bool __isMapped(RzCore *core, ut64 addr, int perm) {
-	if (rz_config_get_b(core->config, "cfg.debug")) {
-		// RzList *maps = core->dbg->maps;
-		RzDebugMap *map = NULL;
-		RzListIter *iter = NULL;
-
-		rz_list_foreach (core->dbg->maps, iter, map) {
-			if (addr >= map->addr && addr < map->addr_end) {
-				if (perm > 0) {
-					if (map->perm & perm) {
-						return true;
-					}
-				} else {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-
-	return rz_io_map_is_mapped(core->io, addr);
-}
-
-static bool __syncDebugMaps(RzCore *core) {
-	if (rz_config_get_b(core->config, "cfg.debug")) {
-		return rz_debug_map_sync(core->dbg);
-	}
-	return false;
-}
-
 static const RzList *__flagsGet(RzCore *core, ut64 offset) {
 	return rz_flag_get_list(core->flags, offset);
 }
@@ -323,8 +293,6 @@ RZ_API int rz_core_bind(RzCore *core, RzCoreBind *bnd) {
 	bnd->cfggeti = (RzCoreConfigGetI)cfggeti;
 	bnd->cfgGet = (RzCoreConfigGet)cfgget;
 	bnd->numGet = (RzCoreNumGet)numget;
-	bnd->isMapped = (RzCoreIsMapped)__isMapped;
-	bnd->syncDebugMaps = (RzCoreDebugMapsSync)__syncDebugMaps;
 	bnd->flagsGet = (RzCoreFlagsGet)__flagsGet;
 	return true;
 }
@@ -2295,6 +2263,34 @@ static int win_eprintf(const char *format, ...) {
 }
 #endif
 
+static bool bp_is_mapped(ut64 addr, int perm, void *user) {
+	RzCore *core = user;
+	if (rz_core_is_debug(core)) {
+		// RzList *maps = core->dbg->maps;
+		RzDebugMap *map = NULL;
+		RzListIter *iter = NULL;
+
+		rz_list_foreach (core->dbg->maps, iter, map) {
+			if (addr < map->addr || addr >= map->addr_end) {
+				continue;
+			}
+			if (perm <= 0 || (map->perm & perm)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	return rz_io_map_is_mapped(core->io, addr);
+}
+
+static void bp_maps_sync(void *user) {
+	RzCore *core = user;
+	if (rz_core_is_debug(core)) {
+		rz_debug_map_sync(core->dbg);
+	}
+}
+
 static void ev_iowrite_cb(RzEvent *ev, int type, void *user, void *data) {
 	RzCore *core = user;
 	RzEventIOWrite *iow = data;
@@ -2502,12 +2498,16 @@ RZ_API bool rz_core_init(RzCore *core) {
 	rz_core_cmd_init(core);
 	rz_core_plugin_init(core);
 
-	core->dbg = rz_debug_new(true);
+	RzBreakpointContext bp_ctx = {
+		.user = core,
+		.is_mapped = bp_is_mapped,
+		.maps_sync = bp_maps_sync
+	};
+	core->dbg = rz_debug_new(&bp_ctx);
 
 	rz_io_bind(core->io, &(core->dbg->iob));
 	rz_io_bind(core->io, &(core->dbg->bp->iob));
 	rz_core_bind(core, &core->dbg->corebind);
-	rz_core_bind(core, &core->dbg->bp->corebind);
 	rz_core_bind(core, &core->io->corebind);
 	core->dbg->analysis = core->analysis; // XXX: dupped instance.. can cause lost pointerz
 	// rz_debug_use (core->dbg, "native");

--- a/librz/debug/debug.c
+++ b/librz/debug/debug.c
@@ -352,7 +352,8 @@ void free_tracenodes_kv(HtUPKv *kv) {
 	free(kv->value);
 }
 
-RZ_API RzDebug *rz_debug_new(int hard) {
+RZ_API RZ_OWN RzDebug *rz_debug_new(RZ_BORROW RZ_NONNULL RzBreakpointContext *bp_ctx) {
+	rz_return_val_if_fail(bp_ctx, NULL);
 	RzDebug *dbg = RZ_NEW0(RzDebug);
 	if (!dbg) {
 		return NULL;
@@ -395,12 +396,10 @@ RZ_API RzDebug *rz_debug_new(int hard) {
 	dbg->main_arena_resolved = false;
 	dbg->glibc_version = 231; /* default version ubuntu 20 */
 	rz_debug_signal_init(dbg);
-	if (hard) {
-		dbg->bp = rz_bp_new();
-		rz_debug_plugin_init(dbg);
-		dbg->bp->iob.init = false;
-		dbg->bp->baddr = 0;
-	}
+	dbg->bp = rz_bp_new(bp_ctx);
+	rz_debug_plugin_init(dbg);
+	dbg->bp->iob.init = false;
+	dbg->bp->baddr = 0;
 	return dbg;
 }
 

--- a/librz/debug/debug.c
+++ b/librz/debug/debug.c
@@ -266,7 +266,8 @@ static int rz_debug_recoil(RzDebug *dbg, RzDebugRecoilMode rc_mode) {
 }
 
 /* add a breakpoint with some typical values */
-RZ_API RzBreakpointItem *rz_debug_bp_add(RzDebug *dbg, ut64 addr, int hw, bool watch, int rw, const char *module, st64 m_delta) {
+RZ_API RZ_BORROW RzBreakpointItem *rz_debug_bp_add(RZ_NONNULL RzDebug *dbg, ut64 addr, int hw, bool watch, int rw, RZ_NULLABLE const char *module, st64 m_delta) {
+	rz_return_val_if_fail(dbg, NULL);
 	int bpsz = rz_bp_size_at(dbg->bp, addr);
 	RzBreakpointItem *bpi;
 	const char *module_name = module;

--- a/librz/debug/debug.c
+++ b/librz/debug/debug.c
@@ -265,7 +265,7 @@ static int rz_debug_recoil(RzDebug *dbg, RzDebugRecoilMode rc_mode) {
 
 /* add a breakpoint with some typical values */
 RZ_API RzBreakpointItem *rz_debug_bp_add(RzDebug *dbg, ut64 addr, int hw, bool watch, int rw, const char *module, st64 m_delta) {
-	int bpsz = rz_bp_size(dbg->bp);
+	int bpsz = rz_bp_size_at(dbg->bp, addr);
 	RzBreakpointItem *bpi;
 	const char *module_name = module;
 	RzListIter *iter;

--- a/librz/debug/p/native/linux/linux_debug.c
+++ b/librz/debug/p/native/linux/linux_debug.c
@@ -100,7 +100,7 @@ int linux_handle_signals(RzDebug *dbg, int tid) {
 		case SIGTRAP: {
 			if (dbg->glob_libs || dbg->glob_unlibs) {
 				ut64 pc_addr = rz_debug_reg_get(dbg, "PC");
-				RzBreakpointItem *b = rz_bp_get_at(dbg->bp, pc_addr - dbg->bpsize);
+				RzBreakpointItem *b = rz_bp_get_ending_at(dbg->bp, pc_addr);
 				if (b && b->internal) {
 					char *p = strstr(b->data, "dbg.");
 					if (p) {

--- a/librz/debug/p/native/linux/linux_debug.c
+++ b/librz/debug/p/native/linux/linux_debug.c
@@ -865,7 +865,7 @@ RzList *linux_thread_list(RzDebug *dbg, int pid, RzList *list) {
 		struct dirent *de;
 		DIR *dh = opendir(buf);
 		// Update the process' memory maps to set correct paths
-		dbg->corebind.syncDebugMaps(dbg->corebind.core);
+		rz_debug_map_sync(dbg);
 		while ((de = readdir(dh))) {
 			if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, "..")) {
 				continue;

--- a/librz/include/rz_bind.h
+++ b/librz/include/rz_bind.h
@@ -16,8 +16,6 @@ typedef char *(*RzCoreCmdStr)(void *core, const char *cmd);
 typedef char *(*RzCoreCmdStrF)(void *core, const char *cmd, ...);
 typedef void (*RzCorePuts)(const char *cmd);
 typedef void (*RzCoreSetArchBits)(void *core, const char *arch, int bits);
-typedef bool (*RzCoreIsMapped)(void *core, ut64 addr, int perm);
-typedef bool (*RzCoreDebugMapsSync)(void *core);
 typedef const char *(*RzCoreGetName)(void *core, ut64 off);
 typedef char *(*RzCoreGetNameDelta)(void *core, ut64 off);
 typedef void (*RzCoreSeekArchBits)(void *core, ut64 addr);
@@ -42,8 +40,6 @@ typedef struct rz_core_bind_t {
 	RzCoreConfigGetI cfggeti;
 	RzCoreConfigGet cfgGet;
 	RzCoreNumGet numGet;
-	RzCoreIsMapped isMapped;
-	RzCoreDebugMapsSync syncDebugMaps;
 	RzCoreFlagsGet flagsGet;
 } RzCoreBind;
 

--- a/librz/include/rz_bp.h
+++ b/librz/include/rz_bp.h
@@ -114,7 +114,7 @@ RZ_API RzBreakpoint *rz_bp_free(RzBreakpoint *bp);
 RZ_API bool rz_bp_del(RzBreakpoint *bp, ut64 addr);
 RZ_API bool rz_bp_del_all(RzBreakpoint *bp);
 
-RZ_API int rz_bp_plugin_add(RzBreakpoint *bp, RzBreakpointPlugin *foo);
+RZ_API bool rz_bp_plugin_add(RzBreakpoint *bp, RZ_BORROW RZ_NONNULL RzBreakpointPlugin *plugin);
 RZ_API int rz_bp_use(RZ_NONNULL RzBreakpoint *bp, RZ_NONNULL const char *name);
 RZ_API int rz_bp_plugin_del(RzBreakpoint *bp, const char *name);
 RZ_API void rz_bp_plugin_list(RzBreakpoint *bp);

--- a/librz/include/rz_bp.h
+++ b/librz/include/rz_bp.h
@@ -134,7 +134,6 @@ RZ_API bool rz_bp_enable_all(RzBreakpoint *bp, int set);
 RZ_API int rz_bp_del_index(RzBreakpoint *bp, int idx);
 RZ_API RzBreakpointItem *rz_bp_get_index(RzBreakpoint *bp, int idx);
 RZ_API int rz_bp_get_index_at(RzBreakpoint *bp, ut64 addr);
-RZ_API RzBreakpointItem *rz_bp_item_new(RzBreakpoint *bp);
 
 RZ_API RzBreakpointItem *rz_bp_get_at(RzBreakpoint *bp, ut64 addr);
 RZ_API RzBreakpointItem *rz_bp_get_in(RzBreakpoint *bp, ut64 addr, int perm);
@@ -168,7 +167,7 @@ RZ_API RzList *rz_bp_traptrace_new(void);
 RZ_API void rz_bp_traptrace_enable(RzBreakpoint *bp, int enable);
 
 /* watchpoint */
-RZ_API RzBreakpointItem *rz_bp_watch_add(RzBreakpoint *bp, ut64 addr, int size, int hw, int rw);
+RZ_API RZ_BORROW RzBreakpointItem *rz_bp_watch_add(RZ_NONNULL RzBreakpoint *bp, ut64 addr, int size, int hw, int perm);
 
 /* serialize */
 typedef void *RzSerializeBpParser;

--- a/librz/include/rz_bp.h
+++ b/librz/include/rz_bp.h
@@ -73,6 +73,7 @@ typedef struct rz_bp_context_t {
 	void *user;
 	bool (*is_mapped)(ut64 addr, int perm, void *user); ///< check if the address is mapped and has the given permissions
 	void (*maps_sync)(void *user); ///< synchronize any maps from the debugee
+	int (*bits_at)(ut64 addr, void *user); ///< get the arch-bitness to use at the given address (e.g. thumb or 32)
 } RzBreakpointContext;
 
 typedef struct rz_bp_t {
@@ -80,7 +81,6 @@ typedef struct rz_bp_t {
 	RzBreakpointContext ctx;
 	int stepcont;
 	int endian;
-	int bits;
 	bool bpinmaps; /* Only enable breakpoints inside a valid map */
 	RzIOBind iob; // compile time dependency
 	RzBreakpointPlugin *cur;
@@ -94,7 +94,6 @@ typedef struct rz_bp_t {
 	RzList *bps; // list of breakpoints
 	RzBreakpointItem **bps_idx;
 	int bps_idx_count;
-	st64 delta;
 	ut64 baddr;
 } RzBreakpoint;
 
@@ -116,15 +115,16 @@ RZ_API bool rz_bp_del(RzBreakpoint *bp, ut64 addr);
 RZ_API bool rz_bp_del_all(RzBreakpoint *bp);
 
 RZ_API int rz_bp_plugin_add(RzBreakpoint *bp, RzBreakpointPlugin *foo);
-RZ_API int rz_bp_use(RzBreakpoint *bp, const char *name, int bits);
+RZ_API int rz_bp_use(RZ_NONNULL RzBreakpoint *bp, RZ_NONNULL const char *name);
 RZ_API int rz_bp_plugin_del(RzBreakpoint *bp, const char *name);
 RZ_API void rz_bp_plugin_list(RzBreakpoint *bp);
 
 RZ_API int rz_bp_in(RzBreakpoint *bp, ut64 addr, int perm);
-RZ_API int rz_bp_size(RzBreakpoint *bp);
+RZ_API int rz_bp_size(RZ_NONNULL RzBreakpoint *bp, int bits);
+RZ_API int rz_bp_size_at(RZ_NONNULL RzBreakpoint *bp, ut64 addr);
 
 /* bp item attribs setters */
-RZ_API int rz_bp_get_bytes(RzBreakpoint *bp, ut8 *buf, int len, int endian, int idx);
+RZ_API int rz_bp_get_bytes(RZ_NONNULL RzBreakpoint *bp, ut64 addr, RZ_NONNULL ut8 *buf, int len);
 RZ_API int rz_bp_set_trace(RzBreakpoint *bp, ut64 addr, int set);
 RZ_API int rz_bp_set_trace_all(RzBreakpoint *bp, int set);
 RZ_API RzBreakpointItem *rz_bp_enable(RzBreakpoint *bp, ut64 addr, int set, int count);

--- a/librz/include/rz_bp.h
+++ b/librz/include/rz_bp.h
@@ -135,7 +135,8 @@ RZ_API int rz_bp_del_index(RzBreakpoint *bp, int idx);
 RZ_API RzBreakpointItem *rz_bp_get_index(RzBreakpoint *bp, int idx);
 RZ_API int rz_bp_get_index_at(RzBreakpoint *bp, ut64 addr);
 
-RZ_API RzBreakpointItem *rz_bp_get_at(RzBreakpoint *bp, ut64 addr);
+RZ_API RZ_BORROW RzBreakpointItem *rz_bp_get_at(RZ_NONNULL RzBreakpoint *bp, ut64 addr);
+RZ_API RZ_BORROW RzBreakpointItem *rz_bp_get_ending_at(RZ_NONNULL RzBreakpoint *bp, ut64 addr);
 RZ_API RzBreakpointItem *rz_bp_get_in(RzBreakpoint *bp, ut64 addr, int perm);
 
 RZ_API bool rz_bp_is_valid(RzBreakpoint *bp, RzBreakpointItem *b);
@@ -148,7 +149,7 @@ RZ_API int rz_bp_add_cond(RzBreakpoint *bp, const char *cond);
 RZ_API int rz_bp_del_cond(RzBreakpoint *bp, int idx);
 RZ_API int rz_bp_add_fault(RzBreakpoint *bp, ut64 addr, int size, int perm);
 
-RZ_API RzBreakpointItem *rz_bp_add_sw(RzBreakpoint *bp, ut64 addr, int size, int perm);
+RZ_API RZ_BORROW RzBreakpointItem *rz_bp_add_sw(RZ_NONNULL RzBreakpoint *bp, ut64 addr, int size, int perm);
 RZ_API RzBreakpointItem *rz_bp_add_hw(RzBreakpoint *bp, ut64 addr, int size, int perm);
 RZ_API void rz_bp_restore_one(RzBreakpoint *bp, RzBreakpointItem *b, bool set);
 RZ_API int rz_bp_restore(RzBreakpoint *bp, bool set);

--- a/librz/include/rz_debug.h
+++ b/librz/include/rz_debug.h
@@ -533,7 +533,7 @@ RZ_API bool rz_debug_is_dead(RzDebug *dbg);
 RZ_API int rz_debug_map_protect(RzDebug *dbg, ut64 addr, int size, int perms);
 
 /* breakpoints (most in rz_bp, this calls those) */
-RZ_API RzBreakpointItem *rz_debug_bp_add(RzDebug *dbg, ut64 addr, int hw, bool watch, int rw, const char *module, st64 m_delta);
+RZ_API RZ_BORROW RzBreakpointItem *rz_debug_bp_add(RZ_NONNULL RzDebug *dbg, ut64 addr, int hw, bool watch, int rw, RZ_NULLABLE const char *module, st64 m_delta);
 RZ_API void rz_debug_bp_rebase(RzDebug *dbg, ut64 old_base, ut64 new_base);
 RZ_API void rz_debug_bp_update(RzDebug *dbg);
 

--- a/librz/include/rz_debug.h
+++ b/librz/include/rz_debug.h
@@ -423,7 +423,7 @@ typedef struct rz_debug_pid_t {
 } RzDebugPid;
 
 #ifdef RZ_API
-RZ_API RzDebug *rz_debug_new(int hard);
+RZ_API RZ_OWN RzDebug *rz_debug_new(RZ_BORROW RZ_NONNULL RzBreakpointContext *bp_ctx);
 RZ_API RzDebug *rz_debug_free(RzDebug *dbg);
 
 RZ_API int rz_debug_attach(RzDebug *dbg, int pid);

--- a/librz/include/rz_debug.h
+++ b/librz/include/rz_debug.h
@@ -262,7 +262,6 @@ typedef struct rz_debug_t {
 	/* dbg.* config options (see e?dbg)
 	 * NOTE: some settings are checked inline instead of tracked here.
 	 */
-	int bpsize; /* size of a breakpoint */
 	char *btalgo; /* select backtrace algorithm */
 	int btdepth; /* backtrace depth */
 	int regcols; /* display columns */

--- a/test/unit/test_debug.c
+++ b/test/unit/test_debug.c
@@ -16,7 +16,8 @@ bool test_rz_debug_use(void) {
 	RzDebug *dbg;
 	bool res;
 
-	dbg = rz_debug_new(true);
+	RzBreakpointContext bp_ctx = { 0 };
+	dbg = rz_debug_new(&bp_ctx);
 	mu_assert_notnull(dbg, "rz_debug_new () failed");
 
 	res = rz_debug_use(dbg, "null");

--- a/test/unit/test_debug.c
+++ b/test/unit/test_debug.c
@@ -56,9 +56,520 @@ bool test_rz_debug_reg_offset(void) {
 	mu_end;
 }
 
+/**
+ * \name Debug Mock Plugins
+ * The below plugin can be used for unit tests to test RzDebug without having
+ * to rely on any system-specific behavior.
+ * @{
+ */
+
+/**
+ * Side-channel to signal failure from inside the plugin
+ * This is fine to be global since unit-tests are single-threaded.
+ */
+static bool dbg_mock_failed = false;
+
+static void dbg_mock_fail() {
+	// use an extra function to debug the tests easier
+	dbg_mock_failed = true;
+}
+
+typedef struct {
+	ut64 pc;
+	bool running;
+	RzStrBuf output; ///< output of print instructions
+	bool is_thumb; ///< only used in multibits variant below
+} DebugMockCtx;
+
+static bool dbg_mock_init(RzDebug *dbg, void **user) {
+	DebugMockCtx *ctx = RZ_NEW0(DebugMockCtx);
+	ctx->pc = 0x30;
+	ctx->running = false;
+	rz_strbuf_init(&ctx->output);
+	*user = ctx;
+	return true;
+}
+
+static void dbg_mock_fini(RzDebug *dbg, void *user) {
+	free(user);
+}
+
+static int dbg_mock_attach(RzDebug *dbg, int pid) {
+	return true;
+}
+
+static int dbg_mock_cont(RzDebug *dbg, int pid, int tid, int sig) {
+	DebugMockCtx *ctx = dbg->plugin_data;
+	ctx->running = true;
+	return RZ_DEBUG_REASON_NONE;
+}
+
+static RzDebugReasonType mock_isa_step(DebugMockCtx *ctx, RzIO *io) {
+	// mock mini instruction set:
+	static const char *op_nop = "\x00\x00\x00\x00"; ///< nop
+	static const char *op_break = "STOP"; ///< software breakpoint
+	static const char *op_print = "PRNT"; ///< print something to ctx->output
+
+	ut8 opcode[4];
+	rz_io_read_at(io, ctx->pc, opcode, sizeof(opcode));
+	ctx->pc += sizeof(opcode);
+	if (!memcmp(opcode, op_nop, sizeof(opcode))) {
+		return RZ_DEBUG_REASON_NONE;
+	}
+	if (!memcmp(opcode, op_break, sizeof(opcode))) {
+		return RZ_DEBUG_REASON_BREAKPOINT;
+	}
+	if (!memcmp(opcode, op_print, sizeof(opcode))) {
+		rz_strbuf_appendf(&ctx->output, "PRNT with next pc = 0x%" PFMT64x "\n", ctx->pc);
+		return RZ_DEBUG_REASON_NONE;
+	}
+	// invalid instruction
+	dbg_mock_fail();
+	return RZ_DEBUG_REASON_ILLEGAL;
+}
+
+RzDebugReasonType dbg_mock_wait(RzDebug *dbg, int pid) {
+	DebugMockCtx *ctx = dbg->plugin_data;
+	if (!ctx->running) {
+		return RZ_DEBUG_REASON_NONE;
+	}
+	RzIO *io = dbg->iob.io;
+	RzDebugReasonType r = RZ_DEBUG_REASON_NONE;
+	for (ut64 fuel = 0x100; fuel; fuel--) {
+		r = mock_isa_step(ctx, io);
+		if (r != RZ_DEBUG_REASON_NONE) {
+			break;
+		}
+	}
+	ctx->running = false;
+	return r;
+}
+
+#define DBG_MOCK_REG_PROFILE_SIZE 8
+
+int dbg_mock_reg_read(RzDebug *dbg, int type, ut8 *buf, int size) {
+	if (type != RZ_REG_TYPE_GPR) {
+		return 0;
+	}
+	DebugMockCtx *ctx = dbg->plugin_data;
+	if (size < DBG_MOCK_REG_PROFILE_SIZE) {
+		dbg_mock_fail();
+		return 0;
+	}
+	rz_write_at_le64(buf, ctx->pc, 0);
+	return DBG_MOCK_REG_PROFILE_SIZE;
+}
+
+int dbg_mock_reg_write(RzDebug *dbg, int type, const ut8 *buf, int size) {
+	if (type != RZ_REG_TYPE_GPR) {
+		return 0;
+	}
+	DebugMockCtx *ctx = dbg->plugin_data;
+	if (size < DBG_MOCK_REG_PROFILE_SIZE) {
+		dbg_mock_fail();
+		return 0;
+	}
+	ctx->pc = rz_read_at_le64(buf, 0);
+	return DBG_MOCK_REG_PROFILE_SIZE;
+}
+
+char *dbg_mock_reg_profile(RzDebug *dbg) {
+	return strdup(
+		"=PC	pc\n"
+		"gpr	pc	.64	0	0\n");
+}
+
+static RzDebugPlugin dbg_mock_plugin = {
+	.name = "mock_dbg",
+	.license = "LGPL3",
+	.arch = "mock_arch",
+	.init = dbg_mock_init,
+	.fini = dbg_mock_fini,
+	.attach = dbg_mock_attach,
+	.cont = dbg_mock_cont,
+	.wait = dbg_mock_wait,
+	.reg_read = dbg_mock_reg_read,
+	.reg_write = dbg_mock_reg_write,
+	.reg_profile = dbg_mock_reg_profile
+};
+
+static RzBreakpointArch bp_mock_plugin_bps[] = {
+	{ .bits = 0, .length = 4, .endian = 0, .bytes = (const ut8 *)"STOP" },
+	{ 0, 0, 0, NULL }
+};
+
+static RzBreakpointPlugin bp_mock_plugin = {
+	.name = "mock_bp",
+	.arch = "moch_arch",
+	.nbps = 1,
+	.bps = bp_mock_plugin_bps,
+};
+
+bool bp_everything_is_mapped(ut64 addr, int perm, void *user) {
+	return true;
+}
+
+static RzBreakpointContext bp_ctx = {
+	.is_mapped = bp_everything_is_mapped,
+};
+
+/// @}
+
+/**
+ * \name "Thumb" Debug Mock Plugins
+ * This is an extension to the above plugin, which supports dynamically switching
+ * between two instruction sets, like arm thumb.
+ * @{
+ */
+
+static RzDebugReasonType mock_isa_multibits_step(DebugMockCtx *ctx, RzIO *io) {
+	if (ctx->is_thumb) {
+		static const char *op_nop = "\x00\x00"; ///< nop
+		static const char *op_break = "st"; ///< software breakpoint
+		static const char *op_print = "pr"; ///< print something (just to have something other than 0s)
+		static const char *op_switch = "sw"; ///< switch to 32bit isa
+
+		ut8 opcode[2];
+		rz_io_read_at(io, ctx->pc, opcode, sizeof(opcode));
+		ctx->pc += sizeof(opcode);
+		if (!memcmp(opcode, op_nop, sizeof(opcode))) {
+			return RZ_DEBUG_REASON_NONE;
+		}
+		if (!memcmp(opcode, op_break, sizeof(opcode))) {
+			return RZ_DEBUG_REASON_BREAKPOINT;
+		}
+		if (!memcmp(opcode, op_print, sizeof(opcode))) {
+			rz_strbuf_appendf(&ctx->output, "pr with next pc = 0x%" PFMT64x "\n", ctx->pc);
+			return RZ_DEBUG_REASON_NONE;
+		}
+		if (!memcmp(opcode, op_switch, sizeof(opcode))) {
+			ctx->is_thumb = false;
+			return RZ_DEBUG_REASON_NONE;
+		}
+	} else {
+		static const char *op_nop = "\x00\x00\x00\x00"; ///< nop
+		static const char *op_break = "STOP"; ///< software breakpoint
+		static const char *op_print = "PRNT"; ///< print something (just to have something other than 0s)
+		static const char *op_switch = "SWCH"; ///< switch to 16bit isa
+
+		ut8 opcode[4];
+		rz_io_read_at(io, ctx->pc, opcode, sizeof(opcode));
+		ctx->pc += sizeof(opcode);
+		if (!memcmp(opcode, op_nop, sizeof(opcode))) {
+			return RZ_DEBUG_REASON_NONE;
+		}
+		if (!memcmp(opcode, op_break, sizeof(opcode))) {
+			return RZ_DEBUG_REASON_BREAKPOINT;
+		}
+		if (!memcmp(opcode, op_print, sizeof(opcode))) {
+			rz_strbuf_appendf(&ctx->output, "PRNT with next pc = 0x%" PFMT64x "\n", ctx->pc);
+			return RZ_DEBUG_REASON_NONE;
+		}
+		if (!memcmp(opcode, op_switch, sizeof(opcode))) {
+			ctx->is_thumb = true;
+			return RZ_DEBUG_REASON_NONE;
+		}
+	}
+	// invalid instruction
+	dbg_mock_fail();
+	return RZ_DEBUG_REASON_ILLEGAL;
+}
+
+RzDebugReasonType dbg_mock_multibits_wait(RzDebug *dbg, int pid) {
+	DebugMockCtx *ctx = dbg->plugin_data;
+	if (!ctx->running) {
+		return RZ_DEBUG_REASON_NONE;
+	}
+	RzIO *io = dbg->iob.io;
+	RzDebugReasonType r = RZ_DEBUG_REASON_NONE;
+	for (ut64 fuel = 0x100; fuel; fuel--) {
+		r = mock_isa_multibits_step(ctx, io);
+		if (r != RZ_DEBUG_REASON_NONE) {
+			break;
+		}
+	}
+	ctx->running = false;
+	return r;
+}
+
+int dbg_mock_multibits_step(RzDebug *dbg) {
+	mock_isa_multibits_step(dbg->plugin_data, dbg->iob.io);
+	return true;
+}
+
+static RzDebugPlugin dbg_mock_multibits_plugin = {
+	.name = "mock_multibits_dbg",
+	.license = "LGPL3",
+	.arch = "mock_multibits_arch",
+	.init = dbg_mock_init,
+	.fini = dbg_mock_fini,
+	.attach = dbg_mock_attach,
+	.cont = dbg_mock_cont,
+	.wait = dbg_mock_multibits_wait,
+	.step = dbg_mock_multibits_step,
+	.reg_read = dbg_mock_reg_read,
+	.reg_write = dbg_mock_reg_write,
+	.reg_profile = dbg_mock_reg_profile
+};
+
+static RzBreakpointArch bp_mock_multibits_plugin_bps[] = {
+	{ .bits = 16, .length = 2, .endian = 0, .bytes = (const ut8 *)"st" },
+	{ .bits = 32, .length = 4, .endian = 0, .bytes = (const ut8 *)"STOP" },
+	{ 0, 0, 0, NULL }
+};
+
+static RzBreakpointPlugin bp_mock_multibits_plugin = {
+	.name = "mock_multibits_bp",
+	.arch = "moch_multibits_arch",
+	.nbps = 2,
+	.bps = bp_mock_multibits_plugin_bps,
+};
+
+/// @}
+
+#define SETUP_DEBUG(dbg_plugin, bp_plugin, bp_ctx) \
+	do { \
+		dbg_mock_failed = false; \
+		dbg = rz_debug_new(bp_ctx); \
+		mu_assert_notnull(dbg, "create debug"); \
+		bool succ = rz_debug_plugin_add(dbg, dbg_plugin); \
+		mu_assert_true(succ, "add mock debug plugin"); \
+		succ = rz_bp_plugin_add(dbg->bp, bp_plugin); \
+		mu_assert_true(succ, "add mock bp plugin"); \
+		io = rz_io_new(); \
+		rz_io_bind(io, &dbg->iob); \
+		rz_io_bind(io, &dbg->bp->iob); \
+		succ = rz_debug_use(dbg, (dbg_plugin)->name); \
+		mu_assert_true(succ, "use mock debug plugin"); \
+		rz_bp_use(dbg->bp, (bp_plugin)->name); \
+		mu_assert_true(succ, "use mock bp plugin"); \
+	} while (0)
+
+/**
+ * \brief Simple sw breakpoint test
+ * Start at 0x30, set breakpoint at 0x50 and continue until it gets hit.
+ */
+static bool test_debug_sw_bp(void) {
+	RzDebug *dbg;
+	RzIO *io;
+	SETUP_DEBUG(&dbg_mock_plugin, &bp_mock_plugin, &bp_ctx);
+
+	rz_io_open_at(io, "malloc://0x1000", RZ_PERM_RW, 0644, 0x0, NULL);
+	rz_io_write_at(io, 0x50, (const ut8 *)"PRNT", 4);
+
+	int r = rz_debug_attach(dbg, 42);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_true(r, "attach");
+
+	rz_debug_reg_sync(dbg, RZ_REG_TYPE_ANY, false);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	ut64 pc = rz_reg_get_value_by_role(dbg->reg, RZ_REG_NAME_PC);
+	mu_assert_eq(pc, 0x30, "initial pc");
+
+	RzBreakpointItem *b = rz_debug_bp_add(dbg, 0x50, false, false, 0, NULL, 0);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_notnull(b, "add bp");
+
+	r = rz_debug_continue(dbg);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_true(r, "continue");
+
+	rz_debug_reg_sync(dbg, RZ_REG_TYPE_ANY, false);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	pc = rz_reg_get_value_by_role(dbg->reg, RZ_REG_NAME_PC);
+	mu_assert_eq(pc, 0x50, "pc recoiled after hitting sw breakpoint at 0x54");
+
+	ut8 data[4];
+	rz_io_read_at(io, 0x50, data, sizeof(data));
+	mu_assert_memeq(data, (const ut8 *)"PRNT", 4, "restored original bytes");
+
+	DebugMockCtx *ctx = dbg->plugin_data;
+	mu_assert_streq(rz_strbuf_get(&ctx->output), "", "no print hit");
+
+	rz_debug_free(dbg);
+	rz_io_free(io);
+	mu_end;
+}
+
+/**
+ * \name Thumb/Non-thumb software breakpoint test
+ * Set up some mixed thumb and non-thumb code, put breakpoints in both parts and check that
+ * all of them are set up correctly (selecting the right byte patterns from the bp plugin) and hit.
+ * @{
+ */
+
+int sw_bp_multibits_bits_at(ut64 addr, void *user) {
+	// this corresponds to the instruction of the program written into io in test_debug_sw_bp_multibits()
+	return addr >= 0x58 && addr < 0x60 ? 16 : 32;
+}
+
+static bool test_debug_sw_bp_multibits(void) {
+	RzBreakpointContext bp_ctx = {
+		.is_mapped = bp_everything_is_mapped,
+		.bits_at = sw_bp_multibits_bits_at
+	};
+
+	RzDebug *dbg;
+	RzIO *io;
+	SETUP_DEBUG(&dbg_mock_multibits_plugin, &bp_mock_multibits_plugin, &bp_ctx);
+
+	rz_io_open_at(io, "malloc://0x1000", RZ_PERM_RW, 0644, 0x0, NULL);
+	// program is some non-thumb code with a chunk of thumb in between
+	rz_io_write_at(io, 0x50, (const ut8 *)"PRNT", 4);
+	rz_io_write_at(io, 0x54, (const ut8 *)"SWCH", 4);
+	rz_io_write_at(io, 0x58, (const ut8 *)"pr", 2);
+	rz_io_write_at(io, 0x5a, (const ut8 *)"pr", 2);
+	rz_io_write_at(io, 0x5e, (const ut8 *)"sw", 2);
+	rz_io_write_at(io, 0x60, (const ut8 *)"PRNT", 2);
+	const char full_code[] =
+		/* 0x4c */ "\x00\x00\x00\x00"
+			   /* 0x50 */ "PRNT"
+			   /* 0x54 */ "SWCH"
+			   /* 0x58 */ "pr"
+			   /* 0x5a */ "pr"
+			   /* 0x5c */ "\x00\x00"
+			   /* 0x5e */ "sw"
+			   /* 0x60 */ "PRNT"
+			   /* 0x64 */ "\x00\x00\x00\x00"
+			   /* 0x68 */ "\x00\x00\x00\x00"
+			   /* 0x6c */ "\x00\x00\x00\x00";
+#define FULL_CODE_SIZE (0x70 - 0x4c)
+	mu_assert_eq(sizeof(full_code) - 1, FULL_CODE_SIZE, "code size");
+	rz_io_write_at(io, 0x4c, (const ut8 *)full_code, FULL_CODE_SIZE);
+
+	int r = rz_debug_attach(dbg, 42);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_true(r, "attach");
+
+	rz_debug_reg_sync(dbg, RZ_REG_TYPE_ANY, false);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	ut64 pc = rz_reg_get_value_by_role(dbg->reg, RZ_REG_NAME_PC);
+	mu_assert_eq(pc, 0x30, "initial pc");
+
+	RzBreakpointItem *b = rz_debug_bp_add(dbg, 0x50, false, false, 0, NULL, 0);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_notnull(b, "add bp in non-thumb");
+	mu_assert_eq(b->size, 4, "non-thumb bp size");
+	b = rz_debug_bp_add(dbg, 0x54, false, false, 0, NULL, 0);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_notnull(b, "add bp at the end of non-thumb");
+	mu_assert_eq(b->size, 4, "non-thumb bp size");
+	b = rz_debug_bp_add(dbg, 0x58, false, false, 0, NULL, 0);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_notnull(b, "add bp at the beginning of thumb");
+	mu_assert_eq(b->size, 2, "thumb bp size");
+	b = rz_debug_bp_add(dbg, 0x5a, false, false, 0, NULL, 0);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_notnull(b, "add bp in the middle of thumb");
+	mu_assert_eq(b->size, 2, "thumb bp size");
+	b = rz_debug_bp_add(dbg, 0x5e, false, false, 0, NULL, 0);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_notnull(b, "add bp at the end of thumb");
+	mu_assert_eq(b->size, 2, "thumb bp size");
+	b = rz_debug_bp_add(dbg, 0x68, false, false, 0, NULL, 0);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_notnull(b, "add bp after thumb");
+	mu_assert_eq(b->size, 4, "non-thumb bp size");
+
+	DebugMockCtx *ctx = dbg->plugin_data;
+
+	r = rz_debug_continue(dbg);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_true(r, "continue");
+	rz_debug_reg_sync(dbg, RZ_REG_TYPE_ANY, false);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	pc = rz_reg_get_value_by_role(dbg->reg, RZ_REG_NAME_PC);
+	mu_assert_eq(pc, 0x50, "pc recoiled after hitting sw breakpoint at 0x54");
+	mu_assert_streq(rz_strbuf_get(&ctx->output), "", "output");
+	ut8 data[FULL_CODE_SIZE];
+	rz_io_read_at(io, 0x4c, data, sizeof(data));
+	mu_assert_memeq(data, (const ut8 *)full_code, sizeof(data), "restored original bytes");
+
+	r = rz_debug_continue(dbg);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_true(r, "continue");
+	rz_debug_reg_sync(dbg, RZ_REG_TYPE_ANY, false);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	pc = rz_reg_get_value_by_role(dbg->reg, RZ_REG_NAME_PC);
+	mu_assert_eq(pc, 0x54, "pc recoiled after hitting sw breakpoint at 0x54");
+	mu_assert_streq(rz_strbuf_get(&ctx->output),
+		"PRNT with next pc = 0x54\n",
+		"output");
+	rz_io_read_at(io, 0x4c, data, sizeof(data));
+	mu_assert_memeq(data, (const ut8 *)full_code, sizeof(data), "restored original bytes");
+
+	r = rz_debug_continue(dbg);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_true(r, "continue");
+	rz_debug_reg_sync(dbg, RZ_REG_TYPE_ANY, false);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	pc = rz_reg_get_value_by_role(dbg->reg, RZ_REG_NAME_PC);
+	mu_assert_eq(pc, 0x58, "pc recoiled after hitting sw breakpoint at 0x54");
+	mu_assert_streq(rz_strbuf_get(&ctx->output),
+		"PRNT with next pc = 0x54\n",
+		"output");
+	rz_io_read_at(io, 0x4c, data, sizeof(data));
+	mu_assert_memeq(data, (const ut8 *)full_code, sizeof(data), "restored original bytes");
+
+	r = rz_debug_continue(dbg);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_true(r, "continue");
+	rz_debug_reg_sync(dbg, RZ_REG_TYPE_ANY, false);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	pc = rz_reg_get_value_by_role(dbg->reg, RZ_REG_NAME_PC);
+	mu_assert_eq(pc, 0x5a, "pc recoiled after hitting sw breakpoint at 0x54");
+	mu_assert_streq(rz_strbuf_get(&ctx->output),
+		"PRNT with next pc = 0x54\n"
+		"pr with next pc = 0x5a\n",
+		"output");
+	rz_io_read_at(io, 0x4c, data, sizeof(data));
+	mu_assert_memeq(data, (const ut8 *)full_code, sizeof(data), "restored original bytes");
+
+	r = rz_debug_continue(dbg);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_true(r, "continue");
+	rz_debug_reg_sync(dbg, RZ_REG_TYPE_ANY, false);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	pc = rz_reg_get_value_by_role(dbg->reg, RZ_REG_NAME_PC);
+	mu_assert_eq(pc, 0x5e, "pc recoiled after hitting sw breakpoint at 0x54");
+	mu_assert_streq(rz_strbuf_get(&ctx->output),
+		"PRNT with next pc = 0x54\n"
+		"pr with next pc = 0x5a\n"
+		"pr with next pc = 0x5c\n",
+		"output");
+	rz_io_read_at(io, 0x4c, data, sizeof(data));
+	mu_assert_memeq(data, (const ut8 *)full_code, sizeof(data), "restored original bytes");
+
+	r = rz_debug_continue(dbg);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	mu_assert_true(r, "continue");
+	rz_debug_reg_sync(dbg, RZ_REG_TYPE_ANY, false);
+	mu_assert_false(dbg_mock_failed, "global failure");
+	pc = rz_reg_get_value_by_role(dbg->reg, RZ_REG_NAME_PC);
+	mu_assert_eq(pc, 0x68, "pc recoiled after hitting sw breakpoint at 0x54");
+	mu_assert_streq(rz_strbuf_get(&ctx->output),
+		"PRNT with next pc = 0x54\n"
+		"pr with next pc = 0x5a\n"
+		"pr with next pc = 0x5c\n"
+		"PRNT with next pc = 0x64\n",
+		"output");
+	rz_io_read_at(io, 0x4c, data, sizeof(data));
+	mu_assert_memeq(data, (const ut8 *)full_code, sizeof(data), "restored original bytes");
+
+#undef FULL_CODE_SIZE
+	rz_debug_free(dbg);
+	rz_io_free(io);
+	mu_end;
+}
+/// @}
+
 int all_tests() {
+	rz_cons_new(); // there is some windows-specific code in debug that accesses the cons singleton
 	mu_run_test(test_rz_debug_use);
 	mu_run_test(test_rz_debug_reg_offset);
+	mu_run_test(test_debug_sw_bp);
+	mu_run_test(test_debug_sw_bp_multibits);
+	rz_cons_free();
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This consists of multiple commits solving different problems. See the individual commit descriptions for details.

The specific motivation is this issues, see how the breakpoint works or not depending on whether a `pd` was called at main before creating it:

![Bildschirmfoto 2022-01-25 um 17 59 13](https://user-images.githubusercontent.com/1460997/151023267-715abe44-e7fc-4f81-90be-2e5387b9e366.png)

That is because the kind of sw breakpoint that was set depended on the current global `asm.bits` (and `dbg.bpsize` set automatically along with it`), but not on the actual bits at the breakpoint address, which may be different. This pr fixes this by always calculating it for the exact address.

**Test plan**

* Start debugging an arm32 executable that starts in thumb mode, but has main as non-thumb
* Before doing anything else, do `dcu main` or `db @ main; dc`
* The breakpoint should be hit
