### PR TITLE
cmd: `t` - add long mode, show size and kind

### DIFF
--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -22472,7 +22472,7 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *seek_register_cd = rz_cmd_desc_argv_new(core->rcmd, s_cd, "sr", rz_seek_register_handler, &seek_register_help);
 	rz_warn_if_fail(seek_register_cd);
 
-	RzCmdDesc *t_cd = rz_cmd_desc_group_modes_new(core->rcmd, root_cd, "t", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON, rz_type_handler, &type_help, &t_help);
+	RzCmdDesc *t_cd = rz_cmd_desc_group_modes_new(core->rcmd, root_cd, "t", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_LONG, rz_type_handler, &type_help, &t_help);
 	rz_warn_if_fail(t_cd);
 	RzCmdDesc *type_del_cd = rz_cmd_desc_argv_new(core->rcmd, t_cd, "t-", rz_type_del_handler, &type_del_help);
 	rz_warn_if_fail(type_del_cd);

--- a/librz/core/cmd_descs/cmd_type.yaml
+++ b/librz/core/cmd_descs/cmd_type.yaml
@@ -10,6 +10,7 @@ commands:
       - RZ_OUTPUT_MODE_STANDARD
       - RZ_OUTPUT_MODE_RIZIN
       - RZ_OUTPUT_MODE_JSON
+      - RZ_OUTPUT_MODE_LONG
     args:
       - name: type
         type: RZ_CMD_ARG_TYPE_ANY_TYPE

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -243,7 +243,7 @@ EXPECT=<<EOF
 pf "d int"
 EOF
 EXPECT_ERR=<<EOF
-ERROR: core: cannot find 'int' type
+ERROR: core: cannot find 'int' type's format
 EOF
 RUN
 
@@ -293,7 +293,7 @@ union xoo {
 };
 EOF
 EXPECT_ERR=<<EOF
-ERROR: core: cannot find 'xoo' type
+ERROR: core: cannot find 'xoo' type's format
 ERROR: Cannot find "xoo" union type
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
 
Extend `t` (types listing) command to show more information by adding  LONG mode (`tl`), adding also kind of the type and the size of it.

**Test plan**

CI is green