### PR TITLE
Fix search range notation in search herald

### DIFF
--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -1284,7 +1284,7 @@ static void do_string_search(RzCore *core, RzInterval search_itv, struct search_
 					const char *bytestr = lenstr > 1 ? "bytes" : "byte";
 					eprintf(" %d %s", kw ? kw->keyword_length : 0, bytestr);
 				}
-				eprintf(" in [0x%" PFMT64x "-0x%" PFMT64x "]\n", itv.addr, rz_itv_end(itv));
+				eprintf(" in [0x%" PFMT64x ",0x%" PFMT64x ")\n", itv.addr, rz_itv_end(itv));
 			}
 			if (!core->search->bckwrds) {
 				RzListIter *it;

--- a/librz/include/rz_util/rz_itv.h
+++ b/librz/include/rz_util/rz_itv.h
@@ -7,13 +7,16 @@
 extern "C" {
 #endif
 
-// An interval in 64-bit address space which is aware of address space wraparound
-// Precondition: 0 <= size < 2**64 and addr + size <= 2**64
-// range is [], [10, 5) => 10 <= x < (10 + 5)
+/**
+ * \brief An interval in 64-bit address space which is aware of address space wraparound.
+ *
+ * Precondition: 0 <= size < 2**64 and addr + size <= 2**64
+ * Interval range is [addr, addr + size)
+ * e.g. with addr = 10 and size = 5, interval range is [10, 15) where 10 <= x < (10 + 5).
+ */
 typedef struct rz_interval_t {
-	// public:
-	ut64 addr;
-	ut64 size;
+	ut64 addr; ///< Start address of the interval.
+	ut64 size; ///< Size of the interval in bytes.
 } RzInterval;
 
 typedef RzInterval rz_itv_t;

--- a/test/db/cmd/regexp
+++ b/test/db/cmd/regexp
@@ -76,15 +76,15 @@ EXPECT=<<EOF
 0x00000010 hit4_0 .abcd[33mbcccd[0me.
 EOF
 EXPECT_ERR=<<EOF
-Searching in [0x0-0x200]
+Searching in [0x0,0x200)
 [2Khits: 2
-Searching in [0x0-0x200]
+Searching in [0x0,0x200)
 [2Khits: 0
-Searching in [0x0-0x200]
+Searching in [0x0,0x200)
 [2Khits: 2
-Searching in [0x0-0x200]
+Searching in [0x0,0x200)
 [2Khits: 1
-Searching in [0x0-0x200]
+Searching in [0x0,0x200)
 [2Khits: 1
 EOF
 RUN
@@ -107,9 +107,9 @@ EXPECT=<<EOF
 0x000001fe hit1_0 .[33mbd[0m.
 EOF
 EXPECT_ERR=<<EOF
-Searching in [0x0-0x200]
+Searching in [0x0,0x200)
 [2Khits: 2
-Searching in [0x0-0x200]
+Searching in [0x0,0x200)
 [2Khits: 1
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

From the definition of `rz_itv_end()`:
https://github.com/rizinorg/rizin/blob/2c1a07d5242f62ebeaacd53113473aa429a3f34c/librz/include/rz_util/rz_itv.h#L42-L44
the address returned by it is one byte _beyond_ the interval and so this pr changes the range notation used in the search herald to reflect that. 

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
