### PR TITLE
Fix visual debug view + %% help update

### DIFF
--- a/librz/core/cmd/cmd_math.c
+++ b/librz/core/cmd/cmd_math.c
@@ -387,6 +387,13 @@ RZ_IPI RzCmdStatus rz_exec_cmd_if_core_num_value_zero_handler(RzCore *core, int 
 	return RZ_CMD_STATUS_OK;
 }
 
+RZ_IPI RzCmdStatus rz_exec_cmd_if_core_num_value_nonzero_handler(RzCore *core, int argc, const char **argv) {
+	if (core->num->value) {
+		core->num->value = rz_core_cmd(core, argv[1], 0);
+	}
+	return RZ_CMD_STATUS_OK;
+}
+
 RZ_IPI RzCmdStatus rz_show_help_vars_handler(RzCore *core, int argc, const char **argv) {
 	rz_core_help_vars_print(core);
 	return RZ_CMD_STATUS_OK;
@@ -575,12 +582,5 @@ RZ_IPI RzCmdStatus rz_get_addr_references_handler(RzCore *core, int argc, const 
 	}
 	rz_cons_println(rstr);
 	free(rstr);
-	return RZ_CMD_STATUS_OK;
-}
-
-RZ_IPI RzCmdStatus rz_exec_cmd_if_core_num_value_positive2_handler(RzCore *core, int argc, const char **argv) {
-	if (core->num->value) {
-		core->num->value = rz_core_cmd(core, argv[1], 0);
-	}
 	return RZ_CMD_STATUS_OK;
 }

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -130,6 +130,7 @@ static const RzCmdDescArg compare_and_set_core_num_value_args[3];
 static const RzCmdDescArg exec_cmd_if_core_num_value_positive_args[2];
 static const RzCmdDescArg exec_cmd_if_core_num_value_negative_args[2];
 static const RzCmdDescArg exec_cmd_if_core_num_value_zero_args[2];
+static const RzCmdDescArg exec_cmd_if_core_num_value_nonzero_args[2];
 static const RzCmdDescArg calculate_string_length_args[2];
 static const RzCmdDescArg calc_expr_show_hex_args[2];
 static const RzCmdDescArg ascii_to_hex_args[2];
@@ -146,7 +147,6 @@ static const RzCmdDescArg input_yank_hud_args[2];
 static const RzCmdDescArg input_msg_args[2];
 static const RzCmdDescArg input_conditional_args[2];
 static const RzCmdDescArg get_addr_references_args[2];
-static const RzCmdDescArg exec_cmd_if_core_num_value_positive2_args[2];
 static const RzCmdDescArg push_escaped_args[2];
 static const RzCmdDescArg analysis_all_esil_args[2];
 static const RzCmdDescArg analyze_all_consecutive_functions_in_section_args[2];
@@ -1941,6 +1941,20 @@ static const RzCmdDescHelp exec_cmd_if_core_num_value_zero_help = {
 	.args = exec_cmd_if_core_num_value_zero_args,
 };
 
