### PR TITLE
Remove `-b32` from bf rzil tests

### DIFF
--- a/test/db/rzil/bf
+++ b/test/db/rzil/bf
@@ -1,6 +1,6 @@
 NAME=hello world
 FILE=bins/bf/hello-ok.bf
-ARGS=-b32 -eio.cache=1
+ARGS=-eio.cache=1
 CMDS=<<EOF
 e asm.arch=bf
 e asm.bytes=true
@@ -21,7 +21,6 @@ RUN
 
 NAME=hello world - unbalanced loop
 FILE=bins/bf/hello-unbalanced-loop.bf
-ARGS=-b32
 CMDS=<<EOF
 e asm.arch=bf
 e asm.bytes=true
@@ -39,7 +38,7 @@ RUN
 
 NAME=loopy hello world
 FILE=bins/bf/hello-loops.bf
-ARGS=-b32 -eio.cache=1
+ARGS=-eio.cache=1
 CMDS=<<EOF
 s 0
 aezi
@@ -52,7 +51,7 @@ RUN
 
 NAME=instructions
 FILE=bins/bf/hello-loops.bf
-ARGS=-b32 -eio.cache=1
+ARGS=-eio.cache=1
 CMDS=<<EOF
 e asm.arch=bf
 e analysis.arch=bf
@@ -112,7 +111,7 @@ RUN
 
 NAME=loopy hello world
 FILE=bins/bf/hello-loops.bf
-ARGS=-b32 -eio.cache=1
+ARGS=-eio.cache=1
 CMDS=<<EOF
 s 0
 aezi
@@ -125,7 +124,7 @@ RUN
 
 NAME=instructions
 FILE=bins/bf/hello-loops.bf
-ARGS=-b32 -eio.cache=1
+ARGS=-eio.cache=1
 CMDS=<<EOF
 e asm.arch=bf
 e analysis.arch=bf


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr just removes `-b32` from the `bf` rzil tests. I don't think there's any good reason to have a 32-bit `bf` machine.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
