### PR TITLE
Clean leftover files after kd test

### DIFF
--- a/test/db/cmd/cmd_k
+++ b/test/db/cmd/cmd_k
@@ -89,6 +89,8 @@ k debug/abc=0
 k debug/*
 kd output_file debug
 k debug/*
+rm output_file
+rm file.sdb
 EOF
 EXPECT=<<EOF
 abc=123


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

The test always left behind output_file and file.sdb artifacts

**Test plan**

`rz-test test/db/cmd/cmd_k` should not leave behind these files