### PR TITLE
Fix bf->sdb leak from bfile.c:rz_bin_file_new

### DIFF
--- a/librz/bin/bfile.c
+++ b/librz/bin/bfile.c
@@ -252,6 +252,7 @@ RZ_IPI void rz_bin_file_free(void /*RzBinFile*/ *_bf) {
 		// TODO: use rz_storage api
 		rz_id_pool_kick_id(bf->rbin->ids->pool, bf->id);
 	}
+	sdb_free(bf->sdb);
 	free(bf);
 }
 


### PR DESCRIPTION
This was reported as a null pointer dereference to radare2 [1], with a
MediaFire link to a reproducer at [2]. In particular, it produces this
rather large leak in valgrind:

==59961== 11,688 (11,504 direct, 184 indirect) bytes in 1 blocks are definitely lost in loss record 22 of 22
==59961==    at 0x4849C0F: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==59961==    by 0x48F27B4: sdb_new (sdb.c:56)
==59961==    by 0x5BF7D42: rz_bin_file_new (bfile.c:224)
==59961==    by 0x5BF8001: rz_bin_file_new_from_buffer (bfile.c:326)
==59961==    by 0x5BEECB6: rz_bin_open_buf (bin.c:302)
==59961==    by 0x5BEF017: rz_bin_open_io (bin.c:360)
==59961==    by 0x5DFFB0B: core_file_do_load_for_io_plugin (cfile.c:692)
==59961==    by 0x5DFFB0B: rz_core_bin_load (cfile.c:938)
==59961==    by 0x4963028: rz_main_rizin (rizin.c:1140)
==59961==    by 0x49D2349: (below main) (libc_start_call_main.h:58)

[1] https://huntr.dev/bounties/bfeb8fb8-644d-4587-80d4-cb704c404013/
[2] https://www.mediafire.com/file/vs8vbmdzh2epznc/poc_00/file

Fixes: https://github.com/rizinorg/rizin/issues/2540
Signed-off-by: John Helmert III <ajak@gentoo.org>

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Details in #2540

Unfortunately, this fix still UAFs on the attached file (when unzipped) for reasons I don't understand. The object is seemingly freed in rz_bin_file_free, but apparently also rz_core_fini. Why?

```
jake@sol ~/git/rizin/build $ ./binrz/rizin/rizin -qAAA ~/Downloads/CVE-2022-1207
WARNING: Invalid section header (check array failed).
WARNING: Invalid program header (check array failed).
WARNING: Failed to initialize program header.
WARNING: Failed to initialize section header.
WARNING: No calling convention defined for this file, analysis may be inaccurate.
=================================================================
==3560489==ERROR: AddressSanitizer: heap-use-after-free on address 0x6260001d0da0 at pc 0x7fc8a2b46dfc bp 0x7ffd9bc86700 sp 0x7ffd9bc866f0
READ of size 8 at 0x6260001d0da0 thread T0
    #0 0x7fc8a2b46dfb in sdb_free ../subprojects/sdb/src/sdb.c:215
    #1 0x7fc8a2b3af59 in ns_free_exc_list ../subprojects/sdb/src/ns.c:50
    #2 0x7fc8a2b3bd41 in sdb_ns_free_all ../subprojects/sdb/src/ns.c:80
    #3 0x7fc8a2b46b67 in sdb_fini ../subprojects/sdb/src/sdb.c:196
    #4 0x7fc8a2b46de2 in sdb_fini ../subprojects/sdb/src/sdb.c:188
    #5 0x7fc8a2b46de2 in sdb_free ../subprojects/sdb/src/sdb.c:219
    #6 0x7fc8a2b3af59 in ns_free_exc_list ../subprojects/sdb/src/ns.c:50
    #7 0x7fc8a2b3bd41 in sdb_ns_free_all ../subprojects/sdb/src/ns.c:80
    #8 0x7fc8a2b46b67 in sdb_fini ../subprojects/sdb/src/sdb.c:196
    #9 0x7fc8a2b46de2 in sdb_fini ../subprojects/sdb/src/sdb.c:188
    #10 0x7fc8a2b46de2 in sdb_free ../subprojects/sdb/src/sdb.c:219
    #11 0x7fc89f60a5f9 in rz_core_fini ../librz/core/core.c:2668
    #12 0x7fc89f60a5f9 in rz_core_fini ../librz/core/core.c:2611
    #13 0x7fc89f60a81d in rz_core_free ../librz/core/core.c:2678
    #14 0x7fc8a2968248 in rz_main_rizin ../librz/main/rizin.c:1528
    #15 0x7fc8a2774349 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #16 0x7fc8a27743fb in __libc_start_main_impl ../csu/libc-start.c:392
    #17 0x55ee4aff8700 in _start (/home/jake/git/rizin/build/binrz/rizin/rizin+0x2700)

0x6260001d0da0 is located 11424 bytes inside of 11504-byte region [0x6260001ce100,0x6260001d0df0)
freed by thread T0 here:
    #0 0x7fc8a2d439e7 in __interceptor_free /usr/src/debug/sys-devel/gcc-11.2.1_p20220115/gcc-11-20220115/libsanitizer/asan/asan_malloc_linux.cpp:127
    #1 0x7fc8a2b46dec in sdb_free ../subprojects/sdb/src/sdb.c:221

previously allocated by thread T0 here:
    #0 0x7fc8a2d43f17 in __interceptor_calloc /usr/src/debug/sys-devel/gcc-11.2.1_p20220115/gcc-11-20220115/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7fc8a2b44934 in sdb_new ../subprojects/sdb/src/sdb.c:56

SUMMARY: AddressSanitizer: heap-use-after-free ../subprojects/sdb/src/sdb.c:215 in sdb_free
Shadow bytes around the buggy address:
  0x0c4c80032160: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4c80032170: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4c80032180: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4c80032190: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c4c800321a0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0c4c800321b0: fd fd fd fd[fd]fd fd fd fd fd fd fd fd fd fa fa
  0x0c4c800321c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4c800321d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4c800321e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4c800321f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c4c80032200: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==3560489==ABORTING
```

[CVE-2022-1207.zip](https://github.com/rizinorg/rizin/files/8482182/CVE-2022-1207.zip)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

This isn't a correct fix, but will add a test for it once a proper fix is clear.

**Closing issues**

Closes #2540
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->