### PR TITLE
Relocation and analysis improvement for Renesas RX

### DIFF
--- a/librz/arch/opcodes/meson.build
+++ b/librz/arch/opcodes/meson.build
@@ -18,6 +18,8 @@ sdb_opcodes_files = [
   'ppc',
   'propeller',
   'riscv',
+  'rx',
+  'rl78',
   'sh',
   'sparc',
   'sysz',

--- a/librz/arch/opcodes/rx.sdb.txt
+++ b/librz/arch/opcodes/rx.sdb.txt
@@ -1,0 +1,129 @@
+abs=absolute value
+add=byte data addition without carry
+sub=subtract data
+adc=addition of byte data with carry
+and=logical and
+bclr=clear a bit
+bnot=inverts a bit
+bset=set a bit
+btst=test a bit to set C/Z flag
+clrpsw=clear a flag in the PSW reg
+cmp=compare two operands
+div=divide signed
+divu=divide unsigned
+emul=extended multiply signed
+emulu=extended multiply unsigned
+fadd=float-point addition
+fcmp=compare float-point
+fdiv=divide float-point
+fmul=multiply float-point
+fsub=subtract float-point
+ftoi=convert float-point to signed integer
+itof=convert signed integer to float-point
+machi=multiply-accumulate the upper words
+maclo=multiply-accumulate the lower words
+max=maximum of two signed integers
+min=minimum of two signed integers
+mov=move data
+mov=move data unsigned
+xchg=exchange data
+mul=multiply data
+mulhi=multiply the upper words
+mullo=multiply the lower words
+mvfachi=move data from upper longword([b32,b63]) of the accumulator(acc)
+mvfacmi=move data from middle longword([b16, b47]) of the accumulator(acc)
+mvtachi=move data to upper longword([b32,b63]) of the accumulator(acc)
+mvtaclo=move data to lower longword([b0, b31]) of the accumulator(acc)
+mvfc=move data from a control register
+mvtc=move data to a control register
+mvtipl=move data to IPL
+neg=negate operand (2's complement)
+not=logical not (1's complement)
+or=logical or
+xor=logical xor
+nop=do nothing
+pop=pop register from stack
+popc=pop a control register from stack
+popm=pop multiple registers from stack
+push= push a register to stack
+pushc=push a control register to stack
+pushm=push multiple registers to stack
+racw=round the accumulator into a word and stores result
+revl=reverse endian within longword
+revw=reverse endian within word
+rmpa=repeat multiply-accumulate
+rolc=rotate left with carry
+rorc=rotate right with carry
+rotl=rotate left
+rotr=rotate right
+round=round float-point to signed integer
+rte=return from exception
+rtfi=return from fast interrupt
+rts=return from subroutine
+rtsd=return from subroutine after deallocating stack frames
+sat=saturate (generate 7FFFFFFFh if flag O and S are set to 1 else generate 80000000)
+satr=saturate from rmpa
+sbb=subtract with borrow
+setpsw=set a flag or bit in PSW
+shar=arithmetic shift right
+shlr=logical shift right
+shll=logical shift left
+scmpu=string compare until not equal
+smovb=string move backward
+smovf=string move forward
+smovu=string move until zero detected
+sstr=string store
+suntil=string search until equal
+swhile=string search while equal
+stnz=store(move) data on not zero
+stz=store(move) on zero
+tst=test logical (S = MSB(op1&op2) Z = !(op1&op2))
+wait=pause and wait interrupt
+int=software interrupt
+jmp=unconditional
+jsr=jump to a subroutine
+bra=unconditional relative branch
+brk=unconditional trap
+bsr=relative branch to a subroutine
+scgeu=store truth value of condition if C == 1 (unsigned <=)
+sceq=store truth value of condition if Z == 1 (==)
+scgtu=store truth value of condition if (C & ~Z) == 1 (unsigned <)
+scpz=store truth value of condition if S == 0 ( >= 0)
+scge=store truth value of condition if (S ^ O) == 0 (signed <=)
+scgt=store truth value of condition if ((S ^ O) | Z) == 0 (signed <)
+sco=store truth value of condition if O == 1 (overflow)
+scltu=store truth value of condition if C == 0 (unsigned >)
+scne=store truth value of condition if Z == 0 (!=)
+scleu=store truth value of condition if (C & ~Z) == 0 (unsigned >=)
+scn=store truth value of condition if S == 1 ( < 0 )
+scle=store truth value of condition if ((S ^ O) | Z) == 1 (<)
+sclt=store truth value of condition if (S ^ O) == 1 (>)
+scno=store truth value of condition if O == 0
+bgeu=conditional relative branch if C == 1 (unsigned <=)
+beq=conditional relative branch if Z == 1 (==)
+bgtu=conditional relative branch if (C & ~Z) == 1 (unsigned <)
+bpz=conditional relative branch if S == 0 ( >= 0)
+bge=conditional relative branch if (S ^ O) == 0 (signed <=)
+bgt=conditional relative branch if ((S ^ O) | Z) == 0 (signed <)
+bo=conditional relative branch if O == 1 (overflow)
+bltu=conditional relative branch if C == 0 (unsigned >)
+bne=conditional relative branch if Z == 0 (!=)
+bleu=conditional relative branch if (C & ~Z) == 0 (unsigned >=)
+bn=conditional relative branch if S == 1 ( < 0 )
+ble=conditional relative branch if ((S ^ O) | Z) == 1 (<)
+blt=conditional relative branch if (S ^ O) == 1 (>)
+bno=conditional relative branch if O == 0
+bmgeu=store truth value of condition to a bit if C == 1 (unsigned <=)
+bmeq=store truth value of condition to a bit if Z == 1 (==)
+bmgtu=store truth value of condition to a bit if (C & ~Z) == 1 (unsigned <)
+bmpz=store truth value of condition to a bit if S == 0 ( >= 0)
+bmge=store truth value of condition to a bit if (S ^ O) == 0 (signed <=)
+bmgt=store truth value of condition to a bit if ((S ^ O) | Z) == 0 (signed <)
+bmo=store truth value of condition to a bit if O == 1 (overflow)
+bmltu=store truth value of condition to a bit if C == 0 (unsigned >)
+bmne=store truth value of condition to a bit if Z == 0 (!=)
+bmleu=store truth value of condition to a bit if (C & ~Z) == 0 (unsigned >=)
+bmn=store truth value of condition to a bit if S == 1 ( < 0 )
+bmle=store truth value of condition to a bit if ((S ^ O) | Z) == 1 (<)
+bmlt=store truth value of condition to a bit if (S ^ O) == 1 (>)
+bmno=store truth value of condition to a bit if O == 0

--- a/librz/bin/format/elf/glibc_elf.h
+++ b/librz/bin/format/elf/glibc_elf.h
@@ -4248,6 +4248,101 @@ enum {
 #define DT_HEXAGON_VER   0x70000001
 #define DT_HEXAGON_PLT   0x70000002
 
+/* Renesas RX specific elf format */
+/* From Renesas RX toolchain source: binutils/bfd/elf32-rx.c & binutils/include/elf/rx.h */
+/* Processor specific flags for the ELF header e_flags field.  */
+#define EF_RX_CPU_MASK      0x000003FF /* specific cpu bits.  */
+#define EF_RX_ALL_FLAGS     (EF_RX_CPU_MASK)
+#define EF_RX_64BIT_DOUBLES (1 << 0)
+#define EF_RX_DSP           (1 << 1) /* Defined in the RX CPU Object file specification, but not explained. */
+#define EF_RX_PID           (1 << 2) /* Unofficial - DJ */
+#define EF_RX_ABI           (1 << 3) /* Binary passes stacked arguments using natural alignment.  Unofficial - NC.  */
+#define EF_RX_SINSNS_SET    (1 << 6) /* Set if bit-5 is significant.  */
+#define EF_RX_SINSNS_YES    (1 << 7) /* Set if string instructions are used in the binary.  */
+#define EF_RX_SINSNS_NO     0 /* Bit-5 if this binary must not be linked with a string instruction using binary.  */
+#define EF_RX_SINSNS_MASK   (3 << 6) /* Mask of bits used to determine string instruction use.  */
+#define EF_RX_V1            (1 << 4) /* RX v1 instructions  */
+#define EF_RX_V2            (1 << 5) /* RX v2 instructions  */
+#define EF_RX_V3            (1 << 8) /* RX v3 instructions  */
+#define EF_RX_V3_DFPU       (1 << 9) /* instructions with DFPU (only for RX v3)*/
+#define EF_RX_V_MASK        (19 << 4) /* Mask of bits used to determine ISA */
+
+/* Renesas RX relocation type */
+#define R_RX_NONE 0x00
+/* These are for data, and are bi-endian.  */
+#define R_RX_DIR32  0x01 /* Was: R_RX_32.  */
+#define R_RX_DIR24S 0x02 /* Was: R_RX_24.  */
+#define R_RX_DIR16  0x03
+#define R_RX_DIR16U 0x04 /* Was: R_RX_16_UNS.  */
+#define R_RX_DIR16S 0x05 /* Was: R_RX_16.  */
+#define R_RX_DIR8   0x06
+#define R_RX_DIR8U  0x07 /* Was: R_RX_8_UNS.  */
+#define R_RX_DIR8S  0x08 /* Was: R_RX_8.  */
+/* Signed pc-relative values.  */
+#define R_RX_DIR24S_PCREL 0x09 /* Was: R_RX_24_PCREL.  */
+#define R_RX_DIR16S_PCREL 0x0a /* Was: R_RX_16_PCREL.  */
+#define R_RX_DIR8S_PCREL  0x0b /* Was: R_RX_8_PCREL.  */
+/* These are for fields in the instructions.  */
+#define R_RX_DIR16UL     0x0c
+#define R_RX_DIR16UW     0x0d
+#define R_RX_DIR8UL      0x0e
+#define R_RX_DIR8UW      0x0f
+#define R_RX_DIR32_REV   0x10
+#define R_RX_DIR16_REV   0x11
+#define R_RX_DIR3U_PCREL 0x12
+/* These are extensions added by Red Hat.  */
+#define R_RX_RH_3_PCREL 0x20 /* Like R_RX_DIR8S_PCREL but only 3-bits.  */
+#define R_RX_RH_16_OP   0x21 /* Like R_RX_DIR16 but for opcodes - always big endian.  */
+#define R_RX_RH_24_OP   0x22 /* Like R_RX_DIR24S but for opcodes - always big endian.  */
+#define R_RX_RH_32_OP   0x23 /* Like R_RX_DIR32 but for opcodes - always big endian.  */
+#define R_RX_RH_24_UNS  0x24 /* Like R_RX_DIR24S but for unsigned values.  */
+#define R_RX_RH_8_NEG   0x25 /* Like R_RX_DIR8 but -x is stored.  */
+#define R_RX_RH_16_NEG  0x26 /* Like R_RX_DIR16 but -x is stored.  */
+#define R_RX_RH_24_NEG  0x27 /* Like R_RX_DIR24S but -x is stored.  */
+#define R_RX_RH_32_NEG  0x28 /* Like R_RX_DIR32 but -x is stored.  */
+#define R_RX_RH_DIFF    0x29 /* Subtract from a previous relocation.  */
+#define R_RX_RH_GPRELB  0x2a /* Byte value, relative to __gp.  */
+#define R_RX_RH_GPRELW  0x2b /* Word value, relative to __gp.  */
+#define R_RX_RH_GPRELL  0x2c /* Long value, relative to __gp.  */
+#define R_RX_RH_RELAX   0x2d /* Marks opcodes suitable for linker relaxation.  */
+/* These are for complex relocs.  */
+// TODO: maybe implement reloc_convert for those
+#define R_RX_ABS32        0x41
+#define R_RX_ABS24S       0x42
+#define R_RX_ABS16        0x43
+#define R_RX_ABS16U       0x44
+#define R_RX_ABS16S       0x45
+#define R_RX_ABS8         0x46
+#define R_RX_ABS8U        0x47
+#define R_RX_ABS8S        0x48
+#define R_RX_ABS24S_PCREL 0x49
+#define R_RX_ABS16S_PCREL 0x4a
+#define R_RX_ABS8S_PCREL  0x4b
+#define R_RX_ABS16UL      0x4c
+#define R_RX_ABS16UW      0x4d
+#define R_RX_ABS8UL       0x4e
+#define R_RX_ABS8UW       0x4f
+#define R_RX_ABS32_REV    0x50
+#define R_RX_ABS16_REV    0x51
+/* For RX operation */
+#define R_RX_SYM       0x80
+#define R_RX_OPneg     0x81
+#define R_RX_OPadd     0x82
+#define R_RX_OPsub     0x83
+#define R_RX_OPmul     0x84
+#define R_RX_OPdiv     0x85
+#define R_RX_OPshla    0x86
+#define R_RX_OPshra    0x87
+#define R_RX_OPsctsize 0x88
+#define R_RX_OPscttop  0x8d
+#define R_RX_OPand     0x90
+#define R_RX_OPor      0x91
+#define R_RX_OPxor     0x92
+#define R_RX_OPnot     0x93
+#define R_RX_OPmod     0x94
+#define R_RX_OPromtop  0x95
+#define R_RX_OPramtop  0x96
+
 __END_DECLS
 
 #endif /* elf.h */

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -1285,6 +1285,34 @@ static void patch_reloc(struct Elf_(rz_bin_elf_obj_t) * obj, RzBinElfReloc *rel,
 		}
 		break;
 	}
+	case EM_RX:
+		// no dynamic for rx-elf program, handle rx elf object reloc type (emulate linkage map)
+		// and no GOT/PLT for existed for rx-elf, leave no imports info for extern symbol
+		switch (rel->type) {
+		// simply use rizin default symbol resolution to map OBJECT variable symbol to vaddr
+		case R_RX_NONE: break;
+		case R_RX_DIR32:
+			val = S + A;
+			rz_buf_write_ble32_at(obj->buf_patched, patch_addr, val, obj->big_endian);
+			break;
+		case R_RX_DIR24S_PCREL:
+			val = S + A - P + 1;
+			if (obj->big_endian) {
+				buf[2] = val;
+				buf[1] = val >> 8;
+				buf[0] = val >> 16;
+			} else {
+				buf[0] = val;
+				buf[1] = val >> 8;
+				buf[2] = val >> 16;
+			}
+			// write 3 Bytes
+			rz_buf_write_at(obj->buf_patched, patch_addr, buf, 3);
+			break;
+		default:
+			RZ_LOG_WARN("Reloc type %d for Renesas RX family not implemented yet.\n", rel->type);
+			break;
+		}
 	}
 }
 
@@ -1482,6 +1510,15 @@ static RzBinReloc *reloc_convert(ELFOBJ *bin, RzBinElfReloc *rel, ut64 GOT) {
 			break;
 		}
 		break;
+	case EM_RX:
+		switch (rel->type) {
+		case R_RX_NONE: break;
+		case R_RX_DIR24S_PCREL: ADD(24, -P);
+		case R_RX_DIR32: SET(32);
+		default:
+			RZ_LOG_WARN("unimplemented ELF/RX reloc type %d\n", rel->type);
+			break;
+		}
 	default: break;
 	}
 

