### PR TITLE
Handling minimum value of st64 in rz_num_abs

### DIFF
--- a/librz/include/rz_util/rz_num.h
+++ b/librz/include/rz_util/rz_num.h
@@ -101,7 +101,14 @@ RZ_API size_t rz_num_base_of_string(RzNum *num, RZ_NONNULL const char *str);
 RZ_API double rz_num_get_float(RzNum *num, const char *str);
 RZ_API bool rz_num_is_hex_prefix(const char *p);
 
-static inline st64 rz_num_abs(st64 num) {
+/**
+ * \brief Absolute value of a 64-bit number. Store result in `ut64`
+ * \return unsigned 64-bit number
+ */
+static inline ut64 rz_num_abs(st64 num) {
+	if (num == ST64_MIN) {
+		return UT64_GT0;
+	}
 	return num < 0 ? -num : num;
 }
 

--- a/test/unit/test_unum.c
+++ b/test/unit/test_unum.c
@@ -169,6 +169,13 @@ bool test_rz_num_bitmask() {
 	mu_end;
 }
 
+bool test_rz_num_abs() {
+	mu_assert_eq(rz_num_abs(ST64_MAX), ST64_MAX, "rz_num_abs(2^63 - 1) = 2^63 - 1");
+	mu_assert_eq(rz_num_abs(0), 0, "rz_num_abs(0) = 0");
+	mu_assert_eq(rz_num_abs(ST64_MIN), UT64_GT0, "rz_num_abs(-2^63) = 2^63");
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_rz_num_units);
 	mu_run_test(test_rz_num_minmax_swap_i);
@@ -179,6 +186,7 @@ bool all_tests() {
 	mu_run_test(test_rz_num_str_split_list);
 	mu_run_test(test_rz_num_align_delta);
 	mu_run_test(test_rz_num_bitmask);
+	mu_run_test(test_rz_num_abs);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [X] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Till now, `rz_abs_num` would give wrong output for `-2^63` if the result was stored in `st64` which was also the return type. It did not directly affect anything because the result was always stored in `ut64` wherever it was used.
Now the return value is set to `ut64` and function description also mandates the use of `ut64` to store the return value.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tests that check for both max and min value of `st64` have been added.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
