### PR TITLE
Remove RZ_NULLABLE from RzSearchFindBytesCallback function pointer type

### DIFF
--- a/librz/search/search_internal.h
+++ b/librz/search/search_internal.h
@@ -62,6 +62,7 @@ typedef bool (*RzSearchIsEmptyCallback)(void *user);
 /**
  * \brief A callback checking a chunk of bytes if it matches the search criteria.
  *
+ * \param fopt The find() search options.
  * \param user The private user data.
  * \param address The address associated with the given bytes.
  * \param buffer The bytes buffer.

--- a/librz/search/search_internal.h
+++ b/librz/search/search_internal.h
@@ -70,7 +70,7 @@ typedef bool (*RzSearchIsEmptyCallback)(void *user);
  * \return True, if a match was found.
  * \return False otherwise.
  */
-typedef bool (*RzSearchFindBytesCallback)(RZ_NULLABLE RzSearchFindOpt *fopt, void *user, ut64 address, const RzBuffer *buffer, RZ_OUT RzThreadQueue *hits);
+typedef bool (*RzSearchFindBytesCallback)(RzSearchFindOpt *fopt, void *user, ut64 address, const RzBuffer *buffer, RZ_OUT RzThreadQueue *hits);
 
 /**
  * \brief A callback to search a graph for a pattern.


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr removes `RZ_NULLABLE` from the `fopt` parameter of the `RzSearchFindBytesCallback` function pointer type, because defaults should be in one place rather than scattered through code. Sorry, forgot to do the removal in #4928.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
