### PR TITLE
Fix cmd_pointer test on Travis

### DIFF
--- a/test/db/cmd/cmd_pointer
+++ b/test/db/cmd/cmd_pointer
@@ -5,7 +5,7 @@ wv8 0xdeadbeefdeadbeef
 *0
 *0 @e:asm.bits=64
 *0 @e:asm.bits=32
-*0 @e:asm.bits=16
+*0 @e:asm.arch=x86,asm.bits=16
 *0 @e:asm.arch=6502,asm.bits=8
 EOF
 EXPECT=<<EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the `cmd_pointer` test on Travis by adding an `asm.arch` override, since both PPC64 and S390X don't support `asm.bits=16`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
