### PR TITLE
rz_debug_trace_ins_after: Downgrade `dbg->cur_op` guard

### DIFF
--- a/librz/debug/trace.c
+++ b/librz/debug/trace.c
@@ -112,7 +112,10 @@ RZ_API bool rz_debug_trace_ins_before(RzDebug *dbg) {
 }
 
 RZ_API bool rz_debug_trace_ins_after(RzDebug *dbg) {
-	rz_return_val_if_fail(dbg->cur_op, false);
+	// rz_return_val_if_fail(dbg->cur_op, false);
+	if (!dbg->cur_op) { // Can happen if hard stepping is available and code is unknown to Rizin
+		return false;
+	}
 	RzListIter *it;
 	RzAnalysisValue *val;
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Currently the "dbg.manycontback" test of `db/archos/linux-x64/dbg_cont_back` can (but not always) fail under `ubuntu-22.04` with `-DRZ_ASSERT_STDOUT=1` (https://github.com/rizinorg/rizin/actions/runs/3553623604/jobs/5969831923#step:19:768):

![trace_ins_before-failed](https://user-images.githubusercontent.com/12002672/204135336-4cc37d70-4c80-4e83-a79f-5f3c4a98129c.PNG)


This pr fixes this by downgrading the `dbg->cur_op` guard in `rz_debug_trace_ins_after()` from `rz_return_val_if_fail` to a normal `if` statement. Possibly a `PTRACE_PEEKTEXT`-based solution would be better -- unfortunately I cannot reproduce the failure locally to test such a solution.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...

----

This is a cherry-pick from #3066.