### PR TITLE
ci: Remove macos-12 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
           [
             linux-meson-clang-tests,
             linux-meson-gcc-tests,
-            macos-meson-clang-tests,
             linux-gcc-tests-asan,
             linux-clang-tests-asan,
             linux-gcc-tests-codecov,
@@ -84,15 +83,6 @@ jobs:
             enabled: ${{ needs.changes.outputs.edited == 'true' }}
             timeout: 45
             cflags: "-DRZ_ASSERT_STDOUT=1 -Wno-cpp"
-            allow_failure: false
-          - name: macos-meson-clang-tests
-            os: macos-12
-            build_system: meson
-            compiler: clang
-            run_tests: true
-            meson_options: -Dbuildtype=release --werror
-            enabled: ${{ needs.changes.outputs.edited == 'true' }}
-            timeout: 60
             allow_failure: false
           - name: linux-gcc-tests-asan
             os: ubuntu-22.04


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Both Intel Macs and the GitHub macos-12 image are going the way of the dodo and since there is woodpecker for mac arm builds, this pr removes the `macos-meson-clang-tests` build.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The removal is appropriate.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
