### PR TITLE
Fix #2582 - Fix `rz_buf_fwd_scan` unit test for big endian archs

### DIFF
--- a/test/unit/test_buf.c
+++ b/test/unit/test_buf.c
@@ -1318,7 +1318,7 @@ ut64 fwd_adder(const ut8 *buf, ut64 sz, void *user) {
 	if (!user || !sz) {
 		return -1;
 	}
-	ut32 *result = user;
+	ut64 *result = user;
 	ut64 i;
 	for (i = 0; i < sz; i++) {
 		*result += buf[i];


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tests pass

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Fixes #2582
