### PR TITLE
Fix arm64 assembler tests on big endian hosts

### DIFF
--- a/librz/asm/arch/arm/armass64.c
+++ b/librz/asm/arch/arm/armass64.c
@@ -847,7 +847,9 @@ static ut32 logical(ArmOp *op, bool invert, LogicalOp opc) {
 		return UT32_MAX;
 	}
 
-	return rz_read_be32(&data);
+	ut8 flip[4];
+	rz_write_le32(flip, data);
+	return rz_read_be32(flip);
 }
 
 static ut32 adrp(ArmOp *op, ut64 addr, ut32 k) { //, int reg, ut64 dst) {
@@ -950,8 +952,8 @@ static ut32 arithmetic(ArmOp *op, int k) {
 	if (op->operands[2].type & ARM_GPR) {
 		data += op->operands[2].reg << 8;
 	} else {
-		data += (op->operands[2].reg & 0x3f) << 18;
-		data += (op->operands[2].reg >> 6) << 8;
+		data += (op->operands[2].immediate & 0x3f) << 18;
+		data += (op->operands[2].immediate >> 6) << 8;
 	}
 
 	if (op->operands[2].type & ARM_CONSTANT && op->operands[3].type & ARM_SHIFT) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes `test/db/asm/arm_64` on big endian hosts. Tested on OpenBSD/sparc64.