### PR TITLE
Cleanup of util/print.c

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -538,8 +538,8 @@ RZ_API void rz_core_analysis_autoname_all_golang_fcns(RzCore *core) {
 		}
 	}
 	if (!gopclntab) {
-		oldstr = rz_print_rowlog(core->print, "Could not find .gopclntab section");
-		rz_print_rowlog_done(core->print, oldstr);
+		oldstr = rz_core_notify_begin(core, "Could not find .gopclntab section");
+		rz_core_notify_done(core, oldstr);
 		return;
 	}
 	int ptr_size = core->analysis->bits / 8;
@@ -581,11 +581,11 @@ RZ_API void rz_core_analysis_autoname_all_golang_fcns(RzCore *core) {
 	}
 	rz_flag_space_pop(core->flags);
 	if (num_syms) {
-		oldstr = rz_print_rowlog(core->print, sdb_fmt("Found %d symbols and saved them at sym.go.*", num_syms));
-		rz_print_rowlog_done(core->print, oldstr);
+		oldstr = rz_core_notify_begin(core, sdb_fmt("Found %d symbols and saved them at sym.go.*", num_syms));
+		rz_core_notify_done(core, oldstr);
 	} else {
-		oldstr = rz_print_rowlog(core->print, "Found no symbols.");
-		rz_print_rowlog_done(core->print, oldstr);
+		oldstr = rz_core_notify_begin(core, "Found no symbols.");
+		rz_core_notify_done(core, oldstr);
 	}
 }
 
