### PR TITLE
[MSP430] Removed code which deletes indicator characters for certain asm syntaxes

### DIFF
--- a/librz/arch/p/asm/asm_msp430.c
+++ b/librz/arch/p/asm/asm_msp430.c
@@ -21,13 +21,7 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	} else {
 		rz_asm_op_set_asm(op, cmd.instr);
 	}
-	char *buf_asm = rz_strbuf_get(&op->buf_asm);
-	if (a->syntax != RZ_ASM_SYNTAX_ATT) {
-		rz_str_replace_ch(buf_asm, '#', 0, 1);
-		// rz_str_replace_ch (buf_asm, "$", "$$", 1);
-		rz_str_replace_ch(buf_asm, '&', 0, 1);
-		rz_str_replace_ch(buf_asm, '%', 0, 1);
-	}
+
 fail:
 	return op->size = ret;
 }

--- a/test/db/analysis/msp430
+++ b/test/db/analysis/msp430
@@ -8,24 +8,24 @@ echo
 afi
 EOF
 EXPECT=<<EOF
-add 0xff9c, sp
-mov loc..strings, r15
-call loc.puts
+add #0xff9c, sp
+mov #loc..strings, r15
+call #loc.puts
 mov sp, r15
-call loc.get_password
+call #loc.get_password
 mov sp, r15
-call loc.check_password
+call #loc.check_password
 tst r15
 jnz $+0x000c
-mov 0x44c7, r15
-call loc.puts
+mov #0x44c7, r15
+call #loc.puts
 jmp $+0x000e
-mov 0x44e4, r15
-call loc.puts
-call loc.unlock_door
+mov #0x44e4, r15
+call #loc.puts
+call #loc.unlock_door
 clr r15
-add 0x0064, sp
-bis 0x00f0, sr
+add #0x0064, sp
+bis #0x00f0, sr
 jmp $-0x0004
 
 offset: 0x00004438
@@ -65,24 +65,24 @@ echo
 afi
 EOF
 EXPECT=<<EOF
-add 0xff9c, sp
-mov loc..strings, r15
-call loc.puts
+add #0xff9c, sp
+mov #loc..strings, r15
+call #loc.puts
 mov sp, r15
-call loc.get_password
+call #loc.get_password
 mov sp, r15
-call loc.check_password
+call #loc.check_password
 tst r15
 jnz $+0x000c
-mov str.Invalid_password_try_again, r15
-call loc.puts
+mov #str.Invalid_password_try_again, r15
+call #loc.puts
 jmp $+0x000e
-mov str.Access_Granted, r15
-call loc.puts
-call loc.unlock_door
+mov #str.Access_Granted, r15
+call #loc.puts
+call #loc.unlock_door
 clr r15
-add 0x0064, sp
-bis 0x00f0, sr
+add #0x0064, sp
+bis #0x00f0, sr
 jmp $-0x0004
 
 offset: 0x00004438

--- a/test/db/asm/msp430
+++ b/test/db/asm/msp430
@@ -1,20 +1,20 @@
 d "adc r11" 0b63
 d "adc.b r11" 4b63
-d "bic 2, r10" 2ac3
-d "bic 4, r10" 2ac2
-d "bic.b 2, 0x0026" e2c32600
-d "bic.b 4, 0x002e" e2c22e00
-d "bis.b 2, 0x0021" e2d32100
-d "br 0x0021" 30402100
-d "br 0x0003" 10420300
+d "bic #2, r10" 2ac3
+d "bic #4, r10" 2ac2
+d "bic.b #2, &0x0026" e2c32600
+d "bic.b #4, &0x002e" e2c22e00
+d "bis.b #2, &0x0021" e2d32100
+d "br #0x0021" 30402100
+d "br &0x0003" 10420300
 d "br sp" 0041
 d "br r10" 004a
-d "call 0xc096" b01296c0
+d "call #0xc096" b01296c0
 d "clr 0x0033" 80433300
 d "clr 0xfffa(r4)" 8443faff
 d "clrn" 22c2
 d "clrz" 22c3
-d "cmp.b 0x003b, 0x0(r11)" fb903b000000
+d "cmp.b #0x003b, 0x0(r11)" fb903b000000
 d "dadc r11" 0ba3
 d "dadc.b r11" 4ba3
 d "dec r11" 1b83
@@ -25,30 +25,30 @@ d "inv 0x3(r5)" b5e30300
 d "inv r10" 3ae3
 d "jeq $+0x0014" 0924
 d "jmp $+0x0010" 073c
-d "mov 0x0003, 0x5(r9)" b94003000500
-d "mov 0x000a, 0x002a" b0400a002a00
-d "mov 0x0021, 0x6(r11)" bb4021000600
-d "mov 1, 0x002c" 90432c00
-d "mov 8, 0x002c" b0422c00
-d "mov 8, 0x002e" b0422e00
-d "mov 0x0033, 0x002e" 924233002e00
-d "mov 0x0033, 0x002a" 904233002a00
-d "mov 0x3(r6), 0x002e" 924603002e00
+d "mov #0x0003, 0x5(r9)" b94003000500
+d "mov #0x000a, 0x002a" b0400a002a00
+d "mov #0x0021, 0x6(r11)" bb4021000600
+d "mov #1, 0x002c" 90432c00
+d "mov #8, 0x002c" b0422c00
+d "mov #8, 0x002e" b0422e00
+d "mov &0x0033, &0x002e" 924233002e00
+d "mov &0x0033, 0x002a" 904233002a00
+d "mov 0x3(r6), &0x002e" 924603002e00
 d "mov 0x5(r10), 0x6(r11)" 9b4a05000600
-d "mov 0x6(r11), 0x0033" 924b06003300
-d "mov.b 0x0021, r15" 5f422100
-d "mov.b r15, 0x0021" c24f2100
+d "mov 0x6(r11), &0x0033" 924b06003300
+d "mov.b &0x0021, r15" 5f422100
+d "mov.b r15, &0x0021" c24f2100
 d "nop" 0343
 d "pop r11" 3b41
 d "pop r4" 3441
-d "push 1" 1312
+d "push #1" 1312
 d "ret" 3041
 d "sbc r11" 0b73
 d "sbc.b r11" 4b73
 d "setc" 12d3
 d "setz" 22d3
-d "tst 0x0003" 82930300
+d "tst &0x0003" 82930300
 d "tst 0x3(r5)" 85930300
 d "tst r10" 0a93
-d "xor.b 0x0020, r15" 7fe02000
-d "xor.b 8, r15" 7fe2
+d "xor.b #0x0020, r15" 7fe02000
+d "xor.b #8, r15" 7fe2


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This should fix [issue #3324](https://github.com/rizinorg/cutter/issues/3324) in Cutter's bug log. 

...

**Test plan**

I have searched in the git history and tracked the introduction of the deleted code to commit hash [c83d5f4664f222f318f8e4ae3910aeb9e5515902](https://github.com/rizinorg/rizin/commit/c83d5f4664f222f318f8e4ae3910aeb9e5515902), I have tried to find any PR or detailed message associated with this hash, explaining why the code was needed, but I found none, the commit was probably added sometimes in the project's pre-history (back when it was radare2). 

As far as I can see, the deleted code has no other effect or purpose except the undesirable effect of deleting indicator characters from the disassembly when the asm syntax isn't AT&T. Any tests breaking due to the removal of this code are wrong tests that should be removed as well.

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

**To verify**

Run `rz-asm -a msp430 -d 3f401000` on dev and then on this PR's branch. On dev, it produces `mov 0x0010, r15` as output, which is wrong, the correct output should include the character '#' before the constant, as it appears on this PR's branch.