### PR TITLE
Avoid warning about unused endian for single byte

### DIFF
--- a/librz/include/rz_util/rz_buf.h
+++ b/librz/include/rz_util/rz_buf.h
@@ -234,8 +234,8 @@ DEFINE_RZ_BUF_WRITE_BLE(64)
 		return true; \
 	}
 
-#define rz_buf_read_ble8_at(b, addr, result, endian) rz_buf_read8_at(b, addr, result)
-#define rz_buf_write_ble8_at(b, addr, value, endian) rz_buf_write8_at(b, addr, value)
+#define rz_buf_read_ble8_at(b, addr, result, endian) ((void)endian, rz_buf_read8_at(b, addr, result))
+#define rz_buf_write_ble8_at(b, addr, value, endian) ((void)endian, rz_buf_write8_at(b, addr, value))
 
 /**
  * \brief Read a big endian or little endian (ut16, ut32, ut64) at the specified offset in the buffer and shifts the offset.


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Currently when building Cutter log gets spammed full with warnings about unused endianess in the 8bit versions of these functions/macros.

**Test plan**

Make sure all the CI platforms still build. I assume core utility functions like this have sufficient test coverage.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
