### PR TITLE
Fix Flirt CRC and add Ff and afsb commands to check function signatures

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3676,8 +3676,9 @@ RZ_API int rz_core_config_init(RzCore *core) {
 		"aixar", "aout", "ar", "bin", "coff", "dos:com", "dos:com:old", "dos:exe", "dos:exe:old",
 		"dosdrv", "elf", "intelhex", "le", "loader", "lx", "moshex", "ne", "nlm", "omf", "omflib",
 		"pe", "pilot", "srec", "w32run", "zip", "all", "none", NULL);
-	SETB("flirt.sig.deflate", false, "enables/disables FLIRT zlib compression when creating a signature file (available only for .sig files)");
+	SETB("flirt.sig.deflate", false, "Enables/disables FLIRT zlib compression when creating a signature file (available only for .sig files)");
 	SETI("flirt.node.optimize", RZ_FLIRT_NODE_OPTIMIZE_MAX, "FLIRT optimization option when creating a signature file (none: 0, normal: 1, smallest: 2)");
+	SETB("flirt.ignore.unknown", true, "When enabled, on FLIRT creation it will ignore any function starting with `fcn.`");
 	SETPREF("flirt.sigdb.path", "", "Additional user defined rizin sigdb location to load on the filesystem.");
 	SETB("flirt.sigdb.load.system", true, "Load signatures from the system path");
 	SETB("flirt.sigdb.load.home", true, "Load signatures from the home path");

--- a/librz/core/cmd_descs/cmd_analysis.yaml
+++ b/librz/core/cmd_descs/cmd_analysis.yaml
@@ -362,6 +362,14 @@ commands:
               - name: signature
                 type: RZ_CMD_ARG_TYPE_STRING
                 optional: true
+          - name: afsb
+            cname: analysis_function_signature_bytes
+            summary: Outputs the function signature bytes, mask and search mask at current address
+            type: RZ_CMD_DESC_TYPE_ARGV_STATE
+            args: []
+            modes:
+              - RZ_OUTPUT_MODE_STANDARD
+              - RZ_OUTPUT_MODE_JSON
           - name: afs!
             cname: analysis_function_signature_editor
             summary: Set function signature at current address by using the editor

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -1997,6 +1997,14 @@ static const RzCmdDescHelp analysis_function_signature_help = {
 	.args = analysis_function_signature_args,
 };
 
+static const RzCmdDescArg analysis_function_signature_bytes_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_function_signature_bytes_help = {
+	.summary = "Outputs the function signature bytes, mask and search mask at current address",
+	.args = analysis_function_signature_bytes_args,
+};
+
 static const RzCmdDescArg analysis_function_signature_editor_args[] = {
 	{ 0 },
 };
@@ -16144,6 +16152,9 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *afs_cd = rz_cmd_desc_group_modes_new(core->rcmd, af_cd, "afs", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_function_signature_handler, &analysis_function_signature_help, &afs_help);
 	rz_warn_if_fail(afs_cd);
+	RzCmdDesc *analysis_function_signature_bytes_cd = rz_cmd_desc_argv_state_new(core->rcmd, afs_cd, "afsb", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_function_signature_bytes_handler, &analysis_function_signature_bytes_help);
+	rz_warn_if_fail(analysis_function_signature_bytes_cd);
+
 	RzCmdDesc *analysis_function_signature_editor_cd = rz_cmd_desc_argv_new(core->rcmd, afs_cd, "afs!", rz_analysis_function_signature_editor_handler, &analysis_function_signature_editor_help);
 	rz_warn_if_fail(analysis_function_signature_editor_cd);
 

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -9866,6 +9866,14 @@ static const RzCmdDescHelp flirt_scan_help = {
 	.args = flirt_scan_args,
 };
 
