### PR TITLE
cons: make RzLineUndoEntry public in rz_cons.h to fix rz-bindgen

### DIFF
--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -24,20 +24,6 @@ typedef enum {
 	MAJOR_BREAK
 } BreakMode;
 
-/**
- * an entry of undo. it represents either a text insertion, deletion, or both.
- * \see undo_add_entry
- */
-typedef struct rz_line_undo_entry_t {
-	int offset; ///< the beginning index of buffer edit.
-	char *deleted_text; ///< text to be deleted. null-terminated
-	int deleted_len; ///< the length of deleted text
-	char *inserted_text; ///< text to be inserted. null-terminated.
-	int inserted_len; ///< the length of inserted text.
-	bool continuous_next; ///< if true, redo function will continuously process the next entry.
-	bool continuous_prev; ///< if true, undo function will continuously process the previous entry.
-} RzLineUndoEntry;
-
 static inline bool is_undo_entry_valid(const RzLineUndoEntry *e) {
 	if (!e) {
 		return false;

--- a/librz/include/rz_cons.h
+++ b/librz/include/rz_cons.h
@@ -1138,6 +1138,20 @@ typedef char *(*RzLineEditorCb)(void *core, const char *str);
 typedef int (*RzLineHistoryUpCb)(RzLine *line);
 typedef int (*RzLineHistoryDownCb)(RzLine *line);
 
+/**
+ * an entry of undo. it represents either a text insertion, deletion, or both.
+ * \see undo_add_entry
+ */
+typedef struct rz_line_undo_entry_t {
+	int offset; ///< the beginning index of buffer edit.
+	char *deleted_text; ///< text to be deleted. null-terminated
+	int deleted_len; ///< the length of deleted text
+	char *inserted_text; ///< text to be inserted. null-terminated.
+	int inserted_len; ///< the length of inserted text.
+	bool continuous_next; ///< if true, redo function will continuously process the next entry.
+	bool continuous_prev; ///< if true, undo function will continuously process the previous entry.
+} RzLineUndoEntry;
+
 struct rz_line_t {
 	RzLineCompletion completion;
 	RzLineNSCompletion ns_completion;


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Although it is not strictly necessary to have `RzLineUndoEntry` in rz_cons.h, it is necessary for rz-bindgen to work correctly because `undo_vec` has a type annotation that references it.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Build rz-bindgen with this patch. I tested it locally and it works.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
