### PR TITLE
Fixes and tests for type bitsizes

### DIFF
--- a/librz/include/rz_type.h
+++ b/librz/include/rz_type.h
@@ -347,11 +347,6 @@ RZ_API RZ_OWN RzList /*<char *>*/ *rz_type_db_find_enums_by_val(const RzTypeDB *
 RZ_API RZ_OWN char *rz_type_db_enum_get_bitfield(const RzTypeDB *typedb, RZ_NONNULL const char *name, ut64 val);
 
 // Type size calculation
-RZ_API ut64 rz_type_db_atomic_bitsize(const RzTypeDB *typedb, RZ_NONNULL RzBaseType *btype);
-RZ_API ut64 rz_type_db_enum_bitsize(const RzTypeDB *typedb, RZ_NONNULL RzBaseType *btype);
-RZ_API ut64 rz_type_db_struct_bitsize(const RzTypeDB *typedb, RZ_NONNULL RzBaseType *btype);
-RZ_API ut64 rz_type_db_union_bitsize(const RzTypeDB *typedb, RZ_NONNULL RzBaseType *btype);
-RZ_API ut64 rz_type_db_typedef_bitsize(const RzTypeDB *typedb, RZ_NONNULL RzBaseType *btype);
 RZ_API ut64 rz_type_db_base_get_bitsize(const RzTypeDB *typedb, RZ_NONNULL RzBaseType *btype);
 RZ_API ut64 rz_type_db_get_bitsize(const RzTypeDB *typedb, RZ_NONNULL RzType *type);
 

--- a/librz/type/type.c
+++ b/librz/type/type.c
@@ -797,20 +797,7 @@ RZ_API ut64 rz_type_db_get_bitsize(const RzTypeDB *typedb, RZ_NONNULL RzType *ty
 	if (!btype) {
 		return 0;
 	}
-	if (btype->kind == RZ_BASE_TYPE_KIND_ENUM && type->identifier.kind == RZ_TYPE_IDENTIFIER_KIND_ENUM) {
-		return rz_type_db_enum_bitsize(typedb, btype);
-	} else if (btype->kind == RZ_BASE_TYPE_KIND_STRUCT && type->identifier.kind == RZ_TYPE_IDENTIFIER_KIND_STRUCT) {
-		return rz_type_db_struct_bitsize(typedb, btype);
-	} else if (btype->kind == RZ_BASE_TYPE_KIND_UNION && type->identifier.kind == RZ_TYPE_IDENTIFIER_KIND_UNION) {
-		return rz_type_db_union_bitsize(typedb, btype);
-	} else if (btype->kind == RZ_BASE_TYPE_KIND_ATOMIC) {
-		return rz_type_db_atomic_bitsize(typedb, btype);
-	} else if (btype->kind == RZ_BASE_TYPE_KIND_TYPEDEF) {
-		return rz_type_db_typedef_bitsize(typedb, btype);
-	}
-	// Should not happen
-	rz_warn_if_reached();
-	return 0;
+	return rz_type_db_base_get_bitsize(typedb, btype);
 }
 
 /**


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

* Fix rz_type_db_get_bitsize() without specifier and add tests
* Fix type bitsizes for struct/union member loops
  Even if the case is nonsensical in practice, we can't rule out the
possibility that a struct or union may contain itself as a member
(optionally through multiple recursion steps). This must be caught when
calculating the size of the type in order to not recurse infinitely.
Structs containing pointers to itself are not meant by this, as that is
perfectly valid and the size is determined without recursion.
However typedefs and arrays must be taken into account.

**Closing issues**

Addresses #329 by fixing the last assert
