### PR TITLE
Fix crash in `iA` commands for undefined arch

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -5255,7 +5255,7 @@ RZ_API bool rz_core_bin_archs_print(RZ_NONNULL RzBin *bin, RZ_NONNULL RzCmdState
 		struct arch_ctx ctx = { 0 };
 		ctx.offset = obj->boffset;
 		ctx.size = obj->obj_size;
-		ctx.arch = info ? info->arch : "unk_0";
+		ctx.arch = (info && info->arch) ? info->arch : "unk_0";
 		ctx.bits = info ? info->bits : 0;
 		ctx.machine = info ? info->machine : "unknown_machine";
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Check string for NULL before printing.

**Test plan**

```
rizin =
[0x0000000]> iA
[0x0000000]> iAj
```

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/3363
