### PR TITLE
Support BE platforms in value range search

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -3697,6 +3697,7 @@ RZ_API int rz_core_search_value_in_range(RzCore *core, RzInterval search_itv, ut
 	bool vinfun = rz_config_get_b(core->config, "analysis.vinfun");
 	bool vinfunr = rz_config_get_b(core->config, "analysis.vinfunrange");
 	bool analyze_strings = rz_config_get_b(core->config, "analysis.strings");
+	bool big_endian = rz_config_get_b(core->config, "cfg.bigendian");
 	ut8 buf[4096];
 	ut64 v64, value = 0, size;
 	ut64 from = search_itv.addr, to = rz_itv_end(search_itv);
@@ -3760,21 +3761,21 @@ RZ_API int rz_core_search_value_in_range(RzCore *core, RzInterval search_itv, ut
 			}
 			switch (vsize) {
 			case 1:
-				value = *(ut8 *)v;
+				value = rz_read_ble8(v);
 				match = (buf[i] >= vmin && buf[i] <= vmax);
 				break;
 			case 2:
-				v16 = rz_read_le16(v); // TODO: support big endian
+				v16 = rz_read_ble16(v, big_endian);
 				match = (v16 >= vmin && v16 <= vmax);
 				value = v16;
 				break;
 			case 4:
-				v32 = rz_read_le32(v); // TODO: support big endian
+				v32 = rz_read_ble32(v, big_endian);
 				match = (v32 >= vmin && v32 <= vmax);
 				value = v32;
 				break;
 			case 8:
-				v64 = rz_read_le64(v); // TODO: support big endian
+				v64 = rz_read_ble64(v, big_endian);
 				match = (v64 >= vmin && v64 <= vmax);
 				value = v64;
 				break;

--- a/test/db/analysis/arm
+++ b/test/db/analysis/arm
@@ -1171,3 +1171,70 @@ EXPECT=<<EOF
 \           0x00000010      pop   {r4, pc}
 EOF
 RUN
+
+NAME=aav thumb detection
+FILE=bins/firmware/armthumb.bin
+ARGS=-aarm -b32
+CMDS=<<EOF
+aav
+fl
+EOF
+EXPECT=<<EOF
+0x0000000d 4 aav.0x0000000d
+EOF
+RUN
+
+NAME=no string on cbz
+FILE=malloc://8096
+CMDS=<<EOF
+e asm.bytes=true
+e asm.arch=arm
+e asm.bits=64
+e cfg.bigendian=false
+e emu.str=true
+wv 0x52800015
+wv 0x340000b5 @ 4
+w hello @ 0x18
+pd 2
+EOF
+EXPECT=<<EOF
+            0x00000000      15008052       movz  w21, 0
+        ,=< 0x00000004      b5000034       cbz   w21, 0x18             ; likely
+EOF
+RUN
+
+NAME=Function definition
+FILE=bins/elf/arm1.bin
+CMDS=<<EOF
+afr @ main
+s 0x000082cc
+pd 1~?*xmalloc
+EOF
+EXPECT=<<EOF
+1
+EOF
+RUN
+
+NAME=raw aac (using a PIC bin)
+FILE=bins/elf/libmagic.so
+CMDS=<<EOF
+aac
+afl~?
+EOF
+EXPECT=<<EOF
+199
+EOF
+RUN
+
+NAME=raw aac with maps (using a PIC bin)
+FILE=bins/elf/libmagic.so
+ARGS=-n -m 0x80000 -a arm -b 16 -e cfg.bigendian=false
+CMDS=<<EOF
+aac
+e search.in=io.maps
+afl~?
+EOF
+EXPECT=<<EOF
+94
+EOF
+RUN

--- a/test/db/analysis/mips
+++ b/test/db/analysis/mips
@@ -857,3 +857,52 @@ afvW
     var_ch  0x7d0
 EOF
 RUN
+
+NAME=aav without vinfun
+FILE=bins/elf/analysis/mipsbe-busybox
+CMDS=<<EOF
+af @ 0x0040eb60
+e analysis.vinfun=false
+aav
+pd 1 @ 0x0040ec8c~?jr
+EOF
+EXPECT=<<EOF
+1
+EOF
+RUN
+
+NAME=aav with vinfun
+FILE=bins/elf/analysis/mipsbe-busybox
+CMDS=<<EOF
+af @ 0x0040eb60
+e analysis.vinfun=true
+aav
+pd 1 @ 0x0040ec8c~?dword
+EOF
+EXPECT=<<EOF
+1
+EOF
+RUN
+
+NAME=aac on mips BE
+FILE=bins/elf/analysis/mipsbe-busybox
+CMDS=<<EOF
+aac
+afl~?
+EOF
+EXPECT=<<EOF
+1268
+EOF
+RUN
+
+NAME=raw aac with maps (less because of wrong map address)
+FILE=bins/elf/analysis/mipsbe-busybox
+ARGS=-n -m 0x80000 -a mips -b32 -e cfg.bigendian=true
+CMDS=<<EOF
+aac
+afl~?
+EOF
+EXPECT=<<EOF
+4
+EOF
+RUN

--- a/test/db/analysis/x86_64
+++ b/test/db/analysis/x86_64
@@ -644,92 +644,6 @@ Type Info at 0x08048fac:
 EOF
 RUN
 
-NAME=aac on mips be
-FILE=bins/elf/analysis/mipsbe-busybox
-CMDS=<<EOF
-aac
-afl~?
-EOF
-EXPECT=<<EOF
-1268
-EOF
-RUN
-
-NAME=raw aac with maps (less because of wrong map address)
-FILE=bins/elf/analysis/mipsbe-busybox
-ARGS=-n -m 0x80000 -a mips -b32 -e cfg.bigendian=true
-CMDS=<<EOF
-aac
-afl~?
-EOF
-EXPECT=<<EOF
-4
-EOF
-RUN
-
-NAME=raw aac (using a PIC bin)
-FILE=bins/elf/libmagic.so
-CMDS=<<EOF
-aac
-afl~?
-EOF
-EXPECT=<<EOF
-199
-EOF
-RUN
-
-NAME=raw aac with maps (using a PIC bin)
-FILE=bins/elf/libmagic.so
-ARGS=-n -m 0x80000 -a arm -b 16 -e cfg.bigendian=false
-CMDS=<<EOF
-aac
-e search.in=io.maps
-afl~?
-EOF
-EXPECT=<<EOF
-94
-EOF
-RUN
-
-NAME=aav without vinfun
-FILE=bins/elf/analysis/mipsbe-busybox
-CMDS=<<EOF
-af @ 0x0040ddb0
-e analysis.vinfun=false
-aav
-pd 1 @ 0x0040decc~?andi
-EOF
-EXPECT=<<EOF
-1
-EOF
-RUN
-
-NAME=aav with vinfun
-FILE=bins/elf/analysis/mipsbe-busybox
-CMDS=<<EOF
-af @ 0x0040ddb0
-e analysis.vinfun=true
-aav
-pd 1 @ 0x0040decc~?dword
-EOF
-EXPECT=<<EOF
-1
-EOF
-RUN
-
-NAME=aav thumb detection
-FILE=bins/firmware/armthumb.bin
-ARGS=-aarm -b32
-CMDS=<<EOF
-aav
-fl
-EOF
-EXPECT=<<EOF
-0x0000000d 4 aav.0x0000000d
-EOF
-RUN
-
-
 NAME=sym is not fcn
 FILE=bins/mach0/mach0-i386
 CMDS=<<EOF
@@ -1352,26 +1266,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-
-NAME=no string on cbz
-FILE=malloc://8096
-CMDS=<<EOF
-e asm.bytes=true
-e asm.arch=arm
-e asm.bits=64
-e cfg.bigendian=false
-e emu.str=true
-wv 0x52800015
-wv 0x340000b5 @ 4
-w hello @ 0x18
-pd 2
-EOF
-EXPECT=<<EOF
-            0x00000000      15008052       movz  w21, 0
-        ,=< 0x00000004      b5000034       cbz   w21, 0x18             ; likely
-EOF
-RUN
-
 NAME=Basic type Matching
 FILE=bins/elf/analysis/x86-helloworld-gcc
 CMDS=<<EOF
@@ -1481,18 +1375,6 @@ EXPECT=<<EOF
 int category
 int fd
 unsigned long request
-EOF
-RUN
-
-NAME=Function definition
-FILE=bins/elf/arm1.bin
-CMDS=<<EOF
-afr @ main
-s 0x000082cc
-pd 1~?*xmalloc
-EOF
-EXPECT=<<EOF
-1
 EOF
 RUN
 

--- a/test/db/analysis/x86_64
+++ b/test/db/analysis/x86_64
@@ -694,7 +694,7 @@ RUN
 NAME=aav without vinfun
 FILE=bins/elf/analysis/mipsbe-busybox
 CMDS=<<EOF
-af @ 0x0040dea4
+af @ 0x0040ddb0
 e analysis.vinfun=false
 aav
 pd 1 @ 0x0040decc~?andi
@@ -707,7 +707,7 @@ RUN
 NAME=aav with vinfun
 FILE=bins/elf/analysis/mipsbe-busybox
 CMDS=<<EOF
-af @ 0x0040dea4
+af @ 0x0040ddb0
 e analysis.vinfun=true
 aav
 pd 1 @ 0x0040decc~?dword

--- a/test/db/cmd/cmd_search
+++ b/test/db/cmd/cmd_search
@@ -620,15 +620,98 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=/v4 search 4 byte
+NAME=/v{2,4,8} value search LE
 FILE==
 CMDS=<<EOF
 wx 0x12345678aabbccddeeff12345678
+e cfg.bigendian=false
+/v2 0x7856
+/v2 0x5678
 /v4 0x78563412
+/v4 0x12345678
+/v8 0x78563412ddccbbaa
+/v8 0xddccbbaa78563412
+/v8 0x12345678aabbccdd
 EOF
 EXPECT=<<EOF
-0x00000000 hit0_0 12345678
-0x0000000a hit0_1 12345678
+0x00000002 hit0_0 5678
+0x0000000c hit0_1 5678
+0x00000000 hit2_0 12345678
+0x0000000a hit2_1 12345678
+0x00000000 hit5_0 12345678aabbccdd
+EOF
+RUN
+
+NAME=/v{2,4,8} value search BE
+FILE==
+CMDS=<<EOF
+wx 0x12345678aabbccddeeff12345678
+e cfg.bigendian=true
+/v2 0x7856
+/v2 0x5678
+/v4 0x78563412
+/v4 0x12345678
+/v8 0x78563412ddccbbaa
+/v8 0xddccbbaa78563412
+/v8 0x12345678aabbccdd
+EOF
+EXPECT=<<EOF
+0x00000002 hit0_0 5678
+0x0000000c hit0_1 5678
+0x00000000 hit2_0 12345678
+0x0000000a hit2_1 12345678
+0x00000000 hit5_0 12345678aabbccdd
+EOF
+RUN
+
+NAME=/V{2,4,8} value search in range LE
+FILE==
+CMDS=<<EOF
+wx 0x12345678aabbccddeeff13345678
+e cfg.bigendian=false
+/V2 0x7854 0x7858
+echo ---
+/V2 0x5677 0x7854
+/V4 0x78563412 0x78563420
+echo ---
+/V4 0x12345678 0x20345678
+/V8 0x12345678aabbccdd 0x14345678aabbccdd
+EOF
+EXPECT=<<EOF
+0x2: 0x7856
+0xc: 0x7856
+---
+0x0: 0x78563412
+0xa: 0x78563413
+---
+0x7: 0x13ffeedd
+0x3: 0x13ffeeddccbbaa78
+EOF
+RUN
+
+NAME=/V{2,4,8} value search in range BE
+FILE==
+CMDS=<<EOF
+wx 0x12345678aabbccddeeff13345678
+e cfg.bigendian=true
+/V2 0x7854 0x7858
+echo ---
+/V2 0x5677 0x7854
+/V4 0x78563412 0x78563420
+echo ---
+/V4 0x12345670 0x20345678
+/V8 0x12345678aabbccdd 0x14345678aabbccdd
+EOF
+EXPECT=<<EOF
+---
+0x2: 0x5678
+0xc: 0x5678
+0xd: 0x7800
+---
+0x0: 0x12345678
+0xa: 0x13345678
+0x0: 0x12345678aabbccdd
+0xa: 0x1334567800000000
 EOF
 RUN
 
@@ -643,18 +726,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=/v4 search 8 byte
-FILE==
-CMDS=<<EOF
-wx 0x12345678aabbccddeeff12345678
-/v4 0x78563412 0xddccbbaa
-EOF
-EXPECT=<<EOF
-0x00000000 hit0_0 12345678aabbccdd
-EOF
-RUN
-
-NAME=/V4j search 4 byte with json
+NAME=/V4j search 4 byte in range with json
 FILE==
 CMDS=<<EOF
 wx 0x12345678aabbccddeeff12345678


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Now search value in range should support both BE and LE platforms (depending on `cfg.bigendian` variable value)

**Test plan**

CI is green