### PR TITLE
Rewrite and extend type paths from offset

### DIFF
--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1629,8 +1629,7 @@ RZ_API bool rz_analysis_type_set_link(RzAnalysis *analysis, RZ_OWN RzType *type,
 RZ_API bool rz_analysis_type_unlink(RzAnalysis *analysis, ut64 addr);
 RZ_API bool rz_analysis_type_unlink_all(RzAnalysis *analysis);
 RZ_API RZ_OWN RzList /*<RzType *>*/ *rz_analysis_type_links(RzAnalysis *analysis);
-RZ_API RZ_OWN RzList /*<RzTypePath *>*/ *rz_analysis_type_links_by_offset(RzAnalysis *analysis, ut64 offset);
-RZ_API RZ_OWN RzList /*<RzTypePath *>*/ *rz_analysis_type_paths_by_address(RzAnalysis *analysis, ut64 addr);
+RZ_API RZ_OWN RzList /*<RzTypePathTuple *>*/ *rz_analysis_type_paths_by_address(RzAnalysis *analysis, ut64 addr);
 
 /* project */
 RZ_API bool rz_analysis_xrefs_init(RzAnalysis *analysis);

--- a/librz/include/rz_type.h
+++ b/librz/include/rz_type.h
@@ -266,6 +266,7 @@ RZ_API RZ_OWN RzList /*<RzBaseType *>*/ *rz_type_db_get_base_types(const RzTypeD
 RZ_API RZ_OWN char *rz_type_db_base_type_as_string(const RzTypeDB *typedb, RZ_NONNULL const RzBaseType *btype);
 RZ_API RZ_OWN char *rz_type_db_base_type_as_pretty_string(RZ_NONNULL const RzTypeDB *typedb, RZ_NONNULL const RzBaseType *btype, unsigned int opts, int unfold_level);
 RZ_API bool rz_type_db_edit_base_type(RzTypeDB *typedb, RZ_NONNULL const char *name, RZ_NONNULL const char *typestr);
+RZ_API RZ_BORROW RzType *rz_type_db_base_type_unwrap_typedef(RZ_NONNULL const RzTypeDB *typedb, RZ_NONNULL const RzBaseType *btype);
 
 // Compound types
 

--- a/librz/include/rz_type.h
+++ b/librz/include/rz_type.h
@@ -172,9 +172,15 @@ struct rz_type_t {
 };
 
 typedef struct rz_type_path_t {
-	RzType *typ;
+	RzType *typ; ///< type at the leaf
 	char *path;
 } RzTypePath;
+
+/// A path and the type that the path came from
+typedef struct rz_type_path_tuple_t {
+	RzTypePath *path;
+	RzType *root;
+} RzTypePathTuple;
 
 /**
  * \brief Type Conditions
@@ -304,7 +310,8 @@ RZ_API RZ_OWN RzBaseType *rz_type_typeclass_get_default_sized(const RzTypeDB *ty
 RZ_API RZ_OWN RzTypePath *rz_type_path_new(RZ_BORROW RZ_NONNULL RzType *type, RZ_OWN RZ_NONNULL char *path);
 RZ_API void rz_type_path_free(RZ_NULLABLE RzTypePath *tpath);
 RZ_API st64 rz_type_offset_by_path(const RzTypeDB *typedb, RZ_NONNULL const char *path);
-RZ_API RZ_OWN RzList /*<RzTypePath *>*/ *rz_type_path_by_offset(const RzTypeDB *typedb, RzBaseType *btype, ut64 offset);
+RZ_API RZ_OWN RzList /*<RzTypePath *>*/ *rz_base_type_path_by_offset(const RzTypeDB *typedb, const RzBaseType *btype, ut64 offset, unsigned int max_depth);
+RZ_API RZ_OWN RzList /*<RzTypePath *>*/ *rz_type_path_by_offset(const RzTypeDB *typedb, const RzType *type, ut64 offset, unsigned int max_depth);
 RZ_API RZ_OWN RzList /*<RzTypePath *>*/ *rz_type_db_get_by_offset(const RzTypeDB *typedb, ut64 offset);
 RZ_API ut64 rz_type_db_struct_member_packed_offset(RZ_NONNULL const RzTypeDB *typedb, RZ_NONNULL const char *name, RZ_NONNULL const char *member);
 RZ_API ut64 rz_type_db_struct_member_offset(RZ_NONNULL const RzTypeDB *typedb, RZ_NONNULL const char *name, RZ_NONNULL const char *member);

--- a/librz/include/rz_vector.h
+++ b/librz/include/rz_vector.h
@@ -276,7 +276,7 @@ static inline void *rz_pvector_tail(RzPVector *vec) {
 }
 
 // returns the respective pointer inside the vector if x is found or NULL otherwise.
-RZ_API void **rz_pvector_contains(RzPVector *vec, void *x);
+RZ_API void **rz_pvector_contains(RzPVector *vec, const void *x);
 
 // removes and returns the pointer at the given index. Does not call free.
 RZ_API void *rz_pvector_remove_at(RzPVector *vec, size_t index);

--- a/librz/type/base.c
+++ b/librz/type/base.c
@@ -246,3 +246,44 @@ RZ_API RZ_BORROW RzBaseType *rz_type_db_get_compound_type(const RzTypeDB *typedb
 	}
 	return t;
 }
+
+/**
+ * \brief Recursively resolve a typedef to its pointed-to type
+ *
+ * The case where the typedef chain contains a loop, meaning a typedef eventually points
+ * to itself, is safely handled here and NULL is returned.
+ *
+ * \param btype a base type that must be of kind RZ_TYPE_KIND_TYPEDEF
+ * \return the first non-typedef type in the chain started by \p btype, or NULL on error or if there is a loop
+ */
+RZ_API RZ_BORROW RzType *rz_type_db_base_type_unwrap_typedef(RZ_NONNULL const RzTypeDB *typedb, RZ_NONNULL const RzBaseType *btype) {
+	rz_return_val_if_fail(typedb && btype && btype->kind == RZ_BASE_TYPE_KIND_TYPEDEF, NULL);
+	RzPVector visited_btypes; // for detecting self-referential typedefs (maybe in multiple steps)
+	rz_pvector_init(&visited_btypes, NULL);
+	RzType *ttype;
+	while (true) {
+		if (rz_pvector_contains(&visited_btypes, (void *)btype)) {
+			// loop detected
+			ttype = NULL;
+			goto end;
+		}
+		ttype = btype->type;
+		rz_return_val_if_fail(ttype, NULL);
+		if (ttype->kind != RZ_TYPE_KIND_IDENTIFIER) {
+			goto end;
+		}
+		RzBaseType *next_btype = rz_type_db_get_base_type(typedb, ttype->identifier.name);
+		if (!next_btype || next_btype->kind != RZ_BASE_TYPE_KIND_TYPEDEF) {
+			goto end;
+		}
+		// push to the vector as late as possible to avoid heap usage if possible
+		if (!rz_pvector_push(&visited_btypes, (void *)btype)) {
+			ttype = NULL;
+			goto end;
+		}
+		btype = next_btype;
+	}
+end:
+	rz_pvector_fini(&visited_btypes);
+	return ttype;
+}

--- a/librz/type/format.c
+++ b/librz/type/format.c
@@ -2912,14 +2912,11 @@ static void base_type_to_format_unfold(const RzTypeDB *typedb, RZ_NONNULL RzBase
 		break;
 	}
 	case RZ_BASE_TYPE_KIND_TYPEDEF: {
-		// Avoid infinite recursion in case of self-referential typedefs
-		if (rz_type_is_identifier(type->type)) {
-			const char *ttype = type_to_identifier(typedb, type->type);
-			if (!strcmp(ttype, type->name)) {
-				break;
-			}
+		RzType *unwrapped = rz_type_db_base_type_unwrap_typedef(typedb, type);
+		if (!unwrapped) {
+			break;
 		}
-		type_to_format_pair(typedb, format, fields, identifier, type->type);
+		type_to_format_pair(typedb, format, fields, identifier, unwrapped);
 		break;
 	}
 	default:

--- a/librz/type/type.c
+++ b/librz/type/type.c
@@ -744,10 +744,11 @@ RZ_API ut64 rz_type_db_union_bitsize(const RzTypeDB *typedb, RZ_NONNULL RzBaseTy
 RZ_API ut64 rz_type_db_typedef_bitsize(const RzTypeDB *typedb, RZ_NONNULL RzBaseType *btype) {
 	rz_return_val_if_fail(typedb && btype && btype->kind == RZ_BASE_TYPE_KIND_TYPEDEF, 0);
 	rz_return_val_if_fail(btype->type, 0);
-	if (btype->type->kind == RZ_TYPE_KIND_IDENTIFIER && !strcmp(btype->type->identifier.name, btype->name)) {
-		return btype->size;
+	RzType *unwrapped = rz_type_db_base_type_unwrap_typedef(typedb, btype);
+	if (!unwrapped) {
+		return 0;
 	}
-	return rz_type_db_get_bitsize(typedb, btype->type);
+	return rz_type_db_get_bitsize(typedb, unwrapped);
 }
 
 /**

--- a/librz/util/vector.c
+++ b/librz/util/vector.c
@@ -348,7 +348,7 @@ RZ_API void rz_pvector_free(RzPVector *vec) {
 	free(vec);
 }
 
-RZ_API void **rz_pvector_contains(RzPVector *vec, void *x) {
+RZ_API void **rz_pvector_contains(RzPVector *vec, const void *x) {
 	rz_return_val_if_fail(vec, NULL);
 	size_t i;
 	for (i = 0; i < vec->v.len; i++) {

--- a/test/unit/test_type.c
+++ b/test/unit/test_type.c
@@ -1077,6 +1077,527 @@ bool test_typedef_loop(void) {
 	str = rz_base_type_as_format(typedb, btype);
 	mu_assert_streq_free(str, "", "format");
 
+	RzList *paths = rz_type_path_by_offset(typedb, ttype, 0, INT_MAX);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	rz_type_free(ttype);
+
+	rz_type_db_free(typedb);
+	mu_end;
+}
+
+bool test_path_by_offset_struct(void) {
+	RzTypeDB *typedb = rz_type_db_new();
+	const char *types_dir = TEST_BUILD_TYPES_DIR;
+	rz_type_db_init(typedb, types_dir, "x86", 64, "linux");
+
+	// -- simple
+
+	char *error_msg = NULL;
+	RzType *ttype = rz_type_parse_string_single(typedb->parser, "struct Hello { int a; uint32_t b; };", &error_msg);
+	mu_assert_notnull(ttype, "type parse successful");
+	mu_assert_eq(ttype->kind, RZ_TYPE_KIND_IDENTIFIER, "parsed type");
+	mu_assert_streq(ttype->identifier.name, "Hello", "parsed type");
+
+	RzList *paths = rz_type_path_by_offset(typedb, ttype, 0, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 1, "paths");
+	RzTypePath *path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".a", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 2, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 4, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 1, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".b", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "uint32_t", "paths");
+	rz_list_free(paths);
+
+	rz_type_free(ttype);
+
+	// -- recursive
+
+	ttype = rz_type_parse_string_single(typedb->parser, "struct World { uint64_t ulu; Hello mulu; int32_t urshak; };", &error_msg);
+	mu_assert_notnull(ttype, "type parse successful");
+	mu_assert_eq(ttype->kind, RZ_TYPE_KIND_IDENTIFIER, "parsed type");
+	mu_assert_streq(ttype->identifier.name, "World", "parsed type");
+
+	paths = rz_type_path_by_offset(typedb, ttype, 0, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 1, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".ulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "uint64_t", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 8, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 2, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".mulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "Hello", "paths");
+	path = rz_list_get_n(paths, 1);
+	mu_assert_streq(path->path, ".mulu.a", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 10, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 12, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 1, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".mulu.b", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "uint32_t", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 8, 2);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 2, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".mulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "Hello", "paths");
+	path = rz_list_get_n(paths, 1);
+	mu_assert_streq(path->path, ".mulu.a", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 8, 1);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 1, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".mulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "Hello", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 8, 0);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	rz_type_free(ttype);
+
+	// -- base type
+
+	RzBaseType *btype = rz_type_db_get_base_type(typedb, "World");
+	mu_assert_notnull(btype, "get base type");
+
+	paths = rz_base_type_path_by_offset(typedb, btype, 8, 2);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 2, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".mulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "Hello", "paths");
+	path = rz_list_get_n(paths, 1);
+	mu_assert_streq(path->path, ".mulu.a", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int", "paths");
+	rz_list_free(paths);
+
+	paths = rz_base_type_path_by_offset(typedb, btype, 8, 1);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 1, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".mulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "Hello", "paths");
+	rz_list_free(paths);
+
+	paths = rz_base_type_path_by_offset(typedb, btype, 8, 0);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	rz_type_db_free(typedb);
+	mu_end;
+}
+
+bool test_path_by_offset_union(void) {
+	RzTypeDB *typedb = rz_type_db_new();
+	const char *types_dir = TEST_BUILD_TYPES_DIR;
+	rz_type_db_init(typedb, types_dir, "x86", 64, "linux");
+
+	// -- simple
+
+	char *error_msg = NULL;
+	RzType *ttype = rz_type_parse_string_single(typedb->parser, "union Card { int fish; uint32_t senf; };", &error_msg);
+	mu_assert_notnull(ttype, "type parse successful");
+	mu_assert_eq(ttype->kind, RZ_TYPE_KIND_IDENTIFIER, "parsed type");
+	mu_assert_streq(ttype->identifier.name, "Card", "parsed type");
+
+	RzList *paths = rz_type_path_by_offset(typedb, ttype, 0, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 2, "paths");
+	RzTypePath *path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".fish", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int", "paths");
+	path = rz_list_get_n(paths, 1);
+	mu_assert_streq(path->path, ".senf", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "uint32_t", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 2, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 4, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	rz_type_free(ttype);
+
+	// -- recursive
+
+	ttype = rz_type_parse_string_single(typedb->parser, "struct Hello { int a; uint32_t b; };", &error_msg);
+	mu_assert_notnull(ttype, "type parse successful");
+	mu_assert_eq(ttype->kind, RZ_TYPE_KIND_IDENTIFIER, "parsed type");
+	mu_assert_streq(ttype->identifier.name, "Hello", "parsed type");
+	rz_type_free(ttype);
+	ttype = rz_type_parse_string_single(typedb->parser, "union World { uint64_t ulu; Hello mulu; int32_t urshak; };", &error_msg);
+	mu_assert_notnull(ttype, "type parse successful");
+	mu_assert_eq(ttype->kind, RZ_TYPE_KIND_IDENTIFIER, "parsed type");
+	mu_assert_streq(ttype->identifier.name, "World", "parsed type");
+
+	paths = rz_type_path_by_offset(typedb, ttype, 0, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 4, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".ulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "uint64_t", "paths");
+	path = rz_list_get_n(paths, 1);
+	mu_assert_streq(path->path, ".mulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "Hello", "paths");
+	path = rz_list_get_n(paths, 2);
+	mu_assert_streq(path->path, ".mulu.a", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int", "paths");
+	path = rz_list_get_n(paths, 3);
+	mu_assert_streq(path->path, ".urshak", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int32_t", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 8, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 4, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 1, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".mulu.b", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "uint32_t", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 0, 2);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 4, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".ulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "uint64_t", "paths");
+	path = rz_list_get_n(paths, 1);
+	mu_assert_streq(path->path, ".mulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "Hello", "paths");
+	path = rz_list_get_n(paths, 2);
+	mu_assert_streq(path->path, ".mulu.a", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int", "paths");
+	path = rz_list_get_n(paths, 3);
+	mu_assert_streq(path->path, ".urshak", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int32_t", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 0, 1);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 3, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".ulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "uint64_t", "paths");
+	path = rz_list_get_n(paths, 1);
+	mu_assert_streq(path->path, ".mulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "Hello", "paths");
+	path = rz_list_get_n(paths, 2);
+	mu_assert_streq(path->path, ".urshak", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int32_t", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 0, 0);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	rz_type_free(ttype);
+
+	// -- base type
+
+	RzBaseType *btype = rz_type_db_get_base_type(typedb, "World");
+	mu_assert_notnull(btype, "get base type");
+
+	paths = rz_base_type_path_by_offset(typedb, btype, 0, 2);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 4, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".ulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "uint64_t", "paths");
+	path = rz_list_get_n(paths, 1);
+	mu_assert_streq(path->path, ".mulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "Hello", "paths");
+	path = rz_list_get_n(paths, 2);
+	mu_assert_streq(path->path, ".mulu.a", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int", "paths");
+	path = rz_list_get_n(paths, 3);
+	mu_assert_streq(path->path, ".urshak", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int32_t", "paths");
+	rz_list_free(paths);
+
+	paths = rz_base_type_path_by_offset(typedb, btype, 0, 1);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 3, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".ulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "uint64_t", "paths");
+	path = rz_list_get_n(paths, 1);
+	mu_assert_streq(path->path, ".mulu", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "Hello", "paths");
+	path = rz_list_get_n(paths, 2);
+	mu_assert_streq(path->path, ".urshak", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int32_t", "paths");
+	rz_list_free(paths);
+
+	paths = rz_base_type_path_by_offset(typedb, btype, 0, 0);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	rz_type_db_free(typedb);
+	mu_end;
+}
+
+bool test_path_by_offset_array(void) {
+	RzTypeDB *typedb = rz_type_db_new();
+	const char *types_dir = TEST_BUILD_TYPES_DIR;
+	rz_type_db_init(typedb, types_dir, "x86", 64, "linux");
+
+	// -- simple
+
+	char *error_msg = NULL;
+	RzType *ttype = rz_type_parse_string_single(typedb->parser, "int [5]", &error_msg);
+	mu_assert_notnull(ttype, "type parse successful");
+	mu_assert_eq(ttype->kind, RZ_TYPE_KIND_ARRAY, "parsed type");
+
+	RzList *paths = rz_type_path_by_offset(typedb, ttype, 0, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 1, "paths");
+	RzTypePath *path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, "[0]", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 1, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 4, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 1, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, "[1]", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 16, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 1, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, "[4]", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 19, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 20, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	rz_type_free(ttype);
+
+	// -- recursive
+
+	ttype = rz_type_parse_string_single(typedb->parser, "struct Hello { int a; uint32_t b; };", &error_msg);
+	mu_assert_notnull(ttype, "type parse successful");
+	mu_assert_eq(ttype->kind, RZ_TYPE_KIND_IDENTIFIER, "parsed type");
+	mu_assert_streq(ttype->identifier.name, "Hello", "parsed type");
+	rz_type_free(ttype);
+
+	ttype = rz_type_parse_string_single(typedb->parser, "Hello [5]", &error_msg);
+	mu_assert_notnull(ttype, "type parse successful");
+	mu_assert_eq(ttype->kind, RZ_TYPE_KIND_ARRAY, "parsed type");
+
+	paths = rz_type_path_by_offset(typedb, ttype, 0, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 2, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, "[0]", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "Hello", "paths");
+	path = rz_list_get_n(paths, 1);
+	mu_assert_streq(path->path, "[0].a", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 12, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 1, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, "[1].b", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "uint32_t", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 0, 2);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 2, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, "[0]", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "Hello", "paths");
+	path = rz_list_get_n(paths, 1);
+	mu_assert_streq(path->path, "[0].a", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 0, 1);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 1, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, "[0]", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "Hello", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 0, 0);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	rz_type_free(ttype);
+
+	rz_type_db_free(typedb);
+	mu_end;
+}
+
+bool test_path_by_offset_typedef(void) {
+	RzTypeDB *typedb = rz_type_db_new();
+	const char *types_dir = TEST_BUILD_TYPES_DIR;
+	rz_type_db_init(typedb, types_dir, "x86", 64, "linux");
+
+	char *error_msg = NULL;
+	RzType *ttype = rz_type_parse_string_single(typedb->parser, "struct Card { int fish; uint32_t senf; };", &error_msg);
+	mu_assert_notnull(ttype, "type parse successful");
+	mu_assert_eq(ttype->kind, RZ_TYPE_KIND_IDENTIFIER, "parsed type");
+	mu_assert_streq(ttype->identifier.name, "Card", "parsed type");
+
+	RzBaseType *btype = rz_type_base_type_new(RZ_BASE_TYPE_KIND_TYPEDEF);
+	btype->name = strdup("Alias");
+	btype->type = RZ_NEW0(RzType);
+	btype->type->kind = RZ_TYPE_KIND_IDENTIFIER;
+	btype->type->identifier.name = strdup("Card");
+	rz_type_db_save_base_type(typedb, btype);
+
+	RzList *paths = rz_type_path_by_offset(typedb, ttype, 0, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 1, "paths");
+	RzTypePath *path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".fish", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "int", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 1, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 4, 5);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 1, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".senf", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "uint32_t", "paths");
+	rz_list_free(paths);
+
+	// Resolving a typedef should not count as a depth step as we
+	// can't observe it in the path.
+	paths = rz_type_path_by_offset(typedb, ttype, 4, 1);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 1, "paths");
+	path = rz_list_get_n(paths, 0);
+	mu_assert_streq(path->path, ".senf", "paths");
+	mu_assert_eq(path->typ->kind, RZ_TYPE_KIND_IDENTIFIER, "paths");
+	mu_assert_streq(path->typ->identifier.name, "uint32_t", "paths");
+	rz_list_free(paths);
+
+	paths = rz_type_path_by_offset(typedb, ttype, 4, 0);
+	mu_assert_notnull(paths, "paths");
+	mu_assert_eq(rz_list_length(paths), 0, "paths");
+	rz_list_free(paths);
+
+	rz_type_free(ttype);
+
 	rz_type_db_free(typedb);
 	mu_end;
 }
@@ -1103,6 +1624,10 @@ int all_tests() {
 	mu_run_test(test_references);
 	mu_run_test(test_addr_bits);
 	mu_run_test(test_typedef_loop);
+	mu_run_test(test_path_by_offset_struct);
+	mu_run_test(test_path_by_offset_union);
+	mu_run_test(test_path_by_offset_array);
+	mu_run_test(test_path_by_offset_typedef);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
# DO NOT SQUASH
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Tests and extends deriving paths into types at a given offset in the
following ways:
- Parameter for limiting the depth of the path
- Array support, e.g. `.member[5].anothermember`
- Typedef support
- Paths can be taken from arbitrary RzTypes, not only RzBaseType
- Removed the typename in the beginning of paths, which can be added by
  the caller if needed

see also the description of the first commit

**Test plan**

see unit tests
