### PR TITLE
Print the max number of lines as default in pd

### DIFF
--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -3275,16 +3275,22 @@ RZ_IPI RzCmdStatus rz_cmd_disassembly_n_bytes_handler(RzCore *core, int argc, co
 }
 
 RZ_IPI RzCmdStatus rz_cmd_disassembly_n_instructions_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
+	int n_instrs = 0;
 	if (argc <= 1) {
-		RZ_LOG_ERROR("Invalid number of arguments\n");
-		return RZ_CMD_STATUS_ERROR;
+		// when no arg, we always use the rows number of the terminal
+		// no args must be always positive, if is not we use 16
+		n_instrs = rz_num_get(core->num, "$r");
+		if (n_instrs < 1) {
+			n_instrs = 16;
+		}
+	} else {
+		n_instrs = (int)rz_num_math(core->num, argv[1]);
+		if (n_instrs == 0) {
+			RZ_LOG_ERROR("The argument cannot be zero\n");
+			return RZ_CMD_STATUS_ERROR;
+		}
 	}
-	int n_instrs = (int)rz_num_math(core->num, argv[1]);
-	if (n_instrs == 0) {
-		RZ_LOG_ERROR("The argument cannot be zero\n");
-		return RZ_CMD_STATUS_ERROR;
-	}
-	return bool2status(core_disassembly(core, argc > 1 && n_instrs == 0 ? 0 : (int)core->blocksize, n_instrs, state, false));
+	return bool2status(core_disassembly(core, argc > 1 ? (int)core->blocksize : 0, n_instrs, state, false));
 }
 
 RZ_IPI RzCmdStatus rz_cmd_disassembly_all_possible_opcodes_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Seems that `pd` had a regression. `pd` has an **optional** argument but we always fail when not given, thus this reverts back the changes and allows to print with a default value equivalent of the max rows number of the terminal (when this fails, then we use 16).