### PR TITLE
Fix potentially invalid memcpy in xtensa

### DIFF
--- a/librz/arch/p_gnu/analysis/analysis_xtensa_gnu.c
+++ b/librz/arch/p_gnu/analysis/analysis_xtensa_gnu.c
@@ -13,7 +13,6 @@
 #define XTENSA_MAX_LENGTH 8
 
 typedef struct {
-	int length_table[16];
 	xtensa_insnbuf insn_buffer;
 	xtensa_insnbuf slot_buffer;
 } XtensaContext;
@@ -21,16 +20,15 @@ typedef struct {
 static bool xtensa_init(void **user) {
 	XtensaContext *ctx = RZ_NEW0(XtensaContext);
 	rz_return_val_if_fail(ctx, false);
-	memcpy(ctx->length_table, (int[16]){ 3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 8, 8 }, sizeof(ctx->length_table));
 	ctx->insn_buffer = NULL;
 	ctx->slot_buffer = NULL;
 	*user = ctx;
 	return true;
 }
 
-static int xtensa_length(RzAnalysis *a, const ut8 *insn) {
-	XtensaContext *ctx = (XtensaContext *)a->plugin_data;
-	return ctx->length_table[*insn & 0xf];
+static int xtensa_length(const ut8 *insn) {
+	static const int length_table[16] = { 3, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 8, 8 };
+	return length_table[*insn & 0xf];
 }
 
 static inline ut64 xtensa_offset(ut64 addr, const ut8 *buf) {
@@ -1962,7 +1960,7 @@ static int xtensa_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut
 		return 1;
 	}
 
-	op->size = xtensa_length(analysis, buf_original);
+	op->size = xtensa_length(buf_original);
 	if (op->size > len_original) {
 		return 1;
 	}


### PR DESCRIPTION


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Regression from bde374dad6e64dc9194cfca9eca23d0330e3378f: When memcpy is a macro (e.g. on macOS <= 10.12), the commas are interpreted as macro argument delimiters. Since length_table is never mutated, we can revert the change and use it as a constant buffer.

**Closing issues**

Partially addresses #4352