### PR TITLE
librz: fix UAF in plugin deletion

### DIFF
--- a/librz/analysis/analysis.c
+++ b/librz/analysis/analysis.c
@@ -190,9 +190,6 @@ RZ_API bool rz_analysis_plugin_del(RzAnalysis *analysis, RZ_NONNULL RzAnalysisPl
 		plugin_fini(analysis);
 		analysis->cur = NULL;
 	}
-	if (p->fini && !p->fini(analysis->plugin_data)) {
-		return false;
-	}
 	return rz_list_delete_data(analysis->plugins, p);
 }
 

--- a/librz/asm/asm.c
+++ b/librz/asm/asm.c
@@ -352,9 +352,6 @@ RZ_API bool rz_asm_plugin_del(RzAsm *a, RZ_NONNULL RzAsmPlugin *p) {
 	if (a->acur == p) {
 		a->acur = NULL;
 	}
-	if (p->fini && !p->fini(a->plugin_data)) {
-		return false;
-	}
 	return rz_list_delete_data(a->plugins, p);
 }
 

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -439,10 +439,10 @@ RZ_API bool rz_bin_xtr_plugin_del(RzBin *bin, RZ_NONNULL RzBinXtrPlugin *plugin)
 	rz_list_foreach_safe (bin->binfiles, it, tmp, bf) {
 		if (bf->curxtr == plugin) {
 			rz_bin_file_delete(bin, bf);
+			if (!plugin_fini(bin, plugin)) {
+				return false;
+			}
 		}
-	}
-	if (!plugin_fini(bin, plugin)) {
-		return false;
 	}
 	return rz_list_delete_data(bin->binxtrs, plugin);
 }

--- a/librz/parse/parse.c
+++ b/librz/parse/parse.c
@@ -68,8 +68,11 @@ RZ_API bool rz_parse_plugin_add(RzParse *p, RZ_NONNULL RzParsePlugin *plugin) {
 
 RZ_API bool rz_parse_plugin_del(RzParse *p, RZ_NONNULL RzParsePlugin *plugin) {
 	rz_return_val_if_fail(p && plugin, false);
-	if (plugin->fini && !plugin->fini(p, p->user)) {
-		return false;
+	if (p->cur == plugin) {
+		if (plugin->fini && !plugin->fini(p, p->user)) {
+			return false;
+		}
+		p->cur = NULL;
 	}
 	return rz_list_delete_data(p->parsers, plugin);
 }


### PR DESCRIPTION
Some libraries have a global "plugin_data" that is initialized only for the current plugin, thus the fini method should only be called for the current plugin as well and not for the others.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
