### PR TITLE
rz_cmd_desc_get_arg: Remove unused `cmd` param

### DIFF
--- a/librz/core/cautocmpl.c
+++ b/librz/core/cautocmpl.c
@@ -677,7 +677,7 @@ static size_t get_arg_number(TSNode arg) {
  * command \p cd . This is based on the type of argument a command may accept.
  */
 static void autocmplt_cmd_arg(RzCore *core, RzLineNSCompletionResult *res, const RzCmdDesc *cd, size_t i_arg, const char *s, size_t len) {
-	const RzCmdDescArg *arg = rz_cmd_desc_get_arg(core->rcmd, cd, i_arg);
+	const RzCmdDescArg *arg = rz_cmd_desc_get_arg(cd, i_arg);
 	if (!arg) {
 		return;
 	}
@@ -771,7 +771,7 @@ static bool fill_autocmplt_data_cmdarg(struct autocmplt_data_t *ad, ut32 start, 
 
 	ad->i_arg = get_arg_number(node);
 
-	const RzCmdDescArg *arg = rz_cmd_desc_get_arg(core->rcmd, ad->cd, ad->i_arg);
+	const RzCmdDescArg *arg = rz_cmd_desc_get_arg(ad->cd, ad->i_arg);
 	if (!arg) {
 		return false;
 	}

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -2204,7 +2204,7 @@ RZ_API bool rz_cmd_desc_remove(RzCmd *cmd, RzCmdDesc *cd) {
  * \p RZ_CMD_ARG_FLAG_ARRAY, where even if there is just one RzCmdDescArg,
  * everything is considered as part of the same RzCmdDescArg.
  */
-RZ_API const RzCmdDescArg *rz_cmd_desc_get_arg(RzCmd *cmd, const RzCmdDesc *cd, size_t i) {
+RZ_API const RzCmdDescArg *rz_cmd_desc_get_arg(const RzCmdDesc *cd, size_t i) {
 	const RzCmdDescArg *arg = cd->help->args;
 	size_t j = 0;
 	while (arg && arg->name) {

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -562,7 +562,7 @@ RZ_API bool rz_cmd_desc_set_default_mode(RzCmdDesc *cd, RzOutputMode mode);
 RZ_API bool rz_cmd_desc_has_handler(const RzCmdDesc *cd);
 RZ_API bool rz_cmd_desc_remove(RzCmd *cmd, RzCmdDesc *cd);
 RZ_API void rz_cmd_foreach_cmdname(RzCmd *cmd, RzCmdDesc *begin, RzCmdForeachNameCb cb, void *user);
-RZ_API const RzCmdDescArg *rz_cmd_desc_get_arg(RzCmd *cmd, const RzCmdDesc *cd, size_t i);
+RZ_API const RzCmdDescArg *rz_cmd_desc_get_arg(const RzCmdDesc *cd, size_t i);
 
 #define rz_cmd_desc_children_foreach(root, it_cd) rz_pvector_foreach (&root->children, it_cd)
 

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -958,18 +958,18 @@ bool test_get_arg(void) {
 	RzCmdDesc *z_cd = rz_cmd_desc_argv_new(cmd, root, "z", z_last_handler, &z_help);
 	RzCmdDesc *x_cd = rz_cmd_desc_argv_new(cmd, root, "x", x_array_handler, &x_help);
 
-	const RzCmdDescArg *a1 = rz_cmd_desc_get_arg(cmd, z_cd, 0);
+	const RzCmdDescArg *a1 = rz_cmd_desc_get_arg(z_cd, 0);
 	mu_assert_streq(a1->name, "a1", "0th arg of z is a1");
-	const RzCmdDescArg *a2 = rz_cmd_desc_get_arg(cmd, z_cd, 1);
+	const RzCmdDescArg *a2 = rz_cmd_desc_get_arg(z_cd, 1);
 	mu_assert_streq(a2->name, "a2", "1th arg of z is a2");
-	const RzCmdDescArg *an = rz_cmd_desc_get_arg(cmd, z_cd, 10);
+	const RzCmdDescArg *an = rz_cmd_desc_get_arg(z_cd, 10);
 	mu_assert_streq(an->name, "a2", "10th arg of z is a2");
 
-	const RzCmdDescArg *b1 = rz_cmd_desc_get_arg(cmd, x_cd, 0);
+	const RzCmdDescArg *b1 = rz_cmd_desc_get_arg(x_cd, 0);
 	mu_assert_streq(b1->name, "b1", "0th arg of x is b1");
-	const RzCmdDescArg *b2 = rz_cmd_desc_get_arg(cmd, x_cd, 1);
+	const RzCmdDescArg *b2 = rz_cmd_desc_get_arg(x_cd, 1);
 	mu_assert_streq(b2->name, "b2", "1th arg of x is b2");
-	const RzCmdDescArg *bn = rz_cmd_desc_get_arg(cmd, x_cd, 10);
+	const RzCmdDescArg *bn = rz_cmd_desc_get_arg(x_cd, 10);
 	mu_assert_null(bn, "10th arg of x does not exist");
 
 	rz_cmd_free(cmd);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr removes the unused `cmd` parameter of `rz_cmd_desc_get_arg()`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
