### PR TITLE
Fix android binaries and missing main callbacks

### DIFF
--- a/binrz/blob/main.c
+++ b/binrz/blob/main.c
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 deroad <wargio@libero.it>
 // SPDX-FileCopyrightText: 2012-2021 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
@@ -6,13 +7,13 @@
 
 int MAIN_NAME(int argc, const ARGV_TYPE **argv) {
 	char **utf8_argv = ARGV_TYPE_TO_UTF8(argc, argv);
-	int rc = 1;
 	const char *prog_name = rz_file_basename(utf8_argv[0]);
-	RzMain *m = rz_main_new(prog_name);
-	if (m) {
-		rc = rz_main_run(m, argc, (const char **)utf8_argv);
-		rz_main_free(m);
+	RzMainCallback main_cb = rz_main_find(prog_name);
+	if (!main_cb) {
+		RZ_LOG_ERROR("rizin: Cannot find main for '%s'. using rizin instead\n", prog_name);
+		main_cb = rz_main_rizin;
 	}
+	int rc = main_cb(argc, (const char **)utf8_argv);
 	FREE_UTF8_ARGV(argc, utf8_argv);
 	return rc;
 }

--- a/binrz/blob/meson_install_links.sh
+++ b/binrz/blob/meson_install_links.sh
@@ -7,7 +7,7 @@ set -e
 mkdir -p "${DESTDIR}/${MESON_INSTALL_PREFIX}/bin"
 cd "${DESTDIR}/${MESON_INSTALL_PREFIX}/bin"
 
-TOOLS="rz-hash rz-run rz-asm rz-bin rz-gg rz-agent rz-diff rz-find rassign2 rz-ax"
+TOOLS="rz-hash rz-run rz-asm rz-bin rz-gg rz-agent rz-diff rz-find rz-sign rz-ax"
 
 for TOOL in $TOOLS ; do
     ln -sf rizin $TOOL ;

--- a/librz/include/rz_main.h
+++ b/librz/include/rz_main.h
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 deroad <wargio@libero.it>
 // SPDX-FileCopyrightText: 2008-2020 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
@@ -13,12 +14,6 @@ extern "C" {
 
 RZ_LIB_VERSION_HEADER(rz_main);
 
-typedef struct rz_main_t {
-	const char *name;
-	int (*main)(int argc, const char **argv);
-	// stdin/stdout
-} RzMain;
-
 #if __WINDOWS__
 #define MAIN_NAME                       wmain
 #define ARGV_TYPE                       wchar_t
@@ -33,10 +28,7 @@ typedef struct rz_main_t {
 
 typedef int (*RzMainCallback)(int argc, const char **argv);
 
-RZ_API RzMain *rz_main_new(const char *name);
-RZ_API void rz_main_free(RzMain *m);
-RZ_API int rz_main_run(RzMain *m, int argc, const char **argv);
-
+RZ_API RzMainCallback *rz_main_find(const char *name);
 RZ_API int rz_main_version_print(const char *program);
 RZ_API int rz_main_rz_ax(int argc, const char **argv);
 RZ_API int rz_main_rz_run(int argc, const char **argv);

--- a/librz/include/rz_main.h
+++ b/librz/include/rz_main.h
@@ -28,7 +28,7 @@ RZ_LIB_VERSION_HEADER(rz_main);
 
 typedef int (*RzMainCallback)(int argc, const char **argv);
 
-RZ_API RzMainCallback *rz_main_find(const char *name);
+RZ_API RzMainCallback rz_main_find(const char *name);
 RZ_API int rz_main_version_print(const char *program);
 RZ_API int rz_main_rz_ax(int argc, const char **argv);
 RZ_API int rz_main_rz_run(int argc, const char **argv);

--- a/librz/main/main.c
+++ b/librz/main/main.c
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 deroad <wargio@libero.it>
 // SPDX-FileCopyrightText: 2012-2020 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
@@ -8,42 +9,33 @@
 
 RZ_LIB_VERSION(rz_main);
 
-static RzMain foo[] = {
-	{ "rz", rz_main_rizin },
-	{ "rz-ax", rz_main_rz_ax },
-	{ "rz-diff", rz_main_rz_diff },
-	{ "rz-find", rz_main_rz_find },
-	{ "rz-run", rz_main_rz_run },
-	{ "rz-asm", rz_main_rz_asm },
-	{ "rz-gg", rz_main_rz_gg },
-	{ "rz-bin", rz_main_rz_bin },
+typedef struct rz_main_t {
+	const char *name;
+	RzMainCallback main;
+} MainEntry;
+
+static MainEntry main_prog[] = {
 	{ "rizin", rz_main_rizin },
-	{ NULL, NULL }
+	{ "rz-agent", rz_main_rz_agent },
+	{ "rz-asm", rz_main_rz_asm },
+	{ "rz-ax", rz_main_rz_ax },
+	{ "rz-bin", rz_main_rz_bin },
+	{ "rz-diff", rz_main_rz_diff },
+	{ "rz-find", rz_main_rz_ax },
+	{ "rz-gg", rz_main_rz_gg },
+	{ "rz-hash", rz_main_rz_hash },
+	{ "rz-run", rz_main_rz_run },
+	{ "rz-sign", rz_main_rz_sign },
+	{ "rz", rz_main_rizin },
 };
 
-RZ_API RzMain *rz_main_new(const char *name) {
-	int i = 0;
-	while (foo[i].name) {
-		if (!strcmp(name, foo[i].name)) {
-			RzMain *m = RZ_NEW0(RzMain);
-			if (m) {
-				m->name = strdup(foo[i].name);
-				m->main = foo[i].main;
-			}
-			return m;
+RZ_API RzMainCallback rz_main_find(const char *name) {
+	for (size_t i = 0; i < RZ_ARRAY_SIZE(main_prog); i++) {
+		if (!strcmp(name, main_prog[i].name)) {
+			return main_prog[i].main;
 		}
-		i++;
 	}
 	return NULL;
-}
-
-RZ_API void rz_main_free(RzMain *m) {
-	free(m);
-}
-
-RZ_API int rz_main_run(RzMain *m, int argc, const char **argv) {
-	rz_return_val_if_fail(m && m->main, -1);
-	return m->main(argc, argv);
 }
 
 RZ_API int rz_main_version_print(const char *progname) {

--- a/librz/main/main.c
+++ b/librz/main/main.c
@@ -26,7 +26,6 @@ static MainEntry main_prog[] = {
 	{ "rz-hash", rz_main_rz_hash },
 	{ "rz-run", rz_main_rz_run },
 	{ "rz-sign", rz_main_rz_sign },
-	{ "rz", rz_main_rizin },
 };
 
 RZ_API RzMainCallback rz_main_find(const char *name) {

--- a/librz/main/main.c
+++ b/librz/main/main.c
@@ -9,7 +9,7 @@
 
 RZ_LIB_VERSION(rz_main);
 
-typedef struct rz_main_t {
+typedef struct main_entry_t {
 	const char *name;
 	RzMainCallback main;
 } MainEntry;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The android build seems to call rz_main which tries to find the program name, but the issue is that list is missing some commands and has some old names.