### PR TITLE
Refine the comment filter while calculating file percentage

### DIFF
--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -3588,7 +3588,7 @@ static RZ_OWN char *screen_bottom_address(RzCore *core) {
 	rtn = rz_str_ndup(lastline + match->start, match->len);
 
 	// filter address in command, xref like ; CALL XREF from entry.fini0 @ 0x6b67
-	char *comment_signs[] = { "@", ";" };
+	char *comment_signs[] = { "@", "XREF" };
 	char *addr_pos = strstr(lastline, rtn);
 	for (ut32 i = 0; i < sizeof(comment_signs) / sizeof(comment_signs[0]); i++) {
 		const char *sign_pos = rz_str_strchr(lastline, comment_signs[i]);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The original code uses the symbol `;` to filter the line like `; CALL XREF @ 0x808080` to avoid the addresses in comments affecting the calculation of file percentage. However, the appearance of `;` in colorizing the code makes every line being filtered.

The following screenshot shows the file percentage without using tmux (which remains 0 before changing).

![image](https://github.com/rizinorg/rizin/assets/58985155/ccbde83a-40d8-4c29-9c90-becebaadff01)


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

CI is green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes https://github.com/rizinorg/rizin/issues/4518
