### PR TITLE
Add rz_log and rz_core_notify functions usable with not-formatted strings.

### DIFF
--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -106,15 +106,15 @@ RZ_API void rz_core_notify_error(RZ_NONNULL RzCore *core, RZ_NONNULL const char 
 	va_end(args);
 }
 
-RZ_API void rz_core_notify_begin_bind(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text) {
+RZ_API void rz_core_notify_begin_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text) {
 	rz_core_notify_begin(core, "%s", text);
 }
 
-RZ_API void rz_core_notify_done_bind(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text) {
+RZ_API void rz_core_notify_done_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text) {
 	rz_core_notify_done(core, "%s", text);
 }
 
-RZ_API void rz_core_notify_error_bind(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text) {
+RZ_API void rz_core_notify_error_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text) {
 	rz_core_notify_error(core, "%s", text);
 }
 

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -106,6 +106,18 @@ RZ_API void rz_core_notify_error(RZ_NONNULL RzCore *core, RZ_NONNULL const char 
 	va_end(args);
 }
 
+RZ_API void rz_core_notify_begin_bind(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text) {
+	rz_core_notify_begin(core, "%s", text);
+}
+
+RZ_API void rz_core_notify_done_bind(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text) {
+	rz_core_notify_done(core, "%s", text);
+}
+
+RZ_API void rz_core_notify_error_bind(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text) {
+	rz_core_notify_error(core, "%s", text);
+}
+
 static int on_fcn_new(RzAnalysis *_analysis, void *_user, RzAnalysisFunction *fcn) {
 	RzCore *core = (RzCore *)_user;
 	const char *cmd = rz_config_get(core->config, "cmd.fcn.new");

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -106,14 +106,32 @@ RZ_API void rz_core_notify_error(RZ_NONNULL RzCore *core, RZ_NONNULL const char 
 	va_end(args);
 }
 
+/**
+ * \brief  Prints a message definining the beginning of a task
+ *
+ * \param  core The RzCore to use
+ * \param  text The message to notify
+ */
 RZ_API void rz_core_notify_begin_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text) {
 	rz_core_notify_begin(core, "%s", text);
 }
 
+/**
+ * \brief  Prints a message definining the end of a task which succeeded
+ *
+ * \param  core The RzCore to use
+ * \param  text The message to notify
+ */
 RZ_API void rz_core_notify_done_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text) {
 	rz_core_notify_done(core, "%s", text);
 }
 
