### PR TITLE
aezsu: Fix outdated `pc` when checking for completion

### DIFF
--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -8035,7 +8035,7 @@ RZ_IPI RzCmdStatus rz_il_vm_step_until_addr_handler(RzCore *core, int argc, cons
 	}
 	RzILVM *vm = core->analysis->il_vm->vm;
 
-	ut64 pc = rz_bv_to_ut64(vm->pc);
+	ut64 pc = rz_reg_get_value_by_role(core->analysis->reg, RZ_REG_NAME_PC);
 	while (pc != address) {
 		if (rz_cons_is_breaked()) {
 			rz_cons_printf("CTRL+C was pressed.\n");

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -8033,10 +8033,12 @@ RZ_IPI RzCmdStatus rz_il_vm_step_until_addr_handler(RzCore *core, int argc, cons
 		RZ_LOG_ERROR("RzIL: the VM is not initialized.\n");
 		return RZ_CMD_STATUS_ERROR;
 	}
-	RzILVM *vm = core->analysis->il_vm->vm;
 
-	ut64 pc = rz_reg_get_value_by_role(core->analysis->reg, RZ_REG_NAME_PC);
-	while (pc != address) {
+	while (1) {
+		ut64 pc = rz_reg_get_value_by_role(core->analysis->reg, RZ_REG_NAME_PC);
+		if (pc == address) {
+			break;
+		}
 		if (rz_cons_is_breaked()) {
 			rz_cons_printf("CTRL+C was pressed.\n");
 			break;
@@ -8044,7 +8046,6 @@ RZ_IPI RzCmdStatus rz_il_vm_step_until_addr_handler(RzCore *core, int argc, cons
 		if (!rz_core_il_step(core)) {
 			break;
 		}
-		pc = rz_bv_to_ut64(vm->pc);
 	}
 	return RZ_CMD_STATUS_OK;
 }

--- a/test/db/cmd/cmd_aez
+++ b/test/db/cmd/cmd_aez
@@ -151,3 +151,23 @@ EXPECT=<<EOF
 0x00010000 8 ptr
 EOF
 RUN
+
+NAME=double aezsu with different start pc
+FILE=bins/bf/2+5.bf
+CMDS=<<EOF
+e io.cache=1
+aezi
+(emu_pc pc; ar pc=$0; ar; aezsu $s; ?e)
+.(emu_pc 1)
+wv1 0 @ ptr
+.(emu_pc 0)
+EOF
+EXPECT=<<EOF
+ptr = 0x00010000
+pc = 0x00000001
+6
+ptr = 0x00010000
+pc = 0x00000000
+7
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes a problem with `aezsu` in which the initial `pc` value was outdated when checking whether the `aezsu` address has been reached, thus causing `aezsu` to fail when run twice.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
