### PR TITLE
Fold same-typed variables if there are more than 3

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -476,6 +476,19 @@ static void update_syscall_ns(RzCore *core) {
 	}
 }
 
+static bool cb_asm_varfold(void *core, void *node) {
+	char *choice[] = { "none", "group", "hide" };
+	RzConfigNode *n = node;
+	const char *user_choice = n->value;
+	for (int i = 0; i < sizeof(choice) / sizeof(choice[0]); i++) {
+		if (!strcmp(choice[i], user_choice)) {
+			return true;
+		}
+	}
+	RZ_LOG_ERROR("asm.var.fold: Invalid choice. Only support `none, group, hide`\n");
+	return false;
+}
+
 static bool cb_asmarch(void *user, void *data) {
 	char asmparser[32];
 	RzCore *core = (RzCore *)user;
@@ -3142,7 +3155,9 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETBPREF("asm.var.access", "false", "Show accesses of local variables");
 	SETBPREF("asm.sub.var", "true", "Substitute variables in disassembly");
 	SETI("asm.var.summary", 0, "Show variables summary instead of full list in disasm (0, 1, 2)");
-	SETI("asm.var.fold", 0, "Fold same-typed variables (0, 1, 2)");
+	n = NODECB("asm.var.fold", "none", &cb_asm_varfold);
+	SETDESC(n, "Fold same-typed variables (support none, group, hide)");
+	SETOPTIONS(n, "none", "group", "hide", NULL);
 	SETBPREF("asm.sub.varonly", "true", "Substitute the entire variable expression with the local variable name (e.g. [local10h] instead of [ebp+local10h])");
 	SETBPREF("asm.sub.reg", "false", "Substitute register names with their associated role name (drp~=)");
 	SETBPREF("asm.sub.rel", "true", "Substitute pc relative expressions in disasm");

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3142,6 +3142,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETBPREF("asm.var.access", "false", "Show accesses of local variables");
 	SETBPREF("asm.sub.var", "true", "Substitute variables in disassembly");
 	SETI("asm.var.summary", 0, "Show variables summary instead of full list in disasm (0, 1, 2)");
+	SETI("asm.var.fold", 0, "Fold same-typed variables (0, 1, 2)");
 	SETBPREF("asm.sub.varonly", "true", "Substitute the entire variable expression with the local variable name (e.g. [local10h] instead of [ebp+local10h])");
 	SETBPREF("asm.sub.reg", "false", "Substitute register names with their associated role name (drp~=)");
 	SETBPREF("asm.sub.rel", "true", "Substitute pc relative expressions in disasm");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

There are three choice for `asm.var.fold`:
+ none -> no fold
+ group -> fold three variables in each group
+ hide -> group the first two variables with ellipsis in tail

as shown in the following picture.

![image](https://github.com/rizinorg/rizin/assets/58985155/b0aaa6c8-3dc5-45e2-a646-6857aaa4f7fd)



**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes https://github.com/rizinorg/rizin/issues/3701
