### PR TITLE
RzIL: add unit-tests for float cmp helpers

### DIFF
--- a/test/unit/test_il_helpers.c
+++ b/test/unit/test_il_helpers.c
@@ -25,6 +25,8 @@ static bool test_il_extract32() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x01234567, "extract32(0x01234567, 0, 32) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	// Extract none
 	val = rz_il_op_new_bitv_from_ut64(32, 0x01234567);
@@ -36,6 +38,8 @@ static bool test_il_extract32() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x0, "extract32(0x01234567, 0, 0) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	// Extract within
 	val = rz_il_op_new_bitv_from_ut64(32, 0x01234567);
@@ -47,6 +51,11 @@ static bool test_il_extract32() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x16, "extract32(0x01234567, 4, 5) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	rz_il_vm_free(vm);
+	rz_il_validate_global_context_free(ctx);
 
 	mu_end;
 }
@@ -69,6 +78,8 @@ static bool test_il_extract64() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x0123456789abcdef, "extract64(0x0123456789abcdef, 0, 64) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	// Extract none
 	val = rz_il_op_new_bitv_from_ut64(64, 0x0123456789abcdef);
@@ -80,6 +91,8 @@ static bool test_il_extract64() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x0, "extract64(0x0123456789abcdef, 0, 0) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	// Extract within
 	val = rz_il_op_new_bitv_from_ut64(64, 0x0123456789abcdef);
@@ -91,6 +104,11 @@ static bool test_il_extract64() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x1e, "extract64(0x0123456789abcdef, 4, 5) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	rz_il_vm_free(vm);
+	rz_il_validate_global_context_free(ctx);
 
 	mu_end;
 }
@@ -113,6 +131,8 @@ static bool test_il_sextract64() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x0123456789abcdef, "sextract64(0x0123456789abcdef, 0, 64) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	// Extract none
 	val = rz_il_op_new_bitv_from_ut64(64, 0x0123456789abcdef);
@@ -124,6 +144,8 @@ static bool test_il_sextract64() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x0, "sextract64(0x0123456789abcdef, 0, 0) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	// Extract within
 	val = rz_il_op_new_bitv_from_ut64(64, 0x0123456789abcdef);
@@ -135,6 +157,11 @@ static bool test_il_sextract64() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0xfffffffffffffff8, "extract64(0x0123456789abcdef, 28, 4) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	rz_il_vm_free(vm);
+	rz_il_validate_global_context_free(ctx);
 
 	mu_end;
 }
@@ -158,6 +185,8 @@ static bool test_il_deposit32() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0xffffffff, "deposit32(0x00000000, 0, 32, 0xffffffff) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	// Deposit none
 	val = rz_il_op_new_bitv_from_ut64(32, 0x00000000);
@@ -170,6 +199,8 @@ static bool test_il_deposit32() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x0, "deposit32(0x00000000, 0, 0, 0xffffffff) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	// Deposit within
 	val = rz_il_op_new_bitv_from_ut64(32, 0xffffffff);
@@ -182,6 +213,8 @@ static bool test_il_deposit32() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0xffff80ff, "deposit32(0xffffffff, 8, 7, 0xffff80ff) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	// Deposit no wrap around
 	val = rz_il_op_new_bitv_from_ut64(32, 0xffffffff);
@@ -194,6 +227,11 @@ static bool test_il_deposit32() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x3fffffff, "deposit32(0xffffffff, 30, 9, 0x0) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	rz_il_vm_free(vm);
+	rz_il_validate_global_context_free(ctx);
 
 	mu_end;
 }
@@ -217,6 +255,8 @@ static bool test_il_deposit64() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0xffffffffffffffff, "deposit64(0x00000000, 0, 64, 0xffffffffffffffff) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	// Deposit none
 	val = rz_il_op_new_bitv_from_ut64(64, 0x0);
@@ -229,6 +269,8 @@ static bool test_il_deposit64() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x0, "deposit64(0x00000000, 0, 0, 0xffffffffffffffff) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	// Deposit within
 	val = rz_il_op_new_bitv_from_ut64(64, 0xffffffffffffffff);
@@ -241,6 +283,8 @@ static bool test_il_deposit64() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0xffffffffffff80ff, "deposit64(0xffffffffffffffff, 8, 7, 0xffff80ff) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	// Deposit no wrap around
 	val = rz_il_op_new_bitv_from_ut64(64, 0xffffffffffffffff);
