### PR TITLE
core/tui: fix NULL deref with highlight when showing xrefs

### DIFF
--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -1281,9 +1281,9 @@ repeat:
 				rz_cons_newline();
 			}
 			/* prepare highlight */
-			char *cmd = strdup(rz_cons_singleton()->highlight);
+			char *cmd = rz_str_new(rz_cons_singleton()->highlight);
 			char *ats = rz_str_newf("%" PFMT64x, curat);
-			if (ats && !*cmd) {
+			if (ats && RZ_STR_ISEMPTY(cmd)) {
 				rz_cons_highlight(ats);
 			}
 			/* print disasm */


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

When pressing `x` in visual mode on a binary it was crashing because `highlight` was NULL and the strdup was failing.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
