### PR TITLE
Fix format generation out of types

### DIFF
--- a/librz/type/format.c
+++ b/librz/type/format.c
@@ -2977,6 +2977,13 @@ static void type_to_format(const RzTypeDB *typedb, RzStrBuf *buf, RzType *type) 
 				rz_strbuf_append(buf, "?");
 			} else if (type->identifier.kind == RZ_TYPE_IDENTIFIER_KIND_ENUM) {
 				rz_strbuf_append(buf, "E");
+			} else {
+				RzBaseType *btyp = rz_type_get_base_type(typedb, type);
+				if (btyp) {
+					RzStrBuf *fields = rz_strbuf_new("");
+					base_type_to_format_no_unfold(typedb, btyp, type->identifier.name, buf, fields);
+					rz_strbuf_free(fields);
+				}
 			}
 		}
 	} else if (type->kind == RZ_TYPE_KIND_ARRAY) {

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -495,10 +495,17 @@ CMDS=<<EOF
 td "struct test_struct{int x;int y;};"
 ts test_struct
 tsd test_struct
+td "typedef uint16_t word;"
+td "typedef uint32_t dword;"
+td "struct test_struct2{word a; word b[5]; word c; word d[10]; dword e;};"
+ts test_struct2
+tsd test_struct2
 EOF
 EXPECT=<<EOF
 pf dd x y
 struct test_struct { int x; int y; };
+pf w[5]ww[10]wd a (word)b c (word)d e
+struct test_struct2 { word a; word b[5]; word c; word d[10]; dword e; };
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Before it generated just `[5]` from `WORD bla[5]` without the `w` appended, now it's the right `[5]w`.

**Test plan**

CI is green

**Closing issues**

closes https://github.com/rizinorg/rizin/issues/3971