### PR TITLE
Force usage of RzList methods instead of direct access of the fields

### DIFF
--- a/librz/analysis/block.c
+++ b/librz/analysis/block.c
@@ -808,7 +808,6 @@ RZ_API RzAnalysisBlock *rz_analysis_block_chop_noreturn(RzAnalysisBlock *block, 
 	// This last step isn't really critical, but nice to have.
 	// Prepare to merge blocks with their predecessors if possible
 	RzList *merge_blocks = rz_list_newf((RzListFree)rz_analysis_block_unref);
-	rz_list_init(merge_blocks);
 	ht_up_foreach(succs, noreturn_get_blocks_cb, merge_blocks);
 
 	// Free/unref BEFORE doing the merge!

--- a/librz/analysis/var.c
+++ b/librz/analysis/var.c
@@ -1758,7 +1758,7 @@ RZ_API char *rz_analysis_fcn_format_sig(RZ_NONNULL RzAnalysis *analysis, RZ_NONN
 		size_t tmp_len = strlen(vartype);
 		rz_strbuf_appendf(buf, "%s%s%s%s", vartype,
 			tmp_len && vartype[tmp_len - 1] == '*' ? "" : " ",
-			var->name, iter->n ? ", " : "");
+			var->name, rz_list_iter_has_next(iter) ? ", " : "");
 		free(vartype);
 	}
 

