### PR TITLE
Remove warning about missing calling convention

### DIFF
--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -731,11 +731,7 @@ static bool core_file_do_load_for_io_plugin(RzCore *r, ut64 baseaddr, ut64 loada
 	if (cf) {
 		rz_pvector_push(&cf->binfiles, binfile);
 	}
-	if (rz_core_bin_apply_all_info(r, binfile)) {
-		if (!r->analysis->sdb_cc->path) {
-			RZ_LOG_WARN("No calling convention defined for this file, analysis may be inaccurate.\n");
-		}
-	}
+	rz_core_bin_apply_all_info(r, binfile);
 	plugin = rz_bin_file_cur_plugin(binfile);
 	if (plugin && !strcmp(plugin->name, "any")) {
 		RzBinObject *obj = rz_bin_cur_object(r->bin);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This warning turned out to be more misleading and spammy than actually
useful. For example, it speaks of a "file" when loading just a malloc,
and many architectures simply do not have any standardized calling
conventions, like 6502 or gb, in which case the analysis is fine without
any loaded cc info.

Example:
<img width="502" alt="Bildschirmfoto 2023-09-11 um 21 57 15" src="https://github.com/rizinorg/rizin/assets/1460997/a4de9997-0c14-43a3-a640-67cf9dcd964e">


**Test plan**

`rz -a 6502 =` should not print any warning.