### PR TITLE
Remove eprintfs from analysis source code.

### DIFF
--- a/librz/analysis/analysis.c
+++ b/librz/analysis/analysis.c
@@ -482,7 +482,7 @@ RZ_API bool rz_analysis_noreturn_add(RzAnalysis *analysis, const char *name, ut6
 		RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(analysis, addr, -1);
 		RzFlagItem *fi = analysis->flb.get_at(analysis->flb.f, addr, false);
 		if (!fcn && !fi) {
-			eprintf("Can't find Function at given address\n");
+			RZ_LOG_ERROR("Cannot find function and flag at address 0x%" PFMT64x "\n", addr);
 			return false;
 		}
 		tmp_name = fcn ? fcn->name : fi->name;
@@ -497,10 +497,10 @@ RZ_API bool rz_analysis_noreturn_add(RzAnalysis *analysis, const char *name, ut6
 			if (name) {
 				sdb_bool_set(NDB, K_NORET_FUNC(name), true, 0);
 			} else {
-				eprintf("Can't find prototype for: %s\n", tmp_name);
+				RZ_LOG_ERROR("Cannot find prototype for: %s\n", tmp_name);
 			}
 		} else {
-			eprintf("Can't find prototype for: %s\n", tmp_name);
+			RZ_LOG_ERROR("Cannot find prototype for: %s\n", tmp_name);
 		}
 		// return false;
 	}
