### PR TITLE
Fix broken seek in visual debug mode

### DIFF
--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -3922,7 +3922,7 @@ RZ_API int rz_core_visual(RzCore *core, const char *input) {
 
 			if (cmdvhex && *cmdvhex) {
 				rz_strf(debugstr,
-					"?0 ; f tmp ; sr %s @e: cfg.seek.silent=true ; %s ; ?1 ; %s ; ?1 ; "
+					"?0 ; f+ tmp ; sr %s @e: cfg.seek.silent=true ; %s ; ?1 ; %s ; ?1 ; "
 					"s tmp @e: cfg.seek.silent=true ; f- tmp ; pd $r",
 					reg, cmdvhex,
 					ref ? CMD_REGISTERS_REFS : CMD_REGISTERS);
@@ -3932,7 +3932,7 @@ RZ_API int rz_core_visual(RzCore *core, const char *input) {
 				const char sign = (delta < 0) ? '+' : '-';
 				const int absdelta = RZ_ABS(delta);
 				rz_strf(debugstr,
-					"diq ; ?0 ; f tmp ; sr %s @e: cfg.seek.silent=true ; %s %d @ $$%c%d;"
+					"diq ; ?0 ; f+ tmp ; sr %s @e: cfg.seek.silent=true ; %s %d @ $$%c%d;"
 					"?1 ; %s;"
 					"?1 ; s tmp @e: cfg.seek.silent=true ; f- tmp ; afal ; pd $r",
 					reg, pxa ? "pxa" : pxw, size, sign, absdelta,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This is a regression since 2f638cad1e5e32279accb3928bef5fed40320c37.
When scrolling through Vpp, it would constantly jump back to offset 0.
When Vpp refreshes, it sets a temporary flag in its hacky command chain
to jump back to the right seek after running some more commands. But
since the aforementioned commit, `f` would only create the flag if there
was no other, so `f+` has to be used.

It might have been nicer to use `@` instead of this flag hack, but the expression syntax is a bit too fragile and ambiguous, so I wasn't able to make it work that way perfectly. In the long run, it would be better to write this in C anyway instead of commands (or rewrite visual from scratch).

**Test plan**

`Vpp`, then scroll over some flags. Scrolling should work as expected and not randomly jump back to 0.