### PR TITLE
Do not throw warning on empty RzIL

### DIFF
--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -5657,6 +5657,11 @@ RZ_API void rz_core_analysis_bytes_il(RZ_NONNULL RzCore *core, RZ_NONNULL const 
 			rz_analysis_op_fini(&op);
 			break;
 		}
+		// Just empty RzIL
+		if (!op.il_op) {
+			RZ_LOG_DEBUG("Empty IL at 0x%08" PFMT64x "...\n", core->offset + idx);
+			break;
+		}
 
 		rz_strbuf_init(&sb);
 		rz_il_op_effect_stringify(op.il_op, &sb, pretty);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

To avoid warnings like that:
```
WARNING: rz_il_op_effect_stringify: assertion 'op & sb' failed (line 1019)
```
when there is instruction with empty RzIL.

**Test plan**

CI is green.