### PR TITLE
Fix `rz_str_ndup()`-related OOB read by using `rz_str_ndup_buflen()`

### DIFF
--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -179,6 +179,7 @@ static inline const char *rz_str_get_null(const char *str) {
 	return str ? str : "(null)";
 }
 RZ_API char *rz_str_ndup(RZ_NULLABLE const char *ptr, int len);
+RZ_API char *rz_str_ndup_buflen(RZ_NULLABLE const char *ptr, int len);
 RZ_API char *rz_str_dup(char *ptr, const char *string);
 RZ_API int rz_str_inject(char *begin, char *end, char *str, int maxlen);
 RZ_API int rz_str_delta(char *p, char a, char b);

--- a/librz/util/astr.c
+++ b/librz/util/astr.c
@@ -56,11 +56,11 @@ RZ_API RASN1String *rz_asn1_stringify_string(const ut8 *buffer, ut32 length) {
 	if (!buffer || !length) {
 		return NULL;
 	}
-	char *str = rz_str_ndup((const char *)buffer, length);
+	char *str = rz_str_ndup_buflen((const char *)buffer, length);
 	if (!str) {
 		return NULL;
 	}
-	rz_str_filter(str, length - 1);
+	rz_str_filter(str, length);
 	return rz_asn1_create_string(str, true, length);
 }
 

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -878,6 +878,26 @@ RZ_API char *rz_str_ndup(RZ_NULLABLE const char *ptr, int len) {
 	return out;
 }
 
+/**
+ * \brief Create new copy of string \p ptr limited to size \p len
+ * \param[in] ptr String to create new copy from
+ * \param[in] len Upper limit for new string size
+ * \return New copy of string \p ptr with size limited by \p len or NULL if \p ptr is NULL.
+ *         Returned buffer size is guaranteed to be len + 1.
+ */
+RZ_API char *rz_str_ndup_buflen(RZ_NULLABLE const char *ptr, int len) {
+	if (!ptr || len < 0) {
+		return NULL;
+	}
+	char *out = malloc(len + 1);
+	if (!out) {
+		return NULL;
+	}
+	memcpy(out, ptr, len);
+	out[len] = 0;
+	return out;
+}
+
 // TODO: deprecate?
 RZ_API char *rz_str_dup(char *ptr, const char *string) {
 	char *str = rz_str_new(string);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [X] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes this [`rz_str_ndup()`-related OOB read](https://github.com/rizinorg/rizin/runs/5828574225?check_suite_focus=true#step:19:26) by using `rz_str_ndup_buflen()`, since unlike [POSIX `strndup()`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/strdup.html), it guarantees that the pointer returned is to a buffer of size `len + 1`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
