### PR TITLE
Revert "Add float to raw bitvector conversion. (#3509)"

### DIFF
--- a/librz/il/il_export.c
+++ b/librz/il/il_export.c
@@ -1384,8 +1384,6 @@ RZ_API RZ_NONNULL const char *rz_il_op_pure_code_stringify(RzILOpPureCode code) 
 		return "fcast_int";
 	case RZ_IL_OP_FCAST_SINT:
 		return "fcast_sint";
-	case RZ_IL_OP_FCAST_RAW:
-		return "fcast_raw";
 	case RZ_IL_OP_FCAST_FLOAT:
 		return "fcast_float";
 	case RZ_IL_OP_FCAST_SFLOAT:

--- a/librz/il/il_opcodes.c
+++ b/librz/il/il_opcodes.c
@@ -873,13 +873,6 @@ RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_fcast_sint(ut32 length, RzFloatRMode
 	return ret;
 }
 
-RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_fcast_raw(RZ_NONNULL RzILOpFloat *f) {
-	rz_return_val_if_fail(f, NULL);
-	RzILOpBitVector *ret;
-	rz_il_op_new_1(BitVector, RZ_IL_OP_FCAST_RAW, RzILOpArgsFCastraw, fcast_raw, f);
-	return ret;
-}
-
 RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_fcast_float(RzFloatFormat format, RzFloatRMode mode, RZ_NONNULL RzILOpBitVector *bv) {
 	rz_return_val_if_fail(bv, NULL);
 	RzILOpFloat *ret;
@@ -1230,9 +1223,6 @@ RZ_API RzILOpPure *rz_il_op_pure_dup(RZ_NONNULL RzILOpPure *op) {
 		CONST_CP2(fcast_sint, length, mode);
 		DUP_OP1(fcast_sint, f);
 		break;
-	case RZ_IL_OP_FCAST_RAW:
-		DUP_OP1(fcast_raw, f);
-		break;
 	case RZ_IL_OP_FCAST_FLOAT:
 		CONST_CP2(fcast_float, format, mode);
 		DUP_OP1(fcast_float, bv);
@@ -1455,11 +1445,6 @@ RZ_API void rz_il_op_pure_free(RZ_NULLABLE RzILOpPure *op) {
 		break;
 	case RZ_IL_OP_FCAST_INT:
 	case RZ_IL_OP_FCAST_SINT:
-		rz_il_op_free_1(pure, fcast_sint, f);
-		break;
-	case RZ_IL_OP_FCAST_RAW:
-		rz_il_op_free_1(pure, fcast_raw, f);
-		break;
 	case RZ_IL_OP_FCONVERT:
 		rz_il_op_free_1(pure, fconvert, f);
 		break;

--- a/librz/il/il_validate.c
+++ b/librz/il/il_validate.c
@@ -584,16 +584,6 @@ VALIDATOR_PURE(fcast_to_int) {
 	return true;
 }
 
-VALIDATOR_PURE(fcast_to_raw) {
-	RzILOpArgsFbits *args = &op->op.fbits;
-	RzILSortPure sort;
-
-	VALIDATOR_DESCEND(args->f, &sort);
-	VALIDATOR_ASSERT(sort.type == RZ_IL_TYPE_PURE_FLOAT, "operand of %s op is not a float.\n", rz_il_op_pure_code_stringify(op->code));
-	*sort_out = rz_il_sort_pure_bv(rz_float_get_format_info(sort.props.f.format, RZ_FLOAT_INFO_TOTAL_LEN));
-	return true;
-}
-
 VALIDATOR_PURE(icast_to_float) {
 	RzILOpArgsFCastfloat *args = &op->op.fcast_float;
 	RzILSortPure sort;
@@ -791,7 +781,6 @@ static ValidatePureFn validate_pure_table[RZ_IL_OP_PURE_MAX] = {
 	[RZ_IL_OP_FMAD] = VALIDATOR_PURE_NAME(float_terop_with_round),
 	[RZ_IL_OP_FCAST_INT] = VALIDATOR_PURE_NAME(fcast_to_int),
 	[RZ_IL_OP_FCAST_SINT] = VALIDATOR_PURE_NAME(fcast_to_int),
-	[RZ_IL_OP_FCAST_RAW] = VALIDATOR_PURE_NAME(fcast_to_raw),
 	[RZ_IL_OP_FCAST_FLOAT] = VALIDATOR_PURE_NAME(icast_to_float),
 	[RZ_IL_OP_FCAST_SFLOAT] = VALIDATOR_PURE_NAME(icast_to_float),
 	[RZ_IL_OP_FCONVERT] = VALIDATOR_PURE_NAME(fconvert),

--- a/librz/il/il_vm_eval.c
+++ b/librz/il/il_vm_eval.c
@@ -72,7 +72,6 @@ void *rz_il_handler_fneg(RzILVM *vm, RzILOpPure *op, RzILTypePure *type);
 void *rz_il_handler_fabs(RzILVM *vm, RzILOpPure *op, RzILTypePure *type);
 void *rz_il_handler_fcast_int(RzILVM *vm, RzILOpPure *op, RzILTypePure *type);
 void *rz_il_handler_fcast_sint(RzILVM *vm, RzILOpPure *op, RzILTypePure *type);
-void *rz_il_handler_fcast_raw(RzILVM *vm, RzILOpPure *op, RzILTypePure *type);
 void *rz_il_handler_fcast_float(RzILVM *vm, RzILOpPure *op, RzILTypePure *type);
 void *rz_il_handler_fcast_sfloat(RzILVM *vm, RzILOpPure *op, RzILTypePure *type);
 void *rz_il_handler_fconvert(RzILVM *vm, RzILOpPure *op, RzILTypePure *type);
@@ -162,7 +161,6 @@ RZ_IPI RzILOpPureHandler rz_il_op_handler_pure_table_default[RZ_IL_OP_PURE_MAX] 
 
 	[RZ_IL_OP_FCAST_INT] = rz_il_handler_fcast_int,
 	[RZ_IL_OP_FCAST_SINT] = rz_il_handler_fcast_sint,
-	[RZ_IL_OP_FCAST_RAW] = rz_il_handler_fcast_raw,
 	[RZ_IL_OP_FCAST_FLOAT] = rz_il_handler_fcast_float,
 	[RZ_IL_OP_FCAST_SFLOAT] = rz_il_handler_fcast_sfloat,
 	[RZ_IL_OP_FCONVERT] = rz_il_handler_fconvert,

--- a/librz/il/theory_fbasic.c
+++ b/librz/il/theory_fbasic.c
@@ -164,19 +164,6 @@ void *rz_il_handler_fcast_sint(RzILVM *vm, RzILOpPure *op, RzILTypePure *type) {
 	return ret;
 }
 
-void *rz_il_handler_fcast_raw(RzILVM *vm, RzILOpPure *op, RzILTypePure *type) {
-	rz_return_val_if_fail(vm && op && type, NULL);
-
-	RzILOpArgsFCastraw cast_raw = op->op.fcast_raw;
-	RzFloat *f = rz_il_evaluate_float(vm, cast_raw.f);
-	RzBitVector *ret = rz_float_to_raw_bitv(f);
-
-	rz_float_free(f);
-
-	*type = RZ_IL_TYPE_PURE_BITVECTOR;
-	return ret;
-}
-
 void *rz_il_handler_fcast_float(RzILVM *vm, RzILOpPure *op, RzILTypePure *type) {
 	rz_return_val_if_fail(vm && op && type, NULL);
 

--- a/librz/include/rz_il/rz_il_opcodes.h
+++ b/librz/include/rz_il/rz_il_opcodes.h
@@ -388,7 +388,6 @@ typedef struct rz_il_op_args_float_unary_t RzILOpArgsFneg;
 typedef struct rz_il_op_args_float_unary_t RzILOpArgsFabs;
 typedef struct rz_il_op_args_float_unary_t RzILOpArgsFsucc;
 typedef struct rz_il_op_args_float_unary_t RzILOpArgsFpred;
-typedef struct rz_il_op_args_float_unary_t RzILOpArgsFCastraw;
 
 /**
  * \brief op structure for cast to bv from float
@@ -568,7 +567,6 @@ typedef enum {
 	RZ_IL_OP_FABS,
 	RZ_IL_OP_FCAST_INT,
 	RZ_IL_OP_FCAST_SINT,
-	RZ_IL_OP_FCAST_RAW,
 	RZ_IL_OP_FCAST_FLOAT,
 	RZ_IL_OP_FCAST_SFLOAT,
 	RZ_IL_OP_FCONVERT,
@@ -659,7 +657,6 @@ struct rz_il_op_pure_t {
 		RzILOpArgsFabs fabs;
 		RzILOpArgsFCastint fcast_int;
 		RzILOpArgsFCastsint fcast_sint;
-		RzILOpArgsFCastraw fcast_raw;
 		RzILOpArgsFCastfloat fcast_float;
 		RzILOpArgsFCastsfloat fcast_sfloat;
 		RzILOpArgsFconvert fconvert;
@@ -750,7 +747,6 @@ RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_fneg(RZ_NONNULL RzILOpFloat *f);
 RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_fabs(RZ_NONNULL RzILOpFloat *f);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_fcast_int(ut32 length, RzFloatRMode mode, RZ_NONNULL RzILOpFloat *f);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_fcast_sint(ut32 length, RzFloatRMode mode, RZ_NONNULL RzILOpFloat *f);
-RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_fcast_raw(RZ_NONNULL RzILOpFloat *x);
 RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_fcast_float(RzFloatFormat format, RzFloatRMode mode, RZ_NONNULL RzILOpBitVector *bv);
 RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_fcast_sfloat(RzFloatFormat format, RzFloatRMode mode, RZ_NONNULL RzILOpBitVector *bv);
 RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_fconvert(RzFloatFormat format, RzFloatRMode mode, RZ_NONNULL RzILOpFloat *f);

--- a/librz/include/rz_util/rz_float.h
+++ b/librz/include/rz_util/rz_float.h
@@ -177,6 +177,4 @@ RZ_API RZ_OWN RzFloat *rz_float_cast_sfloat(RZ_NONNULL RzBitVector *bv, RzFloatF
 RZ_API RZ_OWN RzBitVector *rz_float_cast_int(RZ_NONNULL RzFloat *f, ut32 length, RzFloatRMode mode);
 RZ_API RZ_OWN RzBitVector *rz_float_cast_sint(RZ_NONNULL RzFloat *f, ut32 length, RzFloatRMode mode);
 RZ_API RZ_OWN RzFloat *rz_float_convert(RZ_NONNULL RzFloat *f, RzFloatFormat format, RzFloatRMode mode);
-
-RZ_API RZ_OWN RzBitVector *rz_float_to_raw_bitv(RZ_NONNULL RzFloat *f);
 #endif // RZ_FLOAT_H

--- a/librz/util/float/float.c
+++ b/librz/util/float/float.c
@@ -2876,13 +2876,3 @@ RZ_API RZ_OWN RzBitVector *rz_float_round_significant(bool sign, RzBitVector *si
 RZ_API RZ_OWN RzFloat *rz_float_round_bv_and_pack(bool sign, st32 exp, RzBitVector *sig, RzFloatFormat format, RzFloatRMode mode) {
 	return round_float_bv_new(sign, exp, sig, format, format, mode);
 }
-
-/**
- * \brief  Returns a copy of the internal bitvector
- * \param  f float number
- * \return On success a valid pointer, otherwise NULL.
- */
-RZ_API RZ_OWN RzBitVector *rz_float_to_raw_bitv(RZ_NONNULL RzFloat *f) {
-	rz_return_val_if_fail(f, NULL);
-	return rz_bv_dup(f->s);
-}

--- a/test/unit/test_float.c
+++ b/test/unit/test_float.c
@@ -1395,14 +1395,6 @@ bool f32_ieee_cast_test(void) {
 	rz_float_free(old_f);
 	rz_float_free(expect_f);
 	rz_float_free(new_cast);
-
-	// cast float to raw bitv.
-	fval = rz_float_new_from_ut32_as_f32(0xC00007EF);
-	val = rz_float_to_raw_bitv(fval);
-	mu_assert_true(is_equal_bv(fval->s, val), "check if is really a dup");
-	rz_float_free(fval);
-	rz_bv_free(val);
-
 	mu_end;
 }
 


### PR DESCRIPTION
This reverts commit 74c044ad63660e2e2f4406f337ce7445b5c1ed7a.

This is an actual dup of fbits IL instruction.