### PR TITLE
Meson: Simplify `crca_crc` hash plugin summary output

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -790,6 +790,30 @@ summary({
   'Use RPATH': rpath_summary,
 }, section: 'Configuration', bool_yn: true)
 
+# output will be slightly degraded if there's only 1 crca_crc hash plugin and/or last hash plugin is a crca_crc plugin
+comb_hash_plugins = []
+in_crca_loop = false
+foreach plugin : hash_plugins
+  if plugin.startswith('crca_crc')
+    comb_hash_plugins += (in_crca_loop ? '' : 'crca_crc(') + plugin.substring(8)
+    in_crca_loop = true
+  else
+    if in_crca_loop
+      # add closing parenthesis to last crca_cec plugin
+      parenthesized_last = []
+      foreach item : comb_hash_plugins
+        if item not in [comb_hash_plugins[-1]]
+          parenthesized_last += item
+        endif
+      endforeach
+      parenthesized_last += comb_hash_plugins[-1] + ')'
+      comb_hash_plugins = parenthesized_last
+    endif
+    comb_hash_plugins += plugin
+    in_crca_loop = false
+  endif
+endforeach
+
 summary({
   'Analysis Plugins': analysis_plugins,
   'Assembler Plugins': asm_plugins,
@@ -803,7 +827,7 @@ summary({
   'Egg Plugins': egg_plugins,
   'IO Plugins': io_plugins,
   'Lang Plugins': lang_plugins,
-  'Hash Plugins': hash_plugins,
+  'Hash Plugins': comb_hash_plugins,
   'Parse Plugins': parse_plugins,
   'Demangler Plugins': demangler_plugins,
 }, section: 'Plugins', list_sep: ', ')


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Before:

![before_crca_crc](https://user-images.githubusercontent.com/12002672/177006880-85075bd1-36e6-4709-933f-10d2398a4555.PNG)

As can be seen above, there are many `crca_crc` hash plugins and it is hard to see the versions that are available.

After:

![after_crca_crc](https://user-images.githubusercontent.com/12002672/177006891-94f0a5d1-a551-40d6-8330-ba307906f0db.PNG)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

See whether the "after" output is better (more readable) than the "before" output. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
