### PR TITLE
cmd: rename `avg` into `avgl`, add table mode

### DIFF
--- a/librz/core/cmd_descs/cmd_analysis.yaml
+++ b/librz/core/cmd_descs/cmd_analysis.yaml
@@ -1544,13 +1544,14 @@ commands:
       - name: avg
         summary: Global variables
         subcommands:
-          - name: avg
-            summary: show global variables
+          - name: avgl
+            summary: show/list global variables
             type: RZ_CMD_DESC_TYPE_ARGV_STATE
             cname: analysis_print_global_variable
             modes:
               - RZ_OUTPUT_MODE_STANDARD
               - RZ_OUTPUT_MODE_JSON
+              - RZ_OUTPUT_MODE_TABLE
             args:
               - name: var_name
                 type: RZ_CMD_ARG_TYPE_GLOBAL_VAR

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -4964,7 +4964,7 @@ static const RzCmdDescArg analysis_print_global_variable_args[] = {
 	{ 0 },
 };
 static const RzCmdDescHelp analysis_print_global_variable_help = {
-	.summary = "show global variables",
+	.summary = "show/list global variables",
 	.args = analysis_print_global_variable_args,
 };
 
@@ -19975,8 +19975,11 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *av_cd = rz_cmd_desc_group_modes_new(core->rcmd, cmd_analysis_cd, "av", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON, rz_analysis_list_vtables_handler, &analysis_list_vtables_help, &av_help);
 	rz_warn_if_fail(av_cd);
-	RzCmdDesc *avg_cd = rz_cmd_desc_group_state_new(core->rcmd, av_cd, "avg", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_print_global_variable_handler, &analysis_print_global_variable_help, &avg_help);
+	RzCmdDesc *avg_cd = rz_cmd_desc_group_new(core->rcmd, av_cd, "avg", NULL, NULL, &avg_help);
 	rz_warn_if_fail(avg_cd);
