### PR TITLE
Fix use after free in profile.c

### DIFF
--- a/librz/reg/profile.c
+++ b/librz/reg/profile.c
@@ -61,12 +61,13 @@ static bool parse_type(RZ_OUT RzRegProfileDef *def, const char *type_str) {
 			def->arena_type = def->type;
 		}
 	}
-	free(s);
+	bool res = true;
 	if (def->type < 0 || def->arena_type < 0) {
 		RZ_LOG_WARN("Illegal type appreviation \"%s\"\n", s);
-		return false;
+		res = false;
 	}
-	return true;
+	free(s);
+	return res;
 }
 
 /**

--- a/librz/reg/profile.c
+++ b/librz/reg/profile.c
@@ -63,7 +63,7 @@ static bool parse_type(RZ_OUT RzRegProfileDef *def, const char *type_str) {
 	}
 	bool res = true;
 	if (def->type < 0 || def->arena_type < 0) {
-		RZ_LOG_WARN("Illegal type appreviation \"%s\"\n", s);
+		RZ_LOG_ERROR("Illegal type abbreviation \"%s\"\n", s);
 		res = false;
 	}
 	free(s);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
Resolves the following warning:

```
In file included from ../librz/reg/profile.c:5:
In function ‘parse_type’,
    inlined from ‘parse_def’ at ../librz/reg/profile.c:181:7,
    inlined from ‘parse_reg_profile_str’ at ../librz/reg/profile.c:294:6,
    inlined from ‘rz_reg_set_profile_string’ at ../librz/reg/profile.c:410:7:
../librz/include/rz_util/rz_log.h:55:34: warning: pointer ‘s’ may be used after ‘free’ [-Wuse-after-free]
   55 | #define RZ_LOG_WARN(fmtstr, ...) rz_log(MACRO_LOG_FUNC, __FILE__, \
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   56 |         __LINE__, RZ_LOGLVL_WARN, NULL, fmtstr, ##__VA_ARGS__);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../librz/reg/profile.c:66:17: note: in expansion of macro ‘RZ_LOG_WARN’
   66 |                 RZ_LOG_WARN("Illegal type appreviation \"%s\"\n", s);
      |                 ^~~~~~~~~~~
../librz/reg/profile.c:64:9: note: call to ‘free’ here
   64 |         free(s);
      |         ^~~~~~~
```