### PR TITLE
Fix leaks in rz-asm -A

### DIFF
--- a/librz/main/rz-asm.c
+++ b/librz/main/rz-asm.c
@@ -69,14 +69,10 @@ static char *stackop2str(int type) {
 	return strdup("unknown");
 }
 
-static int showanalysis(RzAsmState *as, RzAnalysisOp *op, ut64 offset, ut8 *buf, int len, PJ *pj) {
-	int ret = rz_analysis_op(as->analysis, op, offset, buf, len, RZ_ANALYSIS_OP_MASK_ESIL);
-	if (ret < 1) {
-		return ret;
-	}
+static void showanalysis(RzAsmState *as, RzAnalysisOp *op, ut64 offset, ut8 *buf, int len, PJ *pj) {
 	char *stackop = stackop2str(op->stackop);
 	const char *optype = rz_analysis_optype_to_string(op->type);
-	char *bytes = rz_hex_bin2strdup(buf, ret);
+	char *bytes = rz_hex_bin2strdup(buf, RZ_MIN(len, op->size));
 	if (as->json) {
 		pj_o(pj);
 		pj_kn(pj, "opcode", offset);
@@ -121,32 +117,34 @@ static int showanalysis(RzAsmState *as, RzAnalysisOp *op, ut64 offset, ut8 *buf,
 	}
 	free(stackop);
 	free(bytes);
-	return ret;
 }
 
 // TODO: add israw/len
 static int show_analinfo(RzAsmState *as, const char *arg, ut64 offset) {
 	ut8 *buf = (ut8 *)strdup((const char *)arg);
 	int ret, len = rz_hex_str2bin((char *)buf, buf);
-	PJ *pj = pj_new();
-	if (!pj) {
-		free(buf);
-		return 0;
+	PJ *pj = NULL;
+	if (as->json) {
+		pj = pj_new();
+		if (!pj) {
+			free(buf);
+			return 0;
+		}
 	}
 
 	RzAnalysisOp aop = { 0 };
 
-	if (as->json) {
+	if (pj) {
 		pj_a(pj);
 	}
 	for (ret = 0; ret < len;) {
 		aop.size = 0;
-		if (rz_analysis_op(as->analysis, &aop, offset, buf + ret, len - ret, RZ_ANALYSIS_OP_MASK_BASIC) < 1) {
+		if (rz_analysis_op(as->analysis, &aop, offset, buf + ret, len - ret, RZ_ANALYSIS_OP_MASK_BASIC | RZ_ANALYSIS_OP_MASK_ESIL) < 1) {
 			eprintf("Error analyzing instruction at 0x%08" PFMT64x "\n", offset);
 			break;
 		}
 		if (aop.size < 1) {
-			if (as->json) {
+			if (pj) {
 				pj_o(pj);
 				pj_ks(pj, "bytes", rz_hex_bin2strdup(buf, ret));
 				pj_ks(pj, "type", "Invalid");
@@ -160,7 +158,7 @@ static int show_analinfo(RzAsmState *as, const char *arg, ut64 offset) {
 		ret += aop.size;
 		rz_analysis_op_fini(&aop);
 	}
-	if (as->json) {
+	if (pj) {
 		pj_end(pj);
 		printf("%s\n", pj_string(pj));
 		pj_free(pj);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

* pj was created always but only freed sometimes
* rz_analysis_op() was called twice without fini, merged into one call

```
==8483== Memcheck, a memory error detector
==8483== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==8483== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==8483== Command: rz-asm -a ghidra -c x86:LE:32:default:gcc -A 89e1909090909090909090909090
==8483== Parent PID: 2753
==8483==
==8483==
==8483== HEAP SUMMARY:
==8483==     in use at exit: 206,067 bytes in 1,521 blocks
==8483==   total heap usage: 6,163,806 allocs, 6,162,285 frees, 341,824,903 bytes allocated
==8483==
==8483== 80 bytes in 1 blocks are definitely lost in loss record 1,419 of 1,447
==8483==    at 0x48445EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==8483==    by 0x5B4025B: rz_analysis_value_new (value.c:7)
==8483==    by 0x7655F89: SleighAnalysisValue::dup() const (SleighAnalysisValue.cpp:273)
==8483==    by 0x7658777: analysis_type_MOV(rz_analysis_t*, rz_analysis_op_t*, std::vector<Pcodeop, std::allocator<Pcodeop> > const&, std::unordered_set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) (analysis_ghidra.cpp:121)
==8483==    by 0x765C58F: analysis_type(rz_analysis_t*, rz_analysis_op_t*, PcodeSlg&, AssemblySlg&) (analysis_ghidra.cpp:778)
==8483==    by 0x766171A: sleigh_op(rz_analysis_t*, rz_analysis_op_t*, unsigned long long, unsigned char const*, int, RzAnalysisOpMask) (analysis_ghidra.cpp:1542)
==8483==    by 0x5B2BDD8: rz_analysis_op (op.c:114)
==8483==    by 0x487738F: show_analinfo (rz-asm.c:144)
==8483==    by 0x4879A07: rz_main_rz_asm (rz-asm.c:868)
==8483==    by 0x109160: main (rz-asm.c:8)
==8483==
==8483== 80 bytes in 1 blocks are definitely lost in loss record 1,420 of 1,447
==8483==    at 0x48445EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==8483==    by 0x5B4025B: rz_analysis_value_new (value.c:7)
==8483==    by 0x7655F89: SleighAnalysisValue::dup() const (SleighAnalysisValue.cpp:273)
==8483==    by 0x7658791: analysis_type_MOV(rz_analysis_t*, rz_analysis_op_t*, std::vector<Pcodeop, std::allocator<Pcodeop> > const&, std::unordered_set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) (analysis_ghidra.cpp:122)
==8483==    by 0x765C58F: analysis_type(rz_analysis_t*, rz_analysis_op_t*, PcodeSlg&, AssemblySlg&) (analysis_ghidra.cpp:778)
==8483==    by 0x766171A: sleigh_op(rz_analysis_t*, rz_analysis_op_t*, unsigned long long, unsigned char const*, int, RzAnalysisOpMask) (analysis_ghidra.cpp:1542)
==8483==    by 0x5B2BDD8: rz_analysis_op (op.c:114)
==8483==    by 0x487738F: show_analinfo (rz-asm.c:144)
==8483==    by 0x4879A07: rz_main_rz_asm (rz-asm.c:868)
==8483==    by 0x109160: main (rz-asm.c:8)
==8483==
==8483== 200 bytes in 1 blocks are definitely lost in loss record 1,429 of 1,447
==8483==    at 0x48445EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==8483==    by 0x4AE5B18: pj_new (pj.c:26)
==8483==    by 0x48772CB: show_analinfo (rz-asm.c:131)
==8483==    by 0x4879A07: rz_main_rz_asm (rz-asm.c:868)
==8483==    by 0x109160: main (rz-asm.c:8)
==8483==
==8483== LEAK SUMMARY:
==8483==    definitely lost: 360 bytes in 3 blocks
==8483==    indirectly lost: 0 bytes in 0 blocks
==8483==      possibly lost: 0 bytes in 0 blocks
==8483==    still reachable: 205,707 bytes in 1,518 blocks
==8483==         suppressed: 0 bytes in 0 blocks
==8483== Reachable blocks (those to which a pointer was found) are not shown.
==8483== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==8483==
==8483== For lists of detected and suppressed errors, rerun with: -s
==8483== ERROR SUMMARY: 3 errors from 3 contexts (suppressed: 0 from 0)
```

**Test plan**

the existing rz-test tests cover this sufficiently