### PR TITLE
Fix oob write in dyldcache accel loading

### DIFF
--- a/librz/bin/format/mach0/dyldcache.c
+++ b/librz/bin/format/mach0/dyldcache.c
@@ -572,6 +572,10 @@ static RzList /*<RzDyldBinImage *>*/ *create_cache_bins(RzDyldCache *cache) {
 							break;
 						}
 						ut16 dep_index = dep_array[k] & 0x7fff;
+						if (dep_index >= cache->hdr->imagesCount) {
+							RZ_LOG_ERROR("dyldcache: depList contents overflow\n");
+							break;
+						}
 						deps[dep_index]++;
 
 						char *dep_name = get_lib_name(cache->buf, &img[dep_index]);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The bin is copyrighted, but the fix is quite obvious. The length of the deps array is `cache->hdr->imagesCount`.