### PR TITLE
The pCd missing instructions is fixed.

### DIFF
--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -5553,7 +5553,7 @@ RZ_IPI RzCmdStatus rz_print_columns_disassembly_handler(RzCore *core, int argc, 
 	for (i = 0; i < columns; i++) {
 		(void)rz_cons_canvas_gotoxy(c, i * (w / columns), 0);
 		// TODO: Use the API directly
-		char *cmd = rz_str_newf("pdq %d @i:%d", rows, rows * i);
+		char *cmd = rz_str_newf("pdq %d @i:%d", rows, i ? rows * i -1 : rows * i);
 		char *dis = rz_core_cmd_str(core, cmd);
 		rz_cons_canvas_write(c, dis);
 		free(cmd);

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -5553,7 +5553,7 @@ RZ_IPI RzCmdStatus rz_print_columns_disassembly_handler(RzCore *core, int argc, 
 	for (i = 0; i < columns; i++) {
 		(void)rz_cons_canvas_gotoxy(c, i * (w / columns), 0);
 		// TODO: Use the API directly
-		char *cmd = rz_str_newf("pdq %d @i:%d", rows, rows * i);
+		char *cmd = rz_str_newf("pdq %d @i:%d", rows, i ? rows * i - 1 : rows * i);
 		char *dis = rz_core_cmd_str(core, cmd);
 		rz_cons_canvas_write(c, dis);
 		free(cmd);

--- a/test/db/cmd/cmd_p_capital_c
+++ b/test/db/cmd/cmd_p_capital_c
@@ -46,9 +46,9 @@ wx 55aa55aa909055aa9090ff20000ff34534ff55f45eaac0c0c0cdf534
 pCd 3
 EOF
 EXPECT=<<EOF
-0x00000000 bge 0x156a95c                0x0000000c ldrbmi r0, [r3, 0xf00]!
-0x00000004 bge 0x156424c                0x00000010 pli [r5, -0xf34]
-0x00000008 smlalshs sb, pc, r0, r0      0x00000014 sbcgt sl, r0, lr, asr sl
+0x00000000 bge 0x156a95c                0x00000008 smlalshs sb, pc, r0, r0
+0x00000004 bge 0x156424c                0x0000000c ldrbmi r0, [r3, 0xf00]!
+0x00000008 smlalshs sb, pc, r0, r0      0x00000010 pli [r5, -0xf34]
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

For details see the issue https://github.com/rizinorg/rizin/issues/3318

The pCd command is missing some instructions when the user inputs specific rows to be shown. However, the instructions are actually present, as discussed in this issue https://github.com/rizinorg/rizin/pull/3213#issuecomment-1399918455. Upon further analysis, it was discovered that the instruction at the initial point caused the first column to have ten rows but miss one instruction row. To address this issue, I changed the canvas size so that it can fit the missing instruction. This did not work as can see other pull request [here](https://github.com/rizinorg/rizin/pull/3431).

Thus tried another solution by changing the receiving instructions and display of them. That is covered in this pull request.

**Test plan**

None

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
#3318 

