### PR TITLE
Remove incomplete ESIL support for RSP

### DIFF
--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -418,7 +418,7 @@ a___  32 64      ppc.as      LGPL3   as PPC Assembler (use RZ_PPC_AS environment
 _dAe  32 64      ppc         BSD     Capstone PowerPC disassembler (by pancake)
 _dA_  32         propeller   LGPL3   propeller disassembly plugin
 _dA_  8 16       pyc         LGPL3   PYC disassemble plugin
-_dAe  32         rsp         LGPL3   Reality Signal Processor
+_dA_  32         rsp         LGPL3   Reality Signal Processor
 adAe  32         sh          LGPL3   SuperH-4 CPU (by DMaroo)
 _dA_  8 16       snes        LGPL3   SuperNES CPU
 _dA_  32 64      sparc       BSD     Capstone SPARC disassembler


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Since the ESIL support was too basic, incomplete and useless in this state, just removing it completely, to make the ESIL->RzIL migration easier: https://github.com/rizinorg/rizin/issues/2080

RSP architecture instruction set:
- https://www.retroreversing.com/n64rsp
- https://bukosek.si/hardware/collection/sgi-o2/n64-rsp-programmers-guide.pdf
- [n64-rsp-programmers-guide.pdf](https://github.com/rizinorg/rizin/files/11571226/n64-rsp-programmers-guide.pdf)

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/2080
