### PR TITLE
Fix integer shift UB in ARM ESIL uplifting

### DIFF
--- a/librz/analysis/arch/arm/arm_esil64.c
+++ b/librz/analysis/arch/arm/arm_esil64.c
@@ -944,7 +944,7 @@ RZ_IPI int rz_arm_cs_analysis_op_64_esil(RzAnalysis *a, RzAnalysisOp *op, ut64 a
 			shift = 48;
 		}
 		ut64 shifted_imm = IMM64(1) << shift;
-		ut64 mask = ~(0xffffLL << shift);
+		ut64 mask = ~(0xffffULL << shift);
 
 		rz_strbuf_setf(&op->esil, "0x%" PFMT64x ",%s,&,%" PFMT64u ",|,%s,=",
 			mask,


### PR DESCRIPTION

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes the following UBSAN error:
```
arm_esil64.c:947:26: runtime error: left shift of 65535 by 48 places cannot be represented in type 'long long int'
```

**Test plan**

CI is green