### PR TITLE
Update zlib subproject to 1.2.12

### DIFF
--- a/subprojects/packagefiles/zlib-1.2.12/meson.build
+++ b/subprojects/packagefiles/zlib-1.2.12/meson.build
@@ -1,4 +1,4 @@
-project('zlib', 'c', version : '1.2.11', license : 'zlib')
+project('zlib', 'c', version : '1.2.12', license : 'zlib')
 
 cc = meson.get_compiler('c')
 

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,7 +1,7 @@
 [wrap-file]
-directory = zlib-1.2.11
-source_url = https://raw.githubusercontent.com/rizinorg/fallback-repo/main/zlib-1.2.11.tar.gz
-source_filename = zlib-1.2.11.tar.gz
-source_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
-patch_directory = zlib-1.2.11
-source_fallback_url = https://zlib.net/fossils/zlib-1.2.11.tar.gz
+directory = zlib-1.2.12
+source_url = https://raw.githubusercontent.com/rizinorg/fallback-repo/main/zlib-1.2.12.tar.gz
+source_filename = zlib-1.2.12.tar.gz
+source_hash = 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
+patch_directory = zlib-1.2.12
+source_fallback_url = https://zlib.net/fossils/zlib-1.2.12.tar.gz


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Version 1.2.12 has these key improvements over 1.2.11:
- Fix a deflate bug when using the `Z_FIXED` strategy that can result in out-of-bound accesses.
- Fix a deflate bug when the window is full in `deflate_stored()`.
- Speed up CRC-32 computations by a factor of 1.5 to 3.
- Use the hardware CRC-32 instruction on ARMv8 processors.
- Speed up `crc32_combine()` with powers of x tables.
- Add `crc32_combine_gen()` and `crc32_combine_op()` for fast combines. 

**Test plan**

CI is green