### PR TITLE
`/e`: Add match length to results

### DIFF
--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -538,12 +538,18 @@ static int _cb_hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 		if (param->outmode == RZ_MODE_JSON) {
 			pj_o(param->pj);
 			pj_kn(param->pj, "offset", base_addr + addr);
+			if (param->regex_search) {
+				pj_ki(param->pj, "len", keyword_len);
+			}
 			pj_ks(param->pj, "type", type);
 			pj_ks(param->pj, "data", s);
 			pj_end(param->pj);
 		} else {
-			rz_cons_printf("0x%08" PFMT64x " %s%d_%d %s\n",
-				base_addr + addr, searchprefix, kw->kwidx, kw->count, s);
+			rz_cons_printf("0x%08" PFMT64x, base_addr + addr);
+			if (param->regex_search) {
+				rz_cons_printf(" %d", keyword_len);
+			}
+			rz_cons_printf(" %s%d_%d %s\n", searchprefix, kw->kwidx, kw->count, s);
 		}
 		free(s);
 		free(buf);

--- a/test/db/cmd/regexp
+++ b/test/db/cmd/regexp
@@ -10,8 +10,8 @@ b 777
 EOF
 EXPECT=<<EOF
 
-0x00000000 hit0_0 "test................"
-0x000001bc hit0_1 "................Test................"
+0x00000000 4 hit0_0 "test................"
+0x000001bc 4 hit0_1 "................Test................"
 EOF
 RUN
 
@@ -40,8 +40,8 @@ b 777
 EOF
 EXPECT=<<EOF
 
-0x00000001 hit0_0 ""test123 ab"..............."
-0x000001bd hit0_1 "..............."Test123 ab"..............."
+0x00000001 10 hit0_0 ""test123 ab"..............."
+0x000001bd 10 hit0_1 "..............."Test123 ab"..............."
 EOF
 RUN
 
@@ -64,16 +64,16 @@ echo -- 5 --
 EOF
 EXPECT=<<EOF
 -- 1 --
-0x00000001 hit0_0 "a[33mbcd[0m[34m............[0mbccc"
-0x00000010 hit0_1 "abcd[34m............[0m[33mbcccd[0me[34m...............[0m"
+0x00000001 3 hit0_0 "a[33mbcd[0m[34m............[0mbccc"
+0x00000010 5 hit0_1 "abcd[34m............[0m[33mbcccd[0me[34m...............[0m"
 -- 2 --
 -- 3 --
-0x00000001 hit2_0 "a[33mbcd[0m[34m............[0mbccc"
-0x00000010 hit2_1 "abcd[34m............[0m[33mbcccd[0me[34m...............[0m"
+0x00000001 3 hit2_0 "a[33mbcd[0m[34m............[0mbccc"
+0x00000010 5 hit2_1 "abcd[34m............[0m[33mbcccd[0me[34m...............[0m"
 -- 4 --
-0x00000001 hit3_0 "a[33mbcd[0m[34m............[0mbccc"
+0x00000001 3 hit3_0 "a[33mbcd[0m[34m............[0mbccc"
 -- 5 --
-0x00000010 hit4_0 "abcd[34m............[0m[33mbcccd[0me[34m...............[0m"
+0x00000010 5 hit4_0 "abcd[34m............[0m[33mbcccd[0me[34m...............[0m"
 EOF
 EXPECT_ERR=<<EOF
 Searching in [0x0,0x200)
@@ -101,10 +101,10 @@ echo ----
 /e /b.*d$/
 EOF
 EXPECT=<<EOF
-0x000000fe hit0_0 "[34m................[0m[33mbcccd[0me[34m...............[0m"
-0x000001fe hit0_1 "[34m................[0m[33mbd[0m[34m................[0m"
+0x000000fe 5 hit0_0 "[34m................[0m[33mbcccd[0me[34m...............[0m"
+0x000001fe 2 hit0_1 "[34m................[0m[33mbd[0m[34m................[0m"
 ----
-0x000001fe hit1_0 "[34m................[0m[33mbd[0m[34m................[0m"
+0x000001fe 2 hit1_0 "[34m................[0m[33mbd[0m[34m................[0m"
 EOF
 EXPECT_ERR=<<EOF
 Searching in [0x0,0x200)
@@ -132,14 +132,14 @@ EXPECT=<<EOF
 0x004186e0 hit0_6 "emory exhausted[34m.[0m[33mlib[0m/xstrtol.c[34m...[0m0 <"
 0x00418e58 hit0_7 "xstrtoumax[34m.[0m/usr/[33mlib[0m[34m.[0mASCII[34m.[0mCHARSETAL"
 ----
-0x00400239 hit1_0 "[34m...............[0m/[33mlib[0m64/ld-linux-x86-"
-0x00400f19 hit1_1 "[34m.[0ma[34m..............[0m[33mlib[0mselinux.so.1[34m.[0m_IT"
-0x00400fae hit1_2 "etfilecon[34m.[0m_fini[34m.[0m[33mlib[0macl.so.1[34m.[0macl_get"
-0x00400feb hit1_3 "l_extended_file[34m.[0m[33mlib[0mc.so.6[34m.[0mfflush[34m.[0mst"
-0x004013c3 hit1_4 "cmp[34m.[0mtcgetpgrp[34m.[0m__[33mlib[0mc_start_main[34m.[0mdir"
-0x0041769a hit1_5 "system call.[34m..[0m/.[33mlib[0ms/[34m.[0mlt-[34m..........[0m"
-0x004186e0 hit1_6 "emory exhausted[34m.[0m[33mlib[0m/xstrtol.c[34m...[0m0 <"
-0x00418e58 hit1_7 "xstrtoumax[34m.[0m/usr/[33mlib[0m[34m.[0mASCII[34m.[0mCHARSETAL"
+0x00400239 3 hit1_0 "[34m...............[0m/[33mlib[0m64/ld-linux-x86-"
+0x00400f19 3 hit1_1 "[34m.[0ma[34m..............[0m[33mlib[0mselinux.so.1[34m.[0m_IT"
+0x00400fae 3 hit1_2 "etfilecon[34m.[0m_fini[34m.[0m[33mlib[0macl.so.1[34m.[0macl_get"
+0x00400feb 3 hit1_3 "l_extended_file[34m.[0m[33mlib[0mc.so.6[34m.[0mfflush[34m.[0mst"
+0x004013c3 3 hit1_4 "cmp[34m.[0mtcgetpgrp[34m.[0m__[33mlib[0mc_start_main[34m.[0mdir"
+0x0041769a 3 hit1_5 "system call.[34m..[0m/.[33mlib[0ms/[34m.[0mlt-[34m..........[0m"
+0x004186e0 3 hit1_6 "emory exhausted[34m.[0m[33mlib[0m/xstrtol.c[34m...[0m0 <"
+0x00418e58 3 hit1_7 "xstrtoumax[34m.[0m/usr/[33mlib[0m[34m.[0mASCII[34m.[0mCHARSETAL"
 EOF
 EXPECT_ERR=<<EOF
 Searching 3 bytes in [0x61d368,0x61d720)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr adds the match length to `/e` regex search results since it can be different for different hits.

This pr is currently just a reminder that regex search results are incomplete without the match length. Once #4762 lands (which has the match length displayed for apparently all searches), this pr can be closed.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
