### PR TITLE
Add thread-safe hash tables

### DIFF
--- a/librz/include/meson.build
+++ b/librz/include/meson.build
@@ -107,6 +107,7 @@ rz_util_files = [
   'rz_util/rz_subprocess.h',
   'rz_util/rz_sys.h',
   'rz_util/rz_table.h',
+  'rz_util/rz_th_ht.h',
   'rz_util/rz_time.h',
   'rz_util/rz_tree.h',
   'rz_util/rz_uleb128.h',

--- a/librz/include/rz_th.h
+++ b/librz/include/rz_th.h
@@ -13,6 +13,8 @@
 #include <rz_list.h>
 #include <rz_vector.h>
 
+#include <rz_util/rz_th_ht.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/librz/include/rz_util/rz_th_ht.h
+++ b/librz/include/rz_util/rz_th_ht.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2023 RizinOrg <info@rizin.re>
+// SPDX-FileCopyrightText: 2023 deroad <wargio@libero.it>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef RZ_TH_HASH_TABLE_H
+#define RZ_TH_HASH_TABLE_H
+
+#include <rz_th.h>
+#include <ht_pp.h>
+#include <ht_up.h>
+#include <ht_uu.h>
+#include <ht_pu.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef RZ_API
+
+#define rz_th_ht_header(name, type, ktype, vtype) \
+	typedef struct rz_th_##name##_t RzThread##type; \
+	RZ_API void rz_th_##name##_free(RzThread##type *ht); \
+	RZ_API RzThread##type *rz_th_##name##_new0(void); \
+	RZ_API RzThread##type *rz_th_##name##_new_opt(type##Options *opt); \
+	RZ_API bool rz_th_##name##_insert(RzThread##type *ht, const ktype key, vtype value); \
+	RZ_API bool rz_th_##name##_update(RzThread##type *ht, const ktype key, vtype value); \
+	RZ_API bool rz_th_##name##_delete(RzThread##type *ht, const ktype key); \
+	RZ_API vtype rz_th_##name##_find(RzThread##type *ht, const ktype key, bool *found); \
+	RZ_API type *rz_th_##name##_move(RzThread##type *ht); \
+	RZ_API void rz_th_##name##_foreach(RzThread##type *ht, type##ForeachCallback cb, void *user)
+
+rz_th_ht_header(ht_pp, HtPP, void *, void *);
+rz_th_ht_header(ht_up, HtUP, ut64, void *);
+rz_th_ht_header(ht_uu, HtUU, ut64, ut64);
+rz_th_ht_header(ht_pu, HtPU, void *, ut64);
+
+#endif /* RZ_API */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RZ_TH_HASH_TABLE_H */

--- a/librz/util/meson.build
+++ b/librz/util/meson.build
@@ -64,6 +64,7 @@ rz_util_common_sources = [
   'table.c',
   'thread.c',
   'thread_cond.c',
+  'thread_hash_table.c',
   'thread_iterators.c',
   'thread_lock.c',
   'thread_pool.c',

--- a/librz/util/thread_hash_table.c
+++ b/librz/util/thread_hash_table.c
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2023 RizinOrg <info@rizin.re>
+// SPDX-FileCopyrightText: 2023 deroad <wargio@libero.it>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_th.h>
+#include <rz_util.h>
+
+#define th_ht_type(name) struct rz_th_##name##_t
+#define th_ht_struct(name, type) \
+	th_ht_type(name) { \
+		type *table; \
+		RzThreadLock *lock; \
+	};
+
+#define th_ht_free(name, v) rz_th_##name##_free(v)
+#define th_ht_free_decl(name) \
+	RZ_API void rz_th_##name##_free(th_ht_type(name) * ht) { \
+		if (!ht) { \
+			return; \
+		} \
+		name##_free(ht->table); \
+		rz_th_lock_free(ht->lock); \
+		free(ht); \
+	}
+
+#define th_ht_new0_decl(name) \
+	RZ_API th_ht_type(name) * rz_th_##name##_new0(void) { \
+		th_ht_type(name) *ht = RZ_NEW0(th_ht_type(name)); \
+		if (!ht) { \
+			return NULL; \
+		} \
+		ht->table = name##_new0(); \
+		ht->lock = rz_th_lock_new(true); \
+		if (!ht->table || !ht->lock) { \
+			th_ht_free(name, ht); \
+			return NULL; \
+		} \
+		return ht; \
+	}
+
+#define th_ht_new_opt_decl(name, type) \
+	RZ_API th_ht_type(name) * rz_th_##name##_new_opt(type##Options *opt) { \
+		th_ht_type(name) *ht = RZ_NEW0(th_ht_type(name)); \
+		if (!ht) { \
+			return NULL; \
+		} \
+		ht->table = name##_new_opt(opt); \
+		ht->lock = rz_th_lock_new(true); \
+		if (!ht->table || !ht->lock) { \
+			th_ht_free(name, ht); \
+			return NULL; \
+		} \
+		return ht; \
+	}
+
+#define th_ht_kv_op_decl(name, op, ktype, vtype) \
+	RZ_API bool rz_th_##name##_##op(th_ht_type(name) * ht, ktype key, vtype value) { \
+		rz_return_val_if_fail(ht && ht->table, false); \
+		rz_th_lock_enter(ht->lock); \
+		bool ret = name##_##op(ht->table, key, value); \
+		rz_th_lock_leave(ht->lock); \
+		return ret; \
+	}
+
+#define th_ht_delete_decl(name, ktype) \
+	RZ_API bool rz_th_##name##_delete(th_ht_type(name) * ht, const ktype key) { \
+		rz_return_val_if_fail(ht && ht->table, false); \
+		rz_th_lock_enter(ht->lock); \
+		bool ret = name##_delete(ht->table, key); \
+		rz_th_lock_leave(ht->lock); \
+		return ret; \
+	}
+
+#define th_ht_find_decl(name, ktype, vtype) \
+	RZ_API vtype rz_th_##name##_find(th_ht_type(name) * ht, const ktype key, bool *found) { \
+		rz_return_val_if_fail(ht && ht->table, 0); \
+		rz_th_lock_enter(ht->lock); \
+		vtype ret = name##_find(ht->table, key, found); \
+		rz_th_lock_leave(ht->lock); \
+		return ret; \
+	}
+
+#define th_ht_move_decl(name, type) \
+	RZ_API type *rz_th_##name##_move(th_ht_type(name) * ht) { \
+		rz_return_val_if_fail(ht && ht->table, false); \
+		rz_th_lock_enter(ht->lock); \
+		type *ret = ht->table; \
+		ht->table = NULL; \
+		rz_th_lock_leave(ht->lock); \
+		return ret; \
+	}
+
+#define th_ht_foreach_decl(name, type) \
+	RZ_API void rz_th_##name##_foreach(th_ht_type(name) * ht, type##ForeachCallback cb, void *user) { \
+		rz_return_if_fail(ht && ht->table && cb); \
+		rz_th_lock_enter(ht->lock); \
+		name##_foreach(ht->table, cb, user); \
+		rz_th_lock_leave(ht->lock); \
+	}
+
+#define th_ht_define(name, type, ktype, vtype) \
+	th_ht_struct(name, type); \
+	th_ht_free_decl(name); \
+	th_ht_new0_decl(name); \
+	th_ht_new_opt_decl(name, type); \
+	th_ht_kv_op_decl(name, insert, const ktype, vtype); \
+	th_ht_kv_op_decl(name, update, const ktype, vtype); \
+	th_ht_delete_decl(name, ktype); \
+	th_ht_find_decl(name, ktype, vtype); \
+	th_ht_move_decl(name, type); \
+	th_ht_foreach_decl(name, type)
+
+th_ht_define(ht_pp, HtPP, void *, void *);
+th_ht_define(ht_up, HtUP, ut64, void *);
+th_ht_define(ht_uu, HtUU, ut64, ut64);
+th_ht_define(ht_pu, HtPU, void *, ut64);

