### PR TITLE
util/iterator: allow retrieve last element

### DIFF
--- a/librz/include/rz_util/rz_iterator.h
+++ b/librz/include/rz_util/rz_iterator.h
@@ -31,6 +31,7 @@ RZ_API RZ_OWN RzIterator *rz_iterator_new(
 	RZ_NULLABLE rz_iterator_free_cb free_u,
 	RZ_NONNULL RZ_OWN void *u);
 RZ_API RZ_BORROW void *rz_iterator_next(RZ_NONNULL RZ_BORROW RzIterator *it);
+RZ_API RZ_BORROW void *rz_iterator_last(RZ_NONNULL RZ_BORROW RzIterator *it);
 RZ_API void rz_iterator_free(RzIterator *it);
 
 #ifdef __cplusplus

--- a/librz/util/iterator.c
+++ b/librz/util/iterator.c
@@ -64,6 +64,27 @@ RZ_API RZ_BORROW void *rz_iterator_next(RZ_NONNULL RZ_BORROW RzIterator *it) {
 	return it->cur;
 }
 
+/**
+ * \brief Fetches the last element with the RzIterator
+ *
+ * This function retrieves the last element in the sequence for a given RzIterator.
+ * It doesn't free any elements.
+ *
+ * \param it A pointer to the RzIterator object.
+ *
+ * \return void* Pointer to the element gotten as the last object in the sequence or NULL if operation failed.
+ */
+RZ_API RZ_BORROW void *rz_iterator_last(RZ_NONNULL RZ_BORROW RzIterator *it) {
+	rz_return_val_if_fail(it && it->next, NULL);
+	void *elem = NULL;
+	void *tail = it->next(it);
+	while (tail) {
+		elem = tail;
+		tail = it->next(it);
+	}
+	return elem;
+}
+
 RZ_API void rz_iterator_free(RzIterator *it) {
 	if (!it) {
 		return;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

It is a bit clunky thing to do, but it is needed for Cutter, and easier to implement on the Rizin side.

See https://github.com/rizinorg/cutter/pull/3298 for details

**Test plan**

CI is green