### PR TITLE
Remove use of deprecated `set-output` in GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,8 +561,7 @@ jobs:
         run: pip3 install --user ninja PyYAML
       - uses: actions/checkout@v3
       - name: Extract rizin version
-        shell: bash
-        run: echo "##[set-output name=version;]$(python sys/version.py)"
+        run: echo "version=$(python sys/version.py)" >> $GITHUB_OUTPUT
         id: extract_version
       - name: Create archive
         run: |
@@ -668,8 +667,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install meson ninja PyYAML
       - name: Extract rizin version
-        shell: pwsh
-        run: echo "##[set-output name=branch;]$( python sys\\version.py )"
+        run: echo "branch=$(python sys/version.py)" >> $GITHUB_OUTPUT
         id: extract_version
       - name: Build and create zip/installer
         shell: pwsh
@@ -897,8 +895,7 @@ jobs:
           choco install -y pkgconfiglite --download-checksum 2038c49d23b5ca19e2218ca89f06df18fe6d870b4c6b54c0498548ef88771f6f --download-checksum-type sha256
           choco install -y cmake
       - name: Extract rizin version
-        shell: pwsh
-        run: echo "##[set-output name=branch;]$( python sys\\version.py )"
+        run: echo "branch=$(python sys/version.py)" >> $GITHUB_OUTPUT
         id: extract_version
       - uses: actions/download-artifact@v3
         with:
@@ -953,8 +950,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Extract rizin version
-        shell: bash
-        run: echo "##[set-output name=branch;]$(python sys/version.py)"
+        run: echo "branch=$(python sys/version.py)" >> $GITHUB_OUTPUT
         id: extract_version
       - name: Create Release
         id: create_release

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Determine current repository
         id: "determine-repo"
-        run: "echo \"::set-output name=repo::${GITHUB_REPOSITORY}\""
+        run: echo "repo=${GITHUB_REPOSITORY}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v3
       - name: Download Coverity Build Tool


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Update to the way recommended by GitHub: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The old way will be disabled  on 31st May 2023

**Test plan**

Ci is green

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/3332
