### PR TITLE
Remove multibyte conversion functions

### DIFF
--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -195,9 +195,6 @@ RZ_API char *rz_str_dup(char *ptr, const char *string);
 RZ_API int rz_str_delta(char *p, char a, char b);
 RZ_API void rz_str_filter(char *str);
 RZ_API const char *rz_str_tok(const char *str1, const char b, size_t len);
-RZ_API wchar_t *rz_str_mb_to_wc(const char *buf);
-RZ_API char *rz_str_wc_to_mb(const wchar_t *buf);
-RZ_API char *rz_str_wc_to_mb_l(const wchar_t *buf, int len);
 RZ_API const char *rz_str_str_xy(const char *s, const char *word, const char *prev, int *x, int *y);
 
 typedef void (*str_operation)(char *c);

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -3719,68 +3719,6 @@ RZ_API char *rz_str_highlight(char *str, const char *word, const char *color, co
 	return strdup(o);
 }
 
-RZ_API wchar_t *rz_str_mb_to_wc(const char *buf) {
-	wchar_t *res_buf = NULL;
-	size_t sz;
-	bool fail = true;
-
-	if (!buf) {
-		return NULL;
-	}
-	sz = mbstowcs(NULL, buf, 0);
-	if (sz == (size_t)-1) {
-		goto err_r_str_mb_to_wc;
-	}
-	res_buf = (wchar_t *)calloc(1, (sz + 1) * sizeof(wchar_t));
-	if (!res_buf) {
-		goto err_r_str_mb_to_wc;
-	}
-	sz = mbstowcs(res_buf, buf, sz + 1);
-	if (sz == (size_t)-1) {
-		goto err_r_str_mb_to_wc;
-	}
-	fail = false;
-err_r_str_mb_to_wc:
-	if (fail) {
-		RZ_FREE(res_buf);
-	}
-	return res_buf;
-}
-
-RZ_API char *rz_str_wc_to_mb_l(const wchar_t *buf, int len) {
-	char *res_buf = NULL;
-	mbstate_t mbstate = { 0 };
-	size_t sz;
-
-	if (!buf || len <= 0) {
-		return NULL;
-	}
-	sz = wcsrtombs(NULL, &buf, 0, &mbstate);
-	if (sz == (size_t)-1) {
-		goto err_r_str_wc_to_mb;
-	}
-	res_buf = RZ_NEWS0(char, sz + 1);
-	if (!res_buf) {
-		goto err_r_str_wc_to_mb;
-	}
-	sz = wcsrtombs(res_buf, &buf, sz + 1, &mbstate);
-	if (sz == (size_t)-1) {
-		goto err_r_str_wc_to_mb;
-	}
-	return res_buf;
-
-err_r_str_wc_to_mb:
-	free(res_buf);
-	return NULL;
-}
-
-RZ_API char *rz_str_wc_to_mb(const wchar_t *buf) {
-	if (!buf) {
-		return NULL;
-	}
-	return rz_str_wc_to_mb_l(buf, wcslen(buf));
-}
-
 RZ_API char *rz_str_from_ut64(ut64 val) {
 	int i = 0;
 	char *v = (char *)&val;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr removes the Rizin multibyte conversion functions. They are unused, untested, the `len` parameter of `rz_str_wc_to_mb_l()` isn't used, and a specialized library like [libiconv](https://www.gnu.org/software/libiconv/) or [ICU](https://icu.unicode.org/) provides more control over the source and destination encodings.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
