### PR TITLE
Refactor and replace .dm* calls with pure C

### DIFF
--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -465,7 +465,7 @@ RZ_API bool rz_core_file_reopen(RzCore *core, const char *args, int perm, int lo
 	}
 	rz_core_seek(core, origoff, true);
 	if (isdebug) {
-		rz_core_cmd0(core, ".dm*");
+		rz_core_debug_map_update_flags(core);
 		rz_core_reg_update_flags(core);
 		rz_core_seek_to_register(core, "PC", false);
 	} else {

--- a/librz/core/cmd/cmd_debug.c
+++ b/librz/core/cmd/cmd_debug.c
@@ -1021,7 +1021,7 @@ static bool get_bin_info(RzCore *core, const char *file, ut64 baseaddr, PJ *pj,
 RZ_IPI RzCmdStatus rz_cmd_debug_list_maps_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
 	CMD_CHECK_DEBUG_DEAD(core);
 	rz_debug_map_sync(core->dbg); // update process memory maps
-	rz_debug_map_print(core->dbg, core->offset, state);
+	rz_core_debug_map_print(core, core->offset, state);
 	return RZ_CMD_STATUS_OK;
 }
 
@@ -1081,7 +1081,7 @@ RZ_IPI RzCmdStatus rz_cmd_debug_map_current_handler(RzCore *core, int argc, cons
 	// RZ_OUTPUT_MODE_LONG is workaround for '.'
 	RzCmdStateOutput state = { 0 };
 	rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_LONG);
-	rz_debug_map_print(core->dbg, addr, &state);
+	rz_core_debug_map_print(core, addr, &state);
 	rz_cmd_state_output_print(&state);
 	rz_cmd_state_output_fini(&state);
 	rz_cons_flush();

--- a/librz/debug/dmap.c
+++ b/librz/debug/dmap.c
@@ -95,6 +95,6 @@ RZ_API RzList *rz_debug_map_list_new(void) {
  * \param user_map Boolean value, if true return memory maps belonging to user space else return memory maps belonging to kernel space
  * \return
  */
-RZ_API RzList *rz_debug_map_list(RzDebug *dbg, bool user_map) {
+RZ_API RZ_BORROW RzList *rz_debug_map_list(RzDebug *dbg, bool user_map) {
 	return user_map ? dbg->maps_user : dbg->maps;
 }

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -71,6 +71,7 @@ RZ_LIB_VERSION_HEADER(rz_core);
 #define RZ_FLAGS_FS_MMIO_REGISTERS_EXTENDED "registers.extended"
 #define RZ_FLAGS_FS_PLATFORM_PORTS          "platform.ports"
 #define RZ_FLAGS_FS_GLOBALS                 "globals"
+#define RZ_FLAGS_FS_DEBUG_MAPS              "maps"
 
 #define RZ_GRAPH_FORMAT_NO     0
 #define RZ_GRAPH_FORMAT_GMLFCN 1
@@ -673,6 +674,8 @@ RZ_API RZ_OWN RzList /*<RzBacktrace *>*/ *rz_core_debug_backtraces(RzCore *core)
 RZ_API void rz_backtrace_free(RZ_NULLABLE RzBacktrace *bt);
 
 RZ_API RzCmdStatus rz_core_debug_plugins_print(RzCore *core, RzCmdStateOutput *state);
+RZ_API void rz_core_debug_map_update_flags(RzCore *core);
+RZ_API void rz_core_debug_map_print(RzCore *core, ut64 addr, RzCmdStateOutput *state);
 
 /* chash.c */
 RZ_API RzCmdStatus rz_core_hash_plugins_print(RzHash *hash, RzCmdStateOutput *state);

--- a/librz/include/rz_debug.h
+++ b/librz/include/rz_debug.h
@@ -501,9 +501,8 @@ RZ_API RzList *rz_debug_map_list_new(void);
 RZ_API RzDebugMap *rz_debug_map_get(RzDebug *dbg, ut64 addr);
 RZ_API RzDebugMap *rz_debug_map_new(char *name, ut64 addr, ut64 addr_end, int perm, int user);
 RZ_API void rz_debug_map_free(RzDebugMap *map);
-RZ_API void rz_debug_map_print(RzDebug *dbg, ut64 addr, RzCmdStateOutput *state);
 RZ_API void rz_debug_map_list_visual(RzDebug *dbg, ut64 addr, const char *input, int colors);
-RZ_API RzList *rz_debug_map_list(RzDebug *dbg, bool user_map);
+RZ_API RZ_BORROW RzList *rz_debug_map_list(RzDebug *dbg, bool user_map);
 
 /* descriptors */
 RZ_API RzDebugDesc *rz_debug_desc_new(int fd, char *path, int perm, int type, int off);

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -1188,7 +1188,7 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 					}
 				}
 			}
