### PR TITLE
Zero-initialize all members of ut128

### DIFF
--- a/librz/include/rz_endian.h
+++ b/librz/include/rz_endian.h
@@ -308,7 +308,7 @@ static inline void rz_write_at_le64(void *dest, ut64 val, size_t offset) {
 }
 
 static inline ut128 rz_read_le128(const void *src) {
-	ut128 val = { 0, 0 };
+	ut128 val;
 	val.High = rz_read_at_le64(src, sizeof(ut64));
 	val.Low = rz_read_le64(src);
 	return val;

--- a/librz/include/rz_endian.h
+++ b/librz/include/rz_endian.h
@@ -128,7 +128,7 @@ static inline void rz_write_at_be64(void *dest, ut64 val, size_t offset) {
 }
 
 static inline ut128 rz_read_be128(const void *src) {
-	ut128 val = { 0 };
+	ut128 val = { 0, 0 };
 	val.High = rz_read_be64(src);
 	val.Low = rz_read_at_be64(src, sizeof(ut64));
 	return val;
@@ -308,7 +308,7 @@ static inline void rz_write_at_le64(void *dest, ut64 val, size_t offset) {
 }
 
 static inline ut128 rz_read_le128(const void *src) {
-	ut128 val = { 0 };
+	ut128 val = { 0, 0 };
 	val.High = rz_read_at_le64(src, sizeof(ut64));
 	val.Low = rz_read_le64(src);
 	return val;

--- a/librz/include/rz_endian.h
+++ b/librz/include/rz_endian.h
@@ -128,7 +128,7 @@ static inline void rz_write_at_be64(void *dest, ut64 val, size_t offset) {
 }
 
 static inline ut128 rz_read_be128(const void *src) {
-	ut128 val = { 0, 0 };
+	ut128 val;
 	val.High = rz_read_be64(src);
 	val.Low = rz_read_at_be64(src, sizeof(ut64));
 	return val;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

To avoid warning when compiled Rizin as part of Cutter:
```
/__w/cutter/cutter/build/Rizin-prefix/include/librz/rz_endian.h: In function 'ut128 rz_read_be128(const void*)':
/__w/cutter/cutter/build/Rizin-prefix/include/librz/rz_endian.h:131:18: warning: missing initializer for member '_ut128::High' [-Wmissing-field-initializers]
  ut128 val = { 0 };
                  ^
/__w/cutter/cutter/build/Rizin-prefix/include/librz/rz_endian.h: In function 'ut128 rz_read_le128(const void*)':
/__w/cutter/cutter/build/Rizin-prefix/include/librz/rz_endian.h:311:18: warning: missing initializer for member '_ut128::High' [-Wmissing-field-initializers]
  ut128 val = { 0 };
                  ^
```

**Test plan**

CI is green