### PR TITLE
rz-run resolve_value: Pass single-quoted strings unaltered

### DIFF
--- a/librz/socket/run.c
+++ b/librz/socket/run.c
@@ -163,12 +163,17 @@ static char *resolve_value(const char *src, size_t *result_len) {
 	if (src[0] == '\'' || src[0] == '"') {
 		delimiter = src[0];
 		if (src_len < 2 || src[src_len - 1] != delimiter) {
-			// the quoted string must have and end.
+			// the quoted string must have an end
 			RZ_LOG_ERROR("rz-run: missing `%c` at the end of the value `%s`\n", delimiter, src);
 			return NULL;
 		}
 		copy = rz_str_ndup(src + 1, src_len - 2);
 		src_len -= 2;
+		if (delimiter == '\'') {
+			// pass single-quoted string unaltered
+			copy_len = src_len;
+			goto end_resolve;
+		}
 	} else {
 		copy = strdup(src);
 	}
@@ -1410,7 +1415,7 @@ RZ_API char *rz_run_get_environ_profile(char **env) {
 			opt.esc_bslash = true;
 			v = rz_str_escape_8bit(v, true, &opt);
 			if (v) {
-				rz_strbuf_appendf(sb, "setenv=%s=\"%s\"\n", k, v);
+				rz_strbuf_appendf(sb, "setenv=%s='%s'\n", k, v);
 				free(v);
 			}
 		}

--- a/test/db/archos/linux-x64/dbg
+++ b/test/db/archos/linux-x64/dbg
@@ -99,7 +99,7 @@ RUN
 NAME=rizin -d no error
 FILE=--
 CMDS=<<EOF
-envDISPLAY=:0
+env DISPLAY=:0
 !rizin -d -qc "" bins/elf/analysis/calls_x64
 EOF
 REGEXP_FILTER_ERR=ERROR.*

--- a/test/db/archos/linux-x64/dbg
+++ b/test/db/archos/linux-x64/dbg
@@ -96,7 +96,7 @@ child received signal 9
 EOF
 RUN
 
-NAME=rizin -d no error
+NAME=rizin -d no error from env
 FILE=--
 CMDS=<<EOF
 env DISPLAY=:0

--- a/test/db/archos/linux-x64/dbg
+++ b/test/db/archos/linux-x64/dbg
@@ -98,7 +98,10 @@ RUN
 
 NAME=rizin -d no error
 FILE=--
-CMDS=!rizin -d -qc "" bins/elf/analysis/calls_x64
+CMDS=<<EOF
+envDISPLAY=:0
+!rizin -d -qc "" bins/elf/analysis/calls_x64
+EOF
 REGEXP_FILTER_ERR=ERROR.*
 EXPECT_ERR=
 RUN

--- a/test/db/archos/linux-x64/dbg
+++ b/test/db/archos/linux-x64/dbg
@@ -95,3 +95,10 @@ EXPECT_ERR=<<EOF
 child received signal 9
 EOF
 RUN
+
+NAME=rizin -d no error
+FILE=--
+CMDS=!rizin -d -qc "" bins/elf/analysis/calls_x64
+REGEXP_FILTER_ERR=ERROR.*
+EXPECT_ERR=
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following error (https://github.com/rizinorg/rizin/actions/runs/5997466915/job/16263926133?pr=3800#step:19:484)

![rz-run-ERROR](https://github.com/rizinorg/rizin/assets/12002672/9c7fcf73-460c-4e19-b761-6699b13c1693)

by making `run.c`'s `resolve_value()` (used by rz-run `setenv` among others) pass single-quoted strings unaltered.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change is appropriate. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
