### PR TITLE
Unblock android builds for x86_64

### DIFF
--- a/librz/debug/p/native/linux/linux_debug.c
+++ b/librz/debug/p/native/linux/linux_debug.c
@@ -890,7 +890,7 @@ RZ_API ut64 get_linux_tls_val(RZ_NONNULL RzDebug *dbg, int tid) {
 		rz_debug_reg_sync(dbg, RZ_REG_TYPE_GPR, false);
 	}
 
-#if __x86_64__
+#if !__ANDROID__ && __x86_64__
 	RzRegItem *ri = rz_reg_get(dbg->reg, "fs", RZ_REG_TYPE_ANY);
 	RZ_DEBUG_REG_T regs;
 	// Fetch gs_base from a ptrace call
@@ -964,7 +964,7 @@ RzList /*<RzDebugPid *>*/ *linux_thread_list(RzDebug *dbg, int pid, RzList /*<Rz
 			rz_debug_reg_sync(dbg, RZ_REG_TYPE_GPR, false);
 			pc = rz_debug_reg_get(dbg, "PC");
 
-#if __x86_64__
+#if !__ANDROID__ && __x86_64__
 			RzRegItem *ri = rz_reg_get(dbg->reg, "fs", RZ_REG_TYPE_ANY);
 			RZ_DEBUG_REG_T regs;
 			// Fetch gs_base from a ptrace call


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

```
 FAILED: librz/debug/librz_debug.a.p/p_native_linux_linux_debug.c.o 
/usr/local/lib/android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android33-clang -Ilibrz/debug/librz_debug.a.p -I. -I.. -Ilibrz -I../librz -Ilibrz/include -I../librz/include -I../librz/bin/format/elf -I../librz/bin/format/dmp -I../librz/bin/format/mdmp -I../librz/bin/format/pe -I../subprojects/rzgdb/include -I../subprojects/rzgdb/include/gdbclient -I../subprojects/rzgdb/include/gdbserver -Isubprojects/rzwinkd -I../subprojects/rzwinkd -Ilibrz/util/sdb/src -I../librz/util/sdb/src -I../librz/bin/format -I../librz/arch/isa -I../librz/arch/isa_gnu -Ilibrz/arch -I../librz/arch -I../librz/type/parser -I../subprojects/rzqnx/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O3 -DRZ_PLUGIN_INCORE=1 -DSUPPORTS_PCRE2_JIT -D_GNU_SOURCE --std=gnu99 -Werror=sizeof-pointer-memaccess -fPIC -MD -MQ librz/debug/librz_debug.a.p/p_native_linux_linux_debug.c.o -MF librz/debug/librz_debug.a.p/p_native_linux_linux_debug.c.o.d -o librz/debug/librz_debug.a.p/p_native_linux_linux_debug.c.o -c ../librz/debug/p/native/linux/linux_debug.c
../librz/debug/p/native/linux/linux_debug.c:899:15: error: no member named 'gs_base' in 'struct pt_regs'
                        tls = regs.gs_base;
                              ~~~~ ^
../librz/debug/p/native/linux/linux_debug.c:973:17: error: no member named 'gs_base' in 'struct pt_regs'
                                        tls = regs.gs_base;
                                              ~~~~ ^
../librz/debug/p/native/linux/linux_debug.c:1053:9: warning: unused variable 'j' [-Wunused-variable]
        int i, j;
               ^
../librz/debug/p/native/linux/linux_debug.c:1179:2: warning: Android X86 does not support DRX [-W#warnings]
#warning Android X86 does not support DRX
 ^
2 warnings and 2 errors generated.

```
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
