### PR TITLE
Cleanup + fixes + dex core commands

### DIFF
--- a/librz/bin/format/dex/dex.h
+++ b/librz/bin/format/dex/dex.h
@@ -129,16 +129,26 @@ typedef struct dex_encoded_method_t {
 	/*encoded_catch_handler_list handlers */
 } DexEncodedMethod;
 
+// small note: on the official documentation all the
+// variables are set as uint (aka ut32) but on their
+// libdexfile defines some fields within class_def
+// as ut16 + padding; to uniform with the real used
+// code you will find some useless _padding variables
 typedef struct dex_class_def_t {
-	ut32 class_idx;
+	ut16 class_idx;
+	ut16 _padding1;
 	ut32 access_flags;
-	ut32 superclass_idx;
+	ut16 superclass_idx;
+	ut16 _padding2;
 	ut32 interfaces_offset;
 	ut32 source_file_idx;
 	ut32 annotations_offset;
 	ut32 class_data_offset;
 	ut32 static_values_offset;
 	ut64 offset;
+
+	ut32 n_interfaces;
+	ut16 *interfaces;
 
 	RzList /*<DexEncodedField>*/ *static_fields;
 	RzList /*<DexEncodedField>*/ *instance_fields;
@@ -213,6 +223,8 @@ RZ_API RZ_OWN char *rz_bin_dex_resolve_field_by_idx(RZ_NONNULL RzBinDex *dex, ut
 RZ_API RZ_OWN char *rz_bin_dex_resolve_class_by_idx(RZ_NONNULL RzBinDex *dex, ut32 class_idx);
 RZ_API RZ_OWN char *rz_bin_dex_resolve_string_by_idx(RZ_NONNULL RzBinDex *dex, ut32 string_idx);
 RZ_API RZ_OWN char *rz_bin_dex_resolve_proto_by_idx(RZ_NONNULL RzBinDex *dex, ut32 proto_idx);
+RZ_API RZ_OWN char *rz_bin_dex_resolve_type_id_by_idx(RZ_NONNULL RzBinDex *dex, ut32 type_idx);
+RZ_API RZ_OWN char *rz_bin_dex_access_flags_readable(ut32 access_flags);
 
 RZ_API ut64 rz_bin_dex_resolve_string_offset_by_idx(RZ_NONNULL RzBinDex *dex, ut32 string_idx);
 RZ_API ut64 rz_bin_dex_resolve_type_id_offset_by_idx(RZ_NONNULL RzBinDex *dex, ut32 type_idx);

--- a/librz/core/meson.build
+++ b/librz/core/meson.build
@@ -1,5 +1,6 @@
 core_plugins = [
   'java',
+  'dex',
 ]
 
 subdir('cmd_descs')
@@ -53,6 +54,7 @@ rz_core_sources = [
   'task.c',
   'vmarks.c',
   'yank.c',
+  'p/core_dex.c',
   'p/core_java.c',
   cmd_descs_ch,
   'cmd/cmd.c',

--- a/librz/core/p/core_dex.c
+++ b/librz/core/p/core_dex.c
@@ -1,0 +1,327 @@
+// SPDX-FileCopyrightText: 2022 deroad <wargio@libero.it>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_types.h>
+#include <rz_lib.h>
+#include <rz_demangler.h>
+#include <rz_cmd.h>
+#include <rz_core.h>
+#include <rz_cons.h>
+#include <string.h>
+#include <rz_analysis.h>
+
+#include "../format/dex/dex.h"
+
+#define name_args(name)    (cmd_##name##_args)
+#define name_help(name)    (cmd_##name##_help)
+#define name_handler(name) (rz_cmd_##name##_handler)
+#define static_description_without_args(command, summ) \
+	static const RzCmdDescArg name_args(command)[] = { \
+		{ 0 }, \
+	}; \
+	static const RzCmdDescHelp name_help(command) = { \
+		.summary = summ, \
+		.args = name_args(command), \
+	}
+#define rz_cmd_desc_argv_modes_new_warn(rcmd, root, cmd, flags) \
+	rz_warn_if_fail(rz_cmd_desc_argv_state_new(rcmd, root, #cmd, flags, name_handler(cmd), &name_help(cmd)))
+
+static RzBinDex *core_dex_get_class(RzCore *core) {
+	if (!core) {
+		return NULL;
+	}
+	RzAnalysis *analysis = core->analysis;
+	if (!analysis || !analysis->binb.bin) {
+		return NULL;
+	}
+	RzBin *b = analysis->binb.bin;
+	if (!b->cur || !b->cur->o) {
+		return NULL;
+	}
+	RzBinPlugin *plugin = b->cur->o->plugin;
+	return plugin && !strcmp(plugin->name, "dex") ? (RzBinDex *)b->cur->o->bin_obj : NULL;
+}
+
+static char *decode_access_flags(ut32 access_flags) {
+	char *str = rz_bin_dex_access_flags_readable(access_flags);
+	if (!str) {
+		return strdup("");
+	}
+	for (size_t i = 0; i < strlen(str); ++i) {
+		str[i] = toupper(str[i]);
+	}
+	return str;
+}
+
+static void dex_print_encoded_field(RzBinDex *dex, ut32 index, DexEncodedField *encoded_field) {
+	if (dex->field_ids_size < encoded_field->field_idx) {
+		rz_cons_printf("    #%-14u: unknown id %" PFMT64u "\n", index, encoded_field->field_idx);
+		return;
+	}
+	DexFieldId *field_id = (DexFieldId *)rz_pvector_at(dex->field_ids, encoded_field->field_idx);
+
+	char *tmp = rz_bin_dex_resolve_type_id_by_idx(dex, field_id->class_idx);
+	rz_cons_printf("    #%-14u: (in %s)\n", index, tmp);
+	free(tmp);
+	tmp = rz_bin_dex_resolve_string_by_idx(dex, field_id->name_idx);
+	rz_cons_printf("      name          : '%s'\n", tmp);
+	free(tmp);
+	tmp = rz_bin_dex_resolve_type_id_by_idx(dex, field_id->type_idx);
+	rz_cons_printf("      type          : '%s'\n", tmp);
+	free(tmp);
+	tmp = decode_access_flags(encoded_field->access_flags);
+	rz_cons_printf("      access        : 0x%04" PFMT64x " (%s)\n", encoded_field->access_flags, tmp ? tmp : "");
+	free(tmp);
+}
+
+static void dex_print_encoded_method(RzBinDex *dex, ut32 index, DexEncodedMethod *encoded_method) {
+	if (dex->method_ids_size < encoded_method->method_idx) {
+		rz_cons_printf("    #%-14u: unknown id %" PFMT64u "\n", index, encoded_method->method_idx);
+		return;
+	}
+	DexMethodId *method_id = (DexMethodId *)rz_pvector_at(dex->method_ids, encoded_method->method_idx);
+
+	char *tmp = rz_bin_dex_resolve_type_id_by_idx(dex, method_id->class_idx);
+	rz_cons_printf("    #%-14u: (in %s)\n", index, tmp);
+	free(tmp);
+	tmp = rz_bin_dex_resolve_string_by_idx(dex, method_id->name_idx);
+	rz_cons_printf("      name          : '%s'\n", tmp);
+	free(tmp);
+	tmp = rz_bin_dex_resolve_proto_by_idx(dex, method_id->proto_idx);
+	rz_cons_printf("      type          : '%s'\n", tmp);
+	free(tmp);
+	tmp = decode_access_flags(encoded_method->access_flags);
+	rz_cons_printf("      access        : 0x%04" PFMT64x " (%s)\n", encoded_method->access_flags, tmp ? tmp : "");
+	free(tmp);
+	rz_cons_printf("      method_idx    : %" PFMT64u "\n", encoded_method->method_idx);
+	rz_cons_printf("      code          : (%s)\n", encoded_method->code_offset >= RZ_DEX_RELOC_ADDRESS ? "none" : "available");
+}
+
+static void dex_print_class_def(RzBinDex *dex, ut32 index, DexClassDef *class_def) {
+	ut32 j;
+	RzListIter *it;
+	DexEncodedField *encoded_field;
+	DexEncodedMethod *encoded_method;
+	rz_cons_printf("Class #%u header:\n", index);
+	rz_cons_printf("offset              : 0x%" PFMT64x "\n", class_def->offset);
+	rz_cons_printf("class_idx           : %u\n", class_def->class_idx);
+	rz_cons_printf("access_flags        : %u (0x%04x)\n", class_def->access_flags, class_def->access_flags);
+	rz_cons_printf("superclass_idx      : %u\n", class_def->superclass_idx);
+	rz_cons_printf("interfaces_off      : %u (0x%06x)\n", class_def->interfaces_offset, class_def->interfaces_offset);
+	rz_cons_printf("source_file_idx     : %u\n", class_def->source_file_idx);
+	rz_cons_printf("annotations_off     : %u (0x%06x)\n", class_def->annotations_offset, class_def->annotations_offset);
+	rz_cons_printf("class_data_off      : %u (0x%06x)\n", class_def->class_data_offset, class_def->class_data_offset);
+	rz_cons_printf("static_values_offset: %u (0x%06x)\n", class_def->static_values_offset, class_def->static_values_offset);
+	j = rz_list_length(class_def->static_fields);
+	rz_cons_printf("static_fields_size  : %u\n", j);
+	j = rz_list_length(class_def->instance_fields);
+	rz_cons_printf("instance_fields_size: %u\n", j);
+	j = rz_list_length(class_def->direct_methods);
+	rz_cons_printf("direct_methods_size : %u\n", j);
+	j = rz_list_length(class_def->virtual_methods);
+	rz_cons_printf("virtual_methods_size: %u\n\n", j);
+
+	rz_cons_printf("Class #%-13u-\n", index);
+	char *tmp = rz_bin_dex_resolve_type_id_by_idx(dex, class_def->class_idx);
+	rz_cons_printf("  Class descriptor  : '%s'\n", tmp);
+	free(tmp);
+	tmp = decode_access_flags(class_def->access_flags);
+	rz_cons_printf("  Access flags      : 0x%04x (%s)\n", class_def->access_flags, tmp ? tmp : "");
+	free(tmp);
+	tmp = rz_bin_dex_resolve_type_id_by_idx(dex, class_def->superclass_idx);
+	rz_cons_printf("  Superclass        : '%s'\n", tmp);
+	free(tmp);
+	rz_cons_printf("  Interfaces        -\n");
+	for (j = 0; j < class_def->n_interfaces; ++j) {
+		tmp = rz_bin_dex_resolve_type_id_by_idx(dex, class_def->interfaces[j]);
+		rz_cons_printf("    #%-15u: '%s'\n", j, tmp);
+		free(tmp);
+	}
+	rz_cons_printf("  Static fields     -\n");
+	j = 0;
+	rz_list_foreach (class_def->static_fields, it, encoded_field) {
+		dex_print_encoded_field(dex, j, encoded_field);
+		j++;
+	}
+	rz_cons_printf("  Instance fields   -\n");
+	j = 0;
+	rz_list_foreach (class_def->instance_fields, it, encoded_field) {
+		dex_print_encoded_field(dex, j, encoded_field);
+		j++;
+	}
+	rz_cons_printf("  Direct methods    -\n");
+	j = 0;
+	rz_list_foreach (class_def->direct_methods, it, encoded_method) {
+		dex_print_encoded_method(dex, j, encoded_method);
+		j++;
+	}
+	rz_cons_printf("  Virtual methods   -\n");
+	j = 0;
+	rz_list_foreach (class_def->virtual_methods, it, encoded_method) {
+		dex_print_encoded_method(dex, j, encoded_method);
+		j++;
+	}
+}
+
+RZ_IPI RzCmdStatus rz_cmd_dexs_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
+	if (argc != 1) {
+		return RZ_CMD_STATUS_WRONG_ARGS;
+	}
+
+	RzBinDex *dex = core_dex_get_class(core);
+	if (!dex) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+
+	// mimic dexdump output
+	char *tmp = NULL;
+	rz_cons_printf("DEX file header:\n");
+	tmp = rz_bin_dex_version(dex);
+	rz_cons_printf("version             : %s\n", tmp);
+	free(tmp);
+	rz_cons_printf("checksum            : %08x\n", dex->checksum);
+	rz_cons_printf("signature           : %02x%02x...%02x%02x\n", dex->signature[0], dex->signature[1], dex->signature[18], dex->signature[19]);
+	rz_cons_printf("file_size           : %u\n", dex->file_size);
+	rz_cons_printf("header_size         : %u\n", dex->header_size);
+	rz_cons_printf("link_size           : %u\n", dex->link_size);
+	rz_cons_printf("link_off            : %u (0x%06x)\n", dex->link_offset, dex->link_offset);
+	rz_cons_printf("string_ids_size     : %u\n", dex->string_ids_size);
+	rz_cons_printf("string_ids_off      : %u (0x%06x)\n", dex->string_ids_offset, dex->string_ids_offset);
+	rz_cons_printf("type_ids_size       : %u\n", dex->type_ids_size);
+	rz_cons_printf("type_ids_off        : %u (0x%06x)\n", dex->type_ids_offset, dex->type_ids_offset);
+	rz_cons_printf("proto_ids_size      : %u\n", dex->proto_ids_size);
+	rz_cons_printf("proto_ids_off       : %u (0x%06x)\n", dex->proto_ids_offset, dex->proto_ids_offset);
+	rz_cons_printf("field_ids_size      : %u\n", dex->field_ids_size);
+	rz_cons_printf("field_ids_off       : %u (0x%06x)\n", dex->field_ids_offset, dex->field_ids_offset);
+	rz_cons_printf("method_ids_size     : %u\n", dex->method_ids_size);
+	rz_cons_printf("method_ids_off      : %u (0x%06x)\n", dex->method_ids_offset, dex->method_ids_offset);
+	rz_cons_printf("class_defs_size     : %u\n", dex->class_defs_size);
+	rz_cons_printf("class_defs_off      : %u (0x%06x)\n", dex->class_defs_offset, dex->class_defs_offset);
+	rz_cons_printf("data_size           : %u\n", dex->data_size);
+	rz_cons_printf("data_off            : %u (0x%06x)\n\n", dex->data_offset, dex->data_offset);
+
+	for (ut32 i = 0; i < rz_pvector_len(dex->class_defs); ++i) {
+		DexClassDef *class_def = rz_pvector_at(dex->class_defs, i);
+		dex_print_class_def(dex, i, class_def);
+	}
+
+	return RZ_CMD_STATUS_OK;
+}
+
+static void dex_print_class_def_exports(RzBinDex *dex, ut32 index, DexClassDef *class_def) {
+	ut32 j;
+	RzListIter *it;
+	DexEncodedField *encoded_field;
+	DexEncodedMethod *encoded_method;
+	rz_cons_printf("Class #%-13u-\n", index);
+	char *tmp = rz_bin_dex_resolve_type_id_by_idx(dex, class_def->class_idx);
+	rz_cons_printf("  Class descriptor  : '%s'\n", tmp);
+	free(tmp);
+	tmp = decode_access_flags(class_def->access_flags);
+	rz_cons_printf("  Access flags      : 0x%04x (%s)\n", class_def->access_flags, tmp ? tmp : "");
+	free(tmp);
+	tmp = rz_bin_dex_resolve_type_id_by_idx(dex, class_def->superclass_idx);
+	rz_cons_printf("  Superclass        : '%s'\n", tmp);
+	free(tmp);
+	rz_cons_printf("  Interfaces        -\n");
+	for (j = 0; j < class_def->n_interfaces; ++j) {
+		tmp = rz_bin_dex_resolve_type_id_by_idx(dex, class_def->interfaces[j]);
+		rz_cons_printf("    #%-15u: '%s'\n", j, tmp);
+		free(tmp);
+	}
+	rz_cons_printf("  Static fields     -\n");
+	j = 0;
+	rz_list_foreach (class_def->static_fields, it, encoded_field) {
+		if ((encoded_field->access_flags & (ACCESS_FLAG_PUBLIC | ACCESS_FLAG_PROTECTED)) != 0) {
+			dex_print_encoded_field(dex, j, encoded_field);
+		}
+		j++;
+	}
+	rz_cons_printf("  Instance fields   -\n");
+	j = 0;
+	rz_list_foreach (class_def->instance_fields, it, encoded_field) {
+		if ((encoded_field->access_flags & (ACCESS_FLAG_PUBLIC | ACCESS_FLAG_PROTECTED)) != 0) {
+			dex_print_encoded_field(dex, j, encoded_field);
+		}
+		j++;
+	}
+	rz_cons_printf("  Direct methods    -\n");
+	j = 0;
+	rz_list_foreach (class_def->direct_methods, it, encoded_method) {
+		if ((encoded_method->access_flags & (ACCESS_FLAG_PUBLIC | ACCESS_FLAG_PROTECTED)) != 0) {
+			dex_print_encoded_method(dex, j, encoded_method);
+		}
+		j++;
+	}
+	rz_cons_printf("  Virtual methods   -\n");
+	j = 0;
+	rz_list_foreach (class_def->virtual_methods, it, encoded_method) {
+		if ((encoded_method->access_flags & (ACCESS_FLAG_PUBLIC | ACCESS_FLAG_PROTECTED)) != 0) {
+			dex_print_encoded_method(dex, j, encoded_method);
+		}
+		j++;
+	}
+}
+
+RZ_IPI RzCmdStatus rz_cmd_dexe_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
+	if (argc != 1) {
+		return RZ_CMD_STATUS_WRONG_ARGS;
+	}
+
+	RzBinDex *dex = core_dex_get_class(core);
+	if (!dex) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+
+	for (ut32 i = 0; i < rz_pvector_len(dex->class_defs); ++i) {
+		DexClassDef *class_def = rz_pvector_at(dex->class_defs, i);
+		if ((class_def->access_flags & ACCESS_FLAG_PUBLIC) != 0) {
+			dex_print_class_def_exports(dex, i, class_def);
+		}
+	}
+
+	return RZ_CMD_STATUS_OK;
+}
+
+static const RzCmdDescHelp dex_usage = {
+	.summary = "Core plugin to visualize dex class information",
+};
+
+static_description_without_args(dexs, "prints the dex structure");
+static_description_without_args(dexe, "prints the dex exported methods");
+
+static bool rz_cmd_dex_init_handler(RzCore *core) {
+	RzCmd *rcmd = core->rcmd;
+	RzCmdDesc *root_cd = rz_cmd_get_root(rcmd);
+	if (!root_cd) {
+		return false;
+	}
+
+	RzCmdDesc *dex = rz_cmd_desc_group_new(rcmd, root_cd, "dex", NULL, NULL, &dex_usage);
+	if (!dex) {
+		rz_warn_if_reached();
+		return false;
+	}
+
+	rz_cmd_desc_argv_modes_new_warn(rcmd, dex, dexs, RZ_OUTPUT_MODE_STANDARD);
+	rz_cmd_desc_argv_modes_new_warn(rcmd, dex, dexe, RZ_OUTPUT_MODE_STANDARD);
+
+	return true;
+}
+
+RzCorePlugin rz_core_plugin_dex = {
+	.name = "dex",
+	.desc = "Suite of dex commands, type `dex` for more info",
+	.license = "LGPL-3.0-only",
+	.author = "deroad",
+	.version = "1.0",
+	.init = rz_cmd_dex_init_handler,
+};
+
+#ifndef RZ_PLUGIN_INCORE
+RZ_API RzLibStruct rizin_plugin = {
+	.type = RZ_LIB_TYPE_CORE,
+	.data = &rz_core_plugin_dex,
+	.version = RZ_VERSION
+};
+#endif

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -1124,6 +1124,7 @@ RZ_API ut16 rz_core_flirt_app_from_option_list(RZ_NONNULL const char *app_list);
 
 /* PLUGINS */
 extern RzCorePlugin rz_core_plugin_java;
+extern RzCorePlugin rz_core_plugin_dex;
 
 /* DECOMPILER PRINTING FUNCTIONS */
 /**

--- a/librz/include/rz_util/rz_buf.h
+++ b/librz/include/rz_util/rz_buf.h
@@ -130,8 +130,8 @@ RZ_API void rz_buf_free(RzBuffer *b);
 RZ_API void rz_buf_set_overflow_byte(RZ_NONNULL RzBuffer *b, ut8 Oxff);
 RZ_DEPRECATE RZ_API RZ_BORROW const ut8 *rz_buf_data(RZ_NONNULL RzBuffer *b, ut64 *size);
 
-RZ_API st64 rz_buf_uleb128(RzBuffer *b, ut64 *v);
-RZ_API st64 rz_buf_sleb128(RzBuffer *b, st64 *v);
+RZ_API st64 rz_buf_uleb128(RZ_NONNULL RzBuffer *buffer, RZ_NONNULL ut64 *value);
+RZ_API st64 rz_buf_sleb128(RZ_NONNULL RzBuffer *buffer, RZ_NONNULL st64 *value);
 
 static inline st64 rz_buf_uleb128_at(RzBuffer *b, ut64 addr, ut64 *v) {
 	rz_buf_seek(b, addr, RZ_BUF_SET);

--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -34,6 +34,7 @@ FILE==
 CMDS=Lc
 EXPECT=<<EOF
 java: Suite of java commands, type `java` for more info (Made by deroad, v1.0, LGPL-3.0-only)
+dex: Suite of dex commands, type `dex` for more info (Made by deroad, v1.0, LGPL-3.0-only)
 EOF
 RUN
 
@@ -41,7 +42,7 @@ NAME=Print the core plugins in JSON
 FILE==
 CMDS=Lcj
 EXPECT=<<EOF
-[{"name":"java","description":"Suite of java commands, type `java` for more info","author":"deroad","version":"1.0","license":"LGPL-3.0-only"}]
+[{"name":"java","description":"Suite of java commands, type `java` for more info","author":"deroad","version":"1.0","license":"LGPL-3.0-only"},{"name":"dex","description":"Suite of dex commands, type `dex` for more info","author":"deroad","version":"1.0","license":"LGPL-3.0-only"}]
 EOF
 RUN
 

--- a/test/db/formats/dex
+++ b/test/db/formats/dex
@@ -1489,3 +1489,114 @@ EXPECT=<<EOF
  6 - r-x 0x0000000a vfile://1/reloc-targets
 EOF
 RUN
+
+NAME=dexdump like output of the dex data 
+FILE=bins/dex/Hello.dex
+CMDS=dexs
+EXPECT=<<EOF
+DEX file header:
+version             : Android 3.2 (API level 13 and earlier)
+checksum            : 1b1f79b5
+signature           : 3c99...7f13
+file_size           : 1000
+header_size         : 112
+link_size           : 0
+link_off            : 0 (0x000000)
+string_ids_size     : 22
+string_ids_off      : 112 (0x000070)
+type_ids_size       : 8
+type_ids_off        : 200 (0x0000c8)
+proto_ids_size      : 5
+proto_ids_off       : 232 (0x0000e8)
+field_ids_size      : 2
+field_ids_off       : 292 (0x000124)
+method_ids_size     : 8
+method_ids_off      : 308 (0x000134)
+class_defs_size     : 1
+class_defs_off      : 372 (0x000174)
+data_size           : 596
+data_off            : 404 (0x000194)
+
+Class #0 header:
+offset              : 0x174
+class_idx           : 0
+access_flags        : 1 (0x0001)
+superclass_idx      : 2
+interfaces_off      : 0 (0x000000)
+source_file_idx     : 2
+annotations_off     : 0 (0x000000)
+class_data_off      : 818 (0x000332)
+static_values_offset: 0 (0x000000)
+static_fields_size  : 0
+instance_fields_size: 1
+direct_methods_size : 2
+virtual_methods_size: 1
+
+Class #0            -
+  Class descriptor  : 'LHello;'
+  Access flags      : 0x0001 (PUBLIC)
+  Superclass        : 'Ljava/lang/Object;'
+  Interfaces        -
+  Static fields     -
+  Instance fields   -
+    #0             : (in LHello;)
+      name          : 'who'
+      type          : 'Ljava/lang/String;'
+      access        : 0x0002 (PRIVATE)
+  Direct methods    -
+    #0             : (in LHello;)
+      name          : '<init>'
+      type          : '(Ljava/lang/String;)V'
+      access        : 0x10001 (PUBLIC CONSTRUCTOR)
+      method_idx    : 0
+      code          : (available)
+    #1             : (in LHello;)
+      name          : 'main'
+      type          : '([Ljava/lang/String;)V'
+      access        : 0x0009 (PUBLIC STATIC)
+      method_idx    : 1
+      code          : (available)
+  Virtual methods   -
+    #0             : (in LHello;)
+      name          : 'say'
+      type          : '()V'
+      access        : 0x0001 (PUBLIC)
+      method_idx    : 2
+      code          : (available)
+EOF
+RUN
+
+
+NAME=dexdump like output of the dex exportable symbols (public/protected) 
+FILE=bins/dex/Hello.dex
+CMDS=dexe
+EXPECT=<<EOF
+Class #0            -
+  Class descriptor  : 'LHello;'
+  Access flags      : 0x0001 (PUBLIC)
+  Superclass        : 'Ljava/lang/Object;'
+  Interfaces        -
+  Static fields     -
+  Instance fields   -
+  Direct methods    -
+    #0             : (in LHello;)
+      name          : '<init>'
+      type          : '(Ljava/lang/String;)V'
+      access        : 0x10001 (PUBLIC CONSTRUCTOR)
+      method_idx    : 0
+      code          : (available)
+    #1             : (in LHello;)
+      name          : 'main'
+      type          : '([Ljava/lang/String;)V'
+      access        : 0x0009 (PUBLIC STATIC)
+      method_idx    : 1
+      code          : (available)
+  Virtual methods   -
+    #0             : (in LHello;)
+      name          : 'say'
+      type          : '()V'
+      access        : 0x0001 (PUBLIC)
+      method_idx    : 2
+      code          : (available)
+EOF
+RUN


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This PR fixes a particular bug where the a class does not have a data section (the code was parsing offset 0 of the file), introduces `dex`/`dexs`/`dexe` commands to dump like `dexdump` (an official android util) and refactors the uleb/sleb rz_buf methods.