### PR TITLE
Fix gcc12 rzgdb -Wuse-after-free warning

### DIFF
--- a/subprojects/rzgdb/src/gdbclient/xml.c
+++ b/subprojects/rzgdb/src/gdbclient/xml.c
@@ -80,12 +80,13 @@ static char *gdbr_read_feature(libgdbr_t *g, const char *file, ut64 *tot_len) {
 				continue;
 			}
 			if (subret_len > retmax - retlen - 1) {
+				ptrdiff_t tagoff = tmp - ret;
 				tmp3 = NULL;
 				if (!(tmp3 = realloc(ret, retmax + subret_len))) {
 					free(subret);
 					goto exit_err;
 				}
-				tmp = tmp3 + (tmp - ret);
+				tmp = tmp3 + tagoff;
 				ret = tmp3;
 				retmax += subret_len + 1;
 			}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following gcc12 warning (https://github.com/rizinorg/rizin/runs/8169129845?check_suite_focus=true#step:9:1240):

![rzgdb-use-after-free](https://user-images.githubusercontent.com/12002672/188297423-db6711f3-87a1-4cc6-84db-38dffa441315.PNG)

This is a cherry-pick from #2997.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
