### PR TITLE
Fix unused variable warnings on MacOS ARM64

### DIFF
--- a/librz/debug/p/debug_native.c
+++ b/librz/debug/p/debug_native.c
@@ -1436,27 +1436,23 @@ static bool arm64_hwbp_del(RzDebug *dbg, RzBreakpoint *bp, RzBreakpointItem *b) 
  * we let the caller handle the work.
  */
 static int rz_debug_native_bp(RzBreakpoint *bp, RzBreakpointItem *b, bool set) {
-	RzDebug *dbg = bp->user;
 	if (b && b->hw) {
 #if __i386__ || __x86_64__
 		return set
-			? drx_add(dbg, bp, b)
-			: drx_del(dbg, bp, b);
+			? drx_add((RzDebug *)bp->user, bp, b)
+			: drx_del((RzDebug *)bp->user, bp, b);
 #elif (__arm64__ || __aarch64__) && __linux__
 		return set
-			? arm64_hwbp_add(dbg, bp, b)
-			: arm64_hwbp_del(dbg, bp, b);
+			? arm64_hwbp_add((RzDebug *)bp->user, bp, b)
+			: arm64_hwbp_del((RzDebug *)bp->user, bp, b);
 #elif __WINDOWS__
 		return set
-			? w32_hwbp_arm_add(dbg, bp, b)
-			: w32_hwbp_arm_del(dbg, bp, b);
+			? w32_hwbp_arm_add((RzDebug *)bp->user, bp, b)
+			: w32_hwbp_arm_del((RzDebug *)bp->user, bp, b);
 #elif __arm__ && __linux__
 		return set
-			? arm32_hwbp_add(dbg, bp, b)
-			: arm32_hwbp_del(dbg, bp, b);
-#elif __riscv
-		dbg = NULL;
-		return false;
+			? arm32_hwbp_add((RzDebug *)bp->user, bp, b)
+			: arm32_hwbp_del((RzDebug *)bp->user, bp, b);
 #endif
 	}
 	return false;

--- a/librz/debug/p/native/xnu/xnu_debug.c
+++ b/librz/debug/p/native/xnu/xnu_debug.c
@@ -716,7 +716,6 @@ static int xnu_write_mem_maps_to_buffer(RzXnuDebug *ctx, RzBuffer *buffer, RzLis
 	vm_offset_t header, int header_end, int segment_command_sz, int *hoffset_out) {
 	RzListIter *iter, *iter2;
 	RzDebugMap *curr_map;
-	int foffset = 0; // start_offset;
 	int hoffset = header_end;
 	kern_return_t kr = KERN_SUCCESS;
 	int error = 0;
@@ -727,6 +726,7 @@ static int xnu_write_mem_maps_to_buffer(RzXnuDebug *ctx, RzBuffer *buffer, RzLis
 	struct segment_command_64 *sc64;
 #elif __i386__ || __ppc__ || __POWERPC__
 	struct segment_command *sc;
+	int foffset = 0; // start_offset;
 #endif
 	rz_list_foreach_safe (mem_maps, iter, iter2, curr_map) {
 		eprintf("Writing section from 0x%" PFMT64x " to 0x%" PFMT64x " (%" PFMT64d ")\n",
@@ -743,7 +743,7 @@ static int xnu_write_mem_maps_to_buffer(RzXnuDebug *ctx, RzBuffer *buffer, RzLis
 		sc64->maxprot = xwrz_testwx(curr_map->user);
 		sc64->initprot = xwrz_testwx(curr_map->perm);
 		sc64->nsects = 0;
-#elif __i386__ || __ppc__
+#elif __i386__ || __ppc__ || __POWERPC__
 		sc = (struct segment_command *)(header + hoffset);
 		sc->cmd = LC_SEGMENT;
 		sc->cmdsize = sizeof(struct segment_command);
@@ -807,7 +807,9 @@ static int xnu_write_mem_maps_to_buffer(RzXnuDebug *ctx, RzBuffer *buffer, RzLis
 		}
 
 		hoffset += segment_command_sz;
+#if __i386__ || __ppc__ || __POWERPC__
 		foffset += curr_map->size;
+#endif
 		vmoffset += curr_map->size;
 	}
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fix warnings on MacOS 12.5.1 M1

**Test plan**

CI is green.