### PR TITLE
Fix OOB in ASN.1 stringify

### DIFF
--- a/librz/util/astr.c
+++ b/librz/util/astr.c
@@ -60,7 +60,7 @@ RZ_API RASN1String *rz_asn1_stringify_string(const ut8 *buffer, ut32 length) {
 	if (!str) {
 		return NULL;
 	}
-	rz_str_filter(str, length);
+	rz_str_filter(str, length - 1);
 	return rz_asn1_create_string(str, true, length);
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes the following error in ASAN builds:

```
[XX] /home/runner/work/rizin/rizin/test/bins/fuzzed <fuzz> /home/runner/work/rizin/rizin/test/bins/fuzzed/SEGV-a94-0b5-0a6
RZ_NOPLUGINS=1 rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -Qc aaa /home/runner/work/rizin/rizin/test/bins/fuzzed/SEGV-a94-0b5-0a6
-- stdout

-- stderr
=================================================================
==34619==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020001a67b7 at pc 0x7f7eb60ace4a bp 0x7ffc2c831020 sp 0x7ffc2c831010
READ of size 1 at 0x6020001a67b7 thread T0
    #0 0x7f7eb60ace49 in rz_str_filter ../librz/util/str.c:2205
    #1 0x7f7eb5fb166f in rz_asn1_stringify_string ../librz/util/astr.c:63
    #2 0x7f7eb61072b1 in rz_x509_parse_name ../librz/util/x509.c:113
    #3 0x7f7eb6022ade in rz_pkcs7_parse_issuerandserialnumber ../librz/util/pkcs7.c:144
    #4 0x7f7eb6022ade in rz_pkcs7_parse_signerinfo ../librz/util/pkcs7.c:176
    #5 0x7f7eb6022ade in rz_pkcs7_parse_signerinfos ../librz/util/pkcs7.c:250
    #6 0x7f7eb6022ade in rz_pkcs7_parse_signeddata ../librz/util/pkcs7.c:292
    #7 0x7f7eb6022ade in rz_pkcs7_parse_cms ../librz/util/pkcs7.c:335
    #8 0x7f7eabdbf712 in bin_pe_init_security ../librz/bin/format/pe/pe.c:3316
    #9 0x7f7eabdbf712 in bin_pe_init ../librz/bin/format/pe/pe.c:3377
    #10 0x7f7eabde7ca3 in Pe32_rz_bin_pe_new_buf ../librz/bin/format/pe/pe.c:4645
    #11 0x7f7eabb3e0ed in load_buffer ../librz/bin/p/bin_pe.inc:25
    #12 0x7f7eaba6db4c in rz_bin_object_new ../librz/bin/bobj.c:273
    #13 0x7f7eaba58dcc in rz_bin_file_new_from_buffer ../librz/bin/bfile.c:331
    #14 0x7f7eaba0f9c5 in rz_bin_open_buf ../librz/bin/bin.c:302
    #15 0x7f7eaba1136b in rz_bin_open_io ../librz/bin/bin.c:360
    #16 0x7f7ea9d793aa in core_file_do_load_for_io_plugin ../librz/core/cfile.c:692
    #17 0x7f7ea9d793aa in rz_core_bin_load ../librz/core/cfile.c:938
    #18 0x7f7eb5b26ad8 in rz_main_rizin ../librz/main/rizin.c:1140
    #19 0x7f7eb4f630b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x240b2)
    #20 0x55a9b47c7add in _start (/home/runner/bin/rizin+0x2add)

0x6020001a67b7 is located 0 bytes to the right of 7-byte region [0x6020001a67b0,0x6020001a67b7)
allocated by thread T0 here:
    #0 0x7f7eb676a808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x7f7eb60a9718 in rz_str_ndup ../librz/util/str.c:872
    #2 0x7f7eb5fb165c in rz_asn1_stringify_string ../librz/util/astr.c:59
    #3 0x7f7eb61072b1 in rz_x509_parse_name ../librz/util/x509.c:113
    #4 0x7f7eb6022ade in rz_pkcs7_parse_issuerandserialnumber ../librz/util/pkcs7.c:144
    #5 0x7f7eb6022ade in rz_pkcs7_parse_signerinfo ../librz/util/pkcs7.c:176
    #6 0x7f7eb6022ade in rz_pkcs7_parse_signerinfos ../librz/util/pkcs7.c:250
    #7 0x7f7eb6022ade in rz_pkcs7_parse_signeddata ../librz/util/pkcs7.c:292
    #8 0x7f7eb6022ade in rz_pkcs7_parse_cms ../librz/util/pkcs7.c:335
    #9 0x7f7eabdbf712 in bin_pe_init_security ../librz/bin/format/pe/pe.c:3316
    #10 0x7f7eabdbf712 in bin_pe_init ../librz/bin/format/pe/pe.c:3377
    #11 0x7f7eabde7ca3 in Pe32_rz_bin_pe_new_buf ../librz/bin/format/pe/pe.c:4645
    #12 0x7f7eabb3e0ed in load_buffer ../librz/bin/p/bin_pe.inc:25
    #13 0x7f7eaba6db4c in rz_bin_object_new ../librz/bin/bobj.c:273
    #14 0x7f7eaba58dcc in rz_bin_file_new_from_buffer ../librz/bin/bfile.c:331
    #15 0x7f7eaba0f9c5 in rz_bin_open_buf ../librz/bin/bin.c:302
    #16 0x7f7eaba1136b in rz_bin_open_io ../librz/bin/bin.c:360
    #17 0x7f7ea9d793aa in core_file_do_load_for_io_plugin ../librz/core/cfile.c:692
    #18 0x7f7ea9d793aa in rz_core_bin_load ../librz/core/cfile.c:938
    #19 0x7f7eb5b26ad8 in rz_main_rizin ../librz/main/rizin.c:1140
    #20 0x7f7eb4f630b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x240b2)

SUMMARY: AddressSanitizer: heap-buffer-overflow ../librz/util/str.c:2205 in rz_str_filter
Shadow bytes around the buggy address:
  0x0c048002cca0: fa fa 00 fa fa fa 00 00 fa fa 00 fa fa fa 00 fa
  0x0c048002ccb0: fa fa 00 00 fa fa 00 00 fa fa 00 fa fa fa 00 00
  0x0c048002ccc0: fa fa 03 fa fa fa 03 fa fa fa 00 03 fa fa 03 fa
  0x0c048002ccd0: fa fa 00 03 fa fa 00 05 fa fa 00 00 fa fa 00 00
  0x0c048002cce0: fa fa 03 fa fa fa 00 00 fa fa 00 fa fa fa 03 fa
=>0x0c048002ccf0: fa fa 00 03 fa fa[07]fa fa fa fa fa fa fa fa fa
  0x0c048002cd00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048002cd10: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048002cd20: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048002cd30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048002cd40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==34619==ABORTING

-- exit status: 1
```
https://github.com/rizinorg/rizin/runs/5813382236?check_suite_focus=true#step:19:20

**Test plan**

CI is green