+static const RzCmdDescArg exec_cmd_if_core_num_value_nonzero_args[] = {
+	{
+		.name = "cmd",
+		.type = RZ_CMD_ARG_TYPE_CMD,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp exec_cmd_if_core_num_value_nonzero_help = {
+	.summary = "Execute command if result of last numeric expression evaluation (related) command was not 0",
+	.args = exec_cmd_if_core_num_value_nonzero_args,
+};
+
 static const RzCmdDescArg calculate_string_length_args[] = {
 	{
 		.name = "str",
@@ -2188,20 +2202,6 @@ static const RzCmdDescArg get_addr_references_args[] = {
 static const RzCmdDescHelp get_addr_references_help = {
 	.summary = "Get references of given address",
 	.args = get_addr_references_args,
-};
-
-static const RzCmdDescArg exec_cmd_if_core_num_value_positive2_args[] = {
-	{
-		.name = "cmd",
-		.type = RZ_CMD_ARG_TYPE_CMD,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
-
-	},
-	{ 0 },
-};
-static const RzCmdDescHelp exec_cmd_if_core_num_value_positive2_help = {
-	.summary = "Execute command if $? register holds positive value",
-	.args = exec_cmd_if_core_num_value_positive2_args,
 };
 
 static const RzCmdDescArg push_escaped_args[] = {
@@ -18480,6 +18480,9 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *exec_cmd_if_core_num_value_zero_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_math_cd, "%!", rz_exec_cmd_if_core_num_value_zero_handler, &exec_cmd_if_core_num_value_zero_help);
 	rz_warn_if_fail(exec_cmd_if_core_num_value_zero_cd);
 
+	RzCmdDesc *exec_cmd_if_core_num_value_nonzero_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_math_cd, "%%", rz_exec_cmd_if_core_num_value_nonzero_handler, &exec_cmd_if_core_num_value_nonzero_help);
+	rz_warn_if_fail(exec_cmd_if_core_num_value_nonzero_cd);
+
 	RzCmdDesc *calculate_string_length_cd = rz_cmd_desc_argv_state_new(core->rcmd, cmd_math_cd, "%l", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_QUIET, rz_calculate_string_length_handler, &calculate_string_length_help);
 	rz_warn_if_fail(calculate_string_length_cd);
 
@@ -18528,9 +18531,6 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *get_addr_references_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_math_cd, "%w", rz_get_addr_references_handler, &get_addr_references_help);
 	rz_warn_if_fail(get_addr_references_cd);
-
-	RzCmdDesc *exec_cmd_if_core_num_value_positive2_cd = rz_cmd_desc_argv_new(core->rcmd, cmd_math_cd, "%%", rz_exec_cmd_if_core_num_value_positive2_handler, &exec_cmd_if_core_num_value_positive2_help);
-	rz_warn_if_fail(exec_cmd_if_core_num_value_positive2_cd);
 
 	RzCmdDesc *push_escaped_cd = rz_cmd_desc_argv_new(core->rcmd, root_cd, "<", rz_push_escaped_handler, &push_escaped_help);
 	rz_warn_if_fail(push_escaped_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -141,6 +141,8 @@ RZ_IPI RzCmdStatus rz_exec_cmd_if_core_num_value_positive_handler(RzCore *core, 
 RZ_IPI RzCmdStatus rz_exec_cmd_if_core_num_value_negative_handler(RzCore *core, int argc, const char **argv);
 // "%!"
 RZ_IPI RzCmdStatus rz_exec_cmd_if_core_num_value_zero_handler(RzCore *core, int argc, const char **argv);
+// "%%"
+RZ_IPI RzCmdStatus rz_exec_cmd_if_core_num_value_nonzero_handler(RzCore *core, int argc, const char **argv);
 // "%l"
 RZ_IPI RzCmdStatus rz_calculate_string_length_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "%X"
@@ -175,8 +177,6 @@ RZ_IPI RzCmdStatus rz_input_msg_handler(RzCore *core, int argc, const char **arg
 RZ_IPI RzCmdStatus rz_input_conditional_handler(RzCore *core, int argc, const char **argv);
 // "%w"
 RZ_IPI RzCmdStatus rz_get_addr_references_handler(RzCore *core, int argc, const char **argv);
-// "%%"
-RZ_IPI RzCmdStatus rz_exec_cmd_if_core_num_value_positive2_handler(RzCore *core, int argc, const char **argv);
 // "<"
 RZ_IPI RzCmdStatus rz_push_escaped_handler(RzCore *core, int argc, const char **argv);
 // "aa"

--- a/librz/core/cmd_descs/cmd_math.yaml
+++ b/librz/core/cmd_descs/cmd_math.yaml
@@ -279,6 +279,12 @@ commands:
     args:
       - name: cmd
         type: RZ_CMD_ARG_TYPE_CMD
+  - name: "%%"
+    summary: Execute command if result of last numeric expression evaluation (related) command was not 0
+    cname: exec_cmd_if_core_num_value_nonzero
+    args:
+      - name: cmd
+        type: RZ_CMD_ARG_TYPE_CMD
   - name: "%l"
     summary: Calculate length of string. Quite mode stores value in `$?` register.
     cname: calculate_string_length
@@ -399,9 +405,3 @@ commands:
     args:
       - name: addr
         type: RZ_CMD_ARG_TYPE_RZNUM
-  - name: "%%"
-    summary: Execute command if $? register holds positive value
-    cname: exec_cmd_if_core_num_value_positive2
-    args:
-      - name: cmd
-        type: RZ_CMD_ARG_TYPE_CMD

--- a/librz/core/tui/modes.h
+++ b/librz/core/tui/modes.h
@@ -7,8 +7,8 @@
 #define NPF  5
 #define PIDX (RZ_ABS(((RzCoreVisual *)core->visual)->printidx % NPF))
 
-#define CMD_REGISTERS      "?== true `e cfg.debug`; ?! dr=; ?? ar=" // select dr= or ar= depending on cfg.debug
-#define CMD_REGISTERS_REFS "?== true `e cfg.debug`; ?! drr; ?? arr" // select drr or arr depending on cfg.debug
+#define CMD_REGISTERS      "%== true `e cfg.debug`; %! dr=; %% ar=" // select dr= or ar= depending on cfg.debug
+#define CMD_REGISTERS_REFS "%== true `e cfg.debug`; %! drr; %% arr" // select drr or arr depending on cfg.debug
 
 extern const char *printfmtSingle[NPF];
 extern const char *printfmtColumns[NPF];

--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -3716,7 +3716,7 @@ RZ_IPI int rz_core_visual(RzCore *core, const char *input) {
 
 			if (cmdvhex && *cmdvhex) {
 				rz_strf(debugstr,
-					"?0 ; f+ tmp ; sr %s @e: cfg.seek.silent=true ; %s ; ?1 ; %s ; ?1 ; "
+					"%%0 ; f+ tmp ; sr %s @e: cfg.seek.silent=true ; %s ; %%1 ; %s ; %%1 ; "
 					"s tmp @e: cfg.seek.silent=true ; f- tmp ; pd $r",
 					reg, cmdvhex,
 					ref ? CMD_REGISTERS_REFS : CMD_REGISTERS);
@@ -3726,9 +3726,9 @@ RZ_IPI int rz_core_visual(RzCore *core, const char *input) {
 				const char sign = (delta < 0) ? '+' : '-';
 				const int absdelta = RZ_ABS(delta);
 				rz_strf(debugstr,
-					"diq ; ?0 ; f+ tmp ; sr %s @e: cfg.seek.silent=true ; %s %d @ $$%c%d;"
-					"?1 ; %s;"
-					"?1 ; s tmp @e: cfg.seek.silent=true ; f- tmp ; afal ; pd $r",
+					"diq ; %%0 ; f+ tmp ; sr %s @e: cfg.seek.silent=true ; %s %d @ $$%c%d;"
+					"%%1 ; %s;"
+					"%%1 ; s tmp @e: cfg.seek.silent=true ; f- tmp ; afal ; pd $r",
 					reg, pxa ? "pxa" : pxw, size, sign, absdelta,
 					ref ? CMD_REGISTERS_REFS : CMD_REGISTERS);
 			}


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fix visual debug view:
Regression from https://github.com/rizinorg/rizin/commit/16e722cffcaf49c3fec4243477e7aba24a7ea6e6:
Visual debug (Vpp) was empty because of broken commands.
While fixing this I also noticed that the help for `%%` was suboptimal:

Correct help for %% command:
The term "positive" is less meaningful for %% as it is dealing only with
unsigned values. It belongs to $! and uses the exact opposite condition,
which is the value being non-zero.

**Test plan**

`rz -c 'Vp'` should display a little hexdump, registers and disassembly
