### PR TITLE
Move DWARF attribute class enum into global scope

### DIFF
--- a/librz/include/rz_bin_dwarf.h
+++ b/librz/include/rz_bin_dwarf.h
@@ -992,25 +992,27 @@ typedef struct {
 } RzBinDwarfBlock;
 
 // http://www.dwarfstd.org/doc/DWARF4.pdf#page=29&zoom=100,0,0
+typedef enum {
+	RzBinDwarfAttr_Address,
+	RzBinDwarfAttr_Block,
+	RzBinDwarfAttr_Constant,
+	RzBinDwarfAttr_UConstant,
+	RzBinDwarfAttr_Exprloc,
+	RzBinDwarfAttr_Flag,
+	RzBinDwarfAttr_LoclistPtr,
+	RzBinDwarfAttr_MacPtr,
+	RzBinDwarfAttr_RangelistPtr,
+	RzBinDwarfAttr_Reference,
+	RzBinDwarfAttr_UnitRef,
+	RzBinDwarfAttr_SecOffset,
+	RzBinDwarfAttr_StrRef, /// An offset into the .debug_str section.
+	RzBinDwarfAttr_StrOffsetIndex, /// An offset to a set of entries in the .debug_str_offsets section.
+	RzBinDwarfAttr_LineStrRef, /// An offset into the .debug_line_str section.
+	RzBinDwarfAttr_String, /// A slice of bytes representing a string. Does not include a final null byte. Not guaranteed to be UTF-8 or anything like that.
+} RzBinDwarfAttrClass;
+
 typedef struct {
-	enum {
-		RzBinDwarfAttr_Address,
-		RzBinDwarfAttr_Block,
-		RzBinDwarfAttr_Constant,
-		RzBinDwarfAttr_UConstant,
-		RzBinDwarfAttr_Exprloc,
-		RzBinDwarfAttr_Flag,
-		RzBinDwarfAttr_LoclistPtr,
-		RzBinDwarfAttr_MacPtr,
-		RzBinDwarfAttr_RangelistPtr,
-		RzBinDwarfAttr_Reference,
-		RzBinDwarfAttr_UnitRef,
-		RzBinDwarfAttr_SecOffset,
-		RzBinDwarfAttr_StrRef, /// An offset into the .debug_str section.
-		RzBinDwarfAttr_StrOffsetIndex, /// An offset to a set of entries in the .debug_str_offsets section.
-		RzBinDwarfAttr_LineStrRef, /// An offset into the .debug_line_str section.
-		RzBinDwarfAttr_String, /// A slice of bytes representing a string. Does not include a final null byte. Not guaranteed to be UTF-8 or anything like that.
-	} kind;
+	RzBinDwarfAttrClass kind;
 	union {
 		RzBinDwarfBlock block;
 		ut64 u64;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr moves the DWARF attribute class enum into global scope to make it C++-friendly as per https://stackoverflow.com/questions/30047021/scope-of-enum-in-c-vs-c, and should fix the redness of rz-ghidra caused by errors such as:

![RzBinDwarfAttr-enum-error](https://github.com/rizinorg/rizin/assets/12002672/d8ecfb71-6a98-4101-9a4e-5995be13bde2)
(https://github.com/rizinorg/rz-ghidra/actions/runs/6392078013/job/17348631634#step:4:6310)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green, including the "Publish Docker image on Docker Hub" build. It (rz-ghidra) does build locally.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
