### PR TITLE
added vn_next break condition

### DIFF
--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -1292,6 +1292,10 @@ static Sdb *get_gnu_verneed(ELFOBJ *bin) {
 
 		sdb_free(sdb_version);
 
+		if (!verneed_entry.vn_next) {
+			break;	
+		}
+		
 		verneed_offset += verneed_entry.vn_next;
 	}
 

--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -1293,9 +1293,9 @@ static Sdb *get_gnu_verneed(ELFOBJ *bin) {
 		sdb_free(sdb_version);
 
 		if (!verneed_entry.vn_next) {
-			break;	
+			break;
 		}
-		
+
 		verneed_offset += verneed_entry.vn_next;
 	}
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

if the dynamic section's verneednum mismatches the true number of entries then the for loop in get_gnu_verneed will continue to iterate on the last entry since vn_next will be 0 on the last entry. If verneednum is set to all 0xff's it will take a very long time to finish this loop naturally drastically hindering binary load time. The solution is simple, to check for when vn_next == 0 and break out of the loop since all entries have been iterated over regardless of what verneednum indicates.

**Test plan**

Copy a binary, /bin/ls, to a test location
Use readelf -d to get the offset into the file for the dynamic section
Hex edit verneednum to all 0xff's
Run rizin ./testbin

