### PR TITLE
core/tui: use API instead of command calls

### DIFF
--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -2469,19 +2469,9 @@ static bool cmd_pxr(RzCore *core, ut64 at, int len, RzCmdStateOutput *state, int
 			rz_strbuf_appendf(sb, "f pxr.%" PFMT64x " @ 0x%" PFMT64x "\n", val, addr);
 		}
 	} else if (mode == RZ_OUTPUT_MODE_STANDARD) {
-		const int ocols = core->print->cols;
-		int bitsize = core->rasm->bits;
-		/* Thumb is 16bit arm but handles 32bit data */
-		if (bitsize == 16) {
-			bitsize = 32;
-		}
-		core->print->cols = 1;
-		core->print->flags |= RZ_PRINT_FLAGS_REFS;
-		char *hexdump_str = rz_print_hexdump_str(core->print, core->offset, core->block, RZ_MIN(len, core->blocksize), wordsize * 8, bitsize / 8, 1);
+		char *hexdump_str = rz_core_print_hexdump_refs(core, core->offset, len, wordsize);
 		rz_strbuf_append(sb, hexdump_str);
 		free(hexdump_str);
-		core->print->flags &= ~RZ_PRINT_FLAGS_REFS;
-		core->print->cols = ocols;
 	} else {
 		rz_warn_if_reached();
 		rz_strbuf_free(sb);

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -161,7 +161,9 @@ RZ_IPI bool rz_core_print_hexdump_diff(RZ_NONNULL RzCore *core, ut64 aa, ut64 ba
 RZ_IPI bool rz_core_print_dump(RZ_NONNULL RzCore *core, RzOutputMode mode, ut64 addr, ut8 n, int len, RzCorePrintFormatType format);
 RZ_IPI bool rz_core_print_hexdump_or_hexdiff(RZ_NONNULL RzCore *core, RzOutputMode mode, ut64 addr, int len, bool use_comments);
 RZ_IPI bool rz_core_print_hexdump_byline(RZ_NONNULL RzCore *core, bool hex_offset, ut64 addr, int len, ut8 size);
+RZ_IPI RZ_OWN char *rz_core_print_hexdump_refs(RZ_NONNULL RzCore *core, ut64 address, size_t len, int wordsize);
 RZ_IPI const char *rz_core_print_stack_command(RZ_NONNULL RzCore *core);
+RZ_IPI RZ_OWN char *rz_core_print_cons_disassembly(RzCore *core, ut64 addr, ut32 byte_len, ut32 inst_len);
 
 /* cmd_seek.c */
 RZ_IPI bool rz_core_seek_to_register(RzCore *core, const char *input, bool is_silent);

--- a/librz/core/tui/modes.c
+++ b/librz/core/tui/modes.c
@@ -7,12 +7,13 @@
 #include "../core_private.h"
 #include "modes.h"
 
+/* Modes used in the simple visual mode triggered by "V" hotkey */
 const char *printfmtSingle[NPF] = {
 	"xc", // HEXDUMP
 	"pd $r", // ASSEMBLY
 	("pxw 64@r:SP;" CMD_REGISTERS ";pd $r"), // DEBUGGER
 	"prc", // OVERVIEW
-	"pss", // PC//  copypasteable views
+	"pxi", // HexII format, for better visualization
 };
 
 const char *printfmtColumns[NPF] = {

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -72,7 +72,7 @@ typedef int (*RzStrRangeCallback)(void *, int);
 #define rz_str_array(x, y)   ((y >= 0 && y < (sizeof(x) / sizeof(*x))) ? x[y] : "")
 RZ_API const char *rz_str_enc_as_string(RzStrEnc enc);
 RZ_API RzStrEnc rz_str_enc_string_as_type(RZ_NULLABLE const char *enc);
-RZ_API char *rz_str_repeat(const char *ch, int sz);
+RZ_API RZ_OWN char *rz_str_repeat(const char *str, ut16 times);
 RZ_API RZ_OWN char *rz_str_pad(const char ch, int len);
 RZ_API const char *rz_str_rstr(const char *base, const char *p);
 RZ_API const char *rz_strstr_ansi(RZ_NONNULL const char *a, RZ_NONNULL const char *b, bool icase);

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -3286,17 +3286,18 @@ RZ_API RZ_OWN char *rz_str_pad(const char ch, int sz) {
 	return pad;
 }
 
-RZ_API char *rz_str_repeat(const char *ch, int sz) {
+/**
+ * \brief Repeats specified \p str string \p times
+ */
+RZ_API RZ_OWN char *rz_str_repeat(const char *str, ut16 times) {
+	rz_return_val_if_fail(str, NULL);
 	int i;
-	if (sz < 0) {
-		sz = 0;
-	}
-	if (sz == 0) {
+	if (times == 0) {
 		return strdup("");
 	}
-	RzStrBuf *buf = rz_strbuf_new(ch);
-	for (i = 1; i < sz; i++) {
-		rz_strbuf_append(buf, ch);
+	RzStrBuf *buf = rz_strbuf_new(str);
+	for (i = 1; i < times; i++) {
+		rz_strbuf_append(buf, str);
 	}
 	return rz_strbuf_drain(buf);
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

File used for examples is `rizin-testbins/elf/float_ex1/float_ex1_arm`, function `sym.imp.malloc` (0x444).

- Replace some command calls with the API
- Change the last default visual mode (`V` then press `p` multiple times) from `pss` to `pxi` (compact HexII format by Ange Albertini) since the `pss` output isn't very useful for such a common mode. Anyone can still run the command, if necessary

**Was**

<img width="709" alt="Screenshot 2024-02-08 at 7 16 48 PM" src="https://github.com/rizinorg/rizin/assets/203261/661bb51d-0580-420e-94fd-66db6156bc92">


**Became**

<img width="550" alt="Screenshot 2024-02-08 at 7 07 39 PM" src="https://github.com/rizinorg/rizin/assets/203261/f8a04aaa-ec67-4fb1-a399-b70e470ddd8a">

- Support for UTF-8 mode (Unicode characters) in the xrefs window. One can reach it by pressing `x` in the visual mode for a function that has one or more **XREF**s, then rotate modes using `p` or `P` keys

<img width="769" alt="Screenshot 2024-02-08 at 7 11 09 PM" src="https://github.com/rizinorg/rizin/assets/203261/c4ab9700-1b55-4d15-a4d0-386b4af9ad89">

<img width="879" alt="Screenshot 2024-02-08 at 7 11 35 PM" src="https://github.com/rizinorg/rizin/assets/203261/dcbe2a83-b18c-42a5-af84-8c0b2ef78808">

<img width="758" alt="Screenshot 2024-02-08 at 7 11 56 PM" src="https://github.com/rizinorg/rizin/assets/203261/2976213b-c666-4579-915e-46cbcca24966">

<img width="752" alt="Screenshot 2024-02-08 at 7 12 20 PM" src="https://github.com/rizinorg/rizin/assets/203261/febf96e8-900f-45bf-85ab-e3dcd09c4dd1">


- Added new util function `rz_str_concat(str1, str2)` for easy string concatenation

**Test plan**

- CI is green
- Try playing with the xrefs window

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/382
Partially addresses https://github.com/rizinorg/rizin/issues/3842