### PR TITLE
Convert `po` commands to the rzshell

### DIFF
--- a/librz/core/cio.c
+++ b/librz/core/cio.c
@@ -927,9 +927,8 @@ RZ_API bool rz_core_write_string_zero_at(RzCore *core, ut64 addr, const char *s)
  * \param buflen Used to return the length of the returned buffer
  * \return The transformed buffer
  */
-RZ_API RZ_OWN ut8 *rz_core_transform_op(RzCore *core, ut64 addr, RzCoreWriteOp op, ut8 *hex, int hexlen, int *buflen) {
+RZ_API RZ_OWN ut8 *rz_core_transform_op(RzCore *core, ut64 addr, RzCoreWriteOp op, RZ_NULLABLE ut8 *hex, size_t hexlen, size_t *buflen) {
 	rz_return_val_if_fail(core, NULL);
-	rz_return_val_if_fail(!hex || hexlen >= 0, NULL);
 	rz_return_val_if_fail(buflen, NULL);
 
 	switch (op) {
@@ -942,7 +941,7 @@ RZ_API RZ_OWN ut8 *rz_core_transform_op(RzCore *core, ut64 addr, RzCoreWriteOp o
 	case RZ_CORE_WRITE_OP_XOR:
 	case RZ_CORE_WRITE_OP_SHIFT_LEFT:
 	case RZ_CORE_WRITE_OP_SHIFT_RIGHT:
-		rz_return_val_if_fail(hex && hexlen >= 0, NULL);
+		rz_return_val_if_fail(hex, NULL);
 		break;
 	default:
 		break;
@@ -1017,7 +1016,7 @@ RZ_API RZ_OWN ut8 *rz_core_transform_op(RzCore *core, ut64 addr, RzCoreWriteOp o
 			break;
 		}
 	}
-	*buflen = len;
+	*buflen = (size_t)len;
 	return buf;
 }
 
@@ -1031,8 +1030,8 @@ RZ_API RZ_OWN ut8 *rz_core_transform_op(RzCore *core, ut64 addr, RzCoreWriteOp o
  * \param hexlen Optional length of the \p hex string. Must be present if \p hex is specified.
  * \return true if the write operation succeeds, false otherwise
  */
-RZ_API bool rz_core_write_block_op_at(RzCore *core, ut64 addr, RzCoreWriteOp op, ut8 *hex, int hexlen) {
-	int buflen;
+RZ_API bool rz_core_write_block_op_at(RzCore *core, ut64 addr, RzCoreWriteOp op, RZ_NULLABLE ut8 *hex, size_t hexlen) {
+	size_t buflen;
 	ut8 *buf = rz_core_transform_op(core, addr, op, hex, hexlen, &buflen);
 	if (!buf) {
 		return false;

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -2301,7 +2301,7 @@ static bool cmd_print_pxA(RzCore *core, int len, RzOutputMode mode) {
 /* Uses data from clipboard if value is NULL */
 static bool print_operation_transform(RzCore *core, RzCoreWriteOp op, RZ_NULLABLE const char *val) {
 	ut8 *hex = NULL;
-	int hexlen = -1, buflen = -1;
+	size_t hexlen = 0, buflen = 0;
 	if (val) {
 		hex = RZ_NEWS(ut8, (strlen(val) + 1) / 2);
 		if (!hex) {

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -537,6 +537,15 @@ static const RzCmdDescArg print_pattern_debrujin_args[2];
 static const RzCmdDescArg print_pattern_oxff_args[2];
 static const RzCmdDescArg print_pattern_num_args[2];
 static const RzCmdDescArg cmd_print_magic_args[2];
+static const RzCmdDescArg print_operation_add_args[2];
+static const RzCmdDescArg print_operation_and_args[2];
+static const RzCmdDescArg print_operation_div_args[2];
+static const RzCmdDescArg print_operation_shl_args[2];
+static const RzCmdDescArg print_operation_mul_args[2];
+static const RzCmdDescArg print_operation_or_args[2];
+static const RzCmdDescArg print_operation_shr_args[2];
+static const RzCmdDescArg print_operation_sub_args[2];
+static const RzCmdDescArg print_operation_xor_args[2];
 static const RzCmdDescArg print_utf16le_args[2];
 static const RzCmdDescArg print_utf32le_args[2];
 static const RzCmdDescArg print_utf16be_args[2];
@@ -12501,6 +12510,159 @@ static const RzCmdDescHelp cmd_print_magic_help = {
 	.args = cmd_print_magic_args,
 };
 
+static const RzCmdDescHelp po_help = {
+	.summary = "Print operation applied on the data",
+};
+static const RzCmdDescArg print_operation_2swap_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp print_operation_2swap_help = {
+	.summary = "2-byte endian swap",
+	.args = print_operation_2swap_args,
+};
+
+static const RzCmdDescArg print_operation_4swap_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp print_operation_4swap_help = {
+	.summary = "4-byte endian swap",
+	.args = print_operation_4swap_args,
+};
+
+static const RzCmdDescArg print_operation_8swap_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp print_operation_8swap_help = {
+	.summary = "8-byte endian swap",
+	.args = print_operation_8swap_args,
+};
+
+static const RzCmdDescArg print_operation_add_args[] = {
+	{
+		.name = "value",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_operation_add_help = {
+	.summary = "Apply addition",
+	.args = print_operation_add_args,
+};
+
+static const RzCmdDescArg print_operation_and_args[] = {
+	{
+		.name = "value",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_operation_and_help = {
+	.summary = "Apply AND operation",
+	.args = print_operation_and_args,
+};
+
+static const RzCmdDescArg print_operation_div_args[] = {
+	{
+		.name = "value",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_operation_div_help = {
+	.summary = "Apply division operation",
+	.args = print_operation_div_args,
+};
+
+static const RzCmdDescArg print_operation_shl_args[] = {
+	{
+		.name = "value",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_operation_shl_help = {
+	.summary = "Apply shift left operation",
+	.args = print_operation_shl_args,
+};
+
+static const RzCmdDescArg print_operation_mul_args[] = {
+	{
+		.name = "value",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_operation_mul_help = {
+	.summary = "Apply multiplication operation",
+	.args = print_operation_mul_args,
+};
+
+static const RzCmdDescArg print_operation_or_args[] = {
+	{
+		.name = "value",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_operation_or_help = {
+	.summary = "Apply OR operation",
+	.args = print_operation_or_args,
+};
+
+static const RzCmdDescArg print_operation_shr_args[] = {
+	{
+		.name = "value",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_operation_shr_help = {
+	.summary = "Apply shift right operation",
+	.args = print_operation_shr_args,
+};
+
+static const RzCmdDescArg print_operation_sub_args[] = {
+	{
+		.name = "value",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_operation_sub_help = {
+	.summary = "Apply subtraction operation",
+	.args = print_operation_sub_args,
+};
+
+static const RzCmdDescArg print_operation_xor_args[] = {
+	{
+		.name = "value",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_operation_xor_help = {
+	.summary = "Apply XOR operation",
+	.args = print_operation_xor_args,
+};
+
 static const RzCmdDescArg print_string_c_cpp_args[] = {
 	{ 0 },
 };
@@ -18709,6 +18871,44 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *cmd_print_magic_cd = rz_cmd_desc_argv_modes_new(core->rcmd, cmd_print_cd, "pm", RZ_OUTPUT_MODE_JSON, rz_cmd_print_magic_handler, &cmd_print_magic_help);
 	rz_warn_if_fail(cmd_print_magic_cd);
+
+	RzCmdDesc *po_cd = rz_cmd_desc_group_new(core->rcmd, cmd_print_cd, "po", NULL, NULL, &po_help);
+	rz_warn_if_fail(po_cd);
+	RzCmdDesc *print_operation_2swap_cd = rz_cmd_desc_argv_new(core->rcmd, po_cd, "po2", rz_print_operation_2swap_handler, &print_operation_2swap_help);
+	rz_warn_if_fail(print_operation_2swap_cd);
+
+	RzCmdDesc *print_operation_4swap_cd = rz_cmd_desc_argv_new(core->rcmd, po_cd, "po4", rz_print_operation_4swap_handler, &print_operation_4swap_help);
+	rz_warn_if_fail(print_operation_4swap_cd);
+
+	RzCmdDesc *print_operation_8swap_cd = rz_cmd_desc_argv_new(core->rcmd, po_cd, "po8", rz_print_operation_8swap_handler, &print_operation_8swap_help);
+	rz_warn_if_fail(print_operation_8swap_cd);
+
+	RzCmdDesc *print_operation_add_cd = rz_cmd_desc_argv_new(core->rcmd, po_cd, "poa", rz_print_operation_add_handler, &print_operation_add_help);
+	rz_warn_if_fail(print_operation_add_cd);
+
+	RzCmdDesc *print_operation_and_cd = rz_cmd_desc_argv_new(core->rcmd, po_cd, "poA", rz_print_operation_and_handler, &print_operation_and_help);
+	rz_warn_if_fail(print_operation_and_cd);
+
+	RzCmdDesc *print_operation_div_cd = rz_cmd_desc_argv_new(core->rcmd, po_cd, "pod", rz_print_operation_div_handler, &print_operation_div_help);
+	rz_warn_if_fail(print_operation_div_cd);
+
+	RzCmdDesc *print_operation_shl_cd = rz_cmd_desc_argv_new(core->rcmd, po_cd, "pol", rz_print_operation_shl_handler, &print_operation_shl_help);
+	rz_warn_if_fail(print_operation_shl_cd);
+
+	RzCmdDesc *print_operation_mul_cd = rz_cmd_desc_argv_new(core->rcmd, po_cd, "pom", rz_print_operation_mul_handler, &print_operation_mul_help);
+	rz_warn_if_fail(print_operation_mul_cd);
+
+	RzCmdDesc *print_operation_or_cd = rz_cmd_desc_argv_new(core->rcmd, po_cd, "poo", rz_print_operation_or_handler, &print_operation_or_help);
+	rz_warn_if_fail(print_operation_or_cd);
+
+	RzCmdDesc *print_operation_shr_cd = rz_cmd_desc_argv_new(core->rcmd, po_cd, "por", rz_print_operation_shr_handler, &print_operation_shr_help);
+	rz_warn_if_fail(print_operation_shr_cd);
+
+	RzCmdDesc *print_operation_sub_cd = rz_cmd_desc_argv_new(core->rcmd, po_cd, "pos", rz_print_operation_sub_handler, &print_operation_sub_help);
+	rz_warn_if_fail(print_operation_sub_cd);
+
+	RzCmdDesc *print_operation_xor_cd = rz_cmd_desc_argv_new(core->rcmd, po_cd, "pox", rz_print_operation_xor_handler, &print_operation_xor_help);
+	rz_warn_if_fail(print_operation_xor_cd);
 
 	RzCmdDesc *print_string_c_cpp_cd = rz_cmd_desc_argv_modes_new(core->rcmd, cmd_print_cd, "psc", RZ_OUTPUT_MODE_STANDARD, rz_print_string_c_cpp_handler, &print_string_c_cpp_help);
 	rz_warn_if_fail(print_string_c_cpp_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -1777,6 +1777,30 @@ RZ_IPI RzCmdStatus rz_cmd_print_timestamp_hfs_handler(RzCore *core, int argc, co
 RZ_IPI RzCmdStatus rz_cmd_print_timestamp_ntfs_handler(RzCore *core, int argc, const char **argv);
 // "pm"
 RZ_IPI RzCmdStatus rz_cmd_print_magic_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
+// "po2"
+RZ_IPI RzCmdStatus rz_print_operation_2swap_handler(RzCore *core, int argc, const char **argv);
+// "po4"
+RZ_IPI RzCmdStatus rz_print_operation_4swap_handler(RzCore *core, int argc, const char **argv);
+// "po8"
+RZ_IPI RzCmdStatus rz_print_operation_8swap_handler(RzCore *core, int argc, const char **argv);
+// "poa"
+RZ_IPI RzCmdStatus rz_print_operation_add_handler(RzCore *core, int argc, const char **argv);
+// "poA"
+RZ_IPI RzCmdStatus rz_print_operation_and_handler(RzCore *core, int argc, const char **argv);
+// "pod"
+RZ_IPI RzCmdStatus rz_print_operation_div_handler(RzCore *core, int argc, const char **argv);
+// "pol"
+RZ_IPI RzCmdStatus rz_print_operation_shl_handler(RzCore *core, int argc, const char **argv);
+// "pom"
+RZ_IPI RzCmdStatus rz_print_operation_mul_handler(RzCore *core, int argc, const char **argv);
+// "poo"
+RZ_IPI RzCmdStatus rz_print_operation_or_handler(RzCore *core, int argc, const char **argv);
+// "por"
+RZ_IPI RzCmdStatus rz_print_operation_shr_handler(RzCore *core, int argc, const char **argv);
+// "pos"
+RZ_IPI RzCmdStatus rz_print_operation_sub_handler(RzCore *core, int argc, const char **argv);
+// "pox"
+RZ_IPI RzCmdStatus rz_print_operation_xor_handler(RzCore *core, int argc, const char **argv);
 // "psc"
 RZ_IPI RzCmdStatus rz_print_string_c_cpp_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 // "psw"

--- a/librz/core/cmd_descs/cmd_print.yaml
+++ b/librz/core/cmd_descs/cmd_print.yaml
@@ -574,6 +574,75 @@ commands:
         optional: true
     modes:
       - RZ_OUTPUT_MODE_JSON
+  - name: po
+    summary: Print operation applied on the data
+    subcommands:
+      - name: po2
+        summary: 2-byte endian swap
+        cname: print_operation_2swap
+        args: []
+      - name: po4
+        summary: 4-byte endian swap
+        cname: print_operation_4swap
+        args: []
+      - name: po8
+        summary: 8-byte endian swap
+        cname: print_operation_8swap
+        args: []
+      - name: poa
+        summary: Apply addition
+        cname: print_operation_add
+        args:
+          - name: value
+            type: RZ_CMD_ARG_TYPE_RZNUM
+      - name: poA
+        summary: Apply AND operation
+        cname: print_operation_and
+        args:
+          - name: value
+            type: RZ_CMD_ARG_TYPE_RZNUM
+      - name: pod
+        summary: Apply division operation
+        cname: print_operation_div
+        args:
+          - name: value
+            type: RZ_CMD_ARG_TYPE_RZNUM
+      - name: pol
+        summary: Apply shift left operation
+        cname: print_operation_shl
+        args:
+          - name: value
+            type: RZ_CMD_ARG_TYPE_RZNUM
+      - name: pom
+        summary: Apply multiplication operation
+        cname: print_operation_mul
+        args:
+          - name: value
+            type: RZ_CMD_ARG_TYPE_RZNUM
+      - name: poo
+        summary: Apply OR operation
+        cname: print_operation_or
+        args:
+          - name: value
+            type: RZ_CMD_ARG_TYPE_RZNUM
+      - name: por
+        summary: Apply shift right operation
+        cname: print_operation_shr
+        args:
+          - name: value
+            type: RZ_CMD_ARG_TYPE_RZNUM
+      - name: pos
+        summary: Apply subtraction operation
+        cname: print_operation_sub
+        args:
+          - name: value
+            type: RZ_CMD_ARG_TYPE_RZNUM
+      - name: pox
+        summary: Apply XOR operation
+        cname: print_operation_xor
+        args:
+          - name: value
+            type: RZ_CMD_ARG_TYPE_RZNUM
   - name: psc
     summary: Generate a C/C++ string
     cname: print_string_c_cpp

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -545,9 +545,9 @@ RZ_API bool rz_core_write_length_string_at(RzCore *core, ut64 addr, const char *
 RZ_API bool rz_core_write_base64d_at(RzCore *core, ut64 addr, RZ_NONNULL const char *s);
 RZ_API bool rz_core_write_base64_at(RzCore *core, ut64 addr, RZ_NONNULL const char *s);
 RZ_API bool rz_core_write_random_at(RzCore *core, ut64 addr, size_t len);
-RZ_API bool rz_core_write_block_op_at(RzCore *core, ut64 addr, RzCoreWriteOp op, ut8 *hex, int hexlen);
+RZ_API bool rz_core_write_block_op_at(RzCore *core, ut64 addr, RzCoreWriteOp op, RZ_NULLABLE ut8 *hex, size_t hexlen);
 RZ_API bool rz_core_write_duplicate_at(RzCore *core, ut64 addr, ut64 from, int len);
-RZ_API RZ_OWN ut8 *rz_core_transform_op(RzCore *core, ut64 addr, RzCoreWriteOp op, ut8 *hex, int hexlen, int *buflen);
+RZ_API RZ_OWN ut8 *rz_core_transform_op(RzCore *core, ut64 addr, RzCoreWriteOp op, RZ_NULLABLE ut8 *hex, size_t hexlen, size_t *buflen);
 RZ_API ut32 rz_core_file_cur_fd(RzCore *core);
 RZ_API RzCmdStatus rz_core_io_cache_print(RzCore *core, RzCmdStateOutput *state);
 RZ_API RzCmdStatus rz_core_io_pcache_print(RzCore *core, RzIODesc *desc, RzCmdStateOutput *state);


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Converted all `po` commands to rzshell without any addition or removal
- Refactored `rz_core_transform_op()` and `rz_core_write_block_op_at()` to use `size_t` instead of `int` for buffer size (`hexlen`).

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/1590
