### PR TITLE
Fix endianness in pyc

### DIFF
--- a/librz/bin/p/bin_pyc.c
+++ b/librz/bin/p/bin_pyc.c
@@ -7,9 +7,9 @@
 
 static bool check_buffer(RzBuffer *b) {
 	if (rz_buf_size(b) > 4) {
-		ut32 buf;
-		rz_buf_read_at(b, 0, (ut8 *)&buf, sizeof(buf));
-		struct pyc_version version = get_pyc_version(buf);
+		ut32 magic = 0;
+		rz_buf_read_le32_at(b, 0, &magic);
+		struct pyc_version version = get_pyc_version(magic);
 		return version.magic != -1;
 	}
 	return false;
@@ -20,9 +20,9 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb
 	if (!ctx) {
 		return false;
 	}
-	ut32 ver;
-	rz_buf_read_at(buf, 0, (ut8 *)&ver, sizeof(ver));
-	ctx->version = get_pyc_version(ver);
+	ut32 magic = 0;
+	rz_buf_read_le32_at(buf, 0, &magic);
+	ctx->version = get_pyc_version(magic);
 	obj->bin_obj = ctx;
 	return true;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Merge only if the endianness issue on travis (`[XX] db/formats/pyc pyc disasm for 2.7`) is fixed