### PR TITLE
Fix #3835: Fix off-by-1 for 32-bit x86 stack args

### DIFF
--- a/librz/analysis/var.c
+++ b/librz/analysis/var.c
@@ -1216,6 +1216,7 @@ static void extract_stack_var(RzAnalysis *analysis, RzAnalysisFunction *fcn, RzA
 					to = rz_type_func_args_count(analysis->typedb, fname);
 				}
 				const int bytes = (fcn->bits ? fcn->bits : analysis->bits) / 8;
+				sum_sz += bytes; // move past the return address
 				for (i = from; stack_rev ? i >= to : i < to; stack_rev ? i-- : i++) {
 					RzType *tp = rz_type_func_args_type(analysis->typedb, fname, i);
 					if (!tp) {

--- a/librz/analysis/var.c
+++ b/librz/analysis/var.c
@@ -1216,7 +1216,9 @@ static void extract_stack_var(RzAnalysis *analysis, RzAnalysisFunction *fcn, RzA
 					to = rz_type_func_args_count(analysis->typedb, fname);
 				}
 				const int bytes = (fcn->bits ? fcn->bits : analysis->bits) / 8;
-				sum_sz += bytes; // move past the return address
+				if (!strcmp(analysis->cur->arch, "x86")) {
+					sum_sz += bytes; // move past the return address
+				}
 				for (i = from; stack_rev ? i >= to : i < to; stack_rev ? i-- : i++) {
 					RzType *tp = rz_type_func_args_type(analysis->typedb, fname, i);
 					if (!tp) {

--- a/test/db/analysis/x86_32
+++ b/test/db/analysis/x86_32
@@ -4223,7 +4223,7 @@ pd 10 @ 0x08049410
 EOF
 EXPECT=<<EOF
 / int main(int argc, char **argv, char **envp);
-|           0x080491ca     0            lea   ecx, [argv]
+|           0x080491ca     0            lea   ecx, [argc]
 |           0x080491ce     0            and   esp, 0xfffffff0
 |           0x080491d1     0 -= 4       push  dword [ecx - 4]
 |           0x080491d4    -4 -= 4       push  ebp

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1663,7 +1663,7 @@ var size_t var_1ch @ stack - 0x1c
 var size_t size @ stack - 0x18
 var char *dest @ stack - 0x14
 var int32_t var_10h @ stack - 0x10
-arg char **argv @ stack + 0x4
+arg int argc @ stack + 0x4
 EOF
 RUN
 
@@ -1680,8 +1680,8 @@ EXPECT=<<EOF
 |           ; var int32_t var_1ch @ stack - 0x1c
 |           ; var int32_t var_18h @ stack - 0x18
 |           ; var int32_t var_14h @ stack - 0x14
-|           ; arg char **argv @ stack + 0x4
-|           ; arg char **envp @ stack + 0x8
+|           ; arg int argc @ stack + 0x4
+|           ; arg char **argv @ stack + 0x8
 |           0x08048d60      push  ebp                                  ; [13] -r-x section size 9756 named .text
 EOF
 RUN

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1667,6 +1667,25 @@ arg char **argv @ stack + 0x4
 EOF
 RUN
 
+NAME=off-by-1 stack arg fix (#3835)
+FILE=bins/elf/true32
+CMDS=aa; pd 1 @ main
+EXPECT=<<EOF
+            ; DATA XREF from entry0 @ 0x8048e5b
+            ;-- section..text:
+/ int main(int argc, char **argv, char **envp);
+|           ; var int32_t var_40h @ stack - 0x40
+|           ; var int32_t var_24h @ stack - 0x24
+|           ; var int32_t var_20h @ stack - 0x20
+|           ; var int32_t var_1ch @ stack - 0x1c
+|           ; var int32_t var_18h @ stack - 0x18
+|           ; var int32_t var_14h @ stack - 0x14
+|           ; arg char **argv @ stack + 0x4
+|           ; arg char **envp @ stack + 0x8
+|           0x08048d60      push  ebp                                  ; [13] -r-x section size 9756 named .text
+EOF
+RUN
+
 NAME=Register based var
 FILE=bins/elf/arg
 CMDS=<<EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes #3835 by considering that the value at `stack` is the return address.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #3835.
