### PR TITLE
Store back-references to core files in RzIOMap

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -10,6 +10,8 @@
 #include <rz_util/rz_time.h>
 #include <rz_basefind.h>
 
+#include "core_private.h"
+
 #define is_in_range(at, from, sz) ((at) >= (from) && (at) < ((from) + (sz)))
 
 #define VA_FALSE    0
@@ -799,6 +801,9 @@ static bool io_create_mem_map(RzIO *io, RZ_NULLABLE RzCoreFile *cf, RzBinMap *ma
 		free(iomap->name);
 		iomap->name = rz_str_newf("mmap.%s", map->name);
 	}
+	if (!iomap->user) {
+		iomap->user = rz_core_io_map_info_new(cf, map->perm);
+	}
 	return true;
 }
 
@@ -867,6 +872,7 @@ static void add_map(RzCore *core, RZ_NULLABLE RzCoreFile *cf, RzBinFile *bf, RzB
 			free(map_name);
 			return;
 		}
+		iomap->user = rz_core_io_map_info_new(cf, perm);
 		free(iomap->name);
 		iomap->name = map_name;
 		if (cf) {
@@ -4673,7 +4679,7 @@ out:
 	return rz_strbuf_drain(buf);
 }
 
-RZ_API RzCmdStatus rz_core_bin_plugin_print(const RzBinPlugin *bp, RzCmdStateOutput *state) {
+RZ_IPI RzCmdStatus rz_core_bin_plugin_print(const RzBinPlugin *bp, RzCmdStateOutput *state) {
 	rz_return_val_if_fail(bp && state, RZ_CMD_STATUS_ERROR);
 
 	rz_cmd_state_output_set_columnsf(state, "sss", "type", "name", "description");
@@ -4713,7 +4719,7 @@ RZ_API RzCmdStatus rz_core_bin_plugin_print(const RzBinPlugin *bp, RzCmdStateOut
 	return RZ_CMD_STATUS_OK;
 }
 
-RZ_API RzCmdStatus rz_core_binxtr_plugin_print(const RzBinXtrPlugin *bx, RzCmdStateOutput *state) {
+RZ_IPI RzCmdStatus rz_core_binxtr_plugin_print(const RzBinXtrPlugin *bx, RzCmdStateOutput *state) {
 	rz_return_val_if_fail(bx && state, RZ_CMD_STATUS_ERROR);
 
 	const char *name = NULL;
@@ -4745,7 +4751,7 @@ RZ_API RzCmdStatus rz_core_binxtr_plugin_print(const RzBinXtrPlugin *bx, RzCmdSt
 	return RZ_CMD_STATUS_OK;
 }
 
-RZ_API RzCmdStatus rz_core_binldr_plugin_print(const RzBinLdrPlugin *ld, RzCmdStateOutput *state) {
+RZ_IPI RzCmdStatus rz_core_binldr_plugin_print(const RzBinLdrPlugin *ld, RzCmdStateOutput *state) {
 	rz_return_val_if_fail(ld && state, RZ_CMD_STATUS_ERROR);
 
 	const char *name;

--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -1263,6 +1263,7 @@ RZ_IPI void rz_core_file_io_map_deleted(RzCore *core, RzIOMap *map) {
 	rz_list_foreach (core->files, it, cf) {
 		rz_pvector_remove_data(&cf->maps, map);
 	}
+	rz_core_io_map_info_free(map->user);
 }
 
 RZ_IPI void rz_core_file_bin_file_deleted(RzCore *core, RzBinFile *bf) {
@@ -1612,4 +1613,18 @@ RZ_IPI void rz_core_io_file_reopen(RzCore *core, int fd, int perms) {
 			}
 		}
 	}
+}
+
+RZ_IPI RzCoreIOMapInfo *rz_core_io_map_info_new(RzCoreFile *cf, int perm_orig) {
+	RzCoreIOMapInfo *info = RZ_NEW(RzCoreIOMapInfo);
+	if (!info) {
+		return NULL;
+	}
+	info->cf = cf;
+	info->perm_orig = perm_orig;
+	return info;
+}
+
+RZ_IPI void rz_core_io_map_info_free(RzCoreIOMapInfo *info) {
+	free(info);
 }

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -138,6 +138,8 @@ RZ_IPI void rz_core_debug_bp_add(RzCore *core, ut64 addr, const char *arg_perm, 
 /* cfile.c */
 RZ_IPI void rz_core_io_file_open(RzCore *core, int fd);
 RZ_IPI void rz_core_io_file_reopen(RzCore *core, int fd, int perms);
+RZ_IPI RzCoreIOMapInfo *rz_core_io_map_info_new(RzCoreFile *cf, int perm_orig);
+RZ_IPI void rz_core_io_map_info_free(RzCoreIOMapInfo *info);
 
 /* cflag.c */
 RZ_IPI void rz_core_flag_print(RzFlag *f, RzCmdStateOutput *state);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -149,6 +149,23 @@ typedef struct rz_core_file_t {
 	RzPVector /*<RzIOMap>*/ maps; ///< all maps that have been created as a result of loading this file
 } RzCoreFile;
 
+/**
+ * Data to be stored inside RzIOMap.user to track back to its origin
+ */
+typedef struct rz_core_io_map_info_t {
+	RzCoreFile *cf;
+
+	/**
+	 * Original perms as specified for example by the RzBinMap.
+	 *
+	 * This may be different from the RzIOMap's perms because io will disable writing if the
+	 * file has been opened read-only. If one needs the info whether a e.g. the segment causing
+	 * this map is writeable, this is the place to look for.
+	 * Used by rz-ghidra for example.
+	 */
+	int perm_orig;
+} RzCoreIOMapInfo;
+
 typedef struct rz_core_times_t {
 	ut64 loadlibs_init_time;
 	ut64 loadlibs_time;

--- a/librz/include/rz_io.h
+++ b/librz/include/rz_io.h
@@ -159,6 +159,14 @@ typedef struct rz_io_map_t {
 	RzInterval itv;
 	ut64 delta; // paddr = itv.addr + delta
 	RZ_NULLABLE char *name;
+
+	/**
+	 * @brief Uninterpreted data to be injected from outside
+	 *
+	 * RZ_EVENT_IO_MAP_DEL may be listened to if any freeing is necessary.
+	 * (Hint when part of RzCore: RzCoreIOMapInfo is stored here)
+	 */
+	void *user;
 } RzIOMap;
 
 typedef struct rz_io_cache_t {

--- a/librz/io/io_map.c
+++ b/librz/io/io_map.c
@@ -184,12 +184,6 @@ RZ_API bool rz_io_map_is_mapped(RzIO *io, ut64 addr) {
 }
 
 RZ_API void rz_io_map_reset(RzIO *io) {
-	void **it;
-	rz_pvector_foreach (&io->maps, it) {
-		RzIOMap *map = *it;
-		RzEventIOMapDel ev = { map };
-		rz_event_send(io->event, RZ_EVENT_IO_MAP_DEL, &ev);
-	}
 	rz_io_map_fini(io);
 	rz_io_map_init(io);
 	io_map_calculate_skyline(io);
@@ -323,6 +317,12 @@ RZ_API void rz_io_map_cleanup(RzIO *io) {
 
 RZ_API void rz_io_map_fini(RzIO *io) {
 	rz_return_if_fail(io);
+	void **it;
+	rz_pvector_foreach (&io->maps, it) {
+		RzIOMap *map = *it;
+		RzEventIOMapDel ev = { map };
+		rz_event_send(io->event, RZ_EVENT_IO_MAP_DEL, &ev);
+	}
 	rz_pvector_clear(&io->maps);
 	rz_id_pool_free(io->map_ids);
 	io->map_ids = NULL;

--- a/test/unit/test_core_bin.c
+++ b/test/unit/test_core_bin.c
@@ -118,36 +118,57 @@ bool test_map(void) {
 	mu_assert_eq(map->itv.addr, 0x403, "map addr");
 	mu_assert_eq(map->itv.size, 1, "map size");
 	mu_assert_eq(map->perm, RZ_PERM_R, "io map perm");
+	RzCoreIOMapInfo *info = map->user;
+	mu_assert_notnull(info, "map info");
+	mu_assert_ptreq(info->cf, f, "map info corefile");
+	mu_assert_eq(info->perm_orig, RZ_PERM_R, "map info perm");
+
 	map = rz_pvector_at(&core->io->maps, 5);
 	mu_assert_streq(map->name, "vmap.vfile map with zeroes", "io map name");
 	mu_assert_eq(map->delta, 0, "map delta");
 	mu_assert_eq(map->itv.addr, 0x400, "map addr");
 	mu_assert_eq(map->itv.size, 3, "map size");
 	mu_assert_eq(map->perm, RZ_PERM_R, "io map perm");
+
 	map = rz_pvector_at(&core->io->maps, 3);
 	mu_assert_streq(map->name, "vmap.vfile map", "io map name");
 	mu_assert_eq(map->delta, 4, "map delta");
 	mu_assert_eq(map->itv.addr, 0x300, "map addr");
 	mu_assert_eq(map->itv.size, 4, "map size");
 	mu_assert_eq(map->perm, RZ_PERM_RWX, "io map perm");
+	info = map->user;
+	mu_assert_notnull(info, "map info");
+	mu_assert_ptreq(info->cf, f, "map info corefile");
+	mu_assert_eq(info->perm_orig, RZ_PERM_RWX, "map info perm");
+
 	map = rz_pvector_at(&core->io->maps, 1);
 	mu_assert_streq(map->name, "mmap.direct map with zeroes", "io map name");
 	mu_assert_eq(map->delta, 0, "map delta");
 	mu_assert_eq(map->itv.addr, 0x202, "map addr");
 	mu_assert_eq(map->itv.size, 0x2e, "map size");
 	mu_assert_eq(map->perm, RZ_PERM_R, "io map perm");
+	info = map->user;
+	mu_assert_notnull(info, "map info");
+	mu_assert_ptreq(info->cf, f, "map info corefile");
+	mu_assert_eq(info->perm_orig, RZ_PERM_R, "map info perm");
+
 	map = rz_pvector_at(&core->io->maps, 2);
 	mu_assert_streq(map->name, "fmap.direct map with zeroes", "io map name");
 	mu_assert_eq(map->delta, 2, "map delta");
 	mu_assert_eq(map->itv.addr, 0x200, "map addr");
 	mu_assert_eq(map->itv.size, 2, "map size");
 	mu_assert_eq(map->perm, RZ_PERM_R, "io map perm");
+
 	map = rz_pvector_at(&core->io->maps, 0);
 	mu_assert_streq(map->name, "fmap.direct map", "io map name");
 	mu_assert_eq(map->delta, 2, "map delta");
 	mu_assert_eq(map->itv.addr, 0x100, "map addr");
 	mu_assert_eq(map->itv.size, 2, "map size");
 	mu_assert_eq(map->perm, RZ_PERM_RX, "io map perm");
+	info = map->user;
+	mu_assert_notnull(info, "map info");
+	mu_assert_ptreq(info->cf, f, "map info corefile");
+	mu_assert_eq(info->perm_orig, RZ_PERM_RX, "map info perm");
 
 	ut8 buf[8];
 	r = rz_io_read_at(core->io, 0, buf, sizeof(buf));

--- a/test/unit/test_io.c
+++ b/test/unit/test_io.c
@@ -496,8 +496,12 @@ bool test_rz_io_map_del(void) {
 	mu_assert_true(red, "read after unmap");
 	mu_assert_memeq(buf, (const ut8 *)"\xff\xff\xff\xff", 4, "read after unmap");
 
+	rz_list_push(tracker.expect, map00);
+	rz_list_push(tracker.expect, map02);
+	rz_list_push(tracker.expect, map10);
+	rz_list_push(tracker.expect, map11);
+	rz_list_push(tracker.expect, map20);
 	rz_io_free(io);
-	// free should not emit any events, we just know everything is closed
 	mu_assert_eq(rz_list_length(tracker.expect), 0, "missing del event");
 	mu_assert_false(tracker.failed_unexpected, "unexpected del event");
 	rz_list_free(tracker.expect);
@@ -535,8 +539,10 @@ bool test_rz_io_map_del_for_fd(void) {
 	mu_assert_true(red, "read after unmap");
 	mu_assert_memeq(buf, (const ut8 *)"\xff\xff\xff\xff", 4, "read after unmap");
 
+	rz_list_push(tracker.expect, map10);
+	rz_list_push(tracker.expect, map11);
+	rz_list_push(tracker.expect, map20);
 	rz_io_free(io);
-	// free should not emit any events, we just know everything is closed
 	mu_assert_eq(rz_list_length(tracker.expect), 0, "missing del event");
 	mu_assert_false(tracker.failed_unexpected, "unexpected del event");
 	rz_list_free(tracker.expect);
@@ -574,8 +580,10 @@ bool test_rz_io_map_del_on_close(void) {
 	mu_assert_true(red, "read after unmap");
 	mu_assert_memeq(buf, (const ut8 *)"\xff\xff\xff\xff", 4, "read after unmap");
 
+	rz_list_push(tracker.expect, map10);
+	rz_list_push(tracker.expect, map11);
+	rz_list_push(tracker.expect, map20);
 	rz_io_free(io);
-	// free should not emit any events, we just know everything is closed
 	mu_assert_eq(rz_list_length(tracker.expect), 0, "missing del event");
 	mu_assert_false(tracker.failed_unexpected, "unexpected del event");
 	rz_list_free(tracker.expect);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This allows tracing an io map back to the RzCoreFile and thus also its
bin file and other info. This is used in rz-ghidra to determine which
memory ranges can be considered readonly to enable constant propagation.

**Test plan**

see the updated unit tests.