### PR TITLE
Removed definitions of methods that has been removed in #2375

### DIFF
--- a/librz/include/rz_util/rz_print.h
+++ b/librz/include/rz_util/rz_print.h
@@ -175,11 +175,6 @@ RZ_API void rz_print_code(RzPrint *p, ut64 addr, const ut8 *buf, int len, char l
 
 RZ_API void rz_print_offset(RzPrint *p, ut64 off, int invert, int opt, int dec, int delta, const char *label);
 RZ_API void rz_print_offset_sg(RzPrint *p, ut64 off, int invert, int offseg, int seggrn, int offdec, int delta, const char *label);
-RZ_API int rz_print_date_dos(RzPrint *p, const ut8 *buf, int len);
-RZ_API int rz_print_date_hfs(RzPrint *p, const ut8 *buf, int len);
-RZ_API int rz_print_date_w32(RzPrint *p, const ut8 *buf, int len);
-RZ_API int rz_print_date_unix(RzPrint *p, const ut8 *buf, int len);
-RZ_API int rz_print_date_get_now(RzPrint *p, char *str);
 RZ_API void rz_print_progressbar(RzPrint *pr, int pc, int _cols);
 RZ_API void rz_print_rangebar(RzPrint *p, ut64 startA, ut64 endA, ut64 min, ut64 max, int cols);
 RZ_API char *rz_print_randomart(const ut8 *dgst_raw, ut32 dgst_raw_len, ut64 addr);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
This PR just removes the header definitions of some methods that has been removed by #2375