### PR TITLE
macos ci: Use `hw.activecpu` instead of `hw.ncpu`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
           meson test -C build --suite integration
           cd test
           if [ "$RUNNER_OS" == "macOS" ]; then
-            rz-test -j `sysctl -n hw.ncpu` -L -o results.json
+            rz-test -j `sysctl -n hw.activecpu` -L -o results.json
           else
             rz-test -L -o results.json
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,9 +180,7 @@ jobs:
           fetch-depth: 2
       - name: Install pkg-config with Homebrew
         if: matrix.os == 'macos-12' && matrix.enabled
-        run: |
-          sysctl -n hw.activecpu
-          brew install pkg-config
+        run: brew install pkg-config
       - name: Install python and other dependencies
         if: (matrix.run_tests || matrix.build_system == 'meson') && matrix.os != 'macos-12' && matrix.enabled
         run: sudo apt-get --assume-yes install python3-wheel python3-setuptools libcapstone4 libcapstone-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,9 @@ jobs:
           fetch-depth: 2
       - name: Install pkg-config with Homebrew
         if: matrix.os == 'macos-12' && matrix.enabled
-        run: brew install pkg-config
+        run: |
+          sysctl -n hw.activecpu
+          brew install pkg-config
       - name: Install python and other dependencies
         if: (matrix.run_tests || matrix.build_system == 'meson') && matrix.os != 'macos-12' && matrix.enabled
         run: sudo apt-get --assume-yes install python3-wheel python3-setuptools libcapstone4 libcapstone-dev


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

As per https://github.com/apple-oss-distributions/xnu/blob/8d741a5de7ff4191bf97d57b9f54c2f6d4a15585/bsd/sys/sysctl.h#L1240-L1242, `hw.activecpu` should be used instead of `hw.ncpu` to set the number of threads in the macos build.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The macos build is green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
