### PR TITLE
Fix big memory leak in graph rendering

### DIFF
--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -3414,7 +3414,6 @@ static int agraph_print(RzAGraph *g, int is_interactive, RzCore *core, RzAnalysi
 	if (!rz_cons_canvas_resize(g->can, w, h)) {
 		return false;
 	}
-	// rz_cons_canvas_clear (g->can);
 	if (!is_interactive) {
 		g->can->sx = -g->x;
 		g->can->sy = -g->y - 1;
@@ -3884,16 +3883,17 @@ RZ_API void rz_agraph_reset(RzAGraph *g) {
 }
 
 RZ_API void rz_agraph_free(RzAGraph *g) {
-	if (g) {
-		ht_pp_free(g->nodes);
-		rz_list_free(g->dummy_nodes);
-		rz_graph_free(g->graph);
-		rz_list_free(g->edges);
-		rz_agraph_set_title(g, NULL);
-		sdb_free(g->db);
-		rz_cons_canvas_free(g->can);
-		free(g);
+	if (!g) {
+		return;
 	}
+	ht_pp_free(g->nodes);
+	rz_list_free(g->dummy_nodes);
+	rz_graph_free(g->graph);
+	rz_list_free(g->edges);
+	rz_agraph_set_title(g, NULL);
+	sdb_free(g->db);
+	rz_cons_canvas_free(g->can);
+	free(g);
 }
 
 RZ_API RzAGraph *rz_agraph_new(RzConsCanvas *can) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

If the next graph was smaller the older one, canvas resizing function wasn't freeing unnecessary lines which produced the following leak:
```
Direct leak of 70656 byte(s) in 384 object(s) allocated from:
    #0 0x7f9886cba6af in __interceptor_malloc (/lib64/libasan.so.8+0xba6af)
    #1 0x7f9884aeaa7f in rz_cons_canvas_resize ../librz/cons/canvas.c:460
    #2 0x7f987c7ae85e in agraph_print ../librz/core/agraph.c:3414
    #3 0x7f987c7bb544 in rz_agraph_print ../librz/core/agraph.c:3655
    #4 0x7f987c7e769c in rz_core_agraph_print ../librz/core/cagraph.c:214
    #5 0x7f987c7ecf66 in rz_core_graph_print_graph ../librz/core/cgraph.c:547
    #6 0x7f987c7ed148 in rz_core_graph_print ../librz/core/cgraph.c:586
    #7 0x7f987cafe034 in rz_analysis_graph_bb_function_handler ../librz/core/cmd/cmd_analysis.c:4595
    #8 0x7f987cbf36f1 in argv_call_cb ../librz/core/cmd/cmd_api.c:745
    #9 0x7f987cbf36f1 in call_cd ../librz/core/cmd/cmd_api.c:804
    #10 0x7f987cbf36f1 in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:822
    #11 0x7f987cbbf6a1 in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:3646
    #12 0x7f987cbbf6a1 in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:3593
    #13 0x7f987caad299 in handle_ts_stmt ../librz/core/cmd/cmd.c:5131
    #14 0x7f987cbc654a in handle_ts_stmt_tmpseek ../librz/core/cmd/cmd.c:5148
    #15 0x7f987cbc654a in handle_ts_tmp_seek_stmt_internal ../librz/core/cmd/cmd.c:3987
    #16 0x7f987cbc654a in handle_ts_tmp_seek_stmt ../librz/core/cmd/cmd.c:3969
    #17 0x7f987caad299 in handle_ts_stmt ../librz/core/cmd/cmd.c:5131
    #18 0x7f987cb6a30a in handle_ts_statements_internal ../librz/core/cmd/cmd.c:5188
    #19 0x7f987cb6a30a in handle_ts_statements ../librz/core/cmd/cmd.c:5153
    #20 0x7f987cb6b6e1 in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:5299
    #21 0x7f987cb6bad1 in rz_core_cmd ../librz/core/cmd/cmd.c:5347
    #22 0x7f987cb877f0 in core_cmd_raw ../librz/core/cmd/cmd.c:5507
    #23 0x7f987cca1997 in rz_core_visual_analysis_refresh_column ../librz/core/tui/vmenus.c:289
    #24 0x7f987cca1997 in rz_core_visual_analysis_refresh ../librz/core/tui/vmenus.c:369
    #25 0x7f987cca40b5 in rz_core_visual_analysis ../librz/core/tui/vmenus.c:617
    #26 0x7f987cc87ae8 in rz_core_visual_cmd ../librz/core/tui/visual.c:2548
    #27 0x7f987cc9a522 in rz_core_visual ../librz/core/tui/visual.c:3683
    #28 0x7f987cbf3005 in call_cd ../librz/core/cmd/cmd_api.c:807
    #29 0x7f987cbf3005 in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:822
    #30 0x7f987cbbf6a1 in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:3646
    #31 0x7f987cbbf6a1 in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:3593
    #32 0x7f987caad299 in handle_ts_stmt ../librz/core/cmd/cmd.c:5131
    #33 0x7f987cb6a30a in handle_ts_statements_internal ../librz/core/cmd/cmd.c:5188
    #34 0x7f987cb6a30a in handle_ts_statements ../librz/core/cmd/cmd.c:5153
    #35 0x7f987cb6b6e1 in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:5299
    #36 0x7f987cb6bad1 in rz_core_cmd ../librz/core/cmd/cmd.c:5347
    #37 0x7f987c93eadc in rz_core_prompt_exec ../librz/core/core.c:2807
    #38 0x7f987c940585 in rz_core_prompt_loop ../librz/core/core.c:2677
    #39 0x7f9885d0c4e4 in rz_main_rizin ../librz/main/rizin.c:1410
```

**Test plan**

- CI is green
- Analyze any file, then go to `Vv` mode, press `P` to reach graph mode, then scroll for some time. You should observe no leaks of the kind mentioned in the description
