### PR TITLE
Fixed wrong subvar in json

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -5809,7 +5809,7 @@ RZ_API RZ_OWN RzPVector /*<RzAnalysisBytes *>*/ *rz_core_analysis_bytes(RZ_NONNU
 		}
 		op->mnemonic = mnem;
 
-		RzAnalysisFunction *fcn = rz_analysis_get_function_at(core->analysis, addr);
+		RzAnalysisFunction *fcn = rz_analysis_get_fcn_in(core->analysis, addr, RZ_ANALYSIS_FCN_TYPE_NULL);
 		char *asm_buff = calloc(strlen(an_asm) + 128, sizeof(char));
 		strcpy(asm_buff, an_asm);
 

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -2719,3 +2719,505 @@ EXPECT=<<EOF
 \           0x00000808      
 EOF
 RUN
+
+NAME=Check output pdr and pdrj to be the same
+FILE=bins/elf/crackme0x05
+CMDS=<<EOF
+aaa
+s main
+pdr
+pdrj~{}
+EOF
+EXPECT=<<EOF
+  ; DATA XREF from entry0 @ 0x80483e7
+/ int main (int argc, char **argv, char **envp);
+| ; var int32_t var_88h @ stack - 0x88
+| ; var int32_t var_7ch @ stack - 0x7c
+| 0x08048540      push  ebp
+| 0x08048541      mov   ebp, esp
+| 0x08048543      sub   esp, 0x88
+| 0x08048549      and   esp, 0xfffffff0
+| 0x0804854c      mov   eax, 0
+| 0x08048551      add   eax, 0xf                                       ; 15
+| 0x08048554      add   eax, 0xf                                       ; 15
+| 0x08048557      shr   eax, 4
+| 0x0804855a      shl   eax, 4
+| 0x0804855d      sub   esp, eax
+| 0x0804855f      mov   dword [esp], str.IOLI_Crackme_Level_0x05       ; [0x804868e:4]=0x494c4f49 ; "IOLI Crackme Level 0x05\n" ; const char *format
+| 0x08048566      call  sym.imp.printf                                 ; int printf(const char *format)
+| 0x0804856b      mov   dword [esp], str.Password:                     ; [0x80486a7:4]=0x73736150 ; "Password: " ; const char *format
+| 0x08048572      call  sym.imp.printf                                 ; int printf(const char *format)
+| 0x08048577      lea   eax, [var_7ch]
+| 0x0804857a      mov   dword [var_88h], eax
+| 0x0804857e      mov   dword [esp], data.080486b2                     ; [0x80486b2:4]=0x7325 ; "%s" ; const char *format
+| 0x08048585      call  sym.imp.scanf                                  ; int scanf(const char *format)
+| 0x0804858a      lea   eax, [var_7ch]
+| 0x0804858d      mov   dword [esp], eax                               ; int32_t arg_4h
+| 0x08048590      call  sym.check
+| 0x08048595      mov   eax, 0
+| 0x0804859a      leave
+\ 0x0804859b      ret
+
+[
+  {
+    "offset": 134513984,
+    "esil": "ebp,4,esp,-,=[4],4,esp,-=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514075,
+    "size": 1,
+    "opcode": "push ebp",
+    "disasm": "push ebp",
+    "bytes": "55",
+    "family": "cpu",
+    "type": "rpush",
+    "reloc": false,
+    "type_num": 268435468,
+    "type2_num": 0,
+    "flags": [
+      "main",
+      "sym.main"
+    ],
+    "xrefs_to": [
+      {
+        "addr": 134513639,
+        "type": "DATA"
+      }
+    ]
+  },
+  {
+    "offset": 134513985,
+    "esil": "esp,ebp,=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514074,
+    "size": 2,
+    "opcode": "mov ebp, esp",
+    "disasm": "mov ebp, esp",
+    "bytes": "89e5",
+    "family": "cpu",
+    "type": "mov",
+    "reloc": false,
+    "type_num": 9,
+    "type2_num": 0
+  },
+  {
+    "offset": 134513987,
+    "val": 136,
+    "esil": "136,esp,-=,136,0x80000000,-,!,31,$o,^,of,:=,31,$s,sf,:=,$z,zf,:=,$p,pf,:=,32,$b,cf,:=,3,$b,af,:=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514070,
+    "size": 6,
+    "opcode": "sub esp, 0x88",
+    "disasm": "sub esp, 0x88",
+    "bytes": "81ec88000000",
+    "family": "cpu",
+    "type": "sub",
+    "reloc": false,
+    "type_num": 18,
+    "type2_num": 0
+  },
+  {
+    "offset": 134513993,
+    "val": 4294967280,
+    "esil": "4294967280,esp,&=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=,0,cf,:=,0,of,:=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514073,
+    "size": 3,
+    "opcode": "and esp, 0xfffffff0",
+    "disasm": "and esp, 0xfffffff0",
+    "bytes": "83e4f0",
+    "family": "cpu",
+    "type": "and",
+    "reloc": false,
+    "type_num": 27,
+    "type2_num": 0
+  },
+  {
+    "offset": 134513996,
+    "val": 0,
+    "esil": "0,eax,=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514071,
+    "size": 5,
+    "opcode": "mov eax, 0",
+    "disasm": "mov eax, 0",
+    "bytes": "b800000000",
+    "family": "cpu",
+    "type": "mov",
+    "reloc": false,
+    "type_num": 9,
+    "type2_num": 0
+  },
+  {
+    "offset": 134514001,
+    "ptr": 15,
+    "val": 15,
+    "esil": "15,eax,+=,31,$o,of,:=,31,$s,sf,:=,$z,zf,:=,31,$c,cf,:=,$p,pf,:=,3,$c,af,:=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514073,
+    "size": 3,
+    "opcode": "add eax, 0xf",
+    "disasm": "add eax, 0xf",
+    "bytes": "83c00f",
+    "family": "cpu",
+    "type": "add",
+    "reloc": false,
+    "type_num": 17,
+    "type2_num": 0
+  },
+  {
+    "offset": 134514004,
+    "ptr": 15,
+    "val": 15,
+    "esil": "15,eax,+=,31,$o,of,:=,31,$s,sf,:=,$z,zf,:=,31,$c,cf,:=,$p,pf,:=,3,$c,af,:=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514073,
+    "size": 3,
+    "opcode": "add eax, 0xf",
+    "disasm": "add eax, 0xf",
+    "bytes": "83c00f",
+    "family": "cpu",
+    "type": "add",
+    "reloc": false,
+    "type_num": 17,
+    "type2_num": 0
+  },
+  {
+    "offset": 134514007,
+    "val": 4,
+    "esil": "0,cf,:=,1,4,-,1,<<,eax,&,?{,1,cf,:=,},4,eax,>>,eax,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514073,
+    "size": 3,
+    "opcode": "shr eax, 4",
+    "disasm": "shr eax, 4",
+    "bytes": "c1e804",
+    "family": "cpu",
+    "type": "shr",
+    "reloc": false,
+    "type_num": 22,
+    "type2_num": 0
+  },
+  {
+    "offset": 134514010,
+    "esil": "0,4,!,!,?{,1,4,-,eax,<<,0x80000000,&,!,!,^,},4,eax,<<=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=,cf,=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514073,
+    "size": 3,
+    "opcode": "shl eax, 4",
+    "disasm": "shl eax, 4",
+    "bytes": "c1e004",
+    "family": "cpu",
+    "type": "shl",
+    "reloc": false,
+    "type_num": 23,
+    "type2_num": 0
+  },
+  {
+    "offset": 134514013,
+    "esil": "eax,esp,-=,eax,0x80000000,-,!,31,$o,^,of,:=,31,$s,sf,:=,$z,zf,:=,$p,pf,:=,32,$b,cf,:=,3,$b,af,:=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514074,
+    "size": 2,
+    "opcode": "sub esp, eax",
+    "disasm": "sub esp, eax",
+    "bytes": "29c4",
+    "family": "cpu",
+    "type": "sub",
+    "reloc": false,
+    "type_num": 18,
+    "type2_num": 0
+  },
+  {
+    "offset": 134514015,
+    "ptr": 134514318,
+    "val": 134514318,
+    "esil": "134514318,esp,=[4]",
+    "refptr": true,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514069,
+    "size": 7,
+    "opcode": "mov dword [esp], 0x804868e",
+    "disasm": "mov dword [esp], str.IOLI_Crackme_Level_0x05",
+    "bytes": "c704248e860408",
+    "family": "cpu",
+    "type": "mov",
+    "reloc": false,
+    "type_num": 9,
+    "type2_num": 0,
+    "xrefs_from": [
+      {
+        "addr": 134514318,
+        "type": "DATA"
+      }
+    ]
+  },
+  {
+    "offset": 134514022,
+    "esil": "134513556,eip,4,esp,-=,esp,=[],eip,=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514071,
+    "size": 5,
+    "opcode": "call 0x8048394",
+    "disasm": "call sym.imp.printf",
+    "bytes": "e829feffff",
+    "family": "cpu",
+    "type": "call",
+    "reloc": false,
+    "type_num": 3,
+    "type2_num": 0,
+    "jump": 134513556,
+    "fail": 134514027,
+    "xrefs_from": [
+      {
+        "addr": 134513556,
+        "type": "CALL"
+      }
+    ]
+  },
+  {
+    "offset": 134514027,
+    "ptr": 134514343,
+    "val": 134514343,
+    "esil": "134514343,esp,=[4]",
+    "refptr": true,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514069,
+    "size": 7,
+    "opcode": "mov dword [esp], 0x80486a7",
+    "disasm": "mov dword [esp], str.Password:",
+    "bytes": "c70424a7860408",
+    "family": "cpu",
+    "type": "mov",
+    "reloc": false,
+    "type_num": 9,
+    "type2_num": 0,
+    "xrefs_from": [
+      {
+        "addr": 134514343,
+        "type": "DATA"
+      }
+    ]
+  },
+  {
+    "offset": 134514034,
+    "esil": "134513556,eip,4,esp,-=,esp,=[],eip,=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514071,
+    "size": 5,
+    "opcode": "call 0x8048394",
+    "disasm": "call sym.imp.printf",
+    "bytes": "e81dfeffff",
+    "family": "cpu",
+    "type": "call",
+    "reloc": false,
+    "type_num": 3,
+    "type2_num": 0,
+    "jump": 134513556,
+    "fail": 134514039,
+    "xrefs_from": [
+      {
+        "addr": 134513556,
+        "type": "CALL"
+      }
+    ]
+  },
+  {
+    "offset": 134514039,
+    "esil": "0x78,ebp,-,eax,=",
+    "refptr": true,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514073,
+    "size": 3,
+    "opcode": "lea eax, [ebp - 0x78]",
+    "disasm": "lea eax, [var_7ch]",
+    "bytes": "8d4588",
+    "family": "cpu",
+    "type": "lea",
+    "reloc": false,
+    "type_num": 33,
+    "type2_num": 0
+  },
+  {
+    "offset": 134514042,
+    "esil": "eax,0x4,esp,+,=[4]",
+    "refptr": true,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514072,
+    "size": 4,
+    "opcode": "mov dword [esp + 4], eax",
+    "disasm": "mov dword [var_88h], eax",
+    "bytes": "89442404",
+    "family": "cpu",
+    "type": "mov",
+    "reloc": false,
+    "type_num": 9,
+    "type2_num": 0
+  },
+  {
+    "offset": 134514046,
+    "ptr": 134514354,
+    "val": 134514354,
+    "esil": "134514354,esp,=[4]",
+    "refptr": true,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514069,
+    "size": 7,
+    "opcode": "mov dword [esp], 0x80486b2",
+    "disasm": "mov dword [esp], data.080486b2",
+    "bytes": "c70424b2860408",
+    "family": "cpu",
+    "type": "mov",
+    "reloc": false,
+    "type_num": 9,
+    "type2_num": 0,
+    "xrefs_from": [
+      {
+        "addr": 134514354,
+        "type": "DATA"
+      }
+    ]
+  },
+  {
+    "offset": 134514053,
+    "esil": "134513524,eip,4,esp,-=,esp,=[],eip,=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514071,
+    "size": 5,
+    "opcode": "call 0x8048374",
+    "disasm": "call sym.imp.scanf",
+    "bytes": "e8eafdffff",
+    "family": "cpu",
+    "type": "call",
+    "reloc": false,
+    "type_num": 3,
+    "type2_num": 0,
+    "jump": 134513524,
+    "fail": 134514058,
+    "xrefs_from": [
+      {
+        "addr": 134513524,
+        "type": "CALL"
+      }
+    ]
+  },
+  {
+    "offset": 134514058,
+    "esil": "0x78,ebp,-,eax,=",
+    "refptr": true,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514073,
+    "size": 3,
+    "opcode": "lea eax, [ebp - 0x78]",
+    "disasm": "lea eax, [var_7ch]",
+    "bytes": "8d4588",
+    "family": "cpu",
+    "type": "lea",
+    "reloc": false,
+    "type_num": 33,
+    "type2_num": 0
+  },
+  {
+    "offset": 134514061,
+    "esil": "eax,esp,=[4]",
+    "refptr": true,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514073,
+    "size": 3,
+    "opcode": "mov dword [esp], eax",
+    "disasm": "mov dword [esp], eax",
+    "bytes": "890424",
+    "family": "cpu",
+    "type": "mov",
+    "reloc": false,
+    "type_num": 9,
+    "type2_num": 0
+  },
+  {
+    "offset": 134514064,
+    "esil": "134513864,eip,4,esp,-=,esp,=[],eip,=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514071,
+    "size": 5,
+    "opcode": "call 0x80484c8",
+    "disasm": "call sym.check",
+    "bytes": "e833ffffff",
+    "family": "cpu",
+    "type": "call",
+    "reloc": false,
+    "type_num": 3,
+    "type2_num": 0,
+    "jump": 134513864,
+    "fail": 134514069,
+    "xrefs_from": [
+      {
+        "addr": 134513864,
+        "type": "CALL"
+      }
+    ]
+  },
+  {
+    "offset": 134514069,
+    "val": 0,
+    "esil": "0,eax,=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514071,
+    "size": 5,
+    "opcode": "mov eax, 0",
+    "disasm": "mov eax, 0",
+    "bytes": "b800000000",
+    "family": "cpu",
+    "type": "mov",
+    "reloc": false,
+    "type_num": 9,
+    "type2_num": 0
+  },
+  {
+    "offset": 134514074,
+    "esil": "ebp,esp,=,esp,[4],ebp,=,4,esp,+=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514075,
+    "size": 1,
+    "opcode": "leave",
+    "disasm": "leave",
+    "bytes": "c9",
+    "family": "cpu",
+    "type": "pop",
+    "reloc": false,
+    "type_num": 14,
+    "type2_num": 0
+  },
+  {
+    "offset": 134514075,
+    "esil": "esp,[4],eip,=,4,esp,+=",
+    "refptr": false,
+    "fcn_addr": 134513984,
+    "fcn_last": 134514075,
+    "size": 1,
+    "opcode": "ret",
+    "disasm": "ret",
+    "bytes": "c3",
+    "family": "cpu",
+    "type": "ret",
+    "reloc": false,
+    "type_num": 5,
+    "type2_num": 0
+  }
+]
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
This fix the output difference between `rz_core_print_disasm_json` and `rz_core_print_disasm` 