### PR TITLE
LE plugin rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Dalvik, EBC, Java, Lua, Python, WebAssembly, Brainfuck, Malbolge
 
 ## Supported File Formats
 
-ELF, Mach-O, Fatmach-O, PE, PE+, MZ, COFF, OMF, NE, LE, TE, XBE, BIOS/UEFI,
+ELF, Mach-O, Fatmach-O, PE, PE+, MZ, COFF, OMF, NE, LE, LX, TE, XBE, BIOS/UEFI,
 Dyldcache, DEX, ART, CGC, ELF, Java class, Android boot image, Plan9 executable,
 ZIMG, MBN/SBL bootloader, ELF coredump, MDMP (Windows minidump), DMP (Windows pagedump),
 WASM (WebAssembly binary), Commodore VICE emulator, QNX,

--- a/librz/bin/format/le/le.c
+++ b/librz/bin/format/le/le.c
@@ -1,10 +1,56 @@
 // SPDX-FileCopyrightText: 2019 GustavoLCR <gugulcr@gmail.com>
+// SPDX-FileCopyrightText: 2023 svr <svr.work@protonmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
+
+/**
+ * \file le.c
+ * \brief LE/LX/LC binary format plugin.
+ *
+ * The LE and LX are two very similar binary formats. Both acronyms stand for "linear executable".
+ * The bulk of information about formats comes in the form of the LX spec by IBM. It's incomplete
+ * and vague in places, so few open source projects have been used to fill in the blanks. The LC
+ * is a variety of LX and is handled in the same way here.
+ *
+ * The LE format is commonly used for:
+ * - For DOS protected mode software using an extender such as DOS/4GW (most common).
+ * - VxD device drivers by a number of MS and Novel OSes.
+ * - In OS/2 occasionally.
+ *
+ * The LX/LC format is used as a main binary format in OS/2.
+ *
+ * The following sources have been used:
+ *
+ * [1] IBM OS/2 16/32-BIT OBJECT MODULE FORMAT (OMF) AND LINEAR EXECUTABLE MODULE FORMAT (LX) rev10:
+ *     http://www.edm2.com/index.php/IBM_OS/2_16/32-bit_Object_Module_Format_%28OMF%29_and_Linear_eXecutable_Module_Format_%28LX%29
+ *
+ * [2] lxLite LX executable packer:
+ *     https://github.com/bitwiseworks/lxlite/blob/master/src/os2exe.pas
+ *
+ * [3] DOS/32 Advanced DOS Extender unbind utility:
+ *     https://github.com/abbec/dos32a/blob/master/src/sb/sbind.asm
+ **/
 
 #include "le.h"
 #include <rz_bin.h>
+#include <rz_types.h>
+#include <sdbht.h>
 
