### PR TITLE
Add descriptions to /cm types

### DIFF
--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -15,6 +15,7 @@ static const RzCmdDescDetail oparen__details[2];
 static const RzCmdDescDetail pointer_details[2];
 static const RzCmdDescDetail interpret_macro_multiple_details[2];
 static const RzCmdDescDetail cmd_search_collision_details[2];
+static const RzCmdDescDetail cmd_search_cryptographic_material_details[2];
 static const RzCmdDescDetail cmd_search_hash_block_details[2];
 static const RzCmdDescDetail slash_v_details[2];
 static const RzCmdDescDetail slash_V_details[2];
@@ -1766,6 +1767,20 @@ static const RzCmdDescHelp cmd_search_collision_help = {
 	.args = cmd_search_collision_args,
 };
 
+static const RzCmdDescDetailEntry cmd_search_cryptographic_material_Types_detail_entries[] = {
+	{ .text = "aes128", .arg_str = NULL, .comment = "Searches for expanded AES 128 keys." },
+	{ .text = "aes192", .arg_str = NULL, .comment = "Searches for expanded AES 192 keys." },
+	{ .text = "aes256", .arg_str = NULL, .comment = "Searches for expanded AES 256 keys." },
+	{ .text = "rsa", .arg_str = NULL, .comment = "Searches for DER/BER encoded RSA keys (see RFC 3447)." },
+	{ .text = "ecc", .arg_str = NULL, .comment = "Searches for DER/BER encoded ECC keys (see RFC 5915)." },
+	{ .text = "safecurves", .arg_str = NULL, .comment = "Searches for DER/BER encoded Safecurves keys (see RFC 8410)." },
+	{ .text = "x509", .arg_str = NULL, .comment = "Searches for DER/BER encoded X.509 certificates." },
+	{ 0 },
+};
+static const RzCmdDescDetail cmd_search_cryptographic_material_details[] = {
+	{ .name = "Types", .entries = cmd_search_cryptographic_material_Types_detail_entries },
+	{ 0 },
+};
 static const char *cmd_search_cryptographic_material_type_choices[] = { "all", "aes128", "aes192", "aes256", "rsa", "ecc", "safecurves", "x509", NULL };
 static const RzCmdDescArg cmd_search_cryptographic_material_args[] = {
 	{
@@ -1779,6 +1794,7 @@ static const RzCmdDescArg cmd_search_cryptographic_material_args[] = {
 };
 static const RzCmdDescHelp cmd_search_cryptographic_material_help = {
 	.summary = "Search cryptographic material.",
+	.details = cmd_search_cryptographic_material_details,
 	.args = cmd_search_cryptographic_material_args,
 };
 

--- a/librz/core/cmd_descs/cmd_search.yaml
+++ b/librz/core/cmd_descs/cmd_search.yaml
@@ -247,6 +247,23 @@ commands:
             - "ecc"
             - "safecurves"
             - "x509"
+      details:
+        - name: Types
+          entries:
+            - text: aes128
+              comment: "Searches for expanded AES 128 keys."
+            - text: aes192
+              comment: "Searches for expanded AES 192 keys."
+            - text: aes256
+              comment: "Searches for expanded AES 256 keys."
+            - text: rsa
+              comment: "Searches for DER/BER encoded RSA keys (see RFC 3447)."
+            - text: ecc
+              comment: "Searches for DER/BER encoded ECC keys (see RFC 5915)."
+            - text: safecurves
+              comment: "Searches for DER/BER encoded Safecurves keys (see RFC 8410)."
+            - text: x509
+              comment: "Searches for DER/BER encoded X.509 certificates."
   - name: "/d"
     summary: Search for a deltified sequence of bytes.
     cname: cmd_search_deltified


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

Adds a description when calling `/cm?`

```
[0x00000000]> /cm?
Usage: /cm[jqt] <type>=all   # Search cryptographic material.
| /cm <type>=all       # Search cryptographic material.
| /cmj <type>=all      # Search cryptographic material. (JSON mode)
| /cmq <type>=all      # Search cryptographic material. (quiet mode)
| /cmt <type>=all      # Search cryptographic material. (table mode)

Types:
| aes128     # Searches for expanded AES 128 keys.
| aes192     # Searches for expanded AES 192 keys.
| aes256     # Searches for expanded AES 256 keys.
| rsa        # Searches for DER/BER encoded rsa keys (see RFC 3447).
| ecc        # Searches for DER/BER encoded ecc keys (see RFC 5915).
| safecurves # Searches for DER/BER encoded safecurves keys (see RFC 8410).
| x509       # Searches for DER/BER encoded x509 certificates.
```