### PR TITLE
Fix disassembly of LDD instruction on AVR

### DIFF
--- a/librz/asm/arch/avr/disassembler.c
+++ b/librz/asm/arch/avr/disassembler.c
@@ -308,7 +308,7 @@ static ut32 avr_dddddcccc_ym(cchar* name, AVROpMnem id, ut16 data[2], ut64 pc, A
 
 static ut32 avr_qcqqcdddddcqqq_y(cchar* name, AVROpMnem id, ut16 data[2], ut64 pc, AVROp *aop, RzStrBuf *sb) {
 	ut16 q = data[0] & 0x0007;
-	ut16 Rd = ((data[0] & 0x01F0) >> 5);
+	ut16 Rd = ((data[0] & 0x01F0) >> 4);
 	q |= ((data[0] & 0x0C00) >> 7);
 	q |= ((data[0] & 0x2000) >> 8);
 

--- a/test/db/analysis/avr
+++ b/test/db/analysis/avr
@@ -37,6 +37,20 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=avr ld/ldd
+FILE=malloc://4096
+CMDS=<<EOF
+e asm.arch=avr
+wx a984fc91a184
+pd 3
+EOF
+EXPECT=<<EOF
+            0x00000000      ldd   r10, Y+9
+            0x00000002      ld    r31, X
+            0x00000004      ldd   r10, Z+9
+EOF
+RUN
+
 NAME=avr DISasm: [sts] - jump check
 FILE=malloc://4096
 CMDS=<<EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

LDD using Y index instruction encodes destination registers within bits 4 to 8, similar to LDD instruction using Z index. To obtain the correct destination register a right shift of 4 bits is needed (similar to what is done inside `avr_qcqqcdddddcqqq_z` function).
This is a bug fix hence no documentation updated.


