### PR TITLE
Add big endian PPC relocs

### DIFF
--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -934,35 +934,33 @@ static void patch_reloc(struct Elf_(rz_bin_elf_obj_t) * obj, RzBinElfReloc *rel,
 		default:
 			break;
 		}
-		RzBuffer *rbuf = rz_buf_new_with_bytes(buf, sizeof(buf));
 		if (low) {
 			switch (low) {
 			case 14:
 				val &= (1 << 14) - 1;
 				rz_buf_read_at(obj->buf_patched, patch_addr, buf, 2);
-				rz_buf_write_ble32_at(rbuf, patch_addr, (rz_read_ble32(buf, big_endian) & ~(RZ_BIT_MASK32(16, 2))) | val << 2, big_endian);
+				rz_write_ble32(buf, (rz_read_ble32(buf, big_endian) & ~(RZ_BIT_MASK32(16, 2))) | val << 2, big_endian);
 				rz_buf_write_at(obj->buf_patched, patch_addr, buf, 2);
 				break;
 			case 24:
 				val &= (1 << 24) - 1;
 				rz_buf_read_at(obj->buf_patched, patch_addr, buf, 4);
-				rz_buf_write_ble32_at(rbuf, patch_addr, (rz_read_ble32(buf, big_endian) & ~(RZ_BIT_MASK32(26, 2))) | val << 2, big_endian);
+				rz_write_ble32(buf, (rz_read_ble32(buf, big_endian) & ~(RZ_BIT_MASK32(26, 2))) | val << 2, big_endian);
 				rz_buf_write_at(obj->buf_patched, patch_addr, buf, 4);
 				break;
 			}
 		} else if (word) {
 			switch (word) {
 			case 2:
-				rz_buf_write_ble16_at(rbuf, patch_addr, val, big_endian);
+				rz_write_ble16(buf, val, big_endian);
 				rz_buf_write_at(obj->buf_patched, patch_addr, buf, 2);
 				break;
 			case 4:
-				rz_buf_write_ble16_at(rbuf, patch_addr, val, big_endian);
+				rz_write_ble32(buf, val, big_endian);
 				rz_buf_write_at(obj->buf_patched, patch_addr, buf, 4);
 				break;
 			}
 		}
