### PR TITLE
Fix commit hash for capstone-next

### DIFF
--- a/subprojects/capstone-next.wrap
+++ b/subprojects/capstone-next.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 url = https://github.com/capstone-engine/capstone.git
-revision = 46154e8605aaefdcca5fecf4ea88b92db5a40ad3
+revision = b87cf06209bbcc092692cb85438e7ece20994104
 directory = capstone-next
 patch_directory = capstone-next


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Solve this:
```
Cloning into '/home/runner/work/rizin/rizin/subprojects/capstone-next'...
fatal: reference is not a tree: 46154e8605aaefdcca5fecf4ea88b92db5a40ad3
err project /home/runner/work/rizin/rizin/subprojects/capstone-next not found
/home/runner/work/rizin/rizin/meson.build:186:21: error in function subproject()
186 |     capstone_proj = subproject('capstone-' + capstone_version, default_options: ['default_library=static'])
                          ^
Error: Process completed with exit code 1.
```

**Test plan**

CI is green