### PR TITLE
removed LE header free

### DIFF
--- a/librz/bin/format/le/le.c
+++ b/librz/bin/format/le/le.c
@@ -530,7 +530,6 @@ static bool le_load_header(rz_bin_le_obj_t *bin) {
 		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->instdemand) ||
 		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->heapsize) ||
 		!rz_buf_read_le32_offset(bin->buf, &off, &bin->header->stacksize)) {
-		free(bin->header);
 		return false;
 	}
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes a double free when loading a invalid LE file. No need to free the header in 'le_load_header' since the 'fail_cleanup' label of 'rz_bin_le_load_buffer' will do this via 'rz_bin_le_free'.


**Test plan**

echo "LEasdf" > test
rizin test

