### PR TITLE
Lift MSP430 machine language to RzIL

### DIFF
--- a/librz/arch/isa/msp430/msp430_disas.c
+++ b/librz/arch/isa/msp430/msp430_disas.c
@@ -7,26 +7,11 @@
 #include <rz_types.h>
 #include <rz_util.h>
 
-#include "msp430_disas.h"
+#include <msp430/msp430_disas.h>
 
-static const char *msp430_register_names[] = {
-	"pc",
-	"sp",
-	"sr",
-	"cg",
-	"r4",
-	"r5",
-	"r6",
-	"r7",
-	"r8",
-	"r9",
-	"r10",
-	"r11",
-	"r12",
-	"r13",
-	"r14",
-	"r15",
-};
+#include <msp430/msp430_register_names.h>
+
+#define WRITE_INSTR_STR(cmd, str) snprintf(cmd->instr, sizeof(cmd->instr), "%s", str)
 
 static const char *two_op_instrs[] = {
 	[MSP430_MOV] = "mov",
@@ -88,14 +73,14 @@ static int get_dst(ut16 instr) {
 	return instr & 0xF;
 }
 
-static void remove_first_operand(struct msp430_cmd *cmd) {
+static void remove_first_operand(Msp430Cmd *cmd) {
 	if (strchr(cmd->operands, ',')) {
 		memmove(cmd->operands, strchr(cmd->operands, ',') + 2,
 			strlen(strchr(cmd->operands, ',') + 2) + 1);
 	}
 }
 
-static void remove_second_operand(struct msp430_cmd *cmd) {
+static void remove_second_operand(Msp430Cmd *cmd) {
 	if (strchr(cmd->operands, ',')) {
 		{
 			*strchr(cmd->operands, ',') = '\0';
@@ -103,9 +88,7 @@ static void remove_second_operand(struct msp430_cmd *cmd) {
 	}
 }
 
-/* TODO: This code is messy, needs to be refactored. */
-static int decode_emulation(ut16 instr, struct msp430_cmd *cmd) {
-	int ret = -1;
+static void decode_emulation(ut16 instr, Msp430Cmd *cmd) {
 	ut8 as, ad, src, dst, bw, opcode;
 
 	as = get_as(instr);
@@ -116,87 +99,129 @@ static int decode_emulation(ut16 instr, struct msp430_cmd *cmd) {
 	opcode = get_twoop_opcode(instr);
 
 	if (opcode == MSP430_ADDC && as == 0 && src == MSP430_R3) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", bw ? "adc.b" : "adc");
+		WRITE_INSTR_STR(cmd, bw ? "adc.b" : "adc");
 		snprintf(cmd->operands, sizeof(cmd->operands), "%s", msp430_register_names[dst]);
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_ADC;
 	} else if (opcode == MSP430_MOV && as == 0 && src == MSP430_R3) {
+		cmd->type = MSP430_EMULATE;
+
 		if (ad == 0 && dst == MSP430_R3) {
 			snprintf(cmd->instr, sizeof(cmd->instr), "nop");
 			cmd->operands[0] = '\0';
+			cmd->opcode = MSP430_NOP;
 		} else {
-			snprintf(cmd->instr, sizeof(cmd->instr), "%s", bw ? "clr.b" : "clr");
+			WRITE_INSTR_STR(cmd, bw ? "clr.b" : "clr");
 			remove_first_operand(cmd);
+			cmd->opcode = MSP430_CLR;
 		}
 	} else if (opcode == MSP430_MOV && as == 3 && src == MSP430_SP) {
+		cmd->type = MSP430_EMULATE;
+
 		if (dst == MSP430_PC) {
 			snprintf(cmd->instr, sizeof(cmd->instr), "ret");
-			cmd->type = MSP430_ONEOP;
-			cmd->opcode = MSP430_RETI;
 			cmd->operands[0] = '\0';
+			cmd->opcode = MSP430_RET;
 		} else {
-			snprintf(cmd->instr, sizeof(cmd->instr), "%s", bw ? "pop.b" : "pop");
+			WRITE_INSTR_STR(cmd, bw ? "pop.b" : "pop");
 			remove_first_operand(cmd);
+			cmd->opcode = MSP430_POP;
 		}
 	} else if (opcode == MSP430_MOV && ad == 0 && dst == MSP430_PC) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", "br");
+		WRITE_INSTR_STR(cmd, "br");
 		remove_second_operand(cmd);
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_BR;
 	} else if (opcode == MSP430_BIC && as == 2 && src == MSP430_SR && dst == MSP430_SR && ad == 0) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", "clrn");
+		WRITE_INSTR_STR(cmd, "clrn");
 		cmd->operands[0] = '\0';
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_CLRN;
 	} else if (opcode == MSP430_BIC && as == 2 && src == MSP430_R3 && dst == MSP430_SR && ad == 0) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", "clrz");
+		WRITE_INSTR_STR(cmd, "clrz");
 		cmd->operands[0] = '\0';
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_CLRZ;
 	} else if (opcode == MSP430_BIC && as == 3 && src == MSP430_SR && dst == MSP430_SR && ad == 0) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", "dint");
+		WRITE_INSTR_STR(cmd, "dint");
 		cmd->operands[0] = '\0';
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_DINT;
 	} else if (opcode == MSP430_BIS && as == 3 && src == MSP430_SR && dst == MSP430_SR && ad == 0) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", "eint");
+		WRITE_INSTR_STR(cmd, "eint");
 		cmd->operands[0] = '\0';
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_EINT;
 	} else if (opcode == MSP430_DADD && as == 0 && src == MSP430_R3) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", bw ? "dadc.b" : "dadc");
+		WRITE_INSTR_STR(cmd, bw ? "dadc.b" : "dadc");
 		remove_first_operand(cmd);
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_DADC;
 	} else if (opcode == MSP430_SUB && as == 1 && src == MSP430_R3) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", bw ? "dec.b" : "dec");
+		WRITE_INSTR_STR(cmd, bw ? "dec.b" : "dec");
 		remove_first_operand(cmd);
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_DEC;
 	} else if (opcode == MSP430_SUB && as == 2 && src == MSP430_R3) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", bw ? "decd.b" : "decd");
+		WRITE_INSTR_STR(cmd, bw ? "decd.b" : "decd");
 		remove_first_operand(cmd);
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_DECD;
 	} else if (opcode == MSP430_ADD && as == 1 && src == MSP430_R3) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", bw ? "inc.b" : "inc");
+		WRITE_INSTR_STR(cmd, bw ? "inc.b" : "inc");
 		remove_first_operand(cmd);
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_INC;
 	} else if (opcode == MSP430_ADD && as == 2 && src == MSP430_R3) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", bw ? "incd.b" : "incd");
+		WRITE_INSTR_STR(cmd, bw ? "incd.b" : "incd");
 		remove_first_operand(cmd);
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_INCD;
 	} else if (opcode == MSP430_XOR && as == 3 && src == MSP430_R3) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", bw ? "inv.b" : "inv");
+		WRITE_INSTR_STR(cmd, bw ? "inv.b" : "inv");
 		remove_first_operand(cmd);
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_INV;
 	} else if (opcode == MSP430_ADD && src == dst) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", bw ? "rla.b" : "rla");
+		WRITE_INSTR_STR(cmd, bw ? "rla.b" : "rla");
 		remove_second_operand(cmd);
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_RLA;
 	} else if (opcode == MSP430_ADDC && src == dst) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", bw ? "rlc.b" : "rlc");
+		WRITE_INSTR_STR(cmd, bw ? "rlc.b" : "rlc");
 		remove_second_operand(cmd);
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_RLC;
 	} else if (opcode == MSP430_SUBC && as == 0 && src == MSP430_R3) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", bw ? "sbc.b" : "sbc");
+		WRITE_INSTR_STR(cmd, bw ? "sbc.b" : "sbc");
 		remove_first_operand(cmd);
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_SBC;
 	} else if (opcode == MSP430_BIS && as == 1 && src == MSP430_R3 && dst == MSP430_SR && ad == 0) {
 		snprintf(cmd->instr, sizeof(cmd->instr), "setc");
 		cmd->operands[0] = '\0';
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_SETC;
 	} else if (opcode == MSP430_BIS && as == 2 && src == MSP430_SR && dst == MSP430_SR && ad == 0) {
 		snprintf(cmd->instr, sizeof(cmd->instr), "setn");
 		cmd->operands[0] = '\0';
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_SETN;
 	} else if (opcode == MSP430_BIS && as == 2 && src == MSP430_R3 && dst == MSP430_SR && ad == 0) {
 		snprintf(cmd->instr, sizeof(cmd->instr), "setz");
 		cmd->operands[0] = '\0';
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_SETZ;
 	} else if (opcode == MSP430_CMP && as == 0 && src == MSP430_R3) {
-		snprintf(cmd->instr, sizeof(cmd->instr), "%s", bw ? "tst.b" : "tst");
+		WRITE_INSTR_STR(cmd, bw ? "tst.b" : "tst");
 		remove_first_operand(cmd);
+		cmd->type = MSP430_EMULATE;
+		cmd->opcode = MSP430_TST;
 	}
-
-	return ret;
 }
 
 /* return #byte of instruction */
