### PR TITLE
core/cmd: fix CHOICES argument selection between choices_cb/choices

### DIFF
--- a/librz/core/cautocmpl.c
+++ b/librz/core/cautocmpl.c
@@ -519,13 +519,13 @@ static void autocmplt_cmd_arg_rznum(RzCore *core, RzLineNSCompletionResult *res,
 
 static void autocmplt_cmd_arg_choices(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len, const RzCmdDescArg *arg) {
 	char **oc, **c;
-	oc = c = arg->choices_cb ? arg->choices_cb(core) : (char **)arg->choices;
+	oc = c = arg->choices.choices_cb ? arg->choices.choices_cb(core) : (char **)arg->choices.choices;
 	for (c = oc; c && *c; c++) {
 		if (!strncmp(*c, s, len)) {
 			rz_line_ns_completion_result_add(res, *c);
 		}
 	}
-	if (arg->choices_cb) {
+	if (arg->choices.choices_cb) {
 		for (c = oc; c && *c; c++) {
 			free(*c);
 		}

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -1410,12 +1410,12 @@ static void fill_args_json(const RzCmd *cmd, const RzCmdDesc *cd, PJ *j) {
 		}
 		if (arg->type == RZ_CMD_ARG_TYPE_CHOICES) {
 			pj_ka(j, "choices");
-			char **ochoice = arg->choices_cb ? arg->choices_cb(cmd->data) : (char **)arg->choices;
+			char **ochoice = arg->choices.choices_cb ? arg->choices.choices_cb(cmd->data) : (char **)arg->choices.choices;
 			for (char **choice = ochoice; *choice; choice++) {
 				pj_s(j, *choice);
 			}
 			pj_end(j);
-			if (arg->choices_cb) {
+			if (arg->choices.choices_cb) {
 				for (char **choice = ochoice; *choice; choice++) {
 					free(*choice);
 				}

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -1572,14 +1572,14 @@ static const RzCmdDescArg analysis_function_create_args[] = {
 		.name = "type",
 		.type = RZ_CMD_ARG_TYPE_CHOICES,
 		.optional = true,
-		.choices = analysis_function_create_type_choices,
+		.choices.choices = analysis_function_create_type_choices,
 
 	},
 	{
 		.name = "diff",
 		.type = RZ_CMD_ARG_TYPE_CHOICES,
 		.optional = true,
-		.choices = analysis_function_create_diff_choices,
+		.choices.choices = analysis_function_create_diff_choices,
 
 	},
 	{ 0 },
@@ -1684,7 +1684,7 @@ static const RzCmdDescArg analysis_function_blocks_add_args[] = {
 		.name = "diff",
 		.type = RZ_CMD_ARG_TYPE_CHOICES,
 		.optional = true,
-		.choices = analysis_function_blocks_add_diff_choices,
+		.choices.choices = analysis_function_blocks_add_diff_choices,
 
 	},
 	{ 0 },
@@ -2413,7 +2413,7 @@ static const RzCmdDescArg analysis_function_opcode_stat_args[] = {
 		.name = "mode",
 		.type = RZ_CMD_ARG_TYPE_CHOICES,
 		.optional = true,
-		.choices = analysis_function_opcode_stat_mode_choices,
+		.choices.choices = analysis_function_opcode_stat_mode_choices,
 
 	},
 	{ 0 },
@@ -2429,7 +2429,7 @@ static const RzCmdDescArg analysis_function_all_opcode_stat_args[] = {
 		.name = "mode",
 		.type = RZ_CMD_ARG_TYPE_CHOICES,
 		.optional = true,
-		.choices = analysis_function_all_opcode_stat_mode_choices,
+		.choices.choices = analysis_function_all_opcode_stat_mode_choices,
 
 	},
 	{ 0 },
@@ -4171,7 +4171,7 @@ static const RzCmdDescArg analysis_hint_set_immbase_args[] = {
 	{
 		.name = "type",
 		.type = RZ_CMD_ARG_TYPE_CHOICES,
-		.choices = analysis_hint_set_immbase_type_choices,
+		.choices.choices = analysis_hint_set_immbase_type_choices,
 
 	},
 	{
@@ -4920,7 +4920,7 @@ static const RzCmdDescArg basefind_compute_args[] = {
 		.name = "pointer_bits",
 		.type = RZ_CMD_ARG_TYPE_CHOICES,
 		.optional = true,
-		.choices = basefind_compute_pointer_bits_choices,
+		.choices.choices = basefind_compute_pointer_bits_choices,
 
 	},
 	{ 0 },
@@ -6369,7 +6369,7 @@ static const RzCmdDescArg cmd_debug_add_watchpoint_args[] = {
 	{
 		.name = "perm",
 		.type = RZ_CMD_ARG_TYPE_CHOICES,
-		.choices = cmd_debug_add_watchpoint_perm_choices,
+		.choices.choices = cmd_debug_add_watchpoint_perm_choices,
 
 	},
 	{ 0 },
@@ -7147,7 +7147,7 @@ static const RzCmdDescArg cmd_heap_arena_bins_print_args[] = {
 		.name = "bin_type",
 		.type = RZ_CMD_ARG_TYPE_CHOICES,
 		.optional = true,
-		.choices = cmd_heap_arena_bins_print_bin_type_choices,
+		.choices.choices = cmd_heap_arena_bins_print_bin_type_choices,
 
 	},
 	{ 0 },
@@ -9127,7 +9127,7 @@ static const RzCmdDescArg cmd_info_demangle_args[] = {
 	{
 		.name = "lang",
 		.type = RZ_CMD_ARG_TYPE_CHOICES,
-		.choices_cb = rz_cmd_info_demangle_lang_choices,
+		.choices.choices_cb = rz_cmd_info_demangle_lang_choices,
 
 	},
 	{
@@ -12054,7 +12054,7 @@ static const RzCmdDescArg seek_next_args[] = {
 		.name = "type",
 		.type = RZ_CMD_ARG_TYPE_CHOICES,
 		.optional = true,
-		.choices = seek_next_type_choices,
+		.choices.choices = seek_next_type_choices,
 
 	},
 	{ 0 },
@@ -12071,7 +12071,7 @@ static const RzCmdDescArg seek_prev_args[] = {
 		.name = "type",
 		.type = RZ_CMD_ARG_TYPE_CHOICES,
 		.optional = true,
-		.choices = seek_prev_type_choices,
+		.choices.choices = seek_prev_type_choices,
 
 	},
 	{ 0 },

--- a/librz/core/cmd_descs/cmd_descs_generate.py
+++ b/librz/core/cmd_descs/cmd_descs_generate.py
@@ -75,8 +75,8 @@ DESC_HELP_DETAILS_TEMPLATE = """static const RzCmdDescDetail {cname}[] = {{
 DECL_DESC_HELP_DETAILS_TEMPLATE = "static const RzCmdDescDetail {cname}[{size}];"
 
 DESC_HELP_ARG_CHOICES = "static const char *{cname}[] = {{ {choices} }};\n"
-DESC_HELP_ARG_UNION_CHOICES = "\t\t.choices = {choices},\n"
-DESC_HELP_ARG_UNION_CHOICES_CB = "\t\t.choices_cb = {choices_cb},\n"
+DESC_HELP_ARG_UNION_CHOICES = "\t\t.choices.choices = {choices},\n"
+DESC_HELP_ARG_UNION_CHOICES_CB = "\t\t.choices.choices_cb = {choices_cb},\n"
 DESC_HELP_ARG_TEMPLATE_FLAGS = "\t\t.flags = {flags},\n"
 DESC_HELP_ARG_TEMPLATE_OPTIONAL = "\t\t.optional = {optional},\n"
 DESC_HELP_ARG_TEMPLATE_NO_SPACE = "\t\t.no_space = {no_space},\n"

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -263,14 +263,19 @@ typedef struct rz_cmd_desc_arg_t {
 	 */
 	union {
 		/**
-		 * List of possible values in case \p type is RZ_CMD_ARG_TYPE_CHOICES.
+		 * Data associated with an argument of \p type RZ_CMD_ARG_TYPE_CHOICES.
 		 */
-		const char **choices;
-		/**
-		 * Callback used to generate a list of possible values in case \p type is RZ_CMD_ARG_TYPE_CHOICES.
-		 * When this is specified, \p choices is ignored.
-		 */
-		RzCmdArgChoiceCb choices_cb;
+		struct {
+			/**
+			 * Predefined list of possible values.
+			 */
+			const char **choices;
+			/**
+			 * Callback used to generate a list of possible values.
+			 * When this is specified, \p choices is ignored.
+			 */
+			RzCmdArgChoiceCb choices_cb;
+		} choices;
 	};
 } RzCmdDescArg;
 

--- a/test/integration/test_autocmplt.c
+++ b/test/integration/test_autocmplt.c
@@ -56,7 +56,7 @@ static char **z_args_choices_cb(RzCore *core) {
 }
 
 static RzCmdDescArg z_args[] = {
-	{ .name = "v1", .type = RZ_CMD_ARG_TYPE_CHOICES, .choices_cb = z_args_choices_cb },
+	{ .name = "v1", .type = RZ_CMD_ARG_TYPE_CHOICES, .choices.choices_cb = z_args_choices_cb },
 	{ 0 },
 };
 

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -556,7 +556,7 @@ bool test_remove_cmd(void) {
 bool test_cmd_args(void) {
 	const char *x_c_choices[] = { "A", "B", "C" };
 	RzCmdDescArg x_args[] = {
-		{ .name = "c", .type = RZ_CMD_ARG_TYPE_CHOICES, .choices = x_c_choices },
+		{ .name = "c", .type = RZ_CMD_ARG_TYPE_CHOICES, .choices.choices = x_c_choices },
 		{ .name = "from", .optional = true, .type = RZ_CMD_ARG_TYPE_NUM },
 		{ .name = "to", .type = RZ_CMD_ARG_TYPE_NUM },
 		{ .name = "n", .optional = true, .type = RZ_CMD_ARG_TYPE_NUM, .default_value = "5" },


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Not sure why I did so, but there was a union including `choices` and `choices_cb` and I was checking if `choices_cb` was set to determine which one to use. This was of course wrong. I solved it by using a struct that includes both `choices` and `choices_cb`, so that the fields get different memory addresses and can be independently checked.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Do `sp <TAB>`. It would segfault without this patch.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
