### PR TITLE
fix the Memory leak: ret

### DIFF
--- a/librz/analysis/p/analysis_avr.c
+++ b/librz/analysis/p/analysis_avr.c
@@ -379,6 +379,7 @@ static ut8 *analysis_mask_avr(RzAnalysis *analysis, int size, const ut8 *data, u
 	rz_strbuf_fini(&sb);
 
 	if (opsize < 2 || !(ret = malloc(opsize))) {
+		free(ret);
 		rz_analysis_op_free(op);
 		return NULL;
 	}


### PR DESCRIPTION
When the opsize is greater than 2 and memory allocation is successful, it will cause a memory leak

Signed-off-by: zengwei zengwei1@uniontech.com

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
