### PR TITLE
rz_cons_free: Move Windows cleanup code below `refcnt` check

### DIFF
--- a/librz/cons/cons.c
+++ b/librz/cons/cons.c
@@ -627,14 +627,14 @@ RZ_API RzCons *rz_cons_new(void) {
 }
 
 RZ_API RzCons *rz_cons_free(void) {
-#if __WINDOWS__
-	rz_cons_enable_mouse(false);
-	restore_console_codepage();
-#endif
 	I.refcnt--;
 	if (I.refcnt != 0) {
 		return NULL;
 	}
+#if __WINDOWS__
+	rz_cons_enable_mouse(false);
+	restore_console_codepage();
+#endif
 	if (I.line) {
 		rz_line_free();
 		I.line = NULL;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr moves the Windows cleanup code in rz_cons_free to below the `refcnt` check since if `I.refcnt` is greater than 1, no cleanup steps should happen.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green. The move makes sense.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
