### PR TITLE
Introduce addr_bits to type db for e.g. thumb

### DIFF
--- a/librz/analysis/analysis.c
+++ b/librz/analysis/analysis.c
@@ -282,6 +282,7 @@ RZ_API bool rz_analysis_set_bits(RzAnalysis *analysis, int bits) {
 			int v = rz_analysis_archinfo(analysis, RZ_ANALYSIS_ARCHINFO_ALIGN);
 			analysis->pcalign = RZ_MAX(0, v);
 			rz_type_db_set_bits(analysis->typedb, bits);
+			rz_type_db_set_address_bits(analysis->typedb, rz_analysis_get_address_bits(analysis));
 			if (!is_hack) {
 				char *types_dir = rz_path_system(RZ_SDB_TYPES);
 				rz_type_db_reload(analysis->typedb, types_dir);

--- a/librz/include/rz_type.h
+++ b/librz/include/rz_type.h
@@ -20,6 +20,7 @@ RZ_LIB_VERSION_HEADER(rz_type);
 typedef struct rz_type_target_t {
 	char *cpu;
 	int bits;
+	int addr_bits; ///< size of a pointer if > 0, otherwise bits is used.
 	char *os;
 	bool big_endian;
 	const char *default_type;
@@ -230,6 +231,7 @@ RZ_API bool rz_type_db_load_sdb_str(RzTypeDB *typedb, RZ_NONNULL const char *str
 RZ_API bool rz_type_db_load_callables_sdb(RzTypeDB *typedb, RZ_NONNULL const char *path);
 RZ_API bool rz_type_db_load_callables_sdb_str(RzTypeDB *typedb, RZ_NONNULL const char *str);
 RZ_API void rz_type_db_set_bits(RzTypeDB *typedb, int bits);
+RZ_API void rz_type_db_set_address_bits(RzTypeDB *typedb, int addr_bits);
 RZ_API void rz_type_db_set_os(RzTypeDB *typedb, const char *os);
 RZ_API void rz_type_db_set_cpu(RzTypeDB *typedb, const char *cpu);
 RZ_API void rz_type_db_set_endian(RzTypeDB *typedb, bool big_endian);

--- a/librz/type/type.c
+++ b/librz/type/type.c
@@ -149,6 +149,21 @@ RZ_API void rz_type_db_set_bits(RzTypeDB *typedb, int bits) {
 }
 
 /**
+ * \brief Set the RzType target adress size
+ *
+ * Important for calculating some types size, especially
+ * pointers's size.
+ *
+ * \param typedb RzTypeDB instance
+ * \param bits size of an address in bits. If <= 0, then
+ *        the value from rz_type_db_set_bits() is used.
+ */
+RZ_API void rz_type_db_set_address_bits(RzTypeDB *typedb, int addr_bits) {
+	rz_return_if_fail(typedb);
+	typedb->target->addr_bits = addr_bits;
+}
+
+/**
  * \brief Set the RzType target architecture operating system
  *
  * Important for calculating some types size, especially
@@ -194,9 +209,7 @@ RZ_API void rz_type_db_set_endian(RzTypeDB *typedb, bool big_endian) {
  * \param typedb RzTypeDB instance
  */
 RZ_API ut8 rz_type_db_pointer_size(const RzTypeDB *typedb) {
-	// TODO: Handle more special cases where the pointer
-	// size is different from the target bitness
-	return typedb->target->bits;
+	return typedb->target->addr_bits > 0 ? typedb->target->addr_bits : typedb->target->bits;
 }
 
 /**

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -188,52 +188,54 @@ pdr~JNI?
 EOF
 EXPECT=<<EOF
 | ; var struct JNINativeInterface JNINativeInterface @ sp+0x12c
-| 0x00000f62      cdb0           sub   JNINativeInterface.GetSuperclassx134
+| 0x00000f62      cdb0           sub   JNINativeInterface.DefineClassx134
 | 0x00000f74      4b93           str   r3, [JNINativeInterface.reserved0]
 | 0x00000f76      039b           ldr   r3, [var_134h]                  ; JNINativeInterface.reserved0
+| 0x00000f7e      d358           ldr   r3, [r2, r3]                    ; JNINativeInterface.GetStringUTFChars
 | 0x00000f82      019a           ldr   r2, [var_13ch]                  ; JNINativeInterface.reserved0
-| 0x00000f8e      4693           str   r3, [JNINativeInterface.GetSuperclassx118]
-| 0x00000f98      4593           str   r3, [JNINativeInterface.GetSuperclassx114]
-| 0x00000f9a      35ab           add   r3, JNINativeInterface.GetSuperclassxd4
-| 0x00000fb0      29ab           add   r3, JNINativeInterface.GetSuperclassxa4
-| 0x00000fc6      1dab           add   r3, JNINativeInterface.GetSuperclassx74
-| 0x00000fdc      11ab           add   r3, JNINativeInterface.GetSuperclassx44
-| 0x00000ff8      469a           ldr   r2, [JNINativeInterface.GetSuperclassx118]
-| 0x00001000      4393           str   r3, [JNINativeInterface.GetSuperclassx10c]
-| 0x00001004      4293           str   r3, [JNINativeInterface.GetSuperclassx108]
+| 0x00000f8e      4693           str   r3, [JNINativeInterface.DefineClassx118]
+| 0x00000f98      4593           str   r3, [JNINativeInterface.DefineClassx114]
+| 0x00000f9a      35ab           add   r3, JNINativeInterface.DefineClassxd4
+| 0x00000fb0      29ab           add   r3, JNINativeInterface.DefineClassxa4
+| 0x00000fc6      1dab           add   r3, JNINativeInterface.DefineClassx74
+| 0x00000fdc      11ab           add   r3, JNINativeInterface.DefineClassx44
+| 0x00000ff8      469a           ldr   r2, [JNINativeInterface.DefineClassx118]
+| 0x00001000      4393           str   r3, [JNINativeInterface.DefineClassx10c]
+| 0x00001004      4293           str   r3, [JNINativeInterface.DefineClassx108]
+| 0x0000100e      d358           ldr   r3, [r2, r3]                    ; JNINativeInterface.GetStringLength
 | 0x00001012      019a           ldr   r2, [var_13ch]                  ; JNINativeInterface.reserved0
-| 0x0000101c      4193           str   r3, [JNINativeInterface.GetSuperclassx104]
-| 0x00001020      4ca8           add   r0, JNINativeInterface.reserved2
-| 0x0000103a      439b           ldr   r3, [JNINativeInterface.GetSuperclassx10c]
-| 0x00001040      439a           ldr   r2, [JNINativeInterface.GetSuperclassx10c]
-| 0x00001042      29ab           add   r3, JNINativeInterface.GetSuperclassxa4
-| 0x00001048      4399           ldr   r1, [JNINativeInterface.GetSuperclassx10c]
-| 0x0000104a      1dab           add   r3, JNINativeInterface.GetSuperclassx74
-| 0x00001052      439b           ldr   r3, [JNINativeInterface.GetSuperclassx10c]
-| 0x00001054      4699           ldr   r1, [JNINativeInterface.GetSuperclassx118]
-| 0x00001066      d258           ldr   r2, [r2, r3]                    ; JNINativeInterface.reserved0
-| 0x00001078      439a           ldr   r2, [JNINativeInterface.GetSuperclassx10c]
-| 0x0000107a      4399           ldr   r1, [JNINativeInterface.GetSuperclassx10c]
-| 0x0000107e      4cad           add   r5, JNINativeInterface.reserved2
-| 0x00001086      4398           ldr   r0, [JNINativeInterface.GetSuperclassx10c]
-| 0x00001088      11ab           add   r3, JNINativeInterface.GetSuperclassx44
-| 0x00001092      4ca8           add   r0, JNINativeInterface.reserved2
-| 0x0000109a      439b           ldr   r3, [JNINativeInterface.GetSuperclassx10c]
-| 0x0000109e      4393           str   r3, [JNINativeInterface.GetSuperclassx10c]
-| 0x000010a0      439b           ldr   r3, [JNINativeInterface.GetSuperclassx10c]
-| 0x000010a4      4293           str   r3, [JNINativeInterface.GetSuperclassx108]
-| 0x000010a6      439b           ldr   r3, [JNINativeInterface.GetSuperclassx10c]
-| 0x000010a8      469a           ldr   r2, [JNINativeInterface.GetSuperclassx118]
-| 0x000010ca      4493           str   r3, [JNINativeInterface.GetSuperclassx110]
-| 0x000010d2      419b           ldr   r3, [JNINativeInterface.GetSuperclassx104]
-| 0x000010d8      459a           ldr   r2, [JNINativeInterface.GetSuperclassx114]
-| 0x000010da      449b           ldr   r3, [JNINativeInterface.GetSuperclassx110]
-| 0x00001114      d258           ldr   r2, [r2, r3]                    ; JNINativeInterface.reserved0
-| 0x0000112e      d258           ldr   r2, [r2, r3]                    ; JNINativeInterface.reserved0
+| 0x0000101c      4193           str   r3, [JNINativeInterface.DefineClassx104]
+| 0x00001020      4ca8           add   r0, JNINativeInterface.reserved1
+| 0x0000103a      439b           ldr   r3, [JNINativeInterface.DefineClassx10c]
+| 0x00001040      439a           ldr   r2, [JNINativeInterface.DefineClassx10c]
+| 0x00001042      29ab           add   r3, JNINativeInterface.DefineClassxa4
+| 0x00001048      4399           ldr   r1, [JNINativeInterface.DefineClassx10c]
+| 0x0000104a      1dab           add   r3, JNINativeInterface.DefineClassx74
+| 0x00001052      439b           ldr   r3, [JNINativeInterface.DefineClassx10c]
+| 0x00001054      4699           ldr   r1, [JNINativeInterface.DefineClassx118]
+| 0x00001066      d258           ldr   r2, [r2, r3]                    ; JNINativeInterface.NewStringUTF
+| 0x00001078      439a           ldr   r2, [JNINativeInterface.DefineClassx10c]
+| 0x0000107a      4399           ldr   r1, [JNINativeInterface.DefineClassx10c]
+| 0x0000107e      4cad           add   r5, JNINativeInterface.reserved1
+| 0x00001086      4398           ldr   r0, [JNINativeInterface.DefineClassx10c]
+| 0x00001088      11ab           add   r3, JNINativeInterface.DefineClassx44
+| 0x00001092      4ca8           add   r0, JNINativeInterface.reserved1
+| 0x0000109a      439b           ldr   r3, [JNINativeInterface.DefineClassx10c]
+| 0x0000109e      4393           str   r3, [JNINativeInterface.DefineClassx10c]
+| 0x000010a0      439b           ldr   r3, [JNINativeInterface.DefineClassx10c]
+| 0x000010a4      4293           str   r3, [JNINativeInterface.DefineClassx108]
+| 0x000010a6      439b           ldr   r3, [JNINativeInterface.DefineClassx10c]
+| 0x000010a8      469a           ldr   r2, [JNINativeInterface.DefineClassx118]
+| 0x000010ca      4493           str   r3, [JNINativeInterface.DefineClassx110]
+| 0x000010d2      419b           ldr   r3, [JNINativeInterface.DefineClassx104]
+| 0x000010d8      459a           ldr   r2, [JNINativeInterface.DefineClassx114]
+| 0x000010da      449b           ldr   r3, [JNINativeInterface.DefineClassx110]
+| 0x00001114      d258           ldr   r2, [r2, r3]                    ; JNINativeInterface.NewStringUTF
+| 0x0000112e      d258           ldr   r2, [r2, r3]                    ; JNINativeInterface.NewStringUTF
 | 0x00001144      4b9a           ldr   r2, [JNINativeInterface.reserved0]
 | 0x00001148      9a42           cmp   r2, r3                          ; JNINativeInterface.reserved0
-| 0x00001150      4db0           add   JNINativeInterface.GetSuperclassx134
-46
+| 0x00001150      4db0           add   JNINativeInterface.DefineClassx134
+48
 EOF
 RUN
 

--- a/test/unit/test_type.c
+++ b/test/unit/test_type.c
@@ -1013,6 +1013,19 @@ bool test_references(void) {
 	mu_end;
 }
 
+bool test_addr_bits(void) {
+	RzTypeDB *typedb = rz_type_db_new();
+	rz_type_db_set_bits(typedb, 32);
+	mu_assert_eq(rz_type_db_pointer_size(typedb), 32, "ptr size");
+	rz_type_db_set_bits(typedb, 64);
+	mu_assert_eq(rz_type_db_pointer_size(typedb), 64, "ptr size");
+	rz_type_db_set_address_bits(typedb, 32); // overrided bits
+	mu_assert_eq(rz_type_db_pointer_size(typedb), 32, "ptr size");
+	rz_type_db_set_bits(typedb, 16);
+	mu_assert_eq(rz_type_db_pointer_size(typedb), 32, "ptr size");
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test(test_types_get_base_type_struct);
 	mu_run_test(test_types_get_base_type_union);
@@ -1033,6 +1046,7 @@ int all_tests() {
 	mu_run_test(test_union_identifier_without_specifier);
 	mu_run_test(test_edit_types);
 	mu_run_test(test_references);
+	mu_run_test(test_addr_bits);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This has the same meaning as rz_analysis_get_address_bits(), i.e. the
size of an address, which is often, but not always the same as the
"asm.bits" bitness, especiall in thumb where it has to be 32, rather
than 16. This fixes pointer size calculation for such cases.

**Test plan**

see the unit test and issue

**Closing issues**

Fix #1835