### PR TITLE
Fix parsing QNX format on BE platforms

### DIFF
--- a/librz/bin/format/qnx/qnx.h
+++ b/librz/bin/format/qnx/qnx.h
@@ -23,75 +23,65 @@ enum {
 	LMF_LINEAR_FIXUP_REC
 };
 
-RZ_PACKED(
-	typedef struct lmf_record {
-		ut8 rec_type;
-		ut8 reserved; // must be 0
-		ut16 data_nbytes; // size of the data record after this.
-		ut16 spare; // must be 0
-	})
-lmf_record;
+typedef struct lmf_record {
+	ut8 rec_type;
+	ut8 reserved; // must be 0
+	ut16 data_nbytes; // size of the data record after this.
+	ut16 spare; // must be 0
+} lmf_record;
 
-RZ_PACKED(
-	typedef struct lmf_data {
-		ut16 segment;
-		ut32 offset;
-	})
-lmf_data;
+#define LMF_DATA_SIZE 6
 
-RZ_PACKED(
-	typedef struct lmf_header {
-		ut16 version;
-		ut16 cflags;
-		ut16 cpu; // 86,186,286,386,486
-		ut16 fpu; // 0, 87,287,387
-		ut16 code_index; // segment of code start;
-		ut16 stack_index; // segment to put the stack
-		ut16 heap_index; // segment to start DS at.
-		ut16 argv_index; // segment to put argv & environment.
-		ut16 spare2[4]; // must be zero;
-		ut32 code_offset; // starting offset of code.
-		ut32 stack_nbytes; // stack size
-		ut32 heap_nbytes; // initial size of heap (optional).
-		ut32 image_base; // starting address of image
-		ut32 spare3[2];
-	})
-lmf_header;
+typedef struct lmf_data {
+	ut16 segment;
+	ut32 offset;
+} lmf_data;
 
-RZ_PACKED(
-	typedef struct lmf_eof {
-		ut8 spare[6];
-	})
-lmf_eof;
+typedef struct lmf_header {
+	ut16 version;
+	ut16 cflags;
+	ut16 cpu; // 86,186,286,386,486
+	ut16 fpu; // 0, 87,287,387
+	ut16 code_index; // segment of code start;
+	ut16 stack_index; // segment to put the stack
+	ut16 heap_index; // segment to start DS at.
+	ut16 argv_index; // segment to put argv & environment.
+	ut16 spare2[4]; // must be zero;
+	ut32 code_offset; // starting offset of code.
+	ut32 stack_nbytes; // stack size
+	ut32 heap_nbytes; // initial size of heap (optional).
+	ut32 image_base; // starting address of image
+	ut32 spare3[2];
+} lmf_header;
+
+typedef struct lmf_eof {
+	ut8 spare[6];
+} lmf_eof;
 
 /* values for the res_type field in the lmf_resource structure */
 enum {
 	RES_USAGE = 0
 };
 
-RZ_PACKED(
-	typedef struct lmf_resource {
-		ut16 res_type;
-		ut16 spare[3];
-	})
-lmf_resource;
+#define LMF_RESOURCE_SIZE 8
 
-RZ_PACKED(
-	typedef struct lmf_rw_end {
-		ut16 verify;
-		ut32 signature;
-	})
-lmf_rw_end;
+typedef struct lmf_resource {
+	ut16 res_type;
+	ut16 spare[3];
+} lmf_resource;
 
-RZ_PACKED(
-	typedef struct {
-		Sdb *kv;
-		lmf_header lmfh;
-		RzList /*<RzBinSection *>*/ *fixups;
-		RzList /*<RzBinSection *>*/ *sections;
-		RzList /*<RzBinMap *>*/ *maps;
-		lmf_rw_end rwend;
-	})
-QnxObj;
+typedef struct lmf_rw_end {
+	ut16 verify;
+	ut32 signature;
+} lmf_rw_end;
+
+typedef struct {
+	Sdb *kv;
+	lmf_header lmfh;
+	RzList /*<RzBinSection *>*/ *fixups;
+	RzList /*<RzBinSection *>*/ *sections;
+	RzList /*<RzBinMap *>*/ *maps;
+	lmf_rw_end rwend;
+} QnxObj;
 
 #endif


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes parsing of the QNX header and data records on big endian platforms.

**Test plan**

- CI is green
- Travis System Z has no QNX errors

**Closing issues**

Partially address https://github.com/rizinorg/rizin/issues/297
