### PR TITLE
reuse: fix DEP5 format for multiline copyright

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -185,18 +185,18 @@ License: LGPL-3.0-only
 
 Files: librz/magic/*
 Copyright: 1986-1995 Ian F. Darwin
-Copyright: 1995-present Christos Zoulas and others
+           1995-present Christos Zoulas and others
 License: BSD-2-Clause
 
 Files: librz/util/regex/*
 Copyright: 1992, 1993, 1994 Henry Spencer
-Copyright: 1992, 1993, 1994 The Regents of the University of California
+           1992, 1993, 1994 The Regents of the University of California
 License: BSD-3-Clause
 
 Files: subprojects/rzheap/rz_jemalloc/*
 Copyright: 2002-present Jason Evans <jasone@canonware.com>
-Copyright: 2007-2012 Mozilla Foundation.
-Copyright: 2009-present Facebook, Inc.
+           2007-2012 Mozilla Foundation.
+           2009-present Facebook, Inc.
 License: BSD-2-Clause
 
 Files: subprojects/rzspp/*
@@ -205,7 +205,7 @@ License: MIT
 
 Files: subprojects/rzwinkd/profiles.h
 Copyright: 2014-2017 The Lemon Man <thatlemon@gmail.com>
-Copyright: 2019-2020 GustavoLCR <gugulcr@gmail.com>
+           2019-2020 GustavoLCR <gugulcr@gmail.com>
 License: LGPL-3.0-only
 
 Files: subprojects/mpc/*


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Should fix annoying redness of the CI
Multiple `Copyright:` fields aren't allowed in the DEP5 file and were simply ignored in the past. Use the proper syntax now: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/#copyright-field

See also https://github.com/fsfe/reuse-tool/issues/803

**Test plan**

CI is green