### PR TITLE
PowerPC relocs

### DIFF
--- a/librz/bin/format/elf/glibc_elf.h
+++ b/librz/bin/format/elf/glibc_elf.h
@@ -2497,7 +2497,7 @@ enum {
 /* PowerPC64 relocations defined by the ABIs */
 #define RZ_PPC64_NONE            RZ_PPC_NONE
 #define RZ_PPC64_ADDR32          RZ_PPC_ADDR32 /* 32bit absolute address */
-#define RZ_PPC64_ADDR24          RZ_PPC_ADDR24 /* 26bit address, word aligned */
+#define RZ_PPC64_ADDR24          RZ_PPC_ADDR24 /* 24bit address, word aligned */
 #define RZ_PPC64_ADDR16          RZ_PPC_ADDR16 /* 16bit absolute address */
 #define RZ_PPC64_ADDR16_LO       RZ_PPC_ADDR16_LO /* lower 16bits of address */
 #define RZ_PPC64_ADDR16_HI       RZ_PPC_ADDR16_HI /* high 16bits of address. */

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -6,6 +6,7 @@
 #include <rz_types.h>
 #include <rz_util.h>
 #include <rz_util/rz_buf.h>
+#include <rz_util/rz_assert.h>
 #include <rz_lib.h>
 #include <rz_bin.h>
 #include <rz_io.h>
@@ -911,6 +912,18 @@ static void patch_reloc(struct Elf_(rz_bin_elf_obj_t) * obj, RzBinElfReloc *rel,
 	case EM_PPC64: {
 		int low = 0, word = 0;
 		switch (rel->type) {
+		case RZ_PPC64_ADDR24:
+			low = 24;
+			val = (S + A) >> 2;
+			break;
+		case RZ_PPC64_ADDR16_HI:
+			word = 2;
+			val = (S + A) >> 16;
+			break;
+		case RZ_PPC64_ADDR16_HA:
+			word = 2;
+			val = (S + A + 0x8000) >> 16;
+			break;
 		case RZ_PPC64_REL16_HA:
 			word = 2;
 			val = (S + A - P + 0x8000) >> 16;
@@ -932,6 +945,7 @@ static void patch_reloc(struct Elf_(rz_bin_elf_obj_t) * obj, RzBinElfReloc *rel,
 			val = S + A - P;
 			break;
 		default:
+			RZ_LOG_WARN("Reloc type %d not implemented.\n", rel->type);
 			break;
 		}
 		if (low) {

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -928,6 +928,10 @@ static void patch_reloc(struct Elf_(rz_bin_elf_obj_t) * obj, RzBinElfReloc *rel,
 			word = 2;
 			val = (S + A - P + 0x8000) >> 16;
 			break;
+		case RZ_PPC64_ADDR16_LO:
+			word = 2;
+			val = (S + A) & 0xffff;
+			break;
 		case RZ_PPC64_REL16_LO:
 			word = 2;
 			val = (S + A - P) & 0xffff;
@@ -1232,6 +1236,8 @@ static RzBinReloc *reloc_convert(ELFOBJ *bin, RzBinElfReloc *rel, ut64 GOT) {
 		case RZ_PPC_REL32: ADD(32, -P);
 		case RZ_PPC_RELATIVE: ADD(32, -P);
 		case RZ_PPC_PLT32: ADD(32, -P);
+		case RZ_PPC_ADDR16: ADD(16, 0);
+		case RZ_PPC_ADDR32: ADD(32, 0);
 		default:
 			RZ_LOG_WARN("unimplemented ELF/PPC reloc type %d\n", rel->type);
 			break;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Adds the PPC64 relocations: `R_PPC64_ADDR24`, `R_PPC64_ADDR16_HA`, `R_PPC64_ADDR16_HI`, `R_PPC64_ADDR16_LO`, `R_PPC_ADDR32`, `R_PPC_ADDR16`

**Test plan**

Non here but https://github.com/rizinorg/rizin/pull/2497 and the test binary of https://github.com/rizinorg/rizin-testbins/pull/75 make use of them.

**Closing issues**

None
