### PR TITLE
Fix il vm aezi and aezs sync behavior

### DIFF
--- a/librz/core/cil.c
+++ b/librz/core/cil.c
@@ -436,6 +436,9 @@ RZ_IPI void rz_core_analysis_il_reinit(RzCore *core) {
 		// initialize the program counter with the current offset
 		rz_reg_set_value_by_role(core->analysis->reg, RZ_REG_NAME_PC, core->offset);
 		rz_core_reg_update_flags(core);
+
+		// sync back to il vm
+		rz_analysis_il_vm_sync_from_reg(core->analysis->il_vm, core->analysis->reg);
 	}
 }
 
@@ -483,6 +486,7 @@ RZ_IPI bool rz_core_analysis_il_vm_set(RzCore *core, const char *var_name, ut64 
 	}
 	if (val) {
 		rz_il_vm_set_global_var(vm->vm, var_name, val);
+		rz_analysis_il_vm_sync_to_reg(vm, core->analysis->reg);
 	}
 	return true;
 }

--- a/librz/il/il_validate.c
+++ b/librz/il/il_validate.c
@@ -602,7 +602,7 @@ VALIDATOR_PURE(fconvert) {
 	VALIDATOR_DESCEND(args->f, &sort);
 	VALIDATOR_ASSERT(sort.type == RZ_IL_TYPE_PURE_FLOAT, "operand of %s op is not a float.\n", rz_il_op_pure_code_stringify(op->code));
 
-	*sort_out = sort;
+	*sort_out = rz_il_sort_pure_float(args->format);
 	return true;
 }
 

--- a/librz/include/rz_il/rz_il_opbuilder_begin.h
+++ b/librz/include/rz_il/rz_il_opbuilder_begin.h
@@ -87,8 +87,6 @@
 #define FMOD(rmode, flx, fly)      rz_il_op_new_fdiv(rmode, flx, fly)
 #define FPOW(rmode, flx, fly)      rz_il_op_new_fpow(rmode, flx, fly)
 #define FMAD(rmode, flx, fly, flz) rz_il_op_new_fmad(rmode, flx, fly, flz)
-#define FNEQ(flx, fly)             OR(FORDER(flx, fly), FORDER(DUP(flx), DUP(fly)))
-#define FEQ(flx, fly)              NOT(FNEQ(flx, fly))
 
 #define IL_FALSE  rz_il_op_new_b0()
 #define IL_TRUE   rz_il_op_new_b1()
@@ -96,6 +94,9 @@
 #define XOR(x, y) rz_il_op_new_bool_xor(x, y)
 #define AND(x, y) rz_il_op_new_bool_and(x, y)
 #define OR(x, y)  rz_il_op_new_bool_or(x, y)
+
+#define FNEQ(flx, fly) OR(FORDER(flx, fly), FORDER(DUP(flx), DUP(fly)))
+#define FEQ(flx, fly)  INV(FNEQ(flx, fly))
 
 #define UNSIGNED(n, x)    rz_il_op_new_unsigned(n, x)
 #define SIGNED(n, x)      rz_il_op_new_signed(n, x)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

1. issue about reg sync 
found aezv [reg] [value] command change the value of register, but those changes would be discard after aezs, I guess it's not the expected behavior. 

that's due to the reg sync, aezv modifies the value of il_vm, but didn't sync back to rz_reg
 the il_vm_step work as follows :
```C
sync_il_reg_from_rz_reg();
evaluate_il()
sync_il_reg_to_rz_reg();
```
if we don't sync those changes to `rz_reg`, `il_vm` will load unchanged reg value from `rz_reg` first when execute `aezs`

- also, sync PC with il_vm in vm initialization, which makes aezv print correct PC value after aezi cmd.

2. Fix a bug in validation
3. Fix a bug of rzil float macro, use `INV` instead of `NOT` 
...

**Test plan**

...

**Closing issues**

...
