### PR TITLE
rz_str_casecmp was using strcmp

### DIFF
--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -66,7 +66,6 @@ RZ_API const char *rz_str_enc_as_string(RzStrEnc enc) {
 }
 
 RZ_API int rz_str_casecmp(const char *s1, const char *s2) {
-	int res;
 #ifdef _MSC_VER
 	return stricmp(s1, s2);
 #else

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -68,14 +68,10 @@ RZ_API const char *rz_str_enc_as_string(RzStrEnc enc) {
 RZ_API int rz_str_casecmp(const char *s1, const char *s2) {
 	int res;
 #ifdef _MSC_VER
-	res = stricmp(s1, s2);
+	return stricmp(s1, s2);
 #else
-	res = strcasecmp(s1, s2);
+	return strcasecmp(s1, s2);
 #endif
-	if (res == 0) {
-		res = strcmp(s1, s2);
-	}
-	return res;
 }
 
 RZ_API int rz_str_ncasecmp(const char *s1, const char *s2, size_t n) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`rz_str_casecmp` was using `strcmp` when the 2 strings were matching which defeats the purpose of case insensitive string compare