### PR TITLE
Fix UB in rz_bv_set_all(..., 64)

### DIFF
--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -351,7 +351,7 @@ RZ_API bool rz_bv_set_all(RZ_NONNULL RzBitVector *bv, bool b) {
 	rz_return_val_if_fail(bv, false);
 
 	if (bv->len <= 64) {
-		bv->bits.small_u = b ? (UT64_MAX & ((1ull << bv->len) - 1)) : 0;
+		bv->bits.small_u = b ? UT64_MAX >> (64 - bv->len) : 0;
 		return b;
 	}
 

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -952,6 +952,38 @@ static bool test_rz_bv_len_bytes(void) {
 	mu_end;
 }
 
+bool test_rz_bv_set_all(void) {
+	RzBitVector *bv = rz_bv_new(43);
+	rz_bv_set_all(bv, true);
+	mu_assert_streq_free(rz_bv_as_hex_string(bv, false), "0x7ffffffffff", "set all 1");
+	rz_bv_set_all(bv, false);
+	mu_assert_streq_free(rz_bv_as_hex_string(bv, false), "0x0", "set all 0");
+	rz_bv_free(bv);
+
+	bv = rz_bv_new(64);
+	rz_bv_set_all(bv, true);
+	mu_assert_streq_free(rz_bv_as_hex_string(bv, false), "0xffffffffffffffff", "set all 1");
+	rz_bv_set_all(bv, false);
+	mu_assert_streq_free(rz_bv_as_hex_string(bv, false), "0x0", "set all 0");
+	rz_bv_free(bv);
+
+	bv = rz_bv_new(73);
+	rz_bv_set_all(bv, true);
+	mu_assert_streq_free(rz_bv_as_hex_string(bv, false), "0x1ffffffffffffffffff", "set all 1");
+	rz_bv_set_all(bv, false);
+	mu_assert_streq_free(rz_bv_as_hex_string(bv, false), "0x0", "set all 0");
+	rz_bv_free(bv);
+
+	bv = rz_bv_new(80);
+	rz_bv_set_all(bv, true);
+	mu_assert_streq_free(rz_bv_as_hex_string(bv, false), "0xffffffffffffffffffff", "set all 1");
+	rz_bv_set_all(bv, false);
+	mu_assert_streq_free(rz_bv_as_hex_string(bv, false), "0x0", "set all 0");
+	rz_bv_free(bv);
+
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_rz_bv_init32);
 	mu_run_test(test_rz_bv_init64);
@@ -973,6 +1005,7 @@ bool all_tests() {
 	mu_run_test(test_rz_bv_div);
 	mu_run_test(test_rz_bv_mod);
 	mu_run_test(test_rz_bv_len_bytes);
+	mu_run_test(test_rz_bv_set_all);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Shifting a 64-bit value by 64 bits is UB. Restructuring it like this is
fine because the bv len must never be 0.