### PR TITLE
Optimize parsing flirt sig files when just reading header infos

### DIFF
--- a/librz/include/rz_flirt.h
+++ b/librz/include/rz_flirt.h
@@ -229,6 +229,7 @@ typedef struct rz_flirt_compressed_options_t {
 	const char *libname;
 } RzFlirtCompressedOptions;
 
+RZ_API RZ_OWN bool rz_sign_flirt_parse_header_compressed_pattern_from_buffer(RZ_NONNULL RzBuffer *flirt_buf, RZ_NONNULL RzFlirtInfo *info);
 RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_compressed_pattern_from_buffer(RZ_NONNULL RzBuffer *flirt_buf, ut8 expected_arch, RZ_NULLABLE RzFlirtInfo *info);
 RZ_API bool rz_sign_flirt_write_compressed_pattern_to_buffer(RZ_NONNULL const RzFlirtNode *node, RZ_NONNULL RzBuffer *buffer, RzFlirtCompressedOptions *options);
 

--- a/librz/signature/sigdb.c
+++ b/librz/signature/sigdb.c
@@ -59,9 +59,9 @@ static bool sigdb_signature_resolve_details(RzSigDBEntry *entry, size_t path_len
 	}
 
 	if (rz_str_endswith(entry->base_name, ".sig")) {
-		node = rz_sign_flirt_parse_compressed_pattern_from_buffer(buffer, RZ_FLIRT_SIG_ARCH_ANY, &info);
+		bool success = rz_sign_flirt_parse_header_compressed_pattern_from_buffer(buffer, &info);
 		rz_buf_free(buffer);
-		if (!node) {
+		if (!success) {
 			return false;
 		}
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This PR optimizes the flirt header parsing when handling sigdb data to avoid long load times