### PR TITLE
Refactor Arm IT handling and fix for 4-byte ops

### DIFF
--- a/librz/asm/arch/arm/arm_it.c
+++ b/librz/asm/arch/arm/arm_it.c
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2022 Florian Märkl <info@florianmaerkl.de>
+// SPDX-FileCopyrightText: 2013-2018 pancake <pancake@nopcode.org>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include "arm_it.h"
+
+typedef union arm_cs_itblock_t {
+	ut8 off[4]; ///< offsets of the up to 4 conditioned instructions from the addr of the it, 0-terminated if less than 4.
+	ut64 packed; ///< for putting into HtUU
+} ArmCSITBlock;
+
+typedef union arm_cs_itcond_t {
+	struct {
+		ut32 cond; ///< arm_cc
+		ut8 off; ///< offset of this instruction from the it, for back-referencing to the ArmCSITBlock
+	};
+	ut64 packed; ///< for putting into HtUU
+} ArmCSITCond;
+
+RZ_API void rz_arm_it_context_init(RzArmITContext *ctx) {
+	ctx->ht_itcond = ht_uu_new0();
+	ctx->ht_itblock = ht_uu_new0();
+}
+
+RZ_API void rz_arm_it_context_fini(RzArmITContext *ctx) {
+	ht_uu_free(ctx->ht_itblock);
+	ht_uu_free(ctx->ht_itcond);
+}
+
+/**
+ * Signal a newly detected IT block
+ * \p insn must be ARM_INS_IT
+ */
+RZ_API void rz_arm_it_update_block(RzArmITContext *ctx, cs_insn *insn) {
+	rz_return_if_fail(ctx && insn && insn->id == ARM_INS_IT);
+	bool found;
+	ht_uu_find(ctx->ht_itblock, insn->address, &found);
+	if (found) {
+		return;
+	}
+	ArmCSITBlock block = { 0 };
+	size_t size = rz_str_nlen(insn->mnemonic, 5);
+	for (size_t i = 1; i < size; i++) {
+		// At this point, we can't know whether each instruction in the block
+		// is 2 or 4 bytes. We build up everything for 2 bytes for now and if
+		// we later encounter a 4 byte instruction with a condition inside of it,
+		// we readjust everything accordingly.
+		ArmCSITCond cond = { 0 };
+		cond.off = block.off[i - 1] = 2 * i;
+		switch (insn->mnemonic[i]) {
+		case 0x74: //'t'
+			cond.cond = insn->detail->arm.cc;
+			break;
+		case 0x65: //'e'
+			cond.cond = (insn->detail->arm.cc % 2) ? insn->detail->arm.cc + 1 : insn->detail->arm.cc - 1;
+			break;
+		default:
+			break;
+		}
+		RZ_STATIC_ASSERT(sizeof(cond) == sizeof(cond.packed));
+		ht_uu_update(ctx->ht_itcond, insn->address + cond.off, cond.packed);
+	}
+	RZ_STATIC_ASSERT(sizeof(block) == sizeof(block.packed));
+	ht_uu_update(ctx->ht_itblock, insn->address, block.packed);
+}
+
+/**
+ * Signal that a non-IT instruction was disassembled and clear any block at the same address.
+ */
+RZ_API void rz_arm_it_update_nonblock(RzArmITContext *ctx, cs_insn *insn) {
+	rz_return_if_fail(ctx && insn);
+	bool found;
+	ArmCSITBlock block = { .packed = ht_uu_find(ctx->ht_itblock, insn->address, &found) };
+	if (!found) {
+		return;
+	}
+	for (size_t i = 0; i < 4 && block.off[i]; i++) {
+		ht_uu_delete(ctx->ht_itcond, insn->address + block.off[i]);
+	}
+	ht_uu_delete(ctx->ht_itblock, insn->address);
+}
+
+/**
+ * Apply any previously tracked IT condition to \p insn
+ * \return true if a condition was found and applied
+ */
+RZ_API bool rz_arm_it_apply_cond(RzArmITContext *ctx, cs_insn *insn) {
+	const ut64 addr = insn->address;
+	bool found;
+	ArmCSITCond cond = { .packed = ht_uu_find(ctx->ht_itcond, addr, &found) };
+	if (!found) {
+		return false;
+	}
+	insn->detail->arm.cc = cond.cond;
+	insn->detail->arm.update_flags = 0;
+
+	// Readjust if we detected that the previous assumption of all-2-byte instructions in
+	// analysis_itblock() was incorrect. See also the comment there.
+	if (insn->size != 4) {
+		return true;
+	}
+	cond.packed = ht_uu_find(ctx->ht_itcond, addr + 2, &found);
+	if (!found) {
+		// Everything fine, nothing to adjust
+		return true;
+	}
+	// Now readjust everything starting with the addr+2 cond
+	ut64 blockaddr = addr + 2 - cond.off;
+	ArmCSITBlock itblock = { .packed = ht_uu_find(ctx->ht_itblock, blockaddr, &found) };
+	if (!found) {
+		return true;
+	}
+	for (size_t i = 0; i < 4; i++) {
+		size_t idx = 3 - i; // Reverse loop so we don't overwrite anything by accident
+		if (!itblock.off[idx]) {
+			continue;
+		}
+		if (itblock.off[idx] < cond.off) {
+			break;
+		}
+		ArmCSITCond adjcond = { .packed = ht_uu_find(ctx->ht_itcond, blockaddr + itblock.off[idx], &found) };
+		if (!found) {
+			continue;
+		}
+		ht_uu_delete(ctx->ht_itcond, blockaddr + itblock.off[idx]);
+		adjcond.off = itblock.off[idx] += 2;
+		ht_uu_update(ctx->ht_itcond, blockaddr + itblock.off[idx], adjcond.packed);
+	}
+	ht_uu_update(ctx->ht_itblock, blockaddr, itblock.packed);
+	return true;
+}

