### PR TITLE
Fix NE reloc endianness bug

### DIFF
--- a/librz/bin/format/ne/ne.c
+++ b/librz/bin/format/ne/ne.c
@@ -560,7 +560,8 @@ RzList /*<RzBinReloc *>*/ *rz_bin_ne_get_relocs(rz_bin_ne_obj_t *bin) {
 				if (rel.index > bin->ne_header->ModRefs || !rel.index) {
 					name = rz_str_newf("UnknownModule%d_%x", rel.index, off); // ????
 				} else {
-					offset = modref[rel.index - 1] + bin->header_offset + bin->ne_header->ImportNameTable;
+					ut16 modref_val = rz_read_le16(&modref[rel.index - 1]);
+					offset = modref_val + bin->header_offset + bin->ne_header->ImportNameTable;
 					name = __read_nonnull_str_at(bin->buf, offset);
 				}
 				if (rel.flags & IMPORTED_ORD) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Test `db/formats/ne NE Relocs and resolve function ordinal names` must succeed under ` s390x` arch on travis