### PR TITLE
Fix pxj output

### DIFF
--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -1410,7 +1410,7 @@ RZ_API RZ_OWN char *rz_print_jsondump_str(RZ_NONNULL RzPrint *p, RZ_NONNULL cons
 		return NULL;
 	}
 	pj_a(j);
-	for (int i = 0; i + bytesize < len; i += bytesize) {
+	for (int i = 0; i + bytesize <= len; i += bytesize) {
 		ut64 word = rz_read_ble(buf + i, p->big_endian, wordsize);
 		pj_n(j, word);
 	}

--- a/test/db/cmd/cmd_pd_bugs
+++ b/test/db/cmd/cmd_pd_bugs
@@ -231,3 +231,22 @@ EXPECT=<<EOF
             0x080484c8      55             push  ebp
 EOF
 RUN
+
+NAME=pxj 4 expects 4 bytes
+FILE=malloc://128
+CMDS=<<EOF
+wx 9030405011223344
+px 4
+pxj 4
+px 6 @ 2
+pxj 6 @ 2
+EOF
+EXPECT=<<EOF
+- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
+0x00000000  9030 4050                                .0@P
+[144,48,64,80]
+- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
+0x00000002  4050 1122 3344                           @P."3D
+[64,80,17,34,51,68]
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

I wasn't able to get the proper output from pxj in jsdec, and then i discovered that the output changed.

before when you do `pxj 3` it was printing only 2 bytes instead of 3 as expected.