### PR TITLE
Fix `rz_str_ndup()`-related OOB read by using `rz_str_ndup_buflen()`

### DIFF
--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -179,6 +179,7 @@ static inline const char *rz_str_get_null(const char *str) {
 	return str ? str : "(null)";
 }
 RZ_API char *rz_str_ndup(RZ_NULLABLE const char *ptr, int len);
+RZ_API char *rz_str_ndup_buflen(RZ_NULLABLE const char *ptr, int len);
 RZ_API char *rz_str_dup(char *ptr, const char *string);
 RZ_API int rz_str_inject(char *begin, char *end, char *str, int maxlen);
 RZ_API int rz_str_delta(char *p, char a, char b);

--- a/librz/util/astr.c
+++ b/librz/util/astr.c
@@ -56,11 +56,11 @@ RZ_API RASN1String *rz_asn1_stringify_string(const ut8 *buffer, ut32 length) {
 	if (!buffer || !length) {
 		return NULL;
 	}
-	char *str = rz_str_ndup((const char *)buffer, length);
+	char *str = rz_str_ndup_buflen((const char *)buffer, length);
 	if (!str) {
 		return NULL;
 	}
-	rz_str_filter(str, length - 1);
+	rz_str_filter(str, length);
 	return rz_asn1_create_string(str, true, length);
 }
 

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -878,6 +878,26 @@ RZ_API char *rz_str_ndup(RZ_NULLABLE const char *ptr, int len) {
 	return out;
 }
 
+/**
+ * \brief Create new copy of string \p ptr limited to size \p len
+ * \param[in] ptr String to create new copy from
+ * \param[in] len Upper limit for new string size
+ * \return New copy of string \p ptr with size limited by \p len or NULL if \p ptr is NULL.
+ *         Returned buffer size is guaranteed to be len + 1.
+ */
+RZ_API char *rz_str_ndup_buflen(RZ_NULLABLE const char *ptr, int len) {
+	if (!ptr || len < 0) {
+		return NULL;
+	}
+	char *out = malloc(len + 1);
+	if (!out) {
+		return NULL;
+	}
+	memcpy(out, ptr, len);
+	out[len] = 0;
+	return out;
+}
+
 // TODO: deprecate?
 RZ_API char *rz_str_dup(char *ptr, const char *string) {
 	char *str = rz_str_new(string);


### PR DESCRIPTION
Dup of #2503 with `fuzz` in branch name.