### PR TITLE
Fix heap buffer over-read in pal.c

### DIFF
--- a/librz/cons/pal.c
+++ b/librz/cons/pal.c
@@ -290,7 +290,7 @@ RZ_API char *rz_cons_pal_parse(const char *str, RzColor *outcol) {
 	char *bgcolor;
 	char *attr = NULL;
 	char out[128];
-	if (!str || RZ_STR_ISEMPTY(str)) {
+	if (RZ_STR_ISEMPTY(str)) {
 		return NULL;
 	}
 	fgcolor = strdup(str);

--- a/librz/cons/pal.c
+++ b/librz/cons/pal.c
@@ -290,7 +290,7 @@ RZ_API char *rz_cons_pal_parse(const char *str, RzColor *outcol) {
 	char *bgcolor;
 	char *attr = NULL;
 	char out[128];
-	if (!str) {
+	if (!str || RZ_STR_ISEMPTY(str)) {
 		return NULL;
 	}
 	fgcolor = strdup(str);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

OOB read is happened here in case of empty string:
https://github.com/rizinorg/rizin/blob/652591f8262d06276133a53c5ec15329f27745de/librz/cons/pal.c#L300
