### PR TITLE
Fix escape sequence used to disable console mouse

### DIFF
--- a/librz/cons/cons.c
+++ b/librz/cons/cons.c
@@ -497,9 +497,7 @@ RZ_API bool rz_cons_enable_mouse(const bool enable) {
 #endif
 		const char *click = enable
 			? "\x1b[?1000;1006;1015h"
-			: "\x1b[?1001r"
-			  "\x1b[?1000l";
-		// : "\x1b[?1000;1006;1015l";
+			: "\x1b[?1000;1006;1015l";
 		// const char *old = enable ? "\x1b[?1001s" "\x1b[?1000h" : "\x1b[?1001r" "\x1b[?1000l";
 		bool enabled = I.mouse;
 		const size_t click_len = strlen(click);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The escape sequence used to disable console mouse seems/is wrong and causes issues with the mouse in some cases, such as leaving visual panels mode the first time in new terminal. This escape sequence seems to be the right one to use according to the documentation. But some Git history spelunking (To figure out why it was commented like this in the first place) and further testing might be in order.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

Manually tested on Widows pwsh 7.2.1 and cmd running on both wt.exe (Windows Terminal) and classic conhost on Windows 10.0.19044.0.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #2216