+/**
+ * \brief  Prints a message definining the end of a task which errored
+ *
+ * \param  core The RzCore to use
+ * \param  text The message to notify
+ */
 RZ_API void rz_core_notify_error_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text) {
 	rz_core_notify_error(core, "%s", text);
 }

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -398,6 +398,10 @@ RZ_API void rz_core_notify_begin(RZ_NONNULL RzCore *core, RZ_NONNULL const char 
 RZ_API void rz_core_notify_done(RZ_NONNULL RzCore *core, RZ_NONNULL const char *format, ...) RZ_PRINTF_CHECK(2, 3);
 RZ_API void rz_core_notify_error(RZ_NONNULL RzCore *core, RZ_NONNULL const char *format, ...) RZ_PRINTF_CHECK(2, 3);
 
+RZ_API void rz_core_notify_begin_bind(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
+RZ_API void rz_core_notify_done_bind(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
+RZ_API void rz_core_notify_error_bind(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
+
 /**
  * \brief APIs to handle Visual Gadgets
  */

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -398,9 +398,9 @@ RZ_API void rz_core_notify_begin(RZ_NONNULL RzCore *core, RZ_NONNULL const char 
 RZ_API void rz_core_notify_done(RZ_NONNULL RzCore *core, RZ_NONNULL const char *format, ...) RZ_PRINTF_CHECK(2, 3);
 RZ_API void rz_core_notify_error(RZ_NONNULL RzCore *core, RZ_NONNULL const char *format, ...) RZ_PRINTF_CHECK(2, 3);
 
-RZ_API void rz_core_notify_begin_bind(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
-RZ_API void rz_core_notify_done_bind(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
-RZ_API void rz_core_notify_error_bind(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
+RZ_API void rz_core_notify_begin_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
+RZ_API void rz_core_notify_done_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
+RZ_API void rz_core_notify_error_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
 
 /**
  * \brief APIs to handle Visual Gadgets

--- a/librz/include/rz_util/rz_log.h
+++ b/librz/include/rz_util/rz_log.h
@@ -84,7 +84,7 @@ RZ_API void rz_log(const char *funcname, const char *filename,
 RZ_API void rz_vlog(const char *funcname, const char *filename,
 	ut32 lineno, RzLogLevel level, const char *tag, const char *fmtstr, va_list args);
 
-RZ_API void rz_log_bind(const char *funcname, const char *filename,
+RZ_API void rz_log_str(const char *funcname, const char *filename,
 	ut32 lineno, RzLogLevel level, const char *tag, const char *msg);
 
 #ifdef __cplusplus

--- a/librz/include/rz_util/rz_log.h
+++ b/librz/include/rz_util/rz_log.h
@@ -84,6 +84,9 @@ RZ_API void rz_log(const char *funcname, const char *filename,
 RZ_API void rz_vlog(const char *funcname, const char *filename,
 	ut32 lineno, RzLogLevel level, const char *tag, const char *fmtstr, va_list args);
 
+RZ_API void rz_log_bind(const char *funcname, const char *filename,
+	ut32 lineno, RzLogLevel level, const char *tag, const char *msg);
+
 #ifdef __cplusplus
 }
 #endif

--- a/librz/util/log.c
+++ b/librz/util/log.c
@@ -272,3 +272,18 @@ RZ_API void rz_log(const char *funcname, const char *filename,
 	rz_vlog(funcname, filename, lineno, level, tag, fmtstr, args);
 	va_end(args);
 }
+
+/**
+ * \brief Logging function for plugins with no vargs support.
+ *
+ * \param funcname Contains the function name of the calling function
+ * \param filename Contains the filename that \p funcname is defined in
+ * \param lineno The line number that this log call is being made from in filename
+ * \param lvl Logging level for output
+ * \param tag An additional string placed after the log level.
+ * \param msg The log message.
+ */
+RZ_API void rz_log_bind(const char *funcname, const char *filename,
+	ut32 lineno, RzLogLevel level, const char *tag, const char *msg) {
+	rz_log(funcname, filename, lineno, level, tag, "%s", msg);
+}

--- a/librz/util/log.c
+++ b/librz/util/log.c
@@ -284,7 +284,7 @@ RZ_API void rz_log(const char *funcname, const char *filename,
  * \param tag A string placed at the beginning of the log message. If NULL, the log level is used.
  * \param msg The log message.
  */
-RZ_API void rz_log_bind(const char *funcname, const char *filename,
+RZ_API void rz_log_str(const char *funcname, const char *filename,
 	ut32 lineno, RzLogLevel level, const char *tag, const char *msg) {
 	rz_log(funcname, filename, lineno, level, tag, "%s", msg);
 }

--- a/librz/util/log.c
+++ b/librz/util/log.c
@@ -260,7 +260,7 @@ RZ_API void rz_vlog(const char *funcname, const char *filename,
  * \param filename Contains the filename that funcname is defined in
  * \param lineno The line number that this log call is being made from in filename
  * \param lvl Logging level for output
- * \param tag A string placed at the beginning of the log message. If NULL, the log level is used.
+ * \param tag A string placed at the beginning of the log message. If NULL, the log level is printed.
  * \param fmtstr A printf like string
 
   This function is used by the RZ_LOG_* preprocessor macros for logging
@@ -275,13 +275,13 @@ RZ_API void rz_log(const char *funcname, const char *filename,
 }
 
 /**
- * \brief Logging function for plugins with no vargs support.
+ * \brief Logging function for simple strings.
  *
  * \param funcname Contains the function name of the calling function
  * \param filename Contains the filename that \p funcname is defined in
  * \param lineno The line number that this log call is being made from in filename
  * \param lvl Logging level for output
- * \param tag A string placed at the beginning of the log message. If NULL, the log level is used.
+ * \param tag A string placed at the beginning of the log message. If NULL, the log level is printed.
  * \param msg The log message.
  */
 RZ_API void rz_log_str(const char *funcname, const char *filename,

--- a/librz/util/log.c
+++ b/librz/util/log.c
@@ -260,6 +260,7 @@ RZ_API void rz_vlog(const char *funcname, const char *filename,
  * \param filename Contains the filename that funcname is defined in
  * \param lineno The line number that this log call is being made from in filename
  * \param lvl Logging level for output
+ * \param tag A string placed at the beginning of the log message. If NULL, the log level is used.
  * \param fmtstr A printf like string
 
   This function is used by the RZ_LOG_* preprocessor macros for logging
@@ -280,7 +281,7 @@ RZ_API void rz_log(const char *funcname, const char *filename,
  * \param filename Contains the filename that \p funcname is defined in
  * \param lineno The line number that this log call is being made from in filename
  * \param lvl Logging level for output
- * \param tag An additional string placed after the log level.
+ * \param tag A string placed at the beginning of the log message. If NULL, the log level is used.
  * \param msg The log message.
  */
 RZ_API void rz_log_bind(const char *funcname, const char *filename,

--- a/test/unit/test_log.c
+++ b/test/unit/test_log.c
@@ -10,6 +10,12 @@ static int small_check(const char *output, const char *funcname, const char *fil
 	return 0;
 }
 
+static int bind_check(const char *output, const char *funcname, const char *filename,
+	ut32 lineno, RzLogLevel level, const char *tag, const char *fmtstr, ...) {
+	mu_assert_streq(output, "ERROR: 3", "bind check msg should be correct");
+	return 0;
+}
+
 static int large_check(const char *output, const char *funcname, const char *filename,
 	ut32 lineno, RzLogLevel level, const char *tag, const char *fmtstr, ...) {
 	char *exp_msg = RZ_NEWS0(char, 2000);
@@ -24,13 +30,23 @@ static int large_check(const char *output, const char *funcname, const char *fil
 
 bool test_log_small(void) {
 	rz_log_del_callback((RzLogCallback)large_check);
+	rz_log_del_callback((RzLogCallback)bind_check);
 	rz_log_add_callback((RzLogCallback)small_check);
 	rz_log("func", "file", 1, RZ_LOGLVL_ERROR, NULL, "%d", 3);
 	mu_end;
 }
 
+bool test_log_binding(void) {
+	rz_log_del_callback((RzLogCallback)large_check);
+	rz_log_del_callback((RzLogCallback)small_check);
+	rz_log_add_callback((RzLogCallback)bind_check);
+	rz_log_bind("func", "file", 1, RZ_LOGLVL_ERROR, NULL, "3");
+	mu_end;
+}
+
 bool test_log_large(void) {
 	rz_log_del_callback((RzLogCallback)small_check);
+	rz_log_del_callback((RzLogCallback)bind_check);
 	rz_log_add_callback((RzLogCallback)large_check);
 	char *buf = RZ_NEWS(char, 1000);
 	memset(buf, 0x41, 999);
@@ -42,6 +58,7 @@ bool test_log_large(void) {
 
 bool all_tests() {
 	mu_run_test(test_log_small);
+	mu_run_test(test_log_binding);
 	mu_run_test(test_log_large);
 	return tests_passed != tests_run;
 }

--- a/test/unit/test_log.c
+++ b/test/unit/test_log.c
@@ -40,7 +40,7 @@ bool test_log_binding(void) {
 	rz_log_del_callback((RzLogCallback)large_check);
 	rz_log_del_callback((RzLogCallback)small_check);
 	rz_log_add_callback((RzLogCallback)bind_check);
-	rz_log_bind("func", "file", 1, RZ_LOGLVL_ERROR, NULL, "3");
+	rz_log_str("func", "file", 1, RZ_LOGLVL_ERROR, NULL, "3");
 	mu_end;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Adds functions which allow to use `rz_log()` and `rz_core_notify_...()` with simple strings (no `printf` like formatting).

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Added

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
