### PR TITLE
Refactoring rizin type system: introduce type scope.

### DIFF
--- a/librz/arch/dwarf_process.c
+++ b/librz/arch/dwarf_process.c
@@ -662,6 +662,10 @@ static bool RzBaseType_eq(const RzBaseType *a, const RzBaseType *b) {
 	if (a == NULL || b == NULL) {
 		return a == NULL && b == NULL;
 	}
+	if (a->scope.cu_name && b->scope.cu_name && RZ_STR_NE(a->scope.cu_name, b->scope.cu_name)) {
+		printf("types '%s' and '%s' are not equal\n", a->name, b->name);
+		return false;
+	}
 	return a->kind == b->kind && a->attrs == b->attrs && RZ_STR_EQ(a->name, b->name);
 }
 
@@ -706,6 +710,11 @@ static RzBaseType *RzBaseType_from_die(DwContext *ctx, const RzBinDwarfDie *die)
 		break;
 	default:
 		return NULL;
+	}
+
+	if (ctx->unit->name) {
+		printf("storing cu_name: '%s'\n", ctx->unit->name);
+		btype->scope.cu_name = rz_str_dup(ctx->unit->name);
 	}
 
 	RzBinDwarfAttr *attr = NULL;

--- a/librz/arch/dwarf_process.c
+++ b/librz/arch/dwarf_process.c
@@ -1759,7 +1759,7 @@ RZ_API void rz_analysis_dwarf_preprocess_info(
 	rz_vector_foreach (&dw->info->units, unit) {
 		debug_info->type_by_offset = ht_up_new(NULL, (HtUPFreeValue)rz_type_free);
 		debug_info->base_type_by_offset = ht_up_new(NULL, (HtUPFreeValue)rz_type_base_type_free);
-		debug_info->base_types_by_name = ht_sp_new(HT_STR_DUP, NULL, (HtSPFreeValue)rz_pvector_free);
+		debug_info->base_types_by_name = ht_sp_new(HT_STR_DUP, NULL, (HtSPFreeValue)rz_pvector_free); // borrows RzBaseType pointers from base_type_by_offset
 
 		if (rz_vector_empty(&unit->dies)) {
 			continue;

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -454,7 +454,7 @@ typedef struct {
 	HtUP /*<ut64, RzCallable *>*/ *callable_by_offset; ///< Store all callables parsed from DWARF by DIE offset
 	HtUP /*<ut64, RzType *>*/ *type_by_offset; ///< Store all RzType parsed from DWARF by DIE offset
 	HtUP /*<ut64, RzBaseType *>*/ *base_type_by_offset; ///< Store all RzBaseType parsed from DWARF by DIE offset
-	HtSP /*<const char*, RzPVector<const RzBaseType *>>*/ *base_types_by_name; ///< Store all RzBaseType parsed from DWARF by DIE offset
+	HtSP /*<const char*, RzPVector<const RzBaseType *>>*/ *base_types_by_name; ///< Store all RzBaseType parsed from DWARF by DIE name
 	DWARF_RegisterMapping dwarf_register_mapping; ///< Store the mapping function between DWARF registers number and register name in current architecture
 	RzBinDWARF *dw; ///< Holds ownership of RzBinDwarf, avoid releasing it prematurely
 	SetU *visited;

--- a/librz/include/rz_type.h
+++ b/librz/include/rz_type.h
@@ -30,7 +30,7 @@ typedef struct rz_type_parser_t RzTypeParser;
 
 typedef struct rz_type_db_t {
 	void *user;
-	HtSP /*<char *, RzBaseType *>*/ *types; //< name -> base type
+	HtSP /*<char *, RzPVector<RzBaseType *>*>*/ *types; //< name -> vector<base type>
 	HtSS /*<char *, char *>*/ *formats; //< name -> `pf` format
 	HtSP /*<char *, RzCallable *>*/ *callables; //< name -> RzCallable (function type)
 	RzTypeTarget *target;
@@ -273,6 +273,7 @@ RZ_API bool rz_base_type_clone_into(
 	RZ_NONNULL RZ_BORROW RZ_IN RzBaseType *src);
 RZ_API RZ_OWN RzBaseType *rz_base_type_clone(RZ_NULLABLE RZ_BORROW RzBaseType *b);
 RZ_API void rz_type_base_type_free(RzBaseType *type);
+RZ_API bool rz_type_base_type_same_scope(const RzBaseType *a, const RzBaseType *b);
 RZ_API RZ_OWN RzBaseType *rz_type_base_type_new(RzBaseTypeKind kind);
 RZ_API RZ_BORROW const char *rz_type_base_type_kind_as_string(RzBaseTypeKind kind);
 
@@ -280,7 +281,7 @@ RZ_API void rz_type_base_enum_case_free(void *e, void *user);
 RZ_API void rz_type_base_struct_member_free(void *e, void *user);
 RZ_API void rz_type_base_union_member_free(void *e, void *user);
 
-RZ_API RZ_BORROW RzBaseType *rz_type_db_get_base_type(const RzTypeDB *typedb, RZ_NONNULL const char *name);
+RZ_API RZ_BORROW RzPVector /*<RzBaseType*>*/ *rz_type_db_get_base_type(const RzTypeDB *typedb, RZ_NONNULL const char *name);
 RZ_API RZ_BORROW RzBaseType *rz_type_db_get_compound_type(const RzTypeDB *typedb, RZ_NONNULL const char *name);
 RZ_API bool rz_type_db_save_base_type(const RzTypeDB *typedb, RzBaseType *type);
 RZ_API bool rz_type_db_update_base_type(const RzTypeDB *typedb, RzBaseType *type);

--- a/librz/include/rz_type.h
+++ b/librz/include/rz_type.h
@@ -39,6 +39,11 @@ typedef struct rz_type_db_t {
 	RzIOBind iob; // for RzIO in formats
 } RzTypeDB;
 
+
+typedef struct rz_type_scope_t {
+	char *cu_name;
+} RzTypeScope;
+
 // All types in RzTypeDB module are either concrete,
 // "base" types that are types already having the
 // concrete size and memory layout
@@ -114,6 +119,7 @@ typedef struct rz_base_type_t {
 	ut64 size; // size of the whole type in bits
 	RzBaseTypeKind kind;
 	RzTypeAttribute attrs;
+	RzTypeScope scope;
 	union {
 		RzBaseTypeStruct struct_data;
 		RzBaseTypeEnum enum_data;

--- a/librz/type/base.c
+++ b/librz/type/base.c
@@ -163,6 +163,7 @@ RZ_API bool rz_base_type_clone_into(
 	rz_mem_copy(dst, sizeof(RzBaseType), src, sizeof(RzBaseType));
 	dst->name = rz_str_dup(src->name);
 	dst->type = src->type ? rz_type_clone(src->type) : NULL;
+	dst->scope.cu_name = rz_str_dup(src->scope.cu_name);
 
 	switch (src->kind) {
 	case RZ_BASE_TYPE_KIND_ENUM:

--- a/librz/type/base.c
+++ b/librz/type/base.c
@@ -54,15 +54,15 @@ RZ_API RZ_BORROW const char *rz_type_base_type_kind_as_string(RzBaseTypeKind kin
  * \param typedb Type Database instance
  * \param name Name of the RzBaseType
  */
-RZ_API RZ_BORROW RzBaseType *rz_type_db_get_base_type(const RzTypeDB *typedb, RZ_NONNULL const char *name) {
+RZ_API RZ_BORROW RzPVector /*<RzBaseType>*/ *rz_type_db_get_base_type(const RzTypeDB *typedb, RZ_NONNULL const char *name) {
 	rz_return_val_if_fail(typedb && name, NULL);
 
 	bool found = false;
-	RzBaseType *btype = ht_sp_find(typedb->types, name, &found);
-	if (!found || !btype) {
+	RzPVector /*<RzBaseType*>*/ *btypes = ht_sp_find(typedb->types, name, &found);
+	if (!found || !btypes) {
 		return NULL;
 	}
-	return btype;
+	return btypes;
 }
 
 /**
@@ -71,9 +71,23 @@ RZ_API RZ_BORROW RzBaseType *rz_type_db_get_base_type(const RzTypeDB *typedb, RZ
  * \param typedb Type Database instance
  * \param type RzBaseType to remove
  */
-RZ_API bool rz_type_db_delete_base_type(RzTypeDB *typedb, RZ_NONNULL RzBaseType *type) {
-	rz_return_val_if_fail(typedb && type && type->name, false);
-	ht_sp_delete(typedb->types, type->name);
+RZ_API bool rz_type_db_delete_base_type(RzTypeDB *typedb, RZ_NONNULL RzBaseType *btype) {
+	rz_return_val_if_fail(typedb && btype && btype->name, false);
+	bool found;
+	RzPVector /*<RzBaseType*>*/ *btypes = ht_sp_find(typedb->types, btype->name, &found);
+	if (!found) {
+		return false;
+	}
+	void **it;
+	size_t idx = 0;
+	rz_pvector_foreach(btypes, it) {
+		RzBaseType *btype_it = *it;
+		if (rz_type_base_type_same_scope(btype_it, btype)) {
+			rz_pvector_remove_at(btypes, idx); // TODO: consider using RzList<RzBaseType*> instead of RzPVector<RzBaseType*> for typedb->types
+			break;
+		}
+		++idx;
+	}
 	return true;
 }
 
@@ -84,9 +98,13 @@ struct list_kind {
 
 static bool base_type_kind_collect_cb(void *user, RZ_UNUSED const char *k, const void *v) {
 	struct list_kind *l = user;
-	RzBaseType *btype = (RzBaseType *)v;
-	if (l->kind == btype->kind) {
-		rz_list_append(l->types, btype);
+	RzPVector /*<RzBaseType*>*/ *btypes = (RzPVector*)v;
+	void **it;
+	rz_pvector_foreach(btypes, it) {
+		RzBaseType *btype = *it;
+		if (l->kind == btype->kind) {
+			rz_list_append(l->types, btype);
+		}
 	}
 	return true;
 }
@@ -108,7 +126,13 @@ RZ_API RZ_OWN RzList /*<RzBaseType *>*/ *rz_type_db_get_base_types_of_kind(const
 static bool base_type_collect_cb(void *user, RZ_UNUSED const char *k, const void *v) {
 	rz_return_val_if_fail(user && k && v, false);
 	RzList *l = user;
-	rz_list_append(l, (void *)v);
+	RzPVector /*<RzBaseType*>*/ *btypes = (RzPVector*)v;
+	
+	void **it;
+	rz_pvector_foreach(btypes, it) {
+		rz_list_append(l, *it);
+	}
+
 	return true;
 }
 
@@ -262,17 +286,34 @@ RZ_API RZ_OWN RzBaseType *rz_type_base_type_new(RzBaseTypeKind kind) {
 	return type;
 }
 
+RZ_API bool rz_type_base_type_same_scope(const RzBaseType *a, const RzBaseType *b) {
+	return RZ_STR_EQ(a->scope.cu_name, b->scope.cu_name);
+}
+
 /**
- * \brief Saves RzBaseType into the Types DB
+ * \brief Saves RzBaseType into the Types DB. Frees the type if fails.
  *
  * \param typedb Type Database instance
  * \param type RzBaseType to save
  */
-RZ_API bool rz_type_db_save_base_type(const RzTypeDB *typedb, RzBaseType *type) {
-	rz_return_val_if_fail(typedb && type && type->name, false);
-	if (!ht_sp_insert(typedb->types, type->name, (void *)type)) {
-		rz_type_base_type_free(type);
-		return false;
+RZ_API bool rz_type_db_save_base_type(const RzTypeDB *typedb, RzBaseType *btype) {
+	rz_return_val_if_fail(typedb && btype && btype->name, false);
+	bool found;
+	RzPVector /*<RzBaseType*>*/ *btypes = ht_sp_find(typedb->types, btype->name, &found);
+	if (!found) {
+		btypes = rz_pvector_new((void (*)(void*))rz_type_base_type_free);
+		ht_sp_insert(typedb->types, btype->name, btypes);
+		rz_pvector_push(btypes, btype);
+	} else {
+		void** it;
+		rz_pvector_foreach(btypes, it) {
+			RzBaseType *btype_it = *it;
+			if (rz_type_base_type_same_scope(btype, btype_it)) { // same name & same scope => btypes are same
+				rz_type_base_type_free(btype);
+				return false;
+			}
+		}
+		rz_pvector_push(btypes, btype);
 	}
 	return true;
 }
@@ -283,12 +324,31 @@ RZ_API bool rz_type_db_save_base_type(const RzTypeDB *typedb, RzBaseType *type) 
  * \param typedb Type Database instance
  * \param type RzBaseType to save
  */
-RZ_API bool rz_type_db_update_base_type(const RzTypeDB *typedb, RzBaseType *type) {
-	rz_return_val_if_fail(typedb && type && type->name, false);
-	if (!ht_sp_update(typedb->types, type->name, (void *)type)) {
-		rz_type_base_type_free(type);
-		return false;
+RZ_API bool rz_type_db_update_base_type(const RzTypeDB *typedb, RZ_OWN RzBaseType *btype) {
+	rz_return_val_if_fail(typedb && btype && btype->name, false);
+	bool found;
+	RzPVector /*<RzBaseType*>*/ *btypes = ht_sp_find(typedb->types, btype->name, &found);
+	if (!found) {
+		btypes = rz_pvector_new((void (*)(void*))rz_type_base_type_free);
+		ht_sp_insert(typedb->types, btype->name, btypes);
+		rz_pvector_push(btypes, btype);
+	} else {
+		void** it;
+		found = false;
+		rz_pvector_foreach(btypes, it) {
+			RzBaseType *btype_it = *it;
+			if (rz_type_base_type_same_scope(btype, btype_it)) {
+				*(RzBaseType**)it = btype; // replace vector element at this position
+				rz_type_base_type_free(btype_it);
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			rz_pvector_push(btypes, btype);
+		}
 	}
+	// TODO: change doxygen OR free on failure indeed.
 	return true;
 }
 

--- a/librz/type/type.c
+++ b/librz/type/type.c
@@ -27,7 +27,7 @@ RZ_API RzTypeDB *rz_type_db_new() {
 		return NULL;
 	}
 	typedb->target->default_type = strdup("int");
-	typedb->types = ht_sp_new(HT_STR_DUP, NULL, (HtSPFreeValue)rz_type_base_type_free);
+	typedb->types = ht_sp_new(HT_STR_DUP, NULL, (HtSPFreeValue)rz_pvector_free);
 	if (!typedb->types) {
 		goto rz_type_db_new_fail;
 	}
@@ -82,7 +82,7 @@ RZ_API void rz_type_db_purge(RzTypeDB *typedb) {
 	ht_sp_free(typedb->callables);
 	typedb->callables = ht_sp_new(HT_STR_DUP, NULL, (HtSPFreeValue)rz_type_callable_free);
 	ht_sp_free(typedb->types);
-	typedb->types = ht_sp_new(HT_STR_DUP, NULL, (HtSPFreeValue)rz_type_base_type_free);
+	typedb->types = ht_sp_new(HT_STR_DUP, NULL, (HtSPFreeValue)rz_pvector_free);
 	rz_type_parser_free(typedb->parser);
 	typedb->parser = rz_type_parser_init(typedb->types, typedb->callables);
 }


### PR DESCRIPTION
Addresses #4421 .
 <!-- Filling this template is mandatory -->
- [ ] Introduce `RzTypeScope`. 
- [x] Make the `*_by_offset` hashtables in `dwarf_process.c` being attached to 1 compilation unit: allocate at the beginning, free before the end of processing current CU.
- [ ] Change implementation of "by name" type requests.
- [ ] Refactor API usage of "by name" type requests.
- [ ] Additional API

# Introduce `RzTypeScope`
Should be a tree-like independent structure like this:
```
┌──────┐                                          
│ src  │                                          
└──┬───┘                                          
   │     ┌────────┐                               
   ├─────┤ headers│                               
   │     └───┬────┘                               
   │         │         ┌►struct A;                
   │         └►inc.h───┤                          
   │                   └►enum E;                  
   │     ┌────────┐                               
   └─────┤  src   │                               
         └───┬────┘                               
             │                                    
             │   ┌────────┐                       
             ├───┤   a    │                       
             │   └───┬────┘                       
             │       └───► a.c───►struct A;       
             │                                    
             ├──► b.c─┬─►struct B;                
             │        │                           
             │        └─►typedef struct B A;      
             │                                    
             └──► c.c (includes headers/inc.h)    
                   │                              
                   ├───► struct A; (headers/inc.h)
                   │                              
                   └───► enum E; (headers/inc.h)  
```

# Change API implementation of "by name" type requests.
- [x] `rz_type_db_get_base_type`
- [ ] `rz_type_db_get_compound_type`
- [x] `rz_type_db_save_base_type`
- [x] `rz_type_db_update_base_type`
- [x] `rz_type_db_delete_base_type`
- [x] `rz_type_db_get_base_types_of_kind`
- [x] `rz_type_db_get_base_types`
- [ ] `rz_type_db_edit_base_type`
- [ ] `rz_type_db_base_type_unwrap_typedef`

# Refactor API usage of "by name" type requests.

`typedb->types` usage:
- [x] `base.c`
- [ ] `serialize_types.c`
- [ ] `type.c`
- [ ] `typeclass.c`
- [ ] `c_cpp_parser.c`
- [ ] `test_type.c`

`rz_type_db.*base_type` usage:
- [ ] `dwarf_process.c`
- [ ] `pdb_process.c`
- [ ] `cpdb.c`
- [ ] `ctypes.c`
- [ ] `base.c`
- [ ] `format.c`
- [ ] `helpers.c`
- [ ] `path.c`
- [ ] `type.c`
- [ ] `typeclass.c`
- [ ] `test_dwarf_integration.c`
- [ ] `test_pdb.c`
- [ ] `test_project_migrate.c`
- [ ] `test_analysis_function.c`
- [ ] `test_serialize_types.c`
- [ ] `test_type.c`

# Additional API
- [ ] get all types for the given scope
- [ ] remove all types for the given scope

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
