### PR TITLE
strings_print json: For efficiency, escape strings only once

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -2725,11 +2725,15 @@ static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzPVector
 			}
 		}
 
-		RzStrEscOptions opt = { 0 };
-		opt.show_asciidot = false;
-		opt.esc_bslash = true;
-		opt.esc_double_quotes = false;
-		char *escaped_string = rz_str_escape_utf8_keep_printable(string->string, &opt);
+		char *escaped_string = NULL;
+		// For JSON, pj_ks does the escaping
+		if (state->mode != RZ_OUTPUT_MODE_JSON && state->mode != RZ_OUTPUT_MODE_LONG_JSON) {
+			RzStrEscOptions opt = { 0 };
+			opt.show_asciidot = false;
+			opt.esc_bslash = true;
+			opt.esc_double_quotes = false;
+			escaped_string = rz_str_escape_utf8_keep_printable(string->string, &opt);
+		}
 
 		switch (state->mode) {
 		case RZ_OUTPUT_MODE_JSON: {
@@ -2742,9 +2746,7 @@ static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzPVector
 			pj_kn(state->d.pj, "length", string->length);
 			pj_ks(state->d.pj, "section", section_name);
 			pj_ks(state->d.pj, "type", type_string);
-			// data itself may be encoded so use pj_ks.
-			// string->string is used instead of escaped_string
-			// because it's pj_ks that does the escaping.
+			// data itself may be encoded so use pj_ks
 			pj_ks(state->d.pj, "string", string->string);
 
 			switch (string->type) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr should improve the performance of `strings_print()` when printing JSON (by reducing executed code).

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
