### PR TITLE
Fix missing declaration of struct timezone.

### DIFF
--- a/librz/include/rz_util/rz_time.h
+++ b/librz/include/rz_util/rz_time.h
@@ -24,6 +24,7 @@ struct rz_timezone {
 	int tz_dsttime; /* type of dst correction */
 };
 #else
+#include <sys/time.h>
 #define rz_timezone timezone
 #endif
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes a bug where on certain configs `struct timezone` is not defined.

Example of warning:
```
[14/17] Compiling C object libcore_pdd.so.p/c_jsdec-plugin.c.o
In file included from /usr/local/include/librz/rz_util.h:37,
                 from /usr/local/include/librz/rz_cmd.h:5,
                 from ../c/jsdec-plugin.c:8:
/usr/local/include/librz/rz_util/rz_time.h:27:21: warning: ‘struct timezone’ declared inside parameter list will not be visible outside of this definition or declaration
   27 | #define rz_timezone timezone
      |                     ^~~~~~~~
/usr/local/include/librz/rz_util/rz_time.h:30:59: note: in expansion of macro ‘rz_timezone’
   30 | RZ_API int rz_time_gettimeofday(struct timeval *p, struct rz_timezone *tz);
      |                                                           ^~~~~~~~~~~
```