### PR TITLE
Convert `pr` commands to the rzshell

### DIFF
--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -554,6 +554,9 @@ static const RzCmdDescArg print_operation_or_args[2];
 static const RzCmdDescArg print_operation_shr_args[2];
 static const RzCmdDescArg print_operation_sub_args[2];
 static const RzCmdDescArg print_operation_xor_args[2];
+static const RzCmdDescArg cmd_print_raw_args[2];
+static const RzCmdDescArg cmd_print_raw_colors_args[2];
+static const RzCmdDescArg cmd_print_raw_string_args[2];
 static const RzCmdDescArg print_utf16le_args[2];
 static const RzCmdDescArg print_utf32le_args[2];
 static const RzCmdDescArg print_utf16be_args[2];
@@ -12847,6 +12850,81 @@ static const RzCmdDescHelp print_operation_xor_help = {
 	.args = print_operation_xor_args,
 };
 
+static const RzCmdDescHelp pr_help = {
+	.summary = "Print raw bytes in different representations",
+};
+static const RzCmdDescArg cmd_print_raw_args[] = {
+	{
+		.name = "len",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_print_raw_help = {
+	.summary = "Print raw bytes",
+	.args = cmd_print_raw_args,
+};
+
+static const RzCmdDescArg cmd_print_raw_colors_args[] = {
+	{
+		.name = "len",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_print_raw_colors_help = {
+	.summary = "Print bytes as colors in palette",
+	.args = cmd_print_raw_colors_args,
+};
+
+static const RzCmdDescHelp prg_help = {
+	.summary = "Print uncompressed data",
+};
+static const RzCmdDescArg cmd_print_raw_gunzip_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_print_raw_gunzip_help = {
+	.summary = "gunzip block and print",
+	.args = cmd_print_raw_gunzip_args,
+};
+
+static const RzCmdDescArg cmd_print_raw_gunzip_verbose_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_print_raw_gunzip_verbose_help = {
+	.summary = "Show consumed bytes and output size",
+	.args = cmd_print_raw_gunzip_verbose_args,
+};
+
+static const RzCmdDescArg cmd_print_raw_printable_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_print_raw_printable_help = {
+	.summary = "Printable chars with real offset",
+	.args = cmd_print_raw_printable_args,
+};
+
+static const RzCmdDescArg cmd_print_raw_string_args[] = {
+	{
+		.name = "len",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_print_raw_string_help = {
+	.summary = "Print raw zero-terminated string",
+	.args = cmd_print_raw_string_args,
+};
+
 static const RzCmdDescArg print_string_c_cpp_args[] = {
 	{ 0 },
 };
@@ -19915,6 +19993,22 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *print_operation_xor_cd = rz_cmd_desc_argv_new(core->rcmd, po_cd, "pox", rz_print_operation_xor_handler, &print_operation_xor_help);
 	rz_warn_if_fail(print_operation_xor_cd);
+
+	RzCmdDesc *pr_cd = rz_cmd_desc_group_new(core->rcmd, cmd_print_cd, "pr", rz_cmd_print_raw_handler, &cmd_print_raw_help, &pr_help);
+	rz_warn_if_fail(pr_cd);
+	RzCmdDesc *cmd_print_raw_colors_cd = rz_cmd_desc_argv_new(core->rcmd, pr_cd, "prc", rz_cmd_print_raw_colors_handler, &cmd_print_raw_colors_help);
+	rz_warn_if_fail(cmd_print_raw_colors_cd);
+
+	RzCmdDesc *prg_cd = rz_cmd_desc_group_new(core->rcmd, pr_cd, "prg", rz_cmd_print_raw_gunzip_handler, &cmd_print_raw_gunzip_help, &prg_help);
+	rz_warn_if_fail(prg_cd);
+	RzCmdDesc *cmd_print_raw_gunzip_verbose_cd = rz_cmd_desc_argv_new(core->rcmd, prg_cd, "prgv", rz_cmd_print_raw_gunzip_verbose_handler, &cmd_print_raw_gunzip_verbose_help);
+	rz_warn_if_fail(cmd_print_raw_gunzip_verbose_cd);
+
+	RzCmdDesc *cmd_print_raw_printable_cd = rz_cmd_desc_argv_new(core->rcmd, pr_cd, "prx", rz_cmd_print_raw_printable_handler, &cmd_print_raw_printable_help);
+	rz_warn_if_fail(cmd_print_raw_printable_cd);
+
+	RzCmdDesc *cmd_print_raw_string_cd = rz_cmd_desc_argv_new(core->rcmd, pr_cd, "prz", rz_cmd_print_raw_string_handler, &cmd_print_raw_string_help);
+	rz_warn_if_fail(cmd_print_raw_string_cd);
 
 	RzCmdDesc *print_string_c_cpp_cd = rz_cmd_desc_argv_modes_new(core->rcmd, cmd_print_cd, "psc", RZ_OUTPUT_MODE_STANDARD, rz_print_string_c_cpp_handler, &print_string_c_cpp_help);
 	rz_warn_if_fail(print_string_c_cpp_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -1827,6 +1827,18 @@ RZ_IPI RzCmdStatus rz_print_operation_shr_handler(RzCore *core, int argc, const 
 RZ_IPI RzCmdStatus rz_print_operation_sub_handler(RzCore *core, int argc, const char **argv);
 // "pox"
 RZ_IPI RzCmdStatus rz_print_operation_xor_handler(RzCore *core, int argc, const char **argv);
+// "pr"
+RZ_IPI RzCmdStatus rz_cmd_print_raw_handler(RzCore *core, int argc, const char **argv);
+// "prc"
+RZ_IPI RzCmdStatus rz_cmd_print_raw_colors_handler(RzCore *core, int argc, const char **argv);
+// "prg"
+RZ_IPI RzCmdStatus rz_cmd_print_raw_gunzip_handler(RzCore *core, int argc, const char **argv);
+// "prgv"
+RZ_IPI RzCmdStatus rz_cmd_print_raw_gunzip_verbose_handler(RzCore *core, int argc, const char **argv);
+// "prx"
+RZ_IPI RzCmdStatus rz_cmd_print_raw_printable_handler(RzCore *core, int argc, const char **argv);
+// "prz"
+RZ_IPI RzCmdStatus rz_cmd_print_raw_string_handler(RzCore *core, int argc, const char **argv);
 // "psc"
 RZ_IPI RzCmdStatus rz_print_string_c_cpp_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 // "psw"

--- a/librz/core/cmd_descs/cmd_print.yaml
+++ b/librz/core/cmd_descs/cmd_print.yaml
@@ -773,6 +773,45 @@ commands:
         args:
           - name: value
             type: RZ_CMD_ARG_TYPE_RZNUM
+  - name: pr
+    summary: Print raw bytes in different representations
+    subcommands:
+      - name: pr
+        summary: Print raw bytes
+        cname: cmd_print_raw
+        args:
+          - name: len
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: prc
+        summary: Print bytes as colors in palette
+        cname: cmd_print_raw_colors
+        args:
+          - name: len
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: prg
+        summary: Print uncompressed data
+        subcommands:
+          - name: prg
+            summary: gunzip block and print
+            cname: cmd_print_raw_gunzip
+            args: []
+          - name: prgv
+            summary: Show consumed bytes and output size
+            cname: cmd_print_raw_gunzip_verbose
+            args: []
+      - name: prx
+        summary: Printable chars with real offset
+        cname: cmd_print_raw_printable
+        args: []
+      - name: prz
+        summary: Print raw zero-terminated string
+        cname: cmd_print_raw_string
+        args:
+          - name: len
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
   - name: psc
     summary: Generate a C/C++ string
     cname: print_string_c_cpp

--- a/test/db/archos/darwin-x64/cmd_i
+++ b/test/db/archos/darwin-x64/cmd_i
@@ -11,8 +11,8 @@ e io.cache=true
 EOF
 EXPECT=<<EOF
 file    A\e¢€𝄞󠁁\.bin
-{"core":{"file":"A\u001b¢\u0080€𝄞\udb40\udc41\\.bin","fd":4,"size":256,"humansz":"256","iorw":true,"mode":"r-x","block":256,"format":"any"}}
+{"core":{"file":"A\u001b¢\u0080€𝄞\udb40\udc41\\.bin","fd":4,"size":22,"humansz":"22","iorw":true,"mode":"r-x","block":256,"format":"any"}}
 file    B\e¢€𝄞󠁁\.bin
-{"core":{"file":"B\u001b¢\u0080€𝄞\udb40\udc41\\.bin","fd":5,"size":256,"humansz":"256","iorw":true,"mode":"r-x","block":256,"format":"any"}}
+{"core":{"file":"B\u001b¢\u0080€𝄞\udb40\udc41\\.bin","fd":5,"size":22,"humansz":"22","iorw":true,"mode":"r-x","block":256,"format":"any"}}
 EOF
 RUN

--- a/test/db/archos/linux-any/cmd_i
+++ b/test/db/archos/linux-any/cmd_i
@@ -14,11 +14,11 @@ $size=?v 1
 EOF
 EXPECT=<<EOF
 file    A\e¢€𝄞󠁁\.bin
-{"core":{"file":"A\u001b¢\u0080€𝄞\udb40\udc41\\.bin","fd":4,"size":256,"humansz":"256","iorw":true,"mode":"r-x","block":256,"format":"any"}}
+{"core":{"file":"A\u001b¢\u0080€𝄞\udb40\udc41\\.bin","fd":4,"size":22,"humansz":"22","iorw":true,"mode":"r-x","block":256,"format":"any"}}
 file    B\e¢€𝄞󠁁\.bin
-{"core":{"file":"B\u001b¢\u0080€𝄞\udb40\udc41\\.bin","fd":5,"size":256,"humansz":"256","iorw":true,"mode":"r-x","block":256,"format":"any"}}
+{"core":{"file":"B\u001b¢\u0080€𝄞\udb40\udc41\\.bin","fd":5,"size":22,"humansz":"22","iorw":true,"mode":"r-x","block":256,"format":"any"}}
 file    B\e¢\x81€𝄞󠁁\.bin
-{"core":{"file":[66,27,194,162,194,128,129,226,130,172,240,157,132,158,243,160,129,129,92,46,98,105,110],"fd":6,"size":256,"humansz":"256","iorw":true,"mode":"r-x","block":256,"format":"any"}}
+{"core":{"file":[66,27,194,162,194,128,129,226,130,172,240,157,132,158,243,160,129,129,92,46,98,105,110],"fd":6,"size":23,"humansz":"23","iorw":true,"mode":"r-x","block":256,"format":"any"}}
 file    €\.bin
 {"core":{"file":"€\\.bin","fd":7,"size":1,"humansz":"1","iorw":true,"mode":"r-x","block":256,"format":"any"}}
 file    \xf0\x82\x82\xac\.bin


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Convert `pr` commands to rzshell
- Instead of `prgi` and `prgo` added `prgv` (verbose) that prints both consumed and produced data length

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/1590