### PR TITLE
struct timezone is obsolete/deprecated

### DIFF
--- a/librz/include/rz_util/rz_time.h
+++ b/librz/include/rz_util/rz_time.h
@@ -18,17 +18,9 @@ extern "C" {
 
 #ifdef _MSC_VER
 struct timeval;
-
-struct rz_timezone {
-	int tz_minuteswest; /* minutes W of Greenwich */
-	int tz_dsttime; /* type of dst correction */
-};
-#else
-#include <sys/time.h>
-#define rz_timezone timezone
 #endif
 
-RZ_API int rz_time_gettimeofday(struct timeval *p, struct rz_timezone *tz);
+RZ_API int rz_time_gettimeofday(struct timeval *p);
 
 // wall clock time in microseconds
 RZ_API ut64 rz_time_now(void);

--- a/librz/util/time.c
+++ b/librz/util/time.c
@@ -23,13 +23,11 @@
  * information.
  *
  * \param p Pointer to a \p timeval structure that will be filled by this function
- * \param tz Pointer to a \p rz_timezone structure that will be filled by this function
  * \return 0 if the function succeeds, -1 on error
  */
-RZ_API int rz_time_gettimeofday(struct timeval *p, struct rz_timezone *tz) {
+RZ_API int rz_time_gettimeofday(struct timeval *p) {
 	// ULARGE_INTEGER ul; // As specified on MSDN.
 	ut64 ul = 0;
-	static int tzflag = 0;
 	FILETIME ft = { 0 };
 	if (p) {
 		// Returns a 64-bit value representing the number of
@@ -54,14 +52,6 @@ RZ_API int rz_time_gettimeofday(struct timeval *p, struct rz_timezone *tz) {
 		p->tv_sec = (long)(ul / 1000000LL);
 		p->tv_usec = (long)(ul % 1000000LL);
 	}
-	if (tz) {
-		if (!tzflag) {
-			_tzset();
-			tzflag++;
-		}
-		tz->tz_minuteswest = _timezone / 60;
-		tz->tz_dsttime = _daylight;
-	}
 	return 0;
 }
 #else
@@ -72,11 +62,11 @@ RZ_API int rz_time_gettimeofday(struct timeval *p, struct rz_timezone *tz) {
  * information.
  *
  * \param p Pointer to a \p timeval structure that will be filled by this function
- * \param tz Pointer to a \p rz_timezone structure that will be filled by this function
  * \return 0 if the function succeeds, -1 on error
  */
-RZ_API int rz_time_gettimeofday(struct timeval *p, struct rz_timezone *tz) {
-	return gettimeofday(p, tz);
+RZ_API int rz_time_gettimeofday(struct timeval *p) {
+	// struct timezone is obsolete and shall not be used.
+	return gettimeofday(p, NULL);
 }
 #endif
 
@@ -93,7 +83,7 @@ RZ_API int rz_time_gettimeofday(struct timeval *p, struct rz_timezone *tz) {
 RZ_API ut64 rz_time_now(void) {
 	ut64 ret;
 	struct timeval now;
-	rz_time_gettimeofday(&now, NULL);
+	rz_time_gettimeofday(&now);
 	ret = now.tv_sec * RZ_USEC_PER_SEC;
 	ret += now.tv_usec;
 	return ret;

--- a/test/unit/test_analysis_block.c
+++ b/test/unit/test_analysis_block.c
@@ -998,7 +998,7 @@ int all_tests() {
 
 int main(int argc, char **argv) {
 	struct timeval tv;
-	rz_time_gettimeofday(&tv, NULL);
+	rz_time_gettimeofday(&tv);
 	unsigned int seed = argc > 1 ? strtoul(argv[1], NULL, 0) : tv.tv_sec + tv.tv_usec;
 	printf("seed for test_analysis_block: %u\n", seed);
 	return all_tests();

--- a/test/unit/test_intervaltree.c
+++ b/test/unit/test_intervaltree.c
@@ -341,7 +341,7 @@ int all_tests() {
 
 int main(int argc, char **argv) {
 	struct timeval tv;
-	rz_time_gettimeofday(&tv, NULL);
+	rz_time_gettimeofday(&tv);
 	unsigned int seed = argc > 1 ? strtoul(argv[1], NULL, 0) : tv.tv_sec + tv.tv_usec;
 	printf("seed for test_intervaltree: %u\n", seed);
 	srand(seed);


### PR DESCRIPTION
https://man7.org/linux/man-pages/man2/gettimeofday.2.html

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

This removes `struct timezone` which is deprecated/obsolete.
We do not really use it and can be safely removed; as per documentation we will always pass `NULL` to `gettimeofday` instead of a valid `struct timezone` pointer.