### PR TITLE
core/file: add API for the `oC` command

### DIFF
--- a/librz/core/cmd/cmd_open.c
+++ b/librz/core/cmd/cmd_open.c
@@ -877,38 +877,7 @@ RZ_IPI RzCmdStatus rz_open_malloc_handler(RzCore *core, int argc, const char **a
 		RZ_LOG_ERROR("Invalid length %d.\n", len);
 		return RZ_CMD_STATUS_ERROR;
 	}
-
-	RzCmdStatus res = RZ_CMD_STATUS_ERROR;
-	ut8 *data = RZ_NEWS(ut8, len);
-	if (!data) {
-		return RZ_CMD_STATUS_ERROR;
-	}
-	if (!rz_io_read_at(core->io, core->offset, data, len)) {
-		RZ_LOG_ERROR("Cannot read %d bytes from current offset.\n", len);
-		goto err;
-	}
-
-	char uri[100];
-	rz_strf(uri, "malloc://%d", len);
-	RzCoreFile *cfile = rz_core_file_open(core, uri, RZ_PERM_RWX, 0);
-	if (!cfile) {
-		RZ_LOG_ERROR("Cannot open '%s'.\n", uri);
-		goto err;
-	}
-
-	if (!rz_core_bin_load(core, uri, 0)) {
-		RZ_LOG_ERROR("Cannot load binary info of '%s'.\n", uri);
-		goto err;
-	}
-
-	RzIODesc *desc = rz_io_desc_get(core->io, cfile->fd);
-	rz_warn_if_fail(desc);
-	rz_io_desc_write_at(desc, 0, data, len);
-	res = RZ_CMD_STATUS_OK;
-
-err:
-	free(data);
-	return res;
+	return bool2status(rz_core_file_malloc_copy_chunk(core, len, core->offset));
 }
 
 static RzCmdStatus open_nobin_file(RzCore *core, const char *uri, ut64 addr, int perms) {

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -528,6 +528,7 @@ RZ_API int rz_core_setup_debugger(RzCore *r, const char *debugbackend, bool atta
 RZ_API bool rz_core_file_open_load(RZ_NONNULL RzCore *core, RZ_NONNULL const char *filepath, ut64 addr, int perms, bool write_mode);
 RZ_API RZ_BORROW RzCoreFile *rz_core_file_open(RZ_NONNULL RzCore *core, RZ_NONNULL const char *file, int flags, ut64 loadaddr);
 RZ_API RZ_BORROW RzCoreFile *rz_core_file_open_many(RZ_NONNULL RzCore *r, RZ_NULLABLE const char *file, int perm, ut64 loadaddr);
+RZ_API bool rz_core_file_malloc_copy_chunk(RzCore *core, size_t len, ut64 offset);
 RZ_API RzCoreFile *rz_core_file_get_by_fd(RzCore *core, int fd);
 RZ_API void rz_core_file_close(RzCoreFile *fh);
 RZ_API bool rz_core_file_close_fd(RzCore *core, int fd);

--- a/test/integration/test_analysis_il.c
+++ b/test/integration/test_analysis_il.c
@@ -86,9 +86,10 @@ static bool test_analysis_il() {
 	rz_core_file_open_load(core, "malloc://0x1000", 0x40000, RZ_PERM_R, false);
 	rz_core_file_open_load(core, "malloc://0x10", 0x50000, RZ_PERM_R, false);
 
-	rz_core_cmd_lines(core, "oC 0x10 @ obj.seckrit   # New file mapping from 0x0-0xf\n");
-
 	ut64 obj_seckrit = rz_num_get(core->num, "obj.seckrit");
+	// New file mapping from 0x0-0xf
+	rz_core_file_malloc_copy_chunk(core, 0x10, obj_seckrit); 
+
 	RzIOMap *map = rz_io_map_get(core->io, 0);
 	rz_io_map_remap(core->io, map->id, obj_seckrit);
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Added missing API corresponding to the `oC` command, which is used often in RzIL setups.

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/4248
