### PR TITLE
Use the no-pie version (no ASLR) for the test

### DIFF
--- a/test/db/archos/darwin-arm64/dbg
+++ b/test/db/archos/darwin-arm64/dbg
@@ -85,7 +85,7 @@ EOF
 RUN
 
 NAME=maps as flags
-FILE=bins/mach0/hello-macos-arm64
+FILE=bins/mach0/hello-macos-arm64-nopie
 ARGS=-d
 CMDS=<<EOF
 fl@F:maps~hello~[1-]


### PR DESCRIPTION
This may fix the annoying mach0 debug test from failing