### PR TITLE
Add macros to generate inf/nan for different types

### DIFF
--- a/librz/include/rz_types_base.h
+++ b/librz/include/rz_types_base.h
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include <limits.h>
 #include <math.h>
+#include <fenv.h>
 
 #define cut8  const unsigned char
 #define ut64  unsigned long long
@@ -95,16 +96,6 @@ typedef struct _utX {
 #define UT8_MIN   0x00U
 #define ASCII_MIN 32
 #define ASCII_MAX 127
-
-#define F32_NAN   (strtof("NAN", NULL))
-#define F32_PINF  (strtof("INF", NULL))
-#define F32_NINF  (-strtof("INF", NULL))
-#define F64_NAN   (strtod("NAN", NULL))
-#define F64_PINF  (strtod("INF", NULL))
-#define F64_NINF  (-strtod("INF", NULL))
-#define F128_NAN  (strtold("NAN", NULL))
-#define F128_PINF (strtold("INF", NULL))
-#define F128_NINF (-strtold("INF", NULL))
 
 #if SSIZE_MAX == ST32_MAX
 #define SZT_MAX  UT32_MAX

--- a/librz/include/rz_types_base.h
+++ b/librz/include/rz_types_base.h
@@ -5,7 +5,6 @@
 #include <sys/types.h>
 #include <limits.h>
 #include <math.h>
-#include <fenv.h>
 
 #define cut8  const unsigned char
 #define ut64  unsigned long long

--- a/librz/include/rz_util/rz_float.h
+++ b/librz/include/rz_util/rz_float.h
@@ -14,25 +14,25 @@
  *
  * Portable float nums in C
  */
-RZ_API float types_gen_f32_nan(void);
-RZ_API float types_gen_f32_inf(void);
-RZ_API double types_gen_f64_nan(void);
-RZ_API double types_gen_f64_inf(void);
-RZ_API long double types_gen_f128_nan(void);
-RZ_API long double types_gen_f128_inf(void);
+RZ_API float rz_types_gen_f32_nan(void);
+RZ_API float rz_types_gen_f32_inf(void);
+RZ_API double rz_types_gen_f64_nan(void);
+RZ_API double rz_types_gen_f64_inf(void);
+RZ_API long double rz_types_gen_f128_nan(void);
+RZ_API long double rz_types_gen_f128_inf(void);
 
-#define F32_NAN   (types_gen_f32_nan())
-#define F32_PINF  (types_gen_f32_inf())
-#define F32_NINF  (-types_gen_f32_inf())
-#define F64_NAN   (types_gen_f64_nan())
-#define F64_PINF  (types_gen_f64_inf())
-#define F64_NINF  (-types_gen_f64_inf())
-#define F80_NAN   (types_gen_f128_nan())
-#define F80_PINF  (types_gen_f128_inf())
-#define F80_NINF  (-types_gen_f128_inf())
-#define F128_NAN  (types_gen_f128_nan())
-#define F128_PINF (types_gen_f128_inf())
-#define F128_NINF (-types_gen_f128_inf())
+#define F32_NAN   (rz_types_gen_f32_nan())
+#define F32_PINF  (rz_types_gen_f32_inf())
+#define F32_NINF  (-rz_types_gen_f32_inf())
+#define F64_NAN   (rz_types_gen_f64_nan())
+#define F64_PINF  (rz_types_gen_f64_inf())
+#define F64_NINF  (-rz_types_gen_f64_inf())
+#define F80_NAN   (rz_types_gen_f128_nan())
+#define F80_PINF  (rz_types_gen_f128_inf())
+#define F80_NINF  (-rz_types_gen_f128_inf())
+#define F128_NAN  (rz_types_gen_f128_nan())
+#define F128_PINF (rz_types_gen_f128_inf())
+#define F128_NINF (-rz_types_gen_f128_inf())
 
 typedef enum rz_float_format_enum {
 	/// basic IEEE 754 float format enums

--- a/librz/include/rz_util/rz_float.h
+++ b/librz/include/rz_util/rz_float.h
@@ -10,6 +10,30 @@
 #define RZ_FLOAT_H
 #include <rz_types.h>
 
+/**
+ *
+ * Portable float nums in C
+ */
+RZ_API float types_gen_f32_nan(void);
+RZ_API float types_gen_f32_inf(void);
+RZ_API double types_gen_f64_nan(void);
+RZ_API double types_gen_f64_inf(void);
+RZ_API long double types_gen_f128_nan(void);
+RZ_API long double types_gen_f128_inf(void);
+
+#define F32_NAN   (types_gen_f32_nan())
+#define F32_PINF  (types_gen_f32_inf())
+#define F32_NINF  (-types_gen_f32_inf())
+#define F64_NAN   (types_gen_f64_nan())
+#define F64_PINF  (types_gen_f64_inf())
+#define F64_NINF  (-types_gen_f64_inf())
+#define F80_NAN   (types_gen_f128_nan())
+#define F80_PINF  (types_gen_f128_inf())
+#define F80_NINF  (-types_gen_f128_inf())
+#define F128_NAN  (types_gen_f128_nan())
+#define F128_PINF (types_gen_f128_inf())
+#define F128_NINF (-types_gen_f128_inf())
+
 typedef enum rz_float_format_enum {
 	/// basic IEEE 754 float format enums
 	/// ref : https://en.wikipedia.org/wiki/IEEE_754#Basic_and_interchange_formats

--- a/librz/util/float/float.c
+++ b/librz/util/float/float.c
@@ -19,12 +19,14 @@
 #include "float_internal.c"
 #include <rz_userconf.h>
 #include <math.h>
+#include <fenv.h>
 
 /**
- * define gen_nan and gen_inf for multiple types
+ * \defgroup Generate Nan and infinite for float/double/long double
+ * @ {
  */
 #define define_types_gen_nan(fname, ftype) \
-	RZ_API inline ftype types_gen_##fname##_nan() { \
+	RZ_API ftype rz_types_gen_##fname##_nan() { \
 		static ftype zero = 0; \
 		ftype ret = zero / zero; \
 		feclearexcept(FE_ALL_EXCEPT); \
@@ -32,7 +34,7 @@
 	}
 
 #define define_types_gen_inf(fname, ftype) \
-	RZ_API inline ftype types_gen_##fname##_inf() { \
+	RZ_API ftype rz_types_gen_##fname##_inf() { \
 		static ftype zero = 0; \
 		static ftype one = 1.0; \
 		ftype ret = one / zero; \
@@ -46,6 +48,7 @@ define_types_gen_nan(f128, long double);
 define_types_gen_inf(f32, float);
 define_types_gen_inf(f64, double);
 define_types_gen_inf(f128, long double);
+/**@}*/
 
 /**
  * \brief return the bitvector string of a float

--- a/librz/util/float/float.c
+++ b/librz/util/float/float.c
@@ -24,7 +24,7 @@
  * define gen_nan and gen_inf for multiple types
  */
 #define define_types_gen_nan(fname, ftype) \
-	inline ftype types_gen_##fname##_nan() { \
+	RZ_API inline ftype types_gen_##fname##_nan() { \
 		static ftype zero = 0; \
 		ftype ret = zero / zero; \
 		feclearexcept(FE_ALL_EXCEPT); \
@@ -32,7 +32,7 @@
 	}
 
 #define define_types_gen_inf(fname, ftype) \
-	inline ftype types_gen_##fname##_inf() { \
+	RZ_API inline ftype types_gen_##fname##_inf() { \
 		static ftype zero = 0; \
 		static ftype one = 1.0; \
 		ftype ret = one / zero; \

--- a/librz/util/float/float.c
+++ b/librz/util/float/float.c
@@ -21,6 +21,33 @@
 #include <math.h>
 
 /**
+ * define gen_nan and gen_inf for multiple types
+ */
+#define define_types_gen_nan(fname, ftype) \
+	inline ftype types_gen_##fname##_nan() { \
+		static ftype zero = 0; \
+		ftype ret = zero / zero; \
+		feclearexcept(FE_ALL_EXCEPT); \
+		return ret; \
+	}
+
+#define define_types_gen_inf(fname, ftype) \
+	inline ftype types_gen_##fname##_inf() { \
+		static ftype zero = 0; \
+		static ftype one = 1.0; \
+		ftype ret = one / zero; \
+		feclearexcept(FE_ALL_EXCEPT); \
+		return ret; \
+	}
+
+define_types_gen_nan(f32, float);
+define_types_gen_nan(f64, double);
+define_types_gen_nan(f128, long double);
+define_types_gen_inf(f32, float);
+define_types_gen_inf(f64, double);
+define_types_gen_inf(f128, long double);
+
+/**
  * \brief return the bitvector string of a float
  * \param f float
  * \return char* string of bitvector


### PR DESCRIPTION
Since `strtold` sometimes return weird value, use a portable solution
- NaN = 0 / 0
- Inf = 1 / 0 

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

see above

**Test plan**

waiting for CI to check portable issues

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
