### PR TITLE
Rename tree-sitter-c fork to avoid confusion

### DIFF
--- a/librz/type/meson.build
+++ b/librz/type/meson.build
@@ -13,14 +13,14 @@ rz_type_sources = [
   'parser/types_storage.c',
 ]
 
-r = run_command(py3_exe, check_meson_subproject_py, 'tree-sitter-c', check: false)
+r = run_command(py3_exe, check_meson_subproject_py, 'rizin-grammar-c', check: false)
 if r.returncode() == 1 and get_option('subprojects_check')
   error('Subprojects are not updated. Please run `git clean -dxff subprojects/` to delete all local subprojects directories. If you want to compile against current subprojects then set option `subprojects_check=false`.')
 endif
 
 
-# use subproject/tree-sitter-c
-# tree_sitter_c_dep = dependency('tree-sitter-c')
+# use subproject/rizin-grammar-c
+# rizin_grammar_c_dep = dependency('rizin-grammar-c')
 
 rz_type_inc = [
   platform_inc,
@@ -32,7 +32,7 @@ rz_type = library('rz_type', rz_type_sources,
   dependencies: [
     rz_util_dep,
     tree_sitter_dep,
-    tree_sitter_c_dep,
+    rizin_grammar_c_dep,
     lrt
   ],
   install: true,

--- a/librz/type/parser/c_cpp_parser.c
+++ b/librz/type/parser/c_cpp_parser.c
@@ -23,7 +23,7 @@ static char *ts_node_sub_string(TSNode node, const char *cstr) {
 }
 
 // Declare the `tree_sitter_c` function, which is
-// implemented by the `tree-sitter-c` library.
+// implemented by the `rizin-grammar-c` (fork of `tree-sitter-c`) library.
 TSLanguage *tree_sitter_c();
 
 // Declare the `tree_sitter_cpp` function, which is

--- a/meson.build
+++ b/meson.build
@@ -300,17 +300,17 @@ if not tree_sitter_dep.found()
   meson.override_dependency('tree-sitter', tree_sitter_dep)
 endif
 
-# handle tree-sitter-c
-r = run_command(py3_exe, check_meson_subproject_py, 'tree-sitter-c', check: false)
+# handle rizin-grammar-c
+r = run_command(py3_exe, check_meson_subproject_py, 'rizin-grammar-c', check: false)
 if r.returncode() == 1 and get_option('subprojects_check')
   error(subproject_clean_error_msg)
 endif
 
-tree_sitter_c_dep = dependency('tree-sitter-c', required: get_option('use_sys_tree_sitter'), static: is_static_build, fallback: [])
-if not tree_sitter_c_dep.found()
-  tree_sitter_c_proj = subproject('tree-sitter-c', default_options: ['default_library=static'])
-  tree_sitter_c_dep = tree_sitter_c_proj.get_variable('tree_sitter_c_dep')
-  # override done in tree sitter c subproject
+rizin_grammar_c_dep = dependency('rizin-grammar-c', required: get_option('use_sys_tree_sitter'), static: is_static_build, fallback: [])
+if not rizin_grammar_c_dep.found()
+  rizin_grammar_c_proj = subproject('rizin-grammar-c', default_options: ['default_library=static'])
+  rizin_grammar_c_dep = rizin_grammar_c_proj.get_variable('rizin_grammar_c_dep')
+  # override done in rizin-grammar-c subproject
 endif
 
 has_debugger = get_option('debugger')

--- a/subprojects/packagefiles/rizin-grammar-c/meson.build
+++ b/subprojects/packagefiles/rizin-grammar-c/meson.build
@@ -1,4 +1,4 @@
-project('tree-sitter-c', 'c', default_options: ['werror=false'])
+project('rizin-grammar-c', 'c', default_options: ['werror=false'])
 
 ts_c_files = [
   'src/parser.c'
@@ -6,15 +6,15 @@ ts_c_files = [
 
 tree_sitter_dep = dependency('tree-sitter')
 
-libtsc = static_library('tree-sitter-c', ts_c_files,
+libtsc = static_library('rizin-grammar-c', ts_c_files,
   include_directories: ['src'],
   implicit_include_directories: false,
   dependencies: tree_sitter_dep.partial_dependency(includes: true)
 )
 
-tree_sitter_c_dep = declare_dependency(
+rizin_grammar_c_dep = declare_dependency(
   link_with: libtsc,
   include_directories: ['src/tree_sitter'],
   dependencies: tree_sitter_dep
 )
-meson.override_dependency('tree-sitter-c', tree_sitter_c_dep)
+meson.override_dependency('rizin-grammar-c', rizin_grammar_c_dep)

--- a/subprojects/rizin-grammar-c.wrap
+++ b/subprojects/rizin-grammar-c.wrap
@@ -1,0 +1,6 @@
+[wrap-git]
+url = https://github.com/rizinorg/rizin-grammar-c
+revision = 81d96d8822b4ae5983a1c6bae0f9fe764b666581
+patch_directory = rizin-grammar-c
+directory = rizin-grammar-c
+depth = 1

--- a/subprojects/tree-sitter-c.wrap
+++ b/subprojects/tree-sitter-c.wrap
@@ -1,6 +1,0 @@
-[wrap-git]
-url = https://github.com/rizinorg/tree-sitter-c
-revision = 81d96d8822b4ae5983a1c6bae0f9fe764b666581
-patch_directory = tree-sitter-c
-directory = tree-sitter-c
-depth = 1


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Rename our C grammar into `rizin-grammar-c`

**Test plan**

CI is green