### PR TITLE
Remove rz_analysis_get_fcns since dups rz_analysis_function_list

### DIFF
--- a/librz/arch/analysis.c
+++ b/librz/arch/analysis.c
@@ -428,12 +428,6 @@ RZ_API void rz_analysis_trace_bb(RzAnalysis *analysis, ut64 addr) {
 	}
 }
 
-RZ_API RzList /*<RzAnalysisFunction *>*/ *rz_analysis_get_fcns(RzAnalysis *analysis) {
-	// avoid received to free this thing
-	analysis->fcns->free = NULL;
-	return analysis->fcns;
-}
-
 RZ_API RzAnalysisOp *rz_analysis_op_hexstr(RzAnalysis *analysis, ut64 addr, const char *str) {
 	RzAnalysisOp *op = rz_analysis_op_new();
 	if (!op) {

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1769,8 +1769,6 @@ RZ_API bool rz_analysis_xrefs_set(RzAnalysis *analysis, ut64 from, ut64 to, RzAn
 RZ_API bool rz_analysis_xrefs_deln(RzAnalysis *analysis, ut64 from, ut64 to, RzAnalysisXRefType type);
 RZ_API bool rz_analysis_xref_del(RzAnalysis *analysis, ut64 from, ut64 to);
 
-RZ_API RzList /*<RzAnalysisFunction *>*/ *rz_analysis_get_fcns(RzAnalysis *analysis);
-
 /* var.c */
 RZ_API RZ_BORROW RzAnalysisVar *rz_analysis_function_set_var(
 	RzAnalysisFunction *fcn,

--- a/librz/main/rz-diff.c
+++ b/librz/main/rz-diff.c
@@ -2086,13 +2086,13 @@ static void core_diff_show(RzCore *core_a, RzCore *core_b, DiffMode mode, bool v
 	RzListIter *iter = NULL;
 	bool color = false, no_name = false;
 
-	fcns_a = rz_list_clone(rz_analysis_get_fcns(core_a->analysis));
+	fcns_a = rz_list_clone(rz_analysis_function_list(core_a->analysis));
 	if (rz_list_empty(fcns_a)) {
 		RZ_LOG_ERROR("rz-diff: No functions found in file0.\n");
 		goto fail;
 	}
 
-	fcns_b = rz_list_clone(rz_analysis_get_fcns(core_b->analysis));
+	fcns_b = rz_list_clone(rz_analysis_function_list(core_b->analysis));
 	if (rz_list_empty(fcns_b)) {
 		RZ_LOG_ERROR("rz-diff: No functions found in file1.\n");
 		goto fail;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

I noticed that we have a duplicated function that does weird things.

Luckly is not used anywhere besides rz_diff

Added https://github.com/rizinorg/rizin/commit/dd6b3005b1eea906ad8104d0f0f6b5209fffbf59