### PR TITLE
Convert `dk` commands to the rzshell

### DIFF
--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -5582,7 +5582,6 @@ RZ_API void rz_core_cmd_init(RzCore *core) {
 		{ "/", "search kw, pattern aes", rz_cmd_search },
 		{ "?", "help message", rz_cmd_help },
 		{ "a", "analysis", rz_cmd_analysis },
-		{ "d", "debugger operations", rz_cmd_debug },
 		{ "k", "perform sdb query", rz_cmd_kuery },
 		{ "p", "print current block", rz_cmd_print },
 		{ "V", "enter visual mode", rz_cmd_visual },

--- a/librz/core/cmd/cmd_debug.c
+++ b/librz/core/cmd/cmd_debug.c
@@ -24,33 +24,6 @@
 		} \
 	} while (0)
 
-static const char *help_msg_d[] = {
-	"Usage:", "d", " # Debug commands",
-	"db", "[?]", "Breakpoints commands",
-	"dbt", "[?]", "Display backtrace based on dbg.btdepth and dbg.btalgo",
-	"dc", "[?]", "Continue execution",
-	"dd", "[?]", "File descriptors (!fd in r1)",
-	"de", "[-sc] [perm] [rm] [e]", "Debug with ESIL (see de?)",
-	"dg", " <file>", "Generate a core-file (WIP)",
-	"di", "[?]", "Show debugger backend information (See dh)",
-	"dk", "[?]", "List, send, get, set, signal handlers of child",
-	"dL", "[?]", "List or set debugger handler",
-	"dm", "[?]", "Show memory maps",
-	"do", "[?]", "Open process (reload, alias for 'oo')",
-	"doc", "", "Close debug session",
-	"dp", "[?]", "List, attach to process or thread id",
-	"dr", "[?]", "Cpu registers",
-	"ds", "[?]", "Step, over, source line",
-	"dt", "[?]", "Display instruction traces",
-	"dw", " <pid>", "Block prompt until pid dies",
-#if __WINDOWS__
-	"dW", "", "List process windows",
-	"dWi", "", "Identify window under cursor",
-#endif
-	"dx", "[?]", "Inject and run code on target process (See gs)",
-	NULL
-};
-
 static const char *help_msg_dcs[] = {
 	"Usage:", "dcs", " Continue until syscall",
 	"dcs", "", "Continue until next syscall",
@@ -65,26 +38,6 @@ static const char *help_msg_dcu[] = {
 	"dcu", " address", "Continue until address",
 	"dcu", " [..tail]", "Continue until the range",
 	"dcu", " [from] [to]", "Continue until the range",
-	NULL
-};
-
-static const char *help_msg_dk[] = {
-	"Usage: dk", "", "Signal commands",
-	"dk", "", "List all signal handlers of child process",
-	"dk", " <signal>", "Send KILL signal to child",
-	"dk", " <signal>=1", "Set signal handler for <signal> in child",
-	"dk?", "<signal>", "Name/signum resolver",
-	"dko", "[?] <signal>", "Reset skip or cont options for given signal",
-	"dko", " <signal> [|skip|cont]", "On signal SKIP handler or CONT into",
-	"dkj", "", "List all signal handlers in JSON",
-	NULL
-};
-
-static const char *help_msg_dko[] = {
-	"Usage:", "dko", " # Signal handling commands",
-	"dko", "", "List existing signal handling",
-	"dko", " [signal]", "Clear handling for a signal",
-	"dko", " [signal] [skip|cont]", "Set handling for a signal",
 	NULL
 };
 
@@ -1524,83 +1477,6 @@ static void debug_trace_calls(RzCore *core, ut64 from, ut64 to, ut64 final_addr)
 	rz_cons_break_pop();
 }
 
