### PR TITLE
Add Undo/Redo to dietline emacs mode

### DIFF
--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -24,6 +24,265 @@ typedef enum {
 	MAJOR_BREAK
 } BreakMode;
 
+/**
+ * an entry of undo. it represents either a text insertion, deletion, or both.
+ * \see undo_add_entry
+ */
+typedef struct rz_line_undo_entry_t {
+	int offset; ///< the beginning index of buffer edit.
+	char *deleted_text; ///< text to be deleted. null-terminated
+	int deleted_len; ///< the length of deleted text
+	char *inserted_text; ///< text to be inserted. null-terminated.
+	int inserted_len; ///< the length of inserted text.
+	bool continuous_next; ///< if true, redo function will continuously process the next entry.
+	bool continuous_prev; ///< if true, undo function will continuously process the previous entry.
+} RzLineUndoEntry;
+
+static inline bool is_undo_entry_valid(const RzLineUndoEntry *e) {
+	if (!e) {
+		return false;
+	}
+	if (e->offset < 0) {
+		return false;
+	}
+	if (!e->deleted_len && !e->inserted_len) {
+		return false;
+	}
+	return true;
+}
+
+static void undo_entry_free(RzLineUndoEntry *e, void *user) {
+	(void)user;
+	RZ_FREE(e->deleted_text);
+	RZ_FREE(e->inserted_text);
+}
+
+static bool undo_reset(void) {
+	if (I.enable_vi_mode || I.hud) {
+		// Undo functionality does not yet support vi_mode.
+		return true;
+	}
+	if (I.undo_vec) {
+		rz_vector_free(I.undo_vec);
+	}
+	I.undo_cursor = 0;
+	I.undo_continue = false;
+	I.undo_vec = rz_vector_new(sizeof(RzLineUndoEntry), (RzVectorFree)undo_entry_free, NULL);
+	return !!I.undo_vec;
+}
+
+/* If possible, concatenate input characters according to the behavior of bash. (Others such as zsh don't do that) */
+static bool undo_concat_entry(const char *diff, const int diff_len) {
+	if (!I.undo_vec->len) {
+		return false;
+	}
+	// undo_vector has one or more entries.
+	if (I.undo_cursor != I.undo_vec->len) {
+		return false;
+	}
+	// cursor is at tail
+	RzLineUndoEntry *e = rz_vector_tail(I.undo_vec);
+	if (!is_undo_entry_valid(e)) {
+		// entry broken
+		undo_reset();
+		return false;
+	}
+	if (e->deleted_len || !e->inserted_len) {
+		// concat only works for inserted text, not deleted or replaced.
+		return false;
+	}
+	if (e->offset + e->inserted_len != I.buffer.index) {
+		return false;
+	}
+	if (e->inserted_len + diff_len > 20) {
+		return false;
+	}
+	e->inserted_text = rz_str_append(e->inserted_text, diff);
+	e->inserted_len += diff_len;
+	if (!e->inserted_text) {
+		// realloc broken
+		undo_reset();
+		return false;
+	}
+	return true;
+}
+
+/**
+ * \brief Add an entry to undo vector.
+ * \param offset The beginning index of buffer edit
+ * \param deleted_text Text to be deleted. need to be allocated beforehand. Either deleted_text or inserted_text should be non-empty.
+ * \param inserted_text Text to be inserted. need to be allocated beforehand. Either deleted_text or inserted_text should be non-empty.
+ * \return true if success and false if failed. when failed, arg texts are freed.
+ * **/
+static bool undo_add_entry(int offset, RZ_OWN char *deleted_text, RZ_OWN char *inserted_text) {
+	if (I.enable_vi_mode || I.hud) {
+		// Undo functionality does not yet support vi_mode.
+		RZ_FREE(deleted_text);
+		RZ_FREE(inserted_text);
+		return false;
+	}
+	if (!I.undo_vec || I.undo_vec->len > RZ_LINE_UNDOSIZE) {
+		undo_reset();
+	}
+	RzLineUndoEntry new_entry = {
+		offset,
+		deleted_text,
+		deleted_text ? rz_str_nlen(deleted_text, RZ_LINE_BUFSIZE) : 0,
+		inserted_text,
+		inserted_text ? rz_str_nlen(inserted_text, RZ_LINE_BUFSIZE) : 0,
+		I.undo_continue,
+		false
+	};
+	if (!is_undo_entry_valid(&new_entry)) {
+		// new entry invalid
+		RZ_FREE(deleted_text);
+		RZ_FREE(inserted_text);
+		return false;
+	}
+	if (I.undo_vec->len) {
+		RzLineUndoEntry *prev_entry = rz_vector_tail(I.undo_vec);
+		if (I.undo_continue) {
+			new_entry.continuous_prev = prev_entry->continuous_next;
+		}
+	}
+	if (I.undo_cursor < I.undo_vec->len) {
+		// remove all entries after undo_cursor
+		for (int i = I.undo_cursor; i < I.undo_vec->len; ++i) {
+			// free entries to avoid memory leak
+			RzLineUndoEntry *e = rz_vector_index_ptr(I.undo_vec, i);
+			undo_entry_free(e, NULL);
+		}
+		rz_vector_remove_range(I.undo_vec, I.undo_cursor, I.undo_vec->len - I.undo_cursor, NULL);
+	}
+	rz_vector_push(I.undo_vec, &new_entry);
+	I.undo_cursor++;
+	return true;
+}
+
+/* To group several entries into one undo action, call undo_continuous_entries_begin/end before and after the sequence of operations. */
+static void undo_continuous_entries_begin() {
+	I.undo_continue = true;
+}
+static void undo_continuous_entries_end() {
+	I.undo_continue = false;
+	if (!I.undo_vec->len) {
+		return;
+	}
+	RzLineUndoEntry *e = rz_vector_tail(I.undo_vec);
+	// terminate
+	e->continuous_next = false;
+}
+
+static bool undo_nothing_to_do(bool is_redo) {
+	if (is_redo && I.undo_cursor == I.undo_vec->len) {
+		return true;
+	} else if (!is_redo && I.undo_cursor == 0) {
+		return true;
+	}
+	return false;
+}
+
+static void line_do(const bool is_redo) {
+	RzLineUndoEntry *e = NULL;
+	bool is_continuous;
+	if (!I.undo_vec) {
+		undo_reset();
+		return;
+	}
+	do {
+		char *deleting_text = NULL;
+		int deleting_len = 0;
+		char *inserting_text = NULL;
+		int inserting_len = 0;
+		int start, end;
+
+		if (undo_nothing_to_do(is_redo)) {
+			break;
+		}
+
+		// obtain entry and set is_continuous
+		if (!is_redo) {
+			// undo
+			e = rz_vector_index_ptr(I.undo_vec, I.undo_cursor - 1);
+			I.undo_cursor--;
+			is_continuous = e->continuous_prev;
+		} else {
+			// redo
+			e = rz_vector_index_ptr(I.undo_vec, I.undo_cursor);
+			I.undo_cursor++;
+			is_continuous = e->continuous_next;
+		}
+
+		if (!is_undo_entry_valid(e)) {
+			// undo_vec broken
+			undo_reset();
+			break;
+		}
+
+		// prepare text and length
+		if (!is_redo) {
+			// When undoing, we delete inserted text, and insert deleted text.
+			if (e->deleted_text) {
+				inserting_text = e->deleted_text;
+				inserting_len = e->deleted_len;
+			}
+			if (e->inserted_text) {
+				deleting_text = e->inserted_text;
+				deleting_len = e->inserted_len;
+			}
+		} else {
+			// When redoing, we insert inserted text, and delete deleted text.
+			if (e->deleted_text) {
+				deleting_text = e->deleted_text;
+				deleting_len = e->deleted_len;
+			}
+			if (e->inserted_text) {
+				inserting_text = e->inserted_text;
+				inserting_len = e->inserted_len;
+			}
+		}
+
+		// action
+		if (deleting_text) {
+			// delete text
+			start = e->offset;
+			end = e->offset + deleting_len;
+			if (start < 0 || end > I.buffer.length) {
+				undo_reset();
+				break;
+			}
+			memmove(I.buffer.data + start, I.buffer.data + end, I.buffer.length - end);
+			I.buffer.length -= deleting_len;
+			I.buffer.data[I.buffer.length] = '\0';
+			I.buffer.index = start;
+		}
+		if (inserting_text) {
+			// insert text
+			start = e->offset;
+			end = e->offset + inserting_len;
+			if (start < 0 || start > I.buffer.length) {
+				undo_reset();
+				break;
+			}
+			memmove(I.buffer.data + end, I.buffer.data + start, I.buffer.length - start);
+			memcpy(I.buffer.data + start, inserting_text, inserting_len);
+			I.buffer.length += inserting_len;
+			I.buffer.data[I.buffer.length] = '\0';
+			I.buffer.index = end;
+		}
+
+	} while (is_continuous);
+	return;
+}
+
+static void line_undo() {
+	line_do(false);
+}
+
+static void line_redo() {
+	line_do(true);
+}
+
 static inline bool is_word_break_char(char ch, bool mode) {
 	int i;
 	if (mode == MAJOR_BREAK) {
@@ -63,6 +322,7 @@ static void backward_kill_word(BreakMode mode) {
 	rz_line_clipboard_push(I.clipboard);
 	memmove(I.buffer.data + i, I.buffer.data + I.buffer.index,
 		I.buffer.length - I.buffer.index + 1);
+	undo_add_entry(i, rz_str_ndup(I.clipboard, len), NULL);
 	I.buffer.length = strlen(I.buffer.data);
 	I.buffer.index = i;
 }
@@ -80,6 +340,7 @@ static void kill_word(BreakMode mode) {
 	I.clipboard = rz_str_ndup(I.buffer.data + I.buffer.index, len);
 	rz_line_clipboard_push(I.clipboard);
 	memmove(I.buffer.data + I.buffer.index, I.buffer.data + i, I.buffer.length - i + 1);
+	undo_add_entry(i, rz_str_ndup(I.clipboard, len), NULL);
 	I.buffer.length -= len;
 }
 
@@ -91,6 +352,7 @@ static void paste(bool *enable_yank_pop) {
 		I.buffer.length += len;
 		memmove(cursor + len, cursor, dist);
 		memcpy(cursor, I.clipboard, len);
+		undo_add_entry(I.buffer.index, NULL, rz_str_ndup(I.clipboard, len));
 		I.buffer.index += len;
 		*enable_yank_pop = true;
 	}
@@ -115,10 +377,10 @@ static void unix_word_rubout(void) {
 		if (I.buffer.index > I.buffer.length) {
 			I.buffer.length = I.buffer.index;
 		}
-		len = I.buffer.index - i + 1;
-		free(I.clipboard);
+		len = I.buffer.index - i;
 		I.clipboard = rz_str_ndup(I.buffer.data + i, len);
 		rz_line_clipboard_push(I.clipboard);
+		undo_add_entry(i, rz_str_ndup(I.clipboard, len), NULL);
 		memmove(I.buffer.data + i,
 			I.buffer.data + I.buffer.index,
 			I.buffer.length - I.buffer.index + 1);
@@ -141,9 +403,12 @@ static int inithist(void) {
 }
 
 /* initialize history stuff */
-RZ_API int rz_line_dietline_init(void) {
+RZ_API bool rz_line_dietline_init(void) {
 	ZERO_FILL(I.completion);
 	if (!inithist()) {
+		return false;
+	}
+	if (!undo_reset()) {
 		return false;
 	}
 	I.echo = true;
@@ -561,10 +826,12 @@ static void selection_widget_select(void) {
 			I.buffer.index = I.buffer.length;
 			return;
 		}
+		char *del_text = strdup(I.buffer.data);
 		I.buffer.length = RZ_MIN(strlen(sel_widget->options[sel_widget->selection]), RZ_LINE_BUFSIZE - 1);
 		memcpy(I.buffer.data, sel_widget->options[sel_widget->selection], I.buffer.length);
 		I.buffer.data[I.buffer.length] = '\0';
 		I.buffer.index = I.buffer.length;
+		undo_add_entry(0, del_text, strdup(I.buffer.data));
 		selection_widget_erase();
 	}
 }
@@ -616,6 +883,16 @@ static void replace_buffer_text(RzLineBuffer *buf, size_t start, size_t end, con
 	}
 
 	size_t diff = end - start;
+	if (diff || s_len) {
+		char *del_text = rz_str_ndup(buf->data + start, diff);
+		char *ins_text = rz_str_ndup(s, s_len);
+		if (diff != s_len || rz_str_cmp(del_text, ins_text, diff)) {
+			undo_add_entry(start, del_text, ins_text);
+		} else {
+			RZ_FREE(del_text);
+			RZ_FREE(ins_text);
+		}
+	}
 	// FIXME: escape s
 	memmove(buf->data + start + s_len, buf->data + end, buf->length - end);
 	memmove(buf->data + start, s, s_len);
@@ -675,6 +952,7 @@ static void print_options(int argc, const char **argv) {
 
 RZ_API void rz_line_autocomplete(void) {
 	char *p;
+	char *del_text = NULL;
 	const char **argv = NULL;
 	int argc = 0, i, j, plen;
 	bool opt = false;
@@ -682,6 +960,7 @@ RZ_API void rz_line_autocomplete(void) {
 
 	if (I.ns_completion.run) {
 		RzLineNSCompletionResult *res = I.ns_completion.run(&I.buffer, I.prompt_type, I.ns_completion.run_user);
+		undo_continuous_entries_begin();
 		if (!res || rz_pvector_empty(&res->options)) {
 			// do nothing
 		} else if (rz_pvector_len(&res->options) == 1) {
@@ -691,6 +970,7 @@ RZ_API void rz_line_autocomplete(void) {
 			if (is_at_end && res->end_string) {
 				replace_buffer_text(&I.buffer, I.buffer.length, I.buffer.length, res->end_string);
 			}
+
 		} else {
 			// otherwise find maxcommonprefix, print it, and then print options
 			char *max_common_pfx = get_max_common_pfx(&res->options);
@@ -700,7 +980,7 @@ RZ_API void rz_line_autocomplete(void) {
 			rz_cons_printf("%s%s\n", I.prompt, I.buffer.data);
 			print_options(rz_pvector_len(&res->options), (const char **)rz_pvector_data(&res->options));
 		}
-
+		undo_continuous_entries_end();
 		rz_line_ns_completion_result_free(res);
 		return;
 	}
@@ -732,6 +1012,9 @@ RZ_API void rz_line_autocomplete(void) {
 	} else {
 		p = I.buffer.data; // XXX: removes current buffer
 		plen = sizeof(I.buffer.data);
+	}
+	if (plen) {
+		del_text = rz_str_ndup(I.buffer.data, I.buffer.length);
 	}
 	/* autocomplete */
 	if (argc == 1) {
@@ -796,6 +1079,12 @@ RZ_API void rz_line_autocomplete(void) {
 		}
 	}
 
+	if (rz_str_cmp(del_text, I.buffer.data, I.buffer.length)) {
+		undo_add_entry(0, del_text, rz_str_ndup(I.buffer.data, I.buffer.length));
+	} else {
+		RZ_FREE(del_text);
+	}
+
 	if (I.prompt_type != RZ_LINE_PROMPT_DEFAULT || cons->show_autocomplete_widget) {
 		selection_widget_update();
 		if (I.sel_widget) {
@@ -820,6 +1109,8 @@ static inline void rotate_kill_ring(bool *enable_yank_pop) {
 		return;
 	}
 	I.buffer.index -= strlen(rz_list_get_n(I.kill_ring, I.kill_ring_ptr));
+	undo_continuous_entries_begin();
+	undo_add_entry(I.buffer.index, rz_str_ndup(I.buffer.data + I.buffer.index, I.buffer.length - I.buffer.index), NULL);
 	I.buffer.data[I.buffer.index] = 0;
 	I.kill_ring_ptr -= 1;
 	if (I.kill_ring_ptr < 0) {
@@ -827,10 +1118,12 @@ static inline void rotate_kill_ring(bool *enable_yank_pop) {
 	}
 	I.clipboard = rz_list_get_n(I.kill_ring, I.kill_ring_ptr);
 	paste(enable_yank_pop);
+	undo_continuous_entries_end();
 }
 
 static inline void __delete_next_char(void) {
 	if (I.buffer.index < I.buffer.length) {
+		undo_add_entry(I.buffer.index, rz_str_ndup(I.buffer.data + I.buffer.index, 1), NULL);
 		int len = rz_str_utf8_charsize(I.buffer.data + I.buffer.index);
 		memmove(I.buffer.data + I.buffer.index,
 			I.buffer.data + I.buffer.index + len,
@@ -840,6 +1133,9 @@ static inline void __delete_next_char(void) {
 }
 
 static inline void __delete_prev_char(void) {
+	if (I.buffer.index > 0) {
+		undo_add_entry(I.buffer.index - 1, rz_str_ndup(I.buffer.data + I.buffer.index - 1, 1), NULL);
+	}
 	if (I.buffer.index < I.buffer.length) {
 		if (I.buffer.index > 0) {
 			size_t len = rz_str_utf8_charsize_prev(I.buffer.data + I.buffer.index, I.buffer.index);
@@ -863,6 +1159,9 @@ static inline void __delete_prev_char(void) {
 }
 
 static inline void delete_till_end(void) {
+	if (I.buffer.index < I.buffer.length) {
+		undo_add_entry(I.buffer.index, strdup(I.buffer.data + I.buffer.index), NULL);
+	}
 	I.buffer.data[I.buffer.index] = '\0';
 	I.buffer.length = I.buffer.index;
 	I.buffer.index = I.buffer.index > 0 ? I.buffer.index - 1 : 0;
@@ -1302,6 +1601,7 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 			rz_cons_clear_line(0);
 		}
 		switch (*buf) {
+
 		case 0: // control-space
 			/* ignore atm */
 			break;
@@ -1333,6 +1633,7 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 						I.buffer.index = I.buffer.length;
 						strncpy(I.buffer.data, tmp_ed_cmd, RZ_LINE_BUFSIZE - 1);
 						I.buffer.data[RZ_LINE_BUFSIZE - 1] = '\0';
+						undo_add_entry(0, NULL, strdup(tmp_ed_cmd));
 					} else {
 						I.buffer.length -= strlen(tmp_ed_cmd);
 					}
@@ -1369,6 +1670,9 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 			}
 			break;
 		case 11: // ^K
+			if (I.buffer.index != I.buffer.length) {
+				undo_add_entry(I.buffer.index, strdup(I.buffer.data + I.buffer.index), NULL);
+			}
 			I.buffer.data[I.buffer.index] = '\0';
 			I.buffer.length = I.buffer.index;
 			break;
@@ -1403,6 +1707,9 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 			free(I.clipboard);
 			I.clipboard = strdup(I.buffer.data);
 			rz_line_clipboard_push(I.clipboard);
+			if (I.buffer.length) {
+				undo_add_entry(0, strdup(I.clipboard), NULL);
+			}
 			I.buffer.data[0] = '\0';
 			I.buffer.length = 0;
 			I.buffer.index = 0;
@@ -1425,6 +1732,7 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 						int len = strlen(txt);
 						I.buffer.length += len;
 						if (I.buffer.length < RZ_LINE_BUFSIZE) {
+							undo_add_entry(I.buffer.index, NULL, strdup(txt));
 							I.buffer.index = I.buffer.length;
 							strcat(I.buffer.data, txt);
 						} else {
@@ -1443,6 +1751,7 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 			break;
 		case 24: // ^X
 			if (I.buffer.index > 0) {
+				undo_add_entry(0, rz_str_ndup(I.buffer.data, I.buffer.index), NULL);
 				strncpy(I.buffer.data, I.buffer.data + I.buffer.index, I.buffer.length);
 				I.buffer.length -= I.buffer.index;
 				I.buffer.index = 0;
@@ -1475,6 +1784,7 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 					gcomp_idx--;
 				}
 			} else {
+				undo_reset();
 				I.history.do_setup_match = o_do_setup_match;
 				rz_line_hist_down();
 			}
@@ -1490,8 +1800,14 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 			} else if (gcomp) {
 				gcomp_idx++;
 			} else {
+				undo_reset();
 				I.history.do_setup_match = o_do_setup_match;
 				rz_line_hist_up();
+			}
+			break;
+		case 31: // ^_ ctrl-/ or ctrl-_
+			if (!gcomp && !I.hud && !I.sel_widget) {
+				line_undo();
 			}
 			break;
 		case 27: // esc-5b-41-00-00 alt/meta key
@@ -1544,6 +1860,12 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 				}
 				if (i >= I.buffer.length) {
 					I.buffer.index = I.buffer.length;
+				}
+				break;
+			case 63: // ^[? Meta-/
+			case 95: // ^[_ Meta-_
+				if (!gcomp && !I.hud && !I.sel_widget) {
+					line_redo();
 				}
 				break;
 			default:
@@ -1618,6 +1940,7 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 						} else if (gcomp) {
 							gcomp_idx++;
 						} else {
+							undo_reset();
 							I.history.do_setup_match = o_do_setup_match;
 							if (rz_line_hist_up() == -1) {
 								rz_cons_break_pop();
@@ -1638,6 +1961,7 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 								gcomp_idx--;
 							}
 						} else {
+							undo_reset();
 							I.history.do_setup_match = o_do_setup_match;
 							if (rz_line_hist_down() == -1) {
 								rz_cons_break_pop();
@@ -1788,11 +2112,15 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 						I.buffer.data[i] = I.buffer.data[i - utflen];
 					}
 					memcpy(I.buffer.data + I.buffer.index, buf, utflen);
+					undo_add_entry(I.buffer.index, NULL, rz_str_ndup(buf, utflen));
 				}
 			} else {
 				if ((I.buffer.length + utflen) < sizeof(I.buffer.data)) {
 					memcpy(I.buffer.data + I.buffer.length, buf, utflen);
 					I.buffer.length += utflen;
+					if (!undo_concat_entry(buf, utflen)) {
+						undo_add_entry(I.buffer.index, NULL, rz_str_ndup(buf, utflen));
+					}
 				}
 				I.buffer.data[I.buffer.length] = '\0';
 			}
@@ -1842,6 +2170,7 @@ RZ_API const char *rz_line_readline_cb(RzLineReadCallback cb, void *user) {
 		}
 	}
 _end:
+	undo_reset();
 	rz_cons_break_pop();
 	rz_cons_set_raw(0);
 	rz_cons_enable_mouse(mouse_status);

--- a/librz/cons/line.c
+++ b/librz/cons/line.c
@@ -12,6 +12,13 @@ static void rz_line_nscompletion_init(RzLineNSCompletion *c) {
 	c->run_user = NULL;
 }
 
+static void undo_free(void) {
+	rz_vector_free(I.undo_vec);
+	I.undo_vec = NULL;
+	I.undo_cursor = 0;
+	I.undo_continue = false;
+}
+
 RZ_API RzLine *rz_line_singleton(void) {
 	return &rz_line_instance;
 }
@@ -44,6 +51,7 @@ RZ_API void rz_line_free(void) {
 	I.prompt = NULL;
 	rz_list_free(I.kill_ring);
 	rz_line_hist_free();
+	undo_free();
 	rz_line_completion_fini(&I.completion);
 }
 

--- a/librz/include/rz_cons.h
+++ b/librz/include/rz_cons.h
@@ -1042,6 +1042,7 @@ RZ_API RZ_OWN RzStrBuf *rz_rangebar(RZ_NONNULL RzBarOptions *opts, ut64 startA, 
 /* rz_line */
 #define RZ_LINE_BUFSIZE  4096
 #define RZ_LINE_HISTSIZE 256
+#define RZ_LINE_UNDOSIZE 512
 
 #define RZ_EDGES_X_INC 4
 
@@ -1142,6 +1143,7 @@ struct rz_line_t {
 	RzLineNSCompletion ns_completion;
 	RzLineBuffer buffer;
 	RzLineHistory history;
+	RzVector /*<RzLineUndoEntry>*/ *undo_vec;
 	RzSelWidget *sel_widget;
 	/* callbacks */
 	RzLineHistoryUpCb cb_history_up;
@@ -1155,6 +1157,8 @@ struct rz_line_t {
 	char *prompt;
 	RzList /*<char *>*/ *kill_ring;
 	int kill_ring_ptr;
+	int undo_cursor;
+	bool undo_continue;
 	char *clipboard;
 	int disable;
 	void *user;
@@ -1181,7 +1185,7 @@ RZ_API RzLine *rz_line_singleton(void);
 RZ_API void rz_line_free(void);
 RZ_API RZ_OWN char *rz_line_get_prompt(void);
 RZ_API void rz_line_set_prompt(const char *prompt);
-RZ_API int rz_line_dietline_init(void);
+RZ_API bool rz_line_dietline_init(void);
 RZ_API void rz_line_clipboard_push(const char *str);
 RZ_API void rz_line_hist_free(void);
 RZ_API void rz_line_autocomplete(void);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Bash and Emacs have the functionality of Undo and Redo. I added code corresponding to those ones into dietline which is used in RzShell. They can be triggered by Ctrl-/ Ctrl-_ for Undo, and Meta-/ Meta-_ for Redo. For that RzLine struct has had a new vector "undo_vec" and an index "undo_cursor". When executing an Undo or Redo action, the cursor moves back and forth while vecotor entries restore the command buffer condition.
As far as I tested manually it works but I am going to add unit tests. Also, I am willing to add Doxygen comments to new functions if necessary.

bonus: I fixed a bug at unix_word_rubout since it cliped too much strings and hindered correct addition of undo_entry.

**Test plan**

To do: add unit tests.

**Closing issues**

closes #572 
