### PR TITLE
Rename functions properly and ensure to remove the old flags.

### DIFF
--- a/librz/flag/flag.c
+++ b/librz/flag/flag.c
@@ -755,6 +755,7 @@ RZ_API void rz_flag_bind(RzFlag *f, RzFlagBind *fb) {
 	fb->exist_at = rz_flag_exist_at;
 	fb->get = rz_flag_get;
 	fb->get_at = rz_flag_get_at;
+	fb->get_at_by_spaces = rz_flag_get_by_spaces;
 	fb->get_list = rz_flag_get_list;
 	fb->set = rz_flag_set;
 	fb->unset = rz_flag_unset;

--- a/librz/flag/flag.c
+++ b/librz/flag/flag.c
@@ -764,6 +764,7 @@ RZ_API void rz_flag_bind(RzFlag *f, RzFlagBind *fb) {
 	fb->set_fs = rz_flag_space_set;
 	fb->push_fs = rz_flag_space_push;
 	fb->pop_fs = rz_flag_space_pop;
+	fb->rename = rz_flag_rename;
 }
 
 static bool flag_count_foreach(RzFlagItem *fi, void *user) {

--- a/librz/include/rz_flag.h
+++ b/librz/include/rz_flag.h
@@ -69,6 +69,7 @@ typedef bool (*RzFlagUnsetOff)(RzFlag *f, ut64 addr);
 typedef RzSpace *(*RzFlagSetSpace)(RzFlag *f, const char *name);
 typedef bool (*RzFlagPopSpace)(RzFlag *f);
 typedef bool (*RzFlagPushSpace)(RzFlag *f, const char *name);
+typedef int (*RzFlagRename)(RzFlag *f, RzFlagItem *item, const char *name);
 
 typedef bool (*RzFlagItemCb)(RzFlagItem *fi, void *user);
 
@@ -87,6 +88,7 @@ typedef struct rz_flag_bind_t {
 	RzFlagSetSpace set_fs;
 	RzFlagPushSpace push_fs;
 	RzFlagPopSpace pop_fs;
+	RzFlagRename rename;
 } RzFlagBind;
 
 #define rz_flag_bind_init(x) memset(&x, 0, sizeof(x))

--- a/librz/include/rz_flag.h
+++ b/librz/include/rz_flag.h
@@ -60,6 +60,7 @@ typedef bool (*RzFlagExistAt)(RzFlag *f, const char *flag_prefix, ut16 fp_size, 
 typedef RzFlagItem *(*RzFlagGet)(RzFlag *f, const char *name);
 typedef RzFlagItem *(*RzFlagGetAtAddr)(RzFlag *f, ut64);
 typedef RzFlagItem *(*RzFlagGetAt)(RzFlag *f, ut64 addr, bool closest);
+typedef RzFlagItem *(*RzFlagGetAtBySpaces)(RzFlag *f, ut64 off, ...);
 typedef const RzList *(*RzFlagGetList)(RzFlag *f, ut64 addr);
 typedef RzFlagItem *(*RzFlagSet)(RzFlag *f, const char *name, ut64 addr, ut32 size);
 typedef bool (*RzFlagUnset)(RzFlag *f, RzFlagItem *item);
@@ -77,6 +78,7 @@ typedef struct rz_flag_bind_t {
 	RzFlagExistAt exist_at;
 	RzFlagGet get;
 	RzFlagGetAt get_at;
+	RzFlagGetAtBySpaces get_at_by_spaces;
 	RzFlagGetList get_list;
 	RzFlagSet set;
 	RzFlagUnset unset;

--- a/librz/signature/flirt.c
+++ b/librz/signature/flirt.c
@@ -433,9 +433,12 @@ static int module_match_buffer(RzAnalysis *analysis, const RzFlirtModule *module
 
 			RzFlagItem *fit = analysis->flb.get_at_by_spaces(analysis->flb.f, next_module_function->addr, "fcn.", "func.", NULL);
 			if (fit) {
-				analysis->flb.unset(analysis->flb.f, fit);
+				// rename old fcn.xxxx to flirt.yyyyy
+				analysis->flb.rename(analysis->flb.f, fit, name);
+			} else {
+				// best effort, add flag..
+				analysis->flb.set(analysis->flb.f, name, next_module_function->addr, next_module_function_size);
 			}
-			analysis->flb.set(analysis->flb.f, name, next_module_function->addr, next_module_function_size);
 			RZ_LOG_DEBUG("FLIRT: Found %s\n", next_module_function->name);
 		}
 	}

--- a/librz/signature/flirt.c
+++ b/librz/signature/flirt.c
@@ -362,6 +362,7 @@ static int module_match_buffer(RzAnalysis *analysis, const RzFlirtModule *module
 	RzListIter *tail_byte_it, *flirt_func_it;
 	RzFlirtTailByte *tail_byte;
 	ut32 name_index = 0;
+	char name[RZ_FLIRT_NAME_MAX];
 
 	if (32 + module->crc_length < buf_size &&
 		module->crc16 != flirt_crc16(b + 32, module->crc_length)) {
@@ -382,7 +383,6 @@ static int module_match_buffer(RzAnalysis *analysis, const RzFlirtModule *module
 
 		next_module_function = rz_analysis_get_function_at((RzAnalysis *)analysis, address + flirt_func->offset);
 		if (next_module_function) {
-			char *name;
 			ut32 next_module_function_size;
 
 			// get function size from flirt signature
@@ -421,27 +421,22 @@ static int module_match_buffer(RzAnalysis *analysis, const RzFlirtModule *module
 				rz_analysis_trim_jmprefs((RzAnalysis *)analysis, next_module_function);
 			}
 
-			// remove old name from map
-			ht_pp_delete(analysis->ht_name_fun, next_module_function->name);
-
-			name = rz_name_filter2(flirt_func->name, true);
-			free(next_module_function->name);
-			next_module_function->name = rz_str_newf("flirt.%s", name);
+			// filter name
+			rz_name_filter(flirt_func->name, -1, true);
 
 			// verify that the name is unique
-			while (ht_pp_find(analysis->ht_name_fun, next_module_function->name, NULL)) {
+			rz_strf(name, "flirt.%s", flirt_func->name);
+			while (!rz_analysis_function_rename(next_module_function, name)) {
 				name_index++;
-				free(next_module_function->name);
-				next_module_function->name = rz_str_newf("flirt.%s_%u", name, name_index);
+				rz_strf(name, "flirt.%s_%u", flirt_func->name, name_index);
 			}
 
-			// insert new name into the map
-			ht_pp_insert(analysis->ht_name_fun, next_module_function->name, next_module_function);
-
-			analysis->flb.set(analysis->flb.f, next_module_function->name,
-				next_module_function->addr, next_module_function_size);
+			RzFlagItem *fit = analysis->flb.get_at_by_spaces(analysis->flb.f, next_module_function->addr, "fcn.", "func.", NULL);
+			if (fit) {
+				analysis->flb.unset(analysis->flb.f, fit);
+			}
+			analysis->flb.set(analysis->flb.f, name, next_module_function->addr, next_module_function_size);
 			RZ_LOG_DEBUG("FLIRT: Found %s\n", next_module_function->name);
-			free(name);
 		}
 	}
 	return true;

--- a/librz/signature/flirt.c
+++ b/librz/signature/flirt.c
@@ -433,12 +433,9 @@ static int module_match_buffer(RzAnalysis *analysis, const RzFlirtModule *module
 
 			RzFlagItem *fit = analysis->flb.get_at_by_spaces(analysis->flb.f, next_module_function->addr, "fcn.", "func.", NULL);
 			if (fit) {
-				// rename old fcn.xxxx to flirt.yyyyy
-				analysis->flb.rename(analysis->flb.f, fit, name);
-			} else {
-				// best effort, add flag..
-				analysis->flb.set(analysis->flb.f, name, next_module_function->addr, next_module_function_size);
+				analysis->flb.unset(analysis->flb.f, fit);
 			}
+			analysis->flb.set(analysis->flb.f, name, next_module_function->addr, next_module_function_size);
 			RZ_LOG_DEBUG("FLIRT: Found %s\n", next_module_function->name);
 		}
 	}

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -688,11 +688,36 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=aa ; zfs libc-v7.sig
+NAME=aa ; zfs libc-v7.sig ; no old flag 
 FILE=bins/elf/analysis/pid_stripped
-CMDS=aa ; zfs bins/other/sigs/libc-v7.sig
+CMDS=aa ; zfs bins/other/sigs/libc-v7.sig ; pd 10 @ flirt.libc_start_main
 EXPECT=<<EOF
 Found 1 FLIRT signatures via bins/other/sigs/libc-v7.sig
+            ; CALL XREF from entry0 @ 0x401384
+/ flirt.libc_start_main (int64_t arg1, int64_t arg2, int64_t arg3, int64_t arg4, int64_t arg5, int64_t arg6, int64_t arg_c0h);
+|           ; var int64_t var_ch @ rsp+0xc
+|           ; var int64_t var_10h @ rsp+0x10
+|           ; var int64_t var_18h @ rsp+0x18
+|           ; var int64_t var_20h @ rsp+0x20
+|           ; var int64_t var_68h @ rsp+0x68
+|           ; var int64_t var_70h @ rsp+0x70
+|           ; arg int64_t arg_c0h @ rsp+0xc0
+|           ; arg int64_t arg1 @ rdi
+|           ; arg int64_t arg2 @ rsi
+|           ; arg int64_t arg3 @ rdx
+|           ; arg int64_t arg4 @ rcx
+|           ; arg int64_t arg5 @ r8
+|           ; arg int64_t arg6 @ r9
+|           0x004e2420      push  r14
+|           0x004e2422      push  r13
+|           0x004e2424      mov   eax, 0
+|           0x004e2429      push  r12
+|           0x004e242b      push  rbp
+|           0x004e242c      mov   r12, r8                              ; arg5
+|           0x004e242f      push  rbx
+|           0x004e2430      mov   rbp, rcx                             ; arg4
+|           0x004e2433      mov   r13, r9                              ; arg6
+|           0x004e2436      sub   rsp, 0x90
 EOF
 RUN
 
@@ -715,7 +740,7 @@ FILE=bins/elf/analysis/pid_stripped
 CMDS=s 0x4e2420 ; af ; s 0x4e25c7 ; af ; zfs bins/other/sigs/libc-v7.sig ; afl ~4e2420
 EXPECT=<<EOF
 Found 1 FLIRT signatures via bins/other/sigs/libc-v7.sig
-0x004e2420   40 664          flirt.__libc_start_main
+0x004e2420   40 664          flirt.libc_start_main
 EOF
 RUN
 
@@ -731,7 +756,7 @@ afl~4e2420
 EOF
 EXPECT=<<EOF
 Found 1 FLIRT signatures via bins/other/sigs/libc-v7.sig
-0x004e2420   40 664          flirt.__libc_start_main
+0x004e2420   40 664          flirt.libc_start_main
 EOF
 RUN
 
@@ -762,7 +787,7 @@ FILE=bins/elf/analysis/pid_stripped
 CMDS=s 0x4e2420 ; af ; s 0x4e25c7 ; af ; zfs bins/other/sigs/libc-v10.sig ; afl ~4e2420
 EXPECT=<<EOF
 Found 1 FLIRT signatures via bins/other/sigs/libc-v10.sig
-0x004e2420   40 664          flirt.__libc_start_main
+0x004e2420   40 664          flirt.libc_start_main
 EOF
 RUN
 
@@ -778,7 +803,7 @@ afl~4e2420
 EOF
 EXPECT=<<EOF
 Found 1 FLIRT signatures via bins/other/sigs/libc-v10.sig
-0x004e2420   40 664          flirt.__libc_start_main
+0x004e2420   40 664          flirt.libc_start_main
 EOF
 RUN
 
@@ -790,252 +815,252 @@ zfs bins/other/sigs/libc6_2.27-3ubuntu1_amd64.sig~silence
 fl @F:flirt
 EOF
 EXPECT=<<EOF
-0x004004d1 86 flirt.__malloc_assert.constprop.13
-0x00400527 35 flirt.__gconv_release_step.part.1
+0x004004d1 86 flirt.malloc_assert.constprop.13
+0x00400527 35 flirt.gconv_release_step.part.1
 0x0040054a 79 flirt.length_mismatch
 0x00400b70 613 flirt.get_common_indeces.constprop.1
-0x00400de0 1657 flirt.__libc_start_main
-0x00401460 385 flirt.__libc_check_standard_fds
-0x004015f0 581 flirt.__libc_setup_tls
-0x00401930 339 flirt.__assert_fail_base
-0x00401a90 80 flirt.__assert_fail
-0x00401ae0 7517 flirt.__dcgettext
-0x00403840 672 flirt._nl_find_domain
-0x00403ae0 5366 flirt._nl_load_domain
-0x004054e0 601 flirt.__cxa_finalize
-0x004056b0 1488 flirt._nl_make_l10nflist
-0x00405c80 286 flirt._nl_normalize_codeset
-0x00405da0 574 flirt._nl_explode_name
-0x00405fe0 28945 flirt.__gettext_free_exp
-0x0040d100 2128 flirt.__gettextparse
-0x0040d950 256 flirt.__gettext_extract_plural
-0x0040da50 60 flirt.__hash_string
-0x0040da90 7 flirt.__umount
+0x00400de0 1657 flirt.libc_start_main
+0x00401460 385 flirt.libc_check_standard_fds
+0x004015f0 581 flirt.libc_setup_tls
+0x00401930 339 flirt.assert_fail_base
+0x00401a90 80 flirt.assert_fail
+0x00401ae0 7517 flirt.dcgettext
+0x00403840 672 flirt.nl_find_domain
+0x00403ae0 5366 flirt.nl_load_domain
+0x004054e0 601 flirt.cxa_finalize
+0x004056b0 1488 flirt.nl_make_l10nflist
+0x00405c80 286 flirt.nl_normalize_codeset
+0x00405da0 574 flirt.nl_explode_name
+0x00405fe0 28945 flirt.gettext_free_exp
+0x0040d100 2128 flirt.gettextparse
+0x0040d950 256 flirt.gettext_extract_plural
+0x0040da50 60 flirt.hash_string
+0x0040da90 7 flirt.umount
 0x0040dbb0 561 flirt.abort
 0x0040ddf0 1092 flirt.msort_with_tmp.part.0
 0x0040e6c0 1160 flirt.qsort
 0x0040e6d0 212 flirt.getenv
-0x0040e7b0 636 flirt.__run_exit_handlers
+0x0040e7b0 636 flirt.run_exit_handlers
 0x0040ea30 32 flirt.exit
-0x0040ea50 288 flirt.__new_exitfn
-0x0040ec70 250 flirt.__cxa_atexit
-0x0040f430 542 flirt.__correctly_grouped_prefixmb
-0x0040f650 192 flirt.___asprintf
+0x0040ea50 288 flirt.new_exitfn
+0x0040ec70 250 flirt.cxa_atexit
+0x0040f430 542 flirt.correctly_grouped_prefixmb
+0x0040f650 192 flirt.asprintf
 0x0040f710 368 flirt.locked_vfxprintf
-0x0040f880 784 flirt.__fxprintf
-0x0040fe20 33103 flirt._IO_fflush
-0x00410210 429 flirt._IO_puts
+0x0040f880 784 flirt.fxprintf
+0x0040fe20 33103 flirt.IO_fflush
+0x00410210 429 flirt.IO_puts
 0x00410410 1898 flirt.adjust_wide_data
-0x004115d0 1182 flirt._IO_wdo_write
-0x00411f00 400 flirt._IO_vasprintf
-0x00412090 374 flirt.__libc_message.constprop.0
-0x00412210 743 flirt.__libc_message
-0x00412500 32 flirt.__libc_fatal
-0x00412520 32 flirt._IO_vtable_check
-0x00412540 164 flirt.__fgets_unlocked
+0x004115d0 1182 flirt.IO_wdo_write
+0x00411f00 400 flirt.IO_vasprintf
+0x00412090 374 flirt.libc_message.constprop.0
+0x00412210 743 flirt.libc_message
+0x00412500 32 flirt.libc_fatal
+0x00412520 32 flirt.IO_vtable_check
+0x00412540 164 flirt.fgets_unlocked
 0x00415430 461 flirt.save_for_backup
-0x00415b80 720 flirt._IO_un_link
-0x00415e50 661 flirt._IO_link_in
-0x004160f0 43 flirt._IO_switch_to_main_get_area
-0x00416150 151 flirt._IO_switch_to_get_mode
-0x004161f0 74 flirt._IO_free_backup_area
-0x00416240 112 flirt.__overflow
-0x004162b0 490 flirt.__underflow
-0x004164a0 514 flirt.__uflow
-0x004166b0 93 flirt._IO_setb
-0x00416710 175 flirt._IO_doallocbuf
-0x00416830 258 flirt._IO_default_xsputn
-0x00416c30 292 flirt._IO_default_setbuf
-0x004170c0 327 flirt._IO_no_init
-0x00417550 127 flirt._IO_sputbackc
-0x00417650 64 flirt._IO_adjust_column
-0x00418090 106 flirt._IO_unsave_markers
-0x004234b0 65 flirt.__strdup
-0x0042b6b0 1022 flirt.__memcmp_sse2
+0x00415b80 720 flirt.IO_un_link
+0x00415e50 661 flirt.IO_link_in
+0x004160f0 43 flirt.IO_switch_to_main_get_area
+0x00416150 151 flirt.IO_switch_to_get_mode
+0x004161f0 74 flirt.IO_free_backup_area
+0x00416240 112 flirt.overflow
+0x004162b0 490 flirt.underflow
+0x004164a0 514 flirt.uflow
+0x004166b0 93 flirt.IO_setb
+0x00416710 175 flirt.IO_doallocbuf
+0x00416830 258 flirt.IO_default_xsputn
+0x00416c30 292 flirt.IO_default_setbuf
+0x004170c0 327 flirt.IO_no_init
+0x00417550 127 flirt.IO_sputbackc
+0x00417650 64 flirt.IO_adjust_column
+0x00418090 106 flirt.IO_unsave_markers
+0x004234b0 65 flirt.strdup
+0x0042b6b0 1022 flirt.memcmp_sse2
 0x00447cf0 1568 flirt.handle_amd
-0x00448310 37 flirt.__cache_sysconf
-0x00448380 9 flirt.__wmemcpy
-0x004491d0 80 flirt.__get_child_max
-0x004492c0 288 flirt.__libc_open64
-0x004493e0 160 flirt.__open64_nocancel
-0x00449480 153 flirt.__libc_read
-0x00449520 36 flirt.__read_nocancel
-0x00449550 153 flirt.__libc_write
-0x004495f0 44 flirt.__write_nocancel
-0x00449650 464 flirt.__libc_fcntl
-0x00449820 125 flirt.__close
-0x004498a0 42 flirt.__close_nocancel
-0x004498d0 1811 flirt.__getcwd
-0x0044a030 142 flirt.__sbrk
-0x0044a0c0 64 flirt.__getpagesize
-0x0044a100 80 flirt.__getdtablesize
+0x00448310 37 flirt.cache_sysconf
+0x00448380 9 flirt.wmemcpy
+0x004491d0 80 flirt.get_child_max
+0x004492c0 288 flirt.libc_open64
+0x004493e0 160 flirt.open64_nocancel
+0x00449480 153 flirt.libc_read
+0x00449520 36 flirt.read_nocancel
+0x00449550 153 flirt.libc_write
+0x004495f0 44 flirt.write_nocancel
+0x00449650 464 flirt.libc_fcntl
+0x00449820 125 flirt.close
+0x004498a0 42 flirt.close_nocancel
+0x004498d0 1811 flirt.getcwd
+0x0044a030 142 flirt.sbrk
+0x0044a0c0 64 flirt.getpagesize
+0x0044a100 80 flirt.getdtablesize
 0x0044a2c0 327 flirt.trecurse
-0x0044a410 982 flirt.__tsearch
-0x0044a7f0 87 flirt.__tfind
-0x0044ae00 175 flirt.__twalk
-0x0044aeb0 435 flirt.__tdestroy
+0x0044a410 982 flirt.tsearch
+0x0044a7f0 87 flirt.tfind
+0x0044ae00 175 flirt.twalk
+0x0044aeb0 435 flirt.tdestroy
 0x0044b070 432 flirt.next_line
-0x0044b220 1168 flirt.__get_nprocs
-0x0044b6b0 224 flirt.__get_nprocs_conf
-0x0044b790 144 flirt.__get_phys_pages
-0x0044b820 144 flirt.__get_avphys_pages
-0x0044b8b0 17 flirt.__getclktck
-0x0044b8d0 82 flirt.__init_misc
-0x0044b990 64 flirt.__libc_alloca_cutoff
-0x0044b9d0 40 flirt.__lll_lock_wait_private
-0x0044ba00 28 flirt.__lll_unlock_wake_private
-0x0044ba20 86 flirt.__libc_enable_asynccancel
-0x0044ba80 89 flirt.__libc_disable_asynccancel
-0x0044baf0 32 flirt.__stack_chk_fail
-0x0044bb10 97 flirt.__fortify_fail_abort
-0x0044bb80 32 flirt.__fortify_fail
-0x0044bc30 114 flirt.__tunable_set_val
-0x0044bcb0 1533 flirt.__tunables_init
-0x0044c2b0 90 flirt.__tunable_get_val
-0x0044c310 1038 flirt._dl_aux_init
-0x0044c720 2296 flirt._dl_non_dynamic_init
-0x0044d020 69 flirt.__libc_init_secure
-0x0044de00 1296 flirt.__gconv_open
-0x0044e310 528 flirt.__gconv
-0x0044e520 89 flirt.__gconv_close
+0x0044b220 1168 flirt.get_nprocs
+0x0044b6b0 224 flirt.get_nprocs_conf
+0x0044b790 144 flirt.get_phys_pages
+0x0044b820 144 flirt.get_avphys_pages
+0x0044b8b0 17 flirt.getclktck
+0x0044b8d0 82 flirt.init_misc
+0x0044b990 64 flirt.libc_alloca_cutoff
+0x0044b9d0 40 flirt.lll_lock_wait_private
+0x0044ba00 28 flirt.lll_unlock_wake_private
+0x0044ba20 86 flirt.libc_enable_asynccancel
+0x0044ba80 89 flirt.libc_disable_asynccancel
+0x0044baf0 32 flirt.stack_chk_fail
+0x0044bb10 97 flirt.fortify_fail_abort
+0x0044bb80 32 flirt.fortify_fail
+0x0044bc30 114 flirt.tunable_set_val
+0x0044bcb0 1533 flirt.tunables_init
+0x0044c2b0 90 flirt.tunable_get_val
+0x0044c310 1038 flirt.dl_aux_init
+0x0044c720 2296 flirt.dl_non_dynamic_init
+0x0044d020 69 flirt.libc_init_secure
+0x0044de00 1296 flirt.gconv_open
+0x0044e310 528 flirt.gconv
+0x0044e520 89 flirt.gconv_close
 0x0044f6c0 1168 flirt.insert_module
-0x0044fb50 1008 flirt.__gconv_get_path
-0x0044ff40 1504 flirt.__gconv_read_conf
-0x00450520 602 flirt.__gconv_get_builtin_trans
+0x0044fb50 1008 flirt.gconv_get_path
+0x0044ff40 1504 flirt.gconv_read_conf
+0x00450520 602 flirt.gconv_get_builtin_trans
 0x00458320 18 flirt.release_libc_mem
 0x004585d0 692 flirt.new_composite_name
-0x00459170 2074 flirt._nl_find_locale
-0x00459990 576 flirt._nl_intern_locale_data
-0x00459bd0 1488 flirt._nl_load_locale
-0x0045a1a0 94 flirt._nl_unload_locale
-0x0045a200 1312 flirt._nl_load_locale_from_archive
-0x0045a870 80 flirt.__setfpucw
-0x0045a8c0 132 flirt.__sigsetjmp
-0x0045abc0 6232 flirt._quicksort
-0x0045c620 19 flirt.__libc_secure_getenv
+0x00459170 2074 flirt.nl_find_locale
+0x00459990 576 flirt.nl_intern_locale_data
+0x00459bd0 1488 flirt.nl_load_locale
+0x0045a1a0 94 flirt.nl_unload_locale
+0x0045a200 1312 flirt.nl_load_locale_from_archive
+0x0045a870 80 flirt.setfpucw
+0x0045a8c0 132 flirt.sigsetjmp
+0x0045abc0 6232 flirt.quicksort
+0x0045c620 19 flirt.libc_secure_getenv
 0x0045ce30 10704 flirt.group_number
-0x0045f800 13172 flirt._IO_vfprintf_internal
+0x0045f800 13172 flirt.IO_vfprintf_internal
 0x00462b80 976 flirt.hack_digit
-0x00465a50 11033 flirt.___printf_fp
-0x00468470 192 flirt.___asprintf_1
-0x00468530 11072 flirt._i18n_number_rewrite
-0x0046b070 13435 flirt._IO_vfwprintf
-0x0046e540 1929 flirt.__parse_one_specmb
-0x0046ecd0 2211 flirt.__parse_one_specwc
-0x0046f6d0 314 flirt._IO_fputs
-0x0046f8e0 413 flirt._IO_fwrite
-0x0046fae0 727 flirt._IO_getdelim
-0x0046fe10 349 flirt._IO_getline
-0x004700f0 320 flirt._IO_padn
-0x00470230 320 flirt._IO_wpadn
+0x00465a50 11033 flirt.printf_fp
+0x00468470 192 flirt.asprintf_1
+0x00468530 11072 flirt.i18n_number_rewrite
+0x0046b070 13435 flirt.IO_vfwprintf
+0x0046e540 1929 flirt.parse_one_specmb
+0x0046ecd0 2211 flirt.parse_one_specwc
+0x0046f6d0 314 flirt.IO_fputs
+0x0046f8e0 413 flirt.IO_fwrite
+0x0046fae0 727 flirt.IO_getdelim
+0x0046fe10 349 flirt.IO_getline
+0x004700f0 320 flirt.IO_padn
+0x00470230 320 flirt.IO_wpadn
 0x00470370 637 flirt.save_for_wbackup.isra.0
-0x004706b0 109 flirt._IO_wsetb
-0x004709d0 117 flirt.__woverflow
-0x00470e40 685 flirt._IO_wdefault_xsputn
-0x00471530 155 flirt._IO_wdoallocbuf
-0x00471640 114 flirt._IO_switch_to_wget_mode
-0x004716c0 99 flirt._IO_free_wbackup_area
-0x004720c0 165 flirt.__libc_scratch_buffer_grow_preserve
-0x00472170 184 flirt.__libc_scratch_buffer_set_array_size
-0x00472230 73 flirt.__strndup
-0x00472280 451 flirt.__strerror_r
-0x00472480 102 flirt.__strtok_r
-0x00472cc0 218 flirt.__argz_create_sep
-0x00472da0 183 flirt.__argz_add_sep
-0x00473890 9 flirt.__wmemcpy_2
-0x004738a0 9 flirt.__wmemcpy_1
-0x00473ab0 480 flirt.__wcrtomb
-0x00473c90 806 flirt.__wcsrtombs
-0x00473fc0 32 flirt.__wcschrnul
+0x004706b0 109 flirt.IO_wsetb
+0x004709d0 117 flirt.woverflow
+0x00470e40 685 flirt.IO_wdefault_xsputn
+0x00471530 155 flirt.IO_wdoallocbuf
+0x00471640 114 flirt.IO_switch_to_wget_mode
+0x004716c0 99 flirt.IO_free_wbackup_area
+0x004720c0 165 flirt.libc_scratch_buffer_grow_preserve
+0x00472170 184 flirt.libc_scratch_buffer_set_array_size
+0x00472230 73 flirt.strndup
+0x00472280 451 flirt.strerror_r
+0x00472480 102 flirt.strtok_r
+0x00472cc0 218 flirt.argz_create_sep
+0x00472da0 183 flirt.argz_add_sep
+0x00473890 9 flirt.wmemcpy_2
+0x004738a0 9 flirt.wmemcpy_1
+0x00473ab0 480 flirt.wcrtomb
+0x00473c90 806 flirt.wcsrtombs
+0x00473fc0 32 flirt.wcschrnul
 0x00474a40 8 flirt.time
-0x00474f90 139 flirt.__rewinddir
-0x00475020 141 flirt.__getdents
-0x004750b0 192 flirt.__fdopendir
-0x004751a0 8 flirt.__getuid
-0x004751b0 8 flirt.__geteuid
-0x004751c0 8 flirt.__getgid
-0x004751d0 8 flirt.__getegid
-0x00475450 256 flirt.__isatty
-0x00475640 63 flirt.__towctrans
-0x00475680 496 flirt.__readonly_area
+0x00474f90 139 flirt.rewinddir
+0x00475020 141 flirt.getdents
+0x004750b0 192 flirt.fdopendir
+0x004751a0 8 flirt.getuid
+0x004751b0 8 flirt.geteuid
+0x004751c0 8 flirt.getgid
+0x004751d0 8 flirt.getegid
+0x00475450 256 flirt.isatty
+0x00475640 63 flirt.towctrans
+0x00475680 496 flirt.readonly_area
 0x00475870 8192 flirt.is_trusted_path_normalize
-0x00477870 686 flirt._dl_dst_count
-0x00477b20 2717 flirt._dl_dst_substitute
-0x004785c0 735 flirt._dl_init_paths
-0x004788a0 4202 flirt._dl_map_object
+0x00477870 686 flirt.dl_dst_count
+0x00477b20 2717 flirt.dl_dst_substitute
+0x004785c0 735 flirt.dl_init_paths
+0x004788a0 4202 flirt.dl_map_object
 0x00479910 3696 flirt.do_lookup_x
-0x0047a780 2747 flirt._dl_lookup_symbol_x
-0x0047b240 176 flirt._dl_setup_hash
-0x0047b2f0 181 flirt._dl_add_to_namespace_list
-0x0047b3b0 783 flirt._dl_new_object
-0x0047d260 2000 flirt._dl_important_hwcaps
-0x0047da30 1446 flirt._dl_debug_vdprintf
-0x0047dfe0 138 flirt._dl_sysdep_read_whole_file
-0x0047e070 162 flirt._dl_debug_printf
-0x0047e120 162 flirt._dl_debug_printf_c
-0x0047e1d0 148 flirt._dl_dprintf
-0x0047e270 102 flirt._dl_name_match_p
-0x0047e2e0 117 flirt._dl_higher_prime_number
-0x0047e360 340 flirt._dl_strtoul
-0x0047eed0 354 flirt._dl_next_tls_modid
-0x0047f060 202 flirt._dl_allocate_tls_storage
-0x0047f540 128 flirt._dl_tls_get_addr_soft
-0x0047f5c0 240 flirt._dl_add_to_slotinfo
-0x0047f6b0 416 flirt._dl_get_origin
-0x0047f850 197 flirt._dl_scope_free
+0x0047a780 2747 flirt.dl_lookup_symbol_x
+0x0047b240 176 flirt.dl_setup_hash
+0x0047b2f0 181 flirt.dl_add_to_namespace_list
+0x0047b3b0 783 flirt.dl_new_object
+0x0047d260 2000 flirt.dl_important_hwcaps
+0x0047da30 1446 flirt.dl_debug_vdprintf
+0x0047dfe0 138 flirt.dl_sysdep_read_whole_file
+0x0047e070 162 flirt.dl_debug_printf
+0x0047e120 162 flirt.dl_debug_printf_c
+0x0047e1d0 148 flirt.dl_dprintf
+0x0047e270 102 flirt.dl_name_match_p
+0x0047e2e0 117 flirt.dl_higher_prime_number
+0x0047e360 340 flirt.dl_strtoul
+0x0047eed0 354 flirt.dl_next_tls_modid
+0x0047f060 202 flirt.dl_allocate_tls_storage
+0x0047f540 128 flirt.dl_tls_get_addr_soft
+0x0047f5c0 240 flirt.dl_add_to_slotinfo
+0x0047f6b0 416 flirt.dl_get_origin
+0x0047f850 197 flirt.dl_scope_free
 0x00480690 48 flirt.length_mismatch_1
-0x004806c0 210 flirt._dl_exception_create
-0x004807a0 729 flirt._dl_exception_create_format
-0x00480a80 38 flirt._dl_exception_free
-0x00480ab0 236 flirt._dl_cache_libcmp
-0x00480ba0 2862 flirt._dl_load_cache_lookup
-0x004816d0 56 flirt._dl_unload_cache
+0x004806c0 210 flirt.dl_exception_create
+0x004807a0 729 flirt.dl_exception_create_format
+0x00480a80 38 flirt.dl_exception_free
+0x00480ab0 236 flirt.dl_cache_libcmp
+0x00480ba0 2862 flirt.dl_load_cache_lookup
+0x004816d0 56 flirt.dl_unload_cache
 0x00482060 195 flirt.fatal_error
-0x00482130 80 flirt._dl_signal_exception
-0x00482180 80 flirt._dl_signal_error
-0x004821d0 208 flirt._dl_catch_exception
-0x004822a0 112 flirt._dl_catch_error
-0x00482310 162 flirt.____longjmp_chk
-0x00482370 59 flirt.__mpn_cmp
-0x004823b0 1466 flirt.__mpn_divrem
-0x00482970 259 flirt.__mpn_lshift
-0x00482a80 259 flirt.__mpn_rshift
-0x00482b90 1072 flirt.__mpn_mul
-0x00482fc0 281 flirt.__mpn_mul_1
-0x004830e0 438 flirt.__mpn_impn_mul_n_basecase
-0x004832a0 1378 flirt.__mpn_impn_mul_n
-0x00483810 431 flirt.__mpn_impn_sqr_n_basecase
-0x004839c0 1262 flirt.__mpn_impn_sqr_n
-0x00483f50 173 flirt.__mpn_sub_n_1
-0x00484000 235 flirt.__mpn_addmul_1
-0x004840f0 144 flirt.__mpn_extract_double
-0x00484180 185 flirt.__mpn_extract_long_double
-0x00484240 286 flirt.__mpn_extract_float128
-0x00484360 203 flirt._itoa_word
+0x00482130 80 flirt.dl_signal_exception
+0x00482180 80 flirt.dl_signal_error
+0x004821d0 208 flirt.dl_catch_exception
+0x004822a0 112 flirt.dl_catch_error
+0x00482310 162 flirt.longjmp_chk
+0x00482370 59 flirt.mpn_cmp
+0x004823b0 1466 flirt.mpn_divrem
+0x00482970 259 flirt.mpn_lshift
+0x00482a80 259 flirt.mpn_rshift
+0x00482b90 1072 flirt.mpn_mul
+0x00482fc0 281 flirt.mpn_mul_1
+0x004830e0 438 flirt.mpn_impn_mul_n_basecase
+0x004832a0 1378 flirt.mpn_impn_mul_n
+0x00483810 431 flirt.mpn_impn_sqr_n_basecase
+0x004839c0 1262 flirt.mpn_impn_sqr_n
+0x00483f50 173 flirt.mpn_sub_n_1
+0x00484000 235 flirt.mpn_addmul_1
+0x004840f0 144 flirt.mpn_extract_double
+0x00484180 185 flirt.mpn_extract_long_double
+0x00484240 286 flirt.mpn_extract_float128
+0x00484360 203 flirt.itoa_word
 0x00484c90 138 flirt.strerror
-0x00484d40 77 flirt.__strsep
-0x00484f50 8 flirt.__getpid
-0x00485160 416 flirt._dl_fixup
-0x00485300 544 flirt._dl_profile_fixup
-0x00485520 2 flirt._dl_call_pltexit
+0x00484d40 77 flirt.strsep
+0x00484f50 8 flirt.getpid
+0x00485160 416 flirt.dl_fixup
+0x00485300 544 flirt.dl_profile_fixup
+0x00485520 2 flirt.dl_call_pltexit
 0x00485530 652 flirt.add_to_global
-0x004857c0 144 flirt._dl_find_dso_for_object
-0x00485850 528 flirt._dl_open
-0x00485a60 298 flirt._dl_show_scope
+0x004857c0 144 flirt.dl_find_dso_for_object
+0x00485850 528 flirt.dl_open
+0x00485a60 298 flirt.dl_show_scope
 0x004863b0 4000 flirt.remove_slotinfo
-0x00487350 121 flirt._dl_close_worker
-0x004874d0 751 flirt._dl_sort_maps
-0x004877c0 416 flirt._dl_tlsdesc_resolve_rela_fixup
-0x00487960 101 flirt._dl_tlsdesc_resolve_hold_fixup
-0x004879d0 25 flirt._dl_unmap
-0x00487cf0 83 flirt._dl_addr_inside_object
-0x00487d50 173 flirt.__mpn_sub_n
-0x00487e00 235 flirt.__mpn_addmul_1_1
-0x004895d0 877 flirt._dl_init
-0x00489940 1806 flirt._dl_check_map_versions
-0x0048fa10 478 flirt.__dl_iterate_phdr
-0x0048fbf0 73 flirt._nl_finddomain_subfreeres
-0x0048fc40 247 flirt._nl_unload_domain
+0x00487350 121 flirt.dl_close_worker
+0x004874d0 751 flirt.dl_sort_maps
+0x004877c0 416 flirt.dl_tlsdesc_resolve_rela_fixup
+0x00487960 101 flirt.dl_tlsdesc_resolve_hold_fixup
+0x004879d0 25 flirt.dl_unmap
+0x00487cf0 83 flirt.dl_addr_inside_object
+0x00487d50 173 flirt.mpn_sub_n
+0x00487e00 235 flirt.mpn_addmul_1_1
+0x004895d0 877 flirt.dl_init
+0x00489940 1806 flirt.dl_check_map_versions
+0x0048fa10 478 flirt.dl_iterate_phdr
+0x0048fbf0 73 flirt.nl_finddomain_subfreeres
+0x0048fc40 247 flirt.nl_unload_domain
 0x00490bb0 218 flirt.free_slotinfo
 EOF
 RUN
@@ -1819,7 +1844,7 @@ aaa
 zfs bins/flirt/elf-x86/libcurl.a.sig
 EOF
 EXPECT=<<EOF
-Found 206 FLIRT signatures via bins/flirt/elf-x86/libcurl.a.sig
+Found 205 FLIRT signatures via bins/flirt/elf-x86/libcurl.a.sig
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

resolves a small bug on how to rename a function and also removes the old flags `fcn.xxxxxx` and replace them with `flirt.zzzzzzz`.

### Old output

```
            ; CALL XREF from entry0 @ 0x401384
            ;-- fcn.004e2420:
┌ flirt.__libc_start_main (int64_t arg1, int64_t arg2, int64_t arg3, int64_t arg4, int64_t arg5, int64_t arg6, int64_t arg_c0h);
│ bp: 0 (vars 0, args 0)
│ sp: 7 (vars 6, args 1)
│ rg: 6 (vars 0, args 6)
│           0x004e2420      push  r14
│           0x004e2422      push  r13
│           0x004e2424      mov   eax, 0
```

### New output

```
            ; CALL XREF from entry0 @ 0x401384
┌ flirt.libc_start_main (int64_t arg1, int64_t arg2, int64_t arg3, int64_t arg4, int64_t arg5, int64_t arg6, int64_t arg_c0h);
│ bp: 0 (vars 0, args 0)
│ sp: 7 (vars 6, args 1)
│ rg: 6 (vars 0, args 6)
│           0x004e2420      push  r14
│           0x004e2422      push  r13
│           0x004e2424      mov   eax, 0
```
