### PR TITLE
Fix Debian Jessie builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,7 +365,12 @@ jobs:
           echo "deb http://archive.debian.org/debian wheezy main" > /etc/apt/sources.list
           echo "deb http://archive.debian.org/debian-security wheezy/updates main" >> /etc/apt/sources.list
           echo "Acquire::Check-Valid-Until no;" > /etc/apt/apt.conf.d/99no-check-valid-until
-
+      - name: Fix containers (Jessie)
+        if: matrix.container == 'debian:jessie'
+        run: |
+          echo "deb http://archive.debian.org/debian jessie main" > /etc/apt/sources.list
+          echo "deb http://archive.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list
+          echo "Acquire::Check-Valid-Until no;" > /etc/apt/apt.conf.d/99no-check-valid-until
       - name: Install tools
         run: apt-get update --yes --force-yes && apt-get install --yes --force-yes patch unzip git gcc make curl pkg-config libc6-i386 build-essential
       - name: Install Python source build dependencies


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
Fixes the following error:
```
Run apt-get update --yes --force-yes && apt-get install --yes --force-yes patch unzip git gcc make curl pkg-config libc6-i386 build-essential
Ign http://security.debian.org/ jessie/updates InRelease
Ign http://security.debian.org/ jessie/updates Release.gpg
Ign http://security.debian.org/ jessie/updates Release
Ign http://deb.debian.org/ jessie InRelease
Err http://security.debian.org/ jessie/updates/main amd64 Packages
  
Ign http://deb.debian.org/ jessie-updates InRelease
Err http://security.debian.org/ jessie/updates/main amd64 Packages
  
Ign http://deb.debian.org/ jessie Release.gpg
Err http://security.debian.org/ jessie/updates/main amd64 Packages
  
Ign http://deb.debian.org/ jessie-updates Release.gpg
Err http://security.debian.org/ jessie/updates/main amd64 Packages
  
Ign http://deb.debian.org/ jessie Release
Err http://security.debian.org/ jessie/updates/main amd64 Packages
  404  Not Found [IP: 151.101.130.132 80]
Ign http://deb.debian.org/ jessie-updates Release
Err http://deb.debian.org/ jessie/main amd64 Packages
  404  Not Found
Err http://deb.debian.org/ jessie-updates/main amd64 Packages
  404  Not Found
W: Failed to fetch http://security.debian.org/debian-security/dists/jessie/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.130.132 80]

W: Failed to fetch http://deb.debian.org/debian/dists/jessie/main/binary-amd64/Packages  404  Not Found

W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/main/binary-amd64/Packages  404  Not Found

E: Some index files failed to download. They have been ignored, or old ones used instead.
```


**Test plan**

CI is green

**Closing issues**

Necessary for https://github.com/rizinorg/rizin/pull/3435