### PR TITLE
Restore original seek offset after iterating over flags with `@@f`

### DIFF
--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -4392,6 +4392,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_flags_stmt) {
 	if (!ts_node_is_null(arg)) {
 		arg_str = ts_node_handle_arg(state, node, arg, 1);
 	}
+	ut64 offorig = core->offset;
 	const RzSpace *flagspace = rz_flag_space_cur(core->flags);
 	RzFlagItem *flag;
 	RzListIter *iter;
@@ -4425,6 +4426,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_flags_stmt) {
 
 err:
 	rz_list_free(match_flag_items);
+	rz_core_seek(core, offorig, true);
 	free(arg_str);
 	return ret;
 }

--- a/test/db/analysis/golang
+++ b/test/db/analysis/golang
@@ -279,6 +279,7 @@ NAME=Parse Golang 1.18 MIPS BE Strings
 FILE=bins/golang/go-re-sample-linux-mips
 CMDS=<<EOF
 aalg
+s main
 e asm.cmt.col=0
 pdr~"
 EOF
@@ -304,6 +305,7 @@ NAME=Parse Golang 1.18 MIPS LE Strings
 FILE=bins/golang/go-re-sample-linux-mipsle
 CMDS=<<EOF
 aalg
+s main
 e asm.cmt.col=0
 pdr~"
 EOF
@@ -329,6 +331,7 @@ NAME=Parse Golang 1.18 MIPS64 BE Strings
 FILE=bins/golang/go-re-sample-linux-mips64
 CMDS=<<EOF
 aalg
+s main
 e asm.cmt.col=0
 pdr~"
 EOF
@@ -354,6 +357,7 @@ NAME=Parse Golang 1.18 MIPS64 LE Strings
 FILE=bins/golang/go-re-sample-linux-mips64le
 CMDS=<<EOF
 aalg
+s main
 e asm.cmt.col=0
 pdr~"
 EOF
@@ -379,6 +383,7 @@ NAME=Parse Golang 1.18 PPC64 BE Strings
 FILE=bins/golang/go-re-sample-linux-ppc64
 CMDS=<<EOF
 aalg
+s main
 e asm.cmt.col=0
 pdr~"
 EOF
@@ -404,6 +409,7 @@ NAME=Parse Golang 1.18 PPC64 LE Strings
 FILE=bins/golang/go-re-sample-linux-ppc64le
 CMDS=<<EOF
 aalg
+s main
 e asm.cmt.col=0
 pdr~"
 EOF
@@ -429,6 +435,7 @@ NAME=Parse Golang 1.18 riscv64 Strings
 FILE=bins/golang/go-re-sample-linux-riscv64
 CMDS=<<EOF
 aalg
+s main
 e asm.cmt.col=0
 pdr~"
 EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [X] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Using the flags iterator `@@f` does not restore the original seek offset after processing the last flag.
This PR simply fixes that. No doc changes needed.

To avoid bloat in the _test_ directory, I didn't add a regression test as this doesn't seem like something that's likely to ever regress in isolation, but I can do so if needed.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Before:

```
$ rizin malloc://1024
[0x00000000]> f foo @ 16
[0x00000000]> %v $$ @@f
0x10
[0x00000010]> s
0x10
```

After:

```
$ rizin malloc://1024
[0x00000000]> f foo @ 16
[0x00000000]> %v $$ @@f
0x10
[0x00000000]> s
0x0
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

N/A
