### PR TITLE
core/cmd: fix afx command JSON output

### DIFF
--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -3692,11 +3692,8 @@ RZ_IPI RzCmdStatus rz_analysis_function_xrefs_handler(RzCore *core, int argc, co
 	ut64 oaddr = core->offset;
 	RzCmdStatus status = RZ_CMD_STATUS_OK;
 	RzList *xrefs = rz_analysis_function_get_xrefs_from(fcn);
-	if (state->mode == RZ_OUTPUT_MODE_JSON) {
-		xref_list_print_to_json(core, xrefs, state->d.pj);
-		status = RZ_CMD_STATUS_WRONG_ARGS;
-		goto exit;
-	}
+	rz_cmd_state_output_array_start(state);
+
 	RzAnalysisXRef *xref;
 	RzListIter *iter;
 	rz_list_foreach (xrefs, iter, xref) {
@@ -3726,6 +3723,9 @@ RZ_IPI RzCmdStatus rz_analysis_function_xrefs_handler(RzCore *core, int argc, co
 			}
 			}
 			break;
+		case RZ_OUTPUT_MODE_JSON:
+			xref_print_to_json(core, xref, state->d.pj);
+			break;
 		default:
 			rz_warn_if_reached();
 			status = RZ_CMD_STATUS_WRONG_ARGS;
@@ -3735,6 +3735,7 @@ RZ_IPI RzCmdStatus rz_analysis_function_xrefs_handler(RzCore *core, int argc, co
 	rz_core_seek(core, oaddr, 1);
 exit:
 	rz_list_free(xrefs);
+	rz_cmd_state_output_array_end(state);
 	return status;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

For some reason WRONG_ARGS was returned in the JSON path of `afx`. This PR fixes it by using a "common" pattern when implementing argv_state-kind of commands, with a switch within a for-loop .

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

```
rizin -A /bin/ls
afxj
```
you should get some output (without this PR it will tell you "wrong arguments").

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
