### PR TITLE
rz-test: do not use rz_vector_insert if there are no tests to add

### DIFF
--- a/binrz/rz-test/rz-test.c
+++ b/binrz/rz-test/rz-test.c
@@ -483,7 +483,11 @@ int rz_test_main(int argc, const char **argv) {
 		}
 	}
 
-	rz_pvector_insert_range(&state.queue, 0, state.db->tests.v.a, rz_pvector_len(&state.db->tests));
+	if (rz_pvector_len(&state.db->tests) != 0) {
+		rz_pvector_insert_range(&state.queue, 0, state.db->tests.v.a, rz_pvector_len(&state.db->tests));
+	} else {
+		eprintf("No tests discovered\n");
+	}
 
 	if (log_mode) {
 		// Log mode prints the state after every completed file.


### PR DESCRIPTION
```
rz-test -i db/archos/darwin-x64/dbg
Running from /Users/ret2libc/workspace/rizinorg/rizin/test
Loaded 0 tests.
Skipping json tests because jq is not available.
No tests discovered
WARNING: rz_vector_index_ptr: assertion 'vec && index < vec->capacity' failed (line 89)
[0/0]                       0 OK         0 BR        0 XX        0 FX
Finished in 0 seconds.
```