### PR TITLE
Fix use after free in pyc due missing return while error handling

### DIFF
--- a/librz/bin/format/pyc/marshal.c
+++ b/librz/bin/format/pyc/marshal.c
@@ -667,6 +667,7 @@ static pyc_object *get_ascii_object_generic(RzBinPycObj *pyc, RzBuffer *buffer, 
 	ret->data = get_bytes(buffer, size);
 	if (!ret->data) {
 		RZ_FREE(ret);
+		return NULL;
 	}
 
 	if (!add_string_to_cache(pyc, addr, ret->data, size, size, RZ_STRING_ENC_8BIT)) {


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Found a Use After Free bug in the pyc format code, if ret-> data is null we free ret but instead of returning we progress onward which will cause the now free'd ret to dereference its data field for the call to add_string_to cache.
