### PR TITLE
fixed inf loop condition

### DIFF
--- a/librz/bin/format/elf/elf_relocs.c
+++ b/librz/bin/format/elf/elf_relocs.c
@@ -167,6 +167,10 @@ static bool get_relocs_entry_from_dt_dynamic(ELFOBJ *bin, RzVector /*<RzBinElfRe
 	}
 
 	if (Elf_(rz_bin_elf_get_dt_info)(bin, DT_RELAENT, &entry_size)) {
+		if (!entry_size) {
+			return false;
+		}
+
 		if (!get_relocs_entry_from_dt_dynamic_aux(bin, relocs, DT_RELA, DT_RELASZ, entry_size, DT_RELA, set)) {
 			return false;
 		}


### PR DESCRIPTION
**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

There is a simple bug in elf_relocs.c that allows for an infinite loop condition to occur when an elf file has its dt_relaent entry set to 0 in the .dynamic section. The problem arises in get_relocs_entry where the relaent value is used to iterate the loop variable forcing the loop to spin on the same offset value.