### PR TITLE
Add a new helper to convert a `long double` to an 80-bit RzIL float

### DIFF
--- a/librz/il/il_opcodes.c
+++ b/librz/il/il_opcodes.c
@@ -796,6 +796,24 @@ RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_float_from_f64(double f) {
 	return ret;
 }
 
+RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_float_from_f80(long double f) {
+	RzFloat *value = rz_float_new_from_f80(f);
+	if (!value) {
+		return NULL;
+	}
+	RzILOpFloat *ret = RZ_NEW0(RzILOpFloat);
+	if (!ret) {
+		rz_float_free(value);
+		return NULL;
+	}
+
+	ret->code = RZ_IL_OP_FLOAT;
+	ret->op.float_.bv = rz_il_op_new_bitv(value->s);
+	ret->op.float_.r = value->r;
+	free(value);
+	return ret;
+}
+
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_fbits(RZ_NONNULL RzILOpFloat *f) {
 	rz_return_val_if_fail(f, NULL);
 	RzILOpBitVector *ret;

--- a/librz/include/rz_il/definitions/sort.h
+++ b/librz/include/rz_il/definitions/sort.h
@@ -5,6 +5,7 @@
 #define RZ_IL_SORT_H
 
 #include <rz_types.h>
+#include <rz_util/rz_float.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,6 +44,9 @@ static inline bool rz_il_sort_pure_eq(RzILSortPure a, RzILSortPure b) {
 		return false;
 	}
 	if (a.type == RZ_IL_TYPE_PURE_BITVECTOR && a.props.bv.length != b.props.bv.length) {
+		return false;
+	}
+	if (a.type == RZ_IL_TYPE_PURE_FLOAT && a.props.f.format != b.props.f.format) {
 		return false;
 	}
 	return true;

--- a/librz/include/rz_il/rz_il_opbuilder_begin.h
+++ b/librz/include/rz_il/rz_il_opbuilder_begin.h
@@ -57,6 +57,7 @@
 #define BV2F(fmt, bv)              rz_il_op_new_float(fmt, bv)
 #define F32(f32)                   rz_il_op_new_float_from_f32(f32)
 #define F64(f64)                   rz_il_op_new_float_from_f64(f64)
+#define F80(f80)                   rz_il_op_new_float_from_f80(f80)
 #define F2BV(fl)                   rz_il_op_new_fbits(fl)
 #define IS_FINITE(fl)              rz_il_op_new_is_finite(fl)
 #define IS_FNAN(fl)                rz_il_op_new_is_nan(fl)

--- a/librz/include/rz_il/rz_il_opbuilder_end.h
+++ b/librz/include/rz_il/rz_il_opbuilder_end.h
@@ -24,6 +24,7 @@
 #undef BV2F
 #undef F32
 #undef F64
+#undef F80
 #undef F2BV
 #undef IS_FINITE
 #undef IS_FNAN

--- a/librz/include/rz_il/rz_il_opcodes.h
+++ b/librz/include/rz_il/rz_il_opcodes.h
@@ -736,6 +736,7 @@ RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_loadw(RzILMemIndex mem, RZ_NONNULL R
 RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_float(RzFloatFormat format, RZ_NONNULL RzILOpBitVector *bv);
 RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_float_from_f32(float f);
 RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_float_from_f64(double f);
+RZ_API RZ_OWN RzILOpFloat *rz_il_op_new_float_from_f80(long double f);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_op_new_fbits(RZ_NONNULL RzILOpFloat *f);
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_is_finite(RZ_NONNULL RzILOpFloat *f);
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_is_nan(RZ_NONNULL RzILOpFloat *f);

--- a/librz/include/rz_util/rz_float.h
+++ b/librz/include/rz_util/rz_float.h
@@ -9,6 +9,7 @@
 #ifndef RZ_FLOAT_H
 #define RZ_FLOAT_H
 #include <rz_types.h>
+#include <rz_util/rz_bitvector.h>
 
 /**
  *

--- a/test/unit/test_il_validate.c
+++ b/test/unit/test_il_validate.c
@@ -1344,6 +1344,21 @@ static bool test_il_validate_pure_float() {
 	mu_end;
 }
 
+static bool test_il_validate_pure_float80() {
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty(24);
+	RzILOpPure *op = rz_il_op_new_float_from_f80(4.2L);
+	RzILSortPure sort;
+	RzILValidateReport report;
+	bool val = rz_il_validate_pure(op, ctx, &sort, &report);
+	mu_assert_true(val, "valid");
+	mu_assert_true(rz_il_sort_pure_eq(sort, rz_il_sort_pure_float(RZ_FLOAT_IEEE754_BIN_80)), "sort");
+	mu_assert_null(report, "no report");
+	rz_il_op_pure_free(op);
+
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
 static bool test_il_validate_pure_fbits() {
 	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty(24);
 
@@ -1745,6 +1760,7 @@ bool all_tests() {
 	mu_run_test(test_il_validate_effect_repeat);
 	mu_run_test(test_il_validate_effect_branch);
 	mu_run_test(test_il_validate_pure_float);
+	mu_run_test(test_il_validate_pure_float80);
 	mu_run_test(test_il_validate_pure_fbits);
 	mu_run_test(test_il_validate_pure_float_bool_uop);
 	mu_run_test(test_il_validate_pure_float_uop);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

New function: `rz_il_op_new_float_from_f80`
New opbuilder: `F80`

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Add a test for `rz_il_op_new_float_from_f80`.
Update `rz_il_sort_pure_eq` to have a float format check as well.
Add a few `includes` in header files so that some types are visible.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Needed for #3865.