### PR TITLE
Convert `as` commands to the rzshell

### DIFF
--- a/librz/core/cmd_descs/cmd_analysis.yaml
+++ b/librz/core/cmd_descs/cmd_analysis.yaml
@@ -1838,3 +1838,48 @@ commands:
         args:
           - name: addr
             type: RZ_CMD_ARG_TYPE_RZNUM
+  - name: as
+    summary: Syscalls
+    subcommands:
+      - name: as
+        summary: Show syscall and arguments
+        cname: analysis_syscall_show
+        args:
+          - name: syscall
+            type: RZ_CMD_ARG_TYPE_NUM
+            optional: true
+      - name: asl
+        summary: List syscalls
+        cname: analysis_syscall_print
+        type: RZ_CMD_DESC_TYPE_ARGV_STATE
+        default_mode: RZ_OUTPUT_MODE_STANDARD
+        modes:
+          - RZ_OUTPUT_MODE_STANDARD
+          - RZ_OUTPUT_MODE_JSON
+        args: []
+      - name: asca
+        summary: Dump syscall info into .asm file
+        cname: analysis_syscall_dump_assembly
+        args:
+          - name: syscall
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+      - name: asc
+        summary: Dump syscall info into .h file
+        cname: analysis_syscall_dump_c
+        args:
+          - name: syscall
+            type: RZ_CMD_ARG_TYPE_STRING
+            optional: true
+      - name: asn
+        summary: Returns the syscall number by the name
+        cname: analysis_syscall_name
+        args:
+          - name: name
+            type: RZ_CMD_ARG_TYPE_STRING
+      - name: asr
+        summary: Returns the syscall name by the number
+        cname: analysis_syscall_number
+        args:
+          - name: number
+            type: RZ_CMD_ARG_TYPE_NUM

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -208,6 +208,11 @@ static const RzCmdDescArg analyze_cycles_args[2];
 static const RzCmdDescArg convert_mne_args[2];
 static const RzCmdDescArg analyse_name_args[2];
 static const RzCmdDescArg analysis_basic_block_find_paths_args[2];
+static const RzCmdDescArg analysis_syscall_show_args[2];
+static const RzCmdDescArg analysis_syscall_dump_assembly_args[2];
+static const RzCmdDescArg analysis_syscall_dump_c_args[2];
+static const RzCmdDescArg analysis_syscall_name_args[2];
+static const RzCmdDescArg analysis_syscall_number_args[2];
 static const RzCmdDescArg block_args[2];
 static const RzCmdDescArg block_decrease_args[2];
 static const RzCmdDescArg block_increase_args[2];
