### PR TITLE
Fix #3806: fuzzy `dbt` checks for CALL indirect on x86

### DIFF
--- a/librz/debug/p/native/bt/fuzzy-all.c
+++ b/librz/debug/p/native/bt/fuzzy-all.c
@@ -21,6 +21,11 @@ static int iscallret(RzDebug *dbg, ut64 addr) {
 					      && (buf[4] & 0x06) != 0x04))) { /* R/M not 10x */
 			return 1;
 		}
+		/* check for 7-byte CALL indirect (encoded by FF 14 25) */
+		(void)dbg->iob.read_at(dbg->iob.io, addr - 7, buf, 7);
+		if (!memcmp(buf, "\xff\x14\x25", 3)) {
+			return 1;
+		}
 		// IMMAMISSINGANYOP
 	} else {
 		RzAnalysisOp op;

--- a/test/db/archos/linux-x64/dbg_trace1
+++ b/test/db/archos/linux-x64/dbg_trace1
@@ -24,11 +24,10 @@ dcu main
 ds 2  # Should be dsui call; ds
 dbt~[6-]  # dbtt here would be nice
 EOF
+REGEXP_FILTER_OUT=(loc\.[a-zA-Z0-9_]+.|main\+\d+.|entry0\+\d+.)
 EXPECT=<<EOF
 loc.func_0 loc.func_00
 main+8
-fs+181840
-fs+182016
 entry0+41
 EOF
 RUN

--- a/test/db/archos/linux-x64/dbg_trace1
+++ b/test/db/archos/linux-x64/dbg_trace1
@@ -26,6 +26,7 @@ dbt~[6-]  # dbtt here would be nice
 EOF
 EXPECT=<<EOF
 loc.func_0 loc.func_00
+main+8
 fs+181840
 fs+182016
 entry0+41

--- a/test/db/archos/linux-x64/dbg_trace1
+++ b/test/db/archos/linux-x64/dbg_trace1
@@ -15,3 +15,19 @@ rip = 0x00000000004004ed
 rip = 0x00000000004004ed
 EOF
 RUN
+
+NAME=missing main stack frame fix (#3806)
+FILE=bins/elf/analysis/calls_x64
+ARGS=-d
+CMDS=<<EOF
+dcu main
+ds 2  # Should be dsui call; ds
+dbt~[6-]  # dbtt here would be nice
+EOF
+EXPECT=<<EOF
+loc.func_0 loc.func_00
+fs+181840
+fs+182016
+entry0+41
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes #3806 by making fuzzy `dbt` check for CALL indirect as encoded in the test binary -- not sure whether there are other possible encodings.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #3806.
