### PR TITLE
Avoid trying to re-create targets in cmake config

### DIFF
--- a/librz/RizinConfig.cmake.in
+++ b/librz/RizinConfig.cmake.in
@@ -88,6 +88,11 @@ foreach(_comp ${Rizin_FIND_COMPONENTS})
     set(Rizin_NOT_FOUND_MESSAGE "Unsupported component: ${_comp}")
     return()
   endif()
+  if (rz_${_comp_lower}_FOUND)
+    # Already got this component, trying to re-add the
+    # target below would be an error
+    continue()
+  endif()
   find_package(rz_${_comp_lower} PATHS ${_rizin_cmake_path})
   if (NOT rz_${_comp_lower}_FOUND)
     set(Rizin_FOUND False)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

When `find_package(Rizin ...)` would be called multiple times, the
second add_library call would error because the target already exists.
![Bildschirmfoto 2022-03-30 um 19 38 05](https://user-images.githubusercontent.com/1460997/160897284-2fd5532e-7b9b-4aad-9219-49cf6ce2aea2.png)

