### PR TITLE
Set `bf` machine memory size to 30,000

### DIFF
--- a/librz/bin/p/bin_bf.c
+++ b/librz/bin/p/bin_bf.c
@@ -139,7 +139,7 @@ static RzList *maps(RzBinFile *bf) {
 	map->paddr = 0;
 	map->vaddr = 0x10000;
 	map->psize = 0;
-	map->vsize = 0x10000;
+	map->vsize = 30000;
 	map->perm = RZ_PERM_RW;
 	map->name = strdup("mem");
 	rz_list_append(ret, map);

--- a/test/db/formats/bf
+++ b/test/db/formats/bf
@@ -23,6 +23,6 @@ NAME=30,000 nulls
 FILE=bins/bf/2+5.bf
 CMDS=o~null
 EXPECT=<<EOF
- 4 - rw- 0x00010000 null://65536
+ 4 - rw- 0x00007530 null://30000
 EOF
 RUN

--- a/test/db/formats/bf
+++ b/test/db/formats/bf
@@ -18,3 +18,11 @@ format   bf
 size     0x2af
 EOF
 RUN
+
+NAME=30,000 nulls
+FILE=bins/bf/2+5.bf
+CMDS=o~null
+EXPECT=<<EOF
+ 4 - rw- 0x00010000 null://65536
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

According to [here](https://gist.github.com/rdebath/0ca09ec0fdcf3f82478f) and [here](https://esolangs.org/w/index.php?title=Brainfuck&oldid=91656#Memory_and_wrapping), the original/usual memory size for a `bf` machine is 30,000 elements. This pr makes it such that rizin's `bf` machine also has 30,000 elements, following the original/usual implementations.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
