### PR TITLE
librz: link to tree-sitter directly

### DIFF
--- a/librz/type/meson.build
+++ b/librz/type/meson.build
@@ -31,6 +31,7 @@ rz_type = library('rz_type', rz_type_sources,
   include_directories: rz_type_inc,
   dependencies: [
     rz_util_dep,
+    tree_sitter_dep,
     tree_sitter_c_dep,
     lrt
   ],


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

tree-sitter symbols are included in this library, so we need to specify the dependency to avoid linking failures due to missing tree-sitter symbols.

See-Also: https://bugs.gentoo.org/928301

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Test build with `-Duse_sys_tree_sitter=enabled` without this change (with a system `tree-sitter` + `tree-sitter-c` installed) yields the link failure:
```
FAILED: librz/type/librz_type.so.0.8.0
cc  -o librz/type/librz_type.so.0.8.0 librz/type/librz_type.so.0.8.0.p/base.c.o librz/type/librz_type.so.0.8.0.p/format.c.o librz/type/librz_type.so.0.8.0.p/function.c.o librz/type/librz_type.so.0.8.0.p/helpers.c.o librz/type/librz_type.so.0.8.0.p/path.c.o librz/type/librz_type.so.0.8.0.p/serialize_functions.c.o librz/type/librz_type.so.0.8.0.p/serialize_types.c.o librz/type/librz_type.so.0.8.0.p/type.c.o librz/type/librz_type.so.0.8.0.p/typeclass.c.o librz/type/librz_type.so.0.8.0.p/parser_c_cpp_parser.c.o librz/type/librz_type.so.0.8.0.p/parser_types_parser.c.o librz/type/librz_type.so.0.8.0.p/parser_types_storage.c.o -Wl,--as-needed -Wl,--no-undefined -shared -fPIC -Wl,-soname,librz_type.so.0.8 '-Wl,-rpath,$ORIGIN/../util' -Wl,-rpath-link,/home/jake/git/rizin/build/librz/util -Wl,--start-group librz/util/librz_util.so.0.8.0 /usr/lib64/libtree-sitter-c.so -lrt -Wl,--end-group
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: librz/type/librz_type.so.0.8.0.p/parser_c_cpp_parser.c.o: in function `type_parse_string':
/home/jake/git/rizin/build/../librz/type/parser/c_cpp_parser.c:143:(.text+0x30): undefined reference to `ts_parser_new'
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: /home/jake/git/rizin/build/../librz/type/parser/c_cpp_parser.c:145:(.text+0x4a): undefined reference to `ts_parser_set_language'
[snip]
```

While I get a successful build with this change. See also #4602 for a related tree-sitter build issue, but the two changes should be distinct from each other.