### PR TITLE
Fix #2288: Clear `ds->opstr` on pdf '`..`'

### DIFF
--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -5428,6 +5428,7 @@ toro:
 					}
 				}
 				rz_analysis_op_fini(&ds->analysis_op);
+				RZ_FREE(ds->opstr);
 				if (!sparse) {
 					rz_cons_printf("..\n");
 					sparse = true;

--- a/test/db/cmd/cmd_af
+++ b/test/db/cmd/cmd_af
@@ -148,7 +148,7 @@ EXPECT=<<EOF
 |      ||   0x08048442      leave
 |      ||   0x08048443      ret
 ..
-\      ``-> 0x08048448      lea     esi, [esi]
+\      ``-> 0x08048448      ret
 EOF
 RUN
 

--- a/test/db/cmd/cmd_pd2
+++ b/test/db/cmd/cmd_pd2
@@ -908,7 +908,7 @@ EXPECT=<<EOF
 |       ,=< 0x0000104b      7403           je    0x1050
 |      @=-> 0x0000104d      ebfe           jmp   0x104d
 ..
-|       `-> 0x00001050      31c0           nop
+|       `-> 0x00001050      31c0           xor   eax, eax
 \           0x00001052      c3             ret
 EOF
 RUN

--- a/test/db/cmd/cmd_pd2
+++ b/test/db/cmd/cmd_pd2
@@ -890,3 +890,25 @@ EXPECT=<<EOF
 |       `=< 0x004014a3      jmp   0x401322
 EOF
 RUN
+
+NAME=pdf '..' fix (#2288)
+FILE=bins/elf/infinite-loop.bf
+CMDS=<<EOF
+e asm.bytes=1
+s main
+aF
+pdf
+EOF
+EXPECT=<<EOF
+            ;-- section..text:
+            ;-- .text:
+/ int main (int argc, char **argv, char **envp);
+|           0x00001040      f30f1efa       endbr64                     ; [14] -r-x section size 389 named .text
+|           0x00001044      8005f52f0000.  add   byte [obj.array], 1   ; [0x4040:1]=0
+|       ,=< 0x0000104b      7403           je    0x1050
+|      @=-> 0x0000104d      ebfe           jmp   0x104d
+..
+|       `-> 0x00001050      31c0           nop
+\           0x00001052      c3             ret
+EOF
+RUN

--- a/test/db/cmd/cmd_pd2
+++ b/test/db/cmd/cmd_pd2
@@ -111,15 +111,15 @@ EXPECT=<<EOF
 |       :   0x00560e67      push  esi
 |      ,==< 0x00560e68      jmp   0x560e7d
 ..
-|      `--> 0x00560e7d      push         ecx
+|      `--> 0x00560e7d      pop   esi
 |       :   0x00560e7e      push  eax
 |       :   0x00560e7f      push  edx
 |      ,==< 0x00560e80      jmp   0x560e96
 ..
-|     |`--> 0x00560e96      mov                   ebx, 0x4fd160dd
+|     |`--> 0x00560e96      rdtsc
 |     | :   0x00560e98      jmp   0x560eb1
 ..
-|     ||:   0x00560eb1      test           al, 0x36
+|     ||:   0x00560eb1      pop   edx
 |     ||:   0x00560eb2      pop   eax
 |     ||:   0x00560eb3      pushfd
 |     ||:   0x00560eb4      push  eax
@@ -238,18 +238,18 @@ EXPECT=<<EOF
 |       :   0x00560e67      56             push  esi
 |      ,==< 0x00560e68      e904000000     jmp   0x560e71
 ..
-|      `--> 0x00560e71      90             push     ecx
+|      `--> 0x00560e71      90             nop
 |       :   0x00560e72      eb09           jmp   0x560e7d
 ..
-|       :   0x00560e7d      5e             add         eax, 0xd4d43b06
+|       :   0x00560e7d      5e             pop   esi
 |       :   0x00560e7e      50             push  eax
 |       :   0x00560e7f      52             push  edx
 |      ,==< 0x00560e80      e911000000     jmp   0x560e96
 ..
-|     |`--> 0x00560e96      0f31           mov                   ebx, 0x4fd160dd
+|     |`--> 0x00560e96      0f31           rdtsc
 |     | :   0x00560e98      e914000000     jmp   0x560eb1
 ..
-|     ||:   0x00560eb1      5a             test           al, 0x36
+|     ||:   0x00560eb1      5a             pop   edx
 \     ||`=< 0x00560eb2      e940c5edff     jmp   0x43d3f7
 
 / fcn.00560e67 ();

--- a/test/db/formats/elf/reloc
+++ b/test/db/formats/elf/reloc
@@ -351,7 +351,7 @@ EXPECT=<<EOF
 |           ;-- case 12:                                               ; from 0x800005e
 |           ;-- case 26:                                               ; from 0x800005e
 |           ;-- case 33:                                               ; from 0x800005e
-|           0x08000068      nop     dword [rax + rax]                  ; arg1
+|           0x08000068      mov   rsi, rdi                             ; arg1
 |           0x0800006b      mov   edi, 1
 |       ,=< 0x08000070      jmp   reloc.target.getPageLengthNV         ; RELOC 32 getPageLengthNV
 ..
@@ -359,25 +359,25 @@ EXPECT=<<EOF
 |       |   ;-- case 9:                                                ; from 0x800005e
 |       |   ;-- case 15:                                               ; from 0x800005e
 |       |   ;-- case 19:                                               ; from 0x800005e
-|       |   0x08000078      nop     dword [rax]                        ; arg1
+|       |   0x08000078      mov   rsi, rdi                             ; arg1
 |       |   0x0800007b      mov   edi, 1
 |      ,==< 0x08000080      jmp   reloc.target.getPageLengthEPROM      ; RELOC 32 getPageLengthEPROM
 ..
 |      ||   ; CODE XREF from sym.owGetPageLength.constprop.0 @ 0x800005e
 |      ||   ;-- case 51:                                               ; from 0x800005e
-|      ||   0x08000088      nop     dword [rax]                        ; arg1
+|      ||   0x08000088      mov   rsi, rdi                             ; arg1
 |      ||   0x0800008b      mov   edi, 1
 |     ,===< 0x08000090      jmp   reloc.target.getPageLengthSHAEE      ; RELOC 32 getPageLengthSHAEE
 ..
 |     |||   ; CODE XREF from sym.owGetPageLength.constprop.0 @ 0x800005e
 |     |||   ;-- case 55:                                               ; from 0x800005e
-|     |||   0x08000098      nop     dword [rax]                        ; arg1
+|     |||   0x08000098      mov   rsi, rdi                             ; arg1
 |     |||   0x0800009b      mov   edi, 1
 |    ,====< 0x080000a0      jmp   reloc.target.getPageLengthEE77       ; RELOC 32 getPageLengthEE77
 ..
 |    ||||   ; CODE XREF from sym.owGetPageLength.constprop.0 @ 0x800005e
 |    ||||   ;-- case 20:                                               ; from 0x800005e
-|    ||||   0x080000a8      nop     dword [rax]                        ; arg1
+|    ||||   0x080000a8      mov   rsi, rdi                             ; arg1
 |    ||||   0x080000ab      mov   edi, 1
 \   ,=====< 0x080000b0      jmp   reloc.target.getPageLengthEE         ; RELOC 32 getPageLengthEE
 EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes #2288 by clearing `ds-opstr` whenever a pdf '`..`' is appropriate.

Some side notes:

1. The function that sets `ds->opstr` is `ds_atabs_option()` (!)
2. The bug of #2288 can actually be repro'd on r2 [8587412](https://github.com/radareorg/radare2/commit/8587412f077e66319025fd774c9a36670f1255f6) by setting `e asm.tabs=6`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #2288.
