### PR TITLE
Fix broken CI

### DIFF
--- a/librz/arch/isa/hexagon/hexagon_arch.c
+++ b/librz/arch/isa/hexagon/hexagon_arch.c
@@ -350,12 +350,14 @@ RZ_API HexState *hexagon_state(bool reset) {
 	state = RZ_NEW0(HexState);
 	if (!state) {
 		RZ_LOG_FATAL("Could not allocate memory for HexState!");
+		return NULL;
 	}
 	for (int i = 0; i < HEXAGON_STATE_PKTS; ++i) {
 		state->pkts[i].bin = rz_list_newf((RzListFree)hex_insn_container_free);
 		state->pkts[i].il_ops = rz_pvector_new(NULL);
 		if (!state->pkts[i].bin) {
 			RZ_LOG_FATAL("Could not initialize instruction list!");
+			return NULL;
 		}
 		hex_clear_pkt(&(state->pkts[i]));
 	}
@@ -672,6 +674,7 @@ RZ_API HexInsn *hexagon_alloc_instr() {
 	HexInsn *hi = RZ_NEW0(HexInsn);
 	if (!hi) {
 		RZ_LOG_FATAL("Could not allocate memory for new instruction.\n");
+		return NULL;
 	}
 	hi->fround_mode = RZ_FLOAT_RMODE_RNE;
 	return hi;
@@ -686,6 +689,7 @@ RZ_API HexInsnContainer *hexagon_alloc_instr_container() {
 	HexInsnContainer *hic = RZ_NEW0(HexInsnContainer);
 	if (!hic) {
 		RZ_LOG_FATAL("Could not allocate memory for new instruction container.\n");
+		return NULL;
 	}
 	return hic;
 }
@@ -702,6 +706,7 @@ RZ_API HexInsnContainer *hexagon_alloc_instr_container() {
 static HexInsnContainer *hex_add_to_pkt(HexState *state, const HexInsnContainer *new_hic, RZ_INOUT HexPkt *pkt, const ut8 k) {
 	if (k > 3) {
 		RZ_LOG_FATAL("Instruction could not be set! A packet can only hold four instructions but k=%d.", k);
+		return NULL;
 	}
 	HexInsnContainer *hic = hexagon_alloc_instr_container();
 	hex_move_insn_container(hic, new_hic);
@@ -1082,6 +1087,7 @@ RZ_API void hexagon_reverse_opcode(const RzAsm *rz_asm, HexReversedOpcode *rz_re
 	HexState *state = hexagon_state(false);
 	if (!state) {
 		RZ_LOG_FATAL("HexState was NULL.");
+		return;
 	}
 	if (rz_asm) {
 		memcpy(&state->rz_asm, rz_asm, sizeof(RzAsm));

--- a/librz/arch/isa/hexagon/hexagon_arch.c
+++ b/librz/arch/isa/hexagon/hexagon_arch.c
@@ -16,6 +16,7 @@
 #include <hexagon/hexagon.h>
 #include <hexagon/hexagon_insn.h>
 #include <hexagon/hexagon_arch.h>
+#include <hexagon/hexagon_il.h>
 
 static inline bool is_invalid_insn_data(ut32 data) {
 	return data == HEX_INVALID_INSN_0 || data == HEX_INVALID_INSN_F;
@@ -211,9 +212,17 @@ RZ_API ut8 hexagon_get_pkt_index_of_addr(const ut32 addr, const HexPkt *p) {
 static void hex_clear_pkt(RZ_NONNULL HexPkt *p) {
 	p->last_instr_present = false;
 	p->is_valid = false;
+	p->is_eob = false;
+	p->hw_loop = HEX_NO_LOOP;
+	p->hw_loop0_addr = 0;
+	p->hw_loop1_addr = 0;
+	p->pkt_addr = 0;
+	p->last_instr_present = false;
+	p->is_valid = false;
 	p->last_access = 0;
 	rz_list_purge(p->bin);
 	rz_pvector_clear(p->il_ops);
+	hex_reset_il_pkt_stats(&p->il_op_stats);
 }
 
 /**
@@ -232,7 +241,6 @@ static HexPkt *hex_get_stale_pkt(HexState *state) {
 			stale_state_pkt = &state->pkts[i];
 		}
 	}
-	hex_clear_pkt(stale_state_pkt);
 	return stale_state_pkt;
 }
 

--- a/librz/arch/isa/hexagon/hexagon_arch.c
+++ b/librz/arch/isa/hexagon/hexagon_arch.c
@@ -91,7 +91,7 @@ RZ_API HexInsnContainer *hex_get_hic_at_addr(HexState *state, const ut32 addr) {
 		RzListIter *iter = NULL;
 		rz_list_foreach (p->bin, iter, hic) {
 			if (addr == hic->addr) {
-				p->last_access = rz_time_now();
+				p->last_access = rz_time_now_mono();
 				RZ_LOG_DEBUG("===== RET buffed_pkts[%d] hic @ 0x010%x ====> \n", i, addr);
 				return hic;
 			}
@@ -259,7 +259,7 @@ RZ_API HexPkt *hex_get_pkt(RZ_BORROW HexState *state, const ut32 addr) {
 		p = &state->pkts[i];
 		rz_list_foreach (p->bin, iter, hic) {
 			if (hic_at_addr(hic, addr)) {
-				p->last_access = rz_time_now();
+				p->last_access = rz_time_now_mono();
 				return p;
 			}
 		}
@@ -636,7 +636,7 @@ static void make_packet_valid(RZ_BORROW HexState *state, RZ_BORROW HexPkt *pkt) 
 		}
 		++i;
 	}
-	pkt->last_access = rz_time_now();
+	pkt->last_access = rz_time_now_mono();
 }
 
 /**
@@ -723,7 +723,7 @@ static HexInsnContainer *hex_add_to_pkt(HexState *state, const HexInsnContainer 
 		// Update the instruction which was previously the first one.
 		hex_set_pkt_info(&state->rz_asm, rz_list_get_n(pkt->bin, 1), pkt, 1, true);
 	}
-	pkt->last_access = rz_time_now();
+	pkt->last_access = rz_time_now_mono();
 	if (pkt->last_instr_present) {
 		make_next_packet_valid(state, pkt);
 	}
@@ -752,7 +752,7 @@ static HexInsnContainer *hex_to_new_pkt(HexState *state, const HexInsnContainer 
 	new_pkt->hw_loop1_addr = pkt->hw_loop1_addr;
 	new_pkt->is_valid = (pkt->is_valid || pkt->last_instr_present);
 	new_pkt->pkt_addr = hic->addr;
-	new_pkt->last_access = rz_time_now();
+	new_pkt->last_access = rz_time_now_mono();
 	hex_set_pkt_info(&state->rz_asm, hic, new_pkt, 0, false);
 	if (new_pkt->last_instr_present) {
 		make_next_packet_valid(state, new_pkt);
@@ -778,7 +778,7 @@ static HexInsnContainer *hex_add_to_stale_pkt(HexState *state, const HexInsnCont
 	pkt->last_instr_present |= is_last_instr(hic->parse_bits);
 	pkt->pkt_addr = new_hic->addr;
 	// p->is_valid = true; // Setting it true also detects a lot of data as valid assembly.
-	pkt->last_access = rz_time_now();
+	pkt->last_access = rz_time_now_mono();
 	hex_set_pkt_info(&state->rz_asm, hic, pkt, 0, false);
 	if (pkt->last_instr_present) {
 		make_next_packet_valid(state, pkt);

--- a/librz/arch/isa/hexagon/hexagon_arch.c
+++ b/librz/arch/isa/hexagon/hexagon_arch.c
@@ -347,7 +347,7 @@ RZ_API HexState *hexagon_state(bool reset) {
 		return state;
 	}
 
-	state = calloc(1, sizeof(HexState));
+	state = RZ_NEW0(HexState);
 	if (!state) {
 		RZ_LOG_FATAL("Could not allocate memory for HexState!");
 	}
@@ -669,7 +669,7 @@ static void make_next_packet_valid(HexState *state, const HexPkt *pkt) {
  * \return HexInsn* The new instruction or NULL on failure.
  */
 RZ_API HexInsn *hexagon_alloc_instr() {
-	HexInsn *hi = calloc(1, sizeof(HexInsn));
+	HexInsn *hi = RZ_NEW0(HexInsn);
 	if (!hi) {
 		RZ_LOG_FATAL("Could not allocate memory for new instruction.\n");
 	}
@@ -683,7 +683,7 @@ RZ_API HexInsn *hexagon_alloc_instr() {
  * \return HexInsnContainer* The new instruction container or NULL on failure.
  */
 RZ_API HexInsnContainer *hexagon_alloc_instr_container() {
-	HexInsnContainer *hic = calloc(1, sizeof(HexInsnContainer));
+	HexInsnContainer *hic = RZ_NEW0(HexInsnContainer);
 	if (!hic) {
 		RZ_LOG_FATAL("Could not allocate memory for new instruction container.\n");
 	}
@@ -1027,7 +1027,7 @@ RZ_API void hex_extend_op(HexState *state, RZ_INOUT HexOp *op, const bool set_ne
 
 	HexConstExt *ce;
 	if (set_new_extender) {
-		ce = calloc(1, sizeof(HexConstExt));
+		ce = RZ_NEW0(HexConstExt);
 		ce->addr = addr + 4;
 		ce->const_ext = op->op.imm;
 		rz_list_append(state->const_ext_l, ce);

--- a/librz/arch/isa/hexagon/hexagon_il.c
+++ b/librz/arch/isa/hexagon/hexagon_il.c
@@ -132,6 +132,7 @@ RZ_IPI bool hex_shuffle_insns(RZ_INOUT HexPkt *p) {
 			op = (HexILOp *)rz_pvector_at(ops, i);
 			if (!op) {
 				RZ_LOG_FATAL("NULL il op at index %" PFMT32d "\n", i);
+				return false;
 			}
 			if (flag && (op->attr & HEX_IL_INSN_ATTR_MEM_WRITE)) {
 				hex_send_insn_to_i(ops, i, last_insn - n_mems);

--- a/librz/util/time.c
+++ b/librz/util/time.c
@@ -30,7 +30,7 @@ RZ_API int rz_time_gettimeofday(struct timeval *p, struct rz_timezone *tz) {
 	// ULARGE_INTEGER ul; // As specified on MSDN.
 	ut64 ul = 0;
 	static int tzflag = 0;
-	FILETIME ft;
+	FILETIME ft = { 0 };
 	if (p) {
 		// Returns a 64-bit value representing the number of
 		// 100-nanosecond intervals since January 1, 1601 (UTC).

--- a/test/db/rzil/hexagon
+++ b/test/db/rzil/hexagon
@@ -295,7 +295,7 @@ RUN
 
 
 NAME=Run v68_scalar
-TIMEOUT=640
+TIMEOUT=900
 FILE=bins/elf/hexagon/rzil/v68_scalar
 CMDS=<<EOF
 e io.cache=1
@@ -307,7 +307,7 @@ EOF
 RUN
 
 NAME=Run v73_scalar
-TIMEOUT=640
+TIMEOUT=900
 FILE=bins/elf/hexagon/rzil/v73_scalar
 CMDS=<<EOF
 e io.cache=1
@@ -319,7 +319,7 @@ EOF
 RUN
 
 NAME=Run test-vma
-TIMEOUT=640
+TIMEOUT=900
 FILE=bins/elf/hexagon/rzil/test-vma
 CMDS=<<EOF
 e io.cache=1
@@ -331,7 +331,7 @@ EOF
 RUN
 
 NAME=Run load_align
-TIMEOUT=640
+TIMEOUT=900
 FILE=bins/elf/hexagon/rzil/load_align
 CMDS=<<EOF
 e io.cache=1
@@ -344,7 +344,7 @@ RUN
 
 NAME=Run mem_noshuf
 FILE=bins/elf/hexagon/rzil/mem_noshuf
-TIMEOUT=640
+TIMEOUT=900
 CMDS=<<EOF
 e io.cache=1
 aezi
@@ -356,7 +356,7 @@ RUN
 
 NAME=Run preg_alias
 FILE=bins/elf/hexagon/rzil/preg_alias
-TIMEOUT=640
+TIMEOUT=900
 CMDS=<<EOF
 e io.cache=1
 aezi
@@ -368,7 +368,7 @@ RUN
 
 NAME=Run dual_stores
 FILE=bins/elf/hexagon/rzil/dual_stores
-TIMEOUT=640
+TIMEOUT=900
 CMDS=<<EOF
 e io.cache=1
 aezi
@@ -380,7 +380,7 @@ RUN
 
 NAME=Run read_write_overlap
 FILE=bins/elf/hexagon/rzil/read_write_overlap
-TIMEOUT=640
+TIMEOUT=900
 CMDS=<<EOF
 e io.cache=1
 aezi


### PR DESCRIPTION
# SQUASH ME

commit message:

Fix Hexagon CI tests:
- Increase timeout for emulation tests for OpenBSD
- Use monotonic clock for timestamps (otherwise two packets can get easily the same timestamp).

Some cleanups
- Replace some `calloc` with `RZ_NEW0`
- Add returns after fatal logs.
- Properly reset all members of a `HexPkt` when cleaned.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->


**TODO**

Windows:

```
[**]            C:\projects\rizin\test\db\analysis\java    18776 OK      1001 BR        0 XX       34 FX
[XX] C:\projects\rizin\test\db\analysis\hexagon hexagon last instr. is endloop branch.
ANSICON=1 RZ_NOPLUGINS=1 C:\projects\rizin\rizin-clang_cl_64_dyn-v0.8.0\bin\rizin.exe -escr.utf8=0 -escr.color=0 -escr.interactive=0 -eflirt.sigdb.load.system=false -eflirt.sigdb.load.home=false -N -Qc 'e analysis.jmp.cref=true
aaa
s 0x00005abc
pd 22
' bins/elf/analysis/hexagon-hello-loop
-- stdout
--- expected
+++ actual
@@ --1,11 +-1,11 @@
 |       ,=< 0x00005abc      ?       if (P3) jump:nt 0x5b1c
-|       |   ; CODE XREF from sym.memcpy @ 0x5abc
+|       |   ; CODE XREF from fcn.00005a90 @ 0x5abc
 |      ,==< 0x00005ac0      /       loop0(0x5acc,R4)
 |      ||   0x00005ac4      |       P0 = cmp.gtu(R4,##0x1)
 |      ||   0x00005ac8      \       R8 = R4
-|      ||   ; CODE XREFS from sym.memcpy @ 0x5ac0, 0x5b10
+|      ||   ; CODE XREFS from fcn.00005a90 @ 0x5ac0, 0x5b10
 |     .`--> 0x00005acc      /       if (P0) R17 = add(R17,##0x20)
 |     : |   0x00005ad0      \       dcfetch(R5+#0x0)
 |     : |   0x00005ad4      /       P3 = cmp.eq(R4,R8)
-- stderr
ERROR: Cannot determine entrypoint, using 0x00005000.
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze function calls
[x] find and analyze function preludes
[x] Analyze len bytes of instructions for references
[x] Check for classes
[x] Finding xrefs in noncode section with analysis.in=io.maps
[x] Analyze value pointers (aav)
[x] Value from 0x00000000 to 0x00003ec0 (aav)
[x] 0x00000000-0x00003ec0 in 0x0-0x3ec0 (aav)
[x] 0x00000000-0x00003ec0 in 0x4000-0xb764 (aav)
[x] Value from 0x00004000 to 0x0000b764 (aav)
[x] 0x00004000-0x0000b764 in 0x0-0x3ec0 (aav)
[x] 0x00004000-0x0000b764 in 0x4000-0xb764 (aav)
[x] Emulate functions to find computed references
[x] Analyze local variables and arguments
[x] Applied 0 FLIRT signatures via sigdb
[x] Propagate noreturn information
[x] Integrate dwarf function information.
[x] Resolve pointers to data sections
[x] Use -AA or aaaa to perform additional experimental analysis.
[XX] C:\projects\rizin\test\db\analysis\hexagon hexagon basic block graph
ANSICON=1 RZ_NOPLUGINS=1 C:\projects\rizin\rizin-clang_cl_64_dyn-v0.8.0\bin\rizin.exe -escr.utf8=0 -escr.color=0 -escr.interactive=0 -eflirt.sigdb.load.system=false -eflirt.sigdb.load.home=false -N -Qc 'aaa
s main
agf
' bins/elf/analysis/hexagon-hello-loop
-- stdout
--- expected
+++ actual
@@ -29,7 +29,7 @@
 |    |                                         |
 |.------------------------------------.    .-----------------.
 ||  0x5154                            |    |  0x5134         |
-|| ; DATA XREF from main @ 0x5130     |    | [   jump 0x5138 |
+|| ; DATA XREF from main @ 0x5130     |    | ?   jump 0x5138 |
 || ?   R0 = ##0x0                     |    `-----------------'
 || [   LR:FP = dealloc_return(FP):raw |        v
 |`------------------------------------'        |
-- stderr
ERROR: Cannot determine entrypoint, using 0x00005000.
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze function calls
[x] find and analyze function preludes
[x] Analyze len bytes of instructions for references
[x] Check for classes
[x] Finding xrefs in noncode section with analysis.in=io.maps
[x] Analyze value pointers (aav)
[x] Value from 0x00000000 to 0x00003ec0 (aav)
[x] 0x00000000-0x00003ec0 in 0x0-0x3ec0 (aav)
[x] 0x00000000-0x00003ec0 in 0x4000-0xb764 (aav)
[x] Value from 0x00004000 to 0x0000b764 (aav)
[x] 0x00004000-0x0000b764 in 0x0-0x3ec0 (aav)
[x] 0x00004000-0x0000b764 in 0x4000-0xb764 (aav)
[x] Emulate functions to find computed references
[x] Analyze local variables and arguments
[x] Applied 0 FLIRT signatures via sigdb
[x] Propagate noreturn information
[x] Integrate dwarf function information.
[x] Resolve pointers to data sections
[x] Use -AA or aaaa to perform additional experimental analysis.
[**]           C:\projects\rizin\test\db\analysis\h8300    18777 OK      1001 BR        0 XX       34 FX

```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All green

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
