### PR TITLE
Remove `sdb_fmt()` calls in RzDebug

### DIFF
--- a/librz/debug/debug.c
+++ b/librz/debug/debug.c
@@ -603,6 +603,7 @@ RZ_API bool rz_debug_select(RzDebug *dbg, int pid, int tid) {
 	ut64 pc = 0;
 	int prev_pid = dbg->pid;
 	int prev_tid = dbg->tid;
+	char tmpbuf[32];
 
 	if (pid < 0) {
 		return false;
@@ -627,7 +628,7 @@ RZ_API bool rz_debug_select(RzDebug *dbg, int pid, int tid) {
 		dbg->tid = tid;
 	}
 
-	rz_io_system(dbg->iob.io, sdb_fmt("pid %d", dbg->tid));
+	rz_io_system(dbg->iob.io, rz_strf(tmpbuf, "pid %d", dbg->tid));
 
 	// Synchronize with the current thread's data
 	if (dbg->corebind.core) {

--- a/librz/debug/dsession.c
+++ b/librz/debug/dsession.c
@@ -251,6 +251,7 @@ RZ_API bool rz_debug_session_add_mem_change(RzDebugSession *session, ut64 addr, 
 static bool serialize_register_cb(void *db, const ut64 k, const void *v) {
 	RzDebugChangeReg *reg;
 	RzVector *vreg = (RzVector *)v;
+	char tmpbuf[32];
 	PJ *j = pj_new();
 	if (!j) {
 		return false;
@@ -265,7 +266,7 @@ static bool serialize_register_cb(void *db, const ut64 k, const void *v) {
 	}
 
 	pj_end(j);
-	sdb_set(db, sdb_fmt("0x%" PFMT64x, k), pj_string(j), 0);
+	sdb_set(db, rz_strf(tmpbuf, "0x%" PFMT64x, k), pj_string(j), 0);
 	pj_free(j);
 	return true;
 }
@@ -278,6 +279,7 @@ static void serialize_registers(Sdb *db, HtUP *registers) {
 static bool serialize_memory_cb(void *db, const ut64 k, const void *v) {
 	RzDebugChangeMem *mem;
 	RzVector *vmem = (RzVector *)v;
+	char tmpbuf[32];
 	PJ *j = pj_new();
 	if (!j) {
 		return false;
@@ -292,7 +294,7 @@ static bool serialize_memory_cb(void *db, const ut64 k, const void *v) {
 	}
 
 	pj_end(j);
-	sdb_set(db, sdb_fmt("0x%" PFMT64x, k), pj_string(j), 0);
+	sdb_set(db, rz_strf(tmpbuf, "0x%" PFMT64x, k), pj_string(j), 0);
 	pj_free(j);
 	return true;
 }
@@ -306,6 +308,7 @@ static void serialize_checkpoints(Sdb *db, RzVector /*<RzDebugCheckpoint>*/ *che
 	RzDebugCheckpoint *chkpt;
 	RzDebugSnap *snap;
 	RzListIter *iter;
+	char tmpbuf[32];
 
 	rz_vector_foreach(checkpoints, chkpt) {
 		// 0x<cnum>={
@@ -360,7 +363,7 @@ static void serialize_checkpoints(Sdb *db, RzVector /*<RzDebugCheckpoint>*/ *che
 		pj_end(j);
 
 		pj_end(j);
-		sdb_set(db, sdb_fmt("0x%x", chkpt->cnum), pj_string(j), 0);
+		sdb_set(db, rz_strf(tmpbuf, "0x%x", chkpt->cnum), pj_string(j), 0);
 		pj_free(j);
 	}
 }
@@ -558,9 +561,6 @@ static bool deserialize_registers_cb(void *user, const char *addr, const char *v
 static void deserialize_registers(Sdb *db, HtUP *registers) {
 	sdb_foreach(db, deserialize_registers_cb, registers);
 }
-
-#define SNAPATTR(ATTR) sdb_fmt("snaps.a[%u]." ATTR, i)
-#define REGATTR(ATTR)  sdb_fmt("registers.%d." ATTR, i)
 
 static bool deserialize_checkpoints_cb(void *user, const char *cnum, const char *v) {
 	const RzJson *child;

--- a/librz/debug/p/debug_io.c
+++ b/librz/debug/p/debug_io.c
@@ -135,7 +135,8 @@ static int __io_continue(RzDebug *dbg, int pid, int tid, int sig) {
 
 // "dk" send kill signal
 static bool __io_kill(RzDebug *dbg, int pid, int tid, int sig) {
-	const char *cmd = sdb_fmt("dk %d", sig);
+	char tmpbuf[32];
+	const char *cmd = rz_strf(tmpbuf, "dk %d", sig);
 	dbg->iob.system(dbg->iob.io, cmd);
 	rz_cons_flush();
 	return true;

--- a/librz/debug/p/debug_native.c
+++ b/librz/debug/p/debug_native.c
@@ -1035,7 +1035,9 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 #endif
 	fd = rz_sys_fopen(path, "r");
 	if (!fd) {
-		perror(sdb_fmt("Cannot open '%s'", path));
+		char *errmsg = rz_str_newf("Cannot open '%s'", path);
+		perror(errmsg);
+		free(errmsg);
 		return NULL;
 	}
 

--- a/librz/debug/p/debug_windbg.c
+++ b/librz/debug/p/debug_windbg.c
@@ -420,6 +420,7 @@ static RzList *windbg_map_get(RzDebug *dbg) {
 	PIMAGE_SECTION_HEADER *s = RZ_NEWS0(PIMAGE_SECTION_HEADER, mod_cnt);
 	RzListIter *it;
 	RzDebugMap *mod = NULL;
+	char tmpbuf[512];
 	size_t i = 0;
 	rz_list_foreach (mod_list, it, mod) {
 		if (FAILED(ITHISCALL(dbgData, ReadImageNtHeaders, mod->addr, h + i))) {
@@ -467,7 +468,7 @@ static RzList *windbg_map_get(RzDebug *dbg) {
 					ut64 sect_vaddr = mod->addr + s[i][j].VirtualAddress;
 					ut64 sect_vsize = (((ut64)s[i][j].Misc.VirtualSize) + p_mask) & ~p_mask;
 					if (mbi.BaseAddress >= sect_vaddr && mbi.BaseAddress < sect_vaddr + sect_vsize) {
-						name = sdb_fmt("%s | %.8s", mod->name, s[i][j].Name);
+						name = rz_strf(tmpbuf, "%s | %.8s", mod->name, s[i][j].Name);
 						break;
 					}
 				}

--- a/librz/debug/p/native/linux/linux_coredump.c
+++ b/librz/debug/p/native/linux/linux_coredump.c
@@ -75,6 +75,7 @@ static prpsinfo_t *linux_get_prpsinfo(RzDebug *dbg, proc_per_process_t *proc_dat
 	prpsinfo_t *p;
 	pid_t mypid;
 	size_t len;
+	char tmpbuf[128];
 
 	p = RZ_NEW0(prpsinfo_t);
 	if (!p) {
@@ -84,7 +85,7 @@ static prpsinfo_t *linux_get_prpsinfo(RzDebug *dbg, proc_per_process_t *proc_dat
 
 	p->pr_pid = mypid = dbg->pid;
 	/* Start filling pr_fname and pr_psargs */
-	file = sdb_fmt("/proc/%d/cmdline", mypid);
+	file = rz_strf(tmpbuf, "/proc/%d/cmdline", mypid);
 	buffer = rz_file_slurp(file, &len);
 	if (!buffer) {
 		eprintf("buffer NULL\n");
@@ -130,7 +131,8 @@ error:
 static proc_per_thread_t *get_proc_thread_content(int pid, int tid) {
 	char *temp_p_sigpend, *temp_p_sighold, *p_sigpend, *p_sighold;
 	size_t size;
-	const char *file = sdb_fmt("/proc/%d/task/%d/stat", pid, tid);
+	char tmpbuf[128];
+	const char *file = rz_strf(tmpbuf, "/proc/%d/task/%d/stat", pid, tid);
 
 	char *buff = rz_file_slurp(file, &size);
 	if (!buff) {
@@ -157,7 +159,7 @@ static proc_per_thread_t *get_proc_thread_content(int pid, int tid) {
 	}
 
 	/* /proc/[pid]/status for uid, gid, sigpend and sighold */
-	file = sdb_fmt("/proc/%d/task/%d/status", pid, tid);
+	file = rz_strf(tmpbuf, "/proc/%d/task/%d/status", pid, tid);
 	buff = rz_file_slurp(file, &size);
 	if (!buff) {
 		free(t);
@@ -558,8 +560,9 @@ static auxv_buff_t *linux_get_auxv(RzDebug *dbg) {
 	auxv_buff_t *auxv = NULL;
 	int auxv_entries;
 	size_t size;
+	char tmpbuf[128];
 
-	const char *file = sdb_fmt("/proc/%d/auxv", dbg->pid);
+	const char *file = rz_strf(tmpbuf, "/proc/%d/auxv", dbg->pid);
 	buff = rz_file_slurp(file, &size);
 	if (!buff) {
 		return NULL;
@@ -781,7 +784,8 @@ static proc_per_process_t *get_proc_process_content(RzDebug *dbg) {
 	char *temp_p_uid, *temp_p_gid, *p_uid, *p_gid;
 	ut16 filter_flags, default_filter_flags = 0x33;
 	char *buff;
-	const char *file = sdb_fmt("/proc/%d/stat", dbg->pid);
+	char tmpbuf[128];
+	const char *file = rz_strf(tmpbuf, "/proc/%d/stat", dbg->pid);
 	size_t size;
 
 	buff = rz_file_slurp(file, &size);
@@ -815,7 +819,7 @@ static proc_per_process_t *get_proc_process_content(RzDebug *dbg) {
 		eprintf("Warning: number of threads is < 1\n");
 		return NULL;
 	}
-	file = sdb_fmt("/proc/%d/status", dbg->pid);
+	file = rz_strf(tmpbuf, "/proc/%d/status", dbg->pid);
 	buff = rz_file_slurp(file, &size);
 	if (!buff) {
 		free(p);
@@ -855,7 +859,7 @@ static proc_per_process_t *get_proc_process_content(RzDebug *dbg) {
 
 	free(buff);
 	/* Check the coredump_filter value if we have*/
-	file = sdb_fmt("/proc/%d/coredump_filter", dbg->pid);
+	file = rz_strf(tmpbuf, "/proc/%d/coredump_filter", dbg->pid);
 	buff = rz_file_slurp(file, &size);
 	if (buff) {
 		sscanf(buff, "%hx", &filter_flags);

--- a/librz/debug/trace.c
+++ b/librz/debug/trace.c
@@ -212,9 +212,10 @@ RZ_API void rz_debug_trace_at(RzDebug *dbg, const char *str) {
 }
 
 RZ_API RzDebugTracepoint *rz_debug_trace_get(RzDebug *dbg, ut64 addr) {
+	char tmpbuf[64];
 	int tag = dbg->trace->tag;
 	return ht_pp_find(dbg->trace->ht,
-		sdb_fmt("trace.%d.%" PFMT64x, tag, addr), NULL);
+		rz_strf(tmpbuf, "trace.%d.%" PFMT64x, tag, addr), NULL);
 }
 
 static int cmpaddr(const void *_a, const void *_b) {
@@ -274,6 +275,7 @@ static int rz_debug_trace_is_traceable(RzDebug *dbg, ut64 addr) {
 
 RZ_API RzDebugTracepoint *rz_debug_trace_add(RzDebug *dbg, ut64 addr, int size) {
 	RzDebugTracepoint *tp;
+	char tmpbuf[64];
 	int tag = dbg->trace->tag;
 	if (!rz_debug_trace_is_traceable(dbg, addr)) {
 		return NULL;
@@ -291,7 +293,7 @@ RZ_API RzDebugTracepoint *rz_debug_trace_add(RzDebug *dbg, ut64 addr, int size) 
 	tp->times = 1;
 	rz_list_append(dbg->trace->traces, tp);
 	ht_pp_update(dbg->trace->ht,
-		sdb_fmt("trace.%d.%" PFMT64x, tag, addr), tp);
+		rz_strf(tmpbuf, "trace.%d.%" PFMT64x, tag, addr), tp);
 	return tp;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`sdb_fmt()` is thread-unsafe, remove it.

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/1168
