### PR TITLE
Fix AVX512 detection and build in blake3

### DIFF
--- a/subprojects/packagefiles/blake3/meson.build
+++ b/subprojects/packagefiles/blake3/meson.build
@@ -9,6 +9,8 @@ blake3_files = [
   'c' / 'blake3.c',
 ]
 
+# Meson simd module is not used on purpose because it is unstable and not supported in muon
+
 blake3_simd = []
 
 simd_avx2 = '''
@@ -19,12 +21,12 @@ simd_avx2 = '''
 int main (int argc, char *argv[]) { __m256i add0 = _mm256_set_epi32(7, 6, 5, 4, 3, 2, 1, 0); return 0; }
 '''
 
-simd_avx512 = '''
+simd_avx512vl = '''
 #if defined(_MSC_VER)
 #include <intrin.h>
 #endif
 #include <immintrin.h>
-int main (int argc, char *argv[]) { __m256i add0 = _mm256_setr_epi64x(0, 1, 2, 3); return 0; }
+int main (int argc, char *argv[]) { __m128i v = _mm_ror_epi32(_mm_set_epi32(3, 2, 1, 0), 5); return 0; }
 '''
 
 simd_sse2 = '''
@@ -53,24 +55,24 @@ int main (int argc, char *argv[]) { uint32x4_t three = set1_128(3); return 0; }
 # msvc can't just compile assembly so we use the intrins directly
 # https://github.com/mesonbuild/meson/issues/9889
 win_msvc_asm = [
-  ['c' / 'blake3_avx2.c',   '-DBLAKE3_NO_AVX2',   'avx2',   simd_avx2,   ['/arch:AVX2']],
-  ['c' / 'blake3_avx512.c', '-DBLAKE3_NO_AVX512', 'avx512', simd_avx512, ['/arch:AVX512']],
-  ['c' / 'blake3_sse2.c',   '-DBLAKE3_NO_SSE2',   'sse2',   simd_sse2,   []], # sse2 extensions are enabled by default
-  ['c' / 'blake3_sse41.c',  '-DBLAKE3_NO_SSE41',  'sse41',  simd_sse41,  []], # sse41 extensions are enabled by default
+  ['c' / 'blake3_avx2.c',   '-DBLAKE3_NO_AVX2',   'avx2',     simd_avx2,     ['/arch:AVX2']],
+  ['c' / 'blake3_avx512.c', '-DBLAKE3_NO_AVX512', 'avx512vl', simd_avx512vl, ['/arch:AVX512']],
+  ['c' / 'blake3_sse2.c',   '-DBLAKE3_NO_SSE2',   'sse2',     simd_sse2,     []], # sse2 extensions are enabled by default
+  ['c' / 'blake3_sse41.c',  '-DBLAKE3_NO_SSE41',  'sse41',    simd_sse41,    []], # sse41 extensions are enabled by default
 ]
 
 win_gnu_asm = [
-  ['c' / 'blake3_avx2_x86-64_windows_gnu.S',   '-DBLAKE3_NO_AVX2',   'avx2',   simd_avx2,   ['-mavx2']],
-  ['c' / 'blake3_avx512_x86-64_windows_gnu.S', '-DBLAKE3_NO_AVX512', 'avx512', simd_avx512, ['-mavx512f', '-mavx512vl']],
-  ['c' / 'blake3_sse2_x86-64_windows_gnu.S',   '-DBLAKE3_NO_SSE2',   'sse2',   simd_sse2,   ['-msse2']],
-  ['c' / 'blake3_sse41_x86-64_windows_gnu.S',  '-DBLAKE3_NO_SSE41',  'sse41',  simd_sse41,  ['-msse4.1']],
+  ['c' / 'blake3_avx2_x86-64_windows_gnu.S',   '-DBLAKE3_NO_AVX2',   'avx2',     simd_avx2,     ['-mavx2']],
+  ['c' / 'blake3_avx512_x86-64_windows_gnu.S', '-DBLAKE3_NO_AVX512', 'avx512vl', simd_avx512vl, ['-mavx512f', '-mavx512vl']],
+  ['c' / 'blake3_sse2_x86-64_windows_gnu.S',   '-DBLAKE3_NO_SSE2',   'sse2',     simd_sse2,     ['-msse2']],
+  ['c' / 'blake3_sse41_x86-64_windows_gnu.S',  '-DBLAKE3_NO_SSE41',  'sse41',    simd_sse41,    ['-msse4.1']],
 ]
 
 unix_asm = [
-  ['c' / 'blake3_avx2_x86-64_unix.S',   '-DBLAKE3_NO_AVX2',   'avx2',   simd_avx2,   ['-mavx2']],
-  ['c' / 'blake3_avx512_x86-64_unix.S', '-DBLAKE3_NO_AVX512', 'avx512', simd_avx512, ['-mavx512f', '-mavx512vl']],
-  ['c' / 'blake3_sse2_x86-64_unix.S',   '-DBLAKE3_NO_SSE2',   'sse2',   simd_sse2,   ['-msse2']],
-  ['c' / 'blake3_sse41_x86-64_unix.S',  '-DBLAKE3_NO_SSE41',  'sse41',  simd_sse41,  ['-msse4.1']],
+  ['c' / 'blake3_avx2_x86-64_unix.S',   '-DBLAKE3_NO_AVX2',   'avx2',     simd_avx2,     ['-mavx2']],
+  ['c' / 'blake3_avx512_x86-64_unix.S', '-DBLAKE3_NO_AVX512', 'avx512vl', simd_avx512vl, ['-mavx512f', '-mavx512vl']],
+  ['c' / 'blake3_sse2_x86-64_unix.S',   '-DBLAKE3_NO_SSE2',   'sse2',     simd_sse2,     ['-msse2']],
+  ['c' / 'blake3_sse41_x86-64_unix.S',  '-DBLAKE3_NO_SSE41',  'sse41',    simd_sse41,    ['-msse4.1']],
 ]
 
 is_x64 = target_machine.cpu_family() == 'x86_64'
@@ -110,17 +112,21 @@ else
   endforeach
 endif
 
+blake3_libs = []
 foreach it : blake3_simd
   file = it[0]
-  flag = it[1]
+  disable_flag = it[1]
   name = it[2]
   code = it[3]
   args = it[4]
   has_extension = cc.compiles(code, args: args, name: name)
   if has_extension
-    blake3_files += file
+    # https://github.com/mesonbuild/meson/issues/1367
+    # Individual static libraries are needed to avoid passing the simd flags to the C files,
+    # which would make functions like memset() use potentially unsupported instructions at runtime.
+    blake3_libs += static_library('blake3_' + name, file, c_args: args)
   else
-    add_project_arguments(flag, language: 'c')
+    add_project_arguments(disable_flag, language: 'c')
   endif
 endforeach
 
@@ -130,6 +136,7 @@ blake3_inc = [
 
 blake3 = static_library('blake3', blake3_files,
   dependencies: [],
+  link_with: blake3_libs,
   include_directories: blake3_inc,
   implicit_include_directories: false
 )


### PR DESCRIPTION


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The test for avx512 could result in false-positives because the _mm256_setr_epi64x intrinsic requires only AVX, not AVX512. Specifically what is needed here is AVX512VL.
In addition, not passing the -mavx* args to the asm compilation failed the build on macOS High Sierra and below (Apple LLVM version 10.0.0, clang-1000.11.45.5)

See also the build failures by version here: https://ports.macports.org/port/rizin/details/

```
highsierra-vm:rizin vmuser$ ninja -Cbuild | head -n 40
ninja: Entering directory `build'
[1/151] Generating gittip_file with a custom command
[2/151] Compiling C object subprojects/blake3/libblake3.a.p/c_blake3_avx512_x86-64_unix.S.o
FAILED: subprojects/blake3/libblake3.a.p/c_blake3_avx512_x86-64_unix.S.o
cc -Isubprojects/blake3/libblake3.a.p -I../subprojects/blake3/c -fcolor-diagnostics -Wall -Winvalid-pch -O0 -g -DBLAKE3_USE_NEON=0 --std=gnu99 -Werror=sizeof-pointer-memaccess -fvisibility=hidden -MD -MQ subprojects/blake3/libblake3.a.p/c_blake3_avx512_x86-64_unix.S.o -MF subprojects/blake3/libblake3.a.p/c_blake3_avx512_x86-64_unix.S.o.d -o subprojects/blake3/libblake3.a.p/c_blake3_avx512_x86-64_unix.S.o -c ../subprojects/blake3/c/blake3_avx512_x86-64_unix.S
../subprojects/blake3/c/blake3_avx512_x86-64_unix.S:42:9: error: instruction requires: AVX-512 ISA
        kmovw k1, r9d
        ^
../subprojects/blake3/c/blake3_avx512_x86-64_unix.S:52:9: error: instruction requires: AVX-512 ISA AVX-512 VL ISA
        vpcmpltud k2, ymm2, ymm0
        ^
../subprojects/blake3/c/blake3_avx512_x86-64_unix.S:53:9: error: instruction requires: AVX-512 ISA AVX-512 VL ISA
        vpcmpltud k3, ymm3, ymm0
        ^
../subprojects/blake3/c/blake3_avx512_x86-64_unix.S:54:21: error: unexpected token in argument list
        vpaddd ymm4 {k2}, ymm4, dword ptr [ADD1+rip] {1to8}
                    ^
../subprojects/blake3/c/blake3_avx512_x86-64_unix.S:55:21: error: unexpected token in argument list
        vpaddd ymm5 {k3}, ymm5, dword ptr [ADD1+rip] {1to8}
                    ^
../subprojects/blake3/c/blake3_avx512_x86-64_unix.S:56:9: error: instruction requires: AVX-512 ISA
        knotw k2, k1
        ^
../subprojects/blake3/c/blake3_avx512_x86-64_unix.S:57:24: error: unexpected token in argument list
        vmovdqa32 ymm2 {k2}, ymm0
                       ^
../subprojects/blake3/c/blake3_avx512_x86-64_unix.S:58:24: error: unexpected token in argument list
        vmovdqa32 ymm3 {k2}, ymm0
                       ^
../subprojects/blake3/c/blake3_avx512_x86-64_unix.S:59:24: error: unexpected token in argument list
        vmovdqa32 ymm4 {k2}, ymm1
                       ^
../subprojects/blake3/c/blake3_avx512_x86-64_unix.S:60:24: error: unexpected token in argument list
        vmovdqa32 ymm5 {k2}, ymm1
                       ^
../subprojects/blake3/c/blake3_avx512_x86-64_unix.S:70:9: error: instruction requires: AVX-512 ISA
        vpbroadcastd zmm0, dword ptr [rcx]
        ^
../subprojects/blake3/c/blake3_avx512_x86-64_unix.S:71:9: error: instruction requires: AVX-512 ISA
        vpbroadcastd zmm1, dword ptr [rcx+0x1*0x4]
...
```

**Test plan**

Compile rizin on macOS High Sierra with default settings, should work fine.
