### PR TITLE
CI: install system capstone dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
         run: brew install pkg-config
       - name: Install python and other dependencies
         if: (matrix.run_tests || matrix.build_system == 'meson') && matrix.os != 'macos-12' && matrix.enabled
-        run: sudo apt-get --assume-yes install python3-wheel python3-setuptools
+        run: sudo apt-get --assume-yes install python3-wheel python3-setuptools libcapstone4 libcapstone-dev
       - name: Install meson and ninja
         if: matrix.build_system == 'meson' && matrix.enabled
         run: pip3 install --user meson ninja PyYAML


### PR DESCRIPTION
Should fix new CI job (again), [works in my fork](https://github.com/ajakk/rizin/actions/runs/4225479841/jobs/7337816135)