### PR TITLE
Remove pz commands and aliases

### DIFF
--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -903,7 +903,7 @@ RZ_IPI int rz_cmd_help(void *data, const char *input) {
 		break;
 	case 'e': // "?e" echo
 		switch (input[1]) {
-		case 't': // "?e=t newtitle"
+		case 't': // "?et newtitle"
 			rz_cons_set_title(rz_str_trim_head_ro(input + 2));
 			break;
 		case '=': { // "?e="

--- a/librz/include/rz_util/rz_print.h
+++ b/librz/include/rz_util/rz_print.h
@@ -34,7 +34,6 @@ extern "C" {
 #define RZ_PRINT_FLAGS_BGFILL   0x00100000
 #define RZ_PRINT_FLAGS_SECTION  0x00200000
 
-typedef int (*RzPrintZoomCallback)(void *user, int mode, ut64 addr, ut8 *bufz, ut64 size);
 typedef const char *(*RzPrintNameCallback)(void *user, ut64 addr);
 typedef int (*RzPrintSizeCallback)(void *user, ut64 addr);
 typedef char *(*RzPrintCommentCallback)(void *user, ut64 addr);
@@ -188,8 +187,6 @@ RZ_API int rz_print_date_hfs(RzPrint *p, const ut8 *buf, int len);
 RZ_API int rz_print_date_w32(RzPrint *p, const ut8 *buf, int len);
 RZ_API int rz_print_date_unix(RzPrint *p, const ut8 *buf, int len);
 RZ_API int rz_print_date_get_now(RzPrint *p, char *str);
-RZ_API void rz_print_zoom(RzPrint *p, void *user, RzPrintZoomCallback cb, ut64 from, ut64 to, int len, int maxlen);
-RZ_API void rz_print_zoom_buf(RzPrint *p, void *user, RzPrintZoomCallback cb, ut64 from, ut64 to, int len, int maxlen);
 RZ_API void rz_print_progressbar(RzPrint *pr, int pc, int _cols);
 RZ_API void rz_print_rangebar(RzPrint *p, ut64 startA, ut64 endA, ut64 min, ut64 max, int cols);
 RZ_API char *rz_print_randomart(const ut8 *dgst_raw, ut32 dgst_raw_len, ut64 addr);

--- a/test/db/cmd/cmd_0
+++ b/test/db/cmd/cmd_0
@@ -473,10 +473,3 @@ CMDS=puw 0
 EXPECT=<<EOF
 EOF
 RUN
-
-NAME=pz 0
-FILE=bins/elf/analysis/hello-arm32
-CMDS=pz 0
-EXPECT=<<EOF
-EOF
-RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

removes `pz` commands and `prc=` (alias for pz).
`prc` is maintained.