### PR TITLE
Fix leaks in rz_type and tests

### DIFF
--- a/librz/type/base.c
+++ b/librz/type/base.c
@@ -204,7 +204,9 @@ RZ_API RZ_OWN char *rz_type_db_base_type_as_string(const RzTypeDB *typedb, RZ_NO
 	rz_return_val_if_fail(typedb && btype, NULL);
 
 	RzType *type = rz_type_identifier_of_base_type(typedb, btype, false);
-	return rz_type_as_pretty_string(typedb, type, NULL, RZ_TYPE_PRINT_NO_END_SEMICOLON | RZ_TYPE_PRINT_ZERO_VLA, 1);
+	char *ret = rz_type_as_pretty_string(typedb, type, NULL, RZ_TYPE_PRINT_NO_END_SEMICOLON | RZ_TYPE_PRINT_ZERO_VLA, 1);
+	rz_type_free(type);
+	return ret;
 }
 
 /**

--- a/librz/type/parser/c_cpp_parser.c
+++ b/librz/type/parser/c_cpp_parser.c
@@ -286,7 +286,9 @@ RZ_API int rz_type_parse_string(RzTypeDB *typedb, const char *code, char **error
 		return -1;
 	}
 	state->verbose = verbose;
-	return type_parse_string(state, code, error_msg);
+	int ret = type_parse_string(state, code, error_msg);
+	c_parser_state_free_keep_ht(state);
+	return ret;
 }
 
 /**

--- a/librz/type/parser/types_parser.c
+++ b/librz/type/parser/types_parser.c
@@ -566,6 +566,7 @@ int parse_struct_node(CParserState *state, TSNode node, const char *text, Parser
 				.offset = 0, // FIXME
 				.size = 0, // FIXME
 			};
+			free(membtpair);
 			void *element = rz_vector_push(members, &memb); // returns null if no space available
 			if (!element) {
 				parser_error(state, "Error appending struct member to the base type\n");
@@ -856,6 +857,7 @@ int parse_union_node(CParserState *state, TSNode node, const char *text, ParserT
 				.offset = 0, // Always 0 for unions
 				.size = 0, // FIXME
 			};
+			free(membtpair);
 			void *element = rz_vector_push(members, &memb); // returns null if no space available
 			if (!element) {
 				parser_error(state, "Error appending union member to the base type\n");
@@ -1273,6 +1275,7 @@ int parse_parameter_list(CParserState *state, TSNode paramlist, const char *text
 			return -1;
 		}
 		if (!argtpair || !argtpair->type) {
+			free(argtpair);
 			return -1;
 		}
 		// Store the parameters if available
@@ -1281,7 +1284,9 @@ int parse_parameter_list(CParserState *state, TSNode paramlist, const char *text
 			identifier = rz_str_newf("arg%d", i);
 		}
 		parser_debug(state, "Adding \"%s\" parameter\n", identifier);
-		if (!c_parser_new_callable_argument(state, (*tpair)->type->callable, identifier, argtpair->type)) {
+		RzType *argtp = argtpair->type;
+		free(argtpair);
+		if (!c_parser_new_callable_argument(state, (*tpair)->type->callable, identifier, argtp)) {
 			parser_error(state, "ERROR: Cannot add the parameter to the function!\n");
 			free(identifier);
 			return -1;
@@ -1904,6 +1909,11 @@ int parse_type_nodes_save(CParserState *state, TSNode node, const char *text) {
 		if (result || !tpair) {
 			return -1;
 		}
+	}
+
+	if (tpair) {
+		rz_type_free(tpair->type);
+		free(tpair);
 	}
 
 	if (result) {

--- a/librz/type/serialize_types.c
+++ b/librz/type/serialize_types.c
@@ -130,6 +130,7 @@ static TypeFormatPair *get_struct_type(RzTypeDB *typedb, Sdb *sdb, const char *s
 			char *error_msg = NULL;
 			RzType *ttype = rz_type_parse_string_single(typedb->parser, type, &error_msg);
 			if (!ttype || error_msg) {
+				free(error_msg);
 				free(values);
 				goto error;
 			}

--- a/librz/type/type.c
+++ b/librz/type/type.c
@@ -14,6 +14,10 @@ static void types_ht_free(HtPPKv *kv) {
 	rz_type_base_type_free(kv->value);
 }
 
+static void types_ht_free_keep_val(HtPPKv *kv) {
+	free(kv->key);
+}
+
 static void formats_ht_free(HtPPKv *kv) {
 	free(kv->key);
 	free(kv->value);
@@ -1311,7 +1315,7 @@ RZ_API bool rz_type_db_edit_base_type(RzTypeDB *typedb, RZ_NONNULL const char *n
 	// Remove the original type first
 	// but do not free them
 	void *freefn = (void *)typedb->types->opt.freefn;
-	typedb->types->opt.freefn = NULL;
+	typedb->types->opt.freefn = types_ht_free_keep_val;
 	ht_pp_delete(typedb->types, t->name);
 	typedb->types->opt.freefn = freefn;
 	char *error_msg = NULL;

--- a/test/unit/test_type.c
+++ b/test/unit/test_type.c
@@ -100,14 +100,14 @@ static bool test_types_get_base_type_struct(void) {
 	mu_assert_true(rz_type_atomic_str_eq(typedb, member->type, "int32_t"), "Incorrect type for struct member");
 	mu_assert_streq(member->name, "cow", "Incorrect name for struct member");
 
-	mu_assert_streq(rz_type_db_base_type_as_string(typedb, base), "struct kappa { int32_t bar; int32_t cow; }", "Incorrect conversion of struct to string");
+	mu_assert_streq_free(rz_type_db_base_type_as_string(typedb, base), "struct kappa { int32_t bar; int32_t cow; }", "Incorrect conversion of struct to string");
 
 	RzBaseType *base2 = rz_type_db_get_base_type(typedb, "lappa");
 	mu_assert_notnull(base2, "Couldn't create get base type of struct \"lappa\"");
 
 	mu_assert_eq(RZ_BASE_TYPE_KIND_STRUCT, base2->kind, "Wrong base type");
 	mu_assert_streq(base2->name, "lappa", "type name");
-	mu_assert_streq(rz_type_db_base_type_as_string(typedb, base2), "struct lappa { int32_t bar; struct kappa cow; }", "Incorrect conversion of struct to string");
+	mu_assert_streq_free(rz_type_db_base_type_as_string(typedb, base2), "struct lappa { int32_t bar; struct kappa cow; }", "Incorrect conversion of struct to string");
 
 	rz_type_db_free(typedb);
 	mu_end;
@@ -139,13 +139,13 @@ static bool test_types_get_base_type_union(void) {
 	mu_assert_true(rz_type_atomic_str_eq(typedb, member->type, "int32_t"), "Incorrect type for union member");
 	mu_assert_streq(member->name, "cow", "Incorrect name for union member");
 
-	mu_assert_streq(rz_type_db_base_type_as_string(typedb, base), "union kappa { int32_t bar; int32_t cow; }", "Incorrect conversion of union to string");
+	mu_assert_streq_free(rz_type_db_base_type_as_string(typedb, base), "union kappa { int32_t bar; int32_t cow; }", "Incorrect conversion of union to string");
 
 	RzBaseType *base2 = rz_type_db_get_base_type(typedb, "lappa");
 	mu_assert_notnull(base2, "Couldn't create get base type of union \"lappa\"");
 	mu_assert_eq(RZ_BASE_TYPE_KIND_UNION, base2->kind, "Wrong base type");
 	mu_assert_streq(base2->name, "lappa", "type name");
-	mu_assert_streq(rz_type_db_base_type_as_string(typedb, base2), "union lappa { int32_t bar; union kappa cow; }", "Incorrect conversion of union to string");
+	mu_assert_streq_free(rz_type_db_base_type_as_string(typedb, base2), "union lappa { int32_t bar; union kappa cow; }", "Incorrect conversion of union to string");
 
 	rz_type_db_free(typedb);
 	mu_end;
@@ -599,7 +599,7 @@ static bool test_type_as_pretty_string(void) {
 	char *pretty_str = rz_type_as_pretty_string(typedb, ttype, "c", RZ_TYPE_PRINT_NO_OPTS, 1);
 	mu_assert_streq(pretty_str, pretty_complex_const_pointer, "complex const pointer type is ugly");
 	free(pretty_str);
-	free(ttype);
+	rz_type_free(ttype);
 
 	error_msg = NULL;
 	ttype = rz_type_parse_string_single(typedb->parser, pretty_struct_array_ptr_func_ptr, &error_msg);
@@ -611,7 +611,7 @@ static bool test_type_as_pretty_string(void) {
 	pretty_str = rz_type_as_pretty_string(typedb, ttype, "leet", RZ_TYPE_PRINT_MULTILINE, 1);
 	mu_assert_streq(pretty_str, pretty_struct_array_ptr_func_ptr_multiline, "struct array ptr func ptr type multiline is ugly");
 	free(pretty_str);
-	free(ttype);
+	rz_type_free(ttype);
 
 	error_msg = NULL;
 	ttype = rz_type_parse_string_single(typedb->parser, pretty_struct_in_struct, &error_msg);
@@ -638,7 +638,7 @@ static bool test_type_as_pretty_string(void) {
 	pretty_str = rz_type_as_pretty_string(typedb, ttype, NULL, RZ_TYPE_PRINT_UNFOLD_ANON_ONLY, -1);
 	mu_assert_streq(pretty_str, pretty_struct_in_struct, "struct in struct type anon unfold is ugly");
 	free(pretty_str);
-	free(ttype);
+	rz_type_free(ttype);
 
 	error_msg = NULL;
 	ttype = rz_type_parse_string_single(typedb->parser, pretty_union_of_struct, &error_msg);
@@ -656,7 +656,7 @@ static bool test_type_as_pretty_string(void) {
 	pretty_str = rz_type_as_pretty_string(typedb, ttype, "maxmult", RZ_TYPE_PRINT_MULTILINE, -3);
 	mu_assert_streq(pretty_str, pretty_union_of_struct_max_multiline, "union of struct type max multiline is ugly");
 	free(pretty_str);
-	free(ttype);
+	rz_type_free(ttype);
 
 	error_msg = NULL;
 	ttype = rz_type_parse_string_single(typedb->parser, pretty_enum, &error_msg);
@@ -668,7 +668,7 @@ static bool test_type_as_pretty_string(void) {
 	pretty_str = rz_type_as_pretty_string(typedb, ttype, "enumult", RZ_TYPE_PRINT_MULTILINE, -2);
 	mu_assert_streq(pretty_str, pretty_enum_multiline, "enum type multiline is ugly");
 	free(pretty_str);
-	free(ttype);
+	rz_type_free(ttype);
 
 	error_msg = NULL;
 	ttype = rz_type_parse_string_single(typedb->parser, "time_t;", &error_msg);
@@ -677,6 +677,7 @@ static bool test_type_as_pretty_string(void) {
 	pretty_str = rz_type_as_pretty_string(typedb, ttype, NULL, RZ_TYPE_PRINT_SHOW_TYPEDEF, 10);
 	mu_assert_streq(pretty_str, pretty_simple_typedef, "simple typedef type is ugly");
 	free(pretty_str);
+	rz_type_free(ttype);
 
 	error_msg = NULL;
 	ttype = rz_type_parse_string_single(typedb->parser, "non_t existent;", &error_msg);
@@ -685,7 +686,9 @@ static bool test_type_as_pretty_string(void) {
 	pretty_str = rz_type_as_pretty_string(typedb, ttype, NULL, RZ_TYPE_PRINT_SHOW_TYPEDEF, 10);
 	mu_assert_streq(pretty_str, "unknown_t;", "unknown type is ugly");
 	free(pretty_str);
+	rz_type_free(ttype);
 
+	rz_type_db_free(typedb);
 	mu_end;
 }
 
@@ -775,7 +778,7 @@ static bool test_struct_func_types(void) {
 	mu_assert_eq(RZ_TYPE_KIND_CALLABLE, member->type->pointer.type->kind, "not function pointer");
 
 	RzCallable *call = member->type->pointer.type->callable;
-	mu_assert_streq(rz_type_as_string(typedb, call->ret), "wchar_t", "function return type");
+	mu_assert_streq_free(rz_type_as_string(typedb, call->ret), "wchar_t", "function return type");
 
 	RzCallableArg *arg;
 	arg = *rz_pvector_index_ptr(call->args, 0);
@@ -846,6 +849,7 @@ static bool test_struct_array_types(void) {
 	mu_assert_true(ttype->kind == RZ_TYPE_KIND_IDENTIFIER, "is identifier");
 	mu_assert_false(ttype->identifier.is_const, "identifier not const");
 	mu_assert_streq(ttype->identifier.name, "albalb", "albalb struct");
+	rz_type_free(ttype);
 
 	RzBaseType *base = rz_type_db_get_base_type(typedb, "albalb");
 	mu_assert_eq(RZ_BASE_TYPE_KIND_STRUCT, base->kind, "not struct");
@@ -869,13 +873,13 @@ static bool test_struct_array_types(void) {
 	mu_assert_true(ttype->kind == RZ_TYPE_KIND_IDENTIFIER, "is identifier");
 	mu_assert_false(ttype->identifier.is_const, "identifier not const");
 	mu_assert_streq(ttype->identifier.name, "alb", "albalb struct");
+	rz_type_free(ttype);
 
 	base = rz_type_db_get_base_type(typedb, "alb");
 	mu_assert_eq(RZ_BASE_TYPE_KIND_STRUCT, base->kind, "not struct");
 	mu_assert_streq(base->name, "alb", "type name");
 	mu_assert_streq_free(rz_type_db_base_type_as_string(typedb, base), array_ptr_struct_test, "type as string with multidimensional array of pointers");
 
-	rz_type_free(ttype);
 	rz_type_db_free(typedb);
 	mu_end;
 }
@@ -952,6 +956,7 @@ static bool test_edit_types(void) {
 	mu_assert_notnull(ttype, "array type parse successfull");
 	const char *id1 = rz_type_identifier(ttype);
 	mu_assert_false(rz_type_db_edit_base_type(typedb, id1, edit_array_old), "edit atomic base type");
+	rz_type_free(ttype);
 
 	ttype = rz_type_parse_string_single(typedb->parser, edit_struct_array_ptr_old, &error_msg);
 	mu_assert_notnull(ttype, "struct type parse successfull");
@@ -1014,6 +1019,7 @@ bool test_addr_bits(void) {
 	mu_assert_eq(rz_type_db_pointer_size(typedb), 32, "ptr size");
 	rz_type_db_set_bits(typedb, 16);
 	mu_assert_eq(rz_type_db_pointer_size(typedb), 32, "ptr size");
+	rz_type_db_free(typedb);
 	mu_end;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

All leaks detected by running valgrind on test/unit/test_type

```
florian@florian-desktop ~/dev/rizin $ valgrind --leak-check=full build/test/unit/test_type
==12767== Memcheck, a memory error detector
==12767== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==12767== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==12767== Command: build/test/unit/test_type
==12767==
test_types_get_base_type_struct OK
test_types_get_base_type_union OK
test_types_get_base_type_enum OK
test_types_get_base_type_typedef OK
test_types_get_base_type_atomic OK
test_types_get_base_type_not_found OK
test_types_get_base_types OK
test_types_get_base_types_of_kind OK
test_type_as_string OK
test_type_as_pretty_string OK
test_enum_types OK
test_const_types OK
test_array_types OK
test_struct_func_types OK
test_struct_array_types OK
test_struct_identifier_without_specifier OK
test_union_identifier_without_specifier OK
ERROR: Atomic type "int"
test_edit_types OK
test_references OK
test_addr_bits OK
==12767==
==12767== HEAP SUMMARY:
==12767==     in use at exit: 204,272 bytes in 9,151 blocks
==12767==   total heap usage: 265,095 allocs, 255,944 frees, 153,913,242 bytes allocated
==12767==
==12767== 1 bytes in 1 blocks are definitely lost in loss record 1 of 334
==12767==    at 0x48447B5: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x4B2ABEA: strdup (strdup.c:42)
==12767==    by 0x49DC7A8: rz_type_parse_string_single (c_cpp_parser.c:382)
==12767==    by 0x49D40F8: get_struct_type (serialize_types.c:131)
==12767==    by 0x49D4C6D: sdb_load_base_types (serialize_types.c:327)
==12767==    by 0x49D5F9E: types_load_sdb (serialize_types.c:596)
==12767==    by 0x49D63B5: rz_serialize_types_load (serialize_types.c:690)
==12767==    by 0x10E216: test_types_get_base_type_not_found (test_type.c:234)
==12767==    by 0x11E043: all_tests (test_type.c:1026)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 4 bytes in 1 blocks are definitely lost in loss record 22 of 334
==12767==    at 0x48447B5: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x4B2ABEA: strdup (strdup.c:42)
==12767==    by 0x49E605A: c_parser_new_structure_naked_type (types_storage.c:251)
==12767==    by 0x49E616C: c_parser_new_structure_type (types_storage.c:281)
==12767==    by 0x49DEA92: parse_struct_node (types_parser.c:376)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x113C30: test_type_as_pretty_string (test_type.c:605)
==12767==    by 0x11E18F: all_tests (test_type.c:1030)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 4 bytes in 1 blocks are definitely lost in loss record 23 of 334
==12767==    at 0x48447B5: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x4B2ABEA: strdup (strdup.c:42)
==12767==    by 0x49E605A: c_parser_new_structure_naked_type (types_storage.c:251)
==12767==    by 0x49E616C: c_parser_new_structure_type (types_storage.c:281)
==12767==    by 0x49DEA92: parse_struct_node (types_parser.c:376)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x1140AD: test_type_as_pretty_string (test_type.c:617)
==12767==    by 0x11E18F: all_tests (test_type.c:1030)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 4 bytes in 1 blocks are definitely lost in loss record 24 of 334
==12767==    at 0x48447B5: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x4B2ABEA: strdup (strdup.c:42)
==12767==    by 0x49E686D: c_parser_new_enum_naked_type (types_storage.c:506)
==12767==    by 0x49E697F: c_parser_new_enum_type (types_storage.c:536)
==12767==    by 0x49E144D: parse_enum_node (types_parser.c:950)
==12767==    by 0x49E2559: parse_type_node_single (types_parser.c:1194)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x115384: test_type_as_pretty_string (test_type.c:662)
==12767==    by 0x11E18F: all_tests (test_type.c:1030)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 4 bytes in 1 blocks are definitely lost in loss record 25 of 334
==12767==    at 0x48447B5: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x4B2ABEA: strdup (strdup.c:42)
==12767==    by 0x4914B20: dupkey (ht_inc.c:31)
==12767==    by 0x49153FF: insert_update (ht_inc.c:236)
==12767==    by 0x4915485: ht_pp_insert (ht_inc.c:247)
==12767==    by 0x49E585E: c_parser_base_type_store (types_storage.c:46)
==12767==    by 0x49DF960: parse_struct_node (types_parser.c:580)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x11CE0E: test_edit_types (test_type.c:956)
==12767==    by 0x11E427: all_tests (test_type.c:1038)
==12767==
==12767== 6 bytes in 1 blocks are definitely lost in loss record 39 of 334
==12767==    at 0x48447B5: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x4B2ABEA: strdup (strdup.c:42)
==12767==    by 0x49E6463: c_parser_new_union_naked_type (types_storage.c:378)
==12767==    by 0x49E6575: c_parser_new_union_type (types_storage.c:408)
==12767==    by 0x49DFF7F: parse_union_node (types_parser.c:668)
==12767==    by 0x49E24F4: parse_type_node_single (types_parser.c:1189)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x114C35: test_type_as_pretty_string (test_type.c:644)
==12767==    by 0x11E18F: all_tests (test_type.c:1030)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 8 bytes in 1 blocks are definitely lost in loss record 51 of 334
==12767==    at 0x48447B5: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x4B2ABEA: strdup (strdup.c:42)
==12767==    by 0x48F3C74: drain (strbuf.c:339)
==12767==    by 0x48F3CCF: rz_strbuf_drain (strbuf.c:344)
==12767==    by 0x49D9EEB: type_as_pretty_string (type.c:1116)
==12767==    by 0x49D9FF3: rz_type_as_pretty_string (type.c:1141)
==12767==    by 0x49D8A0D: rz_type_as_string (type.c:820)
==12767==    by 0x1184A9: test_struct_func_types (test_type.c:778)
==12767==    by 0x11E2DB: all_tests (test_type.c:1034)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 16 bytes in 1 blocks are definitely lost in loss record 62 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E607F: c_parser_new_structure_naked_type (types_storage.c:254)
==12767==    by 0x49E62E7: c_parser_get_structure_type (types_storage.c:325)
==12767==    by 0x49DE8ED: parse_struct_node (types_parser.c:342)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x1140AD: test_type_as_pretty_string (test_type.c:617)
==12767==    by 0x11E18F: all_tests (test_type.c:1030)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 16 bytes in 1 blocks are definitely lost in loss record 63 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E607F: c_parser_new_structure_naked_type (types_storage.c:254)
==12767==    by 0x49E62E7: c_parser_get_structure_type (types_storage.c:325)
==12767==    by 0x49DE8ED: parse_struct_node (types_parser.c:342)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E0C11: parse_union_node (types_parser.c:837)
==12767==    by 0x49E24F4: parse_type_node_single (types_parser.c:1189)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x114C35: test_type_as_pretty_string (test_type.c:644)
==12767==    by 0x11E18F: all_tests (test_type.c:1030)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 16 bytes in 1 blocks are definitely lost in loss record 64 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E607F: c_parser_new_structure_naked_type (types_storage.c:254)
==12767==    by 0x49E616C: c_parser_new_structure_type (types_storage.c:281)
==12767==    by 0x49DEA92: parse_struct_node (types_parser.c:376)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E0C11: parse_union_node (types_parser.c:837)
==12767==    by 0x49E24F4: parse_type_node_single (types_parser.c:1189)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x114C35: test_type_as_pretty_string (test_type.c:644)
==12767==    by 0x11E18F: all_tests (test_type.c:1030)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 16 bytes in 1 blocks are definitely lost in loss record 65 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5F85: c_parser_get_primitive_type (types_storage.c:226)
==12767==    by 0x49DD748: parse_primitive_type (types_parser.c:100)
==12767==    by 0x49E2687: parse_type_node_single (types_parser.c:1209)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x11775D: test_struct_func_types (test_type.c:754)
==12767==    by 0x11E2DB: all_tests (test_type.c:1034)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 16 bytes in 1 blocks are definitely lost in loss record 66 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E705B: c_parser_get_typedef (types_storage.c:756)
==12767==    by 0x49DDD05: parse_sole_type_name (types_parser.c:172)
==12767==    by 0x49E26E5: parse_type_node_single (types_parser.c:1214)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x11775D: test_struct_func_types (test_type.c:754)
==12767==    by 0x11E2DB: all_tests (test_type.c:1034)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 16 bytes in 1 blocks are definitely lost in loss record 67 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5F85: c_parser_get_primitive_type (types_storage.c:226)
==12767==    by 0x49DD748: parse_primitive_type (types_parser.c:100)
==12767==    by 0x49E2687: parse_type_node_single (types_parser.c:1209)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x118B5C: test_struct_func_types (test_type.c:792)
==12767==    by 0x11E2DB: all_tests (test_type.c:1034)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 16 bytes in 1 blocks are definitely lost in loss record 68 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E705B: c_parser_get_typedef (types_storage.c:756)
==12767==    by 0x49DDD05: parse_sole_type_name (types_parser.c:172)
==12767==    by 0x49E26E5: parse_type_node_single (types_parser.c:1214)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x118B5C: test_struct_func_types (test_type.c:792)
==12767==    by 0x11E2DB: all_tests (test_type.c:1034)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 16 bytes in 1 blocks are definitely lost in loss record 69 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5F85: c_parser_get_primitive_type (types_storage.c:226)
==12767==    by 0x49DD748: parse_primitive_type (types_parser.c:100)
==12767==    by 0x49E2687: parse_type_node_single (types_parser.c:1209)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x11A27D: test_struct_array_types (test_type.c:844)
==12767==    by 0x11E32E: all_tests (test_type.c:1035)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 16 bytes in 1 blocks are definitely lost in loss record 70 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5F85: c_parser_get_primitive_type (types_storage.c:226)
==12767==    by 0x49DD748: parse_primitive_type (types_parser.c:100)
==12767==    by 0x49E2687: parse_type_node_single (types_parser.c:1209)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E548F: parse_type_nodes_save (types_parser.c:1877)
==12767==    by 0x49DBDFB: type_parse_string (c_cpp_parser.c:190)
==12767==    by 0x49DC2D2: rz_type_parse_string (c_cpp_parser.c:289)
==12767==    by 0x11BB5C: test_struct_identifier_without_specifier (test_type.c:891)
==12767==    by 0x11E381: all_tests (test_type.c:1036)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 16 bytes in 1 blocks are definitely lost in loss record 71 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5F85: c_parser_get_primitive_type (types_storage.c:226)
==12767==    by 0x49DD748: parse_primitive_type (types_parser.c:100)
==12767==    by 0x49E2687: parse_type_node_single (types_parser.c:1209)
==12767==    by 0x49E0C11: parse_union_node (types_parser.c:837)
==12767==    by 0x49E54F2: parse_type_nodes_save (types_parser.c:1882)
==12767==    by 0x49DBDFB: type_parse_string (c_cpp_parser.c:190)
==12767==    by 0x49DC2D2: rz_type_parse_string (c_cpp_parser.c:289)
==12767==    by 0x11C3D1: test_union_identifier_without_specifier (test_type.c:919)
==12767==    by 0x11E3D4: all_tests (test_type.c:1037)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 16 bytes in 1 blocks are definitely lost in loss record 72 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E705B: c_parser_get_typedef (types_storage.c:756)
==12767==    by 0x49DDD05: parse_sole_type_name (types_parser.c:172)
==12767==    by 0x49E26E5: parse_type_node_single (types_parser.c:1214)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E548F: parse_type_nodes_save (types_parser.c:1877)
==12767==    by 0x49DBDFB: type_parse_string (c_cpp_parser.c:190)
==12767==    by 0x49DC054: rz_type_parse_string_stateless (c_cpp_parser.c:228)
==12767==    by 0x49DA718: rz_type_db_edit_base_type (type.c:1318)
==12767==    by 0x11D067: test_edit_types (test_type.c:961)
==12767==    by 0x11E427: all_tests (test_type.c:1038)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 32 bytes in 2 blocks are definitely lost in loss record 124 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5F85: c_parser_get_primitive_type (types_storage.c:226)
==12767==    by 0x49DD748: parse_primitive_type (types_parser.c:100)
==12767==    by 0x49E2687: parse_type_node_single (types_parser.c:1209)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x1131D9: test_type_as_string (test_type.c:501)
==12767==    by 0x11E13C: all_tests (test_type.c:1029)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 32 bytes in 2 blocks are definitely lost in loss record 125 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5F85: c_parser_get_primitive_type (types_storage.c:226)
==12767==    by 0x49DD748: parse_primitive_type (types_parser.c:100)
==12767==    by 0x49E2687: parse_type_node_single (types_parser.c:1209)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x113C30: test_type_as_pretty_string (test_type.c:605)
==12767==    by 0x11E18F: all_tests (test_type.c:1030)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 32 bytes in 2 blocks are definitely lost in loss record 126 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E705B: c_parser_get_typedef (types_storage.c:756)
==12767==    by 0x49DDD05: parse_sole_type_name (types_parser.c:172)
==12767==    by 0x49E26E5: parse_type_node_single (types_parser.c:1214)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x113C30: test_type_as_pretty_string (test_type.c:605)
==12767==    by 0x11E18F: all_tests (test_type.c:1030)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 32 bytes in 2 blocks are definitely lost in loss record 127 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5F85: c_parser_get_primitive_type (types_storage.c:226)
==12767==    by 0x49DD748: parse_primitive_type (types_parser.c:100)
==12767==    by 0x49E2687: parse_type_node_single (types_parser.c:1209)
==12767==    by 0x49DE308: parse_parameter_declaration_node (types_parser.c:265)
==12767==    by 0x49E2A5E: parse_parameter_list (types_parser.c:1271)
==12767==    by 0x49E483D: parse_type_declarator_node (types_parser.c:1701)
==12767==    by 0x49DF7DC: parse_struct_node (types_parser.c:555)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x113C30: test_type_as_pretty_string (test_type.c:605)
==12767==
==12767== 32 bytes in 2 blocks are definitely lost in loss record 128 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5F85: c_parser_get_primitive_type (types_storage.c:226)
==12767==    by 0x49DD748: parse_primitive_type (types_parser.c:100)
==12767==    by 0x49E2687: parse_type_node_single (types_parser.c:1209)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E0C11: parse_union_node (types_parser.c:837)
==12767==    by 0x49E24F4: parse_type_node_single (types_parser.c:1189)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x114C35: test_type_as_pretty_string (test_type.c:644)
==12767==    by 0x11E18F: all_tests (test_type.c:1030)
==12767==
==12767== 32 bytes in 2 blocks are definitely lost in loss record 129 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5F85: c_parser_get_primitive_type (types_storage.c:226)
==12767==    by 0x49DD748: parse_primitive_type (types_parser.c:100)
==12767==    by 0x49E2687: parse_type_node_single (types_parser.c:1209)
==12767==    by 0x49DE308: parse_parameter_declaration_node (types_parser.c:265)
==12767==    by 0x49E2A5E: parse_parameter_list (types_parser.c:1271)
==12767==    by 0x49E483D: parse_type_declarator_node (types_parser.c:1701)
==12767==    by 0x49DF7DC: parse_struct_node (types_parser.c:555)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x11775D: test_struct_func_types (test_type.c:754)
==12767==
==12767== 32 bytes in 2 blocks are definitely lost in loss record 130 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5F85: c_parser_get_primitive_type (types_storage.c:226)
==12767==    by 0x49DD748: parse_primitive_type (types_parser.c:100)
==12767==    by 0x49E2687: parse_type_node_single (types_parser.c:1209)
==12767==    by 0x49DE308: parse_parameter_declaration_node (types_parser.c:265)
==12767==    by 0x49E2A5E: parse_parameter_list (types_parser.c:1271)
==12767==    by 0x49E483D: parse_type_declarator_node (types_parser.c:1701)
==12767==    by 0x49DF7DC: parse_struct_node (types_parser.c:555)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x118B5C: test_struct_func_types (test_type.c:792)
==12767==
==12767== 32 bytes in 2 blocks are definitely lost in loss record 131 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5F85: c_parser_get_primitive_type (types_storage.c:226)
==12767==    by 0x49DD748: parse_primitive_type (types_parser.c:100)
==12767==    by 0x49E2687: parse_type_node_single (types_parser.c:1209)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x11B229: test_struct_array_types (test_type.c:867)
==12767==    by 0x11E32E: all_tests (test_type.c:1035)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 32 bytes in 2 blocks are definitely lost in loss record 132 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5F85: c_parser_get_primitive_type (types_storage.c:226)
==12767==    by 0x49DD748: parse_primitive_type (types_parser.c:100)
==12767==    by 0x49E2687: parse_type_node_single (types_parser.c:1209)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x11CE0E: test_edit_types (test_type.c:956)
==12767==    by 0x11E427: all_tests (test_type.c:1038)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 32 bytes in 2 blocks are definitely lost in loss record 133 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5F85: c_parser_get_primitive_type (types_storage.c:226)
==12767==    by 0x49DD748: parse_primitive_type (types_parser.c:100)
==12767==    by 0x49E2687: parse_type_node_single (types_parser.c:1209)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E548F: parse_type_nodes_save (types_parser.c:1877)
==12767==    by 0x49DBDFB: type_parse_string (c_cpp_parser.c:190)
==12767==    by 0x49DC054: rz_type_parse_string_stateless (c_cpp_parser.c:228)
==12767==    by 0x49DA718: rz_type_db_edit_base_type (type.c:1318)
==12767==    by 0x11D067: test_edit_types (test_type.c:961)
==12767==    by 0x11E427: all_tests (test_type.c:1038)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 36 (32 direct, 4 indirect) bytes in 1 blocks are definitely lost in loss record 136 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49D0261: rz_type_identifier_of_base_type (helpers.c:17)
==12767==    by 0x49C3376: rz_type_db_base_type_as_string (base.c:206)
==12767==    by 0x110BCA: test_enum_types (test_type.c:396)
==12767==    by 0x11E1E2: all_tests (test_type.c:1031)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 36 (32 direct, 4 indirect) bytes in 1 blocks are definitely lost in loss record 137 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49D0261: rz_type_identifier_of_base_type (helpers.c:17)
==12767==    by 0x49C3376: rz_type_db_base_type_as_string (base.c:206)
==12767==    by 0x117D0C: test_struct_func_types (test_type.c:763)
==12767==    by 0x11E2DB: all_tests (test_type.c:1034)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 36 (32 direct, 4 indirect) bytes in 1 blocks are definitely lost in loss record 138 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49D0261: rz_type_identifier_of_base_type (helpers.c:17)
==12767==    by 0x49C3376: rz_type_db_base_type_as_string (base.c:206)
==12767==    by 0x11B7D8: test_struct_array_types (test_type.c:876)
==12767==    by 0x11E32E: all_tests (test_type.c:1035)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 38 (32 direct, 6 indirect) bytes in 1 blocks are definitely lost in loss record 139 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49D0261: rz_type_identifier_of_base_type (helpers.c:17)
==12767==    by 0x49C3376: rz_type_db_base_type_as_string (base.c:206)
==12767==    by 0x10B56A: test_types_get_base_type_struct (test_type.c:103)
==12767==    by 0x11DEA4: all_tests (test_type.c:1021)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 38 (32 direct, 6 indirect) bytes in 1 blocks are definitely lost in loss record 140 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49D0261: rz_type_identifier_of_base_type (helpers.c:17)
==12767==    by 0x49C3376: rz_type_db_base_type_as_string (base.c:206)
==12767==    by 0x10B98B: test_types_get_base_type_struct (test_type.c:110)
==12767==    by 0x11DEA4: all_tests (test_type.c:1021)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 38 (32 direct, 6 indirect) bytes in 1 blocks are definitely lost in loss record 141 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49D0261: rz_type_identifier_of_base_type (helpers.c:17)
==12767==    by 0x49C3376: rz_type_db_base_type_as_string (base.c:206)
==12767==    by 0x10C410: test_types_get_base_type_union (test_type.c:142)
==12767==    by 0x11DEF7: all_tests (test_type.c:1022)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 38 (32 direct, 6 indirect) bytes in 1 blocks are definitely lost in loss record 142 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49D0261: rz_type_identifier_of_base_type (helpers.c:17)
==12767==    by 0x49C3376: rz_type_db_base_type_as_string (base.c:206)
==12767==    by 0x10C831: test_types_get_base_type_union (test_type.c:148)
==12767==    by 0x11DEF7: all_tests (test_type.c:1022)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 38 (32 direct, 6 indirect) bytes in 1 blocks are definitely lost in loss record 143 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5D59: c_parser_new_primitive_type (types_storage.c:160)
==12767==    by 0x49DDEC9: parse_sole_type_name (types_parser.c:203)
==12767==    by 0x49E26E5: parse_type_node_single (types_parser.c:1214)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x115B06: test_type_as_pretty_string (test_type.c:682)
==12767==    by 0x11E18F: all_tests (test_type.c:1030)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 39 (32 direct, 7 indirect) bytes in 1 blocks are definitely lost in loss record 145 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E7006: c_parser_get_typedef (types_storage.c:747)
==12767==    by 0x49DDD05: parse_sole_type_name (types_parser.c:172)
==12767==    by 0x49E26E5: parse_type_node_single (types_parser.c:1214)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x115801: test_type_as_pretty_string (test_type.c:674)
==12767==    by 0x11E18F: all_tests (test_type.c:1030)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 39 (32 direct, 7 indirect) bytes in 1 blocks are definitely lost in loss record 146 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49D0261: rz_type_identifier_of_base_type (helpers.c:17)
==12767==    by 0x49C3376: rz_type_db_base_type_as_string (base.c:206)
==12767==    by 0x11910B: test_struct_func_types (test_type.c:801)
==12767==    by 0x11E2DB: all_tests (test_type.c:1034)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 39 (32 direct, 7 indirect) bytes in 1 blocks are definitely lost in loss record 147 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E602A: c_parser_new_structure_naked_type (types_storage.c:245)
==12767==    by 0x49E616C: c_parser_new_structure_type (types_storage.c:281)
==12767==    by 0x49DEA92: parse_struct_node (types_parser.c:376)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x11A27D: test_struct_array_types (test_type.c:844)
==12767==    by 0x11E32E: all_tests (test_type.c:1035)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 39 (32 direct, 7 indirect) bytes in 1 blocks are definitely lost in loss record 148 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49D0261: rz_type_identifier_of_base_type (helpers.c:17)
==12767==    by 0x49C3376: rz_type_db_base_type_as_string (base.c:206)
==12767==    by 0x11A82C: test_struct_array_types (test_type.c:853)
==12767==    by 0x11E32E: all_tests (test_type.c:1035)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 48 bytes in 3 blocks are definitely lost in loss record 162 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E5F85: c_parser_get_primitive_type (types_storage.c:226)
==12767==    by 0x49DD748: parse_primitive_type (types_parser.c:100)
==12767==    by 0x49E2687: parse_type_node_single (types_parser.c:1209)
==12767==    by 0x49DF730: parse_struct_node (types_parser.c:547)
==12767==    by 0x49E248F: parse_type_node_single (types_parser.c:1184)
==12767==    by 0x49E4CEA: parse_type_descriptor_single (types_parser.c:1768)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x1140AD: test_type_as_pretty_string (test_type.c:617)
==12767==    by 0x11E18F: all_tests (test_type.c:1030)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 52 (16 direct, 36 indirect) bytes in 1 blocks are definitely lost in loss record 163 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E607F: c_parser_new_structure_naked_type (types_storage.c:254)
==12767==    by 0x49E616C: c_parser_new_structure_type (types_storage.c:281)
==12767==    by 0x49DEA92: parse_struct_node (types_parser.c:376)
==12767==    by 0x49E548F: parse_type_nodes_save (types_parser.c:1877)
==12767==    by 0x49DBDFB: type_parse_string (c_cpp_parser.c:190)
==12767==    by 0x49DC2D2: rz_type_parse_string (c_cpp_parser.c:289)
==12767==    by 0x11BB5C: test_struct_identifier_without_specifier (test_type.c:891)
==12767==    by 0x11E381: all_tests (test_type.c:1036)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 52 (16 direct, 36 indirect) bytes in 1 blocks are definitely lost in loss record 164 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E6488: c_parser_new_union_naked_type (types_storage.c:381)
==12767==    by 0x49E6575: c_parser_new_union_type (types_storage.c:408)
==12767==    by 0x49DFF7F: parse_union_node (types_parser.c:668)
==12767==    by 0x49E54F2: parse_type_nodes_save (types_parser.c:1882)
==12767==    by 0x49DBDFB: type_parse_string (c_cpp_parser.c:190)
==12767==    by 0x49DC2D2: rz_type_parse_string (c_cpp_parser.c:289)
==12767==    by 0x11C3D1: test_union_identifier_without_specifier (test_type.c:919)
==12767==    by 0x11E3D4: all_tests (test_type.c:1037)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 52 (16 direct, 36 indirect) bytes in 1 blocks are definitely lost in loss record 165 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E607F: c_parser_new_structure_naked_type (types_storage.c:254)
==12767==    by 0x49E616C: c_parser_new_structure_type (types_storage.c:281)
==12767==    by 0x49DEA92: parse_struct_node (types_parser.c:376)
==12767==    by 0x49E548F: parse_type_nodes_save (types_parser.c:1877)
==12767==    by 0x49DBDFB: type_parse_string (c_cpp_parser.c:190)
==12767==    by 0x49DC054: rz_type_parse_string_stateless (c_cpp_parser.c:228)
==12767==    by 0x49DA718: rz_type_db_edit_base_type (type.c:1318)
==12767==    by 0x11D067: test_edit_types (test_type.c:961)
==12767==    by 0x11E427: all_tests (test_type.c:1038)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 132 (32 direct, 100 indirect) bytes in 1 blocks are definitely lost in loss record 255 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E31C9: parse_type_abstract_declarator_node (types_parser.c:1389)
==12767==    by 0x49E3402: parse_type_abstract_declarator_node (types_parser.c:1424)
==12767==    by 0x49E3402: parse_type_abstract_declarator_node (types_parser.c:1424)
==12767==    by 0x49E4DF4: parse_type_descriptor_single (types_parser.c:1780)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x11CC4A: test_edit_types (test_type.c:951)
==12767==    by 0x11E427: all_tests (test_type.c:1038)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 133 (32 direct, 101 indirect) bytes in 1 blocks are definitely lost in loss record 256 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49E2EBB: parse_type_abstract_declarator_node (types_parser.c:1336)
==12767==    by 0x49E30D8: parse_type_abstract_declarator_node (types_parser.c:1369)
==12767==    by 0x49E30D8: parse_type_abstract_declarator_node (types_parser.c:1369)
==12767==    by 0x49E4DF4: parse_type_descriptor_single (types_parser.c:1780)
==12767==    by 0x49DC637: rz_type_parse_string_single (c_cpp_parser.c:368)
==12767==    by 0x11391A: test_type_as_pretty_string (test_type.c:596)
==12767==    by 0x11E18F: all_tests (test_type.c:1030)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 168 bytes in 1 blocks are definitely lost in loss record 262 of 334
==12767==    at 0x48447B5: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x48F36F1: rz_strbuf_append_n (strbuf.c:250)
==12767==    by 0x48F35B5: rz_strbuf_append (strbuf.c:226)
==12767==    by 0x48F3AF7: rz_strbuf_vappendf (strbuf.c:313)
==12767==    by 0x48F3925: rz_strbuf_appendf (strbuf.c:285)
==12767==    by 0x49D9A24: type_as_pretty_string (type.c:1046)
==12767==    by 0x49D9FF3: rz_type_as_pretty_string (type.c:1141)
==12767==    by 0x49C339A: rz_type_db_base_type_as_string (base.c:207)
==12767==    by 0x10C410: test_types_get_base_type_union (test_type.c:142)
==12767==    by 0x11DEF7: all_tests (test_type.c:1022)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 169 bytes in 1 blocks are definitely lost in loss record 263 of 334
==12767==    at 0x48447B5: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x48F36F1: rz_strbuf_append_n (strbuf.c:250)
==12767==    by 0x48F35B5: rz_strbuf_append (strbuf.c:226)
==12767==    by 0x48F3AF7: rz_strbuf_vappendf (strbuf.c:313)
==12767==    by 0x48F3925: rz_strbuf_appendf (strbuf.c:285)
==12767==    by 0x49D9849: type_as_pretty_string (type.c:1027)
==12767==    by 0x49D9FF3: rz_type_as_pretty_string (type.c:1141)
==12767==    by 0x49C339A: rz_type_db_base_type_as_string (base.c:207)
==12767==    by 0x10B56A: test_types_get_base_type_struct (test_type.c:103)
==12767==    by 0x11DEA4: all_tests (test_type.c:1021)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 172 bytes in 1 blocks are definitely lost in loss record 264 of 334
==12767==    at 0x48447B5: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x48F36F1: rz_strbuf_append_n (strbuf.c:250)
==12767==    by 0x48F35B5: rz_strbuf_append (strbuf.c:226)
==12767==    by 0x48F3AF7: rz_strbuf_vappendf (strbuf.c:313)
==12767==    by 0x48F3925: rz_strbuf_appendf (strbuf.c:285)
==12767==    by 0x49D9A24: type_as_pretty_string (type.c:1046)
==12767==    by 0x49D9FF3: rz_type_as_pretty_string (type.c:1141)
==12767==    by 0x49C339A: rz_type_db_base_type_as_string (base.c:207)
==12767==    by 0x10C831: test_types_get_base_type_union (test_type.c:148)
==12767==    by 0x11DEF7: all_tests (test_type.c:1022)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 174 bytes in 1 blocks are definitely lost in loss record 265 of 334
==12767==    at 0x48447B5: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x48F36F1: rz_strbuf_append_n (strbuf.c:250)
==12767==    by 0x48F35B5: rz_strbuf_append (strbuf.c:226)
==12767==    by 0x48F3AF7: rz_strbuf_vappendf (strbuf.c:313)
==12767==    by 0x48F3925: rz_strbuf_appendf (strbuf.c:285)
==12767==    by 0x49D9849: type_as_pretty_string (type.c:1027)
==12767==    by 0x49D9FF3: rz_type_as_pretty_string (type.c:1141)
==12767==    by 0x49C339A: rz_type_db_base_type_as_string (base.c:207)
==12767==    by 0x10B98B: test_types_get_base_type_struct (test_type.c:110)
==12767==    by 0x11DEA4: all_tests (test_type.c:1021)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 416 (88 direct, 328 indirect) bytes in 1 blocks are definitely lost in loss record 286 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49DB879: c_parser_state_new (c_cpp_parser.c:34)
==12767==    by 0x49DC279: rz_type_parse_string (c_cpp_parser.c:283)
==12767==    by 0x11BB5C: test_struct_identifier_without_specifier (test_type.c:891)
==12767==    by 0x11E381: all_tests (test_type.c:1036)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 416 (88 direct, 328 indirect) bytes in 1 blocks are definitely lost in loss record 287 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49DB879: c_parser_state_new (c_cpp_parser.c:34)
==12767==    by 0x49DC279: rz_type_parse_string (c_cpp_parser.c:283)
==12767==    by 0x11C3D1: test_union_identifier_without_specifier (test_type.c:919)
==12767==    by 0x11E3D4: all_tests (test_type.c:1037)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 1,216 (336 direct, 880 indirect) bytes in 1 blocks are definitely lost in loss record 311 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49D650D: rz_type_db_new (type.c:35)
==12767==    by 0x11DA4C: test_addr_bits (test_type.c:1008)
==12767==    by 0x11E4CD: all_tests (test_type.c:1040)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== 200,091 (336 direct, 199,755 indirect) bytes in 1 blocks are definitely lost in loss record 334 of 334
==12767==    at 0x48495EF: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12767==    by 0x49D650D: rz_type_db_new (type.c:35)
==12767==    by 0x113741: test_type_as_pretty_string (test_type.c:589)
==12767==    by 0x11E18F: all_tests (test_type.c:1030)
==12767==    by 0x11E522: main (test_type.c:1044)
==12767==
==12767== LEAK SUMMARY:
==12767==    definitely lost: 2,602 bytes in 66 blocks
==12767==    indirectly lost: 201,670 bytes in 9,085 blocks
==12767==      possibly lost: 0 bytes in 0 blocks
==12767==    still reachable: 0 bytes in 0 blocks
==12767==         suppressed: 0 bytes in 0 blocks
==12767==
==12767== For lists of detected and suppressed errors, rerun with: -s
==12767== ERROR SUMMARY: 54 errors from 54 contexts (suppressed: 0 from 0)
```
