### PR TITLE
Remove inefficient rz_mem_swapendian()

### DIFF
--- a/librz/asm/arch/arm/armass.c
+++ b/librz/asm/arch/arm/armass.c
@@ -6187,12 +6187,11 @@ static int arm_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 						RZ_LOG_ERROR("assembler: arm: %s: lsb + width out of bounds\n", ops[i].name);
 						return 0;
 					}
-					ut32 tmp;
-					rz_mem_swapendian((ut8 *)(void *)&tmp, (const ut8 *)(void *)&ao->o, sizeof(tmp));
+					ut32 tmp = rz_swap_ut32(ao->o);
 					tmp |= lsb << 7;
 					tmp |= msb << 16;
 					tmp |= reg << 12;
-					rz_mem_swapendian((ut8 *)(void *)&ao->o, (const ut8 *)(void *)&tmp, sizeof(tmp));
+					ao->o = rz_swap_ut32(tmp);
 					break;
 				}
 				}

--- a/librz/asm/p/asm_sparc_gnu.c
+++ b/librz/asm/p/asm_sparc_gnu.c
@@ -46,7 +46,8 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	buf_global = &op->buf_asm;
 	Offset = a->pc;
 	// disasm inverted
-	rz_mem_swapendian(bytes, buf, 4); // TODO handle thumb
+	ut32 newbuf = rz_swap_ut32(*(ut32 *)buf);
+	memcpy(bytes, &newbuf, 4); // TODO handle thumb
 
 	rz_strbuf_set(&op->buf_asm, "");
 	/* prepare disassembler */

--- a/librz/include/rz_util/rz_mem.h
+++ b/librz/include/rz_util/rz_mem.h
@@ -32,7 +32,6 @@ RZ_API void rz_mem_copybits(ut8 *dst, const ut8 *src, int bits);
 RZ_API void rz_mem_copybits_delta(ut8 *dst, int doff, const ut8 *src, int soff, int bits);
 RZ_API void rz_mem_copyloop(ut8 *dest, const ut8 *orig, int dsize, int osize);
 RZ_API void *rz_mem_copy(void *dest, size_t dmax, const void *src, size_t smax);
-RZ_API void rz_mem_swapendian(ut8 *dest, const ut8 *orig, int size);
 RZ_API int rz_mem_cmp_mask(const ut8 *dest, const ut8 *orig, const ut8 *mask, int len);
 RZ_API const ut8 *rz_mem_mem(const ut8 *haystack, int hlen, const ut8 *needle, int nlen);
 RZ_API const ut8 *rz_mem_mem_aligned(const ut8 *haystack, int hlen, const ut8 *needle, int nlen, int align);

--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -82,7 +82,7 @@ static int format_output(RzNum *num, char mode, const char *s, int force_mode, u
 	}
 	if (has_flag(flags, RZ_AX_FLAG_SWAP_ENDIANNESS)) {
 		ut64 n2 = n;
-		rz_mem_swapendian((ut8 *)&n, (ut8 *)&n2, 8);
+		n = rz_swap_ut64(n2);
 		if (!(int)n) {
 			n >>= 32;
 		}

--- a/librz/parse/filter.c
+++ b/librz/parse/filter.c
@@ -510,15 +510,11 @@ static bool filter(RzParse *p, ut64 addr, RzFlag *f, RzAnalysisHint *hint, char 
 					swap = off & 0xffff;
 				} else {
 					if (off >> 32) {
-						rz_mem_swapendian((ut8 *)&swap, (const ut8 *)&off, sizeof(off));
+						swap = rz_swap_ut64(off);
 					} else if (off >> 16) {
-						ut32 port = 0;
-						rz_mem_swapendian((ut8 *)&port, (const ut8 *)&off, sizeof(port));
-						swap = port;
+						swap = rz_swap_ut32(off);
 					} else {
-						ut16 port = 0;
-						rz_mem_swapendian((ut8 *)&port, (const ut8 *)&off, sizeof(port));
-						swap = port;
+						swap = rz_swap_ut16(off);
 					}
 				}
 				snprintf(num, sizeof(num), "htons (%d)", (int)(swap & 0xFFFF));

--- a/librz/util/mem.c
+++ b/librz/util/mem.c
@@ -186,52 +186,7 @@ RZ_API int rz_mem_set_num(ut8 *dest, int dest_size, ut64 num) {
 	return true;
 }
 
-// This function unconditionally swaps endian of size bytes of orig -> dest
-// TODO: Remove completely
-RZ_API void rz_mem_swapendian(ut8 *dest, const ut8 *orig, int size) {
-	ut8 buffer[8];
-	switch (size) {
-	case 1:
-		*dest = *orig;
-		break;
-	case 2:
-		*buffer = *orig;
-		dest[0] = orig[1];
-		dest[1] = buffer[0];
-		break;
-	case 3:
-		*buffer = *orig;
-		dest[0] = orig[2];
-		dest[1] = orig[1];
-		dest[2] = buffer[0];
-		break;
-	case 4:
-		memcpy(buffer, orig, 4);
-		dest[0] = buffer[3];
-		dest[1] = buffer[2];
-		dest[2] = buffer[1];
-		dest[3] = buffer[0];
-		break;
-	case 8:
-		memcpy(buffer, orig, 8);
-		dest[0] = buffer[7];
-		dest[1] = buffer[6];
-		dest[2] = buffer[5];
-		dest[3] = buffer[4];
-		dest[4] = buffer[3];
-		dest[5] = buffer[2];
-		dest[6] = buffer[1];
-		dest[7] = buffer[0];
-		break;
-	default:
-		if (dest != orig) {
-			memmove(dest, orig, size);
-		}
-	}
-}
-
-// RZ_DOC rz_mem_mem: Finds the needle of nlen size into the haystack of hlen size
-// RZ_UNIT printf("%s\n", rz_mem_mem("food is pure lame", 20, "is", 2));
+/* \brief Finds the \p needle of \p nlen size into the \p haystack of \p hlen size */
 RZ_API const ut8 *rz_mem_mem(const ut8 *haystack, int hlen, const ut8 *needle, int nlen) {
 	int i, until = hlen - nlen + 1;
 	if (hlen < 1 || nlen < 1) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

We already have efficient `rz_swap_*()` functions that could be optimized by the compiler by using builtins when available

**Test plan**

CI is green