### PR TITLE
Fix #2072: Convert main vaddr to paddr first

### DIFF
--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -323,9 +323,10 @@ static ut64 get_main_offset_linux_64_pie(ELFOBJ *bin, ut64 entry, ut8 *buf) {
 			if (vmain >> 16 == ventry >> 16) {
 				return (ut64)vmain;
 			}
-		} else if (0xc7) { // mov rdi, 0xADDR
+		} else if (ch == 0xc7) { // mov rdi, 0xADDR
 			ut8 *p = buf + bo + 3;
-			return (ut64)(ut32)rz_read_le32(p);
+			ut64 addr = (ut64)rz_read_le32(p);
+			return Elf_(rz_bin_elf_v2p_new)(bin, addr);
 		}
 	}
 

--- a/test/db/abi/languages/freepascal
+++ b/test/db/abi/languages/freepascal
@@ -8,21 +8,3 @@ EXPECT=<<EOF
 lang     freepascal
 EOF
 RUN
-
-NAME=LANGUAGES: freepascal main detection
-FILE=bins/abi_bins/elf/languages/freepascal/pick_random
-BROKEN=1
-ARGS=-A
-CMDS=<<EOF
-s main
-pdf
-EOF
-EXPECT=<<EOF
-EOF
-REGEXP_FILTER_ERR=<<EOF
-0x48c1c748
-EOF
-EXPECT_ERR=<<EOF
-0x48c1c748
-EOF
-RUN

--- a/test/db/abi/languages/freepascal
+++ b/test/db/abi/languages/freepascal
@@ -8,3 +8,16 @@ EXPECT=<<EOF
 lang     freepascal
 EOF
 RUN
+
+NAME=LANGUAGES: freepascal main detection
+FILE=bins/abi_bins/elf/languages/freepascal/pick_random
+BROKEN=1 # EXPECT must have output, EXPECT_ERR must be empty
+CMDS=<<EOF
+s main
+pdf
+EOF
+EXPECT=<<EOF
+EOF
+EXPECT_ERR=<<EOF
+EOF
+RUN

--- a/test/db/abi/languages/freepascal
+++ b/test/db/abi/languages/freepascal
@@ -11,6 +11,7 @@ RUN
 
 NAME=LANGUAGES: freepascal main detection
 FILE=bins/abi_bins/elf/languages/freepascal/pick_random
+BROKEN=1
 ARGS=-A
 CMDS=<<EOF
 s main

--- a/test/db/formats/elf/main
+++ b/test/db/formats/elf/main
@@ -166,3 +166,11 @@ EXPECT=<<EOF
 0x4d80
 EOF
 RUN
+
+NAME=main graalvm java (#2072)
+FILE=bins/elf/analysis/graalvm-example-truncated
+CMDS=?v main
+EXPECT=<<EOF
+0x424250
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes #2072 by converting the found main virtual address to a physical address first before returning it, as required by the `binsym()` in `librz/bin/p/bin_elf.inc`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #2072.
