### PR TITLE
Move `%a` to `ascii`, `%F` to `flush`

### DIFF
--- a/librz/core/cmd/cmd_math.c
+++ b/librz/core/cmd/cmd_math.c
@@ -189,11 +189,6 @@ RZ_IPI RzCmdStatus rz_generate_random_number_handler(RzCore *core, int argc, con
 	return RZ_CMD_STATUS_OK;
 }
 
-RZ_IPI RzCmdStatus rz_print_ascii_table_handler(RzCore *core, int argc, const char **argv) {
-	rz_cons_printf("%s", ret_ascii_table());
-	return RZ_CMD_STATUS_OK;
-}
-
 RZ_IPI RzCmdStatus rz_print_binary_handler(RzCore *core, int argc, const char **argv) {
 	char out[128] = RZ_EMPTY;
 	ut64 n = rz_num_math(core->num, argv[1]);
@@ -263,11 +258,6 @@ RZ_IPI RzCmdStatus rz_print_djb2_hash_handler(RzCore *core, int argc, const char
 		ut32 hash = (ut32)rz_str_djb2_hash(argv[i]);
 		rz_cons_printf("0x%08x\n", hash);
 	}
-	return RZ_CMD_STATUS_OK;
-}
-
-RZ_IPI RzCmdStatus rz_flush_console_handler(RzCore *core, int argc, const char **argv) {
-	rz_cons_flush();
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/core/cmd/cmd_shell.c
+++ b/librz/core/cmd/cmd_shell.c
@@ -70,6 +70,12 @@ static ut32 vernum(const char *s) {
 	return res;
 }
 
+// ascii
+RZ_IPI RzCmdStatus rz_cmd_shell_ascii_table_handler(RzCore *core, int argc, const char **argv) {
+	rz_cons_printf("%s", ret_ascii_table());
+	return RZ_CMD_STATUS_OK;
+}
+
 // env
 RZ_IPI RzCmdStatus rz_cmd_shell_env_handler(RzCore *core, int argc, const char **argv) {
 	char *p, **e;
@@ -284,6 +290,12 @@ RZ_IPI RzCmdStatus rz_cmd_shell_sort_handler(RzCore *core, int argc, const char 
 // cls
 RZ_IPI RzCmdStatus rz_cmd_shell_clear_handler(RzCore *core, int argc, const char **argv) {
 	rz_cons_clear00();
+	return RZ_CMD_STATUS_OK;
+}
+
+// flush
+RZ_IPI RzCmdStatus rz_cmd_shell_flush_handler(RzCore *core, int argc, const char **argv) {
+	rz_cons_flush();
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -1503,14 +1503,6 @@ static const RzCmdDescHelp generate_random_number_help = {
 	.args = generate_random_number_args,
 };
 
-static const RzCmdDescArg print_ascii_table_args[] = {
-	{ 0 },
-};
-static const RzCmdDescHelp print_ascii_table_help = {
-	.summary = "Print ASCII table",
-	.args = print_ascii_table_args,
-};
-
 static const RzCmdDescHelp perc_b_help = {
 	.summary = "Base64 encode/decode and print binary commands",
 };
@@ -1665,14 +1657,6 @@ static const RzCmdDescHelp print_djb2_hash_help = {
 	.summary = "Print hash value of given input",
 	.details = print_djb2_hash_details,
 	.args = print_djb2_hash_args,
-};
-
-static const RzCmdDescArg flush_console_args[] = {
-	{ 0 },
-};
-static const RzCmdDescHelp flush_console_help = {
-	.summary = "Flush console",
-	.args = flush_console_args,
 };
 
 static const RzCmdDescDetailEntry print_bitstring_Examples_detail_entries[] = {
@@ -17840,6 +17824,14 @@ static const RzCmdDescHelp shell_help = {
 	.summary = "Common shell commands",
 	.sort_subcommands = true,
 };
+static const RzCmdDescArg cmd_shell_ascii_table_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_shell_ascii_table_help = {
+	.summary = "Print ASCII table",
+	.args = cmd_shell_ascii_table_args,
+};
+
 static const RzCmdDescArg cmd_shell_date_args[] = {
 	{ 0 },
 };
@@ -18148,6 +18140,14 @@ static const RzCmdDescHelp cmd_shell_cls_help = {
 	.args = cmd_shell_cls_args,
 };
 
+static const RzCmdDescArg cmd_shell_flush_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_shell_flush_help = {
+	.summary = "Flush console",
+	.args = cmd_shell_flush_args,
+};
+
 static const RzCmdDescArg cmd_shell_which_args[] = {
 	{
 		.name = "command",
@@ -18388,9 +18388,6 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *generate_random_number_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_math_cd, "%r", rz_generate_random_number_handler, &generate_random_number_help);
 	rz_warn_if_fail(generate_random_number_cd);
 
-	RzCmdDesc *print_ascii_table_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_math_cd, "%a", rz_print_ascii_table_handler, &print_ascii_table_help);
-	rz_warn_if_fail(print_ascii_table_cd);
-
 	RzCmdDesc *perc_b_cd = rz_cmd_desc_group_new(core->rcmd, cmd_math_cd, "%b", rz_print_binary_handler, &print_binary_help, &perc_b_help);
 	rz_warn_if_fail(perc_b_cd);
 	RzCmdDesc *base64_encode_cd = rz_cmd_desc_argv_new(core->rcmd, perc_b_cd, "%b64", rz_base64_encode_handler, &base64_encode_help);
@@ -18407,9 +18404,6 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *print_djb2_hash_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_math_cd, "%h", rz_print_djb2_hash_handler, &print_djb2_hash_help);
 	rz_warn_if_fail(print_djb2_hash_cd);
-
-	RzCmdDesc *flush_console_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_math_cd, "%F", rz_flush_console_handler, &flush_console_help);
-	rz_warn_if_fail(flush_console_cd);
 
 	RzCmdDesc *print_bitstring_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_math_cd, "%f", rz_print_bitstring_handler, &print_bitstring_help);
 	rz_warn_if_fail(print_bitstring_cd);
@@ -21806,6 +21800,9 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *shell_cd = rz_cmd_desc_group_new(core->rcmd, root_cd, "shell", NULL, NULL, &shell_help);
 	rz_warn_if_fail(shell_cd);
+	RzCmdDesc *cmd_shell_ascii_table_cd = rz_cmd_desc_argv_new(core->rcmd, shell_cd, "ascii", rz_cmd_shell_ascii_table_handler, &cmd_shell_ascii_table_help);
+	rz_warn_if_fail(cmd_shell_ascii_table_cd);
+
 	RzCmdDesc *cmd_shell_date_cd = rz_cmd_desc_argv_new(core->rcmd, shell_cd, "date", rz_cmd_shell_date_handler, &cmd_shell_date_help);
 	rz_warn_if_fail(cmd_shell_date_cd);
 
@@ -21865,6 +21862,9 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *cmd_shell_cls_cd = rz_cmd_desc_argv_new(core->rcmd, shell_cd, "cls", rz_cmd_shell_clear_handler, &cmd_shell_cls_help);
 	rz_warn_if_fail(cmd_shell_cls_cd);
+
+	RzCmdDesc *cmd_shell_flush_cd = rz_cmd_desc_argv_new(core->rcmd, shell_cd, "flush", rz_cmd_shell_flush_handler, &cmd_shell_flush_help);
+	rz_warn_if_fail(cmd_shell_flush_cd);
 
 	RzCmdDesc *cmd_shell_which_cd = rz_cmd_desc_argv_new(core->rcmd, shell_cd, "which", rz_cmd_shell_which_handler, &cmd_shell_which_help);
 	rz_warn_if_fail(cmd_shell_which_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -97,8 +97,6 @@ RZ_IPI RzCmdStatus rz_set_active_tab_zero_handler(RzCore *core, int argc, const 
 RZ_IPI RzCmdStatus rz_set_active_tab_next_handler(RzCore *core, int argc, const char **argv);
 // "%r"
 RZ_IPI RzCmdStatus rz_generate_random_number_handler(RzCore *core, int argc, const char **argv);
-// "%a"
-RZ_IPI RzCmdStatus rz_print_ascii_table_handler(RzCore *core, int argc, const char **argv);
 // "%b"
 RZ_IPI RzCmdStatus rz_print_binary_handler(RzCore *core, int argc, const char **argv);
 // "%b64"
@@ -111,8 +109,6 @@ RZ_IPI RzCmdStatus rz_check_between_handler(RzCore *core, int argc, const char *
 RZ_IPI RzCmdStatus rz_print_boundaries_prot_handler(RzCore *core, int argc, const char **argv);
 // "%h"
 RZ_IPI RzCmdStatus rz_print_djb2_hash_handler(RzCore *core, int argc, const char **argv);
-// "%F"
-RZ_IPI RzCmdStatus rz_flush_console_handler(RzCore *core, int argc, const char **argv);
 // "%f"
 RZ_IPI RzCmdStatus rz_print_bitstring_handler(RzCore *core, int argc, const char **argv);
 // "%o"
@@ -2399,6 +2395,8 @@ RZ_IPI RzCmdStatus rz_yank_hex_print_handler(RzCore *core, int argc, const char 
 RZ_IPI RzCmdStatus rz_yank_paste_handler(RzCore *core, int argc, const char **argv);
 // "yz"
 RZ_IPI RzCmdStatus rz_yank_string_handler(RzCore *core, int argc, const char **argv);
+// "ascii"
+RZ_IPI RzCmdStatus rz_cmd_shell_ascii_table_handler(RzCore *core, int argc, const char **argv);
 // "date"
 RZ_IPI RzCmdStatus rz_cmd_shell_date_handler(RzCore *core, int argc, const char **argv);
 // "diff"
@@ -2437,6 +2435,8 @@ RZ_IPI RzCmdStatus rz_cmd_shell_pwd_handler(RzCore *core, int argc, const char *
 RZ_IPI RzCmdStatus rz_cmd_shell_sort_handler(RzCore *core, int argc, const char **argv);
 // "clear"
 RZ_IPI RzCmdStatus rz_cmd_shell_clear_handler(RzCore *core, int argc, const char **argv);
+// "flush"
+RZ_IPI RzCmdStatus rz_cmd_shell_flush_handler(RzCore *core, int argc, const char **argv);
 // "which"
 RZ_IPI RzCmdStatus rz_cmd_shell_which_handler(RzCore *core, int argc, const char **argv);
 // "fortune"

--- a/librz/core/cmd_descs/cmd_math.yaml
+++ b/librz/core/cmd_descs/cmd_math.yaml
@@ -29,10 +29,6 @@ commands:
         type: RZ_CMD_ARG_TYPE_RZNUM
       - name: uplimit
         type: RZ_CMD_ARG_TYPE_RZNUM
-  - name: "%a"
-    summary: Print ASCII table
-    cname: print_ascii_table
-    args: []
   - name: "%b"
     summary: Base64 encode/decode and print binary commands
     type: RZ_CMD_DESC_TYPE_GROUP
@@ -123,10 +119,6 @@ commands:
           - text: "%h"
             arg_str: ILoveRizin
             comment: 0x56b7215a -> hashed value
-  - name: "%F"
-    summary: Flush console
-    cname: flush_console
-    args: []
   - name: "%f"
     summary: bitstring manipulation.
     description: >-

--- a/librz/core/cmd_descs/cmd_shell.yaml
+++ b/librz/core/cmd_descs/cmd_shell.yaml
@@ -4,6 +4,10 @@
 name: cmd_shell
 type: RZ_CMD_DESC_TYPE_GROUP
 commands:
+  - name: ascii
+    summary: Print ASCII table
+    cname: cmd_shell_ascii_table
+    args: []
   - name: date
     summary: Get current date
     cname: cmd_shell_date
@@ -179,6 +183,10 @@ commands:
     summary: clear
     cname: cmd_shell_cls
     handler: cmd_shell_clear
+    args: []
+  - name: flush
+    summary: Flush console
+    cname: cmd_shell_flush
     args: []
   - name: which
     cname: cmd_shell_which


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

After `?` conversion to `%` some commands do not really belong to the "math" category. Moved two of them:
- `%a` to `ascii` (into the "shell" category) to print the ASCII table
- `%F` to `flush` (into the "shell" category) to flush the console, since we already have `clear` and `cls` in the "shell" category

**Test plan**

- CI is green
- Try `%a` and `ascii`
- Try `%F` and `flush`

cc @brightprogrammer 