### PR TITLE
Add user pointer to RzListComparator

### DIFF
--- a/librz/analysis/fcn.c
+++ b/librz/analysis/fcn.c
@@ -2537,7 +2537,7 @@ RZ_API RZ_BORROW RzAnalysisVar *rz_analysis_function_get_arg_idx(RZ_NONNULL RzAn
 	return rz_pvector_at(args, index);
 }
 
-static int typecmp(const void *a, const void *b) {
+static int typecmp(const void *a, const void *b, void *user) {
 	const RzType *t1 = a;
 	const RzType *t2 = b;
 	return !rz_types_equal(t1, t2);
@@ -2555,7 +2555,7 @@ RZ_API RZ_OWN RzList /*<RzType *>*/ *rz_analysis_types_from_fcn(RzAnalysis *anal
 		RzAnalysisVar *var = *it;
 		rz_list_append(type_used, var->type);
 	}
-	RzList *uniq = rz_list_uniq(type_used, typecmp);
+	RzList *uniq = rz_list_uniq(type_used, typecmp, NULL);
 	rz_list_free(type_used);
 	return uniq;
 }

--- a/librz/analysis/reflines.c
+++ b/librz/analysis/reflines.c
@@ -17,11 +17,11 @@ typedef struct refline_end {
 	RzAnalysisRefline *r;
 } ReflineEnd;
 
-static int cmp_asc(const struct refline_end *a, const struct refline_end *b) {
+static int cmp_asc(const struct refline_end *a, const struct refline_end *b, void *user) {
 	return (a->val > b->val) - (a->val < b->val);
 }
 
-static int cmp_by_ref_lvl(const RzAnalysisRefline *a, const RzAnalysisRefline *b) {
+static int cmp_by_ref_lvl(const RzAnalysisRefline *a, const RzAnalysisRefline *b, void *user) {
 	return (a->level < b->level) - (a->level > b->level);
 }
 
@@ -55,7 +55,7 @@ static bool add_refline(RzList /*<RzAnalysisRefline *>*/ *list, RzList /*<Reflin
 		free(item);
 		return false;
 	}
-	rz_list_add_sorted(sten, re1, (RzListComparator)cmp_asc);
+	rz_list_add_sorted(sten, re1, (RzListComparator)cmp_asc, NULL);
 
 	re2 = refline_end_new(item->to, false, item);
 	if (!re2) {
@@ -63,7 +63,7 @@ static bool add_refline(RzList /*<RzAnalysisRefline *>*/ *list, RzList /*<Reflin
 		free(item);
 		return false;
 	}
-	rz_list_add_sorted(sten, re2, (RzListComparator)cmp_asc);
+	rz_list_add_sorted(sten, re2, (RzListComparator)cmp_asc, NULL);
 	return true;
 }
 
@@ -371,7 +371,7 @@ RZ_API RzAnalysisRefStr *rz_analysis_reflines_str(void *_core, ut64 addr, int op
 			return NULL;
 		}
 		if (in_refline(addr, ref) && refline_kept(ref, middle_after, addr)) {
-			rz_list_add_sorted(lvls, (void *)ref, (RzListComparator)cmp_by_ref_lvl);
+			rz_list_add_sorted(lvls, (void *)ref, (RzListComparator)cmp_by_ref_lvl, NULL);
 		}
 	}
 	b = rz_buf_new_with_bytes(NULL, 0);

--- a/librz/analysis/var.c
+++ b/librz/analysis/var.c
@@ -1594,7 +1594,7 @@ static int regvar_comparator(const RzAnalysisVar *a, const RzAnalysisVar *b) {
 	return (a && b) ? (a->argnum > b->argnum) - (a->argnum < b->argnum) : 0;
 }
 
-static int var_comparator(const RzAnalysisVar *a, const RzAnalysisVar *b) {
+static int var_comparator(const RzAnalysisVar *a, const RzAnalysisVar *b, void *user) {
 	if (a->origin.kind == RZ_ANALYSIS_VAR_ORIGIN_DWARF && b->origin.kind == RZ_ANALYSIS_VAR_ORIGIN_DWARF) {
 		return (int)a->origin.dw_var->offset - b->origin.dw_var->offset;
 	}
@@ -1630,8 +1630,8 @@ RZ_API void rz_analysis_fcn_vars_cache_init(
 			rz_list_append(cache->arg_vars, var);
 		}
 	}
-	rz_list_sort(cache->sorted_vars, (RzListComparator)var_comparator);
-	rz_list_sort(cache->arg_vars, (RzListComparator)var_comparator);
+	rz_list_sort(cache->sorted_vars, (RzListComparator)var_comparator, NULL);
+	rz_list_sort(cache->arg_vars, (RzListComparator)var_comparator, NULL);
 }
 
 /**

--- a/librz/analysis/xrefs.c
+++ b/librz/analysis/xrefs.c
@@ -63,7 +63,7 @@ static bool mylistrefs_cb(void *list, const ut64 k, const void *v) {
 	return true;
 }
 
-static int ref_cmp(const RzAnalysisXRef *a, const RzAnalysisXRef *b) {
+static int ref_cmp(const RzAnalysisXRef *a, const RzAnalysisXRef *b, void *user) {
 	if (a->from < b->from) {
 		return -1;
 	}
@@ -80,7 +80,7 @@ static int ref_cmp(const RzAnalysisXRef *a, const RzAnalysisXRef *b) {
 }
 
 static void sortxrefs(RzList /*<RzAnalysisXRef *>*/ *list) {
-	rz_list_sort(list, (RzListComparator)ref_cmp);
+	rz_list_sort(list, (RzListComparator)ref_cmp, NULL);
 }
 
 static void listxrefs(HtUP *m, ut64 addr, RzList /*<RzAnalysisXRef *>*/ *list) {

--- a/librz/bin/bobj.c
+++ b/librz/bin/bobj.c
@@ -273,8 +273,16 @@ RZ_IPI int rz_bin_compare_class_field(RzBinClassField *a, RzBinClassField *b) {
 	return 0;
 }
 
+static int bin_compare_method(RzBinSymbol *a, RzBinSymbol *b, void *user) {
+	return rz_bin_compare_method(a, b);
+}
+
 static int bin_compare_class(RzBinClass *a, RzBinClass *b, void *user) {
 	return rz_bin_compare_class(a, b);
+}
+
+static int bin_compare_class_field(RzBinClassField *a, RzBinClassField *b, void *user) {
+	return rz_bin_compare_class_field(a, b);
 }
 
 /**
@@ -387,9 +395,9 @@ RZ_API RZ_BORROW RzBinSymbol *rz_bin_object_add_method(RZ_NONNULL RzBinObject *o
 	symbol->classname = rz_str_dup(klass);
 
 	if (!c->methods->sorted) {
-		rz_list_sort(c->methods, (RzListComparator)rz_bin_compare_method);
+		rz_list_sort(c->methods, (RzListComparator)bin_compare_method, NULL);
 	}
-	rz_list_add_sorted(c->methods, symbol, (RzListComparator)rz_bin_compare_method);
+	rz_list_add_sorted(c->methods, symbol, (RzListComparator)bin_compare_method, NULL);
 
 	char *key = rz_str_newf(RZ_BIN_FMT_CLASS_HT_GLUE, klass, method);
 	if (key) {
@@ -465,9 +473,9 @@ RZ_API RZ_BORROW RzBinClassField *rz_bin_object_add_field(RZ_NONNULL RzBinObject
 	}
 
 	if (!c->fields->sorted) {
-		rz_list_sort(c->fields, (RzListComparator)rz_bin_compare_class_field);
+		rz_list_sort(c->fields, (RzListComparator)bin_compare_class_field, NULL);
 	}
-	rz_list_add_sorted(c->fields, field, (RzListComparator)rz_bin_compare_class_field);
+	rz_list_add_sorted(c->fields, field, (RzListComparator)bin_compare_class_field, NULL);
 	char *key = rz_str_newf(RZ_BIN_FMT_CLASS_HT_GLUE, klass, name);
 	if (key) {
 		ht_pp_insert(o->glue_to_class_field, key, field);

--- a/librz/bin/bobj_process_class.c
+++ b/librz/bin/bobj_process_class.c
@@ -34,6 +34,14 @@ static void process_class_field(RzBinObject *o, RzBinClassField *field) {
 	free(key);
 }
 
+static int bin_compare_method(RzBinSymbol *a, RzBinSymbol *b, void *user) {
+	return rz_bin_compare_method(a, b);
+}
+
+static int bin_compare_class_field(RzBinClassField *a, RzBinClassField *b, void *user) {
+	return rz_bin_compare_class_field(a, b);
+}
+
 static void process_handle_class(RzBinObject *o, RzBinClass *klass) {
 	if (!klass->name) {
 		klass->name = rz_str_dup("unknown_class");
@@ -57,8 +65,8 @@ static void process_handle_class(RzBinObject *o, RzBinClass *klass) {
 		process_class_field(o, field);
 	}
 
-	rz_list_sort(klass->methods, (RzListComparator)rz_bin_compare_method);
-	rz_list_sort(klass->fields, (RzListComparator)rz_bin_compare_class_field);
+	rz_list_sort(klass->methods, (RzListComparator)bin_compare_method, NULL);
+	rz_list_sort(klass->fields, (RzListComparator)bin_compare_class_field, NULL);
 }
 
 RZ_IPI void rz_bin_set_and_process_classes(RzBinFile *bf, RzBinObject *o) {

--- a/librz/bin/format/mach0/dyldcache.c
+++ b/librz/bin/format/mach0/dyldcache.c
@@ -559,7 +559,7 @@ static char *get_lib_name(RzBuffer *cache_buf, cache_img_t *img) {
 	return strdup("FAIL");
 }
 
-static int string_contains(const void *a, const void *b) {
+static int string_contains(const void *a, const void *b, void *user) {
 	return !strstr((const char *)a, (const char *)b);
 }
 
@@ -697,7 +697,7 @@ static RzList /*<RzDyldBinImage *>*/ *create_cache_bins(RzDyldCache *cache) {
 				if (strstr(lib_name, "libobjc.A.dylib")) {
 					deps[j]++;
 				}
-				if (!rz_list_find(target_lib_names, lib_name, string_contains)) {
+				if (!rz_list_find(target_lib_names, lib_name, string_contains, NULL)) {
 					RZ_FREE(lib_name);
 					continue;
 				}

--- a/librz/bin/format/mach0/mach0_relocs.c
+++ b/librz/bin/format/mach0/mach0_relocs.c
@@ -41,7 +41,7 @@ static void read_relocation_info(struct relocation_info *dst, ut8 *src, bool big
 	}
 }
 
-static int reloc_comparator(struct reloc_t *a, struct reloc_t *b) {
+static int reloc_comparator(struct reloc_t *a, struct reloc_t *b, void *user) {
 	return a->addr - b->addr;
 }
 

--- a/librz/bin/format/objc/mach0_classes.c
+++ b/librz/bin/format/objc/mach0_classes.c
@@ -190,7 +190,7 @@ static void copy_sym_name_with_namespace(char *class_name, char *read_name, RzBi
 	sym->name = strdup(read_name);
 }
 
-static int sort_by_offset(const void *_a, const void *_b) {
+static int sort_by_offset(const void *_a, const void *_b, void *user) {
 	RzBinClassField *a = (RzBinClassField *)_a;
 	RzBinClassField *b = (RzBinClassField *)_b;
 	return a->paddr - b->paddr;
@@ -348,7 +348,7 @@ static void get_ivar_list_t(mach0_ut p, RzBinFile *bf, RzBuffer *buf, RzBinClass
 		offset += sizeof(struct MACH0_(SIVar));
 	}
 	if (!rz_list_empty(klass->fields)) {
-		rz_list_sort(klass->fields, sort_by_offset);
+		rz_list_sort(klass->fields, sort_by_offset, NULL);
 	}
 	field = rz_bin_class_field_new(UT64_MAX, UT64_MAX, "isa", klass->name, NULL, "struct objc_class *");
 	rz_list_prepend(klass->fields, field);

--- a/librz/bin/p/bin_wasm.c
+++ b/librz/bin/p/bin_wasm.c
@@ -17,7 +17,7 @@ static bool check_buffer(RzBuffer *rbuf) {
 	return rbuf && rz_buf_read_at(rbuf, 0, buf, 4) == 4 && !memcmp(buf, RZ_BIN_WASM_MAGIC_BYTES, 4);
 }
 
-static bool find_export(const ut32 *p, const RzBinWasmExportEntry *q) {
+static bool find_export(const ut32 *p, const RzBinWasmExportEntry *q, void *user) {
 	if (q->kind != RZ_BIN_WASM_EXTERNALKIND_Function) {
 		return true;
 	}
@@ -190,7 +190,7 @@ static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
 		if (fcn_name) {
 			ptr->name = strdup(fcn_name);
 
-			is_exp = rz_list_find(exports, &fcn_idx, (RzListComparator)find_export);
+			is_exp = rz_list_find(exports, &fcn_idx, (RzListComparator)find_export, NULL);
 			if (is_exp) {
 				ptr->bind = RZ_BIN_BIND_GLOBAL_STR;
 			}

--- a/librz/bin/p/bin_xnu_kernelcache.c
+++ b/librz/bin/p/bin_xnu_kernelcache.c
@@ -110,7 +110,7 @@ static int prot2perm(int x);
 
 static void rz_kext_free(RKext *kext);
 static void rz_kext_fill_text_range(RKext *kext);
-static int kexts_sort_vaddr_func(const void *a, const void *b);
+static int kexts_sort_vaddr_func(const void *a, const void *b, void *user);
 static struct MACH0_(obj_t) * create_kext_mach0(RzXNUKernelCacheObj *obj, RKext *kext);
 static struct MACH0_(obj_t) * create_kext_shared_mach0(RzXNUKernelCacheObj *obj, RKext *kext);
 
@@ -382,7 +382,7 @@ static RzList /*<RKext *>*/ *filter_kexts(RzXNUKernelCacheObj *obj) {
 
 	if (!is_sorted) {
 		eprintf("SORTING KEXTs...\n");
-		rz_list_sort(kexts, kexts_sort_vaddr_func);
+		rz_list_sort(kexts, kexts_sort_vaddr_func, NULL);
 	}
 	return kexts;
 }
@@ -676,7 +676,7 @@ static void rz_kext_fill_text_range(RKext *kext) {
 	RZ_FREE(sections);
 }
 
-static int kexts_sort_vaddr_func(const void *a, const void *b) {
+static int kexts_sort_vaddr_func(const void *a, const void *b, void *user) {
 	RKext *A = (RKext *)a;
 	RKext *B = (RKext *)b;
 	int vaddr_compare = A->vaddr - B->vaddr;

--- a/librz/config/config.c
+++ b/librz/config/config.c
@@ -469,12 +469,12 @@ beach:
 	return node;
 }
 
-static int cmp(RzConfigNode *a, RzConfigNode *b) {
+static int cmp(RzConfigNode *a, RzConfigNode *b, void *user) {
 	return strcmp(a->name, b->name);
 }
 
 RZ_API void rz_config_lock(RzConfig *cfg, int l) {
-	rz_list_sort(cfg->nodes, (RzListComparator)cmp);
+	rz_list_sort(cfg->nodes, (RzListComparator)cmp, NULL);
 	cfg->lock = l;
 }
 

--- a/librz/config/hold.c
+++ b/librz/config/hold.c
@@ -14,13 +14,13 @@ static void rz_config_hold_num_free(RzConfigHoldNum *hc) {
 	free(hc);
 }
 
-static int key_cmp_hold_s(const void *a, const void *b) {
+static int key_cmp_hold_s(const void *a, const void *b, void *user) {
 	const char *a_s = (const char *)a;
 	const RzConfigHoldChar *b_s = (const RzConfigHoldChar *)b;
 	return strcmp(a_s, b_s->key);
 }
 
-static int key_cmp_hold_i(const void *a, const void *b) {
+static int key_cmp_hold_i(const void *a, const void *b, void *user) {
 	const char *a_s = (const char *)a;
 	const RzConfigHoldNum *b_s = (const RzConfigHoldNum *)b;
 	return strcmp(a_s, b_s->key);
@@ -49,7 +49,7 @@ RZ_API bool rz_config_hold_s(RzConfigHold *h, ...) {
 		}
 	}
 	while ((key = va_arg(ap, char *))) {
-		if (rz_list_find(h->list_char, key, key_cmp_hold_s)) {
+		if (rz_list_find(h->list_char, key, key_cmp_hold_s, NULL)) {
 			continue;
 		}
 		const char *val = rz_config_get(h->cfg, key);
@@ -92,7 +92,7 @@ RZ_API bool rz_config_hold_i(RzConfigHold *h, ...) {
 	}
 	va_start(ap, h);
 	while ((key = va_arg(ap, char *))) {
-		if (rz_list_find(h->list_num, key, key_cmp_hold_i)) {
+		if (rz_list_find(h->list_num, key, key_cmp_hold_i, NULL)) {
 			continue;
 		}
 		RzConfigHoldNum *hc = RZ_NEW0(RzConfigHoldNum);

--- a/librz/cons/grep.c
+++ b/librz/cons/grep.c
@@ -445,7 +445,7 @@ RZ_API void rz_cons_grep_process(char *grep) {
 	}
 }
 
-static int cmp(const void *a, const void *b) {
+static int cmp(const void *a, const void *b, void *user) {
 	char *da = NULL;
 	char *db = NULL;
 	const char *ca = rz_str_trim_head_ro(a);
@@ -752,7 +752,7 @@ RZ_API void rz_cons_grepbuf(void) {
 		char *ptr = cons->context->buffer;
 		char *str;
 		sorted_column = grep->sort;
-		rz_list_sort(sorted_lines, cmp);
+		rz_list_sort(sorted_lines, cmp, NULL);
 		if (grep->sort_invert) {
 			rz_list_reverse(sorted_lines);
 		}

--- a/librz/core/analysis_tp.c
+++ b/librz/core/analysis_tp.c
@@ -525,7 +525,7 @@ static void type_match(RzCore *core, char *fcn_name, ut64 addr, ut64 baddr, cons
 	rz_cons_break_pop();
 }
 
-static int bb_cmpaddr(const void *_a, const void *_b) {
+static int bb_cmpaddr(const void *_a, const void *_b, void *user) {
 	const RzAnalysisBlock *a = _a, *b = _b;
 	return a->addr > b->addr ? 1 : (a->addr < b->addr ? -1 : 0);
 }
@@ -870,7 +870,7 @@ RZ_API void rz_core_analysis_type_match(RzCore *core, RzAnalysisFunction *fcn, H
 		goto out_function;
 	}
 	rz_cons_break_push(NULL, NULL);
-	rz_list_sort(fcn->bbs, bb_cmpaddr);
+	rz_list_sort(fcn->bbs, bb_cmpaddr, NULL);
 	// TODO: The algorithm can be more accurate if blocks are followed by their jmp/fail, not just by address
 	RzAnalysisBlock *bb;
 	rz_list_foreach (fcn->bbs, it, bb) {

--- a/librz/core/basefind.c
+++ b/librz/core/basefind.c
@@ -202,7 +202,7 @@ static bool basefind_pointer_map_iter(BaseFindData *bfd, const ut64 address, con
 	return true;
 }
 
-static int basefind_score_compare(const RzBaseFindScore *a, const RzBaseFindScore *b) {
+static int basefind_score_compare(const RzBaseFindScore *a, const RzBaseFindScore *b, void *user) {
 	if (b->score == a->score) {
 		if (b->candidate == a->candidate) {
 			return 0;
@@ -469,7 +469,7 @@ RZ_API RZ_OWN RzList /*<RzBaseFindScore *>*/ *rz_basefind(RZ_NONNULL RzCore *cor
 		}
 	}
 
-	rz_list_sort(scores, (RzListComparator)basefind_score_compare);
+	rz_list_sort(scores, (RzListComparator)basefind_score_compare, NULL);
 
 rz_basefind_end:
 	if (pool) {

--- a/librz/core/casm.c
+++ b/librz/core/casm.c
@@ -15,7 +15,7 @@ static int is_addr_in_range(ut64 start, ut64 end, ut64 start_range, ut64 end_ran
 static void add_hit_to_sorted_hits(RzList /*<RzCoreAsmHit *>*/ *hits, ut64 addr, int len, ut8 is_valid);
 static int prune_hits_in_addr_range(RzList /*<RzCoreAsmHit *>*/ *hits, ut64 addr, ut64 len, ut8 is_valid);
 
-static int rcoreasm_address_comparator(RzCoreAsmHit *a, RzCoreAsmHit *b) {
+static int coreasm_address_comparator(RzCoreAsmHit *a, RzCoreAsmHit *b, void *user) {
 	if (a->addr == b->addr) {
 		return 0;
 	}
@@ -425,7 +425,7 @@ static void add_hit_to_sorted_hits(RzList /*<RzCoreAsmHit *>*/ *hits, ut64 addr,
 		hit->len = len;
 		hit->valid = is_valid;
 		hit->code = NULL;
-		rz_list_add_sorted(hits, hit, ((RzListComparator)rcoreasm_address_comparator));
+		rz_list_add_sorted(hits, hit, ((RzListComparator)coreasm_address_comparator), NULL);
 	}
 }
 
@@ -484,7 +484,7 @@ static RzCoreAsmHit *find_addr(RzList /*<RzCoreAsmHit *>*/ *hits, ut64 addr) {
 	RzListIter *addr_iter = NULL;
 	RzCoreAsmHit dummy_value;
 	dummy_value.addr = addr;
-	addr_iter = rz_list_find(hits, &dummy_value, ((RzListComparator)rcoreasm_address_comparator));
+	addr_iter = rz_list_find(hits, &dummy_value, ((RzListComparator)coreasm_address_comparator), NULL);
 	return rz_list_iter_get_data(addr_iter);
 }
 
@@ -529,7 +529,7 @@ static int handle_forward_disassemble(RzCore *core, RzList /*<RzCoreAsmHit *>*/ 
 			prune_results = prune_hits_in_addr_range(hits, temp_instr_addr, temp_instr_len, is_valid);
 			add_hit_to_sorted_hits(hits, temp_instr_addr, temp_instr_len, is_valid);
 			if (prune_results) {
-				rz_list_add_sorted(hits, hit, ((RzListComparator)rcoreasm_address_comparator));
+				rz_list_add_sorted(hits, hit, ((RzListComparator)coreasm_address_comparator), NULL);
 				RZ_LOG_DEBUG("Pruned %u hits from list in fwd sweep.\n", prune_results);
 			} else {
 				RZ_FREE(hit);
@@ -715,7 +715,7 @@ static RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_back_disassemble_all(RzCore *cor
 		hit->addr = current_instr_addr;
 		hit->len = current_instr_len;
 		hit->code = NULL;
-		rz_list_add_sorted(hits, hit, ((RzListComparator)rcoreasm_address_comparator));
+		rz_list_add_sorted(hits, hit, ((RzListComparator)coreasm_address_comparator), NULL);
 
 		current_buf_pos--;
 		current_instr_addr--;

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -48,11 +48,11 @@ static void print_node_options(RzConfigNode *node) {
 	}
 }
 
-static int compareName(const RzAnalysisFunction *a, const RzAnalysisFunction *b) {
+static int compareName(const RzAnalysisFunction *a, const RzAnalysisFunction *b, void *user) {
 	return (a && b && a->name && b->name ? strcmp(a->name, b->name) : 0);
 }
 
-static int compareNameLen(const RzAnalysisFunction *a, const RzAnalysisFunction *b) {
+static int compareNameLen(const RzAnalysisFunction *a, const RzAnalysisFunction *b, void *user) {
 	size_t la, lb;
 	if (!a || !b || !a->name || !b->name) {
 		return 0;
@@ -62,11 +62,11 @@ static int compareNameLen(const RzAnalysisFunction *a, const RzAnalysisFunction 
 	return (la > lb) - (la < lb);
 }
 
-static int compareAddress(const RzAnalysisFunction *a, const RzAnalysisFunction *b) {
+static int compareAddress(const RzAnalysisFunction *a, const RzAnalysisFunction *b, void *user) {
 	return (a && b && a->addr && b->addr ? (a->addr > b->addr) - (a->addr < b->addr) : 0);
 }
 
-static int compareSize(const RzAnalysisFunction *a, const RzAnalysisFunction *b) {
+static int compareSize(const RzAnalysisFunction *a, const RzAnalysisFunction *b, void *user) {
 	ut64 sa, sb;
 	// return a && b && a->_size < b->_size;
 	if (!a || !b) {
@@ -3839,11 +3839,11 @@ RZ_API RZ_OWN RzList /*<char *>*/ *rz_core_config_in_space(RZ_NONNULL RzCore *co
 		}
 
 		if (RZ_STR_ISNOTEMPTY(space)) {
-			if (0 == strcmp(name, space) && dot && !rz_list_find(list, dot + 1, (RzListComparator)strcmp)) {
+			if (0 == strcmp(name, space) && dot && !rz_list_find(list, dot + 1, (RzListComparator)strcmp, NULL)) {
 				rz_list_append(list, strdup(dot + 1));
 			}
 		} else {
-			if (!rz_list_find(list, name, (RzListComparator)strcmp)) {
+			if (!rz_list_find(list, name, (RzListComparator)strcmp, NULL)) {
 				rz_list_append(list, strdup(name));
 			}
 		}

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -532,7 +532,7 @@ RZ_API void rz_core_debug_map_print(RzCore *core, ut64 addr, RzCmdStateOutput *s
 	rz_cmd_state_output_array_end(state);
 }
 
-static int cmp(const void *a, const void *b) {
+static int cmp(const void *a, const void *b, void *user) {
 	RzDebugMap *ma = (RzDebugMap *)a;
 	RzDebugMap *mb = (RzDebugMap *)b;
 	return ma->addr - mb->addr;
@@ -580,7 +580,7 @@ static void print_debug_maps_ascii_art(RzDebug *dbg, RzList /*<RzDebugMap *>*/ *
 	if (width < 1) {
 		width = 30;
 	}
-	rz_list_sort(maps, cmp);
+	rz_list_sort(maps, cmp, NULL);
 	mul = findMinMax(maps, &min, &max, 0, width);
 	ut64 last = min;
 	if (min != -1 && mul != 0) {

--- a/librz/core/cil.c
+++ b/librz/core/cil.c
@@ -1076,7 +1076,7 @@ typedef struct {
 	RzList /*<RzAnalysisCaseOp *>*/ *switch_path;
 } IterCtx;
 
-static int find_bb(ut64 *addr, RzAnalysisBlock *bb) {
+static int find_bb(ut64 *addr, RzAnalysisBlock *bb, void *user) {
 	return *addr != bb->addr;
 }
 
@@ -1097,14 +1097,14 @@ static inline bool get_next_i(IterCtx *ctx, size_t *next_i) {
 			RzListIter *bbit = NULL;
 			if (bb->switch_op) {
 				RzAnalysisCaseOp *cop = rz_list_first(bb->switch_op->cases);
-				bbit = rz_list_find(ctx->bbl, &cop->jump, (RzListComparator)find_bb);
+				bbit = rz_list_find(ctx->bbl, &cop->jump, (RzListComparator)find_bb, NULL);
 				if (bbit) {
 					rz_list_push(ctx->switch_path, bb->switch_op->cases->head);
 				}
 			} else {
-				bbit = rz_list_find(ctx->bbl, &bb->jump, (RzListComparator)find_bb);
+				bbit = rz_list_find(ctx->bbl, &bb->jump, (RzListComparator)find_bb, NULL);
 				if (!bbit && bb->fail != UT64_MAX) {
-					bbit = rz_list_find(ctx->bbl, &bb->fail, (RzListComparator)find_bb);
+					bbit = rz_list_find(ctx->bbl, &bb->fail, (RzListComparator)find_bb, NULL);
 				}
 			}
 			if (!bbit) {
@@ -1114,7 +1114,7 @@ static inline bool get_next_i(IterCtx *ctx, size_t *next_i) {
 					rz_reg_arena_pop(ctx->fcn->analysis->reg);
 					prev_bb = rz_list_pop(ctx->path);
 					if (prev_bb->fail != UT64_MAX) {
-						bbit = rz_list_find(ctx->bbl, &prev_bb->fail, (RzListComparator)find_bb);
+						bbit = rz_list_find(ctx->bbl, &prev_bb->fail, (RzListComparator)find_bb, NULL);
 						if (bbit) {
 							rz_reg_arena_push(ctx->fcn->analysis->reg);
 							rz_list_push(ctx->path, prev_bb);
@@ -1127,7 +1127,7 @@ static inline bool get_next_i(IterCtx *ctx, size_t *next_i) {
 							rz_list_pop(ctx->switch_path);
 							rz_list_push(ctx->switch_path, rz_list_iter_get_next(cop_it));
 							cop_it = rz_list_iter_get_next(cop_it);
-							bbit = rz_list_find(ctx->bbl, &cop->jump, (RzListComparator)find_bb);
+							bbit = rz_list_find(ctx->bbl, &cop->jump, (RzListComparator)find_bb, NULL);
 						}
 					}
 					if (cop_it && !rz_list_iter_has_next(cop_it)) {

--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -2830,7 +2830,7 @@ static void foreachOffset(RzCore *core, const char *_cmd, const char *each) {
 	free(cmd);
 }
 
-static int bb_cmp(const void *a, const void *b) {
+static int bb_cmp(const void *a, const void *b, void *user) {
 	const RzAnalysisBlock *ba = a;
 	const RzAnalysisBlock *bb = b;
 	return ba->addr - bb->addr;
@@ -2873,7 +2873,7 @@ RZ_API int rz_core_cmd_foreach(RzCore *core, const char *cmd, char *each) {
 		RzAnalysisFunction *fcn = rz_analysis_get_function_at(core->analysis, core->offset);
 		int bs = core->blocksize;
 		if (fcn) {
-			rz_list_sort(fcn->bbs, bb_cmp);
+			rz_list_sort(fcn->bbs, bb_cmp, NULL);
 			rz_list_foreach (fcn->bbs, iter, bb) {
 				rz_core_block_size(core, bb->size);
 				rz_core_seek(core, bb->addr, true);
@@ -2917,7 +2917,7 @@ RZ_API int rz_core_cmd_foreach(RzCore *core, const char *cmd, char *each) {
 		int i;
 		RzAnalysisFunction *fcn = rz_analysis_get_function_at(core->analysis, core->offset);
 		if (fcn) {
-			rz_list_sort(fcn->bbs, bb_cmp);
+			rz_list_sort(fcn->bbs, bb_cmp, NULL);
 			rz_list_foreach (fcn->bbs, iter, bb) {
 				for (i = 0; i < bb->op_pos_size; i++) {
 					ut64 addr = bb->addr + bb->op_pos[i];
@@ -4686,7 +4686,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_bbs_stmt) {
 	RzListIter *iter;
 	RzAnalysisBlock *bb;
 	RzCmdStatus ret = RZ_CMD_STATUS_OK;
-	rz_list_sort(fcn->bbs, bb_cmp);
+	rz_list_sort(fcn->bbs, bb_cmp, NULL);
 	rz_list_foreach (fcn->bbs, iter, bb) {
 		rz_core_seek(core, bb->addr, true);
 		rz_core_block_size(core, bb->size);
@@ -5613,7 +5613,7 @@ RZ_API ut8 *rz_core_cmd_raw(RzCore *core, const char *cmd, int *length) {
 	return core_cmd_raw(core, cmd, length);
 }
 
-static int compare_cmd_descriptor_name(const void *a, const void *b) {
+static int compare_cmd_descriptor_name(const void *a, const void *b, void *user) {
 	return strcmp(((RzCmdDescriptor *)a)->cmd, ((RzCmdDescriptor *)b)->cmd);
 }
 
@@ -5622,7 +5622,7 @@ static void cmd_descriptor_init(RzCore *core) {
 	RzListIter *iter;
 	RzCmdDescriptor *x, *y;
 	int n = core->cmd_descriptors->length;
-	rz_list_sort(core->cmd_descriptors, compare_cmd_descriptor_name);
+	rz_list_sort(core->cmd_descriptors, compare_cmd_descriptor_name, NULL);
 	rz_list_foreach (core->cmd_descriptors, iter, y) {
 		if (--n < 0) {
 			break;

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -199,7 +199,7 @@ exit:
 	return fcn;
 }
 
-static int cmpaddr(const void *_a, const void *_b) {
+static int cmpaddr(const void *_a, const void *_b, void *user) {
 	const RzAnalysisFunction *a = _a, *b = _b;
 	return (a->addr > b->addr) ? 1 : (a->addr < b->addr) ? -1
 							     : 0;
@@ -2514,7 +2514,7 @@ RZ_IPI RzCmdStatus rz_analysis_function_until_handler(RzCore *core, int argc, co
 	return RZ_CMD_STATUS_OK;
 }
 
-static int var_comparator(const RzAnalysisVar *a, const RzAnalysisVar *b) {
+static int var_comparator(const RzAnalysisVar *a, const RzAnalysisVar *b, void *user) {
 	if (!a || !b) {
 		return 0;
 	}
@@ -2632,7 +2632,7 @@ static void var_list_show(
 	if (!(list && rz_list_length(list) > 0)) {
 		goto fail;
 	}
-	rz_list_sort(list, (RzListComparator)var_comparator);
+	rz_list_sort(list, (RzListComparator)var_comparator, NULL);
 
 	bool color_arg = (rz_config_get_b(core->config, "scr.color") && rz_config_get_b(core->config, "scr.color.args"));
 	VarShowContext ctx = {
@@ -3528,7 +3528,7 @@ RZ_IPI RzCmdStatus rz_analysis_global_variable_xrefs_handler(RzCore *core, int a
 #undef CMD_REGS_REG_PATH
 #undef CMD_REGS_SYNC
 
-static int RzAnalysisRef_cmp(const RzAnalysisXRef *xref1, const RzAnalysisXRef *xref2) {
+static int RzAnalysisRef_cmp(const RzAnalysisXRef *xref1, const RzAnalysisXRef *xref2, void *user) {
 	return xref1->to != xref2->to;
 }
 
@@ -3569,7 +3569,7 @@ static void function_list_print_to_table(RzCore *core, RzList /*<RzAnalysisFunct
 
 		RzList *calls = rz_core_analysis_fcn_get_calls(core, fcn);
 		// Uniquify the list by ref->addr
-		RzList *uniq_calls = rz_list_uniq(calls, (RzListComparator)RzAnalysisRef_cmp);
+		RzList *uniq_calls = rz_list_uniq(calls, (RzListComparator)RzAnalysisRef_cmp, NULL);
 		ut32 calls_num = rz_list_length(uniq_calls);
 		rz_list_free(uniq_calls);
 		rz_list_free(calls);
@@ -3796,7 +3796,7 @@ static void function_list_print_to_json(RzCore *core, RzList /*<RzAnalysisFuncti
 	pj_end(state->d.pj);
 }
 
-static int fcn_cmp_addr(const void *a, const void *b) {
+static int fcn_cmp_addr(const void *a, const void *b, void *user) {
 	const RzAnalysisFunction *fa = a;
 	const RzAnalysisFunction *fb = b;
 	if (fa->addr > fb->addr) {
@@ -3816,7 +3816,7 @@ static RzList /*<RzAnalysisFunction *>*/ *functions_sorted_by_addr(RzAnalysis *a
 	if (!sorted) {
 		return NULL;
 	}
-	rz_list_sort(sorted, fcn_cmp_addr);
+	rz_list_sort(sorted, fcn_cmp_addr, NULL);
 	return sorted;
 }
 
@@ -3895,7 +3895,7 @@ static void function_print_calls(RzCore *core, RzList /*<RzAnalysisFunction *>*/
 		// Get all refs for a function
 		RzList *xrefs = rz_core_analysis_fcn_get_calls(core, fcn);
 		// Uniquify the list by ref->addr
-		RzList *uniq_xrefs = rz_list_uniq(xrefs, (RzListComparator)RzAnalysisRef_cmp);
+		RzList *uniq_xrefs = rz_list_uniq(xrefs, (RzListComparator)RzAnalysisRef_cmp, NULL);
 
 		// don't enter for functions with 0 refs
 		if (!rz_list_empty(uniq_xrefs)) {
@@ -4232,7 +4232,7 @@ static void print_stats(RzCore *core, HtPU *ht, RzAnalysisFunction *fcn, RzCmdSt
 	RzListIter *iter;
 	RzList *list = rz_list_newf(NULL);
 	ht_pu_foreach(ht, (HtPUForeachCallback)list_keys_cb, list);
-	rz_list_sort(list, (RzListComparator)strcmp);
+	rz_list_sort(list, (RzListComparator)strcmp, NULL);
 	if (state->mode == RZ_OUTPUT_MODE_TABLE) {
 		RzTable *t = state->d.t;
 		RzTableColumnType *typeString = rz_table_type("string");
@@ -4322,7 +4322,7 @@ RZ_IPI RzCmdStatus rz_analysis_function_all_opcode_stat_handler(RzCore *core, in
 	}
 
 	ht_pu_foreach(keys_set, (HtPUForeachCallback)list_keys_cb, keys);
-	rz_list_sort(keys, (RzListComparator)strcmp);
+	rz_list_sort(keys, (RzListComparator)strcmp, NULL);
 
 	RzTable *t = state->d.t;
 	RzTableColumnType *typeString = rz_table_type("string");
@@ -6578,7 +6578,7 @@ RZ_IPI RzCmdStatus rz_analysis_data_function_gaps_handler(RzCore *core, int argc
 	RzAnalysisFunction *fcn;
 	RzListIter *iter;
 	int i, wordsize = core->rasm->bits / 8;
-	rz_list_sort(core->analysis->fcns, cmpaddr);
+	rz_list_sort(core->analysis->fcns, cmpaddr, NULL);
 	rz_list_foreach (core->analysis->fcns, iter, fcn) {
 		if (end != UT64_MAX) {
 			int range = fcn->addr - end;

--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -166,7 +166,7 @@ RZ_API RZ_OWN RzList /*<char *>*/ *rz_core_theme_list(RZ_NONNULL RzCore *core) {
 	rz_list_append(list, strdup("default"));
 	ht_pu_foreach(themes, dict2keylist, list);
 
-	rz_list_sort(list, (RzListComparator)strcmp);
+	rz_list_sort(list, (RzListComparator)strcmp, NULL);
 	ht_pu_free(themes);
 	return list;
 }

--- a/librz/core/cmd/cmd_flag.c
+++ b/librz/core/cmd/cmd_flag.c
@@ -319,7 +319,7 @@ RZ_IPI RzCmdStatus rz_flag_relocate_handler(RzCore *core, int argc, const char *
 	return RZ_CMD_STATUS_OK;
 }
 
-static int cmpflag(const void *_a, const void *_b) {
+static int cmpflag(const void *_a, const void *_b, void *user) {
 	const RzFlagItem *flag1 = _a, *flag2 = _b;
 	return (flag1->offset - flag2->offset);
 }
@@ -413,7 +413,7 @@ RZ_IPI RzCmdStatus rz_flag_describe_closest_handler(RzCore *core, int argc, cons
 	char *lmatch = NULL, *umatch = NULL;
 	RzFlagItem *flag;
 	RzListIter *iter;
-	rz_list_sort(temp, &cmpflag);
+	rz_list_sort(temp, &cmpflag, NULL);
 	rz_list_foreach (temp, iter, flag) {
 		if (strstr(flag->name, argv[1]) != NULL) {
 			if (flag->offset < core->offset) {

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -2093,7 +2093,7 @@ RZ_IPI RzCmdStatus rz_cmd_print_magic_handler(RzCore *core, int argc, const char
 	return RZ_CMD_STATUS_OK;
 }
 
-static int bbcmp(RzAnalysisBlock *a, RzAnalysisBlock *b) {
+static int bbcmp(RzAnalysisBlock *a, RzAnalysisBlock *b, void *user) {
 	return a->addr - b->addr;
 }
 
@@ -2246,7 +2246,7 @@ static void func_walk_blocks(RzCore *core, RzAnalysisFunction *f, bool fromHere,
 	const bool orig_bb_middle = rz_config_get_b(core->config, "asm.bb.middle");
 	rz_config_set_b(core->config, "asm.bb.middle", false);
 
-	rz_list_sort(f->bbs, (RzListComparator)bbcmp);
+	rz_list_sort(f->bbs, (RzListComparator)bbcmp, NULL);
 
 	RzAnalysisBlock *b;
 	RzListIter *iter;
@@ -4323,7 +4323,7 @@ static bool core_walk_function_blocks(RzCore *core, RzAnalysisFunction *f, RzCmd
 		}
 	}
 
-	rz_list_sort(f->bbs, (RzListComparator)bbcmp);
+	rz_list_sort(f->bbs, (RzListComparator)bbcmp, NULL);
 	if (state->mode == RZ_OUTPUT_MODE_JSON) {
 		rz_list_foreach (f->bbs, iter, b) {
 			ut8 *buf = malloc(b->size);

--- a/librz/core/cmd/cmd_regs.c
+++ b/librz/core/cmd/cmd_regs.c
@@ -395,7 +395,7 @@ RZ_IPI RzCmdStatus rz_regs_references_handler(RzCore *core, RzReg *reg, RzCmdReg
 	return r;
 }
 
-static int valgroup_regcmp(const void *a, const void *b) {
+static int valgroup_regcmp(const void *a, const void *b, void *user) {
 	const ut64 *A = (const ut64 *)a;
 	const ut64 *B = (const ut64 *)b;
 	if (*A > *B) {
@@ -410,7 +410,7 @@ static int valgroup_regcmp(const void *a, const void *b) {
 static bool valgroup_regcb(void *u, const ut64 k, const void *v) {
 	RzList *sorted = (RzList *)u;
 	ut64 *n = ut64_new(k);
-	rz_list_add_sorted(sorted, n, valgroup_regcmp);
+	rz_list_add_sorted(sorted, n, valgroup_regcmp, NULL);
 	return true;
 }
 

--- a/librz/core/cmd/cmd_search_rop.c
+++ b/librz/core/cmd/cmd_search_rop.c
@@ -255,7 +255,7 @@ static char *rop_classify_constant(RzCore *core, RzList /*<char *>*/ *ropList) {
 		reg_write = parse_list(strstr(out, "reg.write"));
 		mem_read = parse_list(strstr(out, "mem.read"));
 		mem_write = parse_list(strstr(out, "mem.write"));
-		if (!rz_list_find(ops_list, "=", (RzListComparator)strcmp)) {
+		if (!rz_list_find(ops_list, "=", (RzListComparator)strcmp, NULL)) {
 			goto continue_error;
 		}
 		head = rz_reg_get_list(core->analysis->reg, RZ_REG_TYPE_GPR);
@@ -265,7 +265,7 @@ static char *rop_classify_constant(RzCore *core, RzList /*<char *>*/ *ropList) {
 		rz_list_foreach (head, iter_dst, item_dst) {
 			ut64 diff_dst, value_dst;
 			if (!rz_list_find(reg_write, item_dst->name,
-				    (RzListComparator)strcmp)) {
+				    (RzListComparator)strcmp, NULL)) {
 				continue;
 			}
 
@@ -336,7 +336,7 @@ static char *rop_classify_mov(RzCore *core, RzList /*<char *>*/ *ropList) {
 			goto continue_error;
 		}
 
-		if (!rz_list_find(ops_list, "=", (RzListComparator)strcmp)) {
+		if (!rz_list_find(ops_list, "=", (RzListComparator)strcmp, NULL)) {
 			goto continue_error;
 		}
 
@@ -347,7 +347,7 @@ static char *rop_classify_mov(RzCore *core, RzList /*<char *>*/ *ropList) {
 		rz_list_foreach (head, iter_dst, item_dst) {
 			ut64 diff_dst, value_dst;
 			if (!rz_list_find(reg_write, item_dst->name,
-				    (RzListComparator)strcmp)) {
+				    (RzListComparator)strcmp, NULL)) {
 				continue;
 			}
 
@@ -363,7 +363,7 @@ static char *rop_classify_mov(RzCore *core, RzList /*<char *>*/ *ropList) {
 			rz_list_foreach (head, iter_src, item_src) {
 				ut64 diff_src, value_src;
 				if (!rz_list_find(reg_read, item_src->name,
-					    (RzListComparator)strcmp)) {
+					    (RzListComparator)strcmp, NULL)) {
 					continue;
 				}
 				// you never mov from flags
@@ -448,7 +448,7 @@ static char *rop_classify_arithmetic(RzCore *core, RzList /*<char *>*/ *ropList)
 				diff_src1 = rz_reg_get_value(core->analysis->reg, item_src1);
 				rz_reg_arena_swap(core->analysis->reg, false);
 				if (!rz_list_find(reg_read, item_src1->name,
-					    (RzListComparator)strcmp)) {
+					    (RzListComparator)strcmp, NULL)) {
 					continue;
 				}
 
@@ -459,7 +459,7 @@ static char *rop_classify_arithmetic(RzCore *core, RzList /*<char *>*/ *ropList)
 					diff_src2 = rz_reg_get_value(core->analysis->reg, item_src2);
 
 					if (!rz_list_find(reg_read, item_src2->name,
-						    (RzListComparator)strcmp)) {
+						    (RzListComparator)strcmp, NULL)) {
 						continue;
 					}
 					// TODO check condition
@@ -474,7 +474,7 @@ static char *rop_classify_arithmetic(RzCore *core, RzList /*<char *>*/ *ropList)
 						value_dst = rz_reg_get_value(core->analysis->reg, item_dst);
 						rz_reg_arena_swap(core->analysis->reg, false);
 						if (!rz_list_find(reg_write, item_dst->name,
-							    (RzListComparator)strcmp)) {
+							    (RzListComparator)strcmp, NULL)) {
 							continue;
 						}
 						// don't check flags for arithmetic
@@ -584,7 +584,7 @@ static char *rop_classify_arithmetic_const(RzCore *core, RzList /*<char *>*/ *ro
 				rz_reg_arena_swap(core->analysis->reg, false);
 
 				if (!rz_list_find(reg_read, item_src1->name,
-					    (RzListComparator)strcmp)) {
+					    (RzListComparator)strcmp, NULL)) {
 					continue;
 				}
 				rz_list_foreach (head, iter_dst, item_dst) {
@@ -595,7 +595,7 @@ static char *rop_classify_arithmetic_const(RzCore *core, RzList /*<char *>*/ *ro
 					diff_dst = rz_reg_get_value(core->analysis->reg, item_dst);
 					rz_reg_arena_swap(core->analysis->reg, false);
 					if (!rz_list_find(reg_write, item_dst->name,
-						    (RzListComparator)strcmp)) {
+						    (RzListComparator)strcmp, NULL)) {
 						continue;
 					}
 					// don't check flags for arithmetic

--- a/librz/core/cmd/cmd_type.c
+++ b/librz/core/cmd/cmd_type.c
@@ -251,9 +251,9 @@ static void types_xrefs_all(RzCore *core) {
 		}
 		rz_list_free(types);
 	}
-	RzList *uniq_types = rz_list_uniq(types_list, (RzListComparator)strcmp);
+	RzList *uniq_types = rz_list_uniq(types_list, (RzListComparator)strcmp, NULL);
 	rz_list_free(types_list);
-	rz_list_sort(uniq_types, (RzListComparator)strcmp);
+	rz_list_sort(uniq_types, (RzListComparator)strcmp, NULL);
 	char *typestr;
 	rz_list_foreach (uniq_types, iter, typestr) {
 		rz_cons_printf("%s\n", typestr);

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -11,8 +11,8 @@
 RZ_IPI void rz_core_kuery_print(RzCore *core, const char *k);
 RZ_IPI int rz_output_mode_to_char(RzOutputMode mode);
 
-RZ_IPI int bb_cmpaddr(const void *_a, const void *_b);
-RZ_IPI int fcn_cmpaddr(const void *_a, const void *_b);
+RZ_IPI int bb_cmpaddr(const void *_a, const void *_b, void *user);
+RZ_IPI int fcn_cmpaddr(const void *_a, const void *_b, void *user);
 
 RZ_IPI void rz_core_add_string_ref(RzCore *core, ut64 xref_from, ut64 xref_to);
 RZ_IPI bool rz_core_get_string_at(RzCore *core, ut64 address, char **string, size_t *length, RzStrEnc *encoding, bool can_search);

--- a/librz/core/ctypes.c
+++ b/librz/core/ctypes.c
@@ -766,7 +766,7 @@ RZ_API void rz_core_global_vars_propagate_types(RzCore *core, RzAnalysisFunction
 	ut64 oldoff = core->offset;
 	rz_cons_break_push(NULL, NULL);
 	// TODO: The algorithm can be more accurate if blocks are followed by their jmp/fail, not just by address
-	rz_list_sort(fcn->bbs, bb_cmpaddr);
+	rz_list_sort(fcn->bbs, bb_cmpaddr, NULL);
 	rz_list_foreach (fcn->bbs, it, bb) {
 		ut64 at = bb->addr;
 		ut64 to = bb->addr + bb->size;

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -2137,7 +2137,7 @@ static void ds_show_comments_right(RzDisasmState *ds) {
 	ds->show_comment_right = scr;
 }
 
-static int flagCmp(const void *a, const void *b) {
+static int flagCmp(const void *a, const void *b, void *user) {
 	const RzFlagItem *fa = a;
 	const RzFlagItem *fb = b;
 	if (fa->realname && fb->realname) {
@@ -2203,7 +2203,7 @@ static void ds_show_flags(RzDisasmState *ds, bool overlapped) {
 	int case_start = -1, case_prev = 0, case_current = 0;
 	f = rz_analysis_get_function_at(ds->core->analysis, ds->at);
 	const RzList *flaglist = rz_flag_get_list(core->flags, ds->at);
-	RzList *uniqlist = flaglist ? rz_list_uniq(flaglist, flagCmp) : NULL;
+	RzList *uniqlist = flaglist ? rz_list_uniq(flaglist, flagCmp, NULL) : NULL;
 	int count = 0;
 	bool outline = !ds->flags_inline;
 	const char *comma = "";
@@ -6556,7 +6556,7 @@ RZ_API bool rz_core_print_function_disasm_json(RzCore *core, RzAnalysisFunction 
 	pj_kn(pj, "addr", fcn->addr);
 	pj_k(pj, "ops");
 	pj_a(pj);
-	rz_list_sort(fcn->bbs, bb_cmpaddr);
+	rz_list_sort(fcn->bbs, bb_cmpaddr, NULL);
 	rz_list_foreach (fcn->bbs, locs_it, b) {
 
 		ut8 *buf = malloc(b->size);

--- a/librz/core/tui/flags.c
+++ b/librz/core/tui/flags.c
@@ -19,13 +19,13 @@ enum {
 	SORT_OFFSET
 };
 
-static int flag_name_sort(const void *a, const void *b) {
+static int flag_name_sort(const void *a, const void *b, void *user) {
 	const RzFlagItem *fa = (const RzFlagItem *)a;
 	const RzFlagItem *fb = (const RzFlagItem *)b;
 	return strcmp(fa->name, fb->name);
 }
 
-static int flag_offset_sort(const void *a, const void *b) {
+static int flag_offset_sort(const void *a, const void *b, void *user) {
 	const RzFlagItem *fa = (const RzFlagItem *)a;
 	const RzFlagItem *fb = (const RzFlagItem *)b;
 	if (fa->offset < fb->offset) {
@@ -40,10 +40,10 @@ static int flag_offset_sort(const void *a, const void *b) {
 static void sort_flags(RzList /*<RzFlagItem *>*/ *l, int sort) {
 	switch (sort) {
 	case SORT_NAME:
-		rz_list_sort(l, flag_name_sort);
+		rz_list_sort(l, flag_name_sort, NULL);
 		break;
 	case SORT_OFFSET:
-		rz_list_sort(l, flag_offset_sort);
+		rz_list_sort(l, flag_offset_sort, NULL);
 		break;
 	case SORT_NONE:
 	default:

--- a/librz/core/tui/panels.c
+++ b/librz/core/tui/panels.c
@@ -560,7 +560,7 @@ static void __clear_panels_menu(RzCore *core);
 static void __clear_panels_menuRec(RzPanelsMenuItem *pmi);
 static RzStrBuf *__draw_menu(RzCore *core, RzPanelsMenuItem *item);
 static void __handle_menu(RzCore *core, const int key);
-static int cmpstr(const void *_a, const void *_b);
+static int cmpstr(const void *_a, const void *_b, void *user);
 static RzList /*<char *>*/ *__sorted_list(RzCore *core, char *menu[], int count);
 
 /* config */
@@ -4647,7 +4647,7 @@ bool __init_panels_menu(RzCore *core) {
 	return true;
 }
 
-int cmpstr(const void *_a, const void *_b) {
+int cmpstr(const void *_a, const void *_b, void *user) {
 	char *a = (char *)_a, *b = (char *)_b;
 	return strcmp(a, b);
 }
@@ -4660,7 +4660,7 @@ RzList /*<char *>*/ *__sorted_list(RzCore *core, char *menu[], int count) {
 			(void)rz_list_append(list, menu[i]);
 		}
 	}
-	rz_list_sort(list, cmpstr);
+	rz_list_sort(list, cmpstr, NULL);
 	return list;
 }
 

--- a/librz/core/tui/vmenus_graph.c
+++ b/librz/core/tui/vmenus_graph.c
@@ -153,12 +153,12 @@ static void __seek_cursor(RzCoreVisualViewGraph *status) {
 	return;
 }
 
-static int cmpaddr(const void *_a, const void *_b) {
+static int cmpaddr(const void *_a, const void *_b, void *user) {
 	const RzCoreVisualViewGraphItem *a = _a, *b = _b;
 	return a->addr - b->addr;
 }
 
-static int cmpname(const void *_a, const void *_b) {
+static int cmpname(const void *_a, const void *_b, void *user) {
 	const RzCoreVisualViewGraphItem *a = _a, *b = _b;
 	if (!a || !b || !a->name || !b->name) {
 		return 0;
@@ -170,7 +170,7 @@ static void __sort(RzCoreVisualViewGraph *status, RzList /*<RzCoreVisualViewGrap
 	rz_return_if_fail(status && list);
 	RzListComparator cmp = (status->cur_sort == SORT_ADDRESS) ? cmpaddr : cmpname;
 	list->sorted = false;
-	rz_list_sort(list, cmp);
+	rz_list_sort(list, cmp, NULL);
 }
 
 static void __toggleSort(RzCoreVisualViewGraph *status) {

--- a/librz/debug/p/debug_dmp.c
+++ b/librz/debug/p/debug_dmp.c
@@ -843,7 +843,7 @@ static bool rz_debug_dmp_kill(RzDebug *dbg, int pid, int tid, int sig) {
 	return true;
 }
 
-static int is_pc_inside_windmodule(const struct context_type_amd64 *context, const void *list_data) {
+static int is_pc_inside_windmodule(const struct context_type_amd64 *context, const void *list_data, void *user) {
 	const ut64 pc = context->rip;
 	const WindModule *module = list_data;
 	return !(pc >= module->addr && pc < (module->addr + module->size));
@@ -869,7 +869,7 @@ RzList /*<RzDebugFrame *>*/ *rz_debug_dmp_frames(RzDebug *dbg, ut64 at) {
 			if (!modules) {
 				modules = dmp_get_modules(ctx);
 			}
-			RzListIter *it = rz_list_find(modules, &context, (RzListComparator)is_pc_inside_windmodule);
+			RzListIter *it = rz_list_find(modules, &context, (RzListComparator)is_pc_inside_windmodule, NULL);
 			if (!it) {
 				break;
 			}

--- a/librz/debug/p/native/bt/windows-x64.c
+++ b/librz/debug/p/native/bt/windows-x64.c
@@ -206,7 +206,7 @@ static ut64 get_amd64_register(const struct context_type_amd64 *context, ut8 reg
 	}
 }
 
-static int is_pc_inside_module(const void *value, const void *list_data) {
+static int is_pc_inside_module(const void *value, const void *list_data, void *user) {
 	const ut64 pc = *(const ut64 *)value;
 	const RzDebugMap *module = list_data;
 	return !(pc >= module->addr && pc < module->addr_end);
@@ -537,7 +537,7 @@ static bool backtrace_windows_x64(RZ_IN RzDebug *dbg, RZ_INOUT RzList /*<RzDebug
 		rz_list_append(frames, frame);
 
 		// Find in which module current rip is
-		RzListIter *it = rz_list_find(modules, &context->rip, is_pc_inside_module);
+		RzListIter *it = rz_list_find(modules, &context->rip, is_pc_inside_module, NULL);
 		if (!it) {
 			// Either broken stack or module info not avalable (PEB paged out, etc)
 			break;

--- a/librz/debug/p/native/linux/linux_debug.c
+++ b/librz/debug/p/native/linux/linux_debug.c
@@ -564,7 +564,7 @@ RzDebugReasonType linux_dbg_wait(RzDebug *dbg, int pid) {
 			} else if (WIFSTOPPED(status)) {
 				// If tid is not in the thread list and stopped by SIGSTOP,
 				// handle it as a new task.
-				if (!rz_list_find(dbg->threads, &tid, &match_pid) &&
+				if (!rz_list_find(dbg->threads, &tid, &match_pid, NULL) &&
 					WSTOPSIG(status) == SIGSTOP) {
 					reason = linux_handle_new_task(dbg, tid);
 					if (reason != RZ_DEBUG_REASON_UNKNOWN) {
@@ -605,7 +605,7 @@ RzDebugReasonType linux_dbg_wait(RzDebug *dbg, int pid) {
 	return reason;
 }
 
-int match_pid(const void *pid_o, const void *th_o) {
+int match_pid(const void *pid_o, const void *th_o, void *user) {
 	int pid = *(int *)pid_o;
 	RzDebugPid *th = (RzDebugPid *)th_o;
 	return (pid == th->pid) ? 0 : 1;
@@ -722,7 +722,7 @@ int linux_attach(RzDebug *dbg, int pid) {
 	} else {
 		// This means we did a first run, so we probably attached to all possible threads already.
 		// So check if the requested thread is being traced already. If not, attach it
-		if (!rz_list_find(dbg->threads, &pid, &match_pid)) {
+		if (!rz_list_find(dbg->threads, &pid, &match_pid, NULL)) {
 			linux_attach_single_pid(dbg, pid);
 		}
 	}

--- a/librz/debug/p/native/linux/linux_debug.h
+++ b/librz/debug/p/native/linux/linux_debug.h
@@ -175,6 +175,6 @@ bool linux_stop_threads(RzDebug *dbg, int except);
 int linux_handle_signals(RzDebug *dbg, int tid);
 RzDebugReasonType linux_dbg_wait(RzDebug *dbg, int pid);
 char *linux_reg_profile(RzDebug *dbg);
-int match_pid(const void *pid_o, const void *th_o);
+int match_pid(const void *pid_o, const void *th_o, void *user);
 
 #endif

--- a/librz/debug/p/native/windows/windows_debug.c
+++ b/librz/debug/p/native/windows/windows_debug.c
@@ -92,7 +92,7 @@ int w32_init(RzDebug *dbg) {
 	return true;
 }
 
-static int w32_findthread_cmp(int *tid, PTHREAD_ITEM th) {
+static int w32_findthread_cmp(int *tid, PTHREAD_ITEM th, void *user) {
 	return (int)!(*tid == th->tid);
 }
 
@@ -100,7 +100,7 @@ static inline PTHREAD_ITEM find_thread(RzDebug *dbg, int tid) {
 	if (!dbg->threads) {
 		return NULL;
 	}
-	RzListIter *it = rz_list_find(dbg->threads, &tid, (RzListComparator)w32_findthread_cmp);
+	RzListIter *it = rz_list_find(dbg->threads, &tid, (RzListComparator)w32_findthread_cmp, NULL);
 	return it ? rz_list_iter_get_data(it) : NULL;
 }
 
@@ -765,13 +765,13 @@ static void libfree(void *lib) {
 	free(lib_item);
 }
 
-static int findlibcmp(void *BaseOfDll, void *lib) {
+static int findlibcmp(void *BaseOfDll, void *lib, void *user) {
 	PLIB_ITEM lib_item = (PLIB_ITEM)lib;
 	return !lib_item->hFile || lib_item->hFile == INVALID_HANDLE_VALUE || lib_item->BaseOfDll != BaseOfDll;
 }
 
 static void *find_library(void *BaseOfDll) {
-	RzListIter *it = rz_list_find(lib_list, BaseOfDll, (RzListComparator)findlibcmp);
+	RzListIter *it = rz_list_find(lib_list, BaseOfDll, (RzListComparator)findlibcmp, NULL);
 	return it ? rz_list_iter_get_data(it) : NULL;
 }
 

--- a/librz/debug/p/native/xnu/xnu_debug.c
+++ b/librz/debug/p/native/xnu/xnu_debug.c
@@ -1255,7 +1255,7 @@ static RzDebugMap *moduleAt(RzList *list, ut64 addr) {
 	return NULL;
 }
 
-static int cmp(const void *_a, const void *_b) {
+static int cmp(const void *_a, const void *_b, void *user) {
 	const RzDebugMap *a = _a;
 	const RzDebugMap *b = _b;
 	if (a->addr > b->addr) {
@@ -1408,7 +1408,7 @@ RzList *xnu_dbg_maps(RzDebug *dbg, int only_modules) {
 		}
 		rz_list_append(list, m2);
 	}
-	rz_list_sort(list, cmp);
+	rz_list_sort(list, cmp, NULL);
 	rz_list_free(modules);
 	return list;
 }

--- a/librz/debug/p/native/xnu/xnu_threads.c
+++ b/librz/debug/p/native/xnu/xnu_threads.c
@@ -279,7 +279,7 @@ static int xnu_update_thread_info(RzDebug *dbg, xnu_thread_t *thread) {
 	return true;
 }
 
-static int thread_find(thread_t *port, xnu_thread_t *a) {
+static int thread_find(thread_t *port, xnu_thread_t *a, void *user) {
 	return (a && port && (a->port == *port)) ? 0 : 1;
 }
 
@@ -351,7 +351,7 @@ RZ_IPI int rz_xnu_update_thread_list(RzDebug *dbg) {
 		for (i = 0; i < thread_count; i++) {
 			xnu_thread_t *t;
 			iter = rz_list_find(dbg->threads, &thread_list[i],
-				(RzListComparator)&thread_find);
+				(RzListComparator)&thread_find, NULL);
 			// it means is already in our list
 			if (iter) {
 				// free the ownership over the thread
@@ -383,11 +383,11 @@ RZ_IPI xnu_thread_t *rz_xnu_get_thread(RzDebug *dbg, int tid) {
 	}
 	// TODO get the current thread
 	RzListIter *it = rz_list_find(dbg->threads, (const void *)(size_t)&tid,
-		(RzListComparator)&thread_find);
+		(RzListComparator)&thread_find, NULL);
 	if (!it) {
 		tid = rz_xnu_get_cur_thread(dbg);
 		it = rz_list_find(dbg->threads, (const void *)(size_t)&tid,
-			(RzListComparator)&thread_find);
+			(RzListComparator)&thread_find, NULL);
 		if (!it) {
 			eprintf("Thread not found get_xnu_thread\n");
 			return NULL;

--- a/librz/debug/trace.c
+++ b/librz/debug/trace.c
@@ -218,7 +218,7 @@ RZ_API RzDebugTracepoint *rz_debug_trace_get(RzDebug *dbg, ut64 addr) {
 		rz_strf(tmpbuf, "trace.%d.%" PFMT64x, tag, addr), NULL);
 }
 
-static int cmpaddr(const void *_a, const void *_b) {
+static int cmpaddr(const void *_a, const void *_b, void *user) {
 	const RzListInfo *a = _a, *b = _b;
 	return (rz_itv_begin(a->pitv) > rz_itv_begin(b->pitv)) ? 1 : (rz_itv_begin(a->pitv) < rz_itv_begin(b->pitv)) ? -1
 														     : 0;
@@ -257,7 +257,7 @@ RZ_API RZ_OWN RzList /*<RzListInfo *>*/ *rz_debug_traces_info(RzDebug *dbg, ut64
 		rz_list_append(info_list, info);
 	}
 
-	rz_list_sort(info_list, cmpaddr);
+	rz_list_sort(info_list, cmpaddr, NULL);
 	return info_list;
 }
 

--- a/librz/diff/diff.c
+++ b/librz/diff/diff.c
@@ -471,7 +471,7 @@ find_longest_match_fail:
 	return NULL;
 }
 
-static int cmp_matches(RzDiffMatch *m0, RzDiffMatch *m1) {
+static int cmp_matches(RzDiffMatch *m0, RzDiffMatch *m1, void *user) {
 	if (m0->a > m1->a) {
 		return 1;
 	} else if (m0->a < m1->a) {
@@ -557,7 +557,7 @@ RZ_API RZ_OWN RzList /*<RzDiffMatch *>*/ *rz_diff_matches_new(RZ_NONNULL RzDiff 
 		}
 		free(block);
 	}
-	rz_list_sort(matches, (RzListComparator)cmp_matches);
+	rz_list_sort(matches, (RzListComparator)cmp_matches, NULL);
 
 	adj_a = 0;
 	adj_b = 0;

--- a/librz/flag/flag.c
+++ b/librz/flag/flag.c
@@ -37,7 +37,7 @@ static void flag_skiplist_free(void *data) {
 	free(data);
 }
 
-static int flag_skiplist_cmp(const void *va, const void *vb) {
+static int flag_skiplist_cmp(const void *va, const void *vb, void *user) {
 	const RzFlagsAtOffset *a = (RzFlagsAtOffset *)va, *b = (RzFlagsAtOffset *)vb;
 	if (a->off == b->off) {
 		return 0;

--- a/librz/hash/hash.c
+++ b/librz/hash/hash.c
@@ -123,7 +123,7 @@ RZ_API double rz_hash_entropy_fraction(RZ_NONNULL const ut8 *data, ut64 len) {
 	return e;
 }
 
-static int hash_cfg_config_compare(const void *value, const void *data) {
+static int hash_cfg_config_compare(const void *value, const void *data, void *user) {
 	const HashCfgConfig *mdc = (const HashCfgConfig *)data;
 	const char *name = (const char *)value;
 	return strcmp(name, mdc->plugin->name);
@@ -267,7 +267,7 @@ RZ_API void rz_hash_cfg_free(RZ_NONNULL RzHashCfg *md) {
 RZ_API bool rz_hash_cfg_configure(RZ_NONNULL RzHashCfg *md, RZ_NONNULL const char *name) {
 	rz_return_val_if_fail(md && name, false);
 
-	if (rz_list_find(md->configurations, name, hash_cfg_config_compare)) {
+	if (rz_list_find(md->configurations, name, hash_cfg_config_compare, NULL)) {
 		RZ_LOG_WARN("msg digest: '%s' was already configured; skipping.\n", name);
 		return false;
 	}
@@ -513,7 +513,7 @@ RZ_API bool rz_hash_cfg_iterate(RZ_NONNULL RzHashCfg *md, size_t iterate) {
 RZ_API RZ_BORROW const ut8 *rz_hash_cfg_get_result(RZ_NONNULL RzHashCfg *md, RZ_NONNULL const char *name, RZ_NONNULL ut32 *size) {
 	rz_return_val_if_fail(md && name && hash_cfg_has_finshed(md), false);
 
-	RzListIter *it = rz_list_find(md->configurations, name, hash_cfg_config_compare);
+	RzListIter *it = rz_list_find(md->configurations, name, hash_cfg_config_compare, NULL);
 	if (!it) {
 		RZ_LOG_ERROR("msg digest: cannot find configuration for '%s' algorithm.\n", name);
 		return NULL;
@@ -538,7 +538,7 @@ RZ_API RZ_OWN char *rz_hash_cfg_get_result_string(RZ_NONNULL RzHashCfg *md, RZ_N
 	rz_return_val_if_fail(md && name && hash_cfg_has_finshed(md), false);
 
 	ut32 pos = 0;
-	RzListIter *it = rz_list_find(md->configurations, name, hash_cfg_config_compare);
+	RzListIter *it = rz_list_find(md->configurations, name, hash_cfg_config_compare, NULL);
 	if (!it) {
 		RZ_LOG_ERROR("msg digest: cannot find configuration for '%s' algorithm.\n", name);
 		return NULL;
@@ -580,7 +580,7 @@ RZ_API RZ_OWN char *rz_hash_cfg_get_result_string(RZ_NONNULL RzHashCfg *md, RZ_N
 RZ_API RzHashSize rz_hash_cfg_size(RZ_NONNULL RzHashCfg *md, RZ_NONNULL const char *name) {
 	rz_return_val_if_fail(md && name, 0);
 
-	RzListIter *it = rz_list_find(md->configurations, name, hash_cfg_config_compare);
+	RzListIter *it = rz_list_find(md->configurations, name, hash_cfg_config_compare, NULL);
 	if (!it) {
 		RZ_LOG_ERROR("msg digest: cannot find configuration for '%s' algorithm.\n", name);
 		return 0;

--- a/librz/il/il_reg.c
+++ b/librz/il/il_reg.c
@@ -5,7 +5,7 @@
 #include <rz_il/rz_il_vm.h>
 #include <rz_util.h>
 
-static int reg_offset_cmp(const void *value, const void *list_data) {
+static int reg_offset_cmp(const void *value, const void *list_data, void *user) {
 	return ((RzRegItem *)value)->offset - ((RzRegItem *)list_data)->offset;
 }
 
@@ -103,7 +103,7 @@ RZ_API RzILRegBinding *rz_il_reg_binding_derive(RZ_NONNULL RzReg *reg) {
 			rz_list_free(flags);
 			continue;
 		}
-		rz_list_sort(items, reg_offset_cmp);
+		rz_list_sort(items, reg_offset_cmp, NULL);
 		const char *pc = rz_reg_get_name(reg, RZ_REG_NAME_PC);
 		RzRegItem *prev = NULL;
 		rz_list_foreach (items, iter, item) {

--- a/librz/include/rz_list.h
+++ b/librz/include/rz_list.h
@@ -27,7 +27,7 @@ typedef struct rz_list_t {
 } RzList;
 
 // RzListComparator should return -1, 0, 1 to indicate "value < list_data", "value == list_data", "value > list_data".
-typedef int (*RzListComparator)(const void *value, const void *list_data);
+typedef int (*RzListComparator)(const void *value, const void *list_data, void *user);
 
 #ifdef RZ_API
 
@@ -77,11 +77,11 @@ RZ_API RZ_BORROW RzListIter *rz_list_insert(RZ_NONNULL RzList *list, ut32 n, RZ_
 RZ_API ut32 rz_list_length(RZ_NONNULL const RzList *list);
 RZ_API RZ_BORROW void *rz_list_first(RZ_NONNULL const RzList *list);
 RZ_API RZ_BORROW void *rz_list_last(RZ_NONNULL const RzList *list);
-RZ_API RZ_BORROW RzListIter *rz_list_add_sorted(RZ_NONNULL RzList *list, RZ_NONNULL void *data, RZ_NONNULL RzListComparator cmp);
-RZ_API void rz_list_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListComparator cmp);
-RZ_API void rz_list_merge_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListComparator cmp);
-RZ_API void rz_list_insertion_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListComparator cmp);
-RZ_API RZ_OWN RzList *rz_list_uniq(RZ_NONNULL const RzList *list, RZ_NONNULL RzListComparator cmp);
+RZ_API RZ_BORROW RzListIter *rz_list_add_sorted(RzList *list, void *data, RzListComparator cmp, void *user);
+RZ_API void rz_list_sort(RzList *list, RzListComparator cmp, void *user);
+RZ_API void rz_list_merge_sort(RzList *list, RzListComparator cmp, void *user);
+RZ_API void rz_list_insertion_sort(RzList *list, RzListComparator cmp, void *user);
+RZ_API RZ_OWN RzList *rz_list_uniq(const RzList *list, RzListComparator cmp, void *user);
 RZ_API void rz_list_init(RZ_NONNULL RzList *list);
 RZ_API void rz_list_delete(RZ_NONNULL RzList *list, RZ_NONNULL RzListIter *iter);
 RZ_API bool rz_list_delete_data(RZ_NONNULL RzList *list, void *ptr);
@@ -109,7 +109,7 @@ RZ_API RZ_OWN RzList *rz_list_of_sdblist(SdbList *sl);
 /* hashlike api */
 RZ_API RZ_BORROW RzListIter *rz_list_contains(RZ_NONNULL const RzList *list, RZ_NONNULL const void *ptr);
 RZ_API RZ_BORROW RzListIter *rz_list_find_ptr(RZ_NONNULL const RzList *list, RZ_NONNULL const void *ptr);
-RZ_API RZ_BORROW RzListIter *rz_list_find(RZ_NONNULL const RzList *list, const void *p, RZ_NONNULL RzListComparator cmp);
+RZ_API RZ_BORROW RzListIter *rz_list_find(const RzList *list, const void *p, RzListComparator cmp, void *user);
 
 #ifdef __cplusplus
 }

--- a/librz/main/rz-diff.c
+++ b/librz/main/rz-diff.c
@@ -1031,7 +1031,7 @@ static ut32 entry_hash(const RzBinAddr *elem) {
 	return hash;
 }
 
-static int entry_compare(const RzBinAddr *a, const RzBinAddr *b) {
+static int entry_compare(const RzBinAddr *a, const RzBinAddr *b, void *user) {
 	st64 ret;
 	ret = ((st64)b->paddr) - ((st64)a->paddr);
 	if (ret) {
@@ -1086,8 +1086,8 @@ static RzDiff *rz_diff_entries_new(DiffFile *dfile_a, DiffFile *dfile_b) {
 		rz_diff_error_ret(NULL, "cannot get entries from '%s'\n", dfile_b->dio->filename);
 	}
 
-	rz_list_sort(list_a, (RzListComparator)entry_compare);
-	rz_list_sort(list_b, (RzListComparator)entry_compare);
+	rz_list_sort(list_a, (RzListComparator)entry_compare, NULL);
+	rz_list_sort(list_b, (RzListComparator)entry_compare, NULL);
 
 	RzDiffMethods methods = {
 		.elem_at = (RzDiffMethodElemAt)rz_diff_list_elem_at,
@@ -1914,14 +1914,14 @@ fail:
 	return match;
 }
 
-static int compareBlocks(const RzAnalysisBlock *a, const RzAnalysisBlock *b) {
+static int compareBlocks(const RzAnalysisBlock *a, const RzAnalysisBlock *b, void *user) {
 	return (a && b && a->addr && b->addr ? (a->addr > b->addr) - (a->addr < b->addr) : 0);
 }
 
-static int comparePairBlocks(const RzAnalysisMatchPair *ma, const RzAnalysisMatchPair *mb) {
+static int comparePairBlocks(const RzAnalysisMatchPair *ma, const RzAnalysisMatchPair *mb, void *user) {
 	const RzAnalysisBlock *a = ma->pair_a;
 	const RzAnalysisBlock *b = mb->pair_a;
-	return compareBlocks(a, b);
+	return compareBlocks(a, b, user);
 }
 
 /**
@@ -1971,9 +1971,9 @@ static void core_show_function_diff(RzCore *core_a, ut64 addr_a, RzCore *core_b,
 		return;
 	}
 
-	rz_list_sort(result->matches, (RzListComparator)comparePairBlocks);
-	rz_list_sort(result->unmatch_a, (RzListComparator)compareBlocks);
-	rz_list_sort(result->unmatch_b, (RzListComparator)compareBlocks);
+	rz_list_sort(result->matches, (RzListComparator)comparePairBlocks, NULL);
+	rz_list_sort(result->unmatch_a, (RzListComparator)compareBlocks, NULL);
+	rz_list_sort(result->unmatch_b, (RzListComparator)compareBlocks, NULL);
 
 	switch (mode) {
 	case DIFF_MODE_JSON:
@@ -2064,7 +2064,7 @@ static void diff_similarity_as_table(RzAnalysisFunction *fcn_a, RzAnalysisFuncti
 	}
 }
 
-static int comparePairFunctions(const RzAnalysisMatchPair *ma, const RzAnalysisMatchPair *mb) {
+static int comparePairFunctions(const RzAnalysisMatchPair *ma, const RzAnalysisMatchPair *mb, void *user) {
 	const RzAnalysisFunction *a = ma->pair_a;
 	const RzAnalysisFunction *b = mb->pair_a;
 	return (a && b && a->addr && b->addr ? (a->addr > b->addr) - (a->addr < b->addr) : 0);
@@ -2114,9 +2114,9 @@ static void core_diff_show(RzCore *core_a, RzCore *core_b, DiffMode mode, bool v
 		goto fail;
 	}
 
-	rz_list_sort(result->matches, (RzListComparator)comparePairFunctions);
-	rz_list_sort(result->unmatch_a, core_a->analysis->columnSort);
-	rz_list_sort(result->unmatch_b, core_b->analysis->columnSort);
+	rz_list_sort(result->matches, (RzListComparator)comparePairFunctions, NULL);
+	rz_list_sort(result->unmatch_a, core_a->analysis->columnSort, NULL);
+	rz_list_sort(result->unmatch_b, core_b->analysis->columnSort, NULL);
 
 	if (mode == DIFF_MODE_JSON) {
 		pj = pj_new();

--- a/librz/reg/reg.c
+++ b/librz/reg/reg.c
@@ -237,7 +237,7 @@ RZ_API void rz_reg_free_internal(RzReg *reg, bool init) {
 	reg->size = 0;
 }
 
-static int regcmp(RzRegItem *a, RzRegItem *b) {
+static int regcmp(RzRegItem *a, RzRegItem *b, void *user) {
 	int offa = (a->offset * 16) + a->size;
 	int offb = (b->offset * 16) + b->size;
 	return (offa > offb) - (offa < offb);
@@ -253,7 +253,7 @@ RZ_API void rz_reg_reindex(RzReg *reg) {
 			rz_list_append(all, r);
 		}
 	}
-	rz_list_sort(all, (RzListComparator)regcmp);
+	rz_list_sort(all, (RzListComparator)regcmp, NULL);
 	index = 0;
 	rz_list_foreach (all, iter, r) {
 		r->index = index++;

--- a/librz/sign/create.c
+++ b/librz/sign/create.c
@@ -242,7 +242,7 @@ static int flirt_compare_module(const RzFlirtModule *a, const RzFlirtModule *b) 
 	return strcmp(af->name, bf->name);
 }
 
-int flirt_compare_node(const RzFlirtNode *a, const RzFlirtNode *b) {
+int flirt_compare_node(const RzFlirtNode *a, const RzFlirtNode *b, void *user) {
 	if (a->pattern_mask[0] == 0xFF && b->pattern_mask[0] == 0xFF) {
 		return memcmp(a->pattern_bytes, b->pattern_bytes, RZ_MIN(a->length, b->length));
 	}
@@ -282,7 +282,7 @@ static bool flirt_node_shorten_and_insert(const RzFlirtNode *root, RzFlirtNode *
 			// same pattern just merge.
 			rz_list_join(child->module_list, node->module_list);
 			rz_sign_flirt_node_free(node);
-			rz_list_sort(child->module_list, (RzListComparator)flirt_compare_module);
+			rz_list_sort(child->module_list, (RzListComparator)flirt_compare_module, NULL);
 			return true;
 		} else if (child->length == i) {
 			// partial pattern match but matches the child
@@ -290,7 +290,7 @@ static bool flirt_node_shorten_and_insert(const RzFlirtNode *root, RzFlirtNode *
 			if (!flirt_node_shorten_and_insert(child, node)) {
 				return false;
 			}
-			rz_list_sort(child->child_list, (RzListComparator)flirt_compare_node);
+			rz_list_sort(child->child_list, (RzListComparator)flirt_compare_node, NULL);
 		} else if (node->length == i) {
 			// partial pattern match but matches the node
 			rz_list_iter_set_data(it, node);
@@ -320,7 +320,7 @@ static bool flirt_node_shorten_and_insert(const RzFlirtNode *root, RzFlirtNode *
 			}
 			flirt_node_shorten_pattern(node, i);
 			flirt_node_shorten_pattern(child, i);
-			rz_list_sort(middle_node->child_list, (RzListComparator)flirt_compare_node);
+			rz_list_sort(middle_node->child_list, (RzListComparator)flirt_compare_node, NULL);
 		}
 		return true;
 	}
@@ -346,7 +346,7 @@ bool flirt_node_optimize(RzFlirtNode *root) {
 		goto fail;
 	}
 
-	rz_list_sort(childs, (RzListComparator)flirt_compare_node);
+	rz_list_sort(childs, (RzListComparator)flirt_compare_node, NULL);
 
 	RzListIter *it;
 	RzFlirtNode *child;
@@ -508,7 +508,7 @@ RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_node_new(RZ_NONNULL RzAnalysis *analysi
 	}
 
 	if (optimization == RZ_FLIRT_NODE_OPTIMIZE_NONE) {
-		rz_list_sort(root->child_list, (RzListComparator)flirt_compare_node);
+		rz_list_sort(root->child_list, (RzListComparator)flirt_compare_node, NULL);
 	} else if (!flirt_node_optimize(root)) {
 		goto fail;
 	}

--- a/librz/sign/pat.c
+++ b/librz/sign/pat.c
@@ -53,7 +53,7 @@
 
 extern void module_free(RzFlirtModule *module);
 extern bool flirt_node_optimize(RzFlirtNode *root);
-extern int flirt_compare_node(const RzFlirtNode *a, const RzFlirtNode *b);
+extern int flirt_compare_node(const RzFlirtNode *a, const RzFlirtNode *b, void *user);
 
 static inline ut8 decode_byte(char b) {
 	if (b >= '0' && b <= '9') {
@@ -426,7 +426,7 @@ RZ_API RZ_OWN RzFlirtNode *rz_sign_flirt_parse_string_pattern_from_buffer(RZ_NON
 	rz_strbuf_free(line);
 
 	if (optimization == RZ_FLIRT_NODE_OPTIMIZE_NONE) {
-		rz_list_sort(root->child_list, (RzListComparator)flirt_compare_node);
+		rz_list_sort(root->child_list, (RzListComparator)flirt_compare_node, NULL);
 	} else if (!flirt_node_optimize(root)) {
 		rz_sign_flirt_node_free(root);
 		return NULL;

--- a/librz/sign/sigdb.c
+++ b/librz/sign/sigdb.c
@@ -21,7 +21,7 @@ RZ_API void rz_sign_sigdb_signature_free(RZ_NULLABLE RzSigDBEntry *entry) {
 	free(entry);
 }
 
-static int sigdb_signature_cmp(const RzSigDBEntry *a, const RzSigDBEntry *b) {
+static int sigdb_signature_cmp(const RzSigDBEntry *a, const RzSigDBEntry *b, void *user) {
 	return strcmp(a->short_path, b->short_path);
 }
 
@@ -299,6 +299,6 @@ RZ_API RZ_OWN RzList /*<RzSigDBEntry *>*/ *rz_sign_sigdb_list(RZ_NONNULL const R
 		return NULL;
 	}
 	ht_pu_foreach(db->entries, sigdb_to_list, res);
-	rz_list_sort(res, (RzListComparator)sigdb_signature_cmp);
+	rz_list_sort(res, (RzListComparator)sigdb_signature_cmp, NULL);
 	return res;
 }

--- a/librz/util/graph.c
+++ b/librz/util/graph.c
@@ -35,7 +35,7 @@ static void rz_graph_node_free(RzGraphNode *n) {
 	free(n);
 }
 
-static int node_cmp(unsigned int idx, RzGraphNode *b) {
+static int node_cmp(unsigned int idx, RzGraphNode *b, void *user) {
 	return idx == b->idx ? 0 : -1;
 }
 
@@ -127,7 +127,7 @@ RZ_API void rz_graph_free(RzGraph *t) {
 }
 
 RZ_API RzGraphNode *rz_graph_get_node(const RzGraph *t, unsigned int idx) {
-	RzListIter *it = rz_list_find(t->nodes, (void *)(size_t)idx, (RzListComparator)node_cmp);
+	RzListIter *it = rz_list_find(t->nodes, (void *)(size_t)idx, (RzListComparator)node_cmp, NULL);
 	if (!it) {
 		return NULL;
 	}
@@ -135,7 +135,7 @@ RZ_API RzGraphNode *rz_graph_get_node(const RzGraph *t, unsigned int idx) {
 }
 
 RZ_API RzListIter *rz_graph_node_iter(const RzGraph *t, unsigned int idx) {
-	return rz_list_find(t->nodes, (void *)(size_t)idx, (RzListComparator)node_cmp);
+	return rz_list_find(t->nodes, (void *)(size_t)idx, (RzListComparator)node_cmp, NULL);
 }
 
 RZ_API void rz_graph_reset(RzGraph *t) {

--- a/librz/util/list.c
+++ b/librz/util/list.c
@@ -559,12 +559,12 @@ RZ_API RZ_OWN RzList *rz_list_clone(RZ_NONNULL const RzList *list) {
  * \brief Adds an element to a sorted list via the RzListComparator
  *
  **/
-RZ_API RZ_BORROW RzListIter *rz_list_add_sorted(RZ_NONNULL RzList *list, RZ_NONNULL void *data, RZ_NONNULL RzListComparator cmp) {
+RZ_API RZ_BORROW RzListIter *rz_list_add_sorted(RzList *list, void *data, RzListComparator cmp, void *user) {
 	RzListIter *it, *item = NULL;
 
 	rz_return_val_if_fail(list && data && cmp, NULL);
 
-	for (it = list->head; it && it->elem && cmp(data, it->elem) > 0; it = it->next) {
+	for (it = list->head; it && it->elem && cmp(data, it->elem, user) > 0; it = it->next) {
 	}
 	if (it) {
 		item = RZ_NEW0(RzListIter);
@@ -663,21 +663,21 @@ RZ_API RZ_BORROW RzListIter *rz_list_find_ptr(RZ_NONNULL const RzList *list, RZ_
  *
  * \return the first RzListIter that is equall to p w.r.t. cmp.
  */
-RZ_API RZ_BORROW RzListIter *rz_list_find(RZ_NONNULL const RzList *list, const void *p, RZ_NONNULL RzListComparator cmp) {
+RZ_API RZ_BORROW RzListIter *rz_list_find(const RzList *list, const void *p, RzListComparator cmp, void *user) {
 	void *q;
 	RzListIter *iter;
 
 	rz_return_val_if_fail(list, NULL);
 
 	rz_list_foreach (list, iter, q) {
-		if (!cmp(p, q)) {
+		if (!cmp(p, q, user)) {
 			return iter;
 		}
 	}
 	return NULL;
 }
 
-static RzListIter *_merge(RzListIter *first, RzListIter *second, RzListComparator cmp) {
+static RzListIter *_merge(RzListIter *first, RzListIter *second, RzListComparator cmp, void *user) {
 	RzListIter *next = NULL, *result = NULL, *head = NULL;
 	while (first || second) {
 		if (!second) {
@@ -686,7 +686,7 @@ static RzListIter *_merge(RzListIter *first, RzListIter *second, RzListComparato
 		} else if (!first) {
 			next = second;
 			second = second->next;
-		} else if (cmp(first->elem, second->elem) <= 0) {
+		} else if (cmp(first->elem, second->elem, user) <= 0) {
 			next = first;
 			first = first->next;
 		} else {
@@ -726,27 +726,27 @@ static RzListIter *_r_list_half_split(RzListIter *head) {
 	return tmp;
 }
 
-static RzListIter *_merge_sort(RzListIter *head, RzListComparator cmp) {
+static RzListIter *_merge_sort(RzListIter *head, RzListComparator cmp, void *user) {
 	RzListIter *second;
 	if (!head || !head->next) {
 		return head;
 	}
 	second = _r_list_half_split(head);
-	head = _merge_sort(head, cmp);
-	second = _merge_sort(second, cmp);
-	return _merge(head, second, cmp);
+	head = _merge_sort(head, cmp, user);
+	second = _merge_sort(second, cmp, user);
+	return _merge(head, second, cmp, user);
 }
 
 /**
  * \brief Merge sorts the list via the RzListComparator
  *
  **/
-RZ_API void rz_list_merge_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListComparator cmp) {
+RZ_API void rz_list_merge_sort(RzList *list, RzListComparator cmp, void *user) {
 	rz_return_if_fail(list);
 
 	if (!list->sorted && list->head && cmp) {
 		RzListIter *iter;
-		list->head = _merge_sort(list->head, cmp);
+		list->head = _merge_sort(list->head, cmp, user);
 		// update tail reference
 		iter = list->head;
 		while (iter && iter->next) {
@@ -761,7 +761,7 @@ RZ_API void rz_list_merge_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListCompara
  * \brief Insertion sorts the list via the RzListComparator
  *
  **/
-RZ_API void rz_list_insertion_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListComparator cmp) {
+RZ_API void rz_list_insertion_sort(RzList *list, RzListComparator cmp, void *user) {
 	rz_return_if_fail(list);
 
 	if (!list->sorted) {
@@ -770,7 +770,7 @@ RZ_API void rz_list_insertion_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListCom
 		if (cmp) {
 			for (it = list->head; it && it->elem; it = it->next) {
 				for (it2 = it->next; it2 && it2->elem; it2 = it2->next) {
-					if (cmp(it->elem, it2->elem) > 0) {
+					if (cmp(it->elem, it2->elem, user) > 0) {
 						void *t = it->elem;
 						it->elem = it2->elem;
 						it2->elem = t;
@@ -786,12 +786,12 @@ RZ_API void rz_list_insertion_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListCom
  * \brief Sorts via merge sort or via insertion sort a list
  *
  **/
-RZ_API void rz_list_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListComparator cmp) {
+RZ_API void rz_list_sort(RzList *list, RzListComparator cmp, void *user) {
 	rz_return_if_fail(list);
 	if (list->length > 43) {
-		rz_list_merge_sort(list, cmp);
+		rz_list_merge_sort(list, cmp, user);
 	} else {
-		rz_list_insertion_sort(list, cmp);
+		rz_list_insertion_sort(list, cmp, user);
 	}
 }
 
@@ -799,7 +799,7 @@ RZ_API void rz_list_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListComparator cm
  * \brief Returns a new RzList which contains only unique values
  *
  **/
-RZ_API RZ_OWN RzList *rz_list_uniq(RZ_NONNULL const RzList *list, RZ_NONNULL RzListComparator cmp) {
+RZ_API RZ_OWN RzList *rz_list_uniq(const RzList *list, RzListComparator cmp, void *user) {
 	RzListIter *iter, *iter2;
 	void *item, *item2;
 
@@ -812,7 +812,7 @@ RZ_API RZ_OWN RzList *rz_list_uniq(RZ_NONNULL const RzList *list, RZ_NONNULL RzL
 	rz_list_foreach (list, iter, item) {
 		bool found = false;
 		rz_list_foreach (nl, iter2, item2) {
-			if (cmp(item, item2) == 0) {
+			if (cmp(item, item2, user) == 0) {
 				found = true;
 				break;
 			}

--- a/librz/util/range.c
+++ b/librz/util/range.c
@@ -245,7 +245,7 @@ RZ_API int rz_range_contains(RRange *rgs, ut64 addr) {
 	return false;
 }
 
-static int cmp_ranges(void *a, void *b) {
+static int cmp_ranges(void *a, void *b, void *user) {
 	RRangeItem *first = (RRangeItem *)a;
 	RRangeItem *second = (RRangeItem *)b;
 	return (first->fr > second->fr) - (first->fr < second->fr);
@@ -257,7 +257,7 @@ RZ_API int rz_range_sort(RRange *rgs) {
 		return false;
 	}
 	rgs->changed = false;
-	rz_list_sort(rgs->ranges, (RzListComparator)cmp_ranges);
+	rz_list_sort(rgs->ranges, (RzListComparator)cmp_ranges, NULL);
 	if (ch != rgs->ranges->sorted) {
 		rgs->changed = true;
 	}

--- a/librz/util/skiplist.c
+++ b/librz/util/skiplist.c
@@ -54,7 +54,7 @@ static RzSkipListNode *find_insertpoint(RzSkipList *list, void *data, RzSkipList
 
 	for (i = list->list_level; i >= 0; i--) {
 		if (by_data) {
-			while (x->forward[i] != list->head && list->compare(x->forward[i]->data, data) < 0) {
+			while (x->forward[i] != list->head && list->compare(x->forward[i]->data, data, NULL) < 0) {
 				x = x->forward[i];
 			}
 		} else {
@@ -77,7 +77,7 @@ static bool delete_element(RzSkipList *list, void *data, bool by_data) {
 	// locate delete points in the lists of all levels
 	x = find_insertpoint(list, data, update, by_data);
 	// do nothing if the element is not present in the list
-	if (x == list->head || list->compare(x->data, data) != 0) {
+	if (x == list->head || list->compare(x->data, data, NULL) != 0) {
 		return false;
 	}
 
@@ -161,7 +161,7 @@ RZ_API RzSkipListNode *rz_skiplist_insert(RzSkipList *list, void *data) {
 	// locate insertion points in the lists of all levels
 	x = find_insertpoint(list, data, update, true);
 	// check whether the element is already in the list
-	if (x != list->head && !list->compare(x->data, data)) {
+	if (x != list->head && !list->compare(x->data, data, NULL)) {
 		return x;
 	}
 
@@ -209,7 +209,7 @@ RZ_API bool rz_skiplist_delete_node(RzSkipList *list, RzSkipListNode *node) {
 
 RZ_API RzSkipListNode *rz_skiplist_find(RzSkipList *list, void *data) {
 	RzSkipListNode *x = find_insertpoint(list, data, NULL, true);
-	if (x != list->head && list->compare(x->data, data) == 0) {
+	if (x != list->head && list->compare(x->data, data, NULL) == 0) {
 		return x;
 	}
 	return NULL;
@@ -225,7 +225,7 @@ RZ_API RzSkipListNode *rz_skiplist_find_leq(RzSkipList *list, void *data) {
 	int i;
 
 	for (i = list->list_level; i >= 0; i--) {
-		while (x->forward[i] != list->head && list->compare(x->forward[i]->data, data) <= 0) {
+		while (x->forward[i] != list->head && list->compare(x->forward[i]->data, data, NULL) <= 0) {
 			x = x->forward[i];
 		}
 	}

--- a/librz/util/syscmd.c
+++ b/librz/util/syscmd.c
@@ -4,7 +4,7 @@
 #include <rz_core.h>
 #include <errno.h>
 
-static int cmpstr(const void *_a, const void *_b) {
+static int cmpstr(const void *_a, const void *_b, void *user) {
 	const char *a = _a, *b = _b;
 	return (int)strcmp(a, b);
 }
@@ -27,7 +27,7 @@ RZ_API RZ_OWN char *rz_syscmd_sort(RZ_NONNULL const char *file) {
 			eprintf("No such file or directory\n");
 		} else {
 			list = rz_str_split_list(data, "\n", 0);
-			rz_list_sort(list, cmpstr);
+			rz_list_sort(list, cmpstr, NULL);
 			data = rz_list_to_str(list, '\n');
 			rz_list_free(list);
 		}
@@ -109,7 +109,7 @@ RZ_API RZ_OWN char *rz_syscmd_uniq(RZ_NONNULL const char *file) {
 			eprintf("No such file or directory\n");
 		} else {
 			list = rz_str_split_list(data, "\n", 0);
-			RzList *uniq_list = rz_list_uniq(list, cmpstr);
+			RzList *uniq_list = rz_list_uniq(list, cmpstr, NULL);
 			data = rz_list_to_str(uniq_list, '\n');
 			rz_list_free(uniq_list);
 			rz_list_free(list);

--- a/librz/util/table.c
+++ b/librz/util/table.c
@@ -9,11 +9,11 @@ typedef struct row_info {
 	RzListComparator cmp;
 } row_info_t;
 
-static int sortString(const void *a, const void *b) {
+static int sortString(const void *a, const void *b, void *user) {
 	return strcmp(a, b);
 }
 
-static int sortNumber(const void *a, const void *b) {
+static int sortNumber(const void *a, const void *b, void *user) {
 	return rz_num_get(NULL, a) - rz_num_get(NULL, b);
 }
 
@@ -797,7 +797,7 @@ static int cmp(const void *_a, const void *_b, void *user) {
 	RzTableRow *b = (RzTableRow *)_b;
 	const char *wa = rz_pvector_at(a->items, info->nth);
 	const char *wb = rz_pvector_at(b->items, info->nth);
-	return info->cmp(wa, wb);
+	return info->cmp(wa, wb, NULL);
 }
 
 RZ_API void rz_table_sort(RzTable *t, int nth, bool dec) {
@@ -843,7 +843,7 @@ static int rz_rows_cmp(RzPVector /*<char *>*/ *lhs, RzPVector /*<char *>*/ *rhs,
 		item_col = rz_vector_index_ptr(cols, i);
 
 		if (nth == -1 || i == nth) {
-			tmp = item_col->type->cmp(item_lhs, item_rhs);
+			tmp = item_col->type->cmp(item_lhs, item_rhs, NULL);
 			if (tmp) {
 				return tmp;
 			}

--- a/subprojects/rzwinkd/winkd.c
+++ b/subprojects/rzwinkd/winkd.c
@@ -602,7 +602,7 @@ int winkd_write_at_uva(RZ_BORROW RZ_NONNULL WindCtx *ctx, ut64 address, RZ_BORRO
 	return winkd_op_at_uva(ctx, address, (ut8 *)buf, count, true);
 }
 
-int map_comparator(const void *m1, const void *m2) {
+int map_comparator(const void *m1, const void *m2, void *user) {
 	const RzDebugMap *map1 = m1;
 	const RzDebugMap *map2 = m2;
 	return map1->addr > map2->addr ? 1 : map1->addr < map2->addr ? -1
@@ -739,7 +739,7 @@ RzList /*<WindModule *>*/ *winkd_list_modules(RZ_BORROW RZ_NONNULL WindCtx *ctx)
 		}
 		rz_str_utf16_to_utf8((ut8 *)mod->name, length + 1, unname, length + 2, true);
 		free(unname);
-		rz_list_add_sorted(ret, mod, map_comparator);
+		rz_list_add_sorted(ret, mod, map_comparator, NULL);
 
 		ptr = next;
 	} while (ptr != base);

--- a/test/integration/test_auto_analysis.c
+++ b/test/integration/test_auto_analysis.c
@@ -60,7 +60,7 @@ bool test_detected_functions_list_size(const char *fpath) {
 }
 
 // compare function for rz_list_find
-int cmp_fcn_name(const void *value, const void *list_data) {
+int cmp_fcn_name(const void *value, const void *list_data, void *user) {
 	RzAnalysisFunction *fcn = (RzAnalysisFunction*)list_data;
 	return strcmp((const char*)value, fcn->name);
 }
@@ -98,7 +98,7 @@ bool test_new_functions_detected_at_level(TestBinFcnLevel testbin) {
 		}
 
 		// search function
-		bool fcn_found = rz_list_find(fcn_list, fcn_name, cmp_fcn_name) != NULL;
+		bool fcn_found = rz_list_find(fcn_list, fcn_name, cmp_fcn_name, NULL) != NULL;
 		mu_assert("function not found at given analysis level", fcn_found);
 	}
 

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -753,8 +753,8 @@ bool test_foreach_cmdname(void) {
 	mu_assert_eq(rz_list_length(res), RZ_ARRAY_SIZE(exp_regular), "count regular commands that can be executed");
 
 	RzList *exp_regular_l = rz_list_new_from_array((const void **)exp_regular, RZ_ARRAY_SIZE(exp_regular));
-	rz_list_sort(exp_regular_l, (RzListComparator)strcmp);
-	rz_list_sort(res, (RzListComparator)strcmp);
+	rz_list_sort(exp_regular_l, (RzListComparator)strcmp, NULL);
+	rz_list_sort(res, (RzListComparator)strcmp, NULL);
 
 	RzListIter *it;
 	char *s;
@@ -794,8 +794,8 @@ bool test_foreach_cmdname_begin(void) {
 	mu_assert_eq(rz_list_length(res), RZ_ARRAY_SIZE(exp_regular), "count regular commands that can be executed");
 
 	RzList *exp_regular_l = rz_list_new_from_array((const void **)exp_regular, RZ_ARRAY_SIZE(exp_regular));
-	rz_list_sort(exp_regular_l, (RzListComparator)strcmp);
-	rz_list_sort(res, (RzListComparator)strcmp);
+	rz_list_sort(exp_regular_l, (RzListComparator)strcmp, NULL);
+	rz_list_sort(res, (RzListComparator)strcmp, NULL);
 
 	RzListIter *it;
 	char *s;

--- a/test/unit/test_list.c
+++ b/test/unit/test_list.c
@@ -89,7 +89,7 @@ bool test_rz_list_sort(void) {
 	rz_list_append(list, (void *)test3);
 	rz_list_append(list, (void *)test2);
 	// Sort.
-	rz_list_sort(list, (RzListComparator)strcmp);
+	rz_list_sort(list, (RzListComparator)strcmp, NULL);
 	// Check that the list is actually sorted.
 	mu_assert_streq((char *)list->head->elem, "AAAA", "first value in sorted list");
 	mu_assert_streq((char *)list->head->next->elem, "BBBB", "second value in sorted list");
@@ -108,7 +108,7 @@ bool test_rz_list_sort2(void) {
 	rz_list_append(list, (void *)test2);
 	rz_list_append(list, (void *)test1);
 	// Sort.
-	rz_list_merge_sort(list, (RzListComparator)strcmp);
+	rz_list_merge_sort(list, (RzListComparator)strcmp, NULL);
 	// Check that the list is actually sorted.
 	mu_assert_streq((char *)list->head->elem, "AAAA", "first value in sorted list");
 	mu_assert_streq((char *)list->head->next->elem, "BBBB", "second value in sorted list");
@@ -133,7 +133,7 @@ bool test_rz_list_sort3(void) {
 	rz_list_append(list, (void *)&test3);
 	rz_list_append(list, (void *)&test2);
 	// Sort.
-	rz_list_merge_sort(list, (RzListComparator)cmp_range);
+	rz_list_merge_sort(list, (RzListComparator)cmp_range, NULL);
 	// Check that the list is actually sorted.
 	mu_assert_eq(*(int *)list->head->elem, 33480, "first value in sorted list");
 	mu_assert_eq(*(int *)list->head->next->elem, 33508, "second value in sorted list");
@@ -211,7 +211,7 @@ bool test_rz_list_sort5(void) {
 		rz_list_append(list, (void *)upper[i]);
 	}
 	// add more than 43 elements to trigger merge sort
-	rz_list_sort(list, (RzListComparator)strcmp);
+	rz_list_sort(list, (RzListComparator)strcmp, NULL);
 	mu_assert_streq((char *)list->head->elem, upper[0], "First element");
 	mu_assert_streq((char *)list->tail->elem, lower[25], "Last element");
 	rz_list_free(list);
@@ -219,7 +219,7 @@ bool test_rz_list_sort5(void) {
 }
 
 // 3-valued comparator -> {LT,EQ,GT}.
-static int pintcmp(int *a, int *b) {
+static int pintcmp(int *a, int *b, void *user) {
 	return (int)(*a > *b) - (int)(*b > *a);
 }
 
@@ -243,7 +243,7 @@ bool test_rz_list_mergesort_pint() {
 	}
 
 	// invoke sorting
-	rz_list_sort(list, (RzListComparator)pintcmp);
+	rz_list_sort(list, (RzListComparator)pintcmp, NULL);
 
 	// assert the list is sorted as expected
 	RzListIter *iter;
@@ -278,7 +278,7 @@ bool test_rz_list_sort4(void) {
 		rz_list_append(list, (void *)ins_tests_odd[i]);
 	}
 	// Sort.
-	rz_list_merge_sort(list, (RzListComparator)strcmp);
+	rz_list_merge_sort(list, (RzListComparator)strcmp, NULL);
 
 	// Check that the list (odd-length) is actually sorted.
 	RzListIter *next = list->head;
@@ -311,7 +311,7 @@ bool test_rz_list_sort4(void) {
 #endif
 
 	// Sort
-	rz_list_merge_sort(list, (RzListComparator)strcmp);
+	rz_list_merge_sort(list, (RzListComparator)strcmp, NULL);
 
 #if 0 // Debug Printing
 	printf("after sorting 2 \n");

--- a/test/unit/test_serialize_analysis.c
+++ b/test/unit/test_serialize_analysis.c
@@ -1467,9 +1467,9 @@ bool test_analysis_load() {
 	rz_vector_free(vals);
 
 	mu_assert_eq(rz_list_length(analysis->imports), 3, "imports count");
-	mu_assert_notnull(rz_list_find(analysis->imports, "pigs", (RzListComparator)strcmp), "import");
-	mu_assert_notnull(rz_list_find(analysis->imports, "dogs", (RzListComparator)strcmp), "import");
-	mu_assert_notnull(rz_list_find(analysis->imports, "sheep", (RzListComparator)strcmp), "import");
+	mu_assert_notnull(rz_list_find(analysis->imports, "pigs", (RzListComparator)strcmp, NULL), "import");
+	mu_assert_notnull(rz_list_find(analysis->imports, "dogs", (RzListComparator)strcmp, NULL), "import");
+	mu_assert_notnull(rz_list_find(analysis->imports, "sheep", (RzListComparator)strcmp, NULL), "import");
 
 	char *cc = rz_analysis_cc_get(analysis, "sectarian");
 	mu_assert_streq(cc, "rax sectarian (rdx, rcx, stack);", "get cc");

--- a/test/unit/test_skiplist.c
+++ b/test/unit/test_skiplist.c
@@ -4,7 +4,7 @@
 #include <rz_skiplist.h>
 #include "minunit.h"
 
-int cmp_int(int a, int b) {
+int cmp_int(int a, int b, void *user) {
 	return (a > b) - (a < b);
 }
 

--- a/test/unit/test_type.c
+++ b/test/unit/test_type.c
@@ -293,14 +293,14 @@ static void setup_sdb_for_base_types_all(Sdb *res) {
 }
 
 // RzBaseType name comparator
-static int basetypenamecmp(const void *a, const void *b) {
+static int basetypenamecmp(const void *a, const void *b, void *user) {
 	const char *name = (const char *)a;
 	const RzBaseType *btype = (const RzBaseType *)b;
 	return !(btype->name && !strcmp(name, btype->name));
 }
 
 static bool typelist_has(RzList *types, const char *name) {
-	return (rz_list_find(types, name, basetypenamecmp) != NULL);
+	return (rz_list_find(types, name, basetypenamecmp, NULL) != NULL);
 }
 
 static bool test_types_get_base_types(void) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

To provide any context to the comparison function, introduce a "user" pointer that could be used as a method to pass such context. Similar to how it's done now in `RzVectorComparator` and `RzPVectorComparator`.

**Test plan**

CI is green
