### PR TITLE
Remove global variables from GNU z80 disassembler

### DIFF
--- a/librz/arch/isa_gnu/z80/expressions.c
+++ b/librz/arch/isa_gnu/z80/expressions.c
@@ -23,7 +23,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-//#include "z80asm.h"
+#include "z80asm.h"
 
 /* reading expressions. The following operators are supported
  * in order of precedence, with function name:
@@ -39,723 +39,648 @@
  * ~ + - (unary)  rd_factor
  */
 
-static int do_rd_expr (const char **p, char delimiter, int *valid, int level,
-		       int *check, int print_errors);
+static int do_rd_expr(Z80AssemblerState *state, const char **p, char delimiter, int *valid, int level,
+	int *check, int print_errors);
 
 static int
-rd_number (const char **p, const char **endp, int base)
-{
-  int result = 0, i;
-  char *c, num[] = "0123456789abcdefghijklmnopqrstuvwxyz";
-  if (verbose >= 6)
-    fprintf (stderr, "%5d (0x%04x): Starting to read number of base %d"
-	     "(string=%s).\n", stack[sp].line, addr, base, *p);
-  num[base] = '\0';
-  *p = delspc (*p);
-  while (**p && (c = strchr (num, tolower ((const unsigned char)**p))))
-    {
-      i = c - num;
-      if (verbose >= 7)
-	fprintf (stderr, "%5d (0x%04x): Digit found:%1x.\n", stack[sp].line,
-		 addr, i);
-      result = result * base + i;
-      (*p)++;
-    }
-  if (endp)
-    *endp = *p;
-  *p = delspc (*p);
-  if (verbose >= 7)
-    fprintf (stderr, "%5d (0x%04x): rd_number returned %d (%04x).\n",
-	     stack[sp].line, addr, result, result);
-  return result;
+rd_number(Z80AssemblerState *state, const char **p, const char **endp, int base) {
+	int result = 0, i;
+	char *c, num[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+	if (state->verbose >= 6)
+		fprintf(stderr, "%5d (0x%04x): Starting to read number of base %d"
+				"(string=%s).\n",
+			state->stack[state->sp].line, state->addr, base, *p);
+	num[base] = '\0';
+	*p = delspc(*p);
+	while (**p && (c = strchr(num, tolower((const unsigned char)**p)))) {
+		i = c - num;
+		if (state->verbose >= 7)
+			fprintf(stderr, "%5d (0x%04x): Digit found:%1x.\n", state->stack[state->sp].line,
+				state->addr, i);
+		result = result * base + i;
+		(*p)++;
+	}
+	if (endp)
+		*endp = *p;
+	*p = delspc(*p);
+	if (state->verbose >= 7)
+		fprintf(stderr, "%5d (0x%04x): rd_number returned %d (%04x).\n",
+			state->stack[state->sp].line, state->addr, result, result);
+	return result;
 }
 
 static int
-rd_otherbasenumber (const char **p, int *valid, int print_errors)
-{
-  char c;
-  if (verbose >= 6)
-    fprintf (stderr,
-	     "%5d (0x%04x): Starting to read basenumber (string=%s).\n",
-	     stack[sp].line, addr, *p);
-  (*p)++;
-  if (!**p)
-    {
-      if (valid)
-	*valid = 0;
-      else if (print_errors)
-	printerr (1, "unexpected end of line after `@'\n");
-      return 0;
-    }
-  if (**p == '0' || !isalnum ((const unsigned char)**p))
-    {
-      if (valid)
-	*valid = 0;
-      else if (print_errors)
-	printerr (1, "base must be between 1 and z\n");
-      return 0;
-    }
-  c = **p;
-  (*p)++;
-  if (isalpha ((const unsigned char)**p))
-    return rd_number (p, NULL, tolower ((unsigned char)c) - 'a' + 1);
-  return rd_number (p, NULL, c - '0' + 1);
+rd_otherbasenumber(Z80AssemblerState *state, const char **p, int *valid, int print_errors) {
+	char c;
+	if (state->verbose >= 6)
+		fprintf(stderr,
+			"%5d (0x%04x): Starting to read basenumber (string=%s).\n",
+			state->stack[state->sp].line, state->addr, *p);
+	(*p)++;
+	if (!**p) {
+		if (valid)
+			*valid = 0;
+		else if (print_errors)
+			RZ_LOG_ERROR("assembler: z80: unexpected end of line after `@'\n");
+		return 0;
+	}
+	if (**p == '0' || !isalnum((const unsigned char)**p)) {
+		if (valid)
+			*valid = 0;
+		else if (print_errors)
+			RZ_LOG_ERROR("assembler: z80: base must be between 1 and z\n");
+		return 0;
+	}
+	c = **p;
+	(*p)++;
+	if (isalpha((const unsigned char)**p))
+		return rd_number(state, p, NULL, tolower((unsigned char)c) - 'a' + 1);
+	return rd_number(state, p, NULL, c - '0' + 1);
 }
 
 static int
-rd_character (const char **p, int *valid, int print_errors)
-{
-  int i;
-  if (verbose >= 6)
-    fprintf (stderr,
-	     "%5d (0x%04x): Starting to read character (string=%s).\n",
-	     stack[sp].line, addr, *p);
-  i = **p;
-  if (!i)
-    {
-      if (valid)
-	*valid = 0;
-      else if (print_errors)
-	printerr (1, "unexpected end of line in string constant\n");
-      return 0;
-    }
-  if (i == '\\')
-    {
-      (*p)++;
-      if (**p >= '0' && **p <= '7')
-	{
-	  int b, num_digits;
-	  i = 0;
-	  if ((*p)[1] >= '0' && (*p)[1] <= '7')
-	    {
-	      if (**p <= '3' && (*p)[2] >= '0' && (*p)[2] <= '7')
-		num_digits = 3;
-	      else
-		num_digits = 2;
-	    }
-	  else
-	    num_digits = 1;
-	  for (b = 0; b < num_digits; b++)
-	    {
-	      int bit = (*p)[num_digits - 1 - b] - '0';
-	      i += (1 << (b * 3)) * bit;
-	    }
-	  *p += num_digits;
+rd_character(Z80AssemblerState *state, const char **p, int *valid, int print_errors) {
+	int i;
+	if (state->verbose >= 6)
+		fprintf(stderr,
+			"%5d (0x%04x): Starting to read character (string=%s).\n",
+			state->stack[state->sp].line, state->addr, *p);
+	i = **p;
+	if (!i) {
+		if (valid)
+			*valid = 0;
+		else if (print_errors)
+			RZ_LOG_ERROR("assembler: z80: unexpected end of line in string constant\n");
+		return 0;
 	}
-      else
-	{
-	  switch (**p)
-	    {
-	    case 'n':
-	      i = 10;
-	      break;
-	    case 'r':
-	      i = 13;
-	      break;
-	    case 't':
-	      i = 9;
-	      break;
-	    case 'a':
-	      i = 7;
-	      break;
-	    case '\'':
-	      if (valid)
-		*valid = 0;
-	      else if (print_errors)
-		printerr (1, "empty literal character\n");
-	      return 0;
-	    case 0:
-	      if (valid)
-		*valid = 0;
-	      else if (print_errors)
-		printerr (1, "unexpected end of line after "
-			  "backslash in string constant\n");
-	      return 0;
-	    default:
-	      i = **p;
-	    }
-	  (*p)++;
-	}
-    }
-  else
-    (*p)++;
-  if (verbose >= 7)
-    fprintf (stderr, "%5d (0x%04x): rd_character returned %d (%c).\n",
-	     stack[sp].line, addr, i, i);
-  return i;
+	if (i == '\\') {
+		(*p)++;
+		if (**p >= '0' && **p <= '7') {
+			int b, num_digits;
+			i = 0;
+			if ((*p)[1] >= '0' && (*p)[1] <= '7') {
+				if (**p <= '3' && (*p)[2] >= '0' && (*p)[2] <= '7')
+					num_digits = 3;
+				else
+					num_digits = 2;
+			} else
+				num_digits = 1;
+			for (b = 0; b < num_digits; b++) {
+				int bit = (*p)[num_digits - 1 - b] - '0';
+				i += (1 << (b * 3)) * bit;
+			}
+			*p += num_digits;
+		} else {
+			switch (**p) {
+			case 'n':
+				i = 10;
+				break;
+			case 'r':
+				i = 13;
+				break;
+			case 't':
+				i = 9;
+				break;
+			case 'a':
+				i = 7;
+				break;
+			case '\'':
+				if (valid)
+					*valid = 0;
+				else if (print_errors)
+					RZ_LOG_ERROR("assembler: z80: empty literal character\n");
+				return 0;
+			case 0:
+				if (valid)
+					*valid = 0;
+				else if (print_errors)
+					RZ_LOG_ERROR("assembler: z80: unexpected end of line after "
+						     "backslash in string constant\n");
+				return 0;
+			default:
+				i = **p;
+			}
+			(*p)++;
+		}
+	} else
+		(*p)++;
+	if (state->verbose >= 7)
+		fprintf(stderr, "%5d (0x%04x): rd_character returned %d (%c).\n",
+			state->stack[state->sp].line, state->addr, i, i);
+	return i;
 }
 
 static int
-check_label (struct label *labels, const char **p, struct label **ret,
-	     struct label **previous, int force_skip)
-{
-  struct label *l;
-  const char *c;
-  unsigned s2;
-  *p = delspc (*p);
-  for (c = *p; isalnum ((const unsigned char)*c) || *c == '_' || *c == '.'; c++)
-    {
-    }
-  s2 = c - *p;
-  for (l = labels; l; l = l->next)
-    {
-      unsigned s1, s;
-      int cmp;
-      s1 = strlen (l->name);
-      s = s1 < s2 ? s1 : s2;
-      cmp = strncmp (l->name, *p, s);
-      if (cmp > 0 || (cmp == 0 && s1 > s))
-	{
-	  if (force_skip)
-	    *p = c;
-	  return 0;
+check_label(Z80AssemblerState *state, struct label *labels, const char **p, struct label **ret,
+	struct label **previous, int force_skip) {
+	struct label *l;
+	const char *c;
+	unsigned s2;
+	*p = delspc(*p);
+	for (c = *p; isalnum((const unsigned char)*c) || *c == '_' || *c == '.'; c++) {
 	}
-      if (cmp < 0 || s2 > s)
-	{
-	  if (previous)
-	    *previous = l;
-	  continue;
+	s2 = c - *p;
+	for (l = labels; l; l = l->next) {
+		unsigned s1, s;
+		int cmp;
+		s1 = strlen(l->name);
+		s = s1 < s2 ? s1 : s2;
+		cmp = strncmp(l->name, *p, s);
+		if (cmp > 0 || (cmp == 0 && s1 > s)) {
+			if (force_skip)
+				*p = c;
+			return 0;
+		}
+		if (cmp < 0 || s2 > s) {
+			if (previous)
+				*previous = l;
+			continue;
+		}
+		*p = c;
+		/* if label is not valid, compute it */
+		if (l->ref) {
+			compute_ref(state, l->ref, 1);
+			if (!l->ref->done) {
+				/* label was not valid, and isn't computable.  tell the
+				 * caller that it doesn't exist, so it will try again later.
+				 * Set ret to show actual existence.  */
+				if (state->verbose >= 6)
+					fprintf(stderr,
+						"%5d (0x%04x): returning invalid label %s.\n",
+						state->stack[state->sp].line, state->addr, l->name);
+				*ret = l;
+				return 0;
+			}
+		}
+		*ret = l;
+		return 1;
 	}
-      *p = c;
-      /* if label is not valid, compute it */
-      if (l->ref)
-	{
-	  compute_ref (l->ref, 1);
-	  if (!l->ref->done)
-	    {
-	      /* label was not valid, and isn't computable.  tell the
-	       * caller that it doesn't exist, so it will try again later.
-	       * Set ret to show actual existence.  */
-	      if (verbose >= 6)
-		fprintf (stderr,
-			 "%5d (0x%04x): returning invalid label %s.\n",
-			 stack[sp].line, addr, l->name);
-	      *ret = l;
-	      return 0;
-	    }
-	}
-      *ret = l;
-      return 1;
-    }
-  if (force_skip)
-    *p = c;
-  return 0;
+	if (force_skip)
+		*p = c;
+	return 0;
 }
 
 static int
-rd_label (const char **p, int *exists, struct label **previous, int level,
-	  int print_errors)
-{
-  struct label *l = NULL;
-  int s;
-  if (exists)
-    *exists = 0;
-  if (previous)
-    *previous = NULL;
-  if (verbose >= 6)
-    fprintf (stderr, "%5d (0x%04x): Starting to read label (string=%s).\n",
-	     stack[sp].line, addr, *p);
-  for (s = level; s >= 0; --s)
-    {
-      if (check_label (stack[s].labels, p, &l,
-		       (**p == '.' && s == sp) ? previous : NULL, 0))
-	break;
-    }
-  if (s < 0)
-    {
-      /* not yet found */
-      const char *old_p = *p;
-	  /* label does not exist, or is invalid.  This is an error if there
-	   * is no existence check.  */
-	  if (!exists && print_errors)
-	    printerr (1, "using undefined label %.*s\n", *p - old_p, old_p);
-	  /* Return a value to discriminate between non-existing and invalid */
-	  if (verbose >= 7)
-	    fprintf (stderr, "rd_label returns invalid value\n");
-	  return l != NULL;
-    }
-  if (exists)
-    *exists = 1;
-  if (verbose >= 7)
-    fprintf (stderr, "rd_label returns valid value 0x%x\n", l->value);
-  return l->value;
+rd_label(Z80AssemblerState *state, const char **p, int *exists, struct label **previous, int level,
+	int print_errors) {
+	struct label *l = NULL;
+	int s;
+	if (exists)
+		*exists = 0;
+	if (previous)
+		*previous = NULL;
+	if (state->verbose >= 6)
+		fprintf(stderr, "%5d (0x%04x): Starting to read label (string=%s).\n",
+			state->stack[state->sp].line, state->addr, *p);
+	for (s = level; s >= 0; --s) {
+		if (check_label(state, state->stack[s].labels, p, &l,
+			    (**p == '.' && s == state->sp) ? previous : NULL, 0))
+			break;
+	}
+	if (s < 0) {
+		/* Return a value to discriminate between non-existing and invalid */
+		if (state->verbose >= 7)
+			fprintf(stderr, "rd_label returns invalid value\n");
+		return l != NULL;
+	}
+	if (exists)
+		*exists = 1;
+	if (state->verbose >= 7)
+		fprintf(stderr, "rd_label returns valid value 0x%x\n", l->value);
+	return l->value;
 }
 
 static int
-rd_value (const char **p, int *valid, int level, int *check, int print_errors)
-{
-  int sign = 1, not = 0, base, v;
-  const char *p0, *p1, *p2;
-  if (verbose >= 6)
-    fprintf (stderr, "%5d (0x%04x): Starting to read value (string=%s).\n",
-	     stack[sp].line, addr, *p);
-  *p = delspc (*p);
-  while (**p && strchr ("+-~", **p))
-    {
-      if (**p == '-')
-	sign = -sign;
-      else if (**p == '~')
-	not = ~not;
-      (*p)++;
-      *p = delspc (*p);
-    }
-  base = 10;			/* Default base for suffixless numbers */
+rd_value(Z80AssemblerState *state, const char **p, int *valid, int level, int *check, int print_errors) {
+	int sign = 1, not = 0, base, v;
+	const char *p0, *p1, *p2;
+	if (state->verbose >= 6)
+		fprintf(stderr, "%5d (0x%04x): Starting to read value (string=%s).\n",
+			state->stack[state->sp].line, state->addr, *p);
+	*p = delspc(*p);
+	while (**p && strchr("+-~", **p)) {
+		if (**p == '-')
+			sign = -sign;
+		else if (**p == '~')
+			not = ~not ;
+		(*p)++;
+		*p = delspc(*p);
+	}
+	base = 10; /* Default base for suffixless numbers */
 
-  /* Check for parenthesis around full expression: not if no parenthesis */
-  if (**p != '(')
-    *check = 0;
+	/* Check for parenthesis around full expression: not if no parenthesis */
+	if (**p != '(')
+		*check = 0;
 
-  switch (**p)
-    {
-      int exist, retval;
-      char quote;
-      int dummy_check;
-    case '(':
-      (*p)++;
-      dummy_check = 0;
-      retval = not ^ (sign * do_rd_expr (p, ')', valid, level, &dummy_check,
-					 print_errors));
-      ++*p;
-      return retval;
-    case '0':
-      if ((*p)[1] == 'x')
-	{
-	  (*p) += 2;
-	  return not ^ (sign * rd_number (p, NULL, 0x10));
+	switch (**p) {
+		int exist, retval;
+		char quote;
+		int dummy_check;
+	case '(':
+		(*p)++;
+		dummy_check = 0;
+		retval = not ^(sign *do_rd_expr(state, p, ')', valid, level, &dummy_check,
+			print_errors));
+		++*p;
+		return retval;
+	case '0':
+		if ((*p)[1] == 'x') {
+			(*p) += 2;
+			return not ^(sign *rd_number(state, p, NULL, 0x10));
+		}
+		base = 8; /* If first digit it 0, assume octal unless suffix */
+		/* fall through */
+	case '1':
+	case '2':
+	case '3':
+	case '4':
+	case '5':
+	case '6':
+	case '7':
+	case '8':
+	case '9':
+		p0 = *p;
+		rd_number(state, p, &p1, 36); /* Advance to end of numeric string */
+		p1--; /* Last character in numeric string */
+		switch (*p1) {
+		case 'h':
+		case 'H':
+			base = 16;
+			break;
+		case 'b':
+		case 'B':
+			base = 2;
+			break;
+		case 'o':
+		case 'O':
+		case 'q':
+		case 'Q':
+			base = 8;
+			break;
+		case 'd':
+		case 'D':
+			base = 10;
+			break;
+		default: /* No suffix */
+			p1++;
+			break;
+		}
+		v = rd_number(state, &p0, &p2, base);
+		if (p1 != p2) {
+			if (valid)
+				*valid = 0;
+			else if (print_errors)
+				RZ_LOG_ERROR("assembler: z80: invalid character in number: \'%c\'\n", *p2);
+		}
+		return not ^(sign *v);
+	case '$':
+		++*p;
+		*p = delspc(*p);
+		p0 = *p;
+		v = rd_number(state, &p0, &p2, 0x10);
+		if (p2 == *p) {
+			v = state->baseaddr;
+		} else
+			*p = p2;
+		return not ^(sign *v);
+	case '%':
+		(*p)++;
+		return not ^(sign *rd_number(state, p, NULL, 2));
+	case '\'':
+	case '"':
+		quote = **p;
+		++*p;
+		retval = not ^(sign *rd_character(state, p, valid, print_errors));
+		if (**p != quote) {
+			if (valid)
+				*valid = 0;
+			else if (print_errors)
+				RZ_LOG_ERROR("assembler: z80: missing closing quote (%c)\n", quote);
+			return 0;
+		}
+		++*p;
+		return retval;
+	case '@':
+		return not ^(sign *rd_otherbasenumber(state, p, valid, print_errors));
+	case '?':
+		rd_label(state, p, &exist, NULL, level, 0);
+		return not ^(sign *exist);
+	case '&': {
+		++*p;
+		switch (**p) {
+		case 'h':
+		case 'H':
+			base = 0x10;
+			break;
+		case 'o':
+		case 'O':
+			base = 010;
+			break;
+		case 'b':
+		case 'B':
+			base = 2;
+			break;
+		default:
+			if (valid)
+				*valid = 0;
+			else if (print_errors)
+				RZ_LOG_ERROR("assembler: z80: invalid literal starting with &%c\n", **p);
+			return 0;
+		}
+		++*p;
+		return not ^(sign *rd_number(state, p, NULL, base));
 	}
-      base = 8;		/* If first digit it 0, assume octal unless suffix */
-      /* fall through */
-    case '1':
-    case '2':
-    case '3':
-    case '4':
-    case '5':
-    case '6':
-    case '7':
-    case '8':
-    case '9':
-      p0 = *p;
-      rd_number (p, &p1, 36);	/* Advance to end of numeric string */
-      p1--;			/* Last character in numeric string */
-      switch (*p1)
-	{
-	case 'h':
-	case 'H':
-	  base = 16;
-	  break;
-	case 'b':
-	case 'B':
-	  base = 2;
-	  break;
-	case 'o':
-	case 'O':
-	case 'q':
-	case 'Q':
-	  base = 8;
-	  break;
-	case 'd':
-	case 'D':
-	  base = 10;
-	  break;
-	default:		/* No suffix */
-	  p1++;
-	  break;
+	default: {
+		int value;
+		exist = 1;
+		value = rd_label(state, p, valid ? &exist : NULL, NULL, level, print_errors);
+		if (!exist)
+			*valid = 0;
+		return not ^(sign *value);
 	}
-      v = rd_number (&p0, &p2, base);
-      if (p1 != p2)
-	{
-	  if (valid)
-	    *valid = 0;
-	  else if (print_errors)
-	    printerr (1, "invalid character in number: \'%c\'\n", *p2);
 	}
-      return not ^ (sign * v);
-    case '$':
-      ++*p;
-      *p = delspc (*p);
-      p0 = *p;
-      v = rd_number (&p0, &p2, 0x10);
-      if (p2 == *p)
-	{
-	  v = baseaddr;
-	}
-      else
-	*p = p2;
-      return not ^ (sign * v);
-    case '%':
-      (*p)++;
-      return not ^ (sign * rd_number (p, NULL, 2));
-    case '\'':
-    case '"':
-      quote = **p;
-      ++*p;
-      retval = not ^ (sign * rd_character (p, valid, print_errors));
-      if (**p != quote)
-	{
-	  if (valid)
-	    *valid = 0;
-	  else if (print_errors)
-	    printerr (1, "missing closing quote (%c)\n", quote);
-	  return 0;
-	}
-      ++*p;
-      return retval;
-    case '@':
-      return not ^ (sign * rd_otherbasenumber (p, valid, print_errors));
-    case '?':
-      rd_label (p, &exist, NULL, level, 0);
-      return not ^ (sign * exist);
-    case '&':
-      {
-	++*p;
-	switch (**p)
-	  {
-	  case 'h':
-	  case 'H':
-	    base = 0x10;
-	    break;
-	  case 'o':
-	  case 'O':
-	    base = 010;
-	    break;
-	  case 'b':
-	  case 'B':
-	    base = 2;
-	    break;
-	  default:
-	    if (valid)
-	      *valid = 0;
-	    else if (print_errors)
-	      printerr (1, "invalid literal starting with &%c\n", **p);
-	    return 0;
-	  }
-	++*p;
-	return not ^ (sign * rd_number (p, NULL, base));
-      }
-    default:
-      {
-	int value;
-	exist = 1;
-	value = rd_label (p, valid ? &exist : NULL, NULL, level, print_errors);
-	if (!exist)
-	  *valid = 0;
-	return not ^ (sign * value);
-      }
-    }
 }
 
 static int
-rd_factor (const char **p, int *valid, int level, int *check, int print_errors)
-{
-  /* read a factor of an expression */
-  int result;
-  if (verbose >= 6)
-    fprintf (stderr, "%5d (0x%04x): Starting to read factor (string=%s).\n",
-	     stack[sp].line, addr, *p);
-  result = rd_value (p, valid, level, check, print_errors);
-  *p = delspc (*p);
-  while (**p == '*' || **p == '/')
-    {
-      *check = 0;
-      if (**p == '*')
-	{
-	  (*p)++;
-	  result *= rd_value (p, valid, level, check, print_errors);
+rd_factor(Z80AssemblerState *state, const char **p, int *valid, int level, int *check, int print_errors) {
+	/* read a factor of an expression */
+	int result;
+	if (state->verbose >= 6)
+		fprintf(stderr, "%5d (0x%04x): Starting to read factor (string=%s).\n",
+			state->stack[state->sp].line, state->addr, *p);
+	result = rd_value(state, p, valid, level, check, print_errors);
+	*p = delspc(*p);
+	while (**p == '*' || **p == '/') {
+		*check = 0;
+		if (**p == '*') {
+			(*p)++;
+			result *= rd_value(state, p, valid, level, check, print_errors);
+		} else if (**p == '/') {
+			(*p)++;
+			int value = rd_value(state, p, valid, level, check, print_errors);
+			if (value == 0) {
+				RZ_LOG_ERROR("assembler: z80: division by zero\n");
+				return -1;
+			}
+			result /= value;
+		}
+		*p = delspc(*p);
 	}
-      else if (**p == '/')
-	{
-	  (*p)++;
-      int value = rd_value (p, valid, level, check, print_errors);
-      if (value == 0){ 
-        printerr (1, "division by zero\n");
-        return -1;
-      }
-      result /= value;
+	if (state->verbose >= 7)
+		fprintf(stderr, "%5d (0x%04x): rd_factor returned %d (%04x).\n",
+			state->stack[state->sp].line, state->addr, result, result);
+	return result;
+}
+
+static int
+rd_term(Z80AssemblerState *state, const char **p, int *valid, int level, int *check, int print_errors) {
+	/* read a term of an expression */
+	int result;
+	if (state->verbose >= 6)
+		fprintf(stderr, "%5d (0x%04x): Starting to read term (string=%s).\n",
+			state->stack[state->sp].line, state->addr, *p);
+	result = rd_factor(state, p, valid, level, check, print_errors);
+	*p = delspc(*p);
+	while (**p == '+' || **p == '-') {
+		*check = 0;
+		if (**p == '+') {
+			(*p)++;
+			result += rd_factor(state, p, valid, level, check, print_errors);
+		} else if (**p == '-') {
+			(*p)++;
+			result -= rd_factor(state, p, valid, level, check, print_errors);
+		}
+		*p = delspc(*p);
 	}
-      *p = delspc (*p);
-    }
-  if (verbose >= 7)
-    fprintf (stderr, "%5d (0x%04x): rd_factor returned %d (%04x).\n",
-	     stack[sp].line, addr, result, result);
-  return result;
+	if (state->verbose >= 7)
+		fprintf(stderr, "%5d (0x%04x): rd_term returned %d (%04x).\n",
+			state->stack[state->sp].line, state->addr, result, result);
+	return result;
 }
 
 static int
-rd_term (const char **p, int *valid, int level, int *check, int print_errors)
-{
-  /* read a term of an expression */
-  int result;
-  if (verbose >= 6)
-    fprintf (stderr, "%5d (0x%04x): Starting to read term (string=%s).\n",
-	     stack[sp].line, addr, *p);
-  result = rd_factor (p, valid, level, check, print_errors);
-  *p = delspc (*p);
-  while (**p == '+' || **p == '-')
-    {
-      *check = 0;
-      if (**p == '+')
-	{
-	  (*p)++;
-	  result += rd_factor (p, valid, level, check, print_errors);
+rd_expr_shift(Z80AssemblerState *state, const char **p, int *valid, int level, int *check,
+	int print_errors) {
+	int result;
+	if (state->verbose >= 6)
+		fprintf(stderr, "%5d (0x%04x): Starting to read shift expression "
+				"(string=%s).\n",
+			state->stack[state->sp].line, state->addr, *p);
+	result = rd_term(state, p, valid, level, check, print_errors);
+	*p = delspc(*p);
+	while ((**p == '<' || **p == '>') && (*p)[1] == **p) {
+		*check = 0;
+		if (**p == '<') {
+			(*p) += 2;
+			result <<= rd_term(state, p, valid, level, check, print_errors);
+		} else if (**p == '>') {
+			(*p) += 2;
+			result >>= rd_term(state, p, valid, level, check, print_errors);
+		}
+		*p = delspc(*p);
 	}
-      else if (**p == '-')
-	{
-	  (*p)++;
-	  result -= rd_factor (p, valid, level, check, print_errors);
+	if (state->verbose >= 7)
+		fprintf(stderr, "%5d (0x%04x): rd_shift returned %d (%04x).\n",
+			state->stack[state->sp].line, state->addr, result, result);
+	return result;
+}
+
+static int
+rd_expr_unequal(Z80AssemblerState *state, const char **p, int *valid, int level, int *check,
+	int print_errors) {
+	int result;
+	if (state->verbose >= 6)
+		fprintf(stderr, "%5d (0x%04x): Starting to read "
+				"unequality expression (string=%s).\n",
+			state->stack[state->sp].line, state->addr,
+			*p);
+	result = rd_expr_shift(state, p, valid, level, check, print_errors);
+	*p = delspc(*p);
+	if (**p == '<' && (*p)[1] == '=') {
+		*check = 0;
+		(*p) += 2;
+		return result <= rd_expr_unequal(state, p, valid, level, check, print_errors);
+	} else if (**p == '>' && (*p)[1] == '=') {
+		*check = 0;
+		(*p) += 2;
+		return result >= rd_expr_unequal(state, p, valid, level, check, print_errors);
 	}
-      *p = delspc (*p);
-    }
-  if (verbose >= 7)
-    fprintf (stderr, "%5d (0x%04x): rd_term returned %d (%04x).\n",
-	     stack[sp].line, addr, result, result);
-  return result;
-}
-
-static int
-rd_expr_shift (const char **p, int *valid, int level, int *check,
-	       int print_errors)
-{
-  int result;
-  if (verbose >= 6)
-    fprintf (stderr, "%5d (0x%04x): Starting to read shift expression "
-	     "(string=%s).\n", stack[sp].line, addr, *p);
-  result = rd_term (p, valid, level, check, print_errors);
-  *p = delspc (*p);
-  while ((**p == '<' || **p == '>') && (*p)[1] == **p)
-    {
-      *check = 0;
-      if (**p == '<')
-	{
-	  (*p) += 2;
-	  result <<= rd_term (p, valid, level, check, print_errors);
+	if (**p == '<' && (*p)[1] != '<') {
+		*check = 0;
+		(*p)++;
+		return result < rd_expr_unequal(state, p, valid, level, check, print_errors);
+	} else if (**p == '>' && (*p)[1] != '>') {
+		*check = 0;
+		(*p)++;
+		return result > rd_expr_unequal(state, p, valid, level, check, print_errors);
 	}
-      else if (**p == '>')
-	{
-	  (*p) += 2;
-	  result >>= rd_term (p, valid, level, check, print_errors);
+	if (state->verbose >= 7)
+		fprintf(stderr, "%5d (0x%04x): rd_shift returned %d (%04x).\n",
+			state->stack[state->sp].line, state->addr, result, result);
+	return result;
+}
+
+static int
+rd_expr_equal(Z80AssemblerState *state, const char **p, int *valid, int level, int *check,
+	int print_errors) {
+	int result;
+	if (state->verbose >= 6)
+		fprintf(stderr, "%5d (0x%04x): Starting to read equality epression "
+				"(string=%s).\n",
+			state->stack[state->sp].line, state->addr, *p);
+	result = rd_expr_unequal(state, p, valid, level, check, print_errors);
+	*p = delspc(*p);
+	if (**p == '=') {
+		*check = 0;
+		++*p;
+		if (**p == '=')
+			++*p;
+		return result == rd_expr_equal(state, p, valid, level, check, print_errors);
+	} else if (**p == '!' && (*p)[1] == '=') {
+		*check = 0;
+		(*p) += 2;
+		return result != rd_expr_equal(state, p, valid, level, check, print_errors);
 	}
-      *p = delspc (*p);
-    }
-  if (verbose >= 7)
-    fprintf (stderr, "%5d (0x%04x): rd_shift returned %d (%04x).\n",
-	     stack[sp].line, addr, result, result);
-  return result;
+	if (state->verbose >= 7)
+		fprintf(stderr, "%5d (0x%04x): rd_equal returned %d (%04x).\n",
+			state->stack[state->sp].line, state->addr, result, result);
+	return result;
 }
 
 static int
-rd_expr_unequal (const char **p, int *valid, int level, int *check,
-		 int print_errors)
-{
-  int result;
-  if (verbose >= 6)
-    fprintf (stderr, "%5d (0x%04x): Starting to read "
-	     "unequality expression (string=%s).\n", stack[sp].line, addr,
-	     *p);
-  result = rd_expr_shift (p, valid, level, check, print_errors);
-  *p = delspc (*p);
-  if (**p == '<' && (*p)[1] == '=')
-    {
-      *check = 0;
-      (*p) += 2;
-      return result <= rd_expr_unequal (p, valid, level, check, print_errors);
-    }
-  else if (**p == '>' && (*p)[1] == '=')
-    {
-      *check = 0;
-      (*p) += 2;
-      return result >= rd_expr_unequal (p, valid, level, check, print_errors);
-    }
-  if (**p == '<' && (*p)[1] != '<')
-    {
-      *check = 0;
-      (*p)++;
-      return result < rd_expr_unequal (p, valid, level, check, print_errors);
-    }
-  else if (**p == '>' && (*p)[1] != '>')
-    {
-      *check = 0;
-      (*p)++;
-      return result > rd_expr_unequal (p, valid, level, check, print_errors);
-    }
-  if (verbose >= 7)
-    fprintf (stderr, "%5d (0x%04x): rd_shift returned %d (%04x).\n",
-	     stack[sp].line, addr, result, result);
-  return result;
-}
-
-static int
-rd_expr_equal (const char **p, int *valid, int level, int *check,
-	       int print_errors)
-{
-  int result;
-  if (verbose >= 6)
-    fprintf (stderr, "%5d (0x%04x): Starting to read equality epression "
-	     "(string=%s).\n", stack[sp].line, addr, *p);
-  result = rd_expr_unequal (p, valid, level, check, print_errors);
-  *p = delspc (*p);
-  if (**p == '=')
-    {
-      *check = 0;
-      ++*p;
-      if (**p == '=')
-	++ * p;
-      return result == rd_expr_equal (p, valid, level, check, print_errors);
-    }
-  else if (**p == '!' && (*p)[1] == '=')
-    {
-      *check = 0;
-      (*p) += 2;
-      return result != rd_expr_equal (p, valid, level, check, print_errors);
-    }
-  if (verbose >= 7)
-    fprintf (stderr, "%5d (0x%04x): rd_equal returned %d (%04x).\n",
-	     stack[sp].line, addr, result, result);
-  return result;
-}
-
-static int
-rd_expr_and (const char **p, int *valid, int level, int *check,
-	     int print_errors)
-{
-  int result;
-  if (verbose >= 6)
-    fprintf (stderr, "%5d (0x%04x): Starting to read and expression "
-	     "(string=%s).\n", stack[sp].line, addr, *p);
-  result = rd_expr_equal (p, valid, level, check, print_errors);
-  *p = delspc (*p);
-  if (**p == '&')
-    {
-      *check = 0;
-      (*p)++;
-      result &= rd_expr_and (p, valid, level, check, print_errors);
-    }
-  if (verbose >= 7)
-    fprintf (stderr, "%5d (0x%04x): rd_expr_and returned %d (%04x).\n",
-	     stack[sp].line, addr, result, result);
-  return result;
-}
-
-static int
-rd_expr_xor (const char **p, int *valid, int level, int *check,
-	     int print_errors)
-{
-  int result;
-  if (verbose >= 6)
-    fprintf (stderr, "%5d (0x%04x): Starting to read xor expression "
-	     "(string=%s).\n", stack[sp].line, addr, *p);
-  result = rd_expr_and (p, valid, level, check, print_errors);
-  if (verbose >= 7)
-    fprintf (stderr, "%5d (0x%04x): rd_expr_xor: rd_expr_and returned %d "
-	     "(%04x).\n", stack[sp].line, addr, result, result);
-  *p = delspc (*p);
-  if (**p == '^')
-    {
-      *check = 0;
-      (*p)++;
-      result ^= rd_expr_xor (p, valid, level, check, print_errors);
-    }
-  if (verbose >= 7)
-    fprintf (stderr, "%5d (0x%04x): rd_expr_xor returned %d (%04x).\n",
-	     stack[sp].line, addr, result, result);
-  return result;
-}
-
-static int
-rd_expr_or (const char **p, int *valid, int level, int *check,
-	    int print_errors)
-{
-  int result;
-  if (verbose >= 6)
-    fprintf (stderr, "%5d (0x%04x): Starting to read or expression "
-	     "(string=%s).\n", stack[sp].line, addr, *p);
-  result = rd_expr_xor (p, valid, level, check, print_errors);
-  if (verbose >= 7)
-    fprintf (stderr, "%5d (0x%04x): rd_expr_or: rd_expr_xor returned %d "
-	     "(%04x).\n", stack[sp].line, addr, result, result);
-  *p = delspc (*p);
-  if (**p == '|')
-    {
-      *check = 0;
-      (*p)++;
-      result |= rd_expr_or (p, valid, level, check, print_errors);
-    }
-  if (verbose >= 7)
-    fprintf (stderr, "%5d (0x%04x): rd_expr_or returned %d (%04x).\n",
-	     stack[sp].line, addr, result, result);
-  return result;
-}
-
-static int
-do_rd_expr (const char **p, char delimiter, int *valid, int level, int *check,
-	    int print_errors)
-{
-  /* read an expression. delimiter can _not_ be '?' */
-  int result = 0;
-  if (verbose >= 6)
-    fprintf (stderr,
-	     "%5d (0x%04x): Starting to read expression "
-	     "(string=%s, delimiter=%c).\n", stack[sp].line, addr, *p,
-	     delimiter ? delimiter : ' ');
-  *p = delspc (*p);
-  if (!**p || **p == delimiter)
-    {
-      if (valid)
-	*valid = 0;
-      else if (print_errors)
-	printerr (1, "expression expected (not %s)\n", *p);
-      return 0;
-    }
-  result = rd_expr_or (p, valid, level, check, print_errors);
-  *p = delspc (*p);
-  if (**p == '?')
-    {
-      *check = 0;
-      (*p)++;
-      if (result)
-	{
-	  result = do_rd_expr (p, ':', valid, level, check, print_errors);
-	  if (**p)
-	    (*p)++;
-	  do_rd_expr (p, delimiter, valid, level, check, print_errors);
+rd_expr_and(Z80AssemblerState *state, const char **p, int *valid, int level, int *check,
+	int print_errors) {
+	int result;
+	if (state->verbose >= 6)
+		fprintf(stderr, "%5d (0x%04x): Starting to read and expression "
+				"(string=%s).\n",
+			state->stack[state->sp].line, state->addr, *p);
+	result = rd_expr_equal(state, p, valid, level, check, print_errors);
+	*p = delspc(*p);
+	if (**p == '&') {
+		*check = 0;
+		(*p)++;
+		result &= rd_expr_and(state, p, valid, level, check, print_errors);
 	}
-      else
-	{
-	  do_rd_expr (p, ':', valid, level, check, print_errors);
-	  if (**p)
-	    (*p)++;
-	  result = do_rd_expr (p, delimiter, valid, level, check,
-			       print_errors);
-	}
-    }
-  *p = delspc (*p);
-  if (**p && **p != delimiter)
-    {
-      if (valid)
-	*valid = 0;
-      else if (print_errors)
-	printerr (1, "junk at end of expression: %s\n", *p);
-    }
-  if (verbose >= 7)
-    {
-      fprintf (stderr, "%5d (0x%04x): rd_expr returned %d (%04x).\n",
-	       stack[sp].line, addr, result, result);
-      if (valid && !*valid)
-	fprintf (stderr, "%5d (0x%04x): Returning invalid result.\n",
-		 stack[sp].line, addr);
-    }
-  return result;
+	if (state->verbose >= 7)
+		fprintf(stderr, "%5d (0x%04x): rd_expr_and returned %d (%04x).\n",
+			state->stack[state->sp].line, state->addr, result, result);
+	return result;
 }
 
 static int
-rd_expr (const char **p, char delimiter, int *valid, int level,
-	 int print_errors)
-{
-  int check = 1;
-  int result;
-  if (valid)
-    *valid = 1;
-  result = do_rd_expr (p, delimiter, valid, level, &check, print_errors);
-  if (print_errors && (!valid || *valid) && check)
-    printerr (0, "expression fully enclosed in parenthesis\n");
-  return result;
+rd_expr_xor(Z80AssemblerState *state, const char **p, int *valid, int level, int *check,
+	int print_errors) {
+	int result;
+	if (state->verbose >= 6)
+		fprintf(stderr, "%5d (0x%04x): Starting to read xor expression "
+				"(string=%s).\n",
+			state->stack[state->sp].line, state->addr, *p);
+	result = rd_expr_and(state, p, valid, level, check, print_errors);
+	if (state->verbose >= 7)
+		fprintf(stderr, "%5d (0x%04x): rd_expr_xor: rd_expr_and returned %d "
+				"(%04x).\n",
+			state->stack[state->sp].line, state->addr, result, result);
+	*p = delspc(*p);
+	if (**p == '^') {
+		*check = 0;
+		(*p)++;
+		result ^= rd_expr_xor(state, p, valid, level, check, print_errors);
+	}
+	if (state->verbose >= 7)
+		fprintf(stderr, "%5d (0x%04x): rd_expr_xor returned %d (%04x).\n",
+			state->stack[state->sp].line, state->addr, result, result);
+	return result;
+}
+
+static int
+rd_expr_or(Z80AssemblerState *state, const char **p, int *valid, int level, int *check,
+	int print_errors) {
+	int result;
+	if (state->verbose >= 6)
+		fprintf(stderr, "%5d (0x%04x): Starting to read or expression "
+				"(string=%s).\n",
+			state->stack[state->sp].line, state->addr, *p);
+	result = rd_expr_xor(state, p, valid, level, check, print_errors);
+	if (state->verbose >= 7)
+		fprintf(stderr, "%5d (0x%04x): rd_expr_or: rd_expr_xor returned %d "
+				"(%04x).\n",
+			state->stack[state->sp].line, state->addr, result, result);
+	*p = delspc(*p);
+	if (**p == '|') {
+		*check = 0;
+		(*p)++;
+		result |= rd_expr_or(state, p, valid, level, check, print_errors);
+	}
+	if (state->verbose >= 7)
+		fprintf(stderr, "%5d (0x%04x): rd_expr_or returned %d (%04x).\n",
+			state->stack[state->sp].line, state->addr, result, result);
+	return result;
+}
+
+static int
+do_rd_expr(Z80AssemblerState *state, const char **p, char delimiter, int *valid, int level, int *check,
+	int print_errors) {
+	/* read an expression. delimiter can _not_ be '?' */
+	int result = 0;
+	if (state->verbose >= 6)
+		fprintf(stderr,
+			"%5d (0x%04x): Starting to read expression "
+			"(string=%s, delimiter=%c).\n",
+			state->stack[state->sp].line, state->addr, *p,
+			delimiter ? delimiter : ' ');
+	*p = delspc(*p);
+	if (!**p || **p == delimiter) {
+		if (valid)
+			*valid = 0;
+		else if (print_errors)
+			RZ_LOG_ERROR("assembler: z80: expression expected (not %s)\n", *p);
+		return 0;
+	}
+	result = rd_expr_or(state, p, valid, level, check, print_errors);
+	*p = delspc(*p);
+	if (**p == '?') {
+		*check = 0;
+		(*p)++;
+		if (result) {
+			result = do_rd_expr(state, p, ':', valid, level, check, print_errors);
+			if (**p)
+				(*p)++;
+			do_rd_expr(state, p, delimiter, valid, level, check, print_errors);
+		} else {
+			do_rd_expr(state, p, ':', valid, level, check, print_errors);
+			if (**p)
+				(*p)++;
+			result = do_rd_expr(state, p, delimiter, valid, level, check,
+				print_errors);
+		}
+	}
+	*p = delspc(*p);
+	if (**p && **p != delimiter) {
+		if (valid)
+			*valid = 0;
+		else if (print_errors)
+			RZ_LOG_ERROR("assembler: z80: junk at end of expression: %s\n", *p);
+	}
+	if (state->verbose >= 7) {
+		fprintf(stderr, "%5d (0x%04x): rd_expr returned %d (%04x).\n",
+			state->stack[state->sp].line, state->addr, result, result);
+		if (valid && !*valid)
+			fprintf(stderr, "%5d (0x%04x): Returning invalid result.\n",
+				state->stack[state->sp].line, state->addr);
+	}
+	return result;
+}
+
+static int
+rd_expr(Z80AssemblerState *state, const char **p, char delimiter, int *valid, int level,
+	int print_errors) {
+	int check = 1;
+	int result;
+	if (valid)
+		*valid = 1;
+	result = do_rd_expr(state, p, delimiter, valid, level, &check, print_errors);
+	if (print_errors && (!valid || *valid) && check)
+		RZ_LOG_WARN("assembler: z80: expression fully enclosed in parenthesis\n");
+	return result;
 }

--- a/librz/arch/isa_gnu/z80/z80asm.c
+++ b/librz/arch/isa_gnu/z80/z80asm.c
@@ -29,14 +29,10 @@
 #endif
 #include "z80asm.h"
 #include <rz_util.h>
-
 /* hack */
-// must remove: equ, include, incbin, macro
-// static void wrt_ref (int val, int type, int count);
-static unsigned char *obuf;
-static int obuflen = 0;
-#define write_one_byte(x, y) obuf[obuflen++] = x
-#define wrtb(x) obuf[obuflen++] = x
+#include "expressions.c"
+
+#define wrtb(state, x) state.obuf[state.obuflen++] = x
 
 /* global variables */
 /* mnemonics, used as argument to indx() in assemble */
@@ -53,65 +49,6 @@ static const char *mnemonics[] = {
 	"include", "incbin", "if", "else", "endif", "end", "macro", "endm",
 	"seek", NULL
 };
-
-/* current line, address and file */
-static int addr = 0, file;
-/* current number of characters in list file, for indentation */
-// static int listdepth;
-
-/* use readbyte instead of (hl) if writebyte is true */
-static int writebyte;
-static const char *readbyte;
-/* variables which are filled by rd_* functions and used later,
- * like readbyte */
-static const char *readword, *indexjmp, *bitsetres;
-
-/* 0, 0xdd or 0xfd depening on which index prefix should be given */
-static int indexed;
-
-/* increased for every -v option on the command line */
-static int verbose = 0;
-
-/* read commas after indx() if comma > 1. increase for every call */
-static int comma;
-
-/* address at start of line (for references) */
-static int baseaddr;
-
-/* set by readword and readbyte, used for new_reference */
-static char mem_delimiter;
-
-/* line currently being parsed */
-static char *z80buffer = NULL;
-
-/* if a macro is currently being defined */
-static int define_macro = 0;
-
-/* file (and macro) stack */
-static int sp;
-static struct stack stack[MAX_INCLUDE];	/* maximum level of includes */
-
-/* hack */
-#include "expressions.c"
-
-/* print an error message, including current line and file */
-static void printerr(int error, const char *fmt, ...) {
-#if 0
-	va_list l;
-	va_start (l, fmt);
-	if ((sp < 0) || (stack[sp].name == 0)) {
-		fprintf (stderr, "internal assembler error, sp == %i\n", sp);
-		vfprintf (stderr, fmt, l);
-	}
-	fprintf (stderr, "%s%s:%d: %s: ", stack[sp].dir? stack[sp].dir->name: "",
-		stack[sp].name, stack[sp].line, error? "error": "warning");
-	vfprintf (stderr, fmt, l);
-	va_end (l);
-	if (error) {
-		errors++;
-	}
-#endif
-}
 
 /* skip over spaces in string */
 static const char *delspc(const char *ptr) {
@@ -142,16 +79,16 @@ static int has_argument(const char **p) {
 /* During assembly, many literals are not parsed.  Instead, they are saved
  * until all labels are read.  After that, they are parsed.  This function
  * is used during assembly, to find the place where the command continues. */
-static void skipword(const char **pos, char delimiter) {
+static void skipword(Z80AssemblerState *state, const char **pos, char delimiter, int sp) {
 	/* rd_expr will happily read the expression, and possibly return
 	 * an invalid result.  It will update pos, which is what we need.  */
 	/* Pass valid to allow using undefined labels without errors.  */
 	int valid;
-	rd_expr (pos, delimiter, &valid, sp, 0);
+	rd_expr(state, pos, delimiter, &valid, sp, 0);
 }
 
 /* find any of the list[] entries as the start of ptr and return index */
-static int indx(const char **ptr, const char **list, int error, const char **expr) {
+static int indx(Z80AssemblerState *state, const char **ptr, const char **list, int error, const char **expr) {
 	int i;
 	*ptr = delspc (*ptr);
 	if (!**ptr) {
@@ -162,7 +99,7 @@ static int indx(const char **ptr, const char **list, int error, const char **exp
 			return 0;
 		}
 	}
-	if (comma > 1) {
+	if (state->comma > 1) {
 		rd_comma (ptr);
 	}
 	for (i = 0; list[i]; i++) {
@@ -177,14 +114,14 @@ static int indx(const char **ptr, const char **list, int error, const char **exp
 				input = delspc (input);
 			} else if (*check == '*') {
 				*expr = input;
-				mem_delimiter = check[1];
-				rd_expr (&input, mem_delimiter, NULL, sp, 0);
+				state->mem_delimiter = check[1];
+				rd_expr(state, &input, state->mem_delimiter, NULL, state->sp, 0);
 				had_expr = 1;
 			} else if (*check == '+') {
 				if (*input == '+' || *input == '-') {
 					*expr = input;
-					mem_delimiter = check[1];
-					rd_expr (&input, mem_delimiter, NULL, sp, 0);
+					state->mem_delimiter = check[1];
+					rd_expr(state, &input, state->mem_delimiter, NULL, state->sp, 0);
 				}
 			} else if (*check == *input || (*check >= 'a' && *check <= 'z'
 							&& *check - 'a' + 'A' == *input)) {
@@ -205,7 +142,7 @@ static int indx(const char **ptr, const char **list, int error, const char **exp
 			}
 		}
 		*ptr = input;
-		comma++;
+		state->comma++;
 		return i + 1;
 	}
 	// if (error) RZ_LOG_ERROR("assembler: z80: parse error. Remainder of line=%s\n", *ptr);
@@ -213,12 +150,12 @@ static int indx(const char **ptr, const char **list, int error, const char **exp
 }
 
 /* read a mnemonic */
-static int readcommand(const char **p) {
-	return indx (p, mnemonics, 0, NULL);
+static int readcommand(Z80AssemblerState *state, const char **p) {
+	return indx(state, p, mnemonics, 0, NULL);
 }
 
 /* try to read a label and optionally store it in the list */
-static void readlabel(const char **p, int store) {
+static void readlabel(Z80AssemblerState *state, const char **p, int store, int sp) {
 	const char *c, *d, *pos, *dummy;
 	int i, j;
 	struct label *previous;
@@ -242,7 +179,7 @@ static void readlabel(const char **p, int store) {
 	}
 	c = pos + 1;
 	dummy = *p;
-	j = rd_label (&dummy, &i, &previous, sp, 0);
+	j = rd_label(state, &dummy, &i, &previous, sp, 0);
 	if (i || j) {
 		RZ_LOG_ERROR("assembler: z80: duplicate definition of label %s\n", *p);
 		*p = c;
@@ -252,96 +189,98 @@ static void readlabel(const char **p, int store) {
 	*p = c;
 }
 
-static int compute_ref(struct reference *ref, int allow_invalid) {
+static int compute_ref(Z80AssemblerState *state, struct reference *ref, int allow_invalid) {
 	const char *ptr;
 	int valid = 0;
-	int backup_addr = addr;
-	int backup_baseaddr = baseaddr;
-	int backup_comma = comma;
-	int backup_file = file;
-	int backup_sp = sp;
-	sp = ref->level;
-	addr = ref->addr;
-	baseaddr = ref->baseaddr;
-	comma = ref->comma;
-	file = ref->infile;
+	int backup_addr = state->addr;
+	int backup_baseaddr = state->baseaddr;
+	int backup_comma = state->comma;
+	int backup_file = state->file;
+	int backup_sp = state->sp;
+
+	state->sp = ref->level;
+	state->addr = ref->addr;
+	state->baseaddr = ref->baseaddr;
+	state->comma = ref->comma;
+	state->file = ref->infile;
 	ptr = ref->input;
 	if (!ref->done) {
-		ref->computed_value = rd_expr (&ptr, ref->delimiter,
-			allow_invalid? &valid: NULL,
+		ref->computed_value = rd_expr(state, &ptr, ref->delimiter,
+			allow_invalid ? &valid : NULL,
 			ref->level, 1);
 		if (valid) {
 			ref->done = 1;
 		}
 	}
-	sp = backup_sp;
-	addr = backup_addr;
-	baseaddr = backup_baseaddr;
-	comma = backup_comma;
-	file = backup_file;
+
+	state->sp = backup_sp;
+	state->addr = backup_addr;
+	state->baseaddr = backup_baseaddr;
+	state->comma = backup_comma;
+	state->file = backup_file;
 	return ref->computed_value;
 }
 
 /* read a word from input and store it in readword. return 1 on success */
-static int rd_word(const char **p, char delimiter) {
+static int rd_word(Z80AssemblerState *state, const char **p, char delimiter) {
 	*p = delspc (*p);
 	if (**p == 0) {
 		return 0;
 	}
-	readword = *p;
-	mem_delimiter = delimiter;
-	skipword (p, delimiter);
+	state->readword = *p;
+	state->mem_delimiter = delimiter;
+	skipword(state, p, delimiter, state->sp);
 	return 1;
 }
 
 /* read a byte from input and store it in readbyte. return 1 on success */
-static int rd_byte(const char **p, char delimiter) {
+static int rd_byte(Z80AssemblerState *state, const char **p, char delimiter) {
 	*p = delspc (*p);
 	if (**p == 0) {
 		return 0;
 	}
-	readbyte = *p;
-	writebyte = 1;
-	mem_delimiter = delimiter;
-	skipword (p, delimiter);
+	state->readbyte = *p;
+	state->writebyte = 1;
+	state->mem_delimiter = delimiter;
+	skipword(state, p, delimiter, state->sp);
 	return 1;
 }
 
 /* read (SP), DE, or AF */
-static int rd_ex1(const char **p) {
+static int rd_ex1(Z80AssemblerState *state, const char **p) {
 #define DE 2
 #define AF 3
 	const char *list[] = {
 		"( sp )", "de", "af", NULL
 	};
-	return indx (p, list, 1, NULL);
+	return indx(state, p, list, 1, NULL);
 }
 
 /* read first argument of IN */
-static int rd_in(const char **p) {
+static int rd_in(Z80AssemblerState *state, const char **p) {
 #define A 8
 	const char *list[] = {
 		"b", "c", "d", "e", "h", "l", "f", "a", NULL
 	};
-	return indx (p, list, 1, NULL);
+	return indx(state, p, list, 1, NULL);
 }
 
 /* read second argument of out (c),x */
-static int rd_out(const char **p) {
+static int rd_out(Z80AssemblerState *state, const char **p) {
 	const char *list[] = {
 		"b", "c", "d", "e", "h", "l", "0", "a", NULL
 	};
-	return indx (p, list, 1, NULL);
+	return indx(state, p, list, 1, NULL);
 }
 
 /* read (c) or (nn) */
-static int rd_nnc(const char **p) {
+static int rd_nnc(Z80AssemblerState *state, const char **p) {
 #define C 1
 	int i;
 	const char *list[] = {
 		"( c )", "(*)", "a , (*)", NULL
 	};
-	i = indx (p, list, 1, &readbyte);
+	i = indx(state, p, list, 1, &(state->readbyte));
 	if (i < 2) {
 		return i;
 	}
@@ -349,24 +288,24 @@ static int rd_nnc(const char **p) {
 }
 
 /* read (C) */
-static int rd_c(const char **p) {
+static int rd_c(Z80AssemblerState *state, const char **p) {
 	const char *list[] = {
 		"( c )", "( bc )", NULL
 	};
-	return indx (p, list, 1, NULL);
+	return indx(state, p, list, 1, NULL);
 }
 
 /* read a or hl */
-static int rd_a_hl(const char **p) {
+static int rd_a_hl(Z80AssemblerState *state, const char **p) {
 #define HL 2
 	const char *list[] = {
 		"a", "hl", NULL
 	};
-	return indx (p, list, 1, NULL);
+	return indx(state, p, list, 1, NULL);
 }
 
 /* read first argument of ld */
-static int rd_ld(const char **p) {
+static int rd_ld(Z80AssemblerState *state, const char **p) {
 #define ldBC    1
 #define ldDE    2
 #define ldHL    3
@@ -395,86 +334,86 @@ static int rd_ld(const char **p) {
 		"r", "( bc )", "( de )", "( ix +)", "(iy +)", "(*)", NULL
 	};
 	const char *nn;
-	i = indx (p, list, 1, &nn);
+	i = indx(state, p, list, 1, &nn);
 	if (!i) {
 		return 0;
 	}
 	if (i <= 2) {
-		indexed = 0xdd;
+		state->indexed = 0xdd;
 		return ldH + (i == 2);
 	}
 	if (i <= 4) {
-		indexed = 0xfd;
+		state->indexed = 0xfd;
 		return ldH + (i == 4);
 	}
 	i -= 4;
 	if (i == ldIX || i == ldIY) {
-		indexed = i == ldIX? 0xDD: 0xFD;
+		state->indexed = i == ldIX ? 0xDD : 0xFD;
 		return ldHL;
 	}
 	if (i == ld_IX || i == ld_IY) {
-		indexjmp = nn;
-		indexed = i == ld_IX? 0xDD: 0xFD;
+		state->indexjmp = nn;
+		state->indexed = i == ld_IX ? 0xDD : 0xFD;
 		return ld_HL;
 	}
 	if (i == ld_NN) {
-		readword = nn;
+		state->readword = nn;
 	}
 	return i;
 }
 
 /* read first argument of JP */
-static int rd_jp(const char **p) {
+static int rd_jp(Z80AssemblerState *state, const char **p) {
 	int i;
 	const char *list[] = {
 		"nz", "z", "nc", "c", "po", "pe", "p", "m", "( ix )", "( iy )",
 		"(hl)", NULL
 	};
-	i = indx (p, list, 0, NULL);
+	i = indx(state, p, list, 0, NULL);
 	if (i < 9) {
 		return i;
 	}
 	if (i == 11) {
 		return -1;
 	}
-	indexed = 0xDD + 0x20 * (i - 9);
+	state->indexed = 0xDD + 0x20 * (i - 9);
 	return -1;
 }
 
 /* read first argument of JR */
-static int rd_jr(const char **p) {
+static int rd_jr(Z80AssemblerState *state, const char **p) {
 	const char *list[] = {
 		"nz", "z", "nc", "c", NULL
 	};
-	return indx (p, list, 0, NULL);
+	return indx(state, p, list, 0, NULL);
 }
 
 /* read A */
-static int rd_a(const char **p) {
+static int rd_a(Z80AssemblerState *state, const char **p) {
 	const char *list[] = {
 		"a", NULL
 	};
-	return indx (p, list, 1, NULL);
+	return indx(state, p, list, 1, NULL);
 }
 
 /* read bc,de,hl,af */
-static int rd_stack(const char **p) {
+static int rd_stack(Z80AssemblerState *state, const char **p) {
 	int i;
 	const char *list[] = {
 		"bc", "de", "hl", "af", "ix", "iy", NULL
 	};
-	i = indx (p, list, 1, NULL);
+	i = indx(state, p, list, 1, NULL);
 	if (i < 5) {
 		return i;
 	}
-	indexed = 0xDD + 0x20 * (i - 5);
+	state->indexed = 0xDD + 0x20 * (i - 5);
 	return 3;
 }
 
 /* read b,c,d,e,h,l,(hl),a,(ix+nn),(iy+nn),nn
  * but now with extra hl or i[xy](15) for add-instruction
  * and set variables accordingly */
-static int rd_r_add(const char **p) {
+static int rd_r_add(Z80AssemblerState *state, const char **p) {
 #define addHL   15
 	int i;
 	const char *list[] = {
@@ -482,41 +421,41 @@ static int rd_r_add(const char **p) {
 		"( hl )", "a", "( ix +)", "( iy +)", "hl", "ix", "iy", "*", NULL
 	};
 	const char *nn;
-	i = indx (p, list, 0, &nn);
+	i = indx(state, p, list, 0, &nn);
 	if (i == 18) {	/* expression */
-		readbyte = nn;
-		writebyte = 1;
+		state->readbyte = nn;
+		state->writebyte = 1;
 		return 7;
 	}
 	if (i > 14) {	/* hl, ix, iy */
 		if (i > 15) {
-			indexed = 0xDD + 0x20 * (i - 16);
+			state->indexed = 0xDD + 0x20 * (i - 16);
 		}
 		return addHL;
 	}
 	if (i <= 4) {	/* i[xy][hl]  */
-		indexed = 0xdd + 0x20 * (i > 2);
+		state->indexed = 0xdd + 0x20 * (i > 2);
 		return 6 - (i & 1);
 	}
 	i -= 4;
 	if (i < 9) {
 		return i;
 	}
-	indexed = 0xDD + 0x20 * (i - 9);	/* (i[xy] +) */
-	indexjmp = nn;
+	state->indexed = 0xDD + 0x20 * (i - 9); /* (i[xy] +) */
+	state->indexjmp = nn;
 	return 7;
 }
 
 /* read bc,de,hl, or sp */
-static int rd_rr_(const char **p) {
+static int rd_rr_(Z80AssemblerState *state, const char **p) {
 	const char *list[] = {
 		"bc", "de", "hl", "sp", NULL
 	};
-	return indx (p, list, 1, NULL);
+	return indx(state, p, list, 1, NULL);
 }
 
 /* read bc,de,hl|ix|iy,sp. hl|ix|iy only if it is already indexed the same. */
-static int rd_rrxx(const char **p) {
+static int rd_rrxx(Z80AssemblerState *state, const char **p) {
 	const char *listx[] = {
 		"bc", "de", "ix", "sp", NULL
 	};
@@ -526,84 +465,84 @@ static int rd_rrxx(const char **p) {
 	const char *list[] = {
 		"bc", "de", "hl", "sp", NULL
 	};
-	if (indexed == 0xdd) {
-		return indx (p, listx, 1, NULL);
+	if (state->indexed == 0xdd) {
+		return indx(state, p, listx, 1, NULL);
 	}
-	if (indexed == 0xfd) {
-		return indx (p, listy, 1, NULL);
+	if (state->indexed == 0xfd) {
+		return indx(state, p, listy, 1, NULL);
 	}
-	return indx (p, list, 1, NULL);
+	return indx(state, p, list, 1, NULL);
 }
 
 /* read b,c,d,e,h,l,(hl),a,(ix+nn),(iy+nn),nn
  * and set variables accordingly */
-static int rd_r(const char **p) {
+static int rd_r(Z80AssemblerState *state, const char **p) {
 	int i;
 	const char *nn;
 	const char *list[] = {
 		"ixl", "ixh", "iyl", "iyh", "b", "c", "d", "e", "h", "l", "( hl )",
 		"a", "( ix +)", "( iy +)", "*", NULL
 	};
-	i = indx (p, list, 0, &nn);
+	i = indx(state, p, list, 0, &nn);
 	if (i == 15) {	/* expression */
-		readbyte = nn;
-		writebyte = 1;
+		state->readbyte = nn;
+		state->writebyte = 1;
 		return 7;
 	}
 	if (i <= 4) {
-		indexed = 0xdd + 0x20 * (i > 2);
+		state->indexed = 0xdd + 0x20 * (i > 2);
 		return 6 - (i & 1);
 	}
 	i -= 4;
 	if (i < 9) {
 		return i;
 	}
-	indexed = 0xDD + 0x20 * (i - 9);
-	indexjmp = nn;
+	state->indexed = 0xDD + 0x20 * (i - 9);
+	state->indexjmp = nn;
 	return 7;
 }
 
 /* like rd_r(), but without nn */
-static int rd_r_(const char **p) {
+static int rd_r_(Z80AssemblerState *state, const char **p) {
 	int i;
 	const char *list[] = {
 		"b", "c", "d", "e", "h", "l", "( hl )", "a", "( ix +)", "( iy +)", NULL
 	};
-	i = indx (p, list, 1, &indexjmp);
+	i = indx(state, p, list, 1, &(state->indexjmp));
 	if (i < 9) {
 		return i;
 	}
-	indexed = 0xDD + 0x20 * (i - 9);
+	state->indexed = 0xDD + 0x20 * (i - 9);
 	return 7;
 }
 
 /* read a number from 0 to 7, for bit, set or res */
-static int rd_0_7(const char **p) {
+static int rd_0_7(Z80AssemblerState *state, const char **p) {
 	*p = delspc (*p);
 	if (**p == 0) {
 		return 0;
 	}
-	bitsetres = *p;
-	skipword (p, ',');
+	state->bitsetres = *p;
+	skipword(state, p, ',', state->sp);
 	return 1;
 }
 
 /* read long condition. do not error if not found. */
-static int rd_cc(const char **p) {
+static int rd_cc(Z80AssemblerState *state, const char **p) {
 	const char *list[] = {
 		"nz", "z", "nc", "c", "po", "pe", "p", "m", NULL
 	};
-	return indx (p, list, 0, NULL);
+	return indx(state, p, list, 0, NULL);
 }
 
 /* read long or short register,  */
-static int rd_r_rr(const char **p) {
+static int rd_r_rr(Z80AssemblerState *state, const char **p) {
 	int i;
 	const char *list[] = {
 		"iy", "ix", "sp", "hl", "de", "bc", "", "b", "c", "d", "e", "h",
 		"l", "( hl )", "a", "( ix +)", "( iy +)", NULL
 	};
-	i = indx (p, list, 1, &indexjmp);
+	i = indx(state, p, list, 1, &(state->indexjmp));
 	if (!i) {
 		return 0;
 	}
@@ -611,83 +550,83 @@ static int rd_r_rr(const char **p) {
 		return 7 - i;
 	}
 	if (i > 15) {
-		indexed = 0xDD + (i - 16) * 0x20;
+		state->indexed = 0xDD + (i - 16) * 0x20;
 		return -7;
 	}
-	indexed = 0xDD + (2 - i) * 0x20;
+	state->indexed = 0xDD + (2 - i) * 0x20;
 	return 3;
 }
 
 /* read hl */
-static int rd_hl(const char **p) {
+static int rd_hl(Z80AssemblerState *state, const char **p) {
 	const char *list[] = {
 		"hl", NULL
 	};
-	return indx (p, list, 1, NULL);
+	return indx(state, p, list, 1, NULL);
 }
 
 /* read hl, ix, or iy */
-static int rd_hlx(const char **p) {
+static int rd_hlx(Z80AssemblerState *state, const char **p) {
 	int i;
 	const char *list[] = {
 		"hl", "ix", "iy", NULL
 	};
-	i = indx (p, list, 1, NULL);
+	i = indx(state, p, list, 1, NULL);
 	if (i < 2) {
 		return i;
 	}
-	indexed = 0xDD + 0x20 * (i - 2);
+	state->indexed = 0xDD + 0x20 * (i - 2);
 	return 1;
 }
 
 /* read af' */
-static int rd_af_(const char **p) {
+static int rd_af_(Z80AssemblerState *state, const char **p) {
 	const char *list[] = {
 		"af'", NULL
 	};
-	return indx (p, list, 1, NULL);
+	return indx(state, p, list, 1, NULL);
 }
 
 /* read 0(1), 1(3), or 2(4) */
-static int rd_0_2(const char **p) {
+static int rd_0_2(Z80AssemblerState *state, const char **p) {
 	const char *list[] = {
 		"0", "", "1", "2", NULL
 	};
-	return indx (p, list, 1, NULL);
+	return indx(state, p, list, 1, NULL);
 }
 
 /* read argument of ld (hl), */
-static int rd_ld_hl(const char **p) {
+static int rd_ld_hl(Z80AssemblerState *state, const char **p) {
 	int i;
 	const char *list[] = {
 		"b", "c", "d", "e", "h", "l", "", "a", "*", NULL
 	};
-	i = indx (p, list, 0, &readbyte);
+	i = indx(state, p, list, 0, &(state->readbyte));
 	if (i < 9) {
 		return i;
 	}
-	writebyte = 1;
+	state->writebyte = 1;
 	return 7;
 }
 
 /* read argument of ld (nnnn), */
-static int rd_ld_nn(const char **p) {
+static int rd_ld_nn(Z80AssemblerState *state, const char **p) {
 #define ld_nnHL 5
 #define ld_nnA 6
 	int i;
 	const char *list[] = {
 		"bc", "de", "", "sp", "hl", "a", "ix", "iy", NULL
 	};
-	i = indx (p, list, 1, NULL);
+	i = indx(state, p, list, 1, NULL);
 	if (i < 7) {
 		return i;
 	}
-	indexed = 0xdd + 0x20 * (i == 8);
+	state->indexed = 0xdd + 0x20 * (i == 8);
 	return ld_nnHL;
 }
 
 /* read argument of ld a, */
-static int rd_lda(const char **p) {
+static int rd_lda(Z80AssemblerState *state, const char **p) {
 #define A_N 7
 #define A_I 9
 #define A_R 10
@@ -698,70 +637,70 @@ static int rd_lda(const char **p) {
 		"l", "( hl )", "a", "i", "r", "(*)", "*", NULL
 	};
 	const char *nn;
-	i = indx (p, list, 0, &nn);
+	i = indx(state, p, list, 0, &nn);
 	if (i == 2 || i == 5) {
-		indexed = (i == 2)? 0xFD: 0xDD;
-		indexjmp = nn;
+		state->indexed = (i == 2) ? 0xFD : 0xDD;
+		state->indexjmp = nn;
 		return 7;
 	}
 	if (i == 17) {
-		readbyte = nn;
-		writebyte = 1;
+		state->readbyte = nn;
+		state->writebyte = 1;
 		return 7;
 	}
 	if (i == 16) {
-		readword = nn;
+		state->readword = nn;
 	}
 	return i - 5;
 }
 
 /* read argument of ld b|c|d|e|h|l */
-static int rd_ldbcdehla(const char **p) {
+static int rd_ldbcdehla(Z80AssemblerState *state, const char **p) {
 	int i;
 	const char *list[] = {
 		"b", "c", "d", "e", "h", "l", "( hl )", "a", "( ix +)", "( iy +)", "ixh",
 		"ixl", "iyh", "iyl", "*", NULL
 	};
 	const char *nn;
-	i = indx (p, list, 0, &nn);
+	i = indx(state, p, list, 0, &nn);
 	if (i == 15) {
-		readbyte = nn;
-		writebyte = 1;
+		state->readbyte = nn;
+		state->writebyte = 1;
 		return 7;
 	}
 	if (i > 10) {
 		int x;
 		x = 0xdd + 0x20 * (i > 12);
-		if (indexed && indexed != x) {
+		if (state->indexed && state->indexed != x) {
 			RZ_LOG_ERROR("assembler: z80: illegal use of index registers\n");
 			return 0;
 		}
-		indexed = x;
+		state->indexed = x;
 		return 6 - (i & 1);
 	}
 	if (i > 8) {
-		if (indexed) {
+		if (state->indexed) {
 			RZ_LOG_ERROR("assembler: z80: illegal use of index registers\n");
 			return 0;
 		}
-		indexed = 0xDD + 0x20 * (i == 10);
-		indexjmp = nn;
+		state->indexed = 0xDD + 0x20 * (i == 10);
+		state->indexjmp = nn;
 		return 7;
 	}
 	return i;
 }
 
 /* read nnnn, or (nnnn) */
-static int rd_nn_nn(const char **p) {
+static int rd_nn_nn(Z80AssemblerState *state, const char **p) {
 #define _NN 1
 	const char *list[] = {
 		"(*)", "*", NULL
 	};
-	return 2 - indx (p, list, 0, &readword);
+	return 2 - indx(state, p, list, 0, &(state->readword));
 }
 
 /* read {HL|IX|IY},nnnn, or (nnnn) */
-static int rd_sp(const char **p) {
+static int rd_sp(Z80AssemblerState *state, const char **p) {
 #define SPNN 0
 #define SPHL 1
 	int i;
@@ -769,94 +708,94 @@ static int rd_sp(const char **p) {
 		"hl", "ix", "iy", "(*)", "*", NULL
 	};
 	const char *nn;
-	i = indx (p, list, 0, &nn);
+	i = indx(state, p, list, 0, &nn);
 	if (i > 3) {
-		readword = nn;
+		state->readword = nn;
 		return i == 4? 2: 0;
 	}
 	if (i != 1) {
-		indexed = 0xDD + 0x20 * (i - 2);
+		state->indexed = 0xDD + 0x20 * (i - 2);
 	}
 	return 1;
 }
 
 /* do the actual work */
 static int assemble(const char *str, unsigned char *_obuf) {
+	Z80AssemblerState state = {
+		.addr = 0,
+		.z80buffer = strdup(str),
+		.comma = 0,
+		.indexed = 0,
+		.indexjmp = 0,
+		.writebyte = 0,
+		.readbyte = 0,
+		.readword = 0,
+		.define_macro = 0,
+		.verbose = 0,
+
+		.obuflen = 0,
+		.obuf = _obuf,
+	};
+
 	const char *ptr;
 	char *bufptr;
-	int r, s;			/* registers */
+	int r, s; /* registers */
+	int cmd;
 
-	obuflen = 0;
-	obuf = _obuf;
-	int cmd, cont = 1;
-	// XXX: must free
-	z80buffer = strdup (str);
-	if (!cont) {
-		return obuflen;
-	}
-	// if (havelist)
-	// fprintf (listfile, "%04x", addr);
-	for (bufptr = z80buffer; (bufptr = strchr (bufptr, '\n'));) {
+	for (bufptr = state.z80buffer; (bufptr = strchr(bufptr, '\n'));) {
 		*bufptr = ' ';
 	}
-	for (bufptr = z80buffer; (bufptr = strchr (bufptr, '\r'));) {
+	for (bufptr = state.z80buffer; (bufptr = strchr(bufptr, '\r'));) {
 		*bufptr = ' ';
 	}
-	ptr = z80buffer;
-	// lastlabel = NULL;
-	baseaddr = addr;
-	++stack[sp].line;
+	ptr = state.z80buffer;
+	state.baseaddr = state.addr;
+	++state.stack[state.sp].line;
+
 	ptr = delspc (ptr);
 	if (!*ptr) {
-		return obuflen;
+		return state.obuflen;
 	}
-	if (!define_macro) {
-		readlabel (&ptr, 1);
-	} else {
-		readlabel (&ptr, 0);
-	}
+
+	readlabel(&state, &ptr, 1, state.sp);
+
 	ptr = delspc (ptr);
 	if (!*ptr) {
-		return obuflen;
+		return state.obuflen;
 	}
-	comma = 0;
-	indexed = 0;
-	indexjmp = 0;
-	writebyte = 0;
-	readbyte = 0;
-	readword = 0;
-	cmd = readcommand (&ptr) - 1;
+
+	cmd = readcommand(&state, &ptr) - 1;
 	int i, have_quote;
 	switch (cmd) {
 		case Z80_ADC:
-			if (!(r = rd_a_hl (&ptr))) {
+			if (!(r = rd_a_hl(&state, &ptr))) {
 				break;
 			}
 			if (r == HL) {
-				if (!(r = rd_rr_(&ptr))) {
+				if (!(r = rd_rr_(&state, &ptr))) {
 					break;
 				}
-				wrtb (0xED);
+				wrtb(state, 0xED);
 				r--;
-				wrtb (0x4A + 0x10 * r);
+				wrtb(state, 0x4A + 0x10 * r);
 				break;
 			}
-			if (!(r = rd_r (&ptr))) {
+			if (!(r = rd_r(&state, &ptr))) {
 				break;
 			}
 			r--;
-			wrtb (0x88 + r);
+			wrtb(state, 0x88 + r);
 			break;
 		case Z80_ADD:
-			if (!(r = rd_r_add (&ptr))) {
+			if (!(r = rd_r_add(&state, &ptr))) {
 				break;
 			}
 			if (r == addHL) {
-				if (!(r = rd_rrxx (&ptr))) {
+				if (!(r = rd_rrxx(&state, &ptr))) {
 					break;
 				}
 				r--;
-				wrtb (0x09 + 0x10 * r);		/* ADD HL/IX/IY, qq  */
+				wrtb(state, 0x09 + 0x10 * r); /* ADD HL/IX/IY, qq  */
 				break;
 			}
 			if (has_argument (&ptr)) {
@@ -864,259 +803,259 @@ static int assemble(const char *str, unsigned char *_obuf) {
 					RZ_LOG_ERROR("assembler: z80: parse error before: %s\n", ptr);
 					break;
 				}
-				if (!(r = rd_r (&ptr))) {
+				if (!(r = rd_r(&state, &ptr))) {
 					break;
 				}
 				r--;
-				wrtb (0x80 + r);		/* ADD A,r  */
+				wrtb(state, 0x80 + r); /* ADD A,r  */
 				break;
 			}
 			r--;
-			wrtb (0x80 + r);		/* ADD r  */
+			wrtb(state, 0x80 + r); /* ADD r  */
 			break;
 		case Z80_AND:
-			if (!(r = rd_r (&ptr))) {
+			if (!(r = rd_r(&state, &ptr))) {
 				break;
 			}
 			r--;
-			wrtb (0xA0 + r);
+			wrtb(state, 0xA0 + r);
 			break;
 		case Z80_BIT:
-			if (!rd_0_7 (&ptr)) {
+			if (!rd_0_7(&state, &ptr)) {
 				break;
 			}
 			rd_comma (&ptr);
-			if (!(r = rd_r_(&ptr))) {
+			if (!(r = rd_r_(&state, &ptr))) {
 				break;
 			}
-			wrtb (0xCB);
-			wrtb (0x40 + (r - 1));
+			wrtb(state, 0xCB);
+			wrtb(state, 0x40 + (r - 1));
 			break;
 		case Z80_CALL:
-			if ((r = rd_cc (&ptr))) {
+			if ((r = rd_cc(&state, &ptr))) {
 				r--;
-				wrtb (0xC4 + 8 * r);
+				wrtb(state, 0xC4 + 8 * r);
 				rd_comma (&ptr);
 			} else {
-				wrtb (0xCD);
+				wrtb(state, 0xCD);
 			}
 			break;
 		case Z80_CCF:
-			wrtb (0x3F);
+			wrtb(state, 0x3F);
 			break;
 		case Z80_CP:
-			if (!(r = rd_r (&ptr))) {
+			if (!(r = rd_r(&state, &ptr))) {
 				break;
 			}
 			r--;
-			wrtb (0xB8 + r);
+			wrtb(state, 0xB8 + r);
 			break;
 		case Z80_CPD:
-			wrtb (0xED);
-			wrtb (0xA9);
+			wrtb(state, 0xED);
+			wrtb(state, 0xA9);
 			break;
 		case Z80_CPDR:
-			wrtb (0xED);
-			wrtb (0xB9);
+			wrtb(state, 0xED);
+			wrtb(state, 0xB9);
 			break;
 		case Z80_CPI:
-			wrtb (0xED);
-			wrtb (0xA1);
+			wrtb(state, 0xED);
+			wrtb(state, 0xA1);
 			break;
 		case Z80_CPIR:
-			wrtb (0xED);
-			wrtb (0xB1);
+			wrtb(state, 0xED);
+			wrtb(state, 0xB1);
 			break;
 		case Z80_CPL:
-			wrtb (0x2F);
+			wrtb(state, 0x2F);
 			break;
 		case Z80_DAA:
-			wrtb (0x27);
+			wrtb(state, 0x27);
 			break;
 		case Z80_DEC:
-			if (!(r = rd_r_rr (&ptr))) {
+			if (!(r = rd_r_rr(&state, &ptr))) {
 				break;
 			}
 			if (r < 0) {
 				r--;
-				wrtb (0x05 - 8 * r);
+				wrtb(state, 0x05 - 8 * r);
 				break;
 			}
 			r--;
-			wrtb (0x0B + 0x10 * r);
+			wrtb(state, 0x0B + 0x10 * r);
 			break;
 		case Z80_DI:
-			wrtb (0xF3);
+			wrtb(state, 0xF3);
 			break;
 		case Z80_DJNZ:
-			wrtb (0x10);
+			wrtb(state, 0x10);
 			// rd_wrt_jr (&ptr, '\0');
 			break;
 		case Z80_EI:
-			wrtb (0xFB);
+			wrtb(state, 0xFB);
 			break;
 		case Z80_EX:
-			if (!(r = rd_ex1 (&ptr))) {
+			if (!(r = rd_ex1(&state, &ptr))) {
 				break;
 			}
 			switch (r) {
 				case DE:
-					if (!rd_hl (&ptr)) {
+					if (!rd_hl(&state, &ptr)) {
 						break;
 					}
-					wrtb (0xEB);
+					wrtb(state, 0xEB);
 					break;
 				case AF:
-					if (!rd_af_(&ptr)) {
+					if (!rd_af_(&state, &ptr)) {
 						break;
 					}
-					wrtb (0x08);
+					wrtb(state, 0x08);
 					break;
 				default:
-					if (!rd_hlx (&ptr)) {
+					if (!rd_hlx(&state, &ptr)) {
 						break;
 					}
-					wrtb (0xE3);
+					wrtb(state, 0xE3);
 			}
 			break;
 		case Z80_EXX:
-			wrtb (0xD9);
+			wrtb(state, 0xD9);
 			break;
 		case Z80_HALT:
-			wrtb (0x76);
+			wrtb(state, 0x76);
 			break;
 		case Z80_IM:
-			if (!(r = rd_0_2 (&ptr))) {
+			if (!(r = rd_0_2(&state, &ptr))) {
 				break;
 			}
-			wrtb (0xED);
+			wrtb(state, 0xED);
 			r--;
-			wrtb (0x46 + 8 * r);
+			wrtb(state, 0x46 + 8 * r);
 			break;
 		case Z80_IN:
-			if (!(r = rd_in (&ptr))) {
+			if (!(r = rd_in(&state, &ptr))) {
 				break;
 			}
 			if (r == A) {
-				if (!(r = rd_nnc (&ptr))) {
+				if (!(r = rd_nnc(&state, &ptr))) {
 					break;
 				}
 				if (r == C) {
-					wrtb (0xED);
-					wrtb (0x40 + 8 * (A - 1));
+					wrtb(state, 0xED);
+					wrtb(state, 0x40 + 8 * (A - 1));
 					break;
 				}
-				wrtb (0xDB);
+				wrtb(state, 0xDB);
 				break;
 			}
-			if (!rd_c (&ptr)) {
+			if (!rd_c(&state, &ptr)) {
 				break;
 			}
-			wrtb (0xED);
+			wrtb(state, 0xED);
 			r--;
-			wrtb (0x40 + 8 * r);
+			wrtb(state, 0x40 + 8 * r);
 			break;
 		case Z80_INC:
-			if (!(r = rd_r_rr (&ptr))) {
+			if (!(r = rd_r_rr(&state, &ptr))) {
 				break;
 			}
 			if (r < 0) {
 				r++;
-				wrtb (0x04 - 8 * r);
+				wrtb(state, 0x04 - 8 * r);
 				break;
 			}
 			r--;
-			wrtb (0x03 + 0x10 * r);
+			wrtb(state, 0x03 + 0x10 * r);
 			break;
 		case Z80_IND:
-			wrtb (0xED);
-			wrtb (0xAA);
+			wrtb(state, 0xED);
+			wrtb(state, 0xAA);
 			break;
 		case Z80_INDR:
-			wrtb (0xED);
-			wrtb (0xBA);
+			wrtb(state, 0xED);
+			wrtb(state, 0xBA);
 			break;
 		case Z80_INI:
-			wrtb (0xED);
-			wrtb (0xA2);
+			wrtb(state, 0xED);
+			wrtb(state, 0xA2);
 			break;
 		case Z80_INIR:
-			wrtb (0xED);
-			wrtb (0xB2);
+			wrtb(state, 0xED);
+			wrtb(state, 0xB2);
 			break;
 		case Z80_JP:
-			r = rd_jp (&ptr);
+			r = rd_jp(&state, &ptr);
 			if (r < 0) {
-				wrtb (0xE9);
+				wrtb(state, 0xE9);
 				break;
 			}
 			if (r) {
 				r--;
-				wrtb (0xC2 + 8 * r);
+				wrtb(state, 0xC2 + 8 * r);
 				rd_comma (&ptr);
 			} else {
-				wrtb (0xC3);
+				wrtb(state, 0xC3);
 			}
 			break;
 		case Z80_JR:
-			r = rd_jr (&ptr);
+			r = rd_jr(&state, &ptr);
 			if (r) {
 				rd_comma (&ptr);
 			}
-			wrtb (0x18 + 8 * r);
+			wrtb(state, 0x18 + 8 * r);
 			break;
 		case Z80_LD:
-			if (!(r = rd_ld (&ptr))) {
+			if (!(r = rd_ld(&state, &ptr))) {
 				break;
 			}
 			switch (r) {
 				case ld_BC:
 				case ld_DE:
-					if (!rd_a (&ptr)) {
+					if (!rd_a(&state, &ptr)) {
 						break;
 					}
-					wrtb (0x02 + 0x10 * (r == ld_DE ? 1 : 0));
+					wrtb(state, 0x02 + 0x10 * (r == ld_DE ? 1 : 0));
 					break;
 				case ld_HL:
-					r = rd_ld_hl (&ptr) - 1;
-					wrtb (0x70 + r);
+					r = rd_ld_hl(&state, &ptr) - 1;
+					wrtb(state, 0x70 + r);
 					break;
 				case ld_NN:
-					if (!(r = rd_ld_nn (&ptr))) {
+					if (!(r = rd_ld_nn(&state, &ptr))) {
 						break;
 					}
 					if (r == ld_nnA || r == ld_nnHL) {
-						wrtb (0x22 + 0x10 * (r == ld_nnA ? 1 : 0));
+						wrtb(state, 0x22 + 0x10 * (r == ld_nnA ? 1 : 0));
 						break;
 					}
-					wrtb (0xED);
-					wrtb (0x43 + 0x10 * --r);
+					wrtb(state, 0xED);
+					wrtb(state, 0x43 + 0x10 * --r);
 					break;
 				case ldA:
-					if (!(r = rd_lda (&ptr))) {
+					if (!(r = rd_lda(&state, &ptr))) {
 						break;
 					}
 					if (r == A_NN) {
-						wrtb (0x3A);
+						wrtb(state, 0x3A);
 						break;
 					}
 					if (r == A_I || r == A_R) {
-						wrtb (0xED);
-						wrtb (0x57 + 8 * (r == A_R ? 1 : 0));
+						wrtb(state, 0xED);
+						wrtb(state, 0x57 + 8 * (r == A_R ? 1 : 0));
 						break;
 					}
 					if (r == A_N) {
-						char n = rz_num_math (NULL, readbyte);
-						wrtb (0x3E);
-						wrtb (n);
+						char n = rz_num_math(NULL, state.readbyte);
+						wrtb(state, 0x3E);
+						wrtb(state, n);
 						break;
 					}
 					if (r < 0) {
 						r++;
-						wrtb (0x0A - 0x10 * r);
+						wrtb(state, 0x0A - 0x10 * r);
 						break;
 					}
-					wrtb (0x78 + --r);
+					wrtb(state, 0x78 + --r);
 					break;
 				case ldB:
 				case ldC:
@@ -1124,283 +1063,283 @@ static int assemble(const char *str, unsigned char *_obuf) {
 				case ldE:
 				case ldH:
 				case ldL:
-					if (!(s = rd_ldbcdehla (&ptr))) {
+					if (!(s = rd_ldbcdehla(&state, &ptr))) {
 						break;
 					}
 					if (s == 7) {
-						char n = rz_num_math(NULL, readbyte);
-						wrtb (0x08 * (r - 7) + 0x6);
-						wrtb (n);
+						char n = rz_num_math(NULL, state.readbyte);
+						wrtb(state, 0x08 * (r - 7) + 0x6);
+						wrtb(state, n);
 					} else {
-						wrtb (0x40 + 0x08 * (r -7) + (s - 1));
+						wrtb(state, 0x40 + 0x08 * (r - 7) + (s - 1));
 					}
 					break;
 				case ldBC:
 				case ldDE:
-					s = rd_nn_nn (&ptr);
+					s = rd_nn_nn(&state, &ptr);
 					if (s == _NN) {
-						wrtb (0xED);
-						wrtb (0x4B + 0x10 * (r == ldDE ? 1 : 0));
+						wrtb(state, 0xED);
+						wrtb(state, 0x4B + 0x10 * (r == ldDE ? 1 : 0));
 						break;
 					}
-					wrtb (0x01 + (r == ldDE ? 1 : 0) * 0x10);
+					wrtb(state, 0x01 + (r == ldDE ? 1 : 0) * 0x10);
 					break;
 				case ldHL:
-					r = rd_nn_nn (&ptr);
-					wrtb (0x21 + (r == _NN ? 1 : 0) * 9);
+					r = rd_nn_nn(&state, &ptr);
+					wrtb(state, 0x21 + (r == _NN ? 1 : 0) * 9);
 					break;
 				case ldI:
 				case ldR:
-					if (!rd_a (&ptr)) {
+					if (!rd_a(&state, &ptr)) {
 						break;
 					}
-					wrtb (0xED);
-					wrtb (0x47 + 0x08 * (r == ldR ? 1 : 0));
+					wrtb(state, 0xED);
+					wrtb(state, 0x47 + 0x08 * (r == ldR ? 1 : 0));
 					break;
 				case ldSP:
-					r = rd_sp (&ptr);
+					r = rd_sp(&state, &ptr);
 					if (r == SPHL) {
-						wrtb (0xF9);
+						wrtb(state, 0xF9);
 						break;
 					}
 					if (r == SPNN) {
-						wrtb (0x31);
+						wrtb(state, 0x31);
 						break;
 					}
-					wrtb (0xED);
-					wrtb (0x7B);
+					wrtb(state, 0xED);
+					wrtb(state, 0x7B);
 					break;
 			}
 			break;
 		case Z80_LDD:
-			wrtb (0xED);
-			wrtb (0xA8);
+			wrtb(state, 0xED);
+			wrtb(state, 0xA8);
 			break;
 		case Z80_LDDR:
-			wrtb (0xED);
-			wrtb (0xB8);
+			wrtb(state, 0xED);
+			wrtb(state, 0xB8);
 			break;
 		case Z80_LDI:
-			wrtb (0xED);
-			wrtb (0xA0);
+			wrtb(state, 0xED);
+			wrtb(state, 0xA0);
 			break;
 		case Z80_LDIR:
-			wrtb (0xED);
-			wrtb (0xB0);
+			wrtb(state, 0xED);
+			wrtb(state, 0xB0);
 			break;
 		case Z80_NEG:
-			wrtb (0xED);
-			wrtb (0x44);
+			wrtb(state, 0xED);
+			wrtb(state, 0x44);
 			break;
 		case Z80_NOP:
-			wrtb (0x00);
+			wrtb(state, 0x00);
 			break;
 		case Z80_OR:
-			if (!(r = rd_r (&ptr))) {
+			if (!(r = rd_r(&state, &ptr))) {
 				break;
 			}
 			r--;
-			wrtb (0xB0 + r);
+			wrtb(state, 0xB0 + r);
 			break;
 		case Z80_OTDR:
-			wrtb (0xED);
-			wrtb (0xBB);
+			wrtb(state, 0xED);
+			wrtb(state, 0xBB);
 			break;
 		case Z80_OTIR:
-			wrtb (0xED);
-			wrtb (0xB3);
+			wrtb(state, 0xED);
+			wrtb(state, 0xB3);
 			break;
 		case Z80_OUT:
-			if (!(r = rd_nnc (&ptr))) {
+			if (!(r = rd_nnc(&state, &ptr))) {
 				break;
 			}
 			if (r == C) {
-				if (!(r = rd_out (&ptr))) {
+				if (!(r = rd_out(&state, &ptr))) {
 					break;
 				}
-				wrtb (0xED);
+				wrtb(state, 0xED);
 				r--;
-				wrtb (0x41 + 8 * r);
+				wrtb(state, 0x41 + 8 * r);
 				break;
 			}
-			if (!rd_a (&ptr)) {
+			if (!rd_a(&state, &ptr)) {
 				break;
 			}
-			wrtb (0xD3);
+			wrtb(state, 0xD3);
 			break;
 		case Z80_OUTD:
-			wrtb (0xED);
-			wrtb (0xAB);
+			wrtb(state, 0xED);
+			wrtb(state, 0xAB);
 			break;
 		case Z80_OUTI:
-			wrtb (0xED);
-			wrtb (0xA3);
+			wrtb(state, 0xED);
+			wrtb(state, 0xA3);
 			break;
 		case Z80_POP:
-			if (!(r = rd_stack (&ptr))) {
+			if (!(r = rd_stack(&state, &ptr))) {
 				break;
 			}
 			r--;
-			wrtb (0xC1 + 0x10 * r);
+			wrtb(state, 0xC1 + 0x10 * r);
 			break;
 		case Z80_PUSH:
-			if (!(r = rd_stack (&ptr))) {
+			if (!(r = rd_stack(&state, &ptr))) {
 				break;
 			}
 			r--;
-			wrtb (0xC5 + 0x10 * r);
+			wrtb(state, 0xC5 + 0x10 * r);
 			break;
 		case Z80_RES:
-			if (!rd_0_7 (&ptr)) {
+			if (!rd_0_7(&state, &ptr)) {
 				break;
 			}
 			rd_comma (&ptr);
-			if (!(r = rd_r_(&ptr))) {
+			if (!(r = rd_r_(&state, &ptr))) {
 				break;
 			}
-			wrtb (0xCB);
+			wrtb(state, 0xCB);
 			r--;
-			wrtb (0x80 + r);
+			wrtb(state, 0x80 + r);
 			break;
 		case Z80_RET:
-			if (!(r = rd_cc (&ptr))) {
-				wrtb (0xC9);
+			if (!(r = rd_cc(&state, &ptr))) {
+				wrtb(state, 0xC9);
 				break;
 			}
 			r--;
-			wrtb (0xC0 + 8 * r);
+			wrtb(state, 0xC0 + 8 * r);
 			break;
 		case Z80_RETI:
-			wrtb (0xED);
-			wrtb (0x4D);
+			wrtb(state, 0xED);
+			wrtb(state, 0x4D);
 			break;
 		case Z80_RETN:
-			wrtb (0xED);
-			wrtb (0x45);
+			wrtb(state, 0xED);
+			wrtb(state, 0x45);
 			break;
 		case Z80_RL:
-			if (!(r = rd_r_(&ptr))) {
+			if (!(r = rd_r_(&state, &ptr))) {
 				break;
 			}
-			wrtb (0xCB);
+			wrtb(state, 0xCB);
 			r--;
-			wrtb (0x10 + r);
+			wrtb(state, 0x10 + r);
 			break;
 		case Z80_RLA:
-			wrtb (0x17);
+			wrtb(state, 0x17);
 			break;
 		case Z80_RLC:
-			if (!(r = rd_r_(&ptr))) {
+			if (!(r = rd_r_(&state, &ptr))) {
 				break;
 			}
-			wrtb (0xCB);
+			wrtb(state, 0xCB);
 			r--;
-			wrtb (0x00 + r);
+			wrtb(state, 0x00 + r);
 			break;
 		case Z80_RLCA:
-			wrtb (0x07);
+			wrtb(state, 0x07);
 			break;
 		case Z80_RLD:
-			wrtb (0xED);
-			wrtb (0x6F);
+			wrtb(state, 0xED);
+			wrtb(state, 0x6F);
 			break;
 		case Z80_RR:
-			if (!(r = rd_r_(&ptr))) {
+			if (!(r = rd_r_(&state, &ptr))) {
 				break;
 			}
-			wrtb (0xCB);
+			wrtb(state, 0xCB);
 			r--;
-			wrtb (0x18 + r);
+			wrtb(state, 0x18 + r);
 			break;
 		case Z80_RRA:
-			wrtb (0x1F);
+			wrtb(state, 0x1F);
 			break;
 		case Z80_RRC:
-			if (!(r = rd_r_(&ptr))) {
+			if (!(r = rd_r_(&state, &ptr))) {
 				break;
 			}
-			wrtb (0xCB);
+			wrtb(state, 0xCB);
 			r--;
-			wrtb (0x08 + r);
+			wrtb(state, 0x08 + r);
 			break;
 		case Z80_RRCA:
-			wrtb (0x0F);
+			wrtb(state, 0x0F);
 			break;
 		case Z80_RRD:
-			wrtb (0xED);
-			wrtb (0x67);
+			wrtb(state, 0xED);
+			wrtb(state, 0x67);
 			break;
 		case Z80_RST:
 			ptr = "";
 			break;
 		case Z80_SBC:
-			if (!(r = rd_a_hl (&ptr))) {
+			if (!(r = rd_a_hl(&state, &ptr))) {
 				break;
 			}
 			if (r == HL) {
-				if (!(r = rd_rr_(&ptr))) {
+				if (!(r = rd_rr_(&state, &ptr))) {
 					break;
 				}
-				wrtb (0xED);
+				wrtb(state, 0xED);
 				r--;
-				wrtb (0x42 + 0x10 * r);
+				wrtb(state, 0x42 + 0x10 * r);
 				break;
 			}
-			if (!(r = rd_r (&ptr))) {
+			if (!(r = rd_r(&state, &ptr))) {
 				break;
 			}
 			r--;
-			wrtb (0x98 + r);
+			wrtb(state, 0x98 + r);
 			break;
 		case Z80_SCF:
-			wrtb (0x37);
+			wrtb(state, 0x37);
 			break;
 		case Z80_SET:
-			if (!rd_0_7 (&ptr)) {
+			if (!rd_0_7(&state, &ptr)) {
 				break;
 			}
 			rd_comma (&ptr);
-			if (!(r = rd_r_(&ptr))) {
+			if (!(r = rd_r_(&state, &ptr))) {
 				break;
 			}
-			wrtb (0xCB);
+			wrtb(state, 0xCB);
 			r--;
-			wrtb (0xC0 + r);
+			wrtb(state, 0xC0 + r);
 			break;
 		case Z80_SLA:
-			if (!(r = rd_r_(&ptr))) {
+			if (!(r = rd_r_(&state, &ptr))) {
 				break;
 			}
-			wrtb (0xCB);
+			wrtb(state, 0xCB);
 			r--;
-			wrtb (0x20 + r);
+			wrtb(state, 0x20 + r);
 			break;
 		case Z80_SLI:
-			if (!(r = rd_r_(&ptr))) {
+			if (!(r = rd_r_(&state, &ptr))) {
 				break;
 			}
-			wrtb (0xCB);
+			wrtb(state, 0xCB);
 			r--;
-			wrtb (0x30 + r);
+			wrtb(state, 0x30 + r);
 			break;
 		case Z80_SRA:
-			if (!(r = rd_r_(&ptr))) {
+			if (!(r = rd_r_(&state, &ptr))) {
 				break;
 			}
-			wrtb (0xCB);
+			wrtb(state, 0xCB);
 			r--;
-			wrtb (0x28 + r);
+			wrtb(state, 0x28 + r);
 			break;
 		case Z80_SRL:
-			if (!(r = rd_r_(&ptr))) {
+			if (!(r = rd_r_(&state, &ptr))) {
 				break;
 			}
-			wrtb (0xCB);
+			wrtb(state, 0xCB);
 			r--;
-			wrtb (0x38 + r);
+			wrtb(state, 0x38 + r);
 			break;
 		case Z80_SUB:
-			if (!(r = rd_r (&ptr))) {
+			if (!(r = rd_r(&state, &ptr))) {
 				break;
 			}
 			if (has_argument (&ptr)) {		/* SUB A,r ?  */
@@ -1408,19 +1347,19 @@ static int assemble(const char *str, unsigned char *_obuf) {
 					RZ_LOG_ERROR("assembler: z80: parse error before: %s\n", ptr);
 					break;
 				}
-				if (!(r = rd_r (&ptr))) {
+				if (!(r = rd_r(&state, &ptr))) {
 					break;
 				}
 			}
 			r--;
-			wrtb (0x90 + r);
+			wrtb(state, 0x90 + r);
 			break;
 		case Z80_XOR:
-			if (!(r = rd_r (&ptr))) {
+			if (!(r = rd_r(&state, &ptr))) {
 				break;
 			}
 			r--;
-			wrtb (0xA8 + r);
+			wrtb(state, 0xA8 + r);
 			break;
 		case Z80_DEFB:
 		case Z80_DB:
@@ -1434,7 +1373,7 @@ static int assemble(const char *str, unsigned char *_obuf) {
 					int quote = *ptr;
 					++ptr;
 					while (*ptr != quote) {
-						write_one_byte (rd_character (&ptr, NULL, 1), 0);
+						wrtb(state, rd_character(&state, &ptr, NULL, 1));
 						if (*ptr == 0) {
 							RZ_LOG_ERROR("assembler: z80: end of line in quoted string\n");
 							break;
@@ -1443,7 +1382,7 @@ static int assemble(const char *str, unsigned char *_obuf) {
 					++ptr;
 				} else {
 					/* Read expression.  */
-					skipword (&ptr, ',');
+					skipword(&state, &ptr, ',', state.sp);
 				}
 				ptr = delspc (ptr);
 				if (*ptr == ',') {
@@ -1458,7 +1397,7 @@ static int assemble(const char *str, unsigned char *_obuf) {
 			break;
 		case Z80_DEFW:
 		case Z80_DW:
-			if (!rd_word (&ptr, ',')) {
+			if (!rd_word(&state, &ptr, ',')) {
 				RZ_LOG_ERROR("assembler: z80: No data for word definition\n");
 				break;
 			}
@@ -1468,14 +1407,14 @@ static int assemble(const char *str, unsigned char *_obuf) {
 					break;
 				}
 				++ptr;
-				if (!rd_word (&ptr, ',')) {
+				if (!rd_word(&state, &ptr, ',')) {
 					RZ_LOG_ERROR("assembler: z80: Missing expression in defw\n");
 				}
 			}
 			break;
 		case Z80_DEFS:
 		case Z80_DS:
-			r = rd_expr (&ptr, ',', NULL, sp, 1);
+			r = rd_expr(&state, &ptr, ',', NULL, state.sp, 1);
 			if (r < 0) {
 				RZ_LOG_ERROR("assembler: z80: ds should have its first argument >=0"
 						" (not -0x%x)\n", -r);
@@ -1484,19 +1423,19 @@ static int assemble(const char *str, unsigned char *_obuf) {
 			ptr = delspc (ptr);
 			if (*ptr) {
 				rd_comma (&ptr);
-				readbyte = 0;
-				rd_byte (&ptr, '\0');
-				writebyte = 0;
+				state.readbyte = 0;
+				rd_byte(&state, &ptr, '\0');
+				state.writebyte = 0;
 				break;
 			}
 			for (i = 0; i < r; i++) {
-				write_one_byte (0, 0);
+				wrtb(state, 0);
 			}
 			break;
 		case Z80_END:
 			break;
 		case Z80_ORG:
-			addr = rd_expr (&ptr, '\0', NULL, sp, 1) & 0xffff;
+			state.addr = rd_expr(&state, &ptr, '\0', NULL, state.sp, 1) & 0xffff;
 			break;
 		case Z80_IF:
 			break;
@@ -1507,7 +1446,7 @@ static int assemble(const char *str, unsigned char *_obuf) {
 			RZ_LOG_ERROR("assembler: z80: endif without if\n");
 			break;
 		case Z80_ENDM:
-			if (stack[sp].file) {
+			if (state.stack[state.sp].file) {
 				RZ_LOG_ERROR("assembler: z80: endm outside macro definition\n");
 			}
 			break;
@@ -1519,7 +1458,7 @@ static int assemble(const char *str, unsigned char *_obuf) {
 			return 0;
 	}
 
-	return obuflen;
+	return state.obuflen;
 }
 
 // XXX

--- a/librz/arch/isa_gnu/z80/z80asm.h
+++ b/librz/arch/isa_gnu/z80/z80asm.h
@@ -171,18 +171,54 @@ struct reference
   char input[1];		/* variable size buffer containing formula */
 };
 
-/* print an error message, including current line and file */
-static void printerr (int error, const char *fmt, ...);
+typedef struct {
+	/* current line, address and file */
+	int addr, file;
+
+	/* use readbyte instead of (hl) if writebyte is true */
+	int writebyte;
+	const char *readbyte;
+	/* variables which are filled by rd_* functions and used later, like readbyte */
+	const char *readword, *indexjmp, *bitsetres;
+
+	/* 0, 0xdd or 0xfd depening on which index prefix should be given */
+	int indexed;
+
+	/* increased for every -v option on the command line */
+	int verbose;
+
+	/* read commas after indx() if comma > 1. increase for every call */
+	int comma;
+
+	/* address at start of line (for references) */
+	int baseaddr;
+
+	/* set by readword and readbyte, used for new_reference */
+	char mem_delimiter;
+
+	/* line currently being parsed */
+	char *z80buffer;
+
+	/* if a macro is currently being defined */
+	int define_macro;
+
+	unsigned char *obuf;
+	int obuflen;
+
+	/* file (and macro) stack */
+	int sp;
+	struct stack stack[MAX_INCLUDE]; /* maximum level of includes */
+} Z80AssemblerState;
 
 /* skip over spaces in string */
 static const char *delspc (const char *ptr);
 
-static int rd_expr (const char **p, char delimiter, int *valid, int level,
-	     int print_errors);
-static int rd_label (const char **p, int *exists, struct label **previous, int level,
-	      int print_errors);
-static int rd_character (const char **p, int *valid, int print_errors);
+static int rd_expr(Z80AssemblerState *state, const char **p, char delimiter, int *valid, int level,
+	int print_errors);
+static int rd_label(Z80AssemblerState *state, const char **p, int *exists, struct label **previous, int level,
+	int print_errors);
+static int rd_character(Z80AssemblerState *state, const char **p, int *valid, int print_errors);
 
-static int compute_ref (struct reference *ref, int allow_invalid);
+static int compute_ref(Z80AssemblerState *state, struct reference *ref, int allow_invalid);
 
 #endif


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This change removes global variables from librz\arch\isa_gnu\z80. This is a fairly massive change, so sorry in advance for any reviewer, most of the diff is trivial.

The global variables that were removed were shared state that multiple functions in the file could modify, this is in essence the "OO" pattern, the functions that modified the variables were "methods" that operated on the same implicit "object". This pattern were made explicit by moving the variables into a structure, and all the functions were changed so that they accept a pointer to the structure as the first argument. The function that instantiates the structure is the one that starts the assembly process, `assemble`. This function outlives all other functions, ensuring the pointer it passes to the others is valid.

In addition to that change, several minor cleanups were also made:

-  Dead code, presumably added for debugging, was removed (see: the variable `cont`)

-  Dead code branching on the value of the variable `define_macro` was removed, since the variable has one value that no other code modifies.

- Dead code that was nested under an `#if 0` preprocessor directive. The function that used to contain this code is now empty, to be removed in a future cleanup (it's an error logging function that was presumably useful in the original context of the code)


More cleanups to this file is later needed, to remove the function `printerr` and to free the memory returned by `strdup` in the initialization of `z80buffer`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

No new functionality was added so no new tests are necessary. The branch builds and all the tests in db/asm/z80 pass.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
