### PR TITLE
Remove `dk 9` from debug tests

### DIFF
--- a/test/db/archos/darwin-arm64/dbg
+++ b/test/db/archos/darwin-arm64/dbg
@@ -20,7 +20,6 @@ ARGS=-d
 CMDS=<<EOF
 dcu main
 pi 8 @ pc
-dk 9
 EOF
 EXPECT=<<EOF
 sub sp, sp, 0x50
@@ -87,7 +86,6 @@ dr x8
 ds
 dr pc
 dr x8
-dk 9
 EOF
 REGEXP_FILTER_OUT=(([a-zA-Z:=-]+|[0-9a-f][0-9a-f][0-9a-f]|x[0-9]+ = [a-z0-9]+)\s+)
 EXPECT=<<EOF
@@ -121,7 +119,6 @@ dr x8
 dc
 dr pc
 dr x8
-dk 9
 EOF
 REGEXP_FILTER_OUT=(([a-zA-Z:=-]+|[0-9a-f][0-9a-f][0-9a-f]|x[0-9]+ = [a-z0-9]+)\s+)
 EXPECT=<<EOF

--- a/test/db/archos/darwin-x64/dbg
+++ b/test/db/archos/darwin-x64/dbg
@@ -8,7 +8,6 @@ CMDS=<<EOF
 # just make sure pc is in a map of dyld even after sleeping.
 !sleep 0.5
 dm @ rip~*~[9]
-dk 9
 EOF
 EXPECT=<<EOF
 /usr/lib/dyld
@@ -22,7 +21,6 @@ ARGS=-d
 CMDS=<<EOF
 dcu main
 pi 8 @ rip
-dk 9
 EOF
 EXPECT=<<EOF
 push rbp
@@ -45,7 +43,6 @@ FILE=bins/mach0/hello-objc-osx
 ARGS=-d
 CMDS=<<EOF
 dm~hello
-dk 9
 EOF
 REGEXP_FILTER_OUT=([a-zA-Z0-9_\.-]+\s+)
 EXPECT=<<EOF
@@ -63,7 +60,6 @@ CMDS=<<EOF
 fl@F:maps~hello
 ?e --
 dm*~hello,fss
-dk 9
 EOF
 EXPECT=<<EOF
 0x100000000 4096 hello_objc_osx.r_x
@@ -88,7 +84,6 @@ dcu main
 dr rip
 dr rdi
 ps @ rdi
-dk 9
 EOF
 EXPECT=<<EOF
 rip = 0x100000f17
@@ -113,7 +108,6 @@ dr rip
 dc
 dr rip
 dr rdi
-dk 9
 EOF
 EXPECT=<<EOF
 rip = 0x100000f0c

--- a/test/db/archos/linux-x64/dbg
+++ b/test/db/archos/linux-x64/dbg
@@ -24,3 +24,18 @@ efbeadde5dc36690
 5589e5cc5dc36690
 EOF
 RUN
+
+NAME=dk 9
+FILE=bins/elf/analysis/calls_x64
+ARGS=-a x86 -d
+CMDS=<<EOF
+dk 9
+dc
+EOF
+EXPECT=<<EOF
+EOF
+REGEXP_FILTER_ERR=child.*signal [0-9]+.*
+EXPECT_ERR=<<EOF
+child received signal 9
+EOF
+RUN

--- a/test/db/archos/linux-x64/dbg_bps
+++ b/test/db/archos/linux-x64/dbg_bps
@@ -12,7 +12,6 @@ dr PC
 ds
 dr PC
 p8 1@ sym.main
-dk 9
 EOF
 EXPECT=<<EOF
 eip = 0x080482d0
@@ -33,7 +32,6 @@ dr PC
 ds
 dr PC
 p8 1@ sym.main
-dk 9
 EOF
 EXPECT=<<EOF
 eip = 0x08048400
@@ -56,7 +54,6 @@ dr PC
 ds
 dr PC
 p8 1@ sym.main
-dk 9
 EOF
 EXPECT=<<EOF
 eip = 0x080482d0
