### PR TITLE
Revert "rz-test: Set default test dir to '.' (#4741)"

### DIFF
--- a/binrz/rz-test/rz-test.c
+++ b/binrz/rz-test/rz-test.c
@@ -106,6 +106,21 @@ static int help(bool verbose) {
 	return 1;
 }
 
+/**
+ * \brief Find test dir for rz-test symbolic link
+ * \param argv0 A symbolic link to an rz-test binary
+ * \return True if test dir exists
+ *
+ * This function seemingly is to support an easy way to test different core
+ * binaries with their own test sets, via symbolic links to their respective
+ * rz-test binaries. It can be triggered by adding `./` in front of the
+ * testfile name, and needs the rz-test binary to be in `binrz/rz-test/`
+ * relative to its root dir for it to work.
+ *
+ * \deprecated The core binaries are probably different in terms of arch and
+ * os. Such differences should be coverable by archos tests, and so this
+ * function is slated for removal.
+ */
 static bool rz_test_chdir(const char *argv0) {
 #if __UNIX__
 	if (rz_file_is_directory("db")) {

--- a/binrz/rz-test/rz-test.c
+++ b/binrz/rz-test/rz-test.c
@@ -160,6 +160,14 @@ static bool rz_test_test_run_unit(void) {
 	return rz_sys_system("make -C unit all run") == 0;
 }
 
+/**
+ * \brief Change cwd to test root dir (containing the `db/` dir)
+ * \param test_path Test pathname
+ * \return True if test root dir is found
+ *
+ * The cwd change is done so that tests can find their test binaries stored in
+ * the `<test root dir>/bins` dir no matter what the old cwd was.
+ */
 static bool rz_test_chdir_fromtest(const char *test_path) {
 	if (!test_path || *test_path == '@') {
 		test_path = "";

--- a/binrz/rz-test/rz-test.c
+++ b/binrz/rz-test/rz-test.c
@@ -19,7 +19,6 @@
 #define RIZIN_CMD_DEFAULT      "rizin"
 #define RZ_ASM_CMD_DEFAULT     "rz-asm"
 #define JSON_TEST_FILE_DEFAULT "bins/elf/crackme0x00b"
-#define TEST_DIR_DEFAULT       "."
 #define TIMEOUT_DEFAULT        960
 
 #define STRV(x)             #x
@@ -79,7 +78,7 @@ static int help(bool verbose) {
 			"-r",           "[rizin]",        "Path to rizin executable (default is " RIZIN_CMD_DEFAULT ")",
 			"-m",           "[rz-asm]",       "Path to rz-asm executable (default is " RZ_ASM_CMD_DEFAULT ")",
 			"-f",           "[file]",         "File to use for JSON tests (default is " JSON_TEST_FILE_DEFAULT ")",
-			"-C",           "[dir]",          "Chdir before running rz-test (default is '" TEST_DIR_DEFAULT "')",
+			"-C",           "[dir]",          "Chdir before running rz-test (default follows executable symlink + test/new)",
 			"-t",           "[seconds]",      "Timeout per test (default is " TIMEOUT_DEFAULT_STR " seconds)",
 			"-o",           "[file]",         "Output test run information in JSON format to file",
 			"-e",           "[dir]",          "Exclude a particular directory while testing (this option can appear many times)",
@@ -107,8 +106,93 @@ static int help(bool verbose) {
 	return 1;
 }
 
+static bool rz_test_chdir(const char *argv0) {
+#if __UNIX__
+	if (rz_file_is_directory("db")) {
+		return true;
+	}
+	char src_path[PATH_MAX];
+	char *rz_test_path = rz_file_path(argv0);
+	bool found = false;
+
+	ssize_t linklen = readlink(rz_test_path, src_path, sizeof(src_path) - 1);
+	if (linklen != -1) {
+		src_path[linklen] = '\0';
+		char *p = strstr(src_path, RZ_SYS_DIR "binrz" RZ_SYS_DIR "rz-test" RZ_SYS_DIR "rz-test");
+		if (p) {
+			*p = 0;
+			strcat(src_path, RZ_SYS_DIR "test" RZ_SYS_DIR);
+			if (rz_file_is_directory(src_path)) {
+				if (chdir(src_path) != -1) {
+					eprintf("Running from %s\n", src_path);
+					found = true;
+				} else {
+					eprintf("Cannot find '%s' directory\n", src_path);
+				}
+			}
+		}
+	} else {
+		eprintf("Cannot follow the link %s\n", src_path);
+	}
+	free(rz_test_path);
+	return found;
+#else
+	return false;
+#endif
+}
+
 static bool rz_test_test_run_unit(void) {
 	return rz_sys_system("make -C unit all run") == 0;
+}
+
+static bool rz_test_chdir_fromtest(const char *test_path) {
+	if (!test_path || *test_path == '@') {
+		test_path = "";
+	}
+	char *abs_test_path = rz_file_abspath(test_path);
+	if (!rz_file_is_directory(abs_test_path)) {
+		char *last_slash = (char *)rz_str_lchr(abs_test_path, RZ_SYS_DIR[0]);
+		if (last_slash) {
+			*last_slash = 0;
+		}
+	}
+	if (chdir(abs_test_path) == -1) {
+		free(abs_test_path);
+		return false;
+	}
+	free(abs_test_path);
+	bool found = false;
+	char *cwd = NULL;
+	char *old_cwd = NULL;
+	while (true) {
+		cwd = rz_sys_getdir();
+		if (old_cwd && !strcmp(old_cwd, cwd)) {
+			break;
+		}
+		if (rz_file_is_directory("test")) {
+			rz_sys_chdir("test");
+			if (rz_file_is_directory("db")) {
+				found = true;
+				eprintf("Running from %s\n", cwd);
+				break;
+			}
+			rz_sys_chdir("..");
+		}
+		if (rz_file_is_directory("db")) {
+			found = true;
+			eprintf("Running from %s\n", cwd);
+			break;
+		}
+		free(old_cwd);
+		old_cwd = cwd;
+		cwd = NULL;
+		if (chdir("..") == -1) {
+			break;
+		}
+	}
+	free(old_cwd);
+	free(cwd);
+	return found;
 }
 
 static bool log_mode = false;
@@ -254,7 +338,14 @@ int rz_test_main(int argc, const char **argv) {
 			goto beach;
 		}
 	} else {
-		rz_test_dir = TEST_DIR_DEFAULT;
+		bool dir_found = (opt.ind < argc && argv[opt.ind][0] != '.')
+			? rz_test_chdir_fromtest(argv[opt.ind])
+			: rz_test_chdir(argv[0]);
+		if (!dir_found) {
+			eprintf("Cannot find db/ directory related to the given test.\n");
+			ret = -1;
+			goto beach;
+		}
 	}
 
 	if (fuzz_dir) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr reverts #4741 since apparently it has code that allows tests in the official Rizin test hierarchy to find their test binaries (in `test/bins`) no matter what the current working directory is.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Given the `test/db/cmd/cmd_pd` testfile pathname, all of the following should work:
1. `rz-test test/db/cmd/cmd_pd` in the root folder
2. `rz-test db/cmd/cmd_pd` in the `test/` folder
3. `rz-test cmd/cmd_pd` in the `test/db` folder
4. `rz-test cmd_pd` in the `test/db/cmd` folder

One cannot prepend `./` to the `rz-test` arguments above though (except for number 2 for some reason -- `rz-test ./db/cmd/cmd_pd` in the `test/` folder works), but that's an issue for another pr.

Also, all builds should be green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...