### PR TITLE
Use Muon for TinyCC build job

### DIFF
--- a/.github/workflows/tcc.yml
+++ b/.github/workflows/tcc.yml
@@ -50,7 +50,7 @@ jobs:
           cd tinycc
           #git checkout mob
           # Well-tested commit
-          git checkout 5b28165fbf8549c5d92893339e4f6b6181316894
+          git checkout 2eca4df6e9cf31a4c87202668a3e96be1f7601b8
           chmod +x ./configure
 
     - name: Compiling and installing TinyCC
@@ -62,29 +62,35 @@ jobs:
 
     - name: Install dependencies
       run: |
-          sudo apt-get --assume-yes install python3-wheel python3-setuptools
+          sudo apt-get --assume-yes install python3-wheel python3-setuptools pkgconf libcurl4-openssl-dev libpkgconf-dev libarchive-dev
           sudo python3 -m pip install ninja
 
-    - name: Checkout meson from ret2libc git
+    - name: Checkout Muon repository
       run: |
-          git clone https://github.com/ret2libc/meson.git
-          cd meson
-          git checkout tiny-cc
-          python3 setup.py build
-          sudo python3 setup.py install
+          git clone https://git.sr.ht/~lattis/muon
+
+    - name: Compiling and installing Muon
+      working-directory: muon
+      run: |
+          ./bootstrap.sh build
+          build/muon-bootstrap setup build
+          ninja -C build
+          sudo cp build/muon /usr/bin/muon
 
     - name: Checkout our Testsuite Binaries
       uses: actions/checkout@v4
       with:
           repository: rizinorg/rizin-testbins
           path: test/bins
-
-    - name: Meson setup
+    
+    - name: Muon setup
       env:
           CC: tcc
-      run: meson setup --prefix=/usr build
-    - name: Meson compile and install
-      run: ninja -C build && sudo ninja -C build install
+      run: muon setup -Denv.CC=tcc -Dprefix=/usr build
+
+    - name: Ninja compile and install
+      run: ninja -C build && sudo muon -C build install
+
     - name: Run unit tests
       run: ninja -C build test
 

--- a/.github/workflows/tcc.yml
+++ b/.github/workflows/tcc.yml
@@ -62,15 +62,20 @@ jobs:
 
     - name: Install dependencies
       run: |
-          sudo apt-get --assume-yes install python3-wheel python3-setuptools
+          sudo apt-get --assume-yes install python3-wheel python3-setuptools pkgconf libcurl4-openssl-dev libarchive-dev
           sudo python3 -m pip install ninja
 
-    - name: Checkout meson from ret2libc git
+    - name: Checkout Muon repository
       run: |
-          git clone --depth 1 -b tiny-cc https://github.com/ret2libc/meson.git
-          cd meson
-          python3 setup.py build
-          sudo python3 setup.py install
+          git clone https://git.sr.ht/~lattis/muon
+
+    - name: Compiling and installing Muon
+      working-directory: muon
+      run: |
+          ./bootstrap.sh build
+          build/muon-bootstrap setup build
+          ninja -C build
+          sudo cp build/muon /usr/bin/muon
 
     - name: Checkout our Testsuite Binaries
       uses: actions/checkout@v6
@@ -78,14 +83,16 @@ jobs:
           repository: rizinorg/rizin-testbins
           path: test/bins
 
-    - name: Meson setup
+    - name: Muon setup
       env:
           CC: tcc
-      run: meson setup --prefix=/usr build
-    - name: Meson compile and install
-      run: ninja -C build && sudo ninja -C build install
+      # Muon defaults to static libraries, meson to shared ones. Ask for shared
+      # explicitly so this job keeps testing the same layout as every other one.
+      run: muon setup -Dprefix=/usr -Ddefault_library=shared build
+    - name: Muon compile and install
+      run: ninja -C build && sudo muon -C build install
     - name: Run unit tests
-      run: ninja -C build test
+      run: muon -C build test
 
     - name: Install test dependencies
       run: |


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

To avoid the need to maintain Meson fork since they didn't accept the TCC build support - just use Muon which supports TCC out of the box.

**Test plan**

CI is green

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/3325
