### PR TITLE
Fix the crash of command fg

### DIFF
--- a/librz/core/cmd/cmd_flag.c
+++ b/librz/core/cmd/cmd_flag.c
@@ -136,7 +136,6 @@ static void __printRecursive(RzCore *core, RzList *flags, const char *name, RzOu
 	RzListIter *iter;
 	if (mode == RZ_OUTPUT_MODE_RIZIN && RZ_STR_ISEMPTY(name)) {
 		rz_cons_printf("agn root\n");
-		return;
 	}
 	if (rz_flag_get(core->flags, name)) {
 		return;
@@ -299,7 +298,11 @@ RZ_IPI RzCmdStatus rz_flag_local_list_all_handler(RzCore *core, int argc, const 
 RZ_IPI RzCmdStatus rz_flag_graph_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
 	RzList *flags = rz_list_newf(NULL);
 	rz_flag_foreach_space(core->flags, rz_flag_space_cur(core->flags), listFlag, flags);
-	__printRecursive(core, flags, argv[1], state->mode, 0);
+	if (!argv[1]) {
+		__printRecursive(core, flags, "\0", state->mode, 0);
+	} else {
+		__printRecursive(core, flags, argv[1], state->mode, 0);
+	}
 	rz_list_free(flags);
 	return RZ_CMD_STATUS_OK;
 }

--- a/librz/core/cmd/cmd_flag.c
+++ b/librz/core/cmd/cmd_flag.c
@@ -299,7 +299,7 @@ RZ_IPI RzCmdStatus rz_flag_graph_handler(RzCore *core, int argc, const char **ar
 	RzList *flags = rz_list_newf(NULL);
 	rz_flag_foreach_space(core->flags, rz_flag_space_cur(core->flags), listFlag, flags);
 	if (!argv[1]) {
-		__printRecursive(core, flags, "\0", state->mode, 0);
+		__printRecursive(core, flags, "", state->mode, 0);
 	} else {
 		__printRecursive(core, flags, argv[1], state->mode, 0);
 	}

--- a/test/db/cmd/cmd_flags
+++ b/test/db/cmd/cmd_flags
@@ -652,3 +652,40 @@ EXPECT=<<EOF
 0x00000000 64 segment.ehdr
 EOF
 RUN
+
+NAME=show the flag graph
+FILE=bins/elf/ls
+CMDS=<<EOF
+fg section
+EOF
+EXPECT=<<EOF
+        ..in
+            terp
+            it
+        ..note.
+               ABI_tag
+               gnu.build_id
+        ..g
+           nu.
+              hash
+              version
+           nu.version
+           ot
+        ..d
+           yn
+             s
+              ym
+              tr
+             str
+             amic
+           ynstr
+           ata
+        ..r
+           ela.dyn
+           odata
+        ..text
+        ..fini
+        ..eh_frame
+        ..bss
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
Reproduce the crash:
 - rizin /bin/ls
 - fg

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->
CI is green
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...

**Addition**

```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==55838==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7f2e05d607fd bp 0x7ffef7c8e3e0 sp 0x7ffef7c8db78 T0)
==55838==The signal is caused by a READ memory access.
==55838==Hint: address points to the zero page.
    #0 0x7f2e05d607fd  (/usr/lib/libc.so.6+0x1607fd)
    #1 0x7f2e07447351 in __interceptor_strlen /usr/src/debug/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:387
    #2 0x7f2e06da696b in calcsize_key ../subprojects/sdb/src/ht_inc.c:36
    #3 0x7f2e06da696b in ht_pp_find_kv ../subprojects/sdb/src/ht_inc.c:309
    #4 0x7f2e06da6f8d in ht_pp_find ../subprojects/sdb/src/ht_inc.c:328
    #5 0x7f2e0666d8cd in rz_flag_get ../librz/flag/flag.c:312
    #6 0x7f2dfdd1da13 in __printRecursive ../librz/core/cmd/cmd_flag.c:141
    #7 0x7f2dfdd208ed in rz_flag_graph_handler ../librz/core/cmd/cmd_flag.c:302
    #8 0x7f2dfdd0cb7f in argv_call_cb ../librz/core/cmd/cmd_api.c:747
    #9 0x7f2dfdd0cb7f in call_cd ../librz/core/cmd/cmd_api.c:784
    #10 0x7f2dfdd0cb7f in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:802
    #11 0x7f2dfdcab908 in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:3692
    #12 0x7f2dfdcab908 in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:3639
    #13 0x7f2dfdba31db in handle_ts_stmt ../librz/core/cmd/cmd.c:5116
    #14 0x7f2dfdc48a2a in handle_ts_statements_internal ../librz/core/cmd/cmd.c:5173
    #15 0x7f2dfdc48a2a in handle_ts_statements ../librz/core/cmd/cmd.c:5138
    #16 0x7f2dfdc49f8a in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:5281
    #17 0x7f2dfdc4a141 in rz_core_cmd ../librz/core/cmd/cmd.c:5329
    #18 0x7f2dfda278ec in rz_core_prompt_exec ../librz/core/core.c:2828
    #19 0x7f2dfda293c5 in rz_core_prompt_loop ../librz/core/core.c:2698
    #20 0x7f2e06723674 in rz_main_rizin ../librz/main/rizin.c:1410
    #21 0x7f2e05c2928f  (/usr/lib/libc.so.6+0x2928f)
    #22 0x7f2e05c29349 in __libc_start_main (/usr/lib/libc.so.6+0x29349)
    #23 0x561842f27964 in _start (/usr/local/bin/rizin+0x2964)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV (/usr/lib/libc.so.6+0x1607fd) 
==55838==ABORTING

```