### PR TITLE
Pin Meson to 0.61.5 for old CentOS and Debian

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,8 +325,9 @@ jobs:
     steps:
       - name: Install tools
         run: yum install -y patch unzip git gcc make python3-pip
+        # Pin Meson to the last version stil supporting Python 3.6
       - name: Install meson and ninja
-        run: pip3 install meson ninja PyYAML
+        run: pip3 install meson==0.61.5 ninja PyYAML
       - name: Checkout rizin
         run: |
           git clone https://github.com/${{ github.repository }}
@@ -395,13 +396,14 @@ jobs:
           ./configure
           make install
         env:
-          PYVERSION: 3.6.12
+          PYVERSION: 3.6.15
+        # Pin Meson to the last version stil supporting Python 3.6
       - name: Install Meson and Ninja
         run: |
           mkdir ${HOME}/.cache
           chmod +w ${HOME}/.cache
           python3 -m pip install ${TRUSTED} --upgrade pip setuptools
-          python3 -m pip install ${TRUSTED} meson ninja PyYAML
+          python3 -m pip install ${TRUSTED} meson==0.61.5 ninja PyYAML
         env:
           TRUSTED: --trusted-host=pypi.org --trusted-host=files.pythonhosted.org
       - name: Checkout rizin


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Pin Meson to 0.61.5 - the last version that still supports Python 3.6
- Pin Python to 3.6.15 - the last of 3.6.x versions for old Debian jobs

Blocked on/requires https://github.com/rizinorg/rizin/pull/3888 first

**Test plan**

CI is green (CentOS and Debian workers)

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/3882
