### PR TITLE
Fix BitVector division and other stories

### DIFF
--- a/librz/include/rz_util/rz_bitvector.h
+++ b/librz/include/rz_util/rz_bitvector.h
@@ -74,6 +74,10 @@ RZ_API bool rz_bv_lsb(RZ_NONNULL RzBitVector *bv);
 RZ_API bool rz_bv_eq(RZ_NONNULL RzBitVector *x, RZ_NONNULL RzBitVector *y);
 RZ_API bool rz_bv_ule(RZ_NONNULL RzBitVector *x, RZ_NONNULL RzBitVector *y);
 RZ_API bool rz_bv_sle(RZ_NONNULL RzBitVector *x, RZ_NONNULL RzBitVector *y);
+
+RZ_API ut32 rz_bv_clz(RZ_NONNULL RzBitVector *bv);
+RZ_API ut32 rz_bv_ctz(RZ_NONNULL RzBitVector *bv);
+
 // some convert functions
 RZ_API ut8 rz_bv_to_ut8(RZ_NONNULL const RzBitVector *x);
 RZ_API ut16 rz_bv_to_ut16(RZ_NONNULL const RzBitVector *x);

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -133,7 +133,7 @@ RZ_API RZ_OWN char *rz_bv_as_hex_string(RZ_NONNULL RzBitVector *bv, bool pad) {
 			str[j++] = hex[high];
 			pad = true; // pad means "print all" from now on
 		}
