### PR TITLE
Make all visual functions private (RZ_IPI)

### DIFF
--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -4111,7 +4111,7 @@ static void nextword(RzCore *core, RzAGraph *g, const char *word) {
 	nextword(core, g, word);
 }
 
-RZ_API int rz_core_visual_graph(RzCore *core, RzAGraph *g, RzAnalysisFunction *_fcn, int is_interactive) {
+RZ_IPI int rz_core_visual_graph(RzCore *core, RzAGraph *g, RzAnalysisFunction *_fcn, int is_interactive) {
 	if (is_interactive && !rz_cons_is_interactive()) {
 		eprintf("Interactive graph mode requires scr.interactive=true.\n");
 		return 0;

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -2374,7 +2374,7 @@ static bool cb_visual_mode(void *user, void *data) {
 		node->i_value = RZ_CORE_VISUAL_MODE_PX;
 	}
 	RzCore *core = (RzCore *)user;
-	core->printidx = node->i_value;
+	((RzCoreVisual *)core->visual)->printidx = node->i_value;
 	return true;
 }
 

--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -22,8 +22,8 @@
 #include <tree_sitter/api.h>
 TSLanguage *tree_sitter_rzcmd();
 
-RZ_API void rz_save_panels_layout(RzCore *core, const char *_name);
-RZ_API bool rz_load_panels_layout(RzCore *core, const char *_name);
+RZ_IPI void rz_save_panels_layout(RzCore *core, const char *_name);
+RZ_IPI bool rz_load_panels_layout(RzCore *core, const char *_name);
 
 static RzCmdDescriptor *cmd_descriptor(const char *cmd, const char *help[]) {
 	RzCmdDescriptor *d = RZ_NEW0(RzCmdDescriptor);

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -2387,8 +2387,6 @@ RZ_API bool rz_core_init(RzCore *core) {
 	core->print->offname = rz_core_print_offname;
 	core->print->offsize = rz_core_print_offsize;
 	core->print->cb_printf = rz_cons_printf;
-	core->visual_is_inputing = false;
-	core->visual_inputing = NULL;
 #if __WINDOWS__
 	core->print->cb_eprintf = win_eprintf;
 #endif
@@ -2411,7 +2409,6 @@ RZ_API bool rz_core_init(RzCore *core) {
 	core->scriptstack->free = (RzListFree)free;
 	core->times = RZ_NEW0(RzCoreTimes);
 	core->vmode = false;
-	core->printidx = 0;
 	core->lastcmd = NULL;
 	core->cmdlog = NULL;
 	core->stkcmd = NULL;
@@ -2546,6 +2543,8 @@ RZ_API bool rz_core_init(RzCore *core) {
 	core->dbg->cb_printf = rz_cons_printf;
 	core->dbg->bp->cb_printf = rz_cons_printf;
 	core->dbg->ev = core->ev;
+	// Initialize visual modes after everything else but before config init
+	core->visual = rz_core_visual_new();
 	// initialize config before any corebind
 	rz_core_config_init(core);
 
@@ -2618,7 +2617,6 @@ RZ_API void rz_core_fini(RzCore *c) {
 	RZ_FREE(c->cmdqueue);
 	RZ_FREE(c->lastcmd);
 	RZ_FREE(c->stkcmd);
-	RZ_FREE_CUSTOM(c->visual.tabs, rz_list_free);
 	RZ_FREE(c->block);
 	RZ_FREE_CUSTOM(c->autocomplete, rz_core_autocomplete_free);
 
@@ -2650,7 +2648,6 @@ RZ_API void rz_core_fini(RzCore *c) {
 	RZ_FREE_CUSTOM(c->lib, rz_lib_free);
 	RZ_FREE_CUSTOM(c->yank_buf, rz_buf_free);
 	RZ_FREE_CUSTOM(c->graph, rz_agraph_free);
-	RZ_FREE(c->visual_inputing);
 	RZ_FREE(c->asmqjmps);
 	RZ_FREE_CUSTOM(c->sdb, sdb_free);
 	RZ_FREE_CUSTOM(c->parser, rz_parse_free);
@@ -2658,6 +2655,7 @@ RZ_API void rz_core_fini(RzCore *c) {
 	rz_core_seek_free(c);
 	RZ_FREE(c->rtr_host);
 	RZ_FREE(c->curtheme);
+	rz_core_visual_free(c->visual);
 }
 
 RZ_API void rz_core_free(RzCore *c) {

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -217,4 +217,97 @@ static inline RzCmdStatus bool2status(bool val) {
 	return val ? RZ_CMD_STATUS_OK : RZ_CMD_STATUS_ERROR;
 }
 
+/* Visual modes */
+
+typedef enum {
+	RZ_CORE_VISUAL_MODE_PX = 0, ///< Hexadecimal view
+	RZ_CORE_VISUAL_MODE_PD = 1, ///< Disassembly view
+	RZ_CORE_VISUAL_MODE_DB = 2, ///< Debug mode
+	RZ_CORE_VISUAL_MODE_OV = 3, ///< Color blocks (entropy)
+	RZ_CORE_VISUAL_MODE_CD = 4 ///< Print in string format
+} RzCoreVisualMode;
+
+typedef struct rz_core_visual_tab_t {
+	int printidx;
+	ut64 offset;
+	bool cur_enabled;
+	int cur;
+	int ocur;
+	int cols;
+	int disMode;
+	int hexMode;
+	int asm_offset;
+	int asm_instr;
+	int asm_indent;
+	int asm_bytes;
+	int asm_cmt_col;
+	int printMode;
+	int current3format;
+	int current4format;
+	int current5format;
+	int dumpCols;
+	char name[32]; // XXX leak because no  rz_core_visual_tab_free
+	// TODO: cursor and such
+} RzCoreVisualTab;
+
+typedef struct rz_core_visual_t {
+	RzList *tabs;
+	int tab;
+	bool is_inputing; // whether the user is inputing
+	char *inputing; // for filter on the go in Vv mode
+	RzCoreVisualMode printidx;
+} RzCoreVisual;
+
+RZ_IPI RZ_OWN RzCoreVisual *rz_core_visual_new();
+RZ_IPI void rz_core_visual_free(RZ_NULLABLE RzCoreVisual *visual);
+
+RZ_IPI void rz_core_visual_prompt_input(RzCore *core);
+RZ_IPI void rz_core_visual_toggle_hints(RzCore *core);
+RZ_IPI void rz_core_visual_toggle_decompiler_disasm(RzCore *core, bool for_graph, bool reset);
+RZ_IPI void rz_core_visual_applyDisMode(RzCore *core, int disMode);
+RZ_IPI void rz_core_visual_applyHexMode(RzCore *core, int hexMode);
+RZ_IPI int rz_core_visual_xrefs(RzCore *core, bool xref_to, bool fcnInsteadOfAddr);
+RZ_IPI void rz_core_visual_append_help(RzStrBuf *p, const char *title, const char **help);
+
+RZ_IPI bool rz_core_visual_bit_editor(RzCore *core);
+RZ_IPI bool rz_core_visual_hudstuff(RzCore *core);
+RZ_IPI int rz_core_visual_classes(RzCore *core);
+RZ_IPI int rz_core_visual_analysis_classes(RzCore *core);
+RZ_IPI int rz_core_visual(RzCore *core, const char *input);
+RZ_IPI int rz_core_visual_graph(RzCore *core, RzAGraph *g, RzAnalysisFunction *_fcn, int is_interactive);
+RZ_IPI bool rz_core_visual_panels_root(RzCore *core, RzPanelsRoot *panels_root);
+RZ_IPI void rz_core_visual_browse(RzCore *core, const char *arg);
+RZ_IPI int rz_core_visual_cmd(RzCore *core, const char *arg);
+RZ_IPI void rz_core_visual_seek_animation(RzCore *core, ut64 addr);
+RZ_IPI void rz_core_visual_seek_animation_redo(RzCore *core);
+RZ_IPI void rz_core_visual_seek_animation_undo(RzCore *core);
+RZ_IPI void rz_core_visual_asm(RzCore *core, ut64 addr);
+RZ_IPI void rz_core_visual_colors(RzCore *core);
+RZ_IPI void rz_core_visual_showcursor(RzCore *core, int x);
+RZ_IPI void rz_core_visual_offset(RzCore *core);
+RZ_IPI bool rz_core_visual_hud(RzCore *core);
+RZ_IPI void rz_core_visual_jump(RzCore *core, ut8 ch);
+RZ_IPI void rz_core_visual_disasm_up(RzCore *core, int *cols);
+RZ_IPI void rz_core_visual_disasm_down(RzCore *core, RzAsmOp *op, int *cols);
+
+RZ_IPI int rz_core_visual_prevopsz(RzCore *core, ut64 addr);
+RZ_IPI void rz_core_visual_config(RzCore *core);
+RZ_IPI void rz_core_visual_analysis(RzCore *core, const char *input);
+RZ_IPI void rz_core_visual_debugtraces(RzCore *core, const char *input);
+RZ_IPI void rz_core_visual_define(RzCore *core, const char *arg, int distance);
+RZ_IPI int rz_core_visual_trackflags(RzCore *core);
+RZ_IPI int rz_core_visual_view_graph(RzCore *core);
+RZ_IPI int rz_core_visual_view_rop(RzCore *core);
+RZ_IPI int rz_core_visual_comments(RzCore *core);
+RZ_IPI int rz_core_visual_prompt(RzCore *core);
+RZ_IPI bool rz_core_visual_esil(RzCore *core);
+
+/* visual marks */
+RZ_IPI void rz_core_visual_mark_seek(RzCore *core, ut8 ch);
+RZ_IPI void rz_core_visual_mark(RzCore *core, ut8 ch);
+RZ_IPI void rz_core_visual_mark_set(RzCore *core, ut8 ch, ut64 addr);
+RZ_IPI void rz_core_visual_mark_del(RzCore *core, ut8 ch);
+RZ_IPI bool rz_core_visual_mark_dump(RzCore *core);
+RZ_IPI void rz_core_visual_mark_reset(RzCore *core);
+
 #endif

--- a/librz/core/meson.build
+++ b/librz/core/meson.build
@@ -59,7 +59,6 @@ rz_core_sources = [
   'seek.c',
   'serialize_core.c',
   'task.c',
-  'vmarks.c',
   'yank.c',
   'p/core_dex.c',
   'p/core_java.c',
@@ -105,6 +104,7 @@ rz_core_sources = [
   'tui/vmenus.c',
   'tui/vmenus_graph.c',
   'tui/vasm.c',
+  'tui/vmarks.c',
   'tui/panels.c'
 ]
 

--- a/librz/core/tui/panels.c
+++ b/librz/core/tui/panels.c
@@ -362,8 +362,8 @@ static void __panel_prompt(const char *prompt, char *buf, int len);
 static void __panels_layout_refresh(RzCore *core);
 static void __panels_layout(RzPanels *panels);
 static void __layout_default(RzPanels *panels);
-RZ_API void rz_save_panels_layout(RzCore *core, const char *_name);
-RZ_API bool rz_load_panels_layout(RzCore *core, const char *_name);
+RZ_IPI void rz_save_panels_layout(RzCore *core, const char *_name);
+RZ_IPI bool rz_load_panels_layout(RzCore *core, const char *_name);
 static void __split_panel_vertical(RzCore *core, RzPanel *p, const char *name, const char *cmd);
 static void __split_panel_horizontal(RzCore *core, RzPanel *p, const char *name, const char *cmd);
 static void __panel_print(RzCore *core, RzConsCanvas *can, RzPanel *panel, int color);
@@ -5290,7 +5290,7 @@ char *__get_panels_config_file_from_dir(const char *file) {
 	return ret;
 }
 
-RZ_API void rz_save_panels_layout(RzCore *core, const char *oname) {
+RZ_IPI void rz_save_panels_layout(RzCore *core, const char *oname) {
 	int i;
 	if (!core->panels) {
 		return;
@@ -5341,7 +5341,7 @@ void __load_config_menu(RzCore *core) {
 	}
 }
 
-RZ_API bool rz_load_panels_layout(RzCore *core, const char *_name) {
+RZ_IPI bool rz_load_panels_layout(RzCore *core, const char *_name) {
 	if (!core->panels) {
 		return false;
 	}
@@ -5967,7 +5967,7 @@ void __rotate_asmemu(RzCore *core, RzPanel *p) {
 
 static bool fromVisual = false;
 
-RZ_API bool rz_core_visual_panels_root(RzCore *core, RzPanelsRoot *panels_root) {
+RZ_IPI bool rz_core_visual_panels_root(RzCore *core, RzPanelsRoot *panels_root) {
 	fromVisual = core->vmode;
 	if (!panels_root) {
 		panels_root = RZ_NEW0(RzPanelsRoot);

--- a/librz/core/tui/vasm.c
+++ b/librz/core/tui/vasm.c
@@ -70,7 +70,7 @@ static int readline_callback(void *_a, const char *str) {
 	return 1;
 }
 
-RZ_API void rz_core_visual_asm(RzCore *core, ut64 off) {
+RZ_IPI void rz_core_visual_asm(RzCore *core, ut64 off) {
 	RzCoreVisualAsm cva = {
 		.core = core,
 		.off = off

--- a/librz/core/tui/visual_tabs.inc
+++ b/librz/core/tui/visual_tabs.inc
@@ -6,10 +6,12 @@ static void rz_core_visual_tab_free(RzCoreVisualTab *tab) {
 }
 
 static int __core_visual_tab_count(RzCore *core) {
-	return core->visual.tabs ? rz_list_length(core->visual.tabs) : 0;
+	RzCoreVisual *visual = core->visual;
+	return visual->tabs ? rz_list_length(visual->tabs) : 0;
 }
 
 static char *__core_visual_tab_string(RzCore *core, const char *kolor) {
+	RzCoreVisual *visual = core->visual;
 	int hex_cols = rz_config_get_i(core->config, "hex.cols");
 	int scr_color = rz_config_get_i(core->config, "scr.color");
 	if (hex_cols < 4) {
@@ -17,16 +19,16 @@ static char *__core_visual_tab_string(RzCore *core, const char *kolor) {
 	}
 	int i = 0;
 	char *str = NULL;
-	int tabs = rz_list_length(core->visual.tabs);
+	int tabs = rz_list_length(visual->tabs);
 	if (scr_color > 0) {
 		// TODO: use theme
 		if (tabs > 0) {
 			str = rz_str_appendf(str, "%s-+__", kolor);
 		}
 		for (i = 0; i < tabs; i++) {
-			RzCoreVisualTab *tab = rz_list_get_n(core->visual.tabs, i);
+			RzCoreVisualTab *tab = rz_list_get_n(visual->tabs, i);
 			const char *name = (tab && *tab->name) ? tab->name : NULL;
-			if (i == core->visual.tab) {
+			if (i == visual->tab) {
 				str = rz_str_appendf(str, Color_WHITE "_/ %s \\_%s", name ? name : "t=", kolor);
 			} else {
 				str = rz_str_appendf(str, "_%s(%d)_", name ? name : "", i + 1);
@@ -38,11 +40,11 @@ static char *__core_visual_tab_string(RzCore *core, const char *kolor) {
 		}
 		for (i = 0; i < tabs; i++) {
 			const char *name = NULL;
-			RzCoreVisualTab *tab = rz_list_get_n(core->visual.tabs, i);
+			RzCoreVisualTab *tab = rz_list_get_n(visual->tabs, i);
 			if (tab && *tab->name) {
 				name = tab->name;
 			}
-			if (i == core->visual.tab) {
+			if (i == visual->tab) {
 				str = rz_str_appendf(str, "_/ %d:%s \\_", i + 1, name ? name : "'=");
 			} else {
 				str = rz_str_appendf(str, "_(t%d%s%s)__", i + 1, name ? ":" : "", name ? name : "");
@@ -63,7 +65,8 @@ static void visual_tabset(RzCore *core, RzCoreVisualTab *tab) {
 	rz_return_if_fail(core && tab);
 
 	rz_core_seek(core, tab->offset, true);
-	core->printidx = tab->printidx;
+	RzCoreVisual *visual = core->visual;
+	visual->printidx = tab->printidx;
 	core->print->cur_enabled = tab->cur_enabled;
 	core->print->cur = tab->cur;
 	core->print->ocur = tab->ocur;
@@ -92,7 +95,8 @@ static void visual_tabget(RzCore *core, RzCoreVisualTab *tab) {
 	rz_return_if_fail(core && tab);
 
 	tab->offset = core->offset;
-	tab->printidx = core->printidx;
+	RzCoreVisual *visual = core->visual;
+	tab->printidx = visual->printidx;
 	tab->asm_offset = rz_config_get_i(core->config, "asm.offset");
 	tab->asm_instr = rz_config_get_i(core->config, "asm.instr");
 	tab->asm_indent = rz_config_get_i(core->config, "asm.indent");
@@ -121,104 +125,111 @@ static RzCoreVisualTab *rz_core_visual_tab_new(RzCore *core) {
 }
 
 static void rz_core_visual_tab_update(RzCore *core) {
-	if (!core->visual.tabs) {
+	RzCoreVisual *visual = core->visual;
+	if (!visual->tabs) {
 		return;
 	}
-	RzCoreVisualTab *tab = rz_list_get_n(core->visual.tabs, core->visual.tab);
+	RzCoreVisualTab *tab = rz_list_get_n(visual->tabs, visual->tab);
 	if (tab) {
 		visual_tabget(core, tab);
 	}
 }
 
 static RzCoreVisualTab *visual_newtab(RzCore *core) {
-	if (!core->visual.tabs) {
-		core->visual.tabs = rz_list_newf((RzListFree)rz_core_visual_tab_free);
-		if (!core->visual.tabs) {
+	RzCoreVisual *visual = core->visual;
+	if (!visual->tabs) {
+		visual->tabs = rz_list_newf((RzListFree)rz_core_visual_tab_free);
+		if (!visual->tabs) {
 			return NULL;
 		}
-		core->visual.tab = -1;
+		visual->tab = -1;
 		visual_newtab(core);
 	}
-	core->visual.tab++;
+	visual->tab++;
 	RzCoreVisualTab *tab = rz_core_visual_tab_new(core);
 	if (tab) {
-		rz_list_append(core->visual.tabs, tab);
+		rz_list_append(visual->tabs, tab);
 		visual_tabset(core, tab);
 	}
 	return tab;
 }
 
 static void visual_nthtab(RzCore *core, int n) {
-	if (!core->visual.tabs || n < 0 || n >= rz_list_length(core->visual.tabs)) {
+	RzCoreVisual *visual = core->visual;
+	if (!visual->tabs || n < 0 || n >= rz_list_length(visual->tabs)) {
 		return;
 	}
-	core->visual.tab = n;
-	RzCoreVisualTab *tab = rz_list_get_n(core->visual.tabs, core->visual.tab);
+	visual->tab = n;
+	RzCoreVisualTab *tab = rz_list_get_n(visual->tabs, visual->tab);
 	if (tab) {
 		visual_tabset(core, tab);
 	}
 }
 
 static void visual_tabname(RzCore *core) {
-	if (!core->visual.tabs) {
+	RzCoreVisual *visual = core->visual;
+	if (!visual->tabs) {
 		return;
 	}
 	char name[32] = { 0 };
 	prompt_read("tab name: ", name, sizeof(name));
-	RzCoreVisualTab *tab = rz_list_get_n(core->visual.tabs, core->visual.tab);
+	RzCoreVisualTab *tab = rz_list_get_n(visual->tabs, visual->tab);
 	if (tab) {
 		strcpy(tab->name, name);
 	}
 }
 
 static void visual_nexttab(RzCore *core) {
-	if (!core->visual.tabs) {
+	RzCoreVisual *visual = core->visual;
+	if (!visual->tabs) {
 		return;
 	}
-	if (core->visual.tab >= rz_list_length(core->visual.tabs) - 1) {
-		core->visual.tab = -1;
+	if (visual->tab >= rz_list_length(visual->tabs) - 1) {
+		visual->tab = -1;
 	}
-	core->visual.tab++;
-	RzCoreVisualTab *tab = rz_list_get_n(core->visual.tabs, core->visual.tab);
+	visual->tab++;
+	RzCoreVisualTab *tab = rz_list_get_n(visual->tabs, visual->tab);
 	if (tab) {
 		visual_tabset(core, tab);
 	}
 }
 
 static void visual_prevtab(RzCore *core) {
-	if (!core->visual.tabs) {
+	RzCoreVisual *visual = core->visual;
+	if (!visual->tabs) {
 		return;
 	}
-	if (core->visual.tab < 1) {
-		core->visual.tab = rz_list_length(core->visual.tabs) - 1;
+	if (visual->tab < 1) {
+		visual->tab = rz_list_length(visual->tabs) - 1;
 	} else {
-		core->visual.tab--;
+		visual->tab--;
 	}
-	RzCoreVisualTab *tab = rz_list_get_n(core->visual.tabs, core->visual.tab);
+	RzCoreVisualTab *tab = rz_list_get_n(visual->tabs, visual->tab);
 	if (tab) {
 		visual_tabset(core, tab);
 	}
 }
 
 static void visual_closetab(RzCore *core) {
-	if (!core->visual.tabs) {
+	RzCoreVisual *visual = core->visual;
+	if (!visual->tabs) {
 		return;
 	}
-	RzCoreVisualTab *tab = rz_list_get_n(core->visual.tabs, core->visual.tab);
+	RzCoreVisualTab *tab = rz_list_get_n(visual->tabs, visual->tab);
 	if (tab) {
-		rz_list_delete_data(core->visual.tabs, tab);
-		const int tabsCount = rz_list_length(core->visual.tabs);
+		rz_list_delete_data(visual->tabs, tab);
+		const int tabsCount = rz_list_length(visual->tabs);
 		if (tabsCount > 0) {
-			if (core->visual.tab > 0) {
-				core->visual.tab--;
+			if (visual->tab > 0) {
+				visual->tab--;
 			}
-			RzCoreVisualTab *tab = rz_list_get_n(core->visual.tabs, core->visual.tab);
+			RzCoreVisualTab *tab = rz_list_get_n(visual->tabs, visual->tab);
 			if (tab) {
 				visual_tabset(core, tab);
 			}
 		} else {
-			rz_list_free(core->visual.tabs);
-			core->visual.tabs = NULL;
+			rz_list_free(visual->tabs);
+			visual->tabs = NULL;
 		}
 	}
 }

--- a/librz/core/tui/vmarks.c
+++ b/librz/core/tui/vmarks.c
@@ -3,7 +3,7 @@
 
 #include <rz_core.h>
 
-RZ_API void rz_core_visual_mark_reset(RzCore *core) {
+RZ_IPI void rz_core_visual_mark_reset(RzCore *core) {
 	size_t i;
 	for (i = 0; i < UT8_MAX; i++) {
 		core->marks[i] = UT64_MAX;
@@ -11,7 +11,7 @@ RZ_API void rz_core_visual_mark_reset(RzCore *core) {
 	core->marks_init = true;
 }
 
-RZ_API bool rz_core_visual_mark_dump(RzCore *core) {
+RZ_IPI bool rz_core_visual_mark_dump(RzCore *core) {
 	size_t i;
 	if (!core->marks_init) {
 		return false;
@@ -30,28 +30,28 @@ RZ_API bool rz_core_visual_mark_dump(RzCore *core) {
 	return res;
 }
 
-RZ_API void rz_core_visual_mark_set(RzCore *core, ut8 ch, ut64 addr) {
+RZ_IPI void rz_core_visual_mark_set(RzCore *core, ut8 ch, ut64 addr) {
 	if (!core->marks_init) {
 		rz_core_visual_mark_reset(core);
 	}
 	core->marks[ch] = addr;
 }
 
-RZ_API void rz_core_visual_mark_del(RzCore *core, ut8 ch) {
+RZ_IPI void rz_core_visual_mark_del(RzCore *core, ut8 ch) {
 	if (!core->marks_init) {
 		return;
 	}
 	core->marks[ch] = UT64_MAX;
 }
 
-RZ_API void rz_core_visual_mark(RzCore *core, ut8 ch) {
+RZ_IPI void rz_core_visual_mark(RzCore *core, ut8 ch) {
 	if (IS_DIGIT(ch)) {
 		ch += ASCII_MAX + 1;
 	}
 	rz_core_visual_mark_set(core, ch, core->offset);
 }
 
-RZ_API void rz_core_visual_mark_seek(RzCore *core, ut8 ch) {
+RZ_IPI void rz_core_visual_mark_seek(RzCore *core, ut8 ch) {
 	if (core->marks_init && core->marks[ch] != UT64_MAX) {
 		rz_core_seek(core, core->marks[ch], true);
 	}

--- a/librz/core/tui/vmenus.c
+++ b/librz/core/tui/vmenus.c
@@ -86,7 +86,7 @@ static void showreg(RzAnalysisEsil *esil, const char *rn, const char *desc) {
 	rz_cons_printf("%s 0x%08" PFMT64x " (%d) ; %s\n", rn, nm, sz, desc);
 }
 
-RZ_API bool rz_core_visual_esil(RzCore *core) {
+RZ_IPI bool rz_core_visual_esil(RzCore *core) {
 	const int nbits = sizeof(ut64) * 8;
 	char *word = NULL;
 	int x = 0;
@@ -231,7 +231,7 @@ beach:
 	return true;
 }
 
-RZ_API bool rz_core_visual_bit_editor(RzCore *core) {
+RZ_IPI bool rz_core_visual_bit_editor(RzCore *core) {
 	const int nbits = sizeof(ut64) * 8;
 	bool colorBits = false;
 	int i, j, x = 0;
@@ -491,7 +491,7 @@ RZ_API bool rz_core_visual_bit_editor(RzCore *core) {
 	return true;
 }
 
-RZ_API bool rz_core_visual_hudclasses(RzCore *core) {
+RZ_IPI bool rz_core_visual_hudclasses(RzCore *core) {
 	RzListIter *iter, *iter2;
 	RzBinClass *c;
 	RzBinField *f;
@@ -536,7 +536,7 @@ static bool hudstuff_append(RzFlagItem *fi, void *user) {
 	return true;
 }
 
-RZ_API bool rz_core_visual_hudstuff(RzCore *core) {
+RZ_IPI bool rz_core_visual_hudstuff(RzCore *core) {
 	ut64 addr;
 	char *res;
 	RzList *list = rz_list_new();
@@ -783,7 +783,7 @@ static void *show_class(RzCore *core, int mode, int *idx, RzBinClass *_c, const 
 	return NULL;
 }
 
-RZ_API int rz_core_visual_classes(RzCore *core) {
+RZ_IPI int rz_core_visual_classes(RzCore *core) {
 	int ch, index = 0;
 	char cmd[1024];
 	int mode = 'c';
@@ -1074,7 +1074,7 @@ static const char *show_analysis_classes(RzCore *core, char mode, int *idx, SdbL
 // Should the classes be refreshed after command execution with :
 // in case new class information would be added?
 // Add grep?
-RZ_API int rz_core_visual_analysis_classes(RzCore *core) {
+RZ_IPI int rz_core_visual_analysis_classes(RzCore *core) {
 	int ch, index = 0;
 	char command[1024];
 	SdbList *list = rz_analysis_class_get_all(core->analysis, true);
@@ -1229,7 +1229,7 @@ static char *print_rop(void *_core, void *_item, bool selected) {
 	return rz_str_newf("%c %s\n", selected ? '>' : ' ', line);
 }
 
-RZ_API int rz_core_visual_view_rop(RzCore *core) {
+RZ_IPI int rz_core_visual_view_rop(RzCore *core) {
 	RzListIter *iter;
 	const int rows = 7;
 	int cur = 0;
@@ -1482,7 +1482,7 @@ RZ_API int rz_core_visual_view_rop(RzCore *core) {
 	return false;
 }
 
-RZ_API int rz_core_visual_trackflags(RzCore *core) {
+RZ_IPI int rz_core_visual_trackflags(RzCore *core) {
 	const char *fs = NULL, *fs2 = NULL;
 	int hit, i, j, ch;
 	int _option = 0;
@@ -1492,6 +1492,7 @@ RZ_API int rz_core_visual_trackflags(RzCore *core) {
 	int delta = 7;
 	int menu = 0;
 	int sort = SORT_NONE;
+	RzCoreVisual *visual = core->visual;
 
 	if (rz_flag_space_is_empty(core->flags)) {
 		menu = 1;
@@ -1543,15 +1544,15 @@ RZ_API int rz_core_visual_trackflags(RzCore *core) {
 				switch (format) {
 				case 0:
 					snprintf(cmd, sizeof(cmd), "px %d @ %s!64", rows * 16, fs2);
-					core->printidx = 0;
+					visual->printidx = 0;
 					break;
 				case 1:
 					snprintf(cmd, sizeof(cmd), "pd %d @ %s!64", rows, fs2);
-					core->printidx = 1;
+					visual->printidx = 1;
 					break;
 				case 2:
 					snprintf(cmd, sizeof(cmd), "ps @ %s!64", fs2);
-					core->printidx = 5;
+					visual->printidx = 5;
 					break;
 				case 3: strcpy(cmd, "f="); break;
 				default: format = 0; continue;
@@ -1790,7 +1791,8 @@ RZ_API int rz_core_visual_trackflags(RzCore *core) {
 	return true;
 }
 
-RZ_API int rz_core_visual_comments(RzCore *core) {
+RZ_IPI int rz_core_visual_comments(RzCore *core) {
+	RzCoreVisual *visual = core->visual;
 	char *str;
 	char cmd[512], *p = NULL;
 	int ch, option = 0;
@@ -1832,15 +1834,15 @@ RZ_API int rz_core_visual_comments(RzCore *core) {
 		switch (format) {
 		case 0:
 			sprintf(cmd, "px @ 0x%" PFMT64x ":64", from);
-			core->printidx = 0;
+			visual->printidx = 0;
 			break;
 		case 1:
 			sprintf(cmd, "pd 12 @ 0x%" PFMT64x ":64", from);
-			core->printidx = 1;
+			visual->printidx = 1;
 			break;
 		case 2:
 			sprintf(cmd, "ps @ 0x%" PFMT64x ":64", from);
-			core->printidx = 5;
+			visual->printidx = 5;
 			break;
 		default: format = 0; continue;
 		}
@@ -1981,7 +1983,7 @@ static void show_config_options(RzCore *core, const char *opt) {
 	}
 }
 
-RZ_API void rz_core_visual_config(RzCore *core) {
+RZ_IPI void rz_core_visual_config(RzCore *core) {
 	char *fs = NULL, *fs2 = NULL, *desc = NULL;
 	int i, j, ch, hit, show;
 	int option, _option = 0;
@@ -2206,29 +2208,28 @@ static void variable_set_type(RzCore *core, ut64 addr, int vindex, const char *t
 }
 
 /**
- * \brief Convert the string visual_inputing to RzPVector, with WHITESPACE as separators
+ * \brief Convert the string inputing to RzPVector, with WHITESPACE as separators
  *
- * \param visual_inputing
+ * \param inputing
  * \return return the pointer of RzPVector
  */
-static RzPVector *capture_filter_keywords(char *visual_inputing) {
-	rz_return_val_if_fail(visual_inputing, NULL);
-	char *buf, *inputing;
+static RzPVector *capture_filter_keywords(char *inputing) {
+	rz_return_val_if_fail(inputing, NULL);
 	RzPVector *keywords = rz_pvector_new(free);
 
 	if (!keywords) {
 		return NULL;
 	}
-	inputing = rz_str_trim_dup(visual_inputing);
-	buf = rz_str_new("");
-	for (int i = 0; i < strlen(visual_inputing); i++) {
-		if (IS_WHITESPACE(visual_inputing[i])) {
+	char *processing = rz_str_trim_dup(inputing);
+	char *buf = rz_str_new("");
+	for (int i = 0; i < strlen(processing); i++) {
+		if (IS_WHITESPACE(processing[i])) {
 			if (strlen(buf)) {
 				rz_pvector_push(keywords, buf);
 				buf = rz_str_new("");
 			}
 		} else {
-			buf = rz_str_appendch(buf, visual_inputing[i]);
+			buf = rz_str_appendch(buf, processing[i]);
 		}
 	}
 	if (strlen(buf)) {
@@ -2236,7 +2237,7 @@ static RzPVector *capture_filter_keywords(char *visual_inputing) {
 	} else {
 		RZ_FREE(buf);
 	}
-	RZ_FREE(inputing);
+	free(processing);
 	return keywords;
 }
 
@@ -2281,18 +2282,19 @@ static ut64 var_functions_show(RzCore *core, int idx, int show, int cols) {
 	RzList *filter_fcn = core->analysis->fcns, *visual_filter = NULL;
 	int window, i = 0, print_full_func;
 	RzListIter *iter;
+	RzCoreVisual *visual = core->visual;
 
 	// Adjust the windows size automaticaly
 	(void)rz_cons_get_size(&window);
-	window -= core->visual_inputing ? 10 : 8; // Size of printed things
+	window -= visual->inputing ? 10 : 8; // Size of printed things
 	bool color = rz_config_get_i(core->config, "scr.color");
 	const char *color_addr = core->cons->context->pal.offset;
 	const char *color_fcn = core->cons->context->pal.fname;
 
-	if (core->visual_inputing) {
+	if (visual->inputing) {
 		visual_filter = rz_list_newf(NULL);
 		if (visual_filter) {
-			RzPVector *keywords = capture_filter_keywords(core->visual_inputing);
+			RzPVector *keywords = capture_filter_keywords(visual->inputing);
 			if (keywords) {
 				filter_function(core, visual_filter, keywords);
 				RZ_FREE_CUSTOM(keywords, rz_pvector_free);
@@ -2514,9 +2516,8 @@ static void rz_core_vmenu_append_help(RzStrBuf *p, const char **help) {
 }
 
 static ut64 rz_core_visual_analysis_refresh(RzCore *core) {
-	if (!core) {
-		return 0LL;
-	}
+	rz_return_val_if_fail(core, 0);
+	RzCoreVisual *visual = core->visual;
 	ut64 addr;
 	RzStrBuf *buf;
 	char old[1024];
@@ -2554,11 +2555,11 @@ static ut64 rz_core_visual_analysis_refresh(RzCore *core) {
 		rz_cons_printf("%s", drained);
 		free(drained);
 		// hints for filtered keywords
-		if (core->visual_inputing) {
-			if (core->visual_is_inputing) {
-				rz_cons_printf("input keywords: %s\n\n", core->visual_inputing);
+		if (visual->inputing) {
+			if (visual->is_inputing) {
+				rz_cons_printf("input keywords: %s\n\n", visual->inputing);
 			} else {
-				rz_cons_printf("keywords: %s\n\n", core->visual_inputing);
+				rz_cons_printf("keywords: %s\n\n", visual->inputing);
 			}
 		}
 		addr = var_functions_show(core, option, 1, cols);
@@ -2631,7 +2632,7 @@ static void rz_core_visual_debugtraces_help(RzCore *core) {
 	rz_cons_any_key(NULL);
 }
 
-RZ_API void rz_core_visual_debugtraces(RzCore *core, const char *input) {
+RZ_IPI void rz_core_visual_debugtraces(RzCore *core, const char *input) {
 	int i, delta = 0;
 	for (;;) {
 		char *trace_addr_str = rz_core_cmd_strf(core, "dtdq %d", delta);
@@ -2736,10 +2737,11 @@ static void addVar(RzCore *core, int ch, const char *msg) {
 }
 
 /* Like emenu but for real */
-RZ_API void rz_core_visual_analysis(RzCore *core, const char *input) {
+RZ_IPI void rz_core_visual_analysis(RzCore *core, const char *input) {
 	char old[218];
 	int nfcns, ch, _option = 0;
 
+	RzCoreVisual *visual = core->visual;
 	RzConsEvent olde = core->cons->event_resize;
 	void *olde_user = core->cons->event_data;
 	ut64 addr = core->offset;
@@ -2754,8 +2756,8 @@ RZ_API void rz_core_visual_analysis(RzCore *core, const char *input) {
 	rz_config_set_i(core->config, "asm.bytes", 0);
 	for (;;) {
 		nfcns = rz_list_length(core->analysis->fcns);
-		if (core->visual_inputing) {
-			RzPVector *keywords = capture_filter_keywords(core->visual_inputing);
+		if (visual->inputing) {
+			RzPVector *keywords = capture_filter_keywords(visual->inputing);
 			if (keywords) {
 				nfcns = filter_function(core, NULL, keywords);
 			}
@@ -2764,26 +2766,26 @@ RZ_API void rz_core_visual_analysis(RzCore *core, const char *input) {
 		addr = rz_core_visual_analysis_refresh(core);
 
 		// for filter on the go
-		if (level == 0 && core->visual_is_inputing) {
+		if (level == 0 && visual->is_inputing) {
 			int ch = rz_cons_readchar();
 			switch (ch) {
 			case 13: // CR
-				core->visual_is_inputing = false;
-				if (!strlen(core->visual_inputing)) {
-					RZ_FREE(core->visual_inputing);
+				visual->is_inputing = false;
+				if (!strlen(visual->inputing)) {
+					RZ_FREE(visual->inputing);
 				}
 				break;
 			case 127: // Backspace
 			case 8:
-				if (strlen(core->visual_inputing) > 0) {
-					core->visual_inputing[strlen(core->visual_inputing) - 1] = '\0';
+				if (strlen(visual->inputing) > 0) {
+					visual->inputing[strlen(visual->inputing) - 1] = '\0';
 				}
 				break;
 			default:
 				if (!IS_PRINTABLE(ch)) {
 					continue;
 				}
-				core->visual_inputing = rz_str_appendch(core->visual_inputing, ch);
+				visual->inputing = rz_str_appendch(visual->inputing, ch);
 				break;
 			}
 			// mute the following switch while inputing keyword
@@ -2809,9 +2811,9 @@ RZ_API void rz_core_visual_analysis(RzCore *core, const char *input) {
 		case 'f':
 			if (level == 0) {
 				// add new keyword
-				core->visual_is_inputing = true;
-				if (!core->visual_inputing) {
-					core->visual_inputing = rz_str_new("");
+				visual->is_inputing = true;
+				if (!visual->inputing) {
+					visual->inputing = rz_str_new("");
 				}
 				option = 0;
 			}
@@ -2819,7 +2821,7 @@ RZ_API void rz_core_visual_analysis(RzCore *core, const char *input) {
 		case 'F':
 			if (level == 0) {
 				// reset all keywords
-				RZ_FREE(core->visual_inputing);
+				RZ_FREE(visual->inputing);
 			}
 			break;
 		case '[':
@@ -3146,7 +3148,8 @@ static void handleHints(RzCore *core) {
 	}
 }
 
-RZ_API void rz_core_visual_define(RzCore *core, const char *args, int distance) {
+RZ_IPI void rz_core_visual_define(RzCore *core, const char *args, int distance) {
+	RzCoreVisual *visual = core->visual;
 	int plen = core->blocksize;
 	ut64 off = core->offset;
 	int i, h = 0, n, ch, ntotal = 0;
@@ -3302,7 +3305,7 @@ onemoretime:
 	case 'n': {
 		RzAnalysisOp op;
 		ut64 tgt_addr = UT64_MAX;
-		if (!isDisasmPrint(core->printidx)) {
+		if (!isDisasmPrint(visual->printidx)) {
 			break;
 		}
 		// TODO: get the aligned instruction even if the cursor is in the middle of it.
@@ -3612,7 +3615,7 @@ onemoretime:
 	}
 }
 
-RZ_API void rz_core_visual_colors(RzCore *core) {
+RZ_IPI void rz_core_visual_colors(RzCore *core) {
 	char *color = calloc(1, 64), cstr[32];
 	char preview_cmd[128] = "pd $r";
 	int ch, opt = 0, oopt = -1;

--- a/librz/core/tui/vmenus_graph.c
+++ b/librz/core/tui/vmenus_graph.c
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_core.h>
+
+#include "../core_private.h"
+
 #define SORT_ADDRESS 0
 #define SORT_NAME    1
 
@@ -213,7 +216,7 @@ static void __sync_status_with_cursor(RzCoreVisualViewGraph *status) {
 	__sort(status, status->refsCol);
 }
 
-RZ_API int __core_visual_view_graph_update(RzCore *core, RzCoreVisualViewGraph *status) {
+RZ_IPI int __core_visual_view_graph_update(RzCore *core, RzCoreVisualViewGraph *status) {
 	int h, w = rz_cons_get_size(&h);
 	const int colw = w / 4;
 	const int colh = h / 2;
@@ -252,7 +255,7 @@ RZ_API int __core_visual_view_graph_update(RzCore *core, RzCoreVisualViewGraph *
 	return 0;
 }
 
-RZ_API int rz_core_visual_view_graph(RzCore *core) {
+RZ_IPI int rz_core_visual_view_graph(RzCore *core) {
 	RzCoreVisualViewGraph status = { 0 };
 	status.core = core;
 	status.cur_sort = SORT_NAME;

--- a/librz/include/rz_util/rz_table.h
+++ b/librz/include/rz_util/rz_table.h
@@ -55,6 +55,9 @@ typedef struct {
 
 typedef void (*RzTableSelector)(RzTableRow *acc, RzTableRow *new_row, int nth);
 
+RZ_API RzListInfo *rz_listinfo_new(const char *name, RzInterval pitv, RzInterval vitv, int perm, const char *extra);
+RZ_API void rz_listinfo_free(RzListInfo *info);
+
 RZ_API void rz_table_row_fini(RZ_NONNULL void *_row);
 RZ_API void rz_table_column_fini(RZ_NONNULL void *_col);
 RZ_API RzTableColumn *rz_table_column_clone(RzTableColumn *col);

--- a/librz/util/table.c
+++ b/librz/util/table.c
@@ -1202,6 +1202,27 @@ RZ_API void rz_table_hide_header(RzTable *t) {
 	t->showHeader = false;
 }
 
+RZ_API RzListInfo *rz_listinfo_new(const char *name, RzInterval pitv, RzInterval vitv, int perm, const char *extra) {
+	RzListInfo *info = RZ_NEW(RzListInfo);
+	if (info) {
+		info->name = name ? strdup(name) : NULL;
+		info->pitv = pitv;
+		info->vitv = vitv;
+		info->perm = perm;
+		info->extra = extra ? strdup(extra) : NULL;
+	}
+	return info;
+}
+
+RZ_API void rz_listinfo_free(RzListInfo *info) {
+	if (!info) {
+		return;
+	}
+	free(info->name);
+	free(info->extra);
+	free(info);
+}
+
 RZ_API void rz_table_visual_list(RzTable *table, RzList *list, ut64 seek, ut64 len, int width, bool va) {
 	ut64 mul, min = -1, max = -1;
 	RzListIter *iter;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- All these `rz_core_visual_*()` functions do not really make sense as an external API, thus I removed them from public header `librz/include/rz_core.h` and marked as an `RZ_IPI` instead.

- Moved `librz/core/vmarks.c` to `librz/core/tui/vmarks.c` as it belongs in visual stuff.
- Moved `rz_listinfo_*()` functions from `librz/core/visual.c` to `librz/util/table.c` where they are a better fit
- Moved all members of `RzCore` that are related to Visual mode inside the member called `core->visual`.

**Test plan**

- CI is green
- All visual modes work: `V` (`p/P` loop), `Vv`, `V!`, `Ve`, `Vd`, etc
