### PR TITLE
Fix: format/pe: baddr = 0x0000 0000

### DIFF
--- a/librz/bin/format/pe/pe.c
+++ b/librz/bin/format/pe/pe.c
@@ -403,12 +403,6 @@ ut64 PE_(rz_bin_pe_get_image_base)(struct PE_(rz_bin_pe_obj_t) * bin) {
 		return 0LL;
 	}
 	imageBase = bin->nt_headers->optional_header.ImageBase;
-	if (!imageBase) {
-		// this should only happens with messed up binaries
-		// XXX this value should be user defined by bin.baddr
-		// but from here we can not access config API
-		imageBase = 0x10000;
-	}
 	return imageBase;
 }
 


### PR DESCRIPTION
This messed up loading binaries having ImageBase 0x0

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

See issue #2640

**Closing issues**

fixes #2640
