### PR TITLE
pyc: inizialize 'error' before calling 'magic_int_within'

### DIFF
--- a/librz/bin/p/bin_pyc.c
+++ b/librz/bin/p/bin_pyc.c
@@ -98,7 +98,7 @@ static RzBinInfo *info(RzBinFile *arch) {
 		return NULL;
 	}
 
-	bool error;
+	bool error = false;
 	bool is_before_py_36 = magic_int_within(ctx->version.magic, 0x9494, 0x0d16, &error);
 	if (error) {
 		return NULL;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The `error` variable was not inizialized before calling `magic_int_within`.
This should fix the regressions pointed out in #3577.


