### PR TITLE
Drop `scr.interactive` requirement for `s` error

### DIFF
--- a/librz/core/cmd/cmd_seek.c
+++ b/librz/core/cmd/cmd_seek.c
@@ -174,9 +174,7 @@ RZ_IPI RzCmdStatus rz_seek_handler(RzCore *core, int argc, const char **argv) {
 
 	ut64 addr = rz_num_math(core->num, argv[1]);
 	if (core->num->nc.errors) {
-		if (rz_cons_singleton()->context->is_interactive) {
-			eprintf("Cannot seek to unknown address '%s'\n", core->num->nc.calc_buf);
-		}
+		RZ_LOG_ERROR("Cannot seek to unknown address '%s'\n", core->num->nc.calc_buf);
 		return RZ_CMD_STATUS_ERROR;
 	}
 	return bool2cmdstatus(rz_core_seek_and_save(core, addr, true));

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -4969,7 +4969,6 @@ RUN
 NAME=iee elf Cd (64-bit)
 FILE=bins/elf/analysis/ls-linux64
 CMDS=<<EOF
-e scr.interactive=true
 s section..preinit_array
 ?e
 pD $SS @ section..init_array
@@ -4987,7 +4986,7 @@ EXPECT=<<EOF
             0x0021bfb0      .qword 0x0000000000005ce0 ; entry.fini0    ; RELOC 64  ; [19] -rw- section size 8 named .fini_array
 EOF
 EXPECT_ERR=<<EOF
-Cannot seek to unknown address 'section..preinit_array'
+ERROR: Cannot seek to unknown address 'section..preinit_array'
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr drops the `scr.interactive` requirement for the "Cannot seek to unknown address" `s` error.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
