### PR TITLE
Fix endian issues and libs in xbe and extend tests

### DIFF
--- a/librz/bin/format/xbe/xbe.h
+++ b/librz/bin/format/xbe/xbe.h
@@ -16,60 +16,54 @@
 #define XBE_KP_CHIHIRO 0x2290059D
 
 #define XBE_MAX_THUNK 378
-RZ_PACKED(
-	typedef struct {
-		ut32 magic;
-		ut8 signature[0x100];
-		ut32 base;
-		ut32 headers_size;
-		ut32 image_size;
-		ut32 image_header_size;
-		ut32 timestamp;
-		ut32 cert_addr;
-		ut32 sections;
-		ut32 sechdr_addr;
-		ut32 init_flags;
-		ut32 ep;
-		ut32 tls_addr;
-		ut32 pe_data[7];
-		ut32 debug_path_addr;
-		ut32 debug_name_addr;
-		ut32 debug_uname_addr;
-		ut32 kernel_thunk_addr;
-		ut32 nonkernel_import_dir_addr;
-		ut32 lib_versions;
-		ut32 lib_versions_addr;
-		ut32 kernel_lib_addr;
-		ut32 xapi_lib_addr;
-		ut32 padding[2];
-	})
-xbe_header;
+typedef struct {
+	ut8 magic[4];
+	ut8 signature[0x100];
+	ut32 base;
+	ut32 headers_size;
+	ut32 image_size;
+	ut32 image_header_size;
+	ut32 timestamp;
+	ut32 cert_addr;
+	ut32 sections;
+	ut32 sechdr_addr;
+	ut32 init_flags;
+	ut32 ep;
+	ut32 tls_addr;
+	ut32 pe_data[7];
+	ut32 debug_path_addr;
+	ut32 debug_name_addr;
+	ut32 debug_uname_addr;
+	ut32 kernel_thunk_addr;
+	ut32 nonkernel_import_dir_addr;
+	ut32 lib_versions;
+	ut32 lib_versions_addr;
+	ut32 kernel_lib_addr;
+	ut32 xapi_lib_addr;
+	ut32 padding[2];
+} xbe_header;
 
 #define SECT_FLAG_X 0x00000004
 #define SECT_FLAG_W 0x00000001
-RZ_PACKED(
-	typedef struct {
-		ut32 flags;
-		ut32 vaddr;
-		ut32 vsize;
-		ut32 offset;
-		ut32 size;
-		ut32 name_addr;
-		ut32 refcount;
-		ut32 padding[2];
-		ut8 digest[20];
-	})
-xbe_section;
+typedef struct {
+	ut32 flags;
+	ut32 vaddr;
+	ut32 vsize;
+	ut32 offset;
+	ut32 size;
+	ut32 name_addr;
+	ut32 refcount;
+	ut32 padding[2];
+	ut8 digest[20];
+} xbe_section;
 
