### PR TITLE
Fix segfault in rz_seek_end_handler

### DIFF
--- a/librz/core/cmd/cmd_seek.c
+++ b/librz/core/cmd/cmd_seek.c
@@ -334,8 +334,16 @@ RZ_IPI RzCmdStatus rz_seek_begin_handler(RzCore *core, int argc, const char **ar
 
 RZ_IPI RzCmdStatus rz_seek_end_handler(RzCore *core, int argc, const char **argv) {
 	RzIOMap *map = rz_io_map_get(core->io, core->offset);
-	// XXX: this +2 is a hack. must fix gap between sections
-	ut64 addr = map ? map->itv.addr + map->itv.size + 2 : rz_io_fd_size(core->io, core->file->fd);
+	ut64 addr;
+	if (map) {
+		// XXX: this +2 is a hack. must fix gap between sections
+		addr = map->itv.addr + map->itv.size + 2;
+	} else {
+		if (!core->file) {
+			return RZ_CMD_STATUS_ERROR;
+		}
+		addr = rz_io_fd_size(core->io, core->file->fd);
+	}
 	return bool2cmdstatus(rz_core_seek_and_save(core, addr, true));
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Using the `sG` command when Rizin is runned without opening any file causes a segmentation fault.

`rz_seek_end_handler` didn't check `core->file`.

**Test plan**

Run Rizin with command line: `rizin -c sG`.