### PR TITLE
Remove unnecessary parameter and dead code

### DIFF
--- a/librz/util/sdb/src/main.c
+++ b/librz/util/sdb/src/main.c
@@ -181,27 +181,12 @@ static int sdb_dump(const char *db, int fmt) {
 	return sdb_grep_dump(db, fmt, false, NULL);
 }
 
-static int insertkeys(Sdb *s, const char **args, int nargs, int mode) {
+static int insertkeys(Sdb *s, const char **args, int nargs) {
 	int must_save = 0;
 	if (args && nargs > 0) {
 		int i;
 		for (i = 0; i < nargs; i++) {
-			switch (mode) {
-			case '-':
-				must_save |= sdb_query(s, args[i]);
-				break;
-			case '=':
-				if (strchr(args[i], '=')) {
-					char *v, *kv = (char *)strdup(args[i]);
-					v = strchr(kv, '=');
-					if (v) {
-						*v++ = 0;
-						sdb_disk_insert(s, kv, v);
-					}
-					free(kv);
-				}
-				break;
-			}
+			must_save |= sdb_query(s, args[i]);
 		}
 	}
 	return must_save;
@@ -415,7 +400,7 @@ int main(int argc, const char **argv) {
 			sdb_config(s, options);
 			int kvs = db0 + 2;
 			if (kvs < argc) {
-				save |= insertkeys(s, argv + argi + 2, argc - kvs, '-');
+				save |= insertkeys(s, argv + argi + 2, argc - kvs);
 			}
 			for (; (line = slurp(stdin, NULL));) {
 				save |= sdb_query(s, line);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This is a pretty minor change, an internal function insertkeys in librz/util/sdb/src/main.c had an `int mode` parameter being matched against the 2 values `'-'` and `'='`. As per https://github.com/rizinorg/rizin/issues/489 I wanted to remove it in favor of an enum parameter, but when I searched for all the callsites using the name of the function in VSCode full-text search, I found the only callsite to be a call from main passing `'-'` as an argument. Therefore, I deleted all the code except that which executes for a `'-'` match, and since there was only 1 code path now, I deleted the redundant mode parameter as will.

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

No tests necessary, this is a refactoring of a `static` function in a .c file with no .h, and thus it can't possibly be used in other files. Its only use in the file defining it is the call described above, which is trivially correct by inspection.

The branch builds correctly, and no additional test case failures (relative to a build on the latest dev branch, where 15 tests fail on my machine in unrelated test cases) is introduced.
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
