### PR TITLE
Fix fpe and heap buffer overflow

### DIFF
--- a/librz/bin/format/le/le.c
+++ b/librz/bin/format/le/le.c
@@ -1128,6 +1128,7 @@ static RzVector /*<LE_map>*/ *le_create_maps(rz_bin_le_obj_t *bin) {
 	rz_vector_foreach(le_maps, m) {
 		max_vaddr = RZ_MAX(max_vaddr, m->vaddr + m->vsize);
 	}
+	CHECK(h->pagesize);
 	bin->reloc_target_map_base = max_vaddr - max_vaddr % h->pagesize + h->pagesize * 2;
 
 	return le_maps;

--- a/librz/bin/format/le/le.c
+++ b/librz/bin/format/le/le.c
@@ -1129,7 +1129,7 @@ static RzVector /*<LE_map>*/ *le_create_maps(rz_bin_le_obj_t *bin) {
 		max_vaddr = RZ_MAX(max_vaddr, m->vaddr + m->vsize);
 	}
 	CHECK(h->pagesize);
-	bin->reloc_target_map_base = max_vaddr - max_vaddr % h->pagesize + h->pagesize * 2;
+	bin->reloc_target_map_base = max_vaddr - (max_vaddr % h->pagesize) + (h->pagesize * 2);
 
 	return le_maps;
 }

--- a/librz/bin/format/pyc/marshal.c
+++ b/librz/bin/format/pyc/marshal.c
@@ -682,6 +682,10 @@ static pyc_object *get_ascii_object(RzBinPycObj *pyc, RzBuffer *buffer) {
 	ut32 n = 0;
 
 	n = get_ut32(buffer, &error);
+	if (n > ST32_MAX) {
+		RZ_LOG_ERROR("bad marshal data (ascii size out of range)\n");
+		return NULL;
+	}
 	if (error) {
 		return NULL;
 	}
@@ -693,6 +697,10 @@ static pyc_object *get_ascii_interned_object(RzBinPycObj *pyc, RzBuffer *buffer)
 	ut32 n;
 
 	n = get_ut32(buffer, &error);
+	if (n > ST32_MAX) {
+		RZ_LOG_ERROR("bad marshal data (ascii size out of range)\n");
+		return NULL;
+	}
 	if (error) {
 		return NULL;
 	}

--- a/librz/bin/format/pyc/marshal.c
+++ b/librz/bin/format/pyc/marshal.c
@@ -679,14 +679,11 @@ static pyc_object *get_ascii_object_generic(RzBinPycObj *pyc, RzBuffer *buffer, 
 
 static pyc_object *get_ascii_object(RzBinPycObj *pyc, RzBuffer *buffer) {
 	bool error = false;
-	ut32 n = 0;
-
-	n = get_ut32(buffer, &error);
+	ut32 n = get_ut32(buffer, &error);
 	if (n > ST32_MAX) {
 		RZ_LOG_ERROR("bad marshal data (string size out of range)\n");
 		return NULL;
-	}
-	if (error) {
+	} else if (error) {
 		return NULL;
 	}
 	return get_ascii_object_generic(pyc, buffer, n, true);
@@ -694,14 +691,11 @@ static pyc_object *get_ascii_object(RzBinPycObj *pyc, RzBuffer *buffer) {
 
 static pyc_object *get_ascii_interned_object(RzBinPycObj *pyc, RzBuffer *buffer) {
 	bool error = false;
-	ut32 n;
-
-	n = get_ut32(buffer, &error);
+	ut32 n = get_ut32(buffer, &error);
 	if (n > ST32_MAX) {
 		RZ_LOG_ERROR("bad marshal data (string size out of range)\n");
 		return NULL;
-	}
-	if (error) {
+	} else if (error) {
 		return NULL;
 	}
 	return get_ascii_object_generic(pyc, buffer, n, true);

--- a/librz/bin/format/pyc/marshal.c
+++ b/librz/bin/format/pyc/marshal.c
@@ -683,7 +683,7 @@ static pyc_object *get_ascii_object(RzBinPycObj *pyc, RzBuffer *buffer) {
 
 	n = get_ut32(buffer, &error);
 	if (n > ST32_MAX) {
-		RZ_LOG_ERROR("bad marshal data (ascii size out of range)\n");
+		RZ_LOG_ERROR("bad marshal data (string size out of range)\n");
 		return NULL;
 	}
 	if (error) {
@@ -698,7 +698,7 @@ static pyc_object *get_ascii_interned_object(RzBinPycObj *pyc, RzBuffer *buffer)
 
 	n = get_ut32(buffer, &error);
 	if (n > ST32_MAX) {
-		RZ_LOG_ERROR("bad marshal data (ascii size out of range)\n");
+		RZ_LOG_ERROR("bad marshal data (string size out of range)\n");
 		return NULL;
 	}
 	if (error) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`le_create_maps()` didn't check for `h->pagesize` to be non-zero.

`get_ascii_object()` and `get_ascii_interned_object()` didn't check `n` to be less or equal than `ST32_MAX`. This could lead to heap buffer overflow in `get_bytes()`.

**Test plan**

CI is green
