### PR TITLE
visual: mention `o` key in help

### DIFF
--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -298,7 +298,7 @@ static const char *help_msg_visual[] = {
 	"mK/'K", "mark/go to Key (any key)",
 	"n/N", "seek next/prev function/flag/hit (scr.nkey)",
 	"g", "go/seek to given offset (g[g/G]<enter> to seek begin/end of file)",
-	"O", "toggle asm.pseudo and asm.esil",
+	"o/O", "rotate between different formats (next/prev)",
 	"p/P", "rotate print modes (hex, disasm, debug, words, buf)",
 	"q", "back to rizin shell",
 	"r", "toggle call/jmp/lea hints",


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`o/O` rotates between different print modes - in hexadecimal output

**Test plan**

1. Open any binary
2. Open visual hex mode with `VP`
3. Press `o` and `O` to rotate between different hex representations

CI is green