### PR TITLE
Refactor pointer write command `*` to use the API

### DIFF
--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -929,7 +929,10 @@ static RzCmdStatus pointer_write(RzCore *core, const char *addr_arg, const char 
 		return RZ_CMD_STATUS_ERROR;
 	}
 
-	if (rz_str_startswith(value_arg, "0x")) {
+	if (rz_hex_str_is_valid(value_arg, false) > 0) {
+		// write a byte sequence
+		ok = rz_core_write_hexpair(core, addr, value_arg) > 0;
+	} else {
 		// write a numerical value
 		ut64 value = rz_num_math(core->num, value_arg);
 		if (core->num->nc.errors) {
@@ -938,9 +941,6 @@ static RzCmdStatus pointer_write(RzCore *core, const char *addr_arg, const char 
 		}
 
 		ok = rz_core_write_value_at(core, addr, value, core->rasm->bits / 8);
-	} else {
-		// write a byte sequence
-		ok = rz_core_write_hexpair(core, addr, value_arg) > 0;
 	}
 
 	return bool2status(ok);

--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -921,18 +921,37 @@ static RzCmdStatus pointer_read(RzCore *core, const char *expr) {
 	return RZ_CMD_STATUS_OK;
 }
 
+static RzCmdStatus pointer_write(RzCore *core, const char *addr_arg, const char *value_arg) {
+	bool ok;
+	ut64 addr = rz_num_math(core->num, addr_arg);
+	if (core->num->nc.errors) {
+		RZ_LOG_ERROR("Could not convert address argument to number");
+		return RZ_CMD_STATUS_ERROR;
+	}
+
+	if (rz_str_startswith(value_arg, "0x")) {
+		// write a numerical value
+		ut64 value = rz_num_math(core->num, value_arg);
+		if (core->num->nc.errors) {
+			RZ_LOG_ERROR("Could not convert value argument to number");
+			return RZ_CMD_STATUS_ERROR;
+		}
+
+		ok = rz_core_write_value_at(core, addr, value, core->rasm->bits / 8);
+	} else {
+		// write a byte sequence
+		ok = rz_core_write_hexpair(core, addr, value_arg) > 0;
+	}
+
+	return bool2status(ok);
+}
+
 RZ_IPI RzCmdStatus rz_pointer_handler(RzCore *core, int argc, const char **argv) {
-	int ret;
 	switch (argc) {
 	case 2:
 		return pointer_read(core, argv[1]);
 	case 3:
-		if (rz_str_startswith(argv[2], "0x")) {
-			ret = rz_core_cmdf(core, "wv %s @ %s", argv[2], argv[1]);
-		} else {
-			ret = rz_core_cmdf(core, "wx %s @ %s", argv[2], argv[1]);
-		}
-		return rz_cmd_int2status(ret);
+		return pointer_write(core, argv[1], argv[2]);
 	default:
 		return RZ_CMD_STATUS_WRONG_ARGS;
 	}

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -1102,7 +1102,8 @@ static const RzCmdDescHelp macros_call_multiple_help = {
 
 static const RzCmdDescDetailEntry pointer_Examples_detail_entries[] = {
 	{ .text = "*", .arg_str = "entry0=cc", .comment = "write trap in entrypoint" },
-	{ .text = "*", .arg_str = "entry0+10=0x804800", .comment = "write 0x804800 as a 4-byte value at 10 bytes from the entrypoint" },
+	{ .text = "*", .arg_str = "entry0+10=0x804800", .comment = "write 0x804800 with the current bitness, 10 bytes from the entrypoint" },
+	{ .text = "*", .arg_str = "$$=[entry0] @e:asm.bits=32", .comment = "write the 32-bits value read at the entrypoint to the current offset" },
 	{ .text = "*", .arg_str = "entry0", .comment = "read the value contained at the entrypoint" },
 	{ 0 },
 };
@@ -1118,7 +1119,8 @@ static const RzCmdDescArg pointer_args[] = {
 	},
 	{
 		.name = "value",
-		.type = RZ_CMD_ARG_TYPE_NUM,
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
 		.optional = true,
 
 	},
@@ -1126,8 +1128,8 @@ static const RzCmdDescArg pointer_args[] = {
 };
 static const RzCmdDescHelp pointer_help = {
 	.summary = "Pointer read/write data/values",
-	.description = "Read or write values at a given address. When the value starts with `0x`, a 4-bytes value or 8-bytes value is written in the memory at address, depending on the size of the value. When value does not start with `0x` an hexstring with arbitrary length is expected and it is written starting from the specified address.",
-	.args_str = "<addr>[=<0xvalue>|<hexstring>]",
+	.description = "Read or write values at a given address. When the value is a hexstring, it is decoded and written as raw bytes. Otherwise, it is evaluated as an expression and written using the current endianness and bitness settings.",
+	.args_str = "<addr>[=<expr>|<hexstring>]",
 	.details = pointer_details,
 	.args = pointer_args,
 };

--- a/librz/core/cmd_descs/cmd_descs.yaml
+++ b/librz/core/cmd_descs/cmd_descs.yaml
@@ -124,17 +124,15 @@ commands:
     cname: pointer
     summary: Pointer read/write data/values
     description: >
-      Read or write values at a given address. When the value starts with `0x`,
-      a 4-bytes value or 8-bytes value is written in the memory at address,
-      depending on the size of the value. When value does not start with `0x`
-      an hexstring with arbitrary length is expected and it is written starting
-      from the specified address.
-    args_str: "<addr>[=<0xvalue>|<hexstring>]"
+      Read or write values at a given address. When the value is a hexstring,
+      it is decoded and written as raw bytes. Otherwise, it is evaluated as an
+      expression and written using the current endianness and bitness settings.
+    args_str: "<addr>[=<expr>|<hexstring>]"
     args:
       - name: addr
         type: RZ_CMD_ARG_TYPE_RZNUM
       - name: value
-        type: RZ_CMD_ARG_TYPE_NUM
+        type: RZ_CMD_ARG_TYPE_RZNUM
         optional: true
     details:
       - name: Examples
@@ -144,7 +142,10 @@ commands:
             comment: write trap in entrypoint
           - text: "*"
             arg_str: "entry0+10=0x804800"
-            comment: write 0x804800 as a 4-byte value at 10 bytes from the entrypoint
+            comment: write 0x804800 with the current bitness, 10 bytes from the entrypoint
+          - text: "*"
+            arg_str: "$$=[entry0] @e:asm.bits=32"
+            comment: write the 32-bits value read at the entrypoint to the current offset
           - text: "*"
             arg_str: "entry0"
             comment: read the value contained at the entrypoint

--- a/librz/include/rz_util/rz_hex.h
+++ b/librz/include/rz_util/rz_hex.h
@@ -14,7 +14,7 @@ RZ_API int rz_hex_bin2str(const ut8 *in, int len, char *out);
 RZ_API void rz_hex_ut2st_str(const ut32 in, RZ_INOUT char *out, const int len);
 RZ_API char *rz_hex_bin2strdup(const ut8 *in, int len);
 RZ_API bool rz_hex_to_byte(ut8 *val, ut8 c);
-RZ_API int rz_hex_str_is_valid(const char *s);
+RZ_API int rz_hex_str_is_valid(const char *s, bool allow_prefix);
 RZ_API st64 rz_hex_bin_truncate(ut64 in, int n);
 RZ_API char *rz_hex_from_c(const char *code);
 RZ_API char *rz_hex_from_py(const char *code);

--- a/librz/reg/arena.c
+++ b/librz/reg/arena.c
@@ -324,7 +324,7 @@ RZ_API ut8 *rz_reg_arena_dup(RzReg *reg, const ut8 *source) {
 
 RZ_API int rz_reg_arena_set_bytes(RzReg *reg, const char *str) {
 	str = rz_str_trim_head_ro(str);
-	int len = rz_hex_str_is_valid(str);
+	int len = rz_hex_str_is_valid(str, true);
 	if (len == -1) {
 		eprintf("Invalid input\n");
 		return -1;

--- a/librz/util/hex.c
+++ b/librz/util/hex.c
@@ -550,11 +550,19 @@ RZ_API st64 rz_hex_bin_truncate(ut64 in, int n) {
 	return in;
 }
 
-// Check if str contains only hexadecimal characters and return length of bytes
-RZ_API int rz_hex_str_is_valid(const char *str) {
+/**
+ * \brief Check if \p str contains only hexadecimal characters
+ *
+ * Check that the input string is in the hexadecimal form (e.g. "41424344", with whitespace ignored), and return the number of bytes of its raw binary form (4 for the previous example), or an error if non-hexadecimal characters were found
+ *
+ * \param str Input string in hexadecimal form.
+ * \param allow_prefix Whether an optional "0x" prefix may be present at the start of \p str.
+ * \return number of bytes in the raw binary form of \p str, or -1 if invalid characters were found
+ */
+RZ_API int rz_hex_str_is_valid(const char *str, bool allow_prefix) {
 	int i;
 	int len = 0;
-	if (!strncmp(str, "0x", 2)) {
+	if (allow_prefix && !strncmp(str, "0x", 2)) {
 		str += 2;
 	}
 	for (i = 0; str[i] != '\0'; i++) {

--- a/test/db/cmd/cmd_pointer
+++ b/test/db/cmd/cmd_pointer
@@ -40,6 +40,9 @@ wx ffffffffffffffff
 wx ffffffffffffffff
 *0+2=0xbeefdea0+0xd @e:asm.bits=32
 *0 @e:asm.bits=64
+wx efbeaddeffffffff
+*0+4=[0] @e:asm.bits=64
+*0 @e:asm.bits=64
 EOF
 EXPECT=<<EOF
 0xdeadbeefdeadbeef
@@ -48,6 +51,7 @@ EXPECT=<<EOF
 0xffffffffffffbeef
 0xffffffffffffffef
 0xffffbeefdeadffff
+0xdeadbeefdeadbeef
 EOF
 RUN
 

--- a/test/db/cmd/cmd_pointer
+++ b/test/db/cmd/cmd_pointer
@@ -7,6 +7,7 @@ wv8 0xdeadbeefdeadbeef
 *0 @e:asm.bits=32
 *0 @e:asm.arch=x86,asm.bits=16
 *0 @e:asm.arch=6502,asm.bits=8
+*0+2 @e:asm.bits=32
 EOF
 EXPECT=<<EOF
 0xdeadbeefdeadbeef
@@ -14,5 +15,50 @@ EXPECT=<<EOF
 0xdeadbeef
 0xbeef
 0xef
+0xbeefdead
+EOF
+RUN
+
+NAME=pointer write value
+FILE=malloc://1024
+CMDS=<<EOF
+wx ffffffffffffffff
+*0=0xdeadbeefdeadbeef
+*0 @e:asm.bits=64
+wx ffffffffffffffff
+*0=0xdeadbeefdeadbeef @e:asm.bits=64
+*0 @e:asm.bits=64
+wx ffffffffffffffff
+*0=0xdeadbeef @e:asm.bits=32
+*0 @e:asm.bits=64
+wx ffffffffffffffff
+*0=0xbeef @e:asm.arch=x86,asm.bits=16
+*0 @e:asm.bits=64
+wx ffffffffffffffff
+*0=0xef @e:asm.arch=6502,asm.bits=8
+*0 @e:asm.bits=64
+wx ffffffffffffffff
+*0+2=0xbeefdea0+0xd @e:asm.bits=32
+*0 @e:asm.bits=64
+EOF
+EXPECT=<<EOF
+0xdeadbeefdeadbeef
+0xdeadbeefdeadbeef
+0xffffffffdeadbeef
+0xffffffffffffbeef
+0xffffffffffffffef
+0xffffbeefdeadffff
+EOF
+RUN
+
+NAME=pointer write hex
+FILE=malloc://1024
+CMDS=<<EOF
+wx ffffffffffffffff
+*0+2=addeefbe
+*0 @e:asm.bits=64
+EOF
+EXPECT=<<EOF
+0xffffbeefdeadffff
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This PR follows #3788 and refactors the write path for the `*` pointer command, so that it uses the API instead of `rz_core_cmdf`.

I also went a bit further and changed the pointer command's behavior wrt. the value to write:

* previously, the value would be interpreted as a word if it started with _0x_, or as a hexstring otherwise
* with this PR, the value will be interpreted as a hexstring if it's a valid hexstring, or as an expr (eval'ed with `rz_num_math` to a word of the current bitness) otherwise

This doesn't change the behavior for hexstrings, but allows more elaborate commands such as `*entry0=$$` or `*foo=[bar]` (which would previously have been rejected as invalid hexstring values).

This new behavior is fully contained in the last commit of the PR (along with all required changes). I can discard it if you feel it's not appropriate.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

I expanded the `cmd_pointer` regression test file to cover pointer writes.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

N/A
