### PR TITLE
Fix OOB write in `unescape_special_chars()`

### DIFF
--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -2503,8 +2503,10 @@ static char *unescape_special_chars(const char *s, const char *special_chars) {
 			dst[j++] = s[i];
 			continue;
 		}
-		dst[j++] = s[i + 1];
-		i++;
+		dst[j++] = s[++i];
+		if (!s[i]) {
+			break;
+		}
 	}
 	dst[j++] = '\0';
 	return dst;

--- a/test/db/cmd/cmd_fuzzed
+++ b/test/db/cmd/cmd_fuzzed
@@ -57,3 +57,13 @@ EOF
 EXPECT=<<EOF
 EOF
 RUN
+
+NAME=Escaping crash #2
+FILE==
+CMDS=<<EOF
+e scr.null=true
+af \\
+EOF
+EXPECT=<<EOF
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Double backslash (`\\`) at the end of a command would cause an OOB write in `dst` buffer and OOB read in `src` buffer

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tests pass

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None
