### PR TITLE
Remove designated array initializers in `rz_analysis.h`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,6 +20,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       BUILD_DIR: build
       RUN_TESTS: false
+      TEST_INCLUDE_HEADERS_CPP: false
     # VS2022 64
     - builder: vs2022_64
       PYTHON: 'C:\\Python38-x64'
@@ -27,6 +28,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       BUILD_DIR: build
       RUN_TESTS: true
+      TEST_INCLUDE_HEADERS_CPP: true
     # VS2017 64 (Dynamic linking)
     - builder: vs2017_64_dyn
       PYTHON: 'C:\\Python37'
@@ -34,6 +36,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       BUILD_DIR: build
       RUN_TESTS: false
+      TEST_INCLUDE_HEADERS_CPP: false
     # Clang-cl 64 (Dynamic linking)
     - builder: clang_cl_64_dyn
       PYTHON: 'C:\\Python38'
@@ -41,6 +44,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       BUILD_DIR: build
       RUN_TESTS: true
+      TEST_INCLUDE_HEADERS_CPP: false
 
 only_commits:
   files:
@@ -79,12 +83,11 @@ build_script:
 
   - cmd: if %builder% == clang_cl_64_dyn ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2019%" x64 && set CC=clang-cl && %PYTHON%\Scripts\meson setup --buildtype=release --prefix="%CD%\%DIST_FOLDER%" build && %PYTHON%\Scripts\ninja -C build install && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
 
-# Run tests only conditionally
 for:
--
-    matrix:
-        only:
-            - RUN_TESTS: true
+  # Run tests only conditionally
+  - matrix:
+      only:
+        - RUN_TESTS: true
 
     test_script:
       - if %builder% == vs2017_64 ( call "%VSVARSALLPATH2017%" x64 )
@@ -104,6 +107,25 @@ for:
       - cd test
       - rz-test -o results.json -L db
       - cd ..
+
+  # Include header files from C++
+  - matrix:
+      only:
+        - TEST_INCLUDE_HEADERS_CPP: true
+
+    test_script:
+      - if %builder% == vs2017_64 ( call "%VSVARSALLPATH2017%" x64 )
+      - if %builder% == vs2022_64 ( call "%VSVARSALLPATH2022%" x64 )
+      - if %builder% == vs2017_64_dyn ( call "%VSVARSALLPATH2017%" x64 )
+      - if %builder% == clang_cl_64_dyn ( call "%VSVARSALLPATH2019%" x64 )
+      - set PATH=%APPVEYOR_BUILD_FOLDER%\%DIST_FOLDER%\bin;C:\Python38-x64;C:\msys64\mingw64\bin;%PATH%
+      - echo %PATH%
+      - where rizin
+      - rizin -v
+      - copy C:\Python38-x64\python.exe C:\Python38-x64\python3.exe
+      - "%PYTHON%\\Scripts\\meson setup build-cpp-test ./test/unit/cpp"
+      - "%PYTHON%\\Scripts\\meson compile -C build-cpp-test"
+      - "%PYTHON%\\Scripts\\meson test -C build-cpp-test --print-errorlogs"
 
 # Artifacts
 artifacts:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -739,8 +739,8 @@ jobs:
           name: rizin-android-${{ matrix.name }}
           path: /tmp/rizin-android-${{ matrix.name }}.tar.gz
 
