### PR TITLE
Update `rz_sys_breakpoint` proposal.

### DIFF
--- a/librz/include/rz_util/rz_sys.h
+++ b/librz/include/rz_util/rz_sys.h
@@ -136,6 +136,15 @@ RZ_API char *rz_sys_cmd_strf(const char *cmd, ...) RZ_PRINTF_CHECK(1, 2);
 //#define rz_sys_cmd_str(cmd, input, len) rz_sys_cmd_str_full(cmd, input, len, 0)
 RZ_API void rz_sys_backtrace(void);
 
+#ifndef __has_builtin
+#define __has_builtin(n) (0)
+#endif
+
+#if __has_builtin(__builtin_debugtrap)
+#define rz_sys_breakpoint() __builtin_debugtrap()
+#endif
+
+#ifndef rz_sys_breakpoint
 #if __WINDOWS__
 #define rz_sys_breakpoint() \
 	{ __debugbreak(); }
@@ -171,6 +180,7 @@ RZ_API void rz_sys_backtrace(void);
 		char *a = NULL; \
 		*a = 0; \
 	}
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
When available, using `__builtin_debugtrap` which plays better
with debuggers than `__builtin_trap` (SIGTRAP vs SIGILL).

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)