### PR TITLE
Fix openssl 3.0 support due changes on legacy algorithms.

### DIFF
--- a/librz/hash/algorithms/openssl_common.h
+++ b/librz/hash/algorithms/openssl_common.h
@@ -9,6 +9,9 @@
 #include <openssl/sha.h>
 #include <openssl/md4.h>
 #include <openssl/md5.h>
+#include <openssl/err.h>
+
+#include <rz_util.h>
 
 #define rz_openssl_plugin_context_new(pluginname) \
 	static void *openssl_plugin_##pluginname##_context_new() { \
@@ -35,6 +38,10 @@
 	static bool openssl_plugin_##pluginname##_init(void *context) { \
 		rz_return_val_if_fail(context, false); \
 		if (EVP_DigestInit_ex((EVP_MD_CTX *)context, evpmd(), NULL) != 1) { \
+			char emsg[256] = { 0 }; \
+			ERR_error_string_n(ERR_get_error(), emsg, sizeof(emsg)); \
+			RZ_LOG_ERROR("openssl: %s\n", emsg); \
+			ERR_clear_error(); \
 			return false; \
 		} \
 		return true; \
@@ -47,6 +54,10 @@
 			return true; \
 		} \
 		if (EVP_DigestUpdate((EVP_MD_CTX *)context, data, size) != 1) { \
+			char emsg[256] = { 0 }; \
+			ERR_error_string_n(ERR_get_error(), emsg, sizeof(emsg)); \
+			RZ_LOG_ERROR("openssl: %s\n", emsg); \
+			ERR_clear_error(); \
 			return false; \
 		} \
 		return true; \
@@ -56,6 +67,10 @@
 	static bool openssl_plugin_##pluginname##_final(void *context, ut8 *digest) { \
 		rz_return_val_if_fail((context) && (digest), false); \
 		if (EVP_DigestFinal_ex((EVP_MD_CTX *)context, digest, NULL) != 1) { \
+			char emsg[256] = { 0 }; \
+			ERR_error_string_n(ERR_get_error(), emsg, sizeof(emsg)); \
+			RZ_LOG_ERROR("openssl: %s\n", emsg); \
+			ERR_clear_error(); \
 			return false; \
 		} \
 		return true; \

--- a/librz/include/rz_hash.h
+++ b/librz/include/rz_hash.h
@@ -51,7 +51,7 @@ typedef struct rz_hash_cfg_t {
 #ifdef RZ_API
 
 RZ_API RzHash *rz_hash_new(void);
-RZ_API void rz_hash_free(RzHash *rh);
+RZ_API void rz_hash_free(RZ_NULLABLE RzHash *rh);
 RZ_API bool rz_hash_plugin_add(RZ_NONNULL RzHash *rh, RZ_NONNULL RZ_OWN RzHashPlugin *plugin);
 RZ_API bool rz_hash_plugin_del(RZ_NONNULL RzHash *rh, RZ_NONNULL RzHashPlugin *plugin);
 RZ_API RZ_BORROW const RzHashPlugin *rz_hash_plugin_by_index(RZ_NONNULL RzHash *rh, size_t index);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

OpenSSL changed the behaviour in 3.0 so some algos have been moved under the legacy provider.

**Closing issues**

Fix #3841