### PR TITLE
util/print: remove some use of the `cb_printf()` callback

### DIFF
--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -2730,6 +2730,12 @@ RZ_IPI RzCmdStatus rz_print_op_analysis_color_map_handler(RzCore *core, int argc
 	return bool2status(cmd_print_pxA(core, len, state->mode));
 }
 
+void print_cursor(RzPrint *p, int cur, int len, int set) {
+	if (rz_print_have_cursor(p, cur, len)) {
+		rz_cons_printf("%s", RZ_CONS_INVERT(set, 1));
+	}
+}
+
 RZ_IPI RzCmdStatus rz_print_hexdump_bits_handler(RzCore *core, int argc, const char **argv) {
 	int len = argc > 1 ? (int)rz_num_math(core->num, argv[1]) : (int)core->blocksize;
 	if (!len) {
@@ -2757,9 +2763,9 @@ RZ_IPI RzCmdStatus rz_print_hexdump_bits_handler(RzCore *core, int argc, const c
 		memmove(buf + 5, buf + 4, 5);
 		buf[4] = 0;
 
-		rz_print_cursor(core->print, i, 1, 1);
+		print_cursor(core->print, i, 1, 1);
 		rz_cons_printf("%s.%s  ", buf, buf + 5);
-		rz_print_cursor(core->print, i, 1, 0);
+		print_cursor(core->print, i, 1, 0);
 		if (c == 3) {
 			const ut8 *b = core->block + i - 3;
 			int (*k)(const ut8 *, int) = cmd_pxb_k;

--- a/librz/include/rz_util/rz_print.h
+++ b/librz/include/rz_util/rz_print.h
@@ -204,7 +204,6 @@ RZ_API const char *rz_print_byte_color(RzPrint *p, int ch);
 RZ_API void rz_print_raw(RzPrint *p, ut64 addr, const ut8 *buf, int len);
 RZ_API bool rz_print_have_cursor(RzPrint *p, int cur, int len);
 RZ_API bool rz_print_cursor_pointer(RzPrint *p, int cur, int len);
-RZ_API void rz_print_cursor(RzPrint *p, int cur, int len, int set);
 RZ_API int rz_print_get_cursor(RzPrint *p);
 RZ_API void rz_print_set_cursor(RzPrint *p, int curset, int ocursor, int cursor);
 #define SEEFLAG    -2

--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -154,12 +154,6 @@ RZ_API bool rz_print_cursor_pointer(RzPrint *p, int cur, int len) {
 	return false;
 }
 
-RZ_API void rz_print_cursor(RzPrint *p, int cur, int len, int set) {
-	if (rz_print_have_cursor(p, cur, len)) {
-		p->cb_printf("%s", RZ_CONS_INVERT(set, 1));
-	}
-}
-
 RZ_API char *rz_print_hexpair(RzPrint *p, const char *str, int n) {
 	const char *s, *lastcol = Color_WHITE;
 	char *d, *dst = (char *)calloc((strlen(str) + 2), 32);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Remove some of the use of the `cb_printf()` callback

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/1392
