### PR TITLE
Move DEBUGGER checks from C to meson.build

### DIFF
--- a/librz/debug/meson.build
+++ b/librz/debug/meson.build
@@ -5,7 +5,6 @@ debug_plugins = [
   'esil',
   'gdb',
   'io',
-  'native',
   'null',
   'rap',
   'winkd'
@@ -13,10 +12,6 @@ debug_plugins = [
 
 if get_option('use_gpl')
   debug_plugins += 'qnx'
-endif
-
-if host_machine.system() == 'windows'
-  debug_plugins += 'windbg'
 endif
 
 rz_debug_sources = [
@@ -40,7 +35,6 @@ rz_debug_sources = [
   'p/debug_esil.c',
   'p/debug_gdb.c',
   'p/debug_io.c',
-  'p/debug_native.c',
   'p/debug_null.c',
   'p/debug_rap.c',
   'p/debug_winkd.c',
@@ -76,11 +70,39 @@ if get_option('use_gpl')
   rz_debug_sources += 'p/debug_qnx.c'
 endif
 
-if host_machine.system() == 'linux' or host_machine.system() == 'android'
-  rz_debug_sources += ['p/native/linux/linux_debug.c']
-endif
-if host_machine.system() == 'linux'
-  rz_debug_sources += ['p/native/linux/linux_coredump.c']
+if has_debugger
+  debug_plugins += ['native']
+  rz_debug_sources += ['p/debug_native.c']
+
+  if host_machine.system() == 'linux' or host_machine.system() == 'android'
+    rz_debug_sources += ['p/native/linux/linux_debug.c']
+  endif
+  if host_machine.system() == 'linux'
+    rz_debug_sources += ['p/native/linux/linux_coredump.c']
+  endif
+
+  if host_machine.system() != 'windows'
+    rz_debug_sources += [
+      'p/native/procfs.c'
+    ]
+  endif
+
+  if host_machine.system() == 'darwin'
+    rz_debug_sources += [
+      'p/native/xnu/xnu_debug.c',
+      #'p/native/xnu/trap_arm.c',
+      #'p/native/xnu/trap_x86.c',
+      #'p/native/xnu/xnu_excthreads.c',
+      #'p/native/xnu/xnu_threads.c',
+    ]
+  endif
+
+  if ['netbsd', 'openbsd', 'freebsd', 'dragonfly'].contains(host_machine.system())
+    rz_debug_deps += cc.find_library('kvm', required: true, static: is_static_build)
+    rz_debug_sources += [
+      'p/native/bsd/bsd_debug.c',
+    ]
+  endif
 endif
 
 if host_machine.system() == 'windows'
@@ -91,29 +113,8 @@ if host_machine.system() == 'windows'
     'p/native/windows/windows_message.c',
   ]
   rz_debug_deps += dependency('rzw32dbg_wrap')
-endif
 
-if host_machine.system() != 'windows'
-  rz_debug_sources += [
-    'p/native/procfs.c'
-  ]
-endif
-
-if host_machine.system() == 'darwin'
-  rz_debug_sources += [
-    'p/native/xnu/xnu_debug.c',
-    #'p/native/xnu/trap_arm.c',
-    #'p/native/xnu/trap_x86.c',
-    #'p/native/xnu/xnu_excthreads.c',
-    #'p/native/xnu/xnu_threads.c',
-  ]
-endif
-
-if ['netbsd', 'openbsd', 'freebsd', 'dragonfly'].contains(host_machine.system())
-  rz_debug_deps += cc.find_library('kvm', required: true, static: is_static_build)
-  rz_debug_sources += [
-    'p/native/bsd/bsd_debug.c',
-  ]
+  debug_plugins += 'windbg'
 endif
 
 rz_debug_inc = [

--- a/librz/debug/p/debug_native.c
+++ b/librz/debug/p/debug_native.c
@@ -11,8 +11,6 @@
 #include <signal.h>
 #include <sys/types.h>
 
-#if DEBUGGER
-
 #include "native/drx.c" // x86 specific
 #include "rz_cons.h"
 
@@ -84,8 +82,6 @@ RZ_API RzList *rz_w32_dbg_maps(RzDebug *);
 #else
 #define WAITPID_FLAGS 0
 #endif
-
-#endif /* IF DEBUGGER */
 
 /* begin of debugger code */
 #if DEBUGGER

--- a/librz/debug/p/native/linux/linux_coredump.c
+++ b/librz/debug/p/native/linux/linux_coredump.c
@@ -3,8 +3,6 @@
 
 #include <rz_debug.h>
 
-#if DEBUGGER
-
 #if __x86_64__ || __i386__ || __arm__ || __arm64__
 #include <sys/uio.h>
 #include <sys/ptrace.h>
@@ -1536,6 +1534,4 @@ cleanup:
 	free(note_data);
 	return !error;
 }
-#endif
-
 #endif

--- a/librz/debug/p/native/linux/linux_debug.c
+++ b/librz/debug/p/native/linux/linux_debug.c
@@ -3,7 +3,6 @@
 
 #include <rz_userconf.h>
 
-#if DEBUGGER
 #include <rz_debug.h>
 #include <rz_reg.h>
 #include <rz_lib.h>
@@ -1388,5 +1387,3 @@ fail:
 	closedir(dd);
 	return NULL;
 }
-
-#endif

--- a/librz/debug/p/native/xnu/xnu_debug.c
+++ b/librz/debug/p/native/xnu/xnu_debug.c
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_userconf.h>
-#if DEBUGGER
 
 #if XNU_USE_PTRACE
 #define XNU_USE_EXCTHR 0
@@ -1431,5 +1430,3 @@ RzList *xnu_dbg_maps(RzDebug *dbg, int only_modules) {
 	rz_list_free(modules);
 	return list;
 }
-
-#endif

--- a/librz/debug/p/native/xnu/xnu_threads.c
+++ b/librz/debug/p/native/xnu/xnu_threads.c
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_userconf.h>
-#if DEBUGGER
 
 // TODO much work remains to be done
 #include "xnu_debug.h"
@@ -375,4 +374,3 @@ static int xnu_update_thread_list(RzDebug *dbg) {
 		thread_count * sizeof(thread_t));
 	return true;
 }
-#endif

--- a/test/db/archos/linux-x64/dbg_dL
+++ b/test/db/archos/linux-x64/dbg_dL
@@ -8,10 +8,10 @@ EXPECT=<<EOF
 3  ---  esil     LGPL3
 4  ---  gdb      LGPL3
 5  ---  io       MIT
-6  dbg  native   LGPL3
-7  ---  null     MIT
-8  ---  rap      LGPL3
-9  ---  winkd    LGPL3
-10  ---  qnx      LGPL3
+6  ---  null     MIT
+7  ---  rap      LGPL3
+8  ---  winkd    LGPL3
+9  ---  qnx      LGPL3
+10  dbg  native   LGPL3
 EOF
 RUN

--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -330,11 +330,11 @@ EXPECT=<<EOF
 3  dbg  esil     LGPL3
 4  ---  gdb      LGPL3
 5  ---  io       MIT
-6  ---  native   LGPL3
-7  ---  null     MIT
-8  ---  rap      LGPL3
-9  ---  winkd    LGPL3
-10  ---  qnx      LGPL3
+6  ---  null     MIT
+7  ---  rap      LGPL3
+8  ---  winkd    LGPL3
+9  ---  qnx      LGPL3
+10  ---  native   LGPL3
 EOF
 RUN
 
@@ -348,11 +348,11 @@ EXPECT=<<EOF
 3  ---  esil     LGPL3
 4  ---  gdb      LGPL3
 5  ---  io       MIT
-6  dbg  native   LGPL3
-7  ---  null     MIT
-8  ---  rap      LGPL3
-9  ---  winkd    LGPL3
-10  ---  qnx      LGPL3
+6  ---  null     MIT
+7  ---  rap      LGPL3
+8  ---  winkd    LGPL3
+9  ---  qnx      LGPL3
+10  dbg  native   LGPL3
 EOF
 RUN
 
@@ -365,12 +365,12 @@ Ldj~{[2]}
 Ldj~{[3]}
 Ldj~{[4]}
 Ldj~{[5]}
-Ldj~{[6].name}
-Ldj~{[6].license}
+Ldj~{[6]}
 Ldj~{[7]}
 Ldj~{[8]}
 Ldj~{[9]}
-Ldj~{[10]}
+Ldj~{[10].name}
+Ldj~{[10].license}
 EOF
 EXPECT=<<EOF
 {"arch":"bf","name":"bf","license":"LGPL3"}
@@ -379,12 +379,12 @@ EXPECT=<<EOF
 {"arch":"any","name":"esil","license":"LGPL3"}
 {"arch":"x86,arm,sh,mips,avr,lm32,v850,ba2","name":"gdb","license":"LGPL3"}
 {"arch":"any","name":"io","license":"MIT"}
-native
-LGPL3
 {"arch":"any","name":"null","license":"MIT"}
 {"arch":"any","name":"rap","license":"LGPL3"}
 {"arch":"x86","name":"winkd","license":"LGPL3"}
 {"arch":"x86,arm","name":"qnx","license":"LGPL3"}
+native
+LGPL3
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Entire files are now avoided to be built by checking in meson rather
than using #if DEBUGGER. This now also includes bsd_debug.c, which
is currently slightly broken on OpenBSD/sparc64 and caused compile
errors even with -Ddebugger=false.

**Test plan**

Build with `-Ddebugger=false` and `=true` on all kinds of platforms.

Currently tested:

|  | `debugger=false` | `debugger=true` |
|-|-|-|
| OpenBSD/sparc64 | ☑️ | broken (as before) |
| macOS/arm64 | ☑️ | ☑️ |
| Mac OS X/ppc| ☑️ | broken (as before) |
| Linux/x86_64 | ☑️ | CI ☑️ |
| FreeBSD/x86_64 | | CI ☑️ |
| NetBSD/x86_64 | | CI ☑️ |
| OpenBSD/x86_64 | | CI ☑️ |
| Windows/x86_64 | ☑️ | CI ☑️ |