### PR TITLE
PACKAGERS.md - use more up-to-date PKGBUILD example

### DIFF
--- a/doc/PACKAGERS.md
+++ b/doc/PACKAGERS.md
@@ -129,7 +129,7 @@ extract the license/copyright of all files in the repository.
 Examples
 --------
 
-Arch Linux [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=rizin-git)
+Arch Linux [PKGBUILD](https://gitlab.archlinux.org/archlinux/packaging/packages/rizin/-/blob/main/PKGBUILD?ref_type=heads)
 
 Compatibility
 -------------


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The old example (https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=rizin-git) wasn't updated for a long time and stuck at 0.5.0 version, use the official package which is more updated.
