### PR TITLE
Fix arguments alignment in PYC disassembler

### DIFF
--- a/librz/asm/arch/pyc/pyc_dis.c
+++ b/librz/asm/arch/pyc/pyc_dis.c
@@ -48,7 +48,7 @@ int rz_pyc_disasm(RzAsmOp *opstruct, const ut8 *code, RzList /*<pyc_code_object 
 			}
 			const char *arg = parse_arg(&ops->opcodes[op], oparg, names, consts, varnames, freevars, cellvars, ops->opcode_arg_fmt);
 			if (arg != NULL) {
-				rz_strbuf_appendf(&opstruct->buf_asm, "%20s", arg);
+				rz_strbuf_setf(&opstruct->buf_asm, "%-22s%s", name, arg);
 				free((char *)arg);
 			}
 		} else if (ops->bits == 8) {

--- a/test/db/formats/pyc
+++ b/test/db/formats/pyc
@@ -173,17 +173,17 @@ EXPECT=<<EOF
             ;-- entry0:
             ;-- section.module:
             ;-- <module>:
-            0x0000002e      LOAD_CONST Multiline strings can be written
+            0x0000002e      LOAD_CONST             Multiline strings can be written
     using three "s, and are often used
     as documentation. ; [00] ---- section size 3248 named module
-            0x00000030      STORE_NAME             __doc__
-            0x00000032      LOAD_CONST                True
-        ,=< 0x00000034      JUMP_IF_FALSE_OR_POP                  10
-        |   0x00000036      LOAD_CONST               False
+            0x00000030      STORE_NAME            __doc__
+            0x00000032      LOAD_CONST            True
+        ,=< 0x00000034      JUMP_IF_FALSE_OR_POP  10
+        |   0x00000036      LOAD_CONST            False
         `-> 0x00000038      POP_TOP
-            0x0000003a      LOAD_CONST               False
-        ,=< 0x0000003c      JUMP_IF_TRUE_OR_POP                  18
-        |   0x0000003e      LOAD_CONST                True
+            0x0000003a      LOAD_CONST            False
+        ,=< 0x0000003c      JUMP_IF_TRUE_OR_POP   18
+        |   0x0000003e      LOAD_CONST            True
         `-> 0x00000040      POP_TOP
 EOF
 REGEXP_FILTER_ERR=<<EOF
@@ -203,17 +203,17 @@ EXPECT=<<EOF
             ;-- entry0:
             ;-- section.module:
             ;-- <module>:
-            0x0000002a      LOAD_CONST Multiline strings can be written
+            0x0000002a      LOAD_CONST             Multiline strings can be written
     using three "s, and are often used
     as documentation. ; [00] ---- section size 3218 named module
-            0x0000002c      STORE_NAME             __doc__
-            0x0000002e      LOAD_CONST                True
-        ,=< 0x00000030      JUMP_IF_FALSE_OR_POP                  10
-        |   0x00000032      LOAD_CONST               False
+            0x0000002c      STORE_NAME            __doc__
+            0x0000002e      LOAD_CONST            True
+        ,=< 0x00000030      JUMP_IF_FALSE_OR_POP  10
+        |   0x00000032      LOAD_CONST            False
         `-> 0x00000034      POP_TOP
-            0x00000036      LOAD_CONST               False
-        ,=< 0x00000038      JUMP_IF_TRUE_OR_POP                  18
-        |   0x0000003a      LOAD_CONST                True
+            0x00000036      LOAD_CONST            False
+        ,=< 0x00000038      JUMP_IF_TRUE_OR_POP   18
+        |   0x0000003a      LOAD_CONST            True
         `-> 0x0000003c      POP_TOP
 EOF
 REGEXP_FILTER_ERR=<<EOF
@@ -249,16 +249,16 @@ EXPECT=<<EOF
             ;-- entry0:
             ;-- section.module:
             ;-- <module>:
-            0x0000001e      LOAD_CONSTCodeObject(hello_world) from hello.py ; [00] ---- section size 25 named module
+            0x0000001e      LOAD_CONST            CodeObject(hello_world) from hello.py ; [00] ---- section size 25 named module
             0x00000021      MAKE_FUNCTION
-            0x00000024      STORE_NAME         hello_world
-            0x00000027      LOAD_CONST             'world'
+            0x00000024      STORE_NAME            hello_world
+            0x00000027      LOAD_CONST            'world'
             0x0000002a      PRINT_ITEM
             0x0000002b      PRINT_NEWLINE
-            0x0000002c      LOAD_NAME         hello_world
-            0x0000002f      CALL_FUNCTION0 positional, 0 named
+            0x0000002c      LOAD_NAME             hello_world
+            0x0000002f      CALL_FUNCTION         0 positional, 0 named
             0x00000032      POP_TOP
-            0x00000033      LOAD_CONST                None
+            0x00000033      LOAD_CONST            None
 EOF
 REGEXP_FILTER_ERR=<<EOF
 free_object\ \(0\)
@@ -279,16 +279,16 @@ EXPECT=<<EOF
             ;-- section.module:
             ;-- <module>:
 / entry0();
-|           0x0000001e      LOAD_CONSTCodeObject(hello_world) from hello.py ; [00] ---- section size 25 named module
+|           0x0000001e      LOAD_CONST            CodeObject(hello_world) from hello.py ; [00] ---- section size 25 named module
 |           0x00000021      MAKE_FUNCTION
-|           0x00000024      STORE_NAME         hello_world
-|           0x00000027      LOAD_CONST             'world'
+|           0x00000024      STORE_NAME            hello_world
+|           0x00000027      LOAD_CONST            'world'
 |           0x0000002a      PRINT_ITEM
 |           0x0000002b      PRINT_NEWLINE
-|           0x0000002c      LOAD_NAME         hello_world
-|           0x0000002f      CALL_FUNCTION0 positional, 0 named
+|           0x0000002c      LOAD_NAME             hello_world
+|           0x0000002f      CALL_FUNCTION         0 positional, 0 named
 |           0x00000032      POP_TOP
-|           0x00000033      LOAD_CONST                None
+|           0x00000033      LOAD_CONST            None
 \           0x00000036      RETURN_VALUE
 EOF
 REGEXP_FILTER_ERR=<<EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Hi!
This is a one-line modification that fixes the alignment of arguments in the pyc disassembler.
I also updated the relevant tests.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Just open a pyc, and run "pd".
After this PR the arguments are aligned.

---
Thanks,
Luca