### PR TITLE
Move rz_bin_file_golang_compiler usage under bobj.c

### DIFF
--- a/librz/bin/bin_language.c
+++ b/librz/bin/bin_language.c
@@ -76,16 +76,13 @@ RZ_API RzBinLanguage rz_bin_language_detect(RzBinFile *binfile) {
 
 	if (!info) {
 		return RZ_BIN_LANGUAGE_UNKNOWN;
-	} else if (RZ_STR_ISNOTEMPTY(info->lang)) {
-		if (strstr(info->lang, "dart")) {
-			return RZ_BIN_LANGUAGE_DART;
-		} else if (strstr(info->lang, "kotlin")) {
-			return RZ_BIN_LANGUAGE_KOTLIN;
-		} else if (strstr(info->lang, "groovy")) {
-			return RZ_BIN_LANGUAGE_GROOVY;
-		} else if (strstr(info->lang, "swift")) {
-			return RZ_BIN_LANGUAGE_SWIFT;
-		}
+	}
+	RzBinLanguage lang = rz_bin_language_to_id(info->lang);
+	if (lang != RZ_BIN_LANGUAGE_UNKNOWN &&
+		lang != RZ_BIN_LANGUAGE_C &&
+		lang != RZ_BIN_LANGUAGE_OBJC) {
+		// avoid detecting a language if was already specified.
+		return lang;
 	}
 
 	bool is_macho = info->rclass ? strstr(info->rclass, "mach") : false;

--- a/librz/bin/bobj.c
+++ b/librz/bin/bobj.c
@@ -496,6 +496,14 @@ RZ_API int rz_bin_object_set_items(RzBinFile *bf, RzBinObject *o) {
 		REBASE_PADDR(o, o->strings, RzBinString);
 	}
 
+	if (o->info && RZ_STR_ISEMPTY(o->info->compiler)) {
+		free(o->info->compiler);
+		o->info->compiler = rz_bin_file_golang_compiler(bf);
+		if (o->info->compiler) {
+			o->info->lang = "go";
+		}
+	}
+
 	o->lang = rz_bin_language_detect(bf);
 
 	if (bin->filter_rules & (RZ_BIN_REQ_CLASSES | RZ_BIN_REQ_CLASSES_SOURCES)) {

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -1727,13 +1727,6 @@ static RzBinInfo *info(RzBinFile *bf) {
 	lookup_sections(bf, ret);
 	lookup_symbols(bf, ret);
 
-	if (RZ_STR_ISEMPTY(ret->compiler)) {
-		free(ret->compiler);
-		ret->compiler = rz_bin_file_golang_compiler(bf);
-		if (ret->compiler) {
-			ret->lang = "go";
-		}
-	}
 	return ret;
 }
 

--- a/librz/bin/p/bin_mach0.c
+++ b/librz/bin/p/bin_mach0.c
@@ -501,12 +501,7 @@ static RzBinInfo *info(RzBinFile *bf) {
 		ret->lang = bin->lang;
 	}
 	ret->intrp = rz_str_dup(NULL, MACH0_(get_intrp)(bf->o->bin_obj));
-	ret->compiler = rz_bin_file_golang_compiler(bf);
-	if (ret->compiler) {
-		ret->lang = "go";
-	} else {
-		ret->compiler = rz_str_dup(NULL, "");
-	}
+	ret->compiler = rz_str_dup(NULL, "");
 	ret->rclass = strdup("mach0");
 	ret->os = strdup(MACH0_(get_os)(bf->o->bin_obj));
 	ret->subsystem = strdup("darwin");

--- a/librz/bin/p/bin_pe.inc
+++ b/librz/bin/p/bin_pe.inc
@@ -632,10 +632,6 @@ static RzBinInfo *info(RzBinFile *bf) {
 		ret->lang = "vb";
 	}
 
-	ret->compiler = rz_bin_file_golang_compiler(bf);
-	if (ret->compiler) {
-		ret->lang = "go";
-	}
 	if (PE_(rz_bin_pe_is_dll)(bf->o->bin_obj)) {
 		ret->type = strdup("DLL (Dynamic Link Library)");
 	} else {

--- a/test/db/cmd/cmd_pipe
+++ b/test/db/cmd/cmd_pipe
@@ -109,7 +109,7 @@ Copied bins/mach0/mach0_2-x86_64 succesfully
 -------------
 Shared buffer size 0x10e8
 -------------
-{'arch': 'x86', 'baddr': 4294967296, 'binsz': 4328, 'bintype': 'mach0', 'bits': 64, 'class': 'MACH064', 'compiler': '', 'endian': 'LE', 'intrp': '/usr/lib/dyld', 'laddr': 0, 'lang': 'c', 'machine': 'x86 64 all', 'maxopsz': 16, 'minopsz': 1, 'os': 'macos', 'pcalign': 0, 'subsys': 'darwin', 'stripped': False, 'crypto': False, 'havecode': True, 'va': True, 'sanitiz': False, 'static': False, 'linenum': False, 'lsyms': False, 'canary': False, 'PIE': True, 'RELROCS': False, 'NX': False}
+{'arch': 'x86', 'baddr': 4294967296, 'binsz': 4328, 'bintype': 'mach0', 'bits': 64, 'class': 'MACH064', 'endian': 'LE', 'intrp': '/usr/lib/dyld', 'laddr': 0, 'lang': 'c', 'machine': 'x86 64 all', 'maxopsz': 16, 'minopsz': 1, 'os': 'macos', 'pcalign': 0, 'subsys': 'darwin', 'stripped': False, 'crypto': False, 'havecode': True, 'va': True, 'sanitiz': False, 'static': False, 'linenum': False, 'lsyms': False, 'canary': False, 'PIE': True, 'RELROCS': False, 'NX': False}
 - offset -    0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
 0x100000f70  5548 89e5 4883 ec10 c745 fc00 0000 0089  UH..H....E......
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Just moves the usage of `rz_bin_file_golang_compiler` from the plugins into `bobj.c`