@@ -77,7 +74,6 @@ dr PC
 ds
 dr PC
 p8 1@ sym.main
-dk 9
 EOF
 EXPECT=<<EOF
 eip = 0x08048400
@@ -97,7 +93,6 @@ f+ times @ 5
 db @ 0x4000ce
 dbC .(times_stop) @ 0x4000ce
 dc
-dk 9
 EOF
 EXPECT=<<EOF
 Loop 5
@@ -121,7 +116,6 @@ dbC .(break_rax) @ 0x4000ce
 dc
 dr rax
 dr rip
-dk 9
 EOF
 EXPECT=<<EOF
 rax = 0x000031c0
@@ -140,7 +134,6 @@ e cmd.hitinfo=0
 db @ 0x4000ce
 dbC .(trace_rax) @ 0x4000ce
 dc
-dk 9
 EOF
 EXPECT=<<EOF
 rax = 0x00000000

--- a/test/db/archos/linux-x64/dbg_bps2
+++ b/test/db/archos/linux-x64/dbg_bps2
@@ -11,7 +11,6 @@ dc ; dr PC
 ds ; dr PC
 ds ; dr PC
 ds ; dr PC
-dk 9
 EOF
 EXPECT=<<EOF
 rip = 0x004004ed
@@ -36,7 +35,6 @@ dc ; dr PC
 ds ; dr PC
 ds ; dr PC
 ds ; dr PC
-dk 9
 EOF
 EXPECT=<<EOF
 rip = 0x004004ed

--- a/test/db/archos/linux-x64/dbg_cmdbps
+++ b/test/db/archos/linux-x64/dbg_cmdbps
@@ -7,7 +7,6 @@ db @ entry0
 e cmd.bp="?e cmd.bp ran"
 dbc "?e bpcmd ran" @ `dbl:start~:2`
 dc
-dk 9
 EOF
 EXPECT=<<EOF
 cmd.bp ran

--- a/test/db/archos/linux-x64/dbg_cont
+++ b/test/db/archos/linux-x64/dbg_cont
@@ -7,7 +7,6 @@ dcu entry0
 dr PC
 ds
 dr PC
-dk 9
 EOF
 EXPECT=<<EOF
 eip = 0x080482d0
@@ -24,7 +23,6 @@ dcu entry0
 dr PC
 3ds
 dr PC
-dk 9
 EOF
 EXPECT=<<EOF
 eip = 0x080482d0

--- a/test/db/archos/linux-x64/dbg_cont_back
+++ b/test/db/archos/linux-x64/dbg_cont_back
@@ -10,7 +10,6 @@ dc
 dcb
 dcb
 dr rip
-dk 9
 EOF
 EXPECT=<<EOF
 rip = 0x00400574
@@ -28,7 +27,6 @@ dts+
 dc
 dcb
 dr rip
-dk 9
 EOF
 EXPECT=<<EOF
 rip = 0x00400574
@@ -62,7 +60,6 @@ dr rip
 dsb
 dcb
 dr rip
-dk 9
 EOF
 EXPECT=<<EOF
 rip = 0x0040290d

--- a/test/db/archos/linux-x64/dbg_de
+++ b/test/db/archos/linux-x64/dbg_de
@@ -9,7 +9,6 @@ dec
 s rip
 # the call instruction reads rsp, then we should be inside strlen
 pi 1
-dk 9
 EOF
 EXPECT=<<EOF
 jmp qword [reloc.strlen]
@@ -26,7 +25,6 @@ dec
 .drf
 s rip-7
 pi 2
-dk 9
 EOF
 EXPECT=<<EOF
 lea rax, str.Hello

--- a/test/db/archos/linux-x64/dbg_dmi
+++ b/test/db/archos/linux-x64/dbg_dmi
@@ -4,7 +4,6 @@ ARGS=-d
 CMDS=<<EOF
 dmiqq ld
 dmiqq ld _dl_rtld_di_serinfo
-dk 9
 EOF
 EXPECT=<<EOF
 __get_cpu_features
@@ -49,7 +48,6 @@ FILE=/bin/ls
 ARGS=-d
 CMDS=<<EOF
 dmiaqq ld~la_activity
