### PR TITLE
Fix arm64 ldr mask in objc_stubs analysis

### DIFF
--- a/librz/core/analysis_objc.c
+++ b/librz/core/analysis_objc.c
@@ -353,7 +353,7 @@ static const ut8 objc_stubs_mask_arm64[] = {
 	0x1f, 0x00, 0x00, 0x9f, // adrp  x1, <section.__DATA.__objc_const>
 	0xff, 0x03, 0xc0, 0xff, // ldr   x1, [x1, <selector string ptr offset>]
 	0x1f, 0x00, 0x00, 0x9f, // adrp  x16, <reloc base>
-	0xff, 0x0f, 0xe0, 0xff, // ldr   x16, [x16, <reloc offset>]
+	0xff, 0x03, 0xc0, 0xff, // ldr   x16, [x16, <reloc offset>]
 	0xff, 0xff, 0xff, 0xff, // br    x16
 	0xff, 0xff, 0xff, 0xff, // brk   1
 	0xff, 0xff, 0xff, 0xff, // brk   1
@@ -386,7 +386,7 @@ static const ut8 objc_stubs_mask_arm64_32[] = {
 	0x1f, 0x00, 0x00, 0x9f, // adrp  x1, <section.__DATA.__objc_const>
 	0xff, 0x03, 0xc0, 0xff, // ldr   w1, [x1, <selector string ptr offset>]
 	0x1f, 0x00, 0x00, 0x9f, // adrp  x16, <reloc base>
-	0xff, 0x0f, 0xe0, 0xff, // ldr   w16, [x16, <reloc offset>]
+	0xff, 0x03, 0xc0, 0xff, // ldr   w16, [x16, <reloc offset>]
 	0xff, 0xff, 0xff, 0xff, // br    x16
 	0xff, 0xff, 0xff, 0xff, // brk   1
 	0xff, 0xff, 0xff, 0xff, // brk   1
@@ -575,6 +575,9 @@ static void analyze_objc_stubs(RzCore *core, ut64 start, ut64 size) {
 			break;
 		}
 		if (!stride) {
+			RZ_LOG_ERROR("Failed to match any known pattern against __objc_stubs contents. "
+				     "If this is not a manually modified binary, please consider opening an "
+				     "issue to let the rizin team know about this new format.\n");
 			// no pattern matched, cancel the entire search because the section is not in a known format.
 			break;
 		}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This ldr is "LDR (immediate), Unsigned offset" as described in the ISA manual. The mask was covering data bits and thus could lead to false negative matches.

**Test plan**

Tests exist in `test/db/formats/mach0/objc` that cover this code already. They did not catch this bug because the data values in these files did not have any 1s in the respective bits. Adding more tests to cover every bit combination is impractical though.