### PR TITLE
Fix inconsistency between `/` and `/e`

### DIFF
--- a/librz/search/regexp.c
+++ b/librz/search/regexp.c
@@ -32,7 +32,7 @@ RZ_API int rz_search_regexp_update(RzSearch *s, ut64 from, const ut8 *buf, int l
 			return -1;
 		}
 
-		matches = rz_regex_match_all_not_grouped(compiled, (char *)buf, len, 0, RZ_REGEX_DEFAULT);
+		matches = rz_regex_match_all_not_grouped(compiled, (const char *)buf, len, 0, RZ_REGEX_DEFAULT);
 		void **it;
 		rz_pvector_foreach (matches, it) {
 			RzRegexMatch *m = *it;

--- a/librz/search/regexp.c
+++ b/librz/search/regexp.c
@@ -32,12 +32,12 @@ RZ_API int rz_search_regexp_update(RzSearch *s, ut64 from, const ut8 *buf, int l
 			return -1;
 		}
 
-		matches = rz_regex_match_all_not_grouped(compiled, (char *)buf, len, from, RZ_REGEX_DEFAULT);
+		matches = rz_regex_match_all_not_grouped(compiled, (char *)buf, len, 0, RZ_REGEX_DEFAULT);
 		void **it;
 		rz_pvector_foreach (matches, it) {
 			RzRegexMatch *m = *it;
 			kw->keyword_length = m->len; // For a regex search, the keyword can be of variable length
-			int t = rz_search_hit_new(s, kw, m->start);
+			int t = rz_search_hit_new(s, kw, from + m->start);
 			if (t == 0) {
 				ret = -1;
 				rz_pvector_free(matches);

--- a/test/db/cmd/regexp
+++ b/test/db/cmd/regexp
@@ -113,3 +113,42 @@ Searching in [0x0,0x200)
 [2Khits: 1
 EOF
 RUN
+
+NAME=consistency btw / and /e
+FILE=bins/elf/analysis/ls2
+CMDS=<<EOF
+e scr.color=1
+/ lib
+echo ----
+/e /lib/
+EOF
+EXPECT=<<EOF
+0x00400239 hit0_0 ./[33mlib[0m64/ld-linux-x86-.
+0x00400f19 hit0_1 .a[33mlib[0mselinux.so.1_IT.
+0x00400fae hit0_2 .etfilecon_fini[33mlib[0macl.so.1acl_get.
+0x00400feb hit0_3 .l_extended_file[33mlib[0mc.so.6fflushst.
+0x004013c3 hit0_4 .cmptcgetpgrp__[33mlib[0mc_start_maindir.
+0x0041769a hit0_5 .system call./.[33mlib[0ms/lt-.
+0x004186e0 hit0_6 .emory exhausted[33mlib[0m/xstrtol.c0 <.
+0x00418e58 hit0_7 .xstrtoumax/usr/[33mlib[0mASCIICHARSETAL.
+----
+EOF
+EXPECT_ERR=<<EOF
+Searching 3 bytes in [0x61d368,0x61d720)
+[2Khits: 0
+Searching 3 bytes in [0x400000,0x41bc2c)
+[  ]  0x00403a00 < 0x0041bc2c  hits = 5   [# ][  ]  0x00407a00 < 0x0041bc2c  hits = 5   [# ][  ]  0x0040ba00 < 0x0041bc2c  hits = 5   [# ][  ]  0x0040fa00 < 0x0041bc2c  hits = 5   [# ][  ]  0x00413a00 < 0x0041bc2c  hits = 5   [# ][  ]  0x00417a00 < 0x0041bc2c  hits = 6   [# ][  ]  0x0041ba00 < 0x0041bc2c  hits = 8   [# ][2Khits: 8
+Searching 3 bytes in [0x61c5f4,0x61d360)
+[2Khits: 0
+Searching 3 bytes in [0x61bdf0,0x61c5f4)
+[2Khits: 0
+Searching in [0x61d368,0x61d720)
+[2Khits: 0
+Searching in [0x400000,0x41bc2c)
+[2Khits: 0
+Searching in [0x61c5f4,0x61d360)
+[2Khits: 0
+Searching in [0x61bdf0,0x61c5f4)
+[2Khits: 0
+EOF
+RUN

--- a/test/db/cmd/regexp
+++ b/test/db/cmd/regexp
@@ -132,6 +132,14 @@ EXPECT=<<EOF
 0x004186e0 hit0_6 .emory exhausted[33mlib[0m/xstrtol.c0 <.
 0x00418e58 hit0_7 .xstrtoumax/usr/[33mlib[0mASCIICHARSETAL.
 ----
+0x00400239 hit1_0 ./[33mlib[0m64/ld-linux-x86-.
+0x00400f19 hit1_1 .a[33mlib[0mselinux.so.1_IT.
+0x00400fae hit1_2 .etfilecon_fini[33mlib[0macl.so.1acl_get.
+0x00400feb hit1_3 .l_extended_file[33mlib[0mc.so.6fflushst.
+0x004013c3 hit1_4 .cmptcgetpgrp__[33mlib[0mc_start_maindir.
+0x0041769a hit1_5 .system call./.[33mlib[0ms/lt-.
+0x004186e0 hit1_6 .emory exhausted[33mlib[0m/xstrtol.c0 <.
+0x00418e58 hit1_7 .xstrtoumax/usr/[33mlib[0mASCIICHARSETAL.
 EOF
 EXPECT_ERR=<<EOF
 Searching 3 bytes in [0x61d368,0x61d720)
@@ -145,7 +153,7 @@ Searching 3 bytes in [0x61bdf0,0x61c5f4)
 Searching in [0x61d368,0x61d720)
 [2Khits: 0
 Searching in [0x400000,0x41bc2c)
-[2Khits: 0
+[2Khits: 8
 Searching in [0x61c5f4,0x61d360)
 [2Khits: 0
 Searching in [0x61bdf0,0x61c5f4)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes an inconsistency between `/` and `/e`, in which hits were found with `/ <text>` but not with `/e /<text>/` despite a `<text>` that is free of regex operators.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