-static void rz_core_debug_kill(RzCore *core, const char *input) {
-	if (!input || *input == '?') {
-		if (input && input[1]) {
-			const char *signame, *arg = input + 1;
-			int signum = atoi(arg);
-			if (signum > 0) {
-				signame = rz_signal_to_string(signum);
-				if (signame)
-					rz_cons_println(signame);
-			} else {
-				signum = rz_signal_from_string(arg);
-				if (signum > 0) {
-					rz_cons_printf("%d\n", signum);
-				}
-			}
-		} else {
-			rz_core_cmd_help(core, help_msg_dk);
-		}
-	} else if (*input == 'o') {
-		switch (input[1]) {
-		case 0: // "dko" - list signal skip/conts
-			rz_debug_signal_list(core->dbg, RZ_OUTPUT_MODE_STANDARD);
-			break;
-		case ' ': // dko SIGNAL
-			if (input[2]) {
-				char *p, *name = strdup(input + 2);
-				int signum = atoi(name);
-				p = strchr(name, ' ');
-				if (p)
-					*p++ = 0; /* got SIGNAL and an action */
-				// Actions:
-				//  - pass
-				//  - trace
-				//  - stop
-				if (signum < 1)
-					signum = rz_signal_from_string(name);
-				if (signum > 0) {
-					if (!p || !p[0]) { // stop (the usual)
-						rz_debug_signal_setup(core->dbg, signum, 0);
-					} else if (*p == 's') { // skip
-						rz_debug_signal_setup(core->dbg, signum, RZ_DBG_SIGNAL_SKIP);
-					} else if (*p == 'c') { // cont
-						rz_debug_signal_setup(core->dbg, signum, RZ_DBG_SIGNAL_CONT);
-					} else {
-						RZ_LOG_ERROR("core: Invalid option: %s\n", p);
-					}
-				} else {
-					RZ_LOG_ERROR("core: Invalid signal: %s\n", input + 2);
-				}
-				free(name);
-				break;
-			}
-			/* fall through */
-		case '?':
-		default: {
-			rz_core_cmd_help(core, help_msg_dko);
-			// TODO #7967 help refactor: move to detail
-			rz_cons_println("NOTE: [signal] can be a number or a string that resolves with dk?\n"
-					"  skip means do not enter into the signal handler\n"
-					"  continue means enter into the signal handler");
-		}
-		}
-	} else if (*input == 'j') {
-		rz_debug_signal_list(core->dbg, RZ_OUTPUT_MODE_JSON);
-	} else if (!*input) {
-		rz_debug_signal_list(core->dbg, RZ_OUTPUT_MODE_STANDARD);
-	} else {
-		int sig = atoi(input);
-		char *p = strchr(input, '=');
-		if (p) {
-			rz_debug_kill_setup(core->dbg, sig, rz_num_math(core->num, p + 1));
-		} else {
-			rz_debug_kill(core->dbg, core->dbg->pid, core->dbg->tid, sig);
-		}
-	}
-}
-
 static bool cmd_dcu(RzCore *core, const char *input) {
 	const char *ptr = NULL;
 	ut64 from, to, pc;
@@ -1930,25 +1806,6 @@ static void consumeBuffer(RzBuffer *buf, const char *cmd, const char *errmsg) {
 		rz_cons_printf("%02x", tmp);
 	}
 	rz_cons_printf("\n");
-}
-
-RZ_IPI int rz_cmd_debug(void *data, const char *input) {
-	RzCore *core = (RzCore *)data;
-	int follow = 0;
-
-	switch (input[0]) {
-	case 'k': // "dk"
-		rz_core_debug_kill(core, input + 1);
-		break;
-	case '?': // "d?"
-	default:
-		rz_core_cmd_help(core, help_msg_d);
-		break;
-	}
-	if (follow > 0) {
-		rz_core_dbg_follow_seek_register(core);
-	}
-	return 0;
 }
 
 // db
@@ -3354,6 +3211,54 @@ RZ_IPI RzCmdStatus rz_cmd_debug_esil_step_until_handler(RzCore *core, int argc, 
 			break;
 		}
 		addr = naddr;
