### PR TITLE
analysis/dwarf: fix use-after-free

### DIFF
--- a/librz/analysis/var.c
+++ b/librz/analysis/var.c
@@ -459,10 +459,10 @@ RZ_API void rz_analysis_var_init(RZ_BORROW RzAnalysisVar *var) {
 RZ_API void rz_analysis_var_fini(RZ_OWN RzAnalysisVar *var) {
 	rz_return_if_fail(var);
 	rz_analysis_var_clear_accesses(var);
-	rz_type_free(var->type);
+	RZ_FREE_CUSTOM(var->type, rz_type_free);
 	rz_vector_fini(&var->constraints);
-	free(var->name);
-	free(var->comment);
+	RZ_FREE(var->name);
+	RZ_FREE(var->comment);
 	rz_analysis_var_storage_fini(&var->storage);
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes the following ASAN error:
```
[x] Propagate noreturn information
[WARNING: rz_vector_push: assertion 'vec' failed (line 213)
WARNING: rz_vector_push: assertion 'vec' failed (line 213)
=================================================================
==69447==ERROR: AddressSanitizer: heap-use-after-free on address 0x602002f04ab0 at pc 0x00010428bf68 bp 0x00016d0310f0 sp 0x00016d030888
READ of size 1 at 0x602002f04ab0 thread T0
    #0 0x10428bf64 in strcmp+0x4d8 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x17f64)
    #1 0x106906d54 in rz_analysis_function_add_var var.c:423
    #2 0x10682a424 in dwarf_integrate_function dwarf_process.c:1970
    #3 0x103beffb0 in ht_up_foreach ht_inc.c:364
    #4 0x10ccc44ec in rz_core_analysis_everything canalysis.c:4855
    #5 0x10ccd6434 in rz_core_perform_auto_analysis canalysis.c:6483
    #6 0x10cf9742c in rz_analyze_everything_handler cmd_analysis.c:6067
    #7 0x10d07fb04 in rz_cmd_call_parsed_args cmd_api.c:821
    #8 0x10d02744c in handle_ts_arged_stmt cmd.c:3640
    #9 0x10d065afc in handle_ts_stmt cmd.c:5183
    #10 0x10d025c64 in handle_ts_statements cmd.c:5205
    #11 0x10d03ee8c in core_cmd_tsrzcmd cmd.c:5351
    #12 0x10cf28618 in rz_core_cmd cmd.c:5399
    #13 0x10cdf3a18 in rz_core_prompt_exec core.c:2770
    #14 0x10cdf20c8 in rz_core_prompt_loop core.c:2640
    #15 0x10333fa90 in rz_main_rizin rizin.c:1437
    #16 0x18ff5d0dc  (<unknown module>)
    #17 0x1407fffffffffffc  (<unknown module>)

0x602002f04ab0 is located 0 bytes inside of 12-byte region [0x602002f04ab0,0x602002f04abc)
freed by thread T0 here:
    #0 0x1042c7a38 in free+0x90 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x53a38)
    #1 0x1069078f8 in rz_analysis_var_fini var.c:464
    #2 0x10683d34c in RzBinDwarfLocation_as_RzAnalysisVarStorage dwarf_process.c:1868
    #3 0x10683d67c in RzBinDwarfLocation_as_RzAnalysisVarStorage dwarf_process.c:1889
    #4 0x10682a414 in dwarf_integrate_function dwarf_process.c:1966
    #5 0x103beffb0 in ht_up_foreach ht_inc.c:364
    #6 0x10ccc44ec in rz_core_analysis_everything canalysis.c:4855
    #7 0x10ccd6434 in rz_core_perform_auto_analysis canalysis.c:6483
    #8 0x10cf9742c in rz_analyze_everything_handler cmd_analysis.c:6067
    #9 0x10d07fb04 in rz_cmd_call_parsed_args cmd_api.c:821
    #10 0x10d02744c in handle_ts_arged_stmt cmd.c:3640
    #11 0x10d065afc in handle_ts_stmt cmd.c:5183
    #12 0x10d025c64 in handle_ts_statements cmd.c:5205
    #13 0x10d03ee8c in core_cmd_tsrzcmd cmd.c:5351
    #14 0x10cf28618 in rz_core_cmd cmd.c:5399
    #15 0x10cdf3a18 in rz_core_prompt_exec core.c:2770
    #16 0x10cdf20c8 in rz_core_prompt_loop core.c:2640
    #17 0x10333fa90 in rz_main_rizin rizin.c:1437
    #18 0x18ff5d0dc  (<unknown module>)
    #19 0x1407fffffffffffc  (<unknown module>)

previously allocated by thread T0 here:
    #0 0x1042c0cb0 in strdup+0x114 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x4ccb0)
    #1 0x10682a350 in dwarf_integrate_function dwarf_process.c:1966
    #2 0x103beffb0 in ht_up_foreach ht_inc.c:364
    #3 0x10ccc44ec in rz_core_analysis_everything canalysis.c:4855
    #4 0x10ccd6434 in rz_core_perform_auto_analysis canalysis.c:6483
    #5 0x10cf9742c in rz_analyze_everything_handler cmd_analysis.c:6067
    #6 0x10d07fb04 in rz_cmd_call_parsed_args cmd_api.c:821
    #7 0x10d02744c in handle_ts_arged_stmt cmd.c:3640
    #8 0x10d065afc in handle_ts_stmt cmd.c:5183
    #9 0x10d025c64 in handle_ts_statements cmd.c:5205
    #10 0x10d03ee8c in core_cmd_tsrzcmd cmd.c:5351
    #11 0x10cf28618 in rz_core_cmd cmd.c:5399
    #12 0x10cdf3a18 in rz_core_prompt_exec core.c:2770
    #13 0x10cdf20c8 in rz_core_prompt_loop core.c:2640
    #14 0x10333fa90 in rz_main_rizin rizin.c:1437
    #15 0x18ff5d0dc  (<unknown module>)
    #16 0x1407fffffffffffc  (<unknown module>)

SUMMARY: AddressSanitizer: heap-use-after-free (libclang_rt.asan_osx_dynamic.dylib:arm64+0x17f64) in strcmp+0x4d8
Shadow bytes around the buggy address:
  0x602002f04800: fa fa 07 fa fa fa 00 00 fa fa 00 00 fa fa 00 fa
  0x602002f04880: fa fa 00 fa fa fa 00 05 fa fa 00 01 fa fa 00 01
  0x602002f04900: fa fa 00 fa fa fa 06 fa fa fa 00 05 fa fa 03 fa
  0x602002f04980: fa fa 00 fa fa fa 00 fa fa fa 03 fa fa fa 00 fa
  0x602002f04a00: fa fa 07 fa fa fa 00 06 fa fa 00 06 fa fa 00 fa
=>0x602002f04a80: fa fa fd fa fa fa[fd]fd fa fa 07 fa fa fa fa fa
  0x602002f04b00: fa fa 00 04 fa fa 00 04 fa fa fd fd fa fa 00 03
  0x602002f04b80: fa fa 00 00 fa fa 00 04 fa fa 00 04 fa fa 00 00
  0x602002f04c00: fa fa fa fa fa fa 00 00 fa fa fa fa fa fa fa fa
  0x602002f04c80: fa fa fa fa fa fa fa fa fa fa 00 00 fa fa fa fa
  0x602002f04d00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
```
