### PR TITLE
Add comment on load opcodes with the loaded value

### DIFF
--- a/librz/analysis/p/analysis_xtensa.c
+++ b/librz/analysis/p/analysis_xtensa.c
@@ -118,6 +118,7 @@ static void xtensa_shr_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, con
 static void xtensa_l32r_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *buf) {
 	op->type = RZ_ANALYSIS_OP_TYPE_LOAD;
 	op->ptr = ((addr + 3) & ~3) + ((buf[2] << 8 | buf[1]) << 2) - 0x40000;
+	op->refptr = 4;
 }
 
 static void xtensa_snm0_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *buf) {

--- a/test/db/analysis/xtensa
+++ b/test/db/analysis/xtensa
@@ -26,3 +26,18 @@ var int32_t var_8h @ stack - 0x8
 var int32_t var_4h @ stack - 0x4
 EOF
 RUN
+
+
+NAME=xtensa l32r refptr
+FILE=malloc://512
+CMDS=<<EOF
+e asm.arch=xtensa
+e asm.bits=32
+wx 00000000ff11ff1121ffff0df0ff
+pD 3 @ 8
+EOF
+EXPECT=<<EOF
+            0x00000008      l32r  a2, 0x00000004                       ; [0x4:4]=0x11ff11ff
+EOF
+RUN
+


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

First time user of Rizin here, I was doing some analysis on Xtensa code. (esp8266 firmware.) I found that in that architecture 32 bit constant values are loaded into registers by a PC relative load operation, loading the constant from the code segment.

For example:
`0x4000bf52      l32r  a5, 0x400003f4`

As 0x400003f4 is in the ROM as well, the loaded value is known at analysis time, and is usually needed to understand the analyzed function. So I was looking for ways to have the actual value shown in the disassembly, and ultimately came up with the change in this PR.

This modifies the disassembly output by adding a comment to it:

`0x4000bf52      l32r  a5, 0x400003f4                       ; refval: 0x0000ff00`


Actually I'm not yet happy with the change though, there are some things to refine on it:
* Check if the address is indeed in non-writable memory area, and so is useful in static analysis
* The loaded address is always treated as 32 bits, which is true for the Xtensa case, but not necessarily for other platform's load operations. I'll see how the size of the data could be determined
* I'm not sure if "refval" is the right term for the loaded value, maybe there's a more commonly known name for it
* I think it doesn't handle target endianness correctly
* And lastly, there might be better ways to have a similar outcome, maybe even without a code change.

I'm looking for some feedback if this change is deemed worthy for further improvements, or I should just drop it in favor of a different approach.

**Test plan**

(Tested manually so far, I'll look for unit tests for the disassebly functionality.)

