### PR TITLE
Patch Mach-O chained ptrs into sparse overlay RzBuffer

### DIFF
--- a/librz/bin/format/mach0/kernelcache.h
+++ b/librz/bin/format/mach0/kernelcache.h
@@ -29,7 +29,7 @@ typedef struct rz_xnu_kernelcache_parsed_pointer_t {
 
 typedef struct rz_xnu_kernelcache_obj_t {
 	RzBuffer *cache_buf;
-	RzBuffer *rebased_buf;
+	RzBuffer *patched_buf;
 	RCFValueDict *prelink_info;
 	ut64 pa2va_exec;
 	ut64 pa2va_data;
@@ -38,12 +38,11 @@ typedef struct rz_xnu_kernelcache_obj_t {
 	RzXNUKernelCacheRebaseInfo *rebase_info;
 	int (*original_io_read)(RzIO *io, RzIODesc *fd, ut8 *buf, int count);
 	bool rebase_info_populated;
-	bool rebasing_buffer;
 	bool kexts_initialized;
 } RzXNUKernelCacheObj;
 
 RZ_API bool rz_xnu_kernelcache_buf_is_kernelcache(RzBuffer *b);
-RZ_API RzBuffer *rz_xnu_kernelcache_new_rebasing_buf(RzXNUKernelCacheObj *obj);
+RZ_API RzBuffer *rz_xnu_kernelcache_new_patched_buf(RzXNUKernelCacheObj *obj);
 RZ_API bool rz_xnu_kernelcache_needs_rebasing(RzXNUKernelCacheObj *obj);
 RZ_API bool rz_xnu_kernelcache_parse_pointer(RzXNUKernelCacheParsedPointer *ptr, ut64 decorated_addr, RzXNUKernelCacheObj *obj);
 

--- a/librz/bin/format/mach0/mach0.c
+++ b/librz/bin/format/mach0/mach0.c
@@ -2189,18 +2189,7 @@ RzList /*<RzBinVirtualFile *>*/ *MACH0_(get_virtual_files)(RzBinFile *bf) {
 		return NULL;
 	}
 
-	// rebasing+stripping for arm64e
 	struct MACH0_(obj_t) *obj = bf->o->bin_obj;
-	if (MACH0_(needs_rebasing_and_stripping)(obj)) {
-		RzBinVirtualFile *vf = RZ_NEW0(RzBinVirtualFile);
-		if (!vf) {
-			return ret;
-		}
-		vf->buf = MACH0_(new_rebasing_and_stripping_buf)(obj);
-		vf->buf_owned = true;
-		vf->name = strdup(MACH0_VFILE_NAME_REBASED_STRIPPED);
-		rz_list_push(ret, vf);
-	}
 
 	// clang-format off
 	// relocs
@@ -2259,14 +2248,9 @@ RzList /*<RzBinMap *>*/ *MACH0_(get_maps_unpatched)(RzBinFile *bf) {
 		map->name = rz_str_ndup(seg->segname, 16);
 		rz_str_filter(map->name);
 		map->perm = prot2perm(seg->initprot);
-		if (MACH0_(segment_needs_rebasing_and_stripping)(bin, i)) {
-			map->vfile_name = strdup(MACH0_VFILE_NAME_REBASED_STRIPPED);
-			map->paddr = seg->fileoff;
-		} else {
-			// boffset is relevant for fatmach0 where the mach0 is located boffset into the whole file
-			// the rebasing vfile above however is based at the mach0 already
-			map->paddr = seg->fileoff + bf->o->boffset;
-		}
+		// boffset is relevant for fatmach0 where the mach0 is located boffset into the whole file
+		// the rebasing vfile above however is based at the mach0 already
+		map->paddr = seg->fileoff + bf->o->boffset;
 		rz_list_append(ret, map);
 	}
 	return ret;

--- a/librz/bin/format/mach0/mach0.h
+++ b/librz/bin/format/mach0/mach0.h
@@ -189,9 +189,8 @@ struct MACH0_(obj_t) {
 	RzHash *hash;
 };
 
-#define MACH0_VFILE_NAME_REBASED_STRIPPED "rebased_stripped"
-#define MACH0_VFILE_NAME_RELOC_TARGETS    "reloc-targets"
-#define MACH0_VFILE_NAME_PATCHED          "patched"
+#define MACH0_VFILE_NAME_RELOC_TARGETS "reloc-targets"
+#define MACH0_VFILE_NAME_PATCHED       "patched"
 
 void MACH0_(opts_set_default)(struct MACH0_(opts_t) * options, RzBinFile *bf);
 struct MACH0_(obj_t) * MACH0_(new_buf)(RzBuffer *buf, struct MACH0_(opts_t) * options);
@@ -232,8 +231,7 @@ RZ_API RZ_OWN char *MACH0_(get_name)(struct MACH0_(obj_t) * mo, ut32 stridx, boo
 RZ_API ut64 MACH0_(paddr_to_vaddr)(struct MACH0_(obj_t) * bin, ut64 offset);
 RZ_API ut64 MACH0_(vaddr_to_paddr)(struct MACH0_(obj_t) * bin, ut64 addr);
 
-RZ_API void MACH0_(rebase_buffer)(struct MACH0_(obj_t) * obj, ut64 off, ut8 *buf, ut64 count);
-RZ_API RzBuffer *MACH0_(new_rebasing_and_stripping_buf)(struct MACH0_(obj_t) * obj);
+RZ_API void MACH0_(rebase_buffer)(struct MACH0_(obj_t) * obj, RzBuffer *dst);
 RZ_API bool MACH0_(needs_rebasing_and_stripping)(struct MACH0_(obj_t) * obj);
 RZ_API bool MACH0_(segment_needs_rebasing_and_stripping)(struct MACH0_(obj_t) * obj, size_t seg_index);
 

--- a/librz/bin/format/mach0/mach0_rebase.c
+++ b/librz/bin/format/mach0/mach0_rebase.c
@@ -21,9 +21,9 @@
 #define IS_PTR_AUTH(x) ((x & (1ULL << 63)) != 0)
 #define IS_PTR_BIND(x) ((x & (1ULL << 62)) != 0)
 
-RZ_API void MACH0_(rebase_buffer)(struct MACH0_(obj_t) * obj, ut64 off, ut8 *buf, ut64 count) {
-	rz_return_if_fail(obj && buf);
-	ut64 eob = off + count;
+RZ_API void MACH0_(rebase_buffer)(struct MACH0_(obj_t) * obj, RzBuffer *dst) {
+	rz_return_if_fail(obj && dst);
+	ut64 eob = rz_buf_size(obj->b);
 	ut64 nsegs_to_rebase = RZ_MIN(obj->nchained_starts, obj->nsegs);
 	for (int i = 0; i < nsegs_to_rebase; i++) {
 		if (!obj->chained_starts[i]) {
@@ -33,10 +33,10 @@ RZ_API void MACH0_(rebase_buffer)(struct MACH0_(obj_t) * obj, ut64 off, ut8 *buf
 		ut64 page_size = segment->page_size;
 		ut64 start = obj->segs[i].fileoff;
 		ut64 end = start + obj->segs[i].filesize;
-		if (end < off || start > eob || page_size < 1) {
+		if (start > eob || page_size < 1) {
 			continue;
 		}
-		ut64 page_idx = (RZ_MAX(start, off) - start) / page_size;
+		ut64 page_idx = 0;
 		ut64 page_end_idx = (RZ_MIN(eob, end) - start) / page_size;
 		for (; page_idx <= page_end_idx; page_idx++) {
 			if (!segment->page_start || page_idx >= segment->page_count) {
@@ -141,9 +141,8 @@ RZ_API void MACH0_(rebase_buffer)(struct MACH0_(obj_t) * obj, ut64 off, ut8 *buf
 						segment->pointer_format, cursor);
 					goto break_it_all;
 				}
-				ut64 in_buf = cursor - off;
-				if (cursor >= off && cursor <= eob - 8) {
-					rz_write_le64(&buf[in_buf], ptr_value);
+				if (cursor <= eob - 8) {
+					rz_buf_write_le64_at(dst, cursor, ptr_value);
 				}
 				cursor += delta * stride;
 				if (!delta) {
@@ -155,78 +154,6 @@ RZ_API void MACH0_(rebase_buffer)(struct MACH0_(obj_t) * obj, ut64 off, ut8 *buf
 			}
 		}
 	}
-}
-
-typedef struct {
-	struct MACH0_(obj_t) * obj;
-	ut64 off;
-} BufCtx;
-
-static bool buf_init(RzBuffer *b, const void *user) {
-	BufCtx *ctx = RZ_NEW0(BufCtx);
-	if (!ctx) {
-		return false;
-	}
-	ctx->obj = (void *)user;
-	b->priv = ctx;
-	return true;
-}
-
-static bool buf_fini(RzBuffer *b) {
-	BufCtx *ctx = b->priv;
-	free(ctx);
-	return true;
-}
-
-static bool buf_resize(RzBuffer *b, ut64 newsize) {
-	BufCtx *ctx = b->priv;
-	return rz_buf_resize(ctx->obj->b, newsize);
-}
-
-static st64 buf_read(RzBuffer *b, ut8 *buf, ut64 len) {
-	BufCtx *ctx = b->priv;
-	st64 r = rz_buf_read_at(ctx->obj->b, ctx->off, buf, len);
-	if (r <= 0 || !len) {
-		return r;
-	}
-	MACH0_(rebase_buffer)
-	(ctx->obj, ctx->off, buf, RZ_MIN(r, len));
-	return r;
-}
-
-static st64 buf_write(RzBuffer *b, const ut8 *buf, ut64 len) {
-	BufCtx *ctx = b->priv;
-	return rz_buf_write_at(ctx->obj->b, ctx->off, buf, len);
-}
-
-static ut64 buf_get_size(RzBuffer *b) {
-	BufCtx *ctx = b->priv;
-	return rz_buf_size(ctx->obj->b);
-}
-
-static st64 buf_seek(RzBuffer *b, st64 addr, int whence) {
-	BufCtx *ctx = b->priv;
-	return ctx->off = rz_seek_offset(ctx->off, rz_buf_size(b), addr, whence);
-}
-
-static ut8 *buf_get_whole_buf(RzBuffer *b, ut64 *sz) {
-	BufCtx *ctx = b->priv;
-	return (ut8 *)rz_buf_data(ctx->obj->b, sz);
-}
-
-static const RzBufferMethods buf_methods = {
-	.init = buf_init,
-	.fini = buf_fini,
-	.read = buf_read,
-	.write = buf_write,
-	.get_size = buf_get_size,
-	.resize = buf_resize,
-	.seek = buf_seek,
-	.get_whole_buf = buf_get_whole_buf
-};
-
-RZ_API RzBuffer *MACH0_(new_rebasing_and_stripping_buf)(struct MACH0_(obj_t) * obj) {
-	return rz_buf_new_with_methods(&buf_methods, obj);
 }
 
 RZ_API bool MACH0_(needs_rebasing_and_stripping)(struct MACH0_(obj_t) * obj) {

--- a/librz/bin/format/objc/mach0_classes.c
+++ b/librz/bin/format/objc/mach0_classes.c
@@ -1251,16 +1251,9 @@ RZ_API RzList /*<RzBinClass *>*/ *MACH0_(parse_classes)(RzBinFile *bf, objc_cach
 		return NULL;
 	}
 	bigendian = bf->o->info->big_endian;
+	struct MACH0_(obj_t) *obj = bf->o->bin_obj;
 
-	RzBuffer *buf = bf->buf;
-	RzBuffer *owned_buf = NULL;
-	if (MACH0_(needs_rebasing_and_stripping)(bf->o->bin_obj)) {
-		owned_buf = MACH0_(new_rebasing_and_stripping_buf)(bf->o->bin_obj);
-		if (!owned_buf) {
-			return NULL;
-		}
-		buf = owned_buf;
-	}
+	RzBuffer *buf = obj->buf_patched ? obj->buf_patched : bf->buf;
 
 	RzSkipList *relocs = MACH0_(get_relocs)(bf->o->bin_obj);
 
@@ -1273,7 +1266,6 @@ RZ_API RzList /*<RzBinClass *>*/ *MACH0_(parse_classes)(RzBinFile *bf, objc_cach
 
 	struct section_t *sections = NULL;
 	if (!(sections = MACH0_(get_sections)(bf->o->bin_obj))) {
-		rz_buf_free(owned_buf);
 		return ret;
 	}
 
@@ -1350,7 +1342,6 @@ RZ_API RzList /*<RzBinClass *>*/ *MACH0_(parse_classes)(RzBinFile *bf, objc_cach
 get_classes_error:
 	rz_list_free(sctns);
 	rz_list_free(ret);
-	rz_buf_free(owned_buf);
 	// XXX DOUBLE FREE rz_bin_class_free (klass);
 	return NULL;
 }

--- a/librz/bin/p/bin_xnu_kernelcache.c
+++ b/librz/bin/p/bin_xnu_kernelcache.c
@@ -12,7 +12,7 @@
 #include "../format/mach0/kernelcache.h"
 #include "../format/xnu/mig_index.h"
 
-#define VFILE_NAME_REBASED "rebased"
+#define VFILE_NAME_PATCHED "patched"
 
 typedef struct _RPrelinkRange {
 	RzXNUKernelCacheFileRange range;
@@ -175,7 +175,7 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *o, RzBuffer *buf, Sdb *sdb) 
 	o->bin_obj = obj;
 
 	if (rz_xnu_kernelcache_needs_rebasing(obj)) {
-		obj->rebased_buf = rz_xnu_kernelcache_new_rebasing_buf(obj);
+		obj->patched_buf = rz_xnu_kernelcache_new_patched_buf(obj);
 	}
 
 	return true;
@@ -992,14 +992,14 @@ static RzList /*<RzBinVirtualFile *>*/ *virtual_files(RzBinFile *bf) {
 		return NULL;
 	}
 	RzXNUKernelCacheObj *kobj = bf->o->bin_obj;
-	if (kobj->rebased_buf) {
+	if (kobj->patched_buf) {
 		RzBinVirtualFile *vf = RZ_NEW0(RzBinVirtualFile);
 		if (!vf) {
 			return ret;
 		}
-		vf->buf = kobj->rebased_buf;
+		vf->buf = kobj->patched_buf;
 		vf->buf_owned = false;
-		vf->name = strdup(VFILE_NAME_REBASED);
+		vf->name = strdup(VFILE_NAME_PATCHED);
 		rz_list_push(ret, vf);
 	}
 	return ret;
@@ -1038,7 +1038,7 @@ static RzList /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 			map->vaddr = map->paddr;
 		}
 		map->perm = prot2perm(seg->initprot);
-		map->vfile_name = kobj->rebased_buf ? strdup(VFILE_NAME_REBASED) : NULL;
+		map->vfile_name = kobj->patched_buf ? strdup(VFILE_NAME_PATCHED) : NULL;
 		rz_list_append(ret, map);
 	}
 

--- a/test/db/formats/mach0/relocs
+++ b/test/db/formats/mach0/relocs
@@ -1402,7 +1402,7 @@ vaddr paddr type name
 ----------------------
 --
  3 * r-x 0x0001e290 bins/mach0/IOKitTest-arm64e.kext/Contents/MacOS/IOKitTest
- 4 - r-x 0x0001e290 vfile://0/rebased_stripped
+ 4 - r-x 0x0001e290 vfile://0/patched
  1 fd: 3 +0x00000000 0x00000000 - 0x00003fff r-- fmap.__TEXT
  2 fd: 3 +0x00004000 0x00004000 * 0x00007fff r-x fmap.__TEXT_EXEC
  3 fd: 4 +0x00008000 0x00008000 - 0x0000bfff r-- vmap.__DATA


### PR DESCRIPTION


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Patching the chained ptrs on the fly during every read as before turned out to be a major bottleneck on larger binaries. So now we patch everything once into a sparse overlay buffer, like it is already done in ELF and classic Mach-O relocs.

Before:
```
florian-macbook:rizin florian$ ls -lh /System/Applications/Mail.app/Contents/MacOS/Mail
-rwxr-xr-x  1 root  wheel   9.9M Oct 28 10:43 /System/Applications/Mail.app/Contents/MacOS/Mail
florian-macbook:rizin florian$ time rz -Qc "" /System/Applications/Mail.app/Contents/MacOS/Mail

real	0m9.076s
user	0m8.935s
sys	0m0.167s
```
After:
```
florian-macbook:rizin florian$ time rz -Qc "" /System/Applications/Mail.app/Contents/MacOS/Mail

real	0m1.563s
user	0m1.528s
sys	0m0.064s
```

Sufficient tests already exist for the covered functionality.