### PR TITLE
Update Docker image from Debian 10 ("buster") to Debian 12 ("bookworm")

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@
 # $ rizin -d /bin/true
 #
 
-FROM debian:10
+FROM debian:12
 
 # rz-pipe python version
 ARG RZ_PIPE_PY_VERSION=master
@@ -85,7 +85,7 @@ RUN git clone --recurse-submodules -b "$RZ_GHIDRA_VERSION" https://github.com/ri
 WORKDIR /tmp/rz-ghidra
 RUN cmake -DCMAKE_PREFIX_PATH=/tmp/rizin-install/usr -DCMAKE_INSTALL_PREFIX=/usr -B build && cmake --build build && DESTDIR=/tmp/rizin-install cmake --build build --target install
 
-FROM debian:10
+FROM debian:12
 ENV RZ_ARM64_AS=${with_arm64_as:+aarch64-linux-gnu-as}
 ENV RZ_ARM32_AS=${with_arm32_as:+arm-linux-gnueabi-as}
 ENV RZ_PPC_AS=${with_ppc_as:+powerpc64le-linux-gnu-as}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Debian 10 doesn't receive updates anymore and almost EOL. Time to update the base for the Docker image.

**Test plan**

CI is green