### PR TITLE
`/e`: Omit length from herald

### DIFF
--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -134,6 +134,7 @@ struct search_parameters {
 	bool inverse;
 	bool aes_search;
 	bool privkey_search;
+	bool regex_search;
 };
 
 static int search_hash(RzCore *core, const char *hashname, const char *hashstr, ut32 minlen, ut32 maxlen, struct search_parameters *param) {
@@ -1277,10 +1278,13 @@ static void do_string_search(RzCore *core, RzInterval search_itv, struct search_
 			}
 			if (param->outmode != RZ_MODE_JSON) {
 				RzSearchKeyword *kw = rz_list_first(core->search->kws);
-				int lenstr = kw ? kw->keyword_length : 0;
-				const char *bytestr = lenstr > 1 ? "bytes" : "byte";
-				eprintf("Searching %d %s in [0x%" PFMT64x "-0x%" PFMT64x "]\n",
-					kw ? kw->keyword_length : 0, bytestr, itv.addr, rz_itv_end(itv));
+				eprintf("Searching");
+				if (!param->regex_search) {
+					int lenstr = kw ? kw->keyword_length : 0;
+					const char *bytestr = lenstr > 1 ? "bytes" : "byte";
+					eprintf(" %d %s", kw ? kw->keyword_length : 0, bytestr);
+				}
+				eprintf(" in [0x%" PFMT64x "-0x%" PFMT64x "]\n", itv.addr, rz_itv_end(itv));
 			}
 			if (!core->search->bckwrds) {
 				RzListIter *it;
@@ -1734,6 +1738,7 @@ RZ_IPI int rz_cmd_search(void *data, const char *input) {
 		.inverse = false,
 		.aes_search = false,
 		.privkey_search = false,
+		.regex_search = false,
 	};
 	if (!param.cmd_hit) {
 		param.cmd_hit = "";
@@ -2366,6 +2371,7 @@ reread:
 			rz_search_kw_add(core->search, kw);
 			rz_search_begin(core->search);
 			dosearch = true;
+			param.regex_search = true;
 		} else {
 			RZ_LOG_ERROR("core: Missing regex\n");
 		}

--- a/test/db/cmd/regexp
+++ b/test/db/cmd/regexp
@@ -51,9 +51,25 @@ CMDS=<<EOF
 w abcd
 w bcde @ 0x10
 /e /b.*d/~[0-1]
+echo ----
+/e /b.*D/~[0-1]
+echo ----
+/e /b.*D/i~[0-1]
 EOF
 EXPECT=<<EOF
 0x00000001 hit0_0
 0x00000010 hit0_1
+----
+----
+0x00000001 hit2_0
+0x00000010 hit2_1
+EOF
+EXPECT_ERR=<<EOF
+Searching 4 bytes in [0x0-0x200]
+[2Khits: 2
+Searching 4 bytes in [0x0-0x200]
+[2Khits: 0
+Searching 4 bytes in [0x0-0x200]
+[2Khits: 2
 EOF
 RUN

--- a/test/db/cmd/regexp
+++ b/test/db/cmd/regexp
@@ -65,11 +65,11 @@ EXPECT=<<EOF
 0x00000010 hit2_1
 EOF
 EXPECT_ERR=<<EOF
-Searching 4 bytes in [0x0-0x200]
+Searching in [0x0-0x200]
 [2Khits: 2
-Searching 4 bytes in [0x0-0x200]
+Searching in [0x0-0x200]
 [2Khits: 0
-Searching 4 bytes in [0x0-0x200]
+Searching in [0x0-0x200]
 [2Khits: 2
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr omits the length information from the `/e` herald since a regex match may not be of constant length.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
