### PR TITLE
Fix rz_heap_glibc circular include

### DIFF
--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -9,8 +9,6 @@
 extern "C" {
 #endif
 
-typedef struct rz_core_t RzCore;
-
 // RZ_LIB_VERSION_HEADER (rz_cmd);
 
 #define MACRO_LIMIT   1024

--- a/librz/include/rz_heap_glibc.h
+++ b/librz/include/rz_heap_glibc.h
@@ -1,7 +1,8 @@
 #ifndef RZ_HEAP_GLIBC_H
 #define RZ_HEAP_GLIBC_H
 
-#include <rz_core.h>
+#include <rz_types.h>
+#include <rz_list.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -674,4 +674,6 @@ typedef int RzRef;
 		rz_unref(x, n##_free); \
 	}
 
+typedef struct rz_core_t RzCore;
+
 #endif // RZ_TYPES_H


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
`rz_heap_glibc.h` gets included by `rz_core.h` so I was wrong to include `rz_core.h` from heap_glibc.
Instead I forward-declare `RzCore`, like in `rz_cmd.h`