### PR TITLE
Upgrade Python to 3.7.x for old Debian CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,7 +366,7 @@ jobs:
           ./configure
           make install
         env:
-          PYVERSION: 3.6.12
+          PYVERSION: 3.7.13
       - name: Install Meson and Ninja
         run: |
           mkdir ${HOME}/.cache


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Supposed to resolve this error in Debian builds (still happens in CentOS too):
```
 [129/1956] Generating gittip_file with a custom command
FAILED: gittip 
/usr/bin/python3 ../sys/meson_git_wrapper.py /usr/bin/git /__w/rizin/rizin/rizin rev-parse HEAD
Traceback (most recent call last):
  File "../sys/meson_git_wrapper.py", line 63, in <module>
    main()
  File "../sys/meson_git_wrapper.py", line 59, in main
    simple_git_execution([git_exe] + args)
  File "../sys/meson_git_wrapper.py", line 28, in simple_git_execution
    called = subprocess.run(args, check=True, capture_output=True)
  File "/usr/lib64/python3.6/subprocess.py", line 423, in run
    with Popen(*popenargs, **kwargs) as process:
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
