### PR TITLE
core/tui: fix j/k movements when in hexdump mode

### DIFF
--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -1520,7 +1520,7 @@ static void cursor_nextrow(RzCore *core, bool use_ocur) {
 	RzAsmOp op;
 
 	cursor_ocur(core, use_ocur);
-	if (PIDX == 1) { // DISASM
+	if (PIDX == RZ_CORE_VISUAL_MODE_PD) {
 		nextOpcode(core);
 		return;
 	}
@@ -1560,7 +1560,7 @@ static void cursor_nextrow(RzCore *core, bool use_ocur) {
 			return;
 		}
 	}
-	if (p->row_offsets) {
+	if (p->row_offsets && PIDX != RZ_CORE_VISUAL_MODE_PX) {
 		// FIXME: cache the current row
 		row = rz_print_row_at_off(p, p->cur);
 		roff = rz_print_rowoff(p, row);
@@ -1600,7 +1600,7 @@ static void cursor_prevrow(RzCore *core, bool use_ocur) {
 	int row;
 
 	cursor_ocur(core, use_ocur);
-	if (PIDX == 1) { // DISASM
+	if (PIDX == RZ_CORE_VISUAL_MODE_PD) { // DISASM
 		prevOpcode(core);
 		return;
 	}
@@ -1644,7 +1644,7 @@ static void cursor_prevrow(RzCore *core, bool use_ocur) {
 			return;
 		}
 	}
-	if (p->row_offsets) {
+	if (p->row_offsets && PIDX != RZ_CORE_VISUAL_MODE_PX) {
 		int delta, prev_sz;
 
 		// FIXME: cache the current row


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

For some reasons after commit https://github.com/rizinorg/rizin/commit/0908b65bc34a5ce23eeca248f23859802c8b06ef the hexdump view was broken, with `j`/`k` still moving between instructions instead of correctly moving up/down in the visual hexdump mode.

This fixes the problem by avoiding the disassembly path when not necessary. The code is still messy :( 

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

1. Open a binary
2. Go to visual disasm mode (`Vp`)
3. Go back to hexdump mode (`P`)
4. Enter cursor mode (`c`)
5. Move up and down with `j`/`k`

If fixed, you should just move to the previous or next row in the hexdump mode.


**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
