### PR TITLE
Fix forder return type and add feq macro

### DIFF
--- a/librz/il/il_opcodes.c
+++ b/librz/il/il_opcodes.c
@@ -914,7 +914,7 @@ RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_fpred(RZ_NONNULL RzILOpFloat *f) {
 	return ret;
 }
 
-RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_forder(RZ_NONNULL RzILOpFloat *x, RZ_NONNULL RzILOpFloat *y) {
+RZ_API RZ_OWN RzILOpBool *rz_il_op_new_forder(RZ_NONNULL RzILOpFloat *x, RZ_NONNULL RzILOpFloat *y) {
 	rz_return_val_if_fail(x && y, NULL);
 	RzILOpFloat *ret;
 	rz_il_op_new_2(Float, RZ_IL_OP_FORDER, RzILOpArgsForder, forder, x, y);

--- a/librz/include/rz_il/rz_il_opbuilder_begin.h
+++ b/librz/include/rz_il/rz_il_opbuilder_begin.h
@@ -85,6 +85,7 @@
 #define FMOD(rmode, flx, fly)      rz_il_op_new_fdiv(rmode, flx, fly)
 #define FPOW(rmode, flx, fly)      rz_il_op_new_fpow(rmode, flx, fly)
 #define FMAD(rmode, flx, fly, flz) rz_il_op_new_fmad(rmode, flx, fly, flz)
+#define FEQ(flx, fly)              NOT(OR(FORDER(x, y), FORDER(y, x)))
 
 #define IL_FALSE  rz_il_op_new_b0()
 #define IL_TRUE   rz_il_op_new_b1()

--- a/librz/include/rz_il/rz_il_opbuilder_end.h
+++ b/librz/include/rz_il/rz_il_opbuilder_end.h
@@ -53,6 +53,7 @@
 #undef FMOD
 #undef FPOW
 #undef FMAD
+#undef FEQ
 
 #undef IL_FALSE
 #undef IL_TRUE

--- a/librz/include/rz_il/rz_il_opcodes.h
+++ b/librz/include/rz_il/rz_il_opcodes.h
@@ -753,7 +753,7 @@ RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_fconvert(RzFloatFormat format, RzFloatRM
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_frequal(RzFloatRMode x, RzFloatRMode y);
 RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_fsucc(RZ_NONNULL RzILOpFloat *f);
 RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_fpred(RZ_NONNULL RzILOpFloat *f);
-RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_forder(RZ_NONNULL RzILOpFloat *x, RZ_NONNULL RzILOpFloat *y);
+RZ_API RZ_OWN RzILOpBool *rz_il_op_new_forder(RZ_NONNULL RzILOpFloat *x, RZ_NONNULL RzILOpFloat *y);
 RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_fround(RzFloatRMode rmode, RZ_NONNULL RzILOpFloat *f);
 RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_fsqrt(RzFloatRMode rmode, RZ_NONNULL RzILOpFloat *f);
 RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_frsqrt(RzFloatRMode rmode, RZ_NONNULL RzILOpFloat *f);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

1. fix return type of  `forder` operation in RzIL (`RzILOpFloat` -> `RzILOpBool`)
2. add `FEQ` macros

**Test plan**


**Closing issues**
