### PR TITLE
versym bug fixed

### DIFF
--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -1005,6 +1005,11 @@ static bool get_versym_entry_sdb_from_verneed(ELFOBJ *bin, Sdb *sdb, const char 
 			}
 
 			if (vernaux_entry.vna_other != versym) {
+
+				if (!vernaux_entry.vna_next) {
+					break;
+				}
+
 				vernaux_entry_offset += vernaux_entry.vna_next;
 				continue;
 			}
@@ -1024,6 +1029,10 @@ static bool get_versym_entry_sdb_from_verneed(ELFOBJ *bin, Sdb *sdb, const char 
 			}
 
 			return true;
+		}
+
+		if (!verneed_entry.vn_next) {
+			break;
 		}
 
 		verneed_entry_offset += verneed_entry.vn_next;


### PR DESCRIPTION
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Found another bug with elf symbol versioning. With out effecting binary execution, modifications can be made to verneednum of the .dynamic section, vn_cnt(s) of the Elfxx_Verneed structs in the .gnu.version_r section, and vna_other of the Elfxx_Vernaux structs in the .gnu.version_r section that would in a practical sense prevent rizin from ever loading the binary.

If verneednum is set to 0xFFFFFFFFFFFFFFFF when a vna_other has been modified to never match the version identifier used in the .gnu.version symbol version array of a given symbol(s) rizin will iterate on the last entry since vn_next will be zero but the loop condition is no where near finishing. Editing the vn_cnt value for one or multiple Elfxx_Verneed structs will just make the loop condition even larger.

**Test plan**
cp /bin/clear ./testl.elf
edit ./test.elf .dynamic verneednum to all 0xFFs
pick a Elfxx_Vernaux and edit its vna_other (I chose my libc entry and changed 4 to 10)
NOTE: you could also edit vn_cnt(s) to make the loop condition even larger
rizin ./test.elf

