### PR TITLE
meson: do not use `add_global_arguments()`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('rizin', 'c',
   version: 'v0.8.0',
-  license: 'LGPL3',
+  license: 'LGPL-3.0-only',
   meson_version: '>=0.57.0',
   default_options: [
     'buildtype=debugoptimized',

--- a/meson.build
+++ b/meson.build
@@ -80,14 +80,14 @@ if is_static_build
 endif
 
 if cc.has_argument('--std=gnu99')
-  add_global_arguments('--std=gnu99', language: ['c', 'cpp'])
+  add_project_arguments('--std=gnu99', language: ['c', 'cpp'])
 elif cc.has_argument('--std=c99')
-  add_global_arguments('--std=c99', language: ['c', 'cpp'])
+  add_project_arguments('--std=c99', language: ['c', 'cpp'])
 endif
 
 # Sanitize correct usage of rz_strf()
 if cc.has_argument('-Werror=sizeof-pointer-memaccess')
-  add_global_arguments('-Werror=sizeof-pointer-memaccess', language: ['c', 'cpp'])
+  add_project_arguments('-Werror=sizeof-pointer-memaccess', language: ['c', 'cpp'])
 endif
 
 if cc.has_argument('-Wimplicit-fallthrough=3')
@@ -106,16 +106,16 @@ endif
 
 if get_option('default_library') == 'shared'
   if cc.has_argument('-fvisibility=hidden')
-    add_global_arguments('-fvisibility=hidden', language: 'c')
+    add_project_arguments('-fvisibility=hidden', language: 'c')
   endif
 endif
 
 add_project_arguments(['-DRZ_PLUGIN_INCORE=1'], language: 'c')
 b_sanitize_opt = get_option('b_sanitize')
 if (b_sanitize_opt.contains('address') or b_sanitize_opt.contains('undefined')) and cc.get_id() == 'clang'
-  add_global_arguments('-shared-libasan', language: 'c')
+  add_project_arguments('-shared-libasan', language: 'c')
   add_global_link_arguments('-shared-libasan', language: 'c')
-  add_global_arguments('-shared-libasan', language: 'c', native: true)
+  add_project_arguments('-shared-libasan', language: 'c', native: true)
   add_global_link_arguments('-shared-libasan', language: 'c', native: true)
 endif
 

--- a/subprojects/nettle/meson.build
+++ b/subprojects/nettle/meson.build
@@ -1,5 +1,5 @@
 project('nettle', 'c',
-  license: [ 'LGPL'],
+  license: 'LGPL',
   version: '3.7.3'
 )
 # https://git.lysator.liu.se/nettle/nettle

--- a/subprojects/packagefiles/blake3/meson.build
+++ b/subprojects/packagefiles/blake3/meson.build
@@ -1,4 +1,11 @@
-project('blake3', 'c', version: '1.3.1', license : ['CC0-1.0'], meson_version: '>=0.55.0')
+project('blake3', 'c',
+  version: '1.3.1',
+  license: 'CC0-1.0',
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
+)
 
 cc = meson.get_compiler('c')
 

--- a/subprojects/packagefiles/capstone-4.0.2/meson.build
+++ b/subprojects/packagefiles/capstone-4.0.2/meson.build
@@ -1,4 +1,10 @@
-project('capstone', 'c', version: '4.0.2', meson_version: '>=0.55.0')
+project('capstone', 'c',
+  version: '4.0.2',
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
+)
 
 cs_files = [
   'arch/AArch64/AArch64BaseInfo.c',

--- a/subprojects/packagefiles/capstone-5.0.1/meson.build
+++ b/subprojects/packagefiles/capstone-5.0.1/meson.build
@@ -1,4 +1,10 @@
-project('capstone', 'c', version: '5.0.1', meson_version: '>=0.55.0')
+project('capstone', 'c',
+  version: '5.0.1',
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
+)
 
 cs_files = [
   'arch/AArch64/AArch64BaseInfo.c',

--- a/subprojects/packagefiles/capstone-auto-sync-aarch64/meson.build
+++ b/subprojects/packagefiles/capstone-auto-sync-aarch64/meson.build
@@ -1,4 +1,10 @@
-project('capstone', 'c', version: '5.0.1', meson_version: '>=0.55.0')
+project('capstone', 'c',
+  version: '5.0.1',
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
+)
 
 cs_files = [
   'arch/AArch64/AArch64BaseInfo.c',

--- a/subprojects/packagefiles/capstone-next/meson.build
+++ b/subprojects/packagefiles/capstone-next/meson.build
@@ -1,4 +1,10 @@
-project('capstone', 'c', version: 'next', meson_version: '>=0.55.0')
+project('capstone', 'c',
+  version: 'next',
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
+)
 
 cs_files = [
   'arch/Alpha/AlphaDisassembler.c',

--- a/subprojects/packagefiles/libmspack/meson.build
+++ b/subprojects/packagefiles/libmspack/meson.build
@@ -1,4 +1,11 @@
-project('libmspack', 'c', version: '0.10.1alpha', license : ['LGPL2'], meson_version: '>=0.55.0')
+project('libmspack', 'c',
+  version: '0.10.1alpha',
+  license : 'LGPL2',
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
+)
 
 cc = meson.get_compiler('c')
 

--- a/subprojects/packagefiles/libzip-1.9.2/meson.build
+++ b/subprojects/packagefiles/libzip-1.9.2/meson.build
@@ -1,5 +1,11 @@
 project('libzip', 'c',
-  version: '1.9.2')
+  version: '1.9.2',
+  license: 'BSD-3-clause',
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
+)
 
 py3_exe = import('python').find_installation()
 cc = meson.get_compiler('c')

--- a/subprojects/packagefiles/lz4-1.9.4/meson.build
+++ b/subprojects/packagefiles/lz4-1.9.4/meson.build
@@ -1,7 +1,11 @@
 project('lz4', ['c'],
-  license: ['BSD', 'GPLv2'],
+  license: 'BSD-2-Clause-Patent AND GPL-2.0-or-later',
   version: '1.9.4',
-  meson_version: '>=0.47.0')
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
+)
 
 lz4_files = [
   'lib/lz4.c',

--- a/subprojects/packagefiles/rizin-grammar-c/meson.build
+++ b/subprojects/packagefiles/rizin-grammar-c/meson.build
@@ -1,4 +1,11 @@
-project('rizin-grammar-c', 'c', default_options: ['werror=false'])
+project('rizin-grammar-c', 'c',
+  license: 'MIT',
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+    'werror=false'
+    ]
+)
 
 ts_c_files = [
   'src/parser.c'

--- a/subprojects/packagefiles/tree-sitter-0.21.0/meson.build
+++ b/subprojects/packagefiles/tree-sitter-0.21.0/meson.build
@@ -1,4 +1,10 @@
-project('tree-sitter', 'c')
+project('tree-sitter', 'c',
+  license: 'MIT',
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
+)
 
 cc = meson.get_compiler('c')
 

--- a/subprojects/packagefiles/xz-5.2.9/meson.build
+++ b/subprojects/packagefiles/xz-5.2.9/meson.build
@@ -1,7 +1,12 @@
 # liblzma is what upstream uses for their pkg-config name
 project('liblzma', 'c',
   version : '5.2.9',
-  license : 'pd/lgpl2/gpl2/gpl3',)
+  license : ['PD', 'LGPL2', 'GPL2', 'GPL3'],
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
+)
 
 cc = meson.get_compiler('c')
 

--- a/subprojects/packagefiles/zlib-1.3.1/meson.build
+++ b/subprojects/packagefiles/zlib-1.3.1/meson.build
@@ -1,4 +1,11 @@
-project('zlib', 'c', version : '1.3.1', license : 'zlib')
+project('zlib', 'c',
+  version : '1.3.1',
+  license : 'zlib',
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
+)
 
 cc = meson.get_compiler('c')
 

--- a/subprojects/rizin-shell-parser/meson.build
+++ b/subprojects/rizin-shell-parser/meson.build
@@ -1,5 +1,9 @@
 project('rizin-shell-parser', 'c',
-  license : [ 'LGPL']
+  license: 'LGPL-3.0-only',
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
 )
 
 tree_sitter_dep = dependency('tree-sitter')

--- a/subprojects/rzar/meson.build
+++ b/subprojects/rzar/meson.build
@@ -1,5 +1,9 @@
 project('rzar', 'c',
-  license : [ 'LGPL']
+  license: 'LGPL-3.0-only',
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
 )
 
 # handle ar dependency

--- a/subprojects/rzqnx/meson.build
+++ b/subprojects/rzqnx/meson.build
@@ -1,5 +1,9 @@
 project('rzqnx', 'c',
-  license : [ 'GPL']
+  license: 'GPL-2.0-only',
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
 )
 
 qnx_files = [

--- a/subprojects/rzwinkd/meson.build
+++ b/subprojects/rzwinkd/meson.build
@@ -1,5 +1,9 @@
 project('rzwinkd', 'c',
-  license : [ 'LGPL']
+  license: 'LGPL-3.0-only',
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
 )
 
 cc = meson.get_compiler('c')

--- a/subprojects/xxhash/meson.build
+++ b/subprojects/xxhash/meson.build
@@ -1,7 +1,12 @@
 project('xxhash', 'c',
-    # library files are BSD licensed. xxhsum utility is GPL licensed.
-    license : [ 'BSD', 'GPL'],
-    version : '0.6.5')
+  # library files are BSD licensed. xxhsum utility is GPL licensed.
+  version : '0.6.5',
+  license: 'BSD-2-Clause AND GPL-2.0-or-later',
+  meson_version: '>=0.55.0',
+  default_options: [
+    'c_std=c99',
+  ]
+)
 
 inc = include_directories('.')
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`add_global_arguments()` prevents using Rizin as a subproject for Meson WrapDB: https://github.com/rizinorg/rizin/issues/3454

```
wrapdb on  rizin                                                                                                                                                                                           13:49:03
ℤ meson setup builddir -Dwraps=rizin
The Meson build system
Version: 1.2.0
Source dir: /Users/user/Rizin/wrapdb
Build dir: /Users/user/Rizin/wrapdb/builddir
Build type: native build
Project name: wrapdb
Project version: undefined
Host machine cpu family: aarch64
Host machine cpu: aarch64

Executing subproject rizin

rizin| Project name: rizin
rizin| Project version: v0.6.0
rizin| C compiler for the host machine: cc (clang 14.0.0 "Apple clang version 14.0.0 (clang-1400.0.29.202)")
rizin| C linker for the host machine: cc ld64 820.1
rizin| Program python3 found: YES (/opt/homebrew/opt/python@3.11/bin/python3.11)
rizin| Program git found: YES (/usr/bin/git)
rizin| Message: rizin lib version: 0.6
rizin| Compiler for C supports arguments --std=gnu99: YES

subprojects/rizin/meson.build:83:2: ERROR: Function 'add_global_arguments' cannot be used in subprojects because there is no way to make that reliable.
Please only call this if is_subproject() returns false. Alternatively, define a variable that
contains your language-specific arguments and add it to the appropriate *_args kwarg in each target.
```

Switch to use `add_project_arguments()` instead:

https://mesonbuild.com/Reference-manual_functions.html#add_project_arguments

Necessary for https://github.com/rizinorg/rizin/issues/3454

**Test plan**

CI is green