### PR TITLE
Fix tms320 disassembler for big endian hosts

### DIFF
--- a/librz/asm/arch/tms320/tms320_dasm.c
+++ b/librz/asm/arch/tms320/tms320_dasm.c
@@ -18,22 +18,18 @@
 #define get_bits(av, af, an) (((av) >> (af)) & ((2 << (an - 1)) - 1))
 #endif
 
-static inline ut16 be16(ut16 v) {
-	ut16 value = v;
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-	ut8 *pv = (void *)&v;
-	value = (pv[0] << 8) | pv[1];
-#endif
-	return value;
+/**
+ * \return unsigned int to be used as "0x%04X"
+ */
+static inline unsigned int be16(ut16 v) {
+	return ((v & 0xff) << 8) | (v >> 8);
 }
 
-static inline ut32 be24(ut32 v) {
-	ut32 value = v;
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-	ut8 *pv = (void *)&v;
-	value = (pv[0] << 16) | (pv[1] << 8) | pv[2];
-#endif
-	return value;
+/**
+ * \return unsigned int to be used as "0x%06X"
+ */
+static inline unsigned int be24(ut32 v) {
+	return ((v & 0xff) << 16) | (v & 0xff00) | ((v & 0xff0000) >> 16);
 }
 
 /*
@@ -1123,7 +1119,9 @@ insn_head_t *lookup_insn_head(tms320_dasm_t *dasm) {
 
 static void init_dasm(tms320_dasm_t *dasm, const ut8 *stream, int len) {
 	strcpy(dasm->syntax, "invalid");
+	memset(dasm->stream, 0, sizeof(dasm->stream));
 	memcpy(dasm->stream, stream, RZ_MIN(sizeof(dasm->stream), len));
+	dasm->opcode64 = rz_read_le64(dasm->stream);
 
 	dasm->status = 0;
 	dasm->length = 0;

--- a/librz/asm/arch/tms320/tms320_dasm.c
+++ b/librz/asm/arch/tms320/tms320_dasm.c
@@ -418,23 +418,23 @@ const char *get_relop_str(ut8 key, char *str) {
 	return table[key & 3];
 }
 
-const char *get_cond_str(ut8 key, char *str) {
+const char *get_cond_str(ut8 key, char *str, size_t str_sz) {
 	/* 000 FSSS ... 101 FSSS */
 	if ((key >> 4) <= 5) {
 		static const char *op[6] = { "==", "!=", "<", "<=", ">", ">=" };
-		sprintf(str, "%s %s 0", get_freg_str(key & 15, NULL), op[(key >> 4) & 7]);
+		snprintf(str, str_sz, "%s %s 0", get_freg_str(key & 15, NULL), op[(key >> 4) & 7]);
 		return str;
 	}
 
 	/* 110 00SS */
 	if ((key >> 2) == 0x18) {
-		sprintf(str, "overflow(ac%d)", key & 3);
+		snprintf(str, str_sz, "overflow(ac%d)", key & 3);
 		return str;
 	}
 
 	/* 111 00SS */
 	if ((key >> 2) == 0x1C) {
-		sprintf(str, "!overflow(ac%d)", key & 3);
+		snprintf(str, str_sz, "!overflow(ac%d)", key & 3);
 		return str;
 	}
 
@@ -497,14 +497,14 @@ const char *get_cmem_str(ut8 key, char *str) {
 	return table[key & 3];
 }
 
-const char *get_smem_str(ut8 key, char *str) {
+const char *get_smem_str(ut8 key, char *str, size_t str_sz) {
 	// direct memory
 
 	if ((key & 0x01) == 0) {
 #ifdef IDA_COMPATIBLE_MODE
-		sprintf(str, "*sp(#%Xh)", key >> 1);
+		snprintf(str, str_sz, "*sp(#%Xh)", key >> 1);
 #else
-		sprintf(str, "@0x%02X", key >> 1);
+		snprintf(str, str_sz, "@0x%02X", key >> 1);
 #endif
 		return str;
 	}
@@ -798,7 +798,7 @@ void decode_cond(tms320_dasm_t *dasm) {
 	char tmp[64];
 
 	if (field_valid(dasm, CCCCCCC)) {
-		substitute(dasm->syntax, "cond", "%s", get_cond_str(field_value(dasm, CCCCCCC), tmp));
+		substitute(dasm->syntax, "cond", "%s", get_cond_str(field_value(dasm, CCCCCCC), tmp, sizeof(tmp)));
 	}
 
 	substitute(dasm->syntax, "[label, ]", "");
@@ -972,7 +972,7 @@ void decode_addressing_modes(tms320_dasm_t *dasm) {
 	if (field_valid(dasm, AAAAAAAI)) {
 		char str[64], tmp[64];
 
-		snprintf(tmp, sizeof(tmp), "%s", get_smem_str(field_value(dasm, AAAAAAAI), str));
+		snprintf(tmp, sizeof(tmp), "%s", get_smem_str(field_value(dasm, AAAAAAAI), str, sizeof(str)));
 
 		if (field_value(dasm, AAAAAAAI) & 1) {
 			if (strstr(tmp, "k16")) {

--- a/librz/asm/arch/tms320/tms320_dasm.h
+++ b/librz/asm/arch/tms320/tms320_dasm.h
@@ -118,8 +118,8 @@ typedef struct {
 	union {
 		ut8 opcode;
 		ut8 stream[8];
-		ut64 opcode64;
 	};
+	ut64 opcode64; ///< same as rz_read_le64(stream)
 
 #define TMS320_S_INVAL 0x01
 	ut8 status;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The union of stream/opcode64 is unreasonably hard to use right, so we
just read as little endian manually into an extra field. This also
eliminates the need for any endian-specific code, such as in be16/be24.

Tested on OpenBSD/sparc64.
Fixes all tests in test/db/asm/tms320_c55x_32 there.

Plus an additional small change to get rid of sprintf there.