### PR TITLE
Revert "Fix CI build"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -954,7 +954,7 @@ jobs:
         build-debian,
         build-static,
         build-android,
-        build-cpp-linux,
+        build-cpp,
         test-osx-pkg,
         test-windows-clang_cl,
         build-rzpipe,


### PR DESCRIPTION
This reverts commit 61e072344d684c5ab9a572f4ac81f0fb31ef1377. We have imported 61e072344d684c5ab9a572f4ac81f0fb31ef1377, but not commit 714c338e0fcfa468f59d2518f0c0b73d99eff83d, thus let's remove it.

See https://github.com/rizinorg/rizin/actions/runs/6532016983 .
```
[Invalid workflow file: .github/workflows/ci.yml#L957](https://github.com/rizinorg/rizin/actions/runs/6532016983/workflow)
The workflow is not valid. .github/workflows/ci.yml (Line: 957, Col: 9): Job 'create-release' depends on unknown job 'build-cpp-linux'.
```