### PR TITLE
Add len check in esil code before calling rz_analysis_op

### DIFF
--- a/librz/analysis/op.c
+++ b/librz/analysis/op.c
@@ -94,9 +94,9 @@ static int defaultCycles(RzAnalysisOp *op) {
 }
 
 RZ_API int rz_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *data, int len, RzAnalysisOpMask mask) {
-	rz_analysis_op_init(op);
 	rz_return_val_if_fail(analysis && op && len > 0, -1);
 
+	rz_analysis_op_init(op);
 	int ret = RZ_MIN(2, len);
 	if (len > 0 && analysis->cur && analysis->cur->op) {
 		// use core binding to set asm.bits correctly based on the addr

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -3425,6 +3425,9 @@ RZ_API void rz_core_analysis_esil(RzCore *core, ut64 addr, ut64 size, RZ_NULLABL
 
 		rz_analysis_op_fini(&op);
 		rz_asm_set_pc(core->rasm, cur);
+		if (i >= iend) {
+			goto repeat;
+		}
 		rz_analysis_op(core->analysis, &op, cur, buf + i, iend - i, RZ_ANALYSIS_OP_MASK_ESIL | RZ_ANALYSIS_OP_MASK_VAL | RZ_ANALYSIS_OP_MASK_HINT);
 		// if (op.type & 0x80000000 || op.type == 0) {
 		if (op.type == RZ_ANALYSIS_OP_TYPE_ILL || op.type == RZ_ANALYSIS_OP_TYPE_UNK) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Seems that esil code doesn't check if the length is valid (i.e. > 0) of the buffer, thus hitting some asserts.