### PR TITLE
Fix /a input option parsing when the pattern lacks

### DIFF
--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -2219,10 +2219,10 @@ static void do_asm_search(RzCore *core, struct search_parameters *param, const c
 	int kwidx = core->search->n_kws; // (int)rz_config_get_i (core->config, "search.kwidx")-1;
 	RzList *hits;
 	RzIOMap *map;
-	bool regexp = input[1] == '/'; // "/c/"
-	bool everyByte = regexp && input[2] == 'a';
+	bool regexp = input[0] == '/'; // "/c/"
+	bool everyByte = regexp && input[1] == 'a';
 	char *end_cmd = strchr(input, ' ');
-	switch ((end_cmd ? *(end_cmd - 1) : input[1])) {
+	switch ((end_cmd ? *(end_cmd - 1) : input[0])) {
 	case 'j':
 		param->outmode = RZ_MODE_JSON;
 		break;
@@ -3184,7 +3184,7 @@ reread:
 			rz_core_cmd_help(core, help_msg_slash_a);
 		} else if (input[1] == 'd') { // "ad"
 			dosearch = 0;
-			do_asm_search(core, &param, input + 1, 0, search_itv);
+			do_asm_search(core, &param, input + 2, 0, search_itv);
 		} else if (input[1] == 'e') { // "ae"
 			dosearch = 0;
 			do_asm_search(core, &param, input + 2, 'e', search_itv);

--- a/test/db/cmd/cmd_search
+++ b/test/db/cmd/cmd_search
@@ -271,6 +271,26 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=/a JSON output without pattern
+FILE=bins/elf/ioli/crackme0x00
+CMDS=<<EOF
+/adj
+/aej
+/acj
+/aoj
+/aaj
+/aij
+EOF
+EXPECT=<<EOF
+[]
+[]
+[]
+[]
+[]
+[]
+EOF
+RUN
+
 NAME=/ac mov ebx
 FILE=bins/elf/ioli/crackme0x00
 CMDS=<<EOF


### PR DESCRIPTION
**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why. Reason: internal change
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed) Reason: internal change

**Detailed description**

The index specified for input parameters was off by one byte except for `/ad`. Fixed by changing the index specification.

**Test plan**

Run `/acj`.

**Closing issues**