+	}
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_cmd_debug_signal_handler(RzCore *core, int argc, const char **argv) {
+	int signum = rz_num_math(core->num, argv[1]);
+	rz_debug_kill(core->dbg, core->dbg->pid, core->dbg->tid, signum);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_cmd_debug_signal_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
+	rz_core_debug_signal_print(core->dbg, state);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_cmd_debug_signal_name_handler(RzCore *core, int argc, const char **argv) {
+	int signum = rz_num_math(core->num, argv[1]);
+	const char *signame = rz_signal_to_string(signum);
+	if (!signame) {
+		RZ_LOG_ERROR("Invalid signal number\n");
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_cons_println(signame);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_cmd_debug_signal_number_handler(RzCore *core, int argc, const char **argv) {
+	int signum = rz_signal_from_string(argv[1]);
+	if (signum <= 0) {
+		RZ_LOG_ERROR("Invalid signal name\n");
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_cons_printf("%d\n", signum);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_cmd_debug_signal_option_handler(RzCore *core, int argc, const char **argv) {
+	int signum = rz_num_math(core->num, argv[1]);
+	if (!strcmp(argv[2], "skip")) {
+		rz_debug_signal_setup(core->dbg, signum, RZ_DBG_SIGNAL_SKIP);
+	} else if (!strcmp(argv[2], "reset")) {
+		// Reset the signal
+		rz_debug_signal_setup(core->dbg, signum, 0);
+	} else if (!strcmp(argv[2], "continue")) {
+		rz_debug_signal_setup(core->dbg, signum, RZ_DBG_SIGNAL_CONT);
+	} else {
+		RZ_LOG_ERROR("core: Invalid option: %s\n", argv[2]);
+		return RZ_CMD_STATUS_ERROR;
 	}
 	return RZ_CMD_STATUS_OK;
 }

--- a/librz/core/cmd_descs/cmd_debug.yaml
+++ b/librz/core/cmd_descs/cmd_debug.yaml
@@ -686,6 +686,57 @@ commands:
       - RZ_OUTPUT_MODE_QUIET
     default_mode: RZ_OUTPUT_MODE_STANDARD
     args: []
+  - name: dk
+    summary: Debug signals management
+    subcommands:
+      - name: dk
+        summary: Send signal to the child
+        cname: cmd_debug_signal
+        args:
+          - name: signal
+            type: RZ_CMD_ARG_TYPE_NUM
+      - name: dkl
+        summary: List all signal handlers of the child process
+        cname: cmd_debug_signal_list
+        type: RZ_CMD_DESC_TYPE_ARGV_STATE
+        modes:
+          - RZ_OUTPUT_MODE_STANDARD
+          - RZ_OUTPUT_MODE_JSON
+          - RZ_OUTPUT_MODE_QUIET
+          - RZ_OUTPUT_MODE_TABLE
+        default_mode: RZ_OUTPUT_MODE_STANDARD
+        args: []
+      - name: dkn
+        summary: Resolve the name of signal given the number
+        cname: cmd_debug_signal_name
+        args:
+          - name: signal
+            type: RZ_CMD_ARG_TYPE_NUM
+      - name: dkN
+        summary: Resolve the signal number given the name
+        cname: cmd_debug_signal_number
+        args:
+          - name: name
+            type: RZ_CMD_ARG_TYPE_STRING
+      - name: dko
+        summary: Set skip or continue options for a given signal
+        cname: cmd_debug_signal_option
+        args:
+          - name: signal
+            type: RZ_CMD_ARG_TYPE_NUM
+          - name: option
+            type: RZ_CMD_ARG_TYPE_CHOICES
+            choices: ["skip", "continue", "reset"]
+            default_value: "reset"
+        details:
+          - name: Signal options
+            entries:
+              - text: skip
+                comment: Do not enter into the signal handler
+              - text: continue
+                comment: Enter into the signal handler
+              - text: reset
+                comment: Remove all previously set signal options
   - name: dl
     summary: Debug handler
     subcommands:

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -527,6 +527,11 @@ RZ_IPI RzCmdStatus rz_cmd_debug_load_trace_session_handler(RzCore *core, int arg
 RZ_IPI RzCmdStatus rz_cmd_debug_list_trace_session_mmap_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_trace_tag_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_debug_info_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+RZ_IPI RzCmdStatus rz_cmd_debug_signal_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_signal_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+RZ_IPI RzCmdStatus rz_cmd_debug_signal_name_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_signal_number_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_signal_option_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_handler_set_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_handler_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_cmd_debug_list_maps_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
@@ -606,7 +611,6 @@ RZ_IPI RzCmdStatus rz_cmd_debug_inject_assembly_handler(RzCore *core, int argc, 
 RZ_IPI RzCmdStatus rz_cmd_debug_inject_egg_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_inject_opcode_restore_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_inject_syscall_handler(RzCore *core, int argc, const char **argv);
-RZ_IPI int rz_cmd_debug(void *data, const char *input);
 RZ_IPI RzCmdStatus rz_eval_getset_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_eval_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 RZ_IPI RzCmdStatus rz_eval_reset_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/cmd_descs/cmd_descs.yaml
+++ b/librz/core/cmd_descs/cmd_descs.yaml
@@ -216,9 +216,7 @@ commands:
     summary: Code metadata (comments, format, hints, ..)
     subcommands: cmd_meta
   - name: d
-    cname: cmd_debug
     summary: Debugger commands
-    type: RZ_CMD_DESC_TYPE_OLDINPUT
     subcommands: cmd_debug
   - name: e
     summary: List/get/set config evaluable vars

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -140,6 +140,7 @@ RZ_IPI void rz_core_debug_ri(RzCore *core);
 RZ_IPI bool rz_core_debug_pid_print(RzDebug *dbg, int pid, RzCmdStateOutput *state);
 RZ_IPI bool rz_core_debug_thread_print(RzDebug *dbg, int pid, RzCmdStateOutput *state);
 RZ_IPI bool rz_core_debug_desc_print(RzDebug *dbg, RzCmdStateOutput *state);
+RZ_IPI void rz_core_debug_signal_print(RzDebug *dbg, RzCmdStateOutput *state);
 
 /* cfile.c */
 RZ_IPI RzCoreIOMapInfo *rz_core_io_map_info_new(RzCoreFile *cf, int perm_orig);

--- a/librz/include/rz_debug.h
+++ b/librz/include/rz_debug.h
@@ -483,7 +483,6 @@ RZ_API int rz_debug_signal_send(RzDebug *dbg, int num);
 RZ_API int rz_debug_signal_what(RzDebug *dbg, int num);
 RZ_API void rz_debug_signal_setup(RzDebug *dbg, int num, int opt);
 RZ_API int rz_debug_signal_set(RzDebug *dbg, int num, ut64 addr);
-RZ_API void rz_debug_signal_list(RzDebug *dbg, RzOutputMode mode);
 RZ_API bool rz_debug_can_kill(RzDebug *dbg);
 RZ_API int rz_debug_kill(RzDebug *dbg, int pid, int tid, int sig);
 RZ_API RzList /*<void *>*/ *rz_debug_kill_list(RzDebug *dbg);

--- a/test/db/archos/linux-x64/dbg
+++ b/test/db/archos/linux-x64/dbg
@@ -39,3 +39,59 @@ EXPECT_ERR=<<EOF
 child received signal 9
 EOF
 RUN
+
+NAME=dkn and dkN
+FILE==
+ARGS=
+CMDS=<<EOF
+dkn 1
+dkn 9
+dkn 200
+dkn 0
+dkn -15
+dkN SIGHUP
+dkN SIGKILL
+dkN SIGWAT
+EOF
+EXPECT=<<EOF
+SIGHUP
+SIGKILL
+1
+9
+EOF
+EXPECT_ERR=<<EOF
+ERROR: Invalid signal number
+ERROR: Invalid signal number
+ERROR: Invalid signal number
+ERROR: Invalid signal name
+EOF
+RUN
+
+NAME=dko and dkl
+FILE=bins/elf/analysis/calls_x64
+ARGS=-a x86 -d
+CMDS=<<EOF
+dkl~SIGTERM
+dko 15 skip
+dkl~SIGTERM
+dko 15 reset
+dkl~SIGTERM
+dko 15 skip
+dkl~SIGTERM
+dk 15
+dc
+dk 9
+dc
+EOF
+EXPECT=<<EOF
+15 SIGTERM
+15 SIGTERM skip
+15 SIGTERM
+15 SIGTERM skip
+[+] signal 15 aka SIGTERM received 2
+EOF
+REGEXP_FILTER_ERR=child.*signal [0-9]+.*
+EXPECT_ERR=<<EOF
+child received signal 9
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Listing signals moved from `dk` to `dkl`, added TABLE output
- `dk?` resolution commands moved to `dkn` (number to name) and `dkN` (name to number)
- Removed unimplemented commands and functions
- Removed old handler for `d` commands and all of its calls
- Removed `OLDINPUT` from `d` commands, now that all root `d` commands are converted
- Added tests

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/1342
