### PR TITLE
Adjust OpenBSD code to set the process state to be less wrong.

### DIFF
--- a/librz/debug/p/native/bsd/bsd_debug.c
+++ b/librz/debug/p/native/bsd/bsd_debug.c
@@ -218,16 +218,19 @@ RzDebugInfo *bsd_info(RzDebug *dbg, const char *arg) {
 		rdi->gid = kp->p__pgid;
 		rdi->exe = strdup(kp->p_comm);
 
-		rdi->status = RZ_DBG_PROC_STOP;
-
-		if (kp->p_psflags & PS_ZOMBIE) {
-			rdi->status = RZ_DBG_PROC_ZOMBIE;
-		} else if (kp->p_psflags & PS_STOPPED) {
+		switch (kp->p_stat) {
+		case SDEAD:
+			rdi->status = RZ_DBG_PROC_DEAD;
+			break;
+		case SSTOP:
 			rdi->status = RZ_DBG_PROC_STOP;
-		} else if (kp->p_psflags & PS_PPWAIT) {
+			break;
+		case SSLEEP:
 			rdi->status = RZ_DBG_PROC_SLEEP;
-		} else if ((kp->p_psflags & PS_EXEC) || (kp->p_psflags & PS_INEXEC)) {
+			break;
+		default:
 			rdi->status = RZ_DBG_PROC_RUN;
+			break;
 		}
 	}
 


### PR DESCRIPTION
Use the p_stat of the main thread to decide in which state the process is. For multi-threaded applications this is still not quite correct but at least this compiles on OpenBSD-current.

See also https://github.com/openbsd/ports/commit/5d4f90ee105757eda1cd9b31108c3ef6df67c48b

Fix for #4576