### PR TITLE
Better view modes for `p`-cycling in `Vv` view

### DIFF
--- a/librz/core/tui/modes.c
+++ b/librz/core/tui/modes.c
@@ -50,5 +50,5 @@ const char *print5Formats[PRINT_5_FORMATS] = {
 };
 
 const char *printCmds[lastPrintMode] = {
-	"pdf", "pd $r", "afi", "pdsf", "pdc", "pdr"
+	"pdf", "pd $r", "agf", "agl", "afi", "pxa"
 };


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Before when you pressed `p`/`P` to loop through various display modes in the `Vv` mode, it was either largely useless or sometimes broken. I modified the default modes, see screenshots and corresponding commands in the top left corner

## Before

<img width="1220" alt="Screen Shot 2022-09-01 at 08 47 24" src="https://user-images.githubusercontent.com/203261/187809736-96deb700-15cf-4b50-b7a0-faf7917c41d7.png">
<img width="1187" alt="Screen Shot 2022-09-01 at 08 47 57" src="https://user-images.githubusercontent.com/203261/187809754-866dc6a4-4f60-4cb2-95c6-e62beedc704e.png">
<img width="1294" alt="Screen Shot 2022-09-01 at 08 48 22" src="https://user-images.githubusercontent.com/203261/187809794-ffd63976-ae1e-4053-b97c-f73a91ac9f24.png">
<img width="1009" alt="Screen Shot 2022-09-01 at 08 48 44" src="https://user-images.githubusercontent.com/203261/187809864-d61452c1-b5fb-46bd-a188-a00a19ae8e73.png">
<img width="1201" alt="Screen Shot 2022-09-01 at 08 49 07" src="https://user-images.githubusercontent.com/203261/187809889-425ee7ae-d9e0-4452-a59c-72216358e766.png">
<img width="1206" alt="Screen Shot 2022-09-01 at 08 49 27" src="https://user-images.githubusercontent.com/203261/187809917-441b8413-a1a3-4adf-8c4f-56384f667499.png">


## After

<img width="1172" alt="Screen Shot 2022-09-01 at 08 56 06" src="https://user-images.githubusercontent.com/203261/187810267-a6227c38-38d4-4869-bf0c-73d28dc3f930.png">
<img width="1220" alt="Screen Shot 2022-09-01 at 08 56 24" src="https://user-images.githubusercontent.com/203261/187810331-c39a65b6-b4ef-44ed-829d-e80a37ca3c37.png">
<img width="1191" alt="Screen Shot 2022-09-01 at 08 56 43" src="https://user-images.githubusercontent.com/203261/187810365-7e8c7f86-9e59-46e0-b070-b758f8fc6ee9.png">
<img width="1226" alt="Screen Shot 2022-09-01 at 08 57 05" src="https://user-images.githubusercontent.com/203261/187810392-ff82c77e-7ea1-482f-8312-ad129a611ac9.png">
<img width="1211" alt="Screen Shot 2022-09-01 at 08 57 23" src="https://user-images.githubusercontent.com/203261/187810413-71745bb9-de3b-4ba6-8012-cab736bf8f24.png">
<img width="1201" alt="Screen Shot 2022-09-01 at 08 57 46" src="https://user-images.githubusercontent.com/203261/187810471-17ca89cb-d560-467e-9ee9-d092afc2e20b.png">


**Test plan**

- `rizin /bin/ls`
- `aaa`
- `Vv` (navigate to some non-trivial function
- Press `p` and/or `P` to loop between modes

Closes https://github.com/rizinorg/rizin/issues/2979