### PR TITLE
Catch rz_asm_tokenize_asm_string() returning NULL

### DIFF
--- a/librz/asm/asm.c
+++ b/librz/asm/asm.c
@@ -1745,6 +1745,9 @@ rz_asm_colorize_asm_str(RZ_BORROW RzStrBuf *asm_str, RZ_BORROW RzPrint *p, RZ_NU
 		colored_asm = rz_print_colorize_asm_str(p, toks);
 	} else {
 		RzAsmTokenString *ts = rz_asm_tokenize_asm_string(asm_str, param);
+		if (!ts) {
+			return NULL;
+		}
 		ts->op_type = param ? param->ana_op_type : 0;
 		colored_asm = rz_print_colorize_asm_str(p, ts);
 		rz_asm_token_string_free(ts);

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -1205,7 +1205,7 @@ static void print_rop(RzCore *core, RzList /*<RzCoreAsmHit *>*/ *hitlist, PJ *pj
 			} else if (colorize) {
 				RzStrBuf *colored_asm, *bw_str = rz_strbuf_new(rz_asm_op_get_asm(&asmop));
 				colored_asm = rz_asm_colorize_asm_str(bw_str, core->print, rz_asm_get_parse_param(core->analysis->reg, analop.type), asmop.asm_toks);
-				rz_cons_printf(" %s%s;", rz_strbuf_get(colored_asm), Color_RESET);
+				rz_cons_printf(" %s%s;", colored_asm ? rz_strbuf_get(colored_asm) : "", Color_RESET);
 				rz_strbuf_free(colored_asm);
 			} else {
 				rz_cons_printf(" %s;", rz_asm_op_get_asm(&asmop));
@@ -1248,10 +1248,10 @@ static void print_rop(RzCore *core, RzList /*<RzCoreAsmHit *>*/ *hitlist, PJ *pj
 				colored_asm = rz_asm_colorize_asm_str(bw_str, core->print, rz_asm_get_parse_param(core->analysis->reg, analop.type), asmop.asm_toks);
 				if (comment) {
 					rz_cons_printf("  0x%08" PFMT64x " %18s  %s%s ; %s\n",
-						hit->addr, asm_op_hex, rz_strbuf_get(colored_asm), Color_RESET, comment);
+						hit->addr, asm_op_hex, colored_asm ? rz_strbuf_get(colored_asm) : "", Color_RESET, comment);
 				} else {
 					rz_cons_printf("  0x%08" PFMT64x " %18s  %s%s\n",
-						hit->addr, asm_op_hex, rz_strbuf_get(colored_asm), Color_RESET);
+						hit->addr, asm_op_hex, colored_asm ? rz_strbuf_get(colored_asm) : "", Color_RESET);
 				}
 				rz_strbuf_free(colored_asm);
 			} else {

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -1122,7 +1122,9 @@ static void ds_build_op_str(RzDisasmState *ds, bool print_color) {
 			RzStrBuf *colored_asm = rz_asm_colorize_asm_str(bw_asm, core->print, param, ds->asmop.asm_toks);
 			free(param);
 			rz_strbuf_free(bw_asm);
-			rz_return_if_fail(colored_asm);
+			if (!colored_asm) {
+				return;
+			}
 			source = rz_strbuf_drain(colored_asm);
 		} else {
 			source = strdup(source);
@@ -1163,7 +1165,9 @@ static void ds_build_op_str(RzDisasmState *ds, bool print_color) {
 			RzStrBuf *colored_asm = rz_asm_colorize_asm_str(bw_asm, core->print, param, ds->asmop.asm_toks);
 			free(param);
 			rz_strbuf_free(bw_asm);
-			rz_return_if_fail(colored_asm);
+			if (!colored_asm) {
+				return;
+			}
 			source = rz_strbuf_drain(colored_asm);
 		} else {
 			source = ds->opstr ? strdup(ds->opstr) : strdup(rz_asm_op_get_asm(&ds->asmop));
@@ -6520,7 +6524,7 @@ toro:
 					RzAsmParseParam *param = rz_asm_get_parse_param(core->analysis->reg, aop.type);
 					colored_asm = rz_asm_colorize_asm_str(bw_str, core->print, param, asmop.asm_toks);
 					free(param);
-					rz_cons_printf("%s" Color_RESET "\n", rz_strbuf_get(colored_asm));
+					rz_cons_printf("%s" Color_RESET "\n", colored_asm ? rz_strbuf_get(colored_asm) : "");
 					rz_strbuf_free(colored_asm);
 					rz_analysis_op_fini(&aop);
 				} else {
@@ -6796,7 +6800,7 @@ RZ_API RZ_OWN char *rz_core_disasm_instruction(RzCore *core, ut64 addr, ut64 rel
 		RzAsmParseParam *param = rz_asm_get_parse_param(core->analysis->reg, op.type);
 		colored_asm = rz_asm_colorize_asm_str(bw_str, core->print, param, asmop.asm_toks);
 		free(param);
-		return rz_strbuf_drain(colored_asm);
+		return colored_asm ? rz_strbuf_drain(colored_asm) : NULL;
 	} else {
 		buf_asm = rz_str_new(str);
 	}
@@ -6849,7 +6853,7 @@ RZ_API RZ_OWN RzPVector /*<RzCoreDisasmOp *>*/ *rz_core_disasm_all_possible_opco
 		RzStrBuf *colored_asm = rz_asm_colorize_asm_str(bw_str, core->print, param, asm_op.asm_toks);
 		rz_strbuf_free(bw_str);
 		free(param);
-		op->assembly_colored = rz_strbuf_drain(colored_asm);
+		op->assembly_colored = colored_asm ? rz_strbuf_drain(colored_asm) : NULL;
 		rz_analysis_op_fini(&aop);
 	}
 	return vec;

--- a/librz/core/tui/biteditor.c
+++ b/librz/core/tui/biteditor.c
@@ -61,7 +61,7 @@ RZ_IPI bool rz_core_visual_bit_editor(RzCore *core) {
 			RzAsmParseParam *param = rz_asm_get_parse_param(core->analysis->reg, analop.type);
 			RzStrBuf *colored_asm = rz_asm_colorize_asm_str(&asmop.buf_asm, core->print, param, asmop.asm_toks);
 			free(param);
-			rz_cons_printf(Color_RESET "asm: %s\n" Color_RESET, rz_strbuf_get(colored_asm));
+			rz_cons_printf(Color_RESET "asm: %s\n" Color_RESET, colored_asm ? rz_strbuf_get(colored_asm) : "");
 			rz_strbuf_free(colored_asm);
 		}
 		rz_cons_printf(Color_RESET "esl: %s\n" Color_RESET, rz_strbuf_get(&analop.esil));

--- a/librz/core/tui/esil.c
+++ b/librz/core/tui/esil.c
@@ -71,7 +71,7 @@ RZ_IPI bool rz_core_visual_esil(RzCore *core) {
 			RzAsmParseParam *param = rz_asm_get_parse_param(core->analysis->reg, analop.type);
 			colored_asm = rz_asm_colorize_asm_str(&asmop.buf_asm, core->print, param, asmop.asm_toks);
 			free(param);
-			rz_cons_printf(Color_RESET "asm: %s\n" Color_RESET, rz_strbuf_get(colored_asm));
+			rz_cons_printf(Color_RESET "asm: %s\n" Color_RESET, colored_asm ? rz_strbuf_get(colored_asm) : "");
 			rz_strbuf_free(colored_asm);
 		}
 		{


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

rz_asm_tokenize_asm_string() can return NULL for example if the given string is empty, so this has to be caught.
In rz_asm_colorize_asm_str(), we could fallback to returning an empty string, but since this function allocates on the heap, it may return NULL in any case, so we have to adjust all of its callers anyway and that means we can just pass the NULL from rz_asm_tokenize_asm_string().

**Test plan**

```
florian-macbook:rizin florian$ rz -Qc 'pd 2 @e:asm.pseudo=1' test/bins/elf/mipsloop
Segmentation fault: 11
```

should not segfault and instead print:

```
florian-macbook:rizin florian$ rz -Qc 'pd 2 @e:asm.pseudo=1' test/bins/elf/mipsloop
            ;-- entry0:
            ;-- __start:
            ;-- _start:
            0x000804f0      call 0x804f8
            0x000804f4
```

The empty pseudocode here is another issue.