### PR TITLE
Add RzIL vm event memory (read|write) index

### DIFF
--- a/librz/il/il_events.c
+++ b/librz/il/il_events.c
@@ -94,10 +94,11 @@ RZ_API RZ_OWN RzILEvent *rz_il_event_pc_write_new(RZ_NONNULL const RzBitVector *
 
 /**
  * Creates an RzILEvent of type RZ_IL_EVENT_MEM_READ
+ * \param index, RzILMemIndex, index of the memory to read
  * \param addr, RzBitVector, address of the memory where the read op has occurred
  * \param value, RzBitVector, value read from the variable
  */
-RZ_API RZ_OWN RzILEvent *rz_il_event_mem_read_new(RZ_NONNULL const RzBitVector *address, RZ_NULLABLE const RzBitVector *value) {
+RZ_API RZ_OWN RzILEvent *rz_il_event_mem_read_new(RzILMemIndex index, RZ_NONNULL const RzBitVector *address, RZ_NULLABLE const RzBitVector *value) {
 	rz_return_val_if_fail(address && value, NULL);
 
 	RzILEvent *evt = RZ_NEW(RzILEvent);
@@ -106,6 +107,7 @@ RZ_API RZ_OWN RzILEvent *rz_il_event_mem_read_new(RZ_NONNULL const RzBitVector *
 	}
 
 	evt->type = RZ_IL_EVENT_MEM_READ;
+	evt->data.mem_read.index = index;
 	evt->data.mem_read.address = rz_bv_dup(address);
 	evt->data.mem_read.value = rz_bv_dup(value);
 	if (!evt->data.mem_read.address || !evt->data.mem_read.value) {
@@ -118,11 +120,12 @@ RZ_API RZ_OWN RzILEvent *rz_il_event_mem_read_new(RZ_NONNULL const RzBitVector *
 
 /**
  * Creates an RzILEvent of type RZ_IL_EVENT_MEM_WRITE
+ * \param index, RzILMemIndex, index of the memory to store data
  * \param addr, RzBitVector, address of the memory that has changed
  * \param old_v, RzBitVector, old value before the change
  * \param new_v, RzBitVector, new value after the change
  */
-RZ_API RZ_OWN RzILEvent *rz_il_event_mem_write_new(RZ_NONNULL const RzBitVector *addr, RZ_NONNULL const RzBitVector *old_v, RZ_NONNULL const RzBitVector *new_v) {
+RZ_API RZ_OWN RzILEvent *rz_il_event_mem_write_new(RzILMemIndex index, RZ_NONNULL const RzBitVector *addr, RZ_NONNULL const RzBitVector *old_v, RZ_NONNULL const RzBitVector *new_v) {
 	rz_return_val_if_fail(addr && old_v && new_v, NULL);
 
 	RzILEvent *evt = RZ_NEW(RzILEvent);
@@ -131,6 +134,7 @@ RZ_API RZ_OWN RzILEvent *rz_il_event_mem_write_new(RZ_NONNULL const RzBitVector 
 	}
 
 	evt->type = RZ_IL_EVENT_MEM_WRITE;
+	evt->data.mem_write.index = index;
 	evt->data.mem_write.address = rz_bv_dup(addr);
 	evt->data.mem_write.old_value = rz_bv_dup(old_v);
 	evt->data.mem_write.new_value = rz_bv_dup(new_v);

--- a/librz/il/il_export_string.c
+++ b/librz/il/il_export_string.c
@@ -1079,7 +1079,11 @@ RZ_API void rz_il_event_stringify(RZ_NONNULL const RzILEvent *evt, RZ_NONNULL Rz
 	case RZ_IL_EVENT_MEM_READ:
 		tmp0 = rz_bv_as_hex_string(evt->data.mem_read.address, false);
 		tmp1 = evt->data.mem_read.value ? rz_bv_as_hex_string(evt->data.mem_read.value, false) : NULL;
-		rz_strbuf_appendf(sb, "mem_read(addr: %s, value: %s)", tmp0, tmp1 ? tmp1 : "uninitialized memory");
+		if (evt->data.mem_read.index == 0) {
+			rz_strbuf_appendf(sb, "mem_read(addr: %s, value: %s)", tmp0, tmp1 ? tmp1 : "uninitialized memory");
+		} else {
+			rz_strbuf_appendf(sb, "mem_read(index: %u, addr: %s, value: %s)", evt->data.mem_read.index, tmp0, tmp1 ? tmp1 : "uninitialized memory");
+		}
 		break;
 	case RZ_IL_EVENT_VAR_READ:
 		tmp1 = rz_il_value_stringify(evt->data.var_read.value);
@@ -1089,7 +1093,11 @@ RZ_API void rz_il_event_stringify(RZ_NONNULL const RzILEvent *evt, RZ_NONNULL Rz
 		tmp0 = rz_bv_as_hex_string(evt->data.mem_write.address, false);
 		tmp1 = evt->data.mem_write.old_value ? rz_bv_as_hex_string(evt->data.mem_write.old_value, false) : NULL;
 		tmp2 = rz_bv_as_hex_string(evt->data.mem_write.new_value, false);
-		rz_strbuf_appendf(sb, "mem_write(addr: %s, old: %s, new: %s)", tmp0, tmp1 ? tmp1 : "uninitialized memory", tmp2);
+		if (evt->data.mem_write.index == 0) {
+			rz_strbuf_appendf(sb, "mem_write(addr: %s, old: %s, new: %s)", tmp0, tmp1 ? tmp1 : "uninitialized memory", tmp2);
+		} else {
+			rz_strbuf_appendf(sb, "mem_write(index: %u, addr: %s, old: %s, new: %s)", evt->data.mem_write.index, tmp0, tmp1 ? tmp1 : "uninitialized memory", tmp2);
+		}
 		break;
 	case RZ_IL_EVENT_VAR_WRITE:
 		tmp1 = rz_il_value_stringify(evt->data.var_write.old_value);

--- a/librz/il/il_vm_eval.c
+++ b/librz/il/il_vm_eval.c
@@ -204,7 +204,7 @@ RZ_API RzBitVector *rz_il_vm_mem_load(RzILVM *vm, RzILMemIndex index, RzBitVecto
 		return NULL;
 	}
 	RzBitVector *value = rz_il_mem_load(mem, key);
-	rz_il_vm_event_add(vm, rz_il_event_mem_read_new(key, value));
+	rz_il_vm_event_add(vm, rz_il_event_mem_read_new(index, key, value));
 	return value;
 }
 
@@ -225,7 +225,7 @@ RZ_API void rz_il_vm_mem_store(RzILVM *vm, RzILMemIndex index, RzBitVector *key,
 	}
 	RzBitVector *old_value = rz_il_mem_load(mem, key);
 	rz_il_mem_store(mem, key, value);
-	rz_il_vm_event_add(vm, rz_il_event_mem_write_new(key, old_value, value));
+	rz_il_vm_event_add(vm, rz_il_event_mem_write_new(index, key, old_value, value));
 	rz_bv_free(old_value);
 }
 
@@ -243,7 +243,7 @@ RZ_API RzBitVector *rz_il_vm_mem_loadw(RzILVM *vm, RzILMemIndex index, RzBitVect
 		return NULL;
 	}
 	RzBitVector *value = rz_il_mem_loadw(mem, key, n_bits, vm->big_endian);
-	rz_il_vm_event_add(vm, rz_il_event_mem_read_new(key, value));
+	rz_il_vm_event_add(vm, rz_il_event_mem_read_new(index, key, value));
 	return value;
 }
 
@@ -251,6 +251,7 @@ RZ_API RzBitVector *rz_il_vm_mem_loadw(RzILVM *vm, RzILMemIndex index, RzBitVect
  * Store data to memory by key, will create a key-value pair
  * or update the key-value pair if key existed; also generates
  * an RZ_IL_EVENT_MEM_WRITE event
+ * \param  index RzILMemIndex, index of the memory to store data
  * \param  vm    RzILVM* pointer to VM
  * \param  key   RzBitVector, aka address, a key to store data from memory
  * \param  value RzBitVector, aka value to store in memory
@@ -267,7 +268,7 @@ RZ_API void rz_il_vm_mem_storew(RzILVM *vm, RzILMemIndex index, RzBitVector *key
 		RZ_LOG_ERROR("StoreW mem %u 0x%llx failed\n", (unsigned int)index, rz_bv_to_ut64(key));
 		goto end;
 	}
-	rz_il_vm_event_add(vm, rz_il_event_mem_write_new(key, old_value, value));
+	rz_il_vm_event_add(vm, rz_il_event_mem_write_new(index, key, old_value, value));
 end:
 	rz_bv_free(old_value);
 }

--- a/librz/include/rz_il/rz_il_events.h
+++ b/librz/include/rz_il/rz_il_events.h
@@ -28,6 +28,7 @@ typedef enum rz_il_event_id_t {
 } RzILEventId;
 
 typedef struct rz_il_vm_event_mem_read_t {
+	RzILMemIndex index;
 	RZ_NONNULL RzBitVector *address;
 	RZ_NONNULL RzBitVector *value;
 } RzILEventMemRead;
@@ -43,6 +44,7 @@ typedef struct rz_il_vm_event_pc_write_t {
 } RzILEventPCWrite;
 
 typedef struct rz_il_vm_event_mem_write_t {
+	RzILMemIndex index;
 	RZ_NONNULL RzBitVector *address;
 	RZ_NONNULL RzBitVector *old_value;
 	RZ_NONNULL RzBitVector *new_value;
@@ -68,9 +70,9 @@ typedef struct rz_il_vm_event_t {
 
 RZ_API RZ_OWN RzILEvent *rz_il_event_exception_new(RZ_NONNULL const char *exception);
 RZ_API RZ_OWN RzILEvent *rz_il_event_pc_write_new(RZ_NONNULL const RzBitVector *old_pc, RZ_NONNULL const RzBitVector *new_pc);
-RZ_API RZ_OWN RzILEvent *rz_il_event_mem_read_new(RZ_NONNULL const RzBitVector *addr, RZ_NULLABLE const RzBitVector *value);
+RZ_API RZ_OWN RzILEvent *rz_il_event_mem_read_new(RzILMemIndex index, RZ_NONNULL const RzBitVector *addr, RZ_NULLABLE const RzBitVector *value);
 RZ_API RZ_OWN RzILEvent *rz_il_event_var_read_new(RZ_NONNULL const char *name, RZ_NULLABLE const RzILVal *value);
-RZ_API RZ_OWN RzILEvent *rz_il_event_mem_write_new(RZ_NONNULL const RzBitVector *addr, RZ_NONNULL const RzBitVector *old_v, RZ_NONNULL const RzBitVector *new_v);
+RZ_API RZ_OWN RzILEvent *rz_il_event_mem_write_new(RzILMemIndex index, RZ_NONNULL const RzBitVector *addr, RZ_NONNULL const RzBitVector *old_v, RZ_NONNULL const RzBitVector *new_v);
 RZ_API RZ_OWN RzILEvent *rz_il_event_var_write_new(RZ_NONNULL const char *name, RZ_NULLABLE const RzILVal *old_v, RZ_NONNULL const RzILVal *new_v);
 RZ_API void rz_il_event_free(RZ_NULLABLE RzILEvent *evt);
 


### PR DESCRIPTION
This is because the memory of the RzIL VM has an index, but the index is ignored when an event is generated.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
