### PR TITLE
DWARF: fixes for loading big Zlib-compressed sections

### DIFF
--- a/librz/bin/dwarf/endian_reader.c
+++ b/librz/bin/dwarf/endian_reader.c
@@ -78,9 +78,10 @@ RZ_IPI RZ_OWN RzBinEndianReader *rz_bin_dwarf_section_reader(
 	ut64 src_len = len - Chdr_size;
 	ut64 uncompressed_len = 0;
 	ut8 *uncompressed = NULL;
-	RZ_LOG_VERBOSE("Section %s is compressed\n", section->name);
+	RZ_LOG_VERBOSE("Section %s is compressed, type %d%s\n", section->name, ch_type,
+		is_zlib_gnu ? " (GNU)" : "");
 	if (ch_type == ELFCOMPRESS_ZLIB) {
-		int len_tmp;
+		int len_tmp = 0;
 		uncompressed = rz_inflate(
 			src, (int)src_len, NULL, &len_tmp);
 		uncompressed_len = len_tmp;
@@ -106,7 +107,7 @@ RZ_IPI RZ_OWN RzBinEndianReader *rz_bin_dwarf_section_reader(
 		RZ_LOG_WARN("Unsupported compression type: %d\n", ch_type);
 	}
 
-	if (!uncompressed || uncompressed_len <= 0) {
+	if (!uncompressed || uncompressed_len == 0) {
 		RZ_LOG_ERROR("section [%s] uncompress failed\n", section->name);
 		goto err;
 	}

--- a/librz/util/compression.c
+++ b/librz/util/compression.c
@@ -12,8 +12,8 @@
 #include <lzma.h>
 #endif
 
-// set a maximum output buffer of 50MB
-#define MAXOUT 50000000
+// set a maximum output buffer of 5000MB
+#define MAXOUT 5000000000
 
 /**
  * \brief inflate zlib compressed or gzipped, automatically accepts either the zlib or gzip format, and use MAX_WBITS as the window size logarithm.
@@ -66,7 +66,7 @@ RZ_API ut8 *rz_inflatew(RZ_NONNULL const ut8 *src, int srcLen, int *srcConsumed,
 	rz_return_val_if_fail(srcLen > 0, NULL);
 
 	int err = 0;
-	int out_size = 0;
+	ut64 out_size = 0;
 	ut8 *dst = NULL;
 	ut8 *tmp_ptr;
 	z_stream stream;
@@ -87,11 +87,13 @@ RZ_API ut8 *rz_inflatew(RZ_NONNULL const ut8 *src, int srcLen, int *srcConsumed,
 		if (stream.avail_out == 0) {
 			tmp_ptr = realloc(dst, stream.total_out + srcLen * 2);
 			if (!tmp_ptr) {
+				RZ_LOG_ERROR("inflate: not enough memory\n");
 				goto err_exit;
 			}
 			dst = tmp_ptr;
 			out_size += srcLen * 2;
 			if (out_size > MAXOUT) {
+				RZ_LOG_ERROR("inflate: output size is bigger than maximum allowed\n");
 				goto err_exit;
 			}
 			stream.next_out = dst + stream.total_out;
@@ -134,7 +136,7 @@ RZ_API ut8 *rz_deflatew(RZ_NONNULL const ut8 *src, int srcLen, int *srcConsumed,
 	rz_return_val_if_fail(srcLen > 0, NULL);
 
 	int err = 0;
-	int out_size = 0;
+	ut64 out_size = 0;
 	ut8 *dst = NULL;
 	ut8 *tmp_ptr;
 	z_stream stream;

--- a/subprojects/packagefiles/zlib-1.3.1/meson.build
+++ b/subprojects/packagefiles/zlib-1.3.1/meson.build
@@ -1,4 +1,4 @@
-project('zlib', 'c', version : '1.3', license : 'zlib')
+project('zlib', 'c', version : '1.3.1', license : 'zlib')
 
 cc = meson.get_compiler('c')
 

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,7 +1,7 @@
 [wrap-file]
-directory = zlib-1.3
-source_url = https://raw.githubusercontent.com/rizinorg/fallback-repo/main/zlib-1.3.tar.gz
-source_filename = zlib-1.3.tar.gz
-source_hash = ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
-patch_directory = zlib-1.3
-source_fallback_url = https://zlib.net/fossils/zlib-1.3.tar.gz
+directory = zlib-1.3.1
+source_url = https://raw.githubusercontent.com/rizinorg/fallback-repo/main/zlib-1.3.1.tar.gz
+source_filename = zlib-1.3.1.tar.gz
+source_hash = 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+patch_directory = zlib-1.3.1
+source_fallback_url = https://zlib.net/fossils/zlib-1.3.1.tar.gz


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

In real binaries DWARF sections could be much bigger than just 50Mb, could be gigabytes (e.g. for Linux kernel), allow loading these. Also update Zlib version to address some stream inflating issues. Improve error messages.

Zlib-1.3 fails to build with the ASAN on macOS 14, but 1.3.1 succeeds.

Version 1.3.1 has these key updates from 1.3:

-    Reject overflows of zip header fields in minizip.
-    Fix bug in inflateSync() for data held in bit buffer.
-    Add LIT_MEM define to use more memory for a small deflate speedup.
-    Fix decision on the emission of Zip64 end records in minizip.
-    Add bounds checking to ERR_MSG() macro, used by zError().
-    Neutralize zip file traversal attacks in miniunz.
-    Fix a bug in ZLIB_DEBUG compiles in check_match(). 

**Test plan**

CI is green
