### PR TITLE
Fix LE, COFF, LUA, PYC file formats parsing on big-endian platforms

### DIFF
--- a/librz/bin/format/coff/coff.c
+++ b/librz/bin/format/coff/coff.c
@@ -7,7 +7,7 @@
 #include "coff.h"
 
 RZ_API bool rz_coff_supported_arch(const ut8 *buf) {
-	ut16 arch = *(ut16 *)buf;
+	ut16 arch = rz_read_le16(buf);
 	switch (arch) {
 	case COFF_FILE_MACHINE_MIPS16:
 	case COFF_FILE_MACHINE_MIPSFPU:
@@ -135,7 +135,7 @@ RZ_API RzBinAddr *rz_coff_get_entry(struct rz_bin_coff_obj *obj) {
 
 static bool rz_bin_coff_init_hdr(struct rz_bin_coff_obj *obj) {
 	ut16 magic;
-	if (!rz_buf_read_ble16_at(obj->b, 0, &magic, COFF_IS_LITTLE_ENDIAN)) {
+	if (!rz_buf_read_le16_at(obj->b, 0, &magic)) {
 		return false;
 	}
 

--- a/librz/bin/format/coff/coff_specs.h
+++ b/librz/bin/format/coff/coff_specs.h
@@ -209,12 +209,11 @@ RZ_PACKED(
 		ut8 n_numaux; /* Auxiliary Count */
 	});
 
-RZ_PACKED(
-	struct coff_reloc {
-		ut32 rz_vaddr; /* Reference Address */
-		ut32 rz_symndx; /* Symbol index */
-		ut16 rz_type; /* Type of relocation */
-	});
+struct coff_reloc {
+	ut32 rz_vaddr; /* Reference Address */
+	ut32 rz_symndx; /* Symbol index */
+	ut16 rz_type; /* Type of relocation */
+};
 
 #define COFF_SYM_GET_DTYPE(type) (((type) >> 4) & 3)
 #endif /* COFF_SPECS_H */

--- a/librz/bin/format/le/le.c
+++ b/librz/bin/format/le/le.c
@@ -4,7 +4,7 @@
 #include "le.h"
 #include <rz_bin.h>
 
-const char *__get_module_type(rz_bin_le_obj_t *bin) {
+const char *le_get_module_type(rz_bin_le_obj_t *bin) {
 	switch (bin->header->mflags & M_TYPE_MASK) {
 	case M_TYPE_EXE: return "Program module (EXE)";
 	case M_TYPE_DLL: return "Library module (DLL)";
@@ -14,7 +14,7 @@ const char *__get_module_type(rz_bin_le_obj_t *bin) {
 	}
 }
 
-const char *__get_os_type(rz_bin_le_obj_t *bin) {
+const char *le_get_os_type(rz_bin_le_obj_t *bin) {
 	switch (bin->header->os) {
 	case 1: return "OS/2";
 	case 2: return "Windows";
@@ -25,7 +25,7 @@ const char *__get_os_type(rz_bin_le_obj_t *bin) {
 	}
 }
 
-const char *__get_cpu_type(rz_bin_le_obj_t *bin) {
+const char *le_get_cpu_type(rz_bin_le_obj_t *bin) {
 	switch (bin->header->cpu) {
 	case 1: return "80286";
 	case 2: return "80386";
@@ -39,7 +39,7 @@ const char *__get_cpu_type(rz_bin_le_obj_t *bin) {
 	}
 }
 
-const char *__get_arch(rz_bin_le_obj_t *bin) {
+const char *le_get_arch(rz_bin_le_obj_t *bin) {
 	switch (bin->header->cpu) {
 	case 1:
 	case 2:
@@ -57,7 +57,7 @@ const char *__get_arch(rz_bin_le_obj_t *bin) {
 	}
 }
 
-static char *__read_nonnull_str_at(RzBuffer *buf, ut64 *offset) {
+static char *le_read_nonnull_str_at(RzBuffer *buf, ut64 *offset) {
 	ut8 size;
 	if (!rz_buf_read8_at(buf, *offset, &size)) {
 		return NULL;
@@ -74,28 +74,27 @@ static char *__read_nonnull_str_at(RzBuffer *buf, ut64 *offset) {
 	return str;
 }
 
-static RzBinSymbol *__get_symbol(rz_bin_le_obj_t *bin, ut64 *offset) {
+static RzBinSymbol *le_get_symbol(rz_bin_le_obj_t *bin, ut64 *offset) {
 	RzBinSymbol *sym = RZ_NEW0(RzBinSymbol);
 	if (!sym) {
 		return NULL;
 	}
-	char *name = __read_nonnull_str_at(bin->buf, offset);
+	char *name = le_read_nonnull_str_at(bin->buf, offset);
 	if (!name) {
 		rz_bin_symbol_free(sym);
 		return NULL;
 	}
 	sym->name = name;
 	ut16 entry_idx;
-	if (!rz_buf_read_le16_at(bin->buf, *offset, &entry_idx)) {
+	if (!rz_buf_read_le16_offset(bin->buf, offset, &entry_idx)) {
 		rz_bin_symbol_free(sym);
 		return NULL;
 	}
-	*offset += 2;
 	sym->ordinal = entry_idx;
 	return sym;
 }
 
-RzList *__get_entries(rz_bin_le_obj_t *bin) {
+RzList *le_get_entries(rz_bin_le_obj_t *bin) {
 	ut64 offset = (ut64)bin->header->enttab + bin->headerOff;
 	RzList *l = rz_list_newf(free);
 	if (!l) {
@@ -104,7 +103,12 @@ RzList *__get_entries(rz_bin_le_obj_t *bin) {
 	while (true) {
 		LE_entry_bundle_header header;
 		LE_entry_bundle_entry e;
-		rz_buf_read_at(bin->buf, offset, (ut8 *)&header, sizeof(header));
+		ut64 off = offset;
+		if (!(rz_buf_read8_offset(bin->buf, &off, &header.count) &&
+			    rz_buf_read8_offset(bin->buf, &off, &header.type) &&
+			    rz_buf_read_le16_offset(bin->buf, &off, &header.objnum))) {
+			break;
+		}
 		if (!header.count) {
 			break;
 		}
@@ -162,9 +166,9 @@ RzList *__get_entries(rz_bin_le_obj_t *bin) {
 	return l;
 }
 
-static void __get_symbols_at(rz_bin_le_obj_t *bin, RzList *syml, RzList *entl, ut64 offset, ut64 end) {
+static void le_get_symbols_at(rz_bin_le_obj_t *bin, RzList *syml, RzList *entl, ut64 offset, ut64 end) {
 	while (offset < end) {
-		RzBinSymbol *sym = __get_symbol(bin, &offset);
+		RzBinSymbol *sym = le_get_symbol(bin, &offset);
 		if (!sym) {
 			break;
 		}
@@ -186,14 +190,14 @@ static void __get_symbols_at(rz_bin_le_obj_t *bin, RzList *syml, RzList *entl, u
 
 RzList *rz_bin_le_get_symbols(rz_bin_le_obj_t *bin) {
 	RzList *l = rz_list_newf((RzListFree)rz_bin_symbol_free);
-	RzList *entries = __get_entries(bin);
+	RzList *entries = le_get_entries(bin);
 	LE_image_header *h = bin->header;
 	ut64 offset = (ut64)h->restab + bin->headerOff;
 	ut32 end = h->enttab + bin->headerOff;
-	__get_symbols_at(bin, l, entries, offset, end);
+	le_get_symbols_at(bin, l, entries, offset, end);
 	offset = h->nrestab;
 	end = h->nrestab + h->cbnrestab;
-	__get_symbols_at(bin, l, entries, offset, end);
+	le_get_symbols_at(bin, l, entries, offset, end);
 	rz_list_free(entries);
 	return l;
 }
@@ -211,7 +215,7 @@ RzList *rz_bin_le_get_imports(rz_bin_le_obj_t *bin) {
 		if (!imp) {
 			break;
 		}
-		imp->name = __read_nonnull_str_at(bin->buf, &offset);
+		imp->name = le_read_nonnull_str_at(bin->buf, &offset);
 		if (!imp->name) {
 			rz_bin_import_free(imp);
 			break;
@@ -247,7 +251,7 @@ RzList *rz_bin_le_get_libs(rz_bin_le_obj_t *bin) {
 	ut64 offset = (ut64)h->impmod + bin->headerOff;
 	ut64 end = offset + h->impproc - h->impmod;
 	while (offset < end) {
-		char *name = __read_nonnull_str_at(bin->buf, &offset);
+		char *name = le_read_nonnull_str_at(bin->buf, &offset);
 		if (!name) {
 			break;
 		}
@@ -383,8 +387,10 @@ RzList *rz_bin_le_get_sections(rz_bin_le_obj_t *bin) {
 
 			int cur_idx = entry->page_tbl_idx + j - 1;
 			ut64 page_entry_off = objpageentrysz * cur_idx + objmaptbloff;
-			int r = rz_buf_read_at(bin->buf, page_entry_off, (ut8 *)&page, sizeof(page));
-			if (r < sizeof(page)) {
+			ut64 offset = page_entry_off;
+			if (!(rz_buf_read_le32_offset(bin->buf, &offset, &page.offset) &&
+				    rz_buf_read_le16_offset(bin->buf, &offset, &page.size) &&
+				    rz_buf_read_le16_offset(bin->buf, &offset, &page.flags))) {
 				RZ_LOG_WARN("Cannot read out of bounds page table entry.\n");
 				rz_bin_section_free(s);
 				break;
@@ -433,12 +439,12 @@ RzList *rz_bin_le_get_sections(rz_bin_le_obj_t *bin) {
 	return l;
 }
 
-char *__get_modname_by_ord(rz_bin_le_obj_t *bin, ut32 ordinal) {
+char *le_get_modname_by_ord(rz_bin_le_obj_t *bin, ut32 ordinal) {
 	char *modname = NULL;
 	ut64 off = (ut64)bin->header->impmod + bin->headerOff;
 	while (ordinal > 0) {
 		free(modname);
-		modname = __read_nonnull_str_at(bin->buf, &off);
+		modname = le_read_nonnull_str_at(bin->buf, &off);
 		ordinal--;
 	}
 	return modname;
@@ -449,7 +455,7 @@ RzList *rz_bin_le_get_relocs(rz_bin_le_obj_t *bin) {
 	if (!l) {
 		return NULL;
 	}
-	RzList *entries = __get_entries(bin);
+	RzList *entries = le_get_entries(bin);
 	RzList *sections = rz_bin_le_get_sections(bin);
 	LE_image_header *h = bin->header;
 	ut64 cur_page = 0;
@@ -546,20 +552,18 @@ RzList *rz_bin_le_get_relocs(rz_bin_le_obj_t *bin) {
 				if ((header.source & F_SOURCE_TYPE_MASK) != SELECTOR16) {
 					if (header.target & F_TARGET_OFF32) {
 						ut32 tmp;
-						if (!rz_buf_read_ble32_at(bin->buf, offset, &tmp, h->worder)) {
+						if (!rz_buf_read_ble32_offset(bin->buf, &offset, &tmp, h->worder)) {
 							rz_bin_reloc_free(rel);
 							continue;
 						}
 						rel->addend += tmp;
-						offset += sizeof(ut32);
 					} else {
 						ut16 tmp;
-						if (!rz_buf_read_ble16_at(bin->buf, offset, &tmp, h->worder)) {
+						if (!rz_buf_read_ble16_offset(bin->buf, &offset, &tmp, h->worder)) {
 							rz_bin_reloc_free(rel);
 							continue;
 						}
 						rel->addend += tmp;
-						offset += sizeof(ut16);
 					}
 				}
 			}
@@ -569,7 +573,7 @@ RzList *rz_bin_le_get_relocs(rz_bin_le_obj_t *bin) {
 			if (!imp) {
 				break;
 			}
-			char *mod_name = __get_modname_by_ord(bin, ordinal);
+			char *mod_name = le_get_modname_by_ord(bin, ordinal);
 			if (!mod_name) {
 				rz_bin_import_free(imp);
 				break;
@@ -584,19 +588,17 @@ RzList *rz_bin_le_get_relocs(rz_bin_le_obj_t *bin) {
 				ordinal = tmp;
 				offset += sizeof(ut8);
 			} else if (header.target & F_TARGET_OFF32) {
-				if (!rz_buf_read_ble32_at(bin->buf, offset, &ordinal, h->worder)) {
+				if (!rz_buf_read_ble32_offset(bin->buf, &offset, &ordinal, h->worder)) {
 					rz_bin_import_free(imp);
 					break;
 				}
-				offset += sizeof(ut32);
 			} else {
 				ut16 tmp;
-				if (!rz_buf_read_ble16_at(bin->buf, offset, &tmp, h->worder)) {
+				if (!rz_buf_read_ble16_offset(bin->buf, &offset, &tmp, h->worder)) {
 					rz_bin_import_free(imp);
 					break;
 				}
 				ordinal = tmp;
-				offset += sizeof(ut16);
 			}
 			imp->name = rz_str_newf("%s.%u", mod_name, ordinal);
 			imp->ordinal = ordinal;
@@ -611,23 +613,21 @@ RzList *rz_bin_le_get_relocs(rz_bin_le_obj_t *bin) {
 			}
 			ut32 nameoff;
 			if (header.target & F_TARGET_OFF32) {
-				if (!rz_buf_read_ble32_at(bin->buf, offset, &nameoff, h->worder)) {
+				if (!rz_buf_read_ble32_offset(bin->buf, &offset, &nameoff, h->worder)) {
 					rz_bin_import_free(imp);
 					break;
 				}
-				offset += sizeof(ut32);
 			} else {
 				ut16 tmp;
-				if (!rz_buf_read_ble16_at(bin->buf, offset, &tmp, h->worder)) {
+				if (!rz_buf_read_ble16_offset(bin->buf, &offset, &tmp, h->worder)) {
 					rz_bin_import_free(imp);
 					break;
 				}
 				nameoff = tmp;
-				offset += sizeof(ut16);
 			}
 			ut64 off = (ut64)h->impproc + nameoff + bin->headerOff;
-			char *proc_name = __read_nonnull_str_at(bin->buf, &off);
-			char *mod_name = __get_modname_by_ord(bin, ordinal);
+			char *proc_name = le_read_nonnull_str_at(bin->buf, &off);
+			char *mod_name = le_get_modname_by_ord(bin, ordinal);
 			imp->name = rz_str_newf("%s.%s", mod_name ? mod_name : "", proc_name ? proc_name : "");
 			rel->import = imp;
 			break;
@@ -639,19 +639,17 @@ RzList *rz_bin_le_get_relocs(rz_bin_le_obj_t *bin) {
 		if (header.target & F_TARGET_ADDITIVE) {
 			ut32 additive = 0;
 			if (header.target & F_TARGET_ADD32) {
-				if (!rz_buf_read_ble32_at(bin->buf, offset, &additive, h->worder)) {
+				if (!rz_buf_read_ble32_offset(bin->buf, &offset, &additive, h->worder)) {
 					rz_bin_reloc_free(rel);
 					break;
 				}
-				offset += sizeof(ut32);
 			} else {
 				ut16 tmp;
-				if (!rz_buf_read_ble16_at(bin->buf, offset, &tmp, h->worder)) {
+				if (!rz_buf_read_ble16_offset(bin->buf, &offset, &tmp, h->worder)) {
 					rz_bin_reloc_free(rel);
 					break;
 				}
 				additive = tmp;
-				offset += sizeof(ut16);
 			}
 			rel->addend += additive;
 		}
@@ -683,7 +681,7 @@ RzList *rz_bin_le_get_relocs(rz_bin_le_obj_t *bin) {
 
 		while (repeat) {
 			ut16 off;
-			if (!rz_buf_read_ble16_at(bin->buf, offset, &off, h->worder)) {
+			if (!rz_buf_read_ble16_offset(bin->buf, &offset, &off, h->worder)) {
 				break;
 			}
 			rel->vaddr = cur_page_offset + off;
@@ -691,7 +689,6 @@ RzList *rz_bin_le_get_relocs(rz_bin_le_obj_t *bin) {
 			RzBinReloc *new = RZ_NEW0(RzBinReloc);
 			*new = *rel;
 			rz_list_append(l, new);
-			offset += sizeof(ut16);
 			repeat--;
 		}
 		while (offset >= end) {
@@ -724,7 +721,58 @@ RzList *rz_bin_le_get_relocs(rz_bin_le_obj_t *bin) {
 	return l;
 }
 
-static bool __init_header(rz_bin_le_obj_t *bin, RzBuffer *buf) {
+static bool read_le_header_aux(rz_bin_le_obj_t *bin, RzBuffer *buf) {
+	if (!rz_buf_read_at(buf, bin->headerOff, (ut8 *)bin->header, 4)) {
+		return false;
+	}
+	ut64 offset = bin->headerOff + 4; /* skip magic, border, and worder */
+	return rz_buf_read_le32_offset(buf, &offset, &bin->header->level) &&
+		rz_buf_read_le16_offset(buf, &offset, &bin->header->cpu) &&
+		rz_buf_read_le16_offset(buf, &offset, &bin->header->os) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->ver) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->mflags) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->mpages) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->startobj) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->eip) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->stackobj) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->esp) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->pagesize) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->pageshift) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->fixupsize) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->fixupsum) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->ldrsize) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->ldrsum) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->objtab) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->objcnt) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->objmap) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->itermap) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->rsrctab) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->rsrccnt) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->restab) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->enttab) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->dirtab) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->dircnt) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->fpagetab) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->frectab) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->impmod) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->impmodcnt) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->impproc) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->pagesum) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->datapage) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->preload) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->nrestab) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->cbnrestab) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->nressum) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->autodata) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->debuginfo) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->debuglen) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->instpreload) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->instdemand) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->heapsize) &&
+		rz_buf_read_le32_offset(buf, &offset, &bin->header->stacksize);
+}
+
+static bool le_init_header(rz_bin_le_obj_t *bin, RzBuffer *buf) {
 	ut8 magic[2];
 	rz_buf_read_at(buf, 0, magic, sizeof(magic));
 	if (!memcmp(&magic, "MZ", 2)) {
@@ -737,13 +785,11 @@ static bool __init_header(rz_bin_le_obj_t *bin, RzBuffer *buf) {
 		bin->headerOff = 0;
 	}
 	bin->header = RZ_NEW0(LE_image_header);
-	if (bin->header) {
-		rz_buf_read_at(buf, bin->headerOff, (ut8 *)bin->header, sizeof(LE_image_header));
-	} else {
+	if (!bin->header) {
 		RZ_LOG_ERROR("Failed to allocate memory");
 		return false;
 	}
-	return true;
+	return read_le_header_aux(bin, buf);
 }
 
 void rz_bin_le_free(rz_bin_le_obj_t *bin) {
@@ -760,24 +806,32 @@ rz_bin_le_obj_t *rz_bin_le_new_buf(RzBuffer *buf) {
 		return NULL;
 	}
 
-	__init_header(bin, buf);
+	le_init_header(bin, buf);
 	LE_image_header *h = bin->header;
 	if (!memcmp("LE", h->magic, 2)) {
 		bin->is_le = true;
 	}
-	bin->type = __get_module_type(bin);
-	bin->cpu = __get_cpu_type(bin);
-	bin->os = __get_os_type(bin);
-	bin->arch = __get_arch(bin);
+	bin->type = le_get_module_type(bin);
+	bin->cpu = le_get_cpu_type(bin);
+	bin->os = le_get_os_type(bin);
+	bin->arch = le_get_arch(bin);
 	bin->objtbl = calloc(h->objcnt, sizeof(LE_object_entry));
 	if (!bin->objtbl) {
 		rz_bin_le_free(bin);
 		return NULL;
 	}
 	ut64 offset = (ut64)bin->headerOff + h->restab;
-	bin->filename = __read_nonnull_str_at(buf, &offset);
-	rz_buf_read_at(buf, (ut64)h->objtab + bin->headerOff, (ut8 *)bin->objtbl, h->objcnt * sizeof(LE_object_entry));
-
+	bin->filename = le_read_nonnull_str_at(buf, &offset);
+	offset = (ut64)bin->headerOff + h->objtab;
+	for (ut32 i = 0; i < h->objcnt; i++) {
+		LE_object_entry *le_obj_entry = bin->objtbl + i;
+		rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->virtual_size);
+		rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->reloc_base_addr);
+		rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->flags);
+		rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->page_tbl_idx);
+		rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->page_tbl_entries);
+		rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->reserved);
+	}
 	bin->buf = buf;
 	return bin;
 }

--- a/librz/bin/format/luac/v53/parse_53.c
+++ b/librz/bin/format/luac/v53/parse_53.c
@@ -13,20 +13,20 @@ static void lua_load_block(RzBuffer *buffer, void *dest, size_t size, ut64 offse
 }
 
 static ut64 lua_load_integer(RzBuffer *buffer, ut64 offset) {
-	ut64 x;
-	rz_buf_read_at(buffer, offset, (ut8 *)&x, sizeof(ut64));
+	ut64 x = 0;
+	rz_buf_read_le64_at(buffer, offset, &x);
 	return x;
 }
 
 static double lua_load_number(RzBuffer *buffer, ut64 offset) {
-	double x;
-	rz_buf_read_at(buffer, offset, (ut8 *)&x, sizeof(double));
+	double x = 0;
+	rz_buf_read_le64_at(buffer, offset, (ut64 *)&x);
 	return x;
 }
 
 static ut32 lua_load_int(RzBuffer *buffer, ut64 offset) {
-	ut32 x;
-	rz_buf_read_at(buffer, offset, (ut8 *)&x, sizeof(ut32));
+	ut32 x = 0;
+	rz_buf_read_le32_at(buffer, offset, &x);
 	return x;
 }
 

--- a/librz/bin/format/luac/v54/parse_54.c
+++ b/librz/bin/format/luac/v54/parse_54.c
@@ -12,14 +12,14 @@ static void lua_load_block(RzBuffer *buffer, void *dest, size_t size, ut64 offse
 }
 
 static ut64 lua_load_integer(RzBuffer *buffer, ut64 offset) {
-	ut64 x;
-	rz_buf_read_at(buffer, offset, (ut8 *)&x, sizeof(ut64));
+	ut64 x = 0;
+	rz_buf_read_le64_at(buffer, offset, &x);
 	return x;
 }
 
 static double lua_load_number(RzBuffer *buffer, ut64 offset) {
-	double x;
-	rz_buf_read_at(buffer, offset, (ut8 *)&x, sizeof(double));
+	double x = 0;
+	rz_buf_read_le64_at(buffer, offset, (ut64 *)&x);
 	return x;
 }
 

--- a/librz/bin/format/pyc/marshal.c
+++ b/librz/bin/format/pyc/marshal.c
@@ -38,8 +38,7 @@ static ut8 get_ut8(RzBuffer *buffer, bool *error) {
 static ut16 get_ut16(RzBuffer *buffer, bool *error) {
 	ut16 ret = 0;
 
-	int size = rz_buf_read(buffer, (ut8 *)&ret, sizeof(ret));
-	if (size != sizeof(ret)) {
+	if (!rz_buf_read_le16(buffer, &ret)) {
 		*error = true;
 	}
 	return ret;
@@ -47,8 +46,7 @@ static ut16 get_ut16(RzBuffer *buffer, bool *error) {
 
 static ut32 get_ut32(RzBuffer *buffer, bool *error) {
 	ut32 ret = 0;
-	int size = rz_buf_read(buffer, (ut8 *)&ret, sizeof(ret));
-	if (size != sizeof(ret)) {
+	if (!rz_buf_read_le32(buffer, &ret)) {
 		*error = true;
 	}
 	return ret;
@@ -56,8 +54,7 @@ static ut32 get_ut32(RzBuffer *buffer, bool *error) {
 
 static st32 get_st32(RzBuffer *buffer, bool *error) {
 	st32 ret = 0;
-	int size = rz_buf_read(buffer, (ut8 *)&ret, sizeof(ret));
-	if (size < sizeof(ret)) {
+	if (!rz_buf_read_le32(buffer, (ut32 *)&ret)) {
 		*error = true;
 	}
 	return ret;
@@ -65,8 +62,7 @@ static st32 get_st32(RzBuffer *buffer, bool *error) {
 
 static st64 get_st64(RzBuffer *buffer, bool *error) {
 	st64 ret = 0;
-	int size = rz_buf_read(buffer, (ut8 *)&ret, sizeof(ret));
-	if (size < sizeof(ret)) {
+	if (!rz_buf_read_le64(buffer, (ut64 *)&ret)) {
 		*error = true;
 	}
 	return ret;
@@ -74,8 +70,7 @@ static st64 get_st64(RzBuffer *buffer, bool *error) {
 
 static double get_float64(RzBuffer *buffer, bool *error) {
 	double ret = 0;
-	int size = rz_buf_read(buffer, (ut8 *)&ret, sizeof(ret));
-	if (size < sizeof(ret)) {
+	if (!rz_buf_read_le64(buffer, (ut64 *)&ret)) {
 		*error = true;
 	}
 	return ret;


### PR DESCRIPTION
# DO NOT SQUASH!

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Reading file header or body information using proper functions or macroses instead of the direct memory copy.

**Test plan**

Travis CI System Z worker a bit happier than before.


|           |  OK   | XX  |
|--------|-------|-----|
| Before | 14489 | 790 |
| After  | 14516 | 763 |


**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/297