### PR TITLE
Update option shown in `Vv` when seeking to other symbols in `V`

### DIFF
--- a/librz/core/tui/vmenus.c
+++ b/librz/core/tui/vmenus.c
@@ -364,18 +364,6 @@ static void rz_core_vmenu_append_help(RzStrBuf *p, const char **help) {
 	}
 }
 
-static void set_current_option_to_seek(RzCore *core) {
-	RzListIter *iter;
-	RzAnalysisFunction *fcn;
-	int i = 0;
-	rz_list_foreach (core->analysis->fcns, iter, fcn) {
-		if (core->offset == fcn->addr) {
-			option = i;
-		}
-		i++;
-	}
-}
-
 static ut64 rz_core_visual_analysis_refresh(RzCore *core) {
 	rz_return_val_if_fail(core, 0);
 	RzCoreVisual *visual = core->visual;
@@ -396,7 +384,6 @@ static ut64 rz_core_visual_analysis_refresh(RzCore *core) {
 	if (cols > 30) {
 		rz_cons_column(cols);
 	}
-	set_current_option_to_seek(core);
 	switch (level) {
 	// Show functions list help in visual mode
 	case 0: {
@@ -600,6 +587,18 @@ static void addVar(RzCore *core, int ch, const char *msg) {
 	free(type);
 }
 
+static void set_current_option_to_seek(RzCore *core) {
+	RzListIter *iter;
+	RzAnalysisFunction *fcn;
+	int i = 0;
+	rz_list_foreach (core->analysis->fcns, iter, fcn) {
+		if (core->offset == fcn->addr) {
+			option = i;
+		}
+		i++;
+	}
+}
+
 /* Like emenu but for real */
 RZ_IPI void rz_core_visual_analysis(RzCore *core, const char *input) {
 	char old[218];
@@ -615,6 +614,8 @@ RZ_IPI void rz_core_visual_analysis(RzCore *core, const char *input) {
 	core->cons->event_resize = (RzConsEvent)rz_core_visual_analysis_refresh_oneshot;
 
 	level = 0;
+
+	set_current_option_to_seek(core);
 
 	int asmbytes = rz_config_get_i(core->config, "asm.bytes");
 	rz_config_set_i(core->config, "asm.bytes", 0);

--- a/librz/core/tui/vmenus.c
+++ b/librz/core/tui/vmenus.c
@@ -396,7 +396,7 @@ static ut64 rz_core_visual_analysis_refresh(RzCore *core) {
 	if (cols > 30) {
 		rz_cons_column(cols);
 	}
-        set_current_option_to_seek(core);
+	set_current_option_to_seek(core);
 	switch (level) {
 	// Show functions list help in visual mode
 	case 0: {

--- a/librz/core/tui/vmenus.c
+++ b/librz/core/tui/vmenus.c
@@ -364,6 +364,18 @@ static void rz_core_vmenu_append_help(RzStrBuf *p, const char **help) {
 	}
 }
 
+static void set_current_option_to_seek(RzCore *core) {
+	RzListIter *iter;
+	RzAnalysisFunction *fcn;
+	int i = 0;
+	rz_list_foreach (core->analysis->fcns, iter, fcn) {
+		if (core->offset == fcn->addr) {
+			option = i;
+		}
+		i++;
+	}
+}
+
 static ut64 rz_core_visual_analysis_refresh(RzCore *core) {
 	rz_return_val_if_fail(core, 0);
 	RzCoreVisual *visual = core->visual;
@@ -384,6 +396,7 @@ static ut64 rz_core_visual_analysis_refresh(RzCore *core) {
 	if (cols > 30) {
 		rz_cons_column(cols);
 	}
+        set_current_option_to_seek(core);
 	switch (level) {
 	// Show functions list help in visual mode
 	case 0: {
@@ -914,15 +927,7 @@ RZ_IPI void rz_core_visual_analysis(RzCore *core, const char *input) {
 		case 'g': {
 			rz_core_visual_showcursor(core, true);
 			rz_core_visual_offset(core); // change the seek to selected offset
-			RzListIter *iter; // change the current option to selected seek
-			RzAnalysisFunction *fcn;
-			int i = 0;
-			rz_list_foreach (core->analysis->fcns, iter, fcn) {
-				if (core->offset == fcn->addr) {
-					option = i;
-				}
-				i++;
-			}
+			set_current_option_to_seek(core);
 			rz_core_visual_showcursor(core, false);
 		} break;
 		case 'G':


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

After analyzing a binary, when the user:

1. entered visual mode with `V`
2. used `g` to go to a symbol
3. and entered `v`

then the current option would not be set to the location of the symbol the user seeked at.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->



**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #2751 
