### PR TITLE
Better error message for type redefinition

### DIFF
--- a/librz/type/parser/types_parser.c
+++ b/librz/type/parser/types_parser.c
@@ -948,7 +948,7 @@ int parse_enum_node(CParserState *state, TSNode node, const char *text, ParserTy
 	// Now we form both RzType and RzBaseType to store in the Types database
 	ParserTypePair *enum_pair = c_parser_new_enum_type(state, name, body_child_count);
 	if (!enum_pair) {
-		parser_error(state, "Error forming RzType and RzBaseType pair out of enum\n");
+		parser_error(state, "Error forming RzType and RzBaseType pair out of enum: \"%s\"\n", name);
 		result = -1;
 		goto rexit;
 	}

--- a/librz/type/parser/types_storage.c
+++ b/librz/type/parser/types_storage.c
@@ -153,6 +153,7 @@ RZ_OWN ParserTypePair *c_parser_new_primitive_type(CParserState *state, const ch
 	if (c_parser_base_type_exists(state, name)) {
 		// We don't create the type if it exists already in the parser
 		// state with the same name
+		parser_error(state, "Primitive type \"%s\" already exists\n", name);
 		return NULL;
 	}
 
@@ -273,6 +274,7 @@ RZ_OWN ParserTypePair *c_parser_new_structure_type(CParserState *state, RZ_NONNU
 	if (c_parser_base_type_exists(state, name)) {
 		// We don't create the structure if it exists already in the parser
 		// state with the same name
+		parser_error(state, "Structure type \"%s\" already exists\n", name);
 		return NULL;
 	}
 
@@ -399,6 +401,7 @@ RZ_OWN ParserTypePair *c_parser_new_union_type(CParserState *state, RZ_NONNULL c
 	if (c_parser_base_type_exists(state, name)) {
 		// We don't create the structure if it exists already in the parser
 		// state with the same name
+		parser_error(state, "Union type \"%s\" already exists\n", name);
 		return NULL;
 	}
 
@@ -526,6 +529,7 @@ RZ_OWN ParserTypePair *c_parser_new_enum_type(CParserState *state, RZ_NONNULL co
 	if (c_parser_base_type_exists(state, name)) {
 		// We don't create the structure if it exists already in the parser
 		// state with the same name
+		parser_error(state, "Enum type \"%s\" already exists\n", name);
 		return NULL;
 	}
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Better error messages for the types redefinition:
```
[0x0000000]> pfo elf64
Enum type "elf_type" already exists
Error forming RzType and RzBaseType pair out of enum: "elf_type"
```

**Test plan**

CI is green

**Closing issues**
Partially addressing https://github.com/rizinorg/rizin/issues/2474

