### PR TITLE
java: fix `java_class_parse`

### DIFF
--- a/librz/bin/format/java/class_bin.c
+++ b/librz/bin/format/java/class_bin.c
@@ -207,13 +207,15 @@ static bool java_class_parse(RzBinJavaClass *bin, ut64 base, Sdb *kv, RzBuffer *
 			goto java_class_parse_bad;
 		}
 		for (ut32 i = 0; i < bin->methods_count; ++i) {
+			if (is_eob(buf)) {
+				goto java_class_parse_bad;
+			}
 			offset = rz_buf_tell(buf) + base;
 			bin->methods[i] = java_method_new(bin->constant_pool,
 				bin->constant_pool_count, buf, offset, is_oak);
-		}
-		if (is_eob(buf)) {
-			rz_warn_if_reached();
-			goto java_class_parse_bad;
+			if (!bin->methods[i]) {
+				goto java_class_parse_bad;
+			}
 		}
 	}
 

--- a/librz/bin/format/java/class_method.c
+++ b/librz/bin/format/java/class_method.c
@@ -58,19 +58,20 @@ Method *java_method_new(ConstPool **pool, ut32 poolsize, RzBuffer *buf, ut64 off
 	ut64 base = offset - rz_buf_tell(buf);
 
 	if (!java_method_new_aux(buf, method)) {
-		free(method);
-		return NULL;
+		goto err;
 	}
 
 	if (method->attributes_count < 1) {
 		return method;
 	}
+	if (method->attributes_count * 6 + rz_buf_tell(buf) >= rz_buf_size(buf)) {
+		goto err;
+	}
 
 	method->attributes = RZ_NEWS0(Attribute *, method->attributes_count);
 	if (!method->attributes) {
-		free(method);
 		rz_warn_if_reached();
-		return NULL;
+		goto err;
 	}
 
 	for (ut32 i = 0; i < method->attributes_count; ++i) {
@@ -84,6 +85,9 @@ Method *java_method_new(ConstPool **pool, ut32 poolsize, RzBuffer *buf, ut64 off
 		}
 	}
 	return method;
+err:
+	free(method);
+	return NULL;
 }
 
 void java_method_free(Method *method) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

```
rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -eflirt.sigdb.load.system=false -eflirt.sigdb.load.home=false -N -Qc 'e scr.prompt=false ; aaa' bins/java/fba022731cfdd80bc65a899afefead1e
-- stderr
ERROR: java bin: invalid constant pool tag: 23 at 0x2ab
ERROR: java bin: could not parse the constant pool value at offset 2ab
Backtrace 10 stack frames.
0   librz_util.0.8.dylib                0x0000000103291824 rz_sys_backtrace + 44
1   librz_util.0.8.dylib                0x0000000103227380 rz_assert_log + 88
2   librz_bin.0.8.dylib                 0x000000010428504c java_class_parse + 2128
3   librz_bin.0.8.dylib                 0x00000001042847bc rz_bin_java_class_new + 152
4   librz_bin.0.8.dylib                 0x00000001042070e0 load_buffer + 48
5   librz_bin.0.8.dylib                 0x00000001041d5710 rz_bin_object_new + 448
6   librz_bin.0.8.dylib                 0x00000001041c7aa4 rz_bin_file_new_from_buffer + 372
7   librz_bin.0.8.dylib                 0x00000001041cced0 rz_bin_open_buf + 692
8   librz_bin.0.8.dylib                 0x00000001041cc904 rz_bin_open_io + 884
9   librz_core.0.8.dylib                0x0000000105ed5534 core_file_do_load_for_io_plugin + 204

-- exit status: -1
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->


**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
