### PR TITLE
Make xnu reg profile depend on cpu type instead of RzDebug.bits

### DIFF
--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -275,7 +275,6 @@ RZ_API void rz_core_debug_bp_add_noreturn_func(RzCore *core) {
 RZ_IPI void rz_core_debug_attach(RzCore *core, int pid) {
 	char buf[20];
 
-	rz_debug_reg_profile_sync(core->dbg);
 	if (pid > 0) {
 		rz_debug_attach(core->dbg, pid);
 	} else {

--- a/librz/debug/debug.c
+++ b/librz/debug/debug.c
@@ -448,6 +448,11 @@ RZ_API int rz_debug_attach(RzDebug *dbg, int pid) {
 		if (ret != -1) {
 			dbg->reason.type = RZ_DEBUG_REASON_NONE; // after a successful attach, the process is not dead
 			rz_debug_select(dbg, pid, ret); // dbg->pid, dbg->tid);
+			// After an attach, all relevant info to build the reg profile should be available in the plugin.
+			// E.g. in the xnu debugger, the profile may not be available before the attach and cpu type is known.
+			if (!rz_debug_reg_profile_sync(dbg)) {
+				RZ_LOG_WARN("Cannot retrieve reg profile from debug plugin (%s)\n", dbg->cur->name);
+			}
 		}
 	}
 	return ret;

--- a/librz/debug/dreg.c
+++ b/librz/debug/dreg.c
@@ -123,7 +123,14 @@ RZ_API ut64 rz_debug_num_callback(RzNum *userptr, const char *str, int *ok) {
 	return rz_reg_get_value(dbg->reg, ri);
 }
 
+/**
+ * Load the register profile from the current plugin into dbg->reg and
+ * if successful also sync all register contents into it.
+ *
+ * \return whether the register profile was provided by the plugin
+ */
 RZ_API bool rz_debug_reg_profile_sync(RzDebug *dbg) {
+	rz_return_val_if_fail(dbg, false);
 	if (dbg->cur->reg_profile) {
 		char *p = dbg->cur->reg_profile(dbg);
 		if (p) {
@@ -131,7 +138,9 @@ RZ_API bool rz_debug_reg_profile_sync(RzDebug *dbg) {
 			rz_debug_reg_sync(dbg, RZ_REG_TYPE_ANY, false);
 			free(p);
 		} else {
-			RZ_LOG_WARN("Cannot retrieve reg profile from debug plugin (%s)\n", dbg->cur->name);
+			// May happen when the plugin does not yet have enough info
+			// to determine the reg profile
+			rz_reg_set_profile_string(dbg->reg, "");
 			return false;
 		}
 	}

--- a/librz/debug/p/native/xnu/xnu_debug.c
+++ b/librz/debug/p/native/xnu/xnu_debug.c
@@ -282,25 +282,29 @@ int xnu_continue(RzDebug *dbg, int pid, int tid, int sig) {
 }
 
 char *xnu_reg_profile(RzDebug *dbg) {
-#if __i386__ || __x86_64__
-	if (dbg->bits & RZ_SYS_BITS_32) {
-#include "reg/darwin-x86.h"
-	} else if (dbg->bits == RZ_SYS_BITS_64) {
-#include "reg/darwin-x64.h"
-	} else {
-		eprintf("invalid bit size\n");
+#if __POWERPC__
+#include "reg/darwin-ppc.h"
+#else
+	RzXnuDebug *ctx = dbg->plugin_data;
+	if (!ctx || !ctx->cpu) {
+		// not yet attached, arch still unknown
 		return NULL;
 	}
-#elif __POWERPC__
-#include "reg/darwin-ppc.h"
+#if __i386__ || __x86_64__
+	if (ctx->cpu == CPU_TYPE_X86_64) {
+#include "reg/darwin-x64.h"
+	} else {
+#include "reg/darwin-x86.h"
+	}
 #elif __APPLE__ && (__aarch64__ || __arm64__ || __arm__)
-	if (dbg->bits == RZ_SYS_BITS_64) {
+	if (ctx->cpu == CPU_TYPE_ARM64) {
 #include "reg/darwin-arm64.h"
 	} else {
 #include "reg/darwin-arm.h"
 	}
 #else
 #error "Unsupported Apple architecture"
+#endif
 #endif
 }
 

--- a/librz/debug/plugin.c
+++ b/librz/debug/plugin.c
@@ -49,6 +49,8 @@ RZ_API bool rz_debug_use(RzDebug *dbg, const char *str) {
 	if (dbg->cur->init) {
 		dbg->cur->init(dbg, &dbg->plugin_data);
 	}
+	// Syncing the reg profile here may fail if the plugin is not ready, but it should
+	// at least clean up the old RzReg contents.
 	rz_debug_reg_profile_sync(dbg);
 	return true;
 }

--- a/test/db/archos/darwin-arm64/dbg
+++ b/test/db/archos/darwin-arm64/dbg
@@ -160,3 +160,39 @@ Process finished
 
 EOF
 RUN
+
+NAME=break multiple times and check regs (fat)
+FILE=bins/mach0/calculate-macos-fat-arm64-x86_64
+ARGS=-d
+CMDS=<<EOF
+db @ main
+db @ main + 20
+db @ main + 24
+dc
+dr pc
+?e --
+dc
+dr pc
+dr x8
+?e --
+dc
+dr pc
+dr x8
+EOF
+REGEXP_FILTER_OUT=(([a-zA-Z:=-]+|[0-9a-f][0-9a-f][0-9a-f]|x[0-9]+ = [a-z0-9]+)\s+)
+EXPECT=<<EOF
+pc = f30
+--
+pc = f44
+x8 = 0x0000000000000000
+--
+pc = f48
+x8 = 0x0000000000000064
+EOF
+REGEXP_FILTER_ERR=(([a-zA-Z:]+|[0-9a-f][0-9a-f][0-9a-f])\s+)
+EXPECT_ERR=<<EOF
+hit breakpoint at: f30
+hit breakpoint at: f44
+hit breakpoint at: f48
+EOF
+RUN

--- a/test/db/archos/darwin-x64/dbg
+++ b/test/db/archos/darwin-x64/dbg
@@ -120,3 +120,75 @@ hit breakpoint at: 0x100000f0c
 hit breakpoint at: 0x100000f17
 EOF
 RUN
+
+NAME=break multiple times and check regs (fat arm64-x86_64)
+FILE=bins/mach0/calculate-macos-fat-arm64-x86_64
+ARGS=-d
+CMDS=<<EOF
+db @ main
+db @ main + 20
+db @ main + 24
+dc
+dr rip
+?e --
+dc
+dr rip
+dr rax
+?e --
+dc
+dr rip
+dr rax
+EOF
+REGEXP_FILTER_OUT=(([a-zA-Z:=-]+|[0-9a-f][0-9a-f][0-9a-f]|r[^i][a-z]+ = [a-z0-9]+)\s+)
+EXPECT=<<EOF
+rip = f20
+--
+rip = f34
+rax = 0x0000000000000000
+--
+rip = f38
+rax = 0x0000000000000064
+EOF
+REGEXP_FILTER_ERR=(([a-zA-Z:]+|[0-9a-f][0-9a-f][0-9a-f])\s+)
+EXPECT_ERR=<<EOF
+hit breakpoint at: f20
+hit breakpoint at: f34
+hit breakpoint at: f38
+EOF
+RUN
+
+NAME=break multiple times and check regs (fat i386-x86_64)
+FILE=bins/mach0/calculate-macos-fat-i386-x86_64
+ARGS=-d
+CMDS=<<EOF
+db @ main
+db @ main + 61
+db @ main + 67
+dc
+dr rip
+?e --
+dc
+dr rip
+dr rax
+?e --
+dc
+dr rip
+dr rax
+EOF
+REGEXP_FILTER_OUT=(([a-zA-Z:=-]+|[0-9a-f][0-9a-f][0-9a-f]|r[^i][a-z]+ = [a-z0-9]+)\s+)
+EXPECT=<<EOF
+rip = ea0
+--
+rip = edd
+rax = 0x0000000000000190
+--
+rip = ee3
+rax = 0x00000000000000a0
+EOF
+REGEXP_FILTER_ERR=(([a-zA-Z:]+|[0-9a-f][0-9a-f][0-9a-f])\s+)
+EXPECT_ERR=<<EOF
+hit breakpoint at: ea0
+hit breakpoint at: edd
+hit breakpoint at: ee3
+EOF
+RUN


### PR DESCRIPTION


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

RzDebug.bits often has nonsensical contents set from all kinds of places. Specifically, when debugging fat binaries on arm64, it had a value not matching the debuggee when the reg profile was loaded, resulting in the arm32 profile being used.
The right way to determine the profile is to do it after attach, when the cpu type of the debuggee is known.

**Test plan**

see the added tests. The `test/db/archos/darwin-arm64/dbg` one would fail before.