### PR TITLE
Convert some of the `a` commands to the rzshell

### DIFF
--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -2026,9 +2026,6 @@ RZ_IPI int rz_cmd_analysis(void *data, const char *input) {
 	ut32 tbs = core->blocksize;
 	switch (input[0]) {
 	case 'e': cmd_analysis_esil(core, input + 1); break; // "ae"
-	case 'F': // "aF"
-		rz_core_analysis_fcn(core, core->offset, UT64_MAX, RZ_ANALYSIS_XREF_TYPE_NULL, 1);
-		break;
 	case '*': // "a*"
 		rz_core_cmd0_rzshell(core, "afl*");
 		rz_core_cmd0_rzshell(core, "ah*");
@@ -4431,6 +4428,11 @@ RZ_IPI RzCmdStatus rz_analysis_function_describe_offset_handler(RzCore *core, in
 		}
 	}
 	rz_list_free(list);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_analysis_function_add_nodepth_handler(RzCore *core, int argc, const char **argv) {
+	rz_core_analysis_fcn(core, core->offset, UT64_MAX, RZ_ANALYSIS_XREF_TYPE_NULL, 1);
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -2132,33 +2132,6 @@ RZ_IPI int rz_cmd_analysis(void *data, const char *input) {
 	RzCore *core = (RzCore *)data;
 	ut32 tbs = core->blocksize;
 	switch (input[0]) {
-	case 'p': // "ap"
-	{
-		const ut8 *prelude = (const ut8 *)"\xe9\x2d"; //: fffff000";
-		const int prelude_sz = 2;
-		const int bufsz = 4096;
-		ut8 *buf = calloc(1, bufsz);
-		ut64 off = core->offset;
-		if (input[1] == ' ') {
-			off = rz_num_math(core->num, input + 1);
-			rz_io_read_at(core->io, off - bufsz + prelude_sz, buf, bufsz);
-		} else {
-			rz_io_read_at(core->io, off - bufsz + prelude_sz, buf, bufsz);
-		}
-		// const char *prelude = "\x2d\xe9\xf0\x47"; //:fffff000";
-		rz_mem_reverse(buf, bufsz);
-		// rz_print_hexdump (NULL, off, buf, bufsz, 16, -16);
-		const ut8 *pos = rz_mem_mem(buf, bufsz, prelude, prelude_sz);
-		if (pos) {
-			int delta = (size_t)(pos - buf);
-			RZ_LOG_DEBUG("core: POS = %d\n", delta);
-			RZ_LOG_DEBUG("core: HIT = 0x%" PFMT64x "\n", off - delta);
-			rz_cons_printf("0x%08" PFMT64x "\n", off - delta);
-		} else {
-			RZ_LOG_ERROR("core: Cannot find prelude\n");
-		}
-		free(buf);
-	} break;
 	case 'e': cmd_analysis_esil(core, input + 1); break; // "ae"
 	case 'F': // "aF"
 		rz_core_analysis_fcn(core, core->offset, UT64_MAX, RZ_ANALYSIS_XREF_TYPE_NULL, 1);

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -38,18 +38,6 @@ static const char *help_msg_a[] = {
 	NULL
 };
 
-static const char *help_msg_ad[] = {
-	"Usage:", "ad", "[kt] [...]",
-	"ad", " [N] [D]", "analyze N data words at D depth",
-	"ad4", " [N] [D]", "analyze N data words at D depth (asm.bits=32)",
-	"ad8", " [N] [D]", "analyze N data words at D depth (asm.bits=64)",
-	"adf", "", "analyze data in function (use like .adf @@=`afl~[0]`",
-	"adfg", "", "analyze data in function gaps",
-	"adt", "", "analyze data trampolines (wip)",
-	"adk", "", "analyze data kind (code, text, data, invalid, ...)",
-	NULL
-};
-
 static const char *help_msg_ae[] = {
 	"Usage:", "ae[idesr?] [arg]", "ESIL code emulation",
 	"ae", " [expr]", "evaluate ESIL expression",
@@ -372,41 +360,17 @@ static bool core_analysis_name_print(RzCore *core, RzCmdStateOutput *state) {
 	return true;
 }
 
-static void print_trampolines(RzCore *core, ut64 a, ut64 b, size_t element_size) {
-	int i;
-	for (i = 0; i < core->blocksize; i += element_size) {
-		ut32 n;
-		memcpy(&n, core->block + i, sizeof(ut32));
-		if (n >= a && n <= b) {
-			if (element_size == 4) {
-				rz_cons_printf("f trampoline.%x @ 0x%" PFMT64x "\n", n, core->offset + i);
-			} else {
-				rz_cons_printf("f trampoline.%" PFMT32x " @ 0x%" PFMT64x "\n", n, core->offset + i);
-			}
-			rz_cons_printf("Cd %zu @ 0x%" PFMT64x ":%zu\n", element_size, core->offset + i, element_size);
-			// TODO: add data xrefs
+static void print_trampolines(RzCore *core, ut64 minimum, ut64 maximum,
+	size_t element_size) {
+	bool big_endian = rz_config_get_b(core->config, "cfg.big_endian");
+	for (int i = 0; i < core->blocksize; i += element_size) {
+		ut32 n = rz_read_ble32(core->block + i, big_endian);
+		if (n < minimum || n > maximum) {
+			continue;
 		}
-	}
-}
-
-static void cmd_analysis_trampoline(RzCore *core, const char *input) {
-	int bits = rz_config_get_i(core->config, "asm.bits");
-	char *p, *inp = strdup(input);
-	p = strchr(inp, ' ');
-	if (p) {
-		*p = 0;
-	}
-	ut64 a = rz_num_math(core->num, inp);
-	ut64 b = p ? rz_num_math(core->num, p + 1) : 0;
-	free(inp);
-
-	switch (bits) {
-	case 32:
-		print_trampolines(core, a, b, 4);
-		break;
-	case 64:
-		print_trampolines(core, a, b, 8);
-		break;
+		rz_cons_printf("f trampoline.%" PFMT32x " @ 0x%" PFMT64x "\n", n, core->offset + i);
+		rz_cons_printf("Cd %zu @ 0x%" PFMT64x ":%zu\n", element_size, core->offset + i, element_size);
+		// TODO: add data xrefs
 	}
 }
 
@@ -1946,76 +1910,6 @@ static inline RzFlagItem *core_flag_get_at_as_ref_type(RzCore *core, RzAnalysisX
 	}
 }
 
-#define var_ref_list(a, d, t) sdb_fmt("var.0x%" PFMT64x ".%d.%d.%s", \
-	a, 1, d, (t == 'R') ? "reads" : "writes");
-
-static bool analysis_fcn_data(RzCore *core, const char *input) {
-	RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(core->analysis, core->offset, RZ_ANALYSIS_FCN_TYPE_ANY);
-	if (fcn) {
-		int i;
-		bool gap = false;
-		ut64 gap_addr = UT64_MAX;
-		ut32 fcn_size = rz_analysis_function_size_from_entry(fcn);
-		char *bitmap = calloc(1, fcn_size);
-		if (bitmap) {
-			RzAnalysisBlock *b;
-			RzListIter *iter;
-			rz_list_foreach (fcn->bbs, iter, b) {
-				int f = b->addr - fcn->addr;
-				int t = RZ_MIN(f + b->size, fcn_size);
-				if (f >= 0) {
-					while (f < t) {
-						bitmap[f++] = 1;
-					}
-				}
-			}
-		}
-		for (i = 0; i < fcn_size; i++) {
-			ut64 here = fcn->addr + i;
-			if (bitmap && bitmap[i]) {
-				if (gap) {
-					rz_cons_printf("Cd %" PFMT64u " @ 0x%08" PFMT64x "\n", here - gap_addr, gap_addr);
-					gap = false;
-				}
-				gap_addr = UT64_MAX;
-			} else {
-				if (!gap) {
-					gap = true;
-					gap_addr = here;
-				}
-			}
-		}
-		if (gap) {
-			rz_cons_printf("Cd %" PFMT64u " @ 0x%08" PFMT64x "\n", fcn->addr + fcn_size - gap_addr, gap_addr);
-		}
-		free(bitmap);
-		return true;
-	}
-	return false;
-}
-
-static bool analysis_fcn_data_gaps(RzCore *core, const char *input) {
-	ut64 end = UT64_MAX;
-	RzAnalysisFunction *fcn;
-	RzListIter *iter;
-	int i, wordsize = (core->rasm->bits == 64) ? 8 : 4;
-	rz_list_sort(core->analysis->fcns, cmpaddr);
-	rz_list_foreach (core->analysis->fcns, iter, fcn) {
-		if (end != UT64_MAX) {
-			int range = fcn->addr - end;
-			if (range > 0) {
-				for (i = 0; i + wordsize < range; i += wordsize) {
-					rz_cons_printf("Cd %d @ 0x%08" PFMT64x "\n", wordsize, end + i);
-				}
-				rz_cons_printf("Cd %d @ 0x%08" PFMT64x "\n", range - i, end + i);
-				// rz_cons_printf ("Cd %d @ 0x%08"PFMT64x"\n", range, end);
-			}
-		}
-		end = fcn->addr + rz_analysis_function_size_from_entry(fcn);
-	}
-	return true;
-}
-
 RZ_IPI RzCmdStatus rz_analysis_list_vtables_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
 	rz_analysis_list_vtables(core->analysis, mode);
 	return RZ_CMD_STATUS_OK;
@@ -2128,7 +2022,6 @@ RZ_IPI RzCmdStatus rz_analysis_global_variable_retype_handler(RzCore *core, int 
 }
 
 RZ_IPI int rz_cmd_analysis(void *data, const char *input) {
-	const char *r;
 	RzCore *core = (RzCore *)data;
 	ut32 tbs = core->blocksize;
 	switch (input[0]) {
@@ -2140,52 +2033,6 @@ RZ_IPI int rz_cmd_analysis(void *data, const char *input) {
 		rz_core_cmd0_rzshell(core, "afl*");
 		rz_core_cmd0_rzshell(core, "ah*");
 		rz_core_cmd0_rzshell(core, "ax*");
-		break;
-	case 'd': // "ad"
-		switch (input[1]) {
-		case 'f': // "adf"
-			if (input[2] == 'g') {
-				analysis_fcn_data_gaps(core, rz_str_trim_head_ro(input + 1));
-			} else {
-				analysis_fcn_data(core, input + 1);
-			}
-			break;
-		case 't': // "adt"
-			cmd_analysis_trampoline(core, input + 2);
-			break;
-		case ' ': { // "ad"
-			const int default_depth = 1;
-			const char *p;
-			int a, b;
-			a = rz_num_math(core->num, input + 2);
-			p = strchr(input + 2, ' ');
-			b = p ? rz_num_math(core->num, p + 1) : default_depth;
-			if (a < 1) {
-				a = 1;
-			}
-			if (b < 1) {
-				b = 1;
-			}
-			rz_core_analysis_data(core, core->offset, a, b, 0);
-		} break;
-		case 'k': // "adk"
-			r = rz_analysis_data_kind(core->analysis,
-				core->offset, core->block, core->blocksize);
-			rz_cons_println(r);
-			break;
-		case '\0': // "ad"
-			rz_core_analysis_data(core, core->offset, 2 + (core->blocksize / 4), 1, 0);
-			break;
-		case '4': // "ad4"
-			rz_core_analysis_data(core, core->offset, 2 + (core->blocksize / 4), 1, 4);
-			break;
-		case '8': // "ad8"
-			rz_core_analysis_data(core, core->offset, 2 + (core->blocksize / 4), 1, 8);
-			break;
-		default:
-			rz_core_cmd_help(core, help_msg_ad);
-			break;
-		}
 		break;
 	default:
 		rz_core_cmd_help(core, help_msg_a);
@@ -6499,5 +6346,104 @@ RZ_IPI RzCmdStatus rz_global_imports_handler(RzCore *core, int argc, const char 
 
 RZ_IPI RzCmdStatus rz_delete_global_imports_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
 	rz_analysis_purge_imports(core->analysis);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_analysis_data_handler(RzCore *core, int argc, const char **argv) {
+	int count = argc > 1 ? rz_num_math(core->num, argv[1]) : 2 + (core->blocksize / 4);
+	if (count < 1) {
+		RZ_LOG_ERROR("Count could not be negative or zero\n");
+		return RZ_CMD_STATUS_ERROR;
+	}
+	int depth = argc > 2 ? rz_num_math(core->num, argv[2]) : 1;
+	if (depth < 1) {
+		RZ_LOG_ERROR("Depth could not be negative or zero\n");
+		return RZ_CMD_STATUS_ERROR;
+	}
+	int wordsize = argc > 3 ? rz_num_math(core->num, argv[3]) : 0;
+	rz_core_analysis_data(core, core->offset, count, depth, wordsize);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_analysis_data_function_handler(RzCore *core, int argc, const char **argv) {
+	RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(core->analysis, core->offset, RZ_ANALYSIS_FCN_TYPE_ANY);
+	if (!fcn) {
+		RZ_LOG_ERROR("Function not found at the 0x%08" PFMT64x " offset\n", core->offset);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	int i;
+	bool gap = false;
+	ut64 gap_addr = UT64_MAX;
+	ut32 fcn_size = rz_analysis_function_size_from_entry(fcn);
+	char *bitmap = calloc(1, fcn_size);
+	if (bitmap) {
+		RzAnalysisBlock *b;
+		RzListIter *iter;
+		rz_list_foreach (fcn->bbs, iter, b) {
+			int f = b->addr - fcn->addr;
+			int t = RZ_MIN(f + b->size, fcn_size);
+			if (f >= 0) {
+				while (f < t) {
+					bitmap[f++] = 1;
+				}
+			}
+		}
+	}
+	for (i = 0; i < fcn_size; i++) {
+		ut64 here = fcn->addr + i;
+		if (bitmap && bitmap[i]) {
+			if (gap) {
+				rz_cons_printf("Cd %" PFMT64u " @ 0x%08" PFMT64x "\n", here - gap_addr, gap_addr);
+				gap = false;
+			}
+			gap_addr = UT64_MAX;
+		} else {
+			if (!gap) {
+				gap = true;
+				gap_addr = here;
+			}
+		}
+	}
+	if (gap) {
+		rz_cons_printf("Cd %" PFMT64u " @ 0x%08" PFMT64x "\n", fcn->addr + fcn_size - gap_addr, gap_addr);
+	}
+	free(bitmap);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_analysis_data_function_gaps_handler(RzCore *core, int argc, const char **argv) {
+	ut64 end = UT64_MAX;
+	RzAnalysisFunction *fcn;
+	RzListIter *iter;
+	int i, wordsize = core->rasm->bits / 8;
+	rz_list_sort(core->analysis->fcns, cmpaddr);
+	rz_list_foreach (core->analysis->fcns, iter, fcn) {
+		if (end != UT64_MAX) {
+			int range = fcn->addr - end;
+			if (range > 0) {
+				for (i = 0; i + wordsize < range; i += wordsize) {
+					rz_cons_printf("Cd %d @ 0x%08" PFMT64x "\n", wordsize, end + i);
+				}
+				rz_cons_printf("Cd %d @ 0x%08" PFMT64x "\n", range - i, end + i);
+			}
+		}
+		end = fcn->addr + rz_analysis_function_size_from_entry(fcn);
+	}
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_analysis_data_kind_handler(RzCore *core, int argc, const char **argv) {
+	const char *kind = rz_analysis_data_kind(core->analysis,
+		core->offset, core->block, core->blocksize);
+	rz_cons_println(kind);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_analysis_data_trampoline_handler(RzCore *core, int argc, const char **argv) {
+	ut64 minimum = rz_num_math(core->num, argv[1]);
+	ut64 maximum = rz_num_math(core->num, argv[2]);
+
+	int bits = rz_config_get_i(core->config, "asm.bits");
+	print_trampolines(core, minimum, maximum, bits / 8);
 	return RZ_CMD_STATUS_OK;
 }

--- a/librz/core/cmd_descs/cmd_analysis.yaml
+++ b/librz/core/cmd_descs/cmd_analysis.yaml
@@ -813,6 +813,10 @@ commands:
         summary: Show function + delta for given offset
         cname: analysis_function_describe_offset
         args: []
+  - name: aF
+    summary: Analyze function non-recursively
+    cname: analysis_function_add_nodepth
+    args: []
   - name: aeC
     summary: appcall in esil
     cname: analysis_appcall

--- a/librz/core/cmd_descs/cmd_analysis.yaml
+++ b/librz/core/cmd_descs/cmd_analysis.yaml
@@ -170,6 +170,44 @@ commands:
           - RZ_OUTPUT_MODE_STANDARD
           - RZ_OUTPUT_MODE_RIZIN
         args: []
+  - name: ad
+    summary: Analyze data
+    subcommands:
+      - name: ad
+        summary: Analyze <count> data words with <depth>
+        cname: analysis_data
+        args:
+          - name: count
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: depth
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: wordsize
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: adf
+        summary: Analyze data in function
+        cname: analysis_data_function
+        args: []
+      - name: adfg
+        summary: Analyze data in function gaps
+        cname: analysis_data_function_gaps
+        args: []
+      - name: adk
+        summary: Analyze data kind (code, text, data, invalid, etc)
+        cname: analysis_data_kind
+        args: []
+      - name: adt
+        summary: Analyze data trampolines
+        cname: analysis_data_trampoline
+        args:
+          - name: minimum
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            default_value: 0
+          - name: maximum
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            default_value: 0
   - name: af
     summary: Analyze Functions commands
     subcommands:

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -97,6 +97,8 @@ static const RzCmdDescArg analyze_xrefs_section_bytes_args[2];
 static const RzCmdDescArg analyze_function_linked_offsets_args[2];
 static const RzCmdDescArg print_commands_after_traps_args[2];
 static const RzCmdDescArg print_areas_no_functions_args[2];
+static const RzCmdDescArg analysis_data_args[4];
+static const RzCmdDescArg analysis_data_trampoline_args[3];
 static const RzCmdDescArg analysis_function_add_recu_args[2];
 static const RzCmdDescArg analysis_function_add_recu_force_args[2];
 static const RzCmdDescArg analysis_function_create_args[4];
@@ -1601,6 +1603,81 @@ static const RzCmdDescArg analyze_value_to_maps_args[] = {
 static const RzCmdDescHelp analyze_value_to_maps_help = {
 	.summary = "Analyze values referencing a specific section or map",
 	.args = analyze_value_to_maps_args,
+};
+
+static const RzCmdDescHelp ad_help = {
+	.summary = "Analyze data",
+};
+static const RzCmdDescArg analysis_data_args[] = {
+	{
+		.name = "count",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "depth",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "wordsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_data_help = {
+	.summary = "Analyze <count> data words with <depth>",
+	.args = analysis_data_args,
+};
+
+static const RzCmdDescArg analysis_data_function_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_data_function_help = {
+	.summary = "Analyze data in function",
+	.args = analysis_data_function_args,
+};
+
+static const RzCmdDescArg analysis_data_function_gaps_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_data_function_gaps_help = {
+	.summary = "Analyze data in function gaps",
+	.args = analysis_data_function_gaps_args,
+};
+
+static const RzCmdDescArg analysis_data_kind_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_data_kind_help = {
+	.summary = "Analyze data kind (code, text, data, invalid, etc)",
+	.args = analysis_data_kind_args,
+};
+
+static const RzCmdDescArg analysis_data_trampoline_args[] = {
+	{
+		.name = "minimum",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.default_value = "0",
+
+	},
+	{
+		.name = "maximum",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.default_value = "0",
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_data_trampoline_help = {
+	.summary = "Analyze data trampolines",
+	.args = analysis_data_trampoline_args,
 };
 
 static const RzCmdDescHelp af_help = {
@@ -15225,6 +15302,20 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *analyze_value_to_maps_cd = rz_cmd_desc_argv_state_new(core->rcmd, aa_cd, "aav", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN, rz_analyze_value_to_maps_handler, &analyze_value_to_maps_help);
 	rz_warn_if_fail(analyze_value_to_maps_cd);
+
+	RzCmdDesc *ad_cd = rz_cmd_desc_group_new(core->rcmd, cmd_analysis_cd, "ad", rz_analysis_data_handler, &analysis_data_help, &ad_help);
+	rz_warn_if_fail(ad_cd);
+	RzCmdDesc *analysis_data_function_cd = rz_cmd_desc_argv_new(core->rcmd, ad_cd, "adf", rz_analysis_data_function_handler, &analysis_data_function_help);
+	rz_warn_if_fail(analysis_data_function_cd);
+
+	RzCmdDesc *analysis_data_function_gaps_cd = rz_cmd_desc_argv_new(core->rcmd, ad_cd, "adfg", rz_analysis_data_function_gaps_handler, &analysis_data_function_gaps_help);
+	rz_warn_if_fail(analysis_data_function_gaps_cd);
+
+	RzCmdDesc *analysis_data_kind_cd = rz_cmd_desc_argv_new(core->rcmd, ad_cd, "adk", rz_analysis_data_kind_handler, &analysis_data_kind_help);
+	rz_warn_if_fail(analysis_data_kind_cd);
+
+	RzCmdDesc *analysis_data_trampoline_cd = rz_cmd_desc_argv_new(core->rcmd, ad_cd, "adt", rz_analysis_data_trampoline_handler, &analysis_data_trampoline_help);
+	rz_warn_if_fail(analysis_data_trampoline_cd);
 
 	RzCmdDesc *af_cd = rz_cmd_desc_group_new(core->rcmd, cmd_analysis_cd, "af", rz_analysis_function_add_recu_handler, &analysis_function_add_recu_help, &af_help);
 	rz_warn_if_fail(af_cd);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -2719,6 +2719,14 @@ static const RzCmdDescHelp analysis_function_describe_offset_help = {
 	.args = analysis_function_describe_offset_args,
 };
 
+static const RzCmdDescArg analysis_function_add_nodepth_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_function_add_nodepth_help = {
+	.summary = "Analyze function non-recursively",
+	.args = analysis_function_add_nodepth_args,
+};
+
 static const RzCmdDescDetailEntry analysis_appcall_Examples_detail_entries[] = {
 	{ .text = "aeC", .arg_str = " 1 2 @ sym._add", .comment = "Call sym._add(1,2)" },
 	{ 0 },
@@ -15527,6 +15535,9 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *analysis_function_describe_offset_cd = rz_cmd_desc_argv_new(core->rcmd, af_cd, "afd", rz_analysis_function_describe_offset_handler, &analysis_function_describe_offset_help);
 	rz_warn_if_fail(analysis_function_describe_offset_cd);
+
+	RzCmdDesc *analysis_function_add_nodepth_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_analysis_cd, "aF", rz_analysis_function_add_nodepth_handler, &analysis_function_add_nodepth_help);
+	rz_warn_if_fail(analysis_function_add_nodepth_cd);
 
 	RzCmdDesc *analysis_appcall_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_analysis_cd, "aeC", rz_analysis_appcall_handler, &analysis_appcall_help);
 	rz_warn_if_fail(analysis_appcall_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -79,6 +79,11 @@ RZ_IPI RzCmdStatus rz_analyze_function_linked_offsets_handler(RzCore *core, int 
 RZ_IPI RzCmdStatus rz_print_commands_after_traps_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_print_areas_no_functions_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_analyze_value_to_maps_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+RZ_IPI RzCmdStatus rz_analysis_data_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_analysis_data_function_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_analysis_data_function_gaps_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_analysis_data_kind_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_analysis_data_trampoline_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_analysis_function_add_recu_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_analysis_function_create_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_analysis_function_del_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -157,6 +157,7 @@ RZ_IPI RzCmdStatus rz_analysis_function_cc_list_handler(RzCore *core, int argc, 
 RZ_IPI RzCmdStatus rz_analysis_function_cc_load_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_analysis_function_cc_reg_usage_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_analysis_function_describe_offset_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_analysis_function_add_nodepth_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_analysis_appcall_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_analysis_continue_until_except_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_analysis_continue_until_breakpoint_handler(RzCore *core, int argc, const char **argv);

--- a/test/db/analysis/msp430
+++ b/test/db/analysis/msp430
@@ -1,8 +1,8 @@
-NAME=aFr on ELF
+NAME=aF on ELF
 FILE=bins/elf/msp430.elf
 CMDS=<<EOF
 s main
-aFr
+aF
 pif
 afi
 EOF
@@ -54,12 +54,12 @@ diff: type: new
 EOF
 RUN
 
-NAME=aFr on same but ihex and .rz script
+NAME=aF on same but ihex and .rz script
 FILE=ihex://bins/microcorruption/tutorial
 CMDS=<<EOF
 . bins/microcorruption/tutorial.rz
 s main
-aFr
+aF
 pif
 afi
 EOF

--- a/test/db/cmd/cmd_ad
+++ b/test/db/cmd/cmd_ad
@@ -1,0 +1,27 @@
+NAME=ad 4
+FILE=bins/arm/elf/hello_world
+CMDS=<<EOF
+aaa
+s 0x434
+ad 4
+pd 4
+EOF
+EXPECT=<<EOF
+0x00000434  cc0b  number 3020 0xbcc
+0x00000436  0100  pointer  0x00000001
+`- 0x00000001  454c  number 19525 0x4c45
+0x00000438  2000  pointer  0x00000020
+`- 0x00000020  481b  number 6984 0x1b48
+0x0000043a  0000  (null)
+            ; STRING XREFS from entry0 @ 0x40c, 0x410
+            ;-- data.00000434:
+            0x00000434      lsrs  r4, r1, 0xf
+            0x00000436      movs  r1, r0
+            ; DATA XREF from entry0 @ 0x414
+            ;-- data.00000438:
+            0x00000438      .dword 0x00000020
+            ; DATA XREF from entry0 @ 0x420
+            ;-- data.0000043c:
+            0x0000043c      .dword 0x00000030
+EOF
+RUN


### PR DESCRIPTION
# PLEASE DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Removed `ap` command as too specific, incomplete, and untested
- Converted `aF` command to the rzshell
- Converted `ad` commands to the rzshell
- Renamed `ad4` command to the `ad ... 4` and `ad8` to the `ad ... 8` where the last parameter is the word size.

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/1442 (everything except `ae`)