-static int decode_addressing_mode(ut16 instr, ut16 op1, ut16 op2, struct msp430_cmd *cmd) {
+static int decode_addressing_mode(ut16 instr, ut16 op1, ut16 op2, Msp430Cmd *cmd) {
 	int ret = 0, srcOperInCodeWord = 0;
 	ut8 as, ad, src, dst;
 	ut16 op;
@@ -215,9 +240,13 @@ static int decode_addressing_mode(ut16 instr, ut16 op1, ut16 op2, struct msp430_
 		switch (src) {
 		case MSP430_R3: /* CG2 */
 			snprintf(cmd->operands, sizeof(cmd->operands), "#0");
+			cmd->src_mode = MSP430_IMM;
+			cmd->src = 0;
 			break;
 		default: /* register mode */
 			snprintf(cmd->operands, sizeof(cmd->operands), "%s", msp430_register_names[src]);
+			cmd->src_mode = MSP430_REG;
+			cmd->src = src;
 		}
 		ret = 2;
 		break;
@@ -226,18 +255,26 @@ static int decode_addressing_mode(ut16 instr, ut16 op1, ut16 op2, struct msp430_
 		switch (src) {
 		case MSP430_PC: /* symbolic mode */
 			snprintf(cmd->operands, sizeof(cmd->operands), "0x%04x", op1);
+			cmd->src_mode = MSP430_SYM;
+			cmd->src = op1;
 			srcOperInCodeWord = 1;
 			break;
 		case MSP430_R3: /* CG2 */
 			snprintf(cmd->operands, sizeof(cmd->operands), "%s", "#1");
+			cmd->src_mode = MSP430_IMM;
+			cmd->src = 1;
 			ret = 2;
 			break;
 		case MSP430_SR: /* absolute mode */
 			snprintf(cmd->operands, sizeof(cmd->operands), "&0x%04x", op1);
+			cmd->src_mode = MSP430_ABS;
+			cmd->src = op1;
 			srcOperInCodeWord = 1;
 			break;
 		default: /* indexed mode */
 			snprintf(cmd->operands, sizeof(cmd->operands), "0x%x(%s)", op1, msp430_register_names[src]);
+			cmd->src_mode = MSP430_INDX;
+			cmd->src = (op1 << 8) | src;
 			srcOperInCodeWord = 1;
 		}
 		break;
@@ -245,12 +282,18 @@ static int decode_addressing_mode(ut16 instr, ut16 op1, ut16 op2, struct msp430_
 		switch (src) {
 		case MSP430_SR: /* CG1 */
 			snprintf(cmd->operands, sizeof(cmd->operands), "#4");
+			cmd->src_mode = MSP430_IMM;
+			cmd->src = 4;
 			break;
 		case MSP430_R3: /* CG2 */
 			snprintf(cmd->operands, sizeof(cmd->operands), "#2");
+			cmd->src_mode = MSP430_IMM;
+			cmd->src = 2;
 			break;
 		default: /* indirect register mode */
 			snprintf(cmd->operands, sizeof(cmd->operands), "@%s", msp430_register_names[src]);
+			cmd->src_mode = MSP430_IND_REG;
+			cmd->src = src;
 		}
 		ret = 2;
 		break;
@@ -259,25 +302,36 @@ static int decode_addressing_mode(ut16 instr, ut16 op1, ut16 op2, struct msp430_
 		switch (src) {
 		case MSP430_SR: /* CG1 */
 			snprintf(cmd->operands, sizeof(cmd->operands), "#8");
+			cmd->src_mode = MSP430_IMM;
+			cmd->src = 8;
 			break;
 		case MSP430_R3: /* CG2 */
 			snprintf(cmd->operands, sizeof(cmd->operands), "#-1");
+			cmd->src_mode = MSP430_IMM;
+			cmd->src = -1;
 			break;
 		case MSP430_PC: /* immediate mode */
 			snprintf(cmd->operands, sizeof(cmd->operands), "#0x%04x", op1);
+			cmd->src_mode = MSP430_IMM;
+			cmd->src = op1;
 			srcOperInCodeWord = 1;
 			ret = 4;
 			break;
 		default: /* indirect autoincrement mode */
 			snprintf(cmd->operands, sizeof(cmd->operands), "@%s+", msp430_register_names[src]);
+			cmd->src_mode = MSP430_IND_AUTOINC;
+			cmd->src = src;
 		}
 		break;
+	default: RZ_LOG_WARN("UNREACHABLE");
 	}
 
 	/* addressing mode of destination operand */
 	switch (ad) {
 	case 0: /* register mode */
 		snprintf(dstbuf, sizeof(dstbuf), ", %s", msp430_register_names[dst]);
+		cmd->dst_mode = MSP430_REG;
+		cmd->dst = dst;
 		break;
 	case 1:
 		/* check addr. mode of source operand */
@@ -291,14 +345,21 @@ static int decode_addressing_mode(ut16 instr, ut16 op1, ut16 op2, struct msp430_
 		switch (get_dst(instr)) {
 		case MSP430_PC: /* symbolic mode */
 			snprintf(dstbuf, sizeof(dstbuf), ", 0x%04x", op);
+			cmd->dst_mode = MSP430_SYM;
+			cmd->dst = op;
 			break;
 		case MSP430_SR: /* absolute mode */
 			snprintf(dstbuf, sizeof(dstbuf), ", &0x%04x", op);
+			cmd->dst_mode = MSP430_ABS;
+			cmd->dst = op;
 			break;
 		default: /* indexed mode */
 			snprintf(dstbuf, sizeof(dstbuf), ", 0x%x(%s)", op, msp430_register_names[dst]);
+			cmd->dst_mode = MSP430_INDX;
+			cmd->dst = (op << 8) | dst;
 		}
 		break;
+	default: RZ_LOG_WARN("UNREACHABLE");
 	}
 
 	strncat(cmd->operands, dstbuf, sizeof(cmd->operands) - 1 - strlen(cmd->operands));
@@ -306,11 +367,12 @@ static int decode_addressing_mode(ut16 instr, ut16 op1, ut16 op2, struct msp430_
 	return ret;
 }
 
-static int decode_twoop_opcode(ut16 instr, ut16 op1, ut16 op2, struct msp430_cmd *cmd) {
+static int decode_twoop_opcode(ut16 instr, ut16 op1, ut16 op2, Msp430Cmd *cmd) {
 	ut8 opcode = get_twoop_opcode(instr);
 
-	snprintf(cmd->instr, sizeof(cmd->instr), "%s", two_op_instrs[opcode]);
-	if (get_bw(instr)) {
+	WRITE_INSTR_STR(cmd, two_op_instrs[opcode]);
+	cmd->is_byte = get_bw(instr);
+	if (cmd->is_byte) {
 		strncat(cmd->instr, ".b", sizeof(cmd->instr) - 1 - strlen(cmd->instr));
 	}
 
@@ -326,10 +388,10 @@ static ut8 get_jmp_cond(ut16 instr) {
 	return (instr >> 10) & 7;
 }
 
-static void decode_jmp(ut16 instr, struct msp430_cmd *cmd) {
+static void decode_jmp(ut16 instr, Msp430Cmd *cmd) {
 	ut16 addr;
 
-	snprintf(cmd->instr, sizeof(cmd->instr), "%s", jmp_instrs[get_jmp_cond(instr)]);
+	WRITE_INSTR_STR(cmd, jmp_instrs[get_jmp_cond(instr)]);
 
 	addr = instr & 0x3FF;
 
@@ -346,7 +408,7 @@ static int get_oneop_opcode(ut16 instr) {
 	return (instr >> 7) & 0x7;
 }
 
-static int decode_oneop_opcode(ut16 instr, ut16 op, struct msp430_cmd *cmd) {
+static int decode_oneop_opcode(ut16 instr, ut16 op, Msp430Cmd *cmd) {
 	int ret = 2;
 	ut8 as, opcode;
 
@@ -354,7 +416,7 @@ static int decode_oneop_opcode(ut16 instr, ut16 op, struct msp430_cmd *cmd) {
 
 	as = get_as(instr);
 
-	snprintf(cmd->instr, sizeof(cmd->instr), "%s", one_op_instrs[opcode]);
+	WRITE_INSTR_STR(cmd, one_op_instrs[opcode]);
 
 	cmd->opcode = get_oneop_opcode(instr);
 
@@ -370,10 +432,15 @@ static int decode_oneop_opcode(ut16 instr, ut16 op, struct msp430_cmd *cmd) {
 			switch (get_dst(instr)) {
 			case MSP430_R3:
 				snprintf(cmd->operands, sizeof(cmd->operands), "#0");
+				cmd->dst = 0;
+				cmd->dst_mode = MSP430_IMM;
 				break;
 			default:
 				snprintf(cmd->operands, sizeof(cmd->operands),
 					"%s", msp430_register_names[get_dst(instr)]);
+				cmd->dst = get_dst(instr);
+				cmd->dst_mode = MSP430_REG;
+				break;
 			}
 			ret = 2;
 			break;
@@ -383,18 +450,26 @@ static int decode_oneop_opcode(ut16 instr, ut16 op, struct msp430_cmd *cmd) {
 			switch (get_dst(instr)) {
 			case MSP430_R3:
 				snprintf(cmd->operands, sizeof(cmd->operands), "#1");
+				cmd->dst = 1;
+				cmd->dst_mode = MSP430_IMM;
 				/* this is an unusual encoding in that there's no index word */
 				ret = 2;
 				break;
 			case MSP430_PC:
 				snprintf(cmd->operands, sizeof(cmd->operands), "0x%04x", op);
+				cmd->dst = op;
+				cmd->dst_mode = MSP430_SYM;
 				break;
 			case MSP430_SR:
 				snprintf(cmd->operands, sizeof(cmd->operands), "&0x%04x", op);
+				cmd->dst = op;
+				cmd->dst_mode = MSP430_ABS;
 				break;
 			default:
 				snprintf(cmd->operands, sizeof(cmd->operands),
 					"0x%x(%s)", op, msp430_register_names[get_dst(instr)]);
+				cmd->dst = (op << 8) | get_dst(instr);
+				cmd->dst_mode = MSP430_INDX;
 			}
 
 			break;
@@ -402,19 +477,27 @@ static int decode_oneop_opcode(ut16 instr, ut16 op, struct msp430_cmd *cmd) {
 			switch (get_dst(instr)) {
 			case MSP430_SR:
 				snprintf(cmd->operands, sizeof(cmd->operands), "#4");
+				cmd->dst = 4;
+				cmd->dst_mode = MSP430_IMM;
 				break;
 			case MSP430_R3:
 				snprintf(cmd->operands, sizeof(cmd->operands), "#2");
+				cmd->dst = 2;
+				cmd->dst_mode = MSP430_IMM;
 				break;
 			default:
 				snprintf(cmd->operands, sizeof(cmd->operands),
 					"@%s", msp430_register_names[get_dst(instr)]);
+				cmd->dst = get_dst(instr);
+				cmd->dst_mode = MSP430_IND_REG;
 			}
 
 			ret = 2;
 			break;
 		case 3:
 			snprintf(cmd->operands, sizeof(cmd->operands), "#0x%04x", op);
+			cmd->dst = op;
+			cmd->dst_mode = MSP430_IMM;
 			ret = 4;
 			break;
 		default:
@@ -427,6 +510,7 @@ static int decode_oneop_opcode(ut16 instr, ut16 op, struct msp430_cmd *cmd) {
 	}
 
 	cmd->type = MSP430_ONEOP;
+	cmd->is_byte = get_bw(instr);
 
 	return ret;
 }
@@ -438,7 +522,7 @@ enum {
 	MSP430_TWOOP_OPCODE_JUMP3,
 };
 
-int msp430_decode_command(const ut8 *in, int len, struct msp430_cmd *cmd) {
+int msp430_decode_command(const ut8 *in, int len, Msp430Cmd *cmd) {
 	int ret = -1;
 	ut16 operand1 = 0, operand2 = 0;
 	if (len < 2) {
@@ -483,7 +567,7 @@ int msp430_decode_command(const ut8 *in, int len, struct msp430_cmd *cmd) {
 	/* if ret < 0, it's an invalid opcode.Say so and return 2 since
 	 * all MSP430 opcodes are of 16 bits,valid or invalid */
 	if (ret < 0) {
-		cmd->type = MSP430_INV;
+		cmd->type = MSP430_INVALID;
 		snprintf(cmd->instr, sizeof(cmd->instr), "invalid");
 		cmd->operands[0] = '\0';
 		ret = 2;

--- a/librz/arch/isa/msp430/msp430_disas.c
+++ b/librz/arch/isa/msp430/msp430_disas.c
@@ -359,7 +359,7 @@ static int decode_addressing_mode(ut16 instr, ut16 op1, ut16 op2, Msp430Cmd *cmd
 			cmd->dst = (op << 8) | dst;
 		}
 		break;
-	default: RZ_LOG_WARN("UNREACHABLE");
+	default: rz_warn_if_reached();
 	}
 
 	strncat(cmd->operands, dstbuf, sizeof(cmd->operands) - 1 - strlen(cmd->operands));

--- a/librz/arch/isa/msp430/msp430_disas.h
+++ b/librz/arch/isa/msp430/msp430_disas.h
@@ -7,7 +7,7 @@
 #ifndef MSP430_DISAS_H
 #define MSP430_DISAS_H
 
-enum msp430_oneop_opcodes {
+typedef enum msp430_oneop_opcodes {
 	MSP430_RRC,
 	MSP430_SWPB,
 	MSP430_RRA,
@@ -16,9 +16,9 @@ enum msp430_oneop_opcodes {
 	MSP430_CALL,
 	MSP430_RETI,
 	MSP430_UNUSED,
-};
+} Msp430OneopOpcodes;
 
-enum msp430_jumps {
+typedef enum msp430_jumps {
 	MSP430_JNE,
 	MSP430_JEQ,
 	MSP430_JNC,
@@ -27,10 +27,9 @@ enum msp430_jumps {
 	MSP430_JGE,
 	MSP430_JL,
 	MSP430_JMP,
-};
+} Msp430Jumps;
 
-enum msp430_twoop_opcodes {
-	MSP430_JMP_OPC = 0x1,
+typedef enum msp430_twoop_opcodes {
 	MSP430_MOV = 0x4,
 	MSP430_ADD,
 	MSP430_ADDC,
@@ -43,23 +42,44 @@ enum msp430_twoop_opcodes {
 	MSP430_BIS,
 	MSP430_XOR,
 	MSP430_AND,
-};
+} Msp430TwoopOpcodes;
 
-enum msp430_addr_modes {
-	MSP430_DIRECT,
-	MSP430_INDEXED,
-	MSP430_INDIRECT,
-	MSP430_INDIRECT_INC,
-};
+typedef enum msp430_emulated_opcodes {
+	MSP430_ADC,
+	MSP430_BR,
+	MSP430_CLR,
+	MSP430_CLRC,
+	MSP430_CLRN,
+	MSP430_CLRZ,
+	MSP430_DADC,
+	MSP430_DEC,
+	MSP430_DECD,
+	MSP430_DINT,
+	MSP430_EINT,
+	MSP430_INC,
+	MSP430_INCD,
+	MSP430_INV,
+	MSP430_NOP,
+	MSP430_POP,
+	MSP430_RET,
+	MSP430_RLA,
+	MSP430_RLC,
+	MSP430_SBC,
+	MSP430_SETC,
+	MSP430_SETN,
+	MSP430_SETZ,
+	MSP430_TST
+} Msp430EmulatedOpcodes;
 
-enum msp430_cmd_type {
+typedef enum msp430_cmd_type {
 	MSP430_ONEOP,
 	MSP430_TWOOP,
 	MSP430_JUMP,
-	MSP430_INV,
-};
+	MSP430_EMULATE,
+	MSP430_INVALID,
+} Msp430CmdType;
 
-enum msp430_registers {
+typedef enum msp430_registers {
 	MSP430_PC,
 	MSP430_SP,
 	MSP430_SR,
@@ -76,25 +96,45 @@ enum msp430_registers {
 	MSP430_R13,
 	MSP430_R14,
 	MSP430_R15,
-};
+} Msp430Registers;
 
-struct msp430_cmd {
-	ut8 type;
-	ut8 opcode;
-	st16 jmp_addr;
-	ut16 call_addr;
-	ut8 jmp_cond;
+typedef enum Msp430AddressingMode {
+	MSP430_REG, ///< register: Rn, contents of Rn
+	MSP430_INDX, ///< indexed: offset(Rn), contents of Memory[offset + Rn]
+	MSP430_SYM, ///< symbolic: offset, contents of Memory[offset + PC] (as if indexed with Rn = PC)
+	MSP430_ABS, ///< absolute: &addr, contents of Memory[addr] (as if indexed with a zeroed Rn)
+	MSP430_IND_REG, ///< indirect register: @Rn, contents of Memory[Rn] (as if indexed with offset = 0)
+	MSP430_IND_AUTOINC, ///< indirect register auto-increment: @Rn+, same as with indirect register but automatically increments Rn
+	MSP430_IMM ///< immediate: #literal, the literal value itself is the argument
+} Msp430AddressingMode;
 
-	// Null-delimited string representation of an assembly operation mnemonic.
+/**
+ *  \brief represents a disassembled instructions, also used for lifting
+ * */
+typedef struct msp430_cmd {
+	ut8 type; ///< whether it's a one-operand, two-operand, emulated, jump or invalid
+	ut8 opcode; ///< which kind of operation
+
+	st16 jmp_addr; ///< for jumps, what's the address to jump to
+	ut8 jmp_cond; ///< for jumps, when will the jump be taken
+
 	// Length of array: 'i', 'n', 'v', 'a', 'l', 'i', 'd', '\0'
 	// (This is longer than any real assembly mnemonic.)
-	char instr[7 + 1];
+	char instr[7 + 1]; ///< Null-delimited string representation of an assembly operation mnemonic.
 
-	// Null-delimited string representation of assembly operands.
+	bool is_byte; ///< does it have a .b suffix ? (i.e. whether it's a byte instruction or word instruction )
+
 	// Length of array: 2 * ('0', 'x', 4-digit hexadecimal numeral, '(', 'r', 2-digit
 	// decimal numeral, ')'), ',', ' ', '\0'
-	char operands[2 * (2 + 4 + 2 + 3) + 2 + 1];
-};
+	char operands[2 * (2 + 4 + 2 + 3) + 2 + 1]; ///< Null-delimited string representation of assembly operands.
 
-int msp430_decode_command(const ut8 *instr, int len, struct msp430_cmd *cmd);
+	// The source and the dst of the operands, along with their modes
+	// This info is contained in the strings above, but parsing strings to obtain it is ugly so we replicate it here
+	ut32 src; ///< src, doesn't get overwritten for eumlated instructions
+	ut32 dst; ///< dst, doesn't get overwritten for eumlated instructions
+	Msp430AddressingMode src_mode; ///< the addressing mode used by src, will determine how to interpret its 32 bits
+	Msp430AddressingMode dst_mode; ///< the addressing mode used by dst, will determine how to interpret its 32 bits
+} Msp430Cmd;
+
+int msp430_decode_command(const ut8 *instr, int len, Msp430Cmd *cmd);
 #endif /* MSP430_DISAS_H */

--- a/librz/arch/isa/msp430/msp430_il.c
+++ b/librz/arch/isa/msp430/msp430_il.c
@@ -1,0 +1,507 @@
+// SPDX-FileCopyrightText: 2024 Mostafa Mahmoud <ubermenchun@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <msp430/msp430_il.h>
+
+/* \brief TI user guide:
+ *	The 16-bit program counter (PC/R0) points to the next instruction to be executed.
+ */
+#define PC_SIZE 16
+/* \brief TI user guide:
+ *   The Low byte of a word is always an even address. The high byte is at the next odd address.
+ *   For example, if a data word is located at address xxx4h, then the low byte of that data word
+ *   is located at address xxx4h, and the high byte of that word is located at address xxx5h.
+ */
+#define IS_BIG_ENDIAN false
+/* \brief implied by the size of the address space for ordinary MSP430, also the width of the PC
+ * (MSP430-X has a 1 Mega address space addressed by 20 bits, but that is not supported by the lifter)
+ */
+#define MEM_ADDR_SIZE 16U
+
+#include <msp430/msp430_register_names.h>
+#include <msp430/msp430_il_getset.h>
+#include <msp430/msp430_il_flags.h>
+#include <msp430/msp430_il_jmp_utils.h>
+
+#include <rz_il/rz_il_opbuilder_begin.h>
+
+#define BRANCH_UNLESS(c, t, f) BRANCH(c, f, t)
+
+// ************************************* One-Operand Lifters ********************************* //
+/**
+ * \defgroup One_Op_Lifters lifter functions that lift one-operand non-emulated MSP430 instructions
+ * @{
+ */
+RZ_OWN RzILOpEffect *rz_msp430_lift_call_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return SEQ3(
+		MSP430_SETR(MSP430_SP, SUB(MSP430_GETR(MSP430_SP), U16(2))),
+		STOREW(MSP430_GETR(MSP430_SP), ADD(U16(current_addr), U16(instr_size))),
+		JMP(get_destination(op, current_addr)));
+}
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_rrc_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	// rotation is just a shift with filling
+	return SEQ6(
+		/* 1- get the carry (to use later as the filling for the MSB of the operand) */
+		SETL("old_sr", MSP430_GETR(MSP430_SR)),
+		SETL("old_carry", LSB(VARL("old_sr"))),
+		/* 2- get the operand (whether register, memory location, ...) */
+		SETL("operand", get_destination(op, current_addr)),
+		/* 3- Perform the actual Rotate Right through Carry operation. Do:
+				a- Shift the operand by 1 to the right and fill with carry */
+		SETL("result", SHIFTR(VARL("old_carry"), VARL("operand"), U8(1))),
+		/* ...      b- Set the operand to the value of the previous computation */
+		set_destination(op, VARL("result"), current_addr),
+		/* ...      c- Finally set the flags */
+		set_rcc_flags("operand", "result", "old_carry", "old_sr"));
+}
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_sxt_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return SEQ3(
+		SETL("result", SIGNED(16, get_destination(op, current_addr))),
+		set_destination(op, VARL("result"), current_addr),
+		set_sxt_flags("result"));
+}
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_swpb_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	// 1- get lower byte and upper byte of the operand
+	BVPair low_high = get_destination_destructured(op, current_addr);
+	RzILOpBitVector *low_byte = low_high.first;
+	RzILOpBitVector *high_byte = low_high.second;
+
+	// 2- append them in reverse order
+	RzILOpBitVector *result = APPEND(low_byte, high_byte);
+
+	// 3- set them (flags aren't affected)
+	return set_destination(op, result, current_addr);
+}
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_push_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return SEQ2(
+		MSP430_SETR(MSP430_SP, SUB(MSP430_GETR(MSP430_SP), U16(2))),
+		(op->is_byte) ? STORE(MSP430_GETR(MSP430_SP), get_destination(op, current_addr)) : STOREW(MSP430_GETR(MSP430_SP), get_destination(op, current_addr))
+
+	);
+}
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_pop_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return SEQ2(
+		(op->is_byte) ? set_destination(op, LOAD(MSP430_GETR(MSP430_SP)), current_addr) : set_destination(op, LOADW(16, MSP430_GETR(MSP430_SP)), current_addr),
+		MSP430_SETR(MSP430_SP, ADD(MSP430_GETR(MSP430_SP), U16(2))));
+}
+/** @} */
+
+// ************************************* Two-Operand Lifters ********************************  //
+/* \defgroup Two_Op_Lifters lifter functions that lift two-operand non-emulated MSP430 instructions
+ * @{
+ */
+RZ_OWN RzILOpEffect *rz_msp430_lift_add_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return SEQ5(
+		SETL("old_destination", get_destination(op, current_addr)),
+		SETL("source", get_source(op, current_addr)),
+		SETL("result", ADD(VARL("source"), VARL("old_destination"))),
+
+		set_destination(op, VARL("result"), current_addr),
+		set_add_flags("source", "old_destination", "result"));
+}
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_and_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return SEQ5(
+		SETL("old_destination", get_destination(op, current_addr)),
+		SETL("source", get_source(op, current_addr)),
+		SETL("result", LOGAND(VARL("source"), VARL("old_destination"))),
+
+		set_destination(op, VARL("result"), current_addr),
+		set_and_flags("result"));
+}
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_bit_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return SEQ2(
+		SETL("result", LOGAND(get_source(op, current_addr), get_destination(op, current_addr))),
+		set_and_flags("result"));
+}
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_xor_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return SEQ5(
+		SETL("old_destination", get_destination(op, current_addr)),
+		SETL("source", get_source(op, current_addr)),
+		SETL("result", LOGXOR(VARL("source"), VARL("old_destination"))),
+
+		set_destination(op, VARL("result"), current_addr),
+		set_xor_flags("source", "old_destination", "result"));
+}
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_mov_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return set_destination(op, get_source(op, current_addr), current_addr);
+}
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_sub_or_cmp_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, bool write_dst, ut64 current_addr, int instr_size) {
+	RzILOpBitVector *increment_by;
+	RzILOpBitVector *carry_const;
+	RzILOpBitVector *overflow_const;
+	if (op->is_byte) {
+		increment_by = U8(1);
+		carry_const = U8(0);
+		overflow_const = U8(~0x7F);
+	} else {
+		increment_by = U16(1);
+		carry_const = U16(0);
+		overflow_const = U16(~0x7FFF);
+	}
+
+	RzILOpEffect *get_src = SETL("op0", get_source(op, current_addr));
+	RzILOpEffect *neg_src_add1 = SETL("op1", ADD(increment_by, LOGNOT(VARL("op0"))));
+	RzILOpEffect *get_dst = SETL("op2", get_destination(op, current_addr));
+	RzILOpEffect *compute_result = SETL("result", ADD(VARL("op1"), VARL("op2")));
+	RzILOpEffect *set_flags = set_sub_flags("op0", "op1", "op2", "result", carry_const, overflow_const);
+
+	return (write_dst) ? SEQ6( // sub
+				     get_src,
+				     neg_src_add1,
+				     get_dst,
+				     compute_result,
+				     set_destination(op, VARL("result"), current_addr),
+				     set_flags)
+			   : SEQ5( // cmp
+				     get_src,
+				     neg_src_add1,
+				     get_dst,
+				     compute_result,
+				     set_flags);
+}
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_sub_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return rz_msp430_lift_sub_or_cmp_instr(analysis, op, true, current_addr, instr_size);
+}
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_cmp_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return rz_msp430_lift_sub_or_cmp_instr(analysis, op, false, current_addr, instr_size);
+}
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_bis_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	RzILOpBitVector *result = LOGOR(get_source(op, current_addr), get_destination(op, current_addr));
+	return set_destination(op, result, current_addr);
+}
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_bic_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	RzILOpBitVector *result = LOGAND(LOGNOT(get_source(op, current_addr)), get_destination(op, current_addr));
+	return set_destination(op, result, current_addr);
+}
+/* @} */
+
+// ************************************* Emulated Instruction Lifters ******************************** //
+/* \defgroup Emulated_Op_Lifters lifter functions that lift emulated MSP430 instructions
+ * @{
+ */
+RzILOpEffect *rz_msp430_lift_ret_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return SEQ3(
+		SETL("return_address", LOADW(16, MSP430_GETR(MSP430_SP))),
+		MSP430_SETR(MSP430_SP, ADD(MSP430_GETR(MSP430_SP), U16(2))),
+		JMP(VARL("return_address")));
+}
+
+RzILOpEffect *rz_msp430_lift_br_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return JMP(get_source(op, current_addr));
+}
+
+RzILOpEffect *rz_msp430_lift_inc_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	RzILOpBitVector *increment_by;
+	RzILOpEffect *(*flags_setter)(const char *, const char *);
+	if (op->is_byte) {
+		increment_by = U8(1);
+		flags_setter = set_incb_flags;
+	} else {
+		increment_by = U16(1);
+		flags_setter = set_inc_flags;
+	}
+
+	return SEQ4(
+		SETL("old_destination", get_destination(op, current_addr)),
+		SETL("result", ADD(increment_by, VARL("old_destination"))),
+		set_destination(op, VARL("result"), current_addr),
+		flags_setter("result", "old_destination"));
+}
+
+RzILOpEffect *rz_msp430_lift_dec_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	RzILOpBitVector *decrement_by;
+	RzILOpEffect *(*flags_setter)(const char *, const char *);
+	if (op->is_byte) {
+		decrement_by = U8(1);
+		flags_setter = set_decb_flags;
+	} else {
+		decrement_by = U16(1);
+		flags_setter = set_dec_flags;
+	}
+
+	return SEQ4(
+		SETL("old_destination", get_destination(op, current_addr)),
+		SETL("result", SUB(decrement_by, VARL("old_destination"))),
+		set_destination(op, VARL("result"), current_addr),
+		flags_setter("result", "old_destination"));
+}
+
+RzILOpEffect *rz_msp430_lift_clr_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return set_destination(op, (op->is_byte) ? U8(0) : U16(0), current_addr);
+}
+
+RzILOpEffect *rz_msp430_lift_tst_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return set_tst_flags(get_destination(op, current_addr));
+}
+
+RzILOpEffect *rz_msp430_lift_setc_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return set_setc_flags();
+}
+RzILOpEffect *rz_msp430_lift_setn_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return set_setn_flags();
+}
+
+RzILOpEffect *rz_msp430_lift_setz_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return set_setz_flags();
+}
+
+RzILOpEffect *rz_msp430_lift_clrc_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return set_clrc_flags();
+}
+
+RzILOpEffect *rz_msp430_lift_clrn_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return set_clrn_flags();
+}
+
+RzILOpEffect *rz_msp430_lift_clrz_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return set_clrz_flags();
+}
+
+RzILOpEffect *rz_msp430_lift_nop_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	// so easy xD
+	return NOP();
+}
+
+RzILOpEffect *rz_msp430_lift_inv_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return SEQ4(
+		SETL("old_destination", get_destination(op, current_addr)),
+		SETL("result", LOGNOT(VARL("old_destination"))),
+		set_destination(op, VARL("result"), current_addr),
+		set_inv_flags("result", "old_destination"));
+}
+
+RzILOpEffect *rz_msp430_lift_adc_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return BRANCH(
+		check_if_zero_carry(),
+		NOP(),
+		rz_msp430_lift_inc_instr(analysis, op, current_addr, instr_size));
+}
+
+RzILOpEffect *rz_msp430_lift_sbc_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return BRANCH(
+		check_if_zero_carry(),
+		rz_msp430_lift_dec_instr(analysis, op, current_addr, instr_size),
+		NOP());
+}
+
+typedef enum digit_position {
+	DIGIT_0,
+	DIGIT_1,
+	DIGIT_2,
+	DIGIT_3
+} DigitPos;
+
+RzILOpBool *check_if_digit_eq_9(const char *operand_name, DigitPos dp, bool is_byte);
+RzILOpBitVector *increment_digit_clear_lesser_digits(const char *operand_name, DigitPos dp, bool is_byte);
+RzILOpEffect *continue_rz_msp430_lift_dadc_instr();
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_dadc_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	// Since the msp430 manual says the result is not defined if the operand is not a valid BCD number
+	// therefore we're allowed to assume that any digit in the operand is either equal to 9 or less than 9
+	// Say the operand's digits are d3 d2 d1 d0, where each digit is between 0 and 9 inclusive
+	return BRANCH(
+		check_if_zero_carry(),
+		NOP(), // nothing to do
+		SEQ2(
+			SETL("operand", get_destination(op, current_addr)),
+			/* see if d0 is 9 */
+			BRANCH_UNLESS(check_if_digit_eq_9("operand", DIGIT_0, op->is_byte),
+				/* if not, then increment it. Result is d3 d2 d1 (d0 + 1) */
+				SETL("result", increment_digit_clear_lesser_digits("operand", DIGIT_0, op->is_byte)),
+				/* else, see if d1 is 9 */
+				BRANCH_UNLESS(check_if_digit_eq_9("operand", DIGIT_1, op->is_byte),
+					/* if not, then increment it. Result is d3 d2 (d1 + 1) 0 */
+					SETL("result", increment_digit_clear_lesser_digits("operand", DIGIT_1, op->is_byte)),
+					/* else, first see if it's a byte instruction */
+					(op->is_byte) ? SETL("result", U8(0)) : // if so, overflow to 8-bit 0
+						/* otherwise, continue the chain to the 4th digit */
+						continue_rz_msp430_lift_dadc_instr()))));
+}
+
+RzILOpEffect *continue_rz_msp430_lift_dadc_instr() {
+	const bool is_byte = false;
+	return
+		/* see if d2 is 9 */
+		BRANCH_UNLESS(check_if_digit_eq_9("operand", DIGIT_2, is_byte),
+			/* if not, then increment it. Result is d3 (d2 + 1) 0 0 */
+			SETL("result", increment_digit_clear_lesser_digits("operand", DIGIT_2, is_byte)),
+			/* else, see if d3 is 9 */
+			BRANCH_UNLESS(check_if_digit_eq_9("operand", DIGIT_3, is_byte),
+				/* if not, then increment it. Result is (d3 + 1) 0 0 0*/
+				SETL("result", increment_digit_clear_lesser_digits("operand", DIGIT_3, is_byte)),
+				/* else overflow to 16-bit 0 */
+				SETL("result", U16(0))));
+}
+
+RzILOpBool *check_if_digit_eq_9(const char *operand_name, DigitPos dp, bool is_byte) {
+	int mask = 9 << ((int)dp * 4);
+	RzILOpBitVector *m1, *m2;
+	if (is_byte) {
+		m1 = U8(mask);
+		m2 = U8(mask);
+	} else {
+		m1 = U16(mask);
+		m2 = U16(mask);
+	}
+	return EQ(LOGAND(VARL(operand_name), m1), m2);
+}
+
+RzILOpBitVector *increment_digit_clear_lesser_digits(const char *operand_name, DigitPos dp, bool is_byte) {
+	int clear_mask = 0xFFFF << ((int)dp * 4);
+	int increment_by = 1 << ((int)dp * 4);
+	RzILOpBitVector *result = ADD(VARL(operand_name), (is_byte) ? U8(increment_by) : U16(increment_by));
+	return (dp == DIGIT_0) ? result : LOGAND(result, (is_byte) ? U8(clear_mask) : U16(clear_mask));
+}
+/* @} */
+
+// ************************************* Jump Instructions Lifter ******************************** //
+/* \defgroup Jump_Op_Lifter lifter functions that lift jump MSP430 instructions (CALL is not a jump instructino, and BR is also not counted)
+ * @{
+ */
+RZ_OWN RzILOpEffect *rz_msp430_lift_jump_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	RzILOpBitVector *abs_addr = abs_addr_from_rel_addr(U16(current_addr), op->jmp_addr);
+	RzILOpEffect *jmp = JMP(abs_addr);
+
+	// unconditional jump
+	if (op->jmp_cond == MSP430_JMP) {
+		return jmp;
+	}
+	// otherwise, construct the condition to make a guarded branch
+	RzILOpBool *jmp_cond = jmp_condition_constructors[op->jmp_cond](MSP430_GETR(MSP430_SR));
+
+	// if applicable, invert the condition efficiently by swapping THEN and ELSE in the RzIL branch
+	if (jmp_condition_triggers[op->jmp_cond] == JMP_THEN) {
+		return BRANCH(jmp_cond, jmp, NOP());
+	} else {
+		return BRANCH(jmp_cond, NOP(), jmp);
+	}
+}
+/* @} */
+
+// ************************************* End of Lifters ******************************** //
+
+RZ_OWN RzILOpEffect *rz_msp430_dummy() {
+	RZ_LOG_ERROR("UNREACHABLE CONTROL FLOW");
+	return NOP();
+}
+
+RzILOpEffect *rz_msp430_lift_todo(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	NOT_IMPLEMENTED;
+}
+
+#include <rz_il/rz_il_opbuilder_end.h>
+#undef BRANCH_UNLESS
+
+static const MSP430InstructionLifter one_op_lifters[] = {
+	[MSP430_RRC] = rz_msp430_lift_rrc_instr,
+	[MSP430_SWPB] = rz_msp430_lift_swpb_instr,
+	[MSP430_RRA] = rz_msp430_lift_todo,
+	[MSP430_SXT] = rz_msp430_lift_sxt_instr,
+	[MSP430_PUSH] = rz_msp430_lift_push_instr,
+	[MSP430_CALL] = rz_msp430_lift_call_instr,
+	[MSP430_RETI] = rz_msp430_lift_todo,
+	[MSP430_UNUSED] = NULL
+};
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_single_operand_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	rz_return_val_if_fail(
+		op->opcode == MSP430_RRC || op->opcode == MSP430_SWPB || op->opcode == MSP430_RRA ||
+			op->opcode == MSP430_SXT || op->opcode == MSP430_PUSH || op->opcode == MSP430_CALL ||
+			op->opcode == MSP430_RETI,
+		NULL);
+	return one_op_lifters[op->opcode](analysis, op, current_addr, instr_size);
+}
+
+static const MSP430InstructionLifter two_op_lifters[] = {
+	[MSP430_MOV] = rz_msp430_lift_mov_instr,
+	[MSP430_ADD] = rz_msp430_lift_add_instr,
+	[MSP430_ADDC] = rz_msp430_lift_todo,
+	[MSP430_SUBC] = rz_msp430_lift_todo,
+	[MSP430_SUB] = rz_msp430_lift_sub_instr,
+	[MSP430_CMP] = rz_msp430_lift_cmp_instr,
+	[MSP430_DADD] = rz_msp430_lift_todo,
+	[MSP430_BIT] = rz_msp430_lift_bit_instr,
+	[MSP430_BIC] = rz_msp430_lift_bic_instr,
+	[MSP430_BIS] = rz_msp430_lift_bis_instr,
+	[MSP430_XOR] = rz_msp430_lift_xor_instr,
+	[MSP430_AND] = rz_msp430_lift_and_instr
+};
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_double_operand_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return two_op_lifters[op->opcode](analysis, op, current_addr, instr_size);
+}
+
+static const MSP430InstructionLifter emulated_instructions_lifter[] = {
+	[MSP430_ADC] = rz_msp430_lift_adc_instr,
+	[MSP430_BR] = rz_msp430_lift_br_instr,
+	[MSP430_CLR] = rz_msp430_lift_clr_instr,
+	[MSP430_CLRC] = rz_msp430_lift_clrc_instr,
+	[MSP430_CLRN] = rz_msp430_lift_clrn_instr,
+	[MSP430_CLRZ] = rz_msp430_lift_clrz_instr,
+	[MSP430_DADC] = rz_msp430_lift_dadc_instr,
+	[MSP430_DEC] = rz_msp430_lift_dec_instr,
+	[MSP430_DECD] = rz_msp430_lift_todo,
+	[MSP430_DINT] = rz_msp430_lift_todo,
+	[MSP430_EINT] = rz_msp430_lift_todo,
+	[MSP430_INC] = rz_msp430_lift_inc_instr,
+	[MSP430_INCD] = rz_msp430_lift_todo,
+	[MSP430_INV] = rz_msp430_lift_inv_instr,
+	[MSP430_NOP] = rz_msp430_lift_nop_instr,
+	[MSP430_POP] = rz_msp430_lift_pop_instr,
+	[MSP430_RET] = rz_msp430_lift_ret_instr,
+	[MSP430_RLA] = rz_msp430_lift_todo,
+	[MSP430_RLC] = rz_msp430_lift_todo,
+	[MSP430_SBC] = rz_msp430_lift_sbc_instr,
+	[MSP430_SETC] = rz_msp430_lift_setc_instr,
+	[MSP430_SETN] = rz_msp430_lift_setn_instr,
+	[MSP430_SETZ] = rz_msp430_lift_setz_instr,
+	[MSP430_TST] = rz_msp430_lift_tst_instr
+};
+
+RZ_OWN RzILOpEffect *rz_msp430_lift_emulated_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	return emulated_instructions_lifter[op->opcode](analysis, op, current_addr, instr_size);
+}
+
+RZ_OWN RZ_IPI RzILOpEffect *rz_msp430_lift_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL const Msp430Instruction *op, ut64 current_addr, int instr_size) {
+	rz_return_val_if_fail(analysis && op, NULL);
+
+	switch (op->type) {
+	case MSP430_ONEOP: {
+		return rz_msp430_lift_single_operand_instr(analysis, op, current_addr, instr_size);
+	}
+	case MSP430_TWOOP: {
+		return rz_msp430_lift_double_operand_instr(analysis, op, current_addr, instr_size);
+	}
+	case MSP430_JUMP: {
+		return rz_msp430_lift_jump_instr(analysis, op, current_addr, instr_size);
+	}
+	case MSP430_EMULATE: {
+		return rz_msp430_lift_emulated_instr(analysis, op, current_addr, instr_size);
+	}
+
+	// should never happen, op can't be an invalid instruction
+	default:
+		rz_warn_if_reached();
+		return rz_msp430_dummy();
+	}
+}
+
+RZ_OWN RZ_IPI RzAnalysisILConfig *rz_msp430_il_config(RZ_BORROW RZ_NONNULL RzAnalysis *analysis) {
+	rz_return_val_if_fail(analysis, NULL);
+
+	return rz_analysis_il_config_new(PC_SIZE, IS_BIG_ENDIAN, MEM_ADDR_SIZE);
+}

