### PR TITLE
Fix oob read and endian dependency in asm_ebc

### DIFF
--- a/librz/analysis/p/analysis_ebc.c
+++ b/librz/analysis/p/analysis_ebc.c
@@ -69,7 +69,7 @@ static int ebc_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *
 
 	op->addr = addr;
 
-	ret = op->size = ebc_decode_command(buf, &cmd);
+	ret = op->size = ebc_decode_command(buf, len, &cmd);
 
 	if (ret < 0) {
 		return ret;

--- a/librz/asm/arch/ebc/ebc_disas.h
+++ b/librz/asm/arch/ebc/ebc_disas.h
@@ -4,7 +4,7 @@
 #ifndef RZ_EBC_DISAS_H
 #define RZ_EBC_DISAS_H
 
-#include <stdint.h>
+#include <rz_types.h>
 
 #define EBC_OPCODE_MASK     0x3F
 #define EBC_MODIFIER_MASK   0xC0
@@ -93,6 +93,6 @@ typedef struct ebc_command {
 	char operands[EBC_OPERANDS_MAXLEN];
 } ebc_command_t;
 
-int ebc_decode_command(const uint8_t *instr, ebc_command_t *cmd);
+RZ_IPI int ebc_decode_command(const ut8 *instr, size_t sz, ebc_command_t *cmd);
 
 #endif /* EBC_DISAS_H */

--- a/librz/asm/p/asm_ebc.c
+++ b/librz/asm/p/asm_ebc.c
@@ -11,7 +11,7 @@
 
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	ebc_command_t cmd = { { 0 }, { 0 } };
-	int ret = ebc_decode_command(buf, &cmd);
+	int ret = ebc_decode_command(buf, len, &cmd);
 	const char *buf_asm = (cmd.operands[0])
 		? sdb_fmt("%s %s", cmd.instr, cmd.operands)
 		: cmd.instr;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes all tests in test/db/asm/ebc on big endian. Tested on
OpenBSD/sparc64.
Also fixes oob reads in cases like `rz-asm -a ebc -d cc`.