### PR TITLE
Refactor of rz-test to use thread safe functions.

### DIFF
--- a/binrz/rz-test/run.c
+++ b/binrz/rz-test/run.c
@@ -558,7 +558,7 @@ RZ_API RzTestResultInfo *rz_test_run_test(RzTestRunConfig *config, RzTest *test)
 	return ret;
 }
 
-RZ_API void rz_test_test_result_info_free(RzTestResultInfo *result) {
+RZ_API void rz_test_result_info_free(RZ_NULLABLE RzTestResultInfo *result) {
 	if (!result) {
 		return;
 	}

--- a/binrz/rz-test/rz_test.h
+++ b/binrz/rz-test/rz_test.h
@@ -213,6 +213,6 @@ RZ_API void rz_test_test_free(RzTest *test);
 RZ_API char *rz_test_test_name(RzTest *test);
 RZ_API bool rz_test_test_broken(RzTest *test);
 RZ_API RzTestResultInfo *rz_test_run_test(RzTestRunConfig *config, RzTest *test);
-RZ_API void rz_test_test_result_info_free(RzTestResultInfo *result);
+RZ_API void rz_test_result_info_free(RZ_NULLABLE RzTestResultInfo *result);
 
 #endif // RIZIN_RZTEST_H

--- a/librz/util/subprocess.c
+++ b/librz/util/subprocess.c
@@ -57,6 +57,7 @@ typedef struct subprocess_windows_t {
 	DWORD mode_stderr;
 } SubprocessWindows;
 
+// This structure is used by init/fini
 static SubprocessWindows subwin = { 0 };
 
 static bool create_pipe_overlap(HANDLE *pipe_read, HANDLE *pipe_write, LPSECURITY_ATTRIBUTES attrs, DWORD sz, DWORD read_mode, DWORD write_mode) {
@@ -751,12 +752,13 @@ struct rz_subprocess_t {
 };
 
 typedef struct subprocess_unix_t {
-	RzPVector subprocs;
+	RzPVector /*<RzSubprocess *>*/ subprocs;
 	RzThreadLock *subprocs_mutex;
 	int sigchld_pipe[2];
 	RzThread *sigchld_thread;
 } SubprocessUnix;
 
+// This structure is used by init/fini
 static SubprocessUnix subnix = { 0 };
 
 static void subprocess_lock(void) {

--- a/librz/util/subprocess.c
+++ b/librz/util/subprocess.c
@@ -47,13 +47,17 @@ struct rz_subprocess_t {
 
 #define INVALID_POINTER_VALUE ((void *)PTRDIFF_MAX)
 
-static RzThreadLock *subproc_mutex = NULL;
-static long refcount = 0;
-static bool has_procthreadattr = false;
-static volatile long pipe_id = 0;
-static DWORD mode_stdin;
-static DWORD mode_stdout;
-static DWORD mode_stderr;
+typedef struct subprocess_windows_t {
+	RzThreadLock *subproc_mutex;
+	long refcount;
+	bool has_procthreadattr;
+	volatile long pipe_id;
+	DWORD mode_stdin;
+	DWORD mode_stdout;
+	DWORD mode_stderr;
+} SubprocessWindows;
+
+static SubprocessWindows subwin = { 0 };
 
 static bool create_pipe_overlap(HANDLE *pipe_read, HANDLE *pipe_write, LPSECURITY_ATTRIBUTES attrs, DWORD sz, DWORD read_mode, DWORD write_mode) {
 	// see https://stackoverflow.com/a/419736
@@ -61,7 +65,7 @@ static bool create_pipe_overlap(HANDLE *pipe_read, HANDLE *pipe_write, LPSECURIT
 		sz = 4096;
 	}
 	WCHAR name[MAX_PATH];
-	_snwprintf_s(name, _countof(name), sizeof(name), L"\\\\.\\pipe\\rz-pipe-subproc.%d.%ld", (int)GetCurrentProcessId(), (long)InterlockedIncrement(&pipe_id));
+	_snwprintf_s(name, _countof(name), sizeof(name), L"\\\\.\\pipe\\rz-pipe-subproc.%d.%ld", (int)GetCurrentProcessId(), (long)InterlockedIncrement(&subwin.pipe_id));
 	*pipe_read = CreateNamedPipeW(name, PIPE_ACCESS_INBOUND | read_mode, PIPE_TYPE_BYTE | PIPE_WAIT, 1, sz, sz, 120 * 1000, attrs);
 	if (!*pipe_read) {
 		return FALSE;
@@ -79,29 +83,29 @@ static bool create_pipe_overlap(HANDLE *pipe_read, HANDLE *pipe_write, LPSECURIT
 static RzThreadLock *get_subprocess_lock(void) {
 	RzThreadLock *lock;
 	do {
-		lock = InterlockedCompareExchangePointer(&subproc_mutex, INVALID_POINTER_VALUE, INVALID_POINTER_VALUE);
+		lock = InterlockedCompareExchangePointer(&subwin.subproc_mutex, INVALID_POINTER_VALUE, INVALID_POINTER_VALUE);
 	} while (!lock);
 	return lock;
 }
 
 RZ_API bool rz_subprocess_init(void) {
-	long ref = InterlockedIncrement(&refcount);
+	long ref = InterlockedIncrement(&subwin.refcount);
 	RzThreadLock *lock = NULL;
 	if (ref == 1) {
 		lock = rz_th_lock_new(false);
 		if (!lock) {
-			InterlockedExchangePointer(&subproc_mutex, INVALID_POINTER_VALUE);
-			InterlockedDecrement(&refcount);
+			InterlockedExchangePointer(&subwin.subproc_mutex, INVALID_POINTER_VALUE);
+			InterlockedDecrement(&subwin.refcount);
 			return false;
 		}
 		// Enter lock before making it available, so we are the first to run
 		rz_th_lock_enter(lock);
-		InterlockedExchangePointer(&subproc_mutex, lock);
+		InterlockedExchangePointer(&subwin.subproc_mutex, lock);
 	} else {
 		// Spin until theres a lock available or lock initialization failed
 		lock = get_subprocess_lock();
 		if (lock == INVALID_POINTER_VALUE) {
-			InterlockedDecrement(&refcount);
+			InterlockedDecrement(&subwin.refcount);
 			return false;
 		}
 		rz_th_lock_enter(lock);
@@ -113,12 +117,12 @@ RZ_API bool rz_subprocess_init(void) {
 	}
 
 	// Save current console mode
-	GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &mode_stdin);
-	GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &mode_stdout);
-	GetConsoleMode(GetStdHandle(STD_ERROR_HANDLE), &mode_stderr);
+	GetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), &subwin.mode_stdin);
+	GetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), &subwin.mode_stdout);
+	GetConsoleMode(GetStdHandle(STD_ERROR_HANDLE), &subwin.mode_stderr);
 
 #if NTDDI_VERSION >= NTDDI_VISTA
-	if (!has_procthreadattr && IsWindowsVistaOrGreater()) {
+	if (!subwin.has_procthreadattr && IsWindowsVistaOrGreater()) {
 		HMODULE kernel32 = LoadLibraryW(L"kernel32");
 		if (!kernel32) {
 			rz_sys_perror("LoadLibraryW(L\"kernel32\")");
@@ -128,7 +132,7 @@ RZ_API bool rz_subprocess_init(void) {
 		lpUpdateProcThreadAttribute = (UpdateProcThreadAttribute_t)GetProcAddress(kernel32, "UpdateProcThreadAttribute");
 		lpDeleteProcThreadAttributeList = (DeleteProcThreadAttributeList_t)GetProcAddress(kernel32, "DeleteProcThreadAttributeList");
 		if (lpInitializeProcThreadAttributeList && lpUpdateProcThreadAttribute && lpDeleteProcThreadAttributeList) {
-			has_procthreadattr = true;
+			subwin.has_procthreadattr = true;
 		}
 		FreeLibrary(kernel32);
 	}
@@ -140,22 +144,22 @@ leave:
 RZ_API void rz_subprocess_fini(void) {
 	RzThreadLock *lock = NULL;
 	do {
-		if (InterlockedCompareExchange(&refcount, -1, -1) == 0) {
+		if (InterlockedCompareExchange(&subwin.refcount, -1, -1) == 0) {
 			// Shouldn't happen, someone called this function excessively
 			rz_warn_if_reached();
 			return;
 		}
-		lock = InterlockedExchangePointer(&subproc_mutex, NULL);
+		lock = InterlockedExchangePointer(&subwin.subproc_mutex, NULL);
 	} while (!lock);
-	if (InterlockedDecrement(&refcount) > 0) {
-		InterlockedExchangePointer(&subproc_mutex, lock);
+	if (InterlockedDecrement(&subwin.refcount) > 0) {
+		InterlockedExchangePointer(&subwin.subproc_mutex, lock);
 		return;
 	}
 	SetEnvironmentVariableW(L"RZ_PIPE_PATH", NULL);
 	// Restore console mode
-	SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), mode_stdin);
-	SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), mode_stdout);
-	SetConsoleMode(GetStdHandle(STD_ERROR_HANDLE), mode_stderr);
+	SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), subwin.mode_stdin);
+	SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), subwin.mode_stdout);
+	SetConsoleMode(GetStdHandle(STD_ERROR_HANDLE), subwin.mode_stderr);
 	rz_th_lock_free(lock);
 }
 
@@ -373,7 +377,7 @@ RZ_API RZ_OWN RzSubprocess *rz_subprocess_start_opt(RZ_NONNULL const RzSubproces
 	STARTUPINFOW *start_info = &start_info_short;
 #if NTDDI_VERSION >= NTDDI_VISTA
 	STARTUPINFOEXW start_infoex = { .StartupInfo.cb = sizeof(STARTUPINFOEXW) };
-	if (has_procthreadattr) {
+	if (subwin.has_procthreadattr) {
 		SIZE_T attr_list_size = 0;
 		if (!lpInitializeProcThreadAttributeList(NULL, 1, 0, &attr_list_size) &&
 			GetLastError() != ERROR_INSUFFICIENT_BUFFER) {

--- a/librz/util/subprocess.c
+++ b/librz/util/subprocess.c
@@ -750,28 +750,32 @@ struct rz_subprocess_t {
 	int slave_fd;
 };
 
-static RzPVector subprocs;
-static RzThreadLock *subprocs_mutex;
-static int sigchld_pipe[2];
-static RzThread *sigchld_thread;
+typedef struct subprocess_unix_t {
+	RzPVector subprocs;
+	RzThreadLock *subprocs_mutex;
+	int sigchld_pipe[2];
+	RzThread *sigchld_thread;
+} SubprocessUnix;
+
+static SubprocessUnix subnix = { 0 };
 
 static void subprocess_lock(void) {
-	rz_th_lock_enter(subprocs_mutex);
+	rz_th_lock_enter(subnix.subprocs_mutex);
 }
 
 static void subprocess_unlock(void) {
-	rz_th_lock_leave(subprocs_mutex);
+	rz_th_lock_leave(subnix.subprocs_mutex);
 }
 
 static void handle_sigchld(int sig) {
 	ut8 b = 1;
-	rz_xwrite(sigchld_pipe[1], &b, 1);
+	rz_xwrite(subnix.sigchld_pipe[1], &b, 1);
 }
 
 static void *sigchld_th(void *th) {
 	while (true) {
 		ut8 b;
-		ssize_t rd = read(sigchld_pipe[0], &b, 1);
+		ssize_t rd = read(subnix.sigchld_pipe[0], &b, 1);
 		if (rd <= 0) {
 			if (rd < 0) {
 				if (errno == EINTR) {
@@ -793,7 +797,7 @@ static void *sigchld_th(void *th) {
 			subprocess_lock();
 			void **it;
 			RzSubprocess *proc = NULL;
-			rz_pvector_foreach (&subprocs, it) {
+			rz_pvector_foreach (&subnix.subprocs, it) {
 				RzSubprocess *p = *it;
 				if (p->pid == pid) {
 					proc = p;
@@ -819,27 +823,27 @@ static void *sigchld_th(void *th) {
 }
 
 RZ_API bool rz_subprocess_init(void) {
-	rz_pvector_init(&subprocs, NULL);
-	subprocs_mutex = rz_th_lock_new(true);
-	if (!subprocs_mutex) {
+	rz_pvector_init(&subnix.subprocs, NULL);
+	subnix.subprocs_mutex = rz_th_lock_new(true);
+	if (!subnix.subprocs_mutex) {
 		return false;
 	}
-	if (rz_sys_pipe(sigchld_pipe, true) == -1) {
+	if (rz_sys_pipe(subnix.sigchld_pipe, true) == -1) {
 		perror("pipe");
-		rz_th_lock_free(subprocs_mutex);
+		rz_th_lock_free(subnix.subprocs_mutex);
 		return false;
 	}
-	sigchld_thread = rz_th_new(sigchld_th, NULL);
-	if (!sigchld_thread) {
-		rz_sys_pipe_close(sigchld_pipe[0]);
-		rz_sys_pipe_close(sigchld_pipe[1]);
-		rz_th_lock_free(subprocs_mutex);
+	subnix.sigchld_thread = rz_th_new(sigchld_th, NULL);
+	if (!subnix.sigchld_thread) {
+		rz_sys_pipe_close(subnix.sigchld_pipe[0]);
+		rz_sys_pipe_close(subnix.sigchld_pipe[1]);
+		rz_th_lock_free(subnix.subprocs_mutex);
 		return false;
 	}
 	if (rz_sys_signal(SIGCHLD, handle_sigchld) < 0) {
-		rz_sys_pipe_close(sigchld_pipe[0]);
-		rz_sys_pipe_close(sigchld_pipe[1]);
-		rz_th_lock_free(subprocs_mutex);
+		rz_sys_pipe_close(subnix.sigchld_pipe[0]);
+		rz_sys_pipe_close(subnix.sigchld_pipe[1]);
+		rz_th_lock_free(subnix.subprocs_mutex);
 		return false;
 	}
 	return true;
@@ -848,13 +852,13 @@ RZ_API bool rz_subprocess_init(void) {
 RZ_API void rz_subprocess_fini(void) {
 	rz_sys_signal(SIGCHLD, SIG_IGN);
 	ut8 b = 0;
-	rz_xwrite(sigchld_pipe[1], &b, 1);
-	rz_sys_pipe_close(sigchld_pipe[1]);
-	rz_th_wait(sigchld_thread);
-	rz_sys_pipe_close(sigchld_pipe[0]);
-	rz_th_free(sigchld_thread);
-	rz_pvector_clear(&subprocs);
-	rz_th_lock_free(subprocs_mutex);
+	rz_xwrite(subnix.sigchld_pipe[1], &b, 1);
+	rz_sys_pipe_close(subnix.sigchld_pipe[1]);
+	rz_th_wait(subnix.sigchld_thread);
+	rz_sys_pipe_close(subnix.sigchld_pipe[0]);
+	rz_th_free(subnix.sigchld_thread);
+	rz_pvector_clear(&subnix.subprocs);
+	rz_th_lock_free(subnix.subprocs_mutex);
 }
 
 static char **create_child_env(const char *envvars[], const char *envvals[], size_t env_size) {
@@ -1172,7 +1176,7 @@ no_term_change:
 		rz_sys_pipe_close(stderr_pipe[1]);
 	}
 
-	rz_pvector_push(&subprocs, proc);
+	rz_pvector_push(&subnix.subprocs, proc);
 	subprocess_unlock();
 
 	return proc;
@@ -1451,7 +1455,7 @@ RZ_API void rz_subprocess_free(RzSubprocess *proc) {
 		return;
 	}
 	subprocess_lock();
-	rz_pvector_remove_data(&subprocs, proc);
+	rz_pvector_remove_data(&subnix.subprocs, proc);
 	subprocess_unlock();
 	rz_strbuf_fini(&proc->out);
 	rz_strbuf_fini(&proc->err);

--- a/test/unit/test_rz_test.c
+++ b/test/unit/test_rz_test.c
@@ -59,7 +59,7 @@ bool test_rz_test_fix(void) {
 	RzTestDatabase *db = rz_test_test_database_new();
 	database_load(db, FILENAME, 1);
 
-	RzPVector *results = rz_pvector_new((RzPVectorFree)rz_test_test_result_info_free);
+	RzPVector *results = rz_pvector_new((RzPVectorFree)rz_test_result_info_free);
 
 	RzTestResultInfo *result0 = RZ_NEW0(RzTestResultInfo);
 	rz_pvector_push(results, result0);


### PR DESCRIPTION
# do not squash
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This uses the thread-safe functions and cleans up a bit the rz-test code.

Now we automatically detect the core number and use them all unless `-j <n>` is specified.