-		if (pad || low) {
+		if (pad || low || i == bv->_elem_len - 1) {
 			str[j++] = hex[low];
 			pad = true; // pad means "print all" from now on
 		}

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -125,8 +125,7 @@ RZ_API RZ_OWN char *rz_bv_as_hex_string(RZ_NONNULL RzBitVector *bv, bool pad) {
 	str[1] = 'x';
 	ut32 j = 2;
 	for (ut32 i = 0; i < bv->_elem_len; i++) {
-		ut8 b8 = bv->bits.large_a[i];
-		b8 = reverse_byte(b8);
+		ut8 b8 = bv->bits.large_a[bv->_elem_len - i - 1];
 		ut8 high = b8 >> 4;
 		ut8 low = b8 & 15;
 		if (pad || high) {
@@ -334,7 +333,6 @@ RZ_API bool rz_bv_set(RZ_NONNULL RzBitVector *bv, ut32 pos, bool b) {
 	}
 	rz_return_val_if_fail(bv->bits.large_a, false);
 
-	pos = bv->len - pos - 1;
 	if (b) {
 		bv->bits.large_a[pos / BV_ELEM_SIZE] |= (1u << (pos % BV_ELEM_SIZE));
 	} else {
@@ -418,7 +416,6 @@ RZ_API bool rz_bv_get(RZ_NONNULL const RzBitVector *bv, ut32 pos) {
 	}
 
 	rz_return_val_if_fail(bv->bits.large_a, false);
-	pos = bv->len - pos - 1;
 	return ((bv->bits.large_a)[pos / BV_ELEM_SIZE] & (1u << (pos % BV_ELEM_SIZE)));
 }
 

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -1104,6 +1104,38 @@ RZ_API bool rz_bv_cmp(RZ_NONNULL RzBitVector *x, RZ_NONNULL RzBitVector *y) {
 }
 
 /**
+ * Count leading (most significant) zeroes
+ * All bits are considered leading zeroes for a zero bitvector.
+ */
+RZ_API ut32 rz_bv_clz(RZ_NONNULL RzBitVector *bv) {
+	rz_return_val_if_fail(bv, 0);
+	ut32 r = 0;
+	for (ut32 i = rz_bv_len(bv); i; i--) {
+		if (rz_bv_get(bv, i - 1)) {
+			break;
+		}
+		r++;
+	}
+	return r;
+}
+
+/**
+ * Count trailing (least significant) zeroes
+ * All bits are considered trailing zeroes for a zero bitvector.
+ */
+RZ_API ut32 rz_bv_ctz(RZ_NONNULL RzBitVector *bv) {
+	rz_return_val_if_fail(bv, 0);
+	ut32 r = 0;
+	for (ut32 i = 0; i < rz_bv_len(bv); i++) {
+		if (rz_bv_get(bv, i)) {
+			break;
+		}
+		r++;
+	}
+	return r;
+}
+
+/**
  * Get the length of bitvector in bits
  * \param bv RzBitVector
  * \return len ut32, length of bitvector in bits

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -357,13 +357,13 @@ RZ_API bool rz_bv_set_all(RZ_NONNULL RzBitVector *bv, bool b) {
 
 	rz_return_val_if_fail(bv->bits.large_a, false);
 	if (b) {
-		for (ut32 i = 0; i < bv->_elem_len; ++i) {
-			bv->bits.large_a[i] = 0xff;
+		memset(bv->bits.large_a, 0xff, bv->_elem_len);
+		ut32 mod = bv->len % BV_ELEM_SIZE;
+		if (mod) {
+			bv->bits.large_a[bv->len / BV_ELEM_SIZE] = rz_num_bitmask(mod);
 		}
 	} else {
-		for (ut32 i = 0; i < bv->_elem_len; ++i) {
-			bv->bits.large_a[i] = 0;
-		}
+		memset(bv->bits.large_a, 0, bv->_elem_len);
 	}
 
 	return b;
@@ -782,100 +782,80 @@ int bv_unsigned_cmp(RZ_NONNULL RzBitVector *x, RZ_NONNULL RzBitVector *y) {
 /**
  * Result of (x / y) mod 2^length
  * Both operands must have the same length.
- * \param x RzBitVector, Operand
- * \param y RzBitVector, Operand
- * \return ret RzBitVector, point to the new bitvector
+ * If \p y is a zero vector, the result defined as a vector of all ones.
+ *
+ * \param x dividend
+ * \param y divisor
+ * \return ret quotient, of the same length as the operands
  */
 RZ_API RZ_OWN RzBitVector *rz_bv_div(RZ_NONNULL RzBitVector *x, RZ_NONNULL RzBitVector *y) {
-	rz_return_val_if_fail(x && y, NULL);
-	if (x->len != y->len) {
-		rz_warn_if_reached();
-		return NULL;
-	}
+	rz_return_val_if_fail(x && y && x->len == y->len, NULL);
 
 	if (rz_bv_is_zero_vector(y)) {
 		RzBitVector *ret = rz_bv_new(y->len);
 		rz_bv_set_all(ret, true);
-		RZ_LOG_ERROR("RzIL: can't divide by zero\n");
 		return ret;
 	}
 
-	int compare_result = bv_unsigned_cmp(x, y);
+	if (x->len <= 64) {
+		return rz_bv_new_from_ut64(x->len, rz_bv_to_ut64(x) / rz_bv_to_ut64(y));
+	}
 
+	int compare_result = bv_unsigned_cmp(x, y);
 	// dividend < divisor
 	// remainder = dividend, quotient = 0
 	if (compare_result < 0) {
 		return rz_bv_new(x->len);
 	}
-
 	// dividend == divisor
-	// remainder = 0, quotient = dividend
+	// remainder = 0, quotient = 1
 	if (compare_result == 0) {
-		return rz_bv_dup(x);
+		return rz_bv_new_one(rz_bv_len(x));
 	}
 
 	// dividend > divisor
-	RzBitVector *dividend = rz_bv_dup(x);
-	RzBitVector *tmp;
-	ut32 count = 0;
-
-	while (bv_unsigned_cmp(dividend, y) >= 0) {
-		count += 1;
-		tmp = rz_bv_sub(dividend, y, NULL);
-		rz_bv_free(dividend);
-		dividend = tmp;
+	// do typical division by shift and subtract
+	RzBitVector *dend = rz_bv_dup(x);
+	RzBitVector *sor = rz_bv_dup(y);
+	// shift the divisor left to align both highest bits
+	ut32 sorlz = rz_bv_clz(sor);
+	ut32 shift = sorlz - rz_bv_clz(dend);
+	rz_bv_lshift(sor, shift);
+	RzBitVector *quot = rz_bv_new_zero(rz_bv_len(x));
+	for (ut32 b = shift + 1; b; b--) {
+		if (rz_bv_ule(sor, dend)) {
+			rz_bv_set(quot, b - 1, true);
+			RzBitVector *tmp = rz_bv_sub(dend, sor, NULL);
+			rz_bv_free(dend);
+			dend = tmp;
+		}
+		rz_bv_rshift(sor, 1);
 	}
-
-	RzBitVector *remainder = dividend;
-	RzBitVector *quotient = rz_bv_new_from_ut64(x->len, count);
-	rz_bv_free(remainder);
-	return quotient;
+	rz_bv_free(dend);
+	rz_bv_free(sor);
+	return quot;
 }
 
 /**
  * Result of (x mod y) mod 2^length
  * Both operands must have the same length.
- * \param x RzBitVector, Operand
- * \param y RzBitVector, Operand
- * \return ret RzBitVector, point to the new bitvector
+ * If \p y == 0, the result is \p x
+ *
+ * \param x dividend
+ * \param y divisor
+ * \return x - ((x / y) * y)
  */
 RZ_API RZ_OWN RzBitVector *rz_bv_mod(RZ_NONNULL RzBitVector *x, RZ_NONNULL RzBitVector *y) {
-	rz_return_val_if_fail(x && y, NULL);
-	if (x->len != y->len) {
-		rz_warn_if_reached();
-		return NULL;
-	}
-
+	rz_return_val_if_fail(x && y && x->len == y->len, NULL);
 	if (rz_bv_is_zero_vector(y)) {
 		return rz_bv_dup(x);
 	}
-
-	int compare_result = bv_unsigned_cmp(x, y);
-
-	// dividend < divisor
-	// remainder = dividend, quotient = 0
-	if (compare_result < 0) {
-		return rz_bv_dup(x);
-	}
-
-	// dividend == divisor
-	// remainder = 0, quotient = dividend
-	if (compare_result == 0) {
-		return rz_bv_new(x->len);
-	}
-
-	// dividend > divisor
-	RzBitVector *dividend = rz_bv_dup(x);
-	RzBitVector *tmp;
-
-	while (bv_unsigned_cmp(dividend, y) >= 0) {
-		tmp = rz_bv_sub(dividend, y, NULL);
-		rz_bv_free(dividend);
-		dividend = tmp;
-	}
-
-	RzBitVector *remainder = dividend;
-	return remainder;
+	RzBitVector *quot = rz_bv_div(x, y);
+	RzBitVector *remul = rz_bv_mul(quot, y);
+	RzBitVector *r = rz_bv_sub(x, remul, NULL);
+	rz_bv_free(quot);
+	rz_bv_free(remul);
+	return r;
 }
 
 /**

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -724,6 +724,12 @@ bool test_rz_bv_as_hex_string(void) {
 	mu_assert_streq_free(s, "0x0000032a", "string hex value of bv");
 	s = rz_bv_as_hex_string(bv, false);
 	mu_assert_streq_free(s, "0x32a", "string hex value of bv");
+
+	rz_bv_set_from_ut64(bv, 0x0);
+	s = rz_bv_as_hex_string(bv, true);
+	mu_assert_streq_free(s, "0x00000000", "string hex value of bv");
+	s = rz_bv_as_hex_string(bv, false);
+	mu_assert_streq_free(s, "0x0", "string hex value of bv");
 	rz_bv_free(bv);
 
 	// big
@@ -738,11 +744,16 @@ bool test_rz_bv_as_hex_string(void) {
 	mu_assert_streq_free(s, "0x64", "string hex value of bv");
 
 	rz_bv_set(bv, 16, true);
-
 	s = rz_bv_as_hex_string(bv, true);
 	mu_assert_streq_free(s, "0x00000000000000000000000000010064", "string hex value of bv");
 	s = rz_bv_as_hex_string(bv, false);
 	mu_assert_streq_free(s, "0x10064", "string hex value of bv");
+
+	rz_bv_set_from_ut64(bv, 0x0);
+	s = rz_bv_as_hex_string(bv, true);
+	mu_assert_streq_free(s, "0x00000000000000000000000000000000", "string hex value of bv");
+	s = rz_bv_as_hex_string(bv, false);
+	mu_assert_streq_free(s, "0x0", "string hex value of bv");
 
 	rz_bv_free(bv);
 	mu_end;

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -788,6 +788,49 @@ bool test_rz_bv_as_hex_string(void) {
 	mu_end;
 }
 
+bool test_rz_bv_clz(void) {
+#define TEST_CLZ(bva, expect) \
+	do { \
+		RzBitVector *a = bva; \
+		ut32 r = rz_bv_clz(a); \
+		mu_assert_eq(r, expect, "clz"); \
+		rz_bv_free(a); \
+	} while (0)
+
+	TEST_CLZ(rz_bv_new_from_ut64(32, 0x2a), 26);
+	TEST_CLZ(rz_bv_new_from_ut64(32, 0x0), 32);
+	TEST_CLZ(rz_bv_new_from_ut64(32, 0xffffffff), 0);
+	TEST_CLZ(rz_bv_new_from_ut64(64, 0xffffffffffffffff), 0);
+	TEST_CLZ(rz_bv_new_from_ut64(64, 0x2a), 58);
+	TEST_CLZ(rz_bv_new_from_ut64(74, 0x2a), 68);
+	TEST_CLZ(rz_bv_new_from_st64(74, -1), 0);
+	TEST_CLZ(rz_bv_new_from_ut64(74, 0), 74);
+
+#undef TEST_CLZ
+	mu_end;
+}
+
+bool test_rz_bv_ctz(void) {
+#define TEST_CTZ(bva, expect) \
+	do { \
+		RzBitVector *a = bva; \
+		ut32 r = rz_bv_ctz(a); \
+		mu_assert_eq(r, expect, "clz"); \
+		rz_bv_free(a); \
+	} while (0)
+
+	TEST_CTZ(rz_bv_new_from_ut64(32, 0x1), 0);
+	TEST_CTZ(rz_bv_new_from_ut64(32, 0x0), 32);
+	TEST_CTZ(rz_bv_new_from_ut64(32, 0xffffff00), 8);
+	TEST_CTZ(rz_bv_new_from_ut64(64, 0xfffffffffffff800), 11);
+	TEST_CTZ(rz_bv_new_from_ut64(74, 0x8), 3);
+	TEST_CTZ(rz_bv_new_from_st64(74, -1), 0);
+	TEST_CTZ(rz_bv_new_from_ut64(74, 0), 74);
+
+#undef TEST_CTZ
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_rz_bv_init32);
 	mu_run_test(test_rz_bv_init64);
@@ -804,6 +847,8 @@ bool all_tests() {
 	mu_run_test(test_rz_bv_set_from_bytes_le);
 	mu_run_test(test_rz_bv_set_from_bytes_be);
 	mu_run_test(test_rz_bv_as_hex_string);
+	mu_run_test(test_rz_bv_clz);
+	mu_run_test(test_rz_bv_ctz);
 	return tests_passed != tests_run;
 }
 

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -93,6 +93,35 @@ bool test_rz_bv_init128(void) {
 	mu_end;
 }
 
+bool test_rz_bv_init70(void) {
+	char *s = NULL;
+
+	// create by given unsigned 70 bits
+	RzBitVector *bits = rz_bv_new_from_ut64(70, 100);
+	RzBitVector *bits_cmp = rz_bv_new(70);
+
+	// 100 = 64 + 32 + 4 == 0b 0000 0000 0000 0000 0000 0000 0110 0100
+	rz_bv_set(bits_cmp, 2, true);
+	rz_bv_set(bits_cmp, 5, true);
+	rz_bv_set(bits_cmp, 6, true);
+	mu_assert("new from 70", is_equal_bv(bits, bits_cmp));
+
+	// dup
+	RzBitVector *bits_dup = rz_bv_dup(bits);
+	mu_assert("dup from bits 70", is_equal_bv(bits_dup, bits));
+
+	s = rz_bv_as_string(bits);
+	mu_assert_streq_free(s, "0000000000000000000000000000000000000000000000000000000000000001100100", "string bit value of bv");
+
+	s = rz_bv_as_hex_string(bits, true);
+	mu_assert_streq_free(s, "0x000000000000000064", "string hex value of bv");
+
+	rz_bv_free(bits);
+	rz_bv_free(bits_cmp);
+	rz_bv_free(bits_dup);
+	mu_end;
+}
+
 bool test_rz_bv_init_signed(void) {
 	char *s = NULL;
 	RzBitVector *bits = NULL;
@@ -763,6 +792,7 @@ bool all_tests() {
 	mu_run_test(test_rz_bv_init32);
 	mu_run_test(test_rz_bv_init64);
 	mu_run_test(test_rz_bv_init128);
+	mu_run_test(test_rz_bv_init70);
 	mu_run_test(test_rz_bv_init_signed);
 	mu_run_test(test_rz_bv_cmp);
 	mu_run_test(test_rz_bv_eq);


### PR DESCRIPTION
# DO NOT SQUASH!!!

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

### Fix rz_bv_as_hex_string() for big 0

This was printing `0x` instead of `0x0` for big vectors when padding was
disabled.

### Make big bvs store in typical little endian

Previously, bits were stored in the big endian in reversed order, such
that bit 0 of byte 0 would contain the msb. This requires reversing them
for any calculation and becomes even more confusing when the size is not
a multiple of 8, so let's just store them in classic little endian with
bit 0 of byte 0 containing the lsb.
This also fixes rz_bv_as_hex_string() for bvs that have a size not
divisiable by 0.

### Add ctz and clz ops to RzBitVector

typical "count trailing/leading zeroes" used for div

### Fix rz_bv_div() and rz_bv_mod()

Problems fixed:
* Division by repeated addition is horribly slow, now it's classic
  shift+sub
* a / a = 1, not a
* rz_bv_set_all() was setting too many bits if len % 8 != 0
* Removed print on div by 0 because we define it to all 1s (like BAP)

mod just uses div and we use regular ut64 division when possible.

**Test plan**

see the added unit tests