### PR TITLE
ci: use `muon-bootstrap` name for bootstrap

### DIFF
--- a/.github/workflows/muon.yml
+++ b/.github/workflows/muon.yml
@@ -55,7 +55,7 @@ jobs:
       working-directory: muon
       run: |
           ./bootstrap.sh build
-          build/muon setup build
+          build/muon-bootstrap setup build
           ninja -C build
           sudo cp build/muon /usr/bin/muon
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

See https://git.sr.ht/~lattis/muon/commit/6ec469bb42b28f3a1943d58c0e15a8493220c2f7

**Test plan**

CI is green
