### PR TITLE
core/cmd: handle properly errors while executing commands substitution

### DIFF
--- a/librz/core/cmd/cmd_shell.c
+++ b/librz/core/cmd/cmd_shell.c
@@ -17,7 +17,7 @@ RZ_IPI RzCmdStatus rz_cmd_shell_env_handler(RzCore *core, int argc, const char *
 	case 2:
 		p = rz_sys_getenv(argv[1]);
 		if (!p) {
-			return RZ_CMD_STATUS_ERROR;
+			return RZ_CMD_STATUS_OK;
 		}
 		rz_cons_println(p);
 		free(p);

--- a/test/db/cmd/cmd_open
+++ b/test/db/cmd/cmd_open
@@ -87,8 +87,6 @@ RUN
 NAME=o =
 FILE=malloc://1024
 CMDS=<<EOF
-e file.nowarn=true
-e file.loadmethod=append
 o =;ol~?
 EOF
 EXPECT=<<EOF

--- a/test/db/io/maps
+++ b/test/db/io/maps
@@ -65,9 +65,7 @@ NAME=om 0x100;x@0xff
 FILE==
 CMDS=<<EOF
 e io.va=false
-e file.nowarn=true
-e file.loadmethod=append
-om `o~[0]` 0x100
+om `ol~[0]` 0x100
 w pop @ 1
 p8 4 @ 0x100
 EOF


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Before this patch, while executing a command with a command substitution, if the command substitution failed the outer command was executed anyway, giving wrong results in some cases.

This commit makes sure that errors in command substitutions are propagated to the outer command.

Wrong behaviour:
```
[0x00000000]> f ciao
[0x00000000]> fr ciao $(jjjj boh)
ERROR: Command 'jjjj' does not exist.
[0x00000000]> fl
0x00000000 1 jjjj_boh
[0x00000000]>
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Good behaviour:
```
[0x00000000]> f ciao
[0x00000000]> fr ciao $(jjjj boh)
ERROR: Command 'jjjj' does not exist.
ERROR: Error while substituting arguments
ERROR: core: Error while executing command: fr ciao $(jjjj boh)
[0x00000000]> fl
0x00000000 1 ciao
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
