### PR TITLE
Fix NULL deref in table query and add missing help

### DIFF
--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -10570,6 +10570,8 @@ static const RzCmdDescDetailEntry specifiers_Table_space_format_space_specifiers
 	{ .text = "<col>/ne/<val>", .arg_str = NULL, .comment = "Grep rows where column <col> is not equal to <val>." },
 	{ .text = "<col|*>/uniq", .arg_str = NULL, .comment = "Only get the first row where column <col> or all columns are unique." },
 	{ .text = "*/page/<n_page>/<page_size>", .arg_str = NULL, .comment = "Show <page_size> rows starting from the page number <n_page>." },
+	{ .text = "*/head/<n_rows>", .arg_str = NULL, .comment = "Show the first <n_rows> rows." },
+	{ .text = "*/tail/<n_rows>", .arg_str = NULL, .comment = "Show the last <n_rows> rows." },
 	{ .text = "<col>/str/<value>", .arg_str = NULL, .comment = "Grep rows where string <value> is a substring of column <col>." },
 	{ .text = "<col>/strlen/<value>", .arg_str = NULL, .comment = "Grep rows where the length of column <col> is <value>." },
 	{ .text = "<col>/minlen/<value>", .arg_str = NULL, .comment = "Grep rows where the length of column <col> is greater than <value>." },

--- a/librz/core/cmd_descs/cmd_descs.yaml
+++ b/librz/core/cmd_descs/cmd_descs.yaml
@@ -590,6 +590,10 @@ commands:
             comment: Only get the first row where column <col> or all columns are unique.
           - text: "*/page/<n_page>/<page_size>"
             comment: Show <page_size> rows starting from the page number <n_page>.
+          - text: "*/head/<n_rows>"
+            comment: Show the first <n_rows> rows.
+          - text: "*/tail/<n_rows>"
+            comment: Show the last <n_rows> rows.
           - text: "<col>/str/<value>"
             comment: Grep rows where string <value> is a substring of column <col>.
           - text: "<col>/strlen/<value>"

--- a/librz/util/table.c
+++ b/librz/util/table.c
@@ -676,7 +676,7 @@ RZ_API void rz_table_filter(RzTable *t, int nth, int op, const char *un) {
 			match = (nv <= uv);
 			break;
 		case '=':
-			if (nv == 0) {
+			if (nv == 0 && nn != NULL) {
 				match = !strcmp(nn, un);
 			} else {
 				match = (nv == uv);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

```
$ ./build/binrz/rizin/rizin -A /bin/ls
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze function calls (aac)
[x] Analyze len bytes of instructions for references (aar)
[x] Check for classes
[x] Type matching analysis for all functions (aaft)
[x] Propagate noreturn information
[x] Use -AA or aaaa to perform additional experimental analysis.
[x] Applied 0 FLIRT signatures via sigdb
 -- Change the block size with 'b <block-size>'. In visual mode you can also enter rizin command pressing the ':' key (like vi does)
[0x00006b10]> aflt:size/ne/0:addr/ne/0:/head/10,
```

This should return an error, but it should not segfault.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
