### PR TITLE
Convert `dd` commands to rzshell

### DIFF
--- a/librz/core/cmd/cmd_shell.c
+++ b/librz/core/cmd/cmd_shell.c
@@ -257,3 +257,11 @@ RZ_IPI RzCmdStatus rz_cmd_shell_diff_handler(RzCore *core, int argc, const char 
 	free(b);
 	return RZ_CMD_STATUS_OK;
 }
+
+// date
+RZ_IPI RzCmdStatus rz_cmd_shell_date_handler(RzCore *core, int argc, const char **argv) {
+	char *now = rz_time_date_now_to_string();
+	rz_cons_printf("%s\n", now);
+	free(now);
+	return RZ_CMD_STATUS_OK;
+}

--- a/librz/core/cmd_descs/cmd_debug.yaml
+++ b/librz/core/cmd_descs/cmd_debug.yaml
@@ -312,6 +312,67 @@ commands:
         summary: Debug continue until
         cname: cmd_debug_continue_until
         type: RZ_CMD_DESC_TYPE_OLDINPUT
+  - name: dd
+    summary: Debug file descriptors commands
+    subcommands:
+      - name: dd
+        summary: Open and map <file> given the path
+        cname: cmd_debug_descriptor_open
+        args:
+          - name: file
+            type: RZ_CMD_ARG_TYPE_FILE
+      - name: dd-
+        summary: Close the <fd> file descriptor
+        cname: cmd_debug_descriptor_close
+        args:
+          - name: fd
+            type: RZ_CMD_ARG_TYPE_NUM
+      - name: ddl
+        summary: List all file descriptors
+        cname: cmd_debug_descriptor_list
+        args: []
+        type: RZ_CMD_DESC_TYPE_ARGV_STATE
+        default_mode: RZ_OUTPUT_MODE_STANDARD
+        modes:
+          - RZ_OUTPUT_MODE_STANDARD
+          - RZ_OUTPUT_MODE_JSON
+          - RZ_OUTPUT_MODE_TABLE
+      - name: dds
+        summary: Seek given <fd> to the <offset>
+        cname: cmd_debug_descriptor_seek
+        args:
+          - name: fd
+            type: RZ_CMD_ARG_TYPE_NUM
+          - name: offset
+            type: RZ_CMD_ARG_TYPE_NUM
+      - name: ddd
+        summary: Duplicate <fd_src> to <fd_dst>
+        cname: cmd_debug_descriptor_dup
+        args:
+          - name: fd_src
+            type: RZ_CMD_ARG_TYPE_NUM
+          - name: fd_dst
+            type: RZ_CMD_ARG_TYPE_NUM
+      - name: ddr
+        summary: Read <len> bytes from <fd> file at <offset>
+        cname: cmd_debug_descriptor_read
+        args:
+          - name: fd
+            type: RZ_CMD_ARG_TYPE_NUM
+          - name: offset
+            type: RZ_CMD_ARG_TYPE_NUM
+          - name: len
+            type: RZ_CMD_ARG_TYPE_NUM
+      - name: ddw
+        summary: Write <len> bytes to <fd> file at <offset>
+        cname: cmd_debug_descriptor_write
+        args:
+          - name: fd
+            type: RZ_CMD_ARG_TYPE_NUM
+          - name: offset
+            type: RZ_CMD_ARG_TYPE_NUM
+          - name: len
+            type: RZ_CMD_ARG_TYPE_NUM
   - name: do
     summary: Debug (re)open commands
     subcommands:

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -316,6 +316,12 @@ static const RzCmdDescArg cmd_debug_set_cond_bp_win_args[3];
 static const RzCmdDescArg cmd_debug_continue_execution_args[2];
 static const RzCmdDescArg cmd_debug_continue_send_signal_args[3];
 static const RzCmdDescArg cmd_debug_continue_traptrace_args[2];
