### PR TITLE
 Fix meson-build global_arguments

### DIFF
--- a/.github/subproject_test/meson.build
+++ b/.github/subproject_test/meson.build
@@ -1,0 +1,53 @@
+project('subpoj_tester', 'c')
+
+rz_deps = [
+  dependency('rz_core'),
+  dependency('rz_reg'),
+  dependency('rz_flag'),
+  dependency('rz_hash'),
+  dependency('rz_bin'),
+  dependency('rz_bp'),
+  dependency('rz_io'),
+  dependency('rz_search'),
+  dependency('rz_sign'),
+  dependency('rz_cons'),
+  dependency('rz_lang'),
+  dependency('rz_socket'),
+  dependency('rz_type'),
+  dependency('rz_debug'),
+  dependency('rz_il'),
+  dependency('rz_demangler'),
+  dependency('rz_util'),
+  dependency('rz_main'),
+  dependency('rz_crypto'),
+  dependency('rz_config'),
+  dependency('rz_egg'),
+  dependency('rz_syscall'),
+  dependency('rz_magic'),
+  ]
+
+tester_source = custom_target('main.c',
+  command: ['echo', '''
+#include <rz_core.h>
+
+int main(void) {
+    RzCore *core = rz_core_new();
+    rz_cons_printf("hello world\n");
+    rz_core_free(core);
+    return 0;
+}
+  '''],
+  output: 'main.c',
+  capture: true,
+  )
+
+
+subproj_tester = executable('subproj_tester',
+           tester_source,
+           dependencies: rz_deps,
+           pie: true,
+           )
+
+test('basic', subproj_tester)
+
+

--- a/.github/subproject_test/subprojects/rizin.wrap
+++ b/.github/subproject_test/subprojects/rizin.wrap
@@ -1,0 +1,36 @@
+[wrap-git]
+
+url=${REPOSITORY}
+revision=${BRANCH}
+
+depth = 1
+
+[provide]
+rz_core = rz_core_dep
+rz_reg = rz_reg_dep
+rz_flag = rz_flag_dep
+rz_hash = rz_hash_dep
+rz_bin = rz_bin_dep
+rz_bp = rz_bp_dep
+rz_io = rz_io_dep
+rz_search = rz_search_dep
+rz_sign = rz_sign_dep
+rz_cons = rz_cons_dep
+rz_lang = rz_lang_dep
+rz_socket = rz_socket_dep
+rz_type = rz_type_dep
+rz_debug = rz_debug_dep
+#rz_ghidra = rz_ghidra_dep
+rz_il = rz_il_dep
+rz_demangler = rz_demangler_dep
+rz_util = rz_util_dep
+rz_main = rz_main_dep
+rz_asm = rz_asm_dep
+rz_crypto = rz_crypto_dep
+rz_config = rz_config_dep
+rz_egg = rz_egg_dep
+rz_syscall = rz_syscall_dep
+rz_magic = rz_magic_dep
+rz_parse = rz_parse_dep
+rz_analysis = rz_analysis_dep
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1061,3 +1061,31 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+  meson-subproject:
+    name: Test use as meson subproject
+    needs: [ build-and-test ]
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo apt-get --assume-yes update
+        sudo apt-get --assume-yes install python3-wheel python3-setuptools pkgconf libcurl4-openssl-dev libpkgconf-dev libarchive-dev
+        sudo python3 -m pip install ninja meson
+    - name: Replace branch in wrap-file
+      run: |
+        # NOTE: This is a workaround, as meson wrap files cannot be used on remote tracking
+        git checkout -b "_ci_local_branch"
+        sed -i 's@\${REPOSITORY}@file://'"$PWD"'@' .github/subproject_test/subprojects/rizin.wrap
+        sed -i 's@\${BRANCH}@_ci_local_branch@' .github/subproject_test/subprojects/rizin.wrap
+    - name: Meson setup
+      run: meson setup build .github/subproject_test/
+    - name: Checkout our Testsuite Binaries
+      uses: actions/checkout@v4
+      with:
+          repository: rizinorg/rizin-testbins
+          path: .github/subproject_teyt/subprojects/rizin/test/bins
+    - name: Ninja compile and install
+      run: ninja -C build && sudo meson install -C build
+    - name: Run unit tests
+      run: meson test -C build

--- a/meson.build
+++ b/meson.build
@@ -84,10 +84,10 @@ endif
 # Hence, we have to disable them for the newer once.
 # Older compilers don't have these warnings and should not be included with #pragma
 if cc.has_argument('-Wenum-conversion')
-  add_global_arguments('-DCC_SUPPORTS_W_ENUM_CONVERION', language: ['c', 'cpp'])
+  add_project_arguments('-DCC_SUPPORTS_W_ENUM_CONVERION', language: ['c', 'cpp'])
 endif
 if cc.has_argument('-Wenum-compare')
-  add_global_arguments('-DCC_SUPPORTS_W_ENUM_COMPARE', language: ['c', 'cpp'])
+  add_project_arguments('-DCC_SUPPORTS_W_ENUM_COMPARE', language: ['c', 'cpp'])
 endif
 
 if cc.has_argument('--std=gnu99')

--- a/test/integration/meson.build
+++ b/test/integration/meson.build
@@ -1,10 +1,6 @@
-if get_option('enable_tests')
+if get_option('enable_tests') and cli_enabled
   test_conf_data = configuration_data()
-  if cli_enabled
-    test_conf_data.set_quoted('RIZIN_BUILD_PATH', rizin_exe.full_path())
-  else
-    test_conf_data.set_quoted('RIZIN_BUILD_PATH', meson.current_build_dir())
-  endif
+  test_conf_data.set_quoted('RIZIN_BUILD_PATH', rizin_exe.full_path())
   test_conf_data.set_quoted('TEST_BUILD_TYPES_DIR', fs.as_posix(types_build_dir))
   test_config_h = configure_file(
     input: 'test_config.h.in',


### PR DESCRIPTION
* Added a CI-task to check if rizin could be used as subproject
* Fixed some new global-arguments in meson-build

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

It happened again...
* While https://github.com/rizinorg/rizin/pull/4684 was merged,
* https://github.com/rizinorg/rizin/pull/4691 added global-arguments to the meson builds

This makes it (again) impossible to add rizin as subproject.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

To avoid any further regressions, a CI-Task is proposed herein.

The task really just tests if it is possible to use a branch/PR of rizin as subproject. It (currently) wouldn't check for any linker-problems or API-stability as there is no such guaranty in that setup.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Partially addresses https://github.com/rizinorg/rizin/issues/3454

Also:
- The integration tests will be excluded herein, if rizins CLI is disabled by build-configuration. In this case no rizin-binary is available that could be used for the Integration-tests.