### PR TITLE
Improved performance of rz_bv_copy_nbits and rz_bv_set_range

### DIFF
--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -4,6 +4,7 @@
 #include "rz_util.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <limits.h>
 
 #define NELEM(N, ELEMPER) ((N + (ELEMPER)-1) / (ELEMPER))
 #define BV_ELEM_SIZE      8U
@@ -209,25 +210,62 @@ RZ_API ut32 rz_bv_copy(RZ_NONNULL const RzBitVector *src, RZ_NONNULL RzBitVector
  * \param nbit ut32, control the size of copy (in bits)
  * \return copied_size ut32, Actual copied size
  */
+
 RZ_API ut32 rz_bv_copy_nbits(RZ_NONNULL const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
-	rz_return_val_if_fail(src && dst, 0);
+    rz_return_val_if_fail(src && dst, 0);
 
-	ut32 max_nbit = RZ_MIN((src->len - src_start_pos),
-		(dst->len - dst_start_pos));
+    // Determine the chunk size (word size) dynamically
+    const ut32 chunk_size = sizeof(unsigned long) * CHAR_BIT; // Word size in bits
+    ut32 max_nbit = RZ_MIN((src->len - src_start_pos), (dst->len - dst_start_pos));
 
-	// prevent overflow
-	if (max_nbit < nbit) {
-		return 0;
-	}
+    if (max_nbit < nbit) {
+        return 0;
+    }
 
-	// normal case here
-	for (ut32 i = 0; i < nbit; ++i) {
-		bool c = rz_bv_get(src, src_start_pos + i);
-		rz_bv_set(dst, dst_start_pos + i, c);
-	}
+    ut32 bits_copied = 0;
 
-	return nbit;
+    // Handle unaligned prefix
+    while ((src_start_pos % chunk_size != 0 || dst_start_pos % chunk_size != 0) && nbit > 0) {
+        bool bit = rz_bv_get(src, src_start_pos++);
+        rz_bv_set(dst, dst_start_pos++, bit);
+        --nbit;
+        ++bits_copied;
+    }
+
+    // Process aligned chunks
+    while (nbit >= chunk_size) {
+        // Get chunks from the source and destination
+        unsigned long src_chunk = rz_bv_get_chunk(src, src_start_pos / chunk_size);
+        unsigned long dst_chunk = rz_bv_get_chunk(dst, dst_start_pos / chunk_size);
+
+        // Create a mask for the bits to copy
+        unsigned long mask = (1UL << chunk_size) - 1;
+        if (nbit < chunk_size) {
+            mask = (1UL << nbit) - 1;
+        }
+
+        // Merge chunks using the optimized approach
+        unsigned long result = dst_chunk ^ ((dst_chunk ^ src_chunk) & mask);
+        rz_bv_set_chunk(dst, dst_start_pos / chunk_size, result);
+
+        src_start_pos += chunk_size;
+        dst_start_pos += chunk_size;
+        nbit -= chunk_size;
+        bits_copied += chunk_size;
+    }
+
+    // Handle remaining unaligned suffix bits
+    while (nbit > 0) {
+        bool bit = rz_bv_get(src, src_start_pos++);
+        rz_bv_set(dst, dst_start_pos++, bit);
+        --nbit;
+        ++bits_copied;
+    }
+
+    return bits_copied;
 }
+
+
 
 /**
  * Return a new bitvector prepended with bv with n zero bits
@@ -1480,17 +1518,42 @@ RZ_API ut64 rz_bv_to_ut64(RZ_NONNULL const RzBitVector *x) {
  * \return return true if success, else return false
  */
 RZ_API bool rz_bv_set_range(RZ_NONNULL RzBitVector *bv, ut32 pos_start, ut32 pos_end, bool b) {
-	rz_return_val_if_fail(bv, false);
-	if (pos_start > bv->len - 1 || pos_end > bv->len - 1) {
-		return false;
-	}
+    rz_return_val_if_fail(bv, false);
 
-	for (ut32 i = pos_start; i <= pos_end; ++i) {
-		rz_bv_set(bv, i, b);
-	}
+    if (pos_start > bv->len - 1 || pos_end > bv->len - 1 || pos_start > pos_end) {
+        return false;
+    }
 
-	return true;
+    // Determine the chunk size dynamically
+    const ut32 chunk_size = sizeof(unsigned long) * CHAR_BIT;
+
+    // Handle unaligned prefix bits
+    while (pos_start < pos_end && pos_start % chunk_size != 0) {
+        rz_bv_set(bv, pos_start++, b);
+    }
+
+    // Process aligned chunks
+    if (pos_start < pos_end) {
+        ut32 chunk_start = pos_start / chunk_size;
+        ut32 chunk_end = pos_end / chunk_size;
+
+        unsigned long fill_value = b ? ~0UL : 0UL;
+
+        for (ut32 i = chunk_start; i < chunk_end; ++i) {
+            rz_bv_set_chunk(bv, i, fill_value);
+        }
+
+        pos_start = chunk_end * chunk_size;
+    }
+
+    // Handle remaining unaligned suffix bits
+    while (pos_start <= pos_end) {
+        rz_bv_set(bv, pos_start++, b);
+    }
+
+    return true;
 }
+
 
 /**
  * check if bitvector's bits are all set to bit 1

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -9,6 +9,7 @@
 #define NELEM(N, ELEMPER) ((N + (ELEMPER)-1) / (ELEMPER))
 #define BV_ELEM_SIZE      8U
 #define RZ_BV_CHUNK_SIZE  (sizeof(unsigned long) * CHAR_BIT)
+#define SIZE_OF_UNSIGNED_LONG sizeof(unsigned long)
 
 // optimization for reversing 8 bits which uses 32 bits
 // https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith32Bits

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -263,7 +263,6 @@ RZ_API ut32 rz_bv_copy_nbits(RZ_NONNULL const RzBitVector *src, ut32 src_start_p
         rz_bv_set(dst, dst_start_pos++, bit);
         --nbit;
     }
-
     return nbit_original;
 }
 

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -209,25 +209,63 @@ RZ_API ut32 rz_bv_copy(RZ_NONNULL const RzBitVector *src, RZ_NONNULL RzBitVector
  * \param nbit ut32, control the size of copy (in bits)
  * \return copied_size ut32, Actual copied size
  */
+#include <limits.h> // For CHAR_BIT
+
 RZ_API ut32 rz_bv_copy_nbits(RZ_NONNULL const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
-	rz_return_val_if_fail(src && dst, 0);
+    rz_return_val_if_fail(src && dst, 0);
 
-	ut32 max_nbit = RZ_MIN((src->len - src_start_pos),
-		(dst->len - dst_start_pos));
+    // Determine the chunk size (word size) dynamically
+    const ut32 chunk_size = sizeof(unsigned long) * CHAR_BIT; // Word size in bits
+    ut32 max_nbit = RZ_MIN((src->len - src_start_pos), (dst->len - dst_start_pos));
 
-	// prevent overflow
-	if (max_nbit < nbit) {
-		return 0;
-	}
+    if (max_nbit < nbit) {
+        return 0;
+    }
 
-	// normal case here
-	for (ut32 i = 0; i < nbit; ++i) {
-		bool c = rz_bv_get(src, src_start_pos + i);
-		rz_bv_set(dst, dst_start_pos + i, c);
-	}
+    ut32 bits_copied = 0;
 
-	return nbit;
+    // Handle unaligned prefix
+    while ((src_start_pos % chunk_size != 0 || dst_start_pos % chunk_size != 0) && nbit > 0) {
+        bool bit = rz_bv_get(src, src_start_pos++);
+        rz_bv_set(dst, dst_start_pos++, bit);
+        --nbit;
+        ++bits_copied;
+    }
+
+    // Process aligned chunks
+    while (nbit >= chunk_size) {
+        // Get chunks from the source and destination
+        unsigned long src_chunk = rz_bv_get_chunk(src, src_start_pos / chunk_size);
+        unsigned long dst_chunk = rz_bv_get_chunk(dst, dst_start_pos / chunk_size);
+
+        // Create a mask for the bits to copy
+        unsigned long mask = (1UL << chunk_size) - 1;
+        if (nbit < chunk_size) {
+            mask = (1UL << nbit) - 1;
+        }
+
+        // Merge chunks using the optimized approach
+        unsigned long result = dst_chunk ^ ((dst_chunk ^ src_chunk) & mask);
+        rz_bv_set_chunk(dst, dst_start_pos / chunk_size, result);
+
+        src_start_pos += chunk_size;
+        dst_start_pos += chunk_size;
+        nbit -= chunk_size;
+        bits_copied += chunk_size;
+    }
+
+    // Handle remaining unaligned suffix bits
+    while (nbit > 0) {
+        bool bit = rz_bv_get(src, src_start_pos++);
+        rz_bv_set(dst, dst_start_pos++, bit);
+        --nbit;
+        ++bits_copied;
+    }
+
+    return bits_copied;
 }
+
+
 
 /**
  * Return a new bitvector prepended with bv with n zero bits

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -4,6 +4,7 @@
 #include "rz_util.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <limits.h>
 
 #define NELEM(N, ELEMPER) ((N + (ELEMPER)-1) / (ELEMPER))
 #define BV_ELEM_SIZE      8U
@@ -209,7 +210,6 @@ RZ_API ut32 rz_bv_copy(RZ_NONNULL const RzBitVector *src, RZ_NONNULL RzBitVector
  * \param nbit ut32, control the size of copy (in bits)
  * \return copied_size ut32, Actual copied size
  */
-#include <limits.h> // For CHAR_BIT
 
 RZ_API ut32 rz_bv_copy_nbits(RZ_NONNULL const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
     rz_return_val_if_fail(src && dst, 0);

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -1123,43 +1123,23 @@ bool test_rz_bv_copy_nbits(void) {
 	rz_bv_set(src, src->len - 1, true);
 	rz_bv_set(src, src->len - 3, true);
 
-	// Test 1: Copy part of src to a smaller destination
+	/// copy part of bv to a new one with the same size
 	RzBitVector *small = rz_bv_new(part_sz);
 	actual_copy = rz_bv_copy_nbits(src, 0, small, 0, part_sz);
-	mu_assert_eq(actual_copy, part_sz, "copy part_sz to small");
-	mu_assert_streq_free(rz_bv_as_string(small), "11111111", "copy nbits to small bv");
+	mu_assert_eq(actual_copy, part_sz, "copy part_sz to normal");
+	mu_assert_streq_free(rz_bv_as_string(small), "11111111", "copy nbits small bv");
 
-	// Test 2: Copy part of src to a destination of the same size
+	/// copy part of bv to a new one which has more spaces
 	RzBitVector *normal = rz_bv_new(size);
 	actual_copy = rz_bv_copy_nbits(src, 0, normal, 0, part_sz);
-	mu_assert_eq(actual_copy, part_sz, "copy part_sz to normal");
-	mu_assert_streq_free(rz_bv_as_string(normal), "00000000000011111111", "copy nbits to normal bv");
+	mu_assert_eq(actual_copy, part_sz, "copy part_sz bits to normal");
+	mu_assert_streq_free(rz_bv_as_string(normal), "00000000000011111111", "copy nbits normal length bv");
 
-	// Test 3: Copy src to a destination with offset
+	/// copy part of bv to the medium
 	RzBitVector *res = rz_bv_new(size);
 	actual_copy = rz_bv_copy_nbits(src, 0, res, 8, part_sz);
-	mu_assert_eq(actual_copy, part_sz, "copy part_sz to medium offset");
-	mu_assert_streq_free(rz_bv_as_string(res), "00001111111100000000", "copy nbits with offset");
-
-	// Test 4: Copy non-zero bits from src to dst
-	RzBitVector *a = rz_bv_new_from_ut64(32, 0x12345678);
-	RzBitVector *b = rz_bv_new_from_ut64(32, 0x1986);
-	actual_copy = rz_bv_copy_nbits(b, 0, a, a->len - 11, 11);
-	mu_assert_eq(actual_copy, 11, "copy non-zero 11 bits");
-	mu_assert_streq_free(rz_bv_as_hex_string(a, false), "0x30d45678", "non-zero bit copy");
-
-	// Test 5: Copy fails when nbit exceeds the range
-	RzBitVector *too_small = rz_bv_new(part_sz);
-	actual_copy = rz_bv_copy_nbits(src, 0, too_small, 0, part_sz + 2);
-	mu_assert_eq(actual_copy, 0, "copy overflow fails");
-	mu_assert_true(rz_bv_is_zero_vector(too_small), "copy nothing on overflow");
-
-	// Additional Test 6: Copy with unaligned start positions
-	RzBitVector *unaligned_src = rz_bv_new_from_ut64(64, 0xFFFFFFFFFFFFFFFF);
-	RzBitVector *unaligned_dst = rz_bv_new(64);
-	actual_copy = rz_bv_copy_nbits(unaligned_src, 3, unaligned_dst, 5, 20);
-	mu_assert_eq(actual_copy, 20, "unaligned copy works");
-	mu_assert_streq_free(rz_bv_as_string(unaligned_dst), "00000011111111111111110000000000", "unaligned copy result");
+	mu_assert_eq(actual_copy, part_sz, "copy part_sz bits to medium");
+	mu_assert_streq_free(rz_bv_as_string(res), "00001111111100000000", "copy nbits to medium");
 
 	/// copy non-zero, copy last 11 bits of `b` to the head of `a`
 	/// dst : a = 0001 0010 0011 ...

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -1123,23 +1123,43 @@ bool test_rz_bv_copy_nbits(void) {
 	rz_bv_set(src, src->len - 1, true);
 	rz_bv_set(src, src->len - 3, true);
 
-	/// copy part of bv to a new one with the same size
+	// Test 1: Copy part of src to a smaller destination
 	RzBitVector *small = rz_bv_new(part_sz);
 	actual_copy = rz_bv_copy_nbits(src, 0, small, 0, part_sz);
-	mu_assert_eq(actual_copy, part_sz, "copy part_sz to normal");
-	mu_assert_streq_free(rz_bv_as_string(small), "11111111", "copy nbits small bv");
+	mu_assert_eq(actual_copy, part_sz, "copy part_sz to small");
+	mu_assert_streq_free(rz_bv_as_string(small), "11111111", "copy nbits to small bv");
 
-	/// copy part of bv to a new one which has more spaces
+	// Test 2: Copy part of src to a destination of the same size
 	RzBitVector *normal = rz_bv_new(size);
 	actual_copy = rz_bv_copy_nbits(src, 0, normal, 0, part_sz);
-	mu_assert_eq(actual_copy, part_sz, "copy part_sz bits to normal");
-	mu_assert_streq_free(rz_bv_as_string(normal), "00000000000011111111", "copy nbits normal length bv");
+	mu_assert_eq(actual_copy, part_sz, "copy part_sz to normal");
+	mu_assert_streq_free(rz_bv_as_string(normal), "00000000000011111111", "copy nbits to normal bv");
 
-	/// copy part of bv to the medium
+	// Test 3: Copy src to a destination with offset
 	RzBitVector *res = rz_bv_new(size);
 	actual_copy = rz_bv_copy_nbits(src, 0, res, 8, part_sz);
-	mu_assert_eq(actual_copy, part_sz, "copy part_sz bits to medium");
-	mu_assert_streq_free(rz_bv_as_string(res), "00001111111100000000", "copy nbits to medium");
+	mu_assert_eq(actual_copy, part_sz, "copy part_sz to medium offset");
+	mu_assert_streq_free(rz_bv_as_string(res), "00001111111100000000", "copy nbits with offset");
+
+	// Test 4: Copy non-zero bits from src to dst
+	RzBitVector *a = rz_bv_new_from_ut64(32, 0x12345678);
+	RzBitVector *b = rz_bv_new_from_ut64(32, 0x1986);
+	actual_copy = rz_bv_copy_nbits(b, 0, a, a->len - 11, 11);
+	mu_assert_eq(actual_copy, 11, "copy non-zero 11 bits");
+	mu_assert_streq_free(rz_bv_as_hex_string(a, false), "0x30d45678", "non-zero bit copy");
+
+	// Test 5: Copy fails when nbit exceeds the range
+	RzBitVector *too_small = rz_bv_new(part_sz);
+	actual_copy = rz_bv_copy_nbits(src, 0, too_small, 0, part_sz + 2);
+	mu_assert_eq(actual_copy, 0, "copy overflow fails");
+	mu_assert_true(rz_bv_is_zero_vector(too_small), "copy nothing on overflow");
+
+	// Additional Test 6: Copy with unaligned start positions
+	RzBitVector *unaligned_src = rz_bv_new_from_ut64(64, 0xFFFFFFFFFFFFFFFF);
+	RzBitVector *unaligned_dst = rz_bv_new(64);
+	actual_copy = rz_bv_copy_nbits(unaligned_src, 3, unaligned_dst, 5, 20);
+	mu_assert_eq(actual_copy, 20, "unaligned copy works");
+	mu_assert_streq_free(rz_bv_as_string(unaligned_dst), "00000011111111111111110000000000", "unaligned copy result");
 
 	/// copy non-zero, copy last 11 bits of `b` to the head of `a`
 	/// dst : a = 0001 0010 0011 ...


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**
This pull request optimizes the performance of the rz_bv_set_range function. The original implementation iterated through bits one at a time, leading to inefficiencies for large ranges. The updated implementation:

Processes aligned chunks of bits using system word size for faster operations.
Dynamically adjusts chunk size for different architectures (e.g., 32-bit, 64-bit).
Handles unaligned prefix and suffix bits separately while optimizing the main loop.
Adds robust boundary validation to ensure correctness.
This change reduces iteration overhead and improves performance while maintaining compatibility and correctness.

**Test plan**

1. Verify functionality for small ranges, large ranges, and edge cases (unaligned ranges).
2. Test on various architectures to confirm portability (32-bit, 64-bit).
3. Use unit tests to ensure the results match the original functionality.
4. Check for any regressions with existing test suites.

**Closing issues**
Partially addresses #4716 
...
