### PR TITLE
Add sb (= r9) alias to arm assembler

### DIFF
--- a/librz/asm/arch/arm/armass.c
+++ b/librz/asm/arch/arm/armass.c
@@ -615,7 +615,7 @@ static char *getrange(char *s) {
 static int getreg(const char *str) {
 	int i;
 	char *ep;
-	const char *aliases[] = { "sl", "fp", "ip", "sp", "lr", "pc", NULL };
+	const char *aliases[] = { "sb", "sl", "fp", "ip", "sp", "lr", "pc", NULL };
 	if (!str || !*str) {
 		return -1;
 	}
@@ -630,7 +630,7 @@ static int getreg(const char *str) {
 	}
 	for (i = 0; aliases[i]; i++) {
 		if (!strcmpnull(str, aliases[i])) {
-			return 10 + i;
+			return 9 + i;
 		}
 	}
 	return -1;

--- a/test/db/asm/arm_16
+++ b/test/db/asm/arm_16
@@ -9,6 +9,7 @@ a "bl -0x2a" fff7e9ff
 d "bl 0xffffffd6" fff7e9ff
 ad "mov fp, r1" 8b46
 a "mov r9, r1" 8946
+ad "mov sb, r1" 8946
 a "mov r4, r1" 0c46
 ad "add sp, 0x10" 04b0
 a "add sp, 0x16" 0df1160d


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

From #2241
We disassemble `r9` as `sb`, so it should also be supported for assembling this way.