### PR TITLE
Fix dbginfo double free under `-q`

### DIFF
--- a/librz/bin/dbginfo.c
+++ b/librz/bin/dbginfo.c
@@ -152,7 +152,11 @@ RZ_API void rz_bin_source_line_info_free(RzBinSourceLineInfo *sli) {
  */
 RZ_API bool rz_bin_source_line_info_merge(RZ_BORROW RZ_NONNULL RzBinSourceLineInfo *dst, RZ_BORROW RZ_NONNULL RzBinSourceLineInfo *src) {
 	rz_return_val_if_fail(dst && src, false);
-	RzBinSourceLineSample *tmp = realloc(dst->samples, sizeof(RzBinSourceLineSample) * (dst->samples_count + src->samples_count));
+	size_t new_samples_count = dst->samples_count + src->samples_count;
+	if (!new_samples_count) {
+		return true;
+	}
+	RzBinSourceLineSample *tmp = realloc(dst->samples, sizeof(RzBinSourceLineSample) * new_samples_count);
 	if (!tmp) {
 		return false;
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following dbginfo double free under `-q` (https://github.com/rizinorg/rizin/actions/runs/9019207977/job/24781590009?pr=4468#step:19:137):

![dbginfo-dbl-free](https://github.com/rizinorg/rizin/assets/12002672/0830c831-657d-488c-bdd4-4d69b78a06ab)

This is a cherry-pick from #4468.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
