### PR TITLE
Fix UB: Shifting by 24 on `int` is not defined.

### DIFF
--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -1855,8 +1855,8 @@ static inline char cmd_pxb_p(char input) {
 	return IS_PRINTABLE(input) ? input : '.';
 }
 
-static inline int cmd_pxb_k(const ut8 *buffer, int x) {
-	return buffer[3 - x] << (8 * x);
+static inline ut32 cmd_pxb_k(const ut8 *buffer, int x) {
+	return ((ut32)buffer[3 - x]) << (8 * x);
 }
 
 static void print_json_string(RzCore *core, const ut8 *block, ut32 len, RzStrEnc encoding, bool stop_at_nil) {
@@ -2767,10 +2767,10 @@ RZ_IPI RzCmdStatus rz_print_hexdump_bits_handler(RzCore *core, int argc, const c
 		print_cursor(core->print, i, 1, 0);
 		if (c == 3) {
 			const ut8 *b = core->block + i - 3;
-			int (*k)(const ut8 *, int) = cmd_pxb_k;
+			ut32 (*k)(const ut8 *, int) = cmd_pxb_k;
 			char (*p)(char) = cmd_pxb_p;
 
-			int n = k(b, 0) | k(b, 1) | k(b, 2) | k(b, 3);
+			ut32 n = k(b, 0) | k(b, 1) | k(b, 2) | k(b, 3);
 			rz_cons_printf("0x%08x  %c%c%c%c\n",
 				n, p(b[0]), p(b[1]), p(b[2]), p(b[3]));
 			c = -1;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

`buffer[3 - x]` is of type `int` by default. And `x` is 3 at one point.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All green

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
