### PR TITLE
Convert aae to newshell and remove /re

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4721,7 +4721,6 @@ RZ_API void rz_core_analysis_esil(RzCore *core, ut64 addr, ut64 size, RZ_NULLABL
 							char *str2 = sdb_fmt("esilref: '%s'", str);
 							// HACK avoid format string inside string used later as format
 							// string crashes disasm inside agf under some conditions.
-							// https://github.com/rizinorg/rizin/issues/6937
 							rz_str_replace_char(str2, '%', '&');
 							rz_meta_set_string(core->analysis, RZ_META_TYPE_COMMENT, cur, str2);
 							free(str);

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4548,7 +4548,7 @@ RZ_API void rz_core_analysis_esil(RzCore *core, ut64 addr, ut64 size, RZ_NULLABL
 	RZ_NULLABLE const char *sn = rz_reg_get_name(core->analysis->reg, RZ_REG_NAME_SN);
 
 	IterCtx ictx = { start, end, fcn, NULL };
-	size_t i = addr - start;
+	size_t i = 0;
 	do {
 		if (esil_analysis_stop || rz_cons_is_breaked()) {
 			break;
@@ -4666,9 +4666,6 @@ RZ_API void rz_core_analysis_esil(RzCore *core, ut64 addr, ut64 size, RZ_NULLABL
 		}
 		(void)rz_analysis_esil_parse(ESIL, esilstr);
 #define CHECKREF(x) ((refptr && (x) == refptr) || !refptr)
-		// looks like ^C is handled by esil_parse !!!!
-		// rz_analysis_esil_dumpstack (ESIL);
-		// rz_analysis_esil_stack_free (ESIL);
 		switch (op.type) {
 		case RZ_ANALYSIS_OP_TYPE_LEA:
 			// arm64

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4452,7 +4452,14 @@ static inline bool get_next_i(IterCtx *ctx, size_t *next_i) {
 	return true;
 }
 
-RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *target) {
+/**
+ * Analyze references with esil (aae)
+ *
+ * \p addr start address
+ * \p size number of bytes to analyze
+ * \p fcn optional, when analyzing for a specific function
+ */
+RZ_API void rz_core_analysis_esil(RzCore *core, ut64 addr, ut64 size, RZ_NULLABLE RzAnalysisFunction *fcn) {
 	bool cfg_analysis_strings = rz_config_get_i(core->config, "analysis.strings");
 	bool emu_lazy = rz_config_get_i(core->config, "emu.lazy");
 	bool gp_fixed = rz_config_get_i(core->config, "analysis.gpfixed");
@@ -4460,62 +4467,14 @@ RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *tar
 	const char *pcname;
 	RzAnalysisOp op = RZ_EMPTY;
 	ut8 *buf = NULL;
-	bool end_address_set = false;
 	int iend;
 	int minopsize = 4; // XXX this depends on asm->mininstrsize
 	bool archIsArm = false;
-	ut64 addr = core->offset;
 	ut64 start = addr;
-	ut64 end = 0LL;
-	ut64 cur;
-
-	if (!strcmp(str, "?")) {
-		eprintf("Usage: aae[f] [len] [addr] - analyze refs in function, section or len bytes with esil\n");
-		eprintf("  aae $SS @ $S             - analyze the whole section\n");
-		eprintf("  aae $SS str.Hello @ $S   - find references for str.Hellow\n");
-		eprintf("  aaef                     - analyze functions discovered with esil\n");
+	ut64 end = addr + size;
+	if (end <= start) {
 		return;
 	}
-#define CHECKREF(x) ((refptr && (x) == refptr) || !refptr)
-	if (target) {
-		const char *expr = rz_str_trim_head_ro(target);
-		if (*expr) {
-			refptr = ntarget = rz_num_math(core->num, expr);
-			if (!refptr) {
-				ntarget = refptr = addr;
-			}
-		} else {
-			ntarget = UT64_MAX;
-			refptr = 0LL;
-		}
-	} else {
-		ntarget = UT64_MAX;
-		refptr = 0LL;
-	}
-	RzAnalysisFunction *fcn = NULL;
-	if (!strcmp(str, "f")) {
-		fcn = rz_analysis_get_fcn_in(core->analysis, core->offset, 0);
-		if (fcn) {
-			start = rz_analysis_function_min_addr(fcn);
-			addr = fcn->addr;
-			end = rz_analysis_function_max_addr(fcn);
-			end_address_set = true;
-		}
-	}
-
-	if (!end_address_set) {
-		if (str[0] == ' ') {
-			end = addr + rz_num_math(core->num, str + 1);
-		} else {
-			RzIOMap *map = rz_io_map_get(core->io, addr);
-			if (map) {
-				end = map->itv.addr + map->itv.size;
-			} else {
-				end = addr + core->blocksize;
-			}
-		}
-	}
-
 	iend = end - start;
 	if (iend < 0) {
 		return;
@@ -4595,7 +4554,7 @@ RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *tar
 			break;
 		}
 		size_t i_old = i;
-		cur = start + i;
+		ut64 cur = start + i;
 		if (!rz_io_is_valid_offset(core->io, cur, 0)) {
 			break;
 		}
@@ -4706,6 +4665,7 @@ RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *tar
 			rz_reg_setv(core->analysis->reg, gp_reg, gp);
 		}
 		(void)rz_analysis_esil_parse(ESIL, esilstr);
+#define CHECKREF(x) ((refptr && (x) == refptr) || !refptr)
 		// looks like ^C is handled by esil_parse !!!!
 		// rz_analysis_esil_dumpstack (ESIL);
 		// rz_analysis_esil_stack_free (ESIL);
@@ -4716,13 +4676,12 @@ RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *tar
 				if (CHECKREF(ESIL->cur)) {
 					rz_analysis_xrefs_set(core->analysis, cur, ESIL->cur, RZ_ANALYSIS_REF_TYPE_STRING);
 				}
-			} else if ((target && op.ptr == ntarget) || !target) {
-				if (CHECKREF(ESIL->cur)) {
-					if (op.ptr && rz_io_is_valid_offset(core->io, op.ptr, !core->analysis->opt.noncode)) {
-						rz_analysis_xrefs_set(core->analysis, cur, op.ptr, RZ_ANALYSIS_REF_TYPE_STRING);
-					} else {
-						rz_analysis_xrefs_set(core->analysis, cur, ESIL->cur, RZ_ANALYSIS_REF_TYPE_STRING);
-					}
+			}
+			if (CHECKREF(ESIL->cur)) {
+				if (op.ptr && rz_io_is_valid_offset(core->io, op.ptr, !core->analysis->opt.noncode)) {
+					rz_analysis_xrefs_set(core->analysis, cur, op.ptr, RZ_ANALYSIS_REF_TYPE_STRING);
+				} else {
+					rz_analysis_xrefs_set(core->analysis, cur, ESIL->cur, RZ_ANALYSIS_REF_TYPE_STRING);
 				}
 			}
 			if (cfg_analysis_strings) {
@@ -4734,10 +4693,8 @@ RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *tar
 			if (core->analysis->cur && archIsArm) {
 				/* This code is known to work on Thumb, ARM and ARM64 */
 				ut64 dst = ESIL->cur;
-				if ((target && dst == ntarget) || !target) {
-					if (CHECKREF(dst)) {
-						rz_analysis_xrefs_set(core->analysis, cur, dst, RZ_ANALYSIS_REF_TYPE_DATA);
-					}
+				if (CHECKREF(dst)) {
+					rz_analysis_xrefs_set(core->analysis, cur, dst, RZ_ANALYSIS_REF_TYPE_DATA);
 				}
 				if (cfg_analysis_strings) {
 					add_string_ref(core, op.addr, dst);
@@ -4753,26 +4710,24 @@ RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *tar
 				if (!strcmp(op.src[0]->reg->name, "zero")) {
 					break;
 				}
-				if ((target && dst == ntarget) || !target) {
-					if (dst > 0xffff && op.src[1] && (dst & 0xffff) == (op.src[1]->imm & 0xffff) && myvalid(core->io, dst)) {
-						RzFlagItem *f;
-						char *str;
-						if (CHECKREF(dst) || CHECKREF(cur)) {
-							rz_analysis_xrefs_set(core->analysis, cur, dst, RZ_ANALYSIS_REF_TYPE_DATA);
-							if (cfg_analysis_strings) {
-								add_string_ref(core, op.addr, dst);
-							}
-							if ((f = rz_core_flag_get_by_spaces(core->flags, dst))) {
-								rz_meta_set_string(core->analysis, RZ_META_TYPE_COMMENT, cur, f->name);
-							} else if ((str = is_string_at(core, dst, NULL))) {
-								char *str2 = sdb_fmt("esilref: '%s'", str);
-								// HACK avoid format string inside string used later as format
-								// string crashes disasm inside agf under some conditions.
-								// https://github.com/rizinorg/rizin/issues/6937
-								rz_str_replace_char(str2, '%', '&');
-								rz_meta_set_string(core->analysis, RZ_META_TYPE_COMMENT, cur, str2);
-								free(str);
-							}
+				if (dst > 0xffff && op.src[1] && (dst & 0xffff) == (op.src[1]->imm & 0xffff) && myvalid(core->io, dst)) {
+					RzFlagItem *f;
+					char *str;
+					if (CHECKREF(dst) || CHECKREF(cur)) {
+						rz_analysis_xrefs_set(core->analysis, cur, dst, RZ_ANALYSIS_REF_TYPE_DATA);
+						if (cfg_analysis_strings) {
+							add_string_ref(core, op.addr, dst);
+						}
+						if ((f = rz_core_flag_get_by_spaces(core->flags, dst))) {
+							rz_meta_set_string(core->analysis, RZ_META_TYPE_COMMENT, cur, f->name);
+						} else if ((str = is_string_at(core, dst, NULL))) {
+							char *str2 = sdb_fmt("esilref: '%s'", str);
+							// HACK avoid format string inside string used later as format
+							// string crashes disasm inside agf under some conditions.
+							// https://github.com/rizinorg/rizin/issues/6937
+							rz_str_replace_char(str2, '%', '&');
+							rz_meta_set_string(core->analysis, RZ_META_TYPE_COMMENT, cur, str2);
+							free(str);
 						}
 					}
 				}
@@ -4861,6 +4816,7 @@ RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *tar
 			break;
 		}
 	} while (get_next_i(&ictx, &i));
+#undef CHECKREF
 	free(buf);
 	ESIL->cb.hook_mem_read = NULL;
 	ESIL->cb.hook_mem_write = NULL;

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -9122,7 +9122,7 @@ RZ_IPI RzCmdStatus rz_analyse_name_handler(RzCore *core, int argc, const char **
 }
 
 RZ_IPI RzCmdStatus rz_analysis_all_esil_handler(RzCore *core, int argc, const char **argv) {
-	bool reg_flags_defined = !!rz_flag_space_count(core->flags, RZ_FLAGS_FS_REGISTERS);
+	bool reg_flags_defined = rz_flag_space_count(core->flags, RZ_FLAGS_FS_REGISTERS) != 0;
 	if (argc > 1) {
 		rz_core_analysis_esil(core, core->offset, rz_num_get(core->num, argv[1]), NULL);
 	} else {
@@ -9136,7 +9136,7 @@ RZ_IPI RzCmdStatus rz_analysis_all_esil_handler(RzCore *core, int argc, const ch
 }
 
 RZ_IPI RzCmdStatus rz_analysis_all_esil_functions_handler(RzCore *core, int argc, const char **argv) {
-	bool reg_flags_defined = !!rz_flag_space_count(core->flags, RZ_FLAGS_FS_REGISTERS);
+	bool reg_flags_defined = rz_flag_space_count(core->flags, RZ_FLAGS_FS_REGISTERS) != 0;
 	rz_core_analysis_esil_references_all_functions(core);
 	if (!reg_flags_defined) {
 		// hack to not leak flags if not wanted

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -58,7 +58,7 @@ static const char *help_msg_slash[] = {
 	"/p", " patternsize", "search for pattern of given size",
 	"/P", " patternsize", "search similar blocks",
 	"/s", "[*] [threshold]", "find sections by grouping blocks with similar entropy",
-	"/r[erwx]", "[?] sym.printf", "analyze opcode reference an offset (/re for esil)",
+	"/r[rwx]", "[?] sym.printf", "analyze opcode reference an offset",
 	"/R", " [grepopcode]", "search for matching ROP gadgets, semicolon-separated",
 	// moved into /as "/s", "", "search for all syscalls in a region (EXPERIMENTAL)",
 	"/v", "[1248] value", "look for an `cfg.bigendian` 32bit value",
@@ -117,7 +117,6 @@ static const char *help_msg_slash_r[] = {
 	"/r", " [addr]", "search references to this specific address",
 	"/ra", "", "search all references",
 	"/rc", "", "search for call references",
-	"/re", " [addr]", "search references using esil",
 	"/rr", "", "Find read references",
 	"/rw", "", "Find write references",
 	"/rx", "", "Find exec references",
@@ -3086,7 +3085,7 @@ reread:
 			}
 		}
 		goto beach;
-	case 'r': // "/r" and "/re"
+	case 'r': // "/r"
 	{
 		ut64 n = (input[1] == ' ' || (input[1] && input[2] == ' '))
 			? rz_num_math(core->num, input + 2)
@@ -3114,26 +3113,6 @@ reread:
 				rz_core_analysis_search(core, map->itv.addr, rz_itv_end(map->itv), n, 0);
 			}
 		} break;
-		case 'e': // "/re"
-			if (input[2] == '?') {
-				eprintf("Usage: /re $$ - to find references to current address\n");
-			} else {
-				RzListIter *iter;
-				RzIOMap *map;
-				rz_list_foreach (param.boundaries, iter, map) {
-					eprintf("-- 0x%" PFMT64x " 0x%" PFMT64x "\n", map->itv.addr, rz_itv_end(map->itv));
-					ut64 refptr = rz_num_math(core->num, input + 2);
-					ut64 curseek = core->offset;
-					rz_core_seek(core, map->itv.addr, true);
-					char *arg = rz_str_newf(" %" PFMT64d, rz_itv_end(map->itv) - map->itv.addr);
-					char *trg = refptr ? rz_str_newf(" %" PFMT64d, refptr) : strdup("");
-					rz_core_analysis_esil(core, arg, trg);
-					free(arg);
-					free(trg);
-					rz_core_seek(core, curseek, true);
-				}
-			}
-			break;
 		case 'r': // "/rr" - read refs
 		{
 			RzListIter *iter;

--- a/librz/core/cmd_descs/cmd_analysis.yaml
+++ b/librz/core/cmd_descs/cmd_analysis.yaml
@@ -3,6 +3,29 @@
 ---
 name: cmd_analysis
 commands:
+  - name: aae
+    summary: analyze references with ESIL
+    cname: analysis_all_esil
+    type: RZ_CMD_DESC_TYPE_ARGV
+    args:
+      - name: len
+        type: RZ_CMD_ARG_TYPE_RZNUM
+        optional: true
+    details:
+      - name: Examples
+        entries:
+          - text: "aae"
+            arg_str: ""
+            comment: analyze ranges given by analysis.in
+          - text: "aae"
+            arg_str: " $SS @ $S"
+            comment: analyze the whole section
+
+  - name: aaef
+    summary: analyze references with ESIL in all functions
+    cname: analysis_all_esil_functions
+    type: RZ_CMD_DESC_TYPE_ARGV
+    args: []
   - name: af
     summary: Analyze Functions commands
     cname: cmd_analysis_fcn

--- a/librz/core/cmd_descs/cmd_analysis.yaml
+++ b/librz/core/cmd_descs/cmd_analysis.yaml
@@ -20,7 +20,6 @@ commands:
           - text: "aae"
             arg_str: " $SS @ $S"
             comment: analyze the whole section
-
   - name: aaef
     summary: analyze references with ESIL in all functions
     cname: analysis_all_esil_functions

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -12,6 +12,7 @@ static const RzCmdDescDetail system_to_cons_details[2];
 static const RzCmdDescDetail hash_bang_details[2];
 static const RzCmdDescDetail pointer_details[2];
 static const RzCmdDescDetail interpret_macro_multiple_details[2];
+static const RzCmdDescDetail analysis_all_esil_details[2];
 static const RzCmdDescDetail analysis_reg_cond_details[4];
 static const RzCmdDescDetail ar_details[2];
 static const RzCmdDescDetail analysis_hint_set_arch_details[2];
@@ -84,6 +85,7 @@ static const RzCmdDescArg remote_tcp_args[3];
 static const RzCmdDescArg remote_rap_bg_args[2];
 static const RzCmdDescArg cmd_help_search_args[2];
 static const RzCmdDescArg push_escaped_args[2];
+static const RzCmdDescArg analysis_all_esil_args[2];
 static const RzCmdDescArg analysis_function_blocks_add_args[7];
 static const RzCmdDescArg analysis_function_blocks_edge_args[3];
 static const RzCmdDescArg analysis_function_blocks_color_args[3];
@@ -1169,6 +1171,39 @@ static const RzCmdDescHelp push_escaped_help = {
 static const RzCmdDescHelp cmd_analysis_help = {
 	.summary = "Analysis commands",
 };
+static const RzCmdDescDetailEntry analysis_all_esil_Examples_detail_entries[] = {
+	{ .text = "aae", .arg_str = "", .comment = "analyze ranges given by analysis.in" },
+	{ .text = "aae", .arg_str = " $SS @ $S", .comment = "analyze the whole section" },
+	{ 0 },
+};
+static const RzCmdDescDetail analysis_all_esil_details[] = {
+	{ .name = "Examples", .entries = analysis_all_esil_Examples_detail_entries },
+	{ 0 },
+};
+static const RzCmdDescArg analysis_all_esil_args[] = {
+	{
+		.name = "len",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_all_esil_help = {
+	.summary = "analyze references with ESIL",
+	.details = analysis_all_esil_details,
+	.args = analysis_all_esil_args,
+};
+
+static const RzCmdDescArg analysis_all_esil_functions_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_all_esil_functions_help = {
+	.summary = "analyze references with ESIL in all functions",
+	.args = analysis_all_esil_functions_args,
+};
+
 static const RzCmdDescHelp cmd_analysis_fcn_help = {
 	.summary = "Analyze Functions commands",
 };
@@ -12963,6 +12998,12 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *cmd_analysis_cd = rz_cmd_desc_oldinput_new(core->rcmd, root_cd, "a", rz_cmd_analysis, &cmd_analysis_help);
 	rz_warn_if_fail(cmd_analysis_cd);
+	RzCmdDesc *analysis_all_esil_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_analysis_cd, "aae", rz_analysis_all_esil_handler, &analysis_all_esil_help);
+	rz_warn_if_fail(analysis_all_esil_cd);
+
+	RzCmdDesc *analysis_all_esil_functions_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_analysis_cd, "aaef", rz_analysis_all_esil_functions_handler, &analysis_all_esil_functions_help);
+	rz_warn_if_fail(analysis_all_esil_functions_cd);
+
 	RzCmdDesc *cmd_analysis_fcn_cd = rz_cmd_desc_oldinput_new(core->rcmd, cmd_analysis_cd, "af", rz_cmd_analysis_fcn, &cmd_analysis_fcn_help);
 	rz_warn_if_fail(cmd_analysis_fcn_cd);
 	RzCmdDesc *afb_cd = rz_cmd_desc_group_state_new(core->rcmd, cmd_analysis_fcn_cd, "afb", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_TABLE, rz_analysis_function_blocks_list_handler, &analysis_function_blocks_list_help, &afb_help);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -52,6 +52,8 @@ RZ_IPI RzCmdStatus rz_remote_rap_bg_handler(RzCore *core, int argc, const char *
 RZ_IPI RzCmdStatus rz_cmd_help_search_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_IPI int rz_cmd_help(void *data, const char *input);
 RZ_IPI RzCmdStatus rz_push_escaped_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_analysis_all_esil_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_analysis_all_esil_functions_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_analysis_function_blocks_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_analysis_function_blocks_add_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_analysis_function_blocks_del_handler(RzCore *core, int argc, const char **argv);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -695,7 +695,7 @@ RZ_API RzCmdStatus rz_core_core_plugins_print(RzCore *core, RzCmdStateOutput *st
 /* cil.c */
 // TODO : They should have been there, but require `static` vars inside canalysis.c
 //      : Keep esil in canalysis.c, and split the rzil in cil.c
-RZ_API void rz_core_analysis_esil(RzCore *core, const char *str, const char *addr);
+RZ_API void rz_core_analysis_esil(RzCore *core, ut64 addr, ut64 size, RZ_NULLABLE RzAnalysisFunction *fcn);
 RZ_API bool rz_core_esil_cmd(RzAnalysisEsil *esil, const char *cmd, ut64 a1, ut64 a2);
 RZ_API int rz_core_esil_step(RzCore *core, ut64 until_addr, const char *until_expr, ut64 *prev_addr, bool stepOver);
 RZ_API int rz_core_esil_step_back(RzCore *core);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The functionality to analyze only for references that point to a
specific addr, available as `aae <size> <addr>` and `/re` was untested
and at least half broken, so it was removed.
The rest of the code has also been refactored to use less strings and
global state (no core->offset).
