### PR TITLE
Make OpenBSD magic lib somewhat thread safe.

### DIFF
--- a/librz/include/rz_magic.h
+++ b/librz/include/rz_magic.h
@@ -46,6 +46,11 @@ union VALUETYPE {
 	double d;
 }; /* either number or string */
 
+/**
+ * \brief Size of the buffer the rz_magic module checks for magics.
+ */
+#define RZ_MAGIC_BUF_SIZE (HOWMANY * (1 + sizeof(union VALUETYPE)))
+
 /* constants */
 #define MAGICNO        0xF11E041C
 #define VERSIONNO      5
@@ -269,6 +274,12 @@ struct rz_magic_set {
 	/* FIXME: Make the string dynamically allocated so that e.g.
 	   strings matched in files can be longer than MAXstring */
 	union VALUETYPE ms_value; /* either number or string */
+
+	// Previously global non-constant variables in librz/magic/
+	bool ms_setup_done; ///< True if the members below were initialized.
+	int magic_file_formats[FILE_NAMES_SIZE];
+	const char *magic_file_names[FILE_NAMES_SIZE];
+	size_t maxmagic;
 };
 
 #if USE_LIB_MAGIC
@@ -283,7 +294,7 @@ RZ_API void rz_magic_free(RzMagic *);
 
 RZ_API const char *rz_magic_file(RzMagic *, const char *);
 RZ_API const char *rz_magic_descriptor(RzMagic *, int);
-RZ_API const char *rz_magic_buffer(RzMagic *, const void *, size_t);
+RZ_API const char *rz_magic_buffer(RzMagic *, const ut8 *, size_t);
 
 RZ_API const char *rz_magic_error(RzMagic *);
 RZ_API void rz_magic_setflags(RzMagic *, int);

--- a/librz/magic/file.h
+++ b/librz/magic/file.h
@@ -52,7 +52,7 @@ typedef unsigned long unichar;
 
 struct stat;
 const char *file_fmttime(unsigned int, int, char *);
-int file_buffer(struct rz_magic_set *, int, const char *, const void *, size_t);
+int file_buffer(RzMagic *ms, int fd, const char *inname, const ut8 *buf, size_t nb);
 int file_fsmagic(struct rz_magic_set *, const char *, struct stat *);
 int file_pipe2file(struct rz_magic_set *, int, const void *, size_t);
 int file_printf(struct rz_magic_set *, const char *, ...);

--- a/librz/magic/file.h
+++ b/librz/magic/file.h
@@ -71,7 +71,7 @@ void file_oomem(struct rz_magic_set *, size_t);
 void file_error(struct rz_magic_set *, int, const char *, ...);
 void file_magerror(struct rz_magic_set *, const char *, ...);
 void file_magwarn(struct rz_magic_set *, const char *, ...);
-void file_mdump(struct rz_magic *);
+void file_mdump(struct rz_magic_set *ms, struct rz_magic *m);
 void file_showstr(FILE *, const char *, size_t);
 size_t file_mbswidth(const char *);
 const char *file_getbuffer(struct rz_magic_set *);

--- a/librz/magic/funcs.c
+++ b/librz/magic/funcs.c
@@ -163,7 +163,7 @@ void file_badread(RzMagic *ms) {
 	file_error(ms, errno, "error reading");
 }
 
