### PR TITLE
Limit macos CI test threads to `hw.ncpu`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,13 @@ jobs:
           fi
           meson test -C build --suite integration
           cd test
-          rz-test -L -o results.json
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            echo "Mac"
+            rz-test -j `sysctl -n hw.ncpu` -L -o results.json
+          else
+            echo "Not Mac"
+            rz-test -L -o results.json
+          fi
         env:
           ASAN: ${{ matrix.asan }}
           ASAN_OPTIONS: ${{ matrix.asan_options }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,10 +293,8 @@ jobs:
           meson test -C build --suite integration
           cd test
           if [ "$RUNNER_OS" == "macOS" ]; then
-            echo "Mac"
             rz-test -j `sysctl -n hw.ncpu` -L -o results.json
           else
-            echo "Not Mac"
             rz-test -L -o results.json
           fi
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
       - name: Run integration tests and rz-test
         if: matrix.run_tests && matrix.enabled
         run: |
-          # Running the test suite
+          # Running the test suite 
           export PATH=${HOME}/bin:${HOME}/Library/Python/3.9/bin:${HOME}/Library/Python/3.10/bin:${HOME}/Library/Python/3.11/bin:${HOME}/Library/Python/3.12/bin:${HOME}/.local/bin:${PATH}
           export LD_LIBRARY_PATH=${HOME}/lib/$(uname -m)-linux-gnu:${HOME}/lib:${HOME}/lib64:${LD_LIBRARY_PATH}
           export PKG_CONFIG_PATH=${HOME}/lib/pkgconfig:${HOME}/lib/$(uname -m)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
       - name: Run integration tests and rz-test
         if: matrix.run_tests && matrix.enabled
         run: |
-          # Running the test suite 
+          # Running the test suite
           export PATH=${HOME}/bin:${HOME}/Library/Python/3.9/bin:${HOME}/Library/Python/3.10/bin:${HOME}/Library/Python/3.11/bin:${HOME}/Library/Python/3.12/bin:${HOME}/.local/bin:${PATH}
           export LD_LIBRARY_PATH=${HOME}/lib/$(uname -m)-linux-gnu:${HOME}/lib:${HOME}/lib64:${LD_LIBRARY_PATH}
           export PKG_CONFIG_PATH=${HOME}/lib/pkgconfig:${HOME}/lib/$(uname -m)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Based on https://github.com/rizinorg/rizin/pull/4657#issuecomment-2385529051, limiting the number of rz-test threads on `macos-meson-clang-tests` to `hw.ncpu` probably reduces the chance that the multithreading gremlins on the build fails an asm test (or 2).

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The asm tests on `macos-meson-clang-tests` do not fail because of SIGILL (4), or at least the failure rate drops to a nuisance level.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
