### PR TITLE
Move rz_mem_alloc() to rz_alloc.h

### DIFF
--- a/librz/include/rz_util/rz_alloc.h
+++ b/librz/include/rz_util/rz_alloc.h
@@ -5,7 +5,9 @@
 #include <stdlib.h>
 #include <stddef.h>
 
-RZ_API void *rz_malloc_aligned(size_t size, size_t alignment);
+RZ_API RZ_OWN void *rz_mem_alloc(size_t sz);
+RZ_API void rz_mem_free(void *);
+RZ_API RZ_OWN void *rz_malloc_aligned(size_t size, size_t alignment);
 RZ_API void rz_free_aligned(void *p);
 
 #endif

--- a/librz/include/rz_util/rz_mem.h
+++ b/librz/include/rz_util/rz_mem.h
@@ -21,8 +21,6 @@ RZ_API ut64 rz_mem_get_num(const ut8 *b, int size);
 
 /* MEMORY POOL */
 RZ_API void *rz_mem_dup(const void *s, int l);
-RZ_API void *rz_mem_alloc(int sz);
-RZ_API void rz_mem_free(void *);
 RZ_API void rz_mem_memzero(void *, size_t);
 RZ_API void rz_mem_reverse(ut8 *b, int l);
 RZ_API int rz_mem_protect(void *ptr, int size, const char *prot);

--- a/librz/util/alloc.c
+++ b/librz/util/alloc.c
@@ -4,7 +4,7 @@
 #include <rz_util.h>
 #include <rz_util/rz_alloc.h>
 
-RZ_API void *rz_malloc_aligned(size_t size, size_t alignment) {
+RZ_API RZ_OWN void *rz_malloc_aligned(size_t size, size_t alignment) {
 #if HAVE_POSIX_MEMALIGN
 	void *result = NULL;
 	if (posix_memalign(&result, alignment, size) != 0) {
@@ -33,4 +33,12 @@ RZ_API void rz_free_aligned(void *p) {
 #else
 	free(((void **)p)[-1]);
 #endif
+}
+
+RZ_API RZ_OWN void *rz_mem_alloc(size_t sz) {
+	return calloc(sz, 1);
+}
+
+RZ_API void rz_mem_free(void *p) {
+	free(p);
 }

--- a/librz/util/mem.c
+++ b/librz/util/mem.c
@@ -343,14 +343,6 @@ RZ_API bool rz_mem_is_zero(const ut8 *b, int l) {
 	return true;
 }
 
-RZ_API void *rz_mem_alloc(int sz) {
-	return calloc(sz, 1);
-}
-
-RZ_API void rz_mem_free(void *p) {
-	free(p);
-}
-
 RZ_API void rz_mem_memzero(void *dst, size_t l) {
 #ifdef _MSC_VER
 	RtlSecureZeroMemory(dst, l);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Move allocation functions to the `rz_util/rz_alloc.h`

Necessary for https://github.com/rizinorg/rz-ghidra/pull/318

**Test plan**

CI is green.