@@ -563,7 +563,7 @@ static bool noreturn_recurse(RzAnalysis *analysis, ut64 addr) {
 	ut8 bbuf[0x10] = { 0 };
 	ut64 recurse_addr = UT64_MAX;
 	if (!analysis->iob.read_at(analysis->iob.io, addr, bbuf, sizeof(bbuf))) {
-		eprintf("Couldn't read buffer\n");
+		RZ_LOG_ERROR("Cannot read buffer at 0x%" PFMT64x "\n", addr);
 		return false;
 	}
 	if (rz_analysis_op(analysis, &op, addr, bbuf, sizeof(bbuf), RZ_ANALYSIS_OP_MASK_BASIC | RZ_ANALYSIS_OP_MASK_VAL) < 1) {

--- a/librz/analysis/block.c
+++ b/librz/analysis/block.c
@@ -349,9 +349,7 @@ RZ_API bool rz_analysis_block_merge(RzAnalysisBlock *a, RzAnalysisBlock *b) {
 	a->jump = b->jump;
 	a->fail = b->fail;
 	if (a->switch_op) {
-		if (a->analysis->verbose) {
-			eprintf("Dropping switch table at 0x%" PFMT64x " of block at 0x%" PFMT64x "\n", a->switch_op->addr, a->addr);
-		}
+		RZ_LOG_DEBUG("Dropping switch table at 0x%" PFMT64x " of block at 0x%" PFMT64x "\n", a->switch_op->addr, a->addr);
 		rz_analysis_switch_op_free(a->switch_op);
 	}
 	a->switch_op = b->switch_op;

--- a/librz/analysis/cc.c
+++ b/librz/analysis/cc.c
@@ -77,12 +77,12 @@ RZ_API char *rz_analysis_cc_get(RzAnalysis *analysis, const char *name) {
 	int i;
 	// get cc by name and print the expr
 	if (rz_str_cmp(sdb_const_get(DB, name, 0), "cc", -1)) {
-		eprintf("This is not a valid calling convention name\n");
+		RZ_LOG_ERROR("'%s' is not a valid calling convention name\n", name);
 		return NULL;
 	}
 	const char *ret = sdb_const_get(DB, sdb_fmt("cc.%s.ret", name), 0);
 	if (!ret) {
-		eprintf("Cannot find return key\n");
+		RZ_LOG_ERROR("Cannot find return key in calling convention named '%s'\n", name);
 		return NULL;
 	}
 	RzStrBuf *sb = rz_strbuf_new(NULL);

--- a/librz/analysis/data.c
+++ b/librz/analysis/data.c
@@ -114,7 +114,7 @@ RZ_API char *rz_analysis_data_to_string(RzAnalysisData *d, RzConsPrintablePalett
 		return NULL;
 	}
 	if (!rz_strbuf_reserve(sb, mallocsz)) {
-		eprintf("Cannot allocate %d byte(s)\n", mallocsz);
+		RZ_LOG_ERROR("Cannot allocate %d byte(s)\n", mallocsz);
 		rz_strbuf_free(sb);
 		return NULL;
 	}
@@ -230,7 +230,7 @@ RZ_API RzAnalysisData *rz_analysis_data_new_string(ut64 addr, const char *p, int
 		ad->buf = malloc(len + 1);
 		if (!ad->buf) {
 			rz_analysis_data_free(ad);
-			eprintf("Cannot allocate %d byte(s)\n", len + 1);
+			RZ_LOG_ERROR("Cannot allocate %d byte(s)\n", len + 1);
 			return NULL;
 		}
 		memcpy(ad->buf, ad->str, len + 1);

--- a/librz/analysis/esil/esil_interrupt.c
+++ b/librz/analysis/esil/esil_interrupt.c
@@ -55,14 +55,14 @@ RZ_API int rz_analysis_esil_fire_interrupt(RzAnalysisEsil *esil, ut32 intr_num) 
 	}
 
 	if (!esil->interrupts) {
-		eprintf("no interrupts initialized\n");
+		RZ_LOG_ERROR("no interrupts initialized\n");
 		return false;
 	}
 	RzAnalysisEsilInterrupt *intr = ht_up_find(esil->interrupts, intr_num, NULL);
 #if 0
 	// we don't want this warning
 	if (!intr) {
-		eprintf ("Warning no interrupt handler registered for 0x%x\n", intr_num);
+		RZ_LOG_WARN("no interrupt handler registered for 0x%x\n", intr_num);
 	}
 #endif
 	return (intr && intr->handler && intr->handler->cb) ? intr->handler->cb(esil, intr_num, intr->user) : false;

--- a/librz/analysis/esil/esil_sources.c
+++ b/librz/analysis/esil/esil_sources.c
@@ -12,24 +12,20 @@ RZ_API void rz_analysis_esil_sources_init(RzAnalysisEsil *esil) {
 }
 
 RZ_API ut32 rz_analysis_esil_load_source(RzAnalysisEsil *esil, const char *path) {
+	rz_return_val_if_fail(esil && RZ_STR_ISNOTEMPTY(path), 0);
 	RzAnalysisEsilSource *src;
-
-	if (!esil) {
-		eprintf("no esil?\n");
-		return 0;
-	}
 
 	src = RZ_NEW0(RzAnalysisEsilSource);
 	src->content = rz_lib_dl_open(path);
 	if (!src->content) {
-		eprintf("no content\n");
+		RZ_LOG_ERROR("esil: cannot load library (no content)\n");
 		free(src);
 		return 0;
 	}
 
 	rz_analysis_esil_sources_init(esil);
 	if (!rz_id_storage_add(esil->sources, src, &src->id)) {
-		eprintf("cannot add to storage\n");
+		RZ_LOG_ERROR("esil: cannot add to id storage\n");
 		rz_lib_dl_close(src->content);
 		free(src);
 		return 0;

--- a/librz/analysis/esil/esil_stats.c
+++ b/librz/analysis/esil/esil_stats.c
@@ -35,7 +35,7 @@ static int hook_reg_write(RzAnalysisEsil *esil, const char *name, ut64 *val) {
 }
 
 static int hook_NOP_mem_write(RzAnalysisEsil *esil, ut64 addr, const ut8 *buf, int len) {
-	eprintf("NOP WRITE AT 0x%08" PFMT64x "\n", addr);
+	RZ_LOG_DEBUG("esil: NOP write at 0x%08" PFMT64x "\n", addr);
 	return 1; // override
 }
 

--- a/librz/analysis/fcn.c
+++ b/librz/analysis/fcn.c
@@ -20,7 +20,6 @@
 #define MAX_FLG_NAME_SIZE 64
 
 #define FIX_JMP_FWD 0
-#define D           if (a->verbose)
 
 // 64KB max size
 // 256KB max function size
@@ -601,12 +600,10 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 		rz_sys_usleep(analysis->sleep);
 	}
 
-	// check if address is readable //:
+	// check if address is readable
 	if (!analysis->iob.is_valid_offset(analysis->iob.io, addr, 0)) {
 		if (addr != UT64_MAX && !analysis->iob.io->va) {
-			if (analysis->verbose) {
-				eprintf("Invalid address 0x%" PFMT64x ". Try with io.va=true\n", addr);
-			}
+			RZ_LOG_DEBUG("Invalid address 0x%" PFMT64x ". Try with io.va=true\n", addr);
 		}
 		return RZ_ANALYSIS_RET_ERROR; // MUST BE TOO DEEP
 	}
@@ -633,9 +630,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 			if (analysis->opt.recont) {
 				return RZ_ANALYSIS_RET_END;
 			}
-			if (analysis->verbose) {
-				eprintf("rz_analysis_fcn_bb() fails at 0x%" PFMT64x ".\n", addr);
-			}
+			RZ_LOG_DEBUG("%s fails at 0x%" PFMT64x ".\n", __FUNCTION__, addr);
 			return RZ_ANALYSIS_RET_ERROR; // MUST BE NOT DUP
 		}
 
@@ -647,7 +642,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 	if (!analysis->leaddrs) {
 		analysis->leaddrs = rz_list_newf(free_leaddr_pair);
 		if (!analysis->leaddrs) {
-			eprintf("Cannot create leaddr list\n");
+			RZ_LOG_ERROR("Cannot allocate list of pairs<reg, addr> values.\n");
 			gotoBeach(RZ_ANALYSIS_RET_ERROR);
 		}
 	}
@@ -687,9 +682,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 		}
 	}
 	if ((maxlen - (addrbytes * idx)) > MAX_SCAN_SIZE) {
-		if (analysis->verbose) {
-			eprintf("Warning: Skipping large memory region.\n");
-		}
+		RZ_LOG_DEBUG("Skipping large memory region during basic block analysis.\n");
 		maxlen = 0;
 	}
 
@@ -714,20 +707,16 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 		ret = read_ahead(analysis, at, buf, bytes_read);
 
 		if (ret < 0) {
-			eprintf("Failed to read\n");
+			RZ_LOG_ERROR("Failed to read ahead\n");
 			break;
 		}
 		if (isInvalidMemory(analysis, buf, bytes_read)) {
-			if (analysis->verbose) {
-				eprintf("Warning: FFFF opcode at 0x%08" PFMT64x "\n", at);
-			}
+			RZ_LOG_DEBUG("FFFF opcode at 0x%08" PFMT64x "\n", at);
 			gotoBeach(RZ_ANALYSIS_RET_ERROR)
 		}
 		rz_analysis_op_fini(&op);
 		if ((oplen = rz_analysis_op(analysis, &op, at, buf, bytes_read, RZ_ANALYSIS_OP_MASK_ESIL | RZ_ANALYSIS_OP_MASK_VAL | RZ_ANALYSIS_OP_MASK_HINT)) < 1) {
-			if (analysis->verbose) {
-				eprintf("Invalid instruction at 0x%" PFMT64x " with %d bits\n", at, analysis->bits);
-			}
+			RZ_LOG_DEBUG("Invalid instruction at 0x%" PFMT64x " with %d bits\n", at, analysis->bits);
 			// gotoBeach (RZ_ANALYSIS_RET_ERROR);
 			// RET_END causes infinite loops somehow
 			gotoBeach(RZ_ANALYSIS_RET_END);
@@ -773,9 +762,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 					rz_analysis_block_unref(split);
 				}
 				overlapped = true;
-				if (analysis->verbose) {
-					eprintf("Overlapped at 0x%08" PFMT64x "\n", at);
-				}
+				RZ_LOG_DEBUG("Overlapped at 0x%08" PFMT64x "\n", at);
 			}
 		}
 		if (!overlapped) {
@@ -800,7 +787,6 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 					if (from_addr != bb->addr) {
 						bb->fail = handle_addr;
 						ret = analyze_function_locally(analysis, fcn, handle_addr);
-						eprintf("(%s) 0x%08" PFMT64x "\n", handle, handle_addr);
 						if (bb->size == 0) {
 							rz_analysis_function_remove_block(fcn, bb);
 						}
@@ -821,9 +807,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 			// Save the location of it in `delay.idx`
 			// note, we have still increased size of basic block
 			// (and function)
-			if (analysis->verbose) {
-				eprintf("Enter branch delay at 0x%08" PFMT64x ". bb->sz=%" PFMT64u "\n", at - oplen, bb->size);
-			}
+			RZ_LOG_DEBUG("Enter branch delay at 0x%08" PFMT64x ". bb->sz=%" PFMT64u "\n", at - oplen, bb->size);
 			delay.idx = idx - oplen;
 			delay.cnt = op.delay;
 			delay.pending = 1; // we need this in case the actual idx is zero...
@@ -836,9 +820,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 			// track of how many still to process.
 			delay.cnt--;
 			if (!delay.cnt) {
-				if (analysis->verbose) {
-					eprintf("Last branch delayed opcode at 0x%08" PFMT64x ". bb->sz=%" PFMT64u "\n", addr + idx - oplen, bb->size);
-				}
+				RZ_LOG_DEBUG("Last branch delayed opcode at 0x%08" PFMT64x ". bb->sz=%" PFMT64u "\n", addr + idx - oplen, bb->size);
 				delay.after = idx;
 				idx = delay.idx;
 				// At this point, we are still looking at the
@@ -848,19 +830,15 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 				// the branch delay.
 			}
 		} else if (op.delay > 0 && delay.pending) {
-			if (analysis->verbose) {
-				eprintf("Revisit branch delay jump at 0x%08" PFMT64x ". bb->sz=%" PFMT64u "\n", addr + idx - oplen, bb->size);
-			}
+			RZ_LOG_DEBUG("Revisit branch delay jump at 0x%08" PFMT64x ". bb->sz=%" PFMT64u "\n", addr + idx - oplen, bb->size);
 			// This is the second pass of the branch delaying opcode
 			// But we also already counted this instruction in the
 			// size of the current basic block, so we need to fix that
 			if (delay.adjust) {
 				rz_analysis_block_set_size(bb, (ut64)addrbytes * (ut64)delay.after);
 				fcn->ninstr--;
-				if (analysis->verbose) {
-					eprintf("Correct for branch delay @ %08" PFMT64x " bb.addr=%08" PFMT64x " corrected.bb=%" PFMT64u " f.uncorr=%" PFMT64u "\n",
-						addr + idx - oplen, bb->addr, bb->size, rz_analysis_function_linear_size(fcn));
-				}
+				RZ_LOG_DEBUG("Correct for branch delay @ 0x%08" PFMT64x " bb.addr=0x%08" PFMT64x " corrected.bb=%" PFMT64u " f.uncorr=%" PFMT64u "\n",
+					addr + idx - oplen, bb->addr, bb->size, rz_analysis_function_linear_size(fcn));
 			}
 			// Next time, we go to the opcode after the delay count
 			// Take care not to use this below, use delay.un_idx instead ...
@@ -954,7 +932,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 			if (op.ptr != UT64_MAX) {
 				leaddr_pair *pair = RZ_NEW(leaddr_pair);
 				if (!pair) {
-					eprintf("Cannot create leaddr_pair\n");
+					RZ_LOG_ERROR("Cannot allocate pair<reg, addr> structure\n");
 					gotoBeach(RZ_ANALYSIS_RET_ERROR);
 				}
 				pair->op_addr = op.addr;
@@ -1110,7 +1088,6 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 			}
 			int tc = analysis->opt.tailcall;
 			if (tc) {
-				// eprintf ("TAIL CALL AT 0x%llx\n", op.addr);
 				int diff = op.jump - op.addr;
 				if (tc < 0) {
 					ut8 buf[32];
@@ -1431,11 +1408,9 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 				goto beach;
 			}
 			if (!op.cond) {
-				if (analysis->verbose) {
-					eprintf("RET 0x%08" PFMT64x ". overlap=%s %" PFMT64u " %" PFMT64u "\n",
-						addr + delay.un_idx - oplen, rz_str_bool(overlapped),
-						bb->size, rz_analysis_function_linear_size(fcn));
-				}
+				RZ_LOG_DEBUG("RET 0x%08" PFMT64x ". overlap=%s %" PFMT64u " %" PFMT64u "\n",
+					addr + delay.un_idx - oplen, rz_str_bool(overlapped),
+					bb->size, rz_analysis_function_linear_size(fcn));
 				gotoBeach(RZ_ANALYSIS_RET_END);
 			}
 			break;
@@ -1631,7 +1606,7 @@ RZ_API int rz_analysis_fcn(RzAnalysis *analysis, RzAnalysisFunction *fcn, ut64 a
 			analysis->visited = set_u_new();
 		}
 		if (set_u_contains(analysis->visited, addr)) {
-			eprintf("rz_analysis_fcn: analysis.norevisit at 0x%08" PFMT64x " %c\n", addr, reftype);
+			RZ_LOG_DEBUG("rz_analysis_fcn: analysis.norevisit at 0x%08" PFMT64x " %c\n", addr, reftype);
 			return RZ_ANALYSIS_RET_END;
 		}
 		set_u_add(analysis->visited, addr);
@@ -1704,7 +1679,7 @@ RZ_API int rz_analysis_fcn_del(RzAnalysis *a, ut64 addr) {
 	RzAnalysisFunction *fcn;
 	RzListIter *iter, *iter_tmp;
 	rz_list_foreach_safe (a->fcns, iter, iter_tmp, fcn) {
-		D eprintf("fcn at %llx %llx\n", fcn->addr, addr);
+		RZ_LOG_DEBUG("removing function at %" PFMT64x " %" PFMT64x "\n", fcn->addr, addr);
 		if (fcn->addr == addr) {
 			rz_analysis_function_delete(fcn);
 		}
@@ -1765,14 +1740,13 @@ RZ_API RzAnalysisFunction *rz_analysis_get_function_byname(RzAnalysis *a, const 
 
 /* rename RzAnalysisFunctionBB.add() */
 RZ_API bool rz_analysis_fcn_add_bb(RzAnalysis *a, RzAnalysisFunction *fcn, ut64 addr, ut64 size, ut64 jump, ut64 fail, RZ_BORROW RzAnalysisDiff *diff) {
-	D eprintf("Add bb\n");
 	if (size == 0) {
-		eprintf("Warning: empty basic block at 0x%08" PFMT64x " is not allowed.\n", addr);
+		RZ_LOG_ERROR("Empty basic block at 0x%08" PFMT64x " (not allowed).\n", addr);
 		rz_warn_if_reached();
 		return false;
 	}
 	if (size > a->opt.bb_max_size) {
-		eprintf("Warning: can't allocate such big bb of %" PFMT64d " bytes at 0x%08" PFMT64x "\n", (st64)size, addr);
+		RZ_LOG_ERROR("Cannot allocate such big bb of %" PFMT64d " bytes at 0x%08" PFMT64x "\n", (st64)size, addr);
 		rz_warn_if_reached();
 		return false;
 	}
@@ -1839,8 +1813,8 @@ RZ_API int rz_analysis_function_complexity(RzAnalysisFunction *fcn) {
 
 	rz_list_foreach (fcn->bbs, iter, bb) {
 		N++; // nodes
-		if ((!analysis || analysis->verbose) && bb->jump == UT64_MAX && bb->fail != UT64_MAX) {
-			eprintf("Warning: invalid bb jump/fail pair at 0x%08" PFMT64x " (fcn 0x%08" PFMT64x "\n", bb->addr, fcn->addr);
+		if (!analysis && bb->jump == UT64_MAX && bb->fail != UT64_MAX) {
+			RZ_LOG_DEBUG("invalid bb jump/fail pair at 0x%08" PFMT64x " (fcn 0x%08" PFMT64x "\n", bb->addr, fcn->addr);
 		}
 		if (bb->jump == UT64_MAX && bb->fail == UT64_MAX) {
 			P++; // exit nodes
@@ -1856,10 +1830,9 @@ RZ_API int rz_analysis_function_complexity(RzAnalysisFunction *fcn) {
 	}
 
 	int result = E - N + (2 * P);
-	if (result < 1 && (!analysis || analysis->verbose)) {
-		eprintf("Warning: CC = E(%d) - N(%d) + (2 * P(%d)) < 1 at 0x%08" PFMT64x "\n", E, N, P, fcn->addr);
+	if (result < 1 && !analysis) {
+		RZ_LOG_DEBUG("CC = E(%d) - N(%d) + (2 * P(%d)) < 1 at 0x%08" PFMT64x "\n", E, N, P, fcn->addr);
 	}
-	// rz_return_val_if_fail (result > 0, 0);
 	return result;
 }
 
@@ -2007,19 +1980,19 @@ RZ_API bool rz_analysis_function_set_type_str(RzAnalysis *a, RZ_NONNULL RzAnalys
 	RzType *result = rz_type_parse_string_declaration_single(a->typedb->parser, sig, &error_msg);
 	if (!result) {
 		if (error_msg) {
-			eprintf("%s", error_msg);
+			RZ_LOG_ERROR("%s", error_msg);
 			free(error_msg);
 		}
-		eprintf("Cannot parse callable type\n");
+		RZ_LOG_ERROR("Cannot parse callable type\n");
 		return false;
 	}
 	// Parsed result should be RzCallable
 	if (result->kind != RZ_TYPE_KIND_CALLABLE) {
-		eprintf("Parsed function signature should be RzCallable\n");
+		RZ_LOG_ERROR("Parsed function signature should be RzCallable\n");
 		return false;
 	}
 	if (!result->callable) {
-		eprintf("Parsed function signature should not be NULL\n");
+		RZ_LOG_ERROR("Parsed function signature should not be NULL\n");
 		return false;
 	}
 	return rz_analysis_function_set_type(a, f, result->callable);

--- a/librz/analysis/function.c
+++ b/librz/analysis/function.c
@@ -30,23 +30,23 @@ static bool __fcn_exists(RzAnalysis *analysis, const char *name, ut64 addr) {
 	// check if name is already registered
 	bool found = false;
 	if (addr == UT64_MAX) {
-		eprintf("Invalid function address (-1) '%s'\n", name);
+		RZ_LOG_ERROR("Invalid function address (-1) '%s'\n", name);
 		return true;
 	}
 	if (!name) {
-		eprintf("TODO: Empty function name, we must auto generate one\n");
+		RZ_LOG_INFO("Empty function name, we must auto generate one\n");
 		return true;
 	}
 	RzAnalysisFunction *f = ht_pp_find(analysis->ht_name_fun, name, &found);
 	if (f && found) {
-		eprintf("Invalid function name '%s' at 0x%08" PFMT64x "\n", name, addr);
+		RZ_LOG_ERROR("Invalid function name '%s' at 0x%08" PFMT64x "\n", name, addr);
 		return true;
 	}
 	// check if there's a function already in the given address
 	found = false;
 	f = ht_up_find(analysis->ht_addr_fun, addr, &found);
 	if (f && found) {
-		eprintf("Function already defined in 0x%08" PFMT64x "\n", addr);
+		RZ_LOG_ERROR("Function already defined in 0x%08" PFMT64x "\n", addr);
 		return true;
 	}
 	return false;

--- a/librz/analysis/il/analysis_il_trace.c
+++ b/librz/analysis/il/analysis_il_trace.c
@@ -32,14 +32,17 @@ RZ_API RzAnalysisRzilTrace *rz_analysis_rzil_trace_new(RzAnalysis *analysis, RZ_
 	// TODO : maybe we could remove memory && register in rzil trace ?
 	trace->registers = ht_up_new(NULL, htup_vector_free, NULL);
 	if (!trace->registers) {
+		RZ_LOG_ERROR("rzil: Cannot allocate hasmap for trace registers\n");
 		goto error;
 	}
 	trace->memory = ht_up_new(NULL, htup_vector_free, NULL);
 	if (!trace->memory) {
+		RZ_LOG_ERROR("rzil: Cannot allocate hasmap for trace memory\n");
 		goto error;
 	}
 	trace->instructions = rz_pvector_new((RzPVectorFree)rz_analysis_il_trace_instruction_free);
 	if (!trace->instructions) {
+		RZ_LOG_ERROR("rzil: Cannot allocate vector for trace instructions\n");
 		goto error;
 	}
 
@@ -50,6 +53,7 @@ RZ_API RzAnalysisRzilTrace *rz_analysis_rzil_trace_new(RzAnalysis *analysis, RZ_
 		RzRegArena *a = analysis->reg->regset[i].arena;
 		RzRegArena *b = rz_reg_arena_new(a->size);
 		if (!b) {
+			RZ_LOG_ERROR("rzil: Cannot allocate register arena for trace\n");
 			goto error;
 		}
 		if (b->bytes && a->bytes && b->size > 0) {
@@ -59,7 +63,6 @@ RZ_API RzAnalysisRzilTrace *rz_analysis_rzil_trace_new(RzAnalysis *analysis, RZ_
 	}
 	return trace;
 error:
-	eprintf("Fail to init IL trace\n");
 	rz_analysis_esil_trace_free(trace);
 	return NULL;
 }

--- a/librz/analysis/jmptbl.c
+++ b/librz/analysis/jmptbl.c
@@ -10,8 +10,7 @@
 #include <rz_types_overflow.h>
 
 #define aprintf(format, ...) \
-	if (analysis->verbose) \
-	eprintf(format, __VA_ARGS__)
+	RZ_LOG_DEBUG(format, __VA_ARGS__)
 
 static void apply_case(RzAnalysis *analysis, RzAnalysisBlock *block, ut64 switch_addr, ut64 offset_sz, ut64 case_addr, ut64 id, ut64 case_addr_loc) {
 	// eprintf ("** apply_case: 0x%"PFMT64x " from 0x%"PFMT64x "\n", case_addr, case_addr_loc);
@@ -81,15 +80,15 @@ RZ_API bool rz_analysis_walkthrough_casetbl(RZ_NONNULL RzAnalysis *analysis, RZ_
 		params->table_count = analysis->opt.jmptbl_maxcount;
 	}
 	if (params->jmptbl_loc == UT64_MAX) {
-		aprintf("Warning: Invalid JumpTable location 0x%08" PFMT64x "\n", params->jmptbl_loc);
+		aprintf("Invalid jump table location 0x%08" PFMT64x "\n", params->jmptbl_loc);
 		return false;
 	}
 	if (params->casetbl_loc == UT64_MAX) {
-		aprintf("Warning: Invalid CaseTable location 0x%08" PFMT64x "\n", params->jmptbl_loc);
+		aprintf("Invalid case table location 0x%08" PFMT64x "\n", params->jmptbl_loc);
 		return false;
 	}
 	if (jmptable_size_is_invalid(params)) {
-		aprintf("Warning: Invalid JumpTable size at 0x%08" PFMT64x "\n", params->jmp_address);
+		aprintf("Invalid jump table size at 0x%08" PFMT64x "\n", params->jmp_address);
 		return false;
 	}
 	ut64 jmpptr, case_idx, jmpptr_idx;
@@ -181,11 +180,11 @@ RZ_API bool rz_analysis_walkthrough_jmptbl(RZ_NONNULL RzAnalysis *analysis, RZ_N
 		params->table_count = analysis->opt.jmptbl_maxcount;
 	}
 	if (params->jmptbl_loc == UT64_MAX) {
-		aprintf("Warning: Invalid JumpTable location 0x%08" PFMT64x "\n", params->jmptbl_loc);
+		aprintf("Invalid jump table location 0x%08" PFMT64x "\n", params->jmptbl_loc);
 		return false;
 	}
 	if (jmptable_size_is_invalid(params)) {
-		aprintf("Warning: Invalid JumpTable size at 0x%08" PFMT64x "\n", params->jmp_address);
+		aprintf("Invalid jump table size at 0x%08" PFMT64x "\n", params->jmp_address);
 		return false;
 	}
 	ut64 jmpptr, offs;
@@ -476,7 +475,7 @@ RZ_API bool rz_analysis_get_jmptbl_info(RZ_NONNULL RzAnalysis *analysis, RZ_NONN
 	}
 	// predecessor must be a conditional jump
 	if (!prev_bb || !prev_bb->jump || !prev_bb->fail) {
-		aprintf("Warning: [analysis.jmp.tbl] Missing predecesessor cjmp bb at 0x%08" PFMT64x "\n", jmp_address);
+		aprintf("Missing predecesessor on basic block conditional jump at 0x%08" PFMT64x ", required by jump table\n", jmp_address);
 		return false;
 	}
 

--- a/librz/analysis/op.c
+++ b/librz/analysis/op.c
@@ -107,7 +107,7 @@ RZ_API int rz_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, con
 		if (analysis->pcalign && addr % analysis->pcalign) {
 			op->type = RZ_ANALYSIS_OP_TYPE_ILL;
 			op->addr = addr;
-			// eprintf ("Unaligned instruction for %d bits at 0x%"PFMT64x"\n", analysis->bits, addr);
+			// RZ_LOG_DEBUG("Unaligned instruction for %d bits at 0x%"PFMT64x"\n", analysis->bits, addr);
 			op->size = 1;
 			return -1;
 		}
@@ -129,9 +129,7 @@ RZ_API int rz_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, con
 		}
 	}
 	if (!op->mnemonic && (mask & RZ_ANALYSIS_OP_MASK_DISASM)) {
-		if (analysis->verbose) {
-			eprintf("Warning: unhandled RZ_ANALYSIS_OP_MASK_DISASM in rz_analysis_op\n");
-		}
+		RZ_LOG_DEBUG("Warning: unhandled RZ_ANALYSIS_OP_MASK_DISASM in rz_analysis_op\n");
 	}
 	if (mask & RZ_ANALYSIS_OP_MASK_HINT) {
 		RzAnalysisHint *hint = rz_analysis_hint_get(analysis, addr);
@@ -503,7 +501,7 @@ RZ_API char *rz_analysis_op_to_string(RzAnalysis *analysis, RzAnalysisOp *op) {
 	case RZ_ANALYSIS_OP_TYPE_ROR:
 	case RZ_ANALYSIS_OP_TYPE_SWITCH:
 	case RZ_ANALYSIS_OP_TYPE_CASE:
-		eprintf("Command not implemented.\n");
+		RZ_LOG_DEBUG("Command not implemented.\n");
 		free(r0);
 		free(a0);
 		free(a1);

--- a/librz/analysis/p/analysis_arc.c
+++ b/librz/analysis/p/analysis_arc.c
@@ -31,14 +31,6 @@ typedef struct arc_fields_t {
 	st64 limm; /* data stored immediately following the opcode */
 } arc_fields;
 
-static void arccompact_dump_fields(ut64 addr, ut32 words[2], arc_fields *f) {
-#if DEBUG
-	/* Quick and dirty debug print */
-	eprintf("DEBUG: 0x%04llx: %08x op=0x%x subop=0x%x format=0x%x fields.a=0x%x fields.b=0x%x fields.c=0x%x imm=%i limm=%lli\n",
-		addr, words[0], f->opcode, f->subopcode, f->format, f->a, f->b, f->c, f->imm, f->limm);
-#endif
-}
-
 /* For (arguably valid) reasons, the ARCompact CPU uses "middle endian"
 	encoding on Little-Endian systems
  */
@@ -442,7 +434,6 @@ static int arcompact_genops(RzAnalysisOp *op, ut64 addr, ut32 words[2]) {
 		break;
 	}
 
-	arccompact_dump_fields(addr, words, &fields);
 	return op->size;
 }
 
@@ -484,7 +475,6 @@ static int arcompact_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const
 
 	op->size = (fields.opcode >= 0x0c) ? 2 : 4;
 	op->nopcode = op->size;
-	// eprintf ("%x\n", fields.opcode);
 
 	switch (fields.opcode) {
 	case 0:
@@ -1010,7 +1000,6 @@ static int arcompact_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const
 		arcompact_branch(op, addr, fields.imm, 0);
 		break;
 	}
-	arccompact_dump_fields(addr, words, &fields);
 	return op->size;
 }
 

--- a/librz/analysis/p/analysis_luac.c
+++ b/librz/analysis/p/analysis_luac.c
@@ -8,7 +8,7 @@
 
 int rz_lua_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *data, int len, RzAnalysisOpMask mask) {
 	if (!analysis->cpu) {
-		eprintf("Warning : no version info\n");
+		RZ_LOG_ERROR("Cannot get lua version\n");
 		return 0;
 	}
 	if (strcmp(analysis->cpu, "5.4") == 0) {
@@ -16,7 +16,7 @@ int rz_lua_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const 
 	} else if (strcmp(analysis->cpu, "5.3") == 0) {
 		return lua53_anal_op(analysis, op, addr, data, len);
 	} else {
-		eprintf("Warning : no matched version\n");
+		RZ_LOG_ERROR("Cannot find a suitable lua version to handle lua analysis\n");
 	}
 	return 0;
 }

--- a/librz/analysis/p/analysis_mcore.c
+++ b/librz/analysis/p/analysis_mcore.c
@@ -11,7 +11,7 @@ static int mcore_analysis(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, con
 	mcore_t *instr = NULL;
 
 	if (mcore_init(&handle, buf, len)) {
-		eprintf("[!] mcore: bad or invalid data.\n");
+		RZ_LOG_ERROR("mcore: bad or invalid data.\n");
 		return -1;
 	}
 

--- a/librz/analysis/p/analysis_mips_cs.c
+++ b/librz/analysis/p/analysis_mips_cs.c
@@ -684,7 +684,7 @@ capstone bug
 		} else if (OPERAND(0).type == MIPS_OP_REG && OPERAND(1).type == MIPS_OP_REG) {
 			SET_SRC_DST_2_REGS(op);
 		} else {
-			eprintf("Unknown div at 0x%08" PFMT64x "\n", op->addr);
+			RZ_LOG_ERROR("mips: unknown div opcode at 0x%08" PFMT64x "\n", op->addr);
 		}
 		break;
 	}

--- a/librz/analysis/p/analysis_mips_gnu.c
+++ b/librz/analysis/p/analysis_mips_gnu.c
@@ -1062,7 +1062,7 @@ static int mips_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 
 	// Be endian aware
 	opcode = rz_read_ble32(b, analysis->big_endian);
 
-	// eprintf ("MIPS: %02x %02x %02x %02x (after endian: big=%d)\n", buf[0], buf[1], buf[2], buf[3], analysis->big_endian);
+	// RZ_LOG_DEBUG("MIPS: %02x %02x %02x %02x (after endian: big=%d)\n", buf[0], buf[1], buf[2], buf[3], analysis->big_endian);
 	if (opcode == 0) {
 		op->type = RZ_ANALYSIS_OP_TYPE_NOP;
 		return oplen;
@@ -1138,7 +1138,7 @@ static int mips_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 
 			op->type = RZ_ANALYSIS_OP_TYPE_SAR;
 			break;
 		case 8: // jr
-			// eprintf ("%llx jr\n", addr);
+			// RZ_LOG_DEBUG("%" PFMT64x " jr\n", addr);
 			//  TODO: check return value
 			op->delay = 1;
 			insn.id = MIPS_INS_JR;
@@ -1153,7 +1153,7 @@ static int mips_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 
 			}
 			break;
 		case 9: // jalr
-			// eprintf ("%llx jalr\n", addr);
+			// RZ_LOG_DEBUG("%" PFMT64x " jalr\n", addr);
 			op->delay = 1;
 			insn.id = MIPS_INS_JALR;
 			if (rs == 25) {
@@ -1251,7 +1251,7 @@ static int mips_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 
 			insn.id = MIPS_INS_SLTU;
 			break;
 		default:
-			//	eprintf ("%llx %d\n", addr, optype);
+			//	RZ_LOG_DEBUG("%" PFMT64x " %d\n", addr, optype);
 			break;
 		}
 		// family = 'R';

--- a/librz/analysis/p/analysis_ppc_cs.c
+++ b/librz/analysis/p/analysis_ppc_cs.c
@@ -489,7 +489,7 @@ static int analop_vle(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 		case RZ_ANALYSIS_OP_TYPE_XOR:
 			break;
 		default:
-			// eprintf ("Missing an RZ_ANALYSIS_OP_TYPE (%"PFMT64u")\n", op->type);
+			// RZ_LOG_ERROR("Missing an RZ_ANALYSIS_OP_TYPE (%"PFMT64u")\n", op->type);
 			break;
 		}
 		vle_free(instr);

--- a/librz/analysis/p/analysis_riscv.c
+++ b/librz/analysis/p/analysis_riscv.c
@@ -559,15 +559,6 @@ static int riscv_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		} else if (!strncmp(name, "sgt", 3)) {
 			esilprintf(op, "%s,%s,>,%s,=", ARG(2), ARG(1), ARG(0));
 		}
-		// debug
-		// else if (strcmp (name, "unimp") != 0 && name[0] != 'f' && name[1] != 'm') {
-		//	int i;
-		//	eprintf("[esil] missing risc v esil: %s", name);
-		//	for (i = 0; i < args.num; i++) {
-		//		eprintf(" %s", ARG(i));
-		//	}
-		//	eprintf("\n");
-		//}
 #undef ARG
 	}
 

--- a/librz/analysis/p/analysis_riscv_cs.c
+++ b/librz/analysis/p/analysis_riscv_cs.c
@@ -284,7 +284,7 @@ capstone bug
 		} else if (OPERAND(0).type == RISCV_OP_REG && OPERAND(1).type == RISCV_OP_REG) {
 			SET_SRC_DST_2_REGS(op);
 		} else {
-			eprintf("Unknown div at 0x%08" PFMT64x "\n", op->addr);
+			RZ_LOG_ERROR("riscv: unknown div opcode at 0x%08" PFMT64x "\n", op->addr);
 		}
 		break;
 	}

--- a/librz/analysis/p/analysis_wasm.c
+++ b/librz/analysis/p/analysis_wasm.c
@@ -166,10 +166,10 @@ static int wasm_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 
 				}
 			} else {
 				if (advance_till_scope_end(analysis, op, addr + op->size, RZ_ANALYSIS_OP_TYPE_JMP, val, false)) {
-					eprintf("[wasm] cannot find jump type for br (using block type)\n");
+					RZ_LOG_ERROR("wasm: cannot find jump type for br (using block type)\n");
 					rz_analysis_hint_set_jump(analysis, addr, op->jump);
 				} else {
-					eprintf("[wasm] cannot find jump for br\n");
+					RZ_LOG_ERROR("wasm: cannot find jump for br\n");
 				}
 			}
 			rz_analysis_hint_free(hint2);
@@ -195,11 +195,11 @@ static int wasm_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 
 				}
 			} else {
 				if (advance_till_scope_end(analysis, op, addr + op->size, RZ_ANALYSIS_OP_TYPE_CJMP, val, false)) {
-					eprintf("[wasm] cannot find jump type for br_if (using block type)\n");
+					RZ_LOG_ERROR("wasm: cannot find jump type for br_if (using block type)\n");
 					op->fail = addr + op->size;
 					rz_analysis_hint_set_jump(analysis, addr, op->jump);
 				} else {
-					eprintf("[wasm] cannot find jump for br_if\n");
+					RZ_LOG_ERROR("wasm: cannot find jump for br_if\n");
 				}
 			}
 			rz_analysis_hint_free(hint2);

--- a/librz/analysis/p/analysis_x86_cs.c
+++ b/librz/analysis/p/analysis_x86_cs.c
@@ -926,8 +926,9 @@ static void anop_esil(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 			val = 0x8000000000000000;
 			break;
 		default:
-			eprintf("Error: unknown operand size: %d\n", gop.insn->detail->x86.operands[0].size);
+			RZ_LOG_ERROR("x86: unknown operand size: %d\n", gop.insn->detail->x86.operands[0].size);
 			val = 256;
+			break;
 		}
 		ut32 bitsize;
 		src = getarg(&gop, 1, 0, NULL, SRC_AR, NULL);
@@ -1684,7 +1685,8 @@ static void anop_esil(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 			xor = 0xffffffffffffffff;
 			break;
 		default:
-			eprintf("Neg: Unhandled bitsize %d\n", bitsize);
+			RZ_LOG_ERROR("x86: unhandled neg bitsize %d\n", bitsize);
+			break;
 		}
 		esilprintf(op, "%s,!,!,cf,:=,%s,0x%" PFMT64x ",^,1,+,%s,$z,zf,:=,0,of,:=,%d,$s,sf,:=,%d,$o,pf,:=",
 			src, src, xor, dst, bitsize - 1, bitsize - 1);

--- a/librz/analysis/rtti_itanium.c
+++ b/librz/analysis/rtti_itanium.c
@@ -199,7 +199,7 @@ static bool rtti_itanium_vmi_class_type_info_init(RVTableContext *context, ut64 
 	}
 	at = at & 0xffffffff;
 	if (at < 1 || at > 0xfffff) {
-		eprintf("Error reading vmi_base_count\n");
+		RZ_LOG_ERROR("Cannot read vmi_base_count\n");
 		return false;
 	}
 	vmi_cti->vmi_base_count = at;

--- a/librz/analysis/rtti_msvc.c
+++ b/librz/analysis/rtti_msvc.c
@@ -167,9 +167,7 @@ static RzList *rtti_msvc_read_base_class_array(RVTableContext *context, ut32 num
 	ut64 stride = RZ_MIN(context->word_size, 4);
 
 	if (num_base_classes > BASE_CLASSES_MAX) {
-		if (context->analysis->verbose) {
-			eprintf("WARNING: Length of base class array at 0x%08" PFMT64x " exceeds %d.\n", addr, BASE_CLASSES_MAX);
-		}
+		RZ_LOG_DEBUG("Length of base class array at 0x%08" PFMT64x " exceeds %d.\n", addr, BASE_CLASSES_MAX);
 		num_base_classes = BASE_CLASSES_MAX;
 	}
 
@@ -419,7 +417,7 @@ RZ_API char *rz_analysis_rtti_msvc_demangle_class_name(RVTableContext *context, 
 RZ_API void rz_analysis_rtti_msvc_print_complete_object_locator(RVTableContext *context, ut64 addr, int mode) {
 	rtti_complete_object_locator col;
 	if (!rtti_msvc_read_complete_object_locator(context, addr, &col)) {
-		eprintf("Failed to parse Complete Object Locator at 0x%08" PFMT64x "\n", addr);
+		RZ_LOG_ERROR("Failed to parse complete object locator at 0x%08" PFMT64x "\n", addr);
 		return;
 	}
 
@@ -439,7 +437,7 @@ RZ_API void rz_analysis_rtti_msvc_print_complete_object_locator(RVTableContext *
 RZ_API void rz_analysis_rtti_msvc_print_type_descriptor(RVTableContext *context, ut64 addr, int mode) {
 	rtti_type_descriptor td = { 0 };
 	if (!rtti_msvc_read_type_descriptor(context, addr, &td)) {
-		eprintf("Failed to parse Type Descriptor at 0x%08" PFMT64x "\n", addr);
+		RZ_LOG_ERROR("Failed to parse type descriptor at 0x%08" PFMT64x "\n", addr);
 		return;
 	}
 
@@ -461,7 +459,7 @@ RZ_API void rz_analysis_rtti_msvc_print_type_descriptor(RVTableContext *context,
 RZ_API void rz_analysis_rtti_msvc_print_class_hierarchy_descriptor(RVTableContext *context, ut64 addr, int mode) {
 	rtti_class_hierarchy_descriptor chd;
 	if (!rtti_msvc_read_class_hierarchy_descriptor(context, addr, &chd)) {
-		eprintf("Failed to parse Class Hierarchy Descriptor at 0x%08" PFMT64x "\n", addr);
+		RZ_LOG_ERROR("Failed to parse class hierarchy descriptor at 0x%08" PFMT64x "\n", addr);
 		return;
 	}
 
@@ -481,7 +479,7 @@ RZ_API void rz_analysis_rtti_msvc_print_class_hierarchy_descriptor(RVTableContex
 RZ_API void rz_analysis_rtti_msvc_print_base_class_descriptor(RVTableContext *context, ut64 addr, int mode) {
 	rtti_base_class_descriptor bcd;
 	if (!rtti_msvc_read_base_class_descriptor(context, addr, &bcd)) {
-		eprintf("Failed to parse Base Class Descriptor at 0x%08" PFMT64x "\n", addr);
+		RZ_LOG_ERROR("Failed to parse base class descriptor at 0x%08" PFMT64x "\n", addr);
 		return;
 	}
 
@@ -509,7 +507,7 @@ static bool rtti_msvc_print_complete_object_locator_recurse(RVTableContext *cont
 	rtti_complete_object_locator col;
 	if (!rtti_msvc_read_complete_object_locator(context, colAddr, &col)) {
 		if (!strict) {
-			eprintf("Failed to parse Complete Object Locator at 0x%08" PFMT64x " (referenced from 0x%08" PFMT64x ")\n", colAddr, colRefAddr);
+			RZ_LOG_ERROR("Failed to parse complete object locator at 0x%08" PFMT64x " (referenced from 0x%08" PFMT64x ")\n", colAddr, colRefAddr);
 		}
 		return false;
 	}
@@ -519,7 +517,7 @@ static bool rtti_msvc_print_complete_object_locator_recurse(RVTableContext *cont
 	rtti_type_descriptor td = { 0 };
 	if (!rtti_msvc_read_type_descriptor(context, typeDescriptorAddr, &td)) {
 		if (!strict) {
-			eprintf("Failed to parse Type Descriptor at 0x%08" PFMT64x "\n", typeDescriptorAddr);
+			RZ_LOG_ERROR("Failed to parse type descriptor at 0x%08" PFMT64x "\n", typeDescriptorAddr);
 		}
 		return false;
 	}
@@ -529,7 +527,7 @@ static bool rtti_msvc_print_complete_object_locator_recurse(RVTableContext *cont
 	rtti_class_hierarchy_descriptor chd;
 	if (!rtti_msvc_read_class_hierarchy_descriptor(context, classHierarchyDescriptorAddr, &chd)) {
 		if (!strict) {
-			eprintf("Failed to parse Class Hierarchy Descriptor at 0x%08" PFMT64x "\n", classHierarchyDescriptorAddr);
+			RZ_LOG_ERROR("Failed to parse class hierarchy descriptor at 0x%08" PFMT64x "\n", classHierarchyDescriptorAddr);
 		}
 		rtti_type_descriptor_fini(&td);
 		return false;
@@ -545,7 +543,7 @@ static bool rtti_msvc_print_complete_object_locator_recurse(RVTableContext *cont
 	RzList *baseClassArray = rtti_msvc_read_base_class_array(context, chd.num_base_classes, base, baseClassArrayOffset);
 	if (!baseClassArray) {
 		if (!strict) {
-			eprintf("Failed to parse Base Class Array starting at 0x%08" PFMT64x "\n", base + baseClassArrayOffset);
+			RZ_LOG_ERROR("Failed to parse base class array starting at 0x%08" PFMT64x "\n", base + baseClassArrayOffset);
 		}
 		rtti_type_descriptor_fini(&td);
 		return false;
@@ -597,7 +595,7 @@ static bool rtti_msvc_print_complete_object_locator_recurse(RVTableContext *cont
 			rtti_type_descriptor_fini(&btd);
 		} else {
 			if (!strict) {
-				eprintf("Failed to parse Type Descriptor at 0x%08" PFMT64x "\n", baseTypeDescriptorAddr);
+				RZ_LOG_ERROR("Failed to parse type descriptor at 0x%08" PFMT64x "\n", baseTypeDescriptorAddr);
 			}
 		}
 
@@ -753,9 +751,7 @@ RecoveryCompleteObjectLocator *recovery_analysis_complete_object_locator(RRTTIMS
 			continue;
 		}
 		if (!td->valid) {
-			if (context->vt_context->analysis->verbose) {
-				eprintf("Warning: type descriptor of base is invalid.\n");
-			}
+			RZ_LOG_DEBUG("Type descriptor of base is invalid.\n");
 			continue;
 		}
 		RecoveryBaseDescriptor *base_desc = rz_vector_push(&col->base_td, NULL);
@@ -798,11 +794,8 @@ static char *unique_class_name(RzAnalysis *analysis, const char *original_name) 
 	}
 
 	char *name = NULL;
-	if (analysis->verbose) {
-		eprintf("Warning: class name %s already taken!\n", original_name);
-	}
+	RZ_LOG_DEBUG("Class name '%s' was already taken!\n", original_name);
 	int i = 1;
-
 	do {
 		free(name);
 		name = rz_str_newf("%s.%d", original_name, i++);
@@ -864,24 +857,20 @@ static void recovery_apply_bases(RRTTIMSVCAnalContext *context, const char *clas
 	rz_vector_foreach(base_descs, base_desc) {
 		RecoveryTypeDescriptor *base_td = base_desc->td;
 		if (!base_td->valid) {
-			eprintf("Warning Base td is invalid!\n");
+			RZ_LOG_WARN("Base td is invalid!\n");
 			continue;
 		}
 
 		const char *base_class_name;
 		if (!base_td->col) {
-			if (context->vt_context->analysis->verbose) {
-				eprintf("Warning: Base td %s has no col. Falling back to recovery from td only.\n", base_td->td.name);
-			}
+			RZ_LOG_DEBUG("Base td %s has no col. Falling back to recovery from td only.\n", base_td->td.name);
 			base_class_name = recovery_apply_type_descriptor(context, base_td);
 		} else {
 			base_class_name = recovery_apply_complete_object_locator(context, base_td->col);
 		}
 
 		if (!base_class_name) {
-			if (context->vt_context->analysis->verbose) {
-				eprintf("Failed to convert !base td->col or td to a class\n");
-			}
+			RZ_LOG_DEBUG("Failed to convert !base td->col or td to a class\n");
 			continue;
 		}
 
@@ -900,9 +889,7 @@ static const char *recovery_apply_complete_object_locator(RRTTIMSVCAnalContext *
 	}
 
 	if (!col->td) {
-		if (context->vt_context->analysis->verbose) {
-			eprintf("Warning: no td for col at 0x%" PFMT64x "\n", col->addr);
-		}
+		RZ_LOG_DEBUG("No recovery type descriptor for recovery object locator at 0x%" PFMT64x "\n", col->addr);
 		return NULL;
 	}
 
@@ -915,9 +902,7 @@ static const char *recovery_apply_complete_object_locator(RRTTIMSVCAnalContext *
 
 	char *name = rz_analysis_rtti_msvc_demangle_class_name(context->vt_context, col->td->td.name);
 	if (!name) {
-		if (context->vt_context->analysis->verbose) {
-			eprintf("Failed to demangle a class name: \"%s\"\n", col->td->td.name);
-		}
+		RZ_LOG_DEBUG("Failed to demangle a class name: \"%s\"\n", col->td->td.name);
 		name = strdup(col->td->td.name);
 		if (!name) {
 			return NULL;
@@ -954,9 +939,7 @@ static const char *recovery_apply_type_descriptor(RRTTIMSVCAnalContext *context,
 
 	char *name = rz_analysis_rtti_msvc_demangle_class_name(context->vt_context, td->td.name);
 	if (!name) {
-		if (context->vt_context->analysis->verbose) {
-			eprintf("Failed to demangle a class name: \"%s\"\n", td->td.name);
-		}
+		RZ_LOG_DEBUG("Failed to demangle a class name: \"%s\"\n", td->td.name);
 		name = strdup(td->td.name);
 		if (!name) {
 			return NULL;

--- a/librz/analysis/serialize_analysis.c
+++ b/librz/analysis/serialize_analysis.c
@@ -726,7 +726,6 @@ RZ_API RZ_NULLABLE RzAnalysisVar *rz_serialize_analysis_var_load(RZ_NONNULL RzAn
 			break;
 		case VAR_FIELD_DELTA:
 			if (child->type != RZ_JSON_INTEGER) {
-				eprintf("delta nop\n");
 				break;
 			}
 			delta = child->num.s_value;
@@ -840,7 +839,7 @@ RZ_API RZ_NULLABLE RzAnalysisVar *rz_serialize_analysis_var_load(RZ_NONNULL RzAn
 	char *error_msg = NULL;
 	RzType *vartype = rz_type_parse_string_single(fcn->analysis->typedb->parser, type, &error_msg);
 	if (error_msg) {
-		eprintf("Fail to parse the function variable (\"%s\") type: %s\n", name, type);
+		RZ_LOG_ERROR("Fail to parse the function variable (\"%s\") type: %s\n", name, type);
 		RZ_FREE(error_msg);
 		goto beach;
 	}
@@ -1014,7 +1013,7 @@ static bool global_var_load_cb(void *user, const char *k, const char *v) {
 	char *error_msg = NULL;
 	RzType *vartype = rz_type_parse_string_single(ctx->analysis->typedb->parser, type, &error_msg);
 	if (error_msg) {
-		eprintf("Fail to parse the function variable (\"%s\") type: %s\n", name, type);
+		RZ_LOG_ERROR("Fail to parse the function variable (\"%s\") type: %s\n", name, type);
 		RZ_FREE(error_msg);
 		goto beach;
 	}

--- a/librz/analysis/type_pdb.c
+++ b/librz/analysis/type_pdb.c
@@ -158,7 +158,7 @@ static RzType *parse_type(const RzTypeDB *typedb, RzPdbTpiStream *stream, RzPdbT
 		char *error_msg = NULL;
 		typ = rz_type_parse_string_single(typedb->parser, simple_type->type, &error_msg);
 		if (error_msg) {
-			eprintf("%s : Error parsing complex type member \"%s\" type:\n%s\n", __FUNCTION__, simple_type->type, error_msg);
+			RZ_LOG_ERROR("%s : Error parsing complex type member \"%s\" type:\n%s\n", __FUNCTION__, simple_type->type, error_msg);
 			RZ_FREE(error_msg);
 		}
 		return typ;
@@ -386,7 +386,7 @@ static RzTypeStructMember *parse_struct_member(const RzTypeDB *typedb, RzPdbTpiS
 		// For structure, we don't need vtable for now
 		goto cleanup;
 	default:
-		eprintf("%s : unsupported leaf type 0x%x\n", __FUNCTION__, type_info->leaf_type);
+		RZ_LOG_ERROR("%s : unsupported leaf type 0x%x\n", __FUNCTION__, type_info->leaf_type);
 		goto cleanup;
 	}
 	if (!type) {
@@ -503,7 +503,7 @@ static RzTypeUnionMember *parse_union_member(const RzTypeDB *typedb, RzPdbTpiStr
 		break;
 	}
 	default:
-		eprintf("%s : unsupported leaf type 0x%x\n", __FUNCTION__, type_info->leaf_type);
+		RZ_LOG_ERROR("%s : unsupported leaf type 0x%x\n", __FUNCTION__, type_info->leaf_type);
 		goto cleanup;
 	}
 	if (!type) {
@@ -707,7 +707,7 @@ static void parse_types(const RzTypeDB *typedb, RzPdbTpiStream *stream, RzPdbTpi
 	default:
 		// shouldn't happen, happens when someone modifies leafs that get here
 		// but not how they should be parsed
-		eprintf("Unknown type record");
+		RZ_LOG_ERROR("Unknown type record");
 		break;
 	}
 }

--- a/librz/analysis/value.c
+++ b/librz/analysis/value.c
@@ -56,7 +56,7 @@ RZ_API ut64 rz_analysis_value_to_ut64(RzAnalysis *analysis, RzAnalysisValue *val
 	case 4:
 	case 8:
 		// analysis->bio ...
-		eprintf("TODO: memref for to_ut64 not supported\n");
+		RZ_LOG_DEBUG("memref for to_ut64 not supported\n");
 		break;
 	}
 	return num;
@@ -70,7 +70,7 @@ RZ_API int rz_analysis_value_set_ut64(RzAnalysis *analysis, RzAnalysisValue *val
 			rz_mem_set_num(data, val->memref, num);
 			analysis->iob.write_at(analysis->iob.io, addr, data, val->memref);
 		} else {
-			eprintf("No IO binded to rz_analysis\n");
+			RZ_LOG_ERROR("No IO binded to rz_analysis\n");
 		}
 	} else {
 		if (val->reg) {

--- a/librz/core/analysis_objc.c
+++ b/librz/core/analysis_objc.c
@@ -214,9 +214,7 @@ static void core_objc_free(RzCoreObjc *o) {
 static bool objc_find_refs(RzCore *core) {
 	RzCoreObjc *objc = core_objc_new(core);
 	if (!objc) {
-		if (core->analysis->verbose) {
-			eprintf("Could not find necessary Objective-C sections...\n");
-		}
+		RZ_LOG_DEBUG("Could not find necessary Objective-C sections...\n");
 		return false;
 	}
 

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -2473,13 +2473,6 @@ static bool cb_zoombyte(void *user, void *data) {
 	return true;
 }
 
-static bool cb_analverbose(void *user, void *data) {
-	RzCore *core = (RzCore *)user;
-	RzConfigNode *node = (RzConfigNode *)data;
-	core->analysis->verbose = node->i_value;
-	return true;
-}
-
 static bool cb_binverbose(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
@@ -2952,7 +2945,6 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETCB("analysis.cc", analysiscc ? analysiscc : "", (RzConfigCallback)&cb_analysiscc, "Specify default calling convention");
 	const char *analysissyscc = rz_analysis_syscc_default(core->analysis);
 	SETCB("analysis.syscc", analysissyscc ? analysissyscc : "", (RzConfigCallback)&cb_analysissyscc, "Specify default syscall calling convention");
-	SETCB("analysis.verbose", "false", &cb_analverbose, "Show RzAnalysis warnings when analyzing code");
 	SETCB("analysis.roregs", "gp,zero", (RzConfigCallback)&cb_analysis_roregs, "Comma separated list of register names to be readonly");
 	SETICB("analysis.gp", 0, (RzConfigCallback)&cb_analysis_gp, "Set the value of the GP register (MIPS)");
 	SETBPREF("analysis.gpfixed", "true", "Set gp register to analysis.gp before emulating each instruction in aae");

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -619,7 +619,6 @@ typedef struct rz_analysis_t {
 	int stackptr;
 	bool (*log)(struct rz_analysis_t *analysis, const char *msg);
 	bool (*read_at)(struct rz_analysis_t *analysis, ut64 addr, ut8 *buf, int len);
-	bool verbose;
 	int seggrn;
 	RzFlagGetAtAddr flag_get;
 	RzEvent *ev;

--- a/test/db/cmd/cmd_af
+++ b/test/db/cmd/cmd_af
@@ -386,9 +386,9 @@ EXPECT=<<EOF
 0x00001337    0 0            func
 EOF
 EXPECT_ERR=<<EOF
-Invalid function name 'func' at 0x00001337
+ERROR: Invalid function name 'func' at 0x00001337
 Cannot add function (duplicated)
-Invalid function name 'func' at 0x00001337
+ERROR: Invalid function name 'func' at 0x00001337
 Cannot add function (duplicated)
 EOF
 RUN

--- a/test/db/esil/flag_tests
+++ b/test/db/esil/flag_tests
@@ -151,8 +151,6 @@ CMDS=<<EOF
 EOF
 EXPECT=<<EOF
 0x0
-EOF
-EXPECT_ERR=<<EOF
 ESIL TRAP type 3 code 0x00000000 divbyzero
 ESIL TRAP type 3 code 0x00000000 divbyzero
 ESIL TRAP type 3 code 0x00000000 divbyzero

--- a/test/db/esil/math
+++ b/test/db/esil/math
@@ -70,19 +70,20 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=div by zero 0 / 3
+NAME=div by zero 3 / 0
 FILE==
 CMDS=<<EOF
 ae 0,3,/
 ae*
 EOF
 EXPECT=<<EOF
+ESIL TRAP type 3 code 0x00000000 divbyzero
 trap: 3
 trap-code: 0
 EOF
 RUN
 
-NAME=div by zero 3 / 0
+NAME=div 0 / 3
 FILE==
 CMDS=<<EOF
 ae 3,0,/


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Removes all the `eprintf` from the analysis code, also i have removed `analysis.verbose` from the code in favor of `RZ_LOG_DEBUG`.
