### PR TITLE
Fix:  wrong exit condition in rz_analysis_optype_from_string

### DIFF
--- a/librz/analysis/op.c
+++ b/librz/analysis/op.c
@@ -295,7 +295,7 @@ static struct optype {
 RZ_API int rz_analysis_optype_from_string(RZ_NONNULL const char *name) {
 	rz_return_val_if_fail(name, -1);
 	int i;
-	for (i = 0; RZ_ARRAY_SIZE(optypes); i++) {
+	for (i = 0; i < RZ_ARRAY_SIZE(optypes); i++) {
 		if (!strcmp(optypes[i].name, name)) {
 			return optypes[i].type;
 		}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Wrong exit condition leads to segment fault.

Reproduce:
+ `rizin /bin/ls`
+ `aho xxx`

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
