### PR TITLE
Fix hexagon double free under `-q`

### DIFF
--- a/librz/arch/p/asm/asm_hexagon.c
+++ b/librz/arch/p/asm/asm_hexagon.c
@@ -129,7 +129,7 @@ static bool hex_cfg_set(void *user, void *data) {
 	}
 	if (cnode) {
 		pnode->i_value = cnode->i_value;
-		pnode->value = cnode->value;
+		pnode->value = strdup(cnode->value);
 		return true;
 	}
 	return false;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following hexagon double free under `-q` (https://github.com/rizinorg/rizin/actions/runs/8965564640/job/24619305838#step:19:631):

![hexagon-double-free](https://github.com/rizinorg/rizin/assets/12002672/f97266c6-933d-4a63-9106-4f7fdb0b0630)

This is a cherry-pick of a commit in #4468, and is a cherry-pick of rizinorg/rz-hexagon@d24f455204290a4f7bf40d93ab1194a4523fc92f done by hand.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
