### PR TITLE
Fix coff on big endian hosts

### DIFF
--- a/librz/bin/format/coff/coff.h
+++ b/librz/bin/format/coff/coff.h
@@ -44,7 +44,7 @@ RZ_API ut64 rz_coff_perms_from_section_flags(ut32 flags);
 RZ_API struct rz_bin_coff_obj *rz_bin_coff_new_buf(RzBuffer *buf, bool verbose);
 RZ_API void rz_bin_coff_free(struct rz_bin_coff_obj *obj);
 RZ_API RzBinAddr *rz_coff_get_entry(struct rz_bin_coff_obj *obj);
-RZ_API char *rz_coff_symbol_name(struct rz_bin_coff_obj *obj, void *ptr);
+RZ_API char *rz_coff_symbol_name(struct rz_bin_coff_obj *obj, const ut8 *ptr);
 
 RZ_API ut64 rz_coff_import_index_addr(struct rz_bin_coff_obj *obj, ut64 imp_index);
 RZ_API ut64 rz_coff_get_reloc_targets_map_base(struct rz_bin_coff_obj *obj);

--- a/librz/bin/p/bin_coff.c
+++ b/librz/bin/p/bin_coff.c
@@ -56,7 +56,6 @@ static bool is_imported_symbol(struct coff_symbol *s) {
 
 static bool _fill_bin_symbol(RzBin *rbin, struct rz_bin_coff_obj *bin, int idx, RzBinSymbol **sym) {
 	RzBinSymbol *ptr = *sym;
-	struct coff_symbol *s = NULL;
 	struct coff_scn_hdr *sc_hdr = NULL;
 	if (idx < 0 || idx > bin->hdr.f_nsyms) {
 		return false;
@@ -64,8 +63,8 @@ static bool _fill_bin_symbol(RzBin *rbin, struct rz_bin_coff_obj *bin, int idx, 
 	if (!bin->symbols) {
 		return false;
 	}
-	s = &bin->symbols[idx];
-	char *coffname = rz_coff_symbol_name(bin, s);
+	struct coff_symbol *s = &bin->symbols[idx];
+	char *coffname = rz_coff_symbol_name(bin, (const ut8 *)&s->n_name);
 	if (!coffname) {
 		return false;
 	}
@@ -154,7 +153,7 @@ static RzBinImport *_fill_bin_import(struct rz_bin_coff_obj *bin, int idx) {
 		free(ptr);
 		return NULL;
 	}
-	char *coffname = rz_coff_symbol_name(bin, s);
+	char *coffname = rz_coff_symbol_name(bin, (const ut8 *)s->n_name);
 	if (!coffname) {
 		free(ptr);
 		return NULL;
@@ -238,7 +237,7 @@ static RzList /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 			return ret;
 		}
 		struct coff_scn_hdr *hdr = &obj->scn_hdrs[i];
-		ptr->name = rz_coff_symbol_name(obj, hdr);
+		ptr->name = rz_coff_symbol_name(obj, (const ut8 *)hdr->s_name);
 		ptr->psize = hdr->s_size;
 		ptr->vsize = hdr->s_size;
 		ptr->paddr = hdr->s_scnptr;
@@ -284,7 +283,7 @@ static RzList /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		if (!ptr) {
 			return ret;
 		}
-		ptr->name = rz_coff_symbol_name(obj, &obj->scn_hdrs[i]);
+		ptr->name = rz_coff_symbol_name(obj, (const ut8 *)&obj->scn_hdrs[i].s_name);
 		if (strstr(ptr->name, "data")) {
 			ptr->is_data = true;
 		}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Also fixes alignment issues of ut32 values (crashes on sparc).
Fixes test/db/formats/coff