### PR TITLE
Silently fail when sigdb in sys path is not found

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -5973,7 +5973,7 @@ static int core_sigdb_sorter(const RzSigDBEntry *a, const RzSigDBEntry *b) {
 static RzList *core_load_all_signatures_from_sigdb(RzCore *core, bool with_details) {
 	RzList *sysdb = NULL, *userdb = NULL;
 	char *system_sigdb = rz_path_system(RZ_SIGDB);
-	if (RZ_STR_ISNOTEMPTY(system_sigdb)) {
+	if (RZ_STR_ISNOTEMPTY(system_sigdb) && rz_file_is_directory(system_sigdb)) {
 		sysdb = rz_sign_sigdb_load_database(system_sigdb, with_details);
 	}
 	free(system_sigdb);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixed a small bug when sigdb is not installed system wide

![image](https://user-images.githubusercontent.com/561184/159120442-dfb335e7-30e6-4a03-80d8-666b8c9b5720.png)
