### PR TITLE
Fix arm64 analysis to fix regression on ARM64 switch tables.

### DIFF
--- a/subprojects/capstone-next.wrap
+++ b/subprojects/capstone-next.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/capstone-engine/capstone.git
-revision = 34a1e012b7eb8a3b03971cdf2d32b603855d5b09
+revision = b4fde983de9d14c038afef88e79fe1111388e569
 directory = capstone-next
 patch_directory = capstone-next
 depth = 1

--- a/test/db/analysis/golang
+++ b/test/db/analysis/golang
@@ -648,7 +648,7 @@ EXPECT=<<EOF
 0x100006e64 str.pointer
 0x100006eac str.panicwrap:_no___in
 0x1000076d0 str.internal_error___misuse_of_itab
-1710
+1709
 0x10008bada 31 31 slice bounds out of range [:%x]
 0x10008babb 31 31 slice bounds out of range [%x:]
 0x10008be19 32 32 slice bounds out of range [::%x]

--- a/test/db/cmd/cmd_plf
+++ b/test/db/cmd/cmd_plf
@@ -59,7 +59,7 @@ EXPECT=<<EOF
 0x30 (seq (set addr (+ (var x8) (bv 64 0x8))) (set x14 (cast 64 false (loadw 0 32 (var addr)))) (set x8 (cast 64 false (loadw 0 32 (+ (var addr) (bv 64 0x4))))))
 0x34 (set x14 (cast 64 false (^ (cast 32 false (var x10)) (cast 32 false (var x14)))))
 0x38 (set x15 (cast 64 false (^ (cast 32 false (var x11)) (cast 32 false (var x8)))))
-0x3c (set x8 (bv 64 0x5fe60))
+0x3c (set x8 (bv 64 0x5fe9c))
 0x40 nop
 0x44 (seq (set a (cast 32 false (var x9))) (set b (bv 32 0xa)) (set r (- (var a) (var b))) (set cf (ule (var b) (var a))) (set vf (&& (^^ (msb (var a)) (msb (var b))) (^^ (msb (var a)) (msb (var r))))) (set zf (is_zero (var r))) (set nf (msb (var r))))
 0x48 (branch (var zf) (jmp (bv 64 0x394)) nop)
@@ -727,7 +727,7 @@ EXPECT=<<EOF
 0xaa0 (set x8 (cast 64 false (^ (cast 32 false (var x8)) (cast 32 false (var x10)))))
 0xaa4 (set x8 (cast 64 false (^ (cast 32 false (var x8)) (cast 32 false (var x11)))))
 0xaa8 (set x9 (cast 64 false (& (cast 32 false (var x15)) (bv 32 0xff))))
-0xaac (set x10 (bv 64 0x603f0))
+0xaac (set x10 (bv 64 0x60e9c))
 0xab0 nop
 0xab4 (set x9 (cast 64 false (loadw 0 32 (+ (var x10) (<< (cast 64 false (cast 32 false (var x9))) (bv 6 0x2) false)))))
 0xab8 (set x11 (cast 64 false (let res (cast 8 false (>> (cast 32 false (var x8)) (bv 6 0x8) false)) (cast 32 false (var res)))))


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Capstone 6 brought a bug in `adr` and also now some instructions are not detected correctly in the Analysis code for Arm64.