### PR TITLE
Add array bounds, write strings, type limits, overshadowing warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
             os: ubuntu-22.04
             build_system: meson
             compiler: gcc-12
-            cflags: "-DRZ_ASSERT_STDOUT=1 -Wno-cpp -Wtype-limits -Wwrite-strings -Warray-bounds -fsanitize=bounds -fsanitize-undefined-trap-on-error -ftrivial-auto-var-init=pattern -funsigned-char"
+            cflags: "-DRZ_ASSERT_STDOUT=1 -Wno-cpp -Wtype-limits -Wwrite-strings -Warray-bounds -Wshadow=local -fsanitize=bounds -fsanitize-undefined-trap-on-error -ftrivial-auto-var-init=pattern -funsigned-char"
             meson_options: -Dbuildtype=debugoptimized -Db_sanitize=address,undefined --werror
             asan: true
             asan_options: "detect_leaks=0,detect_odr_violation=0,allocator_may_return_null=1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,9 @@ jobs:
             timeout: 60
             allow_failure: false
           - name: linux-gcc-tests-asan
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             build_system: meson
-            compiler: gcc-12
+            compiler: gcc-14
             cflags: "-DRZ_ASSERT_STDOUT=1 -Wno-cpp -Wtype-limits -Wwrite-strings -Warray-bounds -Wshadow=local -fsanitize=bounds -fsanitize-undefined-trap-on-error -ftrivial-auto-var-init=pattern -funsigned-char"
             meson_options: -Dbuildtype=debugoptimized -Db_sanitize=address,undefined --werror
             asan: true
@@ -107,7 +107,7 @@ jobs:
             timeout: 120
             allow_failure: false
           - name: linux-clang-tests-asan
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             build_system: meson
             compiler: clang
             cflags: "-DRZ_ASSERT_STDOUT=1 -Wno-cpp"
@@ -184,8 +184,11 @@ jobs:
       - name: Install python and other dependencies
         if: (matrix.run_tests || matrix.build_system == 'meson') && matrix.os != 'macos-12' && matrix.enabled
         run: sudo apt-get --assume-yes install python3-wheel python3-setuptools libcapstone4 libcapstone-dev
-      - name: Install meson and ninja
-        if: matrix.build_system == 'meson' && matrix.enabled
+      - name: Install meson and ninja (Modern PIP)
+        if: matrix.build_system == 'meson' && matrix.enabled && matrix.os == 'ubuntu-24.04'
+        run: pip3 install --break-system-packages --user meson ninja PyYAML
+      - name: Install meson and ninja (Old PIP)
+        if: matrix.build_system == 'meson' && matrix.enabled && matrix.os != 'ubuntu-24.04'
         run: pip3 install --user meson ninja PyYAML
       - name: Checkout rzpipe
         if: matrix.enabled
@@ -193,8 +196,11 @@ jobs:
         with:
           repository: rizinorg/rz-pipe
           path: test/rz-pipe
-      - name: Install test dependencies
-        if: matrix.run_tests && matrix.enabled
+      - name: Install test dependencies (Modern PIP)
+        if: matrix.run_tests && matrix.enabled && matrix.os == 'ubuntu-24.04'
+        run: pip3 install --break-system-packages --user "file://$GITHUB_WORKSPACE/test/rz-pipe#egg=rzpipe&subdirectory=python" requests
+      - name: Install test dependencies (Old PIP)
+        if: matrix.run_tests && matrix.enabled && matrix.os != 'ubuntu-24.04'
         run: pip3 install --user "file://$GITHUB_WORKSPACE/test/rz-pipe#egg=rzpipe&subdirectory=python" requests
       - name: Install Linux test dependencies
         if: matrix.run_tests && matrix.enabled && matrix.os != 'macos-12'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
             os: ubuntu-22.04
             build_system: meson
             compiler: gcc-12
-            cflags: "-DRZ_ASSERT_STDOUT=1 -Wno-cpp -ftrivial-auto-var-init=pattern -funsigned-char"
+            cflags: "-DRZ_ASSERT_STDOUT=1 -Wno-cpp -Wtype-limits -Wwrite-strings -Warray-bounds -fsanitize=bounds -fsanitize-undefined-trap-on-error -ftrivial-auto-var-init=pattern -funsigned-char"
             meson_options: -Dbuildtype=debugoptimized -Db_sanitize=address,undefined --werror
             asan: true
             asan_options: "detect_leaks=0,detect_odr_violation=0,allocator_may_return_null=1"


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Experiment on adding more restrictions on the C code:
1. Added array bounds checking:
```
        -Warray-bounds
        -fsanitize=bounds
        -fsanitize-undefined-trap-on-error
```
2. Added type limits warnings
3. Added writing into constant strings warnings
4. Added warning on overshadowing variables `-Wshadow=local`

See more at:
- https://people.kernel.org/kees/bounded-flexible-arrays-in-c
- https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html

**Test plan**

CI is green