### PR TITLE
Disable ARM hacks for Capstone 6

### DIFF
--- a/librz/asm/p/asm_arm_cs.c
+++ b/librz/asm/p/asm_arm_cs.c
@@ -7,7 +7,10 @@
 #include <capstone/capstone.h>
 #include "../arch/arm/asm-arm.h"
 #include "../arch/arm/arm_it.h"
+
+#if CS_NEXT_VERSION < 6
 #include "./asm_arm_hacks.inc"
+#endif
 
 typedef struct arm_cs_context_t {
 	RzArmITContext it;
@@ -146,10 +149,12 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	if (!buf) {
 		goto beach;
 	}
+#if CS_NEXT_VERSION < 6
 	int haa = hackyArmAsm(a, op, buf, len);
 	if (haa > 0) {
 		return haa;
 	}
+#endif
 
 	n = cs_disasm(ctx->cd, buf, RZ_MIN(4, len), a->pc, 1, &insn);
 	if (n < 1 || insn->size < 1) {

--- a/test/db/analysis/arm64
+++ b/test/db/analysis/arm64
@@ -118,10 +118,10 @@ cycles: 0
 family: sec
 --
 address: 0x100007f14
-opcode: addg x9, x8, 0x20, 0x0
+opcode: addg x9, x8, 0x20, 0
 esilcost: 0
-disasm: addg x9, x8, 0x20, 0x0
-pseudo: asm("addg x9, x8, 0x20, 0x0")
+disasm: addg x9, x8, 0x20, 0
+pseudo: asm("addg x9, x8, 0x20, 0")
 mnemonic: addg
 mask: ffffffff
 prefix: 0
@@ -149,10 +149,10 @@ ao@ 8
 EOF
 EXPECT=<<EOF
 address: 0x0
-opcode: addg x12, x8, 0x0, 0x2
+opcode: addg x12, x8, 0x200, 2
 esilcost: 0
-disasm: addg x12, x8, 0x0, 0x2
-pseudo: asm("addg x12, x8, 0x0, 0x2")
+disasm: addg x12, x8, 0x200, 2
+pseudo: asm("addg x12, x8, 0x200, 2")
 mnemonic: addg
 mask: ffffffff
 prefix: 0
@@ -166,10 +166,10 @@ cycles: 0
 family: sec
 ---
 address: 0x4
-opcode: addg x9, x8, 0x20, 0x0
+opcode: addg x9, x8, 0x20, 0
 esilcost: 0
-disasm: addg x9, x8, 0x20, 0x0
-pseudo: asm("addg x9, x8, 0x20, 0x0")
+disasm: addg x9, x8, 0x20, 0
+pseudo: asm("addg x9, x8, 0x20, 0")
 mnemonic: addg
 mask: ffffffff
 prefix: 0

--- a/test/db/asm/arm_64
+++ b/test/db/asm/arm_64
@@ -326,24 +326,24 @@ a "msr SP_EL0, x3" 034118d5
 a "msr sp_el0, x3" 034118d5
 a "cbnz w3, 0x1fffd4" a3feff35
 a "cbz x3, 0x1fffe8" 43ffffb4
-d "addg x0, sp, 0x80, 0x4" e0138891
-dE "addg x12, x8, 0x0, 0x2" 91a0090c
+d "addg x0, sp, 0x80, 4" e0138891
+dE "addg x12, x8, 0x200, 2" 91a0090c
 d "subg x0, sp, 0x20, 0xf" e03f82d1
 d "irg sp, x0" 1f10df9a
 d "irg x13, x3, x7" 6d10c79a
 d "subp x13, x7, sp" ed00df9a
 d "gmi x13, x3, x7" 6d14c79a
 d "subps x13, x3, x7" 6d00c7ba
-d "cmpp sp, x13" ff03cdba
-d "stg x13, [x3], 0x0" 6d0420d9
+d "subps xzr, sp, x13" ff03cdba
+d "stg x13, [x3], 0" 6d0420d9
 d "stg x13, [x3, 0x10]" 6d1820d9
 d "stg x13, [x3, 0x10]!" 6d1c20d9
 d "stzgm x12, [x0]" 0c0020d9
 d "ldg x13, [x3, 0x10]" 6d1060d9
-d "ldg x13, [x3, 0x0]" 6d0060d9
+d "ldg x13, [x3]" 6d0060d9
 d "stzg x13, [x3], 0x10" 6d1460d9
-d "stzg x13, [x3, 0x0]" 6d0860d9
-d "stzg x13, [x3, 0x0]!" 6d0c60d9
+d "stzg x13, [x3]" 6d0860d9
+d "stzg x13, [x3, 0]!" 6d0c60d9
 d "st2g sp, [sp], 0x20" ff27a0d9
 d "stgm x0, [x1]" 2000a0d9
 d "stz2g sp, [sp], 0x50" ff57e0d9


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

After auto-sync updates in Capstone, there is no need for those anymore. Moreover, they were implemented inefficiently, so that it leads to a small increase in performance (5-15% depending on the file).

**Test plan**

CI is green
