### PR TITLE
Meson refactor: collect modules in dict and centralize config

### DIFF
--- a/librz/analysis/meson.build
+++ b/librz/analysis/meson.build
@@ -291,49 +291,25 @@ rz_analysis_dep = declare_dependency(link_with: rz_analysis,
                                 include_directories: rz_analysis_inc)
 meson.override_dependency('rz_analysis', rz_analysis_dep)
 
-pkgconfig_mod.generate(rz_analysis,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_analysis',
-  filebase: 'rz_analysis',
-  requires: [
-    'rz_util',
-    'rz_crypto',
-    'rz_reg',
-    'rz_asm',
-    'rz_parse',
-    'rz_syscall',
-    'rz_search',
-    'rz_cons',
-    'rz_diff',
-    'rz_bin',
-    'rz_flag',
-    'rz_type'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'plugindir=@0@'.format(rizin_plugins),
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_analysis.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util', 'rz_crypto', 'rz_reg', 'rz_asm', 'rz_parse',
-    'rz_syscall', 'rz_search', 'rz_cons', 'rz_diff', 'rz_bin', 'rz_flag', 'rz_type']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_analysis.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_analysis': {
+    'target': rz_analysis,
+    'dependencies': [
+      'rz_util',
+      'rz_crypto',
+      'rz_reg',
+      'rz_syscall',
+      'rz_search',
+      'rz_cons',
+      'rz_flag',
+      'rz_hash',
+      'rz_diff',
+      'rz_parse',
+      'rz_asm',
+      'rz_bin',
+      'rz_type',
+      'rz_il',
+    ],
+    'plugins': [analysis_plugins]
+}}
 
 subdir('d')

--- a/librz/asm/meson.build
+++ b/librz/asm/meson.build
@@ -331,43 +331,11 @@ rz_asm_dep = declare_dependency(link_with: rz_asm,
                                include_directories: rz_asm_inc)
 meson.override_dependency('rz_asm', rz_asm_dep)
 
