### PR TITLE
Update SDB for C++ compatibility

### DIFF
--- a/subprojects/sdb.wrap
+++ b/subprojects/sdb.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/rizinorg/sdb.git
-revision = 9e685f97319465fa86dcf24cf7638c260ec4c881
+revision = efb34470cb0d6eb19f4498fcd0c9324180e22647


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Since 170ab3eb3bc9b536b2f469c036a6c3674f831677, `ht_pp.h` was included
before the full `sdb.h`, making the symbols mangled in C++ and thus
breaking Cutter by default.
This has been fixed in sdb now.