### PR TITLE
XTENSA Always fallback on bad CPU and set illegal on bad decoding

### DIFF
--- a/librz/arch/isa/xtensa/xtensa.c
+++ b/librz/arch/isa/xtensa/xtensa.c
@@ -27,16 +27,16 @@ bool xtensa_open(XtensaContext *ctx, const char *cpu, bool big_endian) {
 		return false;
 	}
 	cs_mode mode = big_endian ? CS_MODE_BIG_ENDIAN : CS_MODE_LITTLE_ENDIAN;
-	if (RZ_STR_ISEMPTY(cpu)) {
-		mode |= xtensa_cpu_modes[0].mode;
-	} else {
+	cs_mode mcpu = xtensa_cpu_modes[0].mode;
+	if (RZ_STR_ISNOTEMPTY(cpu)) {
 		for (int i = 0; i < RZ_ARRAY_SIZE(xtensa_cpu_modes); ++i) {
 			if (RZ_STR_EQ(cpu, xtensa_cpu_modes[i].cpu)) {
-				mode |= xtensa_cpu_modes[i].mode;
+				mcpu = xtensa_cpu_modes[i].mode;
 				break;
 			}
 		}
 	}
+	mode |= mcpu;
 	if (mode == ctx->mode) {
 		return true;
 	}

--- a/librz/arch/p/asm/asm_xtensa_cs.c
+++ b/librz/arch/p/asm/asm_xtensa_cs.c
@@ -22,7 +22,9 @@ static int asm_xtensa_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len
 	op->size = ctx->insn->size;
 	xtensa_disassemble_fini(ctx);
 	return op->size;
+
 beach:
+	rz_asm_op_set_asm(op, "illegal");
 	xtensa_disassemble_fini(ctx);
 	return -1;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Fixes the wrong internal logic and enforces `illegal` on fail decoding.