### PR TITLE
flags: new `fdt` command to print more information about flag

### DIFF
--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -21123,10 +21123,10 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *flag_comment_cd = rz_cmd_desc_argv_new(core->rcmd, f_cd, "fC", rz_flag_comment_handler, &flag_comment_help);
 	rz_warn_if_fail(flag_comment_cd);
 
-	RzCmdDesc *fd_cd = rz_cmd_desc_group_state_new(core->rcmd, f_cd, "fd", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_flag_describe_handler, &flag_describe_help, &fd_help);
+	RzCmdDesc *fd_cd = rz_cmd_desc_group_state_new(core->rcmd, f_cd, "fd", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_TABLE | RZ_OUTPUT_MODE_JSON, rz_flag_describe_handler, &flag_describe_help, &fd_help);
 	rz_warn_if_fail(fd_cd);
 	rz_cmd_desc_set_default_mode(fd_cd, RZ_OUTPUT_MODE_STANDARD);
-	RzCmdDesc *flag_describe_at_cd = rz_cmd_desc_argv_state_new(core->rcmd, fd_cd, "fd.", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_flag_describe_at_handler, &flag_describe_at_help);
+	RzCmdDesc *flag_describe_at_cd = rz_cmd_desc_argv_state_new(core->rcmd, fd_cd, "fd.", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_TABLE | RZ_OUTPUT_MODE_JSON, rz_flag_describe_at_handler, &flag_describe_at_help);
 	rz_warn_if_fail(flag_describe_at_cd);
 	rz_cmd_desc_set_default_mode(flag_describe_at_cd, RZ_OUTPUT_MODE_STANDARD);
 

--- a/librz/core/cmd_descs/cmd_flag.yaml
+++ b/librz/core/cmd_descs/cmd_flag.yaml
@@ -206,6 +206,7 @@ commands:
         default_mode: RZ_OUTPUT_MODE_STANDARD
         modes:
           - RZ_OUTPUT_MODE_STANDARD
+          - RZ_OUTPUT_MODE_TABLE
           - RZ_OUTPUT_MODE_JSON
         args: []
       - name: fd.
@@ -215,6 +216,7 @@ commands:
         default_mode: RZ_OUTPUT_MODE_STANDARD
         modes:
           - RZ_OUTPUT_MODE_STANDARD
+          - RZ_OUTPUT_MODE_TABLE
           - RZ_OUTPUT_MODE_JSON
         args: []
       - name: fdw


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Extend `fd` commands to provide more information about the flags:
```
[0x100003a84]> fd?
Usage: fd[jt.w]   # Describe flag
| fd[jt]       # Describe flag + delta for the current offset
| fd.[jt]      # Describe flags for the current offset
| fdw <string> # Describe closest flag by string for the current offset
[0x100003a84]> fdt
name realname vaddr       paddr      size comment
--------------------------------------------------
main main     0x100003a84 0x00013a84 3016
[0x100003a84]> fd.t
name               realname       vaddr       paddr      size comment
----------------------------------------------------------------------
main               main           0x100003a84 0x00013a84 3016
entry0             entry0         0x100003a84 0x00013a84 3016
sym.func.100003a84 func.100003a84 0x100003a84 0x00013a84 0
pc                 pc             0x100003a84 0x00013a84 8
[0x100003a84]>
```

**Test plan**

- Try `fdt` and `fd.t`.

Closes https://github.com/rizinorg/rizin/issues/4498