### PR TITLE
Fix OOB read due to unsafe strdup() usage in dwarf parsing

### DIFF
--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -178,7 +178,7 @@ static inline const char *rz_str_get(const char *str) {
 static inline const char *rz_str_get_null(const char *str) {
 	return str ? str : "(null)";
 }
-RZ_API char *rz_str_ndup(const char *ptr, int len);
+RZ_API char *rz_str_ndup(RZ_NULLABLE const char *ptr, int len);
 RZ_API char *rz_str_dup(char *ptr, const char *string);
 RZ_API int rz_str_inject(char *begin, char *end, char *str, int maxlen);
 RZ_API int rz_str_delta(char *p, char a, char b);

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -858,16 +858,23 @@ RZ_API int rz_str_ccpy(char *dst, char *src, int ch) {
 	return i;
 }
 
-RZ_API char *rz_str_ndup(const char *ptr, int len) {
-	if (len < 0) {
+/**
+ * \brief Create new copy of string \p ptr limited to size \p len
+ * \param[in] ptr String to create new copy from
+ * \param[in] len Upper limit for new string size
+ * \return New copy of string \p ptr with size limited by \p len or NULL if \p ptr is NULL
+ */
+RZ_API char *rz_str_ndup(RZ_NULLABLE const char *ptr, int len) {
+	if (!ptr || len < 0) {
 		return NULL;
 	}
-	char *out = malloc(len + 1);
+	const size_t str_len = rz_str_nlen(ptr, len);
+	char *out = malloc(str_len + 1);
 	if (!out) {
 		return NULL;
 	}
-	strncpy(out, ptr, len);
-	out[len] = 0;
+	memcpy(out, ptr, str_len);
+	out[str_len] = 0;
 	return out;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Use `rz_str_ndup` instead, and fix it to not allocate `len` bytes blindly

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tests pass

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None