--- a/librz/asm/arch/arm/arm_it.h
+++ b/librz/asm/arch/arm/arm_it.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2022 Florian Märkl <info@florianmaerkl.de>
+// SPDX-FileCopyrightText: 2013-2018 pancake <pancake@nopcode.org>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef RZ_ARM_IT_H
+
+/**
+ * \file
+ * Tracking of Arm thumb IT blocks during disassembly.
+ * Note: all of this is really just a best guess approach.
+ */
+
+#include <rz_util.h>
+#include <ht_uu.h>
+#include <capstone.h>
+
+typedef struct rz_arm_it_context_t {
+	HtUU *ht_itblock; ///< addr -> ArmCSITBlock
+	HtUU *ht_itcond; ///< addr -> ArmCSITCond
+} RzArmITContext;
+
+RZ_API void rz_arm_it_context_init(RzArmITContext *ctx);
+RZ_API void rz_arm_it_context_fini(RzArmITContext *ctx);
+RZ_API void rz_arm_it_update_block(RzArmITContext *ctx, cs_insn *insn);
+RZ_API void rz_arm_it_update_nonblock(RzArmITContext *ctx, cs_insn *insn);
+RZ_API bool rz_arm_it_apply_cond(RzArmITContext *ctx, cs_insn *insn);
+
+#endif

