### PR TITLE
RzCore: default dbg.verbose to false

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -2834,15 +2834,7 @@ static bool cb_log_config_colors(void *coreptr, void *nodeptr) {
 static bool cb_dbg_verbose(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
-	const char *value = node->value;
-	switch (value[0]) {
-	case 't':
-	case 'T':
-		core->dbg->verbose = true;
-		break;
-	default:
-		core->dbg->verbose = false;
-	}
+	core->dbg->verbose = node->i_value;
 	return true;
 }
 
@@ -3345,7 +3337,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETBPREF("dbg.skipover", "false", "Make dso perform a dss (same goes for esil and visual/graph");
 	SETI("dbg.hwbp", 0, "Set HW or SW breakpoints");
 	SETCB("dbg.unlibs", "", &cb_dbg_unlibs, "If set stop when unloading matching libname");
-	SETCB("dbg.verbose", "true", &cb_dbg_verbose, "Verbose debug output");
+	SETCB("dbg.verbose", "false", &cb_dbg_verbose, "Verbose debug output");
 	SETBPREF("dbg.slow", "false", "Show stack and regs in visual mode in a slow but verbose mode");
 	SETBPREF("dbg.funcarg", "false", "Display arguments to function call in visual mode");
 

--- a/test/db/archos/linux-x64/dbg_oo
+++ b/test/db/archos/linux-x64/dbg_oo
@@ -103,6 +103,6 @@ ood
 EOF
 REGEXP_FILTER_ERR=([a-zA-Z-]+\s+)
 EXPECT_ERR=<<EOF
-Process with PID attach File -helloworld-gcc  reopened in read-write mode
+Process with PID File -helloworld-gcc  reopened in read-write mode
 EOF
 RUN


### PR DESCRIPTION
Some messages printed by Rizin might be hard to decode at times. Just
stick to the basic information by default.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

new output:
```
$ ./build/binrz/rizin/rizin -d /bin/ls             
Process with PID 144474 started...                                                             
 -- Get a free shell with 'rz-gg -i exec -x'
[0x7fec922a46a0]> dcu main                                                                     
Continue until 0x555ef60d1da0                                                                  
hit breakpoint at: 0x555ef60d1da0
[0x555ef60d1da0]>                    
```
old output:
```
$ ./build/binrz/rizin/rizin -d /bin/ls             
Process with PID 143885 started...                                                             
= attach 143885 143885                                                                         
bin.baddr 0x5644ce3e5000                                                                       
Using 0x5644ce3e5000               
asm.bits 64                                 
 -- Reduce the delta where flag resolving by address is used with cfg.delta
[0x7f041c2516a0]>       
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
