### PR TITLE
rz_heap_glibc.h: Add `have_fastchunks` member to `RzHeap_MallocState_` structs

### DIFF
--- a/librz/include/rz_heap_glibc.h
+++ b/librz/include/rz_heap_glibc.h
@@ -117,6 +117,7 @@ typedef RzHeapChunk32 *mchunkptr32;
 typedef struct rz_malloc_state_32 {
 	int mutex; /* serialized access */
 	int flags; /* flags */
+	int have_fastchunks; /* new free blocks in fastbin chunks? */
 	ut32 fastbinsY[NFASTBINS]; /* array of fastchunks */
 	ut32 top; /* top chunk's base addr */
 	ut32 last_remainder; /* remainder top chunk's addr */
@@ -132,6 +133,7 @@ typedef struct rz_malloc_state_32 {
 typedef struct rz_malloc_state_64 {
 	int mutex; /* serialized access */
 	int flags; /* flags */
+	int have_fastchunks; /* new free blocks in fastbin chunks? */
 	ut64 fastbinsY[NFASTBINS]; /* array of fastchunks */
 	ut64 top; /* top chunk's base addr */
 	ut64 last_remainder; /* remainder top chunk's addr */

--- a/test/db/archos/linux-x64/dbg_dmh
+++ b/test/db/archos/linux-x64/dbg_dmh
@@ -19,18 +19,16 @@ FILE=bins/elf/simple_malloc_x86_64
 ARGS=-d
 CMDS=<<EOF
 dcu main
-dmh
+dmh | tail -n 2
 ?e ----
 7dso
-dmh
+dmh | tail -n 3
 EOF
-REGEXP_FILTER_OUT=(status=[a-z,[0]+)|(size=0x[a-f0-9]+)|-+|\n|[()]|Arena|Chunk
+REGEXP_FILTER_OUT=(status=[a-z,[0]+)|(size=0x[a-f0-9]+)|-+|\n|[()]|Chunk
 EXPECT=<<EOF
-Arena
 Chunk(status=allocated,size=0x11c10)
 Chunk(status=free[0m,size=0xf160)
 ----
-Arena
 Chunk(status=allocated,size=0x11c10)
 Chunk(status=allocated,size=0x20)
 Chunk(status=free[0m,size=0xf140)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Currently the "dmh allocated" test of `db/archos/linux-x64/dbg_dmh` fails under `ubuntu-22.04` (https://github.com/rizinorg/rizin/actions/runs/3528834952/jobs/5919333615#step:19:190):

![dmh_allocated](https://user-images.githubusercontent.com/12002672/203544323-62435ccf-b643-49c9-8bb8-9aaedbd6bef4.PNG)

This pr fixes this by adding the `have_fastchunks` member to the `RzHeap_MallocState_` structs.

Idk why the current code works with `ubuntu-20.04` but fails with `ubuntu-22.04` (_maybe_ it's because of padding decisions by the distribution compiler). However, the `have_fastchunks` member exists in `malloc_struct` (the struct for the glibc malloc main arena) under both [GLIBC 2.35](https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;h=fe9cb9b800a0098a080bdfdaaacbcbed3bf5b164;hb=refs/heads/release/2.35/master#l1835) (`ubuntu-22.04`) and [GLIBC 2.30](https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;h=8c68b21b2be16a088b0cf669fd1441ff98e4f178;hb=refs/heads/release/2.30/master#l1665) (`ubuntu-20.04`), therefore that member should definitely be in the `RzHeap_MallocState_` structs.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...

----

This is a cherry-pick from #3066.