### PR TITLE
SuperH should be less verbose.

### DIFF
--- a/librz/analysis/arch/sh/sh_il.c
+++ b/librz/analysis/arch/sh/sh_il.c
@@ -1651,7 +1651,7 @@ static RzILOpEffect *sh_il_sts(const SHOp *op, ut64 pc, RzAnalysis *analysis, SH
  * To be used for valid SuperH-4 instruction which yet haven't been lifted to the IL
  */
 static RzILOpEffect *sh_il_unimpl(const SHOp *op, ut64 pc, RzAnalysis *analysis, SHILContext *ctx) {
-	RZ_LOG_WARN("SuperH: Instruction with opcode 0x%04x is unimplemented\n", op->opcode);
+	RZ_LOG_DEBUG("SuperH: Instruction with opcode 0x%04x is unimplemented\n", op->opcode);
 	return EMPTY();
 }
 

--- a/librz/analysis/p/analysis_sh.c
+++ b/librz/analysis/p/analysis_sh.c
@@ -1104,8 +1104,9 @@ static int sh_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *d
 	SHOp *ilop = sh_disassembler(opcode);
 	SHILContext *ctx = RZ_NEW0(SHILContext);
 	ctx->use_banked = true;
-
-	rz_sh_il_opcode(analysis, op, addr, ilop, ctx);
+	if (ilop) {
+		rz_sh_il_opcode(analysis, op, addr, ilop, ctx);
+	}
 	RZ_FREE(ctx);
 	RZ_FREE(ilop);
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Seems that the superh code is very verbose, this fixes the output.