### PR TITLE
Add space between the hex and vocabulary

### DIFF
--- a/librz/core/cio.c
+++ b/librz/core/cio.c
@@ -335,7 +335,7 @@ RZ_API int rz_core_write_assembly(RzCore *core, ut64 addr, RZ_NONNULL const char
 	}
 
 	if (!rz_core_write_at(core, core->offset, acode->bytes, acode->len)) {
-		RZ_LOG_ERROR("Cannot write %d bytes at 0x%" PFMT64x "address\n", acode->len, core->offset);
+		RZ_LOG_ERROR("Cannot write %d bytes at 0x%" PFMT64x " address\n", acode->len, core->offset);
 		core->num->value = 1;
 		goto err;
 	}
@@ -384,7 +384,7 @@ RZ_API int rz_core_write_assembly_fill(RzCore *core, ut64 addr, RZ_NONNULL const
 	rz_core_hack(core, "nop");
 
 	if (!rz_core_write_at(core, core->offset, acode->bytes, acode->len)) {
-		RZ_LOG_ERROR("Cannot write %d bytes at 0x%" PFMT64x "address\n", acode->len, core->offset);
+		RZ_LOG_ERROR("Cannot write %d bytes at 0x%" PFMT64x " address\n", acode->len, core->offset);
 		core->num->value = 1;
 		goto err;
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Minor thing. Add space between the hex number and the word. Otherwise, the output would be like `Cannot write 3 bytes at 0x1000address`

![image](https://github.com/rizinorg/rizin/assets/58985155/64d0dd12-940d-4240-8a9b-35c46016815c)


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
