### PR TITLE
For gcc, use `${CC}` when setting `ASAN_LD_PRELOAD`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
               export ASAN_LD_PRELOAD=$(clang -print-file-name=libclang_rt.asan-x86_64.so)
               export LD_LIBRARY_PATH=$(dirname $(clang -print-file-name=libclang_rt.asan-x86_64.so)):${LD_LIBRARY_PATH}
             else
-              export ASAN_LD_PRELOAD=$(gcc -print-file-name=libasan.so)
+              export ASAN_LD_PRELOAD=$(${CC} -print-file-name=libasan.so)
             fi
           fi
           meson test -C build --suite unit
@@ -264,7 +264,7 @@ jobs:
               export ASAN_LD_PRELOAD=$(clang -print-file-name=libclang_rt.asan-x86_64.so)
               export LD_LIBRARY_PATH=$(dirname $(clang -print-file-name=libclang_rt.asan-x86_64.so)):${LD_LIBRARY_PATH}
             else
-              export ASAN_LD_PRELOAD=$(gcc -print-file-name=libasan.so)
+              export ASAN_LD_PRELOAD=$(${CC} -print-file-name=libasan.so)
             fi
           fi
           meson test -C build --suite integration


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr changes `ci.yml` so that `${CC}` is used instead of `gcc` when setting `ASAN_LD_PRELOAD`. This change should make it easy to use gcc versions other than the default for the gcc ASAN build.

This is a cherry-pick from #3066.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
