### PR TITLE
Try searching for backtrace() in libexecinfo.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -327,6 +327,8 @@ foreach it : ccs
   if have_lrt and not it_lrt.found()
     it_lrt = it_cc.find_library('rt', required: true, static: is_static_build)
   endif
+  # FreeBSD has backtrace() in libexecinfo
+  it_lexecinfo = it_cc.find_library('execinfo', required: false)
 
   it_userconf.set('RZ_CHECKS_LEVEL', checks_level)
   it_userconf.set10('IS_PORTABLE', get_option('portable'))
@@ -428,7 +430,7 @@ foreach it : ccs
       ['pipe2', '#define _GNU_SOURCE\n#include <fcntl.h>\n#include <unistd.h>', []],
       # copy_file_range for now disable on freebsd as it s not reliable even for small chunks
       ['copy_file_range', '#ifdef __linux__\n#define _GNU_SOURCE\n#include <unistd.h>\n#endif', []],
-      ['backtrace', '', []],
+      ['backtrace', '', [it_lexecinfo]],
       ['__builtin_bswap16', '', []],
       ['__builtin_bswap32', '', []],
       ['__builtin_bswap64', '', []],


### PR DESCRIPTION
FreeBSD ships the function from this library.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)
