### PR TITLE
Golang string recovery on mips32/64, ppc64, riscv64 and sysz

### DIFF
--- a/librz/analysis/p/analysis_ppc_cs.c
+++ b/librz/analysis/p/analysis_ppc_cs.c
@@ -414,7 +414,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 	return strdup(p);
 }
 
-static int analop_vle(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len) {
+static int analop_vle(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask) {
 	vle_t *instr = NULL;
 	vle_handle handle = { 0 };
 	op->size = 2;
@@ -423,6 +423,9 @@ static int analop_vle(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 		op->type = instr->analysis_op;
 		// op->id = instr->type;
 
+		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
+			op->mnemonic = strdup(instr->name);
+		}
 		switch (op->type) {
 		case RZ_ANALYSIS_OP_TYPE_ILL:
 			break;
@@ -610,7 +613,7 @@ static int analop(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, in
 		if (!a->big_endian) {
 			return -1;
 		}
-		ret = analop_vle(a, op, addr, buf, len);
+		ret = analop_vle(a, op, addr, buf, len, mask);
 		if (ret >= 0) {
 			return op->size;
 		}
@@ -636,6 +639,9 @@ static int analop(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, in
 	if (n < 1) {
 		op->type = RZ_ANALYSIS_OP_TYPE_ILL;
 	} else {
+		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
+			op->mnemonic = strdup(insn->mnemonic);
+		}
 		if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
 			opex(&op->opex, handle, insn);
 		}
@@ -681,10 +687,13 @@ static int analop(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, in
 		case PPC_INS_MR:
 		case PPC_INS_LI:
 			op->type = RZ_ANALYSIS_OP_TYPE_MOV;
+			op->val = IMM(1);
 			esilprintf(op, "%s,%s,=", ARG(1), ARG(0));
 			break;
 		case PPC_INS_LIS:
 			op->type = RZ_ANALYSIS_OP_TYPE_MOV;
+			op->val = IMM(1);
+			op->val <<= 16;
 			esilprintf(op, "%s0000,%s,=", ARG(1), ARG(0));
 			break;
 		case PPC_INS_CLRLWI:
@@ -910,8 +919,10 @@ static int analop(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, in
 			op->type = RZ_ANALYSIS_OP_TYPE_SUB;
 			esilprintf(op, "%s,%s,-,%s,=", ARG(1), ARG(2), ARG(0));
 			break;
-		case PPC_INS_ADD:
 		case PPC_INS_ADDI:
+			op->val = ((st16)IMM(2));
+			// fallthrough
+		case PPC_INS_ADD:
 			op->sign = true;
 			op->type = RZ_ANALYSIS_OP_TYPE_ADD;
 			esilprintf(op, "%s,%s,+,%s,=", ARG(2), ARG(1), ARG(0));

--- a/librz/bin/golang.c
+++ b/librz/bin/golang.c
@@ -252,7 +252,7 @@ static void find_go_build_info(RzBinFile *bf, GoBuildInfo *go_info, RzBinSection
  *
  * \return  Returns a string on success, otherwise NULL
  */
-RZ_API RZ_OWN char *rz_bin_file_golang_compiler(RZ_NONNULL RzBinFile *bf) {
+RZ_IPI RZ_OWN char *rz_bin_file_golang_compiler(RZ_NONNULL RzBinFile *bf) {
 	rz_return_val_if_fail(bf && bf->o, NULL);
 
 	bool is_pe = false;

--- a/librz/bin/i/private.h
+++ b/librz/bin/i/private.h
@@ -20,6 +20,7 @@ RZ_IPI RzBinPlugin *rz_bin_get_binplugin_any(RzBin *bin);
 RZ_IPI RzBinXtrPlugin *rz_bin_get_xtrplugin_by_name(RzBin *bin, const char *name);
 RZ_IPI RzBinPlugin *rz_bin_get_binplugin_by_name(RzBin *bin, const char *name);
 RZ_IPI RzBinPlugin *rz_bin_get_binplugin_by_filename(RzBin *bin);
+RZ_IPI RZ_OWN char *rz_bin_file_golang_compiler(RZ_NONNULL RzBinFile *binfile);
 
 RZ_IPI void rz_bin_section_free(RzBinSection *bs);
 

--- a/librz/core/cmd/cmd_meta.c
+++ b/librz/core/cmd/cmd_meta.c
@@ -384,7 +384,7 @@ RZ_IPI RzCmdStatus rz_meta_data_handler(RzCore *core, int argc, const char **arg
 	ut64 size = rz_num_math(core->num, argv[1]);
 	ut64 repeat = argc > 2 ? rz_num_math(core->num, argv[2]) : 1;
 	if (size == 0 || repeat == 0) {
-		RZ_LOG_ERROR("Data size or repeat count cannot be zero");
+		RZ_LOG_ERROR("Data size or repeat count cannot be zero\n");
 		return RZ_CMD_STATUS_ERROR;
 	}
 	for (i = 0; i < repeat; i++, addr += size) {
@@ -413,7 +413,7 @@ RZ_IPI RzCmdStatus rz_meta_data_remove_handler(RzCore *core, int argc, const cha
 		ut64 size = rz_num_math(core->num, argv[1]);
 		ut64 repeat = argc > 2 ? rz_num_math(core->num, argv[2]) : 1;
 		if (size == 0 || repeat == 0) {
-			RZ_LOG_ERROR("Data size or repeat count cannot be zero");
+			RZ_LOG_ERROR("Data size or repeat count cannot be zero\n");
 			return RZ_CMD_STATUS_ERROR;
 		}
 		for (i = 0; i < repeat; i++, addr += size) {

--- a/librz/core/golang.c
+++ b/librz/core/golang.c
@@ -604,9 +604,6 @@ static bool go_is_sign_match(GoStrRecover *ctx, GoStrInfo *info, GoSignature *si
 	ut32 nlen = 0;
 	memset(info, 0, sizeof(GoStrInfo));
 
-	// if ((ctx->pc + nlen) >= 0x0009a008 && (ctx->pc + nlen) < 0x0009a018) {
-	//	eprintf("n_sigs: %lu\n", n_sigs);
-	// }
 	for (size_t i = 0; i < n_sigs; ++i) {
 		if (nlen >= ctx->size) {
 			return false;
@@ -627,15 +624,6 @@ static bool go_is_sign_match(GoStrRecover *ctx, GoStrInfo *info, GoSignature *si
 			copy[j] = copy[j] & sig->pasm->mask[j];
 		}
 
-		// if ((ctx->pc + nlen) >= 0x0009a008 && (ctx->pc + nlen) <= 0x0009a018) {
-		//	char *p0 = rz_hex_bin2strdup(sig->pasm->pattern, sig->pasm->size);
-		//	char *p1 = rz_hex_bin2strdup(copy, sig->pasm->size);
-		//	eprintf("0x%08" PFMT64x " pat = %s\n", ctx->pc + nlen, p0);
-		//	eprintf("0x%08" PFMT64x " cop = %s\n", ctx->pc + nlen, p1);
-		//	free(p1);
-		//	free(p0);
-		// }
-
 		// verify the masked input matches the pattern
 		if (memcmp(copy, sig->pasm->pattern, sig->pasm->size)) {
 			return false;
@@ -653,9 +641,7 @@ static bool go_is_sign_match(GoStrRecover *ctx, GoStrInfo *info, GoSignature *si
 
 		nlen += sig->pasm->size;
 	}
-	// if ((ctx->pc) >= 0x0009a008 && (ctx->pc) < 0x0009a018) {
-	//	eprintf("found 0x%08" PFMT64x "\n", ctx->pc);
-	// }
+
 	return true;
 }
 
@@ -1510,107 +1496,116 @@ static ut32 golang_recover_string_ppc64(GoStrRecover *ctx) {
 	return 4;
 }
 
-#define read_op_at_or_fail(aop, nbytes, label) \
-	if ((size - nlen) < 1 || rz_analysis_op(analysis, &aop, pc + nlen, bytes + nlen, size - nlen, opmask) < 1) { \
-		nlen = nbytes; \
-		goto label; \
+static bool decode_auipc_set_addr(RzCore *core, GoStrInfo *info, ut64 pc, const ut8 *buffer, const ut32 size) {
+	RzAnalysisOp aop;
+	rz_analysis_op_init(&aop);
+	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_DISASM) < 1) {
+		rz_analysis_op_fini(&aop);
+		return false;
 	}
+	info->addr = pc + aop.val;
+	rz_analysis_op_fini(&aop);
+	return true;
+}
 
-#define reset_and_read_op_at_or_fail(aop, nbytes, label) \
-	rz_analysis_op_fini(&aop); \
-	rz_analysis_op_init(&aop); \
-	read_op_at_or_fail(aop, nbytes, label)
-// Possible riscv64 signatures
-// -------
-// auipc gp, high_string_offset
-// addi  gp, gp, low_string_offset
-// sd    gp, 8(sp)
-// addiw gp, zero, string_size
-// -------
-// auipc gp, high_string_offset
-// addi  gp, gp, low_string_offset
-// sd    gp, 8(sp)
-// li    gp, zero, string_size
-// -------
-// auipc gp, high_string_offset
-// addi  gp, gp, low_string_offset
-// sd    gp, 8(sp)
+go_asm_pattern_define(riscv, 64, auipc, "\x17\x00\x00\x00", "\x7f\x00\x00\x00", true);
+go_asm_pattern_define(riscv, 64, addi, "\x13\x00\x00\x00", "\x7f\x00\x00\x00", false);
+go_asm_pattern_define(riscv, 64, addiw, "\x1b\x00\x00\x00", "\x7f\x70\x00\x00", false);
+go_asm_pattern_define(riscv, 64, li, "\x13\x00\x00\x00", "\x7f\x80\x0F\x00", false);
+go_asm_pattern_define(riscv, 64, any, "\x00\x00\x00\x00", "\x00\x00\x00\x00", false);
+
+static GoSignature go_riscv64_auipc_add_sd_addiw_signature[] = {
+	// auipc gp, high_string_offset
+	{ &go_asm_pattern_name(riscv, 64, auipc), &decode_auipc_set_addr },
+	// addi  gp, gp, low_string_offset
+	{ &go_asm_pattern_name(riscv, 64, addi), &decode_val_add_addr },
+	// sd    gp, 8(sp)
+	{ &go_asm_pattern_name(riscv, 64, any), NULL },
+	// addiw gp, zero, string_size
+	{ &go_asm_pattern_name(riscv, 64, addiw), &decode_val_set_size },
+};
+
+static GoSignature go_riscv64_auipc_add_sd_li_signature[] = {
+	// auipc gp, high_string_offset
+	{ &go_asm_pattern_name(riscv, 64, auipc), &decode_auipc_set_addr },
+	// addi  gp, gp, low_string_offset
+	{ &go_asm_pattern_name(riscv, 64, addi), &decode_val_add_addr },
+	// sd    gp, 8(sp)
+	{ &go_asm_pattern_name(riscv, 64, any), NULL },
+	// li    gp, zero, string_size
+	{ &go_asm_pattern_name(riscv, 64, li), &decode_val_set_size },
+};
+
+static GoSignature go_riscv64_li_sd_auipc_add_signature[] = {
+	// li    gp, zero, string_size
+	{ &go_asm_pattern_name(riscv, 64, li), &decode_val_set_size },
+	// sd    gp, 8(sp)
+	{ &go_asm_pattern_name(riscv, 64, any), NULL },
+	// auipc gp, high_string_offset
+	{ &go_asm_pattern_name(riscv, 64, auipc), &decode_auipc_set_addr },
+	// addi  gp, gp, low_string_offset
+	{ &go_asm_pattern_name(riscv, 64, addi), &decode_val_add_addr },
+};
+
+static GoSignature go_riscv64_addiw_sd_auipc_add_signature[] = {
+	// addiw gp, zero, string_size
+	{ &go_asm_pattern_name(riscv, 64, addiw), &decode_val_set_size },
+	// sd    gp, 8(sp)
+	{ &go_asm_pattern_name(riscv, 64, any), NULL },
+	// auipc gp, high_string_offset
+	{ &go_asm_pattern_name(riscv, 64, auipc), &decode_auipc_set_addr },
+	// addi  gp, gp, low_string_offset
+	{ &go_asm_pattern_name(riscv, 64, addi), &decode_val_add_addr },
+};
+
+static GoSignature go_riscv64_auipc_add_addiw_signature[] = {
+	// auipc gp, high_string_offset
+	{ &go_asm_pattern_name(riscv, 64, auipc), &decode_auipc_set_addr },
+	// addi  gp, gp, low_string_offset
+	{ &go_asm_pattern_name(riscv, 64, addi), &decode_val_add_addr },
+	// addiw gp, zero, string_size
+	{ &go_asm_pattern_name(riscv, 64, addiw), &decode_val_set_size },
+};
+
+static GoSignature go_riscv64_auipc_add_li_signature[] = {
+	// auipc gp, high_string_offset
+	{ &go_asm_pattern_name(riscv, 64, auipc), &decode_auipc_set_addr },
+	// addi  gp, gp, low_string_offset
+	{ &go_asm_pattern_name(riscv, 64, addi), &decode_val_add_addr },
+	// li    gp, zero, string_size
+	{ &go_asm_pattern_name(riscv, 64, li), &decode_val_set_size },
+};
+
+static GoSignature go_riscv64_table_signature[] = {
+	// auipc gp, high_string_offset
+	{ &go_asm_pattern_name(riscv, 64, auipc), &decode_auipc_set_addr },
+	// addi  gp, gp, low_string_offset
+	{ &go_asm_pattern_name(riscv, 64, addi), &decode_val_add_addr },
+	// sd    gp, 8(sp)
+	{ &go_asm_pattern_name(riscv, 64, any), &decode_from_table },
+};
+
 static ut32 golang_recover_string_riscv64(GoStrRecover *ctx) {
-	const ut32 opmask = RZ_ANALYSIS_OP_MASK_DISASM;
 	RzAnalysis *analysis = ctx->core->analysis;
-	ut8 *bytes = ctx->bytes;
-	ut32 size = ctx->size;
-	RzAnalysisOp aop0, aop1;
-	ut32 nlen = 0;
-	ut64 str_addr = 0, str_size = 0, pc = ctx->pc;
-	rz_analysis_op_init(&aop0);
-	rz_analysis_op_init(&aop1);
+	GoStrInfo info = { 0 };
 
-	read_op_at_or_fail(aop0, 0, end);
-	nlen += aop0.size;
-
-	// check if first op is AUIPC or LUI, otherwise skip
-	if (strncmp(aop0.mnemonic, "auipc", 5)) {
-		goto end;
-	} else { // AUIPC
-		str_addr = pc + (ut64)aop0.val;
-	}
-
-	read_op_at_or_fail(aop1, aop0.size, end);
-	nlen += aop1.size;
-
-	// check if second op is ADDI or JALR, otherwise skip
-	if (strncmp(aop1.mnemonic, "addi", 4)) {
-		nlen = aop0.size;
-		goto end;
-	} else { // ADDI
-		str_addr += (st64)aop1.val;
-	}
-
-	reset_and_read_op_at_or_fail(aop1, aop0.size, end);
-	nlen += aop1.size;
-
-	// check if third op is SD, otherwise skip
-	if (strncmp(aop1.mnemonic, "sd", 2)) {
-		nlen = aop0.size;
-		goto end;
-	}
-
-	reset_and_read_op_at_or_fail(aop1, aop0.size, end);
-	nlen += aop1.size;
-
-	// expect last op to be ADDIW or ADDI, otherwise skip
-	if (strcmp(aop1.mnemonic, "addiw") && strcmp(aop1.mnemonic, "addi")) {
-		ut8 tmp[16];
-		if (0 > rz_io_nread_at(ctx->core->io, str_addr, tmp, sizeof(tmp))) {
-			RZ_LOG_ERROR("Failed to read string value at address %" PFMT64x "\n", str_addr);
-			nlen = 0;
-			goto end;
-		}
-		str_addr = rz_read_ble64(tmp, analysis->big_endian);
-		str_size = rz_read_ble64(tmp + 8, analysis->big_endian);
-	} else { // ADDIW or ADDI
-		str_size = aop1.val;
-	}
-	nlen = aop0.size;
-
-	// check that the values are acceptable.
-	if (str_size < 2 || str_size > GO_MAX_STRING_SIZE || str_addr < 1 || str_addr == UT64_MAX) {
-		goto end;
+	if (!go_is_sign_match_autosize(ctx, &info, go_riscv64_auipc_add_sd_addiw_signature) &&
+		!go_is_sign_match_autosize(ctx, &info, go_riscv64_auipc_add_sd_li_signature) &&
+		!go_is_sign_match_autosize(ctx, &info, go_riscv64_li_sd_auipc_add_signature) &&
+		!go_is_sign_match_autosize(ctx, &info, go_riscv64_addiw_sd_auipc_add_signature) &&
+		!go_is_sign_match_autosize(ctx, &info, go_riscv64_auipc_add_addiw_signature) &&
+		!go_is_sign_match_autosize(ctx, &info, go_riscv64_auipc_add_li_signature) &&
+		!go_is_sign_match_autosize(ctx, &info, go_riscv64_table_signature)) {
+		return 4;
 	}
 
 	// try to recover the string.
-	if (!recover_string_at(ctx, str_addr, str_size)) {
-		goto end;
+	if (!recover_string_at(ctx, info.addr, info.size)) {
+		return 4;
 	}
 
-	// add xref
-	rz_analysis_xrefs_set(analysis, pc, str_addr, RZ_ANALYSIS_XREF_TYPE_STRING);
-
-end:
-	rz_analysis_op_fini(&aop0);
-	rz_analysis_op_fini(&aop1);
-	return nlen;
+	rz_analysis_xrefs_set(analysis, info.xref, info.addr, RZ_ANALYSIS_XREF_TYPE_STRING);
+	return 4;
 }
 
 /**

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -1007,7 +1007,6 @@ RZ_API RZ_OWN RzList *rz_bin_file_compute_hashes(RzBin *bin, RzBinFile *bf, ut64
 RZ_API RzList *rz_bin_file_set_hashes(RzBin *bin, RzList *new_hashes);
 RZ_API RzBinPlugin *rz_bin_file_cur_plugin(RzBinFile *binfile);
 RZ_API void rz_bin_file_hash_free(RzBinFileHash *fhash);
-RZ_API RZ_OWN char *rz_bin_file_golang_compiler(RZ_NONNULL RzBinFile *binfile);
 
 // binobject functions
 RZ_API int rz_bin_object_set_items(RzBinFile *binfile, RzBinObject *o);

--- a/librz/include/rz_util/rz_assert.h
+++ b/librz/include/rz_util/rz_assert.h
@@ -35,7 +35,7 @@ RZ_API void rz_assert_log(RzLogLevel level, const char *fmt, ...) RZ_PRINTF_CHEC
 #define rz_warn_if_fail(expr) \
 	do { \
 		if (!(expr)) { \
-			rz_assert_log(RZ_LOGLVL_WARN, "WARNING (%s:%d):%s%s runtime check failed: (%s)\n", \
+			rz_assert_log(RZ_LOGLVL_WARN, "(%s:%d):%s%s runtime check failed: (%s)\n", \
 				__FILE__, __LINE__, RZ_FUNCTION, RZ_FUNCTION[0] ? ":" : "", #expr); \
 		} \
 	} while (0)

--- a/test/db/analysis/golang
+++ b/test/db/analysis/golang
@@ -44,7 +44,7 @@ EXPECT=<<EOF
 ;-- str.flag:
 ;-- str.sort:
 ;-- str.sync:
-13208
+13207
 EOF
 RUN
 
@@ -410,5 +410,30 @@ EXPECT=<<EOF
 | 0x0009a308      lis   r8, 0xd ; 0xb8207 ; "  name:  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=,"
 | 0x0009a384      lis   r7, 0xd ; 0xb820e ; "  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=, goid=,"
 | 0x0009a3e0      lis   r8, 0xd ; 0xbd845 ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
+EOF
+RUN
+
+NAME=Parse Golang 1.18 riscv64 Strings
+FILE=bins/golang/go-re-sample-linux-riscv64
+CMDS=<<EOF
+aalg
+e asm.cmt.col=0
+pdr~"
+EOF
+EXPECT=<<EOF
+| 0x00099898      auipc t2, 0x1e ; 0xb7b60 ; "foogc gp in intmapnilobjpc=ptr\u00b5s\u03bcs <== at  fp= is  lr: of  on  pc= sp: sp=) = ) m=+Inf,r2=-Inf3125: p=AhomChamDashGOGC"
+| 0x00099910      auipc t0, 0x1e ; 0xb7f74 ; "enableerrno objectselectstringstructsweep sysmontimersuint16uint32uint64  name:  tail: (scan  (scan) MB in  Value> allocs dying="
+| 0x00099944      auipc t2, 0x1e ; 0xb7c70 ; "namepc  profra  roots + s0  s1  s10 s11 s2  s3  s4  s5  s6  s7  s8  s9  sbrksp  t0  t1  t2  t3  t4  t5  t6  tp  trueuint  -%s .."
+| 0x00099998      auipc t2, 0x1e ; 0xb7b57 ; "barendfinfoogc gp in intmapnilobjpc=ptr\u00b5s\u03bcs <== at  fp= is  lr: of  on  pc= sp: sp=) = ) m=+Inf,r2=-Inf3125: p=AhomCha"
+| 0x00099a10      auipc t0, 0x1e ; 0xb7dd8 ; "levelmheappanicscav schedsleepslicesudogsweeptracetrap:uint8valuewrite B ->  Value addr= alloc base  code= ctxt: curg= free  goi"
+| 0x00099a60      auipc t1, 0x3e ; 0xbd602 ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
+| 0x00099b4c      auipc t1, 0x3e ; 0xb99cd ; "subcommand 'bar'subcommand 'foo'time: bad [0-9]*workbuf is empty spinningthreads=, 0, {interval: {, p.searchAddr = 0123456789ABC"
+| 0x00099ba4      auipc t1, 0x3e ; 0xb81c2 ; "  level: bytes,  etypes  is not  maxpc=  mcount= minLC=  minutes nalloc= newval= nfreed= packed= pointer stack=[ status ) errno="
+| 0x00099c30      auipc s0, 0x3e ; 0xb7fc3 ; "  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=, goid=,"
+| 0x00099cf8      auipc t1, 0x3e ; 0xb99dd ; "subcommand 'foo'time: bad [0-9]*workbuf is empty spinningthreads=, 0, {interval: {, p.searchAddr = 0123456789ABCDEFX0123456789ab"
+| 0x00099d50      auipc t1, 0x3e ; 0xb83c2 ; "  enable: (forced) -> node= B exp.)  B work ( blocked= in use)\n lockedg= lockedm= m->curg= marked   method:  ms cpu,  not in [ "
+| 0x00099dd0      auipc t1, 0x3e ; 0xb7fbc ; "  name:  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=,"
+| 0x00099e64      auipc s0, 0x3e ; 0xb7fc3 ; "  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=, goid=,"
+| 0x00099edc      auipc t0, 0x3e ; 0xbd602 ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
 EOF
 RUN

--- a/test/db/analysis/golang
+++ b/test/db/analysis/golang
@@ -8,20 +8,16 @@ izq~?
 EOF
 EXPECT=<<EOF
 4759
-0x0063dfb2 str.
 0x0063dfdc str.server.crt
 0x0063e01e str.Reading_server_certificate:__s
 0x0063e1d1 str.https:__localhost:8000
 0x0063e20e str.Failed_get:__s
 0x0063e2e4 str.Failed_reading_response_body:__s
 0x0063e3af str.Got_response__d:__s__s
-0x0063e426 str.
-0x0063e48f str.
 0x0063e49b str.version
 0x0063e4ac str.HTTP_version
-0x0063e4e5 str.
-0x0063e616 str.
-14210
+0x0063e566 str.
+14145
 EOF
 RUN
 
@@ -43,11 +39,12 @@ EXPECT=<<EOF
 0x0066d9a3 str.Got_response__d:__s__s
 0x0066db8c str.version
 0x0066dbaa str.HTTP_version
+0x0066dc76 str.
 0x0066e68d str.Addr
 ;-- str.flag:
 ;-- str.sort:
 ;-- str.sync:
-13349
+13208
 EOF
 RUN
 
@@ -69,7 +66,8 @@ EXPECT=<<EOF
 0x0065dca5 str.Got_response__d:__s__s
 0x0065de6d str.version
 0x0065de8a str.HTTP_version
-13489
+0x0065dfe6 str.
+13360
 EOF
 RUN
 
@@ -119,7 +117,6 @@ EXPECT=<<EOF
 0x002738bc str.s
 0x00273a58 str.https
 0x00273b18 str.d._d._d
-0x00273b20 str.
 0x00273b50 str.beta
 0x00273c20 str.s__s
 0x00273d74 str.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz
@@ -131,10 +128,8 @@ EXPECT=<<EOF
 0x00273fb4 str.btcwallet
 0x0027401c str.btcctl.conf
 0x00274090 str.rpc.cert
-0x00274098 str.
 0x00274104 str.rpc.cert
-0x0027410c str.
-13586
+13466
 EOF
 RUN
 
@@ -148,15 +143,11 @@ izq~?
 EOF
 EXPECT=<<EOF
 5070
-0x0026acd0 str.
-0x0026ad08 str.
 0x0026b000 str.s_command:__v
 0x0026b04c str.1.0
-0x0026b29c str.
 0x0026b310 str.tls:_invalid_server_key_share
 0x0026b314 str.Failed_to_unmarshal_result:__v
 0x0026b444 str.Failed_to_format_result:__v
-0x0026b5a8 str.
 0x0026b5dc str.s_command:__v__code:__s
 0x0026b730 str.Failed_to_read_data_from_stdin:__v
 0x0026b884 str.Not_enough_lines_provided_on_stdin
@@ -165,12 +156,8 @@ EXPECT=<<EOF
 0x0026ba70 str.Unrecognized_command___s
 0x0026baa8 str.Specify__l_to_list_available_commands
 0x0026bb00 str.No_command_specified
-0x0026bb70 str.
-0x0026bb9c str.
 0x0026bc28 str.Chain_Server_Commands:DEBUG_HTTP2
 0x0026bc3c str.Wallet_Server_Commands____wallet_:
-0x0026be24 str.
-0x0026bee0 str.
 0x0026bf1c str.testnet3
 0x0026bf40 str.18334
 0x0026c030 str.simnet
@@ -179,14 +166,9 @@ EXPECT=<<EOF
 0x0026c084 str.18334
 0x0026c090 str.cannot_use__wallet_with__regtest__btcwallet_not_yet_compatible_with_regtest
 0x0026c100 str.8334
-0x0026c140 str.
-0x0026c250 str.
-0x0026c284 str.
 0x0026c2c8 str.localhost
 0x0026c2d0 str.localhost
-0x0026c34c str.
 0x0026c520 str.Use__s__h_to_show_options
-0x0026c564 str.
 0x0026c5f4 str.btcwallet.conf
 0x0026c688 str.Error_creating_a_default_config_file:__v
 0x0026c8ac str.testnet3
@@ -199,53 +181,28 @@ EXPECT=<<EOF
 0x0026cbd0 str.tls:_invalid_server_key_share
 0x0026cbd4 str.Error_parsing_config_file:__v
 0x0026ccb8 str.btcd.conf
-0x0026cd0c str.
 0x0026cd6c str.version
 0x0026cec4 str.The_special_parameter_____indicates_that_a_parameter_should_be_read_from_the_next_unread_line_from_standard_input.
-0x0026cfd0 str.
 0x0026d0a8 str.m___s_rpcuser_____s
 0x0026d0fc str.m___s_rpcpass_____s
 0x0026d150 str.m___s_notls__0_1___:_s
 0x0026d2e0 str.rpcuser__s_rpcpass__s
 0x0026d368 str.notls__s
-0x0026d550 str.
-0x0026d580 str.
-0x0026d5a0 str.
-0x0026d5b8 str.
-0x0026d6e0 str.
-0x0026d738 str.
-0x0026d7c0 str.
-0x0026d83c str.
-0x0026d8c0 str.
-0x0026d8e8 str.
 0x0026d900 str.http
 0x0026d908 str.https
 0x0026d90c str.http
 0x0026d928 str.:
-0x0026d968 str.
 0x0026d9c4 str.POST
 0x0026da28 str.Content_Type
-0x0026da5c str.
-0x0026da64 str.
 0x0026da70 str.application_json
-0x0026db04 str.
 0x0026dbe8 str.error_reading_json_reply:__v
-0x0026dc44 str.
-0x0026dca0 str.
-0x0026dcac str.
 0x0026dcec str.d__s
 0x0026dd70 str.s
-0x0026ddd0 str.
-0x0026de48 str.
-0x0026df20 str.
 0x0026df84 str.d._d._d
 0x0026dfc0 str.beta
 0x0026e0a0 str.s__s
-0x0026e180 str.
 0x0026e1dc str.profilealloc_called_without_a_P_or_outside_bootstrapping
 0x0026e1e0 str.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz
-0x0026e2a0 str.
-0x0026e350 str.
 0x0026e370 str.linux
 0x0026e384 str.btcd
 0x0026e3d0 str.linux
@@ -255,12 +212,7 @@ EXPECT=<<EOF
 0x0026e4b8 str.btcctl.conf
 0x0026e53c str.rpc.cert
 0x0026e5c0 str.rpc.cert
-0x0026e690 str.
-0x0026e6cc str.
-0x0026e6d0 str.
-0x0026e6e0 str.
-0x0026e6e4 str.
-15727
+15577
 EOF
 RUN
 
@@ -275,20 +227,138 @@ iI~compiler
 EOF
 EXPECT=<<EOF
 1429
-0x100006c70 str.
 0x100006dd8 str.value_method
 0x100006e48 str.called_using_nil
 0x100006e64 str.pointer
 0x100006eac str.panicwrap:_no___in
-0x100006f10 str.
-0x100007280 str.
-0x100007420 str.
-0x1000074f0 str.
-0x100007504 str.
-0x10000751c str.
-0x10000752c str.
 0x1000076d0 str.internal_error___misuse_of_itab
-1327
+1288
 compiler go1.18 (cmd -compiler=gc CGO_ENABLED=1 CGO_CFLAGS= CGO_CPPFLAGS= CGO_CXXFLAGS= CGO_LDFLAGS= GOARCH=arm64 GOOS=darwin)
+EOF
+RUN
+
+NAME=Resolve all symbols on a stripped PE go1.12 binary (x64)
+FILE=bins/golang/hello_go_strip.exe
+CMDS=<<EOF
+aalg
+fl~sym.go.~?
+pdfs @ main ~str.
+izq~?
+iI~compiler
+EOF
+EXPECT=<<EOF
+1788
+0x004a699b str.hello__hacktivity
+9074
+compiler go1.15
+EOF
+RUN
+
+NAME=Parse Golang 1.18 BuildInfo ELF
+FILE=bins/golang/GoReSym_118_tip_stripped
+CMDS=iI~compiler
+EXPECT=<<EOF
+compiler devel go1.18-2d1d548 Tue Dec 21 03:55:43 2021 +0000 (path github.com/stevemk14ebr/GoReSym mod github.com/stevemk14ebr/GoReSym (devel)  dep golang.org/x/arch v0.0.0-20201008161808-52c3e6f60cff h1:XmKBi9R6duxOB3lfc72wyrwiOY7X2Jl1wuI+RFOyMDE= -compiler=gc -ldflags=-s -w CGO_ENABLED=1 CGO_CFLAGS= CGO_CPPFLAGS= CGO_CXXFLAGS= CGO_LDFLAGS= GOARCH=amd64 GOOS=linux GOAMD64=v1 vcs=git vcs.revision=4bd670890aee5a14e36be1a72d19ca8573f2433b vcs.time=2021-12-06T17:40:21Z vcs.modified=true)
+EOF
+RUN
+
+
+NAME=Parse Golang 1.18 MIPS BE Strings
+FILE=bins/golang/go-re-sample-linux-mips
+CMDS=<<EOF
+aalg
+e asm.cmt.col=0
+pdr~"
+EOF
+EXPECT=<<EOF
+| 0x000be5ec      lui   v1, 0xd ; 0xd3417 ; "foogc gp in intmapnilobjpc=ptr\u00b5s\u03bcs <== at  fp= is  lr: of  on  pc= sp: sp=) = ) m=+Inf,r2=-Inf3125: p=AhomChamDashGOGC"
+| 0x000be670      lui   at, 0xd ; 0xd3860 ; "enableerrno objectselectstringstructsweep sysmontimersuint16uint32uint64  name:  tail: (scan  (scan) MB in  Value> allocs dying="
+| 0x000be6a8      lui   v1, 0xd ; 0xd3503 ; "nameprofroots + sbrktrueuint  -%s ...\n MB,  and  max= ms,  ptr  tab= top=(nil), fp:1562578125<nil>AdlamBamumBatakBuhidDograErro"
+| 0x000be700      lui   v0, 0xd ; 0xd340e ; "barendfinfoogc gp in intmapnilobjpc=ptr\u00b5s\u03bcs <== at  fp= is  lr: of  on  pc= sp: sp=) = ) m=+Inf,r2=-Inf3125: p=AhomCha"
+| 0x000be784      lui   at, 0xd ; 0xd360f ; "levellink lo   mheappanicpc   r0   r1   r10  r11  r12  r13  r14  r15  r16  r17  r18  r19  r2   r20  r21  r22  r23  r24  r25  r26"
+| 0x000be7dc      lui   v0, 0xf ; 0xd914e ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
+| 0x000be8e4      lui   v0, 0xf ; 0xd54fc ; "subcommand 'bar'subcommand 'foo'time: bad [0-9]*workbuf is empty spinningthreads=, 0, {interval: {, p.searchAddr = 0123456789ABC"
+| 0x000be940      lui   v0, 0xf ; 0xd3aae ; "  level: bytes,  etypes  is not  maxpc=  mcount= minLC=  minutes nalloc= newval= nfreed= pointer stack=[ status ) errno=48828125"
+| 0x000be9d4      lui   a0, 0xf ; 0xd38af ; "  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=, goid=,"
+| 0x000beab8      lui   v0, 0xf ; 0xd550c ; "subcommand 'foo'time: bad [0-9]*workbuf is empty spinningthreads=, 0, {interval: {, p.searchAddr = 0123456789ABCDEFX0123456789ab"
+| 0x000beb14      lui   v0, 0xf ; 0xd3ca6 ; "  enable: (forced) B exp.)  B work ( blocked= in use)\n lockedg= lockedm= m->curg= marked   method:  ms cpu,  not in [ runtime= "
+| 0x000beb9c      lui   v0, 0xf ; 0xd38a8 ; "  name:  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=,"
+| 0x000bec38      lui   a0, 0xf ; 0xd38af ; "  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=, goid=,"
+| 0x000becbc      lui   at, 0xf ; 0xd914e ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
+EOF
+RUN
+
+NAME=Parse Golang 1.18 MIPS LE Strings
+FILE=bins/golang/go-re-sample-linux-mipsle
+CMDS=<<EOF
+aalg
+e asm.cmt.col=0
+pdr~"
+EOF
+EXPECT=<<EOF
+| 0x000be5d0      lui   v1, 0xd ; 0xd3416 ; "foogc gp in intmapnilobjpc=ptr\u00b5s\u03bcs <== at  fp= is  lr: of  on  pc= sp: sp=) = ) m=+Inf,r2=-Inf3125: p=AhomChamDashGOGC"
+| 0x000be654      lui   at, 0xd ; 0xd385f ; "enableerrno objectselectstringstructsweep sysmontimersuint16uint32uint64  name:  tail: (scan  (scan) MB in  Value> allocs dying="
+| 0x000be68c      lui   v1, 0xd ; 0xd3502 ; "nameprofroots + sbrktrueuint  -%s ...\n MB,  and  max= ms,  ptr  tab= top=(nil), fp:1562578125<nil>AdlamBamumBatakBuhidDograErro"
+| 0x000be6e4      lui   v0, 0xd ; 0xd340d ; "barendfinfoogc gp in intmapnilobjpc=ptr\u00b5s\u03bcs <== at  fp= is  lr: of  on  pc= sp: sp=) = ) m=+Inf,r2=-Inf3125: p=AhomCha"
+| 0x000be768      lui   at, 0xd ; 0xd360e ; "levellink lo   mheappanicpc   r0   r1   r10  r11  r12  r13  r14  r15  r16  r17  r18  r19  r2   r20  r21  r22  r23  r24  r25  r26"
+| 0x000be7c0      lui   v0, 0xf ; 0xd914d ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
+| 0x000be8c8      lui   v0, 0xf ; 0xd54fb ; "subcommand 'bar'subcommand 'foo'time: bad [0-9]*workbuf is empty spinningthreads=, 0, {interval: {, p.searchAddr = 0123456789ABC"
+| 0x000be924      lui   v0, 0xf ; 0xd3aad ; "  level: bytes,  etypes  is not  maxpc=  mcount= minLC=  minutes nalloc= newval= nfreed= pointer stack=[ status ) errno=48828125"
+| 0x000be9b8      lui   a0, 0xf ; 0xd38ae ; "  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=, goid=,"
+| 0x000bea9c      lui   v0, 0xf ; 0xd550b ; "subcommand 'foo'time: bad [0-9]*workbuf is empty spinningthreads=, 0, {interval: {, p.searchAddr = 0123456789ABCDEFX0123456789ab"
+| 0x000beaf8      lui   v0, 0xf ; 0xd3ca5 ; "  enable: (forced) B exp.)  B work ( blocked= in use)\n lockedg= lockedm= m->curg= marked   method:  ms cpu,  not in [ runtime= "
+| 0x000beb7c      lui   v0, 0xf ; 0xd38a7 ; "  name:  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=,"
+| 0x000bec18      lui   a0, 0xf ; 0xd38ae ; "  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=, goid=,"
+| 0x000bec9c      lui   at, 0xf ; 0xd914d ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
+EOF
+RUN
+
+NAME=Parse Golang 1.18 MIPS64 BE Strings
+FILE=bins/golang/go-re-sample-linux-mips64
+CMDS=<<EOF
+aalg
+e asm.cmt.col=0
+pdr~"
+EOF
+EXPECT=<<EOF
+| 0x000c0378      lui   v1, 0xe ; 0xe7d69 ; "foogc gp in intmapmsanilobjpc=ptr\u00b5s\u03bcs <== at  fp= is  lr: of  on  pc= sp: sp=) = ) m=+Inf,r2=-Inf3125: p=AhomChamDashG"
+| 0x000c040c      lui   at, 0xf ; 0xe81b6 ; "enableerrno objectselectstringstructsweep sysmontimersuint16uint32uint64  name:  tail: (scan  (scan) MB in  Value> allocs dying="
+| 0x000c0448      lui   v1, 0xe ; 0xe7e54 ; "nameprofroots + sbrktrueuint  -%s ...\n MB,  and  cnt= max= ms,  ptr  tab= top=(nil), fp:1562578125<nil>AdlamBamumBatakBuhidDogr"
+| 0x000c04a8      lui   v0, 0xe ; 0xe7d60 ; "barendfinfoogc gp in intmapmsanilobjpc=ptr\u00b5s\u03bcs <== at  fp= is  lr: of  on  pc= sp: sp=) = ) m=+Inf,r2=-Inf3125: p=Ahom"
+| 0x000c053c      lui   at, 0xe ; 0xe7f65 ; "levellink lo   mheappanicpc   r0   r1   r10  r11  r12  r13  r14  r15  r16  r17  r18  r19  r2   r20  r21  r22  r23  r24  r25  r26"
+| 0x000c05a0      lui   v0, 0x11 ; 0xedacb ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
+| 0x000c06c4      lui   v0, 0x11 ; 0xe9e6b ; "subcommand 'bar'subcommand 'foo'time: bad [0-9]*workbuf is empty spinningthreads=, 0, {interval: {, p.searchAddr = 0123456789ABC"
+| 0x000c0730      lui   v0, 0x11 ; 0xe8404 ; "  level: bytes,  etypes  is not  maxpc=  mcount= minLC=  minutes nalloc= newval= nfreed= packed= pointer stack=[ status ) errno="
+| 0x000c07dc      lui   at, 0x11 ; 0xe8205 ; "  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=, goid=,"
+| 0x000c08d8      lui   v0, 0x11 ; 0xe9e7b ; "subcommand 'foo'time: bad [0-9]*workbuf is empty spinningthreads=, 0, {interval: {, p.searchAddr = 0123456789ABCDEFX0123456789ab"
+| 0x000c0944      lui   v0, 0x11 ; 0xe8604 ; "  enable: (forced) -> node= B exp.)  B work ( blocked= in use)\n lockedg= lockedm= m->curg= marked   method:  ms cpu,  not in [ "
+| 0x000c09e4      lui   v0, 0x11 ; 0xe81fe ; "  name:  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=,"
+| 0x000c0a98      lui   at, 0x11 ; 0xe8205 ; "  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=, goid=,"
+| 0x000c0b34      lui   at, 0x11 ; 0xedacb ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
+EOF
+RUN
+
+NAME=Parse Golang 1.18 MIPS64 LE Strings
+FILE=bins/golang/go-re-sample-linux-mips64le
+CMDS=<<EOF
+aalg
+e asm.cmt.col=0
+pdr~"
+EOF
+EXPECT=<<EOF
+| 0x000c0360      lui   v1, 0xe ; 0xe7d6b ; "foogc gp in intmapmsanilobjpc=ptr\u00b5s\u03bcs <== at  fp= is  lr: of  on  pc= sp: sp=) = ) m=+Inf,r2=-Inf3125: p=AhomChamDashG"
+| 0x000c03f4      lui   at, 0xf ; 0xe81b8 ; "enableerrno objectselectstringstructsweep sysmontimersuint16uint32uint64  name:  tail: (scan  (scan) MB in  Value> allocs dying="
+| 0x000c0430      lui   v1, 0xe ; 0xe7e56 ; "nameprofroots + sbrktrueuint  -%s ...\n MB,  and  cnt= max= ms,  ptr  tab= top=(nil), fp:1562578125<nil>AdlamBamumBatakBuhidDogr"
+| 0x000c0490      lui   v0, 0xe ; 0xe7d62 ; "barendfinfoogc gp in intmapmsanilobjpc=ptr\u00b5s\u03bcs <== at  fp= is  lr: of  on  pc= sp: sp=) = ) m=+Inf,r2=-Inf3125: p=Ahom"
+| 0x000c0524      lui   at, 0xe ; 0xe7f67 ; "levellink lo   mheappanicpc   r0   r1   r10  r11  r12  r13  r14  r15  r16  r17  r18  r19  r2   r20  r21  r22  r23  r24  r25  r26"
+| 0x000c0588      lui   v0, 0x11 ; 0xedacd ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
+| 0x000c06ac      lui   v0, 0x11 ; 0xe9e6d ; "subcommand 'bar'subcommand 'foo'time: bad [0-9]*workbuf is empty spinningthreads=, 0, {interval: {, p.searchAddr = 0123456789ABC"
+| 0x000c0718      lui   v0, 0x11 ; 0xe8406 ; "  level: bytes,  etypes  is not  maxpc=  mcount= minLC=  minutes nalloc= newval= nfreed= packed= pointer stack=[ status ) errno="
+| 0x000c07c4      lui   at, 0x11 ; 0xe8207 ; "  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=, goid=,"
+| 0x000c08c0      lui   v0, 0x11 ; 0xe9e7d ; "subcommand 'foo'time: bad [0-9]*workbuf is empty spinningthreads=, 0, {interval: {, p.searchAddr = 0123456789ABCDEFX0123456789ab"
+| 0x000c092c      lui   v0, 0x11 ; 0xe8606 ; "  enable: (forced) -> node= B exp.)  B work ( blocked= in use)\n lockedg= lockedm= m->curg= marked   method:  ms cpu,  not in [ "
+| 0x000c09c8      lui   v0, 0x11 ; 0xe8200 ; "  name:  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=,"
+| 0x000c0a7c      lui   at, 0x11 ; 0xe8207 ; "  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=, goid=,"
+| 0x000c0b18      lui   at, 0x11 ; 0xedacd ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
 EOF
 RUN

--- a/test/db/analysis/golang
+++ b/test/db/analysis/golang
@@ -362,3 +362,53 @@ EXPECT=<<EOF
 | 0x000c0b18      lui   at, 0x11 ; 0xedacd ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
 EOF
 RUN
+
+NAME=Parse Golang 1.18 PPC64 BE Strings
+FILE=bins/golang/go-re-sample-linux-ppc64
+CMDS=<<EOF
+aalg
+e asm.cmt.col=0
+pdr~"
+EOF
+EXPECT=<<EOF
+| 0x00099f7c      lis   r5, 0xb ; 0xb7d3f ; "foogc gp in intmapnilobjpc=ptrscv\u00b5s\u03bcs <== at  fp= is  lr: of  on  pc= sp: sp=) = ) m=+Inf,r2=-Inf3125: p=AhomChamDashG"
+| 0x00099fec      lis   r4, 0xc ; 0xb8198 ; "enableerrno objectpower9selectstringstructsweep sysmontimersuint16uint32uint64  name:  tail: (scan  (scan) MB in  Value> allocs "
+| 0x0009a00c      lis   r4, 0xb ; 0xb7e32 ; "nameprofroots + sbrktrueuint  -%s ...\n MB,  and  cnt= max= ms,  ptr  tab= top=(nil), fp:1562578125<nil>AdlamBamumBatakBuhidDogr"
+| 0x0009a050      lis   r9, 0xb ; 0xb7d36 ; "barendfinfoogc gp in intmapnilobjpc=ptrscv\u00b5s\u03bcs <== at  fp= is  lr: of  on  pc= sp: sp=) = ) m=+Inf,r2=-Inf3125: p=Ahom"
+| 0x0009a0c0      lis   r4, 0xb ; 0xb7f48 ; "levellink mheappanicpc   r0   r1   r10  r11  r12  r13  r14  r15  r16  r17  r18  r19  r2   r20  r21  r22  r23  r24  r25  r26  r27"
+| 0x0009a108      lis   r9, 0xd ; 0xbd867 ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
+| 0x0009a1cc      lis   r8, 0xd ; 0xb9bf0 ; "subcommand 'bar'subcommand 'foo'time: bad [0-9]*workbuf is empty spinningthreads=, 0, {interval: {, p.searchAddr = 0123456789ABC"
+| 0x0009a218      lis   r8, 0xd ; 0xb83ec ; "  level: bytes,  etypes  is not  maxpc=  mcount= minLC=  minutes nalloc= newval= nfreed= packed= pointer stack=[ status ) errno="
+| 0x0009a290      lis   r7, 0xd ; 0xb81ed ; "  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=, goid=,"
+| 0x0009a330      lis   r8, 0xd ; 0xb9c00 ; "subcommand 'foo'time: bad [0-9]*workbuf is empty spinningthreads=, 0, {interval: {, p.searchAddr = 0123456789ABCDEFX0123456789ab"
+| 0x0009a37c      lis   r8, 0xd ; 0xb85f0 ; "  enable: (forced) -> node= B exp.)  B work ( blocked= in use)\n lockedg= lockedm= m->curg= marked   method:  ms cpu,  not in [ "
+| 0x0009a3f4      lis   r8, 0xd ; 0xb81e6 ; "  name:  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=,"
+| 0x0009a470      lis   r7, 0xd ; 0xb81ed ; "  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=, goid=,"
+| 0x0009a4cc      lis   r8, 0xd ; 0xbd867 ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
+EOF
+RUN
+
+NAME=Parse Golang 1.18 PPC64 LE Strings
+FILE=bins/golang/go-re-sample-linux-ppc64le
+CMDS=<<EOF
+aalg
+e asm.cmt.col=0
+pdr~"
+EOF
+EXPECT=<<EOF
+| 0x00099eac      lis   r5, 0xb ; 0xb7d60 ; "foogc gp in intmapnilobjpc=ptrscv\u00b5s\u03bcs <== at  fp= is  lr: of  on  pc= sp: sp=) = ) m=+Inf,r2=-Inf3125: p=AhomChamDashG"
+| 0x00099f1c      lis   r4, 0xc ; 0xb81b9 ; "enableerrno objectpower9selectstringstructsweep sysmontimersuint16uint32uint64  name:  tail: (scan  (scan) MB in  Value> allocs "
+| 0x00099f3c      lis   r4, 0xb ; 0xb7e53 ; "nameprofroots + sbrktrueuint  -%s ...\n MB,  and  cnt= max= ms,  ptr  tab= top=(nil), fp:1562578125<nil>AdlamBamumBatakBuhidDogr"
+| 0x00099f80      lis   r9, 0xb ; 0xb7d57 ; "barendfinfoogc gp in intmapnilobjpc=ptrscv\u00b5s\u03bcs <== at  fp= is  lr: of  on  pc= sp: sp=) = ) m=+Inf,r2=-Inf3125: p=Ahom"
+| 0x00099ff0      lis   r4, 0xb ; 0xb7f69 ; "levellink mheappanicpc   r0   r1   r10  r11  r12  r13  r14  r15  r16  r17  r18  r19  r2   r20  r21  r22  r23  r24  r25  r26  r27"
+| 0x0009a038      lis   r9, 0xd ; 0xbd845 ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
+| 0x0009a0f0      lis   r8, 0xd ; 0xb9bf3 ; "subcommand 'bar'subcommand 'foo'time: bad [0-9]*workbuf is empty spinningthreads=, 0, {interval: {, p.searchAddr = 0123456789ABC"
+| 0x0009a13c      lis   r8, 0xd ; 0xb840d ; "  level: bytes,  etypes  is not  maxpc=  mcount= minLC=  minutes nalloc= newval= nfreed= packed= pointer stack=[ status ) errno="
+| 0x0009a1b4      lis   r7, 0xd ; 0xb820e ; "  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=, goid=,"
+| 0x0009a248      lis   r8, 0xd ; 0xb9c03 ; "subcommand 'foo'time: bad [0-9]*workbuf is empty spinningthreads=, 0, {interval: {, p.searchAddr = 0123456789ABCDEFX0123456789ab"
+| 0x0009a294      lis   r8, 0xd ; 0xb8610 ; "  enable: (forced) -> node= B exp.)  B work ( blocked= in use)\n lockedg= lockedm= m->curg= marked   method:  ms cpu,  not in [ "
+| 0x0009a308      lis   r8, 0xd ; 0xb8207 ; "  name:  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=,"
+| 0x0009a384      lis   r7, 0xd ; 0xb820e ; "  tail: (scan  (scan) MB in  Value> allocs dying= locks= m->g0= nmsys= pad1=  pad2=  s=nil\n text=  zombie% CPU ((PANIC=, goid=,"
+| 0x0009a3e0      lis   r8, 0xd ; 0xbd845 ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
+EOF
+RUN

--- a/test/db/analysis/golang
+++ b/test/db/analysis/golang
@@ -8,15 +8,20 @@ izq~?
 EOF
 EXPECT=<<EOF
 4759
+0x0063dfb2 str.
 0x0063dfdc str.server.crt
 0x0063e01e str.Reading_server_certificate:__s
 0x0063e1d1 str.https:__localhost:8000
 0x0063e20e str.Failed_get:__s
 0x0063e2e4 str.Failed_reading_response_body:__s
 0x0063e3af str.Got_response__d:__s__s
+0x0063e426 str.
+0x0063e48f str.
 0x0063e49b str.version
-0x0063e4ac str.HT
-14310
+0x0063e4ac str.HTTP_version
+0x0063e4e5 str.
+0x0063e616 str.
+14210
 EOF
 RUN
 
@@ -37,12 +42,12 @@ EXPECT=<<EOF
 0x0066d863 str.Failed_reading_response_body:__s
 0x0066d9a3 str.Got_response__d:__s__s
 0x0066db8c str.version
-0x0066dbaa str.HT
+0x0066dbaa str.HTTP_version
 0x0066e68d str.Addr
 ;-- str.flag:
 ;-- str.sort:
 ;-- str.sync:
-13215
+13349
 EOF
 RUN
 
@@ -63,8 +68,8 @@ EXPECT=<<EOF
 0x0065db5a str.Failed_reading_response_body:__s
 0x0065dca5 str.Got_response__d:__s__s
 0x0065de6d str.version
-0x0065de8a str.HT
-13380
+0x0065de8a str.HTTP_version
+13489
 EOF
 RUN
 
@@ -77,7 +82,7 @@ pdfs @ main ~str.
 izq~?
 EOF
 EXPECT=<<EOF
-5122
+5124
 0x00270aac str.Failed_to_read_data_from_stdin:__v
 0x00270d70 str.s_command:__v
 0x00270db8 str.1.0
@@ -89,9 +94,10 @@ EXPECT=<<EOF
 0x00271580 str.Unrecognized_command___s
 0x00271608 str.No_command_specified
 0x0027186c str.Chain_Server_Commands:DEBUG_HTTP2
-0x0027187c str.Wallet_Server_Commands____wallet_:adding_nil_Certificate_to_CertPoolbad_scalar_length:__d__expected__dchacha20:_wrong_HChaCha20_key_sizecrypto_aes:_invalid_buffer_overlapcrypto_des:_invalid_buffer_overlapcrypto_rc4:_invalid_buffer_overlapcrypto_rsa:_missing_public_modulusdoaddtimer:_P_already_set_in_timerexceeded_max_operation_limit_of__dexpected_an_RSA_public_key__got__TforEachP:_sched.safePointWait____0http2:_aborting_request_body_writehttp:_connection_has_been_hijackedhttp:_persistConn.readLoop_exitinghttp:_read_on_closed_response_bodyillegal_base64_data_at_input_byte_in__u_hexadecimal_character_escapeinvalid_descriptor_range_value:__vinvalid_nested_repetition_operatorinvalid_or_unsupported_Perl_syntaxinvalid_padding_bits_in_BIT_STRINGmalformed_signature:_R_is_negativemalformed_signature:_S_is_negativemax_hash_string_length_is__v_bytesmspan.ensureSwept:_m_is_not_lockedout_of_memory_allocating_allArenasreflect.FuncOf:_too_many_argumentsreflect:_ChanDir_of_non_chan_type_reflect:_Field_index_out_
+0x0027187c str.Wallet_Server_Commands____wallet_:
 0x00271ab4 str.PH2
 0x00271bbc str.cannot_use__wallet_with__regtest__btcwallet_not_yet_compatible_with_regtest
+0x00271e10 str.localhost
 0x00272018 str.Use__s__h_to_show_options
 0x002720ec str.btcwallet.conf
 0x00272188 str.Error_creating_a_default_config_file:__v
@@ -107,11 +113,13 @@ EXPECT=<<EOF
 0x0027347c str.:
 0x00273514 str.POST
 0x00273574 str.Content_Type
+0x002735b4 str.application_json
 0x0027373c str.error_reading_json_reply:__v
 0x00273834 str.d__s
 0x002738bc str.s
 0x00273a58 str.https
 0x00273b18 str.d._d._d
+0x00273b20 str.
 0x00273b50 str.beta
 0x00273c20 str.s__s
 0x00273d74 str.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz
@@ -123,8 +131,10 @@ EXPECT=<<EOF
 0x00273fb4 str.btcwallet
 0x0027401c str.btcctl.conf
 0x00274090 str.rpc.cert
+0x00274098 str.
 0x00274104 str.rpc.cert
-13272
+0x0027410c str.
+13586
 EOF
 RUN
 
@@ -137,44 +147,105 @@ pdfs @ main ~str.
 izq~?
 EOF
 EXPECT=<<EOF
-5069
+5070
+0x0026acd0 str.
+0x0026ad08 str.
 0x0026b000 str.s_command:__v
 0x0026b04c str.1.0
+0x0026b29c str.
+0x0026b310 str.tls:_invalid_server_key_share
 0x0026b314 str.Failed_to_unmarshal_result:__v
 0x0026b444 str.Failed_to_format_result:__v
+0x0026b5a8 str.
 0x0026b5dc str.s_command:__v__code:__s
 0x0026b730 str.Failed_to_read_data_from_stdin:__v
-0x0026b7a8 str.
+0x0026b884 str.Not_enough_lines_provided_on_stdin
 0x0026b998 str.The___s__command_can_only_be_used_via_websockets
+0x0026b9d0 str.Specify__l_to_list_available_commands
 0x0026ba70 str.Unrecognized_command___s
+0x0026baa8 str.Specify__l_to_list_available_commands
 0x0026bb00 str.No_command_specified
+0x0026bb70 str.
+0x0026bb9c str.
 0x0026bc28 str.Chain_Server_Commands:DEBUG_HTTP2
-0x0026bc3c str.Wallet_Server_Commands____wallet_:adding_nil_Certificate_to_CertPoolbad_scalar_length:__d__expected__dchacha20:_wrong_HChaCha20_key_sizecrypto_aes:_invalid_buffer_overlapcrypto_des:_invalid_buffer_overlapcrypto_rc4:_invalid_buffer_overlapcrypto_rsa:_missing_public_modulusdoaddtimer:_P_already_set_in_timerexceeded_max_operation_limit_of__dexpected_an_RSA_public_key__got__TforEachP:_sched.safePointWait____0http2:_aborting_request_body_writehttp:_connection_has_been_hijackedhttp:_persistConn.readLoop_exitinghttp:_read_on_closed_response_bodyillegal_base64_data_at_input_byte_in__u_hexadecimal_character_escapeinvalid_descriptor_range_value:__vinvalid_nested_repetition_operatorinvalid_or_unsupported_Perl_syntaxinvalid_padding_bits_in_BIT_STRINGmalformed_signature:_R_is_negativemalformed_signature:_S_is_negativemax_hash_string_length_is__v_bytesmspan.ensureSwept:_m_is_not_lockedout_of_memory_allocating_allArenasreflect.FuncOf:_too_many_argumentsreflect:_ChanDir_of_non_chan_type_reflect:_Field_index_out_of_boundsreflect:_Field_of_non_struct_type_reflect:_Method_index_out_of_rangereflect:_string_index_out_of_rangeruntime.SetFinalizer:_cannot_pass_runtime:_g_is_running_but_p_is_notruntime:_netpollBreak_write_failedruntime:_unexpected_return_pc_for_schedule:_spinning_with_local_workslice_bounds_out_of_range___x:_y:_slice_bounds_out_of_range__:_x:_y_stream_error:_stream_ID__d___v___vtestnet_seed.bitcoin.schildbach.detimeout_waiting_for_client_prefacetls:_malformed_key_share_extensiontoo_many_references:_cannot_splicetype_must_be__struct_not___s___s__unsupported_authentication_method_x509:_Ed25519_verification_failurex509:_unhandled_critical_extension_d_response_missing_Location_header____must_separate_successive_digits177635683940025046467781066894531252006_01_02T15:04:05.999999999Z07:0088817841970012523233890533447265625CONTINUATION_frame_with_stream_ID_0Failed_to_read_data_from_stdin:__v_attempt_to_clear_non_empty_span_setattempt_to_drop__d_items_from_stackchacha20:_output_smaller_than_inputcrypto_md5:_invalid_hash_sta
+0x0026bc3c str.Wallet_Server_Commands____wallet_:
+0x0026be24 str.
+0x0026bee0 str.
+0x0026bf1c str.testnet3
+0x0026bf40 str.18334
+0x0026c030 str.simnet
+0x0026c054 str.18556
+0x0026c064 str.regtest
+0x0026c084 str.18334
 0x0026c090 str.cannot_use__wallet_with__regtest__btcwallet_not_yet_compatible_with_regtest
+0x0026c100 str.8334
+0x0026c140 str.
+0x0026c250 str.
+0x0026c284 str.
+0x0026c2c8 str.localhost
+0x0026c2d0 str.localhost
+0x0026c34c str.
 0x0026c520 str.Use__s__h_to_show_options
+0x0026c564 str.
 0x0026c5f4 str.btcwallet.conf
 0x0026c688 str.Error_creating_a_default_config_file:__v
+0x0026c8ac str.testnet3
+0x0026c8b4 str.mainnet
+0x0026c8c4 str.simnet
+0x0026c8d4 str.regtest
+0x0026cad4 str.loadConfig
+0x0026cae0 str.profilealloc_called_without_a_P_or_outside_bootstrapping
 0x0026cae4 str.s:_Multiple_network_params_can_t_be_used_together____choose_one
+0x0026cbd0 str.tls:_invalid_server_key_share
 0x0026cbd4 str.Error_parsing_config_file:__v
 0x0026ccb8 str.btcd.conf
+0x0026cd0c str.
+0x0026cd6c str.version
+0x0026cec4 str.The_special_parameter_____indicates_that_a_parameter_should_be_read_from_the_next_unread_line_from_standard_input.
+0x0026cfd0 str.
 0x0026d0a8 str.m___s_rpcuser_____s
 0x0026d0fc str.m___s_rpcpass_____s
 0x0026d150 str.m___s_notls__0_1___:_s
 0x0026d2e0 str.rpcuser__s_rpcpass__s
 0x0026d368 str.notls__s
+0x0026d550 str.
+0x0026d580 str.
+0x0026d5a0 str.
+0x0026d5b8 str.
+0x0026d6e0 str.
+0x0026d738 str.
+0x0026d7c0 str.
+0x0026d83c str.
+0x0026d8c0 str.
+0x0026d8e8 str.
 0x0026d900 str.http
 0x0026d908 str.https
 0x0026d90c str.http
 0x0026d928 str.:
+0x0026d968 str.
 0x0026d9c4 str.POST
 0x0026da28 str.Content_Type
+0x0026da5c str.
+0x0026da64 str.
+0x0026da70 str.application_json
+0x0026db04 str.
 0x0026dbe8 str.error_reading_json_reply:__v
+0x0026dc44 str.
+0x0026dca0 str.
+0x0026dcac str.
 0x0026dcec str.d__s
 0x0026dd70 str.s
+0x0026ddd0 str.
+0x0026de48 str.
+0x0026df20 str.
 0x0026df84 str.d._d._d
 0x0026dfc0 str.beta
 0x0026e0a0 str.s__s
+0x0026e180 str.
+0x0026e1dc str.profilealloc_called_without_a_P_or_outside_bootstrapping
 0x0026e1e0 str.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz
+0x0026e2a0 str.
+0x0026e350 str.
 0x0026e370 str.linux
 0x0026e384 str.btcd
 0x0026e3d0 str.linux
@@ -184,7 +255,12 @@ EXPECT=<<EOF
 0x0026e4b8 str.btcctl.conf
 0x0026e53c str.rpc.cert
 0x0026e5c0 str.rpc.cert
-14828
+0x0026e690 str.
+0x0026e6cc str.
+0x0026e6d0 str.
+0x0026e6e0 str.
+0x0026e6e4 str.
+15727
 EOF
 RUN
 
@@ -199,35 +275,20 @@ iI~compiler
 EOF
 EXPECT=<<EOF
 1429
+0x100006c70 str.
 0x100006dd8 str.value_method
 0x100006e48 str.called_using_nil
 0x100006e64 str.pointer
-13
+0x100006eac str.panicwrap:_no___in
+0x100006f10 str.
+0x100007280 str.
+0x100007420 str.
+0x1000074f0 str.
+0x100007504 str.
+0x10000751c str.
+0x10000752c str.
+0x1000076d0 str.internal_error___misuse_of_itab
+1327
 compiler go1.18 (cmd -compiler=gc CGO_ENABLED=1 CGO_CFLAGS= CGO_CPPFLAGS= CGO_CXXFLAGS= CGO_LDFLAGS= GOARCH=arm64 GOOS=darwin)
-EOF
-RUN
-
-NAME=Resolve all symbols on a stripped PE go1.12 binary (x64)
-FILE=bins/golang/hello_go_strip.exe
-CMDS=<<EOF
-aalg
-fl~sym.go.~?
-pdfs @ main ~str.
-izq~?
-iI~compiler
-EOF
-EXPECT=<<EOF
-1788
-0x004a699b str.hello__hacktivity
-9032
-compiler go1.15
-EOF
-RUN
-
-NAME=Parse Golang 1.18 BuildInfo ELF
-FILE=bins/golang/GoReSym_118_tip_stripped
-CMDS=iI~compiler
-EXPECT=<<EOF
-compiler devel go1.18-2d1d548 Tue Dec 21 03:55:43 2021 +0000 (path github.com/stevemk14ebr/GoReSym mod github.com/stevemk14ebr/GoReSym (devel)  dep golang.org/x/arch v0.0.0-20201008161808-52c3e6f60cff h1:XmKBi9R6duxOB3lfc72wyrwiOY7X2Jl1wuI+RFOyMDE= -compiler=gc -ldflags=-s -w CGO_ENABLED=1 CGO_CFLAGS= CGO_CPPFLAGS= CGO_CXXFLAGS= CGO_LDFLAGS= GOARCH=amd64 GOOS=linux GOAMD64=v1 vcs=git vcs.revision=4bd670890aee5a14e36be1a72d19ca8573f2433b vcs.time=2021-12-06T17:40:21Z vcs.modified=true)
 EOF
 RUN

--- a/test/db/formats/elf/elf-riscv64
+++ b/test/db/formats/elf/elf-riscv64
@@ -421,8 +421,11 @@ intrp    N/A
 laddr    0x00000000
 lang     c
 machine  RISC V
+maxopsz  6
+minopsz  2
 os       linux
 cc       N/A
+pcalign  2
 rpath    NONE
 subsys   linux
 stripped false
@@ -446,7 +449,7 @@ CMDS=<<EOF
 e asm.bytes=true
 e analysis.vars.stackname=true
 e asm.calls=false
-s sym.main
+s main
 af
 pdf
 EOF
@@ -504,11 +507,10 @@ RUN
 NAME=ELF: riscv64: full analysis
 FILE=bins/elf/analysis/guess-number-riscv64
 CMDS=<<EOF
-e analysis.jmp.cref=true
 aaa
 e asm.bytes=true
 e asm.calls=false
-s sym.main
+s main
 pdf
 EOF
 EXPECT=<<EOF
@@ -543,7 +545,6 @@ EXPECT=<<EOF
 |     |::   0x000101a4      ef00002d       jal   ra, dbg.puts
 |     |::   0x000101a8      93070000       li    a5, 0
 |    ,====< 0x000101ac      6f000003       j     0x101dc
-|    ||::   ; CODE XREF from main @ 0x10198
 |    |`---> 0x000101b0      032784fe       lw    a4, -24(s0)
 |    | ::   0x000101b4      8327c4fe       lw    a5, -20(s0)
 |    |,===< 0x000101b8      635af700       ble   a5, a4, 0x101cc
@@ -551,7 +552,6 @@ EXPECT=<<EOF
 |    ||::   0x000101c0      13858752       addi  a0, a5, 1320          ; const char *s
 |    ||::   0x000101c4      ef00002b       jal   ra, dbg.puts
 |    ||`==< 0x000101c8      6ff09ffa       j     0x10170
-|    || :   ; CODE XREF from main @ 0x101b8
 |    |`---> 0x000101cc      b7170200       lui   a5, 0x21
 |    |  :   0x000101d0      13858753       addi  a0, a5, 1336          ; const char *s
 |    |  :   0x000101d4      ef00002a       jal   ra, dbg.puts


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Tests for mips, ppc and riscv added.