--- a/test/db/analysis/rx
+++ b/test/db/analysis/rx
@@ -55,7 +55,7 @@ EOF
 RUN
 
 NAME=RX reloc info
-FILE=bins/rx/reloc_tmp.o
+FILE=bins/rx/reloc_tmp
 ARGS=
 CMDS=<<EOF
 ir
@@ -388,7 +388,7 @@ RUN
 
 
 NAME=RX reloc obj
-FILE=bins/rx/reloc_tmp.o
+FILE=bins/rx/reloc_tmp
 ARGS=
 CMDS=<<EOF
 aa

--- a/test/db/analysis/rx
+++ b/test/db/analysis/rx
@@ -54,6 +54,26 @@ NX       false
 EOF
 RUN
 
+NAME=RX reloc info
+FILE=bins/rx/reloc_tmp.o
+ARGS=
+CMDS=<<EOF
+ir
+EOF
+EXPECT=<<EOF
+vaddr      paddr      target     type   name                     
+-----------------------------------------------------------------
+0x08000042 0x00000042 0x080000a8 SET_32 _static_bar.1425
+0x08000059 0x00000059 0x00000004 SET_32 _local_gint
+0x08000063 0x00000063 0x00000004 SET_32 _local_gint
+0x08000070 0x00000070 0x08000300 SET_32 _extern_int
+0x08000079 0x00000079 0x080000a8 SET_32 _local_static_gint
+0x08000086 0x00000086 0x08000304 ADD_24 _extern_foo - 0x08000086
+0x0800008a 0x0000008a 0x0800003c ADD_24 _top_foo - 0x0800008a
+0x0800008e 0x0000008e 0x08000098 ADD_24 _bottom_foo - 0x0800008e
+EOF
+RUN
+
 NAME=RX morse function
 FILE=bins/rx/morse
 ARGS=

