### PR TITLE
fix the realloc mistake

### DIFF
--- a/subprojects/mpc/mpc.c
+++ b/subprojects/mpc/mpc.c
@@ -1650,20 +1650,27 @@ mpc_parser_t *mpc_failf(const char *fmt, ...) {
   char *buffer;
 
   mpc_parser_t *p = mpc_undefined();
+  if (!p) {
+    return NULL;
+  }
   p->type = MPC_TYPE_FAIL;
 
   va_start(va, fmt);
   buffer = malloc(2048);
   if (!buffer) {
+    mpc_delete(p);
     return NULL;
   }
   vsprintf(buffer, fmt, va);
   va_end(va);
 
   buffer = realloc(buffer, strlen(buffer) + 1);
+  if (!buffer) {
+    mpc_delete(p);
+    return NULL;
+  }
   p->data.fail.m = buffer;
   return p;
-
 }
 
 mpc_parser_t *mpc_lift_val(mpc_val_t *x) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

'buffer' nulled but not freed upon failure