### PR TITLE
Fix flirt detection when function size is less than 32 bytes

### DIFF
--- a/librz/sign/create.c
+++ b/librz/sign/create.c
@@ -216,6 +216,8 @@ static inline bool is_valid_mask_prelude(const ut8 *buffer, ut32 b_size) {
 static int flirt_compare_module(const RzFlirtModule *a, const RzFlirtModule *b) {
 	if (a->length != b->length) {
 		return a->length - b->length;
+	} else if (a->crc_length != b->crc_length) {
+		return a->crc_length - b->crc_length;
 	}
 	const RzFlirtFunction *af = rz_list_first(a->public_functions);
 	const RzFlirtFunction *bf = rz_list_first(b->public_functions);

--- a/test/db/cmd/cmd_signature
+++ b/test/db/cmd/cmd_signature
@@ -339,8 +339,8 @@ EXPECT=<<EOF
 0x004832a0 1378 flirt.mpn_impn_mul_n
 0x00483810 431 flirt.mpn_impn_sqr_n_basecase
 0x004839c0 1262 flirt.mpn_impn_sqr_n
-0x00483f50 173 flirt.mpn_sub_n_1
-0x00484000 235 flirt.mpn_addmul_1
+0x00483f50 173 flirt.mpn_sub_n
+0x00484000 235 flirt.mpn_submul_1
 0x004840f0 144 flirt.mpn_extract_double
 0x00484180 185 flirt.mpn_extract_long_double
 0x00484240 286 flirt.mpn_extract_float128
@@ -348,6 +348,7 @@ EXPECT=<<EOF
 0x00484c90 138 flirt.strerror
 0x00484d40 77 flirt.strsep
 0x00484f50 8 flirt.getpid
+0x00485150 7 flirt.profile_frequency
 0x00485160 416 flirt.dl_fixup
 0x00485300 544 flirt.dl_profile_fixup
 0x00485520 2 flirt.dl_call_pltexit
@@ -362,10 +363,11 @@ EXPECT=<<EOF
 0x00487960 101 flirt.dl_tlsdesc_resolve_hold_fixup
 0x004879d0 25 flirt.dl_unmap
 0x00487cf0 83 flirt.dl_addr_inside_object
-0x00487d50 173 flirt.mpn_sub_n
-0x00487e00 235 flirt.mpn_addmul_1_1
+0x00487d50 173 flirt.mpn_add_n
+0x00487e00 235 flirt.mpn_addmul_1
 0x004895d0 877 flirt.dl_init
 0x00489940 1806 flirt.dl_check_map_versions
+0x0048f380 5 flirt.bsd_getpgrp
 0x0048fa10 478 flirt.dl_iterate_phdr
 0x0048fbf0 73 flirt.nl_finddomain_subfreeres
 0x0048fc40 247 flirt.nl_unload_domain
@@ -382,7 +384,7 @@ aaa
 Fs bins/flirt/elf-x86/libcurl.a.pat
 EOF
 EXPECT=<<EOF
-Found 100 FLIRT signatures via bins/flirt/elf-x86/libcurl.a.pat
+Found 101 FLIRT signatures via bins/flirt/elf-x86/libcurl.a.pat
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

There is a bug where signatures like the one below was not being detected because the matching function was less than 32 bytes
```
4883EC08BA0A00000031F6E8........4883C408C3...................... 00 0000 0015 :0000 atoi
```