### PR TITLE
Fix mismatch 'rz_cons_break_push' and 'rz_cons_break_pop' calls.

### DIFF
--- a/librz/analysis/reflines.c
+++ b/librz/analysis/reflines.c
@@ -258,6 +258,7 @@ RZ_API RzList /*<RzAnalysisRefline *>*/ *rz_analysis_reflines_get(RzAnalysis *an
 
 sten_err:
 list_err:
+	rz_cons_break_pop();
 	rz_list_free(sten);
 	rz_list_free(list);
 	return NULL;

--- a/librz/analysis/rtti_msvc.c
+++ b/librz/analysis/rtti_msvc.c
@@ -190,6 +190,7 @@ static RZ_OWN RzList /*<rtti_base_class_descriptor *>*/ *rtti_msvc_read_base_cla
 			ut8 tmp[4] = { 0 };
 			if (!context->analysis->iob.read_at(context->analysis->iob.io, addr, tmp, 4)) {
 				rz_list_free(ret);
+				rz_cons_break_pop();
 				return NULL;
 			}
 			ut32 (*read_32)(const void *src) = context->analysis->big_endian ? rz_read_be32 : rz_read_le32;

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -2801,6 +2801,7 @@ RZ_API RzList /*<RzAnalysisCycleHook *>*/ *rz_core_analysis_cycles(RzCore *core,
 			if (!ch) {
 				rz_analysis_cycle_frame_free(cf);
 				rz_list_free(hooks);
+				rz_cons_break_pop();
 				return NULL;
 			}
 			ch->addr = addr;
@@ -2986,7 +2987,8 @@ RZ_API int rz_core_search_value_in_range(RzCore *core, RzInterval search_itv, ut
 	rz_cons_break_push(NULL, NULL);
 
 	if (!rz_io_is_valid_offset(core->io, from, 0)) {
-		return -1;
+		hitctr = -1;
+		goto beach;
 	}
 	while (from < to) {
 		size = RZ_MIN(to - from, sizeof(buf));
@@ -3045,7 +3047,8 @@ RZ_API int rz_core_search_value_in_range(RzCore *core, RzInterval search_itv, ut
 				break;
 			default:
 				RZ_LOG_ERROR("core: unknown vsize %d (supported only 1,2,4,8)\n", vsize);
-				return -1;
+				hitctr = -1;
+				goto beach;
 			}
 			if (match && !vinfun) {
 				if (vinfunr) {

--- a/librz/core/cesil.c
+++ b/librz/core/cesil.c
@@ -150,7 +150,7 @@ repeat:
 			} else {
 				rz_reg_setv(core->analysis->reg, "PC", op.addr + op.size);
 			}
-			return 1;
+			return_tail(1);
 		}
 	}
 	rz_reg_setv(core->analysis->reg, name, addr + op.size);

--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -1365,8 +1365,6 @@ static int rz_core_cmd_subst(RzCore *core, char *cmd) {
 		free(cr);
 	}
 
-	rz_cons_break_pop();
-
 	if (tmpseek) {
 		rz_core_seek(core, orig_offset, true);
 		core->tmpseek = original_tmpseek;
@@ -1385,6 +1383,7 @@ static int rz_core_cmd_subst(RzCore *core, char *cmd) {
 		}
 	}
 beach:
+	rz_cons_break_pop();
 	free(icmd);
 	return ret;
 }
@@ -2865,6 +2864,7 @@ RZ_API int rz_core_cmd_foreach(RzCore *core, const char *cmd, char *each) {
 		free(cmdhit);
 	}
 		free(ostr);
+		rz_cons_break_pop();
 		return 0;
 	case '?': // "@@?"
 		rz_core_cmd_help(core, help_msg_at_at);

--- a/librz/core/cmd/cmd_debug.c
+++ b/librz/core/cmd/cmd_debug.c
@@ -2382,6 +2382,7 @@ RZ_IPI RzCmdStatus rz_cmd_debug_continue_back_handler(RzCore *core, int argc, co
 
 	if (!rz_debug_continue_back(core->dbg)) {
 		RZ_LOG_ERROR("core: cannot continue back\n");
+		rz_cons_break_pop();
 		return RZ_CMD_STATUS_ERROR;
 	}
 
@@ -2468,7 +2469,6 @@ RZ_IPI RzCmdStatus rz_cmd_debug_continue_send_signal_handler(RzCore *core, int a
 // dcp
 RZ_IPI RzCmdStatus rz_cmd_debug_continue_mapped_io_handler(RzCore *core, int argc, const char **argv) {
 	CMD_CHECK_DEBUG_DEAD(core);
-	rz_cons_break_push(rz_core_static_debug_stop, core->dbg);
 	RzIOMap *s;
 	ut64 pc;
 	int n = 0;

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -230,6 +230,7 @@ static int search_hash(RzCore *core, const char *hashname, const char *hashstr, 
 						hashname, hashstr, from + i);
 					free(s);
 					free(buf);
+					rz_cons_break_pop();
 					return 1;
 				}
 				free(s);
@@ -241,6 +242,7 @@ static int search_hash(RzCore *core, const char *hashname, const char *hashstr, 
 	eprintf("No hashes found\n");
 	return 0;
 fail:
+	rz_cons_break_pop();
 	return -1;
 }
 
@@ -1557,12 +1559,12 @@ static int rz_core_search_rop(RzCore *core, RzInterval search_itv, int opt, cons
 	if (rz_cons_is_breaked()) {
 		eprintf("\n");
 	}
-	rz_cons_break_pop();
 
 	if (param->outmode == RZ_MODE_JSON) {
 		pj_end(param->pj);
 	}
 bad:
+	rz_cons_break_pop();
 	rz_list_free(rx_list);
 	rz_list_free(end_list);
 	free(grep_arg);

--- a/librz/debug/p/native/windows/windows_debug.c
+++ b/librz/debug/p/native/windows/windows_debug.c
@@ -938,6 +938,7 @@ int w32_dbg_wait(RzDebug *dbg, int pid) {
 	do {
 		/* do not continue when already exited but still open for examination */
 		if (exited_already == pid) {
+			rz_cons_break_pop();
 			return RZ_DEBUG_REASON_DEAD;
 		}
 		memset(&de, 0, sizeof(DEBUG_EVENT));


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
If a function calls `rz_cons_break_push()` but never calls `rz_cons_break_pop()` before return, the stack count of `RzConsContext->break_stack` contains too many elements (each time one too much).

This in turn will lead to not resetting `RzConsContext->breaked` flag. Because the flag is only set to false, if `rz_stack_is_empty(context->break_stack) == true` (in `rz_cons_context_break_push()`).

This wasn't a problem so far, because `RzConsContext->breaked` is simply never set to true (exceptions are some timeout cases as far as I can see). Also these cases when `rz_cons_break_pop()` was forgotten to be called, were edge error cases. So not often hit.

But if Rizin is usd by Cutter `RzConsContext->breaked` is set to `true`, if an `AnalysisTask` interrupt is handled (in `AnalysisTask::interrupt()`). This interrupt is triggered for example, when the introduction dialog is closed and the main Cutter window opens (after the optional `aaa`).

Now, if the binary file was analysed with `aaa`, and a lot of error cases were hit, those error cases sometimes never called `rz_cons_break_pop()` before returning from their function. Although, of course, they should have to the `RzConsContext->break_stack` is in a proper state.

This means, when the main Cutter window opens binary files which trigger many error edge cases, the `RzConsContext->break_stack` is not empty
(because of the not executed `rz_cons_break_pop()`).

This also means, that the last thing done, was setting `RzConsContext->breaked = true` (by `AnalysisTask::interrupt()`).

If Cutter wants to show some disassembly, it calls `rz_core_print_disasm()` which checks `RzConsContext == false` via `rz_cons_is_breaked()`. This condition is never true, because the flag was not reset to `false` because the stack was never empty. So it returns before anything was disassembled.

Hence Cutter gets no disassembly text.


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All green

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Fixes https://github.com/rizinorg/cutter/issues/2552
Fixes https://github.com/rizinorg/cutter/issues/3275

It should at least.