### PR TITLE
[PCRE2] Use `SLJIT_WX_EXECUTABLE_ALLOCATOR` for darwin, since wx allocations are not allowed.

### DIFF
--- a/subprojects/packagefiles/pcre2/meson.build
+++ b/subprojects/packagefiles/pcre2/meson.build
@@ -64,7 +64,7 @@ if cc.get_id() != 'tcc' and target_machine.cpu_family() in cpu_jit_supported
   pcre2_files += ['src/pcre2_jit_compile.c']
 endif
 
-if target_machine.system() == 'openbsd'
+if target_machine.system() == 'openbsd' or target_machine.system() == 'darwin'
   # jit compilation fails with "no more memory" if wx allocations are allowed.
   libpcre2_c_args += ['-DSLJIT_WX_EXECUTABLE_ALLOCATOR']
 elif target_machine.system() == 'netbsd'

--- a/subprojects/packagefiles/pcre2_cross_native/meson.build
+++ b/subprojects/packagefiles/pcre2_cross_native/meson.build
@@ -68,7 +68,7 @@ if cc.get_id() != 'tcc' and target_machine.cpu_family() in cpu_jit_supported
   pcre2_files += ['src/pcre2_jit_compile.c']
 endif
 
-if target_machine.system() == 'openbsd'
+if target_machine.system() == 'openbsd' or target_machine.system() == 'darwin'
   # jit compilation fails with "no more memory" if wx allocations are allowed.
   libpcre2_c_args += ['-DSLJIT_WX_EXECUTABLE_ALLOCATOR']
 elif target_machine.system() == 'netbsd'


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Apparently, `wx` pages are not allowed on [MacOS as well](https://github.com/PCRE2Project/pcre2/issues?q=is%3Aissue+is%3Aopen+MacOS). Disable them.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All green.
@karliss Please test locally with Rizin and Cutter.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
