### PR TITLE
core/canalysis.c: fix the ignored parameter in rz_core_analysis_function_signature_editor

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4647,9 +4647,9 @@ err:
 }
 
 RZ_IPI void rz_core_analysis_function_signature_editor(RzCore *core, ut64 addr) {
-	RzAnalysisFunction *f = rz_analysis_get_fcn_in(core->analysis, core->offset, -1);
+	RzAnalysisFunction *f = rz_analysis_get_fcn_in(core->analysis, addr, -1);
 	if (!f) {
-		RZ_LOG_ERROR("core: cannot find function in 0x%08" PFMT64x "\n", core->offset);
+		RZ_LOG_ERROR("core: cannot find function in 0x%08" PFMT64x "\n", addr);
 		return;
 	}
 


### PR DESCRIPTION

The key `s` doesn't work properly in `Vv` mode. Even if we change selected functions by `j` and `k`, the shown function signature doesn't change.

It seems that `rz_core_analysis_function_signature_editor` forgets to use the parameter `addr`.

https://github.com/rizinorg/rizin/assets/58985155/bcd4fac8-92b5-42d5-bcba-f10797e37321



 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