--- a/librz/arch/isa/msp430/msp430_il.h
+++ b/librz/arch/isa/msp430/msp430_il.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2024 Mostafa Mahmoud <ubermenchun@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef MSP430_IL_H
+#define MSP430_IL_H
+
+#include <rz_analysis.h>
+#include <msp430/msp430_disas.h>
+
+typedef Msp430Cmd Msp430Instruction;
+
+typedef RzILOpEffect *(*MSP430InstructionLifter)(RzAnalysis *analysis, const Msp430Instruction *op, ut64 curr_addr, int instr_size);
+
+RZ_OWN RZ_IPI RzILOpEffect *rz_msp430_lift_instr(RZ_BORROW RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL const Msp430Instruction *op, ut64 current_addr, int size);
+
+RZ_OWN RZ_IPI RzAnalysisILConfig *rz_msp430_il_config(RZ_BORROW RZ_NONNULL RzAnalysis *analysis);
+
+#endif

--- a/librz/arch/isa/msp430/msp430_il_flags.h
+++ b/librz/arch/isa/msp430/msp430_il_flags.h
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: 2024 Mostafa Mahmoud <ubermenchun@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <msp430/msp430_disas.h>
+#include <rz_il/rz_il_opbuilder_begin.h>
+
+RZ_OWN RzILOpBitVector *update_sr_clear_vcnz(RZ_OWN RzILOpBitVector *old_sr_value) {
+	// the general idea is
+	//		1- Zero out the N,Z,C,V bits in the old SR value
+	// 		   By ANDing with a mask of all 1s everywhere and 0s in those flags' positions
+	// 		2- Code can later set those flags by ORing the resulting sr value with a mask
+	// 		   having 1s in the relevant positions and all 0s everywhere else
+	int cnz_zero_mask = 0xFFF8;
+	int vcnz_zero_mask = cnz_zero_mask & (~(1 << 8));
+	return LOGAND(old_sr_value, U16(vcnz_zero_mask));
+}
+
+RZ_OWN RzILOpBitVector *update_sr_z_flag(RZ_OWN RzILOpBool *new_value, RZ_OWN RzILOpBitVector *old_sr_value) {
+	return LOGOR(old_sr_value, SHIFTL0(BOOL_TO_BV(new_value, 16), U8(1)));
+}
+
+RZ_OWN RzILOpBitVector *update_sr_n_flag(RZ_OWN RzILOpBool *new_value, RZ_OWN RzILOpBitVector *old_sr_value) {
+	return LOGOR(old_sr_value, SHIFTL0(BOOL_TO_BV(new_value, 16), U8(2)));
+}
+
+RZ_OWN RzILOpBitVector *update_sr_nz_flags(RZ_OWN RzILOpBitVector *new_value, RZ_OWN RzILOpBitVector *old_sr_value) {
+	RzILOpBool *n_flag_value = MSB(new_value);
+	RzILOpBool *z_flag_value = IS_ZERO(DUP(new_value));
+
+	return update_sr_n_flag(n_flag_value, update_sr_z_flag(z_flag_value, old_sr_value));
+}
+
+RZ_OWN RzILOpBitVector *update_sr_v_flag(RZ_OWN RzILOpBool *new_overflow, RZ_OWN RzILOpBitVector *old_sr_value) {
+	return LOGOR(old_sr_value, SHIFTL0(BOOL_TO_BV(new_overflow, 16), U8(8)));
+}
+
+RZ_OWN RzILOpBitVector *update_sr_v_flag_rcc(RZ_OWN RzILOpBitVector *old_value, RZ_OWN RzILOpBool *old_carry, RZ_OWN RzILOpBitVector *old_sr_value) {
+	// the idea is the same as update_sr_nz_flags: we AND with a mask that zeroes out the bit we care about
+	// then we OR with a mask that have the bit we care about in the same position that we zeroed
+	RzILOpBool *v_flag_value = AND(
+		INV(MSB(old_value)),
+		old_carry);
+
+	return update_sr_v_flag(v_flag_value, old_sr_value);
+}
+
+RZ_OWN RzILOpBitVector *update_sr_c_flag(RzILOpBool *new_carry, RZ_OWN RzILOpBitVector *old_sr_value) {
+	return LOGOR(old_sr_value, BOOL_TO_BV(new_carry, 16));
+}
+
+RZ_OWN RzILOpBitVector *update_sr_c_flag_add(RZ_OWN RzILOpBitVector *op1, RZ_OWN RzILOpBitVector *op2,
+	RZ_OWN RzILOpBitVector *result, RZ_OWN RzILOpBitVector *old_sr_value) {
+	// Review any truth table for a 3-input full adder, and observe that the carry out is 1 if and only if
+	//			1- Both of the inputs are 1
+	//			2- One of the inputs is 1 while the result is 0
+	// In this context, the "inputs" are the most significant bits of the full 16-bit operands
+	RzILOpBool *op1_msb = MSB(op1);
+	RzILOpBool *op2_msb = MSB(op2);
+
+	RzILOpBool *is_carry1 = AND(op1_msb, op2_msb);
+	RzILOpBool *not_result_msb = INV(MSB(result));
+
+	RzILOpBool *is_carry2 = AND(not_result_msb, DUP(op1_msb));
+	RzILOpBool *is_carry3 = AND(DUP(op2_msb), DUP(not_result_msb));
+
+	RzILOpBool *is_carry = OR(OR(is_carry1, is_carry2), is_carry3);
+	return update_sr_c_flag(is_carry, old_sr_value);
+}
+
+RZ_OWN RzILOpBitVector *update_sr_v_flag_add(RZ_OWN RzILOpBitVector *op1, RZ_OWN RzILOpBitVector *op2,
+	RZ_OWN RzILOpBitVector *result, RZ_OWN RzILOpBitVector *old_sr_value) {
+	// Overflow happens if and only if:
+	//			Positive + Positive = Negative
+	//			Negative + Negative = Positive
+	RzILOpBool *op1_sign = MSB(op1);
+	RzILOpBool *op2_sign = MSB(op2);
+
+	// XNOR is the binary equality operator
+	RzILOpBool *op1_op2_have_same_sign = INV(XOR(op1_sign, op2_sign));
+
+	RzILOpBool *result_sign = MSB(result);
+	RzILOpBool *result_has_different_sign = XOR(result_sign, DUP(op1_sign));
+
+	RzILOpBool *is_overflow = AND(op1_op2_have_same_sign, result_has_different_sign);
+	return update_sr_v_flag(is_overflow, old_sr_value);
+}
+
+RZ_OWN RzILOpEffect *set_rcc_flags(const char *operand_name, const char *result_name, const char *old_carry_name, const char *old_sr_name) {
+	// n z as usual
+	RzILOpBitVector *nz = update_sr_nz_flags(VARL(result_name), update_sr_clear_vcnz(VARL(old_sr_name)));
+	// v especially for RCC
+	RzILOpBitVector *vnz = update_sr_v_flag_rcc(VARL(operand_name), VARL(old_carry_name), nz);
+	// and c from the discarded LSB
+	RzILOpBitVector *cvnz = update_sr_c_flag(LSB(VARL(operand_name)), vnz);
+
+	return MSP430_SETR(MSP430_SR, cvnz);
+}
+
+RZ_OWN RzILOpEffect *set_sxt_flags(const char *result_name) {
+	// n z as usual
+	RzILOpBitVector *nz = update_sr_nz_flags(VARL(result_name), update_sr_clear_vcnz(MSP430_GETR(MSP430_SR)));
+	// c as not if result is zero
+	RzILOpBitVector *cnz = update_sr_c_flag(INV(IS_ZERO(VARL(result_name))), nz);
+
+	// v as zero
+	// no need to actually do this, v is already cleared from update_sr_clear_vcnz
+
+	return MSP430_SETR(MSP430_SR, cnz);
+}
+
+RZ_OWN RzILOpEffect *set_and_flags(const char *result_name) {
+	return set_sxt_flags(result_name);
+}
+
+RZ_OWN RzILOpEffect *set_xor_flags(const char *source_name, const char *destination_name, const char *result_name) {
+	// n z as usual
+	RzILOpBitVector *nz = update_sr_nz_flags(VARL(result_name), update_sr_clear_vcnz(MSP430_GETR(MSP430_SR)));
+	// c as not if result is zero
+	RzILOpBitVector *cnz = update_sr_c_flag(INV(IS_ZERO(VARL(result_name))), nz);
+	// v as if both operands are negative
+	RzILOpBitVector *vcnz = update_sr_v_flag(AND(MSB(VARL(source_name)), MSB(VARL(destination_name))), cnz);
+
+	return MSP430_SETR(MSP430_SR, vcnz);
+}
+
+RZ_OWN RzILOpEffect *set_add_flags(const char *source_name, const char *destination_name, const char *result_name) {
+	// n z as usual
+	RzILOpBitVector *nz = update_sr_nz_flags(VARL(result_name), update_sr_clear_vcnz(MSP430_GETR(MSP430_SR)));
+	// c especially for the add
+	RzILOpBitVector *cnz = update_sr_c_flag_add(VARL(source_name), VARL(destination_name), VARL(result_name), nz);
+	// v especially for the add
+	RzILOpBitVector *vcnz = update_sr_v_flag_add(VARL(source_name), VARL(destination_name), VARL(result_name), cnz);
+
+	return MSP430_SETR(MSP430_SR, vcnz);
+}
+
+RZ_OWN RzILOpEffect *do_set_inc_flags(const char *result_name, const char *old_destination_name,
+	RZ_OWN RzILOpBitVector *zero_carry_const, RZ_OWN RzILOpBitVector *overflow_const) {
+	// n as usual
+	RzILOpBool *is_negative = MSB(VARL(result_name));
+	RzILOpBitVector *n = update_sr_n_flag(is_negative, update_sr_clear_vcnz(MSP430_GETR(MSP430_SR)));
+
+	// z c v by comparison to known constants
+	RzILOpBool *is_zero_and_carry = EQ(VARL(old_destination_name), zero_carry_const);
+	RzILOpBool *is_overflow = EQ(VARL(old_destination_name), overflow_const);
+
+	RzILOpBitVector *nzc = LOGOR(ITE(is_zero_and_carry, U16(0x0003), U16(0)), n);
+	RzILOpBitVector *vnzc = update_sr_v_flag(is_overflow, nzc);
+
+	return MSP430_SETR(MSP430_SR, vnzc);
+}
+
+RZ_OWN RzILOpEffect *set_incb_flags(const char *result_name, const char *old_destination_name) {
+	return do_set_inc_flags(result_name, old_destination_name, U8(0xFF), U8(0x7F));
+}
+
+RZ_OWN RzILOpEffect *set_inc_flags(const char *result_name, const char *old_destination_name) {
+	return do_set_inc_flags(result_name, old_destination_name, U16(0xFFFF), U16(0x7FFF));
+}
+
+RZ_OWN RzILOpEffect *do_set_dec_flags(const char *result_name, const char *old_destination_name,
+	RZ_OWN RzILOpBitVector *zero_const, RZ_OWN RzILOpBitVector *carry_const, RZ_OWN RzILOpBitVector *overflow_const) {
+	// n as usual
+	RzILOpBool *is_negative = MSB(VARL(result_name));
+	RzILOpBitVector *n = LOGOR(
+		SHIFTL0(BOOL_TO_BV(is_negative, 16), U8(2)),
+		update_sr_clear_vcnz(MSP430_GETR(MSP430_SR)));
+
+	// z c v by comparison to known constants
+	RzILOpBool *is_zero = EQ(VARL(old_destination_name), zero_const);
+	RzILOpBool *is_carry = INV(EQ(VARL(old_destination_name), carry_const));
+	RzILOpBool *is_overflow = EQ(VARL(old_destination_name), overflow_const);
+
+	RzILOpBitVector *nzc = update_sr_z_flag(is_zero, update_sr_c_flag(is_carry, n));
+	RzILOpBitVector *vnzc = update_sr_v_flag(is_overflow, nzc);
+
+	return MSP430_SETR(MSP430_SR, vnzc);
+}
+
+RZ_OWN RzILOpEffect *set_decb_flags(const char *result_name, const char *old_destination_name) {
+	return do_set_dec_flags(result_name, old_destination_name, U8(1), U8(0), U8(0x80));
+}
+
+RZ_OWN RzILOpEffect *set_dec_flags(const char *result_name, const char *old_destination_name) {
+	return do_set_dec_flags(result_name, old_destination_name, U16(1), U16(0), U16(0x8000));
+}
+
+RZ_OWN RzILOpEffect *set_tst_flags(RZ_OWN RzILOpBitVector *operand) {
+	// no need to do anything to v, it's already cleared
+	RzILOpBitVector *cv = LOGOR(update_sr_clear_vcnz(MSP430_GETR(MSP430_SR)), U16(1)); // set c flag efficiently (no branching with ite, like bool2bv does)
+
+	RzILOpBitVector *nzcv = update_sr_nz_flags(VARL("operand"), cv);
+
+	return SEQ2(SETL("operand", operand), MSP430_SETR(MSP430_SR, nzcv));
+}
+
+RZ_OWN RzILOpEffect *set_inv_flags(const char *result_name, const char *old_destination_name) {
+	RzILOpBool *is_negative = MSB(VARL(result_name));
+	RzILOpBool *is_zero = IS_ZERO(VARL(result_name));
+	RzILOpBool *is_carry = INV(IS_ZERO(VARL(result_name)));
+	RzILOpBool *is_overflow = MSB(VARL(old_destination_name));
+
+	return MSP430_SETR(MSP430_SR,
+		update_sr_n_flag(is_negative,
+			update_sr_z_flag(is_zero,
+				update_sr_c_flag(is_carry,
+					update_sr_v_flag(is_overflow, update_sr_clear_vcnz(MSP430_GETR(MSP430_SR)))))));
+}
+
+RZ_OWN RzILOpEffect *set_sub_flags(const char *source_name, const char *neginc_source_name, const char *dst_name, const char *result_name,
+	RZ_OWN RzILOpBitVector *carry_const, RZ_OWN RzILOpBitVector *overflow_const) {
+	// n z as usual
+	RzILOpBitVector *nz = update_sr_nz_flags(VARL(result_name), update_sr_clear_vcnz(MSP430_GETR(MSP430_SR)));
+	// c especially for the sub
+	RzILOpBitVector *_cnz = update_sr_c_flag_add(VARL(neginc_source_name), VARL(dst_name), VARL(result_name), nz);
+	RzILOpBitVector *cnz = update_sr_c_flag(EQ(VARL(source_name), carry_const), _cnz);
+	// v especially for the sub
+	RzILOpBitVector *_vcnz = update_sr_v_flag_add(VARL(neginc_source_name), VARL(dst_name), VARL(result_name), cnz);
+	RzILOpBitVector *vcnz = update_sr_v_flag(EQ(VARL(source_name), overflow_const), _vcnz);
+
+	return MSP430_SETR(MSP430_SR, vcnz);
+}
+
+RzILOpEffect *set_setc_flags() {
+	return MSP430_SETR(MSP430_SR, LOGOR(MSP430_GETR(MSP430_SR), U16(1)));
+}
+RzILOpEffect *set_setn_flags() {
+	return MSP430_SETR(MSP430_SR, LOGOR(MSP430_GETR(MSP430_SR), U16(1 << 2)));
+}
+
+RzILOpEffect *set_setz_flags() {
+	return MSP430_SETR(MSP430_SR, LOGOR(MSP430_GETR(MSP430_SR), U16(1 << 1)));
+}
+
+RzILOpEffect *set_clrc_flags() {
+	return MSP430_SETR(MSP430_SR, LOGAND(MSP430_GETR(MSP430_SR), U16(~1)));
+	;
+}
+
+RzILOpEffect *set_clrn_flags() {
+	return MSP430_SETR(MSP430_SR, LOGAND(MSP430_GETR(MSP430_SR), U16(~(1 << 2))));
+}
+
+RzILOpEffect *set_clrz_flags() {
+	return MSP430_SETR(MSP430_SR, LOGAND(MSP430_GETR(MSP430_SR), U16(~(1 << 1))));
+}
+
+RzILOpBool *check_if_zero_carry() {
+	return IS_ZERO(LOGAND(MSP430_GETR(MSP430_SP), U16(1)));
+}
+
+#include <rz_il/rz_il_opbuilder_end.h>

