### PR TITLE
Remove the automatically appended n_instr while setting commands in p…

### DIFF
--- a/librz/core/tui/modes.c
+++ b/librz/core/tui/modes.c
@@ -52,3 +52,9 @@ const char *print5Formats[PRINT_5_FORMATS] = {
 const char *printCmds[lastPrintMode] = {
 	"pdf", "pd $r", "agf", "agl", "afi", "pxa"
 };
+
+// the pd* commands that support <n_instr> as argument
+const char *printDisOptimized[] = {
+	"pd", "pda", "pdC", "pde", "pdJ", "pdl",
+	NULL
+};

--- a/librz/core/tui/modes.h
+++ b/librz/core/tui/modes.h
@@ -27,3 +27,4 @@ extern const char *print5Formats[PRINT_5_FORMATS];
 #define lastPrintMode 6
 
 extern const char *printCmds[lastPrintMode];
+extern const char *printDisOptimized[];

--- a/librz/core/tui/panels.c
+++ b/librz/core/tui/panels.c
@@ -5,6 +5,7 @@
 #include <rz_core.h>
 #include <rz_cmd.h>
 #include "../core_private.h"
+#include "modes.h"
 
 #define PANEL_NUM_LIMIT 9
 
@@ -37,12 +38,6 @@
 #define PANEL_CMD_TINYGRAPH     "agft"
 #define PANEL_CMD_HEXDUMP       "xc"
 #define PANEL_CMD_CONSOLE       "$console"
-
-// the commands support <n_instr> as argument
-static const char *command_optimized[] = {
-	"pd", "pda", "pdC", "pde", "pdJ", "pdl",
-	NULL
-};
 
 #define PANEL_CONFIG_MENU_MAX    64
 #define PANEL_CONFIG_PAGE        10
@@ -4047,8 +4042,8 @@ void __print_disassembly_cb(void *user, void *p) {
 	// optimize the commands that support setting the number of instr
 	char *ocmd = panel->model->cmd;
 	ut32 i = 0;
-	while (command_optimized[i]) {
-		if (!strcmp(command_optimized[i++], ocmd)) {
+	while (printDisOptimized[i]) {
+		if (!strcmp(printDisOptimized[i++], ocmd)) {
 			panel->model->cmd = rz_str_newf("%s %d", ocmd, panel->view->pos.h - 3);
 			free(ocmd);
 			break;


### PR DESCRIPTION
…anel mode

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The panel is empty because the command `pdf` does not support the <n_instr> parameter which is appended automatically. 

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes https://github.com/rizinorg/rizin/issues/3829
