### PR TITLE
Replace meson cmake module usage by plain configure_file()

### DIFF
--- a/.github/workflows/muon.yml
+++ b/.github/workflows/muon.yml
@@ -36,9 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Disable CMake module (unsupported by Muon)
-      run: |
-        sed -i "s/import('cmake')/import('cmake', required: false)/" meson.build
     - name: Install dependencies
       run: |
           sudo apt-get --assume-yes update

--- a/librz/RzModulesConfig.cmake.in
+++ b/librz/RzModulesConfig.cmake.in
@@ -21,7 +21,6 @@
 set(RIZIN_MODULE_PREFIXED @RIZIN_MODULE@)
 set(@RIZIN_MODULE@_VERSION @RZ_VERSION@)
 
-# FIXME: workaround for https://github.com/mesonbuild/meson/issues/9702 (see https://github.com/rizinorg/rizin/issues/2102)
 get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/@PACKAGE_RELATIVE_PATH@" ABSOLUTE)
 
 macro(set_and_check _var _file)

--- a/librz/meson.build
+++ b/librz/meson.build
@@ -68,8 +68,11 @@ foreach module_name, module : modules
     conf.set('INSTALL_LIBDIR', rizin_libdir)
     conf.set('INSTALL_PLUGDIR', rizin_plugins)
     conf.set('rizin_libname', module['target'].name())
-    cmake_mod.configure_package_config_file(
-      name: conf.get('rizin_libname'),
+    # meson's cmake module is not used on purpose due to:
+    #   https://todo.sr.ht/~lattis/muon/24
+    #   https://github.com/mesonbuild/meson/issues/9702
+    configure_file(
+      output: conf.get('rizin_libname') + 'Config.cmake',
       input: 'RzModulesConfig.cmake.in',
       install_dir: rizin_cmakedir / conf.get('rizin_libname'),
       configuration: conf,
@@ -98,8 +101,11 @@ if not is_static_libs_only
   conf = configuration_data()
   conf.set('RZ_VERSION', rizin_version)
   conf.set('INSTALL_PLUGDIR', rizin_plugins)
-  cmake_mod.configure_package_config_file(
-    name: 'Rizin',
+  # meson's cmake module is not used on purpose due to:
+  #   https://todo.sr.ht/~lattis/muon/24
+  #   https://github.com/mesonbuild/meson/issues/9702
+  configure_file(
+    output: 'RizinConfig.cmake',
     input: 'RizinConfig.cmake.in',
     install_dir: rizin_cmakedir / 'Rizin',
     configuration: conf,

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,6 @@ project('rizin', 'c',
 py3_exe = import('python').find_installation()
 git_exe = find_program('git', required: false)
 pkgconfig_mod = import('pkgconfig')
-cmake_mod = import('cmake')
 
 # Python scripts used during the build process
 create_tags_rz_py = files('sys/create_tags_rz.py')


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

As due to https://github.com/mesonbuild/meson/issues/9702 we are not
using the expansion of @PACKAGE_INIT@ anyway, the cmake module provides
little additional value over a plain configure_file().
More importantly, by not using it, we get full support for muon, which
does not implement the cmake module yet.

This somewhat affects the reasoning behind https://github.com/rizinorg/rizin/issues/2102 as we don't use the cmake module anymore, but still use the workaround to get the relative path. I am currently evaluating options to get rid of this extra python script.

**Test plan**

CI should be green and muon produces cmake config files when compiling shared libraries.