### PR TITLE
Fix RzIODescData magic checks (Fix #2696)

### DIFF
--- a/librz/include/rz_io.h
+++ b/librz/include/rz_io.h
@@ -105,7 +105,7 @@ typedef struct rz_io_desc_t {
 } RzIODesc;
 
 typedef struct {
-	ut32 magic;
+	ut64 magic;
 	int pid;
 	int tid;
 	void *data;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fix a regression from 7672170c001d55691288edf476aeefcc211fd85c:
The native macOS debugger was broken because of the full 64bit hash
being compared to a truncated version of itself.
This magic is probably entirely superfluous, but we first restore the
functionality as it was before.

**Test plan**

On macOS, `rz -d <some executable>` should show some code/data of the process.

Fix #2696