### PR TITLE
RzCmd: add support for dynamically generated details sections

### DIFF
--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -6019,7 +6019,6 @@ RZ_API void rz_core_cmd_init(RzCore *core) {
 		RzCmdCb cb;
 	} cmds[] = {
 		{ "_", "print last output", rz_cmd_last },
-		{ "#", "calculate hash", rz_cmd_hash },
 		{ "$", "alias", rz_cmd_alias },
 		{ "%", "short version of 'env' command", rz_cmd_env },
 		{ "&", "tasks", rz_cmd_tasks },

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -614,7 +614,6 @@ static const RzCmdDescArg hash_bang_args[] = {
 	{
 		.name = "interpreter-name",
 		.type = RZ_CMD_ARG_TYPE_STRING,
-		.optional = true,
 		.no_space = true,
 
 	},
@@ -628,8 +627,9 @@ static const RzCmdDescArg hash_bang_args[] = {
 	{ 0 },
 };
 static const RzCmdDescHelp hash_bang_help = {
-	.summary = "List all available interpreters / Run interpreter",
+	.summary = "Run interpreter",
 	.details = hash_bang_details,
+	.details_cb = rz_hash_bang_details_cb,
 	.args = hash_bang_args,
 };
 

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -14,6 +14,7 @@ RZ_IPI RzCmdStatus rz_system_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_system_to_cons_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_last_output_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_hash_bang_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdDescDetail *rz_hash_bang_details_cb(RzCore *core, int argc, const char **argv);
 RZ_IPI int rz_cmd_alias(void *data, const char *input);
 RZ_IPI RzCmdStatus rz_cmd_shell_env_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_tasks_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);

--- a/librz/core/cmd_descs/cmd_descs.yaml
+++ b/librz/core/cmd_descs/cmd_descs.yaml
@@ -72,11 +72,10 @@ commands:
     args: []
   - name: "#!"
     cname: hash_bang
-    summary: List all available interpreters / Run interpreter
+    summary: Run interpreter
     args:
       - name: interpreter-name
         type: RZ_CMD_ARG_TYPE_STRING
-        optional: true
         no_space: true
       - name: arg
         type: RZ_CMD_ARG_TYPE_STRING
@@ -94,6 +93,7 @@ commands:
           - text: "#!"
             arg_str: "python foo.py arg1"
             comment: Run foo.py python script and pass it arg1 as argument
+    details_cb: rz_hash_bang_details_cb
   - name: $
     cname: cmd_alias
     summary: Alias commands and strings

--- a/librz/core/cmd_descs/cmd_descs_generate.py
+++ b/librz/core/cmd_descs/cmd_descs_generate.py
@@ -183,8 +183,7 @@ class Arg:
         if self.type == "RZ_CMD_ARG_TYPE_CHOICES":
             return self.cd.cname + "_" + compute_cname(self.name) + "_choices"
 
-        raise Exception(
-            "_get_choices_cname should be called on ARG_TYPE_CHOICES only")
+        raise Exception("_get_choices_cname should be called on ARG_TYPE_CHOICES only")
 
     def _get_union(self):
         if self.type == "RZ_CMD_ARG_TYPE_CHOICES":
@@ -415,8 +414,7 @@ class CmdDesc:
 
     def _validate(self, c):
         if c.keys():
-            print("Command %s has unrecognized properties: %s." %
-                  (self.name, c.keys()))
+            print("Command %s has unrecognized properties: %s." % (self.name, c.keys()))
             sys.exit(1)
 
         if self.type not in CD_VALID_TYPES:
@@ -452,8 +450,7 @@ class CmdDesc:
             sys.exit(1)
 
         if self.cname in CmdDesc.c_cds:
-            print("Another command already has the same cname as %s" %
-                  (self.cname,))
+            print("Another command already has the same cname as %s" % (self.cname,))
             sys.exit(1)
 
         if (
@@ -494,8 +491,7 @@ class CmdDesc:
             out += "\n".join([d.get_cstructure() for d in self.details])
             out += DESC_HELP_DETAILS_TEMPLATE.format(
                 cname=CmdDesc.get_detail_cname(self),
-                details=",\n".join([str(d)
-                                    for d in self.details] + ["\t{ 0 },"]),
+                details=",\n".join([str(d) for d in self.details] + ["\t{ 0 },"]),
             )
             details_cname = CmdDesc.get_detail_cname(self)
         elif self.details_alias is not None:
@@ -503,8 +499,7 @@ class CmdDesc:
 
         if self.args is not None:
             out += "\n".join(
-                [a.get_cstructure()
-                 for a in self.args if a.get_cstructure() != ""]
+                [a.get_cstructure() for a in self.args if a.get_cstructure() != ""]
             )
             out += DESC_HELP_ARGS_TEMPLATE.format(
                 cname=CmdDesc.get_arg_cname(self),
@@ -522,8 +517,7 @@ class CmdDesc:
             else ""
         )
         args_str = (
-            DESC_HELP_TEMPLATE_ARGS_STR.format(
-                args_str=strornull(self.args_str))
+            DESC_HELP_TEMPLATE_ARGS_STR.format(args_str=strornull(self.args_str))
             if self.args_str is not None
             else ""
         )
@@ -638,17 +632,14 @@ def createcd_typegroup(cd):
             cname=cd.cname,
             parent_cname=cd.parent.cname,
             name=strornull(cd.name),
-            handler_cname=(
-                cd.exec_cd and cd.exec_cd.get_handler_cname()) or "NULL",
-            help_cname_ref=(cd.exec_cd and "&" +
-                            cd.exec_cd.get_help_cname()) or "NULL",
+            handler_cname=(cd.exec_cd and cd.exec_cd.get_handler_cname()) or "NULL",
+            help_cname_ref=(cd.exec_cd and "&" + cd.exec_cd.get_help_cname()) or "NULL",
             group_help_cname=cd.get_help_cname(),
         )
         subcommands = (
             cd.exec_cd and cd.subcommands and cd.subcommands[1:]
         ) or cd.subcommands
-        formatted_string += "\n".join([createcd(child)
-                                       for child in subcommands or []])
+        formatted_string += "\n".join([createcd(child) for child in subcommands or []])
 
     return formatted_string
 
@@ -743,9 +734,10 @@ def detail2decl(cd):
 def handler2decl(cd, cd_type, handler_name):
     out = []
     if cd_type == CD_TYPE_ARGV:
-        out.append("RZ_IPI RzCmdStatus %s(RzCore *core, int argc, const char **argv);" % (
-            handler_name,
-        ))
+        out.append(
+            "RZ_IPI RzCmdStatus %s(RzCore *core, int argc, const char **argv);"
+            % (handler_name,)
+        )
     if cd_type == CD_TYPE_ARGV_MODES:
         out.append(
             "RZ_IPI RzCmdStatus %s(RzCore *core, int argc, const char **argv, RzOutputMode mode);"
@@ -760,10 +752,12 @@ def handler2decl(cd, cd_type, handler_name):
         out.append("RZ_IPI int %s(void *data, const char *input);" % (handler_name,))
 
     if cd.details_cb is not None:
-        out.append("RZ_IPI RzCmdDescDetail *%s(RzCore *core, int argc, const char **argv);" % (
-            cd.details_cb,))
+        out.append(
+            "RZ_IPI RzCmdDescDetail *%s(RzCore *core, int argc, const char **argv);"
+            % (cd.details_cb,)
+        )
 
-    return '\n'.join(out) if out != [] else None
+    return "\n".join(out) if out != [] else None
 
 
 parser = argparse.ArgumentParser(
@@ -772,8 +766,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument(
     "--src-output-dir", type=str, required=False, help="Source output directory"
 )
-parser.add_argument("--output-dir", type=str,
-                    required=True, help="Output directory")
+parser.add_argument("--output-dir", type=str, required=True, help="Output directory")
 parser.add_argument(
     "yaml_files",
     type=argparse.FileType("r"),
@@ -814,7 +807,8 @@ handlers_decls = filter(
 
 hf_text = CMDDESCS_H_TEMPLATE.format(
     handlers_declarations="\n".join(
-        [handler2decl(cd, t, h) for cd, t, h in handlers_decls]),
+        [handler2decl(cd, t, h) for cd, t, h in handlers_decls]
+    ),
 )
 with open(os.path.join(args.output_dir, "cmd_descs.h"), "w", encoding="utf8") as f:
     f.write(hf_text)

--- a/librz/core/cmd_descs/cmd_descs_generate.py
+++ b/librz/core/cmd_descs/cmd_descs_generate.py
@@ -757,7 +757,7 @@ def handler2decl(cd, cd_type, handler_name):
             % (cd.details_cb,)
         )
 
-    return "\n".join(out) if out != [] else None
+    return "\n".join(out) if out else None
 
 
 parser = argparse.ArgumentParser(

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -204,6 +204,13 @@ typedef struct rz_cmd_desc_detail_t {
 } RzCmdDescDetail;
 
 /**
+ * Callback used to dynamically generate the details sections in the help of a command.
+ * NOTE: The array of RzCmdDescDetail returned will be freed, so all fields
+ * within need to be dynamically allocated even if they are marked as `const`.
+ */
+typedef RZ_OWN RzCmdDescDetail *(*RzCmdDescDetailCb)(RzCore *core, int argc, const char **argv);
+
+/**
  * A description of an argument of a RzCmdDesc.
  */
 typedef struct rz_cmd_desc_arg_t {
@@ -317,6 +324,15 @@ typedef struct rz_cmd_desc_help_t {
 	 * Optional.
 	 */
 	const RzCmdDescDetail *details;
+	/**
+	 * Function that returns an array of details sections used to better explain
+	 * how to use the command. This is shown together with the long description
+	 * and can be used in addition or in alternative of \p details , when the
+	 * output needs to be generated dynamically.
+	 *
+	 * Optional.
+	 */
+	RzCmdDescDetailCb details_cb;
 	/**
 	 * Description of the arguments accepted by this command.
 	 */
@@ -548,6 +564,8 @@ RZ_API void rz_cmd_foreach_cmdname(RzCmd *cmd, RzCmdDesc *begin, RzCmdForeachNam
 RZ_API const RzCmdDescArg *rz_cmd_desc_get_arg(RzCmd *cmd, const RzCmdDesc *cd, size_t i);
 
 #define rz_cmd_desc_children_foreach(root, it_cd) rz_pvector_foreach (&root->children, it_cd)
+
+RZ_API void rz_cmd_desc_details_free(RzCmdDescDetail *details);
 
 /* RzCmdParsedArgs */
 RZ_API RzCmdParsedArgs *rz_cmd_parsed_args_new(const char *cmd, int n_args, char **args);

--- a/test/db/cmd/cmd_help
+++ b/test/db/cmd/cmd_help
@@ -544,7 +544,7 @@ CMDS=<<EOF
 .?~macro-arg
 EOF
 EXPECT=<<EOF
-| #![<interpreter-name> [<arg1> <arg2> ...]] # List all available interpreters / Run interpreter
+| #!<interpreter-name> [<arg1> <arg2> ...] # Run interpreter
 | .(<macro-name> [<macro-arg1> <macro-arg2> ...]) # Call macro
 EOF
 RUN

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -1285,6 +1285,42 @@ bool test_default_mode(void) {
 	mu_end;
 }
 
+static RzCmdDescDetail *z_details_cb(RzCore *core, int argc, const char **argv) {
+	RzCmdDescDetail *z_details_cb_data = RZ_NEWS0(RzCmdDescDetail, 3);
+	z_details_cb_data[0].name = (const char *)strdup("Examples");
+	RzCmdDescDetailEntry *entries = RZ_NEWS0(RzCmdDescDetailEntry, 3);
+	entries[0].text = (const char *)strdup("z");
+	entries[0].comment = (const char *)strdup("dynamically generated detail");
+	entries[1].text = (const char *)strdup("z");
+	entries[1].comment = (const char *)strdup("dynamically generated detail 2");
+	z_details_cb_data[0].entries = (const RzCmdDescDetailEntry *)entries;
+	z_details_cb_data[1].name = (const char *)strdup("Examples 2");
+	z_details_cb_data[2].entries = NULL;
+	return z_details_cb_data;
+}
+
+bool test_details_cb(void) {
+	RzCmdDescArg z_args[] = { { 0 } };
+	RzCmdDescHelp z_help = { 0 };
+	z_help.summary = "z summary";
+	z_help.args = z_args;
+	z_help.details_cb = z_details_cb;
+
+	RzCmd *cmd = rz_cmd_new(false);
+	RzCmdDesc *root = rz_cmd_get_root(cmd);
+	rz_cmd_desc_argv_modes_new(cmd, root, "z", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_LONG_JSON, z_modes_handler, &z_help);
+
+	RzCmdParsedArgs *pa = rz_cmd_parsed_args_new("z?", 0, NULL);
+	char *h = rz_cmd_get_help(cmd, pa, false);
+	mu_assert_strcontains(h, "# dynamically generated detail", "z help should contain result of the details_cb");
+	mu_assert_strcontains(h, "Examples 2", "z help should contain result of the details_cb 2");
+	free(h);
+	rz_cmd_parsed_args_free(pa);
+
+	rz_cmd_free(cmd);
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test(test_parsed_args_noargs);
 	mu_run_test(test_parsed_args_onearg);
@@ -1323,6 +1359,7 @@ int all_tests() {
 	mu_run_test(test_state_output_concat_mix);
 	mu_run_test(test_state_output_concat_json);
 	mu_run_test(test_default_mode);
+	mu_run_test(test_details_cb);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

So far all the help sections were statically generated from the YAML
files, however sometimes you may want to list things in the help
messages that depend on what is loaded in Rizin (e.g. plugins, etc.).
This patch adds support for a details_cb that provides a dynamically
created RzCmdDescDetail array.

This will be useful also for `woD`/`woE` and probably for other things where adding a new help section makes sense.
![image](https://user-images.githubusercontent.com/562321/155308610-e6a39a42-3e99-4c38-811e-dcb7e3b2a063.png)


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Run `#!?`

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #2359