### PR TITLE
Update capstone next to use CS_OPT_SYNTAX_NO_DOLLAR on loongarch

### DIFF
--- a/librz/arch/isa/loongarch/loongarch.inc
+++ b/librz/arch/isa/loongarch/loongarch.inc
@@ -34,7 +34,13 @@ loongarch_setup_cs_handle(RzAsmLoongArchContext *ctx, bool is_64_bits, bool big_
 	err = cs_option(ctx->h, CS_OPT_DETAIL, CS_OPT_ON);
 	if (err) {
 		const char *error_str = cs_strerror(err);
-		RZ_LOG_ERROR("Failed on cs_option() with error returned: %u: %s\n", err, error_str);
+		RZ_LOG_ERROR("Failed on cs_option(CS_OPT_DETAIL, CS_OPT_ON) with error returned: %u: %s\n", err, error_str);
+		return false;
+	}
+	err = cs_option(ctx->h, CS_OPT_SYNTAX, CS_OPT_SYNTAX_NO_DOLLAR);
+	if (err) {
+		const char *error_str = cs_strerror(err);
+		RZ_LOG_ERROR("Failed on cs_option(CS_OPT_SYNTAX, CS_OPT_SYNTAX_NO_DOLLAR) with error returned: %u: %s\n", err, error_str);
 		return false;
 	}
 	return true;

--- a/librz/arch/p/asm/asm_loongarch_cs.c
+++ b/librz/arch/p/asm/asm_loongarch_cs.c
@@ -29,12 +29,6 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	rz_asm_op_setf_asm(op, "%s%s%s",
 		ctx->insn->mnemonic, RZ_STR_ISNOTEMPTY(ctx->insn->op_str) ? " " : "", ctx->insn->op_str);
 
-	char *str = rz_asm_op_get_asm(op);
-	if (str) {
-		// remove the '$'<registername> in the string
-		rz_str_replace_char(str, '$', 0);
-	}
-
 beach:
 	cs_free(ctx->insn, ctx->count);
 	ctx->insn = NULL;

--- a/subprojects/capstone-next.wrap
+++ b/subprojects/capstone-next.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/capstone-engine/capstone.git
-revision = 9907b22d33693f3beb4b8b7ba261fbdd219afee3
+revision = b102f1b89e0455c072a751d287ab64378c14205f
 directory = capstone-next
 patch_directory = capstone-next
 depth = 1


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style)
- [ ] I've documented or updated the documentation of every function and struct this PR changes. If not so I've explained why.
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the [rizin book](https://github.com/rizinorg/book) with the relevant information (if needed)

**Detailed description**

Updates capstone to https://github.com/capstone-engine/capstone/commit/b102f1b89e0455c072a751d287ab64378c14205f and modifies loongarch to use `CS_OPT_SYNTAX_NO_DOLLAR`