### PR TITLE
Remove ip/eip/rip from lists of bound regs

### DIFF
--- a/librz/analysis/arch/x86/x86_il.c
+++ b/librz/analysis/arch/x86/x86_il.c
@@ -349,7 +349,6 @@ static const char *x86_bound_regs_16[] = {
 	"bx", /* X86_REG_BX */
 	"cx", /* X86_REG_CX */
 	"dx", /* X86_REG_DX */
-	"ip", /* X86_REG_IP */
 	"sp", /* X86_REG_SP */
 	"bp", /* X86_REG_BP */
 	"si", /* X86_REG_SI */
@@ -366,7 +365,6 @@ static const char *x86_bound_regs_32[] = {
 	"ebx", /* X86_REG_EBX */
 	"ecx", /* X86_REG_ECX */
 	"edx", /* X86_REG_EDX */
-	"eip", /* X86_REG_EIP */
 	"esp", /* X86_REG_ESP */
 	"ebp", /* X86_REG_EBP */
 	"esi", /* X86_REG_ESI */
@@ -390,7 +388,6 @@ static const char *x86_bound_regs_64[] = {
 	"rbx", /* X86_REG_RBX */
 	"rcx", /* X86_REG_RCX */
 	"rdx", /* X86_REG_RDX */
-	"rip", /* X86_REG_RIP */
 	"rsp", /* X86_REG_RSP */
 	"rbp", /* X86_REG_RBP */
 	"rsi", /* X86_REG_RSI */


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`aezs` doesn't work properly: `PC` is reseted in `rz_analysis_il_vm_sync_to_reg`

Before:
```
[0x140039e60]> ar PC
rip = 0x0000000140009080
[0x140039e60]> aezs
[0x140039e60]> ar PC
rip = 0x0000000140009080
```

After:
```
[0x140039e60]> ar PC
rip = 0x0000000140009080
[0x140039e60]> aezs
[0x140039e60]> ar PC
rip = 0x0000000140009085
```

