### PR TITLE
Fix ESIL issues: Shift by register, double word store

### DIFF
--- a/librz/analysis/arch/arm/arm_accessors32.h
+++ b/librz/analysis/arch/arm/arm_accessors32.h
@@ -28,12 +28,12 @@
 #define LSHIFT(x)  0
 #define LSHIFT2(x) 0
 #endif
-#define OPCOUNT()     insn->detail->arm.op_count
-#define ISSHIFTED(x)  (insn->detail->arm.operands[x].shift.type != ARM_SFT_INVALID && insn->detail->arm.operands[x].shift.value != 0)
-#define SHIFTTYPE(x)  insn->detail->arm.operands[x].shift.type
+#define OPCOUNT()       insn->detail->arm.op_count
+#define ISSHIFTED(x)    (insn->detail->arm.operands[x].shift.type != ARM_SFT_INVALID && insn->detail->arm.operands[x].shift.value != 0)
+#define SHIFTTYPE(x)    insn->detail->arm.operands[x].shift.type
 #define SHIFTTYPEREG(x) (SHIFTTYPE(x) == ARM_SFT_ASR_REG || SHIFTTYPE(x) == ARM_SFT_LSL_REG || \
-                         SHIFTTYPE(x) == ARM_SFT_LSR_REG || SHIFTTYPE(x) == ARM_SFT_ROR_REG || \
-                         SHIFTTYPE(x) == ARM_SFT_RRX_REG)
+	SHIFTTYPE(x) == ARM_SFT_LSR_REG || SHIFTTYPE(x) == ARM_SFT_ROR_REG || \
+	SHIFTTYPE(x) == ARM_SFT_RRX_REG)
 #define SHIFTVALUE(x) insn->detail->arm.operands[x].shift.value
 
 #define ISWRITEBACK32() insn->detail->arm.writeback

--- a/librz/analysis/arch/arm/arm_accessors32.h
+++ b/librz/analysis/arch/arm/arm_accessors32.h
@@ -31,6 +31,9 @@
 #define OPCOUNT()     insn->detail->arm.op_count
 #define ISSHIFTED(x)  (insn->detail->arm.operands[x].shift.type != ARM_SFT_INVALID && insn->detail->arm.operands[x].shift.value != 0)
 #define SHIFTTYPE(x)  insn->detail->arm.operands[x].shift.type
+#define SHIFTTYPEREG(x) (SHIFTTYPE(x) == ARM_SFT_ASR_REG || SHIFTTYPE(x) == ARM_SFT_LSL_REG || \
+                         SHIFTTYPE(x) == ARM_SFT_LSR_REG || SHIFTTYPE(x) == ARM_SFT_ROR_REG || \
+                         SHIFTTYPE(x) == ARM_SFT_RRX_REG)
 #define SHIFTVALUE(x) insn->detail->arm.operands[x].shift.value
 
 #define ISWRITEBACK32() insn->detail->arm.writeback

