### PR TITLE
Remove globals and refactor to complete implementation of logging.

### DIFF
--- a/librz/bin/dwarf/unit.c
+++ b/librz/bin/dwarf/unit.c
@@ -83,7 +83,7 @@ static bool CU_attrs_parse(
 	RzBinDwarfCompUnit *cu,
 	RzBinDwarfAbbrevDecl *abbrev_decl) {
 
-	RZ_LOG_SILLY("0x%" PFMT64x ":\t%s%s [%" PFMT64d "] %s\n",
+	RZ_LOG_DEBUG("0x%" PFMT64x ":\t%s%s [%" PFMT64d "] %s\n",
 		die->offset, rz_str_indent(die->depth), rz_bin_dwarf_tag(die->tag),
 		die->abbrev_code, rz_bin_dwarf_children(die->has_children));
 	RzBinDwarfAttrSpec *spec = NULL;
@@ -195,7 +195,7 @@ static bool CU_dies_parse(
 		};
 		// there can be "null" entries that have abbr_code == 0
 		if (!abbrev_code) {
-			RZ_LOG_SILLY("0x%" PFMT64x ":\t%sNULL\n", offset, rz_str_indent(die.depth));
+			RZ_LOG_DEBUG("0x%" PFMT64x ":\t%sNULL\n", offset, rz_str_indent(die.depth));
 			rz_vector_push(&unit->dies, &die);
 			depth--;
 			if (depth <= 0) {

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -2880,21 +2880,18 @@ static bool cb_log_config_traplevel(void *coreptr, void *nodeptr) {
 
 static bool cb_log_config_file(void *coreptr, void *nodeptr) {
 	RzConfigNode *node = (RzConfigNode *)nodeptr;
-	const char *value = node->value;
-	rz_log_set_file(value);
-	return true;
+	return rz_log_set_file(node->value);
 }
 
-static bool cb_log_config_srcinfo(void *coreptr, void *nodeptr) {
+static bool cb_log_config_show_sources(void *coreptr, void *nodeptr) {
 	RzConfigNode *node = (RzConfigNode *)nodeptr;
 	const char *value = node->value;
-	switch (value[0]) {
-	case 't':
-	case 'T':
-		rz_log_set_srcinfo(true);
-		break;
-	default:
-		rz_log_set_srcinfo(false);
+	if (rz_str_is_true(value)) {
+		rz_log_set_show_sources(true);
+	} else if (rz_str_is_false(value)) {
+		rz_log_set_show_sources(false);
+	} else {
+		return false;
 	}
 	return true;
 }
@@ -2902,13 +2899,12 @@ static bool cb_log_config_srcinfo(void *coreptr, void *nodeptr) {
 static bool cb_log_config_colors(void *coreptr, void *nodeptr) {
 	RzConfigNode *node = (RzConfigNode *)nodeptr;
 	const char *value = node->value;
-	switch (value[0]) {
-	case 't':
-	case 'T':
+	if (rz_str_is_true(value)) {
 		rz_log_set_colors(true);
-		break;
-	default:
+	} else if (rz_str_is_false(value)) {
 		rz_log_set_colors(false);
+	} else {
+		return false;
 	}
 	return true;
 }
@@ -3338,21 +3334,24 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	// RZ_LOGLEVEL / log.level
 	p = rz_sys_getenv("RZ_LOGLEVEL");
 	SETICB("log.level", p ? atoi(p) : RZ_DEFAULT_LOGLVL, cb_log_config_level, "Target log level/severity"
-										  " (0:SILLY, 1:DEBUG, 2:VERBOSE, 3:INFO, 4:WARN, 5:ERROR, 6:FATAL)");
+										  " (0:DEBUG, 1:VERBOSE, 2:INFO, 3:WARN, 4:ERROR, 5:FATAL)");
 	free(p);
 	// RZ_LOGTRAP_LEVEL / log.traplevel
 	p = rz_sys_getenv("RZ_LOGTRAPLEVEL");
-	SETICB("log.traplevel", p ? atoi(p) : RZ_LOGLVL_FATAL, cb_log_config_traplevel, "Log level for trapping rizin when hit"
-											" (0:SILLY, 1:VERBOSE, 2:DEBUG, 3:INFO, 4:WARN, 5:ERROR, 6:FATAL)");
+	SETICB("log.traplevel", p ? atoi(p) : RZ_DEFAULT_LOGLVL_TRAP, cb_log_config_traplevel, "Log level for trapping rizin when hit"
+											       " (0:VERBOSE, 1:DEBUG, 2:INFO, 3:WARN, 4:ERROR, 5:FATAL)");
 	free(p);
+
 	// RZ_LOGFILE / log.file
 	p = rz_sys_getenv("RZ_LOGFILE");
 	SETCB("log.file", p ? p : "", cb_log_config_file, "Logging output filename / path");
 	free(p);
-	// RZ_LOGSRCINFO / log.srcinfo
-	p = rz_sys_getenv("RZ_LOGSRCINFO");
-	SETCB("log.srcinfo", p ? p : "false", cb_log_config_srcinfo, "Should the log output contain src info (filename:lineno)");
+
+	// RZ_LOGSHOWSOURCES / log.show.sources
+	p = rz_sys_getenv("RZ_LOGSHOWSOURCES");
+	SETCB("log.show.sources", p ? p : "false", cb_log_config_show_sources, "Should the log output contain src info (filename:lineno)");
 	free(p);
+
 	// RZ_LOGCOLORS / log.colors
 	p = rz_sys_getenv("RZ_LOGCOLORS");
 	SETCB("log.colors", p ? p : "false", cb_log_config_colors, "Should the log output use colors (TODO)");

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -2872,11 +2872,13 @@ static bool cb_log_config_level(void *coreptr, void *nodeptr) {
 	return true;
 }
 
-static bool cb_log_config_traplevel(void *coreptr, void *nodeptr) {
+#if RZ_BUILD_DEBUG
+static bool cb_log_config_abortlevel(void *coreptr, void *nodeptr) {
 	RzConfigNode *node = (RzConfigNode *)nodeptr;
-	rz_log_set_traplevel(node->i_value);
+	rz_log_set_abortlevel(node->i_value);
 	return true;
 }
+#endif /* RZ_BUILD_DEBUG */
 
 static bool cb_log_config_file(void *coreptr, void *nodeptr) {
 	RzConfigNode *node = (RzConfigNode *)nodeptr;
@@ -3336,11 +3338,14 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETICB("log.level", p ? atoi(p) : RZ_DEFAULT_LOGLVL, cb_log_config_level, "Target log level/severity"
 										  " (0:DEBUG, 1:VERBOSE, 2:INFO, 3:WARN, 4:ERROR, 5:FATAL)");
 	free(p);
-	// RZ_LOGTRAP_LEVEL / log.traplevel
-	p = rz_sys_getenv("RZ_LOGTRAPLEVEL");
-	SETICB("log.traplevel", p ? atoi(p) : RZ_DEFAULT_LOGLVL_TRAP, cb_log_config_traplevel, "Log level for trapping rizin when hit"
-											       " (0:VERBOSE, 1:DEBUG, 2:INFO, 3:WARN, 4:ERROR, 5:FATAL)");
+
+#if RZ_BUILD_DEBUG
+	// RZ_ABORTLEVEL / log.abortlevel
+	p = rz_sys_getenv("RZ_ABORTLEVEL");
+	SETICB("log.abortlevel", p ? atoi(p) : RZ_DEFAULT_LOGLVL_ABORT, cb_log_config_abortlevel, "Target log level/severity when to abort."
+												  " (0:DEBUG, 1:VERBOSE, 2:INFO, 3:WARN, 4:ERROR, 5:FATAL)");
 	free(p);
+#endif /* RZ_BUILD_DEBUG */
 
 	// RZ_LOGFILE / log.file
 	p = rz_sys_getenv("RZ_LOGFILE");

--- a/librz/include/rz_util/rz_log.h
+++ b/librz/include/rz_util/rz_log.h
@@ -14,13 +14,14 @@
 #endif
 
 typedef enum rz_log_level {
-	RZ_LOGLVL_SILLY = 0,
-	RZ_LOGLVL_DEBUG = 1,
-	RZ_LOGLVL_VERBOSE = 2,
-	RZ_LOGLVL_INFO = 3,
-	RZ_LOGLVL_WARN = 4,
-	RZ_LOGLVL_ERROR = 5,
-	RZ_LOGLVL_FATAL = 6, // This will call rz_sys_breakpoint() and trap the process for debugging!
+	RZ_LOGLVL_DEBUG = 0,
+	RZ_LOGLVL_VERBOSE,
+	RZ_LOGLVL_INFO,
+	RZ_LOGLVL_WARN,
+	RZ_LOGLVL_ERROR,
+	RZ_LOGLVL_FATAL, ///< This will call rz_sys_breakpoint() and trap the process for debugging!
+	/* other flags */
+	RZ_LOGLVL_SIZE,
 	RZ_LOGLVL_NONE = 0xFF
 } RzLogLevel;
 
@@ -29,6 +30,8 @@ typedef enum rz_log_level {
 #else
 #define RZ_DEFAULT_LOGLVL RZ_LOGLVL_ERROR
 #endif
+
+#define RZ_DEFAULT_LOGLVL_TRAP RZ_LOGLVL_FATAL
 
 typedef void (*RzLogCallback)(const char *output, const char *funcname, const char *filename,
 	ut32 lineno, RzLogLevel level, const char *tag, const char *fmtstr, ...) RZ_PRINTF_CHECK(7, 8);
@@ -40,12 +43,9 @@ typedef void (*RzLogCallback)(const char *output, const char *funcname, const ch
 	__LINE__, lvl, tag, fmtstr, ##__VA_ARGS__);
 
 #if RZ_BUILD_DEBUG
-#define RZ_LOG_SILLY(fmtstr, ...) rz_log(MACRO_LOG_FUNC, __FILE__, \
-	__LINE__, RZ_LOGLVL_SILLY, NULL, fmtstr, ##__VA_ARGS__);
 #define RZ_LOG_DEBUG(fmtstr, ...) rz_log(MACRO_LOG_FUNC, __FILE__, \
 	__LINE__, RZ_LOGLVL_DEBUG, NULL, fmtstr, ##__VA_ARGS__);
 #else
-#define RZ_LOG_SILLY(fmtstr, ...)
 #define RZ_LOG_DEBUG(fmtstr, ...)
 #endif
 
@@ -66,14 +66,14 @@ extern "C" {
 
 // Called by rz_core to set the configuration variables
 RZ_API void rz_log_set_level(RzLogLevel level);
-RZ_API void rz_log_set_file(const char *filename);
-RZ_API void rz_log_set_srcinfo(bool show_info);
+RZ_API bool rz_log_set_file(RZ_NULLABLE const char *filename);
+RZ_API void rz_log_set_show_sources(bool show_sources);
 RZ_API void rz_log_set_colors(bool show_colors);
 RZ_API void rz_log_set_traplevel(RzLogLevel level);
 
 // Functions for adding log callbacks
-RZ_API void rz_log_add_callback(RzLogCallback cbfunc);
-RZ_API void rz_log_del_callback(RzLogCallback cbfunc);
+RZ_API void rz_log_add_callback(RZ_NULLABLE RzLogCallback cbfunc);
+RZ_API void rz_log_del_callback(RZ_NULLABLE RzLogCallback cbfunc);
 // TODO: rz_log_get_callbacks()
 
 /* Define rz_log as weak so it can be 'overwritten' externally

--- a/librz/include/rz_util/rz_log.h
+++ b/librz/include/rz_util/rz_log.h
@@ -66,10 +66,10 @@ extern "C" {
 
 // Called by rz_core to set the configuration variables
 RZ_API void rz_log_set_level(RzLogLevel level);
+RZ_API void rz_log_set_traplevel(RzLogLevel level);
 RZ_API bool rz_log_set_file(RZ_NULLABLE const char *filename);
 RZ_API void rz_log_set_show_sources(bool show_sources);
 RZ_API void rz_log_set_colors(bool show_colors);
-RZ_API void rz_log_set_traplevel(RzLogLevel level);
 
 // Functions for adding log callbacks
 RZ_API void rz_log_add_callback(RZ_NULLABLE RzLogCallback cbfunc);

--- a/librz/include/rz_util/rz_log.h
+++ b/librz/include/rz_util/rz_log.h
@@ -31,8 +31,6 @@ typedef enum rz_log_level {
 #define RZ_DEFAULT_LOGLVL RZ_LOGLVL_ERROR
 #endif
 
-#define RZ_DEFAULT_LOGLVL_TRAP RZ_LOGLVL_FATAL
-
 typedef void (*RzLogCallback)(const char *output, const char *funcname, const char *filename,
 	ut32 lineno, RzLogLevel level, const char *tag, const char *fmtstr, ...) RZ_PRINTF_CHECK(7, 8);
 
@@ -43,6 +41,7 @@ typedef void (*RzLogCallback)(const char *output, const char *funcname, const ch
 	__LINE__, lvl, tag, fmtstr, ##__VA_ARGS__);
 
 #if RZ_BUILD_DEBUG
+#define RZ_DEFAULT_LOGLVL_ABORT   RZ_LOGLVL_FATAL
 #define RZ_LOG_DEBUG(fmtstr, ...) rz_log(MACRO_LOG_FUNC, __FILE__, \
 	__LINE__, RZ_LOGLVL_DEBUG, NULL, fmtstr, ##__VA_ARGS__);
 #else
@@ -66,7 +65,7 @@ extern "C" {
 
 // Called by rz_core to set the configuration variables
 RZ_API void rz_log_set_level(RzLogLevel level);
-RZ_API void rz_log_set_traplevel(RzLogLevel level);
+RZ_API void rz_log_set_abortlevel(RzLogLevel level);
 RZ_API bool rz_log_set_file(RZ_NULLABLE const char *filename);
 RZ_API void rz_log_set_show_sources(bool show_sources);
 RZ_API void rz_log_set_colors(bool show_colors);

--- a/librz/util/log.c
+++ b/librz/util/log.c
@@ -54,7 +54,11 @@ static void log_init() {
 	logcfg.lock = rz_th_lock_new(false);
 }
 
-// cconfig.c configuration callback functions below
+/**
+ * \brief      Sets the log level
+ *
+ * \param[in]  level  The log level to set.
+ */
 RZ_API void rz_log_set_level(RzLogLevel level) {
 	log_init();
 	rz_th_lock_enter(logcfg.lock);
@@ -62,6 +66,11 @@ RZ_API void rz_log_set_level(RzLogLevel level) {
 	rz_th_lock_leave(logcfg.lock);
 }
 
+/**
+ * \brief      Sets the log level of the trap
+ *
+ * \param[in]  level  The trap log level to set.
+ */
 RZ_API void rz_log_set_traplevel(RzLogLevel level) {
 	log_init();
 	rz_th_lock_enter(logcfg.lock);
@@ -69,6 +78,14 @@ RZ_API void rz_log_set_traplevel(RzLogLevel level) {
 	rz_th_lock_leave(logcfg.lock);
 }
 
+/**
+ * \brief      When not empty, enable logging to a file.
+ * This method allows to enable or disable logging to a file.
+ * To enable logging, just pass a filename to write to and to
+ * disable the logging is enough to pass an empty or NULL filename.
+ *
+ * \param[in]  filename  The file name to log to.
+ */
 RZ_API bool rz_log_set_file(RZ_NULLABLE const char *filename) {
 	log_init();
 	rz_th_lock_enter(logcfg.lock);
@@ -101,6 +118,11 @@ end:
 	return ret;
 }
 
+/**
+ * \brief      When true, shows the function name and the source lines in the logs.
+ *
+ * \param[in]  show_sources  The boolean value to set show_sources to.
+ */
 RZ_API void rz_log_set_show_sources(bool show_sources) {
 	log_init();
 	rz_th_lock_enter(logcfg.lock);
@@ -108,6 +130,11 @@ RZ_API void rz_log_set_show_sources(bool show_sources) {
 	rz_th_lock_leave(logcfg.lock);
 }
 
+/**
+ * \brief      Enables colored logs.
+ *
+ * \param[in]  show_colors  Sets the pointer to colored or not colored tags.
+ */
 RZ_API void rz_log_set_colors(bool show_colors) {
 	log_init();
 	rz_th_lock_enter(logcfg.lock);
@@ -116,8 +143,9 @@ RZ_API void rz_log_set_colors(bool show_colors) {
 }
 
 /**
- * \brief Add a logging callback
- * \param cbfunc RzLogCallback style function to be called
+ * \brief      Adds a logging callback.
+ *
+ * \param[in]  show_colors  RzLogCallback style function to be called.
  */
 RZ_API void rz_log_add_callback(RZ_NULLABLE RzLogCallback cbfunc) {
 	if (!cbfunc) {
@@ -135,16 +163,19 @@ RZ_API void rz_log_add_callback(RZ_NULLABLE RzLogCallback cbfunc) {
 }
 
 /**
- * \brief Remove a logging callback
+ * \brief        Removes a logging callback
+ *
  * \param cbfunc RzLogCallback style function to be called
  */
 RZ_API void rz_log_del_callback(RZ_NULLABLE RzLogCallback cbfunc) {
-	if (!cbfunc || !logcfg.callbacks) {
+	if (!cbfunc) {
 		return;
 	}
 	log_init();
 	rz_th_lock_enter(logcfg.lock);
-	rz_list_delete_data(logcfg.callbacks, cbfunc);
+	if (logcfg.callbacks) {
+		rz_list_delete_data(logcfg.callbacks, cbfunc);
+	}
 	rz_th_lock_leave(logcfg.lock);
 }
 

--- a/librz/util/log.c
+++ b/librz/util/log.c
@@ -9,7 +9,7 @@
 #include <stdarg.h>
 
 typedef struct log_config_s {
-	RzList *callbacks;
+	RzList /*<RzLogCallback *>*/ *callbacks;
 	RzLogLevel level;
 #if RZ_BUILD_DEBUG
 	RzLogLevel abortlevel;

--- a/test/db/archos/linux-x64/dbg_oo
+++ b/test/db/archos/linux-x64/dbg_oo
@@ -94,7 +94,7 @@ RUN
 
 NAME=dm flags after ood
 FILE=bins/elf/analysis/x86-helloworld-gcc
-ARGS=-e log.level=5
+ARGS=-e log.level=4
 CMDS=<<EOF
 ood
 fl@F:maps~?
@@ -108,7 +108,7 @@ RUN
 
 NAME=ood check for ptrace errors
 FILE=bins/elf/analysis/x86-helloworld-gcc
-ARGS=-e log.level=4
+ARGS=-e log.level=3
 CMDS=<<EOF
 ood
 EOF

--- a/test/db/cmd/cmd_basefind
+++ b/test/db/cmd/cmd_basefind
@@ -5,7 +5,7 @@ CMDS=<<EOF
 e basefind.max.threads=1
 e basefind.search.start=0x06000000
 e basefind.search.end=0x10000000
-e log.level=3
+e log.level=2
 Bj
 Bq
 B

--- a/test/db/cmd/cmd_flags
+++ b/test/db/cmd/cmd_flags
@@ -304,7 +304,7 @@ RUN
 
 NAME=f.lj
 FILE=bins/elf/analysis/main
-ARGS=-e log.level=4
+ARGS=-e log.level=3
 CMDS=<<EOF
 af
 f. patata
@@ -331,7 +331,7 @@ RUN
 
 NAME=f.-
 FILE=bins/elf/analysis/main
-ARGS=-e log.level=4
+ARGS=-e log.level=3
 CMDS=<<EOF
 af
 f. patata

--- a/test/db/formats/elf/main
+++ b/test/db/formats/elf/main
@@ -1,7 +1,7 @@
 NAME=ELF: endbr-main-mov
 FILE=bins/elf/endbr-main
 CMDS=%v main
-ARGS=-e log.level=4
+ARGS=-e log.level=3
 EXPECT=<<EOF
 0x401126
 EOF

--- a/test/db/formats/elf/sections
+++ b/test/db/formats/elf/sections
@@ -100,7 +100,7 @@ RUN
 
 NAME=disable sections load
 FILE=bins/elf/analysis/hello-linux-x86_64
-ARGS=-e log.level=4 -e elf.load.sections=false
+ARGS=-e log.level=3 -e elf.load.sections=false
 CMDS=iS
 EXPECT=<<EOF
 paddr      size vaddr      vsize align perm name      type flags 
@@ -113,7 +113,7 @@ RUN
 
 NAME=disable sections checks
 FILE=bins/elf/libmemalloc-dump-mem
-ARGS=-e log.level=4 -e elf.checks.sections=false
+ARGS=-e log.level=3 -e elf.checks.sections=false
 CMDS=iS
 EXPECT=<<EOF
 paddr      size       vaddr      vsize      align perm name      type              flags                                                                    
@@ -150,7 +150,7 @@ RUN
 
 NAME=disable segments checks
 FILE=bins/elf/analysis/tiny.elf
-ARGS=-e log.level=4 -e elf.checks.segments=false
+ARGS=-e log.level=3 -e elf.checks.segments=false
 CMDS=iS
 EXPECT=<<EOF
 paddr size vaddr vsize align perm name type flags 

--- a/test/db/formats/pdb
+++ b/test/db/formats/pdb
@@ -526,7 +526,7 @@ NAME=Extract pdb via idbx
 FILE==
 CMDS=<<EOF
 idpi bins/pdb/basic32.pd_
-e log.level=3
+e log.level=2
 mkdir .tmp
 idpx bins/pdb/basic32.pd_ .tmp
 !rz-hash -a md5 .tmp/basic32.pdb

--- a/test/db/tools/rz_bin
+++ b/test/db/tools/rz_bin
@@ -52,7 +52,7 @@ RUN
 NAME=rz-bin -k file
 FILE=bins/elf/analysis/hello-linux-x86_64
 CMDS=!rz-bin -k ${RZ_FILE}
-ARGS=-e log.level=4
+ARGS=-e log.level=3
 EXPECT=<<EOF
 EOF
 EXPECT_ERR=<<EOF

--- a/test/db/tools/rz_test
+++ b/test/db/tools/rz_test
@@ -36,7 +36,7 @@ RUN
 NAME=bin with space in filename
 FILE=bins/elf/_Exit (42)
 CMDS=i~^file
-ARGS=-e log.level=4
+ARGS=-e log.level=3
 EXPECT=<<EOF
 file     bins/elf/_Exit (42)
 EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- Removes almost all the globals from the logging api
- Logging C API are now `thread-safe`.
- Implements colored logs and more.
- `RZ_LOG_SILLY` has been removed.
- Should be a bit faster since `fprintf` has been converted to `fputs`.
- Renamed `log.traplevel` to `log.abortlevel` and hide it in release builds.