### PR TITLE
Fix blake3 build when a simd extension is missing

### DIFF
--- a/subprojects/packagefiles/blake3/meson.build
+++ b/subprojects/packagefiles/blake3/meson.build
@@ -112,22 +112,28 @@ else
   endforeach
 endif
 
-blake3_libs = []
+blake3_lib_defs = []
 foreach it : blake3_simd
-  file = it[0]
   disable_flag = it[1]
   name = it[2]
   code = it[3]
   args = it[4]
   has_extension = cc.compiles(code, args: args, name: name)
   if has_extension
-    # https://github.com/mesonbuild/meson/issues/1367
-    # Individual static libraries are needed to avoid passing the simd flags to the C files,
-    # which would make functions like memset() use potentially unsupported instructions at runtime.
-    blake3_libs += static_library('blake3_' + name, file, c_args: args)
+    blake3_lib_defs += [it]
   else
     add_project_arguments(disable_flag, language: 'c')
   endif
+endforeach
+
+# This must not happen inside the loop above because add_project_arguments() calls must precede any
+# build target declaration.
+blake3_libs = []
+foreach it : blake3_lib_defs
+    # https://github.com/mesonbuild/meson/issues/1367
+    # Individual static libraries are needed to avoid passing the simd flags to the C files,
+    # which would make functions like memset() use potentially unsupported instructions at runtime.
+    blake3_libs += static_library('blake3_' + it[2], it[0], c_args: it[4])
 endforeach
 
 blake3_inc = [


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

See https://github.com/rizinorg/rizin/pull/3749

Regression from avx512 fix:

> subprojects/blake3/meson.build:129:4: ERROR: Tried to use 'add_project_arguments' after a build target has been declared.

**Test plan**

CentOS 7 build should be green