--- a/librz/arch/isa/msp430/msp430_il_getset.h
+++ b/librz/arch/isa/msp430/msp430_il_getset.h
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2024 Mostafa Mahmoud <ubermenchun@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <msp430/msp430_il.h>
+#include <msp430/msp430_register_names.h>
+
+#include <rz_il/rz_il_opbuilder_begin.h>
+
+#define MSP430_GETR(r)    VARG(msp430_register_names[r])
+#define MSP430_SETR(r, v) SETG(msp430_register_names[r], v)
+
+#define WORD_SIZED_READ  1
+#define WORD_SIZED_WRITE 2
+
+static inline ut8 word_sizedness(const Msp430Instruction *op);
+
+static inline RZ_OWN RzILOpBitVector *calculate_mem_address(Msp430AddressingMode mode, ut32 operand, ut64 current_addr) {
+	switch (mode) {
+	case MSP430_INDX: return ADD(U16(operand >> 8), MSP430_GETR(operand & 0x000000FF));
+	case MSP430_SYM: return ADD(U16(operand), U16(current_addr));
+	case MSP430_ABS: return U16(operand);
+	case MSP430_IND_REG:
+	case MSP430_IND_AUTOINC:
+		return MSP430_GETR(operand);
+
+	default: return NULL;
+	}
+}
+
+static inline RZ_OWN RzILOpBitVector *decode_operand(const Msp430Instruction *op, Msp430AddressingMode mode, ut32 operand, ut64 current_addr) {
+	switch (mode) {
+	case MSP430_REG: {
+		RzILOpBitVector *reg = MSP430_GETR(operand);
+		if (word_sizedness(op) & WORD_SIZED_READ) {
+			return reg;
+		}
+		return CAST(8, IL_FALSE, reg);
+	}
+
+	case MSP430_IMM: {
+		if (word_sizedness(op) & WORD_SIZED_READ) {
+			return U16(operand);
+		}
+		return U8(operand);
+	}
+
+	default: {
+		RzILOpBitVector *address = calculate_mem_address(mode, operand, current_addr);
+		if (address != NULL) {
+			if (word_sizedness(op) & WORD_SIZED_READ) {
+				return LOADW(16, address);
+			}
+			return LOADW(8, address);
+		}
+
+		rz_warn_if_reached();
+		return U8(0);
+	}
+	}
+}
+
+static inline RZ_OWN RzILOpBitVector *get_source(const Msp430Instruction *op, ut64 current_addr) {
+	return decode_operand(op, op->src_mode, op->src, current_addr);
+}
+
+static inline RZ_OWN RzILOpBitVector *get_destination(const Msp430Instruction *op, ut64 current_addr) {
+	return decode_operand(op, op->dst_mode, op->dst, current_addr);
+}
+
+typedef struct {
+	RzILOpBitVector *first;
+	RzILOpBitVector *second;
+} BVPair;
+
+// special getter for swpb
+// returns the destination as a "destructured" pair of bytes
+static inline RZ_OWN BVPair get_destination_destructured(const Msp430Instruction *op, ut64 current_addr) {
+	switch (op->dst_mode) {
+	case MSP430_REG: {
+		RzILOpBitVector *reg = MSP430_GETR(op->dst);
+		BVPair res;
+		res.first = CAST(8, IL_FALSE, reg);
+		res.second = CAST(8, IL_FALSE, SHIFTR0(DUP(reg), U8(8)));
+		return res;
+	}
+	default: {
+		RzILOpBitVector *address = calculate_mem_address(op->dst_mode, op->dst, current_addr);
+		if (address != NULL) {
+			BVPair res;
+			res.first = LOAD(address);
+			res.second = LOAD(ADD(address, U16(1)));
+			return res;
+		}
+
+		rz_warn_if_reached();
+		BVPair dummy = { .first = U8(0), .second = U8(0) };
+		return dummy;
+	}
+	}
+}
+
+static inline RZ_OWN RzILOpEffect *set_destination(const Msp430Instruction *op, RzILOpBitVector *new_value, ut64 current_addr) {
+	switch (op->dst_mode) {
+	case MSP430_REG: {
+		if (word_sizedness(op) & WORD_SIZED_WRITE) {
+			return MSP430_SETR(op->dst, new_value);
+		}
+		// the general idea is: First we zero the lower byte through ANDing with 0xFF00
+		//                      Then we assign the lower byte to the (byte-length) result through ORing with 0x00<result>
+		// the overall effect is that only the lower byte is assigned, which is what byte-sized operations do
+		return MSP430_SETR(op->dst, UNSIGNED(16, new_value));
+	}
+
+	default: {
+		RzILOpBitVector *address = calculate_mem_address(op->dst_mode, op->dst, current_addr);
+		if (address != NULL) {
+			if (word_sizedness(op) & WORD_SIZED_WRITE) {
+				return STOREW(address, new_value);
+			}
+			return STORE(address, new_value);
+		}
+
+		rz_warn_if_reached();
+		return NOP();
+	}
+	}
+}
+
+static inline ut8 word_sizedness(const Msp430Instruction *op) {
+	// the sign extend is special: it always reads a byte but writes a word
+	// this is the only reason there are 2 flags for the sizedness of a read and the sizedness of a write
+	if (op->opcode == MSP430_SXT) {
+		return WORD_SIZED_WRITE;
+	}
+
+	// otherwise, all instructions read and write with the same sizedness
+	// 0 means the read and write are both byte-sized
+	// 3 = 1|2 means the read and the write are both word-sized
+	return (op->is_byte) ? 0 : (WORD_SIZED_READ | WORD_SIZED_WRITE);
+}
+
+#include <rz_il/rz_il_opbuilder_end.h>

