### PR TITLE
Fix #2993 - Check rz_buf_read_le32_offset return status parsing LE bins

### DIFF
--- a/librz/bin/format/le/le.c
+++ b/librz/bin/format/le/le.c
@@ -825,12 +825,15 @@ rz_bin_le_obj_t *rz_bin_le_new_buf(RzBuffer *buf) {
 	offset = (ut64)bin->headerOff + h->objtab;
 	for (ut32 i = 0; i < h->objcnt; i++) {
 		LE_object_entry *le_obj_entry = bin->objtbl + i;
-		rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->virtual_size);
-		rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->reloc_base_addr);
-		rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->flags);
-		rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->page_tbl_idx);
-		rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->page_tbl_entries);
-		rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->reserved);
+		if (!rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->virtual_size) ||
+			!rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->reloc_base_addr) ||
+			!rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->flags) ||
+			!rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->page_tbl_idx) ||
+			!rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->page_tbl_entries) ||
+			!rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->reserved)) {
+			rz_bin_le_free(bin);
+			return NULL;
+		}
 	}
 	bin->buf = buf;
 	return bin;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Checks the return value of the rz_buf_read_le32_offset when parsing LE binaries

Fix #2993