### PR TITLE
Fix use-after-free of _args[0] in RzRunProfile

### DIFF
--- a/librz/socket/run.c
+++ b/librz/socket/run.c
@@ -565,7 +565,8 @@ RZ_API bool rz_run_parseline(RzRunProfile *p, const char *b) {
 	}
 
 	if (!strcmp(key, "program")) {
-		p->_args[0] = p->_program = strdup(value);
+		p->_args[0] = strdup(value);
+		p->_program = strdup(value);
 	} else if (!strcmp(key, "daemon")) {
 		p->_daemon = true;
 	} else if (!strcmp(key, "system")) {


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Happens e.g. on `rz-run input= -- echo hello`, when echo is resolved through PATH and _program is freed, but the pointer stays in _args[0].
