### PR TITLE
Remove `-Wno-deprecated-non-prototype` from macos build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,6 @@ jobs:
             meson_options: -Dbuildtype=release --werror
             enabled: ${{ needs.changes.outputs.edited == 'true' }}
             timeout: 60
-            cflags: "-Wno-deprecated-non-prototype"
             allow_failure: false
           - name: linux-gcc-tests-asan
             os: ubuntu-22.04

--- a/subprojects/libdemangle.wrap
+++ b/subprojects/libdemangle.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 url = https://github.com/rizinorg/rz-libdemangle.git
-revision = 0031d1aff54fd6e922d7600425284513d32dec65
+revision = e1bbcb889e704c36d42d33cbac132f3c5f5fe91d
 depth = 1


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

As a follow-on from rizinorg/rz-libdemangle#66, this pr removes the need for `-Wno-deprecated-non-prototype` from the macos build by updating libdemangle.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
