### PR TITLE
rz-test: Fix no XX if expected output truncated when REGEXP_FILTER_OUT is set

### DIFF
--- a/binrz/rz-test/run.c
+++ b/binrz/rz-test/run.c
@@ -204,8 +204,17 @@ RZ_API bool rz_test_cmp_cmd_output(const char *output, const char *expect, const
 		bool equal = false;
 		ut32 expect_len = strlen(expect);
 		if (expect_len > 0 && expect[expect_len - 1] == '\n') {
-			// Ignore newline
-			equal = (rz_str_cmp(expect, rz_strbuf_get(match_str), expect_len - 1) == 0);
+			// Ignore newline in expect
+			expect_len--;
+			int match_str_len = rz_strbuf_length(match_str);
+			if (match_str_len && rz_strbuf_get(match_str)[match_str_len - 1] == '\n') {
+				// Ignore newline in match_str
+				match_str_len--;
+			}
+			if (expect_len != match_str_len) {
+				return false;
+			}
+			equal = (rz_str_cmp(expect, rz_strbuf_get(match_str), expect_len) == 0);
 		} else {
 			equal = RZ_STR_EQ(expect, rz_strbuf_get(match_str));
 		}

--- a/test/db/archos/darwin-x64/dbg
+++ b/test/db/archos/darwin-x64/dbg
@@ -153,7 +153,6 @@ f38
 
 rax
 064
-
 EOF
 REGEXP_FILTER_ERR=((hit\sbreakpoint\sat:)|([0-9a-f][0-9a-f][0-9a-f]\n))
 EXPECT_ERR=<<EOF
@@ -165,7 +164,6 @@ f34
 
 hit breakpoint at:
 f38
-
 EOF
 RUN
 
@@ -203,7 +201,6 @@ ee3
 
 rax
 0a0
-
 EOF
 REGEXP_FILTER_ERR=((hit\sbreakpoint\sat:)|([0-9a-f][0-9a-f][0-9a-f]\n))
 EXPECT_ERR=<<EOF
@@ -215,6 +212,5 @@ edd
 
 hit breakpoint at:
 ee3
-
 EOF
 RUN


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes an rz-test false no-XX (i.e. rz-test does not declare XX even though test is XX) if expected output is truncated when REGEXP_FILTER_OUT is set. This fix should work also for REGEXP_FILTER_ERR. For testing this, the following patch can be used:

```patch
diff --git a/test/db/archos/linux-x64/dbg_trace b/test/db/archos/linux-x64/dbg_trace
index 3f11dc724d..c30b49e897 100644
--- a/test/db/archos/linux-x64/dbg_trace
+++ b/test/db/archos/linux-x64/dbg_trace
@@ -68,7 +68,7 @@ entry0+41
 ----
 loc.func_0
 main+8
-entry0+41
+entry0+4
 EOF
 REGEXP_FILTER_ERR=ERROR.*\n
 EXPECT_ERR=
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Manual testing is needed. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