--- a/test/unit/test_threads.c
+++ b/test/unit/test_threads.c
@@ -81,6 +81,46 @@ bool test_thread_queue(void) {
 	mu_end;
 }
 
+bool test_thread_ht(void) {
+	bool v_boolean = false;
+	const char *element = NULL;
+
+	RzThreadHtPP *ht = rz_th_ht_pp_new0();
+	mu_assert_notnull(ht, "rz_th_ht_pp_new0() null check");
+
+	v_boolean = true;
+	element = (const char *)rz_th_ht_pp_find(ht, "not found", &v_boolean);
+	mu_assert_false(v_boolean, "the search must say not found");
+	mu_assert_null(element, "the search must return NULL");
+
+	v_boolean = rz_th_ht_pp_insert(ht, "foo", "bar");
+	mu_assert_true(v_boolean, "the insert must succeed");
+
+	v_boolean = false;
+	element = (const char *)rz_th_ht_pp_find(ht, "foo", &v_boolean);
+	mu_assert_true(v_boolean, "the search must say found");
+	mu_assert_notnull(element, "the search must NOT return NULL");
+	mu_assert_streq(element, "bar", "expecting to find 'bar' when searching for 'foo'");
+
+	element = (const char *)rz_th_ht_pp_find(ht, "foo", NULL);
+	mu_assert_notnull(element, "the search must NOT return NULL");
+	mu_assert_streq(element, "bar", "expecting to find 'bar' when searching for 'foo'");
+
+	v_boolean = rz_th_ht_pp_delete(ht, "not found");
+	mu_assert_false(v_boolean, "the delete must fail");
+
+	v_boolean = rz_th_ht_pp_delete(ht, "foo");
+	mu_assert_true(v_boolean, "the delete must succeed");
+
+	v_boolean = true;
+	element = (const char *)rz_th_ht_pp_find(ht, "foo", &v_boolean);
+	mu_assert_false(v_boolean, "the search must say not found");
+	mu_assert_null(element, "the search must return NULL");
+
+	rz_th_ht_pp_free(ht);
+	mu_end;
+}
+
 void thread_set_bool_arg(bool *value, bool *user) {
 	*value = true;
 	*user = true;
@@ -185,6 +225,7 @@ bool test_thread_iterator_pvec(void) {
 int all_tests() {
 	mu_run_test(test_thread_pool_cores);
 	mu_run_test(test_thread_queue);
+	mu_run_test(test_thread_ht);
 	mu_run_test(test_thread_iterator_list);
 	mu_run_test(test_thread_iterator_pvec);
 	return tests_passed != tests_run;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Adds the thread-safe hashtable.

The interface is the same with the exception of the `move` function which moves the ownership of the hashtable stored inside the RzThreadHtXX to the user.

This is useful for those usages where the hash table needs to be used in a threaded environment for a limited amount of time and then be used only on a single-thread environment.