### PR TITLE
rz-ax: count set bits in number

### DIFF
--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -27,7 +27,7 @@
 #define RZ_AX_FLAG_DUMP_C_BYTES     (1ull << 21) // -i (dump as C byte array)
 #define RZ_AX_FLAG_OCTAL_TO_RAW     (1ull << 22) // -o (octalstr -> raw)
 #define RZ_AX_FLAG_IPADDR_TO_LONG   (1ull << 23) // -I (IP address <-> LONG)
-#define RZ_AX_FLAG_BIN_SET_BYTES    (1ull << 24) // -p (count set bits)
+#define RZ_AX_FLAG_SET_BITS         (1ull << 24) // -p (count set bits)
 
 #define has_flag(f, x) (f & x)
 
@@ -271,7 +271,7 @@ static int rax(RzNum *num, char *str, int len, int last, ut64 *_flags, int *fm) 
 			case 'S': flags ^= RZ_AX_FLAG_RAW_TO_HEX; break;
 			case 'b': flags ^= RZ_AX_FLAG_BIN_TO_STR; break;
 			case 'B': flags ^= RZ_AX_FLAG_STR_TO_BIN; break;
-			case 'p': flags ^= RZ_AX_FLAG_BIN_SET_BYTES; break;
+			case 'p': flags ^= RZ_AX_FLAG_SET_BITS; break;
 			case 'x': flags ^= RZ_AX_FLAG_STR_TO_DJB2; break;
 			case 'k': flags ^= RZ_AX_FLAG_KEEP_BASE; break;
 			case 'f': flags ^= RZ_AX_FLAG_FLOATING_POINT; break;
@@ -414,6 +414,19 @@ dotherax:
 				ch & 2 ? 1 : 0,
 				ch & 1 ? 1 : 0);
 		}
+		return true;
+	} else if (has_flag(flags, RZ_AX_FLAG_SET_BITS)) { // -p (count set bits)
+		ut64 n = rz_num_math(num, str);
+		char strbits[65];
+		int i = 0, set_bits_ctr = 0;
+		rz_num_to_bits(strbits, n);
+		while (strbits[i] != '\0') {
+			if (strbits[i] == '1') {
+				++set_bits_ctr;
+			}
+			++i;
+		}
+		printf("set bits = %d\n", set_bits_ctr);
 		return true;
 	} else if (has_flag(flags, RZ_AX_FLAG_SIGNED_WORD)) { // -w
 		ut64 n = rz_num_math(num, str);

--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -420,29 +420,23 @@ dotherax:
 		char strbits[65];
 		int i = 0, set_bits_ctr = 0;
 		rz_num_to_bits(strbits, n);
-		rz_str_reverse(strbits);	// because we count Right to Left
+		rz_str_reverse(strbits); // because we count Right to Left
 		while (strbits[i] != '\0') {
 			if (strbits[i] == '1') {
 				++set_bits_ctr;
-				if (i == 0)
-				{
-					printf("[%d",i);
-				} else 	if (strbits[i] == '1' && strbits[i-1] == '0')
-			{
-				printf("[%d",i);
-			}
-			}
-			if ( strbits[i] == '0' && strbits[i-1] == '1' )
-			{
-				if (set_bits_ctr == 1)
-				{
-					printf("]: 1\n");
+				if (i == 0) {
+					printf("[%d", i);
+				} else if (strbits[i] == '1' && strbits[i - 1] == '0') {
+					printf("[%d", i);
 				}
-				else
-					printf("-%d]: 1\n",i-1);
+			}
+			if (strbits[i] == '0' && strbits[i - 1] == '1') {
+				if (set_bits_ctr == 1) {
+					printf("]: 1\n");
+				} else
+					printf("-%d]: 1\n", i - 1);
 				set_bits_ctr = 0;
-			} else if (strbits[i] == '1' && strbits[i+1] == '\0')
-			{
+			} else if (strbits[i] == '1' && strbits[i + 1] == '\0') {
 				printf("]: 1\n");
 				set_bits_ctr = 0;
 			}

--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -231,7 +231,7 @@ static int help(void) {
 		"  -u      units                ;  rz-ax -u 389289238 # 317.0M\n"
 		"  -w      signed word          ;  rz-ax -w 16 0xffff\n"
 		"  -v      version              ;  rz-ax -v\n"
-		"  -p      count set bits       ;  rz-ax -p 0xb3\n");
+		"  -p      position of set bits ;  rz-ax -p 0xb3\n");
 	return true;
 }
 

--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -420,13 +420,35 @@ dotherax:
 		char strbits[65];
 		int i = 0, set_bits_ctr = 0;
 		rz_num_to_bits(strbits, n);
+		rz_str_reverse(strbits);	// because we count Right to Left
 		while (strbits[i] != '\0') {
 			if (strbits[i] == '1') {
 				++set_bits_ctr;
+				if (i == 0)
+				{
+					printf("[%d",i);
+				} else 	if (strbits[i] == '1' && strbits[i-1] == '0')
+			{
+				printf("[%d",i);
 			}
+			}
+			if ( strbits[i] == '0' && strbits[i-1] == '1' )
+			{
+				if (set_bits_ctr == 1)
+				{
+					printf("]: 1\n");
+				}
+				else
+					printf("-%d]: 1\n",i-1);
+				set_bits_ctr = 0;
+			} else if (strbits[i] == '1' && strbits[i+1] == '\0')
+			{
+				printf("]: 1\n");
+				set_bits_ctr = 0;
+			}
+
 			++i;
 		}
-		printf("set bits = %d\n", set_bits_ctr);
 		return true;
 	} else if (has_flag(flags, RZ_AX_FLAG_SIGNED_WORD)) { // -w
 		ut64 n = rz_num_math(num, str);

--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -400,7 +400,6 @@ dotherax:
 		return true;
 	} else if (has_flag(flags, RZ_AX_FLAG_STR_TO_BIN)) { // -B (bin -> str)
 		int i = 0;
-		// TODO: move to rz_util
 		for (i = 0; i < strlen(str); i++) {
 			ut8 ch = str[i];
 			printf("%d%d%d%d"

--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -27,7 +27,7 @@
 #define RZ_AX_FLAG_DUMP_C_BYTES     (1ull << 21) // -i (dump as C byte array)
 #define RZ_AX_FLAG_OCTAL_TO_RAW     (1ull << 22) // -o (octalstr -> raw)
 #define RZ_AX_FLAG_IPADDR_TO_LONG   (1ull << 23) // -I (IP address <-> LONG)
-#define RZ_AX_FLAG_SET_BITS         (1ull << 24) // -p (count set bits)
+#define RZ_AX_FLAG_SET_BITS         (1ull << 24) // -p (find position of set bits)
 
 #define has_flag(f, x) (f & x)
 
@@ -415,7 +415,7 @@ dotherax:
 				ch & 1 ? 1 : 0);
 		}
 		return true;
-	} else if (has_flag(flags, RZ_AX_FLAG_SET_BITS)) { // -p (count set bits)
+	} else if (has_flag(flags, RZ_AX_FLAG_SET_BITS)) { // -p (find position of set bits)
 		ut64 n = rz_num_math(num, str);
 		char strbits[65];
 		int i = 0, set_bits_ctr = 0;
@@ -433,11 +433,16 @@ dotherax:
 			if (strbits[i] == '0' && strbits[i - 1] == '1') {
 				if (set_bits_ctr == 1) {
 					printf("]: 1\n");
+				} else if (strbits[i + 1] == '\0') {
+					printf("-%d]: 1\n", i);
 				} else
 					printf("-%d]: 1\n", i - 1);
 				set_bits_ctr = 0;
 			} else if (strbits[i] == '1' && strbits[i + 1] == '\0') {
-				printf("]: 1\n");
+				if (set_bits_ctr == 1) {
+					printf("]: 1\n");
+				} else
+					printf("-%d]: 1\n", i);
 				set_bits_ctr = 0;
 			}
 

--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -27,6 +27,7 @@
 #define RZ_AX_FLAG_DUMP_C_BYTES     (1ull << 21) // -i (dump as C byte array)
 #define RZ_AX_FLAG_OCTAL_TO_RAW     (1ull << 22) // -o (octalstr -> raw)
 #define RZ_AX_FLAG_IPADDR_TO_LONG   (1ull << 23) // -I (IP address <-> LONG)
+#define RZ_AX_FLAG_BIN_SET_BYTES    (1ull << 24) // -p (count set bits)
 
 #define has_flag(f, x) (f & x)
 
@@ -229,7 +230,8 @@ static int help(void) {
 		"  -x      hash string          ;  rz-ax -x linux osx\n"
 		"  -u      units                ;  rz-ax -u 389289238 # 317.0M\n"
 		"  -w      signed word          ;  rz-ax -w 16 0xffff\n"
-		"  -v      version              ;  rz-ax -v\n");
+		"  -v      version              ;  rz-ax -v\n"
+		"  -p      count set bits       ;  rz-ax -p 0xb3\n");
 	return true;
 }
 