+static const RzCmdDescArg cmd_debug_descriptor_open_args[2];
+static const RzCmdDescArg cmd_debug_descriptor_close_args[2];
+static const RzCmdDescArg cmd_debug_descriptor_seek_args[3];
+static const RzCmdDescArg cmd_debug_descriptor_dup_args[3];
+static const RzCmdDescArg cmd_debug_descriptor_read_args[4];
+static const RzCmdDescArg cmd_debug_descriptor_write_args[4];
 static const RzCmdDescArg cmd_debug_process_profile_args[2];
 static const RzCmdDescArg cmd_debug_step_args[2];
 static const RzCmdDescArg cmd_debug_step_back_args[2];
@@ -7036,6 +7042,125 @@ static const RzCmdDescHelp cmd_debug_continue_traptrace_help = {
 
 static const RzCmdDescHelp cmd_debug_continue_until_help = {
 	.summary = "Debug continue until",
+};
+
+static const RzCmdDescHelp dd_help = {
+	.summary = "Debug file descriptors commands",
+};
+static const RzCmdDescArg cmd_debug_descriptor_open_args[] = {
+	{
+		.name = "file",
+		.type = RZ_CMD_ARG_TYPE_FILE,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_debug_descriptor_open_help = {
+	.summary = "Open and map <file> given the path",
+	.args = cmd_debug_descriptor_open_args,
+};
+
+static const RzCmdDescArg cmd_debug_descriptor_close_args[] = {
+	{
+		.name = "fd",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_debug_descriptor_close_help = {
+	.summary = "Close the <fd> file descriptor",
+	.args = cmd_debug_descriptor_close_args,
+};
+
+static const RzCmdDescArg cmd_debug_descriptor_list_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_debug_descriptor_list_help = {
+	.summary = "List all file descriptors",
+	.args = cmd_debug_descriptor_list_args,
+};
+
+static const RzCmdDescArg cmd_debug_descriptor_seek_args[] = {
+	{
+		.name = "fd",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+
+	},
+	{
+		.name = "offset",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_debug_descriptor_seek_help = {
+	.summary = "Seek given <fd> to the <offset>",
+	.args = cmd_debug_descriptor_seek_args,
+};
+
+static const RzCmdDescArg cmd_debug_descriptor_dup_args[] = {
+	{
+		.name = "fd_src",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+
+	},
+	{
+		.name = "fd_dst",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_debug_descriptor_dup_help = {
+	.summary = "Duplicate <fd_src> to <fd_dst>",
+	.args = cmd_debug_descriptor_dup_args,
+};
+
+static const RzCmdDescArg cmd_debug_descriptor_read_args[] = {
+	{
+		.name = "fd",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+
+	},
+	{
+		.name = "offset",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+
+	},
+	{
+		.name = "len",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_debug_descriptor_read_help = {
+	.summary = "Read <len> bytes from <fd> file at <offset>",
+	.args = cmd_debug_descriptor_read_args,
+};
+
+static const RzCmdDescArg cmd_debug_descriptor_write_args[] = {
+	{
+		.name = "fd",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+
+	},
+	{
+		.name = "offset",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+
+	},
+	{
+		.name = "len",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_debug_descriptor_write_help = {
+	.summary = "Write <len> bytes to <fd> file at <offset>",
+	.args = cmd_debug_descriptor_write_args,
 };
 
 static const RzCmdDescHelp do_help = {
@@ -15092,6 +15217,14 @@ static const RzCmdDescHelp shell_help = {
 	.summary = "Common shell commands",
 	.sort_subcommands = true,
 };
+static const RzCmdDescArg cmd_shell_date_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_shell_date_help = {
+	.summary = "Get current date",
+	.args = cmd_shell_date_args,
+};
+
 static const RzCmdDescArg cmd_shell_diff_args[] = {
 	{
 		.name = "A",
@@ -16759,6 +16892,27 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *cmd_debug_continue_until_cd = rz_cmd_desc_oldinput_new(core->rcmd, dc_cd, "dcu", rz_cmd_debug_continue_until, &cmd_debug_continue_until_help);
 	rz_warn_if_fail(cmd_debug_continue_until_cd);
+
+	RzCmdDesc *dd_cd = rz_cmd_desc_group_new(core->rcmd, cmd_debug_cd, "dd", rz_cmd_debug_descriptor_open_handler, &cmd_debug_descriptor_open_help, &dd_help);
+	rz_warn_if_fail(dd_cd);
+	RzCmdDesc *cmd_debug_descriptor_close_cd = rz_cmd_desc_argv_new(core->rcmd, dd_cd, "dd-", rz_cmd_debug_descriptor_close_handler, &cmd_debug_descriptor_close_help);
+	rz_warn_if_fail(cmd_debug_descriptor_close_cd);
+
+	RzCmdDesc *cmd_debug_descriptor_list_cd = rz_cmd_desc_argv_state_new(core->rcmd, dd_cd, "ddl", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_TABLE, rz_cmd_debug_descriptor_list_handler, &cmd_debug_descriptor_list_help);
+	rz_warn_if_fail(cmd_debug_descriptor_list_cd);
+	rz_cmd_desc_set_default_mode(cmd_debug_descriptor_list_cd, RZ_OUTPUT_MODE_STANDARD);
+
+	RzCmdDesc *cmd_debug_descriptor_seek_cd = rz_cmd_desc_argv_new(core->rcmd, dd_cd, "dds", rz_cmd_debug_descriptor_seek_handler, &cmd_debug_descriptor_seek_help);
+	rz_warn_if_fail(cmd_debug_descriptor_seek_cd);
+
+	RzCmdDesc *cmd_debug_descriptor_dup_cd = rz_cmd_desc_argv_new(core->rcmd, dd_cd, "ddd", rz_cmd_debug_descriptor_dup_handler, &cmd_debug_descriptor_dup_help);
+	rz_warn_if_fail(cmd_debug_descriptor_dup_cd);
+
+	RzCmdDesc *cmd_debug_descriptor_read_cd = rz_cmd_desc_argv_new(core->rcmd, dd_cd, "ddr", rz_cmd_debug_descriptor_read_handler, &cmd_debug_descriptor_read_help);
+	rz_warn_if_fail(cmd_debug_descriptor_read_cd);
+
+	RzCmdDesc *cmd_debug_descriptor_write_cd = rz_cmd_desc_argv_new(core->rcmd, dd_cd, "ddw", rz_cmd_debug_descriptor_write_handler, &cmd_debug_descriptor_write_help);
+	rz_warn_if_fail(cmd_debug_descriptor_write_cd);
 
 	RzCmdDesc *do_cd = rz_cmd_desc_group_new(core->rcmd, cmd_debug_cd, "do", NULL, NULL, &do_help);
 	rz_warn_if_fail(do_cd);
@@ -18497,6 +18651,9 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *shell_cd = rz_cmd_desc_group_new(core->rcmd, root_cd, "shell", NULL, NULL, &shell_help);
 	rz_warn_if_fail(shell_cd);
+	RzCmdDesc *cmd_shell_date_cd = rz_cmd_desc_argv_new(core->rcmd, shell_cd, "date", rz_cmd_shell_date_handler, &cmd_shell_date_help);
+	rz_warn_if_fail(cmd_shell_date_cd);
+
 	RzCmdDesc *cmd_shell_diff_cd = rz_cmd_desc_argv_new(core->rcmd, shell_cd, "diff", rz_cmd_shell_diff_handler, &cmd_shell_diff_help);
 	rz_warn_if_fail(cmd_shell_diff_cd);
 

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -476,6 +476,13 @@ RZ_IPI RzCmdStatus rz_cmd_debug_continue_ret_handler(RzCore *core, int argc, con
 RZ_IPI int rz_cmd_debug_continue_syscall(void *data, const char *input);
 RZ_IPI RzCmdStatus rz_cmd_debug_continue_traptrace_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI int rz_cmd_debug_continue_until(void *data, const char *input);
+RZ_IPI RzCmdStatus rz_cmd_debug_descriptor_open_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_descriptor_close_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_descriptor_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+RZ_IPI RzCmdStatus rz_cmd_debug_descriptor_seek_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_descriptor_dup_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_descriptor_read_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_descriptor_write_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_process_profile_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_process_profile_edit_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_process_close_handler(RzCore *core, int argc, const char **argv);
@@ -1052,6 +1059,7 @@ RZ_IPI RzCmdStatus rz_yank_hexpairs_handler(RzCore *core, int argc, const char *
 RZ_IPI RzCmdStatus rz_yank_hex_print_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_yank_paste_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_yank_string_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_shell_date_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_shell_diff_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_shell_exit_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_shell_ls_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_shell.yaml
+++ b/librz/core/cmd_descs/cmd_shell.yaml
@@ -4,6 +4,10 @@
 name: cmd_shell
 type: RZ_CMD_DESC_TYPE_GROUP
 commands:
+  - name: date
+    summary: Get current date
+    cname: cmd_shell_date
+    args: []
   - name: diff
     summary: Compare <A> file with <B>
     cname: cmd_shell_diff

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -138,6 +138,7 @@ RZ_IPI void rz_core_debug_bp_add(RzCore *core, ut64 addr, const char *arg_perm, 
 RZ_IPI void rz_core_debug_ri(RzCore *core);
 RZ_IPI bool rz_core_debug_pid_print(RzDebug *dbg, int pid, RzCmdStateOutput *state);
 RZ_IPI bool rz_core_debug_thread_print(RzDebug *dbg, int pid, RzCmdStateOutput *state);
+RZ_IPI bool rz_core_debug_desc_print(RzDebug *dbg, RzCmdStateOutput *state);
 
 /* cfile.c */
 RZ_IPI RzCoreIOMapInfo *rz_core_io_map_info_new(RzCoreFile *cf, int perm_orig);

--- a/librz/debug/ddesc.c
+++ b/librz/debug/ddesc.c
@@ -67,29 +67,3 @@ RZ_API int rz_debug_desc_write(RzDebug *dbg, int fd, ut64 addr, int len) {
 	}
 	return false;
 }
-
-RZ_API int rz_debug_desc_list(RzDebug *dbg, int rad) {
-	int count = 0;
-	RzList *list;
-	RzListIter *iter;
-	RzDebugDesc *p;
-
-	if (rad) {
-		if (dbg && dbg->cb_printf) {
-			dbg->cb_printf("TODO \n");
-		}
-	} else {
-		if (dbg && dbg->cur && dbg->cur->desc.list) {
-			list = dbg->cur->desc.list(dbg->pid);
-			rz_list_foreach (list, iter, p) {
-				dbg->cb_printf("%i 0x%" PFMT64x " %c%c%c %s\n", p->fd, p->off,
-					(p->perm & RZ_PERM_R) ? 'r' : '-',
-					(p->perm & RZ_PERM_W) ? 'w' : '-',
-					p->type, p->path);
-			}
-			rz_list_purge(list);
-			free(list);
-		}
-	}
-	return count;
-}

--- a/test/db/archos/linux-x64/dbg_fds
+++ b/test/db/archos/linux-x64/dbg_fds
@@ -2,7 +2,7 @@ NAME=dbg.fds.count
 FILE=bins/elf/analysis/elf-nx
 ARGS=-d
 CMDS=<<EOF
-dd~?
+ddl~?
 dk 9
 EOF
 EXPECT=<<EOF
@@ -15,9 +15,9 @@ FILE=bins/elf/analysis/elf-nx
 ARGS=-d
 BROKEN=1
 CMDS=<<EOF
-dd~?
-dd-1
-dd~?
+ddl~?
+dd- 1
+ddl~?
 dk 9
 EOF
 EXPECT=<<EOF
@@ -30,7 +30,7 @@ NAME=dbg.fds.count
 FILE=bins/elf/analysis/elf-nx
 ARGS=-d
 CMDS=<<EOF
-dd~?
+ddl~?
 dk 9
 EOF
 EXPECT=<<EOF


### PR DESCRIPTION

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

* Convert `dd` command to rzshell
* Listing descriptors moved from `dd` to `ddl`
* Added JSON and table modes to `ddl`
* Remove unimplemented `dH` command
* Remove `ddt` command
* Move `date` command to the "shell" category

**Test plan**

- CI is green
- Try `dd` commands
- Try the `date` command

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/1342
