### PR TITLE
Fix endian in Mach-O CPU_TYPE_ARM64 reading

### DIFF
--- a/librz/bin/format/mach0/mach0_specs.h
+++ b/librz/bin/format/mach0/mach0_specs.h
@@ -187,6 +187,7 @@ struct arm_thread_state64 {
 	ut64 sp;
 	ut64 pc;
 	ut32 cpsr;
+	ut32 flags;
 };
 
 typedef struct {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The 34Li1i format was wrong (using big endian) and not fitting the structure. Other changes are related cleanups.

**Test plan**

Test case is in the private test repo because of copyrighted binaries.
