### PR TITLE
RzCmd: add support for dynamic arg choices

### DIFF
--- a/librz/core/cautocmpl.c
+++ b/librz/core/cautocmpl.c
@@ -533,12 +533,19 @@ static void autocmplt_cmd_arg_zign_space(RzCore *core, RzLineNSCompletionResult 
 	}
 }
 
-static void autocmplt_cmd_arg_choices(RzLineNSCompletionResult *res, const char *s, size_t len, const RzCmdDescArg *arg) {
-	const char **c;
-	for (c = arg->choices; *c; c++) {
+static void autocmplt_cmd_arg_choices(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len, const RzCmdDescArg *arg) {
+	char **oc, **c;
+	oc = c = arg->choices_cb ? arg->choices_cb(core) : (char **)arg->choices;
+	for (c = oc; *c; c++) {
 		if (!strncmp(*c, s, len)) {
 			rz_line_ns_completion_result_add(res, *c);
 		}
+	}
+	if (arg->choices_cb) {
+		for (c = oc; *c; c++) {
+			free(*c);
+		}
+		free(oc);
 	}
 }
 
@@ -691,7 +698,7 @@ static void autocmplt_cmd_arg(RzCore *core, RzLineNSCompletionResult *res, const
 		autocmplt_cmd_arg_zign_space(core, res, s, len);
 		break;
 	case RZ_CMD_ARG_TYPE_CHOICES:
-		autocmplt_cmd_arg_choices(res, s, len, arg);
+		autocmplt_cmd_arg_choices(core, res, s, len, arg);
 		break;
 	case RZ_CMD_ARG_TYPE_FCN:
 		autocmplt_cmd_arg_fcn(core, res, s, len);

--- a/librz/core/cmd/cmd_info.c
+++ b/librz/core/cmd/cmd_info.c
@@ -570,6 +570,20 @@ static bool print_demangler_info(const RzDemanglerPlugin *plugin, void *user) {
 	return true;
 }
 
+RZ_IPI char **rz_cmd_info_demangle_lang_choices(RzCore *core) {
+	char **res = RZ_NEWS0(char *, rz_list_length(core->bin->demangler->plugins) + 1);
+	if (!res) {
+		return NULL;
+	}
+	const RzDemanglerPlugin *plugin;
+	RzListIter *it;
+	int i = 0;
+	rz_list_foreach (core->bin->demangler->plugins, it, plugin) {
+		res[i++] = strdup(plugin->language);
+	}
+	return res;
+}
+
 RZ_IPI RzCmdStatus rz_cmd_info_demangle_handler(RzCore *core, int argc, const char **argv) {
 	char *output = NULL;
 	if (!rz_demangler_resolve(core->bin->demangler, argv[2], argv[1], &output)) {

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -7425,12 +7425,11 @@ static const RzCmdDescHelp cmd_info_pdb_download_help = {
 static const RzCmdDescHelp iD_help = {
 	.summary = "Demangle symbol for given language",
 };
-static const char *cmd_info_demangle_lang_choices[] = { "c++", "java", "objc", "swift", "dlang", "msvc", "rust", NULL };
 static const RzCmdDescArg cmd_info_demangle_args[] = {
 	{
 		.name = "lang",
 		.type = RZ_CMD_ARG_TYPE_CHOICES,
-		.choices = cmd_info_demangle_lang_choices,
+		.choices_cb = rz_cmd_info_demangle_lang_choices,
 
 	},
 	{

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -522,6 +522,7 @@ RZ_IPI RzCmdStatus rz_cmd_info_pdb_load_handler(RzCore *core, int argc, const ch
 RZ_IPI RzCmdStatus rz_cmd_info_pdb_show_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_cmd_info_pdb_download_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_cmd_info_demangle_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI char **rz_cmd_info_demangle_lang_choices(RzCore *core);
 RZ_IPI RzCmdStatus rz_cmd_info_demangle_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_cmd_info_entry_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_cmd_info_entryexits_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);

--- a/librz/core/cmd_descs/cmd_descs.yaml
+++ b/librz/core/cmd_descs/cmd_descs.yaml
@@ -59,6 +59,7 @@
 #       flags: same as RzCmdDescArg.flags
 #       default_value: same as RzCmdDescArg.default_value
 #       choices: same as RzCmdDescArg.choices (only valid if type is RZ_CMD_ARG_TYPE_CHOICES)
+#       choices_cb: same as RzCmdDescArg.choices_cb (only valid if type is RZ_CMD_ARG_TYPE_CHOICES)
 #
 ---
 name: root

--- a/librz/core/cmd_descs/cmd_info.yaml
+++ b/librz/core/cmd_descs/cmd_info.yaml
@@ -145,14 +145,7 @@ commands:
         args:
           - name: lang
             type: RZ_CMD_ARG_TYPE_CHOICES
-            choices:
-              - c++
-              - java
-              - objc
-              - swift
-              - dlang
-              - msvc
-              - rust
+            choices_cb: rz_cmd_info_demangle_lang_choices
           - name: symbol
             type: RZ_CMD_ARG_TYPE_STRING
       - name: iDl

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -211,6 +211,11 @@ typedef struct rz_cmd_desc_detail_t {
 typedef RZ_OWN RzCmdDescDetail *(*RzCmdDescDetailCb)(RzCore *core, int argc, const char **argv);
 
 /**
+ * Callback used to dynamically generate the choices of an argument with type \p RZ_CMD_ARG_TYPE_CHOICES
+ */
+typedef RZ_OWN char **(*RzCmdArgChoiceCb)(RzCore *core);
+
+/**
  * A description of an argument of a RzCmdDesc.
  */
 typedef struct rz_cmd_desc_arg_t {
@@ -254,7 +259,7 @@ typedef struct rz_cmd_desc_arg_t {
 	int flags;
 	/**
 	 * Default value for the argument, if it is not specified. This field
-	 * shall be used only when /p optional is true.
+	 * shall be used only when \p optional is true.
 	 */
 	const char *default_value;
 	/**
@@ -262,9 +267,14 @@ typedef struct rz_cmd_desc_arg_t {
 	 */
 	union {
 		/**
-		 * List of possible values in case /p type is RZ_CMD_ARG_TYPE_CHOICES.
+		 * List of possible values in case \p type is RZ_CMD_ARG_TYPE_CHOICES.
 		 */
 		const char **choices;
+		/**
+		 * Callback used to generate a list of possible values in case \p type is RZ_CMD_ARG_TYPE_CHOICES.
+		 * When this is specified, \p choices is ignored.
+		 */
+		RzCmdArgChoiceCb choices_cb;
 	};
 } RzCmdDescArg;
 

--- a/test/unit/test_autocmplt.c
+++ b/test/unit/test_autocmplt.c
@@ -159,7 +159,7 @@ static bool test_autocmplt_newcommand(void) {
 	mu_assert_notnull(r, "r should be returned");
 	mu_assert_eq(r->start, 0, "should autocomplete starting from 0");
 	mu_assert_eq(r->end, 0, "should autocomplete ending at 0");
-	mu_assert_eq(rz_pvector_len(&r->options), 5, "there are 4 commands available");
+	mu_assert_eq(rz_pvector_len(&r->options), 5, "there are 5 commands available");
 	mu_assert_streq(rz_pvector_at(&r->options, 0), "p", "one is p");
 	mu_assert_streq(rz_pvector_at(&r->options, 1), "s", "one is s");
 	mu_assert_streq(rz_pvector_at(&r->options, 2), "xd", "one is xd");


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Some arguments have the type CHOICES, which allows the autocomplete function to provide the list of choices that a user can use. So far this list of choices has been static, however in some cases we want it to be dynamic (e.g. based on which plugins are available).

This PR adds a choices callback to generate the list of strings used as choices.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Try: `iD <TAB>`, it should print the available demangler plugins.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #2167
