### PR TITLE
Modify capitalize flag to make entire OP uppercase ##disasm

### DIFF
--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -2642,7 +2642,10 @@ static int ds_disassemble(RzDisasmState *ds, ut8 *buf, int len) {
 		rz_str_case(rz_asm_op_get_asm(&ds->asmop), 1);
 	} else if (ds->capitalize) {
 		char *ba = rz_asm_op_get_asm(&ds->asmop);
-		*ba = toupper((ut8)*ba);
+		while(*ba >= 'a' && *ba <= 'z') {
+			*ba = toupper((ut8)*ba);
+			ba++;
+		}
 	}
 	if (meta && meta_size != UT64_MAX) {
 		ds->oplen = meta_size;

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -2642,10 +2642,7 @@ static int ds_disassemble(RzDisasmState *ds, ut8 *buf, int len) {
 		rz_str_case(rz_asm_op_get_asm(&ds->asmop), 1);
 	} else if (ds->capitalize) {
 		char *ba = rz_asm_op_get_asm(&ds->asmop);
-		while(*ba >= 'a' && *ba <= 'z') {
-			*ba = toupper((ut8)*ba);
-			ba++;
-		}
+		rz_str_case(ba, true);
 	}
 	if (meta && meta_size != UT64_MAX) {
 		ds->oplen = meta_size;


### PR DESCRIPTION
# SQUASH ME

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

`asm.capitalize` only capitalizes the first letter of assembly instruction printout. Using all caps is more common. This PR changes the `disasm.c` file to capitalize the full assembly language operation, instead of just the first letter.

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Here is an example of the previous behavior:

```
[0x100003a38]> pd 10
            ;-- main:
            ;-- entry0:
            ;-- func.100003a38:
            0x100003a38      7f2303d5       pacibsp
            0x100003a3c      fc6fbaa9       stp   x28, x27, [sp, -0x60]!
            0x100003a40      fa6701a9       stp   x26, x25, [sp, 0x10]
            0x100003a44      f85f02a9       stp   x24, x23, [sp, 0x20]
            0x100003a48      f65703a9       stp   x22, x21, [sp, 0x30]
            0x100003a4c      f44f04a9       stp   x20, x19, [sp, 0x40]
            0x100003a50      fd7b05a9       stp   x29, x30, [sp, 0x50]
            0x100003a54      fd430191       add   x29, sp, 0x50
            0x100003a58      ff0319d1       sub   sp, sp, 0x640
            0x100003a5c      f30301aa       mov   x19, x1
[0x100003a38]> e asm.capitalize=true
[0x100003a38]> pd 10
            ;-- main:
            ;-- entry0:
            ;-- func.100003a38:
            0x100003a38      7f2303d5       Pacibsp
            0x100003a3c      fc6fbaa9       Stp   x28, x27, [sp, -0x60]!
            0x100003a40      fa6701a9       Stp   x26, x25, [sp, 0x10]
            0x100003a44      f85f02a9       Stp   x24, x23, [sp, 0x20]
            0x100003a48      f65703a9       Stp   x22, x21, [sp, 0x30]
            0x100003a4c      f44f04a9       Stp   x20, x19, [sp, 0x40]
            0x100003a50      fd7b05a9       Stp   x29, x30, [sp, 0x50]
            0x100003a54      fd430191       Add   x29, sp, 0x50
            0x100003a58      ff0319d1       Sub   sp, sp, 0x640
            0x100003a5c      f30301aa       Mov   x19, x1
```

And after changes:

```
[0x000067d0]> pd 10
            ;-- entry0:
            0x000067d0      endbr64
            0x000067d4      xor   ebp, ebp
            0x000067d6      mov   r9, rdx
            0x000067d9      pop   rsi
            0x000067da      mov   rdx, rsp
            0x000067dd      and   rsp, 0xfffffffffffffff0
            0x000067e1      push  rax
            0x000067e2      push  rsp
            0x000067e3      lea   r8, [0x00017550]
            0x000067ea      lea   rcx, [0x000174e0]
[0x000067d0]> e asm.capitalize=true
[0x000067d0]> pd 10
            ;-- entry0:
            0x000067d0      ENDBR64
            0x000067d4      XOR   ebp, ebp
            0x000067d6      MOV   r9, rdx
            0x000067d9      POP   rsi
            0x000067da      MOV   rdx, rsp
            0x000067dd      AND   rsp, 0xfffffffffffffff0
            0x000067e1      PUSH  rax
            0x000067e2      PUSH  rsp
            0x000067e3      LEA   r8, [0x00017550]
            0x000067ea      LEA   rcx, [0x000174e0]
```

I have not made any tests. This change is small and is easy to check visually.

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

I haven't made changes to docs / rizin book yet, because I want to see if my changes are accepted first. 

closes #3545 

...
