### PR TITLE
subprocess: Uniformize read access to `proc->ret`

### DIFF
--- a/librz/util/subprocess.c
+++ b/librz/util/subprocess.c
@@ -685,9 +685,9 @@ RZ_API RzSubprocessOutput *rz_subprocess_drain(RzSubprocess *proc) {
 	if (!out) {
 		return NULL;
 	}
+	out->ret = rz_subprocess_ret(proc);
 	out->out = rz_subprocess_out(proc, &out->out_len);
 	out->err = rz_subprocess_err(proc, &out->err_len);
-	out->ret = proc->ret;
 	return out;
 }
 
@@ -1433,9 +1433,9 @@ RZ_API RzSubprocessOutput *rz_subprocess_drain(RzSubprocess *proc) {
 	subprocess_lock();
 	RzSubprocessOutput *out = RZ_NEW(RzSubprocessOutput);
 	if (out) {
+		out->ret = rz_subprocess_ret(proc);
 		out->out = rz_subprocess_out(proc, &out->out_len);
 		out->err = rz_subprocess_err(proc, &out->err_len);
-		out->ret = proc->ret;
 		out->timeout = false;
 	}
 	subprocess_unlock();


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr just uniformizes read access to `proc->ret` in subprocess.c so that it all goes through `rz_subprocess_ret()`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
