### PR TITLE
build: fix BINDIR_DEPTH computation on Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -158,7 +158,7 @@ endif
 
 # Calcualte BINDIR's depth to be able to find the root directory during runtime
 # in portable builds
-py_cmd = 'import os; print((1 if r"@0@" == os.sep else len(os.path.normpath(r"@0@").split(os.sep))) - (1 if r"@1@" == os.sep else len(os.path.normpath(r"@1@").split(os.sep))))'.format(rizin_prefix / rizin_bindir, rizin_prefix)
+py_cmd = 'import os; from pathlib import Path; print(len(Path(os.path.normpath(r"@0@")).parents) - len(Path(os.path.normpath(r"@1@")).parents))'.format(rizin_prefix / rizin_bindir, rizin_prefix)
 py_cmd = run_command(py3_exe, '-c', py_cmd, check: true)
 bindir_depth = py_cmd.stdout().strip()
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Before there was a special case for the root dir and it was implemented by using `os.sep` as the representation for the root. That did not work on Windows. This commit rewrite the BINDIR_DEPTH computation's logic to use Path objects instead.


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

1. Download windows build
2. Install it under D:\ (or C:\ or whatever)
3. Run rizin -H and check that the various directories make sense.

Before the patch RZ_LIBDIR was like `C:\bin\lib`, but the correct value should be `C:\bin`.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
