### PR TITLE
Limit op cache in type matching

### DIFF
--- a/librz/core/analysis_tp.c
+++ b/librz/core/analysis_tp.c
@@ -809,6 +809,8 @@ void propagate_types_among_used_variables(RzCore *core, HtUP *op_cache, RzAnalys
 	}
 }
 
+#define OP_CACHE_LIMIT 8192
+
 RZ_API void rz_core_analysis_type_match(RzCore *core, RzAnalysisFunction *fcn, HtUU *loop_table) {
 	RzListIter *it;
 
@@ -925,6 +927,15 @@ RZ_API void rz_core_analysis_type_match(RzCore *core, RzAnalysisFunction *fcn, H
 			}
 			addr += aop->size;
 			rz_list_free(fcns);
+			// Recreate op_cache if it grows too large to avoid
+			// excessive memory usage.
+			if (op_cache->count > OP_CACHE_LIMIT) {
+				ht_up_free(op_cache);
+				op_cache = ht_up_new(NULL, free_op_cache_kv, NULL);
+				if (!op_cache) {
+					break;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Reduces the peak memory usage of the corkami virtgap.exe test from 1.177GB to 241.9MB (measured with massif).
Fixes this test on my OpenBSD/sparc64 setup.

Before:
```
--------------------------------------------------------------------------------
Command:            rizin -A -Qc  test/bins/pe/virtgap.exe
Massif arguments:   (none)
ms_print arguments: massif.out.414
--------------------------------------------------------------------------------

    GB
1.177^                                                                #
     |                                                               @#
     |                                                              @@#
     |                                                            @@@@#
     |                                                           @@@@@#
     |                                                          @@@@@@#:
     |                                                        @@@@@@@@#:
     |                                                       @@@@@@@@@#:
     |                                                      @@@@@@@@@@#:
     |                                                    @@@@@@@@@@@@#:
     |                                                   @@ @@@@@@@@@@#:
     |                                                  @@@ @@@@@@@@@@#:
     |                                                 @@@@ @@@@@@@@@@#:
     |                                               @@@@@@ @@@@@@@@@@#:
     |                                             @@@ @@@@ @@@@@@@@@@#:
     |                                            @@@@ @@@@ @@@@@@@@@@#:
     |                                          @@@@@@ @@@@ @@@@@@@@@@#:
     |                                          @@@@@@ @@@@ @@@@@@@@@@#:
     |                                         @@@@@@@ @@@@ @@@@@@@@@@#:
     |                                      @@@@@@@@@@ @@@@ @@@@@@@@@@#::
   0 +----------------------------------------------------------------------->Gi
     0                                                                   52.06

--------------------------------------------------------------------------------
  n        time(i)         total(B)   useful-heap(B) extra-heap(B)    stacks(B)
--------------------------------------------------------------------------------
 87 50,094,133,828    1,264,103,264    1,033,047,668   231,055,596            0
81.72% (1,033,047,668B) (heap allocation functions) malloc/new/new[], --alloc-fns, etc.
->10.15% (128,277,192B) 0x607BE8D: rz_core_analysis_op (canalysis.c:1032)
| ->10.15% (128,277,192B) 0x607022F: op_cache_get (analysis_tp.c:280)
| | ->10.15% (128,276,208B) 0x6071736: propagate_types_among_used_variables (analysis_tp.c:635)
| | | ->10.15% (128,276,208B) 0x6072B3E: rz_core_analysis_type_match (analysis_tp.c:924)
| | |   ->10.15% (128,276,208B) 0x608AAF5: rz_core_analysis_types_propagation (canalysis.c:5274)
| | |     ->10.15% (128,276,208B) 0x6089419: rz_core_analysis_everything (canalysis.c:4833)
| | |       ->10.15% (128,276,208B) 0x618E491: core_perform_auto_analysis (cmd_analysis.c:5923)
| | |         ->10.15% (128,276,208B) 0x618E523: rz_analyze_everything_handler (cmd_analysis.c:5938)
| | |           ->10.15% (128,276,208B) 0x61D5059: argv_call_cb (cmd_api.c:745)
| | |             ->10.15% (128,276,208B) 0x61D5330: call_cd (cmd_api.c:804)
| | |               ->10.15% (128,276,208B) 0x61D542D: rz_cmd_call_parsed_args (cmd_api.c:822)
| | |                 ->10.15% (128,276,208B) 0x61C9105: handle_ts_arged_stmt_internal (cmd.c:3646)
| | |                   ->10.15% (128,276,208B) 0x61C8BB6: handle_ts_arged_stmt (cmd.c:3593)
| | |                     ->10.15% (128,276,208B) 0x61D17D5: handle_ts_stmt (cmd.c:5131)
| | |                       ->10.15% (128,276,208B) 0x61D1BF9: handle_ts_statements_internal (cmd.c:5188)
| | |                         ->10.15% (128,276,208B) 0x61D19A0: handle_ts_statements (cmd.c:5153)
| | |                           ->10.15% (128,276,208B) 0x61D2166: core_cmd_tsrzcmd (cmd.c:5299)
| | |                             ->10.15% (128,276,208B) 0x61D23E6: rz_core_cmd (cmd.c:5347)
| | |                               ->10.15% (128,276,208B) 0x61D28C0: rz_core_cmd0 (cmd.c:5447)
| | |                                 ->10.15% (128,276,208B) 0x49C4B1C: rz_main_rizin (rizin.c:1352)
| | |                                   ->10.15% (128,276,208B) 0x109635: main (rizin.c:57)
```

After:
```
--------------------------------------------------------------------------------
Command:            rizin -A -Qc  test/bins/pe/virtgap.exe
Massif arguments:   (none)
ms_print arguments: massif.out.414
--------------------------------------------------------------------------------


    MB
241.9^                                                                 #
     |                                                                @#
     |                                                               @@#
     |                                                              @@@#
     |                                                          @ @ @@@#
     |                                                         @@ @ @@@#
     |                                                       @ @@ @ @@@#
     |                                                       @ @@:@:@@@#
     |                                                 @@  : @ @@:@:@@@#
     |                                                 @ : : @:@@:@:@@@#
     |                                              @  @ : ::@:@@:@:@@@#
     |                                            @ @: @ ::::@:@@:@:@@@#
     |                                            @ @::@ ::::@:@@:@:@@@#
     |                                       @  : @:@::@ ::::@:@@:@:@@@#
     |                                       @  : @:@::@ ::::@:@@:@:@@@#
     |                                       @: ::@:@::@ ::::@:@@:@:@@@#
     |                                       @::::@:@::@ ::::@:@@:@:@@@#
     |                                       @::::@:@::@ ::::@:@@:@:@@@#
     |                                      @@::::@:@::@ ::::@:@@:@:@@@#
     |                                      @@::::@:@::@ ::::@:@@:@:@@@#
   0 +----------------------------------------------------------------------->Gi
     0                                                                   52.18

--------------------------------------------------------------------------------
  n        time(i)         total(B)   useful-heap(B) extra-heap(B)    stacks(B)
--------------------------------------------------------------------------------
 81 51,334,447,419      253,674,776      200,432,826    53,241,950            0
79.01% (200,432,826B) (heap allocation functions) malloc/new/new[], --alloc-fns, etc.
->17.19% (43,595,184B) 0x48FD750: rz_vector_push (vector.c:207)
| ->08.22% (20,857,824B) 0x5AFC4DB: rz_pvector_push (rz_vector.h:305)
| | ->03.29% (8,343,136B) 0x5AFC800: rz_analysis_il_trace_add_reg (il_trace.c:114)
| | | ->03.29% (8,343,136B) 0x5AEC3A2: esil_add_reg_trace (esil_trace.c:21)
| | |   ->03.29% (8,343,136B) 0x5AECE63: trace_hook_reg_write (esil_trace.c:168)
| | |     ->03.29% (8,343,136B) 0x5AE0ED5: rz_analysis_esil_reg_write (esil.c:465)
| | |       ->03.29% (8,343,104B) 0x5AE1BD4: esil_weak_eq (esil.c:725)
| | |       | ->03.29% (8,343,104B) 0x5AE8F71: runword (esil.c:2881)
| | |       |   ->03.29% (8,343,104B) 0x5AE9634: rz_analysis_esil_parse (esil.c:3022)
| | |       |     ->03.29% (8,343,104B) 0x5AEDBA2: rz_analysis_esil_trace_op (esil_trace.c:310)
| | |       |       ->03.29% (8,343,104B) 0x5D4A648: rz_debug_trace_op (trace.c:195)
| | |       |         ->03.29% (8,343,104B) 0x60C5BE4: rz_core_esil_step (cesil.c:163)
| | |       |           ->03.29% (8,343,104B) 0x6072A82: rz_core_analysis_type_match (analysis_tp.c:912)
| | |       |             ->03.29% (8,343,104B) 0x608AB46: rz_core_analysis_types_propagation (canalysis.c:5274)
| | |       |               ->03.29% (8,343,104B) 0x608946A: rz_core_analysis_everything (canalysis.c:4833)
| | |       |                 ->03.29% (8,343,104B) 0x618E4E2: core_perform_auto_analysis (cmd_analysis.c:5923)
| | |       |                   ->03.29% (8,343,104B) 0x618E574: rz_analyze_everything_handler (cmd_analysis.c:5938)
| | |       |                     ->03.29% (8,343,104B) 0x61D50AA: argv_call_cb (cmd_api.c:745)
| | |       |                       ->03.29% (8,343,104B) 0x61D5381: call_cd (cmd_api.c:804)
| | |       |                         ->03.29% (8,343,104B) 0x61D547E: rz_cmd_call_parsed_args (cmd_api.c:822)
| | |       |                           ->03.29% (8,343,104B) 0x61C9156: handle_ts_arged_stmt_internal (cmd.c:3646)
| | |       |                             ->03.29% (8,343,104B) 0x61C8C07: handle_ts_arged_stmt (cmd.c:3593)
| | |       |                               ->03.29% (8,343,104B) 0x61D1826: handle_ts_stmt (cmd.c:5131)
| | |       |                                 ->03.29% (8,343,104B) 0x61D1C4A: handle_ts_statements_internal (cmd.c:5188)
| | |       |                                   ->03.29% (8,343,104B) 0x61D19F1: handle_ts_statements (cmd.c:5153)
| | |       |                                     ->03.29% (8,343,104B) 0x61D21B7: core_cmd_tsrzcmd (cmd.c:5299)
| | |       |                                       ->03.29% (8,343,104B) 0x61D2437: rz_core_cmd (cmd.c:5347)
| | |       |                                         ->03.29% (8,343,104B) 0x61D2911: rz_core_cmd0 (cmd.c:5447)
| | |       |                                           ->03.29% (8,343,104B) 0x49C4B1C: rz_main_rizin (rizin.c:1352)
| | |       |                                             ->03.29% (8,343,104B) 0x109635: main (rizin.c:57)
```