### PR TITLE
arch/xap: refactor the code up to rizin standard

### DIFF
--- a/librz/arch/isa/xap/dis.c
+++ b/librz/arch/isa/xap/dis.c
@@ -3,16 +3,9 @@
 // SPDX-FileCopyrightText: 2024 deroad <wargio@libero.it>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <fcntl.h>
-#include <string.h>
-#include <stdarg.h>
-#include <stdint.h>
-#include "dis.h"
-
 #include <rz_types.h>
 #include <rz_util/rz_assert.h>
+#include "dis.h"
 
 static int decode_fixed(xap_state_t *s, xap_directive_t *d) {
 	switch (d->opcode) {

--- a/librz/arch/isa/xap/dis.c
+++ b/librz/arch/isa/xap/dis.c
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2007 sorbo
 // SPDX-FileCopyrightText: 2010-2019 pancake <pancake@nopcode.org>
+// SPDX-FileCopyrightText: 2024 deroad <wargio@libero.it>
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <stdio.h>

--- a/librz/arch/isa/xap/dis.h
+++ b/librz/arch/isa/xap/dis.h
@@ -15,22 +15,6 @@ typedef struct instruction {
 	ut16 in_operand; // : 8;
 } xap_instruction_t;
 
-#if 0
-struct instruction {
-	ut16 in_mode : 2,
-		in_reg : 2,
-		in_opcode : 4,
-		in_operand : 8;
-#if __sun || defined(_MSC_VER)
-#ifndef _MSC_VER
-#warning XXX related to sunstudio :O
-#endif
-};
-#else
-} __packed;
-#endif
-#endif
-
 typedef struct directive {
 	ut16 opcode;
 	struct instruction d_inst;

--- a/librz/arch/isa/xap/dis.h
+++ b/librz/arch/isa/xap/dis.h
@@ -80,6 +80,7 @@ typedef struct state {
 #define INST_RTS   0x00E2
 #define INST_BRXL  0xfe09
 #define INST_BC    0xff09
+#define INST_BC2   0xfd09
 
 #define REG_AH 0
 #define REG_AL 1

--- a/librz/arch/isa/xap/dis.h
+++ b/librz/arch/isa/xap/dis.h
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2007 sorbo
 // SPDX-FileCopyrightText: 2010-2019 pancake <pancake@nopcode.org>
+// SPDX-FileCopyrightText: 2024 deroad <wargio@libero.it>
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #ifndef _INCLUDE_XAP_DIS_H_

--- a/librz/arch/isa/xap/dis.h
+++ b/librz/arch/isa/xap/dis.h
@@ -6,9 +6,16 @@
 #define _INCLUDE_XAP_DIS_H_
 
 #include <rz_types.h>
+#include <rz_util.h>
 
-#define __packed __attribute__((__packed__))
+typedef struct instruction {
+	ut16 in_mode; // : 2,
+	ut16 in_reg; // : 2,
+	ut16 in_opcode; // : 4,
+	ut16 in_operand; // : 8;
+} xap_instruction_t;
 
+#if 0
 struct instruction {
 	ut16 in_mode : 2,
 		in_reg : 2,
@@ -22,41 +29,41 @@ struct instruction {
 #else
 } __packed;
 #endif
+#endif
 
-struct directive {
+typedef struct directive {
+	ut16 opcode;
 	struct instruction d_inst;
 	int d_operand;
 	int d_prefix;
 	unsigned int d_off;
-	char d_asm[128];
+	RzStrBuf *d_asm;
 	struct directive *d_next;
-};
+} xap_directive_t;
 
-struct label {
+typedef struct label {
 	char l_name[128];
 	unsigned int l_off;
 	struct directive *l_refs[666];
 	int l_refc;
 	struct label *l_next;
-};
+} xap_label_t;
 
-struct state {
+typedef struct state {
 	int s_prefix;
 	unsigned int s_prefix_val;
-	FILE *s_in;
 	unsigned int s_off;
 	char *s_fname;
 	int s_u;
 	unsigned int s_labelno;
 	const unsigned char *s_buf;
-	struct directive s_dirs;
-	struct label s_labels;
-	FILE *s_out;
+	xap_directive_t s_dirs;
+	xap_label_t s_labels;
 	int s_format;
 	int s_nop;
-	struct directive *s_nopd;
+	xap_directive_t *s_nopd;
 	int s_ff_quirk;
-};
+} xap_state_t;
 
 #define MODE_MASK     3
 #define REG_SHIFT     2
@@ -87,6 +94,7 @@ struct state {
 #define ADDR_MODE_RELATIVE   0
 #define ADDR_MODE_X_RELATIVE 2
 
-static void xap_decode(struct state *s, struct directive *d);
+static void xap_decode(xap_state_t *s, xap_directive_t *d);
+static int xap_read_instruction(xap_state_t *s, xap_directive_t *d);
 
 #endif

--- a/librz/arch/p/analysis/analysis_xap.c
+++ b/librz/arch/p/analysis/analysis_xap.c
@@ -71,6 +71,9 @@ static int xap_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *
 	case INST_BC:
 		op->type = RZ_ANALYSIS_OP_TYPE_TRAP;
 		break;
+	case INST_BC2:
+		op->type = RZ_ANALYSIS_OP_TYPE_TRAP;
+		break;
 	case INST_BRXL:
 		op->type = RZ_ANALYSIS_OP_TYPE_TRAP;
 		break;

--- a/librz/arch/p/asm/asm_xap.c
+++ b/librz/arch/p/asm/asm_xap.c
@@ -7,11 +7,11 @@
 #include <rz_util.h>
 #include <rz_asm.h>
 
-static int arch_xap_disasm(RzStrBuf *asm_buf, const unsigned char *buf, ut64 seek) {
+static int arch_xap_disasm(RzStrBuf *asm_buf, const unsigned char *buf, ut64 addr) {
 	xap_state_t s = { 0 };
 	xap_directive_t d = { 0 };
 	s.s_buf = buf;
-	s.s_off = seek;
+	s.s_off = addr;
 	d.d_asm = asm_buf;
 	if (xap_read_instruction(&s, &d) > 0) {
 		xap_decode(&s, &d);

--- a/librz/arch/p/asm/asm_xap.c
+++ b/librz/arch/p/asm/asm_xap.c
@@ -7,20 +7,14 @@
 #include <rz_util.h>
 #include <rz_asm.h>
 
-static int arch_xap_disasm(char *str, const unsigned char *buf, ut64 seek) {
-	struct state *s = get_state();
-	struct directive *d;
-	memset(s, 0, sizeof(*s));
-	s->s_buf = buf;
-	s->s_off = seek;
-	s->s_out = NULL;
-	d = next_inst(s);
-	if (d != NULL) {
-		xap_decode(s, d);
-		strcpy(str, d->d_asm);
-		free(d);
-	} else {
-		*str = '\0';
+static int arch_xap_disasm(RzStrBuf *asm_buf, const unsigned char *buf, ut64 seek) {
+	xap_state_t s = { 0 };
+	xap_directive_t d = { 0 };
+	s.s_buf = buf;
+	s.s_off = seek;
+	d.d_asm = asm_buf;
+	if (xap_read_instruction(&s, &d) > 0) {
+		xap_decode(&s, &d);
 	}
 #if 0
 	if (s->s_ff_quirk) {
@@ -30,9 +24,8 @@ static int arch_xap_disasm(char *str, const unsigned char *buf, ut64 seek) {
 #endif
 	return 0;
 }
-static int disassemble(RzAsm *a, struct rz_asm_op_t *op, const ut8 *buf, int len) {
-	char *buf_asm = rz_strbuf_get(&op->buf_asm);
-	arch_xap_disasm(buf_asm, buf, a->pc);
+static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+	arch_xap_disasm(&op->buf_asm, buf, a->pc);
 	return (op->size = 2);
 }
 

--- a/test/db/analysis/xap
+++ b/test/db/analysis/xap
@@ -1,0 +1,40 @@
+NAME=xap2 example
+FILE=bins/xap/xap2_vm.app
+CMDS=<<EOF
+e asm.arch=xap
+e asm.bytes=true
+pd 30
+EOF
+EXPECT=<<EOF
+            0x00000000      4942           addc  X, @0x0042
+            0x00000002      7647           nadd  AL, @(0x0047, X)
+            0x00000004      416d           addc  AH, @0x006d
+            0x00000006      7070           nadd  AH, #0x0070
+            0x00000008      1800           ld    X, #0x0000
+            0x0000000a      0100           st    FLAGS, @(0x0000, Y)
+            0x0000000c      4bf4           addc  X, @(0xfff4, Y)
+            0x0000000e      bd1f           or    Y, @0x001f
+            0x00000010      9600           sdiv  @(0x0000, X)
+            0x00000012      d500           xor   AL, @0x0000
+            0x00000014      5d29           sub   Y, @0x0029
+            0x00000016      0100           st    FLAGS, @(0x0000, Y)
+            0x00000018      0030           
+            0x0000001a      0000           nop
+            0x0000001c      0c04           unknown
+        ,=< 0x0000001e      e703           blt   @(0x0003, Y)
+        |   0x00000020      47d6           addc  AL, @(0xffd6, Y)
+        |   0x00000022      0200           st    UX, @(0x0000, Y)
+        `-> 0x00000024      2014           print AH, #0x0014
+            0x00000026      8edb           cmp   Y, @(0xffdb, X)
+            0x00000028      0000           nop
+            0x0000002a      0000           nop
+        ,=< 0x0000002c      fc01           bcs   0x0001
+        |   0x0000002e      0000           nop
+        `-> 0x00000030      1409           ld    AL, #0x0009
+        ,=< 0x00000032      f411           beq   0x0011
+        |   0x00000034      0094           
+        |   0x00000036      10b4           ld    AH, #0xffb4
+        |   0x00000038      0005           
+        |   0x0000003a      1800           ld    X, #0x0000
+EOF
+RUN


### PR DESCRIPTION
# SQUASH ME

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Updates xap arch to use the latest api.
- Fixes output using RzStrBuf directly.
(Before)
![image](https://github.com/user-attachments/assets/17f5111b-2db7-457a-8dc2-8f8c514ecb84)
(After)
![image](https://github.com/user-attachments/assets/f789ddce-d4ea-49e8-beb9-7f242cf1e5fa)
- Removes useless global variable.
