### PR TITLE
Fix BE output due bad cast conversion done via pointers

### DIFF
--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -4277,14 +4277,14 @@ static void ds_print_ptr(RzDisasmState *ds, int len, int idx) {
 						ds_print_str(ds, msg, len, refaddr);
 					}
 				} else if (!strcmp(kind, "invalid")) {
-					int *n = (int *)&refaddr;
+					st32 n = (st32)refaddr;
 					ut64 p = ds->analysis_op.val;
 					if (p == UT64_MAX || p == UT32_MAX) {
 						p = ds->analysis_op.ptr;
 					}
 					/* avoid double ; -1 */
 					if (p != UT64_MAX && p != UT32_MAX) {
-						if (*n > -0xfff && *n < 0xfff) {
+						if (n > -0xfff && n < 0xfff) {
 							if (!aligned) {
 								ds_begin_comment(ds);
 							}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Can be merged only if the number of failed tests on `S390X` is lower than before. 