### PR TITLE
Fix #3191 - Esil wrong order in X86_INS_POP

### DIFF
--- a/librz/analysis/p/analysis_x86_cs.c
+++ b/librz/analysis/p/analysis_x86_cs.c
@@ -1087,16 +1087,16 @@ static void anop_esil(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 		case X86_OP_MEM: {
 			dst = getarg(&gop, 0, 1, NULL, DST_AR, NULL);
 			esilprintf(op,
-				"%s,[%d],%s,%d,%s,+=",
-				sp, rs, dst, rs, sp);
+				"%s,[%d],%d,%s,+=,%s",
+				sp, rs, rs, sp, dst);
 			break;
 		}
 		case X86_OP_REG:
 		default: {
 			dst = getarg(&gop, 0, 0, NULL, DST_AR, NULL);
 			esilprintf(op,
-				"%s,[%d],%s,=,%d,%s,+=",
-				sp, rs, dst, rs, sp);
+				"%s,[%d],%d,%s,+=,%s,=",
+				sp, rs, rs, sp, dst);
 			break;
 		}
 		}

--- a/test/db/analysis/x86_64
+++ b/test/db/analysis/x86_64
@@ -4509,3 +4509,27 @@ addr    size jump    fail
 0xa3de6 23   -1      -1
 EOF
 RUN
+
+NAME=X86_INSTR_POP wrong order
+FILE==
+CMDS=<<EOF
+e io.va=true
+e asm.arch=x86
+e asm.bits=64
+aei
+aeim
+ar rdi=0x178000
+ar rsp=rdi-0x30
+wa "push rbp ; mov rbp,rsp ;  lea rsp,[rdi+8] ; push rsp; pop rsp ; push 0x1337 ; pop qword ptr [rsp] ; pop qword ptr [rsp] ; pop qword ptr [rsp] ; pop qword ptr [rsp] ; mov rsp,rbp ; pop rbp ; ret"
+13aes
+pxQ 0x28 @ 0+rdi
+EOF
+EXPECT=<<EOF
+0x00178000 0x0000000000001337 rax+4919
+0x00178008 0x0000000000001337 rax+4919
+0x00178010 0x0000000000001337 rax+4919
+0x00178018 0x0000000000001337 rax+4919
+0x00178020 0x0000000000001337 rax+4919
+EOF
+RUN
+

--- a/test/db/esil/x86_32
+++ b/test/db/esil/x86_32
@@ -2434,3 +2434,26 @@ aes
 ar eflags
 EOF
 RUN
+
+NAME=X86_INSTR_POP wrong order
+FILE==
+CMDS=<<EOF
+e io.va=true
+e asm.arch=x86
+e asm.bits=32
+aei
+aeim
+ar edi=0x178000
+ar esp=edi-0x30
+wa "push ebp ; mov ebp,esp ; lea esp,[edi+8] ; push esp; pop esp ; push 0x1337 ; pop word ptr [esp] ; pop word ptr [esp] ; pop word ptr [esp] ; pop word ptr [esp] ; mov esp,ebp ; pop ebp ; ret"
+13aes
+pxW 20 @ 4+edi
+EOF
+EXPECT=<<EOF
+0x00178004 0x00001337 oeax+4919
+0x00178008 0x00001337 oeax+4919
+0x0017800c 0x00001337 oeax+4919
+0x00178010 0x00001337 oeax+4919
+0x00178014 0x00001337 oeax+4919
+EOF
+RUN

--- a/test/db/formats/elf/helloworld-gcc-elf
+++ b/test/db/formats/elf/helloworld-gcc-elf
@@ -537,7 +537,7 @@ EXPECT=<<EOF
   },
   {
     "offset": 134513410,
-    "esil": "esp,[4],esi,=,4,esp,+=",
+    "esil": "esp,[4],4,esp,+=,esi,=",
     "refptr": false,
     "fcn_addr": 0,
     "fcn_last": 0,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes the wrong x86/x64 pop esil representation.

**Closing issues**

Fix #3191 