### PR TITLE
Remove sdb.wrap file

### DIFF
--- a/subprojects/sdb.wrap
+++ b/subprojects/sdb.wrap
@@ -1,3 +1,0 @@
-[wrap-git]
-url = https://github.com/rizinorg/sdb.git
-revision = e1a015aa1f07169bb70a2260a1262230ffaa3f6a


### PR DESCRIPTION
SDB was recently moved into RzUtil, however I forgot to remove this file.