-		rz_buf_free(rbuf);
 		break;
 	}
 	case EM_386:

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -912,11 +912,11 @@ static void patch_reloc(struct Elf_(rz_bin_elf_obj_t) * obj, RzBinElfReloc *rel,
 		int low = 0, word = 0;
 		switch (rel->type) {
 		case RZ_PPC64_REL16_HA:
-			word = 16;
+			word = 2;
 			val = (S + A - P + 0x8000) >> 16;
 			break;
 		case RZ_PPC64_REL16_LO:
-			word = 16;
+			word = 2;
 			val = (S + A - P) & 0xffff;
 			break;
 		case RZ_PPC64_REL14:
@@ -928,7 +928,7 @@ static void patch_reloc(struct Elf_(rz_bin_elf_obj_t) * obj, RzBinElfReloc *rel,
 			val = (st64)(S + A - P) >> 2;
 			break;
 		case RZ_PPC64_REL32:
-			word = 32;
+			word = 4;
 			val = S + A - P;
 			break;
 		default:
@@ -952,11 +952,11 @@ static void patch_reloc(struct Elf_(rz_bin_elf_obj_t) * obj, RzBinElfReloc *rel,
 			}
 		} else if (word) {
 			switch (word) {
-			case 16:
+			case 2:
 				rz_buf_write_ble16_at(rbuf, patch_addr, val, big_endian);
 				rz_buf_write_at(obj->buf_patched, patch_addr, buf, 2);
 				break;
-			case 32:
+			case 4:
 				rz_buf_write_ble16_at(rbuf, patch_addr, val, big_endian);
 				rz_buf_write_at(obj->buf_patched, patch_addr, buf, 4);
 				break;

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <rz_types.h>
 #include <rz_util.h>
+#include <rz_util/rz_buf.h>
 #include <rz_lib.h>
 #include <rz_bin.h>
 #include <rz_io.h>
@@ -889,6 +890,7 @@ static void patch_reloc(struct Elf_(rz_bin_elf_obj_t) * obj, RzBinElfReloc *rel,
 	RzBinRelocFormularSymbols formular_sym = { .A = A, .B = B, .GOT = GOT, .L = L, .S = S, .P = P, .MB = 0, .G = 0, .GP = 0, .T = 0, .TLS = 0 };
 	ut64 patch_addr = rel->paddr != UT64_MAX ? rel->paddr : Elf_(rz_bin_elf_v2p)(obj, rel->vaddr);
 	ut8 buf[8];
+	bool big_endian = obj->big_endian;
 	switch (e_machine) {
 	case EM_QDSP6:
 		patch_reloc_hexagon(obj->buf_patched, patch_addr, rel->type, &formular_sym);
@@ -910,11 +912,11 @@ static void patch_reloc(struct Elf_(rz_bin_elf_obj_t) * obj, RzBinElfReloc *rel,
 		int low = 0, word = 0;
 		switch (rel->type) {
 		case RZ_PPC64_REL16_HA:
-			word = 2;
+			word = 16;
 			val = (S + A - P + 0x8000) >> 16;
 			break;
 		case RZ_PPC64_REL16_LO:
-			word = 2;
+			word = 16;
 			val = (S + A - P) & 0xffff;
 			break;
 		case RZ_PPC64_REL14:
@@ -926,41 +928,41 @@ static void patch_reloc(struct Elf_(rz_bin_elf_obj_t) * obj, RzBinElfReloc *rel,
 			val = (st64)(S + A - P) >> 2;
 			break;
 		case RZ_PPC64_REL32:
-			word = 4;
+			word = 32;
 			val = S + A - P;
 			break;
 		default:
 			break;
 		}
+		RzBuffer *rbuf = rz_buf_new_with_bytes(buf, sizeof(buf));
 		if (low) {
-			// TODO big-endian
 			switch (low) {
 			case 14:
 				val &= (1 << 14) - 1;
 				rz_buf_read_at(obj->buf_patched, patch_addr, buf, 2);
-				rz_write_le32(buf, (rz_read_le32(buf) & ~((1 << 16) - (1 << 2))) | val << 2);
+				rz_buf_write_ble32_at(rbuf, patch_addr, (rz_read_ble32(buf, big_endian) & ~(RZ_BIT_MASK32(16, 2))) | val << 2, big_endian);
 				rz_buf_write_at(obj->buf_patched, patch_addr, buf, 2);
 				break;
 			case 24:
 				val &= (1 << 24) - 1;
 				rz_buf_read_at(obj->buf_patched, patch_addr, buf, 4);
-				rz_write_le32(buf, (rz_read_le32(buf) & ~((1 << 26) - (1 << 2))) | val << 2);
+				rz_buf_write_ble32_at(rbuf, patch_addr, (rz_read_ble32(buf, big_endian) & ~(RZ_BIT_MASK32(26, 2))) | val << 2, big_endian);
 				rz_buf_write_at(obj->buf_patched, patch_addr, buf, 4);
 				break;
 			}
 		} else if (word) {
-			// TODO big-endian
 			switch (word) {
-			case 2:
-				rz_write_le16(buf, val);
+			case 16:
+				rz_buf_write_ble16_at(rbuf, patch_addr, val, big_endian);
 				rz_buf_write_at(obj->buf_patched, patch_addr, buf, 2);
 				break;
-			case 4:
-				rz_write_le32(buf, val);
+			case 32:
+				rz_buf_write_ble16_at(rbuf, patch_addr, val, big_endian);
 				rz_buf_write_at(obj->buf_patched, patch_addr, buf, 4);
 				break;
 			}
 		}
+		rz_buf_free(rbuf);
 		break;
 	}
 	case EM_386:
@@ -1212,6 +1214,12 @@ static RzBinReloc *reloc_convert(ELFOBJ *bin, RzBinElfReloc *rel, ut64 GOT) {
 		case RZ_PPC_NONE: break;
 		case RZ_PPC_GLOB_DAT: ADD(32, 0);
 		case RZ_PPC_JMP_SLOT: ADD(32, 0);
+		case RZ_PPC_COPY: ADD(32, 0); // copy symbol at runtime
+		case RZ_PPC_REL24: ADD(24, -P);
+		case RZ_PPC_REL14: ADD(16, -P);
+		case RZ_PPC_REL32: ADD(32, -P);
+		case RZ_PPC_RELATIVE: ADD(32, -P);
+		case RZ_PPC_PLT32: ADD(32, -P);
 		default:
 			eprintf("unimplemented ELF/PPC reloc type %d\n", rel->type);
 			break;

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -292,6 +292,7 @@ static inline void *rz_new_copy(int size, void *data) {
 #define RZ_PTR_ALIGN_NEXT(v, t) \
 	((char *)(((size_t)(v) + (t - 1)) & ~(t - 1)))
 
+#define RZ_BIT_MASK32(x, y) ((1UL << (x)) - (1UL << (y)))
 #define RZ_BIT_SET(x, y)    (((ut8 *)x)[y >> 4] |= (1 << (y & 0xf)))
 #define RZ_BIT_UNSET(x, y)  (((ut8 *)x)[y >> 4] &= ~(1 << (y & 0xf)))
 #define RZ_BIT_TOGGLE(x, y) (RZ_BIT_CHK(x, y) ? RZ_BIT_UNSET(x, y) : RZ_BIT_SET(x, y))

--- a/test/db/formats/elf/reloc
+++ b/test/db/formats/elf/reloc
@@ -413,3 +413,35 @@ ret
 EOF
 RUN
 
+NAME=PPC big endian R_PPC_RELATIVE and R_PPC_JMP_SLOT
+FILE=bins/abi_bins/elf/platforms/macppc-openbsd-echo
+BROKEN=1
+CMDS=<<EOF
+# 584 relocs + 2 header lines
+ir~?
+# R_PPC_RELATIVE
+s 0x398f8
+pf bbbb
+pd 1
+# R_PPC_JMP_SLOT
+s 0x39ca4
+pf bbbb
+pd 1
+EOF
+EXPECT=<<EOF
+586
+0x000398f8 = 0x00
+0x000398f9 = 0x01
+0x000398fa = 0x40
+0x000398fb = 0xf4
+            ;-- section..preinit_array:
+            0x000398f8      .dword 0x000140f4                          ; RELOC 32  ; [19] -rw- section size 4 named .preinit_array
+0x00039ca4 = 0x00
+0x00039ca5 = 0x05
+0x00039ca6 = 0x06
+0x00039ca7 = 0x7c
+            ;-- section..plt:
+            ;-- _Jv_RegisterClasses:
+            0x00039ca4      .dword 0x0005067c ; section..glink         ; RELOC 32 _Jv_RegisterClasses ; [23] -rw- section size 4 named .plt
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Extracts the PPC changes made here: https://github.com/rizinorg/rizin/pull/1699

**Test plan**

Two tests for `R_PPC_JMP_SLOT` and `R_PPC_RELATIVE` were added.
The expected values are from IDA.

Unfortunately both tests fail and are therefore marked as broken.

Based on a little debugging the `P` values are incorrect. Possibly a general bug in the elf relocation code?

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
