### PR TITLE
Fix Meson subprojects language option

### DIFF
--- a/subprojects/mpc/meson.build
+++ b/subprojects/mpc/meson.build
@@ -1,4 +1,4 @@
-project('mpc', version: 'd59264ae27228176f5b731871df1a87d7abbb5c8')
+project('mpc', 'c', version: 'd59264ae27228176f5b731871df1a87d7abbb5c8')
 
 mpc_files = [
   'mpc.c'

--- a/subprojects/packagefiles/libzip-1.7.3/meson.build
+++ b/subprojects/packagefiles/libzip-1.7.3/meson.build
@@ -1,4 +1,4 @@
-project('libzip', ['c'],
+project('libzip', 'c',
   default_options : ['c_std=c99', 'buildtype=release'],
   version: '1.7.3')
 

--- a/subprojects/packagefiles/tree-sitter-c/meson.build
+++ b/subprojects/packagefiles/tree-sitter-c/meson.build
@@ -1,4 +1,4 @@
-project('tree-sitter-c', version: 'f05e279aedde06a25801c3f2b2cc8ac17fac52ae', default_options: ['werror=false'])
+project('tree-sitter-c', 'c', version: 'f05e279aedde06a25801c3f2b2cc8ac17fac52ae', default_options: ['werror=false'])
 
 ts_c_files = [
   'src/parser.c'


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes missing language definition for every subproject. Prerequisite to Muon building, see https://todo.sr.ht/~lattis/muon/38 for more details.

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/ideas/issues/18
