### PR TITLE
Make "dbg.px0" test invariant to `ld`

### DIFF
--- a/test/db/archos/linux-x64/dbg_px0
+++ b/test/db/archos/linux-x64/dbg_px0
@@ -1,8 +1,8 @@
 NAME=dbg.px0
 FILE=bins/elf/analysis/elf-nx
 ARGS=-d
-CMDS=px0
+CMDS=db @ entry.init0; dc; px0
 EXPECT=<<EOF
-89e083ec0c50e8a50c
+b8549504088b1085d27505eb938d76
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Currently the "dbg.px0" test of `db/archos/linux-x64/dbg_px0` fails under `ubuntu-22.04` (https://github.com/rizinorg/rizin/actions/runs/3445601856/jobs/5749507940#step:19:327):

![dbg px0](https://user-images.githubusercontent.com/12002672/201453928-bf50effc-1bf5-4557-8b65-cbb68473ee56.PNG)

This pr fixes this by changing the test so that it's invariant to `ld`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...

----

This is a cherry-pick from #3066.