### PR TITLE
Add MS-DOS and Win32 Timestamp Conversion to rz-ax

### DIFF
--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -498,8 +498,8 @@ dotherax:
 		rz_num_units(buf, sizeof(buf), rz_num_math(NULL, str));
 		printf("%s\n", buf);
 		return true;
-	} else if (has_flag(flags, RZ_AX_FLAG_TIMESTAMP_TO_STR) || 
-			has_flag(flags, RZ_AX_FLAG_DOS_TIMESTAMP_TO_STR)) { // -t, -m
+	} else if (has_flag(flags, RZ_AX_FLAG_TIMESTAMP_TO_STR) ||
+		has_flag(flags, RZ_AX_FLAG_DOS_TIMESTAMP_TO_STR)) { // -t, -m
 		RzList *split = rz_str_split_list(str, "GMT", 0);
 		RzListIter *head = rz_list_head(split);
 		char *ts = rz_list_iter_get_data(head);
@@ -510,15 +510,13 @@ dotherax:
 		ut32 n = rz_num_math(num, ts);
 		int timezone = (int)rz_num_math(num, gmt);
 		n += timezone * (60 * 60);
-		char * date = NULL;
+		char *date = NULL;
 		if (has_flag(flags, RZ_AX_FLAG_TIMESTAMP_TO_STR)) {
 			date = rz_time_date_unix_to_string(n);
-		}
-		else { 
+		} else {
 			date = rz_time_date_dos_to_string(n);
 		}
-		if (date != NULL)
-		{
+		if (date != NULL) {
 			printf("%s\n", date);
 			fflush(stdout);
 			free(date);

--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -516,11 +516,11 @@ dotherax:
 		} else {
 			date = rz_time_date_dos_to_string(n);
 		}
+		rz_list_free(split);
 		if (date != NULL) {
 			printf("%s\n", date);
 			fflush(stdout);
 			free(date);
-			rz_list_free(split);
 			return true;
 		}
 		return false;

--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -5,29 +5,30 @@
 #include <rz_util.h>
 #include <rz_util/rz_print.h>
 
-#define RZ_AX_FLAG_HEX_TO_RAW       (1ull << 0) //  -s (hexstr -> raw)
-#define RZ_AX_FLAG_SWAP_ENDIANNESS  (1ull << 1) //  -e (swap endianness)
-#define RZ_AX_FLAG_RAW_TO_HEX       (1ull << 2) //  -S (raw -> hexstr)
-#define RZ_AX_FLAG_BIN_TO_STR       (1ull << 3) //  -b (bin -> str)
-#define RZ_AX_FLAG_STR_TO_DJB2      (1ull << 4) //  -x (str -> djb2 hash)
-#define RZ_AX_FLAG_KEEP_BASE        (1ull << 5) //  -k (keep base)
-#define RZ_AX_FLAG_FLOATING_POINT   (1ull << 6) //  -f (floating point)
-#define RZ_AX_FLAG_FORCE_INTEGER    (1ull << 7) //  -d (force integer)
-#define RZ_AX_FLAG_NUMBER_TO_HEX    (1ull << 9) //  -n (num -> hex)
-#define RZ_AX_FLAG_UNITS            (1ull << 10) // -u (units)
-#define RZ_AX_FLAG_TIMESTAMP_TO_STR (1ull << 11) // -t (timestamp -> str)
-#define RZ_AX_FLAG_BASE64_ENCODE    (1ull << 12) // -E (base64 encode)
-#define RZ_AX_FLAG_BASE64_DECODE    (1ull << 13) // -D (base64 decode)
-#define RZ_AX_FLAG_RAW_TO_LANGBYTES (1ull << 14) // -F (raw -> C or JS or Python bytes)
-#define RZ_AX_FLAG_NUMBER_TO_HEXSTR (1ull << 15) // -N (num -> escaped hex string)
-#define RZ_AX_FLAG_SIGNED_WORD      (1ull << 16) // -w (signed word)
-#define RZ_AX_FLAG_STR_TO_BIN       (1ull << 17) // -B (str -> bin)
-#define RZ_AX_FLAG_RIZIN_CMD        (1ull << 18) // -r (rizin commands)
-#define RZ_AX_FLAG_BIN_TO_BIGNUM    (1ull << 19) // -L (bin -> hex(bignum))
-#define RZ_AX_FLAG_DUMP_C_BYTES     (1ull << 21) // -i (dump as C byte array)
-#define RZ_AX_FLAG_OCTAL_TO_RAW     (1ull << 22) // -o (octalstr -> raw)
-#define RZ_AX_FLAG_IPADDR_TO_LONG   (1ull << 23) // -I (IP address <-> LONG)
-#define RZ_AX_FLAG_SET_BITS         (1ull << 24) // -p (find position of set bits)
+#define RZ_AX_FLAG_HEX_TO_RAW           (1ull << 0) //  -s (hexstr -> raw)
+#define RZ_AX_FLAG_SWAP_ENDIANNESS      (1ull << 1) //  -e (swap endianness)
+#define RZ_AX_FLAG_RAW_TO_HEX           (1ull << 2) //  -S (raw -> hexstr)
+#define RZ_AX_FLAG_BIN_TO_STR           (1ull << 3) //  -b (bin -> str)
+#define RZ_AX_FLAG_STR_TO_DJB2          (1ull << 4) //  -x (str -> djb2 hash)
+#define RZ_AX_FLAG_KEEP_BASE            (1ull << 5) //  -k (keep base)
+#define RZ_AX_FLAG_FLOATING_POINT       (1ull << 6) //  -f (floating point)
+#define RZ_AX_FLAG_FORCE_INTEGER        (1ull << 7) //  -d (force integer)
+#define RZ_AX_FLAG_NUMBER_TO_HEX        (1ull << 9) //  -n (num -> hex)
+#define RZ_AX_FLAG_UNITS                (1ull << 10) // -u (units)
+#define RZ_AX_FLAG_TIMESTAMP_TO_STR     (1ull << 11) // -t (unix timestamp -> str)
+#define RZ_AX_FLAG_BASE64_ENCODE        (1ull << 12) // -E (base64 encode)
+#define RZ_AX_FLAG_BASE64_DECODE        (1ull << 13) // -D (base64 decode)
+#define RZ_AX_FLAG_RAW_TO_LANGBYTES     (1ull << 14) // -F (raw -> C or JS or Python bytes)
+#define RZ_AX_FLAG_NUMBER_TO_HEXSTR     (1ull << 15) // -N (num -> escaped hex string)
+#define RZ_AX_FLAG_SIGNED_WORD          (1ull << 16) // -w (signed word)
+#define RZ_AX_FLAG_STR_TO_BIN           (1ull << 17) // -B (str -> bin)
+#define RZ_AX_FLAG_RIZIN_CMD            (1ull << 18) // -r (rizin commands)
+#define RZ_AX_FLAG_BIN_TO_BIGNUM        (1ull << 19) // -L (bin -> hex(bignum))
+#define RZ_AX_FLAG_DUMP_C_BYTES         (1ull << 21) // -i (dump as C byte array)
+#define RZ_AX_FLAG_OCTAL_TO_RAW         (1ull << 22) // -o (octalstr -> raw)
+#define RZ_AX_FLAG_IPADDR_TO_LONG       (1ull << 23) // -I (IP address <-> LONG)
+#define RZ_AX_FLAG_SET_BITS             (1ull << 24) // -p (find position of set bits)
+#define RZ_AX_FLAG_DOS_TIMESTAMP_TO_STR (1ull << 25) // -m (MS-DOS timestamp -> str)
 
 #define has_flag(f, x) (f & x)
 
@@ -226,7 +227,8 @@ static int help(void) {
 		"  -r      rz style output      ;  rz-ax -r 0x1234\n"
 		"  -s      hexstr -> raw        ;  rz-ax -s 43 4a 50\n"
 		"  -S      raw -> hexstr        ;  rz-ax -S < /bin/ls > ls.hex\n"
-		"  -t      tstamp -> str        ;  rz-ax -t 1234567890\n"
+		"  -t      Unix tstamp -> str   ;  rz-ax -t 1234567890\n"
+		"  -m      MS-DOS tstamp -> str ;  rz-ax -m 1234567890\n"
 		"  -x      hash string          ;  rz-ax -x linux osx\n"
 		"  -u      units                ;  rz-ax -u 389289238 # 317.0M\n"
 		"  -w      signed word          ;  rz-ax -w 16 0xffff\n"
@@ -289,6 +291,7 @@ static int rax(RzNum *num, char *str, int len, int last, ut64 *_flags, int *fm) 
 			case 'i': flags ^= RZ_AX_FLAG_DUMP_C_BYTES; break;
 			case 'o': flags ^= RZ_AX_FLAG_OCTAL_TO_RAW; break;
 			case 'I': flags ^= RZ_AX_FLAG_IPADDR_TO_LONG; break;
+			case 'm': flags ^= RZ_AX_FLAG_DOS_TIMESTAMP_TO_STR; break;
 			case 'v': return rz_main_version_print("rz-ax");
 			case '\0':
 				*_flags = flags;
@@ -495,7 +498,8 @@ dotherax:
 		rz_num_units(buf, sizeof(buf), rz_num_math(NULL, str));
 		printf("%s\n", buf);
 		return true;
-	} else if (has_flag(flags, RZ_AX_FLAG_TIMESTAMP_TO_STR)) { // -t
+	} else if (has_flag(flags, RZ_AX_FLAG_TIMESTAMP_TO_STR) || 
+			has_flag(flags, RZ_AX_FLAG_DOS_TIMESTAMP_TO_STR)) { // -t, -m
 		RzList *split = rz_str_split_list(str, "GMT", 0);
 		RzListIter *head = rz_list_head(split);
 		char *ts = rz_list_iter_get_data(head);
@@ -506,12 +510,22 @@ dotherax:
 		ut32 n = rz_num_math(num, ts);
 		int timezone = (int)rz_num_math(num, gmt);
 		n += timezone * (60 * 60);
-		char *date = rz_time_date_unix_to_string(n);
-		printf("%s\n", date);
-		fflush(stdout);
-		free(date);
-		rz_list_free(split);
-		return true;
+		char * date = NULL;
+		if (has_flag(flags, RZ_AX_FLAG_TIMESTAMP_TO_STR)) {
+			date = rz_time_date_unix_to_string(n);
+		}
+		else { 
+			date = rz_time_date_dos_to_string(n);
+		}
+		if (date != NULL)
+		{
+			printf("%s\n", date);
+			fflush(stdout);
+			free(date);
+			rz_list_free(split);
+			return true;
+		}
+		return false;
 	} else if (has_flag(flags, RZ_AX_FLAG_BASE64_ENCODE)) { // -E
 		const int n = strlen(str);
 		/* http://stackoverflow.com/questions/4715415/base64-what-is-the-worst-possible-increase-in-space-usage */


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [v] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [v] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [v] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [v] I've added tests that prove my fix is effective or that my feature works (if possible)
- [?] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This adds MS-DOS and Win32 timestamp conversions in the `rz-ax` util / command. These have been added as flag `-m` and `-W` respectively. The relevant help / print statements have been edited. Given `rz_time_stamp_is_dos_format` is in the codebase, we can "guess" if the timestamp is MS-DOS or Unix, so it may be better to have that all under the `-t` command, but I don't know if that's a good plan. Would like feedback from the maintainers on everything.

I didn't see any appropriate place in the rizin book for this, but I did update the help command for `rz-ax` with the new field and confirmed it shows up.


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

As long as the `rz_time_date_dos_to_string` function is tested, this can be considered tested. I did not see any tests explicitly testing the `-t` command in the test database.

![added_cmd_and_output](https://github.com/rizinorg/rizin/assets/41171807/693a1d1f-5c8b-42b7-9276-b266b250e8f6)

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #4515 
