### PR TITLE
RzDebug/p/native: do not use ptrace with NT_X86_XSTATE if not supported

### DIFF
--- a/librz/debug/debug.c
+++ b/librz/debug/debug.c
@@ -403,6 +403,7 @@ RZ_API RZ_OWN RzDebug *rz_debug_new(RZ_BORROW RZ_NONNULL RzBreakpointContext *bp
 	rz_debug_plugin_init(dbg);
 	dbg->bp->iob.init = false;
 	dbg->bp->baddr = 0;
+	dbg->nt_x86_xstate_supported = true;
 	return dbg;
 }
 

--- a/librz/debug/p/native/linux/linux_coredump.c
+++ b/librz/debug/p/native/linux/linux_coredump.c
@@ -929,8 +929,7 @@ void *linux_get_xsave_data(RzDebug *dbg, int tid, ut32 size) {
 	}
 	transfer.iov_base = xsave_data;
 	transfer.iov_len = size;
-	if (rz_debug_ptrace(dbg, PTRACE_GETREGSET, tid, (void *)NT_X86_XSTATE, &transfer) < 0) {
-		perror("linux_get_xsave_data");
+	if (rz_debug_ptrace_get_x86_xstate(dbg, tid, &transfer) < 0) {
 		free(xsave_data);
 		return NULL;
 	}
@@ -1339,8 +1338,7 @@ static int get_xsave_size(RzDebug *dbg, int pid) {
 	We could also check this by cpuid instruction https://en.wikipedia.org/wiki/CPUID#EAX.3D1:_Processor_Info_and_Feature_Bits*/
 	local.iov_base = xstate_hdr;
 	local.iov_len = sizeof(xstate_hdr);
-	if (rz_debug_ptrace(dbg, PTRACE_GETREGSET, pid, (void *)NT_X86_XSTATE, &local) < 0) {
-		perror("NT_X86_XSTATE");
+	if (rz_debug_ptrace_get_x86_xstate(dbg, pid, &local) < 0) {
 		return 0;
 	}
 

--- a/librz/debug/p/native/linux/linux_ptrace.h
+++ b/librz/debug/p/native/linux/linux_ptrace.h
@@ -52,4 +52,6 @@
 
 #endif
 
+long rz_debug_ptrace_get_x86_xstate(RzDebug *dbg, pid_t pid, struct iovec *iov);
+
 #endif

--- a/librz/include/rz_debug.h
+++ b/librz/include/rz_debug.h
@@ -318,6 +318,8 @@ typedef struct rz_debug_t {
 	bool verbose;
 	bool main_arena_resolved; /* is the main_arena resolved already? */
 	int glibc_version;
+
+	bool nt_x86_xstate_supported; ///< Track whether X86_FEATURE_XSAVE feature is supported on current kernel
 } RzDebug;
 
 typedef struct rz_debug_desc_plugin_t {


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

If the kernel/system where Rizin is currently run does not support
ptrace(PTRACE_GETREGSET, ..., NT_X86_XSTATE, ...), ENODEV is returned by
the kernel. In such cases, we print the error message once and never
execute the ptrace call again, assuming it is not supported.

Signed-off-by: Riccardo Schirone <sirmy15@gmail.com>


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #2470 