@@ -253,6 +297,11 @@ static bool test_il_deposit64() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x3fffffffffffffff, "deposit64(0xffffffffffffffff, 62, 9, 0x0) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	rz_il_vm_free(vm);
+	rz_il_validate_global_context_free(ctx);
 
 	mu_end;
 }
@@ -273,6 +322,11 @@ static bool test_il_bswap16() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x2301, "bswap16(0x0123) resulting value mismatch.");
+	rz_il_vm_free(vm);
+	rz_il_op_pure_free(result);
+
+	rz_il_validate_global_context_free(ctx);
+	rz_il_value_free(vm_result);
 
 	mu_end;
 }
@@ -293,6 +347,11 @@ static bool test_il_bswap32() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x67452301, "bswap32(0x01234567) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	rz_il_vm_free(vm);
+	rz_il_validate_global_context_free(ctx);
 
 	mu_end;
 }
@@ -313,6 +372,323 @@ static bool test_il_bswap64() {
 	mu_assert_true(valid, "invalid pure");
 	vm_result = rz_il_evaluate_val(vm, result);
 	mu_assert_eq(vm_result->data.bv->bits.small_u, 0xefcdab8967452301, "bswap64(0x0123456789abcdef) resulting value mismatch.");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	rz_il_vm_free(vm);
+	rz_il_validate_global_context_free(ctx);
+
+	mu_end;
+}
+
+static bool test_il_fneq() {
+	RzILVM *vm = rz_il_vm_new(0, 64, false);
+	RzILBool *vm_result = NULL;
+	RzILOpBool *result = NULL;
+
+	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.13371));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.1337 != 0.13371");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(0.13371), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.13371 != 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.1337 != 0.13371L");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.13371L != 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	// result = rz_il_op_new_fneq(rz_il_op_new_float_from_f64(0.1337L), rz_il_op_new_float_from_f32(0.1337));
+	// vm_result = rz_il_evaluate_bool(vm, result);
+	// mu_assert_false(vm_result->b, "0.1337L != 0.1337");
+	// rz_il_bool_free(vm_result);
+	// rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337 != 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f64(0.13371L));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337L != 0.1337L");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	rz_il_vm_free(vm);
+
+	mu_end;
+}
+
+static bool test_il_feq() {
+	RzILVM *vm = rz_il_vm_new(0, 64, false);
+	RzILBool *vm_result = NULL;
+	RzILOpBool *result = NULL;
+
+	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.13371));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337 == 0.13371");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(0.13371), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.13371 == 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337 == 0.13371L");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_feq(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.13371L == 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	// result = rz_il_op_new_feq(rz_il_op_new_float_from_f64(0.1337), rz_il_op_new_float_from_f32(0.1337));
+	// vm_result = rz_il_evaluate_bool(vm, result);
+	// mu_assert_true(vm_result->b, "0.1337L == 0.1337");
+	// rz_il_bool_free(vm_result);
+	// rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.1337 == 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_feq(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f64(0.13371L));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.1337L == 0.1337L");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	rz_il_vm_free(vm);
+
+	mu_end;
+}
+
+static bool test_il_flt() {
+	RzILVM *vm = rz_il_vm_new(0, 64, false);
+	RzILBool *vm_result = NULL;
+	RzILOpBool *result = NULL;
+
+	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.13371));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.1337 < 0.13371");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(0.13371), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.13371 < 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	// result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
+	// vm_result = rz_il_evaluate_bool(vm, result);
+	// mu_assert_true(vm_result->b, "0.1337 < 0.13371L");
+	// rz_il_bool_free(vm_result);
+	// rz_il_op_pure_free(result);
+
+	// result = rz_il_op_new_flt(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f32(0.1337));
+	// vm_result = rz_il_evaluate_bool(vm, result);
+	// mu_assert_false(vm_result->b, "0.13371L < 0.1337");
+	// rz_il_bool_free(vm_result);
+	// rz_il_op_pure_free(result);
+
+	// result = rz_il_op_new_flt(rz_il_op_new_float_from_f64(0.1337), rz_il_op_new_float_from_f32(0.1337));
+	// vm_result = rz_il_evaluate_bool(vm, result);
+	// mu_assert_false(vm_result->b, "0.1337L < 0.1337");
+	// rz_il_bool_free(vm_result);
+	// rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337 < 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_flt(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f64(0.13371L));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337L < 0.1337L");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	rz_il_vm_free(vm);
+
+	mu_end;
+}
+
+static bool test_il_fle() {
+	RzILVM *vm = rz_il_vm_new(0, 64, false);
+	RzILBool *vm_result = NULL;
+	RzILOpBool *result = NULL;
+
+	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.13371));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.1337 <= 0.13371");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(0.13371), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.13371 <= 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	// result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
+	// vm_result = rz_il_evaluate_bool(vm, result);
+	// mu_assert_true(vm_result->b, "0.1337 <= 0.13371L");
+	// rz_il_bool_free(vm_result);
+	// rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fle(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.13371L <= 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	// result = rz_il_op_new_fle(rz_il_op_new_float_from_f64(0.1337), rz_il_op_new_float_from_f32(0.1337));
+	// vm_result = rz_il_evaluate_bool(vm, result);
+	// mu_assert_false(vm_result->b, "0.1337L <= 0.1337");
+	// rz_il_bool_free(vm_result);
+	// rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.1337 <= 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fle(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f64(0.13371L));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.1337L <= 0.1337L");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	rz_il_vm_free(vm);
+
+	mu_end;
+}
+
+static bool test_il_fgt() {
+	RzILVM *vm = rz_il_vm_new(0, 64, false);
+	RzILBool *vm_result = NULL;
+	RzILOpBool *result = NULL;
+
+	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.13371));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337 > 0.13371");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(0.13371), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.13371 > 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	// result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
+	// vm_result = rz_il_evaluate_bool(vm, result);
+	// mu_assert_false(vm_result->b, "0.1337 > 0.13371L");
+	// rz_il_bool_free(vm_result);
+	// rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.13371L > 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	// result = rz_il_op_new_fgt(rz_il_op_new_float_from_f64(0.1337), rz_il_op_new_float_from_f32(0.1337));
+	// vm_result = rz_il_evaluate_bool(vm, result);
+	// mu_assert_false(vm_result->b, "0.1337L > 0.1337");
+	// rz_il_bool_free(vm_result);
+	// rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337 > 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f64(0.13371L));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337L > 0.1337L");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	rz_il_vm_free(vm);
+
+	mu_end;
+}
+
+static bool test_il_fge() {
+	RzILVM *vm = rz_il_vm_new(0, 64, false);
+	RzILBool *vm_result = NULL;
+	RzILOpBool *result = NULL;
+
+	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.13371));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337 >= 0.13371");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(0.13371), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.13371 >= 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	// result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
+	// vm_result = rz_il_evaluate_bool(vm, result);
+	// mu_assert_false(vm_result->b, "0.1337 >= 0.13371L");
+	// rz_il_bool_free(vm_result);
+	// rz_il_op_pure_free(result);
+
+	// result = rz_il_op_new_fge(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f32(0.1337));
+	// vm_result = rz_il_evaluate_bool(vm, result);
+	// mu_assert_true(vm_result->b, "0.13371L >= 0.1337");
+	// rz_il_bool_free(vm_result);
+	// rz_il_op_pure_free(result);
+
+	// result = rz_il_op_new_fge(rz_il_op_new_float_from_f64(0.1337), rz_il_op_new_float_from_f32(0.1337));
+	// vm_result = rz_il_evaluate_bool(vm, result);
+	// mu_assert_true(vm_result->b, "0.1337L >= 0.1337");
+	// rz_il_bool_free(vm_result);
+	// rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.1337 >= 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fge(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f64(0.13371L));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.1337L >= 0.1337L");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	rz_il_vm_free(vm);
 
 	mu_end;
 }
