### PR TITLE
Fix a double free.

### DIFF
--- a/librz/analysis/p/analysis_tricore_cs.c
+++ b/librz/analysis/p/analysis_tricore_cs.c
@@ -1018,6 +1018,9 @@ static void rz_analysis_tricore_fillval(RzAnalysis *a, RzAnalysisOp *op, csh han
 			if (op->dst) {
 				rz_warn_if_reached();
 			}
+			if (av == op->src[srci - 1]) {
+				av = rz_mem_dup(av, sizeof(RzAnalysisValue));
+			}
 			op->dst = av;
 		}
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

If the operand is rw, av gets assigned to op->src[i] and op->dst. Later when op is freed, op->src[i] and op->dst are freed both and so we run into the double free.

This shouldn't be the case for Tricore, but if it does, it breaks badly.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
