### PR TITLE
Add `--print-errorlogs` flag `meson test` for Windows jobs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -100,7 +100,7 @@ for:
       - cd test
       - git clone -q --depth 1 -c core.symlinks=true https://github.com/rizinorg/rizin-testbins bins
       - cd ..
-      - "%PYTHON%\\Scripts\\meson test -C build -t 10"
+      - "%PYTHON%\\Scripts\\meson test -C build -t 10 --print-errorlogs"
       - cd test
       - rz-test -o results.json -L db
       - cd ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -678,7 +678,7 @@ jobs:
       - name: Run C++ test
         run: |
           export PATH=${HOME}/bin:${HOME}/Library/Python/3.8/bin:${HOME}/Library/Python/3.9/bin:${HOME}/.local/bin:${PATH}
-          meson test -C build-cpp-test
+          meson test -C build-cpp-test --print-errorlogs
 
   #  build-extras:
   #    name: Build rizin extras and rzpipe

--- a/test/README.md
+++ b/test/README.md
@@ -44,6 +44,7 @@ To run unit tests, just use `ninja -C build test` (or `meson test -C build`)
 from the top directory (replace `build` with the name of the directory you used
 to build Rizin).
 You can run one specific testcase category (e.g. the whole `test_bin.c` file) using `meson test -C build bin`.
+If you are using `meson test`, you should consider using the `--print-errorlogs` flag.
 
 # Failure Levels
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

I have added the `--print-errorlogs` flag for `meson build` which runs on Windows jobs. This flag is added by default when `nina test` is run. See mesonbuild/meson#9195.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The Appveyor CI in my local repo (DMaroo/rizin) does show the error line after adding the `--print-errorlogs` flag.
https://ci.appveyor.com/project/DMaroo/rizin/builds/42802357/job/092o4alrcsjsyn0l#L3772

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #1556.
