### PR TITLE
Make `rz_line_readline_cb` pass `line` to `__move_cursor_left` instead of `NULL`

### DIFF
--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -1627,7 +1627,7 @@ RZ_API const char *rz_line_readline_cb(RZ_NONNULL RzLine *line, RzLineReadCallba
 			line->buffer.index = 0;
 			break;
 		case 2: // ^b // emacs left
-			__move_cursor_left(NULL);
+			__move_cursor_left(line);
 			break;
 		case 5: // ^E
 			if (line->gcomp) {


### PR DESCRIPTION
Closes #4543.

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
On pressing Ctrl+b, in `rz_line_readline_cb:1629`, `NULL` was passed to `__move_cursor_left`, which, unsurprisingly, led to a segfault. This is fixed by just passing `line` instead.

...

**Test plan**

I've run the CI on my fork and tests are all green.
...