### PR TITLE
Show test path and name in rz-test -i failures

### DIFF
--- a/binrz/rz-test/rz-test.c
+++ b/binrz/rz-test/rz-test.c
@@ -979,6 +979,11 @@ static void interact(RzTestState *state) {
 		}
 
 		printf("#####################\n\n");
+		char *name = rz_test_test_name(result->test);
+		if (name) {
+			printf(Color_RED "[XX]" Color_RESET " %s " Color_YELLOW "%s" Color_RESET "\n", result->test->path, name);
+			free(name);
+		}
 		print_result_diff(&state->run_config, result);
 		bool have_commands = result->test->type == RZ_TEST_TYPE_CMD;
 	menu:


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Adds this line, so during `-i`, the test file and name are also visible:
![Bildschirm­foto 2022-11-08 um 15 42 23](https://user-images.githubusercontent.com/1460997/200595018-f9ae5730-d56b-419e-a8cd-3b99024713ef.png)
