### PR TITLE
docs(PACKAGERS): fix meson option names

### DIFF
--- a/doc/PACKAGERS.md
+++ b/doc/PACKAGERS.md
@@ -78,7 +78,7 @@ At the time of writing, these are:
 * `use_sys_zstd`
 * `use_sys_xxhash`
 * `use_sys_openssl`
-* `use_sys_mspack`
+* `use_sys_libmspack`
 * `use_sys_pcre2`
 * `use_sys_tree_sitter`
 

--- a/doc/PACKAGERS.md
+++ b/doc/PACKAGERS.md
@@ -75,7 +75,7 @@ At the time of writing, these are:
 * `use_sys_lzma`
 * `use_sys_zlib`
 * `use_sys_lz4`
-* `use_sys_zstd`
+* `use_sys_libzstd`
 * `use_sys_xxhash`
 * `use_sys_openssl`
 * `use_sys_libmspack`


### PR DESCRIPTION
the option is not valid, thus removing it

---

relates to https://github.com/Homebrew/homebrew-core/pull/164020