### PR TITLE
RzCore: save/restore bits and arch config values while printing

### DIFF
--- a/librz/config/hold.c
+++ b/librz/config/hold.c
@@ -26,6 +26,17 @@ static int key_cmp_hold_i(const void *a, const void *b) {
 	return strcmp(a_s, b_s->key);
 }
 
+/**
+ * \brief Save the current values of a list of config options that have string values.
+ *
+ * Get the current values of a list of config variables (terminated by NULL) and
+ * save them in the RzConfigHold object \p h . \p rz_config_get is used to
+ * retrieve the current config values.
+ *
+ * \param h Reference to RzConfigHold instance
+ * \param ... List of config variables to save, terminated by NULL.
+ * \return true if at least one variable is correctly saved, false otherwise
+ */
 RZ_API bool rz_config_hold_s(RzConfigHold *h, ...) {
 	va_list ap;
 	char *key;
@@ -56,6 +67,17 @@ RZ_API bool rz_config_hold_s(RzConfigHold *h, ...) {
 	return true;
 }
 
+/**
+ * \brief Save the current values of a list of config options that have integer values.
+ *
+ * Get the current values of a list of config variables (terminated by NULL) and
+ * save them in the RzConfigHold object \p h . \p rz_config_get_i is used to
+ * retrieve the current config values.
+ *
+ * \param h Reference to RzConfigHold instance
+ * \param ... List of config variables to save, terminated by NULL.
+ * \return true if at least one variable is correctly saved, false otherwise
+ */
 RZ_API bool rz_config_hold_i(RzConfigHold *h, ...) {
 	va_list ap;
 	char *key;
@@ -85,6 +107,12 @@ RZ_API bool rz_config_hold_i(RzConfigHold *h, ...) {
 	return true;
 }
 
+/**
+ * \brief Create an opaque object to save/restore some configuration options
+ *
+ * \param cfg RzConfig reference
+ * \return RzConfigHold allocated object
+ */
 RZ_API RzConfigHold *rz_config_hold_new(RzConfig *cfg) {
 	if (cfg) {
 		RzConfigHold *hold = RZ_NEW0(RzConfigHold);
@@ -96,6 +124,11 @@ RZ_API RzConfigHold *rz_config_hold_new(RzConfig *cfg) {
 	return NULL;
 }
 
+/**
+ * \brief Restore whatever config options were previously saved in \p h
+ *
+ * \param h Reference to RzConfigHold
+ */
 RZ_API void rz_config_hold_restore(RzConfigHold *h) {
 	RzListIter *iter;
 	RzConfigHoldChar *hchar;
@@ -111,6 +144,11 @@ RZ_API void rz_config_hold_restore(RzConfigHold *h) {
 	}
 }
 
+/**
+ * \brief Free a RzConfigHold object \p h
+ *
+ * \param h Reference to RzConfigHold
+ */
 RZ_API void rz_config_hold_free(RzConfigHold *h) {
 	if (h) {
 		rz_list_free(h->list_num);

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -554,7 +554,6 @@ static bool cb_asmarch(void *user, void *data) {
 		rz_config_set_i(core->config, "asm.bits", bits);
 	}
 
-	// rz_debug_set_arch (core->dbg, rz_sys_arch_id (node->value), bits);
 	rz_debug_set_arch(core->dbg, node->value, bits);
 	if (!rz_config_set(core->config, "analysis.arch", node->value)) {
 		char *p, *s = strdup(node->value);
@@ -574,10 +573,7 @@ static bool cb_asmarch(void *user, void *data) {
 	if (core->analysis) {
 		const char *asmcpu = rz_config_get(core->config, "asm.cpu");
 		const char *platform = rz_config_get(core->config, "asm.platform");
-		if (!rz_syscall_setup(core->analysis->syscall, node->value, core->analysis->bits, asmcpu, asmos)) {
-			// eprintf ("asm.arch: Cannot setup syscall '%s/%s' from '%s'\n",
-			//	node->value, asmos, RZ_LIBDIR"/rizin/"RZ_VERSION"/syscall");
-		}
+		rz_syscall_setup(core->analysis->syscall, node->value, core->analysis->bits, asmcpu, asmos);
 		update_syscall_ns(core);
 		char *platforms_dir = rz_path_system(RZ_SDB_ARCH_PLATFORMS);
 		char *cpus_dir = rz_path_system(RZ_SDB_ARCH_CPUS);
@@ -586,8 +582,6 @@ static bool cb_asmarch(void *user, void *data) {
 		free(platforms_dir);
 		free(cpus_dir);
 	}
-	// if (!strcmp (node->value, "bf"))
-	//	rz_config_set (core->config, "dbg.backend", "bf");
 	__setsegoff(core->config, node->value, core->rasm->bits);
 
 	// set a default endianness
@@ -670,13 +664,6 @@ static bool cb_asmbits(void *user, void *data) {
 	if (!bits) {
 		return false;
 	}
-#if 0
-// TODO: pretty good optimization, but breaks many tests when arch is different i think
-	if (bits == core->rasm->bits && bits == core->analysis->bits && bits == core->dbg->bits) {
-		// early optimization
-		return true;
-	}
-#endif
 	if (bits > 0) {
 		ret = rz_asm_set_bits(core->rasm, bits);
 		if (!ret) {

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -1702,6 +1702,7 @@ e asm.comments=false
 e asm.functions=false
 e asm.lines.bb=false
 e asm.flags=false
+e asm.arch=x86
 ahb 16
 aha arm
 pd 1
@@ -2473,5 +2474,36 @@ EXPECT=<<EOF
             0x0000080e      lda   #0x41                                ; 0x41,a,=,$z,Z,:=,7,$s,N,:=
             0x00000810      ldx   #0xff                                ; 0xff,x,=,$z,Z,:=,7,$s,N,:=
             0x00000812      sta   0x03ff,x                             ; a,x,0x03ff,+,=[1]
+EOF
+RUN
+
+NAME=remove analysis hint
+FILE==
+CMDS=<<EOF
+e asm.functions=false
+e asm.offset=false
+e asm.lines=false
+e asm.lines.bb=false
+e asm.marks=false
+e asm.bytes=false
+e asm.comments=false
+e asm.flags=false
+e asm.arch=x86
+e asm.bits=64
+wx 31ed4989d1
+pd 1
+aha ppc
+pd 1
+aha-
+pd 1
+aha ppc
+aha 0
+pd 1
+EOF
+EXPECT=<<EOF
+xor   ebp, ebp
+lbz   r10, -0x12cf(r9)
+xor   ebp, ebp
+xor   ebp, ebp
 EOF
 RUN


### PR DESCRIPTION
 **Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

rz_analysis_op calls archbits in RzCoreBind, which sets the arch/bits according to the hints. However, when you delete a hint it finds that they are NULL, thus it does not set them anymore, leaving the older hint in place. Fix this by saving/restoring the config options before doing print_disasm.

NOTE: `pdi` does not work any way, because it uses rz_asm_op instead of rz_analysis_op, but this is not fixed here because it would be a mess...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #2185 
