### PR TITLE
X-Refs to global variable - `avgx`

### DIFF
--- a/librz/analysis/var_global.c
+++ b/librz/analysis/var_global.c
@@ -404,3 +404,15 @@ RZ_API RZ_OWN char *rz_analysis_var_global_get_constraints_readable(RzAnalysisVa
 	}
 	return rz_strbuf_drain_nofree(&sb);
 }
+
+/**
+ * \brief Get the list of x-references to the global variable
+ *
+ * \param analysis RzAnalysis
+ * \param glob Global variable
+ * \return RzList *
+ */
+RZ_API RZ_OWN RzList /*<RzAnalysisXRef *>*/ *rz_analysis_var_global_xrefs(RzAnalysis *analysis, RZ_NONNULL const RzAnalysisVarGlobal *glob) {
+	rz_return_val_if_fail(analysis && glob, NULL);
+	return rz_analysis_xrefs_get_to(analysis, glob->addr);
+}

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -3179,11 +3179,9 @@ static void xref_list_print_as_cmd(RZ_UNUSED RzCore *core, RzList /*<RzAnalysisX
 	}
 }
 
-RZ_IPI RzCmdStatus rz_analysis_xrefs_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
-	RzListIter *iter;
+static void xrefs_list_handler(RzCore *core, RzList /*<RzAnalysisXRef *>*/ *list, RzCmdStateOutput *state) {
 	RzAnalysisXRef *xref;
-	RzCmdStatus status = RZ_CMD_STATUS_OK;
-	RzList *list = rz_analysis_xrefs_list(core->analysis);
+	RzListIter *iter;
 	switch (state->mode) {
 	case RZ_OUTPUT_MODE_STANDARD:
 		xrefs_list_print(core, list);
@@ -3201,18 +3199,21 @@ RZ_IPI RzCmdStatus rz_analysis_xrefs_list_handler(RzCore *core, int argc, const 
 		break;
 	default:
 		rz_warn_if_reached();
-		status = RZ_CMD_STATUS_WRONG_ARGS;
 		break;
 	}
+}
+
+RZ_IPI RzCmdStatus rz_analysis_xrefs_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
+	RzCmdStatus status = RZ_CMD_STATUS_OK;
+	RzList *list = rz_analysis_xrefs_list(core->analysis);
+	xrefs_list_handler(core, list, state);
 	rz_list_free(list);
 	return status;
 }
 
