### PR TITLE
Prefer BE in strings search when it is known

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -65,6 +65,7 @@ static bool find_string_at(RzCore *core, RzBinObject *bobj, ut64 pointer, char *
 	RzBin *bin = core->bin;
 	ut8 buffer[512] = { 0 };
 	bool ret = false;
+	bool big_endian = core->analysis->big_endian;
 	RzDetectedString *detected = NULL;
 
 	RzList *strings = rz_list_newf((RzListFree)rz_detected_string_free);
@@ -82,7 +83,7 @@ static bool find_string_at(RzCore *core, RzBinObject *bobj, ut64 pointer, char *
 		.buf_size = sizeof(buffer),
 		.max_uni_blocks = 4,
 		.min_str_length = min_str_length,
-		.prefer_big_endian = false,
+		.prefer_big_endian = big_endian,
 		.check_ascii_freq = bin->strseach_check_ascii_freq,
 	};
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

In some cases string search should prefer big endian when it's known from the binary loaded.

**Test plan**

CI is green