### PR TITLE
Enable show/close legend in Vv mode

### DIFF
--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -265,6 +265,7 @@ typedef struct rz_core_visual_tab_t {
 typedef struct rz_core_visual_t {
 	RzList /*<RzCoreVisualTab *>*/ *tabs;
 	int tab;
+	bool hide_legend;
 	bool is_inputing; // whether the user is inputing
 	char *inputing; // for filter on the go in Vv mode
 	RzCoreVisualMode printidx;

--- a/librz/core/tui/vmenus.c
+++ b/librz/core/tui/vmenus.c
@@ -131,7 +131,13 @@ static ut64 var_functions_show(RzCore *core, int idx, int show, int cols) {
 
 	// Adjust the windows size automaticaly
 	(void)rz_cons_get_size(&window);
-	window -= visual->inputing ? 10 : 8; // Size of printed things
+	window -= 2; // size of command line in the bottom
+	if (visual->inputing) {
+		window -= 2; // filter size
+	}
+	if (!visual->hide_legend) {
+		window -= 7; // legend size
+	}
 	bool color = rz_config_get_i(core->config, "scr.color");
 	const char *color_addr = core->cons->context->pal.offset;
 	const char *color_fcn = core->cons->context->pal.fname;
@@ -309,7 +315,8 @@ static const char *help_fun_visual[] = {
 	"(a)", "analyze ", "(-)", "delete ", "(x)", "xrefs to ", "(X)", "xrefs from\n",
 	"(r)", "rename ", "(c)", "calls ", "(d)", "define ", "(:)", "shell ", "(v)", "vars\n",
 	"(j/k)", "next/prev ", "(tab)", "column ", "(_)", "hud ", "(?)", " help\n",
-	"(f/F)", "set/reset filter ", "(s)", "function signature ", "(q)", "quit\n\n",
+	"(f/F)", "set/reset filter ", "(s)", "function signature ", "(q)", "quit\n",
+	"(=)", "show/hide legend\n\n",
 	NULL
 };
 
@@ -392,7 +399,9 @@ static ut64 rz_core_visual_analysis_refresh(RzCore *core) {
 		if (color) {
 			rz_cons_strcat("\n" Color_RESET);
 		}
-		rz_core_vmenu_append_help(buf, help_fun_visual);
+		if (!visual->hide_legend) {
+			rz_core_vmenu_append_help(buf, help_fun_visual);
+		}
 		char *drained = rz_strbuf_drain(buf);
 		rz_cons_printf("%s", drained);
 		free(drained);
@@ -650,6 +659,11 @@ RZ_IPI void rz_core_visual_analysis(RzCore *core, const char *input) {
 		ch = rz_cons_arrow_to_hjkl(ch); // get ESC+char, return 'hjkl' char
 
 		switch (ch) {
+		case '=':
+			if (level == 0) {
+				visual->hide_legend = visual->hide_legend ? false : true;
+			}
+			break;
 		case 'f':
 			if (level == 0) {
 				// add new keyword


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

With legend disabled:

<img width="1509" alt="Screen Shot 2022-11-08 at 10 05 26" src="https://user-images.githubusercontent.com/203261/200457267-e797090d-5a4c-4229-96d5-949e54c9621e.png">

With legend enabled:

<img width="1493" alt="Screen Shot 2022-11-08 at 10 06 35" src="https://user-images.githubusercontent.com/203261/200457374-0a2797ba-675d-459b-8e8e-250d4a93f951.png">


<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->


**Test plan**

- Press `=` to disable/enable legend in `Vv` mode, try to scroll up/down, different modes with `p`/`P`, etc
- Exit `Vv` mode then return back and check if state is preserved.

**Closing issues**

closes https://github.com/rizinorg/rizin/issues/2983