### PR TITLE
Add floating point support to math operations

### DIFF
--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -611,8 +611,6 @@ RZ_IPI int rz_cmd_help(void *data, const char *input) {
 			/* binary and floating point */
 			rz_str_bits64(out, n);
 			f = d = core->num->fvalue;
-			memcpy(&f, &n, sizeof(f));
-			memcpy(&d, &n, sizeof(d));
 			/* adjust sign for nan floats, different libcs are confused */
 			if (isnan(f) && signbit(f)) {
 				f = -f;

--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -558,6 +558,7 @@ RZ_IPI int rz_cmd_help(void *data, const char *input) {
 		ut32 s, a;
 		double d;
 		float f;
+		char number[128];
 		char *const inputs = strdup(input + 1);
 		RzList *list = rz_num_str_split_list(inputs);
 		const int list_len = rz_list_length(list);
@@ -581,14 +582,14 @@ RZ_IPI int rz_cmd_help(void *data, const char *input) {
 			a = n & 0x0fff;
 			rz_num_units(unit, sizeof(unit), n);
 			if (*input == 'j') {
-				pj_ks(pj, "int32", sdb_fmt("%d", (st32)(n & UT32_MAX)));
-				pj_ks(pj, "uint32", sdb_fmt("%u", (ut32)n));
-				pj_ks(pj, "int64", sdb_fmt("%" PFMT64d, (st64)n));
-				pj_ks(pj, "uint64", sdb_fmt("%" PFMT64u, (ut64)n));
-				pj_ks(pj, "hex", sdb_fmt("0x%08" PFMT64x, n));
-				pj_ks(pj, "octal", sdb_fmt("0%" PFMT64o, n));
+				pj_ks(pj, "int32", rz_strf(number, "%d", (st32)(n & UT32_MAX)));
+				pj_ks(pj, "uint32", rz_strf(number, "%u", (ut32)n));
+				pj_ks(pj, "int64", rz_strf(number, "%" PFMT64d, (st64)n));
+				pj_ks(pj, "uint64", rz_strf(number, "%" PFMT64u, (ut64)n));
+				pj_ks(pj, "hex", rz_strf(number, "0x%08" PFMT64x, n));
+				pj_ks(pj, "octal", rz_strf(number, "0%" PFMT64o, n));
 				pj_ks(pj, "unit", unit);
-				pj_ks(pj, "segment", sdb_fmt("%04x:%04x", s, a));
+				pj_ks(pj, "segment", rz_strf(number, "%04x:%04x", s, a));
 
 			} else {
 				if (n >> 32) {
@@ -619,12 +620,12 @@ RZ_IPI int rz_cmd_help(void *data, const char *input) {
 				d = -d;
 			}
 			if (*input == 'j') {
-				pj_ks(pj, "fvalue", sdb_fmt("%.1lf", core->num->fvalue));
-				pj_ks(pj, "float", sdb_fmt("%ff", f));
-				pj_ks(pj, "double", sdb_fmt("%lf", d));
-				pj_ks(pj, "binary", sdb_fmt("0b%s", out));
+				pj_ks(pj, "fvalue", rz_strf(number, "%.1lf", core->num->fvalue));
+				pj_ks(pj, "float", rz_strf(number, "%ff", f));
+				pj_ks(pj, "double", rz_strf(number, "%lf", d));
+				pj_ks(pj, "binary", rz_strf(number, "0b%s", out));
 				rz_num_to_trits(out, n);
-				pj_ks(pj, "trits", sdb_fmt("0t%s", out));
+				pj_ks(pj, "trits", rz_strf(number, "0t%s", out));
 			} else {
 				rz_cons_printf("fvalue  %.1lf\n", core->num->fvalue);
 				rz_cons_printf("float   %ff\n", f);

--- a/test/db/cmd/cmd_help
+++ b/test/db/cmd/cmd_help
@@ -148,8 +148,8 @@ unit    1
 segment 0000:0001
 string  "\x01"
 fvalue  1.0
-float   0.000000f
-double  0.000000
+float   1.000000f
+double  1.000000
 binary  0b00000001
 trits   0t1
 1
@@ -188,8 +188,8 @@ unit    16E
 segment fffff000:0fff
 string  "\xff\xff\xff\xff\xff\xff\xff\xff"
 fvalue  -1.0
-float   nanf
-double  nan
+float   -1.000000f
+double  -1.000000
 binary  0b1111111111111111111111111111111111111111111111111111111111111111
 trits   0t11112220022122120101211020120210210211220
 EOF
@@ -207,8 +207,8 @@ unit    2
 segment 0000:0002
 string  "\x02"
 fvalue  3.0
-float   0.000000f
-double  0.000000
+float   3.000000f
+double  3.000000
 binary  0b00000010
 trits   0t2
 EOF
@@ -226,8 +226,8 @@ unit    8
 segment 0000:0008
 string  "\b"
 fvalue  8.0
-float   0.000000f
-double  0.000000
+float   8.000000f
+double  8.000000
 binary  0b00001000
 trits   0t22
 EOF
@@ -245,8 +245,8 @@ unit    16.0E
 segment fffff000:02f7
 string  "\xf7\xc2\xff\xff\xff\xff\xff\xff"
 fvalue  -15625.0
-float   nanf
-double  nan
+float   -15625.000000f
+double  -15625.000000
 binary  0b1111111111111111111111111111111111111111111111111100001011110111
 trits   0t11112220022122120101211020120210000102020
 EOF
@@ -264,8 +264,8 @@ unit    5.6K
 segment 0000:0690
 string  "\x90\x16"
 fvalue  5776.0
-float   0.000000f
-double  0.000000
+float   5776.000000f
+double  5776.000000
 binary  0b0001011010010000
 trits   0t21220221
 EOF
@@ -283,8 +283,8 @@ unit    0
 segment 0000:0000
 string  "\0"
 fvalue  0.0
-float   0.000000f
-double  0.000000
+float   0.010000f
+double  0.010000
 binary  0b00000000
 trits   0t0
 EOF
@@ -302,8 +302,8 @@ unit    1
 segment 0000:0001
 string  "\x01"
 fvalue  1.0
-float   0.000000f
-double  0.000000
+float   1.000000f
+double  1.000000
 binary  0b00000001
 trits   0t1
 EOF
@@ -321,8 +321,8 @@ unit    16
 segment 0000:0010
 string  "\x10"
 fvalue  16.0
-float   0.000000f
-double  0.000000
+float   16.000000f
+double  16.000000
 binary  0b00010000
 trits   0t121
 EOF
@@ -340,8 +340,8 @@ unit    300
 segment 0000:012c
 string  ",\x01"
 fvalue  300.0
-float   0.000000f
-double  0.000000
+float   300.000000f
+double  300.000000
 binary  0b0000000100101100
 trits   0t102010
 EOF
@@ -359,8 +359,8 @@ unit    33
 segment 0000:0021
 string  "!"
 fvalue  33.3
-float   0.000000f
-double  0.000000
+float   33.333332f
+double  33.333333
 binary  0b00100001
 trits   0t1020
 EOF
@@ -378,8 +378,8 @@ unit    103
 segment 0000:0067
 string  "g"
 fvalue  103.0
-float   0.000000f
-double  0.000000
+float   103.000000f
+double  103.000000
 binary  0b01100111
 trits   0t10211
 EOF
@@ -397,8 +397,8 @@ unit    2
 segment 0000:0002
 string  "\x02"
 fvalue  2.0
-float   0.000000f
-double  0.000000
+float   2.000000f
+double  2.000000
 binary  0b00000010
 trits   0t2
 EOF
@@ -416,8 +416,8 @@ unit    4
 segment 0000:0004
 string  "\x04"
 fvalue  4.5
-float   0.000000f
-double  0.000000
+float   4.500000f
+double  4.500000
 binary  0b00000100
 trits   0t11
 EOF

--- a/test/db/cmd/feat_variables
+++ b/test/db/cmd/feat_variables
@@ -275,8 +275,8 @@ unit    8
 segment 0000:0008
 string  "\b"
 fvalue  8.0
-float   0.000000f
-double  0.000000
+float   8.000000f
+double  8.000000
 binary  0b00001000
 trits   0t22
 0x8
@@ -348,8 +348,8 @@ unit    123
 segment 0000:007b
 string  "{"
 fvalue  123.0
-float   0.000000f
-double  0.000000
+float   123.000000f
+double  123.000000
 binary  0b01111011
 trits   0t11120
 EOF

--- a/test/db/formats/firmware
+++ b/test/db/formats/firmware
@@ -38,8 +38,8 @@ unit    1023.9K
 segment f000:0faa
 string  "\xaa\xff\x0f"
 fvalue  1048490.0
-float   0.000000f
-double  0.000000
+float   1048490.000000f
+double  1048490.000000
 binary  0b000011111111111110101010
 trits   0t1222021020222
 EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
```c
// rz_cmd_help()
n = rz_num_math(core->num, str);
// ...
f = d = core->num->fvalue;
memcpy(&f, &n, sizeof(f));
memcpy(&d, &n, sizeof(d));
```
The last two lines seem to be wrong, just remove them. No need to modify `calc.c`
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**
`rz-test -i test/db/cmd/cmd_help`

...

**Closing issues**

closes #2253
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
