### PR TITLE
Unify shell assignment

### DIFF
--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -365,45 +365,43 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_highlight_remove_current_handler(RzCore *co
 }
 
 RZ_IPI RzCmdStatus rz_eval_getset_handler(RzCore *core, int argc, const char **argv) {
-	int i;
-	for (i = 1; i < argc; i++) {
-		RzList *l = rz_str_split_duplist_n(argv[i], "=", 1, false);
-		if (!l) {
-			return RZ_CMD_STATUS_ERROR;
-		}
-		size_t llen = rz_list_length(l);
-		if (!llen) {
-			return RZ_CMD_STATUS_ERROR;
-		}
-		char *key = rz_list_get_n(l, 0);
-		if (RZ_STR_ISEMPTY(key)) {
-			RZ_LOG_ERROR("core: No string specified before `=`. Make sure to use the format <key>=<value> without spaces.\n");
-			rz_list_free(l);
-			continue;
-		}
-
-		if (llen == 1 && rz_str_endswith(key, ".")) {
-			// no value was set, only key with ".". List possible sub-keys.
-			RzCmdStateOutput state = { 0 };
-			rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_QUIET);
-			rz_core_config_print_all(core->config, key, &state);
-			rz_cmd_state_output_print(&state);
-			rz_cmd_state_output_fini(&state);
-		} else if (llen == 1) {
-			// no value was set, show the value of the key
-			const char *v = rz_config_get(core->config, key);
-			if (!v) {
-				RZ_LOG_ERROR("core: Invalid config key '%s'\n", key);
-				rz_list_free(l);
-				return RZ_CMD_STATUS_ERROR;
-			}
-			rz_cons_printf("%s\n", v);
-		} else if (llen == 2) {
-			char *value = rz_list_get_n(l, 1);
-			rz_config_set(core->config, key, value);
-		}
-		rz_list_free(l);
+	RzList *l = rz_str_split_duplist_n(argv[1], "=", 1, true);
+	if (!l) {
+		return RZ_CMD_STATUS_ERROR;
 	}
+	size_t llen = rz_list_length(l);
+	if (!llen) {
+		rz_list_free(l);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	char *key = rz_list_get_n(l, 0);
+	if (RZ_STR_ISEMPTY(key)) {
+		RZ_LOG_ERROR("core: No string specified before `=`. Make sure to use the format <key>=<value>.\n");
+		rz_list_free(l);
+		return RZ_CMD_STATUS_ERROR;
+	}
+
+	if (llen == 1 && rz_str_endswith(key, ".")) {
+		// no value was set, only key with ".". List possible sub-keys.
+		RzCmdStateOutput state = { 0 };
+		rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_QUIET);
+		rz_core_config_print_all(core->config, key, &state);
+		rz_cmd_state_output_print(&state);
+		rz_cmd_state_output_fini(&state);
+	} else if (llen == 1) {
+		// no value was set, show the value of the key
+		const char *v = rz_config_get(core->config, key);
+		if (!v) {
+			RZ_LOG_ERROR("core: Invalid config key '%s'\n", key);
+			rz_list_free(l);
+			return RZ_CMD_STATUS_ERROR;
+		}
+		rz_cons_printf("%s\n", v);
+	} else if (llen == 2) {
+		char *value = rz_list_get_n(l, 1);
+		rz_config_set(core->config, key, value);
+	}
+	rz_list_free(l);
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/core/cmd_descs/cmd_analysis.yaml
+++ b/librz/core/cmd_descs/cmd_analysis.yaml
@@ -992,6 +992,7 @@ commands:
             type: RZ_CMD_ARG_TYPE_RZNUM
       - name: aezv
         summary: Print or modify the current status of the RzIL Virtual Machine
+        args_str: " [<var_name> [= <val>]]"
         cname: il_vm_status
         type: RZ_CMD_DESC_TYPE_ARGV_MODES
         modes:
@@ -1000,11 +1001,9 @@ commands:
           - RZ_OUTPUT_MODE_JSON
           - RZ_OUTPUT_MODE_QUIET
         args:
-          - name: var_name
-            type: RZ_CMD_ARG_TYPE_STRING
-            optional: true
-          - name: number
-            type: RZ_CMD_ARG_TYPE_RZNUM
+          - name: var_name=value
+            type: RZ_CMD_ARG_TYPE_EVAL_FULL
+            flags: RZ_CMD_ARG_FLAG_LAST
             optional: true
   - name: ag
     summary: Analysis graph commands

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -213,7 +213,7 @@ static const RzCmdDescArg il_step_until_opt_args[2];
 static const RzCmdDescArg il_vm_step_args[2];
 static const RzCmdDescArg il_vm_step_with_events_args[2];
 static const RzCmdDescArg il_vm_step_until_addr_args[2];
-static const RzCmdDescArg il_vm_status_args[3];
+static const RzCmdDescArg il_vm_status_args[2];
 static const RzCmdDescArg analysis_graph_dataref_args[2];
 static const RzCmdDescArg analysis_graph_dataref_global_args[2];
 static const RzCmdDescArg analysis_graph_callgraph_function_args[2];
@@ -4048,14 +4048,8 @@ static const RzCmdDescHelp il_vm_step_until_addr_help = {
 
 static const RzCmdDescArg il_vm_status_args[] = {
 	{
-		.name = "var_name",
+		.name = "var_name=value",
 		.type = RZ_CMD_ARG_TYPE_STRING,
-		.optional = true,
-
-	},
-	{
-		.name = "number",
-		.type = RZ_CMD_ARG_TYPE_RZNUM,
 		.flags = RZ_CMD_ARG_FLAG_LAST,
 		.optional = true,
 
@@ -4064,6 +4058,7 @@ static const RzCmdDescArg il_vm_status_args[] = {
 };
 static const RzCmdDescHelp il_vm_status_help = {
 	.summary = "Print or modify the current status of the RzIL Virtual Machine",
+	.args_str = " [<var_name> [= <val>]]",
 	.args = il_vm_status_args,
 };
 

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -9946,14 +9946,14 @@ static const RzCmdDescArg eval_getset_args[] = {
 	{
 		.name = "key=value",
 		.type = RZ_CMD_ARG_TYPE_EVAL_FULL,
-		.flags = RZ_CMD_ARG_FLAG_ARRAY,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
 
 	},
 	{ 0 },
 };
 static const RzCmdDescHelp eval_getset_help = {
 	.summary = "Get/Set value of config variable <key>",
-	.args_str = " <key>[=<val|?>] [<key>[=<val|?>] ...]]",
+	.args_str = " <key> [= <val|?>]",
 	.details = eval_getset_details,
 	.args = eval_getset_args,
 };

--- a/librz/core/cmd_descs/cmd_eval.yaml
+++ b/librz/core/cmd_descs/cmd_eval.yaml
@@ -6,11 +6,11 @@ commands:
   - name: e
     cname: eval_getset
     summary: Get/Set value of config variable <key>
-    args_str: " <key>[=<val|?>] [<key>[=<val|?>] ...]]"
+    args_str: " <key> [= <val|?>]"
     args:
       - name: key=value
         type: RZ_CMD_ARG_TYPE_EVAL_FULL
-        flags: RZ_CMD_ARG_FLAG_ARRAY
+        flags: RZ_CMD_ARG_FLAG_LAST
     details:
       - name: Examples
         entries:

--- a/test/db/archos/linux-x64/dbg_bps
+++ b/test/db/archos/linux-x64/dbg_bps
@@ -264,7 +264,15 @@ NAME=read core->block on short move
 FILE=bins/elf/analysis/x64-loop
 ARGS=-d
 CMDS=<<EOF
-e scr.color=0 asm.offset=false asm.flags=false asm.functions=false asm.lines=false asm.fcn.size=false asm.comments=false asm.debuginfo=false asm.indent=false
+e scr.color=0
+e asm.offset=false
+e asm.flags=false
+e asm.functions=false
+e asm.lines=false
+e asm.fcn.size=false
+e asm.comments=false
+e asm.debuginfo=false
+e asm.indent=false
 dcu main
 pd 5
 dbH @i:2

--- a/test/db/cmd/cmd_aez
+++ b/test/db/cmd/cmd_aez
@@ -93,10 +93,10 @@ s 0
 aezi
 aezv
 echo --
-aezv PC 0x42
+aezv PC=0x42
 aezv
 echo --
-aezv ptr 0xc0ffee
+aezv ptr=0xc0ffee
 aezv
 EOF
 EXPECT=<<EOF

--- a/test/db/cmd/cmd_help
+++ b/test/db/cmd/cmd_help
@@ -154,16 +154,16 @@ Detailed help for w <string> is provided by w??.
 ----
 
 Usage: e[?]   # List/get/set config evaluable vars
-| e <key>[=<val|?>] [<key>[=<val|?>] ...]] # Get/Set value of config variable <key>
-| el[j*qlJ] [<key>]      # List config variables with their descriptions
-| e-                     # Reset config variables
-| e! <key>               # Invert the boolean value of config variable <key>
-| ec[?]                  # Set color for given key (prompt, offset, ...)
-| ee <key>               # Open editor to change the value of config variable <key>
-| er <key>               # Set config variable <key> as read-only
-| es [<key>]             # List all config variable spaces or sub-keys/sub-spaces if a <key> is provided
-| et <key>               # Show type of given config variable <key>
+| e <key> [= <val|?>] # Get/Set value of config variable <key>
+| el[j*qlJ] [<key>]   # List config variables with their descriptions
+| e-                  # Reset config variables
+| e! <key>            # Invert the boolean value of config variable <key>
+| ec[?]               # Set color for given key (prompt, offset, ...)
+| ee <key>            # Open editor to change the value of config variable <key>
+| er <key>            # Set config variable <key> as read-only
+| es [<key>]          # List all config variable spaces or sub-keys/sub-spaces if a <key> is provided
+| et <key>            # Show type of given config variable <key>
 
-Detailed help for e <key>[=<val|?>] [<key>[=<val|?>] ...]] is provided by e??.
+Detailed help for e <key> [= <val|?>] is provided by e??.
 EOF
 RUN

--- a/test/db/rzil/tricore
+++ b/test/db/rzil/tricore
@@ -6,7 +6,7 @@ e io.cache=1
 aaa
 s main
 aezi
-aezv FCX 0x1
+aezv FCX=0x1
 aezsu 0x8000052e
 ps @ obj.seckrit
 EOF


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This change is in response to (#2129) and changes the behavior of the the `e` and `aezv` commands to match the existing assignment behavior of the `ar` & `dr` commands. 

The changes related to `e`:
 * Old behavior was `e k=v k=v ...` allowing multiple assignments and no spaces around the '=' character.
 * New behavior is `e k = v` or `e k=v`.
 * `e` command description updated to new help message and arguments.
 * `e` command handler updated to new argument format.
 * Updated a test using `e`'s help message to reflect the new output.

The changes to `aezv`:
* Old behavior was `aezv k v` with two args for assignment, and no '=' character.
* New behavior is `aezv k = v` or `aezv k=v`, and functionality of `aezv k` is preserved.
* `aezv` command description updated to new help message and arguments.
* `aezv` command handler updated to new argument format.
* Updated a couple tests using `aezv` for assignment to have the '=' character.

The rational for selecting the `ar`/`dr` assignment form over the `e` form (as discussed in #2129) is that multiple assignments of config variables can still be accomplished in a single line via `e k=v; e k=v` as well as the alias and macro features. In addition, the `aezv`, `ar`, and `dr` commands support other operations than just assignment so something like `ar rax=0x1 xmm PC` could be valid, but is not as intuitive. Finally, allowing spaces around the '=' makes the shell a bit less picky.

This PR does not address the assignment used by `$` to assign aliases. To do so would require additional clarification as `$` also supports `:=`, `-=` and `+=` for various features.
...

**Test plan**

Testing involves ensuring correct functionality of the `e` and `aezv` commands.

```
user@f77bf859cbe9:~/host/rizin$ rizin /bin/ls
 -- Use 'rz-bin -ris' to get the import/export symbols of any binary.
[0x000061d0]> e asm.lines
true
[0x000061d0]> e asm.lines = false
[0x000061d0]> e asm.lines
false
[0x000061d0]> e asm.lines=true
[0x000061d0]> e asm.lines
true
[0x000061d0]> e asm.lines = AAAAAAAaAA   aAAAAAAAAAAAAAA AAAAAAa
[0x000061d0]> e asm.lines
false
[0x000061d0]> e asm.lines = AAAAAAAaAA   aAAAAAAAAAAAAAA AAAAAAa
[0x000061d0]> e asm.lines
false
[0x000061d0]> e log.file=/dev/null log.level=5
[0x000061d0]> e log.file
/dev/null log.level=5
[0x000061d0]> aezi
[0x000061d0]> aezv
 PC: 0x00000000000061d0 cr0: 0x0000000000000000 fs: 0x0000000000000000 frip: 0x0000000000000000 rsp: 0x0000000000000000
 rbx: 0x0000000000000000 rdx: 0x0000000000000000 ftw: 0x0000 ss: 0x0000000000000000 af: false swd: 0x0000
 frdp: 0x0000000000000000 ac: false zf: false es: 0x0000000000000000 rdi: 0x0000000000000000 sf: false
 r14: 0x0000000000000000 r15: 0x0000000000000000 cf: false r12: 0x0000000000000000 r13: 0x0000000000000000
 r10: 0x0000000000000000 r11: 0x0000000000000000 tf: false dr0: 0x0000000000000000 gs: 0x0000000000000000
 fop: 0x0000 df: false nt: false rcx: 0x0000000000000000 pf: false if: false r9: 0x0000000000000000
 r8: 0x0000000000000000 ds: 0x0000000000000000 cs: 0x0000000000000000 st2: 0x00000000000000000000
 of: false cwd: 0x0000 st3: 0x00000000000000000000 st0: 0x00000000000000000000 rf: false st1: 0x00000000000000000000
 st6: 0x00000000000000000000 rax: 0x0000000000000000 st7: 0x00000000000000000000 vm: false st4: 0x00000000000000000000
 st5: 0x00000000000000000000 rsi: 0x0000000000000000 rbp: 0x0000000000000000
[0x000061d0]> aezv rbx
 rbx: 0x0000000000000000
[0x000061d0]> aezv rbx=0xffff
rbx = 0xffff
[0x000061d0]> aezv rbx
 rbx: 0x000000000000ffff
[0x000061d0]> aezv rbx = 0xffff0000
rbx = 0xffff0000
[0x000061d0]> aezv rbx
 rbx: 0x00000000ffff0000
[0x000061d0]> aezv rbx = rbx = rbx = PC
rbx = 0x61d0
[0x000061d0]> aezv
 PC: 0x00000000000061d0 cr0: 0x0000000000000000 fs: 0x0000000000000000 frip: 0x0000000000000000 rsp: 0x0000000000000000
 rbx: 0x00000000000061d0 rdx: 0x0000000000000000 ftw: 0x0000 ss: 0x0000000000000000 af: false swd: 0x0000
 frdp: 0x0000000000000000 ac: false zf: false es: 0x0000000000000000 rdi: 0x0000000000000000 sf: false
 r14: 0x0000000000000000 r15: 0x0000000000000000 cf: false r12: 0x0000000000000000 r13: 0x0000000000000000
 r10: 0x0000000000000000 r11: 0x0000000000000000 tf: false dr0: 0x0000000000000000 gs: 0x0000000000000000
 fop: 0x0000 df: false nt: false rcx: 0x0000000000000000 pf: false if: false r9: 0x0000000000000000
 r8: 0x0000000000000000 ds: 0x0000000000000000 cs: 0x0000000000000000 st2: 0x00000000000000000000
 of: false cwd: 0x0000 st3: 0x00000000000000000000 st0: 0x00000000000000000000 rf: false st1: 0x00000000000000000000
 st6: 0x00000000000000000000 rax: 0x0000000000000000 st7: 0x00000000000000000000 vm: false st4: 0x00000000000000000000
 st5: 0x00000000000000000000 rsi: 0x0000000000000000 rbp: 0x0000000000000000
[0x000061d0]> aezv rbx = PC = 0x0
rbx = 0x0
[0x000061d0]> aezv
 PC: 0x00000000000061d0 cr0: 0x0000000000000000 fs: 0x0000000000000000 frip: 0x0000000000000000 rsp: 0x0000000000000000
 rbx: 0x0000000000000000 rdx: 0x0000000000000000 ftw: 0x0000 ss: 0x0000000000000000 af: false swd: 0x0000
 frdp: 0x0000000000000000 ac: false zf: false es: 0x0000000000000000 rdi: 0x0000000000000000 sf: false
 r14: 0x0000000000000000 r15: 0x0000000000000000 cf: false r12: 0x0000000000000000 r13: 0x0000000000000000
 r10: 0x0000000000000000 r11: 0x0000000000000000 tf: false dr0: 0x0000000000000000 gs: 0x0000000000000000
 fop: 0x0000 df: false nt: false rcx: 0x0000000000000000 pf: false if: false r9: 0x0000000000000000
 r8: 0x0000000000000000 ds: 0x0000000000000000 cs: 0x0000000000000000 st2: 0x00000000000000000000
 of: false cwd: 0x0000 st3: 0x00000000000000000000 st0: 0x00000000000000000000 rf: false st1: 0x00000000000000000000
 st6: 0x00000000000000000000 rax: 0x0000000000000000 st7: 0x00000000000000000000 vm: false st4: 0x00000000000000000000
 st5: 0x00000000000000000000 rsi: 0x0000000000000000 rbp: 0x0000000000000000
```

...

**Closing issues**

Partially closes #2129 

...
