### PR TITLE
Remove rz_str_mb_to_wc_l()

### DIFF
--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -197,7 +197,6 @@ RZ_API void rz_str_filter(char *str);
 RZ_API const char *rz_str_tok(const char *str1, const char b, size_t len);
 RZ_API wchar_t *rz_str_mb_to_wc(const char *buf);
 RZ_API char *rz_str_wc_to_mb(const wchar_t *buf);
-RZ_API wchar_t *rz_str_mb_to_wc_l(const char *buf, int len);
 RZ_API char *rz_str_wc_to_mb_l(const wchar_t *buf, int len);
 RZ_API const char *rz_str_str_xy(const char *s, const char *word, const char *prev, int *x, int *y);
 

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -3719,15 +3719,15 @@ RZ_API char *rz_str_highlight(char *str, const char *word, const char *color, co
 	return strdup(o);
 }
 
-RZ_API wchar_t *rz_str_mb_to_wc_l(const char *buf, int len) {
+RZ_API wchar_t *rz_str_mb_to_wc(const char *buf) {
 	wchar_t *res_buf = NULL;
 	size_t sz;
 	bool fail = true;
 
-	if (!buf || len <= 0) {
+	if (!buf) {
 		return NULL;
 	}
-	sz = mbstowcs(NULL, buf, len);
+	sz = mbstowcs(NULL, buf, 0);
 	if (sz == (size_t)-1) {
 		goto err_r_str_mb_to_wc;
 	}
@@ -3779,13 +3779,6 @@ RZ_API char *rz_str_wc_to_mb(const wchar_t *buf) {
 		return NULL;
 	}
 	return rz_str_wc_to_mb_l(buf, wcslen(buf));
-}
-
-RZ_API wchar_t *rz_str_mb_to_wc(const char *buf) {
-	if (!buf) {
-		return NULL;
-	}
-	return rz_str_mb_to_wc_l(buf, strlen(buf));
 }
 
 RZ_API char *rz_str_from_ut64(ut64 val) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr removes `rz_str_mb_to_wc_l()` since it uses `mbstowcs()` in an unsupported manner -- `len` there is actually ignored. From [man mbstowcs](https://linux.die.net/man/3/mbstowcs):

"If _dest_ is NULL, _n_ is ignored, and the conversion proceeds as above, except that the converted wide characters are not written out to memory, and that no length limit exists."

Apparently there's no replacement glibc function that can be used but `rz_str_mb_to_wc_l()` isn't used anywhere in Rizin. This is a cherry-pick from #2997. The use of 0 for the last mbstowcs parameter fixes https://github.com/rizinorg/rizin/pull/2874#issuecomment-1206506805.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
