### PR TITLE
Fix #2291 - Fix stealing register vars accesses when taking over blocks

### DIFF
--- a/librz/analysis/fcn.c
+++ b/librz/analysis/fcn.c
@@ -433,9 +433,18 @@ static bool fcn_takeover_block_recursive_followthrough_cb(RzAnalysisBlock *block
 			void **it;
 			rz_pvector_foreach (cloned_vars_used, it) {
 				RzAnalysisVar *other_var = *it;
-				const int actual_delta = other_var->kind == RZ_ANALYSIS_VAR_KIND_SPV
-					? other_var->delta + ctx->stack_diff
-					: other_var->delta + (other_fcn->bp_off - our_fcn->bp_off);
+				int actual_delta = 0;
+				switch (other_var->kind) {
+				case RZ_ANALYSIS_VAR_KIND_SPV:
+					actual_delta = other_var->delta + ctx->stack_diff;
+					break;
+				case RZ_ANALYSIS_VAR_KIND_BPV:
+					actual_delta = other_var->delta + (other_fcn->bp_off - our_fcn->bp_off);
+					break;
+				case RZ_ANALYSIS_VAR_KIND_REG:
+					actual_delta = other_var->delta;
+					break;
+				}
 				RzAnalysisVar *our_var = rz_analysis_function_get_var(our_fcn, other_var->kind, actual_delta);
 				if (!our_var) {
 					our_var = rz_analysis_function_set_var(our_fcn, actual_delta, other_var->kind, other_var->type, 0, other_var->isarg, other_var->name);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Adds the missing case for `RZ_ANALYSIS_VAR_KIND_REG`

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Manually tested

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Fixes #2291