### PR TITLE
Fix capstone v3 support

### DIFF
--- a/librz/analysis/p/analysis_sparc_cs.c
+++ b/librz/analysis/p/analysis_sparc_cs.c
@@ -6,10 +6,6 @@
 #include <capstone/capstone.h>
 #include <capstone/sparc.h>
 
-#if CS_API_MAJOR < 2
-#error Old Capstone not supported
-#endif
-
 #define INSOP(n) insn->detail->sparc.operands[n]
 #define INSCC    insn->detail->sparc.cc
 

--- a/librz/analysis/p/analysis_sysz.c
+++ b/librz/analysis/p/analysis_sysz.c
@@ -7,10 +7,6 @@
 #include <capstone/systemz.h>
 // instruction set: http://www.tachyonsoft.com/inst390m.htm
 
-#if CS_API_MAJOR < 2
-#error Old Capstone not supported
-#endif
-
 #define INSOP(n) insn->detail->sysz.operands[n]
 
 static void opex(RzStrBuf *buf, csh handle, cs_insn *insn) {

--- a/librz/analysis/p/analysis_tms320c64x.c
+++ b/librz/analysis/p/analysis_tms320c64x.c
@@ -12,11 +12,6 @@
 #warning Cannot find capstone-tms320c64x support
 #endif
 
-#if CS_API_MAJOR < 2
-#undef CAPSONT_HAS_TMS320C64X
-#define CAPSTONE_HAS_TMS320C64X 0
-#endif
-
 #if CAPSTONE_HAS_TMS320C64X
 
 #define INSOP(n) insn->detail->tms320c64x.operands[n]

--- a/librz/analysis/p/analysis_x86_cs.c
+++ b/librz/analysis/p/analysis_x86_cs.c
@@ -28,10 +28,6 @@ call = 4
 #define HAVE_CSGRP_PRIVILEGE 0
 #endif
 
-#if CS_API_MAJOR < 2
-#error Old Capstone not supported
-#endif
-
 #define opexprintf(op, fmt, ...) rz_strbuf_setf(&op->opex, fmt, ##__VA_ARGS__)
 #define INSOP(n)                 insn->detail->x86.operands[n]
 #define INSOPS                   insn->detail->x86.op_count

--- a/librz/analysis/p/analysis_xcore_cs.c
+++ b/librz/analysis/p/analysis_xcore_cs.c
@@ -6,10 +6,6 @@
 #include <capstone/capstone.h>
 #include <capstone/xcore.h>
 
-#if CS_API_MAJOR < 2
-#error Old Capstone not supported
-#endif
-
 #define INSOP(n) insn->detail->xcore.operands[n]
 
 static void opex(RzStrBuf *buf, csh handle, cs_insn *insn) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Remove the CS 2 and CS 1 support ifdefs (v3 is the oldest version we support now anyway, and it will fail to be built with CS 2, for example)

Fix the compilation problem on capstone v3 CI job:
```
../librz/analysis/arch/arm/arm_il32.c: In function ‘vmov’:
../librz/analysis/arch/arm/arm_il32.c:236:62: error: ‘cs_arm_op’ has no member named ‘neon_lane’
  236 | #define NEON_LANE(n)            insn->detail->arm.operands[n].neon_lane
      |                                                              ^
../librz/analysis/arch/arm/arm_il32.c:2653:13: note: in expansion of macro ‘NEON_LANE’
 2653 |         if (NEON_LANE(0) != -1 && !is_core_reg(REGID(0)) && is_core_reg(REGID(1))) {
      |             ^~~~~~~~~
../librz/analysis/arch/arm/arm_il32.c:236:62: error: ‘cs_arm_op’ has no member named ‘neon_lane’
  236 | #define NEON_LANE(n)            insn->detail->arm.operands[n].neon_lane
      |                                                              ^
../librz/analysis/arch/arm/arm_il32.c:2656:41: note: in expansion of macro ‘NEON_LANE’
 2656 |                 if (!VVEC_SIZE(insn) || NEON_LANE(0) == -1) {
      |                                         ^~~~~~~~~
../librz/analysis/arch/arm/arm_il32.c:236:62: error: ‘cs_arm_op’ has no member named ‘neon_lane’
  236 | #define NEON_LANE(n)            insn->detail->arm.operands[n].neon_lane
      |                                                              ^
../librz/analysis/arch/arm/arm_il32.c:2660:49: note: in expansion of macro ‘NEON_LANE’
 2660 |                 return write_reg_lane(REGID(0), NEON_LANE(0), VVEC_SIZE(insn), rt_val);
      |                                                 ^~~~~~~~~
../librz/analysis/arch/arm/arm_il32.c:236:62: error: ‘cs_arm_op’ has no member named ‘neon_lane’
  236 | #define NEON_LANE(n)            insn->detail->arm.operands[n].neon_lane
      |                                                              ^
../librz/analysis/arch/arm/arm_il32.c:2664:13: note: in expansion of macro ‘NEON_LANE’
 2664 |         if (NEON_LANE(1) != -1 && !is_core_reg(REGID(1)) && is_core_reg(REGID(0))) {
      |             ^~~~~~~~~
../librz/analysis/arch/arm/arm_il32.c:236:62: error: ‘cs_arm_op’ has no member named ‘neon_lane’
  236 | #define NEON_LANE(n)            insn->detail->arm.operands[n].neon_lane
      |                                                              ^
../librz/analysis/arch/arm/arm_il32.c:2675:69: note: in expansion of macro ‘NEON_LANE’
 2675 |                 RzILOpBitVector *lane_val = read_reg_lane(REGID(1), NEON_LANE(1), DT_WIDTH(insn));
      |                                                                     ^~~~~~~~~
../librz/analysis/arch/arm/arm_il32.c: In function ‘vldn_single_lane’:
../librz/analysis/arch/arm/arm_il32.c:236:62: error: ‘cs_arm_op’ has no member named ‘neon_lane’
  236 | #define NEON_LANE(n)            insn->detail->arm.operands[n].neon_lane
      |                                                              ^
../librz/analysis/arch/arm/arm_il32.c:3109:30: note: in expansion of macro ‘NEON_LANE’
 3109 |         unsigned char lane = NEON_LANE(0);
      |                              ^~~~~~~~~
../librz/analysis/arch/arm/arm_il32.c: In function ‘vldn’:
../librz/analysis/arch/arm/arm_il32.c:236:62: error: ‘cs_arm_op’ has no member named ‘neon_lane’
  236 | #define NEON_LANE(n)            insn->detail->arm.operands[n].neon_lane
      |                                                              ^
../librz/analysis/arch/arm/arm_il32.c:3254:13: note: in expansion of macro ‘NEON_LANE’
 3254 |         if (NEON_LANE(0) != -1) {
      |             ^~~~~~~~~
../librz/analysis/arch/arm/arm_il32.c: In function ‘vstn_from_single_lane’:
../librz/analysis/arch/arm/arm_il32.c:236:62: error: ‘cs_arm_op’ has no member named ‘neon_lane’
  236 | #define NEON_LANE(n)            insn->detail->arm.operands[n].neon_lane
      |                                                              ^
../librz/analysis/arch/arm/arm_il32.c:3389:30: note: in expansion of macro ‘NEON_LANE’
 3389 |         unsigned char lane = NEON_LANE(0);
      |                              ^~~~~~~~~
../librz/analysis/arch/arm/arm_il32.c: In function ‘vstn’:
../librz/analysis/arch/arm/arm_il32.c:236:62: error: ‘cs_arm_op’ has no member named ‘neon_lane’
  236 | #define NEON_LANE(n)            insn->detail->arm.operands[n].neon_lane
      |                                                              ^
../librz/analysis/arch/arm/arm_il32.c:3447:13: note: in expansion of macro ‘NEON_LANE’
 3447 |         if (NEON_LANE(0) != -1) {
      |             ^~~~~~~~~
../librz/analysis/arch/arm/arm_il32.c: In function ‘vdup’:
../librz/analysis/arch/arm/arm_il32.c:236:62: error: ‘cs_arm_op’ has no member named ‘neon_lane’
  236 | #define NEON_LANE(n)            insn->detail->arm.operands[n].neon_lane
      |                                                              ^
../librz/analysis/arch/arm/arm_il32.c:3612:28: note: in expansion of macro ‘NEON_LANE’
 3612 |         bool is_dup_lane = NEON_LANE(1) == -1;
      |                            ^~~~~~~~~
../librz/analysis/arch/arm/arm_il32.c:236:62: error: ‘cs_arm_op’ has no member named ‘neon_lane’
  236 | #define NEON_LANE(n)            insn->detail->arm.operands[n].neon_lane
      |                                                              ^
../librz/analysis/arch/arm/arm_il32.c:3615:81: note: in expansion of macro ‘NEON_LANE’
 3615 |                 RzILOpBitVector *scalar = is_dup_lane ? read_reg_lane(REGID(1), NEON_LANE(1), elem_bits) : UNSIGNED(elem_bits, REG(1));
      |                                                                                 ^~~~~~~~~
```
See full log at https://github.com/rizinorg/rizin/actions/runs/5495426137/jobs/10014813074

**Test plan**

CI is green