### PR TITLE
visual: remove `prc=a` mode

### DIFF
--- a/librz/core/tui/modes.c
+++ b/librz/core/tui/modes.c
@@ -42,7 +42,7 @@ const char *print3Formats[PRINT_3_FORMATS] = { //  not used at all. its handled 
 };
 
 const char *print4Formats[PRINT_4_FORMATS] = {
-	"prc", "prc=a", "pxAv", "pxx", "p=e $r-2", "pk 64"
+	"prc", "pxA", "pxx", "p=e $r-2", "pk 64"
 };
 
 const char *print5Formats[PRINT_5_FORMATS] = {

--- a/librz/core/tui/modes.h
+++ b/librz/core/tui/modes.h
@@ -16,7 +16,7 @@ extern const char *printfmtColumns[NPF];
 // to print the stack in the debugger view
 #define PRINT_HEX_FORMATS 10
 #define PRINT_3_FORMATS   2
-#define PRINT_4_FORMATS   7
+#define PRINT_4_FORMATS   5
 #define PRINT_5_FORMATS   8
 
 extern const char *printHexFormats[PRINT_HEX_FORMATS];


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`prc=a` was removed during the `pr` conversion as unnecessary: https://github.com/rizinorg/rizin/commit/fd64b7ee25ccdfd6c3dd0536b8e322fd8bca39fc
 Remove it from visual modes as well.

**Test plan**
CI is green