@@ -326,6 +702,12 @@ bool all_tests() {
 	mu_run_test(test_il_bswap16);
 	mu_run_test(test_il_bswap32);
 	mu_run_test(test_il_bswap64);
+	mu_run_test(test_il_fneq);
+	mu_run_test(test_il_feq);
+	mu_run_test(test_il_flt);
+	mu_run_test(test_il_fle);
+	mu_run_test(test_il_fgt);
+	mu_run_test(test_il_fge);
 
 	return tests_passed != tests_run;
 }

--- a/test/unit/test_il_helpers.c
+++ b/test/unit/test_il_helpers.c
@@ -386,45 +386,45 @@ static bool test_il_fneq() {
 	RzILBool *vm_result = NULL;
 	RzILOpBool *result = NULL;
 
-	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.13371));
+	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337001));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_true(vm_result->b, "0.1337 != 0.13371");
+	mu_assert_true(vm_result->b, "0.1337 != 0.1337001");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(0.13371), rz_il_op_new_float_from_f32(0.1337));
+	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(0.1337001), rz_il_op_new_float_from_f32(0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_true(vm_result->b, "0.13371 != 0.1337");
+	mu_assert_true(vm_result->b, "0.1337001 != 0.1337");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
+	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(-0.1337001), rz_il_op_new_float_from_f32(-0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_true(vm_result->b, "0.1337 != 0.13371L");
+	mu_assert_true(vm_result->b, "-0.1337001 != -0.1337");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f32(0.1337));
+	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(-0.1337001));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_true(vm_result->b, "0.13371L != 0.1337");
+	mu_assert_true(vm_result->b, "-0.1337 != -0.1337001");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	// result = rz_il_op_new_fneq(rz_il_op_new_float_from_f64(0.1337L), rz_il_op_new_float_from_f32(0.1337));
-	// vm_result = rz_il_evaluate_bool(vm, result);
-	// mu_assert_false(vm_result->b, "0.1337L != 0.1337");
-	// rz_il_bool_free(vm_result);
-	// rz_il_op_pure_free(result);
+	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "-0.1337 != 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(-0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "-0.1337 != -0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
 	mu_assert_false(vm_result->b, "0.1337 != 0.1337");
