### PR TITLE
Not an error

### DIFF
--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -423,8 +423,7 @@ RZ_API bool rz_core_file_reopen(RzCore *core, const char *args, int perm, int lo
 		rz_core_file_set_by_file(core, file);
 		ofile = NULL;
 		odesc = NULL;
-		//	core->file = file;
-		RZ_LOG_ERROR("File %s reopened in %s mode\n", path,
+		RZ_LOG_WARN("File %s reopened in %s mode\n", path,
 			(perm & RZ_PERM_W) ? "read-write" : "read-only");
 
 		if (loadbin && (loadbin == 2 || had_rbin_info)) {

--- a/test/db/archos/linux-x64/dbg_oo
+++ b/test/db/archos/linux-x64/dbg_oo
@@ -108,7 +108,7 @@ RUN
 
 NAME=ood check for ptrace errors
 FILE=bins/elf/analysis/x86-helloworld-gcc
-ARGS=-e log.level=5
+ARGS=-e log.level=4
 CMDS=<<EOF
 ood
 EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
1. Reopening debugged file with `ood` prints out an error of *ERROR: File xxx reopened in read-write mode*, instead of written as an info with RZ_LOG_INFO:
```shell
$ rizin /bin/ls
 -- Find expanded AES keys in memory with '/ca'
[0x00006ab0]> ood
ERROR: rz-run: invalid hexpair string `0`
Process with PID 5677 started...
ERROR: File dbg:///usr/bin/ls reopened in read-write mode
[0x7f94745a72b0]>
```

2. Running rizin with `-d` **always** outputs an error message of *invalid hexpair string*, also when reopened with `ood` (see number 1 above):
```shell
$ rizin -d /bin/ls
ERROR: rz-run: invalid hexpair string `0`
Process with PID 5606 started...
 -- Temporally drop the verbosity prefixing the commands with ':'
[0x7f46f789a2b0]>
```
My understanding is that `resolve_value()` gets called many times iteratively by other functions, therefore will **always** reach a `src_len`  value of 1.

...  

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
