### PR TITLE
Fix memory leak in RzParse ARM and MIPS

### DIFF
--- a/librz/parse/p/parse_arm_pseudo.c
+++ b/librz/parse/p/parse_arm_pseudo.c
@@ -246,6 +246,7 @@ static char *subvar_stack(RzParse *p, RzAnalysisOp *op, RZ_NULLABLE RzAnalysisFu
 
 	RzRegex var_re;
 	if (rz_regex_comp(&var_re, re_str, RZ_REGEX_EXTENDED | RZ_REGEX_ICASE) != 0) {
+		rz_regex_fini(&var_re);
 		return tstr;
 	}
 	RzRegexMatch match[4] = { 0 };

--- a/librz/parse/p/parse_mips_pseudo.c
+++ b/librz/parse/p/parse_mips_pseudo.c
@@ -170,10 +170,12 @@ static char *subvar_stack(RzParse *p, RzAnalysisOp *op, RZ_NULLABLE RzAnalysisFu
 
 	RzRegex var_re;
 	if (rz_regex_comp(&var_re, re_str, RZ_REGEX_EXTENDED | RZ_REGEX_ICASE) != 0) {
+		rz_regex_fini(&var_re);
 		return tstr;
 	}
 	RzRegexMatch match[4];
 	if (rz_regex_exec(&var_re, tstr, RZ_ARRAY_SIZE(match), match, 0) != 0) {
+		rz_regex_fini(&var_re);
 		return tstr;
 	}
 	for (size_t i = 0; i < RZ_ARRAY_SIZE(match); i++) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fix huge memory leaks similar to https://github.com/rizinorg/rizin/commit/66e4f71dfa51bd53e134e8248f8c1c8ee3ef8872 but for ARM and MIPS

**Test plan**

CI is green
