### PR TITLE
Remove typelink remnants

### DIFF
--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -500,7 +500,6 @@ typedef struct rz_analysis_t {
 	RzIntervalTree meta;
 	RzSpaces meta_spaces;
 	RzTypeDB *typedb; // Types management
-	HtUP *type_links; // Type links to the memory address or register
 	Sdb *sdb_cc; // calling conventions
 	Sdb *sdb_classes;
 	Sdb *sdb_classes_attrs;
@@ -1724,14 +1723,6 @@ RZ_API bool rz_analysis_var_global_rename(RzAnalysis *analysis, RZ_NONNULL const
 RZ_API void rz_analysis_var_global_set_type(RzAnalysisVarGlobal *glob, RZ_NONNULL RZ_BORROW RzType *type);
 RZ_API void rz_analysis_var_global_add_constraint(RzAnalysisVarGlobal *glob, RzTypeConstraint *constraint);
 RZ_API RZ_OWN char *rz_analysis_var_global_get_constraints_readable(RzAnalysisVarGlobal *glob);
-
-// Maintaining type links
-RZ_API bool rz_analysis_type_link_exists(RzAnalysis *analysis, ut64 addr);
-RZ_API RZ_BORROW RzType *rz_analysis_type_link_at(RzAnalysis *analysis, ut64 addr);
-RZ_API bool rz_analysis_type_set_link(RzAnalysis *analysis, RZ_OWN RzType *type, ut64 addr);
-RZ_API bool rz_analysis_type_unlink(RzAnalysis *analysis, ut64 addr);
-RZ_API bool rz_analysis_type_unlink_all(RzAnalysis *analysis);
-RZ_API RZ_OWN RzList /*<RzType *>*/ *rz_analysis_type_links(RzAnalysis *analysis);
 RZ_API RZ_OWN RzList /*<RzTypePathTuple *>*/ *rz_analysis_type_paths_by_address(RzAnalysis *analysis, ut64 addr);
 
 /* project */


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Should fix this:
```
Run echo "import rizin" > testimport.py
Traceback (most recent call last):
  File "/home/runner/work/rizin/rizin/testimport.py", line 1, in <module>
    import rizin
  File "/usr/lib/python3/dist-packages/rizin.py", line 1[5](https://github.com/rizinorg/rizin/actions/runs/5446563067/jobs/9907861971?pr=3634#step:9:6), in <module>
    import _rizin
ImportError: /usr/lib/python3/dist-packages/_rizin.cpython-310-x8[6](https://github.com/rizinorg/rizin/actions/runs/5446563067/jobs/9907861971?pr=3634#step:9:7)_64-linux-gnu.so: undefined symbol: rz_analysis_type_link_at
Error: Process completed with exit code 1.
```

https://github.com/rizinorg/rizin/actions/runs/5446563067/jobs/9907861971?pr=3634

**Test plan**

CI is green
