### PR TITLE
linux_heap_glibc.c: Get main arena addr from mallopt() instead

### DIFF
--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -58,9 +58,11 @@ static GHT GH(get_va_symbol)(RzCore *core, const char *path, const char *sym_nam
 	return vaddr;
 }
 
+#if 0
 static inline GHT GH(align_address_to_size)(ut64 addr, ut64 align) {
 	return addr + ((align - (addr % align)) % align);
 }
+#endif
 
 static inline GHT GH(get_next_pointer)(RzCore *core, GHT pos, GHT next) {
 	return (core->dbg->glibc_version < 232) ? next : (GHT)((pos >> 12) ^ next);

--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -427,7 +427,7 @@ static void GH(print_arena_stats)(RzCore *core, GHT m_arena, MallocState *main_a
 	PRINT_GA("}\n\n");
 }
 
-static inline bool is_map_name_libc(const char *map_name) {
+static inline bool GH(is_map_name_libc)(const char *map_name) {
 	return strstr(map_name, "/libc-") || strstr(map_name, "/libc.");
 }
 
@@ -454,11 +454,11 @@ RZ_API bool GH(rz_heap_resolve_main_arena)(RzCore *core, GHT *m_arena) {
 		rz_debug_map_sync(core->dbg);
 		rz_list_foreach (core->dbg->maps, iter, map) {
 			/* Try to find the main arena address using the glibc's symbols. */
-			if (is_map_name_libc(map->name) && first_libc && main_arena_sym == GHT_MAX) {
+			if (GH(is_map_name_libc)(map->name) && first_libc && main_arena_sym == GHT_MAX) {
 				first_libc = false;
 				main_arena_sym = GH(get_main_arena_with_symbol)(core, map);
 			}
-			if (is_map_name_libc(map->name) && map->perm == RZ_PERM_RW) {
+			if (GH(is_map_name_libc)(map->name) && map->perm == RZ_PERM_RW) {
 				libc_addr_sta = map->addr;
 				libc_addr_end = map->addr_end;
 				break;

--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -72,25 +72,51 @@ static GHT GH(get_main_arena_with_symbol)(RzCore *core, RzDebugMap *map) {
 	rz_return_val_if_fail(base_addr != GHT_MAX, GHT_MAX);
 
 	GHT main_arena = GHT_MAX;
-	GHT vaddr = GHT_MAX;
+	GHT off = GHT_MAX;
 	char *path = strdup(map->name);
 	if (path && rz_file_exists(path)) {
-		vaddr = GH(get_va_symbol)(core, path, "main_arena");
-		if (vaddr != GHT_MAX) {
-			main_arena = base_addr + vaddr;
-		} else {
-			vaddr = GH(get_va_symbol)(core, path, "__malloc_hook");
-			if (vaddr == GHT_MAX) {
-				return main_arena;
+		off = GH(get_va_symbol)(core, path, "main_arena");
+		if (off != GHT_MAX) {
+			main_arena = base_addr + off;
+			goto beach;
+		}
+		RzBinInfo *info = rz_bin_get_info(core->bin);
+		if (!strcmp(info->arch, "x86") && info->bits == 64 &&
+			// Assumes that the vaddr of LOAD0 is 0x0
+			(off = GH(get_va_symbol)(core, path, "mallopt")) != GHT_MAX) {
+			// This code looks for the following instructions:
+			//     mov edx, 1
+			//     (lock) cmpxchg dword [<main_arena_addr>], edx
+			//
+			// The instructions should be part of the following C
+			// code in mallopt():
+			//     __libc_lock_lock (av->mutex);
+			ut64 mallopt_addr = base_addr + off;
+			ut8 bytes[200] = { 0 };
+			rz_io_read_at(core->io, mallopt_addr, bytes, sizeof(bytes));
+			const ut8 mov[] = { 0xba, 0x1, 0x0, 0x0, 0x0 };
+			const ut8 cmpxchg[] = { 0x0f, 0xb1, 0x15 };
+			const ut8 *mov_ptr = rz_mem_mem(bytes, sizeof(bytes), mov, sizeof(mov));
+			if (!mov_ptr ||
+				sizeof(bytes) - (mov_ptr - bytes) <
+					sizeof(mov) + 1 /* LOCK */ + sizeof(cmpxchg) + sizeof(ut32)) {
+				goto beach;
 			}
-			RzBinInfo *info = rz_bin_get_info(core->bin);
-			if (!strcmp(info->arch, "x86")) {
-				main_arena = GH(align_address_to_size)(vaddr + base_addr + sizeof(GHT), 0x20);
-			} else if (!strcmp(info->arch, "arm")) {
-				main_arena = vaddr + base_addr - sizeof(GHT) * 2 - sizeof(MallocState);
+			const ut8 *cmpxchg_ptr = mov_ptr + sizeof(mov);
+			if (*cmpxchg_ptr == 0xf0) { // LOCK prefix
+				cmpxchg_ptr++;
 			}
+			if (memcmp(cmpxchg_ptr, cmpxchg, sizeof(cmpxchg))) {
+				goto beach;
+			}
+			const ut8 *main_arena_off_ptr = cmpxchg_ptr + sizeof(cmpxchg);
+			ut32 main_arena_off = rz_read_le32(main_arena_off_ptr);
+			ut64 rip_addr = (main_arena_off_ptr + sizeof(ut32) - bytes) + mallopt_addr;
+			main_arena = rip_addr + main_arena_off;
+			goto beach;
 		}
 	}
+beach:
 	free(path);
 	return main_arena;
 }
@@ -399,6 +425,10 @@ static void GH(print_arena_stats)(RzCore *core, GHT m_arena, MallocState *main_a
 	PRINT_GA("}\n\n");
 }
 
+static inline bool is_map_name_libc(const char *map_name) {
+	return strstr(map_name, "/libc-") || strstr(map_name, "/libc.");
+}
+
 /**
  * \brief Store the base address of main arena at m_arena
  * \param core RzCore pointer
@@ -422,11 +452,11 @@ RZ_API bool GH(rz_heap_resolve_main_arena)(RzCore *core, GHT *m_arena) {
 		rz_debug_map_sync(core->dbg);
 		rz_list_foreach (core->dbg->maps, iter, map) {
 			/* Try to find the main arena address using the glibc's symbols. */
-			if (strstr(map->name, "/libc-") && first_libc && main_arena_sym == GHT_MAX) {
+			if (is_map_name_libc(map->name) && first_libc && main_arena_sym == GHT_MAX) {
 				first_libc = false;
 				main_arena_sym = GH(get_main_arena_with_symbol)(core, map);
 			}
-			if (strstr(map->name, "/libc-") && map->perm == RZ_PERM_RW) {
+			if (is_map_name_libc(map->name) && map->perm == RZ_PERM_RW) {
 				libc_addr_sta = map->addr;
 				libc_addr_end = map->addr_end;
 				break;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Currently the "dmhd with no allocated bins" test of `db/archos/linux-x64/dbg_dmhd` fails under `ubuntu-22.04` (https://github.com/rizinorg/rizin/actions/runs/3489207377/jobs/5839022868#step:19:224):

![dmhd_no_allocated_bins](https://user-images.githubusercontent.com/12002672/203059583-4b4e51c2-5ab5-439b-9f29-aec7887a21dc.PNG)

This pr fixes this by partially rewriting `GH(get_main_arena_with_symbol)` so that it gets the main arena address off `mallopt()` code (details are in the comments). For context, the C line mentioned in the comments is [this line](https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;h=fe9cb9b800a0098a080bdfdaaacbcbed3bf5b164;hb=refs/heads/release/2.35/master#l5452). Since getting the main arena address off the address of `__malloc_hook` seems somewhat arbitrary, all code based on `__malloc_hook` has been removed, including arm support.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...

----

This is a cherry-pick from #3066.