### PR TITLE
Skip including lzma.h if not available

### DIFF
--- a/librz/util/compression.c
+++ b/librz/util/compression.c
@@ -3,7 +3,10 @@
 
 #include <rz_util.h>
 #include <zlib.h>
+
+#if HAVE_LZMA
 #include <lzma.h>
+#endif
 
 // set a maximum output buffer of 50MB
 #define MAXOUT 50000000


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This fixes compilation with -Duse_lzma=false

**Test plan**

`meson build -Duse_lzma=false && ninja -C build`