### PR TITLE
Dex add support for some imports within direct_methods via super calls

### DIFF
--- a/test/db/analysis/dalvik
+++ b/test/db/analysis/dalvik
@@ -5,11 +5,13 @@ EXPECT=<<EOF
 0x10000025c    1 34           entry0
 0x8000000000    1 2            sym.Ljava_io_PrintStream_.println_Ljava_lang_String__V
 0x100000238    1 20           method.public.constructor.LHello_._init___V
+0x8000000006    1 2            sym.Ljava_lang_Object_._init___V
 0x100000290    1 84           method.public.LHello_.foo_I_V
-0x8000000006    1 2            sym.Ljava_lang_StringBuilder_.append_Ljava_lang_String__Ljava_lang_StringBuilder
+0x8000000008    1 2            sym.Ljava_lang_StringBuilder_._init___V
+0x800000000a    1 2            sym.Ljava_lang_StringBuilder_.append_Ljava_lang_String__Ljava_lang_StringBuilder
 0x8000000002    1 2            sym.Ljava_lang_Integer_._init__I_V
 0x8000000004    1 2            sym.Ljava_lang_Integer_.toString__Ljava_lang_String
-0x8000000008    1 2            sym.Ljava_lang_StringBuilder_.toString__Ljava_lang_String
+0x800000000c    1 2            sym.Ljava_lang_StringBuilder_.toString__Ljava_lang_String
 0x1000002f4    1 20           method.public.constructor.LWorld_._init___V
 0x100000318    1 68           method.public.LWorld_.foo_I_V
 EOF
@@ -28,9 +30,16 @@ FILE=bins/dex/HelloWorld.dex
 CMDS=aa; axt @ sym.LHello_._init___V
 EXPECT=<<EOF
 entry0 0x10000026e [CALL] invoke-direct {v0}, LHello;-><init>()V
-method.public.LHello_.foo_I_V 0x100000298 [CALL] invoke-direct {v1}, Ljava/lang/StringBuilder;-><init>()V
-method.public.constructor.LWorld_._init___V; void <init>() 0x1000002f4 [CALL] invoke-direct {v1}, Ljava/lang/Object;-><init>()V
-method.public.LWorld_.foo_I_V 0x100000320 [CALL] invoke-direct {v1}, Ljava/lang/StringBuilder;-><init>()V
+EOF
+RUN
+
+NAME=Dalvik HelloWorld func xref to super method
+FILE=bins/dex/org.radare.radare2installer.dex
+CMDS=aaa; axt @ sym.Landroid_app_Activity_.onDestroy__V~invoke-super
+EXPECT=<<EOF
+method.public.Lorg_radare_radare2installer_ConsoleActivity_.onDestroy__V; void onDestroy() 0x100019e50 [CALL] invoke-super {v1}, Landroid/app/Activity;->onDestroy()V
+method.public.Lorg_radare_radare2installer_LaunchActivity_.onDestroy__V 0x10001a256 [CALL] invoke-super {v1}, Landroid/app/Activity;->onDestroy()V
+method.public.Lorg_radare_radare2installer_WebActivity_.onDestroy__V; void onDestroy() 0x10001e574 [CALL] invoke-super {v2}, Landroid/app/Activity;->onDestroy()V
 EOF
 RUN
 

--- a/test/db/formats/dex
+++ b/test/db/formats/dex
@@ -159,10 +159,10 @@ EXPECT=<<EOF
 0x8000000000 2 java.io.PrintStream imp.println(Ljava/lang/String;)V
 0x8000000002 2 java.lang.Integer imp.<init>(I)V
 0x8000000004 2 java.lang.Integer imp.toString()Ljava/lang/String;
-0x100000238 20 java.lang.Object void <init>()
-0x100000238 20 java.lang.StringBuilder void <init>()
-0x8000000006 2 java.lang.StringBuilder imp.append(Ljava/lang/String;)Ljava/lang/StringBuilder;
-0x8000000008 2 java.lang.StringBuilder imp.toString()Ljava/lang/String;
+0x8000000006 2 java.lang.Object imp.<init>()V
+0x8000000008 2 java.lang.StringBuilder imp.<init>()V
+0x800000000a 2 java.lang.StringBuilder imp.append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+0x800000000c 2 java.lang.StringBuilder imp.toString()Ljava/lang/String;
 EOF
 RUN
 
@@ -176,8 +176,6 @@ EXPECT=<<EOF
 0x00000208 1 class.LWorld
 0x100000228 908 section.data
 0x100000238 20 sym.LHello_._init___V
-0x100000238 20 sym.Ljava_lang_Object_._init___V
-0x100000238 20 sym.Ljava_lang_StringBuilder_._init___V
 0x100000238 1 method.public.constructor.LHello_._init___V
 0x10000025c 256 main
 0x10000025c 1 entry0
@@ -222,12 +220,14 @@ EXPECT=<<EOF
 0x1000004f2 0 sym.LHello_.localVar
 0x100000506 0 sym.LWorld_.worldVar
 0x100000508 0 sym.LWorld_.worldVar2
-0x8000000000 10 section.reloc_targets
+0x8000000000 14 section.reloc_targets
 0x8000000000 2 sym.Ljava_io_PrintStream_.println_Ljava_lang_String__V
 0x8000000002 2 sym.Ljava_lang_Integer_._init__I_V
 0x8000000004 2 sym.Ljava_lang_Integer_.toString__Ljava_lang_String
-0x8000000006 2 sym.Ljava_lang_StringBuilder_.append_Ljava_lang_String__Ljava_lang_StringBuilder
-0x8000000008 2 sym.Ljava_lang_StringBuilder_.toString__Ljava_lang_String
+0x8000000006 2 sym.Ljava_lang_Object_._init___V
+0x8000000008 2 sym.Ljava_lang_StringBuilder_._init___V
+0x800000000a 2 sym.Ljava_lang_StringBuilder_.append_Ljava_lang_String__Ljava_lang_StringBuilder
+0x800000000c 2 sym.Ljava_lang_StringBuilder_.toString__Ljava_lang_String
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fix #2416

For some reasons also direct_methods contains imports due the calls to super, this means that not all relocs were resolved.

New output:
![image](https://user-images.githubusercontent.com/561184/161407028-ee950168-7fdf-429f-8d82-e987a38d5a22.png)

Old output:
![image](https://user-images.githubusercontent.com/561184/161407046-c1b50dc4-8b87-4d59-ac17-e2931496039a.png)
