### PR TITLE
Add ruler to histogram output

### DIFF
--- a/librz/cons/histogram.c
+++ b/librz/cons/histogram.c
@@ -41,6 +41,7 @@ RZ_API RZ_OWN RzStrBuf *rz_histogram_horizontal(RZ_NONNULL RzHistogramOptions *o
 	ut32 rows = height > 0 ? height : 10;
 	const char *vline = opts->unicode ? RUNE_LINE_VERT : "|";
 	const char *block = opts->unicode ? UTF_BLOCK : "#";
+	const char *ruler = opts->unicode ? "│" : "|";
 	const char *kol[5];
 	kol[0] = opts->pal->call;
 	kol[1] = opts->pal->jmp;
@@ -63,6 +64,7 @@ RZ_API RZ_OWN RzStrBuf *rz_histogram_horizontal(RZ_NONNULL RzHistogramOptions *o
 					rz_strbuf_append(buf, " ");
 				}
 			}
+			rz_strbuf_appendf(buf, " %s%3zu", ruler, (255 - threshold));
 			rz_strbuf_append(buf, "\n");
 		}
 		return buf;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [x] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pull request adds a vertical ruler to the horizontal histogram output in `librz/cons/histogram.c`. The ruler includes value ranges and uses a vertical Unicode line character if `scr.utf8=true`.

I've added y-axis numbering, which is computed as 255 - threshold, where the threshold is calculated for each row. Please let me know if this approach is acceptable or if any adjustments are needed. Should it be added to the interactive histogram too?

Here are two images showing the expected output:
* Image 1: `p== 50` with `scr.utf8=true`

![peqeq50_true](https://github.com/user-attachments/assets/5dc6d577-95fd-41e1-8eac-3d388aba3cc0)

* Image 2: `p== 50` with `scr.utf8=false`

![peqeq50_false](https://github.com/user-attachments/assets/2b299586-35d9-40b4-b6d2-ad69e4f09f53)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

1. Enable `scr.utf8=true` in the configuration.
2. Generate a horizontal histogram using the `p==` command.
3. Verify that the vertical ruler is displayed correctly with value ranges.
4. Disable `scr.utf8=true` and repeat the test to ensure the ruler is displayed correctly without Unicode characters.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Addresses #129 but might need improvement
