### PR TITLE
Update libdemangle to latest main and add LD command as alias of iDl

### DIFF
--- a/librz/core/cmd/cmd_plugins.c
+++ b/librz/core/cmd/cmd_plugins.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_core.h>
+#include <cmd_descs.h>
 
 RZ_IPI RzCmdStatus rz_plugins_load_handler(RzCore *core, int argc, const char **argv) {
 	return rz_lib_open(core->lib, rz_str_trim_head_ro(argv[1])) ? RZ_CMD_STATUS_OK : RZ_CMD_STATUS_ERROR;
@@ -56,4 +57,9 @@ RZ_IPI RzCmdStatus rz_plugins_io_print_handler(RzCore *core, int argc, const cha
 
 RZ_IPI RzCmdStatus rz_plugins_parser_print_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
 	return rz_core_parser_plugins_print(core->parser, state);
+}
+
+RZ_IPI RzCmdStatus rz_plugins_demanglers_print_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
+	// alias for iDl
+	return rz_cmd_info_demangle_list_handler(core, argc, argv, state);
 }

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -11739,6 +11739,14 @@ static const RzCmdDescHelp plugins_parser_print_help = {
 	.args = plugins_parser_print_args,
 };
 
+static const RzCmdDescArg plugins_demanglers_print_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp plugins_demanglers_print_help = {
+	.summary = "List the demanglers plugins (alias for iDl)",
+	.args = plugins_demanglers_print_args,
+};
+
 static const RzCmdDescHelp o_help = {
 	.summary = "Open files and handle opened files",
 };
@@ -21452,6 +21460,10 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *plugins_parser_print_cd = rz_cmd_desc_argv_state_new(core->rcmd, L_cd, "Lp", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_plugins_parser_print_handler, &plugins_parser_print_help);
 	rz_warn_if_fail(plugins_parser_print_cd);
+
+	RzCmdDesc *plugins_demanglers_print_cd = rz_cmd_desc_argv_state_new(core->rcmd, L_cd, "LD", RZ_OUTPUT_MODE_TABLE | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_JSON, rz_plugins_demanglers_print_handler, &plugins_demanglers_print_help);
+	rz_warn_if_fail(plugins_demanglers_print_cd);
+	rz_cmd_desc_set_default_mode(plugins_demanglers_print_cd, RZ_OUTPUT_MODE_TABLE);
 
 	RzCmdDesc *o_cd = rz_cmd_desc_group_new(core->rcmd, root_cd, "o", rz_open_handler, &open_help, &o_help);
 	rz_warn_if_fail(o_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -1610,6 +1610,8 @@ RZ_IPI RzCmdStatus rz_plugins_bin_print_handler(RzCore *core, int argc, const ch
 RZ_IPI RzCmdStatus rz_plugins_io_print_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "Lp"
 RZ_IPI RzCmdStatus rz_plugins_parser_print_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+// "LD"
+RZ_IPI RzCmdStatus rz_plugins_demanglers_print_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "o"
 RZ_IPI RzCmdStatus rz_open_handler(RzCore *core, int argc, const char **argv);
 // "o+"

--- a/librz/core/cmd_descs/cmd_plugins.yaml
+++ b/librz/core/cmd_descs/cmd_plugins.yaml
@@ -99,3 +99,13 @@ commands:
     modes:
       - RZ_OUTPUT_MODE_STANDARD
       - RZ_OUTPUT_MODE_JSON
+  - name: LD
+    cname: plugins_demanglers_print
+    summary: List the demanglers plugins (alias for iDl)
+    type: RZ_CMD_DESC_TYPE_ARGV_STATE
+    args: []
+    default_mode: RZ_OUTPUT_MODE_TABLE
+    modes:
+      - RZ_OUTPUT_MODE_TABLE
+      - RZ_OUTPUT_MODE_QUIET
+      - RZ_OUTPUT_MODE_JSON

--- a/librz/demangler/demangler.c
+++ b/librz/demangler/demangler.c
@@ -32,7 +32,7 @@ DEFINE_DEMANGLER_PLUGIN(cpp, "c++", "LGPL3", "deroad", libdemangle_handler_cxx);
 DEFINE_DEMANGLER_PLUGIN(swift, "swift", "MIT", "pancake", libdemangle_handler_swift);
 #endif
 
-DEFINE_DEMANGLER_PLUGIN(rust, "rust", "LGPL3", "Dhruv Maroo", libdemangle_handler_rust);
+DEFINE_DEMANGLER_PLUGIN(rust, "rust", "LGPL3", "Dhruv Maroo/RizinOrg", libdemangle_handler_rust);
 DEFINE_DEMANGLER_PLUGIN(java, "java", "LGPL3", "deroad", libdemangle_handler_java);
 DEFINE_DEMANGLER_PLUGIN(msvc, "msvc", "LGPL3", "inisider", libdemangle_handler_msvc);
 DEFINE_DEMANGLER_PLUGIN(objc, "objc", "LGPL3", "pancake", libdemangle_handler_objc);

--- a/subprojects/libdemangle.wrap
+++ b/subprojects/libdemangle.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 url = https://github.com/rizinorg/rz-libdemangle.git
-revision = 3eb0ef8efdf8d22bd5cfde1f7df1c1e48ef75a70
+revision = 498e00785ebdff8867f403799e6b709d98cd82f6
 depth = 1

--- a/test/db/tools/rz_bin
+++ b/test/db/tools/rz_bin
@@ -889,7 +889,7 @@ msvc   LGPL3        inisider
 objc   LGPL3        pancake
 pascal LGPL3        deroad
 c++    GPL-2,LGPL3  FSF/deroad
-rust   LGPL3        Dhruv Maroo
+rust   LGPL3        Dhruv Maroo/RizinOrg
 swift  MIT          pancake
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Updates libdemangle to latest main to support rust v0 demangling. also adds `LD` command as alias of `iDl` since it is easier to find it under the `L` command.