-  build-cpp:
-    name: Include Rizin headers from C++ program
+  build-cpp-linux:
+    name: Include Rizin headers from C++ program (Linux)
     runs-on: ubuntu-22.04
     if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'cpp') || ((contains(github.ref, 'release-') || github.ref == 'refs/heads/stable') && github.event_name == 'push') || github.event_name == 'schedule'
     needs: [build-and-test]

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -713,6 +713,8 @@ typedef enum rz_analysis_var_kind_t {
 	RZ_ANALYSIS_VAR_KIND_INVALID = 0, ///< Invalid or unspecified variable
 	RZ_ANALYSIS_VAR_KIND_FORMAL_PARAMETER, ///< Variable is function formal parameter
 	RZ_ANALYSIS_VAR_KIND_VARIABLE, ///< Variable is local variable
+	/* End enum */
+	RZ_ANALYSIS_VAR_KIND_END  ///< Number of RzAnalysisVarKind enums
 } RzAnalysisVarKind;
 
 typedef struct dwarf_variable_t {
@@ -728,17 +730,19 @@ typedef struct dwarf_variable_t {
 typedef enum {
 	RZ_ANALYSIS_VAR_ORIGIN_NONE = 0, ///< Variable was created from rizin
 	RZ_ANALYSIS_VAR_ORIGIN_DWARF, ///< Variable was created from DWARF information
+	/* End enum */
+	RZ_ANALYSIS_VAR_ORIGIN_END  ///< Number of RzAnalysisVarOriginKind enums
 } RzAnalysisVarOriginKind;
 
-static const char *RzAnalysisVarKind_strings[] = {
-	[RZ_ANALYSIS_VAR_KIND_INVALID] = "invalid",
-	[RZ_ANALYSIS_VAR_KIND_FORMAL_PARAMETER] = "formal_parameter",
-	[RZ_ANALYSIS_VAR_KIND_VARIABLE] = "variable",
+static const char *RzAnalysisVarKind_strings[RZ_ANALYSIS_VAR_KIND_END] = {
+	"invalid", /* RZ_ANALYSIS_VAR_KIND_INVALID */
+	"formal_parameter", /* RZ_ANALYSIS_VAR_KIND_FORMAL_PARAMETER */
+	"variable" /* RZ_ANALYSIS_VAR_KIND_VARIABLE */
 };
 
 static const char *RzAnalysisVarOriginKind_strings[] = {
-	[RZ_ANALYSIS_VAR_ORIGIN_NONE] = "none",
-	[RZ_ANALYSIS_VAR_ORIGIN_DWARF] = "DWARF",
+	"none", /* RZ_ANALYSIS_VAR_ORIGIN_NONE */
+	"DWARF" /* RZ_ANALYSIS_VAR_ORIGIN_DWARF */
 };
 
 #define RZ_ANALYSIS_AS_STRING_IMPL(T, name, strings) \

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -714,7 +714,7 @@ typedef enum rz_analysis_var_kind_t {
 	RZ_ANALYSIS_VAR_KIND_FORMAL_PARAMETER, ///< Variable is function formal parameter
 	RZ_ANALYSIS_VAR_KIND_VARIABLE, ///< Variable is local variable
 	/* End enum */
-	RZ_ANALYSIS_VAR_KIND_END  ///< Number of RzAnalysisVarKind enums
+	RZ_ANALYSIS_VAR_KIND_END ///< Number of RzAnalysisVarKind enums
 } RzAnalysisVarKind;
 
 typedef struct dwarf_variable_t {
@@ -731,18 +731,18 @@ typedef enum {
 	RZ_ANALYSIS_VAR_ORIGIN_NONE = 0, ///< Variable was created from rizin
 	RZ_ANALYSIS_VAR_ORIGIN_DWARF, ///< Variable was created from DWARF information
 	/* End enum */
-	RZ_ANALYSIS_VAR_ORIGIN_END  ///< Number of RzAnalysisVarOriginKind enums
+	RZ_ANALYSIS_VAR_ORIGIN_END ///< Number of RzAnalysisVarOriginKind enums
 } RzAnalysisVarOriginKind;
 
 static const char *RzAnalysisVarKind_strings[RZ_ANALYSIS_VAR_KIND_END] = {
 	"invalid", /* RZ_ANALYSIS_VAR_KIND_INVALID */
 	"formal_parameter", /* RZ_ANALYSIS_VAR_KIND_FORMAL_PARAMETER */
-	"variable" /* RZ_ANALYSIS_VAR_KIND_VARIABLE */
+	"variable", /* RZ_ANALYSIS_VAR_KIND_VARIABLE */
 };
 
-static const char *RzAnalysisVarOriginKind_strings[] = {
+static const char *RzAnalysisVarOriginKind_strings[RZ_ANALYSIS_VAR_ORIGIN_END] = {
 	"none", /* RZ_ANALYSIS_VAR_ORIGIN_NONE */
-	"DWARF" /* RZ_ANALYSIS_VAR_ORIGIN_DWARF */
+	"DWARF", /* RZ_ANALYSIS_VAR_ORIGIN_DWARF */
 };
 
 #define RZ_ANALYSIS_AS_STRING_IMPL(T, name, strings) \


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Removed designated array initializers from the code. MSVC C++ compiler seems to not be able to compile it since it is a C99 thing, and MSVC C++ does not entirely support C99.

MCVE: https://godbolt.org/z/af3v7rWfh.

Also added a new test in Appveyor for testing inclusion of Rizin headers in C++ files. The test is only enabled for VS2022.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The new CI for compiling the Rizin headers included in a C++ passes succesfully, and green CI.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Fixes the build for rizinorg/cutter#3247.

<sub>(Ignore the branch name)</sub>
