### PR TITLE
Make rz-pipe tests invariant to local user config

### DIFF
--- a/test/scripts/get-funcs.py
+++ b/test/scripts/get-funcs.py
@@ -1,6 +1,6 @@
 import rzpipe
 
-rzp = rzpipe.open()
+rzp = rzpipe.open(flags=["-N"])
 rzp.cmd("aa")
 print("\nFunction names:")
 for func in rzp.cmdj("aflj"):

--- a/test/scripts/shared_memory.py
+++ b/test/scripts/shared_memory.py
@@ -18,7 +18,7 @@ for fname in FILENAMES:
         print("Shared buffer size 0x{0:x}".format(data_size))
         print("-------------")
 
-        rzp = rzpipe.open("shm://{0:s}/{1:d}".format(shm.name, data_size))
+        rzp = rzpipe.open("shm://{0:s}/{1:d}".format(shm.name, data_size), flags=["-N"])
         rzp.cmd("e scr.color=0")
         rzp.cmd("e scr.utf8=false")
         rzp.cmd("e scr.interactive=false")


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

My rizinrc has `e asm.bytes=1` and this broke these tests