### PR TITLE
Fix pcalign after changing analysis bits

### DIFF
--- a/librz/analysis/analysis.c
+++ b/librz/analysis/analysis.c
@@ -279,6 +279,8 @@ RZ_API bool rz_analysis_set_bits(RzAnalysis *analysis, int bits) {
 		if (analysis->bits != bits) {
 			bool is_hack = is_arm_thumb_hack(analysis, bits);
 			analysis->bits = bits;
+			int v = rz_analysis_archinfo(analysis, RZ_ANALYSIS_ARCHINFO_ALIGN);
+			analysis->pcalign = RZ_MAX(0, v);
 			rz_type_db_set_bits(analysis->typedb, bits);
 			if (!is_hack) {
 				char *types_dir = rz_path_system(RZ_SDB_TYPES);

--- a/test/db/analysis/arm
+++ b/test/db/analysis/arm
@@ -1098,3 +1098,18 @@ EXPECT=<<EOF
 main 0x512 [DATA] add r3, pc
 EOF
 RUN
+
+NAME=arm pcalign
+FILE=
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+e asm.pcalign
+e asm.bits=16
+e asm.pcalign
+EOF
+EXPECT=<<EOF
+4
+2
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
This fixes a bug that showed up after 2bdec10f98b3dc9dbb7f5855010b091dad1f4f13
because the bits value was set after cpu, but pcalign was already 4 then
and not updated by bits for example in:
```
rz-asm -a arm -b 16 -o 0x1059e -A dff81000
```

**Test plan**

#2241 contains test cases that cover this. Adding them separately does not really make much sense since this is very implementation-specific. The rz-test test that is added in this pr succeeds both before and after the code change because core does a lot more stuff when switching, so it's only for testing the thumb/arm pcalign.