### PR TITLE
cmd_open.c: clear previous items when reopen another file

### DIFF
--- a/librz/core/cmd/cmd_open.c
+++ b/librz/core/cmd/cmd_open.c
@@ -786,6 +786,9 @@ static RzCmdStatus open_file(RzCore *core, const char *filepath, ut64 addr, int 
 		return RZ_CMD_STATUS_ERROR;
 	}
 
+	// clear the previous flag items
+	rz_flag_unset_all(core->flags);
+
 	core->num->value = cfile->fd;
 	if (addr == 0) { // if no baddr defined, use the one provided by the file
 		addr = UT64_MAX;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Unexpected behavior happens while reopening another file.

reproduce step:
1. `rizin`
2. `o arm1.bin`
3. `o hello-v850e`
4. `s sym.main`

There is no `sym.main` in `hello-v850e`, the address of `sym.main` of `arm1.bin` will be selected. 

BTW, plz check is there any other info needs to be removed while reopening another file. I am not familiar with RzCore structure. 


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
