### PR TITLE
core: remove plugin from list if init fails

### DIFF
--- a/librz/core/cplugin.c
+++ b/librz/core/cplugin.c
@@ -30,6 +30,7 @@ RZ_API bool rz_core_plugin_add(RzCore *core, RZ_NONNULL RzCorePlugin *plugin) {
 	rz_return_val_if_fail(plugin && plugin->init && plugin->name && plugin->author && plugin->license, false);
 	RZ_PLUGIN_CHECK_AND_ADD(core->plugins, plugin, RzCorePlugin);
 	if (!plugin->init(core)) {
+		RZ_PLUGIN_REMOVE(core->plugins, plugin);
 		return false;
 	}
 	return true;
@@ -45,12 +46,13 @@ RZ_API bool rz_core_plugin_del(RzCore *core, RZ_NONNULL RzCorePlugin *plugin) {
 
 RZ_API bool rz_core_plugin_init(RzCore *core) {
 	int i;
+	bool res = true;
 	core->plugins = rz_list_new();
 	for (i = 0; i < RZ_ARRAY_SIZE(core_static_plugins); i++) {
 		if (!rz_core_plugin_add(core, core_static_plugins[i])) {
-			RZ_LOG_ERROR("core: error loading core plugin\n");
-			return false;
+			RZ_LOG_ERROR("core: error loading core plugin '%s'\n", core_static_plugins[i]->name);
+			res = false;
 		}
 	}
-	return true;
+	return res;
 }

--- a/librz/include/rz_lib.h
+++ b/librz/include/rz_lib.h
@@ -117,6 +117,11 @@ typedef struct rz_lib_t {
 		rz_list_append(plugins, plugin); \
 	} while (0)
 
+#define RZ_PLUGIN_REMOVE(plugins, plugin) \
+	do { \
+		rz_list_delete_data(plugins, plugin); \
+	} while (0)
+
 #ifdef RZ_API
 RZ_API RzLib *rz_lib_new(RZ_NULLABLE const char *symname, RZ_NULLABLE const char *symnamefunc);
 RZ_API void rz_lib_free(RzLib *lib);

--- a/librz/util/lib.c
+++ b/librz/util/lib.c
@@ -168,11 +168,14 @@ static bool lib_open_ptr(RzLib *lib, const char *file, void *handler, RzLibStruc
 	p->free = stru->free;
 
 	bool ret = lib_run_handler(lib, p, stru);
-	if (ret) {
-		rz_list_append(lib->plugins, p);
+	if (!ret) {
+		free(p->file);
+		free(p);
+		return false;
 	}
 
-	return ret;
+	rz_list_append(lib->plugins, p);
+	return true;
 }
 
 /**


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

If a plugin fails to initialize itself, it should not be added to the `core->plugins` list.
I've checked that other modules do not make the same mistake, but it seems they are fine.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Change the `java` plugin to register under the `psp` command (instead of `java`). Recompile rizin and test that the `java` plugin does not appear in `Lc` output (but `dex` plugin does appear).

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #4297 
