### PR TITLE
Symbol size is not an int, but ut32

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -1905,7 +1905,7 @@ static bool symbols_print(RzCore *core, RzBinFile *bf, RzCmdStateOutput *state, 
 	RzListIter *iter;
 
 	rz_cmd_state_output_array_start(state);
-	rz_cmd_state_output_set_columnsf(state, "dXXssdss", "nth", "paddr", "vaddr", "bind", "type", "size", "lib", "name");
+	rz_cmd_state_output_set_columnsf(state, "dXXssnss", "nth", "paddr", "vaddr", "bind", "type", "size", "lib", "name");
 
 	rz_list_foreach (symbols, iter, symbol) {
 		if (!symbol->name) {
@@ -1937,11 +1937,12 @@ static bool symbols_print(RzCore *core, RzBinFile *bf, RzCmdStateOutput *state, 
 			free(rz_symbol_name);
 			rz_symbol_name = tmp;
 		}
+		ut64 size = symbol->size;
 
 		switch (state->mode) {
 		case RZ_OUTPUT_MODE_QUIET:
-			rz_cons_printf("0x%08" PFMT64x " %d %s%s%s\n",
-				addr, (int)symbol->size,
+			rz_cons_printf("0x%08" PFMT64x " %" PFMT64u " %s%s%s\n",
+				addr, size,
 				sn.libname ? sn.libname : "", sn.libname ? " " : "",
 				rz_symbol_name);
 			break;
@@ -1958,7 +1959,7 @@ static bool symbols_print(RzCore *core, RzBinFile *bf, RzCmdStateOutput *state, 
 			pj_ks(state->d.pj, "realname", symbol->name);
 			pj_ki(state->d.pj, "ordinal", symbol->ordinal);
 			pj_ks(state->d.pj, "bind", symbol->bind);
-			pj_kn(state->d.pj, "size", (ut64)symbol->size);
+			pj_kn(state->d.pj, "size", size);
 			pj_ks(state->d.pj, "type", symbol->type);
 			pj_kn(state->d.pj, "vaddr", addr);
 			pj_kn(state->d.pj, "paddr", symbol->paddr);
@@ -1967,13 +1968,13 @@ static bool symbols_print(RzCore *core, RzBinFile *bf, RzCmdStateOutput *state, 
 			pj_end(state->d.pj);
 			break;
 		case RZ_OUTPUT_MODE_TABLE:
-			rz_table_add_rowf(state->d.t, "dXXssdss",
+			rz_table_add_rowf(state->d.t, "dXXssnss",
 				symbol->ordinal,
 				symbol->paddr,
 				addr,
 				symbol->bind ? symbol->bind : "NONE",
 				symbol->type ? symbol->type : "NONE",
-				symbol->size,
+				size,
 				rz_str_get(symbol->libname),
 				rz_str_get_null(rz_symbol_name));
 			break;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

If the size is big enough it will output negative numbers.

![image](https://user-images.githubusercontent.com/561184/161980727-cbe09121-c8d4-4ddf-9eb3-ce0bac00a4a4.png)

this will patch to show this as follows:

![image](https://user-images.githubusercontent.com/561184/161980835-5f37baff-e8c6-4abc-ab1a-5262d6f2cebd.png)
