### PR TITLE
Remove syncing dbg->bits -> asm.bits

### DIFF
--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -181,15 +181,6 @@ RZ_API bool rz_core_debug_continue_until(RzCore *core, ut64 addr, ut64 to) {
 	return true;
 }
 
-RZ_IPI void rz_core_debug_sync_bits(RzCore *core) {
-	if (rz_core_is_debug(core)) {
-		ut64 asm_bits = rz_config_get_i(core->config, "asm.bits");
-		if (asm_bits != core->dbg->bits * 8) {
-			rz_config_set_i(core->config, "asm.bits", core->dbg->bits * 8);
-		}
-	}
-}
-
 RZ_IPI void rz_core_debug_single_step_in(RzCore *core) {
 	if (rz_core_is_debug(core)) {
 		if (core->print->cur_enabled) {
@@ -965,7 +956,6 @@ RZ_API void rz_core_dbg_follow_seek_register(RzCore *core) {
 	if ((pc < core->offset) || (pc > (core->offset + follow))) {
 		rz_core_seek_to_register(core, "PC", false);
 	}
-	rz_core_debug_sync_bits(core);
 }
 
 static void foreach_reg_set_or_clear(RzCore *core, bool set) {

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -129,7 +129,6 @@ RZ_IPI RzList /*<RzRegItem *>*/ *rz_core_reg_flags_candidates(RzCore *core, RzRe
 RZ_IPI void rz_core_reg_print_diff(RzReg *reg, RzList /*<RzRegItem *>*/ *items);
 
 /* cdebug.c */
-RZ_IPI void rz_core_debug_sync_bits(RzCore *core);
 RZ_IPI void rz_core_debug_single_step_in(RzCore *core);
 RZ_IPI void rz_core_debug_single_step_over(RzCore *core);
 RZ_IPI void rz_core_debug_continue(RzCore *core);

--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -3153,7 +3153,6 @@ RZ_IPI void rz_core_visual_title(RzCore *core, int color) {
 			} else if (follow < 0) {
 				rz_core_seek(core, curpc + follow, true);
 			}
-			rz_core_debug_sync_bits(core);
 			oldpc = curpc;
 		}
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

As already mentioned in 8681cdc43b708eeda28bf3920455fc714cb9c71c, the deprecated dbg->bits is set and used quite randomly, for example on macOS/arm64, disassembling sometimes sets it to 16, then stepping with dbg.follow enabled syncs that value back to asm.bits, which makes no sense and breaks further disassembly.
So in light of a future removal of dbg->bits, we remove this usage of it to fix the issue.

**Test plan**

Incorrect/old behavior, notice how it switches `asm.bits` to 16:
```
florian-macbook:rizin florian$ rz -d test/bins/mach0/hello-macos-arm64
 -- Red paper or blue paper?
[0x102350560]> dcu main
Continue until 0x10233bc88
hit breakpoint at: 0x10233bc88
[0x10233bc88]> e asm.bits
64
[0x10233bc88]> pd 5
            ;-- main:
            ;-- entry0:
            ;-- _main:
            ;-- func.100003c88:
            ;-- x20:
            ;-- pc:
            0x10233bc88      ff4301d1       sub   sp, sp, 0x50
            0x10233bc8c      fd7b04a9       stp   x29, x30, [sp, 0x40]
            0x10233bc90      fd030191       add   x29, sp, 0x40
            0x10233bc94      280000b0       adrp  x8, NSLog            ; hello_macos_arm64.rw.0
                                                                       ; 0x102340000
            0x10233bc98      08010691       add   x8, x8, 0x180
[0x10233bc88]> ds
[0x10233bc88]> e asm.bits
16
[0x10233bc88]> pd 5
        ╎   ;-- main:
        ╎   ;-- entry0:
        ╎   ;-- _main:
        ╎   ;-- func.100003c88:
        ╎   ;-- x20:
        ╎   0x10233bc88      ff43           mvns  r7, r7
        └─< 0x10233bc8a      01d1           bne   0x233bc90
            ;-- pc:
            0x10233bc8c      fd7b           ldrb  r5, [r7, 0xf]
            0x10233bc8e      04a9           add   r1, sp, 0x10
            0x10233bc90      fd03           lsls  r5, r7, 0xf
```

This switch should not happen and the second disassembly should be arm64, not thumb arm32.

**Closing issues**

Addresses #2696