@@ -269,6 +271,7 @@ static int rax(RzNum *num, char *str, int len, int last, ut64 *_flags, int *fm) 
 			case 'S': flags ^= RZ_AX_FLAG_RAW_TO_HEX; break;
 			case 'b': flags ^= RZ_AX_FLAG_BIN_TO_STR; break;
 			case 'B': flags ^= RZ_AX_FLAG_STR_TO_BIN; break;
+			case 'p': flags ^= RZ_AX_FLAG_BIN_SET_BYTES; break;
 			case 'x': flags ^= RZ_AX_FLAG_STR_TO_DJB2; break;
 			case 'k': flags ^= RZ_AX_FLAG_KEEP_BASE; break;
 			case 'f': flags ^= RZ_AX_FLAG_FLOATING_POINT; break;

--- a/test/db/tools/rz_ax
+++ b/test/db/tools/rz_ax
@@ -537,3 +537,22 @@ EXPECT=<<EOF
 1
 EOF
 RUN
+
+NAME=rz-ax -p
+FILE==
+CMDS=!rz-ax -p 0xb3
+EXPECT=<<EOF
+[0-1]: 1
+[4-5]: 1
+[7]: 1
+EOF
+RUN
+
+NAME=rz-ax -p
+FILE==
+CMDS=!rz-ax -p 110
+EXPECT=<<EOF
+[1-3]: 1
+[5-6]: 1
+EOF
+RUN


### PR DESCRIPTION
Signed-off-by: Dhruva Gole <goledhruva@gmail.com>

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
The idea is to allow a new bit mode for rz-ax that will print the position of set bits and their count in the following format:
```
$ rz-ax =2 0xb3
10110011b
$ rz-ax -B 0xb3
[0-1]: 1
[4-5]: 1
[7]: 1
```
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**
TODO
<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**
closes https://github.com/rizinorg/rizin/issues/2458
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
