### PR TITLE
Fix blake3 build with incompatible assemblers

### DIFF
--- a/subprojects/packagefiles/blake3/meson.build
+++ b/subprojects/packagefiles/blake3/meson.build
@@ -79,7 +79,9 @@ is_x64 = target_machine.cpu_family() == 'x86_64'
 is_arm = target_machine.cpu_family() == 'aarch64'
 has_intrins = cc.has_header('immintrin.h')
 
+has_simd = false
 if has_intrins and is_arm
+  has_simd = true
   has_neon = cc.compiles(simd_neon, args: [], name: 'neon')
   if has_neon
     blake3_files += 'c' / 'blake3_neon.c'
@@ -88,17 +90,22 @@ if has_intrins and is_arm
     add_project_arguments('-DBLAKE3_USE_NEON=0', language: 'c')
   endif
 elif has_intrins and is_x64
+  has_simd = true
   if target_machine.system() == 'windows'
     if cc.get_id() == 'msvc'
       blake3_simd = win_msvc_asm
     else # gcc or clang
       blake3_simd = win_gnu_asm
     endif
-  else # unix only
+  elif cc.compiles(files('unix_syntax_check.S')[0], args: [], name: 'asm_syntax') # unix only, check if the compiler supports the used asm syntax
     blake3_simd = unix_asm
+  else
+    has_simd = false
   endif
   add_project_arguments('-DBLAKE3_USE_NEON=0', language: 'c')
-else
+endif
+
+if not has_simd
   # since we do not support SIMD we just use the portable code.
   blake3_flags = [
     '-DBLAKE3_NO_SSE2',

--- a/subprojects/packagefiles/blake3/unix_syntax_check.S
+++ b/subprojects/packagefiles/blake3/unix_syntax_check.S
@@ -1,0 +1,30 @@
+#if defined(__ELF__) && defined(__linux__)
+.section .note.GNU-stack,"",%progbits
+#endif
+
+#if defined(__ELF__) && defined(__CET__) && defined(__has_include)
+#if __has_include(<cet.h>)
+#include <cet.h>
+#endif
+#endif
+
+#if !defined(_CET_ENDBR)
+#define _CET_ENDBR
+#endif
+
+.intel_syntax noprefix
+.global _blake3_hash_many_avx2
+.global blake3_hash_many_avx2
+#ifdef __APPLE__
+.text
+#else
+.section .text
+#endif
+        .p2align  6
+        mov r10d, dword ptr [rsp+0x110+8*rax]
+        jc 3f
+        nop
+		nop
+3:
+		nop
+		nop


### PR DESCRIPTION


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Apple Clang 4.2 on Mac OS X 10.7 Lion does support avx2, but it has issues with some of the asm syntax used, in particular jc and some mov syntax.
So we add an additional check for a short assembly snippet.

**Test plan**

Build on x86_64 platforms should recognize simd extensions as before (can be checked in the CI output), but building on Lion should not fail.