### PR TITLE
Enable subproject tree-sitter-c in librz/type

### DIFF
--- a/librz/type/meson.build
+++ b/librz/type/meson.build
@@ -18,7 +18,9 @@ if r.returncode() == 1 and get_option('subprojects_check')
   error('Subprojects are not updated. Please run `git clean -dxff subprojects/` to delete all local subprojects directories. If you want to compile against current subprojects then set option `subprojects_check=false`.')
 endif
 
-tree_sitter_c_dep = dependency('tree-sitter-c')
+
+# use subproject/tree-sitter-c
+# tree_sitter_c_dep = dependency('tree-sitter-c')
 
 rz_type_inc = [
   platform_inc,

--- a/meson.build
+++ b/meson.build
@@ -300,6 +300,19 @@ if not tree_sitter_dep.found()
   meson.override_dependency('tree-sitter', tree_sitter_dep)
 endif
 
+# handle tree-sitter-c
+r = run_command(py3_exe, check_meson_subproject_py, 'tree-sitter-c', check: false)
+if r.returncode() == 1 and get_option('subprojects_check')
+  error(subproject_clean_error_msg)
+endif
+
+tree_sitter_c_dep = dependency('tree-sitter-c', required: get_option('use_sys_tree_sitter'), static: is_static_build, fallback: [])
+if not tree_sitter_c_dep.found()
+  tree_sitter_c_proj = subproject('tree-sitter-c', default_options: ['default_library=static'])
+  tree_sitter_c_dep = tree_sitter_c_proj.get_variable('tree_sitter_c_dep')
+  # override done in tree sitter c subproject
+endif
+
 has_debugger = get_option('debugger')
 have_ptrace = not ['windows', 'cygwin', 'sunos', 'haiku'].contains(host_machine.system())
 use_ptrace_wrap = ['linux'].contains(host_machine.system())


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

If the tree-sitter-c library is already installed on the system, then during the linking process of the rz_type library, /usr/lib/tree-sitter-c.so will be used preferentially, which leads to multiple `undefined reference` error about `ts_*` function family. 

this pr enable the `tree-sitter-c.wrap` under subproject according to `use_sys_treesitter` option

**Test plan**

**Closing issues**
