### PR TITLE
Handle endianess during NE format parsing

### DIFF
--- a/librz/bin/format/ne/ne.c
+++ b/librz/bin/format/ne/ne.c
@@ -311,7 +311,10 @@ static bool __ne_get_resources(rz_bin_ne_obj_t *bin) {
 		if (!res->entry) {
 			break;
 		}
-		rz_buf_read_at(bin->buf, off, (ut8 *)&ti, sizeof(ti));
+		ut64 offset = off;
+		rz_buf_read_le16_offset(bin->buf, &offset, &ti.rtTypeID);
+		rz_buf_read_le16_offset(bin->buf, &offset, &ti.rtResourceCount);
+		rz_buf_read_le32_offset(bin->buf, &offset, &ti.rtReserved);
 		if (!ti.rtTypeID) {
 			break;
 		} else if (ti.rtTypeID & 0x8000) {
@@ -323,12 +326,18 @@ static bool __ne_get_resources(rz_bin_ne_obj_t *bin) {
 		off += sizeof(NE_image_typeinfo_entry);
 		int i;
 		for (i = 0; i < ti.rtResourceCount; i++) {
-			NE_image_nameinfo_entry ni;
 			rz_ne_resource_entry *ren = RZ_NEW0(rz_ne_resource_entry);
 			if (!ren) {
 				break;
 			}
-			rz_buf_read_at(bin->buf, off, (ut8 *)&ni, sizeof(NE_image_nameinfo_entry));
+			offset = off;
+			NE_image_nameinfo_entry ni = { 0 };
+			rz_buf_read_le16_offset(bin->buf, &offset, &ni.rnOffset);
+			rz_buf_read_le16_offset(bin->buf, &offset, &ni.rnLength);
+			rz_buf_read_le16_offset(bin->buf, &offset, &ni.rnFlags);
+			rz_buf_read_le16_offset(bin->buf, &offset, &ni.rnID);
+			rz_buf_read_le16_offset(bin->buf, &offset, &ni.rnHandle);
+			rz_buf_read_le16_offset(bin->buf, &offset, &ni.rnUsage);
 			ren->offset = ni.rnOffset << alignment;
 			ren->size = ni.rnLength;
 			if (ni.rnID & 0x8000) {
@@ -508,7 +517,12 @@ RzList *rz_bin_ne_get_relocs(rz_bin_ne_obj_t *bin) {
 				return NULL;
 			}
 			NE_image_reloc_item rel;
-			rz_buf_read_at(bin->buf, off, (ut8 *)&rel, sizeof(rel));
+			ut64 offset = off;
+			rz_buf_read8_offset(bin->buf, &offset, &rel.type);
+			rz_buf_read8_offset(bin->buf, &offset, &rel.flags);
+			rz_buf_read_le16_offset(bin->buf, &offset, &rel.offset);
+			rz_buf_read_le16_offset(bin->buf, &offset, &rel.align1);
+			rz_buf_read_le16_offset(bin->buf, &offset, &rel.func_ord);
 			reloc->paddr = seg->paddr + rel.offset;
 			switch (rel.type) {
 			case LOBYTE:
@@ -527,7 +541,6 @@ RzList *rz_bin_ne_get_relocs(rz_bin_ne_obj_t *bin) {
 				break;
 			}
 
-			ut32 offset;
 			if (rel.flags & (IMPORTED_ORD | IMPORTED_NAME)) {
 				RzBinImport *imp = RZ_NEW0(RzBinImport);
 				if (!imp) {
@@ -613,6 +626,44 @@ RzList *rz_bin_ne_get_relocs(rz_bin_ne_obj_t *bin) {
 	return relocs;
 }
 
+static bool read_ne_header(NE_image_header *ne, RzBuffer *buf, ut64 off) {
+	ut64 offset = off;
+	return (rz_buf_read8_offset(buf, &offset, (ut8 *)&ne->sig[0]) &&
+		rz_buf_read8_offset(buf, &offset, (ut8 *)&ne->sig[1]) &&
+		rz_buf_read8_offset(buf, &offset, &ne->MajLinkerVersion) &&
+		rz_buf_read8_offset(buf, &offset, &ne->MinLinkerVersion) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->EntryTableOffset) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->EntryTableLength) &&
+		rz_buf_read_le32_offset(buf, &offset, &ne->FileLoadCRC) &&
+		rz_buf_read8_offset(buf, &offset, &ne->ProgFlags) &&
+		rz_buf_read8_offset(buf, &offset, &ne->ApplFlags) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->AutoDataSegIndex) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->InitHeapSize) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->InitStackSize) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->ipEntryPoint) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->csEntryPoint) &&
+		rz_buf_read_le32_offset(buf, &offset, &ne->InitStack) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->SegCount) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->ModRefs) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->NoResNamesTabSiz) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->SegTableOffset) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->ResTableOffset) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->ResidNamTable) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->ModRefTable) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->ImportNameTable) &&
+		rz_buf_read_le32_offset(buf, &offset, &ne->OffStartNonResTab) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->MovEntryCount) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->FileAlnSzShftCnt) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->nResTabEntries) &&
+		rz_buf_read8_offset(buf, &offset, &ne->targOS) &&
+		rz_buf_read8_offset(buf, &offset, &ne->OS2EXEFlags) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->retThunkOffset) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->segrefthunksoff) &&
+		rz_buf_read_le16_offset(buf, &offset, &ne->mincodeswap) &&
+		rz_buf_read8_offset(buf, &offset, (ut8 *)&ne->expctwinver[0]) &&
+		rz_buf_read8_offset(buf, &offset, (ut8 *)&ne->expctwinver[1]));
+}
+
 bool rz_bin_ne_buf_init(RzBuffer *buf, rz_bin_ne_obj_t *bin) {
 	if (!rz_buf_read_le16_at(buf, 0x3c, &bin->header_offset)) {
 		return false;
@@ -623,7 +674,10 @@ bool rz_bin_ne_buf_init(RzBuffer *buf, rz_bin_ne_obj_t *bin) {
 		return false;
 	}
 	bin->buf = buf;
-	rz_buf_read_at(buf, bin->header_offset, (ut8 *)bin->ne_header, sizeof(NE_image_header));
+	if (!read_ne_header(bin->ne_header, bin->buf, bin->header_offset)) {
+		RZ_FREE(bin->ne_header);
+		return false;
+	}
 	if (bin->ne_header->FileAlnSzShftCnt > 31) {
 		return false;
 	}
@@ -633,16 +687,22 @@ bool rz_bin_ne_buf_init(RzBuffer *buf, rz_bin_ne_obj_t *bin) {
 	}
 	bin->os = __get_target_os(bin);
 
-	ut16 offset = bin->ne_header->SegTableOffset + bin->header_offset;
-	ut16 size = bin->ne_header->SegCount * sizeof(NE_image_segment_entry);
-	if (!size) {
+	if (!bin->ne_header->SegCount) {
 		return false;
 	}
 	bin->segment_entries = calloc(bin->ne_header->SegCount, sizeof(NE_image_segment_entry));
 	if (!bin->segment_entries) {
 		return false;
 	}
-	rz_buf_read_at(buf, offset, (ut8 *)bin->segment_entries, size);
+
+	ut64 offset = bin->ne_header->SegTableOffset + bin->header_offset;
+	for (ut32 i = 0; i < bin->ne_header->SegCount; i++) {
+		NE_image_segment_entry *ne_segment_entry = bin->segment_entries + i;
+		rz_buf_read_le16_offset(buf, &offset, &ne_segment_entry->offset);
+		rz_buf_read_le16_offset(buf, &offset, &ne_segment_entry->length);
+		rz_buf_read_le16_offset(buf, &offset, &ne_segment_entry->flags);
+		rz_buf_read_le16_offset(buf, &offset, &ne_segment_entry->minAllocSz);
+	}
 	if (!bin->ne_header->EntryTableLength) {
 		return false;
 	}

--- a/librz/bin/format/ne/ne_specs.h
+++ b/librz/bin/format/ne/ne_specs.h
@@ -95,7 +95,7 @@ typedef struct {
 	ut32 FileLoadCRC; // 32-bit CRC of entire contents of file
 	ut8 ProgFlags; // Program flags, bitmapped
 	ut8 ApplFlags; // Application flags, bitmapped
-	ut8 AutoDataSegIndex; // The automatic data segment index
+	ut16 AutoDataSegIndex; // The automatic data segment index
 	ut16 InitHeapSize; // The intial local heap size
 	ut16 InitStackSize; // The inital stack size
 	ut16 ipEntryPoint; // IP entry point offset
@@ -111,7 +111,7 @@ typedef struct {
 	ut16 ImportNameTable; // Offset of imported names table (array of counted strings, terminated with string of length 00h)
 	ut32 OffStartNonResTab; // Offset from start of file to non-resident names table
 	ut16 MovEntryCount; // Count of moveable entry point listed in entry table
-	ut16 FileAlnSzShftCnt; // File alligbment size shift count (0=9(default 512 byte pages))
+	ut16 FileAlnSzShftCnt; // File alignment size shift count (0=9(default 512 byte pages))
 	ut16 nResTabEntries; // Number of resource table entries
 	ut8 targOS; // Target OS
 	ut8 OS2EXEFlags; // Other OS/2 flags


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Note, also it fixes the issue in wrongly defined header structure:
```c
    uint8_t AutoDataSegIndex;   //The automatic data segment index
```
should have been this instead:
```c
    uint16_t AutoDataSegIndex;   //The automatic data segment index
```
It was working only because the structure was read as a whole, and the compiler aligned it on a 2-byte boundary.

Should fix the following test errors on big-endian machines:
```
[XX] db/formats/ne NE Code
RZ_NOPLUGINS=1 /home/travis/build/rizinorg/rizin/install/bin/rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -Qc 'pi 10 @ sym.WNDPROC' bins/ne/anim8.exe
-- stdout
--- expected
+++ actual
@@ -1,10 +1,0 @@
-mov ax, ds
-nop
-inc bp
-push bp
-mov bp, sp
-push ds
-mov ds, ax
-mov ax, 0x5c
-call 0x4d35
-push si
-- stderr
Invalid address (sym.WNDPROC)
Error while executing command: pi 10 @ sym.WNDPROC
```

etc

**Test plan**

- CI is green
- Number of broken tests on System Z Travis CI worker is reduced

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/297
