### PR TITLE
Fix asm_riscv on big endian hosts

### DIFF
--- a/librz/asm/arch/riscv/riscv.c
+++ b/librz/asm/arch/riscv/riscv.c
@@ -320,7 +320,11 @@ static int riscv_dis(RzAsm *a, RzAsmOp *rop, const ut8 *buf, ut64 len) {
 	if (len < 2) {
 		return -1;
 	}
-	memcpy (&insn, buf, RZ_MIN (sizeof (insn), len));
+	// Read <= 8 bytes into 8-byte buffer in little endian fashion
+	RZ_STATIC_ASSERT(sizeof(insn) == 8);
+	ut8 tmp[8] = { 0 };
+	memcpy(&tmp, buf, RZ_MIN(sizeof(insn), len));
+	insn = rz_read_le64(tmp);
 	int insn_len = riscv_insn_length(insn);
 	if (len < insn_len) {
 		return -1;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This fixes all tests in test/db/asm/riscv_32 on be, tested on
OpenBSD/sparc64.