### PR TITLE
Fix and test rz_json_as_string() for primitives

### DIFF
--- a/librz/util/json_parser.c
+++ b/librz/util/json_parser.c
@@ -538,26 +538,10 @@ static void json_pj_recurse(const RzJson *json, PJ *pj) {
 	}
 }
 
-static void json_pj_handler(const RzJson *json, PJ *pj) {
-	if (json->type == RZ_JSON_OBJECT) {
-		pj_o(pj);
-	} else if (json->type == RZ_JSON_ARRAY) {
-		pj_a(pj);
-	}
-	RzJson *js;
-	for (js = json->children.first; js; js = js->next) {
-		json_pj_recurse(js, pj);
-	}
-	if (json->type == RZ_JSON_OBJECT || json->type == RZ_JSON_ARRAY) {
-		pj_end(pj);
-	}
-}
-
 RZ_API RZ_OWN char *rz_json_as_string(const RzJson *json) {
 	rz_return_val_if_fail(json, NULL);
-	rz_return_val_if_fail(json->type != RZ_JSON_NULL, NULL);
 	PJ *pj = pj_new();
-	json_pj_handler(json, pj);
+	json_pj_recurse(json, pj);
 	char *str = pj_drain(pj);
 	return str;
 }

--- a/test/unit/test_json.c
+++ b/test/unit/test_json.c
@@ -221,12 +221,14 @@ static int check_expected_4(RzJson *j) {
 static int check_expected_5(RzJson *j) {
 	mu_assert_eq(j->type, RZ_JSON_STRING, "string type");
 	mu_assert_streq(j->str_value, "string value", "string value");
+	mu_assert_streq_free(rz_json_as_string(j), "\"string value\"", "string as string");
 	return MU_PASSED;
 }
 
 static int check_expected_6(RzJson *j) {
 	mu_assert_eq(j->type, RZ_JSON_BOOLEAN, "boolean type");
 	mu_assert_eq(j->num.u_value, 1, "boolean value");
+	mu_assert_streq_free(rz_json_as_string(j), "true", "boolean as string");
 	return MU_PASSED;
 }
 
@@ -234,11 +236,13 @@ static int check_expected_7(RzJson *j) {
 	mu_assert_eq(j->type, RZ_JSON_DOUBLE, "double type");
 	mu_assert("double value",
 		j->num.dbl_value < (-1.0e-2 + 1.0e-13) && j->num.dbl_value > (-1.0e-2 - 1.0e-13));
+	mu_assert_streq_free(rz_json_as_string(j), "-0.010000", "double as string");
 	return MU_PASSED;
 }
 
 static int check_expected_8(RzJson *j) {
 	mu_assert_eq(j->type, RZ_JSON_NULL, "null type");
+	mu_assert_streq_free(rz_json_as_string(j), "null", "null as string");
 	return MU_PASSED;
 }
 
@@ -1009,6 +1013,13 @@ static int check_expected_58(RzJson *j) {
 	return MU_PASSED;
 }
 
+static int check_expected_59(RzJson *j) {
+	mu_assert_eq(j->type, RZ_JSON_INTEGER, "integer type");
+	mu_assert_eq(j->num.u_value, 42, "integer value");
+	mu_assert_streq_free(rz_json_as_string(j), "42", "integer as string");
+	return MU_PASSED;
+}
+
 JsonTest tests[] = {
 	{ // 0
 		"    {\n      \"some-int\": 195,\n      \"array1\": [ 3, 5.1, -7, \"nin"
@@ -1251,6 +1262,9 @@ JsonTest tests[] = {
 		" \"/OTHER/\",\n      \"obj\": {\"KEY\":\"VAL\", \"obj\":{\"KEY\":\"VAL"
 		"\"}}\n    }\n",
 		check_expected_58 },
+	{ // 59
+		"42",
+		check_expected_59 },
 };
 
 static int test_json(int test_number, char *input, int (*check)(RzJson *j)) {


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Allowing converting the primitive json values null, number, string and
bool to be converted to strings is useful, simplifies the code and fixes
crashes when converting otherwise valid RzJson objects.

**Test plan**

see tests