### PR TITLE
Remove invalidate any string with a colon

### DIFF
--- a/librz/core/golang.c
+++ b/librz/core/golang.c
@@ -183,6 +183,7 @@ static char *detect_go_package_from_name(const char *string) {
 	 * - `type..` because is just the definition of a function linked to a defined go `typedef`
 	 */
 	if (rz_str_startswith(string, "main.") ||
+		rz_str_startswith(string, "type:") ||
 		rz_str_startswith(string, "type..")) {
 		return NULL;
 	}
@@ -203,6 +204,11 @@ static char *detect_go_package_from_name(const char *string) {
 		} else if (string[i] == '/') {
 			end = NULL;
 		} else if (string[i] == '(') {
+			if (!end) {
+				end = string + i;
+			}
+			break;
+		} else if (string[i] == ':') {
 			if (!end) {
 				end = string + i;
 			}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

I noticed that the detection code for the go packages allows packages with `:` which is wrong.