### PR TITLE
Remove some of `sdb_fmt()` calls in RzCore

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -2947,12 +2947,13 @@ RZ_IPI void rz_core_add_string_ref(RzCore *core, ut64 xref_from, ut64 xref_to) {
 	if (rz_core_get_string_at(core, xref_to, &string, &length, &encoding, true)) {
 		rz_analysis_xrefs_set(core->analysis, xref_from, xref_to, RZ_ANALYSIS_XREF_TYPE_DATA);
 		rz_name_filter(string, -1, true);
-		char *flagname = sdb_fmt("str.%s", string);
+		char *flagname = rz_str_newf("str.%s", string);
 		rz_flag_space_push(core->flags, RZ_FLAGS_FS_STRINGS);
 		rz_flag_set(core->flags, flagname, xref_to, length);
 		rz_flag_space_pop(core->flags);
 		rz_meta_set_with_subtype(core->analysis, RZ_META_TYPE_STRING, encoding, xref_to, length, string);
 		free(string);
+		free(flagname);
 	}
 }
 

--- a/librz/core/cil.c
+++ b/librz/core/cil.c
@@ -1421,12 +1421,13 @@ RZ_API void rz_core_analysis_esil(RzCore *core, ut64 addr, ut64 size, RZ_NULLABL
 						if ((f = rz_core_flag_get_by_spaces(core->flags, dst))) {
 							rz_meta_set_string(core->analysis, RZ_META_TYPE_COMMENT, cur, f->name);
 						} else if (rz_core_get_string_at(core, dst, &str, NULL, NULL, true)) {
-							char *str2 = sdb_fmt("esilref: '%s'", str);
+							char *str2 = rz_str_newf("esilref: '%s'", str);
 							// HACK avoid format string inside string used later as format
 							// string crashes disasm inside agf under some conditions.
 							rz_str_replace_char(str2, '%', '&');
 							rz_meta_set_string(core->analysis, RZ_META_TYPE_COMMENT, cur, str2);
 							free(str);
+							free(str2);
 						}
 					}
 				}

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -414,6 +414,7 @@ static int _cb_hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 	ut64 base_addr = 0;
 	bool use_color = core->print->flags & RZ_PRINT_FLAGS_COLOR;
 	int keyword_len = kw ? kw->keyword_length + (search->mode == RZ_SEARCH_DELTAKEY) : 0;
