### PR TITLE
cons: make RzLineUndoEntry public in rz_cons.h to fix rz-bindgen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -794,7 +794,9 @@ jobs:
           mkdir rizin && pwd && ls -l
           tar -C rizin --strip-components=1 -xvf rizin-src.tar.xz
       - name: Install dependencies
-        run: sudo apt-get --assume-yes install wget unzip python3-wheel python3-setuptools build-essential python3-pip && sudo pip3 install meson ninja
+        run: |
+          sudo apt update
+          sudo apt-get --assume-yes install cmake swig pkg-config clang libclang-dev llvm wget unzip python3-wheel python3-setuptools build-essential python3-pip && sudo pip3 install meson ninja
       - name: Install rizin
         run: |
           export PATH=$PATH:/usr/local/bin
@@ -805,9 +807,6 @@ jobs:
         with:
           repository: rizinorg/rz-bindgen
           path: rz-bindgen
-      - name: Install dependencies
-        run: |
-          sudo apt install --assume-yes libclang-14-dev
       - name: Build rz-bindgen
         run: |
           meson setup --prefix=/usr -Dplugin=enabled build

--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -28,7 +28,7 @@ typedef enum {
  * an entry of undo. it represents either a text insertion, deletion, or both.
  * \see undo_add_entry
  */
-typedef struct rz_line_undo_entry_t {
+struct rz_line_undo_entry_t {
 	int offset; ///< the beginning index of buffer edit.
 	char *deleted_text; ///< text to be deleted. null-terminated
 	int deleted_len; ///< the length of deleted text
@@ -36,7 +36,7 @@ typedef struct rz_line_undo_entry_t {
 	int inserted_len; ///< the length of inserted text.
 	bool continuous_next; ///< if true, redo function will continuously process the next entry.
 	bool continuous_prev; ///< if true, undo function will continuously process the previous entry.
-} RzLineUndoEntry;
+};
 
 static inline bool is_undo_entry_valid(const RzLineUndoEntry *e) {
 	if (!e) {

--- a/librz/include/rz_cons.h
+++ b/librz/include/rz_cons.h
@@ -1138,6 +1138,8 @@ typedef char *(*RzLineEditorCb)(void *core, const char *str);
 typedef int (*RzLineHistoryUpCb)(RzLine *line);
 typedef int (*RzLineHistoryDownCb)(RzLine *line);
 
+typedef struct rz_line_undo_entry_t RzLineUndoEntry;
+
 struct rz_line_t {
 	RzLineCompletion completion;
 	RzLineNSCompletion ns_completion;


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Although it is not strictly necessary to have `RzLineUndoEntry` in rz_cons.h, it is necessary for rz-bindgen to work correctly because `undo_vec` has a type annotation that references it.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Build rz-bindgen with this patch. I tested it locally and it works.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
