### PR TITLE
Fix -Wunused-but-set-variable warnings

### DIFF
--- a/librz/cons/grep.c
+++ b/librz/cons/grep.c
@@ -466,7 +466,7 @@ RZ_API void rz_cons_grepbuf(void) {
 	const int len = cons->context->buffer_len;
 	RzConsGrep *grep = &cons->context->grep;
 	const char *in = buf;
-	int ret, total_lines = 0, buffer_len = 0, l = 0, tl = 0;
+	int ret, total_lines = 0, l = 0, tl = 0;
 	bool show = false;
 	if (cons->filter) {
 		cons->context->buffer_len = 0;
@@ -648,7 +648,6 @@ RZ_API void rz_cons_grepbuf(void) {
 						rz_strbuf_append(ob, str);
 						rz_strbuf_append(ob, "\n");
 					}
-					buffer_len += ret + 1;
 					free(str);
 				}
 				if (!grep->range_line) {

--- a/librz/core/linux_heap_jemalloc.c
+++ b/librz/core/linux_heap_jemalloc.c
@@ -104,6 +104,7 @@ static bool GH(rz_resolve_jemalloc)(RzCore *core, char *symname, ut64 *symbol) {
 	free(path);
 	return false;
 #else
+	(void)jemalloc_addr;
 	RZ_LOG_INFO("Resolving %s from libjemalloc.2... ", symname);
 	// this is quite sloooow, we must optimize dmi
 	char *va = rz_core_cmd_strf(core, "dmi libjemalloc.2 %s$~[1]", symname);

--- a/librz/diff/unified_diff.c
+++ b/librz/diff/unified_diff.c
@@ -147,8 +147,6 @@ static inline void diff_unified_lines_hl(RzDiff *diff, RzDiffOp *op, RzStrBuf *s
 
 	// Fill char_bounds array
 	ut32 bounds_idx = 0;
-	ut32 count = 0;
-	ut32 count_b = 0;
 	bool newline = false;
 	st32 i = a_beg;
 	st32 j = b_beg;
@@ -162,7 +160,6 @@ static inline void diff_unified_lines_hl(RzDiff *diff, RzDiffOp *op, RzStrBuf *s
 		stringify(elem, &tmp);
 		len = rz_strbuf_length(&tmp);
 		p = rz_strbuf_get(&tmp);
-		count += len;
 		if (len > 0 && p[len - 1] == '\n') {
 			len--;
 			newline = true;
@@ -178,7 +175,6 @@ static inline void diff_unified_lines_hl(RzDiff *diff, RzDiffOp *op, RzStrBuf *s
 			stringify(elem_b, &tmp2);
 			len_b = rz_strbuf_length(&tmp2);
 			p_b = rz_strbuf_get(&tmp2);
-			count_b += len_b;
 			if (len_b > 0 && p_b[len_b - 1] == '\n') {
 				len_b--;
 			}
@@ -209,7 +205,6 @@ static inline void diff_unified_lines_hl(RzDiff *diff, RzDiffOp *op, RzStrBuf *s
 	char prefix = del_prefix;
 	const char *bcol = DIFF_COLOR(prefix);
 	const char *bbgcol = DIFF_BGCOLOR(prefix);
-	count = 0;
 	newline = false;
 	bounds_idx = 0;
 
@@ -225,7 +220,6 @@ static inline void diff_unified_lines_hl(RzDiff *diff, RzDiffOp *op, RzStrBuf *s
 		stringify(elem, &tmp);
 		len = rz_strbuf_length(&tmp);
 		p = rz_strbuf_get(&tmp);
-		count += len;
 		if (len > 0 && p[len - 1] == '\n') {
 			len--;
 			newline = true;
@@ -249,7 +243,6 @@ static inline void diff_unified_lines_hl(RzDiff *diff, RzDiffOp *op, RzStrBuf *s
 	prefix = ins_prefix;
 	bcol = DIFF_COLOR(prefix);
 	bbgcol = DIFF_BGCOLOR(prefix);
-	count = 0;
 	newline = false;
 	bounds_idx = 0;
 
@@ -265,7 +258,6 @@ static inline void diff_unified_lines_hl(RzDiff *diff, RzDiffOp *op, RzStrBuf *s
 		stringify(elem, &tmp);
 		len = rz_strbuf_length(&tmp);
 		p = rz_strbuf_get(&tmp);
-		count += len;
 		if (len > 0 && p[len - 1] == '\n') {
 			len--;
 			newline = true;

--- a/librz/util/range.c
+++ b/librz/util/range.c
@@ -351,7 +351,6 @@ int rz_range_get_n(RRange *rgs, int n, ut64 *fr, ut64 *to) {
             |__|    |__|       |_|
 #endif
 RRange *rz_range_inverse(RRange *rgs, ut64 fr, ut64 to, int flags) {
-	ut64 total = 0;
 	RzListIter *iter;
 	RRangeItem *r = NULL;
 	RRange *newrgs = rz_range_new();
@@ -361,16 +360,12 @@ RRange *rz_range_inverse(RRange *rgs, ut64 fr, ut64 to, int flags) {
 	rz_list_foreach (rgs->ranges, iter, r) {
 		if (r->fr > fr && r->fr < to) {
 			rz_range_add(newrgs, fr, r->fr, 1);
-			// eprintf("0x%08"PFMT64x" .. 0x%08"PFMT64x"\n", fr, r->fr);
-			total += (r->fr - fr);
 			fr = r->to;
 		}
 	}
 	if (fr < to) {
-		// eprintf("0x%08"PFMT64x" .. 0x%08"PFMT64x"\n", fr, to);
 		rz_range_add(newrgs, fr, to, 1);
 	}
-	// eprintf("Total bytes: %"PFMT64d"\n", total);
 	return newrgs;
 }
 

--- a/librz/util/zip.c
+++ b/librz/util/zip.c
@@ -290,7 +290,7 @@ RZ_API bool rz_inflatew_buf(RZ_NONNULL RzBuffer *src, RZ_NONNULL RzBuffer *dst, 
 
 	int err = 0, flush = Z_NO_FLUSH;
 	bool ret = true;
-	ut64 dst_cursor = 0, src_cursor = 0;
+	ut64 src_cursor = 0;
 	ut64 src_readlen = 0;
 	z_stream stream;
 
@@ -307,7 +307,6 @@ RZ_API bool rz_inflatew_buf(RZ_NONNULL RzBuffer *src, RZ_NONNULL RzBuffer *dst, 
 	int comp_factor = 1032; // maximum compression ratio
 	ut8 *src_tmpbuf = malloc(block_size), *dst_tmpbuf = malloc(comp_factor * block_size);
 
-	dst_cursor = rz_buf_tell(dst);
 	while ((src_readlen = rz_buf_read_at(src, src_cursor, src_tmpbuf, block_size)) > 0) {
 		src_cursor += src_readlen;
 		stream.avail_in = src_readlen;
@@ -326,7 +325,7 @@ RZ_API bool rz_inflatew_buf(RZ_NONNULL RzBuffer *src, RZ_NONNULL RzBuffer *dst, 
 			goto return_goto;
 		}
 
-		dst_cursor += rz_buf_write(dst, dst_tmpbuf, stream.total_out);
+		rz_buf_write(dst, dst_tmpbuf, stream.total_out);
 	}
 
 	if (src_consumed) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

As seen with:
Apple clang version 13.1.6 (clang-1316.0.21.2.5)
Target: arm64-apple-darwin21.4.0

```
[133/1564] Compiling C object librz/util/librz_util.0.4.dylib.p/range.c.o
../librz/util/range.c:354:7: warning: variable 'total' set but not used [-Wunused-but-set-variable]
        ut64 total = 0;
             ^
1 warning generated.
[170/1564] Compiling C object librz/util/librz_util.0.4.dylib.p/zip.c.o
../librz/util/zip.c:293:7: warning: variable 'dst_cursor' set but not used [-Wunused-but-set-variable]
        ut64 dst_cursor = 0, src_cursor = 0;
             ^
1 warning generated.
[235/1564] Compiling C object librz/cons/librz_cons.0.4.dylib.p/grep.c.o
../librz/cons/grep.c:469:28: warning: variable 'buffer_len' set but not used [-Wunused-but-set-variable]
        int ret, total_lines = 0, buffer_len = 0, l = 0, tl = 0;
                                  ^
1 warning generated.
[256/1564] Compiling C object librz/diff/librz_diff.0.4.dylib.p/diff.c.o
In file included from ../librz/diff/diff.c:124:
../librz/diff/unified_diff.c:151:7: warning: variable 'count_b' set but not used [-Wunused-but-set-variable]
        ut32 count_b = 0;
             ^
../librz/diff/unified_diff.c:150:7: warning: variable 'count' set but not used [-Wunused-but-set-variable]
        ut32 count = 0;
             ^
2 warnings generated.
[1445/1564] Compiling C object librz/core/librz_core.0.4.dylib.p/cmd_cmd.c.o
In file included from ../librz/core/cmd/cmd.c:76:
In file included from ../librz/core/cmd/cmd_debug.c:14:
In file included from ../librz/core/cmd/../linux_heap_jemalloc.c:7:
../librz/core/cmd/../linux_heap_jemalloc.c:71:7: warning: variable 'jemalloc_addr' set but not used [-Wunused-but-set-variable]
        ut64 jemalloc_addr = UT64_MAX;
             ^
In file included from ../librz/core/cmd/cmd.c:76:
In file included from ../librz/core/cmd/cmd_debug.c:14:
../librz/core/cmd/../linux_heap_jemalloc.c:71:7: warning: variable 'jemalloc_addr' set but not used [-Wunused-but-set-variable]
        ut64 jemalloc_addr = UT64_MAX;
             ^
2 warnings generated.
```
