### PR TITLE
Fix rz_core_search_value_in_range (aav) for big endian hosts

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4965,17 +4965,17 @@ RZ_API int rz_core_search_value_in_range(RzCore *core, RzInterval search_itv, ut
 				match = (buf[i] >= vmin && buf[i] <= vmax);
 				break;
 			case 2:
-				v16 = *(uut16 *)v;
+				v16 = rz_read_le16(v); // TODO: support big endian
 				match = (v16 >= vmin && v16 <= vmax);
 				value = v16;
 				break;
 			case 4:
-				v32 = *(uut32 *)v;
+				v32 = rz_read_le32(v); // TODO: support big endian
 				match = (v32 >= vmin && v32 <= vmax);
 				value = v32;
 				break;
 			case 8:
-				v64 = *(uut64 *)v;
+				v64 = rz_read_le64(v); // TODO: support big endian
 				match = (v64 >= vmin && v64 <= vmax);
 				value = v64;
 				break;

--- a/librz/include/rz_types_base.h
+++ b/librz/include/rz_types_base.h
@@ -26,13 +26,6 @@ typedef intptr_t ssize_t;
 #define RZ_ALIGNED(x) __attribute__((aligned(x)))
 #endif
 
-typedef RZ_ALIGNED(1) ut16 uut16;
-typedef RZ_ALIGNED(1) ut32 uut32;
-typedef RZ_ALIGNED(1) ut64 uut64;
-typedef RZ_ALIGNED(1) st16 ust16;
-typedef RZ_ALIGNED(1) st32 ust32;
-typedef RZ_ALIGNED(1) st64 ust64;
-
 typedef union {
 	ut8 v8;
 	ut16 v16;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The *(uut64 *)v and similar were naturally dependent on the host endian,
so all current tests assume little endian there, meaning we should use
`rz_read_le...` to fix it on big endian machines without touching the
behavior for now. Later it will be interesting to make this analysis
also respect the to-be-analyzed arch's endianness.

On top of that, the uut64 type's desired unaligned property does not
seem to work on OpenBSD/sparc64 here and it still crashed when the
pointer was unaligned, for example when doing aav on
test/bins/mach0/misaligned_data-iOS-armv7.

This fixes test/db/analysis/arm and possibly others too.