### PR TITLE
Fix SEP parsing crash

### DIFF
--- a/librz/bin/p/bin_xtr_sep64.c
+++ b/librz/bin/p/bin_xtr_sep64.c
@@ -186,6 +186,9 @@ static RzBinXtrData *oneshot_buffer(RzBin *bin, RzBuffer *b, int idx) {
 	if (!bin->cur->xtr_obj) {
 		bin->cur->xtr_obj = sep64_xtr_ctx_new(b);
 	}
+	if (!bin->cur->xtr_obj) {
+		return NULL;
+	}
 	RSepXtr64Ctx *ctx = bin->cur->xtr_obj;
 
 	RSepSlice64 *slice = sep64_xtr_ctx_get_slice(ctx, b, idx);
@@ -198,22 +201,22 @@ static RzBinXtrData *oneshot_buffer(RzBin *bin, RzBuffer *b, int idx) {
 
 static RzList /*<RzBinXtrData *>*/ *oneshotall_buffer(RzBin *bin, RzBuffer *b) {
 	RzBinXtrData *data = oneshot_buffer(bin, b, 0);
-	if (data) {
-		int narch = data->file_count;
-		RzList *res = rz_list_newf(rz_bin_xtrdata_free);
-		if (!res) {
-			rz_bin_xtrdata_free(data);
-			return NULL;
-		}
-		rz_list_append(res, data);
-		int i;
-		for (i = 1; data && i < narch; i++) {
-			data = oneshot_buffer(bin, b, i);
-			rz_list_append(res, data);
-		}
-		return res;
+	if (!data) {
+		return NULL;
 	}
-	return NULL;
+	int narch = data->file_count;
+	RzList *res = rz_list_newf(rz_bin_xtrdata_free);
+	if (!res) {
+		rz_bin_xtrdata_free(data);
+		return NULL;
+	}
+	rz_list_append(res, data);
+	int i;
+	for (i = 1; data && i < narch; i++) {
+		data = oneshot_buffer(bin, b, i);
+		rz_list_append(res, data);
+	}
+	return res;
 }
 
 static RSepXtr64Ctx *sep64_xtr_ctx_new(RzBuffer *buf) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes the following crash:
```
ℤ lldb $(which rizin)
(lldb) target create "/Users/user/.local/bin/rizin"
Current executable set to '/Users/user/.local/bin/rizin' (arm64).
(lldb) run sepfw
Process 32383 launched: '/Users/user/.local/bin/rizin' (arm64)
Process 32383 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x0000000100e42fac librz_bin.0.7.dylib`oneshot_buffer [inlined] sep64_xtr_ctx_get_slice(ctx=0x0000000000000000, whole=0x0000600001b1da40, idx=0) at bin_xtr_sep64.c:285:18 [opt]
   282 	}
   283
   284 	static RSepSlice64 *sep64_xtr_ctx_get_slice(RSepXtr64Ctx *ctx, RzBuffer *whole, int idx) {
-> 285 		if (idx >= ctx->hdr->n_apps + 3) {
   286 			return NULL;
   287 		}
   288
Target 0: (rizin) stopped.
warning: librz_bin.0.7.dylib was compiled with optimization - stepping may behave oddly; variables may not be available.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x0000000100e42fac librz_bin.0.7.dylib`oneshot_buffer [inlined] sep64_xtr_ctx_get_slice(ctx=0x0000000000000000, whole=0x0000600001b1da40, idx=0) at bin_xtr_sep64.c:285:18 [opt]
    frame #1: 0x0000000100e42fac librz_bin.0.7.dylib`oneshot_buffer(bin=0x000000012d7047c0, b=0x0000600001b1da40, idx=0) at bin_xtr_sep64.c:191:23 [opt]
    frame #2: 0x0000000100e432e8 librz_bin.0.7.dylib`oneshotall_buffer(bin=0x000000012d7047c0, b=0x0000600001b1da40) at bin_xtr_sep64.c:200:23 [opt]
    frame #3: 0x0000000100e06c50 librz_bin.0.7.dylib`rz_bin_file_xtr_load_buffer(bin=0x000000012d7047c0, xtr=0x0000000100f6d040, filename="sepfw", buf=0x0000600001b1da40, obj_opts=0x000000016fdfeab8, idx=<unavailable>, fd=3) at bfile.c:305:18 [opt]
    frame #4: 0x0000000100e08cdc librz_bin.0.7.dylib`rz_bin_open_buf(bin=0x000000012d7047c0, buf=0x0000600001b1da40, opt=0x000000016fdfeab0) at bin.c:279:11 [opt]
    frame #5: 0x0000000100e08a00 librz_bin.0.7.dylib`rz_bin_open_io(bin=0x000000012d7047c0, opt=0x000000016fdfeab0) at bin.c:347:18 [opt]
    frame #6: 0x00000001013701b0 librz_core.0.7.dylib`rz_core_bin_load [inlined] core_file_do_load_for_io_plugin(r=0x000000012d809a00, baseaddr=18446744073709551615, loadaddr=0) at cfile.c:731:23 [opt]
    frame #7: 0x000000010137016c librz_core.0.7.dylib`rz_core_bin_load(r=0x000000012d809a00, filenameuri="sepfw", baddr=18446744073709551615) at cfile.c:980:4 [opt]
    frame #8: 0x000000010049ff6c librz_main.0.7.dylib`rz_main_rizin(argc=<unavailable>, argv=0x000000016fdfefe0) at rizin.c:1159:14 [opt]
    frame #9: 0x00000001897650e0 dyld`start + 2360
(lldb) p ctx
(RSepXtr64Ctx *) $0 = NULL
(lldb) frame select 1
frame #1: 0x0000000100e42fac librz_bin.0.7.dylib`oneshot_buffer(bin=0x000000012d7047c0, b=0x0000600001b1da40, idx=0) at bin_xtr_sep64.c:191:23 [opt]
   188 		}
   189 		RSepXtr64Ctx *ctx = bin->cur->xtr_obj;
   190
-> 191 		RSepSlice64 *slice = sep64_xtr_ctx_get_slice(ctx, b, idx);
   192 		RzBinXtrData *res = rz_bin_xtrdata_new(slice->buf, slice->nominal_offset, slice->total_size, 3 + ctx->hdr->n_apps, slice->meta);
   193
   194 		rz_buf_free(slice->buf);
(lldb) p bin->cur
(RzBinFile *) $1 = 0x0000600003e0c4d0
(lldb) p bin->cur->xtr_obj
(void *) $2 = 0x0000000000000000
````
**Test plan**

CI is green