### PR TITLE
dbt: Don't show 2nd flag name if eql to 1st flag name

### DIFF
--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -868,6 +868,7 @@ RZ_API void rz_backtrace_free(RZ_NULLABLE RzBacktrace *bt) {
 static void get_backtrace_info(RzCore *core, RzDebugFrame *frame, ut64 addr,
 	char **flagdesc, char **flagdesc2, char **pcstr, char **spstr) {
 	RzFlagItem *f = rz_flag_get_at(core->flags, frame->addr, true);
+	RzFlagItem *f2 = NULL;
 	*flagdesc = NULL;
 	*flagdesc2 = NULL;
 	if (f) {
@@ -884,20 +885,20 @@ static void get_backtrace_info(RzCore *core, RzDebugFrame *frame, ut64 addr,
 			*flagdesc = rz_str_newf("%s", f->name);
 		}
 		if (!strchr(f->name, '.')) {
-			f = rz_flag_get_at(core->flags, frame->addr - 1, true);
+			f2 = rz_flag_get_at(core->flags, frame->addr - 1, true);
 		}
-		if (f) {
-			if (f->offset != addr) {
-				int delta = (int)(frame->addr - 1 - f->offset);
+		if (f2 && f2 != f) {
+			if (f2->offset != addr) {
+				int delta = (int)(frame->addr - 1 - f2->offset);
 				if (delta > 0) {
-					*flagdesc2 = rz_str_newf("%s+%d", f->name, delta + 1);
+					*flagdesc2 = rz_str_newf("%s+%d", f2->name, delta + 1);
 				} else if (delta < 0) {
-					*flagdesc2 = rz_str_newf("%s%d", f->name, delta + 1);
+					*flagdesc2 = rz_str_newf("%s%d", f2->name, delta + 1);
 				} else {
-					*flagdesc2 = rz_str_newf("%s+1", f->name);
+					*flagdesc2 = rz_str_newf("%s+1", f2->name);
 				}
 			} else {
-				*flagdesc2 = rz_str_newf("%s", f->name);
+				*flagdesc2 = rz_str_newf("%s", f2->name);
 			}
 		}
 	}

--- a/test/db/archos/linux-x64/dbg_trace1
+++ b/test/db/archos/linux-x64/dbg_trace1
@@ -21,11 +21,16 @@ FILE=bins/elf/analysis/calls_x64
 ARGS=-d
 CMDS=<<EOF
 dcu main
+dbt
+echo ----
 ds 2  # Should be dsui call; ds
 dbt~[6-]  # dbtt here would be nice
 EOF
-REGEXP_FILTER_OUT=(loc\.\S+.|main\+\d+.|entry0\+\d+.)
+REGEXP_FILTER_OUT=(loc\.\S+.|main\S*.|entry0\+\d+\s+|-+.)
 EXPECT=<<EOF
+main loc.func_6+6
+entry0+41 
+----
 loc.func_0 loc.func_00
 main+8
 entry0+41

--- a/test/db/archos/linux-x64/dbg_trace1
+++ b/test/db/archos/linux-x64/dbg_trace1
@@ -31,7 +31,7 @@ EXPECT=<<EOF
 main loc.func_6+6
 entry0+41 
 ----
-loc.func_0 loc.func_00
+loc.func_0
 main+8
 entry0+41
 EOF

--- a/test/db/formats/dmp/dmp
+++ b/test/db/formats/dmp/dmp
@@ -187,7 +187,7 @@ mov qword [rsp + 8], rcx
 mov qword [rsp + 0x10], rdx
 mov qword [rsp + 0x18], r8
 mov qword [rsp + 0x20], r9
-0  0xfffff8047bdf5a80 sp: 0xffff850429890ee8  0    [??]  pdb.ntkrnlmp.KeBugCheckEx pdb.ntkrnlmp.KeBugCheckEx0
+0  0xfffff8047bdf5a80 sp: 0xffff850429890ee8  0    [??]  pdb.ntkrnlmp.KeBugCheckEx 
 1  0xfffff8047be0f4e1 sp: 0xffff850429890ef0  56   [??]  pdb.ntkrnlmp.string_::3655334267::_Kernel_MUI_Lang_::1575215452+5649 
 2  0xfffff8047bdcc052 sp: 0xffff850429890f30  104  [??]  pdb.ntkrnlmp.__C_specific_handler+162 
 3  0xfffff8047bdfe942 sp: 0xffff850429890fa0  40   [??]  pdb.ntkrnlmp.RtlpExecuteHandlerForException+18 
@@ -403,7 +403,7 @@ int3
 ret
 int3
 int3
-0  0xfffff805108776a0 sp: 0xfffff805135684f8  0    [??]  pdb.ntkrnlmp.RtlpBreakWithStatusInstruction pdb.ntkrnlmp.RtlpBreakWithStatusInstruction0
+0  0xfffff805108776a0 sp: 0xfffff805135684f8  0    [??]  pdb.ntkrnlmp.RtlpBreakWithStatusInstruction 
 1  0xfffff805110dd222 sp: 0xfffff80513568500  568  [??]  pdb.ntkrnlmp.string_::2500419057::__Device_Ramdisk_::253687359+25426 
 2  0xfffff80510c50204 sp: 0xfffff80513568740  776  [??]  pdb.ntkrnlmp.KiInitializeKernel+1364 
 3  0xfffff80510c45219 sp: 0xfffff80513568a50  1448 [??]  pdb.ntkrnlmp.KiSystemStartup+521 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr makes `dbt` **not** print the 2nd flag name if it's equal to the first flag name.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
