### PR TITLE
Fix gcc11-asan arcompact-dis -Wstringop-truncation warning

### DIFF
--- a/librz/asm/arch/arc/gnu/arcompact-dis.c
+++ b/librz/asm/arch/arc/gnu/arcompact-dis.c
@@ -3731,7 +3731,7 @@ int ARCompact_decodeInstr(bfd_vma address, /* Address of this instruction.  */
 	fprintf_ftype func = info->fprintf_func;
 	int bytes;
 	int lowbyte, highbyte;
-	char buf[256];
+	char buf[allOperandsSize + 1];
 
 	if (info->disassembler_options) {
 		parse_disassembler_options(info->disassembler_options);
@@ -3828,7 +3828,7 @@ int ARCompact_decodeInstr(bfd_vma address, /* Address of this instruction.  */
 			if (operand[0] != '@') {
 				/* Branch instruction with 3 operands, Translation is required
 				   only for the third operand. Print the first 2 operands */
-				strncpy(buf, operand, sizeof(buf));
+				strncpy(buf, operand, sizeof(buf) - 1);
 				buf[sizeof(buf) - 1] = '\0';
 				tmpBuffer = strtok(buf, "@");
 				(*func)(stream, "%s", tmpBuffer);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following gcc11-asan warning from `arcompact-dis.c` (https://github.com/rizinorg/rizin/actions/runs/3250835989/jobs/5335038444#step:9:1938):

![arcompact-dis-strncpy](https://user-images.githubusercontent.com/12002672/195971839-08a6e181-4592-44e7-9cd1-f2d13bfdec03.PNG)

This is a cherry-pick from #3066.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
