### PR TITLE
Remove RZ_HOMD_OLD_PLUGINS after transition period ended

### DIFF
--- a/librz/core/libs.c
+++ b/librz/core/libs.c
@@ -72,11 +72,6 @@ static void loadSystemPlugins(RzCore *core, int where) {
 		char *hpd = rz_path_home_prefix(RZ_PLUGINS);
 		rz_lib_opendir(core->lib, hpd, false);
 		free(hpd);
-
-		// TODO: remove after 0.4.0 is released
-		hpd = rz_path_home_prefix(RZ_HOME_OLD_PLUGINS);
-		rz_lib_opendir(core->lib, hpd, false);
-		free(hpd);
 	}
 	if (where & RZ_CORE_LOADLIBS_SYSTEM) {
 		char *spd = rz_path_system(RZ_PLUGINS);

--- a/librz/include/rz_userconf.h.in
+++ b/librz/include/rz_userconf.h.in
@@ -93,10 +93,6 @@
 #define RZ_HOME_CACHEDIR  RZ_JOIN_2_PATHS(".cache", "rizin")
 
 #define RZ_HOME_HISTORY RZ_JOIN_2_PATHS(RZ_HOME_CACHEDIR, "history")
-// NOTE: Temporarly added only for compatibility reasons given that the plugin
-// directory has changed. For one release we are going to support also old paths
-// to give distros, plugin maintainers, etc. a bit more time to adapt
-#define RZ_HOME_OLD_PLUGINS RZ_JOIN_3_PATHS("share", "rizin", "plugins")
 
 #define RZ_HOME_CONFIG_RC     RZ_JOIN_2_PATHS(RZ_HOME_CONFIGDIR, "rizinrc")
 #define RZ_HOME_CONFIG_RC_DIR RZ_JOIN_2_PATHS(RZ_HOME_CONFIGDIR, "rizinrc.d")

--- a/librz/main/rz-asm.c
+++ b/librz/main/rz-asm.c
@@ -491,14 +491,10 @@ static void __load_plugins(RzAsmState *as) {
 	}
 
 	char *homeplugindir = rz_path_home_prefix(RZ_PLUGINS);
-	// TODO: remove after 0.4.0 is released
-	char *oldhomeplugindir = rz_path_home_prefix(RZ_HOME_OLD_PLUGINS);
 	char *sysplugindir = rz_path_system(RZ_PLUGINS);
 	rz_lib_opendir(as->l, homeplugindir, false);
-	rz_lib_opendir(as->l, oldhomeplugindir, false);
 	rz_lib_opendir(as->l, sysplugindir, false);
 	free(homeplugindir);
-	free(oldhomeplugindir);
 	free(sysplugindir);
 
 	free(tmp);

--- a/librz/main/rz-bin.c
+++ b/librz/main/rz-bin.c
@@ -709,8 +709,6 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 	bin = core.bin;
 	if (!(tmp = rz_sys_getenv("RZ_BIN_NOPLUGINS"))) {
 		char *homeplugindir = rz_path_home_prefix(RZ_PLUGINS);
-		// TODO: remove after 0.4.0 is released
-		char *oldhomeplugindir = rz_path_home_prefix(RZ_HOME_OLD_PLUGINS);
 		char *plugindir = rz_path_system(RZ_PLUGINS);
 		RzLib *l = rz_lib_new(NULL, NULL);
 		rz_lib_add_handler(l, RZ_LIB_TYPE_DEMANGLER, "demangler plugins",
@@ -725,10 +723,8 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 			rz_lib_opendir(l, path, false);
 		}
 		rz_lib_opendir(l, homeplugindir, false);
-		rz_lib_opendir(l, oldhomeplugindir, false);
 		rz_lib_opendir(l, plugindir, false);
 		free(homeplugindir);
-		free(oldhomeplugindir);
 		free(plugindir);
 		free(path);
 		rz_lib_free(l);

--- a/librz/util/lib.c
+++ b/librz/util/lib.c
@@ -290,16 +290,6 @@ RZ_API int rz_lib_open(RzLib *lib, const char *file) {
 		return -1;
 	}
 
-	// TODO: remove after 0.4.0 is released
-	if (strstr(file, RZ_HOME_OLD_PLUGINS)) {
-		char *oldhomeplugins = rz_path_home_prefix(RZ_HOME_OLD_PLUGINS);
-		char *homeplugins = rz_path_home_prefix(RZ_PLUGINS);
-		const char *basename = rz_file_basename(file);
-		RZ_LOG_WARN("Loading plugins from '%s' is deprecated, please install plugin '%s' in '%s' instead.\n", oldhomeplugins, basename, homeplugins);
-		free(homeplugins);
-		free(oldhomeplugins);
-	}
-
 	void *handler = rz_lib_dl_open(file);
 	if (!handler) {
 		RZ_LOG_INFO("Cannot open library: '%s'\n", file);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Move any plugin to `~/.local/share/rizin/plugins/`. With this new patch, rizin should not load it from there, nor give a warning about it, because that path is not supported anymore.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes https://github.com/rizinorg/rizin/issues/2046
