### PR TITLE
Demangle flags symbols

### DIFF
--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -3418,8 +3418,10 @@ static void ds_print_fcn_name(RzDisasmState *ds) {
 			if (ds->core->vmode && (rz_str_startswith(flag->name, "sym.") || (flag_sym = rz_flag_get_by_spaces(ds->core->flags, ds->analysis_op.jump, RZ_FLAGS_FS_SYMBOLS, NULL))) && flag_sym->demangled) {
 				return;
 			}
-			ds_begin_comment(ds);
-			ds_comment(ds, true, "; %s", flag->name);
+			if (ds->core->flags->realnames && flag->realname) {
+				ds_begin_comment(ds);
+				ds_comment(ds, true, "; %s", flag->name);
+			}
 			return;
 		}
 	}

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -2261,7 +2261,7 @@ static void ds_show_flags(RzDisasmState *ds, bool overlapped) {
 			}
 		}
 
-		if (flag->realname) {
+		if (ds->core->flags->realnames && flag->realname) {
 			if (!strncmp(flag->name, "switch.", 7)) {
 				rz_cons_printf(FLAG_PREFIX "switch");
 			} else if (!strncmp(flag->name, "case.", 5)) {
@@ -2349,7 +2349,7 @@ static void ds_show_flags(RzDisasmState *ds, bool overlapped) {
 			}
 		} else {
 			if (outline) {
-				rz_cons_printf("%s", flag->name);
+				rz_cons_printf(FLAG_PREFIX "%s", flag->name);
 			} else {
 				rz_cons_printf("%s%s", comma, flag->name);
 			}

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -2261,7 +2261,7 @@ static void ds_show_flags(RzDisasmState *ds, bool overlapped) {
 			}
 		}
 
-		if (ds->core->flags->realnames && flag->realname) {
+		if (flag->realname) {
 			if (!strncmp(flag->name, "switch.", 7)) {
 				rz_cons_printf(FLAG_PREFIX "switch");
 			} else if (!strncmp(flag->name, "case.", 5)) {

--- a/test/db/analysis/riscv
+++ b/test/db/analysis/riscv
@@ -54,7 +54,7 @@ e asm.pseudo=1
 pd 5
 EOF
 EXPECT=<<EOF
-            0x00010178      ef00c01f       jmp ra                      ; sym.printf
+            0x00010178      ef00c01f       jmp ra
             0x0001017c      930784fe       a5 = s0 - 24
             0x00010180      93850700       a1 = a5
             0x00010184      b7170200       a5 = 0x21

--- a/test/db/cmd/cmd_flags
+++ b/test/db/cmd/cmd_flags
@@ -719,3 +719,15 @@ EXPECT=<<EOF
         ..bss
 EOF
 RUN
+
+NAME=pd shows real names and flag name in comments
+FILE=bins/elf/demangle-test-cpp
+CMDS=<<EOF
+pd 1 @ 0x000011ef @e:asm.flags.real=true
+pd 1 @ 0x000011ef @e:asm.flags.real=false
+EOF
+EXPECT=<<EOF
+            0x000011ef      call  std::vector<int, std::allocator<int> >::vector() ; method.std::vector_int__std::allocator_int___.vector
+            0x000011ef      call  method.std::vector_int__std::allocator_int___.vector
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

I'd like to have `asm.flags.real=true` by default, however one of the problems with having that enabled is that the users cannot easily know what is the flag name they should use to reference the symbol.

For example:
```
call  std::vector<int, std::allocator<int> >::vector()
```
It is not immediately clear that the flag name (which should be used in commands like `s`) is `method.std::vector_int__std::allocator_int___.vector`.

The idea is that we want the flag name to be displayed as comment (but only when the real names are displayed!):
```
-> asm.flags.real=true

call  std::vector<int, std::allocator<int> >::vector() ; method.std::vector_int__std::allocator_int___.vector
```
```
-> asm.flags.real=false
call  method.std::vector_int__std::allocator_int___.vector
```

These comments are not displayed in visual mode because the user can easily use the "jumpkeys"(the numbers near the calls e.g. `[1]`) to move between functions.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

See attached test.
Moreover, ensure that in visual mode the comments are not displayed.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
