### PR TITLE
Refactor srec reading to not use sscanf

### DIFF
--- a/librz/util/hex.c
+++ b/librz/util/hex.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <ctype.h>
 
-/* int c; ret = hex_to_byte(&c, 'c'); */
+/* int c = 0; ret = hex_to_byte(&c, 'c'); */
 RZ_API bool rz_hex_to_byte(ut8 *val, ut8 c) {
 	if (IS_DIGIT(c)) {
 		*val = (ut8)(*val) * 16 + (c - '0');

--- a/test/db/io/srec
+++ b/test/db/io/srec
@@ -81,7 +81,6 @@ RUN
 
 NAME=arm1.bin.srec
 FILE=srec://bins/srec/arm1.bin.srec
-TIMEOUT=1320
 CMDS=<<EOF
 iI
 iS


### PR DESCRIPTION

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Parsing with sscanf turned out to cause an extreme slowdown. As only hex values are being read, this can be done with RzUtil-provided functionality.

On OpenBSD/sparc64, before:
```
sparc$ time rz -Qc "" srec://test/bins/srec/arm1.bin.srec
   46m51.38s real    46m50.37s user     0m00.67s system
```
after:
```
sparc$ time rz -Qc "" srec://test/bins/srec/arm1.bin.srec
    0m04.92s real     0m03.85s user     0m00.91s system
```

**Test plan**

Relevant test cases exist in test/db/io/srec.