### PR TITLE
Add missing help for Vb modes in V?

### DIFF
--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -259,6 +259,7 @@ static const char *help_visual[] = {
 	"?", "full help",
 	"!", "enter panels",
 	"a", "code analysis",
+	"b", "browse mode",
 	"c", "toggle cursor",
 	"d", "debugger / emulator",
 	"e", "toggle configurations",


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Adds an entry for `Vb` when calling `V?`