### PR TITLE
subprocess: Provide signal number on signal termination

### DIFF
--- a/librz/util/subprocess.c
+++ b/librz/util/subprocess.c
@@ -812,8 +812,10 @@ static void *sigchld_th(void *th) {
 
 			if (WIFEXITED(wstat)) {
 				proc->ret = WEXITSTATUS(wstat);
+			} else if (WIFSIGNALED(wstat)) {
+				proc->ret = -(WTERMSIG(wstat));
 			} else {
-				proc->ret = -1;
+				proc->ret = -128;
 			}
 			rz_th_sem_post(proc->ret_sem);
 			subprocess_unlock();


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr makes subprocess.c provide the signal number on subprocess signal termination through the subprocess' exit status.

Example output (11 here is Linux SIGSEGV though a strategically-placed `*(int *)0 = 1` in `binrz/rz-asm/rz-asm.c`):

![signal_11_exit_status](https://github.com/user-attachments/assets/5a7f057d-6198-497c-99f0-44b71ccf04a6)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change is appropriate and doesn't cause problems down the line.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
