### PR TITLE
Added valid empty json output for mach0 and any other info->rclass

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -4370,8 +4370,12 @@ static void bin_elf_versioninfo(RzCore *r, PJ *pj, int mode) {
 	bin_elf_versioninfo_verneed(r, pj, mode);
 }
 
-static void bin_mach0_versioninfo(RzCore *r) {
+static void bin_mach0_versioninfo(RzCore *r, PJ *pj, int mode) {
 	/* TODO */
+	if (IS_MODE_JSON(mode)) {
+		pj_o(pj);
+		pj_end(pj);
+	}
 }
 
 static int bin_versioninfo(RzCore *r, PJ *pj, int mode) {
@@ -4384,9 +4388,12 @@ static int bin_versioninfo(RzCore *r, PJ *pj, int mode) {
 	} else if (!strncmp("elf", info->rclass, 3)) {
 		bin_elf_versioninfo(r, pj, mode);
 	} else if (!strncmp("mach0", info->rclass, 5)) {
-		bin_mach0_versioninfo(r);
+		bin_mach0_versioninfo(r, pj, mode);
 	} else {
-		if (mode != RZ_MODE_JSON) {
+		if (IS_MODE_JSON(mode)) {
+			pj_o(pj);
+			pj_end(pj);
+		} else {
 			rz_cons_println("Unknown format");
 		}
 		return false;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixed `iVj` output for mach0 (which is not implemented) and handled the else block also