### PR TITLE
Remove some more of `sdb_fmt()` calls

### DIFF
--- a/librz/core/cagraph.c
+++ b/librz/core/cagraph.c
@@ -243,7 +243,9 @@ RZ_IPI bool rz_core_agraph_add_shortcut(RzCore *core, RzAGraph *g, RzANode *an, 
 	if (!shortcut) {
 		return false;
 	}
-	sdb_set(g->db, sdb_fmt("agraph.nodes.%s.shortcut", title), shortcut, 0);
+	char *key = rz_str_newf("agraph.nodes.%s.shortcut", title);
+	sdb_set(g->db, key, shortcut, 0);
+	free(key);
 	// title + "[o{shortcut}]", so w + 3 ?
 	an->shortcut_w = strlen(shortcut) + 3;
 	free(shortcut);

--- a/librz/core/cmd/cmd_magic.c
+++ b/librz/core/cmd/cmd_magic.c
@@ -127,8 +127,9 @@ static int rz_core_magic_at(RzCore *core, const char *file, ut64 addr, int depth
 		}
 		{
 			const char *searchprefix = rz_config_get(core->config, "search.prefix");
-			const char *flag = sdb_fmt("%s%d_%d", searchprefix, 0, kw_count++);
+			char *flag = rz_str_newf("%s%d_%d", searchprefix, 0, kw_count++);
 			rz_flag_set(core->flags, flag, addr + adelta, 1);
+			free(flag);
 		}
 		// TODO: This must be a callback .. move this into RSearch?
 		if (!pj) {

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -1308,6 +1308,7 @@ static void annotated_hexdump(RzCore *core, int len) {
 	int i, j, low, max, here, rows;
 	bool marks = false, setcolor = true, hascolor = false;
 	ut8 ch = 0;
+	char tmpbuf[20] = { 0 };
 	char *colors[10] = { NULL };
 	for (i = 0; i < 10; i++) {
 		colors[i] = rz_cons_rainbow_get(i, 10, false);
@@ -1347,8 +1348,7 @@ static void annotated_hexdump(RzCore *core, int len) {
 	bytes = calloc(nb_cons_cols * 40, sizeof(char));
 	if (!bytes)
 		goto err_bytes;
-#if 1
-	int addrpadlen = strlen(sdb_fmt("%08" PFMT64x, addr)) - 8;
+	int addrpadlen = strlen(rz_strf(tmpbuf, "%08" PFMT64x, addr)) - 8;
 	char addrpad[32];
 	if (addrpadlen > 0) {
 		memset(addrpad, ' ', addrpadlen);
@@ -1360,7 +1360,6 @@ static void annotated_hexdump(RzCore *core, int len) {
 		addrpadlen = 0;
 	}
 	strcpy(bytes + addrpadlen, "- offset -  ");
-#endif
 	j = strlen(bytes);
 	for (i = 0; i < nb_cols; i += 2) {
 		sprintf(bytes + j, format, (i & 0xf), (i + 1) & 0xf);
@@ -5411,7 +5410,7 @@ static void analysis_stats_json_info(RzCore *core, RzCoreAnalysisStats *as, RzCo
 static void analysis_stats_table_info(RzCore *core, RzCoreAnalysisStats *as, RzCoreAnalysisStatsItem *sitem, ut64 blockidx, RzCmdStateOutput *state) {
 	ut64 at = rz_core_analysis_stats_get_block_from(as, blockidx);
 	if ((sitem->flags) || (sitem->functions) || (sitem->comments) || (sitem->symbols) || (sitem->strings)) {
-		rz_table_add_rowf(state->d.t, "sddddd", sdb_fmt("0x%09" PFMT64x "", at), sitem->flags,
+		rz_table_add_rowf(state->d.t, "xddddd", at, sitem->flags,
 			sitem->functions, sitem->comments, sitem->symbols, sitem->strings);
 	}
 }

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -1997,8 +1997,11 @@ static bool do_analysis_search(RzCore *core, struct search_parameters *param, co
 				RzSyscallItem *si;
 				RzList *list = rz_syscall_list(core->analysis->syscall);
 				rz_list_foreach (list, iter, si) {
-					rz_cons_printf("%s = 0x%02x.%s\n",
-						si->name, si->swi, syscallNumber(si->num));
+					if (si->num > SYSCALL_HEX_LIMIT) {
+						rz_cons_printf("%s = 0x%02x.%x\n", si->name, si->swi, si->num);
+					} else {
+						rz_cons_printf("%s = 0x%02x.%d\n", si->name, si->swi, si->num);
+					}
 				}
 				rz_list_free(list);
 				break;

--- a/librz/core/csyscall.c
+++ b/librz/core/csyscall.c
@@ -4,8 +4,8 @@
 
 #include <rz_core.h>
 
-static const char *syscallNumber(int n) {
-	return sdb_fmt(n > 1000 ? "0x%x" : "%d", n);
+static const char *syscallNumberFmt(int n) {
+	return n > 1000 ? "0x%x" : "%d";
 }
 
 /**
@@ -26,6 +26,7 @@ static const char *syscallNumber(int n) {
 RZ_API RZ_OWN char *rz_core_syscall_as_string(RzCore *core, st64 n, ut64 addr) {
 	int i;
 	char str[64];
+	char tmpbuf[32] = { 0 };
 	st64 N = n;
 	int defVector = rz_syscall_get_swi(core->analysis->syscall);
 	if (defVector > 0) {
@@ -43,9 +44,11 @@ RZ_API RZ_OWN char *rz_core_syscall_as_string(RzCore *core, st64 n, ut64 addr) {
 		item = rz_syscall_get(core->analysis->syscall, N, -1);
 	}
 	if (!item) {
-		return rz_str_newf("%s = unknown ()", syscallNumber(n));
+		const char *syscallnum = rz_strf(tmpbuf, syscallNumberFmt(n), n);
+		return rz_str_newf("%s = unknown ()", syscallnum);
 	}
-	char *res = rz_str_newf("%s = %s (", syscallNumber(item->num), item->name);
+	const char *syscallnum = rz_strf(tmpbuf, syscallNumberFmt(item->num), item->num);
+	char *res = rz_str_newf("%s = %s (", syscallnum, item->name);
 	// TODO: move this to rz_syscall
 	const char *cc = rz_analysis_syscc_default(core->analysis);
 	// TODO replace the hardcoded CC with the sdb ones

--- a/librz/io/p/io_winedbg.c
+++ b/librz/io/p/io_winedbg.c
@@ -229,6 +229,7 @@ static struct winedbg_x86_32 regState(void) {
 }
 
 static char *__system(RzIO *io, RzIODesc *fd, const char *cmd) {
+	char tmpbuf[64];
 	if (!strcmp(cmd, "")) {
 		return NULL;
 	}
@@ -316,7 +317,7 @@ static char *__system(RzIO *io, RzIODesc *fd, const char *cmd) {
 	} else if (!strncmp(cmd, "dr", 2)) {
 		printcmd(io, "info reg");
 	} else if (!strncmp(cmd, "db ", 3)) {
-		free(runcmd(sdb_fmt("break *%x", rz_num_get(NULL, cmd + 3) || io->off)));
+		free(runcmd(rz_strf(tmpbuf, "break *%x", rz_num_get(NULL, cmd + 3) || io->off)));
 	} else if (!strncmp(cmd, "ds", 2)) {
 		free(runcmd("stepi"));
 	} else if (!strncmp(cmd, "dc", 2)) {

--- a/librz/syscall/syscall.c
+++ b/librz/syscall/syscall.c
@@ -348,18 +348,19 @@ RZ_API RzSyscallItem *rz_syscall_get(RzSyscall *s, int num, int swi) {
 		return NULL;
 	}
 	const char *ret, *ret2, *key;
+	char tmpbuf[64] = { 0 };
 	swi = getswi(s, swi);
 	if (swi < 16) {
-		key = sdb_fmt("%d.%d", swi, num);
+		key = rz_strf(tmpbuf, "%d.%d", swi, num);
 	} else {
-		key = sdb_fmt("0x%02x.%d", swi, num);
+		key = rz_strf(tmpbuf, "0x%02x.%d", swi, num);
 	}
 	ret = sdb_const_get(s->db, key, 0);
 	if (!ret) {
-		key = sdb_fmt("0x%02x.0x%02x", swi, num); // Workaround until Syscall SDB is fixed
+		key = rz_strf(tmpbuf, "0x%02x.0x%02x", swi, num); // Workaround until Syscall SDB is fixed
 		ret = sdb_const_get(s->db, key, 0);
 		if (!ret) {
-			key = sdb_fmt("0x%02x.%d", num, swi); // Workaround until Syscall SDB is fixed
+			key = rz_strf(tmpbuf, "0x%02x.%d", num, swi); // Workaround until Syscall SDB is fixed
 			ret = sdb_const_get(s->db, key, 0);
 			if (!ret) {
 				return NULL;

--- a/subprojects/rzgdb/src/gdbclient/core.c
+++ b/subprojects/rzgdb/src/gdbclient/core.c
@@ -157,6 +157,7 @@ int gdbr_connect(libgdbr_t *g, const char *host, int port) {
 	int i;
 	int ret = -1;
 	void *bed = NULL;
+	char tmpbuf[16];
 
 	if (!g || !host) {
 		return -1;
@@ -179,7 +180,7 @@ int gdbr_connect(libgdbr_t *g, const char *host, int port) {
 	if (*host == '/') {
 		ret = rz_socket_connect_serial(g->sock, host, port, 1);
 	} else {
-		ret = rz_socket_connect_tcp(g->sock, host, sdb_fmt("%d", port), 1);
+		ret = rz_socket_connect_tcp(g->sock, host, rz_strf(tmpbuf, "%d", port), 1);
 	}
 	rz_cons_sleep_end(bed);
 	rz_cons_break_push(gdbr_break_process, g);
@@ -929,6 +930,7 @@ end:
 int gdbr_step(libgdbr_t *g, int tid) {
 	int ret = -1;
 	char thread_id[64] = { 0 };
+	char tmpbuf[20] = { 0 };
 
 	if (!gdbr_lock_enter(g)) {
 		goto end;
@@ -936,7 +938,7 @@ int gdbr_step(libgdbr_t *g, int tid) {
 
 	if (tid <= 0 || write_thread_id(thread_id, sizeof(thread_id) - 1, g->pid, tid, g->stub_features.multiprocess) < 0) {
 		send_vcont(g, "vCont?", NULL);
-		send_vcont(g, sdb_fmt("Hc%d", tid), NULL);
+		send_vcont(g, rz_strf(tmpbuf, "Hc%d", tid), NULL);
 		ret = send_vcont(g, CMD_C_STEP, NULL);
 		goto end;
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`sdb_fmt()` is thread-unsafe, remove it.

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/1168
