### PR TITLE
Remove `RZ_BIRTH`

### DIFF
--- a/librz/include/rz_version.h.in
+++ b/librz/include/rz_version.h.in
@@ -7,7 +7,6 @@
 #define RZ_VERSION_NUMBER @RZ_VERSION_NUMBER@
 #define RZ_VERSION "@RZ_VERSION@"
 #define RZ_GITTIP "@RZ_GITTIP@"
-#define RZ_BIRTH "@RZ_BIRTH@"
 #mesondefine RZ_PACKAGER_VERSION
 #mesondefine RZ_PACKAGER
 #endif

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -3932,10 +3932,6 @@ RZ_API RzList *rz_str_wrap(char *str, size_t width) {
 #define RZ_GITTIP ""
 #endif
 
-#ifndef RZ_BIRTH
-#define RZ_BIRTH "unknown"
-#endif
-
 #ifdef RZ_PACKAGER_VERSION
 #ifdef RZ_PACKAGER
 #define RZ_STR_PKG_VERSION_STRING ", package: " RZ_PACKAGER_VERSION " (" RZ_PACKAGER ")"
@@ -3958,7 +3954,7 @@ RZ_API char *rz_str_version(const char *program) {
 	}
 	if (RZ_STR_ISNOTEMPTY(RZ_GITTIP)) {
 		rz_strbuf_append(sb, "\n");
-		rz_strbuf_append(sb, "commit: " RZ_GITTIP ", build: " RZ_BIRTH);
+		rz_strbuf_append(sb, "commit: " RZ_GITTIP);
 	}
 	return rz_strbuf_drain(sb);
 }

--- a/meson.build
+++ b/meson.build
@@ -71,23 +71,6 @@ if get_option('rizin_gittip') != ''
   gittip = get_option('rizin_gittip')
 endif
 
-# Get current date
-if host_machine.system() == 'windows'
-  rizinbirth = run_command('cmd', '/c', 'echo %date%__%time%', check: true)
-else
-  rizinbirth = run_command('sh', '-c', '''
-      SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}";
-      FORMAT="+%Y-%m-%d__%H:%M:%S";
-      date -u -d "@$SOURCE_DATE_EPOCH" "$FORMAT" 2>/dev/null ||
-      date -u -r  "$SOURCE_DATE_EPOCH" "$FORMAT" 2>/dev/null ||
-      date -u "$FORMAT"''', check: true)
-endif
-if rizinbirth.returncode() != 0
-  rizinbirth = ''
-else
-  rizinbirth = rizinbirth.stdout().strip()
-endif
-
 rizin_libversion = '@0@.@1@'.format(rizin_version_major, rizin_version_minor)
 message('rizin lib version: ' + rizin_libversion)
 
@@ -541,7 +524,6 @@ versionconf.set('RZ_VERSION_PATCH', rizin_version_patch)
 versionconf.set('RZ_VERSION_NUMBER', rizin_version_number)
 versionconf.set('RZ_VERSION', rizin_version)
 versionconf.set('RZ_GITTIP', gittip)
-versionconf.set('RZ_BIRTH', rizinbirth)
 if packager_version != ''
   versionconf.set_quoted('RZ_PACKAGER_VERSION', packager_version)
   if packager != ''

--- a/test/db/tools/rz_agent
+++ b/test/db/tools/rz_agent
@@ -1,6 +1,6 @@
 NAME=rz-agent -v
 FILE==
-CMDS=!rz-agent -v | grep -c build
+CMDS=!rz-agent -v | grep -c commit
 EXPECT=<<EOF
 1
 EOF

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -434,7 +434,7 @@ RUN
 
 NAME=rz-asm -v
 FILE==
-CMDS=!rz-asm -v  | grep -c build
+CMDS=!rz-asm -v  | grep -c commit
 EXPECT=<<EOF
 1
 EOF

--- a/test/db/tools/rz_ax
+++ b/test/db/tools/rz_ax
@@ -532,7 +532,7 @@ RUN
 
 NAME=rz-ax -v
 FILE==
-CMDS=!rz-ax -v | grep -c build
+CMDS=!rz-ax -v | grep -c commit
 EXPECT=<<EOF
 1
 EOF

--- a/test/db/tools/rz_bin
+++ b/test/db/tools/rz_bin
@@ -927,7 +927,7 @@ RUN
 
 NAME=rz-bin -v
 FILE==
-CMDS=!rz-bin -v | grep -c build
+CMDS=!rz-bin -v | grep -c commit
 EXPECT=<<EOF
 1
 EOF

--- a/test/db/tools/rz_find
+++ b/test/db/tools/rz_find
@@ -69,7 +69,7 @@ RUN
 
 NAME=rz-find -v
 FILE==
-CMDS=!rz-find -v | grep -c build
+CMDS=!rz-find -v | grep -c commit
 EXPECT=<<EOF
 1
 EOF

--- a/test/db/tools/rz_gg
+++ b/test/db/tools/rz_gg
@@ -116,7 +116,7 @@ RUN
 
 NAME=rz-gg -v
 FILE==
-CMDS=!rz-gg -v | grep -c build
+CMDS=!rz-gg -v | grep -c commit
 EXPECT=<<EOF
 1
 EOF

--- a/test/db/tools/rz_run
+++ b/test/db/tools/rz_run
@@ -1,6 +1,6 @@
 NAME=rz-run -v 
 FILE==
-CMDS=!rz-run -v | grep -c build
+CMDS=!rz-run -v | grep -c commit
 EXPECT=<<EOF
 1
 EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The timestamp shown by `rizin -v` i.e. `RZ_BIRTH` doesn't appear useful as version info, even for debugging purposes, whether or not it's a build timestamp or a configure timestamp. Consider:

1. If you ever forgot whether you're recompiled the code changes you've just made, rerun the build.
2. It updates every time a build system file (e.g. a `meson.build` file) is modified whether or not build configuration settings have actually changed.
3. Do you actually remember what happened at the shown timestamp, for instance at `2022-06-25__11:44:09`? Even if you did, there's no easy way to revert to the code at that timestamp.

Therefore, this pr removes `RZ_BIRTH` and its associated machinery.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

There's no good reason to keep `RZ_BIRTH` (see also discussion at #2799). All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...

----

The tests were fixed using:

```sh
REGEX="grep -c build" bash -c 'git grep -l "$REGEX" | xargs -n 1 sed -i "s/$REGEX/grep -c commit/"'
```