### PR TITLE
Fix parsing of GDB <reg> tags not separated by whitespace

### DIFF
--- a/subprojects/rzgdb/src/gdbclient/xml.c
+++ b/subprojects/rzgdb/src/gdbclient/xml.c
@@ -894,7 +894,7 @@ static RzList *_extract_regs(char *regstr, RzList *flags, char *pc_alias) {
 			rz_list_set_n(regs, regnum, tmpreg);
 		}
 		*regstr_end = '/';
-		regstr = regstr_end + 3;
+		regstr = regstr_end + 2;
 		if (rz_str_startswith(regstr, "</feature>")) {
 			regstr += sizeof("</feature>");
 			// Revert to default


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

`regstr_end + 3` would advance into the next `<reg>` tag if there is no whitespace between the two tags. This would cause the latter register to be ignored by the parser. Such an XML is for example used by [mGBA's GDB stub](https://github.com/mgba-emu/mgba/blob/49d9b70e6f2015165b6719a6da8ea842e996fde0/src/debugger/gdb-stub.c#L35-L36).

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

In one terminal:
```
$ gdbserver localhost:2345 ls
```

In another terminal:
```
$ rizin -c dr -D gdb gdb://localhost:2345
```

Verify that the register list is complete for your architecture.

For testing with [mGBA](https://github.com/mgba-emu/mgba), which generates the problematic XML:

1. Run the emulator and load any rom ([free homebrew roms are available](https://hh.gbdev.io/games/gba))
1. Click Tools -> Start GDB server
1. Click Start
1. Run `rizin -c dr -D gdb gdb://localhost:2345` 
1. Verify that the register list is complete: `r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, sp, lr, pc, cpsr` (currently in the dev branch, the odd-numbered registers are omitted)

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->