### PR TITLE
Fix quit confirmation during debuggin session.

### DIFF
--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -1463,6 +1463,7 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 						if (rz_config_get_i(r->config, "dbg.exitkills") &&
 							rz_debug_can_kill(r->dbg) &&
 							rz_cons_yesno('y', "Do you want to kill the process? (Y/n)")) {
+							rz_config_set_i(r->config, "scr.confirmquit", false);
 							rz_debug_kill(r->dbg, r->dbg->pid, r->dbg->tid, 9); // KILL
 						}
 					} else {

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -1487,7 +1487,6 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 					if (rz_config_get_i(r->config, "dbg.exitkills") &&
 						rz_debug_can_kill(r->dbg) &&
 						rz_cons_yesno('y', "Do you want to kill the process? (Y/n)")) {
-						rz_config_set_i(r->config, "scr.confirmquit", false);
 						rz_debug_kill(r->dbg, r->dbg->pid, r->dbg->tid, 9); // KILL
 					}
 				}

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -1483,12 +1483,10 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 					if (rz_config_get_i(r->config, "dbg.exitkills") && y_kill_debug) {
 						rz_debug_kill(r->dbg, r->dbg->pid, r->dbg->tid, 9); // KILL
 					}
-				} else {
-					if (rz_config_get_i(r->config, "dbg.exitkills") &&
+				} else if (rz_config_get_i(r->config, "dbg.exitkills") &&
 						rz_debug_can_kill(r->dbg) &&
 						rz_cons_yesno('y', "Do you want to kill the process? (Y/n)")) {
-						rz_debug_kill(r->dbg, r->dbg->pid, r->dbg->tid, 9); // KILL
-					}
+					rz_debug_kill(r->dbg, r->dbg->pid, r->dbg->tid, 9); // KILL
 				}
 			}
 		} else {

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -1453,25 +1453,6 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 				}
 			}
 
-			if (debug) {
-				if (no_question_debug) {
-					if (rz_config_get_i(r->config, "dbg.exitkills") && y_kill_debug) {
-						rz_debug_kill(r->dbg, r->dbg->pid, r->dbg->tid, 9); // KILL
-					}
-				} else {
-					if (rz_cons_yesno('y', "Do you want to quit? (Y/n)")) {
-						if (rz_config_get_i(r->config, "dbg.exitkills") &&
-							rz_debug_can_kill(r->dbg) &&
-							rz_cons_yesno('y', "Do you want to kill the process? (Y/n)")) {
-							rz_config_set_i(r->config, "scr.confirmquit", false);
-							rz_debug_kill(r->dbg, r->dbg->pid, r->dbg->tid, 9); // KILL
-						}
-					} else {
-						continue;
-					}
-				}
-			}
-
 			prj = rz_config_get(r->config, "prj.file");
 			bool compress = rz_config_get_b(r->config, "prj.compress");
 			RzProjectErr prj_err = RZ_PROJECT_ERR_SUCCESS;
@@ -1494,6 +1475,21 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 			if (rz_config_get_i(r->config, "scr.confirmquit")) {
 				if (!rz_cons_yesno('n', "Do you want to quit? (Y/n)")) {
 					continue;
+				}
+			}
+
+			if (debug) {
+				if (no_question_debug) {
+					if (rz_config_get_i(r->config, "dbg.exitkills") && y_kill_debug) {
+						rz_debug_kill(r->dbg, r->dbg->pid, r->dbg->tid, 9); // KILL
+					}
+				} else {
+					if (rz_config_get_i(r->config, "dbg.exitkills") &&
+						rz_debug_can_kill(r->dbg) &&
+						rz_cons_yesno('y', "Do you want to kill the process? (Y/n)")) {
+						rz_config_set_i(r->config, "scr.confirmquit", false);
+						rz_debug_kill(r->dbg, r->dbg->pid, r->dbg->tid, 9); // KILL
+					}
 				}
 			}
 		} else {

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -1484,8 +1484,8 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 						rz_debug_kill(r->dbg, r->dbg->pid, r->dbg->tid, 9); // KILL
 					}
 				} else if (rz_config_get_i(r->config, "dbg.exitkills") &&
-						rz_debug_can_kill(r->dbg) &&
-						rz_cons_yesno('y', "Do you want to kill the process? (Y/n)")) {
+					rz_debug_can_kill(r->dbg) &&
+					rz_cons_yesno('y', "Do you want to kill the process? (Y/n)")) {
 					rz_debug_kill(r->dbg, r->dbg->pid, r->dbg->tid, 9); // KILL
 				}
 			}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

In `librz/main/rizin.c` , when in debugger session the program ask for quit confirmation independent of `scr.confirmquit` true or false. 
So the quit confirmation when in debug session is removed, and the code for debug session is pasted below the general quit confirm message, Now if user wants to quit then only program will ask to kill the process otherwise the program will just continue

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

Closes #3818
