### PR TITLE
Refactor the pointer command to use the API

### DIFF
--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -908,12 +908,24 @@ RZ_IPI RzCmdStatus rz_push_escaped_handler(RzCore *core, int argc, const char **
 	return res;
 }
 
+static RzCmdStatus pointer_read(RzCore *core, const char *expr) {
+	ut64 n = rz_num_math(core->num, expr);
+	if (core->num->dbz) {
+		RZ_LOG_ERROR("core: RzNum ERROR: Division by Zero\n");
+		return RZ_CMD_STATUS_ERROR;
+	}
+	if (!rz_io_read_i(core->io, n, &n, core->rasm->bits / 8, core->print->big_endian)) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_cons_printf("0x%" PFMT64x "\n", n);
+	return RZ_CMD_STATUS_OK;
+}
+
 RZ_IPI RzCmdStatus rz_pointer_handler(RzCore *core, int argc, const char **argv) {
 	int ret;
 	switch (argc) {
 	case 2:
-		ret = rz_core_cmdf(core, "?v [%s]", argv[1]);
-		return rz_cmd_int2status(ret);
+		return pointer_read(core, argv[1]);
 	case 3:
 		if (rz_str_startswith(argv[2], "0x")) {
 			ret = rz_core_cmdf(core, "wv %s @ %s", argv[2], argv[1]);

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -576,21 +576,10 @@ static ut64 num_callback(RzNum *userptr, const char *str, int *ok) {
 		if (ok) {
 			*ok = 1;
 		}
-		ut8 buf[sizeof(ut64)] = RZ_EMPTY;
-		(void)rz_io_read_at(core->io, n, buf, RZ_MIN(sizeof(buf), refsz));
-		switch (refsz) {
-		case 8:
-			return rz_read_ble64(buf, core->print->big_endian);
-		case 4:
-			return rz_read_ble32(buf, core->print->big_endian);
-		case 2:
-			return rz_read_ble16(buf, core->print->big_endian);
-		case 1:
-			return rz_read_ble8(buf);
-		default:
-			RZ_LOG_ERROR("core: invalid reference size: %d (%s)\n", refsz, str);
+		if (!rz_io_read_i(core->io, n, &n, refsz, core->print->big_endian)) {
 			return 0LL;
 		}
+		return n;
 	} break;
 	case '$':
 		if (ok) {

--- a/test/db/cmd/cmd_pointer
+++ b/test/db/cmd/cmd_pointer
@@ -1,0 +1,18 @@
+NAME=pointer read
+FILE=malloc://1024
+CMDS=<<EOF
+wv8 0xdeadbeefdeadbeef
+*0
+*0 @e:asm.bits=64
+*0 @e:asm.bits=32
+*0 @e:asm.bits=16
+*0 @e:asm.arch=6502,asm.bits=8
+EOF
+EXPECT=<<EOF
+0xdeadbeefdeadbeef
+0xdeadbeefdeadbeef
+0xdeadbeef
+0xbeef
+0xef
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [X] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [X] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

See issue #3780. The `*` command still uses `rz_core_cmdf`, and the read case even invokes an no-longer-existent command (`?v` instead of `%v`).

This PR fixes the `*` command for read (and I'll also try to do writes shortly) by using the API.

This is a fix, no documentation or book updates needed.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

I've included a _pointer read_ test case in the newly-created `test/db/cmd/cmd_pointer`.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #3780 
