### PR TITLE
Make color promt test not load user settings

### DIFF
--- a/test/db/tools/rz
+++ b/test/db/tools/rz
@@ -205,7 +205,7 @@ RUN
 
 NAME=color prompt
 FILE==
-CMDS=!rizin -e cfg.fortunes=0 -e scr.color=1 -c "< \nq\n" =
+CMDS=!rizin -e cfg.fortunes=0 -e scr.color=1 -N -c "< \nq\n" =
 EXPECT=<<EOF
 [2K[0m[33m[0x00000000]>[0m [33m[0x00000000]>[0m [2K[33m[0x00000000]>[0m 
 [2K[0m[33m[0x00000000]>[0m [33m[0x00000000]>[0m [2K[2K[0m[33m[0x00000000]>[0m q[33m[0x00000000]>[0m q[2K[33m[0x00000000]>[0m q


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

When a color theme is set in rizinrc, this test would fail.