### PR TITLE
Fix radare2 CVEs

### DIFF
--- a/librz/bin/format/mach0/dyldcache.c
+++ b/librz/bin/format/mach0/dyldcache.c
@@ -153,27 +153,27 @@ static void populate_cache_maps(RzDyldCache *cache) {
 
 	ut32 i;
 	ut32 n_maps = 0;
+	ut64 max_count = 0;
 	for (i = 0; i < cache->n_hdr; i++) {
 		cache_hdr_t *hdr = &cache->hdr[i];
 		if (!hdr->mappingCount || !hdr->mappingOffset) {
 			continue;
 		}
+		max_count = RZ_MAX(hdr->mappingCount, max_count);
 		n_maps += hdr->mappingCount;
 	}
 
-	cache_map_t *maps = NULL;
-	if (n_maps != 0) {
-		cache->maps_index = RZ_NEWS0(ut32, cache->n_hdr);
-		if (!cache->maps_index) {
-			return;
-		}
-		maps = RZ_NEWS0(cache_map_t, n_maps);
-	}
-	if (!maps) {
+	if (n_maps < 1 || n_maps < max_count /* overflow */) {
 		cache->maps = NULL;
 		cache->n_maps = 0;
 		return;
 	}
+
+	cache->maps_index = RZ_NEWS0(ut32, cache->n_hdr);
+	if (!cache->maps_index) {
+		return;
+	}
+	cache_map_t *maps = RZ_NEWS0(cache_map_t, n_maps);
 
 	ut32 next_map = 0;
 	ut32 last_idx = UT32_MAX;

--- a/librz/bin/format/mach0/mach0_relocs.c
+++ b/librz/bin/format/mach0/mach0_relocs.c
@@ -34,7 +34,7 @@ static void parse_relocation_info(struct MACH0_(obj_t) * bin, RzSkipList *relocs
 	for (i = 0; i < num; i++) {
 		struct relocation_info a_info = info[i];
 		ut32 sym_num = a_info.r_symbolnum;
-		if (sym_num > bin->nsymtab) {
+		if (sym_num >= bin->nsymtab) {
 			continue;
 		}
 

--- a/test/db/formats/dyldcache
+++ b/test/db/formats/dyldcache
@@ -425,3 +425,13 @@ address     index class    flags name
 0x182068000 0x0000000184078028   (....... @ section.lib_libhello_1.0.dylib.8.__DATA_CONST.__objc_classlist 6510051368 lib_libhello-1.0.dylib.18.__AUTH.__objc_data _OBJC_CLASS_$_Test R 0x184078000
 EOF
 RUN
+
+NAME=dyldcache CVE-2022-1244
+FILE=bins/dyldcache/CVE-2022-1244
+CMDS=<<EOF
+aaa
+q
+EOF
+EXPECT=<<EOF
+EOF
+RUN

--- a/test/db/formats/mach0/relocs
+++ b/test/db/formats/mach0/relocs
@@ -1475,3 +1475,12 @@ call reloc.target.bzero
             0x000720c8      .qword 0x0000000000000000                  ; RELOC TARGET 2 bzero
 EOF
 RUN
+
+NAME=reloc symbol overflow CVE-2022-1240
+FILE=bins/mach0/reloc-symidx-overflow
+CMDS=<<EOF
+q
+EOF
+EXPECT=<<EOF
+EOF
+RUN


### PR DESCRIPTION
# DO NOT SQUASH

This this an Out of Bound read caused by missing sanitization of the
parsed dyldcache parsed structure.
Introduced via c19eaa88431505f267093aca7feead37ce804d49
Original r2 commit: 09e20cd53d00a1497bf50349fe6eb812b4f54ac5

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This this an Out of Bound read caused by missing sanitization of the
parsed dyldcache parsed structure.
Introduced via c19eaa8
Original r2 commit: 09e20cd53d00a1497bf50349fe6eb812b4f54ac5