-dk 9
 EOF
 EXPECT=<<EOF
 la_activity
@@ -63,7 +61,6 @@ CMDS=<<EOF
 dmias ld
 s sym._dl_rtld_di_serinfo
 fN
-dk 9
 EOF
 EXPECT=<<EOF
 _dl_rtld_di_serinfo

--- a/test/db/archos/linux-x64/dbg_dr
+++ b/test/db/archos/linux-x64/dbg_dr
@@ -329,7 +329,6 @@ dr esi=0x42
 dr edi=0x42
 dr rflags=0
 ?== true `e cfg.debug`; ?! dr; ?? ar
-dk 9
 EOF
 EXPECT=<<EOF
 false

--- a/test/db/archos/linux-x64/dbg_dts
+++ b/test/db/archos/linux-x64/dbg_dts
@@ -10,7 +10,6 @@ dtsf ./
 dr rip
 ds 10
 dr rip
-dk 9
 rm ./session.sdb
 rm ./registers.sdb
 rm ./memory.sdb
@@ -37,7 +36,6 @@ ds
 s
 dsb
 s
-dk 9
 EOF
 EXPECT=<<EOF
 0x40052f

--- a/test/db/archos/linux-x64/dbg_fds
+++ b/test/db/archos/linux-x64/dbg_fds
@@ -3,7 +3,6 @@ FILE=bins/elf/analysis/elf-nx
 ARGS=-d
 CMDS=<<EOF
 ddl~?
-dk 9
 EOF
 EXPECT=<<EOF
 3
@@ -18,7 +17,6 @@ CMDS=<<EOF
 ddl~?
 dd- 1
 ddl~?
-dk 9
 EOF
 EXPECT=<<EOF
 3
@@ -31,7 +29,6 @@ FILE=bins/elf/analysis/elf-nx
 ARGS=-d
 CMDS=<<EOF
 ddl~?
-dk 9
 EOF
 EXPECT=<<EOF
 3

--- a/test/db/archos/linux-x64/dbg_io
+++ b/test/db/archos/linux-x64/dbg_io
@@ -4,7 +4,6 @@ ARGS=-d
 CMDS=<<EOF
 sr PC
 p8 4
-dk 9
 NOT_EXPECT=1
 EOF
 EXPECT=<<EOF
@@ -32,7 +31,6 @@ s entry0
 p8 2
 wx 9090
 p8 2
-dk 9
 EOF
 EXPECT=<<EOF
 f30f

--- a/test/db/archos/linux-x64/dbg_maps
+++ b/test/db/archos/linux-x64/dbg_maps
@@ -3,7 +3,6 @@ FILE=bins/elf/analysis/elf-nx
 ARGS=-d
 CMDS=<<EOF
 dm~?/
-dk 9
 EOF
 EXPECT=<<EOF
 6
@@ -15,7 +14,6 @@ FILE=bins/elf/analysis/elf-nx
 ARGS=-d
 CMDS=<<EOF
 dm~?
-dk 9
 EOF
 EXPECT=<<EOF
 9
@@ -28,7 +26,6 @@ ARGS=-d
 CMDS=<<EOF
 fl@F:maps~?
 dm*~?
-dk 9
 EOF
 EXPECT=<<EOF
 9

--- a/test/db/archos/linux-x64/dbg_oo
+++ b/test/db/archos/linux-x64/dbg_oo
@@ -5,7 +5,6 @@ BROKEN=1
 CMDS=<<EOF
 10oo
 e file.path
-dk 9
 EOF
 EXPECT=<<EOF
 dbg:///bin/ls
@@ -19,7 +18,6 @@ BROKEN=1
 CMDS=<<EOF
 10ood
 e file.path
-dk 9
 EOF
 EXPECT=<<EOF
 dbg:///bin/ls
@@ -101,7 +99,6 @@ CMDS=<<EOF
 ood
 fl@F:maps~?
 dm*~?
-dk 9
 EOF
 EXPECT=<<EOF
 9