-	rz_il_bool_free(vm_result);
-	rz_il_op_pure_free(result);
-
-	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f64(0.13371L));
-	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_false(vm_result->b, "0.1337L != 0.1337L");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
@@ -438,45 +438,45 @@ static bool test_il_feq() {
 	RzILBool *vm_result = NULL;
 	RzILOpBool *result = NULL;
 
-	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.13371));
+	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337001));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_false(vm_result->b, "0.1337 == 0.13371");
+	mu_assert_false(vm_result->b, "0.1337 == 0.1337001");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(0.13371), rz_il_op_new_float_from_f32(0.1337));
+	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(0.1337001), rz_il_op_new_float_from_f32(0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_false(vm_result->b, "0.13371 == 0.1337");
+	mu_assert_false(vm_result->b, "0.1337001 == 0.1337");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
+	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(-0.1337001), rz_il_op_new_float_from_f32(-0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_false(vm_result->b, "0.1337 == 0.13371L");
+	mu_assert_false(vm_result->b, "-0.1337001 == -0.1337");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	result = rz_il_op_new_feq(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f32(0.1337));
+	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(-0.1337001));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_false(vm_result->b, "0.13371L == 0.1337");
+	mu_assert_false(vm_result->b, "-0.1337 == -0.1337001");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	// result = rz_il_op_new_feq(rz_il_op_new_float_from_f64(0.1337), rz_il_op_new_float_from_f32(0.1337));
-	// vm_result = rz_il_evaluate_bool(vm, result);
-	// mu_assert_true(vm_result->b, "0.1337L == 0.1337");
-	// rz_il_bool_free(vm_result);
-	// rz_il_op_pure_free(result);
+	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "-0.1337 == 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(-0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "-0.1337 == -0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
 	mu_assert_true(vm_result->b, "0.1337 == 0.1337");
-	rz_il_bool_free(vm_result);
-	rz_il_op_pure_free(result);
-
-	result = rz_il_op_new_feq(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f64(0.13371L));
-	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_true(vm_result->b, "0.1337L == 0.1337L");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
@@ -490,45 +490,45 @@ static bool test_il_flt() {
 	RzILBool *vm_result = NULL;
 	RzILOpBool *result = NULL;
 
-	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.13371));
+	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337001));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_true(vm_result->b, "0.1337 < 0.13371");
+	mu_assert_true(vm_result->b, "0.1337 < 0.1337001");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(0.13371), rz_il_op_new_float_from_f32(0.1337));
+	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(0.1337001), rz_il_op_new_float_from_f32(0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_false(vm_result->b, "0.13371 < 0.1337");
+	mu_assert_false(vm_result->b, "0.1337001 < 0.1337");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
+	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(-0.1337001), rz_il_op_new_float_from_f32(-0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_true(vm_result->b, "0.1337 < 0.13371L");
+	mu_assert_true(vm_result->b, "-0.1337001 < -0.1337");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	// result = rz_il_op_new_flt(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f32(0.1337));
-	// vm_result = rz_il_evaluate_bool(vm, result);
-	// mu_assert_false(vm_result->b, "0.13371L < 0.1337");
-	// rz_il_bool_free(vm_result);
-	// rz_il_op_pure_free(result);
+	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(-0.1337001));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "-0.1337 < -0.1337001");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
 
