### PR TITLE
[dalvik] handle move-exception after gotos/returns and mid op jumps

### DIFF
--- a/librz/analysis/fcn.c
+++ b/librz/analysis/fcn.c
@@ -19,8 +19,6 @@
 // 16 KB is the maximum size for a basic block
 #define MAX_FLG_NAME_SIZE 64
 
-#define FIX_JMP_FWD 0
-
 // 64KB max size
 // 256KB max function size
 #define MAX_FCN_SIZE (1024 * 256)
@@ -367,14 +365,15 @@ static RzAnalysisBlock *bbget(RzAnalysis *analysis, ut64 addr, bool jumpmid) {
 	RzAnalysisBlock *ret = NULL;
 	rz_list_foreach (intersecting, iter, bb) {
 		ut64 eaddr = bb->addr + bb->size;
-		if (((bb->addr >= eaddr && addr == bb->addr) || rz_analysis_block_contains(bb, addr)) && (!jumpmid || rz_analysis_block_op_starts_at(bb, addr))) {
+		if (((bb->addr >= eaddr && addr == bb->addr) ||
+			    rz_analysis_block_contains(bb, addr)) &&
+			(!jumpmid || rz_analysis_block_op_starts_at(bb, addr))) {
 			if (analysis->opt.delay) {
 				ut8 *buf = malloc(bb->size);
 				if (analysis->iob.read_at(analysis->iob.io, bb->addr, buf, bb->size)) {
 					const int last_instr_idx = bb->ninstr - 1;
 					bool in_delay_slot = false;
-					int i;
-					for (i = last_instr_idx; i >= 0; i--) {
+					for (int i = last_instr_idx; i >= 0; i--) {
 						const ut64 off = rz_analysis_block_get_op_offset(bb, i);
 						const ut64 at = bb->addr + off;
 						if (addr <= at || off >= bb->size) {
@@ -588,13 +587,18 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 	} delay = {
 		0
 	};
-	bool arch_destroys_dst = does_arch_destroys_dst(analysis->cur->arch);
-	bool is_arm = analysis->cur->arch && !strncmp(analysis->cur->arch, "arm", 3);
 	char tmp_buf[MAX_FLG_NAME_SIZE + 5] = "skip";
-	bool is_x86 = is_arm ? false : analysis->cur->arch && !strncmp(analysis->cur->arch, "x86", 3);
-	bool is_amd64 = is_x86 ? fcn->cc && !strcmp(fcn->cc, "amd64") : false;
-	bool is_dalvik = is_x86 ? false : analysis->cur->arch && !strncmp(analysis->cur->arch, "dalvik", 6);
-	bool is_hexagon = is_x86 ? false : analysis->cur->arch && !strncmp(analysis->cur->arch, "hexagon", 7);
+	bool arch_destroys_dst = does_arch_destroys_dst(analysis->cur->arch);
+	bool is_arm = false, is_x86 = false, is_amd64 = false, is_dalvik = false, is_hexagon = false;
+	if (analysis->cur->arch) {
+		is_arm = !strncmp(analysis->cur->arch, "arm", 3);
+		is_x86 = !strncmp(analysis->cur->arch, "x86", 3);
+		is_dalvik = !strncmp(analysis->cur->arch, "dalvik", 6);
+		is_hexagon = !strncmp(analysis->cur->arch, "hexagon", 7);
+	}
+	is_amd64 = is_x86 ? fcn->cc && !strcmp(fcn->cc, "amd64") : false;
+	bool can_jmpmid = analysis->opt.jmpmid && (is_dalvik || is_x86);
+
 	RzRegItem *variadic_reg = NULL;
 	if (is_amd64) {
 		variadic_reg = rz_reg_get(analysis->reg, "rax", RZ_REG_TYPE_GPR);
@@ -623,7 +627,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 	}
 
 	if (!bb) {
-		RzAnalysisBlock *existing_bb = bbget(analysis, addr, analysis->opt.jmpmid && is_x86);
+		RzAnalysisBlock *existing_bb = bbget(analysis, addr, can_jmpmid);
 		if (existing_bb) {
 			bool existing_in_fcn = rz_list_contains(existing_bb->fcns, fcn);
 			existing_bb = rz_analysis_block_split(existing_bb, addr);
@@ -730,6 +734,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 			// RET_END causes infinite loops somehow
 			gotoBeach(RZ_ANALYSIS_RET_END);
 		}
+
 		const char *bp_reg = analysis->reg->name[RZ_REG_NAME_BP];
 		const char *sp_reg = analysis->reg->name[RZ_REG_NAME_SP];
 		bool has_stack_regs = bp_reg && sp_reg;
@@ -756,14 +761,15 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 				}
 			}
 		}
+
 		if (op.hint.new_bits) {
 			rz_analysis_hint_set_bits(analysis, op.jump, op.hint.new_bits);
 		}
 		if (idx > 0 && !overlapped) {
-			bbg = bbget(analysis, at, analysis->opt.jmpmid && is_x86);
+			bbg = bbget(analysis, at, can_jmpmid);
 			if (bbg && bbg != bb) {
 				bb->jump = at;
-				if (analysis->opt.jmpmid && is_x86) {
+				if (can_jmpmid) {
 					// This happens when we purposefully walked over another block and overlapped it
 					// and now we hit an offset where the instructions match again.
 					// So we need to split the overwalked block.
@@ -1087,17 +1093,11 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 					gotoBeach(RZ_ANALYSIS_RET_END);
 				}
 			}
-#if FIX_JMP_FWD
-			bb->jump = op.jump;
-			bb->fail = UT64_MAX;
-			FITFCNSZ();
-			gotoBeach(RZ_ANALYSIS_RET_END);
-#else
 			if (!overlapped) {
 				set_bb_branches(bb, op.jump, UT64_MAX);
 			}
 			rz_analysis_task_item_new(analysis, tasks, fcn, NULL, op.jump);
-			if (continue_after_jump && is_hexagon) {
+			if (continue_after_jump && (is_hexagon || (is_dalvik && op.cond == RZ_TYPE_COND_EXCEPTION))) {
 				rz_analysis_task_item_new(analysis, tasks, fcn, NULL, op.addr + op.size);
 				gotoBeach(RZ_ANALYSIS_RET_BRANCH);
 			}
@@ -1117,7 +1117,6 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 				}
 			}
 			goto beach;
-#endif
 			break;
 		case RZ_ANALYSIS_OP_TYPE_SUB:
 			if (op.val != UT64_MAX && op.val > 0 && op.val < analysis->opt.jmptbl_maxcount) {
@@ -1223,7 +1222,9 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 			// without which the analysis is really slow,
 			// presumably because each opcode would get revisited
 			// (and already covered by a bb) many times
-			goto beach;
+			if (!is_dalvik) {
+				goto beach;
+			}
 			// For some reason, branch delayed code (MIPS) needs to continue
 			break;
 		case RZ_ANALYSIS_OP_TYPE_UCALL:
@@ -1604,6 +1605,12 @@ RZ_API void rz_analysis_del_jmprefs(RzAnalysis *analysis, RzAnalysisFunction *fc
 
 /* Does NOT invalidate read-ahead cache. */
 RZ_API int rz_analysis_fcn(RzAnalysis *analysis, RzAnalysisFunction *fcn, ut64 addr, ut64 len, int reftype) {
+	bool can_jmpmid = false;
+	if (analysis->cur->arch) {
+		bool is_x86 = !strncmp(analysis->cur->arch, "x86", 3);
+		bool is_dalvik = !strncmp(analysis->cur->arch, "dalvik", 6);
+		can_jmpmid = analysis->opt.jmpmid && (is_dalvik || is_x86);
+	}
 	RzPVector *metas = rz_meta_get_all_in(analysis, addr, RZ_META_TYPE_ANY);
 	void **it;
 	rz_pvector_foreach (metas, it) {
@@ -1654,14 +1661,13 @@ RZ_API int rz_analysis_fcn(RzAnalysis *analysis, RzAnalysisFunction *fcn, ut64 a
 		RzListIter *iter;
 		RzAnalysisBlock *bb;
 		ut64 endaddr = fcn->addr;
-		const bool is_x86 = analysis->cur->arch && !strcmp(analysis->cur->arch, "x86");
 
 		// set function size as length of continuous sequence of bbs
 		rz_list_sort(fcn->bbs, &cmpaddr);
 		rz_list_foreach (fcn->bbs, iter, bb) {
 			if (endaddr == bb->addr) {
 				endaddr += bb->size;
-			} else if ((endaddr < bb->addr && bb->addr - endaddr < BB_ALIGN) || (analysis->opt.jmpmid && is_x86 && endaddr > bb->addr && bb->addr + bb->size > endaddr)) {
+			} else if ((endaddr < bb->addr && bb->addr - endaddr < BB_ALIGN) || (can_jmpmid && endaddr > bb->addr && bb->addr + bb->size > endaddr)) {
 				endaddr = bb->addr + bb->size;
 			} else {
 				break;
@@ -2065,11 +2071,16 @@ RZ_API RzAnalysisBlock *rz_analysis_fcn_bbget_in(const RzAnalysis *analysis, RzA
 	if (addr == UT64_MAX) {
 		return NULL;
 	}
-	const bool is_x86 = analysis->cur->arch && !strcmp(analysis->cur->arch, "x86");
+	bool can_jmpmid = false;
+	if (analysis->cur->arch) {
+		bool is_x86 = !strncmp(analysis->cur->arch, "x86", 3);
+		bool is_dalvik = !strncmp(analysis->cur->arch, "dalvik", 6);
+		can_jmpmid = analysis->opt.jmpmid && (is_dalvik || is_x86);
+	}
 	RzListIter *iter;
 	RzAnalysisBlock *bb;
 	rz_list_foreach (fcn->bbs, iter, bb) {
-		if (addr >= bb->addr && addr < (bb->addr + bb->size) && (!analysis->opt.jmpmid || !is_x86 || rz_analysis_block_op_starts_at(bb, addr))) {
+		if (addr >= bb->addr && addr < (bb->addr + bb->size) && (!can_jmpmid || rz_analysis_block_op_starts_at(bb, addr))) {
 			return bb;
 		}
 	}

--- a/librz/analysis/p/analysis_dalvik.c
+++ b/librz/analysis/p/analysis_dalvik.c
@@ -400,7 +400,6 @@ static int dalvik_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut
 	case 0xf1: // return-void-barrier
 		op->type = RZ_ANALYSIS_OP_TYPE_RET;
 		op->eob = true;
-		// TODO: handle return if(0x0e) {} else {}
 		if (mask & RZ_ANALYSIS_OP_MASK_ESIL) {
 			if (data[0] == 0x0e) { // return-void
 				esilprintf(op, "sp,[8],ip,=,8,sp,+=");
@@ -411,9 +410,8 @@ static int dalvik_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut
 		}
 		break;
 	case 0x28: // goto
-		op->jump = addr + ((char)data[1]) * 2;
+		op->jump = addr + (((short)(char)data[1]) * 2);
 		op->type = RZ_ANALYSIS_OP_TYPE_JMP;
-		op->eob = true;
 		if (mask & RZ_ANALYSIS_OP_MASK_ESIL) {
 			esilprintf(op, "0x%" PFMT64x ",ip,=", op->jump);
 		}
@@ -422,7 +420,6 @@ static int dalvik_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut
 		if (len > 3) {
 			op->jump = addr + (short)(data[2] | data[3] << 8) * 2;
 			op->type = RZ_ANALYSIS_OP_TYPE_JMP;
-			op->eob = true;
 			if (mask & RZ_ANALYSIS_OP_MASK_ESIL) {
 				esilprintf(op, "0x%" PFMT64x ",ip,=", op->jump);
 			}
@@ -433,7 +430,6 @@ static int dalvik_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut
 			st64 dst = (st64)(data[2] | (data[3] << 8) | (data[4] << 16) | ((ut32)data[5] << 24));
 			op->jump = addr + (dst * 2);
 			op->type = RZ_ANALYSIS_OP_TYPE_JMP;
-			op->eob = true;
 			if (mask & RZ_ANALYSIS_OP_MASK_ESIL) {
 				esilprintf(op, "0x%" PFMT64x ",ip,=", op->jump);
 			}
@@ -468,11 +464,9 @@ static int dalvik_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut
 	case 0x36: // if-gt
 	case 0x37: // if-le
 		op->type = RZ_ANALYSIS_OP_TYPE_CJMP;
-		// XXX fix this better the check is to avoid an oob
-		if (len > 2) {
-			op->jump = addr + (len > 3 ? (short)(data[2] | data[3] << 8) * 2 : 0);
+		if (len > 3) {
+			op->jump = addr + ((short)(data[2] | data[3] << 8) * 2);
 			op->fail = addr + sz;
-			op->eob = true;
 			if (mask & RZ_ANALYSIS_OP_MASK_ESIL) {
 				ut32 vA = data[1];
 				ut32 vB = data[2];
@@ -488,11 +482,9 @@ static int dalvik_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut
 	case 0x3c: // if-gtz
 	case 0x3d: // if-lez
 		op->type = RZ_ANALYSIS_OP_TYPE_CJMP;
-		// XXX fix this better the check is to avoid an oob
-		if (len > 2) {
-			op->jump = addr + (len > 3 ? (short)(data[2] | data[3] << 8) * 2 : 0);
+		if (len > 3) {
+			op->jump = addr + ((short)(data[2] | data[3] << 8) * 2);
 			op->fail = addr + sz;
-			op->eob = true;
 			if (mask & RZ_ANALYSIS_OP_MASK_ESIL) {
 				ut32 vA = data[1];
 				const char *cond = getCondz(data[0]);
@@ -695,6 +687,15 @@ static int dalvik_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut
 		op->type = RZ_ANALYSIS_OP_TYPE_SHL;
 		break;
 	}
+
+	if ((op->type == RZ_ANALYSIS_OP_TYPE_JMP || op->type == RZ_ANALYSIS_OP_TYPE_RET) &&
+		len > op->size && data[op->size] == 0x0d) {
+		// if the return/goto is followed by a move-exception then the analysis should keep going.
+		// this is because the function is supposed to have a try-catch
+		op->eob = false;
+		op->cond = RZ_TYPE_COND_EXCEPTION;
+	}
+
 	return sz;
 }
 

--- a/librz/analysis/p/analysis_dalvik.c
+++ b/librz/analysis/p/analysis_dalvik.c
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2021-2022 deroad <wargio@libero.it>
 // SPDX-FileCopyrightText: 2010-2019 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
@@ -410,15 +411,19 @@ static int dalvik_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut
 		}
 		break;
 	case 0x28: // goto
-		op->jump = addr + (((short)(char)data[1]) * 2);
-		op->type = RZ_ANALYSIS_OP_TYPE_JMP;
-		if (mask & RZ_ANALYSIS_OP_MASK_ESIL) {
-			esilprintf(op, "0x%" PFMT64x ",ip,=", op->jump);
+		if (len > 1) {
+			st32 rel = (signed char)data[1];
+			op->jump = addr + (rel * 2);
+			op->type = RZ_ANALYSIS_OP_TYPE_JMP;
+			if (mask & RZ_ANALYSIS_OP_MASK_ESIL) {
+				esilprintf(op, "0x%" PFMT64x ",ip,=", op->jump);
+			}
 		}
 		break;
 	case 0x29: // goto/16
 		if (len > 3) {
-			op->jump = addr + (short)(data[2] | data[3] << 8) * 2;
+			st32 rel = (short)(data[3] << 8 | data[2]);
+			op->jump = addr + (rel * 2);
 			op->type = RZ_ANALYSIS_OP_TYPE_JMP;
 			if (mask & RZ_ANALYSIS_OP_MASK_ESIL) {
 				esilprintf(op, "0x%" PFMT64x ",ip,=", op->jump);
@@ -427,8 +432,8 @@ static int dalvik_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut
 		break;
 	case 0x2a: // goto/32
 		if (len > 5) {
-			st64 dst = (st64)(data[2] | (data[3] << 8) | (data[4] << 16) | ((ut32)data[5] << 24));
-			op->jump = addr + (dst * 2);
+			st32 rel = (st32)(data[2] | (data[3] << 8) | (data[4] << 16) | (data[5] << 24));
+			op->jump = addr + (rel * 2);
 			op->type = RZ_ANALYSIS_OP_TYPE_JMP;
 			if (mask & RZ_ANALYSIS_OP_MASK_ESIL) {
 				esilprintf(op, "0x%" PFMT64x ",ip,=", op->jump);
@@ -465,7 +470,8 @@ static int dalvik_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut
 	case 0x37: // if-le
 		op->type = RZ_ANALYSIS_OP_TYPE_CJMP;
 		if (len > 3) {
-			op->jump = addr + ((short)(data[2] | data[3] << 8) * 2);
+			int rel = (int)(data[3] << 8 | data[2]);
+			op->jump = addr + (rel * 2);
 			op->fail = addr + sz;
 			if (mask & RZ_ANALYSIS_OP_MASK_ESIL) {
 				ut32 vA = data[1];
@@ -483,7 +489,8 @@ static int dalvik_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut
 	case 0x3d: // if-lez
 		op->type = RZ_ANALYSIS_OP_TYPE_CJMP;
 		if (len > 3) {
-			op->jump = addr + ((short)(data[2] | data[3] << 8) * 2);
+			int rel = (int)(data[3] << 8 | data[2]);
+			op->jump = addr + (rel * 2);
 			op->fail = addr + sz;
 			if (mask & RZ_ANALYSIS_OP_MASK_ESIL) {
 				ut32 vA = data[1];

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -5196,7 +5196,7 @@ static void xrefs_graph(RzCore *core, ut64 addr, int level, HtUU *ht, RzOutputMo
 	RzList *xrefs = rz_analysis_xrefs_get_to(core->analysis, addr);
 	bool open_object = false;
 	if (!rz_list_empty(xrefs)) {
-		RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(core->analysis, addr, -1);
+		RzAnalysisFunction *fcn = rz_analysis_get_fcn_in_bounds(core->analysis, addr, -1);
 		if (fcn) {
 			if (is_rz) {
 				rz_cons_printf("agn 0x%08" PFMT64x " %s\n", fcn->addr, fcn->name);
@@ -5224,7 +5224,7 @@ static void xrefs_graph(RzCore *core, ut64 addr, int level, HtUU *ht, RzOutputMo
 		}
 	}
 	rz_list_foreach (xrefs, iter, xref) {
-		RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(core->analysis, xref->from, -1);
+		RzAnalysisFunction *fcn = rz_analysis_get_fcn_in_bounds(core->analysis, xref->from, -1);
 		if (fcn) {
 			if (is_rz) {
 				rz_cons_printf("agn 0x%08" PFMT64x " %s\n", fcn->addr, fcn->name);

--- a/librz/include/rz_type.h
+++ b/librz/include/rz_type.h
@@ -200,6 +200,7 @@ typedef enum {
 	RZ_TYPE_COND_HEX_SCL_FALSE, // Hexagon only: Scalar instruction if(!Pu)
 	RZ_TYPE_COND_HEX_VEC_TRUE, // Hexagon only: Vector instruction if(Pu)
 	RZ_TYPE_COND_HEX_VEC_FALSE, // Hexagon only: Vector instruction if(!Pu)
+	RZ_TYPE_COND_EXCEPTION, // when the jump is taken only during an exception
 } RzTypeCond;
 
 /**

--- a/librz/type/helpers.c
+++ b/librz/type/helpers.c
@@ -490,6 +490,7 @@ RZ_API RZ_BORROW const char *rz_type_cond_tostring(RzTypeCond cc) {
 	case RZ_TYPE_COND_HEX_SCL_FALSE: return "scl-f";
 	case RZ_TYPE_COND_HEX_VEC_TRUE: return "vec-t";
 	case RZ_TYPE_COND_HEX_VEC_FALSE: return "vec-f";
+	case RZ_TYPE_COND_EXCEPTION: return "excptn";
 	}
 	return "??";
 }

--- a/test/db/analysis/dalvik
+++ b/test/db/analysis/dalvik
@@ -108,3 +108,90 @@ sp = 0x00000000
 bp = 0x00000000
 EOF
 RUN
+
+NAME=Resolve also exception paths found after gotos/returns
+FILE=apk://bins/dex/ade8bef0ac29fa363fc9afd958af0074478aef650adeb0318517b48bd996d5d5.apk
+CMDS=<<EOF
+aaa
+axg @ 0x800000021c
+EOF
+EXPECT=<<EOF
+- 0x800000021c fcn 0x800000021c sym.Landroid_telephony_TelephonyManager_.getDeviceId__Ljava_lang_String
+  - 0x100018936 fcn 0x1000186b0 method.public.static.Lcom_network_android_SmsReceiver_.a_Lorg_xmlpull_v1_XmlSerializer_Ljava_io_StringWriter_Landroid_content_Context__V
+  - 0x1000186b0 fcn 0x1000186b0 method.public.static.Lcom_network_android_SmsReceiver_.a_Lorg_xmlpull_v1_XmlSerializer_Ljava_io_StringWriter_Landroid_content_Context__V
+    - 0x100025f78 fcn 0x100025f70 method.private.static.Lcom_network_android_g_.a_Landroid_content_Context__B_BLjava_io_StringWriter_Ljava_lang_String_Ljava_util_Vector__V
+    - 0x100025f70 fcn 0x100025f70 method.private.static.Lcom_network_android_g_.a_Landroid_content_Context__B_BLjava_io_StringWriter_Ljava_lang_String_Ljava_util_Vector__V
+      - 0x10002666c fcn 0x10002653c method.public.static.Lcom_network_android_g_.a_Ljava_lang_String_Ljava_lang_String_Lcom_network_android_x__Ljava_lang_String___BLandroid_content_Context__B_V
+      - 0x10002653c fcn 0x10002653c method.public.static.Lcom_network_android_g_.a_Ljava_lang_String_Ljava_lang_String_Lcom_network_android_x__Ljava_lang_String___BLandroid_content_Context__B_V
+        - 0x100019cac fcn 0x100019c60 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context_I_V
+        - 0x100019c60 fcn 0x100019c60 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context_I_V
+          - 0x100019d1c fcn 0x100019c60 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context_I_V
+          - 0x100019e00 fcn 0x100019c60 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context_I_V
+          - 0x10001c7a0 fcn 0x10001c6f0 method.public.final.Lcom_network_android_a_j_.run__V
+        - 0x10001ac02 fcn 0x10001abb8 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context__BZZ_V
+        - 0x10001abb8 fcn 0x10001abb8 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context__BZZ_V
+          - 0x10001ab9e fcn 0x10001ab9c method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context__B_V
+          - 0x10001ab9c fcn 0x10001ab9c method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context__B_V
+            - 0x100027fe2 fcn 0x100027fb4 method.public.static.Lcom_network_android_j_.a_Landroid_content_Context_ZZS_Z
+            - 0x100027fb4 fcn 0x100027fb4 method.public.static.Lcom_network_android_j_.a_Landroid_content_Context_ZZS_Z
+              - 0x100027e8e fcn 0x100027df0 method.public.static.Lcom_network_android_j_.a_Landroid_content_Context_ZZ_Z
+              - 0x100027df0 fcn 0x100027df0 method.public.static.Lcom_network_android_j_.a_Landroid_content_Context_ZZ_Z
+                - 0x10001c948 fcn 0x10001c918 method.public.final.Lcom_network_android_a_l_.run__V
+                - 0x10001c918 fcn 0x10001c918 method.public.final.Lcom_network_android_a_l_.run__V
+                  - 0x10000ed93 ???
+                - 0x10001dcd4 fcn 0x10001dcb0 method.public.static.Lcom_network_android_agent_NetworkApp_.b_Landroid_content_Context__V
+                - 0x10001dcb0 fcn 0x10001dcb0 method.public.static.Lcom_network_android_agent_NetworkApp_.b_Landroid_content_Context__V
+                  - 0x10001dc44 fcn 0x10001daf4 method.static.synthetic.Lcom_network_android_agent_NetworkApp_.a_Lcom_network_android_agent_NetworkApp__V
+                  - 0x10001daf4 fcn 0x10001daf4 method.static.synthetic.Lcom_network_android_agent_NetworkApp_.a_Lcom_network_android_agent_NetworkApp__V
+                    - 0x10001e918 fcn 0x10001e914 method.public.final.Lcom_network_android_agent_c_.run__V
+                  - 0x10001ea30 fcn 0x10001ea2c method.public.final.Lcom_network_android_agent_e_.run__V
+                - 0x10001dd60 fcn 0x10001dcb0 method.public.static.Lcom_network_android_agent_NetworkApp_.b_Landroid_content_Context__V
+                - 0x10001ddb0 fcn 0x10001dcb0 method.public.static.Lcom_network_android_agent_NetworkApp_.b_Landroid_content_Context__V
+                - 0x10001ed72 fcn 0x10001eca0 method.protected.final.Lcom_network_android_android_monitor_AppServicePinger_.onHandleIntent_Landroid_content_Intent__V
+                - 0x1000285e2 fcn 0x1000285d4 method.public.static.Lcom_network_android_j_.c_Landroid_content_Context__Z
+                - 0x1000285d4 fcn 0x1000285d4 method.public.static.Lcom_network_android_j_.c_Landroid_content_Context__Z
+                  - 0x100028322 fcn 0x1000282fc method.public.static.Lcom_network_android_j_.b_Landroid_content_Context__V
+                  - 0x1000282fc fcn 0x1000282fc method.public.static.Lcom_network_android_j_.b_Landroid_content_Context__V
+                    - 0x100028812 fcn 0x1000287f4 method.public.final.Lcom_network_android_l_.run__V
+                  - 0x100028802 fcn 0x1000287f4 method.public.final.Lcom_network_android_l_.run__V
+                - 0x100045a44 fcn 0x100045a1c method.public.final.Lcom_network_h_k_.run__V
+              - 0x10002d7aa fcn 0x10002d714 method.protected.static.Lcom_network_android_monitor_observer_BatteryReceiver_.a_Landroid_content_Intent_Landroid_content_Context__V
+              - 0x10002d714 fcn 0x10002d714 method.protected.static.Lcom_network_android_monitor_observer_BatteryReceiver_.a_Landroid_content_Intent_Landroid_content_Context__V
+                - 0x10002d6f8 fcn 0x10002d6c4 method.public.static.Lcom_network_android_monitor_observer_BatteryReceiver_.a_Landroid_content_Context__Ljava_lang_String
+                - 0x10002d6c4 fcn 0x10002d6c4 method.public.static.Lcom_network_android_monitor_observer_BatteryReceiver_.a_Landroid_content_Context__Ljava_lang_String
+                  - 0x1000188ec fcn 0x1000186b0 method.public.static.Lcom_network_android_SmsReceiver_.a_Lorg_xmlpull_v1_XmlSerializer_Ljava_io_StringWriter_Landroid_content_Context__V
+                - 0x10002fc8c fcn 0x10002fc84 method.public.final.Lcom_network_android_monitor_observer_s_.run__V
+            - 0x10002811a fcn 0x100028064 method.public.static.Lcom_network_android_j_.a_Landroid_telephony_TelephonyManager_Landroid_content_Context_ZLandroid_net_ConnectivityManager__Z
+            - 0x100028064 fcn 0x100028064 method.public.static.Lcom_network_android_j_.a_Landroid_telephony_TelephonyManager_Landroid_content_Context_ZLandroid_net_ConnectivityManager__Z
+              - 0x10001eb52 fcn 0x10001eac4 method.public.final.Lcom_network_android_agent_g_.run__V
+              - 0x100027f7a fcn 0x100027df0 method.public.static.Lcom_network_android_j_.a_Landroid_content_Context_ZZ_Z
+          - 0x10001c09c fcn 0x10001c074 method.private.static.Lcom_network_android_a_c_.g_Landroid_content_Context__V
+          - 0x10001c074 fcn 0x10001c074 method.private.static.Lcom_network_android_a_c_.g_Landroid_content_Context__V
+            - 0x100019eae fcn 0x100019e34 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context_III_V
+            - 0x100019e34 fcn 0x100019e34 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context_III_V
+              - 0x10001c440 fcn 0x10001c404 method.public.final.Lcom_network_android_a_f_.run__V
+              - 0x10001c48a fcn 0x10001c404 method.public.final.Lcom_network_android_a_f_.run__V
+              - 0x10001ea86 fcn 0x10001ea68 method.public.final.Lcom_network_android_agent_f_.run__V
+            - 0x100019f70 fcn 0x100019ed8 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context_ILjava_lang_String__V
+            - 0x100019ed8 fcn 0x100019ed8 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context_ILjava_lang_String__V
+              - 0x10001c8d0 fcn 0x10001c7f8 method.public.final.Lcom_network_android_a_k_.onReceive_Landroid_content_Context_Landroid_content_Intent__V
+            - 0x10001a1a2 fcn 0x100019f98 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context_ILjava_lang_String_I_V
+            - 0x100019f98 fcn 0x100019f98 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context_ILjava_lang_String_I_V
+              - 0x100019d90 fcn 0x100019c60 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context_I_V
+              - 0x100019de0 fcn 0x100019c60 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context_I_V
+              - 0x10001b088 fcn 0x10001b084 method.public.static.Lcom_network_android_a_c_.b_Landroid_content_Context_I_V
+              - 0x10001b084 fcn 0x10001b084 method.public.static.Lcom_network_android_a_c_.b_Landroid_content_Context_I_V
+                - 0x10001c2e2 fcn 0x10001c1c8 method.public.final.Lcom_network_android_a_e_.run__V
+                - 0x10001c39e fcn 0x10001c1c8 method.public.final.Lcom_network_android_a_e_.run__V
+                - 0x10001c41c fcn 0x10001c404 method.public.final.Lcom_network_android_a_f_.run__V
+                - 0x10001c74c fcn 0x10001c6f0 method.public.final.Lcom_network_android_a_j_.run__V
+              - 0x10001bf4a fcn 0x10001befc method.public.static.Lcom_network_android_a_c_.e_Landroid_content_Context__V
+              - 0x10001befc fcn 0x10001befc method.public.static.Lcom_network_android_a_c_.e_Landroid_content_Context__V
+                - 0x10001c9f4 fcn 0x10001c9f0 method.public.final.Lcom_network_android_a_m_.run__V
+              - 0x10001c6ba fcn 0x10001c6ac method.public.final.Lcom_network_android_a_i_.run__V
+          - 0x10001c962 fcn 0x10001c918 method.public.final.Lcom_network_android_a_l_.run__V
+        - 0x10001c248 fcn 0x10001c1c8 method.public.final.Lcom_network_android_a_e_.run__V
+        - 0x100028408 fcn 0x1000282fc method.public.static.Lcom_network_android_j_.b_Landroid_content_Context__V
+  - 0x10001a24e fcn 0x100019f98 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context_ILjava_lang_String_I_V
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fix #2587 

The analysis was not performed correctly when an instruction was jumping in the middle of another instruction which lead to broken xrefs and missing basic blocks.

The test covers the analysis by checking where the xrefs even on the mid flags.