### PR TITLE
Elf symbol versioning fixes

### DIFF
--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -1005,6 +1005,11 @@ static bool get_versym_entry_sdb_from_verneed(ELFOBJ *bin, Sdb *sdb, const char 
 			}
 
 			if (vernaux_entry.vna_other != versym) {
+
+				if (!vernaux_entry.vna_next) {
+					break;
+				}
+
 				vernaux_entry_offset += vernaux_entry.vna_next;
 				continue;
 			}
@@ -1024,6 +1029,10 @@ static bool get_versym_entry_sdb_from_verneed(ELFOBJ *bin, Sdb *sdb, const char 
 			}
 
 			return true;
+		}
+
+		if (!verneed_entry.vn_next) {
+			break;
 		}
 
 		verneed_entry_offset += verneed_entry.vn_next;

--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -1238,6 +1238,10 @@ static Sdb *get_verneed_entry_sdb(ELFOBJ *bin, Elf_(Verneed) verneed_entry, size
 
 		sdb_free(sdb_vernaux);
 
+		if (!vernaux_entry.vna_next) {
+			break;
+		}
+
 		vernaux_entry_offset += vernaux_entry.vna_next;
 	}
 

--- a/test/db/formats/elf/sym_version
+++ b/test/db/formats/elf/sym_version
@@ -1,0 +1,7 @@
+NAME=sym_version
+FILE=bins/elf/sym_version
+CMDS=
+EXPECT=<<EOF
+EOF
+TIMEOUT=5
+RUN


### PR DESCRIPTION
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

 BUG00:  I found another condition with symbol versioning in the elf code that can have a big impact on load time. Elfxx_Verneed structures in the .gnu.version_r section have a field vn_cnt that declares the number of Elfxx_Vernaux structures after it. This value can be edited to 0xFFFF with out impacting binary functionality but will impact load times in rizin by continually iterating on the last entry since vna_next will be 0 on the last entry.

The fix is simple, just break the loop when vna_next is 0 regardless of vn_cnt. This brought the load time from about 2 minutes for a few KB test file to a few seconds. The load times would just get worse if multiple Elfxx_Verneed structures had modified vn_cnt values.

BUG01: Found another bug with elf symbol versioning. With out effecting binary execution, modifications can be made to verneednum of the .dynamic section, vn_cnt(s) of the Elfxx_Verneed structs in the .gnu.version_r section, and vna_other of the Elfxx_Vernaux structs in the .gnu.version_r section that would in a practical sense prevent rizin from ever loading the binary.

If verneednum is set to 0xFFFFFFFFFFFFFFFF when a vna_other has been modified to never match the version identifier used in the .gnu.version symbol version array of a given symbol(s) rizin will iterate on the last entry since vn_next will be zero but the loop condition is no where near finishing. Editing the vn_cnt value for one or multiple Elfxx_Verneed structs will just make the loop condition even larger.


**Test plan**

BUG00: 
Pick a test binary, I just used /bin/clear since its simple and small
Use readelf -V to get the address to a Elfxx_Verneed
edit the vn_cnt of the chosen Elfxx_Verneed to 0xFFFF
run 'rizin test.elf'

BUG01:
cp /bin/clear ./testl.elf
edit ./test.elf .dynamic verneednum to all 0xFFs
pick a Elfxx_Vernaux and edit its vna_other (I chose my libc entry and changed 4 to 10)
you could also edit vn_cnt(s) to make the loop condition even larger
rizin ./test.elf

NOTE: the test bin uploaded to the rizin-testbins repo will cover these 2 bugs and also another from pull  #3214