### PR TITLE
Use blocksize to determine size for rz_cmd_disassembly_n_bytes_handler()

### DIFF
--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -3262,7 +3262,7 @@ static bool core_disassembly(RzCore *core, int n_bytes, int n_instrs, RzCmdState
 }
 
 RZ_IPI RzCmdStatus rz_cmd_disassembly_n_bytes_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
-	int n_bytes = argc > 1 ? (int)rz_num_math(core->num, argv[1]) : core->blocksize;
+	ut64 n_bytes = argc > 1 ? (int)rz_num_math(core->num, argv[1]) : core->blocksize;
 	if (n_bytes == 0) {
 		RZ_LOG_ERROR("The argument cannot be zero\n");
 		return RZ_CMD_STATUS_ERROR;

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -3262,11 +3262,7 @@ static bool core_disassembly(RzCore *core, int n_bytes, int n_instrs, RzCmdState
 }
 
 RZ_IPI RzCmdStatus rz_cmd_disassembly_n_bytes_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
-	if (argc <= 1) {
-		RZ_LOG_ERROR("Invalid number of arguments\n");
-		return RZ_CMD_STATUS_ERROR;
-	}
-	int n_bytes = (int)rz_num_math(core->num, argv[1]);
+	int n_bytes = argc > 1 ? (int)rz_num_math(core->num, argv[1]) : core->blocksize;
 	if (n_bytes == 0) {
 		RZ_LOG_ERROR("The argument cannot be zero\n");
 		return RZ_CMD_STATUS_ERROR;

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -3262,7 +3262,7 @@ static bool core_disassembly(RzCore *core, int n_bytes, int n_instrs, RzCmdState
 }
 
 RZ_IPI RzCmdStatus rz_cmd_disassembly_n_bytes_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
-	ut64 n_bytes = argc > 1 ? (int)rz_num_math(core->num, argv[1]) : core->blocksize;
+	ut64 n_bytes = argc > 1 ? (ut64)rz_num_math(core->num, argv[1]) : core->blocksize;
 	if (n_bytes == 0) {
 		RZ_LOG_ERROR("The argument cannot be zero\n");
 		return RZ_CMD_STATUS_ERROR;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Commands like pD are accepts optional argument, but rz_cmd_disassembly_n_bytes_handler() requires it. Add current core->blocksize as failback to help calculating correct size.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Current dev threats no args `pD` as error, but rizin book and `pD?` states that should be correct command:
```
[0x00001100]> bf sym.main
[0x00001100]> pD @ sym.main
ERROR: Invalid number of arguments
```
After applied changes `pD` should correctly dump file without optional argument:

```
[0x00001100]> bf sym.main
[0x00001100]> pD @ sym.main
            ;-- main:
            0x000011e9      endbr64
            0x000011ed      push  rbp
            0x000011ee      mov   rbp, rsp
            0x000011f1      sub   rsp, 0x40
            0x000011f5      mov   dword [rbp - 0x34], edi
            0x000011f8      mov   qword [rbp - 0x40], rsi
...
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
