### PR TITLE
Enable specifying exact reg bindings in RzAnalysisILConfig

### DIFF
--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1135,17 +1135,22 @@ typedef struct rz_analysis_il_init_state_t {
  * * Size of the program counter: given explicitly in `pc_size`
  * * Endian: given explicitly in `big_endian`
  * * Memories: currently always one memory with index 0 bound against IO, with key size given by `mem_key_size` and value size of 8
- * * Registers: currently implicit, derived from the register profile with `rz_il_reg_binding_derive()`
+ * * Registers: given explicitly in `reg_bindings` or derived from the register profile with `rz_il_reg_binding_derive()`
  * * Labels: given explicitly in `labels`
  * * Initial State of Variables: optionally given in `init_state`
  */
 typedef struct rz_analysis_il_config_t {
 	ut32 pc_size; ///< size of the program counter in bits
 	bool big_endian;
+	/**
+	 * Optional null-terminated array of registers to bind to global vars of the same name.
+	 * If not specified, rz_il_reg_binding_derive will be used.
+	 */
+	RZ_NULLABLE const char **reg_bindings;
 	ut32 mem_key_size; ///< address size for memory 0, bound against IO
 	RzPVector /* <RzILEffectLabel> */ labels; ///< global labels, primarily for syscall/hook callbacks
 	RZ_NULLABLE RzAnalysisILInitState *init_state; ///< optional, initial contents for variables/registers, etc.
-	// more information might go in here, for example additional memories, register bindings, etc.
+	// more information might go in here, for example additional memories, etc.
 } RzAnalysisILConfig;
 
 /**


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Cherry-pick from #2241 
ARM has register aliases of the same size, so the current `rz_il_reg_binding_derive()` just picks one of them (which one is unspecified). Trying to make automatic derivation account for this would become too awkward, so it's better to just specify the binding explicitly in such cases, which plugins can do now.