--- a/librz/arch/isa/msp430/msp430_il_jmp_utils.h
+++ b/librz/arch/isa/msp430/msp430_il_jmp_utils.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2024 Mostafa Mahmoud <ubermenchun@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_analysis.h>
+#include <msp430/msp430_disas.h>
+
+#include <rz_il/rz_il_opbuilder_begin.h>
+
+RZ_OWN RzILOpBitVector *abs_addr_from_rel_addr(RzILOpBitVector *curr_pc, st16 rel_addr) {
+	return ADD(curr_pc, S16(rel_addr));
+}
+
+RzILOpBool *mk_jne_cond(RzILOpBitVector *curr_sr) {
+	// test if the Z bit in the SR register is 0
+	return IS_ZERO(LOGAND(curr_sr, U16(2)));
+}
+
+RzILOpBool *mk_jnc_cond(RzILOpBitVector *curr_sr) {
+	// test if the C bit in the SR register is 0
+	return IS_ZERO(LOGAND(curr_sr, U16(1)));
+}
+
+RzILOpBool *mk_jn_cond(RzILOpBitVector *curr_sr) {
+	// test if the N flag in the SR register is 1
+	return EQ(LOGAND(curr_sr, U16(4)), U16(4));
+}
+
+RzILOpBool *mk_jge_cond(RzILOpBitVector *curr_sr) {
+	int mask = 4 | (1 << 8);
+	RzILOpBitVector *nv = LOGAND(curr_sr, U16(mask));
+	// test if both the N and V flags are set or reset
+	return OR(IS_ZERO(nv), EQ(DUP(nv), U16(mask)));
+}
+
+#include <rz_il/rz_il_opbuilder_end.h>
+
+typedef RzILOpBool *(*JmpConditionConstructor)(RzILOpBitVector *curr_sr);
+
+JmpConditionConstructor jmp_condition_constructors[] = {
+	[MSP430_JNE] = mk_jne_cond,
+	[MSP430_JEQ] = mk_jne_cond, // invert by switching the THEN and ELSE
+	[MSP430_JNC] = mk_jnc_cond,
+	[MSP430_JC] = mk_jnc_cond, // invert by switching the THEN and ELSE
+	[MSP430_JN] = mk_jn_cond,
+	[MSP430_JGE] = mk_jge_cond,
+	[MSP430_JL] = mk_jge_cond // invert by switching the THEN and ELSE
+};
+
+enum jmp_trigger {
+	JMP_THEN,
+	JMP_ELSE
+};
+
+enum jmp_trigger jmp_condition_triggers[] = {
+	[MSP430_JNE] = JMP_THEN,
+	[MSP430_JEQ] = JMP_ELSE,
+	[MSP430_JNC] = JMP_THEN,
+	[MSP430_JC] = JMP_ELSE,
+	[MSP430_JN] = JMP_THEN,
+	[MSP430_JGE] = JMP_THEN,
+	[MSP430_JL] = JMP_ELSE
+};

