### PR TITLE
Fix aeA when rz_analysis_op fails.

### DIFF
--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -1015,13 +1015,13 @@ static bool cmd_aea(RzCore *core, int mode, ut64 addr, int length) {
 	esil->nowrite = true;
 	for (ops = ptr = 0; ptr < buf_sz && hasNext(mode); ops++, ptr += len) {
 		len = rz_analysis_op(core->analysis, &aop, addr + ptr, buf + ptr, buf_sz - ptr, RZ_ANALYSIS_OP_MASK_ESIL | RZ_ANALYSIS_OP_MASK_HINT);
+		if (len < 1) {
+			RZ_LOG_ERROR("core: Invalid 0x%08" PFMT64x " instruction %02x %02x\n",
+				addr + ptr, buf[ptr], buf[ptr + 1]);
+			break;
+		}
 		esilstr = RZ_STRBUF_SAFEGET(&aop.esil);
 		if (RZ_STR_ISNOTEMPTY(esilstr)) {
-			if (len < 1) {
-				RZ_LOG_ERROR("core: Invalid 0x%08" PFMT64x " instruction %02x %02x\n",
-					addr + ptr, buf[ptr], buf[ptr + 1]);
-				break;
-			}
 			rz_analysis_esil_parse(esil, esilstr);
 			rz_analysis_esil_stack_free(esil);
 		}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Within `aeA` if `rz_analysis_op` returns 0 or negative value, it never fails and keeps looping.

**Closing issues**

Fix #4002