### PR TITLE
Fix: Propeller and Hexagon out of bounds reads

### DIFF
--- a/librz/analysis/p/analysis_hexagon.c
+++ b/librz/analysis/p/analysis_hexagon.c
@@ -19,6 +19,7 @@
 #include "hexagon_arch.h"
 
 RZ_API int hexagon_v6_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask) {
+	rz_return_val_if_fail(analysis && op && buf && len >= 4, -1);
 	if (analysis->pcalign == 0) {
 		analysis->pcalign = 0x4;
 	}

--- a/librz/analysis/p/analysis_hexagon.c
+++ b/librz/analysis/p/analysis_hexagon.c
@@ -19,7 +19,11 @@
 #include "hexagon_arch.h"
 
 RZ_API int hexagon_v6_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask) {
-	rz_return_val_if_fail(analysis && op && buf && len >= 4, -1);
+	rz_return_val_if_fail(analysis && op && buf, -1);
+	if (len < 4) {
+		RZ_LOG_WARN("Couldn't disassemble instruction at 0x%x. Less than 4 bytes were provided.\n", (ut32)addr);
+		return -1;
+	}
 	if (analysis->pcalign == 0) {
 		analysis->pcalign = 0x4;
 	}

--- a/librz/analysis/p/analysis_propeller.c
+++ b/librz/analysis/p/analysis_propeller.c
@@ -12,6 +12,7 @@
 #include <propeller_disas.h>
 
 static int propeller_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask) {
+	rz_return_val_if_fail(analysis && op && buf && len >= 4, -1);
 	int ret;
 	struct propeller_cmd cmd;
 

--- a/librz/analysis/p/analysis_propeller.c
+++ b/librz/analysis/p/analysis_propeller.c
@@ -12,7 +12,11 @@
 #include <propeller_disas.h>
 
 static int propeller_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask) {
-	rz_return_val_if_fail(analysis && op && buf && len >= 4, -1);
+	rz_return_val_if_fail(analysis && op && buf, -1);
+	if (len < 4) {
+		RZ_LOG_WARN("Couldn't disassemble instruction at 0x%x. Less than 4 bytes were provided.\n", (ut32)addr);
+		return -1;
+	}
 	int ret;
 	struct propeller_cmd cmd;
 

--- a/librz/asm/p/asm_hexagon.c
+++ b/librz/asm/p/asm_hexagon.c
@@ -27,6 +27,7 @@
  * \return int Size of the reversed opcode.
  */
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int l) {
+  rz_return_val_if_fail(a && op && buf && l >= 4, -1);
 	ut32 addr = (ut32)a->pc;
 	HexReversedOpcode rev = { .action = HEXAGON_DISAS, .ana_op = NULL, .asm_op = op };
 

--- a/librz/asm/p/asm_hexagon.c
+++ b/librz/asm/p/asm_hexagon.c
@@ -27,7 +27,7 @@
  * \return int Size of the reversed opcode.
  */
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int l) {
-  rz_return_val_if_fail(a && op && buf && l >= 4, -1);
+	rz_return_val_if_fail(a && op && buf && l >= 4, -1);
 	ut32 addr = (ut32)a->pc;
 	HexReversedOpcode rev = { .action = HEXAGON_DISAS, .ana_op = NULL, .asm_op = op };
 

--- a/librz/asm/p/asm_propeller.c
+++ b/librz/asm/p/asm_propeller.c
@@ -10,6 +10,7 @@
 #include <propeller_disas.h>
 
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+	rz_return_val_if_fail(a && op && buf && len >= 4, -1);
 	const char *buf_asm;
 	struct propeller_cmd cmd;
 	int ret = propeller_decode_command(buf, &cmd);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The Hexagon and Propeller plugins did not check the arguments given to their `op()` and `disassemble()` functions.
This let to this issue: https://github.com/rizinorg/rizin/issues/2082

This PR adds NULL and out of bounds checks before processing the buffer.

**Test plan**

Manually tested with Valgrind and the binaries from https://github.com/rizinorg/rizin/issues/2082:

<details>
  <summary>Propeller</summary>

```
> valgrind ./build/binrz/rizin/rizin -TQA id\:000141\,sig\:06\,sync\:f2\,src\:052868

==4545== Memcheck, a memory error detector
==4545== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==4545== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==4545== Command: ./build/binrz/rizin/rizin -TQA id:000141,sig:06,sync:f2,src:052868
==4545== 
WARNING: Invalid section header (check array failed).
WARNING: Invalid program header (check array failed).
WARNING: Failed to initialize program header.
WARNING: Failed to initialize section header.
WARNING: No calling convention defined for this file, analysis may be inaccurate.
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze function calls (aac)
[WARNING: propeller_op: assertion 'analysis && op && buf && len >= 4' failed (line 15)
WARNING: propeller_op: assertion 'analysis && op && buf && len >= 4' failed (line 15)
WARNING: propeller_op: assertion 'analysis && op && buf && len >= 4' failed (line 15)
WARNING: propeller_op: assertion 'analysis && op && buf && len >= 4' failed (line 15)
WARNING: propeller_op: assertion 'analysis && op && buf && len >= 4' failed (line 15)
WARNING: propeller_op: assertion 'analysis && op && buf && len >= 4' failed (line 15)
[x] Analyze len bytes of instructions for references (aar)
[x] Check for classes
[x] Finding xrefs in noncode section with analysis.in=io.maps
[x] Analyze value pointers (aav)
[x] Value from 0x00010000 to 0x000143cf (aav)
[x] 0x00010000-0x000143cf in 0x10000-0x143cf (aav)
[x] Emulate functions to find computed references (aaef)
[x] Propagate noreturn information
[x] Use -AA or aaaa to perform additional experimental analysis.
[x] Applied 0 FLIRT signatures via sigdb
==4545== 
==4545== HEAP SUMMARY:
==4545==     in use at exit: 1,208,440 bytes in 14,130 blocks
==4545==   total heap usage: 42,885 allocs, 28,755 frees, 11,925,050 bytes allocated
==4545== 
==4545== LEAK SUMMARY:
==4545==    definitely lost: 0 bytes in 0 blocks
==4545==    indirectly lost: 0 bytes in 0 blocks
==4545==      possibly lost: 384 bytes in 18 blocks
==4545==    still reachable: 1,208,056 bytes in 14,112 blocks
==4545==         suppressed: 0 bytes in 0 blocks
==4545== Rerun with --leak-check=full to see details of leaked memory
==4545== 
==4545== For lists of detected and suppressed errors, rerun with: -s
==4545== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
</details>

<details>
  <summary>Hexagon</summary>

```
> valgrind ./build/binrz/rizin/rizin -TQA id\:000141\,sig\:06\,sync\:f2\,src\:052868 

==4545== Memcheck, a memory error detector
==4545== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==4545== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==4545== Command: ./build/binrz/rizin/rizin -TQA id:000141,sig:06,sync:f2,src:052868
==4545== 
WARNING: Invalid section header (check array failed).
WARNING: Invalid program header (check array failed).
WARNING: Failed to initialize program header.
WARNING: Failed to initialize section header.
WARNING: No calling convention defined for this file, analysis may be inaccurate.
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze function calls (aac)
[WARNING: propeller_op: assertion 'analysis && op && buf && len >= 4' failed (line 15)
WARNING: propeller_op: assertion 'analysis && op && buf && len >= 4' failed (line 15)
WARNING: propeller_op: assertion 'analysis && op && buf && len >= 4' failed (line 15)
WARNING: propeller_op: assertion 'analysis && op && buf && len >= 4' failed (line 15)
WARNING: propeller_op: assertion 'analysis && op && buf && len >= 4' failed (line 15)
WARNING: propeller_op: assertion 'analysis && op && buf && len >= 4' failed (line 15)
[x] Analyze len bytes of instructions for references (aar)
[x] Check for classes
[x] Finding xrefs in noncode section with analysis.in=io.maps
[x] Analyze value pointers (aav)
[x] Value from 0x00010000 to 0x000143cf (aav)
[x] 0x00010000-0x000143cf in 0x10000-0x143cf (aav)
[x] Emulate functions to find computed references (aaef)
[x] Propagate noreturn information
[x] Use -AA or aaaa to perform additional experimental analysis.
[x] Applied 0 FLIRT signatures via sigdb
==4545== 
==4545== HEAP SUMMARY:
==4545==     in use at exit: 1,208,440 bytes in 14,130 blocks
==4545==   total heap usage: 42,885 allocs, 28,755 frees, 11,925,050 bytes allocated
==4545== 
==4545== LEAK SUMMARY:
==4545==    definitely lost: 0 bytes in 0 blocks
==4545==    indirectly lost: 0 bytes in 0 blocks
==4545==      possibly lost: 384 bytes in 18 blocks
==4545==    still reachable: 1,208,056 bytes in 14,112 blocks
==4545==         suppressed: 0 bytes in 0 blocks
==4545== Rerun with --leak-check=full to see details of leaked memory
==4545== 
==4545== For lists of detected and suppressed errors, rerun with: -s
==4545== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
</details>

**Closing issues**

closes https://github.com/rizinorg/rizin/issues/2082
