### PR TITLE
Add FreeBSD x86_64 debug tests

### DIFF
--- a/test/db/archos/freebsd-x64/dbg
+++ b/test/db/archos/freebsd-x64/dbg
@@ -1,0 +1,170 @@
+NAME=di + dp
+FILE=bins/elf/hello-freebsd-x64
+ARGS=-d
+CMDS=<<EOF
+di~hello
+dp~[5]
+EOF
+EXPECT=<<EOF
+exe=hello-freebsd-x64
+hello-freebsd-x64
+EOF
+RUN
+
+NAME=spawn + attach and suspend
+FILE=bins/elf/hello-freebsd-x64
+ARGS=-d
+CMDS=<<EOF
+!sleep 0.5
+dm @ rip~*~[8]
+EOF
+EXPECT=<<EOF
+/libexec/ld-elf.so.1
+EOF
+RUN
+
+NAME=dcu + read
+FILE=bins/elf/hello-freebsd-x64
+ARGS=-d
+CMDS=<<EOF
+dcu main
+pi 10 @ rip
+EOF
+EXPECT=<<EOF
+pushh rbp
+mov rbp, rsp
+sub rsp, 0x10
+mov dword [rbp - 4], 0
+movabs rdi, 0x200538
+mov al, 0
+call sym.imp.printf
+xor eax, eax
+add rsp, 0x10
+pop rbp
+EOF
+REGEXP_FILTER_ERR=(([a-zA-Z:]+|[0-9a-f][0-9a-f][0-9a-f])\s+)
+EXPECT_ERR=<<EOF
+Continue until c88
+hit breakpoint at: c88
+EOF
+RUN
+
+NAME=maps
+FILE=bins/elf/hello-freebsd-x64
+ARGS=-d
+CMDS=<<EOF
+dm~hello~[3-]
+EOF
+REGEXP_FILTER_OUT=([a-zA-Z0-9_\.-]+\s+)
+EXPECT=<<EOF
+- usr 4K s --x /usr/home/rizin/rizin/rizin-testbins/elf/hello-freebsd-x64 ? usr_home_rizin_rizin_rizin_testbins_elf_hello_freebsd_x64.__x
+- usr 4K s r-x /usr/home/rizin/rizin/rizin-testbins/elf/hello-freebsd-x64 ? usr_home_rizin_rizin_rizin_testbins_elf_hello_freebsd_x64.r_x
+* usr 4K s -wx /usr/home/rizin/rizin/rizin-testbins/elf/hello-freebsd-x64 ? usr_home_rizin_rizin_rizin_testbins_elf_hello_freebsd_x64._wx
+EOF
+RUN
+
+NAME=maps as flags
+FILE=bins/elf/hello-freebsd-x64
+ARGS=-d
+CMDS=<<EOF
+fl@F:maps~hello~[1-]
+?e --
+dm*~hello~[0-2]
+EOF
+EXPECT=<<EOF
+4096 usr_home_rizin_rizin_rizin_testbins_elf_hello_freebsd_x64.__x
+4096 usr_home_rizin_rizin_rizin_testbins_elf_hello_freebsd_x64.r_x
+4096 usr_home_rizin_rizin_rizin_testbins_elf_hello_freebsd_x64._wx
+--
+f+ map.usr_home_rizin_rizin_rizin_testbins_elf_hello_freebsd_x64.__x 0x00001000
+f+ map.usr_home_rizin_rizin_rizin_testbins_elf_hello_freebsd_x64.r_x 0x00001000
+f+ map.usr_home_rizin_rizin_rizin_testbins_elf_hello_freebsd_x64._wx 0x00001000
+EOF
+RUN
+
+NAME=step and check pc
+FILE=bins/elf/calculate-freebsd-x64
+ARGS=-d
+CMDS=<<EOF
+dcu main
+5 ds
+dr rip
+dr rdx
+?e --
+ds
+dr rip
+dr rdx
+EOF
+REGEXP_FILTER_OUT=(([a-zA-Z:=-]+|[0-9a-f][0-9a-f][0-9a-f]|x[0-9]+ = [a-z0-9]+)\s+)
+EXPECT=<<EOF
+pc = f44
+x8 = 0x0000000000000000
+--
+pc = f48
+x8 = 0x0000000000000064
+EOF
+REGEXP_FILTER_ERR=(([a-zA-Z:]+|[0-9a-f][0-9a-f][0-9a-f])\s+)
+EXPECT_ERR=<<EOF
+Continue until f30
+hit breakpoint at: f30
+EOF
+RUN
+
+NAME=break multiple times and check regs
+FILE=bins/elf/calculate-freebsd-x64
+ARGS=-d
+CMDS=<<EOF
+db @ main
+db @ main + 20
+db @ main + 24
+dc
+dr rip
+?e --
+dc
+dr rip
+dr rax
+?e --
+dc
+dr rip
+dr rax
+EOF
+REGEXP_FILTER_OUT=(([a-zA-Z:=-]+|[0-9a-f][0-9a-f][0-9a-f]|x[0-9]+ = [a-z0-9]+)\s+)
+EXPECT=<<EOF
+rip = f30
+--
+rip = f44
+rax = 0x0000000000000000
+--
+rip = f48
+rax = 0x0000000000000064
+EOF
+REGEXP_FILTER_ERR=(([a-zA-Z:]+|[0-9a-f][0-9a-f][0-9a-f])\s+)
+EXPECT_ERR=<<EOF
+hit breakpoint at: f30
+hit breakpoint at: f44
+hit breakpoint at: f48
+EOF
+RUN
+
+NAME=write gpr
+FILE=bins/elf/calculate-freebsd-x64
+ARGS=-d
+CMDS=<<EOF
+db @ main + 64
+dc
+dr rax
+dr rax = 1337
+dc
+EOF
+EXPECT=<<EOF
+rax = 0x000000000000002a
+Result = 1337
+EOF
+REGEXP_FILTER_ERR=(([a-zA-Z:]+|[0-9a-f][0-9a-f][0-9a-f])\s+)
+EXPECT_ERR=<<EOF
+hit breakpoint at: f70
+
+Process finished
+
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Adds basic FreeBSD x86_64 debug tests.

Requires https://github.com/rizinorg/rizin-testbins/pull/101

**Test plan**

FreeBSD CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/3072