### PR TITLE
rz_core_task_enqueue: Set semaphore init val immediately

### DIFF
--- a/librz/core/task.c
+++ b/librz/core/task.c
@@ -385,10 +385,7 @@ RZ_API void rz_core_task_enqueue(RzCoreTaskScheduler *scheduler, RzCoreTask *tas
 	TASK_SIGSET_T old_sigset;
 	tasks_lock_enter(scheduler, &old_sigset);
 	if (!task->running_sem) {
-		task->running_sem = rz_th_sem_new(1);
-	}
-	if (task->running_sem) {
-		rz_th_sem_wait(task->running_sem);
+		task->running_sem = rz_th_sem_new(0);
 	}
 	rz_list_append(scheduler->tasks, task);
 	task->thread = rz_th_new((RzThreadFunction)task_run_thread, task);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr sets immediately the semaphore initial value in rz_core_task_enqueue() without going through rz_th_sem_wait(). Curious to know whether this simplification causes any problems.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
