### PR TITLE
Update `librz/asm/arch/cris/gnu/` to the latest binutils

### DIFF
--- a/librz/asm/arch/cris/gnu/cris-dis.c
+++ b/librz/asm/arch/cris/gnu/cris-dis.c
@@ -20,6 +20,7 @@
    Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
    MA 02110-1301, USA.  */
 
+#include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/librz/asm/arch/cris/gnu/cris-dis.c
+++ b/librz/asm/arch/cris/gnu/cris-dis.c
@@ -20,12 +20,21 @@
    Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
    MA 02110-1301, USA.  */
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include "disas-asm.h"
 #include "sysdep.h"
 #include "opcode/cris.h"
 #include "libiberty.h"
+
+/* Return TRUE if the start of STR matches PREFIX, FALSE otherwise.  */
+
+static inline bool
+startswith (const char *str, const char *prefix)
+{
+  return strncmp (str, prefix, strlen (prefix)) == 0;
+}
 
 /* No instruction will be disassembled longer than this.  In theory, and
    in silicon, address prefixes can be cascaded.  In practice, cascading

--- a/librz/asm/arch/cris/gnu/cris-opc.c
+++ b/librz/asm/arch/cris/gnu/cris-opc.c
@@ -1,5 +1,5 @@
 /* cris-opc.c -- Table of opcodes for the CRIS processor.
-   Copyright 2000, 2001, 2004, 2007 Free Software Foundation, Inc.
+   Copyright (C) 2000-2022 Free Software Foundation, Inc.
    Contributed by Axis Communications AB, Lund, Sweden.
    Originally written for GAS 1.38.1 by Mikael Asker.
    Reorganized by Hans-Peter Nilsson.

--- a/librz/asm/arch/include/opcode/cris.h
+++ b/librz/asm/arch/include/opcode/cris.h
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2000, 2001, 2004 Free Software Foundation, Inc.
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-FileCopyrightText: 2000-2022 Free Software Foundation, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /* cris.h -- Header file for CRIS opcode and register tables.
    Copyright (C) 2000-2022 Free Software Foundation, Inc.

--- a/librz/asm/arch/include/opcode/cris.h
+++ b/librz/asm/arch/include/opcode/cris.h
@@ -2,26 +2,27 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 /* cris.h -- Header file for CRIS opcode and register tables.
-   Copyright (C) 2000, 2001, 2004 Free Software Foundation, Inc.
+   Copyright (C) 2000-2022 Free Software Foundation, Inc.
    Contributed by Axis Communications AB, Lund, Sweden.
    Originally written for GAS 1.38.1 by Mikael Asker.
    Updated, BFDized and GNUified by Hans-Peter Nilsson.
 
-This file is part of GAS, GDB and the GNU binutils.
+   This file is part of GAS, GDB and the GNU binutils.
 
-GAS, GDB, and GNU binutils is free software; you can redistribute it
-and/or modify it under the terms of the GNU General Public License as
-published by the Free Software Foundation; either version 2, or (at your
-option) any later version.
+   GAS, GDB, and GNU binutils is free software; you can redistribute it
+   and/or modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation; either version 3, or (at your
+   option) any later version.
 
-GAS, GDB, and GNU binutils are distributed in the hope that they will be
-useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+   GAS, GDB, and GNU binutils are distributed in the hope that they will be
+   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.  */
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
+   MA 02110-1301, USA.  */
 
 #ifndef __CRIS_H_INCLUDED_
 #define __CRIS_H_INCLUDED_


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr updates `librz/asm/arch/cris/gnu/` to the [latest binutils](https://github.com/bminor/binutils-gdb/tree/4ed07377e47addf4dd0594ac5b16d7e4cdb19436/opcodes) as requested by #814. I've had to add definitions for `bool` and `startswith` from binutils-gdb's [bfd-in.h](https://github.com/bminor/binutils-gdb/blob/4ed07377e47addf4dd0594ac5b16d7e4cdb19436/bfd/bfd-in.h). Following is a patch showing the differences between Rizin's cris-dis.c and binutils-gdb's cris-dis.c if this pr is merged.

```patch
diff --git a/../binutils-gdb/opcodes/cris-dis.c b/librz/asm/arch/cris/gnu/cris-dis.c
index 914a37f21c..fca168b364 100644
--- a/../binutils-gdb/opcodes/cris-dis.c
+++ b/librz/asm/arch/cris/gnu/cris-dis.c
@@ -20,10 +20,22 @@
    Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
    MA 02110-1301, USA.  */
 
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include "disas-asm.h"
 #include "sysdep.h"
-#include "dis-asm.h"
 #include "opcode/cris.h"
 #include "libiberty.h"
+
+/* Return TRUE if the start of STR matches PREFIX, FALSE otherwise.  */
+
+static inline bool
+startswith (const char *str, const char *prefix)
+{
+  return strncmp (str, prefix, strlen (prefix)) == 0;
+}
 
 /* No instruction will be disassembled longer than this.  In theory, and
    in silicon, address prefixes can be cascaded.  In practice, cascading
@@ -99,7 +111,7 @@ static int cris_constraint
 /* Parse disassembler options and store state in info.  FIXME: For the
    time being, we abuse static variables.  */
 
-static bool
+bool
 cris_parse_disassembler_options (disassemble_info *info,
 				 enum cris_disass_family distype)
 {
@@ -818,6 +830,7 @@ print_with_operands (const struct cris_opcode *opcodep,
       case ']':
       case ',':
 	*tp++ = *s;
+	*tp++ = ' ';
 	break;
 
       case '!':
@@ -1328,6 +1341,7 @@ print_with_operands (const struct cris_opcode *opcodep,
 	const struct cris_spec_reg *sregp
 	  = spec_reg_info ((insn >> 12) & 15, disdata->distype);
 
+if (sregp) {
 	if (sregp->name == NULL)
 	  /* Should have been caught as a non-match eariler.  */
 	  *tp++ = '?';
@@ -1338,6 +1352,7 @@ print_with_operands (const struct cris_opcode *opcodep,
 	    strcpy (tp, sregp->name);
 	    tp += strlen (tp);
 	  }
+}
       }
       break;
 
@@ -1574,7 +1589,7 @@ print_insn_cris_generic (bfd_vma memaddr,
 
 /* Disassemble, prefixing register names with `$'.  CRIS v0..v10.  */
 
-static int
+int
 print_insn_cris_with_register_prefix (bfd_vma vma,
 				      disassemble_info *info)
 {
@@ -1586,7 +1601,7 @@ print_insn_cris_with_register_prefix (bfd_vma vma,
 
 /* Disassemble, prefixing register names with `$'.  CRIS v32.  */
 
-static int
+int
 print_insn_crisv32_with_register_prefix (bfd_vma vma,
 					 disassemble_info *info)
 {
@@ -1599,7 +1614,7 @@ print_insn_crisv32_with_register_prefix (bfd_vma vma,
 /* Disassemble, prefixing register names with `$'.
    Common v10 and v32 subset.  */
 
-static int
+int
 print_insn_crisv10_v32_with_register_prefix (bfd_vma vma,
 					     disassemble_info *info)
 {
@@ -1611,7 +1626,7 @@ print_insn_crisv10_v32_with_register_prefix (bfd_vma vma,
 
 /* Disassemble, no prefixes on register names.  CRIS v0..v10.  */
 
-static int
+int
 print_insn_cris_without_register_prefix (bfd_vma vma,
 					 disassemble_info *info)
 {
@@ -1623,7 +1638,7 @@ print_insn_cris_without_register_prefix (bfd_vma vma,
 
 /* Disassemble, no prefixes on register names.  CRIS v32.  */
 
-static int
+int
 print_insn_crisv32_without_register_prefix (bfd_vma vma,
 					    disassemble_info *info)
 {
@@ -1636,7 +1651,7 @@ print_insn_crisv32_without_register_prefix (bfd_vma vma,
 /* Disassemble, no prefixes on register names.
    Common v10 and v32 subset.  */
 
-static int
+int
 print_insn_crisv10_v32_without_register_prefix (bfd_vma vma,
 						disassemble_info *info)
 {
@@ -1651,9 +1666,11 @@ print_insn_crisv10_v32_without_register_prefix (bfd_vma vma,
    FIXME: We should improve the solution to avoid the multitude of
    functions seen above.  */
 
+#define CR16_SUPPORTS_CPU 0
 disassembler_ftype
 cris_get_disassembler (bfd *abfd)
 {
+#if CR16_SUPPORTS_CPU
   /* If there's no bfd in sight, we return what is valid as input in all
      contexts if fed back to the assembler: disassembly *with* register
      prefix.  Unfortunately this will be totally wrong for v32.  */
@@ -1678,6 +1695,10 @@ cris_get_disassembler (bfd *abfd)
     return print_insn_crisv10_v32_without_register_prefix;
   return print_insn_cris_without_register_prefix;
 }
+#else
+	return print_insn_crisv32_without_register_prefix;
+#endif
+}
 
 /* Local variables:
    eval: (c-set-style "gnu")
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...

----

The updates were done using `git add -p`. The patch above was done using `git diff --no-index`. For reference, the following is the current difference between Rizin's cris-dis.c and the original import at 274f22001dcc9a90ccd7c1937338c2fd2aa17433 (the directory for both is `libr/asm` because I couldn't get `git diff` to recognize the move from `libr` to `librz`):

```patch
diff --git a/libr/asm/arch/cris/gnu/cris-dis.c b/libr/asm/arch/cris/gnu/cris-dis.c
index 68af292702..e543084f5f 100644
--- a/libr/asm/arch/cris/gnu/cris-dis.c
+++ b/libr/asm/arch/cris/gnu/cris-dis.c
@@ -21,7 +21,9 @@
    Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
    MA 02110-1301, USA.  */
 
-#include "dis-asm.h"
+#include <stdlib.h>
+#include <string.h>
+#include "disas-asm.h"
 #include "sysdep.h"
 #include "opcode/cris.h"
 #include "libiberty.h"
@@ -100,7 +102,7 @@ static int cris_constraint
 /* Parse disassembler options and store state in info.  FIXME: For the
    time being, we abuse static variables.  */
 
-static bfd_boolean
+bfd_boolean
 cris_parse_disassembler_options (disassemble_info *info,
 				 enum cris_disass_family distype)
 {
@@ -816,6 +818,7 @@ print_with_operands (const struct cris_opcode *opcodep,
       case ']':
       case ',':
 	*tp++ = *s;
+	*tp++ = ' ';
 	break;
 
       case '!':
@@ -848,7 +851,7 @@ print_with_operands (const struct cris_opcode *opcodep,
       case 'n':
 	{
 	  /* Like N but pc-relative to the start of the insn.  */
-	  unsigned long number
+	  unsigned long long number
 	    = (buffer[2] + buffer[3] * 256 + buffer[4] * 65536
 	       + buffer[5] * 0x1000000 + addr);
 
@@ -1329,6 +1332,7 @@ print_with_operands (const struct cris_opcode *opcodep,
 	const struct cris_spec_reg *sregp
 	  = spec_reg_info ((insn >> 12) & 15, disdata->distype);
 
+if (sregp) {
 	if (sregp->name == NULL)
 	  /* Should have been caught as a non-match eariler.  */
 	  *tp++ = '?';
@@ -1339,6 +1343,7 @@ print_with_operands (const struct cris_opcode *opcodep,
 	    strcpy (tp, sregp->name);
 	    tp += strlen (tp);
 	  }
+}
       }
       break;
 
@@ -1575,7 +1580,7 @@ print_insn_cris_generic (bfd_vma memaddr,
 
 /* Disassemble, prefixing register names with `$'.  CRIS v0..v10.  */
 
-static int
+int
 print_insn_cris_with_register_prefix (bfd_vma vma,
 				      disassemble_info *info)
 {
@@ -1587,7 +1592,7 @@ print_insn_cris_with_register_prefix (bfd_vma vma,
 
 /* Disassemble, prefixing register names with `$'.  CRIS v32.  */
 
-static int
+int
 print_insn_crisv32_with_register_prefix (bfd_vma vma,
 					 disassemble_info *info)
 {
@@ -1600,7 +1605,7 @@ print_insn_crisv32_with_register_prefix (bfd_vma vma,
 /* Disassemble, prefixing register names with `$'.
    Common v10 and v32 subset.  */
 
-static int
+int
 print_insn_crisv10_v32_with_register_prefix (bfd_vma vma,
 					     disassemble_info *info)
 {
@@ -1612,7 +1617,7 @@ print_insn_crisv10_v32_with_register_prefix (bfd_vma vma,
 
 /* Disassemble, no prefixes on register names.  CRIS v0..v10.  */
 
-static int
+int
 print_insn_cris_without_register_prefix (bfd_vma vma,
 					 disassemble_info *info)
 {
@@ -1624,7 +1629,7 @@ print_insn_cris_without_register_prefix (bfd_vma vma,
 
 /* Disassemble, no prefixes on register names.  CRIS v32.  */
 
-static int
+int
 print_insn_crisv32_without_register_prefix (bfd_vma vma,
 					    disassemble_info *info)
 {
@@ -1637,7 +1642,7 @@ print_insn_crisv32_without_register_prefix (bfd_vma vma,
 /* Disassemble, no prefixes on register names.
    Common v10 and v32 subset.  */
 
-static int
+int
 print_insn_crisv10_v32_without_register_prefix (bfd_vma vma,
 						disassemble_info *info)
 {
@@ -1652,9 +1657,11 @@ print_insn_crisv10_v32_without_register_prefix (bfd_vma vma,
    FIXME: We should improve the solution to avoid the multitude of
    functions seen above.  */
 
+#define CR16_SUPPORTS_CPU 0
 disassembler_ftype
 cris_get_disassembler (bfd *abfd)
 {
+#if CR16_SUPPORTS_CPU
 const int mode = 0; // V32 by default
   /* If there's no bfd in sight, we return what is valid as input in all
      contexts if fed back to the assembler: disassembly *with* register
@@ -1687,6 +1694,9 @@ case 1: // V10_V32
 default:
   return print_insn_cris_without_register_prefix;
 }
+#else
+	return print_insn_crisv32_without_register_prefix;
+#endif
 }
 
 /* Local variables:
```