### PR TITLE
x86 Disassembly Optimization

### DIFF
--- a/librz/analysis/p/analysis_x86_cs.c
+++ b/librz/analysis/p/analysis_x86_cs.c
@@ -3219,12 +3219,14 @@ static int analop(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, in
 	}
 
 	if (ctx->insn) {
-		// x86 RzIL uplifting
-		X86ILIns x86_il_ins = {
-			.structure = &ctx->insn->detail->x86,
-			.mnem = ctx->insn->id
-		};
-		rz_x86_il_opcode(a, op, addr, &x86_il_ins);
+		if (mask & RZ_ANALYSIS_OP_MASK_IL) {
+			// x86 RzIL uplifting
+			X86ILIns x86_il_ins = {
+				.structure = &ctx->insn->detail->x86,
+				.mnem = ctx->insn->id
+			};
+			rz_x86_il_opcode(a, op, addr, &x86_il_ins);
+		}
 
 		//#if X86_GRP_PRIVILEGE>0
 #if HAVE_CSGRP_PRIVILEGE

--- a/librz/core/golang.c
+++ b/librz/core/golang.c
@@ -652,7 +652,7 @@ static bool go_is_sign_match(GoStrRecover *ctx, GoStrInfo *info, GoSignature *si
 static ut32 decode_one_opcode_size(GoStrRecover *ctx) {
 	RzAnalysisOp aop;
 	rz_analysis_op_init(&aop);
-	if (rz_analysis_op(ctx->core->analysis, &aop, ctx->pc, ctx->bytes, ctx->size, RZ_ANALYSIS_OP_MASK_DISASM) < 1) {
+	if (rz_analysis_op(ctx->core->analysis, &aop, ctx->pc, ctx->bytes, ctx->size, RZ_ANALYSIS_OP_MASK_BASIC) < 1) {
 		rz_analysis_op_fini(&aop);
 		return 0;
 	}
@@ -681,7 +681,7 @@ static bool decode_from_table(RzCore *core, GoStrInfo *info, ut64 pc, const ut8 
 static bool decode_val_set_size(RzCore *core, GoStrInfo *info, ut64 pc, const ut8 *buffer, const ut32 size) {
 	RzAnalysisOp aop;
 	rz_analysis_op_init(&aop);
-	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_DISASM) < 1) {
+	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_BASIC) < 1) {
 		rz_analysis_op_fini(&aop);
 		return false;
 	}
@@ -693,7 +693,7 @@ static bool decode_val_set_size(RzCore *core, GoStrInfo *info, ut64 pc, const ut
 static bool decode_val_set_addr(RzCore *core, GoStrInfo *info, ut64 pc, const ut8 *buffer, const ut32 size) {
 	RzAnalysisOp aop;
 	rz_analysis_op_init(&aop);
-	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_DISASM) < 1) {
+	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_BASIC) < 1) {
 		rz_analysis_op_fini(&aop);
 		return false;
 	}
@@ -705,7 +705,7 @@ static bool decode_val_set_addr(RzCore *core, GoStrInfo *info, ut64 pc, const ut
 static bool decode_val_add_addr(RzCore *core, GoStrInfo *info, ut64 pc, const ut8 *buffer, const ut32 size) {
 	RzAnalysisOp aop;
 	rz_analysis_op_init(&aop);
-	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_DISASM) < 1) {
+	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_BASIC) < 1) {
 		rz_analysis_op_fini(&aop);
 		return false;
 	}
@@ -717,7 +717,7 @@ static bool decode_val_add_addr(RzCore *core, GoStrInfo *info, ut64 pc, const ut
 static bool decode_ptr_set_addr(RzCore *core, GoStrInfo *info, ut64 pc, const ut8 *buffer, const ut32 size) {
 	RzAnalysisOp aop;
 	rz_analysis_op_init(&aop);
-	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_DISASM) < 1) {
+	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_BASIC) < 1) {
 		rz_analysis_op_fini(&aop);
 		return false;
 	}
@@ -729,7 +729,7 @@ static bool decode_ptr_set_addr(RzCore *core, GoStrInfo *info, ut64 pc, const ut
 static bool decode_disp_set_addr(RzCore *core, GoStrInfo *info, ut64 pc, const ut8 *buffer, const ut32 size) {
 	RzAnalysisOp aop;
 	rz_analysis_op_init(&aop);
-	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_DISASM) < 1) {
+	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_BASIC) < 1) {
 		rz_analysis_op_fini(&aop);
 		return false;
 	}
@@ -1046,7 +1046,7 @@ static bool decode_ldr_set_addr(RzCore *core, GoStrInfo *info, ut64 pc, const ut
 	ut64 addr = 0;
 
 	rz_analysis_op_init(&aop);
-	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_DISASM) < 1) {
+	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_BASIC) < 1) {
 		rz_analysis_op_fini(&aop);
 		return false;
 	}
@@ -1119,7 +1119,7 @@ static ut32 golang_recover_string_arm32(GoStrRecover *ctx) {
 static bool decode_lui_set_addr(RzCore *core, GoStrInfo *info, ut64 pc, const ut8 *buffer, const ut32 size) {
 	RzAnalysisOp aop;
 	rz_analysis_op_init(&aop);
-	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_DISASM) < 1) {
+	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_BASIC) < 1) {
 		rz_analysis_op_fini(&aop);
 		return false;
 	}
@@ -1503,7 +1503,7 @@ static ut32 golang_recover_string_ppc64(GoStrRecover *ctx) {
 static bool decode_auipc_set_addr(RzCore *core, GoStrInfo *info, ut64 pc, const ut8 *buffer, const ut32 size) {
 	RzAnalysisOp aop;
 	rz_analysis_op_init(&aop);
-	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_DISASM) < 1) {
+	if (rz_analysis_op(core->analysis, &aop, pc, buffer, size, RZ_ANALYSIS_OP_MASK_BASIC) < 1) {
 		rz_analysis_op_fini(&aop);
 		return false;
 	}


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

See commit descriptions, specifically for optimizing the golang string tests:

Before:
```
sparc$ time rz -Qc 'aalg' test/bins/golang/example-server-1.18-stripped
[x] Found go 1.18 pclntab data.
[x] Recovered 4794 symbols and saved them at sym.go.*
[x] Analyze all flags starting with sym.go. (aF @@f:sym.go.*)
[x] Recovering go strings from bin maps
[x] Analyze all instructions to recover all strings used in sym.go.*
[x] Recovered 6218 strings from the sym.go.* functions.
   15m16.32s real    15m13.49s user     0m01.68s system
```

After:
```
sparc$ time rz -Qc 'aalg' test/bins/golang/example-server-1.18-stripped
[x] Found go 1.18 pclntab data.
[x] Recovered 4794 symbols and saved them at sym.go.*
[x] Analyze all flags starting with sym.go. (aF @@f:sym.go.*)
[x] Recovering go strings from bin maps
[x] Analyze all instructions to recover all strings used in sym.go.*
[x] Recovered 6218 strings from the sym.go.* functions.
   10m45.48s real    10m42.42s user     0m01.94s system
```

This performance differences comes almost only from the first commit in here, avoiding to build the IL in these cases. The second commit makes no noticeable difference, but comes for free.

**Test plan**

CI should still be green
