### PR TITLE
Support ARM ELF THM_PC22 / THM_JUMP24 relocs

### DIFF
--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -1023,7 +1023,7 @@ static void patch_reloc_hexagon(RZ_INOUT RzBuffer *buf_patched, const ut64 patch
 // AARCH64-specific defines
 // Take the PAGE component of an address or offset.
 #define PG(x)         ((x) & ~0xFFFULL)
-#define PG_OFFSET(x)  ((x)&0xFFFULL)
+#define PG_OFFSET(x)  ((x) & 0xFFFULL)
 #define ADR_IMM_MASK1 (((1U << 2) - 1) << 29)
 #define ADR_IMM_MASK2 (((1U << 19) - 1) << 5)
 #define ADR_IMM_MASK3 (((1U << 19) - 1) << 2)
@@ -1040,14 +1040,41 @@ static void patch_reloc(struct Elf_(rz_bin_elf_obj_t) * obj, RzBinElfReloc *rel,
 	case EM_QDSP6:
 		patch_reloc_hexagon(obj->buf_patched, patch_addr, rel->type, &formular_sym);
 		break;
-	case EM_ARM:
-		val = S + A;
-		if (!rel->sym && rel->mode == DT_REL) {
-			rz_buf_read_at(obj->buf_patched, patch_addr, buf, 4);
-			val += obj->big_endian ? rz_read_be32(buf) : rz_read_le32(buf);
+	case EM_ARM: {
+		ut16 keephw1, keephw2;
+		ut32 nbytes = 4;
+		rz_buf_read_at(obj->buf_patched, patch_addr, buf, 4);
+		switch (rel->type) {
+		case RZ_ARM_THM_JUMP24:
+		case RZ_ARM_THM_PC22:
+			// Encoding B  T4, BL T1, BLX T2: Val = S:I1:I2:imm10:imm11:0
+			// I1 = NOT(J1 EOR S)
+			// I2 = NOT(J2 EOR S)
+			val = S + A;
+			keephw1 = rz_read_ble16(&buf[0], big_endian);
+			keephw2 = rz_read_ble16(&buf[2], big_endian);
+			rz_write_ble16(&buf[0],
+				(keephw1 & 0xF800U) | // opcode
+					((val >> 14) & 0x0400U) | // sign
+					((val >> 12) & 0x03FFU), // imm 10
+				big_endian);
+			rz_write_ble16(&buf[2],
+				(keephw2 & 0xD000U) | // opcode
+					(((~(val >> 10)) ^ (val >> 11)) & 0x2000) | // J1
+					(((~(val >> 11)) ^ (val >> 13)) & 0x0800) | // J2
+					((val >> 1) & 0x07ff), // imm11
+				big_endian);
+			break;
+		default:
+			val = S + A;
+			if (!rel->sym && rel->mode == DT_REL) {
+				val += rz_read_ble32(buf, big_endian);
+			}
+			rz_write_ble32(buf, val, big_endian);
 		}
-		rz_buf_write_ble32_at(obj->buf_patched, patch_addr, val, obj->big_endian);
+		rz_buf_write_at(obj->buf_patched, patch_addr, buf, nbytes);
 		break;
+	}
 	case EM_AARCH64: {
 		ut32 keep;
 		ut32 nbytes = 4;
@@ -1435,6 +1462,7 @@ static RzBinReloc *reloc_convert(ELFOBJ *bin, RzBinElfReloc *rel, ut64 GOT) {
 		case RZ_ARM_CALL: ADD(24, -P);
 		case RZ_ARM_JUMP24: ADD(24, -P);
 		case RZ_ARM_THM_JUMP24: ADD(24, -P);
+		case RZ_ARM_THM_PC22: ADD(24, -P);
 		case RZ_ARM_PREL31: ADD(32, -P);
 		case RZ_ARM_MOVW_PREL_NC: ADD(16, -P);
 		case RZ_ARM_MOVT_PREL: ADD(32, -P);

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -1023,7 +1023,7 @@ static void patch_reloc_hexagon(RZ_INOUT RzBuffer *buf_patched, const ut64 patch
 // AARCH64-specific defines
 // Take the PAGE component of an address or offset.
 #define PG(x)         ((x) & ~0xFFFULL)
-#define PG_OFFSET(x)  ((x) & 0xFFFULL)
+#define PG_OFFSET(x)  ((x)&0xFFFULL)
 #define ADR_IMM_MASK1 (((1U << 2) - 1) << 29)
 #define ADR_IMM_MASK2 (((1U << 19) - 1) << 5)
 #define ADR_IMM_MASK3 (((1U << 19) - 1) << 2)

--- a/test/db/formats/elf/elf-relarm
+++ b/test/db/formats/elf/elf-relarm
@@ -116,6 +116,26 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=ELF: arm thumb relocs 1
+FILE=bins/elf/mbedtls-bignum-thumb-interwork.so
+CMDS=<<EOF
+ir~?
+# ARM_THM_PC22
+s 0x08000b82
+pf bbbb
+pd 1
+EOF
+EXPECT=<<EOF
+4810
+0x08000b82 = 0x19
+0x08000b83 = 0xf0
+0x08000b84 = 0xaa
+0x08000b85 = 0xfa
+            ;-- memset:
+            0x08000b82      bl    memset                               ; RELOC 24 memset
+EOF
+RUN
+
 NAME=ELF: arm64 relocs 1
 FILE=bins/elf/r2pay-arm64.so
 CMDS=<<EOF


### PR DESCRIPTION
This revision adds proper support for the following ARM ELF relocations:

- `RZ_ARM_THM_PC22`
- `RZ_ARM_THM_JUMP24`

These require a rather special encoding as some bits of the relative offset are encoded in a non-common fashion.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

As of now, rizin implements a rather rudimentary handling of ARM ELF Relocation: it just overwrites the the patch address with the value calculated for the symbol. While this works in some cases, there are others that do not, most notably `ARM_THM_PC22` and `ARM_THM_JUMP24` that use a quite _different_ encoding.

With this change, the relocations are correctly handled and lead to properly encoded values. Note that this change doesn't handle possible overflows for which some thunk would need to be inserted.

The implementation was heavily inspired by [lld's implementation](https://github.com/llvm/llvm-project/blob/597ac471cc7da97ccf957362a7e9f7a52d6910ee/lld/ELF/Arch/ARM.cpp#L601), although the special cases (e.g. BL/BLX patching, missing J1J2 support) are not considered in this change.

I did not extend the documentation as it is not that detailed / does not even exist here.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

To test the change, it would be sufficient to check that after relocation, the `bl` instruction to the proper target exists and is not replaced by some unrelated instruction.

Example:

Previously:

    ┌ sym.mbedtls_md5_init();
    │           0x08000034      push  {r3, lr}                             ; RELOC TARGET 32 .text.mbedtls_md5_init @ 0x08000034 ; [04] -r-x section size 12 named .text.mbedtls_md5_init
    │           0x08000036      movs  r1, 0
    │           0x08000038      movs  r2, 0x58                             ; 'X'
    │           ;-- memset:
    │           0x0800003a      ldr   r0, [r1, 0xc]                        ; RELOC 32 memset
    │           0x0800003c      lsrs  r0, r0, 0x20
    └           0x0800003e      pop   {r3, pc}


With this change:

    ┌ sym.mbedtls_md5_init();
    │           0x08000034      push  {r3, lr}                             ; RELOC TARGET 32 .text.mbedtls_md5_init @ 0x08000034 ; [04] -r-x section size 12 named .text.mbedtls_md5_init
    │           0x08000036      movs  r1, 0
    │           0x08000038      movs  r2, 0x58                             ; 'X'
    │           ;-- memset:
    │           0x0800003a      bl    memset                               ; RELOC 24 memset
    └           0x0800003e      pop   {r3, pc}


I added a test for a binary that contains THM_PC22.


**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

-
