### PR TITLE
Legacy Mac OS X Compatibility (Fix #4352)

### DIFF
--- a/librz/bin/dwarf/endian_reader.h
+++ b/librz/bin/dwarf/endian_reader.h
@@ -140,7 +140,7 @@ static inline bool R_read_cstring(RzBinEndianReader *R, const char **x) {
 	if (!(R->data && R->offset + 1 <= R->length)) {
 		return false;
 	}
-	ut64 len = strnlen((char *)R_data(R), R_remain(R));
+	ut64 len = rz_str_nlen((char *)R_data(R), R_remain(R));
 	*x = (const char *)R_data(R);
 	R->offset += len + 1;
 	return true;

--- a/librz/debug/p/native/xnu/xnu_debug.c
+++ b/librz/debug/p/native/xnu/xnu_debug.c
@@ -500,7 +500,11 @@ RzList *xnu_thread_list(RzDebug *dbg, int pid, RzList *list) {
 #if __arm__ || __arm64__ || __aarch_64__
 #define CPU_PC (dbg->bits == RZ_SYS_BITS_64) ? state.arm64.__pc : state.arm32.__pc
 #elif __POWERPC__
+#if __DARWIN_UNIX03
+#define CPU_PC state.__srr0
+#else
 #define CPU_PC state.srr0
+#endif
 #elif __x86_64__ || __i386__
 #define CPU_PC (dbg->bits == RZ_SYS_BITS_64) ? state.uts.ts64.__rip : state.uts.ts32.__eip
 #endif

--- a/librz/debug/p/native/xnu/xnu_debug.c
+++ b/librz/debug/p/native/xnu/xnu_debug.c
@@ -1154,8 +1154,10 @@ static void xnu_map_free(RzDebugMap *map) {
 }
 
 static RzList *xnu_dbg_modules(RzDebug *dbg) {
-#if __POWERPC__
+#if !defined(MAC_OS_X_VERSION_10_7)
 #warning TODO: xnu_dbg_modules not supported
+	// TASK_DYLD_INFO introduced in 10.6
+	// TASK_DYLD_ALL_IMAGE_INFO_* introduced in 10.7
 	return NULL;
 #else
 	rz_return_val_if_fail(dbg && dbg->plugin_data, NULL);

--- a/librz/debug/p/native/xnu/xnu_debug.h
+++ b/librz/debug/p/native/xnu/xnu_debug.h
@@ -72,12 +72,10 @@ int ptrace(int _request, pid_t _pid, caddr_t _addr, int _data);
 #include <sys/fcntl.h>
 #include <sys/proc.h>
 
-// G3
 #if __POWERPC__
 #include <sys/ptrace.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-#include <mach/ppc/_types.h>
 #include <mach/ppc/thread_status.h>
 // iPhone5
 #elif __aarch64
@@ -88,7 +86,6 @@ int ptrace(int _request, pid_t _pid, caddr_t _addr, int _data);
 #elif __arm64
 #include <mach/arm/thread_status.h>
 #else
-// iMac
 /* x86 32/64 */
 #include <mach/i386/thread_status.h>
 #include <sys/ucontext.h>

--- a/librz/debug/p/native/xnu/xnu_excthreads.c
+++ b/librz/debug/p/native/xnu/xnu_excthreads.c
@@ -45,9 +45,8 @@ RZ_IPI bool xnu_modify_trace_bit(RzDebug *dbg, xnu_thread_t *th, int enable) {
 }
 
 #elif __POWERPC__ // ppc processor
-// XXX poor support at this stage i don't care so much. Once intel and arm done it could be done
-// TODO add better support for ppc
-RZ_IPI bool xnu_modify_trace_bit(RzDebug *dbg, void *th, int enable) {
+// TODO: Implement and test this for ppc too. Below is an old example for reference.
+RZ_IPI bool xnu_modify_trace_bit(RzDebug *dbg, xnu_thread_t *th, int enable) {
 	return false;
 }
 #if 0

--- a/librz/debug/p/native/xnu/xnu_threads.c
+++ b/librz/debug/p/native/xnu/xnu_threads.c
@@ -109,7 +109,7 @@ RZ_IPI bool rz_xnu_thread_set_drx(RzXnuDebug *ctx, xnu_thread_t *thread) {
 #ifndef PPC_DEBUG_STATE32
 #define PPC_DEBUG_STATE32 1
 #endif
-	ppc_debug_state_t *regs;
+	// ppc_debug_state_t *regs;
 	// thread->flavor = PPC_DEBUG_STATE32;
 	// thread->count  = RZ_MIN (thread->count, sizeof (regs->uds.ds32));
 	return false;

--- a/librz/debug/p/native/xnu/xnu_threads.c
+++ b/librz/debug/p/native/xnu/xnu_threads.c
@@ -220,7 +220,9 @@ RZ_IPI bool rz_xnu_thread_get_gpr(RzXnuDebug *ctx, xnu_thread_t *thread) {
 }
 
 static bool xnu_fill_info_thread(RzDebug *dbg, xnu_thread_t *thread) {
-#if __POWERPC__
+#if !defined(MAC_OS_X_VERSION_10_6)
+	// THREAD_IDENTIFIER_INFO introduced in 10.6
+	// TODO: use e.g. only basic info as a fallback here
 	thread->name = strdup("unknown");
 	return false;
 #else


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

The relevant flag we want to use with posix_spawn is POSIX_SPAWN_CLOEXEC_DEFAULT, for which checking for `__POWERPC__` made no sense. This caused build failures on Mac OS X 10.6 and potential kernel panics on 10.7.

**Test plan**

Try to build on various Mac OS X versions: 
- [x] 10.5 ppc
- [x] 10.5 x86
- [x] 10.6 x86
- [x] 10.7 x86
- [x] 10.8 x86

**Closing Issues**

Fix #4352