### PR TITLE
Add Nord color theme

### DIFF
--- a/librz/cons/d/nord
+++ b/librz/cons/d/nord
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2022 Anton Kochkov <anton.kochkov@gmail.com>
+# SPDX-License-Identifier: LGPL-3.0-only
+
+ec b0x00 rgb:6c768a
+ec b0x7f rgb:81a1c1
+ec b0xff rgb:aba2a2
+ec bin rgb:eceff4
+ec btext rgb:ecefd4
+ec ucall rgb:bf604a
+ec call rgb:bf616a
+ec ujmp rgb:88c0df
+ec cjmp rgb:88d0f0
+ec jmp rgb:88c0d0
+ec cmp rgb:5e81ac
+ec comment rgb:b48ead
+ec usrcmt rgb:a1a1c1
+ec ret rgb:81a1c1
+ec fline rgb:d8dee9
+ec flow rgb:88d0e0
+ec flow2 rgb:888
+ec fname rgb:8fbcbb
+ec label rgb:ebcb8b
+ec math rgb:d8dee9
+ec mov rgb:eceff4
+ec nop rgb:4c566a
+ec num rgb:a3be97
+ec offset rgb:6c767a
+ec other rgb:91b1d0
+ec pop rgb:e5e9f0
+ec prompt rgb:81a1c1
+ec push rgb:e5e9f0
+ec reg rgb:68e0e2
+ec args rgb:88d0f2
+ec help rgb:ebcb8c
+ec input rgb:eeb366
+ec trap rgb:b47ead
+ec swi rgb:b47ead
+ec creg rgb:ed9366
+ec flag rgb:b3ceac
+ec linehl rgb:004
+
+ec graph.box rgb:d8dee9
+ec graph.box2 rgb:bf614a
+ec graph.box3 rgb:4c566a
+ec graph.box4 rgb:4c566a
+ec graph.true rgb:a3be8c
+ec graph.false rgb:bf616a
+ec graph.ujump rgb:88c0df
+ec graph.current rgb:81a1c1
+ec graph.traced rgb:93ae80
+
+ec func_var rgb:d08770
+ec func_var_type rgb:ebcb8b
+ec func_var_addr rgb:d8dee9
+
+ec ai.read rgb:a97e9d
+ec ai.write rgb:c07e9d
+ec ai.exec rgb:e08ead
+ec ai.seq rgb:f98ead
+ec ai.ascii rgb:f9ceed
+
+ec widget_bg rgb:4cf rgb:344
+ec widget_sel black rgb:4cf

--- a/test/db/cmd/cmd_ec
+++ b/test/db/cmd/cmd_ec
@@ -339,6 +339,6 @@ CMDS=<<EOF
 ecoj
 EOF
 EXPECT=<<EOF
-["ayu","basic","behelit","bold","bright","cga","consonance","cutter","dark","darkda","default","defragger","durian","focus","gb","gentoo","lima","mars","matrix","monokai","ogray","onedark","pink","rasta","sepia","smyck","solarized","tango","twilight","white","white2","xvilka","zenburn"]
+["ayu","basic","behelit","bold","bright","cga","consonance","cutter","dark","darkda","default","defragger","durian","focus","gb","gentoo","lima","mars","matrix","monokai","nord","ogray","onedark","pink","rasta","sepia","smyck","solarized","tango","twilight","white","white2","xvilka","zenburn"]
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Added a new "nord" color theme based on this palette:
- https://www.nordtheme.com/docs/colors-and-palettes
- https://www.nordtheme.com/ports/vim

<img width="1502" alt="Screen Shot 2022-12-16 at 15 45 58" src="https://user-images.githubusercontent.com/203261/208061202-ecba742a-02fe-4995-b835-f74a6f88e01c.png">

<img width="1502" alt="Screen Shot 2022-12-16 at 15 47 43" src="https://user-images.githubusercontent.com/203261/208061261-b876bdef-f868-4851-b50f-7cbc7bba6f80.png">

<img width="940" alt="Screen Shot 2022-12-16 at 16 57 40" src="https://user-images.githubusercontent.com/203261/208061505-8e0a996e-f2f8-49f1-975b-515aadf0d9d9.png">


Main colors are:

<img width="251" alt="Screen Shot 2022-12-16 at 12 58 43" src="https://user-images.githubusercontent.com/203261/208026414-436f1dc5-ca2f-41f3-802d-2c2d88ed983b.png">
