### PR TITLE
Fix wB test due broken pv1

### DIFF
--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -5721,6 +5721,7 @@ static bool print_value(RzCore *core, PrintValueOptions *opts, RzCmdStateOutput 
 	int blocksize = core->blocksize;
 	ut8 *block_end = core->block + blocksize;
 
+	bool big_endian = rz_config_get_b(core->config, "cfg.bigendian");
 	if (block + 8 >= block_end) {
 		RZ_LOG_ERROR("core: block is truncated.\n");
 		return false;
@@ -5741,19 +5742,19 @@ static bool print_value(RzCore *core, PrintValueOptions *opts, RzCmdStateOutput 
 			block += opts->size;
 			break;
 		case 2:
-			v = rz_read_ble16(block, core->print->big_endian);
+			v = rz_read_ble16(block, big_endian);
 			block += opts->size;
 			break;
 		case 4:
-			v = rz_read_ble32(block, core->print->big_endian);
+			v = rz_read_ble32(block, big_endian);
 			block += opts->size;
 			break;
 		case 8:
-			v = rz_read_ble64(block, core->print->big_endian);
+			v = rz_read_ble64(block, big_endian);
 			block += opts->size;
 			break;
 		case 0:
-			v = rz_read_ble64(block, core->print->big_endian);
+			v = rz_read_ble64(block, big_endian);
 			opts->size = core->rasm->bits / 8;
 			switch (core->rasm->bits / 8) {
 			case 1: v &= UT8_MAX; break;

--- a/librz/core/cmd/cmd_write.c
+++ b/librz/core/cmd/cmd_write.c
@@ -76,6 +76,7 @@ static bool encrypt_or_decrypt_block(RzCore *core, const char *algo, const char 
 }
 
 static void cmd_write_bits(RzCore *core, int set, ut64 val) {
+	bool big_endian = rz_config_get_b(core->config, "cfg.bigendian");
 	ut8 buf[sizeof(ut64)];
 	ut64 ret, orig;
 	// used to set/unset bit in current address
@@ -83,13 +84,13 @@ static void cmd_write_bits(RzCore *core, int set, ut64 val) {
 		cmd_write_fail(core);
 		return;
 	}
-	orig = rz_read_ble64(buf, core->rasm->big_endian);
+	orig = rz_read_ble64(buf, big_endian);
 	if (set) {
 		ret = orig | val;
 	} else {
 		ret = orig & (~(val));
 	}
-	rz_write_ble64(buf, ret, core->rasm->big_endian);
+	rz_write_ble64(buf, ret, big_endian);
 	if (!rz_core_write_at(core, core->offset, buf, sizeof(buf))) {
 		cmd_write_fail(core);
 	}

--- a/test/db/cmd/cmd_w
+++ b/test/db/cmd/cmd_w
@@ -1,6 +1,7 @@
 NAME=wB
 FILE==
 CMDS=<<EOF
+e cfg.bigendian=false
 wB 0x55
 pv1
 wB 0x55


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes pv1 endianness (the cmd/write test on s390x must pass)