### PR TITLE
Make `dbg.stepback` test invariant to env

### DIFF
--- a/test/db/archos/linux-x64/dbg_step_back
+++ b/test/db/archos/linux-x64/dbg_step_back
@@ -3,22 +3,20 @@ FILE=bins/elf/analysis/ls-linux-x86_64-zlul
 ARGS=-d -e dbg.bpsysign=true
 CMDS=<<EOF
 db @ main
-db @ 0x004028fe
+db @ 0x004028b6
 dc
 dts+
 dc
-dsb
-dsb
-dr rbx
-dr rcx
-dr r12
 dr rip
+$rsp_after=$`dr rsp`
+2dsb
+dr rip
+?v `dr rsp~[1]`-`$rsp_after~[0]`
 EOF
 EXPECT=<<EOF
-rbx = 0x0000000000000001
-rcx = 0x00736c6974756572
-r12 = 0x0000000000404870
-rip = 0x00000000004028f9
+rip = 0x00000000004028b6
+rip = 0x00000000004028af
+0x398
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr makes the `dbg.stepback` test of `db/archos/linux-x64/dbg_step_back` invariant to its environment so that it works under both `ubuntu-20.04` and `ubuntu-22.04`.

This is a cherry-pick from #3066.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
