### PR TITLE
Fix string flag sizes after aar (Fix #3305)

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -2183,7 +2183,7 @@ static void set_new_xref(RzCore *core, ut64 xref_from, ut64 xref_to, RzAnalysisX
 		rz_name_filter(string, -1, true);
 		char *flagname = rz_str_newf("str.%s", string);
 		rz_flag_space_push(core->flags, RZ_FLAGS_FS_STRINGS);
-		(void)rz_flag_set(core->flags, flagname, xref_to, 1);
+		(void)rz_flag_set(core->flags, flagname, xref_to, length);
 		rz_flag_space_pop(core->flags);
 		free(flagname);
 		free(string);

--- a/test/db/analysis/hexagon
+++ b/test/db/analysis/hexagon
@@ -667,8 +667,8 @@ EOF
 EXPECT=<<EOF
             0x00000000      ?       R1 = ##0xc                         ; "Where is Wally?"
             0x00000004      [   memw(R17+#0x0) = ##0x1c                ; "There is Wally!"
-0x0000000c 1 str.Where_is_Wally
-0x0000001c 1 str.There_is_Wally
+0x0000000c 16 str.Where_is_Wally
+0x0000001c 16 str.There_is_Wally
 EOF
 RUN
 

--- a/test/db/formats/elf/strings
+++ b/test/db/formats/elf/strings
@@ -11,78 +11,84 @@ RUN
 
 NAME=iz (utf-16)
 FILE=bins/elf/analysis/hello-utf-16
-BROKEN=1
 CMDS=<<EOF
 iz~Hello
+fl@F:strings
 s sym.main
 af
 pdf~str.Hello
+aar
+fl@F:strings
 EOF
 EXPECT=<<EOF
-vaddr=0x004005e8 paddr=0x000005e8 ordinal=000 sz=24 len=11 section=.rodata type=wide string=Hello World
-|           0x0040052e      48c745f8e805.  mov qword [local_8h], str.Hello_World
+0   0x000005e8 0x004005e8 11  26   .rodata utf16le Hello World
+0x004005e8 26 str.Hello_World
+0x00400608 16 str.S
+|           0x0040052e      mov   qword [var_10h], str.Hello_World     ; 0x4005e8 ; u"\ufeffHello World\ufeff\n"
+0x004005e8 26 str.Hello_World
+0x00400608 16 str.S
 EOF
 RUN
 
 NAME=iz (utf-32)
 FILE=bins/elf/analysis/hello-utf-32
-BROKEN=1
 CMDS=<<EOF
 iz~Hello
+fl@F:strings
 s sym.main
 af
 pdf~str.Hello
+aar
+fl@F:strings
 EOF
 EXPECT=<<EOF
-vaddr=0x004005e8 paddr=0x000005e8 ordinal=000 sz=56 len=13 section=.rodata type=wide32 string=Hello World
-|           0x0040052e      48c745f8e805.  mov qword [local_8h], str.Hello_World
+0   0x000005e8 0x004005e8 11  52   .rodata utf32le Hello World
+0x004005e8 52 str.Hello_World
+0x00400628 32 str.S
+|           0x0040052e      mov   qword [var_10h], str.Hello_World     ; 0x4005e8 ; U"\ufeffHello World\ufeff\n"
+0x004005e8 52 str.Hello_World
+0x00400628 32 str.S
 EOF
 RUN
 
 NAME=iz (utf-16le)
 FILE=bins/elf/analysis/hello-utf-16le
-BROKEN=1
 CMDS=<<EOF
 iz~Hello
+fl@F:strings
 s sym.main
 af
 pdf~str.Hello
+aar
+fl@F:strings
 EOF
 EXPECT=<<EOF
-vaddr=0x004005e8 paddr=0x000005e8 ordinal=000 sz=24 len=11 section=.rodata type=wide string=Hello World
-|           0x0040052e      48c745f8e805.  mov qword [local_8h], str.Hello_World
+0   0x000005e4 0x004005e4 12  26   .rodata utf16le Hello World\n
+0x004005e4 26 str.Hello_World
+0x00400600 16 str.S
+|           0x0040052e      mov   qword [var_10h], str.Hello_World     ; 0x4005e4 ; u"Hello World\n"
+0x004005e4 26 str.Hello_World
+0x00400600 16 str.S
 EOF
 RUN
 
 NAME=iz (utf-32le)
 FILE=bins/elf/analysis/hello-utf-32le
-BROKEN=1
 CMDS=<<EOF
 iz~Hello
+fl@F:strings
 s sym.main
 af
 pdf~str.Hello
+aar
+fl@F:strings
 EOF
 EXPECT=<<EOF
-vaddr=0x004005e8 paddr=0x000005e8 ordinal=000 sz=56 len=13 section=.rodata type=wide32 string=Hello World
-|           0x0040052e      48c745f8e805.  mov qword [local_8h], str.Hello_World
-EOF
-RUN
-
-NAME=iz
-FILE=bins/elf/analysis/hello-utf-16
-BROKEN=1
-CMDS=iz~Hello
-EXPECT=<<EOF
-vaddr=0x004005e8 paddr=0x000005e8 ordinal=000 sz=24 len=11 section=.rodata type=wide string=Hello World
-EOF
-RUN
-
-NAME=iz
-FILE=bins/elf/analysis/hello-utf-32
-BROKEN=1
-CMDS=iz~Hello
-EXPECT=<<EOF
-vaddr=0x004005e8 paddr=0x000005e8 ordinal=000 sz=56 len=13 section=.rodata type=wide32 string=Hello World
+0   0x000005e8 0x004005e8 12  52   .rodata utf32le Hello World\n
+0x004005e8 52 str.Hello_World
+0x00400620 32 str.S
+|           0x0040052e      mov   qword [var_10h], str.Hello_World     ; 0x4005e8 ; U"Hello World\n"
+0x004005e8 52 str.Hello_World
+0x00400620 32 str.S
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Regression from 7af13531663b7bf42a5cf0353132c47f9fce9e5e, but most likely already broken before and only made visible by it: String flags set from bin had their size set to how many bytes the string takes, but were overwritten to a size of 1 after running aar.

**Test plan**

see updated tests

**Closing issues**

Fix #3305