### PR TITLE
Fix big memory leak in parsing x86 disasm

### DIFF
--- a/librz/parse/p/parse_x86_pseudo.c
+++ b/librz/parse/p/parse_x86_pseudo.c
@@ -320,10 +320,12 @@ static char *subvar_stack(RzParse *p, RzAnalysisOp *op, RZ_NULLABLE RzAnalysisFu
 
 	RzRegex var_re;
 	if (rz_regex_comp(&var_re, re_str, RZ_REGEX_EXTENDED | RZ_REGEX_ICASE) != 0) {
+		rz_regex_fini(&var_re);
 		return tstr;
 	}
 	RzRegexMatch match[4];
 	if (rz_regex_exec(&var_re, tstr, RZ_ARRAY_SIZE(match), match, 0) != 0) {
+		rz_regex_fini(&var_re);
 		return tstr;
 	}
 	for (size_t i = 0; i < RZ_ARRAY_SIZE(match); i++) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes the following huge memory leak:
```
Direct leak of 29526 byte(s) in 74 object(s) allocated from:
    #0 0x7f4ccc6ba097 in calloc (/lib64/libasan.so.8+0xba097)
    #1 0x7f4ccbdbcd62 in rz_regex_comp ../librz/util/regex/regcomp.c:301
    #2 0x7f4cca03e6fc in subvar_stack ../librz/parse/p/parse_x86_pseudo.c:322
    #3 0x7f4cca03e6fc in subvar ../librz/parse/p/parse_x86_pseudo.c:449
    #4 0x7f4cc21a6263 in ds_build_op_str ../librz/core/disasm.c:1052
    #5 0x7f4cc21d3e10 in rz_core_print_disasm ../librz/core/disasm.c:5630
    #6 0x7f4cc22a7076 in core_disassembly ../librz/core/cmd/cmd_print.c:3818
    #7 0x7f4cc232fe46 in rz_cmd_disassembly_n_instructions_handler ../librz/core/cmd/cmd_print.c:3851
    #8 0x7f4cc23f3aad in argv_call_cb ../librz/core/cmd/cmd_api.c:767
    #9 0x7f4cc23f3aad in call_cd ../librz/core/cmd/cmd_api.c:804
    #10 0x7f4cc23f3aad in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:822
    #11 0x7f4cc23bf691 in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:3646
    #12 0x7f4cc23bf691 in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:3593
    #13 0x7f4cc22ad289 in handle_ts_stmt ../librz/core/cmd/cmd.c:5131
    #14 0x7f4cc23c653a in handle_ts_stmt_tmpseek ../librz/core/cmd/cmd.c:5148
    #15 0x7f4cc23c653a in handle_ts_tmp_seek_stmt_internal ../librz/core/cmd/cmd.c:3987
    #16 0x7f4cc23c653a in handle_ts_tmp_seek_stmt ../librz/core/cmd/cmd.c:3969
    #17 0x7f4cc22ad289 in handle_ts_stmt ../librz/core/cmd/cmd.c:5131
    #18 0x7f4cc236a2fa in handle_ts_statements_internal ../librz/core/cmd/cmd.c:5188
    #19 0x7f4cc236a2fa in handle_ts_statements ../librz/core/cmd/cmd.c:5153
    #20 0x7f4cc236b6d1 in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:5299
    #21 0x7f4cc236bac1 in rz_core_cmd ../librz/core/cmd/cmd.c:5347
    #22 0x7f4cc23877e0 in core_cmd_raw ../librz/core/cmd/cmd.c:5507
    #23 0x7f4cc24a1987 in rz_core_visual_analysis_refresh_column ../librz/core/tui/vmenus.c:289
    #24 0x7f4cc24a1987 in rz_core_visual_analysis_refresh ../librz/core/tui/vmenus.c:369
    #25 0x7f4cc24a40a5 in rz_core_visual_analysis ../librz/core/tui/vmenus.c:617
    #26 0x7f4cc2487ad8 in rz_core_visual_cmd ../librz/core/tui/visual.c:2548
    #27 0x7f4cc249a512 in rz_core_visual ../librz/core/tui/visual.c:3683
    #28 0x7f4cc23f2ff5 in call_cd ../librz/core/cmd/cmd_api.c:807
    #29 0x7f4cc23f2ff5 in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:822
    #30 0x7f4cc23bf691 in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:3646
    #31 0x7f4cc23bf691 in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:3593
    #32 0x7f4cc22ad289 in handle_ts_stmt ../librz/core/cmd/cmd.c:5131
    #33 0x7f4cc236a2fa in handle_ts_statements_internal ../librz/core/cmd/cmd.c:5188
    #34 0x7f4cc236a2fa in handle_ts_statements ../librz/core/cmd/cmd.c:5153
    #35 0x7f4cc236b6d1 in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:5299
    #36 0x7f4cc236bac1 in rz_core_cmd ../librz/core/cmd/cmd.c:5347
    #37 0x7f4cc213eadc in rz_core_prompt_exec ../librz/core/core.c:2807
    #38 0x7f4cc2140585 in rz_core_prompt_loop ../librz/core/core.c:2677
    #39 0x7f4ccb70c4e4 in rz_main_rizin ../librz/main/rizin.c:1410
    #40 0x7f4ccae4a50f in __libc_start_call_main (/lib64/libc.so.6+0x2750f)
```

**Test plan**

- CI is green
- Open any x86 executable, run analysis, start visual mode with disasm, and scroll back and forth for a while. Observe no huge leaks.