### PR TITLE
Add `-21` rizin flag that redirects stderr to stdout

### DIFF
--- a/test/db/cmd/cmd_arp
+++ b/test/db/cmd/cmd_arp
@@ -1,5 +1,6 @@
 NAME=arpg
 FILE==
+ARGS=-21
 CMDS=<<EOF
 arpg scripts/gdb-reg-profile.txt > $a
 ?v $?
@@ -11,6 +12,8 @@ EOF
 EXPECT=<<EOF
 0x0
 98
+Could not parse line: 0      0       4 uint32_t
+ERROR: Cannot parse gdb profile.
 0x1
 0
 EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr proposes adding the `-21` command line flag to `rizin` that redirects stderr to stdout. This is useful in tests for a complete view of test output with the output sequence being what actually happened. Also, this could be useful for logging without a shell.

`-21` should be a long option (i.e. `--21`) but a Rizin version of `getopt_long()` currently doesn't exist.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Adding the flag makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
