### PR TITLE
Fix div by zero in 's++' and 's--'

### DIFF
--- a/librz/core/cmd/cmd_seek.c
+++ b/librz/core/cmd/cmd_seek.c
@@ -196,18 +196,20 @@ RZ_IPI RzCmdStatus rz_seek_base_handler(RzCore *core, int argc, const char **arg
 }
 
 RZ_IPI RzCmdStatus rz_seek_blocksize_backward_handler(RzCore *core, int argc, const char **argv) {
-	int n = 1;
-	if (argc == 2) {
-		n = rz_num_math(core->num, argv[1]);
+	int n = argc == 2 ? rz_num_math(core->num, argv[1]) : 1;
+	if (n < 1) {
+		RZ_LOG_ERROR("invalid argument: number is negative or zero\n");
+		return RZ_CMD_STATUS_ERROR;
 	}
 	int delta = -core->blocksize / n;
 	return bool2cmdstatus(rz_core_seek_delta(core, delta, true));
 }
 
 RZ_IPI RzCmdStatus rz_seek_blocksize_forward_handler(RzCore *core, int argc, const char **argv) {
-	int n = 1;
-	if (argc == 2) {
-		n = rz_num_math(core->num, argv[1]);
+	int n = argc == 2 ? rz_num_math(core->num, argv[1]) : 1;
+	if (n < 1) {
+		RZ_LOG_ERROR("invalid argument: number is negative or zero\n");
+		return RZ_CMD_STATUS_ERROR;
 	}
 	int delta = core->blocksize / n;
 	return bool2cmdstatus(rz_core_seek_delta(core, delta, true));

--- a/test/db/cmd/cmd_seek
+++ b/test/db/cmd/cmd_seek
@@ -346,3 +346,19 @@ EXPECT=<<EOF
 0x543a0
 EOF
 RUN
+
+NAME=s-- and s++ with negative or zero argument
+FILE==
+CMDS=<<EOF
+s-- -1
+s++ -1
+s-- 0
+s++ 0
+EOF
+EXPECT_ERR=<<EOF
+ERROR: invalid argument: number is negative or zero
+ERROR: invalid argument: number is negative or zero
+ERROR: invalid argument: number is negative or zero
+ERROR: invalid argument: number is negative or zero
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Running `s-- 0` and `s++ 0` causes floating point exception.

`rz_seek_blocksize_backward_handler` and `rz_seek_blocksize_forward_handler` didn't check for `n` to be non-zero.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Run `s++ 0` and `s-- 0`.