@@ -4280,6 +4285,88 @@ static const RzCmdDescArg analysis_basic_block_find_paths_args[] = {
 static const RzCmdDescHelp analysis_basic_block_find_paths_help = {
 	.summary = "Find paths from current seek to the given address",
 	.args = analysis_basic_block_find_paths_args,
+};
+
+static const RzCmdDescHelp as_help = {
+	.summary = "Syscalls",
+};
+static const RzCmdDescArg analysis_syscall_show_args[] = {
+	{
+		.name = "syscall",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_syscall_show_help = {
+	.summary = "Show syscall and arguments",
+	.args = analysis_syscall_show_args,
+};
+
+static const RzCmdDescArg analysis_syscall_print_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_syscall_print_help = {
+	.summary = "List syscalls",
+	.args = analysis_syscall_print_args,
+};
+
+static const RzCmdDescArg analysis_syscall_dump_assembly_args[] = {
+	{
+		.name = "syscall",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_syscall_dump_assembly_help = {
+	.summary = "Dump syscall info into .asm file",
+	.args = analysis_syscall_dump_assembly_args,
+};
+
+static const RzCmdDescArg analysis_syscall_dump_c_args[] = {
+	{
+		.name = "syscall",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_syscall_dump_c_help = {
+	.summary = "Dump syscall info into .h file",
+	.args = analysis_syscall_dump_c_args,
+};
+
+static const RzCmdDescArg analysis_syscall_name_args[] = {
+	{
+		.name = "name",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_syscall_name_help = {
+	.summary = "Returns the syscall number by the name",
+	.args = analysis_syscall_name_args,
+};
+
+static const RzCmdDescArg analysis_syscall_number_args[] = {
+	{
+		.name = "number",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_syscall_number_help = {
+	.summary = "Returns the syscall name by the number",
+	.args = analysis_syscall_number_args,
 };
 
 static const RzCmdDescHelp b_help = {
@@ -14354,6 +14441,24 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *analysis_basic_block_find_paths_cd = rz_cmd_desc_argv_state_new(core->rcmd, ab_cd, "abt", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_basic_block_find_paths_handler, &analysis_basic_block_find_paths_help);
 	rz_warn_if_fail(analysis_basic_block_find_paths_cd);
+
+	RzCmdDesc *as_cd = rz_cmd_desc_group_new(core->rcmd, cmd_analysis_cd, "as", rz_analysis_syscall_show_handler, &analysis_syscall_show_help, &as_help);
+	rz_warn_if_fail(as_cd);
+	RzCmdDesc *analysis_syscall_print_cd = rz_cmd_desc_argv_state_new(core->rcmd, as_cd, "asl", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_syscall_print_handler, &analysis_syscall_print_help);
+	rz_warn_if_fail(analysis_syscall_print_cd);
+	rz_cmd_desc_set_default_mode(analysis_syscall_print_cd, RZ_OUTPUT_MODE_STANDARD);
+
+	RzCmdDesc *analysis_syscall_dump_assembly_cd = rz_cmd_desc_argv_new(core->rcmd, as_cd, "asca", rz_analysis_syscall_dump_assembly_handler, &analysis_syscall_dump_assembly_help);
+	rz_warn_if_fail(analysis_syscall_dump_assembly_cd);
+
+	RzCmdDesc *analysis_syscall_dump_c_cd = rz_cmd_desc_argv_new(core->rcmd, as_cd, "asc", rz_analysis_syscall_dump_c_handler, &analysis_syscall_dump_c_help);
+	rz_warn_if_fail(analysis_syscall_dump_c_cd);
+
+	RzCmdDesc *analysis_syscall_name_cd = rz_cmd_desc_argv_new(core->rcmd, as_cd, "asn", rz_analysis_syscall_name_handler, &analysis_syscall_name_help);
+	rz_warn_if_fail(analysis_syscall_name_cd);
+
+	RzCmdDesc *analysis_syscall_number_cd = rz_cmd_desc_argv_new(core->rcmd, as_cd, "asr", rz_analysis_syscall_number_handler, &analysis_syscall_number_help);
+	rz_warn_if_fail(analysis_syscall_number_cd);
 
 	RzCmdDesc *b_cd = rz_cmd_desc_group_state_new(core->rcmd, root_cd, "b", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_RIZIN, rz_block_handler, &block_help, &b_help);
 	rz_warn_if_fail(b_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -271,6 +271,12 @@ RZ_IPI RzCmdStatus rz_analyse_name_handler(RzCore *core, int argc, const char **
 RZ_IPI RzCmdStatus rz_analysis_basic_block_info_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_analysis_basic_block_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_analysis_basic_block_find_paths_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+RZ_IPI RzCmdStatus rz_analysis_syscall_show_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_analysis_syscall_print_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+RZ_IPI RzCmdStatus rz_analysis_syscall_dump_assembly_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_analysis_syscall_dump_c_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_analysis_syscall_name_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_analysis_syscall_number_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI int rz_cmd_analysis(void *data, const char *input);
 RZ_IPI RzCmdStatus rz_block_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_block_decrease_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/csyscall.c
+++ b/librz/core/csyscall.c
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2009-2021 pancake <pancake@nopcode.org>
+// SPDX-FileCopyrightText: 2009-2021 maijin <maijin21@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_core.h>
+
+static const char *syscallNumber(int n) {
+	return sdb_fmt(n > 1000 ? "0x%x" : "%d", n);
+}
+
+/**
+ * \brief Returns the syscall representation as a string
+ *
+ * Given the syscall number and address it resolves the syscall
+ * for the selected `asm.arch` and `asm.os` values and print
+ * its arguments.
+ *
+ * The number of the syscall can also be -1 to try to read
+ * the value of the syscall from the register that is the syscall
+ * number by the selected calling convention.
+ *
+ * \param core RzCore instance
+ * \param n number of the syscall
+ * \param addr address of the syscall
+ */
+RZ_API RZ_OWN char *rz_core_syscall_as_string(RzCore *core, st64 n, ut64 addr) {
+	int i;
+	char str[64];
+	st64 N = n;
+	int defVector = rz_syscall_get_swi(core->analysis->syscall);
+	if (defVector > 0) {
+		n = -1;
+	}
+	if (n == -1 || defVector > 0) {
+		n = (int)rz_core_reg_getv_by_role_or_name(core, "oeax");
+		if (!n || n == -1) {
+			const char *a0 = rz_reg_get_name(core->analysis->reg, RZ_REG_NAME_SN);
+			n = (a0 == NULL) ? -1 : (int)rz_core_reg_getv_by_role_or_name(core, a0);
+		}
+	}
+	RzSyscallItem *item = rz_syscall_get(core->analysis->syscall, n, defVector);
+	if (!item) {
+		item = rz_syscall_get(core->analysis->syscall, N, -1);
+	}
+	if (!item) {
+		return rz_str_newf("%s = unknown ()", syscallNumber(n));
+	}
+	char *res = rz_str_newf("%s = %s (", syscallNumber(item->num), item->name);
+	// TODO: move this to rz_syscall
+	const char *cc = rz_analysis_syscc_default(core->analysis);
+	// TODO replace the hardcoded CC with the sdb ones
+	for (i = 0; i < item->args; i++) {
+		// XXX this is a hack to make syscall args work on x86-32 and x86-64
+		// we need to shift sn first.. which is bad, but needs to be redesigned
+		int regidx = i;
+		if (core->rasm->bits == 32 && core->rasm->cur && !strcmp(core->rasm->cur->arch, "x86")) {
+			regidx++;
+		}
+		ut64 arg = rz_core_arg_get(core, cc, regidx); // TODO here
+		// rz_cons_printf ("(%d:0x%"PFMT64x")\n", i, arg);
+		if (item->sargs) {
+			switch (item->sargs[i]) {
+			case 'p': // pointer
+				res = rz_str_appendf(res, "0x%08" PFMT64x "", arg);
+				break;
+			case 'i':
+				res = rz_str_appendf(res, "%" PFMT64u "", arg);
+				break;
+			case 'z':
+				memset(str, 0, sizeof(str));
+				rz_io_read_at(core->io, arg, (ut8 *)str, sizeof(str) - 1);
+				rz_str_filter(str);
+				res = rz_str_appendf(res, "\"%s\"", str);
+				break;
+			case 'Z': {
+				// TODO replace the hardcoded CC with the sdb ones
+				ut64 len = rz_core_arg_get(core, cc, i + 2);
+				len = RZ_MIN(len + 1, sizeof(str) - 1);
+				if (len == 0) {
+					len = 16; // override default
+				}
+				(void)rz_io_read_at(core->io, arg, (ut8 *)str, len);
+				str[len] = 0;
+				rz_str_filter(str);
+				res = rz_str_appendf(res, "\"%s\"", str);
+			} break;
+			default:
+				res = rz_str_appendf(res, "0x%08" PFMT64x "", arg);
+				break;
+			}
+		} else {
+			res = rz_str_appendf(res, "0x%08" PFMT64x "", arg);
+		}
+		if (i + 1 < item->args) {
+			res = rz_str_appendf(res, ", ");
+		}
+	}
+	rz_syscall_item_free(item);
+	return rz_str_appendf(res, ")");
+}

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -4770,7 +4770,7 @@ static void ds_print_esil_analysis(RzDisasmState *ds) {
 	}
 	switch (ds->analysis_op.type) {
 	case RZ_ANALYSIS_OP_TYPE_SWI: {
-		char *s = cmd_syscall_dostr(core, ds->analysis_op.val, at);
+		char *s = rz_core_syscall_as_string(core, ds->analysis_op.val, at);
 		if (s) {
 			ds_comment_esil(ds, true, true, "; %s", s);
 			free(s);

--- a/librz/core/meson.build
+++ b/librz/core/meson.build
@@ -37,6 +37,7 @@ rz_core_sources = [
   'csign.c',
   'ctypes.c',
   'cvfile.c',
+  'csyscall.c',
   'disasm.c',
   'fortune.c',
   'gdiff.c',

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -1027,8 +1027,7 @@ RZ_API void rz_core_analysis_stats_free(RzCoreAnalStats *s);
 RZ_API int rz_line_hist_offset_up(RzLine *line);
 RZ_API int rz_line_hist_offset_down(RzLine *line);
 
-// TODO : move into debug or syscall++
-RZ_API char *cmd_syscall_dostr(RzCore *core, st64 num, ut64 addr);
+RZ_API RZ_OWN char *rz_core_syscall_as_string(RzCore *core, st64 num, ut64 addr);
 
 /* tasks */
 

--- a/test/db/esil/arm_16
+++ b/test/db/esil/arm_16
@@ -1093,7 +1093,7 @@ RUN
 NAME=arm s110 syscalls asl ascii
 FILE==
 ARGS=-aarm -b16 -easm.os=s110
-CMDS=asl sd_evt_get
+CMDS=asn sd_evt_get
 EXPECT=<<EOF
 81
 EOF
@@ -1102,7 +1102,7 @@ RUN
 NAME=arm s110 syscalls asl num
 FILE==
 ARGS=-aarm -b16 -easm.os=s110
-CMDS=asl 0x51
+CMDS=asr 0x51
 EXPECT=<<EOF
 sd_evt_get
 EOF

--- a/test/db/json/json2
+++ b/test/db/json/json2
@@ -1,6 +1,6 @@
 aoj
 arj
-asj
+aslj
 avj
 axfj
 axfj @ sym.main


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- `asj` now became `aslj`
- `ask` was removed
- `as <name>` became `asn <name>`
- `as`, `asca`, `asc` take now only the number as the argument

I have a question though - should I ignore the name argument in `asca` and `asc` completely, or return it back and allow the argument to be **either** syscall number or syscall name?

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/1442
