### PR TITLE
Fix double free of enum member name

### DIFF
--- a/librz/core/cmd/cmd_type.c
+++ b/librz/core/cmd/cmd_type.c
@@ -43,13 +43,12 @@ static void types_cc_print(RzCore *core, const char *cc, RzOutputMode mode) {
 static RzCmdStatus types_enum_member_find(RzCore *core, const char *enum_name, const char *enum_value) {
 	rz_return_val_if_fail(enum_name || enum_value, RZ_CMD_STATUS_ERROR);
 	ut64 value = rz_num_math(core->num, enum_value);
-	char *enum_member = rz_type_db_enum_member_by_val(core->analysis->typedb, enum_name, value);
+	const char *enum_member = rz_type_db_enum_member_by_val(core->analysis->typedb, enum_name, value);
 	if (!enum_member) {
 		RZ_LOG_ERROR("Cannot find matching enum member");
 		return RZ_CMD_STATUS_ERROR;
 	}
 	rz_cons_println(enum_member);
-	free(enum_member);
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/include/rz_type.h
+++ b/librz/include/rz_type.h
@@ -334,7 +334,7 @@ RZ_API RzBaseType *rz_type_db_get_struct(const RzTypeDB *typedb, const char *nam
 RZ_API RzBaseType *rz_type_db_get_typedef(const RzTypeDB *typedb, RZ_NONNULL const char *name);
 
 RZ_API int rz_type_db_enum_member_by_name(const RzTypeDB *typedb, const char *name, const char *member);
-RZ_API RZ_BORROW char *rz_type_db_enum_member_by_val(const RzTypeDB *typedb, const char *name, ut64 val);
+RZ_API RZ_BORROW const char *rz_type_db_enum_member_by_val(const RzTypeDB *typedb, const char *name, ut64 val);
 RZ_API RZ_OWN RzList *rz_type_db_find_enums_by_val(const RzTypeDB *typedb, ut64 val);
 RZ_API char *rz_type_db_enum_get_bitfield(const RzTypeDB *typedb, const char *name, ut64 val);
 

--- a/librz/type/format.c
+++ b/librz/type/format.c
@@ -1363,7 +1363,7 @@ static void rz_type_format_bitfield(const RzTypeDB *typedb, RzStrBuf *outbuf, ut
 
 static void rz_type_format_enum(const RzTypeDB *typedb, RzStrBuf *outbuf, ut64 seeki, char *fmtname,
 	char *fieldname, ut64 addr, int mode, int size) {
-	char *enumvalue = NULL;
+	const char *enumvalue = NULL;
 	addr &= (1ULL << (size * 8)) - 1;
 	if (MUSTSEE && !SEEVALUE) {
 		rz_strbuf_appendf(outbuf, "0x%08" PFMT64x " = ", seeki);

--- a/librz/type/type.c
+++ b/librz/type/type.c
@@ -505,7 +505,7 @@ RZ_API RzBaseType *rz_type_db_get_enum(const RzTypeDB *typedb, RZ_NONNULL const 
  * \param name The name of the enum to search in
  * \param val The value to search for
  */
-RZ_API RZ_BORROW char *rz_type_db_enum_member_by_val(const RzTypeDB *typedb, RZ_NONNULL const char *name, ut64 val) {
+RZ_API RZ_BORROW const char *rz_type_db_enum_member_by_val(const RzTypeDB *typedb, RZ_NONNULL const char *name, ut64 val) {
 	rz_return_val_if_fail(typedb && name, NULL);
 	RzBaseType *btype = rz_type_db_get_base_type(typedb, name);
 	if (!btype) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

`rz_type_db_enum_member_by_val` returns a borrowed pointer, so freeing it is wrong

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tests pass

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None