--- a/librz/analysis/arch/arm/arm_esil32.c
+++ b/librz/analysis/arch/arm/arm_esil32.c
@@ -659,11 +659,11 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 					if (ISSHIFTED(2)) {
 						// it seems strd does not support SHIFT which is good, but have a check nonetheless
 					} else {
-						r_strbuf_appendf(&op->esil, "%s,%s,+,0xffffffff,&,=[4],%s,4,%s,+,0xffffffff,&,=[4]",
+						rz_strbuf_appendf(&op->esil, "%s,%s,+,0xffffffff,&,=[4],%s,4,%s,+,0xffffffff,&,=[4]",
 							REG(0), MEMBASE(2), REG(1), MEMBASE(2));
 						if (insn->detail->arm.writeback) {
 							const char sign = ISMEMINDEXSUB(2) ? '-' : '+';
-							r_strbuf_appendf(&op->esil, ",%s,%s,%c=",
+							rz_strbuf_appendf(&op->esil, ",%s,%s,%c=",
 								MEMINDEX(2), MEMBASE(2), sign);
 						}
 					}

--- a/librz/analysis/arch/arm/arm_esil32.c
+++ b/librz/analysis/arch/arm/arm_esil32.c
@@ -138,11 +138,19 @@ static const char *arg(RzAnalysis *a, csh *handle, cs_insn *insn, char *buf, int
 	switch (insn->detail->arm.operands[n].type) {
 	case ARM_OP_REG:
 		if (ISSHIFTED(n)) {
-			sprintf(buf, "%u,%s,%s",
-				LSHIFT2(n),
-				rz_str_get_null(cs_reg_name(*handle,
-					insn->detail->arm.operands[n].reg)),
-				DECODE_SHIFT(n));
+			if (SHIFTTYPEREG(n)) {
+				sprintf(buf, "%s,%s,%s",
+					cs_reg_name(*handle, LSHIFT2(n)),
+					rz_str_get_null(cs_reg_name(*handle,
+						insn->detail->arm.operands[n].reg)),
+					DECODE_SHIFT(n));
+			} else {
+				sprintf(buf, "%u,%s,%s",
+					LSHIFT2(n),
+					rz_str_get_null(cs_reg_name(*handle,
+						insn->detail->arm.operands[n].reg)),
+					DECODE_SHIFT(n));
+			}
 		} else {
 			sprintf(buf, "%s",
 				rz_str_get_null(cs_reg_name(*handle,

--- a/librz/analysis/arch/arm/arm_esil32.c
+++ b/librz/analysis/arch/arm/arm_esil32.c
@@ -610,11 +610,10 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 			}
 		}
 		if (OPCOUNT() == 3) { // e.g. 'str r2, [r3], 4
-			if (ISIMM(2)) { // e.g. 'str r2, [r3], 4
+			if (ISIMM(2) && str_ldr_bytes != 8) { // e.g. 'str r2, [r3], 4
 				rz_strbuf_appendf(&op->esil, "%s,%s,0xffffffff,&,=[%d],%d,%s,+=",
 					REG(0), MEMBASE(1), str_ldr_bytes, IMM(2), MEMBASE(1));
-			}
-			if (ISREG(2)) { // e.g. 'str r2, [r3], r1
+			} else if (str_ldr_bytes != 8) {
 				if (ISSHIFTED(2)) { // e.g. 'str r2, [r3], r1, lsl 4'
 					switch (SHIFTTYPE(2)) {
 					case ARM_SFT_LSL:
@@ -660,11 +659,12 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 					if (ISSHIFTED(2)) {
 						// it seems strd does not support SHIFT which is good, but have a check nonetheless
 					} else {
-						rz_strbuf_appendf(&op->esil, "%s,%s,%s,+,0xffffffff,&,=[4],%s,4,%s,+,%s,+,0xffffffff,&,=[4]",
-							REG(0), MEMINDEX(2), MEMBASE(2), REG(1), MEMINDEX(2), MEMBASE(2));
+						r_strbuf_appendf(&op->esil, "%s,%s,+,0xffffffff,&,=[4],%s,4,%s,+,0xffffffff,&,=[4]",
+							REG(0), MEMBASE(2), REG(1), MEMBASE(2));
 						if (insn->detail->arm.writeback) {
-							rz_strbuf_appendf(&op->esil, ",%s,%s,+,%s,=",
-								MEMINDEX(2), MEMBASE(2), MEMBASE(2));
+							const char sign = ISMEMINDEXSUB(2) ? '-' : '+';
+							r_strbuf_appendf(&op->esil, ",%s,%s,%c=",
+								MEMINDEX(2), MEMBASE(2), sign);
 						}
 					}
 				}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes:
- Shifting by register. Now shifts by actual register value. Not by its id.
- `strd`. `disp` gets subtracted or added depending on sign. And only four bytes are loaded for each reg.

**Test plan**

All green

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
