### PR TITLE
Always check the length before returning the head or tail

### DIFF
--- a/librz/include/rz_vector.h
+++ b/librz/include/rz_vector.h
@@ -113,6 +113,9 @@ static inline void *rz_vector_head(const RzVector *vec) {
 // returns a pointer to the last element of the vector
 static inline void *rz_vector_tail(RzVector *vec) {
 	rz_return_val_if_fail(vec, NULL);
+	if (vec->len < 1) {
+		return NULL;
+	}
 	return (char *)vec->a + vec->elem_size * (vec->len - 1);
 }
 

--- a/librz/include/rz_vector.h
+++ b/librz/include/rz_vector.h
@@ -292,12 +292,18 @@ static inline void **rz_pvector_data(RzPVector *vec) {
 // returns the first element of the vector
 static inline void *rz_pvector_head(RzPVector *vec) {
 	rz_return_val_if_fail(vec, NULL);
+	if (vec->v.len < 1) {
+		return NULL;
+	}
 	return ((void **)vec->v.a)[0];
 }
 
 // returns the last element of the vector
 static inline void *rz_pvector_tail(RzPVector *vec) {
 	rz_return_val_if_fail(vec, NULL);
+	if (vec->v.len < 1) {
+		return NULL;
+	}
 	return ((void **)vec->v.a)[vec->v.len - 1];
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This bug was found due a crash in silhouette.

RzPVector & RzVector seems to not check the length when invoking get head/tail methods.

https://github.com/rizinorg/rz-silhouette/issues/10