### PR TITLE
Improve cmd_help.yaml and fix random number generator

### DIFF
--- a/librz/cons/cons.c
+++ b/librz/cons/cons.c
@@ -183,13 +183,13 @@ static inline void __cons_write(const char *obuf, int olen) {
 RZ_API RzColor rz_cons_color_random(ut8 alpha) {
 	RzColor rcolor = { 0 };
 	if (CTX(color_mode) > COLOR_MODE_16) {
-		rcolor.r = rz_num_rand(0xff);
-		rcolor.g = rz_num_rand(0xff);
-		rcolor.b = rz_num_rand(0xff);
+		rcolor.r = rz_num_rand32(0xff);
+		rcolor.g = rz_num_rand32(0xff);
+		rcolor.b = rz_num_rand32(0xff);
 		rcolor.a = alpha;
 		return rcolor;
 	}
-	int r = rz_num_rand(16);
+	int r = rz_num_rand32(16);
 	switch (r) {
 	case 0:
 	case 1: rcolor = (RzColor)RzColor_RED; break;

--- a/librz/core/cio.c
+++ b/librz/core/cio.c
@@ -776,7 +776,7 @@ RZ_API bool rz_core_write_random_at(RzCore *core, ut64 addr, size_t len) {
 
 	rz_num_irand();
 	for (int i = 0; i < len; i++) {
-		buf[i] = rz_num_rand(256);
+		buf[i] = rz_num_rand32(256);
 	}
 
 	if (!rz_core_write_at(core, addr, buf, len)) {

--- a/librz/core/cmd/cmd_math.c
+++ b/librz/core/cmd/cmd_math.c
@@ -176,7 +176,7 @@ RZ_IPI RzCmdStatus rz_generate_random_number_handler(RzCore *core, int argc, con
 		return RZ_CMD_STATUS_ERROR;
 	}
 
-	core->num->value = (ut64)(low + rz_num_rand(high - low));
+	core->num->value = (ut64)(low + rz_num_rand64(high - low));
 	rz_cons_printf("0x%" PFMT64x "\n", core->num->value);
 
 	return RZ_CMD_STATUS_OK;

--- a/librz/core/cmd/cmd_math.c
+++ b/librz/core/cmd/cmd_math.c
@@ -165,14 +165,18 @@ RZ_IPI RzCmdStatus rz_set_active_tab_next_handler(RzCore *core, int argc, const 
 }
 
 RZ_IPI RzCmdStatus rz_generate_random_number_handler(RzCore *core, int argc, const char **argv) {
-	// TODO: Add support for 64 bit random numbers
 	const char *lowlimit = argv[1];
-	ut32 low = (ut32)rz_num_math(core->num, lowlimit);
+	ut64 low = (ut32)rz_num_math(core->num, lowlimit);
 
 	const char *uplimit = argv[2];
-	ut32 high = (ut32)rz_num_math(core->num, uplimit);
+	ut64 high = (ut32)rz_num_math(core->num, uplimit);
 
-	core->num->value = (ut64)(low + rz_num_rand(high));
+	if (low >= high) {
+		RZ_LOG_ERROR("core : Invalid arguments passed to %s : low-limit shouldn't be more then high-limit", argv[0]);
+		return RZ_CMD_STATUS_ERROR;
+	}
+
+	core->num->value = (ut64)(low + rz_num_rand(high - low));
 	rz_cons_printf("0x%" PFMT64x "\n", core->num->value);
 
 	return RZ_CMD_STATUS_OK;

--- a/librz/core/cmd/cmd_math.c
+++ b/librz/core/cmd/cmd_math.c
@@ -165,25 +165,14 @@ RZ_IPI RzCmdStatus rz_set_active_tab_next_handler(RzCore *core, int argc, const 
 }
 
 RZ_IPI RzCmdStatus rz_generate_random_number_handler(RzCore *core, int argc, const char **argv) {
-	// TODO : Add support for 64bit random numbers
-	ut64 b = 0;
-	ut32 r = argc < 2 ? 0 : UT32_MAX;
+	// TODO: Add support for 64 bit random numbers
+	const char *lowlimit = argv[1];
+	ut32 low = (ut32)rz_num_math(core->num, lowlimit);
 
-	if (argc == 2) {
-		const char *out = argv[1];
-		if (argc == 3) {
-			const char *p = argv[2];
-			b = (ut32)rz_num_math(core->num, out);
-			r = (ut32)rz_num_math(core->num, p) - b;
-		} else {
-			r = (ut32)rz_num_math(core->num, out);
-		}
-	}
+	const char *uplimit = argv[2];
+	ut32 high = (ut32)rz_num_math(core->num, uplimit);
 
-	if (!r) {
-		r = UT32_MAX >> 1;
-	}
-	core->num->value = (ut64)(b + rz_num_rand(r));
+	core->num->value = (ut64)(low + rz_num_rand(high));
 	rz_cons_printf("0x%" PFMT64x "\n", core->num->value);
 
 	return RZ_CMD_STATUS_OK;

--- a/librz/core/cmd/cmd_shell.c
+++ b/librz/core/cmd/cmd_shell.c
@@ -554,13 +554,13 @@ RZ_API RZ_OWN char *rz_core_clippy(RZ_NONNULL RzCore *core, RZ_NONNULL const cha
 		f = avatar_orangg[0];
 	} else if (type == RZ_AVATAR_CYBCAT) {
 		l = strdup(rz_str_pad('-', msglen));
-		f = avatar_cybcat[rz_num_rand(RZ_ARRAY_SIZE(avatar_cybcat))];
+		f = avatar_cybcat[rz_num_rand32(RZ_ARRAY_SIZE(avatar_cybcat))];
 	} else if (rz_config_get_i(core->config, "scr.utf8")) {
 		l = (char *)rz_str_repeat("─", msglen);
-		f = avatar_clippy_utf8[rz_num_rand(RZ_ARRAY_SIZE(avatar_clippy_utf8))];
+		f = avatar_clippy_utf8[rz_num_rand32(RZ_ARRAY_SIZE(avatar_clippy_utf8))];
 	} else {
 		l = strdup(rz_str_pad('-', msglen));
-		f = avatar_clippy[rz_num_rand(RZ_ARRAY_SIZE(avatar_clippy))];
+		f = avatar_clippy[rz_num_rand32(RZ_ARRAY_SIZE(avatar_clippy))];
 	}
 
 	char *string = rz_str_newf(f, l, s, msg, s, l);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -109,11 +109,11 @@ static const RzCmdDescArg cmd_help_search_args[2];
 static const RzCmdDescArg calculate_expr_args[2];
 static const RzCmdDescArg generate_random_number_args[3];
 static const RzCmdDescArg print_binary_args[2];
-static const RzCmdDescArg base64_encode_args[3];
-static const RzCmdDescArg base64_decode_args[3];
+static const RzCmdDescArg base64_encode_args[2];
+static const RzCmdDescArg base64_decode_args[2];
 static const RzCmdDescArg check_between_args[4];
 static const RzCmdDescArg print_boundaries_prot_args[2];
-static const RzCmdDescArg print_djb2_hash_args[3];
+static const RzCmdDescArg print_djb2_hash_args[2];
 static const RzCmdDescArg print_bitstring_args[3];
 static const RzCmdDescArg eval_expr_print_octal_args[2];
 static const RzCmdDescArg num_to_units_args[2];
@@ -1528,16 +1528,9 @@ static const RzCmdDescDetail base64_encode_details[] = {
 };
 static const RzCmdDescArg base64_encode_args[] = {
 	{
-		.name = "str",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.no_space = true,
-
-	},
-	{
 		.name = "strs",
 		.type = RZ_CMD_ARG_TYPE_STRING,
 		.flags = RZ_CMD_ARG_FLAG_ARRAY,
-		.optional = true,
 
 	},
 	{ 0 },
@@ -1549,7 +1542,7 @@ static const RzCmdDescHelp base64_encode_help = {
 };
 
 static const RzCmdDescDetailEntry base64_decode_Examples_detail_entries[] = {
-	{ .text = "%b64-", .arg_str = "SUxvdmVSaXppbgo=", .comment = "(ILoveRizin) Decodes given base64 string" },
+	{ .text = "%b64- ", .arg_str = "SUxvdmVSaXppbgo=", .comment = "(ILoveRizin) Decodes given base64 string" },
 	{ 0 },
 };
 static const RzCmdDescDetail base64_decode_details[] = {
@@ -1558,16 +1551,9 @@ static const RzCmdDescDetail base64_decode_details[] = {
 };
 static const RzCmdDescArg base64_decode_args[] = {
 	{
-		.name = "b64str",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.no_space = true,
-
-	},
-	{
 		.name = "b64strs",
 		.type = RZ_CMD_ARG_TYPE_STRING,
 		.flags = RZ_CMD_ARG_FLAG_ARRAY,
-		.optional = true,
 
 	},
 	{ 0 },
@@ -1628,7 +1614,7 @@ static const RzCmdDescHelp print_boundaries_prot_help = {
 };
 
 static const RzCmdDescDetailEntry print_djb2_hash_Examples_detail_entries[] = {
-	{ .text = "%h", .arg_str = "ILoveRizin", .comment = "0x56b7215a -> hashed value" },
+	{ .text = "%h ", .arg_str = "ILoveRizin", .comment = "0x56b7215a -> hashed value" },
 	{ 0 },
 };
 static const RzCmdDescDetail print_djb2_hash_details[] = {
@@ -1637,16 +1623,9 @@ static const RzCmdDescDetail print_djb2_hash_details[] = {
 };
 static const RzCmdDescArg print_djb2_hash_args[] = {
 	{
-		.name = "str",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.no_space = true,
-
-	},
-	{
 		.name = "strs",
 		.type = RZ_CMD_ARG_TYPE_STRING,
 		.flags = RZ_CMD_ARG_FLAG_ARRAY,
-		.optional = true,
 
 	},
 	{ 0 },
@@ -1688,7 +1667,7 @@ static const RzCmdDescHelp print_bitstring_help = {
 };
 
 static const RzCmdDescDetailEntry eval_expr_print_octal_Examples_detail_entries[] = {
-	{ .text = "%o", .arg_str = "123", .comment = "0173 in octal" },
+	{ .text = "%o", .arg_str = " 123", .comment = "0173 in octal" },
 	{ .text = "%o", .arg_str = " 321", .comment = "0501 in octal" },
 	{ 0 },
 };
@@ -1899,9 +1878,9 @@ static const RzCmdDescHelp compare_and_set_core_num_value_help = {
 };
 
 static const RzCmdDescDetailEntry exec_cmd_if_core_num_value_positive_Examples_detail_entries[] = {
-	{ .text = "%=1; %+", .arg_str = "%%x", .comment = "Will display hexdump at current seek address" },
-	{ .text = "%=-2; %+", .arg_str = "%%x", .comment = "Won\"t do anything" },
-	{ .text = "%=0; %+", .arg_str = "%%x", .comment = "Won\"t do anything" },
+	{ .text = "%=1; %+", .arg_str = " %%x", .comment = "Will display hexdump at current seek address" },
+	{ .text = "%=-2; %+", .arg_str = " %%x", .comment = "Won\"t do anything" },
+	{ .text = "%=0; %+", .arg_str = " %%x", .comment = "Won\"t do anything" },
 	{ 0 },
 };
 static const RzCmdDescDetail exec_cmd_if_core_num_value_positive_details[] = {
@@ -1924,9 +1903,9 @@ static const RzCmdDescHelp exec_cmd_if_core_num_value_positive_help = {
 };
 
 static const RzCmdDescDetailEntry exec_cmd_if_core_num_value_negative_Examples_detail_entries[] = {
-	{ .text = "%=1; %-", .arg_str = "%%x", .comment = "Won\"t do anything" },
-	{ .text = "%=-2; %-", .arg_str = "%%x", .comment = "Will display hexdump at current seek address" },
-	{ .text = "%=0; %+", .arg_str = "%%x", .comment = "Won\"t do anything" },
+	{ .text = "%=1; %-", .arg_str = " %%x", .comment = "Won\"t do anything" },
+	{ .text = "%=-2; %-", .arg_str = " %%x", .comment = "Will display hexdump at current seek address" },
+	{ .text = "%=0; %+", .arg_str = " %%x", .comment = "Won\"t do anything" },
 	{ 0 },
 };
 static const RzCmdDescDetail exec_cmd_if_core_num_value_negative_details[] = {

--- a/librz/core/cmd_descs/cmd_math.yaml
+++ b/librz/core/cmd_descs/cmd_math.yaml
@@ -43,13 +43,9 @@ commands:
         summary: Base64 encode
         cname: base64_encode
         args:
-          - name: str
-            type: RZ_CMD_ARG_TYPE_STRING
-            no_space: true
           - name: strs
             type: RZ_CMD_ARG_TYPE_STRING
             flags: RZ_CMD_ARG_FLAG_ARRAY
-            optional: true
         details:
           - name: Examples
             entries:
@@ -60,17 +56,13 @@ commands:
         summary: Base64 decode. Maximum input length = 4*(strlen(str)).
         cname: base64_decode
         args:
-          - name: b64str
-            type: RZ_CMD_ARG_TYPE_STRING
-            no_space: true
           - name: b64strs
             type: RZ_CMD_ARG_TYPE_STRING
             flags: RZ_CMD_ARG_FLAG_ARRAY
-            optional: true
         details:
           - name: Examples
             entries:
-              - text: "%b64-"
+              - text: "%b64- "
                 arg_str: SUxvdmVSaXppbgo=
                 comment: (ILoveRizin) Decodes given base64 string
   - name: "%btw"
@@ -106,17 +98,13 @@ commands:
     summary: Print hash value of given input
     cname: print_djb2_hash
     args:
-      - name: str
-        type: RZ_CMD_ARG_TYPE_STRING
-        no_space: true
       - name: strs
         type: RZ_CMD_ARG_TYPE_STRING
         flags: RZ_CMD_ARG_FLAG_ARRAY
-        optional: true
     details:
       - name: Examples
         entries:
-          - text: "%h"
+          - text: "%h "
             arg_str: ILoveRizin
             comment: 0x56b7215a -> hashed value
   - name: "%f"
@@ -151,7 +139,7 @@ commands:
       - name: Examples
         entries:
           - text: "%o"
-            arg_str: "123"
+            arg_str: " 123"
             comment: 0173 in octal
           - text: "%o"
             arg_str: " 321"
@@ -259,13 +247,13 @@ commands:
       - name: Examples
         entries:
           - text: "%=1; %+"
-            arg_str: "%%x"
+            arg_str: " %%x"
             comment: Will display hexdump at current seek address
           - text: "%=-2; %+"
-            arg_str: "%%x"
+            arg_str: " %%x"
             comment: Won"t do anything
           - text: "%=0; %+"
-            arg_str: "%%x"
+            arg_str: " %%x"
             comment: Won"t do anything
   - name: "%-"
     summary: Execute given command if $? register is less than 0
@@ -277,13 +265,13 @@ commands:
       - name: Examples
         entries:
           - text: "%=1; %-"
-            arg_str: "%%x"
+            arg_str: " %%x"
             comment: Won"t do anything
           - text: "%=-2; %-"
-            arg_str: "%%x"
+            arg_str: " %%x"
             comment: Will display hexdump at current seek address
           - text: "%=0; %+"
-            arg_str: "%%x"
+            arg_str: " %%x"
             comment: Won"t do anything
   - name: "%!"
     summary: Execute command if result of last numeric expression evaluation (related) command was 0

--- a/librz/core/rtr_http.c
+++ b/librz/core/rtr_http.c
@@ -71,7 +71,7 @@ static int rz_core_rtr_http_run(RzCore *core, int launch, int browse, const char
 
 	if (!strcmp(port, "0")) {
 		rz_num_irand();
-		iport = 1024 + rz_num_rand(45256);
+		iport = 1024 + rz_num_rand32(45256);
 		snprintf(buf, sizeof(buf), "%d", iport);
 		port = buf;
 	}

--- a/librz/core/tui/colors.c
+++ b/librz/core/tui/colors.c
@@ -128,9 +128,9 @@ RZ_IPI void rz_core_visual_colors(RzCore *core) {
 			rz_cons_pal_random();
 			break;
 		case '.':
-			rcolor.r = rz_num_rand(0xff);
-			rcolor.g = rz_num_rand(0xff);
-			rcolor.b = rz_num_rand(0xff);
+			rcolor.r = rz_num_rand32(0xff);
+			rcolor.g = rz_num_rand32(0xff);
+			rcolor.b = rz_num_rand32(0xff);
 			break;
 		case 'c':
 			rz_line_set_prompt("Preview command> ");

--- a/librz/include/rz_util/rz_num.h
+++ b/librz/include/rz_util/rz_num.h
@@ -89,7 +89,7 @@ RZ_API ut64 rz_num_math(RzNum *num, const char *str);
 RZ_API ut64 rz_num_get(RZ_NULLABLE RzNum *num, RZ_NULLABLE const char *str);
 RZ_API int rz_num_to_bits(char *out, ut64 num);
 RZ_API int rz_num_to_trits(char *out, ut64 num); // Rename this please
-RZ_API int rz_num_rand(int max);
+RZ_API ut64 rz_num_rand(ut64 max);
 RZ_API void rz_num_irand(void);
 RZ_API ut64 rz_get_input_num_value(RzNum *num, const char *input_value);
 RZ_API bool rz_is_valid_input_num_value(RzNum *num, const char *input_value);

--- a/librz/include/rz_util/rz_num.h
+++ b/librz/include/rz_util/rz_num.h
@@ -89,7 +89,8 @@ RZ_API ut64 rz_num_math(RzNum *num, const char *str);
 RZ_API ut64 rz_num_get(RZ_NULLABLE RzNum *num, RZ_NULLABLE const char *str);
 RZ_API int rz_num_to_bits(char *out, ut64 num);
 RZ_API int rz_num_to_trits(char *out, ut64 num); // Rename this please
-RZ_API ut64 rz_num_rand(ut64 max);
+RZ_API ut32 rz_num_rand32(ut32 max);
+RZ_API ut64 rz_num_rand64(ut64 max);
 RZ_API void rz_num_irand(void);
 RZ_API ut64 rz_get_input_num_value(RzNum *num, const char *input_value);
 RZ_API bool rz_is_valid_input_num_value(RzNum *num, const char *input_value);

--- a/librz/io/p/io_zip.c
+++ b/librz/io/p/io_zip.c
@@ -240,7 +240,7 @@ RzIOZipFileObj *rz_io_zip_create_new_file(const char *archivename, const char *f
 		zfo->archivename = strdup(archivename);
 		zfo->name = strdup(sb ? sb->name : filename);
 		zfo->entry = !sb ? -1 : sb->index;
-		zfo->fd = rz_num_rand(0xFFFF); // XXX: Use rz_io_fd api
+		zfo->fd = rz_num_rand32(0xFFFF); // XXX: Use rz_io_fd api
 		zfo->perm = perm;
 		zfo->mode = mode;
 		zfo->rw = rw;

--- a/librz/socket/socket.c
+++ b/librz/socket/socket.c
@@ -251,7 +251,7 @@ RZ_API RzSocket *rz_socket_new(bool is_ssl) {
 
 RZ_API bool rz_socket_spawn(RzSocket *s, const char *cmd, unsigned int timeout) {
 	// XXX TODO: dont use sockets, we can achieve the same with pipes
-	const int port = 2000 + rz_num_rand(2000);
+	const int port = 2000 + rz_num_rand32(2000);
 	int childPid = rz_sys_fork();
 	if (childPid == 0) {
 		char *a = rz_str_replace(strdup(cmd), "\\", "\\\\", true);

--- a/librz/util/file.c
+++ b/librz/util/file.c
@@ -639,7 +639,7 @@ RZ_API char *rz_file_slurp_random_line_count(const char *file, int *line) {
 			if (str[i] == '\n') {
 				// here rand doesn't have any security implication
 				//  https://www.securecoding.cert.org/confluence/display/c/MSC30-C.+Do+not+use+the+rand()+function+for+generating+pseudorandom+numbers
-				if (!(rz_num_rand((++(*line))))) {
+				if (!(rz_num_rand32((++(*line))))) {
 					selection = (*line - 1); /* The line we want. */
 				}
 			}

--- a/librz/util/unum.c
+++ b/librz/util/unum.c
@@ -31,25 +31,31 @@ static void rz_num_srand(int seed) {
 #endif
 }
 
-static ut64 rz_rand(ut64 mod) {
-	ut64 r;
+static ut32 rz_rand32(ut32 mod) {
 #if HAVE_ARC4RANDOM_UNIFORM
-	r = (ut64)arc4random_uniform(mod);
-	r *= (ut64)arc4random_uniform(mod);
+	return (ut32)arc4random_uniform(mod);
 #else
-	r = (ut64)rand();
-	r *= (ut64)rand();
-	r %= mod;
+	r = (ut32)rand() % mod;
 #endif
+}
 
-	return r;
+static ut64 rz_rand64(ut64 mod) {
+#if HAVE_ARC4RANDOM_UNIFORM
+	return (ut64)arc4random_uniform(mod) << 32 | (ut64)arc4random_uniform(mod);
+#else
+	return ((ut64)rand() << 32 | (ut64)rand()) % mod;
+#endif
 }
 
 RZ_API void rz_num_irand(void) {
 	rz_num_srand(rz_time_now());
 }
 
-RZ_API ut64 rz_num_rand(ut64 max) {
+// NOTE: The random generator will be seeded twice
+// but I don't think that'll be a problem since it'll
+// be seeded twice at max
+
+RZ_API ut32 rz_num_rand32(ut32 max) {
 	static bool rand_initialized = false;
 	if (!rand_initialized) {
 		rz_num_irand();
@@ -58,7 +64,19 @@ RZ_API ut64 rz_num_rand(ut64 max) {
 	if (!max) {
 		max = 1;
 	}
-	return rz_rand(max);
+	return rz_rand32(max);
+}
+
+RZ_API ut64 rz_num_rand64(ut64 max) {
+	static bool rand_initialized = false;
+	if (!rand_initialized) {
+		rz_num_irand();
+		rand_initialized = true;
+	}
+	if (!max) {
+		max = 1;
+	}
+	return rz_rand64(max);
 }
 
 RZ_API void rz_num_minmax_swap(ut64 *a, ut64 *b) {

--- a/librz/util/unum.c
+++ b/librz/util/unum.c
@@ -500,9 +500,6 @@ static ut64 rz_num_op(RzNum *num, char op, ut64 a, ut64 b) {
 	return b;
 }
 
-/**
- *
- **/
 RZ_API static ut64 rz_num_math_internal(RzNum *num, char *s) {
 	ut64 ret = 0LL;
 	char *p = s;

--- a/librz/util/unum.c
+++ b/librz/util/unum.c
@@ -35,7 +35,7 @@ static ut32 rz_rand32(ut32 mod) {
 #if HAVE_ARC4RANDOM_UNIFORM
 	return (ut32)arc4random_uniform(mod);
 #else
-	r = (ut32)rand() % mod;
+	return (ut32)rand() % mod;
 #endif
 }
 
@@ -47,6 +47,9 @@ static ut64 rz_rand64(ut64 mod) {
 #endif
 }
 
+/**
+ * \brief Seed the random number generator.
+ **/
 RZ_API void rz_num_irand(void) {
 	rz_num_srand(rz_time_now());
 }
@@ -55,6 +58,12 @@ RZ_API void rz_num_irand(void) {
 // but I don't think that'll be a problem since it'll
 // be seeded twice at max
 
+/**
+ * \brief Generate 32 bit random numbers.
+ *
+ * \param max Maximum value of generated random numbers.
+ * \return Random value between 0 to max.
+ **/
 RZ_API ut32 rz_num_rand32(ut32 max) {
 	static bool rand_initialized = false;
 	if (!rand_initialized) {
@@ -67,6 +76,12 @@ RZ_API ut32 rz_num_rand32(ut32 max) {
 	return rz_rand32(max);
 }
 
+/**
+ * \brief Generate 64 bit random numbers.
+ *
+ * \param max Maximum value of generated random numbers.
+ * \return Random value between 0 to max.
+ **/
 RZ_API ut64 rz_num_rand64(ut64 max) {
 	static bool rand_initialized = false;
 	if (!rand_initialized) {
@@ -79,6 +94,13 @@ RZ_API ut64 rz_num_rand64(ut64 max) {
 	return rz_rand64(max);
 }
 
+/**
+ * \brief Swap a and b if a is greater than b.
+ * 64-bit version.
+ *
+ * \param a Pointer to first value.
+ * \param b Pointer to second value.
+ **/
 RZ_API void rz_num_minmax_swap(ut64 *a, ut64 *b) {
 	if (*a > *b) {
 		ut64 tmp = *a;
@@ -87,6 +109,13 @@ RZ_API void rz_num_minmax_swap(ut64 *a, ut64 *b) {
 	}
 }
 
+/**
+ * \brief Swap a and b if a is greater than b.
+ * 32bit integer version.
+ *
+ * \param a Pointer to first value.
+ * \param b Pointer to second value.
+ **/
 RZ_API void rz_num_minmax_swap_i(int *a, int *b) {
 	if (*a > *b) {
 		ut64 tmp = *a;
@@ -95,6 +124,14 @@ RZ_API void rz_num_minmax_swap_i(int *a, int *b) {
 	}
 }
 
+/**
+ * \brief Create a new RzNum for handling numerical expressions.
+ *
+ * \param cb Callback.
+ * \param cb2 Second callback.
+ * \param ptr User defined data.
+ * \return Created RzNum pointer on success, NULL otherwise.
+ **/
 RZ_API RzNum *rz_num_new(RzNumCallback cb, RzNumCallback2 cb2, void *ptr) {
 	RzNum *num = RZ_NEW0(RzNum);
 	if (!num) {
@@ -107,6 +144,11 @@ RZ_API RzNum *rz_num_new(RzNumCallback cb, RzNumCallback2 cb2, void *ptr) {
 	return num;
 }
 
+/**
+ * \brief Destroy the RzNum object.
+ *
+ * \param RzNum to be destroy.
+ **/
 RZ_API void rz_num_free(RzNum *num) {
 	free(num);
 }
@@ -458,6 +500,9 @@ static ut64 rz_num_op(RzNum *num, char op, ut64 a, ut64 b) {
 	return b;
 }
 
+/**
+ *
+ **/
 RZ_API static ut64 rz_num_math_internal(RzNum *num, char *s) {
 	ut64 ret = 0LL;
 	char *p = s;
@@ -476,6 +521,13 @@ RZ_API static ut64 rz_num_math_internal(RzNum *num, char *s) {
 }
 #endif /* !RZ_NUM_USE_CALC */
 
+/**
+ * \brief Compute an numerical expression.
+ *
+ * \param num RzNum instance.
+ * \param str Numerical expression.
+ * \return Evaluated expression's value.
+ **/
 RZ_API ut64 rz_num_math(RzNum *num, const char *str) {
 #if RZ_NUM_USE_CALC
 	ut64 ret;
@@ -552,6 +604,13 @@ RZ_API ut64 rz_num_math(RzNum *num, const char *str) {
 #endif
 }
 
+/**
+ * \brief Check if given string represents a float value or not.
+ *
+ * \param num RzNum instance.
+ * \param str Numerical value.
+ * \return Non zero value if float, 0 otherwise.
+ **/
 RZ_API int rz_num_is_float(RzNum *num, const char *str) {
 	return (IS_DIGIT(*str) && (strchr(str, '.') || str[strlen(str) - 1] == 'f'));
 }

--- a/librz/util/unum.c
+++ b/librz/util/unum.c
@@ -22,8 +22,7 @@ RZ_API bool rz_num_is_hex_prefix(const char *p) {
 	return (p[0] == '0' && p[1] == 'x');
 }
 
-// TODO: rename to rz_num_srand()
-static void rz_srand(int seed) {
+static void rz_num_srand(int seed) {
 #if HAVE_ARC4RANDOM_UNIFORM
 	// no-op
 	(void)seed;
@@ -32,19 +31,25 @@ static void rz_srand(int seed) {
 #endif
 }
 
-static int rz_rand(int mod) {
+static ut64 rz_rand(ut64 mod) {
+	ut64 r;
 #if HAVE_ARC4RANDOM_UNIFORM
-	return (int)arc4random_uniform(mod);
+	r = (ut64)arc4random_uniform(mod);
+	r *= (ut64)arc4random_uniform(mod);
 #else
-	return rand() % mod;
+	r = (ut64)rand();
+	r *= (ut64)rand();
+	r %= mod;
 #endif
+
+	return r;
 }
 
 RZ_API void rz_num_irand(void) {
-	rz_srand(rz_time_now());
+	rz_num_srand(rz_time_now());
 }
 
-RZ_API int rz_num_rand(int max) {
+RZ_API ut64 rz_num_rand(ut64 max) {
 	static bool rand_initialized = false;
 	if (!rand_initialized) {
 		rz_num_irand();

--- a/subprojects/rzwinkd/iob_net.c
+++ b/subprojects/rzwinkd/iob_net.c
@@ -365,7 +365,7 @@ static bool _sendResponsePacket(iobnet_t *obj, const ut8 *pokedata) {
 	memcpy(resbuf + 2, pokedata + 10, 32);
 	// Generate 32 bytes random Host Key
 	for (i = 0; i < 32; i++) {
-		int rand = rz_num_rand(0xFF);
+		int rand = rz_num_rand32(0xFF);
 		resbuf[i + 34] = rand & 0xFF;
 	}
 

--- a/test/unit/test_contrbtree.c
+++ b/test/unit/test_contrbtree.c
@@ -25,15 +25,15 @@ bool test_rz_rbtree_cont_insert() {
 	RContRBTree *tree = rz_rbtree_cont_new();
 	ut32 i;
 	for (i = 0; i < 2000; i++) {
-		ut32 v = (ut32)rz_num_rand(UT32_MAX >> 1);
-		rz_rbtree_cont_insert(tree, (void *)(size_t)v, simple_cmp, NULL);
+		ut64 v = (ut64)rz_num_rand(UT64_MAX >> 1);
+		rz_rbtree_cont_insert(tree, (void *)v, simple_cmp, NULL);
 	}
 	i = 0;
 	bool ret = true;
 	void *v;
 	RBIter ator;
 	rz_rbtree_cont_foreach(tree, ator, v) {
-		const ut32 next = (ut32)(size_t)v;
+		const ut64 next = (ut64)v;
 		ret &= (i <= next);
 		i = next;
 	}

--- a/test/unit/test_contrbtree.c
+++ b/test/unit/test_contrbtree.c
@@ -25,7 +25,7 @@ bool test_rz_rbtree_cont_insert() {
 	RContRBTree *tree = rz_rbtree_cont_new();
 	ut32 i;
 	for (i = 0; i < 2000; i++) {
-		ut64 v = (ut64)rz_num_rand(UT64_MAX >> 1);
+		ut64 v = (ut64)rz_num_rand64(UT64_MAX >> 1);
 		rz_rbtree_cont_insert(tree, (void *)v, simple_cmp, NULL);
 	}
 	i = 0;

--- a/test/unit/test_contrbtree.c
+++ b/test/unit/test_contrbtree.c
@@ -25,15 +25,15 @@ bool test_rz_rbtree_cont_insert() {
 	RContRBTree *tree = rz_rbtree_cont_new();
 	ut32 i;
 	for (i = 0; i < 2000; i++) {
-		ut64 v = (ut64)rz_num_rand64(UT64_MAX >> 1);
-		rz_rbtree_cont_insert(tree, (void *)v, simple_cmp, NULL);
+		ut32 v = rz_num_rand32(UT32_MAX >> 1);
+		rz_rbtree_cont_insert(tree, (void *)(size_t)v, simple_cmp, NULL);
 	}
 	i = 0;
 	bool ret = true;
 	void *v;
 	RBIter ator;
 	rz_rbtree_cont_foreach(tree, ator, v) {
-		const ut64 next = (ut64)v;
+		const ut32 next = (ut32)(size_t)v;
 		ret &= (i <= next);
 		i = next;
 	}


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
Addresses #3440 to improve `cmd_help.yaml` commands help. Also fixes a bug where random number generator command `%r` generated wrong output. Since there was not test to check the output, it slipped but now it's fixed.

Added support for 64bit random numbers. Current implementation takes OR of two 32 bit random numbers to generate a 64 bit random number.

**Closing issues**

#3440 
