### PR TITLE
Handle logging of larger strings

### DIFF
--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -3582,7 +3582,7 @@ static void get_help_wrong_cmd(RzCore *core, const char *cmdname) {
 	if (!help_msg) {
 		goto help_pra_err;
 	}
-	RZ_LOG_ERROR("core: %s", help_msg);
+	RZ_LOG_ERROR("%s", help_msg);
 	free(help_msg);
 help_pra_err:
 	rz_cmd_parsed_args_free(help_pra);
@@ -3646,19 +3646,19 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(arged_stmt) {
 	res = rz_cmd_call_parsed_args(state->core->rcmd, pr_args);
 	if (res == RZ_CMD_STATUS_WRONG_ARGS) {
 		const char *cmdname = rz_cmd_parsed_args_cmd(pr_args);
-		RZ_LOG_ERROR("core: Wrong number of arguments passed to `%s`, see its help with `%s?`\n\n", cmdname, cmdname);
+		RZ_LOG_ERROR("Wrong number of arguments passed to `%s`, see its help with `%s?`\n\n", cmdname, cmdname);
 		get_help_wrong_cmd(state->core, cmdname);
 	} else if (res == RZ_CMD_STATUS_NONEXISTINGCMD) {
 		const char *cmdname = rz_cmd_parsed_args_cmd(pr_args);
-		RZ_LOG_ERROR("core: Command '%s' does not exist.\n", cmdname);
+		RZ_LOG_ERROR("Command '%s' does not exist.\n", cmdname);
 		if (rz_str_endswith(cmdname, "?") && pr_args->argc > 1) {
-			RZ_LOG_ERROR("core: Did you want to see the help? Try `%s` without any argument.\n", cmdname);
+			RZ_LOG_ERROR("Did you want to see the help? Try `%s` without any argument.\n", cmdname);
 		} else {
 			// Let's try to find the first command/group in the ancestor chain
 			// that could provide some help
 			RzCmdDesc *hcd = rz_cmd_get_desc_best(state->core->rcmd, cmdname);
 			if (hcd) {
-				RZ_LOG_ERROR("core: Displaying the help of command '%s'.\n\n", hcd->name);
+				RZ_LOG_ERROR("Displaying the help of command '%s'.\n\n", hcd->name);
 				get_help_wrong_cmd(state->core, hcd->name);
 			}
 		}

--- a/librz/util/log.c
+++ b/librz/util/log.c
@@ -85,17 +85,21 @@ RZ_API void rz_vlog(const char *funcname, const char *filename,
 	// TODO: Colors
 
 	// Build output string with src info, and formatted output
-	char output_buf[LOG_OUTPUTBUF_SIZE] = ""; // Big buffer for building the output string
+	RzStrBuf sb;
+	rz_strbuf_init(&sb);
+
 	if (!tag) {
 		tag = RZ_BETWEEN(0, level, RZ_ARRAY_SIZE(level_tags) - 1) ? level_tags[level] : "";
 	}
-	int offset = snprintf(output_buf, LOG_OUTPUTBUF_SIZE, "%s: ", tag);
+	rz_strbuf_append(&sb, tag);
+	rz_strbuf_append(&sb, ": ");
 	if (cfg_logsrcinfo) {
-		offset += snprintf(output_buf + offset, LOG_OUTPUTBUF_SIZE - offset, "%s in %s:%i: ", funcname, filename, lineno);
+		rz_strbuf_appendf(&sb, "%s in %s:%i: ", funcname, filename, lineno);
 	}
-	vsnprintf(output_buf + offset, LOG_OUTPUTBUF_SIZE - offset, fmtstr, args);
+	rz_strbuf_vappendf(&sb, fmtstr, args);
 
 	// Actually print out the string with our callbacks
+	char *output_buf = rz_strbuf_drain_nofree(&sb);
 	if (log_cbs && rz_list_length(log_cbs) > 0) {
 		RzListIter *it;
 		RzLogCallback cb;

--- a/test/db/cmd/cmd_w
+++ b/test/db/cmd/cmd_w
@@ -330,10 +330,10 @@ EOF
 EXPECT=<<EOF
 EOF
 EXPECT_ERR=<<EOF
-ERROR: core: Command 'wv8@10' does not exist.
-ERROR: core: Displaying the help of command 'wv8'.
+ERROR: Command 'wv8@10' does not exist.
+ERROR: Displaying the help of command 'wv8'.
 
-ERROR: core: Usage: wv8 <value>   # Write value of 8 byte
+ERROR: Usage: wv8 <value>   # Write value of 8 byte
 
 Write the number passed as argument at the current offset as 8 - bytes, respecting the cfg.bigendian variable
 

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -68,6 +68,7 @@ if get_option('enable_tests')
     'itv',
     'json',
     'list',
+    'log',
     'lzma',
     'ovf',
     'pj',

--- a/test/unit/test_log.c
+++ b/test/unit/test_log.c
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2022 Riccardo Schirone <sirmy15@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_util.h>
+#include "minunit.h"
+
+static int small_check(const char *output, const char *funcname, const char *filename,
+	ut32 lineno, RzLogLevel level, const char *tag, const char *fmtstr, ...) {
+	mu_assert_streq(output, "ERROR: 3", "small check msg should be correct");
+	return 0;
+}
+
+static int large_check(const char *output, const char *funcname, const char *filename,
+	ut32 lineno, RzLogLevel level, const char *tag, const char *fmtstr, ...) {
+	char *exp_msg = RZ_NEWS0(char, 2000);
+	strcpy(exp_msg, "ERROR: ");
+	for (size_t i = 0; i < 999; i++) {
+		exp_msg[strlen("ERROR: ") + i] = 'A';
+	}
+	mu_assert_streq(output, exp_msg, "large check msg should be correct");
+	free(exp_msg);
+	return 0;
+}
+
+bool test_log_small(void) {
+	rz_log_del_callback((RzLogCallback)large_check);
+	rz_log_add_callback((RzLogCallback)small_check);
+	rz_log("func", "file", 1, RZ_LOGLVL_ERROR, NULL, "%d", 3);
+	mu_end;
+}
+
+bool test_log_large(void) {
+	rz_log_del_callback((RzLogCallback)small_check);
+	rz_log_add_callback((RzLogCallback)large_check);
+	char *buf = RZ_NEWS(char, 1000);
+	memset(buf, 0x41, 999);
+	buf[999] = '\0';
+	rz_log("func", "file", 1, RZ_LOGLVL_ERROR, NULL, "%s", buf);
+	free(buf);
+	mu_end;
+}
+
+bool all_tests() {
+	mu_run_test(test_log_small);
+	mu_run_test(test_log_large);
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Before this patch the rz_vlog function was using a local array of 512 bytes, however when dealing with colors and escape chars (e.g. like when printing the commands help after you insert the wrong number of args) the string can easily become very long and it was truncated because of that.

This PR fixes it by just using a RzStrBuf to take care of the growing string to log. It might be a bit slower overall, but we don't care because it is just logging.

I have also removed the `core: ` prefix when printing the error message after inserting the wrong number of args for some commands. User do not care about the error being `core` or something else, they just want to see what to do and the `core: ` makes things harder to read for no good reason. I think we went a bit too far with adding logging information as much as I now see `core: ` or similar everywhere, but we are using RZ_LOG_ERROR also for printing user-displayed errors.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Running invalid commands like `aesp` or `wv` should still print the correct error message.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
