### PR TITLE
Add version checks for Capstone so that x86 IL compiles for v3

### DIFF
--- a/librz/analysis/arch/x86/x86_il.c
+++ b/librz/analysis/arch/x86/x86_il.c
@@ -95,6 +95,7 @@ static const char *x86_registers[] = {
 	[X86_REG_DR5] = "dr5",
 	[X86_REG_DR6] = "dr6",
 	[X86_REG_DR7] = "dr7",
+#if CS_API_MAJOR >= 4
 	[X86_REG_DR8] = "dr8",
 	[X86_REG_DR9] = "dr9",
 	[X86_REG_DR10] = "dr10",
@@ -103,6 +104,7 @@ static const char *x86_registers[] = {
 	[X86_REG_DR13] = "dr13",
 	[X86_REG_DR14] = "dr14",
 	[X86_REG_DR15] = "dr15",
+#endif
 	[X86_REG_FP0] = "fp0",
 	[X86_REG_FP1] = "fp1",
 	[X86_REG_FP2] = "fp2",
@@ -885,6 +887,12 @@ static RzILOpPure *x86_il_get_operand_bits(X86Op op, int analysis_bits) {
 		break;
 	case X86_OP_MEM:
 		ret = LOADW(BITS_PER_BYTE * op.size, x86_il_get_memaddr_bits(op.mem, analysis_bits));
+		break;
+#if CS_API_MAJOR <= 3
+	case X86_OP_FP:
+		RZ_LOG_WARN("RzIL: x86: Floating point instructions not implemented yet\n");
+		break;
+#endif
 	}
 	return ret;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Now the x86 IL lifting compiles for all supported Capstone versions (`bundled`, `v3`, `v4`, `next`).

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Green CI.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #3209.
