### PR TITLE
block cleanup mechanism proposal.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,3 @@
-Language: Cpp
 MaxEmptyLinesToKeep: 1
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false
@@ -8,6 +7,7 @@ ContinuationIndentWidth: 8
 IndentCaseLabels: false
 IndentFunctionDeclarationAfterType: false
 IndentWidth: 8
+ObjCBlockIndentWidth: 8
 UseTab: ForContinuationAndIndentation
 ColumnLimit: 0
 BreakBeforeBraces: Attach

--- a/librz/debug/p/native/linux/linux_debug.c
+++ b/librz/debug/p/native/linux/linux_debug.c
@@ -1332,8 +1332,8 @@ RzList *linux_desc_list(int pid) {
 		return NULL;
 	}
 	ret = rz_list_newf((RzListFree)rz_debug_desc_free);
+	rz_block_cleanup({closedir(dd);});
 	if (!ret) {
-		closedir(dd);
 		return NULL;
 	}
 	while ((de = (struct dirent *)readdir(dd))) {
@@ -1379,11 +1379,9 @@ RzList *linux_desc_list(int pid) {
 		}
 		rz_list_append(ret, desc);
 	}
-	closedir(dd);
 	return ret;
 
 fail:
 	rz_list_free(ret);
-	closedir(dd);
 	return NULL;
 }

--- a/librz/debug/p/native/linux/linux_debug.c
+++ b/librz/debug/p/native/linux/linux_debug.c
@@ -1332,8 +1332,8 @@ RzList *linux_desc_list(int pid) {
 		return NULL;
 	}
 	ret = rz_list_newf((RzListFree)rz_debug_desc_free);
-	rz_block_cleanup({closedir(dd);});
 	if (!ret) {
+		closedir(dd);
 		return NULL;
 	}
 	while ((de = (struct dirent *)readdir(dd))) {
@@ -1379,9 +1379,11 @@ RzList *linux_desc_list(int pid) {
 		}
 		rz_list_append(ret, desc);
 	}
+	closedir(dd);
 	return ret;
 
 fail:
 	rz_list_free(ret);
+	closedir(dd);
 	return NULL;
 }

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -175,20 +175,22 @@ typedef enum {
 #define FUNC_ATTR_ALWAYS_INLINE         __attribute__((always_inline))
 
 #if defined(__clang__) && defined(__BLOCKS__)
-	static inline void rz_dummy(void (^*block)(void)) {
-		(*block)();
+static inline void rz_dummy(void (^*block)(void)) {
+	(*block)();
+}
+#define FUNC_BLOCK_CONCAT(line, block) \
+	__attribute__((unused, cleanup(rz_dummy))) void (^rz_func_block_cleanup_##line)(void) = ^{ \
+		block \
 	}
-#define FUNC_BLOCK_CONCAT(line, block)				\
-	__attribute__((unused, cleanup(rz_dummy))) void (^rz_func_block_cleanup_ ## line)(void) = ^{block}
 #else
-#define FUNC_BLOCK_CONCAT(line, block)				\
-	void rz_func_block_cleanup_ ## line () {		\
-		block						\
-	}							\
-	int __attribute__((unused)) rz_dummy_ ## line __attribute__((__cleanup__(rz_func_block_cleanup_ ## line))) = 0
+#define FUNC_BLOCK_CONCAT(line, block) \
+	void rz_func_block_cleanup_##line() { \
+		block \
+	} \
+	int __attribute__((unused)) rz_dummy_##line __attribute__((__cleanup__(rz_func_block_cleanup_##line))) = 0
 #endif
 #define FUNC_BLOCK_CONCAT2(block, line) FUNC_BLOCK_CONCAT(line, block)
-#define rz_block_cleanup(block) FUNC_BLOCK_CONCAT2(block, __LINE__)
+#define rz_block_cleanup(block)         FUNC_BLOCK_CONCAT2(block, __LINE__)
 #else
 #define FUNC_ATTR_MALLOC
 #define FUNC_ATTR_ALLOC_SIZE(x)

--- a/meson.build
+++ b/meson.build
@@ -113,11 +113,16 @@ endif
 
 add_project_arguments(['-DRZ_PLUGIN_INCORE=1'], language: 'c')
 b_sanitize_opt = get_option('b_sanitize')
-if (b_sanitize_opt.contains('address') or b_sanitize_opt.contains('undefined')) and cc.get_id() == 'clang'
-  add_global_arguments('-shared-libasan', language: 'c')
-  add_global_link_arguments('-shared-libasan', language: 'c')
-  add_global_arguments('-shared-libasan', language: 'c', native: true)
-  add_global_link_arguments('-shared-libasan', language: 'c', native: true)
+if cc.get_id() == 'clang'
+  if cc.has_argument('-fblocks')
+    add_global_arguments('-fblocks', language: ['c', 'cpp'])
+  endif
+  if (b_sanitize_opt.contains('address') or b_sanitize_opt.contains('undefined')) and cc.get_id() == 'clang'
+    add_global_arguments('-shared-libasan', language: 'c')
+    add_global_link_arguments('-shared-libasan', language: 'c')
+    add_global_arguments('-shared-libasan', language: 'c', native: true)
+    add_global_link_arguments('-shared-libasan', language: 'c', native: true)
+  endif
 endif
 
 fs = import('fs')


### PR DESCRIPTION
works mainly with clang/libBlocksRuntime but has gcc implementation as well.
conceal in linux_desc_list for the moment as proof of concept.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)

