### PR TITLE
Use `ar` in some rzil bf tests instead of `aezv`

### DIFF
--- a/test/db/rzil/bf
+++ b/test/db/rzil/bf
@@ -1722,19 +1722,21 @@ w + @ 2
 aezi
 ara+
 aezsu $s; ?e
-aezv
+ar
 ?e --- Reset everything ---
 ara-
-aezi  # Shouldn't be necessary
-aezv
 wcr
+ar
+aezi  # Shouldn't be necessary
 aezsu $s; ?e
 EOF
 EXPECT=<<EOF
 8
- PC: 0x00000000000002af ptr: 0x0000000000010000
+ptr = 0x00010000
+pc = 0x000002af
 --- Reset everything ---
- PC: 0x0000000000000000 ptr: 0x0000000000010000
+ptr = 0x00010000
+pc = 0x00000000
 7
 EOF
 RUN
@@ -1746,11 +1748,12 @@ CMDS=<<EOF
 e io.cache=1
 ar pc=1
 aezi
-aezv
+ar
 aezsu $s; ?e
 EOF
 EXPECT=<<EOF
- PC: 0x0000000000000001 ptr: 0x0000000000010000
+ptr = 0x00010000
+pc = 0x00000001
 6
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr replaces some usage of `aezv` in the rzil `bf` tests with `ar` as it is the primary source for emulation register values.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
