### PR TITLE
Convert some of the `rz_core_cmd*()` calls to the proper C API calls.

### DIFF
--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -3502,7 +3502,7 @@ static int agraph_print(RzAGraph *g, int is_interactive, RzCore *core, RzAnalysi
 			mustFlush = true;
 		}
 		if (core && core->scr_gadgets) {
-			rz_core_cmd0(core, "pg");
+			rz_core_gadget_print(core);
 		}
 		if (mustFlush) {
 			rz_cons_flush();

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -217,7 +217,8 @@ RZ_IPI void rz_core_debug_single_step_over(RzCore *core) {
 			rz_core_dbg_follow_seek_register(core);
 			core->print->cur_enabled = 0;
 		} else {
-			rz_core_cmd(core, "dso", 0);
+			rz_core_debug_step_over(core, 1);
+			rz_core_dbg_follow_seek_register(core);
 			rz_core_reg_update_flags(core);
 		}
 	} else {

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -1978,14 +1978,22 @@ static bool do_analysis_search(RzCore *core, struct search_parameters *param, co
 					rz_cons_println(str);
 				}
 				break;
-			case 's': // "als"
-				rz_core_cmd0(core, "asl");
+			case 's': { // "/als"
+				RzListIter *iter;
+				RzSyscallItem *si;
+				RzList *list = rz_syscall_list(core->analysis->syscall);
+				rz_list_foreach (list, iter, si) {
+					rz_cons_printf("%s = 0x%02x.%s\n",
+						si->name, si->swi, syscallNumber(si->num));
+				}
+				rz_list_free(list);
 				break;
+			}
 			case 0:
 				rz_core_cmd0(core, "aoml");
 				break;
 			default:
-				eprintf("wat\n");
+				RZ_LOG_ERROR("/al%c - unknown command\n", type);
 				break;
 			}
 			return false;
@@ -2005,14 +2013,7 @@ static bool do_analysis_search(RzCore *core, struct search_parameters *param, co
 		input++;
 	}
 	if (type == 's') {
-		eprintf("Shouldn't reach\n");
-// ??
-#if 0
-	case 's': // "/s"
-		do_syscall_search (core, &param);
-		dosearch = false;
-		break;
-#endif
+		rz_warn_if_reached();
 		return true;
 	}
 	if (mode == 'j') {

--- a/librz/core/tui/panels.c
+++ b/librz/core/tui/panels.c
@@ -4792,25 +4792,11 @@ void __do_panels_refreshOneShot(RzCore *core) {
 }
 
 void __panel_single_step_in(RzCore *core) {
-	if (rz_config_get_b(core->config, "cfg.debug")) {
-		rz_core_debug_step_one(core, 1);
-		rz_core_reg_update_flags(core);
-	} else {
-		rz_core_esil_step(core, UT64_MAX, NULL, NULL, false);
-		rz_core_reg_update_flags(core);
-	}
+	rz_core_debug_single_step_in(core);
 }
 
 void __panel_single_step_over(RzCore *core) {
-	bool io_cache = rz_config_get_b(core->config, "io.cache");
-	rz_config_set_b(core->config, "io.cache", false);
-	if (rz_config_get_b(core->config, "cfg.debug")) {
-		rz_core_cmd(core, "dso", 0);
-		rz_core_reg_update_flags(core);
-	} else {
-		rz_core_analysis_esil_step_over(core);
-	}
-	rz_config_set_b(core->config, "io.cache", io_cache);
+	rz_core_debug_single_step_over(core);
 }
 
 void __panel_breakpoint(RzCore *core) {

--- a/librz/core/tui/vmenus.c
+++ b/librz/core/tui/vmenus.c
@@ -1674,9 +1674,8 @@ RZ_API int rz_core_visual_trackflags(RzCore *core) {
 			case 0: // new flag space
 				rz_cons_show_cursor(true);
 				rz_line_set_prompt("add flagspace: ");
-				strcpy(cmd, "fs ");
-				if (rz_cons_fgets(cmd + 3, sizeof(cmd) - 3, 0, NULL) > 0) {
-					rz_core_cmd(core, cmd, 0);
+				if (rz_cons_fgets(cmd, sizeof(cmd), 0, NULL) > 0) {
+					rz_flag_space_set(core->flags, cmd);
 					rz_cons_set_raw(1);
 					rz_cons_show_cursor(false);
 				}


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Convert some of the Rizin command calls using `rz_core_cmd()`, `rz_core_cmdf()`, and `rz_core_cmd0()` APIs to calling the respective **RZ_API** or **RZ_IPI** functions in the `librz/core/` files.

Before:
```sh
$ rg "rz_core_cmd[0f(]" librz/core/ | wc -l
312
```
After:
```sh
$ rg "rz_core_cmd[0f(]" librz/core/ | wc -l
306
```

**Test plan**

- CI is green
- **Stepping over** and **stepping in** still works in the Visual Panels mode.

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/383
Partially addresses https://github.com/rizinorg/rizin/issues/397