@@ -5801,12 +5801,12 @@ RZ_API bool rz_core_analysis_everything(RzCore *core, bool experimental, char *d
 	bool plugin_supports_esil = core->analysis->cur->esil;
 	const char *oldstr = NULL;
 	if (rz_str_startswith(rz_config_get(core->config, "bin.lang"), "go")) {
-		oldstr = rz_print_rowlog(core->print, "Find function and symbol names from golang binaries (aang)");
-		rz_print_rowlog_done(core->print, oldstr);
+		oldstr = rz_core_notify_begin(core, "Find function and symbol names from golang binaries (aang)");
+		rz_core_notify_done(core, oldstr);
 		rz_core_analysis_autoname_all_golang_fcns(core);
-		oldstr = rz_print_rowlog(core->print, "Analyze all flags starting with sym.go. (aF @@f:sym.go.*)");
+		oldstr = rz_core_notify_begin(core, "Analyze all flags starting with sym.go. (aF @@f:sym.go.*)");
 		rz_core_cmd0(core, "aF @@f:sym.go.*");
-		rz_print_rowlog_done(core->print, oldstr);
+		rz_core_notify_done(core, oldstr);
 	}
 	rz_core_task_yield(&core->tasks);
 	if (!cfg_debug) {
@@ -5823,42 +5823,42 @@ RZ_API bool rz_core_analysis_everything(RzCore *core, bool experimental, char *d
 		return false;
 	}
 
-	oldstr = rz_print_rowlog(core->print, "Analyze function calls (aac)");
+	oldstr = rz_core_notify_begin(core, "Analyze function calls (aac)");
 	(void)rz_cmd_analysis_calls(core, "", false, false); // "aac"
 	rz_core_seek(core, curseek, true);
-	rz_print_rowlog_done(core->print, oldstr);
+	rz_core_notify_done(core, oldstr);
 	rz_core_task_yield(&core->tasks);
 	if (rz_cons_is_breaked()) {
 		return false;
 	}
 
 	if (is_unknown_file(core)) {
-		oldstr = rz_print_rowlog(core->print, "find and analyze function preludes (aap)");
+		oldstr = rz_core_notify_begin(core, "find and analyze function preludes (aap)");
 		(void)rz_core_search_preludes(core, false); // "aap"
 		didAap = true;
-		rz_print_rowlog_done(core->print, oldstr);
+		rz_core_notify_done(core, oldstr);
 		rz_core_task_yield(&core->tasks);
 		if (rz_cons_is_breaked()) {
 			return false;
 		}
 	}
 
-	oldstr = rz_print_rowlog(core->print, "Analyze len bytes of instructions for references (aar)");
+	oldstr = rz_core_notify_begin(core, "Analyze len bytes of instructions for references (aar)");
 	(void)rz_core_analysis_refs(core, ""); // "aar"
-	rz_print_rowlog_done(core->print, oldstr);
+	rz_core_notify_done(core, oldstr);
 	rz_core_task_yield(&core->tasks);
 	if (rz_cons_is_breaked()) {
 		return false;
 	}
 	if (is_apple_target(core)) {
-		oldstr = rz_print_rowlog(core->print, "Check for objc references");
-		rz_print_rowlog_done(core->print, oldstr);
+		oldstr = rz_core_notify_begin(core, "Check for objc references");
+		rz_core_notify_done(core, oldstr);
 		cmd_analysis_objc(core, true);
 	}
 	rz_core_task_yield(&core->tasks);
-	oldstr = rz_print_rowlog(core->print, "Check for classes");
+	oldstr = rz_core_notify_begin(core, "Check for classes");
 	rz_analysis_class_recover_all(core->analysis);
-	rz_print_rowlog_done(core->print, oldstr);
+	rz_core_notify_done(core, oldstr);
 	rz_core_task_yield(&core->tasks);
 	rz_config_set_i(core->config, "analysis.calls", c);
 	rz_core_task_yield(&core->tasks);
@@ -5870,11 +5870,11 @@ RZ_API bool rz_core_analysis_everything(RzCore *core, bool experimental, char *d
 		rz_core_task_yield(&core->tasks);
 		bool pcache = rz_config_get_b(core->config, "io.pcache");
 		rz_config_set_b(core->config, "io.pcache", false);
-		oldstr = rz_print_rowlog(core->print, "Emulate functions to find computed references (aaef)");
+		oldstr = rz_core_notify_begin(core, "Emulate functions to find computed references (aaef)");
 		if (plugin_supports_esil) {
 			rz_core_analysis_esil_references_all_functions(core);
 		}
-		rz_print_rowlog_done(core->print, oldstr);
+		rz_core_notify_done(core, oldstr);
 		rz_core_task_yield(&core->tasks);
 		rz_config_set_b(core->config, "io.pcache", pcache);
 		if (rz_cons_is_breaked()) {
@@ -5882,10 +5882,10 @@ RZ_API bool rz_core_analysis_everything(RzCore *core, bool experimental, char *d
 		}
 	}
 	if (rz_config_get_i(core->config, "analysis.autoname")) {
-		oldstr = rz_print_rowlog(core->print, "Speculatively constructing a function name "
-						      "for fcn.* and sym.func.* functions (aan)");
+		oldstr = rz_core_notify_begin(core, "Speculatively constructing a function name "
+						    "for fcn.* and sym.func.* functions (aan)");
 		rz_core_analysis_autoname_all_fcns(core);
-		rz_print_rowlog_done(core->print, oldstr);
+		rz_core_notify_done(core, oldstr);
 		rz_core_task_yield(&core->tasks);
 	}
 	if (core->analysis->opt.vars) {
@@ -5907,45 +5907,45 @@ RZ_API bool rz_core_analysis_everything(RzCore *core, bool experimental, char *d
 		rz_core_task_yield(&core->tasks);
 	}
 	if (!sdb_isempty(core->analysis->sdb_zigns)) {
-		oldstr = rz_print_rowlog(core->print, "Check for zignature from zigns folder (z/)");
+		oldstr = rz_core_notify_begin(core, "Check for zignature from zigns folder (z/)");
 		rz_core_cmd0(core, "z/");
-		rz_print_rowlog_done(core->print, oldstr);
+		rz_core_notify_done(core, oldstr);
 		rz_core_task_yield(&core->tasks);
 	}
 	if (plugin_supports_esil) {
-		oldstr = rz_print_rowlog(core->print, "Type matching analysis for all functions (aaft)");
+		oldstr = rz_core_notify_begin(core, "Type matching analysis for all functions (aaft)");
 		rz_core_analysis_types_propagation(core);
-		rz_print_rowlog_done(core->print, oldstr);
+		rz_core_notify_done(core, oldstr);
 		rz_core_task_yield(&core->tasks);
 	}
 
-	oldstr = rz_print_rowlog(core->print, "Propagate noreturn information");
+	oldstr = rz_core_notify_begin(core, "Propagate noreturn information");
 	rz_core_analysis_propagate_noreturn(core, UT64_MAX);
-	rz_print_rowlog_done(core->print, oldstr);
+	rz_core_notify_done(core, oldstr);
 	rz_core_task_yield(&core->tasks);
 
 	// Apply DWARF function information
 	Sdb *dwarf_sdb = sdb_ns(core->analysis->sdb, "dwarf", 0);
 	if (dwarf_sdb) {
-		oldstr = rz_print_rowlog(core->print, "Integrate dwarf function information.");
+		oldstr = rz_core_notify_begin(core, "Integrate dwarf function information.");
 		rz_analysis_dwarf_integrate_functions(core->analysis, core->flags, dwarf_sdb);
-		rz_print_rowlog_done(core->print, oldstr);
+		rz_core_notify_done(core, oldstr);
 	}
 
-	oldstr = rz_print_rowlog(core->print, "Use -AA or aaaa to perform additional experimental analysis.");
-	rz_print_rowlog_done(core->print, oldstr);
+	oldstr = rz_core_notify_begin(core, "Use -AA or aaaa to perform additional experimental analysis.");
+	rz_core_notify_done(core, oldstr);
 
 	if (experimental) {
 		if (!didAap) {
-			oldstr = rz_print_rowlog(core->print, "Finding function preludes");
+			oldstr = rz_core_notify_begin(core, "Finding function preludes");
 			(void)rz_core_search_preludes(core, false); // "aap"
-			rz_print_rowlog_done(core->print, oldstr);
+			rz_core_notify_done(core, oldstr);
 			rz_core_task_yield(&core->tasks);
 		}
 
-		oldstr = rz_print_rowlog(core->print, "Enable constraint types analysis for variables");
+		oldstr = rz_core_notify_begin(core, "Enable constraint types analysis for variables");
 		rz_config_set(core->config, "analysis.types.constraint", "true");
-		rz_print_rowlog_done(core->print, oldstr);
+		rz_core_notify_done(core, oldstr);
 	}
 	rz_core_seek_undo(core);
 	if (dh_orig) {
@@ -5959,10 +5959,10 @@ RZ_API bool rz_core_analysis_everything(RzCore *core, bool experimental, char *d
 	if (rz_config_get_b(core->config, "analysis.apply.signature")) {
 		int n_applied = 0;
 		char message[100];
-		rz_print_rowlog(core->print, "Applying signatures from sigdb");
+		rz_core_notify_begin(core, "Applying signatures from sigdb");
 		rz_core_analysis_sigdb_apply(core, &n_applied, NULL);
 		rz_strf(message, "Applied %d FLIRT signatures via sigdb", n_applied);
-		rz_print_rowlog_done(core->print, message);
+		rz_core_notify_done(core, message);
 	}
 
 	return true;
@@ -6494,8 +6494,8 @@ RZ_IPI void rz_core_analysis_value_pointers(RzCore *core, RzOutputMode mode) {
 	int archAlign = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_ALIGN);
 	rz_config_set_i(core->config, "search.align", archAlign);
 	rz_config_set(core->config, "analysis.in", "io.maps.x");
-	const char *oldstr = rz_print_rowlog(core->print, "Finding xrefs in noncode section with analysis.in=io.maps");
-	rz_print_rowlog_done(core->print, oldstr);
+	const char *oldstr = rz_core_notify_begin(core, "Finding xrefs in noncode section with analysis.in=io.maps");
+	rz_core_notify_done(core, oldstr);
 
 	int vsize = 4; // 32bit dword
 	if (core->rasm->bits == 64) {
@@ -6503,8 +6503,8 @@ RZ_IPI void rz_core_analysis_value_pointers(RzCore *core, RzOutputMode mode) {
 	}
 
 	// body
-	oldstr = rz_print_rowlog(core->print, "Analyze value pointers (aav)");
-	rz_print_rowlog_done(core->print, oldstr);
+	oldstr = rz_core_notify_begin(core, "Analyze value pointers (aav)");
+	rz_core_notify_done(core, oldstr);
 	rz_cons_break_push(NULL, NULL);
 	if (is_debug) {
 		RzList *list = rz_core_get_boundaries_prot(core, 0, "dbg.map", "analysis");
@@ -6517,8 +6517,8 @@ RZ_IPI void rz_core_analysis_value_pointers(RzCore *core, RzOutputMode mode) {
 			if (rz_cons_is_breaked()) {
 				break;
 			}
-			oldstr = rz_print_rowlog(core->print, sdb_fmt("from 0x%" PFMT64x " to 0x%" PFMT64x " (aav)", map->itv.addr, rz_itv_end(map->itv)));
-			rz_print_rowlog_done(core->print, oldstr);
+			oldstr = rz_core_notify_begin(core, sdb_fmt("from 0x%" PFMT64x " to 0x%" PFMT64x " (aav)", map->itv.addr, rz_itv_end(map->itv)));
+			rz_core_notify_done(core, oldstr);
 			(void)rz_core_search_value_in_range(core, map->itv,
 				map->itv.addr, rz_itv_end(map->itv), vsize, _CbInRangeAav, (void *)&mode);
 		}
@@ -6540,12 +6540,12 @@ RZ_IPI void rz_core_analysis_value_pointers(RzCore *core, RzOutputMode mode) {
 			// TODO: Reduce multiple hits for same addr
 			from = rz_itv_begin(map2->itv);
 			to = rz_itv_end(map2->itv);
-			oldstr = rz_print_rowlog(core->print, sdb_fmt("Value from 0x%08" PFMT64x " to 0x%08" PFMT64x " (aav)", from, to));
+			oldstr = rz_core_notify_begin(core, sdb_fmt("Value from 0x%08" PFMT64x " to 0x%08" PFMT64x " (aav)", from, to));
 			if ((to - from) > MAX_SCAN_SIZE) {
 				eprintf("Warning: Skipping large region\n");
 				continue;
 			}
-			rz_print_rowlog_done(core->print, oldstr);
+			rz_core_notify_done(core, oldstr);
 			rz_list_foreach (list, iter, map) {
 				ut64 begin = map->itv.addr;
 				ut64 end = rz_itv_end(map->itv);
@@ -6553,12 +6553,12 @@ RZ_IPI void rz_core_analysis_value_pointers(RzCore *core, RzOutputMode mode) {
 					break;
 				}
 				if (end - begin > UT32_MAX) {
-					oldstr = rz_print_rowlog(core->print, "Skipping huge range");
-					rz_print_rowlog_done(core->print, oldstr);
+					oldstr = rz_core_notify_begin(core, "Skipping huge range");
+					rz_core_notify_done(core, oldstr);
 					continue;
 				}
-				oldstr = rz_print_rowlog(core->print, sdb_fmt("0x%08" PFMT64x "-0x%08" PFMT64x " in 0x%" PFMT64x "-0x%" PFMT64x " (aav)", from, to, begin, end));
-				rz_print_rowlog_done(core->print, oldstr);
+				oldstr = rz_core_notify_begin(core, sdb_fmt("0x%08" PFMT64x "-0x%08" PFMT64x " in 0x%" PFMT64x "-0x%" PFMT64x " (aav)", from, to, begin, end));
+				rz_core_notify_done(core, oldstr);
 				(void)rz_core_search_value_in_range(core, map->itv, from, to, vsize, _CbInRangeAav, (void *)&mode);
 			}
 		}

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -5174,11 +5174,11 @@ static int cmd_analysis_all(RzCore *core, const char *input) {
 				goto jacuzzi;
 			}
 			ut64 curseek = core->offset;
-			oldstr = rz_print_rowlog(core->print, "Analyze all flags starting with sym. and entry0 (aa)");
+			oldstr = rz_core_notify_begin(core, "Analyze all flags starting with sym. and entry0 (aa)");
 			rz_cons_break_push(NULL, NULL);
 			rz_cons_break_timeout(rz_config_get_i(core->config, "analysis.timeout"));
 			rz_core_analysis_all(core);
-			rz_print_rowlog_done(core->print, oldstr);
+			rz_core_notify_done(core, oldstr);
 			rz_core_task_yield(&core->tasks);
 			// Run pending analysis immediately after analysis
 			// Usefull when running commands with ";" or via rizin -c,-i

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -24,6 +24,49 @@ static ut64 letter_divs[RZ_CORE_ASMQJMPS_LEN_LETTERS - 1] = {
 
 extern bool rz_core_is_project(RzCore *core, const char *name);
 
+/**
+ * \brief  Prints a message definining the beginning of a task
+ *
+ * \param  core     The RzCore to use
+ * \param  message  The message to notify
+ *
+ * \return Returns the same pointer as message
+ */
+RZ_API const char *rz_core_notify_begin(RZ_NONNULL RzCore *core, RZ_NONNULL const char *message) {
+	rz_return_val_if_fail(core && message, NULL);
+	bool use_color = rz_config_get_i(core->config, "scr.color") > 0;
+	bool verbose = rz_config_get_b(core->config, "scr.prompt");
+	if (!verbose) {
+		return message;
+	}
+	if (use_color) {
+		fprintf(stderr, "[ ] " Color_YELLOW "%s\r[" Color_RESET, message);
+	} else {
+		fprintf(stderr, "[ ] %s\r[", message);
+	}
+	return message;
+}
+
+/**
+ * \brief  Prints a message definining the end of a task
+ *
+ * \param  core     The RzCore to use
+ * \param  message  The message to notify
+ */
+RZ_API void rz_core_notify_done(RZ_NONNULL RzCore *core, RZ_NONNULL const char *message) {
+	rz_return_if_fail(core && message);
+	bool use_color = rz_config_get_i(core->config, "scr.color") > 0;
+	bool verbose = rz_config_get_b(core->config, "scr.prompt");
+	if (!verbose) {
+		return;
+	}
+	if (use_color) {
+		fprintf(stderr, "\r" Color_GREEN "[x]" Color_RESET " %s\n", message);
+		return;
+	}
+	fprintf(stderr, "\r[x] %s\n", message);
+}
+
 static int on_fcn_new(RzAnalysis *_analysis, void *_user, RzAnalysisFunction *fcn) {
 	RzCore *core = (RzCore *)_user;
 	const char *cmd = rz_config_get(core->config, "cmd.fcn.new");

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -421,6 +421,9 @@ typedef int (*RzCoreSearchCallback)(RzCore *core, ut64 from, ut8 *buf, int len);
 #ifdef RZ_API
 RZ_API int rz_core_bind(RzCore *core, RzCoreBind *bnd);
 
+RZ_API const char *rz_core_notify_begin(RZ_NONNULL RzCore *core, RZ_NONNULL const char *message);
+RZ_API void rz_core_notify_done(RZ_NONNULL RzCore *core, RZ_NONNULL const char *message);
+
 /**
  * \brief APIs to handle Visual Gadgets
  */

--- a/librz/include/rz_util/rz_print.h
+++ b/librz/include/rz_util/rz_print.h
@@ -177,9 +177,6 @@ RZ_API ut32 rz_print_rowoff(RzPrint *p, int i);
 RZ_API void rz_print_set_rowoff(RzPrint *p, int i, ut32 offset, bool overwrite);
 RZ_API int rz_print_row_at_off(RzPrint *p, ut32 offset);
 
-RZ_API const char *rz_print_rowlog(RzPrint *print, const char *str);
-RZ_API void rz_print_rowlog_done(RzPrint *print, const char *str);
-
 // WIP
 RZ_API void rz_print_set_screenbounds(RzPrint *p, ut64 addr);
 RZ_API char *rz_print_json_indent(const char *s, bool color, const char *tab, const char **colors);

--- a/librz/include/rz_util/rz_print.h
+++ b/librz/include/rz_util/rz_print.h
@@ -145,7 +145,6 @@ RZ_API void rz_print_bytes(RzPrint *p, const ut8 *buf, int len, const char *fmt)
 RZ_API void rz_print_fill(RzPrint *p, const ut8 *arr, int size, ut64 addr, int step);
 RZ_API void rz_print_byte(RzPrint *p, const char *fmt, int idx, ut8 ch);
 RZ_API const char *rz_print_byte_color(RzPrint *p, int ch);
-RZ_API void rz_print_c(RzPrint *p, const ut8 *str, int len);
 RZ_API void rz_print_raw(RzPrint *p, ut64 addr, const ut8 *buf, int len);
 RZ_API bool rz_print_have_cursor(RzPrint *p, int cur, int len);
 RZ_API bool rz_print_cursor_pointer(RzPrint *p, int cur, int len);

--- a/librz/include/rz_util/rz_print.h
+++ b/librz/include/rz_util/rz_print.h
@@ -132,7 +132,6 @@ RZ_API void rz_print_set_is_interrupted_cb(RzPrintIsInterruptedCallback cb);
 
 /* ... */
 RZ_API char *rz_print_hexpair(RzPrint *p, const char *str, int idx);
-RZ_API void rz_print_hex_from_base2(RzPrint *p, char *bin_str);
 RZ_API RzPrint *rz_print_new(void);
 RZ_API RzPrint *rz_print_free(RzPrint *p);
 RZ_API void rz_print_set_flags(RzPrint *p, int _flags);

--- a/librz/include/rz_util/rz_print.h
+++ b/librz/include/rz_util/rz_print.h
@@ -143,7 +143,6 @@ RZ_API void rz_print_hexii(RzPrint *p, ut64 addr, const ut8 *buf, int len, int s
 RZ_API void rz_print_hexdump(RzPrint *p, ut64 addr, const ut8 *buf, int len, int base, int step, size_t zoomsz);
 RZ_API void rz_print_hexdump_simple(const ut8 *buf, int len);
 RZ_API int rz_print_jsondump(RzPrint *p, const ut8 *buf, int len, int wordsize);
-RZ_API void rz_print_hexpairs(RzPrint *p, ut64 addr, const ut8 *buf, int len);
 RZ_API void rz_print_hexdiff(RzPrint *p, ut64 aa, const ut8 *a, ut64 ba, const ut8 *b, int len, int scndcol);
 RZ_API void rz_print_bytes(RzPrint *p, const ut8 *buf, int len, const char *fmt);
 RZ_API void rz_print_fill(RzPrint *p, const ut8 *arr, int size, ut64 addr, int step);

--- a/librz/include/rz_util/rz_print.h
+++ b/librz/include/rz_util/rz_print.h
@@ -135,7 +135,6 @@ RZ_API char *rz_print_hexpair(RzPrint *p, const char *str, int idx);
 RZ_API RzPrint *rz_print_new(void);
 RZ_API RzPrint *rz_print_free(RzPrint *p);
 RZ_API void rz_print_set_flags(RzPrint *p, int _flags);
-RZ_API void rz_print_unset_flags(RzPrint *p, int flags);
 RZ_API void rz_print_addr(RzPrint *p, ut64 addr);
 RZ_API void rz_print_section(RzPrint *p, ut64 at);
 RZ_API void rz_print_hexii(RzPrint *p, ut64 addr, const ut8 *buf, int len, int step);

--- a/librz/include/rz_util/rz_print.h
+++ b/librz/include/rz_util/rz_print.h
@@ -141,7 +141,6 @@ RZ_API void rz_print_addr(RzPrint *p, ut64 addr);
 RZ_API void rz_print_section(RzPrint *p, ut64 at);
 RZ_API void rz_print_hexii(RzPrint *p, ut64 addr, const ut8 *buf, int len, int step);
 RZ_API void rz_print_hexdump(RzPrint *p, ut64 addr, const ut8 *buf, int len, int base, int step, size_t zoomsz);
-RZ_API void rz_print_hexdump_simple(const ut8 *buf, int len);
 RZ_API int rz_print_jsondump(RzPrint *p, const ut8 *buf, int len, int wordsize);
 RZ_API void rz_print_hexdiff(RzPrint *p, ut64 aa, const ut8 *a, ut64 ba, const ut8 *b, int len, int scndcol);
 RZ_API void rz_print_bytes(RzPrint *p, const ut8 *buf, int len, const char *fmt);

--- a/librz/include/rz_util/rz_print.h
+++ b/librz/include/rz_util/rz_print.h
@@ -149,7 +149,6 @@ RZ_API void rz_print_raw(RzPrint *p, ut64 addr, const ut8 *buf, int len);
 RZ_API bool rz_print_have_cursor(RzPrint *p, int cur, int len);
 RZ_API bool rz_print_cursor_pointer(RzPrint *p, int cur, int len);
 RZ_API void rz_print_cursor(RzPrint *p, int cur, int len, int set);
-RZ_API void rz_print_cursor_range(RzPrint *p, int cur, int to, int set);
 RZ_API int rz_print_get_cursor(RzPrint *p);
 RZ_API void rz_print_set_cursor(RzPrint *p, int curset, int ocursor, int cursor);
 #define SEEFLAG    -2

--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -179,7 +179,6 @@ static void print_hex_from_base2(char *base2) {
 	free(bytes);
 }
 
-
 static void print_ascii_table(void) {
 	printf("%s", ret_ascii_table());
 }

--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -1757,31 +1757,3 @@ RZ_API int rz_print_jsondump(RzPrint *p, const ut8 *buf, int len, int wordsize) 
 	p->cb_printf("]\n");
 	return words;
 }
-
-RZ_API const char *rz_print_rowlog(RzPrint *print, const char *str) {
-	int use_color = print->flags & RZ_PRINT_FLAGS_COLOR;
-	bool verbose = print->scr_prompt;
-	rz_return_val_if_fail(print->cb_eprintf, NULL);
-	if (!verbose) {
-		return NULL;
-	}
-	if (use_color) {
-		print->cb_eprintf("[ ] " Color_YELLOW "%s\r[" Color_RESET, str);
-	} else {
-		print->cb_eprintf("[ ] %s\r[", str);
-	}
-	return str;
-}
-
-RZ_API void rz_print_rowlog_done(RzPrint *print, const char *str) {
-	int use_color = print->flags & RZ_PRINT_FLAGS_COLOR;
-	bool verbose = print->scr_prompt;
-	rz_return_if_fail(print->cb_eprintf);
-	if (verbose) {
-		if (use_color) {
-			print->cb_eprintf("\r" Color_GREEN "[x]" Color_RESET " %s\n", str);
-		} else {
-			print->cb_eprintf("\r[x] %s\n", str);
-		}
-	}
-}

--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -393,13 +393,6 @@ RZ_API void rz_print_byte(RzPrint *p, const char *fmt, int idx, ut8 ch) {
 	rz_print_cursor(p, idx, 1, 0);
 }
 
-RZ_API void rz_print_hexpairs(RzPrint *p, ut64 addr, const ut8 *buf, int len) {
-	int i;
-	for (i = 0; i < len; i++) {
-		p->cb_printf("%02x ", buf[i]);
-	}
-}
-
 static bool checkSparse(const ut8 *p, int len, int ch) {
 	int i;
 	ut8 q = *p;

--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -106,10 +106,6 @@ RZ_API void rz_print_set_flags(RzPrint *p, int _flags) {
 	p->flags = _flags;
 }
 
-RZ_API void rz_print_unset_flags(RzPrint *p, int flags) {
-	p->flags = p->flags & (p->flags ^ flags);
-}
-
 RZ_API void rz_print_set_cursor(RzPrint *p, int enable, int ocursor, int cursor) {
 	if (!p) {
 		return;

--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -1779,61 +1779,6 @@ RZ_API int rz_print_jsondump(RzPrint *p, const ut8 *buf, int len, int wordsize) 
 	return words;
 }
 
-RZ_API void rz_print_hex_from_base2(RzPrint *p, char *base2) {
-	bool first = true;
-	const int len = strlen(base2);
-	if (len < 1) {
-		return;
-	}
-
-	RzPrint defprint = { .cb_printf = libc_printf };
-	if (!p) {
-		p = &defprint;
-	}
-
-	// we split each section by 8 bits and have bytes.
-	ut32 bytes_size = (len >> 3) + (len & 7 ? 1 : 0);
-	ut8 *bytes = calloc(bytes_size, sizeof(ut8));
-	if (!bytes) {
-		eprintf("cannot allocate %d bytes\n", bytes_size);
-		return;
-	}
-
-	int c = len & 7;
-	if (c) {
-		// align counter to 8 bits
-		c = 8 - c;
-	}
-	for (int i = 0, j = 0; i < len && j < bytes_size; i++, c++) {
-		if (base2[i] != '1' && base2[i] != '0') {
-			eprintf("invalid base2 number %c at char %d\n", base2[i], i);
-			free(bytes);
-			return;
-		}
-		// c & 7 is c % 8
-		if (c > 0 && !(c & 7)) {
-			j++;
-		}
-		bytes[j] <<= 1;
-		bytes[j] |= base2[i] - '0';
-	}
-
-	p->cb_printf("0x");
-	for (int i = 0; i < bytes_size; ++i) {
-		if (first) {
-			if (i != (bytes_size - 1) && !bytes[i]) {
-				continue;
-			}
-			p->cb_printf("%x", bytes[i]);
-			first = false;
-		} else {
-			p->cb_printf("%02x", bytes[i]);
-		}
-	}
-	p->cb_printf("\n");
-	free(bytes);
-}
-
 RZ_API const char *rz_print_rowlog(RzPrint *print, const char *str) {
 	int use_color = print->flags & RZ_PRINT_FLAGS_COLOR;
 	bool verbose = print->scr_prompt;

--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -1180,23 +1180,6 @@ RZ_API void rz_print_raw(RzPrint *p, ut64 addr, const ut8 *buf, int len) {
 	p->write(buf, len);
 }
 
-RZ_API void rz_print_c(RzPrint *p, const ut8 *str, int len) {
-	int i, inc = p->width / 6;
-	p->cb_printf("#define _BUFFER_SIZE %d\n"
-		     "unsigned char buffer[_BUFFER_SIZE] = {\n",
-		len);
-	for (i = 0; !rz_print_is_interrupted() && i < len;) {
-		rz_print_byte(p, "0x%02x", i, str[i]);
-		if (++i < len) {
-			p->cb_printf(", ");
-		}
-		if (!(i % inc)) {
-			p->cb_printf("\n");
-		}
-	}
-	p->cb_printf(" };\n");
-}
-
 // HACK :D
 static RzPrint staticp = {
 	.cb_printf = libc_printf

--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -1066,10 +1066,6 @@ RZ_API void rz_print_hexdump(RzPrint *p, ut64 addr, const ut8 *buf, int len, int
 	}
 }
 
-RZ_API void rz_print_hexdump_simple(const ut8 *buf, int len) {
-	rz_print_hexdump(NULL, 0, buf, len, 16, 16, 0);
-}
-
 static const char *getbytediff(RzPrint *p, char *fmt, ut8 a, ut8 b) {
 	if (*fmt) {
 		if (a == b) {


### PR DESCRIPTION
# DO NOT SQUASH ME

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Moved `rz_print_rowlog/rz_print_rowlog_done` to `rz_core_notify_begin/rz_core_notify_done` under rz_core
- Removed `rz_print_cursor_range` because does not exist.
- Removed `rz_print_c` because unused.
- Removed `rz_print_unset_flags` because unused.
- Moved `rz_print_hex_from_base2` under rz-ax since it is used only there.
- Removed `rz_print_hexdump_simple` because unused.
- Removed `rz_print_hexpairs` because unused.
