### PR TITLE
CI: env vars on windows work differently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -667,7 +667,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install meson ninja PyYAML
       - name: Extract rizin version
-        run: echo "branch=$(python sys/version.py)" >> $GITHUB_OUTPUT
+        shell: pwsh
+        run: echo "branch=$(python sys/version.py)" >> $Env:GITHUB_OUTPUT
         id: extract_version
       - name: Build and create zip/installer
         shell: pwsh
@@ -895,7 +896,8 @@ jobs:
           choco install -y pkgconfiglite --download-checksum 2038c49d23b5ca19e2218ca89f06df18fe6d870b4c6b54c0498548ef88771f6f --download-checksum-type sha256
           choco install -y cmake
       - name: Extract rizin version
-        run: echo "branch=$(python sys/version.py)" >> $GITHUB_OUTPUT
+        shell: pwsh
+        run: echo "branch=$(python sys/version.py)" >> $Env:GITHUB_OUTPUT
         id: extract_version
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Hopefully fix https://github.com/rizinorg/rizin/issues/3350 . We can see whether the windows jobs produce the correctly named artifacts.