### PR TITLE
`/e`: Set `RZ_REGEX_MULTILINE` for `^` and `$`

### DIFF
--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -42,7 +42,7 @@ static const char *help_msg_slash[] = {
 	"/b", "", "search backwards, command modifier, followed by other command",
 	"/c", "[?][adr]", "search for crypto materials",
 	"/d", " 101112", "search for a deltified sequence of bytes",
-	"/e", " /pattern/[i]", "match regular expression (end-of-string for ^ and $ is '\\0')",
+	"/e", " /pattern/[i]", "match regular expression (beginning-of-string for ^ and $ is '\\0')",
 	"/E", " esil-expr", "offset matching given esil expressions $$ = here",
 	"/f", "", "search forwards, (command modifier)",
 	"/F", " file [off] [sz]", "search contents of file with offset and size",

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -42,7 +42,7 @@ static const char *help_msg_slash[] = {
 	"/b", "", "search backwards, command modifier, followed by other command",
 	"/c", "[?][adr]", "search for crypto materials",
 	"/d", " 101112", "search for a deltified sequence of bytes",
-	"/e", " /pattern/[i]", "match regular expression",
+	"/e", " /pattern/[i]", "match regular expression (end-of-string for ^ and $ is '\\0')",
 	"/E", " esil-expr", "offset matching given esil expressions $$ = here",
 	"/f", "", "search forwards, (command modifier)",
 	"/F", " file [off] [sz]", "search contents of file with offset and size",

--- a/librz/search/regexp.c
+++ b/librz/search/regexp.c
@@ -20,7 +20,7 @@ RZ_API int rz_search_regexp_update(RzSearch *s, ut64 from, const ut8 *buf, int l
 	rz_regex_set_nul_as_newline(ccontext);
 
 	rz_list_foreach (s->kws, iter, kw) {
-		int cflags = RZ_REGEX_EXTENDED;
+		int cflags = RZ_REGEX_EXTENDED | RZ_REGEX_MULTILINE;
 
 		if (kw->icase) {
 			cflags |= RZ_REGEX_CASELESS;

--- a/test/db/cmd/regexp
+++ b/test/db/cmd/regexp
@@ -51,19 +51,27 @@ CMDS=<<EOF
 w abcd
 w bcccde @ 0x10
 e scr.color=1
+echo -- 1 --
 /e /b.*d/
-echo ----
+echo -- 2 --
 /e /b.*D/
-echo ----
+echo -- 3 --
 /e /b.*D/i
+echo -- 4 --
+/e /b.*d$/
+echo -- 5 --
+/e /^b.*d/
 EOF
 EXPECT=<<EOF
+-- 1 --
 0x00000001 hit0_0 .a[33mbcd[0mbccc.
 0x00000010 hit0_1 .abcd[33mbcccd[0me.
-----
-----
+-- 2 --
+-- 3 --
 0x00000001 hit2_0 .a[33mbcd[0mbccc.
 0x00000010 hit2_1 .abcd[33mbcccd[0me.
+-- 4 --
+-- 5 --
 EOF
 EXPECT_ERR=<<EOF
 Searching in [0x0-0x200]
@@ -72,5 +80,9 @@ Searching in [0x0-0x200]
 [2Khits: 0
 Searching in [0x0-0x200]
 [2Khits: 2
+Searching in [0x0-0x200]
+[2Khits: 0
+Searching in [0x0-0x200]
+[2Khits: 0
 EOF
 RUN

--- a/test/db/cmd/regexp
+++ b/test/db/cmd/regexp
@@ -71,7 +71,9 @@ EXPECT=<<EOF
 0x00000001 hit2_0 .a[33mbcd[0mbccc.
 0x00000010 hit2_1 .abcd[33mbcccd[0me.
 -- 4 --
+0x00000001 hit3_0 .a[33mbcd[0mbccc.
 -- 5 --
+0x00000010 hit4_0 .abcd[33mbcccd[0me.
 EOF
 EXPECT_ERR=<<EOF
 Searching in [0x0-0x200]
@@ -81,8 +83,8 @@ Searching in [0x0-0x200]
 Searching in [0x0-0x200]
 [2Khits: 2
 Searching in [0x0-0x200]
-[2Khits: 0
+[2Khits: 1
 Searching in [0x0-0x200]
-[2Khits: 0
+[2Khits: 1
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr sets `RZ_REGEX_MULTILINE` for the `/e` regex search so that `^` and `$` can match the beginning and end respectively of a C string. For `^`, there is probably the assumption that the string is at the beginning of the searched area or has a `\0` before it.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