-	// result = rz_il_op_new_flt(rz_il_op_new_float_from_f64(0.1337), rz_il_op_new_float_from_f32(0.1337));
-	// vm_result = rz_il_evaluate_bool(vm, result);
-	// mu_assert_false(vm_result->b, "0.1337L < 0.1337");
-	// rz_il_bool_free(vm_result);
-	// rz_il_op_pure_free(result);
+	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "-0.1337 < 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(-0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "-0.1337 < -0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
 	mu_assert_false(vm_result->b, "0.1337 < 0.1337");
-	rz_il_bool_free(vm_result);
-	rz_il_op_pure_free(result);
-
-	result = rz_il_op_new_flt(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f64(0.13371L));
-	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_false(vm_result->b, "0.1337L < 0.1337L");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
@@ -542,45 +542,45 @@ static bool test_il_fle() {
 	RzILBool *vm_result = NULL;
 	RzILOpBool *result = NULL;
 
-	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.13371));
+	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337001));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_true(vm_result->b, "0.1337 <= 0.13371");
+	mu_assert_true(vm_result->b, "0.1337 <= 0.1337001");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(0.13371), rz_il_op_new_float_from_f32(0.1337));
+	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(0.1337001), rz_il_op_new_float_from_f32(0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_false(vm_result->b, "0.13371 <= 0.1337");
+	mu_assert_false(vm_result->b, "0.1337001 <= 0.1337");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	// result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
-	// vm_result = rz_il_evaluate_bool(vm, result);
-	// mu_assert_true(vm_result->b, "0.1337 <= 0.13371L");
-	// rz_il_bool_free(vm_result);
-	// rz_il_op_pure_free(result);
-
-	result = rz_il_op_new_fle(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f32(0.1337));
+	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(-0.1337001), rz_il_op_new_float_from_f32(-0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_false(vm_result->b, "0.13371L <= 0.1337");
+	mu_assert_true(vm_result->b, "-0.1337001 <= -0.1337");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	result = rz_il_op_new_fle(rz_il_op_new_float_from_f64(0.1337), rz_il_op_new_float_from_f32(0.1337));
+	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(-0.1337001));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_false(vm_result->b, "0.1337L <= 0.1337");
+	mu_assert_false(vm_result->b, "-0.1337 <= -0.1337001");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "-0.1337 <= 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(-0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "-0.1337 <= -0.1337");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
 	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
 	mu_assert_true(vm_result->b, "0.1337 <= 0.1337");
-	rz_il_bool_free(vm_result);
-	rz_il_op_pure_free(result);
-
-	result = rz_il_op_new_fle(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f64(0.13371L));
-	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_true(vm_result->b, "0.1337L <= 0.1337L");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
@@ -594,45 +594,45 @@ static bool test_il_fgt() {
 	RzILBool *vm_result = NULL;
 	RzILOpBool *result = NULL;
 
-	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.13371));
+	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337001));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_false(vm_result->b, "0.1337 > 0.13371");
+	mu_assert_false(vm_result->b, "0.1337 > 0.1337001");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(0.13371), rz_il_op_new_float_from_f32(0.1337));
+	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(0.1337001), rz_il_op_new_float_from_f32(0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_true(vm_result->b, "0.13371 > 0.1337");
+	mu_assert_true(vm_result->b, "0.1337001 > 0.1337");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	// result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
-	// vm_result = rz_il_evaluate_bool(vm, result);
-	// mu_assert_false(vm_result->b, "0.1337 > 0.13371L");
-	// rz_il_bool_free(vm_result);
-	// rz_il_op_pure_free(result);
-
-	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f32(0.1337));
+	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(-0.1337001), rz_il_op_new_float_from_f32(-0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_true(vm_result->b, "0.13371L > 0.1337");
+	mu_assert_false(vm_result->b, "-0.1337001 > -0.1337");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	// result = rz_il_op_new_fgt(rz_il_op_new_float_from_f64(0.1337), rz_il_op_new_float_from_f32(0.1337));
-	// vm_result = rz_il_evaluate_bool(vm, result);
-	// mu_assert_false(vm_result->b, "0.1337L > 0.1337");
-	// rz_il_bool_free(vm_result);
-	// rz_il_op_pure_free(result);
+	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(-0.1337001));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "-0.1337 > -0.1337001");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "-0.1337 > 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(-0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "-0.1337 > -0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
 	mu_assert_false(vm_result->b, "0.1337 > 0.1337");
