### PR TITLE
rz-test: Fix last line of diff when REGEXP_FILTER_OUT/_ERR is set

### DIFF
--- a/binrz/rz-test/rz-test.c
+++ b/binrz/rz-test/rz-test.c
@@ -755,14 +755,22 @@ static void *worker_th(RzTestState *state) {
 	return NULL;
 }
 
+static char *get_matched_str(const char *regexp, const char *str) {
+	RzStrBuf *match_str = rz_test_regex_full_match_str(regexp, str);
+	int len = rz_strbuf_length(match_str);
+	if (len && rz_strbuf_get(match_str)[len - 1] != '\n') { // empty matches are not changed
+		rz_strbuf_append(match_str, "\n");
+	}
+	return rz_strbuf_drain(match_str);
+}
+
 static void print_diff(const char *actual, const char *expected, const char *regexp) {
 	RzDiff *d = NULL;
 	char *uni = NULL;
 	const char *output = actual;
 
 	if (regexp) {
-		RzStrBuf *match_str = rz_test_regex_full_match_str(regexp, actual);
-		output = rz_strbuf_drain(match_str);
+		output = get_matched_str(regexp, actual);
 	}
 
 	d = rz_diff_lines_new(expected, output, NULL);
@@ -1234,15 +1242,6 @@ static void replace_cmd_kv_file(const char *path, ut64 line_begin, ut64 line_end
 	}
 	save_test_file_for_fix(path, newc);
 	free(newc);
-}
-
-static char *get_matched_str(const char *regexp, const char *str) {
-	RzStrBuf *match_str = rz_test_regex_full_match_str(regexp, str);
-	int len = rz_strbuf_length(match_str);
-	if (len && rz_strbuf_get(match_str)[len - 1] != '\n') { // empty matches are not changed
-		rz_strbuf_append(match_str, "\n");
-	}
-	return rz_strbuf_drain(match_str);
 }
 
 static bool interact_fix_cmd(RzTestResultInfo *result, RzPVector /*<RzTestResultInfo *>*/ *fixup_results) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the last line of the diff when REGEXP_FILTER_OUT/_ERR is set (example problem shown below) by adding a newline as appropriate.

![debug_dmh](https://github.com/user-attachments/assets/fa2e7610-d502-498d-b4a3-1f9dae3fccd7)

The following changes to tests were used for testing:

```patch
diff --git a/test/db/archos/linux-x64/dbg_afvd b/test/db/archos/linux-x64/dbg_afvd
index 84a16a4c4e..7a19405eac 100644
--- a/test/db/archos/linux-x64/dbg_afvd
+++ b/test/db/archos/linux-x64/dbg_afvd
@@ -10,6 +10,7 @@ afvd var_ch
 EOF
 REGEXP_FILTER_OUT=('.'\s*)
 EXPECT=<<EOF
+'b'
 'a'
 EOF
 RUN
diff --git a/test/db/archos/linux-x64/dbg_dmh b/test/db/archos/linux-x64/dbg_dmh
index 5e46cfd6c8..eccc3c3c57 100644
--- a/test/db/archos/linux-x64/dbg_dmh
+++ b/test/db/archos/linux-x64/dbg_dmh
@@ -33,7 +33,7 @@ size=0xf160
 status=allocated
 size=0x11c10
 status=allocated
-size=0x20
+size=0x2
 status=free
 size=0xf140
 EOF
diff --git a/test/db/archos/linux-x64/dbg_oo b/test/db/archos/linux-x64/dbg_oo
index 9b2d83e4de..514368331d 100644
--- a/test/db/archos/linux-x64/dbg_oo
+++ b/test/db/archos/linux-x64/dbg_oo
@@ -114,7 +114,7 @@ ood
 EOF
 REGEXP_FILTER_ERR=(Process\swith\sPID)|(helloworld-gcc\sreopened\sin\sread-write\smode)
 EXPECT_ERR=<<EOF
-Process with PID
+Proce with PID
 helloworld-gcc reopened in read-write mode
 EOF
 RUN
diff --git a/test/db/archos/linux-x64/dbg_trace b/test/db/archos/linux-x64/dbg_trace
index 3f11dc724d..50848da7a3 100644
--- a/test/db/archos/linux-x64/dbg_trace
+++ b/test/db/archos/linux-x64/dbg_trace
@@ -71,5 +71,7 @@ main+8
 entry0+41
 EOF
 REGEXP_FILTER_ERR=ERROR.*\n
-EXPECT_ERR=
+EXPECT_ERR=<<EOF
+abc
+EOF
 RUN
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Manual testing is needed. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
