### PR TITLE
Replace strdup with rz_str_dup

### DIFF
--- a/librz/arch/acode.c
+++ b/librz/arch/acode.c
@@ -29,8 +29,8 @@ RZ_API void rz_asm_equ_item_free(RzAsmEqu *equ) {
 static RzAsmEqu *__asm_equ_new(const char *key, const char *value) {
 	RzAsmEqu *equ = RZ_NEW0(RzAsmEqu);
 	if (equ) {
-		equ->key = strdup(key);
-		equ->value = strdup(value);
+		equ->key = rz_str_dup(key);
+		equ->value = rz_str_dup(value);
 	}
 	return equ;
 }
@@ -44,7 +44,7 @@ RZ_API bool rz_asm_code_set_equ(RzAsmCode *code, const char *key, const char *va
 		rz_list_foreach (code->equs, iter, equ) {
 			if (!strcmp(equ->key, key)) {
 				free(equ->value);
-				equ->value = strdup(value);
+				equ->value = rz_str_dup(value);
 				return true;
 			}
 		}

--- a/librz/arch/analysis.c
+++ b/librz/arch/analysis.c
@@ -83,7 +83,7 @@ RZ_API RzAnalysis *rz_analysis_new(void) {
 	analysis->bb_tree = NULL;
 	analysis->ht_addr_fun = ht_up_new(NULL, NULL);
 	analysis->ht_name_fun = ht_sp_new(HT_STR_DUP, NULL, NULL);
-	analysis->os = strdup(RZ_SYS_OS);
+	analysis->os = rz_str_dup(RZ_SYS_OS);
 	analysis->esil_goto_limit = RZ_ANALYSIS_ESIL_GOTO_LIMIT;
 	analysis->opt.nopskip = true; // skip nops in code analysis
 	analysis->opt.hpskip = false; // skip `mov reg,reg` and `lea reg,[reg]`
@@ -286,7 +286,7 @@ static bool analysis_set_os(RzAnalysis *analysis, const char *os) {
 		os = RZ_SYS_OS;
 	}
 	free(analysis->os);
-	analysis->os = strdup(os);
+	analysis->os = rz_str_dup(os);
 	char *types_dir = rz_path_system(RZ_SDB_TYPES);
 	rz_type_db_set_os(analysis->typedb, os);
 	rz_type_db_reload(analysis->typedb, types_dir);
@@ -367,7 +367,7 @@ RZ_API void rz_analysis_set_cpu(RzAnalysis *analysis, const char *cpu) {
 		return;
 	}
 	free(analysis->cpu);
-	analysis->cpu = cpu ? strdup(cpu) : NULL;
+	analysis->cpu = rz_str_dup(cpu);
 	int v = rz_analysis_archinfo(analysis, RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN);
 	if (v != -1) {
 		analysis->pcalign = v;
@@ -612,7 +612,7 @@ RZ_API bool rz_analysis_noreturn_add(RzAnalysis *analysis, const char *name, ut6
 		}
 	}
 	if (rz_type_func_exist(analysis->typedb, tmp_name)) {
-		fnl_name = strdup(tmp_name);
+		fnl_name = rz_str_dup(tmp_name);
 	} else if (!(fnl_name = rz_analysis_function_name_guess(analysis->typedb, (char *)tmp_name))) {
 		if (addr == UT64_MAX) {
 			if (name) {
@@ -816,7 +816,7 @@ RZ_API void rz_analysis_add_import(RzAnalysis *analysis, const char *imp) {
 			return;
 		}
 	}
-	char *cimp = strdup(imp);
+	char *cimp = rz_str_dup(imp);
 	if (!cimp) {
 		return;
 	}

--- a/librz/arch/asm.c
+++ b/librz/arch/asm.c
@@ -503,7 +503,7 @@ RZ_API bool rz_asm_use(RzAsm *a, const char *name) {
 RZ_DEPRECATE RZ_API void rz_asm_set_cpu(RzAsm *a, const char *cpu) {
 	if (a) {
 		free(a->cpu);
-		a->cpu = cpu ? strdup(cpu) : NULL;
+		a->cpu = rz_str_dup(cpu);
 	}
 }
 
@@ -725,7 +725,7 @@ RZ_API void rz_asm_list_directives(void) {
 RZ_API int rz_asm_assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
 	rz_return_val_if_fail(a && op && buf, 0);
 	int ret = 0;
-	char *b = strdup(buf);
+	char *b = rz_str_dup(buf);
 	if (!b) {
 		return 0;
 	}
@@ -871,7 +871,7 @@ RZ_API RzAsmCode *rz_asm_massemble(RzAsm *a, const char *assembly) {
 		free(tokens);
 		return rz_asm_code_free(acode);
 	}
-	lbuf = strdup(assembly);
+	lbuf = rz_str_dup(assembly);
 	acode->code_align = 0;
 
 	/* consider ,, an alias for a newline */
@@ -900,7 +900,7 @@ RZ_API RzAsmCode *rz_asm_massemble(RzAsm *a, const char *assembly) {
 			if (sp) {
 				char osp = *sp;
 				*sp = 0;
-				aa = strdup(p);
+				aa = rz_str_dup(p);
 				*sp = osp;
 				num = rz_syscall_get_num(a->syscall, aa + 5);
 				snprintf(val, sizeof(val), "%d", num);
@@ -1022,7 +1022,7 @@ RZ_API RzAsmCode *rz_asm_massemble(RzAsm *a, const char *assembly) {
 					// if (stage != 2) {
 					if (ptr_start[1] && ptr_start[1] != ' ') {
 						*ptr = 0;
-						char *p = strdup(ptr_start);
+						char *p = rz_str_dup(ptr_start);
 						*ptr = ':';
 						if (acode->code_align) {
 							off += (acode->code_align - (off % acode->code_align));
@@ -1060,7 +1060,7 @@ RZ_API RzAsmCode *rz_asm_massemble(RzAsm *a, const char *assembly) {
 					ret = rz_asm_pseudo_string(&op, ptr + 8, 1);
 				} else if (!strncmp(ptr, ".string ", 8)) {
 					rz_str_trim(ptr + 8);
-					char *str = strdup(ptr + 8);
+					char *str = rz_str_dup(ptr + 8);
 					ret = rz_asm_pseudo_string(&op, str, 1);
 					free(str);
 				} else if (!strncmp(ptr, ".ascii", 6)) {
@@ -1151,7 +1151,7 @@ RZ_API RzAsmCode *rz_asm_massemble(RzAsm *a, const char *assembly) {
 					if (!*ptr_start) {
 						continue;
 					}
-					str = rz_asm_code_equ_replace(acode, strdup(ptr_start));
+					str = rz_asm_code_equ_replace(acode, rz_str_dup(ptr_start));
 					rz_asm_op_fini(&op);
 					rz_asm_op_init(&op);
 					ret = rz_asm_assemble(a, &op, str);
@@ -1293,7 +1293,7 @@ RZ_API int rz_asm_mnemonics_byname(RzAsm *a, const char *name) {
 
 RZ_API RzAsmCode *rz_asm_rasm_assemble(RzAsm *a, const char *buf, bool use_spp) {
 	rz_return_val_if_fail(a && buf, NULL);
-	char *lbuf = strdup(buf);
+	char *lbuf = rz_str_dup(buf);
 	if (!lbuf) {
 		return NULL;
 	}
@@ -1309,7 +1309,7 @@ RZ_API RzAsmCode *rz_asm_rasm_assemble(RzAsm *a, const char *buf, bool use_spp) 
 		lbuf = replace_directives(lbuf);
 		spp_eval(lbuf, &out);
 		free(lbuf);
-		lbuf = strdup(rz_strbuf_get(out.cout));
+		lbuf = rz_str_dup(rz_strbuf_get(out.cout));
 	}
 	acode = rz_asm_massemble(a, lbuf);
 	free(lbuf);

--- a/librz/arch/cc.c
+++ b/librz/arch/cc.c
@@ -36,14 +36,14 @@ RZ_API void rz_analysis_cc_del(RzAnalysis *analysis, const char *name) {
 
 RZ_API bool rz_analysis_cc_set(RzAnalysis *analysis, const char *expr) {
 	rz_return_val_if_fail(analysis && expr, false);
-	char *e = strdup(expr);
+	char *e = rz_str_dup(expr);
 	char *p = strchr(e, '(');
 	if (!p) {
 		free(e);
 		return false;
 	}
 	*p++ = 0;
-	char *args = strdup(p);
+	char *args = rz_str_dup(p);
 	rz_str_trim(p);
 	char *end = strchr(args, ')');
 	if (!end) {
@@ -275,7 +275,7 @@ RZ_API RzList /*<char *>*/ *rz_analysis_calling_conventions(RzAnalysis *analysis
 	RzPVector *items = sdb_get_items_filter(analysis->sdb_cc, filter_cc, NULL, true);
 	rz_pvector_foreach (items, iter) {
 		SdbKv *kv = *iter;
-		rz_list_append(ccl, strdup(sdbkv_key(kv)));
+		rz_list_append(ccl, rz_str_dup(sdbkv_key(kv)));
 	}
 	rz_pvector_free(items);
 	return ccl;

--- a/librz/arch/class.c
+++ b/librz/arch/class.c
@@ -907,7 +907,7 @@ RZ_API RzAnalysisClassErr rz_analysis_class_base_get(RzAnalysis *analysis, const
 	char *next;
 	sdb_anext(cur, &next);
 
-	base->class_name = strdup(cur);
+	base->class_name = rz_str_dup(cur);
 	if (!base->class_name) {
 		free(content);
 		return RZ_ANALYSIS_CLASS_ERR_OTHER;

--- a/librz/arch/cond.c
+++ b/librz/arch/cond.c
@@ -86,7 +86,7 @@ RZ_API char *rz_analysis_cond_to_string(RzAnalysisCond *cond) {
 	}
 	free(val0);
 	free(val1);
-	return out ? out : strdup("?");
+	return out ? out : rz_str_dup("?");
 }
 
 RZ_API RzAnalysisCond *rz_analysis_cond_new_from_op(RzAnalysisOp *op) {

--- a/librz/arch/dwarf_process.c
+++ b/librz/arch/dwarf_process.c
@@ -2009,7 +2009,7 @@ static bool RzAnalysisDwarfVariable_as_RzAnalysisVar(RzAnalysis *a, RzAnalysisFu
 		return false;
 	}
 	var->type = DW_var->type ? rz_type_clone(DW_var->type) : rz_type_new_default(a->typedb);
-	var->name = strdup(DW_var->prefer_name ? DW_var->prefer_name : "");
+	var->name = rz_str_dup(DW_var->prefer_name ? DW_var->prefer_name : "");
 	var->kind = DW_var->kind;
 	var->fcn = f;
 	var->origin.kind = RZ_ANALYSIS_VAR_ORIGIN_DWARF;

--- a/librz/arch/esil/esil.c
+++ b/librz/arch/esil/esil.c
@@ -379,7 +379,7 @@ RZ_API bool rz_analysis_esil_push(RzAnalysisEsil *esil, const char *str) {
 	if (!str || !esil || !*str || esil->stackptr > (esil->stacksize - 1)) {
 		return false;
 	}
-	esil->stack[esil->stackptr++] = strdup(str);
+	esil->stack[esil->stackptr++] = rz_str_dup(str);
 	return true;
 }
 

--- a/librz/arch/fcn.c
+++ b/librz/arch/fcn.c
@@ -790,7 +790,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 			const char *name = analysis->coreb.getName(analysis->coreb.core, at);
 			if (name) {
 				if (rz_str_startswith(name, "try.") && rz_str_endswith(name, ".from")) {
-					char *handle = strdup(name);
+					char *handle = rz_str_dup(name);
 					// handle = rz_str_replace (handle, ".from", ".to", 0);
 					ut64 from_addr = analysis->coreb.numGet(analysis->coreb.core, handle);
 					handle = rz_str_replace(handle, ".from", ".catch", 0);
@@ -910,7 +910,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 			// Is this a mov of immediate value into a register?
 			if (op.dst && op.dst->reg && op.dst->reg->name && op.val > 0 && op.val != UT64_MAX) {
 				free(last_reg_mov_lea_name);
-				if ((last_reg_mov_lea_name = strdup(op.dst->reg->name))) {
+				if ((last_reg_mov_lea_name = rz_str_dup(op.dst->reg->name))) {
 					last_reg_mov_lea_val = op.val;
 					last_is_reg_mov_lea = true;
 				}
@@ -921,7 +921,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 				movscale = op.scale;
 				if (op.src[0] && op.src[0]->reg) {
 					free(movbasereg);
-					movbasereg = strdup(op.src[0]->reg->name);
+					movbasereg = rz_str_dup(op.src[0]->reg->name);
 				} else {
 					RZ_FREE(movbasereg);
 				}
@@ -948,9 +948,9 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 				pair->op_addr = op.addr;
 				pair->leaddr = op.ptr; // XXX movdisp is dupped but seems to be trashed sometimes(?), better track leaddr separately
 				pair->reg = op.reg
-					? strdup(op.reg)
+					? rz_str_dup(op.reg)
 					: op.dst && op.dst->reg
-					? strdup(op.dst->reg->name)
+					? rz_str_dup(op.dst->reg->name)
 					: NULL;
 				rz_list_append(analysis->leaddrs, pair);
 			}
@@ -959,7 +959,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 			}
 			if (op.dst && op.dst->reg && op.dst->reg->name && op.ptr > 0 && op.ptr != UT64_MAX) {
 				free(last_reg_mov_lea_name);
-				if ((last_reg_mov_lea_name = strdup(op.dst->reg->name))) {
+				if ((last_reg_mov_lea_name = rz_str_dup(op.dst->reg->name))) {
 					last_reg_mov_lea_val = op.ptr;
 					last_is_reg_mov_lea = true;
 				}
@@ -2605,7 +2605,7 @@ RZ_API RZ_OWN RzCallable *rz_analysis_function_clone_type(RzAnalysis *analysis, 
 	// Check first if there is a match with some pre-existing RzCallable type in the database
 	char *shortname = rz_analysis_function_name_guess(analysis->typedb, f->name);
 	if (!shortname) {
-		shortname = strdup(f->name);
+		shortname = rz_str_dup(f->name);
 	}
 	// At this point the `callable` pointer is *borrowed*
 	RzCallable *callable = rz_type_func_get(analysis->typedb, shortname);

--- a/librz/arch/filter.c
+++ b/librz/arch/filter.c
@@ -32,7 +32,7 @@ static char *findEnd(const char *s) {
 		s++;
 		// also skip ansi escape codes here :?
 	}
-	return strdup(s);
+	return rz_str_dup(s);
 }
 
 static void insert(char *dst, const char *src) {
@@ -130,7 +130,7 @@ static void __replaceRegisters(RzReg *reg, char *s, bool x86) {
 		}
 		if (x86 && *k == 'r') {
 			replaceWords(s, k, v);
-			char *reg32 = strdup(k);
+			char *reg32 = rz_str_dup(k);
 			*reg32 = 'e';
 			replaceWords(s, reg32, v);
 		} else {
@@ -576,7 +576,7 @@ RZ_API bool rz_parse_filter(RzParse *p, ut64 addr, RzFlag *f, RzAnalysisHint *hi
 // easier to use, should replace rz_parse_filter(), but its not using rflag, analhint, endian, etc
 RZ_API char *rz_parse_filter_dup(RzParse *p, ut64 addr, const char *opstr) {
 	const size_t out_len = 256;
-	char *in = strdup(opstr);
+	char *in = rz_str_dup(opstr);
 	char *out = calloc(out_len, 1);
 	if (!rz_parse_filter(p, addr, NULL, NULL, in, out, out_len, false)) {
 		free(out);

--- a/librz/arch/function.c
+++ b/librz/arch/function.c
@@ -175,7 +175,7 @@ RZ_API RzAnalysisFunction *rz_analysis_create_function(RzAnalysis *analysis, con
 	fcn->bits = analysis->bits;
 	if (name) {
 		free(fcn->name);
-		fcn->name = strdup(name);
+		fcn->name = rz_str_dup(name);
 	} else {
 		const char *fcnprefix = analysis->coreb.cfgGet ? analysis->coreb.cfgGet(analysis->coreb.core, "analysis.fcnprefix") : NULL;
 		if (RZ_STR_ISEMPTY(fcnprefix)) {
@@ -268,7 +268,7 @@ RZ_API bool rz_analysis_function_rename(RzAnalysisFunction *fcn, const char *nam
 		}
 		return false;
 	}
-	char *newname = strdup(name);
+	char *newname = rz_str_dup(name);
 	if (!newname) {
 		return false;
 	}
@@ -409,7 +409,7 @@ static RZ_OWN char *function_name_try_guess(RzTypeDB *typedb, RZ_NONNULL char *n
 		return NULL;
 	}
 	if (rz_type_func_exist(typedb, name)) {
-		return strdup(name);
+		return rz_str_dup(name);
 	}
 	return NULL;
 }
@@ -495,7 +495,7 @@ RZ_API RZ_OWN char *rz_analysis_function_name_guess(RzTypeDB *typedb, RZ_NONNULL
 		return result;
 	}
 
-	str = strdup(str);
+	str = rz_str_dup(str);
 	clean_function_name(str);
 
 	if (*str == '_' && (result = function_name_try_guess(typedb, str + 1))) {

--- a/librz/arch/hint.c
+++ b/librz/arch/hint.c
@@ -199,7 +199,7 @@ static RzAnalysisRangedHintRecordBase *ensure_ranged_hint_record(RBTree *tree, u
 RZ_API void rz_analysis_hint_set_offset(RzAnalysis *a, ut64 addr, const char *typeoff) {
 	SET_HINT(RZ_ANALYSIS_ADDR_HINT_TYPE_TYPE_OFFSET,
 		 free(r->type_offset);
-		 r->type_offset = strdup(typeoff););
+		 r->type_offset = rz_str_dup(typeoff););
 }
 
 RZ_API void rz_analysis_hint_set_nword(RzAnalysis *a, ut64 addr, int nword) {
@@ -241,19 +241,19 @@ RZ_API void rz_analysis_hint_set_ret(RzAnalysis *a, ut64 addr, ut64 val) {
 RZ_API void rz_analysis_hint_set_syntax(RzAnalysis *a, ut64 addr, const char *syn) {
 	SET_HINT(RZ_ANALYSIS_ADDR_HINT_TYPE_SYNTAX,
 		 free(r->syntax);
-		 r->syntax = strdup(syn););
+		 r->syntax = rz_str_dup(syn););
 }
 
 RZ_API void rz_analysis_hint_set_opcode(RzAnalysis *a, ut64 addr, const char *opcode) {
 	SET_HINT(RZ_ANALYSIS_ADDR_HINT_TYPE_OPCODE,
 		 free(r->opcode);
-		 r->opcode = strdup(opcode););
+		 r->opcode = rz_str_dup(opcode););
 }
 
 RZ_API void rz_analysis_hint_set_esil(RzAnalysis *a, ut64 addr, const char *esil) {
 	SET_HINT(RZ_ANALYSIS_ADDR_HINT_TYPE_ESIL,
 		 free(r->esil);
-		 r->esil = strdup(esil););
+		 r->esil = rz_str_dup(esil););
 }
 
 RZ_API void rz_analysis_hint_set_type(RzAnalysis *a, ut64 addr, int type) {
@@ -278,7 +278,7 @@ RZ_API void rz_analysis_hint_set_arch(RzAnalysis *a, ut64 addr, RZ_NULLABLE cons
 		return;
 	}
 	free(record->arch);
-	record->arch = arch ? strdup(arch) : NULL;
+	record->arch = rz_str_dup(arch);
 }
 
 RZ_API void rz_analysis_hint_set_bits(RzAnalysis *a, ut64 addr, int bits) {
@@ -476,19 +476,19 @@ static void hint_merge(RzAnalysisHint *hint, RzAnalysisAddrHintRecord *record) {
 		hint->size = record->size;
 		break;
 	case RZ_ANALYSIS_ADDR_HINT_TYPE_SYNTAX:
-		hint->syntax = record->syntax ? strdup(record->syntax) : NULL;
+		hint->syntax = rz_str_dup(record->syntax);
 		break;
 	case RZ_ANALYSIS_ADDR_HINT_TYPE_OPTYPE:
 		hint->type = record->optype;
 		break;
 	case RZ_ANALYSIS_ADDR_HINT_TYPE_OPCODE:
-		hint->opcode = record->opcode ? strdup(record->opcode) : NULL;
+		hint->opcode = rz_str_dup(record->opcode);
 		break;
 	case RZ_ANALYSIS_ADDR_HINT_TYPE_TYPE_OFFSET:
-		hint->offset = record->type_offset ? strdup(record->type_offset) : NULL;
+		hint->offset = rz_str_dup(record->type_offset);
 		break;
 	case RZ_ANALYSIS_ADDR_HINT_TYPE_ESIL:
-		hint->esil = record->esil ? strdup(record->esil) : NULL;
+		hint->esil = rz_str_dup(record->esil);
 		break;
 	case RZ_ANALYSIS_ADDR_HINT_TYPE_HIGH:
 		hint->high = true;
@@ -518,7 +518,7 @@ RZ_API RzAnalysisHint *rz_analysis_hint_get(RzAnalysis *a, ut64 addr) {
 		}
 	}
 	const char *arch = rz_analysis_hint_arch_at(a, addr, NULL);
-	hint->arch = arch ? strdup(arch) : NULL;
+	hint->arch = rz_str_dup(arch);
 	hint->bits = rz_analysis_hint_bits_at(a, addr, NULL);
 	if ((!records || rz_vector_empty(records)) && !hint->arch && !hint->bits) {
 		// no hints found

--- a/librz/arch/isa/8051/8051_disas.c
+++ b/librz/arch/isa/8051/8051_disas.c
@@ -121,7 +121,7 @@ char *rz_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 				}
 			} else {
 				*olen = -1;
-				return strdup("truncated");
+				return rz_str_dup("truncated");
 			}
 			break;
 		case 3:
@@ -159,7 +159,7 @@ char *rz_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 				}
 			} else {
 				*olen = -1;
-				return strdup("truncated");
+				return rz_str_dup("truncated");
 			}
 			break;
 		default:

--- a/librz/arch/isa/arm/armass.c
+++ b/librz/arch/isa/arm/armass.c
@@ -889,7 +889,7 @@ static ut32 thumb_getshift(const char *str) {
 	const char *shifts[] = {
 		"LSL", "LSR", "ASR", "ROR", 0, "RRX"
 	};
-	char *type = strdup(str);
+	char *type = rz_str_dup(str);
 	char *arg;
 	char *space;
 	ut32 res = 0;
@@ -914,7 +914,7 @@ static ut32 thumb_getshift(const char *str) {
 		return 0;
 	}
 	*space = 0;
-	arg = strdup(++space);
+	arg = rz_str_dup(++space);
 
 	for (i = 0; shifts[i]; i++) {
 		if (!strcmp(type, shifts[i])) {

--- a/librz/arch/isa/arm/armass64.c
+++ b/librz/arch/isa/arm/armass64.c
@@ -1007,7 +1007,7 @@ static ut32 bitfield(ArmOp *op, int k) {
 }
 
 static bool parseOperands(char *str, ArmOp *op) {
-	char *t = strdup(str);
+	char *t = rz_str_dup(str);
 	int operand = 0;
 	char *token = t;
 	char *x;
@@ -1294,7 +1294,7 @@ static bool parseOperands(char *str, ArmOp *op) {
 }
 
 static bool parseOpcode(const char *str, ArmOp *op) {
-	char *in = strdup(str);
+	char *in = rz_str_dup(str);
 	char *space = strchr(in, ' ');
 	if (!space) {
 		op->operands[0].type = ARM_NOTYPE;

--- a/librz/arch/isa/avr/assembler.c
+++ b/librz/arch/isa/avr/assembler.c
@@ -991,7 +991,7 @@ static void sanitize_input(char *cinput, st32 input_size) {
 
 static char **tokens_new(cchar *input, st32 input_size, ut32 *ntokens) {
 
-	char *cinput = strdup(input);
+	char *cinput = rz_str_dup(input);
 	if (!cinput) {
 		rz_warn_if_reached();
 		return NULL;

--- a/librz/arch/isa/luac/v53/analysis_53.c
+++ b/librz/arch/isa/luac/v53/analysis_53.c
@@ -21,7 +21,7 @@ int lua53_anal_op(RzAnalysis *anal, RzAnalysisOp *op, ut64 addr, const ut8 *data
 	if (GET_OPCODE(instruction) > OP_EXTRAARG) {
 		return op->size;
 	}
-	// op->mnemonic = strdup ();
+	// op->mnemonic = rz_str_dup ();
 
 	switch (GET_OPCODE(instruction)) {
 	case OP_MOVE: /*      A B     R(A) := R(B)                                    */

--- a/librz/arch/isa/mips/mips_assembler.c
+++ b/librz/arch/isa/mips/mips_assembler.c
@@ -149,7 +149,7 @@ static int getreg(const char *p) {
 RZ_IPI int mips_assemble_opcode(const char *str, ut64 pc, ut8 *out) {
 	int i, hasp;
 	char w0[32], w1[32], w2[32], w3[32];
-	char *s = strdup(str);
+	char *s = rz_str_dup(str);
 	if (!s) {
 		return -1;
 	}
@@ -170,7 +170,7 @@ RZ_IPI int mips_assemble_opcode(const char *str, ut64 pc, ut8 *out) {
 		if (arg) {
 			snprintf(opstr, sizeof(opstr), "jalr ra ra %s", arg + 1);
 			free(s);
-			s = strdup(opstr);
+			s = rz_str_dup(opstr);
 			if (!s) {
 				return -1;
 			}

--- a/librz/arch/isa/pic/pic16_analysis.c
+++ b/librz/arch/isa/pic/pic16_analysis.c
@@ -208,5 +208,5 @@ char *pic16_get_reg_profile(RzAnalysis *a) {
 		"gpr tosh .8 25 0\n"
 		"gpr tris .8 26 0\n"
 		"gpr _bank .8 27 0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }

--- a/librz/arch/isa/pic/pic18_analysis.c
+++ b/librz/arch/isa/pic/pic18_analysis.c
@@ -403,5 +403,5 @@ char *pic18_get_reg_profile(RzAnalysis *esil) {
 		"gpr wregs .8 101 0\n"
 		"gpr statuss .8 102 0\n"
 		"gpr bsrs .8 103 0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }

--- a/librz/arch/isa/pyc/opcode.c
+++ b/librz/arch/isa/pyc/opcode.c
@@ -245,7 +245,7 @@ void add_arg_fmt(pyc_opcodes *ret, char *op_name, const char *(*formatter)(ut32 
 
 void(def_opN)(struct op_parameter par) {
 	free(par.op_obj[par.op_code].op_name);
-	par.op_obj[par.op_code].op_name = strdup(par.op_name);
+	par.op_obj[par.op_code].op_name = rz_str_dup(par.op_name);
 	par.op_obj[par.op_code].op_code = par.op_code;
 	par.op_obj[par.op_code].op_pop = par.pop;
 	par.op_obj[par.op_code].op_push = par.push;

--- a/librz/arch/isa/sh/assembler.c
+++ b/librz/arch/isa/sh/assembler.c
@@ -24,7 +24,7 @@ static SHAddrMode sh_pb_get_addrmode(SHParamBuilder pb) {
  * \return char* Duplicated output "spaced out" string
  */
 static char *sh_op_space_params(const char *buffer) {
-	char *spaced = strdup(buffer);
+	char *spaced = rz_str_dup(buffer);
 	bool inside_paren = false;
 
 	for (ut8 i = 0; spaced[i] != '\0'; i++) {
@@ -87,9 +87,9 @@ static ut32 sh_op_param_bits(SHParamBuilder shb, const char *param, SHScaling sc
 
 	ut32 opcode = 0;
 	struct sh_param_builder_addr_t shba = shb.addr;
-	char *const reg = strdup(param);
-	char *const dup = strdup(param);
-	char *const disp = strdup(param);
+	char *const reg = rz_str_dup(param);
+	char *const dup = rz_str_dup(param);
+	char *const disp = rz_str_dup(param);
 	ut8 d;
 
 	switch (shba.mode) {
@@ -209,7 +209,7 @@ static ut32 sh_op_param_bits(SHParamBuilder shb, const char *param, SHScaling sc
 static ut64 sh_op_movl_param_bits(const char *reg_direct, const char *reg_disp_indirect) {
 	ut64 opcode = sh_op_reg_bits(reg_direct, NIB1);
 
-	char *const dup = strdup(reg_disp_indirect);
+	char *const dup = rz_str_dup(reg_disp_indirect);
 	char *comma = strchr(dup, ',');
 	if (!comma) {
 		goto fail;
@@ -222,7 +222,7 @@ static ut64 sh_op_movl_param_bits(const char *reg_direct, const char *reg_disp_i
 	}
 	*paren = '\0';
 
-	char *const disp = strdup(reg_disp_indirect);
+	char *const disp = rz_str_dup(reg_disp_indirect);
 	sscanf(dup, "@(%s", disp);
 	ut8 d = (rz_num_get(NULL, disp) / sh_scaling_size[SH_SCALING_L]) & 0xf;
 	opcode |= d << NIB0;

--- a/librz/arch/isa/tms320/c55x_plus/c55plus_decode.c
+++ b/librz/arch/isa/tms320/c55x_plus/c55plus_decode.c
@@ -136,7 +136,7 @@ static char *decode_regis(char *reg_arg, st32 hash_code, ut32 ins_bits,
 			*err_code = -1;
 			return NULL;
 		}
-		res = (check_arg(ins_bits, err_code) != 0 && *err_code == 0) ? strdup("dbl(") : NULL;
+		res = (check_arg(ins_bits, err_code) != 0 && *err_code == 0) ? rz_str_dup("dbl(") : NULL;
 		if (*err_code < 0) {
 			return NULL;
 		}
@@ -147,7 +147,7 @@ static char *decode_regis(char *reg_arg, st32 hash_code, ut32 ins_bits,
 			*err_code = -1;
 			return NULL;
 		}
-		res = (check_arg(ins_bits, err_code) && *err_code == 0) ? strdup(")") : NULL;
+		res = (check_arg(ins_bits, err_code) && *err_code == 0) ? rz_str_dup(")") : NULL;
 		if (*err_code < 0) {
 			return NULL;
 		}
@@ -553,7 +553,7 @@ static char *get_token_decoded(st32 hash_code, char *ins_token, ut32 ins_token_l
 	case 64:
 	case 65:
 		if (!reg_arg || *reg_arg == '\0') {
-			res = strdup("<register>");
+			res = rz_str_dup("<register>");
 			goto ret_decode;
 		}
 		res = decode_regis(reg_arg, hash_code, ins_bits, ret_ins_bits, err_code);
@@ -561,18 +561,18 @@ static char *get_token_decoded(st32 hash_code, char *ins_token, ut32 ins_token_l
 			return NULL;
 		}
 		break;
-	case 35: res = ins_bits ? strdup(" || far()") : NULL; break;
-	case 36: res = ins_bits ? strdup(" || local()") : NULL; break;
+	case 35: res = ins_bits ? rz_str_dup(" || far()") : NULL; break;
+	case 36: res = ins_bits ? rz_str_dup(" || local()") : NULL; break;
 	case 37: res = get_opers(ins_bits); break;
 	case 38:
 		res = ins_bits ? "lo" : "hi";
-		res = strdup(res);
+		res = rz_str_dup(res);
 		break;
 	case 39: res = get_cmp_op(ins_bits); break;
 	case 40:
 	case 48:
 		sprintf(buff_aux, "#0x%x", (ins_bits << (32 - ins_token_len) >> (32 - ins_token_len)));
-		res = strdup(buff_aux);
+		res = rz_str_dup(buff_aux);
 		break;
 	case 70:
 	case 72:
@@ -594,7 +594,7 @@ static char *get_token_decoded(st32 hash_code, char *ins_token, ut32 ins_token_l
 		} else {
 			sprintf(buff_aux, "-#0x%lx", (long unsigned int)ins_bits);
 		}
-		res = strdup(buff_aux);
+		res = rz_str_dup(buff_aux);
 		if (!reg_arg || *reg_arg != 'm') {
 			break;
 		}
@@ -621,10 +621,10 @@ static char *get_token_decoded(st32 hash_code, char *ins_token, ut32 ins_token_l
 			ins_bits = ins_bits << (32 - ins_token_len) >> (32 - ins_token_len);
 		}
 		if (reg_arg && *reg_arg == 'i') {
-			res = strdup("");
+			res = rz_str_dup("");
 		} else {
 			sprintf(buff_aux, "#0x%06lx", (long unsigned int)ins_bits);
-			res = strdup(buff_aux);
+			res = rz_str_dup(buff_aux);
 		}
 		break;
 	case 42:
@@ -724,7 +724,7 @@ static char *get_token_decoded(st32 hash_code, char *ins_token, ut32 ins_token_l
 		} else {
 			res = "<W !flags>";
 		}
-		res = strdup(res);
+		res = rz_str_dup(res);
 		break;
 	case 53:
 	case 54:
@@ -784,7 +784,7 @@ static char *get_token_decoded(st32 hash_code, char *ins_token, ut32 ins_token_l
 				res = "<$/#>";
 			}
 		}
-		res = strdup(res);
+		res = rz_str_dup(res);
 		break;
 	case 2:
 		if (!ins_bits) {
@@ -801,7 +801,7 @@ static char *get_token_decoded(st32 hash_code, char *ins_token, ut32 ins_token_l
 				res = "<%>";
 			}
 		}
-		res = strdup(res);
+		res = rz_str_dup(res);
 		break;
 	case 12:
 		if (!ins_bits) {
@@ -820,7 +820,7 @@ static char *get_token_decoded(st32 hash_code, char *ins_token, ut32 ins_token_l
 				res = "</>";
 			}
 		}
-		res = strdup(res);
+		res = rz_str_dup(res);
 		break;
 	case 29:
 		if (!ins_bits) {
@@ -837,10 +837,10 @@ static char *get_token_decoded(st32 hash_code, char *ins_token, ut32 ins_token_l
 				res = "<saturate>";
 			}
 		}
-		res = strdup(res);
+		res = rz_str_dup(res);
 		break;
 	case 16:
-		res = (ins_bits != 0) ? strdup("t3 = ") : NULL;
+		res = (ins_bits != 0) ? rz_str_dup("t3 = ") : NULL;
 		break;
 	case 17:
 		if (!ins_bits) {
@@ -857,7 +857,7 @@ static char *get_token_decoded(st32 hash_code, char *ins_token, ut32 ins_token_l
 				res = "<4>";
 			}
 		}
-		res = strdup(res);
+		res = rz_str_dup(res);
 		break;
 	case 78:
 		if (!rz_str_ncasecmp(ins_token, "q_SAT", 5)) {
@@ -875,7 +875,7 @@ static char *get_token_decoded(st32 hash_code, char *ins_token, ut32 ins_token_l
 			if (C55PLUS_DEBUG) {
 				printf("OP(78): TOKEN=%s\n", res);
 			}
-			res = strdup(res);
+			res = rz_str_dup(res);
 		}
 		break;
 	}

--- a/librz/arch/isa/tms320/c55x_plus/decode_funcs.c
+++ b/librz/arch/isa/tms320/c55x_plus/decode_funcs.c
@@ -17,7 +17,7 @@ char *get_tc2_tc1(ut32 ins_bits) {
 		}
 		res = "tc2";
 	}
-	return strdup(res);
+	return rz_str_dup(res);
 }
 
 char *get_trans_reg(ut32 ins_bits) {
@@ -52,7 +52,7 @@ char *get_trans_reg(ut32 ins_bits) {
 	default:
 		fprintf(stderr, "Invalid transaction instruction 0x%x\n", ins_bits);
 	}
-	return res ? strdup(res) : NULL;
+	return rz_str_dup(res);
 }
 
 char *get_AR_regs_class1(ut32 ins_bits) {
@@ -260,7 +260,7 @@ char *get_reg_pair(ut32 idx) {
 	}
 
 	if (res != NULL) {
-		res = strdup(res);
+		res = rz_str_dup(res);
 	}
 
 	return res;
@@ -325,7 +325,7 @@ char *get_reg_name_3(ut32 idx) {
 	}
 
 	if (res != NULL) {
-		res = strdup(res);
+		res = rz_str_dup(res);
 	}
 	return res;
 }
@@ -380,7 +380,7 @@ char *get_reg_name_2(ut32 idx) {
 	}
 
 	if (res != NULL) {
-		res = strdup(res);
+		res = rz_str_dup(res);
 	}
 
 	return res;
@@ -635,7 +635,7 @@ char *get_reg_name_1(ut32 idx) {
 	}
 
 	if (res != NULL) {
-		res = strdup(res);
+		res = rz_str_dup(res);
 	}
 
 	return res;
@@ -850,7 +850,7 @@ char *get_status_regs_and_bits(char *reg_arg, int reg_bit) {
 	}
 
 	if (res != NULL) {
-		res = strdup(res);
+		res = rz_str_dup(res);
 	}
 
 	return res;
@@ -945,71 +945,71 @@ char *get_reg_name_4(ut32 idx) {
 		res = "ac7.l";
 		break;
 	}
-	return res ? strdup(res) : NULL;
+	return rz_str_dup(res);
 }
 
 char *get_opers(ut8 oper_byte) {
 	switch (oper_byte) {
 	case 0xE0u:
-		return strdup("overflow(ac0)");
+		return rz_str_dup("overflow(ac0)");
 	case 0xE1u:
-		return strdup("overflow(ac1)");
+		return rz_str_dup("overflow(ac1)");
 	case 0xE2u:
-		return strdup("overflow(ac2)");
+		return rz_str_dup("overflow(ac2)");
 	case 0xE3u:
-		return strdup("overflow(ac3)");
+		return rz_str_dup("overflow(ac3)");
 	case 0xE4u:
-		return strdup("tc1");
+		return rz_str_dup("tc1");
 	case 0xE5u:
-		return strdup("tc2");
+		return rz_str_dup("tc2");
 	case 0xE6u:
-		return strdup("carry");
+		return rz_str_dup("carry");
 	case 0xE7u:
-		return strdup("overflow(govf)");
+		return rz_str_dup("overflow(govf)");
 	case 0xE8u:
-		return strdup("tc1 & tc2");
+		return rz_str_dup("tc1 & tc2");
 	case 0xE9u:
-		return strdup("tc1 & !tc2");
+		return rz_str_dup("tc1 & !tc2");
 	case 0xEAu:
-		return strdup("!tc1 & tc2");
+		return rz_str_dup("!tc1 & tc2");
 	case 0xEBu:
-		return strdup("!tc1 & !tc2");
+		return rz_str_dup("!tc1 & !tc2");
 	case 0xECu:
-		return strdup("word_mode");
+		return rz_str_dup("word_mode");
 	case 0xEDu:
-		return strdup("byte_mode");
+		return rz_str_dup("byte_mode");
 	case 0xF0u:
-		return strdup("!overflow(ac0)");
+		return rz_str_dup("!overflow(ac0)");
 	case 0xF1u:
-		return strdup("!overflow(ac1)");
+		return rz_str_dup("!overflow(ac1)");
 	case 0xF2u:
-		return strdup("!overflow(ac2)");
+		return rz_str_dup("!overflow(ac2)");
 	case 0xF3u:
-		return strdup("!overflow(ac3)");
+		return rz_str_dup("!overflow(ac3)");
 	case 0xF4u:
-		return strdup("!tc1");
+		return rz_str_dup("!tc1");
 	case 0xF5u:
-		return strdup("!tc2");
+		return rz_str_dup("!tc2");
 	case 0xF6u:
-		return strdup("!carry");
+		return rz_str_dup("!carry");
 	case 0xF7u:
-		return strdup("!overflow(govf)");
+		return rz_str_dup("!overflow(govf)");
 	case 0xF8u:
-		return strdup("tc1 | tc2");
+		return rz_str_dup("tc1 | tc2");
 	case 0xF9u:
-		return strdup("tc1 | !tc2");
+		return rz_str_dup("tc1 | !tc2");
 	case 0xFAu:
-		return strdup("!tc1 | tc2");
+		return rz_str_dup("!tc1 | tc2");
 	case 0xFBu:
-		return strdup("!tc1 | !tc2");
+		return rz_str_dup("!tc1 | !tc2");
 	case 0xFCu:
-		return strdup("tc1 ^ tc2");
+		return rz_str_dup("tc1 ^ tc2");
 	case 0xFDu:
-		return strdup("tc1 ^ !tc2");
+		return rz_str_dup("tc1 ^ !tc2");
 	case 0xFEu:
-		return strdup("!tc1 ^ tc2");
+		return rz_str_dup("!tc1 ^ tc2");
 	case 0xFFu:
-		return strdup("!tc1 ^ !tc2");
+		return rz_str_dup("!tc1 ^ !tc2");
 	default: {
 		ut8 oper_type = oper_byte >> 5;
 		if (oper_type != 6) {
@@ -1057,7 +1057,7 @@ char *get_cmp_op(ut32 idx) {
 	case 2: res = "<"; break;
 	case 3: res = ">="; break;
 	}
-	return res ? strdup(res) : NULL;
+	return rz_str_dup(res);
 }
 
 char *get_sim_reg(char *reg_arg, ut32 ins_bits) {
@@ -1069,10 +1069,10 @@ char *get_sim_reg(char *reg_arg, ut32 ins_bits) {
 	case 0:
 		if (reg_arg && strchr(reg_arg, 'w')) {
 			if (code == 62) {
-				return strdup("sim0");
+				return rz_str_dup("sim0");
 			}
 			if (code == 63) {
-				return strdup("sim0");
+				return rz_str_dup("sim0");
 			}
 		}
 		aux = get_reg_name_1(ins_bits >> 2);
@@ -1088,7 +1088,7 @@ char *get_sim_reg(char *reg_arg, ut32 ins_bits) {
 		break;
 	case 1:
 	case 3:
-		res = strdup("<reserved>");
+		res = rz_str_dup("<reserved>");
 		break;
 	}
 	return res;

--- a/librz/arch/isa/tms320/c55x_plus/utils.c
+++ b/librz/arch/isa/tms320/c55x_plus/utils.c
@@ -42,5 +42,5 @@ char *get_hex_str(ut32 hex_num) {
 	aux[1] = hex_str[hex_num & 0xF];
 	aux[0] = hex_str[(hex_num >> 4) & 0xF];
 
-	return strdup(aux);
+	return rz_str_dup(aux);
 }

--- a/librz/arch/isa/tms320/c55x_plus/utils.h
+++ b/librz/arch/isa/tms320/c55x_plus/utils.h
@@ -5,6 +5,7 @@
 #define UUTILS_H
 
 #include <rz_types.h>
+#include <rz_util.h>
 #define C55PLUS_DEBUG 0
 
 char *strcat_dup(char *s1, char *s2, st32 n_free);

--- a/librz/arch/isa/tms320/c64x/c64x.c
+++ b/librz/arch/isa/tms320/c64x/c64x.c
@@ -89,7 +89,7 @@ char *tms320_c64x_mnemonics(RzAsm *a, int id, bool json, void *c64x) {
 		if (json) {
 			return vname ? rz_str_newf("[\"%s\"]\n", vname) : NULL;
 		}
-		return vname ? strdup(vname) : NULL;
+		return rz_str_dup(vname);
 	}
 	RzStrBuf *buf = rz_strbuf_new("");
 	if (json) {

--- a/librz/arch/isa/tms320/c64x/c64x.h
+++ b/librz/arch/isa/tms320/c64x/c64x.h
@@ -5,6 +5,7 @@
 #define TMS320_C64X_CAPSTONE_H
 
 #include <rz_asm.h>
+#include <rz_util.h>
 #include <rz_analysis.h>
 #include <capstone/capstone.h>
 

--- a/librz/arch/labels.c
+++ b/librz/arch/labels.c
@@ -22,7 +22,7 @@ RZ_API bool rz_analysis_function_set_label(RzAnalysisFunction *fcn, const char *
 	if (ht_sp_find(fcn->label_addrs, name, NULL)) {
 		return false;
 	}
-	char *n = strdup(name);
+	char *n = rz_str_dup(name);
 	if (!ht_up_insert(fcn->labels, addr, n)) {
 		free(n);
 		return false;

--- a/librz/arch/meta.c
+++ b/librz/arch/meta.c
@@ -122,7 +122,7 @@ static bool meta_set(RzAnalysis *a, RzAnalysisMetaType type, int subtype, ut64 f
 	if (is_string_with_zeroes(type, subtype)) {
 		item->str = rz_str_ndup(str, item->size);
 	} else {
-		item->str = str ? strdup(str) : NULL;
+		item->str = rz_str_dup(str);
 	}
 	if (str && !item->str) {
 		if (!node) { // If we just created this

--- a/librz/arch/op.c
+++ b/librz/arch/op.c
@@ -162,7 +162,7 @@ RZ_API RzAnalysisOp *rz_analysis_op_copy(RzAnalysisOp *op) {
 	}
 	*nop = *op;
 	if (op->mnemonic) {
-		nop->mnemonic = strdup(op->mnemonic);
+		nop->mnemonic = rz_str_dup(op->mnemonic);
 		if (!nop->mnemonic) {
 			free(nop);
 			return NULL;
@@ -356,13 +356,13 @@ RZ_API char *rz_analysis_op_to_string(RzAnalysis *analysis, RzAnalysisOp *op) {
 	char *a0 = rz_analysis_value_to_string(op->src[0]);
 	char *a1 = rz_analysis_value_to_string(op->src[1]);
 	if (!r0) {
-		r0 = strdup("?");
+		r0 = rz_str_dup("?");
 	}
 	if (!a0) {
-		a0 = strdup("?");
+		a0 = rz_str_dup("?");
 	}
 	if (!a1) {
-		a1 = strdup("?");
+		a1 = rz_str_dup("?");
 	}
 
 	switch (op->type) {
@@ -532,7 +532,7 @@ RZ_API char *rz_analysis_op_to_string(RzAnalysis *analysis, RzAnalysisOp *op) {
 	free(r0);
 	free(a0);
 	free(a1);
-	return strdup(ret);
+	return rz_str_dup(ret);
 }
 
 RZ_API const char *rz_analysis_stackop_tostring(int s) {
@@ -581,7 +581,7 @@ RZ_API RZ_NULLABLE RZ_OWN char *rz_analysis_op_describe_sp_effect(RzAnalysisOp *
 	case RZ_ANALYSIS_STACK_INC:
 		return rz_str_newf("%c= %" PFMT64d, op->stackptr > 0 ? '-' : '+', RZ_ABS(op->stackptr));
 	case RZ_ANALYSIS_STACK_RESET:
-		return strdup(":= 0");
+		return rz_str_dup(":= 0");
 	default:
 		return NULL;
 	}
@@ -658,7 +658,7 @@ RZ_API int rz_analysis_op_hint(RzAnalysisOp *op, RzAnalysisHint *hint) {
 		if (hint->opcode) {
 			/* XXX: this is not correct */
 			free(op->mnemonic);
-			op->mnemonic = strdup(hint->opcode);
+			op->mnemonic = rz_str_dup(hint->opcode);
 			changes++;
 		}
 		if (hint->esil) {

--- a/librz/arch/p/analysis/analysis_6502.c
+++ b/librz/arch/p/analysis/analysis_6502.c
@@ -418,7 +418,7 @@ static char *_6502_op_mnemonic(snes_op_t *op) {
 	}
 	const char *end = strchr(op->name, ' ');
 	if (!end) {
-		return strdup(op->name);
+		return rz_str_dup(op->name);
 	}
 	return rz_str_ndup(op->name, end - op->name);
 }
@@ -1177,7 +1177,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr	N	.1	.31	0\n"
 		"gpr	sp	.8	4	0\n"
 		"gpr	pc	.16	5	0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static int esil_6502_init(RzAnalysisEsil *esil) {

--- a/librz/arch/p/analysis/analysis_8051.c
+++ b/librz/arch/p/analysis/analysis_8051.c
@@ -1067,7 +1067,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr	_sfr	.32	28 0\n"
 		"gpr	_xdata	.32 32 0\n"
 		"gpr	_pdata	.32	36 0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static ut32 map_direct_addr(RzAnalysis *analysis, ut8 addr) {

--- a/librz/arch/p/analysis/analysis_amd29k.c
+++ b/librz/arch/p/analysis/analysis_amd29k.c
@@ -275,7 +275,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr	lr126   .32 2024 0\n"
 		"gpr	lr127   .32 2032 0\n"
 		"gpr	lr128   .32 2040 0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p/analysis/analysis_arm_cs.c
+++ b/librz/arch/p/analysis/analysis_arm_cs.c
@@ -2106,7 +2106,7 @@ static int analysis_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *bu
 	if (n < 1) {
 		op->type = RZ_ANALYSIS_OP_TYPE_ILL;
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup("invalid");
+			op->mnemonic = rz_str_dup("invalid");
 		}
 	} else {
 #if CS_NEXT_VERSION < 6
@@ -2541,7 +2541,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 			"fpu	q15	.128	308	0\n"
 			"flg    fpscr .32   324 0\n";
 	}
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *analysis, RzAnalysisInfoType query) {

--- a/librz/arch/p/analysis/analysis_avr.c
+++ b/librz/arch/p/analysis/analysis_avr.c
@@ -349,7 +349,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		// Store Program Memory Control and Status Register (SPMCSR)
 		"gpr	spmcsr	.8	64	0\n";
 
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *analysis, RzAnalysisInfoType query) {

--- a/librz/arch/p/analysis/analysis_bf.c
+++ b/librz/arch/p/analysis/analysis_bf.c
@@ -187,7 +187,7 @@ static int bf_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *b
 			op->il_op = bf_llimit(analysis, addr, op->jump);
 		}
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup("while [ptr]");
+			op->mnemonic = rz_str_dup("while [ptr]");
 		}
 		op->type = RZ_ANALYSIS_OP_TYPE_CJMP;
 		op->fail = addr + 1;
@@ -199,7 +199,7 @@ static int bf_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *b
 			op->il_op = bf_rlimit(analysis, addr, op->jump);
 		}
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup("loop");
+			op->mnemonic = rz_str_dup("loop");
 		}
 		op->type = RZ_ANALYSIS_OP_TYPE_UJMP;
 		break;
@@ -209,7 +209,7 @@ static int bf_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *b
 			op->il_op = bf_right_arrow();
 		}
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup("inc ptr");
+			op->mnemonic = rz_str_dup("inc ptr");
 		}
 		break;
 	case '<':
@@ -218,7 +218,7 @@ static int bf_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *b
 			op->il_op = bf_left_arrow();
 		}
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup("dec ptr");
+			op->mnemonic = rz_str_dup("dec ptr");
 		}
 		break;
 	case '+':
@@ -227,7 +227,7 @@ static int bf_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *b
 			op->il_op = bf_inc();
 		}
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup("inc [ptr]");
+			op->mnemonic = rz_str_dup("inc [ptr]");
 		}
 		break;
 	case '-':
@@ -236,7 +236,7 @@ static int bf_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *b
 			op->il_op = bf_dec();
 		}
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup("dec [ptr]");
+			op->mnemonic = rz_str_dup("dec [ptr]");
 		}
 		break;
 	case '.':
@@ -244,7 +244,7 @@ static int bf_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *b
 			op->il_op = bf_out();
 		}
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup("out [ptr]");
+			op->mnemonic = rz_str_dup("out [ptr]");
 		}
 		op->type = RZ_ANALYSIS_OP_TYPE_STORE;
 		break;
@@ -253,7 +253,7 @@ static int bf_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *b
 			op->il_op = bf_in();
 		}
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup("in [ptr]");
+			op->mnemonic = rz_str_dup("in [ptr]");
 		}
 		op->type = RZ_ANALYSIS_OP_TYPE_LOAD;
 		break;
@@ -261,7 +261,7 @@ static int bf_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *b
 	case 0xff:
 		op->type = RZ_ANALYSIS_OP_TYPE_TRAP;
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup("trap");
+			op->mnemonic = rz_str_dup("trap");
 		}
 		break;
 	default:
@@ -270,7 +270,7 @@ static int bf_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *b
 			op->il_op = rz_il_op_new_nop();
 		}
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup("nop");
+			op->mnemonic = rz_str_dup("nop");
 		}
 		break;
 	}
@@ -278,7 +278,7 @@ static int bf_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *b
 }
 
 static char *get_reg_profile(RzAnalysis *analysis) {
-	return strdup(
+	return rz_str_dup(
 		"=PC	pc\n"
 		"=BP	ptr\n"
 		"=SP	ptr\n"

--- a/librz/arch/p/analysis/analysis_dalvik.c
+++ b/librz/arch/p/analysis/analysis_dalvik.c
@@ -50,7 +50,7 @@ static int dalvik_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut
 	int sz = dalvik_opcodes[data[0]].len;
 	if (!op || sz > len) {
 		if (op && (mask & RZ_ANALYSIS_OP_MASK_DISASM)) {
-			op->mnemonic = strdup("invalid");
+			op->mnemonic = rz_str_dup("invalid");
 		}
 		return -1;
 	}
@@ -754,7 +754,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr	ip	.32	116	0\n"
 		"gpr	sp	.32	120	0\n"
 		"gpr	bp	.32	124	0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p/analysis/analysis_gb.c
+++ b/librz/arch/p/analysis/analysis_gb.c
@@ -1194,7 +1194,7 @@ static int gb_anop(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 
 			sprintf(mn, gb_op[data[0]].name, reg);
 			break;
 		}
-		op->mnemonic = strdup(mn);
+		op->mnemonic = rz_str_dup(mn);
 	}
 	op->addr = addr;
 	op->type = RZ_ANALYSIS_OP_TYPE_UNK;
@@ -2002,7 +2002,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr	mbcram	.16	16	0\n"
 
 		"gpr	ime	.1	18	0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static int esil_gb_init(RzAnalysisEsil *esil) {

--- a/librz/arch/p/analysis/analysis_h8300.c
+++ b/librz/arch/p/analysis/analysis_h8300.c
@@ -714,7 +714,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr	Z	.1	.146	0\n"
 		"gpr	V	.1	.145	0\n"
 		"gpr	C	.1	.144	0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 RzAnalysisPlugin rz_analysis_plugin_h8300 = {

--- a/librz/arch/p/analysis/analysis_hexagon.c
+++ b/librz/arch/p/analysis/analysis_hexagon.c
@@ -745,7 +745,7 @@ RZ_API char *get_reg_profile(RzAnalysis *analysis) {
 		"sys	S77:76_tmp	.64	220096	0\n"
 		"sys	S79:78	.64	220160	0\n"
 		"sys	S79:78_tmp	.64	220224	0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 RzAnalysisPlugin rz_analysis_plugin_hexagon = {

--- a/librz/arch/p/analysis/analysis_i4004.c
+++ b/librz/arch/p/analysis/analysis_i4004.c
@@ -42,7 +42,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr	PC1	.64	34	0\n"
 		"gpr	PC2	.64	34	0\n"
 		"gpr	PC3	.64	34	0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 RzAnalysisPlugin rz_analysis_plugin_i4004 = {

--- a/librz/arch/p/analysis/analysis_java.c
+++ b/librz/arch/p/analysis/analysis_java.c
@@ -141,7 +141,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"=A6	garbage\n"
 		"gpr	pc	    .32 0  0\n"
 		"gpr	garbage	.32 32 0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p/analysis/analysis_m680x_cs.c
+++ b/librz/arch/p/analysis/analysis_m680x_cs.c
@@ -524,7 +524,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr	sp	.16	48	0\n"
 		"gpr	a0	.16	48	0\n"
 		"gpr	a1	.16	48	0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static bool m680x_analysis_fini(void *user) {

--- a/librz/arch/p/analysis/analysis_m68k_cs.c
+++ b/librz/arch/p/analysis/analysis_m68k_cs.c
@@ -774,7 +774,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr	fpcr	.32	176	0\n"
 		"gpr	fpsr	.32	180	0\n"
 		"gpr	fpiar	.32	184	0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static bool m68k_fini(void *user) {

--- a/librz/arch/p/analysis/analysis_mcore.c
+++ b/librz/arch/p/analysis/analysis_mcore.c
@@ -107,7 +107,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr	cr30  .32 184 0\n"
 		"gpr	cr31  .32 188 0\n"
 		"gpr	pc	.32 192 0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p/analysis/analysis_mips_cs.c
+++ b/librz/arch/p/analysis/analysis_mips_cs.c
@@ -773,7 +773,7 @@ static int analyze_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const u
 	n = cs_disasm(hndl, (ut8 *)buf, len, addr, 1, &insn);
 	if (n < 1 || insn->size < 1) {
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup("invalid");
+			op->mnemonic = rz_str_dup("invalid");
 		}
 		goto beach;
 	}
@@ -1209,7 +1209,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 			"gpr	t	.64	280	0\n";
 		break;
 	}
-	return p ? strdup(p) : NULL;
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p/analysis/analysis_msp430.c
+++ b/librz/arch/p/analysis/analysis_msp430.c
@@ -116,7 +116,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr r13 .16  26    0\n"
 		"gpr r14 .16  28    0\n"
 		"gpr r15 .16  30    0\n";
-	return strdup(prof);
+	return rz_str_dup(prof);
 }
 
 RzAnalysisPlugin rz_analysis_plugin_msp430 = {

--- a/librz/arch/p/analysis/analysis_null.c
+++ b/librz/arch/p/analysis/analysis_null.c
@@ -12,7 +12,7 @@ static int null_analysis(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, cons
 }
 
 static char *null_get_reg_profile(RzAnalysis *analysis) {
-	return strdup("");
+	return rz_str_dup("");
 }
 
 RzAnalysisPlugin rz_analysis_plugin_null = {

--- a/librz/arch/p/analysis/analysis_ppc_cs.c
+++ b/librz/arch/p/analysis/analysis_ppc_cs.c
@@ -494,7 +494,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 			"flg	ov	.1	2585	0	# Overflow\n"
 			"flg	ca	.1	2586	0	# Carry\n"
 			"gpr	0	.64	2587	0	# The zero register.\n";
-		return strdup(p);
+		return rz_str_dup(p);
 	} else {
 		p =
 			"=PC	pc\n"
@@ -755,7 +755,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 			"flg	ov	.1	2585	0	# Overflow\n"
 			"flg	ca	.1	2586	0	# Carry\n"
 			"gpr	0	.32	2587	0	# The zero register.\n";
-		return strdup(p);
+		return rz_str_dup(p);
 	}
 }
 
@@ -769,7 +769,7 @@ static int analyze_op_vle(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 
 		// op->id = instr->type;
 
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup(instr->name);
+			op->mnemonic = rz_str_dup(instr->name);
 		}
 		switch (op->type) {
 		case RZ_ANALYSIS_OP_TYPE_ILL:
@@ -991,7 +991,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	} else {
 		op->il_op = rz_ppc_cs_get_il_op(ctx->handle, insn, mode);
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup(insn->mnemonic);
+			op->mnemonic = rz_str_dup(insn->mnemonic);
 		}
 		if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
 			opex(&op->opex, ctx->handle, insn);

--- a/librz/arch/p/analysis/analysis_pyc.c
+++ b/librz/arch/p/analysis/analysis_pyc.c
@@ -30,7 +30,7 @@ static int archinfo(RzAnalysis *analysis, RzAnalysisInfoType query) {
 }
 
 static char *get_reg_profile(RzAnalysis *analysis) {
-	return strdup(
+	return rz_str_dup(
 		"=PC    pc\n"
 		"=BP    bp\n"
 		"=SP    sp\n"

--- a/librz/arch/p/analysis/analysis_riscv_cs.c
+++ b/librz/arch/p/analysis/analysis_riscv_cs.c
@@ -585,7 +585,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 
 		break;
 	}
-	return (p && *p) ? strdup(p) : NULL;
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p/analysis/analysis_rl78.c
+++ b/librz/arch/p/analysis/analysis_rl78.c
@@ -253,7 +253,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"flg	isp0	.1	0	0	in_service_priority_flags_bit_0\n"
 		"flg	cy	.1	0	0	carry\n";
 
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 RzAnalysisPlugin rz_analysis_plugin_rl78 = {

--- a/librz/arch/p/analysis/analysis_rsp.c
+++ b/librz/arch/p/analysis/analysis_rsp.c
@@ -630,7 +630,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr    $vcc	.128	724	0\n"
 		"gpr    $vce	.128	740	0\n";
 
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p/analysis/analysis_rx.c
+++ b/librz/arch/p/analysis/analysis_rx.c
@@ -373,7 +373,7 @@ static char *analysis_rx_reg_profile(RzAnalysis *analysis) {
 		"flg    fof   .1     .772  0\n"
 		"flg    fvf   .1     .773  0\n"
 		"flg    rmode   .2   .798  0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 RzAnalysisPlugin rz_analysis_plugin_rx = {

--- a/librz/arch/p/analysis/analysis_sh.c
+++ b/librz/arch/p/analysis/analysis_sh.c
@@ -1171,7 +1171,7 @@ static RZ_OWN char *sh_get_reg_profile(RzAnalysis *analysis) {
 		"gpr	macl	.32	132		0\n"
 		"gpr	pr		.32	136		0\n";
 
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p/analysis/analysis_sparc_cs.c
+++ b/librz/arch/p/analysis/analysis_sparc_cs.c
@@ -391,7 +391,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr	i6	.32	136	0\n"
 		"gpr	fp	.32	136	0\n"
 		"gpr	i7	.32	140	0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p/analysis/analysis_spc700.c
+++ b/librz/arch/p/analysis/analysis_spc700.c
@@ -38,7 +38,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr	N	.1	.31	0\n"
 		"gpr	sp	.8	4	0\n"
 		"gpr	pc	.16	5	0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 RzAnalysisPlugin rz_analysis_plugin_spc700 = {

--- a/librz/arch/p/analysis/analysis_sysz.c
+++ b/librz/arch/p/analysis/analysis_sysz.c
@@ -177,7 +177,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr	r13	.32	52	0\n"
 		"gpr	r14	.32	56	0\n"
 		"gpr	r15	.32	60	0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p/analysis/analysis_tms320.c
+++ b/librz/arch/p/analysis/analysis_tms320.c
@@ -342,7 +342,7 @@ static char *get_reg_profile(RZ_BORROW RzAnalysis *a) {
 			;
 	}
 
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 RzAnalysisPlugin rz_analysis_plugin_tms320 = {

--- a/librz/arch/p/analysis/analysis_tricore_cs.c
+++ b/librz/arch/p/analysis/analysis_tricore_cs.c
@@ -245,7 +245,7 @@ static char *tricore_reg_profile(RzAnalysis *_) {
 		"drx	set_FZ	.1	902	0\n"
 		"drx	set_FU	.1	903	0\n"
 		"drx	set_FX	.1	904	0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static void tricore_opex(RzAsmTriCoreContext *ctx, RzStrBuf *sb);
@@ -275,7 +275,7 @@ tricore_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *data, int len,
 	if (ctx->count <= 0 || !ctx->insn) {
 		op->type = RZ_ANALYSIS_OP_TYPE_ILL;
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup("invalid");
+			op->mnemonic = rz_str_dup("invalid");
 		}
 		goto beach;
 	}

--- a/librz/arch/p/analysis/analysis_v810.c
+++ b/librz/arch/p/analysis/analysis_v810.c
@@ -559,7 +559,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"flg	s   .1 152.30 0\n"
 		"flg	z   .1 152.31 0\n";
 
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 RzAnalysisPlugin rz_analysis_plugin_v810 = {

--- a/librz/arch/p/analysis/analysis_v850.c
+++ b/librz/arch/p/analysis/analysis_v850.c
@@ -415,7 +415,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"flg	ov  .1 152.29 0\n" // overflow
 		"flg	s   .1 152.30 0\n" // signed result
 		"flg	z   .1 152.31 0\n"; // zero result
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 /**

--- a/librz/arch/p/analysis/analysis_wasm.c
+++ b/librz/arch/p/analysis/analysis_wasm.c
@@ -446,7 +446,7 @@ static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
 }
 
 static char *get_reg_profile(RzAnalysis *analysis) {
-	return strdup(
+	return rz_str_dup(
 		"=PC	pc\n"
 		"=BP	bp\n"
 		"=SP	sp\n"

--- a/librz/arch/p/analysis/analysis_x86_cs.c
+++ b/librz/arch/p/analysis/analysis_x86_cs.c
@@ -3156,7 +3156,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	if (n < 1) {
 		op->type = RZ_ANALYSIS_OP_TYPE_ILL;
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-			op->mnemonic = strdup("invalid");
+			op->mnemonic = rz_str_dup("invalid");
 		}
 	} else {
 		if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
@@ -3706,7 +3706,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		 break;
 #endif
 	}
-	return (p && *p) ? strdup(p) : NULL;
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p/asm/asm_arm_cs.c
+++ b/librz/arch/p/asm/asm_arm_cs.c
@@ -247,7 +247,7 @@ static char *mnemonics(RzAsm *a, int id, bool json) {
 		if (json) {
 			return name ? rz_str_newf("[\"%s\"]\n", name) : NULL;
 		}
-		return name ? strdup(name) : NULL;
+		return rz_str_dup(name);
 	}
 	RzStrBuf *buf = rz_strbuf_new("");
 	if (json) {

--- a/librz/arch/p/asm/asm_bf.c
+++ b/librz/arch/p/asm/asm_bf.c
@@ -22,21 +22,21 @@ static RZ_OWN RzPVector /*<RzAsmTokenPattern *>*/ *get_token_patterns(RzAsm *a) 
 	// Mnemonic pattern
 	RzAsmTokenPattern *pat = RZ_NEW0(RzAsmTokenPattern);
 	pat->type = RZ_ASM_TOKEN_MNEMONIC;
-	pat->pattern = strdup(
+	pat->pattern = rz_str_dup(
 		"^(while|inc|dec|out|in|trap|nop|invalid|loop)");
 	rz_pvector_push(pvec, pat);
 
 	// ptr pattern
 	pat = RZ_NEW0(RzAsmTokenPattern);
 	pat->type = RZ_ASM_TOKEN_REGISTER;
-	pat->pattern = strdup(
+	pat->pattern = rz_str_dup(
 		"ptr");
 	rz_pvector_push(pvec, pat);
 
 	// reference pattern
 	pat = RZ_NEW0(RzAsmTokenPattern);
 	pat->type = RZ_ASM_TOKEN_OPERATOR;
-	pat->pattern = strdup(
+	pat->pattern = rz_str_dup(
 		"\\[|\\]" // Matches a single bracket
 	);
 	rz_pvector_push(pvec, pat);
@@ -44,7 +44,7 @@ static RZ_OWN RzPVector /*<RzAsmTokenPattern *>*/ *get_token_patterns(RzAsm *a) 
 	// Separator pattern
 	pat = RZ_NEW0(RzAsmTokenPattern);
 	pat->type = RZ_ASM_TOKEN_SEPARATOR;
-	pat->pattern = strdup(
+	pat->pattern = rz_str_dup(
 		"\\s+");
 	rz_pvector_push(pvec, pat);
 

--- a/librz/arch/p/asm/asm_dalvik.c
+++ b/librz/arch/p/asm/asm_dalvik.c
@@ -73,7 +73,7 @@ static int dalvik_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 
 	strasm = NULL;
 	if (size <= len) {
-		strasm = strdup(dalvik_opcodes[i].name);
+		strasm = rz_str_dup(dalvik_opcodes[i].name);
 		size = dalvik_opcodes[i].len;
 		switch (dalvik_opcodes[i].fmt) {
 		case fmtop: break;

--- a/librz/arch/p/asm/asm_hexagon.c
+++ b/librz/arch/p/asm/asm_hexagon.c
@@ -24,7 +24,7 @@ static RZ_OWN RzPVector /*<RzAsmTokenPattern *>*/ *get_token_patterns() {
 
 	RzAsmTokenPattern *pat = RZ_NEW0(RzAsmTokenPattern);
 	pat->type = RZ_ASM_TOKEN_META;
-	pat->pattern = strdup(
+	pat->pattern = rz_str_dup(
 		"^[\\[\\?\\/\\|\\\\\\{┌│└]|" // Packet prefix
 		"(∎|[<\\}])[\\s:]endloop[01]{1,2}" // Endloop markers
 	);
@@ -32,7 +32,7 @@ static RZ_OWN RzPVector /*<RzAsmTokenPattern *>*/ *get_token_patterns() {
 
 	pat = RZ_NEW0(RzAsmTokenPattern);
 	pat->type = RZ_ASM_TOKEN_META;
-	pat->pattern = strdup(
+	pat->pattern = rz_str_dup(
 		"\\#{1,2}|\\}$|" // Immediate prefix, Closing packet bracket
 		"\\.new|:n?t|:raw|<err>" // .new and jump hints
 	);
@@ -40,42 +40,42 @@ static RZ_OWN RzPVector /*<RzAsmTokenPattern *>*/ *get_token_patterns() {
 
 	pat = RZ_NEW0(RzAsmTokenPattern);
 	pat->type = RZ_ASM_TOKEN_REGISTER;
-	pat->pattern = strdup(
+	pat->pattern = rz_str_dup(
 		"[CNPRMQVO]\\d{1,2}(:\\d{1,2})?(in)?" // Registers and double registers
 	);
 	rz_pvector_push(pvec, pat);
 
 	pat = RZ_NEW0(RzAsmTokenPattern);
 	pat->type = RZ_ASM_TOKEN_REGISTER;
-	pat->pattern = strdup(
+	pat->pattern = rz_str_dup(
 		"GP|HTID|UGP|LR|FP|SP" // Other regs
 	);
 	rz_pvector_push(pvec, pat);
 
 	pat = RZ_NEW0(RzAsmTokenPattern);
 	pat->type = RZ_ASM_TOKEN_NUMBER;
-	pat->pattern = strdup(
+	pat->pattern = rz_str_dup(
 		"0x(\\d|[abcdef])+" // Hexadecimal numbers
 	);
 	rz_pvector_push(pvec, pat);
 
 	pat = RZ_NEW0(RzAsmTokenPattern);
 	pat->type = RZ_ASM_TOKEN_MNEMONIC;
-	pat->pattern = strdup(
+	pat->pattern = rz_str_dup(
 		"\\w+_\\w+|[a-zA-Z]+\\d+[a-zA-Z]*" // Mnemonics with a decimal number in the name.
 	);
 	rz_pvector_push(pvec, pat);
 
 	pat = RZ_NEW0(RzAsmTokenPattern);
 	pat->type = RZ_ASM_TOKEN_NUMBER;
-	pat->pattern = strdup(
+	pat->pattern = rz_str_dup(
 		"\\d+" // Decimal numbers
 	);
 	rz_pvector_push(pvec, pat);
 
 	pat = RZ_NEW0(RzAsmTokenPattern);
 	pat->type = RZ_ASM_TOKEN_SEPARATOR;
-	pat->pattern = strdup(
+	pat->pattern = rz_str_dup(
 		"\\s+|" // Spaces and tabs
 		"[,;\\.\\(\\)\\{\\}:]" // Brackets and others
 	);
@@ -83,21 +83,21 @@ static RZ_OWN RzPVector /*<RzAsmTokenPattern *>*/ *get_token_patterns() {
 
 	pat = RZ_NEW0(RzAsmTokenPattern);
 	pat->type = RZ_ASM_TOKEN_OPERATOR;
-	pat->pattern = strdup(
+	pat->pattern = rz_str_dup(
 		"[+*&+?=!^\\/|-]{1,2}" // +,-,=,],[, ! (not the packet prefix)
 	);
 	rz_pvector_push(pvec, pat);
 
 	pat = RZ_NEW0(RzAsmTokenPattern);
 	pat->type = RZ_ASM_TOKEN_OPERATOR;
-	pat->pattern = strdup(
+	pat->pattern = rz_str_dup(
 		"\\]|\\[|<{1,2}|>{1,2}" // +,-,=,],[, ! (not the packet prefix)
 	);
 	rz_pvector_push(pvec, pat);
 
 	pat = RZ_NEW0(RzAsmTokenPattern);
 	pat->type = RZ_ASM_TOKEN_MNEMONIC;
-	pat->pattern = strdup(
+	pat->pattern = rz_str_dup(
 		"\\w+" // Alphanumeric mnemonics
 	);
 	rz_pvector_push(pvec, pat);
@@ -129,7 +129,7 @@ static bool hex_cfg_set(void *user, void *data) {
 	}
 	if (cnode) {
 		pnode->i_value = cnode->i_value;
-		pnode->value = strdup(cnode->value);
+		pnode->value = rz_str_dup(cnode->value);
 		return true;
 	}
 	return false;

--- a/librz/arch/p/asm/asm_tricore_cs.c
+++ b/librz/arch/p/asm/asm_tricore_cs.c
@@ -45,7 +45,7 @@ beach:
 	do { \
 		RzAsmTokenPattern *pat = RZ_NEW0(RzAsmTokenPattern); \
 		pat->type = RZ_ASM_TOKEN_##_type; \
-		pat->pattern = strdup(_pat); \
+		pat->pattern = rz_str_dup(_pat); \
 		rz_pvector_push(pvec, pat); \
 	} while (0)
 

--- a/librz/arch/p/asm/asm_x86_nz.c
+++ b/librz/arch/p/asm/asm_x86_nz.c
@@ -5120,7 +5120,7 @@ static int parseOpcode(RzAsm *a, const char *op, Opcode *out) {
 		op += 4;
 	}
 	char *args = strchr(op, ' ');
-	out->mnemonic = args ? rz_str_ndup(op, args - op) : strdup(op);
+	out->mnemonic = args ? rz_str_ndup(op, args - op) : rz_str_dup(op);
 	out->operands[0].type = out->operands[1].type = 0;
 	out->operands[0].extended = out->operands[1].extended = false;
 	out->operands[0].reg = out->operands[0].regs[0] = out->operands[0].regs[1] = X86R_UNDEFINED;

--- a/librz/arch/p/asm/cs_helper.h
+++ b/librz/arch/p/asm/cs_helper.h
@@ -50,7 +50,7 @@ typedef struct {
 			if (json) { \
 				return vname ? rz_str_newf("[\"%s\"]\n", vname) : NULL; \
 			} \
-			return vname ? strdup(vname) : NULL; \
+			return rz_str_dup(vname); \
 		} \
 		RzStrBuf *buf = rz_strbuf_new(""); \
 		if (json) { \

--- a/librz/arch/p/parse/parse_6502_pseudo.c
+++ b/librz/arch/p/parse/parse_6502_pseudo.c
@@ -108,7 +108,7 @@ RzList /*<char *>*/ *_6502_tokenize(const char *assembly, size_t length) {
 	}
 
 	if (insert_zero) {
-		rz_list_insert(tokens, rz_list_length(tokens) - 1, strdup("0"));
+		rz_list_insert(tokens, rz_list_length(tokens) - 1, rz_str_dup("0"));
 	}
 
 	return tokens;

--- a/librz/arch/p/parse/parse_arm_pseudo.c
+++ b/librz/arch/p/parse/parse_arm_pseudo.c
@@ -337,7 +337,7 @@ static char *subvar_stack(RzParse *p, RzAnalysisOp *op, RZ_NULLABLE RzAnalysisFu
 static bool subvar(RzParse *p, RzAnalysisFunction *f, RzAnalysisOp *op, char *data, char *str, int len) {
 	const ut64 addr = op->addr;
 	const int oplen = op->size;
-	char *tstr = strdup(data);
+	char *tstr = rz_str_dup(data);
 	if (!tstr) {
 		return false;
 	}

--- a/librz/arch/p/parse/parse_avr_pseudo.c
+++ b/librz/arch/p/parse/parse_avr_pseudo.c
@@ -140,7 +140,7 @@ RzList /*<char *>*/ *avr_tokenize(const char *assembly, size_t length) {
 	}
 
 	if (insert_zero) {
-		rz_list_insert(tokens, rz_list_length(tokens) - 1, strdup("0"));
+		rz_list_insert(tokens, rz_list_length(tokens) - 1, rz_str_dup("0"));
 	}
 
 	return tokens;

--- a/librz/arch/p/parse/parse_m68k_pseudo.c
+++ b/librz/arch/p/parse/parse_m68k_pseudo.c
@@ -85,7 +85,7 @@ RzList /*<char *>*/ *m68k_tokenize(const char *assembly, size_t length) {
 }
 
 static bool parse(RzParse *parse, const char *assembly, RzStrBuf *sb) {
-	char *copy = strdup(assembly);
+	char *copy = rz_str_dup(assembly);
 	if (!copy) {
 		rz_strbuf_setf(sb, "asm(\"%s\")", assembly);
 		return true;

--- a/librz/arch/p/parse/parse_mips_pseudo.c
+++ b/librz/arch/p/parse/parse_mips_pseudo.c
@@ -132,7 +132,7 @@ RzList /*<char *>*/ *mips_tokenize(const char *assembly, size_t length) {
 	}
 
 	if (insert_zero) {
-		rz_list_insert(tokens, rz_list_length(tokens) - 1, strdup("0"));
+		rz_list_insert(tokens, rz_list_length(tokens) - 1, rz_str_dup("0"));
 	}
 
 	return tokens;
@@ -240,7 +240,7 @@ static char *subvar_stack(RzParse *p, RzAnalysisOp *op, RZ_NULLABLE RzAnalysisFu
 }
 
 static bool subvar(RzParse *p, RzAnalysisFunction *f, RzAnalysisOp *op, char *data, char *str, int len) {
-	char *tstr = strdup(data);
+	char *tstr = rz_str_dup(data);
 	tstr = subvar_stack(p, op, f, tstr);
 	bool ret = true;
 	if (len > strlen(tstr)) {

--- a/librz/arch/p/parse/parse_ppc_pseudo.c
+++ b/librz/arch/p/parse/parse_ppc_pseudo.c
@@ -1704,7 +1704,7 @@ static bool parse(RzParse *p, const char *data, RzStrBuf *sb) {
 			}
 			replace(nw, wa, str);
 			{
-				char *p = strdup(str);
+				char *p = rz_str_dup(str);
 				p = rz_str_replace(p, "+ -", "- ", 0);
 				p = rz_str_replace(p, " + ]", "]  ", 0);
 				//  p = rz_str_replace (p, "if (r0 == r0) trap", "trap            ", 0);

--- a/librz/arch/p/parse/parse_v850_pseudo.c
+++ b/librz/arch/p/parse/parse_v850_pseudo.c
@@ -120,13 +120,13 @@ RzList /*<char *>*/ *v850_tokenize(const char *assembly, size_t length) {
 	buf = rz_list_first(tokens);
 	for (i = 0; i < RZ_ARRAY_SIZE(v850_short_op); ++i) {
 		if (!strcmp(buf, v850_short_op[i])) {
-			rz_list_insert(tokens, 1, strdup("0"));
+			rz_list_insert(tokens, 1, rz_str_dup("0"));
 			break;
 		}
 	}
 
 	if (insert_zero) {
-		rz_list_insert(tokens, rz_list_length(tokens) - 1, strdup("0"));
+		rz_list_insert(tokens, rz_list_length(tokens) - 1, rz_str_dup("0"));
 	}
 
 	return tokens;

--- a/librz/arch/p/parse/parse_x86_pseudo.c
+++ b/librz/arch/p/parse/parse_x86_pseudo.c
@@ -176,8 +176,8 @@ static bool parse(RzParse *p, const char *data, RzStrBuf *sb) {
 	if (len >= sizeof(w0) || sz >= sizeof(w0)) {
 		return false;
 	}
-	// strdup can be slow here :?
-	if (!(buf = strdup(data))) {
+	// rz_str_dup can be slow here :?
+	if (!(buf = rz_str_dup(data))) {
 		return false;
 	}
 	*w0 = *w1 = *w2 = *w3 = '\0';
@@ -391,7 +391,7 @@ static char *subvar_stack(RzParse *p, RzAnalysisOp *op, RZ_NULLABLE RzAnalysisFu
 static bool subvar(RzParse *p, RzAnalysisFunction *f, RzAnalysisOp *op, char *data, char *str, int len) {
 	const ut64 addr = op->addr;
 	const int oplen = op->size;
-	char *tstr = strdup(data);
+	char *tstr = rz_str_dup(data);
 	if (!tstr) {
 		return false;
 	}

--- a/librz/arch/p_gnu/analysis/analysis_arc_gnu.c
+++ b/librz/arch/p_gnu/analysis/analysis_arc_gnu.c
@@ -1127,7 +1127,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 	/* TODO: */
 	/* Should I add the Auxiliary Register Set? */
 	/* it contains the flag bits, amongst other things */
-	return strdup(p16);
+	return rz_str_dup(p16);
 }
 
 RzAnalysisPlugin rz_analysis_plugin_arc_gnu = {

--- a/librz/arch/p_gnu/analysis/analysis_cris_gnu.c
+++ b/librz/arch/p_gnu/analysis/analysis_cris_gnu.c
@@ -277,7 +277,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr	r15	.32	60	0\n"
 		// ADD P REGISTERS
 		;
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 RzAnalysisPlugin rz_analysis_plugin_cris_gnu = {

--- a/librz/arch/p_gnu/analysis/analysis_mips_gnu.c
+++ b/librz/arch/p_gnu/analysis/analysis_mips_gnu.c
@@ -1767,7 +1767,7 @@ static char *mips_get_reg_profile(RzAnalysis *analysis) {
 		/* extra */
 		"gpr	pc	.64	272	0\n";
 #endif
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p_gnu/analysis/analysis_riscv_gnu.c
+++ b/librz/arch/p_gnu/analysis/analysis_riscv_gnu.c
@@ -328,7 +328,7 @@ static int riscv_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	}
 
 	if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
-		op->mnemonic = strdup(o->name);
+		op->mnemonic = rz_str_dup(o->name);
 	}
 
 	if (o->args) {
@@ -655,7 +655,7 @@ static int riscv_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	}
 	if (mask & RZ_ANALYSIS_OP_MASK_VAL && args.num) {
 		op->dst = RZ_NEW0(RzAnalysisValue);
-		char *argf = strdup(o->args);
+		char *argf = rz_str_dup(o->args);
 		const char *comma = NULL;
 		int dst_idx = 0, src_idx;
 		if (op->type == RZ_ANALYSIS_OP_TYPE_STORE) {
@@ -905,7 +905,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 
 		break;
 	}
-	return (p && *p) ? strdup(p) : NULL;
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p_gnu/analysis/analysis_sparc_gnu.c
+++ b/librz/arch/p_gnu/analysis/analysis_sparc_gnu.c
@@ -594,7 +594,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"fpu	qf60	.128	544	0\n" /* df60 df62 */
 		"gpr	fsr	.64	560	0\n"; /* note that
 						   we've left out the filler */
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p_gnu/analysis/analysis_xtensa_gnu.c
+++ b/librz/arch/p_gnu/analysis/analysis_xtensa_gnu.c
@@ -2017,7 +2017,7 @@ static int xtensa_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut
 }
 
 static char *get_reg_profile(RzAnalysis *analysis) {
-	return strdup(
+	return rz_str_dup(
 		// Assuming call0 ABI
 		"# a0		return address\n"
 		"# a1		stack pointer\n"

--- a/librz/arch/p_gnu/analysis/analysis_z80_gnu.c
+++ b/librz/arch/p_gnu/analysis/analysis_z80_gnu.c
@@ -408,7 +408,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 		"gpr	mbcram	.16	16	0\n"
 
 		"gpr	ime	.1	18	0\n";
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p_gnu/parse/parse_riscv_gnu.c
+++ b/librz/arch/p_gnu/parse/parse_riscv_gnu.c
@@ -182,7 +182,7 @@ static bool parse(RzParse *p, const char *data, RzStrBuf *sb) {
 					rz_str_cpy(num + 1, ptr);
 					ptr = (char *)rz_str_lchr(buf, ']');
 					if (n && ptr) {
-						char *rest = strdup(ptr + 1);
+						char *rest = rz_str_dup(ptr + 1);
 						size_t dist = len + 1 - (ptr - buf);
 						if (n > 0) {
 							snprintf(ptr, dist, "+%d]%s", n, rest);
@@ -208,7 +208,7 @@ static bool parse(RzParse *p, const char *data, RzStrBuf *sb) {
 		}
 	}
 	{
-		char *s = strdup(str);
+		char *s = rz_str_dup(str);
 		s = rz_str_replace(s, "+ -", "- ", 1);
 		s = rz_str_replace(s, "- -", "+ ", 1);
 		rz_strf(str, "%s", s);

--- a/librz/arch/parse.c
+++ b/librz/arch/parse.c
@@ -94,7 +94,7 @@ RZ_API bool rz_parse_use(RzParse *p, const char *name) {
 // this function is a bit confussing, assembles C code into wat?, whehres theh input and wheres the output
 // and its unused. so imho it sshould be DEPRECATED this conflicts with rasm.assemble imhoh
 RZ_API bool rz_parse_assemble(RzParse *p, char *data, char *str) {
-	char *in = strdup(str);
+	char *in = rz_str_dup(str);
 	bool ret = false;
 	char *s, *o;
 

--- a/librz/arch/pdb_process.c
+++ b/librz/arch/pdb_process.c
@@ -163,7 +163,7 @@ static RzType *procedure_parse(
 	if (!name) {
 		typ->callable->name = create_type_name_from_offset(type->index);
 	} else {
-		typ->callable->name = strdup(name);
+		typ->callable->name = rz_str_dup(name);
 	}
 
 	typ->callable->cc = rz_bin_pdb_calling_convention_as_string(lf_procedure->func_attr.calling_convention);
@@ -201,7 +201,7 @@ static RzType *mfunction_parse(const RzTypeDB *typedb, RzPdbTpiStream *stream, R
 	}
 	type->kind = RZ_TYPE_KIND_CALLABLE;
 	type->callable = callable;
-	type->callable->name = strdup(name);
+	type->callable->name = rz_str_dup(name);
 	type->callable->cc = rz_bin_pdb_calling_convention_as_string(lf_mfunction->func_attr.calling_convention);
 	// parse return type
 	RzPdbTpiType *ret_type = rz_bin_pdb_get_type_by_index(stream, lf_mfunction->return_type);
@@ -368,7 +368,7 @@ static RzTypeStructMember *class_member_parse(
 	if (!member) {
 		goto cleanup;
 	}
-	member->name = strdup(name);
+	member->name = rz_str_dup(name);
 	member->type = type;
 	member->offset = offset;
 	return member;
@@ -400,7 +400,7 @@ static RzType *create_rztype(RzPdbTpiType *type, RzTypeIdentifierKind kind, cons
 	}
 	t->kind = RZ_TYPE_KIND_IDENTIFIER;
 	t->identifier.kind = kind;
-	t->identifier.name = is_tpitype_unnamed(name) ? create_type_name_from_offset(type->index) : strdup(name);
+	t->identifier.name = is_tpitype_unnamed(name) ? create_type_name_from_offset(type->index) : rz_str_dup(name);
 	return t;
 }
 
@@ -462,7 +462,7 @@ static RzType *class_parse(const RzTypeDB *typedb, RzPdbTpiStream *stream, RzPdb
 			return NULL;
 		}
 		base_type->type = typ;
-		base_type->name = strdup(typ->identifier.name);
+		base_type->name = rz_str_dup(typ->identifier.name);
 		base_type->attrs = RZ_TYPE_TYPECLASS_INVALID;
 		if (!rz_type_db_save_base_type(typedb, base_type)) {
 			return NULL;
@@ -544,7 +544,7 @@ static RzTypeUnionMember *union_member_parse(const RzTypeDB *typedb, RzPdbTpiStr
 	if (!member) {
 		goto cleanup;
 	}
-	member->name = strdup(name);
+	member->name = rz_str_dup(name);
 	member->type = type;
 	member->offset = offset;
 	return member;
@@ -592,7 +592,7 @@ static RzType *union_parse(const RzTypeDB *typedb, RzPdbTpiStream *stream, RzPdb
 			return NULL;
 		}
 		base_type->type = typ;
-		base_type->name = strdup(typ->identifier.name);
+		base_type->name = rz_str_dup(typ->identifier.name);
 		base_type->attrs = RZ_TYPE_TYPECLASS_INVALID;
 		if (!rz_type_db_save_base_type(typedb, base_type)) {
 			return NULL;
@@ -644,7 +644,7 @@ static RzTypeEnumCase *enumerate_parse(RzPdbTpiType *type) {
 	if (!cas) {
 		goto cleanup;
 	}
-	cas->name = strdup(name);
+	cas->name = rz_str_dup(name);
 	cas->val = value;
 	return cas;
 cleanup:
@@ -696,7 +696,7 @@ static RzType *enum_parse(const RzTypeDB *typedb, RzPdbTpiStream *stream, RzPdbT
 			rz_type_base_type_free(base_type);
 			return NULL;
 		}
-		base_type->name = is_tpitype_unnamed(name) ? create_type_name_from_offset(type->index) : strdup(name);
+		base_type->name = is_tpitype_unnamed(name) ? create_type_name_from_offset(type->index) : rz_str_dup(name);
 		base_type->size = rz_type_db_get_bitsize(typedb, btype);
 		base_type->type = btype;
 		base_type->attrs = RZ_TYPE_TYPECLASS_INVALID;

--- a/librz/arch/platform_profile.c
+++ b/librz/arch/platform_profile.c
@@ -27,12 +27,12 @@ RZ_API RZ_OWN RzPlatformProfile *rz_platform_profile_new() {
 	if (!profile) {
 		return NULL;
 	}
-	profile->registers_mmio = ht_up_new((HtUPDupValue)strdup, free);
+	profile->registers_mmio = ht_up_new((HtUPDupValue)rz_str_dup, free);
 	if (!profile->registers_mmio) {
 		free(profile);
 		return NULL;
 	}
-	profile->registers_extended = ht_up_new((HtUPDupValue)strdup, free);
+	profile->registers_extended = ht_up_new((HtUPDupValue)rz_str_dup, free);
 	if (!profile->registers_extended) {
 		ht_up_free(profile->registers_mmio);
 		free(profile);
@@ -235,8 +235,8 @@ RZ_API bool rz_platform_profiles_init(RzPlatformTarget *t, const char *cpu, cons
 	}
 	free(t->cpu);
 	free(t->arch);
-	t->cpu = strdup(cpu);
-	t->arch = strdup(arch);
+	t->cpu = rz_str_dup(cpu);
+	t->arch = rz_str_dup(arch);
 	rz_platform_load_profile_sdb(t, path);
 	free(path);
 	return true;

--- a/librz/arch/platform_target_index.c
+++ b/librz/arch/platform_target_index.c
@@ -12,7 +12,7 @@ RZ_API RZ_OWN RzPlatformItem *rz_platform_item_new(RZ_NULLABLE const char *name)
 	if (!item) {
 		return NULL;
 	}
-	item->name = name ? strdup(name) : NULL;
+	item->name = rz_str_dup(name);
 	item->comment = NULL;
 	return item;
 }

--- a/librz/arch/rtti_msvc.c
+++ b/librz/arch/rtti_msvc.c
@@ -403,7 +403,7 @@ RZ_API char *rz_analysis_rtti_msvc_demangle_class_name(RVTableContext *context, 
 	if (ret && *ret) {
 		char *n = strchr(ret, ' ');
 		if (n && *(++n)) {
-			char *tmp = strdup(n);
+			char *tmp = rz_str_dup(n);
 			free(ret);
 			ret = tmp;
 		} else {
@@ -792,7 +792,7 @@ RecoveryTypeDescriptor *recovery_analysis_type_descriptor(RRTTIMSVCAnalContext *
 
 static char *unique_class_name(RzAnalysis *analysis, const char *original_name) {
 	if (!rz_analysis_class_exists(analysis, original_name)) {
-		return strdup(original_name);
+		return rz_str_dup(original_name);
 	}
 
 	char *name = NULL;
@@ -879,7 +879,7 @@ static void recovery_apply_bases(RRTTIMSVCAnalContext *context, const char *clas
 		RzAnalysisBaseClass base;
 		base.id = NULL;
 		base.offset = (ut64)base_desc->bcd->where.mdisp;
-		base.class_name = strdup(base_class_name);
+		base.class_name = rz_str_dup(base_class_name);
 		rz_analysis_class_base_set(context->vt_context->analysis, class_name, &base);
 		rz_analysis_class_base_fini(&base);
 	}
@@ -905,7 +905,7 @@ static const char *recovery_apply_complete_object_locator(RRTTIMSVCAnalContext *
 	char *name = rz_analysis_rtti_msvc_demangle_class_name(context->vt_context, col->td->td.name);
 	if (!name) {
 		RZ_LOG_DEBUG("Failed to demangle a class name: \"%s\"\n", col->td->td.name);
-		name = strdup(col->td->td.name);
+		name = rz_str_dup(col->td->td.name);
 		if (!name) {
 			return NULL;
 		}
@@ -942,7 +942,7 @@ static const char *recovery_apply_type_descriptor(RRTTIMSVCAnalContext *context,
 	char *name = rz_analysis_rtti_msvc_demangle_class_name(context->vt_context, td->td.name);
 	if (!name) {
 		RZ_LOG_DEBUG("Failed to demangle a class name: \"%s\"\n", td->td.name);
-		name = strdup(td->td.name);
+		name = rz_str_dup(td->td.name);
 		if (!name) {
 			return NULL;
 		}

--- a/librz/arch/serialize_analysis.c
+++ b/librz/arch/serialize_analysis.c
@@ -710,7 +710,7 @@ RZ_API RZ_OWN RzAnalysisVar *rz_serialize_analysis_var_load(
 		if (!ret) {
 			goto beach;
 		}
-		ret->name = strdup(name);
+		ret->name = rz_str_dup(name);
 		ret->type = vartype;
 		ret->fcn = fcn;
 		rz_mem_copy(&ret->storage, sizeof(RzAnalysisVarStorage), &storage, sizeof(RzAnalysisVarStorage));
@@ -727,7 +727,7 @@ RZ_API RZ_OWN RzAnalysisVar *rz_serialize_analysis_var_load(
 	ret->kind = k;
 	if (comment) {
 		free(ret->comment);
-		ret->comment = strdup(comment);
+		ret->comment = rz_str_dup(comment);
 	}
 	RzAnalysisVarAccess *acc;
 	rz_vector_foreach (&accesses, acc) {
@@ -1209,7 +1209,7 @@ static bool function_load_cb(void *user, const SdbKv *kv) {
 			if (function->name) {
 				free(function->name);
 			}
-			function->name = strdup(child->str_value);
+			function->name = rz_str_dup(child->str_value);
 			break;
 		case FUNCTION_FIELD_BITS:
 			if (child->type != RZ_JSON_INTEGER) {
@@ -1297,7 +1297,7 @@ static bool function_load_cb(void *user, const SdbKv *kv) {
 				if (baby->type != RZ_JSON_STRING) {
 					continue;
 				}
-				char *import = strdup(baby->str_value);
+				char *import = rz_str_dup(baby->str_value);
 				if (!import) {
 					break;
 				}
@@ -1713,7 +1713,7 @@ static bool meta_load_cb(void *user, const SdbKv *kv) {
 		item->type = type;
 		item->subtype = subtype;
 		item->space = space_name ? rz_spaces_get(&analysis->meta_spaces, space_name) : NULL;
-		item->str = str ? strdup(str) : NULL;
+		item->str = rz_str_dup(str);
 		if (str && !item->str) {
 			free(item);
 			continue;

--- a/librz/arch/var.c
+++ b/librz/arch/var.c
@@ -282,7 +282,7 @@ static RZ_OWN RzType *var_type_default(RzAnalysis *analysis, int size) {
 		return NULL;
 	}
 	type->kind = RZ_TYPE_KIND_IDENTIFIER;
-	type->identifier.name = strdup(typestr);
+	type->identifier.name = rz_str_dup(typestr);
 	if (!type->identifier.name) {
 		free(type);
 		return NULL;
@@ -370,7 +370,7 @@ RZ_API RZ_BORROW RzAnalysisVar *rz_analysis_function_set_var(
 		RZ_FREE(var->name);
 	}
 
-	var->name = strdup(name);
+	var->name = rz_str_dup(name);
 	var->storage = *stor;
 	rz_analysis_var_storage_poolify(fcn->analysis, &var->storage);
 	if (type) {
@@ -744,7 +744,7 @@ RZ_API RZ_NULLABLE char *rz_analysis_function_var_expr_for_reg_access_at(RzAnaly
 	if (var_offset) {
 		return rz_str_newf("%s + 0x%" PFMT64x, var->name, var_offset);
 	} else {
-		return strdup(var->name);
+		return rz_str_dup(var->name);
 	}
 }
 
@@ -764,7 +764,7 @@ RZ_API bool rz_analysis_var_rename(RzAnalysisVar *var, const char *new_name, boo
 		}
 		return false;
 	}
-	char *nn = strdup(new_name);
+	char *nn = rz_str_dup(new_name);
 	if (!nn) {
 		return false;
 	}
@@ -1126,7 +1126,7 @@ static void extract_stack_var(RzAnalysis *analysis, RzAnalysisFunction *fcn, RzA
 		if (!op_esil) {
 			return;
 		}
-		esil_buf = strdup(op_esil);
+		esil_buf = rz_str_dup(op_esil);
 		if (!esil_buf) {
 			return;
 		}
@@ -1235,7 +1235,7 @@ static void extract_stack_var(RzAnalysis *analysis, RzAnalysisFunction *fcn, RzA
 					}
 					if (sum_sz == stack_off) {
 						vartype = tp;
-						varname = strdup(rz_type_func_args_name(analysis->typedb, fname, i));
+						varname = rz_str_dup(rz_type_func_args_name(analysis->typedb, fname, i));
 						break;
 					}
 					ut64 bit_sz = rz_type_db_get_bitsize(analysis->typedb, tp);
@@ -1451,7 +1451,7 @@ RZ_API void rz_analysis_extract_rarg(RzAnalysis *analysis, RzAnalysisOp *op, RzA
 				}
 				if (found_arg) {
 					type = found_arg->type;
-					vname = name = strdup(found_arg->name);
+					vname = name = rz_str_dup(found_arg->name);
 				}
 			}
 			if (!vname) {
@@ -1515,7 +1515,7 @@ RZ_API void rz_analysis_extract_rarg(RzAnalysis *analysis, RzAnalysisOp *op, RzA
 	if (selfreg) {
 		bool is_used_like_an_arg = is_used_like_arg(selfreg, opsreg, opdreg, op, analysis);
 		if (reg_set[i] != 2 && is_used_like_an_arg) {
-			char *vname = strdup("self");
+			char *vname = rz_str_dup("self");
 			RzAnalysisVarStorage stor;
 			rz_analysis_var_storage_init_reg(&stor, selfreg);
 			RzAnalysisVar *newvar = rz_analysis_function_set_var(fcn, &stor, NULL, size, vname);
@@ -1536,7 +1536,7 @@ RZ_API void rz_analysis_extract_rarg(RzAnalysis *analysis, RzAnalysisOp *op, RzA
 	const char *errorreg = rz_analysis_cc_error(analysis, fcn->cc);
 	if (errorreg) {
 		if (reg_set[i] == 0 && STR_EQUAL(opdreg, errorreg)) {
-			char *vname = strdup("error");
+			char *vname = rz_str_dup("error");
 			RzAnalysisVarStorage stor;
 			rz_analysis_var_storage_init_reg(&stor, errorreg);
 			RzAnalysisVar *newvar = rz_analysis_function_set_var(fcn, &stor, NULL, size, vname);

--- a/librz/arch/var_global.c
+++ b/librz/arch/var_global.c
@@ -17,7 +17,7 @@ RZ_API RZ_OWN RzAnalysisVarGlobal *rz_analysis_var_global_new(RZ_NONNULL const c
 	if (!glob) {
 		return NULL;
 	}
-	glob->name = strdup(name);
+	glob->name = rz_str_dup(name);
 	glob->addr = addr;
 	glob->analysis = NULL;
 
@@ -323,7 +323,7 @@ RZ_API bool rz_analysis_var_global_rename(RzAnalysis *analysis, RZ_NONNULL const
 	}
 
 	RZ_FREE(glob->name);
-	glob->name = strdup(newname);
+	glob->name = rz_str_dup(newname);
 	return ht_sp_update_key(analysis->ht_global_var, old_name, newname);
 }
 

--- a/librz/bin/bfile.c
+++ b/librz/bin/bfile.c
@@ -106,10 +106,10 @@ RZ_API bool rz_bin_file_object_new_from_xtr_data(RzBin *bin, RzBinFile *bf, RzBi
 	free(o->info->arch);
 	free(o->info->machine);
 	free(o->info->type);
-	o->info->file = strdup(bf->file);
-	o->info->arch = strdup(data->metadata->arch);
-	o->info->machine = strdup(data->metadata->machine);
-	o->info->type = strdup(data->metadata->type);
+	o->info->file = rz_str_dup(bf->file);
+	o->info->arch = rz_str_dup(data->metadata->arch);
+	o->info->machine = rz_str_dup(data->metadata->machine);
+	o->info->type = rz_str_dup(data->metadata->type);
 	o->info->bits = data->metadata->bits;
 	o->info->has_crypto = bf->o->info->has_crypto;
 	data->loaded = true;
@@ -378,8 +378,8 @@ static inline bool add_file_hash(RzHashCfg *md, const char *name, RzPVector /*<R
 		return false;
 	}
 
-	fh->type = strdup(name);
-	fh->hex = strdup(hash);
+	fh->type = rz_str_dup(name);
+	fh->hex = rz_str_dup(hash);
 	rz_pvector_push(vec, fh);
 	return true;
 }

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -173,13 +173,13 @@ RZ_API RZ_OWN char *rz_bin_symbol_name(RZ_NONNULL RzBinSymbol *s) {
 	if (s->dup_count) {
 		return rz_str_newf("%s_%d", s->name, s->dup_count);
 	}
-	return strdup(s->name);
+	return rz_str_dup(s->name);
 }
 
 RZ_API RzBinSymbol *rz_bin_symbol_new(const char *name, ut64 paddr, ut64 vaddr) {
 	RzBinSymbol *sym = RZ_NEW0(RzBinSymbol);
 	if (sym) {
-		sym->name = name ? strdup(name) : NULL;
+		sym->name = rz_str_dup(name);
 		sym->paddr = paddr;
 		sym->vaddr = vaddr;
 	}
@@ -896,7 +896,7 @@ RZ_API RzBinObject *rz_bin_cur_object(RzBin *bin) {
 RZ_API void rz_bin_force_plugin(RzBin *bin, const char *name) {
 	rz_return_if_fail(bin);
 	free(bin->force);
-	bin->force = (name && *name) ? strdup(name) : NULL;
+	bin->force = RZ_STR_ISNOTEMPTY(name) ? rz_str_dup(name) : NULL;
 }
 
 RZ_API const char *rz_bin_entry_type_string(int etype) {
@@ -1077,7 +1077,7 @@ RZ_API RZ_OWN RzPVector /*<RzBinMap *>*/ *rz_bin_maps_of_file_sections(RZ_NONNUL
 		if (!map) {
 			goto hcf;
 		}
-		map->name = sec->name ? strdup(sec->name) : NULL;
+		map->name = rz_str_dup(sec->name);
 		map->paddr = sec->paddr;
 		map->psize = sec->size;
 		map->vaddr = sec->vaddr;
@@ -1115,7 +1115,7 @@ RZ_API RzPVector /*<RzBinSection *>*/ *rz_bin_sections_of_maps(RzPVector /*<RzBi
 		if (!sec) {
 			break;
 		}
-		sec->name = map->name ? strdup(map->name) : NULL;
+		sec->name = rz_str_dup(map->name);
 		sec->paddr = map->paddr;
 		sec->size = map->psize;
 		sec->vaddr = map->vaddr;
@@ -1129,7 +1129,7 @@ RZ_API RzPVector /*<RzBinSection *>*/ *rz_bin_sections_of_maps(RzPVector /*<RzBi
 RZ_API RzBinSection *rz_bin_section_new(const char *name) {
 	RzBinSection *s = RZ_NEW0(RzBinSection);
 	if (s) {
-		s->name = name ? strdup(name) : NULL;
+		s->name = rz_str_dup(name);
 	}
 	return s;
 }

--- a/librz/bin/bobj.c
+++ b/librz/bin/bobj.c
@@ -232,7 +232,7 @@ static RzBinClass *bin_class_new(RzBinObject *o, const char *name, const char *s
 		return NULL;
 	}
 
-	c->name = strdup(name);
+	c->name = rz_str_dup(name);
 	c->super = rz_str_dup(super);
 	c->methods = rz_list_newf((RzListFree)rz_bin_symbol_free);
 	c->fields = rz_list_newf((RzListFree)rz_bin_class_field_free);
@@ -304,7 +304,7 @@ RZ_API RZ_BORROW RzBinClass *rz_bin_object_add_class(RZ_NONNULL RzBinObject *o, 
 	RzBinClass *oclass = ht_sp_find(o->name_to_class_object, name, NULL);
 	if (oclass) {
 		if (super && !oclass->super) {
-			oclass->super = strdup(super);
+			oclass->super = rz_str_dup(super);
 		}
 		if (oclass->addr == UT64_MAX) {
 			oclass->addr = vaddr;

--- a/librz/bin/bobj_process.c
+++ b/librz/bin/bobj_process.c
@@ -110,7 +110,7 @@ static char *get_swift_field(const char *demangled, const char *classname) {
 	if (p) {
 		char *q = strstr(demangled, classname);
 		if (q && q[strlen(classname)] == '.') {
-			q = strdup(q + strlen(classname) + 1);
+			q = rz_str_dup(q + strlen(classname) + 1);
 			char *r = strchr(q, '.');
 			if (r) {
 				*r = 0;

--- a/librz/bin/dbginfo.c
+++ b/librz/bin/dbginfo.c
@@ -335,7 +335,7 @@ RZ_API RZ_OWN char *rz_bin_source_line_addr2text(
 	}
 	const char *filepath = opt.abspath ? s->file : rz_file_basename(s->file);
 	if (!s->line) {
-		return strdup(filepath);
+		return rz_str_dup(filepath);
 	}
 
 	RzStrBuf sb = { 0 };

--- a/librz/bin/filter.c
+++ b/librz/bin/filter.c
@@ -42,7 +42,7 @@ static bool false_positive(const char *str) {
 RZ_API bool rz_bin_strpurge(RzBin *bin, const char *str, ut64 refaddr) {
 	bool purge = false;
 	if (bin->strpurge) {
-		char *addrs = strdup(bin->strpurge);
+		char *addrs = rz_str_dup(bin->strpurge);
 		if (addrs) {
 			int splits = rz_str_split(addrs, ',');
 			int i;

--- a/librz/bin/format/coff/coff.c
+++ b/librz/bin/format/coff/coff.c
@@ -59,21 +59,21 @@ RZ_API char *rz_coff_symbol_name(struct rz_bin_coff_obj *obj, const ut8 *ptr) {
 	ut32 zero = rz_read_at_ble32(ptr, 0, obj->endian == COFF_IS_BIG_ENDIAN);
 	ut32 offset = rz_read_at_ble32(ptr, 4, obj->endian == COFF_IS_BIG_ENDIAN);
 	if (!ptr) {
-		return strdup("");
+		return rz_str_dup("");
 	}
 	if (zero) {
 		return rz_str_ndup((const char *)ptr, 8);
 	}
 	ut32 addr = obj->hdr.f_symptr + obj->hdr.f_nsyms * sizeof(struct coff_symbol) + offset;
 	if (addr > obj->size) {
-		return strdup("");
+		return rz_str_dup("");
 	}
 	char n[256] = { 0 };
 	st64 len = rz_buf_read_at(obj->b, addr, (ut8 *)n, sizeof(n) - 1);
 	if (len < 1) {
-		return strdup("");
+		return rz_str_dup("");
 	}
-	return strdup(n);
+	return rz_str_dup(n);
 }
 
 static int rz_coff_rebase_sym(struct rz_bin_coff_obj *obj, RzBinAddr *addr, struct coff_symbol *sym) {

--- a/librz/bin/format/dex/dex.c
+++ b/librz/bin/format/dex/dex.c
@@ -927,7 +927,7 @@ static void set_lib_and_class_name(char *mangled, char **out_class, char **out_l
 
 	*out_class = object;
 	if (!is_java_lang || startswith(object, "java.lang")) {
-		*out_lib = strdup(object);
+		*out_lib = rz_str_dup(object);
 	} else {
 		*out_lib = rz_str_newf("java.lang.%s", object);
 	}
@@ -1202,7 +1202,7 @@ static RzBinSection *section_new(const char *name, ut32 perm, ut32 size, ut64 pa
 	if (!section) {
 		return NULL;
 	}
-	section->name = strdup(name);
+	section->name = rz_str_dup(name);
 	section->paddr = paddr;
 	section->vaddr = vaddr;
 	section->size = section->vsize = size;
@@ -2015,19 +2015,19 @@ RZ_API RZ_OWN char *rz_bin_dex_version(RZ_NONNULL RzBinDex *dex) {
 	// https://cs.android.com/android/platform/superproject/+/master:dalvik/dx/src/com/android/dex/DexFormat.java;l=55;bpv=1;bpt=0
 	// https://developer.android.com/studio/releases/platforms
 	if (startswith((char *)dex->version, "009")) {
-		return strdup("Android M3 release (Nov-Dec 2007)");
+		return rz_str_dup("Android M3 release (Nov-Dec 2007)");
 	} else if (startswith((char *)dex->version, "013")) {
-		return strdup("Android M5 release (Feb-Mar 2008)");
+		return rz_str_dup("Android M5 release (Feb-Mar 2008)");
 	} else if (startswith((char *)dex->version, "035")) {
-		return strdup("Android 3.2 (API level 13 and earlier)");
+		return rz_str_dup("Android 3.2 (API level 13 and earlier)");
 	} else if (startswith((char *)dex->version, "037")) {
-		return strdup("Android 7 (API level 24 and earlier)");
+		return rz_str_dup("Android 7 (API level 24 and earlier)");
 	} else if (startswith((char *)dex->version, "038")) {
-		return strdup("Android 8 (API level 26 and earlier)");
+		return rz_str_dup("Android 8 (API level 26 and earlier)");
 	} else if (startswith((char *)dex->version, "039")) {
-		return strdup("Android 9 (API level 28 and earlier)");
+		return rz_str_dup("Android 9 (API level 28 and earlier)");
 	} else if (startswith((char *)dex->version, "040")) {
-		return strdup("Android 10+ (Aug 2019)");
+		return rz_str_dup("Android 10+ (Aug 2019)");
 	}
 	return NULL;
 }

--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -714,7 +714,7 @@ static char *get_ver_flags(ut32 flags) {
 	char *result = NULL;
 
 	if (!flags) {
-		return strdup("none");
+		return rz_str_dup("none");
 	}
 
 	for (size_t i = 0; i < RZ_ARRAY_SIZE(ver_flags_translation_table); i++) {
@@ -737,7 +737,7 @@ static char *get_osabi_name_from_section_note(ELFOBJ *bin, RzBinElfSection *sect
 
 	for (size_t i = 0; i < RZ_ARRAY_SIZE(section_note_osabi_translation_table); i++) {
 		if (!strcmp(section->name, section_note_osabi_translation_table[i].note_name)) {
-			return strdup(section_note_osabi_translation_table[i].os_name);
+			return rz_str_dup(section_note_osabi_translation_table[i].os_name);
 		}
 	}
 
@@ -767,13 +767,13 @@ static char *get_osabi_name_from_shdr(ELFOBJ *bin) {
 static char *get_osabi_name_from_ehdr(ELFOBJ *bin) {
 	switch (bin->ehdr.e_ident[EI_OSABI]) {
 	case ELFOSABI_LINUX:
-		return strdup("linux");
+		return rz_str_dup("linux");
 	case ELFOSABI_SOLARIS:
-		return strdup("solaris");
+		return rz_str_dup("solaris");
 	case ELFOSABI_FREEBSD:
-		return strdup("freebsd");
+		return rz_str_dup("freebsd");
 	case ELFOSABI_HPUX:
-		return strdup("hpux");
+		return rz_str_dup("hpux");
 	}
 
 	return NULL;
@@ -820,15 +820,15 @@ static bool file_type_is_os_specific(ELFOBJ *bin) {
 static char *get_file_type_basic(RZ_NONNULL ELFOBJ *bin) {
 	switch (bin->ehdr.e_type) {
 	case ET_NONE:
-		return strdup("NONE (None)");
+		return rz_str_dup("NONE (None)");
 	case ET_REL:
-		return strdup("REL (Relocatable file)");
+		return rz_str_dup("REL (Relocatable file)");
 	case ET_EXEC:
-		return strdup("EXEC (Executable file)");
+		return rz_str_dup("EXEC (Executable file)");
 	case ET_DYN:
-		return strdup("DYN (Shared object file)");
+		return rz_str_dup("DYN (Shared object file)");
 	case ET_CORE:
-		return strdup("CORE (Core file)");
+		return rz_str_dup("CORE (Core file)");
 	}
 
 	return NULL;
@@ -839,11 +839,11 @@ static char *get_cpu_mips(ELFOBJ *bin) {
 
 	for (size_t i = 0; i < RZ_ARRAY_SIZE(cpu_mips_translation_table); i++) {
 		if (mips_arch == cpu_mips_translation_table[i].arch) {
-			return strdup(cpu_mips_translation_table[i].name);
+			return rz_str_dup(cpu_mips_translation_table[i].name);
 		}
 	}
 
-	return strdup(" Unknown mips ISA");
+	return rz_str_dup(" Unknown mips ISA");
 }
 
 static bool is_elf_class64(ELFOBJ *bin) {
@@ -880,15 +880,15 @@ static bool is_mips_n32(ELFOBJ *bin) {
 
 static char *get_abi_mips(ELFOBJ *bin) {
 	if (is_elf_class64(bin)) {
-		return strdup("n64");
+		return rz_str_dup("n64");
 	}
 
 	if (is_mips_n32(bin)) {
-		return strdup("n32");
+		return rz_str_dup("n32");
 	}
 
 	if (is_mips_o32(bin)) {
-		return strdup("o32");
+		return rz_str_dup("o32");
 	}
 
 	return NULL;
@@ -1449,11 +1449,11 @@ RZ_OWN char *Elf_(rz_bin_elf_get_arch)(RZ_NONNULL ELFOBJ *bin) {
 
 	for (size_t i = 0; i < RZ_ARRAY_SIZE(arch_translation_table); i++) {
 		if (bin->ehdr.e_machine == arch_translation_table[i].arch) {
-			return strdup(arch_translation_table[i].name);
+			return rz_str_dup(arch_translation_table[i].name);
 		}
 	}
 
-	return strdup("");
+	return rz_str_dup("");
 }
 
 /**
@@ -1489,7 +1489,7 @@ RZ_OWN char *Elf_(rz_bin_elf_get_elf_class)(RZ_NONNULL ELFOBJ *bin) {
 
 	for (size_t i = 0; i < RZ_ARRAY_SIZE(class_translation_table); i++) {
 		if (bin->ehdr.e_ident[EI_CLASS] == class_translation_table[i].class) {
-			return strdup(class_translation_table[i].name);
+			return rz_str_dup(class_translation_table[i].name);
 		}
 	}
 
@@ -1535,7 +1535,7 @@ RZ_OWN char *Elf_(rz_bin_elf_get_head_flag)(RZ_NONNULL ELFOBJ *bin) {
 
 	if (RZ_STR_ISEMPTY(head_flag)) {
 		free(head_flag);
-		return strdup("unknown_flag");
+		return rz_str_dup("unknown_flag");
 	}
 
 	return head_flag;
@@ -1554,7 +1554,7 @@ RZ_OWN char *Elf_(rz_bin_elf_get_machine_name)(RZ_NONNULL ELFOBJ *bin) {
 
 	for (size_t i = 0; i < RZ_ARRAY_SIZE(machine_name_translation_table); i++) {
 		if (bin->ehdr.e_machine == machine_name_translation_table[i].machine) {
-			return strdup(machine_name_translation_table[i].name);
+			return rz_str_dup(machine_name_translation_table[i].name);
 		}
 	}
 
@@ -1581,7 +1581,7 @@ RZ_OWN char *Elf_(rz_bin_elf_get_osabi_name)(RZ_NONNULL ELFOBJ *bin) {
 		return name;
 	}
 
-	return strdup("linux");
+	return rz_str_dup("linux");
 }
 
 /**

--- a/librz/bin/format/elf/elf_sections.c
+++ b/librz/bin/format/elf/elf_sections.c
@@ -74,7 +74,7 @@ static bool create_section_from_phdr(ELFOBJ *bin, RzVector /*<RzBinElfSection>*/
 
 	section.rva = addr;
 	section.size = sz;
-	section.name = strdup(name);
+	section.name = rz_str_dup(name);
 	if (!section.name) {
 		return false;
 	}

--- a/librz/bin/format/elf/elf_strtab.c
+++ b/librz/bin/format/elf/elf_strtab.c
@@ -56,7 +56,7 @@ RZ_OWN char *Elf_(rz_bin_elf_strtab_get_dup)(RZ_NONNULL RzBinElfStrtab *strtab, 
 		return NULL;
 	}
 
-	char *result = strdup(strtab->data + index);
+	char *result = rz_str_dup(strtab->data + index);
 	if (!result) {
 		return NULL;
 	}

--- a/librz/bin/format/java/class_bin.c
+++ b/librz/bin/format/java/class_bin.c
@@ -315,42 +315,42 @@ RZ_API RZ_OWN char *rz_bin_java_class_version(RZ_NONNULL RzBinJavaClass *bin) {
 #define is_version(bin, major, minor) ((bin)->major_version == (major) && (bin)->minor_version >= (minor))
 	if (bin->major_version < 45 ||
 		(bin->major_version == 45 && bin->minor_version < 3)) {
-		return strdup("Java SE 1.0.2"); // old format
+		return rz_str_dup("Java SE 1.0.2"); // old format
 	} else if (is_version(bin, 45, 3)) {
-		return strdup("Java SE 1.1");
+		return rz_str_dup("Java SE 1.1");
 	} else if (is_version(bin, 46, 0)) {
-		return strdup("Java SE 1.2");
+		return rz_str_dup("Java SE 1.2");
 	} else if (is_version(bin, 47, 0)) {
-		return strdup("Java SE 1.3");
+		return rz_str_dup("Java SE 1.3");
 	} else if (is_version(bin, 48, 0)) {
-		return strdup("Java SE 1.4");
+		return rz_str_dup("Java SE 1.4");
 	} else if (is_version(bin, 49, 0)) {
-		return strdup("Java SE 1.5"); // enum, generics, annotations
+		return rz_str_dup("Java SE 1.5"); // enum, generics, annotations
 	} else if (is_version(bin, 50, 0)) {
-		return strdup("Java SE 1.6"); // stackmaps
+		return rz_str_dup("Java SE 1.6"); // stackmaps
 	} else if (is_version(bin, 51, 0)) {
-		return strdup("Java SE 1.7");
+		return rz_str_dup("Java SE 1.7");
 	} else if (is_version(bin, 52, 0)) {
-		return strdup("Java SE 1.8"); // lambda, type annos, param names
+		return rz_str_dup("Java SE 1.8"); // lambda, type annos, param names
 	} else if (is_version(bin, 53, 0)) {
-		return strdup("Java SE 1.9"); // modules, indy string concat
+		return rz_str_dup("Java SE 1.9"); // modules, indy string concat
 	} else if (is_version(bin, 54, 0)) {
-		return strdup("Java SE 10");
+		return rz_str_dup("Java SE 10");
 	} else if (is_version(bin, 55, 0)) {
-		return strdup("Java SE 11"); // constant dynamic, nest mates
+		return rz_str_dup("Java SE 11"); // constant dynamic, nest mates
 	} else if (is_version(bin, 56, 0)) {
-		return strdup("Java SE 12");
+		return rz_str_dup("Java SE 12");
 	} else if (is_version(bin, 57, 0)) {
-		return strdup("Java SE 13");
+		return rz_str_dup("Java SE 13");
 	} else if (is_version(bin, 58, 0)) {
-		return strdup("Java SE 14");
+		return rz_str_dup("Java SE 14");
 	} else if (is_version(bin, 59, 0)) {
-		return strdup("Java SE 15");
+		return rz_str_dup("Java SE 15");
 	} else if (is_version(bin, 60, 0)) {
-		return strdup("Java SE 16");
+		return rz_str_dup("Java SE 16");
 	}
 #undef is_version
-	return strdup("unknown");
+	return rz_str_dup("unknown");
 }
 
 RZ_API ut64 rz_bin_java_class_debug_info(RZ_NONNULL RzBinJavaClass *bin) {
@@ -456,7 +456,7 @@ RZ_API RZ_OWN char *rz_bin_java_class_name(RZ_NONNULL RzBinJavaClass *bin) {
 
 	if (!cpool || java_constant_pool_resolve(cpool, &index, NULL) != 1) {
 		RZ_LOG_ERROR("java bin: unknown class name at constant pool index %u\n", bin->this_class);
-		return strdup("unknown_class");
+		return rz_str_dup("unknown_class");
 	}
 
 	char *tmp = java_class_constant_pool_stringify_at(bin, index);
@@ -474,7 +474,7 @@ RZ_API RZ_OWN char *rz_bin_java_class_super(RZ_NONNULL RzBinJavaClass *bin) {
 	const ConstPool *cpool = java_class_constant_pool_at(bin, bin->super_class);
 	if (!cpool || java_constant_pool_resolve(cpool, &index, NULL) != 1) {
 		RZ_LOG_ERROR("java bin: unknown super name at constant pool index %u\n", bin->this_class);
-		return strdup("unknown_super");
+		return rz_str_dup("unknown_super");
 	}
 	char *tmp = java_class_constant_pool_stringify_at(bin, index);
 	if (!tmp) {
@@ -811,17 +811,17 @@ RZ_API void rz_bin_java_class_as_source_code(RZ_NONNULL RzBinJavaClass *bin, RZ_
 
 			char *name = java_class_constant_pool_stringify_at(bin, method->name_index);
 			if (!name) {
-				name = strdup("?");
+				name = rz_str_dup("?");
 			}
 			char *desc = java_class_constant_pool_stringify_at(bin, method->descriptor_index);
 			if (!desc) {
-				desc = strdup("(?)V");
+				desc = rz_str_dup("(?)V");
 			}
 
 			if (desc[0] == '(') {
 				tmp = rz_str_newf("%s%s", name, desc);
 			} else {
-				tmp = strdup(name);
+				tmp = rz_str_dup(name);
 			}
 			free(desc);
 			free(name);
@@ -1043,7 +1043,7 @@ RZ_API RZ_OWN RzPVector /*<RzBinString *>*/ *rz_bin_java_class_strings(RZ_NONNUL
 			bstr->ordinal = i;
 			bstr->length = attr->attribute_length;
 			bstr->size = attr->attribute_length;
-			bstr->string = strdup(attr->info);
+			bstr->string = rz_str_dup(attr->info);
 			bstr->type = RZ_STRING_ENC_UTF8;
 			rz_pvector_push(vec, bstr);
 		}
@@ -1055,7 +1055,7 @@ static char *add_class_name_to_name(char *name, char *classname) {
 	if (classname) {
 		return rz_str_newf("%s.%s", classname, name);
 	}
-	return strdup(name);
+	return rz_str_dup(name);
 }
 
 static char *demangle_java_and_free(char *mangled) {
@@ -1085,7 +1085,7 @@ static void set_lib_and_class_name(char *mangled, char **out_class, char **out_l
 	if (is_java_lang && !startswith(object, "java.lang")) {
 		*out_lib = rz_str_newf("java.lang.%s", object);
 	} else {
-		*out_lib = strdup(object);
+		*out_lib = rz_str_dup(object);
 	}
 }
 
@@ -1136,7 +1136,7 @@ RZ_API RZ_OWN RzList /*<RzBinSymbol *>*/ *rz_bin_java_class_methods_as_symbols(R
 			}
 			char *desc = java_class_constant_pool_stringify_at(bin, method->descriptor_index);
 			if (!desc) {
-				desc = strdup("(?)V");
+				desc = rz_str_dup("(?)V");
 			}
 
 			set_lib_and_class_name(rz_bin_java_class_name(bin), &symbol->classname, &symbol->libname);
@@ -1518,17 +1518,17 @@ RZ_API RZ_OWN RzList /*<RzBinSymbol *>*/ *rz_bin_java_class_const_pool_as_symbol
 
 			char *desc = java_class_constant_pool_stringify_at(bin, descriptor_index);
 			if (!desc) {
-				desc = strdup("(?)V");
+				desc = rz_str_dup("(?)V");
 			}
 
 			method_name = java_class_constant_pool_stringify_at(bin, name_index);
 			if (!method_name) {
-				method_name = strdup("unknown_method");
+				method_name = rz_str_dup("unknown_method");
 			}
 
 			classname = java_class_constant_pool_stringify_at(bin, class_name_index);
 			if (!classname) {
-				classname = strdup("unknown_class");
+				classname = rz_str_dup("unknown_class");
 			}
 
 			set_lib_and_class_name(rz_str_newf("L%s;", classname), &symbol->classname, &symbol->libname);
@@ -1536,7 +1536,7 @@ RZ_API RZ_OWN RzList /*<RzBinSymbol *>*/ *rz_bin_java_class_const_pool_as_symbol
 			if (desc[0] == '(') {
 				symbol->dname = rz_str_newf("%s%s", method_name, desc);
 			} else {
-				symbol->dname = strdup(method_name);
+				symbol->dname = rz_str_dup(method_name);
 			}
 			symbol->dname = demangle_java_and_free(symbol->dname);
 			symbol->bind = RZ_BIN_BIND_IMPORT_STR;
@@ -1637,7 +1637,7 @@ RZ_API RZ_OWN RzPVector /*<RzBinImport *>*/ *rz_bin_java_class_const_pool_as_imp
 			}
 
 			set_lib_and_class_name(rz_str_newf("L%s;", object), &import->classname, &import->libname);
-			import->name = strdup("*");
+			import->name = rz_str_dup("*");
 			import->bind = RZ_BIN_BIND_WEAK_STR;
 			import->type = RZ_BIN_TYPE_IFACE_STR;
 			import->ordinal = i;
@@ -1739,7 +1739,7 @@ static RzBinSection *new_section(const char *name, ut64 start, ut64 end, ut32 pe
 		rz_warn_if_reached();
 		return NULL;
 	}
-	section->name = strdup(name);
+	section->name = rz_str_dup(name);
 	if (!section->name) {
 		rz_warn_if_reached();
 		free(section);

--- a/librz/bin/format/le/le.c
+++ b/librz/bin/format/le/le.c
@@ -295,7 +295,7 @@ static RZ_BORROW LE_import *le_add_import(rz_bin_le_obj_t *bin,
 	RzBinSymbol *sym = le_add_symbol(bin, sym_ord, sym_vaddr);
 	CHECK(le_imp->symbol = sym);
 	sym->is_imported = true;
-	CHECK(sym->name = strdup(le_imp->import->name));
+	CHECK(sym->name = rz_str_dup(le_imp->import->name));
 
 	CHECK(ht_pp_insert(bin->le_import_ht, le_imp, NULL));
 	return le_imp;
@@ -1692,7 +1692,7 @@ RZ_OWN RzPVector /*<RzBinAddr *>*/ *rz_bin_le_get_entry_points(RzBinFile *bf) {
 static void str_copy(void *dst, void *src) {
 	char **_dst = (char **)dst;
 	char **_src = (char **)src;
-	*_dst = strdup(*_src);
+	*_dst = rz_str_dup(*_src);
 }
 
 RZ_OWN RzPVector /*<char *>*/ *rz_bin_le_get_libs(RzBinFile *bf) {
@@ -1727,7 +1727,7 @@ RZ_OWN RzPVector /*<RzBinVirtualFile *>*/ *rz_bin_le_get_virtual_files(RzBinFile
 	if (bin->buf_patched) {
 		// patched vfile over main buffer
 		CHECK(vf = RZ_NEW0(RzBinVirtualFile));
-		CHECK(vf->name = strdup(VFILE_NAME_PATCHED));
+		CHECK(vf->name = rz_str_dup(VFILE_NAME_PATCHED));
 		vf->buf = bin->buf_patched;
 		vf->buf_owned = false;
 		CHECK(rz_pvector_push(vfiles, vf));
@@ -1741,7 +1741,7 @@ RZ_OWN RzPVector /*<RzBinVirtualFile *>*/ *rz_bin_le_get_virtual_files(RzBinFile
 			continue;
 		}
 		CHECK(vf = RZ_NEW0(RzBinVirtualFile));
-		CHECK(vf->name = strdup(le_map->vfile_name));
+		CHECK(vf->name = rz_str_dup(le_map->vfile_name));
 		vf->buf = le_map->vfile_buf;
 		vf->buf_owned = false;
 		CHECK(rz_pvector_push(vfiles, vf));
@@ -1752,7 +1752,7 @@ RZ_OWN RzPVector /*<RzBinVirtualFile *>*/ *rz_bin_le_get_virtual_files(RzBinFile
 	ut64 rtmsz = le_reloc_targets_vfile_size(bin);
 	if (rtmsz) {
 		CHECK(vf = RZ_NEW0(RzBinVirtualFile));
-		CHECK(vf->name = strdup(VFILE_NAME_RELOC_TARGETS))
+		CHECK(vf->name = rz_str_dup(VFILE_NAME_RELOC_TARGETS))
 		CHECK(vf->buf = rz_buf_new_empty(rtmsz));
 		vf->buf_owned = true;
 		CHECK(rz_pvector_push(vfiles, vf));
@@ -1854,11 +1854,11 @@ RZ_OWN RzPVector /*<RzBinMap *>*/ *rz_bin_le_get_maps(RzBinFile *bf) {
 		CHECK(map->name = rz_str_newf("obj%u_map%u", obj_num, map_num));
 		if (le_map->is_physical) {
 			map->paddr = le_map->paddr;
-			CHECK(map->vfile_name = strdup(VFILE_NAME_PATCHED));
+			CHECK(map->vfile_name = rz_str_dup(VFILE_NAME_PATCHED));
 		} else {
 			map->paddr = 0;
 			if (map->psize != 0) {
-				CHECK(map->vfile_name = strdup(le_map->vfile_name));
+				CHECK(map->vfile_name = rz_str_dup(le_map->vfile_name));
 			}
 		}
 		CHECK(rz_pvector_push(maps, map));
@@ -1871,8 +1871,8 @@ RZ_OWN RzPVector /*<RzBinMap *>*/ *rz_bin_le_get_maps(RzBinFile *bf) {
 	map->vaddr = bin->reloc_target_map_base;
 	map->psize = rtmsz;
 	map->vsize = rtmsz;
-	CHECK(map->name = strdup(VFILE_NAME_RELOC_TARGETS));
-	CHECK(map->vfile_name = strdup(VFILE_NAME_RELOC_TARGETS));
+	CHECK(map->name = rz_str_dup(VFILE_NAME_RELOC_TARGETS));
+	CHECK(map->vfile_name = rz_str_dup(VFILE_NAME_RELOC_TARGETS));
 	CHECK(rz_pvector_push(maps, map));
 
 	return maps;

--- a/librz/bin/format/mach0/coresymbolication.c
+++ b/librz/bin/format/mach0/coresymbolication.c
@@ -158,7 +158,7 @@ RZ_API RzCoreSymCacheElement *rz_coresym_cache_element_new(RzBinFile *bf, RzBuff
 	}
 	ut8 *end = b + hdr->size;
 	if (file_name) {
-		result->file_name = strdup(file_name);
+		result->file_name = rz_str_dup(file_name);
 	} else if (hdr->file_name_off) {
 		result->file_name = str_dup_safe(b, b + (size_t)hdr->file_name_off, end);
 	}

--- a/librz/bin/format/mach0/dyldcache.c
+++ b/librz/bin/format/mach0/dyldcache.c
@@ -557,9 +557,9 @@ static char *get_lib_name(RzBuffer *cache_buf, cache_img_t *img) {
 	char *lib_name = file;
 	if (rz_buf_read_at(cache_buf, img->pathFileOffset, (ut8 *)file, sizeof(file)) == sizeof(file)) {
 		file[255] = 0;
-		return strdup(lib_name);
+		return rz_str_dup(lib_name);
 	}
-	return strdup("FAIL");
+	return rz_str_dup("FAIL");
 }
 
 static int string_contains(const void *a, const void *b, void *user) {
@@ -777,15 +777,15 @@ static RzList /*<RzDyldBinImage *>*/ *create_cache_bins(RzDyldCache *cache) {
 								scan--;
 							}
 							if (*scan == '/') {
-								bin->file = strdup(scan + 1);
+								bin->file = rz_str_dup(scan + 1);
 							} else {
-								bin->file = strdup(last_slash + 1);
+								bin->file = rz_str_dup(last_slash + 1);
 							}
 						} else {
-							bin->file = strdup(last_slash + 1);
+							bin->file = rz_str_dup(last_slash + 1);
 						}
 					} else {
-						bin->file = strdup(file);
+						bin->file = rz_str_dup(file);
 					}
 				} else {
 					bin->file = rz_str_newf("unknown_image_%08" PFMT64x, symbols_off);

--- a/librz/bin/format/mach0/mach0.c
+++ b/librz/bin/format/mach0/mach0.c
@@ -806,7 +806,7 @@ static bool parse_signature(struct MACH0_(obj_t) * bin, ut64 off) {
 
 	data = link.dataoff;
 	if (data > bin->size || data + sizeof(struct super_blob_t) > bin->size) {
-		bin->signature = (ut8 *)strdup("Malformed entitlement");
+		bin->signature = (ut8 *)rz_str_dup("Malformed entitlement");
 		return true;
 	}
 
@@ -829,7 +829,7 @@ static bool parse_signature(struct MACH0_(obj_t) * bin, ut64 off) {
 	// $ openssl pkcs7 -inform DER -print_certs -text -in a
 	for (i = 0; i < super.count; i++) {
 		if (data + i > bin->size) {
-			bin->signature = (ut8 *)strdup("Malformed entitlement");
+			bin->signature = (ut8 *)rz_str_dup("Malformed entitlement");
 			break;
 		}
 		struct blob_index_t bi;
@@ -844,7 +844,7 @@ static bool parse_signature(struct MACH0_(obj_t) * bin, ut64 off) {
 			if (true || isVerbose) {
 				ut64 off = data + idx.offset;
 				if (off > bin->size || off + sizeof(struct blob_t) > bin->size) {
-					bin->signature = (ut8 *)strdup("Malformed entitlement");
+					bin->signature = (ut8 *)rz_str_dup("Malformed entitlement");
 					break;
 				}
 				struct blob_t entitlements = { 0 };
@@ -864,10 +864,10 @@ static bool parse_signature(struct MACH0_(obj_t) * bin, ut64 off) {
 							bin->signature[len] = '\0';
 						}
 					} else {
-						bin->signature = (ut8 *)strdup("Malformed entitlement");
+						bin->signature = (ut8 *)rz_str_dup("Malformed entitlement");
 					}
 				} else {
-					bin->signature = (ut8 *)strdup("Malformed entitlement");
+					bin->signature = (ut8 *)rz_str_dup("Malformed entitlement");
 				}
 			}
 			break;
@@ -935,7 +935,7 @@ static bool parse_signature(struct MACH0_(obj_t) * bin, ut64 off) {
 		}
 	}
 	if (!bin->signature) {
-		bin->signature = (ut8 *)strdup("No entitlement found");
+		bin->signature = (ut8 *)rz_str_dup("No entitlement found");
 	}
 	return true;
 }
@@ -1923,7 +1923,7 @@ RzPVector /*<RzBinVirtualFile *>*/ *MACH0_(get_virtual_files)(RzBinFile *bf) {
 		}
 		vf->buf = buf;
 		vf->buf_owned = true;
-		vf->name = strdup(MACH0_VFILE_NAME_RELOC_TARGETS);
+		vf->name = rz_str_dup(MACH0_VFILE_NAME_RELOC_TARGETS);
 		rz_pvector_push(ret, vf);
 	}
 	// virtual file mirroring the raw file, but with relocs patched
@@ -1934,7 +1934,7 @@ RzPVector /*<RzBinVirtualFile *>*/ *MACH0_(get_virtual_files)(RzBinFile *bf) {
 		}
 		vf->buf = obj->buf_patched;
 		vf->buf_owned = false;
-		vf->name = strdup(MACH0_VFILE_NAME_PATCHED);
+		vf->name = rz_str_dup(MACH0_VFILE_NAME_PATCHED);
 		rz_pvector_push(ret, vf);
 	}
 	return ret;
@@ -2252,7 +2252,7 @@ static bool parse_import_stub(struct MACH0_(obj_t) * bin, struct symbol_t *symbo
 				if (*symstr == '_') {
 					symstr++;
 				}
-				symbol->name = strdup(symstr);
+				symbol->name = rz_str_dup(symstr);
 				return true;
 			}
 		}
@@ -2472,7 +2472,7 @@ static void assign_export_symbol_t(struct MACH0_(obj_t) * bin, const char *name,
 		}
 		sym_ctx->symbols[j].size = 0;
 		sym_ctx->symbols[j].type = RZ_BIN_MACH0_SYMBOL_TYPE_EXT;
-		sym_ctx->symbols[j].name = strdup(name);
+		sym_ctx->symbols[j].name = rz_str_dup(name);
 		sym_ctx->j++;
 	}
 }
@@ -2870,11 +2870,11 @@ const char *MACH0_(get_cputype)(struct MACH0_(obj_t) * bin) {
 
 char *MACH0_(get_cpusubtype_from_hdr)(struct MACH0_(mach_header) * hdr) {
 	rz_return_val_if_fail(hdr, NULL);
-	return strdup(rz_mach0_cpusubtype_tostring(hdr->cputype, hdr->cpusubtype));
+	return rz_str_dup(rz_mach0_cpusubtype_tostring(hdr->cputype, hdr->cpusubtype));
 }
 
 char *MACH0_(get_cpusubtype)(struct MACH0_(obj_t) * bin) {
-	return bin ? MACH0_(get_cpusubtype_from_hdr)(&bin->hdr) : strdup("Unknown");
+	return bin ? MACH0_(get_cpusubtype_from_hdr)(&bin->hdr) : rz_str_dup("Unknown");
 }
 
 bool MACH0_(is_pie)(struct MACH0_(obj_t) * bin) {
@@ -2902,11 +2902,11 @@ char *MACH0_(get_filetype_from_hdr)(struct MACH0_(mach_header) * hdr) {
 	case MH_KEXT_BUNDLE: mhtype = "Kernel extension bundle file"; break;
 	case MH_FILESET: mhtype = "Kernel cache file"; break;
 	}
-	return strdup(mhtype);
+	return rz_str_dup(mhtype);
 }
 
 char *MACH0_(get_filetype)(struct MACH0_(obj_t) * bin) {
-	return bin ? MACH0_(get_filetype_from_hdr)(&bin->hdr) : strdup("Unknown");
+	return bin ? MACH0_(get_filetype_from_hdr)(&bin->hdr) : rz_str_dup("Unknown");
 }
 
 ut64 MACH0_(get_main)(struct MACH0_(obj_t) * bin) {

--- a/librz/bin/format/mach0/mach0_chained_fixups.c
+++ b/librz/bin/format/mach0/mach0_chained_fixups.c
@@ -156,7 +156,7 @@ RZ_API bool MACH0_(get_chained_import)(struct MACH0_(obj_t) * obj, ut32 ordinal,
 
 RZ_API RZ_OWN char *MACH0_(chained_import_read_symbol_name)(struct MACH0_(obj_t) * obj, struct MACH0_(chained_import_t) * imp) {
 	if (imp->name) {
-		return strdup(imp->name);
+		return rz_str_dup(imp->name);
 	}
 	return MACH0_(read_chained_symbol)(obj, imp->name_offset);
 }
@@ -287,7 +287,7 @@ static void reconstruct_threaded_bind(ut64 paddr, ut64 vaddr, st64 addend, ut8 r
 	}
 	RzDyldChainedImportThreaded *imp = rz_vector_index_ptr(&cf->imports, sym_ord);
 	free(imp->sym_name);
-	imp->sym_name = strdup(sym_name);
+	imp->sym_name = rz_str_dup(sym_name);
 	imp->lib_ord = lib_ord;
 	imp->addend = addend;
 }

--- a/librz/bin/format/mdmp/mdmp_pe.c
+++ b/librz/bin/format/mdmp/mdmp_pe.c
@@ -114,8 +114,8 @@ RzPVector /*<RzBinImport *>*/ *PE_(rz_bin_mdmp_pe_get_imports)(struct PE_(rz_bin
 			break;
 		}
 		filter_import(imports[i].name);
-		ptr->name = strdup((const char *)imports[i].name);
-		ptr->libname = *imports[i].libname ? strdup((const char *)imports[i].libname) : NULL;
+		ptr->name = rz_str_dup((const char *)imports[i].name);
+		ptr->libname = RZ_STR_ISNOTEMPTY(imports[i].libname) ? rz_str_dup((const char *)imports[i].libname) : NULL;
 		ptr->bind = "NONE";
 		ptr->type = RZ_BIN_TYPE_FUNC_STR;
 		ptr->ordinal = imports[i].ordinal;
@@ -167,9 +167,9 @@ RzPVector /*<RzBinSection *>*/ *PE_(rz_bin_mdmp_pe_get_sections)(struct PE_(rz_b
 			break;
 		}
 		if (sections[i].name[0]) {
-			ptr->name = strdup((char *)sections[i].name);
+			ptr->name = rz_str_dup((char *)sections[i].name);
 		} else {
-			ptr->name = strdup("");
+			ptr->name = rz_str_dup("");
 		}
 		ptr->size = sections[i].size;
 		if (ptr->size > pe_bin->bin->size) {
@@ -233,8 +233,8 @@ RzList /*<RzBinSymbol *>*/ *PE_(rz_bin_mdmp_pe_get_symbols)(RzBin *rbin, struct 
 			if (offset > pe_bin->vaddr) {
 				offset -= pe_bin->vaddr;
 			}
-			ptr->name = strdup((char *)symbols[i].name);
-			ptr->libname = *symbols[i].libname ? strdup((char *)symbols[i].libname) : NULL;
+			ptr->name = rz_str_dup((char *)symbols[i].name);
+			ptr->libname = RZ_STR_ISNOTEMPTY(symbols[i].libname) ? rz_str_dup((char *)symbols[i].libname) : NULL;
 			ptr->forwarder = rz_str_constpool_get(&rbin->constpool, (char *)symbols[i].forwarder);
 			ptr->bind = RZ_BIN_BIND_GLOBAL_STR;
 			ptr->type = RZ_BIN_TYPE_FUNC_STR;
@@ -257,8 +257,8 @@ RzList /*<RzBinSymbol *>*/ *PE_(rz_bin_mdmp_pe_get_symbols)(RzBin *rbin, struct 
 			if (offset > pe_bin->vaddr) {
 				offset -= pe_bin->vaddr;
 			}
-			ptr->name = strdup((const char *)imports[i].name);
-			ptr->libname = *imports[i].libname ? strdup((const char *)imports[i].libname) : NULL;
+			ptr->name = rz_str_dup((const char *)imports[i].name);
+			ptr->libname = RZ_STR_ISNOTEMPTY(imports[i].libname) ? rz_str_dup((const char *)imports[i].libname) : NULL;
 			ptr->is_imported = true;
 			ptr->bind = "NONE";
 			ptr->type = RZ_BIN_TYPE_FUNC_STR;

--- a/librz/bin/format/ne/ne.c
+++ b/librz/bin/format/ne/ne.c
@@ -274,7 +274,7 @@ static char *__resource_type_str(int type) {
 	default:
 		return rz_str_newf("UNKNOWN (%d)", type);
 	}
-	return strdup(typeName);
+	return rz_str_dup(typeName);
 }
 
 static void __free_resource_entry(void *entry) {

--- a/librz/bin/format/nxo/nxo.c
+++ b/librz/bin/format/nxo/nxo.c
@@ -18,7 +18,7 @@ static char *readString(RzBuffer *buf, int off) {
 		return NULL;
 	}
 	symbol[sizeof(symbol) - 1] = 0;
-	return strdup(symbol);
+	return rz_str_dup(symbol);
 }
 
 const char *fileType(const ut8 *buf) {
@@ -99,7 +99,7 @@ static void walkSymbols(RzBuffer *buf, RzBinNXOObj *bin, ut64 symtab, ut64 strta
 			imp->ordinal = bin->imports_vec->v.len;
 			rz_pvector_push(bin->imports_vec, imp);
 			sym->is_imported = true;
-			sym->name = strdup(symName);
+			sym->name = rz_str_dup(symName);
 			if (!sym->name) {
 				goto out_walk_symbol;
 			}

--- a/librz/bin/format/objc/mach0_classes.c
+++ b/librz/bin/format/objc/mach0_classes.c
@@ -186,8 +186,8 @@ static void copy_sym_name_with_namespace(char *class_name, char *read_name, RzBi
 	if (!class_name) {
 		class_name = "";
 	}
-	sym->classname = strdup(class_name);
-	sym->name = strdup(read_name);
+	sym->classname = rz_str_dup(class_name);
+	sym->name = rz_str_dup(read_name);
 }
 
 static int sort_by_offset(const void *_a, const void *_b, void *user) {
@@ -294,7 +294,7 @@ static void get_ivar_list_t(mach0_ut p, RzBinFile *bf, RzBuffer *buf, RzBinClass
 			}
 			char *name;
 			if (bin->has_crypto) {
-				name = strdup("some_encrypted_data");
+				name = rz_str_dup("some_encrypted_data");
 				left = strlen(name) + 1;
 			} else {
 				int name_len = RZ_MIN(MAX_CLASS_NAME_LEN, left);
@@ -324,7 +324,7 @@ static void get_ivar_list_t(mach0_ut p, RzBinFile *bf, RzBuffer *buf, RzBinClass
 			}
 			char *type = NULL;
 			if (is_crypted == 1) {
-				type = strdup("some_encrypted_data");
+				type = rz_str_dup("some_encrypted_data");
 				// 	left = strlen (name) + 1;
 			} else {
 				int type_len = RZ_MIN(MAX_CLASS_NAME_LEN, left);
@@ -449,7 +449,7 @@ static void get_objc_property_list(mach0_ut p, RzBinFile *bf, RzBuffer *buf, RzB
 				goto error;
 			}
 			if (bin->has_crypto) {
-				name = strdup("some_encrypted_data");
+				name = rz_str_dup("some_encrypted_data");
 				left = strlen(name) + 1;
 			} else {
 				int name_len = RZ_MIN(MAX_CLASS_NAME_LEN, left);
@@ -474,7 +474,7 @@ static void get_objc_property_list(mach0_ut p, RzBinFile *bf, RzBuffer *buf, RzB
 			if (r + left < r) goto error;
 
 			if (is_crypted == 1) {
-				name = strdup ("some_encrypted_data");
+				name = rz_str_dup ("some_encrypted_data");
 				left = strlen (name) + 1;
 			} else {
 				name = malloc (left);
@@ -628,7 +628,7 @@ static void get_method_list_t(mach0_ut p, RzBinFile *bf, RzBuffer *buf, char *cl
 				goto error;
 			}
 			if (bin->has_crypto) {
-				name = strdup("some_encrypted_data");
+				name = rz_str_dup("some_encrypted_data");
 				left = strlen(name) + 1;
 			} else {
 				int name_len = RZ_MIN(MAX_CLASS_NAME_LEN, left);
@@ -653,7 +653,7 @@ static void get_method_list_t(mach0_ut p, RzBinFile *bf, RzBuffer *buf, char *cl
 				goto error;
 			}
 			if (bin->has_crypto) {
-				rtype = strdup("some_encrypted_data");
+				rtype = rz_str_dup("some_encrypted_data");
 				left = strlen(rtype) + 1;
 			} else {
 				left = 1;
@@ -667,7 +667,7 @@ static void get_method_list_t(mach0_ut p, RzBinFile *bf, RzBuffer *buf, char *cl
 				}
 				rtype[left] = 0;
 			}
-			method->rtype = strdup(rtype);
+			method->rtype = rz_str_dup(rtype);
 			RZ_FREE(rtype);
 		}
 
@@ -817,7 +817,7 @@ static void get_protocol_list_t(mach0_ut p, RzBinFile *bf, RzBuffer *buf, RzBinC
 				return;
 			}
 			if (bin->has_crypto) {
-				name = strdup("some_encrypted_data");
+				name = rz_str_dup("some_encrypted_data");
 				left = strlen(name) + 1;
 			} else {
 				int name_len = RZ_MIN(MAX_CLASS_NAME_LEN, left);
@@ -867,7 +867,7 @@ static char *demangle_classname(const char *s) {
 		len = atoi(s + off);
 		modlen = strlen(s + off);
 		if (!len || len >= modlen) {
-			return strdup(s);
+			return rz_str_dup(s);
 		}
 		module = rz_str_ndup(skipnum(s + off), len);
 		int skip = (skipnum(s + off) - s) + len;
@@ -881,14 +881,14 @@ static char *demangle_classname(const char *s) {
 		modlen = strlen(kstr);
 		if (!len || len >= modlen) {
 			free(module);
-			return strdup(s);
+			return rz_str_dup(s);
 		}
 		klass = rz_str_ndup(skipnum(kstr), len);
 		ret = rz_str_newf("%s.%s", module, klass);
 		free(module);
 		free(klass);
 	} else {
-		ret = strdup(s);
+		ret = rz_str_dup(s);
 	}
 	return ret;
 }
@@ -967,7 +967,7 @@ static char *get_class_name(mach0_ut p, RzBinFile *bf, RzBuffer *buf) {
 			return NULL;
 		}
 		if (bin->has_crypto) {
-			return strdup("some_encrypted_data");
+			return rz_str_dup("some_encrypted_data");
 		} else {
 			int name_len = RZ_MIN(MAX_CLASS_NAME_LEN, left);
 			char *name = malloc(name_len + 1);
@@ -1061,7 +1061,7 @@ static void get_class_ro_t(mach0_ut p, RzBinFile *bf, RzBuffer *buf, ut32 *is_me
 			return;
 		}
 		if (bin->has_crypto) {
-			klass->name = strdup("some_encrypted_data");
+			klass->name = rz_str_dup("some_encrypted_data");
 			left = strlen(klass->name) + 1;
 		} else {
 			int name_len = RZ_MIN(MAX_CLASS_NAME_LEN, left);
@@ -1168,7 +1168,7 @@ RZ_API void MACH0_(get_class_t)(mach0_ut p, RzBinFile *bf, RzBuffer *buf, RzBinC
 			char *target_class_name = (char *)((struct reloc_t *)found->data)->name;
 			if (rz_str_startswith(target_class_name, _objc_class)) {
 				target_class_name += _objc_class_len;
-				klass->super = strdup(target_class_name);
+				klass->super = rz_str_dup(target_class_name);
 			}
 		}
 	} else if (c.superclass) {
@@ -1213,10 +1213,10 @@ static RzList *parse_swift_classes(RzBinFile *bf) {
 	ret = rz_list_newf (rz_bin_string_free);
 	rz_list_foreach (bf->o->strings, iter, str) {
 		if (!strncmp (str->string, "_TtC", 4)) {
-			char *msg = strdup (str->string + 4);
+			char *msg = rz_str_dup (str->string + 4);
 			cls = RZ_NEW0 (RzBinClass);
-			cls->name = strdup (msg);
-			cls->super = strdup (msg);
+			cls->name = rz_str_dup (msg);
+			cls->super = rz_str_dup (msg);
 			cls->index = idx++;
 			rz_list_append (ret, cls);
 			free (msg);

--- a/librz/bin/format/omf/omf.c
+++ b/librz/bin/format/omf/omf.c
@@ -487,7 +487,7 @@ static int cpy_omf_names(rz_bin_omf_obj *obj) {
 		while (++ct_rec < lname->nb_elem) {
 			if (!((char **)lname->elems)[ct_rec]) {
 				obj->names[ct_obj++] = NULL;
-			} else if (!(obj->names[ct_obj++] = strdup(((char **)lname->elems)[ct_rec]))) {
+			} else if (!(obj->names[ct_obj++] = rz_str_dup(((char **)lname->elems)[ct_rec]))) {
 				return false;
 			}
 		}
@@ -530,7 +530,7 @@ static int get_omf_symbol_info(rz_bin_omf_obj *obj) {
 				return false;
 			}
 			memcpy(obj->symbols[ct_obj], ((OMF_symbol *)symbols->elems) + ct_rec, sizeof(*(obj->symbols[ct_obj])));
-			obj->symbols[ct_obj]->name = strdup(((OMF_symbol *)symbols->elems)[ct_rec].name);
+			obj->symbols[ct_obj]->name = rz_str_dup(((OMF_symbol *)symbols->elems)[ct_rec].name);
 			ct_obj++;
 		}
 		tmp = tmp->next;

--- a/librz/bin/format/pe/pe_imports.c
+++ b/librz/bin/format/pe/pe_imports.c
@@ -94,7 +94,7 @@ static int bin_pe_parse_imports(RzBinPEObj *bin,
 				free(symdllname);
 				strncpy(name, dll_name, sizeof(name) - 1);
 				name[sizeof(name) - 1] = 0;
-				symdllname = strdup(name);
+				symdllname = rz_str_dup(name);
 
 				// remove the trailling ".dll"
 				size_t len = strlen(symdllname);
@@ -109,7 +109,7 @@ static int bin_pe_parse_imports(RzBinPEObj *bin,
 					}
 					db = NULL;
 					free(sdb_module);
-					sdb_module = strdup(symdllname);
+					sdb_module = rz_str_dup(symdllname);
 					filename = rz_str_newf("%s.sdb", symdllname);
 					if (filename && rz_file_exists(filename)) {
 						db = sdb_new(NULL, filename, 0);

--- a/librz/bin/format/pe/pe_info.c
+++ b/librz/bin/format/pe/pe_info.c
@@ -64,7 +64,7 @@ char *PE_(rz_bin_pe_get_machine)(RzBinPEObj *bin) {
 		default: machine = "unknown";
 		}
 	}
-	return machine ? strdup(machine) : NULL;
+	return rz_str_dup(machine);
 }
 
 // TODO: make it const! like in elf
@@ -75,28 +75,28 @@ char *PE_(rz_bin_pe_get_os)(RzBinPEObj *bin) {
 	}
 	switch (bin->nt_headers->optional_header.Subsystem) {
 	case PE_IMAGE_SUBSYSTEM_NATIVE:
-		os = strdup("native");
+		os = rz_str_dup("native");
 		break;
 	case PE_IMAGE_SUBSYSTEM_WINDOWS_GUI:
 	case PE_IMAGE_SUBSYSTEM_WINDOWS_CUI:
 	case PE_IMAGE_SUBSYSTEM_WINDOWS_CE_GUI:
-		os = strdup("windows");
+		os = rz_str_dup("windows");
 		break;
 	case PE_IMAGE_SUBSYSTEM_POSIX_CUI:
-		os = strdup("posix");
+		os = rz_str_dup("posix");
 		break;
 	case PE_IMAGE_SUBSYSTEM_EFI_APPLICATION:
 	case PE_IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER:
 	case PE_IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER:
 	case PE_IMAGE_SUBSYSTEM_EFI_ROM:
-		os = strdup("efi");
+		os = rz_str_dup("efi");
 		break;
 	case PE_IMAGE_SUBSYSTEM_XBOX:
-		os = strdup("xbox");
+		os = rz_str_dup("xbox");
 		break;
 	default:
 		// XXX: this is unknown
-		os = strdup("windows");
+		os = rz_str_dup("windows");
 	}
 	return os;
 }
@@ -105,9 +105,9 @@ char *PE_(rz_bin_pe_get_os)(RzBinPEObj *bin) {
 char *PE_(rz_bin_pe_get_class)(RzBinPEObj *bin) {
 	if (bin && bin->nt_headers) {
 		switch (bin->nt_headers->optional_header.Magic) {
-		case PE_IMAGE_FILE_TYPE_PE32: return strdup("PE32");
-		case PE_IMAGE_FILE_TYPE_PE32PLUS: return strdup("PE32+");
-		default: return strdup("Unknown");
+		case PE_IMAGE_FILE_TYPE_PE32: return rz_str_dup("PE32");
+		case PE_IMAGE_FILE_TYPE_PE32PLUS: return rz_str_dup("PE32+");
+		default: return rz_str_dup("Unknown");
 		}
 	}
 	return NULL;
@@ -116,45 +116,45 @@ char *PE_(rz_bin_pe_get_class)(RzBinPEObj *bin) {
 char *PE_(rz_bin_pe_get_arch)(RzBinPEObj *bin) {
 	char *arch;
 	if (!bin || !bin->nt_headers) {
-		return strdup("x86");
+		return rz_str_dup("x86");
 	}
 	switch (bin->nt_headers->file_header.Machine) {
 	case PE_IMAGE_FILE_MACHINE_ALPHA:
 	case PE_IMAGE_FILE_MACHINE_ALPHA64:
-		arch = strdup("alpha");
+		arch = rz_str_dup("alpha");
 		break;
 	case PE_IMAGE_FILE_MACHINE_ARM:
 	case PE_IMAGE_FILE_MACHINE_ARMNT:
 	case PE_IMAGE_FILE_MACHINE_THUMB:
-		arch = strdup("arm");
+		arch = rz_str_dup("arm");
 		break;
 	case PE_IMAGE_FILE_MACHINE_M68K:
-		arch = strdup("m68k");
+		arch = rz_str_dup("m68k");
 		break;
 	case PE_IMAGE_FILE_MACHINE_MIPS16:
 	case PE_IMAGE_FILE_MACHINE_MIPSFPU:
 	case PE_IMAGE_FILE_MACHINE_MIPSFPU16:
 	case PE_IMAGE_FILE_MACHINE_WCEMIPSV2:
-		arch = strdup("mips");
+		arch = rz_str_dup("mips");
 		break;
 	case PE_IMAGE_FILE_MACHINE_POWERPC:
 	case PE_IMAGE_FILE_MACHINE_POWERPCFP:
 	case PE_IMAGE_FILE_MACHINE_POWERPCBE:
-		arch = strdup("ppc");
+		arch = rz_str_dup("ppc");
 		break;
 	case PE_IMAGE_FILE_MACHINE_EBC:
-		arch = strdup("ebc");
+		arch = rz_str_dup("ebc");
 		break;
 	case PE_IMAGE_FILE_MACHINE_ARM64:
-		arch = strdup("arm");
+		arch = rz_str_dup("arm");
 		break;
 	case PE_IMAGE_FILE_MACHINE_RISCV32:
 	case PE_IMAGE_FILE_MACHINE_RISCV64:
 	case PE_IMAGE_FILE_MACHINE_RISCV128:
-		arch = strdup("riscv");
+		arch = rz_str_dup("riscv");
 		break;
 	default:
-		arch = strdup("x86");
+		arch = rz_str_dup("x86");
 	}
 	return arch;
 }
@@ -198,23 +198,23 @@ char *PE_(rz_bin_pe_get_subsystem)(RzBinPEObj *bin) {
 			break;
 		}
 	}
-	return subsystem ? strdup(subsystem) : NULL;
+	return rz_str_dup(subsystem);
 }
 
 char *PE_(rz_bin_pe_get_cc)(RzBinPEObj *bin) {
 	if (bin && bin->nt_headers) {
 		if (is_arm(bin)) {
 			if (is_thumb(bin)) {
-				return strdup("arm16");
+				return rz_str_dup("arm16");
 			}
 			switch (bin->nt_headers->optional_header.Magic) {
-			case PE_IMAGE_FILE_TYPE_PE32: return strdup("arm32");
-			case PE_IMAGE_FILE_TYPE_PE32PLUS: return strdup("arm64");
+			case PE_IMAGE_FILE_TYPE_PE32: return rz_str_dup("arm32");
+			case PE_IMAGE_FILE_TYPE_PE32PLUS: return rz_str_dup("arm64");
 			}
 		} else {
 			switch (bin->nt_headers->optional_header.Magic) {
-			case PE_IMAGE_FILE_TYPE_PE32: return strdup("cdecl");
-			case PE_IMAGE_FILE_TYPE_PE32PLUS: return strdup("ms");
+			case PE_IMAGE_FILE_TYPE_PE32: return rz_str_dup("cdecl");
+			case PE_IMAGE_FILE_TYPE_PE32PLUS: return rz_str_dup("ms");
 			}
 		}
 	}

--- a/librz/bin/format/pe/pe_rsrc.c
+++ b/librz/bin/format/pe/pe_rsrc.c
@@ -1315,7 +1315,7 @@ static char *_resource_type_str(int type) {
 		break;
 	default: return rz_str_newf("UNKNOWN (%d)", type);
 	}
-	return strdup(typeName);
+	return rz_str_dup(typeName);
 }
 
 static int read_image_resource_directory_entry(RzBuffer *b, ut64 addr, Pe_image_resource_directory_entry *entry) {
@@ -1480,10 +1480,10 @@ static void _parse_resource_directory(RzBinPEObj *bin, Pe_image_resource_directo
 			rs->timestr = rz_time_stamp_to_str(dir->TimeDateStamp);
 		}
 		rs->type = _resource_type_str(type);
-		rs->language = strdup(_resource_lang_str(entry.u1.Name & 0x3ff));
+		rs->language = rz_str_dup(_resource_lang_str(entry.u1.Name & 0x3ff));
 		rs->data = data;
 		if (resource_name) {
-			rs->name = strdup(resource_name);
+			rs->name = rz_str_dup(resource_name);
 		} else {
 			rs->name = rz_str_newf("%d", id);
 		}

--- a/librz/bin/format/pe/pe_security.c
+++ b/librz/bin/format/pe/pe_security.c
@@ -26,7 +26,7 @@ char *PE_(bin_pe_compute_authentihash)(RzBinPEObj *bin) {
 		return NULL;
 	}
 
-	char *hashtype = strdup(bin->spcinfo->messageDigest.digestAlgorithm.algorithm->string);
+	char *hashtype = rz_str_dup(bin->spcinfo->messageDigest.digestAlgorithm.algorithm->string);
 	rz_str_replace_char(hashtype, '-', 0);
 
 	RzHashCfg *md = rz_hash_cfg_new_with_algo2(bin->hash, hashtype);

--- a/librz/bin/format/pyc/marshal.c
+++ b/librz/bin/format/pyc/marshal.c
@@ -88,7 +88,7 @@ static pyc_object *get_none_object(void) {
 		return NULL;
 	}
 	ret->type = TYPE_NONE;
-	ret->data = strdup("None");
+	ret->data = rz_str_dup("None");
 	if (!ret->data) {
 		RZ_FREE(ret);
 	}
@@ -101,7 +101,7 @@ static pyc_object *get_false_object(void) {
 		return NULL;
 	}
 	ret->type = TYPE_FALSE;
-	ret->data = strdup("False");
+	ret->data = rz_str_dup("False");
 	if (!ret->data) {
 		RZ_FREE(ret);
 	}
@@ -114,7 +114,7 @@ static pyc_object *get_true_object(void) {
 		return NULL;
 	}
 	ret->type = TYPE_TRUE;
-	ret->data = strdup("True");
+	ret->data = rz_str_dup("True");
 	if (!ret->data) {
 		RZ_FREE(ret);
 	}
@@ -189,7 +189,7 @@ static pyc_object *get_long_object(RzBuffer *buffer) {
 		neg = true;
 	}
 	if (ndigits == 0) {
-		ret->data = strdup("0x0");
+		ret->data = rz_str_dup("0x0");
 	} else {
 		// the explicit cast is safe since ndigits is positive
 		size = (size_t)ndigits * 15;
@@ -831,7 +831,7 @@ static pyc_object *copy_object(pyc_object *object) {
 	case TYPE_SHORT_ASCII:
 	case TYPE_ASCII_INTERNED:
 	case TYPE_SHORT_ASCII_INTERNED:
-		copy->data = strdup(object->data);
+		copy->data = rz_str_dup(object->data);
 		break;
 	case TYPE_CODE_v0:
 	case TYPE_CODE_v1: {
@@ -1186,7 +1186,7 @@ static bool extract_sections_symbols(RzBinPycObj *pyc, pyc_object *obj, RzPVecto
 	if (!prefix || !section || !symbol) {
 		goto fail;
 	}
-	section->name = strdup(prefix);
+	section->name = rz_str_dup(prefix);
 	if (!section->name) {
 		goto fail;
 	}
@@ -1200,7 +1200,7 @@ static bool extract_sections_symbols(RzBinPycObj *pyc, pyc_object *obj, RzPVecto
 	}
 	section = NULL;
 	// start building symbol
-	symbol->name = strdup(prefix);
+	symbol->name = rz_str_dup(prefix);
 	// symbol->bind;
 	symbol->type = RZ_BIN_TYPE_FUNC_STR;
 	symbol->size = cobj->end_offset - cobj->start_offset;

--- a/librz/bin/format/te/te.c
+++ b/librz/bin/format/te/te.c
@@ -167,27 +167,27 @@ char *rz_bin_te_get_arch(struct rz_bin_te_obj_t *bin) {
 	switch (bin->header->Machine) {
 	case TE_IMAGE_FILE_MACHINE_ALPHA:
 	case TE_IMAGE_FILE_MACHINE_ALPHA64:
-		arch = strdup("alpha");
+		arch = rz_str_dup("alpha");
 		break;
 	case TE_IMAGE_FILE_MACHINE_ARM:
 	case TE_IMAGE_FILE_MACHINE_THUMB:
-		arch = strdup("arm");
+		arch = rz_str_dup("arm");
 		break;
 	case TE_IMAGE_FILE_MACHINE_M68K:
-		arch = strdup("m68k");
+		arch = rz_str_dup("m68k");
 		break;
 	case TE_IMAGE_FILE_MACHINE_MIPS16:
 	case TE_IMAGE_FILE_MACHINE_MIPSFPU:
 	case TE_IMAGE_FILE_MACHINE_MIPSFPU16:
 	case TE_IMAGE_FILE_MACHINE_WCEMIPSV2:
-		arch = strdup("mips");
+		arch = rz_str_dup("mips");
 		break;
 	case TE_IMAGE_FILE_MACHINE_POWERPC:
 	case TE_IMAGE_FILE_MACHINE_POWERPCFP:
-		arch = strdup("ppc");
+		arch = rz_str_dup("ppc");
 		break;
 	default:
-		arch = strdup("x86");
+		arch = rz_str_dup("x86");
 	}
 	return arch;
 }
@@ -228,91 +228,91 @@ char *rz_bin_te_get_machine(struct rz_bin_te_obj_t *bin) {
 	}
 	switch (bin->header->Machine) {
 	case TE_IMAGE_FILE_MACHINE_ALPHA:
-		machine = strdup("Alpha");
+		machine = rz_str_dup("Alpha");
 		break;
 	case TE_IMAGE_FILE_MACHINE_ALPHA64:
-		machine = strdup("Alpha 64");
+		machine = rz_str_dup("Alpha 64");
 		break;
 	case TE_IMAGE_FILE_MACHINE_AM33:
-		machine = strdup("AM33");
+		machine = rz_str_dup("AM33");
 		break;
 	case TE_IMAGE_FILE_MACHINE_AMD64:
-		machine = strdup("AMD 64");
+		machine = rz_str_dup("AMD 64");
 		break;
 	case TE_IMAGE_FILE_MACHINE_ARM:
-		machine = strdup("ARM");
+		machine = rz_str_dup("ARM");
 		break;
 	case TE_IMAGE_FILE_MACHINE_CEE:
-		machine = strdup("CEE");
+		machine = rz_str_dup("CEE");
 		break;
 	case TE_IMAGE_FILE_MACHINE_CEF:
-		machine = strdup("CEF");
+		machine = rz_str_dup("CEF");
 		break;
 	case TE_IMAGE_FILE_MACHINE_EBC:
-		machine = strdup("EBC");
+		machine = rz_str_dup("EBC");
 		break;
 	case TE_IMAGE_FILE_MACHINE_I386:
-		machine = strdup("i386");
+		machine = rz_str_dup("i386");
 		break;
 	case TE_IMAGE_FILE_MACHINE_IA64:
-		machine = strdup("ia64");
+		machine = rz_str_dup("ia64");
 		break;
 	case TE_IMAGE_FILE_MACHINE_M32R:
-		machine = strdup("M32R");
+		machine = rz_str_dup("M32R");
 		break;
 	case TE_IMAGE_FILE_MACHINE_M68K:
-		machine = strdup("M68K");
+		machine = rz_str_dup("M68K");
 		break;
 	case TE_IMAGE_FILE_MACHINE_MIPS16:
-		machine = strdup("Mips 16");
+		machine = rz_str_dup("Mips 16");
 		break;
 	case TE_IMAGE_FILE_MACHINE_MIPSFPU:
-		machine = strdup("Mips FPU");
+		machine = rz_str_dup("Mips FPU");
 		break;
 	case TE_IMAGE_FILE_MACHINE_MIPSFPU16:
-		machine = strdup("Mips FPU 16");
+		machine = rz_str_dup("Mips FPU 16");
 		break;
 	case TE_IMAGE_FILE_MACHINE_POWERPC:
-		machine = strdup("PowerPC");
+		machine = rz_str_dup("PowerPC");
 		break;
 	case TE_IMAGE_FILE_MACHINE_POWERPCFP:
-		machine = strdup("PowerPC FP");
+		machine = rz_str_dup("PowerPC FP");
 		break;
 	case TE_IMAGE_FILE_MACHINE_R10000:
-		machine = strdup("R10000");
+		machine = rz_str_dup("R10000");
 		break;
 	case TE_IMAGE_FILE_MACHINE_R3000:
-		machine = strdup("R3000");
+		machine = rz_str_dup("R3000");
 		break;
 	case TE_IMAGE_FILE_MACHINE_R4000:
-		machine = strdup("R4000");
+		machine = rz_str_dup("R4000");
 		break;
 	case TE_IMAGE_FILE_MACHINE_SH3:
-		machine = strdup("SH3");
+		machine = rz_str_dup("SH3");
 		break;
 	case TE_IMAGE_FILE_MACHINE_SH3DSP:
-		machine = strdup("SH3DSP");
+		machine = rz_str_dup("SH3DSP");
 		break;
 	case TE_IMAGE_FILE_MACHINE_SH3E:
-		machine = strdup("SH3E");
+		machine = rz_str_dup("SH3E");
 		break;
 	case TE_IMAGE_FILE_MACHINE_SH4:
-		machine = strdup("SH4");
+		machine = rz_str_dup("SH4");
 		break;
 	case TE_IMAGE_FILE_MACHINE_SH5:
-		machine = strdup("SH5");
+		machine = rz_str_dup("SH5");
 		break;
 	case TE_IMAGE_FILE_MACHINE_THUMB:
-		machine = strdup("Thumb");
+		machine = rz_str_dup("Thumb");
 		break;
 	case TE_IMAGE_FILE_MACHINE_TRICORE:
-		machine = strdup("Tricore");
+		machine = rz_str_dup("Tricore");
 		break;
 	case TE_IMAGE_FILE_MACHINE_WCEMIPSV2:
-		machine = strdup("WCE Mips V2");
+		machine = rz_str_dup("WCE Mips V2");
 		break;
 	default:
-		machine = strdup("unknown");
+		machine = rz_str_dup("unknown");
 	}
 	return machine;
 }
@@ -325,28 +325,28 @@ char *rz_bin_te_get_os(struct rz_bin_te_obj_t *bin) {
 
 	switch (bin->header->Subsystem) {
 	case TE_IMAGE_SUBSYSTEM_NATIVE:
-		os = strdup("native");
+		os = rz_str_dup("native");
 		break;
 	case TE_IMAGE_SUBSYSTEM_WINDOWS_GUI:
 	case TE_IMAGE_SUBSYSTEM_WINDOWS_CUI:
 	case TE_IMAGE_SUBSYSTEM_WINDOWS_CE_GUI:
-		os = strdup("windows");
+		os = rz_str_dup("windows");
 		break;
 	case TE_IMAGE_SUBSYSTEM_POSIX_CUI:
-		os = strdup("posix");
+		os = rz_str_dup("posix");
 		break;
 	case TE_IMAGE_SUBSYSTEM_EFI_APPLICATION:
 	case TE_IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER:
 	case TE_IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER:
 	case TE_IMAGE_SUBSYSTEM_EFI_ROM:
-		os = strdup("efi");
+		os = rz_str_dup("efi");
 		break;
 	case TE_IMAGE_SUBSYSTEM_XBOX:
-		os = strdup("xbox");
+		os = rz_str_dup("xbox");
 		break;
 	default:
 		// XXX: this is unknown
-		os = strdup("windows");
+		os = rz_str_dup("windows");
 	}
 	return os;
 }
@@ -388,37 +388,37 @@ char *rz_bin_te_get_subsystem(struct rz_bin_te_obj_t *bin) {
 	}
 	switch (bin->header->Subsystem) {
 	case TE_IMAGE_SUBSYSTEM_NATIVE:
-		subsystem = strdup("Native");
+		subsystem = rz_str_dup("Native");
 		break;
 	case TE_IMAGE_SUBSYSTEM_WINDOWS_GUI:
-		subsystem = strdup("Windows GUI");
+		subsystem = rz_str_dup("Windows GUI");
 		break;
 	case TE_IMAGE_SUBSYSTEM_WINDOWS_CUI:
-		subsystem = strdup("Windows CUI");
+		subsystem = rz_str_dup("Windows CUI");
 		break;
 	case TE_IMAGE_SUBSYSTEM_POSIX_CUI:
-		subsystem = strdup("POSIX CUI");
+		subsystem = rz_str_dup("POSIX CUI");
 		break;
 	case TE_IMAGE_SUBSYSTEM_WINDOWS_CE_GUI:
-		subsystem = strdup("Windows CE GUI");
+		subsystem = rz_str_dup("Windows CE GUI");
 		break;
 	case TE_IMAGE_SUBSYSTEM_EFI_APPLICATION:
-		subsystem = strdup("EFI Application");
+		subsystem = rz_str_dup("EFI Application");
 		break;
 	case TE_IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER:
-		subsystem = strdup("EFI Boot Service Driver");
+		subsystem = rz_str_dup("EFI Boot Service Driver");
 		break;
 	case TE_IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER:
-		subsystem = strdup("EFI Runtime Driver");
+		subsystem = rz_str_dup("EFI Runtime Driver");
 		break;
 	case TE_IMAGE_SUBSYSTEM_EFI_ROM:
-		subsystem = strdup("EFI ROM");
+		subsystem = rz_str_dup("EFI ROM");
 		break;
 	case TE_IMAGE_SUBSYSTEM_XBOX:
-		subsystem = strdup("XBOX");
+		subsystem = rz_str_dup("XBOX");
 		break;
 	default:
-		subsystem = strdup("Unknown");
+		subsystem = rz_str_dup("Unknown");
 	}
 	return subsystem;
 }

--- a/librz/bin/format/xnu/rz_cf_dict.c
+++ b/librz/bin/format/xnu/rz_cf_dict.c
@@ -567,7 +567,7 @@ static void rz_cf_value_string_free(RzCFValueString *string) {
 }
 
 static void rz_cf_value_string_print(RzCFValueString *string) {
-	char *escaped = strdup(string->value);
+	char *escaped = rz_str_dup(string->value);
 	escaped = rz_str_replace(escaped, "\"", "\\\"", 1);
 	printf("\"%s\"", escaped);
 	RZ_FREE(escaped);

--- a/librz/bin/p/bin_any.c
+++ b/librz/bin/p/bin_any.c
@@ -23,7 +23,7 @@ static char *get_filetype(RzBuffer *b) {
 	rz_buf_read_at(b, 0, buf, sizeof(buf));
 	tmp = rz_magic_buffer(ck, buf, sizeof(buf));
 	if (tmp) {
-		res = strdup(tmp);
+		res = rz_str_dup(tmp);
 	}
 	rz_magic_free(ck);
 	return res;
@@ -35,7 +35,7 @@ static RzBinInfo *info(RzBinFile *bf) {
 		return NULL;
 	}
 	ret->lang = "";
-	ret->file = bf->file ? strdup(bf->file) : NULL;
+	ret->file = rz_str_dup(bf->file);
 	ret->type = get_filetype(bf->buf);
 	ret->has_pi = 0;
 	ret->has_canary = 0;

--- a/librz/bin/p/bin_art.c
+++ b/librz/bin/p/bin_art.c
@@ -107,18 +107,18 @@ static RzBinInfo *info(RzBinFile *bf) {
 	}
 	ArtObj *ao = bf->o->bin_obj;
 	ret->lang = NULL;
-	ret->file = bf->file ? strdup(bf->file) : NULL;
-	ret->type = strdup("ART");
+	ret->file = rz_str_dup(bf->file);
+	ret->type = rz_str_dup("ART");
 
 	ret->bclass = malloc(5);
 	memcpy(ret->bclass, &ao->art.version, 4);
 	ret->bclass[3] = 0;
 
-	ret->rclass = strdup("program");
-	ret->os = strdup("android");
-	ret->subsystem = strdup("unknown");
-	ret->machine = strdup("arm");
-	ret->arch = strdup("arm");
+	ret->rclass = rz_str_dup("program");
+	ret->os = rz_str_dup("android");
+	ret->subsystem = rz_str_dup("unknown");
+	ret->machine = rz_str_dup("arm");
+	ret->arch = rz_str_dup("arm");
 	ret->has_va = 1;
 	ret->has_pi = ao->art.compile_pic;
 	ret->bits = 16; // 32? 64?
@@ -161,7 +161,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("load");
+	ptr->name = rz_str_dup("load");
 	ptr->size = rz_buf_size(bf->buf);
 	ptr->vsize = art.image_size; // TODO: align?
 	ptr->paddr = 0;
@@ -172,7 +172,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("bitmap");
+	ptr->name = rz_str_dup("bitmap");
 	ptr->size = art.bitmap_size;
 	ptr->vsize = art.bitmap_size;
 	ptr->paddr = art.bitmap_offset;
@@ -183,7 +183,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("oat");
+	ptr->name = rz_str_dup("oat");
 	ptr->paddr = art.bitmap_offset;
 	ptr->vaddr = art.oat_file_begin;
 	ptr->size = art.oat_file_end - art.oat_file_begin;
@@ -194,7 +194,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("oat_data");
+	ptr->name = rz_str_dup("oat_data");
 	ptr->paddr = art.bitmap_offset;
 	ptr->vaddr = art.oat_data_begin;
 	ptr->size = art.oat_data_end - art.oat_data_begin;

--- a/librz/bin/p/bin_avr.c
+++ b/librz/bin/p/bin_avr.c
@@ -128,12 +128,12 @@ static RzBinInfo *info(RzBinFile *bf) {
 	rz_return_val_if_fail(bf, NULL);
 	RzBinInfo *bi = RZ_NEW0(RzBinInfo);
 	if (bi) {
-		bi->file = strdup(bf->file);
-		bi->type = strdup("ROM");
-		bi->machine = strdup("ATmel");
-		bi->os = strdup("avr");
+		bi->file = rz_str_dup(bf->file);
+		bi->type = rz_str_dup("ROM");
+		bi->machine = rz_str_dup("ATmel");
+		bi->os = rz_str_dup("avr");
 		bi->has_va = 0; // 1;
-		bi->arch = strdup("avr");
+		bi->arch = rz_str_dup("avr");
 		bi->bits = 8;
 	}
 	return bi;
@@ -159,7 +159,7 @@ static RzPVector /*<RzBinAddr *>*/ *entries(RzBinFile *bf) {
 static void addsym(RzPVector /*<RzBinSymbol *>*/ *ret, const char *name, ut64 addr) {
 	RzBinSymbol *ptr = RZ_NEW0(RzBinSymbol);
 	if (ptr) {
-		ptr->name = strdup(name ? name : "");
+		ptr->name = rz_str_dup(name ? name : "");
 		ptr->paddr = ptr->vaddr = addr;
 		ptr->size = 0;
 		ptr->ordinal = 0;

--- a/librz/bin/p/bin_bf.c
+++ b/librz/bin/p/bin_bf.c
@@ -28,14 +28,14 @@ static RzBinInfo *info(RzBinFile *bf) {
 		return NULL;
 	}
 	ret->lang = NULL;
-	ret->file = bf->file ? strdup(bf->file) : NULL;
-	ret->type = strdup("brainfuck");
-	ret->bclass = strdup("1.0");
-	ret->rclass = strdup("program");
-	ret->os = strdup("any");
-	ret->subsystem = strdup("unknown");
-	ret->machine = strdup("brainfuck");
-	ret->arch = strdup("bf");
+	ret->file = rz_str_dup(bf->file);
+	ret->type = rz_str_dup("brainfuck");
+	ret->bclass = rz_str_dup("1.0");
+	ret->rclass = rz_str_dup("program");
+	ret->os = rz_str_dup("any");
+	ret->subsystem = rz_str_dup("unknown");
+	ret->machine = rz_str_dup("brainfuck");
+	ret->arch = rz_str_dup("bf");
 	ret->has_va = 1;
 	ret->bits = 64; // RzIL emulation of bf uses 64bit values
 	ret->big_endian = 0;
@@ -129,7 +129,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	map->psize = bf->size;
 	map->vsize = bf->size;
 	map->perm = RZ_PERM_RWX;
-	map->name = strdup("code");
+	map->name = rz_str_dup("code");
 	rz_pvector_push(ret, map);
 
 	map = RZ_NEW0(RzBinMap);
@@ -142,7 +142,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	map->psize = 0;
 	map->vsize = 30000;
 	map->perm = RZ_PERM_RW;
-	map->name = strdup("mem");
+	map->name = rz_str_dup("mem");
 	rz_pvector_push(ret, map);
 	return ret;
 }

--- a/librz/bin/p/bin_bflt.c
+++ b/librz/bin/p/bin_bflt.c
@@ -50,8 +50,8 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	map->psize = obj->hdr.data_start;
 	map->vsize = obj->hdr.data_start;
 	map->perm = RZ_PERM_RWX;
-	map->name = strdup("hdr+text");
-	map->vfile_name = obj->buf_patched ? strdup(VFILE_NAME_PATCHED) : NULL;
+	map->name = rz_str_dup("hdr+text");
+	map->vfile_name = obj->buf_patched ? rz_str_dup(VFILE_NAME_PATCHED) : NULL;
 	rz_pvector_push(ret, map);
 
 	map = RZ_NEW0(RzBinMap);
@@ -64,8 +64,8 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	map->psize = obj->hdr.data_end - obj->hdr.data_start;
 	map->vsize = rz_bflt_get_data_vsize(obj);
 	map->perm = RZ_PERM_RWX;
-	map->name = strdup("data+bss");
-	map->vfile_name = obj->buf_patched ? strdup(VFILE_NAME_PATCHED) : NULL;
+	map->name = rz_str_dup("data+bss");
+	map->vfile_name = obj->buf_patched ? rz_str_dup(VFILE_NAME_PATCHED) : NULL;
 	rz_pvector_push(ret, map);
 
 	return ret;
@@ -89,7 +89,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	sec->size = obj->hdr.data_start;
 	sec->vsize = obj->hdr.data_start;
 	sec->perm = RZ_PERM_RWX;
-	sec->name = strdup("TEXT");
+	sec->name = rz_str_dup("TEXT");
 	sec->is_segment = true;
 	rz_pvector_push(ret, sec);
 
@@ -102,7 +102,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	sec->size = obj->hdr.data_start;
 	sec->vsize = rz_bflt_get_data_vsize(obj);
 	sec->perm = RZ_PERM_RWX;
-	sec->name = strdup("DATA");
+	sec->name = rz_str_dup("DATA");
 	sec->is_segment = true;
 	rz_pvector_push(ret, sec);
 
@@ -117,7 +117,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	sec->size = BFLT_HDR_SIZE;
 	sec->vsize = BFLT_HDR_SIZE;
 	sec->perm = RZ_PERM_RWX;
-	sec->name = strdup("header");
+	sec->name = rz_str_dup("header");
 	rz_pvector_push(ret, sec);
 
 	sec = RZ_NEW0(RzBinSection);
@@ -129,7 +129,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	sec->size = obj->hdr.data_start - BFLT_HDR_SIZE;
 	sec->vsize = obj->hdr.data_start - BFLT_HDR_SIZE;
 	sec->perm = RZ_PERM_RWX;
-	sec->name = strdup("text");
+	sec->name = rz_str_dup("text");
 	rz_pvector_push(ret, sec);
 
 	sec = RZ_NEW0(RzBinSection);
@@ -141,7 +141,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	sec->size = obj->hdr.data_end - obj->hdr.data_start;
 	sec->vsize = obj->hdr.data_end - obj->hdr.data_start;
 	sec->perm = RZ_PERM_RWX;
-	sec->name = strdup("data");
+	sec->name = rz_str_dup("data");
 	sec->is_data = true;
 	rz_pvector_push(ret, sec);
 
@@ -154,7 +154,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	sec->size = 0;
 	sec->vsize = obj->hdr.bss_end - obj->hdr.data_end;
 	sec->perm = RZ_PERM_RWX;
-	sec->name = strdup("bss");
+	sec->name = rz_str_dup("bss");
 	sec->is_data = true;
 	rz_pvector_push(ret, sec);
 
@@ -176,7 +176,7 @@ static RzPVector /*<RzBinVirtualFile *>*/ *virtual_files(RzBinFile *bf) {
 			return r;
 		}
 		vf->buf = obj->buf_patched;
-		vf->name = strdup(VFILE_NAME_PATCHED);
+		vf->name = rz_str_dup(VFILE_NAME_PATCHED);
 		rz_pvector_push(r, vf);
 	}
 	return r;
@@ -222,18 +222,18 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!(info = RZ_NEW0(RzBinInfo))) {
 		return NULL;
 	}
-	info->file = bf->file ? strdup(bf->file) : NULL;
-	info->rclass = strdup("bflt");
-	info->bclass = strdup("bflt");
-	info->type = strdup("bFLT (Executable file)");
-	info->os = strdup("Linux");
-	info->subsystem = strdup("uClinux");
-	info->arch = strdup("arm"); // this is a wild guess, the format does not specify any arch, but arm is probably the most popular
+	info->file = rz_str_dup(bf->file);
+	info->rclass = rz_str_dup("bflt");
+	info->bclass = rz_str_dup("bflt");
+	info->type = rz_str_dup("bFLT (Executable file)");
+	info->os = rz_str_dup("Linux");
+	info->subsystem = rz_str_dup("uClinux");
+	info->arch = rz_str_dup("arm"); // this is a wild guess, the format does not specify any arch, but arm is probably the most popular
 	info->big_endian = obj->big_endian;
 	info->bits = 32;
 	info->has_va = true;
 	info->dbg_info = 0;
-	info->machine = strdup("unknown");
+	info->machine = rz_str_dup("unknown");
 	info->has_pi = true;
 	return info;
 }

--- a/librz/bin/p/bin_bios.c
+++ b/librz/bin/p/bin_bios.c
@@ -69,14 +69,14 @@ static RzBinInfo *info(RzBinFile *bf) {
 		return NULL;
 	}
 	ret->lang = NULL;
-	ret->file = bf->file ? strdup(bf->file) : NULL;
-	ret->type = strdup("bios");
-	ret->bclass = strdup("1.0");
-	ret->rclass = strdup("bios");
-	ret->os = strdup("any");
-	ret->subsystem = strdup("unknown");
-	ret->machine = strdup("pc");
-	ret->arch = strdup("x86");
+	ret->file = rz_str_dup(bf->file);
+	ret->type = rz_str_dup("bios");
+	ret->bclass = rz_str_dup("1.0");
+	ret->rclass = rz_str_dup("bios");
+	ret->os = rz_str_dup("any");
+	ret->subsystem = rz_str_dup("unknown");
+	ret->machine = rz_str_dup("pc");
+	ret->arch = rz_str_dup("x86");
 	ret->has_va = 1;
 	ret->bits = 16;
 	ret->big_endian = 0;
@@ -96,7 +96,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("bootblk"); // Maps to 0xF000:0000 segment
+	ptr->name = rz_str_dup("bootblk"); // Maps to 0xF000:0000 segment
 	ptr->vsize = ptr->size = 0x10000;
 	ptr->paddr = rz_buf_size(bf->buf) - ptr->size;
 	ptr->vaddr = 0xf0000;
@@ -107,7 +107,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
 			return ret;
 		}
-		ptr->name = strdup("_e000"); // Maps to 0xE000:0000 segment
+		ptr->name = rz_str_dup("_e000"); // Maps to 0xE000:0000 segment
 		ptr->vsize = ptr->size = 0x10000;
 		ptr->paddr = rz_buf_size(obj) - 2 * ptr->size;
 		ptr->vaddr = 0xe0000;

--- a/librz/bin/p/bin_bootimg.c
+++ b/librz/bin/p/bin_bootimg.c
@@ -131,18 +131,18 @@ static RzBinInfo *info(RzBinFile *bf) {
 	}
 
 	ret->lang = NULL;
-	ret->file = bf->file ? strdup(bf->file) : NULL;
-	ret->type = strdup("Android Boot Image");
-	ret->os = strdup("android");
-	ret->subsystem = strdup("unknown");
-	ret->machine = strdup("arm");
-	ret->arch = strdup("arm");
+	ret->file = rz_str_dup(bf->file);
+	ret->type = rz_str_dup("Android Boot Image");
+	ret->os = rz_str_dup("android");
+	ret->subsystem = rz_str_dup("unknown");
+	ret->machine = rz_str_dup("arm");
+	ret->arch = rz_str_dup("arm");
 	ret->has_va = 1;
 	ret->has_pi = 0;
 	ret->bits = 16;
 	ret->big_endian = 0;
 	ret->dbg_info = 0;
-	ret->rclass = strdup("image");
+	ret->rclass = rz_str_dup("image");
 	return ret;
 }
 
@@ -189,7 +189,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("header");
+	ptr->name = rz_str_dup("header");
 	ptr->size = sizeof(BootImage);
 	ptr->vsize = bi->page_size;
 	ptr->paddr = 0;
@@ -200,7 +200,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("kernel");
+	ptr->name = rz_str_dup("kernel");
 	ptr->size = bi->kernel_size;
 	ptr->vsize = ADD_REMAINDER(ptr->size, bi->page_size);
 	ptr->paddr = bi->page_size;
@@ -213,7 +213,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
 			return ret;
 		}
-		ptr->name = strdup("ramdisk");
+		ptr->name = rz_str_dup("ramdisk");
 		ptr->size = bi->ramdisk_size;
 		ptr->vsize = ADD_REMAINDER(bi->ramdisk_size, bi->page_size);
 		ptr->paddr = ROUND_DOWN(base, bi->page_size);
@@ -227,7 +227,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
 			return ret;
 		}
-		ptr->name = strdup("second");
+		ptr->name = rz_str_dup("second");
 		ptr->size = bi->second_size;
 		ptr->vsize = ADD_REMAINDER(bi->second_size, bi->page_size);
 		ptr->paddr = ROUND_DOWN(base, bi->page_size);

--- a/librz/bin/p/bin_coff.c
+++ b/librz/bin/p/bin_coff.c
@@ -204,7 +204,7 @@ static RzPVector /*<RzBinVirtualFile *>*/ *virtual_files(RzBinFile *bf) {
 		}
 		vf->buf = buf;
 		vf->buf_owned = true;
-		vf->name = strdup(VFILE_NAME_RELOC_TARGETS);
+		vf->name = rz_str_dup(VFILE_NAME_RELOC_TARGETS);
 		rz_pvector_push(r, vf);
 	}
 	// virtual file mirroring the raw file, but with relocs patched
@@ -215,7 +215,7 @@ static RzPVector /*<RzBinVirtualFile *>*/ *virtual_files(RzBinFile *bf) {
 			return r;
 		}
 		vf->buf = buf_patched;
-		vf->name = strdup(VFILE_NAME_PATCHED);
+		vf->name = rz_str_dup(VFILE_NAME_PATCHED);
 		rz_pvector_push(r, vf);
 	}
 	return r;
@@ -247,7 +247,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		}
 		ptr->perm = rz_coff_perms_from_section_flags(hdr->s_flags);
 		if (hdr->s_nreloc) {
-			ptr->vfile_name = strdup(VFILE_NAME_PATCHED);
+			ptr->vfile_name = rz_str_dup(VFILE_NAME_PATCHED);
 		}
 		rz_pvector_push(ret, ptr);
 	}
@@ -258,13 +258,13 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		if (!map) {
 			return ret;
 		}
-		map->name = strdup("reloc-targets");
+		map->name = rz_str_dup("reloc-targets");
 		map->paddr = 0;
 		map->psize = rtmsz;
 		map->vaddr = rz_coff_get_reloc_targets_map_base(obj);
 		map->vsize = rtmsz;
 		map->perm = RZ_PERM_R;
-		map->vfile_name = strdup(VFILE_NAME_RELOC_TARGETS);
+		map->vfile_name = rz_str_dup(VFILE_NAME_RELOC_TARGETS);
 		rz_pvector_push_front(ret, map);
 	}
 	return ret;
@@ -390,12 +390,12 @@ static RzBinInfo *info(RzBinFile *bf) {
 	RzBinInfo *ret = RZ_NEW0(RzBinInfo);
 	struct rz_bin_coff_obj *obj = (struct rz_bin_coff_obj *)bf->o->bin_obj;
 
-	ret->file = bf->file ? strdup(bf->file) : NULL;
-	ret->rclass = strdup("coff");
-	ret->bclass = strdup("coff");
-	ret->type = strdup("COFF (Executable file)");
-	ret->os = strdup("any");
-	ret->subsystem = strdup("any");
+	ret->file = rz_str_dup(bf->file);
+	ret->rclass = rz_str_dup("coff");
+	ret->bclass = rz_str_dup("coff");
+	ret->type = rz_str_dup("COFF (Executable file)");
+	ret->os = rz_str_dup("any");
+	ret->subsystem = rz_str_dup("any");
 	ret->big_endian = obj->endian;
 	ret->has_va = true;
 	ret->dbg_info = 0;
@@ -419,77 +419,77 @@ static RzBinInfo *info(RzBinFile *bf) {
 	case COFF_FILE_MACHINE_MIPS16:
 	case COFF_FILE_MACHINE_MIPSFPU:
 	case COFF_FILE_MACHINE_MIPSFPU16:
-		ret->machine = strdup("mips");
-		ret->arch = strdup("mips");
+		ret->machine = rz_str_dup("mips");
+		ret->arch = rz_str_dup("mips");
 		ret->bits = 32;
 		break;
 	case COFF_FILE_MACHINE_I386:
-		ret->machine = strdup("i386");
-		ret->arch = strdup("x86");
+		ret->machine = rz_str_dup("i386");
+		ret->arch = rz_str_dup("x86");
 		ret->bits = 32;
 		break;
 	case COFF_FILE_MACHINE_AMD64:
-		ret->machine = strdup("AMD64");
-		ret->arch = strdup("x86");
+		ret->machine = rz_str_dup("AMD64");
+		ret->arch = rz_str_dup("x86");
 		ret->bits = 64;
 		break;
 	case COFF_FILE_MACHINE_H8300:
-		ret->machine = strdup("H8300");
-		ret->arch = strdup("h8300");
+		ret->machine = rz_str_dup("H8300");
+		ret->arch = rz_str_dup("h8300");
 		ret->bits = 16;
 		break;
 	case COFF_FILE_MACHINE_AMD29KBE:
 	case COFF_FILE_MACHINE_AMD29KLE:
-		ret->cpu = strdup("29000");
-		ret->machine = strdup("amd29k");
-		ret->arch = strdup("amd29k");
+		ret->cpu = rz_str_dup("29000");
+		ret->machine = rz_str_dup("amd29k");
+		ret->arch = rz_str_dup("amd29k");
 		ret->bits = 32;
 		break;
 	case COFF_FILE_MACHINE_THUMB:
-		ret->machine = strdup("arm");
-		ret->arch = strdup("arm");
+		ret->machine = rz_str_dup("arm");
+		ret->arch = rz_str_dup("arm");
 		ret->bits = 16;
 		break;
 	case COFF_FILE_MACHINE_ARM:
 	case COFF_FILE_MACHINE_ARMNT:
-		ret->machine = strdup("arm");
-		ret->arch = strdup("arm");
+		ret->machine = rz_str_dup("arm");
+		ret->arch = rz_str_dup("arm");
 		ret->bits = 32;
 		break;
 	case COFF_FILE_MACHINE_ARM64:
-		ret->machine = strdup("arm");
-		ret->arch = strdup("arm");
+		ret->machine = rz_str_dup("arm");
+		ret->arch = rz_str_dup("arm");
 		ret->bits = 64;
 		break;
 	case COFF_FILE_MACHINE_SH3:
 	case COFF_FILE_MACHINE_SH3DSP:
 	case COFF_FILE_MACHINE_SH4:
 	case COFF_FILE_MACHINE_SH5:
-		ret->machine = strdup("sh");
-		ret->arch = strdup("sh");
+		ret->machine = rz_str_dup("sh");
+		ret->arch = rz_str_dup("sh");
 		ret->bits = 32;
 		break;
 	case COFF_FILE_TI_COFF:
 		switch (obj->target_id) {
 		case COFF_FILE_MACHINE_TMS320C54:
-			ret->machine = strdup("c54x");
-			ret->arch = strdup("tms320");
+			ret->machine = rz_str_dup("c54x");
+			ret->arch = rz_str_dup("tms320");
 			ret->bits = 32;
 			break;
 		case COFF_FILE_MACHINE_TMS320C55:
-			ret->machine = strdup("c55x");
-			ret->arch = strdup("tms320");
+			ret->machine = rz_str_dup("c55x");
+			ret->arch = rz_str_dup("tms320");
 			ret->bits = 32;
 			break;
 		case COFF_FILE_MACHINE_TMS320C55PLUS:
-			ret->machine = strdup("c55x+");
-			ret->arch = strdup("tms320");
+			ret->machine = rz_str_dup("c55x+");
+			ret->arch = rz_str_dup("tms320");
 			ret->bits = 32;
 			break;
 		}
 		break;
 	default:
-		ret->machine = strdup("unknown");
+		ret->machine = rz_str_dup("unknown");
 	}
 
 	return ret;

--- a/librz/bin/p/bin_dex.c
+++ b/librz/bin/p/bin_dex.c
@@ -19,15 +19,15 @@ static RzBinInfo *info(RzBinFile *bf) {
 	}
 
 	binfo->lang = "java";
-	binfo->file = strdup(bf->file);
-	binfo->type = strdup("DEX CLASS");
+	binfo->file = rz_str_dup(bf->file);
+	binfo->type = rz_str_dup("DEX CLASS");
 	binfo->bclass = rz_bin_dex_version(dex);
 	binfo->has_va = true;
-	binfo->rclass = strdup("class");
-	binfo->os = strdup("linux");
-	binfo->subsystem = strdup("any");
-	binfo->machine = strdup("Dalvik VM");
-	binfo->arch = strdup("dalvik");
+	binfo->rclass = rz_str_dup("class");
+	binfo->os = rz_str_dup("linux");
+	binfo->subsystem = rz_str_dup("any");
+	binfo->machine = rz_str_dup("Dalvik VM");
+	binfo->arch = rz_str_dup("dalvik");
 	binfo->bits = 32;
 	binfo->big_endian = false;
 	binfo->dbg_info = rz_bin_dex_debug_info(dex);
@@ -163,7 +163,7 @@ static RzPVector /*<RzBinVirtualFile *>*/ *virtual_files(RzBinFile *bf) {
 	}
 	vf->buf = buffer;
 	vf->buf_owned = false;
-	vf->name = strdup(RZ_DEX_RELOC_TARGETS);
+	vf->name = rz_str_dup(RZ_DEX_RELOC_TARGETS);
 
 	rz_pvector_push(vfiles, vf);
 	return vfiles;
@@ -224,7 +224,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		if (strcmp(map->name, RZ_DEX_RELOC_TARGETS)) {
 			continue;
 		}
-		map->vfile_name = strdup(RZ_DEX_RELOC_TARGETS);
+		map->vfile_name = rz_str_dup(RZ_DEX_RELOC_TARGETS);
 	}
 	return maps;
 }

--- a/librz/bin/p/bin_dmp64.c
+++ b/librz/bin/p/bin_dmp64.c
@@ -151,11 +151,11 @@ static RzBinInfo *info(RzBinFile *bf) {
 	}
 	struct rz_bin_dmp64_obj_t *obj = (struct rz_bin_dmp64_obj_t *)bf->o->bin_obj;
 
-	ret->arch = obj->header->MachineImageType == 0xaa64 ? strdup("arm") : strdup("x86");
+	ret->arch = obj->header->MachineImageType == 0xaa64 ? rz_str_dup("arm") : rz_str_dup("x86");
 	ret->bits = 64;
-	ret->machine = obj->header->MachineImageType == 0xaa64 ? strdup("ARM64") : strdup("AMD64");
-	ret->rclass = strdup("dmp64");
-	ret->type = strdup("Windows Crash Dump");
+	ret->machine = obj->header->MachineImageType == 0xaa64 ? rz_str_dup("ARM64") : rz_str_dup("AMD64");
+	ret->rclass = rz_str_dup("dmp64");
+	ret->type = rz_str_dup("Windows Crash Dump");
 	ret->has_va = true;
 
 	switch (obj->header->ProductType) {
@@ -175,7 +175,7 @@ static RzBinInfo *info(RzBinFile *bf) {
 			obj->header->MinorVersion);
 		break;
 	default:
-		ret->os = strdup("Unknown");
+		ret->os = rz_str_dup("Unknown");
 	}
 
 	return ret;
@@ -232,7 +232,7 @@ static RzPVector /*<char *>*/ *libs(RzBinFile *bf) {
 	RzListIter *it;
 	dmp_driver_desc *driver;
 	rz_list_foreach (obj->drivers, it, driver) {
-		char *file = strdup(driver->file);
+		char *file = rz_str_dup(driver->file);
 		if (!file) {
 			break;
 		}

--- a/librz/bin/p/bin_dol.c
+++ b/librz/bin/p/bin_dol.c
@@ -62,7 +62,7 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb
 	if (!dol) {
 		return false;
 	}
-	char *lowername = strdup(bf->file);
+	char *lowername = rz_str_dup(bf->file);
 	if (!lowername) {
 		goto dol_err;
 	}
@@ -123,7 +123,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	}
 	/* bss section */
 	s = RZ_NEW0(RzBinSection);
-	s->name = strdup("bss");
+	s->name = rz_str_dup("bss");
 	s->paddr = 0;
 	s->vaddr = dol->bss_addr;
 	s->size = dol->bss_size;
@@ -151,12 +151,12 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!ret) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
+	ret->file = rz_str_dup(bf->file);
 	ret->big_endian = true;
-	ret->type = strdup("ROM");
-	ret->machine = strdup("Nintendo Wii");
-	ret->os = strdup("wii-ios");
-	ret->arch = strdup("ppc");
+	ret->type = rz_str_dup("ROM");
+	ret->machine = rz_str_dup("Nintendo Wii");
+	ret->os = rz_str_dup("wii-ios");
+	ret->arch = rz_str_dup("ppc");
 	ret->has_va = true;
 	ret->bits = 32;
 

--- a/librz/bin/p/bin_dyldcache.c
+++ b/librz/bin/p/bin_dyldcache.c
@@ -109,20 +109,20 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!(ret = RZ_NEW0(RzBinInfo))) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->bclass = strdup("dyldcache");
-	ret->os = strdup(rz_dyldcache_get_platform_str(cache));
+	ret->file = rz_str_dup(bf->file);
+	ret->bclass = rz_str_dup("dyldcache");
+	ret->os = rz_str_dup(rz_dyldcache_get_platform_str(cache));
 	if (strstr(cache->hdr->magic, "x86_64")) {
-		ret->arch = strdup("x86");
+		ret->arch = rz_str_dup("x86");
 		ret->bits = 64;
 	} else {
-		ret->arch = strdup("arm");
+		ret->arch = rz_str_dup("arm");
 		ret->bits = strstr(cache->hdr->magic, "arm64") ? 64 : 32;
 	}
-	ret->machine = strdup(ret->arch);
-	ret->subsystem = strdup("xnu");
+	ret->machine = rz_str_dup(ret->arch);
+	ret->subsystem = rz_str_dup("xnu");
 	ret->guid = rz_hex_bin2strdup((ut8 *)cache->hdr->uuid, sizeof(cache->hdr->uuid));
-	ret->type = strdup(rz_dyldcache_get_type_str(cache));
+	ret->type = rz_str_dup(rz_dyldcache_get_type_str(cache));
 	ret->has_va = true;
 	ret->big_endian = big_endian;
 	ret->dbg_info = 0;
@@ -156,7 +156,7 @@ void symbols_from_bin(RzDyldCache *cache, RzPVector /*<RzBinSymbol *>*/ *ret, Rz
 		if (!sym) {
 			break;
 		}
-		sym->name = strdup(symbols[i].name);
+		sym->name = rz_str_dup(symbols[i].name);
 		sym->vaddr = symbols[i].addr;
 		sym->forwarder = "NONE";
 		sym->bind = (symbols[i].type == RZ_BIN_MACH0_SYMBOL_TYPE_LOCAL) ? RZ_BIN_BIND_LOCAL_STR : RZ_BIN_BIND_GLOBAL_STR;
@@ -251,7 +251,7 @@ static RzPVector /*<RzBinVirtualFile *>*/ *virtual_files(RzBinFile *bf) {
 		}
 		vf->buf = rz_dyldcache_new_rebasing_buf(cache);
 		vf->buf_owned = true;
-		vf->name = strdup(RZ_DYLDCACHE_VFILE_NAME_REBASED);
+		vf->name = rz_str_dup(RZ_DYLDCACHE_VFILE_NAME_REBASED);
 		rz_pvector_push(ret, vf);
 	}
 	return ret;
@@ -294,7 +294,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		map->vaddr = cache->maps[i].address + slide;
 		map->perm = prot2perm(cache->maps[i].initProt);
 		if (rz_dyldcache_range_needs_rebasing(cache, map->paddr, map->psize)) {
-			map->vfile_name = strdup(RZ_DYLDCACHE_VFILE_NAME_REBASED);
+			map->vfile_name = rz_str_dup(RZ_DYLDCACHE_VFILE_NAME_REBASED);
 		}
 		rz_pvector_push(ret, map);
 	}

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -577,17 +577,17 @@ static char *setphname(ut16 mach, Elf_(Word) ptyp) {
 	// TODO to complete over time
 	if (mach == EM_ARM) {
 		if (ptyp == SHT_ARM_EXIDX) {
-			return strdup("EXIDX");
+			return rz_str_dup("EXIDX");
 		}
 	} else if (mach == EM_MIPS) {
 		if (ptyp == PT_MIPS_ABIFLAGS) {
-			return strdup("ABIFLAGS");
+			return rz_str_dup("ABIFLAGS");
 		} else if (ptyp == PT_MIPS_REGINFO) {
-			return strdup("REGINFO");
+			return rz_str_dup("REGINFO");
 		}
 	}
 
-	return strdup("UNKNOWN");
+	return rz_str_dup("UNKNOWN");
 }
 
 static bool is_wordable_section(const char *name) {
@@ -683,11 +683,11 @@ static RzPVector /*<RzBinMap *>*/ *maps_unpatched(RzBinFile *bf) {
 
 			// map names specific to core files...
 			if (core_sp != UT64_MAX && core_sp >= iter->data.p_vaddr && core_sp < iter->data.p_vaddr + iter->data.p_memsz) {
-				map->name = strdup("[stack]");
+				map->name = rz_str_dup("[stack]");
 			} else {
 				RzBinElfNoteFile *nf = note_file_for_load_segment(obj, &iter->data);
 				if (nf && nf->file) {
-					map->name = strdup(nf->file);
+					map->name = rz_str_dup(nf->file);
 				}
 			}
 			// generic names
@@ -722,7 +722,7 @@ static RzPVector /*<RzBinMap *>*/ *maps_unpatched(RzBinFile *bf) {
 		if (!map) {
 			return ret;
 		}
-		map->name = strdup("uphdr");
+		map->name = rz_str_dup("uphdr");
 		map->paddr = 0;
 		map->psize = bf->size;
 		map->vaddr = 0x10000;
@@ -740,7 +740,7 @@ static RzPVector /*<RzBinMap *>*/ *maps_unpatched(RzBinFile *bf) {
 		if (bf->size < ehdr_size) {
 			ehdr_size = bf->size;
 		}
-		map->name = strdup("ehdr");
+		map->name = rz_str_dup("ehdr");
 		map->paddr = 0;
 		map->psize = ehdr_size;
 		map->vaddr = obj->baddr;
@@ -1636,7 +1636,7 @@ static RzPVector /*<RzBinVirtualFile *>*/ *virtual_files(RzBinFile *bf) {
 		}
 		vf->buf = buf;
 		vf->buf_owned = true;
-		vf->name = strdup(VFILE_NAME_RELOC_TARGETS);
+		vf->name = rz_str_dup(VFILE_NAME_RELOC_TARGETS);
 		rz_pvector_push(r, vf);
 	}
 	// virtual file mirroring the raw file, but with relocs patched
@@ -1646,7 +1646,7 @@ static RzPVector /*<RzBinVirtualFile *>*/ *virtual_files(RzBinFile *bf) {
 			return r;
 		}
 		vf->buf = obj->buf_patched;
-		vf->name = strdup(VFILE_NAME_PATCHED);
+		vf->name = rz_str_dup(VFILE_NAME_PATCHED);
 		rz_pvector_push(r, vf);
 	}
 	return r;
@@ -1730,7 +1730,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 
 		switch (iter->data.p_type) {
 		case PT_DYNAMIC:
-			ptr->name = strdup("DYNAMIC");
+			ptr->name = rz_str_dup("DYNAMIC");
 			break;
 		case PT_LOAD: {
 			ptr->name = rz_str_newf("LOAD%zu", n++);
@@ -1738,41 +1738,41 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 			break;
 		}
 		case PT_INTERP:
-			ptr->name = strdup("INTERP");
+			ptr->name = rz_str_dup("INTERP");
 			break;
 		case PT_GNU_STACK:
-			ptr->name = strdup("GNU_STACK");
+			ptr->name = rz_str_dup("GNU_STACK");
 			break;
 		case PT_GNU_RELRO:
-			ptr->name = strdup("GNU_RELRO");
+			ptr->name = rz_str_dup("GNU_RELRO");
 			break;
 		case PT_GNU_EH_FRAME:
-			ptr->name = strdup("GNU_EH_FRAME");
+			ptr->name = rz_str_dup("GNU_EH_FRAME");
 			break;
 		case PT_PHDR:
-			ptr->name = strdup("PHDR");
+			ptr->name = rz_str_dup("PHDR");
 			break;
 		case PT_TLS:
-			ptr->name = strdup("TLS");
+			ptr->name = rz_str_dup("TLS");
 			break;
 		case PT_NOTE:
-			ptr->name = strdup("NOTE");
+			ptr->name = rz_str_dup("NOTE");
 			break;
 		case PT_OPENBSD_RANDOMIZE:
-			ptr->name = strdup("OPENBSD_RANDOMIZE");
+			ptr->name = rz_str_dup("OPENBSD_RANDOMIZE");
 			break;
 		case PT_OPENBSD_WXNEEDED:
-			ptr->name = strdup("OPENBSD_WXNEEDED");
+			ptr->name = rz_str_dup("OPENBSD_WXNEEDED");
 			break;
 		case PT_OPENBSD_BOOTDATA:
-			ptr->name = strdup("OPENBSD_BOOTDATA");
+			ptr->name = rz_str_dup("OPENBSD_BOOTDATA");
 			break;
 		case PT_OPENBSD_NOBTCFI:
-			ptr->name = strdup("OPENBSD_NOBTCFI");
+			ptr->name = rz_str_dup("OPENBSD_NOBTCFI");
 			break;
 		default:
 			if (ptr->size == 0 && ptr->vsize == 0) {
-				ptr->name = strdup("NONE");
+				ptr->name = rz_str_dup("NONE");
 			} else {
 				ptr->name = setphname(mach, iter->data.p_type);
 			}
@@ -1788,7 +1788,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		if (bf->size < ehdr_size) {
 			ehdr_size = bf->size;
 		}
-		ptr->name = strdup("ehdr");
+		ptr->name = rz_str_dup("ehdr");
 		ptr->paddr = 0;
 		ptr->vaddr = obj->baddr;
 		ptr->size = ehdr_size;
@@ -1983,15 +1983,13 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!(ret = RZ_NEW0(RzBinInfo))) {
 		return NULL;
 	}
-	ret->file = bf->file
-		? strdup(bf->file)
-		: NULL;
+	ret->file = rz_str_dup(bf->file);
 	ELFOBJ *obj = bf->o->bin_obj;
 	if ((str = Elf_(rz_bin_elf_get_rpath)(obj))) {
-		ret->rpath = strdup(str);
+		ret->rpath = rz_str_dup(str);
 		free(str);
 	} else {
-		ret->rpath = strdup("NONE");
+		ret->rpath = rz_str_dup("NONE");
 	}
 	if (!(str = Elf_(rz_bin_elf_get_file_type)(obj))) {
 		free(ret);
@@ -2038,7 +2036,7 @@ static RzBinInfo *info(RzBinFile *bf) {
 		ret->features = str;
 	}
 
-	ret->rclass = strdup("elf");
+	ret->rclass = rz_str_dup("elf");
 	ret->bits = obj->bits;
 	if (!strcmp(ret->arch, "avr")) {
 		ret->bits = 16;

--- a/librz/bin/p/bin_java.c
+++ b/librz/bin/p/bin_java.c
@@ -22,15 +22,15 @@ static RzBinInfo *info(RzBinFile *bf) {
 		return NULL;
 	}
 	binfo->lang = rz_bin_java_class_language(jclass);
-	binfo->file = strdup(bf->file);
-	binfo->type = strdup("JAVA CLASS");
+	binfo->file = rz_str_dup(bf->file);
+	binfo->type = rz_str_dup("JAVA CLASS");
 	binfo->bclass = rz_bin_java_class_version(jclass);
 	binfo->has_va = false;
-	binfo->rclass = strdup("class");
-	binfo->os = strdup("any");
-	binfo->subsystem = strdup("any");
-	binfo->machine = strdup("jvm");
-	binfo->arch = strdup("java");
+	binfo->rclass = rz_str_dup("class");
+	binfo->os = rz_str_dup("any");
+	binfo->subsystem = rz_str_dup("any");
+	binfo->machine = rz_str_dup("jvm");
+	binfo->arch = rz_str_dup("java");
 	binfo->bits = 32;
 	binfo->big_endian = true;
 	binfo->dbg_info = rz_bin_java_class_debug_info(jclass);

--- a/librz/bin/p/bin_le.c
+++ b/librz/bin/p/bin_le.c
@@ -13,11 +13,11 @@ static RzBinInfo *le_info(RzBinFile *bf) {
 	rz_bin_le_obj_t *bin = bf->o->bin_obj;
 	LE_header *h = bin->header;
 	info->bits = 32;
-	info->type = strdup(bin->type);
-	info->cpu = strdup(bin->cpu);
-	info->os = strdup(bin->os);
-	info->arch = strdup(bin->arch);
-	info->file = strdup(bin->modname ? bin->modname : "");
+	info->type = rz_str_dup(bin->type);
+	info->cpu = rz_str_dup(bin->cpu);
+	info->os = rz_str_dup(bin->os);
+	info->arch = rz_str_dup(bin->arch);
+	info->file = rz_str_dup(bin->modname ? bin->modname : "");
 	info->big_endian = h->border || h->worder;
 	info->has_va = true;
 	info->baddr = 0;

--- a/librz/bin/p/bin_mach0.c
+++ b/librz/bin/p/bin_mach0.c
@@ -217,7 +217,7 @@ static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSymbol))) {
 			break;
 		}
-		ptr->name = strdup((char *)syms[i].name);
+		ptr->name = rz_str_dup((char *)syms[i].name);
 		ptr->is_imported = syms[i].is_imported;
 		ptr->forwarder = "NONE";
 		ptr->bind = (syms[i].type == RZ_BIN_MACH0_SYMBOL_TYPE_LOCAL) ? RZ_BIN_BIND_LOCAL_STR : RZ_BIN_BIND_GLOBAL_STR;
@@ -306,7 +306,7 @@ static RzBinImport *import_from_name(RzBin *rbin, const char *orig_name, HtPP *i
 	if (*name == '_') {
 		name++;
 	}
-	ptr->name = strdup(name);
+	ptr->name = rz_str_dup(name);
 	ptr->bind = "NONE";
 	ptr->type = rz_str_constpool_get(&rbin->constpool, type);
 
@@ -433,7 +433,7 @@ static RzPVector /*<char *>*/ *libs(RzBinFile *bf) {
 	}
 	if ((libs = MACH0_(get_libs)(obj->bin_obj))) {
 		for (i = 0; !libs[i].last; i++) {
-			ptr = strdup(libs[i].name);
+			ptr = rz_str_dup(libs[i].name);
 			rz_pvector_push(ret, ptr);
 		}
 		free(libs);
@@ -453,7 +453,7 @@ static RzBinInfo *info(RzBinFile *bf) {
 
 	bin = bf->o->bin_obj;
 	if (bf->file) {
-		ret->file = strdup(bf->file);
+		ret->file = rz_str_dup(bf->file);
 	}
 	if ((str = MACH0_(get_class)(bf->o->bin_obj))) {
 		ret->bclass = str;
@@ -467,10 +467,10 @@ static RzBinInfo *info(RzBinFile *bf) {
 	}
 	ret->intrp = rz_str_dup(MACH0_(get_intrp)(bf->o->bin_obj));
 	ret->compiler = rz_str_dup("");
-	ret->rclass = strdup("mach0");
-	ret->os = strdup("darwin");
-	ret->subsystem = strdup(MACH0_(get_platform)(bf->o->bin_obj));
-	ret->arch = strdup(MACH0_(get_cputype)(bf->o->bin_obj));
+	ret->rclass = rz_str_dup("mach0");
+	ret->os = rz_str_dup("darwin");
+	ret->subsystem = rz_str_dup(MACH0_(get_platform)(bf->o->bin_obj));
+	ret->arch = rz_str_dup(MACH0_(get_cputype)(bf->o->bin_obj));
 	ret->machine = MACH0_(get_cpusubtype)(bf->o->bin_obj);
 	ret->type = MACH0_(get_filetype)(bf->o->bin_obj);
 	ret->big_endian = MACH0_(is_big_endian)(bf->o->bin_obj);

--- a/librz/bin/p/bin_mbn.c
+++ b/librz/bin/p/bin_mbn.c
@@ -111,7 +111,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("text");
+	ptr->name = rz_str_dup("text");
 	ptr->size = sb->psize;
 	ptr->vsize = sb->psize;
 	ptr->paddr = sb->paddr + 40;
@@ -123,7 +123,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("sign");
+	ptr->name = rz_str_dup("sign");
 	ptr->size = sb->sign_sz;
 	ptr->vsize = sb->sign_sz;
 	ptr->paddr = sb->sign_va - sb->vaddr;
@@ -136,7 +136,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
 			return ret;
 		}
-		ptr->name = strdup("cert");
+		ptr->name = rz_str_dup("cert");
 		ptr->size = sb->cert_sz;
 		ptr->vsize = sb->cert_sz;
 		ptr->paddr = sb->cert_va - sb->vaddr;
@@ -154,14 +154,14 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!(ret = RZ_NEW0(RzBinInfo))) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->bclass = strdup("bootloader");
-	ret->rclass = strdup("mbn");
-	ret->os = strdup("MBN");
-	ret->arch = strdup("arm");
-	ret->machine = strdup(ret->arch);
-	ret->subsystem = strdup("mbn");
-	ret->type = strdup("sbl"); // secondary boot loader
+	ret->file = rz_str_dup(bf->file);
+	ret->bclass = rz_str_dup("bootloader");
+	ret->rclass = rz_str_dup("mbn");
+	ret->os = rz_str_dup("MBN");
+	ret->arch = rz_str_dup("arm");
+	ret->machine = rz_str_dup(ret->arch);
+	ret->subsystem = rz_str_dup("mbn");
+	ret->type = rz_str_dup("sbl"); // secondary boot loader
 	ret->bits = bits;
 	ret->has_va = true;
 	ret->has_crypto = true; // must be false if there' no sign or cert sections

--- a/librz/bin/p/bin_mdmp.c
+++ b/librz/bin/p/bin_mdmp.c
@@ -60,11 +60,11 @@ static RzBinInfo *mdmp_info(RzBinFile *bf) {
 
 	ret->big_endian = false;
 	ret->claimed_checksum = rz_str_newf("0x%08x", obj->hdr->check_sum);
-	ret->file = bf->file ? strdup(bf->file) : NULL;
+	ret->file = rz_str_dup(bf->file);
 	ret->has_va = true;
-	ret->rclass = strdup("mdmp");
-	ret->rpath = strdup("NONE");
-	ret->type = strdup("MDMP (MiniDump crash report data)");
+	ret->rclass = rz_str_dup("mdmp");
+	ret->rpath = rz_str_dup("NONE");
+	ret->type = rz_str_dup("MDMP (MiniDump crash report data)");
 
 	sdb_set(bf->sdb, "mdmp.flags", rz_strf(tmpbuf, "0x%08" PFMT64x, obj->hdr->flags));
 	sdb_num_set(bf->sdb, "mdmp.streams", obj->hdr->number_of_streams);
@@ -72,26 +72,26 @@ static RzBinInfo *mdmp_info(RzBinFile *bf) {
 	if (obj->streams.system_info) {
 		switch (obj->streams.system_info->processor_architecture) {
 		case MDMP_PROCESSOR_ARCHITECTURE_INTEL:
-			ret->machine = strdup("i386");
-			ret->arch = strdup("x86");
+			ret->machine = rz_str_dup("i386");
+			ret->arch = rz_str_dup("x86");
 			ret->bits = 32;
 			break;
 		case MDMP_PROCESSOR_ARCHITECTURE_ARM:
-			ret->machine = strdup("ARM");
+			ret->machine = rz_str_dup("ARM");
 			ret->big_endian = false;
 			break;
 		case MDMP_PROCESSOR_ARCHITECTURE_IA64:
-			ret->machine = strdup("IA64");
-			ret->arch = strdup("IA64");
+			ret->machine = rz_str_dup("IA64");
+			ret->arch = rz_str_dup("IA64");
 			ret->bits = 64;
 			break;
 		case MDMP_PROCESSOR_ARCHITECTURE_AMD64:
-			ret->machine = strdup("AMD64");
-			ret->arch = strdup("x86");
+			ret->machine = rz_str_dup("AMD64");
+			ret->arch = rz_str_dup("x86");
 			ret->bits = 64;
 			break;
 		default:
-			ret->machine = strdup("Unknown");
+			ret->machine = rz_str_dup("Unknown");
 			break;
 		}
 
@@ -115,7 +115,7 @@ static RzBinInfo *mdmp_info(RzBinFile *bf) {
 				obj->streams.system_info->build_number);
 			break;
 		default:
-			ret->os = strdup("Unknown");
+			ret->os = rz_str_dup("Unknown");
 		}
 	}
 

--- a/librz/bin/p/bin_menuet.c
+++ b/librz/bin/p/bin_menuet.c
@@ -124,7 +124,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("text");
+	ptr->name = rz_str_dup("text");
 	ptr->size = rz_read_ble32(buf + 16, false);
 	ptr->vsize = ptr->size + (ptr->size % 4096);
 	ptr->paddr = rz_read_ble32(buf + 12, false);
@@ -137,7 +137,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
 			return ret;
 		}
-		ptr->name = strdup("idata");
+		ptr->name = rz_str_dup("idata");
 		const ut32 idata_start = rz_read_ble32(buf + 40, false);
 		const ut32 idata_end = rz_read_ble32(buf + 44, false);
 		ptr->size = idata_end - idata_start;
@@ -154,14 +154,14 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 static RzBinInfo *info(RzBinFile *bf) {
 	RzBinInfo *ret = RZ_NEW0(RzBinInfo);
 	if (ret) {
-		ret->file = strdup(bf->file);
-		ret->bclass = strdup("program");
-		ret->rclass = strdup("menuet");
-		ret->os = strdup("MenuetOS");
-		ret->arch = strdup("x86");
-		ret->machine = strdup(ret->arch);
-		ret->subsystem = strdup("kolibri");
-		ret->type = strdup("EXEC");
+		ret->file = rz_str_dup(bf->file);
+		ret->bclass = rz_str_dup("program");
+		ret->rclass = rz_str_dup("menuet");
+		ret->os = rz_str_dup("MenuetOS");
+		ret->arch = rz_str_dup("x86");
+		ret->machine = rz_str_dup(ret->arch);
+		ret->subsystem = rz_str_dup("kolibri");
+		ret->type = rz_str_dup("EXEC");
 		ret->bits = 32;
 		ret->has_va = true;
 		ret->big_endian = 0;

--- a/librz/bin/p/bin_mz.c
+++ b/librz/bin/p/bin_mz.c
@@ -171,14 +171,14 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!ret) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->bclass = strdup("MZ");
-	ret->rclass = strdup("mz");
-	ret->os = strdup("DOS");
-	ret->arch = strdup("x86");
-	ret->machine = strdup("i386");
-	ret->type = strdup("EXEC (Executable file)");
-	ret->subsystem = strdup("DOS");
+	ret->file = rz_str_dup(bf->file);
+	ret->bclass = rz_str_dup("MZ");
+	ret->rclass = rz_str_dup("mz");
+	ret->os = rz_str_dup("DOS");
+	ret->arch = rz_str_dup("x86");
+	ret->machine = rz_str_dup("i386");
+	ret->type = rz_str_dup("EXEC (Executable file)");
+	ret->subsystem = rz_str_dup("DOS");
 	ret->bits = 16;
 	ret->dbg_info = 0;
 	ret->big_endian = false;

--- a/librz/bin/p/bin_ne.c
+++ b/librz/bin/p/bin_ne.c
@@ -88,8 +88,8 @@ RzBinInfo *info(RzBinFile *bf) {
 	RzBinInfo *i = RZ_NEW0(RzBinInfo);
 	if (i) {
 		i->bits = 16;
-		i->arch = strdup("x86");
-		i->os = strdup(ne->os);
+		i->arch = rz_str_dup("x86");
+		i->os = rz_str_dup(ne->os);
 		i->claimed_checksum = rz_str_newf("%08x", ne->ne_header->FileLoadCRC);
 	}
 	return i;

--- a/librz/bin/p/bin_nes.c
+++ b/librz/bin/p/bin_nes.c
@@ -30,11 +30,11 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!(ret = RZ_NEW0(RzBinInfo))) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->type = strdup("ROM");
-	ret->machine = strdup("Nintendo NES");
-	ret->os = strdup("nes");
-	ret->arch = strdup("6502");
+	ret->file = rz_str_dup(bf->file);
+	ret->type = rz_str_dup("ROM");
+	ret->machine = rz_str_dup("Nintendo NES");
+	ret->os = rz_str_dup("nes");
+	ret->arch = rz_str_dup("6502");
 	ret->bits = 8;
 	ret->has_va = 1;
 	return ret;
@@ -45,7 +45,7 @@ static void addsym(RzPVector /*<RzBinSymbol *>*/ *ret, const char *name, ut64 ad
 	if (!ptr) {
 		return;
 	}
-	ptr->name = strdup(name ? name : "");
+	ptr->name = rz_str_dup(name ? name : "");
 	ptr->paddr = ptr->vaddr = addr;
 	ptr->size = size;
 	ptr->ordinal = 0;
@@ -98,7 +98,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("ROM");
+	ptr->name = rz_str_dup("ROM");
 	ptr->paddr = INES_HDR_SIZE;
 	ptr->size = ihdr.prg_page_count_16k * PRG_PAGE_SIZE;
 	bool mirror = ROM_START_ADDRESS + ptr->size <= ROM_MIRROR_ADDRESS; // not a 256bit ROM, mapper 0 mirrors the complete ROM in this case
@@ -110,7 +110,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
 			return ret;
 		}
-		ptr->name = strdup("ROM_MIRROR");
+		ptr->name = rz_str_dup("ROM_MIRROR");
 		ptr->paddr = INES_HDR_SIZE;
 		ptr->size = ihdr.prg_page_count_16k * PRG_PAGE_SIZE;
 		ptr->vaddr = ROM_MIRROR_ADDRESS;
@@ -131,7 +131,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	m->name = strdup("RAM");
+	m->name = rz_str_dup("RAM");
 	m->addr = RAM_START_ADDRESS;
 	m->size = RAM_SIZE;
 	m->perms = rz_str_rwx("rwx");
@@ -140,7 +140,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 		return ret;
 	}
 	m->mirrors = rz_pvector_new(rz_bin_mem_free);
-	n->name = strdup("RAM_MIRROR_2");
+	n->name = rz_str_dup("RAM_MIRROR_2");
 	n->addr = RAM_MIRROR_2_ADDRESS;
 	n->size = RAM_MIRROR_2_SIZE;
 	n->perms = rz_str_rwx("rwx");
@@ -150,7 +150,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 		m->mirrors = NULL;
 		return ret;
 	}
-	n->name = strdup("RAM_MIRROR_3");
+	n->name = rz_str_dup("RAM_MIRROR_3");
 	n->addr = RAM_MIRROR_3_ADDRESS;
 	n->size = RAM_MIRROR_3_SIZE;
 	n->perms = rz_str_rwx("rwx");
@@ -159,7 +159,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	m->name = strdup("PPU_REG");
+	m->name = rz_str_dup("PPU_REG");
 	m->addr = PPU_REG_ADDRESS;
 	m->size = PPU_REG_SIZE;
 	m->perms = rz_str_rwx("rwx");
@@ -182,7 +182,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	m->name = strdup("APU_AND_IOREGS");
+	m->name = rz_str_dup("APU_AND_IOREGS");
 	m->addr = APU_AND_IOREGS_START_ADDRESS;
 	m->size = APU_AND_IOREGS_SIZE;
 	m->perms = rz_str_rwx("rwx");
@@ -191,7 +191,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	m->name = strdup("SRAM");
+	m->name = rz_str_dup("SRAM");
 	m->addr = SRAM_START_ADDRESS;
 	m->size = SRAM_SIZE;
 	m->perms = rz_str_rwx("rwx");

--- a/librz/bin/p/bin_nin3ds.c
+++ b/librz/bin/p/bin_nin3ds.c
@@ -101,13 +101,13 @@ static void n3ds_destroy(RzBinFile *bf) {
 static char *n3ds_section_name(N3DSFirmSectHdr *shdr) {
 	switch (shdr->type) {
 	case N3DS_TYPE_ARM9:
-		return strdup(N3DS_STR_ARM9);
+		return rz_str_dup(N3DS_STR_ARM9);
 	case N3DS_TYPE_ARM11:
-		return strdup(N3DS_STR_ARM11);
+		return rz_str_dup(N3DS_STR_ARM11);
 	case N3DS_TYPE_SYSMODULE:
-		return strdup(N3DS_STR_SYSMODULE);
+		return rz_str_dup(N3DS_STR_SYSMODULE);
 	case N3DS_TYPE_K11_EXT:
-		return strdup(N3DS_STR_K11_EXT);
+		return rz_str_dup(N3DS_STR_K11_EXT);
 	default:
 		return rz_str_newf("section_%x", shdr->address);
 	}
@@ -211,10 +211,10 @@ static RzBinInfo *n3ds_info(RzBinFile *bf) {
 		return NULL;
 	}
 
-	ret->type = strdup("FIRM");
-	ret->machine = strdup("Nintendo 3DS");
-	ret->os = strdup("n3ds");
-	ret->arch = strdup("arm");
+	ret->type = rz_str_dup("FIRM");
+	ret->machine = rz_str_dup("Nintendo 3DS");
+	ret->os = rz_str_dup("n3ds");
+	ret->arch = rz_str_dup("arm");
 	ret->has_va = true;
 	ret->bits = 32;
 	return ret;
@@ -225,7 +225,7 @@ static RzBinFileHash *n3ds_hash_buffer(const char *name, const ut8 *hash, size_t
 	if (!fh) {
 		return NULL;
 	}
-	fh->type = strdup(name);
+	fh->type = rz_str_dup(name);
 	fh->hex = rz_hex_bin2strdup(hash, size);
 	return fh;
 }
@@ -281,13 +281,13 @@ static RzPVector /*<RzBinFileHash *>*/ *n3ds_hashes(RzBinFile *bf) {
 static RZ_OWN char *n3ds_section_type_to_string(ut64 type) {
 	switch (type) {
 	case N3DS_TYPE_ARM9:
-		return strdup(N3DS_DESCR_ARM9);
+		return rz_str_dup(N3DS_DESCR_ARM9);
 	case N3DS_TYPE_ARM11:
-		return strdup(N3DS_DESCR_ARM11);
+		return rz_str_dup(N3DS_DESCR_ARM11);
 	case N3DS_TYPE_SYSMODULE:
-		return strdup(N3DS_DESCR_SYSMODULE);
+		return rz_str_dup(N3DS_DESCR_SYSMODULE);
 	case N3DS_TYPE_K11_EXT:
-		return strdup(N3DS_DESCR_K11_EXT);
+		return rz_str_dup(N3DS_DESCR_K11_EXT);
 	default:
 		return NULL;
 	}

--- a/librz/bin/p/bin_ninds.c
+++ b/librz/bin/p/bin_ninds.c
@@ -218,7 +218,7 @@ static RzPVector /*<RzBinSection *>*/ *nds_sections(RzBinFile *bf) {
 	NDSRom *rom = nds_get_rom(bf);
 	NDSHeader *hdr = &rom->header;
 
-	ptr9->name = strdup("arm9");
+	ptr9->name = rz_str_dup("arm9");
 	ptr9->size = hdr->arm9_size;
 	ptr9->vsize = hdr->arm9_size;
 	ptr9->paddr = hdr->arm9_rom_offset;
@@ -226,7 +226,7 @@ static RzPVector /*<RzBinSection *>*/ *nds_sections(RzBinFile *bf) {
 	ptr9->perm = perm_rwx;
 	rz_pvector_push(ret, ptr9);
 
-	ptr7->name = strdup("arm7");
+	ptr7->name = rz_str_dup("arm7");
 	ptr7->size = hdr->arm7_size;
 	ptr7->vsize = hdr->arm7_size;
 	ptr7->paddr = hdr->arm7_rom_offset;
@@ -323,10 +323,10 @@ static RzBinInfo *nds_info(RzBinFile *bf) {
 	NDSHeader *hdr = nds_get_hdr(bf);
 
 	ret->file = rz_str_newf("%.12s - %.4s", hdr->title, hdr->gamecode);
-	ret->type = strdup("ROM");
-	ret->machine = strdup("Nintendo DS");
-	ret->os = strdup("nds");
-	ret->arch = strdup("arm");
+	ret->type = rz_str_dup("ROM");
+	ret->machine = rz_str_dup("Nintendo DS");
+	ret->os = rz_str_dup("nds");
+	ret->arch = rz_str_dup("arm");
 	ret->has_va = true;
 	ret->bits = 32;
 	return ret;

--- a/librz/bin/p/bin_ningb.c
+++ b/librz/bin/p/bin_ningb.c
@@ -174,7 +174,7 @@ static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
 		return ret;
 	}
 
-	ptr[8]->name = strdup("Interrupt_Vblank");
+	ptr[8]->name = rz_str_dup("Interrupt_Vblank");
 	ptr[8]->paddr = ptr[8]->vaddr = 64;
 	ptr[8]->size = 1;
 	ptr[8]->ordinal = 8;
@@ -184,7 +184,7 @@ static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
 		return ret;
 	}
 
-	ptr[9]->name = strdup("Interrupt_LCDC-Status");
+	ptr[9]->name = rz_str_dup("Interrupt_LCDC-Status");
 	ptr[9]->paddr = ptr[9]->vaddr = 72;
 	ptr[9]->size = 1;
 	ptr[9]->ordinal = 9;
@@ -194,7 +194,7 @@ static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
 		return ret;
 	}
 
-	ptr[10]->name = strdup("Interrupt_Timer-Overflow");
+	ptr[10]->name = rz_str_dup("Interrupt_Timer-Overflow");
 	ptr[10]->paddr = ptr[10]->vaddr = 80;
 	ptr[10]->size = 1;
 	ptr[10]->ordinal = 10;
@@ -204,7 +204,7 @@ static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
 		return ret;
 	}
 
-	ptr[11]->name = strdup("Interrupt_Serial-Transfere");
+	ptr[11]->name = rz_str_dup("Interrupt_Serial-Transfere");
 	ptr[11]->paddr = ptr[11]->vaddr = 88;
 	ptr[11]->size = 1;
 	ptr[11]->ordinal = 11;
@@ -214,7 +214,7 @@ static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
 		return ret;
 	}
 
-	ptr[12]->name = strdup("Interrupt_Joypad");
+	ptr[12]->name = rz_str_dup("Interrupt_Joypad");
 	ptr[12]->paddr = ptr[12]->vaddr = 96;
 	ptr[12]->size = 1;
 	ptr[12]->ordinal = 12;
@@ -241,9 +241,9 @@ static RzBinInfo *info(RzBinFile *bf) {
 		ret->type = rz_str_newf("%s card_%02x", gbtype, (ut32)rom_header[67]);
 	}
 	ret->file = rz_str_ndup((const char *)&rom_header[48], 16);
-	ret->machine = strdup("Gameboy");
-	ret->os = strdup("any");
-	ret->arch = strdup("gb");
+	ret->machine = rz_str_dup("Gameboy");
+	ret->os = rz_str_dup("any");
+	ret->arch = rz_str_dup("gb");
 	ret->has_va = true;
 	ret->bits = 16;
 	ret->big_endian = 0;
@@ -261,7 +261,7 @@ RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	m->name = strdup("fastram");
+	m->name = rz_str_dup("fastram");
 	m->addr = 0xff80LL;
 	m->size = 0x80;
 	m->perms = rz_str_rwx("rwx");
@@ -270,7 +270,7 @@ RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 	if (!(m = RZ_NEW0(RzBinMem))) {
 		return ret;
 	}
-	m->name = strdup("ioports");
+	m->name = rz_str_dup("ioports");
 	m->addr = 0xff00LL;
 	m->size = 0x4c;
 	m->perms = rz_str_rwx("rwx");
@@ -279,7 +279,7 @@ RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 	if (!(m = RZ_NEW0(RzBinMem))) {
 		return ret;
 	}
-	m->name = strdup("oam");
+	m->name = rz_str_dup("oam");
 	m->addr = 0xfe00LL;
 	m->size = 0xa0;
 	m->perms = rz_str_rwx("rwx");
@@ -288,7 +288,7 @@ RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 	if (!(m = RZ_NEW0(RzBinMem))) {
 		return ret;
 	}
-	m->name = strdup("videoram");
+	m->name = rz_str_dup("videoram");
 	m->addr = 0x8000LL;
 	m->size = 0x2000;
 	m->perms = rz_str_rwx("rwx");
@@ -297,7 +297,7 @@ RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 	if (!(m = RZ_NEW0(RzBinMem))) {
 		return ret;
 	}
-	m->name = strdup("iram");
+	m->name = rz_str_dup("iram");
 	m->addr = 0xc000LL;
 	m->size = 0x2000;
 	m->perms = rz_str_rwx("rwx");
@@ -310,7 +310,7 @@ RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 		m->mirrors = NULL;
 		return ret;
 	}
-	n->name = strdup("iram_echo");
+	n->name = rz_str_dup("iram_echo");
 	n->addr = 0xe000LL;
 	n->size = 0x1e00;
 	n->perms = rz_str_rwx("rx");

--- a/librz/bin/p/bin_ningba.c
+++ b/librz/bin/p/bin_ningba.c
@@ -53,9 +53,9 @@ static RzBinInfo *info(RzBinFile *bf) {
 	rz_buf_read_at(bf->buf, 0xa0, rom_info, 16);
 	ret->file = rz_str_ndup((const char *)rom_info, 12);
 	ret->type = rz_str_ndup((char *)&rom_info[12], 4);
-	ret->machine = strdup("GameBoy Advance");
-	ret->os = strdup("any");
-	ret->arch = strdup("arm");
+	ret->machine = rz_str_dup("GameBoy Advance");
+	ret->os = rz_str_dup("any");
+	ret->arch = rz_str_dup("arm");
 	ret->has_va = 1;
 	ret->bits = 32;
 	ret->big_endian = 0;
@@ -74,7 +74,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		free(s);
 		return NULL;
 	}
-	s->name = strdup("ROM");
+	s->name = rz_str_dup("ROM");
 	s->paddr = 0;
 	s->vaddr = 0x8000000;
 	s->size = sz;

--- a/librz/bin/p/bin_nro.c
+++ b/librz/bin/p/bin_nro.c
@@ -129,7 +129,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 			goto maps_err;
 		}
 
-		map->name = strdup("sig0");
+		map->name = rz_str_dup("sig0");
 		map->paddr = sig0;
 		map->psize = sig0sz;
 		map->vsize = sig0sz;
@@ -144,7 +144,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	if (!(map = RZ_NEW0(RzBinMap))) {
 		return ret;
 	}
-	map->name = strdup("text");
+	map->name = rz_str_dup("text");
 	ut32 tmp;
 	if (!rz_buf_read_le32_at(b, NRO_OFF(text_memoffset), &tmp)) {
 		goto maps_err;
@@ -165,7 +165,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	if (!(map = RZ_NEW0(RzBinMap))) {
 		return ret;
 	}
-	map->name = strdup("ro");
+	map->name = rz_str_dup("ro");
 	if (!rz_buf_read_le32_at(b, NRO_OFF(ro_memoffset), &tmp)) {
 		goto maps_err;
 	}
@@ -185,7 +185,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	if (!(map = RZ_NEW0(RzBinMap))) {
 		return ret;
 	}
-	map->name = strdup("data");
+	map->name = rz_str_dup("data");
 	if (!rz_buf_read_le32_at(b, NRO_OFF(data_memoffset), &tmp)) {
 		goto maps_err;
 	}
@@ -219,7 +219,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("header");
+	ptr->name = rz_str_dup("header");
 	ptr->size = 0x80;
 	ptr->vsize = 0x80;
 	ptr->paddr = 0;
@@ -244,7 +244,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 			free(ret);
 			return NULL;
 		}
-		ptr->name = strdup("mod0");
+		ptr->name = rz_str_dup("mod0");
 		ptr->size = mod0sz;
 		ptr->vsize = mod0sz;
 		ptr->paddr = mod0;
@@ -306,21 +306,21 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!ft) {
 		ft = "nro";
 	}
-	ret->file = strdup(bf->file);
-	ret->rclass = strdup(ft);
-	ret->os = strdup("switch");
-	ret->arch = strdup("arm");
-	ret->machine = strdup("Nintendo Switch");
-	ret->subsystem = strdup(ft);
+	ret->file = rz_str_dup(bf->file);
+	ret->rclass = rz_str_dup(ft);
+	ret->os = rz_str_dup("switch");
+	ret->arch = rz_str_dup("arm");
+	ret->machine = rz_str_dup("Nintendo Switch");
+	ret->subsystem = rz_str_dup(ft);
 	if (!strncmp(ft, "nrr", 3)) {
-		ret->bclass = strdup("program");
-		ret->type = strdup("EXEC (executable file)");
+		ret->bclass = rz_str_dup("program");
+		ret->type = rz_str_dup("EXEC (executable file)");
 	} else if (!strncmp(ft, "nro", 3)) {
-		ret->bclass = strdup("object");
-		ret->type = strdup("OBJECT (executable code)");
+		ret->bclass = rz_str_dup("object");
+		ret->type = rz_str_dup("OBJECT (executable code)");
 	} else { // mod
-		ret->bclass = strdup("library");
-		ret->type = strdup("MOD (executable library)");
+		ret->bclass = rz_str_dup("library");
+		ret->type = rz_str_dup("MOD (executable library)");
 	}
 	ret->bits = 64;
 	ret->has_va = true;

--- a/librz/bin/p/bin_nso.c
+++ b/librz/bin/p/bin_nso.c
@@ -252,7 +252,7 @@ static RzPVector /*<RzBinVirtualFile *>*/ *virtual_files(RzBinFile *bf) {
 		}
 		vf->buf = bin->decompressed;
 		vf->buf_owned = false;
-		vf->name = strdup(VFILE_NAME_DECOMPRESSED);
+		vf->name = rz_str_dup(VFILE_NAME_DECOMPRESSED);
 		rz_pvector_push(ret, vf);
 	}
 	return ret;
@@ -272,12 +272,12 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	if (!map) {
 		return ret;
 	}
-	map->name = strdup("text");
+	map->name = rz_str_dup("text");
 	map->paddr = bin->decompressed ? 0 : hdr->text_memoffset;
 	map->vsize = map->psize = hdr->text_size;
 	map->vaddr = hdr->text_loc + ba;
 	map->perm = RZ_PERM_RX;
-	map->vfile_name = bin->decompressed ? strdup(VFILE_NAME_DECOMPRESSED) : NULL;
+	map->vfile_name = bin->decompressed ? rz_str_dup(VFILE_NAME_DECOMPRESSED) : NULL;
 	rz_pvector_push(ret, map);
 
 	// add ro segment
@@ -285,12 +285,12 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	if (!map) {
 		return ret;
 	}
-	map->name = strdup("ro");
+	map->name = rz_str_dup("ro");
 	map->paddr = bin->decompressed ? hdr->text_size : hdr->ro_memoffset;
 	map->vsize = map->psize = hdr->ro_size;
 	map->vaddr = hdr->ro_loc + ba;
 	map->perm = RZ_PERM_R;
-	map->vfile_name = bin->decompressed ? strdup(VFILE_NAME_DECOMPRESSED) : NULL;
+	map->vfile_name = bin->decompressed ? rz_str_dup(VFILE_NAME_DECOMPRESSED) : NULL;
 	rz_pvector_push(ret, map);
 
 	// add data segment
@@ -298,12 +298,12 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	if (!map) {
 		return ret;
 	}
-	map->name = strdup("data");
+	map->name = rz_str_dup("data");
 	map->paddr = bin->decompressed ? hdr->text_size + hdr->ro_size : hdr->data_memoffset;
 	map->vsize = map->psize = hdr->data_size;
 	map->vaddr = hdr->data_loc + ba;
 	map->perm = RZ_PERM_RW;
-	map->vfile_name = bin->decompressed ? strdup(VFILE_NAME_DECOMPRESSED) : NULL;
+	map->vfile_name = bin->decompressed ? rz_str_dup(VFILE_NAME_DECOMPRESSED) : NULL;
 	rz_pvector_push(ret, map);
 	return ret;
 }
@@ -319,7 +319,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("header");
+	ptr->name = rz_str_dup("header");
 	ut32 tmp;
 	if (!rz_buf_read_le32_at(b, NSO_OFF(text_memoffset), &tmp)) {
 		rz_pvector_free(ret);
@@ -371,14 +371,14 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!ft) {
 		ft = "nso";
 	}
-	ret->file = strdup(bf->file);
-	ret->rclass = strdup(ft);
-	ret->os = strdup("switch");
-	ret->arch = strdup("arm");
-	ret->machine = strdup("Nintendo Switch");
-	ret->subsystem = strdup(ft);
-	ret->bclass = strdup("program");
-	ret->type = strdup("EXEC (executable file)");
+	ret->file = rz_str_dup(bf->file);
+	ret->rclass = rz_str_dup(ft);
+	ret->os = rz_str_dup("switch");
+	ret->arch = rz_str_dup("arm");
+	ret->machine = rz_str_dup("Nintendo Switch");
+	ret->subsystem = rz_str_dup(ft);
+	ret->bclass = rz_str_dup("program");
+	ret->type = rz_str_dup("EXEC (executable file)");
 	ret->bits = 64;
 	ret->has_va = true;
 	ret->big_endian = false;

--- a/librz/bin/p/bin_omf.c
+++ b/librz/bin/p/bin_omf.c
@@ -125,7 +125,7 @@ static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
 			return ret;
 		}
 		sym_omf = ((rz_bin_omf_obj *)bf->o->bin_obj)->symbols[ct_sym++];
-		sym->name = strdup(sym_omf->name);
+		sym->name = rz_str_dup(sym_omf->name);
 		sym->forwarder = "NONE";
 		sym->paddr = rz_bin_omf_get_paddr_sym(bf->o->bin_obj, sym_omf);
 		sym->vaddr = rz_bin_omf_get_vaddr_sym(bf->o->bin_obj, sym_omf);
@@ -142,14 +142,14 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!(ret = RZ_NEW0(RzBinInfo))) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->bclass = strdup("OMF");
-	ret->rclass = strdup("omf");
+	ret->file = rz_str_dup(bf->file);
+	ret->bclass = rz_str_dup("OMF");
+	ret->rclass = rz_str_dup("omf");
 	// the "E" is here to made rva return the same value for 16 bit en 32 bits files
-	ret->type = strdup("E OMF (Relocatable Object Module Format)");
-	ret->os = strdup("any");
-	ret->machine = strdup("i386");
-	ret->arch = strdup("x86");
+	ret->type = rz_str_dup("E OMF (Relocatable Object Module Format)");
+	ret->os = rz_str_dup("any");
+	ret->machine = rz_str_dup("i386");
+	ret->arch = rz_str_dup("x86");
 	ret->big_endian = false;
 	ret->has_va = true;
 	ret->bits = rz_bin_omf_get_bits(bf->o->bin_obj);

--- a/librz/bin/p/bin_p9.c
+++ b/librz/bin/p/bin_p9.c
@@ -68,7 +68,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	ptr->name = strdup("text");
+	ptr->name = rz_str_dup("text");
 	ptr->size = textsize;
 	ptr->vsize = textsize + (textsize % 4096);
 	ptr->paddr = 8 * 4;
@@ -85,7 +85,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
 			return ret;
 		}
-		ptr->name = strdup("data");
+		ptr->name = rz_str_dup("data");
 		ptr->size = datasize;
 		ptr->vsize = datasize + (datasize % 4096);
 		ptr->paddr = textsize + (8 * 4);
@@ -105,7 +105,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
 			return ret;
 		}
-		ptr->name = strdup("syms");
+		ptr->name = rz_str_dup("syms");
 		ptr->size = symssize;
 		ptr->vsize = symssize + (symssize % 4096);
 		ptr->paddr = datasize + textsize + (8 * 4);
@@ -123,7 +123,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
 			return ret;
 		}
-		ptr->name = strdup("spsz");
+		ptr->name = rz_str_dup("spsz");
 		ptr->size = spszsize;
 		ptr->vsize = spszsize + (spszsize % 4096);
 		ptr->paddr = symssize + datasize + textsize + (8 * 4);
@@ -143,7 +143,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
 			return ret;
 		}
-		ptr->name = strdup("pcsz");
+		ptr->name = rz_str_dup("pcsz");
 		ptr->size = pcszsize;
 		ptr->vsize = pcszsize + (pcszsize % 4096);
 		ptr->paddr = spszsize + symssize + datasize + textsize + (8 * 4);
@@ -177,14 +177,14 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!(ret = RZ_NEW0(RzBinInfo))) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->bclass = strdup("program");
-	ret->rclass = strdup("p9");
-	ret->os = strdup("Plan9");
-	ret->arch = strdup(rz_sys_arch_str(bina));
-	ret->machine = strdup(ret->arch);
-	ret->subsystem = strdup("plan9");
-	ret->type = strdup("EXEC (executable file)");
+	ret->file = rz_str_dup(bf->file);
+	ret->bclass = rz_str_dup("program");
+	ret->rclass = rz_str_dup("p9");
+	ret->os = rz_str_dup("Plan9");
+	ret->arch = rz_str_dup(rz_sys_arch_str(bina));
+	ret->machine = rz_str_dup(ret->arch);
+	ret->subsystem = rz_str_dup("plan9");
+	ret->type = rz_str_dup("EXEC (executable file)");
 	ret->bits = bits;
 	ret->has_va = true;
 	ret->big_endian = big_endian;

--- a/librz/bin/p/bin_pe.c
+++ b/librz/bin/p/bin_pe.c
@@ -122,7 +122,7 @@ static char *signature(RzBinFile *bf, bool json) {
 	if (json) {
 		PJ *pj = pj_new();
 		if (!pj) {
-			return strdup("{}");
+			return rz_str_dup("{}");
 		}
 		rz_pkcs7_cms_json(bin->cms, pj);
 		return pj_drain(pj);
@@ -146,7 +146,7 @@ static RzPVector /*<RzBinField *>*/ *fields(RzBinFile *bf) {
 	RzListIter *it;
 	Pe_image_rich_entry *rich;
 	rz_list_foreach (bin->rich_entries, it, rich) {
-		rz_pvector_push(ret, rz_bin_field_new(addr, addr, 0, "RICH_ENTRY_NAME", strdup(rich->productName), "s", false));
+		rz_pvector_push(ret, rz_bin_field_new(addr, addr, 0, "RICH_ENTRY_NAME", rz_str_dup(rich->productName), "s", false));
 		ROWL(tmpbuf, "RICH_ENTRY_ID", 2, rich->productId, "x");
 		addr += 2;
 		ROWL(tmpbuf, "RICH_ENTRY_VERSION", 2, rich->minVersion, "x");

--- a/librz/bin/p/bin_pe.inc
+++ b/librz/bin/p/bin_pe.inc
@@ -155,7 +155,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	if (!map) {
 		return ret;
 	}
-	map->name = strdup("header");
+	map->name = rz_str_dup("header");
 	map->paddr = 0;
 	ut32 aligned_hdr_size = UT32_MAX;
 	if (bin->nt_headers->optional_header.FileAlignment != 0) {
@@ -174,7 +174,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 			break;
 		}
 		map->paddr = sections[i].paddr;
-		map->name = strdup((char *)sections[i].name);
+		map->name = rz_str_dup((char *)sections[i].name);
 		map->psize = sections[i].size;
 		if (map->psize > bin->size) {
 			if (sections[i].vsize < bin->size) {
@@ -216,7 +216,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
 			break;
 		}
-		ptr->name = strdup((char *)sections[i].name);
+		ptr->name = rz_str_dup((char *)sections[i].name);
 		ptr->size = sections[i].size;
 		ptr->vsize = sections[i].vsize;
 		ptr->flags = sections[i].flags;
@@ -337,8 +337,8 @@ static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
 			if (!(ptr = RZ_NEW0(RzBinSymbol))) {
 				break;
 			}
-			ptr->name = strdup((char *)symbols[i].name);
-			ptr->libname = *symbols[i].libname ? strdup((char *)symbols[i].libname) : NULL;
+			ptr->name = rz_str_dup((char *)symbols[i].name);
+			ptr->libname = RZ_STR_ISNOTEMPTY(symbols[i].libname) ? rz_str_dup((char *)symbols[i].libname) : NULL;
 			ptr->forwarder = rz_str_constpool_get(&bf->rbin->constpool, (char *)symbols[i].forwarder);
 			// strncpy (ptr->bind, "NONE", RZ_BIN_SIZEOF_STRINGS);
 			ptr->bind = RZ_BIN_BIND_GLOBAL_STR;
@@ -363,7 +363,7 @@ static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSymbol))) {
 			return ret;
 		}
-		ptr->name = strdup("gopclntab");
+		ptr->name = rz_str_dup("gopclntab");
 		ptr->bind = RZ_BIN_BIND_GLOBAL_STR;
 		ptr->type = RZ_BIN_TYPE_NOTYPE_STR;
 		ptr->size = go_pclntab_size;
@@ -379,8 +379,8 @@ static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
 				break;
 			}
 			// strncpy (ptr->name, (char*)symbols[i].name, RZ_BIN_SIZEOF_STRINGS);
-			ptr->name = strdup((const char *)imports[i].name);
-			ptr->libname = strdup((const char *)imports[i].libname);
+			ptr->name = rz_str_dup((const char *)imports[i].name);
+			ptr->libname = rz_str_dup((const char *)imports[i].libname);
 			ptr->is_imported = true;
 			// strncpy (ptr->forwarder, (char*)imports[i].forwarder, RZ_BIN_SIZEOF_STRINGS);
 			ptr->bind = "NONE";
@@ -455,8 +455,8 @@ static RzPVector /*<RzBinImport *>*/ *imports(RzBinFile *bf) {
 			break;
 		}
 		filter_import(imports[i].name);
-		ptr->name = strdup((char *)imports[i].name);
-		ptr->libname = strdup((char *)imports[i].libname);
+		ptr->name = rz_str_dup((char *)imports[i].name);
+		ptr->libname = rz_str_dup((char *)imports[i].libname);
 		ptr->bind = "NONE";
 		ptr->type = "FUNC";
 		ptr->ordinal = imports[i].ordinal;
@@ -521,24 +521,24 @@ static RzPVector /*<RzBinResource *>*/ *resources(RzBinFile *bf) {
 		}
 
 		br->index = index++;
-		br->name = strdup(rs->name);
+		br->name = rz_str_dup(rs->name);
 		if (!br->name) {
 			rz_bin_resource_free(br);
 			goto err;
 		}
-		br->time = strdup(rs->timestr);
+		br->time = rz_str_dup(rs->timestr);
 		if (!br->time) {
 			rz_bin_resource_free(br);
 			goto err;
 		}
 		br->vaddr = PE_(rz_bin_pe_get_image_base)(obj) + rs->data->OffsetToData;
 		br->size = rs->data->Size;
-		br->type = strdup(rs->type);
+		br->type = rz_str_dup(rs->type);
 		if (!br->type) {
 			rz_bin_resource_free(br);
 			goto err;
 		}
-		br->language = strdup(rs->language);
+		br->language = rz_str_dup(rs->language);
 		if (!br->language) {
 			rz_bin_resource_free(br);
 			goto err;
@@ -602,9 +602,9 @@ static RzBinInfo *info(RzBinFile *bf) {
 		return NULL;
 	}
 	bin = bf->o->bin_obj;
-	ret->file = strdup(bf->file);
+	ret->file = rz_str_dup(bf->file);
 	ret->bclass = PE_(rz_bin_pe_get_class)(bf->o->bin_obj);
-	ret->rclass = strdup("pe");
+	ret->rclass = rz_str_dup("pe");
 	ret->os = PE_(rz_bin_pe_get_os)(bf->o->bin_obj);
 	ret->arch = PE_(rz_bin_pe_get_arch)(bf->o->bin_obj);
 	ret->machine = PE_(rz_bin_pe_get_machine)(bf->o->bin_obj);
@@ -621,9 +621,9 @@ static RzBinInfo *info(RzBinFile *bf) {
 	rz_pvector_free(libs);
 
 	if (PE_(rz_bin_pe_is_dll)(bf->o->bin_obj)) {
-		ret->type = strdup("DLL (Dynamic Link Library)");
+		ret->type = rz_str_dup("DLL (Dynamic Link Library)");
 	} else {
-		ret->type = strdup("EXEC (Executable file)");
+		ret->type = rz_str_dup("EXEC (Executable file)");
 	}
 	claimed_checksum = PE_(bin_pe_get_claimed_checksum)(bf->o->bin_obj);
 	actual_checksum = PE_(bin_pe_get_actual_checksum)(bf->o->bin_obj);
@@ -693,8 +693,8 @@ static RzPVector /*<RzBinFileHash *>*/ *compute_hashes(RzBinFile *bf) {
 	if (authentihash) {
 		RzBinFileHash *authhash = RZ_NEW0(RzBinFileHash);
 		if (authhash) {
-			authhash->type = strdup("authentihash");
-			authhash->hex = strdup(authentihash);
+			authhash->type = rz_str_dup("authentihash");
+			authhash->hex = rz_str_dup(authentihash);
 			rz_pvector_push(file_hashes, authhash);
 		}
 	}

--- a/librz/bin/p/bin_pe64.c
+++ b/librz/bin/p/bin_pe64.c
@@ -78,7 +78,7 @@ static RzPVector /*<RzBinField *>*/ *fields(RzBinFile *bf) {
 	RzListIter *it;
 	Pe_image_rich_entry *rich;
 	rz_list_foreach (bin->rich_entries, it, rich) {
-		rz_pvector_push(ret, rz_bin_field_new(addr, addr, 0, "RICH_ENTRY_NAME", strdup(rich->productName), "s", false));
+		rz_pvector_push(ret, rz_bin_field_new(addr, addr, 0, "RICH_ENTRY_NAME", rz_str_dup(rich->productName), "s", false));
 		ROWL(tmpbuf, "RICH_ENTRY_ID", 2, rich->productId, "x");
 		addr += 2;
 		ROWL(tmpbuf, "RICH_ENTRY_VERSION", 2, rich->minVersion, "x");

--- a/librz/bin/p/bin_pebble.c
+++ b/librz/bin/p/bin_pebble.c
@@ -72,14 +72,14 @@ static RzBinInfo *info(RzBinFile *bf) {
 		return NULL;
 	}
 	ret->lang = NULL;
-	ret->file = strdup(bf->file);
-	ret->type = strdup("pebble");
+	ret->file = rz_str_dup(bf->file);
+	ret->type = rz_str_dup("pebble");
 	ret->bclass = rz_str_ndup(pai.name, 32);
 	ret->rclass = rz_str_ndup(pai.company, 32);
-	ret->os = strdup("rtos");
-	ret->subsystem = strdup("pebble");
-	ret->machine = strdup("watch");
-	ret->arch = strdup("arm"); // thumb only
+	ret->os = rz_str_dup("rtos");
+	ret->subsystem = rz_str_dup("pebble");
+	ret->machine = rz_str_dup("watch");
+	ret->arch = rz_str_dup("arm"); // thumb only
 	ret->has_va = 1;
 	ret->bits = 16;
 	ret->big_endian = 0;
@@ -103,7 +103,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("relocs");
+	ptr->name = rz_str_dup("relocs");
 	ptr->vsize = ptr->size = pai.num_reloc_entries * sizeof(ut32);
 	ptr->vaddr = ptr->paddr = pai.reloc_list_start;
 	ptr->perm = RZ_PERM_RW;
@@ -116,7 +116,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("symtab");
+	ptr->name = rz_str_dup("symtab");
 	ptr->vsize = ptr->size = 0;
 	ptr->vaddr = ptr->paddr = pai.sym_table_addr;
 	ptr->perm = RZ_PERM_R;
@@ -128,7 +128,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("text");
+	ptr->name = rz_str_dup("text");
 	ptr->vaddr = ptr->paddr = 0x80;
 	ptr->vsize = ptr->size = textsize - ptr->paddr;
 	ptr->perm = RZ_PERM_RWX;
@@ -137,7 +137,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("header");
+	ptr->name = rz_str_dup("header");
 	ptr->vsize = ptr->size = sizeof(PebbleAppInfo);
 	ptr->vaddr = ptr->paddr = 0;
 	ptr->perm = RZ_PERM_R;

--- a/librz/bin/p/bin_prg.c
+++ b/librz/bin/p/bin_prg.c
@@ -27,11 +27,11 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!ret) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->type = strdup("PRG");
-	ret->machine = strdup("Commodore 64");
-	ret->os = strdup("c64");
-	ret->arch = strdup("6502");
+	ret->file = rz_str_dup(bf->file);
+	ret->type = rz_str_dup("PRG");
+	ret->machine = rz_str_dup("Commodore 64");
+	ret->os = rz_str_dup("c64");
+	ret->arch = rz_str_dup("6502");
 	ret->bits = 8;
 	ret->has_va = 1;
 	return ret;
@@ -50,7 +50,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!section) {
 		return ret;
 	}
-	section->name = strdup("prg");
+	section->name = rz_str_dup("prg");
 	section->paddr = 2;
 	section->size = sz - 2;
 	section->vaddr = baddr(bf);

--- a/librz/bin/p/bin_psxexe.c
+++ b/librz/bin/p/bin_psxexe.c
@@ -34,11 +34,11 @@ static RzBinInfo *info(RzBinFile *bf) {
 		return NULL;
 	}
 
-	ret->file = strdup(bf->file);
-	ret->type = strdup("Sony PlayStation 1 Executable");
-	ret->machine = strdup("Sony PlayStation 1");
-	ret->os = strdup("psx");
-	ret->arch = strdup("mips");
+	ret->file = rz_str_dup(bf->file);
+	ret->type = rz_str_dup("Sony PlayStation 1 Executable");
+	ret->machine = rz_str_dup("Sony PlayStation 1");
+	ret->os = rz_str_dup("psx");
+	ret->arch = rz_str_dup("mips");
 	ret->bits = 32;
 	ret->has_va = true;
 	return ret;
@@ -68,7 +68,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 
 	sz = rz_buf_size(bf->buf);
 
-	sect->name = strdup("TEXT");
+	sect->name = rz_str_dup("TEXT");
 	sect->paddr = PSXEXE_TEXTSECTION_OFFSET;
 	sect->size = sz - PSXEXE_TEXTSECTION_OFFSET;
 	sect->vaddr = psxheader.t_addr;

--- a/librz/bin/p/bin_pyc.c
+++ b/librz/bin/p/bin_pyc.c
@@ -104,16 +104,16 @@ static RzBinInfo *info(RzBinFile *arch) {
 		return NULL;
 	}
 
-	ret->file = strdup(arch->file);
+	ret->file = rz_str_dup(arch->file);
 	ret->type = rz_str_newf("Python %s byte-compiled file", ctx->version.version);
-	ret->bclass = strdup("Python byte-compiled file");
-	ret->rclass = strdup("pyc");
-	ret->arch = strdup("pyc");
+	ret->bclass = rz_str_dup("Python byte-compiled file");
+	ret->rclass = rz_str_dup("pyc");
+	ret->arch = rz_str_dup("pyc");
 	ret->machine = rz_str_newf("Python %s VM (rev %s)", ctx->version.version,
 		ctx->version.revision);
-	ret->os = strdup("any");
+	ret->os = rz_str_dup("any");
 	ret->bits = is_before_py_36 ? 16 : 8;
-	ret->cpu = strdup(ctx->version.version); // pass version info in cpu, Asm plugin will get it
+	ret->cpu = rz_str_dup(ctx->version.version); // pass version info in cpu, Asm plugin will get it
 	return ret;
 }
 

--- a/librz/bin/p/bin_qnx.c
+++ b/librz/bin/p/bin_qnx.c
@@ -124,7 +124,7 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb
 			if (!ptr) {
 				goto beach;
 			}
-			ptr->name = strdup("LMF_RESOURCE");
+			ptr->name = rz_str_dup("LMF_RESOURCE");
 			ptr->paddr = offset;
 			ptr->vsize = lrec.data_nbytes - LMF_RESOURCE_SIZE;
 			ptr->size = ptr->vsize;
@@ -134,7 +134,7 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb
 			if (!map) {
 				goto beach;
 			}
-			map->name = ptr->name ? strdup(ptr->name) : NULL;
+			map->name = rz_str_dup(ptr->name);
 			map->paddr = ptr->paddr;
 			map->psize = ptr->size;
 			map->vsize = ptr->vsize;
@@ -153,7 +153,7 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb
 				free(ptr);
 				goto beach;
 			}
-			ptr->name = strdup("LMF_LOAD");
+			ptr->name = rz_str_dup("LMF_LOAD");
 			ptr->paddr = offset;
 			ptr->vaddr = ldata.offset;
 			ptr->vsize = lrec.data_nbytes - LMF_DATA_SIZE;
@@ -164,7 +164,7 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb
 			if (!map) {
 				goto beach;
 			}
-			map->name = ptr->name ? strdup(ptr->name) : NULL;
+			map->name = rz_str_dup(ptr->name);
 			map->paddr = ptr->paddr;
 			map->psize = ptr->size;
 			map->vsize = ptr->vsize;
@@ -231,14 +231,14 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!ret) {
 		return NULL;
 	}
-	ret->file = bf->file ? strdup(bf->file) : NULL;
-	ret->type = strdup("QNX Executable");
-	ret->bclass = strdup("qnx");
-	ret->machine = strdup("i386");
-	ret->rclass = strdup("QNX");
-	ret->arch = strdup("x86");
-	ret->os = strdup("any");
-	ret->subsystem = strdup("any");
+	ret->file = rz_str_dup(bf->file);
+	ret->type = rz_str_dup("QNX Executable");
+	ret->bclass = rz_str_dup("qnx");
+	ret->machine = rz_str_dup("i386");
+	ret->rclass = rz_str_dup("QNX");
+	ret->arch = rz_str_dup("x86");
+	ret->os = rz_str_dup("any");
+	ret->subsystem = rz_str_dup("any");
 	ret->lang = "C/C++";
 	ret->signature = true;
 	return ret;

--- a/librz/bin/p/bin_sfc.c
+++ b/librz/bin/p/bin_sfc.c
@@ -85,11 +85,11 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!(ret = RZ_NEW0(RzBinInfo))) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->type = strdup("ROM");
-	ret->machine = strdup("Super NES / Super Famicom");
-	ret->os = strdup("snes");
-	ret->arch = strdup("snes");
+	ret->file = rz_str_dup(bf->file);
+	ret->type = rz_str_dup("ROM");
+	ret->machine = rz_str_dup("Super NES / Super Famicom");
+	ret->os = rz_str_dup("snes");
+	ret->arch = rz_str_dup("snes");
 	ret->bits = 16;
 	ret->has_va = 1;
 	return ret;
@@ -114,7 +114,7 @@ static void addsym(RzList *ret, const char *name, ut64 addr, ut32 size) {
 	if (!ptr) {
 		return;
 	}
-	ptr->name = strdup (name? name: "");
+	ptr->name = rz_str_dup (name? name: "");
 	ptr->paddr = ptr->vaddr = addr;
 	ptr->size = size;
 	ptr->ordinal = 0;
@@ -196,7 +196,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	m->name = strdup("LOWRAM");
+	m->name = rz_str_dup("LOWRAM");
 	m->addr = LOWRAM_START_ADDRESS;
 	m->size = LOWRAM_SIZE;
 	m->perms = rz_str_rwx("rwx");
@@ -206,7 +206,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 		return ret;
 	}
 	m->mirrors = rz_pvector_new(rz_bin_mem_free);
-	m->name = strdup("LOWRAM_MIRROR");
+	m->name = rz_str_dup("LOWRAM_MIRROR");
 	m->addr = LOWRAM_MIRROR_START_ADDRESS;
 	m->size = LOWRAM_MIRROR_SIZE;
 	m->perms = rz_str_rwx("rwx");
@@ -216,7 +216,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 		rz_pvector_free(m_bak->mirrors);
 		return ret;
 	}
-	m->name = strdup("HIRAM");
+	m->name = rz_str_dup("HIRAM");
 	m->addr = HIRAM_START_ADDRESS;
 	m->size = HIRAM_SIZE;
 	m->perms = rz_str_rwx("rwx");
@@ -224,7 +224,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 	if (!(m = RZ_NEW0(RzBinMem))) {
 		return ret;
 	}
-	m->name = strdup("EXTRAM");
+	m->name = rz_str_dup("EXTRAM");
 	m->addr = EXTRAM_START_ADDRESS;
 	m->size = EXTRAM_SIZE;
 	m->perms = rz_str_rwx("rwx");
@@ -232,7 +232,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 	if (!(m = RZ_NEW0(RzBinMem))) {
 		return ret;
 	}
-	m->name = strdup("PPU1_REG");
+	m->name = rz_str_dup("PPU1_REG");
 	m->addr = PPU1_REG_ADDRESS;
 	m->size = PPU1_REG_SIZE;
 	m->perms = rz_str_rwx("rwx");
@@ -241,7 +241,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	m->name = strdup("DSP_REG");
+	m->name = rz_str_dup("DSP_REG");
 	m->addr = DSP_REG_ADDRESS;
 	m->size = DSP_REG_SIZE;
 	m->perms = rz_str_rwx("rwx");
@@ -250,7 +250,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	m->name = strdup("OLDJOY_REG");
+	m->name = rz_str_dup("OLDJOY_REG");
 	m->addr = OLDJOY_REG_ADDRESS;
 	m->size = OLDJOY_REG_SIZE;
 	m->perms = rz_str_rwx("rwx");
@@ -259,7 +259,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	m->name = strdup("PPU2_REG");
+	m->name = rz_str_dup("PPU2_REG");
 	m->addr = PPU2_REG_ADDRESS;
 	m->size = PPU2_REG_SIZE;
 	m->perms = rz_str_rwx("rwx");

--- a/librz/bin/p/bin_smd.c
+++ b/librz/bin/p/bin_smd.c
@@ -114,14 +114,14 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!(ret = RZ_NEW0(RzBinInfo))) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->type = strdup("ROM");
-	ret->machine = strdup("Sega Megadrive");
+	ret->file = rz_str_dup(bf->file);
+	ret->type = rz_str_dup("ROM");
+	ret->machine = rz_str_dup("Sega Megadrive");
 	ut8 tmp[32];
 	rz_buf_read_at(bf->buf, 0x100, tmp, sizeof(tmp));
 	ret->bclass = rz_str_ndup((char *)tmp, 32);
-	ret->os = strdup("smd");
-	ret->arch = strdup("m68k");
+	ret->os = rz_str_dup("smd");
+	ret->arch = rz_str_dup("m68k");
 	ret->bits = 16;
 	ret->has_va = 1;
 	ret->big_endian = 1;
@@ -133,7 +133,7 @@ static void addsym(RzPVector /*<RzBinSymbol *>*/ *ret, const char *name, ut64 ad
 	if (!ptr) {
 		return;
 	}
-	ptr->name = strdup(name ? name : "");
+	ptr->name = rz_str_dup(name ? name : "");
 	ptr->paddr = ptr->vaddr = addr;
 	ptr->size = 0;
 	ptr->ordinal = 0;
@@ -261,7 +261,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("vtable");
+	ptr->name = rz_str_dup("vtable");
 	ptr->paddr = ptr->vaddr = 0;
 	ptr->size = ptr->vsize = 0x100;
 	ptr->perm = RZ_PERM_R;
@@ -270,7 +270,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("header");
+	ptr->name = rz_str_dup("header");
 	ptr->paddr = ptr->vaddr = 0x100;
 	ptr->size = ptr->vsize = sizeof(SMD_Header);
 	ptr->perm = RZ_PERM_R;
@@ -279,7 +279,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!(ptr = RZ_NEW0(RzBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup("text");
+	ptr->name = rz_str_dup("text");
 	ptr->paddr = ptr->vaddr = 0x100 + sizeof(SMD_Header);
 	{
 		SMD_Header hdr = { { 0 } };

--- a/librz/bin/p/bin_sms.c
+++ b/librz/bin/p/bin_sms.c
@@ -43,11 +43,11 @@ static RzBinInfo *info(RzBinFile *bf) {
 		free(ret);
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->type = strdup("ROM");
-	ret->machine = strdup("SEGA MasterSystem");
-	ret->os = strdup("sms");
-	ret->arch = strdup("z80");
+	ret->file = rz_str_dup(bf->file);
+	ret->type = rz_str_dup("ROM");
+	ret->machine = rz_str_dup("SEGA MasterSystem");
+	ret->os = rz_str_dup("sms");
+	ret->arch = rz_str_dup("z80");
 	ret->has_va = 1;
 	ret->bits = 8;
 	if (!check_buffer(bf->buf)) {

--- a/librz/bin/p/bin_spc700.c
+++ b/librz/bin/p/bin_spc700.c
@@ -29,11 +29,11 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!(ret = RZ_NEW0(RzBinInfo))) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->type = strdup("Sound File Data");
-	ret->machine = strdup("SPC700");
-	ret->os = strdup("spc700");
-	ret->arch = strdup("spc700");
+	ret->file = rz_str_dup(bf->file);
+	ret->type = rz_str_dup("Sound File Data");
+	ret->machine = rz_str_dup("SPC700");
+	ret->os = rz_str_dup("spc700");
+	ret->arch = rz_str_dup("spc700");
 	ret->bits = 16;
 	ret->has_va = 1;
 	return ret;
@@ -56,7 +56,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	ptr->name = strdup("RAM");
+	ptr->name = rz_str_dup("RAM");
 	ptr->paddr = RAM_START_ADDRESS;
 	ptr->size = RAM_SIZE;
 	ptr->vaddr = 0x0;

--- a/librz/bin/p/bin_symbols.c
+++ b/librz/bin/p/bin_symbols.c
@@ -170,10 +170,10 @@ static RzBinSymbol *bin_symbol_from_symbol(RzCoreSymCacheElement *element, RzCor
 	RzBinSymbol *sym = RZ_NEW0(RzBinSymbol);
 	if (sym) {
 		if (s->name && s->mangled_name) {
-			sym->dname = strdup(s->name);
-			sym->name = strdup(s->mangled_name);
+			sym->dname = rz_str_dup(s->name);
+			sym->name = rz_str_dup(s->mangled_name);
 		} else if (s->name) {
-			sym->name = strdup(s->name);
+			sym->name = rz_str_dup(s->name);
 		} else if (s->mangled_name) {
 			sym->name = s->mangled_name;
 		}
@@ -335,13 +335,13 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!ret) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->bclass = strdup("symbols");
-	ret->os = strdup("unknown");
-	ret->arch = sm.arch ? strdup(sm.arch) : NULL;
+	ret->file = rz_str_dup(bf->file);
+	ret->bclass = rz_str_dup("symbols");
+	ret->os = rz_str_dup("unknown");
+	ret->arch = rz_str_dup(sm.arch);
 	ret->bits = sm.bits;
-	ret->type = strdup("Symbols file");
-	ret->subsystem = strdup("llvm");
+	ret->type = rz_str_dup("Symbols file");
+	ret->subsystem = rz_str_dup("llvm");
 	ret->has_va = true;
 
 	return ret;

--- a/librz/bin/p/bin_te.c
+++ b/librz/bin/p/bin_te.c
@@ -88,7 +88,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSection))) {
 			break;
 		}
-		ptr->name = strdup((char *)sections[i].name);
+		ptr->name = rz_str_dup((char *)sections[i].name);
 		ptr->size = sections[i].size;
 		ptr->vsize = sections[i].vsize;
 		ptr->paddr = sections[i].paddr;
@@ -122,14 +122,14 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!ret) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->bclass = strdup("TE");
-	ret->rclass = strdup("te");
+	ret->file = rz_str_dup(bf->file);
+	ret->bclass = rz_str_dup("TE");
+	ret->rclass = rz_str_dup("te");
 	ret->os = rz_bin_te_get_os(bf->o->bin_obj);
 	ret->arch = rz_bin_te_get_arch(bf->o->bin_obj);
 	ret->machine = rz_bin_te_get_machine(bf->o->bin_obj);
 	ret->subsystem = rz_bin_te_get_subsystem(bf->o->bin_obj);
-	ret->type = strdup("EXEC (Executable file)");
+	ret->type = rz_str_dup("EXEC (Executable file)");
 	ret->bits = rz_bin_te_get_bits(bf->o->bin_obj);
 	ret->big_endian = 1;
 	ret->dbg_info = 0;

--- a/librz/bin/p/bin_vsf.c
+++ b/librz/bin/p/bin_vsf.c
@@ -129,7 +129,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	m->name = strdup("RAM");
+	m->name = rz_str_dup("RAM");
 	m->addr = 0; // start address
 	m->size = _machines[vsf_obj->machine_idx].ram_size;
 	m->perms = rz_str_rwx("rwx");
@@ -160,7 +160,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 			if (!(ptr = RZ_NEW0(RzBinSection))) {
 				return ret;
 			}
-			ptr->name = strdup("BASIC");
+			ptr->name = rz_str_dup("BASIC");
 			ptr->paddr = vsf_obj->rom + rz_offsetof(struct vsf_c64rom, basic);
 			ptr->size = 1024 * 8; // (8k)
 			ptr->vaddr = 0xa000;
@@ -172,7 +172,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 			if (!(ptr = RZ_NEW0(RzBinSection))) {
 				return ret;
 			}
-			ptr->name = strdup("KERNAL");
+			ptr->name = rz_str_dup("KERNAL");
 			ptr->paddr = vsf_obj->rom + rz_offsetof(struct vsf_c64rom, kernal);
 			ptr->size = 1024 * 8; // (8k)
 			ptr->vaddr = 0xe000;
@@ -187,7 +187,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 			if (!(ptr = RZ_NEW0(RzBinSection))) {
 				return ret;
 			}
-			ptr->name = strdup("BASIC");
+			ptr->name = rz_str_dup("BASIC");
 			ptr->paddr = vsf_obj->rom + rz_offsetof(struct vsf_c128rom, basic);
 			ptr->size = 1024 * 28; // (28k)
 			ptr->vaddr = 0x4000;
@@ -199,7 +199,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 			if (!(ptr = RZ_NEW0(RzBinSection))) {
 				return ret;
 			}
-			ptr->name = strdup("MONITOR");
+			ptr->name = rz_str_dup("MONITOR");
 			// skip first 28kb  since "BASIC" and "MONITOR" share the same section in VSF
 			ptr->paddr = vsf_obj->rom + rz_offsetof(struct vsf_c128rom, basic) + 1024 * 28;
 			ptr->size = 1024 * 4; // (4k)
@@ -212,7 +212,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 			if (!(ptr = RZ_NEW0(RzBinSection))) {
 				return ret;
 			}
-			ptr->name = strdup("EDITOR");
+			ptr->name = rz_str_dup("EDITOR");
 			ptr->paddr = vsf_obj->rom + rz_offsetof(struct vsf_c128rom, editor);
 			ptr->size = 1024 * 4; // (4k)
 			ptr->vaddr = 0xc000;
@@ -224,7 +224,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 			if (!(ptr = RZ_NEW0(RzBinSection))) {
 				return ret;
 			}
-			ptr->name = strdup("KERNAL");
+			ptr->name = rz_str_dup("KERNAL");
 			ptr->paddr = vsf_obj->rom + rz_offsetof(struct vsf_c128rom, kernal);
 			ptr->size = 1024 * 8; // (8k)
 			ptr->vaddr = 0xe000;
@@ -244,7 +244,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 			if (!(ptr = RZ_NEW0(RzBinSection))) {
 				return ret;
 			}
-			ptr->name = strdup("RAM");
+			ptr->name = rz_str_dup("RAM");
 			ptr->paddr = vsf_obj->mem + offset;
 			ptr->size = size;
 			ptr->vaddr = 0x0;
@@ -260,7 +260,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 			if (!(ptr = RZ_NEW0(RzBinSection))) {
 				return ret;
 			}
-			ptr->name = strdup("RAM BANK 0");
+			ptr->name = rz_str_dup("RAM BANK 0");
 			ptr->paddr = vsf_obj->mem + offset;
 			ptr->size = size;
 			ptr->vaddr = 0x0;
@@ -271,7 +271,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 			if (!(ptr = RZ_NEW0(RzBinSection))) {
 				return ret;
 			}
-			ptr->name = strdup("RAM BANK 1");
+			ptr->name = rz_str_dup("RAM BANK 1");
 			ptr->paddr = vsf_obj->mem + offset + size;
 			ptr->size = size;
 			ptr->vaddr = 0x0;
@@ -304,11 +304,11 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!(ret = RZ_NEW0(RzBinInfo))) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->type = strdup("Snapshot");
-	ret->machine = strdup(_machines[m_idx].desc);
-	ret->os = strdup(_machines[m_idx].name);
-	ret->arch = strdup("6502");
+	ret->file = rz_str_dup(bf->file);
+	ret->type = rz_str_dup("Snapshot");
+	ret->machine = rz_str_dup(_machines[m_idx].desc);
+	ret->os = rz_str_dup(_machines[m_idx].name);
+	ret->arch = rz_str_dup("6502");
 	ret->bits = 8;
 	ret->has_va = true;
 

--- a/librz/bin/p/bin_wasm.c
+++ b/librz/bin/p/bin_wasm.c
@@ -104,7 +104,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 			rz_pvector_free(ret);
 			return NULL;
 		}
-		ptr->name = strdup((char *)sec->name);
+		ptr->name = rz_str_dup((char *)sec->name);
 		if (sec->id == RZ_BIN_WASM_SECTION_DATA || sec->id == RZ_BIN_WASM_SECTION_MEMORY) {
 			ptr->is_data = true;
 		}
@@ -150,8 +150,8 @@ static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinSymbol))) {
 			goto bad_alloc;
 		}
-		ptr->name = strdup(imp->field_str);
-		ptr->libname = strdup(imp->module_str);
+		ptr->name = rz_str_dup(imp->field_str);
+		ptr->libname = rz_str_dup(imp->module_str);
 		ptr->is_imported = true;
 		ptr->forwarder = "NONE";
 		ptr->bind = "NONE";
@@ -188,7 +188,7 @@ static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
 
 		const char *fcn_name = rz_bin_wasm_get_function_name(bin, fcn_idx);
 		if (fcn_name) {
-			ptr->name = strdup(fcn_name);
+			ptr->name = rz_str_dup(fcn_name);
 
 			is_exp = rz_list_find(exports, &fcn_idx, (RzListComparator)find_export, NULL);
 			if (is_exp) {
@@ -247,8 +247,8 @@ static RzPVector /*<RzBinImport *>*/ *imports(RzBinFile *bf) {
 		if (!(ptr = RZ_NEW0(RzBinImport))) {
 			goto bad_alloc;
 		}
-		ptr->name = strdup(import->field_str);
-		ptr->classname = strdup(import->module_str);
+		ptr->name = rz_str_dup(import->field_str);
+		ptr->classname = rz_str_dup(import->module_str);
 		ptr->ordinal = i;
 		ptr->bind = "NONE";
 		switch (import->kind) {
@@ -284,14 +284,14 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!(ret = RZ_NEW0(RzBinInfo))) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->bclass = strdup("module");
-	ret->rclass = strdup("wasm");
-	ret->os = strdup("WebAssembly");
-	ret->arch = strdup("wasm");
-	ret->machine = strdup(ret->arch);
-	ret->subsystem = strdup("wasm");
-	ret->type = strdup("EXEC");
+	ret->file = rz_str_dup(bf->file);
+	ret->bclass = rz_str_dup("module");
+	ret->rclass = rz_str_dup("wasm");
+	ret->os = rz_str_dup("WebAssembly");
+	ret->arch = rz_str_dup("wasm");
+	ret->machine = rz_str_dup(ret->arch);
+	ret->subsystem = rz_str_dup("wasm");
+	ret->type = rz_str_dup("EXEC");
 	ret->bits = 32;
 	ret->has_va = 0;
 	ret->big_endian = false;

--- a/librz/bin/p/bin_xbe.c
+++ b/librz/bin/p/bin_xbe.c
@@ -347,12 +347,12 @@ static RzBinInfo *info(RzBinFile *bf) {
 	memset(dbg_name, 0, sizeof(dbg_name));
 	rz_buf_read_at(bf->buf, obj->header.debug_name_addr - obj->header.base, dbg_name, sizeof(dbg_name));
 	dbg_name[sizeof(dbg_name) - 1] = 0;
-	ret->file = strdup((char *)dbg_name);
-	ret->bclass = strdup("program");
-	ret->machine = strdup("Microsoft Xbox");
-	ret->os = strdup("xbox");
-	ret->type = strdup("Microsoft Xbox executable");
-	ret->arch = strdup("x86");
+	ret->file = rz_str_dup((char *)dbg_name);
+	ret->bclass = rz_str_dup("program");
+	ret->machine = rz_str_dup("Microsoft Xbox");
+	ret->os = rz_str_dup("xbox");
+	ret->type = rz_str_dup("Microsoft Xbox executable");
+	ret->arch = rz_str_dup("x86");
 	ret->has_va = 1;
 	ret->bits = 32;
 	ret->big_endian = 0;

--- a/librz/bin/p/bin_xnu_kernelcache.c
+++ b/librz/bin/p/bin_xnu_kernelcache.c
@@ -54,7 +54,7 @@ typedef struct _RKmodInfo {
 
 #define KEXT_SHORT_NAME_FROM_SECTION(io_section) ({ \
 	char *result = NULL; \
-	char *clone = strdup(io_section->name); \
+	char *clone = rz_str_dup(io_section->name); \
 	char *cursor = strstr(clone, "__"); \
 	if (cursor) { \
 		cursor--; \
@@ -65,7 +65,7 @@ typedef struct _RKmodInfo {
 			*cursor = 0; \
 			cursor = strrchr(cursor, '.'); \
 			if (cursor) { \
-				result = strdup(cursor + 1); \
+				result = rz_str_dup(cursor + 1); \
 				RZ_FREE(clone); \
 			} \
 		} \
@@ -519,7 +519,7 @@ static RzList /*<RKext *>*/ *carve_kexts(RzXNUKernelCacheObj *obj) {
 				continue;
 			}
 
-			kext->name = strdup(all_infos[j].name);
+			kext->name = rz_str_dup(all_infos[j].name);
 			kext->own_name = true;
 			break;
 		}
@@ -623,7 +623,7 @@ static RzList /*<RKext *>*/ *kexts_from_load_commands(RzXNUKernelCacheObj *obj) 
 		kext->vaddr = K_PPTR(kext->vaddr);
 		kext->pa2va_exec = obj->pa2va_exec;
 		kext->pa2va_data = obj->pa2va_data;
-		kext->name = strdup(padded_name);
+		kext->name = rz_str_dup(padded_name);
 		kext->own_name = true;
 		free(padded_name);
 		rz_list_push(kexts, kext);
@@ -999,7 +999,7 @@ static RzPVector /*<RzBinVirtualFile *>*/ *virtual_files(RzBinFile *bf) {
 		}
 		vf->buf = kobj->patched_buf;
 		vf->buf_owned = false;
-		vf->name = strdup(VFILE_NAME_PATCHED);
+		vf->name = rz_str_dup(VFILE_NAME_PATCHED);
 		rz_pvector_push(ret, vf);
 	}
 	return ret;
@@ -1038,7 +1038,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 			map->vaddr = map->paddr;
 		}
 		map->perm = prot2perm(seg->initprot);
-		map->vfile_name = kobj->patched_buf ? strdup(VFILE_NAME_PATCHED) : NULL;
+		map->vfile_name = kobj->patched_buf ? rz_str_dup(VFILE_NAME_PATCHED) : NULL;
 		rz_pvector_push(ret, map);
 	}
 
@@ -1177,7 +1177,7 @@ static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
 
 	symbols_from_mach0(ret, obj->mach0, bf, 0, 0);
 
-	HtUP *kernel_syms_by_addr = ht_up_new((HtUPDupValue)strdup, free);
+	HtUP *kernel_syms_by_addr = ht_up_new((HtUPDupValue)rz_str_dup, free);
 	if (!kernel_syms_by_addr) {
 		rz_pvector_free(ret);
 		return NULL;
@@ -1260,7 +1260,7 @@ static void symbols_from_mach0(RzPVector /*<RzBinSymbol *>*/ *ret, struct MACH0_
 		if (!sym) {
 			break;
 		}
-		sym->name = strdup(symbols[i].name);
+		sym->name = rz_str_dup(symbols[i].name);
 		sym->vaddr = symbols[i].addr;
 		sym->forwarder = "NONE";
 		sym->bind = (symbols[i].type == RZ_BIN_MACH0_SYMBOL_TYPE_LOCAL) ? "LOCAL" : "GLOBAL";
@@ -1753,14 +1753,14 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!(ret = RZ_NEW0(RzBinInfo))) {
 		return NULL;
 	}
-	ret->file = strdup(bf->file);
-	ret->bclass = strdup("kernelcache");
-	ret->rclass = strdup("ios");
-	ret->os = strdup("iOS");
-	ret->arch = strdup("arm"); // XXX
-	ret->machine = strdup(ret->arch);
-	ret->subsystem = strdup("xnu");
-	ret->type = strdup("kernel-cache");
+	ret->file = rz_str_dup(bf->file);
+	ret->bclass = rz_str_dup("kernelcache");
+	ret->rclass = rz_str_dup("ios");
+	ret->os = rz_str_dup("iOS");
+	ret->arch = rz_str_dup("arm"); // XXX
+	ret->machine = rz_str_dup(ret->arch);
+	ret->subsystem = rz_str_dup("xnu");
+	ret->type = rz_str_dup("kernel-cache");
 	ret->bits = 64;
 	ret->has_va = true;
 	ret->big_endian = big_endian;

--- a/librz/bin/p/bin_xtr_fatmach0.c
+++ b/librz/bin/p/bin_xtr_fatmach0.c
@@ -60,7 +60,7 @@ static int size(RzBin *bin) {
 }
 
 static inline void fill_metadata_info_from_hdr(RzBinXtrMetadata *meta, struct MACH0_(mach_header) * hdr) {
-	meta->arch = strdup(MACH0_(get_cputype_from_hdr)(hdr));
+	meta->arch = rz_str_dup(MACH0_(get_cputype_from_hdr)(hdr));
 	meta->bits = MACH0_(get_bits_from_hdr)(hdr);
 	meta->machine = MACH0_(get_cpusubtype_from_hdr)(hdr);
 	meta->type = MACH0_(get_filetype_from_hdr)(hdr);

--- a/librz/bin/p/bin_xtr_sep64.c
+++ b/librz/bin/p/bin_xtr_sep64.c
@@ -299,11 +299,11 @@ static RSepSlice64 *sep64_xtr_ctx_get_slice(RSepXtr64Ctx *ctx, RzBuffer *whole, 
 	ut64 total_size = 0;
 
 	if (idx == 0) {
-		name = strdup("boot");
+		name = rz_str_dup("boot");
 		slice_buf = rz_buf_new_slice(whole, 0, ctx->hdr->kernel_base_paddr);
 		total_size = ctx->hdr->kernel_base_paddr;
 	} else if (idx == 1) {
-		name = strdup("kernel");
+		name = rz_str_dup("kernel");
 		info = mach0_info_new(whole, ctx->hdr->kernel_base_paddr, whole_size - ctx->hdr->kernel_base_paddr);
 		if (!info) {
 			goto beach;
@@ -345,10 +345,10 @@ static RSepSlice64 *sep64_xtr_ctx_get_slice(RSepXtr64Ctx *ctx, RzBuffer *whole, 
 	if (info) {
 		fill_metadata_info_from_hdr(meta, info->hdr);
 	} else {
-		meta->arch = strdup("arm");
+		meta->arch = rz_str_dup("arm");
 		meta->bits = 64;
-		meta->machine = strdup("arm64e");
-		meta->type = strdup("Executable file");
+		meta->machine = rz_str_dup("arm64e");
+		meta->type = rz_str_dup("Executable file");
 	}
 
 	meta->xtr_type = "SEP";
@@ -484,7 +484,7 @@ beach:
 }
 
 static inline void fill_metadata_info_from_hdr(RzBinXtrMetadata *meta, struct MACH0_(mach_header) * hdr) {
-	meta->arch = strdup(MACH0_(get_cputype_from_hdr)(hdr));
+	meta->arch = rz_str_dup(MACH0_(get_cputype_from_hdr)(hdr));
 	meta->bits = MACH0_(get_bits_from_hdr)(hdr);
 	meta->machine = MACH0_(get_cpusubtype_from_hdr)(hdr);
 	meta->type = MACH0_(get_filetype_from_hdr)(hdr);

--- a/librz/bin/p/bin_z64.c
+++ b/librz/bin/p/bin_z64.c
@@ -113,7 +113,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	text->name = strdup("text");
+	text->name = rz_str_dup("text");
 	text->size = rz_buf_size(bf->buf) - N64_ROM_START;
 	text->vsize = text->size;
 	text->paddr = N64_ROM_START;
@@ -135,10 +135,10 @@ static RzBinInfo *info(RzBinFile *bf) {
 	}
 	memcpy(GameName, n64_header.Name, sizeof(n64_header.Name));
 	ret->file = rz_str_newf("%s (%c)", GameName, n64_header.CountryCode);
-	ret->os = strdup("n64");
-	ret->arch = strdup("mips");
-	ret->machine = strdup("Nintendo 64");
-	ret->type = strdup("ROM");
+	ret->os = rz_str_dup("n64");
+	ret->arch = rz_str_dup("mips");
+	ret->machine = rz_str_dup("Nintendo 64");
+	ret->type = rz_str_dup("ROM");
 	ret->bits = 64;
 	ret->has_va = true;
 	ret->big_endian = true;

--- a/librz/bin/p/bin_zimg.c
+++ b/librz/bin/p/bin_zimg.c
@@ -38,15 +38,15 @@ static RzBinInfo *info(RzBinFile *bf) {
 	if (!ret) {
 		return NULL;
 	}
-	ret->file = bf->file ? strdup(bf->file) : NULL;
-	ret->type = strdup("Linux zImage Kernel");
+	ret->file = rz_str_dup(bf->file);
+	ret->type = rz_str_dup("Linux zImage Kernel");
 	ret->has_va = false;
-	ret->bclass = strdup("Compressed Linux Kernel");
-	ret->rclass = strdup("zimg");
-	ret->os = strdup("linux");
-	ret->subsystem = strdup("linux");
-	ret->machine = strdup("ARM"); // TODO: can be other cpus
-	ret->arch = strdup("arm");
+	ret->bclass = rz_str_dup("Compressed Linux Kernel");
+	ret->rclass = rz_str_dup("zimg");
+	ret->os = rz_str_dup("linux");
+	ret->subsystem = rz_str_dup("linux");
+	ret->machine = rz_str_dup("ARM"); // TODO: can be other cpus
+	ret->arch = rz_str_dup("arm");
 	ret->lang = "C";
 	ret->bits = 32;
 	ret->big_endian = 0;

--- a/librz/bin/pdb/pdb_downloader.c
+++ b/librz/bin/pdb/pdb_downloader.c
@@ -78,7 +78,7 @@ static char *download(struct SPDBDownloader *pd) {
 
 	if (opt->extract == 0) {
 		char *extractor_cmd = NULL;
-		char *archive_name = strdup(opt->dbg_file);
+		char *archive_name = rz_str_dup(opt->dbg_file);
 		archive_name[strlen(archive_name) - 1] = '_';
 		char *abspath_to_archive = rz_str_newf("%s%s%s%s%s%s%s",
 			opt->symbol_store_path, RZ_SYS_DIR,
@@ -126,10 +126,10 @@ void init_pdb_downloader(SPDBDownloaderOpt *opt, SPDBDownloader *pd) {
 		eprintf("Cannot allocate memory for SPDBDownloaderOpt.\n");
 		return;
 	}
-	pd->opt->dbg_file = strdup(opt->dbg_file);
-	pd->opt->guid = strdup(opt->guid);
-	pd->opt->symbol_server = strdup(opt->symbol_server);
-	pd->opt->symbol_store_path = strdup(opt->symbol_store_path);
+	pd->opt->dbg_file = rz_str_dup(opt->dbg_file);
+	pd->opt->guid = rz_str_dup(opt->guid);
+	pd->opt->symbol_server = rz_str_dup(opt->symbol_server);
+	pd->opt->symbol_store_path = rz_str_dup(opt->symbol_store_path);
 	pd->opt->extract = opt->extract;
 	pd->download = download;
 }
@@ -222,7 +222,7 @@ RZ_API RZ_OWN char *rz_bin_symserver_download(RZ_NONNULL const SPDBDownloaderOpt
 	SPDBDownloader downloader;
 	SPDBDownloaderOpt opt = *options;
 	char *path = NULL;
-	char *symbol_server = strdup(options->symbol_server);
+	char *symbol_server = rz_str_dup(options->symbol_server);
 	char *server = strtok(symbol_server, ";");
 	while (server && !path) {
 		opt.symbol_server = server;

--- a/librz/bin/pdb/tpi.c
+++ b/librz/bin/pdb/tpi.c
@@ -38,23 +38,23 @@ RZ_API RZ_OWN char *rz_bin_pdb_calling_convention_as_string(RZ_NONNULL RzPdbTpiC
 	switch (idx) {
 	case NEAR_C:
 	case FAR_C:
-		return strdup("__cdecl");
+		return rz_str_dup("__cdecl");
 	case NEAR_PASCAL:
 	case FAR_PASCAL:
-		return strdup("__pascal");
+		return rz_str_dup("__pascal");
 	case NEAR_FAST:
 	case FAR_FAST:
-		return strdup("__fastcall");
+		return rz_str_dup("__fastcall");
 	case NEAR_STD:
 	case FAR_STD:
-		return strdup("__stdcall");
+		return rz_str_dup("__stdcall");
 	case NEAR_SYS:
 	case FAR_SYS:
-		return strdup("__syscall");
+		return rz_str_dup("__syscall");
 	case THISCALL:
-		return strdup("__thiscall");
+		return rz_str_dup("__thiscall");
 	case NEAR_VEC:
-		return strdup("__vectorcall");
+		return rz_str_dup("__vectorcall");
 	default:
 		return NULL;
 	}

--- a/librz/bin/relocs_patch.c
+++ b/librz/bin/relocs_patch.c
@@ -106,7 +106,7 @@ RZ_API void rz_bin_relocs_patch_maps(RZ_NONNULL RzPVector /*<RzBinMap *>*/ *maps
 				// avoid using the patched file if there is nothing different in this range
 				continue;
 			}
-			map->vfile_name = strdup(vfile_name_patched);
+			map->vfile_name = rz_str_dup(vfile_name_patched);
 			map->paddr = buf_addr;
 		}
 	}
@@ -117,13 +117,13 @@ RZ_API void rz_bin_relocs_patch_maps(RZ_NONNULL RzPVector /*<RzBinMap *>*/ *maps
 		if (!map) {
 			return;
 		}
-		map->name = strdup("reloc-targets");
+		map->name = rz_str_dup("reloc-targets");
 		map->paddr = 0;
 		map->psize = target_vfile_size;
 		map->vaddr = target_vfile_base;
 		map->vsize = target_vfile_size;
 		map->perm = RZ_PERM_R;
-		map->vfile_name = strdup(vfile_name_reloc_targets);
+		map->vfile_name = rz_str_dup(vfile_name_reloc_targets);
 		rz_pvector_push_front(maps, map);
 	}
 }

--- a/librz/bp/bp.c
+++ b/librz/bp/bp.c
@@ -425,7 +425,7 @@ RZ_API bool rz_bp_item_set_cond(RZ_NONNULL RzBreakpointItem *item, RZ_NULLABLE c
 
 	char *tmp_cond = NULL;
 	if (cond) {
-		tmp_cond = strdup(cond);
+		tmp_cond = rz_str_dup(cond);
 		if (!tmp_cond) {
 			return false;
 		}
@@ -447,7 +447,7 @@ RZ_API bool rz_bp_item_set_data(RZ_NONNULL RzBreakpointItem *item, RZ_NULLABLE c
 
 	char *tmp_data = NULL;
 	if (data) {
-		tmp_data = strdup(data);
+		tmp_data = rz_str_dup(data);
 		if (!tmp_data) {
 			return false;
 		}
@@ -469,7 +469,7 @@ RZ_API bool rz_bp_item_set_expr(RZ_NONNULL RzBreakpointItem *item, RZ_NULLABLE c
 
 	char *tmp_expr = NULL;
 	if (expr) {
-		tmp_expr = strdup(expr);
+		tmp_expr = rz_str_dup(expr);
 		if (!tmp_expr) {
 			return false;
 		}
@@ -491,7 +491,7 @@ RZ_API bool rz_bp_item_set_name(RZ_NONNULL RzBreakpointItem *item, RZ_NULLABLE c
 
 	char *tmp_name = NULL;
 	if (name) {
-		tmp_name = strdup(name);
+		tmp_name = rz_str_dup(name);
 		if (!tmp_name) {
 			return false;
 		}

--- a/librz/bp/serialize_bp.c
+++ b/librz/bp/serialize_bp.c
@@ -256,10 +256,10 @@ static bool bp_load_cb(void *user, const SdbKv *kv) {
 	}
 
 	if (bp_item_temp.name) {
-		bp_item->name = strdup(bp_item_temp.name);
+		bp_item->name = rz_str_dup(bp_item_temp.name);
 	}
 	if (bp_item_temp.module_name) {
-		bp_item->module_name = strdup(bp_item_temp.module_name);
+		bp_item->module_name = rz_str_dup(bp_item_temp.module_name);
 	}
 	bp_item->module_delta = bp_item_temp.module_delta;
 	bp_item->delta = bp_item_temp.delta;
@@ -274,13 +274,13 @@ static bool bp_load_cb(void *user, const SdbKv *kv) {
 		bp_item->pids[i] = bp_item_temp.pids[i];
 	}
 	if (bp_item_temp.data) {
-		bp_item->data = strdup(bp_item_temp.data);
+		bp_item->data = rz_str_dup(bp_item_temp.data);
 	}
 	if (bp_item_temp.cond) {
-		bp_item->cond = strdup(bp_item_temp.cond);
+		bp_item->cond = rz_str_dup(bp_item_temp.cond);
 	}
 	if (bp_item_temp.expr) {
-		bp_item->expr = strdup(bp_item_temp.expr);
+		bp_item->expr = rz_str_dup(bp_item_temp.expr);
 	}
 	ret = true;
 

--- a/librz/config/config.c
+++ b/librz/config/config.c
@@ -9,8 +9,8 @@ RZ_API RZ_OWN RzConfigNode *rz_config_node_new(RZ_NONNULL const char *name, RZ_N
 	if (!node) {
 		return NULL;
 	}
-	node->name = strdup(name);
-	node->value = strdup(value);
+	node->name = rz_str_dup(name);
+	node->value = rz_str_dup(value);
 	node->flags = CN_RW | CN_STR;
 	node->i_value = rz_num_get(NULL, value);
 	node->options = rz_list_new();
@@ -23,9 +23,9 @@ RZ_API RZ_OWN RzConfigNode *rz_config_node_clone(RzConfigNode *n) {
 	if (!cn) {
 		return NULL;
 	}
-	cn->name = strdup(n->name);
-	cn->desc = n->desc ? strdup(n->desc) : NULL;
-	cn->value = strdup(n->value ? n->value : "");
+	cn->name = rz_str_dup(n->name);
+	cn->desc = n->desc ? rz_str_dup(n->desc) : NULL;
+	cn->value = rz_str_dup(n->value ? n->value : "");
 	cn->i_value = n->i_value;
 	cn->flags = n->flags;
 	cn->setter = n->setter;
@@ -213,11 +213,11 @@ RZ_API RzConfigNode *rz_config_set_b(RzConfig *cfg, RZ_NONNULL const char *name,
 
 		oi = node->i_value;
 		if (node->value) {
-			ov = strdup(node->value);
+			ov = rz_str_dup(node->value);
 		}
 		if (rz_config_node_is_bool(node)) {
 			node->i_value = value ? 1 : 0;
-			char *svalue = strdup(rz_str_bool(value));
+			char *svalue = rz_str_dup(rz_str_bool(value));
 			if (svalue) {
 				free(node->value);
 				node->value = svalue;
@@ -251,7 +251,7 @@ RZ_API RzConfigNode *rz_config_set_b(RzConfig *cfg, RZ_NONNULL const char *name,
 				node->i_value = oi;
 			}
 			free(node->value);
-			node->value = strdup(ov ? ov : "");
+			node->value = rz_str_dup(ov ? ov : "");
 		}
 	}
 
@@ -278,18 +278,18 @@ RZ_API RzConfigNode *rz_config_set(RzConfig *cfg, RZ_NONNULL const char *name, c
 		}
 		oi = node->i_value;
 		if (node->value) {
-			ov = strdup(node->value);
+			ov = rz_str_dup(node->value);
 			if (!ov) {
 				goto beach;
 			}
 		} else {
 			free(node->value);
-			node->value = strdup("");
+			node->value = rz_str_dup("");
 		}
 		if (rz_config_node_is_bool(node)) {
 			bool b = rz_str_is_true(value);
 			node->i_value = b ? 1 : 0;
-			char *value = strdup(rz_str_bool(b));
+			char *value = rz_str_dup(rz_str_bool(b));
 			if (value) {
 				free(node->value);
 				node->value = value;
@@ -297,14 +297,14 @@ RZ_API RzConfigNode *rz_config_set(RzConfig *cfg, RZ_NONNULL const char *name, c
 		} else {
 			if (!value) {
 				free(node->value);
-				node->value = strdup("");
+				node->value = rz_str_dup("");
 				node->i_value = 0;
 			} else {
 				if (node->value == value) {
 					goto beach;
 				}
 				free(node->value);
-				node->value = strdup(value);
+				node->value = rz_str_dup(value);
 				if (IS_DIGIT(*value) || (value[0] == '-' && IS_DIGIT(value[1]))) {
 					if (strchr(value, '/')) {
 						node->i_value = rz_num_get(cfg->num, value);
@@ -342,7 +342,7 @@ RZ_API RzConfigNode *rz_config_set(RzConfig *cfg, RZ_NONNULL const char *name, c
 				node->i_value = oi;
 			}
 			free(node->value);
-			node->value = strdup(ov ? ov : "");
+			node->value = rz_str_dup(ov ? ov : "");
 			free(ov);
 			return NULL;
 		}
@@ -384,7 +384,7 @@ RZ_API const char *rz_config_node_desc(RzConfigNode *node, RZ_NULLABLE const cha
 	rz_return_val_if_fail(node, NULL);
 	if (desc) {
 		free(node->desc);
-		node->desc = strdup(desc);
+		node->desc = rz_str_dup(desc);
 	}
 	return node->desc;
 }
@@ -426,11 +426,11 @@ RZ_API RzConfigNode *rz_config_set_i(RzConfig *cfg, RZ_NONNULL const char *name,
 			goto beach;
 		}
 		if (node->value) {
-			ov = strdup(node->value);
+			ov = rz_str_dup(node->value);
 		}
 		rz_config_node_value_format_i(buf, sizeof(buf), i, NULL);
 		free(node->value);
-		node->value = strdup(buf);
+		node->value = rz_str_dup(buf);
 		if (!node->value) {
 			node = NULL;
 			goto beach;
@@ -461,7 +461,7 @@ RZ_API RzConfigNode *rz_config_set_i(RzConfig *cfg, RZ_NONNULL const char *name,
 		if (!ret) {
 			node->i_value = oi;
 			free(node->value);
-			node->value = strdup(ov ? ov : "");
+			node->value = rz_str_dup(ov ? ov : "");
 		}
 	}
 beach:
@@ -537,7 +537,7 @@ RZ_API void rz_config_visual_hit_i(RzConfig *cfg, const char *name, int delta) {
 }
 
 RZ_API void rz_config_bump(RzConfig *cfg, const char *key) {
-	char *orig = strdup(rz_config_get(cfg, key));
+	char *orig = rz_str_dup(rz_config_get(cfg, key));
 	if (orig) {
 		rz_config_set(cfg, key, orig);
 		free(orig);

--- a/librz/config/hold.c
+++ b/librz/config/hold.c
@@ -58,8 +58,8 @@ RZ_API bool rz_config_hold_s(RzConfigHold *h, ...) {
 		}
 		RzConfigHoldChar *hc = RZ_NEW0(RzConfigHoldChar);
 		if (hc) {
-			hc->key = strdup(key);
-			hc->value = strdup(val);
+			hc->key = rz_str_dup(key);
+			hc->value = rz_str_dup(val);
 			rz_list_append(h->list_char, hc);
 		}
 	}
@@ -99,7 +99,7 @@ RZ_API bool rz_config_hold_i(RzConfigHold *h, ...) {
 		if (!hc) {
 			continue;
 		}
-		hc->key = strdup(key);
+		hc->key = rz_str_dup(key);
 		hc->value = rz_config_get_i(h->cfg, key);
 		rz_list_append(h->list_num, hc);
 	}

--- a/librz/cons/canvas.c
+++ b/librz/cons/canvas.c
@@ -255,7 +255,7 @@ RZ_API RzConsCanvas *rz_cons_canvas_new(int w, int h) {
 	if (!rz_str_constpool_init(&c->constpool)) {
 		goto beach;
 	}
-	c->attrs = ht_up_new((HtUPDupValue)strdup, free);
+	c->attrs = ht_up_new((HtUPDupValue)rz_str_dup, free);
 	if (!c->attrs) {
 		goto beach;
 	}

--- a/librz/cons/cons.c
+++ b/librz/cons/cons.c
@@ -73,7 +73,7 @@ static RzConsStack *cons_stack_dump(bool recreate) {
 		if (data->grep) {
 			memcpy(data->grep, &CTX(grep), sizeof(RzConsGrep));
 			if (CTX(grep).str) {
-				data->grep->str = strdup(CTX(grep).str);
+				data->grep->str = rz_str_dup(CTX(grep).str);
 			}
 		}
 		if (recreate && CTX(buffer_sz) > 0) {
@@ -834,7 +834,7 @@ RZ_API const char *rz_cons_get_buffer(void) {
  */
 RZ_API RZ_OWN char *rz_cons_get_buffer_dup(void) {
 	const char *s = rz_cons_get_buffer();
-	return s ? strdup(s) : NULL;
+	return rz_str_dup(s);
 }
 
 RZ_API int rz_cons_get_buffer_len(void) {
@@ -1829,10 +1829,10 @@ RZ_API void rz_cons_highlight(const char *word) {
 		if (I.highlight) {
 			if (strcmp(word, I.highlight)) {
 				free(I.highlight);
-				I.highlight = strdup(word);
+				I.highlight = rz_str_dup(word);
 			}
 		} else {
-			I.highlight = strdup(word);
+			I.highlight = rz_str_dup(word);
 		}
 		rword = malloc(word_len + linv[0] + linv[1] + 1);
 		if (!rword) {
@@ -1935,7 +1935,7 @@ RZ_API char *rz_cons_swap_ground(const char *col) {
 		/* is foreground */
 		return rz_str_newf("\x1b[4%s", col + 3);
 	}
-	return strdup(col);
+	return rz_str_dup(col);
 }
 
 RZ_API bool rz_cons_drop(int n) {
@@ -1989,7 +1989,7 @@ RZ_API const char *rz_cons_get_rune(const ut8 ch) {
 RZ_API void rz_cons_breakword(RZ_NULLABLE const char *s) {
 	free(I.break_word);
 	if (s) {
-		I.break_word = strdup(s);
+		I.break_word = rz_str_dup(s);
 		I.break_word_len = strlen(s);
 	} else {
 		I.break_word = NULL;

--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -478,7 +478,7 @@ static void setup_hist_match(RzLine *line) {
 	if (line->history.do_setup_match) {
 		RZ_FREE(line->history.match);
 		if (*line->buffer.data) {
-			line->history.match = strdup(line->buffer.data);
+			line->history.match = rz_str_dup(line->buffer.data);
 		}
 	}
 	line->history.do_setup_match = false;
@@ -576,7 +576,7 @@ RZ_API bool rz_line_hist_add(RZ_NONNULL RzLine *line, RZ_NONNULL const char *str
 		}
 		line->history.top--;
 	}
-	line->history.data[line->history.top++] = strdup(str);
+	line->history.data[line->history.top++] = rz_str_dup(str);
 	line->history.index = line->history.top;
 	return true;
 }
@@ -840,12 +840,12 @@ static void selection_widget_select(RzLine *line) {
 			line->buffer.index = line->buffer.length;
 			return;
 		}
-		char *del_text = strdup(line->buffer.data);
+		char *del_text = rz_str_dup(line->buffer.data);
 		line->buffer.length = RZ_MIN(strlen(sel_widget->options[sel_widget->selection]), RZ_LINE_BUFSIZE - 1);
 		memcpy(line->buffer.data, sel_widget->options[sel_widget->selection], line->buffer.length);
 		line->buffer.data[line->buffer.length] = '\0';
 		line->buffer.index = line->buffer.length;
-		undo_add_entry(line, 0, del_text, strdup(line->buffer.data));
+		undo_add_entry(line, 0, del_text, rz_str_dup(line->buffer.data));
 		selection_widget_erase(NULL);
 	}
 }
@@ -1175,7 +1175,7 @@ static inline void __delete_prev_char(RzLine *line) {
 
 static inline void delete_till_end(RzLine *line) {
 	if (line->buffer.index < line->buffer.length) {
-		undo_add_entry(line, line->buffer.index, strdup(line->buffer.data + line->buffer.index), NULL);
+		undo_add_entry(line, line->buffer.index, rz_str_dup(line->buffer.data + line->buffer.index), NULL);
 	}
 	line->buffer.data[line->buffer.index] = '\0';
 	line->buffer.length = line->buffer.index;
@@ -1645,7 +1645,7 @@ RZ_API const char *rz_line_readline_cb(RZ_NONNULL RzLine *line, RzLineReadCallba
 						line->buffer.index = line->buffer.length;
 						strncpy(line->buffer.data, tmp_ed_cmd, RZ_LINE_BUFSIZE - 1);
 						line->buffer.data[RZ_LINE_BUFSIZE - 1] = '\0';
-						undo_add_entry(line, 0, NULL, strdup(tmp_ed_cmd));
+						undo_add_entry(line, 0, NULL, rz_str_dup(tmp_ed_cmd));
 					} else {
 						line->buffer.length -= strlen(tmp_ed_cmd);
 					}
@@ -1683,7 +1683,7 @@ RZ_API const char *rz_line_readline_cb(RZ_NONNULL RzLine *line, RzLineReadCallba
 			break;
 		case 11: // ^K
 			if (line->buffer.index != line->buffer.length) {
-				undo_add_entry(line, line->buffer.index, strdup(line->buffer.data + line->buffer.index), NULL);
+				undo_add_entry(line, line->buffer.index, rz_str_dup(line->buffer.data + line->buffer.index), NULL);
 			}
 			line->buffer.data[line->buffer.index] = '\0';
 			line->buffer.length = line->buffer.index;
@@ -1716,10 +1716,10 @@ RZ_API const char *rz_line_readline_cb(RZ_NONNULL RzLine *line, RzLineReadCallba
 			break;
 		case 21: // ^U - cut
 			free(line->clipboard);
-			line->clipboard = strdup(line->buffer.data);
+			line->clipboard = rz_str_dup(line->buffer.data);
 			rz_line_clipboard_push(line, line->clipboard);
 			if (line->buffer.length) {
-				undo_add_entry(line, 0, strdup(line->clipboard), NULL);
+				undo_add_entry(line, 0, rz_str_dup(line->clipboard), NULL);
 			}
 			line->buffer.data[0] = '\0';
 			line->buffer.length = 0;
@@ -1743,7 +1743,7 @@ RZ_API const char *rz_line_readline_cb(RZ_NONNULL RzLine *line, RzLineReadCallba
 						int len = strlen(txt);
 						line->buffer.length += len;
 						if (line->buffer.length < RZ_LINE_BUFSIZE) {
-							undo_add_entry(line, line->buffer.index, NULL, strdup(txt));
+							undo_add_entry(line, line->buffer.index, NULL, rz_str_dup(txt));
 							line->buffer.index = line->buffer.length;
 							strcat(line->buffer.data, txt);
 						} else {

--- a/librz/cons/grep.c
+++ b/librz/cons/grep.c
@@ -132,7 +132,7 @@ static void parse_grep_expression(const char *str) {
 					grep->less = 1;
 				}
 			} else {
-				char *jsonPath = strdup(str + 1);
+				char *jsonPath = rz_str_dup(str + 1);
 				char *jsonPathEnd = strchr(jsonPath, '}');
 				if (jsonPathEnd) {
 					*jsonPathEnd = 0;
@@ -318,7 +318,7 @@ while_end:
 
 	free(grep->str);
 	if (*ptr) {
-		grep->str = (char *)strdup(ptr);
+		grep->str = (char *)rz_str_dup(ptr);
 		do {
 			optr = ptr;
 			ptr = strchr(ptr, ','); // grep keywords
@@ -342,7 +342,7 @@ while_end:
 				optr, RZ_CONS_GREP_WORD_SIZE);
 		} while (ptr);
 	} else {
-		grep->str = strdup(ptr);
+		grep->str = rz_str_dup(ptr);
 		grep->nstrings++;
 		grep->strings[0][0] = 0;
 	}
@@ -452,8 +452,8 @@ static int cmp(const void *a, const void *b, void *user) {
 	}
 	RzConsGrep *grep = user;
 	if (grep->sorted_column > 0) {
-		da = strdup(ca);
-		db = strdup(cb);
+		da = rz_str_dup(ca);
+		db = rz_str_dup(cb);
 		int colsa = rz_str_word_set0(da);
 		int colsb = rz_str_word_set0(db);
 		ca = (colsa > grep->sorted_column) ? rz_str_word_get0(da, grep->sorted_column) : "";
@@ -560,7 +560,7 @@ RZ_API void rz_cons_grepbuf(void) {
 				Color_RESET,
 				NULL
 			};
-			char *bb = strdup(buf);
+			char *bb = rz_str_dup(buf);
 			rz_str_ansi_filter(bb, NULL, NULL, -1);
 			char *out = (cons->context->grep.human)
 				? rz_print_json_human(bb)
@@ -875,9 +875,9 @@ RZ_API int rz_cons_grep_line(char *buf, int len) {
 			grep->unsorted_lines = rz_list_newf(free);
 		}
 		if (cons->lines >= grep->sort_row) {
-			rz_list_append(grep->sorted_lines, strdup(buf));
+			rz_list_append(grep->sorted_lines, rz_str_dup(buf));
 		} else {
-			rz_list_append(grep->unsorted_lines, strdup(buf));
+			rz_list_append(grep->unsorted_lines, rz_str_dup(buf));
 		}
 		buf[len] = ch;
 	}

--- a/librz/cons/hud.c
+++ b/librz/cons/hud.c
@@ -24,7 +24,7 @@ RZ_API char *rz_cons_hud_string(const char *s) {
 		eprintf("Hud mode requires scr.interactive=true.\n");
 		return NULL;
 	}
-	char *os, *track, *ret, *o = strdup(s);
+	char *os, *track, *ret, *o = rz_str_dup(s);
 	if (!o) {
 		return NULL;
 	}
@@ -41,7 +41,7 @@ RZ_API char *rz_cons_hud_string(const char *s) {
 		if (o[i] == '\n') {
 			o[i] = 0;
 			if (*os && *os != '#') {
-				track = strdup(os);
+				track = rz_str_dup(os);
 				if (!rz_list_append(fl, track)) {
 					free(track);
 					break;
@@ -64,7 +64,7 @@ RZ_API char *rz_cons_hud_string(const char *s) {
 static bool __matchString(char *entry, char *filter, char *mask, const int mask_size) {
 	char *p, *current_token = filter;
 	const char *filter_end = filter + strlen(filter);
-	char *ansi_filtered = strdup(entry);
+	char *ansi_filtered = rz_str_dup(entry);
 	int *cps;
 	rz_str_ansi_filter(ansi_filtered, NULL, &cps, -1);
 	entry = ansi_filtered;
@@ -134,7 +134,7 @@ static RzList /*<char *>*/ *hud_filter(RzList /*<char *>*/ *list, char *user_inp
 			if (x) {
 				*x = 0;
 			}
-			p = strdup(current_entry);
+			p = rz_str_dup(current_entry);
 			// if the filter is empty, print the entry and move on
 			if (!user_input[0]) {
 				rz_list_append(res, rz_str_newf(" %c %s", first_line ? '-' : ' ', p));
@@ -259,7 +259,7 @@ RZ_API char *rz_cons_hud(RzList /*<char *>*/ *list, const char *prompt) {
 					rz_cons_enable_mouse(false);
 					rz_cons_show_cursor(true);
 					rz_cons_set_raw(false);
-					return strdup(selected_entry);
+					return rz_str_dup(selected_entry);
 				}
 			} else {
 				goto _beach;
@@ -282,9 +282,9 @@ RZ_API char *rz_cons_hud_path(const char *path, int dir) {
 	RzList *files;
 	if (path) {
 		path = rz_str_trim_head_ro(path);
-		tmp = strdup(*path ? path : "./");
+		tmp = rz_str_dup(*path ? path : "./");
 	} else {
-		tmp = strdup("./");
+		tmp = rz_str_dup("./");
 	}
 	files = rz_sys_dir(tmp);
 	if (files) {

--- a/librz/cons/input.c
+++ b/librz/cons/input.c
@@ -704,5 +704,5 @@ RZ_API char *rz_cons_input(const char *msg) {
 	rz_cons_fgets(buf, sizeof(buf), 0, NULL);
 	rz_line_set_prompt(I->line, oprompt);
 	free(oprompt);
-	return strdup(buf);
+	return rz_str_dup(buf);
 }

--- a/librz/cons/less.c
+++ b/librz/cons/less.c
@@ -34,11 +34,11 @@ RZ_API int rz_cons_less_str(const char *str, const char *exitkeys) {
 	RzPVector **mla;
 
 	// rcons kills str after flushing the buffer, so we must keep a copy
-	char *ostr = strdup(str);
+	char *ostr = rz_str_dup(str);
 	if (!ostr) {
 		return 0;
 	}
-	char *p = strdup(str);
+	char *p = rz_str_dup(str);
 	if (!p) {
 		free(ostr);
 		return 0;

--- a/librz/cons/line.c
+++ b/librz/cons/line.c
@@ -24,7 +24,7 @@ RZ_API RZ_OWN RzLine *rz_line_new(void) {
 	if (!line) {
 		return NULL;
 	}
-	line->prompt = strdup("> ");
+	line->prompt = rz_str_dup("> ");
 	line->kill_ring = rz_list_newf(free);
 	line->kill_ring_ptr = -1;
 #if __WINDOWS__
@@ -56,14 +56,14 @@ RZ_API void rz_line_free(RZ_NULLABLE RzLine *line) {
 RZ_API void rz_line_clipboard_push(RZ_NONNULL RzLine *line, RZ_NONNULL const char *str) {
 	rz_return_if_fail(line && str);
 	line->kill_ring_ptr += 1;
-	rz_list_insert(line->kill_ring, line->kill_ring_ptr, strdup(str));
+	rz_list_insert(line->kill_ring, line->kill_ring_ptr, rz_str_dup(str));
 }
 
 // handle const or dynamic prompts?
 RZ_API void rz_line_set_prompt(RZ_NONNULL RzLine *line, RZ_NONNULL const char *prompt) {
 	rz_return_if_fail(line && prompt);
 	free(line->prompt);
-	line->prompt = strdup(prompt);
+	line->prompt = rz_str_dup(prompt);
 	RzCons *cons = rz_cons_singleton();
 	line->cb_fkey = cons->cb_fkey;
 }
@@ -71,7 +71,7 @@ RZ_API void rz_line_set_prompt(RZ_NONNULL RzLine *line, RZ_NONNULL const char *p
 // handle const or dynamic prompts?
 RZ_API RZ_OWN char *rz_line_get_prompt(RZ_NONNULL RzLine *line) {
 	rz_return_val_if_fail(line, NULL);
-	return strdup(line->prompt);
+	return rz_str_dup(line->prompt);
 }
 
 RZ_API void rz_line_completion_init(RzLineCompletion *completion, size_t args_limit) {
@@ -91,7 +91,7 @@ RZ_API void rz_line_completion_push(RzLineCompletion *completion, const char *st
 		return;
 	}
 	if (rz_pvector_len(&completion->args) < completion->args_limit) {
-		char *s = strdup(str);
+		char *s = rz_str_dup(str);
 		if (s) {
 			rz_pvector_push(&completion->args, (void *)s);
 		}
@@ -166,7 +166,7 @@ RZ_API void rz_line_ns_completion_result_add(RzLineNSCompletionResult *res, cons
 	if (ht_pp_find(res->options_ht, option, NULL)) {
 		return;
 	}
-	char *dup = strdup(option);
+	char *dup = rz_str_dup(option);
 	rz_pvector_push(&res->options, dup);
 	ht_pp_insert(res->options_ht, dup, dup);
 }

--- a/librz/cons/pal.c
+++ b/librz/cons/pal.c
@@ -293,7 +293,7 @@ RZ_API char *rz_cons_pal_parse(const char *str, RzColor *outcol) {
 	if (RZ_STR_ISEMPTY(str)) {
 		return NULL;
 	}
-	fgcolor = strdup(str);
+	fgcolor = rz_str_dup(str);
 	if (!fgcolor) {
 		return NULL;
 	}
@@ -419,7 +419,7 @@ RZ_API char *rz_cons_pal_parse(const char *str, RzColor *outcol) {
 		*outcol = rcolor;
 	}
 	free(fgcolor);
-	return (*out && !outcol) ? strdup(out) : NULL;
+	return (*out && !outcol) ? rz_str_dup(out) : NULL;
 }
 
 static void rz_cons_pal_show_gs(void) {
@@ -552,7 +552,7 @@ RZ_API void rz_cons_pal_list(int rad, const char *arg) {
 			}
 			hasnext = (keys[i + 1].name) ? "\n" : "";
 			// TODO Need to replace the '.' char because this is not valid CSS
-			char *name = strdup(keys[i].name);
+			char *name = rz_str_dup(keys[i].name);
 			int j, len = strlen(name);
 			for (j = 0; j < len; j++) {
 				if (name[j] == '.') {
@@ -564,7 +564,7 @@ RZ_API void rz_cons_pal_list(int rad, const char *arg) {
 			free(name);
 		} break;
 		case 'h':
-			name = strdup(keys[i].name);
+			name = rz_str_dup(keys[i].name);
 			rz_str_replace_char(name, '.', '_');
 			rz_cons_printf(".%s { color:#%02x%02x%02x }\n",
 				name, rcolor->r, rcolor->g, rcolor->b);

--- a/librz/cons/prompt.c
+++ b/librz/cons/prompt.c
@@ -14,11 +14,11 @@ RZ_API RZ_OWN char *rz_cons_prompt(RZ_NONNULL const char *str, RZ_NULLABLE const
 	rz_return_val_if_fail(str, NULL);
 	char cmd[1024];
 	char *res = NULL;
-	char *oprompt = strdup(rz_cons_singleton()->line->prompt);
+	char *oprompt = rz_str_dup(rz_cons_singleton()->line->prompt);
 	rz_cons_show_cursor(true);
 	if (txt && *txt) {
 		free(rz_cons_singleton()->line->contents);
-		rz_cons_singleton()->line->contents = strdup(txt);
+		rz_cons_singleton()->line->contents = rz_str_dup(txt);
 	} else {
 		RZ_FREE(rz_cons_singleton()->line->contents);
 	}
@@ -29,7 +29,7 @@ RZ_API RZ_OWN char *rz_cons_prompt(RZ_NONNULL const char *str, RZ_NULLABLE const
 	}
 	// line[strlen(line)-1]='\0';
 	if (*cmd) {
-		res = strdup(cmd);
+		res = rz_str_dup(cmd);
 	}
 	rz_line_set_prompt(rz_cons_singleton()->line, oprompt);
 	free(oprompt);

--- a/librz/cons/rgb.c
+++ b/librz/cons/rgb.c
@@ -345,5 +345,5 @@ RZ_API char *rz_cons_rgb_tostring(ut8 r, ut8 g, ut8 b) {
 	if (r == 0xff && g == 0x00 && b == 0xff) {
 		str = "magenta";
 	}
-	return str ? strdup(str) : rz_str_newf("#%02x%02x%02x", r, g, b);
+	return str ? rz_str_dup(str) : rz_str_newf("#%02x%02x%02x", r, g, b);
 }

--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -3662,7 +3662,7 @@ RZ_API void rz_agraph_print_json(RzAGraph *g, PJ *pj) {
 	}
 	rz_list_foreach (nodes, it, node) {
 		RzANode *anode = (RzANode *)node->data;
-		char *label = strdup(anode->body);
+		char *label = rz_str_dup(anode->body);
 		pj_o(pj);
 		pj_ki(pj, "id", anode->gnode->idx);
 		pj_ks(pj, "title", anode->title);
@@ -3681,7 +3681,7 @@ RZ_API void rz_agraph_print_json(RzAGraph *g, PJ *pj) {
 
 RZ_API void rz_agraph_set_title(RzAGraph *g, const char *title) {
 	free(g->title);
-	g->title = title ? strdup(title) : NULL;
+	g->title = rz_str_dup(title);
 	sdb_set(g->db, "agraph.title", g->title);
 }
 
@@ -3746,8 +3746,8 @@ RZ_API RzANode *rz_agraph_add_node(const RzAGraph *g, const char *title, const c
 		return NULL;
 	}
 
-	res->title = title ? rz_str_trunc_ellipsis(title, 255) : strdup("");
-	res->body = body ? strdup(body) : strdup("");
+	res->title = title ? rz_str_trunc_ellipsis(title, 255) : rz_str_dup("");
+	res->body = rz_str_dup(body ? body : "");
 	res->layer = -1;
 	res->pos_in_layer = -1;
 	res->is_dummy = false;
@@ -3761,7 +3761,7 @@ RZ_API RzANode *rz_agraph_add_node(const RzAGraph *g, const char *title, const c
 		char *s, *estr, *b;
 		size_t len;
 		sdb_array_add(g->db, "agraph.nodes", res->title);
-		b = strdup(res->body);
+		b = rz_str_dup(res->body);
 		len = strlen(b);
 		if (len > 0 && b[len - 1] == '\n') {
 			b[len - 1] = '\0';
@@ -4136,7 +4136,7 @@ static void nextword(RzCore *core, RzAGraph *g, const char *word) {
 		}
 	}
 	free(gh->old_word);
-	gh->old_word = strdup(word);
+	gh->old_word = rz_str_dup(word);
 	free(s);
 	if (!a && count == 0) {
 		return;
@@ -4301,7 +4301,7 @@ RZ_IPI int rz_core_visual_graph(RzCore *core, RzAGraph *g, RzAnalysisFunction *_
 			showcursor(core, true);
 			const char *cmd = rz_config_get(core->config, "cmd.gprompt");
 			rz_line_set_prompt(line, "cmd.gprompt> ");
-			line->contents = strdup(cmd);
+			line->contents = rz_str_dup(cmd);
 			const char *buf = rz_line_readline(line);
 			line->contents = NULL;
 			rz_config_set(core->config, "cmd.gprompt", buf);

--- a/librz/core/analysis_tp.c
+++ b/librz/core/analysis_tp.c
@@ -176,7 +176,7 @@ static void get_src_regname(RzCore *core, ut64 addr, char *regname, int size) {
 		rz_analysis_op_free(op);
 		return;
 	}
-	char *op_esil = strdup(rz_strbuf_get(&op->esil));
+	char *op_esil = rz_str_dup(rz_strbuf_get(&op->esil));
 	char *tmp = strchr(op_esil, ',');
 	if (tmp) {
 		*tmp = '\0';
@@ -188,7 +188,7 @@ static void get_src_regname(RzCore *core, ut64 addr, char *regname, int size) {
 			const char *reg = rz_reg_32_to_64(analysis->reg, op_esil);
 			if (reg) {
 				free(op_esil);
-				op_esil = strdup(reg);
+				op_esil = rz_str_dup(reg);
 			}
 		}
 		strncpy(regname, op_esil, size - 1);
@@ -320,7 +320,7 @@ bool function_argument_type_derive(RZ_NULLABLE const RzCallable *callable, int a
 		return false;
 	}
 	*type = rz_type_clone(arg->type);
-	*name = strdup(arg->name);
+	*name = rz_str_dup(arg->name);
 	return true;
 }
 
@@ -605,7 +605,7 @@ static void propagate_return_type(RzCore *core, RzAnalysisOp *aop, RzAnalysisOp 
 		} else if (type == RZ_ANALYSIS_OP_TYPE_MOV) {
 			RZ_FREE(ctx->ret_reg);
 			if (single_write_reg && single_write_reg->reg_name) {
-				ctx->ret_reg = strdup(single_write_reg->reg_name);
+				ctx->ret_reg = rz_str_dup(single_write_reg->reg_name);
 			}
 		}
 	} else if (single_write_reg) {
@@ -664,24 +664,24 @@ void propagate_types_among_used_variables(RzCore *core, HtUP *op_cache, RzAnalys
 		// from the RzAnalysisFunction if nothing was found in the RzTypeDB
 		if (full_name) {
 			if (rz_type_func_exist(core->analysis->typedb, full_name)) {
-				fcn_name = strdup(full_name);
+				fcn_name = rz_str_dup(full_name);
 			} else {
 				fcn_name = rz_analysis_function_name_guess(core->analysis->typedb, full_name);
 			}
 			if (!fcn_name) {
-				fcn_name = strdup(full_name);
+				fcn_name = rz_str_dup(full_name);
 				userfnc = true;
 			}
 			const char *Cc = rz_analysis_cc_func(core->analysis, fcn_name);
 			if (Cc && rz_analysis_cc_exist(core->analysis, Cc)) {
-				char *cc = strdup(Cc);
+				char *cc = rz_str_dup(Cc);
 				type_match(core, fcn_name, aop->addr, bb->addr, cc, prev_idx, userfnc, callee_addr, op_cache);
 				prev_idx = ctx->cur_idx;
 				ctx->retctx->ret_type = rz_type_func_ret(core->analysis->typedb, fcn_name);
 				RZ_FREE(ctx->retctx->ret_reg);
 				const char *rr = rz_analysis_cc_ret(core->analysis, cc);
 				if (rr) {
-					ctx->retctx->ret_reg = strdup(rr);
+					ctx->retctx->ret_reg = rz_str_dup(rr);
 				}
 				ctx->retctx->resolved = false;
 				free(cc);

--- a/librz/core/basefind.c
+++ b/librz/core/basefind.c
@@ -75,7 +75,7 @@ static RzBinFile *basefind_new_bin_file(RzCore *core) {
 		return NULL;
 	}
 
-	bf->file = strdup(desc->name);
+	bf->file = rz_str_dup(desc->name);
 	bf->size = rz_io_desc_size(desc);
 	if (bf->size == UT64_MAX) {
 		RZ_LOG_ERROR("basefind: filesize exeeds memory size (UT64_MAX).\n");

--- a/librz/core/cagraph.c
+++ b/librz/core/cagraph.c
@@ -10,9 +10,9 @@ RZ_IPI void rz_core_agraph_reset(RzCore *core) {
 }
 
 RZ_IPI void rz_core_agraph_add_node(RzCore *core, const char *title, const char *body) {
-	char *b = strdup(body);
+	char *b = rz_str_dup(body);
 	if (rz_str_startswith(b, "base64:")) {
-		char *newbody = strdup(b);
+		char *newbody = rz_str_dup(b);
 		if (!newbody) {
 			free(b);
 			return;
@@ -101,7 +101,7 @@ RZ_IPI void rz_core_agraph_print_interactive(RzCore *core) {
 }
 
 static void agraph_print_node_dot(RzANode *n, void *user) {
-	char *label = strdup(n->body);
+	char *label = rz_str_dup(n->body);
 	// label = rz_str_replace (label, "\n", "\\l", 1);
 
 	if (!label || !*label) {

--- a/librz/core/carg.c
+++ b/librz/core/carg.c
@@ -87,14 +87,14 @@ RZ_API char *resolve_fcn_name(RzAnalysis *analysis, const char *func_name) {
 	const char *str = func_name;
 	const char *name = func_name;
 	if (rz_type_func_exist(analysis->typedb, func_name)) {
-		return strdup(func_name);
+		return rz_str_dup(func_name);
 	}
 	while ((str = strchr(str, '.'))) {
 		name = str + 1;
 		str++;
 	}
 	if (rz_type_func_exist(analysis->typedb, name)) {
-		return strdup(name);
+		return rz_str_dup(name);
 	}
 	return rz_analysis_function_name_guess(analysis->typedb, (char *)func_name);
 }
@@ -289,7 +289,7 @@ RZ_API RZ_OWN RzList /*<RzAnalysisFuncArg *>*/ *rz_core_get_func_args(RzCore *co
 		rz_list_free(list);
 		return NULL;
 	}
-	char *cc = strdup(rz_analysis_cc_func(core->analysis, key));
+	char *cc = rz_str_dup(rz_analysis_cc_func(core->analysis, key));
 	const char *src = rz_analysis_cc_arg(core->analysis, cc, 0); // src of first argument
 	if (!cc) {
 		// unsupported calling convention

--- a/librz/core/casm.c
+++ b/librz/core/casm.c
@@ -168,7 +168,7 @@ RZ_API RzCmdStatus rz_core_asm_plugins_print(RzCore *core, const char *arch, RzC
 	if (arch) {
 		rz_list_foreach (a->plugins, iter, ap) {
 			if (ap->cpus && !strcmp(arch, ap->name)) {
-				char *c = strdup(ap->cpus);
+				char *c = rz_str_dup(ap->cpus);
 				int n = rz_str_split(c, ',');
 				for (i = 0; i < n; i++) {
 					rz_cons_println(rz_str_word_get0(c, i));
@@ -231,7 +231,7 @@ RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_strsearch(RzCore *core, const ch
 	if (!(buf = (ut8 *)calloc(core->blocksize, 1))) {
 		return NULL;
 	}
-	if (!(ptr = strdup(input))) {
+	if (!(ptr = rz_str_dup(input))) {
 		free(buf);
 		return NULL;
 	}
@@ -333,7 +333,7 @@ RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_strsearch(RzCore *core, const ch
 					continue;
 				}
 				// opsz = aop.size;
-				opst = strdup(rz_strbuf_get(&aop.esil));
+				opst = rz_str_dup(rz_strbuf_get(&aop.esil));
 				rz_analysis_op_fini(&aop);
 			} else {
 				if (!(len = rz_asm_disassemble(
@@ -346,7 +346,7 @@ RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_strsearch(RzCore *core, const ch
 					continue;
 				}
 				// opsz = op.size;
-				opst = strdup(rz_strbuf_get(&op.buf_asm));
+				opst = rz_str_dup(rz_strbuf_get(&op.buf_asm));
 				rz_asm_op_fini(&op);
 			}
 			if (opst) {
@@ -388,7 +388,7 @@ RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_strsearch(RzCore *core, const ch
 						goto beach;
 					}
 					code[strlen(code) - 2] = 0;
-					hit->code = strdup(code);
+					hit->code = rz_str_dup(code);
 					rz_list_append(hits, hit);
 					RZ_FREE(code);
 					matchcount = 0;

--- a/librz/core/cautocmpl.c
+++ b/librz/core/cautocmpl.c
@@ -261,7 +261,7 @@ static void autocmplt_cmd_arg_file(RzLineNSCompletionResult *res, const char *s,
 
 	if (RZ_STR_ISEMPTY(input)) {
 		free(input);
-		input = strdup(".");
+		input = rz_str_dup(".");
 	} else if (!rz_file_is_abspath(input) && !rz_str_startswith(input, ".")) {
 		const char *fmt = ".%s%s";
 #if __WINDOWS__
@@ -312,7 +312,7 @@ static void autocmplt_cmd_arg_env(RzLineNSCompletionResult *res, const char *s, 
 	res->end_string = "";
 	for (env = rz_sys_get_environ(); *env; env++) {
 		const char *eq = strchr(*env, '=');
-		char *envkey = eq ? rz_str_ndup(*env, eq - *env) : strdup(*env);
+		char *envkey = eq ? rz_str_ndup(*env, eq - *env) : rz_str_dup(*env);
 		if (!strncmp(envkey, s, len)) {
 			rz_line_ns_completion_result_add(res, envkey);
 		}

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -103,7 +103,7 @@ RZ_API void rz_core_bin_export_info(RzCore *core, int mode) {
 		SdbKv *kv = *iter;
 		const char *k = sdbkv_key(kv);
 		const char *v = sdbkv_value(kv);
-		char *dup = strdup(k);
+		char *dup = rz_str_dup(k);
 		if ((flagname = strstr(dup, ".offset"))) {
 			*flagname = 0;
 			flagname = dup;
@@ -114,7 +114,7 @@ RZ_API void rz_core_bin_export_info(RzCore *core, int mode) {
 				rz_flag_set(core->flags, flagname, nv, 0);
 			}
 			free(offset);
-			offset = strdup(v);
+			offset = rz_str_dup(v);
 		}
 		if (strstr(dup, ".cparse")) {
 			if (IS_MODE_RZCMD(mode)) {
@@ -138,11 +138,11 @@ RZ_API void rz_core_bin_export_info(RzCore *core, int mode) {
 		SdbKv *kv = *iter;
 		const char *k = sdbkv_key(kv);
 		const char *v = sdbkv_value(kv);
-		char *dup = strdup(k);
+		char *dup = rz_str_dup(k);
 		if ((flagname = strstr(dup, ".format"))) {
 			*flagname = 0;
 			if (!offset) {
-				offset = strdup("0");
+				offset = rz_str_dup("0");
 			}
 			flagname = dup;
 			if (IS_MODE_RZCMD(mode)) {
@@ -157,11 +157,11 @@ RZ_API void rz_core_bin_export_info(RzCore *core, int mode) {
 		SdbKv *kv = *iter;
 		const char *k = sdbkv_key(kv);
 		const char *v = sdbkv_value(kv);
-		char *dup = strdup(k);
+		char *dup = rz_str_dup(k);
 		if ((flagname = strstr(dup, ".format"))) {
 			*flagname = 0;
 			if (!offset) {
-				offset = strdup("0");
+				offset = rz_str_dup("0");
 			}
 			flagname = dup;
 			int fmtsize = rz_type_format_struct_size(core->analysis->typedb, v, 0, 0);
@@ -1202,7 +1202,7 @@ static void set_bin_relocs(RzCore *r, RzBinObject *o, RzBinReloc *reloc, bool va
 				sdb_free(*db);
 				*db = NULL;
 				free(*sdb_module);
-				*sdb_module = strdup(module);
+				*sdb_module = rz_str_dup(module);
 				/* always lowercase */
 				filename = rz_str_newf("%s.sdb", module);
 				rz_str_case(filename, false);
@@ -1535,7 +1535,7 @@ RZ_API bool rz_core_bin_apply_symbols(RzCore *core, RzBinFile *binfile, bool va)
 					}
 				} else {
 					fi = rz_flag_set(core->flags, sn.methflag, addr, symbol->size);
-					char *comment = (fi && fi->comment) ? strdup(fi->comment) : NULL;
+					char *comment = (fi && fi->comment) ? rz_str_dup(fi->comment) : NULL;
 					if (comment) {
 						rz_flag_item_set_comment(fi, comment);
 						RZ_FREE(comment);
@@ -1544,7 +1544,7 @@ RZ_API bool rz_core_bin_apply_symbols(RzCore *core, RzBinFile *binfile, bool va)
 			} else {
 				const char *n = sn.demname ? sn.demname : symbol->name;
 				const char *fn = sn.demflag ? sn.demflag : sn.nameflag;
-				char *fnp = (core->bin->prefix) ? rz_str_newf("%s.%s", core->bin->prefix, fn) : strdup(fn ? fn : "");
+				char *fnp = (core->bin->prefix) ? rz_str_newf("%s.%s", core->bin->prefix, fn) : rz_str_dup(fn ? fn : "");
 
 				RzFlagItem *fi = rz_flag_get(core->flags, fnp);
 				if (fi) {
@@ -2086,9 +2086,9 @@ RZ_API bool rz_core_bin_cur_export_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzB
 
 static char *dup_import_name(RzBinImport *import, bool demangle) {
 	if (demangle && import->dname) {
-		return strdup(import->dname);
+		return rz_str_dup(import->dname);
 	} else if (import->name) {
-		return strdup(import->name);
+		return rz_str_dup(import->name);
 	}
 	return NULL;
 }
@@ -2789,7 +2789,7 @@ static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzPVector
 					}
 					if (*(ptr + 1) == '\\') {
 						if (!no_dbl_bslash_str) {
-							no_dbl_bslash_str = strdup(str);
+							no_dbl_bslash_str = rz_str_dup(str);
 							if (!no_dbl_bslash_str) {
 								break;
 							}
@@ -2906,7 +2906,7 @@ RZ_API RZ_OWN RzPVector /*<RzBinString *>*/ *rz_core_bin_whole_strings(RZ_NONNUL
 			free(bf);
 			return NULL;
 		}
-		bf->file = strdup(desc->name);
+		bf->file = rz_str_dup(desc->name);
 		bf->size = (int)rz_io_desc_size(desc);
 		if (bf->size == UT64_MAX) {
 			free(bf);
@@ -3367,55 +3367,55 @@ static char *get_rp(const char *rtype) {
 	char *rp = NULL;
 	switch (rtype[0]) {
 	case 'v':
-		rp = strdup("void");
+		rp = rz_str_dup("void");
 		break;
 	case 'c':
-		rp = strdup("char");
+		rp = rz_str_dup("char");
 		break;
 	case 'i':
-		rp = strdup("int");
+		rp = rz_str_dup("int");
 		break;
 	case 's':
-		rp = strdup("short");
+		rp = rz_str_dup("short");
 		break;
 	case 'l':
-		rp = strdup("long");
+		rp = rz_str_dup("long");
 		break;
 	case 'q':
-		rp = strdup("long long");
+		rp = rz_str_dup("long long");
 		break;
 	case 'C':
-		rp = strdup("unsigned char");
+		rp = rz_str_dup("unsigned char");
 		break;
 	case 'I':
-		rp = strdup("unsigned int");
+		rp = rz_str_dup("unsigned int");
 		break;
 	case 'S':
-		rp = strdup("unsigned short");
+		rp = rz_str_dup("unsigned short");
 		break;
 	case 'L':
-		rp = strdup("unsigned long");
+		rp = rz_str_dup("unsigned long");
 		break;
 	case 'Q':
-		rp = strdup("unsigned long long");
+		rp = rz_str_dup("unsigned long long");
 		break;
 	case 'f':
-		rp = strdup("float");
+		rp = rz_str_dup("float");
 		break;
 	case 'd':
-		rp = strdup("double");
+		rp = rz_str_dup("double");
 		break;
 	case 'D':
-		rp = strdup("long double");
+		rp = rz_str_dup("long double");
 		break;
 	case 'B':
-		rp = strdup("bool");
+		rp = rz_str_dup("bool");
 		break;
 	case '#':
-		rp = strdup("CLASS");
+		rp = rz_str_dup("CLASS");
 		break;
 	default:
-		rp = strdup("unknown");
+		rp = rz_str_dup("unknown");
 		break;
 	}
 	return rp;
@@ -3424,10 +3424,10 @@ static char *get_rp(const char *rtype) {
 // https://nshipster.com/type-encodings/
 static char *objc_type_toc(const char *objc_type) {
 	if (!objc_type) {
-		return strdup("void*");
+		return rz_str_dup("void*");
 	}
 	if (*objc_type == '^' && objc_type[1] == '{') {
-		char *a = strdup(objc_type + 2);
+		char *a = rz_str_dup(objc_type + 2);
 		char *b = strchr(a, '>');
 		if (b) {
 			*b = 0;
@@ -3436,7 +3436,7 @@ static char *objc_type_toc(const char *objc_type) {
 		return a;
 	}
 	if (*objc_type == '<') {
-		char *a = strdup(objc_type + 1);
+		char *a = rz_str_dup(objc_type + 1);
 		char *b = strchr(a, '>');
 		if (b) {
 			*b = 0;
@@ -3444,46 +3444,46 @@ static char *objc_type_toc(const char *objc_type) {
 		return a;
 	}
 	if (!strcmp(objc_type, "f")) {
-		return strdup("float");
+		return rz_str_dup("float");
 	}
 	if (!strcmp(objc_type, "d")) {
-		return strdup("double");
+		return rz_str_dup("double");
 	}
 	if (!strcmp(objc_type, "i")) {
-		return strdup("int");
+		return rz_str_dup("int");
 	}
 	if (!strcmp(objc_type, "s")) {
-		return strdup("short");
+		return rz_str_dup("short");
 	}
 	if (!strcmp(objc_type, "l")) {
-		return strdup("long");
+		return rz_str_dup("long");
 	}
 	if (!strcmp(objc_type, "L")) {
-		return strdup("unsigned long");
+		return rz_str_dup("unsigned long");
 	}
 	if (!strcmp(objc_type, "*")) {
-		return strdup("char*");
+		return rz_str_dup("char*");
 	}
 	if (!strcmp(objc_type, "c")) {
-		return strdup("bool");
+		return rz_str_dup("bool");
 	}
 	if (!strcmp(objc_type, "v")) {
-		return strdup("void");
+		return rz_str_dup("void");
 	}
 	if (!strcmp(objc_type, "#")) {
-		return strdup("class");
+		return rz_str_dup("class");
 	}
 	if (!strcmp(objc_type, "B")) {
-		return strdup("cxxbool");
+		return rz_str_dup("cxxbool");
 	}
 	if (!strcmp(objc_type, "Q")) {
-		return strdup("uint64_t");
+		return rz_str_dup("uint64_t");
 	}
 	if (!strcmp(objc_type, "q")) {
-		return strdup("long long");
+		return rz_str_dup("long long");
 	}
 	if (!strcmp(objc_type, "C")) {
-		return strdup("uint8_t");
+		return rz_str_dup("uint8_t");
 	}
 	if (strlen(objc_type) == 1) {
 		RZ_LOG_ERROR("core: unknown objc type '%s'\n", objc_type);
@@ -3493,12 +3493,12 @@ static char *objc_type_toc(const char *objc_type) {
 		s[strlen(s) - 1] = '*';
 		return s;
 	}
-	return strdup(objc_type);
+	return rz_str_dup(objc_type);
 }
 
 static char *objc_name_toc(const char *objc_name) {
 	const char *n = rz_str_lchr(objc_name, ')');
-	char *s = strdup(n ? n + 1 : objc_name);
+	char *s = rz_str_dup(n ? n + 1 : objc_name);
 	char *p = strchr(s, '(');
 	if (p) {
 		*p = 0;
@@ -3662,20 +3662,20 @@ static void classdump_cpp(RzBinClass *c) {
 
 static inline char *demangle_type(const char *any) {
 	if (!any) {
-		return strdup("unknown");
+		return rz_str_dup("unknown");
 	}
 	switch (any[0]) {
 	case 'L': return rz_demangler_java(any, RZ_DEMANGLER_FLAG_ENABLE_ALL);
-	case 'B': return strdup("byte");
-	case 'C': return strdup("char");
-	case 'D': return strdup("double");
-	case 'F': return strdup("float");
-	case 'I': return strdup("int");
-	case 'J': return strdup("long");
-	case 'S': return strdup("short");
-	case 'V': return strdup("void");
-	case 'Z': return strdup("boolean");
-	default: return strdup("unknown");
+	case 'B': return rz_str_dup("byte");
+	case 'C': return rz_str_dup("char");
+	case 'D': return rz_str_dup("double");
+	case 'F': return rz_str_dup("float");
+	case 'I': return rz_str_dup("int");
+	case 'J': return rz_str_dup("long");
+	case 'S': return rz_str_dup("short");
+	case 'V': return rz_str_dup("void");
+	case 'Z': return rz_str_dup("boolean");
+	default: return rz_str_dup("unknown");
 	}
 }
 
@@ -3691,13 +3691,13 @@ static void classdump_java(RzBinClass *c) {
 	char *package = NULL, *classname = NULL;
 	char *tmp = (char *)rz_str_rchr(c->name, NULL, '.');
 	if (tmp) {
-		package = strdup(c->name);
-		classname = strdup(tmp + 1);
+		package = rz_str_dup(c->name);
+		classname = rz_str_dup(tmp + 1);
 		classname[strlen(classname) - 1] = 0;
 		simplify = true;
 	} else {
-		package = strdup("defpackage");
-		classname = strdup(c->name);
+		package = rz_str_dup("defpackage");
+		classname = rz_str_dup(c->name);
 	}
 
 	rz_cons_printf("package %s;\n\n", package);
@@ -3708,7 +3708,7 @@ static void classdump_java(RzBinClass *c) {
 		visibility = resolve_java_visibility(f->visibility_str);
 		char *ftype = demangle_type(f->type);
 		if (!ftype) {
-			ftype = strdup(f->type);
+			ftype = rz_str_dup(f->type);
 		} else if (simplify && ftype && package && classname) {
 			// hide the current package in the demangled value.
 			ftype = rz_str_replace(ftype, package, classname, 1);
@@ -3725,7 +3725,7 @@ static void classdump_java(RzBinClass *c) {
 		visibility = resolve_java_visibility(sym->visibility_str);
 		char *dem = rz_demangler_java(mn, RZ_DEMANGLER_FLAG_ENABLE_ALL);
 		if (!dem) {
-			dem = strdup(mn);
+			dem = rz_str_dup(mn);
 		} else if (simplify && dem && package && classname) {
 			// hide the current package in the demangled value.
 			dem = rz_str_replace(dem, package, classname, 1);
@@ -4537,7 +4537,7 @@ RZ_API int rz_core_bin_set_arch_bits(RzCore *r, const char *name, const char *ar
 		rz_core_bin_set_cur(r, binfile);
 		if (binfile->o && binfile->o->info) {
 			free(binfile->o->info->arch);
-			binfile->o->info->arch = strdup(arch);
+			binfile->o->info->arch = rz_str_dup(arch);
 			binfile->o->info->bits = bits;
 		}
 		return rz_core_bin_apply_all_info(r, binfile);
@@ -4685,7 +4685,7 @@ RZ_API RZ_OWN char *rz_core_bin_class_build_flag_name(RZ_NONNULL RzBinClass *cls
 	}
 
 	if (cls->visibility_str) {
-		char *copy = strdup(cls->visibility_str);
+		char *copy = rz_str_dup(cls->visibility_str);
 		rz_str_replace_ch(copy, ' ', '.', 1);
 		ret = rz_str_newf("class.%s.%s", copy, cls->name);
 		free(copy);
@@ -4708,7 +4708,7 @@ RZ_API RZ_OWN char *rz_core_bin_super_build_flag_name(RZ_NONNULL RzBinClass *cls
 	}
 
 	if (cls->visibility_str) {
-		char *copy = strdup(cls->visibility_str);
+		char *copy = rz_str_dup(cls->visibility_str);
 		rz_str_replace_ch(copy, ' ', '.', 1);
 		ret = rz_str_newf("super.%s.%s.%s", copy, cls->name, cls->super);
 		free(copy);
@@ -4733,7 +4733,7 @@ RZ_API RZ_OWN char *rz_core_bin_method_build_flag_name(RZ_NONNULL RzBinClass *cl
 	rz_strbuf_initf(&buf, "method");
 
 	if (meth->visibility_str) {
-		char *copy = strdup(meth->visibility_str);
+		char *copy = rz_str_dup(meth->visibility_str);
 		rz_str_replace_ch(copy, ' ', '.', 1);
 		rz_strbuf_appendf(&buf, ".%s", copy);
 		free(copy);
@@ -4761,7 +4761,7 @@ RZ_API RZ_OWN char *rz_core_bin_field_build_flag_name(RZ_NONNULL RzBinClass *cls
 	rz_strbuf_initf(&buf, "field");
 
 	if (field->visibility_str) {
-		char *copy = strdup(field->visibility_str);
+		char *copy = rz_str_dup(field->visibility_str);
 		rz_str_replace_ch(copy, ' ', '.', 1);
 		rz_strbuf_appendf(&buf, ".%s", copy);
 		free(copy);
@@ -4940,13 +4940,13 @@ RZ_API RZ_OWN char *rz_core_bin_pdb_get_filename(RZ_NONNULL RzCore *core) {
 	// Check raw path for debug filename
 	bool file_found = rz_file_exists(info->debug_file_name);
 	if (file_found) {
-		return strdup(info->debug_file_name);
+		return rz_str_dup(info->debug_file_name);
 	}
 	// Check debug filename basename in current directory
 	const char *basename = rz_file_dos_basename(info->debug_file_name);
 	file_found = rz_file_exists(basename);
 	if (file_found) {
-		return strdup(basename);
+		return rz_str_dup(basename);
 	}
 	// Check if debug file is in file directory
 	char *dir = rz_file_dirname(core->bin->cur->file);
@@ -5323,7 +5323,7 @@ RZ_API bool rz_core_bin_pdb_load(RZ_NONNULL RzCore *core, RZ_NONNULL const char 
 	if (!buf) {
 		return false;
 	}
-	char *s = strdup(buf);
+	char *s = rz_str_dup(buf);
 	if (!s) {
 		return false;
 	}

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -414,7 +414,7 @@ static void print_debug_map_line(RzDebug *dbg, RzDebugMap *map, ut64 addr, RzCmd
 		if (!flagname) {
 			flagname = "";
 		} else if (map->name) {
-			char *filtered_name = strdup(map->name);
+			char *filtered_name = rz_str_dup(map->name);
 			rz_name_filter(filtered_name, 0, true);
 			if (!strncmp(flagname, "map.", 4) &&
 				!strcmp(flagname + 4, filtered_name)) {

--- a/librz/core/cesil.c
+++ b/librz/core/cesil.c
@@ -25,16 +25,16 @@ static ut64 initializeEsil(RzCore *core) {
 	{
 		const char *cmd_esil_step = rz_config_get(core->config, "cmd.esil.step");
 		if (cmd_esil_step && *cmd_esil_step) {
-			esil->cmd_step = strdup(cmd_esil_step);
+			esil->cmd_step = rz_str_dup(cmd_esil_step);
 		}
 		const char *cmd_esil_step_out = rz_config_get(core->config, "cmd.esil.stepout");
 		if (cmd_esil_step_out && *cmd_esil_step_out) {
-			esil->cmd_step_out = strdup(cmd_esil_step_out);
+			esil->cmd_step_out = rz_str_dup(cmd_esil_step_out);
 		}
 		{
 			const char *s = rz_config_get(core->config, "cmd.esil.intr");
 			if (s) {
-				char *my = strdup(s);
+				char *my = rz_str_dup(s);
 				if (my) {
 					rz_config_set(core->config, "cmd.esil.intr", my);
 					free(my);

--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -74,7 +74,7 @@ static RZ_OWN RzPVector /*<RzBinSection *>*/ *__save_old_sections(RzCore *core) 
 			break;
 		}
 		*old_sec = *sec;
-		old_sec->name = strdup(sec->name);
+		old_sec->name = rz_str_dup(sec->name);
 		old_sec->format = NULL;
 		rz_pvector_push(old_sections, old_sec);
 	}
@@ -245,7 +245,7 @@ RZ_API void rz_core_file_reopen_remote_debug(RzCore *core, const char *uri, ut64
 	rz_config_set_b(core->config, "cfg.debug", true);
 	// Set referer as the original uri so we could return to it with `oo`
 	desc->referer = desc->uri;
-	desc->uri = strdup(uri);
+	desc->uri = rz_str_dup(uri);
 
 	if ((file = rz_core_file_open(core, uri, RZ_PERM_R | RZ_PERM_W, addr))) {
 		fd = file->fd;
@@ -293,10 +293,10 @@ RZ_API void rz_core_file_reopen_debug(RzCore *core, const char *args) {
 	}
 
 	RzBinFile *bf = rz_bin_file_find_by_fd(core->bin, ofile->fd);
-	char *binpath = (bf && bf->file) ? strdup(bf->file) : NULL;
+	char *binpath = (bf && bf->file) ? rz_str_dup(bf->file) : NULL;
 	if (!binpath) {
 		if (rz_file_exists(desc->name)) {
-			binpath = strdup(desc->name);
+			binpath = rz_str_dup(desc->name);
 		}
 	}
 	if (!binpath) {
@@ -336,7 +336,7 @@ RZ_API bool rz_core_file_reopen(RzCore *core, const char *args, int perm, int lo
 	RzBinFile *bf = ofile ? rz_bin_file_find_by_fd(core->bin, ofile->fd)
 			      : NULL;
 	RzIODesc *odesc = (core->io && ofile) ? rz_io_desc_get(core->io, ofile->fd) : NULL;
-	char *ofilepath = NULL, *obinfilepath = (bf && bf->file) ? strdup(bf->file) : NULL;
+	char *ofilepath = NULL, *obinfilepath = (bf && bf->file) ? rz_str_dup(bf->file) : NULL;
 	int ret = false;
 	ut64 origoff = core->offset;
 	if (odesc) {
@@ -389,9 +389,9 @@ RZ_API bool rz_core_file_reopen(RzCore *core, const char *args, int perm, int lo
 	// HACK: move last mapped address to higher place
 	// XXX - why does this hack work?
 	// when the new memory maps are created.
-	path = strdup(ofilepath);
+	path = rz_str_dup(ofilepath);
 	free(obinfilepath);
-	obinfilepath = strdup(ofilepath);
+	obinfilepath = rz_str_dup(ofilepath);
 
 	// rz_str_trim (path);
 	file = rz_core_file_open(core, path, perm, laddr);

--- a/librz/core/cgraph.c
+++ b/librz/core/cgraph.c
@@ -22,7 +22,7 @@ static inline bool is_between(ut64 a, ut64 x, ut64 b) {
 
 static inline char *core_flag_name(const RzCore *core, ut64 addr) {
 	RzFlagItem *item = rz_flag_get_i(core->flags, addr);
-	return item ? strdup(item->name) : rz_str_newf("0x%08" PFMT64x, addr);
+	return item ? rz_str_dup(item->name) : rz_str_newf("0x%08" PFMT64x, addr);
 }
 
 static inline void core_graph_dataref(RzCore *core, RzAnalysisFunction *fcn, RzGraph /*<RzGraphNodeInfo *>*/ *graph) {
@@ -259,7 +259,7 @@ static inline char *block_disasm(RzCore *core, ut64 addr, RzAnalysisBlock *bb) {
 	rz_core_print_disasm(core, b->addr, block, b->size, 9999, NULL, &disasm_options);
 	rz_cons_filter();
 	const char *retstr = rz_str_get(rz_cons_get_buffer());
-	char *opcodes = strdup(retstr);
+	char *opcodes = rz_str_dup(retstr);
 	rz_cons_pop();
 	rz_cons_echo(NULL);
 	free(block);

--- a/librz/core/cil.c
+++ b/librz/core/cil.c
@@ -32,7 +32,7 @@ static void core_esil_init(RzCore *core) {
 	esil->verbose = verbose;
 	const char *s = rz_config_get(core->config, "cmd.esil.intr");
 	if (s) {
-		char *my = strdup(s);
+		char *my = rz_str_dup(s);
 		if (my) {
 			rz_config_set(core->config, "cmd.esil.intr", my);
 			free(my);

--- a/librz/core/cio.c
+++ b/librz/core/cio.c
@@ -422,7 +422,7 @@ RZ_API RzCmdStatus rz_core_io_plugin_print(RzIOPlugin *plugin, RzCmdStateOutput 
 
 		if (plugin->uris) {
 			char *uri;
-			char *uris = strdup(plugin->uris);
+			char *uris = rz_str_dup(plugin->uris);
 			RzList *plist = rz_str_split_list(uris, ",", 0);
 			RzListIter *piter;
 			pj_k(pj, "uris");
@@ -605,7 +605,7 @@ RZ_API bool rz_core_write_value_inc_at(RzCore *core, ut64 addr, st64 value, int 
 RZ_API bool rz_core_write_string_at(RzCore *core, ut64 addr, RZ_NONNULL const char *s) {
 	rz_return_val_if_fail(core && s, false);
 
-	char *str = strdup(s);
+	char *str = rz_str_dup(s);
 	if (!str) {
 		return false;
 	}
@@ -631,7 +631,7 @@ RZ_API bool rz_core_write_string_wide_at(RzCore *core, ut64 addr, const char *s)
 	rz_return_val_if_fail(core && s, false);
 
 	bool res = false;
-	char *str = strdup(s);
+	char *str = rz_str_dup(s);
 	if (!str) {
 		return false;
 	}
@@ -673,7 +673,7 @@ str_err:
 RZ_API bool rz_core_write_length_string_at(RzCore *core, ut64 addr, const char *s) {
 	rz_return_val_if_fail(core && s, false);
 
-	char *str = strdup(s);
+	char *str = rz_str_dup(s);
 	if (!str) {
 		return false;
 	}
@@ -905,7 +905,7 @@ RZ_API RzCmdStatus rz_core_io_pcache_print(RzCore *core, RzIODesc *desc, RzCmdSt
 RZ_API bool rz_core_write_string_zero_at(RzCore *core, ut64 addr, const char *s) {
 	rz_return_val_if_fail(core && s, false);
 
-	char *str = strdup(s);
+	char *str = rz_str_dup(s);
 	if (!str) {
 		return false;
 	}

--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -268,7 +268,7 @@ static char *langFromHashbang(RzCore *core, const char *file) {
 			if (nl) {
 				*nl = 0;
 			}
-			nl = strdup(firstLine + 2);
+			nl = rz_str_dup(firstLine + 2);
 			close(fd);
 			return nl;
 		}
@@ -292,7 +292,7 @@ RZ_API bool rz_core_run_script(RzCore *core, RZ_NONNULL const char *file) {
 			return false;
 		}
 	}
-	rz_list_push(core->scriptstack, strdup(file));
+	rz_list_push(core->scriptstack, rz_str_dup(file));
 
 	if (!strcmp(file, "-")) {
 		char *out = rz_core_editor(core, NULL, NULL);
@@ -301,7 +301,7 @@ RZ_API bool rz_core_run_script(RzCore *core, RZ_NONNULL const char *file) {
 			free(out);
 		}
 	} else if (rz_str_endswith(file, ".html")) {
-		char *httpIndex = strdup(rz_config_get(core->config, "http.index"));
+		char *httpIndex = rz_str_dup(rz_config_get(core->config, "http.index"));
 		char *absfile = rz_file_abspath(file);
 		rz_config_set(core->config, "http.index", absfile);
 		free(absfile);
@@ -385,7 +385,7 @@ RZ_API bool rz_core_run_script(RzCore *core, RZ_NONNULL const char *file) {
 				} else if (!strcmp(ext, "sh")) {
 					char *shell = rz_sys_getenv("SHELL");
 					if (!shell) {
-						shell = strdup("sh");
+						shell = rz_str_dup("sh");
 					}
 					if (shell) {
 						rz_lang_use(core->lang, "pipe");
@@ -549,7 +549,7 @@ RZ_IPI int rz_cmd_kuery(void *data, const char *input) {
 			return false;
 		}
 		if (input[1] == ' ') {
-			char *n, *o, *p = strdup(input + 2);
+			char *n, *o, *p = rz_str_dup(input + 2);
 			// TODO: slash split here? or inside sdb_ns ?
 			for (n = o = p; n; o = n) {
 				n = strchr(o, '/'); // SDB_NS_SEPARATOR NAMESPACE
@@ -579,7 +579,7 @@ RZ_IPI int rz_cmd_kuery(void *data, const char *input) {
 			}
 			if (sdb_hist) {
 				if ((rz_list_length(sdb_hist) == 1) || (rz_list_length(sdb_hist) > 1 && strcmp(rz_list_get_n(sdb_hist, 1), buf))) {
-					rz_list_insert(sdb_hist, 1, strdup(buf));
+					rz_list_insert(sdb_hist, 1, rz_str_dup(buf));
 				}
 				line->sdbshell_hist_iter = sdb_hist->head;
 			}
@@ -593,7 +593,7 @@ RZ_IPI int rz_cmd_kuery(void *data, const char *input) {
 		break;
 	case 'o': // "ko"
 		if (input[1] == ' ') {
-			char *fn = strdup(input + 2);
+			char *fn = rz_str_dup(input + 2);
 			if (!fn) {
 				RZ_LOG_ERROR("core: Unable to allocate memory\n");
 				return 0;
@@ -627,7 +627,7 @@ RZ_IPI int rz_cmd_kuery(void *data, const char *input) {
 		break;
 	case 'd': // "kd"
 		if (input[1] == ' ') {
-			char *fn = strdup(input + 2);
+			char *fn = rz_str_dup(input + 2);
 			char *ns = strchr(fn, ' ');
 			if (ns) {
 				*ns++ = 0;
@@ -658,7 +658,7 @@ RZ_IPI int rz_cmd_kuery(void *data, const char *input) {
 
 	sp = strchr(input + 1, ' ');
 	if (sp) {
-		char *inp = strdup(input);
+		char *inp = rz_str_dup(input);
 		inp[(size_t)(sp - input)] = 0;
 		s = sdb_ns(core->sdb, inp + 1, 1);
 		out = sdb_querys(s, NULL, 0, sp + 1);
@@ -989,9 +989,9 @@ RZ_API int rz_core_cmd_pipe_old(RzCore *core, char *rizin_cmd, char *shell_cmd) 
 }
 
 static char *parse_tmp_evals(RzCore *core, const char *str) {
-	char *s = strdup(str);
+	char *s = rz_str_dup(str);
 	int i, argc = rz_str_split(s, ',');
-	char *res = strdup("");
+	char *res = rz_str_dup("");
 	if (!s || !res) {
 		free(s);
 		free(res);
@@ -1078,7 +1078,7 @@ static int rz_core_cmd_subst(RzCore *core, char *cmd) {
 	/* must store a local orig_offset because there can be
 	 * nested call of this function */
 	ut64 orig_offset = core->offset;
-	icmd = strdup(cmd);
+	icmd = rz_str_dup(cmd);
 	if (!icmd) {
 		goto beach;
 	}
@@ -1170,7 +1170,7 @@ static int rz_core_cmd_subst(RzCore *core, char *cmd) {
 		if (rz_cons_is_breaked()) {
 			break;
 		}
-		char *cr = strdup(cmdrep);
+		char *cr = rz_str_dup(cmdrep);
 		core->break_loop = false;
 		ret = rz_core_cmd_subst_i(core, cmd, colon, (rep == orep - 1) ? &tmpseek : NULL);
 		if (ret && *cmd == 'q') {
@@ -1241,7 +1241,7 @@ static void tmpenvs_free(void *item) {
 
 static bool set_tmp_arch(RzCore *core, char *arch, char **tmparch) {
 	rz_return_val_if_fail(tmparch, false);
-	*tmparch = strdup(rz_config_get(core->config, "asm.arch"));
+	*tmparch = rz_str_dup(rz_config_get(core->config, "asm.arch"));
 	rz_config_set(core->config, "asm.arch", arch);
 	core->fixedarch = true;
 	return true;
@@ -1249,7 +1249,7 @@ static bool set_tmp_arch(RzCore *core, char *arch, char **tmparch) {
 
 static bool set_tmp_bits(RzCore *core, int bits, char **tmpbits, int *cmd_ignbithints) {
 	rz_return_val_if_fail(tmpbits, false);
-	*tmpbits = strdup(rz_config_get(core->config, "asm.bits"));
+	*tmpbits = rz_str_dup(rz_config_get(core->config, "asm.bits"));
 	rz_config_set_i(core->config, "asm.bits", bits);
 	core->fixedbits = true;
 	// XXX: why?
@@ -1373,7 +1373,7 @@ static int rz_core_cmd_subst_i(RzCore *core, char *cmd, char *colon, bool *tmpse
 					cpipe = rz_cons_pipe_open(str, 1, append);
 				}
 			}
-			line = strdup(cmd);
+			line = rz_str_dup(cmd);
 			line = rz_str_replace(line, "\\\"", "\"", true);
 			if (p && *p && p[1] == '|') {
 				str = (char *)rz_str_trim_head_ro(p + 2);
@@ -1732,7 +1732,7 @@ next2:
 				}
 			}
 			str = rz_str_append(str, ptr2 + 1);
-			cmd = rz_str_append(strdup(cmd), str);
+			cmd = rz_str_append(rz_str_dup(cmd), str);
 			core->num->value = value;
 			ret = rz_core_cmd_subst(core, cmd);
 			free(cmd);
@@ -1822,7 +1822,7 @@ escape_backtick:
 		if (ptr[1] == '?') {
 			rz_core_cmd_help(core, help_msg_at);
 		} else if (ptr[1] == '%') { // "@%"
-			char *k = strdup(ptr + 2);
+			char *k = rz_str_dup(ptr + 2);
 			char *v = strchr(k, '=');
 			if (v) {
 				*v++ = 0;
@@ -1883,7 +1883,7 @@ escape_backtick:
 			case 'r': // "@r:" // regname
 				if (ptr[1] == ':') {
 					ut64 regval;
-					char *mander = strdup(ptr + 2);
+					char *mander = rz_str_dup(ptr + 2);
 					char *sep = findSeparator(mander);
 					if (sep) {
 						char ch = *sep;
@@ -2411,7 +2411,7 @@ RZ_API int rz_core_cmd_foreach3(RzCore *core, const char *cmd, char *each) { // 
 				if (item->type != i) {
 					continue;
 				}
-				rz_list_append(list, strdup(item->name));
+				rz_list_append(list, rz_str_dup(item->name));
 			}
 			const char *item_name;
 			rz_list_foreach (list, iter, item_name) {
@@ -2605,7 +2605,7 @@ RZ_API int rz_core_cmd_foreach3(RzCore *core, const char *cmd, char *each) { // 
 }
 
 static void foreachOffset(RzCore *core, const char *_cmd, const char *each) {
-	char *cmd = strdup(_cmd);
+	char *cmd = rz_str_dup(_cmd);
 	char *nextLine = NULL;
 	ut64 addr;
 	/* foreach list of items */
@@ -2679,12 +2679,12 @@ RZ_API int rz_core_cmd_foreach(RzCore *core, const char *cmd, char *each) {
 	}
 
 	oseek = core->offset;
-	ostr = str = strdup(each);
+	ostr = str = rz_str_dup(each);
 	rz_cons_break_push(NULL, NULL); // pop on return
 	switch (each[0]) {
 	case '/': // "@@/"
 	{
-		char *cmdhit = strdup(rz_config_get(core->config, "cmd.hit"));
+		char *cmdhit = rz_str_dup(rz_config_get(core->config, "cmd.hit"));
 		rz_config_set(core->config, "cmd.hit", cmd);
 		rz_core_cmd0(core, each);
 		rz_config_set(core->config, "cmd.hit", cmdhit);
@@ -2907,7 +2907,7 @@ RZ_API int rz_core_cmd_foreach(RzCore *core, const char *cmd, char *each) {
 			}
 			ch = str[i];
 			str[i] = '\0';
-			word = strdup(str + j);
+			word = rz_str_dup(str + j);
 			if (!word) {
 				break;
 			}
@@ -3221,7 +3221,7 @@ static char *do_handle_substitution_cmd(struct tsr2cmd_state *state, TSNode inn_
 	}
 
 	// replace the output of the sub command with the current argument
-	char *out = strdup(o_out);
+	char *out = rz_str_dup(o_out);
 	rz_str_trim(out);
 	RZ_LOG_DEBUG("output of inner command: '%s'\n", out);
 	free(o_out);
@@ -4577,7 +4577,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_hit_stmt) {
 	TSNode command = ts_node_named_child(node, 0);
 	TSNode search_cmd = ts_node_named_child(node, 1);
 	char *command_str = ts_node_sub_string(command, state->input);
-	char *cmdhit = strdup(rz_config_get(core->config, "cmd.hit"));
+	char *cmdhit = rz_str_dup(rz_config_get(core->config, "cmd.hit"));
 	rz_config_set(core->config, "cmd.hit", command_str);
 	RzCmdStatus res = handle_ts_stmt(state, search_cmd);
 	rz_config_set(core->config, "cmd.hit", cmdhit);
@@ -4635,7 +4635,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_interpret_stmt) {
 	rz_list_append(edits, e);
 
 	TSNode op = ts_node_child(node, 1);
-	e = create_cmd_edit(state, op, strdup("@@="));
+	e = create_cmd_edit(state, op, rz_str_dup("@@="));
 	rz_list_append(edits, e);
 
 	TSNode new_command;
@@ -4673,7 +4673,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_interpret_offsetssizes_stmt) {
 	rz_list_append(edits, e);
 
 	TSNode op = ts_node_child(node, 1);
-	e = create_cmd_edit(state, op, strdup("@@@="));
+	e = create_cmd_edit(state, op, rz_str_dup("@@@="));
 	rz_list_append(edits, e);
 
 	TSNode new_command;
@@ -4777,7 +4777,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_register_stmt) {
 			if (item->type != i) {
 				continue;
 			}
-			rz_list_append(list, strdup(item->name));
+			rz_list_append(list, rz_str_dup(item->name));
 		}
 		const char *item_name;
 		rz_list_foreach (list, iter, item_name) {
@@ -5252,7 +5252,7 @@ static RzCmdStatus core_cmd_tsrzcmd(RzCore *core, const char *cstr, bool split_l
 	bool language_ok = ts_parser_set_language(parser, (TSLanguage *)core->rcmd->language);
 	rz_return_val_if_fail(language_ok, RZ_CMD_STATUS_INVALID);
 
-	char *input = strdup(rz_str_trim_head_ro(cstr));
+	char *input = rz_str_dup(rz_str_trim_head_ro(cstr));
 
 	TSTree *tree = ts_parser_parse_string(parser, NULL, input, strlen(input));
 	if (!tree) {
@@ -5399,7 +5399,7 @@ RZ_API char *rz_core_disassemble_bytes(RzCore *core, ut64 addr, int b) {
 }
 
 RZ_API int rz_core_cmd_buffer(RzCore *core, const char *buf) {
-	char *ptr, *optr, *str = strdup(buf);
+	char *ptr, *optr, *str = rz_str_dup(buf);
 	if (!str) {
 		return false;
 	}
@@ -5455,7 +5455,7 @@ RZ_API char *rz_core_cmd_str_pipe(RzCore *core, const char *cmd) {
 			free(tmp);
 			return rz_core_cmd_str(core, cmd);
 		}
-		char *_cmd = strdup(cmd);
+		char *_cmd = rz_str_dup(cmd);
 		rz_core_cmd(core, _cmd, 0);
 		rz_cons_flush();
 		rz_cons_pipe_close(cpipe);
@@ -5464,7 +5464,7 @@ RZ_API char *rz_core_cmd_str_pipe(RzCore *core, const char *cmd) {
 			rz_file_rm(tmp);
 			free(tmp);
 			free(_cmd);
-			return s ? s : strdup("");
+			return s ? s : rz_str_dup("");
 		}
 		RZ_LOG_ERROR("core: slurp %s fails\n", tmp);
 		rz_file_rm(tmp);
@@ -5505,7 +5505,7 @@ static ut8 *core_cmd_raw(RzCore *core, const char *cmd, int *length) {
 		retstr = (ut8 *)rz_str_newlen(static_str, len);
 		*length = len;
 	} else {
-		retstr = (ut8 *)strdup(rz_str_get(static_str));
+		retstr = (ut8 *)rz_str_dup(rz_str_get(static_str));
 	}
 
 	rz_cons_pop();

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -454,7 +454,7 @@ static void core_analysis_bytes_desc(RzCore *core, const ut8 *buf, int len, int 
 			break;
 		}
 
-		char *opname = strdup(rz_asm_op_get_asm(&asmop));
+		char *opname = rz_str_dup(rz_asm_op_get_asm(&asmop));
 		if (opname) {
 			rz_str_split(opname, ' ');
 			char *d = rz_asm_describe(core->rasm, opname);
@@ -703,7 +703,7 @@ static char *fcnjoin(RzList /*<RzAnalysisFunction *>*/ *list) {
 	rz_list_foreach (list, iter, n) {
 		rz_strbuf_appendf(&buf, " 0x%08" PFMT64x, n->addr);
 	}
-	char *s = strdup(rz_strbuf_get(&buf));
+	char *s = rz_str_dup(rz_strbuf_get(&buf));
 	rz_strbuf_fini(&buf);
 	return s;
 }
@@ -716,7 +716,7 @@ static char *ut64join(RzList /*<ut64 *>*/ *list) {
 	rz_list_foreach (list, iter, n) {
 		rz_strbuf_appendf(&buf, " 0x%08" PFMT64x, *n);
 	}
-	char *s = strdup(rz_strbuf_get(&buf));
+	char *s = rz_str_dup(rz_strbuf_get(&buf));
 	rz_strbuf_fini(&buf);
 	return s;
 }
@@ -866,14 +866,14 @@ static int myregwrite(RzAnalysisEsil *esil, const char *name, ut64 *val) {
 	AeaStats *stats = esil->user;
 	if (!IS_DIGIT(*name)) {
 		if (!contains(stats->regs, name)) {
-			rz_list_push(stats->regs, strdup(name));
+			rz_list_push(stats->regs, rz_str_dup(name));
 		}
 		if (!contains(stats->regwrite, name)) {
-			rz_list_push(stats->regwrite, strdup(name));
+			rz_list_push(stats->regwrite, rz_str_dup(name));
 		}
 		char *v = rz_str_newf("%" PFMT64d, *val);
 		if (!contains(stats->regvalues, v)) {
-			rz_list_push(stats->regvalues, strdup(v));
+			rz_list_push(stats->regvalues, rz_str_dup(v));
 		}
 		free(v);
 	}
@@ -885,14 +885,14 @@ static int myregread(RzAnalysisEsil *esil, const char *name, ut64 *val, int *len
 	if (!IS_DIGIT(*name)) {
 		if (!contains(stats->inputregs, name)) {
 			if (!contains(stats->regwrite, name)) {
-				rz_list_push(stats->inputregs, strdup(name));
+				rz_list_push(stats->inputregs, rz_str_dup(name));
 			}
 		}
 		if (!contains(stats->regs, name)) {
-			rz_list_push(stats->regs, strdup(name));
+			rz_list_push(stats->regs, rz_str_dup(name));
 		}
 		if (!contains(stats->regread, name)) {
-			rz_list_push(stats->regread, strdup(name));
+			rz_list_push(stats->regread, rz_str_dup(name));
 		}
 	}
 	return 0;
@@ -1036,7 +1036,7 @@ static bool cmd_aea(RzCore *core, int mode, ut64 addr, int length) {
 		char *reg;
 		rz_list_foreach (stats.regs, iter, reg) {
 			if (!contains(stats.regwrite, reg)) {
-				rz_list_push(regnow, strdup(reg));
+				rz_list_push(regnow, rz_str_dup(reg));
 			}
 		}
 	}
@@ -1636,7 +1636,7 @@ static void cmd_analysis_esil(RzCore *core, const char *input) {
 		int ret, bufsz;
 
 		input = rz_str_trim_head_ro(input + 1);
-		hex = strdup(input);
+		hex = rz_str_dup(input);
 		if (!hex) {
 			break;
 		}
@@ -2295,7 +2295,7 @@ RZ_IPI RzCmdStatus rz_analysis_function_signature_bytes_handler(RzCore *core, in
 
 	if (!(s_pattern = rz_hex_bin2strdup(pattern, size)) ||
 		!(s_mask = rz_hex_bin2strdup(mask, size)) ||
-		!(s_search = strdup(s_pattern))) {
+		!(s_search = rz_str_dup(s_pattern))) {
 		RZ_LOG_ERROR("core: failed to convert pattern & mask to string\n");
 		status = RZ_CMD_STATUS_ERROR;
 		goto fail;
@@ -3344,7 +3344,7 @@ RZ_IPI RzCmdStatus rz_analysis_xrefs_to_graph_cmd_handler(RzCore *core, int argc
 	rz_list_foreach (list, iter, xref) {
 		char *str = rz_core_cmd_strf(core, "fd @ 0x%" PFMT64x, xref->from);
 		if (!str) {
-			str = strdup("?\n");
+			str = rz_str_dup("?\n");
 		}
 		rz_str_trim_tail(str);
 		rz_cons_printf("agn 0x%" PFMT64x " \"%s\"\n", xref->from, str);
@@ -4153,7 +4153,7 @@ RZ_IPI RzCmdStatus rz_analysis_function_import_list_handler(RzCore *core, int ar
 				return RZ_CMD_STATUS_ERROR;
 			}
 		}
-		char *import = strdup(argv[1]);
+		char *import = rz_str_dup(argv[1]);
 		if (!import || !rz_list_append(fcn->imports, import)) {
 			free(import);
 			return RZ_CMD_STATUS_ERROR;
@@ -4258,7 +4258,7 @@ static void print_stats(RzCore *core, HtSU *ht, RzAnalysisFunction *fcn, RzCmdSt
 			rz_list_free(list);
 			return;
 		}
-		rz_pvector_push(items, strdup(fcn->name));
+		rz_pvector_push(items, rz_str_dup(fcn->name));
 		rz_list_foreach (list, iter, name) {
 			int nv = (int)ht_su_find(ht, name, NULL);
 			rz_pvector_push(items, rz_str_newf("%d", nv));
@@ -4354,8 +4354,8 @@ RZ_IPI RzCmdStatus rz_analysis_function_all_opcode_stat_handler(RzCore *core, in
 		}
 		ut64 fcnAddr = ht_su_find(db, ".addr", NULL);
 		RzAnalysisFunction *fcn = rz_analysis_get_function_at(core->analysis, fcnAddr);
-		rz_pvector_push(items, fcn ? strdup(fcn->name) : strdup(""));
-		rz_pvector_push(items, fcn ? rz_str_newf("0x%08" PFMT64x, fcnAddr) : strdup("0"));
+		rz_pvector_push(items, fcn ? rz_str_dup(fcn->name) : rz_str_dup(""));
+		rz_pvector_push(items, fcn ? rz_str_newf("0x%08" PFMT64x, fcnAddr) : rz_str_dup("0"));
 		rz_list_foreach (keys, iter, key) {
 			ut32 n = (ut32)ht_su_find(db, key, NULL);
 			rz_pvector_push(items, rz_str_newf("%u", n));
@@ -4704,7 +4704,7 @@ RZ_IPI char **rz_analysis_graph_format_choices(RzCore *core) {
 		return NULL;
 	}
 	for (ut8 i = 0; i < sz - 1; ++i) {
-		res[i] = strdup(formats[i]);
+		res[i] = rz_str_dup(formats[i]);
 	}
 	res[sz - 1] = NULL;
 	return res;
@@ -5331,8 +5331,8 @@ static RzCmdStatus class_method_error(RzAnalysisClassErr err) {
 
 RZ_IPI RzCmdStatus rz_analysis_class_method_add_handler(RzCore *core, int argc, const char **argv) {
 	RzAnalysisMethod meth;
-	meth.name = strdup(argv[2]);
-	meth.real_name = strdup(argv[2]);
+	meth.name = rz_str_dup(argv[2]);
+	meth.real_name = rz_str_dup(argv[2]);
 	meth.method_type = RZ_ANALYSIS_CLASS_METHOD_DEFAULT;
 	meth.addr = rz_num_math(core->num, argv[3]);
 	meth.vtable_offset = -1;
@@ -5374,7 +5374,7 @@ RZ_IPI RzCmdStatus rz_analysis_class_base_add_handler(RzCore *core, int argc, co
 	RzAnalysisBaseClass base;
 	base.id = NULL;
 	base.offset = 0;
-	base.class_name = strdup(argv[2]);
+	base.class_name = rz_str_dup(argv[2]);
 	if (argc == 4) {
 		base.offset = rz_num_math(core->num, argv[3]);
 	}
@@ -5989,8 +5989,8 @@ RZ_IPI RzCmdStatus rz_analysis_basic_block_list_handler(RzCore *core, int argc, 
 			pj_end(pj);
 			break;
 		case RZ_OUTPUT_MODE_TABLE: {
-			char *jump = block->jump != UT64_MAX ? rz_str_newf("0x%08" PFMT64x, block->jump) : strdup("");
-			char *fail = block->fail != UT64_MAX ? rz_str_newf("0x%08" PFMT64x, block->fail) : strdup("");
+			char *jump = block->jump != UT64_MAX ? rz_str_newf("0x%08" PFMT64x, block->jump) : rz_str_dup("");
+			char *fail = block->fail != UT64_MAX ? rz_str_newf("0x%08" PFMT64x, block->fail) : rz_str_dup("");
 			char *call = ut64join(calls);
 			char *xref = ut64join(calls);
 			char *fcns = fcnjoin(block->fcns);

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -160,7 +160,7 @@ static RzCmdDesc *create_cmd_desc(RzCmd *cmd, RzCmdDesc *parent, RzCmdDescType t
 		return NULL;
 	}
 	res->type = type;
-	res->name = strdup(name);
+	res->name = rz_str_dup(name);
 	if (!res->name) {
 		goto err;
 	}
@@ -323,7 +323,7 @@ RZ_API RzCmdDesc *rz_cmd_desc_get_exec(RzCmdDesc *cd) {
 
 static RzCmdDesc *cmd_get_desc_best(RzCmd *cmd, const char *cmd_identifier, bool best_match) {
 	rz_return_val_if_fail(cmd && cmd_identifier, NULL);
-	char *cmdid = strdup(cmd_identifier);
+	char *cmdid = rz_str_dup(cmd_identifier);
 	char *end_cmdid = cmdid + strlen(cmdid);
 	RzCmdDesc *res = NULL;
 	bool is_exact_match = true;
@@ -490,7 +490,7 @@ RZ_API int rz_cmd_alias_set(RzCmd *cmd, const char *k, const char *v, int remote
 		int matches = !strcmp(k, cmd->aliases.keys[i]);
 		if (matches) {
 			free(cmd->aliases.values[i]);
-			cmd->aliases.values[i] = strdup(v);
+			cmd->aliases.values[i] = rz_str_dup(v);
 			free(tofree);
 			return 1;
 		}
@@ -509,8 +509,8 @@ RZ_API int rz_cmd_alias_set(RzCmd *cmd, const char *k, const char *v, int remote
 				sizeof(char *) * cmd->aliases.count);
 			if (V) {
 				cmd->aliases.values = V;
-				cmd->aliases.keys[i] = strdup(k);
-				cmd->aliases.values[i] = strdup(v);
+				cmd->aliases.keys[i] = rz_str_dup(k);
+				cmd->aliases.values[i] = rz_str_dup(v);
 				cmd->aliases.remote[i] = remote;
 			}
 		}
@@ -930,7 +930,7 @@ static void fill_wrapped_comment(RzCmd *cmd, RzStrBuf *sb, const char *comment, 
 		help_color = use_color ? cons->context->pal.help : "";
 	}
 	if (is_interactive && cols > 0 && cols - columns > MIN_SUMMARY_WIDTH && !RZ_STR_ISEMPTY(comment)) {
-		char *text = strdup(comment);
+		char *text = rz_str_dup(comment);
 		RzList *wrapped_text = rz_str_wrap(text, cols - columns - 2);
 		RzListIter *it;
 		const char *line;
@@ -1358,7 +1358,7 @@ static char *oldinput_get_help(RzCmd *cmd, RzCmdDesc *cd, RzCmdParsedArgs *a) {
 		res = rz_cons_get_buffer_dup();
 	}
 	if (!res) {
-		res = strdup("");
+		res = rz_str_dup("");
 	}
 	rz_cons_pop();
 	return res;
@@ -1536,7 +1536,7 @@ RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_col
 }
 
 RZ_API char *rz_cmd_get_help(RzCmd *cmd, RzCmdParsedArgs *args, bool use_color) {
-	char *cmdid = strdup(rz_cmd_parsed_args_cmd(args));
+	char *cmdid = rz_str_dup(rz_cmd_parsed_args_cmd(args));
 	if (!cmdid) {
 		return NULL;
 	}
@@ -1583,11 +1583,11 @@ RZ_API bool rz_cmd_macro_add(RZ_NONNULL RzCmd *cmd, RZ_NONNULL const char *name,
 	if (!macro) {
 		return false;
 	}
-	macro->name = strdup(name);
+	macro->name = rz_str_dup(name);
 	if (!macro->name) {
 		goto err;
 	}
-	macro->code = strdup(code);
+	macro->code = rz_str_dup(code);
 	if (!macro->code) {
 		goto err;
 	}
@@ -1599,7 +1599,7 @@ RZ_API bool rz_cmd_macro_add(RZ_NONNULL RzCmd *cmd, RZ_NONNULL const char *name,
 		goto err;
 	}
 	for (size_t i = 0; i < macro->nargs; i++) {
-		macro->args[i] = strdup(args[i]);
+		macro->args[i] = rz_str_dup(args[i]);
 		if (!macro->args[i]) {
 			goto err;
 		}
@@ -1632,11 +1632,11 @@ RZ_API bool rz_cmd_macro_update(RZ_NONNULL RzCmd *cmd, RZ_NONNULL const char *na
 	char **new_args = NULL;
 	size_t new_nargs = 0;
 
-	new_name = strdup(name);
+	new_name = rz_str_dup(name);
 	if (!new_name) {
 		goto err;
 	}
-	new_code = strdup(code);
+	new_code = rz_str_dup(code);
 	if (!new_code) {
 		goto err;
 	}
@@ -1647,7 +1647,7 @@ RZ_API bool rz_cmd_macro_update(RZ_NONNULL RzCmd *cmd, RZ_NONNULL const char *na
 		goto err;
 	}
 	for (size_t i = 0; i < new_nargs; i++) {
-		new_args[i] = strdup(args[i]);
+		new_args[i] = rz_str_dup(args[i]);
 		if (!new_args[i]) {
 			goto err;
 		}
@@ -1720,7 +1720,7 @@ RZ_API RZ_OWN RzList /*<RzCmdMacro *>*/ *rz_cmd_macro_list(RZ_NONNULL RzCmd *cmd
 }
 
 static RzCmdStatus macro_call(RzCmd *cmd, const RzCmdMacro *macro, const char **argv) {
-	char *code = strdup(macro->code);
+	char *code = rz_str_dup(macro->code);
 	char key[100];
 	size_t i;
 	for (i = 0; i < macro->nargs; i++) {
@@ -1844,10 +1844,10 @@ RZ_API RzCmdParsedArgs *rz_cmd_parsed_args_new(const char *cmd, int n_args, char
 	res->has_space_after_cmd = true;
 	res->argc = n_args + 1;
 	res->argv = RZ_NEWS0(char *, res->argc + 1);
-	res->argv[0] = strdup(cmd);
+	res->argv[0] = rz_str_dup(cmd);
 	int i;
 	for (i = 1; i < res->argc; i++) {
-		res->argv[i] = strdup(args[i - 1]);
+		res->argv[i] = rz_str_dup(args[i - 1]);
 	}
 	res->argv[res->argc] = NULL;
 	return res;
@@ -1888,10 +1888,10 @@ RZ_API bool rz_cmd_parsed_args_setargs(RzCmdParsedArgs *a, int n_args, char **ar
 	if (!tmp) {
 		return false;
 	}
-	tmp[0] = strdup(a->argv[0]);
+	tmp[0] = rz_str_dup(a->argv[0]);
 	int i;
 	for (i = 1; i < n_args + 1; i++) {
-		tmp[i] = strdup(args[i - 1]);
+		tmp[i] = rz_str_dup(args[i - 1]);
 		if (!tmp[i]) {
 			goto err;
 		}
@@ -1913,7 +1913,7 @@ RZ_API bool rz_cmd_parsed_args_addarg(RzCmdParsedArgs *a, const char *arg) {
 	}
 
 	a->argv = tmp;
-	a->argv[a->argc] = strdup(arg);
+	a->argv[a->argc] = rz_str_dup(arg);
 	a->argv[a->argc + 1] = NULL;
 	a->argc++;
 	return true;
@@ -1921,7 +1921,7 @@ RZ_API bool rz_cmd_parsed_args_addarg(RzCmdParsedArgs *a, const char *arg) {
 
 RZ_API bool rz_cmd_parsed_args_setcmd(RzCmdParsedArgs *a, const char *cmd) {
 	rz_return_val_if_fail(a && a->argv && a->argv[0], false);
-	char *tmp = strdup(cmd);
+	char *tmp = rz_str_dup(cmd);
 	if (!tmp) {
 		return false;
 	}
@@ -2360,7 +2360,7 @@ RZ_API char *rz_cmd_escape_arg(const char *arg, RzCmdEscape esc) {
 	case RZ_CMD_ESCAPE_PF_ARG:
 		return escape_special_chars(arg, SPECIAL_CHARS_PF);
 	}
-	rz_return_val_if_reached(strdup(arg));
+	rz_return_val_if_reached(rz_str_dup(arg));
 }
 
 /**
@@ -2380,7 +2380,7 @@ RZ_API char *rz_cmd_unescape_arg(const char *arg, RzCmdEscape esc) {
 	case RZ_CMD_ESCAPE_PF_ARG:
 		return unescape_special_chars(arg, SPECIAL_CHARS_PF);
 	}
-	rz_return_val_if_reached(strdup(arg));
+	rz_return_val_if_reached(rz_str_dup(arg));
 }
 
 /**

--- a/librz/core/cmd/cmd_cmp.c
+++ b/librz/core/cmd/cmd_cmp.c
@@ -117,7 +117,7 @@ static bool core_cmp_bits(RzCore *core, RzCompareData *cmp) {
 // c
 RZ_IPI RzCmdStatus rz_cmd_cmp_string_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
 	RzCmdStatus ret = RZ_CMD_STATUS_ERROR;
-	char *unescaped = strdup(argv[1]);
+	char *unescaped = rz_str_dup(argv[1]);
 	int len = rz_str_unescape(unescaped);
 	RzCompareData *cmp = rz_core_cmp_mem_data(core, core->offset, (ut8 *)unescaped, len);
 	if (!cmp) {
@@ -316,7 +316,7 @@ RZ_IPI RzCmdStatus rz_cmd_cmp_remove_watcher_handler(RzCore *core, int argc, con
 
 // cx
 RZ_IPI RzCmdStatus rz_cmd_cmp_hexpair_string_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
-	char *input = strdup(argv[1]);
+	char *input = rz_str_dup(argv[1]);
 	rz_str_remove_char(input, ' ');
 	unsigned char *buf;
 	int ret = false;

--- a/librz/core/cmd/cmd_debug.c
+++ b/librz/core/cmd/cmd_debug.c
@@ -56,7 +56,7 @@ struct trace_node {
 
 // XXX those tmp files are never removed and we shuoldnt use files for this
 static void set_profile_string(RzCore *core, const char *str) {
-	char *file = strdup(rz_config_get(core->config, "dbg.profile"));
+	char *file = rz_str_dup(rz_config_get(core->config, "dbg.profile"));
 	if (RZ_STR_ISEMPTY(file)) {
 		free(file);
 		file = rz_file_temp("rz-run");
@@ -72,7 +72,7 @@ static void cmd_debug_cont_syscall(RzCore *core, const char *_str) {
 	int i, *syscalls = NULL;
 	int count = 0;
 	if (_str && *_str) {
-		char *str = strdup(_str);
+		char *str = rz_str_dup(_str);
 		count = rz_str_word_set0(str);
 		syscalls = calloc(sizeof(int), count);
 		for (i = 0; i < count; i++) {
@@ -563,7 +563,7 @@ static int dump_maps(RzCore *core, int perm, const char *filename) {
 			}
 			rz_io_read_at(core->io, map->addr, buf, map->size);
 			char *file = filename
-				? strdup(filename)
+				? rz_str_dup(filename)
 				: rz_str_newf("0x%08" PFMT64x "-0x%08" PFMT64x "-%s.dmp",
 					  map->addr, map->addr_end, rz_str_rwx_i(map->perm));
 			if (!rz_file_dump(file, buf, map->size, 0)) {
@@ -595,7 +595,7 @@ static void cmd_debug_current_modules(RzCore *core, RzOutputMode mode) { // "dmm
 		} else if (mode == RZ_OUTPUT_MODE_RIZIN) {
 			/* Escape backslashes (e.g. for Windows). */
 			char *escaped_path = rz_str_escape(map->file);
-			char *filtered_name = strdup(map->name);
+			char *filtered_name = rz_str_dup(map->name);
 			rz_name_filter(filtered_name, 0, true);
 			rz_cons_printf("f mod.%s @ 0x%08" PFMT64x "\n",
 				filtered_name, map->addr);
@@ -629,7 +629,7 @@ static void cmd_debug_modules(RzCore *core, RzCmdStateOutput *state) { // "dmm"
 		} else if (mode == RZ_OUTPUT_MODE_RIZIN) {
 			/* Escape backslashes (e.g. for Windows). */
 			char *escaped_path = rz_str_escape(map->file);
-			char *filtered_name = strdup(map->name);
+			char *filtered_name = rz_str_dup(map->name);
 			rz_name_filter(filtered_name, 0, true);
 			rz_cons_printf("f mod.%s @ 0x%08" PFMT64x "\n",
 				filtered_name, map->addr);
@@ -891,7 +891,7 @@ RZ_IPI int rz_cmd_debug_dmi(void *data, const char *input) {
 			mode = RZ_MODE_PRINT;
 			break;
 		}
-		ptr = strdup(input[0] ? rz_str_trim_head_ro(input + 1) : "");
+		ptr = rz_str_dup(input[0] ? rz_str_trim_head_ro(input + 1) : "");
 		if (!ptr || !*ptr) {
 			rz_core_cmd(core, "dmm", 0);
 			free(ptr);
@@ -1299,7 +1299,7 @@ RZ_IPI void rz_core_debug_bp_add(RzCore *core, ut64 addr, const char *arg_perm, 
 			rz_bp_item_set_name(bpi, name);
 			free(name);
 		} else {
-			bpi->name = strdup(f->name);
+			bpi->name = rz_str_dup(f->name);
 		}
 	} else {
 		char *name = rz_str_newf("0x%08" PFMT64x, addr);
@@ -3129,7 +3129,7 @@ RZ_IPI RzCmdStatus rz_cmd_debug_core_dump_generate_handler(RzCore *core, int arg
 		RZ_LOG_ERROR("core: Not debugging, can't write core file.\n");
 		return RZ_CMD_STATUS_ERROR;
 	}
-	char *corefile = argc > 1 ? strdup(argv[1]) : rz_str_newf("core.%u", core->dbg->pid);
+	char *corefile = argc > 1 ? rz_str_dup(argv[1]) : rz_str_newf("core.%u", core->dbg->pid);
 	RZ_LOG_WARN("core: Writing to file '%s'\n", corefile);
 	rz_file_rm(corefile);
 	RzBuffer *dst = rz_buf_new_file(corefile, O_RDWR | O_CREAT, 0644);

--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -132,7 +132,7 @@ RZ_API RZ_OWN RzPVector /*<char *>*/ *rz_core_get_themes(RZ_NONNULL RzCore *core
 		rz_set_s_free(themes);
 		return NULL;
 	}
-	rz_pvector_push(vec, strdup("default"));
+	rz_pvector_push(vec, rz_str_dup("default"));
 	rz_pvector_sort(vec, (RzPVectorComparator)compare_strings, NULL);
 	rz_set_s_free(themes);
 	return vec;

--- a/librz/core/cmd/cmd_flag.c
+++ b/librz/core/cmd/cmd_flag.c
@@ -82,7 +82,7 @@ static RzList /*<char *>*/ *__childrenFlagsOf(RzCore *core, RzList /*<RzFlagItem
 		const char *only = __isOnlySon(core, flags, kw);
 		if (only) {
 			free(kw);
-			kw = strdup(only);
+			kw = rz_str_dup(only);
 		} else {
 			const char *fname = NULL;
 			size_t fname_len = 0;
@@ -685,7 +685,7 @@ static bool rename_flag_ordinal(RzFlagItem *fi, void *user) {
 }
 
 static void flag_ordinals(RzCore *core, const char *glob) {
-	char *pfx = strdup(glob);
+	char *pfx = rz_str_dup(glob);
 	char *p = strchr(pfx, '*');
 	if (p) {
 		*p = 0;

--- a/librz/core/cmd/cmd_hash.c
+++ b/librz/core/cmd/cmd_hash.c
@@ -20,7 +20,7 @@ RZ_IPI RzCmdDescDetail *rz_hash_bang_details_cb(RzCore *core, int argc, const ch
 	if (!details) {
 		return NULL;
 	}
-	details[0].name = (const char *)strdup("Available interpreters");
+	details[0].name = (const char *)rz_str_dup("Available interpreters");
 	if (!details->name) {
 		goto err;
 	}
@@ -31,8 +31,8 @@ RZ_IPI RzCmdDescDetail *rz_hash_bang_details_cb(RzCore *core, int argc, const ch
 	}
 	int i = 0;
 	rz_list_foreach (core->lang->langs, iter, lp) {
-		entries[i].text = (char *)strdup("#!");
-		entries[i].arg_str = (char *)strdup(lp->name);
+		entries[i].text = (char *)rz_str_dup("#!");
+		entries[i].arg_str = (char *)rz_str_dup(lp->name);
 		entries[i].comment = (char *)rz_str_newf("%s (%s)", lp->desc, lp->license);
 		if (!entries[i].text || !entries[i].arg_str || !entries[i].comment) {
 			goto err;

--- a/librz/core/cmd/cmd_info.c
+++ b/librz/core/cmd/cmd_info.c
@@ -53,7 +53,7 @@ static bool is_equal_file_hashes(RzPVector /*<RzBinFileHash *>*/ *lfile_hashes, 
 
 static bool source_file_collect_cb(void *user, const char *k, const void *v) {
 	RzPVector *r = user;
-	char *f = strdup(k);
+	char *f = rz_str_dup(k);
 	if (f) {
 		rz_pvector_push(r, f);
 	}
@@ -474,7 +474,7 @@ RZ_IPI RzCmdStatus rz_cmd_info_dwarf_handler(RzCore *core, int argc, const char 
 }
 
 RZ_IPI RzCmdStatus rz_cmd_info_pdb_load_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
-	char *filename = argc > 1 ? strdup(argv[1]) : rz_core_bin_pdb_get_filename(core);
+	char *filename = argc > 1 ? rz_str_dup(argv[1]) : rz_core_bin_pdb_get_filename(core);
 	if (!filename) {
 		RZ_LOG_ERROR("Cannot find the right PDB file to load\n");
 		return RZ_CMD_STATUS_ERROR;
@@ -491,7 +491,7 @@ RZ_IPI RzCmdStatus rz_cmd_info_pdb_load_handler(RzCore *core, int argc, const ch
 }
 
 RZ_IPI RzCmdStatus rz_cmd_info_pdb_show_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
-	char *filename = argc > 1 ? strdup(argv[1]) : rz_core_bin_pdb_get_filename(core);
+	char *filename = argc > 1 ? rz_str_dup(argv[1]) : rz_core_bin_pdb_get_filename(core);
 	if (!filename) {
 		RZ_LOG_ERROR("Cannot find the right PDB file to load\n");
 		return RZ_CMD_STATUS_ERROR;
@@ -576,7 +576,7 @@ RZ_IPI char **rz_cmd_info_demangle_lang_choices(RzCore *core) {
 	RzListIter *it;
 	int i = 0;
 	rz_list_foreach (core->bin->demangler->plugins, it, plugin) {
-		res[i++] = strdup(plugin->language);
+		res[i++] = rz_str_dup(plugin->language);
 	}
 	return res;
 }

--- a/librz/core/cmd/cmd_magic.c
+++ b/librz/core/cmd/cmd_magic.c
@@ -69,7 +69,7 @@ static int rz_core_magic_at(RzCore *core, const char *file, ut64 addr, int depth
 		ck = rz_magic_new(0);
 		if (file) {
 			free(ofile);
-			ofile = strdup(file);
+			ofile = rz_str_dup(file);
 			if (!rz_magic_load(ck, file)) {
 				RZ_LOG_ERROR("core: failed rz_magic_load (\"%s\") %s\n", file, rz_magic_error(ck));
 				ck = NULL;
@@ -111,7 +111,7 @@ static int rz_core_magic_at(RzCore *core, const char *file, ut64 addr, int depth
 			ret = mod + 1;
 			goto seek_exit;
 		}
-		p = strdup(str);
+		p = rz_str_dup(str);
 		fmt = p;
 		// processing newlinez
 		for (q = p; *q; q++) {

--- a/librz/core/cmd/cmd_math.c
+++ b/librz/core/cmd/cmd_math.c
@@ -447,7 +447,7 @@ RZ_IPI RzCmdDescDetail *rz_cmd_math_help_vars_details_cb(RzCore *core, int argc,
 	if (!details) {
 		return NULL;
 	}
-	details[0].name = (const char *)strdup("Rizin variables");
+	details[0].name = (const char *)rz_str_dup("Rizin variables");
 	if (!details->name) {
 		goto err;
 	}
@@ -459,18 +459,18 @@ RZ_IPI RzCmdDescDetail *rz_cmd_math_help_vars_details_cb(RzCore *core, int argc,
 	int i;
 	for (i = 0; i < RZ_ARRAY_SIZE(core_vars); i++) {
 		struct rz_core_var *var = &core_vars[i];
-		entries[i].text = (char *)strdup(var->name);
-		entries[i].arg_str = strdup("");
-		entries[i].comment = strdup(var->description);
+		entries[i].text = (char *)rz_str_dup(var->name);
+		entries[i].arg_str = rz_str_dup("");
+		entries[i].comment = rz_str_dup(var->description);
 		if (!entries[i].text || !entries[i].arg_str || !entries[i].comment) {
 			goto err;
 		}
 	}
 	for (int j = 0; j < RZ_ARRAY_SIZE(help_core_vars); j++, i++) {
 		struct rz_core_var *var = &help_core_vars[j];
-		entries[i].text = (char *)strdup(var->name);
-		entries[i].arg_str = strdup("");
-		entries[i].comment = strdup(var->description);
+		entries[i].text = (char *)rz_str_dup(var->name);
+		entries[i].arg_str = rz_str_dup("");
+		entries[i].comment = rz_str_dup(var->description);
 		if (!entries[i].text || !entries[i].arg_str || !entries[i].comment) {
 			goto err;
 		}

--- a/librz/core/cmd/cmd_meta.c
+++ b/librz/core/cmd/cmd_meta.c
@@ -115,7 +115,7 @@ static RzCmdStatus meta_variable_comment_append(RzCore *core, const char *name, 
 			rz_cons_println(var->comment);
 		}
 	} else {
-		var->comment = strdup(comment);
+		var->comment = rz_str_dup(comment);
 	}
 	free(heap_comment);
 	return RZ_CMD_STATUS_OK;
@@ -307,7 +307,7 @@ RZ_IPI RzCmdStatus rz_comment_unique_handler(RzCore *core, int argc, const char 
 			comment = s;
 		}
 	} else {
-		comment = strdup(argv[1]);
+		comment = rz_str_dup(argv[1]);
 	}
 	if (comment) {
 		rz_core_meta_comment_add(core, comment, core->offset);

--- a/librz/core/cmd/cmd_open.c
+++ b/librz/core/cmd/cmd_open.c
@@ -991,7 +991,7 @@ RZ_IPI RzCmdStatus rz_reopen_debug_file_handler(RzCore *core, int argc, const ch
 
 RZ_IPI RzCmdStatus rz_reopen_debug_rzrun_handler(RzCore *core, int argc, const char **argv) {
 	char *file = rz_file_temp("rz-run");
-	char *s = strdup(argv[1]);
+	char *s = rz_str_dup(argv[1]);
 	rz_config_set(core->config, "dbg.profile", file);
 	rz_str_replace_char(s, ',', '\n');
 	rz_file_dump(file, (const ut8 *)s, strlen(s), 0);
@@ -1022,7 +1022,7 @@ static RzCmdStatus reopen_nobin_headers(RzCore *core, int add_perms) {
 		return RZ_CMD_STATUS_ERROR;
 	}
 	int perms = core->io->desc->perm | add_perms;
-	char *fname = strdup(desc->name);
+	char *fname = rz_str_dup(desc->name);
 	if (!fname) {
 		return RZ_CMD_STATUS_ERROR;
 	}

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -520,7 +520,7 @@ static void colordump(RzCore *core, const ut8 *block, int len) {
 					ch = ' ';
 				}
 			} else {
-				color = strdup("");
+				color = rz_str_dup("");
 				if (show_cursor && core->print->cur == j) {
 					ch = '_';
 				} else {
@@ -533,7 +533,7 @@ static void colordump(RzCore *core, const ut8 *block, int len) {
 				ch = core->print->io_unalloc_ch;
 				if (show_color) {
 					free(color);
-					color = strdup(Color_RESET);
+					color = rz_str_dup(Color_RESET);
 					if (ch == ' ') {
 						ch = '.';
 					}
@@ -967,7 +967,7 @@ static void annotated_hexdump(RzCore *core, int len) {
 					fend = addr + j + flag->size;
 				}
 				free(note[j]);
-				note[j] = rz_str_prepend(strdup(flag->name), "/");
+				note[j] = rz_str_prepend(rz_str_dup(flag->name), "/");
 				marks = true;
 				color_idx++;
 				color_idx %= 10;
@@ -5079,8 +5079,8 @@ RZ_IPI RzCmdStatus rz_print_columns_debug_handler(RzCore *core, int argc, const 
 		rows = user_rows;
 	}
 	bool asm_minicols = rz_config_get_i(core->config, "asm.minicols");
-	char *o_ao = strdup(rz_config_get(core->config, "asm.offset"));
-	char *o_ab = strdup(rz_config_get(core->config, "asm.bytes"));
+	char *o_ao = rz_str_dup(rz_config_get(core->config, "asm.offset"));
+	char *o_ab = rz_str_dup(rz_config_get(core->config, "asm.bytes"));
 	if (asm_minicols) {
 		// Set asm.offset and asm.bytes configs to false to avoid printing them
 		rz_config_set_b(core->config, "asm.offset", false);

--- a/librz/core/cmd/cmd_regs.c
+++ b/librz/core/cmd/cmd_regs.c
@@ -149,7 +149,7 @@ RZ_API bool rz_core_reg_assign_sync(RZ_NONNULL RzCore *core, RZ_NONNULL RzReg *r
  * \param eq_pos index of the '=' in arg
  */
 static RzCmdStatus assign_reg(RzCore *core, RzReg *reg, RzCmdRegSync sync_cb, RZ_NONNULL const char *arg, size_t eq_pos) {
-	char *str = strdup(arg);
+	char *str = rz_str_dup(arg);
 	if (!str) {
 		return RZ_CMD_STATUS_ERROR;
 	}

--- a/librz/core/cmd/cmd_remote.c
+++ b/librz/core/cmd/cmd_remote.c
@@ -239,10 +239,10 @@ RZ_IPI RzCmdStatus rz_remote_tcp_handler(RzCore *core, int argc, const char **ar
 		char *host, *port = strchr(argv[1], ':');
 		if (port) {
 			host = rz_str_ndup(argv[1], port - argv[1]);
-			port = strdup(port + 1);
+			port = rz_str_dup(port + 1);
 		} else {
-			host = strdup("localhost");
-			port = strdup(argv[1]);
+			host = rz_str_dup("localhost");
+			port = rz_str_dup(argv[1]);
 		}
 		char *rbuf = rz_core_rtr_cmds_query(core, host, port, argv[2]);
 		if (rbuf) {
@@ -260,5 +260,5 @@ RZ_API void rz_core_rtr_enable(RZ_NONNULL RzCore *core, const char *cmdremote) {
 	rz_return_if_fail(core && cmdremote);
 
 	RZ_FREE(core->cmdremote);
-	core->cmdremote = strdup(cmdremote);
+	core->cmdremote = rz_str_dup(cmdremote);
 }

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -454,7 +454,7 @@ static int _cb_hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 			pre = getstring(buf, prectx);
 			pos = getstring(buf + prectx + len, ctx);
 			if (!pos) {
-				pos = strdup("");
+				pos = rz_str_dup("");
 			}
 			if (param->outmode == RZ_MODE_JSON) {
 				wrd = getstring(buf + prectx, len);
@@ -2261,7 +2261,7 @@ RZ_IPI int rz_cmd_search(void *data, const char *input) {
 		}
 	} else {
 		free(core->lastsearch);
-		core->lastsearch = strdup(input);
+		core->lastsearch = rz_str_dup(input);
 	}
 
 	core->in_search = true;
@@ -2510,14 +2510,14 @@ reread:
 				RZ_LOG_ERROR("core:  /ccb - binary (any number is valid)\n");
 				goto beach;
 			}
-			char *s = strdup(arg);
+			char *s = rz_str_dup(arg);
 			char *sp = strchr(s, ' ');
 			int mode = input[2];
 			if (sp) {
 				*sp = 0;
 				sp++;
 				char *hashName = s;
-				ut8 *hashValue = (ut8 *)strdup(sp);
+				ut8 *hashValue = (ut8 *)rz_str_dup(sp);
 				if (hashValue) {
 					if (!rz_str_startswith((const char *)hashValue, "0x")) {
 						// TODO: support bigger hashes
@@ -2832,7 +2832,7 @@ reread:
 		}
 		// fallthrough
 	case ' ': // "/ " search string
-		inp = strdup(input + 1 + ignorecase + (param.outmode == RZ_MODE_JSON ? 1 : 0));
+		inp = rz_str_dup(input + 1 + ignorecase + (param.outmode == RZ_MODE_JSON ? 1 : 0));
 		len = rz_str_unescape(inp);
 		rz_search_reset(core->search, RZ_SEARCH_KEYWORD);
 		rz_search_set_distance(core->search, (int)rz_config_get_i(core->config, "search.distance"));
@@ -3012,7 +3012,7 @@ reread:
 			rz_core_cmd_help(core, help_msg_slash_x);
 		} else {
 			RzSearchKeyword *kw;
-			char *s, *p = strdup(input + param_offset);
+			char *s, *p = rz_str_dup(input + param_offset);
 			rz_search_reset(core->search, RZ_SEARCH_KEYWORD);
 			rz_search_set_distance(core->search, (int)rz_config_get_i(core->config, "search.distance"));
 			s = strchr(p, ':');
@@ -3040,7 +3040,7 @@ reread:
 		if (input[1] == ' ') {
 			// TODO: support /+j
 			char *buf = malloc(strlen(input) * 2);
-			char *str = strdup(input + 2);
+			char *str = rz_str_dup(input + 2);
 			int ochunksize;
 			int i, len, chunksize = rz_config_get_i(core->config, "search.chunk");
 			if (chunksize < 1) {

--- a/librz/core/cmd/cmd_search_rop.c
+++ b/librz/core/cmd/cmd_search_rop.c
@@ -49,7 +49,7 @@ static char *parse_register(const RzCore *core, const char *str, ut64 *idx) {
 
 	// Check if the register is correct for the given architecture.
 	if (rz_analysis_is_reg_in_profile(core->analysis, reg)) {
-		return strdup(reg);
+		return rz_str_dup(reg);
 	}
 
 	return NULL;
@@ -269,7 +269,7 @@ static bool parse_reg_op_const(const RzCore *core, const char *str, RzRopConstra
 
 	char op_str[16];
 	rz_strf(op_str, "%" PFMT64u, const_value);
-	rop_constraint->args[SRC_CONST] = strdup(op_str);
+	rop_constraint->args[SRC_CONST] = rz_str_dup(op_str);
 	const char *value_str = rz_il_op_pure_code_stringify(*op);
 	rop_constraint->args[OP] = rz_str_dup(value_str);
 	return true;
@@ -295,7 +295,7 @@ RZ_API RZ_OWN RzRopSearchContext *rz_core_rop_search_context_new(RZ_NONNULL cons
 		return NULL;
 	}
 
-	context->greparg = greparg ? strdup(greparg) : NULL;
+	context->greparg = rz_str_dup(greparg);
 	context->mode_str = rz_config_get(core->config, "search.in");
 	context->arch = rz_config_get(core->config, "asm.arch");
 	context->regexp = regexp;

--- a/librz/core/cmd/cmd_seek.c
+++ b/librz/core/cmd/cmd_seek.c
@@ -166,7 +166,7 @@ RZ_IPI RzCmdStatus rz_seek_handler(RzCore *core, int argc, const char **argv) {
 	// NOTE: hack to make it work with local function labels
 	char *ptr;
 	if ((ptr = strstr(argv[1], "+.")) != NULL) {
-		char *dup = strdup(argv[1]);
+		char *dup = rz_str_dup(argv[1]);
 		dup[ptr - argv[1]] = '\x00';
 		core->offset = rz_num_math(core->num, dup);
 		free(dup);
@@ -243,7 +243,7 @@ RZ_IPI RzCmdStatus rz_seek_history_list_handler(RzCore *core, int argc, const ch
 			if (f->offset != undo->offset) {
 				name = rz_str_newf("%s+%" PFMT64d, f->name, undo->offset - f->offset);
 			} else {
-				name = strdup(f->name);
+				name = rz_str_dup(f->name);
 			}
 		}
 		current_met |= undo->is_current;

--- a/librz/core/cmd/cmd_shell.c
+++ b/librz/core/cmd/cmd_shell.c
@@ -22,9 +22,9 @@ static char *showfile(char *res, const int nth, const char *fpath, const char *n
 	}
 	const bool isdir = rz_file_is_directory(n);
 	if (isdir) {
-		nn = rz_str_append(strdup(fpath), "/");
+		nn = rz_str_append(rz_str_dup(fpath), "/");
 	} else {
-		nn = strdup(fpath);
+		nn = rz_str_dup(fpath);
 	}
 	if (!*nn) {
 		free(nn);
@@ -46,7 +46,7 @@ static char *showfile(char *res, const int nth, const char *fpath, const char *n
 		uid = sb.st_uid;
 		gid = sb.st_gid;
 		perm = sb.st_mode & 0777;
-		if (!(u_rwx = strdup(rz_str_rwx_i(perm >> 6)))) {
+		if (!(u_rwx = rz_str_dup(rz_str_rwx_i(perm >> 6)))) {
 			free(nn);
 			return res;
 		}
@@ -68,7 +68,7 @@ static char *showfile(char *res, const int nth, const char *fpath, const char *n
 		}
 	}
 #else
-	u_rwx = strdup("-");
+	u_rwx = rz_str_dup("-");
 	fch = isdir ? 'd' : '-';
 #endif
 	if (printfmt == 'q') {
@@ -177,13 +177,13 @@ static char *syscmd_ls(RZ_NONNULL const int argc, const char **argv) {
 			}
 			memcpy(d, path, off);
 			path = (const char *)d;
-			pattern = strdup(p + 1);
+			pattern = rz_str_dup(p + 1);
 		} else {
-			pattern = strdup(path);
+			pattern = rz_str_dup(path);
 			path = ".";
 		}
 	} else {
-		pattern = strdup("*");
+		pattern = rz_str_dup("*");
 	}
 	if (rz_file_is_regular(path)) {
 		res = showfile(res, 0, path, path, printfmt);
@@ -195,17 +195,17 @@ static char *syscmd_ls(RZ_NONNULL const int argc, const char **argv) {
 	files = rz_sys_dir(path);
 
 	if (path[strlen(path) - 1] == '/') {
-		dir = strdup(path);
+		dir = rz_str_dup(path);
 	} else {
-		dir = rz_str_append(strdup(path), "/");
+		dir = rz_str_append(rz_str_dup(path), "/");
 	}
 	int nth = 0;
 	if (printfmt == FMT_JSON) {
-		res = strdup("[");
+		res = rz_str_dup("[");
 	}
 	needs_newline = 0;
 	rz_list_foreach (files, iter, name) {
-		char *n = rz_str_append(strdup(dir), name);
+		char *n = rz_str_append(rz_str_dup(dir), name);
 		if (!n) {
 			break;
 		}
@@ -287,7 +287,7 @@ static ut32 vernum(const char *s) {
 	// XXX this is known to be buggy, only works for strings like "x.x.x"
 	// XXX anything like "x.xx.x" will break the parsing
 	// XXX -git is ignored, maybe we should shift for it
-	char *a = strdup(s);
+	char *a = rz_str_dup(s);
 	a = rz_str_replace(a, ".", "0", 1);
 	char *dash = strchr(a, '-');
 	if (dash) {

--- a/librz/core/cmd/cmd_system.c
+++ b/librz/core/cmd/cmd_system.c
@@ -44,7 +44,7 @@ static const char *system_apply_env_var(const char *env, const char *value, cons
 	}
 
 	if (!*alloc_str) {
-		*alloc_str = strdup(arg);
+		*alloc_str = rz_str_dup(arg);
 	}
 
 	*alloc_str = rz_str_replace(*alloc_str, env, value, 1);

--- a/librz/core/cmd/cmd_type.c
+++ b/librz/core/cmd/cmd_type.c
@@ -248,7 +248,7 @@ static void types_xrefs_all(RzCore *core) {
 		rz_list_foreach (types, iter2, type) {
 			const char *ident = rz_type_identifier(type);
 			if (ident) {
-				rz_list_push(types_list, strdup(ident));
+				rz_list_push(types_list, rz_str_dup(ident));
 			}
 		}
 		rz_list_free(types);

--- a/librz/core/cmd/cmd_write.c
+++ b/librz/core/cmd/cmd_write.c
@@ -20,10 +20,10 @@ static bool encrypt_or_decrypt_block(RzCore *core, const char *algo, const char 
 	bool no_key_mode = !strcmp("base64", algo) || !strcmp("base91", algo) || !strcmp("punycode", algo);
 	ut8 *binkey = NULL;
 	if (!strncmp(key, "s:", 2)) {
-		binkey = (ut8 *)strdup(key + 2);
+		binkey = (ut8 *)rz_str_dup(key + 2);
 		keylen = strlen(key + 2);
 	} else {
-		binkey = (ut8 *)strdup(key);
+		binkey = (ut8 *)rz_str_dup(key);
 		keylen = rz_hex_str2bin(key, binkey);
 	}
 	if (!no_key_mode && keylen < 1) {
@@ -245,7 +245,7 @@ err:
 
 RZ_IPI RzCmdStatus rz_write_from_socket_handler(RzCore *core, int argc, const char **argv) {
 	RzCmdStatus res = RZ_CMD_STATUS_ERROR;
-	char *address = strdup(argv[1]);
+	char *address = rz_str_dup(argv[1]);
 	ut64 sz = argc > 2 ? rz_num_math(core->num, argv[2]) : core->blocksize;
 
 	size_t n_split = rz_str_split(address, ':');

--- a/librz/core/cmeta.c
+++ b/librz/core/cmeta.c
@@ -101,7 +101,7 @@ RZ_IPI void rz_core_meta_print(RzCore *core, RzAnalysisMetaItem *d, ut64 start, 
 		} else if (d->type == RZ_META_TYPE_VARTYPE) {
 			// Sanitize (don't escape) Ct comments so we can see "char *", etc.
 			free(str);
-			str = strdup(d->str);
+			str = rz_str_dup(d->str);
 			rz_str_sanitize(str);
 			pstr = str;
 		} else if (d->type != RZ_META_TYPE_COMMENT) {
@@ -159,7 +159,7 @@ RZ_IPI void rz_core_meta_print(RzCore *core, RzAnalysisMetaItem *d, ut64 start, 
 				const char *type = rz_meta_type_to_string(d->type);
 				char *s = sdb_encode((const ut8 *)pstr, -1);
 				if (!s) {
-					s = strdup(pstr);
+					s = rz_str_dup(pstr);
 				}
 				if (mode == RZ_OUTPUT_MODE_RIZIN) {
 					if (!strcmp(type, "CCu")) {
@@ -375,7 +375,7 @@ RZ_IPI void rz_core_meta_print_list_in_function(RzCore *core, RzAnalysisMetaType
 
 RZ_IPI void rz_core_meta_append(RzCore *core, const char *newcomment, RzAnalysisMetaType mtype, ut64 addr) {
 	const char *comment = rz_meta_get_string(core->analysis, mtype, addr);
-	char *nc = strdup(newcomment);
+	char *nc = rz_str_dup(newcomment);
 	rz_str_unescape(nc);
 	if (comment) {
 		char *text = rz_str_newf("%s %s", comment, nc);

--- a/librz/core/cmp.c
+++ b/librz/core/cmp.c
@@ -192,9 +192,9 @@ RZ_API RZ_OWN RzList /*<RzCompareData *>*/ *rz_core_cmp_disasm(RzCore *core, ut6
 			buf + j, len - j);
 
 		comp->len = UT8_MAX;
-		comp->data1 = (ut8 *)strdup(rz_strbuf_get(&op.buf_asm));
+		comp->data1 = (ut8 *)rz_str_dup(rz_strbuf_get(&op.buf_asm));
 		comp->addr1 = addr1 + i;
-		comp->data2 = (ut8 *)strdup(rz_strbuf_get(&op2.buf_asm));
+		comp->data2 = (ut8 *)rz_str_dup(rz_strbuf_get(&op2.buf_asm));
 		comp->addr2 = addr2 + j;
 		comp->same = !strcmp((char *)comp->data1, (char *)comp->data2); // we can assume that instructions can be represented as plain chars
 		rz_list_append(cmp_list, comp);

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -301,7 +301,7 @@ RZ_API char *rz_core_add_asmqjmp(RzCore *core, ut64 addr) {
 			return NULL;
 		}
 		rz_core_set_asmqjmps(core, t, sizeof(t), i);
-		return strdup(t);
+		return rz_str_dup(t);
 	}
 	return NULL;
 }
@@ -364,7 +364,7 @@ static char *getNameDelta(RzCore *core, ut64 addr) {
 				: item->name;
 			return rz_str_newf("%s+%" PFMT64u, name, addr - item->offset);
 		}
-		return strdup(item->name);
+		return rz_str_dup(item->name);
 	}
 	return NULL;
 }
@@ -591,7 +591,7 @@ static ut64 num_callback(RzNum *userptr, const char *str, int *ok) {
 		// push state
 		if (str[0] && str[1]) {
 			const char *q;
-			char *o = strdup(str + 1);
+			char *o = rz_str_dup(str + 1);
 			if (o) {
 				q = rz_num_calc_index(core->num, NULL);
 				if (q) {
@@ -634,7 +634,7 @@ static ut64 num_callback(RzNum *userptr, const char *str, int *ok) {
 				RZ_LOG_ERROR("core: expected '{' after 'k'.\n");
 				break;
 			}
-			bptr = strdup(str + 3);
+			bptr = rz_str_dup(str + 3);
 			ptr = strchr(bptr, '}');
 			if (!ptr) {
 				// invalid json
@@ -655,7 +655,7 @@ static ut64 num_callback(RzNum *userptr, const char *str, int *ok) {
 			free(out);
 			return ret;
 		case '{': // ${ev} eval var
-			bptr = strdup(str + 2);
+			bptr = rz_str_dup(str + 2);
 			ptr = strchr(bptr, '}');
 			if (ptr) {
 				ptr[0] = '\0';
@@ -670,7 +670,7 @@ static ut64 num_callback(RzNum *userptr, const char *str, int *ok) {
 			return rz_cons_get_size(NULL);
 		case 'r': // $r
 			if (str[2] == '{') {
-				bptr = strdup(str + 3);
+				bptr = rz_str_dup(str + 3);
 				ptr = strchr(bptr, '}');
 				if (!ptr) {
 					free(bptr);
@@ -688,7 +688,7 @@ static ut64 num_callback(RzNum *userptr, const char *str, int *ok) {
 			break;
 		case 'e': // $e
 			if (str[2] == '{') { // $e{flag} flag off + size
-				char *flagName = strdup(str + 3);
+				char *flagName = rz_str_dup(str + 3);
 				int flagLength = strlen(flagName);
 				if (flagLength > 0) {
 					flagName[flagLength - 1] = 0;
@@ -747,7 +747,7 @@ static ut64 num_callback(RzNum *userptr, const char *str, int *ok) {
 			return core->blocksize;
 		case 's': // $s file size
 			if (str[2] == '{') { // $s{flag} flag size
-				bptr = strdup(str + 3);
+				bptr = rz_str_dup(str + 3);
 				ptr = strchr(bptr, '}');
 				if (!ptr) {
 					// invalid json
@@ -1013,7 +1013,7 @@ RZ_API char *rz_core_analysis_hasrefs(RzCore *core, ut64 value, int mode) {
 		return res;
 	}
 	RzFlagItem *fi = rz_flag_get_i(core->flags, value);
-	return fi ? strdup(fi->name) : NULL;
+	return fi ? rz_str_dup(fi->name) : NULL;
 }
 
 static char *getvalue(ut64 value, int bits) {
@@ -1278,10 +1278,10 @@ RZ_API char *rz_core_analysis_get_comments(RzCore *core, ut64 addr) {
 			return rz_str_newf("%s %s", type, cmt);
 		}
 		if (type) {
-			return strdup(type);
+			return rz_str_dup(type);
 		}
 		if (cmt) {
-			return strdup(cmt);
+			return rz_str_dup(cmt);
 		}
 	}
 	return NULL;
@@ -1501,7 +1501,7 @@ RZ_API bool rz_core_init(RzCore *core) {
 	rz_core_seek_reset(core);
 	core->lastsearch = NULL;
 	core->cmdfilter = NULL;
-	core->curtheme = strdup("default");
+	core->curtheme = rz_str_dup("default");
 	core->switch_file_view = 0;
 	core->cmdremote = 0;
 	core->incomment = false;
@@ -1924,7 +1924,7 @@ RZ_API int rz_core_prompt(RzCore *r, int sync) {
 		return rz_core_prompt_exec(r);
 	}
 	free(r->cmdqueue);
-	r->cmdqueue = strdup(line);
+	r->cmdqueue = rz_str_dup(line);
 	if (r->scr_gadgets && *line && *line != 'q') {
 		rz_core_gadget_print(r);
 	}
@@ -1972,7 +1972,7 @@ RZ_API char *rz_core_op_str(RzCore *core, ut64 addr) {
 	rz_asm_set_pc(core->rasm, addr);
 	rz_io_read_at(core->io, addr, buf, sizeof(buf));
 	int ret = rz_asm_disassemble(core->rasm, &op, buf, sizeof(buf));
-	char *str = (ret > 0) ? strdup(rz_strbuf_get(&op.buf_asm)) : NULL;
+	char *str = (ret > 0) ? rz_str_dup(rz_strbuf_get(&op.buf_asm)) : NULL;
 	rz_asm_op_fini(&op);
 	return str;
 }
@@ -2145,7 +2145,7 @@ reaccept:
 				if (cmd_output) {
 					cmd_len = strlen(cmd_output) + 1;
 				} else {
-					cmd_output = strdup("");
+					cmd_output = rz_str_dup("");
 					cmd_len = 0;
 				}
 				bufw = malloc(cmd_len + 5);
@@ -2297,7 +2297,7 @@ RZ_API RZ_OWN char *rz_core_editor(const RzCore *core, RZ_NULLABLE const char *f
 
 	bool readonly = false;
 	if (file && *file != '*') {
-		name = strdup(file);
+		name = rz_str_dup(file);
 		fd = rz_sys_open(file, O_RDWR, 0644);
 		if (fd == -1) {
 			fd = rz_sys_open(file, O_RDWR | O_CREAT, 0644);

--- a/librz/core/cpdb.c
+++ b/librz/core/cpdb.c
@@ -138,7 +138,7 @@ static bool symbol_dump(const RzPdb *pdb, const PDBSymbol *symbol, void *u) {
 		}
 
 		char *name = rz_demangler_msvc(public->name, RZ_DEMANGLER_FLAG_BASE);
-		name = (name) ? name : strdup(public->name);
+		name = (name) ? name : rz_str_dup(public->name);
 
 		switch (ctx->state->mode) {
 		case RZ_OUTPUT_MODE_JSON: // JSON
@@ -230,7 +230,7 @@ static bool symbol_load(const RzPdb *pdb, const PDBSymbol *symbol, void *u) {
 		}
 
 		char *name = rz_demangler_msvc(public->name, dflags);
-		name = (name) ? name : strdup(public->name);
+		name = (name) ? name : rz_str_dup(public->name);
 		char *filtered_name = rz_name_filter2(name, true);
 		char *fname = rz_str_newf("pdb.%s.%s", ctx->file, filtered_name);
 
@@ -295,7 +295,7 @@ static void pdb_symbols_load(
 		baddr = rz_config_get_i(core->config, "bin.baddr");
 		RZ_LOG_WARN("core: cannot find base address, flags will probably be misplaced\n");
 	}
-	char *file = rz_str_replace(strdup(pdbfile), ".pdb", "", 0);
+	char *file = rz_str_replace(rz_str_dup(pdbfile), ".pdb", "", 0);
 	rz_flag_space_push(core->flags, RZ_FLAGS_FS_SYMBOLS);
 
 	PDBLoadContext ctx = {

--- a/librz/core/cprint.c
+++ b/librz/core/cprint.c
@@ -453,7 +453,7 @@ RZ_API RZ_OWN char *rz_core_print_hexdump_byline_str(RZ_NONNULL RzCore *core, bo
 			st64 delta = (st64)(v - f->offset);
 			if (delta >= 0 && delta < 8192) {
 				if (v == f->offset) {
-					fn = strdup(f->name);
+					fn = rz_str_dup(f->name);
 				} else {
 					fn = rz_str_newf("%s+%" PFMT64d, f->name, v - f->offset);
 				}
@@ -614,7 +614,7 @@ RZ_IPI RZ_OWN char *rz_core_print_cons_disassembly(RzCore *core, ut64 addr, ut32
 	rz_core_print_disasm(core, addr, block, byte_len, inst_len, NULL, &disasm_options);
 	rz_cons_filter();
 	const char *cons_str = rz_str_get(rz_cons_get_buffer());
-	char *ret = strdup(cons_str);
+	char *ret = rz_str_dup(cons_str);
 	rz_cons_pop();
 	rz_cons_echo(NULL);
 	free(block);
@@ -818,7 +818,7 @@ RZ_API RZ_OWN char *rz_core_print_disasm_strings(RZ_NONNULL RzCore *core, RzCore
 				string2 = rz_str_ndup(str + 1, qoe - str - 1);
 			} else {
 				free(string2);
-				string2 = strdup(str + 1);
+				string2 = rz_str_dup(str + 1);
 			}
 			if (string2) {
 				RZ_FREE(string);
@@ -843,7 +843,7 @@ RZ_API RZ_OWN char *rz_core_print_disasm_strings(RZ_NONNULL RzCore *core, RzCore
 			}
 		}
 		if (str) {
-			string2 = mark_malloc ? str : strdup(str);
+			string2 = mark_malloc ? str : rz_str_dup(str);
 			linecolor = RZ_CONS_COLOR(call);
 		}
 		if (!string && string2) {
@@ -872,7 +872,7 @@ RZ_API RZ_OWN char *rz_core_print_disasm_strings(RZ_NONNULL RzCore *core, RzCore
 					}
 					if (rz_str_startswith(comment, "switch table")) {
 						free(switchcmp);
-						switchcmp = strdup(comment);
+						switchcmp = rz_str_dup(comment);
 					}
 					RZ_FREE(comment);
 				}

--- a/librz/core/ctypes.c
+++ b/librz/core/ctypes.c
@@ -672,7 +672,7 @@ static void set_offset_hint(RzCore *core, RzAnalysisOp *op, RZ_BORROW RzTypePath
 	if (tpath->root->kind != RZ_TYPE_KIND_IDENTIFIER) {
 		return;
 	}
-	char *cmt = (offimm == 0) ? strdup(tpath->path->path) : rz_type_as_string(core->analysis->typedb, tpath->root);
+	char *cmt = (offimm == 0) ? rz_str_dup(tpath->path->path) : rz_type_as_string(core->analysis->typedb, tpath->root);
 	if (offimm > 0) {
 		// Set only the type path as the analysis hint
 		// only and only if the types are the exact match between

--- a/librz/core/cvfile.c
+++ b/librz/core/cvfile.c
@@ -38,7 +38,7 @@ static RzIODesc *vf_open(RzIO *io, const char *pathname, int rw, int mode) {
 	if (!vf_check(io, pathname, false)) {
 		return NULL;
 	}
-	char *vfile_path = strdup(pathname + URI_SCHEME_LEN); // path like "<binfile id>/<filename>"
+	char *vfile_path = rz_str_dup(pathname + URI_SCHEME_LEN); // path like "<binfile id>/<filename>"
 	if (!vfile_path) {
 		return NULL;
 	}

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -905,9 +905,9 @@ static void ds_build_op_str(RzDisasmState *ds, bool print_color) {
 	if (ds->use_esil) {
 		free(ds->opstr);
 		if (*RZ_STRBUF_SAFEGET(&ds->analysis_op.esil)) {
-			ds->opstr = strdup(RZ_STRBUF_SAFEGET(&ds->analysis_op.esil));
+			ds->opstr = rz_str_dup(RZ_STRBUF_SAFEGET(&ds->analysis_op.esil));
 		} else {
-			ds->opstr = strdup(",");
+			ds->opstr = rz_str_dup(",");
 		}
 		return;
 	}
@@ -924,11 +924,11 @@ static void ds_build_op_str(RzDisasmState *ds, bool print_color) {
 				snprintf(ds->str, sizeof(ds->str), "%s", tmp);
 				ds->opstr = tmp;
 			} else {
-				ds->opstr = strdup("");
+				ds->opstr = rz_str_dup("");
 				ds->str[0] = 0;
 			}
 		} else {
-			ds->opstr = strdup(assembly);
+			ds->opstr = rz_str_dup(assembly);
 		}
 	}
 	if (ds->opstr && core->bin && core->bin->cur) {
@@ -977,7 +977,7 @@ static void ds_build_op_str(RzDisasmState *ds, bool print_color) {
 		rz_parse_subvar(core->parser, f, &ds->analysis_op, ds->opstr, ds->strsub, sizeof(ds->strsub));
 		if (*ds->strsub) {
 			free(ds->opstr);
-			ds->opstr = strdup(ds->strsub);
+			ds->opstr = rz_str_dup(ds->strsub);
 		}
 		if (core->parser->subrel) {
 			RzList *list = rz_analysis_xrefs_get_from(core->analysis, at);
@@ -1003,7 +1003,7 @@ static void ds_build_op_str(RzDisasmState *ds, bool print_color) {
 	}
 	if (ds->hint && ds->hint->opcode) {
 		free(ds->opstr);
-		ds->opstr = strdup(ds->hint->opcode);
+		ds->opstr = rz_str_dup(ds->hint->opcode);
 	}
 	if (ds->subnames) {
 		RzSpace *ofs = core->parser->flagspace;
@@ -1039,7 +1039,7 @@ static void ds_build_op_str(RzDisasmState *ds, bool print_color) {
 			if (ox) {
 				char *e = strchr(ox, ']');
 				if (e) {
-					e = strdup(e);
+					e = rz_str_dup(e);
 					ut64 addr = rz_num_get(NULL, ox);
 					if (addr > ds->min_ref_addr) {
 						RzFlagItem *fi = rz_flag_get_i(ds->core->flags, addr);
@@ -1054,7 +1054,7 @@ static void ds_build_op_str(RzDisasmState *ds, bool print_color) {
 		}
 		core->parser->flagspace = ofs;
 		free(ds->opstr);
-		ds->opstr = strdup(ds->str);
+		ds->opstr = rz_str_dup(ds->str);
 	} else {
 		ds_opstr_try_colorize(ds, print_color);
 	}
@@ -1328,7 +1328,7 @@ static void ds_show_xrefs(RzDisasmState *ds) {
 						continue;
 					}
 				}
-				name = strdup(fun->name);
+				name = rz_str_dup(fun->name);
 				rz_list_append(addrs, rz_num_dup(xrefi->from));
 			} else {
 				f = rz_flag_get_at(core->flags, xrefi->from, true);
@@ -1341,10 +1341,10 @@ static void ds_show_xrefs(RzDisasmState *ds) {
 							continue;
 						}
 					}
-					name = strdup(f->name);
+					name = rz_str_dup(f->name);
 					rz_list_append(addrs, rz_num_dup(xrefi->from - f->offset));
 				} else {
-					name = strdup("unk");
+					name = rz_str_dup("unk");
 				}
 			}
 			ds_begin_line(ds);
@@ -1452,7 +1452,7 @@ static void ds_atabs_option(RzDisasmState *ds) {
 		comma = 0;
 		brackets = 0;
 		n = (ds->atabs - i);
-		t = strdup(b + 1); // XXX slow!
+		t = rz_str_dup(b + 1); // XXX slow!
 		if (n < 1) {
 			n = 1;
 		}
@@ -2030,7 +2030,7 @@ static void ds_show_comments_describe(RzDisasmState *ds) {
 	/* respect asm.describe */
 	char *desc = NULL;
 	if (ds->asm_describe && !ds->has_description) {
-		char *op, *locase = strdup(rz_asm_op_get_asm(&ds->asmop));
+		char *op, *locase = rz_str_dup(rz_asm_op_get_asm(&ds->asmop));
 		if (!locase) {
 			return;
 		}
@@ -2068,7 +2068,7 @@ static void ds_show_comments_right(RzDisasmState *ds) {
 			ds->comment = rz_str_newf("%s; %s", COLOR_ARG(ds, func_var_type), vartype);
 		} else if (item && item->comment && *item->comment) {
 			ds->ocomment = item->comment;
-			ds->comment = strdup(item->comment);
+			ds->comment = rz_str_dup(item->comment);
 		}
 	} else if (vartype) {
 		ds->comment = rz_str_newf("%s; %s %s%s; %s", COLOR_ARG(ds, func_var_type), vartype, COLOR_RESET(ds), COLOR(ds, usercomment), comment);
@@ -2324,7 +2324,7 @@ static void ds_show_flags(RzDisasmState *ds, bool overlapped) {
 				outline = false;
 				docolon = false;
 			} else {
-				char *name = strdup(flag->realname ? flag->realname : flag->name);
+				char *name = rz_str_dup(flag->realname ? flag->realname : flag->name);
 				if (name) {
 					rz_str_ansi_filter(name, NULL, NULL, -1);
 					if (!ds->flags_inline || nth == 0) {
@@ -2375,7 +2375,7 @@ static void ds_update_ref_lines(RzDisasmState *ds) {
 		ds->line = line->str;
 		ds->line_col = line->cols;
 		free(ds->refline);
-		ds->refline = ds->line ? strdup(ds->line) : NULL;
+		ds->refline = ds->line ? rz_str_dup(ds->line) : NULL;
 		free(ds->refline2);
 		free(ds->prev_line_col);
 		free(line);
@@ -2401,8 +2401,8 @@ static void ds_update_ref_lines(RzDisasmState *ds) {
 		free(ds->refline);
 		free(ds->refline2);
 		free(ds->prev_line_col);
-		ds->refline = strdup("");
-		ds->refline2 = strdup("");
+		ds->refline = rz_str_dup("");
+		ds->refline2 = rz_str_dup("");
 		ds->line = NULL;
 		ds->line_col = NULL;
 		ds->prev_line_col = NULL;
@@ -2447,7 +2447,7 @@ static int ds_disassemble(RzDisasmState *ds, ut8 *buf, int len) {
 	}
 	if (ds->hint && ds->hint->opcode) {
 		free(ds->opstr);
-		ds->opstr = strdup(ds->hint->opcode);
+		ds->opstr = rz_str_dup(ds->hint->opcode);
 	}
 	rz_asm_op_fini(&ds->asmop);
 	ret = rz_asm_disassemble(core->rasm, &ds->asmop, buf, len);
@@ -2519,7 +2519,7 @@ static int ds_disassemble(RzDisasmState *ds, ut8 *buf, int len) {
 		if (ds->prev_ins) {
 			RZ_FREE(ds->prev_ins);
 		}
-		ds->prev_ins = strdup(rz_asm_op_get_asm(&ds->asmop));
+		ds->prev_ins = rz_str_dup(rz_asm_op_get_asm(&ds->asmop));
 	}
 	ds->oplen = ds->asmop.size;
 
@@ -2552,7 +2552,7 @@ static int ds_disassemble(RzDisasmState *ds, ut8 *buf, int len) {
 			snprintf(ds->str, sizeof(ds->str), "%s", tmp);
 			ds->opstr = tmp;
 		} else {
-			ds->opstr = strdup("");
+			ds->opstr = rz_str_dup("");
 			ds->str[0] = 0;
 		}
 	}
@@ -2642,7 +2642,7 @@ static void ds_print_lines_left(RzDisasmState *ds) {
 		if (ds->show_section_perm && core->bin && core->bin->cur) {
 			int va = rz_config_get_i(core->config, "io.va");
 			RzBinSection *sec = rz_bin_get_section_at(core->bin->cur->o, ds->at, va);
-			str = strdup(sec ? rz_str_rwx_i(sec->perm) : "---");
+			str = rz_str_dup(sec ? rz_str_rwx_i(sec->perm) : "---");
 		}
 		if (ds->show_section_name && core->bin && core->bin->cur) {
 			int va = rz_config_get_i(core->config, "io.va");
@@ -2654,7 +2654,7 @@ static void ds_print_lines_left(RzDisasmState *ds) {
 				str = rz_str_appendf(str, "%10.10s", sec->name);
 			}
 		}
-		char *sect = str ? str : strdup("");
+		char *sect = str ? str : rz_str_dup("");
 		printCol(ds, sect, ds->show_section_col, COLOR(ds, reg));
 		free(sect);
 	}
@@ -3253,7 +3253,7 @@ static void ds_print_show_bytes(RzDisasmState *ds) {
 				pad[j] = ' ';
 			}
 			pad[j] = '\0';
-			str = strdup("");
+			str = rz_str_dup("");
 		} else {
 			str = rz_asm_op_get_hex(&ds->asmop);
 			if (rz_str_ansi_len(str) > ds->nb) {
@@ -3845,7 +3845,7 @@ static inline bool is_filtered_flag(RzDisasmState *ds, const char *name) {
 	ut64 refaddr = ds->analysis_op.ptr;
 	const char *analysis_flag = rz_meta_get_string(ds->core->analysis, RZ_META_TYPE_STRING, refaddr);
 	if (analysis_flag) {
-		char *dupped = strdup(analysis_flag);
+		char *dupped = rz_str_dup(analysis_flag);
 		if (dupped) {
 			rz_name_filter(dupped, -1, true);
 			if (!strcmp(&name[4], dupped)) {
@@ -4214,7 +4214,7 @@ static int mymemwrite2(RzAnalysisEsil *esil, ut64 addr, const ut8 *buf, int len)
 static char *ssa_get(RzAnalysisEsil *esil, const char *reg) {
 	RzDisasmState *ds = esil->user;
 	if (isdigit(*reg)) {
-		return strdup(reg);
+		return rz_str_dup(reg);
 	}
 	if (!ds->ssa) {
 		ds->ssa = sdb_new0();
@@ -4801,7 +4801,7 @@ static void ds_print_calls_hints(RzDisasmState *ds) {
 		return;
 	}
 	if (rz_type_func_exist(analysis->typedb, full_name)) {
-		name = strdup(full_name);
+		name = rz_str_dup(full_name);
 	} else if (!(name = rz_analysis_function_name_guess(analysis->typedb, full_name))) {
 		return;
 	}
@@ -4850,7 +4850,7 @@ static void ds_print_comments_right(RzDisasmState *ds) {
 		mi = NULL;
 	}
 	if (is_code && ds->asm_describe && !ds->has_description) {
-		char *op, *locase = strdup(rz_asm_op_get_asm(&ds->asmop));
+		char *op, *locase = rz_str_dup(rz_asm_op_get_asm(&ds->asmop));
 		if (!locase) {
 			return;
 		}
@@ -4875,7 +4875,7 @@ static void ds_print_comments_right(RzDisasmState *ds) {
 					ds_align_comment(ds);
 				}
 				if (strchr(comment, '\n')) {
-					comment = strdup(comment);
+					comment = rz_str_dup(comment);
 					if (comment) {
 						ds_newline(ds);
 						ds_begin_line(ds);
@@ -5725,7 +5725,7 @@ RZ_API int rz_core_print_disasm_instructions_with_buf(RzCore *core, ut64 address
 		len += RZ_MAX(0, ret);
 		if (ds->hint && ds->hint->opcode) {
 			free(ds->opstr);
-			ds->opstr = strdup(ds->hint->opcode);
+			ds->opstr = rz_str_dup(ds->hint->opcode);
 		} else {
 			if (ds->decode && !ds->immtrim) {
 				RZ_FREE(ds->opstr);
@@ -5734,10 +5734,10 @@ RZ_API int rz_core_print_disasm_instructions_with_buf(RzCore *core, ut64 address
 					rz_analysis_op(core->analysis, &ds->analysis_op, ds->at, buf + i, nb_bytes - i, RZ_ANALYSIS_OP_MASK_ALL);
 				}
 				tmpopstr = rz_analysis_op_to_string(core->analysis, &ds->analysis_op);
-				ds->opstr = (tmpopstr) ? tmpopstr : strdup(rz_asm_op_get_asm(&ds->asmop));
+				ds->opstr = (tmpopstr) ? tmpopstr : rz_str_dup(rz_asm_op_get_asm(&ds->asmop));
 			} else if (ds->immtrim) {
 				free(ds->opstr);
-				ds->opstr = strdup(rz_asm_op_get_asm(&ds->asmop));
+				ds->opstr = rz_str_dup(rz_asm_op_get_asm(&ds->asmop));
 				rz_parse_immtrim(ds->opstr);
 			} else if (ds->use_esil) {
 				if (!hasanalysis) {
@@ -5748,7 +5748,7 @@ RZ_API int rz_core_print_disasm_instructions_with_buf(RzCore *core, ut64 address
 				}
 				if (*RZ_STRBUF_SAFEGET(&ds->analysis_op.esil)) {
 					free(ds->opstr);
-					ds->opstr = strdup(RZ_STRBUF_SAFEGET(&ds->analysis_op.esil));
+					ds->opstr = rz_str_dup(RZ_STRBUF_SAFEGET(&ds->analysis_op.esil));
 				}
 			} else if (ds->subnames) {
 				RzSpace *ofs = core->parser->flagspace;
@@ -5767,19 +5767,19 @@ RZ_API int rz_core_print_disasm_instructions_with_buf(RzCore *core, ut64 address
 				}
 				ds_build_op_str(ds, true);
 				free(ds->opstr);
-				ds->opstr = strdup(ds->str);
+				ds->opstr = rz_str_dup(ds->str);
 
 				if (!(ds->show_color && ds->colorop) && !ds->opstr) {
-					ds->opstr = strdup(rz_asm_op_get_asm(&ds->asmop));
+					ds->opstr = rz_str_dup(rz_asm_op_get_asm(&ds->asmop));
 				}
 
 				core->parser->flagspace = ofs;
 			} else {
-				ds->opstr = strdup(rz_asm_op_get_asm(&ds->asmop));
+				ds->opstr = rz_str_dup(rz_asm_op_get_asm(&ds->asmop));
 			}
 			if (ds->immtrim) {
 				free(ds->opstr);
-				ds->opstr = strdup(rz_asm_op_get_asm(&ds->asmop));
+				ds->opstr = rz_str_dup(rz_asm_op_get_asm(&ds->asmop));
 				ds->opstr = rz_parse_immtrim(ds->opstr);
 			}
 		}
@@ -6663,7 +6663,7 @@ RZ_API RZ_OWN RzPVector /*<RzCoreDisasmOp *>*/ *rz_core_disasm_all_possible_opco
 		RzAsmOp asm_op = { 0 };
 		op->size = rz_asm_disassemble(core->rasm, &asm_op, ptr, length);
 		op->hex = rz_hex_bin2strdup(ptr, RZ_MAX(op->size, 1));
-		op->assembly = strdup(op->size > 0 ? rz_asm_op_get_asm(&asm_op) : "illegal");
+		op->assembly = rz_str_dup(op->size > 0 ? rz_asm_op_get_asm(&asm_op) : "illegal");
 
 		RzAnalysisOp aop = { 0 };
 		rz_analysis_op_init(&aop);

--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -88,7 +88,7 @@ static GHT GH(get_main_arena_with_symbol)(RzCore *core, RzDebugMap *map) {
 
 	GHT main_arena = GHT_MAX;
 	GHT off = GHT_MAX;
-	char *path = strdup(map->name);
+	char *path = rz_str_dup(map->name);
 	if (path && rz_file_exists(path)) {
 		off = GH(get_va_symbol)(core, path, "main_arena");
 		if (off != GHT_MAX) {
@@ -178,7 +178,7 @@ static ut8 *GH(get_glibc_banner)(RzCore *core, const char *section_name,
 			goto cleanup;
 		}
 		buf_parse = (ut8 *)rz_mem_mem((const ut8 *)buf, rz_section->size, (const ut8 *)"GNU C Library", strlen("GNU C Library"));
-		ret_buf = (ut8 *)strdup((char *)buf_parse);
+		ret_buf = (ut8 *)rz_str_dup((char *)buf_parse);
 		break;
 	}
 
@@ -2736,7 +2736,7 @@ RZ_IPI int GH(rz_cmd_heap_bins_list_print)(RzCore *core, const char *input) {
 		free(main_arena);
 		return RZ_CMD_STATUS_ERROR;
 	}
-	char *m_state_str, *dup = strdup(input);
+	char *m_state_str, *dup = rz_str_dup(input);
 	if (*dup) {
 		strtok(dup, ":");
 		m_state_str = strtok(NULL, ":");
@@ -2781,7 +2781,7 @@ RZ_IPI int GH(rz_cmd_heap_fastbins_print)(void *data, const char *input) {
 		return RZ_CMD_STATUS_ERROR;
 	}
 	bool main_arena_only = false;
-	char *m_state_str, *dup = strdup(input);
+	char *m_state_str, *dup = rz_str_dup(input);
 	if (*dup) {
 		strtok(dup, ":");
 		m_state_str = strtok(NULL, ":");

--- a/librz/core/p/core_dex.c
+++ b/librz/core/p/core_dex.c
@@ -45,7 +45,7 @@ static RzBinDex *core_dex_get_class(RzCore *core) {
 static char *decode_access_flags(ut32 access_flags) {
 	char *str = rz_bin_dex_access_flags_readable(access_flags);
 	if (!str) {
-		return strdup("");
+		return rz_str_dup("");
 	}
 	for (size_t i = 0; i < strlen(str); ++i) {
 		str[i] = toupper(str[i]);

--- a/librz/core/project_migrate.c
+++ b/librz/core/project_migrate.c
@@ -49,7 +49,7 @@ bool v1_v2_types_foreach_cb(void *user, const SdbKv *kv) {
 	}
 	V1V2TypesCtx *ctx = user;
 	sdb_set(ctx->noreturn_db, k, v);
-	rz_list_push(ctx->moved_keys, strdup(k));
+	rz_list_push(ctx->moved_keys, rz_str_dup(k));
 	return true;
 }
 
@@ -100,14 +100,14 @@ bool v2_v3_types_foreach_cb(void *user, const SdbKv *kv) {
 	const char *v = sdbkv_value(kv);
 	if (rz_str_startswith(k, "func.") || !strcmp(v, "func")) {
 		sdb_set(ctx->callables_db, k, v);
-		rz_list_push(ctx->moved_keys, strdup(k));
+		rz_list_push(ctx->moved_keys, rz_str_dup(k));
 	} else if (rz_str_startswith(k, "link.")) {
 		// Old addresses were stored as hexadecimal numbers without `0x` part
 		// New addresses have them
 		char *tl_key = rz_str_newf("0x%s", k + strlen("link."));
 		sdb_set(ctx->typelinks_db, tl_key, v);
 		free(tl_key);
-		rz_list_push(ctx->moved_keys, strdup(k));
+		rz_list_push(ctx->moved_keys, rz_str_dup(k));
 	}
 	return true;
 }
@@ -379,7 +379,7 @@ bool v10_v11_functions_foreach_cb(void *user, const SdbKv *kv) {
 	const char *k = sdbkv_key(kv);
 	const char *v = sdbkv_value(kv);
 	V10V11FunctionsCtx *ctx = user;
-	char *json_str = strdup(v);
+	char *json_str = rz_str_dup(v);
 	RzJson *j = rz_json_parse(json_str);
 	bool ret = false;
 	if (!j || j->type != RZ_JSON_OBJECT) {
@@ -508,7 +508,7 @@ bool v12_v13_types_foreach_cb(void *user, const SdbKv *kv) {
 		pj_end(j);
 		sdb_set(ctx->global_vars_db, k, pj_string(j));
 		pj_free(j);
-		rz_list_push(ctx->moved_keys, strdup(k));
+		rz_list_push(ctx->moved_keys, rz_str_dup(k));
 	}
 	return true;
 }

--- a/librz/core/rop.c
+++ b/librz/core/rop.c
@@ -259,7 +259,7 @@ RZ_API RZ_OWN RzRopRegInfo *rz_core_rop_reg_info_new(RZ_NONNULL const RzCore *co
 	RzRegItem *item_dst;
 	rz_list_foreach (head, iter_dst, item_dst) {
 		if (RZ_STR_EQ(name, item_dst->name) && item_dst->type == RZ_REG_TYPE_GPR) {
-			reg_info->name = strdup(name);
+			reg_info->name = rz_str_dup(name);
 			break;
 		}
 	}
@@ -392,7 +392,7 @@ RZ_API RZ_OWN RzRopRegInfo *rz_core_rop_reg_info_dup(RZ_BORROW RZ_NONNULL RzRopR
 		return NULL;
 	}
 
-	dup->name = strdup(src->name);
+	dup->name = rz_str_dup(src->name);
 	dup->is_mem_read = src->is_mem_read;
 	dup->is_pc_write = src->is_pc_write;
 	dup->is_mem_write = src->is_mem_write;
@@ -1336,7 +1336,7 @@ static RzList /*<char *>*/ *handle_grep_args(const char *greparg, const bool reg
 		return NULL;
 	}
 
-	char *grep_arg = strdup(greparg);
+	char *grep_arg = rz_str_dup(greparg);
 	if (!grep_arg) {
 		return NULL;
 	}
@@ -1353,7 +1353,7 @@ static RzList /*<char *>*/ *handle_grep_args(const char *greparg, const bool reg
 
 	const char *tok = strtok(gregexp, ";");
 	while (tok) {
-		char *rx = strdup(tok);
+		char *rx = rz_str_dup(tok);
 		if (!rx) {
 			break;
 		}

--- a/librz/core/rtr.c
+++ b/librz/core/rtr.c
@@ -104,7 +104,7 @@ static void showcursor(RzCore *core, int x) {
 }
 
 static char *rtr_dir_files(const char *path) {
-	char *ptr = strdup("<html><body>\n");
+	char *ptr = rz_str_dup("<html><body>\n");
 	const char *file;
 	RzListIter *iter;
 	// list files
@@ -819,7 +819,7 @@ RZ_API void rz_core_rtr_cmd(RzCore *core, const char *input) {
 				return;
 			}
 			rap_th->core = core;
-			rap_th->input = strdup(input + 1);
+			rap_th->input = rz_str_dup(input + 1);
 			rap_th->loop = rz_atomic_bool_new(true);
 
 			rapthread = rz_th_new((RzThreadFunction)rz_core_rtr_rap_thread, rap_th);
@@ -935,7 +935,7 @@ RZ_API char *rz_core_rtr_cmds_query(RzCore *core, const char *host, const char *
 		retries--;
 	}
 	if (retries > 0) {
-		rbuf = strdup("");
+		rbuf = rz_str_dup("");
 		rz_socket_write(s, (void *)cmd, strlen(cmd));
 		// rz_socket_write (s, "px\n", 3);
 		for (;;) {

--- a/librz/core/rtr_http.c
+++ b/librz/core/rtr_http.c
@@ -46,7 +46,7 @@ static int rz_core_rtr_http_handler_get_file(RzCore *core, RzSocketHTTPRequest *
 	char *dir = NULL;
 	if (rz_config_get_i(core->config, "http.dirlist")) {
 		if (rz_file_is_directory(rs->path)) {
-			dir = strdup(rs->path);
+			dir = rz_str_dup(rs->path);
 		}
 	}
 	if (rz_config_get_i(core->config, "http.upget")) {
@@ -99,7 +99,7 @@ static int rz_core_rtr_http_handler_get_cmd(RzCore *core, RzSocketHTTPRequest *r
 		char *refstr = NULL;
 		if (httpref_enabled) {
 			if (strstr(httpref, "http")) {
-				refstr = strdup(httpref);
+				refstr = rz_str_dup(httpref);
 			} else {
 				refstr = rz_str_newf("http://localhost:%d/", atoi(port));
 			}
@@ -150,7 +150,7 @@ static int rz_core_rtr_http_handler_get_index(RzCore *core, RzSocketHTTPRequest 
 	const char *index = rz_config_get(core->config, "http.index");
 	if (rz_config_get_i(core->config, "http.dirlist")) {
 		if (rz_file_is_directory(rs->path)) {
-			dir = strdup(rs->path);
+			dir = rz_str_dup(rs->path);
 		}
 	}
 	const char *root = rz_config_get(core->config, "http.root");
@@ -159,8 +159,8 @@ static int rz_core_rtr_http_handler_get_index(RzCore *core, RzSocketHTTPRequest 
 	if (!strcmp(rs->path, "/")) {
 		free(rs->path);
 		if (*index == '/') {
-			rs->path = strdup(index);
-			path = strdup(index);
+			rs->path = rz_str_dup(index);
+			path = rz_str_dup(index);
 		} else {
 			rs->path = rz_str_newf("/%s", index);
 			path = rz_file_root(root, rs->path);
@@ -175,13 +175,13 @@ static int rz_core_rtr_http_handler_get_index(RzCore *core, RzSocketHTTPRequest 
 		}
 	} else {
 		if (*index == '/') {
-			path = strdup(index);
+			path = rz_str_dup(index);
 		} else {
 		}
 	}
 	// FD IS OK HERE
 	if (rs->path[strlen(rs->path) - 1] == '/') {
-		path = (*index == '/') ? strdup(index) : rz_str_append(path, index);
+		path = (*index == '/') ? rz_str_dup(index) : rz_str_append(path, index);
 	} else {
 		if (rz_file_is_directory(path)) {
 			char *res = rz_str_newf("Location: %s/\n%s", rs->path, headers);
@@ -480,7 +480,7 @@ static int rz_core_rtr_http_run(RzCore *core, int launch, int browse, const char
 			bool accepted = false;
 			const char *allows_host;
 			char *p, *peer = rz_socket_to_string(rs->s);
-			char *allows = strdup(allow);
+			char *allows = rz_str_dup(allow);
 			// eprintf ("Firewall (%s)\n", allows);
 			int i, count = rz_str_split(allows, ',');
 			p = strchr(peer, ':');
@@ -520,7 +520,7 @@ static int rz_core_rtr_http_run(RzCore *core, int launch, int browse, const char
 		}
 		if (rz_config_get_i(core->config, "http.dirlist")) {
 			if (rz_file_is_directory(rs->path)) {
-				dir = strdup(rs->path);
+				dir = rz_str_dup(rs->path);
 			}
 		}
 		if (rz_config_get_i(core->config, "http.cors")) {

--- a/librz/core/serialize_core.c
+++ b/librz/core/serialize_core.c
@@ -334,7 +334,7 @@ typedef struct {
  **/
 static bool seek_load_item(SeekLoadCtx *ctx, const char *k, const char *v) {
 	bool ret = false;
-	char *json_str = strdup(v);
+	char *json_str = rz_str_dup(v);
 	if (!json_str) {
 		return true;
 	}
@@ -372,7 +372,7 @@ static bool seek_load_item(SeekLoadCtx *ctx, const char *k, const char *v) {
 		// Switch to the vector of redos
 		ctx->vec = &ctx->core->seek_history.redos;
 		// Remember we've found the current seek
-		ctx->current_key = strdup(k);
+		ctx->current_key = rz_str_dup(k);
 	} else {
 		if (seek_item.is_current) {
 			// Warn about this additional "current" seek

--- a/librz/core/task.c
+++ b/librz/core/task.c
@@ -586,7 +586,7 @@ static CmdTaskCtx *cmd_task_ctx_new(RzCore *core, const char *cmd, RzCoreCmdTask
 		free(ctx);
 		return NULL;
 	}
-	ctx->cmd = strdup(cmd);
+	ctx->cmd = rz_str_dup(cmd);
 	ctx->cmd_log = false;
 	ctx->res = NULL;
 	ctx->finished_cb = finished_cb;

--- a/librz/core/tui/classes.c
+++ b/librz/core/tui/classes.c
@@ -93,7 +93,7 @@ static void *show_class(RzCore *core, int mode, int *idx, RzBinClass *_c, const 
 				}
 			}
 
-			char *mflags = strdup("");
+			char *mflags = rz_str_dup("");
 
 			if (rz_str_startswith(name, _c->name)) {
 				name += strlen(_c->name);

--- a/librz/core/tui/comments.c
+++ b/librz/core/tui/comments.c
@@ -37,7 +37,7 @@ RZ_IPI int rz_core_visual_comments(RzCore *core) {
 				from = addr;
 				size = 1; // XXX: remove this thing size for comments is useless d->size;
 				free(p);
-				p = strdup(str);
+				p = rz_str_dup(str);
 				rz_cons_printf("  >  %s\n", str);
 			} else {
 				rz_cons_printf("     %s\n", str);

--- a/librz/core/tui/define.c
+++ b/librz/core/tui/define.c
@@ -199,7 +199,7 @@ onemoretime:
 				if (item) {
 					const char *ptr = rz_str_lchr(item->name, '.');
 					if (ptr) {
-						man = strdup(ptr + 1);
+						man = rz_str_dup(ptr + 1);
 					}
 				}
 			}

--- a/librz/core/tui/panels.c
+++ b/librz/core/tui/panels.c
@@ -1651,7 +1651,7 @@ void __handleComment(RzCore *core) {
 		}
 		if (buf[3] == ' ') {
 			int j, len = strlen(buf);
-			char *duped = strdup(buf);
+			char *duped = rz_str_dup(buf);
 			for (i = 4, j = 4; i < len; i++, j++) {
 				char c = duped[i];
 				if (c == '"' && i != (len - 1)) {
@@ -3581,8 +3581,8 @@ int __symbols_cb(void *user) {
 int __program_cb(void *user) {
 	RzCore *core = (RzCore *)user;
 	char *dh_orig = core->dbg->cur
-		? strdup(core->dbg->cur->name)
-		: strdup("esil");
+		? rz_str_dup(core->dbg->cur->name)
+		: rz_str_dup("esil");
 	rz_core_analysis_all(core);
 	rz_core_analysis_everything(core, false, dh_orig);
 	return 0;
@@ -4263,7 +4263,7 @@ RZ_OWN RzPanelsMenuItem *rz_panels_menu_item_new(RZ_NULLABLE const char *name, R
 	}
 	item->selectedIndex = 0;
 	rz_pvector_init(&item->submenus, (RzPVectorFree)rz_panels_menu_item_free);
-	item->name = name ? strdup(name) : NULL;
+	item->name = rz_str_dup(name);
 	item->cb = cb;
 	return item;
 }
@@ -4371,7 +4371,7 @@ void __init_menu_color_settings_layout(void *_core, const char *parent) {
 	RzCore *core = (RzCore *)_core;
 	const char *color = core->cons->context->pal.graph_box2;
 	const char *curtheme = rz_core_theme_get(core);
-	char *now = strdup(curtheme);
+	char *now = rz_str_dup(curtheme);
 	rz_str_split(now, '\n');
 	parent = "Settings.Colors";
 	RzStrBuf *buf = rz_strbuf_new(NULL);
@@ -6420,7 +6420,7 @@ RZ_OWN char *get_word_from_canvas(RzCore *core, RzPanelsTab *tab, int x, int y) 
 	if (sp2) {
 		*sp2 = 0;
 	}
-	char *res = strdup(sp);
+	char *res = rz_str_dup(sp);
 	free(r);
 	free(R);
 	free(cs);
@@ -6451,7 +6451,7 @@ RZ_OWN char *get_word_from_canvas_for_menu(RzCore *core, RzPanelsTab *tab, int x
 	}
 	char *ret = rz_str_newlen(pos += strlen(padding), i - strlen(padding));
 	if (!ret) {
-		ret = strdup(pos);
+		ret = rz_str_dup(pos);
 	}
 	free(r);
 	free(R);

--- a/librz/core/tui/rop.c
+++ b/librz/core/tui/rop.c
@@ -40,7 +40,7 @@ RZ_IPI int rz_core_visual_view_rop(RzCore *core) {
 	bool show_color = core->print->flags & RZ_PRINT_FLAGS_COLOR;
 	bool forceaddr = false;
 	ut64 addr = UT64_MAX;
-	char *cursearch = strdup(linestr);
+	char *cursearch = rz_str_dup(linestr);
 	while (true) {
 		rz_cons_clear00();
 		rz_cons_printf("[0x%08" PFMT64x "]-[visual-rzrop] %s (see pdp command)\n",
@@ -178,7 +178,7 @@ RZ_IPI int rz_core_visual_view_rop(RzCore *core) {
 				delta = 0;
 				addr = UT64_MAX;
 				cur = 0;
-				cursearch = strdup(linestr);
+				cursearch = rz_str_dup(linestr);
 				free(ropstr);
 				ropstr = rz_core_cmd_strf(core, "\"/Rl %s\" @e:scr.color=0", linestr);
 				rz_list_free(rops);

--- a/librz/core/tui/tabs.c
+++ b/librz/core/tui/tabs.c
@@ -32,7 +32,7 @@ RZ_IPI RZ_OWN char *rz_core_visual_tab_string(RzCore *core, const char *kolor) {
 	int hex_cols = rz_config_get_i(core->config, "hex.cols");
 	int scr_color = rz_config_get_i(core->config, "scr.color");
 	if (hex_cols < 4) {
-		return strdup("");
+		return rz_str_dup("");
 	}
 	int i = 0;
 	char *str = NULL;

--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -1221,13 +1221,13 @@ repeat:
 				RzAnalysisFunction *fun = rz_analysis_get_fcn_in(core->analysis, xaddr1, RZ_ANALYSIS_FCN_TYPE_NULL);
 				char *name;
 				if (fun) {
-					name = strdup(fun->name);
+					name = rz_str_dup(fun->name);
 				} else {
 					RzFlagItem *f = rz_flag_get_at(core->flags, xaddr1, true);
 					if (f) {
 						name = rz_str_newf("%s + %" PFMT64d, f->name, xaddr1 - f->offset);
 					} else {
-						name = strdup("unk");
+						name = rz_str_dup("unk");
 					}
 				}
 				if (w > 45) {
@@ -1462,13 +1462,13 @@ static void visual_comma(RzCore *core) {
 	ut64 addr = core->offset + (core->print->cur_enabled ? core->print->cur : 0);
 	char *comment, *cmtfile;
 	const char *prev_cmt = rz_meta_get_string(core->analysis, RZ_META_TYPE_COMMENT, addr);
-	comment = prev_cmt ? strdup(prev_cmt) : NULL;
+	comment = rz_str_dup(prev_cmt);
 	cmtfile = rz_str_between(comment, ",(", ")");
 	if (!cmtfile) {
 		char *fn;
 		fn = rz_cons_input("<comment-file> ");
 		if (fn && *fn) {
-			cmtfile = strdup(fn);
+			cmtfile = rz_str_dup(fn);
 			if (!comment || !*comment) {
 				comment = rz_str_newf(",(%s)", fn);
 				rz_meta_set_string(core->analysis, RZ_META_TYPE_COMMENT, addr, comment);
@@ -2261,7 +2261,7 @@ RZ_IPI int rz_core_visual_cmd(RzCore *core, const char *arg) {
 #define I core->cons
 			const char *cmd = rz_config_get(core->config, "cmd.vprompt");
 			rz_line_set_prompt(line, "cmd.vprompt> ");
-			I->line->contents = strdup(cmd);
+			I->line->contents = rz_str_dup(cmd);
 			buf = rz_line_readline(line);
 			I->line->contents = NULL;
 			(void)rz_config_set(core->config, "cmd.vprompt", buf);
@@ -2273,7 +2273,7 @@ RZ_IPI int rz_core_visual_cmd(RzCore *core, const char *arg) {
 #define I core->cons
 			const char *cmd = rz_config_get(core->config, "cmd.cprompt");
 			rz_line_set_prompt(line, "cmd.cprompt> ");
-			line->contents = strdup(cmd);
+			line->contents = rz_str_dup(cmd);
 			buf = rz_line_readline(line);
 			if (buf && !strcmp(buf, "|")) {
 				RZ_FREE(line->contents);
@@ -2492,7 +2492,7 @@ RZ_IPI int rz_core_visual_cmd(RzCore *core, const char *arg) {
 				if (rz_cons_fgets(buf + 4, sizeof(buf) - 4, 0, NULL) < 0) {
 					buf[0] = '\0';
 				}
-				char *p = strdup(buf);
+				char *p = rz_str_dup(buf);
 				int cur = core->print->cur;
 				if (cur >= core->blocksize) {
 					cur = core->print->cur - 1;
@@ -3567,7 +3567,7 @@ static RZ_OWN char *screen_bottom_address(RzCore *core) {
 	if (!core->cons->context->buffer) {
 		return NULL;
 	}
-	char *output = strdup(core->cons->context->buffer);
+	char *output = rz_str_dup(core->cons->context->buffer);
 	size_t line_count = 0, *line_index = rz_str_split_lines(output, &line_count);
 	int rows;
 	rz_cons_get_size(&rows);

--- a/librz/core/tui/vmenus.c
+++ b/librz/core/tui/vmenus.c
@@ -23,7 +23,7 @@ static void function_rename(RzCore *core, ut64 addr, const char *name) {
 		if (fcn->addr == addr) {
 			rz_flag_unset_name(core->flags, fcn->name);
 			free(fcn->name);
-			fcn->name = strdup(name);
+			fcn->name = rz_str_dup(name);
 			rz_flag_set(core->flags, name, addr, rz_analysis_function_size_from_entry(fcn));
 			break;
 		}
@@ -573,7 +573,7 @@ static char *__prompt(const char *msg, void *p) {
 	if (!rz_cons_fgets(res, sizeof(res), 0, NULL)) {
 		res[0] = 0;
 	}
-	return strdup(res);
+	return rz_str_dup(res);
 }
 
 static void addVar(RzCore *core, int ch, const char *msg) {

--- a/librz/core/yank.c
+++ b/librz/core/yank.c
@@ -363,7 +363,7 @@ RZ_API bool rz_core_yank_hexpair(RzCore *core, const char *str) {
 	if (RZ_STR_ISEMPTY(str)) {
 		return false;
 	}
-	char *out = strdup(str);
+	char *out = rz_str_dup(str);
 	int len = rz_hex_str2bin(str, (ut8 *)str);
 	if (len > 0) {
 		rz_core_yank_set(core, core->offset, (ut8 *)out, len);

--- a/librz/debug/ddesc.c
+++ b/librz/debug/ddesc.c
@@ -9,7 +9,7 @@ RZ_API RzDebugDesc *rz_debug_desc_new(int fd, char *path, int perm, int type, in
 	RzDebugDesc *desc = RZ_NEW(RzDebugDesc);
 	if (desc) {
 		desc->fd = fd;
-		desc->path = strdup(path);
+		desc->path = rz_str_dup(path);
 		desc->perm = perm;
 		desc->type = type;
 		desc->off = off;

--- a/librz/debug/debug.c
+++ b/librz/debug/debug.c
@@ -352,7 +352,7 @@ RZ_API RZ_BORROW RzBreakpointItem *rz_debug_bp_add(RZ_NONNULL RzDebug *dbg, ut64
 	}
 	if (bpi) {
 		if (module_name) {
-			bpi->module_name = strdup(module_name);
+			bpi->module_name = rz_str_dup(module_name);
 			bpi->name = rz_str_newf("%s+0x%" PFMT64x, module_name, m_delta);
 		}
 		bpi->module_delta = m_delta;
@@ -373,7 +373,7 @@ RZ_API RZ_OWN RzDebug *rz_debug_new(RZ_BORROW RZ_NONNULL RzBreakpointContext *bp
 		return NULL;
 	}
 	// RZ_SYS_ARCH
-	dbg->arch = strdup(RZ_SYS_ARCH);
+	dbg->arch = rz_str_dup(RZ_SYS_ARCH);
 	dbg->bits = RZ_SYS_BITS;
 	dbg->trace_forks = 1;
 	dbg->forked_pid = -1;
@@ -511,7 +511,7 @@ RZ_API bool rz_debug_set_arch(RzDebug *dbg, const char *arch, int bits) {
 			}
 		}
 		free(dbg->arch);
-		dbg->arch = strdup(arch);
+		dbg->arch = rz_str_dup(arch);
 		return true;
 	}
 	return false;
@@ -1735,7 +1735,7 @@ RZ_API ut64 rz_debug_get_baddr(RzDebug *dbg, const char *file) {
 	}
 #endif
 	if (!abspath && file) {
-		abspath = strdup(file);
+		abspath = rz_str_dup(file);
 	}
 	if (abspath) {
 		rz_list_foreach (dbg->maps, iter, map) {

--- a/librz/debug/desil.c
+++ b/librz/debug/desil.c
@@ -29,7 +29,7 @@ RzList *esil_watchpoints = NULL;
 #define ESIL dbg->analysis->esil
 
 static int exprmatch(RzDebug *dbg, ut64 addr, const char *expr) {
-	char *e = strdup(expr);
+	char *e = rz_str_dup(expr);
 	if (!e) {
 		return 0;
 	}
@@ -142,7 +142,7 @@ static int exprtoken(RzDebug *dbg, char *s, const char *sep, char **o) {
 static int exprmatchreg(RzDebug *dbg, const char *regname, const char *expr) {
 	int ret = 0;
 	char *p;
-	char *s = strdup(expr);
+	char *s = rz_str_dup(expr);
 	if (!s) {
 		return 0;
 	}
@@ -323,7 +323,7 @@ RZ_API void rz_debug_esil_watch(RzDebug *dbg, int rwx, int dev, const char *expr
 	}
 	ew->rwx = rwx;
 	ew->dev = dev;
-	ew->expr = strdup(expr);
+	ew->expr = rz_str_dup(expr);
 	rz_list_append(EWPS, ew);
 }
 

--- a/librz/debug/dmap.c
+++ b/librz/debug/dmap.c
@@ -14,7 +14,7 @@ RZ_API RZ_OWN RzDebugMap *rz_debug_map_new(RZ_NULLABLE char *name, ut64 begin, u
 	if (!map) {
 		return NULL;
 	}
-	map->name = strdup(name ? name : "");
+	map->name = rz_str_dup(name ? name : "");
 	map->addr = begin;
 	map->addr_end = end;
 	map->size = end - begin;

--- a/librz/debug/dsession.c
+++ b/librz/debug/dsession.c
@@ -639,7 +639,7 @@ static bool deserialize_checkpoints_cb(void *user, const SdbKv *kv) {
 			eprintf("Error: failed to allocate RzDebugSnap snap");
 			continue;
 		}
-		snap->name = strdup(namej->str_value);
+		snap->name = rz_str_dup(namej->str_value);
 		snap->addr = addrj->num.u_value;
 		snap->addr_end = addr_endj->num.u_value;
 		snap->size = sizej->num.u_value;

--- a/librz/debug/p/common_winkd.c
+++ b/librz/debug/p/common_winkd.c
@@ -109,7 +109,7 @@ bool winkd_download_module_and_pdb(WindModule *module, const char *symserver, co
 		return false;
 	}
 	if (pdbpath) {
-		*pdbpath = strdup(ppath->str_value);
+		*pdbpath = rz_str_dup(ppath->str_value);
 	}
 	rz_json_free(json);
 	free(res);

--- a/librz/debug/p/debug_bf.c
+++ b/librz/debug/p/debug_bf.c
@@ -123,7 +123,7 @@ static int brainfuck_detach(RzDebug *dbg, int pid) {
 }
 
 static char *brainfuck_reg_profile(RzDebug *dbg) {
-	return strdup(
+	return rz_str_dup(
 		"=PC	pc\n"
 		"=SP	esp\n"
 		"=BP	ptr\n"

--- a/librz/debug/p/debug_bochs.c
+++ b/librz/debug/p/debug_bochs.c
@@ -574,7 +574,7 @@ static char *bochs_reg_profile(RzDebug *dbg) {
 	int bits = dbg->analysis->bits;
 
 	if (bits == 16 || bits == 32 || bits == 64) {
-		return strdup(
+		return rz_str_dup(
 			"=PC	rip\n"
 			"=SP	rsp\n"
 			"=BP	rbp\n"

--- a/librz/debug/p/debug_dmp.c
+++ b/librz/debug/p/debug_dmp.c
@@ -150,7 +150,7 @@ static bool rz_debug_dmp_init(RzDebug *dbg, void **user) {
 			// TODO: Convert to API call
 			dbg->corebind.cmdf(dbg->corebind.core, "idp \"%s\"", pdbpath);
 			free(exepath);
-			kernel_pdb = strdup(rz_file_basename(pdbpath));
+			kernel_pdb = rz_str_dup(rz_file_basename(pdbpath));
 			free(pdbpath);
 			if (!ctx->windctx.profile) {
 				winkd_build_profile(&ctx->windctx, dbg->analysis->typedb);
@@ -182,7 +182,7 @@ static bool rz_debug_dmp_init(RzDebug *dbg, void **user) {
 		kpb_flag_name = rz_str_newf("pdb.%s.KiProcessorBlock", kernel_pdb);
 		free(kernel_pdb);
 	} else {
-		kpb_flag_name = strdup("0");
+		kpb_flag_name = rz_str_dup("0");
 	}
 	const ut64 KiProcessorBlock = dbg->corebind.numGet(dbg->corebind.core, kpb_flag_name);
 	free(kpb_flag_name);
@@ -200,7 +200,7 @@ static bool rz_debug_dmp_init(RzDebug *dbg, void **user) {
 		// Map ETHREAD into address space
 		const ut64 address = 0x1000;
 		map = rz_io_map_new(core->io, desc->fd, RZ_PERM_R, ThreadOffset, address, CallStackOffset - ThreadOffset);
-		map->name = strdup("kernel.target.ethread");
+		map->name = rz_str_dup("kernel.target.ethread");
 		WindThread *target_thread = winkd_get_thread_at(&ctx->windctx, address);
 
 		ctx->windctx.target_thread.ethread = address;
@@ -213,7 +213,7 @@ static bool rz_debug_dmp_init(RzDebug *dbg, void **user) {
 				// Map EPROCESS into address space
 				const ut64 current_process = winkd_read_ptr_at(&ctx->windctx, ctx->windctx.read_at_kernel_virtual, thread->ethread + ctx->kthread_process_offset);
 				RzIOMap *map = rz_io_map_new(core->io, desc->fd, RZ_PERM_R, ProcessOffset, current_process, ThreadOffset - ProcessOffset);
-				map->name = strdup("kernel.target.eprocess");
+				map->name = rz_str_dup("kernel.target.eprocess");
 				WindProc *process = winkd_get_process_at(&ctx->windctx, current_process);
 				ctx->windctx.target = *process;
 				ctx->windctx.target_thread = *thread;
@@ -292,7 +292,7 @@ static RzList /*<RzDebugPid *>*/ *rz_debug_dmp_pids(RzDebug *dbg, int pid) {
 			rz_list_free(pids);
 			return NULL;
 		}
-		newpid->path = strdup(p->name);
+		newpid->path = rz_str_dup(p->name);
 		newpid->pid = p->uniqueid;
 		newpid->status = 's';
 		newpid->runnable = true;
@@ -772,7 +772,7 @@ static RzList /*<WindModule *>*/ *dmp_get_modules(DmpCtx *ctx) {
 			rz_list_free(ret);
 			return NULL;
 		}
-		mod->name = strdup(driver->file);
+		mod->name = rz_str_dup(driver->file);
 		mod->size = driver->size;
 		mod->addr = driver->base;
 		mod->timestamp = driver->timestamp;
@@ -798,7 +798,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_dmp_modules(RzDebug *dbg) {
 			return NULL;
 		}
 		RZ_PTR_MOVE(mod->file, m->name);
-		mod->name = strdup(rz_file_dos_basename(mod->file));
+		mod->name = rz_str_dup(rz_file_dos_basename(mod->file));
 		mod->size = m->size;
 		mod->addr = m->addr;
 		mod->addr_end = m->addr + m->size;
@@ -827,7 +827,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_dmp_maps(RzDebug *dbg) {
 		}
 		if (m->file) {
 			RZ_PTR_MOVE(map->file, m->file);
-			map->name = strdup(rz_file_dos_basename(map->file));
+			map->name = rz_str_dup(rz_file_dos_basename(map->file));
 		}
 		map->size = m->end - m->start;
 		map->addr = m->start;

--- a/librz/debug/p/debug_gdb.c
+++ b/librz/debug/p/debug_gdb.c
@@ -263,7 +263,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_gdb_map_get(RzDebug *dbg) { // TODO
 		}
 		map->offset = offset;
 		map->shared = map_is_shared;
-		map->file = strdup(name);
+		map->file = rz_str_dup(name);
 		rz_list_append(retlist, map);
 		ptr = strtok(NULL, "\n");
 	}
@@ -288,7 +288,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_gdb_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -301,7 +301,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_gdb_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;
@@ -452,7 +452,7 @@ static const char *rz_debug_gdb_reg_profile(RzDebug *dbg) {
 		gdbr_set_architecture(ctx->desc, arch, bits);
 	}
 	if (ctx->desc->target.regprofile) {
-		return strdup(ctx->desc->target.regprofile);
+		return rz_str_dup(ctx->desc->target.regprofile);
 	}
 	return NULL;
 }

--- a/librz/debug/p/debug_qnx.c
+++ b/librz/debug/p/debug_qnx.c
@@ -12,7 +12,7 @@ RZ_API RzDebugPid *__r_debug_pid_new(const char *path, int pid, char status, ut6
 	if (!p) {
 		return NULL;
 	}
-	p->path = strdup(path);
+	p->path = rz_str_dup(path);
 	p->pid = pid;
 	p->status = status;
 	p->runnable = true;
@@ -227,7 +227,7 @@ static const char *rz_debug_qnx_reg_profile(RzDebug *dbg) {
 	int bits = dbg->analysis->bits;
 	switch (arch) {
 	case RZ_SYS_ARCH_X86:
-		return strdup(
+		return rz_str_dup(
 			"=PC	eip\n"
 			"=SP	esp\n"
 			"=BP	ebp\n"
@@ -256,7 +256,7 @@ static const char *rz_debug_qnx_reg_profile(RzDebug *dbg) {
 		);
 	case RZ_SYS_ARCH_ARM:
 		if (bits == 32) {
-			return strdup(
+			return rz_str_dup(
 				"=PC	r15\n"
 				"=SP	r14\n" // XXX
 				"=A0	r0\n"

--- a/librz/debug/p/debug_windbg.c
+++ b/librz/debug/p/debug_windbg.c
@@ -398,7 +398,7 @@ static RzList *windbg_modules_get(RzDebug *dbg) {
 		}
 		RzDebugMap *mod = rz_debug_map_new(mod_name, params[i].Base, params[i].Base + params[i].Size, 0, params[i].Size);
 		if (mod) {
-			mod->file = strdup(image_name);
+			mod->file = rz_str_dup(image_name);
 			rz_list_append(modules_list, mod);
 		}
 		free(mod_name);
@@ -577,8 +577,8 @@ static RzDebugInfo *windbg_info(RzDebug *dbg, const char *arg) {
 		}
 		info->pid = dbg->pid;
 		info->tid = dbg->tid;
-		info->exe = strdup(exeinfo);
-		info->cmdline = strdup(cmdline);
+		info->exe = rz_str_dup(exeinfo);
+		info->cmdline = rz_str_dup(cmdline);
 	}
 	return NULL;
 }

--- a/librz/debug/p/debug_winkd.c
+++ b/librz/debug/p/debug_winkd.c
@@ -189,7 +189,7 @@ static int rz_debug_winkd_attach(RZ_BORROW RZ_NONNULL RzDebug *dbg, int pid) {
 		}
 	}
 	if (!mod->name) {
-		mod->name = strdup("\\ntoskrnl.exe");
+		mod->name = rz_str_dup("\\ntoskrnl.exe");
 	}
 	char *exepath, *pdbpath;
 	if (!winkd_download_module_and_pdb(mod,
@@ -290,7 +290,7 @@ static RzList /*<RzDebugPid *>*/ *rz_debug_winkd_pids(RZ_BORROW RZ_NONNULL RzDeb
 			rz_list_free(pids);
 			return NULL;
 		}
-		newpid->path = strdup(p->name);
+		newpid->path = rz_str_dup(p->name);
 		newpid->pid = p->uniqueid;
 		newpid->status = 's';
 		newpid->runnable = true;
@@ -418,7 +418,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_winkd_maps(RZ_BORROW RZ_NONNULL RzDeb
 		}
 		if (m->file) {
 			RZ_PTR_MOVE(map->file, m->file);
-			map->name = strdup(rz_file_dos_basename(map->file));
+			map->name = rz_str_dup(rz_file_dos_basename(map->file));
 		}
 		map->size = m->end - m->start;
 		map->addr = m->start;

--- a/librz/debug/p/native/android_arm.c
+++ b/librz/debug/p/native/android_arm.c
@@ -489,7 +489,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 		}
 		map->offset = offset;
 		map->shared = map_is_shared;
-		map->file = strdup(name);
+		map->file = rz_str_dup(name);
 		rz_list_append(list, map);
 	}
 	fclose(fd);
@@ -512,7 +512,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -525,7 +525,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;

--- a/librz/debug/p/native/android_arm64.c
+++ b/librz/debug/p/native/android_arm64.c
@@ -489,7 +489,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 		}
 		map->offset = offset;
 		map->shared = map_is_shared;
-		map->file = strdup(name);
+		map->file = rz_str_dup(name);
 		rz_list_append(list, map);
 	}
 	fclose(fd);
@@ -512,7 +512,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -525,7 +525,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;

--- a/librz/debug/p/native/android_x86_64.c
+++ b/librz/debug/p/native/android_x86_64.c
@@ -489,7 +489,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 		}
 		map->offset = offset;
 		map->shared = map_is_shared;
-		map->file = strdup(name);
+		map->file = rz_str_dup(name);
 		rz_list_append(list, map);
 	}
 	fclose(fd);
@@ -512,7 +512,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -525,7 +525,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;

--- a/librz/debug/p/native/apple_aarch64.c
+++ b/librz/debug/p/native/apple_aarch64.c
@@ -185,7 +185,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -198,7 +198,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;

--- a/librz/debug/p/native/apple_x86_64.c
+++ b/librz/debug/p/native/apple_x86_64.c
@@ -185,7 +185,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -198,7 +198,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;

--- a/librz/debug/p/native/bsd/bsd_debug.c
+++ b/librz/debug/p/native/bsd/bsd_debug.c
@@ -170,7 +170,7 @@ RzDebugInfo *bsd_info(RzDebug *dbg, const char *arg) {
 	rdi->tid = dbg->tid;
 	rdi->uid = kp->ki_uid;
 	rdi->gid = kp->ki_pgid;
-	rdi->exe = strdup(kp->ki_comm);
+	rdi->exe = rz_str_dup(kp->ki_comm);
 
 	switch (kp->ki_stat) {
 	case SSLEEP:
@@ -216,7 +216,7 @@ RzDebugInfo *bsd_info(RzDebug *dbg, const char *arg) {
 		rdi->tid = dbg->tid;
 		rdi->uid = kp->p_uid;
 		rdi->gid = kp->p__pgid;
-		rdi->exe = strdup(kp->p_comm);
+		rdi->exe = rz_str_dup(kp->p_comm);
 
 		switch (kp->p_stat) {
 		case SDEAD:
@@ -258,7 +258,7 @@ RzDebugInfo *bsd_info(RzDebug *dbg, const char *arg) {
 		rdi->tid = dbg->tid;
 		rdi->uid = kp->p_uid;
 		rdi->gid = kp->p__pgid;
-		rdi->exe = strdup(kp->p_comm);
+		rdi->exe = rz_str_dup(kp->p_comm);
 
 		rdi->status = RZ_DBG_PROC_STOP;
 

--- a/librz/debug/p/native/bt/generic-x64.c
+++ b/librz/debug/p/native/bt/generic-x64.c
@@ -103,7 +103,7 @@ static RzList /*<RzDebugFrame *>*/ *backtrace_x86_64_analysis(RzDebug *dbg, ut64
 		frame->size = 0;
 		frame->sp = _rbp;
 		frame->bp = _rbp + 8;
-		// frame->name = (fcn && fcn->name) ? strdup (fcn->name) : NULL;
+		// frame->name = (fcn && fcn->name) ? rz_str_dup (fcn->name) : NULL;
 		rz_list_append(list, frame);
 		_rbp = ebp2;
 	}

--- a/librz/debug/p/native/dragonfly.c
+++ b/librz/debug/p/native/dragonfly.c
@@ -356,7 +356,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 		if (!map) {
 			break;
 		}
-		map->file = strdup(name);
+		map->file = rz_str_dup(name);
 		rz_list_append(list, map);
 	}
 	fclose(fd);
@@ -379,7 +379,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -392,7 +392,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;

--- a/librz/debug/p/native/kfbsd.c
+++ b/librz/debug/p/native/kfbsd.c
@@ -362,7 +362,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 		if (!map) {
 			break;
 		}
-		map->file = strdup(name);
+		map->file = rz_str_dup(name);
 		rz_list_append(list, map);
 	}
 	fclose(fd);
@@ -385,7 +385,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -398,7 +398,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;

--- a/librz/debug/p/native/linux/linux_coredump.c
+++ b/librz/debug/p/native/linux/linux_coredump.c
@@ -92,7 +92,7 @@ static prpsinfo_t *linux_get_prpsinfo(RzDebug *dbg, proc_per_process_t *proc_dat
 		goto error;
 	}
 	buffer[len] = 0;
-	pfname = strdup(buffer);
+	pfname = rz_str_dup(buffer);
 	if (!pfname) {
 		goto error;
 	}
@@ -299,7 +299,7 @@ static char *isAnonymousKeyword(const char *pp) {
 static bool has_map_anonymous_content(char *buff_smaps, unsigned long start_addr, unsigned long end_addr) {
 	char *pp, *extern_tok = NULL, *keyw = NULL;
 	char *identity = rz_str_newf(fmt_addr, start_addr, end_addr);
-	char *str = strdup(buff_smaps);
+	char *str = rz_str_dup(buff_smaps);
 	char *p = strtok_r(str, "\n", &extern_tok);
 	for (; p; p = strtok_r(NULL, "\n", &extern_tok)) {
 		if (strstr(p, identity)) {
@@ -334,7 +334,7 @@ static bool dump_this_map(char *buff_smaps, linux_map_entry_t *entry, ut8 filter
 		free(identity);
 		return false;
 	}
-	aux = strdup(buff_smaps);
+	aux = rz_str_dup(buff_smaps);
 	if (!aux) {
 		free(identity);
 		return false;
@@ -507,7 +507,7 @@ static linux_map_entry_t *linux_get_mapped_files(RzDebug *dbg, ut8 filter_flags)
 		pmentry->end_addr = map->addr_end;
 		pmentry->offset = map->offset;
 		pmentry->name = strncmp(map->name, "unk", strlen("unk"))
-			? strdup(map->name)
+			? rz_str_dup(map->name)
 			: NULL;
 		pmentry->perms = map->perm;
 		pmentry->shared = map->shared;

--- a/librz/debug/p/native/linux/linux_debug.c
+++ b/librz/debug/p/native/linux/linux_debug.c
@@ -740,7 +740,7 @@ static char *read_link(int pid, const char *file) {
 	int ret = readlink(path, buf, sizeof(buf));
 	if (ret > 0) {
 		buf[sizeof(buf) - 1] = '\0';
-		return strdup(buf);
+		return rz_str_dup(buf);
 	}
 	return NULL;
 }
@@ -832,7 +832,7 @@ RzDebugPid *fill_pid_info(const char *info, const char *path, int tid) {
 	}
 
 	pid_info->pid = tid;
-	pid_info->path = path ? strdup(path) : NULL;
+	pid_info->path = rz_str_dup(path);
 	pid_info->runnable = true;
 	pid_info->pc = 0;
 	return pid_info;

--- a/librz/debug/p/native/linux/reg/linux-arm.h
+++ b/librz/debug/p/native/linux/reg/linux-arm.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2015 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=SP	r13\n"
 	"=LR	r14\n"
 	"=PC	r15\n"

--- a/librz/debug/p/native/linux/reg/linux-arm64.h
+++ b/librz/debug/p/native/linux/reg/linux-arm64.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // NGREG 34
-return strdup(
+return rz_str_dup(
 	"=PC	pc\n"
 	"=BP	x29\n"
 	"=SP	sp\n"

--- a/librz/debug/p/native/linux/reg/linux-loongarch64.h
+++ b/librz/debug/p/native/linux/reg/linux-loongarch64.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Wenlong Zhang <zhangwenlong@loongson.cn>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC    pc\n"
 	"=SP    sp\n"
 	"=BP    fp\n"

--- a/librz/debug/p/native/linux/reg/linux-mips.h
+++ b/librz/debug/p/native/linux/reg/linux-mips.h
@@ -44,7 +44,7 @@ PC = 272
    It is using the same arena->size, but we are only using the last 4 bytes
    (LITTLE ENDIAN PROBLEMS?)
 */
-return strdup(
+return rz_str_dup(
 	"=PC    pc\n"
 	"=SP    sp\n"
 	"=BP    fp\n"

--- a/librz/debug/p/native/linux/reg/linux-mips64.h
+++ b/librz/debug/p/native/linux/reg/linux-mips64.h
@@ -30,7 +30,7 @@ PC = 272
 #endif
 
 #endif
-return strdup(
+return rz_str_dup(
 	"=PC	pc\n"
 	"=SP	sp\n"
 	"=BP	fp\n"

--- a/librz/debug/p/native/linux/reg/linux-ppc.h
+++ b/librz/debug/p/native/linux/reg/linux-ppc.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2016 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC	srr0\n"
 	"=SP	srr1\n"
 	"=SR	srr1\n" // status register ??

--- a/librz/debug/p/native/linux/reg/linux-ppc64.h
+++ b/librz/debug/p/native/linux/reg/linux-ppc64.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2017 Fangrui Song <i@maskray.me>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC  pc\n"
 	"=SP  r1\n"
 	"=A0  r3\n"

--- a/librz/debug/p/native/linux/reg/linux-riscv64.h
+++ b/librz/debug/p/native/linux/reg/linux-riscv64.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2019 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC	pc\n"
 	"=SP	x2\n"
 	"=BP	x4\n"

--- a/librz/debug/p/native/linux/reg/linux-s390x.h
+++ b/librz/debug/p/native/linux/reg/linux-s390x.h
@@ -60,7 +60,7 @@ Linux (currently) always uses IEEE & emulates G5 IEEE format on older machines,
 ( provided the kernel is configured for this ).
 #endif
 
-return strdup(
+return rz_str_dup(
 	"=PC	pc\n"
 	"=LR	r14\n"
 	"=SP	r15\n"

--- a/librz/debug/p/native/linux/reg/linux-x64-32.h
+++ b/librz/debug/p/native/linux/reg/linux-x64-32.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // 64bit host debugging 32bit binary
-return strdup(
+return rz_str_dup(
 	"=PC	eip\n"
 	"=SP	esp\n"
 	"=BP	ebp\n"

--- a/librz/debug/p/native/linux/reg/linux-x64.h
+++ b/librz/debug/p/native/linux/reg/linux-x64.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // 64bit host debugging 64bit target
-return strdup(
+return rz_str_dup(
 	"=PC	rip\n"
 	"=SP	rsp\n"
 	"=BP	rbp\n"

--- a/librz/debug/p/native/linux/reg/linux-x86.h
+++ b/librz/debug/p/native/linux/reg/linux-x86.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // 32bit host debugging 32bit target
-return strdup(
+return rz_str_dup(
 	"=PC	eip\n"
 	"=SP	esp\n"
 	"=BP	ebp\n"

--- a/librz/debug/p/native/linux_aarch64.c
+++ b/librz/debug/p/native/linux_aarch64.c
@@ -563,7 +563,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 		}
 		map->offset = offset;
 		map->shared = map_is_shared;
-		map->file = strdup(name);
+		map->file = rz_str_dup(name);
 		rz_list_append(list, map);
 	}
 	fclose(fd);
@@ -586,7 +586,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -599,7 +599,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;

--- a/librz/debug/p/native/linux_arm.c
+++ b/librz/debug/p/native/linux_arm.c
@@ -564,7 +564,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 		}
 		map->offset = offset;
 		map->shared = map_is_shared;
-		map->file = strdup(name);
+		map->file = rz_str_dup(name);
 		rz_list_append(list, map);
 	}
 	fclose(fd);
@@ -587,7 +587,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -600,7 +600,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;

--- a/librz/debug/p/native/linux_arm64.c
+++ b/librz/debug/p/native/linux_arm64.c
@@ -564,7 +564,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 		}
 		map->offset = offset;
 		map->shared = map_is_shared;
-		map->file = strdup(name);
+		map->file = rz_str_dup(name);
 		rz_list_append(list, map);
 	}
 	fclose(fd);
@@ -587,7 +587,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -600,7 +600,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;

--- a/librz/debug/p/native/linux_other.c
+++ b/librz/debug/p/native/linux_other.c
@@ -563,7 +563,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 		}
 		map->offset = offset;
 		map->shared = map_is_shared;
-		map->file = strdup(name);
+		map->file = rz_str_dup(name);
 		rz_list_append(list, map);
 	}
 	fclose(fd);
@@ -586,7 +586,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -599,7 +599,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;

--- a/librz/debug/p/native/linux_x86_64.c
+++ b/librz/debug/p/native/linux_x86_64.c
@@ -564,7 +564,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 		}
 		map->offset = offset;
 		map->shared = map_is_shared;
-		map->file = strdup(name);
+		map->file = rz_str_dup(name);
 		rz_list_append(list, map);
 	}
 	fclose(fd);
@@ -587,7 +587,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -600,7 +600,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;

--- a/librz/debug/p/native/maps/darwin.c
+++ b/librz/debug/p/native/maps/darwin.c
@@ -161,7 +161,7 @@ static RzList *ios_dbg_maps(RzDebug *dbg) {
 				eprintf("Cannot create rz_debug_map_new\n");
 				break;
 			}
-			mr->file = strdup(module_name);
+			mr->file = rz_str_dup(module_name);
 			i++;
 			rz_list_append(list, mr);
 		}
@@ -267,7 +267,7 @@ static RzList *osx_dbg_maps (RzDebug *dbg) {
 				eprintf ("Cannot create rz_debug_map_new\n");
 				break;
 			}
-			mr->file = strdup (module_name);
+			mr->file = rz_str_dup (module_name);
 			rz_list_append (list, mr);
 		}
 }

--- a/librz/debug/p/native/netbsd.c
+++ b/librz/debug/p/native/netbsd.c
@@ -352,7 +352,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 		if (!map) {
 			break;
 		}
-		map->file = strdup(name);
+		map->file = rz_str_dup(name);
 		rz_list_append(list, map);
 	}
 	fclose(fd);
@@ -375,7 +375,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -388,7 +388,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;

--- a/librz/debug/p/native/openbsd.c
+++ b/librz/debug/p/native/openbsd.c
@@ -353,7 +353,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 		if (!map) {
 			break;
 		}
-		map->file = strdup(name);
+		map->file = rz_str_dup(name);
 		rz_list_append(list, map);
 	}
 	fclose(fd);
@@ -376,7 +376,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -389,7 +389,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;

--- a/librz/debug/p/native/reg/kfbsd-arm64.h
+++ b/librz/debug/p/native/reg/kfbsd-arm64.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // NGREG 34
-return strdup(
+return rz_str_dup(
 	"=PC	pc\n"
 	"=BP	x29\n"
 	"=SP	sp\n"

--- a/librz/debug/p/native/reg/kfbsd-x64.h
+++ b/librz/debug/p/native/reg/kfbsd-x64.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2015 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC	rip\n"
 	"=SP	rsp\n"
 	"=BP	rbp\n"

--- a/librz/debug/p/native/reg/kfbsd-x86.h
+++ b/librz/debug/p/native/reg/kfbsd-x86.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2015 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC	eip\n"
 	"=SP	esp\n"
 	"=BP	ebp\n"

--- a/librz/debug/p/native/reg/netbsd-x64.h
+++ b/librz/debug/p/native/reg/netbsd-x64.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2015 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC	rip\n"
 	"=SP	rsp\n"
 	"=BP	rbp\n"

--- a/librz/debug/p/native/reg/netbsd-x86.h
+++ b/librz/debug/p/native/reg/netbsd-x86.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2015 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC	eip\n"
 	"=SP	esp\n"
 	"=BP	ebp\n"

--- a/librz/debug/p/native/reg/windows-arm.h
+++ b/librz/debug/p/native/reg/windows-arm.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2020 GustavoLCR <gugulcr@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC     pc\n"
 	"=SP     sp\n"
 	"=BP     fp\n"

--- a/librz/debug/p/native/reg/windows-arm64.h
+++ b/librz/debug/p/native/reg/windows-arm64.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2020 GustavoLCR <gugulcr@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC     pc\n"
 	"=SP     sp\n"
 	"=BP     fp\n"

--- a/librz/debug/p/native/reg/windows-arm64_32.h
+++ b/librz/debug/p/native/reg/windows-arm64_32.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 GustavoLCR <gugulcr@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC     pc\n"
 	"=SP     sp\n"
 	"=BP     fp\n"

--- a/librz/debug/p/native/reg/windows-x64.h
+++ b/librz/debug/p/native/reg/windows-x64.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2015 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC	rip\n"
 	"=SP	rsp\n"
 	"=BP	rbp\n"

--- a/librz/debug/p/native/reg/windows-x86.h
+++ b/librz/debug/p/native/reg/windows-x86.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2015 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC	eip\n"
 	"=SP	esp\n"
 	"=BP	ebp\n"

--- a/librz/debug/p/native/windows.c
+++ b/librz/debug/p/native/windows.c
@@ -281,7 +281,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 	rz_list_foreach_safe (list, iter, iter2, map) {
 		const char *file = map->file;
 		if (!map->file) {
-			file = map->file = strdup(map->name);
+			file = map->file = rz_str_dup(map->name);
 		}
 		must_delete = true;
 		if (file && *file == '/') {
@@ -294,7 +294,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_modules_get(RzDebug *dbg) {
 		} else {
 			rz_list_append(last, map);
 			free(lastname);
-			lastname = strdup(file);
+			lastname = rz_str_dup(file);
 		}
 	}
 	list->free = NULL;

--- a/librz/debug/p/native/windows/windows_debug.c
+++ b/librz/debug/p/native/windows/windows_debug.c
@@ -802,8 +802,8 @@ static void add_library(DWORD pid, LPVOID lpBaseOfDll, HANDLE hFile, char *dllna
 	lib->pid = pid;
 	lib->hFile = hFile;
 	lib->BaseOfDll = lpBaseOfDll;
-	lib->Path = strdup(dllname);
-	lib->Name = strdup(rz_file_basename(dllname));
+	lib->Path = rz_str_dup(dllname);
+	lib->Name = rz_str_dup(rz_file_basename(dllname));
 
 	(void)rz_list_append(lib_list, lib);
 }
@@ -1301,7 +1301,7 @@ RzList *w32_thread_list(RzDebug *dbg, int pid, RzList *list) {
 		}
 		if (!path) {
 			// TODO: enum processes to get binary's name
-			path = strdup("???");
+			path = rz_str_dup("???");
 		}
 		int saved_tid = dbg->tid;
 		do {

--- a/librz/debug/p/native/windows/windows_message.c
+++ b/librz/debug/p/native/windows/windows_message.c
@@ -281,7 +281,7 @@ static window *window_from_handle(HANDLE hwnd) {
 	win->name = rz_utf16_to_utf8(tmp);
 	free(tmp);
 	if (!win->name) {
-		win->name = strdup("");
+		win->name = rz_str_dup("");
 	}
 	return win;
 }
@@ -461,7 +461,7 @@ RZ_API void rz_w32_print_windows(RzDebug *dbg) {
 
 RZ_API bool rz_w32_add_winmsg_breakpoint(RzDebug *dbg, const char *msg_name, const char *window_id) {
 	rz_return_val_if_fail(dbg && msg_name, false);
-	char *name = strdup(msg_name);
+	char *name = rz_str_dup(msg_name);
 	rz_str_trim(name);
 
 	DWORD type = get_msg_type(name);

--- a/librz/debug/p/native/xnu/reg/darwin-arm.h
+++ b/librz/debug/p/native/xnu/reg/darwin-arm.h
@@ -17,7 +17,7 @@ VFP: FPU
 	ut32 r[64]
 	ut32 fpscr
 #endif
-return strdup(
+return rz_str_dup(
 	"=PC	r15\n"
 	"=LR	r14\n"
 	"=SP	r13\n"

--- a/librz/debug/p/native/xnu/reg/darwin-arm64.h
+++ b/librz/debug/p/native/xnu/reg/darwin-arm64.h
@@ -9,7 +9,7 @@
         __ut64    __pc;             /* Program counter */
         __uint32_t    __cpsr;   /* Current program status register */
 #endif
-return strdup(
+return rz_str_dup(
 	"=PC	pc\n"
 	"=SP	sp\n" // XXX
 	"=BP	x30\n" // XXX

--- a/librz/debug/p/native/xnu/reg/darwin-ppc.h
+++ b/librz/debug/p/native/xnu/reg/darwin-ppc.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2015 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC	srr0\n"
 	"=SP	srr1\n"
 	"=SR	srr1\n" // status register ??

--- a/librz/debug/p/native/xnu/reg/darwin-x64.h
+++ b/librz/debug/p/native/xnu/reg/darwin-x64.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2015 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC	rip\n"
 	"=SP	rsp\n"
 	"=BP	rbp\n"

--- a/librz/debug/p/native/xnu/reg/darwin-x86.h
+++ b/librz/debug/p/native/xnu/reg/darwin-x86.h
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2015 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-return strdup(
+return rz_str_dup(
 	"=PC	eip\n"
 	"=SP	esp\n"
 	"=BP	ebp\n"

--- a/librz/debug/p/native/xnu/xnu_debug.c
+++ b/librz/debug/p/native/xnu/xnu_debug.c
@@ -464,7 +464,7 @@ RzDebugInfo *xnu_info(RzDebug *dbg, const char *arg) {
 	file_path_len = proc_pidpath(rdi->pid, file_path, sizeof(file_path));
 	if (file_path_len > 0) {
 		file_path[file_path_len] = 0;
-		rdi->exe = strdup(file_path);
+		rdi->exe = rz_str_dup(file_path);
 	}
 	if (proc_pidinfo(rdi->pid, PROC_PIDTBSDINFO, 0,
 		    &proc, PROC_PIDTBSDINFO_SIZE) == PROC_PIDTBSDINFO_SIZE) {
@@ -1241,7 +1241,7 @@ static RzList *xnu_dbg_modules(RzDebug *dbg) {
 			eprintf("Cannot create rz_debug_map_new\n");
 			break;
 		}
-		mr->file = strdup(file_path);
+		mr->file = rz_str_dup(file_path);
 		mr->shared = true;
 		rz_list_append(list, mr);
 	}
@@ -1277,10 +1277,10 @@ static RzDebugMap *rz_debug_map_clone(RzDebugMap *m) {
 	RzDebugMap *map = RZ_NEWCOPY(RzDebugMap, m);
 	// memcpy (map, m, sizeof (RzDebugMap));
 	if (m->name) {
-		map->name = strdup(m->name);
+		map->name = rz_str_dup(m->name);
 	}
 	if (m->file) {
-		map->file = strdup(m->file);
+		map->file = rz_str_dup(m->file);
 	}
 	return map;
 }
@@ -1373,10 +1373,10 @@ RzList *xnu_dbg_maps(RzDebug *dbg, int only_modules) {
 			}
 			RzDebugMap *rdm = moduleAt(modules, address);
 			if (rdm) {
-				mr->file = strdup(rdm->name);
+				mr->file = rz_str_dup(rdm->name);
 			} else {
 				if (*module_name) {
-					mr->file = strdup(module_name);
+					mr->file = rz_str_dup(module_name);
 				}
 			}
 			if (mr->file) {

--- a/librz/debug/p/native/xnu/xnu_threads.c
+++ b/librz/debug/p/native/xnu/xnu_threads.c
@@ -223,7 +223,7 @@ static bool xnu_fill_info_thread(RzDebug *dbg, xnu_thread_t *thread) {
 #if !defined(MAC_OS_X_VERSION_10_6)
 	// THREAD_IDENTIFIER_INFO introduced in 10.6
 	// TODO: use e.g. only basic info as a fallback here
-	thread->name = strdup("unknown");
+	thread->name = rz_str_dup("unknown");
 	return false;
 #else
 	mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
@@ -244,16 +244,16 @@ static bool xnu_fill_info_thread(RzDebug *dbg, xnu_thread_t *thread) {
 	RZ_FREE(thread->name);
 #if TARGET_OS_IPHONE
 	// TODO proc_pidinfo here
-	thread->name = strdup("unknown");
+	thread->name = rz_str_dup("unknown");
 #else
 	struct proc_threadinfo proc_threadinfo;
 	int ret_proc = proc_pidinfo(dbg->pid, PROC_PIDTHREADINFO,
 		identifier_info.thread_handle,
 		&proc_threadinfo, PROC_PIDTHREADINFO_SIZE);
 	if (ret_proc && proc_threadinfo.pth_name[0]) {
-		thread->name = strdup(proc_threadinfo.pth_name);
+		thread->name = rz_str_dup(proc_threadinfo.pth_name);
 	} else {
-		thread->name = strdup("unknown");
+		thread->name = rz_str_dup("unknown");
 	}
 #endif
 #endif
@@ -268,7 +268,7 @@ static xnu_thread_t *xnu_get_thread_with_info(RzDebug *dbg, thread_t port) {
 	thread->port = port;
 	if (!xnu_fill_info_thread(dbg, thread)) {
 		free(thread->name);
-		thread->name = strdup("unknown");
+		thread->name = rz_str_dup("unknown");
 	}
 	return thread;
 }
@@ -276,7 +276,7 @@ static xnu_thread_t *xnu_get_thread_with_info(RzDebug *dbg, thread_t port) {
 static int xnu_update_thread_info(RzDebug *dbg, xnu_thread_t *thread) {
 	if (!xnu_fill_info_thread(dbg, thread)) {
 		free(thread->name);
-		thread->name = strdup("unknown");
+		thread->name = rz_str_dup("unknown");
 	}
 	return true;
 }

--- a/librz/debug/pid.c
+++ b/librz/debug/pid.c
@@ -8,7 +8,7 @@ RZ_API RzDebugPid *rz_debug_pid_new(const char *path, int pid, int uid, char sta
 	if (!p) {
 		return NULL;
 	}
-	p->path = strdup(path);
+	p->path = rz_str_dup(path);
 	p->pid = pid;
 	p->uid = uid;
 	p->status = status;

--- a/librz/debug/snap.c
+++ b/librz/debug/snap.c
@@ -24,7 +24,7 @@ RZ_API RzDebugSnap *rz_debug_snap_map(RzDebug *dbg, RzDebugMap *map) {
 		return NULL;
 	}
 
-	snap->name = strdup(map->name);
+	snap->name = rz_str_dup(map->name);
 	snap->addr = map->addr;
 	snap->addr_end = map->addr_end;
 	snap->size = map->size;

--- a/librz/debug/trace.c
+++ b/librz/debug/trace.c
@@ -208,7 +208,7 @@ RZ_API void rz_debug_trace_op(RzDebug *dbg, RzAnalysisOp *op) {
 RZ_API void rz_debug_trace_at(RzDebug *dbg, const char *str) {
 	// TODO: parse offsets and so use ut64 instead of strstr()
 	free(dbg->trace->addresses);
-	dbg->trace->addresses = (str && *str) ? strdup(str) : NULL;
+	dbg->trace->addresses = (str && *str) ? rz_str_dup(str) : NULL;
 }
 
 RZ_API RzDebugTracepoint *rz_debug_trace_get(RzDebug *dbg, ut64 addr) {

--- a/librz/egg/egg.c
+++ b/librz/egg/egg.c
@@ -212,7 +212,7 @@ RZ_API bool rz_egg_load_file(RzEgg *egg, const char *file) {
 	// We have to reset the RzEgg state first
 	rz_egg_reset(egg);
 	if (rz_str_endswith(file, ".c")) {
-		char *fileSanitized = strdup(file);
+		char *fileSanitized = rz_str_dup(file);
 		rz_str_sanitize(fileSanitized);
 		const char *arch = rz_sys_arch_str(egg->arch);
 		const char *os = rz_egg_os_as_string(egg->os);
@@ -468,7 +468,7 @@ static inline char *eon(char *n) {
 RZ_API int rz_egg_padding(RzEgg *egg, const char *pad) {
 	int number;
 	ut8 *buf, padding_byte;
-	char *p, *o = strdup(pad);
+	char *p, *o = rz_str_dup(pad);
 
 	for (p = o; *p;) { // parse pad string
 		const char f = *p++;

--- a/librz/egg/egg_Cfile.c
+++ b/librz/egg/egg_Cfile.c
@@ -30,7 +30,7 @@ static char *rz_egg_Cfile_getCompiler(void) {
 		output = rz_file_path(compilers[i]);
 		if (strcmp(output, compilers[i])) {
 			free(output);
-			return strdup(compilers[i]);
+			return rz_str_dup(compilers[i]);
 		}
 		free(output);
 	}
@@ -94,15 +94,15 @@ static struct cEnv_t *rz_egg_Cfile_set_cEnv(const char *arch, const char *os, in
 		cEnv->FMT = "mach0";
 		if (!strcmp(arch, "x86")) {
 			if (bits == 32) {
-				cEnv->CFLAGS = strdup("-arch i386 -fPIC -fPIE");
-				cEnv->LDFLAGS = strdup("-arch i386 -shared -c -fPIC -fPIE -pie");
+				cEnv->CFLAGS = rz_str_dup("-arch i386 -fPIC -fPIE");
+				cEnv->LDFLAGS = rz_str_dup("-arch i386 -shared -c -fPIC -fPIE -pie");
 			} else {
-				cEnv->CFLAGS = strdup("-arch x86_64 -fPIC -fPIE");
-				cEnv->LDFLAGS = strdup("-arch x86_64 -shared -c -fPIC -fPIE -pie");
+				cEnv->CFLAGS = rz_str_dup("-arch x86_64 -fPIC -fPIE");
+				cEnv->LDFLAGS = rz_str_dup("-arch x86_64 -shared -c -fPIC -fPIE -pie");
 			}
 		} else {
-			cEnv->CFLAGS = strdup("-shared -c -fPIC -pie -fPIE");
-			cEnv->LDFLAGS = strdup("-shared -c -fPIC -pie -fPIE");
+			cEnv->CFLAGS = rz_str_dup("-shared -c -fPIC -pie -fPIE");
+			cEnv->LDFLAGS = rz_str_dup("-shared -c -fPIC -pie -fPIE");
 		}
 		cEnv->SHDR = rz_str_newf("\n.text\n%s _main\n", cEnv->JMP);
 	} else {
@@ -113,15 +113,15 @@ static struct cEnv_t *rz_egg_Cfile_set_cEnv(const char *arch, const char *os, in
 			cEnv->JMP);
 		if (!strcmp(arch, "x86")) {
 			if (bits == 32) {
-				cEnv->CFLAGS = strdup("-fPIC -fPIE -pie -fpic -m32");
-				cEnv->LDFLAGS = strdup("-fPIC -fPIE -pie -fpic -m32");
+				cEnv->CFLAGS = rz_str_dup("-fPIC -fPIE -pie -fpic -m32");
+				cEnv->LDFLAGS = rz_str_dup("-fPIC -fPIE -pie -fpic -m32");
 			} else {
-				cEnv->CFLAGS = strdup("-fPIC -fPIE -pie -fpic -m64");
-				cEnv->LDFLAGS = strdup("-fPIC -fPIE -pie -fpic -m64");
+				cEnv->CFLAGS = rz_str_dup("-fPIC -fPIE -pie -fpic -m64");
+				cEnv->LDFLAGS = rz_str_dup("-fPIC -fPIE -pie -fpic -m64");
 			}
 		} else {
-			cEnv->CFLAGS = strdup("-fPIC -fPIE -pie -fpic -nostartfiles");
-			cEnv->LDFLAGS = strdup("-fPIC -fPIE -pie -fpic -nostartfiles");
+			cEnv->CFLAGS = rz_str_dup("-fPIC -fPIE -pie -fpic -nostartfiles");
+			cEnv->LDFLAGS = rz_str_dup("-fPIC -fPIE -pie -fpic -nostartfiles");
 		}
 	}
 
@@ -140,12 +140,12 @@ static struct cEnv_t *rz_egg_Cfile_set_cEnv(const char *arch, const char *os, in
 	use_clang = false;
 	if (!strcmp(cEnv->TRIPLET, "darwin-arm-64")) {
 		free(cEnv->CC);
-		cEnv->CC = strdup("xcrun --sdk iphoneos gcc -arch arm64 -miphoneos-version-min=0.0");
+		cEnv->CC = rz_str_dup("xcrun --sdk iphoneos gcc -arch arm64 -miphoneos-version-min=0.0");
 		use_clang = true;
 		cEnv->TEXT = "0.__TEXT.__text";
 	} else if (!strcmp(cEnv->TRIPLET, "darwin-arm-32")) {
 		free(cEnv->CC);
-		cEnv->CC = strdup("xcrun --sdk iphoneos gcc -arch armv7 -miphoneos-version-min=0.0");
+		cEnv->CC = rz_str_dup("xcrun --sdk iphoneos gcc -arch armv7 -miphoneos-version-min=0.0");
 		use_clang = true;
 		cEnv->TEXT = "0.__TEXT.__text";
 	}
@@ -156,7 +156,7 @@ static struct cEnv_t *rz_egg_Cfile_set_cEnv(const char *arch, const char *os, in
 		goto fail;
 	}
 	free(cEnv->CFLAGS);
-	cEnv->CFLAGS = strdup(buffer);
+	cEnv->CFLAGS = rz_str_dup(buffer);
 
 	if (use_clang) {
 		free(buffer);
@@ -167,7 +167,7 @@ static struct cEnv_t *rz_egg_Cfile_set_cEnv(const char *arch, const char *os, in
 			goto fail;
 		}
 		free(cEnv->CFLAGS);
-		cEnv->CFLAGS = strdup(buffer);
+		cEnv->CFLAGS = rz_str_dup(buffer);
 	} else {
 		free(buffer);
 		buffer = rz_str_newf("%s -z execstack -fomit-frame-pointer"
@@ -177,7 +177,7 @@ static struct cEnv_t *rz_egg_Cfile_set_cEnv(const char *arch, const char *os, in
 			goto fail;
 		}
 		free(cEnv->CFLAGS);
-		cEnv->CFLAGS = strdup(buffer);
+		cEnv->CFLAGS = rz_str_dup(buffer);
 	}
 	free(buffer);
 	buffer = rz_str_newf("%s -nostdlib", cEnv->LDFLAGS);
@@ -185,7 +185,7 @@ static struct cEnv_t *rz_egg_Cfile_set_cEnv(const char *arch, const char *os, in
 		goto fail;
 	}
 	free(cEnv->LDFLAGS);
-	cEnv->LDFLAGS = strdup(buffer);
+	cEnv->LDFLAGS = rz_str_dup(buffer);
 
 	if (rz_egg_Cfile_check_cEnv(cEnv)) {
 		eprintf("Error with cEnv allocation!\n");

--- a/librz/egg/emit_trace.c
+++ b/librz/egg/emit_trace.c
@@ -25,7 +25,7 @@ static void emit_init(RzEgg *egg) {
 static char *emit_syscall(RzEgg *egg, int num) {
 	char buf[32];
 	snprintf(buf, sizeof(buf), "syscall (%d)\n", num);
-	return strdup(buf);
+	return rz_str_dup(buf);
 }
 
 static void emit_frame(RzEgg *egg, int sz) {

--- a/librz/egg/emit_x86.c
+++ b/librz/egg/emit_x86.c
@@ -47,7 +47,7 @@ static void emit_init(RzEgg *egg) {
 static char *emit_syscall(RzEgg *egg, int nargs) {
 	char p[512];
 	if (attsyntax) {
-		return strdup(": mov $`.arg`, %" RZ_AX "\n: " SYSCALL_ATT "\n");
+		return rz_str_dup(": mov $`.arg`, %" RZ_AX "\n: " SYSCALL_ATT "\n");
 	}
 	switch (egg->os) {
 	case RZ_EGG_OS_LINUX:
@@ -72,7 +72,7 @@ static char *emit_syscall(RzEgg *egg, int nargs) {
 	default:
 		return NULL;
 	}
-	return strdup(p);
+	return rz_str_dup(p);
 }
 
 static void emit_frame(RzEgg *egg, int sz) {

--- a/librz/egg/p/egg_xor.c
+++ b/librz/egg/p/egg_xor.c
@@ -14,7 +14,7 @@ static RzBuffer *build(RzEgg *egg) {
 
 	if (!key || !*key) {
 		free(key);
-		key = strdup(default_key);
+		key = rz_str_dup(default_key);
 		eprintf("XOR key not provided. Using (%s) as the key\n", key);
 	}
 	nkey = rz_num_math(NULL, key);

--- a/librz/egg/rlcc/rlcc.c
+++ b/librz/egg/rlcc/rlcc.c
@@ -92,7 +92,7 @@ static void processNode(mpc_ast_t *node) {
 			}
 		}
 	} else if (isComment(node)) {
-		char *s = strdup(node->contents + 2);
+		char *s = rz_str_dup(node->contents + 2);
 		int len = strlen(s);
 		if (node->contents[1] == '*') {
 			s[len - 2] = 0;

--- a/librz/flag/flag.c
+++ b/librz/flag/flag.c
@@ -123,7 +123,7 @@ static RzFlagsAtOffset *flags_at_offset(RzFlag *f, ut64 off) {
 }
 
 static char *filter_item_name(const char *name) {
-	char *res = strdup(name);
+	char *res = rz_str_dup(name);
 	if (!res) {
 		return NULL;
 	}
@@ -666,28 +666,28 @@ err:
 RZ_API void rz_flag_item_set_alias(RzFlagItem *item, const char *alias) {
 	rz_return_if_fail(item);
 	free(item->alias);
-	item->alias = RZ_STR_ISEMPTY(alias) ? NULL : strdup(alias);
+	item->alias = RZ_STR_ISEMPTY(alias) ? NULL : rz_str_dup(alias);
 }
 
 /* add/replace/remove the comment of a flag item */
 RZ_API void rz_flag_item_set_comment(RzFlagItem *item, const char *comment) {
 	rz_return_if_fail(item);
 	free(item->comment);
-	item->comment = RZ_STR_ISEMPTY(comment) ? NULL : strdup(comment);
+	item->comment = RZ_STR_ISEMPTY(comment) ? NULL : rz_str_dup(comment);
 }
 
 /* add/replace/remove the realname of a flag item */
 RZ_API void rz_flag_item_set_realname(RzFlagItem *item, const char *realname) {
 	rz_return_if_fail(item);
 	free_item_realname(item);
-	item->realname = RZ_STR_ISEMPTY(realname) ? NULL : strdup(realname);
+	item->realname = RZ_STR_ISEMPTY(realname) ? NULL : rz_str_dup(realname);
 }
 
 /* add/replace/remove the color of a flag item */
 RZ_API const char *rz_flag_item_set_color(RzFlagItem *item, const char *color) {
 	rz_return_val_if_fail(item, NULL);
 	free(item->color);
-	item->color = (color && *color) ? strdup(color) : NULL;
+	item->color = STRDUP_OR_NULL(color);
 	return item->color;
 }
 

--- a/librz/flag/serialize_flag.c
+++ b/librz/flag/serialize_flag.c
@@ -55,7 +55,7 @@ static bool zone_load_cb(void *user, const SdbKv *kv) {
 	if (!item) {
 		goto beach;
 	}
-	item->name = strdup(sdbkv_key(kv));
+	item->name = rz_str_dup(sdbkv_key(kv));
 	if (!item->name) {
 		free(item);
 		goto beach;

--- a/librz/flag/tags.c
+++ b/librz/flag/tags.c
@@ -20,7 +20,7 @@ RZ_API RZ_OWN RzList /*<char *>*/ *rz_flag_tags_list(RzFlag *f) {
 		if (strlen(tag) < 5) {
 			continue;
 		}
-		rz_list_append(res, (void *)strdup(tag + 4));
+		rz_list_append(res, (void *)rz_str_dup(tag + 4));
 	}
 	rz_pvector_free(items);
 	return res;

--- a/librz/flag/zones.c
+++ b/librz/flag/zones.c
@@ -41,7 +41,7 @@ RZ_API bool rz_flag_zone_add(RzFlag *f, const char *name, ut64 addr) {
 			rz_flag_zone_reset(f);
 		}
 		zi = RZ_NEW0(RzFlagZoneItem);
-		zi->name = strdup(name);
+		zi->name = rz_str_dup(name);
 		zi->from = zi->to = addr;
 		rz_list_append(f->zones, zi);
 	}

--- a/librz/hash/hash.c
+++ b/librz/hash/hash.c
@@ -597,7 +597,7 @@ RZ_API RZ_OWN char *rz_hash_cfg_get_result_string(RZ_NONNULL RzHashCfg *md, RZ_N
 		double entropy = rz_read_be_double(mdc->digest);
 		return rz_str_newf("%.8f", entropy);
 	} else if (!strcmp(name, "ssdeep")) {
-		return strdup((char *)mdc->digest);
+		return rz_str_dup((char *)mdc->digest);
 	}
 
 	char *string = malloc((mdc->digest_size * 2) + 1);

--- a/librz/il/definitions/label.c
+++ b/librz/il/definitions/label.c
@@ -8,7 +8,7 @@ RZ_API RzILEffectLabel *rz_il_effect_label_new(RZ_NONNULL const char *name, RzIL
 	if (!lbl) {
 		return NULL;
 	}
-	lbl->label_id = strdup(name);
+	lbl->label_id = rz_str_dup(name);
 	lbl->type = type;
 	return lbl;
 }

--- a/librz/il/definitions/variable.c
+++ b/librz/il/definitions/variable.c
@@ -16,7 +16,7 @@ RZ_API RZ_OWN RzILVar *rz_il_variable_new(RZ_NONNULL const char *name, RzILSortP
 	if (!ret) {
 		return NULL;
 	}
-	ret->name = strdup(name);
+	ret->name = rz_str_dup(name);
 	if (!ret->name) {
 		free(ret);
 		return NULL;

--- a/librz/il/il_events.c
+++ b/librz/il/il_events.c
@@ -59,7 +59,7 @@ RZ_API RZ_OWN RzILEvent *rz_il_event_exception_new(RZ_NONNULL const char *except
 	}
 
 	evt->type = RZ_IL_EVENT_EXCEPTION;
-	evt->data.exception = strdup(exception);
+	evt->data.exception = rz_str_dup(exception);
 	if (!evt->data.exception) {
 		rz_il_event_free(evt);
 		RZ_LOG_ERROR("RzIL: cannot allocate exception string\n");
@@ -158,7 +158,7 @@ RZ_API RZ_OWN RzILEvent *rz_il_event_var_read_new(RZ_NONNULL const char *name, R
 	}
 
 	evt->type = RZ_IL_EVENT_VAR_READ;
-	evt->data.var_read.variable = strdup(name);
+	evt->data.var_read.variable = rz_str_dup(name);
 	evt->data.var_read.value = rz_il_value_dup(value);
 	if (!evt->data.var_read.variable || !evt->data.var_read.value) {
 		rz_il_event_free(evt);
@@ -183,7 +183,7 @@ RZ_API RZ_OWN RzILEvent *rz_il_event_var_write_new(RZ_NONNULL const char *name, 
 	}
 
 	evt->type = RZ_IL_EVENT_VAR_WRITE;
-	evt->data.var_write.variable = strdup(name);
+	evt->data.var_write.variable = rz_str_dup(name);
 	evt->data.var_write.old_value = rz_il_value_dup(old_v);
 	evt->data.var_write.new_value = rz_il_value_dup(new_v);
 	if (!evt->data.var_write.variable ||

--- a/librz/il/il_export_string.c
+++ b/librz/il/il_export_string.c
@@ -1241,9 +1241,9 @@ RZ_API RZ_OWN char *rz_il_sort_pure_stringify(RzILSortPure sort) {
 	case RZ_IL_TYPE_PURE_BITVECTOR:
 		return rz_str_newf("bitvector:%u", (unsigned int)sort.props.bv.length);
 	case RZ_IL_TYPE_PURE_BOOL:
-		return strdup("bool");
+		return rz_str_dup("bool");
 	case RZ_IL_TYPE_PURE_FLOAT:
 		return rz_str_newf("float:%u", (unsigned int)sort.props.f.format);
 	}
-	return strdup("invalid");
+	return rz_str_dup("invalid");
 }

--- a/librz/il/il_reg.c
+++ b/librz/il/il_reg.c
@@ -62,7 +62,7 @@ RZ_API RzILRegBinding *rz_il_reg_binding_derive(RZ_NONNULL RzReg *reg) {
 			}
 			// all good, bind it
 			rz_list_push(flags, item);
-			char *name = strdup(item->name);
+			char *name = rz_str_dup(item->name);
 			if (!name) {
 				rz_list_free(flags);
 				goto err;
@@ -117,7 +117,7 @@ RZ_API RzILRegBinding *rz_il_reg_binding_derive(RZ_NONNULL RzReg *reg) {
 				// pc is handled outside of reg binding
 				continue;
 			}
-			char *name = strdup(item->name);
+			char *name = rz_str_dup(item->name);
 			if (!name) {
 				rz_list_free(flags);
 				rz_list_free(items);
@@ -185,7 +185,7 @@ RZ_API RzILRegBinding *rz_il_reg_binding_exactly(RZ_NONNULL RzReg *reg, size_t r
 			// overlap detected
 			goto err_regs;
 		}
-		rb->regs[i].name = strdup(regs[i]);
+		rb->regs[i].name = rz_str_dup(regs[i]);
 		if (!rb->regs[i].name) {
 			goto err_regs;
 		}

--- a/librz/io/io.c
+++ b/librz/io/io.c
@@ -213,7 +213,7 @@ RZ_API RzList /*<RzIODesc *>*/ *rz_io_open_many(RzIO *io, const char *uri, int p
 				desc->plugin = plugin;
 			}
 			if (!desc->uri) {
-				desc->uri = strdup(uri);
+				desc->uri = rz_str_dup(uri);
 			}
 			// should autofd be honored here?
 			rz_io_desc_add(io, desc);

--- a/librz/io/io_desc.c
+++ b/librz/io/io_desc.c
@@ -27,7 +27,7 @@ RZ_API RzIODesc *rz_io_desc_new(RzIO *io, RzIOPlugin *plugin, const char *uri, i
 		desc->data = data;
 		desc->perm = perm;
 		// because the uri-arg may live on the stack
-		desc->uri = strdup(uri);
+		desc->uri = rz_str_dup(uri);
 	}
 	return desc;
 }
@@ -121,10 +121,10 @@ RZ_API RzIODesc *rz_io_desc_open(RzIO *io, const char *uri, int perm, int mode) 
 	}
 	// for none static callbacks, those that cannot use rz_io_desc_new
 	if (!desc->name) {
-		desc->name = strdup(uri);
+		desc->name = rz_str_dup(uri);
 	}
 	if (!desc->uri) {
-		desc->uri = strdup(uri);
+		desc->uri = rz_str_dup(uri);
 	}
 	if (!desc->plugin) {
 		desc->plugin = plugin;
@@ -150,10 +150,10 @@ RZ_API RzIODesc *rz_io_desc_open_plugin(RzIO *io, RzIOPlugin *plugin, const char
 		desc->plugin = plugin;
 	}
 	if (!desc->uri) {
-		desc->uri = strdup(uri);
+		desc->uri = rz_str_dup(uri);
 	}
 	if (!desc->name) {
-		desc->name = strdup(uri);
+		desc->name = rz_str_dup(uri);
 	}
 	if (!rz_io_desc_add(io, desc)) {
 		rz_io_desc_free(desc);

--- a/librz/io/io_map.c
+++ b/librz/io/io_map.c
@@ -334,7 +334,7 @@ RZ_API void rz_io_map_set_name(RzIOMap *map, const char *name) {
 		return;
 	}
 	free(map->name);
-	map->name = strdup(name);
+	map->name = rz_str_dup(name);
 }
 
 RZ_API void rz_io_map_del_name(RzIOMap *map) {

--- a/librz/io/p/io_ar.c
+++ b/librz/io/p/io_ar.c
@@ -42,7 +42,7 @@ static RzList /*<RzIODesc *>*/ *rz_io_ar_open_many(RzIO *io, const char *file, i
 			rz_list_free(list_fds);
 			return NULL;
 		}
-		desc->name = strdup(arfp->name);
+		desc->name = rz_str_dup(arfp->name);
 		if (!rz_list_append(list_fds, desc)) {
 			rz_list_free(all);
 			rz_list_free(list_fds);
@@ -57,7 +57,7 @@ static RzList /*<RzIODesc *>*/ *rz_io_ar_open_many(RzIO *io, const char *file, i
 static RzIODesc *rz_io_ar_open(RzIO *io, const char *file, int perm, int mode) {
 	rz_return_val_if_fail(io && file, NULL);
 	RzIODesc *res = NULL;
-	char *uri = strdup(file);
+	char *uri = rz_str_dup(file);
 	if (!uri) {
 		return NULL;
 	}
@@ -82,7 +82,7 @@ static RzIODesc *rz_io_ar_open(RzIO *io, const char *file, int perm, int mode) {
 	if (!res) {
 		goto err;
 	}
-	res->name = strdup(filename);
+	res->name = rz_str_dup(filename);
 err:
 	free(uri);
 	return res;

--- a/librz/io/p/io_bochs.c
+++ b/librz/io/p/io_bochs.c
@@ -112,7 +112,7 @@ static RzIODesc *io_bochs_open(RzIO *io, const char *file, int rw, int mode) {
 	size_t bin_path_length = hashtag - file - BOCHS_URI_SIZE;
 	RzSubprocess *bochs = NULL;
 	char *bochs_bin_path = rz_str_ndup(file + BOCHS_URI_SIZE, bin_path_length);
-	char *bochs_cfg_path = strdup(hashtag + 1);
+	char *bochs_cfg_path = rz_str_dup(hashtag + 1);
 
 	const char *args[3] = {
 		"-f",

--- a/librz/io/p/io_debug.c
+++ b/librz/io/p/io_debug.c
@@ -127,7 +127,7 @@ static int fork_and_ptraceme(RzIO *io, int bits, const char *cmd) {
 		return -1;
 	}
 	setup_tokens();
-	char *_cmd = io->args ? rz_str_appendf(strdup(cmd), " %s", io->args) : strdup(cmd);
+	char *_cmd = io->args ? rz_str_appendf(rz_str_dup(cmd), " %s", io->args) : rz_str_dup(cmd);
 	char **argv = rz_str_argv(_cmd, NULL);
 	char *cmdline = NULL;
 	// We need to build a command line with quoted argument and escaped quotes
@@ -197,7 +197,7 @@ static RzRunProfile *_get_run_profile(RzIO *io, int bits, char **argv) {
 		rz_run_free(rp);
 		return NULL;
 	}
-	rp->_program = strdup(argv[0]);
+	rp->_program = rz_str_dup(argv[0]);
 
 	rp->_dodebug = true;
 	if (RZ_STR_ISNOTEMPTY(io->runprofile)) {
@@ -413,7 +413,7 @@ static int fork_and_ptraceme_for_unix(RzIO *io, int bits, const char *cmd) {
 
 static int fork_and_ptraceme(RzIO *io, int bits, const char *cmd) {
 	// Before calling the platform implementation, append arguments to the command if they have been provided
-	char *eff_cmd = io->args ? rz_str_appendf(strdup(cmd), " %s", io->args) : strdup(cmd);
+	char *eff_cmd = io->args ? rz_str_appendf(rz_str_dup(cmd), " %s", io->args) : rz_str_dup(cmd);
 	if (!eff_cmd) {
 		return -1;
 	}
@@ -531,7 +531,7 @@ static RzIODesc *__open(RzIO *io, const char *file, int rw, int mode) {
 		}
 		if (ret) {
 			ret->plugin = _plugin;
-			ret->referer = strdup(file); // kill this
+			ret->referer = rz_str_dup(file); // kill this
 		}
 	}
 	return ret;

--- a/librz/io/p/io_default.c
+++ b/librz/io/p/io_default.c
@@ -74,7 +74,7 @@ RzIOMMapFileObj *rz_io_def_mmap_create_new_file(RzIO *io, const char *filename, 
 	if (mmo->nocache) {
 		filename += strlen("nocache://");
 	}
-	mmo->filename = strdup(filename);
+	mmo->filename = rz_str_dup(filename);
 	mmo->perm = rz_sys_open_perms(perm);
 	mmo->mode = mode;
 	if (!mmo->nocache) {
@@ -133,7 +133,7 @@ static RzIODesc *rz_io_def_mmap_open(RzIO *io, const char *file, int perm, int m
 	}
 	RzIODesc *d = rz_io_desc_new(io, &rz_io_plugin_default, mmo->filename, perm, mode, mmo);
 	if (!d->name) {
-		d->name = strdup(mmo->filename);
+		d->name = rz_str_dup(mmo->filename);
 	}
 	return d;
 }

--- a/librz/io/p/io_dmp.c
+++ b/librz/io/p/io_dmp.c
@@ -88,7 +88,7 @@ static RzIODesc *dmp_open(RzIO *io, const char *file, int rw, int mode) {
 		free(ctx);
 		return NULL;
 	}
-	c->fd->name = strdup(file + 6);
+	c->fd->name = rz_str_dup(file + 6);
 	ctx->windctx.user = c;
 	return c->fd;
 }

--- a/librz/io/p/io_mach.c
+++ b/librz/io/p/io_mach.c
@@ -404,7 +404,7 @@ static RzIODesc *__open(RzIO *io, const char *file, int rw, int mode) {
 	// sleep 1s to get proper path (program name instead of ls) (racy)
 	pidpath = pid
 		? rz_sys_pid_to_path(pid)
-		: strdup("kernel");
+		: rz_str_dup("kernel");
 	if (!strncmp(file, "smach://", 8)) {
 		ret = rz_io_desc_new(io, &rz_io_plugin_mach, &file[1],
 			rw | RZ_PERM_X, mode, iodd);

--- a/librz/io/p/io_rap.c
+++ b/librz/io/p/io_rap.c
@@ -218,7 +218,7 @@ static char *__rap_system(RzIO *io, RzIODesc *fd, const char *command) {
 		if (str && *str) {
 			res = io->cb_core_cmdstr (io->user, str);
 		} else {
-			res = strdup ("");
+			res = rz_str_dup ("");
 		}
 		eprintf ("[%s]=>(%s)\n", str, res);
 		reslen = strlen (res);

--- a/librz/io/p/io_rzweb.c
+++ b/librz/io/p/io_rzweb.c
@@ -108,7 +108,7 @@ static RzIODesc *__open(RzIO *io, const char *pathname, int rw, int mode) {
 		if (!mal) {
 			return NULL;
 		}
-		char *path = strdup(pathname + 8);
+		char *path = rz_str_dup(pathname + 8);
 		int path_len = strlen(path);
 		if (path_len > 0) {
 			if (path[path_len - 1] == '/') {

--- a/librz/io/p/io_self.c
+++ b/librz/io/p/io_self.c
@@ -140,7 +140,7 @@ static int update_self_regions(RzIO *io, int pid) {
 		}
 		self_sections[self_sections_count].from = rz_num_get(NULL, region);
 		self_sections[self_sections_count].to = rz_num_get(NULL, region2);
-		self_sections[self_sections_count].name = strdup(name);
+		self_sections[self_sections_count].name = rz_str_dup(name);
 		self_sections[self_sections_count].perm = perm;
 		self_sections_count++;
 		rz_num_get(NULL, region2);
@@ -157,7 +157,7 @@ static int update_self_regions(RzIO *io, int pid) {
 	while (get_next_image_info(0, &cookie, &ii) == B_OK) {
 		self_sections[self_sections_count].from = (ut64)ii.text;
 		self_sections[self_sections_count].to = (ut64)((char *)ii.text + ii.text_size);
-		self_sections[self_sections_count].name = strdup(ii.name);
+		self_sections[self_sections_count].name = rz_str_dup(ii.name);
 		self_sections[self_sections_count].perm = 0;
 		self_sections_count++;
 	}
@@ -221,7 +221,7 @@ static int update_self_regions(RzIO *io, int pid) {
 
 		self_sections[self_sections_count].from = (ut64)c->pr_vaddr;
 		self_sections[self_sections_count].to = (ut64)(c->pr_vaddr + c->pr_size);
-		self_sections[self_sections_count].name = strdup(name);
+		self_sections[self_sections_count].name = rz_str_dup(name);
 		self_sections[self_sections_count].perm = perm;
 		self_sections_count++;
 	}
@@ -347,7 +347,7 @@ static char *__system(RzIO *io, RzIODesc *fd, const char *cmd) {
 	} else if (!strncmp(cmd, "call ", 5)) {
 		size_t cbptr = 0;
 		ut64 result = 0;
-		char *argv = strdup(cmd + 5);
+		char *argv = rz_str_dup(cmd + 5);
 		int argc = rz_str_word_set0(argv);
 		if (argc == 0) {
 			eprintf("Usage: R!call [fcnptr] [a0] [a1] ...\n");
@@ -676,7 +676,7 @@ bool bsd_proc_vmmaps(RzIO *io, int pid) {
 
 			self_sections[self_sections_count].from = entry->kve_start;
 			self_sections[self_sections_count].to = entry->kve_end;
-			self_sections[self_sections_count].name = strdup(entry->kve_path);
+			self_sections[self_sections_count].name = rz_str_dup(entry->kve_path);
 			self_sections[self_sections_count].perm = perm;
 			self_sections_count++;
 			p_start += sz;
@@ -785,7 +785,7 @@ exit:
 
 			self_sections[self_sections_count].from = entry->kve_start;
 			self_sections[self_sections_count].to = entry->kve_end;
-			self_sections[self_sections_count].name = strdup(entry->kve_path);
+			self_sections[self_sections_count].name = rz_str_dup(entry->kve_path);
 			self_sections[self_sections_count].perm = perm;
 			self_sections_count++;
 			p_start += sz;

--- a/librz/io/p/io_tcp.c
+++ b/librz/io/p/io_tcp.c
@@ -38,7 +38,7 @@ static ut8 *tcpme(const char *pathname, int *code, int *len) {
 		}
 	} else {
 		/* connect and slurp the end point */
-		char *host = strdup(pathname);
+		char *host = rz_str_dup(pathname);
 		if (!host) {
 			return NULL;
 		}

--- a/librz/io/p/io_windbg.c
+++ b/librz/io/p/io_windbg.c
@@ -447,7 +447,7 @@ static RzIODesc *windbg_open(RzIO *io, const char *uri, int perm, int mode) {
 	}
 	argv = tmp;
 	memmove(argv + 1, argv, argv_sz - sizeof(char *));
-	argv[0] = strdup(WINDBGURI);
+	argv[0] = rz_str_dup(WINDBGURI);
 	argc++;
 	const char *command = NULL;
 	bool image_path_set = false, symbol_path_set = false;
@@ -524,7 +524,7 @@ static RzIODesc *windbg_open(RzIO *io, const char *uri, int perm, int mode) {
 	if (!symbol_path_set) {
 		const char *store = io->corebind.cfgGet(core, "pdb.symstore");
 		const char *server = io->corebind.cfgGet(core, "pdb.server");
-		char *s = strdup(server);
+		char *s = rz_str_dup(server);
 		rz_str_replace_ch(s, ';', '*', true);
 		char *sympath = rz_str_newf("cache*;srv*%s*%s", store, s);
 		ITHISCALL(dbgSymbols, SetSymbolPath, sympath);
@@ -575,7 +575,7 @@ static RzIODesc *windbg_open(RzIO *io, const char *uri, int perm, int mode) {
 	rz_str_argv_free(argv);
 remote_client:
 	fd = rz_io_desc_new(io, &rz_io_plugin_windbg, uri, perm | RZ_PERM_X, mode, idbg);
-	fd->name = strdup(args);
+	fd->name = rz_str_dup(args);
 	if (cur_dbg_plugin_is_windbg(core->dbg)) {
 		core->dbg->plugin_data = idbg;
 	}

--- a/librz/io/p/io_winedbg.c
+++ b/librz/io/p/io_winedbg.c
@@ -297,7 +297,7 @@ static char *__system(RzIO *io, RzIODesc *fd, const char *cmd) {
 			"flg	nt	.1	.201	0\n"
 			"flg	rf	.1	.202	0\n"
 			"flg	vm	.1	.203	0\n";
-		return strdup(msg);
+		return rz_str_dup(msg);
 	} else if (!strncmp(cmd, "dr*", 3)) {
 		struct winedbg_x86_32 r = regState();
 		io->cb_printf("f eip @ 0x%08x\n", r.eip);

--- a/librz/io/p/io_zip.c
+++ b/librz/io/p/io_zip.c
@@ -179,7 +179,7 @@ RzList /*<char *>*/ *rz_io_zip_get_files(const char *archivename, ut32 perm, int
 	for (i = 0; i < num_entries; i++) {
 		zip_stat_init(&sb);
 		zip_stat_index(zipArch, i, 0, &sb);
-		if ((name = strdup(sb.name))) {
+		if ((name = rz_str_dup(sb.name))) {
 			rz_list_append(files, name);
 		}
 	}
@@ -239,8 +239,8 @@ RzIOZipFileObj *rz_io_zip_create_new_file(const char *archivename, const char *f
 	RzIOZipFileObj *zfo = RZ_NEW0(RzIOZipFileObj);
 	if (zfo) {
 		zfo->b = rz_buf_new_with_bytes(NULL, 0);
-		zfo->archivename = strdup(archivename);
-		zfo->name = strdup(sb ? sb->name : filename);
+		zfo->archivename = rz_str_dup(archivename);
+		zfo->name = rz_str_dup(sb ? sb->name : filename);
 		zfo->entry = !sb ? -1 : sb->index;
 		zfo->fd = rz_num_rand32(0xFFFF); // XXX: Use rz_io_fd api
 		zfo->perm = perm;
@@ -295,7 +295,7 @@ static RzList /*<RzIODesc *>*/ *rz_io_zip_open_many(RzIO *io, const char *file, 
 		return NULL;
 	}
 
-	zip_uri = strdup(file);
+	zip_uri = rz_str_dup(file);
 	if (!zip_uri) {
 		return NULL;
 	}
@@ -367,7 +367,7 @@ char *rz_io_zip_get_by_file_idx(const char *archivename, const char *idx, ut32 p
 		zip_stat_init(&sb);
 		zip_stat_index(zipArch, i, 0, &sb);
 		if (file_idx == i) {
-			filename = strdup(sb.name);
+			filename = rz_str_dup(sb.name);
 			break;
 		}
 	}
@@ -438,7 +438,7 @@ static char *find_apk_binary(const char *filename, int rw, int mode, RzIO *io) {
 				}
 				zfo->io_backref = io;
 				RzIODesc *desc = rz_io_desc_new(io, &rz_io_plugin_zip, zfo->name, rw, mode, zfo);
-				desc->name = strdup(name);
+				desc->name = rz_str_dup(name);
 				rz_io_desc_add(io, desc);
 			}
 		}
@@ -457,14 +457,14 @@ static RzIODesc *rz_io_zip_open(RzIO *io, const char *file, int rw, int mode) {
 	if (!rz_io_zip_plugin_open(io, file, false)) {
 		return NULL;
 	}
-	zip_uri = strdup(file);
+	zip_uri = rz_str_dup(file);
 	if (!zip_uri) {
 		return NULL;
 	}
 	uri_path = strstr(zip_uri, "://");
 	if (uri_path) {
 		tmp = strstr(uri_path + 3, "//");
-		zip_filename = tmp ? strdup(tmp) : NULL;
+		zip_filename = rz_str_dup(tmp);
 		// 1) Tokenize to the '//' and find the base file directory ('/')
 		if (!zip_filename) {
 			if (!strncmp(zip_uri, "apk://", 6)) {
@@ -472,11 +472,11 @@ static RzIODesc *rz_io_zip_open(RzIO *io, const char *file, int rw, int mode) {
 			} else if (!strncmp(zip_uri, "ipa://", 6)) {
 				zip_filename = find_ipa_binary(uri_path + 3, rw, mode);
 			} else {
-				zip_filename = strdup(uri_path + 1);
+				zip_filename = rz_str_dup(uri_path + 1);
 			}
 		} else {
 			free(zip_filename);
-			zip_filename = strdup(uri_path + 1);
+			zip_filename = rz_str_dup(uri_path + 1);
 		}
 	}
 	tmp = zip_filename;
@@ -492,7 +492,7 @@ static RzIODesc *rz_io_zip_open(RzIO *io, const char *file, int rw, int mode) {
 			// null terminating uri to filename here.
 			*filename_in_zipfile++ = 0;
 			*filename_in_zipfile++ = 0;
-			filename_in_zipfile = strdup(filename_in_zipfile);
+			filename_in_zipfile = rz_str_dup(filename_in_zipfile);
 			// check for :: index
 		} else if ((filename_in_zipfile = strstr(zip_filename, "::")) &&
 			filename_in_zipfile[2]) {
@@ -505,7 +505,7 @@ static RzIODesc *rz_io_zip_open(RzIO *io, const char *file, int rw, int mode) {
 		} else {
 			filename_in_zipfile = rz_str_newf("%s", zip_filename);
 			RZ_FREE(tmp);
-			zip_filename = strdup(uri_path + 3);
+			zip_filename = rz_str_dup(uri_path + 3);
 			if (!strcmp(zip_filename, filename_in_zipfile)) {
 				// RZ_FREE (zip_filename);
 				RZ_FREE(filename_in_zipfile);

--- a/librz/lang/lang.c
+++ b/librz/lang/lang.c
@@ -81,8 +81,8 @@ RZ_API bool rz_lang_define(RzLang *lang, const char *type, const char *name, voi
 	if (!def) {
 		return false;
 	}
-	def->type = strdup(type);
-	def->name = strdup(name);
+	def->type = rz_str_dup(type);
+	def->name = rz_str_dup(name);
 	def->value = value;
 	rz_list_append(lang->defs, def);
 	return true;
@@ -234,7 +234,7 @@ RZ_API int rz_lang_prompt(RzLang *lang) {
 	RzLineHistory histnull = { 0 };
 	RzLineCompletion oc = line->completion;
 	RzLineCompletion ocnull = { 0 };
-	char *prompt = strdup(line->prompt);
+	char *prompt = rz_str_dup(line->prompt);
 	line->completion = ocnull;
 	line->history = histnull;
 

--- a/librz/lang/p/c.c
+++ b/librz/lang/p/c.c
@@ -52,7 +52,7 @@ static int lang_c_file(RzLang *lang, const char *file) {
 	}
 	cc = rz_sys_getenv("CC");
 	if (RZ_STR_ISEMPTY(cc)) {
-		cc = strdup("gcc");
+		cc = rz_str_dup("gcc");
 	}
 	char *libdir = rz_path_libdir();
 	char *pkgconf_path = rz_file_path_join(libdir, "pkgconfig");

--- a/librz/lang/p/cpipe.c
+++ b/librz/lang/p/cpipe.c
@@ -44,7 +44,7 @@ static int lang_cpipe_file(RzLang *lang, const char *file) {
 	cc = rz_sys_getenv("CC");
 	if (RZ_STR_ISEMPTY(cc)) {
 		free(cc);
-		cc = strdup("gcc");
+		cc = rz_str_dup("gcc");
 	}
 	char *libdir = rz_path_libdir();
 	char *pkgconf_path = rz_file_path_join(libdir, "pkgconfig");

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -531,7 +531,7 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 
 	set_color_default(r);
 	bool load_l = true;
-	char *debugbackend = strdup("native");
+	char *debugbackend = rz_str_dup("native");
 
 	RzGetopt opt;
 	rz_getopt_init(&opt, argc, argv, "=02AMCwxfF:H:hm:e:nk:NdqQs:p:b:B:a:Lui:I:l:R:r:c:D:vVSTzuXt");
@@ -544,7 +544,7 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 			break;
 		case '=':
 			RZ_FREE(r->cmdremote);
-			r->cmdremote = strdup("");
+			r->cmdremote = rz_str_dup("");
 			break;
 		case '2':
 			noStderr = true;
@@ -594,7 +594,7 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 		case 'D': {
 			debug = 2;
 			free(debugbackend);
-			debugbackend = strdup(opt.arg);
+			debugbackend = rz_str_dup(opt.arg);
 			RzCmdStateOutput state = { 0 };
 			rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_QUIET);
 			if (!strcmp(opt.arg, "?")) {
@@ -788,16 +788,16 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 					}
 					if (p) {
 						*p = 0;
-						pfile = strdup(program);
+						pfile = rz_str_dup(program);
 					}
 				}
 				free(msg);
 			} else {
 				eprintf("Cannot read dbg.profile '%s'\n", dbg_profile);
-				pfile = NULL; // strdup ("");
+				pfile = NULL; // rz_str_dup ("");
 			}
 		} else {
-			pfile = argv[opt.ind] ? strdup(argv[opt.ind]) : NULL;
+			pfile = rz_str_dup(argv[opt.ind]);
 		}
 	}
 
@@ -849,14 +849,14 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 		}
 		const char *src = haveRarunProfile ? pfile : argv[opt.ind];
 		if (src && *src) {
-			char *uri = strdup(src);
+			char *uri = rz_str_dup(src);
 			if (uri) {
 				char *p = strstr(uri, "://");
 				if (p) {
 					*p = 0;
 					// TODO: this must be specified by the io plugin, not hardcoded here
 					if (!strcmp(uri, "winedbg")) {
-						debugbackend = strdup("io");
+						debugbackend = rz_str_dup("io");
 					} else {
 						debugbackend = uri;
 						uri = NULL;
@@ -1007,7 +1007,7 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 				}
 				if (strcmp(debugbackend, "native")) {
 					if (!haveRarunProfile) {
-						pfile = strdup(argv[opt.ind++]);
+						pfile = rz_str_dup(argv[opt.ind++]);
 					}
 					// If plugin is winkd we should keep RWX permission to be able to write to the fd
 					if (strcmp(debugbackend, "winkd")) {
@@ -1061,7 +1061,7 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 				const char *f = (haveRarunProfile && pfile) ? pfile : argv[opt.ind];
 				is_gdb = (!memcmp(f, "gdb://", RZ_MIN(f ? strlen(f) : 0, 6)));
 				if (!is_gdb) {
-					pfile = strdup("dbg://");
+					pfile = rz_str_dup("dbg://");
 				}
 #if __UNIX__
 				/* implicit ./ to make unix behave like windows */
@@ -1069,11 +1069,11 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 					char *path, *escaped_path;
 					if (strchr(f, '/')) {
 						// f is a path
-						path = strdup(f);
+						path = rz_str_dup(f);
 					} else {
 						// f is a filename
 						if (rz_file_exists(f)) {
-							path = rz_str_prepend(strdup(f), "./");
+							path = rz_str_prepend(rz_str_dup(f), "./");
 						} else {
 							path = rz_file_path(f);
 						}
@@ -1130,7 +1130,7 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 			if (opt.ind < argc) {
 				RZ_FREE(pfile);
 				while (opt.ind < argc) {
-					pfile = strdup(argv[opt.ind++]);
+					pfile = rz_str_dup(argv[opt.ind++]);
 					fh = rz_core_file_open(r, pfile, perms, mapaddr);
 					if (!fh && perms & RZ_PERM_W) {
 						perms |= RZ_PERM_CREAT;
@@ -1343,7 +1343,7 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 		/* check if file.path has changed */
 		if (iod && !strstr(iod->uri, "://")) {
 			const char *npath;
-			char *path = strdup(rz_config_get(r->config, "file.path"));
+			char *path = rz_str_dup(rz_config_get(r->config, "file.path"));
 			iod = r->io ? rz_io_desc_get(r->io, fh->fd) : NULL;
 			npath = rz_config_get(r->config, "file.path");
 			if (!quiet && path && *path && npath && strcmp(path, npath)) {

--- a/librz/main/rz-asm.c
+++ b/librz/main/rz-asm.c
@@ -60,13 +60,13 @@ static void __as_free(RzAsmState *as) {
 
 static char *stackop2str(int type) {
 	switch (type) {
-	case RZ_ANALYSIS_STACK_NULL: return strdup("null");
-	case RZ_ANALYSIS_STACK_NOP: return strdup("nop");
-	// case RZ_ANALYSIS_STACK_INCSTACK: return strdup ("incstack");
-	case RZ_ANALYSIS_STACK_GET: return strdup("get");
-	case RZ_ANALYSIS_STACK_SET: return strdup("set");
+	case RZ_ANALYSIS_STACK_NULL: return rz_str_dup("null");
+	case RZ_ANALYSIS_STACK_NOP: return rz_str_dup("nop");
+	// case RZ_ANALYSIS_STACK_INCSTACK: return rz_str_dup ("incstack");
+	case RZ_ANALYSIS_STACK_GET: return rz_str_dup("get");
+	case RZ_ANALYSIS_STACK_SET: return rz_str_dup("set");
 	}
-	return strdup("unknown");
+	return rz_str_dup("unknown");
 }
 
 static void showanalysis(RzAsmState *as, RzAnalysisOp *op, ut64 offset, ut8 *buf, int len, PJ *pj) {
@@ -121,7 +121,7 @@ static void showanalysis(RzAsmState *as, RzAnalysisOp *op, ut64 offset, ut8 *buf
 
 // TODO: add israw/len
 static int show_analinfo(RzAsmState *as, const char *arg, ut64 offset) {
-	ut8 *buf = (ut8 *)strdup((const char *)arg);
+	ut8 *buf = (ut8 *)rz_str_dup((const char *)arg);
 	int ret, len = rz_hex_str2bin((char *)buf, buf);
 	PJ *pj = NULL;
 	if (as->json) {
@@ -888,9 +888,9 @@ RZ_API int rz_main_rz_asm(int argc, const char *argv[]) {
 			goto beach;
 		}
 		if (dis) {
-			char *usrstr = strdup(opt.argv[opt.ind]);
+			char *usrstr = rz_str_dup(opt.argv[opt.ind]);
 			if (!usrstr) {
-				eprintf("rz-asm: disassemble strdup OOM\n");
+				eprintf("rz-asm: disassemble rz_str_dup OOM\n");
 				ret = 1;
 				goto beach;
 			}

--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -744,7 +744,7 @@ RZ_API int rz_main_rz_ax(int argc, const char **argv) {
 	} else {
 		ut64 flags = 0;
 		for (i = 1; i < argc; i++) {
-			char *argv_i = strdup(argv[i]);
+			char *argv_i = rz_str_dup(argv[i]);
 			rz_str_unescape(argv_i);
 			rax(num, argv_i, 0, i == argc - 1, &flags, &fm);
 			free(argv_i);

--- a/librz/main/rz-bin.c
+++ b/librz/main/rz-bin.c
@@ -275,7 +275,7 @@ static char *stdin_gets(bool liberate) {
 	if (feof(stdin)) {
 		return NULL;
 	}
-	return strdup(stdin_buf);
+	return rz_str_dup(stdin_buf);
 }
 
 static void __sdb_prompt(Sdb *sdb) {
@@ -339,7 +339,7 @@ static bool extract_binobj(const RzBinFile *bf, RzBinXtrData *data, int idx) {
 	if (!arch) {
 		arch = "unknown";
 	}
-	path = strdup(filename);
+	path = rz_str_dup(filename);
 	if (!path) {
 		return false;
 	}
@@ -498,7 +498,7 @@ static int rzbin_do_operation(RzBin *bin, const char *op, int rad, const char *o
 	bool rc = true;
 
 	/* Implement alloca with fixed-size buffer? */
-	if (!(arg = strdup(op))) {
+	if (!(arg = rz_str_dup(op))) {
 		return false;
 	}
 	if ((ptr = strchr(arg, '/'))) {
@@ -846,7 +846,7 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 		case 'a': arch = opt.arg; break;
 		case 'C':
 			set_action(RZ_BIN_REQ_CREATE);
-			create = strdup(opt.arg);
+			create = rz_str_dup(opt.arg);
 			break;
 		case 'u': bin->filter = 0; break;
 		case 'k': query = opt.arg; break;
@@ -859,7 +859,7 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 				set_action(RZ_BIN_REQ_CLASSES);
 			}
 			break;
-		case 'f': arch_name = strdup(opt.arg); break;
+		case 'f': arch_name = rz_str_dup(opt.arg); break;
 		case 'F': forcebin = opt.arg; break;
 		case 'b': bits = rz_num_math(NULL, opt.arg); break;
 		case 'm':

--- a/librz/main/rz-diff.c
+++ b/librz/main/rz-diff.c
@@ -524,11 +524,11 @@ static bool rz_diff_calculate_distance(DiffContext *ctx) {
 	double similarity = 0.0;
 
 	if (ctx->command_line) {
-		if (!(a_buffer = (ut8 *)strdup(ctx->file_a))) {
+		if (!(a_buffer = (ut8 *)rz_str_dup(ctx->file_a))) {
 			goto rz_diff_calculate_distance_bad;
 		}
 		a_size = strlen((const char *)a_buffer);
-		if (!(b_buffer = (ut8 *)strdup(ctx->file_b))) {
+		if (!(b_buffer = (ut8 *)rz_str_dup(ctx->file_b))) {
 			goto rz_diff_calculate_distance_bad;
 		}
 		b_size = strlen((const char *)b_buffer);
@@ -1554,7 +1554,7 @@ static char *basic_block_opcodes(RzCore *core, RzAnalysisBlock *bbi) {
 	rz_core_print_disasm(core, b->addr, block, b->size, 9999, NULL, &disasm_options);
 	rz_cons_filter();
 	const char *retstr = rz_str_get(rz_cons_get_buffer());
-	opcodes = strdup(retstr);
+	opcodes = rz_str_dup(retstr);
 exit:
 	rz_cons_pop();
 	rz_cons_echo(NULL);
@@ -2677,7 +2677,7 @@ static char *visual_prompt(DiffHexView *hview, const char *prompt) {
 	rz_cons_flush();
 	rz_cons_fgets(buf, sizeof(buf), 0, NULL);
 	if (*buf) {
-		return strdup(buf);
+		return rz_str_dup(buf);
 	}
 	return NULL;
 }

--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -405,7 +405,7 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 
 	if (ro->mode == RZ_SEARCH_MAGIC) {
 		/* TODO: implement using api */
-		char *tostr = (to && to != UT64_MAX) ? rz_str_newf("-e search.to=%" PFMT64d, to) : strdup("");
+		char *tostr = (to && to != UT64_MAX) ? rz_str_newf("-e search.to=%" PFMT64d, to) : rz_str_dup("");
 		rz_sys_cmdf("rizin"
 			    " -e search.in=range"
 			    " -e search.align=%d"

--- a/librz/main/rz-gg.c
+++ b/librz/main/rz-gg.c
@@ -192,7 +192,7 @@ RZ_API int rz_main_rz_gg(int argc, const char **argv) {
 			contents = opt.arg;
 			break;
 		case 'w': {
-			char *arg = strdup(opt.arg);
+			char *arg = rz_str_dup(opt.arg);
 			char *p = strchr(arg, ':');
 			if (p) {
 				int len, off;
@@ -329,7 +329,7 @@ RZ_API int rz_main_rz_gg(int argc, const char **argv) {
 			break;
 		case 'q':
 			get_offset = 1;
-			sequence = strdup(opt.arg);
+			sequence = rz_str_dup(opt.arg);
 			break;
 		default:
 			goto fail;
@@ -455,7 +455,7 @@ RZ_API int rz_main_rz_gg(int argc, const char **argv) {
 	/* set output (create output file if needed) */
 	if (ofileauto) {
 		if (file) {
-			char *o, *q, *p = strdup(file);
+			char *o, *q, *p = rz_str_dup(file);
 			if ((o = strchr(p, '.'))) {
 				while ((q = strchr(o + 1, '.'))) {
 					o = q;

--- a/librz/main/rz-hash.c
+++ b/librz/main/rz-hash.c
@@ -228,7 +228,7 @@ static void rz_hash_show_algorithms(RzHashContext *ctx) {
 		if ((x)->k) { \
 			rz_hash_error(x, RZ_HASH_OP_UNKNOWN, "invalid combination of arguments for '-%c'\n", c); \
 		} else if (h || strlen(s) < 1) { \
-			(x)->k = strdup(s); \
+			(x)->k = rz_str_dup(s); \
 		} else { \
 			(x)->k = rz_str_newf("s:%s", s); \
 		} \
@@ -236,7 +236,7 @@ static void rz_hash_show_algorithms(RzHashContext *ctx) {
 
 #define rz_hash_ctx_set_mode(x, m)   rz_hash_ctx_set_val(x, mode, RZ_HASH_MODE_STANDARD, m)
 #define rz_hash_ctx_set_op(x, o)     rz_hash_ctx_set_val(x, operation, RZ_HASH_OP_UNKNOWN, o)
-#define rz_hash_ctx_set_str(x, k, s) rz_hash_ctx_set_val(x, k, NULL, strdup(s))
+#define rz_hash_ctx_set_str(x, k, s) rz_hash_ctx_set_val(x, k, NULL, rz_str_dup(s))
 
 static bool hash_parse_string(const char *option, const char *string, ut8 **buffer, size_t *bufsize) {
 	char *sstdin = NULL;

--- a/librz/reg/profile.c
+++ b/librz/reg/profile.c
@@ -60,7 +60,7 @@ static int expect_reg_type_by_name(const char *str) {
  */
 static bool parse_type(RZ_OUT RzRegProfileDef *def, const char *type_str) {
 	rz_return_val_if_fail(def && type_str, false);
-	char *s = strdup(type_str);
+	char *s = rz_str_dup(type_str);
 	char *at = strchr(s, '@');
 	if (at) {
 		// This register has a secondary type e.g. xmm@fpu
@@ -168,8 +168,8 @@ static bool parse_alias(RZ_OUT RzList /*<RzRegProfileAlias *>*/ *alias_list, RZ_
 		return false;
 	}
 
-	pa->alias = strdup(alias);
-	pa->reg_name = strdup(real_name);
+	pa->alias = rz_str_dup(alias);
+	pa->reg_name = rz_str_dup(real_name);
 	pa->role = role;
 	rz_list_append(alias_list, pa);
 
@@ -196,7 +196,7 @@ static bool parse_def(RZ_OUT RzList /*<RzRegProfileDef *>*/ *def_list, RZ_BORROW
 	if (!name) {
 		goto reg_parse_error;
 	}
-	def->name = strdup(name);
+	def->name = rz_str_dup(name);
 
 	if (!parse_type(def, rz_list_get_n(tokens, 0))) {
 		RZ_LOG_WARN("Invalid register type.\n");
@@ -228,9 +228,9 @@ static bool parse_def(RZ_OUT RzList /*<RzRegProfileDef *>*/ *def_list, RZ_BORROW
 		}
 		if (comment_flag[0] == '#') {
 			// Remove # from the comment
-			def->comment = strdup(comment_flag + 1);
+			def->comment = rz_str_dup(comment_flag + 1);
 		} else {
-			def->flags = strdup(comment_flag);
+			def->flags = rz_str_dup(comment_flag);
 		}
 	}
 	RZ_LOG_DEBUG("profile: register def: %s %d %d %s\n", def->name, def->size, def->offset, def->flags);
@@ -289,7 +289,7 @@ static bool parse_reg_profile_str(RZ_OUT RzList /*<RzRegProfileAlias *>*/ *alias
 		}
 		if (rz_str_strchr(line, "#")) {
 			RzList *line_and_cmt = rz_str_split_duplist_n_regex(line, "\\#", 0, true);
-			char *raw_comment = strdup(rz_list_last(line_and_cmt));
+			char *raw_comment = rz_str_dup(rz_list_last(line_and_cmt));
 			if (!raw_comment) {
 				RZ_LOG_WARN("Comment could not be split from register definition. Line: \"%s\"\n", line);
 				continue;
@@ -396,7 +396,7 @@ RZ_API bool rz_reg_set_reg_profile(RZ_BORROW RzReg *reg) {
 			return false;
 		}
 
-		item->name = strdup(def->name);
+		item->name = rz_str_dup(def->name);
 
 		item->type = def->type;
 		item->arena = def->arena_type;
@@ -411,10 +411,10 @@ RZ_API bool rz_reg_set_reg_profile(RZ_BORROW RzReg *reg) {
 		item->packed_size = def->packed;
 
 		if (def->comment) {
-			item->comment = strdup(def->comment);
+			item->comment = rz_str_dup(def->comment);
 		}
 		if (def->flags) {
-			item->flags = strdup(def->flags);
+			item->flags = rz_str_dup(def->flags);
 		}
 
 		add_item_to_regset(reg, item);
@@ -445,7 +445,7 @@ RZ_API bool rz_reg_set_profile_string(RZ_NONNULL RzReg *reg, RZ_NONNULL const ch
 	rz_reg_arena_shrink(reg);
 
 	// Cache the profile string
-	reg->reg_profile_str = strdup(profile_str);
+	reg->reg_profile_str = rz_str_dup(profile_str);
 	reg->reg_profile.defs = rz_list_newf((RzListFree)rz_reg_profile_def_free);
 	reg->reg_profile.alias = rz_list_newf((RzListFree)rz_reg_profile_alias_free);
 	rz_return_val_if_fail(reg->reg_profile.defs && reg->reg_profile.alias, true);

--- a/librz/sign/sigdb.c
+++ b/librz/sign/sigdb.c
@@ -86,9 +86,9 @@ static bool sigdb_signature_resolve_details(RzSigDBEntry *entry, size_t path_len
 
 skip_details:
 	bin_end[0] = 0;
-	entry->bin_name = strdup(copy_path);
+	entry->bin_name = rz_str_dup(copy_path);
 	arch_end[0] = 0;
-	entry->arch_name = strdup(bin_end + strlen(RZ_SYS_DIR));
+	entry->arch_name = rz_str_dup(bin_end + strlen(RZ_SYS_DIR));
 	bits_end[0] = 0;
 	entry->arch_bits = rz_get_input_num_value(NULL, arch_end + strlen(RZ_SYS_DIR));
 
@@ -132,7 +132,7 @@ RZ_API RZ_OWN RzSigDb *rz_sign_sigdb_load_database(RZ_NONNULL const char *sigdb_
 			goto fail;
 		}
 
-		sig->file_path = strdup(file);
+		sig->file_path = rz_str_dup(file);
 		if (!sig->file_path || !sigdb_signature_resolve_details(sig, path_len, with_details)) {
 			rz_sign_sigdb_signature_free(sig);
 			goto fail;

--- a/librz/socket/run.c
+++ b/librz/socket/run.c
@@ -94,7 +94,7 @@ RZ_API void rz_run_reset(RzRunProfile *p) {
 
 RZ_API bool rz_run_parse(RzRunProfile *pf, const char *profile) {
 	rz_return_val_if_fail(pf && profile, false);
-	char *p, *o, *str = strdup(profile);
+	char *p, *o, *str = rz_str_dup(profile);
 	if (!str) {
 		return false;
 	}
@@ -166,7 +166,7 @@ static char *resolve_value(const char *src, size_t *result_len) {
 			goto end_resolve;
 		}
 	} else {
-		copy = strdup(src);
+		copy = rz_str_dup(src);
 	}
 
 	copy_len = src_len = rz_str_unescape(copy);
@@ -213,7 +213,7 @@ static char *resolve_value(const char *src, size_t *result_len) {
 		size_t msg_len = backtick_end - (copy + 1);
 		if (msg_len < 1) {
 			free(copy);
-			return strdup("");
+			return rz_str_dup("");
 		}
 		*backtick_end = 0;
 		char *tmp = rz_sys_cmd_str(copy + 1, NULL, NULL);
@@ -518,46 +518,46 @@ RZ_API bool rz_run_parseline(RzRunProfile *p, const char *b) {
 	}
 
 	if (!strcmp(key, "program")) {
-		p->_args[0] = strdup(value);
-		p->_program = strdup(value);
+		p->_args[0] = rz_str_dup(value);
+		p->_program = rz_str_dup(value);
 	} else if (!strcmp(key, "daemon")) {
 		p->_daemon = true;
 	} else if (!strcmp(key, "system")) {
-		p->_system = strdup(value);
+		p->_system = rz_str_dup(value);
 	} else if (!strcmp(key, "runlib")) {
-		p->_runlib = strdup(value);
+		p->_runlib = rz_str_dup(value);
 	} else if (!strcmp(key, "runlib.fcn")) {
-		p->_runlib_fcn = strdup(value);
+		p->_runlib_fcn = rz_str_dup(value);
 	} else if (!strcmp(key, "aslr")) {
 		p->_aslr = parse_bool(value);
 	} else if (!strcmp(key, "pid")) {
 		p->_pid = parse_bool(value);
 	} else if (!strcmp(key, "pidfile")) {
-		p->_pidfile = strdup(value);
+		p->_pidfile = rz_str_dup(value);
 	} else if (!strcmp(key, "connect")) {
-		p->_connect = strdup(value);
+		p->_connect = rz_str_dup(value);
 	} else if (!strcmp(key, "listen")) {
-		p->_listen = strdup(value);
+		p->_listen = rz_str_dup(value);
 	} else if (!strcmp(key, "pty")) {
 		p->_pty = parse_bool(value);
 	} else if (!strcmp(key, "stdio")) {
 		if (value[0] == '!') {
-			p->_stdio = strdup(value);
+			p->_stdio = rz_str_dup(value);
 		} else {
-			p->_stdout = strdup(value);
-			p->_stderr = strdup(value);
-			p->_stdin = strdup(value);
+			p->_stdout = rz_str_dup(value);
+			p->_stderr = rz_str_dup(value);
+			p->_stdin = rz_str_dup(value);
 		}
 	} else if (!strcmp(key, "stdout")) {
-		p->_stdout = strdup(value);
+		p->_stdout = rz_str_dup(value);
 	} else if (!strcmp(key, "stdin")) {
-		p->_stdin = strdup(value);
+		p->_stdin = rz_str_dup(value);
 	} else if (!strcmp(key, "stderr")) {
-		p->_stderr = strdup(value);
+		p->_stderr = rz_str_dup(value);
 	} else if (!strcmp(key, "input")) {
-		p->_input = strdup(value);
+		p->_input = rz_str_dup(value);
 	} else if (!strcmp(key, "chdir")) {
-		p->_chgdir = strdup(value);
+		p->_chgdir = rz_str_dup(value);
 	} else if (!strcmp(key, "core")) {
 		p->_docore = parse_bool(value);
 	} else if (!strcmp(key, "fork")) {
@@ -573,21 +573,21 @@ RZ_API bool rz_run_parseline(RzRunProfile *p, const char *b) {
 	} else if (!strcmp(key, "bits")) {
 		p->_bits = atoi(value);
 	} else if (!strcmp(key, "chroot")) {
-		p->_chroot = strdup(value);
+		p->_chroot = rz_str_dup(value);
 	} else if (!strcmp(key, "libpath")) {
-		p->_libpath = strdup(value);
+		p->_libpath = rz_str_dup(value);
 	} else if (!strcmp(key, "preload")) {
-		p->_preload = strdup(value);
+		p->_preload = rz_str_dup(value);
 	} else if (!strcmp(key, "rzpreload")) {
 		p->_rzpreload = parse_bool(value);
 	} else if (!strcmp(key, "setuid")) {
-		p->_setuid = strdup(value);
+		p->_setuid = rz_str_dup(value);
 	} else if (!strcmp(key, "seteuid")) {
-		p->_seteuid = strdup(value);
+		p->_seteuid = rz_str_dup(value);
 	} else if (!strcmp(key, "setgid")) {
-		p->_setgid = strdup(value);
+		p->_setgid = rz_str_dup(value);
 	} else if (!strcmp(key, "setegid")) {
-		p->_setegid = strdup(value);
+		p->_setegid = rz_str_dup(value);
 	} else if (!strcmp(key, "nice")) {
 		p->_nice = atoi(value);
 	} else if (!strcmp(key, "timeout")) {
@@ -1303,7 +1303,7 @@ RZ_API char *rz_run_get_environ_profile(char **env) {
 	}
 	RzStrBuf *sb = rz_strbuf_new(NULL);
 	while (*env) {
-		char *k = strdup(*env);
+		char *k = rz_str_dup(*env);
 		char *v = strchr(k, '=');
 		if (v) {
 			*v++ = 0;

--- a/librz/socket/socket.c
+++ b/librz/socket/socket.c
@@ -254,7 +254,7 @@ RZ_API bool rz_socket_spawn(RzSocket *s, const char *cmd, unsigned int timeout) 
 	const int port = 2000 + rz_num_rand32(2000);
 	int childPid = rz_sys_fork();
 	if (childPid == 0) {
-		char *a = rz_str_replace(strdup(cmd), "\\", "\\\\", true);
+		char *a = rz_str_replace(rz_str_dup(cmd), "\\", "\\\\", true);
 		int res = rz_sys_cmdf("rz-run system=\"%s\" listen=%d", a, port);
 		free(a);
 #if 0

--- a/librz/socket/socket_http.c
+++ b/librz/socket/socket_http.c
@@ -120,7 +120,7 @@ static char *socket_http_answer(RzSocket *s, int *code, int *rlen, ut32 redirect
 			}
 		}
 	} else {
-		res = strdup("");
+		res = rz_str_dup("");
 	}
 exit:
 	free(buf);
@@ -230,7 +230,7 @@ static char *socket_http_get_recursive(const char *url, int *code, int *rlen, ut
 	}
 #endif
 	char *response, *host, *path, *port = "80";
-	char *uri = strdup(url);
+	char *uri = rz_str_dup(url);
 	if (!uri) {
 		return NULL;
 	}
@@ -291,7 +291,7 @@ RZ_API char *rz_socket_http_get(const char *url, int *code, int *rlen) {
 RZ_API char *rz_socket_http_post(const char *url, const char *data, int *code, int *rlen) {
 	RzSocket *s;
 	bool ssl = rz_str_startswith(url, "https://");
-	char *uri = strdup(url);
+	char *uri = rz_str_dup(url);
 	if (!uri) {
 		return NULL;
 	}

--- a/librz/socket/socket_http_server.c
+++ b/librz/socket/socket_http_server.c
@@ -57,21 +57,21 @@ RZ_API RzSocketHTTPRequest *rz_socket_http_accept(RzSocket *s, RzSocketHTTPOptio
 			if (p) {
 				*p = 0;
 			}
-			hr->method = strdup(buf);
+			hr->method = rz_str_dup(buf);
 			if (p) {
 				q = strstr(p + 1, " HTTP"); // strchr (p+1, ' ');
 				if (q) {
 					*q = 0;
 				}
-				hr->path = strdup(p + 1);
+				hr->path = rz_str_dup(p + 1);
 			}
 		} else {
 			if (!hr->referer && !strncmp(buf, "Referer: ", 9)) {
-				hr->referer = strdup(buf + 9);
+				hr->referer = rz_str_dup(buf + 9);
 			} else if (!hr->agent && !strncmp(buf, "User-Agent: ", 12)) {
-				hr->agent = strdup(buf + 12);
+				hr->agent = rz_str_dup(buf + 12);
 			} else if (!hr->host && !strncmp(buf, "Host: ", 6)) {
-				hr->host = strdup(buf + 6);
+				hr->host = rz_str_dup(buf + 6);
 			} else if (!strncmp(buf, "Content-Length: ", 16)) {
 				content_length = atoi(buf + 16);
 			} else if (so->httpauth && !strncmp(buf, "Authorization: Basic ", 21)) {

--- a/librz/socket/socket_rap_server.c
+++ b/librz/socket/socket_rap_server.c
@@ -9,7 +9,7 @@ RZ_API RzSocketRapServer *rz_socket_rap_server_new(bool use_ssl, const char *por
 	rz_return_val_if_fail(port, NULL);
 	RzSocketRapServer *s = RZ_NEW0(RzSocketRapServer);
 	if (s) {
-		s->port = strdup(port);
+		s->port = rz_str_dup(port);
 		s->fd = rz_socket_new(use_ssl);
 		if (s->fd) {
 			return s;

--- a/librz/syscall/syscall.c
+++ b/librz/syscall/syscall.c
@@ -26,7 +26,7 @@ RZ_API RZ_OWN RzSysregItem *rz_sysreg_item_new(RZ_NULLABLE const char *name) {
 	}
 	sysregitem->comment = NULL;
 	sysregitem->type = NULL;
-	sysregitem->name = name ? strdup(name) : NULL;
+	sysregitem->name = rz_str_dup(name);
 	return sysregitem;
 }
 
@@ -242,13 +242,13 @@ RZ_API bool rz_syscall_setup(RzSyscall *s, const char *arch, int bits, const cha
 	sysregs_changed = sysregs_reload_needed(s, arch, bits, cpu);
 
 	free(s->os);
-	s->os = strdup(os);
+	s->os = rz_str_dup(os);
 
 	free(s->cpu);
-	s->cpu = strdup(cpu);
+	s->cpu = rz_str_dup(cpu);
 
 	free(s->arch);
-	s->arch = strdup(arch);
+	s->arch = rz_str_dup(arch);
 
 	s->bits = bits;
 
@@ -288,7 +288,7 @@ RZ_API RzSyscallItem *rz_syscall_item_new_from_string(const char *name, const ch
 	if (!name || !s) {
 		return NULL;
 	}
-	o = strdup(s);
+	o = rz_str_dup(s);
 	int cols = rz_str_split(o, ',');
 	if (cols < 3) {
 		free(o);
@@ -300,7 +300,7 @@ RZ_API RzSyscallItem *rz_syscall_item_new_from_string(const char *name, const ch
 		free(o);
 		return NULL;
 	}
-	si->name = strdup(name);
+	si->name = rz_str_dup(name);
 	si->swi = (int)rz_num_get(NULL, rz_str_word_get0(o, 0));
 	si->num = (int)rz_num_get(NULL, rz_str_word_get0(o, 1));
 	si->args = (int)rz_num_get(NULL, rz_str_word_get0(o, 2));

--- a/librz/type/format.c
+++ b/librz/type/format.c
@@ -1232,7 +1232,7 @@ static void rz_type_format_nulltermstring(const RzTypeDB *typedb, RzPrint *p, Rz
 	if (MUSTSET) {
 		int buflen = strlen((const char *)buf + seeki);
 		int vallen = strlen(setval);
-		char *ons, *newstring = ons = strdup(setval);
+		char *ons, *newstring = ons = rz_str_dup(setval);
 		if ((newstring[0] == '\"' && newstring[vallen - 1] == '\"') || (newstring[0] == '\'' && newstring[vallen - 1] == '\'')) {
 			newstring[vallen - 1] = '\0';
 			newstring++;
@@ -1301,7 +1301,7 @@ static void rz_type_format_nulltermwidestring(RzPrint *p, RzStrBuf *outbuf, cons
 	if (MUSTSET) {
 		int vallen = strlen(setval);
 		char *newstring, *ons;
-		newstring = ons = strdup(setval);
+		newstring = ons = rz_str_dup(setval);
 		if ((newstring[0] == '\"' && newstring[vallen - 1] == '\"') || (newstring[0] == '\'' && newstring[vallen - 1] == '\'')) {
 			newstring[vallen - 1] = '\0';
 			newstring++;
@@ -1532,7 +1532,7 @@ static int format_struct_size(const RzTypeDB *typedb, const char *parent_format,
 	if (!fmt2) {
 		fmt2 = f;
 	}
-	char *o = strdup(fmt2);
+	char *o = rz_str_dup(fmt2);
 	if (!o) {
 		return -1;
 	}
@@ -1544,9 +1544,9 @@ static int format_struct_size(const RzTypeDB *typedb, const char *parent_format,
 	}
 	if (*end) {
 		*end = 0;
-		args = strdup(end + 1);
+		args = rz_str_dup(end + 1);
 	} else {
-		args = strdup("");
+		args = rz_str_dup("");
 	}
 
 	if (fmt[0] == '{') {
@@ -1654,7 +1654,7 @@ static int format_struct_size(const RzTypeDB *typedb, const char *parent_format,
 			if (!wordAtIndex) {
 				break;
 			}
-			structname = strdup(wordAtIndex);
+			structname = rz_str_dup(wordAtIndex);
 			if (*structname == '(') {
 				endname = (char *)rz_str_rchr(structname, NULL, ')');
 			} else {
@@ -1793,13 +1793,13 @@ static int rz_type_format_struct(const RzTypeDB *typedb, RzPrint *p, RzStrBuf *o
 		return 0;
 	}
 	if (anon) {
-		fmt = strdup(name);
+		fmt = rz_str_dup(name);
 	} else {
 		const char *dbfmt = rz_type_db_format_get(typedb, name);
 		if (!dbfmt) { // Fetch struct info from types DB
 			fmt = rz_type_format(typedb, name);
 		} else {
-			fmt = strdup(dbfmt);
+			fmt = rz_str_dup(dbfmt);
 		}
 	}
 	if (RZ_STR_ISEMPTY(fmt)) {
@@ -1841,40 +1841,40 @@ static char *get_format_type(const char fmt, const char arg) {
 	switch (fmt) {
 	case 'b':
 	case 'C':
-		type = strdup("uint8_t");
+		type = rz_str_dup("uint8_t");
 		break;
 	case 'c':
-		type = strdup("int8_t");
+		type = rz_str_dup("int8_t");
 		break;
 	case 'd':
 	case 'i':
 	case 'o':
 	case 'x':
-		type = strdup("int32_t");
+		type = rz_str_dup("int32_t");
 		break;
 	case 'E':
-		type = strdup("enum");
+		type = rz_str_dup("enum");
 		break;
 	case 'f':
-		type = strdup("float");
+		type = rz_str_dup("float");
 		break;
 	case 'F':
-		type = strdup("double");
+		type = rz_str_dup("double");
 		break;
 	case 'q':
-		type = strdup("uint64_t");
+		type = rz_str_dup("uint64_t");
 		break;
 	case 'u':
-		type = strdup("uleb128_t");
+		type = rz_str_dup("uleb128_t");
 		break;
 	case 'Q':
-		type = strdup("uint128_t");
+		type = rz_str_dup("uint128_t");
 		break;
 	case 'w':
-		type = strdup("uint16_t");
+		type = rz_str_dup("uint16_t");
 		break;
 	case 'X':
-		type = strdup("uint8_t[]");
+		type = rz_str_dup("uint8_t[]");
 		break;
 	case 'D':
 	case 's':
@@ -1882,22 +1882,22 @@ static char *get_format_type(const char fmt, const char arg) {
 	case 't':
 	case 'z':
 	case 'Z':
-		type = strdup("char*");
+		type = rz_str_dup("char*");
 		break;
 	case 'n':
 	case 'N':
 		switch (arg) {
 		case '1':
-			type = strdup(fmt == 'n' ? "int8_t" : "uint8_t");
+			type = rz_str_dup(fmt == 'n' ? "int8_t" : "uint8_t");
 			break;
 		case '2':
-			type = strdup(fmt == 'n' ? "int16_t" : "uint16_t");
+			type = rz_str_dup(fmt == 'n' ? "int16_t" : "uint16_t");
 			break;
 		case '4':
-			type = strdup(fmt == 'n' ? "int32_t" : "uint32_t");
+			type = rz_str_dup(fmt == 'n' ? "int32_t" : "uint32_t");
 			break;
 		case '8':
-			type = strdup(fmt == 'n' ? "int64_t" : "uint64_t");
+			type = rz_str_dup(fmt == 'n' ? "int64_t" : "uint64_t");
 			break;
 		}
 		break;
@@ -1922,7 +1922,7 @@ RZ_API const char *rz_type_db_format_get(const RzTypeDB *typedb, const char *nam
 RZ_API void rz_type_db_format_set(RzTypeDB *typedb, const char *name, const char *fmt) {
 	rz_return_if_fail(typedb && name && fmt);
 	// TODO: We should check if the file format is valid (e.g. syntax) before storing it
-	ht_ss_insert(typedb->formats, name, strdup(fmt));
+	ht_ss_insert(typedb->formats, name, rz_str_dup(fmt));
 }
 
 static bool format_collect_cb(void *user, const char *k, const char *v) {
@@ -1970,7 +1970,7 @@ static int rz_type_format_data_internal(const RzTypeDB *typedb, RzPrint *p, RzSt
 	if (!fmt) {
 		fmt = formatname;
 	}
-	internal_format = strdup(fmt);
+	internal_format = rz_str_dup(fmt);
 	fmt = internal_format;
 	while (*fmt && IS_WHITECHAR(*fmt)) {
 		fmt++;
@@ -1995,7 +1995,7 @@ static int rz_type_format_data_internal(const RzTypeDB *typedb, RzPrint *p, RzSt
 	endian = typedb->target->big_endian;
 
 	if (ofield && ofield != MINUSONE) {
-		field = strdup(ofield);
+		field = rz_str_dup(ofield);
 	}
 	/* get times */
 	otimes = times = atoi(arg);
@@ -2031,7 +2031,7 @@ static int rz_type_format_data_internal(const RzTypeDB *typedb, RzPrint *p, RzSt
 			args++;
 			tmp = *args;
 		}
-		args = strdup(args);
+		args = rz_str_dup(args);
 		nargs = rz_str_word_set0_stack(args);
 		if (nargs == 0) {
 			RZ_FREE(args);
@@ -2076,7 +2076,7 @@ static int rz_type_format_data_internal(const RzTypeDB *typedb, RzPrint *p, RzSt
 			if (strchr(formatname, ' ')) {
 				fmtname = rz_str_newf("0x%" PFMT64x, seek);
 			} else {
-				fmtname = strdup(formatname);
+				fmtname = rz_str_dup(formatname);
 			}
 		} else {
 			fmtname = rz_str_newf("0x%" PFMT64x, seek);
@@ -2169,7 +2169,7 @@ static int rz_type_format_data_internal(const RzTypeDB *typedb, RzPrint *p, RzSt
 					*dot = '\0';
 				}
 				free(oarg);
-				oarg = fieldname = strdup(rz_str_word_get0(args, idx));
+				oarg = fieldname = rz_str_dup(rz_str_word_get0(args, idx));
 				if (ISSTRUCT || tmp == 'E' || tmp == 'B' || tmp == 'r') {
 					if (*fieldname == '(') {
 						fmtname = fieldname + 1;
@@ -3053,15 +3053,15 @@ RZ_API RZ_OWN char *rz_type_as_format(const RzTypeDB *typedb, RZ_NONNULL RzType 
 	if (type->kind == RZ_TYPE_KIND_CALLABLE) {
 		// We can't print anything useful for function type
 		// Thus we consider this is just a `void *` pointer
-		return strdup("p");
+		return rz_str_dup("p");
 	}
 	// Special case of callable ptr or `void *`
 	if (rz_type_is_void_ptr(type) || rz_type_is_callable_ptr(type)) {
-		return strdup("p");
+		return rz_str_dup("p");
 	}
 	// Special case of `char *`
 	if (rz_type_is_char_ptr(type)) {
-		return strdup("z");
+		return rz_str_dup("z");
 	}
 	RzStrBuf *buf = rz_strbuf_new(NULL);
 	type_to_format(typedb, buf, type);

--- a/librz/type/function.c
+++ b/librz/type/function.c
@@ -20,7 +20,7 @@ RZ_API RZ_OWN RzCallable *rz_type_callable_new(RZ_NULLABLE const char *name) {
 		return NULL;
 	}
 	callable->ret = NULL;
-	callable->name = name ? strdup(name) : NULL;
+	callable->name = rz_str_dup(name);
 	callable->args = rz_pvector_new((RzPVectorFree)rz_type_callable_arg_free);
 	return callable;
 }
@@ -37,7 +37,7 @@ RZ_API RZ_OWN RzCallable *rz_type_callable_clone(RZ_BORROW RZ_NONNULL const RzCa
 		return NULL;
 	}
 	newcallable->ret = callable->ret ? rz_type_clone(callable->ret) : NULL;
-	newcallable->name = callable->name ? strdup(callable->name) : NULL;
+	newcallable->name = rz_str_dup(callable->name);
 	newcallable->args = rz_pvector_new((RzPVectorFree)rz_type_callable_arg_free);
 	void **it;
 	rz_pvector_foreach (callable->args, it) {
@@ -72,7 +72,7 @@ RZ_API RZ_OWN RzCallableArg *rz_type_callable_arg_new(RzTypeDB *typedb, RZ_NONNU
 	if (!arg) {
 		return NULL;
 	}
-	arg->name = strdup(name);
+	arg->name = rz_str_dup(name);
 	arg->type = type;
 	return arg;
 }
@@ -88,7 +88,7 @@ RZ_API RZ_OWN RzCallableArg *rz_type_callable_arg_clone(RZ_BORROW RZ_NONNULL con
 	if (!newarg) {
 		return NULL;
 	}
-	newarg->name = strdup(arg->name);
+	newarg->name = rz_str_dup(arg->name);
 	newarg->type = rz_type_clone(arg->type);
 	return newarg;
 }
@@ -260,7 +260,7 @@ RZ_API bool rz_type_func_cc_set(RzTypeDB *typedb, const char *name, const char *
 	if (!callable) {
 		return false;
 	}
-	callable->cc = strdup(cc);
+	callable->cc = rz_str_dup(cc);
 	return true;
 }
 
@@ -436,7 +436,7 @@ static inline char *callable_name_or_ptr(RZ_NONNULL const RzCallable *callable, 
 		// Due to the portability issues with other solutions we use this hack to repeat the '*' character
 		return rz_str_newf("(%.*s%s)", (int)ptr_depth, "****************", rz_str_get(callable->name));
 	} else {
-		return strdup(rz_str_get(callable->name));
+		return rz_str_dup(rz_str_get(callable->name));
 	}
 }
 
@@ -573,7 +573,7 @@ RZ_API bool rz_type_func_noreturn_drop(RzTypeDB *typedb, RZ_NONNULL const char *
 static bool function_names_collect_cb(void *user, RZ_UNUSED const char *k, const void *v) {
 	RzList *l = (RzList *)user;
 	RzCallable *callable = (RzCallable *)v;
-	rz_list_append(l, strdup(callable->name));
+	rz_list_append(l, rz_str_dup(callable->name));
 	return true;
 }
 
@@ -593,7 +593,7 @@ static bool noreturn_function_names_collect_cb(void *user, RZ_UNUSED const char 
 	RzList *l = (RzList *)user;
 	RzCallable *callable = (RzCallable *)v;
 	if (callable->noret) {
-		rz_list_append(l, strdup(callable->name));
+		rz_list_append(l, rz_str_dup(callable->name));
 	}
 	return true;
 }

--- a/librz/type/helpers.c
+++ b/librz/type/helpers.c
@@ -19,7 +19,7 @@ RZ_API RZ_OWN RzType *rz_type_identifier_of_base_type(const RzTypeDB *typedb, RZ
 		return NULL;
 	}
 	type->kind = RZ_TYPE_KIND_IDENTIFIER;
-	type->identifier.name = strdup(btype->name);
+	type->identifier.name = rz_str_dup(btype->name);
 	type->identifier.is_const = is_const;
 	switch (btype->kind) {
 	case RZ_BASE_TYPE_KIND_STRUCT:

--- a/librz/type/parser/c_cpp_parser.c
+++ b/librz/type/parser/c_cpp_parser.c
@@ -199,7 +199,7 @@ static int type_parse_string(CParserState *state, const char *code, char **error
 		RZ_LOG_DEBUG("Warnings:\n");
 		RZ_LOG_DEBUG("%s", warning_msgs);
 		if (error_msg) {
-			*error_msg = strdup(error_msgs);
+			*error_msg = rz_str_dup(error_msgs);
 		}
 		free(error_msgs);
 		free(warning_msgs);
@@ -382,7 +382,7 @@ RZ_API RZ_OWN RzType *rz_type_parse_string_single(RzTypeParser *parser, const ch
 		RZ_LOG_DEBUG("Warnings:\n");
 		RZ_LOG_DEBUG("%s", warning_msgs);
 		if (error_msg) {
-			*error_msg = strdup(error_msgs);
+			*error_msg = rz_str_dup(error_msgs);
 		}
 		free(error_msgs);
 		free(warning_msgs);
@@ -472,7 +472,7 @@ RZ_API RZ_OWN RzType *rz_type_parse_string_declaration_single(RzTypeParser *pars
 		RZ_LOG_DEBUG("Warnings:\n");
 		RZ_LOG_DEBUG("%s", warning_msgs);
 		if (error_msg) {
-			*error_msg = strdup(error_msgs);
+			*error_msg = rz_str_dup(error_msgs);
 		}
 		free(error_msgs);
 		free(warning_msgs);

--- a/librz/type/parser/types_parser.c
+++ b/librz/type/parser/types_parser.c
@@ -1717,7 +1717,7 @@ int parse_type_declarator_node(CParserState *state, TSNode node, const char *tex
 			node_malformed_error(state, parameter_list, text, "parameter_list");
 			return -1;
 		}
-		naked_callable->callable->name = strdup(*identifier);
+		naked_callable->callable->name = rz_str_dup(*identifier);
 		// Preserve the parent callable type
 		parent_type = (*tpair)->type;
 		// Then override with the naked callable type to proceed with parameter parsing

--- a/librz/type/parser/types_storage.c
+++ b/librz/type/parser/types_storage.c
@@ -127,7 +127,7 @@ RZ_OWN ParserTypePair *c_parser_new_unspecified_naked_type(CParserState *state, 
 	}
 	type->kind = RZ_TYPE_KIND_IDENTIFIER;
 	type->identifier.is_const = is_const;
-	type->identifier.name = strdup(name);
+	type->identifier.name = rz_str_dup(name);
 	type->identifier.kind = RZ_TYPE_IDENTIFIER_KIND_UNSPECIFIED;
 
 	ParserTypePair *tpair = RZ_NEW0(ParserTypePair);
@@ -163,7 +163,7 @@ RZ_OWN ParserTypePair *c_parser_new_primitive_type(CParserState *state, RZ_NONNU
 	}
 	type->kind = RZ_TYPE_KIND_IDENTIFIER;
 	type->identifier.is_const = is_const;
-	type->identifier.name = strdup(name);
+	type->identifier.name = rz_str_dup(name);
 	if (!type->identifier.name) {
 		free(type);
 		return NULL;
@@ -175,7 +175,7 @@ RZ_OWN ParserTypePair *c_parser_new_primitive_type(CParserState *state, RZ_NONNU
 		rz_type_free(type);
 		return NULL;
 	}
-	base_type->name = strdup(name);
+	base_type->name = rz_str_dup(name);
 	if (!base_type->name) {
 		rz_type_free(type);
 		rz_type_base_type_free(base_type);
@@ -220,7 +220,7 @@ RZ_OWN ParserTypePair *c_parser_get_primitive_type(CParserState *state, RZ_NONNU
 	}
 	type->kind = RZ_TYPE_KIND_IDENTIFIER;
 	type->identifier.is_const = is_const;
-	type->identifier.name = strdup(name);
+	type->identifier.name = rz_str_dup(name);
 	type->identifier.kind = RZ_TYPE_IDENTIFIER_KIND_UNSPECIFIED;
 
 	ParserTypePair *tpair = RZ_NEW0(ParserTypePair);
@@ -248,7 +248,7 @@ RZ_OWN ParserTypePair *c_parser_new_structure_naked_type(CParserState *state, RZ
 	}
 	type->kind = RZ_TYPE_KIND_IDENTIFIER;
 	type->identifier.is_const = false;
-	type->identifier.name = strdup(name);
+	type->identifier.name = rz_str_dup(name);
 	type->identifier.kind = RZ_TYPE_IDENTIFIER_KIND_STRUCT;
 
 	ParserTypePair *tpair = RZ_NEW0(ParserTypePair);
@@ -289,7 +289,7 @@ RZ_OWN ParserTypePair *c_parser_new_structure_type(CParserState *state, RZ_NONNU
 		free(tpair);
 		return NULL;
 	}
-	base_type->name = strdup(name);
+	base_type->name = rz_str_dup(name);
 	base_type->type = NULL;
 	tpair->btype = base_type;
 
@@ -375,7 +375,7 @@ RZ_OWN ParserTypePair *c_parser_new_union_naked_type(CParserState *state, RZ_NON
 	}
 	type->kind = RZ_TYPE_KIND_IDENTIFIER;
 	type->identifier.is_const = false;
-	type->identifier.name = strdup(name);
+	type->identifier.name = rz_str_dup(name);
 	type->identifier.kind = RZ_TYPE_IDENTIFIER_KIND_UNION;
 
 	ParserTypePair *tpair = RZ_NEW0(ParserTypePair);
@@ -417,7 +417,7 @@ RZ_OWN ParserTypePair *c_parser_new_union_type(CParserState *state, RZ_NONNULL c
 		return NULL;
 	}
 
-	base_type->name = strdup(name);
+	base_type->name = rz_str_dup(name);
 	base_type->type = NULL;
 	tpair->btype = base_type;
 
@@ -503,7 +503,7 @@ RZ_OWN ParserTypePair *c_parser_new_enum_naked_type(CParserState *state, RZ_NONN
 	}
 	type->kind = RZ_TYPE_KIND_IDENTIFIER;
 	type->identifier.is_const = false;
-	type->identifier.name = strdup(name);
+	type->identifier.name = rz_str_dup(name);
 	type->identifier.kind = RZ_TYPE_IDENTIFIER_KIND_ENUM;
 
 	ParserTypePair *tpair = RZ_NEW0(ParserTypePair);
@@ -545,7 +545,7 @@ RZ_OWN ParserTypePair *c_parser_new_enum_type(CParserState *state, RZ_NONNULL co
 		return NULL;
 	}
 
-	base_type->name = strdup(name);
+	base_type->name = rz_str_dup(name);
 	base_type->type = NULL;
 	tpair->btype = base_type;
 
@@ -631,7 +631,7 @@ RZ_OWN ParserTypePair *c_parser_new_typedef_naked_type(CParserState *state, RZ_N
 	}
 	type->kind = RZ_TYPE_KIND_IDENTIFIER;
 	type->identifier.is_const = false;
-	type->identifier.name = strdup(name);
+	type->identifier.name = rz_str_dup(name);
 	type->identifier.kind = RZ_TYPE_IDENTIFIER_KIND_UNSPECIFIED;
 
 	ParserTypePair *tpair = RZ_NEW0(ParserTypePair);
@@ -701,7 +701,7 @@ RZ_OWN ParserTypePair *c_parser_new_typedef(CParserState *state, RZ_NONNULL cons
 		free(tpair);
 		return NULL;
 	}
-	base_type->name = strdup(name);
+	base_type->name = rz_str_dup(name);
 
 	if (!c_parser_base_type_exists(state, base)) {
 		// If it not exists already in the parser
@@ -716,7 +716,7 @@ RZ_OWN ParserTypePair *c_parser_new_typedef(CParserState *state, RZ_NONNULL cons
 			return NULL;
 		}
 		type->kind = RZ_TYPE_KIND_IDENTIFIER;
-		type->identifier.name = strdup(base);
+		type->identifier.name = rz_str_dup(base);
 		type->identifier.is_const = false;
 		base_type->type = type;
 	}
@@ -750,7 +750,7 @@ RZ_OWN ParserTypePair *c_parser_get_typedef(CParserState *state, RZ_NONNULL cons
 	}
 	type->kind = RZ_TYPE_KIND_IDENTIFIER;
 	type->identifier.is_const = false;
-	type->identifier.name = strdup(name);
+	type->identifier.name = rz_str_dup(name);
 	type->identifier.kind = RZ_TYPE_IDENTIFIER_KIND_UNSPECIFIED;
 
 	ParserTypePair *tpair = RZ_NEW0(ParserTypePair);
@@ -815,7 +815,7 @@ RZ_OWN RzType *c_parser_new_callable(CParserState *state, RZ_NONNULL const char 
 			free(type);
 			return NULL;
 		}
-		callable->name = strdup(name);
+		callable->name = rz_str_dup(name);
 		callable->args = rz_pvector_new((RzPVectorFree)rz_type_callable_arg_free);
 	}
 	type->kind = RZ_TYPE_KIND_CALLABLE;
@@ -846,7 +846,7 @@ bool c_parser_new_callable_argument(CParserState *state, RZ_NONNULL RzCallable *
 	if (!arg) {
 		return false;
 	}
-	arg->name = strdup(name);
+	arg->name = rz_str_dup(name);
 	arg->type = type;
 	rz_pvector_push(callable->args, arg);
 	return true;

--- a/librz/type/serialize_functions.c
+++ b/librz/type/serialize_functions.c
@@ -23,7 +23,7 @@ static RzType *parse_type_string_cached(RzTypeParser *parser, HtSP *cache, const
 	}
 	r = rz_type_parse_string_single(parser, str, error_msg);
 	if (r) {
-		char *reminder = strdup(str);
+		char *reminder = rz_str_dup(str);
 		if (reminder) {
 			ht_sp_insert(cache, str, r);
 			rz_list_push(newly_added, reminder);

--- a/librz/type/serialize_types.c
+++ b/librz/type/serialize_types.c
@@ -46,7 +46,7 @@ static TypeFormatPair *get_enum_type(Sdb *sdb, const char *sname) {
 		goto error;
 	}
 
-	base_type->name = strdup(sname);
+	base_type->name = rz_str_dup(sname);
 	RzVector *cases = &base_type->enum_data.cases;
 	if (!rz_vector_reserve(cases, (size_t)sdb_alen(members))) {
 		goto error;
@@ -65,7 +65,7 @@ static TypeFormatPair *get_enum_type(Sdb *sdb, const char *sname) {
 			goto error;
 		}
 
-		RzTypeEnumCase cas = { .name = strdup(cur), .val = strtol(value, NULL, 16) };
+		RzTypeEnumCase cas = { .name = rz_str_dup(cur), .val = strtol(value, NULL, 16) };
 
 		void *element = rz_vector_push(cases, &cas); // returns null if no space available
 		if (!element) {
@@ -99,7 +99,7 @@ static TypeFormatPair *get_struct_type(RzTypeDB *typedb, Sdb *sdb, const char *s
 	if (!base_type) {
 		return NULL;
 	}
-	base_type->name = strdup(sname);
+	base_type->name = rz_str_dup(sname);
 
 	char *sdb_members = get_type_data(sdb, "struct", sname);
 	if (sdb_members) {
@@ -136,7 +136,7 @@ static TypeFormatPair *get_struct_type(RzTypeDB *typedb, Sdb *sdb, const char *s
 			}
 
 			RzTypeStructMember memb = {
-				.name = strdup(cur),
+				.name = rz_str_dup(cur),
 				.type = ttype,
 				.offset = strtol(offset, NULL, 10)
 			};
@@ -159,7 +159,7 @@ static TypeFormatPair *get_struct_type(RzTypeDB *typedb, Sdb *sdb, const char *s
 
 	TypeFormatPair *tpair = RZ_NEW0(TypeFormatPair);
 	tpair->type = base_type;
-	tpair->format = format ? strdup(format) : NULL;
+	tpair->format = rz_str_dup(format);
 
 	return tpair;
 
@@ -177,7 +177,7 @@ static TypeFormatPair *get_union_type(RzTypeDB *typedb, Sdb *sdb, const char *sn
 		return NULL;
 	}
 
-	base_type->name = strdup(sname);
+	base_type->name = rz_str_dup(sname);
 
 	char *sdb_members = get_type_data(sdb, "union", sname);
 	if (sdb_members) {
@@ -207,7 +207,7 @@ static TypeFormatPair *get_union_type(RzTypeDB *typedb, Sdb *sdb, const char *sn
 			}
 
 			RzTypeUnionMember memb = {
-				.name = strdup(cur),
+				.name = rz_str_dup(cur),
 				.type = ttype
 			};
 			free(values);
@@ -228,7 +228,7 @@ static TypeFormatPair *get_union_type(RzTypeDB *typedb, Sdb *sdb, const char *sn
 
 	TypeFormatPair *tpair = RZ_NEW0(TypeFormatPair);
 	tpair->type = base_type;
-	tpair->format = format ? strdup(format) : NULL;
+	tpair->format = rz_str_dup(format);
 
 	return tpair;
 
@@ -246,7 +246,7 @@ static TypeFormatPair *get_typedef_type(RzTypeDB *typedb, Sdb *sdb, const char *
 		return NULL;
 	}
 
-	base_type->name = strdup(sname);
+	base_type->name = rz_str_dup(sname);
 	char *type = get_type_data(sdb, "typedef", sname);
 	char *error_msg = NULL;
 	RzType *ttype = rz_type_parse_string_single(typedb->parser, type, &error_msg);
@@ -289,12 +289,12 @@ static TypeFormatPair *get_atomic_type(RzTypeDB *typedb, Sdb *sdb, const char *s
 		goto error;
 	}
 	ttype->kind = RZ_TYPE_KIND_IDENTIFIER;
-	ttype->identifier.name = strdup(sname);
+	ttype->identifier.name = rz_str_dup(sname);
 	ttype->identifier.is_const = false; // We don't preload const types by default
 	ttype->identifier.kind = RZ_TYPE_IDENTIFIER_KIND_UNSPECIFIED;
 	base_type->type = ttype;
 
-	base_type->name = strdup(sname);
+	base_type->name = rz_str_dup(sname);
 	RzStrBuf key;
 	base_type->size = sdb_num_get(sdb, rz_strbuf_initf(&key, "type.%s.size", sname));
 	RzTypeTypeclass typeclass = RZ_TYPE_TYPECLASS_NONE;
@@ -308,7 +308,7 @@ static TypeFormatPair *get_atomic_type(RzTypeDB *typedb, Sdb *sdb, const char *s
 
 	TypeFormatPair *tpair = RZ_NEW0(TypeFormatPair);
 	tpair->type = base_type;
-	tpair->format = format ? strdup(format) : NULL;
+	tpair->format = rz_str_dup(format);
 
 	return tpair;
 

--- a/librz/type/type.c
+++ b/librz/type/type.c
@@ -26,7 +26,7 @@ RZ_API RzTypeDB *rz_type_db_new() {
 		free(typedb);
 		return NULL;
 	}
-	typedb->target->default_type = strdup("int");
+	typedb->target->default_type = rz_str_dup("int");
 	typedb->types = ht_sp_new(HT_STR_DUP, NULL, (HtSPFreeValue)rz_type_base_type_free);
 	if (!typedb->types) {
 		goto rz_type_db_new_fail;
@@ -101,20 +101,20 @@ static void set_default_type(RzTypeTarget *target, int bits) {
 	}
 	switch (bits) {
 	case 8:
-		target->default_type = strdup("int8_t");
+		target->default_type = rz_str_dup("int8_t");
 		break;
 	case 16:
-		target->default_type = strdup("int16_t");
+		target->default_type = rz_str_dup("int16_t");
 		break;
 	case 32:
-		target->default_type = strdup("int32_t");
+		target->default_type = rz_str_dup("int32_t");
 		break;
 	case 64:
-		target->default_type = strdup("int64_t");
+		target->default_type = rz_str_dup("int64_t");
 		break;
 	default:
 		rz_warn_if_reached();
-		target->default_type = strdup("int");
+		target->default_type = rz_str_dup("int");
 	}
 }
 
@@ -159,7 +159,7 @@ RZ_API void rz_type_db_set_address_bits(RzTypeDB *typedb, int addr_bits) {
  */
 RZ_API void rz_type_db_set_os(RzTypeDB *typedb, const char *os) {
 	free(typedb->target->os);
-	typedb->target->os = os ? strdup(os) : NULL;
+	typedb->target->os = rz_str_dup(os);
 }
 
 /**
@@ -173,7 +173,7 @@ RZ_API void rz_type_db_set_os(RzTypeDB *typedb, const char *os) {
  */
 RZ_API void rz_type_db_set_cpu(RzTypeDB *typedb, const char *cpu) {
 	free(typedb->target->cpu);
-	typedb->target->cpu = cpu ? strdup(cpu) : NULL;
+	typedb->target->cpu = rz_str_dup(cpu);
 }
 
 /**
@@ -835,7 +835,7 @@ static bool type_decl_as_pretty_string(const RzTypeDB *typedb, const RzType *typ
 		*self_ref = false;
 		ht_sp_find(used_types, type->identifier.name, self_ref);
 		*self_ref = *self_ref && !is_anon; // no self_ref for anon types
-		*self_ref_typename = *self_ref ? strdup(type->identifier.name) : NULL;
+		*self_ref_typename = *self_ref ? rz_str_dup(type->identifier.name) : NULL;
 
 		RzBaseType *btype = rz_type_db_get_base_type(typedb, type->identifier.name);
 		if (!btype && !allow_non_exist) {

--- a/librz/util/axml.c
+++ b/librz/util/axml.c
@@ -310,7 +310,7 @@ RZ_API RZ_OWN char *rz_axml_decode(RZ_NONNULL const ut8 *data, const ut64 data_s
 
 	rz_return_val_if_fail(data, NULL);
 	if (data_size == 0) {
-		return strdup("");
+		return rz_str_dup("");
 	}
 
 	RzBuffer *buffer = rz_buf_new_with_pointers(data, data_size, false);

--- a/librz/util/file.c
+++ b/librz/util/file.c
@@ -119,7 +119,7 @@ Example:
 */
 RZ_API char *rz_file_dirname(const char *path) {
 	rz_return_val_if_fail(path, NULL);
-	char *newpath = strdup(path);
+	char *newpath = rz_str_dup(path);
 	char *ptr = (char *)rz_str_rchr(newpath, NULL, '/');
 	if (ptr) {
 		if (ptr == newpath) {
@@ -219,10 +219,10 @@ RZ_API bool rz_file_is_abspath(const char *file) {
 RZ_API RZ_OWN char *rz_file_abspath_rel(const char *cwd, const char *file) {
 	char *ret = NULL;
 	if (RZ_STR_ISEMPTY(file) || !strcmp(file, ".") || !strcmp(file, "./")) {
-		return strdup(cwd);
+		return rz_str_dup(cwd);
 	}
 	if (strstr(file, "://")) {
-		return strdup(file);
+		return rz_str_dup(file);
 	}
 	ret = rz_path_home_expand(file);
 #if __UNIX__
@@ -238,7 +238,7 @@ RZ_API RZ_OWN char *rz_file_abspath_rel(const char *cwd, const char *file) {
 #elif __WINDOWS__
 	// Network path
 	if (!strncmp(ret, "\\\\", 2)) {
-		return strdup(ret);
+		return rz_str_dup(ret);
 	}
 	if (!strchr(ret, ':')) {
 		char *tmp = rz_str_newf("%s" RZ_SYS_DIR "%s", cwd, ret);
@@ -254,7 +254,7 @@ RZ_API RZ_OWN char *rz_file_abspath_rel(const char *cwd, const char *file) {
 	char rp[PATH_MAX] = { 0 };
 	char *abspath = realpath(ret, rp); // second arg == NULL is only an extension
 	if (abspath) {
-		abspath = strdup(abspath);
+		abspath = rz_str_dup(abspath);
 		if (abspath) {
 			free(ret);
 			ret = abspath;
@@ -330,7 +330,7 @@ diverge:
 }
 
 RZ_API char *rz_file_path_local_to_unix(const char *path) {
-	char *r = strdup(path);
+	char *r = rz_str_dup(path);
 	if (!r) {
 		return NULL;
 	}
@@ -341,7 +341,7 @@ RZ_API char *rz_file_path_local_to_unix(const char *path) {
 }
 
 RZ_API char *rz_file_path_unix_to_local(const char *path) {
-	char *r = strdup(path);
+	char *r = rz_str_dup(path);
 	if (!r) {
 		return NULL;
 	}
@@ -369,7 +369,7 @@ RZ_API char *rz_file_path(const char *bin) {
 	}
 #endif
 	if (path_env) {
-		str = path = strdup(path_env);
+		str = path = rz_str_dup(path_env);
 		do {
 			ptr = strchr(str, RZ_SYS_ENVSEP[0]);
 			if (ptr) {
@@ -387,7 +387,7 @@ RZ_API char *rz_file_path(const char *bin) {
 	}
 	free(path_env);
 	free(path);
-	return strdup(bin);
+	return rz_str_dup(bin);
 }
 
 RZ_API char *rz_file_binsh(void) {
@@ -401,7 +401,7 @@ RZ_API char *rz_file_binsh(void) {
 		return bin_sh;
 	}
 	free(bin_sh);
-	bin_sh = strdup("/bin/sh");
+	bin_sh = rz_str_dup("/bin/sh");
 	return bin_sh;
 }
 
@@ -663,7 +663,7 @@ RZ_API char *rz_file_slurp_random_line_count(const char *file, int *line) {
 					break;
 				}
 			}
-			ptr = strdup(ptr);
+			ptr = rz_str_dup(ptr);
 		}
 		free(str);
 	}
@@ -699,7 +699,7 @@ RZ_API char *rz_file_slurp_line(const char *file, int line, int context) {
 				break;
 			}
 		}
-		ptr = strdup(ptr);
+		ptr = rz_str_dup(ptr);
 		free(str);
 	}
 	return ptr;
@@ -727,7 +727,7 @@ RZ_API RZ_OWN char *rz_file_slurp_lines_from_bottom(const char *file, int line) 
 			}
 		}
 		ptr = str + i;
-		ptr = strdup(ptr);
+		ptr = rz_str_dup(ptr);
 		free(str);
 	}
 	return ptr;
@@ -766,7 +766,7 @@ RZ_API char *rz_file_slurp_lines(const char *file, int line, int count) {
 				}
 			}
 		}
-		ptr = strdup(ptr);
+		ptr = rz_str_dup(ptr);
 		free(str);
 	}
 	return ptr;
@@ -774,7 +774,7 @@ RZ_API char *rz_file_slurp_lines(const char *file, int line, int count) {
 
 RZ_API char *rz_file_root(const char *root, const char *path) {
 	rz_return_val_if_fail(root && path, NULL);
-	char *ret, *s = rz_str_replace(strdup(path), "..", "", 1);
+	char *ret, *s = rz_str_replace(rz_str_dup(path), "..", "", 1);
 	// XXX ugly hack
 	while (strstr(s, "..")) {
 		s = rz_str_replace(s, "..", "", 1);
@@ -785,7 +785,7 @@ RZ_API char *rz_file_root(const char *root, const char *path) {
 	while (strstr(s, "//")) {
 		s = rz_str_replace(s, "//", "", 1);
 	}
-	ret = rz_str_append(strdup(root), RZ_SYS_DIR);
+	ret = rz_str_append(rz_str_dup(root), RZ_SYS_DIR);
 	ret = rz_str_append(ret, s);
 	free(s);
 	return ret;
@@ -902,7 +902,7 @@ repeat:
 		path = pathbuf;
 		goto repeat;
 	}
-	return strdup(pathbuf);
+	return rz_str_dup(pathbuf);
 #endif
 	return NULL;
 }
@@ -978,7 +978,7 @@ RZ_API RzMmap *rz_file_mmap(const char *file, int perm, int mode, ut64 base) {
 	m->base = base;
 	m->perm = perm;
 	m->len = 0;
-	m->filename = strdup(file);
+	m->filename = rz_str_dup(file);
 	m->mode = mode;
 	if (!m->filename) {
 		rz_file_mmap_free(m);
@@ -1123,7 +1123,7 @@ err_r_file_mkstemp:
 	}
 	umask(mask);
 	if (oname) {
-		*oname = (h != -1) ? strdup(name) : NULL;
+		*oname = (h != -1) ? rz_str_dup(name) : NULL;
 	}
 	free(name);
 #endif
@@ -1143,7 +1143,7 @@ RZ_API char *rz_file_tmpdir(void) {
 	if ((len = GetTempPathW(MAX_PATH + 1, tmpdir)) == 0) {
 		path = rz_sys_getenv("TEMP");
 		if (!path) {
-			path = strdup("C:\\WINDOWS\\Temp\\");
+			path = rz_str_dup("C:\\WINDOWS\\Temp\\");
 		}
 	} else {
 		tmpdir[len] = 0;
@@ -1166,9 +1166,9 @@ RZ_API char *rz_file_tmpdir(void) {
 	}
 	if (!path) {
 #if __ANDROID__
-		path = strdup("/data/data/org.rizin.rizininstaller/rizin/tmp");
+		path = rz_str_dup("/data/data/org.rizin.rizininstaller/rizin/tmp");
 #else
-		path = strdup("/tmp");
+		path = rz_str_dup("/tmp");
 #endif
 	}
 #endif
@@ -1222,8 +1222,8 @@ RZ_API bool rz_file_copy(const char *src, const char *dst) {
 	free(d);
 	return ret;
 #else
-	char *src2 = rz_str_replace(strdup(src), "'", "\\'", 1);
-	char *dst2 = rz_str_replace(strdup(dst), "'", "\\'", 1);
+	char *src2 = rz_str_replace(rz_str_dup(src), "'", "\\'", 1);
+	char *dst2 = rz_str_replace(rz_str_dup(dst), "'", "\\'", 1);
 	int rc = rz_sys_cmdf("cp -f '%s' '%s'", src2, dst2);
 	free(src2);
 	free(dst2);
@@ -1263,11 +1263,11 @@ static void recursive_search_glob(const char *path, const char *glob, RzList /*<
 }
 
 RZ_API RzList /*<char *>*/ *rz_file_globsearch(const char *_globbed_path, int maxdepth) {
-	char *globbed_path = strdup(_globbed_path);
+	char *globbed_path = rz_str_dup(_globbed_path);
 	RzList *files = rz_list_newf(free);
 	char *glob = strchr(globbed_path, '*');
 	if (!glob) {
-		rz_list_append(files, strdup(globbed_path));
+		rz_list_append(files, rz_str_dup(globbed_path));
 	} else {
 		*glob = '\0';
 		char *last_slash = (char *)rz_str_last(globbed_path, RZ_SYS_DIR);
@@ -1315,10 +1315,10 @@ RZ_API RZ_OWN char *rz_file_path_join(RZ_NONNULL const char *s1, RZ_NULLABLE con
 	rz_return_val_if_fail(s1, NULL);
 
 	if (s1[0] == 0) {
-		return strdup(s2);
+		return rz_str_dup(s2);
 	}
 	if (!s2) {
-		return strdup(s1);
+		return rz_str_dup(s1);
 	}
 	bool ends_with_dir = s1[strlen(s1) - 1] == RZ_SYS_DIR[0];
 	const char *sep = ends_with_dir ? "" : RZ_SYS_DIR;

--- a/librz/util/float/float.c
+++ b/librz/util/float/float.c
@@ -321,15 +321,15 @@ RZ_API RZ_OWN char *rz_float_as_dec_string(RZ_NULLABLE RzFloat *f) {
 	RzFloatSpec type = rz_float_detect_spec(f);
 	switch (type) {
 	case RZ_FLOAT_SPEC_ZERO:
-		return strdup("0.0");
+		return rz_str_dup("0.0");
 	case RZ_FLOAT_SPEC_PINF:
-		return strdup("+inf");
+		return rz_str_dup("+inf");
 	case RZ_FLOAT_SPEC_NINF:
-		return strdup("-inf");
+		return rz_str_dup("-inf");
 	case RZ_FLOAT_SPEC_QNAN:
 		/* fall-thru */
 	case RZ_FLOAT_SPEC_SNAN:
-		return strdup("nan");
+		return rz_str_dup("nan");
 	default:
 		break;
 	}

--- a/librz/util/ht/ht_inc.c
+++ b/librz/util/ht/ht_inc.c
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <rz_util/rz_assert.h>
+#include <rz_util/rz_str.h>
 
 #define LOAD_FACTOR     1
 #define S_ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))

--- a/librz/util/ht/ht_sp.c
+++ b/librz/util/ht/ht_sp.c
@@ -28,13 +28,13 @@ static void fini_kv_val(HT_(Kv) *kv, void *user) {
  *
  * Keys are compared using strcmp function.
  * Size of keys is calculated using strlen function.
- * Copies of keys are made using strdup function if appropriate option is set.
+ * Copies of keys are made using rz_str_dup function if appropriate option is set.
  */
 RZ_API RZ_OWN HtName_(Ht) *Ht_(new)(HtStrOption key_opt, RZ_NULLABLE HT_(DupValue) dup_val, RZ_NULLABLE HT_(FreeValue) free_val) {
 	HT_(Options) opt = {
 		.cmp = (HT_(Comparator))strcmp,
 		.hashfn = (HT_(HashFunction))sdb_hash,
-		.dupkey = key_opt == HT_STR_DUP ? (HT_(DupKey))strdup : NULL,
+		.dupkey = key_opt == HT_STR_DUP ? (HT_(DupKey))rz_str_dup : NULL,
 		.dupvalue = dup_val,
 		.calcsizeK = (HT_(CalcSizeK))strlen,
 		.calcsizeV = NULL,

--- a/librz/util/ht/ht_ss.c
+++ b/librz/util/ht/ht_ss.c
@@ -27,14 +27,14 @@ static void fini_kv_val(HT_(Kv) *kv, void *user) {
  *
  * Keys are compared using strcmp function.
  * Size of keys is calculated using strlen function.
- * Copies of keys/values are made using strdup function if appropriate option is set.
+ * Copies of keys/values are made using rz_str_dup function if appropriate option is set.
  */
 RZ_API RZ_OWN HtName_(Ht) *Ht_(new)(HtStrOption key_opt, HtStrOption val_opt) {
 	HT_(Options) opt = {
 		.cmp = (HT_(Comparator))strcmp,
 		.hashfn = (HT_(HashFunction))sdb_hash,
-		.dupkey = key_opt == HT_STR_DUP ? (HT_(DupKey))strdup : NULL,
-		.dupvalue = val_opt == HT_STR_DUP ? (HT_(DupValue))strdup : NULL,
+		.dupkey = key_opt == HT_STR_DUP ? (HT_(DupKey))rz_str_dup : NULL,
+		.dupvalue = val_opt == HT_STR_DUP ? (HT_(DupValue))rz_str_dup : NULL,
 		.calcsizeK = (HT_(CalcSizeK))strlen,
 		.calcsizeV = (HT_(CalcSizeV))strlen,
 		.finiKV = key_opt == HT_STR_CONST ? fini_kv_val : fini_kv,

--- a/librz/util/ht/ht_su.c
+++ b/librz/util/ht/ht_su.c
@@ -15,13 +15,13 @@ static void fini_kv_key(HT_(Kv) *kv, RZ_UNUSED void *user) {
  *
  * Keys are compared using strcmp function.
  * Size of keys is calculated using strlen function.
- * Copies of keys are made using strdup function if appropriate option is set.
+ * Copies of keys are made using rz_str_dup function if appropriate option is set.
  */
 RZ_API RZ_OWN HtName_(Ht) *Ht_(new)(HtStrOption key_opt) {
 	HT_(Options) opt = {
 		.cmp = (HT_(Comparator))strcmp,
 		.hashfn = (HT_(HashFunction))sdb_hash,
-		.dupkey = key_opt == HT_STR_DUP ? (HT_(DupKey))strdup : NULL,
+		.dupkey = key_opt == HT_STR_DUP ? (HT_(DupKey))rz_str_dup : NULL,
 		.dupvalue = NULL,
 		.calcsizeK = (HT_(CalcSizeK))strlen,
 		.calcsizeV = NULL,

--- a/librz/util/json_parser.c
+++ b/librz/util/json_parser.c
@@ -559,7 +559,7 @@ RZ_API RZ_OWN char *rz_json_as_string(const RzJson *json, bool with_key) {
 	rz_return_val_if_fail(json, NULL);
 	if (json->type == RZ_JSON_STRING && (!with_key || !json->key)) {
 		// Printing string without surrounding quotes
-		return strdup(json->str_value);
+		return rz_str_dup(json->str_value);
 	}
 	PJ *pj = pj_new();
 	if (!pj) {
@@ -614,8 +614,8 @@ RZ_API bool rz_json_eq(RZ_NONNULL RZ_BORROW const RzJson *a, RZ_NONNULL RZ_BORRO
  */
 RZ_API bool rz_json_string_eq(RZ_NONNULL RZ_BORROW const char *sa, RZ_NONNULL RZ_BORROW const char *sb) {
 	rz_return_val_if_fail(sa && sb, false);
-	char *sa_dup = strdup(sa);
-	char *sb_dup = strdup(sb);
+	char *sa_dup = rz_str_dup(sa);
+	char *sb_dup = rz_str_dup(sb);
 	RzJson *a = rz_json_parse(sa_dup);
 	RzJson *b = NULL;
 	bool ret = false;

--- a/librz/util/lib.c
+++ b/librz/util/lib.c
@@ -28,8 +28,8 @@ RZ_API RzLib *rz_lib_new(RZ_NULLABLE const char *symname, RZ_NULLABLE const char
 	}
 	lib->handlers = rz_list_newf(free);
 	lib->plugins = rz_list_new();
-	lib->symname = strdup(symname ? symname : RZ_LIB_SYMNAME);
-	lib->symnamefunc = strdup(symnamefunc ? symnamefunc : RZ_LIB_SYMFUNC);
+	lib->symname = rz_str_dup(symname ? symname : RZ_LIB_SYMNAME);
+	lib->symnamefunc = rz_str_dup(symnamefunc ? symnamefunc : RZ_LIB_SYMFUNC);
 	lib->opened_dirs = ht_su_new(HT_STR_DUP);
 	return lib;
 }
@@ -120,7 +120,7 @@ static bool lib_already_loaded(RzLib *lib, const char *file) {
 }
 
 static char *major_minor(const char *s) {
-	char *a = strdup(s);
+	char *a = rz_str_dup(s);
 	char *p = strchr(a, '.');
 	if (p) {
 		p = strchr(p + 1, '.');
@@ -163,7 +163,7 @@ static bool lib_open_ptr(RzLib *lib, const char *file, void *handler, RzLibStruc
 
 	p->type = stru->type;
 	p->data = stru->data;
-	p->file = strdup(file);
+	p->file = rz_str_dup(file);
 	p->handler = lib_handler;
 	p->free = stru->free;
 

--- a/librz/util/name.c
+++ b/librz/util/name.c
@@ -94,7 +94,7 @@ RZ_API char *rz_name_filter2(const char *name, bool strict) {
 	while (!rz_name_validate_char(*name, strict)) {
 		name++;
 	}
-	char *res = strdup(name);
+	char *res = rz_str_dup(name);
 	for (i = 0; res[i]; i++) {
 		if (!rz_name_validate_char(res[i], strict)) {
 			res[i] = '_';

--- a/librz/util/path.c
+++ b/librz/util/path.c
@@ -95,7 +95,7 @@ RZ_API void rz_path_set_prefix(RZ_NONNULL const char *path) {
 	rz_th_lock_enter(portable_prefix_mutex);
 	free(portable_prefix);
 	if (RZ_STR_ISNOTEMPTY(path)) {
-		portable_prefix = strdup(path);
+		portable_prefix = rz_str_dup(path);
 	} else {
 		portable_prefix = set_portable_prefix();
 	}
@@ -277,13 +277,13 @@ RZ_API RZ_OWN char *rz_path_home(RZ_NULLABLE const char *path) {
 RZ_API RZ_OWN char *rz_path_home_expand(RZ_NULLABLE const char *path) {
 	// if the path does not start with `~`, there is nothing to expand
 	if (path && path[0] != '~') {
-		return strdup(path);
+		return rz_str_dup(path);
 	}
 
 	// if the path starts with `~` but it is not `~/` or just `~`, then it is a
 	// valid name (e.g. `~hello`)
 	if (path && path[0] && path[1] && path[1] != '/') {
-		return strdup(path);
+		return rz_str_dup(path);
 	}
 
 	return rz_path_home(path + 1);
@@ -304,7 +304,7 @@ RZ_API RZ_OWN char *rz_path_realpath(RZ_NULLABLE const char *path) {
 	char buf[PATH_MAX] = { 0 };
 	const char *rp = realpath(path, buf);
 	if (rp) {
-		return strdup(rp);
+		return rz_str_dup(rp);
 	}
 #elif __WINDOWS__
 	wchar_t buf[MAX_PATH] = { 0 };

--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -1388,7 +1388,7 @@ RZ_API RZ_OWN char *rz_print_jsondump_str(RZ_NONNULL RzPrint *p, RZ_NONNULL cons
 		pj_n(j, word);
 	}
 	pj_end(j);
-	char *str = strdup(pj_string(j));
+	char *str = rz_str_dup(pj_string(j));
 	pj_free(j);
 	return str;
 }

--- a/librz/util/regex.c
+++ b/librz/util/regex.c
@@ -60,7 +60,7 @@ RZ_API RZ_OWN RzRegex *rz_regex_new(RZ_NONNULL const char *pattern, RzRegexFlags
 		} else {
 			// In PCRE2 with the extended flag set, ascii space characters ' ' are skipped.
 			// We need to replace them with \s unfortunately to keep our API stable.
-			fixed_pat = rz_str_replace(strdup(pattern), " ", "\\s", 1);
+			fixed_pat = rz_str_replace(rz_str_dup(pattern), " ", "\\s", 1);
 			pat = fixed_pat;
 		}
 	} else {

--- a/librz/util/spaces.c
+++ b/librz/util/spaces.c
@@ -15,7 +15,7 @@ RZ_API RzSpaces *rz_spaces_new(const char *name) {
 
 RZ_API bool rz_spaces_init(RzSpaces *sp, const char *name) {
 	rz_return_val_if_fail(sp && name, false);
-	sp->name = strdup(name);
+	sp->name = rz_str_dup(name);
 	if (!sp->name) {
 		goto fail;
 	}
@@ -109,7 +109,7 @@ RZ_API RzSpace *rz_spaces_add(RzSpaces *sp, const char *name) {
 		return NULL;
 	}
 
-	s->name = strdup(name);
+	s->name = rz_str_dup(name);
 	if (!s->name) {
 		free(s);
 		return NULL;
@@ -151,7 +151,7 @@ RZ_API bool rz_spaces_unset(RzSpaces *sp, const char *name) {
 	RBIter it;
 	RzSpace *s;
 	rz_spaces_foreach(sp, it, s) {
-		rz_list_append(names, strdup(s->name));
+		rz_list_append(names, rz_str_dup(s->name));
 	}
 
 	RzListIter *lit;
@@ -222,7 +222,7 @@ RZ_API bool rz_spaces_rename(RzSpaces *sp, const char *oname, const char *nname)
 
 	rz_rbtree_delete(&sp->spaces, (void *)s->name, name_space_cmp, NULL, NULL, NULL);
 	free(s->name);
-	s->name = strdup(nname);
+	s->name = rz_str_dup(nname);
 	rz_rbtree_insert(&sp->spaces, s, &s->rb, space_cmp, NULL);
 
 	return true;

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -644,7 +644,7 @@ static const char *skip_separator_chars(const char *text) {
  */
 RZ_API RZ_OWN char *rz_str_skip_separator_chars(RZ_NONNULL const char *text) {
 	rz_return_val_if_fail(text, NULL);
-	return strdup(skip_separator_chars(text));
+	return rz_str_dup(skip_separator_chars(text));
 }
 
 // Counts the number of words (separated by separator characters: newlines, tabs,
@@ -844,8 +844,8 @@ RZ_API const char *rz_str_rsep(const char *base, const char *p, const char *sep)
 }
 
 RZ_API const char *rz_str_rstr(const char *base, const char *p) {
-	char *s = strdup(base);
-	char *k = strdup(p);
+	char *s = rz_str_dup(base);
+	char *k = rz_str_dup(p);
 	rz_str_reverse(s);
 	rz_str_reverse(k);
 	char *q = strstr(s, k);
@@ -900,7 +900,7 @@ RZ_API const char *rz_str_nstr(const char *s, const char *find, int slen) {
  */
 RZ_API const char *rz_str_case_nstr(RZ_NONNULL const char *s, RZ_NONNULL const char *find, int slen) {
 	rz_return_val_if_fail(s && find, NULL);
-	char *new_s = strdup(s), *new_find = strdup(find);
+	char *new_s = rz_str_dup(s), *new_find = rz_str_dup(find);
 	const char *res = NULL;
 	rz_str_case(new_s, false);
 	rz_str_case(new_find, false);
@@ -932,7 +932,7 @@ RZ_API char *rz_str_trunc_ellipsis(const char *str, int len) {
 		return NULL;
 	}
 	if (strlen(str) < len) {
-		return strdup(str);
+		return rz_str_dup(str);
 	}
 	char *buf = rz_str_newlen(str, len);
 	if (buf && len > 4) {
@@ -948,7 +948,7 @@ RZ_API char *rz_str_newf(const char *fmt, ...) {
 	va_start(ap, fmt);
 	if (!strchr(fmt, '%')) {
 		va_end(ap);
-		return strdup(fmt);
+		return rz_str_dup(fmt);
 	}
 	va_copy(ap2, ap);
 	int ret = vsnprintf(NULL, 0, fmt, ap2);
@@ -1080,7 +1080,7 @@ RZ_API RZ_OWN char *rz_str_dup(RZ_NULLABLE const char *str) {
 RZ_API char *rz_str_prepend(char *ptr, const char *string) {
 	int slen, plen;
 	if (!ptr) {
-		return strdup(string);
+		return rz_str_dup(string);
 	}
 	plen = strlen(ptr);
 	slen = strlen(string);
@@ -1121,7 +1121,7 @@ RZ_API char *rz_str_append_owned(char *ptr, char *string) {
  */
 RZ_API RZ_OWN char *rz_str_append(RZ_OWN RZ_NULLABLE char *ptr, const char *string) {
 	if (string && !ptr) {
-		return strdup(string);
+		return rz_str_dup(string);
 	}
 	if (RZ_STR_ISEMPTY(string)) {
 		return ptr;
@@ -1267,7 +1267,7 @@ RZ_API char *rz_str_replace_icase(char *str, const char *key, const char *val, i
 		}
 
 		if (keep_case) {
-			char *tmp_val = strdup(val);
+			char *tmp_val = rz_str_dup(val);
 			char *str_case = rz_str_ndup(p, klen);
 			if (!tmp_val || !str_case) {
 				free(tmp_val);
@@ -1339,7 +1339,7 @@ RZ_API char *rz_str_replace_thunked(char *str, char *clean, int *thunk, int clen
 
 		int newo = thunk[i + klen] - thunk[i];
 		rz_str_ansi_filter(str_p, NULL, NULL, newo);
-		scnd = strdup(str_p + newo);
+		scnd = rz_str_dup(str_p + newo);
 		bias = vlen - newo;
 
 		slen += bias;
@@ -1369,7 +1369,7 @@ RZ_API char *rz_str_replace_in(char *str, ut32 sz, const char *key, const char *
 	if (!str || !key || !val) {
 		return NULL;
 	}
-	char *heaped = rz_str_replace(strdup(str), key, val, g);
+	char *heaped = rz_str_replace(rz_str_dup(str), key, val, g);
 	if (heaped) {
 		strncpy(str, heaped, sz);
 		free(heaped);
@@ -2257,7 +2257,7 @@ RZ_API char *rz_str_ansi_crop(const char *str, ut32 x, ut32 y, ut32 x2, ut32 y2)
 	size_t rz_len, str_len = 0, nr_of_lines = 0;
 	ut32 ch = 0, cw = 0;
 	if (x2 <= x || y2 <= y || !str) {
-		return strdup("");
+		return rz_str_dup("");
 	}
 	s = s_start = str;
 	while (*s) {
@@ -2682,7 +2682,7 @@ RZ_API char **rz_str_argv(const char *cmdline, int *_argc) {
 			cmdline_current++;
 		}
 		args[args_current++] = '\0';
-		argv[argc++] = strdup(&args[arg_begin]);
+		argv[argc++] = rz_str_dup(&args[arg_begin]);
 		if (argc >= argv_len) {
 			argv_len *= 2;
 			char **tmp = realloc(argv, argv_len * sizeof(char *));
@@ -3122,10 +3122,10 @@ RZ_API char *rz_str_prefix_all(const char *s, const char *pfx) {
 	int pfx_len = 0;
 
 	if (!s) {
-		return strdup(pfx);
+		return rz_str_dup(pfx);
 	}
 	if (!pfx) {
-		return strdup(s);
+		return rz_str_dup(s);
 	}
 	len = strlen(s);
 	pfx_len = strlen(pfx);
@@ -3238,9 +3238,9 @@ RZ_API char *rz_str_crop(const char *str, unsigned int x, unsigned int y,
 	char *r, *ret;
 	unsigned int ch = 0, cw = 0;
 	if (x2 < 1 || y2 < 1 || !str) {
-		return strdup("");
+		return rz_str_dup("");
 	}
-	r = ret = strdup(str);
+	r = ret = rz_str_dup(str);
 	while (*str) {
 		/* crop height */
 		if (ch >= y2) {
@@ -3332,7 +3332,7 @@ RZ_API RZ_OWN char *rz_str_repeat(const char *str, ut16 times) {
 	rz_return_val_if_fail(str, NULL);
 	int i;
 	if (times == 0) {
-		return strdup("");
+		return rz_str_dup("");
 	}
 	RzStrBuf *buf = rz_strbuf_new(str);
 	for (i = 1; i < times; i++) {
@@ -3431,7 +3431,7 @@ static RzList /*<char *>*/ *str_split_list_common(char *str, const char *c, int 
 	for (; e;) {
 		e = strstr(aux, c);
 		if (n > 0 && ++i > n) {
-			rz_list_append(lst, dup ? strdup(aux) : aux);
+			rz_list_append(lst, dup ? rz_str_dup(aux) : aux);
 			break;
 		}
 		if (e) {
@@ -3441,7 +3441,7 @@ static RzList /*<char *>*/ *str_split_list_common(char *str, const char *c, int 
 		if (trim) {
 			rz_str_trim(aux);
 		}
-		rz_list_append(lst, dup ? strdup(aux) : aux);
+		rz_list_append(lst, dup ? rz_str_dup(aux) : aux);
 		aux = e;
 	}
 	return lst;
@@ -3547,7 +3547,7 @@ RZ_API RZ_OWN RzList /*<char *>*/ *rz_str_split_list_regex(RZ_NONNULL char *str,
  */
 RZ_API RzList /*<char *>*/ *rz_str_split_duplist(const char *_str, const char *c, bool trim) {
 	rz_return_val_if_fail(_str && c, NULL);
-	char *str = strdup(_str);
+	char *str = rz_str_dup(_str);
 	RzList *res = str_split_list_common(str, c, 0, trim, true);
 	free(str);
 	return res;
@@ -3568,7 +3568,7 @@ RZ_API RzList /*<char *>*/ *rz_str_split_duplist(const char *_str, const char *c
  */
 RZ_API RzList /*<char *>*/ *rz_str_split_duplist_n(const char *_str, const char *c, int n, bool trim) {
 	rz_return_val_if_fail(_str && c, NULL);
-	char *str = strdup(_str);
+	char *str = rz_str_dup(_str);
 	RzList *res = str_split_list_common(str, c, n, trim, true);
 	free(str);
 	return res;
@@ -3589,7 +3589,7 @@ RZ_API RzList /*<char *>*/ *rz_str_split_duplist_n(const char *_str, const char 
  */
 RZ_API RZ_OWN RzList /*<char *>*/ *rz_str_split_duplist_n_regex(RZ_NONNULL const char *_str, RZ_NONNULL const char *r, int n, bool trim) {
 	rz_return_val_if_fail(_str && r, NULL);
-	char *str = strdup(_str);
+	char *str = rz_str_dup(_str);
 	RzRegex *regex = rz_regex_new(r, RZ_REGEX_EXTENDED, 0);
 	RzList *res = str_split_list_common_regex(str, regex, n, trim, true);
 	free(str);
@@ -3748,7 +3748,7 @@ RZ_API char *rz_str_highlight(char *str, const char *word, const char *color, co
 	ut32 l_reset = strlen(color_reset);
 	ut32 l_color = color ? strlen(color) : 0;
 	if (!color) {
-		return strdup(str);
+		return rz_str_dup(str);
 	}
 	if (!word || !*word) {
 		return rz_str_newf("%s%s%s", color, str, color_reset);
@@ -3800,7 +3800,7 @@ RZ_API char *rz_str_highlight(char *str, const char *word, const char *color, co
 			break;
 		}
 	}
-	return strdup(o);
+	return rz_str_dup(o);
 }
 
 RZ_API char *rz_str_from_ut64(ut64 val) {
@@ -3940,7 +3940,7 @@ RZ_API char *rz_str_scale(const char *s, int w, int h) {
 	// for now this function is ascii only (no utf8 or ansi escapes)
 	RzListIter *iter;
 	char *line;
-	char *str = strdup(s);
+	char *str = rz_str_dup(s);
 	RzList *lines = rz_str_split_list(str, "\n", 0);
 	int i, j;
 	int rows = 0;
@@ -3964,7 +3964,7 @@ RZ_API char *rz_str_scale(const char *s, int w, int h) {
 			linetext[j] = srcline[zoomedcol];
 		}
 		if (curline != zoomedline) {
-			rz_list_append(out, strdup(linetext));
+			rz_list_append(out, rz_str_dup(linetext));
 			curline = zoomedline;
 		}
 		memset(linetext, ' ', w);

--- a/librz/util/str_trim.c
+++ b/librz/util/str_trim.c
@@ -76,7 +76,7 @@ RZ_API char *rz_str_trim_lines(char *str) {
 }
 
 RZ_API char *rz_str_trim_dup(const char *str) {
-	char *a = strdup(str);
+	char *a = rz_str_dup(str);
 	rz_str_trim(a);
 	return a;
 }

--- a/librz/util/strbuf.c
+++ b/librz/util/strbuf.c
@@ -310,7 +310,7 @@ RZ_API ut8 *rz_strbuf_getbin(RzStrBuf *sb, int *len) {
 }
 
 static inline char *drain(RzStrBuf *sb) {
-	return sb->ptr ? sb->ptr : strdup(sb->buf);
+	return sb->ptr ? sb->ptr : rz_str_dup(sb->buf);
 }
 
 RZ_API RZ_OWN char *rz_strbuf_drain(RzStrBuf *sb) {

--- a/librz/util/subprocess.c
+++ b/librz/util/subprocess.c
@@ -895,7 +895,7 @@ static char **create_child_env(const char *envvars[], const char *envvals[], siz
 		return NULL;
 	}
 	for (size_t i = 0; i < size; i++) {
-		new_env[i] = strdup(environ[i]);
+		new_env[i] = rz_str_dup(environ[i]);
 	}
 	for (size_t i = 0; i <= new_env_size; i++) {
 		new_env[size + i] = NULL;

--- a/librz/util/sys.c
+++ b/librz/util/sys.c
@@ -307,7 +307,7 @@ RZ_API RzList /*<char *>*/ *rz_sys_dir(const char *path) {
 		if (list) {
 			list->free = free;
 			while ((entry = readdir(dir))) {
-				rz_list_append(list, strdup(entry->d_name));
+				rz_list_append(list, rz_str_dup(entry->d_name));
 			}
 		}
 		closedir(dir);
@@ -535,7 +535,7 @@ RZ_API int rz_sys_crash_handler(const char *cmd) {
 #endif
 
 	free(crash_handler_cmd);
-	crash_handler_cmd = strdup(cmd);
+	crash_handler_cmd = rz_str_dup(cmd);
 
 	rz_sys_sigaction(sig, signal_handler);
 #else
@@ -568,7 +568,7 @@ RZ_API char *rz_sys_getenv(const char *key) {
 		return NULL;
 	}
 	b = getenv(key);
-	return b ? strdup(b) : NULL;
+	return rz_str_dup(b);
 #endif
 }
 
@@ -919,7 +919,7 @@ RZ_API bool rz_sys_mkdir(const char *dir) {
 RZ_API bool rz_sys_mkdirp(const char *dir) {
 	bool ret = true;
 	char slash = RZ_SYS_DIR[0];
-	char *path = strdup(dir), *ptr = path;
+	char *path = rz_str_dup(dir), *ptr = path;
 	if (!path) {
 		RZ_LOG_ERROR("rz_sys_mkdirp: Unable to allocate memory\n");
 		return false;
@@ -1207,7 +1207,7 @@ RZ_API char *rz_sys_pid_to_path(int pid) {
 						RZ_LOG_ERROR("rz_sys_pid_to_path: Error calling rz_str_newf\n");
 						return NULL;
 					}
-					result = strdup(tmp);
+					result = rz_str_dup(tmp);
 					break;
 				}
 				free(dvc);
@@ -1227,7 +1227,7 @@ RZ_API char *rz_sys_pid_to_path(int pid) {
 	if (ret <= 0) {
 		return NULL;
 	}
-	return strdup(pathbuf);
+	return rz_str_dup(pathbuf);
 #else
 	int ret;
 #if __FreeBSD__ || __DragonFly__
@@ -1264,7 +1264,7 @@ RZ_API char *rz_sys_pid_to_path(int pid) {
 		}
 	} else {
 		char *sp;
-		char *xpath = strdup(getenv("PATH"));
+		char *xpath = rz_str_dup(getenv("PATH"));
 		char *path = strtok_r(xpath, ":", &sp);
 		struct stat st;
 
@@ -1316,7 +1316,7 @@ RZ_API char *rz_sys_pid_to_path(int pid) {
 	}
 	pathbuf[ret] = 0;
 #endif
-	return strdup(pathbuf);
+	return rz_str_dup(pathbuf);
 #endif
 }
 
@@ -1373,7 +1373,7 @@ RZ_API char *rz_sys_whoami(char *buf) {
 		buf = _buf;
 	}
 	sprintf(buf, "pid%d", pid);
-	return hasbuf ? buf : strdup(buf);
+	return hasbuf ? buf : rz_str_dup(buf);
 }
 
 RZ_API int rz_sys_getpid(void) {
@@ -1393,11 +1393,11 @@ RZ_API RSysInfo *rz_sys_info(void) {
 	if (uname(&un) != -1) {
 		RSysInfo *si = RZ_NEW0(RSysInfo);
 		if (si) {
-			si->sysname = strdup(un.sysname);
-			si->nodename = strdup(un.nodename);
-			si->release = strdup(un.release);
-			si->version = strdup(un.version);
-			si->machine = strdup(un.machine);
+			si->sysname = rz_str_dup(un.sysname);
+			si->nodename = rz_str_dup(un.nodename);
+			si->release = rz_str_dup(un.release);
+			si->version = rz_str_dup(un.version);
+			si->machine = rz_str_dup(un.machine);
 			return si;
 		}
 	}
@@ -1426,7 +1426,7 @@ RZ_API RSysInfo *rz_sys_info(void) {
 		type != REG_SZ) {
 		goto beach;
 	}
-	si->sysname = strdup(tmp);
+	si->sysname = rz_str_dup(tmp);
 
 	size = sizeof(major);
 	if (RegQueryValueExA(key, "CurrentMajorVersionNumber", NULL, &type,
@@ -1455,7 +1455,7 @@ RZ_API RSysInfo *rz_sys_info(void) {
 		type != REG_SZ) {
 		goto beach;
 	}
-	si->release = strdup(tmp);
+	si->release = rz_str_dup(tmp);
 beach:
 	RegCloseKey(key);
 	return si;
@@ -1805,7 +1805,7 @@ RZ_API int rz_sys_execl(const char *pathname, const char *arg, ...) {
 	}
 	va_end(count_args);
 	char **argv = RZ_NEWS0(char *, argc + 2);
-	argv[0] = strdup(pathname);
+	argv[0] = rz_str_dup(pathname);
 	for (i = 1; i <= argc; i++) {
 		argv[i] = va_arg(args, char *);
 	}
@@ -1826,7 +1826,7 @@ RZ_API int rz_sys_execl(const char *pathname, const char *arg, ...) {
 	}
 	va_end(count_args);
 	char **argv = RZ_NEWS0(char *, argc + 2);
-	argv[0] = strdup(pathname);
+	argv[0] = rz_str_dup(pathname);
 	for (i = 1; i <= argc; i++) {
 		argv[i] = va_arg(args, char *);
 	}
@@ -1863,7 +1863,7 @@ RZ_API int rz_sys_system(const char *command) {
 #include <spawn.h>
 RZ_API int rz_sys_system(const char *command) {
 	int argc;
-	char *cmd = strdup(command);
+	char *cmd = rz_str_dup(command);
 	char **argv = rz_str_argv(cmd, &argc);
 	if (argv) {
 		char *argv0 = rz_file_path(argv[0]);
@@ -1878,7 +1878,7 @@ RZ_API int rz_sys_system(const char *command) {
 #include <spawn.h>
 RZ_API int rz_sys_system(const char *command) {
 	if (!strchr(command, '|')) {
-		char **argv, *cmd = strdup(command);
+		char **argv, *cmd = rz_str_dup(command);
 		int rc, pid, argc;
 		char *isbg = strchr(cmd, '&');
 		// XXX this is hacky

--- a/librz/util/syscmd.c
+++ b/librz/util/syscmd.c
@@ -20,7 +20,7 @@ RZ_API RZ_OWN char *rz_syscmd_sort(RZ_NONNULL const char *file) {
 		p = file;
 	}
 	if (p && *p) {
-		char *filename = strdup(p);
+		char *filename = rz_str_dup(p);
 		rz_str_trim(filename);
 		char *data = rz_file_slurp(filename, NULL);
 		if (!data) {
@@ -49,7 +49,7 @@ RZ_API RZ_OWN char *rz_syscmd_head(RZ_NONNULL const char *file, int count) {
 		p = file;
 	}
 	if (p && *p) {
-		char *filename = strdup(p);
+		char *filename = rz_str_dup(p);
 		rz_str_trim(filename);
 		char *data = rz_file_slurp_lines(filename, 1, count);
 		if (!data) {
@@ -75,7 +75,7 @@ RZ_API RZ_OWN char *rz_syscmd_tail(RZ_NONNULL const char *file, int count) {
 		}
 	}
 	if (p && *p) {
-		char *filename = strdup(p);
+		char *filename = rz_str_dup(p);
 		rz_str_trim(filename);
 		char *data = rz_file_slurp_lines_from_bottom(filename, count);
 		if (!data) {
@@ -102,7 +102,7 @@ RZ_API RZ_OWN char *rz_syscmd_uniq(RZ_NONNULL const char *file) {
 		}
 	}
 	if (p && *p) {
-		char *filename = strdup(p);
+		char *filename = rz_str_dup(p);
 		rz_str_trim(filename);
 		char *data = rz_file_slurp(filename, NULL);
 		if (!data) {
@@ -141,8 +141,8 @@ RZ_API RZ_OWN char *rz_syscmd_join(RZ_NONNULL const char *file1, RZ_NONNULL cons
 		}
 	}
 	if (p1 && *p1 && p2 && *p2) {
-		char *filename1 = strdup(p1);
-		char *filename2 = strdup(p2);
+		char *filename1 = rz_str_dup(p1);
+		char *filename2 = rz_str_dup(p2);
 		rz_str_trim(filename1);
 		rz_str_trim(filename2);
 		char *data1 = rz_file_slurp(filename1, NULL);
@@ -163,7 +163,7 @@ RZ_API RZ_OWN char *rz_syscmd_join(RZ_NONNULL const char *file1, RZ_NONNULL cons
 			char *str1, *str2;
 			RzListIter *iter1, *iter2;
 			rz_list_foreach (list1, iter1, str1) {
-				char *field = strdup(str1); // extract comman field
+				char *field = rz_str_dup(str1); // extract comman field
 				char *end = strchr(field, ' ');
 				if (end) {
 					*end = '\0';
@@ -209,7 +209,7 @@ RZ_API RZ_OWN char *rz_syscmd_cat(RZ_NONNULL const char *file) {
 		}
 	}
 	if (p && *p) {
-		char *filename = strdup(p);
+		char *filename = rz_str_dup(p);
 		rz_str_trim(filename);
 		char *data = rz_file_slurp(filename, NULL);
 		if (!data) {
@@ -232,8 +232,8 @@ RZ_API RZ_OWN char *rz_syscmd_mkdir(RZ_NONNULL const char *dir) {
 	}
 	int ret;
 	char *dirname = (!strncmp(suffix, "-p ", 3))
-		? strdup(suffix + 3)
-		: strdup(suffix);
+		? rz_str_dup(suffix + 3)
+		: rz_str_dup(suffix);
 	rz_str_trim(dirname);
 	ret = rz_sys_mkdirp(dirname);
 	if (!ret && rz_sys_mkdir_failed()) {

--- a/librz/util/unum.c
+++ b/librz/util/unum.c
@@ -311,7 +311,7 @@ RZ_API ut64 rz_num_get(RZ_NULLABLE RzNum *num, RZ_NULLABLE const char *str) {
 		if (lodash) {
 			// Support 0x1000_f000_4000
 			// TODO: Only take underscores separated every 4 chars starting at the end
-			char *s = strdup(str + 2);
+			char *s = rz_str_dup(str + 2);
 			if (s) {
 				rz_str_replace_char(s, '_', 0);
 				errno = 0;
@@ -555,7 +555,7 @@ RZ_API int rz_num_to_trits(char *out, ut64 num) {
 }
 
 RZ_API int rz_num_conditional(RzNum *num, const char *str) {
-	char *lgt, *t, *p, *s = strdup(str);
+	char *lgt, *t, *p, *s = rz_str_dup(str);
 	int res = 0;
 	ut64 n, a, b;
 	p = s;
@@ -678,10 +678,10 @@ RZ_API char *rz_num_as_string(RzNum *___, ut64 n, bool printable_only) {
 		num >>= 8;
 	}
 	if (ret) {
-		return strdup(str);
+		return rz_str_dup(str);
 	}
 	if (!printable_only) {
-		return strdup("\\0");
+		return rz_str_dup("\\0");
 	}
 	return NULL;
 }
@@ -780,7 +780,7 @@ static ut64 rz_num_tailff(RzNum *num, const char *hex) {
 RZ_API int rz_num_between(RzNum *num, const char *input_value) {
 	int i;
 	ut64 ns[3];
-	char *const str = strdup(input_value);
+	char *const str = rz_str_dup(input_value);
 	RzList *nums = rz_num_str_split_list(str);
 	int len = rz_list_length(nums);
 	if (len < 3) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Replaces all the calls to `strdup` to `rz_str_dup`

Fix #4633 but does not fix the actual cause.