--- a/test/db/analysis/rx
+++ b/test/db/analysis/rx
@@ -234,7 +234,7 @@ EXPECT=<<EOF
 0xfff4034c    1 16           sym._putc
 0xfff4035c    1 15           sym._strcmp
 0xfff4036b    1 17           sym._strtok
-0xfff4037c   13 103  -> 81   sym.___strtok_r
+0xfff4037c   12 103  -> 73   sym.___strtok_r
 0xfff403e3    1 6            sym._strtok_r
 0xfff403e9   35 4023 -> 411  sym.__vfprintf_r
 0xfff413ee    1 18           sym._vfprintf
@@ -243,8 +243,8 @@ EXPECT=<<EOF
 0xfff41511    1 16           sym.___swbuf
 0xfff41521    1 16           sym.___swsetup_r
 0xfff415d2   11 112  -> 79   sym.___call_exitprocs
-0xfff41657   11 263  -> 215  sym._quorem
-0xfff4175e   33 2479 -> 400  sym.__dtoa_r
+0xfff41657   11 263  -> 211  sym._quorem
+0xfff4175e  232 2479 -> 2275 sym.__dtoa_r
 0xfff4210d    6 223  -> 53   sym.___sflush_r
 0xfff42229    5 43   -> 34   sym.__fflush_r
 0xfff42254    3 35           sym._fflush