-const char *le_get_module_type(rz_bin_le_obj_t *bin) {
+#define CHECK(expr) \
+	if (!(expr)) { \
+		goto fail_cleanup; \
+	}
+
+#define CHECK_READ(X, tmp, out) \
+	CHECK(rz_buf_read##X##_offset(buf, offset, &tmp) && *offset <= offset_end) \
+	out = tmp;
+
+#define CHECK_READ8(out)  CHECK_READ(8, tmp8, out)
+#define CHECK_READ16(out) CHECK_READ(_le16, tmp16, out)
+#define CHECK_READ32(out) CHECK_READ(_le32, tmp32, out)
+
+/// --- Auxilliary functions ----------------------------------------------------------------------
+
+static const char *le_get_module_type(rz_bin_le_obj_t *bin) {
 	switch (bin->header->mflags & M_TYPE_MASK) {
 	case M_TYPE_EXE: return "Program module (EXE)";
 	case M_TYPE_DLL: return "Library module (DLL)";
@@ -14,7 +60,7 @@ const char *le_get_module_type(rz_bin_le_obj_t *bin) {
 	}
 }
 
-const char *le_get_os_type(rz_bin_le_obj_t *bin) {
+static const char *le_get_os_type(rz_bin_le_obj_t *bin) {
 	switch (bin->header->os) {
 	case 1: return "OS/2";
 	case 2: return "Windows";
@@ -25,7 +71,7 @@ const char *le_get_os_type(rz_bin_le_obj_t *bin) {
 	}
 }
 
-const char *le_get_cpu_type(rz_bin_le_obj_t *bin) {
+static const char *le_get_cpu_type(rz_bin_le_obj_t *bin) {
 	switch (bin->header->cpu) {
 	case 1: return "80286";
 	case 2: return "80386";
@@ -39,7 +85,7 @@ const char *le_get_cpu_type(rz_bin_le_obj_t *bin) {
 	}
 }
 
-const char *le_get_arch(rz_bin_le_obj_t *bin) {
+static const char *le_get_arch(rz_bin_le_obj_t *bin) {
 	switch (bin->header->cpu) {
 	case 1:
 	case 2:
@@ -57,828 +103,1754 @@ const char *le_get_arch(rz_bin_le_obj_t *bin) {
 	}
 }
 
-static char *le_read_nonnull_str_at(RzBuffer *buf, ut64 *offset) {
-	ut8 size;
-	if (!rz_buf_read8_at(buf, *offset, &size)) {
-		return NULL;
+static bool le_read_len_str_offset(RzBuffer *buf, ut64 *offset, char **out) {
+	*out = NULL;
+	ut8 len;
+	if (!rz_buf_read8_offset(buf, offset, &len)) {
+		return false;
 	}
 
-	size &= 0x7F; // Max is 127
-	if (!size) {
-		return NULL;
+	if (!len) {
+		return true; // success yet *out == NULL, this is why the return value is bool
 	}
-	(*offset)++;
-	char *str = calloc((ut64)size + 1, sizeof(char));
-	rz_buf_read_at(buf, *offset, (ut8 *)str, size);
-	*offset += size;
-	return str;
+
+	ut8 *str = calloc((size_t)len + 1, sizeof(char));
+	if (!str) {
+		return false;
+	}
+	if (!rz_buf_read_offset(buf, offset, str, len)) {
+		free(str);
+		return false;
+	}
+	for (ut8 *s = str; s != str + len; s++) {
+		// non-ascii characters should not appear here
+		if (*s == 0 || *s > 127) {
+			free(str);
+			return false;
+		}
+	}
+	*out = (char *)str;
+	return true;
 }
 
-static RzBinSymbol *le_get_symbol(rz_bin_le_obj_t *bin, ut64 *offset) {
+static ut32 le_reloc_target_offset(ut32 i) {
+	// TODO supposedly i860 / mips binaries exist, will 4 byte alignment suffice?
+	return i * 4;
+}
+
+static ut32 le_reloc_target_vaddr(rz_bin_le_obj_t *bin, ut32 i) {
+	return bin->reloc_target_map_base + le_reloc_target_offset(i);
+}
+
+static ut32 le_reloc_targets_vfile_size(rz_bin_le_obj_t *bin) {
+	return le_reloc_target_offset(bin->reloc_targets_count);
+}
+
+static ut32 le_obj_perm(LE_object *obj) {
+	ut32 perm = 0;
+	perm |= obj->flags & O_READABLE ? RZ_PERM_R : 0;
+	perm |= obj->flags & O_WRITABLE ? RZ_PERM_W : 0;
+	perm |= obj->flags & O_EXECUTABLE ? RZ_PERM_X : 0;
+	return perm;
+}
+
+static ut64 le_vaddr_to_paddr(rz_bin_le_obj_t *bin, ut32 vaddr) {
+	LE_map *m;
+	rz_vector_foreach(bin->le_maps, m) {
+		if (m->vaddr <= vaddr && vaddr <= m->vaddr + m->vsize) {
+			if (vaddr > m->vaddr + m->size) {
+				return 0;
+			} else {
+				return m->paddr + (vaddr - m->vaddr);
+			}
+		}
+	}
+	return 0;
+}
+
+static void le_import_free(LE_import *imp) {
+	if (!imp) {
+		return;
+	}
+	free(imp->proc_name);
+	free(imp);
+}
+
+static ut32 le_import_hash(LE_import *imp) {
+	ut32 ord_mix = (((ut32)imp->mod_ord + 1) << 16) ^ (imp->proc_ord + 1);
+	return sdb_hash(imp->proc_name) ^ ((ord_mix + 1013904223) * 1664525);
+}
+
+static int le_import_cmp(LE_import *a, LE_import *b) {
+	if (a->mod_ord != b->mod_ord) {
+		return a->mod_ord < b->mod_ord ? -1 : 1;
+	}
+	if (a->proc_ord != b->proc_ord) {
+		return a->proc_ord < b->proc_ord ? -1 : 1;
+	}
+	return rz_str_cmp(a->proc_name, b->proc_name, -1);
+}
+
+static void le_free_import_kv(HtPPKv *kv) {
+	le_import_free(kv->key);
+}
+
+static RZ_BORROW RzBinImport *le_add_bin_import(rz_bin_le_obj_t *bin, const LE_import *le_imp) {
+	if (!le_imp) {
+		return NULL;
+	}
+	RzBinImport *import = RZ_NEW0(RzBinImport);
+	if (!import) {
+	fail_cleanup:
+		rz_bin_import_free(import);
+		return NULL;
+	}
+	const char *libname = "";
+	if (le_imp->mod_ord - 1 < rz_pvector_len(bin->imp_mod_names)) {
+		libname = rz_pvector_at(bin->imp_mod_names, le_imp->mod_ord - 1);
+	}
+	if (le_imp->proc_name) {
+		CHECK(import->name = rz_str_newf("%s_%s", libname, le_imp->proc_name));
+	} else {
+		CHECK(import->name = rz_str_newf("%s_%u", libname, le_imp->proc_ord));
+	}
+	import->bind = RZ_BIN_BIND_GLOBAL_STR;
+	import->type = RZ_BIN_TYPE_UNKNOWN_STR;
+	CHECK(rz_list_append(bin->imports, import));
+	import->ordinal = ++bin->reloc_targets_count;
+	return import;
+}
+
+static RZ_BORROW RzBinSymbol *le_add_symbol(rz_bin_le_obj_t *bin, ut32 ordinal, ut32 vaddr) {
 	RzBinSymbol *sym = RZ_NEW0(RzBinSymbol);
 	if (!sym) {
 		return NULL;
 	}
-	char *name = le_read_nonnull_str_at(bin->buf, offset);
-	if (!name) {
+	if (!ordinal) {
+		if (rz_list_empty(bin->symbols)) {
+			ordinal = 1;
+		} else {
+			ordinal = ((RzBinSymbol *)rz_list_tail(bin->symbols)->data)->ordinal + 1;
+		}
+	}
+	if (!rz_list_append(bin->symbols, sym)) {
 		rz_bin_symbol_free(sym);
 		return NULL;
 	}
-	sym->name = name;
-	ut16 entry_idx;
-	if (!rz_buf_read_le16_offset(bin->buf, offset, &entry_idx)) {
-		rz_bin_symbol_free(sym);
-		return NULL;
-	}
-	sym->ordinal = entry_idx;
+	sym->ordinal = ordinal;
+	sym->vaddr = vaddr;
+	sym->paddr = le_vaddr_to_paddr(bin, vaddr);
+	sym->bind = RZ_BIN_BIND_GLOBAL_STR;
+	sym->type = RZ_BIN_TYPE_UNKNOWN_STR;
 	return sym;
 }
 
-static bool read_le_entry_bundle_entry(RzBuffer *buf, ut64 addr, LE_entry_bundle_entry *e, LE_entry_bundle_type type) {
-	ut64 offset = addr;
-	switch (type) {
-	case ENTRY16:
-		return rz_buf_read8_offset(buf, &offset, &e->entry_16.flags) &&
-			rz_buf_read_le16_offset(buf, &offset, &e->entry_16.offset);
-	case CALLGATE:
-		return rz_buf_read8_offset(buf, &offset, &e->callgate.flags) &&
-			rz_buf_read_le16_offset(buf, &offset, &e->callgate.offset) &&
-			rz_buf_read_le16_offset(buf, &offset, &e->callgate.callgate_sel);
-	case ENTRY32:
-		return rz_buf_read8_offset(buf, &offset, &e->entry_32.flags) &&
-			rz_buf_read_le32_offset(buf, &offset, &e->entry_32.offset);
-	case FORWARDER:
-		return rz_buf_read8_offset(buf, &offset, &e->forwarder.flags) &&
-			rz_buf_read_le16_offset(buf, &offset, &e->forwarder.import_ord) &&
-			rz_buf_read_le32_offset(buf, &offset, &e->forwarder.offset);
-	default:
-		memset(e, 0, sizeof(LE_entry_bundle_entry));
-		return false;
-	}
-}
+static RZ_BORROW LE_import *le_add_import(rz_bin_le_obj_t *bin,
+	ut16 mod_ord, bool proc_by_ord, ut32 proc, ut32 sym_ord) {
 
-RzList /*<char *>*/ *le_get_entries(rz_bin_le_obj_t *bin) {
-	ut64 offset = (ut64)bin->header->enttab + bin->headerOff;
-	RzList *l = rz_list_newf(free);
-	if (!l) {
+	RzBinImport *bin_imp = NULL;
+	LE_import *le_imp = NULL;
+	char *proc_name = NULL;
+	if (false) {
+	fail_cleanup:
+		le_import_free(le_imp);
+		rz_bin_import_free(bin_imp);
+		free(proc_name);
 		return NULL;
 	}
+
+	if (!bin->le_import_ht) {
+		HtPPOptions opt = {
+			.freefn = (HtPPKvFreeFunc)le_free_import_kv,
+			.cmp = (HtPPListComparator)le_import_cmp,
+			.hashfn = (HtPPHashFunction)le_import_hash,
+		};
+		CHECK(bin->le_import_ht = ht_pp_new_opt(&opt));
+	}
+
+	ut32 proc_ord = 0;
+	if (proc_by_ord) {
+		proc_ord = proc;
+	} else {
+		// The "overload bit" described in "[1] 3.15 Import Procedure Name Table" makes no
+		// sense, so using the same le_read_len_str_offset() that is used elsewhere
+		ut64 off = bin->le_off + bin->header->impproc + proc;
+		CHECK(le_read_len_str_offset(bin->buf, &off, &proc_name));
+	}
+	LE_import key = { .mod_ord = mod_ord, .proc_name = proc_name, .proc_ord = proc_ord };
+	HtPPKv *kv = ht_pp_find_kv(bin->le_import_ht, &key, NULL);
+	if (kv) {
+		free(proc_name);
+		return kv->key;
+	}
+
+	// import does not exists yet, insert a new one
+	CHECK(le_imp = RZ_NEW0(LE_import));
+	*le_imp = key;
+	proc_name = NULL;
+
+	CHECK(le_imp->import = le_add_bin_import(bin, le_imp));
+
+	ut32 sym_vaddr = le_reloc_target_vaddr(bin, le_imp->import->ordinal - 1);
+	RzBinSymbol *sym = le_add_symbol(bin, sym_ord, sym_vaddr);
+	CHECK(le_imp->symbol = sym);
+	sym->is_imported = true;
+	CHECK(sym->name = strdup(le_imp->import->name));
+
+	CHECK(ht_pp_insert(bin->le_import_ht, le_imp, NULL));
+	return le_imp;
+}
+
+/**
+ * \brief Read/write bytes from/to virtual memory range possibly crossing upper page boundary.
+ * \param bin rz_bin_le_obj_t, LE binary
+ * \param page LE_page*, the page where the first written byte lies
+ * \param data_vaddr ut32, virtual address where data is read from / written to
+ * \param data ut*, a buffer for reading / a data for writing
+ * \param data_len ut32, buffer length
+ * \param read bool, read if true, otherwise write
+ * \return success bool, false if any read/write errors occurred, true otherwise
+ *
+ * LX fixups (aka relocations) are a bit tricky. This function is needed to support:
+ *   - parsing fixup chains (read mode, read=true)
+ *   - applying fixups (write mode, read=false)
+ *
+ * In LE/LX format such reads / writes can happen on a page boundary, or on a partial page,
+ * where two parts of a page belong to different vfiles. Consider two adjacent pages,
+ * \p io_page, and its next page in virtual space:
+ *
+ *                      io_page                         next page
+ *     ..][...............oooooooooooooooooo][...............ooooooooooooooooo][..
+ *         \physical part/\zeroed virt part/  \physical part/\zeroed virt part/
+ *               (1)             (2)                (3)             (4)
+ *
+ * Intervals (1), (2), (3), (4) can each correspond to its own map+vfile pair. Consider few
+ * possible I/O scenarios:
+ *
+ *   - inside (1)
+ *   - on the boundary (1)-(2)
+ *   - inside (2)
+ *   - on the boundary (2)-(3)
+ *   - touching (1)-(2)-(3) -- possible when (2) is very small and is covered by I/O
+ *
+ * Note that \p data_vaddr is required to be inside \p io_page, so it's impossible
+ * for I/O to cross the lower boundary of (1) or happen wholly to the right of (2).
+ *
+ * The function works by iterating maps left to right for as long as there's hope of finding
+ * intersections with the I/O interval. When patching fixups \p data_len never exceeds
+ * 6 bytes (for 16:32 fixups), but the algorithm should work for any \p data_len.
+ **/
+static bool page_io(rz_bin_le_obj_t *bin, LE_page *io_page,
+	ut32 data_vaddr, ut8 *data, ut32 data_len, bool read) {
+
+	for (ut32 mi = io_page->le_map_num - 1; mi < rz_vector_len(bin->le_maps); mi++) {
+		LE_map *m = rz_vector_index_ptr(bin->le_maps, mi);
+		if (m->obj_num != io_page->obj_num) {
+			return true; // the map belonging to another object reached, stop
+		}
+
+		ut32 vfile_beg = m->vaddr;
+		ut32 vfile_end = m->vaddr + m->size;
+		ut32 vdata_beg = data_vaddr;
+		ut32 vdata_end = data_vaddr + data_len;
+		if (vdata_end <= vfile_beg) {
+			return true; // no further intersections possible, stop
+		}
+		if (vfile_end <= vdata_beg) {
+			continue; // no intersection yet, try next map
+		}
+
+		ut32 vbeg = RZ_MAX(vfile_beg, vdata_beg);
+		ut32 vend = RZ_MIN(vfile_end, vdata_end);
+		ut32 len = vend - vbeg;
+
+		RzBuffer *vfile_buf = m->is_physical ? bin->buf_patched : m->vfile_buf;
+		ut64 paddr = m->paddr + vbeg - vfile_beg;
+		ut8 *buf = data + vbeg - vdata_beg;
+		if (!vfile_buf) {
+			// likely vfiles haven't been created correctly
+			RZ_LOG_ERROR("LE: attempted %s %d byte(s) at 0x%" PFMT64x " of map %s "
+				     "with no buffer.\n",
+				read ? "reading" : "writing", len, paddr,
+				m->vfile_name ? m->vfile_name : "NULL");
+			rz_return_val_if_reached(false);
+		}
+		bool good;
+		if (read) {
+			good = rz_buf_read_at(vfile_buf, paddr, buf, len) == len;
+		} else {
+			good = rz_buf_write_at(vfile_buf, paddr, buf, len) == len;
+		}
+		if (!good) {
+			// likely data_vaddr is outside page_io, misused this function
+			RZ_LOG_ERROR("LE: error %s vfile, %d byte(s) at 0x%" PFMT64x ".\n",
+				read ? "reading" : "writing", len, paddr);
+			rz_return_val_if_reached(false);
+		}
+	}
+	return true;
+}
+
+static bool page_read(rz_bin_le_obj_t *bin, LE_page *io_page, ut32 vaddr, ut8 *buf, ut32 len) {
+	return page_io(bin, io_page, vaddr, buf, len, true);
+}
+
+static bool page_write(rz_bin_le_obj_t *bin, LE_page *io_page, ut32 vaddr, ut8 *buf, ut32 len) {
+	return page_io(bin, io_page, vaddr, buf, len, false);
+}
+
+static ut32 le_reloc_vaddr(rz_bin_le_obj_t *bin, LE_reloc *reloc) {
+	return bin->le_pages[reloc->src_page].vaddr + reloc->src_off;
+}
+
+static ut32 le_reloc_size(LE_reloc *reloc) {
+	static const ut8 szmap[] = {
+		[FIXUP_BYTE] = 1,
+		[FIXUP_SEL16] = 2,
+		[FIXUP_OFF16] = 2,
+		[FIXUP_OFF32] = 4,
+		[FIXUP_SEL16_OFF16] = 4,
+		[FIXUP_REL32] = 4,
+		[FIXUP_SEL16_OFF32] = 6,
+	};
+	return reloc->type < sizeof(szmap) ? szmap[reloc->type] : 0;
+}
+
+/// --- Loading all things LE from the binary -----------------------------------------------------
+
+/**
+ * \brief Find offsets of an LE header or an MZ/LE header pair.
+ *
+ *  Supported cases:
+ *  - A standalone LE binary (just an LE header).
+ *  - An MZ stub followed by an LE executbale (MZ-LE).
+ *  - A DOS extender bound executable typical for DOS protected mode software (MZ-BW-MZ-LE).
+ *
+ * Header search is implemented after the code in [3]
+ **/
+static bool le_get_header_offset(RzBuffer *b, ut64 *mz_off, ut64 *le_off) {
+	for (ut64 pos = 0, mz = 0;;) {
+		ut8 magic[2];
+		if (rz_buf_read_at(b, pos, magic, 2) != 2) {
+			break;
+		}
+
+		if (!memcmp(magic, "LE", 2) || !memcmp(magic, "LX", 2) || !memcmp(magic, "LC", 2)) {
+			if (mz_off) {
+				*mz_off = mz;
+			}
+			if (le_off) {
+				*le_off = pos;
+			}
+			return true;
+		}
+
+		bool is_mz = !memcmp(magic, "MZ", 2);
+		if (is_mz) {
+			ut32 bound_le_off;
+			if (!rz_buf_read_le32_at(b, pos + 0x3c, &bound_le_off)) {
+				break;
+			}
+			if (bound_le_off & 0xFFFF) {
+				mz = pos;
+				pos += bound_le_off;
+				continue;
+			}
+		}
+
+		// BW is a DOS extender related header similar to MZ
+		if (is_mz || !memcmp(magic, "BW", 2)) {
+			ut16 page_count;
+			ut16 last_page_bytes;
+			if (!rz_buf_read_le16_at(b, pos + 2, &last_page_bytes) ||
+				!rz_buf_read_le16_at(b, pos + 4, &page_count)) {
+				break;
+			}
+			pos += ((ut64)page_count - is_mz) * 512 + last_page_bytes;
+			continue;
+		}
+		break;
+	}
+	return false;
+}
+
+// See [1] 3.2 LX Header
+static bool le_load_header(rz_bin_le_obj_t *bin) {
+	if (!le_get_header_offset(bin->buf, &bin->mz_off, &bin->le_off)) {
+		return false;
+	}
+
+	ut64 off = bin->le_off;
+	bin->header = RZ_NEW0(LE_header);
+	if (!bin->header ||
+		!rz_buf_read_offset(bin->buf, &off, bin->header->magic, 2) ||
+		!rz_buf_read8_offset(bin->buf, &off, &bin->header->border) ||
+		!rz_buf_read8_offset(bin->buf, &off, &bin->header->worder) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->level) ||
+		!rz_buf_read_le16_offset(bin->buf, &off, &bin->header->cpu) ||
+		!rz_buf_read_le16_offset(bin->buf, &off, &bin->header->os) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->ver) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->mflags) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->mpages) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->startobj) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->eip) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->stackobj) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->esp) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->pagesize) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->pageshift) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->fixupsize) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->fixupsum) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->ldrsize) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->ldrsum) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->objtab) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->objcnt) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->objmap) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->itermap) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->rsrctab) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->rsrccnt) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->restab) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->enttab) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->dirtab) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->dircnt) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->fpagetab) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->frectab) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->impmod) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->impmodcnt) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->impproc) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->pagesum) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->datapage) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->preload) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->nrestab) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->cbnrestab) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->nressum) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->autodata) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->debuginfo) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->debuglen) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->instpreload) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->instdemand) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->heapsize) ||
+		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->stacksize)) {
+		free(bin->header);
+		return false;
+	}
+
+	if (bin->header->border || bin->header->worder) {
+		// shouldn't be hard to support, but I couldn't find any such binaries to test on
+		RZ_LOG_ERROR("LE: only little-endian byte and word order is supported, "
+			     "got (%d, %d), expected (0, 0).\n",
+			bin->header->border, bin->header->worder);
+		return false;
+	}
+	bin->is_le = !memcmp("LE", bin->header->magic, 2);
+
+	return true;
+}
+
+// Loading objects, see [1] 3.4 Object Table
+static bool le_load_objects(rz_bin_le_obj_t *bin) {
+	LE_header *h = bin->header;
+	if (!h->objcnt) {
+		return true; // no objects, binary is a forwarders-only library
+	}
+	ut64 offset = bin->le_off + h->objtab;
+	if (rz_buf_size(bin->buf) < offset + sizeof(LE_object) * h->objcnt) {
+		return false;
+	}
+	bin->objects = calloc(h->objcnt, sizeof(LE_object));
+	if (!bin->objects) {
+		return false;
+	}
+	for (LE_object *obj = bin->objects; obj != bin->objects + h->objcnt; obj++) {
+		if (!rz_buf_read_le32_offset(bin->buf, &offset, &obj->virtual_size) ||
+			!rz_buf_read_le32_offset(bin->buf, &offset, &obj->reloc_base_addr) ||
+			!rz_buf_read_le32_offset(bin->buf, &offset, &obj->flags) ||
+			!rz_buf_read_le32_offset(bin->buf, &offset, &obj->page_tbl_idx) ||
+			!rz_buf_read_le32_offset(bin->buf, &offset, &obj->page_tbl_entries) ||
+			!rz_buf_read_le32_offset(bin->buf, &offset, &obj->reserved)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+// Loading a single non-empty entry, see [1] 3.8.1-4
+static bool le_load_entry_record(rz_bin_le_obj_t *bin, ut64 *offset, ut8 type, ut32 obj_num,
+	RzVector /*<LE_entry>*/ *entries) {
+
+	if (false) {
+	fail_cleanup:
+		return false;
+	}
+	LE_entry e = { .is_empty = false };
+
+	ut32 sym_ord = rz_vector_len(entries) + 1;
+	ut8 entry_flags;
+	ut32 entry_off;
+	switch (type) {
+	case ENTRY_16: {
+		ut16 offset16;
+		CHECK(rz_buf_read8_offset(bin->buf, offset, &entry_flags));
+		CHECK(rz_buf_read_le16_offset(bin->buf, offset, &offset16));
+		entry_off = offset16;
+		break;
+	}
+
+	case ENTRY_CALLGATE: {
+		ut16 offset16;
+		ut16 callgate; // unused
+		CHECK(rz_buf_read8_offset(bin->buf, offset, &entry_flags));
+		CHECK(rz_buf_read_le16_offset(bin->buf, offset, &offset16));
+		CHECK(rz_buf_read_le16_offset(bin->buf, offset, &callgate));
+		entry_off = offset16;
+		break;
+	}
+
+	case ENTRY_32: {
+		CHECK(rz_buf_read8_offset(bin->buf, offset, &entry_flags));
+		CHECK(rz_buf_read_le32_offset(bin->buf, offset, &entry_off));
+		break;
+	}
+
+	case ENTRY_FORWARDER: {
+		ut16 imp_mod_ord;
+		ut32 imp_proc;
+		CHECK(rz_buf_read8_offset(bin->buf, offset, &entry_flags));
+		CHECK(rz_buf_read_le16_offset(bin->buf, offset, &imp_mod_ord));
+		CHECK(rz_buf_read_le32_offset(bin->buf, offset, &imp_proc));
+		e.is_forwarder = true;
+		e.is_exported = true;
+		bool proc_by_ord = entry_flags & E_IMPORT_BY_ORD;
+		e.is_forwarder_import_by_ord = proc_by_ord;
+		LE_import *le_imp;
+		CHECK(le_imp = le_add_import(bin, imp_mod_ord, proc_by_ord, imp_proc, sym_ord));
+		e.symbol = le_imp->symbol;
+		break;
+	}
+	}
+
+	if (type == ENTRY_16 || type == ENTRY_CALLGATE || type == ENTRY_32) {
+		e.is_exported = entry_flags & E_EXPORTED;
+		e.is_shared = entry_flags & E_SHARED;
+		e.is_param_dword = type == ENTRY_32;
+		e.param_count = entry_flags >> E_PARAM_COUNT_SHIFT;
+		e.obj_num = obj_num;
+		if (obj_num - 1 < bin->header->objcnt) {
+			ut32 entry_vaddr = bin->objects[obj_num - 1].reloc_base_addr + entry_off;
+			CHECK(e.symbol = le_add_symbol(bin, sym_ord, entry_vaddr));
+		} else {
+			// rare, 16 bit only, TODO what is it?
+			RZ_LOG_WARN("LE: invalid object #%u specified for symbol %u\n",
+				obj_num, sym_ord);
+		}
+	}
+
+	CHECK(rz_vector_push(entries, &e));
+	return true;
+}
+
+// Loading symbols, see [1] 3.8 Entry Table
+static RZ_OWN RzVector /*<LE_entry>*/ *le_load_entries(rz_bin_le_obj_t *bin) {
+	char *name = NULL;
+	RzVector *entries = rz_vector_new(sizeof(LE_entry), NULL, NULL);
+	if (!entries) {
+	fail_cleanup:
+		rz_vector_free(entries);
+		free(name);
+		return NULL;
+	}
+
+	ut64 offset = bin->le_off + bin->header->enttab;
 	while (true) {
-		LE_entry_bundle_header header;
-		LE_entry_bundle_entry e;
-		ut64 off = offset;
-		if (!(rz_buf_read8_offset(bin->buf, &off, &header.count) &&
-			    rz_buf_read8_offset(bin->buf, &off, &header.type) &&
-			    rz_buf_read_le16_offset(bin->buf, &off, &header.objnum))) {
+		ut8 entry_count;
+		CHECK(rz_buf_read8_offset(bin->buf, &offset, &entry_count));
+		if (!entry_count) {
 			break;
 		}
-		if (!header.count) {
-			break;
-		}
-		if ((header.type & ~ENTRY_PARAMETER_TYPING_PRESENT) == UNUSED_ENTRY) {
-			offset += sizeof(header.type) + sizeof(header.count);
-			while (header.count) {
-				rz_list_append(l, strdup("")); // (ut64 *)-1);
-				header.count--;
+		ut8 entry_type;
+		CHECK(rz_buf_read8_offset(bin->buf, &offset, &entry_type));
+		ut8 type = entry_type & ~E_PARAM_TYPING_PRESENT;
+		rz_vector_reserve(entries, rz_vector_len(entries) + entry_count);
+
+		switch (type) {
+		case ENTRY_EMPTY: {
+			LE_entry e = { .is_empty = true };
+			while (entry_count--) {
+				rz_vector_push(entries, &e);
 			}
 			continue;
 		}
-		offset += sizeof(LE_entry_bundle_header);
-		bool typeinfo = header.type & ENTRY_PARAMETER_TYPING_PRESENT;
-		int i;
-		for (i = 0; i < header.count; i++) {
-			LE_entry_bundle_type bundle_type = header.type & ~ENTRY_PARAMETER_TYPING_PRESENT;
-			ut64 entry = UT64_MAX;
-			read_le_entry_bundle_entry(bin->buf, offset, &e, bundle_type);
-			switch (bundle_type) {
-			case ENTRY16:
-				if ((header.objnum - 1) < bin->header->objcnt) {
-					entry = (ut64)e.entry_16.offset + bin->objtbl[header.objnum - 1].reloc_base_addr;
-				}
-				offset += sizeof(e.entry_16);
-				if (typeinfo) {
-					offset += (ut64)(e.entry_16.flags & ENTRY_PARAM_COUNT_MASK) * 2;
-				}
+
+		case ENTRY_16:
+		case ENTRY_CALLGATE:
+		case ENTRY_32:
+		case ENTRY_FORWARDER: {
+			ut16 obj_num = 0;
+			CHECK(rz_buf_read_le16_offset(bin->buf, &offset, &obj_num));
+			for (int i = 0; i < entry_count; i++) {
+				CHECK(le_load_entry_record(bin, &offset, type, obj_num, entries));
+			}
+			continue;
+		}
+		}
+		RZ_LOG_WARN("LE: unsupported entry bundle type %d, skipping the remainder "
+			    "of the table after having read %" PFMTSZu " entries.\n",
+			type, rz_vector_len(entries));
+		break;
+	}
+
+	// Load symbol names, see [1] 3.7 Resident or Non-resident Name Table Entry
+	LE_header *h = bin->header;
+	ut64 offset_beg[2] = { bin->le_off + h->restab, bin->mz_off + h->nrestab };
+	ut64 offset_end[2] = { bin->le_off + h->enttab, bin->mz_off + h->nrestab + h->cbnrestab };
+	for (ut32 i = 0; i < 2; i++) {
+		ut64 off = offset_beg[i], end = offset_end[i];
+		while (off + 1 <= end) {
+			if (!le_read_len_str_offset(bin->buf, &off, &name)) {
 				break;
-			case CALLGATE:
-				if ((header.objnum - 1) < bin->header->objcnt) {
-					entry = (ut64)e.callgate.offset + bin->objtbl[header.objnum - 1].reloc_base_addr;
-				}
-				offset += sizeof(e.callgate);
-				if (typeinfo) {
-					offset += (ut64)(e.callgate.flags & ENTRY_PARAM_COUNT_MASK) * 2;
-				}
+			}
+			if (off + 2 > end) {
+				RZ_FREE(name);
 				break;
-			case ENTRY32:
-				if ((header.objnum - 1) < bin->header->objcnt) {
-					entry = (ut64)e.entry_32.offset + bin->objtbl[header.objnum - 1].reloc_base_addr;
+			}
+			ut16 entry_ord;
+			CHECK(rz_buf_read_le16_offset(bin->buf, &off, &entry_ord));
+			if (name && entry_ord - 1 < rz_vector_len(entries)) {
+				LE_entry *e = rz_vector_index_ptr(entries, entry_ord - 1);
+				if (e->symbol && !e->symbol->name) {
+					e->symbol->name = name;
+					name = NULL;
+					continue;
 				}
-				offset += sizeof(e.entry_32);
-				if (typeinfo) {
-					offset += (ut64)(e.entry_32.flags & ENTRY_PARAM_COUNT_MASK) * 2;
-				}
+			}
+			RZ_FREE(name);
+		}
+	}
+
+	// try naming entries accessible only by ordinal
+	LE_entry *e;
+	int ei = 0;
+	rz_vector_foreach(entries, e) {
+		ei++;
+		if (!e->is_empty && !e->is_forwarder && e->symbol && !e->symbol->name) {
+			e->symbol->name = rz_str_newf("%u", ei);
+		}
+	}
+
+	return entries;
+}
+
+// Loading page map, see [1] 3.5 Object Page Table
+static RZ_OWN LE_page *le_load_pages(rz_bin_le_obj_t *bin) {
+	LE_header *h = bin->header;
+	ut64 offset = bin->le_off + h->objmap;
+	LE_page *le_pages = NULL;
+	if (rz_buf_size(bin->buf) < offset + (ut64)h->mpages * (bin->is_le ? 4 : 8)) {
+	fail_cleanup:
+		free(le_pages);
+		return NULL;
+	}
+	CHECK(le_pages = calloc(h->mpages, sizeof(LE_header)));
+
+	LE_page *page = le_pages;
+	for (ut32 page_i = 0; page_i < h->mpages; page_i++, page++) {
+		if (bin->is_le) {
+			// 4 byte record: 3 byte big endian page number, 1 byte flags
+			ut32 record;
+			CHECK(rz_buf_read_be32_offset(bin->buf, &offset, &record));
+			ut32 page_num = record >> 8;
+			ut8 page_flags = record & 0xFF;
+			if (page_flags != 0) {
+				RZ_LOG_WARN("LE: unsupported LE page flags 0x%02x for page #%d.\n",
+					page_flags, page_i + 1);
+			}
+			if (!page_num) {
+				// This is likely the result of file damage or tempering, guessing
+				// number being just an 1-based index would work for typical LE.
+				page_num = page_i + 1;
+				RZ_LOG_WARN("LE: page #%u invalid page number corrected.\n", page_num);
+			}
+			page->type = PAGE_LEGAL;
+			page->paddr = bin->mz_off + h->datapage + (ut64)(page_num - 1) * h->pagesize;
+			page->psize = page_i != h->mpages - 1 ? h->pagesize : h->le_last_page_size;
+		} else {
+			// 8 byte record: 4 offset, 2 size, 2 flags
+			ut32 page_offset;
+			ut16 page_size;
+			ut16 page_flags;
+			CHECK(rz_buf_read_le32_offset(bin->buf, &offset, &page_offset));
+			CHECK(rz_buf_read_le16_offset(bin->buf, &offset, &page_size));
+			CHECK(rz_buf_read_le16_offset(bin->buf, &offset, &page_flags));
+			ut32 off = page_offset << h->pageshift;
+			switch (page_flags) {
+			case PAGE_LEGAL:
+				page->paddr = bin->mz_off + h->datapage + off;
 				break;
-			case FORWARDER:
-				offset += sizeof(e.forwarder);
+			case PAGE_ITERATED:
+			case PAGE_COMPRESSED:
+				page->paddr = bin->mz_off + h->itermap + off;
+				break;
+			case PAGE_INVALID:
+			case PAGE_RANGE:
+			default:
+				page_flags = PAGE_ZEROED;
+				RZ_LOG_WARN("LE: unsupported LX page flags 0x%04x for page #%d.\n",
+					page_flags, page_i + 1);
+			case PAGE_ZEROED:
+				break;
+			}
+			page->type = (LE_page_type)page_flags;
+			page->psize = page_size;
+		}
+	}
+
+	// assign object number to pages, calculate vaddr
+	for (ut32 oi = 0; oi < h->objcnt; oi++) {
+		LE_object *obj = &bin->objects[oi];
+		ut32 voff = 0;
+		LE_page *page = &le_pages[obj->page_tbl_idx - 1];
+		for (ut32 i = 0; i < obj->page_tbl_entries; i++, page++) {
+			page->obj_num = oi + 1;
+			page->vaddr = obj->reloc_base_addr + voff;
+			page->vsize = h->pagesize;
+			voff += h->pagesize;
+		}
+		if (voff > obj->virtual_size) {
+			ut32 extra = voff - obj->virtual_size;
+			if (extra < h->pagesize) {
+				page->vsize -= extra;
+			} else {
+				RZ_LOG_WARN("LE: object #%u vsize is smaller than the sum of its "
+					    "pages 0x%x < 0x%x, object has been extended.\n",
+					oi + 1, obj->virtual_size, voff);
+				obj->virtual_size = voff;
+			}
+		}
+	}
+
+	// assign fixup page map boundaries
+	ut32 fixup_page_base_paddr = bin->le_off + h->frectab;
+	ut64 fixup_map_paddr = bin->le_off + h->fpagetab;
+	for (ut32 pi = 0; pi <= h->mpages; pi++) {
+		ut32 start;
+		if (!rz_buf_read_le32_offset(bin->buf, &fixup_map_paddr, &start)) {
+			goto fail_cleanup;
+		}
+		start += fixup_page_base_paddr;
+		if (pi < h->mpages) {
+			le_pages[pi].fixup_page_start = start;
+		}
+		if (pi > 0) {
+			le_pages[pi - 1].fixup_page_end = start;
+		}
+	}
+
+	return le_pages;
+}
+
+// See [2] UnpackMethod1 for the algortihm.
+static void le_unpack_iterated(rz_bin_le_obj_t *bin, ut8 *out, ut32 out_size, LE_page *page) {
+	if (false) {
+	fail_cleanup:
+		RZ_LOG_WARN("LE: unpacking type 1 (iterated) page at 0x%" PFMT64x " failed.\n",
+			page->paddr);
+		return;
+	}
+	ut64 off = page->paddr;
+	ut64 end = off + page->psize;
+	while (off < end) {
+		ut16 reps, len;
+		CHECK(off + 2 <= end);
+		CHECK(rz_buf_read_le16_offset(bin->buf, &off, &reps));
+		if (reps == 0) {
+			break;
+		}
+		CHECK(off + 2 <= end);
+		CHECK(rz_buf_read_le16_offset(bin->buf, &off, &len));
+		CHECK(len <= out_size && off + len <= end);
+		CHECK(rz_buf_read_offset(bin->buf, &off, out, len));
+		ut8 *pattern = out;
+		out += len;
+		out_size -= len;
+		for (ut32 i = 1; i < reps; i++) {
+			memcpy(out, pattern, RZ_MIN(out_size, len));
+			if (out_size < len) {
+				break;
+			}
+			out += len;
+			out_size -= len;
+		}
+		break;
+	}
+}
+
+// See [2] UnpackMethod2 for the algortihm.
+static void le_unpack_compressed(rz_bin_le_obj_t *bin, ut8 *out, ut32 out_size, LE_page *page) {
+	ut8 tmp8;
+	ut16 tmp16;
+	RzBuffer *buf = bin->buf;
+	ut64 off = page->paddr, *offset = &off;
+	ut64 offset_end = *offset + page->psize;
+	ut32 out_size_total = out_size;
+
+	if (false) {
+	fail_cleanup:
+		RZ_LOG_WARN("LE: unpacking type 5 (compressed) page at 0x%" PFMT64x " failed.\n",
+			page->paddr);
+		return;
+	}
+
+// copy N bytes from source
+#define COPY(N) \
+	CHECK(*offset + (N) <= offset_end && (N) <= out_size); \
+	CHECK(rz_buf_read_offset(buf, offset, out, (N))); \
+	out += (N); \
+	out_size -= (N);
+
+// appends N bytes at *(out - backstep) to *out, ranges can overlap!
+#define DUP(backstep, N) \
+	CHECK(out_size_total - out_size >= backstep); \
+	for (ut32 i = (N); i; i--, out++, out_size--) { \
+		*out = *(out - backstep); \
+	}
+
+	while (*offset < offset_end) {
+		ut8 b1;
+		CHECK_READ8(b1);
+
+		ut8 type = b1 & 3;
+		if (type == 0) {
+			if (b1 == 0) {
+				ut8 b2, b3;
+				CHECK_READ8(b2);
+				if (b2 == 0) {
+					break;
+				}
+				CHECK_READ8(b3);
+				CHECK(b2 <= out_size);
+				memset(out, b3, b2);
+				out += b2;
+				out_size -= b2;
+			} else {
+				COPY(b1 >> 2);
+			}
+
+		} else if (type == 1) {
+			ut16 bof;
+			ut8 b2;
+			*offset -= 1;
+			CHECK_READ16(bof);
+			bof >>= 7;
+			b2 = ((b1 >> 4) & 7) + 3;
+			b1 = ((b1 >> 2) & 3);
+			COPY(b1);
+			DUP(bof, b2);
+
+		} else if (type == 2) {
+			ut16 bof;
+			*offset -= 1;
+			CHECK_READ16(bof);
+			bof >>= 4;
+			b1 = ((b1 >> 2) & 3) + 3;
+			DUP(bof, b1);
+
+		} else if (type == 3) {
+			ut8 b2;
+			ut16 word1, word2, bof;
+			*offset -= 1;
+			CHECK_READ16(word1);
+			*offset -= 1;
+			CHECK_READ16(word2);
+			b1 = (word1 >> 2) & 0xf;
+			b2 = (word1 >> 6) & 0x3f;
+			bof = word2 >> 4;
+			COPY(b1);
+			DUP(bof, b2);
+		}
+	}
+#undef DUP
+#undef COPY
+}
+
+static void le_map_fini(void *map, void *unused) {
+	LE_map *m = map;
+	rz_buf_free(m->vfile_buf);
+	free(m->vfile_buf_data);
+	free(m->vfile_name);
+}
+
+static bool le_add_map(RzVector /*<LE_map>*/ *le_maps, LE_map *map, LE_page *page) {
+	if (map->vsize == 0 || (map->size == 0 && map->is_physical)) {
+		return true; // adding empty maps makes no sense, might happen in a crafted binary
+	}
+	LE_map *prev = rz_vector_empty(le_maps) ? NULL : rz_vector_tail(le_maps);
+	bool prev_ok = prev && prev->obj_num == map->obj_num && prev->is_physical == map->is_physical;
+	bool merge_virtual = prev_ok && !map->is_physical;
+	bool merge_physical = prev_ok && map->is_physical && prev->paddr + prev->size == map->paddr;
+	if (merge_virtual || merge_physical) {
+		prev->size += map->size;
+		prev->vsize += map->vsize;
+	} else {
+		if (!rz_vector_push(le_maps, map)) {
+			return false;
+		}
+	}
+	if (!page->le_map_num) {
+		page->le_map_num = rz_vector_len(le_maps);
+	}
+	return true;
+}
+
+static RzVector /*<LE_map>*/ *le_create_maps(rz_bin_le_obj_t *bin) {
+	RzVector *le_maps = rz_vector_new(sizeof(LE_map), le_map_fini, NULL);
+	ut8 *tmp_buf = NULL;
+	if (!le_maps) {
+	fail_cleanup:
+		rz_vector_free(le_maps);
+		free(tmp_buf);
+		return NULL;
+	}
+
+	LE_header *h = bin->header;
+	for (ut32 oi = 0; oi != h->objcnt; oi++) {
+		LE_object *obj = &bin->objects[oi];
+		LE_map m = { .obj_num = oi + 1 };
+		size_t len_before = rz_vector_len(le_maps);
+		ut32 beg = obj->page_tbl_idx - 1, end = beg + obj->page_tbl_entries;
+		for (ut32 pi = beg; pi != end; pi++) {
+			LE_page *page = &bin->le_pages[pi];
+			m.first_page_num = pi + 1;
+			if (page->type == PAGE_LEGAL) {
+				// physical part of a normal page
+				m.size = page->psize;
+				m.vsize = page->psize;
+				m.paddr = page->paddr;
+				m.vaddr = page->vaddr;
+				m.is_physical = true;
+				CHECK(le_add_map(le_maps, &m, page));
+				if (page->psize < page->vsize) {
+					// zero padded virtual remainder of a normal page
+					m.size = 0;
+					m.vsize = h->pagesize - page->psize;
+					m.paddr = 0;
+					m.vaddr = page->vaddr + page->psize;
+					m.is_physical = false;
+					CHECK(le_add_map(le_maps, &m, page));
+				}
+			} else {
+				// virtual unpacked or zero filled page
+				m.size = page->vsize;
+				m.vsize = page->vsize;
+				m.paddr = 0;
+				m.vaddr = page->vaddr;
+				m.is_physical = false;
+				CHECK(le_add_map(le_maps, &m, page));
+			}
+		}
+
+		// if the last map is zero-filled virtual, merge it with the preceding map
+		if (rz_vector_len(le_maps) >= len_before + 2) {
+			LE_map *last = rz_vector_tail(le_maps), *prev = last - 1;
+			if (last->size == 0) {
+				prev->vsize += last->vsize;
+				rz_vector_pop(le_maps, NULL);
+			}
+		}
+
+		// if an object has no pages, create a single map for the whole object
+		if (rz_vector_len(le_maps) == len_before) {
+			m.size = 0;
+			m.vsize = obj->virtual_size;
+			m.paddr = 0;
+			m.vaddr = obj->reloc_base_addr;
+			m.is_physical = false;
+			CHECK(rz_vector_push(le_maps, &m));
+		} else {
+			// otherwise extend last map to match object vsize
+			LE_map *last = rz_vector_tail(le_maps);
+			ut32 obj_vend = obj->reloc_base_addr + obj->virtual_size;
+			if (obj_vend > last->vaddr + last->vsize) {
+				last->vsize = obj_vend - last->vaddr;
+			}
+		}
+
+		((LE_map *)rz_vector_tail(le_maps))->is_obj_last = true;
+	}
+
+	// name maps
+	LE_map *m;
+	ut32 num = 1;
+	rz_vector_foreach(le_maps, m) {
+		const char *map_kind = m->is_physical ? "physical" : "virtual";
+		CHECK(m->vfile_name = rz_str_newf("obj%d-%s%u", m->obj_num, map_kind, num++));
+	}
+
+	// allocate buffers, fill zero pages, unpack compressed pages
+	rz_vector_foreach(le_maps, m) {
+		if (m->is_physical) {
+			continue;
+		}
+		if (m->size == 0 && m->is_obj_last) {
+			continue; // fully virtual and last map in object, no need for vfile
+		}
+		ut32 buf_size = m->size ? m->size : m->vsize;
+		CHECK(tmp_buf = RZ_NEWS0(ut8, buf_size));
+		ut32 offset = 0;
+		for (ut32 pi = m->first_page_num - 1; pi < bin->header->mpages; pi++) {
+			LE_page *page = &bin->le_pages[pi];
+			if (page->le_map_num - 1 != m - (LE_map *)rz_vector_head(le_maps)) {
+				break;
+			}
+			ut32 size = page->vsize;
+			if (page->type == PAGE_LEGAL) {
+				// !is_physical && type == PAGE_LEGAL means zero padded remainder
+				// of a normal page, thus its size is physical size inverted
+				size = h->pagesize - page->psize;
+			}
+			CHECK(offset + size <= buf_size);
+			switch (page->type) {
+			case PAGE_ITERATED:
+				le_unpack_iterated(bin, tmp_buf + offset, size, page);
+				break;
+			case PAGE_COMPRESSED:
+				le_unpack_compressed(bin, tmp_buf + offset, size, page);
 				break;
 			default:
 				break;
 			}
-			if (entry != UT64_MAX) {
-				rz_list_append(l, rz_str_newf("0x%" PFMT64x, entry));
-			}
+			offset += size;
 		}
+		CHECK(m->vfile_buf = rz_buf_new_with_pointers(tmp_buf, m->size, false));
+		m->vfile_buf_data = tmp_buf;
+		tmp_buf = NULL;
 	}
-	return l;
+
+	// calculate reloc_target_map_base
+	ut32 max_vaddr = 0;
+	rz_vector_foreach(le_maps, m) {
+		max_vaddr = RZ_MAX(max_vaddr, m->vaddr + m->vsize);
+	}
+	bin->reloc_target_map_base = max_vaddr - max_vaddr % h->pagesize + h->pagesize * 2;
+
+	return le_maps;
 }
 
-static void le_get_symbols_at(rz_bin_le_obj_t *bin, RzList /*<RzBinSymbol *>*/ *syml, RzList /*<char *>*/ *entl, ut64 offset, ut64 end) {
-	while (offset < end) {
-		RzBinSymbol *sym = le_get_symbol(bin, &offset);
-		if (!sym) {
-			break;
-		}
-		if (sym->ordinal) {
-			const char *n = rz_list_get_n(entl, sym->ordinal - 1);
-			if (n) {
-				sym->vaddr = rz_num_get(NULL, n);
-				sym->bind = RZ_BIN_BIND_GLOBAL_STR;
-				sym->type = RZ_BIN_TYPE_FUNC_STR;
-				rz_list_append(syml, sym);
-			} else {
-				rz_bin_symbol_free(sym);
-			}
-		} else {
-			rz_bin_symbol_free(sym);
-		}
-	}
-}
-
-RzList /*<RzBinSymbol *>*/ *rz_bin_le_get_symbols(rz_bin_le_obj_t *bin) {
-	RzList *l = rz_list_newf((RzListFree)rz_bin_symbol_free);
-	RzList *entries = le_get_entries(bin);
-	LE_image_header *h = bin->header;
-	ut64 offset = (ut64)h->restab + bin->headerOff;
-	ut32 end = h->enttab + bin->headerOff;
-	le_get_symbols_at(bin, l, entries, offset, end);
-	offset = h->nrestab;
-	end = h->nrestab + h->cbnrestab;
-	le_get_symbols_at(bin, l, entries, offset, end);
-	rz_list_free(entries);
-	return l;
-}
-
-RzList /*<RzBinImport *>*/ *rz_bin_le_get_imports(rz_bin_le_obj_t *bin) {
-	RzList *l = rz_list_newf((RzListFree)rz_bin_import_free);
-	if (!l) {
-		return NULL;
-	}
-	LE_image_header *h = bin->header;
-	ut64 offset = (ut64)h->impproc + bin->headerOff + 1; // First entry is a null string
-	ut64 end = (ut64)h->fixupsize + h->fpagetab + bin->headerOff;
-	while (offset < end) {
-		RzBinImport *imp = RZ_NEW0(RzBinImport);
-		if (!imp) {
-			break;
-		}
-		imp->name = le_read_nonnull_str_at(bin->buf, &offset);
-		if (!imp->name) {
-			rz_bin_import_free(imp);
-			break;
-		}
-		imp->type = RZ_BIN_TYPE_FUNC_STR;
-		rz_list_append(l, imp);
-	}
-	return l;
-}
-
-RzList /*<RzBinAddr *>*/ *rz_bin_le_get_entrypoints(rz_bin_le_obj_t *bin) {
-	RzList *l = rz_list_newf((RzListFree)free);
-	if (!l) {
-		return NULL;
-	}
-	RzBinAddr *entry = RZ_NEW0(RzBinAddr);
-	if (entry) {
-		if ((bin->header->startobj - 1) < bin->header->objcnt) {
-			entry->vaddr = (ut64)bin->objtbl[bin->header->startobj - 1].reloc_base_addr + bin->header->eip;
-		}
-	}
-	rz_list_append(l, entry);
-
-	return l;
-}
-
-RzList /*<char *>*/ *rz_bin_le_get_libs(rz_bin_le_obj_t *bin) {
-	RzList *l = rz_list_newf((RzListFree)free);
-	if (!l) {
-		return NULL;
-	}
-	LE_image_header *h = bin->header;
-	ut64 offset = (ut64)h->impmod + bin->headerOff;
-	ut64 end = offset + h->impproc - h->impmod;
-	while (offset < end) {
-		char *name = le_read_nonnull_str_at(bin->buf, &offset);
-		if (!name) {
-			break;
-		}
-		rz_list_append(l, name);
-	}
-	return l;
-}
-
-/*
- *	Creates & appends to l iter_n sections with the same paddr for each iter record.
- *	page->size is the total size of iter records that describe the page
- *	TODO: Don't do this
- */
-static void __create_iter_sections(RzList /*<RzBinSection *>*/ *l, rz_bin_le_obj_t *bin, RzBinSection *sec, LE_object_page_entry *page, ut64 vaddr, int cur_page) {
-	rz_return_if_fail(l && bin && sec && page);
-	LE_image_header *h = bin->header;
-	ut32 offset = (h->itermap + (page->offset << (bin->is_le ? 0 : h->pageshift)));
-
-	// Gets the first iter record
-	ut16 iter_n;
-	if (!rz_buf_read_ble16_at(bin->buf, offset, &iter_n, h->worder)) {
-		return;
-	}
-
-	offset += sizeof(ut16);
-	ut16 data_size;
-	if (!rz_buf_read_ble16_at(bin->buf, offset, &data_size, h->worder)) {
-		return;
-	}
-
-	offset += sizeof(ut16);
-
-	ut64 tot_size = 0;
-	int iter_cnt = 0;
-	ut64 bytes_left = page->size;
-	while (iter_n && bytes_left > 0) {
-		int i;
-		for (i = 0; i < iter_n; i++) {
-			RzBinSection *s = RZ_NEW0(RzBinSection);
-			if (!s) {
-				break;
-			}
-			s->name = rz_str_newf("%s.page.%d.iter.%d", sec->name, cur_page, iter_cnt);
-			s->bits = sec->bits;
-			s->perm = sec->perm;
-			s->size = data_size;
-			s->vsize = data_size;
-			s->paddr = offset;
-			s->vaddr = vaddr;
-			vaddr += data_size;
-			tot_size += data_size;
-			rz_list_append(l, s);
-			iter_cnt++;
-		}
-		bytes_left -= sizeof(ut16) * 2 + data_size;
-		// Get the next iter record
-		offset += data_size;
-
-		if (!rz_buf_read_ble16_at(bin->buf, offset, &iter_n, h->worder)) {
-			return;
-		}
-		offset += sizeof(ut16);
-
-		if (!rz_buf_read_ble16_at(bin->buf, offset, &data_size, h->worder)) {
-			return;
-		}
-		offset += sizeof(ut16);
-	}
-	if (tot_size < h->pagesize) {
-		RzBinSection *s = RZ_NEW0(RzBinSection);
-		if (!s) {
-			return;
-		}
-		s->name = rz_str_newf("%s.page.%d.iter.zerofill", sec->name, cur_page);
-		s->bits = sec->bits;
-		s->perm = sec->perm;
-		s->vsize = h->pagesize - tot_size;
-		s->vaddr = vaddr;
-		rz_list_append(l, s);
-	}
-}
-
-// TODO: Compressed page
-RzList /*<RzBinSection *>*/ *rz_bin_le_get_sections(rz_bin_le_obj_t *bin) {
-	RzList *l = rz_list_newf((RzListFree)rz_bin_section_free);
-	if (!l) {
-		return NULL;
-	}
-	LE_image_header *h = bin->header;
-	ut32 pages_start_off = h->datapage;
-	int i;
-	for (i = 0; i < h->objcnt; i++) {
-		RzBinSection *sec = RZ_NEW0(RzBinSection);
-		if (!sec) {
-			return l;
-		}
-		LE_object_entry *entry = &bin->objtbl[i];
-		sec->name = rz_str_newf("obj.%d", i + 1);
-		sec->vsize = entry->virtual_size;
-		sec->vaddr = entry->reloc_base_addr;
-		if (entry->flags & O_READABLE) {
-			sec->perm |= RZ_PERM_R;
-		}
-		if (entry->flags & O_WRITABLE) {
-			sec->perm |= RZ_PERM_W;
-		}
-		if (entry->flags & O_EXECUTABLE) {
-			sec->perm |= RZ_PERM_X;
-		}
-		if (entry->flags & O_BIG_BIT) {
-			sec->bits = RZ_SYS_BITS_32;
-		} else {
-			sec->bits = RZ_SYS_BITS_16;
-		}
-		sec->is_data = entry->flags & O_RESOURCE || !(sec->perm & RZ_PERM_X);
-		if (!entry->page_tbl_entries) {
-			rz_list_append(l, sec);
-		}
-		int j;
-		ut32 page_size_sum = 0;
-		ut32 next_idx = i < h->objcnt - 1 ? bin->objtbl[i + 1].page_tbl_idx - 1 : UT32_MAX;
-		ut32 objmaptbloff = h->objmap + bin->headerOff;
-		ut64 objpageentrysz = bin->is_le ? sizeof(ut32) : sizeof(LE_object_page_entry);
-		for (j = 0; j < entry->page_tbl_entries; j++) {
-			LE_object_page_entry page;
-			RzBinSection *s = RZ_NEW0(RzBinSection);
-			if (!s) {
-				rz_bin_section_free(sec);
-				return l;
-			}
-			s->name = rz_str_newf("%s.page.%d", sec->name, j);
-			s->is_data = sec->is_data;
-
-			int cur_idx = entry->page_tbl_idx + j - 1;
-			ut64 page_entry_off = objpageentrysz * cur_idx + objmaptbloff;
-			ut64 offset = page_entry_off;
-			if (!(rz_buf_read_le32_offset(bin->buf, &offset, &page.offset) &&
-				    rz_buf_read_le16_offset(bin->buf, &offset, &page.size) &&
-				    rz_buf_read_le16_offset(bin->buf, &offset, &page.flags))) {
-				RZ_LOG_WARN("Cannot read out of bounds page table entry.\n");
-				rz_bin_section_free(s);
-				break;
-			}
-			if (cur_idx < next_idx) { // If not true rest of pages will be zeroes
-				if (bin->is_le) {
-					// Why is it big endian???
-					ut32 tmp_offset;
-					if (!rz_buf_read_be32_at(bin->buf, page_entry_off, &tmp_offset)) {
-						rz_bin_section_free(s);
-						break;
-					}
-
-					ut64 offset = tmp_offset >> 8;
-					s->paddr = (offset - 1) * h->pagesize + pages_start_off;
-					if (entry->page_tbl_idx + j == h->mpages) {
-						page.size = h->pageshift;
-					} else {
-						page.size = h->pagesize;
-					}
-				} else if (page.flags == P_ITERATED) {
-					ut64 vaddr = sec->vaddr + page_size_sum;
-					__create_iter_sections(l, bin, sec, &page, vaddr, j);
-					rz_bin_section_free(s);
-					page_size_sum += h->pagesize;
-					continue;
-				} else if (page.flags == P_COMPRESSED) {
-					// TODO
-					RZ_LOG_WARN("Compressed page not handled: %s", s->name);
-				} else if (page.flags != P_ZEROED) {
-					s->paddr = ((ut64)page.offset << h->pageshift) + pages_start_off;
-				}
-			}
-			s->vsize = h->pagesize;
-			s->vaddr = sec->vaddr + page_size_sum;
-			s->perm = sec->perm;
-			s->size = page.size;
-			s->bits = sec->bits;
-			rz_list_append(l, s);
-			page_size_sum += s->vsize;
-		}
-		if (entry->page_tbl_entries) {
-			rz_bin_section_free(sec);
-		}
-	}
-	return l;
-}
-
-char *le_get_modname_by_ord(rz_bin_le_obj_t *bin, ut32 ordinal) {
+static RZ_OWN RzPVector /*<char *>*/ *le_load_import_mod_names(rz_bin_le_obj_t *bin) {
+	RzPVector *names = rz_pvector_new(free);
 	char *modname = NULL;
-	ut64 off = (ut64)bin->header->impmod + bin->headerOff;
-	while (ordinal > 0) {
+	if (!names) {
+	fail_cleanup:
+		rz_pvector_free(names);
 		free(modname);
-		modname = le_read_nonnull_str_at(bin->buf, &off);
-		ordinal--;
+		return NULL;
 	}
-	return modname;
+	ut64 off = bin->le_off + bin->header->impmod;
+	for (ut32 i = 0; i < bin->header->impmodcnt; i++) {
+		if (!le_read_len_str_offset(bin->buf, &off, &modname)) {
+			break;
+		}
+		CHECK(rz_pvector_push(names, modname));
+		modname = NULL;
+	}
+	return names;
 }
 
-RzList /*<RzBinReloc *>*/ *rz_bin_le_get_relocs(rz_bin_le_obj_t *bin) {
-	RzList *l = rz_list_newf((RzListFree)free);
-	if (!l) {
-		return NULL;
-	}
-	RzList *entries = le_get_entries(bin);
-	RzList *sections = rz_bin_le_get_sections(bin);
-	LE_image_header *h = bin->header;
-	ut64 cur_page = 0;
-	const ut64 fix_rec_tbl_off = (ut64)h->frectab + bin->headerOff;
-	ut32 tmp_offset;
-	if (!rz_buf_read_ble32_at(bin->buf, (ut64)h->fpagetab + bin->headerOff + cur_page * sizeof(ut32), &tmp_offset, h->worder)) {
-		rz_list_free(l);
-		rz_list_free(entries);
-		rz_list_free(sections);
-		return NULL;
-	}
-
-	ut64 offset = tmp_offset + fix_rec_tbl_off;
-
-	ut32 tmp_end;
-	if (!rz_buf_read_ble32_at(bin->buf, (ut64)h->fpagetab + bin->headerOff + (cur_page + 1) * sizeof(ut32), &tmp_end, h->worder)) {
-		rz_list_free(l);
-		rz_list_free(entries);
-		rz_list_free(sections);
-		return NULL;
-	}
-	ut64 end = tmp_end + fix_rec_tbl_off;
-
-	const RzBinSection *cur_section = (RzBinSection *)rz_list_get_n(sections, cur_page);
-	ut64 cur_page_offset = cur_section ? cur_section->vaddr : 0;
-	while (cur_page < h->mpages) {
-		RzBinReloc *rel = RZ_NEW0(RzBinReloc);
-		bool rel_appended = false; // whether rel has been appended to l and must not be freed
-		if (!rel) {
-			break;
-		}
-		LE_fixup_record_header header;
-		if (!(rz_buf_read8_offset(bin->buf, &offset, &header.source) &&
-			    rz_buf_read8_offset(bin->buf, &offset, &header.target))) {
-			RZ_LOG_WARN("Cannot read out of bounds relocation.\n");
-			free(rel);
-			break;
-		}
-		switch (header.source & F_SOURCE_TYPE_MASK) {
-		case BYTEFIXUP:
-			rel->type = RZ_BIN_RELOC_8;
-			break;
-		case SELECTOR16:
-		case OFFSET16:
-			rel->type = RZ_BIN_RELOC_16;
-			break;
-		case OFFSET32:
-		case POINTER32:
-		case SELFOFFSET32:
-			rel->type = RZ_BIN_RELOC_32;
-			break;
-		case POINTER48:
-			rel->type = 48;
-			break;
-		}
-		ut8 repeat = 0;
-		ut16 source = 0;
-		if (header.source & F_SOURCE_LIST) {
-			if (!rz_buf_read8_at(bin->buf, offset, &repeat)) {
-				rz_bin_reloc_free(rel);
-				break;
-			}
-			offset += sizeof(ut8);
-		} else {
-			if (!rz_buf_read_ble16_at(bin->buf, offset, &source, h->worder)) {
-				rz_bin_reloc_free(rel);
-				break;
-			}
-			offset += sizeof(ut16);
-		}
-		ut32 ordinal;
-		if (header.target & F_TARGET_ORD16) {
-			ut16 tmp;
-			if (!rz_buf_read_ble16_at(bin->buf, offset, &tmp, h->worder)) {
-				rz_bin_reloc_free(rel);
-				break;
-			}
-			ordinal = tmp;
-			offset += sizeof(ut16);
-		} else {
-			ut8 tmp;
-			if (!rz_buf_read8_at(bin->buf, offset, &tmp)) {
-				rz_bin_reloc_free(rel);
-				break;
-			}
-			ordinal = tmp;
-			offset += sizeof(ut8);
-		}
-		switch (header.target & F_TARGET_TYPE_MASK) {
-		case INTERNAL:
-			if ((ordinal - 1) < bin->header->objcnt) {
-				rel->addend = bin->objtbl[ordinal - 1].reloc_base_addr;
-				if ((header.source & F_SOURCE_TYPE_MASK) != SELECTOR16) {
-					if (header.target & F_TARGET_OFF32) {
-						ut32 tmp;
-						if (!rz_buf_read_ble32_offset(bin->buf, &offset, &tmp, h->worder)) {
-							rz_bin_reloc_free(rel);
-							continue;
-						}
-						rel->addend += tmp;
-					} else {
-						ut16 tmp;
-						if (!rz_buf_read_ble16_offset(bin->buf, &offset, &tmp, h->worder)) {
-							rz_bin_reloc_free(rel);
-							continue;
-						}
-						rel->addend += tmp;
-					}
-				}
-			}
-			break;
-		case IMPORTORD: {
-			RzBinImport *imp = RZ_NEW0(RzBinImport);
-			if (!imp) {
-				break;
-			}
-			char *mod_name = le_get_modname_by_ord(bin, ordinal);
-			if (!mod_name) {
-				rz_bin_import_free(imp);
-				break;
-			}
-
-			if (header.target & F_TARGET_ORD8) {
-				ut8 tmp;
-				if (!rz_buf_read8_at(bin->buf, offset, &tmp)) {
-					rz_bin_import_free(imp);
-					break;
-				}
-				ordinal = tmp;
-				offset += sizeof(ut8);
-			} else if (header.target & F_TARGET_OFF32) {
-				if (!rz_buf_read_ble32_offset(bin->buf, &offset, &ordinal, h->worder)) {
-					rz_bin_import_free(imp);
-					break;
-				}
-			} else {
-				ut16 tmp;
-				if (!rz_buf_read_ble16_offset(bin->buf, &offset, &tmp, h->worder)) {
-					rz_bin_import_free(imp);
-					break;
-				}
-				ordinal = tmp;
-			}
-			imp->name = rz_str_newf("%s.%u", mod_name, ordinal);
-			imp->ordinal = ordinal;
-			rel->import = imp;
-			free(mod_name);
-			break;
-		}
-		case IMPORTNAME: {
-			RzBinImport *imp = RZ_NEW0(RzBinImport);
-			if (!imp) {
-				break;
-			}
-			ut32 nameoff;
-			if (header.target & F_TARGET_OFF32) {
-				if (!rz_buf_read_ble32_offset(bin->buf, &offset, &nameoff, h->worder)) {
-					rz_bin_import_free(imp);
-					break;
-				}
-			} else {
-				ut16 tmp;
-				if (!rz_buf_read_ble16_offset(bin->buf, &offset, &tmp, h->worder)) {
-					rz_bin_import_free(imp);
-					break;
-				}
-				nameoff = tmp;
-			}
-			ut64 off = (ut64)h->impproc + nameoff + bin->headerOff;
-			char *proc_name = le_read_nonnull_str_at(bin->buf, &off);
-			char *mod_name = le_get_modname_by_ord(bin, ordinal);
-			imp->name = rz_str_newf("%s.%s", mod_name ? mod_name : "", proc_name ? proc_name : "");
-			rel->import = imp;
-			break;
-		}
-		case INTERNALENTRY:
-			rel->addend = (ut64)(size_t)rz_list_get_n(entries, ordinal - 1);
-			break;
-		}
-		if (header.target & F_TARGET_ADDITIVE) {
-			ut32 additive = 0;
-			if (header.target & F_TARGET_ADD32) {
-				if (!rz_buf_read_ble32_offset(bin->buf, &offset, &additive, h->worder)) {
-					rz_bin_reloc_free(rel);
-					break;
-				}
-			} else {
-				ut16 tmp;
-				if (!rz_buf_read_ble16_offset(bin->buf, &offset, &tmp, h->worder)) {
-					rz_bin_reloc_free(rel);
-					break;
-				}
-				additive = tmp;
-			}
-			rel->addend += additive;
-		}
-		if (!repeat) {
-			rel->vaddr = cur_page_offset + source;
-			rel->paddr = cur_section ? cur_section->paddr + source : 0;
-			rz_list_append(l, rel);
-			rel_appended = true;
-		}
-
-		if (header.target & F_TARGET_CHAIN) {
-			ut32 fixupinfo;
-			if (!rz_buf_read_ble32_at(bin->buf, cur_page_offset + source, &fixupinfo, h->worder)) {
-				break;
-			}
-
-			ut64 base_target_address = rel->addend - (fixupinfo & 0xFFFFF);
-			do {
-				if (!rz_buf_read_ble32_at(bin->buf, cur_page_offset + source, &fixupinfo, h->worder)) {
-					break;
-				}
-				RzBinReloc *new = RZ_NEW0(RzBinReloc);
-				*new = *rel;
-				new->addend = base_target_address + (fixupinfo & 0xFFFFF);
-				rz_list_append(l, new);
-				source = (fixupinfo >> 20) & 0xFFF;
-			} while (source != 0xFFF);
-		}
-
-		while (repeat) {
-			ut16 off;
-			if (!rz_buf_read_ble16_offset(bin->buf, &offset, &off, h->worder)) {
-				break;
-			}
-			rel->vaddr = cur_page_offset + off;
-			rel->paddr = cur_section ? cur_section->paddr + off : 0;
-			RzBinReloc *new = RZ_NEW0(RzBinReloc);
-			*new = *rel;
-			rz_list_append(l, new);
-			repeat--;
-		}
-		while (offset >= end) {
-			cur_page++;
-			if (cur_page >= h->mpages) {
-				break;
-			}
-			ut64 at = h->fpagetab + bin->headerOff;
-			ut32 w0;
-			if (!rz_buf_read_ble32_at(bin->buf, at + cur_page * sizeof(ut32), &w0, h->worder)) {
-				break;
-			}
-			ut32 w1;
-			if (!rz_buf_read_ble32_at(bin->buf, at + (cur_page + 1) * sizeof(ut32), &w1, h->worder)) {
-				break;
-			}
-			offset = fix_rec_tbl_off + w0;
-			end = fix_rec_tbl_off + w1;
-			if (offset < end) {
-				cur_section = (RzBinSection *)rz_list_get_n(sections, cur_page);
-				cur_page_offset = cur_section ? cur_section->vaddr : 0;
-			}
-		}
-		if (!rel_appended) {
-			rz_bin_reloc_free(rel);
-		}
-	}
-	rz_list_free(entries);
-	rz_list_free(sections);
-	return l;
-}
-
-static bool read_le_header_aux(rz_bin_le_obj_t *bin, RzBuffer *buf) {
-	if (!rz_buf_read_at(buf, bin->headerOff, (ut8 *)bin->header, 4)) {
+static bool le_patch_relocs(rz_bin_le_obj_t *bin) {
+	// possibly resize vfiles
+	ut32 *max_vaddr = NULL;
+	LE_map **last_map = NULL;
+	if (false) {
+	fail_cleanup:
+		free(max_vaddr);
+		free(last_map);
 		return false;
 	}
-	ut64 offset = bin->headerOff + 4; /* skip magic, border, and worder */
-	return rz_buf_read_le32_offset(buf, &offset, &bin->header->level) &&
-		rz_buf_read_le16_offset(buf, &offset, &bin->header->cpu) &&
-		rz_buf_read_le16_offset(buf, &offset, &bin->header->os) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->ver) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->mflags) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->mpages) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->startobj) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->eip) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->stackobj) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->esp) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->pagesize) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->pageshift) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->fixupsize) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->fixupsum) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->ldrsize) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->ldrsum) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->objtab) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->objcnt) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->objmap) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->itermap) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->rsrctab) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->rsrccnt) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->restab) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->enttab) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->dirtab) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->dircnt) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->fpagetab) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->frectab) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->impmod) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->impmodcnt) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->impproc) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->pagesum) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->datapage) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->preload) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->nrestab) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->cbnrestab) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->nressum) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->autodata) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->debuginfo) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->debuglen) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->instpreload) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->instdemand) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->heapsize) &&
-		rz_buf_read_le32_offset(buf, &offset, &bin->header->stacksize);
-}
 