-			rz_core_cmd0(r, ".dm*");
+			rz_core_debug_map_update_flags(r);
 			// Set Thumb Mode if necessary
 			RzRegItem *thumb_reg = rz_reg_get(r->dbg->reg, "thumb", RZ_REG_TYPE_ANY);
 			if (thumb_reg && rz_reg_get_value(r->dbg->reg, thumb_reg)) {

--- a/test/db/archos/darwin-arm64/dbg
+++ b/test/db/archos/darwin-arm64/dbg
@@ -33,3 +33,38 @@ str x8, [sp, 0x10]
 EOF
 RUN
 
+NAME=maps
+FILE=bins/mach0/hello-macos-arm64
+ARGS=-d
+CMDS=<<EOF
+dm~hello~[3-]
+EOF
+REGEXP_FILTER_OUT=([a-zA-Z0-9_\.-]+\s+)
+EXPECT=<<EOF
+- usr 16K u r-x hello-macos-arm64 hello-macos-arm64 hello_macos_arm64.r_x
+- usr 16K u rw- hello-macos-arm64 hello-macos-arm64 hello_macos_arm64.rw
+- usr 16K u rw- hello-macos-arm64 hello-macos-arm64 hello_macos_arm64.rw.0
+- usr 16K u r-- hello-macos-arm64 hello-macos-arm64 hello_macos_arm64.r
+EOF
+RUN
+
+NAME=maps as flags
+FILE=bins/mach0/hello-macos-arm64
+ARGS=-d
+CMDS=<<EOF
+fl@F:maps~hello~[1-]
+?e --
+dm*~hello~[0-2]
+EOF
+EXPECT=<<EOF
+16384 hello_macos_arm64.r_x
+16384 hello_macos_arm64.rw
+16384 hello_macos_arm64.rw.0
+16384 hello_macos_arm64.r
+--
+f+ map.hello_macos_arm64.r_x 0x00004000
+f+ map.hello_macos_arm64.rw 0x00004000
+f+ map.hello_macos_arm64.rw 0x00004000
+f+ map.hello_macos_arm64.r 0x00004000
+EOF
+RUN

--- a/test/db/archos/darwin-x64/dbg
+++ b/test/db/archos/darwin-x64/dbg
@@ -33,3 +33,37 @@ lea rsi, reloc.objc_msgSend_fixup
 EOF
 RUN
 
+NAME=maps
+FILE=bins/mach0/hello-objc-osx
+ARGS=-d
+CMDS=<<EOF
+dm~hello
+EOF
+REGEXP_FILTER_OUT=([a-zA-Z0-9_\.-]+\s+)
+EXPECT=<<EOF
+0x0000000100000000 - 0x0000000100001000 - usr     4K u r-x hello-objc-osx hello-objc-osx hello_objc_osx.r_x
+0x0000000100001000 - 0x0000000100002000 - usr     4K u rw- hello-objc-osx hello-objc-osx hello_objc_osx.rw
+0x0000000100002000 - 0x0000000100003000 - usr     4K u r-- hello-objc-osx hello-objc-osx hello_objc_osx.r
+EOF
+RUN
+
+NAME=maps as flags
+FILE=bins/mach0/hello-objc-osx
+ARGS=-d
+CMDS=<<EOF
+fl@F:maps~hello
+?e --
+dm*~hello,fss
+EOF
+EXPECT=<<EOF
+0x100000000 4096 hello_objc_osx.r_x
+0x100001000 4096 hello_objc_osx.rw
+0x100002000 4096 hello_objc_osx.r
+--
+fss+ maps
+f+ map.hello_objc_osx.r_x 0x00001000 @ 0x100000000
+f+ map.hello_objc_osx.rw 0x00001000 @ 0x100001000
+f+ map.hello_objc_osx.r 0x00001000 @ 0x100002000
+fss-
+EOF
+RUN

--- a/test/db/archos/linux-x64/dbg_maps
+++ b/test/db/archos/linux-x64/dbg_maps
@@ -22,6 +22,20 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=debug map flags count
+FILE=bins/elf/analysis/elf-nx
+ARGS=-d
+CMDS=<<EOF
+fl@F:maps~?
+dm*~?
+dk 9
+EOF
+EXPECT=<<EOF
+9
+11
+EOF
+RUN
+
 NAME=dbg.maps.count.after.map
 FILE=bins/elf/analysis/x86-helloworld-gcc
 ARGS=-d

--- a/test/db/archos/linux-x64/dbg_oo
+++ b/test/db/archos/linux-x64/dbg_oo
@@ -95,6 +95,21 @@ Hello world!
 EOF
 RUN
 
+NAME=dm flags after ood
+FILE=bins/elf/analysis/x86-helloworld-gcc
+ARGS=-e log.level=5
+CMDS=<<EOF
+ood
+fl@F:maps~?
+dm*~?
+dk 9
+EOF
+EXPECT=<<EOF
+9
+11
+EOF
+RUN
+
 NAME=ood check for ptrace errors
 FILE=bins/elf/analysis/x86-helloworld-gcc
 ARGS=-e log.level=5
@@ -104,6 +119,5 @@ EOF
 REGEXP_FILTER_ERR=([a-zA-Z-]+\s+)
 EXPECT_ERR=<<EOF
 Process with PID File -helloworld-gcc  reopened in read-write mode
-Cannot create flag at because there is already flag
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This fixes the following minor issues:
* Errors like "Cannot create flag (...) because there is already (...)
  flag" during debug startup
* Unnecessary seeks during .dm* causing io reads and e.g. delays of up
  to 5s on x86 macOS during debug startup
* Flags are now created in the "maps" flagspace, rather than globally,
  making them easier to clean up later


**Test plan**

See added tests.