### PR TITLE
string search json: Remove `data` property

### DIFF
--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -458,23 +458,20 @@ static int _cb_hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 			return 0;
 		}
 		switch (kw->type) {
-		case RZ_SEARCH_KEYWORD_TYPE_STRING: {
-			const int ctx = 16;
-			const int prectx = addr > 16 ? ctx : addr;
-			char *pre, *pos, *wrd;
-			const int len = keyword_len;
-			char *buf = calloc(1, len + 32 + ctx * 2);
+		case RZ_SEARCH_KEYWORD_TYPE_STRING:
 			type = "string";
-			rz_io_read_at(core->io, addr - prectx, (ut8 *)buf, len + (ctx * 2));
-			pre = getstring(buf, prectx, use_color);
-			pos = getstring(buf + prectx + len, ctx, use_color);
-			if (!pos) {
-				pos = rz_str_dup("");
-			}
-			if (param->outmode == RZ_MODE_JSON) {
-				wrd = getstring(buf + prectx, len, false);
-				s = rz_str_newf("%s%s%s", pre, wrd, pos);
-			} else {
+			if (param->outmode != RZ_MODE_JSON) {
+				const int ctx = 16;
+				const int prectx = addr > 16 ? ctx : addr;
+				char *pre, *pos, *wrd;
+				const int len = keyword_len;
+				char *buf = calloc(1, len + 32 + ctx * 2);
+				rz_io_read_at(core->io, addr - prectx, (ut8 *)buf, len + (ctx * 2));
+				pre = getstring(buf, prectx, use_color);
+				pos = getstring(buf + prectx + len, ctx, use_color);
+				if (!pos) {
+					pos = rz_str_dup("");
+				}
 				wrd = rz_str_utf16_encode(buf + prectx, len);
 				if (use_color) {
 					char *pre_color = get_colored_context(pre);
@@ -486,13 +483,11 @@ static int _cb_hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 				} else {
 					s = rz_str_newf("\"%s%s%s\"", pre, wrd, pos);
 				}
+				free(buf);
+				free(pre);
+				free(wrd);
+				free(pos);
 			}
-			free(buf);
-			free(pre);
-			free(wrd);
-			free(pos);
-		}
-			free(p);
 			break;
 		default:
 			len = keyword_len; // 8 byte context
@@ -524,10 +519,13 @@ static int _cb_hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 		}
 
 		if (param->outmode == RZ_MODE_JSON) {
+			// TODO: offset alone not sufficient for regex search
 			pj_o(param->pj);
 			pj_kn(param->pj, "offset", base_addr + addr);
 			pj_ks(param->pj, "type", type);
-			pj_ks(param->pj, "data", s);
+			if (kw->type != RZ_SEARCH_KEYWORD_TYPE_STRING) {
+				pj_ks(param->pj, "data", s);
+			}
 			pj_end(param->pj);
 		} else {
 			rz_cons_printf("0x%08" PFMT64x " %s%d_%d %s\n",

--- a/test/db/cmd/cmd_json
+++ b/test/db/cmd/cmd_json
@@ -37,8 +37,7 @@ EXPECT=<<EOF
 [
   {
     "offset": 4203952,
-    "type": "string",
-    "data": "cation1\\Release\\ConsoleApplication1.pdb..... ... ......"
+    "type": "string"
   }
 ]
 EOF

--- a/test/db/cmd/cmd_search
+++ b/test/db/cmd/cmd_search
@@ -126,7 +126,7 @@ NAME=/j escaped
 FILE=bins/mach0/escaped
 CMDS=/j hello
 EXPECT=<<EOF
-[{"offset":8019,"type":"string","data":"....]........c:\\hello\\world..M......."}]
+[{"offset":8019,"type":"string"}]
 EOF
 RUN
 
@@ -168,7 +168,7 @@ wx 666f6f005c
 /j foo
 EOF
 EXPECT=<<EOF
-[{"offset":0,"type":"string","data":"foo.\\.............."}]
+[{"offset":0,"type":"string"}]
 EOF
 RUN
 

--- a/test/db/cmd/cmd_search_hit
+++ b/test/db/cmd/cmd_search_hit
@@ -20,7 +20,7 @@ ps @@/j hello
 EOF
 EXPECT=<<EOF
 hello
-[{"offset":10,"type":"string","data":"..........hello................"}]
+[{"offset":10,"type":"string"}]
 EOF
 RUN
 
@@ -42,7 +42,7 @@ wx 0067
 /j g
 EOF
 EXPECT=<<EOF
-[{"offset":1,"type":"string","data":".g................"}]
+[{"offset":1,"type":"string"}]
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

For fixed-length string search (not regex search), it is sufficient to have only the hit offset / address to determine the boundaries of a match. Thus, this pr proposes removing the `data` property from string search json, putting the onus on the scripter to decide what to do next with the hit offsets. The main advantage of removal is to reduce the space needed for the json string, but this also sidesteps the issues of `data` encoding and length, and cleans up the code a bit. 

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
