### PR TITLE
Set return type of rz_strbuf_length() to size_t

### DIFF
--- a/binrz/rz-test/run.c
+++ b/binrz/rz-test/run.c
@@ -206,7 +206,7 @@ RZ_API bool rz_test_cmp_cmd_output(const char *output, const char *expect, const
 		if (expect_len > 0 && expect[expect_len - 1] == '\n') {
 			// Ignore newline in expect
 			expect_len--;
-			int match_str_len = rz_strbuf_length(match_str);
+			size_t match_str_len = rz_strbuf_length(match_str);
 			if (match_str_len && rz_strbuf_get(match_str)[match_str_len - 1] == '\n') {
 				// Ignore newline in match_str
 				match_str_len--;

--- a/binrz/rz-test/rz-test.c
+++ b/binrz/rz-test/rz-test.c
@@ -704,7 +704,7 @@ static void *worker_th(RzTestState *state) {
 
 static char *get_matched_str(const char *regexp, const char *str) {
 	RzStrBuf *match_str = rz_test_regex_full_match_str(regexp, str);
-	int len = rz_strbuf_length(match_str);
+	size_t len = rz_strbuf_length(match_str);
 	if (len && rz_strbuf_get(match_str)[len - 1] != '\n') { // empty matches are not changed
 		rz_strbuf_append(match_str, "\n");
 	}

--- a/librz/include/rz_util/rz_strbuf.h
+++ b/librz/include/rz_util/rz_strbuf.h
@@ -30,7 +30,7 @@ RZ_API bool rz_strbuf_vappendf(RzStrBuf *sb, const char *fmt, va_list ap);
 RZ_API char *rz_strbuf_get(RzStrBuf *sb);
 RZ_API RZ_OWN char *rz_strbuf_drain(RzStrBuf *sb);
 RZ_API RZ_OWN char *rz_strbuf_drain_nofree(RzStrBuf *sb);
-RZ_API int rz_strbuf_length(RzStrBuf *sb);
+RZ_API size_t rz_strbuf_length(RzStrBuf *sb);
 RZ_API void rz_strbuf_free(RzStrBuf *sb);
 RZ_API void rz_strbuf_fini(RzStrBuf *sb);
 RZ_API void rz_strbuf_init(RzStrBuf *sb);

--- a/librz/util/strbuf.c
+++ b/librz/util/strbuf.c
@@ -25,7 +25,7 @@ RZ_API bool rz_strbuf_is_empty(RzStrBuf *sb) {
 	return sb->len == 0;
 }
 
-RZ_API int rz_strbuf_length(RzStrBuf *sb) {
+RZ_API size_t rz_strbuf_length(RzStrBuf *sb) {
 	rz_return_val_if_fail(sb, 0);
 	return sb->len;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr sets the return type of rz_strbuf_length() to `size_t` from `int`, because:

1. That's more accurate.
2. `int` implies possible negativity while `size_t` doesn't.

Apart from adding 4 bytes to the return value of rz_strbuf_length(), I don't think there are any practical effects.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