+	char tmpbuf[128];
 
 	if (searchshow && kw && kw->keyword_length > 0) {
 		int len, i, extra, mallocsize;
@@ -512,7 +513,7 @@ static int _cb_hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 		}
 	}
 	if (searchflags && kw) {
-		const char *flag = sdb_fmt("%s%d_%d", searchprefix, kw->kwidx, kw->count);
+		const char *flag = rz_strf(tmpbuf, "%s%d_%d", searchprefix, kw->kwidx, kw->count);
 		rz_flag_set(core->flags, flag, base_addr + addr, keyword_len);
 	}
 	if (*param->cmd_hit) {
@@ -1145,6 +1146,7 @@ static void print_rop(RzCore *core, RzList /*<RzCoreAsmHit *>*/ *hitlist, PJ *pj
 	const bool rop_comments = rz_config_get_i(core->config, "rop.comments");
 	const bool esil = rz_config_get_i(core->config, "asm.esil");
 	const bool rop_db = rz_config_get_i(core->config, "rop.db");
+	char tmpbuf[16];
 
 	if (rop_db) {
 		db = sdb_ns(core->sdb, "rop", true);
@@ -1187,7 +1189,7 @@ static void print_rop(RzCore *core, RzList /*<RzCoreAsmHit *>*/ *hitlist, PJ *pj
 		if (db && hit) {
 			const ut64 addr = ((RzCoreAsmHit *)rz_list_get_head_data(hitlist))->addr;
 			// rz_cons_printf ("Gadget size: %d\n", (int)size);
-			const char *key = sdb_fmt("0x%08" PFMT64x, addr);
+			const char *key = rz_strf(tmpbuf, "0x%08" PFMT64x, addr);
 			rop_classify(core, db, ropList, key, size);
 		}
 		if (hit) {
@@ -1228,7 +1230,7 @@ static void print_rop(RzCore *core, RzList /*<RzCoreAsmHit *>*/ *hitlist, PJ *pj
 		if (db && hit) {
 			const ut64 addr = ((RzCoreAsmHit *)rz_list_get_head_data(hitlist))->addr;
 			// rz_cons_printf ("Gadget size: %d\n", (int)size);
-			const char *key = sdb_fmt("0x%08" PFMT64x, addr);
+			const char *key = rz_strf(tmpbuf, "0x%08" PFMT64x, addr);
 			rop_classify(core, db, ropList, key, size);
 		}
 		break;
@@ -1282,7 +1284,7 @@ static void print_rop(RzCore *core, RzList /*<RzCoreAsmHit *>*/ *hitlist, PJ *pj
 		if (db && hit) {
 			const ut64 addr = ((RzCoreAsmHit *)rz_list_get_head_data(hitlist))->addr;
 			// rz_cons_printf ("Gadget size: %d\n", (int)size);
-			const char *key = sdb_fmt("0x%08" PFMT64x, addr);
+			const char *key = rz_strf(tmpbuf, "0x%08" PFMT64x, addr);
 			rop_classify(core, db, ropList, key, size);
 		}
 	}
@@ -2219,6 +2221,7 @@ static void do_asm_search(RzCore *core, struct search_parameters *param, const c
 	RzIOMap *map;
 	bool regexp = input[0] == '/'; // "/c/"
 	bool everyByte = regexp && input[1] == 'a';
+	char tmpbuf[128];
 	char *end_cmd = strchr(input, ' ');
 	switch ((end_cmd ? *(end_cmd - 1) : input[0])) {
 	case 'j':
@@ -2296,7 +2299,7 @@ static void do_asm_search(RzCore *core, struct search_parameters *param, const c
 					break;
 				}
 				if (searchflags) {
-					const char *flagname = sdb_fmt("%s%d_%d", searchprefix, kwidx, count);
+					const char *flagname = rz_strf(tmpbuf, "%s%d_%d", searchprefix, kwidx, count);
 					if (flagname) {
 						rz_flag_set(core->flags, flagname, hit->addr, hit->len);
 					}

--- a/librz/core/rtr.c
+++ b/librz/core/rtr.c
@@ -790,6 +790,7 @@ static void *rz_core_rtr_rap_thread(RapThread *rt) {
 
 RZ_API void rz_core_rtr_cmd(RzCore *core, const char *input) {
 	unsigned int cmd_len = 0;
+	char tmpbuf[8];
 	int fd = atoi(input);
 	if (!fd && *input != '0') {
 		fd = -1;
@@ -860,7 +861,7 @@ RZ_API void rz_core_rtr_cmd(RzCore *core, const char *input) {
 			return;
 		}
 		rz_socket_close(s);
-		if (!rz_socket_connect(s, rh->host, sdb_fmt("%d", rh->port), RZ_SOCKET_PROTO_TCP, 0)) {
+		if (!rz_socket_connect(s, rh->host, rz_strf(tmpbuf, "%d", rh->port), RZ_SOCKET_PROTO_TCP, 0)) {
 			RZ_LOG_ERROR("core: Cannot connect to '%s' (%d)\n", rh->host, rh->port);
 			rz_socket_free(s);
 			return;

--- a/librz/core/tui/define.c
+++ b/librz/core/tui/define.c
@@ -230,11 +230,13 @@ onemoretime:
 		tgt_addr = op.jump != UT64_MAX ? op.jump : op.ptr;
 		RzAnalysisVar *var = rz_analysis_get_used_function_var(core->analysis, op.addr);
 		if (var) {
-			char *newname = rz_cons_input(sdb_fmt("New variable name for '%s': ", var->name));
-			if (newname && *newname) {
+			char *inputstr = rz_str_newf("New variable name for '%s': ", var->name);
+			char *newname = rz_cons_input(inputstr);
+			if (RZ_STR_ISNOTEMPTY(newname)) {
 				rz_analysis_var_rename(var, newname, true);
 				free(newname);
 			}
+			free(inputstr);
 		} else if (tgt_addr != UT64_MAX) {
 			RzAnalysisFunction *fcn = rz_analysis_get_function_at(core->analysis, tgt_addr);
 			RzFlagItem *f = rz_flag_get_i(core->flags, tgt_addr);
@@ -498,11 +500,13 @@ onemoretime:
 		}
 
 		if (var) {
-			char *newname = rz_cons_input(sdb_fmt("New variable name for '%s': ", var->name));
-			if (newname && *newname) {
+			char *inputstr = rz_str_newf("New variable name for '%s': ", var->name);
+			char *newname = rz_cons_input(inputstr);
+			if (RZ_STR_ISNOTEMPTY(newname)) {
 				rz_analysis_var_rename(var, newname, true);
 				free(newname);
 			}
+			free(inputstr);
 		} else {
 			eprintf("Cannot find instruction with a variable\n");
 			rz_cons_any_key(NULL);

--- a/librz/core/tui/panels.c
+++ b/librz/core/tui/panels.c
@@ -4182,16 +4182,17 @@ void __add_menu(RzCore *core, const char *parent, const char *name, RzPanelsMenu
 	RzCoreVisual *visual = core->visual;
 	RzPanels *panels = visual->panels;
 	RzPanelsMenuItem *p_item, *item = RZ_NEW0(RzPanelsMenuItem);
+	char tmpbuf[512];
 	if (!item) {
 		return;
 	}
 	if (parent) {
 		void *addr = ht_pp_find(panels->mht, parent, NULL);
 		p_item = (RzPanelsMenuItem *)addr;
-		ht_pp_insert(panels->mht, sdb_fmt("%s.%s", parent, name), item);
+		ht_pp_insert(panels->mht, rz_strf(tmpbuf, "%s.%s", parent, name), item);
 	} else {
 		p_item = panels->panels_menu->root;
-		ht_pp_insert(panels->mht, sdb_fmt("%s", name), item);
+		ht_pp_insert(panels->mht, rz_strf(tmpbuf, "%s", name), item);
 	}
 	item->n_sub = 0;
 	item->selectedIndex = 0;
@@ -4225,9 +4226,10 @@ void __update_menu(RzCore *core, const char *parent, RZ_NULLABLE RzPanelMenuUpda
 	void *addr = ht_pp_find(panels->mht, parent, NULL);
 	RzPanelsMenuItem *p_item = (RzPanelsMenuItem *)addr;
 	int i;
+	char tmpbuf[512];
 	for (i = 0; i < p_item->n_sub; i++) {
 		RzPanelsMenuItem *sub = p_item->sub[i];
-		ht_pp_delete(visual->panels->mht, sdb_fmt("%s.%s", parent, sub->name));
+		ht_pp_delete(visual->panels->mht, rz_strf(tmpbuf, "%s.%s", parent, sub->name));
 	}
 	p_item->sub = NULL;
 	p_item->n_sub = 0;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`sdb_fmt()` is thread-unsafe, remove it.

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/1168
