### PR TITLE
[ARM64] Set correct family type for system hints.

### DIFF
--- a/test/db/analysis/arm64
+++ b/test/db/analysis/arm64
@@ -237,3 +237,20 @@ afvW
 \           0x00000028     0            ret
 EOF
 RUN
+
+NAME=pacibsp considered a valid function preamble
+FILE=malloc://1024
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 7f2303d5fc6fbaa9fa6701a9f85f02a9
+af
+pd 4
+EOF
+EXPECT=<<EOF
+/ fcn.00000000();
+|           0x00000000      pacibsp
+|           0x00000004      stp   x28, x27, [sp, -0x60]!
+|           0x00000008      stp   x26, x25, [sp, 0x10]
+|           0x0000000c      stp   x24, x23, [sp, 0x20]
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Pointer authentication instructions like `pacibsp` are encoded as alias for `hint`.
Due to this they got assigned the `nop` type and got neglected as valid function preamble.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Test added

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes https://github.com/rizinorg/rizin/issues/4039
