### PR TITLE
Add rz_path_set_prefix to allow setting the prefix path 

### DIFF
--- a/librz/include/rz_util/rz_path.h
+++ b/librz/include/rz_util/rz_path.h
@@ -7,6 +7,7 @@
 extern "C" {
 #endif
 
+RZ_API void rz_path_set_prefix(RZ_NULLABLE const char *path);
 RZ_API RZ_OWN char *rz_path_prefix(RZ_NULLABLE const char *path);
 RZ_API RZ_OWN char *rz_path_incdir(void);
 RZ_API RZ_OWN char *rz_path_bindir(void);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Cutter does not run from bindir when packaged on OSX therefore the bindir path will always fail