### PR TITLE
Fix PPC RZIL endianness issue on SystemZ

### DIFF
--- a/librz/analysis/arch/ppc/ppc_il_ops.c
+++ b/librz/analysis/arch/ppc/ppc_il_ops.c
@@ -429,7 +429,7 @@ static RzILOpEffect *compare_op(RZ_BORROW csh handle, RZ_BORROW cs_insn *insn, c
 		rB = cs_reg_name(handle, INSOP(1).reg);
 		imm = INSOP(1).imm;
 	} else {
-		crX = cs_reg_name(handle, INSOP(0).imm);
+		crX = cs_reg_name(handle, INSOP(0).reg);
 		rA = cs_reg_name(handle, INSOP(1).reg);
 		rB = cs_reg_name(handle, INSOP(2).reg);
 		imm = INSOP(2).imm;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fix endianness issue by passing `cs_ppc_op.reg` instead of `.imm` to `cs_reg_name`.

The issue with using the `.imm` union member is that it is a `st64` while `.reg` is an enum (on SystemZ 32bit wide).
On little endian systems `.reg == .imm`. Not so on big endian systems. In which
case it is `.reg == .imm >> 32`.

This fixes the failing tests mentioned here: https://github.com/rizinorg/rizin/issues/297#issuecomment-1217341292

**Test plan**

All PPC RZIL tests and asm RZIL tests are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
