### PR TITLE
arm: use `cortexm` cpu instead of `cortex`

### DIFF
--- a/librz/analysis/p/analysis_arm_cs.c
+++ b/librz/analysis/p/analysis_arm_cs.c
@@ -1737,7 +1737,7 @@ static int analysis_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *bu
 	int n, ret;
 	mode |= (a->big_endian) ? CS_MODE_BIG_ENDIAN : CS_MODE_LITTLE_ENDIAN;
 	if (RZ_STR_ISNOTEMPTY(a->cpu)) {
-		if (strstr(a->cpu, "cortex")) {
+		if (strstr(a->cpu, "cortexm") || strstr(a->cpu, "cortex-m")) {
 			mode |= CS_MODE_MCLASS;
 		}
 		if (a->bits != 64 && strstr(a->cpu, "v8")) {

--- a/librz/asm/p/asm_arm_cs.c
+++ b/librz/asm/p/asm_arm_cs.c
@@ -102,7 +102,7 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	}
 
 	if (a->cpu) {
-		if (strstr(a->cpu, "cortex")) {
+		if (strstr(a->cpu, "cortexm") || strstr(a->cpu, "cortex-m")) {
 			mode |= CS_MODE_MCLASS;
 		}
 		if (a->bits != 64) {
@@ -298,7 +298,7 @@ static char *mnemonics(RzAsm *a, int id, bool json) {
 RzAsmPlugin rz_asm_plugin_arm_cs = {
 	.name = "arm",
 	.desc = "Capstone ARM disassembler",
-	.cpus = "v8,cortex,arm1176,cortexA72,cortexA8",
+	.cpus = "v8,cortexm,arm1176,cortexA72,cortexA8",
 	.platforms = "bcm2835,omap3430",
 	.features = "v8",
 	.license = "BSD",

--- a/test/db/asm/arm_cortexm_16
+++ b/test/db/asm/arm_cortexm_16
@@ -1,1 +1,2 @@
 d "mrs r0, primask" eff31080
+d "msr basepri, r3" 83f31188

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -32,15 +32,15 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=pd v8 and cortex
+NAME=pd V8 and Cortex-M profiles 
 FILE=malloc://128
 ARGS=-a arm -b 16
 CMDS=<<EOF
 echo
 pad fff7c0ea@e:asm.cpu=v8
-pad fff7c0ea@e:asm.cpu=cortex
+pad fff7c0ea@e:asm.cpu=cortexm
 pad fff7c0ea@e:asm.cpu=v8
-pad fff7c0ea@e:asm.cpu=cortex
+pad fff7c0ea@e:asm.cpu=cortexm
 pad fff7c0ea@e:asm.cpu=v8
 pad fff7c0ea@e:asm.cpu=
 pad fff7c0ea@e:asm.cpu=tetris

--- a/test/db/cmd/cmd_pd_bugs
+++ b/test/db/cmd/cmd_pd_bugs
@@ -15,7 +15,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=pd arm cortex 0
+NAME=pd arm cortex-m 0
 FILE==
 ARGS=-a arm -b 16
 CMDS=wx 80f30988; pi 1
@@ -25,9 +25,9 @@ EOF
 EXPECT_ERR=
 RUN
 
-NAME=pd arm cortex 1
+NAME=pd arm cortex-m 1
 FILE==
-ARGS=-a arm -b 16 -e asm.cpu=cortex
+ARGS=-a arm -b 16 -e asm.cpu=cortexm
 CMDS=wx 80f30988;pi 1
 EXPECT=<<EOF
 msr psp, r0
@@ -35,10 +35,10 @@ EOF
 EXPECT_ERR=
 RUN
 
-NAME=pd arm cortex 2
+NAME=pd arm cortex-m 2
 FILE==
 ARGS=-a arm -b 16
-CMDS=e asm.cpu=cortex;wx 80f30988;pi 1
+CMDS=e asm.cpu=cortexm;wx 80f30988;pi 1
 EXPECT=<<EOF
 msr psp, r0
 EOF

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -388,7 +388,7 @@ RUN
 
 NAME=rz-asm -c
 FILE==
-CMDS=!rz-asm -a arm -b 16 -d -c cortex 0x80f30988
+CMDS=!rz-asm -a arm -b 16 -d -c cortexm 0x80f30988
 EXPECT=<<EOF
 msr psp, r0
 EOF
@@ -396,7 +396,7 @@ RUN
 
 NAME=rz-asm -A with -c and -o
 FILE==
-CMDS=!rz-asm -a arm -b 16 -A -o 0x1000 -c cortex 0x80f30988
+CMDS=!rz-asm -a arm -b 16 -A -o 0x1000 -c cortexm 0x80f30988
 EXPECT=<<EOF
 offset:   0x00001000
 bytes:    80f30988


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Before Rizin enabled "M" profile if it met any string "cortex" in `asm.cpu`. But this is wrong, since "Cortex-A" models do not have "M" profile: https://developer.arm.com/Architectures/M-Profile%20Architecture

Use `cortexm` instead. Rename and add one more test from https://github.com/rizinorg/rizin/issues/3505

**Test plan**

CI is green