--- a/librz/arch/isa/msp430/msp430_register_names.h
+++ b/librz/arch/isa/msp430/msp430_register_names.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2024 Mostafa Mahmoud <ubermenchun@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef MSP430_REGISTER_NAMES_H
+#define MSP430_REGISTER_NAMES_H
+
+static const char *msp430_register_names[] = {
+	"pc",
+	"sp",
+	"sr",
+	"cg",
+	"r4",
+	"r5",
+	"r6",
+	"r7",
+	"r8",
+	"r9",
+	"r10",
+	"r11",
+	"r12",
+	"r13",
+	"r14",
+	"r15",
+	NULL
+};
+
+#endif

--- a/librz/arch/meson.build
+++ b/librz/arch/meson.build
@@ -219,6 +219,7 @@ arch_isa_sources = [
   'isa/mcore/mcore.c',
   'isa/mips/mips_assembler.c',
   'isa/msp430/msp430_disas.c',
+  'isa/msp430/msp430_il.c',
   'isa/or1k/or1k_disas.c',
   'isa/pic/pic14.c',
   'isa/pic/pic16.c',

--- a/librz/arch/p/analysis/analysis_msp430.c
+++ b/librz/arch/p/analysis/analysis_msp430.c
@@ -9,13 +9,13 @@
 #include <rz_util.h>
 
 #include <msp430/msp430_disas.h>
+#include <msp430/msp430_il.h>
 
 static int msp430_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask) {
 	int ret;
 	struct msp430_cmd cmd;
 
 	memset(&cmd, 0, sizeof(cmd));
-	// op->id = ???;
 	op->size = -1;
 	op->nopcode = 1;
 	op->type = RZ_ANALYSIS_OP_TYPE_UNK;
@@ -87,7 +87,36 @@ static int msp430_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut
 		op->type = RZ_ANALYSIS_OP_TYPE_UNK;
 	}
 
