### PR TITLE
[RzIL] Add remaining comparison aliases and tests

### DIFF
--- a/librz/il/il_opcodes.c
+++ b/librz/il/il_opcodes.c
@@ -300,6 +300,42 @@ RZ_API RZ_OWN RzILOpBool *rz_il_op_new_slt(RZ_NONNULL RzILOpPure *x, RZ_NONNULL 
 }
 
 /**
+ * unsigned greater or equal
+ */
+RZ_API RZ_OWN RzILOpBool *rz_il_op_new_uge(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y) {
+	rz_return_val_if_fail(x && y, NULL);
+	return rz_il_op_new_bool_or(
+		rz_il_op_new_bool_inv(rz_il_op_new_ule(x, y)),
+		rz_il_op_new_eq(rz_il_op_pure_dup(x), rz_il_op_pure_dup(y)));
+}
+
+/**
+ * signed greater or equal
+ */
+RZ_API RZ_OWN RzILOpBool *rz_il_op_new_sge(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y) {
+	rz_return_val_if_fail(x && y, NULL);
+	return rz_il_op_new_bool_or(
+		rz_il_op_new_bool_inv(rz_il_op_new_sle(x, y)),
+		rz_il_op_new_eq(rz_il_op_pure_dup(x), rz_il_op_pure_dup(y)));
+}
+
+/**
+ * unsigned strictly greater than
+ */
+RZ_API RZ_OWN RzILOpBool *rz_il_op_new_ugt(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y) {
+	rz_return_val_if_fail(x && y, NULL);
+	return rz_il_op_new_bool_inv(rz_il_op_new_ule(x, y));
+}
+
+/**
+ * signed strictly greater than
+ */
+RZ_API RZ_OWN RzILOpBool *rz_il_op_new_sgt(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y) {
+	rz_return_val_if_fail(x && y, NULL);
+	return rz_il_op_new_bool_inv(rz_il_op_new_sle(x, y));
+}
+
+/**
  *  \brief op structure for casting bitv
  */
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_cast(ut32 length, RZ_NONNULL RzILOpBool *fill, RZ_NONNULL RzILOpBitVector *val) {

--- a/librz/include/rz_il/rz_il_opcodes.h
+++ b/librz/include/rz_il/rz_il_opcodes.h
@@ -461,6 +461,10 @@ RZ_API RZ_OWN RzILOpBool *rz_il_op_new_ule(RZ_NONNULL RzILOpPure *x, RZ_NONNULL 
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_sle(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_ult(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_slt(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
+RZ_API RZ_OWN RzILOpBool *rz_il_op_new_uge(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
+RZ_API RZ_OWN RzILOpBool *rz_il_op_new_sge(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
+RZ_API RZ_OWN RzILOpBool *rz_il_op_new_ugt(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
+RZ_API RZ_OWN RzILOpBool *rz_il_op_new_sgt(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_cast(ut32 length, RZ_NONNULL RzILOpBool *fill, RZ_NONNULL RzILOpBitVector *val);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_unsigned(ut32 length, RZ_NONNULL RzILOpBitVector *val); // "zero extension"
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_signed(ut32 length, RZ_NONNULL RzILOpBitVector *val); // "sign extension"

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -1072,11 +1072,7 @@ RZ_API bool rz_bv_sle(RZ_NONNULL RzBitVector *x, RZ_NONNULL RzBitVector *y) {
 	bool x_msb = rz_bv_msb(x);
 	bool y_msb = rz_bv_msb(y);
 
-	if (x_msb && y_msb) {
-		return !rz_bv_ule(x, y);
-	}
-
-	if (!x_msb && !y_msb) {
+	if (x_msb == y_msb) {
 		return rz_bv_ule(x, y);
 	}
 

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -371,23 +371,45 @@ bool test_rz_bv_cmp(void) {
 	rz_bv_set(x, 1, true);
 	rz_bv_set(x, 2, true);
 	rz_bv_set(x, 7, true);
-
 	y = rz_bv_new(8);
 	rz_bv_set(y, 0, true);
 	rz_bv_set(y, 1, true);
 	rz_bv_set(y, 2, true);
-
 	// get msb and lsb of y
 	bool msb, lsb;
 	msb = rz_bv_msb(y);
 	lsb = rz_bv_lsb(y);
-
 	mu_assert("msb", msb == false);
 	mu_assert("lsb", lsb == true);
+	mu_assert_false(rz_bv_ule(x, y), "ule of -/+");
+	mu_assert_true(rz_bv_ule(y, x), "ule of +/-");
+	mu_assert_true(rz_bv_sle(x, y), "sle of -/+");
+	mu_assert_false(rz_bv_sle(y, x), "sle of +/-");
+	rz_bv_free(x);
+	rz_bv_free(y);
 
-	mu_assert("Unsigned : x > y", !rz_bv_ule(x, y));
-	mu_assert("Signed : x < y", rz_bv_sle(x, y));
+	x = rz_bv_new_from_st64(32, -42);
+	y = rz_bv_new_from_st64(32, -20);
+	mu_assert_true(rz_bv_sle(x, y), "sle of -/-");
+	mu_assert_false(rz_bv_sle(y, x), "sle of -/-");
+	mu_assert_true(rz_bv_ule(x, y), "sle of -/-");
+	mu_assert_false(rz_bv_ule(y, x), "sle of -/-");
+	rz_bv_free(x);
+	rz_bv_free(y);
 
+	x = rz_bv_new_from_st64(32, 42);
+	y = rz_bv_new_from_st64(32, 20);
+	mu_assert_false(rz_bv_sle(x, y), "sle of +/+");
+	mu_assert_true(rz_bv_sle(y, y), "sle of +/+");
+	mu_assert_false(rz_bv_ule(x, y), "ule of +/+");
+	mu_assert_true(rz_bv_ule(y, y), "ule of +/+");
+	rz_bv_free(x);
+	rz_bv_free(y);
+
+	x = rz_bv_new_from_st64(32, 42);
+	y = rz_bv_new_from_st64(32, 42);
+	mu_assert_true(rz_bv_sle(x, y), "sle of ==");
+	mu_assert_true(rz_bv_ule(x, y), "ule of ==");
 	rz_bv_free(x);
 	rz_bv_free(y);
 

--- a/test/unit/test_il_vm.c
+++ b/test/unit/test_il_vm.c
@@ -809,6 +809,57 @@ static bool test_rzil_vm_op_shiftl() {
 	mu_end;
 }
 
+static bool test_rzil_vm_op_compare() {
+	RzILVM *vm = rz_il_vm_new(0, 8, true);
+#define TEST_COMPARE(sign, name, lv, rv, expect) \
+	do { \
+		RzILOpBool *op = rz_il_op_new_##sign##name(rz_il_op_new_bitv_from_##sign##t64(32, lv), rz_il_op_new_bitv_from_##sign##t64(32, rv)); \
+		RzILBool *r = rz_il_evaluate_bool(vm, op); \
+		rz_il_op_pure_free(op); \
+		mu_assert_notnull(r, "eval"); \
+		mu_assert_##expect(r->b, "eval val"); \
+		rz_il_bool_free(r); \
+	} while (0);
+
+	TEST_COMPARE(u, le, 100, 100, true);
+	TEST_COMPARE(u, le, 100, 101, true);
+	TEST_COMPARE(u, le, 101, 100, false);
+	TEST_COMPARE(u, le, -1, 100, false);
+	TEST_COMPARE(u, lt, 100, 100, false);
+	TEST_COMPARE(u, lt, 100, 101, true);
+	TEST_COMPARE(u, lt, 101, 100, false);
+	TEST_COMPARE(u, lt, -1, 100, false);
+	TEST_COMPARE(u, ge, 100, 100, true);
+	TEST_COMPARE(u, ge, 100, 101, false);
+	TEST_COMPARE(u, ge, 101, 100, true);
+	TEST_COMPARE(u, ge, -1, 100, true);
+	TEST_COMPARE(u, gt, 100, 100, false);
+	TEST_COMPARE(u, gt, 100, 101, false);
+	TEST_COMPARE(u, gt, 101, 100, true);
+	TEST_COMPARE(u, gt, -1, 100, true);
+
+	TEST_COMPARE(s, le, 100, 100, true);
+	TEST_COMPARE(s, le, 100, 101, true);
+	TEST_COMPARE(s, le, 101, 100, false);
+	TEST_COMPARE(s, le, -1, 100, true);
+	TEST_COMPARE(s, lt, 100, 100, false);
+	TEST_COMPARE(s, lt, 100, 101, true);
+	TEST_COMPARE(s, lt, 101, 100, false);
+	TEST_COMPARE(s, lt, -1, 100, true);
+	TEST_COMPARE(s, ge, 100, 100, true);
+	TEST_COMPARE(s, ge, 100, 101, false);
+	TEST_COMPARE(s, ge, 101, 100, true);
+	TEST_COMPARE(s, ge, -1, 100, false);
+	TEST_COMPARE(s, gt, 100, 100, false);
+	TEST_COMPARE(s, gt, 100, 101, false);
+	TEST_COMPARE(s, gt, 101, 100, true);
+	TEST_COMPARE(s, gt, -1, 100, false);
+
+#undef TEST_COMPARE
+	rz_il_vm_free(vm);
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_rzil_vm_init);
 	mu_run_test(test_rzil_vm_global_vars);
@@ -834,6 +885,7 @@ bool all_tests() {
 	mu_run_test(test_rzil_vm_op_append);
 	mu_run_test(test_rzil_vm_op_shiftr);
 	mu_run_test(test_rzil_vm_op_shiftl);
+	mu_run_test(test_rzil_vm_op_compare);
 	return tests_passed != tests_run;
 }
 

--- a/test/unit/test_il_vm.c
+++ b/test/unit/test_il_vm.c
@@ -825,35 +825,43 @@ static bool test_rzil_vm_op_compare() {
 	TEST_COMPARE(u, le, 100, 101, true);
 	TEST_COMPARE(u, le, 101, 100, false);
 	TEST_COMPARE(u, le, -1, 100, false);
+	TEST_COMPARE(u, le, -42, -13, true);
 	TEST_COMPARE(u, lt, 100, 100, false);
 	TEST_COMPARE(u, lt, 100, 101, true);
 	TEST_COMPARE(u, lt, 101, 100, false);
 	TEST_COMPARE(u, lt, -1, 100, false);
+	TEST_COMPARE(u, lt, -42, -13, true);
 	TEST_COMPARE(u, ge, 100, 100, true);
 	TEST_COMPARE(u, ge, 100, 101, false);
 	TEST_COMPARE(u, ge, 101, 100, true);
 	TEST_COMPARE(u, ge, -1, 100, true);
+	TEST_COMPARE(u, ge, -42, -13, false);
 	TEST_COMPARE(u, gt, 100, 100, false);
 	TEST_COMPARE(u, gt, 100, 101, false);
 	TEST_COMPARE(u, gt, 101, 100, true);
 	TEST_COMPARE(u, gt, -1, 100, true);
+	TEST_COMPARE(u, gt, -42, -13, false);
 
 	TEST_COMPARE(s, le, 100, 100, true);
 	TEST_COMPARE(s, le, 100, 101, true);
 	TEST_COMPARE(s, le, 101, 100, false);
 	TEST_COMPARE(s, le, -1, 100, true);
+	TEST_COMPARE(s, le, -42, -13, true);
 	TEST_COMPARE(s, lt, 100, 100, false);
 	TEST_COMPARE(s, lt, 100, 101, true);
 	TEST_COMPARE(s, lt, 101, 100, false);
 	TEST_COMPARE(s, lt, -1, 100, true);
+	TEST_COMPARE(s, lt, -42, -13, true);
 	TEST_COMPARE(s, ge, 100, 100, true);
 	TEST_COMPARE(s, ge, 100, 101, false);
 	TEST_COMPARE(s, ge, 101, 100, true);
 	TEST_COMPARE(s, ge, -1, 100, false);
+	TEST_COMPARE(s, ge, -42, -13, false);
 	TEST_COMPARE(s, gt, 100, 100, false);
 	TEST_COMPARE(s, gt, 100, 101, false);
 	TEST_COMPARE(s, gt, 101, 100, true);
 	TEST_COMPARE(s, gt, -1, 100, false);
+	TEST_COMPARE(s, gt, -42, -13, false);
 
 #undef TEST_COMPARE
 	rz_il_vm_free(vm);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This adds all remaining combinations of `(signed|unsigned) (greater|less) (than|or equal)` and tests for them.
The newly added "ops" are just aliases using `ule` or `sle`.

**Test plan**

see the unit tests