### PR TITLE
Avoid syncing regs in between multiple IL steps

### DIFF
--- a/librz/analysis/il/analysis_il.c
+++ b/librz/analysis/il/analysis_il.c
@@ -229,15 +229,17 @@ RZ_API bool rz_analysis_il_vm_sync_to_reg(RzAnalysisILVM *vm, RZ_NONNULL RzReg *
 }
 
 /**
- * Perform a single step in the VM
+ * Repeatedly perform steps in the VM until the condition callback returns false
  *
  * If given, this syncs the contents of \p reg into the vm.
- * Then it disassembles an instruction at the program counter of the vm and executes it.
- * Finally, if no error occured, the contents are optionally synced back to \p reg.
+ * Then it repeatedly disassembles an instruction at the program counter of the vm and executes it as long as cond() returns true.
+ * Finally the contents are optionally synced back to \p reg.
  *
- * \return and indicator for which error occured, if any
+ * \return and indicator for which error occured, if any, or RZ_ANALYSIS_IL_STEP_RESULT_SUCCESS if cond() returned false
  */
-RZ_API RzAnalysisILStepResult rz_analysis_il_vm_step(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL RzAnalysisILVM *vm, RZ_NULLABLE RzReg *reg) {
+RZ_API RzAnalysisILStepResult rz_analysis_il_vm_step_while(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL RzAnalysisILVM *vm, RZ_NULLABLE RzReg *reg,
+	bool (*cond)(RzAnalysisILVM *vm, void *user), void *user) {
+
 	rz_return_val_if_fail(analysis && vm, false);
 	RzAnalysisPlugin *cur = analysis->cur;
 	if (!cur || !analysis->read_at) {
@@ -247,27 +249,57 @@ RZ_API RzAnalysisILStepResult rz_analysis_il_vm_step(RZ_NONNULL RzAnalysis *anal
 	if (reg) {
 		rz_analysis_il_vm_sync_from_reg(vm, reg);
 	}
-	ut64 addr = rz_bv_to_ut64(vm->vm->pc);
 
-	ut8 code[32] = { 0 };
-	analysis->read_at(analysis, addr, code, sizeof(code));
-	RzAnalysisOp op = { 0 };
-	int r = rz_analysis_op(analysis, &op, addr, code, sizeof(code), RZ_ANALYSIS_OP_MASK_IL | RZ_ANALYSIS_OP_MASK_HINT);
-	RzILOpEffect *ilop = r < 0 ? NULL : op.il_op;
+	RzAnalysisILStepResult res = RZ_ANALYSIS_IL_STEP_RESULT_SUCCESS;
+	while (cond(vm, user)) {
+		ut64 addr = rz_bv_to_ut64(vm->vm->pc);
+		ut8 code[32] = { 0 };
+		analysis->read_at(analysis, addr, code, sizeof(code));
+		RzAnalysisOp op = { 0 };
+		int r = rz_analysis_op(analysis, &op, addr, code, sizeof(code), RZ_ANALYSIS_OP_MASK_IL | RZ_ANALYSIS_OP_MASK_HINT);
+		RzILOpEffect *ilop = r < 0 ? NULL : op.il_op;
 
-	RzAnalysisILStepResult res;
-	if (ilop) {
-		bool succ = rz_il_vm_step(vm->vm, ilop, addr + (op.size > 0 ? op.size : 1));
-		res = succ ? RZ_ANALYSIS_IL_STEP_RESULT_SUCCESS : RZ_ANALYSIS_IL_STEP_IL_RUNTIME_ERROR;
-		if (reg) {
-			rz_analysis_il_vm_sync_to_reg(vm, reg);
+		if (ilop) {
+			bool succ = rz_il_vm_step(vm->vm, ilop, addr + (op.size > 0 ? op.size : 1));
+			if (!succ) {
+				res = RZ_ANALYSIS_IL_STEP_IL_RUNTIME_ERROR;
+			}
+		} else {
+			res = RZ_ANALYSIS_IL_STEP_INVALID_OP;
 		}
-	} else {
-		res = RZ_ANALYSIS_IL_STEP_INVALID_OP;
-	}
 
-	rz_analysis_op_fini(&op);
+		rz_analysis_op_fini(&op);
+		if (res != RZ_ANALYSIS_IL_STEP_RESULT_SUCCESS) {
+			break;
+		}
+	}
+	if (reg) {
+		rz_analysis_il_vm_sync_to_reg(vm, reg);
+	}
 	return res;
+}
+
+static bool step_cond_once(RzAnalysisILVM *vm, void *user) {
+	bool *stepped = user;
+	if (*stepped) {
+		return false;
+	}
+	*stepped = true;
+	return true;
+}
+
+/**
+ * Perform a single step in the VM
+ *
+ * If given, this syncs the contents of \p reg into the vm.
+ * Then it disassembles an instruction at the program counter of the vm and executes it.
+ * Finally the contents are optionally synced back to \p reg.
+ *
+ * \return and indicator for which error occured, if any
+ */
+RZ_API RzAnalysisILStepResult rz_analysis_il_vm_step(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL RzAnalysisILVM *vm, RZ_NULLABLE RzReg *reg) {
+	bool stepped = false;
+	return rz_analysis_il_vm_step_while(analysis, vm, reg, step_cond_once, &stepped);
 }
 
 /// @}

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -4504,11 +4504,7 @@ RZ_IPI RzCmdStatus rz_il_vm_initialize_handler(RzCore *core, int argc, const cha
 
 RZ_IPI RzCmdStatus rz_il_vm_step_handler(RzCore *core, int argc, const char **argv) {
 	ut64 repeat_times = argc == 1 ? 1 : rz_num_math(NULL, argv[1]);
-	for (ut64 i = 0; i < repeat_times; ++i) {
-		if (!rz_core_il_step(core)) {
-			break;
-		}
-	}
+	rz_core_il_step(core, repeat_times);
 	return RZ_CMD_STATUS_OK;
 }
 
@@ -4538,25 +4534,7 @@ RZ_IPI RzCmdStatus rz_il_vm_step_with_events_handler(RzCore *core, int argc, con
 
 RZ_IPI RzCmdStatus rz_il_vm_step_until_addr_handler(RzCore *core, int argc, const char **argv) {
 	ut64 address = rz_num_math(core->num, argv[1]);
-
-	if (!core->analysis->il_vm) {
-		RZ_LOG_ERROR("RzIL: the VM is not initialized.\n");
-		return RZ_CMD_STATUS_ERROR;
-	}
-
-	while (1) {
-		ut64 pc = rz_reg_get_value_by_role(core->analysis->reg, RZ_REG_NAME_PC);
-		if (pc == address) {
-			break;
-		}
-		if (rz_cons_is_breaked()) {
-			rz_cons_printf("CTRL+C was pressed.\n");
-			break;
-		}
-		if (!rz_core_il_step(core)) {
-			break;
-		}
-	}
+	rz_core_il_step_until(core, address);
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -28,7 +28,8 @@ RZ_IPI void rz_core_debug_esil_watch_print(RzDebug *dbg, RzCmdStateOutput *state
 RZ_IPI void rz_core_analysis_il_reinit(RzCore *core);
 RZ_IPI bool rz_core_analysis_il_vm_set(RzCore *core, const char *var_name, ut64 value);
 RZ_IPI void rz_core_analysis_il_vm_status(RzCore *core, const char *varname, RzOutputMode mode);
-RZ_IPI bool rz_core_il_step(RzCore *core);
+RZ_IPI bool rz_core_il_step(RzCore *core, ut64 n);
+RZ_IPI bool rz_core_il_step_until(RzCore *core, ut64 until);
 RZ_IPI bool rz_core_analysis_il_step_with_events(RzCore *core, PJ *pj);
 
 RZ_IPI bool rz_core_analysis_var_rename(RzCore *core, const char *name, const char *newname);

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1565,6 +1565,8 @@ RZ_API void rz_analysis_il_vm_free(RZ_NULLABLE RzAnalysisILVM *vm);
 RZ_API void rz_analysis_il_vm_sync_from_reg(RzAnalysisILVM *vm, RZ_NONNULL RzReg *reg);
 RZ_API bool rz_analysis_il_vm_sync_to_reg(RzAnalysisILVM *vm, RZ_NONNULL RzReg *reg);
 RZ_API RzAnalysisILStepResult rz_analysis_il_vm_step(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL RzAnalysisILVM *vm, RZ_NULLABLE RzReg *reg);
+RZ_API RzAnalysisILStepResult rz_analysis_il_vm_step_while(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL RzAnalysisILVM *vm, RZ_NULLABLE RzReg *reg,
+	bool (*cond)(RzAnalysisILVM *vm, void *user), void *user);
 RZ_API bool rz_analysis_il_vm_setup(RzAnalysis *analysis);
 RZ_API void rz_analysis_il_vm_cleanup(RzAnalysis *analysis);
 

--- a/test/db/rzil/ppc64
+++ b/test/db/rzil/ppc64
@@ -574,6 +574,7 @@ RUN
 NAME=emulateme-big-endian
 FILE=bins/elf/ppc/emulateme-ppc64be
 TIMEOUT=30
+ARGS=-T
 CMDS=<<EOF
 s sym.decrypt
 ps @ obj.seckrit
@@ -598,6 +599,7 @@ RUN
 NAME=emulateme-little-endian
 FILE=bins/elf/ppc/emulateme-ppc64le
 TIMEOUT=30
+ARGS=-T
 CMDS=<<EOF
 s sym.decrypt
 ps @ obj.seckrit


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

When stepping multiple times in the analysis RzIL vm, it is not necessary to sync the regs from and to RzReg between every instruction, but only at the beginning and at the end.
The conditions for stepping until an addr and fixed-count stepping are handled as callbacks inside rz_analysis_il_vm_step_while(), so the sync logic does not have to be exposed to the caller.

Before:
```
sparc$ time rizin -N -T -Qc 's sym.decrypt; ps @ obj.seckrit; aezi; o malloc://0x1000 0x400000; o malloc://0x10 0x500000; e io.cache=1; w AnyColourYouLike @ 0x500000; ar r1=0x400000; ar r3=0x500000; aezsu 0x001007f8; ps @ obj.seckrit' test/bins/elf/ppc/emulateme-ppc64le
QSMwX\x14Q_El\x17\x7fnx\x7f\x1c
Hello from RzIL!
    0m21.84s real     0m19.41s user     0m01.98s system
```
After:
```
sparc$ time rizin -N -T -Qc 's sym.decrypt; ps @ obj.seckrit; aezi; o malloc://0x1000 0x400000; o malloc://0x10 0x500000; e io.cache=1; w AnyColourYouLike @ 0x500000; ar r1=0x400000; ar r3=0x500000; aezsu 0x001007f8; ps @ obj.seckrit' test/bins/elf/ppc/emulateme-ppc64le
QSMwX\x14Q_El\x17\x7fnx\x7f\x1c
Hello from RzIL!
    0m14.38s real     0m11.70s user     0m02.24s system
```

I am also adding a change to the test this is affecting to speed it up even more by skipping the hash loading.