+	if (mask & RZ_ANALYSIS_OP_MASK_IL) {
+		RzILOpEffect *il_op = rz_msp430_lift_instr(analysis, &cmd, addr, op->size);
+		op->il_op = il_op;
+	}
 	return ret;
+}
+
+static char *get_reg_profile(RzAnalysis *analysis) {
+	const char *prof =
+		"=PC pc\n"
+		"=SP sp\n"
+		"=A0 r4\n"
+		"=A1 r5\n"
+		"gpr pc  .16  0     0\n"
+		"gpr sp  .16  2     0\n"
+		"gpr sr  .16  4     0\n"
+		"gpr cg  .16  6     0\n"
+		"gpr r4  .16  8     0\n"
+		"gpr r5  .16  10    0\n"
+		"gpr r6  .16  12    0\n"
+		"gpr r7  .16  14    0\n"
+		"gpr r8  .16  16    0\n"
+		"gpr r9  .16  18    0\n"
+		"gpr r10 .16  20    0\n"
+		"gpr r11 .16  22    0\n"
+		"gpr r12 .16  24    0\n"
+		"gpr r13 .16  26    0\n"
+		"gpr r14 .16  28    0\n"
+		"gpr r15 .16  30    0\n";
+	return strdup(prof);
 }
 
 RzAnalysisPlugin rz_analysis_plugin_msp430 = {
@@ -97,4 +126,6 @@ RzAnalysisPlugin rz_analysis_plugin_msp430 = {
 	.arch = "msp430",
 	.bits = 16,
 	.op = msp430_op,
+	.il_config = rz_msp430_il_config,
+	.get_reg_profile = get_reg_profile
 };

--- a/test/db/asm/msp430
+++ b/test/db/asm/msp430
@@ -1,54 +1,64 @@
-d "adc r11" 0b63
-d "adc.b r11" 4b63
-d "bic #2, r10" 2ac3
-d "bic #4, r10" 2ac2
-d "bic.b #2, &0x0026" e2c32600
-d "bic.b #4, &0x002e" e2c22e00
-d "bis.b #2, &0x0021" e2d32100
-d "br #0x0021" 30402100
-d "br &0x0003" 10420300
-d "br sp" 0041
-d "br r10" 004a
-d "call #0xc096" b01296c0
-d "clr 0x0033" 80433300
-d "clr 0xfffa(r4)" 8443faff
-d "clrn" 22c2
-d "clrz" 22c3
-d "cmp.b #0x003b, 0x0(r11)" fb903b000000
-d "dadc r11" 0ba3
-d "dadc.b r11" 4ba3
-d "dec r11" 1b83
-d "dec.b r11" 5b83
-d "inc r11" 1b53
-d "inv 0x0003" b0e30300
-d "inv 0x3(r5)" b5e30300
-d "inv r10" 3ae3
-d "jeq $+0x0014" 0924
-d "jmp $+0x0010" 073c
-d "mov #0x0003, 0x5(r9)" b94003000500
-d "mov #0x000a, 0x002a" b0400a002a00
-d "mov #0x0021, 0x6(r11)" bb4021000600
-d "mov #1, 0x002c" 90432c00
-d "mov #8, 0x002c" b0422c00
-d "mov #8, 0x002e" b0422e00
-d "mov &0x0033, &0x002e" 924233002e00
-d "mov &0x0033, 0x002a" 904233002a00
-d "mov 0x3(r6), &0x002e" 924603002e00
-d "mov 0x5(r10), 0x6(r11)" 9b4a05000600
-d "mov 0x6(r11), &0x0033" 924b06003300
-d "mov.b &0x0021, r15" 5f422100
-d "mov.b r15, &0x0021" c24f2100
-d "nop" 0343
-d "pop r11" 3b41
-d "pop r4" 3441
-d "push #1" 1312
-d "ret" 3041
-d "sbc r11" 0b73
-d "sbc.b r11" 4b73
-d "setc" 12d3
-d "setz" 22d3
-d "tst &0x0003" 82930300
-d "tst 0x3(r5)" 85930300
-d "tst r10" 0a93
-d "xor.b #0x0020, r15" 7fe02000
-d "xor.b #8, r15" 7fe2
+d "adc r11" 0b63 0x0 (branch (is_zero (& (var sp) (bv 16 0x1))) nop (seq (set old_destination (var r11)) (set result (+ (bv 16 0x1) (var old_destination))) (set r11 (var result)) (set sr (| (| (ite (== (var old_destination) (bv 16 0xffff)) (bv 16 0x3) (bv 16 0x0)) (| (& (var sr) (bv 16 0xfef8)) (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false))) (<< (ite (== (var old_destination) (bv 16 0x7fff)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false)))))
+d "adc.b r11" 4b63 0x0 (branch (is_zero (& (var sp) (bv 16 0x1))) nop (seq (set old_destination (cast 8 false (var r11))) (set result (+ (bv 8 0x1) (var old_destination))) (set r11 (cast 16 false (var result))) (set sr (| (| (ite (== (var old_destination) (bv 8 0xff)) (bv 16 0x3) (bv 16 0x0)) (| (& (var sr) (bv 16 0xfef8)) (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false))) (<< (ite (== (var old_destination) (bv 8 0x7f)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false)))))
+d "add #0x0010, r9" 39501000 0x0 (seq (set old_destination (var r9)) (set source (bv 16 0x10)) (set result (+ (var source) (var old_destination))) (set r9 (var result)) (set sr (| (| (| (| (& (var sr) (bv 16 0xfef8)) (<< (ite (is_zero (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false)) (ite (|| (|| (&& (msb (var source)) (msb (var old_destination))) (&& (! (msb (var result))) (msb (var source)))) (&& (msb (var old_destination)) (! (msb (var result))))) (bv 16 0x1) (bv 16 0x0))) (<< (ite (&& (! (^^ (msb (var source)) (msb (var old_destination)))) (^^ (msb (var result)) (msb (var source)))) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false))))
+d "and.b #0xf0f0, r12" 7cf0f0f0 0x0 (seq (set old_destination (cast 8 false (var r12))) (set source (bv 8 0xf0)) (set result (& (var source) (var old_destination))) (set r12 (cast 16 false (var result))) (set sr (| (| (| (& (var sr) (bv 16 0xfef8)) (<< (ite (is_zero (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false)) (ite (! (is_zero (var result))) (bv 16 0x1) (bv 16 0x0)))))
+d "bic #2, r10" 2ac3 0x0 (set r10 (& (~ (bv 16 0x2)) (var r10)))
+d "bic #4, r10" 2ac2 0x0 (set r10 (& (~ (bv 16 0x4)) (var r10)))
+d "bic.b #2, &0x0026" e2c32600 0x0 (store 0 (bv 16 0x26) (& (~ (bv 8 0x2)) (loadw 0 8 (bv 16 0x26))))
+d "bic.b #4, &0x002e" e2c22e00 0x0 (store 0 (bv 16 0x2e) (& (~ (bv 8 0x4)) (loadw 0 8 (bv 16 0x2e))))
+d "bis.b #2, &0x0021" e2d32100 0x0 (store 0 (bv 16 0x21) (| (bv 8 0x2) (loadw 0 8 (bv 16 0x21))))
+d "bit #0x0015, &0x4242" b2b015004242 0x0 (seq (set result (& (bv 16 0x15) (loadw 0 16 (bv 16 0x4242)))) (set sr (| (| (| (& (var sr) (bv 16 0xfef8)) (<< (ite (is_zero (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false)) (ite (! (is_zero (var result))) (bv 16 0x1) (bv 16 0x0)))))
+d "br #0x0021" 30402100 0x0 (jmp (bv 16 0x21))
+d "br &0x0003" 10420300 0x0 (jmp (loadw 0 16 (bv 16 0x3)))
+d "br sp" 0041 0x0 (jmp (var sp))
+d "br r10" 004a 0x0 (jmp (var r10))
+d "call #0xc096" b01296c0 0x0 (seq (set sp (- (var sp) (bv 16 0x2))) (storew 0 (var sp) (+ (bv 16 0x0) (bv 16 0x4))) (jmp (bv 16 0xc096)))
+d "clr 0x0033" 80433300 0x0 (storew 0 (+ (bv 16 0x33) (bv 16 0x0)) (bv 16 0x0))
+d "clr 0xfffa(r4)" 8443faff 0x0 (storew 0 (+ (bv 16 0xfffa) (var r4)) (bv 16 0x0))
+d "clrn" 22c2 0x0 (set sr (& (var sr) (bv 16 0xfffb)))
+d "clrz" 22c3 0x0 (set sr (& (var sr) (bv 16 0xfffd)))
+d "cmp.b #0x003b, 0x0(r11)" fb903b000000 0x0 (seq (set op0 (bv 8 0x3b)) (set op1 (+ (bv 8 0x1) (~ (var op0)))) (set op2 (loadw 0 8 (+ (bv 16 0x0) (var r11)))) (set result (+ (var op1) (var op2))) (set sr (| (| (| (| (| (| (& (var sr) (bv 16 0xfef8)) (<< (ite (is_zero (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false)) (ite (|| (|| (&& (msb (var op1)) (msb (var op2))) (&& (! (msb (var result))) (msb (var op1)))) (&& (msb (var op2)) (! (msb (var result))))) (bv 16 0x1) (bv 16 0x0))) (ite (== (var op0) (bv 8 0x0)) (bv 16 0x1) (bv 16 0x0))) (<< (ite (&& (! (^^ (msb (var op1)) (msb (var op2)))) (^^ (msb (var result)) (msb (var op1)))) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false)) (<< (ite (== (var op0) (bv 8 0x80)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false))))
+d "dadc r11" 0ba3 0x0 (branch (is_zero (& (var sp) (bv 16 0x1))) nop (seq (set operand (var r11)) (branch (== (& (var operand) (bv 16 0x9)) (bv 16 0x9)) (branch (== (& (var operand) (bv 16 0x90)) (bv 16 0x90)) (branch (== (& (var operand) (bv 16 0x900)) (bv 16 0x900)) (branch (== (& (var operand) (bv 16 0x9000)) (bv 16 0x9000)) (set result (bv 16 0x0)) (set result (& (+ (var operand) (bv 16 0x1000)) (bv 16 0xf000)))) (set result (& (+ (var operand) (bv 16 0x100)) (bv 16 0xff00)))) (set result (& (+ (var operand) (bv 16 0x10)) (bv 16 0xfff0)))) (set result (+ (var operand) (bv 16 0x1))))))
+d "dadc.b r11" 4ba3 0x0 (branch (is_zero (& (var sp) (bv 16 0x1))) nop (seq (set operand (cast 8 false (var r11))) (branch (== (& (var operand) (bv 8 0x9)) (bv 8 0x9)) (branch (== (& (var operand) (bv 8 0x90)) (bv 8 0x90)) (set result (bv 8 0x0)) (set result (& (+ (var operand) (bv 8 0x10)) (bv 8 0xf0)))) (set result (+ (var operand) (bv 8 0x1))))))
+d "dec r11" 1b83 0x0 (seq (set old_destination (var r11)) (set result (- (bv 16 0x1) (var old_destination))) (set r11 (var result)) (set sr (| (| (| (| (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false) (& (var sr) (bv 16 0xfef8))) (ite (! (== (var old_destination) (bv 16 0x0))) (bv 16 0x1) (bv 16 0x0))) (<< (ite (== (var old_destination) (bv 16 0x1)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (== (var old_destination) (bv 16 0x8000)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false))))
+d "dec.b r11" 5b83 0x0 (seq (set old_destination (cast 8 false (var r11))) (set result (- (bv 8 0x1) (var old_destination))) (set r11 (cast 16 false (var result))) (set sr (| (| (| (| (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false) (& (var sr) (bv 16 0xfef8))) (ite (! (== (var old_destination) (bv 8 0x0))) (bv 16 0x1) (bv 16 0x0))) (<< (ite (== (var old_destination) (bv 8 0x1)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (== (var old_destination) (bv 8 0x80)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false))))
+d "inc r11" 1b53 0x0 (seq (set old_destination (var r11)) (set result (+ (bv 16 0x1) (var old_destination))) (set r11 (var result)) (set sr (| (| (ite (== (var old_destination) (bv 16 0xffff)) (bv 16 0x3) (bv 16 0x0)) (| (& (var sr) (bv 16 0xfef8)) (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false))) (<< (ite (== (var old_destination) (bv 16 0x7fff)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false))))
+d "inv 0x0003" b0e30300 0x73 (seq (set old_destination (loadw 0 16 (+ (bv 16 0x3) (bv 16 0x73)))) (set result (~ (var old_destination))) (storew 0 (+ (bv 16 0x3) (bv 16 0x73)) (var result)) (set sr (| (| (| (| (& (var sr) (bv 16 0xfef8)) (<< (ite (msb (var old_destination)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false)) (ite (! (is_zero (var result))) (bv 16 0x1) (bv 16 0x0))) (<< (ite (is_zero (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false))))
+d "inv 0x3(r5)" b5e30300 0x0 (seq (set old_destination (loadw 0 16 (+ (bv 16 0x3) (var r5)))) (set result (~ (var old_destination))) (storew 0 (+ (bv 16 0x3) (var r5)) (var result)) (set sr (| (| (| (| (& (var sr) (bv 16 0xfef8)) (<< (ite (msb (var old_destination)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false)) (ite (! (is_zero (var result))) (bv 16 0x1) (bv 16 0x0))) (<< (ite (is_zero (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false))))
+d "inv r10" 3ae3 0x0 (seq (set old_destination (var r10)) (set result (~ (var old_destination))) (set r10 (var result)) (set sr (| (| (| (| (& (var sr) (bv 16 0xfef8)) (<< (ite (msb (var old_destination)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false)) (ite (! (is_zero (var result))) (bv 16 0x1) (bv 16 0x0))) (<< (ite (is_zero (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false))))
+d "jeq $+0x0014" 0924 0x0 (branch (is_zero (& (var sr) (bv 16 0x2))) nop (jmp (+ (bv 16 0x0) (bv 16 0x14))))
+d "jeq $+0x0400" ff25 0x0 (branch (is_zero (& (var sr) (bv 16 0x2))) nop (jmp (+ (bv 16 0x0) (bv 16 0x400))))
+d "jeq $-0x01fe" 0027 0x0 (branch (is_zero (& (var sr) (bv 16 0x2))) nop (jmp (+ (bv 16 0x0) (bv 16 0xfe02))))
+d "jmp $+0x0010" 073c 0x0 (jmp (+ (bv 16 0x0) (bv 16 0x10)))
+d "mov #0x0003, 0x5(r9)" b94003000500 0x0 (storew 0 (+ (bv 16 0x5) (var r9)) (bv 16 0x3))
+d "mov #0x000a, 0x002a" b0400a002a00 0x0 (storew 0 (+ (bv 16 0x2a) (bv 16 0x0)) (bv 16 0xa))
+d "mov #0x0021, 0x6(r11)" bb4021000600 0x0 (storew 0 (+ (bv 16 0x6) (var r11)) (bv 16 0x21))
+d "mov #1, 0x002c" 90432c00 0x0 (storew 0 (+ (bv 16 0x2c) (bv 16 0x0)) (bv 16 0x1))
+d "mov #8, 0x002c" b0422c00 0x0 (storew 0 (+ (bv 16 0x2c) (bv 16 0x0)) (bv 16 0x8))
+d "mov #8, 0x002e" b0422e00 0x0 (storew 0 (+ (bv 16 0x2e) (bv 16 0x0)) (bv 16 0x8))
+d "mov &0x0033, &0x002e" 924233002e00 0x0 (storew 0 (bv 16 0x2e) (loadw 0 16 (bv 16 0x33)))
+d "mov &0x0033, 0x002a" 904233002a00 0x42 (storew 0 (+ (bv 16 0x2a) (bv 16 0x42)) (loadw 0 16 (bv 16 0x33)))
+d "mov 0x3(r6), &0x002e" 924603002e00 0x0 (storew 0 (bv 16 0x2e) (loadw 0 16 (+ (bv 16 0x3) (var r6))))
+d "mov 0x5(r10), 0x6(r11)" 9b4a05000600 0x0 (storew 0 (+ (bv 16 0x6) (var r11)) (loadw 0 16 (+ (bv 16 0x5) (var r10))))
+d "mov 0x6(r11), &0x0033" 924b06003300 0x0 (storew 0 (bv 16 0x33) (loadw 0 16 (+ (bv 16 0x6) (var r11))))
+d "mov.b &0x0021, r15" 5f422100 0x0 (set r15 (cast 16 false (loadw 0 8 (bv 16 0x21))))
+d "mov.b r15, &0x0021" c24f2100 0x0 (store 0 (bv 16 0x21) (cast 8 false (var r15)))
+d "mov #0x0042, r6" 36404200 0x0 (set r6 (bv 16 0x42))
+d "mov r6, r10" 0a46 0x0 (set r10 (var r6))
+d "nop" 0343 0x0 nop
+d "pop r11" 3b41 0x0 (seq (set r11 (loadw 0 16 (var sp))) (set sp (+ (var sp) (bv 16 0x2))))
+d "pop r4" 3441 0x0 (seq (set r4 (loadw 0 16 (var sp))) (set sp (+ (var sp) (bv 16 0x2))))
+d "push #1" 1312 0x0 (seq (set sp (- (var sp) (bv 16 0x2))) (storew 0 (var sp) (bv 16 0x1)))
+d "ret" 3041 0x0 (seq (set return_address (loadw 0 16 (var sp))) (set sp (+ (var sp) (bv 16 0x2))) (jmp (var return_address)))
+d "rrc r4" 0410 0x0 (seq (set old_sr (var sr)) (set old_carry (lsb (var old_sr))) (set operand (var r4)) (set result (>> (var operand) (bv 8 0x1) (var old_carry))) (set r4 (var result)) (set sr (| (| (| (| (& (var old_sr) (bv 16 0xfef8)) (<< (ite (is_zero (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false)) (<< (ite (&& (! (msb (var operand))) (var old_carry)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false)) (ite (lsb (var operand)) (bv 16 0x1) (bv 16 0x0)))))
+d "sbc r11" 0b73 0x0 (branch (is_zero (& (var sp) (bv 16 0x1))) (seq (set old_destination (var r11)) (set result (- (bv 16 0x1) (var old_destination))) (set r11 (var result)) (set sr (| (| (| (| (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false) (& (var sr) (bv 16 0xfef8))) (ite (! (== (var old_destination) (bv 16 0x0))) (bv 16 0x1) (bv 16 0x0))) (<< (ite (== (var old_destination) (bv 16 0x1)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (== (var old_destination) (bv 16 0x8000)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false)))) nop)
+d "sbc.b r11" 4b73 0x0 (branch (is_zero (& (var sp) (bv 16 0x1))) (seq (set old_destination (cast 8 false (var r11))) (set result (- (bv 8 0x1) (var old_destination))) (set r11 (cast 16 false (var result))) (set sr (| (| (| (| (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false) (& (var sr) (bv 16 0xfef8))) (ite (! (== (var old_destination) (bv 8 0x0))) (bv 16 0x1) (bv 16 0x0))) (<< (ite (== (var old_destination) (bv 8 0x1)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (== (var old_destination) (bv 8 0x80)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false)))) nop)
+d "setc" 12d3 0x0 (set sr (| (var sr) (bv 16 0x1)))
+d "setz" 22d3 0x0 (set sr (| (var sr) (bv 16 0x2)))
+d "swpb r15" 8f10 0x0 (set r15 (append (cast 8 false (var r15)) (cast 8 false (>> (var r15) (bv 8 0x8) false))))
+d "sxt r5" 8511 0x0 (seq (set result (cast 16 (msb (cast 8 false (var r5))) (cast 8 false (var r5)))) (set r5 (var result)) (set sr (| (| (| (& (var sr) (bv 16 0xfef8)) (<< (ite (is_zero (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false)) (ite (! (is_zero (var result))) (bv 16 0x1) (bv 16 0x0)))))
+d "tst &0x0003" 82930300 0x0 (seq (set operand (loadw 0 16 (bv 16 0x3))) (set sr (| (| (| (& (var sr) (bv 16 0xfef8)) (bv 16 0x1)) (<< (ite (is_zero (var operand)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (msb (var operand)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false))))
+d "tst 0x3(r5)" 85930300 0x0 (seq (set operand (loadw 0 16 (+ (bv 16 0x3) (var r5)))) (set sr (| (| (| (& (var sr) (bv 16 0xfef8)) (bv 16 0x1)) (<< (ite (is_zero (var operand)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (msb (var operand)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false))))
+d "tst r10" 0a93 0x0 (seq (set operand (var r10)) (set sr (| (| (| (& (var sr) (bv 16 0xfef8)) (bv 16 0x1)) (<< (ite (is_zero (var operand)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (msb (var operand)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false))))
+d "xor.b #0x0020, r15" 7fe02000 0x0 (seq (set old_destination (cast 8 false (var r15))) (set source (bv 8 0x20)) (set result (^ (var source) (var old_destination))) (set r15 (cast 16 false (var result))) (set sr (| (| (| (| (& (var sr) (bv 16 0xfef8)) (<< (ite (is_zero (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false)) (ite (! (is_zero (var result))) (bv 16 0x1) (bv 16 0x0))) (<< (ite (&& (msb (var source)) (msb (var old_destination))) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false))))
+d "xor.b #8, r15" 7fe2 0x0 (seq (set old_destination (cast 8 false (var r15))) (set source (bv 8 0x8)) (set result (^ (var source) (var old_destination))) (set r15 (cast 16 false (var result))) (set sr (| (| (| (| (& (var sr) (bv 16 0xfef8)) (<< (ite (is_zero (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x1) false)) (<< (ite (msb (var result)) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x2) false)) (ite (! (is_zero (var result))) (bv 16 0x1) (bv 16 0x0))) (<< (ite (&& (msb (var source)) (msb (var old_destination))) (bv 16 0x1) (bv 16 0x0)) (bv 8 0x8) false))))

--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -409,7 +409,7 @@ _dA__ 32         malbolge    LGPL3   Malbolge Ternary VM (by condret)
 _dA__ 32         mcore       LGPL3   Motorola MCORE disassembler
 _d___ 16         mcs96       LGPL3   condrets car
 adAe_ 16 32 64   mips        BSD     Capstone MIPS disassembler
-_dA__ 16         msp430      LGPL3   msp430 disassembly plugin
+_dA_I 16         msp430      LGPL3   msp430 disassembly plugin
 adA__ 16 32 64   null        MIT     no disassemble (by pancake) v1.0.0
 _dA__ 32         or1k        LGPL3   OpenRISC 1000
 _dAeI 16 32      pic         LGPL3   PIC disassembler

--- a/test/db/rzil/msp430
+++ b/test/db/rzil/msp430
@@ -1,0 +1,21 @@
+NAME=Testing the decryption in emulateme
+FILE=bins/msp430/emulateme.msp430
+TIMEOUT=10
+CMDS=<<EOF
+aaaa
+e io.cache=1
+s main
+aezi
+aezv r12 0x2
+aezv r13 0x512
+aezv sp 0x600
+aezsu 0x8104
+ps @ obj.seckrit
+EOF
+EXPECT=<<EOF
+r12 = 0x2
+r13 = 0x512
+sp = 0x600
+Hello from RzIL!
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This PR is the first step towards lifting of the MSP430 instruction set to the RzIL representation. MSP430 is a quite simple architecture with comprehensive references here (http://elec327.github.io/assets/documents/slau144j_userguide.pdf), here (https://www.ti.com/sc/docs/products/micro/msp430/userguid/ag_b.pdf) and (https://www.ti.com/sc/docs/products/micro/msp430/userguid/ag_04.pdf). 

In this PR, only lifting of the following 3 single-operand instruction is implemented. This is deliberate to keep the diff small. The rest of the lifting could be either new commits on this same branch and PR or future PRs.

Instructions lifted:
 
- RRC (Rotate Right through Carry): takes a single operand which is also the destination, shifts it right by 1 position. The MSB becomes the carry flag, and the carry flag becomes the discarded LSB (from before the shift). Other flags are updated as specified in the references. Instruction has word-sized and byte-sized variants.

- SWPB (Swap Bytes): takes a single operand which is also the destination, and exchanges the 2 bytes in it. Doesn't update the flags or any other CPU state. Always a word-sized operation.

- SXT (Sign eXTension): takes a single operand which is also the destination, and replicates the MSB of the lower byte of the operand to the entire upper byte (e.g. if the lower byte is less than 128, the upper byte is 255, else the upper byte is 0). Always a word-sized operation that reads the lower byte and writes the upper byte of the operand.

Each instruction in the MSP430 has seven addressing modes, only one of them is implemented in this PR, namely the Register Addressing Mode, where the operand(s) are a register index. Other indexing modes including memory access and immediates should be straightforward to add later. 

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
