### PR TITLE
Add an option to provide a custom prefix for portable binaries

### DIFF
--- a/librz/include/rz_userconf.h.in
+++ b/librz/include/rz_userconf.h.in
@@ -54,6 +54,8 @@
 #define RZ_DATDIR  "@DATADIR@"
 #define RZ_WWWROOT "@WWWROOT@"
 
+#define RZ_BINDIR_DEPTH  @BINDIR_DEPTH@
+
 #define RZ_PLUGINS  "@PLUGINS@"
 #define RZ_DATADIR  "@DATADIR_RZ@"
 #define RZ_SDB      "@SDB@"

--- a/meson.build
+++ b/meson.build
@@ -177,11 +177,8 @@ if (b_sanitize_opt.contains('address') or b_sanitize_opt.contains('undefined')) 
   library_linkflags += '-shared-libasan'
 endif
 
-if get_option('portable_prefix') != '' and get_option('portable') == true
-  rizin_prefix = get_option('portable_prefix')
-else
-  rizin_prefix = get_option('prefix')
-endif
+
+rizin_prefix = get_option('prefix')
 rizin_bindir = get_option('bindir')
 rizin_libdir = get_option('libdir')
 rizin_cmakedir = rizin_libdir / 'cmake'
@@ -211,6 +208,12 @@ else
   rizin_plugins = rizin_libdir / 'rizin' / 'plugins'
   rizin_bindings = rizin_libdir / 'rizin-bindings'
 endif
+
+# Calcualte BINDIR's depth to be able to find the root directory during runtime
+# in portable builds
+py_cmd = 'import os; print(len(os.path.normpath(r"@0@").split(os.sep)) - len(os.path.normpath(r"@1@").split(os.sep)))'.format(rizin_prefix / rizin_bindir, rizin_prefix)
+py_cmd = run_command(py3_exe, '-c', py_cmd)
+bindir_depth = py_cmd.stdout().strip()
 
 opts_overwrite = [
   'rizin_wwwroot',
@@ -377,6 +380,7 @@ userconf.set10('USE_LIB_XXHASH', xxhash_dep.found())
 userconf.set10('DEBUGGER', has_debugger)
 userconf.set('PREFIX', rizin_prefix)
 userconf.set('BINDIR', rizin_bindir)
+userconf.set('BINDIR_DEPTH', bindir_depth)
 userconf.set('LIBDIR', rizin_libdir)
 userconf.set('INCLUDEDIR', rizin_incdir)
 userconf.set('DATADIR_RZ', rizin_datdir_rz)

--- a/meson.build
+++ b/meson.build
@@ -177,8 +177,11 @@ if (b_sanitize_opt.contains('address') or b_sanitize_opt.contains('undefined')) 
   library_linkflags += '-shared-libasan'
 endif
 
-
-rizin_prefix = get_option('prefix')
+if get_option('portable_prefix') != '' and get_option('portable') == true
+  rizin_prefix = get_option('portable_prefix')
+else
+  rizin_prefix = get_option('prefix')
+endif
 rizin_bindir = get_option('bindir')
 rizin_libdir = get_option('libdir')
 rizin_cmakedir = rizin_libdir / 'cmake'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,7 @@ option('local', type: 'combo', choices: ['enabled', 'disabled', 'absolute', 'aut
 option('blob', type: 'boolean', value: false, description: 'Compile just one binary which dispatch to the right handlers based on the name used to call it')
 option('subprojects_check', type: 'boolean', value: true, description: 'Check if git subprojects are up-to-date. Might be useful to disable this when developing on a different subproject version')
 option('portable', type: 'boolean', value: false, description: 'Make rizin installation moveable, by using relative paths instead of absolute ones')
+option('portable_prefix', type: 'string', value: '', description: 'Set a relative runtime prefix for portable binaries. Useful when bundling Rizin with another binary')
 
 option('rizin_wwwroot', type: 'string', value: '', description: 'Install path for www files')
 option('rizin_sdb', type: 'string', value: '', description: '')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,7 +6,6 @@ option('local', type: 'combo', choices: ['enabled', 'disabled', 'absolute', 'aut
 option('blob', type: 'boolean', value: false, description: 'Compile just one binary which dispatch to the right handlers based on the name used to call it')
 option('subprojects_check', type: 'boolean', value: true, description: 'Check if git subprojects are up-to-date. Might be useful to disable this when developing on a different subproject version')
 option('portable', type: 'boolean', value: false, description: 'Make rizin installation moveable, by using relative paths instead of absolute ones')
-option('portable_prefix', type: 'string', value: '', description: 'Set a relative runtime prefix for portable binaries. Useful when bundling Rizin with another binary')
 
 option('rizin_wwwroot', type: 'string', value: '', description: 'Install path for www files')
 option('rizin_sdb', type: 'string', value: '', description: '')


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Provide a way to set a custom prefix in [rz_path_prefix](https://github.com/rizinorg/rizin/blob/dev/librz/util/path.c#L25) for binaries that bundle with rizin.

This change aims to solve [#2897](https://github.com/rizinorg/cutter/issues/2897) - the Cutter build artifact fails to find the themes directory due to changes in [rz_path_prefix](https://github.com/rizinorg/rizin/blob/dev/librz/util/path.c#L25), which only returns the relative prefix for portable binaries that return true for `rz_str_endswith(<pid path>, RZ_SYS_DIR RZ_BINDIR)`. Since Windows Cutter sets `RZ_BINDIR=.` and Linux Cutter runs from the root directory while `RZ_BINDIR=bin`, the original build directory prefix is returned in all cases.

**Test plan**

Verify that [#2897](https://github.com/rizinorg/cutter/issues/2897) is solved by these changes.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
