### PR TITLE
debug: i386 register profile lacks `gs_base`

### DIFF
--- a/librz/debug/p/native/linux/linux_debug.c
+++ b/librz/debug/p/native/linux/linux_debug.c
@@ -964,7 +964,7 @@ RzList /*<RzDebugPid *>*/ *linux_thread_list(RzDebug *dbg, int pid, RzList /*<Rz
 			rz_debug_reg_sync(dbg, RZ_REG_TYPE_GPR, false);
 			pc = rz_debug_reg_get(dbg, "PC");
 
-#if (__x86_64__ || __i386__)
+#if __x86_64__
 			RzRegItem *ri = rz_reg_get(dbg->reg, "fs", RZ_REG_TYPE_ANY);
 			RZ_DEBUG_REG_T regs;
 			// Fetch gs_base from a ptrace call


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Missed this one more occurrence the last time:
```
#35 407.4 cc -Ilibrz/debug/librz_debug.so.0.8.0.p -I. -I../*** -Ilibrz -I../***/librz -Ilibrz/include -I../***/librz/include -I../***/librz/bin/format/elf -I../***/librz/bin/format/dmp -I../***/librz/bin/format/mdmp -I../***/librz/bin/format/pe -I../***/subprojects/rzgdb/include -I../***/subprojects/rzgdb/include/gdbclient -I../***/subprojects/rzgdb/include/gdbserver -Isubprojects/rzwinkd -I../***/subprojects/rzwinkd -Ilibrz/util/sdb/src -I../***/librz/util/sdb/src -I../***/librz/bin/format -I../***/librz/arch/isa -I../***/librz/arch/isa_gnu -Ilibrz/arch -I../***/librz/arch -I../***/librz/type/parser -I../***/subprojects/rzqnx/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O2 -g -Wimplicit-fallthrough=3 -DRZ_PLUGIN_INCORE=1 -DSUPPORTS_PCRE2_JIT -D_GNU_SOURCE --std=gnu99 -Werror=sizeof-pointer-memaccess -fvisibility=hidden -fPIC -MD -MQ librz/debug/librz_debug.so.0.8.0.p/p_native_linux_linux_debug.c.o -MF librz/debug/librz_debug.so.0.8.0.p/p_native_linux_linux_debug.c.o.d -o librz/debug/librz_debug.so.0.8.0.p/p_native_linux_linux_debug.c.o -c ../***/librz/debug/p/native/linux/linux_debug.c
#35 407.4 ../***/librz/debug/p/native/linux/linux_debug.c: In function ‘linux_thread_list’:
#35 407.4 ../***/librz/debug/p/native/linux/linux_debug.c:973:16: error: ‘struct user_regs_struct’ has no member named ‘gs_base’
#35 407.4       tls = regs.gs_base;
#35 407.4                 ^
```

**Test plan**

CI is green