### PR TITLE
cons: Show last line of output even if it has no `\n`

### DIFF
--- a/librz/analysis/p/analysis_bf.c
+++ b/librz/analysis/p/analysis_bf.c
@@ -36,6 +36,8 @@ static void bf_syscall_read(RzILVM *vm, RzILOpEffect *op) {
 	rz_bv_free(bv);
 }
 
+static PrintfCallback cb_printf = NULL;
+
 static void bf_syscall_write(RzILVM *vm, RzILOpEffect *op) {
 	RzILVal *ptr_val = rz_il_vm_get_var_value(vm, RZ_IL_VAR_KIND_GLOBAL, "ptr");
 	if (ptr_val->type != RZ_IL_TYPE_PURE_BITVECTOR) {
@@ -44,9 +46,8 @@ static void bf_syscall_write(RzILVM *vm, RzILOpEffect *op) {
 	}
 	RzBitVector *bv = rz_il_vm_mem_load(vm, 0, ptr_val->data.bv);
 	ut32 c = rz_bv_to_ut32(bv);
-	if (c) {
-		putchar(c);
-		fflush(stdout);
+	if (c && cb_printf) {
+		cb_printf("%c", c);
 	}
 	rz_bv_free(bv);
 }
@@ -154,6 +155,7 @@ RzILOpEffect *bf_rlimit(RzAnalysis *analysis, ut64 addr, ut64 target) {
 }
 
 static RzAnalysisILConfig *il_config(RzAnalysis *analysis) {
+	cb_printf = analysis->cb_printf;
 	RzAnalysisILConfig *cfg = rz_analysis_il_config_new(64, false, 64);
 	cfg->init_state = rz_analysis_il_init_state_new();
 	if (!cfg->init_state) {

--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -972,18 +972,20 @@ static void __print_prompt(void) {
 	int columns = rz_cons_get_size(NULL) - 2;
 	int chars = strlen(I.buffer.data);
 	int len, i, cols = RZ_MAX(1, columns - rz_str_ansi_len(I.prompt) - 2);
+	const char *nonl_line = cons->context->last_nonl_line;
+	nonl_line = nonl_line ? nonl_line : "";
 	if (cons->line->prompt_type == RZ_LINE_PROMPT_OFFSET) {
 		rz_cons_gotoxy(0, cons->rows);
 		rz_cons_flush();
 	}
 	rz_cons_clear_line(0);
 	if (cons->context->color_mode > 0) {
-		printf("\r%s%s", Color_RESET, I.prompt);
+		printf("\r%s%s%s", nonl_line, Color_RESET, I.prompt);
 	} else {
-		printf("\r%s", I.prompt);
+		printf("\r%s%s", nonl_line, I.prompt);
 	}
 	fwrite(I.buffer.data, 1, RZ_MIN(cols, chars), stdout);
-	printf("\r%s", I.prompt);
+	printf("\r%s%s", nonl_line, I.prompt);
 	if (I.buffer.index > cols) {
 		printf("< ");
 		i = I.buffer.index - cols;
@@ -2021,11 +2023,14 @@ _end:
 	rz_cons_set_raw(0);
 	rz_cons_enable_mouse(mouse_status);
 	if (I.echo) {
-		printf("\r%s%s\n", I.prompt, I.buffer.data);
+		const char *nonl_line = cons->context->last_nonl_line;
+		nonl_line = nonl_line ? nonl_line : "";
+		printf("\r%s%s%s\n", nonl_line, I.prompt, I.buffer.data);
 		fflush(stdout);
 	}
 
 	RZ_FREE(I.sel_widget);
+	RZ_FREE(cons->context->last_nonl_line);
 
 	// should be here or not?
 	if (!memcmp(I.buffer.data, "!history", 8)) {

--- a/librz/include/rz_cons.h
+++ b/librz/include/rz_cons.h
@@ -476,6 +476,7 @@ typedef struct rz_cons_context_t {
 	char *buffer;
 	size_t buffer_len;
 	size_t buffer_sz;
+	char *last_nonl_line;
 
 	bool breaked;
 	RzStack *break_stack;

--- a/test/db/tools/rz
+++ b/test/db/tools/rz
@@ -197,3 +197,21 @@ EXPECT=<<EOF
 [2K[0m[33m[0x00000000]>[0m [33m[0x00000000]>[0m [2K[2K[0m[33m[0x00000000]>[0m q[33m[0x00000000]>[0m q[2K[33m[0x00000000]>[0m q
 EOF
 RUN
+
+NAME=nonl last line (b/w)
+FILE==
+CMDS=!rizin -e cfg.fortunes=0 -e scr.color=0 -e io.cache=1 -c "aezi; aezsu $s; < \nq\n" bins/bf/2+5.bf
+EXPECT=<<EOF
+7[2K7[0x00000000]> 7[0x00000000]> [2K7[0x00000000]> 
+[2K[0x00000000]> [0x00000000]> [2K[2K[0x00000000]> q[0x00000000]> q[2K[0x00000000]> q
+EOF
+RUN
+
+NAME=nonl last line (color)
+FILE==
+CMDS=!rizin -e cfg.fortunes=0 -e scr.color=1 -e io.cache=1 -c "aezi; aezsu $s; < \nq\n" bins/bf/2+5.bf
+EXPECT=<<EOF
+7[2K7[0m[33m[0x00000000]>[0m 7[33m[0x00000000]>[0m [2K7[33m[0x00000000]>[0m 
+[2K[0m[33m[0x00000000]>[0m [33m[0x00000000]>[0m [2K[2K[0m[33m[0x00000000]>[0m q[33m[0x00000000]>[0m q[2K[33m[0x00000000]>[0m q
+EOF
+RUN

--- a/test/db/tools/rz
+++ b/test/db/tools/rz
@@ -200,18 +200,18 @@ RUN
 
 NAME=nonl last line (b/w)
 FILE==
-CMDS=!rizin -e cfg.fortunes=0 -e scr.color=0 -e io.cache=1 -c "aezi; aezsu $s; < \nq\n" bins/bf/2+5.bf
+CMDS=!rizin -e cfg.fortunes=0 -e scr.color=0 -e io.cache=1 -c "aezi; aezsu $s; ar pc=0; aezsu $s; < \nq\n" bins/bf/2+5.bf
 EXPECT=<<EOF
-7[2K7[0x00000000]> 7[0x00000000]> [2K7[0x00000000]> 
+7n[2K7n[0x00000000]> 7n[0x00000000]> [2K7n[0x00000000]> 
 [2K[0x00000000]> [0x00000000]> [2K[2K[0x00000000]> q[0x00000000]> q[2K[0x00000000]> q
 EOF
 RUN
 
 NAME=nonl last line (color)
 FILE==
-CMDS=!rizin -e cfg.fortunes=0 -e scr.color=1 -e io.cache=1 -c "aezi; aezsu $s; < \nq\n" bins/bf/2+5.bf
+CMDS=!rizin -e cfg.fortunes=0 -e scr.color=1 -e io.cache=1 -c "aezi; aezsu $s; ar pc=0; aezsu $s; < \nq\n" bins/bf/2+5.bf
 EXPECT=<<EOF
-7[2K7[0m[33m[0x00000000]>[0m 7[33m[0x00000000]>[0m [2K7[33m[0x00000000]>[0m 
+7n[2K7n[0m[33m[0x00000000]>[0m 7n[33m[0x00000000]>[0m [2K7n[33m[0x00000000]>[0m 
 [2K[0m[33m[0x00000000]>[0m [33m[0x00000000]>[0m [2K[2K[0m[33m[0x00000000]>[0m q[33m[0x00000000]>[0m q[2K[33m[0x00000000]>[0m q
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr makes the rz_cons prompt show the last line of command output even if it has no '`\n`' (newline). The following before/after images illustrate this.

From `rizin bins/bf/2+5.bf`:

__Before:__

![before-nonl_last_line](https://user-images.githubusercontent.com/12002672/156917874-45112a43-7661-460f-9440-7c4854ace473.PNG)

__After:__

![after-nonl_last_line](https://user-images.githubusercontent.com/12002672/156917961-85c3b01b-3cdf-4ec8-854e-e962083e1be9.PNG)

For this to work with `analysis_bf.c`, it needs to call into rz_cons (currently indirectly using `cb_printf`) instead of calling `putchar()` directly.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