+static const RzCmdDescArg flirt_function_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp flirt_function_help = {
+	.summary = "Outputs the flirt function signature info",
+	.args = flirt_function_args,
+};
+
 static const RzCmdDescArg apply_signatures_from_sigdb_args[] = {
 	{
 		.name = "filter",
@@ -17831,6 +17839,9 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *flirt_scan_cd = rz_cmd_desc_argv_new(core->rcmd, F_cd, "Fs", rz_flirt_scan_handler, &flirt_scan_help);
 	rz_warn_if_fail(flirt_scan_cd);
+
+	RzCmdDesc *flirt_function_cd = rz_cmd_desc_argv_new(core->rcmd, F_cd, "Ff", rz_flirt_function_handler, &flirt_function_help);
+	rz_warn_if_fail(flirt_function_cd);
 
 	RzCmdDesc *apply_signatures_from_sigdb_cd = rz_cmd_desc_argv_new(core->rcmd, F_cd, "Fa", rz_apply_signatures_from_sigdb_handler, &apply_signatures_from_sigdb_help);
 	rz_warn_if_fail(apply_signatures_from_sigdb_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -1356,6 +1356,8 @@ RZ_IPI RzCmdStatus rz_flirt_create_handler(RzCore *core, int argc, const char **
 RZ_IPI RzCmdStatus rz_flirt_dump_handler(RzCore *core, int argc, const char **argv);
 // "Fs"
 RZ_IPI RzCmdStatus rz_flirt_scan_handler(RzCore *core, int argc, const char **argv);
+// "Ff"
+RZ_IPI RzCmdStatus rz_flirt_function_handler(RzCore *core, int argc, const char **argv);
 // "Fa"
 RZ_IPI RzCmdStatus rz_apply_signatures_from_sigdb_handler(RzCore *core, int argc, const char **argv);
 // "Fl"

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -193,6 +193,8 @@ RZ_IPI RzCmdStatus rz_analysis_function_blocks_color_handler(RzCore *core, int a
 RZ_IPI RzCmdStatus rz_analysis_function_setbits_handler(RzCore *core, int argc, const char **argv);
 // "afs"
 RZ_IPI RzCmdStatus rz_analysis_function_signature_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
+// "afsb"
+RZ_IPI RzCmdStatus rz_analysis_function_signature_bytes_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "afs!"
 RZ_IPI RzCmdStatus rz_analysis_function_signature_editor_handler(RzCore *core, int argc, const char **argv);
 // "afsr"

--- a/librz/core/cmd_descs/cmd_flirt.yaml
+++ b/librz/core/cmd_descs/cmd_flirt.yaml
@@ -21,6 +21,10 @@ commands:
     args:
       - name: filename
         type: RZ_CMD_ARG_TYPE_FILE
+  - name: Ff
+    cname: flirt_function
+    summary: Outputs the flirt function signature info
+    args: []
   - name: Fa
     summary: Apply signatures from sigdb
     cname: apply_signatures_from_sigdb

--- a/librz/core/csign.c
+++ b/librz/core/csign.c
@@ -443,7 +443,8 @@ RZ_API bool rz_core_flirt_create_file(RZ_NONNULL RzCore *core, RZ_NONNULL const 
 		return false;
 	}
 
-	RzFlirtNode *node = rz_sign_flirt_node_new(core->analysis, optimize);
+	bool ignore_unknown = rz_config_get_b(core->config, "flirt.ignore.unknown");
+	RzFlirtNode *node = rz_sign_flirt_node_new(core->analysis, optimize, ignore_unknown);
 	if (!node) {
 		return false;
 	}

--- a/librz/include/rz_flirt.h
+++ b/librz/include/rz_flirt.h
@@ -214,7 +214,8 @@ typedef struct rz_flirt_info_t {
 } RzFlirtInfo;
 
 RZ_API ut32 rz_sign_flirt_node_count_nodes(RZ_NONNULL const RzFlirtNode *node);
-RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_node_new(RZ_NONNULL RzAnalysis *analysis, ut32 optimization);
+RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_node_new(RZ_NONNULL RzAnalysis *analysis, ut32 optimization, bool ignore_unknown);
+RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_node_from_function(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL RzAnalysisFunction *func, bool tail_bytes);
 RZ_API void rz_sign_flirt_node_free(RZ_NULLABLE RzFlirtNode *node);
 RZ_API void rz_sign_flirt_info_fini(RZ_NULLABLE RzFlirtInfo *info);
 

--- a/librz/sign/create.c
+++ b/librz/sign/create.c
@@ -60,6 +60,23 @@ static RzFlirtFunction *flirt_function_new(const char *name, bool is_local, ut64
 	return function;
 }
 
+/**
+ * The CRC used for the function can only be calculated with non-masked bytes
+ * after the prelude.
+ * The length of the buffer must be between 0 and 0xFF.
+ * All the extra bytes not used by the CRC will be used in for the tail.
+ */
+static ut32 flirt_crc16_length(RZ_NONNULL const ut8 *mask, size_t size) {
+	rz_return_val_if_fail(mask, 0);
+	size = RZ_MIN(size, 0xFF);
+	for (size_t i = 0; i < size; ++i) {
+		if (mask[i] != 0xFF) {
+			return i;
+		}
+	}
+	return size;
+}
+
 static RzFlirtModule *flirt_module_new(RzAnalysis *analysis, RzAnalysisFunction *func, const ut8 *buffer, const ut8 *mask, ut64 b_size, bool tail_bytes) {
 	RzFlirtModule *module = RZ_NEW0(RzFlirtModule);
 	if (!module) {
@@ -87,14 +104,15 @@ static RzFlirtModule *flirt_module_new(RzAnalysis *analysis, RzAnalysisFunction 
 
 	if (b_size > 0 && buffer) {
 		// the crc should be generated only for when the buffer is > RZ_FLIRT_MAX_PRELUDE_SIZE
-		module->crc_length = RZ_MIN(b_size, 0xFF);
+		// also the size can be zero if after the prelude there is only masked bytes
+		module->crc_length = flirt_crc16_length(mask, b_size);
 		module->crc16 = flirt_crc16(buffer, module->crc_length);
 	}
 
-	module->length = rz_analysis_function_linear_size(func);
+	module->length = rz_analysis_function_size_from_entry(func);
 
 	if (tail_bytes) {
-		for (ut32 i = 0; i < RZ_MIN(b_size, 0xFF); ++i) {
+		for (ut32 i = module->crc_length, k = 0; i < b_size && k < 0xFF; ++i, ++k) {
 			if (mask[i] != 0xff) {
 				continue;
 			}
@@ -347,14 +365,103 @@ fail:
 	return false;
 }
 
+static RzFlirtNode *flirt_create_child_from_function(RzAnalysis *analysis, RzAnalysisFunction *func, bool tail_bytes) {
+	RzFlirtNode *child = NULL;
+	ut64 func_size = rz_analysis_function_size_from_entry(func);
+	if (func_size < 1) {
+		return NULL;
+	}
+
+	if (func_size > ST32_MAX) {
+		RZ_LOG_ERROR("FLIRT: this function exceeds the max size allowed by iob->read_at.\n");
+		RZ_LOG_ERROR("FLIRT: this should never happen. please open a bug report.\n");
+		return NULL;
+	}
+
+	ut8 *pattern = malloc(func_size);
+	if (!pattern) {
+		RZ_LOG_ERROR("FLIRT: cannot allocate function buffer.\n");
+		return NULL;
+	}
+
+	if (!analysis->iob.read_at(analysis->iob.io, func->addr, pattern, (int)func_size)) {
+		RZ_LOG_WARN("FLIRT: couldn't read function %s at 0x%" PFMT64x ".\n", func->name, func->addr);
+		free(pattern);
+		return NULL;
+	}
+
+	ut8 *mask = rz_analysis_mask(analysis, func_size, pattern, func->addr);
+	if (!mask) {
+		RZ_LOG_ERROR("FLIRT: cannot calculate pattern mask.\n");
+		free(pattern);
+		return NULL;
+	} else if (!is_valid_mask_prelude(mask, func_size)) {
+		RZ_LOG_ERROR("FLIRT: the function '%s' has a mask which remove all the bytes from the pattern.\n", func->name);
+		goto fail;
+	}
+
+	for (ut32 i = func_size - 1; i > 1; --i) {
+		if (mask[i] != 0xFF) {
+			func_size--;
+			continue;
+		}
+		break;
+	}
+
+	child = flirt_create_child_from_analysis(analysis, func, pattern, mask, func_size, tail_bytes);
+
+fail:
+	free(pattern);
+	free(mask);
+	return child;
+}
+
+/**
+ * \brief      Creates a RzFlirtNode from a given function
+ *
+ * \param      analysis    The RzAnalysis structure to use
+ * \param      func        The function to add in the flirt node
+ * \param      tail_bytes  When false throws any tail bytes
+ *
+ * \return     Generated FLIRT node.
+ */
+RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_node_from_function(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL RzAnalysisFunction *func, bool tail_bytes) {
+	rz_return_val_if_fail(analysis && analysis->coreb.core && func && func->name, NULL);
+
+	RzFlirtNode *child = flirt_create_child_from_function(analysis, func, tail_bytes);
+	if (!child) {
+		return NULL;
+	}
+
+	RzFlirtNode *root = RZ_NEW0(RzFlirtNode);
+	if (!root ||
+		!(root->child_list = rz_list_newf((RzListFree)rz_sign_flirt_node_free))) {
+		RZ_LOG_ERROR("FLIRT: cannot allocate root node.\n");
+		goto fail;
+	}
+
+	if (!rz_list_append(root->child_list, child)) {
+		RZ_LOG_ERROR("FLIRT: cannot append child to root list.\n");
+		goto fail;
+	}
+
+	return root;
+
+fail:
+	rz_sign_flirt_node_free(child);
+	rz_sign_flirt_node_free(root);
+	return NULL;
+}
+
 /**
  * \brief Generates the FLIRT signatures and returns an RzFlirtNode
  *
- * \param  analysis     The RzAnalysis structure to derive the signatures.
- * \param  optimization Optimization to apply after creation of the flatten nodes.
- * \return              Generated FLIRT root node.
+ * \param  analysis        The RzAnalysis structure to derive the signatures.
+ * \param  optimization    Optimization to apply after creation of the flatten nodes.
+ * \param  ignore_unknown  When enabled adds also the `fcn.XXXXXXX` functions.
+ * \return                 Generated FLIRT root node.
  */
-RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_node_new(RZ_NONNULL RzAnalysis *analysis, ut32 optimization) {
+RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_node_new(RZ_NONNULL RzAnalysis *analysis, ut32 optimization, bool ignore_unknown) {
 	rz_return_val_if_fail(analysis && analysis->coreb.core, NULL);
 	if (optimization > RZ_FLIRT_NODE_OPTIMIZE_MAX) {
 		RZ_LOG_ERROR("FLIRT: optimization value is invalid (%u > RZ_FLIRT_NODE_OPTIMIZE_MAX).\n", optimization);
@@ -376,60 +483,19 @@ RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_node_new(RZ_NONNULL RzAnalysis *analysi
 	RzListIter *it;
 	RzAnalysisFunction *func;
 	rz_list_foreach (analysis->fcns, it, func) {
-		ut64 func_size = rz_analysis_function_linear_size(func);
 		if (!func->name) {
 			RZ_LOG_ERROR("FLIRT: function at 0x%" PFMT64x " has a null name. skipping function...\n", func->addr);
 			continue;
-		} else if ((func->type != RZ_ANALYSIS_FCN_TYPE_FCN &&
-				   func->type != RZ_ANALYSIS_FCN_TYPE_LOC &&
-				   func->type != RZ_ANALYSIS_FCN_TYPE_SYM) ||
-			func_size < 1 ||
-			starts_with_flag(func->name, "imp.") ||
-			starts_with_flag(func->name, "sym.imp.")) {
+		} else if (starts_with_flag(func->name, "imp.") ||
+			starts_with_flag(func->name, "sym.imp.") ||
+			(ignore_unknown && starts_with_flag(func->name, "fcn."))) {
 			continue;
 		}
 
-		if (func_size > ST32_MAX) {
-			RZ_LOG_ERROR("FLIRT: this function exceeds the max size allowed by iob->read_at.\n");
-			RZ_LOG_ERROR("FLIRT: this should never happen. please open a bug report.\n");
+		RzFlirtNode *child = flirt_create_child_from_function(analysis, func, tail_bytes);
+		if (!child) {
 			goto fail;
-		}
-
-		ut8 *pattern = malloc(func_size);
-		if (!pattern) {
-			RZ_LOG_ERROR("FLIRT: cannot allocate function buffer.\n");
-			goto fail;
-		}
-
-		if (!analysis->iob.read_at(analysis->iob.io, func->addr, pattern, (int)func_size)) {
-			RZ_LOG_WARN("FLIRT: couldn't read function %s at 0x%" PFMT64x ".\n", func->name, func->addr);
-			free(pattern);
-			continue;
-		}
-
-		ut8 *mask = rz_analysis_mask(analysis, func_size, pattern, func->addr);
-		if (!mask) {
-			RZ_LOG_ERROR("FLIRT: cannot calculate pattern mask.\n");
-			free(pattern);
-			goto fail;
-		} else if (!is_valid_mask_prelude(mask, func_size)) {
-			free(pattern);
-			free(mask);
-			continue;
-		}
-
-		for (ut32 i = func_size - 1; i > 1; --i) {
-			if (mask[i] != 0xFF) {
-				func_size--;
-				continue;
-			}
-			break;
-		}
-
-		RzFlirtNode *child = flirt_create_child_from_analysis(analysis, func, pattern, mask, func_size, tail_bytes);
-		RZ_FREE(pattern);
-		free(mask);
-		if (!child || !rz_list_append(root->child_list, child)) {
+		} else if (!rz_list_append(root->child_list, child)) {
 			RZ_LOG_ERROR("FLIRT: cannot append child to root list.\n");
 			rz_sign_flirt_node_free(child);
 			goto fail;

--- a/test/db/cmd/cmd_signature
+++ b/test/db/cmd/cmd_signature
@@ -202,11 +202,6 @@ EXPECT=<<EOF
 0x0044a030 142 flirt.sbrk
 0x0044a0c0 64 flirt.getpagesize
 0x0044a100 80 flirt.getdtablesize
-0x0044a2c0 327 flirt.trecurse
-0x0044a410 982 flirt.tsearch
-0x0044a7f0 87 flirt.tfind
-0x0044ae00 175 flirt.twalk
-0x0044aeb0 435 flirt.tdestroy
 0x0044b070 432 flirt.next_line
 0x0044b220 1168 flirt.get_nprocs
 0x0044b6b0 224 flirt.get_nprocs_conf
@@ -215,16 +210,11 @@ EXPECT=<<EOF
 0x0044b8b0 17 flirt.getclktck
 0x0044b8d0 82 flirt.init_misc
 0x0044b990 64 flirt.libc_alloca_cutoff
-0x0044b9d0 40 flirt.lll_lock_wait_private
-0x0044ba00 28 flirt.lll_unlock_wake_private
 0x0044ba20 86 flirt.libc_enable_asynccancel
 0x0044ba80 89 flirt.libc_disable_asynccancel
 0x0044baf0 32 flirt.stack_chk_fail
 0x0044bb10 97 flirt.fortify_fail_abort
 0x0044bb80 32 flirt.fortify_fail
-0x0044bc30 114 flirt.tunable_set_val
-0x0044bcb0 1533 flirt.tunables_init
-0x0044c2b0 90 flirt.tunable_get_val
 0x0044c310 1038 flirt.dl_aux_init
 0x0044c720 2296 flirt.dl_non_dynamic_init
 0x0044d020 69 flirt.libc_init_secure
@@ -320,15 +310,12 @@ EXPECT=<<EOF
 0x004806c0 210 flirt.dl_exception_create
 0x004807a0 729 flirt.dl_exception_create_format
 0x00480a80 38 flirt.dl_exception_free
-0x00480ab0 236 flirt.dl_cache_libcmp
-0x00480ba0 2862 flirt.dl_load_cache_lookup
-0x004816d0 56 flirt.dl_unload_cache
 0x00482060 195 flirt.fatal_error
 0x00482130 80 flirt.dl_signal_exception
 0x00482180 80 flirt.dl_signal_error
 0x004821d0 208 flirt.dl_catch_exception
 0x004822a0 112 flirt.dl_catch_error
-0x00482310 162 flirt.longjmp_chk
+0x00482310 82 flirt.longjmp
 0x00482370 59 flirt.mpn_cmp
 0x004823b0 1466 flirt.mpn_divrem
 0x00482970 259 flirt.mpn_lshift
@@ -344,7 +331,6 @@ EXPECT=<<EOF
 0x004840f0 144 flirt.mpn_extract_double
 0x00484180 185 flirt.mpn_extract_long_double
 0x00484240 286 flirt.mpn_extract_float128
-0x00484360 203 flirt.itoa_word
 0x00484c90 138 flirt.strerror
 0x00484d40 77 flirt.strsep
 0x00484f50 8 flirt.getpid
@@ -384,7 +370,7 @@ aaa
 Fs bins/flirt/elf-x86/libcurl.a.pat
 EOF
 EXPECT=<<EOF
-Found 101 FLIRT signatures via bins/flirt/elf-x86/libcurl.a.pat
+Found 148 FLIRT signatures via bins/flirt/elf-x86/libcurl.a.pat
 EOF
 RUN
 
@@ -397,7 +383,7 @@ aaa
 Fs bins/flirt/elf-x86/libcurl.a.sig
 EOF
 EXPECT=<<EOF
-Found 205 FLIRT signatures via bins/flirt/elf-x86/libcurl.a.sig
+Found 148 FLIRT signatures via bins/flirt/elf-x86/libcurl.a.sig
 EOF
 RUN
 
@@ -417,49 +403,51 @@ CMDS=<<EOF
 e flirt.sigdb.load.system=false
 e flirt.sigdb.load.home=false
 aaa
-Fs bins/flirt/elf-x86/test.symbols.pat~silence
-pdf @ main
+Fs bins/flirt/elf-x86/test.stripped.pat~silence
+af @ data.004011a5
+pdf @ data.004011a5
 EOF
 EXPECT=<<EOF
-            ; DATA XREF from flirt.entry0 @ 0x401791
-/ int main (int argc, char **argv, char **envp);
-|           ; var int64_t var_18h @ rbp-0x18
-|           ; var int64_t var_dh @ rbp-0xd
+            ; DATA XREF from entry0 @ 0x40105f
+/ data.004011a5 (int64_t arg1, int64_t arg2);
+|           ; var int64_t var_70h @ rbp-0x70
+|           ; var int64_t var_64h @ rbp-0x64
+|           ; var int64_t var_60h @ rbp-0x60
 |           ; var int64_t var_8h @ rbp-0x8
-|           0x00401895      push  rbp
-|           0x00401896      mov   rbp, rsp
-|           0x00401899      sub   rsp, 0x20
-|           0x0040189d      mov   rax, qword fs:[0x28]
-|           0x004018a6      mov   qword [var_8h], rax
-|           0x004018aa      xor   eax, eax
-|           0x004018ac      lea   rax, data.00482004                   ; 0x482004 ; "r"
-|           0x004018b3      mov   rsi, rax                             ; int64_t arg2
-|           0x004018b6      lea   rax, str.test                        ; 0x482006 ; "test"
-|           0x004018bd      mov   rdi, rax                             ; int64_t arg1
-|           0x004018c0      call  flirt.IO_fopen64
-|           0x004018c5      mov   qword [var_18h], rax
-|           0x004018c9      mov   rax, qword [var_18h]
-|           0x004018cd      mov   edx, 1                               ; int64_t arg3
-|           0x004018d2      mov   esi, 5                               ; int64_t arg2
-|           0x004018d7      mov   rdi, rax                             ; uint64_t arg1
-|           0x004018da      call  flirt.fseek
-|           0x004018df      mov   rdx, qword [var_18h]
-|           0x004018e3      lea   rax, [var_dh]
-|           0x004018e7      mov   rcx, rdx                             ; int64_t arg4
-|           0x004018ea      mov   edx, 1                               ; int64_t arg3
-|           0x004018ef      mov   esi, 5                               ; int64_t arg2
-|           0x004018f4      mov   rdi, rax                             ; int64_t arg1
-|           0x004018f7      call  flirt.IO_fread
-|           0x004018fc      mov   rax, qword [var_18h]
-|           0x00401900      mov   rdi, rax                             ; int64_t arg1
-|           0x00401903      call  flirt.IO_fclose
-|           0x00401908      mov   eax, 0
-|           0x0040190d      mov   rdx, qword [var_8h]
-|           0x00401911      sub   rdx, qword fs:[0x28]
-|       ,=< 0x0040191a      je    0x401921
-|       |   0x0040191c      call  flirt.chk_fail
-|       `-> 0x00401921      leave
-\           0x00401922      ret
+|           ; arg int64_t arg1 @ rdi
+|           ; arg int64_t arg2 @ rsi
+|           0x004011a5      push  rbp
+|           0x004011a6      mov   rbp, rsp
+|           0x004011a9      sub   rsp, 0x70
+|           0x004011ad      mov   dword [var_64h], edi                 ; arg1
+|           0x004011b0      mov   qword [var_70h], rsi                 ; arg2
+|           0x004011b4      mov   rax, qword fs:[0x28]
+|           0x004011bd      mov   qword [var_8h], rax
+|           0x004011c1      xor   eax, eax
+|           0x004011c3      mov   rax, qword [var_70h]
+|           0x004011c7      add   rax, 8
+|           0x004011cb      mov   rax, qword [rax]
+|           0x004011ce      mov   rdi, rax
+|           0x004011d1      call  flirt.atoi
+|           0x004011d6      mov   edx, eax
+|           0x004011d8      lea   rax, [var_60h]
+|           0x004011dc      mov   ecx, edx
+|           0x004011de      lea   rdx, str.Hello__d                    ; segment.LOAD2
+|                                                                      ; 0x404000 ; "Hello %d\n"
+|           0x004011e5      mov   esi, 0x50                            ; 'P' ; 80
+|           0x004011ea      mov   rdi, rax
+|           0x004011ed      mov   eax, 0
+|           0x004011f2      call  flirt.snprintf
+|           0x004011f7      lea   rax, [var_60h]
+|           0x004011fb      mov   rdi, rax
+|           0x004011fe      call  flirt.puts
+|           0x00401203      mov   eax, 0
+|           0x00401208      mov   rdx, qword [var_8h]
+|           0x0040120c      sub   rdx, qword fs:[0x28]
+|       ,=< 0x00401215      je    0x40121c
+|       |   0x00401217      call  fcn.0040146f
+|       `-> 0x0040121c      leave
+\           0x0040121d      ret
 EOF
 RUN
 
@@ -470,49 +458,51 @@ CMDS=<<EOF
 e flirt.sigdb.load.system=false
 e flirt.sigdb.load.home=false
 aaa
-Fs bins/flirt/elf-x86/test.symbols.sig~silence
-pdf @ main
+Fs bins/flirt/elf-x86/test.stripped.sig~silence
+af @ data.004011a5
+pdf @ data.004011a5
 EOF
 EXPECT=<<EOF
-            ; DATA XREF from flirt.entry0 @ 0x401791
-/ int main (int argc, char **argv, char **envp);
-|           ; var int64_t var_18h @ rbp-0x18
-|           ; var int64_t var_dh @ rbp-0xd
+            ; DATA XREF from entry0 @ 0x40105f
+/ data.004011a5 (int64_t arg1, int64_t arg2);
+|           ; var int64_t var_70h @ rbp-0x70
+|           ; var int64_t var_64h @ rbp-0x64
+|           ; var int64_t var_60h @ rbp-0x60
 |           ; var int64_t var_8h @ rbp-0x8
-|           0x00401895      push  rbp
-|           0x00401896      mov   rbp, rsp
-|           0x00401899      sub   rsp, 0x20
-|           0x0040189d      mov   rax, qword fs:[0x28]
-|           0x004018a6      mov   qword [var_8h], rax
-|           0x004018aa      xor   eax, eax
-|           0x004018ac      lea   rax, data.00482004                   ; 0x482004 ; "r"
-|           0x004018b3      mov   rsi, rax                             ; int64_t arg2
-|           0x004018b6      lea   rax, str.test                        ; 0x482006 ; "test"
-|           0x004018bd      mov   rdi, rax                             ; int64_t arg1
-|           0x004018c0      call  flirt.IO_fopen64
-|           0x004018c5      mov   qword [var_18h], rax
-|           0x004018c9      mov   rax, qword [var_18h]
-|           0x004018cd      mov   edx, 1                               ; int64_t arg3
-|           0x004018d2      mov   esi, 5                               ; int64_t arg2
-|           0x004018d7      mov   rdi, rax                             ; uint64_t arg1
-|           0x004018da      call  flirt.fseek
-|           0x004018df      mov   rdx, qword [var_18h]
-|           0x004018e3      lea   rax, [var_dh]
-|           0x004018e7      mov   rcx, rdx                             ; int64_t arg4
-|           0x004018ea      mov   edx, 1                               ; int64_t arg3
-|           0x004018ef      mov   esi, 5                               ; int64_t arg2
-|           0x004018f4      mov   rdi, rax                             ; int64_t arg1
-|           0x004018f7      call  flirt.IO_fread
-|           0x004018fc      mov   rax, qword [var_18h]
-|           0x00401900      mov   rdi, rax                             ; int64_t arg1
-|           0x00401903      call  flirt.IO_fclose
-|           0x00401908      mov   eax, 0
-|           0x0040190d      mov   rdx, qword [var_8h]
-|           0x00401911      sub   rdx, qword fs:[0x28]
-|       ,=< 0x0040191a      je    0x401921
-|       |   0x0040191c      call  flirt.chk_fail
-|       `-> 0x00401921      leave
-\           0x00401922      ret
+|           ; arg int64_t arg1 @ rdi
+|           ; arg int64_t arg2 @ rsi
+|           0x004011a5      push  rbp
+|           0x004011a6      mov   rbp, rsp
+|           0x004011a9      sub   rsp, 0x70
+|           0x004011ad      mov   dword [var_64h], edi                 ; arg1
+|           0x004011b0      mov   qword [var_70h], rsi                 ; arg2
+|           0x004011b4      mov   rax, qword fs:[0x28]
+|           0x004011bd      mov   qword [var_8h], rax
+|           0x004011c1      xor   eax, eax
+|           0x004011c3      mov   rax, qword [var_70h]
+|           0x004011c7      add   rax, 8
+|           0x004011cb      mov   rax, qword [rax]
+|           0x004011ce      mov   rdi, rax
+|           0x004011d1      call  flirt.atoi
+|           0x004011d6      mov   edx, eax
+|           0x004011d8      lea   rax, [var_60h]
+|           0x004011dc      mov   ecx, edx
+|           0x004011de      lea   rdx, str.Hello__d                    ; segment.LOAD2
+|                                                                      ; 0x404000 ; "Hello %d\n"
+|           0x004011e5      mov   esi, 0x50                            ; 'P' ; 80
+|           0x004011ea      mov   rdi, rax
+|           0x004011ed      mov   eax, 0
+|           0x004011f2      call  flirt.snprintf
+|           0x004011f7      lea   rax, [var_60h]
+|           0x004011fb      mov   rdi, rax
+|           0x004011fe      call  flirt.puts
+|           0x00401203      mov   eax, 0
+|           0x00401208      mov   rdx, qword [var_8h]
+|           0x0040120c      sub   rdx, qword fs:[0x28]
+|       ,=< 0x00401215      je    0x40121c
+|       |   0x00401217      call  fcn.0040146f
+|       `-> 0x0040121c      leave
+\           0x0040121d      ret
 EOF
 RUN
 
@@ -525,9 +515,9 @@ e flirt.sigdb.path=bins/sigdb/fake-db
 Fl
 EOF
 EXPECT=<<EOF
-bin arch bits name          modules details                    
----------------------------------------------------------------
-elf x86  64   match.sig     1       Built with rizin 0.4.0-git
+bin arch bits name          modules details                
+-----------------------------------------------------------
+elf x86  64   match.sig     1       Built with rizin 0.5.0
 elf x86  64   not-match.pat 1       
 EOF
 RUN
@@ -539,11 +529,13 @@ e flirt.sigdb.load.system=false
 e flirt.sigdb.load.home=false
 e flirt.sigdb.path=bins/sigdb/fake-db
 aaa
-afl~printf
+afl~flirt
 EOF
 EXPECT=<<EOF
-0x00409c70   18 516  -> 514  flirt.printf
-0x0046fc50    7 516  -> 342  flirt.printf_1
+0x00409c70    5 208          flirt.printf
+0x0046ffb0    4 208          flirt.printf_1
+0x0046fe50    4 208  -> 197  flirt.printf_2
+0x0046fc50    4 208  -> 201  flirt.printf_3
 EOF
 RUN
 
@@ -559,7 +551,31 @@ afl~printf
 EOF
 EXPECT=<<EOF
 Applying elf/x86/64/match.sig signature file
-0x00409c70   18 516  -> 514  flirt.printf
-0x0046fc50    7 516  -> 342  flirt.printf_1
+0x00409c70    5 208          flirt.printf
+0x0046ffb0    4 208          flirt.printf_1
+0x0046fe50    4 208  -> 197  flirt.printf_2
+0x0046fc50    4 208  -> 201  flirt.printf_3
+EOF
+RUN
+
+NAME=Check function signature flirt and rizin
+FILE=bins/sigdb/elf-x86-64-static-libc
+CMDS=<<EOF
+aaa
+afsb @ 0x00409c70
+afsbj ~{} @ 0x00409c70
+Ff @ 0x00409c70
+EOF
+EXPECT=<<EOF
+pattern f30f1efa4881ecd80000004989fa4889742428488954243048894c24384c894424404c894c244884c074370f294424500f294c24600f295424700f299c24800000000f29a424900000000f29ac24a00000000f29b424b00000000f29bc24c000000064488b042528000000488944241831c0488b3d274a0a004889e231c9488d8424e00000004c89d6c70424080000004889442408488d442420c7442404300000004889442410e8842e0000488b54241864482b14252800000075084881c4d8000000c3e8b7e103000f1f8000000000
+mask ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000ffffffffffff00000000ffffffffffffffffffffffffffffff00ffffffffffffffffff00000000ffffffffffffff
+search f30f1efa4881ecd80000004989fa4889742428488954243048894c24384c894424404c894c244884c074..0f294424500f294c24600f295424700f299c24800000000f29a424900000000f29ac24a00000000f29b424b00000000f29bc24c000000064488b042528000000488944241831c048............4889e231c9488d8424e00000004c89d6c70424080000004889442408488d442420c7..............4889442410e8........488b54241864482b14252800000075..4881c4d8000000c3e8........0f1f8000000000
+{
+  "pattern": "f30f1efa4881ecd80000004989fa4889742428488954243048894c24384c894424404c894c244884c074370f294424500f294c24600f295424700f299c24800000000f29a424900000000f29ac24a00000000f29b424b00000000f29bc24c000000064488b042528000000488944241831c0488b3d274a0a004889e231c9488d8424e00000004c89d6c70424080000004889442408488d442420c7442404300000004889442410e8842e0000488b54241864482b14252800000075084881c4d8000000c3e8b7e103000f1f8000000000",
+  "mask": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000ffffffffffff00000000ffffffffffffffffffffffffffffff00ffffffffffffffffff00000000ffffffffffffff",
+  "search": "f30f1efa4881ecd80000004989fa4889742428488954243048894c24384c894424404c894c244884c074..0f294424500f294c24600f295424700f299c24800000000f29a424900000000f29ac24a00000000f29b424b00000000f29bc24c000000064488b042528000000488944241831c048............4889e231c9488d8424e00000004c89d6c70424080000004889442408488d442420c7..............4889442410e8........488b54241864482b14252800000075..4881c4d8000000c3e8........0f1f8000000000"
+}
+F30F1EFA4881ECD80000004989FA4889742428488954243048894C24384C8944 0A CA1D 00D0 :0000 fcn.00409c70 ......................0F294424500F294C24600F295424700F299C24800000000F29A424900000000F29AC24A00000000F29B424B00000000F29BC24C000000064488B042528000000488944241831C048............4889E231C9488D8424E00000004C89D6C70424080000004889442408488D442420C7..............4889442410E8........488B54241864482B14252800000075..4881C4D8000000C3E8........0F1F8000000000
+---
 EOF
 RUN


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This PR requires this bin PR which breaks all the other PR tests. 
- https://github.com/rizinorg/rizin-testbins/pull/92

There were some bugs in the flirt code that made the whole signature set wrong.
- The CRC calculation was wrong, now it is correct and following flirt standard
- The way the signatures were applied was wrong
- The way the CRC was checked was wrong
- Now pat and sig files matches the same functions correctly with the same number of matches

The PR also adds 2 new commands:
- `afsb` generates the rizin signature of the function at the current offset (including the search signature to use with `/x` command)
![image](https://user-images.githubusercontent.com/561184/197824899-492b9965-8913-4f94-b8ee-c6f36d505123.png)
- `Ff` outputs only the FLIRT pattern of the function at the current offset. 
![image](https://user-images.githubusercontent.com/561184/197825430-9a67149d-5cd7-4b50-953c-b1eb22d5a03f.png)

Now the output is correct and matches 100% the output of IDA (with the exception of the byte mask which slightly differ from theirs)

This has been identified and tested with @ret2libc 
