### PR TITLE
ELF: skip visited segments in compute_symbols_from_segment()

### DIFF
--- a/librz/bin/format/elf/elf_symbols.c
+++ b/librz/bin/format/elf/elf_symbols.c
@@ -253,18 +253,17 @@ static void elf_symbol_fini(void *e, RZ_UNUSED void *user) {
 }
 
 static bool compute_symbols_from_segment(ELFOBJ *bin, RzVector /*<RzBinElfSymbol>*/ *result, struct symbols_segment *segment, RzBinElfSymbolFilter filter, HtUU *set) {
+	if (has_already_been_processed(bin, segment->offset, set)) {
+		return true;
+	}
+
+	if (!ht_uu_insert(set, segment->offset, 1ULL)) {
+		return false;
+	}
+
 	ut64 offset = segment->offset + segment->entry_size;
 
 	for (size_t i = 1; i < segment->number; i++) {
-		if (has_already_been_processed(bin, offset, set)) {
-			offset += segment->entry_size;
-			continue;
-		}
-
-		if (!ht_uu_insert(set, offset, offset)) {
-			return false;
-		}
-
 		Elf_(Sym) entry;
 		if (!get_symbol_entry(bin, offset, &entry)) {
 			return false;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

I am not familiar with ELF format but I think it is enough to memorize offset of visited symbol segments.
Related: #4386