### PR TITLE
rz_cons_print_fps: Fix double->int conversion warning

### DIFF
--- a/librz/cons/cons.c
+++ b/librz/cons/cons.c
@@ -1064,7 +1064,7 @@ RZ_API void rz_cons_print_fps(int col) {
 		if (diff < 0) {
 			fps = 0;
 		} else {
-			fps = (diff < 1000000) ? (1000000.0 / diff) : 0;
+			fps = (diff < 1000000) ? (int)(1000000.0 / diff + 0.5) : 0;
 		}
 		prev = now;
 	} else {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following warning (https://ci.appveyor.com/project/rizinorg/rizin/builds/43145343/job/cjfgh2cej416cbpo?fullLog=true#L1063):

![cons_fps_warning](https://user-images.githubusercontent.com/12002672/161994071-1d3677cb-07de-4910-8116-51e4a50ae406.PNG)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green. The warning is no longer there. `scr.fps` works as intended.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
