### PR TITLE
Use `-fno-strict-aliasing` with Capstone next build

### DIFF
--- a/subprojects/packagefiles/capstone-next/meson.build
+++ b/subprojects/packagefiles/capstone-next/meson.build
@@ -90,11 +90,10 @@ if meson.get_compiler('c').has_argument('-Wmaybe-uninitialized')
   libcapstone_c_args += '-Wno-maybe-uninitialized'
 endif
 
-# Currently, Capstone next breaks on the gcc release build. This dials down the
-# optimization level.
-if get_option('buildtype') == 'release' and meson.get_compiler('c').get_id() == 'gcc'
-  libcapstone_c_args += '-O1'
-endif
+# As of a128f31d20befedbf06ca9560f1bb23b5ebb3c4e, the Capstone
+# AArch64_AM_isSVEMaskOfIdenticalElements family of functions violates C strict
+# aliasing rules
+libcapstone_c_args += '-fno-strict-aliasing'
 
 libcapstone = library('capstone', cs_files,
   c_args: libcapstone_c_args,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The following Capstone next code:
https://github.com/capstone-engine/capstone/blob/a128f31d20befedbf06ca9560f1bb23b5ebb3c4e/arch/AArch64/AArch64AddressingModes.h#L826-L840 is elegant code for defining a family of functions, but unfortunately C strict aliasing rules disallow type punning like this unless `T` is a `char` type. Therefore, this pr adds `-fno-strict-aliasing` to the Capstone next build so that the compiler doesn't optimize based on those rules.

This pr refines #4054 and is a step towards solving #4048.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
