### PR TITLE
Use `meson setup <dir>` instead of `meson <dir>`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -71,13 +71,13 @@ install:
 build_script:
   - appveyor AddMessage "Compiling rizin %RZ_VERSION% (%builder%)"
 
-  - cmd: if %builder% == vs2017_64 ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2017%" x64 && %PYTHON%\Scripts\meson --buildtype=release --prefix="%CD%\%DIST_FOLDER%" --default-library=static -Db_vscrt=static_from_buildtype build && %PYTHON%\Scripts\ninja -C build install && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
+  - cmd: if %builder% == vs2017_64 ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2017%" x64 && %PYTHON%\Scripts\meson setup --buildtype=release --prefix="%CD%\%DIST_FOLDER%" --default-library=static -Db_vscrt=static_from_buildtype build && %PYTHON%\Scripts\ninja -C build install && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
 
-  - cmd: if %builder% == vs2022_64 ( choco install mingw && refreshenv && set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2022%" x64 && %PYTHON%\Scripts\meson --buildtype=release --prefix="%CD%\%DIST_FOLDER%" --default-library=static -Db_vscrt=static_from_buildtype build && %PYTHON%\Scripts\ninja -C build install && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
+  - cmd: if %builder% == vs2022_64 ( choco install mingw && refreshenv && set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2022%" x64 && %PYTHON%\Scripts\meson setup --buildtype=release --prefix="%CD%\%DIST_FOLDER%" --default-library=static -Db_vscrt=static_from_buildtype build && %PYTHON%\Scripts\ninja -C build install && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
 
-  - cmd: if %builder% == vs2017_64_dyn ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2017%" x64 && %PYTHON%\Scripts\meson --buildtype=release --prefix="%CD%\%DIST_FOLDER%" build && %PYTHON%\Scripts\ninja -C build install && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
+  - cmd: if %builder% == vs2017_64_dyn ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2017%" x64 && %PYTHON%\Scripts\meson setup --buildtype=release --prefix="%CD%\%DIST_FOLDER%" build && %PYTHON%\Scripts\ninja -C build install && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
 
-  - cmd: if %builder% == clang_cl_64_dyn ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2019%" x64 && set CC=clang-cl && %PYTHON%\Scripts\meson --buildtype=release --prefix="%CD%\%DIST_FOLDER%" build && %PYTHON%\Scripts\ninja -C build install && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
+  - cmd: if %builder% == clang_cl_64_dyn ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2019%" x64 && set CC=clang-cl && %PYTHON%\Scripts\meson setup --buildtype=release --prefix="%CD%\%DIST_FOLDER%" build && %PYTHON%\Scripts\ninja -C build install && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
 
 # Run tests only conditionally
 for:

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -20,7 +20,7 @@ tasks:
         sudo python3 -m pip install 'git+https://github.com/rizinorg/rz-pipe#egg=rzpipe&subdirectory=python'
     - build: |
         cd rizin
-        meson --prefix=${HOME} build
+        meson setup --prefix=${HOME} build
         ninja -C build
     - install: |
         cd rizin

--- a/.builds/netbsd.yml
+++ b/.builds/netbsd.yml
@@ -23,7 +23,7 @@ tasks:
         # Workaround to avoid running rz-pipe test since there is no python3 symlink but a python3.8 binary available.
         rm -f test/db/cmd/cmd_pipe
         rm -f test/db/archos/not-windows-any/cmd_pipe
-        meson --prefix=${HOME} build
+        meson setup --prefix=${HOME} build
         ninja -C build
     - install: |
         cd rizin

--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -18,7 +18,7 @@ tasks:
         /usr/local/bin/python3 -m pip install --user 'git+https://github.com/rizinorg/rz-pipe#egg=rzpipe&subdirectory=python'
     - build: |
         cd rizin
-        meson --prefix=${HOME} build
+        meson setup --prefix=${HOME} build
         ninja -C build
     - install: |
         cd rizin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,13 @@ jobs:
           echo "deb http://archive.debian.org/debian jessie main" > /etc/apt/sources.list
           echo "deb http://archive.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list
           echo "Acquire::Check-Valid-Until no;" > /etc/apt/apt.conf.d/99no-check-valid-until
+      - name: Fix containers (Stretch)
+        if: matrix.container == 'debian:stretch'
+        run: |
+          echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
+          echo "deb http://archive.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list
+          echo "Acquire::Check-Valid-Until no;" > /etc/apt/apt.conf.d/99no-check-valid-until
+
       - name: Install tools
         run: apt-get update --yes --force-yes && apt-get install --yes --force-yes patch unzip git gcc make curl pkg-config libc6-i386 build-essential
       - name: Install Python source build dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
               export LD_LIBRARY_PATH=$(dirname $(clang -print-file-name=libclang_rt.asan-x86_64.so)):${LD_LIBRARY_PATH}
             fi
           fi
-          meson --prefix=${HOME} ${{ matrix.meson_options }} build && ninja -C build
+          meson setup --prefix=${HOME} ${{ matrix.meson_options }} build && ninja -C build
         env:
           ASAN: ${{ matrix.asan }}
           CC: ${{ matrix.compiler }}
@@ -332,7 +332,7 @@ jobs:
         run: git clone https://github.com/rizinorg/rizin-testbins test/bins
         working-directory: rizin
       - name: Build
-        run: meson --prefix=/usr build && ninja -C build
+        run: meson setup --prefix=/usr build && ninja -C build
         working-directory: rizin
       - name: Install
         run: ninja -C build install
@@ -402,7 +402,7 @@ jobs:
         run: git clone https://github.com/rizinorg/rizin-testbins test/bins
         working-directory: rizin
       - name: Build with Meson + Ninja
-        run: meson --prefix=/usr build && ninja -C build
+        run: meson setup --prefix=/usr build && ninja -C build
         working-directory: rizin
       - name: Install with Ninja
         run: ninja -C build install
@@ -448,7 +448,7 @@ jobs:
         run: git clone https://github.com/rizinorg/rizin-testbins test/bins
         working-directory: rizin
       - name: Build with Meson + Ninja
-        run: meson --prefix=/usr -Dbuildtype=debugoptimized -Db_sanitize=address,undefined --werror build && ninja -C build
+        run: meson setup --prefix=/usr -Dbuildtype=debugoptimized -Db_sanitize=address,undefined --werror build && ninja -C build
         working-directory: rizin
         env:
           CFLAGS: -DASAN=1 -DRZ_ASSERT_STDOUT=1 -Wno-cpp
@@ -496,7 +496,7 @@ jobs:
         run: git clone https://github.com/rizinorg/rizin-testbins test/bins
         working-directory: rizin
       - name: Build with Meson + Ninja
-        run: meson --prefix=/usr -Dbuildtype=release --werror build && ninja -C build
+        run: meson setup --prefix=/usr -Dbuildtype=release --werror build && ninja -C build
         working-directory: rizin
         env:
           CFLAGS: -Wno-cpp
@@ -531,7 +531,7 @@ jobs:
       - name: Compile with meson
         run: |
           mkdir -p ${HOME}/rizin-static
-          meson --prefix=${HOME}/rizin-static --buildtype release --default-library static -Dinstall_sigdb=true -Dstatic_runtime=true -Dportable=true build
+          meson setup --prefix=${HOME}/rizin-static --buildtype release --default-library static -Dinstall_sigdb=true -Dstatic_runtime=true -Dportable=true build
           ninja -C build && ninja -C build install
           tar -C ${HOME}/rizin-static --xz -cf rizin-static.tar.xz $(ls ${HOME}/rizin-static)
         working-directory: rizin
@@ -580,7 +580,7 @@ jobs:
       - name: Create archive
         run: |
           export PATH=${HOME}/.local/bin:${PATH}
-          meson build
+          meson setup build
           cd build
           meson dist --include-subprojects --no-tests
           ls -l meson-dist
@@ -610,7 +610,7 @@ jobs:
       - name: Install rizin
         run: |
           export PATH=${HOME}/bin:${HOME}/Library/Python/3.9/bin:${HOME}/Library/Python/3.10/bin:${HOME}/Library/Python/3.11/bin:${HOME}/.local/bin:${PATH}
-          meson --prefix=/usr --buildtype=release build && ninja -C build && sudo ninja -C build install
+          meson setup --prefix=/usr --buildtype=release build && ninja -C build && sudo ninja -C build install
         working-directory: rizin
       - name: Check that installed rizin runs
         run: rizin -qcq /bin/ls
@@ -713,7 +713,7 @@ jobs:
         run: |
           export PATH=${HOME}/.local/bin:${PATH}
           sed -i 's@\${ANDROID_NDK}@'"${ANDROID_NDK}"'@' .github/meson-android-${{ matrix.name }}.ini
-          meson --buildtype release --default-library static --prefix=/tmp/android-dir -Dportable=true -Dblob=true -Dstatic_runtime=true build --cross-file .github/meson-android-${{ matrix.name }}.ini
+          meson setup --buildtype release --default-library static --prefix=/tmp/android-dir -Dportable=true -Dblob=true -Dstatic_runtime=true build --cross-file .github/meson-android-${{ matrix.name }}.ini
           ninja -C build && ninja -C build install
       - name: Create rizin-android-${{ matrix.name }}.tar.gz
         run: |
@@ -739,12 +739,12 @@ jobs:
       - name: Compile & Install Rizin
         run: |
           export PATH=${HOME}/bin:${HOME}/Library/Python/3.9/bin:${HOME}/Library/Python/3.10/bin:${HOME}/Library/Python/3.11/bin:${HOME}/.local/bin:${PATH}
-          meson --buildtype release --prefix=/usr build
+          meson setup --buildtype release --prefix=/usr build
           ninja -C build && sudo ninja -C build install
       - name: Compile C++ test
         run: |
           export PATH=${HOME}/bin:${HOME}/Library/Python/3.9/bin:${HOME}/Library/Python/3.10/bin:${HOME}/Library/Python/3.11/bin:${HOME}/.local/bin:${PATH}
-          meson --prefix=/usr build-cpp-test ./test/unit/cpp
+          meson setup --prefix=/usr build-cpp-test ./test/unit/cpp
           meson compile -C build-cpp-test
       - name: Run C++ test
         run: |
@@ -771,7 +771,7 @@ jobs:
       - name: Install rizin
         run: |
           export PATH=$PATH:/usr/local/bin
-          meson --prefix=/usr --buildtype=release build && ninja -C build && sudo ninja -C build install
+          meson setup --prefix=/usr --buildtype=release build && ninja -C build && sudo ninja -C build install
         working-directory: rizin
       - name: Install rz-pipe-py
         run: |
@@ -800,7 +800,7 @@ jobs:
       - name: Install rizin
         run: |
           export PATH=$PATH:/usr/local/bin
-          meson --prefix=/usr --buildtype=release build && ninja -C build && sudo ninja -C build install
+          meson setup --prefix=/usr --buildtype=release build && ninja -C build && sudo ninja -C build install
         working-directory: rizin
       - name: Checkout rz-bindgen
         uses: actions/checkout@v3

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -34,7 +34,7 @@ jobs:
         if: steps.determine-repo.outputs.repo == 'rizinorg/rizin'
 
       - name: Meson
-        run: meson build
+        run: meson setup build
         if: steps.determine-repo.outputs.repo == 'rizinorg/rizin'
 
       - name: Build with cov-build

--- a/.github/workflows/tcc.yml
+++ b/.github/workflows/tcc.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Meson setup
       env:
           CC: tcc
-      run: meson --prefix=/usr build
+      run: meson setup --prefix=/usr build
     - name: Meson compile and install
       run: ninja -C build && sudo ninja -C build install
     - name: Run unit tests

--- a/travis-script
+++ b/travis-script
@@ -36,7 +36,7 @@ if [ "${COVERAGE}" == "1" ] ; then
 	OPTS="${OPTS} -Db_coverage=true"
 fi
 
-meson --prefix=${TRAVIS_BUILD_DIR}/install ${OPTS} build || exit 1
+meson setup --prefix=${TRAVIS_BUILD_DIR}/install ${OPTS} build || exit 1
 ninja -C build || exit 1
 ninja -C build install || exit 1
 export PKG_CONFIG_PATH=$(pwd)/build/meson-private:${PKG_CONFIG_PATH}


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes the following warning:
```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```