-pkgconfig_mod.generate(rz_asm,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_asm',
-  filebase: 'rz_asm',
-  requires: [
-    'rz_util',
-    'rz_syscall',
-    'rz_parse',
-    'rz_flag',
-    'rz_bin',
-    'rz_socket'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'plugindir=@0@'.format(rizin_plugins),
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_asm.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util', 'rz_syscall', 'rz_flag', 'rz_parse', 'rz_bin']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_asm.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_asm': {
+    'target': rz_asm,
+    'dependencies': ['rz_util', 'rz_config', 'rz_syscall', 'rz_flag', 'rz_parse', 'rz_bin'],
+    'plugins': [asm_plugins]
+}}
 
 subdir('d')
 subdir('cpus')

--- a/librz/bin/meson.build
+++ b/librz/bin/meson.build
@@ -281,41 +281,17 @@ rz_bin_dep = declare_dependency(link_with: rz_bin,
                                include_directories: rz_bin_inc)
 meson.override_dependency('rz_bin', rz_bin_dep)
 
-pkgconfig_mod.generate(rz_bin,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_bin',
-  filebase: 'rz_bin',
-  requires: pkgconfig_magic_requires + [
-    'rz_util',
-    'rz_io',
-    'rz_socket',
-    'rz_syscall',
-    'rz_type'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'plugindir=@0@'.format(rizin_plugins),
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_bin.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util', 'rz_io', 'rz_socket', 'rz_syscall', 'rz_type']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_bin.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_bin': {
+    'target': rz_bin,
+    'dependencies': [
+      'rz_magic',
+      'rz_util',
+      'rz_io',
+      'rz_socket',
+      'rz_syscall',
+      'rz_type'
+    ],
+    'plugins': [bin_plugins, bin_xtr_plugins]
+}}
 
 subdir('d')

--- a/librz/bp/meson.build
+++ b/librz/bp/meson.build
@@ -42,35 +42,8 @@ rz_bp_dep = declare_dependency(link_with: rz_bp,
                               include_directories: [platform_inc])
 meson.override_dependency('rz_bp', rz_bp_dep)
 
-pkgconfig_mod.generate(rz_bp,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_bp',
-  filebase: 'rz_bp',
-  requires: [
-    'rz_util'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'plugindir=@0@'.format(rizin_plugins),
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_bp.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_bp.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_bp': {
+    'target': rz_bp,
+    'dependencies': ['rz_util'],
+    'plugins': [bp_plugins]
+}}

--- a/librz/config/meson.build
+++ b/librz/config/meson.build
@@ -22,34 +22,7 @@ rz_config_dep = declare_dependency(link_with: rz_config,
                                   include_directories: [platform_inc])
 meson.override_dependency('rz_config', rz_config_dep)
 
-pkgconfig_mod.generate(rz_config,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_config',
-  filebase: 'rz_config',
-  requires: [
-    'rz_util'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_config.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_config.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_config': {
+    'target': rz_config,
+    'dependencies': ['rz_util']
+}}

--- a/librz/cons/meson.build
+++ b/librz/cons/meson.build
@@ -33,36 +33,9 @@ rz_cons_dep = declare_dependency(link_with: rz_cons,
                                 include_directories: [platform_inc])
 meson.override_dependency('rz_cons', rz_cons_dep)
 
-pkgconfig_mod.generate(rz_cons,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_cons',
-  filebase: 'rz_cons',
-  requires: [
-    'rz_util'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_cons.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_cons.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_cons': {
+    'target': rz_cons,
+    'dependencies': ['rz_util']
+}}
 
 subdir('d')

--- a/librz/core/meson.build
+++ b/librz/core/meson.build
@@ -166,62 +166,35 @@ rz_core_dep = declare_dependency(link_with: rz_core,
                                 include_directories: rz_core_inc)
 meson.override_dependency('rz_core', rz_core_dep)
 
-pkgconfig_mod.generate(
-  rz_core,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_core',
-  filebase: 'rz_core',
-  requires: pkgconfig_magic_requires + [
-    'rz_util',
-    'rz_demangler',
-    'rz_diff',
-    'rz_reg',
-    'rz_syscall',
-    'rz_search',
-    'rz_cons',
-    'rz_analysis',
-    'rz_socket',
-    'rz_type',
-    'rz_io',
-    'rz_lang',
-    'rz_hash',
-    'rz_flag',
-    'rz_parse',
-    'rz_egg',
-    'rz_debug',
-    'rz_crypto',
-    'rz_config',
-    'rz_bin',
-    'rz_asm',
-    'rz_bp',
-    'rz_sign',
-    'rz_il'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'plugindir=@0@'.format(rizin_plugins),
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
+modules += { 'rz_core': {
+    'target': rz_core,
+    'dependencies': [
+      'rz_magic',
+      'rz_util',
+      'rz_demangler',
+      'rz_diff',
+      'rz_reg',
+      'rz_syscall',
+      'rz_search',
+      'rz_cons',
+      'rz_analysis',
+      'rz_socket',
+      'rz_type',
+      'rz_io',
+      'rz_lang',
+      'rz_hash',
+      'rz_flag',
+      'rz_parse',
+      'rz_egg',
+      'rz_debug',
+      'rz_crypto',
+      'rz_config',
+      'rz_bin',
+      'rz_asm',
+      'rz_bp',
+      'rz_sign',
+      'rz_il'
+    ],
+    'plugins': [core_plugins]
+}}
 
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_core.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util', 'rz_demangler', 'rz_diff', 'rz_magic',
-    'rz_socket', 'rz_flag', 'rz_cons', 'rz_lang', 'rz_hash', 'rz_crypto', 'rz_io', 'rz_reg',
-    'rz_bp', 'rz_syscall', 'rz_parse', 'rz_asm', 'rz_egg', 'rz_search', 'rz_sign', 'rz_il',
-    'rz_analysis', 'rz_type', 'rz_debug', 'rz_config', 'rz_bin']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_core.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif

--- a/librz/crypto/meson.build
+++ b/librz/crypto/meson.build
@@ -62,35 +62,8 @@ rz_crypto_dep = declare_dependency(link_with: rz_crypto,
                                   include_directories: [platform_inc])
 meson.override_dependency('rz_crypto', rz_crypto_dep)
 
-pkgconfig_mod.generate(rz_crypto,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_crypto',
-  filebase: 'rz_crypto',
-  requires: [
-    'rz_util'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'plugindir=@0@'.format(rizin_plugins),
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_crypto.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_crypto.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_crypto': {
+    'target': rz_crypto,
+    'dependencies': ['rz_util'],
+    'plugins': [crypto_plugins]
+}}

--- a/librz/debug/meson.build
+++ b/librz/debug/meson.build
@@ -153,45 +153,20 @@ rz_debug_dep = declare_dependency(link_with: rz_debug,
                                  include_directories: rz_debug_inc)
 meson.override_dependency('rz_debug', rz_debug_dep)
 
-pkgconfig_mod.generate(rz_debug,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_debug',
-  filebase: 'rz_debug',
-  requires: [
-    'rz_util',
-    'rz_hash',
-    'rz_reg',
-    'rz_syscall',
-    'rz_analysis',
-    'rz_io',
-    'rz_bin',
-    'rz_bp',
-    'rz_cons',
-    'rz_egg',
-    'rz_type'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'plugindir=@0@'.format(rizin_plugins),
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_debug.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util', 'rz_hash', 'rz_reg', 'rz_syscall', 'rz_analysis', 'rz_io', 'rz_bin', 'rz_bp', 'rz_cons', 'rz_egg', 'rz_type']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_debug.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_debug': {
+    'target': rz_debug,
+    'dependencies': [
+      'rz_util',
+      'rz_hash',
+      'rz_reg',
+      'rz_syscall',
+      'rz_analysis',
+      'rz_io',
+      'rz_bin',
+      'rz_bp',
+      'rz_cons',
+      'rz_egg',
+      'rz_type'
+    ],
+    'plugins': [debug_plugins]
+}}

--- a/librz/demangler/meson.build
+++ b/librz/demangler/meson.build
@@ -39,35 +39,8 @@ rz_demangler = library('rz_demangler', rz_demangler_sources,
 rz_demangler_dep = declare_dependency(link_with: rz_demangler, include_directories: [platform_inc])
 meson.override_dependency('rz_demangler', rz_demangler_dep)
 
-pkgconfig_mod.generate(rz_demangler,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_demangler',
-  filebase: 'rz_demangler',
-  requires: [
-    'rz_util'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'plugindir=@0@'.format(rizin_plugins),
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_demangler.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_demangler.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_demangler': {
+    'target': rz_demangler,
+    'dependencies': ['rz_util'],
+    'plugins': [demangler_plugins]
+}}

--- a/librz/diff/meson.build
+++ b/librz/diff/meson.build
@@ -21,34 +21,7 @@ rz_diff_dep = declare_dependency(link_with: rz_diff,
                                 include_directories: [platform_inc])
 meson.override_dependency('rz_diff', rz_diff_dep)
 
-pkgconfig_mod.generate(rz_diff,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_diff',
-  filebase: 'rz_diff',
-  requires: [
-    'rz_util'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_diff.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_diff.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_diff': {
+    'target': rz_diff,
+    'dependencies': ['rz_util']
+}}

--- a/librz/egg/meson.build
+++ b/librz/egg/meson.build
@@ -45,37 +45,8 @@ rz_egg_dep = declare_dependency(link_with: rz_egg,
                                include_directories: [platform_inc])
 meson.override_dependency('rz_egg', rz_egg_dep)
 
-pkgconfig_mod.generate(rz_egg,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_egg',
-  filebase: 'rz_egg',
-  requires: [
-    'rz_util',
-    'rz_asm',
-    'rz_syscall'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'plugindir=@0@'.format(rizin_plugins),
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_egg.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util', 'rz_asm', 'rz_syscall']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_egg.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_egg': {
+    'target': rz_egg,
+    'dependencies': ['rz_util', 'rz_asm', 'rz_syscall'],
+    'plugins': [egg_plugins]
+}}

--- a/librz/flag/meson.build
+++ b/librz/flag/meson.build
@@ -23,36 +23,9 @@ rz_flag_dep = declare_dependency(link_with: rz_flag,
                                 include_directories: [platform_inc])
 meson.override_dependency('rz_flag', rz_flag_dep)
 
-pkgconfig_mod.generate(rz_flag,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_flag',
-  filebase: 'rz_flag',
-  requires: [
-    'rz_util'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_flag.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_flag.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_flag': {
+    'target': rz_flag,
+    'dependencies': ['rz_util']
+}}
 
 subdir('d')

--- a/librz/hash/meson.build
+++ b/librz/hash/meson.build
@@ -130,35 +130,8 @@ rz_hash_dep = declare_dependency(link_with: rz_hash,
                                 include_directories: [platform_inc])
 meson.override_dependency('rz_hash', rz_hash_dep)
 
-pkgconfig_mod.generate(rz_hash,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_hash',
-  filebase: 'rz_hash',
-  requires: [
-    'rz_util'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'plugindir=@0@'.format(rizin_plugins),
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_hash.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_hash.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_hash': {
+    'target': rz_hash,
+    'dependencies': ['rz_util'],
+    'plugins': [hash_plugins]
+}}

--- a/librz/il/meson.build
+++ b/librz/il/meson.build
@@ -41,35 +41,7 @@ rz_il_dep = declare_dependency(link_with: rz_il,
                                 include_directories: rz_il_inc)
 meson.override_dependency('rz_il', rz_il_dep)
 
-pkgconfig_mod.generate(rz_il,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_il',
-  filebase: 'rz_il',
-  requires: [
-    'rz_util',
-    'rz_reg'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_il.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_il.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_il': {
+    'target': rz_il,
+    'dependencies': ['rz_util', 'rz_reg']
+}}

--- a/librz/io/meson.build
+++ b/librz/io/meson.build
@@ -152,36 +152,8 @@ rz_io_dep = declare_dependency(link_with: rz_io,
                               include_directories: platform_inc)
 meson.override_dependency('rz_io', rz_io_dep)
 
-pkgconfig_mod.generate(rz_io,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_io',
-  filebase: 'rz_io',
-  requires: [
-    'rz_util',
-    'rz_socket'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'plugindir=@0@'.format(rizin_plugins),
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_io.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util', 'rz_socket', 'rz_hash', 'rz_crypto', 'rz_cons']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_io.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_io': {
+    'target': rz_io,
+    'dependencies': ['rz_util', 'rz_socket', 'rz_hash', 'rz_crypto', 'rz_cons'],
+    'plugins': [io_plugins]
+}}

--- a/librz/lang/meson.build
+++ b/librz/lang/meson.build
@@ -45,36 +45,8 @@ rz_lang_dep = declare_dependency(link_with: rz_lang,
                                 include_directories: [platform_inc])
 meson.override_dependency('rz_lang', rz_lang_dep)
 
-pkgconfig_mod.generate(rz_lang,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_lang',
-  filebase: 'rz_lang',
-  requires: [
-    'rz_util',
-    'rz_cons'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'plugindir=@0@'.format(rizin_plugins),
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_lang.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util', 'rz_cons']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_lang.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_lang': {
+    'target': rz_lang,
+    'dependencies': ['rz_util', 'rz_cons'],
+    'plugins': [lang_plugins]
+}}

--- a/librz/magic/meson.build
+++ b/librz/magic/meson.build
@@ -35,37 +35,9 @@ rz_magic_dep = declare_dependency(
 )
 meson.override_dependency('rz_magic', rz_magic_dep)
 
-pkgconfig_mod.generate(rz_magic,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_magic',
-  filebase: 'rz_magic',
-  requires: [
-    'rz_util'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-pkgconfig_magic_requires = ['rz_magic']
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_magic.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_magic.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_magic': {
+    'target': rz_magic,
+    'dependencies': ['rz_util']
+}}
 
 subdir('d')

--- a/librz/main/meson.build
+++ b/librz/main/meson.build
@@ -57,39 +57,14 @@ rz_main_dep = declare_dependency(link_with: rz_main,
                                 dependencies: rz_main_deps)
 meson.override_dependency('rz_main', rz_main_dep)
 
-pkgconfig_mod.generate(rz_main,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_main',
-  filebase: 'rz_main',
-  requires: [
-    'rz_core',
-    'rz_demangler',
-    'rz_asm',
-    'rz_sign',
-    'rz_diff',
-    'rz_syscall'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_main.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_core']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_main.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_main': {
+    'target': rz_main,
+    'dependencies': [
+      'rz_core',
+      'rz_demangler',
+      'rz_asm',
+      'rz_sign',
+      'rz_diff',
+      'rz_syscall'
+    ]
+}}

--- a/librz/meson.build
+++ b/librz/meson.build
@@ -1,3 +1,6 @@
+
+modules = {} # every rizin module subdir registers in here
+
 subdir('include')
 
 subdir('util')
@@ -30,30 +33,59 @@ subdir('core')
 
 subdir('main')
 
-plugins = [
-  core_plugins,
-  analysis_plugins,
-  asm_plugins,
-  bp_plugins,
-  bin_plugins,
-  bin_xtr_plugins,
-  crypto_plugins,
-  io_plugins,
-  debug_plugins,
-  egg_plugins,
-  lang_plugins,
-  hash_plugins,
-  parse_plugins,
-  demangler_plugins,
-]
-
 conf_data = configuration_data()
-foreach plugin : plugins
-  l = []
-  foreach p : plugin.get('list')
-    l += ['&' + plugin.get('base_cname') + p]
-  endforeach
-  conf_data.set(plugin.get('conf_name'), ', '.join(l))
+foreach module_name, module : modules
+  include_subdirs = ['librz']
+  if 'include_subdirs_extra' in module
+    include_subdirs += module['include_subdirs_extra']
+  endif
+
+  # pkg-config
+  pkgconfig_vars = []
+  if 'plugins' in module
+    pkgconfig_vars += ['plugindir=@0@'.format(rizin_plugins)]
+  endif
+  pkgconfig_vars += ['datdir=@0@'.format(rizin_datdir_rz)]
+
+  pkgconfig_mod.generate(module['target'],
+    subdirs: include_subdirs,
+    version: rizin_version,
+    name: module_name,
+    filebase: module_name,
+    requires: module['dependencies'],
+    description: 'rizin foundation libraries',
+    variables: pkgconfig_vars,
+  )
+
+  # cmake
+  if not is_static_libs_only
+    conf = configuration_data()
+    conf.set('RZ_VERSION', rizin_version)
+    conf.set('RIZIN_MODULE', module['target'].name())
+    conf.set('RIZIN_MODULE_DEPS', ' '.join(module['dependencies']))
+    conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
+    conf.set('INSTALL_INCDIR', rizin_incdir)
+    conf.set('INSTALL_LIBDIR', rizin_libdir)
+    conf.set('INSTALL_PLUGDIR', rizin_plugins)
+    conf.set('rizin_libname', module['target'].name())
+    cmake_mod.configure_package_config_file(
+      name: conf.get('rizin_libname'),
+      input: 'RzModulesConfig.cmake.in',
+      install_dir: rizin_cmakedir / conf.get('rizin_libname'),
+      configuration: conf,
+    )
+  endif
+
+  # plugins
+  if 'plugins' in module
+    foreach plugin : module['plugins']
+      l = []
+      foreach p : plugin.get('list')
+        l += ['&' + plugin.get('base_cname') + p]
+      endforeach
+      conf_data.set(plugin.get('conf_name'), ', '.join(l))
+    endforeach
+  endif
 endforeach
 
 config_h = configure_file(

--- a/librz/parse/meson.build
+++ b/librz/parse/meson.build
@@ -70,39 +70,8 @@ rz_parse_dep = declare_dependency(link_with: rz_parse,
                                  include_directories: platform_inc)
 meson.override_dependency('rz_parse', rz_parse_dep)
 
-pkgconfig_mod.generate(rz_parse,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_parse',
-  filebase: 'rz_parse',
-  requires: [
-    'rz_util',
-    'rz_flag',
-    'rz_cons',
-    'rz_syscall',
-    'rz_reg'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'plugindir=@0@'.format(rizin_plugins),
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_parse.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util', 'rz_flag', 'rz_syscall', 'rz_reg', 'rz_cons']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_parse.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_parse': {
+    'target': rz_parse,
+    'dependencies': ['rz_util', 'rz_flag', 'rz_syscall', 'rz_reg', 'rz_cons'],
+    'plugins': [parse_plugins]
+}}

--- a/librz/reg/meson.build
+++ b/librz/reg/meson.build
@@ -23,37 +23,9 @@ rz_reg_dep = declare_dependency(link_with: rz_reg,
                                include_directories: [platform_inc])
 meson.override_dependency('rz_reg', rz_reg_dep)
 
-pkgconfig_mod.generate(rz_reg,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_reg',
-  filebase: 'rz_reg',
-  requires: [
-    'rz_util'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'plugindir=@0@'.format(rizin_plugins),
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_reg.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_reg.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_reg': {
+    'target': rz_reg,
+    'dependencies': ['rz_util']
+}}
 
 subdir('d')

--- a/librz/search/meson.build
+++ b/librz/search/meson.build
@@ -24,34 +24,7 @@ rz_search_dep = declare_dependency(link_with: rz_search,
                                   include_directories: [platform_inc])
 meson.override_dependency('rz_search', rz_search_dep)
 
-pkgconfig_mod.generate(rz_search,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_search',
-  filebase: 'rz_search',
-  requires: [
-    'rz_util'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_search.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_search.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_search': {
+    'target': rz_search,
+    'dependencies': ['rz_util']
+}}

--- a/librz/sign/meson.build
+++ b/librz/sign/meson.build
@@ -36,40 +36,15 @@ rz_sign_dep = declare_dependency(link_with: rz_sign,
                                 include_directories: rz_sign_inc)
 meson.override_dependency('rz_sign', rz_sign_dep)
 
-pkgconfig_mod.generate(rz_sign,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_sign',
-  filebase: 'rz_sign',
-  requires: [
-    'rz_util',
-    'rz_analysis',
-    'rz_diff',
-    'rz_hash',
-    'rz_search',
-    'rz_type',
-    'rz_flag',
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_sign.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util', 'rz_analysis', 'rz_diff', 'rz_hash', 'rz_search', 'rz_type', 'rz_flag']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_sign.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_sign': {
+    'target': rz_sign,
+    'dependencies': [
+      'rz_util',
+      'rz_analysis',
+      'rz_diff',
+      'rz_hash',
+      'rz_type',
+      'rz_search',
+      'rz_flag',
+    ]
+}}

--- a/librz/socket/meson.build
+++ b/librz/socket/meson.build
@@ -40,34 +40,7 @@ rz_socket_dep = declare_dependency(link_with: rz_socket,
   include_directories: [platform_inc])
 meson.override_dependency('rz_socket', rz_socket_dep)
 
-pkgconfig_mod.generate(rz_socket,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_socket',
-  filebase: 'rz_socket',
-  requires: [
-    'rz_util'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_socket.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_socket.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_socket': {
+    'target': rz_socket,
+    'dependencies': ['rz_util']
+}}

--- a/librz/syscall/meson.build
+++ b/librz/syscall/meson.build
@@ -18,36 +18,9 @@ rz_syscall_dep = declare_dependency(link_with: rz_syscall,
                                    include_directories: [platform_inc])
 meson.override_dependency('rz_syscall', rz_syscall_dep)
 
-pkgconfig_mod.generate(rz_syscall,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_syscall',
-  filebase: 'rz_syscall',
-  requires: [
-    'rz_util'
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_syscall.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_syscall.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_syscall': {
+    'target': rz_syscall,
+    'dependencies': ['rz_util']
+}}
 
 subdir('d')

--- a/librz/type/meson.build
+++ b/librz/type/meson.build
@@ -45,34 +45,7 @@ rz_type_dep = declare_dependency(link_with: rz_type,
                                 include_directories: rz_type_inc)
 meson.override_dependency('rz_type', rz_type_dep)
 
-pkgconfig_mod.generate(rz_type,
-  subdirs: 'librz',
-  version: rizin_version,
-  name: 'rz_type',
-  filebase: 'rz_type',
-  requires: [
-    'rz_util',
-  ],
-  description: 'rizin foundation libraries',
-  variables: [
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_type.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join(['rz_util']))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_type.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_type': {
+    'target': rz_type,
+    'dependencies': ['rz_util']
+}}

--- a/librz/util/meson.build
+++ b/librz/util/meson.build
@@ -179,34 +179,11 @@ else
   rz_util_native_dep = rz_util_dep
 endif
 
-pkgconfig_mod.generate(rz_util,
-  subdirs: ['librz', 'librz/sdb'],
-  version: rizin_version,
-  name: 'rz_util',
-  filebase: 'rz_util',
-  description: 'rizin foundation libraries',
-  variables: [
-    'datdir=@0@'.format(rizin_datdir_rz),
-  ],
-)
-
-if not is_static_libs_only
-  conf = configuration_data()
-  conf.set('RZ_VERSION', rizin_version)
-  conf.set('RIZIN_MODULE', rz_util.name())
-  conf.set('RIZIN_MODULE_DEPS', ' '.join([]))
-  conf.set('PACKAGE_RELATIVE_PATH', cmake_package_relative_path)
-  conf.set('INSTALL_INCDIR', rizin_incdir)
-  conf.set('INSTALL_LIBDIR', rizin_libdir)
-  conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  conf.set('rizin_libname', rz_util.name())
-  cmake_mod.configure_package_config_file(
-    name: conf.get('rizin_libname'),
-    input: '../RzModulesConfig.cmake.in',
-    install_dir: rizin_cmakedir / conf.get('rizin_libname'),
-    configuration: conf,
-  )
-endif
+modules += { 'rz_util': {
+    'target': rz_util,
+    'dependencies': [],
+    'include_subdirs_extra': ['librz/sdb']
+}}
 
 sdb_exe = executable('sdb_native', 'sdb/src/main.c',
   dependencies: rz_util_native_dep,


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Duplicated code for pkg-config and cmake configuration is avoided by
letting every rizin module register itself in a global dictionary
called "modules" which is then iterated in one place to perform any
shared logic, inspired by how qemu handles multiple targets in its meson
build system.

This is an almost pure refactor, so the resulting .pc/.cmake files
should be identical with the following exceptions:
- rz_reg.pc does not have plugindir anymore as rz_reg has no plugins.
- Some other modules have their dependencies in .pc files altered to be
  consistent with cmake.

**Test plan**

Compiling should work and installed `lib/cmake` and `lib/pkgconfig` contents should be identical to before except where noted above.