### PR TITLE
Refine MACH0_(imports_count)()

### DIFF
--- a/librz/bin/format/mach0/mach0.c
+++ b/librz/bin/format/mach0/mach0.c
@@ -2749,8 +2749,12 @@ void MACH0_(imports_foreach)(struct MACH0_(obj_t) * bin, mach0_import_foreach_cb
  */
 size_t MACH0_(imports_count)(struct MACH0_(obj_t) * bin) {
 	if (MACH0_(has_chained_fixups)(bin)) {
-		return MACH0_(chained_imports_count)(bin) + bin->dysymtab.nundefsym;
+		return MACH0_(chained_imports_count)(bin);
 	} else {
+		if (bin->dysymtab.nundefsym > bin->nsymtab) {
+			RZ_LOG_ERROR("Invalid nundefsym value in LC_DYSYMTAB");
+			return 0;
+		}
 		return bin->dysymtab.nundefsym;
 	}
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

For chained imports, we do not parse undefined symbols, so the upper bound can be reduced there.
For non-chained imports, we can check for a definitely invalid value using nsyms from LC_SYMTAB.

**Test plan**

current tests should still pass, including fuzz tests