### PR TITLE
Weaken f80 assertions in test_float for non-x86

### DIFF
--- a/test/unit/test_float.c
+++ b/test/unit/test_float.c
@@ -618,16 +618,23 @@ bool float_print_num(void) {
 	rz_float_free(f64);
 
 	RzFloat *f80 = rz_float_new_from_f80(13.0335l);
-	/* Need the check since ARM does not support 128-bit long doubles and Windows ignores it. */
-#if __arm__ || __arm64__ || __WINDOWS__
-	mu_assert_streq_free(rz_float_as_hex_string(f80, true), "0x4002d089374bc6a7f000", "float80 hex value");
-#else
+	// Need the check since 80-bit long double is an x86 speciality and MSVC ignores it.
+#if (__i386__ || __x86_64__) && !__WINDOWS__
 	mu_assert_streq_free(rz_float_as_hex_string(f80, true), "0x4002d089374bc6a7ef9e", "float80 hex value");
-#endif
-#if __arm__ || __arm64__ || __WINDOWS__
-	mu_assert_streq_free(rz_float_as_string(f80), "+100000000000010|1101000010001001001101110100101111000110101001111111000000000000", "float80 bit value");
-#else
 	mu_assert_streq_free(rz_float_as_string(f80), "+100000000000010|1101000010001001001101110100101111000110101001111110111110011110", "float80 bit value");
+#else
+	char *str = rz_float_as_hex_string(f80, true);
+	if (str && strlen(str) == 22) {
+		// Mask away anything beyond 64-bit influence because it differs between sparc and arm for example.
+		memset(str + 18, 'x', 4);
+	}
+	mu_assert_streq_free(str, "0x4002d089374bc6a7xxxx", "float80 hex value");
+	str = rz_float_as_string(f80);
+	if (str && strlen(str) == 81) {
+		// Mask away anything beyond 64-bit influence because it differs between sparc and arm for example.
+		memset(str + 60, 'x', 81 - 60);
+	}
+	mu_assert_streq_free(str, "+100000000000010|1101000010001001001101110100101111000110101xxxxxxxxxxxxxxxxxxxxx", "float80 bit value");
 #endif
 	mu_assert_streq_free(rz_float_as_dec_string(f80), "13.0335", "float80 numeric value");
 	rz_float_free(f80);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

OpenBSD/sparc64 uses 128-bit floats as long double by default while our tests seeminly assumed either 64-bit or 80-bit, both of which produce different results than 128 here. Since 80-bit is x86-specific, we check only the bits we know will be identical between other architectures.

**Test plan**

`test/unit/test_float` passes on all platforms