### PR TITLE
Remove lcmds field on RzCmd

### DIFF
--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -194,7 +194,6 @@ RZ_API RzCmd *rz_cmd_new(bool has_cons) {
 		return cmd;
 	}
 	cmd->has_cons = has_cons;
-	cmd->lcmds = rz_list_new();
 	for (i = 0; i < NCMDS; i++) {
 		cmd->cmds[i] = NULL;
 	}
@@ -215,7 +214,6 @@ RZ_API RzCmd *rz_cmd_free(RzCmd *cmd) {
 	rz_cmd_alias_free(cmd);
 	rz_cmd_macro_fini(&cmd->macro);
 	ht_pp_free(cmd->ht_cmds);
-	rz_list_free(cmd->lcmds);
 	for (i = 0; i < NCMDS; i++) {
 		if (cmd->cmds[i]) {
 			RZ_FREE(cmd->cmds[i]);

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -480,7 +480,6 @@ typedef struct rz_cmd_t {
 	RzCmdNullCb nullcallback;
 	RzCmdItem *cmds[UT8_MAX];
 	RzCmdMacro macro;
-	RzList *lcmds;
 	RzCmdAlias aliases;
 	void *language; // used to store TSLanguage *
 	HtUP *ts_symbols_ht;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The `lcmds` field of the `RzCmd` struct is not used anywhere.