### PR TITLE
Fix C++ use for rz_* allocation functions

### DIFF
--- a/librz/include/rz_util/rz_alloc.h
+++ b/librz/include/rz_util/rz_alloc.h
@@ -5,9 +5,16 @@
 #include <stdlib.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 RZ_API RZ_OWN void *rz_mem_alloc(size_t sz);
 RZ_API void rz_mem_free(void *);
 RZ_API RZ_OWN void *rz_malloc_aligned(size_t size, size_t alignment);
 RZ_API void rz_free_aligned(void *p);
 
+#ifdef __cplusplus
+}
 #endif
+#endif //  RZ_ALLOC_H


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
Fixes for C++ users of `<rz_util/rz_alloc.h>`: Cutter, rz-ghidra

**Test plan**

CI is green