### PR TITLE
Use theme color for `pxa` header

### DIFF
--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -1321,6 +1321,9 @@ stage_left:
 		strcat(x, y); \
 		x += strlen(y); \
 	}
+
+#define Pal(x, y) (x->cons && x->cons->context->pal.y) ? x->cons->context->pal.y
+
 static void annotated_hexdump(RzCore *core, int len) {
 	if (!len) {
 		return;
@@ -1404,7 +1407,9 @@ static void annotated_hexdump(RzCore *core, int len) {
 		sprintf(bytes + j + i, "%0X", i % 17);
 	}
 	if (usecolor) {
-		rz_cons_strcat(Color_GREEN);
+		const char *color_title = Pal(core, offset)
+		    : Color_MAGENTA;
+		rz_cons_strcat(color_title);
 		rz_cons_strcat(bytes);
 		rz_cons_strcat(Color_RESET);
 	} else {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Use the color from theme palette for the header of `pxa` command (before it was always green)

**Test plan**

- Compare the output of `px` and `pxa`
- Analyze the file, start `Vv` mode, then press `P`/`p` until annotated hexdump mode appears.

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/3251