+	RzCmdDesc *analysis_print_global_variable_cd = rz_cmd_desc_argv_state_new(core->rcmd, avg_cd, "avgl", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_TABLE, rz_analysis_print_global_variable_handler, &analysis_print_global_variable_help);
+	rz_warn_if_fail(analysis_print_global_variable_cd);
+
 	RzCmdDesc *analysis_global_variable_add_cd = rz_cmd_desc_argv_new(core->rcmd, avg_cd, "avga", rz_analysis_global_variable_add_handler, &analysis_global_variable_add_help);
 	rz_warn_if_fail(analysis_global_variable_add_cd);
 

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -569,7 +569,7 @@ RZ_IPI RzCmdStatus rz_global_imports_handler(RzCore *core, int argc, const char 
 RZ_IPI RzCmdStatus rz_delete_global_imports_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "av"
 RZ_IPI RzCmdStatus rz_analysis_list_vtables_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
-// "avg"
+// "avgl"
 RZ_IPI RzCmdStatus rz_analysis_print_global_variable_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "avga"
 RZ_IPI RzCmdStatus rz_analysis_global_variable_add_handler(RzCore *core, int argc, const char **argv);

--- a/test/db/cmd/cmd_avg
+++ b/test/db/cmd/cmd_avg
@@ -2,9 +2,9 @@ NAME=avga # add global variable
 FILE==
 CMDS=<<EOF
 avga foo int @ 0x100
-avg
+avgl
 avga bar char @ 0x1000
-avg
+avgl
 EOF
 EXPECT=<<EOF
 global int foo @ 0x100
@@ -13,15 +13,15 @@ global char bar @ 0x1000
 EOF
 RUN
 
-NAME=avgj # output in json mode
+NAME=avgjl # output in json mode
 FILE==
 CMDS=<<EOF
 avga foo int @ 0x100
 avga bar char @ 0x1000
-avgj
+avglj
 EOF
 EXPECT=<<EOF
-[{"name":"foo","type":"int","addr":"0x100"},{"name":"bar","type":"char","addr":"0x1000"}]
+[{"name":"foo","type":"int","size":4,"addr":"0x100"},{"name":"bar","type":"char","size":1,"addr":"0x1000"}]
 EOF
 RUN
 
@@ -30,13 +30,13 @@ FILE==
 CMDS=<<EOF
 avga foo int @ 0x100
 avga bar char @ 0x1000
-avg
+avgl
 avgd 0x100
-avg
+avgl
 avga foofoo int @ 0x100
-avg
+avgl
 avgd 0x102
-avg
+avgl
 EOF
 EXPECT=<<EOF
 global int foo @ 0x100
@@ -52,9 +52,9 @@ NAME=avgn # rename global variable
 FILE==
 CMDS=<<EOF
 avga foo int @ 0x100
-avg
+avgl
 avgn foo bar
-avg
+avgl
 EOF
 EXPECT=<<EOF
 global int foo @ 0x100
@@ -66,25 +66,25 @@ NAME=avgt # retype global variable
 FILE==
 CMDS=<<EOF
 avga foo int @ 0x100
-avg
+avgl
 avgt foo char
-avg
+avgl
 avgt foo "struct a { int a; char b; };"
-avg
+avgl
 avgt foo "struct { int a; char b; void (*c)(int a, char b); };"
-avg
+avgl
 avgt foo "union { int a; char b; };"
-avg
+avgl
 avgt foo "enum { A=0,B,C,D };"
-avg
+avgl
 avgt foo "enum foo { A=0,B,C,D };"
-avg
+avgl
 avgt foo "void (*a)(int a, char b);"
-avg
+avgl
 avgt foo "char *"
-avg
+avgl
 avgt foo "char [50]"
-avg
+avgl
 EOF
 EXPECT=<<EOF
 global int foo @ 0x100
@@ -100,10 +100,10 @@ global char [50] foo @ 0x100
 EOF
 RUN
 
-NAME=avg <non-existing-var>
+NAME=avgl <non-existing-var>
 FILE==
 CMDS=<<EOF
-avg foo
+avgl foo
 EOF
 EXPECT=<<EOF
 EOF

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -518,7 +518,7 @@ NAME="Static variables inside function"
 FILE=bins/elf/dwarf/static_var
 CMDS=<<EOF
 aaa
-avg
+avgl
 avgx qwe
 avgx bla
 echo "fn1"
@@ -554,7 +554,7 @@ NAME="Global and static variables"
 FILE=bins/elf/dwarf_go_tree
 CMDS=<<EOF
 aaa
-avg
+avgl
 EOF
 EXPECT=<<EOF
 global error internal/oserror.ErrClosed @ 0x565370

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -77,10 +77,10 @@ s 2
 avga bla short
 sd +6
 avga foo int
-avgj
+avglj
 EOF
 EXPECT=<<EOF
-[{"name":"bla","type":"short","addr":"0x2"},{"name":"foo","type":"int","addr":"0x8"}]
+[{"name":"bla","type":"short","size":2,"addr":"0x2"},{"name":"foo","type":"int","size":4,"addr":"0x8"}]
 EOF
 RUN
 
@@ -90,7 +90,7 @@ CMDS=<<EOF
 avga bla int @ 0x4
 w test @ 0x10
 avga foo "char *" @ 0x10
-avg
+avgl
 EOF
 EXPECT=<<EOF
 global int bla @ 0x4

--- a/test/db/formats/pdb
+++ b/test/db/formats/pdb
@@ -41,7 +41,7 @@ NAME=Load global variables from PDB
 FILE=
 CMDS=<<EOF
 idp bins/pdb/Project1.pdb
-avg
+avgl
 EOF
 EXPECT=<<EOF
 global struct IMAGE_LOAD_CONFIG_DIRECTORY32_2 _load_config_used @ 0x165b0
@@ -99,7 +99,7 @@ FILE=bins/pdb/exceptions-test.exe
 CMDS=<<EOF
 idp
 aaa
-avg
+avgl
 echo ---
 avgx __guard_check_icall_fptr
 pd 3 @ 0x140007344

--- a/test/integration/test_autocmplt.c
+++ b/test/integration/test_autocmplt.c
@@ -445,14 +445,14 @@ static bool test_autocmplt_global(void) {
 	rz_analysis_var_global_set_type(glob2, typ);
 
 	RzLineBuffer *buf = &core->cons->line->buffer;
-	const char *s = "avg ";
+	const char *s = "avgl ";
 	strcpy(buf->data, s);
 	buf->length = strlen(s);
 	buf->index = buf->length;
 
 	RzLineNSCompletionResult *r = rz_core_autocomplete_rzshell(core, buf, RZ_LINE_PROMPT_DEFAULT);
 	mu_assert_notnull(r, "r should not be null");
-	mu_assert_eq(r->start, strlen("avg "), "should autocomplete the last arg");
+	mu_assert_eq(r->start, strlen("avgl "), "should autocomplete the last arg");
 	mu_assert_eq(r->end, buf->length, "should autocomplete ending at end of buffer");
 	mu_assert_eq(rz_pvector_len(&r->options), 2, "there are 2 global vars");
 	mu_assert_streq(rz_pvector_at(&r->options, 0), "GINT", "GINT found");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Rename `avg` into `avgl` since it effectively lists global variables, also add TABLE mode, and extend with the size. 

**Test plan**

CI is green