### PR TITLE
Dalvik disassembly should not throw error for single opcode

### DIFF
--- a/librz/analysis/p/analysis_dalvik.c
+++ b/librz/analysis/p/analysis_dalvik.c
@@ -48,7 +48,7 @@ static const char *getCondz(ut8 cond) {
 
 static int dalvik_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *data, int len, RzAnalysisOpMask mask) {
 	int sz = dalvik_opcodes[data[0]].len;
-	if (!op || sz >= len) {
+	if (!op || sz > len) {
 		if (op && (mask & RZ_ANALYSIS_OP_MASK_DISASM)) {
 			op->mnemonic = strdup("invalid");
 		}

--- a/test/db/analysis/dalvik
+++ b/test/db/analysis/dalvik
@@ -197,18 +197,28 @@ EOF
 RUN
 
 NAME=Dalvik disassemble single opcode pdfj
-FILE=apk://bins/dex/14d9f1a92dd984d6040cc41ed06e273e.apk
-CMDS=aa; pdfj @ 549755814276
+FILE=malloc://32
+CMDS=<<EOF
+e asm.arch=dalvik
+wx 0e00
+af
+pdfj
+EOF
 EXPECT=<<EOF
-{"name":"sym.Lcom_android_internal_telephony_ITelephony_Stub_.updateServiceLocation__V","size":2,"addr":549755814276,"ops":[{"offset":549755814276,"esil":"sp,[8],ip,=,8,sp,+=","refptr":false,"fcn_addr":549755814276,"fcn_last":549755814276,"size":2,"opcode":"return-void","disasm":"return-void","bytes":"0e00","family":"cpu","type":"ret","reloc":false,"type_num":5,"type2_num":0,"flags":["sym.Lcom_android_internal_telephony_ITelephony_Stub_.updateServiceLocation__V"]}]}
+{"name":"fcn.00000000","size":2,"addr":0,"ops":[{"offset":0,"esil":"sp,[8],ip,=,8,sp,+=","refptr":false,"fcn_addr":0,"fcn_last":0,"size":2,"opcode":"return-void","disasm":"return-void","bytes":"0e00","family":"cpu","type":"ret","reloc":false,"type_num":5,"type2_num":0,"flags":["fcn.00000000"]}]}
 EOF
 RUN
 
 NAME=Dalvik disassemble single opcode pdf
-FILE=apk://bins/dex/14d9f1a92dd984d6040cc41ed06e273e.apk
-CMDS=aa; pdf @ 549755814276
+FILE=
+CMDS=<<EOF
+e asm.arch=dalvik
+wx 0e00
+af
+pdf
+EOF
 EXPECT=<<EOF
-/ sym.Lcom_android_internal_telephony_ITelephony_Stub_.updateServiceLocation__V ();
-\           0x8000000184      return-void
+/ fcn.00000000 ();
+\           0x00000000      return-void
 EOF
 RUN

--- a/test/db/analysis/dalvik
+++ b/test/db/analysis/dalvik
@@ -195,3 +195,20 @@ EXPECT=<<EOF
   - 0x10001a24e fcn 0x100019f98 method.public.static.Lcom_network_android_a_c_.a_Landroid_content_Context_ILjava_lang_String_I_V
 EOF
 RUN
+
+NAME=Dalvik disassemble single opcode pdfj
+FILE=apk://bins/dex/14d9f1a92dd984d6040cc41ed06e273e.apk
+CMDS=aa; pdfj @ 549755814276
+EXPECT=<<EOF
+{"name":"sym.Lcom_android_internal_telephony_ITelephony_Stub_.updateServiceLocation__V","size":2,"addr":549755814276,"ops":[{"offset":549755814276,"esil":"sp,[8],ip,=,8,sp,+=","refptr":false,"fcn_addr":549755814276,"fcn_last":549755814276,"size":2,"opcode":"return-void","disasm":"return-void","bytes":"0e00","family":"cpu","type":"ret","reloc":false,"type_num":5,"type2_num":0,"flags":["sym.Lcom_android_internal_telephony_ITelephony_Stub_.updateServiceLocation__V"]}]}
+EOF
+RUN
+
+NAME=Dalvik disassemble single opcode pdf
+FILE=apk://bins/dex/14d9f1a92dd984d6040cc41ed06e273e.apk
+CMDS=aa; pdf @ 549755814276
+EXPECT=<<EOF
+/ sym.Lcom_android_internal_telephony_ITelephony_Stub_.updateServiceLocation__V ();
+\           0x8000000184      return-void
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Dalvik bytecode disassembler uses `>=` to check if the provided buffer is of appropriate size. Instead it should just use `>`, This allows to disassemble singular opcodes.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The new integration test should pass ~~(binary added in rizinorg/rizin-testbins#97)~~.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #3254.
