### PR TITLE
Fix #2859 - Use minstring in all bin plugins

### DIFF
--- a/librz/bin/p/bin_bflt.c
+++ b/librz/bin/p/bin_bflt.c
@@ -249,7 +249,7 @@ static void destroy(RzBinFile *bf) {
 }
 
 static RzList /*<RzBinString *>*/ *strings(RzBinFile *bf) {
-	return rz_bin_file_strings(bf, 0, false);
+	return rz_bin_file_strings(bf, bf->minstrlen, false);
 }
 
 RzBinPlugin rz_bin_plugin_bflt = {

--- a/librz/bin/p/bin_dmp64.c
+++ b/librz/bin/p/bin_dmp64.c
@@ -81,7 +81,7 @@ static void header(RzBinFile *bf) {
 }
 
 static RzList /*<RzBinString *>*/ *strings(RzBinFile *bf) {
-	return rz_bin_file_strings(bf, 4, false);
+	return rz_bin_file_strings(bf, bf->minstrlen, false);
 }
 
 static RzList /*<RzBinField *>*/ *fields(RzBinFile *bf) {

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -1963,5 +1963,5 @@ static ut64 size(RzBinFile *bf) {
 }
 
 static RzList /*<RzBinString *>*/ *strings(RzBinFile *bf) {
-	return rz_bin_file_strings(bf, 4, false);
+	return rz_bin_file_strings(bf, bf->minstrlen, false);
 }

--- a/librz/bin/p/bin_le.c
+++ b/librz/bin/p/bin_le.c
@@ -150,7 +150,7 @@ static RzBinInfo *info(RzBinFile *bf) {
 }
 
 static RzList /*<RzBinString *>*/ *strings(RzBinFile *bf) {
-	return rz_bin_file_strings(bf, 0, false);
+	return rz_bin_file_strings(bf, bf->minstrlen, false);
 }
 
 RzBinPlugin rz_bin_plugin_le = {

--- a/librz/bin/p/bin_mach0.c
+++ b/librz/bin/p/bin_mach0.c
@@ -822,7 +822,7 @@ static ut64 size(RzBinFile *bf) {
 }
 
 static RzList /*<RzBinString *>*/ *strings(RzBinFile *bf) {
-	return rz_bin_file_strings(bf, 4, false);
+	return rz_bin_file_strings(bf, bf->minstrlen, false);
 }
 
 RzBinPlugin rz_bin_plugin_mach0 = {

--- a/librz/bin/p/bin_mach064.c
+++ b/librz/bin/p/bin_mach064.c
@@ -288,7 +288,7 @@ static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol sym) {
 }
 
 static RzList /*<RzBinString *>*/ *strings(RzBinFile *bf) {
-	return rz_bin_file_strings(bf, 4, false);
+	return rz_bin_file_strings(bf, bf->minstrlen, false);
 }
 
 RzBinPlugin rz_bin_plugin_mach064 = {

--- a/librz/bin/p/bin_mdmp.c
+++ b/librz/bin/p/bin_mdmp.c
@@ -466,7 +466,7 @@ static bool mdmp_check_buffer(RzBuffer *b) {
 }
 
 static RzList /*<RzBinString *>*/ *mdmp_strings(RzBinFile *bf) {
-	return rz_bin_file_strings(bf, 0, false);
+	return rz_bin_file_strings(bf, bf->minstrlen, false);
 }
 
 RzBinPlugin rz_bin_plugin_mdmp = {

--- a/librz/bin/p/bin_pe.inc
+++ b/librz/bin/p/bin_pe.inc
@@ -727,7 +727,7 @@ static RzList /*<RzBinFileHash *>*/ *compute_hashes(RzBinFile *bf) {
 }
 
 static RzList /*<RzBinString *>*/ *strings(RzBinFile *bf) {
-	return rz_bin_file_strings(bf, 4, false);
+	return rz_bin_file_strings(bf, bf->minstrlen, false);
 }
 
 /**

--- a/librz/bin/p/bin_psxexe.c
+++ b/librz/bin/p/bin_psxexe.c
@@ -110,7 +110,8 @@ static RzList /*<RzBinAddr *>*/ *entries(RzBinFile *bf) {
 
 static RzList /*<RzBinString *>*/ *strings(RzBinFile *bf) {
 	// hardcode minstrlen = 20
-	return rz_bin_file_strings(bf, 20, true);
+	int minstrlen = bf->minstrlen ? bf->minstrlen : 20;
+	return rz_bin_file_strings(bf, minstrlen, true);
 }
 
 RzBinPlugin rz_bin_plugin_psxexe = {

--- a/librz/bin/p/bin_smd.c
+++ b/librz/bin/p/bin_smd.c
@@ -316,7 +316,7 @@ static RzList /*<RzBinAddr *>*/ *entries(RzBinFile *bf) { // Should be 3 offsets
 }
 
 static RzList /*<RzBinString *>*/ *strings(RzBinFile *bf) {
-	return rz_bin_file_strings(bf, 0, false);
+	return rz_bin_file_strings(bf, bf->minstrlen, false);
 }
 
 RzBinPlugin rz_bin_plugin_smd = {

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -2496,6 +2496,7 @@ static bool cb_binmaxstr(void *user, void *data) {
 		core->bin->maxstrlen = v;
 		RzBinFile *bf = rz_bin_cur(core->bin);
 		if (bf && bf->o) {
+			bf->maxstrlen = v;
 			rz_bin_object_reset_strings(core->bin, bf, bf->o);
 		}
 		return true;
@@ -2507,13 +2508,15 @@ static bool cb_binminstr(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
 	if (core->bin) {
-		int v = node->i_value;
+		int v = (int)node->i_value;
 		if (v < 1) {
-			v = 4; // HACK
+			// when less than 1 always enforce 4 as the min string length.
+			v = 4;
 		}
 		core->bin->minstrlen = v;
 		RzBinFile *bf = rz_bin_cur(core->bin);
 		if (bf && bf->o) {
+			bf->minstrlen = v;
 			rz_bin_object_reset_strings(core->bin, bf, bf->o);
 		}
 		return true;

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -2468,10 +2468,11 @@ static bool cb_binmaxstrbuf(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
 	if (core->bin) {
-		int v = node->i_value;
+		int v = (int)node->i_value;
 		ut64 old_v = core->bin->maxstrbuf;
 		if (v < 1) {
-			v = 4; // HACK
+			// when less than 1 always enforce 4 as the min string length.
+			v = 4;
 		}
 		core->bin->maxstrbuf = v;
 		if (v > old_v) {
@@ -2489,8 +2490,8 @@ static bool cb_binmaxstr(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
 	if (core->bin) {
-		int v = node->i_value;
-		if (v < 0) {
+		int v = (int)node->i_value;
+		if (v < 1) {
 			v = 0;
 		}
 		core->bin->maxstrlen = v;
@@ -3182,8 +3183,8 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETI("bin.laddr", 0, "Base address for loading library ('*.so')");
 	SETCB("bin.dbginfo", "true", &cb_bindbginfo, "Load debug information at startup if available");
 	SETBPREF("bin.relocs", "true", "Load relocs information at startup if available");
-	SETICB("bin.minstr", 0, &cb_binminstr, "Minimum string length for rz_bin");
-	SETICB("bin.maxstr", 0, &cb_binmaxstr, "Maximum string length for rz_bin");
+	SETICB("bin.minstr", 0, &cb_binminstr, "Minimum string length for strings in bin plugins");
+	SETICB("bin.maxstr", 0, &cb_binmaxstr, "Maximum string length for strings in bin plugins");
 	SETICB("bin.maxstrbuf", 1024 * 1024 * 10, &cb_binmaxstrbuf, "Maximum size of range to load strings from");
 	n = NODECB("bin.str.enc", "guess", &cb_binstrenc);
 	SETDESC(n, "Default string encoding of binary");

--- a/librz/main/rz-bin.c
+++ b/librz/main/rz-bin.c
@@ -935,13 +935,16 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 		case 'n':
 			name = opt.arg;
 			break;
-		case 'N':
+		case 'N': {
 			tmp = strchr(opt.arg, ':');
-			rz_config_set(core.config, "bin.minstr", opt.arg);
+			int bin_strlen = rz_num_math(NULL, opt.arg);
+			rz_config_set_i(core.config, "bin.minstr", bin_strlen);
 			if (tmp) {
-				rz_config_set(core.config, "bin.maxstr", tmp + 1);
+				bin_strlen = rz_num_math(NULL, tmp + 1);
+				rz_config_set_i(core.config, "bin.maxstr", bin_strlen);
 			}
 			break;
+		}
 		case 'h':
 			rz_core_fini(&core);
 			return rabin_show_help(1);
@@ -1135,8 +1138,6 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 			return 1;
 		}
 	}
-	bin->minstrlen = rz_config_get_i(core.config, "bin.minstr");
-	bin->maxstrbuf = rz_config_get_i(core.config, "bin.maxstrbuf");
 
 	rz_bin_force_plugin(bin, forcebin);
 	rz_bin_load_filter(bin, action);
@@ -1168,6 +1169,11 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 	if (baddr != UT64_MAX) {
 		rz_bin_set_baddr(bin, baddr);
 	}
+
+	bf->minstrlen = bin->minstrlen = rz_config_get_i(core.config, "bin.minstr");
+	bf->maxstrlen = bin->maxstrlen = rz_config_get_i(core.config, "bin.maxstr");
+	bin->maxstrbuf = rz_config_get_i(core.config, "bin.maxstrbuf");
+
 	if (rawstr) {
 		PJ *pj = NULL;
 		if (out_mode == RZ_MODE_JSON) {
@@ -1191,6 +1197,8 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 			printf("%s", pj_string(pj));
 			pj_free(pj);
 		}
+	} else if (bf && bf->o) {
+		rz_bin_object_reset_strings(bin, bf, bf->o);
 	}
 	if (query) {
 		if (out_mode) {

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -3909,14 +3909,14 @@ nth paddr      vaddr       len size section             type  string
 -- geq 12 --
 nth paddr      vaddr       len size section             type  string            
 --------------------------------------------------------------------------------
-4   0x00000d73 0x100000d73 12  13   2.__TEXT.__cstring  ascii Hello World 
-10  0x00000db9 0x100000db9 13  14   2.__TEXT.__cstring  ascii v24@0:8i16i20
-16  0x00001078 0x100001078 12  13   9.__DATA.__cfstring ascii cstr.Hello World 
+0   0x00000d73 0x100000d73 12  13   2.__TEXT.__cstring  ascii Hello World 
+1   0x00000db9 0x100000db9 13  14   2.__TEXT.__cstring  ascii v24@0:8i16i20
+2   0x00001078 0x100001078 12  13   9.__DATA.__cfstring ascii cstr.Hello World 
 -- leq 13 --
 nth paddr      vaddr       len size section             type  string            
 --------------------------------------------------------------------------------
-4   0x00000d73 0x100000d73 12  13   2.__TEXT.__cstring  ascii Hello World 
-16  0x00001078 0x100001078 12  13   9.__DATA.__cfstring ascii cstr.Hello World 
+0   0x00000d73 0x100000d73 12  13   2.__TEXT.__cstring  ascii Hello World 
+2   0x00001078 0x100001078 12  13   9.__DATA.__cfstring ascii cstr.Hello World 
 EOF
 RUN
 
@@ -5628,5 +5628,24 @@ bits 32
 bits     64
 bits 64
 64
+EOF
+RUN
+
+NAME=print elf strings but with bin.minstr=2
+FILE=bins/elf/smallstrings.elf
+CMDS=<<EOF
+iz
+iz @e:bin.minstr=2
+EOF
+EXPECT=<<EOF
+nth paddr      vaddr      len size section type  string 
+--------------------------------------------------------
+0   0x0000200d 0x0000200d 4   5    .rodata ascii 4444
+nth paddr      vaddr      len size section type  string 
+--------------------------------------------------------
+0   0x00002006 0x00002006 2   3    .rodata ascii 22
+1   0x00002009 0x00002009 3   4    .rodata ascii 333
+2   0x0000200d 0x0000200d 4   5    .rodata ascii 4444
+3   0x00003008 0x00004008 2   3    .data   ascii \b@
 EOF
 RUN

--- a/test/db/tools/rz_bin
+++ b/test/db/tools/rz_bin
@@ -1222,3 +1222,18 @@ EXPECT=<<EOF
 [{"vaddr":77,"paddr":77,"ordinal":0,"size":45,"length":44,"section":"","type":"ascii","string":"!This program cannot be run in DOS mode.\r\r\n$"},{"vaddr":155,"paddr":155,"ordinal":1,"size":6,"length":5,"section":"","type":"ascii","string":"Q\fb.Q"},{"vaddr":189,"paddr":189,"ordinal":2,"size":5,"length":4,"section":"","type":"ascii","string":"b.Q{"},{"vaddr":205,"paddr":205,"ordinal":3,"size":8,"length":7,"section":"","type":"ascii","string":"b.Q4<*P"},{"vaddr":213,"paddr":213,"ordinal":4,"size":6,"length":5,"section":"","type":"ascii","string":"b.Q4<"},{"vaddr":221,"paddr":221,"ordinal":5,"size":8,"length":7,"section":"","type":"ascii","string":"b.Q4<,P"},{"vaddr":229,"paddr":229,"ordinal":6,"size":8,"length":7,"section":"","type":"ascii","string":"b.QRich"},{"vaddr":241,"paddr":241,"ordinal":7,"size":30,"length":29,"section":"","type":"ascii","string":"https://malwarec2.com/drd.exe"}]
 EOF
 RUN
+
+NAME=rz-bin load elf but with bin.minstr=2
+FILE=bins/elf/smallstrings.elf
+CMDS=!rz-bin -z -N2 ${RZ_FILE}
+EXPECT=<<EOF
+[Strings]
+nth paddr      vaddr      len size section type  string 
+--------------------------------------------------------
+0   0x00002006 0x00002006 2   3    .rodata ascii 22
+1   0x00002009 0x00002009 3   4    .rodata ascii 333
+2   0x0000200d 0x0000200d 4   5    .rodata ascii 4444
+3   0x00003008 0x00004008 2   3    .data   ascii \b@
+
+EOF
+RUN


### PR DESCRIPTION
# SQUASH ME

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

These changes allows most of the plugins using `rz_bin_file_strings` to allow the user to define the smallest string length instead of hardcoding it in the plugin.

**Test plan**

Added test for rz-bin and rizin

**Closing issues**

Fix #2859