### PR TITLE
Blind patch for windows debugger to load libraries

### DIFF
--- a/librz/debug/p/debug_native.c
+++ b/librz/debug/p/debug_native.c
@@ -345,7 +345,7 @@ static RzDebugReasonType rz_debug_native_wait(RzDebug *dbg, int pid) {
 						rz_bin_file_set_cur_binfile(core->bin, cur);
 					}
 				} else {
-					RZ_LOG_VERBOSE("The library %s does not exist.\n", lib_path);
+					RZ_LOG_ERROR("The library %s does not exist.\n", lib_path);
 				}
 				free(lib_path);
 			}

--- a/librz/debug/p/debug_native.c
+++ b/librz/debug/p/debug_native.c
@@ -325,14 +325,15 @@ static RzDebugReasonType rz_debug_native_wait(RzDebug *dbg, int pid) {
 			bool autoload_pdb = dbg->corebind.cfggeti(core, "pdb.autoload");
 			if (autoload_pdb) {
 				PLIB_ITEM lib = native_info->lib;
-				if (rz_file_exists(lib->Path)) {
+				char *lib_path = rz_utf16_to_utf8(lib->Path);
+				if (lib_path && rz_file_exists(lib_path)) {
 					if (tracelib(dbg, "load", native_info->lib)) {
 						reason = RZ_DEBUG_REASON_TRAP;
 					}
 					RzBinOptions opts = { 0 };
 					opts.obj_opts.baseaddr = (uintptr_t)lib->BaseOfDll;
 					RzBinFile *cur = rz_bin_cur(core->bin);
-					RzBinFile *bf = rz_bin_open(core->bin, lib->Path, &opts);
+					RzBinFile *bf = rz_bin_open(core->bin, lib_path, &opts);
 					if (bf) {
 						const RzBinInfo *info = rz_bin_object_get_info(bf->o);
 						if (RZ_STR_ISNOTEMPTY(info->debug_file_name)) {
@@ -344,8 +345,9 @@ static RzDebugReasonType rz_debug_native_wait(RzDebug *dbg, int pid) {
 						rz_bin_file_set_cur_binfile(core->bin, cur);
 					}
 				} else {
-					RZ_LOG_VERBOSE("The library %s does not exist.\n", lib->Path);
+					RZ_LOG_VERBOSE("The library %s does not exist.\n", lib_path);
 				}
+				free(lib_path);
 			}
 		} else {
 			RZ_LOG_WARN("Loading unknown library.\n");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
This is a blind patch to load external libraries for the windows native debugger.

**Closing issues**

Might fix https://github.com/rizinorg/rizin/issues/4107
