### PR TITLE
rz-test: Assume `-C .` if `db/` dir not found

### DIFF
--- a/binrz/rz-test/rz-test.c
+++ b/binrz/rz-test/rz-test.c
@@ -313,9 +313,8 @@ int rz_test_main(int argc, const char **argv) {
 	} else {
 		bool dir_found = rz_test_chdir_fromtest(opt.ind < argc ? argv[opt.ind] : NULL);
 		if (!dir_found) {
-			eprintf("Cannot find db/ directory related to the given test.\n");
-			ret = -1;
-			goto beach;
+			eprintf("Cannot find db/ directory related to the given test. Assuming '-C .'.\n");
+			rz_test_dir = ".";
 		}
 	}
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr makes rz-test assume `-C .` (i.e. set rz-test working directory to the current working directory) if a `db/` dir is not found, rather than error out. This allows easy running of testfiles outside the official Rizin test hierarchy.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The above is reasonable. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
