### PR TITLE
bin/dwarf: fix dSYM separate loading

### DIFF
--- a/librz/bin/dwarf/dwarf.c
+++ b/librz/bin/dwarf/dwarf.c
@@ -211,15 +211,17 @@ static void binary_close(DwBinary *b) {
 RZ_API RZ_OWN RzBinDWARF *rz_bin_dwarf_load_dsym(RZ_BORROW RZ_NONNULL RzBinFile *bf) {
 	rz_return_val_if_fail(bf && bf->o, NULL);
 
+	if (RZ_STR_ISEMPTY(bf->file)) {
+		return NULL;
+	}
+
 	RzBinDWARF *dw = NULL;
 	RzStrBuf path_buf = { 0 };
 	DwBinary binary = { 0 };
 	char *file_abspath = rz_file_abspath(bf->file);
-	const char *filename = rz_str_rchr(bf->file, NULL, '/');
-	if (RZ_STR_ISEMPTY(filename)) {
-		goto out;
-	}
-	rz_strbuf_initf(&path_buf, "%s%s%s", file_abspath, ".dSYM/Contents/Resources/DWARF", filename);
+	const char *filename = rz_file_basename(bf->file);
+	const char *dwarf_path = ".dSYM/Contents/Resources/DWARF/";
+	rz_strbuf_initf(&path_buf, "%s%s%s", file_abspath, dwarf_path, filename);
 	if (!rz_file_exists(rz_strbuf_get(&path_buf))) {
 		goto out;
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Before it failed to load if you just had "bla" in `bf->file`. Now it loads corresponding `bla.dSYM/...` just fine.

**Test plan**

CI is green