### PR TITLE
Fix filling RzAnalysisDisasmText.arrow when asm.lines=false

### DIFF
--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -897,7 +897,9 @@ static void ds_reflines_init(RzDisasmState *ds) {
 
 	lastaddr = UT64_MAX;
 
-	if (ds->show_lines_bb || ds->pj) {
+	// refline info is needed when it is shown as ascii,
+	// or returned as part of a json or C struct representation.
+	if (ds->show_lines_bb || ds->vec || ds->pj) {
 		ds_reflines_fini(ds);
 		analysis->reflines = rz_analysis_reflines_get(analysis,
 			ds->addr, ds->buf, ds->len, ds->l,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The arrow info is needed to print custom reflines, for example in Cutter. In such a case, asm.lines will generally be false to not have the lines also printed inside the text.

Fixes https://github.com/rizinorg/cutter/issues/3045