### PR TITLE
Ensure ELF symbols always have a name.

### DIFF
--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -496,7 +496,11 @@ static RzBinSymbol *convert_symbol(ELFOBJ *bin, RzBinElfSymbol *elf_symbol) {
 
 	result->paddr = elf_symbol->paddr;
 	result->vaddr = elf_symbol->vaddr;
-	result->name = rz_str_dup(elf_symbol->name);
+	if (RZ_STR_ISNOTEMPTY(elf_symbol->name)) {
+		result->name = rz_str_dup(elf_symbol->name);
+	} else {
+		result->name = rz_str_newf("unknown_%u", elf_symbol->ordinal);
+	}
 	result->forwarder = "NONE";
 	result->bind = elf_symbol->bind;
 	result->type = elf_symbol->type;

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -3167,7 +3167,7 @@ nth paddr      vaddr      bind   type   size lib name
 25  ---------- 0x080496b4 LOCAL  SECT   0        .bss
 26  ---------- 0x00000000 LOCAL  SECT   0        .comment
 27  ---------- 0x00000000 LOCAL  FILE   0        init.c
-28  ---------- 0x00000000 LOCAL  FILE   0        
+28  ---------- 0x00000000 LOCAL  FILE   0        unknown_28
 29  ---------- 0x00000000 LOCAL  FILE   0        crtstuff.c
 30  0x000005a4 0x080495a4 LOCAL  OBJ    0        __JCR_LIST__
 31  0x00000340 0x08048340 LOCAL  FUNC   0        deregister_tm_clones
@@ -3181,7 +3181,7 @@ nth paddr      vaddr      bind   type   size lib name
 39  ---------- 0x00000000 LOCAL  FILE   0        crtstuff.c
 40  0x00000598 0x08048598 LOCAL  OBJ    0        __FRAME_END__
 41  0x000005a4 0x080495a4 LOCAL  OBJ    0        __JCR_END__
-42  ---------- 0x00000000 LOCAL  FILE   0        
+42  ---------- 0x00000000 LOCAL  FILE   0        unknown_42
 43  0x000005a0 0x080495a0 LOCAL  NOTYPE 0        __init_array_end
 44  0x000005a8 0x080495a8 LOCAL  OBJ    0        _DYNAMIC
 45  0x0000059c 0x0804959c LOCAL  NOTYPE 0        __init_array_start
@@ -3571,7 +3571,7 @@ nth paddr      vaddr      bind   type   size lib name
 25  ---------- 0x00600910 LOCAL  SECT   0        .bss
 26  ---------- 0x00000000 LOCAL  SECT   0        .comment
 27  ---------- 0x00000000 LOCAL  FILE   0        init.c
-28  ---------- 0x00000000 LOCAL  FILE   0        
+28  ---------- 0x00000000 LOCAL  FILE   0        unknown_28
 29  ---------- 0x00000000 LOCAL  FILE   0        crtstuff.c
 30  0x000006f0 0x006006f0 LOCAL  OBJ    0        __JCR_LIST__
 31  0x00000440 0x00400440 LOCAL  FUNC   0        deregister_tm_clones
@@ -3585,7 +3585,7 @@ nth paddr      vaddr      bind   type   size lib name
 39  ---------- 0x00000000 LOCAL  FILE   0        crtstuff.c
 40  0x000006d8 0x004006d8 LOCAL  OBJ    0        __FRAME_END__
 41  0x000006f0 0x006006f0 LOCAL  OBJ    0        __JCR_END__
-42  ---------- 0x00000000 LOCAL  FILE   0        
+42  ---------- 0x00000000 LOCAL  FILE   0        unknown_42
 43  0x000006e8 0x006006e8 LOCAL  NOTYPE 0        __init_array_end
 44  0x000006f8 0x006006f8 LOCAL  OBJ    0        _DYNAMIC
 45  0x000006e0 0x006006e0 LOCAL  NOTYPE 0        __init_array_start

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -8845,8 +8845,7 @@ var double c @ ...
 |       ,=< 0x0000803e      cbnz  r3, 0x804e
 |       |   0x00008040      ldr   r3, [data.00008054]                  ; [0x8054:4]=0
 |      ,==< 0x00008042      cbz   r3, 0x804a
-|      ||   0x00008044      ldr   r0,                                  ; data.00008058
-|      ||                                                              ; [0x8058:4]=0x977c obj.__FRAME_END
+|      ||   0x00008044      ldr   r0, unknown_34                       ; [data.00008058:4]=0x977c obj.__FRAME_END
 |      ||   0x00008046      nop.w
 |      `--> 0x0000804a      movs  r3, 1
 |       |   0x0000804c      strb  r3, [r4]

--- a/test/db/formats/elf/elf-riscv64
+++ b/test/db/formats/elf/elf-riscv64
@@ -142,7 +142,7 @@ nth paddr      vaddr      bind   type   size lib name
 126 0x00011858 0x00020858 LOCAL  FUNC   444      _fpadd_parts
 127 ---------- 0x00000000 LOCAL  FILE   0        libgcc2.c
 128 ---------- 0x00000000 LOCAL  FILE   0        errno.c
-129 ---------- 0x00000000 LOCAL  FILE   0        
+129 ---------- 0x00000000 LOCAL  FILE   0        unknown_129
 130 0x00013630 0x00022630 LOCAL  NOTYPE 0        __fini_array_end
 131 0x00013628 0x00022628 LOCAL  NOTYPE 0        __fini_array_start
 132 0x00013628 0x00022628 LOCAL  NOTYPE 0        __init_array_end

--- a/test/db/formats/elf/symbols
+++ b/test/db/formats/elf/symbols
@@ -38,7 +38,7 @@ nth paddr      vaddr      bind   type   size lib name
 22  0x00200844 0x01c00844 LOCAL  SECT   0        .custom_text
 23  ---------- 0x00000000 LOCAL  SECT   0        .comment
 24  ---------- 0x00000000 LOCAL  FILE   0        custom_ldscript.c
-25  ---------- 0x00000000 LOCAL  FILE   0        
+25  ---------- 0x00000000 LOCAL  FILE   0        unknown_25
 26  0x00000660 0x00600660 LOCAL  NOTYPE 0        __init_array_end
 27  0x00000660 0x00600660 LOCAL  OBJ    0        _DYNAMIC
 28  0x00000660 0x00600660 LOCAL  NOTYPE 0        __init_array_start

--- a/test/db/tools/rz_bin
+++ b/test/db/tools/rz_bin
@@ -482,7 +482,7 @@ nth paddr      vaddr      bind   type   size lib name
 25  ---------- 0x080496b4 LOCAL  SECT   0        .bss
 26  ---------- 0x00000000 LOCAL  SECT   0        .comment
 27  ---------- 0x00000000 LOCAL  FILE   0        init.c
-28  ---------- 0x00000000 LOCAL  FILE   0        
+28  ---------- 0x00000000 LOCAL  FILE   0        unknown_28
 29  ---------- 0x00000000 LOCAL  FILE   0        crtstuff.c
 30  0x000005a4 0x080495a4 LOCAL  OBJ    0        __JCR_LIST__
 31  0x00000340 0x08048340 LOCAL  FUNC   0        deregister_tm_clones
@@ -496,7 +496,7 @@ nth paddr      vaddr      bind   type   size lib name
 39  ---------- 0x00000000 LOCAL  FILE   0        crtstuff.c
 40  0x00000598 0x08048598 LOCAL  OBJ    0        __FRAME_END__
 41  0x000005a4 0x080495a4 LOCAL  OBJ    0        __JCR_END__
-42  ---------- 0x00000000 LOCAL  FILE   0        
+42  ---------- 0x00000000 LOCAL  FILE   0        unknown_42
 43  0x000005a0 0x080495a0 LOCAL  NOTYPE 0        __init_array_end
 44  0x000005a8 0x080495a8 LOCAL  OBJ    0        _DYNAMIC
 45  0x0000059c 0x0804959c LOCAL  NOTYPE 0        __init_array_start


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

By standard, elf files can have no-name symbols. this break stuff in rizin and it should never happen

Fix #4577