### PR TITLE
Fix false-positive skipping of components in cmake config

### DIFF
--- a/librz/RizinConfig.cmake.in
+++ b/librz/RizinConfig.cmake.in
@@ -88,7 +88,7 @@ foreach(_comp ${Rizin_FIND_COMPONENTS})
     set(Rizin_NOT_FOUND_MESSAGE "Unsupported component: ${_comp}")
     return()
   endif()
-  if (rz_${_comp_lower}_FOUND)
+  if (TARGET "Rizin::${_comp}")
     # Already got this component, trying to re-add the
     # target below would be an error
     continue()


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

When calling
```
find_package(Rizin REQUIRED COMPONENTS Core)
find_package(Rizin REQUIRED COMPONENTS Util)
```
The first call would create only `Rizin::Core`, but `rz_util_FOUND`
would aso be true. Thus, in the second call, `Rizin::Util` would not be
created because of this check.
So instead of the `..._FOUND` variable, we directly check if the
`Rizin::...` target exists.