### PR TITLE
search: Clear progress before results

### DIFF
--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -2465,6 +2465,11 @@ static RzCmdStatus cmd_core_handle_search_hits(RzCore *core, RzCmdStateOutput *s
 		return RZ_CMD_STATUS_ERROR;
 	}
 
+	if (rz_config_get_b(core->config, "search.show_progress")) {
+		// clear last progress notification, if any
+		rz_cons_clear_line(1);
+	}
+
 	RzListIter *it = NULL;
 	RzSearchHit *hit = NULL;
 	const char *cmd_hit = NULL;

--- a/librz/search/search.c
+++ b/librz/search/search.c
@@ -565,12 +565,15 @@ static void *search_cancel_th(void *user) {
 	RzSearchOpt *opt = ctx->opt;
 
 	do {
+		rz_sys_usleep(RZ_SEARCH_CANCEL_CHECK_INTERVAL_USEC);
+		if (!rz_atomic_bool_get(ctx->loop)) {
+			break;
+		}
 		size_t n_hits = rz_th_queue_size(ctx->hits);
 		if (opt->cancel_cb(opt->cancel_usr, n_hits, RZ_SEARCH_CANCEL_REGULAR_CHECK)) {
 			rz_atomic_bool_set(ctx->loop, false);
 			break;
 		}
-		rz_sys_usleep(RZ_SEARCH_CANCEL_CHECK_INTERVAL_USEC);
 	} while (rz_atomic_bool_get(ctx->loop));
 
 	return NULL;

--- a/librz/search/search.c
+++ b/librz/search/search.c
@@ -564,7 +564,7 @@ static void *search_cancel_th(void *user) {
 	search_ctx_t *ctx = (search_ctx_t *)user;
 	RzSearchOpt *opt = ctx->opt;
 
-	do {
+	while (true) {
 		rz_sys_usleep(RZ_SEARCH_CANCEL_CHECK_INTERVAL_USEC);
 		if (!rz_atomic_bool_get(ctx->loop)) {
 			break;
@@ -574,7 +574,7 @@ static void *search_cancel_th(void *user) {
 			rz_atomic_bool_set(ctx->loop, false);
 			break;
 		}
-	} while (rz_atomic_bool_get(ctx->loop));
+	}
 
 	return NULL;
 }

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -285,12 +285,13 @@ RUN
 
 NAME=String Search - ~[0]
 FILE=bins/cmd/search/string_encodings/Latin-Lipsum.ascii
+ARGS=-1
 CMDS=<<EOF
 e search.show_progress=true
 /z "placerat ut, eu etiam vitae nam"~[0]
 EOF
 EXPECT=<<EOF
-0x000000fa
+Searching... hits: 00x000000fa
 EOF
 RUN
 

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -291,7 +291,7 @@ e search.show_progress=true
 /z "placerat ut, eu etiam vitae nam"~[0]
 EOF
 EXPECT=<<EOF
-Searching... hits: 00x000000fa
+[2K0x000000fa
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The search progress notification is of significant length, so if the first result line is short, then there will be an unwanted tail, e.g.

![slash-z-first-has-tail](https://github.com/user-attachments/assets/245a5dca-19df-452d-8621-030f01c3d7f1)

due to use of just `\r`. This pr clears the last progress notification before printing the results so the above will not happen. It also sleeps first before printing search progress, rather than the other way around, to prevent unnecessary flicker.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green. Test may be racy, but hopefully CI computers are fast enough.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
