### PR TITLE
RzUtil/str: remove `len` argument from rz_str_filter

### DIFF
--- a/librz/bin/format/mach0/mach0.c
+++ b/librz/bin/format/mach0/mach0.c
@@ -2277,7 +2277,7 @@ RzList *MACH0_(get_maps_unpatched)(RzBinFile *bf) {
 		map->vaddr = seg->vmaddr;
 		map->vsize = seg->vmsize;
 		map->name = rz_str_ndup(seg->segname, 16);
-		rz_str_filter(map->name, -1);
+		rz_str_filter(map->name);
 		map->perm = prot2perm(seg->initprot);
 		if (MACH0_(segment_needs_rebasing_and_stripping)(bin, i)) {
 			map->vfile_name = strdup(MACH0_VFILE_NAME_REBASED_STRIPPED);
@@ -2331,7 +2331,7 @@ RzList *MACH0_(get_segments)(RzBinFile *bf) {
 			// TODO s->flags = seg->flags;
 			s->name = rz_str_ndup(seg->segname, 16);
 			s->is_segment = true;
-			rz_str_filter(s->name, -1);
+			rz_str_filter(s->name);
 			s->perm = prot2perm(seg->initprot);
 			rz_list_append(list, s);
 		}
@@ -2469,7 +2469,7 @@ struct section_t *MACH0_(get_sections)(struct MACH0_(obj_t) * bin) {
 			sections[i].flags = seg->flags;
 			rz_strf(sectname, "%.16s", seg->segname);
 			sectname[16] = 0;
-			rz_str_filter(sectname, -1);
+			rz_str_filter(sectname);
 			// hack to support multiple sections with same name
 			sections[i].perm = prot2perm(seg->initprot);
 			sections[i].last = 0;
@@ -2496,7 +2496,7 @@ struct section_t *MACH0_(get_sections)(struct MACH0_(obj_t) * bin) {
 		sections[i].align = bin->sects[i].align;
 		sections[i].flags = bin->sects[i].flags;
 		rz_strf(sectname, "%.16s", bin->sects[i].sectname);
-		rz_str_filter(sectname, -1);
+		rz_str_filter(sectname);
 		rz_strf(raw_segname, "%.16s", bin->sects[i].segname);
 		for (j = 0; j < bin->nsegs; j++) {
 			if (sections[i].addr >= bin->segs[j].vmaddr &&
@@ -2615,7 +2615,7 @@ RZ_API RZ_OWN char *MACH0_(get_name)(struct MACH0_(obj_t) * mo, ut32 stridx, boo
 	if (len > 0) {
 		char *res = rz_str_ndup(symstr, len);
 		if (filter) {
-			rz_str_filter(res, -1);
+			rz_str_filter(res);
 		}
 		return res;
 	}

--- a/librz/bin/p/bin_xnu_kernelcache.c
+++ b/librz/bin/p/bin_xnu_kernelcache.c
@@ -1028,7 +1028,7 @@ static RzList *maps(RzBinFile *bf) {
 		char segname[17];
 		struct MACH0_(segment_command) *seg = &kobj->mach0->segs[i];
 		rz_str_ncpy(segname, seg->segname, 17);
-		rz_str_filter(segname, -1);
+		rz_str_filter(segname);
 		map->name = rz_str_newf("%d.%s", i, segname);
 		map->paddr = seg->fileoff + bf->o->boffset;
 		map->psize = seg->vmsize;
@@ -1088,7 +1088,7 @@ static RzList *sections(RzBinFile *bf) {
 
 		seg = &kobj->mach0->segs[i];
 		rz_str_ncpy(segname, seg->segname, 17);
-		rz_str_filter(segname, -1);
+		rz_str_filter(segname);
 		ptr->name = rz_str_newf("%d.%s", i, segname);
 		ptr->size = seg->vmsize;
 		ptr->vsize = seg->vmsize;

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -2493,7 +2493,7 @@ static bool cb_binprefix(void *user, void *data) {
 			char *name = (char *)rz_file_basename(core->bin->file);
 			if (name) {
 				rz_name_filter(name, strlen(name), true);
-				rz_str_filter(name, strlen(name));
+				rz_str_filter(name);
 				core->bin->prefix = strdup(name);
 				free(name);
 			}

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -710,7 +710,7 @@ RZ_API char *cmd_syscall_dostr(RzCore *core, st64 n, ut64 addr) {
 			case 'z':
 				memset(str, 0, sizeof(str));
 				rz_io_read_at(core->io, arg, (ut8 *)str, sizeof(str) - 1);
-				rz_str_filter(str, strlen(str));
+				rz_str_filter(str);
 				res = rz_str_appendf(res, "\"%s\"", str);
 				break;
 			case 'Z': {
@@ -722,7 +722,7 @@ RZ_API char *cmd_syscall_dostr(RzCore *core, st64 n, ut64 addr) {
 				}
 				(void)rz_io_read_at(core->io, arg, (ut8 *)str, len);
 				str[len] = 0;
-				rz_str_filter(str, -1);
+				rz_str_filter(str);
 				res = rz_str_appendf(res, "\"%s\"", str);
 			} break;
 			default:

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -4080,7 +4080,7 @@ static void ds_print_ptr(RzDisasmState *ds, int len, int idx) {
 						msg2[len - 1] = 0;
 						kind = rz_analysis_data_kind(core->analysis, refaddr, (const ut8 *)msg2, len - 1);
 						if (kind && !strcmp(kind, "text")) {
-							rz_str_filter(msg2, 0);
+							rz_str_filter(msg2);
 							if (*msg2) {
 								char *lala = rz_str_newf("\"%s\"", msg2);
 								free(msg2);
@@ -4153,7 +4153,7 @@ static void ds_print_ptr(RzDisasmState *ds, int len, int idx) {
 			if (strlen(msg) != 1) {
 				char *msg2 = rz_str_new(msg);
 				if (msg2) {
-					rz_str_filter(msg2, 0);
+					rz_str_filter(msg2);
 					if (!strncmp(msg2, "UH..", 4)) {
 						print_msg = false;
 					}

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -182,7 +182,7 @@ RZ_API char *rz_str_ndup(RZ_NULLABLE const char *ptr, int len);
 RZ_API char *rz_str_dup(char *ptr, const char *string);
 RZ_API int rz_str_inject(char *begin, char *end, char *str, int maxlen);
 RZ_API int rz_str_delta(char *p, char a, char b);
-RZ_API void rz_str_filter(char *str, int len);
+RZ_API void rz_str_filter(char *str);
 RZ_API const char *rz_str_tok(const char *str1, const char b, size_t len);
 RZ_API wchar_t *rz_str_mb_to_wc(const char *buf);
 RZ_API char *rz_str_wc_to_mb(const wchar_t *buf);

--- a/librz/util/astr.c
+++ b/librz/util/astr.c
@@ -60,8 +60,8 @@ RZ_API RASN1String *rz_asn1_stringify_string(const ut8 *buffer, ut32 length) {
 	if (!str) {
 		return NULL;
 	}
-	rz_str_filter(str, length - 1);
-	return rz_asn1_create_string(str, true, length);
+	rz_str_filter(str);
+	return rz_asn1_create_string(str, true, strlen(str));
 }
 
 RZ_API RASN1String *rz_asn1_stringify_utctime(const ut8 *buffer, ut32 length) {

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -2196,12 +2196,14 @@ RZ_API void rz_str_filter_zeroline(char *str, int len) {
 	str[i] = 0;
 }
 
-RZ_API void rz_str_filter(char *str, int len) {
+/**
+ * \brief Convert all non-printable characters in \p str with '.'
+ *
+ * \param str String to make printable.
+ */
+RZ_API void rz_str_filter(char *str) {
 	size_t i;
-	if (len < 1) {
-		len = strlen(str);
-	}
-	for (i = 0; i < len; i++) {
+	for (i = 0; str[i]; i++) {
 		if (!IS_PRINTABLE(str[i])) {
 			str[i] = '.';
 		}

--- a/test/unit/test_str.c
+++ b/test/unit/test_str.c
@@ -674,6 +674,20 @@ bool test_rz_str_ndup(void) {
 	mu_end;
 }
 
+bool test_rz_str_filter(void) {
+	char buf[10] = "hel\x01\x02\x03lo";
+	char *buf2 = rz_str_ndup("AAA\001\002AAA", 20);
+	char *buf3 = rz_str_ndup("AAA\001\002AAA", 5);
+
+	rz_str_filter(buf);
+	mu_assert_streq(buf, "hel...lo", "static buffer should be filtered");
+	rz_str_filter(buf2);
+	mu_assert_streq_free(buf2, "AAA..AAA", "allocated buffer with ndup 20 should be filtered");
+	rz_str_filter(buf3);
+	mu_assert_streq_free(buf3, "AAA..", "allocated buffer with ndup 5 should be filtered");
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_rz_str_newf);
 	mu_run_test(test_rz_str_replace_char_once);
@@ -712,6 +726,7 @@ bool all_tests() {
 	mu_run_test(test_rz_strf);
 	mu_run_test(test_rz_str_nlen);
 	mu_run_test(test_rz_str_ndup);
+	mu_run_test(test_rz_str_filter);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
All uses of rz_str_filter already passed either strlen(..) or -1 or 0,
which was the same as computing strlen(...). The only case where a
different value was passed was in astr.c, where the string was anyway
allocated with rz_str_ndup(). Thus the string passed to rz_str_filter()
is always zero-terminated and we don't need to compute the length in
rz_str_filter() to traverse it all, but we can just stop at the first
NULL byte.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->


See #2504. Should fix a OOB-read (https://github.com/rizinorg/rizin/runs/5828574225?check_suite_focus=true#step:19:26).

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
