### PR TITLE
RzCore: read core block before printing

### DIFF
--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -7265,6 +7265,8 @@ static void core_disassembly_n_instructions(RzCore *core, int n_instrs, RzCmdSta
 			rz_core_block_size(core, new_blocksize);
 		}
 		rz_core_seek(core, new_offset, true);
+	} else {
+		rz_core_block_read(core);
 	}
 
 	switch (state->mode) {
@@ -7622,7 +7624,10 @@ RZ_IPI RzCmdStatus rz_cmd_disassembly_n_instrs_as_text_json_handler(RzCore *core
 			rz_core_block_size(core, new_blocksize);
 		}
 		rz_core_seek(core, new_offset, true);
+	} else {
+		rz_core_block_read(core);
 	}
+
 	if (rz_cons_singleton()->is_html) {
 		rz_cons_singleton()->is_html = false;
 		rz_cons_singleton()->was_html = true;
@@ -7681,6 +7686,8 @@ RZ_IPI RzCmdStatus rz_cmd_sizes_of_n_instructions_handler(RzCore *core, int argc
 			rz_core_block_size(core, new_blocksize);
 		}
 		rz_core_seek(core, new_offset, true);
+	} else {
+		rz_core_block_read(core);
 	}
 
 	rz_cmd_state_output_array_start(state);

--- a/test/db/archos/linux-x64/dbg_bps
+++ b/test/db/archos/linux-x64/dbg_bps
@@ -267,3 +267,28 @@ EXPECT=<<EOF
 hw
 EOF
 RUN
+
+NAME=read core->block on short move
+FILE=bins/elf/analysis/x64-loop
+ARGS=-d
+CMDS=<<EOF
+e scr.color=0 asm.offset=false asm.flags=false asm.functions=false asm.lines=false asm.fcn.size=false asm.comments=false asm.dwarf=false asm.indent=false
+dcu main
+pd 5
+dbH @i:2
+dc
+pd 5
+EOF
+EXPECT=<<EOF
+     push  rbp
+     mov   rbp, rsp
+     sub   rsp, 0x20
+     mov   dword [rbp - 0x14], edi
+     mov   qword [rbp - 0x20], rsi
+b    sub   rsp, 0x20
+     mov   dword [rbp - 0x14], edi
+     mov   qword [rbp - 0x20], rsi
+     mov   dword [rbp - 4], 0
+     jmp   0x400523
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

With the new `pd` conversion to newshell, it seems that those commands directly use `core->block`, which when setting hardware breakpoints (possibly also in other cases) might be outdated. In general, I think we should try to remove core->block as much as possible and maybe use an internal(transparent) cache within RzCore/RzIo.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

See issue.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes https://github.com/rizinorg/rizin/issues/2692
