### PR TITLE
Various Breakpoint Changes

### DIFF
--- a/librz/bp/bp_io.c
+++ b/librz/bp/bp_io.c
@@ -58,6 +58,11 @@ RZ_API bool rz_bp_restore_except(RzBreakpoint *bp, bool set, ut64 addr) {
 		if (bp->breakpoint && bp->breakpoint(bp, b, set)) {
 			continue;
 		}
+		// Hardware breakpoints do not need memory restoration and are not handled here
+		if (b->hw) {
+			rc = true;
+			continue;
+		}
 
 		/* write (o|b)bytes from every breakpoint in rz_bp if not handled by plugin */
 		rz_bp_restore_one(bp, b, set);

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3340,7 +3340,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 
 	SETCB("dbg.libs", "", &cb_dbg_libs, "If set stop when loading matching libname");
 	SETBPREF("dbg.skipover", "false", "Make dso perform a dss (same goes for esil and visual/graph");
-	SETI("dbg.hwbp", 0, "Set HW or SW breakpoints");
+	SETB("dbg.hwbp", false, "Use hardware instead of software breakpoints by default");
 	SETCB("dbg.unlibs", "", &cb_dbg_unlibs, "If set stop when unloading matching libname");
 	SETCB("dbg.verbose", "false", &cb_dbg_verbose, "Verbose debug output");
 	SETBPREF("dbg.slow", "false", "Show stack and regs in visual mode in a slow but verbose mode");

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -229,8 +229,8 @@ RZ_API void rz_core_debug_breakpoint_toggle(RZ_NONNULL RzCore *core, ut64 addr) 
 	if (bpi) {
 		rz_bp_del(core->dbg->bp, addr);
 	} else {
-		int hwbp = (int)rz_config_get_i(core->config, "dbg.hwbp");
-		bpi = rz_debug_bp_add(core->dbg, addr, hwbp, false, 0, NULL, 0);
+		bool hwbp = (int)rz_config_get_b(core->config, "dbg.hwbp");
+		bpi = rz_debug_bp_add(core->dbg, addr, hwbp ? 1 : 0, false, 0, NULL, 0);
 		if (!bpi) {
 			RZ_LOG_ERROR("core: cannot set breakpoint at 0x%" PFMT64x "\n", addr);
 		}
@@ -253,11 +253,11 @@ RZ_API void rz_core_debug_bp_add_noreturn_func(RzCore *core) {
 	RzBinSymbol *symbol;
 	RzListIter *iter;
 	RzBreakpointItem *bp;
-	int hwbp = rz_config_get_i(core->config, "dbg.hwbp");
+	bool hwbp = rz_config_get_b(core->config, "dbg.hwbp");
 	rz_list_foreach (symbols, iter, symbol) {
 		if (symbol->type && !strcmp(symbol->type, RZ_BIN_TYPE_FUNC_STR)) {
 			if (rz_analysis_noreturn_at(core->analysis, symbol->vaddr)) {
-				bp = rz_debug_bp_add(core->dbg, symbol->vaddr, hwbp, false, 0, NULL, 0);
+				bp = rz_debug_bp_add(core->dbg, symbol->vaddr, hwbp ? 1 : 0, false, 0, NULL, 0);
 				if (!bp) {
 					RZ_LOG_ERROR("Unable to add a breakpoint into a noreturn function %s at addr 0x%" PFMT64x "\n", symbol->name, symbol->vaddr);
 					return;

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -230,7 +230,7 @@ RZ_API void rz_core_debug_breakpoint_toggle(RZ_NONNULL RzCore *core, ut64 addr) 
 		rz_bp_del(core->dbg->bp, addr);
 	} else {
 		bool hwbp = (int)rz_config_get_b(core->config, "dbg.hwbp");
-		bpi = rz_debug_bp_add(core->dbg, addr, hwbp ? 1 : 0, false, 0, NULL, 0);
+		bpi = rz_debug_bp_add(core->dbg, addr, 0, hwbp, false, 0, NULL, 0);
 		if (!bpi) {
 			RZ_LOG_ERROR("core: cannot set breakpoint at 0x%" PFMT64x "\n", addr);
 		}
@@ -257,7 +257,7 @@ RZ_API void rz_core_debug_bp_add_noreturn_func(RzCore *core) {
 	rz_list_foreach (symbols, iter, symbol) {
 		if (symbol->type && !strcmp(symbol->type, RZ_BIN_TYPE_FUNC_STR)) {
 			if (rz_analysis_noreturn_at(core->analysis, symbol->vaddr)) {
-				bp = rz_debug_bp_add(core->dbg, symbol->vaddr, hwbp ? 1 : 0, false, 0, NULL, 0);
+				bp = rz_debug_bp_add(core->dbg, symbol->vaddr, 0, hwbp, false, 0, NULL, 0);
 				if (!bp) {
 					RZ_LOG_ERROR("Unable to add a breakpoint into a noreturn function %s at addr 0x%" PFMT64x "\n", symbol->name, symbol->vaddr);
 					return;
@@ -819,7 +819,7 @@ RZ_API bool rz_core_debug_step_over(RzCore *core, int steps) {
 	rz_reg_arena_swap(core->dbg->reg, true);
 	rz_debug_step_over(core->dbg, steps);
 	if (bpi) {
-		(void)rz_debug_bp_add(core->dbg, addr, hwbp, false, 0, NULL, 0);
+		(void)rz_debug_bp_add(core->dbg, addr, 0, hwbp, false, 0, NULL, 0);
 	}
 	rz_core_reg_update_flags(core);
 	return true;
@@ -847,7 +847,7 @@ RZ_API bool rz_core_debug_step_skip(RzCore *core, int times) {
 	rz_reg_setv(core->analysis->reg, "PC", addr);
 	rz_core_reg_update_flags(core);
 	if (bpi) {
-		(void)rz_debug_bp_add(core->dbg, addr, hwbp, false, 0, NULL, 0);
+		(void)rz_debug_bp_add(core->dbg, addr, 0, hwbp, false, 0, NULL, 0);
 	}
 	return true;
 }

--- a/librz/core/cmd_descs/cmd_debug.yaml
+++ b/librz/core/cmd_descs/cmd_debug.yaml
@@ -232,6 +232,9 @@ commands:
               - r
               - w
               - rw
+          - name: size
+            type: RZ_CMD_ARG_TYPE_RZNUM
+            optional: true
         details:
           - name: Valid permission arguments
             entries:
@@ -241,6 +244,16 @@ commands:
                 comment: "write only"
               - text: "rw"
                 comment: "read-write"
+          - name: Example sizes
+            entries:
+              - text: "1"
+                comment: "watch only a single byte"
+              - text: "2"
+                comment: "watch a 16-bit value"
+              - text: "4"
+                comment: "watch a 32-bit value"
+              - text: "8"
+                comment: "watch a 64-bit value"
       - name: dbW
         summary: Set conditional breakpoint on a window message handler (only for Windows)
         cname: cmd_debug_set_cond_bp_win

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -49,7 +49,7 @@ static const RzCmdDescDetail cmd_cmp_unified_details[2];
 static const RzCmdDescDetail cw_details[2];
 static const RzCmdDescDetail cmd_debug_list_bp_details[2];
 static const RzCmdDescDetail cmd_debug_add_cond_bp_details[2];
-static const RzCmdDescDetail cmd_debug_add_watchpoint_details[2];
+static const RzCmdDescDetail cmd_debug_add_watchpoint_details[3];
 static const RzCmdDescDetail cmd_debug_esil_add_details[2];
 static const RzCmdDescDetail cmd_debug_signal_option_details[2];
 static const RzCmdDescDetail debug_reg_cond_details[4];
@@ -365,7 +365,7 @@ static const RzCmdDescArg cmd_debug_bp_plugin_args[2];
 static const RzCmdDescArg cmd_debug_remove_bp_plugin_args[2];
 static const RzCmdDescArg cmd_debug_display_bt_oneline_args[2];
 static const RzCmdDescArg cmd_debug_bp_set_expr_cur_offset_args[2];
-static const RzCmdDescArg cmd_debug_add_watchpoint_args[2];
+static const RzCmdDescArg cmd_debug_add_watchpoint_args[3];
 static const RzCmdDescArg cmd_debug_set_cond_bp_win_args[3];
 static const RzCmdDescArg cmd_debug_continue_execution_args[2];
 static const RzCmdDescArg cmd_debug_continue_send_signal_args[3];
@@ -7748,8 +7748,17 @@ static const RzCmdDescDetailEntry cmd_debug_add_watchpoint_Valid_space_permissio
 	{ .text = "rw", .arg_str = NULL, .comment = "read-write" },
 	{ 0 },
 };
+
+static const RzCmdDescDetailEntry cmd_debug_add_watchpoint_Example_space_sizes_detail_entries[] = {
+	{ .text = "1", .arg_str = NULL, .comment = "watch only a single byte" },
+	{ .text = "2", .arg_str = NULL, .comment = "watch a 16-bit value" },
+	{ .text = "4", .arg_str = NULL, .comment = "watch a 32-bit value" },
+	{ .text = "8", .arg_str = NULL, .comment = "watch a 64-bit value" },
+	{ 0 },
+};
 static const RzCmdDescDetail cmd_debug_add_watchpoint_details[] = {
 	{ .name = "Valid permission arguments", .entries = cmd_debug_add_watchpoint_Valid_space_permission_space_arguments_detail_entries },
+	{ .name = "Example sizes", .entries = cmd_debug_add_watchpoint_Example_space_sizes_detail_entries },
 	{ 0 },
 };
 static const char *cmd_debug_add_watchpoint_perm_choices[] = { "r", "w", "rw", NULL };
@@ -7758,6 +7767,13 @@ static const RzCmdDescArg cmd_debug_add_watchpoint_args[] = {
 		.name = "perm",
 		.type = RZ_CMD_ARG_TYPE_CHOICES,
 		.choices.choices = cmd_debug_add_watchpoint_perm_choices,
+
+	},
+	{
+		.name = "size",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.optional = true,
 
 	},
 	{ 0 },

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -133,7 +133,7 @@ RZ_IPI void rz_core_debug_single_step_over(RzCore *core);
 RZ_IPI void rz_core_debug_continue(RzCore *core);
 RZ_IPI void rz_core_debug_attach(RzCore *core, int pid);
 RZ_IPI void rz_core_debug_print_status(RzCore *core);
-RZ_IPI void rz_core_debug_bp_add(RzCore *core, ut64 addr, const char *arg_perm, bool hwbp, bool watch);
+RZ_IPI void rz_core_debug_bp_add(RzCore *core, ut64 addr, const char *arg_perm, const char *arg_size, bool hwbp, bool watch);
 RZ_IPI void rz_core_debug_ri(RzCore *core);
 RZ_IPI bool rz_core_debug_pid_print(RzDebug *dbg, int pid, RzCmdStateOutput *state);
 RZ_IPI bool rz_core_debug_thread_print(RzDebug *dbg, int pid, RzCmdStateOutput *state);

--- a/librz/core/tui/panels.c
+++ b/librz/core/tui/panels.c
@@ -3614,7 +3614,7 @@ int __watch_points_cb(void *user) {
 	__panel_prompt(rwPrompt, perm, sizeof(perm));
 	ut64 addr = rz_num_math(core->num, addrBuf);
 	bool hwbp = rz_config_get_b(core->config, "dbg.hwbp");
-	rz_core_debug_bp_add(core, addr, perm, hwbp, true);
+	rz_core_debug_bp_add(core, addr, perm, NULL, hwbp, true);
 	return 0;
 }
 

--- a/librz/debug/debug.c
+++ b/librz/debug/debug.c
@@ -266,10 +266,25 @@ static int rz_debug_recoil(RzDebug *dbg, RzDebugRecoilMode rc_mode) {
 	return rz_debug_bps_enable(dbg);
 }
 
-/* add a breakpoint with some typical values */
-RZ_API RZ_BORROW RzBreakpointItem *rz_debug_bp_add(RZ_NONNULL RzDebug *dbg, ut64 addr, int hw, bool watch, int rw, RZ_NULLABLE const char *module, st64 m_delta) {
+/**
+ * Add a breakpoint with some typical values
+ *
+ * \param addr where to place the breakpoint
+ * \param size the size of the breakpoint or 0 for auto-detection, relevant for watchpoints
+ * \param hw whether to set a hardware breakpoint instead of a software one
+ * \param watch whether to set a watchpoint
+ * \param perm if \p watch is true, rwx permissions for the watchpoint
+ * \param module if not null, in which module to set the breakpoint
+ * \param m_delta offset inside \p module
+ */
+RZ_API RZ_BORROW RzBreakpointItem *rz_debug_bp_add(RZ_NONNULL RzDebug *dbg, ut64 addr, ut64 size, bool hw, bool watch, int perm, RZ_NULLABLE const char *module, st64 m_delta) {
 	rz_return_val_if_fail(dbg, NULL);
-	int bpsz = rz_bp_size_at(dbg->bp, addr);
+	if (watch) {
+		// Software watchpoints not supported
+		hw = true;
+	}
+	int bpsz = size ? size : (hw && !watch) ? 1
+						: rz_bp_size_at(dbg->bp, addr);
 	RzBreakpointItem *bpi;
 	const char *module_name = module;
 	RzListIter *iter;
@@ -329,8 +344,7 @@ RZ_API RZ_BORROW RzBreakpointItem *rz_debug_bp_add(RZ_NONNULL RzDebug *dbg, ut64
 		}
 	}
 	if (watch) {
-		hw = 1; // XXX
-		bpi = rz_bp_watch_add(dbg->bp, addr, bpsz, hw, rw);
+		bpi = rz_bp_watch_add(dbg->bp, addr, bpsz, hw, perm);
 	} else {
 		bpi = hw
 			? rz_bp_add_hw(dbg->bp, addr, bpsz, RZ_PERM_X)

--- a/librz/debug/p/native/windows/windows_message.c
+++ b/librz/debug/p/native/windows/windows_message.c
@@ -496,7 +496,7 @@ RZ_API bool rz_w32_add_winmsg_breakpoint(RzDebug *dbg, const char *msg_name, con
 		free(name);
 		return false;
 	}
-	RzBreakpointItem *b = rz_debug_bp_add(dbg, offset, 0, 0, 0, NULL, 0);
+	RzBreakpointItem *b = rz_debug_bp_add(dbg, offset, 0, false, false, 0, NULL, 0);
 	if (!b) {
 		free(name);
 		return false;

--- a/librz/include/rz_debug.h
+++ b/librz/include/rz_debug.h
@@ -531,7 +531,7 @@ RZ_API bool rz_debug_is_dead(RzDebug *dbg);
 RZ_API int rz_debug_map_protect(RzDebug *dbg, ut64 addr, int size, int perms);
 
 /* breakpoints (most in rz_bp, this calls those) */
-RZ_API RZ_BORROW RzBreakpointItem *rz_debug_bp_add(RZ_NONNULL RzDebug *dbg, ut64 addr, int hw, bool watch, int rw, RZ_NULLABLE const char *module, st64 m_delta);
+RZ_API RZ_BORROW RzBreakpointItem *rz_debug_bp_add(RZ_NONNULL RzDebug *dbg, ut64 addr, ut64 size, bool hw, bool watch, int perm, RZ_NULLABLE const char *module, st64 m_delta);
 RZ_API void rz_debug_bp_rebase(RzDebug *dbg, ut64 old_base, ut64 new_base);
 RZ_API void rz_debug_bp_update(RzDebug *dbg);
 

--- a/test/unit/test_serialize_debug.c
+++ b/test/unit/test_serialize_debug.c
@@ -28,7 +28,7 @@ bool test_debug_serialize_save() {
 	RzDebug *debug = core->dbg;
 	mu_assert_notnull(debug, "debug null");
 
-	RzBreakpointItem *bp_item = rz_debug_bp_add(debug, 0x1337, 0, false, 1, "hax", 42);
+	RzBreakpointItem *bp_item = rz_debug_bp_add(debug, 0x1337, 0, false, false, 1, "hax", 42);
 	mu_assert_notnull(bp_item, "bp_item null");
 	bool set = rz_bp_item_set_cond(bp_item, "bp_cond");
 	mu_assert_true(set, "failed to set cond");


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fix dbg.hwbp config var:
The var was created as an int node, but read as boolean, which is always
false. Since it is used as boolean, creating it as such fits best.

Avoid unnecessary "hw breakpoints not yet supported" warning:
This warning could happen when debug calls into bp for restoring
software breakpoints and hardware breakpoints exist at the same time.
These do not need memory restoration so we can avoid calling into
rz_bp_restore_one() at all.

Add specifiable size for watchpoints and tests:
rz_bp_size_at() is not always the right size for a watchpoint, so we add
the possibility to specify the size as an extra argument to dmw.

**Test plan**

For dbg.hwbp:

Enter debug, set `dbg.hwbp=1` and try to set a breakpoint with `db`. It should be created as a hw breakpoint, not sw.
This becomes especially apparent in e.g. https://git.sr.ht/~thestr4ng3r/rz-commodore with vice:// where sw breakpoints are not supported.

For watchpoint size:

Set a watchpoint with `dbw <perm> <size>`. It should then have the specified size
