### PR TITLE
Fix trailing bits in rz_bv_set_to_bytes_le()

### DIFF
--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -1302,14 +1302,23 @@ RZ_API void rz_bv_set_to_bytes_le(RZ_NONNULL const RzBitVector *bv, RZ_OUT RZ_NO
 	ut32 bytes = rz_bv_len_bytes(bv);
 	if (bv->len > 64) {
 		for (ut32 i = 0; i < bytes; i++) {
-			ut8 b8 = bv->bits.large_a[i];
-			buf[i] = reverse_byte(b8);
+			if (i + 1 == bytes && bv->len % 8) {
+				buf[i] &= (0xff << (bv->len % 8)) & 0xff;
+				buf[i] |= bv->bits.large_a[i];
+			} else {
+				buf[i] = bv->bits.large_a[i];
+			}
 		}
 		return;
 	}
 	ut64 val = bv->bits.small_u;
 	for (ut32 i = 0; i < bytes; i++) {
-		buf[i] = val & 0xFF;
+		if (i + 1 == bytes && bv->len % 8) {
+			buf[i] &= (0xff << (bv->len % 8)) & 0xff;
+			buf[i] |= val & 0xff;
+		} else {
+			buf[i] = val & 0xff;
+		}
 		val >>= 8;
 	}
 }
@@ -1325,8 +1334,7 @@ RZ_API void rz_bv_set_to_bytes_be(RZ_NONNULL const RzBitVector *bv, RZ_OUT RZ_NO
 	if (bv->len > 64) {
 		ut32 end = bytes - 1;
 		for (ut32 i = 0; i < bytes; i++) {
-			ut8 b8 = bv->bits.large_a[i];
-			buf[end - i] = reverse_byte(b8);
+			buf[end - i] = bv->bits.large_a[i];
 		}
 		return;
 	}

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -980,7 +980,53 @@ bool test_rz_bv_set_all(void) {
 	rz_bv_set_all(bv, false);
 	mu_assert_streq_free(rz_bv_as_hex_string(bv, false), "0x0", "set all 0");
 	rz_bv_free(bv);
+	mu_end;
+}
 
+static bool test_rz_bv_set_to_bytes_le(void) {
+	{
+		ut8 buf8[8] = { 0 };
+		RzBitVector *bv = rz_bv_new_from_ut64(64, 0xc0ffee4201234567);
+		rz_bv_set_to_bytes_le(bv, buf8);
+		const ut8 expect8[8] = { 0x67, 0x45, 0x23, 0x01, 0x42, 0xee, 0xff, 0xc0 };
+		mu_assert_memeq(buf8, expect8, sizeof(expect8), "set to bytes le");
+		rz_bv_free(bv);
+	}
+	{
+		ut8 buf4[4] = { 0 };
+		RzBitVector *bv = rz_bv_new_from_ut64(32, 0xc0ffee42);
+		rz_bv_set_to_bytes_le(bv, buf4);
+		const ut8 expect4[4] = { 0x42, 0xee, 0xff, 0xc0 };
+		mu_assert_memeq(buf4, expect4, sizeof(expect4), "set to bytes le");
+		rz_bv_free(bv);
+	}
+	{
+		ut8 buf2[2] = { 0xff, 0xff }; // make sure these trailing bits are not overwritten
+		RzBitVector *bv = rz_bv_new_from_ut64(13, 0x0);
+		rz_bv_set_to_bytes_le(bv, buf2);
+		const ut8 expect2[2] = { 0x0, 0xe0 };
+		mu_assert_memeq(buf2, expect2, sizeof(expect2), "set to bytes le");
+		rz_bv_free(bv);
+	}
+	{
+		ut8 buf9[9] = { 0 };
+		RzBitVector *bv = rz_bv_new_from_ut64(64 + 8, 0xc0ffee4200000000);
+		rz_bv_lshift_fill(bv, 8, true);
+		rz_bv_set_to_bytes_le(bv, buf9);
+		const ut8 expect9[9] = { 0xff, 0x00, 0x00, 0x00, 0x00, 0x42, 0xee, 0xff, 0xc0 };
+		mu_assert_memeq(buf9, expect9, sizeof(expect9), "set to bytes le");
+		rz_bv_free(bv);
+	}
+	{
+		ut8 buf9[9] = { 0 };
+		buf9[8] = 0xff; // make sure these trailing bits are not overwritten
+		RzBitVector *bv = rz_bv_new_from_ut64(64 + 6, 0xffffee00000000);
+		rz_bv_lshift_fill(bv, 8, true);
+		rz_bv_set_to_bytes_le(bv, buf9);
+		const ut8 expect9[9] = { 0xff, 0x00, 0x00, 0x00, 0x00, 0xee, 0xff, 0xff, 0xc0 };
+		mu_assert_memeq(buf9, expect9, sizeof(expect9), "set to bytes le");
+		rz_bv_free(bv);
+	}
 	mu_end;
 }
 
@@ -1006,6 +1052,7 @@ bool all_tests() {
 	mu_run_test(test_rz_bv_mod);
 	mu_run_test(test_rz_bv_len_bytes);
 	mu_run_test(test_rz_bv_set_all);
+	mu_run_test(test_rz_bv_set_to_bytes_le);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Any traling bits in the last byte that is to be written should be left
alone.
