### PR TITLE
Fix endian issue and unaligned access in PDB

### DIFF
--- a/librz/bin/pdb/pdb.c
+++ b/librz/bin/pdb/pdb.c
@@ -23,7 +23,7 @@ static bool parse_pdb_stream(RzPdb *pdb, RzPdbMsfStream *stream) {
 		!rz_buf_read_le32(buf, &s->hdr.unique_id.data1) ||
 		!rz_buf_read_le16(buf, &s->hdr.unique_id.data2) ||
 		!rz_buf_read_le16(buf, &s->hdr.unique_id.data3) ||
-		!rz_buf_read_le64(buf, (ut64 *)&s->hdr.unique_id.data4)) {
+		rz_buf_read(buf, s->hdr.unique_id.data4, 8) != 8) {
 		return false;
 	}
 

--- a/librz/include/rz_pdb.h
+++ b/librz/include/rz_pdb.h
@@ -189,6 +189,9 @@ enum pdb_stream_version {
 	VC140 = 20140508,
 };
 
+/**
+ * Like GUID in windows.h/guiddef.h
+ */
 typedef struct {
 	ut32 data1;
 	ut16 data2;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

data4 is not 8-aligned so this would crash on sparc64 when storing the
value. However treating this as ut64 is wrong anyway since it is really
meant to be just an array.

Related to #1931

**Test plan**

Run `test/integration/test_pdb.c` on sparc64