### PR TITLE
fixed vn_cnt bug

### DIFF
--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -1238,6 +1238,10 @@ static Sdb *get_verneed_entry_sdb(ELFOBJ *bin, Elf_(Verneed) verneed_entry, size
 
 		sdb_free(sdb_vernaux);
 
+		if(!vernaux_entry.vna_next) {
+			break;
+		}
+
 		vernaux_entry_offset += vernaux_entry.vna_next;
 	}
 

--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -1238,7 +1238,7 @@ static Sdb *get_verneed_entry_sdb(ELFOBJ *bin, Elf_(Verneed) verneed_entry, size
 
 		sdb_free(sdb_vernaux);
 
-		if(!vernaux_entry.vna_next) {
+		if (!vernaux_entry.vna_next) {
 			break;
 		}
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

I found another condition with symbol versioning in the elf code that can have a big impact on load time. Elfxx_Verneed structures in the .gnu.version_r section have a field vn_cnt that declares the number of Elfxx_Vernaux structures after it. This value can be edited to 0xFFFF with out impacting binary functionality but will impact load times in rizin by continually iterating on the last entry since vna_next will be 0 on the last entry.

The fix is simple, just break the loop when vna_next is 0 regardless of vn_cnt. This brought the load time from about 2 minutes for a few KB test file to a few seconds. The load times would just get worse if multiple Elfxx_Verneed structures had modified vn_cnt values.



**Test plan**

Pick a test binary, I just used /bin/clear since its simple and small
Use readelf -V to get the address to a Elfxx_Verneed
edit the vn_cnt of the chosen Elfxx_Verneed to 0xFFFF
run 'rizin test.elf' 

