### PR TITLE
Prevent reallocation of hash table buffer on dwarf parsing

### DIFF
--- a/librz/include/rz_bin_dwarf.h
+++ b/librz/include/rz_bin_dwarf.h
@@ -771,6 +771,7 @@ typedef struct {
 	size_t capacity;
 	RzBinDwarfCompUnit *comp_units;
 	HtUP /*<ut64 offset, DwarfDie *die>*/ *lookup_table;
+	size_t n_dwarf_dies;
 
 	/**
 	 * Cache mapping from an offset in the debug_line section to a string


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Keep a count of how many `dies` we found to reserve a size for the hashtable. Prevents its constant realocation as we populate it

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tests pass

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None
