### PR TITLE
Add patching for R_386_32 and R_386_PC32

### DIFF
--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -963,6 +963,21 @@ static void patch_reloc(struct Elf_(rz_bin_elf_obj_t) * obj, RzBinElfReloc *rel,
 		}
 		break;
 	}
+	case EM_386:
+		switch (rel->type) {
+		case RZ_386_32:
+		case RZ_386_PC32:
+			rz_buf_read_at(obj->buf_patched, patch_addr, buf, 4);
+			val = rz_read_le32(buf) + S + A;
+			if (rel->type == RZ_386_PC32) {
+				val -= P;
+			}
+			rz_write_le32(buf, val);
+			rz_buf_write_at(obj->buf_patched, patch_addr, buf, 4);
+		default:
+			break;
+		}
+		break;
 	case EM_X86_64: {
 		int word = 0;
 		switch (rel->type) {

--- a/test/db/formats/elf/reloc
+++ b/test/db/formats/elf/reloc
@@ -382,3 +382,34 @@ EXPECT=<<EOF
 \   ,=====< 0x080000b0      jmp   reloc.target.getPageLengthEE         ; RELOC 32 getPageLengthEE
 EOF
 RUN
+
+NAME=x86 32bit relocs in kernel module
+FILE=bins/elf/linux-example-x86-32.ko
+CMDS=<<EOF
+s 0x0800007c
+pi 15
+px 0x26
+EOF
+EXPECT=<<EOF
+call reloc.target.__fentry
+push ebp
+mov ebp, esp
+push reloc.target..rodata.str1.1
+call reloc.target.printk
+xor eax, eax
+leave
+ret
+push ebp
+mov ebp, esp
+push str.Ulu_mulu
+call reloc.target.printk
+pop eax
+leave
+ret
+- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
+0x0800007c  e8d7 c802 0055 89e5 68a2 0000 08e8 cec8  .....U..h.......
+0x0800008c  0200 31c0 c9c3 5589 e568 b100 0008 e8bd  ..1...U..h......
+0x0800009c  c802 0058 c9c3                           ...X..
+EOF
+RUN
+

--- a/test/db/formats/elf/sections
+++ b/test/db/formats/elf/sections
@@ -75,12 +75,12 @@ FILE=bins/elf/pngrutil_o
 CMDS=oml
 EXPECT=<<EOF
  1 fd: 4 +0x00000000 0x0800870c - 0x080090c7 r-- vmap.reloc-targets
- 2 fd: 3 +0x00000034 0x08000034 - 0x080055c7 r-x fmap..text
+ 2 fd: 5 +0x00000034 0x08000034 - 0x080055c7 r-x vmap..text
  3 fd: 3 +0x00007328 0x08007328 - 0x0800852f --x fmap..rel.text
- 4 fd: 3 +0x000055c8 0x080055c8 - 0x0800642b r-- fmap..rodata
+ 4 fd: 5 +0x000055c8 0x080055c8 - 0x0800642b r-- vmap..rodata
  5 fd: 3 +0x00008530 0x08008530 - 0x0800858f --- fmap..rel.rodata
  6 fd: 3 +0x0000642c 0x0800642c - 0x08006461 --- fmap..comment
- 7 fd: 3 +0x00006464 0x08006464 - 0x080068cb r-- fmap..eh_frame
+ 7 fd: 5 +0x00006464 0x08006464 - 0x080068cb r-- vmap..eh_frame
  8 fd: 3 +0x00008590 0x08008590 - 0x0800869f --- fmap..rel.eh_frame
  9 fd: 3 +0x000086a0 0x080086a0 - 0x08008702 --- fmap..shstrtab
 10 fd: 3 +0x000068cc 0x080068cc - 0x08006e5b --- fmap..symtab


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Reference is `apply_relocate()` in `arch/x86/kernel/module.c` of linux 3906fe9bb7f1a2c8667ae54e967dc8690824f4ea
The targets shown in `ir` are still somewhat off, but that should probably be done after #1699

Fix partially #2277