### PR TITLE
Fix CVE-2022-1207: out of bound read in GNU cris analysis plugin

### DIFF
--- a/librz/arch/p_gnu/analysis/analysis_cris_gnu.c
+++ b/librz/arch/p_gnu/analysis/analysis_cris_gnu.c
@@ -4,10 +4,15 @@
 #include <rz_asm.h>
 #include <rz_lib.h>
 
+#define CRIS_MIN_OP_SIZE 2
+
 static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask) {
 	int opsize = -1;
 	op->type = -1;
-	opsize = 2;
+	opsize = CRIS_MIN_OP_SIZE;
+	if (len < CRIS_MIN_OP_SIZE) {
+		return -1;
+	}
 	switch (buf[0]) {
 	case 0x3f:
 	case 0x4f:


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

https://nvd.nist.gov/vuln/detail/CVE-2022-1207