### PR TITLE
Fix CS4 & CS5 build since CS_MODE_MIPS4 is available only on CS6+

### DIFF
--- a/librz/arch/p/arch_mips_cs.c
+++ b/librz/arch/p/arch_mips_cs.c
@@ -98,15 +98,15 @@ static bool cs_mode_from_cpu(const char *cpu, int bits, bool big_endian, cs_mode
 		return_on_cpu("r4400", CS_MODE_MIPS3);
 		return_on_cpu("r4600", CS_MODE_MIPS3);
 		return_on_cpu("r4700", CS_MODE_MIPS3);
-		return_on_cpu("r5000", CS_MODE_MIPS4);
-		return_on_cpu("rm5000", CS_MODE_MIPS4);
-		return_on_cpu("rm7000", CS_MODE_MIPS4);
-		return_on_cpu("r8000", CS_MODE_MIPS4);
-		return_on_cpu("r9000", CS_MODE_MIPS4);
-		return_on_cpu("r10000", CS_MODE_MIPS4);
-		return_on_cpu("r12000", CS_MODE_MIPS4);
-		return_on_cpu("r14000", CS_MODE_MIPS4);
-		return_on_cpu("r16000", CS_MODE_MIPS4);
+		return_on_cpu("r5000", CS_MODE_MIPS64);
+		return_on_cpu("rm5000", CS_MODE_MIPS64);
+		return_on_cpu("rm7000", CS_MODE_MIPS64);
+		return_on_cpu("r8000", CS_MODE_MIPS64);
+		return_on_cpu("r9000", CS_MODE_MIPS64);
+		return_on_cpu("r10000", CS_MODE_MIPS64);
+		return_on_cpu("r12000", CS_MODE_MIPS64);
+		return_on_cpu("r14000", CS_MODE_MIPS64);
+		return_on_cpu("r16000", CS_MODE_MIPS64);
 	}
 
 #else // CS_NEXT_VERSION >= 6


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

Fixes the redness of CS4 CS5 builds.