### PR TITLE
Fix gcc12 rz_cons_visual_write -Wstringop-overread warnings

### DIFF
--- a/librz/cons/cons.c
+++ b/librz/cons/cons.c
@@ -1102,7 +1102,6 @@ static int real_strlen(const char *ptr, int len) {
 
 RZ_API void rz_cons_visual_write(char *buffer) {
 	char white[1024];
-	int cols = I.columns;
 	int alen, plen, lines = I.rows;
 	bool break_lines = I.break_lines;
 	const char *endptr;
@@ -1111,6 +1110,9 @@ RZ_API void rz_cons_visual_write(char *buffer) {
 	if (I.null) {
 		return;
 	}
+	rz_return_if_fail(I.columns > 0); // modulo by 0 is UB
+	unsigned int cols = I.columns;
+
 	memset(&white, ' ', sizeof(white));
 	while ((nl = strchr(ptr, '\n'))) {
 		int len = ((int)(size_t)(nl - ptr)) + 1;
@@ -1140,7 +1142,7 @@ RZ_API void rz_cons_visual_write(char *buffer) {
 			}
 		} else {
 			if (lines > 0) {
-				int w = cols - (alen % cols == 0 ? cols : alen % cols);
+				unsigned int w = cols - (alen % cols == 0 ? cols : alen % cols);
 				__cons_write(pptr, plen);
 				if (I.blankline && w > 0) {
 					if (w > sizeof(white) - 1) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes gcc12 warnings of the following form (https://github.com/rizinorg/rizin/runs/8136832166?check_suite_focus=true#step:9:1212):

![rz_cons_visual_write-stringop-overread](https://user-images.githubusercontent.com/12002672/188269623-915600a5-3cd1-4d70-bf96-4c3c1f49701f.PNG)

This is a cherry-pick from #2997.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