-	rz_il_bool_free(vm_result);
-	rz_il_op_pure_free(result);
-
-	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f64(0.13371L));
-	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_false(vm_result->b, "0.1337L > 0.1337L");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
@@ -646,45 +646,45 @@ static bool test_il_fge() {
 	RzILBool *vm_result = NULL;
 	RzILOpBool *result = NULL;
 
-	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.13371));
+	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337001));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_false(vm_result->b, "0.1337 >= 0.13371");
+	mu_assert_false(vm_result->b, "0.1337 >= 0.1337001");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(0.13371), rz_il_op_new_float_from_f32(0.1337));
+	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(0.1337001), rz_il_op_new_float_from_f32(0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_true(vm_result->b, "0.13371 >= 0.1337");
+	mu_assert_true(vm_result->b, "0.1337001 >= 0.1337");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
+	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(-0.1337001), rz_il_op_new_float_from_f32(-0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_false(vm_result->b, "0.1337 >= 0.13371L");
+	mu_assert_false(vm_result->b, "-0.1337001 >= -0.1337");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	// result = rz_il_op_new_fge(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f32(0.1337));
-	// vm_result = rz_il_evaluate_bool(vm, result);
-	// mu_assert_true(vm_result->b, "0.13371L >= 0.1337");
-	// rz_il_bool_free(vm_result);
-	// rz_il_op_pure_free(result);
+	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(-0.1337001));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "-0.1337 >= -0.1337001");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
 
-	// result = rz_il_op_new_fge(rz_il_op_new_float_from_f64(0.1337), rz_il_op_new_float_from_f32(0.1337));
-	// vm_result = rz_il_evaluate_bool(vm, result);
-	// mu_assert_true(vm_result->b, "0.1337L >= 0.1337");
-	// rz_il_bool_free(vm_result);
-	// rz_il_op_pure_free(result);
+	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "-0.1337 >= 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(-0.1337), rz_il_op_new_float_from_f32(-0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "-0.1337 >= -0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
 	mu_assert_true(vm_result->b, "0.1337 >= 0.1337");
-	rz_il_bool_free(vm_result);
-	rz_il_op_pure_free(result);
-
-	result = rz_il_op_new_fge(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f64(0.13371L));
-	vm_result = rz_il_evaluate_bool(vm, result);
-	mu_assert_true(vm_result->b, "0.1337L >= 0.1337L");
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 

--- a/test/unit/test_il_helpers.c
+++ b/test/unit/test_il_helpers.c
@@ -502,11 +502,11 @@ static bool test_il_flt() {
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	// result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
-	// vm_result = rz_il_evaluate_bool(vm, result);
-	// mu_assert_true(vm_result->b, "0.1337 < 0.13371L");
-	// rz_il_bool_free(vm_result);
-	// rz_il_op_pure_free(result);
+	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.1337 < 0.13371L");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	// result = rz_il_op_new_flt(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f32(0.1337));
 	// vm_result = rz_il_evaluate_bool(vm, result);
@@ -566,11 +566,11 @@ static bool test_il_fle() {
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	// result = rz_il_op_new_fle(rz_il_op_new_float_from_f64(0.1337), rz_il_op_new_float_from_f32(0.1337));
-	// vm_result = rz_il_evaluate_bool(vm, result);
-	// mu_assert_false(vm_result->b, "0.1337L <= 0.1337");
-	// rz_il_bool_free(vm_result);
-	// rz_il_op_pure_free(result);
+	result = rz_il_op_new_fle(rz_il_op_new_float_from_f64(0.1337), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337L <= 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337));
 	vm_result = rz_il_evaluate_bool(vm, result);
@@ -658,11 +658,11 @@ static bool test_il_fge() {
 	rz_il_bool_free(vm_result);
 	rz_il_op_pure_free(result);
 
-	// result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
-	// vm_result = rz_il_evaluate_bool(vm, result);
-	// mu_assert_false(vm_result->b, "0.1337 >= 0.13371L");
-	// rz_il_bool_free(vm_result);
-	// rz_il_op_pure_free(result);
+	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f64(0.13371L));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337 >= 0.13371L");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	// result = rz_il_op_new_fge(rz_il_op_new_float_from_f64(0.13371L), rz_il_op_new_float_from_f32(0.1337));
 	// vm_result = rz_il_evaluate_bool(vm, result);

--- a/test/unit/test_il_helpers.c
+++ b/test/unit/test_il_helpers.c
@@ -386,6 +386,24 @@ static bool test_il_fneq() {
 	RzILBool *vm_result = NULL;
 	RzILOpBool *result = NULL;
 
+	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(F32_NAN));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "0.1337 != NaN");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(F32_NAN), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "NaN != 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(F32_NAN), rz_il_op_new_float_from_f32(F32_NAN));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_true(vm_result->b, "NaN != NaN");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
 	result = rz_il_op_new_fneq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337001));
 	vm_result = rz_il_evaluate_bool(vm, result);
 	mu_assert_true(vm_result->b, "0.1337 != 0.1337001");
