### PR TITLE
Bump version of libdemangle to support Delphi C++

### DIFF
--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -1287,7 +1287,6 @@ RZ_API const RzBinXtrPlugin *rz_bin_xtrplugin_get(RZ_NONNULL RzBin *bin, RZ_NONN
 	return NULL;
 }
 
-#if WITH_GPL
 static char *bin_demangle_cxx(RzBinFile *bf, const char *symbol, ut64 vaddr) {
 	char *out = rz_demangler_cxx(symbol);
 	if (!out || !bf) {
@@ -1329,14 +1328,8 @@ static char *bin_demangle_cxx(RzBinFile *bf, const char *symbol, ut64 vaddr) {
 }
 
 static char *bin_demangle_rust(RzBinFile *binfile, const char *symbol, ut64 vaddr) {
-	char *str = NULL;
-	if (!(str = bin_demangle_cxx(binfile, symbol, vaddr))) {
-		return str;
-	}
-	free(str);
 	return rz_demangler_rust(symbol);
 }
-#endif
 
 /**
  * \brief Demangles a symbol based on the language or the RzBinFile data
@@ -1441,13 +1434,8 @@ RZ_API RZ_OWN char *rz_bin_demangle(RZ_NULLABLE RzBinFile *bf, RZ_NULLABLE const
 	case RZ_BIN_LANGUAGE_OBJC: demangled = rz_demangler_objc(symbol); break;
 	case RZ_BIN_LANGUAGE_MSVC: demangled = rz_demangler_msvc(symbol); break;
 	case RZ_BIN_LANGUAGE_PASCAL: demangled = rz_demangler_pascal(symbol); break;
-#if WITH_GPL
 	case RZ_BIN_LANGUAGE_RUST: demangled = bin_demangle_rust(bf, symbol, vaddr); break;
 	case RZ_BIN_LANGUAGE_CXX: demangled = bin_demangle_cxx(bf, symbol, vaddr); break;
-#else
-	case RZ_BIN_LANGUAGE_RUST: demangled = NULL; break;
-	case RZ_BIN_LANGUAGE_CXX: demangled = NULL; break;
-#endif
 	default:
 		if (bin) {
 			rz_demangler_resolve(bin->demangler, symbol, language, &demangled);

--- a/librz/demangler/demangler.c
+++ b/librz/demangler/demangler.c
@@ -17,14 +17,18 @@
 	}
 
 #if WITH_GPL
-DEFINE_DEMANGLER_PLUGIN(cpp, "c++", "GPL-2", "Free Software Foundation", libdemangle_handler_cxx);
-// rust demangler requires the cpp one.
-DEFINE_DEMANGLER_PLUGIN(rust, "rust", "LGPL3", "pancake", libdemangle_handler_rust);
-#endif
+// cpp demangler contains GPL2 code and LGPL3 for delphi
+DEFINE_DEMANGLER_PLUGIN(cpp, "c++", "GPL-2,LGPL3", "FSF/deroad", libdemangle_handler_cxx);
+#else
+// cpp demangler contain only the LGPL3 for delphi
+DEFINE_DEMANGLER_PLUGIN(cpp, "c++", "LGPL3", "deroad", libdemangle_handler_cxx);
+#endif /* WITH_GPL */
+
 #if WITH_SWIFT_DEMANGLER
 DEFINE_DEMANGLER_PLUGIN(swift, "swift", "MIT", "pancake", libdemangle_handler_swift);
 #endif
 
+DEFINE_DEMANGLER_PLUGIN(rust, "rust", "LGPL3", "Dhruv Maroo", libdemangle_handler_rust);
 DEFINE_DEMANGLER_PLUGIN(java, "java", "LGPL3", "deroad", libdemangle_handler_java);
 DEFINE_DEMANGLER_PLUGIN(msvc, "msvc", "LGPL3", "inisider", libdemangle_handler_msvc);
 DEFINE_DEMANGLER_PLUGIN(objc, "objc", "LGPL3", "pancake", libdemangle_handler_objc);
@@ -45,11 +49,7 @@ RZ_API RZ_OWN char *rz_demangler_java(RZ_NULLABLE const char *symbol) {
  * \brief Demangles c++ symbols
  */
 RZ_API RZ_OWN char *rz_demangler_cxx(RZ_NONNULL const char *symbol) {
-#if WITH_GPL
 	return libdemangle_handler_cxx(symbol);
-#else
-	return NULL;
-#endif
 }
 
 /**
@@ -70,11 +70,7 @@ RZ_API RZ_OWN char *rz_demangler_pascal(RZ_NONNULL const char *symbol) {
  * \brief Demangles rust symbols
  */
 RZ_API RZ_OWN char *rz_demangler_rust(RZ_NONNULL const char *symbol) {
-#if WITH_GPL
 	return libdemangle_handler_rust(symbol);
-#else
-	return NULL;
-#endif
 }
 
 /**

--- a/librz/main/rz-bin.c
+++ b/librz/main/rz-bin.c
@@ -623,7 +623,7 @@ static void __listPlugins(RzBin *bin, const char *plugin_name, PJ *pj, int rad) 
 
 static bool print_demangler_info(const RzDemanglerPlugin *plugin, void *user) {
 	(void)user;
-	printf("%-6s %-8s %s\n", plugin->language, plugin->license, plugin->author);
+	printf("%-6s %-12s %s\n", plugin->language, plugin->license, plugin->author);
 	return true;
 }
 

--- a/subprojects/libdemangle.wrap
+++ b/subprojects/libdemangle.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/rizinorg/rz-libdemangle.git
-revision = f2f627ff2e4dde38d8025272398a9243b89b81a0
+revision = 67a71ac32f4730660219adc61e37a34cef4ba921

--- a/test/db/tools/rz_bin
+++ b/test/db/tools/rz_bin
@@ -884,13 +884,13 @@ EOF
 EXPECT=<<EOF
 Language 'Invalid' is unsupported
 List of supported languages:
-java   LGPL3    deroad
-msvc   LGPL3    inisider
-objc   LGPL3    pancake
-pascal LGPL3    deroad
-c++    GPL-2    Free Software Foundation
-rust   LGPL3    pancake
-swift  MIT      pancake
+java   LGPL3        deroad
+msvc   LGPL3        inisider
+objc   LGPL3        pancake
+pascal LGPL3        deroad
+c++    GPL-2,LGPL3  FSF/deroad
+rust   LGPL3        Dhruv Maroo
+swift  MIT          pancake
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Updates libdemangle to support Delphi C++ demangling.

I have fixed also the usage of the GPL code since now the rust demangler is not anymore using the GPL-2 code

Linked to: https://github.com/rizinorg/rz-libdemangle/pull/33