### PR TITLE
python: fix `yield` into `yield from`

### DIFF
--- a/librz/core/cmd_descs/rzshell_which.py
+++ b/librz/core/cmd_descs/rzshell_which.py
@@ -19,8 +19,7 @@ from cmd_descs_util import (
 
 
 def get_yaml_files(basedir):
-    for file in glob.glob(os.path.join(basedir, "*.yaml")):
-        yield file
+    yield from glob.glob(os.path.join(basedir, "*.yaml")):
 
 
 def find_entry(commands, rzcommand):

--- a/test/scripts/gdbserver.py
+++ b/test/scripts/gdbserver.py
@@ -22,8 +22,7 @@ def execute(cmd):
     with subprocess.Popen(
         cmd, stderr=subprocess.PIPE, universal_newlines=True
     ) as popen:
-        for stderr_line in iter(popen.stderr.readline, ""):
-            yield stderr_line
+        yield from iter(popen.stderr.readline, ""):
 
 
 def main():


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fix the following pylint complaints:
```
pylint: Command line or configuration file:1: UserWarning: 'BaseException' is not a proper value for the 'overgeneral-exceptions' option. Use fully qualified name (maybe 'builtins.BaseException' ?) instead. This will cease to be checked at runtime when the configuration upgrader is released.
pylint: Command line or configuration file:1: UserWarning: 'Exception' is not a proper value for the 'overgeneral-exceptions' option. Use fully qualified name (maybe 'builtins.Exception' ?) instead. This will cease to be checked at runtime when the configuration upgrader is released.
************* Module gdbserver
test/scripts/gdbserver.py:25:8: R1737: Use 'yield from' directly instead of yielding each element one by one (use-yield-from)
************* Module rzshell_which
librz/core/cmd_descs/rzshell_which.py:16:4: R1737: Use 'yield from' directly instead of yielding each element one by one (use-yield-from)

-----------------------------------
Your code has been rated at 9.98/10
```

See https://pylint.pycqa.org/en/stable/user_guide/messages/refactor/use-yield-from.html for more details

**Test plan**

pylint CI job is green