### PR TITLE
Parse go 1.20 & 1.21 pclntab

### DIFF
--- a/librz/bin/p/bin_pe.inc
+++ b/librz/bin/p/bin_pe.inc
@@ -263,15 +263,20 @@ static bool is_go_pclntab(ut8 *magic) {
 #define IS_GOPCLNTAB_1_16_BE(x) (x[3] == 0xfa && x[2] == 0xff && x[1] == 0xff && x[0] == 0xff && x[4] == 0x00 && x[5] == 0x00)
 #define IS_GOPCLNTAB_1_18_LE(x) (x[0] == 0xf0 && x[1] == 0xff && x[2] == 0xff && x[3] == 0xff && x[4] == 0x00 && x[5] == 0x00)
 #define IS_GOPCLNTAB_1_18_BE(x) (x[3] == 0xf0 && x[2] == 0xff && x[1] == 0xff && x[0] == 0xff && x[4] == 0x00 && x[5] == 0x00)
+#define IS_GOPCLNTAB_1_20_LE(x) (x[0] == 0xf1 && x[1] == 0xff && x[2] == 0xff && x[3] == 0xff && x[4] == 0x00 && x[5] == 0x00)
+#define IS_GOPCLNTAB_1_20_BE(x) (x[3] == 0xf1 && x[2] == 0xff && x[1] == 0xff && x[0] == 0xff && x[4] == 0x00 && x[5] == 0x00)
 	return IS_GOPCLNTAB_1_2_LE(magic) || IS_GOPCLNTAB_1_2_BE(magic) ||
 		IS_GOPCLNTAB_1_16_LE(magic) || IS_GOPCLNTAB_1_16_BE(magic) ||
-		IS_GOPCLNTAB_1_18_LE(magic) || IS_GOPCLNTAB_1_18_BE(magic);
+		IS_GOPCLNTAB_1_18_LE(magic) || IS_GOPCLNTAB_1_18_BE(magic) ||
+		IS_GOPCLNTAB_1_20_LE(magic) || IS_GOPCLNTAB_1_20_BE(magic);
 #undef IS_GOPCLNTAB_1_2_LE
 #undef IS_GOPCLNTAB_1_2_BE
 #undef IS_GOPCLNTAB_1_16_LE
 #undef IS_GOPCLNTAB_1_16_BE
 #undef IS_GOPCLNTAB_1_18_LE
 #undef IS_GOPCLNTAB_1_18_BE
+#undef IS_GOPCLNTAB_1_20_LE
+#undef IS_GOPCLNTAB_1_20_BE
 }
 
 static ut64 find_go_pclntab(RzBinFile *bf, ut32 *size, ut64 *vaddr) {

--- a/test/db/analysis/golang
+++ b/test/db/analysis/golang
@@ -456,3 +456,63 @@ EXPECT=<<EOF
 | 0x00099edc      auipc t0, 0x3e ; 0xbd602 ; "expected 'foo' or 'bar' subcommandsfile type does not support deadlinefindrunnable: netpoll with spinninggreyobject: obj not poi"
 EOF
 RUN
+
+NAME=Resolve all symbols on a stripped windows go1.21 binary
+FILE=bins/golang/go-re-sample-windows-amd64-go121.exe
+CMDS=<<EOF
+aalg
+fl~sym.go.~?
+pdfs @ main ~str.
+izq~?
+EOF
+EXPECT=<<EOF
+1604
+0x00490237 str.foo
+0x00490292 str.enable
+0x004902a0 str.enable
+0x004902b0 str.name
+0x004902c0 str.name
+0x004902f2 str.bar
+0x0049034d str.level
+0x0049035b str.level
+0x00490448 str.subcommand__bar
+0x00490495 str.level:
+0x0049051d str.tail:
+0x004905c2 str.subcommand__foo
+0x00490615 str.enable:
+0x00490692 str.name:
+0x0049071e str.tail:
+0x00490780 str.expected__foo__or__bar__subcommands
+20633
+EOF
+RUN
+
+NAME=Resolve all symbols on a stripped linux go1.21 binary
+FILE=bins/golang/go-re-sample-linux-amd64-go121
+CMDS=<<EOF
+aalg
+fl~sym.go.~?
+pdfs @ main ~str.
+izq~?
+EOF
+EXPECT=<<EOF
+1587
+0x004875b7 str.foo
+0x00487612 str.enable
+0x00487620 str.enable
+0x00487630 str.name
+0x00487640 str.name
+0x00487672 str.bar
+0x004876cd str.level
+0x004876db str.level
+0x004877c8 str.subcommand__bar
+0x00487815 str.level:
+0x0048789d str.tail:
+0x00487942 str.subcommand__foo
+0x00487995 str.enable:
+0x00487a12 str.name:
+0x00487a9e str.tail:
+0x00487b00 str.expected__foo__or__bar__subcommands
+3558
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This is a patch for allowing parsing go 1.20 & 1.21 pclntab.

From the go changes, i don't see any differences between 1.18,1.19,1.20 and 1.21.

I have updated the generic code for PE also.

Fix #3946 