### PR TITLE
Remove RZ_BIN_STRING_ENC_* in favor of RZ_STRING_ENC_*

### DIFF
--- a/librz/bin/bfile.c
+++ b/librz/bin/bfile.c
@@ -27,64 +27,11 @@ static RzBinString *__stringAt(RzBinFile *bf, RzList *ret, ut64 addr) {
 	return NULL;
 }
 
-static inline void detected_string_to_bin_string(RzBinString *dst, RzDetectedString *src) {
-	int type = -1;
-	switch (src->type) {
-	case RZ_STRING_ENC_8BIT:
-		type = RZ_BIN_STRING_ENC_8BIT;
-		break;
-	case RZ_STRING_ENC_UTF8:
-		type = RZ_BIN_STRING_ENC_UTF8;
-		break;
-	case RZ_STRING_ENC_UTF16LE:
-		type = RZ_BIN_STRING_ENC_WIDE_LE;
-		break;
-	case RZ_STRING_ENC_UTF32LE:
-		type = RZ_BIN_STRING_ENC_WIDE32_LE;
-		break;
-	case RZ_STRING_ENC_UTF16BE:
-		type = RZ_BIN_STRING_ENC_WIDE_BE;
-		break;
-	case RZ_STRING_ENC_UTF32BE:
-		type = RZ_BIN_STRING_ENC_WIDE32_BE;
-		break;
-	case RZ_STRING_ENC_IBM037:
-		type = RZ_BIN_STRING_ENC_IBM037;
-		break;
-	case RZ_STRING_ENC_IBM290:
-		type = RZ_BIN_STRING_ENC_IBM290;
-		break;
-	case RZ_STRING_ENC_EBCDIC_ES:
-		type = RZ_BIN_STRING_ENC_EBCDIC_ES;
-		break;
-	case RZ_STRING_ENC_EBCDIC_UK:
-		type = RZ_BIN_STRING_ENC_EBCDIC_UK;
-		break;
-	case RZ_STRING_ENC_EBCDIC_US:
-		type = RZ_BIN_STRING_ENC_EBCDIC_US;
-		break;
-	case RZ_STRING_ENC_GUESS:
-		type = RZ_BIN_STRING_ENC_DETECT;
-		break;
-	default:
-		break;
-	}
-
-	dst->string = src->string;
-	dst->size = src->size;
-	dst->length = src->length;
-	dst->type = type;
-	dst->paddr = src->addr;
-	dst->vaddr = src->addr;
-
-	free(src);
-}
-
 static void string_scan_range(RzList *list, RzBinFile *bf, size_t min, const ut64 from, const ut64 to, RzStrEnc type) {
 	RzListIter *it;
-	RzDetectedString *str;
+	RzDetectedString *detected;
 
-	RzList *str_list = rz_list_new();
+	RzList *str_list = rz_list_newf(free);
 	if (!str_list) {
 		return;
 	}
@@ -104,16 +51,26 @@ static void string_scan_range(RzList *list, RzBinFile *bf, size_t min, const ut6
 	}
 
 	int ord = 0;
-	rz_list_foreach (str_list, it, str) {
-		RzBinString *bs = RZ_NEW0(RzBinString);
-		detected_string_to_bin_string(bs, str);
-		bs->ordinal = ord++;
-		if (bf->o) {
-			bs->paddr += bf->o->boffset;
-			bs->vaddr = rz_bin_object_p2v(bf->o, bs->paddr);
-			ht_up_insert(bf->o->strings_db, bs->vaddr, bs);
+	rz_list_foreach (str_list, it, detected) {
+		RzBinString *bstr = RZ_NEW0(RzBinString);
+		if (!bstr) {
+			RZ_LOG_ERROR("Cannot allocate RzBinString\n");
+			break;
 		}
-		rz_list_append(list, bs);
+
+		bstr->string = detected->string;
+		bstr->size = detected->size;
+		bstr->length = detected->length;
+		bstr->type = detected->type;
+		bstr->paddr = detected->addr;
+		bstr->vaddr = detected->addr;
+		bstr->ordinal = ord++;
+		if (bf->o) {
+			bstr->paddr += bf->o->boffset;
+			bstr->vaddr = rz_bin_object_p2v(bf->o, bstr->paddr);
+			ht_up_insert(bf->o->strings_db, bstr->vaddr, bstr);
+		}
+		rz_list_append(list, bstr);
 	}
 
 	rz_list_free(str_list);

--- a/librz/bin/bfile.c
+++ b/librz/bin/bfile.c
@@ -31,7 +31,7 @@ static void string_scan_range(RzList *list, RzBinFile *bf, size_t min, const ut6
 	RzListIter *it;
 	RzDetectedString *detected;
 
-	RzList *str_list = rz_list_newf(free);
+	RzList *str_list = rz_list_newf((RzListFree)rz_detected_string_free);
 	if (!str_list) {
 		return;
 	}
@@ -58,7 +58,7 @@ static void string_scan_range(RzList *list, RzBinFile *bf, size_t min, const ut6
 			break;
 		}
 
-		bstr->string = detected->string;
+		RZ_PTR_MOVE(bstr->string, detected->string);
 		bstr->size = detected->size;
 		bstr->length = detected->length;
 		bstr->type = detected->type;

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -69,25 +69,6 @@ RZ_API RzBinXtrData *rz_bin_xtrdata_new(RzBuffer *buf, ut64 offset, ut64 size, u
 	return data;
 }
 
-RZ_API RZ_BORROW const char *rz_bin_string_type(int type) {
-	switch (type) {
-	case RZ_BIN_STRING_ENC_8BIT: return "ascii";
-	case RZ_BIN_STRING_ENC_UTF8: return "utf8";
-	case RZ_BIN_STRING_ENC_MUTF8: return "mutf8";
-	case RZ_BIN_STRING_ENC_WIDE_LE: return "utf16le";
-	case RZ_BIN_STRING_ENC_WIDE32_LE: return "utf32le";
-	case RZ_BIN_STRING_ENC_WIDE_BE: return "utf16be";
-	case RZ_BIN_STRING_ENC_WIDE32_BE: return "utf32be";
-	case RZ_BIN_STRING_ENC_BASE64: return "base64";
-	case RZ_STRING_ENC_IBM037: return "ibm037";
-	case RZ_STRING_ENC_IBM290: return "ibm290";
-	case RZ_STRING_ENC_EBCDIC_ES: return "ebcdices";
-	case RZ_STRING_ENC_EBCDIC_UK: return "ebcdicuk";
-	case RZ_STRING_ENC_EBCDIC_US: return "ebcdicus";
-	}
-	return "ascii"; // XXX
-}
-
 RZ_API void rz_bin_xtrdata_free(void /*RzBinXtrData*/ *data_) {
 	RzBinXtrData *data = data_;
 	rz_return_if_fail(data);

--- a/librz/bin/bobj.c
+++ b/librz/bin/bobj.c
@@ -639,7 +639,7 @@ RZ_IPI void rz_bin_object_filter_strings(RzBinObject *bo) {
 			if (rz_str_is_printable(dec) && strlen(dec) > 3) {
 				free(ptr->string);
 				ptr->string = dec;
-				ptr->type = RZ_BIN_STRING_ENC_BASE64;
+				ptr->type = RZ_STRING_ENC_BASE64;
 			} else {
 				free(dec);
 			}

--- a/librz/bin/format/dex/dex.c
+++ b/librz/bin/format/dex/dex.c
@@ -755,7 +755,7 @@ RZ_API RZ_OWN RzList /*<RzBinString*>*/ *rz_bin_dex_strings(RZ_NONNULL RzBinDex 
 		bstr->length = string->size;
 		bstr->size = string->size;
 		bstr->string = rz_str_ndup(string->data, string->size);
-		bstr->type = RZ_BIN_STRING_ENC_UTF8;
+		bstr->type = RZ_STRING_ENC_UTF8;
 		if (!rz_list_append(strings, bstr)) {
 			free(bstr);
 		}

--- a/librz/bin/format/java/class_bin.c
+++ b/librz/bin/format/java/class_bin.c
@@ -1014,7 +1014,7 @@ RZ_API RZ_OWN RzList *rz_bin_java_class_strings(RZ_NONNULL RzBinJavaClass *bin) 
 			bstr->length = cpool->size;
 			bstr->size = cpool->size;
 			bstr->string = string;
-			bstr->type = RZ_BIN_STRING_ENC_MUTF8;
+			bstr->type = RZ_STRING_ENC_MUTF8;
 			rz_list_append(list, bstr);
 		}
 	}
@@ -1032,7 +1032,7 @@ RZ_API RZ_OWN RzList *rz_bin_java_class_strings(RZ_NONNULL RzBinJavaClass *bin) 
 			bstr->length = attr->attribute_length;
 			bstr->size = attr->attribute_length;
 			bstr->string = strdup(attr->info);
-			bstr->type = RZ_BIN_STRING_ENC_UTF8;
+			bstr->type = RZ_STRING_ENC_UTF8;
 			rz_list_append(list, bstr);
 		}
 	}

--- a/librz/bin/format/luac/luac_bin.c
+++ b/librz/bin/format/luac/luac_bin.c
@@ -65,6 +65,7 @@ void luac_add_string(RzList *string_list, char *string, ut64 offset, ut64 size) 
 	bin_string->size = size;
 	bin_string->length = size;
 	bin_string->string = rz_str_new(string);
+	bin_string->type = RZ_STRING_ENC_UTF8;
 
 	rz_list_append(string_list, bin_string);
 }

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -2668,7 +2668,7 @@ static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzList *l
 
 		section = obj ? rz_bin_get_section_at(obj, paddr, 0) : NULL;
 		section_name = section ? section->name : "";
-		type_string = rz_bin_string_type(string->type);
+		type_string = rz_str_enc_as_string(string->type);
 		if (b64str) {
 			ut8 *s = rz_base64_decode_dyn(string->string, -1);
 			if (s && *s && IS_PRINTABLE(*s)) {
@@ -2702,10 +2702,10 @@ static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzList *l
 			pj_ks(state->d.pj, "string", escaped_string);
 
 			switch (string->type) {
-			case RZ_BIN_STRING_ENC_UTF8:
-			case RZ_BIN_STRING_ENC_MUTF8:
-			case RZ_BIN_STRING_ENC_WIDE_LE:
-			case RZ_BIN_STRING_ENC_WIDE32_LE:
+			case RZ_STRING_ENC_UTF8:
+			case RZ_STRING_ENC_MUTF8:
+			case RZ_STRING_ENC_UTF16LE:
+			case RZ_STRING_ENC_UTF32LE:
 				block_list = rz_utf_block_list((const ut8 *)string->string, -1, NULL);
 				if (block_list) {
 					if (block_list[0] == 0 && block_list[1] == -1) {
@@ -2756,10 +2756,10 @@ static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzList *l
 
 			RzStrBuf *buf = rz_strbuf_new(str);
 			switch (string->type) {
-			case RZ_BIN_STRING_ENC_UTF8:
-			case RZ_BIN_STRING_ENC_MUTF8:
-			case RZ_BIN_STRING_ENC_WIDE_LE:
-			case RZ_BIN_STRING_ENC_WIDE32_LE:
+			case RZ_STRING_ENC_UTF8:
+			case RZ_STRING_ENC_MUTF8:
+			case RZ_STRING_ENC_UTF16LE:
+			case RZ_STRING_ENC_UTF32LE:
 				block_list = rz_utf_block_list((const ut8 *)string->string, -1, NULL);
 				if (block_list) {
 					if (block_list[0] == 0 && block_list[1] == -1) {

--- a/librz/core/golang.c
+++ b/librz/core/golang.c
@@ -518,7 +518,7 @@ static bool add_new_bin_string(RzCore *core, char *string, ut64 vaddr, ut32 size
 	bstr->ordinal = rz_list_length(bf->o->strings);
 	bstr->length = bstr->size = size;
 	bstr->string = string;
-	bstr->type = RZ_BIN_STRING_ENC_UTF8;
+	bstr->type = RZ_STRING_ENC_UTF8;
 	if (!rz_list_append(bf->o->strings, bstr)) {
 		RZ_LOG_ERROR("Failed append new go string to strings list\n");
 		rz_bin_string_free(bstr);

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -162,23 +162,6 @@ typedef enum {
 #define RZ_BIN_LANGUAGE_HAS_BLOCKS(x) ((x)&RZ_BIN_LANGUAGE_BLOCKS)
 
 enum {
-	RZ_BIN_STRING_ENC_DETECT = 'g',
-	RZ_BIN_STRING_ENC_8BIT = 'b', // unknown 8bit encoding but with ASCII from 0 to 0x7f
-	RZ_BIN_STRING_ENC_UTF8 = '8',
-	RZ_BIN_STRING_ENC_MUTF8 = 'm', // modified utf8
-	RZ_BIN_STRING_ENC_WIDE_LE = 'u', // utf16 / widechar string
-	RZ_BIN_STRING_ENC_WIDE32_LE = 'U', // utf32
-	RZ_BIN_STRING_ENC_WIDE_BE = 'n', // utf16-be / widechar string
-	RZ_BIN_STRING_ENC_WIDE32_BE = 'N', // utf32-be
-	RZ_BIN_STRING_ENC_BASE64 = '6',
-	RZ_BIN_STRING_ENC_IBM037 = 'c',
-	RZ_BIN_STRING_ENC_IBM290 = 'd',
-	RZ_BIN_STRING_ENC_EBCDIC_UK = 'k',
-	RZ_BIN_STRING_ENC_EBCDIC_US = 's',
-	RZ_BIN_STRING_ENC_EBCDIC_ES = 't',
-};
-
-enum {
 	RZ_BIN_CLASS_PRIVATE,
 	RZ_BIN_CLASS_PUBLIC,
 	RZ_BIN_CLASS_FRIENDLY,
@@ -979,7 +962,6 @@ RZ_API bool rz_bin_select_bfid(RzBin *bin, ut32 bf_id);
 RZ_API bool rz_bin_use_arch(RzBin *bin, const char *arch, int bits, const char *name);
 RZ_API RzBuffer *rz_bin_create(RzBin *bin, const char *plugin_name, const ut8 *code, int codelen, const ut8 *data, int datalen, RzBinArchOptions *opt);
 
-RZ_API RZ_BORROW const char *rz_bin_string_type(int type);
 RZ_API const char *rz_bin_entry_type_string(int etype);
 
 RZ_API bool rz_bin_file_object_new_from_xtr_data(RzBin *bin, RzBinFile *bf, RzBinObjectLoadOptions *opts, RzBinXtrData *data);

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -18,10 +18,12 @@ typedef enum {
 typedef enum {
 	RZ_STRING_ENC_8BIT = 'b', // unknown 8bit encoding but with ASCII from 0 to 0x7f
 	RZ_STRING_ENC_UTF8 = '8',
+	RZ_STRING_ENC_MUTF8 = 'm', // modified utf8
 	RZ_STRING_ENC_UTF16LE = 'u',
 	RZ_STRING_ENC_UTF32LE = 'U',
 	RZ_STRING_ENC_UTF16BE = 'n',
 	RZ_STRING_ENC_UTF32BE = 'N',
+	RZ_STRING_ENC_BASE64 = '6',
 	RZ_STRING_ENC_IBM037 = 'c',
 	RZ_STRING_ENC_IBM290 = 'd',
 	RZ_STRING_ENC_EBCDIC_UK = 'k',
@@ -66,6 +68,7 @@ typedef int (*RzStrRangeCallback)(void *, int);
 #define RZ_STR_DUP(x)        ((x) ? strdup((x)) : NULL)
 #define rz_str_array(x, y)   ((y >= 0 && y < (sizeof(x) / sizeof(*x))) ? x[y] : "")
 RZ_API const char *rz_str_enc_as_string(RzStrEnc enc);
+RZ_API RzStrEnc rz_str_enc_string_as_type(RZ_NULLABLE const char *enc);
 RZ_API char *rz_str_repeat(const char *ch, int sz);
 RZ_API const char *rz_str_pad(const char ch, int len);
 RZ_API const char *rz_str_rstr(const char *base, const char *p);

--- a/librz/main/rz-bin.c
+++ b/librz/main/rz-bin.c
@@ -657,7 +657,7 @@ static void print_string(RzBinFile *bf, RzBinString *string, PJ *pj, int mode) {
 		string->vaddr = s->vaddr + (string->paddr - s->paddr);
 	}
 	vaddr = bf->o ? rz_bin_object_get_vaddr(bf->o, string->paddr, string->vaddr) : UT64_MAX;
-	const char *type_string = rz_bin_string_type(string->type);
+	const char *type_string = rz_str_enc_as_string(string->type);
 	const char *section_name = s ? s->name : "";
 
 	switch (mode) {

--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -153,7 +153,7 @@ static void print_bin_string(RzBinFile *bf, RzBinString *string, PJ *pj) {
 
 	if (pj) {
 		const char *section_name = s ? s->name : "";
-		const char *type_string = rz_bin_string_type(string->type);
+		const char *type_string = rz_str_enc_as_string(string->type);
 		pj_o(pj);
 		pj_kn(pj, "vaddr", string->vaddr);
 		pj_kn(pj, "paddr", string->paddr);

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -85,7 +85,7 @@ RZ_API const char *rz_str_enc_as_string(RzStrEnc enc) {
 RZ_API RzStrEnc rz_str_enc_string_as_type(RZ_NULLABLE const char *encoding) {
 	if (!encoding || !strncmp(encoding, "guess", 5)) {
 		return RZ_STRING_ENC_GUESS;
-	} else if (!strcmp(encoding, "ascii")) {
+	} else if (!strcmp(encoding, "ascii") || !strcmp(encoding, "8bit")) {
 		return RZ_STRING_ENC_8BIT;
 	} else if (!strcmp(encoding, "mutf8")) {
 		return RZ_STRING_ENC_MUTF8;

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -43,9 +43,11 @@ static const char *rwxstr[] = {
 RZ_API const char *rz_str_enc_as_string(RzStrEnc enc) {
 	switch (enc) {
 	case RZ_STRING_ENC_8BIT:
-		return "8bit";
+		return "ascii";
 	case RZ_STRING_ENC_UTF8:
 		return "utf8";
+	case RZ_STRING_ENC_MUTF8:
+		return "mutf8";
 	case RZ_STRING_ENC_UTF16LE:
 		return "utf16le";
 	case RZ_STRING_ENC_UTF32LE:
@@ -54,22 +56,65 @@ RZ_API const char *rz_str_enc_as_string(RzStrEnc enc) {
 		return "utf16be";
 	case RZ_STRING_ENC_UTF32BE:
 		return "utf32be";
+	case RZ_STRING_ENC_BASE64:
+		return "base64";
 	case RZ_STRING_ENC_IBM037:
 		return "ibm037";
 	case RZ_STRING_ENC_IBM290:
 		return "ibm290";
-	case RZ_STRING_ENC_EBCDIC_UK:
-		return "ebcdic_uk";
-	case RZ_STRING_ENC_EBCDIC_US:
-		return "ebcdic_us";
 	case RZ_STRING_ENC_EBCDIC_ES:
-		return "ebcdic_es";
+		return "ebcdices";
+	case RZ_STRING_ENC_EBCDIC_UK:
+		return "ebcdicuk";
+	case RZ_STRING_ENC_EBCDIC_US:
+		return "ebcdicus";
 	case RZ_STRING_ENC_GUESS:
 		return "guessed";
 	default:
 		rz_warn_if_reached();
 		return "unknown";
 	}
+}
+
+/**
+ * \brief      converts an encoding name to RzStrEnc
+ *
+ * \param[in]  encoding Encoding name
+ * \return     Returns a RzStrEnc type.
+ */
+RZ_API RzStrEnc rz_str_enc_string_as_type(RZ_NULLABLE const char *encoding) {
+	if (!encoding || !strncmp(encoding, "guess", 5)) {
+		return RZ_STRING_ENC_GUESS;
+	} else if (!strcmp(encoding, "ascii")) {
+		return RZ_STRING_ENC_8BIT;
+	} else if (!strcmp(encoding, "mutf8")) {
+		return RZ_STRING_ENC_MUTF8;
+	} else if (!strcmp(encoding, "utf8")) {
+		return RZ_STRING_ENC_UTF8;
+	} else if (!strcmp(encoding, "utf16le")) {
+		return RZ_STRING_ENC_UTF16LE;
+	} else if (!strcmp(encoding, "utf32le")) {
+		return RZ_STRING_ENC_UTF32LE;
+	} else if (!strcmp(encoding, "utf16be")) {
+		return RZ_STRING_ENC_UTF16BE;
+	} else if (!strcmp(encoding, "utf32be")) {
+		return RZ_STRING_ENC_UTF32BE;
+	} else if (!strcmp(encoding, "ibm037")) {
+		return RZ_STRING_ENC_IBM037;
+	} else if (!strcmp(encoding, "ibm290")) {
+		return RZ_STRING_ENC_IBM290;
+	} else if (!strcmp(encoding, "ebcdices")) {
+		return RZ_STRING_ENC_EBCDIC_ES;
+	} else if (!strcmp(encoding, "ebcdicuk")) {
+		return RZ_STRING_ENC_EBCDIC_UK;
+	} else if (!strcmp(encoding, "ebcdicus")) {
+		return RZ_STRING_ENC_EBCDIC_US;
+	} else if (!strcmp(encoding, "base64")) {
+		return RZ_STRING_ENC_BASE64;
+	}
+
+	RZ_LOG_ERROR("rz_str: encoding %s not supported\n", encoding);
+	return RZ_STRING_ENC_GUESS;
 }
 
 RZ_API int rz_str_casecmp(const char *s1, const char *s2) {

--- a/test/db/cmd/cmd_psj
+++ b/test/db/cmd/cmd_psj
@@ -5,7 +5,7 @@ wx 72697a696e20697320636f6f6c
 psj 13
 EOF
 EXPECT=<<EOF
-{"string":"rizin is cool","offset":0,"section":"unknown","length":13,"type":"8bit"}
+{"string":"rizin is cool","offset":0,"section":"unknown","length":13,"type":"ascii"}
 EOF
 RUN
 
@@ -16,7 +16,7 @@ s 0x00008358
 psj 11
 EOF
 EXPECT=<<EOF
-{"string":"Hello World","offset":33624,"section":".rodata","length":11,"type":"8bit"}
+{"string":"Hello World","offset":33624,"section":".rodata","length":11,"type":"ascii"}
 EOF
 RUN
 

--- a/test/db/cmd/metadata
+++ b/test/db/cmd/metadata
@@ -375,7 +375,7 @@ Ch 2 @ 0x00000200
 Cf 4 x @ 0x00000300
 Cm 8 wwww @ 0x00000380
 ----
-[{"offset":0,"type":"Cs","name":"aGVsbG8gd29ybGQ=","enc":"8bit","ascii":true}]
+[{"offset":0,"type":"Cs","name":"aGVsbG8gd29ybGQ=","enc":"ascii","ascii":true}]
 ----
 [{"offset":256,"type":"Cd","name":"3","size":3}]
 ----
@@ -387,7 +387,7 @@ Cm 8 wwww @ 0x00000380
 ----
 [{"offset":896,"type":"Cm","name":"wwww"}]
 ----
-[{"offset":0,"type":"Cs","name":"aGVsbG8gd29ybGQ=","enc":"8bit","ascii":true},{"offset":0,"type":"CCu","name":"Hello!"},{"offset":256,"type":"Cd","name":"3","size":3},{"offset":512,"type":"Ch","name":"2"},{"offset":768,"type":"Cf","name":"x"},{"offset":896,"type":"Cm","name":"wwww"}]
+[{"offset":0,"type":"Cs","name":"aGVsbG8gd29ybGQ=","enc":"ascii","ascii":true},{"offset":0,"type":"CCu","name":"Hello!"},{"offset":256,"type":"Cd","name":"3","size":3},{"offset":512,"type":"Ch","name":"2"},{"offset":768,"type":"Cf","name":"x"},{"offset":896,"type":"Cm","name":"wwww"}]
 EOF
 RUN
 
@@ -414,7 +414,7 @@ Csb @ 0x1400160b8
 Cslj
 EOF
 EXPECT=<<EOF
-[{"offset":5368799392,"type":"Cs","name":"bGF0aW4xIGdhdGU6IM67q84=","enc":"8bit","ascii":false},{"offset":5368799416,"type":"Cs","name":"ICAtLSBpbiBDb25FbXUsIHJ1biBgY2hjcCAyODU5MWAgdG8gc2VlIHRoZSBnYXRlLg==","enc":"8bit","ascii":true}]
+[{"offset":5368799392,"type":"Cs","name":"bGF0aW4xIGdhdGU6IM67q84=","enc":"ascii","ascii":false},{"offset":5368799416,"type":"Cs","name":"ICAtLSBpbiBDb25FbXUsIHJ1biBgY2hjcCAyODU5MWAgdG8gc2VlIHRoZSBnYXRlLg==","enc":"ascii","ascii":true}]
 EOF
 RUN
 
@@ -480,7 +480,7 @@ Cslj
 EOF
 EXPECT=<<EOF
 [{"offset":5368799256,"type":"Cs","name":"CXdpZGVcZXNjOiAbWzBtwqENCg==","enc":"utf16le","ascii":false}]
-[{"offset":5368799256,"type":"Cs","name":"CQ==","enc":"8bit","ascii":true}]
+[{"offset":5368799256,"type":"Cs","name":"CQ==","enc":"ascii","ascii":true}]
 [{"offset":5368799256,"type":"Cs","name":"CXdpZGVcZXNjOiAbWzBtwqENCg==","enc":"utf16le","ascii":false}]
 [{"offset":5368799256,"type":"Cs","name":"CXdpZGVcZXNjOiAbWzBtwqENCg==","enc":"utf16le","ascii":false}]
 EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Removes `RZ_BIN_STRING_ENC_*` enums which are a dup of `RZ_STRING_ENC_*` enums.