### PR TITLE
Fix the memory leak in  `rz_core_print_disasm_instructions_with_buf`

### DIFF
--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -5685,10 +5685,12 @@ RZ_API int rz_core_print_disasm_instructions_with_buf(RzCore *core, ut64 address
 		buf = malloc(RZ_ABS(nb_bytes) + 1);
 		if (!buf) {
 			RZ_LOG_ERROR("Fail to alloc memory.");
+			ds_free(ds);
 			return 0;
 		}
 		if (rz_io_nread_at(core->io, address, buf, RZ_ABS(nb_bytes) + 1) == -1) {
 			RZ_LOG_ERROR("Fail to read from 0x%" PFMT64x ".", address);
+			ds_free(ds);
 			free(buf);
 			return 0;
 		}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

```
** CID 434154:    (RESOURCE_LEAK)
/librz/core/disasm.c: 5667 in rz_core_print_disasm_instructions_with_buf()
/librz/core/disasm.c: 5662 in rz_core_print_disasm_instructions_with_buf()


________________________________________________________________________________________________________
*** CID 434154:    (RESOURCE_LEAK)
/librz/core/disasm.c: 5667 in rz_core_print_disasm_instructions_with_buf()
5661                            RZ_LOG_ERROR("Fail to alloc memory.");
5662                            return 0;
5663                    }
5664                    if (rz_io_nread_at(core->io, address, buf, RZ_ABS(nb_bytes) + 1) == -1) {
5665                            RZ_LOG_ERROR("Fail to read from 0x%" PFMT64x ".", address);
5666                            free(buf);
>>>     CID 434154:    (RESOURCE_LEAK)
>>>     Variable "ds" going out of scope leaks the storage it points to.
5667                            return 0;
5668                    }
5669            }
5670     
5671            rz_cons_break_push(NULL, NULL);
5672            // build ranges to map addr with bits
/librz/core/disasm.c: 5662 in rz_core_print_disasm_instructions_with_buf()
5656            ds->len = nb_opcodes * 8;
5657     
5658            if (!buf) {
5659                    buf = malloc(RZ_ABS(nb_bytes) + 1);
5660                    if (!buf) {
5661                            RZ_LOG_ERROR("Fail to alloc memory.");
>>>     CID 434154:    (RESOURCE_LEAK)
>>>     Variable "ds" going out of scope leaks the storage it points to.
5662                            return 0;
5663                    }
5664                    if (rz_io_nread_at(core->io, address, buf, RZ_ABS(nb_bytes) + 1) == -1) {
5665                            RZ_LOG_ERROR("Fail to read from 0x%" PFMT64x ".", address);
5666                            free(buf);
5667                            return 0;

```


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

CI is green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
