### PR TITLE
Remove eprintfs from asm source code

### DIFF
--- a/librz/asm/arch/arm/armass.c
+++ b/librz/asm/arch/arm/armass.c
@@ -5836,14 +5836,14 @@ static int arm_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 						// TODO: control if branch out of range
 						ret = (getnum(ao->a[0]) - (int)ao->off - 8) / 4;
 						if (ret >= 0x00800000 || ret < (int)0xff800000) {
-							eprintf("Branch into out of range\n");
+							RZ_LOG_ERROR("assembler: arm: %s: invalid branch address (out of range).\n", ops[i].name);
 							return 0;
 						}
 						ao->o |= ((ret >> 16) & 0xff) << 8;
 						ao->o |= ((ret >> 8) & 0xff) << 16;
 						ao->o |= ((ret)&0xff) << 24;
 					} else {
-						eprintf("This branch does not accept reg as arg\n");
+						RZ_LOG_ERROR("assembler: arm: %s: instruction does not accept a register as argument\n", ops[i].name);
 						return 0;
 					}
 					break;
@@ -6046,7 +6046,7 @@ static int arm_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 							ao->o |= (y << 24);
 							ao->o |= (z << 16);
 						} else {
-							eprintf("Parameter %d out of range (0-255)\n", (int)b);
+							RZ_LOG_ERROR("assembler: arm: %s: parameter %d is out of range (0-255)\n", ops[i].name, b);
 							return 0;
 						}
 					} else {
@@ -6059,7 +6059,7 @@ static int arm_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 					if (ao->a[2]) {
 						int n = getnum(ao->a[2]);
 						if (n & 1) {
-							eprintf("Invalid multiplier\n");
+							RZ_LOG_ERROR("assembler: arm: %s: multiplier argument is not pair\n", ops[i].name);
 							return 0;
 						}
 						ao->o |= (n >> 1) << 16;
@@ -6215,7 +6215,7 @@ ut32 armass_assemble(const char *str, ut64 off, int thumb) {
 		return -1;
 	}
 	if (assemble[thumb](&aop, off, buf) <= 0) {
-		// eprintf ("armass: Unknown opcode (%s)\n", buf);
+		// RZ_LOG_ERROR("armass: Unknown opcode (%s)\n", buf);
 		return -1;
 	}
 	return aop.o;

--- a/librz/asm/arch/arm/armass64.c
+++ b/librz/asm/arch/arm/armass64.c
@@ -810,7 +810,7 @@ static ut32 adrp(ArmOp *op, ut64 addr, ut32 k) { //, int reg, ut64 dst) {
 	if (op->operands[0].type == ARM_GPR) {
 		data |= encode1reg(op);
 	} else {
-		eprintf("Usage: adrp x0, addr\n");
+		RZ_LOG_ERROR("assembler: arm64: adrp: invalid assembly. valid usage: adrp x0, addr\n");
 		return UT32_MAX;
 	}
 	if (op->operands[1].type == ARM_CONSTANT) {
@@ -818,7 +818,7 @@ static ut32 adrp(ArmOp *op, ut64 addr, ut32 k) { //, int reg, ut64 dst) {
 		at = op->operands[1].immediate - addr;
 		at /= 4;
 	} else {
-		eprintf("Usage: adrp, x0, addr\n");
+		RZ_LOG_ERROR("assembler: arm64: adrp: invalid assembly. valid usage: adrp x0, addr\n");
 		return UT32_MAX;
 	}
 	ut8 b0 = at;
@@ -996,7 +996,7 @@ static bool parseOperands(char *str, ArmOp *op) {
 			token++;
 		}
 		if (operand >= MAX_OPERANDS) {
-			eprintf("Too many operands\n");
+			RZ_LOG_ERROR("assembler: arm64: maximum number of operands reached.\n");
 			return false;
 		}
 		op->operands[operand].type = ARM_NOTYPE;

--- a/librz/asm/arch/java/jvm.c
+++ b/librz/asm/arch/java/jvm.c
@@ -7,7 +7,7 @@
 
 #define fail_if_no_enough_buffer_or_set(bytecode, jvm, n) \
 	if ((jvm->size - jvm->current) < n) { \
-		eprintf("%u < %u", jvm->size - jvm->current, n); \
+		RZ_LOG_DEBUG("java: buffer is not big enough (available: %u, needed: %u)\n", jvm->size - jvm->current, n); \
 		return false; \
 	} \
 	bytecode->size = n

--- a/librz/asm/arch/luac/lua_arch.c
+++ b/librz/asm/arch/luac/lua_arch.c
@@ -128,7 +128,7 @@ int lua_load_next_arg_start(const char *raw_string, char *recv_buf) {
 
 bool lua_is_valid_num_value_string(const char *str) {
 	if (!rz_is_valid_input_num_value(NULL, str)) {
-		eprintf("luac_assembler: %s is not a valid number argument\n", str);
+		RZ_LOG_ERROR("assembler: lua: %s is not a valid number argument\n", str);
 		return false;
 	}
 	return true;

--- a/librz/asm/arch/luac/v53/disassembly_53.c
+++ b/librz/asm/arch/luac/v53/disassembly_53.c
@@ -6,6 +6,7 @@
 
 int lua53_disasm(RzAsmOp *op, const ut8 *buf, int len, LuaOpNameList opnames) {
 	if (len < 4) {
+		RZ_LOG_DEBUG("Cannot disassemble lua53 opcode (truncated).\n");
 		return 0;
 	}
 	ut32 instruction = lua_build_instruction(buf);

--- a/librz/asm/arch/luac/v53/opcode_53.c
+++ b/librz/asm/arch/luac/v53/opcode_53.c
@@ -10,7 +10,7 @@
 LuaOpNameList get_lua53_opnames(void) {
 	LuaOpNameList list = RZ_NEWS(char *, LUA_NUM_OPCODES + 1);
 	if (list == NULL) {
-		eprintf("No Op Names\n");
+		RZ_LOG_ERROR("Cannot allocate lua53 opcode list.\n");
 		return NULL;
 	}
 

--- a/librz/asm/arch/luac/v54/disassembly_54.c
+++ b/librz/asm/arch/luac/v54/disassembly_54.c
@@ -5,7 +5,7 @@
 
 int lua54_disasm(RzAsmOp *op, const ut8 *buf, int len, LuaOpNameList opnames) {
 	if (len < 4) {
-		eprintf("truncated opcode\n");
+		RZ_LOG_DEBUG("Cannot disassemble lua54 opcode (truncated).\n");
 		return 0;
 	}
 

--- a/librz/asm/arch/luac/v54/opcode_54.c
+++ b/librz/asm/arch/luac/v54/opcode_54.c
@@ -9,7 +9,7 @@
 LuaOpNameList get_lua54_opnames(void) {
 	LuaOpNameList list = RZ_NEWS(char *, LUA_NUM_OPCODES + 1);
 	if (list == NULL) {
-		eprintf("No Op Names\n");
+		RZ_LOG_ERROR("Cannot allocate lua54 opcode list.\n");
 		return NULL;
 	}
 

--- a/librz/asm/arch/mips/mipsasm.c
+++ b/librz/asm/arch/mips/mipsasm.c
@@ -121,8 +121,8 @@ static int mips_j(ut8 *b, int op, int addr) {
 
 static int getreg(const char *p) {
 	int n;
-	if (!p || !*p) {
-		eprintf("Missing argument\n");
+	if (RZ_STR_ISEMPTY(p)) {
+		RZ_LOG_ERROR("assembler: mips: invalid assembly (missing an argument).\n");
 		return -1;
 	}
 	/* check if it's a register */
@@ -141,7 +141,7 @@ static int getreg(const char *p) {
 	if (n != 0 || p[0] == '0') {
 		return n;
 	}
-	eprintf("Invalid reg name (%s) at pos %d\n", p, n);
+	RZ_LOG_ERROR("assembler: mips: invalid reg name (%s) at pos %d.\n", p, n);
 	return -1;
 }
 

--- a/librz/asm/arch/pyc/opcode.c
+++ b/librz/asm/arch/pyc/opcode.c
@@ -260,7 +260,7 @@ void(store_opN)(struct op_parameter par) {
 		def_op(.op_obj = par.op_obj, .op_name = par.op_name, .op_code = par.op_code, .pop = par.pop, .push = par.push);
 		break;
 	default:
-		eprintf("Error in store_op in opcode.c, call function %u.\n", par.func);
+		RZ_LOG_ERROR("Error in store_op in pyc/opcode.c, call function %u.\n", par.func);
 		return;
 	}
 	par.op_obj[par.op_code].type |= HASSTORE;
@@ -309,6 +309,6 @@ void(rm_op)(struct op_parameter par) {
 		op_obj->op_name = rz_str_newf("<%u>", par.op_code);
 		op_obj->type = op_obj->op_pop = op_obj->op_push = 0;
 	} else {
-		eprintf("Error in rm_op() while constructing opcodes for .pyc file: \n .op_code = %u, .op_name = %s", par.op_code, par.op_name);
+		RZ_LOG_ERROR("Error in rm_op() while constructing opcodes for .pyc file: \n .op_code = %u, .op_name = %s", par.op_code, par.op_name);
 	}
 }

--- a/librz/asm/arch/z80/z80asm.c
+++ b/librz/asm/arch/z80/z80asm.c
@@ -127,7 +127,7 @@ static const char *delspc(const char *ptr) {
 static void rd_comma(const char **p) {
 	*p = delspc (*p);
 	if (**p != ',') {
-		eprintf ("`,' expected. Remainder of line: %s\n", *p);
+		RZ_LOG_ERROR("assembler: z80: `,' expected. Remainder of line: %s\n", *p);
 		return;
 	}
 	*p = delspc ((*p) + 1);
@@ -156,7 +156,7 @@ static int indx(const char **ptr, const char **list, int error, const char **exp
 	*ptr = delspc (*ptr);
 	if (!**ptr) {
 		if (error) {
-			eprintf ("unexpected end of line\n");
+			RZ_LOG_ERROR("assembler: z80: unexpected end of line\n");
 			return 0;
 		} else {
 			return 0;
@@ -208,7 +208,7 @@ static int indx(const char **ptr, const char **list, int error, const char **exp
 		comma++;
 		return i + 1;
 	}
-	// if (error) eprintf ("parse error. Remainder of line=%s\n", *ptr);
+	// if (error) RZ_LOG_ERROR("assembler: z80: parse error. Remainder of line=%s\n", *ptr);
 	return 0;
 }
 
@@ -233,7 +233,7 @@ static void readlabel(const char **p, int store) {
 		return;
 	}
 	if (pos == *p) {
-		eprintf ("`:' found without a label");
+		RZ_LOG_ERROR("assembler: z80: `:' found without a label");
 		return;
 	}
 	if (!store) {
@@ -244,7 +244,7 @@ static void readlabel(const char **p, int store) {
 	dummy = *p;
 	j = rd_label (&dummy, &i, &previous, sp, 0);
 	if (i || j) {
-		eprintf ("duplicate definition of label %s\n", *p);
+		RZ_LOG_ERROR("assembler: z80: duplicate definition of label %s\n", *p);
 		*p = c;
 		return;
 	}
@@ -733,7 +733,7 @@ static int rd_ldbcdehla(const char **p) {
 		int x;
 		x = 0xdd + 0x20 * (i > 12);
 		if (indexed && indexed != x) {
-			eprintf ("illegal use of index registers\n");
+			RZ_LOG_ERROR("assembler: z80: illegal use of index registers\n");
 			return 0;
 		}
 		indexed = x;
@@ -741,7 +741,7 @@ static int rd_ldbcdehla(const char **p) {
 	}
 	if (i > 8) {
 		if (indexed) {
-			eprintf ("illegal use of index registers\n");
+			RZ_LOG_ERROR("assembler: z80: illegal use of index registers\n");
 			return 0;
 		}
 		indexed = 0xDD + 0x20 * (i == 10);
@@ -861,7 +861,7 @@ static int assemble(const char *str, unsigned char *_obuf) {
 			}
 			if (has_argument (&ptr)) {
 				if (r != A) {
-					eprintf ("parse error before: %s\n", ptr);
+					RZ_LOG_ERROR("assembler: z80: parse error before: %s\n", ptr);
 					break;
 				}
 				if (!(r = rd_r (&ptr))) {
@@ -1405,7 +1405,7 @@ static int assemble(const char *str, unsigned char *_obuf) {
 			}
 			if (has_argument (&ptr)) {		/* SUB A,r ?  */
 				if (r != A) {
-					eprintf ("parse error before: %s\n", ptr);
+					RZ_LOG_ERROR("assembler: z80: parse error before: %s\n", ptr);
 					break;
 				}
 				if (!(r = rd_r (&ptr))) {
@@ -1436,7 +1436,7 @@ static int assemble(const char *str, unsigned char *_obuf) {
 					while (*ptr != quote) {
 						write_one_byte (rd_character (&ptr, NULL, 1), 0);
 						if (*ptr == 0) {
-							eprintf ("end of line in quoted string\n");
+							RZ_LOG_ERROR("assembler: z80: end of line in quoted string\n");
 							break;
 						}
 					}
@@ -1451,7 +1451,7 @@ static int assemble(const char *str, unsigned char *_obuf) {
 					continue;
 				}
 				if (*ptr != 0) {
-					eprintf ("junk in byte definition: %s\n", ptr);
+					RZ_LOG_ERROR("assembler: z80: junk in byte definition: %s\n", ptr);
 				}
 				break;
 			}
@@ -1459,7 +1459,7 @@ static int assemble(const char *str, unsigned char *_obuf) {
 		case Z80_DEFW:
 		case Z80_DW:
 			if (!rd_word (&ptr, ',')) {
-				eprintf ("No data for word definition\n");
+				RZ_LOG_ERROR("assembler: z80: No data for word definition\n");
 				break;
 			}
 			while (1) {
@@ -1469,7 +1469,7 @@ static int assemble(const char *str, unsigned char *_obuf) {
 				}
 				++ptr;
 				if (!rd_word (&ptr, ',')) {
-					eprintf ("Missing expression in defw\n");
+					RZ_LOG_ERROR("assembler: z80: Missing expression in defw\n");
 				}
 			}
 			break;
@@ -1477,7 +1477,7 @@ static int assemble(const char *str, unsigned char *_obuf) {
 		case Z80_DS:
 			r = rd_expr (&ptr, ',', NULL, sp, 1);
 			if (r < 0) {
-				eprintf ("ds should have its first argument >=0"
+				RZ_LOG_ERROR("assembler: z80: ds should have its first argument >=0"
 						" (not -0x%x)\n", -r);
 				break;
 			}
@@ -1501,21 +1501,21 @@ static int assemble(const char *str, unsigned char *_obuf) {
 		case Z80_IF:
 			break;
 		case Z80_ELSE:
-			eprintf ("else without if\n");
+			RZ_LOG_ERROR("assembler: z80: else without if\n");
 			break;
 		case Z80_ENDIF:
-			eprintf ("endif without if\n");
+			RZ_LOG_ERROR("assembler: z80: endif without if\n");
 			break;
 		case Z80_ENDM:
 			if (stack[sp].file) {
-				eprintf ("endm outside macro definition\n");
+				RZ_LOG_ERROR("assembler: z80: endm outside macro definition\n");
 			}
 			break;
 		case Z80_SEEK:
-			eprintf ("seek error\n");
+			RZ_LOG_ERROR("assembler: z80: seek error\n");
 			break;
 		default:
-			// eprintf ("command or comment expected (was %s)\n", ptr);
+			// RZ_LOG_ERROR("assembler: z80: command or comment expected (was %s)\n", ptr);
 			return 0;
 	}
 

--- a/librz/asm/asm.c
+++ b/librz/asm/asm.c
@@ -55,7 +55,7 @@ static int rz_asm_pseudo_string(RzAsmOp *op, char *input, int zero) {
 
 static inline int rz_asm_pseudo_arch(RzAsm *a, char *input) {
 	if (!rz_asm_use(a, input)) {
-		eprintf("Error: Unknown plugin\n");
+		RZ_LOG_ERROR("Unknown asm plugin name '%s'\n", input);
 		return -1;
 	}
 	return 0;
@@ -63,7 +63,7 @@ static inline int rz_asm_pseudo_arch(RzAsm *a, char *input) {
 
 static inline int rz_asm_pseudo_bits(RzAsm *a, char *input) {
 	if (!(rz_asm_set_bits(a, rz_num_math(NULL, input)))) {
-		eprintf("Error: Unsupported value for .bits.\n");
+		RZ_LOG_ERROR("Unsupported bits (%s) value for the selected asm plugin.\n", input);
 		return -1;
 	}
 	return 0;
@@ -75,12 +75,11 @@ static inline int rz_asm_pseudo_org(RzAsm *a, char *input) {
 }
 
 static inline int rz_asm_pseudo_intN(RzAsm *a, RzAsmOp *op, char *input, int n) {
-	short s;
-	int i;
-	long int l;
+	ut16 s;
+	ut32 i;
 	ut64 s64 = rz_num_math(NULL, input);
 	if (n != 8 && s64 >> (n * 8)) {
-		eprintf("int16 Out is out of range\n");
+		RZ_LOG_ERROR("Cannot write a number that does not fit within a int%d type.\n", (n * 8));
 		return 0;
 	}
 	// XXX honor endian here
@@ -89,14 +88,13 @@ static inline int rz_asm_pseudo_intN(RzAsm *a, RzAsmOp *op, char *input, int n) 
 		return 0;
 	}
 	if (n == 2) {
-		s = (short)s64;
+		s = (ut16)(st16)s64;
 		rz_write_ble16(buf, s, a->big_endian);
 	} else if (n == 4) {
-		i = (int)s64;
+		i = (ut32)(st32)s64;
 		rz_write_ble32(buf, i, a->big_endian);
 	} else if (n == 8) {
-		l = (long int)s64;
-		rz_write_ble64(buf, l, a->big_endian);
+		rz_write_ble64(buf, (ut64)s64, a->big_endian);
 	} else {
 		return 0;
 	}
@@ -163,7 +161,7 @@ static inline int rz_asm_pseudo_incbin(RzAsmOp *op, char *input) {
 	size_t count = (size_t)rz_num_math(NULL, rz_str_word_get0(input, 2));
 	char *content = rz_file_slurp(input, &bytes_read);
 	if (!content) {
-		eprintf("Could not open '%s'.\n", input);
+		RZ_LOG_ERROR("Could not open '%s'.\n", input);
 		return -1;
 	}
 	if (skip > 0) {
@@ -378,7 +376,7 @@ RZ_API bool rz_asm_set_big_endian(RzAsm *a, bool b) {
 		a->big_endian = true;
 		break;
 	default:
-		eprintf("RzAsmPlugin doesn't specify endianness\n");
+		RZ_LOG_DEBUG("The asm plugin doesn't specify endianness.\n");
 		break;
 	}
 	return a->big_endian;
@@ -764,12 +762,12 @@ RZ_API RzAsmCode *rz_asm_massemble(RzAsm *a, const char *assembly) {
 			const size_t new_tokens_size = tokens_size * 2;
 			if (sizeof(char *) * new_tokens_size <= sizeof(char *) * tokens_size) {
 				// overflow
-				eprintf("Too many tokens\n");
+				RZ_LOG_ERROR("Too many tokens while assembling (overflow).\n");
 				goto fail;
 			}
 			char **new_tokens = realloc(tokens, sizeof(char *) * new_tokens_size);
 			if (!new_tokens) {
-				eprintf("Too many tokens\n");
+				RZ_LOG_ERROR("Cannot reallocate meory for tokens while assembling.\n");
 				goto fail;
 			}
 			tokens_size = new_tokens_size;
@@ -945,7 +943,7 @@ RZ_API RzAsmCode *rz_asm_massemble(RzAsm *a, const char *assembly) {
 				} else if ((!strncmp(ptr, ".byte ", 6)) || (!strncmp(ptr, ".int8 ", 6))) {
 					ret = rz_asm_pseudo_byte(&op, ptr + 6);
 				} else if (!strncmp(ptr, ".glob", 5)) { // .global .globl
-					//	eprintf (".global directive not yet implemented\n");
+					RZ_LOG_DEBUG(".global directive not yet implemented\n");
 					ret = 0;
 					continue;
 				} else if (!strncmp(ptr, ".equ ", 5)) {
@@ -960,31 +958,31 @@ RZ_API RzAsmCode *rz_asm_massemble(RzAsm *a, const char *assembly) {
 						*ptr2 = '\0';
 						rz_asm_code_set_equ(acode, ptr + 5, ptr2 + 1);
 					} else {
-						eprintf("Invalid syntax for '.equ': Use '.equ <word> <word>'\n");
+						RZ_LOG_ERROR("Invalid syntax for '.equ': Use '.equ <word> <word>'\n");
 					}
 				} else if (!strncmp(ptr, ".org ", 5)) {
 					ret = rz_asm_pseudo_org(a, ptr + 5);
 				} else if (rz_str_startswith(ptr, ".offset ")) {
-					eprintf("Invalid use of the .offset directory. This directive is only supported in rizin -c 'waf'.\n");
+					RZ_LOG_ERROR("Invalid use of the .offset directory. This directive is only supported in rizin -c 'waf'.\n");
 				} else if (!strncmp(ptr, ".text", 5)) {
 					acode->code_offset = a->pc;
 				} else if (!strncmp(ptr, ".data", 5)) {
 					acode->data_offset = a->pc;
 				} else if (!strncmp(ptr, ".incbin", 7)) {
 					if (ptr[7] != ' ') {
-						eprintf("incbin missing filename\n");
+						RZ_LOG_ERROR("Invalid syntax for '.incbin': Use '.incbin <filename>'\n");
 						continue;
 					}
 					ret = rz_asm_pseudo_incbin(&op, ptr + 8);
 				} else {
-					eprintf("Unknown directive (%s)\n", ptr);
+					RZ_LOG_ERROR("Unknown directive named '%s'\n", ptr);
 					goto fail;
 				}
 				if (!ret) {
 					continue;
 				}
 				if (ret < 0) {
-					eprintf("!!! Oops (%s)\n", ptr);
+					RZ_LOG_ERROR("Something went wrong when handling the directive '%s'.\n", ptr);
 					goto fail;
 				}
 			} else { /* Instruction */
@@ -1006,7 +1004,7 @@ RZ_API RzAsmCode *rz_asm_massemble(RzAsm *a, const char *assembly) {
 			}
 			if (stage == STAGES - 1) {
 				if (ret < 1) {
-					eprintf("Cannot assemble '%s' at line %d\n", ptr_start, linenum);
+					RZ_LOG_ERROR("Cannot assemble '%s' at line %d\n", ptr_start, linenum);
 					goto fail;
 				}
 				acode->len = idx + ret;

--- a/librz/asm/binutils_as.c
+++ b/librz/asm/binutils_as.c
@@ -10,7 +10,7 @@ int binutils_assemble(RzAsm *a, RzAsmOp *op, const char *buf, const char *as, co
 		as = user_as;
 	}
 	if (RZ_STR_ISEMPTY(as)) {
-		eprintf("Please set %s env to define a %s assembler program\n", env, a->cur->arch);
+		RZ_LOG_ERROR("Please set '%s' env to define a '%s' assembler program\n", env, a->cur->arch);
 		return 1;
 	}
 
@@ -59,7 +59,7 @@ int binutils_assemble(RzAsm *a, RzAsmOp *op, const char *buf, const char *as, co
 		begin = rz_mem_mem(obuf, len, (const ut8 *)"BEGINMARK", 9);
 		end = rz_mem_mem(obuf, len, (const ut8 *)"ENDMARK", 7);
 		if (!begin || !end) {
-			eprintf("Cannot find water marks\n");
+			RZ_LOG_ERROR("Cannot find water marks BEGINMARK or/and ENDMARK\n");
 			len = 0;
 		} else {
 			len = (int)(size_t)(end - begin - 9);
@@ -71,7 +71,7 @@ int binutils_assemble(RzAsm *a, RzAsmOp *op, const char *buf, const char *as, co
 		}
 		res = op->size = len;
 	} else {
-		eprintf("Error running: %s", cmd);
+		RZ_LOG_ERROR("Failed to run command: '%s'\n", cmd);
 	}
 
 beach:

--- a/librz/asm/p/asm_arm_cs.c
+++ b/librz/asm/p/asm_arm_cs.c
@@ -234,7 +234,7 @@ static int assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
 	} else {
 		opcode = armass_assemble(buf, a->pc, is_thumb);
 		if (a->bits != 32 && a->bits != 16) {
-			eprintf("Error: ARM assembler only supports 16 or 32 bits\n");
+			RZ_LOG_ERROR("assembler: arm: cannot assemble instruction due invalid 'asm.bits' value (accepted only 16 or 32 bits).\n");
 			return -1;
 		}
 	}

--- a/librz/asm/p/asm_luac.c
+++ b/librz/asm/p/asm_luac.c
@@ -8,7 +8,7 @@ int rz_luac_disasm(RzAsm *a, RzAsmOp *opstruct, const ut8 *buf, int len) {
 	int r = 0;
 
 	if (!a->cpu) {
-		eprintf("Warning : no version info, specify it with `-c` option\n");
+		RZ_LOG_ERROR("disassembler: lua: no version info, specify it with `asm.cpu` option\n");
 		return -1;
 	}
 
@@ -19,7 +19,7 @@ int rz_luac_disasm(RzAsm *a, RzAsmOp *opstruct, const ut8 *buf, int len) {
 		oplist = get_lua53_opnames();
 		r = lua53_disasm(opstruct, buf, len, oplist);
 	} else {
-		eprintf("Warning : version %s is not supported\n", a->cpu);
+		RZ_LOG_ERROR("disassembler: lua: version %s is not supported\n", a->cpu);
 		return -1;
 	}
 
@@ -34,7 +34,7 @@ int rz_luac_asm(RzAsm *a, RzAsmOp *opstruct, const char *str) {
 	ut8 buffer[4];
 
 	if (!a->cpu) {
-		eprintf("Warning : no version info, specify it with `-c` option\n");
+		RZ_LOG_ERROR("assembler: lua: no version info, specify it with `asm.cpu` option\n");
 		return -1;
 	}
 
@@ -47,7 +47,7 @@ int rz_luac_asm(RzAsm *a, RzAsmOp *opstruct, const char *str) {
 			return -1;
 		}
 	} else {
-		eprintf("Warning : version %s is not supported\n", a->cpu);
+		RZ_LOG_ERROR("assembler: lua: version %s is not supported\n", a->cpu);
 		return -1;
 	}
 

--- a/librz/asm/p/asm_pyc.c
+++ b/librz/asm/p/asm_pyc.c
@@ -36,7 +36,7 @@ static int disassemble(RzAsm *a, RzAsmOp *opstruct, const ut8 *buf, int len) {
 	if (!opcodes_cache || !pyc_opcodes_equal(opcodes_cache, a->cpu)) {
 		opcodes_cache = get_opcode_by_version(a->cpu);
 		if (opcodes_cache == NULL) {
-			eprintf("[x]Require Info from code object, use rizin instead\n");
+			RZ_LOG_ERROR("disassembler: pyc: unsupported pyc opcode cpu/version (asm.cpu=%s).\n", a->cpu);
 			return len;
 		}
 		opcodes_cache->bits = a->bits;

--- a/librz/asm/p/asm_x86_nasm.c
+++ b/librz/asm/p/asm_x86_nasm.c
@@ -7,7 +7,7 @@
 static int assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
 	char *ipath, *opath;
 	if (a->syntax != RZ_ASM_SYNTAX_INTEL) {
-		eprintf("asm.x86.nasm does not support non-intel syntax\n");
+		RZ_LOG_ERROR("assembler: x86.nasm: the assembler does not support non-intel syntax\n");
 		return -1;
 	}
 
@@ -35,7 +35,7 @@ static int assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
 		op->size = read(ofd, buf, sizeof(buf));
 		rz_asm_op_set_buf(op, buf, op->size);
 	} else {
-		eprintf("Error running 'nasm'\n");
+		RZ_LOG_ERROR("assembler: x86.nasm: failed to run command 'nasm %s -o %s'\n", ipath, opath);
 	}
 
 	close(ofd);

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -131,7 +131,7 @@ FILE==
 CMDS=!rz-asm -a x86 -b 32 "mov hello, eax"
 EXPECT=
 EXPECT_ERR=<<EOF
-Cannot assemble 'mov hello, eax' at line 3
+ERROR: Cannot assemble 'mov hello, eax' at line 3
 EOF
 RUN
 
@@ -140,7 +140,7 @@ FILE==
 CMDS=!rz-asm -a x86 -b 32 "mov 33, eax"
 EXPECT=
 EXPECT_ERR=<<EOF
-Cannot assemble 'mov 33, eax' at line 3
+ERROR: Cannot assemble 'mov 33, eax' at line 3
 EOF
 RUN
 
@@ -149,7 +149,7 @@ FILE==
 CMDS=!rz-asm -a x86 -b 32 "mov eax, hello"
 EXPECT=
 EXPECT_ERR=<<EOF
-Cannot assemble 'mov eax, hello' at line 3
+ERROR: Cannot assemble 'mov eax, hello' at line 3
 EOF
 RUN
 
@@ -158,7 +158,7 @@ FILE==
 CMDS=!rz-asm -a x86 -b 32 "mov eax, 0x1122334455"
 EXPECT=
 EXPECT_ERR=<<EOF
-Cannot assemble 'mov eax, 0x1122334455' at line 3
+ERROR: Cannot assemble 'mov eax, 0x1122334455' at line 3
 EOF
 RUN
 
@@ -170,8 +170,8 @@ CMDS=<<EOF
 EOF
 EXPECT=
 EXPECT_ERR=<<EOF
-Cannot assemble 'mov rax, 0x112233445566778899' at line 3
-Cannot assemble 'mov eax, 0x1122334455' at line 3
+ERROR: Cannot assemble 'mov rax, 0x112233445566778899' at line 3
+ERROR: Cannot assemble 'mov eax, 0x1122334455' at line 3
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Removes all the `eprintf` from the asm code