### PR TITLE
rizin-shell-parser: Fix build with newest tree-sitter

### DIFF
--- a/subprojects/rizin-shell-parser/src/parser.c
+++ b/subprojects/rizin-shell-parser/src/parser.c
@@ -1,4 +1,4 @@
-#include <tree_sitter/parser.h>
+#include "tree_sitter/parser.h"
 
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push

--- a/subprojects/rizin-shell-parser/src/scanner.c
+++ b/subprojects/rizin-shell-parser/src/scanner.c
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2020 ret2libc <sirmy15@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <tree_sitter/parser.h>
+#include "tree_sitter/parser.h"
 #include <ctype.h>
 #include <wctype.h>
 #include <stdio.h>


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [X] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [X] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

I was getting

```
../subprojects/rizin-shell-parser/src/scanner.c:4:10: error: 'tree_sitter/parser.h' file not found with <angled> include; use "quotes" instead
#include <tree_sitter/parser.h>
         ^~~~~~~~~~~~~~~~~~~~~~
         "tree_sitter/parser.h"
```

A bit searching revealed this: https://github.com/tree-sitter/tree-sitter/issues/2677#issuecomment-1743483770

> To answer your question, the Makefile does not install parser.h because each parser repo should use the generated parser included locally when the CLI command "tree-sitter generate" is invoked (hence why those include parser.h, to stick em in the repo)

Apparently, using angle brackets was causing `/usr/include/tree-sitter/parser.h` to be picked up until it stopped from being installed.