### PR TITLE
Do not emit non-JSON when emitting versions

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -4346,7 +4346,9 @@ static int bin_versioninfo(RzCore *r, PJ *pj, int mode) {
 	} else if (!strncmp("mach0", info->rclass, 5)) {
 		bin_mach0_versioninfo(r);
 	} else {
-		rz_cons_println("Unknown format");
+		if (mode != RZ_MODE_JSON) {
+			rz_cons_println("Unknown format");
+		}
 		return false;
 	}
 	return true;


### PR DESCRIPTION
**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why. Reason: the function is not documented.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible) Reason: the function is not tested.
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed) Reason: not needed.

**Detailed description**

Do not emit non-JSON string when emitting versions in JSON mode.

**Test plan**

1. Install Kernel Debug Kit 12.2 build 21D49. For details, see: https://developer.apple.com/documentation/apple-silicon/debugging-a-custom-kernel-extension2. 
2. Open `/Library/Developer/KDKs/KDK_12.2_21D49.kdk/System/Library/Kernels/kernel.development.t8101` with Cutter and confirm it does not emit JSON parse error.

**Closing issues**