### PR TITLE
Fix debugless build on E2K (Elbrus) platforms

### DIFF
--- a/subprojects/rzheap/rz_jemalloc/internal/jemalloc_internal.h
+++ b/subprojects/rzheap/rz_jemalloc/internal/jemalloc_internal.h
@@ -283,6 +283,9 @@ typedef unsigned szind_t;
 #  ifdef __le32__
 #    define LG_QUANTUM		4
 #  endif
+#  ifdef __e2k__
+#    define LG_QUANTUM		4
+#  endif
 #  ifndef LG_QUANTUM
 #    error "Unknown minimum alignment for architecture; specify via "
 	 "--with-lg-quantum"


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes building of Rizin with debugger disabled (`-Ddebugger=false`) on E2K (Elbrus) architecture. The debugger would require [support of the architecture itself](https://github.com/rizinorg/ideas/issues/17) and debug register profile.

**Test plan**

- CI is green
- It builds on Elbrus with `meson -Ddebugger=false build && ninja -C build`