### PR TITLE
Remove static and global varibles in esil_trace.c

### DIFF
--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1189,6 +1189,8 @@ typedef struct rz_analysis_esil_inter_state_t {
 	ut64 emustack_max;
 	RzList /*<RzAnalysisEsilMemoryRegion *>*/ *memreads;
 	RzList /*<RzAnalysisEsilMemoryRegion *>*/ *memwrites;
+	RzAnalysisEsilCallbacks callbacks;
+	bool callbacks_set;
 } RzAnalysisEsilInterState;
 
 /* Alias RegChange and MemChange */


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Remove mutable static/global variables and reuse `RzAnalysisEsilInterState` introduced earlier.

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/4055
