### PR TITLE
Convert `p=` commands to rzshell

### DIFF
--- a/librz/cons/histogram.c
+++ b/librz/cons/histogram.c
@@ -121,6 +121,14 @@ static void histogram_block(RZ_NONNULL RzHistogramOptions *opts, RZ_NONNULL RzSt
 /**
  * \brief Create the string buffer with the vertical histogram
  *
+ * │████████████████████████████████████████████████
+ * │███
+ * │████████████████████████████████████████████
+ * │█████████████████████
+ * │███████████████████████████████████████████████
+ * │█████████████
+ * │██████████████
+ *
  * \param opts Histogram options: color, style, legend and cursor position
  * \param data A buffer with the numerical data in the format of one byte per value
  * \param width Width of the histogram

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -597,6 +597,33 @@ static const RzCmdDescArg print_url_encode_zero_args[2];
 static const RzCmdDescArg print_minus_args[2];
 static const RzCmdDescArg print_minus_entropy_args[2];
 static const RzCmdDescArg print_minus_table_args[2];
+static const RzCmdDescArg print_equal_args[4];
+static const RzCmdDescArg print_equal_two_args[2];
+static const RzCmdDescArg print_equal_0x00_args[4];
+static const RzCmdDescArg print_equal_0xff_args[4];
+static const RzCmdDescArg print_equal_bbs_args[4];
+static const RzCmdDescArg print_equal_stats_args[4];
+static const RzCmdDescArg print_equal_call_args[4];
+static const RzCmdDescArg print_equal_entropy_args[4];
+static const RzCmdDescArg print_equal_invalid_args[4];
+static const RzCmdDescArg print_equal_jump_args[4];
+static const RzCmdDescArg print_equal_m_args[2];
+static const RzCmdDescArg print_equal_printable_args[4];
+static const RzCmdDescArg print_equal_priv_args[4];
+static const RzCmdDescArg print_equal_z_args[4];
+static const RzCmdDescArg print_equal_equal_args[4];
+static const RzCmdDescArg print_equal_equal_0x00_args[4];
+static const RzCmdDescArg print_equal_equal_0xff_args[4];
+static const RzCmdDescArg print_equal_equal_bbs_args[4];
+static const RzCmdDescArg print_equal_equal_stats_args[4];
+static const RzCmdDescArg print_equal_equal_call_args[4];
+static const RzCmdDescArg print_equal_equal_entropy_args[4];
+static const RzCmdDescArg print_equal_equal_invalid_args[4];
+static const RzCmdDescArg print_equal_equal_jump_args[4];
+static const RzCmdDescArg print_equal_equal_m_args[4];
+static const RzCmdDescArg print_equal_equal_printable_args[4];
+static const RzCmdDescArg print_equal_equal_priv_args[4];
+static const RzCmdDescArg print_equal_equal_z_args[4];
 static const RzCmdDescArg project_save_args[2];
 static const RzCmdDescArg project_open_args[2];
 static const RzCmdDescArg project_open_no_bin_io_args[2];
@@ -13517,6 +13544,725 @@ static const RzCmdDescHelp print_minus_table_help = {
 	.args = print_minus_table_args,
 };
 
+static const RzCmdDescHelp p_equal__help = {
+	.summary = "Blocks information representation as a histogram",
+};
+static const RzCmdDescArg print_equal_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_help = {
+	.summary = "Show a vertical histogram of bytes in current block",
+	.args = print_equal_args,
+};
+
+static const RzCmdDescArg print_equal_d_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_d_help = {
+	.summary = "Show a summary of min/max/number of unique bytes in the current block",
+	.args = print_equal_d_args,
+};
+
+static const RzCmdDescArg print_equal_two_args[] = {
+	{
+		.name = "step",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_two_help = {
+	.summary = "Show progress bars of int16 values",
+	.args = print_equal_two_args,
+};
+
+static const RzCmdDescArg print_equal_0x00_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_0x00_help = {
+	.summary = "Show a vertical histogram of 0x00 bytes per each block",
+	.args = print_equal_0x00_args,
+};
+
+static const RzCmdDescArg print_equal_0xff_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_0xff_help = {
+	.summary = "Show a vertical histogram of 0xFF bytes per each block",
+	.args = print_equal_0xff_args,
+};
+
+static const RzCmdDescArg print_equal_bbs_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_bbs_help = {
+	.summary = "Show a vertical histogram of basic blocks per each block",
+	.args = print_equal_bbs_args,
+};
+
+static const RzCmdDescArg print_equal_stats_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_stats_help = {
+	.summary = "Show a vertical histogram of statistical maps per each block",
+	.args = print_equal_stats_args,
+};
+
+static const RzCmdDescArg print_equal_call_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_call_help = {
+	.summary = "Show a vertical histogram of calls per each block",
+	.args = print_equal_call_args,
+};
+
+static const RzCmdDescArg print_equal_entropy_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_entropy_help = {
+	.summary = "Show a vertical histogram of entropy per each block",
+	.args = print_equal_entropy_args,
+};
+
+static const RzCmdDescArg print_equal_invalid_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_invalid_help = {
+	.summary = "Show a vertical histogram of invalid instructions per each block",
+	.args = print_equal_invalid_args,
+};
+
+static const RzCmdDescArg print_equal_jump_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_jump_help = {
+	.summary = "Show a vertical histogram of jumps and conditional jumps per each block",
+	.args = print_equal_jump_args,
+};
+
+static const RzCmdDescArg print_equal_m_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_m_help = {
+	.summary = "Show a vertical histogram of number of flags and marks per each block",
+	.args = print_equal_m_args,
+};
+
+static const RzCmdDescArg print_equal_printable_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_printable_help = {
+	.summary = "Show a vertical histogram of printable bytes per each block",
+	.args = print_equal_printable_args,
+};
+
+static const RzCmdDescArg print_equal_priv_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_priv_help = {
+	.summary = "Show a vertical histogram of syscalls and privileged instructions per each block",
+	.args = print_equal_priv_args,
+};
+
+static const RzCmdDescArg print_equal_z_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_z_help = {
+	.summary = "Show a vertical histogram of number of chars in strings per each block",
+	.args = print_equal_z_args,
+};
+
+static const RzCmdDescHelp p_equal__equal__help = {
+	.summary = "Blocks information representation as a horizontal histogram",
+};
+static const RzCmdDescArg print_equal_equal_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_equal_help = {
+	.summary = "Show a horizontal histogram of bytes in current block",
+	.args = print_equal_equal_args,
+};
+
+static const RzCmdDescArg print_equal_equal_0x00_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_equal_0x00_help = {
+	.summary = "Show a horizontal histogram of 0x00 bytes per each block",
+	.args = print_equal_equal_0x00_args,
+};
+
+static const RzCmdDescArg print_equal_equal_0xff_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_equal_0xff_help = {
+	.summary = "Show a horizontal histogram of 0xFF bytes per each block",
+	.args = print_equal_equal_0xff_args,
+};
+
+static const RzCmdDescArg print_equal_equal_bbs_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_equal_bbs_help = {
+	.summary = "Show a horizontal histogram of basic blocks per each block",
+	.args = print_equal_equal_bbs_args,
+};
+
+static const RzCmdDescArg print_equal_equal_stats_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_equal_stats_help = {
+	.summary = "Show a horizontal histogram of statistical maps per each block",
+	.args = print_equal_equal_stats_args,
+};
+
+static const RzCmdDescArg print_equal_equal_call_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_equal_call_help = {
+	.summary = "Show a horizontal histogram of calls per each block",
+	.args = print_equal_equal_call_args,
+};
+
+static const RzCmdDescArg print_equal_equal_entropy_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_equal_entropy_help = {
+	.summary = "Show a horizontal histogram of entropy per each block",
+	.args = print_equal_equal_entropy_args,
+};
+
+static const RzCmdDescArg print_equal_equal_invalid_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_equal_invalid_help = {
+	.summary = "Show a vertical histogram of invalid instructions per each block",
+	.args = print_equal_equal_invalid_args,
+};
+
+static const RzCmdDescArg print_equal_equal_jump_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_equal_jump_help = {
+	.summary = "Show a horizontal histogram of jumps and conditional jumps per each block",
+	.args = print_equal_equal_jump_args,
+};
+
+static const RzCmdDescArg print_equal_equal_m_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_equal_m_help = {
+	.summary = "Show a horizontal histogram of number of flags and marks per each block",
+	.args = print_equal_equal_m_args,
+};
+
+static const RzCmdDescArg print_equal_equal_printable_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_equal_printable_help = {
+	.summary = "Show a horizontal histogram of printable bytes per each block",
+	.args = print_equal_equal_printable_args,
+};
+
+static const RzCmdDescArg print_equal_equal_priv_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_equal_priv_help = {
+	.summary = "Show a vertical histogram of syscalls and privileged instructions per each block",
+	.args = print_equal_equal_priv_args,
+};
+
+static const RzCmdDescArg print_equal_equal_z_args[] = {
+	{
+		.name = "blocks",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "totalsize",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.optional = true,
+
+	},
+	{
+		.name = "skip",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_equal_equal_z_help = {
+	.summary = "Show a vertical histogram of number of chars in strings per each block",
+	.args = print_equal_equal_z_args,
+};
+
 static const RzCmdDescHelp P_help = {
 	.summary = "Project management",
 };
@@ -19310,6 +20056,88 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *print_minus_table_cd = rz_cmd_desc_argv_state_new(core->rcmd, p_minus__cd, "p-h", RZ_OUTPUT_MODE_TABLE, rz_print_minus_table_handler, &print_minus_table_help);
 	rz_warn_if_fail(print_minus_table_cd);
 	rz_cmd_desc_set_default_mode(print_minus_table_cd, RZ_OUTPUT_MODE_TABLE);
+
+	RzCmdDesc *p_equal__cd = rz_cmd_desc_group_new(core->rcmd, cmd_print_cd, "p=", rz_print_equal_handler, &print_equal_help, &p_equal__help);
+	rz_warn_if_fail(p_equal__cd);
+	RzCmdDesc *print_equal_d_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__cd, "p=d", rz_print_equal_d_handler, &print_equal_d_help);
+	rz_warn_if_fail(print_equal_d_cd);
+
+	RzCmdDesc *print_equal_two_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__cd, "p=2", rz_print_equal_two_handler, &print_equal_two_help);
+	rz_warn_if_fail(print_equal_two_cd);
+
+	RzCmdDesc *print_equal_0x00_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__cd, "p=0", rz_print_equal_0x00_handler, &print_equal_0x00_help);
+	rz_warn_if_fail(print_equal_0x00_cd);
+
+	RzCmdDesc *print_equal_0xff_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__cd, "p=F", rz_print_equal_0xff_handler, &print_equal_0xff_help);
+	rz_warn_if_fail(print_equal_0xff_cd);
+
+	RzCmdDesc *print_equal_bbs_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__cd, "p=a", rz_print_equal_bbs_handler, &print_equal_bbs_help);
+	rz_warn_if_fail(print_equal_bbs_cd);
+
+	RzCmdDesc *print_equal_stats_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__cd, "p=A", rz_print_equal_stats_handler, &print_equal_stats_help);
+	rz_warn_if_fail(print_equal_stats_cd);
+
+	RzCmdDesc *print_equal_call_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__cd, "p=c", rz_print_equal_call_handler, &print_equal_call_help);
+	rz_warn_if_fail(print_equal_call_cd);
+
+	RzCmdDesc *print_equal_entropy_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__cd, "p=e", rz_print_equal_entropy_handler, &print_equal_entropy_help);
+	rz_warn_if_fail(print_equal_entropy_cd);
+
+	RzCmdDesc *print_equal_invalid_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__cd, "p=i", rz_print_equal_invalid_handler, &print_equal_invalid_help);
+	rz_warn_if_fail(print_equal_invalid_cd);
+
+	RzCmdDesc *print_equal_jump_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__cd, "p=j", rz_print_equal_jump_handler, &print_equal_jump_help);
+	rz_warn_if_fail(print_equal_jump_cd);
+
+	RzCmdDesc *print_equal_m_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__cd, "p=m", rz_print_equal_m_handler, &print_equal_m_help);
+	rz_warn_if_fail(print_equal_m_cd);
+
+	RzCmdDesc *print_equal_printable_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__cd, "p=p", rz_print_equal_printable_handler, &print_equal_printable_help);
+	rz_warn_if_fail(print_equal_printable_cd);
+
+	RzCmdDesc *print_equal_priv_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__cd, "p=s", rz_print_equal_priv_handler, &print_equal_priv_help);
+	rz_warn_if_fail(print_equal_priv_cd);
+
+	RzCmdDesc *print_equal_z_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__cd, "p=z", rz_print_equal_z_handler, &print_equal_z_help);
+	rz_warn_if_fail(print_equal_z_cd);
+
+	RzCmdDesc *p_equal__equal__cd = rz_cmd_desc_group_new(core->rcmd, p_equal__cd, "p==", rz_print_equal_equal_handler, &print_equal_equal_help, &p_equal__equal__help);
+	rz_warn_if_fail(p_equal__equal__cd);
+	RzCmdDesc *print_equal_equal_0x00_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__equal__cd, "p==0", rz_print_equal_equal_0x00_handler, &print_equal_equal_0x00_help);
+	rz_warn_if_fail(print_equal_equal_0x00_cd);
+
+	RzCmdDesc *print_equal_equal_0xff_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__equal__cd, "p==F", rz_print_equal_equal_0xff_handler, &print_equal_equal_0xff_help);
+	rz_warn_if_fail(print_equal_equal_0xff_cd);
+
+	RzCmdDesc *print_equal_equal_bbs_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__equal__cd, "p==a", rz_print_equal_equal_bbs_handler, &print_equal_equal_bbs_help);
+	rz_warn_if_fail(print_equal_equal_bbs_cd);
+
+	RzCmdDesc *print_equal_equal_stats_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__equal__cd, "p==A", rz_print_equal_equal_stats_handler, &print_equal_equal_stats_help);
+	rz_warn_if_fail(print_equal_equal_stats_cd);
+
+	RzCmdDesc *print_equal_equal_call_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__equal__cd, "p==c", rz_print_equal_equal_call_handler, &print_equal_equal_call_help);
+	rz_warn_if_fail(print_equal_equal_call_cd);
+
+	RzCmdDesc *print_equal_equal_entropy_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__equal__cd, "p==e", rz_print_equal_equal_entropy_handler, &print_equal_equal_entropy_help);
+	rz_warn_if_fail(print_equal_equal_entropy_cd);
+
+	RzCmdDesc *print_equal_equal_invalid_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__equal__cd, "p==i", rz_print_equal_equal_invalid_handler, &print_equal_equal_invalid_help);
+	rz_warn_if_fail(print_equal_equal_invalid_cd);
+
+	RzCmdDesc *print_equal_equal_jump_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__equal__cd, "p==j", rz_print_equal_equal_jump_handler, &print_equal_equal_jump_help);
+	rz_warn_if_fail(print_equal_equal_jump_cd);
+
+	RzCmdDesc *print_equal_equal_m_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__equal__cd, "p==m", rz_print_equal_equal_m_handler, &print_equal_equal_m_help);
+	rz_warn_if_fail(print_equal_equal_m_cd);
+
+	RzCmdDesc *print_equal_equal_printable_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__equal__cd, "p==p", rz_print_equal_equal_printable_handler, &print_equal_equal_printable_help);
+	rz_warn_if_fail(print_equal_equal_printable_cd);
+
+	RzCmdDesc *print_equal_equal_priv_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__equal__cd, "p==s", rz_print_equal_equal_priv_handler, &print_equal_equal_priv_help);
+	rz_warn_if_fail(print_equal_equal_priv_cd);
+
+	RzCmdDesc *print_equal_equal_z_cd = rz_cmd_desc_argv_new(core->rcmd, p_equal__equal__cd, "p==z", rz_print_equal_equal_z_handler, &print_equal_equal_z_help);
+	rz_warn_if_fail(print_equal_equal_z_cd);
 
 	RzCmdDesc *P_cd = rz_cmd_desc_group_new(core->rcmd, root_cd, "P", NULL, NULL, &P_help);
 	rz_warn_if_fail(P_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -1923,6 +1923,62 @@ RZ_IPI RzCmdStatus rz_print_minus_handler(RzCore *core, int argc, const char **a
 RZ_IPI RzCmdStatus rz_print_minus_entropy_handler(RzCore *core, int argc, const char **argv);
 // "p-h"
 RZ_IPI RzCmdStatus rz_print_minus_table_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+// "p="
+RZ_IPI RzCmdStatus rz_print_equal_handler(RzCore *core, int argc, const char **argv);
+// "p=d"
+RZ_IPI RzCmdStatus rz_print_equal_d_handler(RzCore *core, int argc, const char **argv);
+// "p=2"
+RZ_IPI RzCmdStatus rz_print_equal_two_handler(RzCore *core, int argc, const char **argv);
+// "p=0"
+RZ_IPI RzCmdStatus rz_print_equal_0x00_handler(RzCore *core, int argc, const char **argv);
+// "p=F"
+RZ_IPI RzCmdStatus rz_print_equal_0xff_handler(RzCore *core, int argc, const char **argv);
+// "p=a"
+RZ_IPI RzCmdStatus rz_print_equal_bbs_handler(RzCore *core, int argc, const char **argv);
+// "p=A"
+RZ_IPI RzCmdStatus rz_print_equal_stats_handler(RzCore *core, int argc, const char **argv);
+// "p=c"
+RZ_IPI RzCmdStatus rz_print_equal_call_handler(RzCore *core, int argc, const char **argv);
+// "p=e"
+RZ_IPI RzCmdStatus rz_print_equal_entropy_handler(RzCore *core, int argc, const char **argv);
+// "p=i"
+RZ_IPI RzCmdStatus rz_print_equal_invalid_handler(RzCore *core, int argc, const char **argv);
+// "p=j"
+RZ_IPI RzCmdStatus rz_print_equal_jump_handler(RzCore *core, int argc, const char **argv);
+// "p=m"
+RZ_IPI RzCmdStatus rz_print_equal_m_handler(RzCore *core, int argc, const char **argv);
+// "p=p"
+RZ_IPI RzCmdStatus rz_print_equal_printable_handler(RzCore *core, int argc, const char **argv);
+// "p=s"
+RZ_IPI RzCmdStatus rz_print_equal_priv_handler(RzCore *core, int argc, const char **argv);
+// "p=z"
+RZ_IPI RzCmdStatus rz_print_equal_z_handler(RzCore *core, int argc, const char **argv);
+// "p=="
+RZ_IPI RzCmdStatus rz_print_equal_equal_handler(RzCore *core, int argc, const char **argv);
+// "p==0"
+RZ_IPI RzCmdStatus rz_print_equal_equal_0x00_handler(RzCore *core, int argc, const char **argv);
+// "p==F"
+RZ_IPI RzCmdStatus rz_print_equal_equal_0xff_handler(RzCore *core, int argc, const char **argv);
+// "p==a"
+RZ_IPI RzCmdStatus rz_print_equal_equal_bbs_handler(RzCore *core, int argc, const char **argv);
+// "p==A"
+RZ_IPI RzCmdStatus rz_print_equal_equal_stats_handler(RzCore *core, int argc, const char **argv);
+// "p==c"
+RZ_IPI RzCmdStatus rz_print_equal_equal_call_handler(RzCore *core, int argc, const char **argv);
+// "p==e"
+RZ_IPI RzCmdStatus rz_print_equal_equal_entropy_handler(RzCore *core, int argc, const char **argv);
+// "p==i"
+RZ_IPI RzCmdStatus rz_print_equal_equal_invalid_handler(RzCore *core, int argc, const char **argv);
+// "p==j"
+RZ_IPI RzCmdStatus rz_print_equal_equal_jump_handler(RzCore *core, int argc, const char **argv);
+// "p==m"
+RZ_IPI RzCmdStatus rz_print_equal_equal_m_handler(RzCore *core, int argc, const char **argv);
+// "p==p"
+RZ_IPI RzCmdStatus rz_print_equal_equal_printable_handler(RzCore *core, int argc, const char **argv);
+// "p==s"
+RZ_IPI RzCmdStatus rz_print_equal_equal_priv_handler(RzCore *core, int argc, const char **argv);
+// "p==z"
+RZ_IPI RzCmdStatus rz_print_equal_equal_z_handler(RzCore *core, int argc, const char **argv);
 // "p"
 RZ_IPI int rz_cmd_print(void *data, const char *input);
 // "Ps"

--- a/librz/core/cmd_descs/cmd_print.yaml
+++ b/librz/core/cmd_descs/cmd_print.yaml
@@ -1257,3 +1257,352 @@ commands:
           - name: depth
             type: RZ_CMD_ARG_TYPE_RZNUM
             optional: true
+  - name: p=
+    summary: Blocks information representation as a histogram
+    subcommands:
+      - name: p=
+        summary: Show a vertical histogram of bytes in current block
+        cname: print_equal
+        args:
+          - name: blocks
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: totalsize
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: skip
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: p=d
+        summary: Show a summary of min/max/number of unique bytes in the current block
+        cname: print_equal_d
+        args: []
+      - name: p=2
+        summary: Show progress bars of int16 values
+        cname: print_equal_two
+        args:
+          - name: step
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: p=0
+        summary: Show a vertical histogram of 0x00 bytes per each block
+        cname: print_equal_0x00
+        args:
+          - name: blocks
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: totalsize
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: skip
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: p=F
+        summary: Show a vertical histogram of 0xFF bytes per each block
+        cname: print_equal_0xff
+        args:
+          - name: blocks
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: totalsize
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: skip
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: p=a
+        summary: Show a vertical histogram of basic blocks per each block
+        cname: print_equal_bbs
+        args:
+          - name: blocks
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: totalsize
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: skip
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: p=A
+        summary: Show a vertical histogram of statistical maps per each block
+        cname: print_equal_stats
+        args:
+          - name: blocks
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: totalsize
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: skip
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: p=c
+        summary: Show a vertical histogram of calls per each block
+        cname: print_equal_call
+        args:
+          - name: blocks
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: totalsize
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: skip
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: p=e
+        summary: Show a vertical histogram of entropy per each block
+        cname: print_equal_entropy
+        args:
+          - name: blocks
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: totalsize
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: skip
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: p=i
+        summary: Show a vertical histogram of invalid instructions per each block
+        cname: print_equal_invalid
+        args:
+          - name: blocks
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: totalsize
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: skip
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: p=j
+        summary: Show a vertical histogram of jumps and conditional jumps per each block
+        cname: print_equal_jump
+        args:
+          - name: blocks
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: totalsize
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: skip
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: p=m
+        summary: Show a vertical histogram of number of flags and marks per each block
+        cname: print_equal_m
+        args:
+          - name: blocks
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: p=p
+        summary: Show a vertical histogram of printable bytes per each block
+        cname: print_equal_printable
+        args:
+          - name: blocks
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: totalsize
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: skip
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: p=s
+        summary: Show a vertical histogram of syscalls and privileged instructions per each block
+        cname: print_equal_priv
+        args:
+          - name: blocks
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: totalsize
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: skip
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: p=z
+        summary: Show a vertical histogram of number of chars in strings per each block
+        cname: print_equal_z
+        args:
+          - name: blocks
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: totalsize
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+          - name: skip
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
+      - name: p==
+        summary: Blocks information representation as a horizontal histogram
+        subcommands:
+          - name: p==
+            summary: Show a horizontal histogram of bytes in current block
+            cname: print_equal_equal
+            args:
+              - name: blocks
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: totalsize
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: skip
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+          - name: p==0
+            summary: Show a horizontal histogram of 0x00 bytes per each block
+            cname: print_equal_equal_0x00
+            args:
+              - name: blocks
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: totalsize
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: skip
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+          - name: p==F
+            summary: Show a horizontal histogram of 0xFF bytes per each block
+            cname: print_equal_equal_0xff
+            args:
+              - name: blocks
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: totalsize
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: skip
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+          - name: p==a
+            summary: Show a horizontal histogram of basic blocks per each block
+            cname: print_equal_equal_bbs
+            args:
+              - name: blocks
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: totalsize
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: skip
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+          - name: p==A
+            summary: Show a horizontal histogram of statistical maps per each block
+            cname: print_equal_equal_stats
+            args:
+              - name: blocks
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: totalsize
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: skip
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+          - name: p==c
+            summary: Show a horizontal histogram of calls per each block
+            cname: print_equal_equal_call
+            args:
+              - name: blocks
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: totalsize
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: skip
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+          - name: p==e
+            summary: Show a horizontal histogram of entropy per each block
+            cname: print_equal_equal_entropy
+            args:
+              - name: blocks
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: totalsize
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: skip
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+          - name: p==i
+            summary: Show a vertical histogram of invalid instructions per each block
+            cname: print_equal_equal_invalid
+            args:
+              - name: blocks
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: totalsize
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: skip
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+          - name: p==j
+            summary: Show a horizontal histogram of jumps and conditional jumps per each block
+            cname: print_equal_equal_jump
+            args:
+              - name: blocks
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: totalsize
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: skip
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+          - name: p==m
+            summary: Show a horizontal histogram of number of flags and marks per each block
+            cname: print_equal_equal_m
+            args:
+              - name: blocks
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: totalsize
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: skip
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+          - name: p==p
+            summary: Show a horizontal histogram of printable bytes per each block
+            cname: print_equal_equal_printable
+            args:
+              - name: blocks
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: totalsize
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: skip
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+          - name: p==s
+            summary: Show a vertical histogram of syscalls and privileged instructions per each block
+            cname: print_equal_equal_priv
+            args:
+              - name: blocks
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: totalsize
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: skip
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+          - name: p==z
+            summary: Show a vertical histogram of number of chars in strings per each block
+            cname: print_equal_equal_z
+            args:
+              - name: blocks
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: totalsize
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true
+              - name: skip
+                type: RZ_CMD_ARG_TYPE_RZNUM
+                optional: true

--- a/test/db/cmd/cmd_0
+++ b/test/db/cmd/cmd_0
@@ -5,13 +5,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=p=b 0
-FILE=bins/elf/analysis/hello-arm32
-CMDS=p=b 0
-EXPECT=<<EOF
-EOF
-RUN
-
 NAME=p=d 0
 FILE=bins/elf/analysis/hello-arm32
 CMDS=p=d 0

--- a/test/db/cmd/cmd_print
+++ b/test/db/cmd/cmd_print
@@ -28,13 +28,13 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=p=b 0xff 0x00
+NAME=p= 0xff 0x00
 FILE==
 CMDS=<<EOF
 b 2
 wx 0xff
 e zoom.in=raw
-p=b 2 2@ 0
+p= 2 2@ 0
 EOF
 EXPECT=<<EOF
 0x00000000 000 00ff |###################################################
@@ -56,7 +56,7 @@ RUN
 NAME=p=d
 FILE=bins/elf/arm1.bin
 ARGS=-n
-CMDS=p=d 10 @ 0
+CMDS=p=d @!10 @ 0
 EXPECT=<<EOF
 min:              0  0x0
 max:              127  0x7f
@@ -152,34 +152,6 @@ EXPECT=<<EOF
 0x00000066 002 001e |##
 0x00000099 003 0028 |#######
 0x000000cc 004 001e |######
-EOF
-RUN
-
-NAME=p=Aq
-FILE==
-CMDS=<<EOF
-f test @ 0
-f ulu @ 2
-f mulu @ 0x100
-p=Aq 0x10
-EOF
-EXPECT=<<EOF
-0x00000000 0 2
-0x00000020 1 0
-0x00000040 2 0
-0x00000060 3 0
-0x00000080 4 0
-0x000000a0 5 0
-0x000000c0 6 0
-0x000000e0 7 0
-0x00000100 8 1
-0x00000120 9 0
-0x00000140 10 0
-0x00000160 11 0
-0x00000180 12 0
-0x000001a0 13 0
-0x000001c0 14 0
-0x000001e0 15 0
 EOF
 RUN
 


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Convert all `p=` (and corresponding `p==` subcommands) to rzshell.
- Removed `p=b` as an alias to `p=` (and `p==b` as an alias to `p==`)
- Removed QUIET and JSON modes for `p=` commands, there is no viable reason to need this, or we should provide a proper API instead for that.

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/1590