### PR TITLE
Make CMake config generation optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,7 @@ project('rizin', 'c',
 py3_exe = import('python').find_installation()
 git_exe = find_program('git', required: false)
 pkgconfig_mod = import('pkgconfig')
-cmake_mod = import('cmake')
+cmake_mod = import('cmake', required: false)
 
 # Python scripts used during the build process
 create_tags_rz_py = files('sys/create_tags_rz.py')


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Generate CMake config files only if the `cmake` Meson module is installed and active. It's a necessary prerequisite for the Muon build system support since there are no near term plans to implement CMake support in it: https://todo.sr.ht/~lattis/muon/24

**Test plan**

CI is green

Partially addresses https://github.com/rizinorg/ideas/issues/18