### PR TITLE
Remove typelink remnants

### DIFF
--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -93,9 +93,6 @@ RZ_IPI void rz_core_types_function_noreturn_print(RzCore *core, RzOutputMode mod
 RZ_IPI void rz_core_types_show_format(RzCore *core, const char *name, RzOutputMode mode);
 RZ_IPI void rz_core_types_struct_print_format_all(RzCore *core);
 RZ_IPI void rz_core_types_union_print_format_all(RzCore *core);
-RZ_IPI void rz_core_types_link_print(RzCore *core, RzType *type, ut64 addr, RzOutputMode mode, PJ *pj);
-RZ_IPI void rz_core_types_link_print_all(RzCore *core, RzOutputMode mode);
-RZ_IPI void rz_core_types_link_show(RzCore *core, ut64 addr);
 RZ_IPI void rz_core_types_print_all(RzCore *core, RzOutputMode mode);
 RZ_IPI void rz_types_define(RzCore *core, const char *type);
 RZ_IPI bool rz_types_open_file(RzCore *core, const char *path);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -497,7 +497,6 @@ RZ_API bool rz_core_analysis_objc_refs(RzCore *core, bool auto_analysis);
 RZ_API void rz_core_analysis_objc_stubs(RzCore *core);
 RZ_API void rz_core_analysis_cc_init(RzCore *core);
 RZ_API void rz_core_analysis_paths(RzCore *core, ut64 from, ut64 to, bool followCalls, int followDepth, bool is_json);
-RZ_API void rz_core_types_link(RzCore *core, const char *typestr, ut64 addr);
 RZ_API RZ_OWN char *rz_core_types_as_c(RZ_NONNULL RzCore *core, RZ_NONNULL const char *name, bool multiline);
 RZ_API RZ_OWN char *rz_core_types_as_c_all(RZ_NONNULL RzCore *core, bool multiline);
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Should fix the following `rz-bindgen` error:
```
 [3/4] Compiling C++ object _rizin.cp38-win_amd64.pyd.p/meson-generated_.._rizin_wrap.cxx.obj
    rizin_wrap.cxx: In function 'PyObject* _wrap_RzBuffer_fwd_scan(PyObject*, PyObject*)':
    rizin_wrap.cxx:76586:3: warning: NULL used in arithmetic [-Wpointer-arith]
       SWIG_contract_assert((result!=NULL), "Contract violation: require: (result!=NULL)");
       ^~~~~~~~~~~~~~~~~~~~
    [4/4] Linking target _rizin.cp38-win_amd64.pyd
    FAILED: _rizin.cp38-win_amd64.pyd
    "c++"  -o _rizin.cp38-win_amd64.pyd _rizin.cp38-win_amd64.pyd.p/meson-generated_.._rizin_wrap.cxx.obj "-Wl,--allow-shlib-undefined" "-Wl,-O1" "-shared" "-Wl,--start-group" "-Wl,--out-implib=_rizin.cp38-win_amd64.dll.a" "C:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\nuget-cpython\python.3.8.10\tools\python38.dll" "C:rizin/lib/rz_analysis.lib" "C:rizin/lib/rz_asm.lib" "C:rizin/lib/rz_bin.lib" "C:rizin/lib/rz_bp.lib" "C:rizin/lib/rz_config.lib" "C:rizin/lib/rz_cons.lib" "C:rizin/lib/rz_core.lib" "C:rizin/lib/rz_crypto.lib" "C:rizin/lib/rz_debug.lib" "C:rizin/lib/rz_demangler.lib" "C:rizin/lib/rz_diff.lib" "C:rizin/lib/rz_egg.lib" "C:rizin/lib/rz_flag.lib" "C:rizin/lib/rz_hash.lib" "C:rizin/lib/rz_il.lib" "C:rizin/lib/rz_io.lib" "C:rizin/lib/rz_lang.lib" "C:rizin/lib/rz_magic.lib" "C:rizin/lib/rz_parse.lib" "C:rizin/lib/rz_reg.lib" "C:rizin/lib/rz_search.lib" "C:rizin/lib/rz_sign.lib" "C:rizin/lib/rz_socket.lib" "C:rizin/lib/rz_syscall.lib" "C:rizin/lib/rz_type.lib" "C:rizin/lib/rz_util.lib" "-lkernel32" "-luser32" "-lgdi32" "-lwinspool" "-lshell32" "-lole32" "-loleaut32" "-luuid" "-lcomdlg32" "-ladvapi32" "-Wl,--end-group"
    _rizin.cp38-win_amd64.pyd.p/meson-generated_.._rizin_wrap.cxx.obj:rizin_wrap.cxx:(.text+0xbc1ff): undefined reference to `rz_core_types_link'
    collect2.exe: error: ld returned 1 exit status
    ninja: build stopped: subcommand failed.
```

