### PR TITLE
get_main_offset_linux_64_pie, lea: Apply `maindelta` to vaddr of `entry`

### DIFF
--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -321,7 +321,7 @@ static ut64 get_main_offset_linux_64_pie(ELFOBJ *bin, ut64 entry, ut8 *buf) {
 			ut64 vmain = (ut64)(entry + bo + maindelta) + 7;
 			ut64 ventry = Elf_(rz_bin_elf_p2v_new)(bin, entry);
 			if (vmain >> 16 == ventry >> 16) {
-				return (ut64)vmain;
+				return Elf_(rz_bin_elf_v2p_new)(bin, vmain);
 			}
 		} else if (ch == 0xc7) { // mov rdi, 0xADDR
 			ut8 *p = buf + bo + 3;

--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -315,14 +315,15 @@ static ut64 get_main_offset_linux_64_pie(ELFOBJ *bin, ut64 entry, ut8 *buf) {
 	}
 	if (buf[bo] == 0x48) {
 		ut8 ch = buf[bo + 1];
-		if (ch == 0x8d) { // lea rdi, qword [rip-0x21c4]
+		if (ch == 0x8d) { // lea rdi, qword [rip + MAINDELTA]
 			ut8 *p = buf + bo + 3;
 			st32 maindelta = (st32)rz_read_le32(p);
-			ut64 vmain = (ut64)(entry + bo + maindelta) + 7;
 			ut64 ventry = Elf_(rz_bin_elf_p2v_new)(bin, entry);
-			if (vmain >> 16 == ventry >> 16) {
-				return Elf_(rz_bin_elf_v2p_new)(bin, vmain);
+			if (ventry == UT64_MAX) {
+				return UT64_MAX;
 			}
+			ut64 vmain = (ut64)(ventry + bo + maindelta) + 7;
+			return Elf_(rz_bin_elf_v2p_new)(bin, vmain);
 		} else if (ch == 0xc7) { // mov rdi, 0xADDR
 			ut8 *p = buf + bo + 3;
 			ut64 addr = (ut64)rz_read_le32(p);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

~~This pr follows up on #2320 by making `get_main_offset_linux_64_pie()` return a physical address on `lea`.~~

This pr reworks the `lea` algo in `get_main_offset_linux_64_pie()` so that `maindelta` is applied to the virtual address of `entry`. This is because `maindelta` should only be applied in the virtual address space.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
