### PR TITLE
Remove global variables from Visual mode

### DIFF
--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -271,6 +271,12 @@ typedef struct rz_core_visual_t {
 	int printMode;
 	int color;
 	int debug;
+	/* Insert mode */
+	bool insertMode;
+	int insertNibble;
+	/* Split view */
+	bool splitView;
+	ut64 splitPtr;
 	/* Output formats */
 	int currentFormat;
 	int current0format;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Remove global state from the main visual mode (`V`).

**Test plan**

1. CI is green
2. All visual modes work as before.

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/1874
