### PR TITLE
Fix initialization and conversion for 80-bit floats

### DIFF
--- a/librz/util/float/float.c
+++ b/librz/util/float/float.c
@@ -2639,6 +2639,10 @@ RZ_API RZ_OWN RzFloat *rz_float_convert(RZ_NONNULL RzFloat *f, RzFloatFormat for
 	RzFloatFormat old_format = f->r;
 	bool sign = get_sign(f->s, old_format);
 	ut32 man_len = rz_float_get_format_info(old_format, RZ_FLOAT_INFO_MAN_LEN);
+	if (old_format == RZ_FLOAT_IEEE754_BIN_80) {
+		/* Special case, see [rz_float_info_bin80] for more. */
+		man_len--;
+	}
 
 	// recover hidden bit if it's a normal float
 	// for sub-normal, we also set a fake hidden bit 1 to use round_float

--- a/librz/util/float/float.c
+++ b/librz/util/float/float.c
@@ -155,6 +155,10 @@ static bool float_is_mantissa_zero(RzFloat *f) {
 		} \
 		int bias = rz_float_get_format_info(f->r, RZ_FLOAT_INFO_BIAS) - 1; \
 		ut32 manl = rz_float_get_format_info(f->r, RZ_FLOAT_INFO_MAN_LEN); \
+		if (f->r == RZ_FLOAT_IEEE754_BIN_80) { \
+			/* Special case, see [rz_float_info_bin80] for more. */ \
+			manl--; \
+		} \
 		int exponent = float_exponent(f) - bias; \
 		ftype fractional = 0.0; \
 		for (ut32 i = 0; i < manl; ++i) { \
@@ -376,23 +380,28 @@ RZ_API RZ_OWN RzFloat *rz_float_dup(RZ_NONNULL RzFloat *f) {
 			fractional /= two; \
 			exponent++; \
 		} \
+		/* manbv is the significand's bitvector. */ \
+		RzBitVector *manbv = rz_bv_new_from_ut64(manl + 1, 0); \
+		if (!manbv) { \
+			return false; \
+		} \
 		for (ut32 i = 0; i < manl && fractional != zero; ++i) { \
 			fractional *= two; \
 			if (fractional >= one) { \
 				fractional -= one; \
-				rz_bv_set(f->s, manl - i, true); \
+				rz_bv_set(manbv, manl - i, true); \
 			} \
 		} \
 		if (roundl(fractional) > 0.5l) { \
-			rz_bv_set(f->s, 0, true); \
+			rz_bv_set(manbv, 0, true); \
 		} \
 		RzBitVector *expbv = rz_bv_new_from_ut64(expl, exponent); \
 		if (!expbv) { \
 			return false; \
 		} \
-		rz_bv_copy_nbits(expbv, 0, f->s, manl, expl); \
+		f->s = pack_float_bv(is_negative, expbv, manbv, f->r); \
+		rz_bv_free(manbv); \
 		rz_bv_free(expbv); \
-		rz_bv_set(f->s, f->s->len - 1, is_negative); \
 		return true; \
 	}
 

--- a/test/unit/test_float.c
+++ b/test/unit/test_float.c
@@ -617,9 +617,9 @@ bool float_print_num(void) {
 	mu_assert_streq_free(rz_float_as_dec_string(f64), "1.55678", "float64 numeric value");
 	rz_float_free(f64);
 
-	RzFloat *f80 = rz_float_new_from_f80(13.0335);
-	mu_assert_streq_free(rz_float_as_hex_string(f80, true), "0x4002a1126e978d4fe000", "float80 hex value");
-	mu_assert_streq_free(rz_float_as_string(f80), "+100000000000010|1010000100010010011011101001011110001101010011111110000000000000", "float80 bit value");
+	RzFloat *f80 = rz_float_new_from_f80(13.0335l);
+	mu_assert_streq_free(rz_float_as_hex_string(f80, true), "0x4002d089374bc6a7ef9e", "float80 hex value");
+	mu_assert_streq_free(rz_float_as_string(f80), "+100000000000010|1101000010001001001101110100101111000110101001111110111110011110", "float80 bit value");
 	mu_assert_streq_free(rz_float_as_dec_string(f80), "13.0335", "float80 numeric value");
 	rz_float_free(f80);
 

--- a/test/unit/test_float.c
+++ b/test/unit/test_float.c
@@ -1398,6 +1398,37 @@ bool f32_ieee_cast_test(void) {
 	mu_end;
 }
 
+bool f80_round_test(void) {
+	/* To 80-bit */
+	RzFloat *old_f = rz_float_new_from_f64(14.285714285714286);
+	RzFloat *expect_f = rz_float_new_from_f80(14.2857142857142864756l);
+	RzFloat *new_cast = rz_float_convert(old_f, RZ_FLOAT_IEEE754_BIN_80, RZ_FLOAT_RMODE_RNE);
+	mu_assert_false(rz_float_cmp(expect_f, new_cast), "test convert 14.285714285714286d to 14.2857142857142864756l");
+	rz_float_free(old_f);
+	rz_float_free(expect_f);
+	rz_float_free(new_cast);
+
+	/* From 80-bit */
+	old_f = rz_float_new_from_f80(13.37l);
+	expect_f = rz_float_new_from_f32(13.37f);
+	new_cast = rz_float_convert(old_f, RZ_FLOAT_IEEE754_BIN_32, RZ_FLOAT_RMODE_RNE);
+	mu_assert_false(rz_float_cmp(expect_f, new_cast), "test convert 13.37l to 13.37f");
+	rz_float_free(old_f);
+	rz_float_free(expect_f);
+	rz_float_free(new_cast);
+	mu_end;
+
+	/* From 80-bit to 80-bit (should lead to the same value) */
+	old_f = rz_float_new_from_f80(66668466788774.6870804l);
+	expect_f = rz_float_new_from_f80(66668466788774.6870804l);
+	new_cast = rz_float_convert(old_f, RZ_FLOAT_IEEE754_BIN_80, RZ_FLOAT_RMODE_RNE);
+	mu_assert_false(rz_float_cmp(expect_f, new_cast), "test convert 66668466788774.6870804l to itself");
+	rz_float_free(old_f);
+	rz_float_free(expect_f);
+	rz_float_free(new_cast);
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(rz_float_new_from_hex_test);
 	mu_run_test(f32_ieee_format_test);
@@ -1421,6 +1452,7 @@ bool all_tests() {
 	mu_run_test(f32_new_round_test);
 	mu_run_test(f32_ieee_fround_test);
 	mu_run_test(f32_ieee_cast_test);
+	mu_run_test(f80_round_test);
 	return tests_passed != tests_run;
 }
 

--- a/test/unit/test_float.c
+++ b/test/unit/test_float.c
@@ -618,8 +618,17 @@ bool float_print_num(void) {
 	rz_float_free(f64);
 
 	RzFloat *f80 = rz_float_new_from_f80(13.0335l);
+	/* Need the check since ARM does not support 128-bit long doubles and Windows ignores it. */
+#if __arm__ || __arm64__ || __WINDOWS__
+	mu_assert_streq_free(rz_float_as_hex_string(f80, true), "0x4002d089374bc6a7f000", "float80 hex value");
+#else
 	mu_assert_streq_free(rz_float_as_hex_string(f80, true), "0x4002d089374bc6a7ef9e", "float80 hex value");
+#endif
+#if __arm__ || __arm64__ || __WINDOWS__
+	mu_assert_streq_free(rz_float_as_string(f80), "+100000000000010|1101000010001001001101110100101111000110101001111111000000000000", "float80 bit value");
+#else
 	mu_assert_streq_free(rz_float_as_string(f80), "+100000000000010|1101000010001001001101110100101111000110101001111110111110011110", "float80 bit value");
+#endif
 	mu_assert_streq_free(rz_float_as_dec_string(f80), "13.0335", "float80 numeric value");
 	rz_float_free(f80);
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Now we can _correctly_ initialize an 80-bit `RzFloat` and also convert floats from and to 80-bit floats.

It is kind of unfortunate to deal with the idiosyncrasy of 80-bit float this way (through if conditions checking for 80-bit float). There must be cleaner ways, but they would require more refactor, and are probably not worth it since we wouldn't be changing the float code that often.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Added a new unit test for 80-bit float conversion. Added 80-bit float initialization in an existing unit test.

The `#if` check in the tests is necessary since ARM does not support a wide `long double` type. Windows also resorts to 64-bit float when using `long double`. I'm not sure if these are the only platforms which don't support it. But in any case, we'll be able to find out by the failing test on other platforms as well.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None.
