### PR TITLE
Add Mars color theme

### DIFF
--- a/librz/cons/d/mars
+++ b/librz/cons/d/mars
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2022 Anton Kochkov <anton.kochkov@gmail.com>
+# SPDX-License-Identifier: LGPL-3.0-only
+
+ec b0x00 rgb:4f2526
+ec b0x7f rgb:727069
+ec b0xff rgb:443d35
+ec bin rgb:988c77
+ec btext rgb:abb0ce
+
+ec call rgb:f48d20
+ec ucall rgb:f07019
+ec jmp rgb:ee320b
+ec ujmp rgb:a01a0a
+ec cjmp rgb:871a0a
+
+ec args rgb:8e735c
+ec cmp rgb:a0a0a0
+ec comment rgb:7f1609
+ec usrcmt rgb:d0e0b0
+ec reg rgb:fdf4cb
+ec creg rgb:d0e0a0
+ec flag rgb:b0270e
+ec fline rgb:dd0045
+ec flow rgb:f72
+ec flow2 rgb:fff
+ec fname rgb:de0008
+ec help rgb:9a2813
+ec input rgb:f72
+ec label rgb:d20009
+ec math rgb:777
+ec mov rgb:ded0d0
+ec nop rgb:544
+ec num rgb:d10007
+ec offset rgb:686660
+ec other rgb:4c4040
+ec pop rgb:99300f
+ec prompt rgb:8b1409
+ec push rgb:99300f
+ec ret rgb:f55521
+ec swi rgb:ff7020
+ec trap rgb:f07020
+ec linehl rgb:111
+
+ec graph.true rgb:e99e35
+ec graph.false rgb:9b260c
+ec graph.ujump rgb:bf614a
+ec graph.current rgb:fff862
+ec graph.traced rgb:f00005
+ec graph.box rgb:de3a0b
+ec graph.box2 rgb:7c0003
+ec graph.box3 rgb:370001
+ec graph.box4 rgb:370001
+
+ec func_var rgb:d18066
+ec func_var_type rgb:f07020
+ec func_var_addr rgb:82260e
+
+ec ai.read rgb:e0c0c0
+ec ai.write rgb:e0b0b0
+ec ai.exec rgb:e0a0a0
+ec ai.seq rgb:e09090
+ec ai.ascii rgb:f06050
+
+ec widget_bg rgb:f07020 rgb:333
+ec widget_sel rgb:333 rgb:f07020

--- a/test/db/cmd/cmd_ec
+++ b/test/db/cmd/cmd_ec
@@ -339,6 +339,6 @@ CMDS=<<EOF
 ecoj
 EOF
 EXPECT=<<EOF
-["ayu","basic","behelit","bold","bright","cga","consonance","cutter","dark","darkda","default","defragger","durian","focus","gb","gentoo","lima","matrix","monokai","ogray","onedark","pink","rasta","sepia","smyck","solarized","tango","twilight","white","white2","xvilka","zenburn"]
+["ayu","basic","behelit","bold","bright","cga","consonance","cutter","dark","darkda","default","defragger","durian","focus","gb","gentoo","lima","mars","matrix","monokai","ogray","onedark","pink","rasta","sepia","smyck","solarized","tango","twilight","white","white2","xvilka","zenburn"]
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Added "mars" color theme that is based on the color palette of DOOM Mars landscapes and real Mars photos

<img width="1219" alt="Screen Shot 2022-12-16 at 22 46 07" src="https://user-images.githubusercontent.com/203261/208126097-3102a155-8bb5-4091-8519-8ea98c1d0d55.png">

<img width="1156" alt="Screen Shot 2022-12-16 at 22 46 32" src="https://user-images.githubusercontent.com/203261/208126156-00c12cdd-227f-44cb-aa1d-6833fb410a55.png">

<img width="959" alt="Screen Shot 2022-12-16 at 22 47 02" src="https://user-images.githubusercontent.com/203261/208126181-c19a39a4-e1fc-4f92-ac0a-e94b61df1ff8.png">

Palette itself:

<img width="498" alt="Screen Shot 2022-12-16 at 23 01 04" src="https://user-images.githubusercontent.com/203261/208126694-1919ed2a-9b26-4583-b001-3e60c9f3ea2b.png">

