### PR TITLE
rz-run: remove overriding @val@ env values

### DIFF
--- a/librz/socket/run.c
+++ b/librz/socket/run.c
@@ -176,33 +176,6 @@ static char *resolve_value(const char *src, size_t *result_len) {
 	const char *end = copy + src_len;
 
 	switch (*copy) {
-	case '@': {
-		char *at_end = NULL;
-		size_t at_size = strtol(copy + 1, &at_end, 10);
-		if (!at_size || *at_end != '@') {
-			RZ_LOG_ERROR("rz-run: invalid @<num>@ in `%s`\n", copy);
-			free(copy);
-			return NULL;
-		}
-		at_end++;
-		size_t suffix_len = end - at_end;
-		if (suffix_len < 1) {
-			RZ_LOG_ERROR("rz-run: invalid string after @<num>@ in `%s`\n", copy);
-			free(copy);
-			return NULL;
-		}
-		char *buf = malloc(at_size + 1);
-		if (buf) {
-			buf[at_size] = 0;
-			for (size_t i = 0; i < at_size; i++) {
-				buf[i] = at_end[i % suffix_len];
-			}
-		}
-		free(copy);
-		copy = buf;
-		copy_len = at_size;
-		break;
-	}
 	case '`': {
 		char *backtick_end = strchr(src + 1, '`');
 		if (!backtick_end) {
@@ -238,7 +211,7 @@ static char *resolve_value(const char *src, size_t *result_len) {
 			copy[src_len] = 0;
 		} else {
 			if (copy + 2 >= end) {
-				RZ_LOG_ERROR("rz-run: missing strin after `!` in `%s`\n", copy);
+				RZ_LOG_ERROR("rz-run: missing string after `!` in `%s`\n", copy);
 				free(copy);
 				return NULL;
 			}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Remove the feature of resolving `@val@` values in environment variables.

**Test plan**

CI is green

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/3646