-int file_buffer(RzMagic *ms, int fd, const char *inname, const void *buf, size_t nb) {
+int file_buffer(RzMagic *ms, int fd, const char *inname, const ut8 *buf, size_t nb) {
 	int mime, m = 0;
 	if (!ms) {
 		return -1;

--- a/librz/magic/magic.c
+++ b/librz/magic/magic.c
@@ -139,8 +139,7 @@ static const char *file_or_fd(RzMagic *ms, const char *inname, int fd) {
 	 * one extra for terminating '\0', and
 	 * some overlapping space for matches near EOF
 	 */
-#define SLOP (1 + sizeof(union VALUETYPE))
-	if (!(buf = malloc(HOWMANY + SLOP))) {
+	if (!(buf = malloc(RZ_MAGIC_BUF_SIZE))) {
 		return NULL;
 	}
 
@@ -218,7 +217,7 @@ static const char *file_or_fd(RzMagic *ms, const char *inname, int fd) {
 	}
 #endif
 
-	(void)memset(buf + nbytes, 0, SLOP); /* NUL terminate */
+	(void)memset(buf + nbytes, 0, RZ_MAGIC_BUF_SIZE); /* NUL terminate */
 	if (file_buffer(ms, fd, inname, buf, (size_t)nbytes) == -1) {
 		goto done;
 	}
@@ -305,7 +304,7 @@ RZ_API const char *rz_magic_file(RzMagic *ms, const char *inname) {
 	return file_or_fd(ms, inname, 0); // 0 = stdin
 }
 
-RZ_API const char *rz_magic_buffer(RzMagic *ms, const void *buf, size_t nb) {
+RZ_API const char *rz_magic_buffer(RzMagic *ms, const ut8 *buf, size_t nb) {
 	if (file_reset(ms) == -1) {
 		return NULL;
 	}

--- a/librz/magic/mdump.c
+++ b/librz/magic/mdump.c
@@ -44,7 +44,7 @@
 #define SZOF(a) (sizeof(a) / sizeof(a[0]))
 
 #ifndef COMPILE_ONLY
-void file_mdump(struct rz_magic *m) {
+void file_mdump(struct rz_magic_set *ms, struct rz_magic *m) {
 	static const char optyp[] = { FILE_OPS };
 	char pp[ASCTIME_BUF_MINLEN];
 
@@ -54,7 +54,7 @@ void file_mdump(struct rz_magic *m) {
 	if (m->flag & INDIR) {
 		(void)eprintf("(%s,",
 			/* Note: type is unsigned */
-			(m->in_type < file_nnames) ? magic_file_names[m->in_type] : "*bad*");
+			(m->in_type < FILE_MAGICSIZE) ? ms->magic_file_names[m->in_type] : "*bad*");
 		if (m->in_op & FILE_OPINVERSE)
 			(void)fputc('~', stderr);
 		(void)eprintf("%c%u),",
@@ -63,7 +63,7 @@ void file_mdump(struct rz_magic *m) {
 	}
 	(void)eprintf(" %s%s", (m->flag & UNSIGNED) ? "u" : "",
 		/* Note: type is unsigned */
-		(m->type < file_nnames) ? magic_file_names[m->type] : "*bad*");
+		(m->type < FILE_MAGICSIZE) ? ms->magic_file_names[m->type] : "*bad*");
 	if (m->mask_op & FILE_OPINVERSE)
 		(void)fputc('~', stderr);
 

--- a/librz/magic/softmagic.c
+++ b/librz/magic/softmagic.c
@@ -885,7 +885,7 @@ static int mget(RzMagic *ms, const ut8 *s, struct rz_magic *m, size_t nbytes, un
 
 	if ((ms->flags & RZ_MAGIC_DEBUG) != 0) {
 		mdebug(offset, (char *)(void *)p, sizeof(union VALUETYPE));
-		file_mdump(m);
+		file_mdump(ms, m);
 	}
 
 	if (m->flag & INDIR) {
@@ -1159,7 +1159,7 @@ static int mget(RzMagic *ms, const ut8 *s, struct rz_magic *m, size_t nbytes, un
 		if ((ms->flags & RZ_MAGIC_DEBUG) != 0) {
 			mdebug(offset, (char *)(void *)p,
 				sizeof(union VALUETYPE));
-			file_mdump(m);
+			file_mdump(ms, m);
 		}
 	}
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

It moves the global variables into struct magic_set. Simply because this is everyhwere available.
This is a simple removal of all mutable global variables. Nothing more yet.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All green 

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
