### PR TITLE
Move `minunit.h` include due to compile errors.

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -186,8 +186,8 @@ Rizin, but to test new API or new code we suggest to write small unit tests.
 
 The basic structure of a unit test is the following:
 ```C
-#include "minunit.h"
 #include <rz_XXXXX.h>
+#include "minunit.h" // Place at the bottom of includes.
 
 static bool test_my_feature(void) {
 	// code to test the behaviour


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

If `#incluude "minunit.h"` is placed at the top of includes the test won't compile. Fails with something like:

```c
FAILED: test/unit/test_tokens.p/test_tokens.c.o 
...

../test/unit/minunit.h:41:29: error: unknown type name ‘size_t’
   41 | void snprint_mem(char *out, size_t out_size, const ut8 *buf, size_t len) {
      |                             ^~~~~~

etc.
```

So it should be placed correctly in the doc.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
