### PR TITLE
Fix `fl.` commands and add tests

### DIFF
--- a/librz/core/cflag.c
+++ b/librz/core/cflag.c
@@ -10,6 +10,7 @@
 struct print_flag_t {
 	RzFlag *f;
 	PJ *pj;
+	RzTable *tbl;
 	bool in_range;
 	ut64 range_from;
 	ut64 range_to;
@@ -17,8 +18,12 @@ struct print_flag_t {
 	bool real;
 };
 
-static bool print_flag_name(RzFlagItem *fi, void *user) {
-	rz_cons_printf("%s\n", fi->name);
+static bool print_flag_name(RzFlagItem *flag, void *user) {
+	struct print_flag_t *u = (struct print_flag_t *)user;
+	if (u->in_range && (flag->offset < u->range_from || flag->offset >= u->range_to)) {
+		return true;
+	}
+	rz_cons_printf("%s\n", flag->name);
 	return true;
 }
 
@@ -95,71 +100,49 @@ static bool print_flag_orig_name(RzFlagItem *flag, void *user) {
 	return true;
 }
 
-typedef struct {
-	RzTable *t;
-} FlagTableData;
-
-static bool __tableItemCallback(RzFlagItem *flag, void *user) {
-	FlagTableData *ftd = user;
+static bool print_flag_table(RzFlagItem *flag, void *user) {
+	struct print_flag_t *u = (struct print_flag_t *)user;
+	if (u->in_range && (flag->offset < u->range_from || flag->offset >= u->range_to)) {
+		return true;
+	}
 	if (!RZ_STR_ISEMPTY(flag->name)) {
-		RzTable *t = ftd->t;
 		const char *spaceName = (flag->space && flag->space->name) ? flag->space->name : "";
-		rz_table_add_rowf(t, "Xdss", flag->offset, flag->size, spaceName, flag->name);
+		rz_table_add_rowf(u->tbl, "Xdss", flag->offset, flag->size, spaceName, flag->name);
 	}
 	return true;
 }
 
 static void flag_print(RzFlag *f, RzCmdStateOutput *state, ut64 range_from, ut64 range_to, bool in_range) {
 	rz_return_if_fail(f);
+	struct print_flag_t u = {
+		.f = f,
+		.in_range = in_range,
+		.range_from = range_from,
+		.range_to = range_to,
+		.real = false
+	};
+
 	switch (state->mode) {
 	case RZ_OUTPUT_MODE_QUIET:
-		rz_flag_foreach_space(f, rz_flag_space_cur(f), print_flag_name, f);
+		rz_flag_foreach_space(f, rz_flag_space_cur(f), print_flag_name, &u);
 		break;
-	case RZ_OUTPUT_MODE_STANDARD: {
-		struct print_flag_t u = {
-			.f = f,
-			.in_range = in_range,
-			.range_from = range_from,
-			.range_to = range_to,
-			.real = false
-		};
+	case RZ_OUTPUT_MODE_STANDARD:
 		rz_flag_foreach_space(f, rz_flag_space_cur(f), print_flag_orig_name, &u);
 		break;
-	}
-	case RZ_OUTPUT_MODE_JSON: {
-		struct print_flag_t u = {
-			.f = f,
-			.pj = state->d.pj,
-			.in_range = in_range,
-			.range_from = range_from,
-			.range_to = range_to,
-			.real = false
-		};
+	case RZ_OUTPUT_MODE_JSON:
+		u.pj = state->d.pj;
 		pj_a(state->d.pj);
 		rz_flag_foreach_space(f, rz_flag_space_cur(f), print_flag_json, &u);
 		pj_end(state->d.pj);
 		break;
-	}
-	case RZ_OUTPUT_MODE_RIZIN: {
-		struct print_flag_t u = {
-			.f = f,
-			.in_range = in_range,
-			.range_from = range_from,
-			.range_to = range_to,
-			.fs = NULL,
-		};
+	case RZ_OUTPUT_MODE_RIZIN:
 		rz_flag_foreach_space(f, rz_flag_space_cur(f), print_flag_rizin, &u);
 		break;
-	}
-	case RZ_OUTPUT_MODE_TABLE: {
-		FlagTableData ftd = { 0 };
-		ftd.t = state->d.t;
+	case RZ_OUTPUT_MODE_TABLE:
+		u.tbl = state->d.t;
 		rz_cmd_state_output_set_columnsf(state, "Xdss", "addr", "size", "space", "name");
-
-		RzSpace *curSpace = rz_flag_space_cur(f);
-		rz_flag_foreach_space(f, curSpace, __tableItemCallback, &ftd);
+		rz_flag_foreach_space(f, rz_flag_space_cur(f), print_flag_table, &u);
 		break;
-	}
 	default:
 		rz_warn_if_reached();
 		break;

--- a/test/db/cmd/cmd_flags
+++ b/test/db/cmd/cmd_flags
@@ -641,6 +641,36 @@ bla ~
 EOF
 RUN
 
+NAME=flag list at
+FILE==
+CMDS=<<EOF
+f blah 0x0000000a @ 0x0000000b
+f bloh 0x00000003 @ 0x00000002
+fl. @ 0x0000000b
+fl.j @ 0x0000000b
+fl.t @ 0x0000000b
+fl.q @ 0x0000000b
+fl. @ 0x00000002
+fl.j @ 0x00000002
+fl.t @ 0x00000002
+fl.q @ 0x00000002
+EOF
+EXPECT=<<EOF
+0x0000000b 10 blah
+[{"name":"blah","size":10,"offset":11}]
+addr       size space name 
+---------------------------
+0x0000000b 10         blah
+blah
+0x00000002 3 bloh
+[{"name":"bloh","size":3,"offset":2}]
+addr       size space name 
+---------------------------
+0x00000002 3          bloh
+bloh
+EOF
+RUN
+
 NAME=no useless flags at 0
 FILE=bins/elf/ls
 CMDS=<<EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Before some `fl.` subcommands listed all flags, not only located in specified range - `fl.q`("QUIET" mode), `fl.t` ("TABLE" mode). Also added tests for these.

Simplified code a bit as well.

**Test plan**

CI is green