### PR TITLE
netbsd.yml: Use `ensurepip` instead of `get-pip.py`

### DIFF
--- a/.builds/netbsd.yml
+++ b/.builds/netbsd.yml
@@ -5,7 +5,6 @@ packages:
     - gmake
     - clang
     - python38
-    - wget
 environment:
     CXX: clang++
     CC: clang
@@ -15,8 +14,7 @@ sources:
 hottub_trigger: '^(dev|stable|bsd-.+|dist-.+)$'
 tasks:
     - rzpipe: |
-        wget https://bootstrap.pypa.io/get-pip.py
-        python3.8 get-pip.py
+        python3.8 -m ensurepip --user
         python3.8 -m pip install --user 'git+https://github.com/rizinorg/rz-pipe#egg=rzpipe&subdirectory=python'
     - build: |
         cd rizin


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Apparently NetBSD now includes `pyexpat` with the `python38` package, possibly through https://github.com/NetBSD/pkgsrc/commit/0943c3be06301f9fb21f27491d41ff7b4a78b233#diff-cd7019a4295cb49ca71a380021e6d7fdbc830e390be29ffedc36fd903ab0868fR2007, so this pr reverts `netbsd.yml` back to using `ensurepip` to install pip, since that appears better than manually downloading a file and executing that file.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The NetBSD build is green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