@@ -437,6 +455,24 @@ static bool test_il_feq() {
 	RzILVM *vm = rz_il_vm_new(0, 64, false);
 	RzILBool *vm_result = NULL;
 	RzILOpBool *result = NULL;
+
+	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(F32_NAN));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337 == NaN");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(F32_NAN), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "NaN == 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(F32_NAN), rz_il_op_new_float_from_f32(F32_NAN));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "NaN == NaN");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	result = rz_il_op_new_feq(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337001));
 	vm_result = rz_il_evaluate_bool(vm, result);
@@ -490,6 +526,24 @@ static bool test_il_flt() {
 	RzILBool *vm_result = NULL;
 	RzILOpBool *result = NULL;
 
+	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(F32_NAN));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337 < NaN");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(F32_NAN), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "NaN < 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(F32_NAN), rz_il_op_new_float_from_f32(F32_NAN));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "NaN < NaN");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
 	result = rz_il_op_new_flt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337001));
 	vm_result = rz_il_evaluate_bool(vm, result);
 	mu_assert_true(vm_result->b, "0.1337 < 0.1337001");
@@ -541,6 +595,24 @@ static bool test_il_fle() {
 	RzILVM *vm = rz_il_vm_new(0, 64, false);
 	RzILBool *vm_result = NULL;
 	RzILOpBool *result = NULL;
+
+	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(F32_NAN));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337 <= NaN");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(F32_NAN), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "NaN <= 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(F32_NAN), rz_il_op_new_float_from_f32(F32_NAN));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "NaN <= NaN");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	result = rz_il_op_new_fle(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337001));
 	vm_result = rz_il_evaluate_bool(vm, result);
@@ -594,6 +666,24 @@ static bool test_il_fgt() {
 	RzILBool *vm_result = NULL;
 	RzILOpBool *result = NULL;
 
+	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(F32_NAN));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337 > NaN");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(F32_NAN), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "NaN > 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(F32_NAN), rz_il_op_new_float_from_f32(F32_NAN));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "NaN > NaN");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
 	result = rz_il_op_new_fgt(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337001));
 	vm_result = rz_il_evaluate_bool(vm, result);
 	mu_assert_false(vm_result->b, "0.1337 > 0.1337001");
@@ -645,6 +735,24 @@ static bool test_il_fge() {
 	RzILVM *vm = rz_il_vm_new(0, 64, false);
 	RzILBool *vm_result = NULL;
 	RzILOpBool *result = NULL;
+
+	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(F32_NAN));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "0.1337 >= NaN");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(F32_NAN), rz_il_op_new_float_from_f32(0.1337));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "NaN >= 0.1337");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
+
+	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(F32_NAN), rz_il_op_new_float_from_f32(F32_NAN));
+	vm_result = rz_il_evaluate_bool(vm, result);
+	mu_assert_false(vm_result->b, "NaN >= NaN");
+	rz_il_bool_free(vm_result);
+	rz_il_op_pure_free(result);
 
 	result = rz_il_op_new_fge(rz_il_op_new_float_from_f32(0.1337), rz_il_op_new_float_from_f32(0.1337001));
 	vm_result = rz_il_evaluate_bool(vm, result);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
PR also includes fix of memory leaks in `test_il_helpers.c`

Have no clue how to create a `RzILOpFloat` with NaN value. So some cases are not covered.