@@ -290,7 +290,7 @@ EXPECT=<<EOF
 0xfff42e44   18 100  -> 85   sym.___lo0bits
 0xfff42ea8    3 44           sym.___i2b
 0xfff42ed4   22 291  -> 287  sym.___multiply
-0xfff42ffc   13 122  -> 98   sym.___pow5mult
+0xfff42ffc   13 122          sym.___pow5mult
 0xfff43076   12 179  -> 153  sym.___lshift
 0xfff4312b    7 45           sym.___mcmp
 0xfff4315a   12 190          sym.___mdiff
@@ -342,7 +342,7 @@ EXPECT=<<EOF
 0xfff447e2    1 12           sym._abort
 0xfff447ee    7 52   -> 50   sym.__init_signal_r
 0xfff44822    6 50           sym.__signal_r
-0xfff44856    9 81   -> 75   sym.__raise_r
+0xfff44856    9 81   -> 68   sym.__raise_r
 0xfff448a7   12 81   -> 78   sym.___sigtramp_r
 0xfff448f8    1 14           sym._raise
 0xfff44906    1 16           sym._signal
@@ -365,3 +365,64 @@ EXPECT=<<EOF
 0xfff45548    1 4            loc..LANCHOR0_0xfff45548
 EOF
 RUN
+
+
+NAME=RX reloc obj
+FILE=bins/rx/reloc_tmp.o
+ARGS=
+CMDS=<<EOF
+aa
+pd 37
+EOF
+EXPECT=<<EOF
+            ; CALL XREF from sym._main @ 0x8000082
+            ;-- section.P:
+            ;-- P:
+/ sym._static_foo();
+|           0x08000034      push.L r10,                                ; [01] -r-x section size 114 named P
+|           0x08000036      mov.L r0, r10, 
+|           0x08000038      nop   
+\           0x08000039      rtsd  #0x1, r10, 
+            ; CALL XREF from sym._main @ 0x8000089
+            ;-- _top_foo:
+/ sym._top_foo();
+|           0x0800003c      push.L r10,                                ; RELOC TARGET 24 _top_foo @ 0x0800003c - 0x800008a
+|           0x0800003e      mov.L r0, r10, 
+|           0x08000040      mov   #obj._local_static_gint, r5,         ; RELOC 32 _static_bar.1425 @ 0x080000a8
+|           0x08000046      mov.L #0x2, [r5], 
+|           0x08000049      nop   
+\           0x0800004a      rtsd  #0x1, r10, 
+/ int sym._main(int argc, char **argv, char **envp);
+|           0x0800004d      push.L r10, 
+|           0x0800004f      add   #0xf8, r0, r10
+|           0x08000052      mov.L r10, r0, 
+|           0x08000054      mov.L #0x1, [r10], 
+|           0x08000057      mov   #0x4, r5,                            ; RELOC 32 _local_gint @ 0x00000004
+|           0x0800005d      mov.L #0x1234, [r5], 
+|           0x08000061      mov   #0x4, r5,                            ; RELOC 32 _local_gint @ 0x00000004
+|           0x08000067      mov.L [r5], r5, 
+|           0x08000069      neg   r5, 
+|           0x0800006b      mov.L r5, 0x1[r10], 
+|           0x0800006e      mov   #reloc.target._extern_int, r5,       ; RELOC 32 _extern_int
+|           0x08000074      mov.W #0x67, [r5], 
+|           0x08000077      mov   #obj._local_static_gint, r5,         ; RELOC 32 _local_static_gint @ 0x080000a8
+|           0x0800007d      mov.L #0xabcd, [r5], 
+|           0x08000082      bsr.W  #0xffb2,                            ; sym._static_foo
+|           0x08000085      bsr.A  #0x27f,                             ; RELOC 24 _extern_foo
+|           0x08000089      bsr.A  #0xffffb3,                          ; sym._top_foo; RELOC 24 _top_foo @ 0x0800003c - 0x800008a
+|           0x0800008d      bsr.A  #0xb,                               ; sym._bottom_foo; RELOC 24 _bottom_foo @ 0x08000098 - 0x800008e
+|           0x08000091      mov   #0x0, r5, 
+|           0x08000093      mov.L r5, r1, 
+\           0x08000095      rtsd  #0x3, r10, 
+            ; CALL XREF from sym._main @ 0x800008d
+            ;-- _bottom_foo:
+/ sym._bottom_foo();
+|           0x08000098      push.L r10,                                ; RELOC TARGET 24 _bottom_foo @ 0x08000098 - 0x800008e
+|           0x0800009a      add   #0xfc, r0, r10
+|           0x0800009d      mov.L r10, r0, 
+|           0x0800009f      mov.L #0xa, [r10], 
+|           0x080000a2      nop   
+\           0x080000a3      rtsd  #0x2, r10, 
+EOF
+RUN
+


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

- [x] stack pointer
- [x] relocation for rx-elf obj
- [x] mnemonic sdb

**Test plan**

Test with an rx-elf object which compiled from the following source:
```C
static int local_static_gint;
int local_gint;
extern unsigned short extern_int;

void extern_foo();
void bottom_foo();

static void static_foo() {
    return;
}

void top_foo() {
    static int static_bar = 0x01;

    static_bar = 0x02;
    return;
}

int main() {
    int local_i = 1;

    local_gint = 0x1234;
    int x = -local_gint;
    extern_int = 0x67;
    local_static_gint = 0xabcd;

    static_foo();
    extern_foo();
    top_foo();

    // void (*fn_ptr)() = &extern_foo;
    // fn_ptr();

    bottom_foo();

    return 0;
}

void bottom_foo() {
    int x = 10;
    return;
}
```
compile command: `rx-elf-gcc -c reloc_tmp.c -o reloc_tmp.o` ; and check with `rx-elf-readelf` and `rx-elf-ld`

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