--- a/librz/asm/asm.c
+++ b/librz/asm/asm.c
@@ -398,8 +398,7 @@ static void set_plugin_configs(RZ_BORROW RzAsm *rz_asm, RZ_BORROW RzConfig *pcfg
 	RzConfig *conf = ((RzCore *)(rz_asm->core))->config;
 	RzConfigNode *n;
 	RzListIter *it;
-	rz_list_foreach_iter(pcfg->nodes, it) {
-		n = it->data;
+	rz_list_foreach (pcfg->nodes, it, n) {
 		if (!rz_config_add_node(conf, rz_config_node_clone(n))) {
 			RZ_LOG_WARN("Failed to add \"%s\" to the global config.\n", n->name)
 		}
@@ -418,8 +417,7 @@ static void unset_plugins_config(RZ_BORROW RzAsm *rz_asm, RZ_BORROW RzConfig *pc
 	RzConfig *conf = ((RzCore *)(rz_asm->core))->config;
 	RzConfigNode *n;
 	RzListIter *it;
-	rz_list_foreach_iter(pcfg->nodes, it) {
-		n = it->data;
+	rz_list_foreach (pcfg->nodes, it, n) {
 		if (!rz_config_rm(conf, n->name)) {
 			RZ_LOG_WARN("Failed to remove \"%s\" from the global config.", n->name)
 		}

--- a/librz/bin/format/le/le.c
+++ b/librz/bin/format/le/le.c
@@ -230,7 +230,7 @@ static RZ_BORROW RzBinSymbol *le_add_symbol(rz_bin_le_obj_t *bin, ut32 ordinal, 
 		if (rz_list_empty(bin->symbols)) {
 			ordinal = 1;
 		} else {
-			ordinal = ((RzBinSymbol *)rz_list_tail(bin->symbols)->data)->ordinal + 1;
+			ordinal = ((RzBinSymbol *)rz_list_get_tail_data(bin->symbols))->ordinal + 1;
 		}
 	}
 	if (!rz_list_append(bin->symbols, sym)) {

--- a/librz/bin/format/mach0/dyldcache.c
+++ b/librz/bin/format/mach0/dyldcache.c
@@ -507,7 +507,7 @@ static void match_bin_entries(RzDyldCache *cache, void *entries) {
 		if (!it) {
 			break;
 		}
-		bin = it->data;
+		bin = rz_list_iter_get_data(it);
 		if (!bin) {
 			break;
 		}
@@ -521,7 +521,8 @@ static void match_bin_entries(RzDyldCache *cache, void *entries) {
 				bin->nlist_start_index = e->nlistStartIndex;
 				bin->nlist_count = e->nlistCount;
 			}
-			it = it->n;
+
+			it = rz_list_iter_get_next(it);
 		}
 	}
 

--- a/librz/bin/format/mz/mz.c
+++ b/librz/bin/format/mz/mz.c
@@ -138,7 +138,7 @@ RzList /*<RzBinSection *>*/ *rz_bin_mz_get_segments(const struct rz_bin_mz_obj_t
 	rz_list_foreach (seg_list, iter, section) {
 		section->name = rz_str_newf("seg_%03d", section_number);
 		if (section_number) {
-			RzBinSection *p_section = iter->p->data;
+			RzBinSection *p_section = rz_list_iter_get_prev_data(iter);
 			p_section->size = section->vaddr - p_section->vaddr;
 			p_section->vsize = p_section->size;
 		}

--- a/librz/bin/format/pe/pe_clr.c
+++ b/librz/bin/format/pe/pe_clr.c
@@ -31,16 +31,17 @@ RZ_OWN RzList /*<RzBinSymbol *>*/ *PE_(rz_bin_pe_get_clr_symbols)(RzBinPEObj *bi
 	ut32 type_methods_end = type_methods_start;
 
 	if (type_it) {
-		Pe_image_metadata_typedef *typedef_ = type_it->data;
+		Pe_image_metadata_typedef *typedef_ = rz_list_iter_get_data(type_it);
 		type_name = rz_buf_get_string(bin->clr->strings, typedef_->name);
 		type_namespace = rz_buf_get_string(bin->clr->strings, typedef_->namespace);
 
-		type_methods_start = ((Pe_image_metadata_typedef *)type_it->data)->methodlist;
+		type_methods_start = typedef_->methodlist;
 		type_methods_end = rz_pvector_len(bin->clr->methoddefs) + 1;
 
-		type_it = type_it->n;
+		type_it = rz_list_iter_get_next(type_it);
 		if (type_it) {
-			type_methods_end = ((Pe_image_metadata_typedef *)type_it->data)->methodlist;
+			Pe_image_metadata_typedef *itypedef_ = rz_list_iter_get_data(type_it);
+			type_methods_end = itypedef_->methodlist;
 		}
 	}
 
@@ -54,14 +55,15 @@ RZ_OWN RzList /*<RzBinSymbol *>*/ *PE_(rz_bin_pe_get_clr_symbols)(RzBinPEObj *bi
 			free(type_name);
 			free(type_namespace);
 
-			Pe_image_metadata_typedef *typedef_ = type_it->data;
+			Pe_image_metadata_typedef *typedef_ = rz_list_iter_get_data(type_it);
 			type_name = rz_buf_get_string(bin->clr->strings, typedef_->name);
 			type_namespace = rz_buf_get_string(bin->clr->strings, typedef_->namespace);
 
 			// Update next end
-			type_it = type_it->n;
+			type_it = rz_list_iter_get_next(type_it);
 			if (type_it) {
-				type_methods_end = ((Pe_image_metadata_typedef *)type_it->data)->methodlist;
+				Pe_image_metadata_typedef *next_typedef_ = rz_list_iter_get_data(type_it);
+				type_methods_end = next_typedef_->methodlist;
 			} else {
 				type_methods_end = rz_pvector_len(bin->clr->methoddefs) + 1;
 			}

--- a/librz/bin/format/pyc/marshal.c
+++ b/librz/bin/format/pyc/marshal.c
@@ -1151,8 +1151,10 @@ static pyc_object *get_object(RzBinPycObj *pyc, RzBuffer *buffer) {
 	}
 
 	if (flag && ref_idx) {
-		free_object(ref_idx->data);
-		ref_idx->data = copy_object(ret);
+		void *p = rz_list_iter_get_data(ref_idx);
+		free_object(p);
+		p = copy_object(ret);
+		rz_list_iter_set_data(ref_idx, p);
 	}
 	return ret;
 }

--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -55,10 +55,6 @@ static const char *mousemodes[] = {
 /* don't use macros for this */
 #define get_anode(gn) ((gn) ? (RzANode *)(gn)->data : NULL)
 
-#define graph_foreach_anode(list, it, pos, anode) \
-	if (list) \
-		for ((it) = (list)->head; (it) && ((pos) = (it)->data) && (pos) && ((anode) = (RzANode *)(pos)->data); (it) = (it)->n)
-
 struct len_pos_t {
 	int len;
 	int pos;
@@ -210,7 +206,10 @@ static void update_node_dimension(const RzGraph /*<RzANode *>*/ *g, int is_mini,
 	RzGraphNode *gn;
 	RzListIter *it;
 	RzANode *n;
-	graph_foreach_anode (nodes, it, gn, n) {
+	rz_list_foreach (nodes, it, gn) {
+		if (!(n = gn->data)) {
+			break;
+		}
 		if (is_mini) {
 			n->h = 1;
 			n->w = MINIGRAPH_NODE_MIN_WIDTH;
@@ -482,9 +481,11 @@ static int **get_crossing_matrix(const RzGraph /*<RzANode *>*/ *g,
 			if (rz_cons_is_breaked()) {
 				goto err_row;
 			}
-			graph_foreach_anode (neigh, itk, gk, ak) {
-				int s;
-				for (s = 0; s < layers[i].n_nodes; s++) {
+			rz_list_foreach (neigh, itk, gk) {
+				if (!(ak = gk->data)) {
+					break;
+				}
+				for (size_t s = 0; s < layers[i].n_nodes; s++) {
 					const RzGraphNode *gs = layers[i].nodes[s];
 					const RzList *neigh_s;
 					RzGraphNode *gt;
@@ -495,7 +496,10 @@ static int **get_crossing_matrix(const RzGraph /*<RzANode *>*/ *g,
 						continue;
 					}
 					neigh_s = rz_graph_get_neighbours(g, gs);
-					graph_foreach_anode (neigh_s, itt, gt, at) {
+					rz_list_foreach (neigh_s, itt, gt) {
+						if (!(at = gt->data)) {
+							break;
+						}
 						if (at->pos_in_layer < ak->pos_in_layer) {
 							m[aj->pos_in_layer][as->pos_in_layer]++;
 						}
@@ -642,16 +646,23 @@ static void assign_layers(const RzAGraph *g) {
 	layer_vis.finish_node = (RzGraphNodeCallback)add_sorted;
 	rz_graph_dfs(g->graph, &layer_vis);
 
-	graph_foreach_anode (topological_sort, it, gn, n) {
+	rz_list_foreach (topological_sort, it, gn) {
+		if (!(n = gn->data)) {
+			break;
+		}
 		const RzList *innodes = rz_graph_innodes(g->graph, gn);
 		RzListIter *it;
 		RzGraphNode *prev;
-		RzANode *preva;
+		RzANode *pnode;
 
 		n->layer = 0;
-		graph_foreach_anode (innodes, it, prev, preva) {
-			if (preva->layer + 1 > n->layer) {
-				n->layer = preva->layer + 1;
+
+		rz_list_foreach (innodes, it, prev) {
+			if (!(pnode = prev->data)) {
+				break;
+			}
+			if (pnode->layer + 1 > n->layer) {
+				n->layer = pnode->layer + 1;
 			}
 		}
 	}
@@ -721,7 +732,10 @@ static void create_layers(RzAGraph *g) {
 
 	/* identify max layer */
 	g->n_layers = 0;
-	graph_foreach_anode (nodes, it, gn, n) {
+	rz_list_foreach (nodes, it, gn) {
+		if (!(n = gn->data)) {
+			break;
+		}
 		if (n->layer > g->n_layers) {
 			g->n_layers = n->layer;
 		}
@@ -734,7 +748,10 @@ static void create_layers(RzAGraph *g) {
 	}
 	g->layers = RZ_NEWS0(struct layer_t, g->n_layers);
 
-	graph_foreach_anode (nodes, it, gn, n) {
+	rz_list_foreach (nodes, it, gn) {
+		if (!(n = gn->data)) {
+			break;
+		}
 		g->layers[n->layer].n_nodes++;
 	}
 
@@ -746,7 +763,10 @@ static void create_layers(RzAGraph *g) {
 			1 + g->layers[i].n_nodes);
 		g->layers[i].position = 0;
 	}
-	graph_foreach_anode (nodes, it, gn, n) {
+	rz_list_foreach (nodes, it, gn) {
+		if (!(n = gn->data)) {
+			break;
+		}
 		n->pos_in_layer = g->layers[n->layer].position;
 		g->layers[n->layer].nodes[g->layers[n->layer].position++] = gn;
 	}
@@ -943,7 +963,10 @@ static RzList /*<RzGraphNode *>*/ **compute_classes(const RzAGraph *g, HtPP *v_n
 	const RzListIter *it;
 	RzANode *n;
 
-	graph_foreach_anode (rz_graph_get_nodes(g->graph), it, gn, n) {
+	rz_list_foreach (rz_graph_get_nodes(g->graph), it, gn) {
+		if (!(n = gn->data)) {
+			break;
+		}
 		n->klass = -1;
 	}
 
@@ -962,7 +985,10 @@ static RzList /*<RzGraphNode *>*/ **compute_classes(const RzAGraph *g, HtPP *v_n
 				if (!res[c]) {
 					res[c] = rz_list_new();
 				}
-				graph_foreach_anode (laj, it, gn, n) {
+				rz_list_foreach (laj, it, gn) {
+					if (!(n = gn->data)) {
+						break;
+					}
 					rz_list_append(res[c], gn);
 					n->klass = c;
 				}
@@ -1022,7 +1048,10 @@ static void adjust_class(const RzAGraph *g, int is_left, RzList /*<RzGraphNode *
 	const RzANode *an;
 	int dist = INT_MAX, v, is_first = true;
 
-	graph_foreach_anode (classes[c], it, gn, an) {
+	rz_list_foreach (classes[c], it, gn) {
+		if (!(an = gn->data)) {
+			break;
+		}
 		const RzGraphNode *sibling;
 		const RzANode *sibl_anode;
 
@@ -1043,13 +1072,19 @@ static void adjust_class(const RzAGraph *g, int is_left, RzList /*<RzGraphNode *
 		RzList *heap = rz_list_new();
 		int len;
 
-		graph_foreach_anode (classes[c], it, gn, an) {
+		rz_list_foreach (classes[c], it, gn) {
+			if (!(an = gn->data)) {
+				break;
+			}
 			const RzList *neigh = rz_graph_all_neighbours(g->graph, gn);
 			const RzGraphNode *gk;
 			const RzListIter *itk;
 			const RzANode *ak;
 
-			graph_foreach_anode (neigh, itk, gk, ak) {
+			rz_list_foreach (neigh, itk, gk) {
+				if (!(ak = gk->data)) {
+					break;
+				}
 				if (ak->klass < c) {
 					size_t d = (ak->x - an->x);
 					if (d > 0) {
@@ -1070,7 +1105,10 @@ static void adjust_class(const RzAGraph *g, int is_left, RzList /*<RzGraphNode *
 		rz_list_free(heap);
 	}
 
-	graph_foreach_anode (classes[c], it, gn, an) {
+	rz_list_foreach (classes[c], it, gn) {
+		if (!(an = gn->data)) {
+			break;
+		}
 		const int old_val = hash_get_int(res, gn);
 		const int new_val = is_left ? old_val + dist : old_val - dist;
 		ht_pu_update(res, gn, (ut64)(size_t)new_val);
@@ -1102,7 +1140,10 @@ static void place_nodes(const RzAGraph *g, const RzGraphNode *gn, int is_left, H
 	const RzListIter *itk;
 	const RzANode *ak;
 
-	graph_foreach_anode (lv, itk, gk, ak) {
+	rz_list_foreach (lv, itk, gk) {
+		if (!(ak = gk->data)) {
+			break;
+		}
 		const RzGraphNode *sibling;
 		const RzANode *sibl_anode;
 
@@ -1126,7 +1167,10 @@ static void place_nodes(const RzAGraph *g, const RzGraphNode *gn, int is_left, H
 		p = is_left ? 0 : 50;
 	}
 
-	graph_foreach_anode (lv, itk, gk, ak) {
+	rz_list_foreach (lv, itk, gk) {
+		if (!(ak = gk->data)) {
+			break;
+		}
 		ht_pu_update(res, gk, (ut64)(size_t)p);
 		set_p_add(placed, gk);
 	}
@@ -1196,7 +1240,10 @@ static void place_dummies(const RzAGraph *g) {
 	}
 
 	nodes = rz_graph_get_nodes(g->graph);
-	graph_foreach_anode (nodes, it, gn, n) {
+	rz_list_foreach (nodes, it, gn) {
+		if (!(n = gn->data)) {
+			break;
+		}
 		n->x = (hash_get_int(xminus, gn) + hash_get_int(xplus, gn)) / 2;
 	}
 
@@ -1301,7 +1348,10 @@ static void place_single(const RzAGraph *g, int l, const RzGraphNode *bm, const 
 	}
 
 	int sum_x = 0;
-	graph_foreach_anode (neigh, itk, gk, ak) {
+	rz_list_foreach (neigh, itk, gk) {
+		if (!(ak = gk->data)) {
+			break;
+		}
 		if (ak->is_reversed) {
 			len--;
 			continue;
@@ -1354,8 +1404,10 @@ static void collect_changes(const RzAGraph *g, int l, const RzGraphNode *b, int 
 		neigh = from_up
 			? rz_graph_innodes(g->graph, vi)
 			: rz_graph_get_neighbours(g->graph, vi);
-
-		graph_foreach_anode (neigh, it, v, av) {
+		rz_list_foreach (neigh, it, v) {
+			if (!(av = v->data)) {
+				break;
+			}
 			if ((is_left && av->x >= avi->x) || (!is_left && av->x <= avi->x)) {
 				c++;
 			} else {
@@ -1575,7 +1627,10 @@ static void place_original(RzAGraph *g) {
 		return;
 	}
 
-	graph_foreach_anode (nodes, itn, gn, an) {
+	rz_list_foreach (nodes, itn, gn) {
+		if (!(an = gn->data)) {
+			break;
+		}
 		if (!an->is_dummy) {
 			continue;
 		}
@@ -1596,23 +1651,6 @@ static void place_original(RzAGraph *g) {
 	ht_pu_free(P);
 	ht_pu_free(D);
 }
-
-#if 0
-static void remove_dummy_nodes(const RzAGraph *g) {
-	const RzList *nodes = rz_graph_get_nodes (g->graph);
-	RzGraphNode *gn;
-	RzListIter *it;
-	RzANode *n;
-
-	graph_foreach_anode (nodes, it, gn, n) {
-		if (n->is_dummy) {
-			rz_graph_del_node (g->graph, gn);
-			n->gnode = NULL;
-			free_anode (n);
-		}
-	}
-}
-#endif
 
 static void set_layer_gap(RzAGraph *g) {
 	int gap = 0;
@@ -1639,7 +1677,10 @@ static void set_layer_gap(RzAGraph *g) {
 			if (!outnodes || !a) {
 				continue;
 			}
-			graph_foreach_anode (outnodes, itn, gb, b) {
+			rz_list_foreach (outnodes, itn, gb) {
+				if (!(b = gb->data)) {
+					break;
+				}
 				if (g->layout == 0) { // vertical layout
 					if ((b->x != a->x) || b->layer <= a->layer) {
 						gap += 1;
@@ -1674,7 +1715,10 @@ static void fix_back_edge_dummy_nodes(RzAGraph *g, RzANode *from, RzANode *to) {
 	int i;
 	rz_return_if_fail(g && from && to);
 	const RzList *neighbours = rz_graph_get_neighbours(g->graph, to->gnode);
-	graph_foreach_anode (neighbours, it, gv, v) {
+	rz_list_foreach (neighbours, it, gv) {
+		if (!(v = gv->data)) {
+			break;
+		}
 		tmp = v;
 		while (tmp->is_dummy) {
 			tmp = (RzANode *)(((RzGraphNode *)rz_list_first(tmp->gnode->out_nodes))->data);
@@ -1722,7 +1766,10 @@ static int get_edge_number(const RzAGraph *g, RzANode *src, RzANode *dst, bool o
 			? rz_graph_get_neighbours(g->graph, src->gnode)
 			: rz_graph_innodes(g->graph, dst->gnode);
 		const int exit_edges = rz_list_length(neighbours);
-		graph_foreach_anode (neighbours, itn, gv, v) {
+		rz_list_foreach (neighbours, itn, gv) {
+			if (!(v = gv->data)) {
+				break;
+			}
 			cur_nth = nth;
 			if (g->is_callgraph) {
 				cur_nth = 0;
@@ -1805,7 +1852,10 @@ static void backedge_info(RzAGraph *g) {
 				outedge += rz_list_length(neighbours);
 			}
 
-			graph_foreach_anode (neighbours, itm, gb, b) {
+			rz_list_foreach (neighbours, itm, gb) {
+				if (!(b = gb->data)) {
+					break;
+				}
 				if (b->layer > a->layer) {
 					continue;
 				}
@@ -2233,7 +2283,10 @@ static void fold_asm_trace(RzCore *core, RzAGraph *g) {
 	RzANode *n;
 
 	RzANode *curnode = get_anode(g->curnode);
-	graph_foreach_anode (nodes, it, gn, n) {
+	rz_list_foreach (nodes, it, gn) {
+		if (!(n = gn->data)) {
+			break;
+		}
 		if (curnode == n) {
 			n->is_mini = false;
 			g->need_reload_nodes = true;
@@ -2248,18 +2301,19 @@ static void fold_asm_trace(RzCore *core, RzAGraph *g) {
 }
 
 static void delete_dup_edges(RzAGraph *g) {
-	RzListIter *it, *in_it, *in_it2, *in_it2_tmp;
+	RzListIter *it, *in_it, *in_it2, *tmp;
 	RzGraphNode *n, *a, *b;
 	rz_list_foreach (g->graph->nodes, it, n) {
 		rz_list_foreach (n->out_nodes, in_it, a) {
-			for (in_it2 = in_it->n; in_it2 && (b = in_it2->data, in_it2_tmp = in_it2->n, 1); in_it2 = in_it2_tmp) {
-				if (a->idx == b->idx) {
-					rz_list_delete(n->out_nodes, in_it2);
-					rz_list_delete_data(n->all_neighbours, b);
-					rz_list_delete_data(b->in_nodes, n);
-					rz_list_delete_data(b->all_neighbours, n);
-					g->graph->n_edges--;
+			rz_list_foreach_iter_safe(rz_list_iter_get_next(in_it), in_it2, tmp, b) {
+				if (a->idx != b->idx) {
+					continue;
 				}
+				rz_list_delete(n->out_nodes, in_it2);
+				rz_list_delete_data(n->all_neighbours, b);
+				rz_list_delete_data(b->in_nodes, n);
+				rz_list_delete_data(b->all_neighbours, n);
+				g->graph->n_edges--;
 			}
 		}
 	}
@@ -2503,7 +2557,10 @@ static const RzGraphNode *find_near_of(const RzAGraph *g, const RzGraphNode *cur
 	const int start_x = acur ? acur->x : default_v;
 	const int start_y = acur ? acur->y : default_v;
 
-	graph_foreach_anode (nodes, it, gn, n) {
+	rz_list_foreach (nodes, it, gn) {
+		if (!(n = gn->data)) {
+			break;
+		}
 		// tab in horizontal layout is not correct, lets force vertical nextnode for now (g->layout == 0)
 		bool isNear = true
 			? is_near(n, start_x, start_y, is_next)
@@ -2543,7 +2600,10 @@ static void update_graph_sizes(RzAGraph *g) {
 	max_x = max_y = INT_MIN;
 	min_gn = max_gn = NULL;
 
-	graph_foreach_anode (rz_graph_get_nodes(g->graph), it, gk, ak) {
+	rz_list_foreach (rz_graph_get_nodes(g->graph), it, gk) {
+		if (!(ak = gk->data)) {
+			break;
+		}
 		const RzList *nd = NULL;
 		int len;
 		if (ak->x < g->x) {
@@ -2664,7 +2724,10 @@ static void agraph_set_layout(RzAGraph *g) {
 	set_layout(g);
 
 	update_graph_sizes(g);
-	graph_foreach_anode (rz_graph_get_nodes(g->graph), it, n, a) {
+	rz_list_foreach (rz_graph_get_nodes(g->graph), it, n) {
+		if (!(a = n->data)) {
+			break;
+		}
 		if (a->is_dummy) {
 			continue;
 		}
@@ -2705,7 +2768,10 @@ static void agraph_print_nodes(const RzAGraph *g) {
 	RzListIter *it;
 	RzANode *n;
 
-	graph_foreach_anode (nodes, it, gn, n) {
+	rz_list_foreach (nodes, it, gn) {
+		if (!(n = gn->data)) {
+			break;
+		}
 		if (gn != g->curnode) {
 			agraph_print_node(g, n);
 		}
@@ -2745,9 +2811,15 @@ static void agraph_print_edges_simple(RzAGraph *g) {
 	RzGraphNode *gn, *gn2;
 	RzListIter *iter, *iter2;
 	const RzList *nodes = rz_graph_get_nodes(g->graph);
-	graph_foreach_anode (nodes, iter, gn, n) {
+	rz_list_foreach (nodes, iter, gn) {
+		if (!(n = gn->data)) {
+			break;
+		}
 		const RzList *outnodes = n->gnode->out_nodes;
-		graph_foreach_anode (outnodes, iter2, gn2, n2) {
+		rz_list_foreach (outnodes, iter2, gn2) {
+			if (!(n2 = gn2->data)) {
+				break;
+			}
 			int sx = n->w / 2;
 			int sy = n->h;
 			int sx2 = n2->w / 2;
@@ -2803,8 +2875,10 @@ static void agraph_print_edges(RzAGraph *g) {
 	RzList *lyr = rz_list_new();
 	RzList *bckedges = rz_list_new();
 	struct tmplayer *tl, *tm;
-
-	graph_foreach_anode (nodes, itm, ga, a) {
+	rz_list_foreach (nodes, itm, ga) {
+		if (!(a = ga->data)) {
+			break;
+		}
 		const RzGraphNode *gb;
 		RzANode *b;
 		RzList *neighbours = (RzList *)rz_graph_get_neighbours(g->graph, ga);
@@ -2860,7 +2934,10 @@ static void agraph_print_edges(RzAGraph *g) {
 			rz_list_sort(neighbours, first_x_cmp);
 		}
 
-		graph_foreach_anode (neighbours, itn, gb, b) {
+		rz_list_foreach (neighbours, itn, gb) {
+			if (!(b = gb->data)) {
+				break;
+			}
 			out_nth = get_edge_number(g, a, b, true);
 			in_nth = get_edge_number(g, a, b, false);
 
@@ -3718,7 +3795,10 @@ RZ_API bool rz_agraph_del_node(const RzAGraph *g, const char *title) {
 	sdb_set(g->db, sdb_fmt("agraph.nodes.%s.neighbours", res->title), NULL, 0);
 
 	const RzList *innodes = rz_graph_innodes(g->graph, res->gnode);
-	graph_foreach_anode (innodes, it, gn, an) {
+	rz_list_foreach (innodes, it, gn) {
+		if (!(an = gn->data)) {
+			break;
+		}
 		const char *key = sdb_fmt("agraph.nodes.%s.neighbours", an->title);
 		sdb_array_remove(g->db, key, res->title, 0);
 	}
@@ -3751,8 +3831,10 @@ static bool user_edge_cb(struct g_cb *user, RZ_UNUSED const void *k, const void 
 	const RzList *neigh = rz_graph_get_neighbours(g->graph, n->gnode);
 	RzListIter *it;
 	RzGraphNode *gn;
-
-	graph_foreach_anode (neigh, it, gn, an) {
+	rz_list_foreach (neigh, it, gn) {
+		if (!(an = gn->data)) {
+			break;
+		}
 		cb(n, an, user_data);
 	}
 	return true;

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -3259,7 +3259,7 @@ static inline bool get_next_i(IterCtx *ctx, size_t *next_i) {
 					}
 					if (!bbit && cop_it) {
 						RzAnalysisCaseOp *cop = rz_list_iter_get_data(cop_it);
-						if (cop->jump == prev_bb->addr && rz_list_iter_get_next(cop_it)) {
+						if (cop->jump == prev_bb->addr && rz_list_iter_has_next(cop_it)) {
 							cop = rz_list_iter_get_next_data(cop_it);
 							rz_list_pop(ctx->switch_path);
 							rz_list_push(ctx->switch_path, rz_list_iter_get_next(cop_it));
@@ -3267,7 +3267,7 @@ static inline bool get_next_i(IterCtx *ctx, size_t *next_i) {
 							bbit = rz_list_find(ctx->bbl, &cop->jump, (RzListComparator)find_bb);
 						}
 					}
-					if (cop_it && !rz_list_iter_get_next(cop_it)) {
+					if (cop_it && !rz_list_iter_has_next(cop_it)) {
 						rz_list_pop(ctx->switch_path);
 						cop_it = rz_list_last(ctx->switch_path);
 					}

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -316,7 +316,7 @@ RZ_IPI void rz_core_analysis_bbs_asciiart(RzCore *core, RzAnalysisFunction *fcn)
 	}
 	RzListIter *iter;
 	RzAnalysisBlock *b;
-	ls_foreach (fcn->bbs, iter, b) {
+	rz_list_foreach (fcn->bbs, iter, b) {
 		RzInterval inter = (RzInterval){ b->addr, b->size };
 		RzListInfo *info = rz_listinfo_new(NULL, inter, inter, -1, NULL);
 		if (!info) {
@@ -335,7 +335,7 @@ RZ_IPI void rz_core_analysis_bbs_asciiart(RzCore *core, RzAnalysisFunction *fcn)
 RZ_IPI void rz_core_analysis_fcn_returns(RzCore *core, RzAnalysisFunction *fcn) {
 	RzListIter *iter;
 	RzAnalysisBlock *b;
-	ls_foreach (fcn->bbs, iter, b) {
+	rz_list_foreach (fcn->bbs, iter, b) {
 		if (b->jump == UT64_MAX) {
 			ut64 retaddr = rz_analysis_block_get_op_addr(b, b->ninstr - 1);
 			if (retaddr == UT64_MAX) {
@@ -3258,16 +3258,16 @@ static inline bool get_next_i(IterCtx *ctx, size_t *next_i) {
 						}
 					}
 					if (!bbit && cop_it) {
-						RzAnalysisCaseOp *cop = cop_it->data;
-						if (cop->jump == prev_bb->addr && cop_it->n) {
-							cop = cop_it->n->data;
+						RzAnalysisCaseOp *cop = rz_list_iter_get_data(cop_it);
+						if (cop->jump == prev_bb->addr && rz_list_iter_get_next(cop_it)) {
+							cop = rz_list_iter_get_next_data(cop_it);
 							rz_list_pop(ctx->switch_path);
-							rz_list_push(ctx->switch_path, cop_it->n);
-							cop_it = cop_it->n;
+							rz_list_push(ctx->switch_path, rz_list_iter_get_next(cop_it));
+							cop_it = rz_list_iter_get_next(cop_it);
 							bbit = rz_list_find(ctx->bbl, &cop->jump, (RzListComparator)find_bb);
 						}
 					}
-					if (cop_it && !cop_it->n) {
+					if (cop_it && !rz_list_iter_get_next(cop_it)) {
 						rz_list_pop(ctx->switch_path);
 						cop_it = rz_list_last(ctx->switch_path);
 					}
@@ -3279,7 +3279,7 @@ static inline bool get_next_i(IterCtx *ctx, size_t *next_i) {
 				rz_list_free(ctx->bbl);
 				return false;
 			}
-			ctx->cur_bb = bbit->data;
+			ctx->cur_bb = rz_list_iter_get_data(bbit);
 			rz_list_push(ctx->path, ctx->cur_bb);
 			rz_list_delete(ctx->bbl, bbit);
 			*next_i = ctx->cur_bb->addr - ctx->start_addr;

--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -612,21 +612,21 @@ static bool callback_foreach_kv(void *user, const char *k, const char *v) {
 }
 
 RZ_API int rz_line_hist_sdb_up(RzLine *line) {
-	if (!line->sdbshell_hist_iter || !line->sdbshell_hist_iter->n) {
+	if (!rz_list_iter_get_next(line->sdbshell_hist_iter)) {
 		return false;
 	}
-	line->sdbshell_hist_iter = line->sdbshell_hist_iter->n;
-	strncpy(line->buffer.data, line->sdbshell_hist_iter->data, RZ_LINE_BUFSIZE - 1);
+	line->sdbshell_hist_iter = rz_list_iter_get_next(line->sdbshell_hist_iter);
+	strncpy(line->buffer.data, rz_list_iter_get_data(line->sdbshell_hist_iter), RZ_LINE_BUFSIZE - 1);
 	line->buffer.index = line->buffer.length = strlen(line->buffer.data);
 	return true;
 }
 
 RZ_API int rz_line_hist_sdb_down(RzLine *line) {
-	if (!line->sdbshell_hist_iter || !line->sdbshell_hist_iter->p) {
+	if (!rz_list_iter_get_prev(line->sdbshell_hist_iter)) {
 		return false;
 	}
-	line->sdbshell_hist_iter = line->sdbshell_hist_iter->p;
-	strncpy(line->buffer.data, line->sdbshell_hist_iter->data, RZ_LINE_BUFSIZE - 1);
+	line->sdbshell_hist_iter = rz_list_iter_get_prev(line->sdbshell_hist_iter);
+	strncpy(line->buffer.data, rz_list_iter_get_data(line->sdbshell_hist_iter), RZ_LINE_BUFSIZE - 1);
 	line->buffer.index = line->buffer.length = strlen(line->buffer.data);
 	return true;
 }

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -918,7 +918,7 @@ static void showregs(RzList /*<char *>*/ *list) {
 		RzListIter *iter;
 		rz_list_foreach (list, iter, reg) {
 			rz_cons_print(reg);
-			if (iter->n) {
+			if (rz_list_iter_has_next(iter)) {
 				rz_cons_printf(" ");
 			}
 		}

--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -26,7 +26,7 @@ static bool pal_seek(RzCore *core, RzConsPalSeekMode mode, const char *file, RzL
 	}
 	switch (mode) {
 	case RZ_CONS_PAL_SEEK_PREVIOUS: {
-		const char *next_fn = iter->n ? iter->n->data : NULL;
+		const char *next_fn = rz_list_iter_get_next_data(iter);
 		if (!core->curtheme) {
 			return true;
 		}
@@ -38,7 +38,7 @@ static bool pal_seek(RzCore *core, RzConsPalSeekMode mode, const char *file, RzL
 		break;
 	}
 	case RZ_CONS_PAL_SEEK_NEXT: {
-		const char *prev_fn = iter->p ? iter->p->data : NULL;
+		const char *prev_fn = rz_list_iter_get_prev_data(iter);
 		if (!core->curtheme) {
 			return true;
 		}

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -1180,7 +1180,7 @@ static void print_rop(RzCore *core, RzList /*<RzCoreAsmHit *>*/ *hitlist, PJ *pj
 		}
 		pj_end(pj);
 		if (db && hit) {
-			const ut64 addr = ((RzCoreAsmHit *)hitlist->head->data)->addr;
+			const ut64 addr = ((RzCoreAsmHit *)rz_list_get_head_data(hitlist))->addr;
 			// rz_cons_printf ("Gadget size: %d\n", (int)size);
 			const char *key = sdb_fmt("0x%08" PFMT64x, addr);
 			rop_classify(core, db, ropList, key, size);
@@ -1195,7 +1195,7 @@ static void print_rop(RzCore *core, RzList /*<RzCoreAsmHit *>*/ *hitlist, PJ *pj
 		// Print gadgets in a 'linear manner', each sequence
 		// on one line.
 		rz_cons_printf("0x%08" PFMT64x ":",
-			((RzCoreAsmHit *)hitlist->head->data)->addr);
+			((RzCoreAsmHit *)rz_list_get_head_data(hitlist))->addr);
 		rz_list_foreach (hitlist, iter, hit) {
 			ut8 *buf = malloc(hit->len);
 			rz_io_read_at(core->io, hit->addr, buf, hit->len);
@@ -1221,7 +1221,7 @@ static void print_rop(RzCore *core, RzList /*<RzCoreAsmHit *>*/ *hitlist, PJ *pj
 			rz_analysis_op_fini(&aop);
 		}
 		if (db && hit) {
-			const ut64 addr = ((RzCoreAsmHit *)hitlist->head->data)->addr;
+			const ut64 addr = ((RzCoreAsmHit *)rz_list_get_head_data(hitlist))->addr;
 			// rz_cons_printf ("Gadget size: %d\n", (int)size);
 			const char *key = sdb_fmt("0x%08" PFMT64x, addr);
 			rop_classify(core, db, ropList, key, size);
@@ -1275,7 +1275,7 @@ static void print_rop(RzCore *core, RzList /*<RzCoreAsmHit *>*/ *hitlist, PJ *pj
 			rz_analysis_op_fini(&aop);
 		}
 		if (db && hit) {
-			const ut64 addr = ((RzCoreAsmHit *)hitlist->head->data)->addr;
+			const ut64 addr = ((RzCoreAsmHit *)rz_list_get_head_data(hitlist))->addr;
 			// rz_cons_printf ("Gadget size: %d\n", (int)size);
 			const char *key = sdb_fmt("0x%08" PFMT64x, addr);
 			rop_classify(core, db, ropList, key, size);
@@ -1500,7 +1500,7 @@ static int rz_core_search_rop(RzCore *core, RzInterval search_itv, int opt, cons
 					if (gadgetSdb) {
 						RzListIter *iter;
 
-						RzCoreAsmHit *hit = (RzCoreAsmHit *)hitlist->head->data;
+						RzCoreAsmHit *hit = (RzCoreAsmHit *)rz_list_get_head_data(hitlist);
 						char *headAddr = rz_str_newf("%" PFMT64x, hit->addr);
 						if (!headAddr) {
 							result = false;
@@ -1526,8 +1526,8 @@ static int rz_core_search_rop(RzCore *core, RzInterval search_itv, int opt, cons
 					if ((mode == 'q') && subchain) {
 						do {
 							print_rop(core, hitlist, NULL, mode);
-							hitlist->head = hitlist->head->n;
-						} while (hitlist->head->n);
+							hitlist->head = hitlist->head->next;
+						} while (hitlist->head->next);
 					} else {
 						print_rop(core, hitlist, param->pj, mode);
 					}

--- a/librz/core/cmd/cmd_type.c
+++ b/librz/core/cmd/cmd_type.c
@@ -189,7 +189,7 @@ static void types_xrefs_summary(RzCore *core) {
 		rz_list_foreach (uniq, iter2, type) {
 			char *str = rz_type_as_string(analysis->typedb, type);
 			if (str) {
-				rz_cons_printf("%s%s", str, iter2->n ? "," : "\n");
+				rz_cons_printf("%s%s", str, rz_list_iter_has_next(iter2) ? "," : "\n");
 			}
 			free(str);
 		}

--- a/librz/core/csign.c
+++ b/librz/core/csign.c
@@ -302,7 +302,7 @@ static void flirt_print_module(const RzFlirtModule *module) {
 			rz_cons_printf(")");
 		}
 		rz_cons_printf("%04X:%s", func->offset, func->name);
-		if (pub_func_it->n) {
+		if (rz_list_iter_has_next(pub_func_it)) {
 			rz_cons_printf(" ");
 		}
 	}
@@ -315,7 +315,7 @@ static void flirt_print_module(const RzFlirtModule *module) {
 		rz_cons_printf(" (REF ");
 		rz_list_foreach (module->referenced_functions, ref_func_it, ref_func) {
 			rz_cons_printf("%04X: %s", ref_func->offset, ref_func->name);
-			if (ref_func_it->n) {
+			if (rz_list_iter_has_next(ref_func_it)) {
 				rz_cons_printf(" ");
 			}
 		}

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -1343,7 +1343,7 @@ static void ds_show_xrefs(RzDisasmState *ds) {
 			realname = NULL;
 			fun = fcnIn(ds, xrefi->from, -1);
 			if (fun) {
-				if (iter != xrefs->tail) {
+				if (iter != rz_list_tail(xrefs)) {
 					ut64 next_addr = ((RzAnalysisXRef *)rz_list_iter_get_next_data(iter))->from;
 					next_fun = rz_analysis_get_fcn_in(core->analysis, next_addr, -1);
 					if (next_fun && next_fun->addr == fun->addr) {
@@ -1356,8 +1356,8 @@ static void ds_show_xrefs(RzDisasmState *ds) {
 			} else {
 				f = rz_flag_get_at(core->flags, xrefi->from, true);
 				if (f) {
-					if (iter != xrefs->tail) {
-						ut64 next_addr = ((RzAnalysisXRef *)rz_list_iter_has_next(iter))->from;
+					if (iter != rz_list_tail(xrefs)) {
+						ut64 next_addr = ((RzAnalysisXRef *)rz_list_iter_get_next_data(iter))->from;
 						next_f = rz_flag_get_at(core->flags, next_addr, true);
 						if (next_f && f->offset == next_f->offset) {
 							rz_list_append(addrs, rz_num_dup(xrefi->from - f->offset));
@@ -1380,7 +1380,7 @@ static void ds_show_xrefs(RzDisasmState *ds) {
 			ut64 *addrptr;
 			rz_list_foreach (addrs, it, addrptr) {
 				if (addrptr && *addrptr) {
-					ds_comment(ds, false, "%s%s0x%" PFMT64x, it == addrs->head ? "" : ", ", plus, *addrptr);
+					ds_comment(ds, false, "%s%s0x%" PFMT64x, it == rz_list_head(addrs) ? "" : ", ", plus, *addrptr);
 				}
 			}
 			if (realname && (!fun || rz_analysis_get_function_at(core->analysis, ds->at))) {

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -1314,7 +1314,7 @@ static void ds_show_xrefs(RzDisasmState *ds) {
 			ds_comment(ds, false, "%s 0x%08" PFMT64x "  ",
 				rz_analysis_xrefs_type_tostring(xrefi->type), xrefi->from);
 			if (count == cols) {
-				if (iter->n) {
+				if (rz_list_iter_has_next(iter)) {
 					ds_print_color_reset(ds);
 					ds_newline(ds);
 					ds_begin_line(ds);
@@ -1344,7 +1344,7 @@ static void ds_show_xrefs(RzDisasmState *ds) {
 			fun = fcnIn(ds, xrefi->from, -1);
 			if (fun) {
 				if (iter != xrefs->tail) {
-					ut64 next_addr = ((RzAnalysisXRef *)(iter->n->data))->from;
+					ut64 next_addr = ((RzAnalysisXRef *)rz_list_iter_get_next_data(iter))->from;
 					next_fun = rz_analysis_get_fcn_in(core->analysis, next_addr, -1);
 					if (next_fun && next_fun->addr == fun->addr) {
 						rz_list_append(addrs, rz_num_dup(xrefi->from));
@@ -1357,7 +1357,7 @@ static void ds_show_xrefs(RzDisasmState *ds) {
 				f = rz_flag_get_at(core->flags, xrefi->from, true);
 				if (f) {
 					if (iter != xrefs->tail) {
-						ut64 next_addr = ((RzAnalysisXRef *)(iter->n->data))->from;
+						ut64 next_addr = ((RzAnalysisXRef *)rz_list_iter_has_next(iter))->from;
 						next_f = rz_flag_get_at(core->flags, next_addr, true);
 						if (next_f && f->offset == next_f->offset) {
 							rz_list_append(addrs, rz_num_dup(xrefi->from - f->offset));
@@ -1754,15 +1754,15 @@ static void printVarSummary(RzDisasmState *ds, RzList /*<RzAnalysisVar *>*/ *lis
  **/
 static ut32 fold_variables(RzCore *core, RzDisasmState *ds, RzListIter /*<RzAnalysisVar *>*/ *iter) {
 	ut32 iter_mov = 0;
-	RzAnalysisVar *var = iter->data;
+	RzAnalysisVar *var = rz_list_iter_get_data(iter);
 	if (!strcmp(ds->fold_var, "none") || rz_analysis_var_is_arg(var)) {
 		return iter_mov;
 	}
 	char *vartype = rz_type_as_string(core->analysis->typedb, var->type);
-	RzListIter *temp_it = iter->n;
+	RzListIter *temp_it = rz_list_iter_get_next(iter);
 	ut32 same_type_cnt = 1;
 	while (temp_it) {
-		RzAnalysisVar *temp_var = temp_it->data;
+		RzAnalysisVar *temp_var = rz_list_iter_get_data(temp_it);
 		if (!temp_var) {
 			break;
 		}
@@ -1776,7 +1776,7 @@ static ut32 fold_variables(RzCore *core, RzDisasmState *ds, RzListIter /*<RzAnal
 		}
 		same_type_cnt += 1;
 		free(temp_vartype);
-		temp_it = temp_it->n;
+		temp_it = rz_list_iter_get_next(temp_it);
 	}
 
 	// fold if more than 3 same-typed variables
@@ -1790,12 +1790,12 @@ static ut32 fold_variables(RzCore *core, RzDisasmState *ds, RzListIter /*<RzAnal
 	// fold_var = hide -> group the first two var with ellipsis in tail
 	ut32 group_num = strcmp(ds->fold_var, "group") ? 2 : 3;
 	while (iter_mov < group_num) {
-		RzAnalysisVar *temp_var = iter->data;
+		RzAnalysisVar *temp_var = rz_list_iter_get_data(iter);
 		const RzStackAddr off = temp_var->storage.stack_off;
 		const char sign = off >= 0 ? '+' : '-';
 		rz_strbuf_appendf(sb, "%s @ stack %c 0x%" PFMT64x "; ", temp_var->name, sign, RZ_ABS(off));
 		iter_mov++;
-		iter = iter->n;
+		iter = rz_list_iter_get_next(iter);
 	}
 	// remove extra "; " in tail
 	rz_strbuf_slice(sb, 0, sb->len - 2);
@@ -1849,7 +1849,7 @@ static void ds_show_fn_vars_lines(
 		if (iter_mov > 0) {
 			int cnt = 0;
 			while (cnt++ < iter_mov - 1) {
-				iter = iter->n;
+				iter = rz_list_iter_get_next(iter);
 			}
 			continue;
 		}
@@ -2329,7 +2329,7 @@ static void ds_show_flags(RzDisasmState *ds, bool overlapped) {
 							rz_cons_printf("%d:", case_prev);
 						}
 						if (iter != uniqlist->head && iter != uniqlist->tail) {
-							iter = iter->p;
+							iter = rz_list_iter_get_prev(iter);
 						}
 						case_start = case_current;
 					} else {

--- a/librz/core/tui/config.c
+++ b/librz/core/tui/config.c
@@ -61,7 +61,7 @@ static void show_config_options(RzCore *core, const char *opt) {
 		RzListIter *iter;
 		RzStrBuf *sb = rz_strbuf_new(" Options: ");
 		rz_list_foreach (node->options, iter, item) {
-			rz_strbuf_appendf(sb, "%s%s", iter->p ? ", " : "", item);
+			rz_strbuf_appendf(sb, "%s%s", rz_list_iter_has_prev(iter) ? ", " : "", item);
 			if (rz_strbuf_length(sb) + 5 >= w) {
 				char *s = rz_strbuf_drain(sb);
 				rz_cons_println(s);

--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -1196,7 +1196,7 @@ repeat:
 				rz_cons_printf("...");
 				break;
 			}
-			if (!iter->n && idx < skip) {
+			if (!rz_list_iter_has_next(iter) && idx < skip) {
 				skip = idx;
 			}
 			if (idx >= skip) {

--- a/librz/debug/p/debug_dmp.c
+++ b/librz/debug/p/debug_dmp.c
@@ -609,16 +609,17 @@ static void debug_dmp_set_i386_registers(RzReg *reg, struct context_type_i386 *c
 static void debug_dmp_set_current_context(WindCtx *ctx, RzReg *reg, ut8 *buf) {
 	if (ctx->is_arm && ctx->is_64bit) {
 		// ARM 64
-		return debug_dmp_set_arm64_registers(reg, (struct context_type_arm64 *)buf);
+		debug_dmp_set_arm64_registers(reg, (struct context_type_arm64 *)buf);
 	} else if (ctx->is_arm && !ctx->is_64bit) {
 		// ARM 32
-		return debug_dmp_set_arm32_registers(reg, (struct context_type_arm *)buf);
+		debug_dmp_set_arm32_registers(reg, (struct context_type_arm *)buf);
 	} else if (ctx->is_64bit) {
 		// AMD 64
-		return debug_dmp_set_amd64_registers(reg, (struct context_type_amd64 *)buf);
+		debug_dmp_set_amd64_registers(reg, (struct context_type_amd64 *)buf);
+	} else {
+		// i386
+		debug_dmp_set_i386_registers(reg, (struct context_type_i386 *)buf);
 	}
-	// i386
-	return debug_dmp_set_i386_registers(reg, (struct context_type_i386 *)buf);
 }
 
 static size_t debug_dmp_get_current_context_size(WindCtx *ctx) {

--- a/librz/debug/p/native/windows/windows_debug.c
+++ b/librz/debug/p/native/windows/windows_debug.c
@@ -101,7 +101,7 @@ static inline PTHREAD_ITEM find_thread(RzDebug *dbg, int tid) {
 		return NULL;
 	}
 	RzListIter *it = rz_list_find(dbg->threads, &tid, (RzListComparator)w32_findthread_cmp);
-	return it ? it->data : NULL;
+	return it ? rz_list_iter_get_data(it) : NULL;
 }
 
 static PTHREAD_ITEM add_thread(RzDebug *dbg, DWORD pid, DWORD tid, HANDLE hThread, LPVOID lpThreadLocalBase, LPVOID lpStartAddress, BOOL bFinished) {
@@ -772,7 +772,7 @@ static int findlibcmp(void *BaseOfDll, void *lib) {
 
 static void *find_library(void *BaseOfDll) {
 	RzListIter *it = rz_list_find(lib_list, BaseOfDll, (RzListComparator)findlibcmp);
-	return it ? it->data : NULL;
+	return it ? rz_list_iter_get_data(it) : NULL;
 }
 
 static void remove_library(PLIB_ITEM library) {
@@ -809,7 +809,7 @@ static void add_library(DWORD pid, LPVOID lpBaseOfDll, HANDLE hFile, char *dllna
 }
 
 static void *last_library(void) {
-	return rz_list_tail(lib_list) ? rz_list_tail(lib_list)->data : NULL;
+	return rz_list_get_tail_data(lib_list);
 }
 
 static bool breaked = false;

--- a/librz/debug/p/native/xnu/xnu_threads.c
+++ b/librz/debug/p/native/xnu/xnu_threads.c
@@ -393,7 +393,7 @@ RZ_IPI xnu_thread_t *rz_xnu_get_thread(RzDebug *dbg, int tid) {
 			return NULL;
 		}
 	}
-	return (xnu_thread_t *)it->data;
+	return (xnu_thread_t *)rz_list_iter_get_data(it);
 }
 
 /* XXX: right now it just returns the first thread, not the one selected in dbg->tid */

--- a/librz/flag/flag.c
+++ b/librz/flag/flag.c
@@ -484,7 +484,7 @@ RZ_API char *rz_flag_get_liststr(RzFlag *f, ut64 off) {
 	char *p = NULL;
 	rz_list_foreach (list, iter, fi) {
 		p = rz_str_appendf(p, "%s%s",
-			fi->realname, iter->n ? "," : "");
+			fi->realname, rz_list_iter_has_next(iter) ? "," : "");
 	}
 	return p;
 }

--- a/librz/include/rz_list.h
+++ b/librz/include/rz_list.h
@@ -10,10 +10,13 @@ extern "C" {
 
 typedef void (*RzListFree)(void *ptr);
 
-typedef struct rz_list_iter_t {
-	void *data;
-	struct rz_list_iter_t *n, *p;
-} RzListIter;
+typedef struct rz_list_iter_t RzListIter;
+
+struct rz_list_iter_t {
+	void *elem;
+	RzListIter *next;
+	RzListIter *prev;
+};
 
 typedef struct rz_list_t {
 	RzListIter *head;
@@ -23,12 +26,6 @@ typedef struct rz_list_t {
 	bool sorted;
 } RzList;
 
-typedef struct rz_list_range_t {
-	HtPP *h;
-	RzList *l;
-	// RzListComparator c;
-} RzListRange;
-
 // RzListComparator should return -1, 0, 1 to indicate "value < list_data", "value == list_data", "value > list_data".
 typedef int (*RzListComparator)(const void *value, const void *list_data);
 
@@ -36,44 +33,51 @@ typedef int (*RzListComparator)(const void *value, const void *list_data);
 
 #define rz_list_foreach(list, it, pos) \
 	if (list) \
-		for (it = list->head; it && (pos = it->data, 1); it = it->n)
-#define rz_list_foreach_iter(list, it) \
-	if (list) \
-		for (it = list->head; it; it = it->n)
+		for (it = list->head; it && (pos = it->elem, 1); it = it->next)
+#define rz_list_foreach_iter(iter, it, pos) \
+	for (it = iter; it && (pos = it->elem, 1); it = it->next)
 /* Safe when calling rz_list_delete() while iterating over the list. */
 #define rz_list_foreach_safe(list, it, tmp, pos) \
 	if (list) \
-		for (it = list->head; it && (pos = it->data, tmp = it->n, 1); it = tmp)
+		for (it = list->head; it && (pos = it->elem, tmp = it->next, 1); it = tmp)
+#define rz_list_foreach_iter_safe(iter, it, tmp, pos) \
+	for (it = iter; it && (pos = it->elem, tmp = it->next, 1); it = tmp)
 #define rz_list_foreach_prev(list, it, pos) \
 	if (list) \
-		for (it = list->tail; it && (pos = it->data, 1); it = it->p)
+		for (it = list->tail; it && (pos = it->elem, 1); it = it->prev)
 #define rz_list_foreach_prev_safe(list, it, tmp, pos) \
-	for (it = list->tail; it && (pos = it->data, tmp = it->p, 1); it = tmp)
+	for (it = list->tail; it && (pos = it->elem, tmp = it->prev, 1); it = tmp)
 
 #define rz_list_empty(x) (!(x) || !(x)->length)
 #define rz_list_head(x)  ((x) ? (x)->head : NULL)
 #define rz_list_tail(x)  ((x) ? (x)->tail : NULL)
 
 #define rz_list_iter_get(x) \
-	x->data; \
-	x = x->n
-#define rz_list_iter_next(x) (x ? 1 : 0)
-#define rz_list_iter_cur(x)  x->p
+	x->elem; \
+	x = x->next
+#define rz_list_iter_next(x)     (x ? 1 : 0)
+#define rz_list_iter_cur(x)      x->prev
+#define rz_list_iter_has_next(x) (x->next)
+#define rz_list_iter_has_prev(x) (x->prev)
 
 RZ_API RZ_OWN RzList *rz_list_new(void);
-RZ_API RZ_OWN RzList *rz_list_newf(RzListFree f);
+RZ_API RZ_OWN RzList *rz_list_newf(RZ_NULLABLE RzListFree f);
 RZ_API RZ_OWN RzList *rz_list_new_from_array(RZ_NONNULL const void **arr, size_t arr_size);
-RZ_API RZ_BORROW RzListIter *rz_list_iter_get_next(RzListIter *iter);
-RZ_API RZ_BORROW void *rz_list_iter_get_next_data(RzListIter *iter);
-RZ_API ut32 rz_list_set_n(RZ_NONNULL RzList *list, ut32 n, void *p);
-RZ_API void *rz_list_iter_get_data(RzListIter *iter);
-RZ_API RZ_BORROW RzListIter *rz_list_append(RZ_NONNULL RzList *list, void *data);
-RZ_API RZ_BORROW RzListIter *rz_list_prepend(RZ_NONNULL RzList *list, void *data);
-RZ_API RZ_BORROW RzListIter *rz_list_insert(RZ_NONNULL RzList *list, ut32 n, void *data);
+RZ_API RZ_BORROW RzListIter *rz_list_iter_get_prev(RZ_NONNULL RzListIter *iter);
+RZ_API RZ_BORROW RzListIter *rz_list_iter_get_next(RZ_NONNULL RzListIter *iter);
+RZ_API RZ_BORROW void *rz_list_iter_get_prev_data(RZ_NONNULL RzListIter *iter);
+RZ_API RZ_BORROW void *rz_list_iter_get_next_data(RZ_NONNULL RzListIter *iter);
+RZ_API ut32 rz_list_set_n(RZ_NONNULL RzList *list, ut32 n, RZ_NONNULL void *data);
+RZ_API void *rz_list_iter_get_data(RZ_NONNULL RzListIter *iter);
+RZ_API bool rz_list_iter_set_data(RZ_NONNULL RzListIter *iter, RZ_NULLABLE void *data);
+RZ_API bool rz_list_iter_swap_data(RZ_NONNULL RzListIter *iter0, RZ_NONNULL RzListIter *iter1);
+RZ_API RZ_BORROW RzListIter *rz_list_append(RZ_NONNULL RzList *list, RZ_NONNULL void *data);
+RZ_API RZ_BORROW RzListIter *rz_list_prepend(RZ_NONNULL RzList *list, RZ_NONNULL void *data);
+RZ_API RZ_BORROW RzListIter *rz_list_insert(RZ_NONNULL RzList *list, ut32 n, RZ_NONNULL void *data);
 RZ_API ut32 rz_list_length(RZ_NONNULL const RzList *list);
 RZ_API RZ_BORROW void *rz_list_first(RZ_NONNULL const RzList *list);
 RZ_API RZ_BORROW void *rz_list_last(RZ_NONNULL const RzList *list);
-RZ_API RZ_BORROW RzListIter *rz_list_add_sorted(RZ_NONNULL RzList *list, void *data, RZ_NONNULL RzListComparator cmp);
+RZ_API RZ_BORROW RzListIter *rz_list_add_sorted(RZ_NONNULL RzList *list, RZ_NONNULL void *data, RZ_NONNULL RzListComparator cmp);
 RZ_API void rz_list_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListComparator cmp);
 RZ_API void rz_list_merge_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListComparator cmp);
 RZ_API void rz_list_insertion_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListComparator cmp);
@@ -82,8 +86,8 @@ RZ_API void rz_list_init(RZ_NONNULL RzList *list);
 RZ_API void rz_list_delete(RZ_NONNULL RzList *list, RZ_NONNULL RzListIter *iter);
 RZ_API bool rz_list_delete_data(RZ_NONNULL RzList *list, void *ptr);
 RZ_API void rz_list_purge(RZ_NONNULL RzList *list);
-RZ_API void rz_list_free(RzList *list);
-RZ_API RZ_OWN RzListIter *rz_list_item_new(void *data);
+RZ_API void rz_list_free(RZ_NULLABLE RzList *list);
+RZ_API RZ_OWN RzListIter *rz_list_item_new(RZ_NULLABLE void *data);
 RZ_API void rz_list_split(RZ_NONNULL RzList *list, void *ptr);
 RZ_API void rz_list_split_iter(RZ_NONNULL RzList *list, RZ_NONNULL RzListIter *iter);
 RZ_API bool rz_list_join(RZ_NONNULL RzList *list1, RZ_NONNULL RzList *list2);
@@ -91,11 +95,13 @@ RZ_API RZ_BORROW void *rz_list_get_n(RZ_NONNULL const RzList *list, ut32 n);
 RZ_API ut32 rz_list_del_n(RZ_NONNULL RzList *list, ut32 n);
 RZ_API RZ_BORROW void *rz_list_get_top(RZ_NONNULL const RzList *list);
 RZ_API RZ_BORROW void *rz_list_get_bottom(RZ_NONNULL const RzList *list);
-RZ_API RZ_BORROW RzListIter *rz_list_iterator(const RzList *list);
+RZ_API RZ_BORROW RzListIter *rz_list_iterator(RZ_NONNULL const RzList *list);
 RZ_API RZ_BORROW RzListIter *rz_list_push(RZ_NONNULL RzList *list, void *item);
 RZ_API RZ_OWN void *rz_list_pop(RZ_NONNULL RzList *list);
 RZ_API RZ_OWN void *rz_list_pop_head(RZ_NONNULL RzList *list);
 RZ_API void rz_list_reverse(RZ_NONNULL RzList *list);
+RZ_API RZ_BORROW void *rz_list_get_head_data(RZ_NONNULL RzList *list);
+RZ_API RZ_BORROW void *rz_list_get_tail_data(RZ_NONNULL RzList *list);
 RZ_API RZ_OWN RzList *rz_list_clone(RZ_NONNULL const RzList *list);
 RZ_API RZ_OWN char *rz_list_to_str(RZ_NONNULL RzList *list, char ch);
 RZ_API RZ_OWN RzList *rz_list_of_sdblist(SdbList *sl);

--- a/librz/io/p/io_ar.c
+++ b/librz/io/p/io_ar.c
@@ -47,7 +47,7 @@ static RzList /*<RzIODesc *>*/ *rz_io_ar_open_many(RzIO *io, const char *file, i
 			rz_list_free(list_fds);
 			return NULL;
 		}
-		it->data = NULL;
+		rz_list_iter_set_data(it, NULL);
 	}
 	rz_list_free(all);
 	return list_fds;

--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -497,11 +497,11 @@ dotherax:
 		return true;
 	} else if (has_flag(flags, RZ_AX_FLAG_TIMESTAMP_TO_STR)) { // -t
 		RzList *split = rz_str_split_list(str, "GMT", 0);
-		RzListIter *it = rz_list_head(split);
-		char *ts = rz_list_iter_get_data(split);
-		const char *gmt = NULL;
-		if (rz_list_length(split) >= 2 && strlen(rz_list_iter_get_next_data(split)) >= 2) {
-			gmt = (const char *)rz_list_iter_get_next_data(split);
+		RzListIter *head = rz_list_head(split);
+		char *ts = rz_list_iter_get_data(head);
+		const char *gmt = rz_list_iter_get_next_data(head);
+		if (gmt && strlen(gmt) < 2) {
+			gmt = NULL;
 		}
 		ut32 n = rz_num_math(num, ts);
 		int timezone = (int)rz_num_math(num, gmt);

--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -497,10 +497,11 @@ dotherax:
 		return true;
 	} else if (has_flag(flags, RZ_AX_FLAG_TIMESTAMP_TO_STR)) { // -t
 		RzList *split = rz_str_split_list(str, "GMT", 0);
-		char *ts = rz_list_head(split)->data;
+		RzListIter *it = rz_list_head(split);
+		char *ts = rz_list_iter_get_data(split);
 		const char *gmt = NULL;
-		if (rz_list_length(split) >= 2 && strlen(rz_list_head(split)->n->data) >= 2) {
-			gmt = (const char *)rz_list_head(split)->n->data;
+		if (rz_list_length(split) >= 2 && strlen(rz_list_iter_get_next_data(split)) >= 2) {
+			gmt = (const char *)rz_list_iter_get_next_data(split);
 		}
 		ut32 n = rz_num_math(num, ts);
 		int timezone = (int)rz_num_math(num, gmt);

--- a/librz/parse/p/parse_arm_pseudo.c
+++ b/librz/parse/p/parse_arm_pseudo.c
@@ -194,7 +194,8 @@ RzList /*<char *>*/ *arm_tokenize(const char *assembly, size_t length) {
 	if (comma_replace) {
 		RzListIter *it;
 		rz_list_foreach (tokens, it, buf) {
-			it->data = rz_str_replace(buf, ",", comma_replace, 1);
+			char *repl = rz_str_replace(buf, ",", comma_replace, 1);
+			rz_list_iter_set_data(it, repl);
 		}
 	}
 

--- a/librz/parse/p/parse_dalvik_pseudo.c
+++ b/librz/parse/p/parse_dalvik_pseudo.c
@@ -245,7 +245,8 @@ RzList /*<char *>*/ *dalvik_tokenize(const char *assembly, size_t length) {
 	if (comma_replace) {
 		RzListIter *it;
 		rz_list_foreach (tokens, it, buf) {
-			it->data = rz_str_replace(buf, ",", comma_replace, 1);
+			char *repl = rz_str_replace(buf, ",", comma_replace, 1);
+			rz_list_iter_set_data(it, repl);
 		}
 	}
 

--- a/librz/parse/p/parse_sh_pseudo.c
+++ b/librz/parse/p/parse_sh_pseudo.c
@@ -162,7 +162,8 @@ RzList /*<char *>*/ *sh_tokenize(const char *assembly, size_t length) {
 
 	RzListIter *it;
 	rz_list_foreach (tokens, it, buf) {
-		it->data = rz_str_replace(buf, ",", " + ", 1);
+		char *repl = rz_str_replace(buf, ",", " + ", 1);
+		rz_list_iter_set_data(it, repl);
 	}
 
 	return tokens;

--- a/librz/parse/p/parse_z80_pseudo.c
+++ b/librz/parse/p/parse_z80_pseudo.c
@@ -141,7 +141,8 @@ RzList /*<char *>*/ *z80_tokenize(const char *assembly, size_t length) {
 	if (comma_replace) {
 		RzListIter *it;
 		rz_list_foreach (tokens, it, buf) {
-			it->data = rz_str_replace(buf, ",", comma_replace, 1);
+			char *repl = rz_str_replace(buf, ",", comma_replace, 1);
+			rz_list_iter_set_data(it, repl);
 		}
 	}
 

--- a/librz/reg/arena.c
+++ b/librz/reg/arena.c
@@ -214,10 +214,8 @@ RZ_API void rz_reg_arena_swap(RzReg *reg, int copy) {
 		if (rz_list_length(reg->regset[i].pool) > 1) {
 			RzListIter *ia = reg->regset[i].cur;
 			RzListIter *ib = reg->regset[i].pool->head;
-			void *tmp = ia->data;
-			ia->data = ib->data;
-			ib->data = tmp;
-			reg->regset[i].arena = ia->data;
+			rz_list_iter_swap_data(ia, ib);
+			reg->regset[i].arena = rz_list_iter_get_data(ia);
 		} else {
 			break;
 		}
@@ -236,10 +234,10 @@ RZ_API void rz_reg_arena_pop(RzReg *reg) {
 		}
 		a = rz_list_pop(reg->regset[i].pool);
 		rz_reg_arena_free(a);
-		a = reg->regset[i].pool->tail->data;
+		a = rz_list_get_tail_data(reg->regset[i].pool);
 		if (a) {
 			reg->regset[i].arena = a;
-			reg->regset[i].cur = reg->regset[i].pool->tail;
+			reg->regset[i].cur = rz_list_tail(reg->regset[i].pool);
 		}
 	}
 }

--- a/librz/sign/create.c
+++ b/librz/sign/create.c
@@ -293,7 +293,7 @@ static bool flirt_node_shorten_and_insert(const RzFlirtNode *root, RzFlirtNode *
 			rz_list_sort(child->child_list, (RzListComparator)flirt_compare_node);
 		} else if (node->length == i) {
 			// partial pattern match but matches the node
-			it->data = node;
+			rz_list_iter_set_data(it, node);
 			flirt_node_shorten_pattern(child, i);
 			if (!rz_list_append(node->child_list, child)) {
 				RZ_LOG_ERROR("FLIRT: cannot append child to optimized list.\n");
@@ -307,7 +307,7 @@ static bool flirt_node_shorten_and_insert(const RzFlirtNode *root, RzFlirtNode *
 				rz_sign_flirt_node_free(node);
 				return false;
 			}
-			it->data = middle_node;
+			rz_list_iter_set_data(it, middle_node);
 			if (!rz_list_append(middle_node->child_list, child)) {
 				RZ_LOG_ERROR("FLIRT: cannot append child to optimized list.\n");
 				rz_sign_flirt_node_free(node);
@@ -351,7 +351,7 @@ bool flirt_node_optimize(RzFlirtNode *root) {
 	RzListIter *it;
 	RzFlirtNode *child;
 	rz_list_foreach (childs, it, child) {
-		it->data = NULL;
+		rz_list_iter_set_data(it, NULL);
 		if (!flirt_node_shorten_and_insert(root, child)) {
 			goto fail;
 		}

--- a/librz/sign/flirt.c
+++ b/librz/sign/flirt.c
@@ -412,7 +412,7 @@ static int module_match_buffer(RzAnalysis *analysis, const RzFlirtModule *module
 			ut64 flirt_fcn_size = module->length - flirt_func->offset;
 			RzFlirtFunction *next_flirt_func;
 			RzListIter *next_it;
-			rz_list_foreach_iter(it, next_it, next_flirt_func) {
+			rz_list_foreach_iter(rz_list_iter_get_next(it), next_it, next_flirt_func) {
 				if (!next_flirt_func->is_local && !next_flirt_func->negative_offset) {
 					flirt_fcn_size = next_flirt_func->offset - flirt_func->offset;
 					break;

--- a/librz/sign/flirt.c
+++ b/librz/sign/flirt.c
@@ -411,14 +411,12 @@ static int module_match_buffer(RzAnalysis *analysis, const RzFlirtModule *module
 			// get function size from flirt signature
 			ut64 flirt_fcn_size = module->length - flirt_func->offset;
 			RzFlirtFunction *next_flirt_func;
-			RzListIter *next_it = it->n;
-			while (next_it) {
-				next_flirt_func = next_it->data;
+			RzListIter *next_it;
+			rz_list_foreach_iter(it, next_it, next_flirt_func) {
 				if (!next_flirt_func->is_local && !next_flirt_func->negative_offset) {
 					flirt_fcn_size = next_flirt_func->offset - flirt_func->offset;
 					break;
 				}
-				next_it = next_it->n;
 			}
 			// resize function if needed
 			next_module_function_size = rz_analysis_function_linear_size(next_module_function);

--- a/librz/util/graph.c
+++ b/librz/util/graph.c
@@ -131,7 +131,7 @@ RZ_API RzGraphNode *rz_graph_get_node(const RzGraph *t, unsigned int idx) {
 	if (!it) {
 		return NULL;
 	}
-	return (RzGraphNode *)it->data;
+	return (RzGraphNode *)rz_list_iter_get_data(it);
 }
 
 RZ_API RzListIter *rz_graph_node_iter(const RzGraph *t, unsigned int idx) {

--- a/librz/util/list.c
+++ b/librz/util/list.c
@@ -6,41 +6,84 @@
 #include <rz_util.h>
 
 /**
+ * \brief returns the prev RzList iterator in the list
+ *
+ **/
+RZ_API RZ_BORROW RzListIter *rz_list_iter_get_prev(RZ_NONNULL RzListIter *iter) {
+	rz_return_val_if_fail(iter, NULL);
+	return iter->prev;
+}
+/**
  * \brief returns the next RzList iterator in the list
  *
  **/
-RZ_API RZ_BORROW RzListIter *rz_list_iter_get_next(RzListIter *iter) {
+RZ_API RZ_BORROW RzListIter *rz_list_iter_get_next(RZ_NONNULL RzListIter *iter) {
 	rz_return_val_if_fail(iter, NULL);
-	return iter->n;
+	return iter->next;
+}
+
+/**
+ * \brief returns the value stored in the prev RzList iterator
+ *
+ **/
+RZ_API RZ_BORROW void *rz_list_iter_get_prev_data(RZ_NONNULL RzListIter *iter) {
+	rz_return_val_if_fail(iter, NULL);
+	RzListIter *p = iter->prev;
+	if (!p) {
+		return NULL;
+	}
+	return p->elem;
 }
 
 /**
  * \brief returns the value stored in the next RzList iterator
  *
  **/
-RZ_API RZ_BORROW void *rz_list_iter_get_next_data(RzListIter *iter) {
+RZ_API RZ_BORROW void *rz_list_iter_get_next_data(RZ_NONNULL RzListIter *iter) {
 	rz_return_val_if_fail(iter, NULL);
-	RzListIter *n = iter->n;
+	RzListIter *n = iter->next;
 	if (!n) {
 		return NULL;
 	}
-	return n->data;
+	return n->elem;
 }
 
 /**
- * \brief returns the value stored in the list element
+ * \brief returns the value stored in the list iterator
  *
  **/
-RZ_API void *rz_list_iter_get_data(RzListIter *iter) {
+RZ_API void *rz_list_iter_get_data(RZ_NONNULL RzListIter *iter) {
 	rz_return_val_if_fail(iter, NULL);
-	return iter->data;
+	return iter->elem;
+}
+
+/**
+ * \brief Sets the value stored in the list iterator and returns true if succeeds
+ *
+ **/
+RZ_API bool rz_list_iter_set_data(RZ_NONNULL RzListIter *iter, RZ_NULLABLE void *data) {
+	rz_return_val_if_fail(iter, false);
+	iter->elem = data;
+	return true;
+}
+
+/**
+ * \brief swaps the data held by two iterators and returns true if succeeds
+ *
+ **/
+RZ_API bool rz_list_iter_swap_data(RZ_NONNULL RzListIter *iter0, RZ_NONNULL RzListIter *iter1) {
+	rz_return_val_if_fail(iter0 && iter1, false);
+	void *tmp = iter0->elem;
+	iter0->elem = iter1->elem;
+	iter1->elem = tmp;
+	return true;
 }
 
 /**
  * \brief returns the first RzList iterator int the list
  *
  **/
-RZ_API RZ_BORROW RzListIter *rz_list_iterator(const RzList *list) {
+RZ_API RZ_BORROW RzListIter *rz_list_iterator(RZ_NONNULL const RzList *list) {
 	rz_return_val_if_fail(list, NULL);
 	return list->head;
 }
@@ -54,21 +97,12 @@ RZ_API RZ_BORROW RzListIter *rz_list_push(RZ_NONNULL RzList *list, void *item) {
 }
 
 /**
- * \brief Returns the next element of the list
- *
- **/
-RZ_API RzListIter *rz_list_get_next(RzListIter *iter) {
-	rz_return_val_if_fail(iter, NULL);
-	return iter->n;
-}
-
-/**
  * \brief Returns the first element of the list
  *
  **/
 RZ_API RZ_BORROW void *rz_list_first(RZ_NONNULL const RzList *list) {
 	rz_return_val_if_fail(list, NULL);
-	return list->head ? list->head->data : NULL;
+	return list->head ? list->head->elem : NULL;
 }
 
 /**
@@ -77,7 +111,7 @@ RZ_API RZ_BORROW void *rz_list_first(RZ_NONNULL const RzList *list) {
  **/
 RZ_API RZ_BORROW void *rz_list_last(RZ_NONNULL const RzList *list) {
 	rz_return_val_if_fail(list, NULL);
-	return list->tail ? list->tail->data : NULL;
+	return list->tail ? list->tail->elem : NULL;
 }
 
 /**
@@ -114,7 +148,7 @@ RZ_API void rz_list_purge(RZ_NONNULL RzList *list) {
 
 	RzListIter *it = list->head;
 	while (it) {
-		RzListIter *next = it->n;
+		RzListIter *next = it->next;
 		rz_list_delete(list, it);
 		it = next;
 	}
@@ -126,11 +160,12 @@ RZ_API void rz_list_purge(RZ_NONNULL RzList *list) {
  * \brief Empties the list and frees the list pointer
  *
  **/
-RZ_API void rz_list_free(RzList *list) {
-	if (list) {
-		rz_list_purge(list);
-		free(list);
+RZ_API void rz_list_free(RZ_NULLABLE RzList *list) {
+	if (!list) {
+		return;
 	}
+	rz_list_purge(list);
+	free(list);
 }
 
 /**
@@ -154,10 +189,10 @@ RZ_API bool rz_list_delete_data(RZ_NONNULL RzList *list, void *ptr) {
 RZ_API void rz_list_delete(RZ_NONNULL RzList *list, RZ_NONNULL RzListIter *iter) {
 	rz_return_if_fail(list && iter);
 	rz_list_split_iter(list, iter);
-	if (list->free && iter->data) {
-		list->free(iter->data);
+	if (list->free && iter->elem) {
+		list->free(iter->elem);
 	}
-	iter->data = NULL;
+	iter->elem = NULL;
 	free(iter);
 }
 
@@ -166,13 +201,13 @@ RZ_API void rz_list_split(RZ_NONNULL RzList *list, void *ptr) {
 
 	RzListIter *iter = rz_list_iterator(list);
 	while (iter) {
-		void *item = iter->data;
+		void *item = iter->elem;
 		if (ptr == item) {
 			rz_list_split_iter(list, iter);
 			free(iter);
 			break;
 		}
-		iter = iter->n;
+		iter = iter->next;
 	}
 }
 
@@ -180,16 +215,16 @@ RZ_API void rz_list_split_iter(RZ_NONNULL RzList *list, RZ_NONNULL RzListIter *i
 	rz_return_if_fail(list);
 
 	if (list->head == iter) {
-		list->head = iter->n;
+		list->head = iter->next;
 	}
 	if (list->tail == iter) {
-		list->tail = iter->p;
+		list->tail = iter->prev;
 	}
-	if (iter->p) {
-		iter->p->n = iter->n;
+	if (iter->prev) {
+		iter->prev->next = iter->next;
 	}
-	if (iter->n) {
-		iter->n->p = iter->p;
+	if (iter->next) {
+		iter->next->prev = iter->prev;
 	}
 	list->length--;
 }
@@ -208,10 +243,10 @@ RZ_API bool rz_list_join(RZ_NONNULL RzList *list1, RZ_NONNULL RzList *list2) {
 		list1->head = list2->head;
 		list1->tail = list2->tail;
 	} else {
-		list1->tail->n = list2->head;
-		list2->head->p = list1->tail;
+		list1->tail->next = list2->head;
+		list2->head->prev = list1->tail;
 		list1->tail = list2->tail;
-		list1->tail->n = NULL;
+		list1->tail->next = NULL;
 		list1->sorted = false;
 	}
 	list1->length += list2->length;
@@ -237,7 +272,7 @@ RZ_API RZ_OWN RzList *rz_list_new(void) {
  * \brief Returns a new initialized RzList pointer and sets the free method
  *
  **/
-RZ_API RZ_OWN RzList *rz_list_newf(RzListFree f) {
+RZ_API RZ_OWN RzList *rz_list_newf(RZ_NULLABLE RzListFree f) {
 	RzList *l = rz_list_new();
 	if (l) {
 		l->free = f;
@@ -265,10 +300,10 @@ RZ_API RZ_OWN RzList *rz_list_new_from_array(RZ_NONNULL const void **arr, size_t
  * \brief Creates a RzListIter element that can be inserted into a RzList
  *
  **/
-RZ_API RZ_OWN RzListIter *rz_list_item_new(void *data) {
+RZ_API RZ_OWN RzListIter *rz_list_item_new(RZ_NULLABLE void *data) {
 	RzListIter *item = RZ_NEW0(RzListIter);
 	if (item) {
-		item->data = data;
+		item->elem = data;
 	}
 	return item;
 }
@@ -277,7 +312,7 @@ RZ_API RZ_OWN RzListIter *rz_list_item_new(void *data) {
  * \brief Appends at the end of the list a new element
  *
  **/
-RZ_API RZ_BORROW RzListIter *rz_list_append(RZ_NONNULL RzList *list, void *data) {
+RZ_API RZ_BORROW RzListIter *rz_list_append(RZ_NONNULL RzList *list, RZ_NONNULL void *data) {
 	RzListIter *item = NULL;
 
 	rz_return_val_if_fail(list, NULL);
@@ -287,11 +322,11 @@ RZ_API RZ_BORROW RzListIter *rz_list_append(RZ_NONNULL RzList *list, void *data)
 		return item;
 	}
 	if (list->tail) {
-		list->tail->n = item;
+		list->tail->next = item;
 	}
-	item->data = data;
-	item->p = list->tail;
-	item->n = NULL;
+	item->elem = data;
+	item->prev = list->tail;
+	item->next = NULL;
 	list->tail = item;
 	if (!list->head) {
 		list->head = item;
@@ -305,7 +340,7 @@ RZ_API RZ_BORROW RzListIter *rz_list_append(RZ_NONNULL RzList *list, void *data)
  * \brief Appends at the beginning of the list a new element
  *
  **/
-RZ_API RZ_BORROW RzListIter *rz_list_prepend(RZ_NONNULL RzList *list, void *data) {
+RZ_API RZ_BORROW RzListIter *rz_list_prepend(RZ_NONNULL RzList *list, RZ_NONNULL void *data) {
 	rz_return_val_if_fail(list, NULL);
 
 	RzListIter *item = RZ_NEW0(RzListIter);
@@ -313,11 +348,11 @@ RZ_API RZ_BORROW RzListIter *rz_list_prepend(RZ_NONNULL RzList *list, void *data
 		return NULL;
 	}
 	if (list->head) {
-		list->head->p = item;
+		list->head->prev = item;
 	}
-	item->data = data;
-	item->n = list->head;
-	item->p = NULL;
+	item->elem = data;
+	item->next = list->head;
+	item->prev = NULL;
 	list->head = item;
 	if (!list->tail) {
 		list->tail = item;
@@ -331,7 +366,7 @@ RZ_API RZ_BORROW RzListIter *rz_list_prepend(RZ_NONNULL RzList *list, void *data
  * \brief Inserts a new element at the N-th position
  *
  **/
-RZ_API RZ_BORROW RzListIter *rz_list_insert(RZ_NONNULL RzList *list, ut32 n, void *data) {
+RZ_API RZ_BORROW RzListIter *rz_list_insert(RZ_NONNULL RzList *list, ut32 n, RZ_NONNULL void *data) {
 	RzListIter *it, *item;
 	ut32 i;
 
@@ -340,19 +375,19 @@ RZ_API RZ_BORROW RzListIter *rz_list_insert(RZ_NONNULL RzList *list, ut32 n, voi
 	if (!list->head || !n) {
 		return rz_list_prepend(list, data);
 	}
-	for (it = list->head, i = 0; it && it->data; it = it->n, i++) {
+	for (it = list->head, i = 0; it && it->elem; it = it->next, i++) {
 		if (i == n) {
 			item = RZ_NEW(RzListIter);
 			if (!item) {
 				return NULL;
 			}
-			item->data = data;
-			item->n = it;
-			item->p = it->p;
-			if (it->p) {
-				it->p->n = item;
+			item->elem = data;
+			item->next = it;
+			item->prev = it->prev;
+			if (it->prev) {
+				it->prev->next = item;
 			}
-			it->p = item;
+			it->prev = item;
 			list->length++;
 			list->sorted = true;
 			return item;
@@ -376,10 +411,10 @@ RZ_API RZ_OWN void *rz_list_pop(RZ_NONNULL RzList *list) {
 		if (list->head == list->tail) {
 			list->head = list->tail = NULL;
 		} else {
-			list->tail = iter->p;
-			list->tail->n = NULL;
+			list->tail = iter->prev;
+			list->tail->next = NULL;
 		}
-		data = iter->data;
+		data = iter->elem;
 		free(iter);
 		list->length--;
 	}
@@ -400,10 +435,10 @@ RZ_API RZ_OWN void *rz_list_pop_head(RZ_NONNULL RzList *list) {
 		if (list->head == list->tail) {
 			list->head = list->tail = NULL;
 		} else {
-			list->head = iter->n;
-			list->head->p = NULL;
+			list->head = iter->next;
+			list->head->prev = NULL;
 		}
-		data = iter->data;
+		data = iter->elem;
 		free(iter);
 		list->length--;
 	}
@@ -420,19 +455,19 @@ RZ_API ut32 rz_list_del_n(RZ_NONNULL RzList *list, ut32 n) {
 
 	rz_return_val_if_fail(list, false);
 
-	for (it = list->head, i = 0; it && it->data; it = it->n, i++) {
+	for (it = list->head, i = 0; it && it->elem; it = it->next, i++) {
 		if (i == n) {
-			if (!it->p && !it->n) {
+			if (!it->prev && !it->next) {
 				list->head = list->tail = NULL;
-			} else if (!it->p) {
-				it->n->p = NULL;
-				list->head = it->n;
-			} else if (!it->n) {
-				it->p->n = NULL;
-				list->tail = it->p;
+			} else if (!it->prev) {
+				it->next->prev = NULL;
+				list->head = it->next;
+			} else if (!it->next) {
+				it->prev->next = NULL;
+				list->tail = it->prev;
 			} else {
-				it->p->n = it->n;
-				it->n->p = it->p;
+				it->prev->next = it->next;
+				it->next->prev = it->prev;
 			}
 			rz_list_delete(list, it);
 			return true;
@@ -448,7 +483,7 @@ RZ_API ut32 rz_list_del_n(RZ_NONNULL RzList *list, ut32 n) {
 RZ_API RZ_BORROW void *rz_list_get_top(RZ_NONNULL const RzList *list) {
 	rz_return_val_if_fail(list, NULL);
 
-	return list->tail ? list->tail->data : NULL;
+	return list->tail ? list->tail->elem : NULL;
 }
 
 /**
@@ -458,7 +493,7 @@ RZ_API RZ_BORROW void *rz_list_get_top(RZ_NONNULL const RzList *list) {
 RZ_API RZ_BORROW void *rz_list_get_bottom(RZ_NONNULL const RzList *list) {
 	rz_return_val_if_fail(list, NULL);
 
-	return list->head ? list->head->data : NULL;
+	return list->head ? list->head->elem : NULL;
 }
 
 /**
@@ -470,14 +505,32 @@ RZ_API void rz_list_reverse(RZ_NONNULL RzList *list) {
 
 	rz_return_if_fail(list);
 
-	for (it = list->head; it && it->data; it = it->p) {
-		tmp = it->p;
-		it->p = it->n;
-		it->n = tmp;
+	for (it = list->head; it && it->elem; it = it->prev) {
+		tmp = it->prev;
+		it->prev = it->next;
+		it->next = tmp;
 	}
 	tmp = list->head;
 	list->head = list->tail;
 	list->tail = tmp;
+}
+
+/**
+ * \brief Returns the data of the first element of the list
+ *
+ **/
+RZ_API RZ_BORROW void *rz_list_get_head_data(RZ_NONNULL RzList *list) {
+	rz_return_val_if_fail(list, NULL);
+	return rz_list_iter_get_data(list->head);
+}
+
+/**
+ * \brief Returns the data of the last element of the list
+ *
+ **/
+RZ_API RZ_BORROW void *rz_list_get_tail_data(RZ_NONNULL RzList *list) {
+	rz_return_val_if_fail(list, NULL);
+	return rz_list_iter_get_data(list->tail);
 }
 
 /**
@@ -506,27 +559,26 @@ RZ_API RZ_OWN RzList *rz_list_clone(RZ_NONNULL const RzList *list) {
  * \brief Adds an element to a sorted list via the RzListComparator
  *
  **/
-RZ_API RZ_BORROW RzListIter *rz_list_add_sorted(RZ_NONNULL RzList *list, void *data, RZ_NONNULL RzListComparator cmp) {
+RZ_API RZ_BORROW RzListIter *rz_list_add_sorted(RZ_NONNULL RzList *list, RZ_NONNULL void *data, RZ_NONNULL RzListComparator cmp) {
 	RzListIter *it, *item = NULL;
 
 	rz_return_val_if_fail(list && data && cmp, NULL);
 
-	for (it = list->head; it && it->data && cmp(data, it->data) > 0; it = it->n) {
-		;
+	for (it = list->head; it && it->elem && cmp(data, it->elem) > 0; it = it->next) {
 	}
 	if (it) {
 		item = RZ_NEW0(RzListIter);
 		if (!item) {
 			return NULL;
 		}
-		item->n = it;
-		item->p = it->p;
-		item->data = data;
-		item->n->p = item;
-		if (!item->p) {
+		item->next = it;
+		item->prev = it->prev;
+		item->elem = data;
+		item->next->prev = item;
+		if (!item->prev) {
 			list->head = item;
 		} else {
-			item->p->n = item;
+			item->prev->next = item;
 		}
 		list->length++;
 	} else {
@@ -540,17 +592,17 @@ RZ_API RZ_BORROW RzListIter *rz_list_add_sorted(RZ_NONNULL RzList *list, void *d
  * \brief Sets the N-th element of the list
  *
  **/
-RZ_API ut32 rz_list_set_n(RZ_NONNULL RzList *list, ut32 n, void *p) {
+RZ_API ut32 rz_list_set_n(RZ_NONNULL RzList *list, ut32 n, RZ_NONNULL void *data) {
 	RzListIter *it;
 	ut32 i;
 
 	rz_return_val_if_fail(list, false);
-	for (it = list->head, i = 0; it; it = it->n, i++) {
+	for (it = list->head, i = 0; it; it = it->next, i++) {
 		if (i == n) {
 			if (list->free) {
-				list->free(it->data);
+				list->free(it->elem);
 			}
-			it->data = p;
+			it->elem = data;
 			list->sorted = false;
 			return true;
 		}
@@ -567,10 +619,13 @@ RZ_API RZ_BORROW void *rz_list_get_n(RZ_NONNULL const RzList *list, ut32 n) {
 	ut32 i;
 
 	rz_return_val_if_fail(list, NULL);
+	if (n >= list->length) {
+		return NULL;
+	}
 
-	for (it = list->head, i = 0; it && it->data; it = it->n, i++) {
+	for (it = list->head, i = 0; it && it->elem; it = it->next, i++) {
 		if (i == n) {
-			return it->data;
+			return it->elem;
 		}
 	}
 	return NULL;
@@ -627,29 +682,29 @@ static RzListIter *_merge(RzListIter *first, RzListIter *second, RzListComparato
 	while (first || second) {
 		if (!second) {
 			next = first;
-			first = first->n;
+			first = first->next;
 		} else if (!first) {
 			next = second;
-			second = second->n;
-		} else if (cmp(first->data, second->data) <= 0) {
+			second = second->next;
+		} else if (cmp(first->elem, second->elem) <= 0) {
 			next = first;
-			first = first->n;
+			first = first->next;
 		} else {
 			next = second;
-			second = second->n;
+			second = second->next;
 		}
 		if (!head) {
 			result = next;
 			head = result;
-			head->p = NULL;
+			head->prev = NULL;
 		} else {
-			result->n = next;
-			next->p = result;
-			result = result->n;
+			result->next = next;
+			next->prev = result;
+			result = result->next;
 		}
 	}
-	head->p = NULL;
-	next->n = NULL;
+	head->prev = NULL;
+	next->next = NULL;
 	return head;
 }
 
@@ -657,23 +712,23 @@ static RzListIter *_r_list_half_split(RzListIter *head) {
 	RzListIter *tmp;
 	RzListIter *fast;
 	RzListIter *slow;
-	if (!head || !head->n) {
+	if (!head || !head->next) {
 		return head;
 	}
 	slow = head;
 	fast = head;
-	while (fast && fast->n && fast->n->n) {
-		fast = fast->n->n;
-		slow = slow->n;
+	while (fast && fast->next && fast->next->next) {
+		fast = fast->next->next;
+		slow = slow->next;
 	}
-	tmp = slow->n;
-	slow->n = NULL;
+	tmp = slow->next;
+	slow->next = NULL;
 	return tmp;
 }
 
 static RzListIter *_merge_sort(RzListIter *head, RzListComparator cmp) {
 	RzListIter *second;
-	if (!head || !head->n) {
+	if (!head || !head->next) {
 		return head;
 	}
 	second = _r_list_half_split(head);
@@ -694,8 +749,8 @@ RZ_API void rz_list_merge_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListCompara
 		list->head = _merge_sort(list->head, cmp);
 		// update tail reference
 		iter = list->head;
-		while (iter && iter->n) {
-			iter = iter->n;
+		while (iter && iter->next) {
+			iter = iter->next;
 		}
 		list->tail = iter;
 	}
@@ -713,12 +768,12 @@ RZ_API void rz_list_insertion_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListCom
 		RzListIter *it;
 		RzListIter *it2;
 		if (cmp) {
-			for (it = list->head; it && it->data; it = it->n) {
-				for (it2 = it->n; it2 && it2->data; it2 = it2->n) {
-					if (cmp(it->data, it2->data) > 0) {
-						void *t = it->data;
-						it->data = it2->data;
-						it2->data = t;
+			for (it = list->head; it && it->elem; it = it->next) {
+				for (it2 = it->next; it2 && it2->elem; it2 = it2->next) {
+					if (cmp(it->elem, it2->elem) > 0) {
+						void *t = it->elem;
+						it->elem = it2->elem;
+						it2->elem = t;
 					}
 				}
 			}

--- a/librz/util/table.c
+++ b/librz/util/table.c
@@ -1366,7 +1366,8 @@ RZ_API RZ_OWN RzTable *rz_table_transpose(RZ_NONNULL RzTable *t) {
 			for (i = 0; i < t->totalCols; i++) {
 				rz_table_add_row(transpose, item, NULL);
 				if (rz_list_iter_has_next(iter)) {
-					item = rz_list_iter_get(iter);
+					iter = rz_list_iter_get_next(iter);
+					item = rz_list_iter_get_data(iter);
 				}
 			}
 		}

--- a/librz/util/table.c
+++ b/librz/util/table.c
@@ -1362,12 +1362,11 @@ RZ_API RZ_OWN RzTable *rz_table_transpose(RZ_NONNULL RzTable *t) {
 	if (row_name && t->rows) {
 		iter = row_name->head;
 		if (iter) {
-			item = iter->data;
+			item = rz_list_iter_get_data(iter);
 			for (i = 0; i < t->totalCols; i++) {
 				rz_table_add_row(transpose, item, NULL);
-				if (iter->n) {
-					iter = iter->n;
-					item = iter->data;
+				if (rz_list_iter_has_next(iter)) {
+					item = rz_list_iter_get(iter);
 				}
 			}
 		}

--- a/subprojects/rzgdb/src/gdbclient/xml.c
+++ b/subprojects/rzgdb/src/gdbclient/xml.c
@@ -886,7 +886,7 @@ static RzList *_extract_regs(char *regstr, RzList *flags, char *pc_alias) {
 			for (i = regnum - rz_list_length(regs); i > 0; i--) {
 				// temporary placeholder reg. we trust the xml is correct and this will be replaced.
 				rz_list_push(regs, tmpreg);
-				rz_list_tail(regs)->data = NULL;
+				rz_list_iter_set_data(rz_list_tail(regs), NULL);
 			}
 			rz_list_push(regs, tmpreg);
 		} else {

--- a/test/integration/test_dwarf.c
+++ b/test/integration/test_dwarf.c
@@ -446,7 +446,7 @@ bool test_dwarf_cpp_empty_line_info(void) { // this should work for dwarf2 aswel
 		bin->cur, NULL, false);
 	mu_assert_notnull(li, "line info");
 	mu_assert_eq(rz_list_length(li->units), 25, "line units count");
-	RzBinDwarfLineUnit *lunit = rz_list_tail(li->units)->data;
+	RzBinDwarfLineUnit *lunit = rz_list_get_tail_data(li->units);
 	mu_assert_notnull(lunit, "line unit");
 
 	RzBinDwarfLineHdr *hdr = &lunit->hdr;

--- a/test/unit/test_agraph.c
+++ b/test/unit/test_agraph.c
@@ -29,7 +29,7 @@ bool test_graph_to_agraph() {
 	RzListIter *iter;
 	RzGraphNode *node;
 	int i = 0;
-	ls_foreach (agraph->graph->nodes, iter, node) {
+	rz_list_foreach (agraph->graph->nodes, iter, node) {
 		RzANode *info = node->data;
 		switch (i++) {
 		case 0:
@@ -39,7 +39,7 @@ bool test_graph_to_agraph() {
 				RzListIter *iter;
 				RzGraphNode *out_node;
 				int i = 0;
-				ls_foreach (node->out_nodes, iter, out_node) {
+				rz_list_foreach (node->out_nodes, iter, out_node) {
 					RzANode *info = out_node->data;
 					switch (i++) {
 					case 0:
@@ -60,7 +60,7 @@ bool test_graph_to_agraph() {
 				RzListIter *iter;
 				RzGraphNode *out_node;
 				int i = 0;
-				ls_foreach (node->out_nodes, iter, out_node) {
+				rz_list_foreach (node->out_nodes, iter, out_node) {
 					RzANode *info = out_node->data;
 					switch (i++) {
 					case 0:
@@ -78,7 +78,7 @@ bool test_graph_to_agraph() {
 				RzListIter *iter;
 				RzGraphNode *out_node;
 				int i = 0;
-				ls_foreach (node->out_nodes, iter, out_node) {
+				rz_list_foreach (node->out_nodes, iter, out_node) {
 					RzANode *info = out_node->data;
 					switch (i++) {
 					case 0:

--- a/test/unit/test_analysis_block_invars.inl
+++ b/test/unit/test_analysis_block_invars.inl
@@ -20,7 +20,7 @@ static bool block_check_invariants(RzAnalysis *analysis) {
 		rz_list_foreach (block->fcns, fcniter, fcn) {
 			RzListIter *fcniter2;
 			RzAnalysisFunction *fcn2;
-			for (fcniter2 = fcniter->n; fcniter2 && (fcn2 = fcniter2->data, 1); fcniter2 = fcniter2->n) {
+			rz_list_foreach_iter(rz_list_iter_get_next(fcniter), fcniter2, fcn2) {
 				mu_assert_ptrneq (fcn, fcn2, "duplicate function in basic block");
 			}
 			mu_assert ("block references function, but function does not reference block", rz_list_contains (fcn->bbs, block));
@@ -44,7 +44,7 @@ static bool block_check_invariants(RzAnalysis *analysis) {
 				max = block->addr + block->size;
 			}
 			realsz += block->size;
-			for (blockiter2 = blockiter->n; blockiter2 && (block2 = blockiter2->data, 1); blockiter2 = blockiter2->n) {
+			rz_list_foreach_iter(rz_list_iter_get_next(blockiter), blockiter2, block2) {
 				mu_assert_ptrneq (block, block2, "duplicate basic block in function");
 			}
 			mu_assert ("function references block, but block does not reference function", rz_list_contains (block->fcns, fcn));

--- a/test/unit/test_analysis_class_graph.c
+++ b/test/unit/test_analysis_class_graph.c
@@ -24,7 +24,7 @@ bool test_inherit_graph_creation() {
 	RzListIter *iter;
 	RzGraphNode *node;
 	int i = 0;
-	ls_foreach (graph->nodes, iter, node) {
+	rz_list_foreach (graph->nodes, iter, node) {
 		RzGraphNodeInfo *info = node->data;
 		switch (i++) {
 		case 0:
@@ -34,7 +34,7 @@ bool test_inherit_graph_creation() {
 				RzListIter *iter;
 				RzGraphNode *out_node;
 				int i = 0;
-				ls_foreach (node->out_nodes, iter, out_node) {
+				rz_list_foreach (node->out_nodes, iter, out_node) {
 					RzGraphNodeInfo *info = out_node->data;
 					switch (i++) {
 					case 0:
@@ -55,7 +55,7 @@ bool test_inherit_graph_creation() {
 				RzListIter *iter;
 				RzGraphNode *out_node;
 				int i = 0;
-				ls_foreach (node->out_nodes, iter, out_node) {
+				rz_list_foreach (node->out_nodes, iter, out_node) {
 					RzGraphNodeInfo *info = out_node->data;
 					switch (i++) {
 					case 0:
@@ -73,7 +73,7 @@ bool test_inherit_graph_creation() {
 				RzListIter *iter;
 				RzGraphNode *out_node;
 				int i = 0;
-				ls_foreach (node->out_nodes, iter, out_node) {
+				rz_list_foreach (node->out_nodes, iter, out_node) {
 					RzGraphNodeInfo *info = out_node->data;
 					switch (i++) {
 					case 0:

--- a/test/unit/test_list.c
+++ b/test/unit/test_list.c
@@ -91,9 +91,9 @@ bool test_rz_list_sort(void) {
 	// Sort.
 	rz_list_sort(list, (RzListComparator)strcmp);
 	// Check that the list is actually sorted.
-	mu_assert_streq((char *)list->head->data, "AAAA", "first value in sorted list");
-	mu_assert_streq((char *)list->head->n->data, "BBBB", "second value in sorted list");
-	mu_assert_streq((char *)list->head->n->n->data, "CCCC", "third value in sorted list");
+	mu_assert_streq((char *)list->head->elem, "AAAA", "first value in sorted list");
+	mu_assert_streq((char *)list->head->next->elem, "BBBB", "second value in sorted list");
+	mu_assert_streq((char *)list->head->next->next->elem, "CCCC", "third value in sorted list");
 	rz_list_free(list);
 	mu_end;
 }
@@ -110,9 +110,9 @@ bool test_rz_list_sort2(void) {
 	// Sort.
 	rz_list_merge_sort(list, (RzListComparator)strcmp);
 	// Check that the list is actually sorted.
-	mu_assert_streq((char *)list->head->data, "AAAA", "first value in sorted list");
-	mu_assert_streq((char *)list->head->n->data, "BBBB", "second value in sorted list");
-	mu_assert_streq((char *)list->head->n->n->data, "CCCC", "third value in sorted list");
+	mu_assert_streq((char *)list->head->elem, "AAAA", "first value in sorted list");
+	mu_assert_streq((char *)list->head->next->elem, "BBBB", "second value in sorted list");
+	mu_assert_streq((char *)list->head->next->next->elem, "CCCC", "third value in sorted list");
 	rz_list_free(list);
 	mu_end;
 }
@@ -135,9 +135,9 @@ bool test_rz_list_sort3(void) {
 	// Sort.
 	rz_list_merge_sort(list, (RzListComparator)cmp_range);
 	// Check that the list is actually sorted.
-	mu_assert_eq(*(int *)list->head->data, 33480, "first value in sorted list");
-	mu_assert_eq(*(int *)list->head->n->data, 33508, "second value in sorted list");
-	mu_assert_eq(*(int *)list->head->n->n->data, 33964, "third value in sorted list");
+	mu_assert_eq(*(int *)list->head->elem, 33480, "first value in sorted list");
+	mu_assert_eq(*(int *)list->head->next->elem, 33508, "second value in sorted list");
+	mu_assert_eq(*(int *)list->head->next->next->elem, 33964, "third value in sorted list");
 	rz_list_free(list);
 	mu_end;
 }
@@ -157,7 +157,7 @@ bool test_rz_list_length(void) {
 	iter = list->head;
 	while (iter) {
 		count++;
-		iter = iter->n;
+		iter = iter->next;
 	}
 	mu_assert_eq(list->length, 3, "First length check");
 
@@ -191,7 +191,7 @@ bool test_rz_list_length(void) {
 	count = 0;
 	while (iter) {
 		count++;
-		iter = iter->n;
+		iter = iter->next;
 	}
 	mu_assert_eq(list->length, count, "Tenth length check");
 	rz_list_free(list);
@@ -212,8 +212,8 @@ bool test_rz_list_sort5(void) {
 	}
 	// add more than 43 elements to trigger merge sort
 	rz_list_sort(list, (RzListComparator)strcmp);
-	mu_assert_streq((char *)list->head->data, upper[0], "First element");
-	mu_assert_streq((char *)list->tail->data, lower[25], "Last element");
+	mu_assert_streq((char *)list->head->elem, upper[0], "First element");
+	mu_assert_streq((char *)list->tail->elem, lower[25], "Last element");
 	rz_list_free(list);
 	mu_end;
 }
@@ -247,8 +247,8 @@ bool test_rz_list_mergesort_pint() {
 
 	// assert the list is sorted as expected
 	RzListIter *iter;
-	for (i = 0, iter = list->head; i < RZ_ARRAY_SIZE(expected); i++, iter = iter->n) {
-		mu_assert_eq(*(int *)iter->data, expected[i], "array content mismatch");
+	for (i = 0, iter = list->head; i < RZ_ARRAY_SIZE(expected); i++, iter = iter->next) {
+		mu_assert_eq(*(int *)iter->elem, expected[i], "array content mismatch");
 	}
 
 	rz_list_free(list);
@@ -285,8 +285,8 @@ bool test_rz_list_sort4(void) {
 	for (i = 0; i < RZ_ARRAY_SIZE(exp_tests_odd); ++i) {
 		char buf[BUF_LENGTH];
 		snprintf(buf, BUF_LENGTH, "%d-th value in sorted list", i);
-		mu_assert_streq((char *)next->data, exp_tests_odd[i], buf);
-		next = next->n;
+		mu_assert_streq((char *)next->elem, exp_tests_odd[i], buf);
+		next = next->next;
 	}
 
 #if 0 // Debug Print
@@ -325,8 +325,8 @@ bool test_rz_list_sort4(void) {
 	for (i = 0; i < RZ_ARRAY_SIZE(exp_tests_even); ++i) {
 		char buf[BUF_LENGTH];
 		snprintf(buf, BUF_LENGTH, "%d-th value in sorted list", i);
-		mu_assert_streq((char *)next->data, exp_tests_even[i], buf);
-		next = next->n;
+		mu_assert_streq((char *)next->elem, exp_tests_even[i], buf);
+		next = next->next;
 	}
 	rz_list_free(list);
 	mu_end;
@@ -359,16 +359,16 @@ bool test_rz_list_append_prepend(void) {
 	iter = list->head;
 	for (i = 0; i < RZ_ARRAY_SIZE(test); ++i) {
 		snprintf(buf, BUF_LENGTH, "%d-th value in list from head", i);
-		mu_assert_streq((char *)iter->data, test[i], buf);
-		iter = iter->n;
+		mu_assert_streq((char *)iter->elem, test[i], buf);
+		iter = iter->next;
 	}
 
 	// Check that the previous sequence is correct
 	iter = list->tail;
 	for (i = (RZ_ARRAY_SIZE(test)) - 1; i > 0; --i) {
 		snprintf(buf, BUF_LENGTH, "%d-th value in list from tail", i);
-		mu_assert_streq((char *)iter->data, test[i], buf);
-		iter = iter->p;
+		mu_assert_streq((char *)iter->elem, test[i], buf);
+		iter = iter->prev;
 	}
 
 	rz_list_free(list);
@@ -423,8 +423,8 @@ bool test_rz_list_reverse(void) {
 	RzListIter *iter = list->head;
 	for (i = 0; i < RZ_ARRAY_SIZE(test); ++i) {
 		snprintf(buf, BUF_LENGTH, "%d-th value in list after reverse", i);
-		mu_assert_streq((char *)iter->data, test[i], buf);
-		iter = iter->n;
+		mu_assert_streq((char *)iter->elem, test[i], buf);
+		iter = iter->next;
 	}
 
 	rz_list_free(list);
@@ -450,9 +450,9 @@ bool test_rz_list_clone(void) {
 	RzListIter *iter2 = list2->head;
 	for (i = 0; i < RZ_ARRAY_SIZE(test); ++i) {
 		snprintf(buf, BUF_LENGTH, "%d-th value after clone", i);
-		mu_assert_streq((char *)iter2->data, (char *)iter1->data, buf);
-		iter1 = iter1->n;
-		iter2 = iter2->n;
+		mu_assert_streq((char *)iter2->elem, (char *)iter1->elem, buf);
+		iter1 = iter1->next;
+		iter2 = iter2->next;
 	}
 
 	rz_list_free(list1);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Cleans the usage of RzList across the codebase to avoid abuse of the members and adds missing functionalities.