### PR TITLE
Convert `de` commands to the rzshell

### DIFF
--- a/librz/core/cmd_descs/cmd_debug.yaml
+++ b/librz/core/cmd_descs/cmd_debug.yaml
@@ -373,6 +373,67 @@ commands:
             type: RZ_CMD_ARG_TYPE_NUM
           - name: len
             type: RZ_CMD_ARG_TYPE_NUM
+  - name: de
+    summary: Manage ESIL watchpoints
+    subcommands:
+      - name: de
+        summary: Add ESIL watchpoint
+        cname: cmd_debug_esil_add
+        args:
+          - name: perm
+            type: RZ_CMD_ARG_TYPE_STRING
+          - name: kind
+            type: RZ_CMD_ARG_TYPE_CHOICES
+            choices:
+              - reg
+              - mem
+          - name: expression
+            type: RZ_CMD_ARG_TYPE_STRING
+        details:
+          - name: Examples
+            entries:
+              - text: de
+                arg_str: "r reg rip"
+                comment: Stop when reads RIP register
+              - text: de
+                arg_str: "rw mem ADDR"
+                comment: Stop when read or write in ADDR
+              - text: de
+                arg_str: "w r rdx"
+                comment: Stop when rdx register is modified
+              - text: de
+                arg_str: "x m FROM..TO"
+                comment: Stop when rip in range
+      - name: de-*
+        summary: Remove all ESIL watchpoints
+        cname: cmd_debug_esil_remove
+        args: []
+      - name: del
+        summary: List all ESIL watchpoints
+        cname: cmd_debug_esil_list
+        args: []
+        type: RZ_CMD_DESC_TYPE_ARGV_STATE
+        modes:
+          - RZ_OUTPUT_MODE_JSON
+          - RZ_OUTPUT_MODE_TABLE
+          - RZ_OUTPUT_MODE_STANDARD
+          - RZ_OUTPUT_MODE_RIZIN
+      - name: dec
+        summary: Continue execution until matching expression
+        cname: cmd_debug_esil_continue
+        args: []
+      - name: des
+        summary: Step-in <N> instructions with ESIL
+        cname: cmd_debug_esil_step
+        args:
+          - name: N
+            type: RZ_CMD_ARG_TYPE_NUM
+      - name: desu
+        summary: Step until specified <address>
+        cname: cmd_debug_esil_step_until
+        args:
+          - name: <address>
+            type: RZ_CMD_ARG_TYPE_RZNUM
   - name: dg
     summary: Generate core dump file
     cname: cmd_debug_core_dump_generate

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -482,6 +482,12 @@ RZ_IPI RzCmdStatus rz_cmd_debug_descriptor_seek_handler(RzCore *core, int argc, 
 RZ_IPI RzCmdStatus rz_cmd_debug_descriptor_dup_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_descriptor_read_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_descriptor_write_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_esil_add_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_esil_remove_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_esil_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+RZ_IPI RzCmdStatus rz_cmd_debug_esil_continue_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_esil_step_handler(RzCore *core, int argc, const char **argv);
+RZ_IPI RzCmdStatus rz_cmd_debug_esil_step_until_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_core_dump_generate_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_process_profile_handler(RzCore *core, int argc, const char **argv);
 RZ_IPI RzCmdStatus rz_cmd_debug_process_profile_edit_handler(RzCore *core, int argc, const char **argv);

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -23,6 +23,7 @@ RZ_IPI void rz_core_analysis_esil_references_all_functions(RzCore *core);
 RZ_IPI void rz_core_analysis_esil_emulate(RzCore *core, ut64 addr, ut64 until_addr, int off);
 RZ_IPI void rz_core_analysis_esil_emulate_bb(RzCore *core);
 RZ_IPI void rz_core_analysis_esil_default(RzCore *core);
+RZ_IPI void rz_core_debug_esil_watch_print(RzDebug *dbg, RzCmdStateOutput *state);
 
 RZ_IPI void rz_core_analysis_il_reinit(RzCore *core);
 RZ_IPI bool rz_core_analysis_il_vm_set(RzCore *core, const char *var_name, ut64 value);

--- a/librz/debug/desil.c
+++ b/librz/debug/desil.c
@@ -3,8 +3,8 @@
 
 #include <rz_debug.h>
 
-#if 0
-	/* debugesil performs step into + esil conditionals */
+/*
+	debugesil performs step into + esil conditionals
 	ESIL conditionals can be used to detect when a specific address is
 	accessed, or a register. Those esil conditionals must be evaluated
 	every iteration to ensure the register values are updated. Think
@@ -15,16 +15,9 @@
 	de rw reg eax
 	de-*
 
-#expression can be a number or a range(if..is found)
-#The <=, >=, ==, <, > comparisons are also supported
-
-#endif
-
-typedef struct {
-	int rwx;
-	int dev;
-	char *expr;
-} EsilBreak;
+	expression can be a number or a range(if..is found)
+	The <=, >=, ==, <, > comparisons are also supported
+*/
 
 // TODO: Kill those globals
 RzDebug *dbg = NULL;
@@ -69,7 +62,7 @@ static int exprmatch(RzDebug *dbg, ut64 addr, const char *expr) {
 }
 
 static int esilbreak_check_pc(RzDebug *dbg, ut64 pc) {
-	EsilBreak *ew;
+	RzDebugEsilWatchpoint *ew;
 	RzListIter *iter;
 	if (!pc) {
 		pc = rz_debug_reg_get(dbg, dbg->reg->name[RZ_REG_NAME_PC]);
@@ -85,7 +78,7 @@ static int esilbreak_check_pc(RzDebug *dbg, ut64 pc) {
 }
 
 static int esilbreak_mem_read(RzAnalysisEsil *esil, ut64 addr, ut8 *buf, int len) {
-	EsilBreak *ew;
+	RzDebugEsilWatchpoint *ew;
 	RzListIter *iter;
 	eprintf(Color_GREEN "MEM READ 0x%" PFMT64x "\n" Color_RESET, addr);
 	rz_list_foreach (EWPS, iter, ew) {
@@ -100,7 +93,7 @@ static int esilbreak_mem_read(RzAnalysisEsil *esil, ut64 addr, ut8 *buf, int len
 }
 
 static int esilbreak_mem_write(RzAnalysisEsil *esil, ut64 addr, const ut8 *buf, int len) {
-	EsilBreak *ew;
+	RzDebugEsilWatchpoint *ew;
 	RzListIter *iter;
 	eprintf(Color_RED "MEM WRTE 0x%" PFMT64x "\n" Color_RESET, addr);
 	rz_list_foreach (EWPS, iter, ew) {
@@ -115,7 +108,7 @@ static int esilbreak_mem_write(RzAnalysisEsil *esil, ut64 addr, const ut8 *buf, 
 }
 
 static int esilbreak_reg_read(RzAnalysisEsil *esil, const char *regname, ut64 *num, int *size) {
-	EsilBreak *ew;
+	RzDebugEsilWatchpoint *ew;
 	RzListIter *iter;
 	if (regname[0] >= '0' && regname[0] <= '9') {
 		// eprintf (Color_CYAN"IMM READ %s\n"Color_RESET, regname);
@@ -191,7 +184,7 @@ static int exprmatchreg(RzDebug *dbg, const char *regname, const char *expr) {
 }
 
 static int esilbreak_reg_write(RzAnalysisEsil *esil, const char *regname, ut64 *num) {
-	EsilBreak *ew;
+	RzDebugEsilWatchpoint *ew;
 	RzListIter *iter;
 	if (regname[0] >= '0' && regname[0] <= '9') {
 		// this should never happen
@@ -286,7 +279,7 @@ RZ_API ut64 rz_debug_esil_step(RzDebug *dbg, ut32 count) {
 			break;
 		}
 		if (has_match) {
-			eprintf("EsilBreak match at 0x%08" PFMT64x "\n", opc);
+			eprintf("RzDebugEsilWatchpoint match at 0x%08" PFMT64x "\n", opc);
 			break;
 		}
 		if (count > 0) {
@@ -305,7 +298,7 @@ RZ_API ut64 rz_debug_esil_continue(RzDebug *dbg) {
 	return rz_debug_esil_step(dbg, UT32_MAX);
 }
 
-static void ewps_free(EsilBreak *ew) {
+static void ewps_free(RzDebugEsilWatchpoint *ew) {
 	RZ_FREE(ew->expr);
 	free(ew);
 }
@@ -322,7 +315,7 @@ RZ_API void rz_debug_esil_watch(RzDebug *dbg, int rwx, int dev, const char *expr
 		}
 		EWPS->free = (RzListFree)ewps_free;
 	}
-	EsilBreak *ew = RZ_NEW0(EsilBreak);
+	RzDebugEsilWatchpoint *ew = RZ_NEW0(RzDebugEsilWatchpoint);
 	if (!ew) {
 		RZ_FREE(EWPS);
 		return;
@@ -338,10 +331,6 @@ RZ_API void rz_debug_esil_watch_reset(RzDebug *dbg) {
 	EWPS = NULL;
 }
 
-RZ_API void rz_debug_esil_watch_list(RzDebug *dbg) {
-	EsilBreak *ew;
-	RzListIter *iter;
-	rz_list_foreach (EWPS, iter, ew) {
-		dbg->cb_printf("de %s %c %s\n", rz_str_rwx_i(ew->rwx), ew->dev, ew->expr);
-	}
+RZ_API RZ_BORROW RzList /*<RzDebugEsilWatchpoint *>*/ *rz_debug_esil_watch_list(RzDebug *dbg) {
+	return EWPS;
 }

--- a/librz/include/rz_debug.h
+++ b/librz/include/rz_debug.h
@@ -424,6 +424,12 @@ typedef struct rz_backtrace_t {
 	char *flagdesc2;
 } RzBacktrace;
 
+typedef struct rz_debug_esil_watchpoint_t {
+	int rwx;
+	int dev;
+	char *expr;
+} RzDebugEsilWatchpoint;
+
 #ifdef RZ_API
 RZ_API RZ_OWN RzDebug *rz_debug_new(RZ_BORROW RZ_NONNULL RzBreakpointContext *bp_ctx);
 RZ_API RzDebug *rz_debug_free(RzDebug *dbg);
@@ -562,7 +568,7 @@ RZ_API ut64 rz_debug_esil_step(RzDebug *dbg, ut32 count);
 RZ_API ut64 rz_debug_esil_continue(RzDebug *dbg);
 RZ_API void rz_debug_esil_watch(RzDebug *dbg, int rwx, int dev, const char *expr);
 RZ_API void rz_debug_esil_watch_reset(RzDebug *dbg);
-RZ_API void rz_debug_esil_watch_list(RzDebug *dbg);
+RZ_API RZ_BORROW RzList /*<RzDebugEsilWatchpoint *>*/ *rz_debug_esil_watch_list(RzDebug *dbg);
 RZ_API int rz_debug_esil_watch_empty(RzDebug *dbg);
 RZ_API void rz_debug_esil_prestep(RzDebug *d, int p);
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Converted `de` commands to rzshell
- Listing is done now with `del` instead of `de`, added JSON and TABLE outputs
- Moved some code from `librz/debug/desil.c` to `librz/core/cesil.c`

Please don't spend too much time reviewing ESIL parts of the code since we will remove them some time in the future anyway: https://github.com/rizinorg/rizin/issues/2080

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/1342
