### PR TITLE
Always detach when quitting from -q or -Q

### DIFF
--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -1438,9 +1438,6 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 							rz_cons_yesno('y', "Do you want to kill the process? (Y/n)")) {
 							rz_debug_kill(r->dbg, r->dbg->pid, r->dbg->tid, 9); // KILL
 						}
-						// Even if killed above, we must still detach, otherwise
-						// there will be a zombie on macOS!
-						rz_debug_detach(r->dbg, r->dbg->pid);
 					} else {
 						continue;
 					}
@@ -1489,6 +1486,11 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 	/* capture return value */
 	ret = r->num->value;
 beach:
+	if (!rz_debug_is_dead(r->dbg)) {
+		// Always detach properly if still attached, even if we already killed the process,
+		// otherwise there will be a zombie on macOS!
+		rz_debug_detach(r->dbg, r->dbg->pid);
+	}
 	if (quietLeak) {
 		exit(ret);
 		return ret;

--- a/test/db/archos/darwin-arm64/dbg
+++ b/test/db/archos/darwin-arm64/dbg
@@ -20,6 +20,7 @@ ARGS=-d
 CMDS=<<EOF
 dcu main
 pi 8 @ pc
+dk 9
 EOF
 EXPECT=<<EOF
 sub sp, sp, 0x50

--- a/test/db/archos/darwin-x64/dbg
+++ b/test/db/archos/darwin-x64/dbg
@@ -8,6 +8,7 @@ CMDS=<<EOF
 # just make sure pc is in a map of dyld even after sleeping.
 !sleep 0.5
 dm @ rip~*~[9]
+dk 9
 EOF
 EXPECT=<<EOF
 /usr/lib/dyld
@@ -21,6 +22,7 @@ ARGS=-d
 CMDS=<<EOF
 dcu main
 pi 8 @ rip
+dk 9
 EOF
 EXPECT=<<EOF
 push rbp
@@ -43,6 +45,7 @@ FILE=bins/mach0/hello-objc-osx
 ARGS=-d
 CMDS=<<EOF
 dm~hello
+dk 9
 EOF
 REGEXP_FILTER_OUT=([a-zA-Z0-9_\.-]+\s+)
 EXPECT=<<EOF
@@ -60,6 +63,7 @@ CMDS=<<EOF
 fl@F:maps~hello
 ?e --
 dm*~hello,fss
+dk 9
 EOF
 EXPECT=<<EOF
 0x100000000 4096 hello_objc_osx.r_x

--- a/test/db/archos/linux-x64/dbg_de
+++ b/test/db/archos/linux-x64/dbg_de
@@ -9,6 +9,7 @@ dec
 s rip
 # the call instruction reads rsp, then we should be inside strlen
 pi 1
+dk 9
 EOF
 EXPECT=<<EOF
 jmp qword [reloc.strlen]
@@ -25,6 +26,7 @@ dec
 .drf
 s rip-7
 pi 2
+dk 9
 EOF
 EXPECT=<<EOF
 lea rax, str.Hello

--- a/test/db/archos/linux-x64/dbg_dts
+++ b/test/db/archos/linux-x64/dbg_dts
@@ -10,6 +10,7 @@ dtsf ./
 dr rip
 ds 10
 dr rip
+dk 9
 rm ./session.sdb
 rm ./registers.sdb
 rm ./memory.sdb
@@ -36,6 +37,7 @@ ds
 s
 dsb
 s
+dk 9
 EOF
 EXPECT=<<EOF
 0x40052f

--- a/test/db/archos/linux-x64/dbg_step
+++ b/test/db/archos/linux-x64/dbg_step
@@ -170,6 +170,7 @@ CMDS=<<EOF
 dcu main
 dsu 0x400546
 dr rip
+dk 9
 EOF
 EXPECT=<<EOF
 rip = 0x00400546
@@ -183,6 +184,7 @@ CMDS=<<EOF
 dcu main
 dsui mov eax
 dr rip
+dk 9
 EOF
 EXPECT=<<EOF
 0x00400575 7 call qword [0x600958]
@@ -213,6 +215,7 @@ CMDS=<<EOF
 dcu 0x00400574
 dsi rax=2
 dr rax
+dk 9
 EOF
 EXPECT=<<EOF
 rax = 0x00000002

--- a/test/db/archos/linux-x64/dbg_step_back
+++ b/test/db/archos/linux-x64/dbg_step_back
@@ -76,6 +76,7 @@ dc
 dsb
 dsb
 dr rip
+dk 9
 EOF
 EXPECT=<<EOF
 rip = 0x0040053b


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Previously, on macOS we were detaching properly when the user quit rizin
after an interactive `rz -d <file>` session, but not on
`rz -d -Qc <cmd> <file>`, which would leave behind a zombie process.
Now, the process is detached and keeps running, which also matches the
behavior on Linux. Hence the `dk 9` additions in the tests, to not
spoil the output with whatever the processes print.

Should fix the output in #3057

**Test plan**

* `rz -d -Qc 'dcu main' test/bins/mach0/hello-macos-arm64` should show some "Hello World!" output as the detached process finishes running and `ps -e | grep ' (.\+)'` should not show any zombie process left behind afterwards.
* CI for Linux and Windows is still green