### PR TITLE
Linux heap - skip invalid addresses in main arena

### DIFF
--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -1306,6 +1306,10 @@ void GH(print_malloc_states)(RzCore *core, GHT m_arena, MallocState *main_arena,
 		ta->next = main_arena->next;
 		while (GH(is_arena)(core, m_arena, ta->next) && ta->next != m_arena) {
 			ut64 ta_addr = ta->next;
+			/* If the pointer is equal to unsigned -1, we assume it is invalid */
+			if (ta->next == GHT_MAX) {
+				break;
+			}
 			if (!GH(rz_heap_update_main_arena)(core, ta->next, ta)) {
 				goto end;
 			}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Backport of https://github.com/radareorg/radare2/commit/f81c7dee37983957d8bc702de637780b0504d318

**Test plan**

1. `rizin -d /bin/ls`
2. `db @ sym.imp.free; dc`
3. `dmh`
4. `dmha`

**Closing issues**

Should address https://github.com/rizinorg/rizin/issues/3053