### PR TITLE
Fix Coverity defects for SuperH lifting, assembler and disassembler

### DIFF
--- a/librz/asm/arch/sh/assembler.c
+++ b/librz/asm/arch/sh/assembler.c
@@ -106,6 +106,9 @@ static ut32 sh_op_param_bits(SHParamBuilder shb, const char *param, SHScaling sc
 	case SH_REG_INDIRECT_I: {
 		// @%s+
 		char *plus = strchr(dup, '+');
+		if (!plus) {
+			break;
+		}
 		*plus = '\0';
 		sscanf(dup, "@%s", reg);
 		opcode = sh_op_reg_bits(reg, shba.start);
@@ -119,11 +122,17 @@ static ut32 sh_op_param_bits(SHParamBuilder shb, const char *param, SHScaling sc
 	case SH_REG_INDIRECT_DISP: {
 		// @(%s,%s)
 		char *comma = strchr(dup, ',');
+		if (!comma) {
+			break;
+		}
 		*comma = '\0';
 		sscanf(dup, "@(%s", disp);
 
 		comma++;
 		char *paren = strchr(comma, ')');
+		if (!paren) {
+			break;
+		}
 		*paren = '\0';
 
 		d = (rz_num_get(NULL, disp) / sh_scaling_size[scaling]) & 0xf;
@@ -134,6 +143,9 @@ static ut32 sh_op_param_bits(SHParamBuilder shb, const char *param, SHScaling sc
 	case SH_REG_INDIRECT_INDEXED: {
 		// @(r0,%s)
 		char *paren = strchr(dup, ')');
+		if (!paren) {
+			break;
+		}
 		*paren = '\0';
 		paren = dup + strlen("@(r0,");
 		opcode = sh_op_reg_bits(paren, shba.start);
@@ -142,6 +154,9 @@ static ut32 sh_op_param_bits(SHParamBuilder shb, const char *param, SHScaling sc
 	case SH_GBR_INDIRECT_DISP: {
 		// @(%s,gbr)
 		char *comma = strchr(dup, ',');
+		if (!comma) {
+			break;
+		}
 		*comma = '\0';
 		sscanf(dup, "@(%s", disp);
 		d = rz_num_get(NULL, disp) / sh_scaling_size[scaling];
@@ -151,6 +166,9 @@ static ut32 sh_op_param_bits(SHParamBuilder shb, const char *param, SHScaling sc
 	case SH_PC_RELATIVE_DISP: {
 		// @(%s,pc)
 		char *comma = strchr(dup, ',');
+		if (!comma) {
+			break;
+		}
 		*comma = '\0';
 		sscanf(dup, "@(%s,pc)", disp);
 		d = rz_num_get(NULL, disp) / sh_scaling_size[scaling];

--- a/librz/asm/arch/sh/assembler.c
+++ b/librz/asm/arch/sh/assembler.c
@@ -193,9 +193,15 @@ static ut64 sh_op_movl_param_bits(const char *reg_direct, const char *reg_disp_i
 
 	char *const dup = strdup(reg_disp_indirect);
 	char *comma = strchr(dup, ',');
+	if (!comma) {
+		goto fail;
+	}
 	*comma = '\0';
 	char *reg = comma + 1;
 	char *paren = strchr(reg, ')');
+	if (!paren) {
+		goto fail;
+	}
 	*paren = '\0';
 
 	char *const disp = strdup(reg_disp_indirect);
@@ -204,8 +210,9 @@ static ut64 sh_op_movl_param_bits(const char *reg_direct, const char *reg_disp_i
 	opcode |= d << NIB0;
 	opcode |= sh_op_reg_bits(reg, NIB2);
 
-	free(dup);
 	free(disp);
+fail:
+	free(dup);
 	return opcode;
 }
 

--- a/librz/asm/arch/sh/disassembler.c
+++ b/librz/asm/arch/sh/disassembler.c
@@ -226,7 +226,7 @@ RZ_IPI RZ_OWN char *sh_op_to_str(RZ_NONNULL const SHOp *op, ut64 pc) {
 	if (!op->str_mnem) {
 		return NULL;
 	}
-	RzStrBuf *buf = rz_strbuf_new(rz_str_newf("%s", op->str_mnem));
+	RzStrBuf *buf = rz_strbuf_new(op->str_mnem);
 
 	char *param = NULL;
 	if ((param = sh_op_param_to_str(op->param[0], op->scaling, pc))) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

 - Check for `NULL` result for `strchr` in `sh_op_movl_param_bits`


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

CI should be green and Coverity should not give any defects (to be checked once merged).

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None.
