### PR TITLE
meson: Remove unused `version_commit`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -49,9 +49,6 @@ if meson.is_subproject()
   endif
 endif
 
-# by default, not version commit is used
-version_commit = '0'
-
 gittip = ''
 
 fs = import('fs')
@@ -61,10 +58,6 @@ if git_exe.found() and fs.exists('.git')
   if git_rev_parse.returncode() == 0
     gittip = git_rev_parse.stdout().strip()
   endif
-endif
-
-if get_option('rizin_version_commit') != ''
-  version_commit = get_option('rizin_version_commit')
 endif
 
 if get_option('rizin_gittip') != ''

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,7 +17,6 @@ option('rizin_hud', type: 'string', value: '', description: 'Install path for hu
 option('rizin_plugins', type: 'string', value: '', description: 'Path where plugins are expected to be found')
 option('rizin_bindings', type: 'string', value: '', description: 'Path where rizin bindings are expected to be found')
 
-option('rizin_version_commit', type: 'string', value: '')
 option('rizin_gittip', type: 'string', value: '')
 option('checks_level', type: 'integer', value: 9999, description: 'Value between 0 and 3 to enable different level of assert (see RZ_CHECKS_LEVEL). By default its value depends on buildtype (2 on debug, 1 on release).')
 option('use_sys_capstone', type: 'feature', value: 'disabled')


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr removes `version_commit` and `rizin_version_commit` from the Rizin Meson build system because they are not used.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