--- a/librz/asm/meson.build
+++ b/librz/asm/meson.build
@@ -135,6 +135,7 @@ rz_asm_sources = [
   'arch/8051/8051_ass.c',
   'arch/arm/armass.c',
   'arch/arm/armass64.c',
+  'arch/arm/arm_it.c',
   'arch/avr/disassembler.c',
   'arch/avr/assembler.c',
   'arch/cr16/cr16_disas.c',

--- a/librz/asm/p/asm_arm_cs.c
+++ b/librz/asm/p/asm_arm_cs.c
@@ -6,11 +6,11 @@
 #include <ht_uu.h>
 #include <capstone.h>
 #include "../arch/arm/asm-arm.h"
+#include "../arch/arm/arm_it.h"
 #include "./asm_arm_hacks.inc"
 
 typedef struct arm_cs_context_t {
-	HtUU *ht_itblock;
-	HtUU *ht_it;
+	RzArmITContext it;
 	csh cd;
 	int omode;
 	int obits;
@@ -83,38 +83,6 @@ static const char *cc_name(arm_cc cc) {
 	}
 }
 
-static void disass_itblock(RzAsm *a, cs_insn *insn) {
-	ArmCSContext *ctx = (ArmCSContext *)a->plugin_data;
-	size_t i, size;
-	size = rz_str_nlen(insn->mnemonic, 5);
-	ht_uu_update(ctx->ht_itblock, a->pc, size);
-	for (i = 1; i < size; i++) {
-		switch (insn->mnemonic[i]) {
-		case 0x74: //'t'
-			ht_uu_update(ctx->ht_it, a->pc + (i * insn->size), insn->detail->arm.cc);
-			break;
-		case 0x65: //'e'
-			ht_uu_update(ctx->ht_it, a->pc + (i * insn->size), (insn->detail->arm.cc % 2) ? insn->detail->arm.cc + 1 : insn->detail->arm.cc - 1);
-			break;
-		default:
-			break;
-		}
-	}
-}
-
-static void check_itblock(RzAsm *a, cs_insn *insn) {
-	ArmCSContext *ctx = (ArmCSContext *)a->plugin_data;
-	size_t x;
-	bool found;
-	ut64 itlen = ht_uu_find(ctx->ht_itblock, a->pc, &found);
-	if (found) {
-		for (x = 1; x < itlen; x++) {
-			ht_uu_delete(ctx->ht_it, a->pc + (x * insn->size));
-		}
-		ht_uu_delete(ctx->ht_itblock, a->pc);
-	}
-}
-
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	ArmCSContext *ctx = (ArmCSContext *)a->plugin_data;
 
@@ -122,10 +90,9 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	cs_insn *insn = NULL;
 	cs_mode mode = 0;
 	int ret, n = 0;
-	bool found = false;
-	ut64 itcond;
 
-	mode |= (a->bits == 16) ? CS_MODE_THUMB : CS_MODE_ARM;
+	bool thumb = a->bits == 16;
+	mode |= thumb ? CS_MODE_THUMB : CS_MODE_ARM;
 	mode |= (a->big_endian) ? CS_MODE_BIG_ENDIAN : CS_MODE_LITTLE_ENDIAN;
 	if (mode != ctx->omode || a->bits != ctx->obits) {
 		cs_close(&ctx->cd);
@@ -188,17 +155,14 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	if (op && !op->size) {
 		op->size = insn->size;
 		if (insn->id == ARM_INS_IT) {
-			disass_itblock(a, insn);
+			rz_arm_it_update_block(&ctx->it, insn);
 		} else {
-			check_itblock(a, insn);
+			rz_arm_it_update_nonblock(&ctx->it, insn);
 		}
-		itcond = ht_uu_find(ctx->ht_it, a->pc, &found);
-		if (found) {
-			insn->detail->arm.cc = itcond;
-			insn->detail->arm.update_flags = 0;
+		if (thumb && rz_arm_it_apply_cond(&ctx->it, insn)) {
 			char *tmpstr = rz_str_newf("%s%s",
 				cs_insn_name(ctx->cd, insn->id),
-				cc_name(itcond));
+				cc_name(insn->detail->arm.cc));
 			rz_str_cpy(insn->mnemonic, tmpstr);
 			free(tmpstr);
 		}
@@ -277,8 +241,7 @@ static bool arm_init(void **user) {
 	if (!ctx) {
 		return false;
 	}
-	ctx->ht_it = ht_uu_new0();
-	ctx->ht_itblock = ht_uu_new0();
+	rz_arm_it_context_init(&ctx->it);
 	ctx->cd = 0;
 	ctx->omode = -1;
 	ctx->obits = 32;
@@ -290,8 +253,7 @@ static bool arm_fini(void *user) {
 	rz_return_val_if_fail(user, false);
 	ArmCSContext *ctx = (ArmCSContext *)user;
 	cs_close(&ctx->cd);
-	ht_uu_free(ctx->ht_itblock);
-	ht_uu_free(ctx->ht_it);
+	rz_arm_it_context_fini(&ctx->it);
 	free(ctx);
 	return true;
 }

--- a/test/db/analysis/arm
+++ b/test/db/analysis/arm
@@ -1113,3 +1113,40 @@ EXPECT=<<EOF
 2
 EOF
 RUN
+
+NAME=arm thumb it tracking
+FILE=malloc://0x1000
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=16
+s 0x100
+wx 54bf53f8182c52181846
+pi 4
+ao @ 0x102~mnemonic
+ao @ 0x106~mnemonic
+ao @ 0x108~mnemonic
+?e -- Update after code change
+wx 1846
+pi 4
+ao @ 0x102~mnemonic
+ao @ 0x106~mnemonic
+ao @ 0x108~mnemonic
+EOF
+EXPECT=<<EOF
+ite pl
+ldrpl r2, [r3, -0x18]
+addmi r2, r2, r1
+mov r0, r3
+mnemonic: ldrpl
+mnemonic: addmi
+mnemonic: mov
+-- Update after code change
+mov r0, r3
+ldr r2, [r3, -0x18]
+adds r2, r2, r1
+mov r0, r3
+mnemonic: ldr
+mnemonic: adds
+mnemonic: mov
+EOF
+RUN


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The code was duplicated in both asm and anylsis, so now it's in
arm_it.c.
Previously, conditions were applied to N offsets after an IT instruction
using a fixed stride of 2 bytes. This obviously breaks for 4-byte thumb2
instructions, but whenever we find such an instruction, we can check if
there is a condition inside of it and readjust if necessary.

**Test plan**

see the added test