### PR TITLE
Resolve golang string structures in data section

### DIFF
--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -1121,6 +1121,53 @@ RZ_API void rz_bin_section_free(RzBinSection *bs) {
 	}
 }
 
+static bool is_data_permission(ut32 permissions) {
+	switch (permissions) {
+	case RZ_PERM_R:
+		/* fall-thru */
+	case RZ_PERM_RX:
+		/* fall-thru */
+	case RZ_PERM_RW:
+		return true;
+	default:
+		return false;
+	}
+}
+
+/**
+ * \brief      Checks whether the given section contains data
+ *
+ * \param      section  The section to test
+ *
+ * \return     Returns false on error or if is not a data section, otherwise true
+ */
+RZ_API bool rz_bin_section_is_data(RZ_NONNULL RzBinSection *section) {
+	rz_return_val_if_fail(section, false);
+	if (section->size < 1) {
+		return false;
+	} else if (section->name && strstr(section->name, "data")) {
+		return true;
+	}
+	return is_data_permission(section->perm & RZ_PERM_RWX);
+}
+
+/**
+ * \brief      Checks whether the given map contains data
+ *
+ * \param      map  The map to test
+ *
+ * \return     Returns false on error or if is not a data map, otherwise true
+ */
+RZ_API bool rz_bin_map_is_data(RZ_NONNULL RzBinMap *map) {
+	rz_return_val_if_fail(map, false);
+	if (map->psize < 1) {
+		return false;
+	} else if (map->name && strstr(map->name, "data")) {
+		return true;
+	}
+	return is_data_permission(map->perm & RZ_PERM_RWX);
+}
+
 /**
  * \brief Converts the RzBinSection type to the string representation
  *

--- a/librz/bin/bobj.c
+++ b/librz/bin/bobj.c
@@ -785,6 +785,14 @@ RZ_API RZ_OWN RzList /*<RzBinSection *>*/ *rz_bin_object_get_segments(RZ_NONNULL
 }
 
 /**
+ * \brief Get list of \p RzBinMap representing only the maps of the binary object.
+ */
+RZ_API RZ_OWN RzList /*<RzBinMap *>*/ *rz_bin_object_get_maps(RZ_NONNULL RzBinObject *obj) {
+	rz_return_val_if_fail(obj, NULL);
+	return obj->maps;
+}
+
+/**
  * \brief Get list of \p RzBinClass representing the classes (e.g. C++ classes) defined in the binary object.
  */
 RZ_API const RzList /*<RzBinClass *>*/ *rz_bin_object_get_classes(RZ_NONNULL RzBinObject *obj) {

--- a/librz/core/golang.c
+++ b/librz/core/golang.c
@@ -1651,7 +1651,7 @@ static void core_recover_golang_strings_from_data_pointers(RzCore *core, GoStrRe
 				break;
 			}
 
-			if (0 > rz_io_nread_at(core->io, current, buffer, length)) {
+			if (rz_io_nread_at(core->io, current, buffer, length) < 0) {
 				RZ_LOG_ERROR("Failed to read map at address %" PFMT64x "\n", current);
 				break;
 			}

--- a/librz/core/golang.c
+++ b/librz/core/golang.c
@@ -1616,7 +1616,7 @@ static ut32 golang_recover_string_riscv64(GoStrRecover *ctx) {
 // the first offset is always the pointer to the squashed strings and the next word
 // is the size of the string
 static void core_recover_golang_strings_from_data_pointers(RzCore *core, GoStrRecover *ctx) {
-	rz_core_notify_begin(core, "Recovering go strings from the data sections");
+	rz_core_notify_begin(core, "Recovering go strings from bin maps");
 
 	RzAnalysis *analysis = core->analysis;
 	const ut32 word_size = analysis->bits / 8;
@@ -1677,7 +1677,7 @@ static void core_recover_golang_strings_from_data_pointers(RzCore *core, GoStrRe
 
 end:
 	free(buffer);
-	rz_core_notify_done(core, "Recovering go strings from the data sections");
+	rz_core_notify_done(core, "Recovering go strings from bin maps");
 }
 
 /**

--- a/librz/core/golang.c
+++ b/librz/core/golang.c
@@ -4,6 +4,7 @@
 #include <rz_core.h>
 
 #define GO_MAX_STRING_SIZE 0x4000
+#define GO_MAX_TABLE_SIZE  0x10000
 
 #define GO_1_2  (12)
 #define GO_1_16 (116)
@@ -527,6 +528,12 @@ static bool add_new_bin_string(RzCore *core, char *string, ut64 vaddr, ut32 size
 static bool recover_string_at(GoStrRecover *ctx, ut64 str_addr, ut64 str_size) {
 	// check that the values are acceptable.
 	if (str_size < 2 || str_size > GO_MAX_STRING_SIZE || str_addr < 1 || str_addr == UT64_MAX) {
+		return false;
+	}
+
+	// skip possible pointers that matches to symbols flags, because these are already handled.
+	RzFlagItem *fi = rz_flag_get_by_spaces(ctx->core->flags, str_addr, RZ_FLAGS_FS_SYMBOLS, NULL);
+	if (fi && !strncmp(fi->name, "sym.", 4)) {
 		return false;
 	}
 
@@ -1605,6 +1612,74 @@ static ut32 golang_recover_string_riscv64(GoStrRecover *ctx) {
 	return 4;
 }
 
+// Sometimes the data-structures has strings, but these are stored in tables where
+// the first offset is always the pointer to the squashed strings and the next word
+// is the size of the string
+static void core_recover_golang_strings_from_data_pointers(RzCore *core, GoStrRecover *ctx) {
+	rz_core_notify_begin(core, "Recovering go strings from the data sections");
+
+	RzAnalysis *analysis = core->analysis;
+	const ut32 word_size = analysis->bits / 8;
+	RzListIter *iter;
+	RzBinMap *map;
+	ut8 *buffer = NULL;
+	ut64 string_addr, string_size;
+	RzBinObject *object = rz_bin_cur_object(core->bin);
+	RzList *map_list = object ? rz_bin_object_get_maps(object) : NULL;
+	if (!map_list) {
+		RZ_LOG_ERROR("Failed to get the RzBinMap list\n");
+		goto end;
+	}
+
+	buffer = malloc(GO_MAX_TABLE_SIZE);
+	if (!buffer) {
+		RZ_LOG_ERROR("Failed to allocate table buffer\n");
+		goto end;
+	}
+
+	rz_list_foreach (map_list, iter, map) {
+		if (!rz_bin_map_is_data(map) || map->psize < (word_size * 2)) {
+			continue;
+		}
+
+		ut64 current = map->vaddr;
+		ut64 end = map->vaddr + map->psize;
+
+		do {
+			size_t length = RZ_MIN((end - current), GO_MAX_TABLE_SIZE);
+			if (length < (word_size * 2)) {
+				break;
+			}
+
+			if (0 > rz_io_nread_at(core->io, current, buffer, length)) {
+				RZ_LOG_ERROR("Failed to read map at address %" PFMT64x "\n", current);
+				break;
+			}
+
+			length -= word_size;
+			for (size_t i = 0; i < length; i += word_size) {
+				string_addr = rz_read_ble(buffer + i, analysis->big_endian, analysis->bits);
+				string_size = rz_read_ble(buffer + i + word_size, analysis->big_endian, analysis->bits);
+				if (!string_addr || !string_size) {
+					continue;
+				} else if (word_size == sizeof(ut32) && string_addr == UT32_MAX) {
+					continue;
+				} else if (word_size == sizeof(ut64) && string_addr == UT64_MAX) {
+					continue;
+				}
+				if (recover_string_at(ctx, string_addr, string_size)) {
+					rz_analysis_xrefs_set(analysis, current + i, string_addr, RZ_ANALYSIS_XREF_TYPE_STRING);
+				}
+			}
+			current += length;
+		} while (current < end);
+	}
+
+end:
+	free(buffer);
+	rz_core_notify_done(core, "Recovering go strings from the data sections");
+}
+
 /**
  * \brief      Attempts to recover all golang string
  *
@@ -1612,7 +1687,6 @@ static ut32 golang_recover_string_riscv64(GoStrRecover *ctx) {
  */
 RZ_API void rz_core_analysis_resolve_golang_strings(RzCore *core) {
 	rz_return_if_fail(core && core->analysis && core->analysis->fcns && core->io);
-	rz_core_notify_begin(core, "Analyze all instructions to recover all strings used in sym.go.*");
 
 	const char *asm_arch = rz_config_get(core->config, "asm.arch");
 	ut32 asm_bits = rz_config_get_i(core->config, "asm.bits");
@@ -1625,6 +1699,9 @@ RZ_API void rz_core_analysis_resolve_golang_strings(RzCore *core) {
 	GoStrRecover ctx = { 0 };
 	ctx.core = core;
 
+	core_recover_golang_strings_from_data_pointers(core, &ctx);
+
+	rz_core_notify_begin(core, "Analyze all instructions to recover all strings used in sym.go.*");
 	if (!strcmp(asm_arch, "x86")) {
 		switch (asm_bits) {
 		case 32:

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -815,10 +815,12 @@ typedef struct rz_bin_bind_t {
 
 RZ_API void rz_bin_virtual_file_free(RzBinVirtualFile *vfile);
 RZ_API void rz_bin_map_free(RzBinMap *map);
+RZ_API bool rz_bin_map_is_data(RZ_NONNULL RzBinMap *map);
 RZ_API RZ_OWN RzList /*<RzBinMap *>*/ *rz_bin_maps_of_file_sections(RZ_NONNULL RzBinFile *binfile);
 RZ_API RzList /*<RzBinSection *>*/ *rz_bin_sections_of_maps(RzList /*<RzBinMap *>*/ *maps);
 RZ_API RzBinSection *rz_bin_section_new(const char *name);
 RZ_API void rz_bin_section_free(RzBinSection *bs);
+RZ_API bool rz_bin_section_is_data(RZ_NONNULL RzBinSection *section);
 RZ_API RZ_OWN char *rz_bin_section_type_to_string(RzBin *bin, int type);
 RZ_API RZ_OWN RzList /*<char *>*/ *rz_bin_section_flag_to_list(RzBin *bin, ut64 flag);
 RZ_API void rz_bin_info_free(RzBinInfo *rb);
@@ -917,6 +919,7 @@ RZ_API const RzList /*<char *>*/ *rz_bin_object_get_libs(RZ_NONNULL RzBinObject 
 RZ_API const RzList /*<RzBinSection *>*/ *rz_bin_object_get_sections_all(RZ_NONNULL RzBinObject *obj);
 RZ_API RZ_OWN RzList /*<RzBinSection *>*/ *rz_bin_object_get_sections(RZ_NONNULL RzBinObject *obj);
 RZ_API RZ_OWN RzList /*<RzBinSection *>*/ *rz_bin_object_get_segments(RZ_NONNULL RzBinObject *obj);
+RZ_API RZ_OWN RzList /*<RzBinMap *>*/ *rz_bin_object_get_maps(RZ_NONNULL RzBinObject *obj);
 RZ_API const RzList /*<RzBinClass *>*/ *rz_bin_object_get_classes(RZ_NONNULL RzBinObject *obj);
 RZ_API const RzList /*<RzBinString *>*/ *rz_bin_object_get_strings(RZ_NONNULL RzBinObject *obj);
 RZ_API const RzList /*<RzBinMem *>*/ *rz_bin_object_get_mem(RZ_NONNULL RzBinObject *obj);

--- a/test/db/analysis/golang
+++ b/test/db/analysis/golang
@@ -17,7 +17,7 @@ EXPECT=<<EOF
 0x0063e49b str.version
 0x0063e4ac str.HTTP_version
 0x0063e566 str.
-12937
+14294
 EOF
 RUN
 
@@ -44,7 +44,7 @@ EXPECT=<<EOF
 ;-- str.flag:
 ;-- str.sort:
 ;-- str.sync:
-12321
+13495
 EOF
 RUN
 
@@ -67,7 +67,7 @@ EXPECT=<<EOF
 0x0065de6d str.version
 0x0065de8a str.HTTP_version
 0x0065dfe6 str.
-13224
+14341
 EOF
 RUN
 
@@ -129,7 +129,7 @@ EXPECT=<<EOF
 0x0027401c str.btcctl.conf
 0x00274090 str.rpc.cert
 0x00274104 str.rpc.cert
-12895
+14104
 EOF
 RUN
 
@@ -212,7 +212,7 @@ EXPECT=<<EOF
 0x0026e4b8 str.btcctl.conf
 0x0026e53c str.rpc.cert
 0x0026e5c0 str.rpc.cert
-14736
+15678
 EOF
 RUN
 
@@ -223,6 +223,7 @@ aalg
 fl~sym.go.~?
 pdfs @ sym.go.runtime.panicwrap ~str.
 izq~?
+izq~ slice bounds out of range
 iI~compiler
 EOF
 EXPECT=<<EOF
@@ -232,7 +233,20 @@ EXPECT=<<EOF
 0x100006e64 str.pointer
 0x100006eac str.panicwrap:_no___in
 0x1000076d0 str.internal_error___misuse_of_itab
-1297
+1709
+0x10008bada 31 31 slice bounds out of range [:%x]
+0x10008babb 31 31 slice bounds out of range [%x:]
+0x10008be19 32 32 slice bounds out of range [::%x]
+0x10008bdf9 32 32 slice bounds out of range [:%x:]
+0x10008bdd9 32 32 slice bounds out of range [%x::]
+0x10008dbfa 46 46 slice bounds out of range [:%x] with length %y
+0x10008ddcf 48 48 slice bounds out of range [:%x] with capacity %y
+0x10008c235 33 33 slice bounds out of range [%x:%y]
+0x10008dd40 47 47 slice bounds out of range [::%x] with length %y
+0x10008dfe8 49 49 slice bounds out of range [::%x] with capacity %y
+0x10008c5a0 34 34 slice bounds out of range [:%x:%y]
+0x10008c57e 34 34 slice bounds out of range [%x:%y:]
+0x10008a871 25 25 slice bounds out of range
 compiler go1.18 (cmd -compiler=gc CGO_ENABLED=1 CGO_CFLAGS= CGO_CPPFLAGS= CGO_CXXFLAGS= CGO_LDFLAGS= GOARCH=arm64 GOOS=darwin)
 EOF
 RUN
@@ -249,7 +263,7 @@ EOF
 EXPECT=<<EOF
 1788
 0x004a699b str.hello__hacktivity
-8555
+9222
 compiler go1.15
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This resolves the go string structures in a very simplistic way by looking for offsets in sections which names contains the `data` substring. all the golang strings in tables are always set in the following way: `pointer` followed by the string `size`, stored in 32 or 64 bit words.

These structures are especially used in go 1.12 and 1.16