### PR TITLE
Error when log file cannot be opened.

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -2880,9 +2880,13 @@ static bool cb_log_config_abortlevel(void *coreptr, void *nodeptr) {
 }
 #endif /* RZ_BUILD_DEBUG */
 
-static bool cb_log_config_file(void *coreptr, void *nodeptr) {
+static bool cb_log_file(void *coreptr, void *nodeptr) {
 	RzConfigNode *node = (RzConfigNode *)nodeptr;
-	return rz_log_set_file(node->value);
+	if (!rz_log_set_file(node->value)) {
+		RZ_LOG_ERROR("log.file: cannot open '%s'\n", node->value);
+		return false;
+	}
+	return true;
 }
 
 static bool cb_log_config_show_sources(void *coreptr, void *nodeptr) {
@@ -3349,7 +3353,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 
 	// RZ_LOGFILE / log.file
 	p = rz_sys_getenv("RZ_LOGFILE");
-	SETCB("log.file", p ? p : "", cb_log_config_file, "Logging output filename / path");
+	SETCB("log.file", p ? p : "", cb_log_file, "Logging output filename / path");
 	free(p);
 
 	// RZ_LOGSHOWSOURCES / log.show.sources


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Adds an error message when the log file cannot be opened.
```
[0x00000000]> e log.file=/usr/aaaa
ERROR: log.file: cannot open '/usr/aaaa'
[0x00000000]> e log.file

[0x00000000]> e log.file=/tmp/aa.log
```