### PR TITLE
Add support for PT_OPENBSD_NOBTCFI detection

### DIFF
--- a/librz/bin/format/elf/elf.h
+++ b/librz/bin/format/elf/elf.h
@@ -299,6 +299,7 @@ bool Elf_(rz_bin_elf_is_static)(RZ_NONNULL ELFOBJ *bin);
 bool Elf_(rz_bin_elf_is_stripped)(RZ_NONNULL ELFOBJ *bin);
 int Elf_(rz_bin_elf_get_bits)(RZ_NONNULL ELFOBJ *bin);
 int Elf_(rz_bin_elf_has_relro)(RZ_NONNULL ELFOBJ *bin);
+bool Elf_(rz_bin_elf_has_nobtcfi)(RZ_NONNULL ELFOBJ *bin);
 ut64 Elf_(rz_bin_elf_get_baddr)(RZ_NONNULL ELFOBJ *bin);
 ut64 Elf_(rz_bin_elf_get_boffset)(RZ_NONNULL ELFOBJ *bin);
 ut64 Elf_(rz_bin_elf_get_entry_offset)(RZ_NONNULL ELFOBJ *bin);

--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -1765,6 +1765,18 @@ int Elf_(rz_bin_elf_has_relro)(RZ_NONNULL ELFOBJ *bin) {
 }
 
 /**
+ * \brief Analyse if the elf binary was compiled with -Wl,-z,nobtcfi on OpenBSD
+ */
+bool Elf_(rz_bin_elf_has_nobtcfi)(RZ_NONNULL ELFOBJ *bin) {
+	rz_return_val_if_fail(bin, false);
+	if (!Elf_(rz_bin_elf_has_segments)(bin)) {
+		return false;
+	}
+	RzBinElfSegment *segment = Elf_(rz_bin_elf_get_segment_with_type)(bin, PT_OPENBSD_NOBTCFI);
+	return segment && segment->is_valid;
+}
+
+/**
  * \brief Check the binary endianness
  * \param elf type
  * \return is_big_endian ?

--- a/librz/bin/format/elf/elf_specs.h
+++ b/librz/bin/format/elf/elf_specs.h
@@ -208,6 +208,7 @@
 #define PT_OPENBSD_RANDOMIZE 0x65a3dbe6 /* Random data */
 #define PT_OPENBSD_WXNEEDED  0x65a3dbe7 /* Allowing writable/executable mapping */
 #define PT_OPENBSD_BOOTDATA  0x65a41be6 /* Boot time data */
+#define PT_OPENBSD_NOBTCFI   0x65a3dbe8 /* Branch Target Control Flow Integrity opt-out */
 #endif
 
 #endif // _INCLUDE_ELF_SPECS_H

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -1599,6 +1599,9 @@ static RzList /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		case PT_OPENBSD_BOOTDATA:
 			ptr->name = strdup("OPENBSD_BOOTDATA");
 			break;
+		case PT_OPENBSD_NOBTCFI:
+			ptr->name = strdup("OPENBSD_NOBTCFI");
+			break;
 		default:
 			if (ptr->size == 0 && ptr->vsize == 0) {
 				ptr->name = strdup("NONE");
@@ -1869,6 +1872,7 @@ static RzBinInfo *info(RzBinFile *bf) {
 	ret->big_endian = Elf_(rz_bin_elf_is_big_endian)(obj);
 	ret->has_va = Elf_(rz_bin_elf_has_va)(obj);
 	ret->has_nx = Elf_(rz_bin_elf_has_nx)(obj);
+	ret->has_nobtcfi = Elf_(rz_bin_elf_has_nobtcfi)(obj);
 	ret->intrp = Elf_(rz_bin_elf_get_intrp)(obj);
 	ret->compiler = Elf_(rz_bin_elf_get_compiler)(obj);
 	ret->dbg_info = 0;

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -3131,6 +3131,9 @@ RZ_API bool rz_core_bin_info_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile
 		pj_kb(pj, "linenum", RZ_BIN_DBG_LINENUMS & info->dbg_info);
 		pj_kb(pj, "lsyms", RZ_BIN_DBG_SYMS & info->dbg_info);
 		pj_kb(pj, "canary", info->has_canary);
+		if (info->has_nobtcfi) {
+			pj_kb(pj, "nobtcfi", true);
+		}
 		pj_kb(pj, "PIE", info->has_pi);
 		pj_kb(pj, "RELROCS", RZ_BIN_DBG_RELOCS & info->dbg_info);
 		pj_kb(pj, "NX", info->has_nx);
@@ -3235,6 +3238,9 @@ RZ_API bool rz_core_bin_info_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile
 		table_add_row_bool(t, "linenum", RZ_BIN_DBG_LINENUMS & info->dbg_info);
 		table_add_row_bool(t, "lsyms", RZ_BIN_DBG_SYMS & info->dbg_info);
 		table_add_row_bool(t, "canary", info->has_canary);
+		if (info->has_nobtcfi) {
+			table_add_row_bool(t, "nobtcfi", true);
+		}
 		table_add_row_bool(t, "PIE", info->has_pi);
 		table_add_row_bool(t, "RELROCS", RZ_BIN_DBG_RELOCS & info->dbg_info);
 		table_add_row_bool(t, "NX", info->has_nx);

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -234,6 +234,7 @@ typedef struct rz_bin_info_t {
 	int has_sanitizers;
 	int has_crypto;
 	int has_nx;
+	bool has_nobtcfi; ///< OpenBSD, linked with -Wl,-z,nobtcfi to opt-out of IBT/BTI
 	int big_endian;
 	char *actual_checksum;
 	char *claimed_checksum;

--- a/test/db/formats/elf/sections
+++ b/test/db/formats/elf/sections
@@ -182,3 +182,18 @@ EXPECT=<<EOF
 true
 EOF
 RUN
+
+NAME=OpenBSD nobtcfi
+FILE=bins/elf/openbsd-arm64-nobtcfi
+CMDS=<<EOF
+i~^nobtcfi
+ij~{.bin.nobtcfi}
+iSS~OPENBSD
+EOF
+EXPECT=<<EOF
+nobtcfi  true
+true
+0x00000b58 0x30  0x00020b58 0x30  0x8     -rw- OPENBSD_RANDOMIZE
+0x00000000 0x0   0x00000000 0x0   0x0     ---x OPENBSD_NOBTCFI
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

OpenBSD enables arm64 BTI or Intel IBT by default, except when the binary was linked with -Wl,-z,nobtcfi in order to opt-out. In this case, a PT_OPENBSD_NOBTCFI section will exist, which we can indicate in the bin info.
See also https://undeadly.org/cgi?action=article;sid=20230714121907

Original Commit: 4551bf03461595a9645051347ad026974227ac6d

**Test plan**

see the added test