### PR TITLE
Use `rz_file_path_join` in rz-find to avoid duplicated dir separator

### DIFF
--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -322,7 +322,7 @@ static int rzfind_open_dir(RzfindOptions *ro, const char *dir) {
 			if (*fname == '.') {
 				continue;
 			}
-			fullpath = rz_str_newf("%s" RZ_SYS_DIR "%s", dir, fname);
+			fullpath = rz_file_path_join(dir, fname);
 			(void)rzfind_open(ro, fullpath);
 			free(fullpath);
 		}


### PR DESCRIPTION
  This commit contains two parts. One is adding functions
  used to trim specific char in str. The other one is a
  fix to remove redundant slash in tail.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

While using `rz-find -s abc /bin/`, the output will contain duplicate slash, like `/bin//ls`. 

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
