### PR TITLE
Check if WARNING: pj_ks: assertion 'j && k && v' failed (line 171) goes away

### DIFF
--- a/librz/util/json_parser.c
+++ b/librz/util/json_parser.c
@@ -545,13 +545,14 @@ static void json_pj_recurse(const RzJson *json, PJ *pj, bool with_key) {
  */
 RZ_API RZ_OWN char *rz_json_as_string(const RzJson *json, bool with_key) {
 	rz_return_val_if_fail(json, NULL);
+	const char *value = json->str_value ? json->str_value : ""; 
 	PJ *pj = pj_new();
 	if (json->type == RZ_JSON_STRING) {
 		if (with_key && json->key) {
-			pj_ks(pj, json->key, json->str_value);
+			pj_ks(pj, json->key, value);
 		} else {
 			// Printing string without surrounding quotes
-			pj_S(pj, json->str_value);
+			pj_S(pj, value);
 		}
 	} else {
 		json_pj_recurse(json, pj, with_key);


### PR DESCRIPTION
…

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Resolve the following warning
```
[XX] db/cmd/cmd_list Print the debug plugins in JSON
RZ_NOPLUGINS=1 /home/travis/build/rizinorg/rizin/install/bin/rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -Qc 'Ldj~{[0]}
Ldj~{[1]}
Ldj~{[2]}
Ldj~{[3]}
Ldj~{[4]}
Ldj~{[5]}
Ldj~{[6]}
Ldj~{[7]}
Ldj~{[8]}
Ldj~{[9]}
Ldj~{[10].name}
Ldj~{[10].license}
' =
-- stdout
--- expected
+++ actual
@@ -10,3 +10,15 @@
 {"arch":"x86,arm","name":"qnx","license":"LGPL3"}
 native
 LGPL3
+WARNING: pj_ks: assertion 'j && k && v' failed (line 171)
+WARNING: pj_ks: assertion 'j && k && v' failed (line 171)
+WARNING: pj_ks: assertion 'j && k && v' failed (line 171)
+WARNING: pj_ks: assertion 'j && k && v' failed (line 171)
+WARNING: pj_ks: assertion 'j && k && v' failed (line 171)
+WARNING: pj_ks: assertion 'j && k && v' failed (line 171)
+WARNING: pj_ks: assertion 'j && k && v' failed (line 171)
+WARNING: pj_ks: assertion 'j && k && v' failed (line 171)
+WARNING: pj_ks: assertion 'j && k && v' failed (line 171)
+WARNING: pj_ks: assertion 'j && k && v' failed (line 171)
+WARNING: pj_ks: assertion 'j && k && v' failed (line 171)
+WARNING: pj_ks: assertion 'j && k && v' failed (line 171)
```