### PR TITLE
Remove usage of rz_bin_is_big_endian

### DIFF
--- a/librz/asm/p/asm_ppc_cs.c
+++ b/librz/asm/p/asm_ppc_cs.c
@@ -56,13 +56,9 @@ static int decompile_ps(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	static int omode = -1, obits = -1;
-	int n, ret;
+	int n, ret, mode;
 	ut64 off = a->pc;
 	cs_insn *insn;
-	int mode = (a->bits == 64) ? CS_MODE_64 : (a->bits == 32) ? CS_MODE_32
-								  : 0;
-	mode |= a->big_endian ? CS_MODE_BIG_ENDIAN : CS_MODE_LITTLE_ENDIAN;
-
 	if (a->cpu && strncmp(a->cpu, "vle", 3) == 0) {
 		// vle is big-endian only
 		if (!a->big_endian) {
@@ -82,6 +78,18 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 			return op->size;
 		}
 	}
+	switch (a->bits) {
+	case 32:
+		mode = CS_MODE_32;
+		break;
+	case 64:
+		mode = CS_MODE_64;
+		break;
+	default:
+		mode = 0;
+		break;
+	}
+	mode |= a->big_endian ? CS_MODE_BIG_ENDIAN : CS_MODE_LITTLE_ENDIAN;
 	if (mode != omode || a->bits != obits) {
 		cs_close(&handle);
 		handle = 0;

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -736,12 +736,6 @@ RZ_DEPRECATE RZ_API RzList *rz_bin_get_mem(RzBin *bin) {
 	return o ? (RzList *)rz_bin_object_get_mem(o) : NULL;
 }
 
-RZ_DEPRECATE RZ_API int rz_bin_is_big_endian(RzBin *bin) {
-	rz_return_val_if_fail(bin, false);
-	RzBinObject *o = rz_bin_cur_object(bin);
-	return o ? rz_bin_object_is_big_endian(o) : false;
-}
-
 RZ_DEPRECATE RZ_API int rz_bin_is_static(RzBin *bin) {
 	rz_return_val_if_fail(bin, false);
 	RzBinObject *o = rz_bin_cur_object(bin);

--- a/librz/bin/bobj.c
+++ b/librz/bin/bobj.c
@@ -870,6 +870,14 @@ RZ_API RZ_BORROW RzBinString *rz_bin_object_get_string_at(RZ_NONNULL RzBinObject
 }
 
 /**
+ * \brief Return true if the binary object \p obj is big endian.
+ */
+RZ_API bool rz_bin_object_is_big_endian(RzBinObject *obj) {
+	rz_return_val_if_fail(obj, false);
+	return obj->info ? obj->info->big_endian : false;
+}
+
+/**
  * \brief Return true if the binary object \p obj is detected as statically compiled.
  */
 RZ_API bool rz_bin_object_is_static(RzBinObject *obj) {

--- a/librz/bin/bobj.c
+++ b/librz/bin/bobj.c
@@ -870,14 +870,6 @@ RZ_API RZ_BORROW RzBinString *rz_bin_object_get_string_at(RZ_NONNULL RzBinObject
 }
 
 /**
- * \brief Return true if the binary object \p obj is big endian.
- */
-RZ_API bool rz_bin_object_is_big_endian(RzBinObject *obj) {
-	rz_return_val_if_fail(obj, false);
-	return obj->info ? obj->info->big_endian : false;
-}
-
-/**
  * \brief Return true if the binary object \p obj is detected as statically compiled.
  */
 RZ_API bool rz_bin_object_is_static(RzBinObject *obj) {

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -578,15 +578,12 @@ static bool cb_asmarch(void *user, void *data) {
 	__setsegoff(core->config, node->value, core->rasm->bits);
 
 	// set a default endianness
-	int bigbin = rz_bin_is_big_endian(core->bin);
-	if (bigbin == -1 /* error: no endianness detected in binary */) {
-		bigbin = rz_config_get_i(core->config, "cfg.bigendian");
-	}
+	bool big_endian = rz_config_get_b(core->config, "cfg.bigendian");
 
 	// try to set endian of RzAsm to match binary
-	rz_asm_set_big_endian(core->rasm, bigbin);
+	rz_asm_set_big_endian(core->rasm, big_endian);
 	// set endian of display to match binary
-	core->print->big_endian = bigbin;
+	core->print->big_endian = big_endian;
 
 	rz_asm_set_cpu(core->rasm, asm_cpu);
 	free(asm_cpu);
@@ -611,7 +608,7 @@ static bool cb_asmarch(void *user, void *data) {
 		rz_core_analysis_type_init(core);
 	}
 	// set endian of RzAnalysis to match binary
-	rz_analysis_set_big_endian(core->analysis, bigbin);
+	rz_analysis_set_big_endian(core->analysis, big_endian);
 	rz_core_analysis_cc_init(core);
 
 	const char *platform = rz_config_get(core->config, "asm.platform");

--- a/librz/core/cmd/cmd_meta.c
+++ b/librz/core/cmd/cmd_meta.c
@@ -478,8 +478,7 @@ RZ_IPI RzCmdStatus rz_meta_string_8bit_handler(RzCore *core, int argc, const cha
 
 RZ_IPI RzCmdStatus rz_meta_string_wide16_handler(RzCore *core, int argc, const char **argv) {
 	ut64 size = argc > 1 ? rz_num_math(core->num, argv[1]) : 0;
-	RzBinObject *obj = rz_bin_cur_object(core->bin);
-	bool big_endian = obj ? rz_bin_object_is_big_endian(obj) : RZ_SYS_ENDIAN;
+	bool big_endian = rz_config_get_b(core->config, "cfg.bigendian");
 	RzStrEnc enc = big_endian ? RZ_STRING_ENC_UTF16BE : RZ_STRING_ENC_UTF16LE;
 	if (!rz_core_meta_string_add(core, core->offset, size, enc, NULL)) {
 		return RZ_CMD_STATUS_ERROR;
@@ -489,8 +488,7 @@ RZ_IPI RzCmdStatus rz_meta_string_wide16_handler(RzCore *core, int argc, const c
 
 RZ_IPI RzCmdStatus rz_meta_string_wide32_handler(RzCore *core, int argc, const char **argv) {
 	ut64 size = argc > 1 ? rz_num_math(core->num, argv[1]) : 0;
-	RzBinObject *obj = rz_bin_cur_object(core->bin);
-	bool big_endian = obj ? rz_bin_object_is_big_endian(obj) : RZ_SYS_ENDIAN;
+	bool big_endian = rz_config_get_b(core->config, "cfg.bigendian");
 	RzStrEnc enc = big_endian ? RZ_STRING_ENC_UTF32BE : RZ_STRING_ENC_UTF32LE;
 	if (!rz_core_meta_string_add(core, core->offset, size, enc, NULL)) {
 		return RZ_CMD_STATUS_ERROR;

--- a/librz/core/cmeta.c
+++ b/librz/core/cmeta.c
@@ -433,7 +433,7 @@ static bool meta_string_guess_add(RzCore *core, ut64 addr, size_t limit, char **
 		free(name);
 		return false;
 	}
-	bool big_endian = obj ? rz_bin_object_is_big_endian(obj) : RZ_SYS_ENDIAN;
+	bool big_endian = rz_config_get_b(core->config, "cfg.bigendian");
 	RzUtilStrScanOptions scan_opt = {
 		.buf_size = 2048,
 		.max_uni_blocks = 4,

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -937,6 +937,7 @@ RZ_API const RzList *rz_bin_object_get_resources(RZ_NONNULL RzBinObject *obj);
 RZ_API const RzList *rz_bin_object_get_symbols(RZ_NONNULL RzBinObject *obj);
 RZ_API bool rz_bin_object_reset_strings(RZ_NONNULL RzBin *bin, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzBinObject *obj);
 RZ_API RzBinString *rz_bin_object_get_string_at(RZ_NONNULL RzBinObject *obj, ut64 address, bool is_va);
+RZ_API bool rz_bin_object_is_big_endian(RZ_NONNULL RzBinObject *obj);
 RZ_API bool rz_bin_object_is_static(RZ_NONNULL RzBinObject *obj);
 RZ_API RZ_OWN RzVector *rz_bin_object_sections_mapping_list(RZ_NONNULL RzBinObject *obj);
 RZ_API RZ_OWN RzPVector *rz_bin_object_get_maps_at(RzBinObject *o, ut64 off, bool va);

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -919,7 +919,6 @@ RZ_API RZ_DEPRECATE RZ_BORROW RzList *rz_bin_get_classes(RZ_NONNULL RzBin *bin);
 RZ_API RZ_DEPRECATE RZ_BORROW RzList *rz_bin_get_strings(RZ_NONNULL RzBin *bin);
 RZ_API RZ_DEPRECATE RZ_BORROW RzList *rz_bin_get_mem(RZ_NONNULL RzBin *bin);
 RZ_API RZ_DEPRECATE RZ_BORROW RzList *rz_bin_get_symbols(RZ_NONNULL RzBin *bin);
-RZ_API RZ_DEPRECATE int rz_bin_is_big_endian(RZ_NONNULL RzBin *bin);
 RZ_API RZ_DEPRECATE int rz_bin_is_static(RZ_NONNULL RzBin *bin);
 RZ_API RzList *rz_bin_file_get_trycatch(RZ_NONNULL RzBinFile *bf);
 

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -937,7 +937,6 @@ RZ_API const RzList *rz_bin_object_get_resources(RZ_NONNULL RzBinObject *obj);
 RZ_API const RzList *rz_bin_object_get_symbols(RZ_NONNULL RzBinObject *obj);
 RZ_API bool rz_bin_object_reset_strings(RZ_NONNULL RzBin *bin, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzBinObject *obj);
 RZ_API RzBinString *rz_bin_object_get_string_at(RZ_NONNULL RzBinObject *obj, ut64 address, bool is_va);
-RZ_API bool rz_bin_object_is_big_endian(RZ_NONNULL RzBinObject *obj);
 RZ_API bool rz_bin_object_is_static(RZ_NONNULL RzBinObject *obj);
 RZ_API RZ_OWN RzVector *rz_bin_object_sections_mapping_list(RZ_NONNULL RzBinObject *obj);
 RZ_API RZ_OWN RzPVector *rz_bin_object_get_maps_at(RzBinObject *o, ut64 off, bool va);

--- a/test/db/analysis/ppc
+++ b/test/db/analysis/ppc
@@ -583,3 +583,39 @@ EXPECT=<<EOF
 ]
 EOF
 RUN
+
+NAME=ppc vle big-endian
+FILE=bins/firmware/ppc-big-endian-vle.bin
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e asm.cpu=vle
+e cfg.bigendian=true
+pd 10
+?e ensure that the endianness is kept
+pd 10
+EOF
+EXPECT=<<EOF
+            0x00000000      se_mflr r0
+            0x00000002      e_stwu r1 0xfffffff0(r1)
+            0x00000006      se_stw r31 0xc(r1)
+            0x00000008      se_stw r0 0x14(r1)
+            0x0000000a      se_cmpi r4 0x0
+            0x0000000c      e_li  r11 0x0
+        ,=< 0x00000010      e_beq cr0 0x212
+        |   0x00000014      e_addi r10 r4 0xffffffff
+        |   0x00000018      e_srwi r10 r10 0x2
+        |   0x0000001c      e_addi r7 r10 0x2
+ensure that the endianness is kept
+            0x00000000      se_mflr r0
+            0x00000002      e_stwu r1 0xfffffff0(r1)
+            0x00000006      se_stw r31 0xc(r1)
+            0x00000008      se_stw r0 0x14(r1)
+            0x0000000a      se_cmpi r4 0x0
+            0x0000000c      e_li  r11 0x0
+        ,=< 0x00000010      e_beq cr0 0x212
+        |   0x00000014      e_addi r10 r4 0xffffffff
+        |   0x00000018      e_srwi r10 r10 0x2
+        |   0x0000001c      e_addi r7 r10 0x2
+EOF
+RUN


### PR DESCRIPTION


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Remove usage of `rz_bin_is_big_endian` which changes the endianness set  by the user

Fix #2756