### PR TITLE
Fix NetBSD 10 build

### DIFF
--- a/librz/debug/p/native/bsd/bsd_debug.c
+++ b/librz/debug/p/native/bsd/bsd_debug.c
@@ -64,9 +64,10 @@ static void addr_to_string(struct sockaddr_storage *ss, char *buffer, int buflen
 
 int bsd_handle_signals(RzDebug *dbg) {
 #if __KFBSD__ || __NetBSD__
+	siginfo_t siginfo;
+#if __KFBSD__
 	// Trying to figure out a bit by the signal
 	struct ptrace_lwpinfo linfo = { 0 };
-	siginfo_t siginfo;
 	int ret = ptrace(PT_LWPINFO, dbg->pid, (char *)&linfo, sizeof(linfo));
 	if (ret == -1) {
 		if (errno == ESRCH) {
@@ -83,7 +84,6 @@ int bsd_handle_signals(RzDebug *dbg) {
 		return 0;
 	}
 
-#if __KFBSD__
 	siginfo = linfo.pl_siginfo;
 #else
 	struct ptrace_siginfo sinfo = { 0 };
@@ -108,6 +108,13 @@ int bsd_handle_signals(RzDebug *dbg) {
 	case SIGSEGV:
 		dbg->reason.type = RZ_DEBUG_REASON_SEGFAULT;
 		break;
+#if __NetBSD__
+	case SIGTRAP:
+		if (siginfo.si_code == TRAP_BKPT) {
+			dbg->reason.type = RZ_DEBUG_REASON_BREAKPOINT;
+		}
+		break;
+#endif
 	}
 
 	return 0;

--- a/librz/debug/p/native/bsd/bsd_debug.c
+++ b/librz/debug/p/native/bsd/bsd_debug.c
@@ -110,7 +110,7 @@ int bsd_handle_signals(RzDebug *dbg) {
 		break;
 #if __NetBSD__
 	case SIGTRAP:
-		if (siginfo.si_code == TRAP_BKPT) {
+		if (siginfo.si_code == TRAP_BRKPT) {
 			dbg->reason.type = RZ_DEBUG_REASON_BREAKPOINT;
 		}
 		break;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr is a blind fix just to make the NetBSD build go green. Theoretically, the fix makes sense based on an examination of current code and the following web pages:

- https://man.netbsd.org/NetBSD-9.3/ptrace.2
- https://man.netbsd.org/NetBSD-10.0/ptrace.2
- https://blog.netbsd.org/tnf/entry/improving_the_ptrace_2_api
- https://man.freebsd.org/cgi/man.cgi?query=ptrace

but no manual testing has been done and I don't think there are any automated tests either.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #4523.
