### PR TITLE
pxi: Add missing `:` at Last_Offset+1

### DIFF
--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -339,7 +339,7 @@ RZ_API void rz_print_hexii(RzPrint *rp, ut64 addr, const ut8 *buf, int len, int 
 		}
 		p("\n");
 	}
-	p("%8" PFMT64x " ]\n", addr + i);
+	p("%8" PFMT64x ": ]\n", addr + i);
 }
 
 /**

--- a/test/db/cmd/cmd_px
+++ b/test/db/cmd/cmd_px
@@ -398,6 +398,6 @@ EXPECT=<<EOF
            0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
        0: f3 0f 1e fa .U .H 89 e5 eb fe                  
       30:                                        ## ## ##
-      40 ]
+      40: ]
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

For `pxi`, this pr just adds back the missing `:` at Last_Offset+1, following https://github.com/kastelo/hexii and https://github.com/gunmetalbackupgooglecode/corkami/blob/master/src/HexII/HexII.png.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
