### PR TITLE
Fix rizinorg/cutter#3117 null deref due unknown type

### DIFF
--- a/librz/type/format.c
+++ b/librz/type/format.c
@@ -2855,7 +2855,7 @@ static void base_type_to_format_unfold(const RzTypeDB *typedb, RZ_NONNULL RzBase
 		rz_vector_foreach(&type->struct_data.members, memb) {
 			const char *membtype = type_to_identifier(typedb, memb->type);
 			// Avoid infinite recursion in case of self-referential structures
-			if (!strcmp(membtype, type->name)) {
+			if (!membtype || !strcmp(membtype, type->name)) {
 				continue;
 			}
 			if (rz_type_is_identifier(memb->type)) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes https://github.com/rizinorg/cutter/issues/3117
Fixes https://github.com/rizinorg/cutter/issues/3085