### PR TITLE
Rename `separator_get_first` and `word_get_first` ##refactor

### DIFF
--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -155,7 +155,7 @@ static inline const char *rz_str_word_get_next0(const char *str) {
 	return str + strlen(str) + 1;
 }
 RZ_API const char *rz_str_word_get0(const char *str, int idx);
-RZ_API char *rz_str_word_get_first(const char *string);
+RZ_API char *rz_str_skip_separator_chars(const char *string);
 RZ_API void rz_str_trim(RZ_NONNULL RZ_INOUT char *str);
 RZ_API void rz_str_trim_char(RZ_NONNULL RZ_INOUT char *str, const char c);
 RZ_API char *rz_str_trim_dup(const char *str);

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -155,7 +155,7 @@ static inline const char *rz_str_word_get_next0(const char *str) {
 	return str + strlen(str) + 1;
 }
 RZ_API const char *rz_str_word_get0(const char *str, int idx);
-RZ_API char *rz_str_skip_separator_chars(const char *string);
+RZ_API RZ_OWN char *rz_str_skip_separator_chars(const char *string);
 RZ_API void rz_str_trim(RZ_NONNULL RZ_INOUT char *str);
 RZ_API void rz_str_trim_char(RZ_NONNULL RZ_INOUT char *str, const char c);
 RZ_API char *rz_str_trim_dup(const char *str);

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -155,7 +155,7 @@ static inline const char *rz_str_word_get_next0(const char *str) {
 	return str + strlen(str) + 1;
 }
 RZ_API const char *rz_str_word_get0(const char *str, int idx);
-RZ_API RZ_OWN char *rz_str_skip_separator_chars(const char *string);
+RZ_API RZ_OWN char *rz_str_skip_separator_chars(RZ_NONNULL const char *string);
 RZ_API void rz_str_trim(RZ_NONNULL RZ_INOUT char *str);
 RZ_API void rz_str_trim_char(RZ_NONNULL RZ_INOUT char *str, const char c);
 RZ_API char *rz_str_trim_dup(const char *str);

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -637,7 +637,7 @@ static const char *skip_separator_chars(const char *text) {
  *
  * This function iterates through the given string and skips over any separator characters until it reaches the first non-separator character.
  */
-RZ_API char *rz_str_skip_separator_chars(const char *text) {
+RZ_API RZ_OWN char *rz_str_skip_separator_chars(const char *text) {
 	return strdup(skip_separator_chars(text));
 }
 

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -618,7 +618,7 @@ RZ_API int rz_str_char_count(const char *string, char ch) {
 	return count;
 }
 
-static const char *separator_get_first(const char *text) {
+static const char *skip_non_separator_chars(const char *text) {
 	for (; *text && !IS_SEPARATOR(*text); text++)
 		;
 	;
@@ -626,7 +626,7 @@ static const char *separator_get_first(const char *text) {
 	return text;
 }
 
-static const char *word_get_first(const char *text) {
+static const char *skip_separator_chars(const char *text) {
 	for (; *text && IS_SEPARATOR(*text); text++)
 		;
 	;
@@ -634,19 +634,19 @@ static const char *word_get_first(const char *text) {
 	return text;
 }
 
-RZ_API char *rz_str_word_get_first(const char *text) {
-	return strdup(word_get_first(text));
+RZ_API char *rz_str_skip_separator_chars(const char *text) {
+	return strdup(skip_separator_chars(text));
 }
 
 // Counts the number of words (separated by separator characters: newlines, tabs,
 // return, space). See rz_util.h for more details of the IS_SEPARATOR macro.
 RZ_API int rz_str_word_count(const char *string) {
 	int word;
-	const char *text = word_get_first(string);
+	const char *text = skip_separator_chars(string);
 
 	for (word = 0; *text; word++) {
-		text = separator_get_first(text);
-		text = word_get_first(text);
+		text = skip_non_separator_chars(text);
+		text = skip_separator_chars(text);
 	}
 
 	return word;

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -620,14 +620,16 @@ RZ_API int rz_str_char_count(const char *string, char ch) {
 
 static const char *skip_non_separator_chars(const char *text) {
 	rz_return_val_if_fail(text, NULL);
-	for (; *text && !IS_SEPARATOR(*text); text++);
+	for (; *text && !IS_SEPARATOR(*text); text++)
+		;
 
 	return text;
 }
 
 static const char *skip_separator_chars(const char *text) {
 	rz_return_val_if_fail(text, NULL);
-	for (; *text && IS_SEPARATOR(*text); text++);
+	for (; *text && IS_SEPARATOR(*text); text++)
+		;
 
 	return text;
 }

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -634,6 +634,13 @@ static const char *skip_separator_chars(const char *text) {
 	return text;
 }
 
+/**
+ * \brief Skips over separator characters and moves to the first non-separator character in the string.
+ * \param text The string to process.
+ * \return A pointer to the first non-separator character in the string.
+ *
+ * This function iterates through the given string and skips over any separator characters until it reaches the first non-separator character.
+ */
 RZ_API char *rz_str_skip_separator_chars(const char *text) {
 	return strdup(skip_separator_chars(text));
 }

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -619,6 +619,7 @@ RZ_API int rz_str_char_count(const char *string, char ch) {
 }
 
 static const char *skip_non_separator_chars(const char *text) {
+	rz_return_val_if_fail(text, NULL);
 	for (; *text && !IS_SEPARATOR(*text); text++);
 
 	return text;

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -619,9 +619,7 @@ RZ_API int rz_str_char_count(const char *string, char ch) {
 }
 
 static const char *skip_non_separator_chars(const char *text) {
-	for (; *text && !IS_SEPARATOR(*text); text++)
-		;
-	;
+	for (; *text && !IS_SEPARATOR(*text); text++);
 
 	return text;
 }

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -627,9 +627,7 @@ static const char *skip_non_separator_chars(const char *text) {
 }
 
 static const char *skip_separator_chars(const char *text) {
-	for (; *text && IS_SEPARATOR(*text); text++)
-		;
-	;
+	for (; *text && IS_SEPARATOR(*text); text++);
 
 	return text;
 }

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -625,6 +625,7 @@ static const char *skip_non_separator_chars(const char *text) {
 }
 
 static const char *skip_separator_chars(const char *text) {
+	rz_return_val_if_fail(text, NULL);
 	for (; *text && IS_SEPARATOR(*text); text++);
 
 	return text;
@@ -637,7 +638,8 @@ static const char *skip_separator_chars(const char *text) {
  *
  * This function iterates through the given string and skips over any separator characters until it reaches the first non-separator character.
  */
-RZ_API RZ_OWN char *rz_str_skip_separator_chars(const char *text) {
+RZ_API RZ_OWN char *rz_str_skip_separator_chars(RZ_NONNULL const char *text) {
+	rz_return_val_if_fail(text, NULL);
 	return strdup(skip_separator_chars(text));
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.

**Detailed description**
This merge request addresses an issue where the function `rz_word_get_first` was misleadingly named, causing confusion about its actual functionality. Initially, I mistakenly believed that this function would return the first word of a string. However, upon closer inspection, I discovered that the function's purpose was to skip over separator characters and move to the first non-separator character in the string. To rectify this confusion and improve code clarity, the function has been renamed to `skip_separator_chars`. I also proceeded to rename its counterpart function, `separator_get_first`, to `skip_non_separator_chars`.

**Test plan**
I have not made any tests being just a refactor.

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->