-static rz_bin_le_obj_t *le_init_header(RzBuffer *buf) {
-	rz_bin_le_obj_t *bin = RZ_NEW0(rz_bin_le_obj_t);
-	if (!bin) {
-		return NULL;
+	// mark last map for each object
+	CHECK(last_map = RZ_NEWS0(LE_map *, bin->header->objcnt));
+	LE_map *m;
+	rz_vector_foreach(bin->le_maps, m) {
+		last_map[m->obj_num - 1] = m;
 	}
-	ut8 magic[2];
-	rz_buf_read_at(buf, 0, magic, sizeof(magic));
-	if (!memcmp(&magic, "MZ", 2)) {
-		ut16 tmp;
-		if (!rz_buf_read_le16_at(buf, 0x3c, &tmp)) {
-			rz_bin_le_free(bin);
-			return NULL;
+
+	// search maximum vaddr patched by relocs for each object
+	CHECK(max_vaddr = RZ_NEWS0(ut32, bin->header->objcnt));
+	for (ut32 oi = 0; oi < bin->header->objcnt; oi++) {
+		max_vaddr[oi] = bin->objects[oi].reloc_base_addr; // set minimum
+	}
+	RzListIter *iter;
+	LE_reloc *reloc;
+	rz_list_foreach (bin->le_relocs, iter, reloc) {
+		LE_page *page = &bin->le_pages[reloc->src_page];
+		if (page->obj_num) {
+			ut32 *max = &max_vaddr[page->obj_num - 1];
+			*max = RZ_MAX(*max, le_reloc_vaddr(bin, reloc) + le_reloc_size(reloc));
 		}
-		bin->headerOff = tmp;
-	} else {
-		bin->headerOff = 0;
-	}
-	bin->header = RZ_NEW0(LE_image_header);
-	if (!bin->header) {
-		RZ_LOG_ERROR("le: Failed to allocate memory\n");
-		rz_bin_le_free(bin);
-		return NULL;
 	}
 
-	if (!read_le_header_aux(bin, buf)) {
-		RZ_LOG_ERROR("le: Failed to read LE header\n");
-		rz_bin_le_free(bin);
-		return NULL;
+	// extending allocated parts of objects to allow patching virtual region
+	for (ut32 oi = 0; oi < bin->header->objcnt; oi++) {
+		m = last_map[oi];
+		if (max_vaddr[oi] > m->vaddr + m->size) {
+			ut32 sz = max_vaddr[oi] - m->vaddr;
+
+			// without tmp realloc failure would result in a leak
+			ut8 *tmp = realloc(m->vfile_buf_data, sz);
+			CHECK(m->vfile_buf_data = tmp);
+			rz_buf_free(m->vfile_buf);
+			CHECK(m->vfile_buf = rz_buf_new_with_pointers(tmp, sz, false));
+			m->size = sz;
+		}
 	}
 
-	return bin;
+	RZ_FREE(max_vaddr);
+	RZ_FREE(last_map);
+
+	rz_list_foreach (bin->le_relocs, iter, reloc) {
+		LE_page *page = &bin->le_pages[reloc->src_page];
+		if (page->obj_num == 0) {
+			continue;
+		}
+
+		LE_fixup_type t = reloc->type;
+		ut32 vaddr = le_reloc_vaddr(bin, reloc);
+
+		if (t == FIXUP_BYTE) {
+			// TODO FIXUP_BYTE is unsupported, occurances are extremely rare though.
+			continue;
+		}
+
+		// write 32 bit offset
+		if (t == FIXUP_REL32 || t == FIXUP_SEL16_OFF32 || t == FIXUP_OFF32) {
+			ut8 tmp[4];
+			ut32 target = reloc->target_vaddr + reloc->addend;
+			if (t == FIXUP_REL32) {
+				target -= vaddr + 4; // relative offset, for call/jump
+			}
+			rz_write_le32(tmp, target);
+			CHECK(page_write(bin, page, vaddr, tmp, sizeof(tmp)));
+		}
+
+		// write 16 bit offset
+		if (t == FIXUP_SEL16_OFF16 || t == FIXUP_OFF16) {
+			ut8 tmp[2];
+			ut32 obj = reloc->trg_obj_num;
+			if (obj) {
+				ut32 obj_base = obj <= bin->header->objcnt
+					? bin->objects[obj - 1].reloc_base_addr
+					: bin->reloc_target_map_base;
+				ut32 target = reloc->target_vaddr + reloc->addend - obj_base;
+				if (target <= UT16_MAX) {
+					rz_write_le16(tmp, target);
+					CHECK(page_write(bin, page, vaddr, tmp, 2));
+				} else {
+					RZ_LOG_WARN("LE: failed to apply fixup at vaddr=0x%x, "
+						    "16 bit target offset=0x%x is too big.\n",
+						vaddr, target);
+				}
+			} else {
+				RZ_LOG_WARN("LE: failed to apply fixup at vaddr=0x%x, "
+					    "no target object specified.\n",
+					vaddr);
+			}
+		}
+
+		// write selector
+		if (t == FIXUP_SEL16_OFF32 || t == FIXUP_SEL16_OFF16 || t == FIXUP_SEL16) {
+			ut8 tmp[2];
+			rz_write_le16(tmp, reloc->trg_obj_num);
+			vaddr += le_reloc_size(reloc) - 2; // selector is patched at tailing 2 bytes
+			CHECK(page_write(bin, page, vaddr, tmp, 2));
+		}
+	}
+
+	if (bin->buf_patched) {
+		rz_buf_sparse_set_write_mode(bin->buf_patched, RZ_BUF_SPARSE_WRITE_MODE_THROUGH);
+	}
+	return true;
 }
 
-void rz_bin_le_free(rz_bin_le_obj_t *bin) {
-	rz_return_if_fail(bin);
+static bool le_append_fixup(rz_bin_le_obj_t *bin, LE_reloc *reloc, RzList /*<RzBinReloc *>*/ *out,
+	bool skip_fixup) {
+
+	if (skip_fixup) {
+		return true; // Fixup has been parsed but contains invalid data, ignore and proceed
+	}
+
+	if (reloc->src_off < 0) {
+		// Skipping fixups with negative source offset, since they are already accounted for
+		// on the preceding page as per [1] 3.13 Fixup Record Table:
+		//
+		//  Note: For fixups that cross page boundaries, a separate fixup record is
+		//  specified for each page. An offset is still used for the 2nd page, but it
+		//  now becomes a negative offset since the fixup originated on the preceding
+		//  page. (For example if only the last one byte of a 32-bit address is on
+		//  the page to be fixed up, then the offset would have a value of -3)"
+		//
+		return true; // Not an error
+	}
+
+	LE_reloc *tmp = RZ_NEWCOPY(LE_reloc, reloc);
+	if (!tmp || !rz_list_append(out, tmp)) {
+		free(tmp);
+		return false;
+	}
+	return true;
+}
+
+static bool le_load_fixup_record(rz_bin_le_obj_t *bin, RzList /*<RzBinReloc *>*/ *relocs_out,
+	ut32 page_i, ut64 *offset, ut64 offset_end) {
+
+	LE_header *h = bin->header;
+	ut64 start_offset = *offset;
+	if (false) {
+	fail_cleanup:
+		RZ_LOG_WARN("LE: unsupported or malformed fixup record at 0x%" PFMT64x
+			    ", skipping the rest of the page.\n",
+			start_offset);
+		return false;
+	}
+
+	// variables used in CHECK_READ*
+	RzBuffer *buf = bin->buf;
+	ut32 tmp32 = 0;
+	ut16 tmp16 = 0;
+	ut8 tmp8 = 0;
+
+	LE_page *cur_page = &bin->le_pages[page_i];
+	LE_reloc rel = { .src_page = page_i };
+
+	ut8 src_flags;
+	CHECK_READ8(src_flags);
+	rel.type = src_flags & F_SOURCE_TYPE_MASK;
+	// TODO what does src_flags & F_SOURCE_ALIAS do? only valid when segment selector is present
+
+	ut8 trg_flags;
+	CHECK_READ8(trg_flags);
+	ut8 trg_type = trg_flags & F_TARGET_TYPE_MASK;
+
+	ut8 src_list_count = 0;
+	st16 src_off = 0; // signed integer, can be negative!
+	if (src_flags & F_SOURCE_LIST) {
+		CHECK_READ8(src_list_count);
+	} else {
+		CHECK_READ16(src_off);
+	}
+
+	ut16 ordinal;
+	if (trg_flags & F_TARGET_ORD16) {
+		CHECK_READ16(ordinal);
+	} else {
+		CHECK_READ8(ordinal);
+	}
+
+	bool skip_fixup = false;
+	ut16 imp_mod_ord = 0;
+	ut32 imp_proc_ord = 0;
+	ut32 imp_proc_name_off = 0;
+	ut32 target_base_vaddr = 0;
+	switch (trg_type) {
+	case TARGET_INTERNAL:
+		if (ordinal - 1 < h->objcnt) {
+			rel.trg_obj_num = ordinal;
+			target_base_vaddr = bin->objects[ordinal - 1].reloc_base_addr;
+		} else {
+			skip_fixup = true;
+		}
+		if (rel.type != FIXUP_SEL16) {
+			ut32 target_offset;
+			if (trg_flags & F_TARGET_OFF32) {
+				CHECK_READ32(target_offset);
+			} else {
+				CHECK_READ16(target_offset);
+			}
+			rel.target_vaddr = target_base_vaddr + target_offset;
+		} else {
+			// FIXUP_SEL16 doesn't truly have a target_vaddr, it targets a segment as a
+			// whole and writes a "segment selector". Here target_vaddr is set to its
+			// target segment's start. It's purely for informational purposes, otherwise
+			// there would be no way to understand its target by ir command output.
+			rel.target_vaddr = target_base_vaddr;
+		}
+		break;
+
+	case TARGET_IMPORT_ORDINAL:
+		imp_mod_ord = ordinal;
+		if (trg_flags & F_TARGET_ORD8) {
+			CHECK_READ8(imp_proc_ord);
+		} else if (trg_flags & F_TARGET_OFF32) {
+			CHECK_READ32(imp_proc_ord);
+		} else {
+			CHECK_READ16(imp_proc_ord);
+		}
+		break;
+
+	case TARGET_IMPORT_NAME:
+		imp_mod_ord = ordinal;
+		if (trg_flags & F_TARGET_OFF32) {
+			CHECK_READ32(imp_proc_name_off);
+		} else {
+			CHECK_READ16(imp_proc_name_off);
+		}
+		break;
+
+	case TARGET_INTERNAL_ENTRY: {
+		LE_entry *e = NULL;
+		if (ordinal - 1 < rz_vector_len(bin->le_entries)) {
+			e = rz_vector_index_ptr(bin->le_entries, ordinal - 1);
+		}
+		if (!e || e->is_empty || e->is_forwarder || !e->symbol) {
+			RZ_LOG_WARN("LE: relocation references invalid entry #%d.\n", ordinal);
+			skip_fixup = true;
+			break;
+		}
+		rel.symbol = e->symbol;
+		rel.target_vaddr = e->symbol->vaddr;
+		rel.trg_obj_num = e->obj_num;
+		if (e->obj_num - 1 < h->objcnt) {
+			target_base_vaddr = bin->objects[e->obj_num - 1].reloc_base_addr;
+		}
+		break;
+	}
+
+	default:
+		RZ_LOG_WARN("LE: unsupported fixup target type %u.\n", trg_type);
+		goto fail_cleanup;
+	}
+
+	if (imp_mod_ord) {
+		rel.trg_obj_num = h->objcnt + 1; // pseudo object for imports
+		bool proc_by_ord = imp_proc_ord > 0;
+		ut32 proc = proc_by_ord ? imp_proc_ord : imp_proc_name_off;
+		LE_import *le_imp;
+		CHECK(le_imp = le_add_import(bin, imp_mod_ord, proc_by_ord, proc, 0));
+		rel.import = le_imp->import;
+		rel.target_vaddr = le_imp->symbol->vaddr;
+	}
+
+	if (trg_flags & F_TARGET_ADDITIVE) {
+		if (trg_flags & F_TARGET_ADD32) {
+			CHECK_READ32(rel.addend);
+		} else {
+			CHECK_READ16(rel.addend);
+		}
+	}
+
+	// handle fixup chain, sources list, or just a single fixup
+	RzListIter *prev_tail = rz_list_tail(relocs_out);
+	if (!src_list_count) {
+		rel.src_off = src_off; // in non-list cases src_off has already been read by now
+
+		// [1] 3.13.5 Internal Chaining Fixups
+		bool is_chain = trg_flags & F_TARGET_CHAIN;
+		if (is_chain) {
+			ut64 start_paddr = cur_page->paddr + src_off;
+			for (ut32 cnt = 0; src_off != 0xFFF; cnt++) {
+				if (src_off < 0 || src_off + 4 > h->pagesize || cnt > h->pagesize) {
+					RZ_LOG_WARN("LE: malformed or circular fixup chain at 0x%" PFMT64x ".\n",
+						start_paddr);
+					while (relocs_out->tail != prev_tail) {
+						rz_bin_reloc_free(rz_list_pop(relocs_out));
+					}
+					break;
+				}
+
+				union {
+					ut32 fixupinfo;
+					ut8 buf[4];
+				} u = { .fixupinfo = 0 };
+				CHECK(page_read(bin, cur_page, cur_page->vaddr + src_off, u.buf, 4));
+				rel.target_vaddr = target_base_vaddr + (u.fixupinfo & 0xFFFFF);
+				rel.src_off = src_off;
+				CHECK(le_append_fixup(bin, &rel, relocs_out, skip_fixup));
+				src_off = u.fixupinfo >> 20;
+			}
+		} else if (!is_chain) {
+			CHECK(le_append_fixup(bin, &rel, relocs_out, skip_fixup));
+		}
+	} else {
+		while (src_list_count--) {
+			CHECK_READ16(rel.src_off);
+			CHECK(le_append_fixup(bin, &rel, relocs_out, skip_fixup));
+		}
+	}
+
+	return true;
+}
+
+static RZ_OWN RzList /*<LE_reloc *>*/ *le_load_relocs(rz_bin_le_obj_t *bin) {
+	RzList *relocs = rz_list_newf((RzListFree)rz_bin_reloc_free);
+	if (!relocs) {
+		return NULL;
+	}
+	for (ut32 pi = 0; pi < bin->header->mpages; pi++) {
+		LE_page *page = &bin->le_pages[pi];
+		ut64 off = page->fixup_page_start, end = page->fixup_page_end;
+		while (off < end) {
+			if (!le_load_fixup_record(bin, relocs, pi, &off, end)) {
+				break; // malformed page, continue reading from the next page
+			}
+		}
+	}
+	return relocs;
+}
+
+/// --- Plugin callbacks --------------------------------------------------------------------------
+
+static void rz_bin_le_free(rz_bin_le_obj_t *bin) {
+	if (!bin) {
+		return;
+	}
 	free(bin->header);
-	free(bin->objtbl);
-	free(bin->filename);
+	free(bin->modname);
+	rz_buf_free(bin->buf_patched);
+	free(bin->objects);
+	free(bin->le_pages);
+	rz_vector_free(bin->le_maps);
+	rz_pvector_free(bin->imp_mod_names);
+	rz_list_free(bin->symbols);
+	rz_vector_free(bin->le_entries);
+	rz_list_free(bin->imports);
+	ht_pp_free(bin->le_import_ht);
+	rz_list_free(bin->le_relocs);
 	free(bin);
 }
 
-rz_bin_le_obj_t *rz_bin_le_new_buf(RzBuffer *buf) {
-	rz_bin_le_obj_t *bin = le_init_header(buf);
+void rz_bin_le_destroy(RzBinFile *bf) {
+	rz_bin_le_free(bf->o->bin_obj);
+}
+
+bool rz_bin_le_load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb) {
+	rz_return_val_if_fail(bf && obj && buf, false);
+	rz_bin_le_obj_t *bin = RZ_NEW0(rz_bin_le_obj_t);
+	char const *err_ctx = ", unable to load file header.";
 	if (!bin) {
-		return NULL;
-	}
-
-	LE_image_header *h = bin->header;
-	if (!memcmp("LE", h->magic, 2)) {
-		bin->is_le = true;
-	}
-
-	if (UT32_MUL_OVFCHK(h->objcnt, sizeof(LE_object_entry))) {
-		RZ_LOG_ERROR("le: overflow on objcnt\n");
+	fail_cleanup:
+		RZ_LOG_ERROR("LE: loading binary failed%s\n", err_ctx);
 		rz_bin_le_free(bin);
-		return NULL;
+		return false;
+	}
+	bin->buf = buf;
+	CHECK(le_load_header(bin));
+
+	if (bin->header->objcnt) {
+		CHECK(bin->buf_patched = rz_buf_new_sparse_overlay(buf, RZ_BUF_SPARSE_WRITE_MODE_SPARSE));
+	} else {
+		RZ_LOG_WARN("LE: binary has no code, probably a forwarder-only library.\n");
 	}
 
 	bin->type = le_get_module_type(bin);
 	bin->cpu = le_get_cpu_type(bin);
 	bin->os = le_get_os_type(bin);
 	bin->arch = le_get_arch(bin);
-	bin->objtbl = calloc(h->objcnt, sizeof(LE_object_entry));
-	if (!bin->objtbl) {
-		rz_bin_le_free(bin);
+
+	ut64 off = bin->le_off + bin->header->restab;
+	le_read_len_str_offset(bin->buf, &off, &bin->modname);
+
+	err_ctx = ", unable to load objects.";
+	CHECK(le_load_objects(bin));
+	err_ctx = ", unable to load data pages.";
+	CHECK(bin->le_pages = le_load_pages(bin));
+	err_ctx = ", unable to build maps.";
+	CHECK(bin->le_maps = le_create_maps(bin));
+	err_ctx = ", unable to load imports.";
+	CHECK(bin->imports = rz_list_newf((RzListFree)rz_bin_import_free));
+	CHECK(bin->symbols = rz_list_newf((RzListFree)rz_bin_symbol_free));
+	CHECK(bin->imp_mod_names = le_load_import_mod_names(bin));
+	CHECK(bin->le_entries = le_load_entries(bin));
+	err_ctx = ", unable to load and apply relocations.";
+	CHECK(bin->le_relocs = le_load_relocs(bin));
+	CHECK(le_patch_relocs(bin));
+
+	obj->bin_obj = bin;
+	return true;
+}
+
+bool rz_bin_le_check_buffer(RzBuffer *b) {
+	return le_get_header_offset(b, NULL, NULL);
+}
+
+static void no_free(void *unused) {}
+
+RZ_OWN RzList /*<RzBinImport *>*/ *rz_bin_le_get_imports(RzBinFile *bf) {
+	rz_bin_le_obj_t *bin = bf->o->bin_obj;
+	if (rz_list_empty(bin->imports)) {
 		return NULL;
 	}
-	ut64 offset = (ut64)bin->headerOff + h->restab;
-	bin->filename = le_read_nonnull_str_at(buf, &offset);
-	offset = (ut64)bin->headerOff + h->objtab;
-	for (ut32 i = 0; i < h->objcnt; i++) {
-		LE_object_entry *le_obj_entry = bin->objtbl + i;
-		if (!rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->virtual_size) ||
-			!rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->reloc_base_addr) ||
-			!rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->flags) ||
-			!rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->page_tbl_idx) ||
-			!rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->page_tbl_entries) ||
-			!rz_buf_read_le32_offset(buf, &offset, &le_obj_entry->reserved)) {
-			rz_bin_le_free(bin);
-			return NULL;
+	RzList *l = rz_list_clone(bin->imports);
+	l->free = no_free; // silence assertion, there's no need to delete imports
+	return l;
+}
+
+RZ_OWN RzList /*<RzBinSymbol *>*/ *rz_bin_le_get_symbols(RzBinFile *bf) {
+	rz_bin_le_obj_t *bin = bf->o->bin_obj;
+	if (rz_list_empty(bin->symbols)) {
+		return NULL;
+	}
+	return rz_list_clone(bin->symbols);
+}
+
+RZ_OWN RzList /*<RzBinSection *>*/ *rz_bin_le_get_sections(RzBinFile *bf) {
+	rz_bin_le_obj_t *bin = bf->o->bin_obj;
+	RzList *sections = rz_list_newf((RzListFree)rz_bin_section_free);
+	RzBinSection *sec = NULL;
+	if (!sections) {
+	fail_cleanup:
+		rz_list_free(sections);
+		rz_bin_section_free(sec);
+		return NULL;
+	}
+
+	ut32 obj_num = 0, sec_num = 0;
+	LE_map *le_map;
+	rz_vector_foreach(bin->le_maps, le_map) {
+		CHECK(sec = RZ_NEW0(RzBinSection));
+
+		if (obj_num == le_map->obj_num) {
+			sec_num++;
+		} else {
+			obj_num = le_map->obj_num;
+			sec_num = 1;
+		}
+		CHECK(sec->name = rz_str_newf("obj%u_%u", obj_num, sec_num));
+
+		sec->size = le_map->size;
+		sec->vsize = le_map->vsize;
+		sec->vaddr = le_map->vaddr;
+		sec->paddr = le_map->paddr;
+
+		LE_object *obj = &bin->objects[obj_num - 1];
+		sec->perm = le_obj_perm(obj);
+		sec->bits = obj->flags & O_BIG_BIT ? RZ_SYS_BITS_32 : RZ_SYS_BITS_16;
+		sec->is_data = obj->flags & O_RESOURCE || !(sec->perm & RZ_PERM_X);
+
+		CHECK(rz_list_append(sections, sec));
+		sec = NULL;
+	}
+
+	return sections;
+}
+
+RZ_OWN RzList /*<RzBinAddr *>*/ *rz_bin_le_get_entry_points(RzBinFile *bf) {
+	rz_bin_le_obj_t *bin = bf->o->bin_obj;
+	LE_header *h = bin->header;
+	RzBinAddr *addr = NULL;
+	RzList *entries = rz_list_newf((RzListFree)free);
+	if (!entries) {
+	fail_cleanup:
+		rz_list_free(entries);
+		free(addr);
+		return NULL;
+	}
+
+	// EXE entry point or DLL initialization routine, h->startobj can be 0 (invalid) for DLL,
+	// which means this particular DLL does not need initialization.
+	if (h->startobj - 1 < h->objcnt) {
+		CHECK(addr = RZ_NEW0(RzBinAddr));
+		addr->vaddr = bin->objects[h->startobj - 1].reloc_base_addr + h->eip;
+		addr->paddr = le_vaddr_to_paddr(bin, addr->vaddr);
+		CHECK(rz_list_append(entries, addr));
+		addr = NULL;
+	}
+
+	// Exported functions, only DLLs have these.
+	LE_entry *e;
+	rz_vector_foreach(bin->le_entries, e) {
+		if (!e->is_empty && !e->is_forwarder && e->is_exported && e->symbol) {
+			CHECK(addr = RZ_NEW0(RzBinAddr));
+			addr->vaddr = e->symbol->vaddr;
+			addr->paddr = le_vaddr_to_paddr(bin, addr->vaddr);
+			CHECK(rz_list_append(entries, addr));
+			addr = NULL;
 		}
 	}
-	bin->buf = buf;
-	return bin;
+
+	return entries;
+}
+
+RZ_OWN RzList /*<char *>*/ *rz_bin_le_get_libs(RzBinFile *bf) {
+	rz_bin_le_obj_t *bin = bf->o->bin_obj;
+	if (rz_pvector_empty(bin->imp_mod_names)) {
+		return NULL;
+	}
+	RzList *libs = rz_list_new();
+	if (!libs) {
+	fail_cleanup:
+		rz_list_free(libs);
+		return NULL;
+	}
+	void **it;
+	rz_pvector_foreach (bin->imp_mod_names, it) {
+		CHECK(rz_list_append(libs, *it));
+	}
+	return libs;
+}
+
+#define VFILE_NAME_PATCHED       "patched"
+#define VFILE_NAME_RELOC_TARGETS "reloc-targets"
+
+RZ_OWN RzList /*<RzBinVirtualFile *>*/ *rz_bin_le_get_virtual_files(RzBinFile *bf) {
+	rz_bin_le_obj_t *bin = bf->o->bin_obj;
+	RzBinVirtualFile *vf = NULL;
+	RzBuffer *buf = NULL;
+	RzList *vfiles = rz_list_newf((RzListFree)rz_bin_virtual_file_free);
+	if (!vfiles) {
+	fail_cleanup:
+		rz_bin_virtual_file_free(vf);
+		rz_list_free(vfiles);
+		rz_buf_free(buf);
+		return NULL;
+	}
+
+	if (bin->buf_patched) {
+		// patched vfile over main buffer
+		CHECK(vf = RZ_NEW0(RzBinVirtualFile));
+		CHECK(vf->name = strdup(VFILE_NAME_PATCHED));
+		vf->buf = bin->buf_patched;
+		vf->buf_owned = false;
+		CHECK(rz_list_append(vfiles, vf));
+		vf = NULL;
+	}
+
+	// virtual file per memory range not backed by physical pages (unpacked & zero-filled pages)
+	LE_map *le_map;
+	rz_vector_foreach(bin->le_maps, le_map) {
+		if (le_map->is_physical) {
+			continue;
+		}
+		CHECK(vf = RZ_NEW0(RzBinVirtualFile));
+		CHECK(vf->name = strdup(le_map->vfile_name));
+		vf->buf = le_map->vfile_buf;
+		vf->buf_owned = false;
+		CHECK(rz_list_append(vfiles, vf));
+		vf = NULL;
+	}
+
+	// virtual file for reloc targets
+	ut64 rtmsz = le_reloc_targets_vfile_size(bin);
+	if (rtmsz) {
+		CHECK(vf = RZ_NEW0(RzBinVirtualFile));
+		CHECK(vf->name = strdup(VFILE_NAME_RELOC_TARGETS))
+		CHECK(vf->buf = rz_buf_new_empty(rtmsz));
+		vf->buf_owned = true;
+		CHECK(rz_list_append(vfiles, vf));
+		vf = NULL;
+	}
+
+	return vfiles;
+}
+
+RZ_OWN RzList /*<RzBinReloc *>*/ *rz_bin_le_get_relocs(RzBinFile *bf) {
+	rz_bin_le_obj_t *bin = bf->o->bin_obj;
+	RzList /*<LE_reloc *>*/ *le_relocs = bin->le_relocs;
+	RzList /*<RzBinReloc *>*/ *relocs = rz_list_newf((RzListFree)rz_bin_reloc_free);
+	RzBinReloc *reloc = NULL;
+	if (!relocs) {
+	fail_cleanup:
+		rz_list_free(relocs);
+		rz_bin_reloc_free(reloc);
+		return NULL;
+	}
+
+	RzListIter *it;
+	LE_reloc *le_reloc;
+	rz_list_foreach (le_relocs, it, le_reloc) {
+		CHECK(reloc = RZ_NEW0(RzBinReloc));
+		CHECK(rz_list_append(relocs, reloc));
+		reloc->symbol = le_reloc->symbol;
+		reloc->import = le_reloc->import;
+		reloc->addend = le_reloc->addend;
+		reloc->vaddr = le_reloc_vaddr(bin, le_reloc);
+		reloc->paddr = le_vaddr_to_paddr(bin, reloc->vaddr);
+		reloc->target_vaddr = le_reloc->target_vaddr;
+
+		switch (le_reloc->type) {
+		case FIXUP_BYTE:
+			reloc->type = RZ_BIN_RELOC_8;
+			break;
+
+		case FIXUP_SEL16:
+		case FIXUP_OFF16:
+			reloc->type = RZ_BIN_RELOC_16;
+			break;
+
+		case FIXUP_OFF32:
+		case FIXUP_SEL16_OFF16:
+		case FIXUP_REL32:
+			reloc->type = RZ_BIN_RELOC_32;
+			break;
+
+		case FIXUP_SEL16_OFF32:
+			reloc->type = RZ_BIN_RELOC_32;
+			reloc = NULL;
+
+			// adding additional 2-byte relocation right after the 4-byte one
+			// to represent a 48 bit 16:32 relocation
+			CHECK(reloc = RZ_NEW0(RzBinReloc));
+			*reloc = *(RzBinReloc *)rz_list_tail(relocs)->data;
+			reloc->vaddr += 4;
+			reloc->paddr += 4;
+			reloc->type = RZ_BIN_RELOC_16;
+			CHECK(rz_list_append(relocs, reloc));
+			reloc = NULL;
+			break;
+
+		default:
+			break;
+		}
+	}
+	return relocs;
+}
+
+RZ_OWN RzList /*<RzBinMap *>*/ *rz_bin_le_get_maps(RzBinFile *bf) {
+	rz_bin_le_obj_t *bin = bf->o->bin_obj;
+	RzList *maps = rz_list_newf((RzListFree)rz_bin_map_free);
+	RzBinMap *map = NULL;
+	if (!maps) {
+	fail_cleanup:
+		rz_list_free(maps);
+		rz_bin_map_free(map);
+		return NULL;
+	}
+
+	LE_map *le_map;
+	ut32 map_num = 0;
+	ut32 obj_num = 0;
+	rz_vector_foreach(bin->le_maps, le_map) {
+		LE_object *obj = &bin->objects[le_map->obj_num - 1];
+		if (le_map->obj_num != obj_num) {
+			obj_num = le_map->obj_num;
+			map_num = 1;
+		} else {
+			map_num++;
+		}
+		CHECK(map = RZ_NEW0(RzBinMap));
+		map->perm = le_obj_perm(obj);
+		map->vaddr = le_map->vaddr;
+		map->psize = le_map->size;
+		map->vsize = le_map->vsize;
+		CHECK(map->name = rz_str_newf("obj%u_map%u", obj_num, map_num));
+		if (le_map->is_physical) {
+			map->paddr = le_map->paddr;
+			CHECK(map->vfile_name = strdup(VFILE_NAME_PATCHED));
+		} else {
+			map->paddr = 0;
+			if (map->psize != 0) {
+				CHECK(map->vfile_name = strdup(le_map->vfile_name));
+			}
+		}
+		CHECK(rz_list_append(maps, map));
+		map = NULL;
+	}
+
+	CHECK(map = RZ_NEW0(RzBinMap));
+	ut64 rtmsz = le_reloc_targets_vfile_size(bin);
+	map->perm = RZ_PERM_R | RZ_PERM_X;
+	map->vaddr = bin->reloc_target_map_base;
+	map->psize = rtmsz;
+	map->vsize = rtmsz;
+	CHECK(map->name = strdup(VFILE_NAME_RELOC_TARGETS));
+	CHECK(map->vfile_name = strdup(VFILE_NAME_RELOC_TARGETS));
+	CHECK(rz_list_append(maps, map));
+
+	return maps;
 }

--- a/librz/bin/format/le/le.h
+++ b/librz/bin/format/le/le.h
@@ -1,30 +1,115 @@
 // SPDX-FileCopyrightText: 2019 GustavoLCR <gugulcr@gmail.com>
+// SPDX-FileCopyrightText: 2023 svr <svr.work@protonmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #ifndef LE_H
 #define LE_H
 #include <rz_bin.h>
+#include <rz_types.h>
+#include <sdbht.h>
 #include "le_specs.h"
 
+typedef struct LE_object_s {
+	ut32 virtual_size;
+	ut32 reloc_base_addr;
+	ut32 flags;
+	ut32 page_tbl_idx; // The number of the first object page table entry for this object, 1-based
+	ut32 page_tbl_entries;
+	ut32 reserved;
+} LE_object;
+
+typedef struct LE_page_s {
+	ut64 paddr;
+	ut32 vaddr;
+	ut32 psize;
+	ut32 vsize;
+	ut16 type;
+	ut32 obj_num; // 1-base objects entry index
+	ut32 le_map_num; // first map corresponding to this page
+	ut32 fixup_page_start;
+	ut32 fixup_page_end;
+} LE_page;
+
+typedef struct LE_map_s {
+	RZ_NULLABLE ut8 *vfile_buf_data;
+	RZ_NULLABLE RzBuffer *vfile_buf;
+	RZ_NULLABLE char *vfile_name;
+	ut64 paddr;
+	ut32 vaddr;
+	ut32 size;
+	ut32 vsize;
+	ut32 obj_num;
+	ut32 first_page_num;
+	bool is_physical : 1;
+	bool is_obj_last : 1;
+} LE_map;
+
+typedef struct LE_entry_s {
+	bool is_empty : 1;
+	bool is_exported : 1;
+	bool is_shared : 1;
+	bool is_forwarder : 1;
+	bool is_forwarder_import_by_ord : 1;
+	bool is_param_dword : 1;
+	ut8 param_count; // word or dword count depending on is_param_dword
+	ut32 obj_num;
+	RZ_BORROW RzBinSymbol *symbol;
+} LE_entry;
+
+typedef struct LE_import_s {
+	ut16 mod_ord;
+	ut32 proc_ord;
+	char *proc_name;
+	RZ_BORROW RzBinImport *import;
+	RZ_BORROW RzBinSymbol *symbol;
+} LE_import;
+
+typedef struct LE_reloc_s {
+	LE_fixup_type type;
+	RZ_NULLABLE RZ_BORROW RzBinSymbol *symbol;
+	RZ_NULLABLE RZ_BORROW RzBinImport *import;
+	ut32 addend;
+	ut32 src_page;
+	st16 src_off;
+	ut32 trg_obj_num;
+	ut32 target_vaddr;
+} LE_reloc;
+
 typedef struct rz_bin_le_obj_s {
-	LE_image_header *header;
-	bool is_le; /* Used for differences between LE and LX */
-	char *filename;
+	ut64 mz_off; /* File offset of the MZ header if present */
+	ut64 le_off; /* File offset of the LE header */
+	LE_header *header;
+	char *modname;
+	bool is_le;
 	const char *type;
 	const char *cpu;
 	const char *os;
 	const char *arch;
-	ut32 headerOff; /* File offset to start of LE/LX header */
-	LE_object_entry *objtbl;
-	void *buf; /* Pointer to RzBuffer of file */
+	RZ_BORROW RzBuffer *buf; /* Pointer to RzBuffer of file */
+	RzBuffer *buf_patched; /* overlay over the original file with relocs patched */
+	LE_object *objects; // contains header->objcnt elements
+	LE_page *le_pages; // contains header->mpages elements
+	RzVector /*<LE_map>*/ *le_maps;
+	RzPVector /*<char *>*/ *imp_mod_names;
+	RzList /*<RzBinSymbol *>*/ *symbols;
+	RzVector /*<LE_entry>*/ *le_entries;
+	RzList /*<RzBinImport *>*/ *imports;
+	HtPP /*<LE_import *, NULL>*/ *le_import_ht;
+	RzList /*<LE_reloc *>*/ *le_relocs;
+	ut32 reloc_target_map_base;
+	ut32 reloc_targets_count;
 } rz_bin_le_obj_t;
 
-rz_bin_le_obj_t *rz_bin_le_new_buf(RzBuffer *buf);
-void rz_bin_le_free(rz_bin_le_obj_t *bin);
-RzList /*<RzBinAddr *>*/ *rz_bin_le_get_entrypoints(rz_bin_le_obj_t *bin);
-RzList /*<RzBinSection *>*/ *rz_bin_le_get_sections(rz_bin_le_obj_t *bin);
-RzList /*<RzBinSymbol *>*/ *rz_bin_le_get_symbols(rz_bin_le_obj_t *bin);
-RzList /*<RzBinImport *>*/ *rz_bin_le_get_imports(rz_bin_le_obj_t *bin);
-RzList /*<char *>*/ *rz_bin_le_get_libs(rz_bin_le_obj_t *bin);
-RzList /*<RzBinReloc *>*/ *rz_bin_le_get_relocs(rz_bin_le_obj_t *bin);
+bool rz_bin_le_check_buffer(RzBuffer *b);
+bool rz_bin_le_load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb);
+void rz_bin_le_destroy(RzBinFile *bf);
+RZ_OWN RzList /*<RzBinMap *>*/ *rz_bin_le_get_maps(RzBinFile *bf);
+RZ_OWN RzList /*<RzBinAddr *>*/ *rz_bin_le_get_entry_points(RzBinFile *bf);
+RZ_OWN RzList /*<RzBinSection *>*/ *rz_bin_le_get_sections(RzBinFile *bf);
+RZ_OWN RzList /*<RzBinSymbol *>*/ *rz_bin_le_get_symbols(RzBinFile *bf);
+RZ_OWN RzList /*<RzBinImport *>*/ *rz_bin_le_get_imports(RzBinFile *bf);
+RZ_OWN RzList /*<char *>*/ *rz_bin_le_get_libs(RzBinFile *bf);
+RZ_OWN RzList /*<RzBinReloc *>*/ *rz_bin_le_get_relocs(RzBinFile *bf);
+RZ_OWN RzList /*<RzBinVirtualFile *>*/ *rz_bin_le_get_virtual_files(RzBinFile *bf);
+
 #endif

--- a/librz/bin/p/bin_le.c
+++ b/librz/bin/p/bin_le.c
@@ -1,59 +1,44 @@
 // SPDX-FileCopyrightText: 2019 GustavoLCR <gugulcr@gmail.com>
+// SPDX-FileCopyrightText: 2023 svr <svr.work@protonmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_bin.h>
 #include "../format/le/le.h"
 
-static bool check_buffer(RzBuffer *b) {
-	ut64 length = rz_buf_size(b);
-	if (length < 2) {
-		return false;
+static RzBinInfo *le_info(RzBinFile *bf) {
+	RzBinInfo *info = RZ_NEW0(RzBinInfo);
+	if (!info) {
+		return NULL;
 	}
-
-	ut16 idx;
-	if (!rz_buf_read_le16_at(b, 0x3c, &idx)) {
-		return false;
-	}
-
-	if ((ut64)idx + 26 < length) {
-		ut8 buf[2];
-		rz_buf_read_at(b, 0, buf, sizeof(buf));
-		if (!memcmp(buf, "LX", 2) || !memcmp(buf, "LE", 2)) {
-			return true;
-		}
-		if (!memcmp(buf, "MZ", 2)) {
-			rz_buf_read_at(b, idx, buf, sizeof(buf));
-			if (!memcmp(buf, "LX", 2) || !memcmp(buf, "LE", 2)) {
-				return true;
-			}
-		}
-	}
-	return false;
+	rz_bin_le_obj_t *bin = bf->o->bin_obj;
+	LE_header *h = bin->header;
+	info->bits = 32;
+	info->type = strdup(bin->type);
+	info->cpu = strdup(bin->cpu);
+	info->os = strdup(bin->os);
+	info->arch = strdup(bin->arch);
+	info->file = strdup(bin->modname ? bin->modname : "");
+	info->big_endian = h->border || h->worder;
+	info->has_va = true;
+	info->baddr = 0;
+	return info;
 }
 
-static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb) {
-	rz_return_val_if_fail(bf && obj && buf, false);
-	rz_bin_le_obj_t *res = rz_bin_le_new_buf(buf);
-	if (res) {
-		obj->bin_obj = res;
-		return true;
-	}
-	return false;
-}
-
-static void destroy(RzBinFile *bf) {
-	rz_bin_le_free(bf->o->bin_obj);
-}
-
-static void header(RzBinFile *bf) {
+static void le_header(RzBinFile *bf) {
 	rz_return_if_fail(bf && bf->rbin && bf->o && bf->o->bin_obj);
 	RzBin *rbin = bf->rbin;
 	rz_bin_le_obj_t *bin = bf->o->bin_obj;
-	LE_image_header *h = bin->header;
+	LE_header *h = bin->header;
 	PrintfCallback p = rbin->cb_printf;
 	if (!h || !p) {
 		return;
 	}
+	if (bin->mz_off == bin->le_off) {
+		p("MZ header not present\n");
+	} else {
+		p("MZ header offset: 0x%" PFMT64x "\n", bin->mz_off);
+	}
+	p("LE header offset: 0x%" PFMT64x "\n", bin->le_off);
 	p("Signature: %2s\n", h->magic);
 	p("Byte Order: %s\n", h->border ? "Big" : "Little");
 	p("Word Order: %s\n", h->worder ? "Big" : "Little");
@@ -61,92 +46,74 @@ static void header(RzBinFile *bf) {
 	p("CPU: %s\n", bin->cpu);
 	p("OS: %s\n", bin->os);
 	p("Version: %u\n", h->ver);
-	p("Flags: 0x%04x\n", h->mflags);
+	p("Flags: 0x%08x", h->mflags);
+	if (h->mflags) {
+#define PF_(mask, cond, name) \
+	if ((h->mflags & mask) cond) { \
+		p(" " name); \
+	}
+		PF_(M_SINGLE_DATA, , "SINGLEDATA");
+		PF_(M_PP_LIB_INIT, , "INITINSTANCE");
+		PF_(M_PP_LIB_TERM, , "TERMINSTANCE");
+		PF_(M_INTERNAL_FIXUP, , "NOINTFIXUPS");
+		PF_(M_EXTERNAL_FIXUP, , "NOEXTFIXUPS");
+		if (h->mflags & M_USES_PM_WINDOWING) {
+			p(" PMWINAPI");
+		} else {
+			PF_(M_PM_WINDOWING_INCOMP, , " PMWININCOMP");
+			PF_(M_PM_WINDOWING_COMPAT, , " PMWINCOMPAT");
+		}
+		PF_(M_TYPE_PM_DLL, , "PROTDLL");
+		PF_(M_TYPE_MASK, == M_TYPE_EXE, "EXE");
+		PF_(M_TYPE_MASK, == M_TYPE_DLL, "DLL");
+		PF_(M_TYPE_MASK, == M_TYPE_PDD, "PDD");
+		PF_(M_TYPE_MASK, == M_TYPE_VDD, "VDD");
+		PF_(M_MP_UNSAFE, , "MPUNSAFE");
+	}
+	p("\n");
 	p("Pages: %u\n", h->mpages);
 	p("InitialEipObj: %u\n", h->startobj);
-	p("InitialEip: 0x%04x\n", h->eip);
+	p("InitialEip: 0x%x\n", h->eip);
 	p("InitialStackObj: %u\n", h->stackobj);
-	p("InitialEsp: 0x%04x\n", h->esp);
-	p("Page Size: 0x%04x\n", h->pagesize);
+	p("InitialEsp: 0x%x\n", h->esp);
+	p("Page Size: 0x%x\n", h->pagesize);
 	if (bin->is_le) {
-		p("Last Page Size: 0x%04x\n", h->pageshift);
+		p("Last Page Size: 0x%x\n", h->le_last_page_size);
 	} else {
-		p("Page Shift: 0x%04x\n", h->pageshift);
+		p("Page Shift: 0x%x\n", h->pageshift);
 	}
-	p("Fixup Size: 0x%04x\n", h->fixupsize);
-	p("Fixup Checksum: 0x%04x\n", h->fixupsum);
-	p("Loader Size: 0x%04x\n", h->ldrsize);
-	p("Loader Checksum: 0x%04x\n", h->ldrsum);
-	p("Obj Table: 0x%04x\n", h->objtab);
+	p("Fixup Size: 0x%x\n", h->fixupsize);
+	p("Fixup Checksum: 0x%x\n", h->fixupsum);
+	p("Loader Size: 0x%x\n", h->ldrsize);
+	p("Loader Checksum: 0x%x\n", h->ldrsum);
+	p("Obj Table: 0x%x\n", h->objtab);
 	p("Obj Count: %u\n", h->objcnt);
-	p("Obj Page Map: 0x%04x\n", h->objmap);
-	p("Obj Iter Data Map: 0x%04x\n", h->itermap);
-	p("Resource Table: 0x%04x\n", h->rsrctab);
+	p("Obj Page Map: 0x%x\n", h->objmap);
+	p("Obj Iter Data Map: 0x%x\n", h->itermap);
+	p("Resource Table: 0x%x\n", h->rsrctab);
 	p("Resource Count: %u\n", h->rsrccnt);
-	p("Resident Name Table: 0x%04x\n", h->restab);
-	p("Entry Table: 0x%04x\n", h->enttab);
-	p("Directives Table: 0x%04x\n", h->dirtab);
+	p("Resident Name Table: 0x%x\n", h->restab);
+	p("Entry Table: 0x%x\n", h->enttab);
+	p("Directives Table: 0x%x\n", h->dirtab);
 	p("Directives Count: %u\n", h->dircnt);
-	p("Fixup Page Table: 0x%04x\n", h->fpagetab);
-	p("Fixup Record Table: 0x%04x\n", h->frectab);
-	p("Import Module Name Table: 0x%04x\n", h->impmod);
+	p("Fixup Page Table: 0x%x\n", h->fpagetab);
+	p("Fixup Record Table: 0x%x\n", h->frectab);
+	p("Import Module Name Table: 0x%x\n", h->impmod);
 	p("Import Module Name Count: %u\n", h->impmodcnt);
-	p("Import Procedure Name Table: 0x%04x\n", h->impproc);
-	p("Per-Page Checksum Table: 0x%04x\n", h->pagesum);
-	p("Enumerated Data Pages: 0x%04x\n", h->datapage);
+	p("Import Procedure Name Table: 0x%x\n", h->impproc);
+	p("Per-Page Checksum Table: 0x%x\n", h->pagesum);
+	p("Enumerated Data Pages: 0x%x\n", h->datapage);
 	p("Number of preload pages: %u\n", h->preload);
-	p("Non-resident Names Table: 0x%04x\n", h->nrestab);
+	p("Non-resident Names Table: 0x%x\n", h->nrestab);
 	p("Size Non-resident Names: %u\n", h->cbnrestab);
-	p("Checksum Non-resident Names: 0x%04x\n", h->nressum);
+	p("Checksum Non-resident Names: 0x%x\n", h->nressum);
 	p("Autodata Obj: %u\n", h->autodata);
-	p("Debug Info: 0x%04x\n", h->debuginfo);
-	p("Debug Length: 0x%04x\n", h->debuglen);
+	p("Debug Info: 0x%x\n", h->debuginfo);
+	p("Debug Length: 0x%x\n", h->debuglen);
 	p("Preload pages: %u\n", h->instpreload);
 	p("Demand pages: %u\n", h->instdemand);
-	p("Heap Size: 0x%04x\n", h->heapsize);
-	p("Stack Size: 0x%04x\n", h->stacksize);
-}
-
-static RzList /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
-	return rz_bin_le_get_sections(bf->o->bin_obj);
-}
-
-static RzList /*<RzBinAddr *>*/ *entries(RzBinFile *bf) {
-	return rz_bin_le_get_entrypoints(bf->o->bin_obj);
-}
-
-static RzList /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
-	return rz_bin_le_get_symbols(bf->o->bin_obj);
-}
-
-static RzList /*<RzBinImport *>*/ *imports(RzBinFile *bf) {
-	return rz_bin_le_get_imports(bf->o->bin_obj);
-}
-
-static RzList /*<char *>*/ *libs(RzBinFile *bf) {
-	return rz_bin_le_get_libs(bf->o->bin_obj);
-}
-
-static RzList /*<RzBinReloc *>*/ *relocs(RzBinFile *bf) {
-	return rz_bin_le_get_relocs(bf->o->bin_obj);
-}
-
-static RzBinInfo *info(RzBinFile *bf) {
-	RzBinInfo *info = RZ_NEW0(RzBinInfo);
-	if (info) {
-		rz_bin_le_obj_t *bin = bf->o->bin_obj;
-		LE_image_header *h = bin->header;
-		info->bits = 32;
-		info->type = strdup(bin->type);
-		info->cpu = strdup(bin->cpu);
-		info->os = strdup(bin->os);
-		info->arch = strdup(bin->arch);
-		info->file = strdup(bin->filename ? bin->filename : "");
-		info->big_endian = h->worder;
-		info->has_va = true;
-		info->baddr = 0;
-	}
-	return info;
+	p("Heap Size: 0x%x\n", h->heapsize);
+	p("Stack Size: 0x%x\n", h->stacksize);
 }
 
 static RzList /*<RzBinString *>*/ *strings(RzBinFile *bf) {
@@ -158,19 +125,20 @@ RzBinPlugin rz_bin_plugin_le = {
 	.desc = "LE/LX format plugin",
 	.author = "GustavoLCR",
 	.license = "LGPL3",
-	.check_buffer = &check_buffer,
-	.load_buffer = &load_buffer,
-	.destroy = &destroy,
-	.info = &info,
-	.header = &header,
-	.maps = &rz_bin_maps_of_file_sections,
-	.sections = &sections,
-	.entries = &entries,
-	.symbols = &symbols,
-	.imports = &imports,
+	.check_buffer = &rz_bin_le_check_buffer,
+	.load_buffer = &rz_bin_le_load_buffer,
+	.destroy = &rz_bin_le_destroy,
+	.info = &le_info,
+	.header = &le_header,
+	.virtual_files = &rz_bin_le_get_virtual_files,
+	.maps = &rz_bin_le_get_maps,
+	.sections = &rz_bin_le_get_sections,
+	.entries = &rz_bin_le_get_entry_points,
+	.symbols = &rz_bin_le_get_symbols,
+	.imports = &rz_bin_le_get_imports,
 	.strings = &strings,
-	.libs = &libs,
-	.relocs = &relocs,
+	.libs = &rz_bin_le_get_libs,
+	.relocs = &rz_bin_le_get_relocs,
 	.minstrlen = 4
 	// .regstate = &regstate
 };

--- a/test/db/formats/le
+++ b/test/db/formats/le
@@ -18,69 +18,10 @@ NAME=cdogs.exe sections
 FILE=bins/le/cdogs.exe
 CMDS=iS
 EXPECT=<<EOF
-paddr      size   vaddr      vsize  align perm name          type flags 
-------------------------------------------------------------------------
-0x0000d200 0x1000 0x00010000 0x1000 0x0   -r-x obj.1.page.0       
-0x0000e200 0x1000 0x00011000 0x1000 0x0   -r-x obj.1.page.1       
-0x0000f200 0x1000 0x00012000 0x1000 0x0   -r-x obj.1.page.2       
-0x00010200 0x1000 0x00013000 0x1000 0x0   -r-x obj.1.page.3       
-0x00011200 0x1000 0x00014000 0x1000 0x0   -r-x obj.1.page.4       
-0x00012200 0x1000 0x00015000 0x1000 0x0   -r-x obj.1.page.5       
-0x00013200 0x1000 0x00016000 0x1000 0x0   -r-x obj.1.page.6       
-0x00014200 0x1000 0x00017000 0x1000 0x0   -r-x obj.1.page.7       
-0x00015200 0x1000 0x00018000 0x1000 0x0   -r-x obj.1.page.8       
-0x00016200 0x1000 0x00019000 0x1000 0x0   -r-x obj.1.page.9       
-0x00017200 0x1000 0x0001a000 0x1000 0x0   -r-x obj.1.page.10      
-0x00018200 0x1000 0x0001b000 0x1000 0x0   -r-x obj.1.page.11      
-0x00019200 0x1000 0x0001c000 0x1000 0x0   -r-x obj.1.page.12      
-0x0001a200 0x1000 0x0001d000 0x1000 0x0   -r-x obj.1.page.13      
-0x0001b200 0x1000 0x0001e000 0x1000 0x0   -r-x obj.1.page.14      
-0x0001c200 0x1000 0x0001f000 0x1000 0x0   -r-x obj.1.page.15      
-0x0001d200 0x1000 0x00020000 0x1000 0x0   -r-x obj.1.page.16      
-0x0001e200 0x1000 0x00021000 0x1000 0x0   -r-x obj.1.page.17      
-0x0001f200 0x1000 0x00022000 0x1000 0x0   -r-x obj.1.page.18      
-0x00020200 0x1000 0x00023000 0x1000 0x0   -r-x obj.1.page.19      
-0x00021200 0x1000 0x00024000 0x1000 0x0   -r-x obj.1.page.20      
-0x00022200 0x1000 0x00025000 0x1000 0x0   -r-x obj.1.page.21      
-0x00023200 0x1000 0x00026000 0x1000 0x0   -r-x obj.1.page.22      
-0x00024200 0x1000 0x00027000 0x1000 0x0   -r-x obj.1.page.23      
-0x00025200 0x1000 0x00028000 0x1000 0x0   -r-x obj.1.page.24      
-0x00026200 0x1000 0x00029000 0x1000 0x0   -r-x obj.1.page.25      
-0x00027200 0x1000 0x0002a000 0x1000 0x0   -r-x obj.1.page.26      
-0x00028200 0x1000 0x0002b000 0x1000 0x0   -r-x obj.1.page.27      
-0x00029200 0x1000 0x0002c000 0x1000 0x0   -r-x obj.1.page.28      
-0x0002a200 0x1000 0x0002d000 0x1000 0x0   -r-x obj.1.page.29      
-0x0002b200 0x1000 0x0002e000 0x1000 0x0   -r-x obj.1.page.30      
-0x0002c200 0x1000 0x0002f000 0x1000 0x0   -r-x obj.1.page.31      
-0x0002d200 0x1000 0x00030000 0x1000 0x0   -r-x obj.1.page.32      
-0x0002e200 0x1000 0x00031000 0x1000 0x0   -r-x obj.1.page.33      
-0x0002f200 0x1000 0x00032000 0x1000 0x0   -r-x obj.1.page.34      
-0x00030200 0x1000 0x00033000 0x1000 0x0   -r-x obj.1.page.35      
-0x00031200 0x1000 0x00034000 0x1000 0x0   -r-x obj.1.page.36      
-0x00032200 0x1000 0x00035000 0x1000 0x0   -r-x obj.1.page.37      
-0x00033200 0x1000 0x00036000 0x1000 0x0   -r-x obj.1.page.38      
-0x00034200 0x1000 0x00037000 0x1000 0x0   -r-x obj.1.page.39      
-0x00035200 0x1000 0x00038000 0x1000 0x0   -r-x obj.1.page.40      
-0x00036200 0x1000 0x00039000 0x1000 0x0   -r-x obj.1.page.41      
-0x00037200 0x1000 0x0003a000 0x1000 0x0   -r-x obj.1.page.42      
-0x00038200 0x1000 0x0003b000 0x1000 0x0   -r-x obj.1.page.43      
-0x00039200 0x1000 0x0003c000 0x1000 0x0   -r-x obj.1.page.44      
-0x0003a200 0x1000 0x00040000 0x1000 0x0   -rw- obj.2.page.0       
-0x0003b200 0x1000 0x00041000 0x1000 0x0   -rw- obj.2.page.1       
-0x0003c200 0x1000 0x00042000 0x1000 0x0   -rw- obj.2.page.2       
-0x0003d200 0x1000 0x00043000 0x1000 0x0   -rw- obj.2.page.3       
-0x0003e200 0x1000 0x00044000 0x1000 0x0   -rw- obj.2.page.4       
-0x0003f200 0x1000 0x00045000 0x1000 0x0   -rw- obj.2.page.5       
-0x00040200 0x1000 0x00046000 0x1000 0x0   -rw- obj.2.page.6       
-0x00041200 0x1000 0x00047000 0x1000 0x0   -rw- obj.2.page.7       
-0x00042200 0x1000 0x00048000 0x1000 0x0   -rw- obj.2.page.8       
-0x00043200 0x1000 0x00049000 0x1000 0x0   -rw- obj.2.page.9       
-0x00044200 0x1000 0x0004a000 0x1000 0x0   -rw- obj.2.page.10      
-0x00045200 0x1000 0x0004b000 0x1000 0x0   -rw- obj.2.page.11      
-0x00046200 0x1000 0x0004c000 0x1000 0x0   -rw- obj.2.page.12      
-0x00047200 0x1000 0x0004d000 0x1000 0x0   -rw- obj.2.page.13      
-0x00048200 0x1000 0x0004e000 0x1000 0x0   -rw- obj.2.page.14      
-0x00049200 0xd8c  0x0004f000 0x1000 0x0   -rw- obj.2.page.15      
+paddr      size    vaddr      vsize   align perm name   type flags 
+-------------------------------------------------------------------
+0x0000d200 0x2d000 0x00010000 0x2d000 0x0   -r-x obj1_1      
+0x0003a200 0xfd8c  0x00040000 0x26030 0x0   -rw- obj2_1      
 EOF
 RUN
 
@@ -155,7 +96,7 @@ cat $relocs~0x0004e~?
 cat $relocs~0x0004f~?
 EOF
 EXPECT=<<EOF
-5239
+5237
 151
 160
 102
@@ -199,9 +140,9 @@ EXPECT=<<EOF
 179
 103
 128
-158
+157
 128
-9
+8
 0
 0
 282
@@ -212,14 +153,14 @@ EXPECT=<<EOF
 0
 0
 95
-82
+81
 45
-7
+6
 0
 0
 381
 561
-590
+588
 EOF
 RUN
 
@@ -243,26 +184,12 @@ NAME=GCC.EXE sections
 FILE=bins/le/GCC.EXE
 CMDS=iS
 EXPECT=<<EOF
-paddr      size   vaddr      vsize     align perm name          type flags 
----------------------------------------------------------------------------
-0x00001000 0x1000 0x00010000 0x1000    0x0   -r-x obj.1.page.0       
-0x00002000 0x1000 0x00011000 0x1000    0x0   -r-x obj.1.page.1       
-0x00003000 0x1000 0x00012000 0x1000    0x0   -r-x obj.1.page.2       
-0x00004000 0x1000 0x00013000 0x1000    0x0   -r-x obj.1.page.3       
-0x00005000 0x1000 0x00014000 0x1000    0x0   -r-x obj.1.page.4       
-0x00006000 0x1000 0x00015000 0x1000    0x0   -r-x obj.1.page.5       
-0x00007000 0x1000 0x00016000 0x1000    0x0   -r-x obj.1.page.6       
-0x00008000 0x1000 0x00017000 0x1000    0x0   -r-x obj.1.page.7       
-0x00009000 0x1000 0x00018000 0x1000    0x0   -r-x obj.1.page.8       
-0x0000a000 0x1000 0x00019000 0x1000    0x0   -r-x obj.1.page.9       
-0x0000b000 0x1000 0x0001a000 0x1000    0x0   -r-x obj.1.page.10      
-0x0000c000 0x1000 0x0001b000 0x1000    0x0   -r-x obj.1.page.11      
-0x0000d000 0x1000 0x0001c000 0x1000    0x0   -r-x obj.1.page.12      
-0x0000e000 0x1000 0x0001d000 0x1000    0x0   -r-x obj.1.page.13      
-0x0000f000 0x1000 0x0001e000 0x1000    0x0   -r-x obj.1.page.14      
-0x00010000 0x1000 0x00020000 0x1000    0x0   -rw- obj.2.page.0       
-0x00000000 0x0    0x00030000 0x2000000 0x0   -rw- obj.3              
-0x00000000 0x0    0x02030000 0x800000  0x0   -rw- obj.4              
+paddr      size   vaddr      vsize     align perm name   type flags 
+--------------------------------------------------------------------
+0x00001000 0xf000 0x00010000 0xf000    0x0   -r-x obj1_1      
+0x00010000 0x1000 0x00020000 0x2804    0x0   -rw- obj2_1      
+0x00000000 0x0    0x00030000 0x2000000 0x0   -rw- obj3_1      
+0x00000000 0x0    0x02030000 0x800000  0x0   -rw- obj4_1      
 EOF
 RUN
 
@@ -270,19 +197,19 @@ NAME=GCC.EXE relocations
 FILE=bins/le/GCC.EXE
 CMDS=ir
 EXPECT=<<EOF
-vaddr      paddr      type   name         
-------------------------------------------
-0x00010006 0x00001006 SET_32 emx.1
-0x0001000d 0x0000100d SET_32 emx.2
-0x0001d210 0x0000e210 SET_32 doscalls.273
-0x0001d234 0x0000e234 SET_32 doscalls.253
-0x0001d266 0x0000e266 SET_32 doscalls.283
-0x0001d282 0x0000e282 SET_32 doscalls.229
-0x0001d2f2 0x0000e2f2 SET_32 doscalls.257
-0x0001d389 0x0000e389 SET_32 doscalls.282
-0x0001d39f 0x0000e39f SET_32 doscalls.257
-0x0001d3d9 0x0000e3d9 SET_32 doscalls.281
-0x0001d3f4 0x0000e3f4 SET_32 doscalls.257
+vaddr      paddr      target     type   name         
+-----------------------------------------------------
+0x00010006 0x00001006 0x02832000 SET_32 emx_1
+0x0001000d 0x0000100d 0x02832004 SET_32 emx_2
+0x0001d210 0x0000e210 0x02832008 SET_32 doscalls_273
+0x0001d234 0x0000e234 0x0283200c SET_32 doscalls_253
+0x0001d266 0x0000e266 0x02832010 SET_32 doscalls_283
+0x0001d282 0x0000e282 0x02832014 SET_32 doscalls_229
+0x0001d2f2 0x0000e2f2 0x02832018 SET_32 doscalls_257
+0x0001d389 0x0000e389 0x0283201c SET_32 doscalls_282
+0x0001d39f 0x0000e39f 0x02832018 SET_32 doscalls_257
+0x0001d3d9 0x0000e3d9 0x02832020 SET_32 doscalls_281
+0x0001d3f4 0x0000e3f4 0x02832018 SET_32 doscalls_257
 EOF
 RUN
 
@@ -310,6 +237,7 @@ FILE=bins/le/GNUGREP.DLL
 CMDS=ie:vaddr:quiet
 EXPECT=<<EOF
 0x00010000
+0x00010ddc
 EOF
 RUN
 
@@ -317,9 +245,50 @@ NAME=GNUGREP.DLL symbol
 FILE=bins/le/GNUGREP.DLL
 CMDS=is
 EXPECT=<<EOF
-nth paddr      vaddr      bind   type size lib name     
---------------------------------------------------------
-1   0x00000000 0x00010ddc GLOBAL FUNC 0        grepmain
+nth paddr      vaddr      bind   type size lib name            
+---------------------------------------------------------------
+1   0x000023dc 0x00010ddc GLOBAL UNK  0        grepmain
+2   0x00000000 0x00043000 GLOBAL UNK  0        imp.EMXLIBC_513
+3   0x00000000 0x00043004 GLOBAL UNK  0        imp.emx_2
+4   0x00000000 0x00043008 GLOBAL UNK  0        imp.EMXLIBC_770
+5   0x00000000 0x0004300c GLOBAL UNK  0        imp.EMXLIBC_712
+6   0x00000000 0x00043010 GLOBAL UNK  0        imp.EMXLIBC_521
+7   0x00000000 0x00043014 GLOBAL UNK  0        imp.EMXLIBC_205
+8   0x00000000 0x00043018 GLOBAL UNK  0        imp.EMXLIBC_402
+9   0x00000000 0x0004301c GLOBAL UNK  0        imp.EMXLIBC_595
+10  0x00000000 0x00043020 GLOBAL UNK  0        imp.EMXLIBC_403
+11  0x00000000 0x00043024 GLOBAL UNK  0        imp.EMXLIBC_534
+12  0x00000000 0x00043028 GLOBAL UNK  0        imp.EMXLIBC_214
+13  0x00000000 0x0004302c GLOBAL UNK  0        imp.EMXLIBC_218
+14  0x00000000 0x00043030 GLOBAL UNK  0        imp.EMXLIBC_219
+15  0x00000000 0x00043034 GLOBAL UNK  0        imp.EMXLIBC_221
+16  0x00000000 0x00043038 GLOBAL UNK  0        imp.EMXLIBC_545
+17  0x00000000 0x0004303c GLOBAL UNK  0        imp.EMXLIBC_801
+18  0x00000000 0x00043040 GLOBAL UNK  0        imp.EMXLIBC_546
+19  0x00000000 0x00043044 GLOBAL UNK  0        imp.EMXLIBC_548
+20  0x00000000 0x00043048 GLOBAL UNK  0        imp.EMXLIBC_228
+21  0x00000000 0x0004304c GLOBAL UNK  0        imp.EMXLIBC_557
+22  0x00000000 0x00043050 GLOBAL UNK  0        imp.EMXLIBC_817
+23  0x00000000 0x00043054 GLOBAL UNK  0        imp.EMXLIBC_705
+24  0x00000000 0x00043058 GLOBAL UNK  0        imp.EMXLIBC_520
+25  0x00000000 0x0004305c GLOBAL UNK  0        imp.EMXLIBC_716
+26  0x00000000 0x00043060 GLOBAL UNK  0        imp.EMXLIBC_525
+27  0x00000000 0x00043064 GLOBAL UNK  0        imp.EMXLIBC_400
+28  0x00000000 0x00043068 GLOBAL UNK  0        imp.EMXLIBC_215
+29  0x00000000 0x0004306c GLOBAL UNK  0        imp.EMXLIBC_541
+30  0x00000000 0x00043070 GLOBAL UNK  0        imp.EMXLIBC_223
+31  0x00000000 0x00043074 GLOBAL UNK  0        imp.EMXLIBC_504
+32  0x00000000 0x00043078 GLOBAL UNK  0        imp.EMXLIBC_700
+33  0x00000000 0x0004307c GLOBAL UNK  0        imp.EMXLIBC_509
+34  0x00000000 0x00043080 GLOBAL UNK  0        imp.EMXLIBC_761
+35  0x00000000 0x00043084 GLOBAL UNK  0        imp.EMXLIBC_315
+36  0x00000000 0x00043088 GLOBAL UNK  0        imp.EMXLIBC_401
+37  0x00000000 0x0004308c GLOBAL UNK  0        imp.EMXLIBC_213
+38  0x00000000 0x00043090 GLOBAL UNK  0        imp.GNUREGEX_4
+39  0x00000000 0x00043094 GLOBAL UNK  0        imp.GNUREGEX_6
+40  0x00000000 0x00043098 GLOBAL UNK  0        imp.GNUREGEX_9
+41  0x00000000 0x0004309c GLOBAL UNK  0        imp.GNUREGEX_12
+42  0x00000000 0x000430a0 GLOBAL UNK  0        imp.EMXLIBC_207
 EOF
 RUN
 
@@ -327,19 +296,12 @@ NAME=GNUGREP.DLL sections
 FILE=bins/le/GNUGREP.DLL
 CMDS=iS
 EXPECT=<<EOF
-paddr      size   vaddr      vsize  align perm name         type flags 
------------------------------------------------------------------------
-0x00001600 0x1000 0x00010000 0x1000 0x0   -r-x obj.1.page.0      
-0x00002600 0x1000 0x00011000 0x1000 0x0   -r-x obj.1.page.1      
-0x00003600 0x1000 0x00012000 0x1000 0x0   -r-x obj.1.page.2      
-0x00004600 0x1000 0x00013000 0x1000 0x0   -r-x obj.1.page.3      
-0x00005600 0x1000 0x00014000 0x1000 0x0   -r-x obj.1.page.4      
-0x00006600 0x1000 0x00015000 0x1000 0x0   -r-x obj.1.page.5      
-0x00007600 0x1000 0x00016000 0x1000 0x0   -r-x obj.1.page.6      
-0x00008600 0xe00  0x00017000 0x1000 0x0   -r-x obj.1.page.7      
-0x00009400 0x200  0x00020000 0x1000 0x0   -r-x obj.2.page.0      
-0x00009600 0x200  0x00030000 0x1000 0x0   -r-x obj.3.page.0      
-0x00001400 0x200  0x00040000 0x1000 0x0   -rw- obj.4.page.0      
+paddr      size   vaddr      vsize  align perm name   type flags 
+-----------------------------------------------------------------
+0x00001600 0x7e00 0x00010000 0x8000 0x0   -r-x obj1_1      
+0x00009400 0x200  0x00020000 0x1000 0x0   -r-x obj2_1      
+0x00009600 0x200  0x00030000 0x1000 0x0   -r-x obj3_1      
+0x00001400 0x200  0x00040000 0x1000 0x0   -rw- obj4_1      
 EOF
 RUN
 
@@ -381,41 +343,71 @@ aac
 aflc
 EOF
 EXPECT=<<EOF
-802
+789
 EOF
 RUN
 
 NAME=LE: corkami cdogs.exe - entrypoint
-BROKEN=1
 FILE=bins/le/cdogs.exe
 CMDS=s
 EXPECT=<<EOF
-0x3bc
+0x26058
 EOF
 RUN
 
 NAME=LE: corkami cdogs.exe - pi 1
-BROKEN=1
 FILE=bins/le/cdogs.exe
 CMDS=pi 1
 EXPECT=<<EOF
-jmp 0x465
+jmp 0x260d0
 EOF
 RUN
 
-NAME=LE: cdogs.exe segments
-BROKEN=1
-FILE=bins/le/cdogs.exe
-CMDS=iS*
+NAME=DOSEXT.EXE open extender binary
+FILE=bins/le/DOSEXT.EXE
+CMDS=iH~header offset
 EXPECT=<<EOF
-fs sections
-S 0x00000060 0x00000060 0x00002930 0x00002930 seg_000 23
-f section.seg_000 10544 0x00000060
-f section_end.seg_000 1 0x00002990
-CC section 0 va=0x00000060 pa=0x00000060 sz=10544 vsz=10544 rwx=-rwx seg_000 @ 0x00000060
-S 0x00002990 0x00002990 0x00000402 0x00000402 seg_001 23
-f section.seg_001 1026 0x00002990
-f section_end.seg_001 1 0x00002d92
-CC section 1 va=0x00002990 pa=0x00002990 sz=1026 vsz=1026 rwx=-rwx seg_001 @ 0x00002990
+MZ header offset: 0x352a4
+LE header offset: 0x3803c
+EOF
+RUN
+
+NAME=hellolx.dll unpack iterated page
+FILE=bins/le/hellolx.dll
+CMDS=p8 12 @ 0x20004
+EXPECT=<<EOF
+68656c6c6f206c7820646c6c
+EOF
+RUN
+
+NAME=sdl.dll unpack compressed page
+FILE=bins/le/sdl.dll
+CMDS=p8 8 @ 0x20000
+EXPECT=<<EOF
+ccebfd9090909000
+EOF
+RUN
+
+NAME=sdl.dll 16:32 fixup
+FILE=bins/le/sdl.dll
+CMDS=p8 6 @ 0x1000B
+EXPECT=<<EOF
+595005000200
+EOF
+RUN
+
+NAME=sdl.dll 32 bit relative fixup
+FILE=bins/le/sdl.dll
+CMDS=p8 4 @ 0x202bd
+EXPECT=<<EOF
+3fad0500
+EOF
+RUN
+
+NAME=sdl.dll 32 bit absolute fixup
+FILE=bins/le/sdl.dll
+CMDS=p8 4 @ 0x20b32
+EXPECT=<<EOF
+69010600
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

I've been working on LE/LX plugin for some time. I intended just to apply relocations, but ended up with almost a complete rewrite. The original code was unsalvageable IMO, a fix to all its issues would be almost as heavy as a rewrite and would be very convoluted. Anyway, git diff for librz/bin/format/le/le.c is useless, one needs to read the whole thing to review it. 

The list of notable fixes:

1. Relocations are now applied, so analysis is able to decode jump tables.
2. Virtual files are used for patching, imports now point to reloc-targets virtual file. 
3. The minimum amount of continuous sections is created. The old code used to create a section per memory page. This is frustrating when file has hundreds of pages, but just two LE objects (segments). Those objects are usually continuous and such file should have just two sections. However pages can occur out of order or some pages may be compressed, so it's not always possible to create a single continuous section per object.
4. DOS extender bound LE executables are supported now. The old code used to work only in pure LE or MZ+LE cases. This is for working with DOS-era software, a lot of games used DOS/4GW then. 
5. Compressed (type 5) pages are supported now.
6. Added some support for 16-bit relocations.

Besides numerous small issues were fixed, misparsing LE entries, phantom fixups, memory leaks, undefined behavior, endless loops, etc. The new code should be more robust on malformed input.

I am not sure if I should elaborate on the implementation and in what detail. Code has some comments, should be reasonably readable, but let me know if you have any questions.

...

**Test plan**

I've updated tests accordingly. I ran ```rz-test test/db/formats/le``` when testing. I also tested on multiple OS/2 warp 4.52 files, but those are probably copyrighted.

...

**Closing issues**

Is part of #1530

...
