### PR TITLE
Fix variable declaration in `Vv` mode

### DIFF
--- a/librz/core/tui/vmenus.c
+++ b/librz/core/tui/vmenus.c
@@ -725,17 +725,14 @@ RZ_IPI void rz_core_visual_analysis(RzCore *core, const char *input) {
 				rz_core_analysis_function_add(core, NULL, core->offset, false);
 				break;
 			case 1: {
-				eprintf("Select variable source ('r'egister, 's'tackptr or 'b'aseptr): ");
+				eprintf("Select variable source ('r'egister or 's'tack): ");
 				int type = rz_cons_readchar();
 				switch (type) {
 				case 'r':
 					addVar(core, type, "Source Register Name: ");
 					break;
 				case 's':
-					addVar(core, type, "BP Relative Delta: ");
-					break;
-				case 'b':
-					addVar(core, type, "SP Relative Delta: ");
+					addVar(core, type, "Stack Relative Delta: ");
 					break;
 				}
 			} break;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Since the change of function variables it wasn't working

**Test plan**

1. `rizin <binary>`
2. `aaa`
3. `Vv`
4. Press `v` (variables) then `a` (add variable)
5. Try to define either new register or stack variable

<img width="390" alt="Screenshot 2023-02-03 at 11 52 55" src="https://user-images.githubusercontent.com/203261/216508762-9ad32878-232b-4c19-96b2-654164112083.png">
