### PR TITLE
Remove static and global variables in disasm and analysis

### DIFF
--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -26,9 +26,7 @@
 #define DS_ANALYSIS_OP_MASK (RZ_ANALYSIS_OP_MASK_BASIC | RZ_ANALYSIS_OP_MASK_ESIL | \
 	RZ_ANALYSIS_OP_MASK_VAL | (ds->show_cmt_il ? RZ_ANALYSIS_OP_MASK_IL : 0))
 
-// ugly globals but meh
-static ut64 emustack_min = 0LL;
-static ut64 emustack_max = 0LL;
+#define ESILISTATE core->analysis->esilinterstate
 
 static const ut8 MAX_OPSIZE = 16;
 static const ut8 MIN_OPSIZE = 1;
@@ -671,8 +669,8 @@ static RzDisasmState *ds_init(RzCore *core) {
 		const char *uri = "malloc://32K";
 		ut64 size = rz_num_get(core->num, "32K");
 		ut64 addr = rz_reg_getv(core->analysis->reg, "SP") - (size / 2);
-		emustack_min = addr;
-		emustack_max = addr + size;
+		ESILISTATE->emustack_min = addr;
+		ESILISTATE->emustack_max = addr + size;
 		ds->stackFd = rz_io_fd_open(core->io, uri, RZ_PERM_RW, 0);
 		RzIOMap *map = rz_io_map_add(core->io, ds->stackFd, RZ_PERM_RW, 0LL, addr, size);
 		if (!map) {
@@ -798,8 +796,6 @@ static RzDisasmState *ds_init(RzCore *core) {
 	return ds;
 }
 
-static ut64 lastaddr = UT64_MAX;
-
 static void ds_reflines_fini(RzDisasmState *ds) {
 	RzAnalysis *analysis = ds->core->analysis;
 	rz_list_free(analysis->reflines);
@@ -811,8 +807,6 @@ static void ds_reflines_fini(RzDisasmState *ds) {
 
 static void ds_reflines_init(RzDisasmState *ds) {
 	RzAnalysis *analysis = ds->core->analysis;
-
-	lastaddr = UT64_MAX;
 
 	// refline info is needed when it is shown as ascii,
 	// or returned as part of a json or C struct representation.
@@ -4248,7 +4242,7 @@ static int mymemwrite1(RzAnalysisEsil *esil, ut64 addr, const ut8 *buf, int len)
 }
 
 static int mymemwrite2(RzAnalysisEsil *esil, ut64 addr, const ut8 *buf, int len) {
-	return (addr >= emustack_min && addr < emustack_max);
+	return (addr >= esil->analysis->esilinterstate->emustack_min && addr < esil->analysis->esilinterstate->emustack_max);
 }
 
 static char *ssa_get(RzAnalysisEsil *esil, const char *reg) {

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1185,6 +1185,8 @@ typedef struct rz_analysis_esil_inter_state_t {
 	bool analysis_stop;
 	ut64 last_read;
 	ut64 last_data;
+	ut64 emustack_min;
+	ut64 emustack_max;
 } RzAnalysisEsilInterState;
 
 /* Alias RegChange and MemChange */

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1187,6 +1187,8 @@ typedef struct rz_analysis_esil_inter_state_t {
 	ut64 last_data;
 	ut64 emustack_min;
 	ut64 emustack_max;
+	RzList /*<RzAnalysisEsilMemoryRegion *>*/ *memreads;
+	RzList /*<RzAnalysisEsilMemoryRegion *>*/ *memwrites;
 } RzAnalysisEsilInterState;
 
 /* Alias RegChange and MemChange */
@@ -1310,6 +1312,12 @@ typedef struct rz_analysis_esil_basic_block_t {
 	char *expr; // synthesized esil-expression for this block
 	RzAnalysisEsilBlockEnterType enter; // maybe more type is needed here
 } RzAnalysisEsilBB;
+
+// Structure to represent memory reads and writes during ESIL tracing
+typedef struct rz_analysis_esil_memory_region_t {
+	ut64 addr; ///< memory address
+	size_t size; ///< size of the region
+} RzAnalysisEsilMemoryRegion;
 
 // TODO: rm data + len
 typedef int (*RzAnalysisOpCallback)(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *data, int len, RzAnalysisOpMask mask);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Remove mutable static/global variables and reuse `RzAnalysisEsilInterState` introduced earlier.

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/4055
