### PR TITLE
Expose rz_core_prevop_addr* as RZ_API + docs

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -6403,7 +6403,8 @@ RZ_IPI ut64 rz_core_prevop_addr_heuristic(RzCore *core, ut64 addr) {
  *
  * \return if analysis was able to find the previous instruction address
  */
-RZ_API bool rz_core_prevop_addr(RzCore *core, ut64 start_addr, int numinstrs, ut64 *prev_addr) {
+RZ_API bool rz_core_prevop_addr(RzCore *core, ut64 start_addr, int numinstrs, RZ_OUT RZ_BORROW RZ_NONNULL ut64 *prev_addr) {
+	rz_return_val_if_fail(core && prev_addr, false);
 	RzAnalysisBlock *bb;
 	int i;
 	// Check that we're in a bb, otherwise this prevop stuff won't work.
@@ -6428,8 +6429,8 @@ RZ_API bool rz_core_prevop_addr(RzCore *core, ut64 start_addr, int numinstrs, ut
  * no concrete analysis info is available.
  */
 RZ_API ut64 rz_core_prevop_addr_force(RzCore *core, ut64 start_addr, int numinstrs) {
-	int i;
-	for (i = 0; i < numinstrs; i++) {
+	rz_return_val_if_fail(core, UT64_MAX);
+	for (int i = 0; i < numinstrs; i++) {
 		start_addr = rz_core_prevop_addr_heuristic(core, start_addr);
 	}
 	return start_addr;

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -6331,3 +6331,106 @@ RZ_API void rz_core_analysis_calls(RZ_NONNULL RzCore *core, bool imports_only) {
 	rz_cons_break_pop();
 	rz_list_free(ranges);
 }
+
+/**
+ * Try to guess the address of the instruction before addr
+ */
+RZ_IPI ut64 rz_core_prevop_addr_heuristic(RzCore *core, ut64 addr) {
+#define OPDELTA 32
+	ut8 buf[OPDELTA * 2];
+	ut64 target, base;
+	RzAnalysisBlock *bb;
+	RzAnalysisOp op;
+	int len, ret, i;
+	int minop = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE);
+	int maxop = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_MAX_OP_SIZE);
+
+	if (minop == maxop) {
+		if (minop == -1) {
+			return addr - 4;
+		}
+		return addr - minop;
+	}
+
+	// let's see if we can use analysis info to get the previous instruction
+	// TODO: look in the current basicblock, then in the current function
+	// and search in all functions only as a last chance, to try to speed
+	// up the process.
+	bb = rz_analysis_find_most_relevant_block_in(core->analysis, addr - minop);
+	if (bb) {
+		ut64 res = rz_analysis_block_get_op_addr_in(bb, addr - minop);
+		if (res != UT64_MAX) {
+			return res;
+		}
+	}
+	// if we analysis info didn't help then fallback to the dumb solution.
+	int midflags = rz_config_get_i(core->config, "asm.flags.middle");
+	target = addr;
+	base = target > OPDELTA ? target - OPDELTA : 0;
+	rz_io_read_at(core->io, base, buf, sizeof(buf));
+	for (i = 0; i < sizeof(buf); i++) {
+		ret = rz_analysis_op(core->analysis, &op, base + i,
+			buf + i, sizeof(buf) - i, RZ_ANALYSIS_OP_MASK_BASIC);
+		if (ret > 0) {
+			len = op.size;
+			if (len < 1) {
+				len = 1;
+			}
+			rz_analysis_op_fini(&op); // XXX
+			if (midflags >= RZ_MIDFLAGS_REALIGN) {
+				int skip_bytes = rz_core_flag_in_middle(core, base + i, len, &midflags);
+				if (skip_bytes && base + i + skip_bytes < target) {
+					i += skip_bytes - 1;
+					continue;
+				}
+			}
+		} else {
+			len = 1;
+		}
+		if (target <= base + i + len) {
+			return base + i;
+		}
+		i += len - 1;
+	}
+	return target > 4 ? target - 4 : 0;
+}
+
+/**
+ * Search of the numinstrs-th instruction before start_addr.
+ *
+ * Sets prev_addr to the value of the instruction numinstrs back.
+ * If we can't use the analysis, then sets prev_addr to UT64_MAX and returns false
+ *
+ * \return if analysis was able to find the previous instruction address
+ */
+RZ_API bool rz_core_prevop_addr(RzCore *core, ut64 start_addr, int numinstrs, ut64 *prev_addr) {
+	RzAnalysisBlock *bb;
+	int i;
+	// Check that we're in a bb, otherwise this prevop stuff won't work.
+	bb = rz_analysis_find_most_relevant_block_in(core->analysis, start_addr);
+	if (bb) {
+		if (rz_analysis_block_get_op_addr_in(bb, start_addr) != UT64_MAX) {
+			// Do some analysis looping.
+			for (i = 0; i < numinstrs; i++) {
+				*prev_addr = rz_core_prevop_addr_heuristic(core, start_addr);
+				start_addr = *prev_addr;
+			}
+			return true;
+		}
+	}
+	// Dang! not in a bb, return false and fallback to other methods.
+	*prev_addr = UT64_MAX;
+	return false;
+}
+
+/**
+ * Like rz_core_prevop_addr(), but also uses heuristics as fallback if
+ * no concrete analysis info is available.
+ */
+RZ_API ut64 rz_core_prevop_addr_force(RzCore *core, ut64 start_addr, int numinstrs) {
+	int i;
+	for (i = 0; i < numinstrs; i++) {
+		start_addr = rz_core_prevop_addr_heuristic(core, start_addr);
+	}
+	return start_addr;
+}

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -47,6 +47,7 @@ RZ_IPI void rz_core_analysis_function_until(RzCore *core, ut64 addr_end);
 RZ_IPI void rz_core_analysis_value_pointers(RzCore *core, RzOutputMode mode);
 RZ_IPI void rz_core_analysis_cc_print(RzCore *core, RZ_NONNULL const char *cc, RZ_NULLABLE PJ *pj);
 RZ_IPI void rz_core_analysis_resolve_pointers_to_data(RzCore *core);
+RZ_IPI ut64 rz_core_prevop_addr_heuristic(RzCore *core, ut64 addr);
 
 /* cmeta.c */
 RZ_IPI void rz_core_spaces_print(RzCore *core, RzSpaces *spaces, RzCmdStateOutput *state);

--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -1076,10 +1076,15 @@ static ut64 prevop_addr(RzCore *core, ut64 addr) {
 	return target > 4 ? target - 4 : 0;
 }
 
-//  Returns true if we can use analysis to find the previous operation address,
-//  sets prev_addr to the value of the instruction numinstrs back.
-//  If we can't use the analysis, then set prev_addr to UT64_MAX and return false;
-RZ_IPI bool rz_core_prevop_addr(RzCore *core, ut64 start_addr, int numinstrs, ut64 *prev_addr) {
+/**
+ * Search of the numinstrs-th instruction before start_addr.
+ *
+ * Sets prev_addr to the value of the instruction numinstrs back.
+ * If we can't use the analysis, then sets prev_addr to UT64_MAX and returns false
+ *
+ * \return if analysis was able to find the previous instruction address
+ */
+RZ_API bool rz_core_prevop_addr(RzCore *core, ut64 start_addr, int numinstrs, ut64 *prev_addr) {
 	RzAnalysisBlock *bb;
 	int i;
 	// Check that we're in a bb, otherwise this prevop stuff won't work.
@@ -1099,9 +1104,11 @@ RZ_IPI bool rz_core_prevop_addr(RzCore *core, ut64 start_addr, int numinstrs, ut
 	return false;
 }
 
-//  Like rz_core_prevop_addr(), but also uses fallback from prevop_addr() if
-//  no analysis info is available.
-RZ_IPI ut64 rz_core_prevop_addr_force(RzCore *core, ut64 start_addr, int numinstrs) {
+/**
+ * Like rz_core_prevop_addr(), but also uses heuristics as fallback if
+ * no concrete analysis info is available.
+ */
+RZ_API ut64 rz_core_prevop_addr_force(RzCore *core, ut64 start_addr, int numinstrs) {
 	int i;
 	for (i = 0; i < numinstrs; i++) {
 		start_addr = prevop_addr(core, start_addr);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -484,7 +484,7 @@ RZ_API RzLineNSCompletionResult *rz_core_autocomplete_rzshell(RzCore *core, RzLi
 RZ_IPI void rz_core_print_scrollbar(RzCore *core);
 RZ_IPI void rz_core_print_scrollbar_bottom(RzCore *core);
 RZ_API void rz_core_help_vars_print(RzCore *core);
-RZ_API bool rz_core_prevop_addr(RzCore *core, ut64 start_addr, int numinstrs, ut64 *prev_addr);
+RZ_API bool rz_core_prevop_addr(RzCore *core, ut64 start_addr, int numinstrs, RZ_OUT RZ_BORROW RZ_NONNULL ut64 *prev_addr);
 RZ_API ut64 rz_core_prevop_addr_force(RzCore *core, ut64 start_addr, int numinstrs);
 RZ_API RzBinReloc *rz_core_getreloc(RzCore *core, ut64 addr, int size);
 RZ_API RzBinReloc *rz_core_get_reloc_to(RzCore *core, ut64 addr);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -484,8 +484,8 @@ RZ_API RzLineNSCompletionResult *rz_core_autocomplete_rzshell(RzCore *core, RzLi
 RZ_IPI void rz_core_print_scrollbar(RzCore *core);
 RZ_IPI void rz_core_print_scrollbar_bottom(RzCore *core);
 RZ_API void rz_core_help_vars_print(RzCore *core);
-RZ_IPI bool rz_core_prevop_addr(RzCore *core, ut64 start_addr, int numinstrs, ut64 *prev_addr);
-RZ_IPI ut64 rz_core_prevop_addr_force(RzCore *core, ut64 start_addr, int numinstrs);
+RZ_API bool rz_core_prevop_addr(RzCore *core, ut64 start_addr, int numinstrs, ut64 *prev_addr);
+RZ_API ut64 rz_core_prevop_addr_force(RzCore *core, ut64 start_addr, int numinstrs);
 RZ_API RzBinReloc *rz_core_getreloc(RzCore *core, ut64 addr, int size);
 RZ_API RzBinReloc *rz_core_get_reloc_to(RzCore *core, ut64 addr);
 RZ_API ut64 rz_core_get_asmqjmps(RzCore *core, const char *str);


### PR DESCRIPTION


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This was sort of a regression from
59b38e6efaf00b9b9869e0ec5baba4f1b9605f37, where it was switched to RZ_IPI in the header to be consistent with the source. However we need RZ_API because it is used at least in Cutter.

**Test plan**

Build cutter dev against this. This should not happen:
```
Undefined symbols for architecture arm64:
  "_rz_core_prevop_addr", referenced from:
      XrefsDialog::updatePreview(unsigned long long)::$_2::operator()(rz_core_t*) const in XrefsDialog.cpp.o
  "_rz_core_prevop_addr_force", referenced from:
      CutterCore::prevOpAddr(unsigned long long, int) in Cutter.cpp.o
      XrefsDialog::updatePreview(unsigned long long)::$_2::operator()(rz_core_t*) const in XrefsDialog.cpp.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```