### PR TITLE
Refactoring wasm and allow string to be longer than 256 bytes.

### DIFF
--- a/librz/bin/format/wasm/wasm.c
+++ b/librz/bin/format/wasm/wasm.c
@@ -83,7 +83,7 @@ static size_t consume_str_r(RzBuffer *b, ut64 max, size_t sz, char *out) {
 		return 0;
 	}
 	if (sz > 0) {
-		rz_buf_read(b, (ut8 *)out, RZ_MIN(RZ_BIN_WASM_STRING_LENGTH - 1, sz));
+		rz_buf_read(b, (ut8 *)out, sz);
 	} else {
 		*out = 0;
 	}
@@ -118,7 +118,7 @@ static size_t consume_locals_r(RzBuffer *b, ut64 max, RzBinWasmCodeEntry *out) {
 	}
 	ut32 count = out->local_count;
 	if (count > 0) {
-		if (!(out->locals = RZ_NEWS0(struct rz_bin_wasm_local_entry_t, count))) {
+		if (!(out->locals = RZ_NEWS0(RzBinWasmLocalEntry, count))) {
 			return 0;
 		}
 	}
@@ -141,7 +141,7 @@ beach:
 	return 0;
 }
 
-static size_t consume_limits_r(RzBuffer *b, ut64 max, struct rz_bin_wasm_resizable_limits_t *out) {
+static size_t consume_limits_r(RzBuffer *b, ut64 max, RzBinWasmResizableLimits *out) {
 	if (!b || max >= rz_buf_size(b) || rz_buf_tell(b) > max || !out) {
 		return 0;
 	}
@@ -174,22 +174,97 @@ static RzList /*<RzBinWasmSection *>*/ *rz_bin_wasm_get_sections_by_id(RzList /*
 	return ret;
 }
 
+static bool parse_string(RzBuffer *b, ut64 max, RZ_OUT char **str_out, ut32 *str_len) {
+	ut32 len = 0;
+	char *str = NULL;
+
+	if (!(consume_u32_r(b, max, &len))) {
+		return false;
+	}
+
+	str = RZ_NEWS(char, len + 1);
+	if (!str) {
+		return false;
+	}
+
+	if (consume_str_r(b, max, len, str) < (size_t)len) {
+		free(str);
+		return false;
+	}
+
+	str[len] = 0;
+
+	if (str_out) {
+		*str_out = str;
+	}
+
+	if (str_len) {
+		*str_len = len;
+	}
+
+	return true;
+}
+
 // Free
 static void rz_bin_wasm_free_types(RzBinWasmTypeEntry *ptr) {
-	if (ptr) {
-		free(ptr->param_types);
+	if (!ptr) {
+		return;
 	}
+	free(ptr->param_types);
 	free(ptr);
 }
 
 static void rz_bin_wasm_free_codes(RzBinWasmCodeEntry *ptr) {
-	if (ptr) {
-		free(ptr->locals);
+	if (!ptr) {
+		return;
 	}
+	free(ptr->locals);
 	free(ptr);
 }
 
+static void bin_wasm_name_free(RzBinWasmName *wn) {
+	if (!wn) {
+		return;
+	}
+
+	free(wn->name);
+	free(wn);
+}
+
+static void bin_wasm_section_free(RzBinWasmSection *ws) {
+	if (!ws) {
+		return;
+	}
+
+	free(ws->name);
+	free(ws);
+}
+
+static void bin_wasm_import_free(RzBinWasmImportEntry *wi) {
+	if (!wi) {
+		return;
+	}
+
+	free(wi->module_str);
+	free(wi->field_str);
+	free(wi);
+}
+
 // Parsing
+static RzBinWasmName *bin_wasm_name_new(RzBuffer *b, ut64 max) {
+	RzBinWasmName *wn = RZ_NEW0(RzBinWasmName);
+	if (!wn) {
+		return NULL;
+	}
+
+	if (!parse_string(b, max, (char **)&wn->name, &wn->len)) {
+		bin_wasm_name_free(wn);
+		return NULL;
+	}
+
+	return wn;
+}
+
 static RzList /*<void *>*/ *get_entries_from_section(RzBinWasmObj *bin, RzBinWasmSection *sec, ParseEntryFcn parse_entry, RzListFree free_entry) {
 	rz_return_val_if_fail(sec && bin, NULL);
 
@@ -239,7 +314,7 @@ static void *parse_type_entry(RzBuffer *b, ut64 max) {
 		goto beach;
 	}
 	if (count > 0) {
-		if (!(ptr->param_types = RZ_NEWS0(rz_bin_wasm_value_type_t, count))) {
+		if (!(ptr->param_types = RZ_NEWS0(RzBinWasmValueType, count))) {
 			goto beach;
 		}
 	}
@@ -266,33 +341,28 @@ beach:
 	rz_bin_wasm_free_types(ptr);
 	return NULL;
 }
+
 static void *parse_import_entry(RzBuffer *b, ut64 max) {
 	RzBinWasmImportEntry *ptr = RZ_NEW0(RzBinWasmImportEntry);
 	if (!ptr) {
 		return NULL;
 	}
-	if (!(consume_u32_r(b, max, &ptr->module_len))) {
+	if (!parse_string(b, max, &ptr->module_str, &ptr->module_len)) {
 		goto beach;
 	}
-	if (consume_str_r(b, max, ptr->module_len, ptr->module_str) < ptr->module_len) {
-		goto beach;
-	}
-	if (!(consume_u32_r(b, max, &ptr->field_len))) {
-		goto beach;
-	}
-	if (consume_str_r(b, max, ptr->field_len, ptr->field_str) < ptr->field_len) {
+	if (!parse_string(b, max, &ptr->field_str, &ptr->field_len)) {
 		goto beach;
 	}
 	if (!(consume_u7_r(b, max, &ptr->kind))) {
 		goto beach;
 	}
 	switch (ptr->kind) {
-	case 0: // Function
+	case RZ_BIN_WASM_EXTERNALKIND_Function:
 		if (!(consume_u32_r(b, max, &ptr->type_f))) {
 			goto beach;
 		}
 		break;
-	case 1: // Table
+	case RZ_BIN_WASM_EXTERNALKIND_Table:
 		if (!(consume_s7_r(b, max, (st8 *)&ptr->type_t.elem_type))) {
 			goto beach;
 		}
@@ -300,12 +370,12 @@ static void *parse_import_entry(RzBuffer *b, ut64 max) {
 			goto beach;
 		}
 		break;
-	case 2: // Memory
+	case RZ_BIN_WASM_EXTERNALKIND_Memory:
 		if (!(consume_limits_r(b, max, &ptr->type_m.limits))) {
 			goto beach;
 		}
 		break;
-	case 3: // Global
+	case RZ_BIN_WASM_EXTERNALKIND_Global:
 		if (!(consume_s7_r(b, max, (st8 *)&ptr->type_g.content_type))) {
 			goto beach;
 		}
@@ -316,10 +386,11 @@ static void *parse_import_entry(RzBuffer *b, ut64 max) {
 	default:
 		goto beach;
 	}
+
 	return ptr;
 
 beach:
-	free(ptr);
+	bin_wasm_import_free(ptr);
 	return NULL;
 }
 
@@ -328,10 +399,7 @@ static void *parse_export_entry(RzBuffer *b, ut64 max) {
 	if (!ptr) {
 		return NULL;
 	}
-	if (!(consume_u32_r(b, max, &ptr->field_len))) {
-		goto beach;
-	}
-	if (consume_str_r(b, max, ptr->field_len, ptr->field_str) < ptr->field_len) {
+	if (!parse_string(b, max, &ptr->field_str, &ptr->field_len)) {
 		goto beach;
 	}
 	if (!(consume_u7_r(b, max, &ptr->kind))) {
@@ -408,30 +476,18 @@ static bool parse_namemap(RzBuffer *b, ut64 max, RzIDStorage *map, ut32 *count) 
 	}
 
 	for (i = 0; i < *count; i++) {
-		struct rz_bin_wasm_name_t *name = RZ_NEW0(struct rz_bin_wasm_name_t);
-		if (!name) {
-			return false;
-		}
-
 		ut32 idx;
 		if (!(consume_u32_r(b, max, &idx))) {
-			RZ_FREE(name);
 			return false;
 		}
 
-		if (!(consume_u32_r(b, max, &name->len))) {
-			RZ_FREE(name);
+		RzBinWasmName *wn = bin_wasm_name_new(b, max);
+		if (!wn) {
 			return false;
 		}
 
-		if (!(consume_str_r(b, max, name->len, (char *)name->name))) {
-			RZ_FREE(name);
-			return false;
-		}
-		name->name[name->len] = 0;
-
-		if (!rz_id_storage_add(map, name, &idx)) {
-			RZ_FREE(name);
+		if (!rz_id_storage_add(map, wn, &idx)) {
+			bin_wasm_name_free(wn);
 			return false;
 		};
 	}
@@ -455,21 +511,15 @@ static void *parse_custom_name_entry(RzBuffer *b, ut64 max) {
 	};
 
 	switch (ptr->type) {
-	case RZ_BIN_WASM_NAMETYPE_Module:
-		ptr->mod_name = RZ_NEW0(struct rz_bin_wasm_name_t);
-		if (!ptr->mod_name) {
-			goto beach;
-		}
-		if (!(consume_u32_r(b, max, &ptr->mod_name->len))) {
+	case RZ_BIN_WASM_NAMETYPE_Module: {
+		RzBinWasmName *wn = bin_wasm_name_new(b, max);
+		if (!wn) {
 			goto beach;
 		}
 
-		if (!(consume_str_r(b, max, ptr->mod_name->len, (char *)ptr->mod_name->name))) {
-			goto beach;
-		}
+		ptr->mod_name = wn;
+	} break;
 
-		ptr->mod_name->name[ptr->mod_name->len] = 0;
-		break;
 	case RZ_BIN_WASM_NAMETYPE_Function:
 		ptr->func = RZ_NEW0(RzBinWasmCustomNameFunctionNames);
 		if (!ptr->func) {
@@ -486,6 +536,7 @@ static void *parse_custom_name_entry(RzBuffer *b, ut64 max) {
 			goto beach;
 		}
 		break;
+
 	case RZ_BIN_WASM_NAMETYPE_Local:
 		ptr->local = RZ_NEW0(RzBinWasmCustomNameLocalNames);
 		if (!ptr->local) {
@@ -630,7 +681,7 @@ static RzList /*<RzBinWasmTypeEntry *>*/ *rz_bin_wasm_get_type_entries(RzBinWasm
 }
 
 static RzList /*<RzBinWasmImportEntry *>*/ *rz_bin_wasm_get_import_entries(RzBinWasmObj *bin, RzBinWasmSection *sec) {
-	return get_entries_from_section(bin, sec, parse_import_entry, (RzListFree)free);
+	return get_entries_from_section(bin, sec, parse_import_entry, (RzListFree)bin_wasm_import_free);
 }
 
 static RzList /*<RzBinWasmExportEntry *>*/ *rz_bin_wasm_get_export_entries(RzBinWasmObj *bin, RzBinWasmSection *sec) {
@@ -810,7 +861,7 @@ RzList /*<RzBinWasmSection *>*/ *rz_bin_wasm_get_sections(RzBinWasmObj *bin) {
 	if (bin->g_sections) {
 		return bin->g_sections;
 	}
-	if (!(ret = rz_list_newf((RzListFree)free))) {
+	if (!(ret = rz_list_newf((RzListFree)bin_wasm_section_free))) {
 		return NULL;
 	}
 	RzBuffer *b = bin->buf;
@@ -839,56 +890,53 @@ RzList /*<RzBinWasmSection *>*/ *rz_bin_wasm_get_sections(RzBinWasmObj *bin) {
 		ptr->offset = rz_buf_tell(b);
 		switch (ptr->id) {
 		case RZ_BIN_WASM_SECTION_CUSTOM:
-			if (!(consume_u32_r(b, max, &ptr->name_len))) {
-				goto beach;
-			}
-			if (consume_str_r(b, max, ptr->name_len, (char *)ptr->name) < ptr->name_len) {
+			if (!parse_string(b, max, &ptr->name, &ptr->name_len)) {
 				goto beach;
 			}
 			break;
 		case RZ_BIN_WASM_SECTION_TYPE:
-			strcpy(ptr->name, "type");
-			ptr->name_len = 4;
+			ptr->name = rz_str_dup("type");
+			ptr->name_len = strlen("type");
 			break;
 		case RZ_BIN_WASM_SECTION_IMPORT:
-			strcpy(ptr->name, "import");
-			ptr->name_len = 6;
+			ptr->name = rz_str_dup("import");
+			ptr->name_len = strlen("import");
 			break;
 		case RZ_BIN_WASM_SECTION_FUNCTION:
-			strcpy(ptr->name, "function");
-			ptr->name_len = 8;
+			ptr->name = rz_str_dup("function");
+			ptr->name_len = strlen("function");
 			break;
 		case RZ_BIN_WASM_SECTION_TABLE:
-			strcpy(ptr->name, "table");
-			ptr->name_len = 5;
+			ptr->name = rz_str_dup("table");
+			ptr->name_len = strlen("table");
 			break;
 		case RZ_BIN_WASM_SECTION_MEMORY:
-			strcpy(ptr->name, "memory");
-			ptr->name_len = 6;
+			ptr->name = rz_str_dup("memory");
+			ptr->name_len = strlen("memory");
 			break;
 		case RZ_BIN_WASM_SECTION_GLOBAL:
-			strcpy(ptr->name, "global");
-			ptr->name_len = 6;
+			ptr->name = rz_str_dup("global");
+			ptr->name_len = strlen("global");
 			break;
 		case RZ_BIN_WASM_SECTION_EXPORT:
-			strcpy(ptr->name, "export");
-			ptr->name_len = 6;
+			ptr->name = rz_str_dup("export");
+			ptr->name_len = strlen("export");
 			break;
 		case RZ_BIN_WASM_SECTION_START:
-			strcpy(ptr->name, "start");
-			ptr->name_len = 5;
+			ptr->name = rz_str_dup("start");
+			ptr->name_len = strlen("start");
 			break;
 		case RZ_BIN_WASM_SECTION_ELEMENT:
-			strcpy(ptr->name, "element");
-			ptr->name_len = 7;
+			ptr->name = rz_str_dup("element");
+			ptr->name_len = strlen("element");
 			break;
 		case RZ_BIN_WASM_SECTION_CODE:
-			strcpy(ptr->name, "code");
-			ptr->name_len = 4;
+			ptr->name = rz_str_dup("code");
+			ptr->name_len = strlen("code");
 			break;
 		case RZ_BIN_WASM_SECTION_DATA:
-			strcpy(ptr->name, "data");
-			ptr->name_len = 4;
+			ptr->name = rz_str_dup("data");
+			ptr->name_len = strlen("data");
 			break;
 		default:
 			RZ_LOG_ERROR("wasm: unkown section id: %d\n", ptr->id);
@@ -907,7 +955,7 @@ RzList /*<RzBinWasmSection *>*/ *rz_bin_wasm_get_sections(RzBinWasmObj *bin) {
 		}
 		rz_buf_seek(b, ptr->payload_len, RZ_BUF_CUR);
 		if (!rz_list_append(ret, ptr)) {
-			free(ptr);
+			bin_wasm_section_free(ptr);
 			// should it jump to beach?
 		}
 		ptr = NULL;
@@ -916,7 +964,7 @@ RzList /*<RzBinWasmSection *>*/ *rz_bin_wasm_get_sections(RzBinWasmObj *bin) {
 	return ret;
 beach:
 	RZ_LOG_ERROR("wasm: failed to read sections\n");
-	free(ptr);
+	bin_wasm_section_free(ptr);
 	return ret;
 }
 
@@ -1199,7 +1247,7 @@ const char *rz_bin_wasm_get_function_name(RzBinWasmObj *bin, ut32 idx) {
 	RzBinWasmCustomNameEntry *nam;
 	rz_list_foreach (bin->g_names, iter, nam) {
 		if (nam->type == RZ_BIN_WASM_NAMETYPE_Function) {
-			struct rz_bin_wasm_name_t *n = NULL;
+			RzBinWasmName *n = NULL;
 
 			if ((n = rz_id_storage_get(nam->func->names, idx))) {
 				return (const char *)n->name;

--- a/librz/bin/format/wasm/wasm.h
+++ b/librz/bin/format/wasm/wasm.h
@@ -14,9 +14,8 @@
 
 #define RZ_BIN_WASM_MAGIC_BYTES "\x00" \
 				"asm"
-#define RZ_BIN_WASM_VERSION       0x1
-#define RZ_BIN_WASM_STRING_LENGTH 256
-#define RZ_BIN_WASM_END_OF_CODE   0xb
+#define RZ_BIN_WASM_VERSION     0x1
+#define RZ_BIN_WASM_END_OF_CODE 0xb
 
 #define RZ_BIN_WASM_SECTION_CUSTOM   0x0
 #define RZ_BIN_WASM_SECTION_TYPE     0x1
@@ -40,42 +39,42 @@ typedef enum {
 	RZ_BIN_WASM_VALUETYPE_ANYFUNC = 0x10,
 	RZ_BIN_WASM_VALUETYPE_FUNC = 0x20,
 	RZ_BIN_WASM_VALUETYPE_EMPTY = 0x40,
-} rz_bin_wasm_value_type_t;
+} RzBinWasmValueType;
 
 typedef enum {
 	RZ_BIN_WASM_EXTERNALKIND_Function = 0x0,
 	RZ_BIN_WASM_EXTERNALKIND_Table = 0x1,
 	RZ_BIN_WASM_EXTERNALKIND_Memory = 0x2,
 	RZ_BIN_WASM_EXTERNALKIND_Global = 0x3,
-} rz_bin_wasm_external_kind_t;
+} RzBinWasmExternalKind;
 
 typedef enum {
 	RZ_BIN_WASM_NAMETYPE_Module = 0x0,
 	RZ_BIN_WASM_NAMETYPE_Function = 0x1,
 	RZ_BIN_WASM_NAMETYPE_Local = 0x2,
-} rz_bin_wasm_custom_name_type_t;
+} RzBinWasmCustomNameType;
 
-struct rz_bin_wasm_init_expr_t {
+typedef struct rz_bin_wasm_init_expr_t {
 	// bytecode	terminated in 0xb
 	size_t len;
-};
+} RzBinWasmInitExpr;
 
-struct rz_bin_wasm_resizable_limits_t {
+typedef struct rz_bin_wasm_resizable_limits_t {
 	ut8 flags; // 1 if max field is present, 0 otherwise
 	ut32 initial;
 	ut32 maximum;
-};
+} RzBinWasmResizableLimits;
 
-struct rz_bin_wasm_name_t {
+typedef struct rz_bin_wasm_name_t {
 	ut32 len;
-	ut8 name[RZ_BIN_WASM_STRING_LENGTH];
-};
+	ut8 *name;
+} RzBinWasmName;
 
 typedef struct rz_bin_wasm_section_t {
 	ut8 id;
 	ut32 size;
 	ut32 name_len;
-	char name[RZ_BIN_WASM_STRING_LENGTH];
+	char *name;
 	ut32 offset;
 	ut32 payload_data;
 	ut32 payload_len;
@@ -85,38 +84,37 @@ typedef struct rz_bin_wasm_section_t {
 typedef struct rz_bin_wasm_type_t {
 	ut8 form;
 	ut32 param_count;
-	rz_bin_wasm_value_type_t *param_types;
+	RzBinWasmValueType *param_types;
 	st8 return_count; // MVP = 1
-	rz_bin_wasm_value_type_t return_type;
-	char to_str[RZ_BIN_WASM_STRING_LENGTH];
+	RzBinWasmValueType return_type;
 } RzBinWasmTypeEntry;
 
 // Other Types
-struct rz_bin_wasm_global_type_t {
-	rz_bin_wasm_value_type_t content_type;
+typedef struct rz_bin_wasm_global_type_t {
+	RzBinWasmValueType content_type;
 	ut8 mutability;
-};
+} RzBinWasmGlobalType;
 
-struct rz_bin_wasm_table_type_t {
-	rz_bin_wasm_value_type_t elem_type;
-	struct rz_bin_wasm_resizable_limits_t limits;
-};
+typedef struct rz_bin_wasm_table_type_t {
+	RzBinWasmValueType elem_type;
+	RzBinWasmResizableLimits limits;
+} RzBinWasmTableType;
 
-struct rz_bin_wasm_memory_type_t {
-	struct rz_bin_wasm_resizable_limits_t limits;
-};
+typedef struct rz_bin_wasm_memory_type_t {
+	RzBinWasmResizableLimits limits;
+} RzBinWasmMemoryType;
 
 typedef struct rz_bin_wasm_import_t {
 	ut32 module_len;
-	char module_str[RZ_BIN_WASM_STRING_LENGTH];
+	char *module_str;
 	ut32 field_len;
-	char field_str[RZ_BIN_WASM_STRING_LENGTH];
+	char *field_str;
 	ut8 kind;
 	union {
 		ut32 type_f;
-		struct rz_bin_wasm_global_type_t type_g;
-		struct rz_bin_wasm_table_type_t type_t;
-		struct rz_bin_wasm_memory_type_t type_m;
+		RzBinWasmGlobalType type_g;
+		RzBinWasmTableType type_t;
+		RzBinWasmMemoryType type_m;
 	};
 
 } RzBinWasmImportEntry;
@@ -127,22 +125,22 @@ typedef struct rz_bin_wasm_function_t {
 
 typedef struct rz_bin_wasm_table_t {
 	ut8 element_type; // only anyfunc
-	struct rz_bin_wasm_resizable_limits_t limits;
+	RzBinWasmResizableLimits limits;
 } RzBinWasmTableEntry;
 
 typedef struct rz_bin_wasm_memory_t {
-	struct rz_bin_wasm_resizable_limits_t limits;
+	RzBinWasmResizableLimits limits;
 } RzBinWasmMemoryEntry;
 
 typedef struct rz_bin_wasm_global_t {
-	rz_bin_wasm_value_type_t content_type;
+	RzBinWasmValueType content_type;
 	ut8 mutability; // 0 if immutable, 1 if mutable
-	struct rz_bin_wasm_init_expr_t init;
+	RzBinWasmInitExpr init;
 } RzBinWasmGlobalEntry;
 
 typedef struct rz_bin_wasm_export_t {
 	ut32 field_len;
-	char field_str[RZ_BIN_WASM_STRING_LENGTH];
+	char *field_str;
 	ut8 kind;
 	ut32 index;
 } RzBinWasmExportEntry;
@@ -151,14 +149,14 @@ typedef struct rz_bin_wasm_start_t {
 	ut32 index;
 } RzBinWasmStartEntry;
 
-struct rz_bin_wasm_local_entry_t {
+typedef struct rz_bin_wasm_local_entry_t {
 	ut32 count;
-	rz_bin_wasm_value_type_t type;
-};
+	RzBinWasmValueType type;
+} RzBinWasmLocalEntry;
 
 typedef struct rz_bin_wasm_element_t {
 	ut32 index;
-	struct rz_bin_wasm_init_expr_t init;
+	RzBinWasmInitExpr init;
 	ut32 num_elem;
 	ut32 elems[];
 } RzBinWasmElementEntry;
@@ -170,13 +168,11 @@ typedef struct rz_bin_wasm_code_t {
 	ut32 code; // offset
 	ut32 len; // real bytecode length
 	ut8 byte; // 0xb, indicating end of the body
-	char name[RZ_BIN_WASM_STRING_LENGTH];
-	char *signature;
 } RzBinWasmCodeEntry;
 
 typedef struct rz_bin_wasm_data_t {
 	ut32 index; // linear memory index (0 in MVP)
-	struct rz_bin_wasm_init_expr_t offset; // bytecode evaluated at runtime
+	RzBinWasmInitExpr offset; // bytecode evaluated at runtime
 	ut32 size;
 	ut32 data; // offset
 } RzBinWasmDataEntry;
@@ -207,7 +203,7 @@ typedef struct rz_bin_wasm_custom_name_entry_t {
 
 	ut8 payload_data;
 	union {
-		struct rz_bin_wasm_name_t *mod_name;
+		RzBinWasmName *mod_name;
 		RzBinWasmCustomNameFunctionNames *func;
 		RzBinWasmCustomNameLocalNames *local;
 	};
@@ -253,6 +249,6 @@ RzList /*<RzBinWasmDataEntry *>*/ *rz_bin_wasm_get_datas(RzBinWasmObj *bin);
 RzList /*<RzBinWasmCustomNameEntry *>*/ *rz_bin_wasm_get_custom_names(RzBinWasmObj *bin);
 ut32 rz_bin_wasm_get_entrypoint(RzBinWasmObj *bin);
 const char *rz_bin_wasm_get_function_name(RzBinWasmObj *bin, ut32 idx);
-const char *rz_bin_wasm_valuetype_to_string(rz_bin_wasm_value_type_t type);
+const char *rz_bin_wasm_valuetype_to_string(RzBinWasmValueType type);
 
 #endif

--- a/test/db/formats/web_assembly
+++ b/test/db/formats/web_assembly
@@ -44,3 +44,11 @@ EXPECT=<<EOF
  5 fd: 3 +0x00000000 0x00000000 * 0x00000423 r-x 
 EOF
 RUN
+
+NAME=WASM dotnet with long names
+FILE=bins/wasm/dotnet.wasm
+CMDS=isQ~__cxx_atomic_compare_exchange_strong
+EXPECT=<<EOF
+bool std::__2::__cxx_atomic_compare_exchange_strong<icu::numparse::impl::NumberParserImpl*>(std::__2::__cxx_atomic_base_impl<icu::numparse::impl::NumberParserImpl*>*, icu::numparse::impl::NumberParserImpl**, icu::numparse::impl::NumberParserImpl*, std::__2::memory_order, std::__2::memory_order)
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

The old code was subject to a heap overflow due the strings being limited in size.

I took advantage of the issue to do a small refactoring.