### PR TITLE
Drop `-fno-strict-aliasing` flag from capstone next build

### DIFF
--- a/subprojects/capstone-next.wrap
+++ b/subprojects/capstone-next.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/capstone-engine/capstone.git
-revision = 31ea133e64cb6576524e61b734681260104d0a6f
+revision = cb2b87974d6bdc347578eddea4558802bb6a0c1b
 directory = capstone-next
 patch_directory = capstone-next
 depth = 1

--- a/subprojects/packagefiles/capstone-next/meson.build
+++ b/subprojects/packagefiles/capstone-next/meson.build
@@ -90,11 +90,6 @@ if meson.get_compiler('c').has_argument('-Wmaybe-uninitialized')
   libcapstone_c_args += '-Wno-maybe-uninitialized'
 endif
 
-# As of a128f31d20befedbf06ca9560f1bb23b5ebb3c4e, the Capstone
-# AArch64_AM_isSVEMaskOfIdenticalElements family of functions violates C strict
-# aliasing rules
-libcapstone_c_args += '-fno-strict-aliasing'
-
 libcapstone = library('capstone', cs_files,
   c_args: libcapstone_c_args,
   include_directories: capstone_includes,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

After capstone-engine/capstone@cb2b87974d6bdc347578eddea4558802bb6a0c1b, the original reason for `-fno-strict-aliasing` for the capstone next build no longer applies and therefore the flag should be dropped.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds (except the rz-bindgen build) are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #4048.
