### PR TITLE
Avoid closing -1 in rz_subprocess_wait()

### DIFF
--- a/librz/util/subprocess.c
+++ b/librz/util/subprocess.c
@@ -1003,9 +1003,11 @@ static RzSubprocessWaitReason subprocess_wait(RzSubprocess *proc, ut64 timeout_m
  * \param timeout_ms Wait for at most this amount of millisecond
  */
 RZ_API RzSubprocessWaitReason rz_subprocess_wait(RzSubprocess *proc, ut64 timeout_ms) {
-	// Close subprocess stdin
-	rz_sys_pipe_close(proc->stdin_fd);
-	proc->stdin_fd = -1;
+	if (proc->stdin_fd != -1) {
+		// Close subprocess stdin to tell it that no more input will come from us
+		rz_sys_pipe_close(proc->stdin_fd);
+		proc->stdin_fd = -1;
+	}
 	// Empty buffers and read everything we can
 	rz_strbuf_fini(&proc->out);
 	rz_strbuf_init(&proc->out);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The stdin_fd may be -1 whenever a subprocess does not have its stdin piped.
This appeared as a failed assertion on Mac OS X 10.5, where rz_sys_pipe_close()
uses a hashtable to track fds.

![Bildschirmfoto 2022-03-28 um 21 07 06](https://user-images.githubusercontent.com/1460997/160469800-b1a42ca2-c1ea-45f4-a1ac-6252e9926ad0.png)
![Bild 4](https://user-images.githubusercontent.com/1460997/160470256-9cc08307-747c-4482-9524-b70ad7939956.png)
