### PR TITLE
aezsu: Always print `\n` in case output has none

### DIFF
--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -8047,6 +8047,7 @@ RZ_IPI RzCmdStatus rz_il_vm_step_until_addr_handler(RzCore *core, int argc, cons
 			break;
 		}
 	}
+	rz_cons_newline();
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/test/db/cmd/cmd_aez
+++ b/test/db/cmd/cmd_aez
@@ -8,6 +8,7 @@ aezsu 0x10
 aezv
 EOF
 EXPECT=<<EOF
+
  PC: 0x0000000000000010 ptr: 0x0000000000010001
 EOF
 RUN
@@ -23,6 +24,7 @@ aezsu 0x10
 ar
 EOF
 EXPECT=<<EOF
+
 ptr = 0x00010004
 pc = 0x00000004
 EOF
@@ -157,7 +159,7 @@ FILE=bins/bf/2+5.bf
 CMDS=<<EOF
 e io.cache=1
 aezi
-(emu_pc pc; ar pc=$0; ar; aezsu $s; ?e)
+(emu_pc pc; ar pc=$0; ar; aezsu $s)
 .(emu_pc 1)
 wv1 0 @ ptr
 .(emu_pc 0)
@@ -176,7 +178,7 @@ NAME=double aezi with different offsets
 FILE=bins/bf/2+5.bf
 CMDS=<<EOF
 e io.cache=1
-(emu_start start; aezi @ $0; aezsu $s; ?e)
+(emu_start start; aezi @ $0; aezsu $s)
 .(emu_start 1)
 w0 1 @ ptr
 .(emu_start 2)

--- a/test/db/rzil/6502
+++ b/test/db/rzil/6502
@@ -242,6 +242,7 @@ aezsu 0x84f
 ps @ 0x91b
 EOF
 EXPECT=<<EOF
+
 HELLO FROM RZIL
 EOF
 RUN

--- a/test/db/rzil/arm32
+++ b/test/db/rzil/arm32
@@ -68,6 +68,7 @@ aezsu 0x00010594
 ps @ obj.seckrit
 EOF
 EXPECT=<<EOF
+
 Hello from RzIL!
 EOF
 EXPECT_ERR=

--- a/test/db/rzil/bf
+++ b/test/db/rzil/bf
@@ -1707,7 +1707,7 @@ FILE=bins/bf/2+5.bf
 CMDS=<<EOF
 e io.cache=1
 aezi
-aezsu $s; ?e
+aezsu $s
 EOF
 EXPECT=<<EOF
 7
@@ -1721,13 +1721,13 @@ e io.cache=1
 w + @ 2
 aezi
 ara+
-aezsu $s; ?e
+aezsu $s
 ar
 ?e --- Reset everything ---
 ara-
 wc-*
 ar
-aezsu $s; ?e
+aezsu $s
 EOF
 EXPECT=<<EOF
 8


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Per https://github.com/rizinorg/rizin/pull/2385#discussion_r820618089, this pr makes `aezsu` print an `\n` always. This is so the prompt will not clobber the last line of `aeszu` output if the last line is not terminated by an `\n`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
