### PR TITLE
debug: i386 register profile lacks `gs_base`

### DIFF
--- a/librz/debug/p/native/linux/linux_debug.c
+++ b/librz/debug/p/native/linux/linux_debug.c
@@ -890,7 +890,7 @@ RZ_API ut64 get_linux_tls_val(RZ_NONNULL RzDebug *dbg, int tid) {
 		rz_debug_reg_sync(dbg, RZ_REG_TYPE_GPR, false);
 	}
 
-#if (__x86_64__ || __i386__)
+#if __x86_64__
 	RzRegItem *ri = rz_reg_get(dbg->reg, "fs", RZ_REG_TYPE_ANY);
 	RZ_DEBUG_REG_T regs;
 	// Fetch gs_base from a ptrace call


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fix the following error while building Docker:
```
#35 [linux/386 stage-0  8/15] RUN meson --prefix=/usr -Dinstall_sigdb=true /tmp/build && 	meson compile -C /tmp/build && 	meson install --destdir /tmp/***-install -C /tmp/build
#35 396.3 [1587/1998] Compiling C object librz/debug/librz_debug.so.0.8.0.p/snap.c.o
#35 396.5 [1588/1998] Compiling C object librz/debug/librz_debug.so.0.8.0.p/serialize_debug.c.o
#35 397.1 [1589/1998] Compiling C object librz/debug/librz_debug.so.0.8.0.p/p_bfvm.c.o
#35 397.1 [1590/1998] Compiling C object librz/debug/librz_debug.so.0.8.0.p/p_common_windows.c.o
#35 397.2 [1591/1998] Compiling C object librz/debug/librz_debug.so.0.8.0.p/trace.c.o
#35 397.4 [1592/1998] Compiling C object librz/debug/librz_debug.so.0.8.0.p/p_common_winkd.c.o
#35 397.5 [1593/1998] Compiling C object librz/sign/librz_sign.so.0.8.0.p/flirt.c.o
#35 398.6 [1594/1998] Compiling C object librz/debug/librz_debug.so.0.8.0.p/p_debug_io.c.o
#35 398.7 [1595/1998] Compiling C object librz/debug/librz_debug.so.0.8.0.p/p_debug_bochs.c.o
#35 398.9 [1596/1998] Compiling C object librz/debug/librz_debug.so.0.8.0.p/p_debug_bf.c.o
#35 399.2 [1597/1998] Compiling C object librz/debug/librz_debug.so.0.8.0.p/p_debug_gdb.c.o
#35 399.4 [1598/1998] Compiling C object librz/debug/librz_debug.so.0.8.0.p/p_debug_null.c.o
#35 399.5 [1599/1998] Compiling C object librz/arch/librz_arch.so.0.8.0.p/isa_hexagon_il_ops_hexagon_il_M2_ops.c.o
#35 399.6 [1600/1998] Compiling C object librz/debug/librz_debug.so.0.8.0.p/p_debug_rap.c.o
#35 400.3 [1601/1998] Compiling C object librz/debug/librz_debug.so.0.8.0.p/p_native_linux_linux_debug.c.o
#35 400.3 FAILED: librz/debug/librz_debug.so.0.8.0.p/p_native_linux_linux_debug.c.o 
#35 400.3 cc -Ilibrz/debug/librz_debug.so.0.8.0.p -I. -I../*** -Ilibrz -I../***/librz -Ilibrz/include -I../***/librz/include -I../***/librz/bin/format/elf -I../***/librz/bin/format/dmp -I../***/librz/bin/format/mdmp -I../***/librz/bin/format/pe -I../***/subprojects/rzgdb/include -I../***/subprojects/rzgdb/include/gdbclient -I../***/subprojects/rzgdb/include/gdbserver -Isubprojects/rzwinkd -I../***/subprojects/rzwinkd -Ilibrz/util/sdb/src -I../***/librz/util/sdb/src -I../***/librz/bin/format -I../***/librz/arch/isa -I../***/librz/arch/isa_gnu -Ilibrz/arch -I../***/librz/arch -I../***/librz/type/parser -I../***/subprojects/rzqnx/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O2 -g -Wimplicit-fallthrough=3 -DRZ_PLUGIN_INCORE=1 -DSUPPORTS_PCRE2_JIT -D_GNU_SOURCE --std=gnu99 -Werror=sizeof-pointer-memaccess -fvisibility=hidden -fPIC -MD -MQ librz/debug/librz_debug.so.0.8.0.p/p_native_linux_linux_debug.c.o -MF librz/debug/librz_debug.so.0.8.0.p/p_native_linux_linux_debug.c.o.d -o librz/debug/librz_debug.so.0.8.0.p/p_native_linux_linux_debug.c.o -c ../***/librz/debug/p/native/linux/linux_debug.c
#35 400.3 ../***/librz/debug/p/native/linux/linux_debug.c: In function ‘get_linux_tls_val’:
#35 400.3 ../***/librz/debug/p/native/linux/linux_debug.c:899:14: error: ‘struct user_regs_struct’ has no member named ‘gs_base’
#35 400.3     tls = regs.gs_base;
#35 400.3               ^
#35 400.3 ../***/librz/debug/p/native/linux/linux_debug.c: In function ‘linux_thread_list’:
#35 400.3 ../***/librz/debug/p/native/linux/linux_debug.c:973:16: error: ‘struct user_regs_struct’ has no member named ‘gs_base’
#35 400.3       tls = regs.gs_base;
#35 400.3                 ^
```

See https://github.com/rizinorg/rizin/actions/runs/8391638263/job/22986004979#step:9:8669

**Test plan**

CI is green