-RZ_PACKED(
-	typedef struct {
-		ut8 name[8];
-		ut16 major;
-		ut16 minor;
-		ut16 build;
-		ut16 flags;
-	})
-xbe_lib;
+typedef struct {
+	ut8 name[8];
+	ut16 major;
+	ut16 minor;
+	ut16 build;
+	ut16 flags;
+} xbe_lib;
 
 typedef struct {
 	xbe_header header;

--- a/librz/bin/p/bin_xbe.c
+++ b/librz/bin/p/bin_xbe.c
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Florian Märkl <info@florianmaerkl.de>
 // SPDX-FileCopyrightText: 2014-2019 LemonBoy <thatlemon@gmail.com>
 // SPDX-FileCopyrightText: 2014-2019 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
@@ -13,6 +14,63 @@ static const char *kt_name[] = {
 #include "../format/xbe/kernel.h"
 };
 
+static bool read_xbe_header(xbe_header *hdr, RzBuffer *b, ut64 off) {
+	if (rz_buf_read_at(b, off, hdr->magic, sizeof(hdr->magic)) != sizeof(hdr->magic) ||
+		rz_buf_read_at(b, off + 4, hdr->signature, sizeof(hdr->signature)) != sizeof(hdr->signature) ||
+		!rz_buf_read_le32_at(b, off + 0x104, &hdr->base) ||
+		!rz_buf_read_le32_at(b, off + 0x104 + sizeof(ut32), &hdr->headers_size) ||
+		!rz_buf_read_le32_at(b, off + 0x104 + sizeof(ut32) * 2, &hdr->image_size) ||
+		!rz_buf_read_le32_at(b, off + 0x104 + sizeof(ut32) * 3, &hdr->image_header_size) ||
+		!rz_buf_read_le32_at(b, off + 0x104 + sizeof(ut32) * 4, &hdr->timestamp) ||
+		!rz_buf_read_le32_at(b, off + 0x104 + sizeof(ut32) * 5, &hdr->cert_addr) ||
+		!rz_buf_read_le32_at(b, off + 0x104 + sizeof(ut32) * 6, &hdr->sections) ||
+		!rz_buf_read_le32_at(b, off + 0x104 + sizeof(ut32) * 7, &hdr->sechdr_addr) ||
+		!rz_buf_read_le32_at(b, off + 0x104 + sizeof(ut32) * 8, &hdr->init_flags) ||
+		!rz_buf_read_le32_at(b, off + 0x104 + sizeof(ut32) * 9, &hdr->ep) ||
+		!rz_buf_read_le32_at(b, off + 0x104 + sizeof(ut32) * 10, &hdr->tls_addr)) {
+		return false;
+	}
+	off += 0x104 + sizeof(ut32) * 11;
+	for (size_t i = 0; i < RZ_ARRAY_SIZE(hdr->pe_data); i++) {
+		if (!rz_buf_read_le32_at(b, off, &hdr->pe_data[i])) {
+			return false;
+		}
+		off += sizeof(ut32);
+	}
+	return rz_buf_read_le32_at(b, off, &hdr->debug_path_addr) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32), &hdr->debug_name_addr) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 2, &hdr->debug_uname_addr) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 3, &hdr->kernel_thunk_addr) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 4, &hdr->nonkernel_import_dir_addr) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 5, &hdr->lib_versions) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 6, &hdr->lib_versions_addr) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 7, &hdr->kernel_lib_addr) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 8, &hdr->xapi_lib_addr) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 9, &hdr->padding[0]) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 10, &hdr->padding[1]);
+}
+
+static bool read_xbe_section(xbe_section *sect, RzBuffer *b, ut64 off) {
+	return rz_buf_read_le32_at(b, off, &sect->flags) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32), &sect->vaddr) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 2, &sect->vsize) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 3, &sect->offset) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 4, &sect->size) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 5, &sect->name_addr) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 6, &sect->refcount) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 7, &sect->padding[0]) &&
+		rz_buf_read_le32_at(b, off + sizeof(ut32) * 8, &sect->padding[1]) &&
+		rz_buf_read_at(b, off + sizeof(ut32) * 9, sect->digest, sizeof(sect->digest)) == sizeof(sect->digest);
+}
+
+static bool read_xbe_lib(xbe_lib *lib, RzBuffer *b, ut64 off) {
+	return rz_buf_read_at(b, off, lib->name, sizeof(lib->name)) == sizeof(lib->name) &&
+		rz_buf_read_le16_at(b, off + 8, &lib->major) &&
+		rz_buf_read_le16_at(b, off + 8 + sizeof(ut16), &lib->minor) &&
+		rz_buf_read_le16_at(b, off + 8 + sizeof(ut16) * 2, &lib->build) &&
+		rz_buf_read_le16_at(b, off + 8 + sizeof(ut16) * 3, &lib->flags);
+}
+
 static bool check_buffer(RzBuffer *b) {
 	ut8 magic[4];
 	if (rz_buf_read_at(b, 0, magic, sizeof(magic)) == 4) {
@@ -26,8 +84,7 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *o, RzBuffer *buf, Sdb *sdb) 
 	if (!obj) {
 		return false;
 	}
-	st64 r = rz_buf_read_at(buf, 0, (ut8 *)&obj->header, sizeof(obj->header));
-	if (r != sizeof(obj->header)) {
+	if (!read_xbe_header(&obj->header, buf, 0)) {
 		RZ_FREE(obj);
 		return false;
 	}
@@ -89,7 +146,6 @@ static RzList *entries(RzBinFile *bf) {
 }
 
 static RzList *sections(RzBinFile *bf) {
-	xbe_section *sect = NULL;
 	rz_bin_xbe_obj_t *obj = NULL;
 	xbe_header *h = NULL;
 	RzList *ret = NULL;
@@ -113,144 +169,101 @@ static RzList *sections(RzBinFile *bf) {
 	if (h->sections < 1 || h->sections > 255) {
 		goto out_error;
 	}
-	sect = calloc(h->sections, sizeof(xbe_section));
-	if (!sect) {
-		goto out_error;
-	}
 	addr = h->sechdr_addr - h->base;
 	if (addr > bf->size || addr + (sizeof(xbe_section) * h->sections) > bf->size) {
 		goto out_error;
 	}
-	r = rz_buf_read_at(bf->buf, addr, (ut8 *)sect, sizeof(xbe_section) * h->sections);
-	if (r < 1) {
-		goto out_error;
-	}
 	for (i = 0; i < h->sections; i++) {
+		xbe_section sect;
+		if (!read_xbe_section(&sect, bf->buf, addr + i * sizeof(xbe_section))) {
+			goto out_error;
+		}
 		RzBinSection *item = RZ_NEW0(RzBinSection);
-		addr = sect[i].name_addr - h->base;
+		ut32 name_addr = sect.name_addr - h->base;
 		tmp[0] = 0;
-		if (addr > bf->size || addr + sizeof(tmp) > bf->size) {
+		if (name_addr > bf->size || name_addr + sizeof(tmp) > bf->size) {
 			free(item);
 			goto out_error;
 		}
-		r = rz_buf_read_at(bf->buf, addr, (ut8 *)tmp, sizeof(tmp));
+		r = rz_buf_read_at(bf->buf, name_addr, (ut8 *)tmp, sizeof(tmp));
 		if (r < 1) {
 			free(item);
 			goto out_error;
 		}
 		tmp[sizeof(tmp) - 1] = 0;
 		item->name = rz_str_newf("%s.%i", tmp, i);
-		item->paddr = sect[i].offset;
-		item->vaddr = sect[i].vaddr;
-		item->size = sect[i].size;
-		item->vsize = sect[i].vsize;
+		item->paddr = sect.offset;
+		item->vaddr = sect.vaddr;
+		item->size = sect.size;
+		item->vsize = sect.vsize;
 
 		item->perm = RZ_PERM_R;
-		if (sect[i].flags & SECT_FLAG_X) {
+		if (sect.flags & SECT_FLAG_X) {
 			item->perm |= RZ_PERM_X;
 		}
-		if (sect[i].flags & SECT_FLAG_W) {
+		if (sect.flags & SECT_FLAG_W) {
 			item->perm |= RZ_PERM_W;
 		}
 		rz_list_append(ret, item);
 	}
-	free(sect);
 	return ret;
 out_error:
 	rz_list_free(ret);
-	free(sect);
 	return NULL;
 }
 
-static RzList *libs(RzBinFile *bf) {
-	rz_bin_xbe_obj_t *obj;
-	xbe_header *h = NULL;
-	int i, off, libs, r;
+/**
+ * Generate a string like "<LIBNAME> <MAJOR>.<MINOR>.<BUILD>"
+ * by reading an xbe_lib at the given offset.
+ */
+static char *describe_xbe_lib_at(RzBuffer *b, ut64 off, ut64 filesz) {
+	if (off + sizeof(xbe_lib) > filesz) {
+		return NULL;
+	}
 	xbe_lib lib;
-	RzList *ret;
-	char *s;
-	ut32 addr;
+	if (!read_xbe_lib(&lib, b, off)) {
+		return NULL;
+	}
+	// lib.name may not be 0-terminated
+	char name[9];
+	RZ_STATIC_ASSERT(sizeof(name) == sizeof(lib.name) + 1);
+	memcpy(name, lib.name, sizeof(lib.name));
+	name[sizeof(lib.name)] = 0;
+	return rz_str_newf("%s %i.%i.%i", name, lib.major, lib.minor, lib.build);
+}
 
+static RzList *libs(RzBinFile *bf) {
 	if (!bf || !bf->o || !bf->o->bin_obj) {
 		return NULL;
 	}
-	obj = bf->o->bin_obj;
-	h = &obj->header;
-	ret = rz_list_new();
+	rz_bin_xbe_obj_t *obj = bf->o->bin_obj;
+	xbe_header *h = &obj->header;
+	RzList *ret = rz_list_newf(free);
 	if (!ret) {
 		return NULL;
 	}
-	ret->free = free;
-	if (h->kernel_lib_addr < h->base) {
-		off = 0;
-	} else {
-		off = h->kernel_lib_addr - h->base;
-	}
-	if (off > bf->size || off + sizeof(xbe_lib) > bf->size) {
-		goto out_error;
-	}
-	r = rz_buf_read_at(bf->buf, off, (ut8 *)&lib, sizeof(xbe_lib));
-	if (r < 1) {
-		goto out_error;
-	}
-	lib.name[7] = 0;
-	s = rz_str_newf("%s %i.%i.%i", lib.name, lib.major, lib.minor, lib.build);
-	if (s) {
-		rz_list_append(ret, s);
-	}
-	if (h->xapi_lib_addr < h->base) {
-		off = 0;
-	} else {
-		off = h->xapi_lib_addr - h->base;
-	}
-	if (off > bf->size || off + sizeof(xbe_lib) > bf->size) {
-		goto out_error;
-	}
-	r = rz_buf_read_at(bf->buf, off, (ut8 *)&lib, sizeof(xbe_lib));
-	if (r < 1) {
-		goto out_error;
-	}
 
-	lib.name[7] = 0;
-	s = rz_str_newf("%s %i.%i.%i", lib.name, lib.major, lib.minor, lib.build);
-	if (s) {
-		rz_list_append(ret, s);
-	}
-	libs = h->lib_versions;
-	if (libs < 1) {
-		goto out_error;
-	}
-	for (i = 0; i < libs; i++) {
-		addr = h->lib_versions_addr - h->base + (i * sizeof(xbe_lib));
-		if (addr > bf->size || addr + sizeof(xbe_lib) > bf->size) {
-			goto out_error;
+	// Hint: h->kernel_lib_addr and h->xapi_lib_addr also point to xbe_lib structs,
+	// but in our known samples, they just point into the array below, so no need
+	// to check them explicitly.
+
+	for (ut32 i = 0; i < h->lib_versions; i++) {
+		ut64 addr = h->lib_versions_addr - h->base + (i * sizeof(xbe_lib));
+		char *lib = describe_xbe_lib_at(bf->buf, addr, bf->size);
+		if (!lib) {
+			break;
 		}
-		r = rz_buf_read_at(bf->buf, addr, (ut8 *)&lib, sizeof(xbe_lib));
-		if (r < 1) {
-			goto out_error;
-		}
-		// make sure it ends with 0
-		lib.name[7] = '\0';
-		s = rz_str_newf("%s %i.%i.%i", lib.name, lib.major, lib.minor, lib.build);
-		if (s) {
-			rz_list_append(ret, s);
-		}
+		rz_list_push(ret, lib);
 	}
 
 	return ret;
-out_error:
-	rz_list_free(ret);
-	return NULL;
 }
 
 static RzList *symbols(RzBinFile *bf) {
 	rz_bin_xbe_obj_t *obj;
 	xbe_header *h;
 	RzList *ret;
-	int i, found = false;
-	ut32 thunk_addr[XBE_MAX_THUNK];
 	ut32 kt_addr;
-	xbe_section sect;
 	ut32 addr;
 
 	if (!bf || !bf->o || !bf->o->bin_obj) {
@@ -264,17 +277,18 @@ static RzList *symbols(RzBinFile *bf) {
 	if (!ret) {
 		return NULL;
 	}
-	eprintf("sections %d\n", h->sections);
 	int limit = h->sections;
 	if (limit * (sizeof(xbe_section)) >= bf->size - h->sechdr_addr) {
 		goto out_error;
 	}
-	for (i = 0; found == false && i < limit; i++) {
+	xbe_section sect;
+	bool found = false;
+	for (size_t i = 0; found == false && i < limit; i++) {
 		addr = h->sechdr_addr - h->base + (sizeof(xbe_section) * i);
-		if (addr > bf->size || addr + sizeof(sect) > bf->size) {
+		if (addr > bf->size || addr + sizeof(sect) > bf->size ||
+			!read_xbe_section(&sect, bf->buf, addr)) {
 			goto out_error;
 		}
-		rz_buf_read_at(bf->buf, addr, (ut8 *)&sect, sizeof(sect));
 		if (kt_addr >= sect.vaddr && kt_addr < sect.vaddr + sect.vsize) {
 			found = true;
 		}
@@ -283,14 +297,16 @@ static RzList *symbols(RzBinFile *bf) {
 		goto out_error;
 	}
 	addr = sect.offset + (kt_addr - sect.vaddr);
+	ut32 thunk_addr[XBE_MAX_THUNK];
 	if (addr > bf->size || addr + sizeof(thunk_addr) > bf->size) {
 		goto out_error;
 	}
-	i = rz_buf_read_at(bf->buf, addr, (ut8 *)&thunk_addr, sizeof(thunk_addr));
-	if (i != sizeof(thunk_addr)) {
-		goto out_error;
+	for (size_t i = 0; i < RZ_ARRAY_SIZE(thunk_addr); i++) {
+		if (!rz_buf_read_le32_at(bf->buf, addr + i * sizeof(ut32), &thunk_addr[i])) {
+			goto out_error;
+		}
 	}
-	for (i = 0; i < XBE_MAX_THUNK && thunk_addr[i]; i++) {
+	for (size_t i = 0; i < XBE_MAX_THUNK && thunk_addr[i]; i++) {
 		RzBinSymbol *sym = RZ_NEW0(RzBinSymbol);
 		if (!sym) {
 			goto out_error;
@@ -298,7 +314,6 @@ static RzList *symbols(RzBinFile *bf) {
 		const ut32 thunk_index = thunk_addr[i] ^ 0x80000000;
 		// Basic sanity checks
 		if (thunk_addr[i] & 0x80000000 && thunk_index > 0 && thunk_index <= XBE_MAX_THUNK) {
-			eprintf("thunk_index %d\n", thunk_index);
 			sym->name = rz_str_newf("kt.%s", kt_name[thunk_index - 1]);
 			sym->vaddr = (h->kernel_thunk_addr ^ obj->kt_key) + (4 * i);
 			sym->paddr = sym->vaddr - h->base;

--- a/test/db/formats/xbe
+++ b/test/db/formats/xbe
@@ -66,3 +66,16 @@ CMDS=q!
 EXPECT=<<EOF
 EOF
 RUN
+
+NAME=xbe library versions
+FILE=bins/xbe/nxdk-hello-dummy-libs.xbe
+CMDS=il
+EXPECT=<<EOF
+library       
+--------------
+RIZIN0 42.5.0
+RIZIN1 42.6.1
+RIZIN2 42.7.2
+RIZIN3 42.8.3
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Apart from obvious big endian parsing bugs, this also tests `il` with
xbe, since that had endianness issues too and was previously untested.
To be able to have meaningful tests there, extra entries for the
explicit kernel and xapi pointers found in the xbe header have been
removed, since these always seem to point into the regular library array
anyway and would thus result in duplicates.

**Test plan**

This fixes test/db/formats/xbe on OpenBSD/sparc64.