-RZ_IPI RzCmdStatus rz_analysis_xrefs_to_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
+static void xrefs_to_list_handler(RzCore *core, RzList /*<RzAnalysisXRef *>*/ *list, RzCmdStateOutput *state) {
 	RzAnalysisXRef *xref;
 	RzListIter *iter;
-	RzCmdStatus status = RZ_CMD_STATUS_OK;
-	RzList *list = rz_analysis_xrefs_get_to(core->analysis, core->offset);
 	switch (state->mode) {
 	case RZ_OUTPUT_MODE_STANDARD:
 		rz_list_foreach (list, iter, xref) {
@@ -3247,9 +3248,14 @@ RZ_IPI RzCmdStatus rz_analysis_xrefs_to_list_handler(RzCore *core, int argc, con
 		break;
 	default:
 		rz_warn_if_reached();
-		status = RZ_CMD_STATUS_WRONG_ARGS;
 		break;
 	}
+}
+
+RZ_IPI RzCmdStatus rz_analysis_xrefs_to_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
+	RzCmdStatus status = RZ_CMD_STATUS_OK;
+	RzList *list = rz_analysis_xrefs_get_to(core->analysis, core->offset);
+	xrefs_to_list_handler(core, list, state);
 	rz_list_free(list);
 	return status;
 }
@@ -3490,6 +3496,19 @@ RZ_IPI RzCmdStatus rz_analysis_xrefs_graph_handler(RzCore *core, int argc, const
 	xrefs_graph(core, core->offset, 0, ht, state->mode, pj);
 	ht_uu_free(ht);
 	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_analysis_global_variable_xrefs_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
+	RzAnalysisVarGlobal *glob = rz_analysis_var_global_get_byname(core->analysis, argv[1]);
+	if (!glob) {
+		RZ_LOG_ERROR("Global variable '%s' does not exist!\n", argv[1]);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	RzCmdStatus status = RZ_CMD_STATUS_OK;
+	RzList *list = rz_analysis_var_global_xrefs(core->analysis, glob);
+	xrefs_to_list_handler(core, list, state);
+	rz_list_free(list);
+	return status;
 }
 
 #define CMD_REGS_PREFIX   analysis

--- a/librz/core/cmd_descs/cmd_analysis.yaml
+++ b/librz/core/cmd_descs/cmd_analysis.yaml
@@ -1580,6 +1580,18 @@ commands:
                 type: RZ_CMD_ARG_TYPE_GLOBAL_VAR
               - name: type
                 type: RZ_CMD_ARG_TYPE_ANY_TYPE
+          - name: avgx
+            summary: print all xrefs to the global variable
+            type: RZ_CMD_DESC_TYPE_ARGV_STATE
+            cname: analysis_global_variable_xrefs
+            modes:
+              - RZ_OUTPUT_MODE_STANDARD
+              - RZ_OUTPUT_MODE_JSON
+              - RZ_OUTPUT_MODE_QUIET
+              - RZ_OUTPUT_MODE_RIZIN
+            args:
+              - name: name
+                type: RZ_CMD_ARG_TYPE_GLOBAL_VAR
       - name: avr
         summary: try to parse RTTI at vtable addr (see analysis.cpp.abi)
         type: RZ_CMD_DESC_TYPE_ARGV_MODES

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -250,6 +250,7 @@ static const RzCmdDescArg analysis_global_variable_delete_byname_args[2];
 static const RzCmdDescArg analysis_global_variable_rename_args[3];
 static const RzCmdDescArg analysis_global_variable_print_args[2];
 static const RzCmdDescArg analysis_global_variable_retype_args[3];
+static const RzCmdDescArg analysis_global_variable_xrefs_args[2];
 static const RzCmdDescArg analysis_rtti_demangle_class_name_args[2];
 static const RzCmdDescArg analysis_xrefs_set_0_args[2];
 static const RzCmdDescArg analysis_xrefs_set_c_args[2];
@@ -4878,6 +4879,19 @@ static const RzCmdDescArg analysis_global_variable_retype_args[] = {
 static const RzCmdDescHelp analysis_global_variable_retype_help = {
 	.summary = "change the global variable type",
 	.args = analysis_global_variable_retype_args,
+};
+
+static const RzCmdDescArg analysis_global_variable_xrefs_args[] = {
+	{
+		.name = "name",
+		.type = RZ_CMD_ARG_TYPE_GLOBAL_VAR,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_global_variable_xrefs_help = {
+	.summary = "print all xrefs to the global variable",
+	.args = analysis_global_variable_xrefs_args,
 };
 
 static const RzCmdDescArg analysis_print_rtti_args[] = {
@@ -19497,6 +19511,9 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *analysis_global_variable_retype_cd = rz_cmd_desc_argv_new(core->rcmd, avg_cd, "avgt", rz_analysis_global_variable_retype_handler, &analysis_global_variable_retype_help);
 	rz_warn_if_fail(analysis_global_variable_retype_cd);
+
+	RzCmdDesc *analysis_global_variable_xrefs_cd = rz_cmd_desc_argv_state_new(core->rcmd, avg_cd, "avgx", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_RIZIN, rz_analysis_global_variable_xrefs_handler, &analysis_global_variable_xrefs_help);
+	rz_warn_if_fail(analysis_global_variable_xrefs_cd);
 
 	RzCmdDesc *analysis_print_rtti_cd = rz_cmd_desc_argv_modes_new(core->rcmd, av_cd, "avr", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_print_rtti_handler, &analysis_print_rtti_help);
 	rz_warn_if_fail(analysis_print_rtti_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -565,6 +565,8 @@ RZ_IPI RzCmdStatus rz_analysis_global_variable_rename_handler(RzCore *core, int 
 RZ_IPI RzCmdStatus rz_analysis_global_variable_print_handler(RzCore *core, int argc, const char **argv);
 // "avgt"
 RZ_IPI RzCmdStatus rz_analysis_global_variable_retype_handler(RzCore *core, int argc, const char **argv);
+// "avgx"
+RZ_IPI RzCmdStatus rz_analysis_global_variable_xrefs_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "avr"
 RZ_IPI RzCmdStatus rz_analysis_print_rtti_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 // "avra"

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1863,6 +1863,7 @@ RZ_API bool rz_analysis_var_global_rename(RzAnalysis *analysis, RZ_NONNULL const
 RZ_API void rz_analysis_var_global_set_type(RzAnalysisVarGlobal *glob, RZ_NONNULL RZ_BORROW RzType *type);
 RZ_API void rz_analysis_var_global_add_constraint(RzAnalysisVarGlobal *glob, RzTypeConstraint *constraint);
 RZ_API RZ_OWN char *rz_analysis_var_global_get_constraints_readable(RzAnalysisVarGlobal *glob);
+RZ_API RZ_OWN RzList /*<RzAnalysisXRef *>*/ *rz_analysis_var_global_xrefs(RzAnalysis *analysis, RZ_NONNULL const RzAnalysisVarGlobal *glob);
 RZ_API RZ_OWN RzList /*<RzTypePathTuple *>*/ *rz_analysis_type_paths_by_address(RzAnalysis *analysis, ut64 addr);
 
 /* project */

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -3,6 +3,8 @@ FILE=bins/elf/dwarf/static_var
 CMDS=<<EOF
 aaa
 avg
+avgx qwe
+avgx bla
 echo "fn1"
 afvll @ dbg.fn1
 echo "fn2"
@@ -15,6 +17,9 @@ global char [19] anonymous_var_0xb4 @ 0x2021
 global const float qwe @ 0x2034
 global char * bla @ 0x4088
 global char [5] anonymous_var_0x59 @ 0x2010
+dbg.fn2 0x11b4 [DATA] lea rax, obj.fn2.qwe
+dbg.fn1 0x116a [DATA] mov qword [obj.fn1.bla], rax
+dbg.fn1 0x1171 [DATA] mov rsi, qword [obj.fn1.bla]
 fn1
 arg int b origin=DWARF @ rbp-8
 arg int a origin=DWARF @ rbp-4


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Allows to see the X-refs to the global variable, similarly to the `axt` output.

**Test plan**

CI is green

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/4015
