### PR TITLE
Fixes #2976: Add comment at cursor location in visual mode

### DIFF
--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -3127,7 +3127,8 @@ RZ_IPI int rz_core_visual_cmd(RzCore *core, const char *arg) {
 			break;
 		case ';':
 			rz_cons_gotoxy(0, 0);
-			add_comment(core, core->offset, "Enter a comment: ('-' to remove, '!' to use cfg.editor)\n");
+			ut64 addr = core->print->cur_enabled ? core->offset + core->print->cur : core->offset;
+			add_comment(core, addr, "Enter a comment: ('-' to remove, '!' to use cfg.editor)\n");
 			break;
 		case 'b':
 			rz_core_visual_browse(core, arg + 1);


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This fixes https://github.com/rizinorg/rizin/issues/2976 by adding the cursor offset to the core offset when cursor mode is enabled.
I'm unsure how to test this with automated tests. Are there any examples of tests of similar features?

**Test plan**
1. rizin -w any_file
2. VP
3. c
4. navigate somewhere different than the screen page offset
5. press ; and enter a comment
6. observe it adds it at the location of the cursor and _not_ at the top of the page

**Closing issues**
closes #2976 