### PR TITLE
strbuf.c: Fix some assert return values

### DIFF
--- a/librz/util/strbuf.c
+++ b/librz/util/strbuf.c
@@ -165,7 +165,7 @@ RZ_API const char *rz_strbuf_set(RzStrBuf *sb, const char *s) {
 }
 
 RZ_API const char *rz_strbuf_setf(RzStrBuf *sb, const char *fmt, ...) {
-	rz_return_val_if_fail(sb && fmt, false);
+	rz_return_val_if_fail(sb && fmt, NULL);
 
 	va_list ap;
 	va_start(ap, fmt);
@@ -175,7 +175,7 @@ RZ_API const char *rz_strbuf_setf(RzStrBuf *sb, const char *fmt, ...) {
 }
 
 RZ_API const char *rz_strbuf_vsetf(RzStrBuf *sb, const char *fmt, va_list ap) {
-	rz_return_val_if_fail(sb && fmt, false);
+	rz_return_val_if_fail(sb && fmt, NULL);
 
 	const char *ret = NULL;
 	va_list ap2;
@@ -279,7 +279,7 @@ RZ_API bool rz_strbuf_append_n(RzStrBuf *sb, const char *s, size_t l) {
 RZ_API bool rz_strbuf_appendf(RzStrBuf *sb, const char *fmt, ...) {
 	va_list ap;
 
-	rz_return_val_if_fail(sb && fmt, -1);
+	rz_return_val_if_fail(sb && fmt, false);
 
 	va_start(ap, fmt);
 	bool ret = rz_strbuf_vappendf(sb, fmt, ap);
@@ -292,7 +292,7 @@ RZ_API bool rz_strbuf_vappendf(RzStrBuf *sb, const char *fmt, va_list ap) {
 	va_list ap2;
 	char string[1024];
 
-	rz_return_val_if_fail(sb && fmt, -1);
+	rz_return_val_if_fail(sb && fmt, false);
 
 	if (sb->weakref) {
 		return false;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes some `rz_return_val_if_fail()` return values in `strbuf.c` so that they are of the return type of their enclosing function.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
