### PR TITLE
Refactor rz_core_analysis_get_stats() and fix edge cases

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -3707,7 +3707,7 @@ static bool block_flags_stat(RzFlagItem *fi, void *user) {
  * \param highest address to consider, inclusive. Must be greater than or equal to from.
  * \param size of a single block in the output
  */
-RZ_API RzCoreAnalysisStats *rz_core_analysis_get_stats(RzCore *core, ut64 from, ut64 to, ut64 step) {
+RZ_API RZ_OWN RzCoreAnalysisStats *rz_core_analysis_get_stats(RZ_NONNULL RzCore *core, ut64 from, ut64 to, ut64 step) {
 	rz_return_val_if_fail(core && to >= from && step, NULL);
 	RzAnalysisFunction *F;
 	RzAnalysisBlock *B;
@@ -3814,14 +3814,16 @@ RZ_API void rz_core_analysis_stats_free(RzCoreAnalysisStats *s) {
 /**
  * Get the lowest address that the i-th block in s covers (inclusive)
  */
-RZ_API ut64 rz_core_analysis_stats_get_block_from(const RzCoreAnalysisStats *s, size_t i) {
+RZ_API ut64 rz_core_analysis_stats_get_block_from(RZ_NONNULL const RzCoreAnalysisStats *s, size_t i) {
+	rz_return_val_if_fail(s, 0);
 	return s->from + s->step * i;
 }
 
 /**
  * Get the highest address that the i-th block in s covers (inclusive)
  */
-RZ_API ut64 rz_core_analysis_stats_get_block_to(const RzCoreAnalysisStats *s, size_t i) {
+RZ_API ut64 rz_core_analysis_stats_get_block_to(RZ_NONNULL const RzCoreAnalysisStats *s, size_t i) {
+	rz_return_val_if_fail(s, 0);
 	size_t count = rz_vector_len(&s->blocks);
 	rz_return_val_if_fail(i < count, 0);
 	if (i + 1 == count) {

--- a/librz/flag/flag.c
+++ b/librz/flag/flag.c
@@ -810,7 +810,8 @@ RZ_API void rz_flag_foreach_prefix(RzFlag *f, const char *pfx, int pfx_len, RzFl
  * \param from inclusive
  * \param to inclusive
  */
-RZ_API void rz_flag_foreach_range(RzFlag *f, ut64 from, ut64 to, RzFlagItemCb cb, void *user) {
+RZ_API void rz_flag_foreach_range(RZ_NONNULL RzFlag *f, ut64 from, ut64 to, RzFlagItemCb cb, void *user) {
+	rz_return_if_fail(f);
 	FOREACH_BODY(fi->offset >= from && fi->offset <= to);
 }
 

--- a/librz/flag/flag.c
+++ b/librz/flag/flag.c
@@ -806,8 +806,12 @@ RZ_API void rz_flag_foreach_prefix(RzFlag *f, const char *pfx, int pfx_len, RzFl
 	FOREACH_BODY(!strncmp(fi->name, pfx, pfx_len));
 }
 
+/**
+ * \param from inclusive
+ * \param to inclusive
+ */
 RZ_API void rz_flag_foreach_range(RzFlag *f, ut64 from, ut64 to, RzFlagItemCb cb, void *user) {
-	FOREACH_BODY(fi->offset >= from && fi->offset < to);
+	FOREACH_BODY(fi->offset >= from && fi->offset <= to);
 }
 
 RZ_API void rz_flag_foreach_glob(RzFlag *f, const char *glob, RzFlagItemCb cb, void *user) {

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -1030,6 +1030,11 @@ RZ_API const char **rz_core_help_vars_get(RzCore *core);
 
 /* analysis stats */
 
+/**
+ * Single sub-range of statistics as part of an entire RzCoreAnalysisStats.
+ *
+ * The range that this covers is given by rz_core_analysis_stats_get_block_from()/to().
+ */
 typedef struct {
 	ut32 youarehere;
 	ut32 flags;
@@ -1042,6 +1047,9 @@ typedef struct {
 	ut32 perm;
 } RzCoreAnalysisStatsItem;
 
+/**
+ * Statistics for a range of memory, split up into smaller blocks.
+ */
 typedef struct {
 	ut64 from;
 	ut64 to;
@@ -1051,10 +1059,10 @@ typedef struct {
 
 RZ_API char *rz_core_analysis_hasrefs(RzCore *core, ut64 value, int mode);
 RZ_API char *rz_core_analysis_get_comments(RzCore *core, ut64 addr);
-RZ_API RzCoreAnalysisStats *rz_core_analysis_get_stats(RzCore *a, ut64 from, ut64 to, ut64 step);
+RZ_API RZ_OWN RzCoreAnalysisStats *rz_core_analysis_get_stats(RZ_NONNULL RzCore *a, ut64 from, ut64 to, ut64 step);
 RZ_API void rz_core_analysis_stats_free(RzCoreAnalysisStats *s);
-RZ_API ut64 rz_core_analysis_stats_get_block_from(const RzCoreAnalysisStats *s, size_t i);
-RZ_API ut64 rz_core_analysis_stats_get_block_to(const RzCoreAnalysisStats *s, size_t i);
+RZ_API ut64 rz_core_analysis_stats_get_block_from(RZ_NONNULL const RzCoreAnalysisStats *s, size_t i);
+RZ_API ut64 rz_core_analysis_stats_get_block_to(RZ_NONNULL const RzCoreAnalysisStats *s, size_t i);
 
 RZ_API int rz_line_hist_offset_up(RzLine *line);
 RZ_API int rz_line_hist_offset_down(RzLine *line);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -1040,15 +1040,21 @@ typedef struct {
 	ut32 symbols;
 	ut32 strings;
 	ut32 perm;
-} RzCoreAnalStatsItem;
+} RzCoreAnalysisStatsItem;
+
 typedef struct {
-	RzCoreAnalStatsItem *block;
-} RzCoreAnalStats;
+	ut64 from;
+	ut64 to;
+	ut64 step;
+	RzVector blocks;
+} RzCoreAnalysisStats;
 
 RZ_API char *rz_core_analysis_hasrefs(RzCore *core, ut64 value, int mode);
 RZ_API char *rz_core_analysis_get_comments(RzCore *core, ut64 addr);
-RZ_API RzCoreAnalStats *rz_core_analysis_get_stats(RzCore *a, ut64 from, ut64 to, ut64 step);
-RZ_API void rz_core_analysis_stats_free(RzCoreAnalStats *s);
+RZ_API RzCoreAnalysisStats *rz_core_analysis_get_stats(RzCore *a, ut64 from, ut64 to, ut64 step);
+RZ_API void rz_core_analysis_stats_free(RzCoreAnalysisStats *s);
+RZ_API ut64 rz_core_analysis_stats_get_block_from(const RzCoreAnalysisStats *s, size_t i);
+RZ_API ut64 rz_core_analysis_stats_get_block_to(const RzCoreAnalysisStats *s, size_t i);
 
 RZ_API int rz_line_hist_offset_up(RzLine *line);
 RZ_API int rz_line_hist_offset_down(RzLine *line);

--- a/librz/include/rz_flag.h
+++ b/librz/include/rz_flag.h
@@ -127,7 +127,7 @@ RZ_API const char *rz_flag_color(RzFlag *f, RzFlagItem *it, const char *color);
 RZ_API int rz_flag_count(RzFlag *f, const char *glob);
 RZ_API void rz_flag_foreach(RzFlag *f, RzFlagItemCb cb, void *user);
 RZ_API void rz_flag_foreach_prefix(RzFlag *f, const char *pfx, int pfx_len, RzFlagItemCb cb, void *user);
-RZ_API void rz_flag_foreach_range(RzFlag *f, ut64 from, ut64 to, RzFlagItemCb cb, void *user);
+RZ_API void rz_flag_foreach_range(RZ_NONNULL RzFlag *f, ut64 from, ut64 to, RzFlagItemCb cb, void *user);
 RZ_API void rz_flag_foreach_glob(RzFlag *f, const char *glob, RzFlagItemCb cb, void *user);
 RZ_API void rz_flag_foreach_space(RzFlag *f, const RzSpace *space, RzFlagItemCb cb, void *user);
 RZ_API void rz_flag_foreach_space_glob(RzFlag *f, const char *glob, const RzSpace *space, RzFlagItemCb cb, void *user);

--- a/librz/include/rz_util/rz_num.h
+++ b/librz/include/rz_util/rz_num.h
@@ -154,6 +154,18 @@ CONVERT_TO_TWO_COMPLEMENT(64)
 /// Typical comparison (1/0/-1) for two numbers of arbitrary types, including unsigned
 #define RZ_NUM_CMP(a, b) ((a) > (b) ? 1 : ((b) > (a) ? -1 : 0))
 
+/**
+ * Divide 2^64 by the given divisor
+ *
+ * Idea: https://stackoverflow.com/a/55584872
+ * Proof: https://git.sr.ht/~thestr4ng3r/isa-bit-twiddling/tree/808253ab4d262f9e7dd7b87d0396f1afd7c5804b/item/Bit_Twiddling.thy#L26-43
+ *
+ * \param divisor must be non-zero
+ */
+static inline ut64 rz_num_2_pow_64_div(ut64 divisor) {
+	return (-divisor) / divisor + 1;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/db/cmd/cmd_p-
+++ b/test/db/cmd/cmd_p-
@@ -17,3 +17,254 @@ EXPECT=<<EOF
 
 EOF
 RUN
+
+NAME=p-
+FILE=bins/elf/analysis/x86-helloworld-gcc
+CMDS=<<EOF
+s 0x8048000
+e search.in=io.map
+p-
+e search.in=io.maps
+p-
+EOF
+EXPECT=<<EOF
+0x08048000 [^._______ssss_s__ssssss_ss_ss_ss__sz_s____s] 0x0804859c
+0x08048000 [^_sssssszss_____________________________s_s] 0x080496d0
+EOF
+RUN
+
+NAME=p- without any file
+FILE=--
+CMDS=p-
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=p- with malloc://512
+FILE=malloc://512
+CMDS=p-
+EXPECT=<<EOF
+0x00000000 [^__________________________________________] 0x00000200
+EOF
+RUN
+
+NAME=p- bounds
+FILE=malloc://0x1000
+CMDS=<<EOF
+e hex.cols=0
+f test @ 0x1000
+p- 0x40 # 0x1000 % 0x40 = 0
+p- 0xa # 0x1000 % 0xa != 0
+f- test
+f test @ 0xfff
+p- 0x40 # 0x1000 % 0x40 = 0
+p- 0xa # 0x1000 % 0xa != 0
+EOF
+EXPECT=<<EOF
+0x00000000 [^_______________________________________________________________] 0x00001000
+0x00000000 [^_________] 0x00001000
+0x00000000 [^______________________________________________________________.] 0x00001000
+0x00000000 [^________.] 0x00001000
+EOF
+RUN
+
+NAME=p-j
+FILE=malloc://0x1000
+CMDS=<<EOF
+e hex.cols=0
+f test @ 0x1000
+p-j 0x4~{} # 0x1000 % 0x4 = 0
+?e -------
+p-j 0xa~{} # 0x1000 % 0xa != 0
+?e -------
+f- test
+f test @ 0xfff
+af+ hello @ 0x3ff
+afb+ 0x3ff 0x3ff 0x10
+p-j 0x4~{} # 0x1000 % 0x40 = 0
+?e -------
+p-j 0xa~{} # 0x1000 % 0xa != 0
+EOF
+EXPECT=<<EOF
+{
+  "from": 0,
+  "to": 4096,
+  "blocksize": 1024,
+  "blocks": [
+    {
+      "offset": 0,
+      "size": 1024,
+      "perm": "rwx"
+    },
+    {
+      "offset": 1024,
+      "size": 1024,
+      "perm": "rwx"
+    },
+    {
+      "offset": 2048,
+      "size": 1024,
+      "perm": "rwx"
+    },
+    {
+      "offset": 3072,
+      "size": 1024,
+      "perm": "rwx"
+    }
+  ]
+}
+-------
+{
+  "from": 0,
+  "to": 4096,
+  "blocksize": 410,
+  "blocks": [
+    {
+      "offset": 0,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 410,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 820,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 1230,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 1640,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 2050,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 2460,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 2870,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 3280,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 3690,
+      "size": 406,
+      "perm": "rwx"
+    }
+  ]
+}
+-------
+{
+  "from": 0,
+  "to": 4096,
+  "blocksize": 1024,
+  "blocks": [
+    {
+      "offset": 0,
+      "size": 1024,
+      "flags": 1,
+      "functions": 1,
+      "in_functions": 1,
+      "perm": "rwx"
+    },
+    {
+      "offset": 1024,
+      "size": 1024,
+      "in_functions": 1,
+      "perm": "rwx"
+    },
+    {
+      "offset": 2048,
+      "size": 1024,
+      "perm": "rwx"
+    },
+    {
+      "offset": 3072,
+      "size": 1024,
+      "flags": 1,
+      "perm": "rwx"
+    }
+  ]
+}
+-------
+{
+  "from": 0,
+  "to": 4096,
+  "blocksize": 410,
+  "blocks": [
+    {
+      "offset": 0,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 410,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 820,
+      "size": 410,
+      "flags": 1,
+      "functions": 1,
+      "in_functions": 1,
+      "perm": "rwx"
+    },
+    {
+      "offset": 1230,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 1640,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 2050,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 2460,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 2870,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 3280,
+      "size": 410,
+      "perm": "rwx"
+    },
+    {
+      "offset": 3690,
+      "size": 406,
+      "flags": 1,
+      "perm": "rwx"
+    }
+  ]
+}
+EOF
+RUN

--- a/test/db/cmd/cmd_print
+++ b/test/db/cmd/cmd_print
@@ -155,6 +155,34 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=p=Aq
+FILE==
+CMDS=<<EOF
+f test @ 0
+f ulu @ 2
+f mulu @ 0x100
+p=Aq 0x10
+EOF
+EXPECT=<<EOF
+0x00000000 0 2
+0x00000020 1 0
+0x00000040 2 0
+0x00000060 3 0
+0x00000080 4 0
+0x000000a0 5 0
+0x000000c0 6 0
+0x000000e0 7 0
+0x00000100 8 1
+0x00000120 9 0
+0x00000140 10 0
+0x00000160 11 0
+0x00000180 12 0
+0x000001a0 13 0
+0x000001c0 14 0
+0x000001e0 15 0
+EOF
+RUN
+
 NAME=p8 10
 FILE=malloc://1024
 CMDS=wx 90909090909090909090 ; p8 10
@@ -659,21 +687,6 @@ nop
 nop
 nop
 nop
-EOF
-RUN
-
-NAME=p- with "r2 --"
-FILE=--
-CMDS=p-
-EXPECT=<<EOF
-EOF
-RUN
-
-NAME=p- with malloc://512
-FILE=malloc://512
-CMDS=p-
-EXPECT=<<EOF
-0x00000000 [^_____________________________________________] 0x00000200
 EOF
 RUN
 

--- a/test/db/formats/elf/helloworld-gcc-elf
+++ b/test/db/formats/elf/helloworld-gcc-elf
@@ -316,21 +316,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=p-
-FILE=bins/elf/analysis/x86-helloworld-gcc
-CMDS=<<EOF
-s 0x8048000
-e search.in=io.map
-p-
-e search.in=io.maps
-p-
-EOF
-EXPECT=<<EOF
-0x08048000 [^._______ss_s__s_sss_ssssss_ss_ss__sz_s____] 0x0804859c
-0x08048000 [^_sssssszss_____________________________sss] 0x080496d0
-EOF
-RUN
-
 NAME=pu 10
 FILE=bins/elf/analysis/x86-helloworld-gcc
 CMDS=pu 10

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -33,6 +33,7 @@ if get_option('enable_tests')
     'config',
     'cons',
     'contrbtree',
+    'core_analysis_stats',
     'core_bin',
     'core_cmd',
     'core_seek',

--- a/test/unit/test_core_analysis_stats.c
+++ b/test/unit/test_core_analysis_stats.c
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2022 Florian Märkl <info@florianmaerkl.de>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_core.h>
+#include "minunit.h"
+
+bool test_stats_bounds(void) {
+	RzCore *core = rz_core_new();
+
+	rz_flag_set(core->flags, "peri", 7, 1);
+	rz_flag_set(core->flags, "phery", -7, 1);
+	rz_meta_set_string(core->analysis, RZ_META_TYPE_STRING, -0x23, "elephant talk");
+
+	// low extreme
+	RzCoreAnalysisStats *as = rz_core_analysis_get_stats(core, 0, 0xff, 0x20);
+	mu_assert_notnull(as, "stats");
+	mu_assert_eq(rz_vector_len(&as->blocks), 0x100 / 0x20, "blocks count");
+	mu_assert_eq(((RzCoreAnalysisStatsItem *)rz_vector_index_ptr(&as->blocks, 0))->flags, 1, "flags");
+	rz_core_analysis_stats_free(as);
+
+	// high extreme
+	as = rz_core_analysis_get_stats(core, -0x100, UT64_MAX, 0x20);
+	mu_assert_notnull(as, "stats");
+	mu_assert_eq(rz_vector_len(&as->blocks), 0x100 / 0x20, "blocks count");
+	mu_assert_eq(((RzCoreAnalysisStatsItem *)rz_vector_index_ptr(&as->blocks, 7))->flags, 1, "flags");
+	mu_assert_eq(((RzCoreAnalysisStatsItem *)rz_vector_index_ptr(&as->blocks, 7))->strings, 0, "strings");
+	mu_assert_eq(((RzCoreAnalysisStatsItem *)rz_vector_index_ptr(&as->blocks, 6))->strings, 1, "strings");
+	rz_core_analysis_stats_free(as);
+
+	// entire range
+	as = rz_core_analysis_get_stats(core, 0, UT64_MAX, 1ull << 61);
+	mu_assert_notnull(as, "stats");
+	mu_assert_eq(rz_vector_len(&as->blocks), 8, "blocks count");
+	mu_assert_eq(((RzCoreAnalysisStatsItem *)rz_vector_index_ptr(&as->blocks, 7))->flags, 1, "flags");
+	mu_assert_eq(((RzCoreAnalysisStatsItem *)rz_vector_index_ptr(&as->blocks, 7))->strings, 1, "strings");
+	mu_assert_eq(((RzCoreAnalysisStatsItem *)rz_vector_index_ptr(&as->blocks, 6))->flags, 0, "flags");
+	mu_assert_eq(((RzCoreAnalysisStatsItem *)rz_vector_index_ptr(&as->blocks, 6))->strings, 0, "strings");
+	rz_core_analysis_stats_free(as);
+
+	// not divisable
+	as = rz_core_analysis_get_stats(core, 0, UT64_MAX, (1ull << 61) + 3);
+	mu_assert_notnull(as, "stats");
+	mu_assert_eq(rz_vector_len(&as->blocks), 8, "blocks count");
+	mu_assert_eq(((RzCoreAnalysisStatsItem *)rz_vector_index_ptr(&as->blocks, 7))->flags, 1, "flags");
+	mu_assert_eq(((RzCoreAnalysisStatsItem *)rz_vector_index_ptr(&as->blocks, 7))->strings, 1, "strings");
+	mu_assert_eq(((RzCoreAnalysisStatsItem *)rz_vector_index_ptr(&as->blocks, 6))->flags, 0, "flags");
+	mu_assert_eq(((RzCoreAnalysisStatsItem *)rz_vector_index_ptr(&as->blocks, 6))->strings, 0, "strings");
+	rz_core_analysis_stats_free(as);
+
+	rz_core_free(core);
+	mu_end;
+}
+
+int all_tests() {
+	mu_run_test(test_stats_bounds);
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Range is now explicitly inclusive/inclusive to allow generating stats
for the entire 64bit range.
This especially also removes the obscure "Cannot alloc for this range",
which could be observed in Cutter, and adds a more meaningful error to
the p- command whenever no range is available.

**Test plan**

see the added tests