--- a/test/db/archos/linux-x64/dbg_step
+++ b/test/db/archos/linux-x64/dbg_step
@@ -22,7 +22,6 @@ FILE=/bin/ls
 ARGS=-d
 CMDS=<<EOF
 id~?
-dk 9
 EOF
 EXPECT=<<EOF
 0
@@ -37,7 +36,6 @@ dr rax=rip > /dev/null
 ?vi rax-rip
 db @ rip
 dso
-dk 9
 ?vi rax-rip~?^0$
 EOF
 EXPECT=<<EOF
@@ -166,7 +164,6 @@ CMDS=<<EOF
 dcu main
 dsu 0x400546
 dr rip
-dk 9
 EOF
 EXPECT=<<EOF
 rip = 0x00400546
@@ -180,7 +177,6 @@ CMDS=<<EOF
 dcu main
 dsui mov eax
 dr rip
-dk 9
 EOF
 EXPECT=<<EOF
 0x00400575 7 call qword [0x600958]
@@ -211,7 +207,6 @@ CMDS=<<EOF
 dcu 0x00400574
 dsi rax=2
 dr rax
-dk 9
 EOF
 EXPECT=<<EOF
 rax = 0x00000002

--- a/test/db/archos/linux-x64/dbg_step_back
+++ b/test/db/archos/linux-x64/dbg_step_back
@@ -13,7 +13,6 @@ dr rbx
 dr rcx
 dr r12
 dr rip
-dk 9
 EOF
 EXPECT=<<EOF
 rbx = 0x00000001
@@ -46,7 +45,6 @@ dr rcx
 dr r10
 dr rbp
 dr rip
-dk 9
 EOF
 EXPECT=<<EOF
 rax = 0x00400574
@@ -76,7 +74,6 @@ dc
 dsb
 dsb
 dr rip
-dk 9
 EOF
 EXPECT=<<EOF
 rip = 0x0040053b

--- a/test/db/archos/linux-x64/dbg_trace1
+++ b/test/db/archos/linux-x64/dbg_trace1
@@ -8,7 +8,6 @@ db @ sym.called_in_loop
 dbc dr PC @ sym.called_in_loop
 dbte @ sym.called_in_loop
 dc
-dk 9
 EOF
 EXPECT=<<EOF
 rip = 0x004004ed

--- a/test/db/archos/linux-x64/dbg_trace2
+++ b/test/db/archos/linux-x64/dbg_trace2
@@ -8,7 +8,6 @@ db @ sym.called_in_loop
 dbc dr PC @ sym.called_in_loop
 dbte @ sym.called_in_loop
 dc
-dk 9
 EOF
 EXPECT=<<EOF
 rip = 0x004004ed

--- a/test/db/archos/linux-x64/dbg_wps
+++ b/test/db/archos/linux-x64/dbg_wps
@@ -6,7 +6,6 @@ CMDS=<<EOF
 dbw 0x80484b0 r
 dc
 dr rip
-dk 9
 EOF
 EXPECT=<<EOF
 0x08048409

--- a/test/notworking_db/darwin-x64/dbg
+++ b/test/notworking_db/darwin-x64/dbg
@@ -8,7 +8,6 @@ db @ entry0
 e cmd.bp="?e cmd.bp ran"
 dbc "?e bpcmd ran" @ `dbl:start~:2`
 dc
-dk 9
 EOF
 EXPECT=<<EOF
 cmd.bp ran

--- a/test/notworking_db/darwin-x64/dbg_cmdbps
+++ b/test/notworking_db/darwin-x64/dbg_cmdbps
@@ -8,7 +8,6 @@ db @ entry0
 e cmd.bp="?e cmd.bp ran"
 dbc "?e bpcmd ran" @ `db~[0]`
 dc
-dk 9
 EOF
 EXPECT=<<EOF
 cmd.bp ran


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr removes `dk 9` from debug tests since it shouldn't be necessary anymore after #3068.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...

----

The removal was done using:

```sh
REGEX='^dk 9' bash -c 'git grep -l "$REGEX" test/*/dbg* | xargs -n 1 sed -i "/$REGEX/d"'
```