### PR TITLE
bin/elf: autodetect RL78 architecture

### DIFF
--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -268,6 +268,7 @@ static const struct arch_translation arch_translation_table[] = {
 	{ EM_PROPELLER, "propeller" },
 	{ EM_MICROBLAZE, "microblaze.gnu" },
 	{ EM_RISCV, "riscv" },
+	{ EM_RL78, "rl78" },
 	{ EM_VAX, "vax" },
 	{ EM_XTENSA, "xtensa" },
 	{ EM_LANAI, "lanai" },

--- a/test/db/analysis/rl78
+++ b/test/db/analysis/rl78
@@ -1,6 +1,6 @@
 NAME=RL78 caesar_nostrip info
 FILE=bins/rl78/caesar_nostrip
-ARGS=-a rl78
+ARGS=
 CMDS=<<EOF
 pd 4 @ entry0
 iI
@@ -12,7 +12,7 @@ EXPECT=<<EOF
             0x00000780      mov   es, #0x0
             0x00000782      movw  bc, #0x472
             0x00000785      clrw  ax
-arch     N/A
+arch     rl78
 cpu      N/A
 baddr    0x00000000
 binsz    0x00008360
@@ -50,7 +50,7 @@ RUN
 
 NAME=RL78 caesar_nostrip function bodies
 FILE=bins/rl78/caesar_nostrip
-ARGS=-a rl78
+ARGS=
 CMDS=<<EOF
 aaa
 pdf @ sym._decrypt
@@ -165,7 +165,7 @@ RUN
 
 NAME=RL78 caesar_nostrip function list
 FILE=bins/rl78/caesar_nostrip
-ARGS=-a rl78
+ARGS=
 CMDS=<<EOF
 aaa
 afl


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

RL78 architecture wasn't correctly detected from ELF files before, fix that.

**Test plan**

CI is green
