### PR TITLE
Port `/h` and `/s` to RzSearch.

### DIFF
--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -46,78 +46,6 @@ struct search_parameters {
 	bool regex_search;
 };
 
-static int search_hash(RzCore *core, const char *hashname, const char *hashstr, ut32 minlen, ut32 maxlen, struct search_parameters *param) {
-	RzIOMap *map;
-	ut8 *buf;
-	int i, j;
-	RzListIter *iter;
-
-	if (!minlen || minlen == UT32_MAX) {
-		minlen = core->blocksize;
-	}
-	if (!maxlen || maxlen == UT32_MAX) {
-		maxlen = minlen;
-	}
-
-	rz_cons_break_push(NULL, NULL);
-	for (j = minlen; j <= maxlen; j++) {
-		ut32 len = j;
-		eprintf("Searching %s for %d byte length.\n", hashname, j);
-		rz_list_foreach (param->boundaries, iter, map) {
-			if (rz_cons_is_breaked()) {
-				break;
-			}
-			ut64 from = map->itv.addr, to = rz_itv_end(map->itv);
-			st64 bufsz;
-			bufsz = to - from;
-			if (len > bufsz) {
-				RZ_LOG_ERROR("core: Hash length is bigger than range 0x%" PFMT64x "\n", from);
-				continue;
-			}
-			buf = malloc(bufsz);
-			if (!buf) {
-				RZ_LOG_ERROR("core: Cannot allocate %" PFMT64d " bytes\n", bufsz);
-				goto fail;
-			}
-			eprintf("Search in range 0x%08" PFMT64x " and 0x%08" PFMT64x "\n", from, to);
-			int blocks = (int)(to - from - len);
-			eprintf("Carving %d blocks...\n", blocks);
-			(void)rz_io_read_at(core->io, from, buf, bufsz);
-			for (i = 0; (from + i + len) < to; i++) {
-				if (rz_cons_is_breaked()) {
-					break;
-				}
-				char *s = rz_hash_cfg_calculate_small_block_string(core->hash, hashname, buf + i, len, NULL, false);
-				if (!s) {
-					RZ_LOG_ERROR("core: Hash fail\n");
-					break;
-				}
-				if (!(i % 5)) {
-					eprintf("%d\r", i);
-				}
-				// eprintf ("0x%08"PFMT64x" %s\n", from+i, s);
-				if (!strcmp(s, hashstr)) {
-					eprintf("Found at 0x%" PFMT64x "\n", from + i);
-					rz_cons_printf("f hash.%s.%s @ 0x%" PFMT64x "\n",
-						hashname, hashstr, from + i);
-					free(s);
-					free(buf);
-					rz_cons_break_pop();
-					return 1;
-				}
-				free(s);
-			}
-			free(buf);
-		}
-	}
-	rz_cons_break_pop();
-	eprintf("No hashes found\n");
-	return 0;
-fail:
-	rz_cons_break_pop();
-	return -1;
-}
-
 RZ_IPI RzCmdStatus rz_cmd_info_gadget_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
 	const char *input = argc > 1 ? argv[1] : "";
 	if (!input) {
@@ -999,74 +927,6 @@ done:
 	return false;
 }
 
-static void do_section_search(RzCore *core, struct search_parameters *param, const char *input) {
-	double threshold = 1;
-	bool r2mode = false;
-	if (input && *input) {
-		if (*input == '*') {
-			r2mode = true;
-		}
-		sscanf(input, "%lf", &threshold);
-		if (threshold < 1) {
-			threshold = 1;
-		}
-	}
-	int buf_size = core->blocksize;
-	ut8 *buf = malloc(buf_size);
-	if (!buf) {
-		return;
-	}
-	double oe = 0;
-	RzListIter *iter;
-	RzIOMap *map;
-	ut64 begin = UT64_MAX;
-	ut64 at, end = 0;
-	int index = 0;
-	bool lastBlock = true;
-	rz_cons_break_push(NULL, NULL);
-	rz_list_foreach (param->boundaries, iter, map) {
-		ut64 from = map->itv.addr;
-		ut64 to = rz_itv_end(map->itv);
-		if (rz_cons_is_breaked()) {
-			break;
-		}
-		for (at = from; at < to; at += buf_size) {
-			if (begin == UT64_MAX) {
-				begin = at;
-			}
-			rz_io_read_at(core->io, at, buf, buf_size);
-			double e = rz_hash_entropy(buf, buf_size);
-			double diff = oe - e;
-			diff = RZ_ABS(diff);
-			end = at + buf_size;
-			if (diff > threshold) {
-				if (r2mode) {
-					rz_cons_printf("f entropy_section_%d 0x%08" PFMT64x " @ 0x%08" PFMT64x "\n", index, end - begin, begin);
-				} else {
-					rz_cons_printf("0x%08" PFMT64x " - 0x%08" PFMT64x " ~ %lf\n", begin, end, e);
-				}
-				begin = UT64_MAX;
-				index++;
-				lastBlock = false;
-			} else {
-				lastBlock = true;
-			}
-			oe = e;
-		}
-		begin = UT64_MAX;
-	}
-	if (begin != UT64_MAX && lastBlock) {
-		if (r2mode) {
-			rz_cons_printf("f entropy_section_%d 0x%08" PFMT64x " @ 0x%08" PFMT64x "\n", index, end - begin, begin);
-		} else {
-			rz_cons_printf("0x%08" PFMT64x " - 0x%08" PFMT64x " ~ %d .. last\n", begin, end, 0);
-		}
-		index++;
-	}
-	rz_cons_break_pop();
-	free(buf);
-}
-
 static void do_asm_search(RzCore *core, struct search_parameters *param, const char *input, int mode, RzInterval search_itv) {
 	RzCoreAsmHit *hit;
 	RzListIter *iter, *itermap;
@@ -1927,34 +1787,6 @@ reread:
 			RZ_LOG_ERROR("core: Missing delta\n");
 		}
 		break;
-	case 'h': // "/h"
-	{
-		char *p, *arg = rz_str_trim_dup(input + 1);
-		p = strchr(arg, ' ');
-		if (p) {
-			*p++ = 0;
-			if (*arg == '?') {
-				RZ_LOG_ERROR("core: Usage: /h md5 [hash] [datalen]\n");
-			} else {
-				ut32 min = UT32_MAX;
-				ut32 max = UT32_MAX;
-				char *pmax, *pmin = strchr(p, ' ');
-				if (pmin) {
-					*pmin++ = 0;
-					pmax = strchr(pmin, ' ');
-					if (pmax) {
-						*pmax++ = 0;
-						max = rz_num_math(core->num, pmax);
-					}
-					min = rz_num_math(core->num, pmin);
-				}
-				search_hash(core, arg, p, min, max, &param);
-			}
-		} else {
-			RZ_LOG_ERROR("core: Missing hash. See ph?\n");
-		}
-		free(arg);
-	} break;
 	case 'f': // "/f" forward search
 		if (core->offset) {
 			RzInterval itv = { core->offset, -core->offset };
@@ -1965,9 +1797,6 @@ reread:
 				search_itv = rz_itv_intersect(search_itv, itv);
 			}
 		}
-		break;
-	case 's': // "/s"
-		do_section_search(core, &param, input + 1);
 		break;
 	case '+': // "/+"
 		if (input[1] == ' ') {
@@ -2432,6 +2261,55 @@ error:
 	return RZ_CMD_STATUS_ERROR;
 }
 
+// "/ch"
+RZ_IPI RzCmdStatus rz_cmd_search_hash_block_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
+	rz_return_val_if_fail(core, RZ_CMD_STATUS_ERROR);
+	RzSearchOpt *search_opts = setup_search_options(core);
+	RzList *hits = NULL;
+	if (!search_opts) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+
+	CMD_SEARCH_BEGIN();
+
+	bool progress = rz_config_get_b(core->config, "search.show_progress");
+	if (!rz_search_opt_set_cancel_cb(search_opts, cmd_search_progress_cancel, progress ? state : NULL)) {
+		RZ_LOG_ERROR("code: Failed to setup default search options.\n");
+		goto error;
+	}
+	RzSearchHashFindData *data = rz_search_hash_get_find_data(core->hash, argv[1], argv[2], argv[3]);
+	if (!data) {
+		RZ_LOG_ERROR("Failed to initialized search data.\n");
+		goto error;
+	}
+
+	hits = rz_core_search_hash_material(core, search_opts, data);
+	if (!hits) {
+		RZ_LOG_ERROR("Failed to perform search.\n");
+		goto error;
+	}
+
+	CMD_SEARCH_END();
+	rz_search_opt_free(search_opts);
+	return cmd_core_handle_search_hits(core, state, hits);
+
+error:
+	rz_list_free(hits);
+	rz_search_opt_free(search_opts);
+	CMD_SEARCH_END();
+	return RZ_CMD_STATUS_ERROR;
+}
+
+// "/ce"
+RZ_IPI RzCmdStatus rz_cmd_search_hash_entropy_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
+	const char *argv_ch[4];
+	argv_ch[0] = argv[0];
+	argv_ch[1] = "entropy_fract";
+	argv_ch[2] = argv[1];
+	argv_ch[3] = argv[2];
+	return rz_cmd_search_hash_block_handler(core, 4, argv_ch, state);
+}
+
 // "/cc"
 RZ_IPI RzCmdStatus rz_cmd_search_collision_handler(RzCore *core, int argc, const char **argv) {
 	return pass_to_legacy_api(core, argc, argv, RZ_OUTPUT_MODE_STANDARD);
@@ -2530,11 +2408,6 @@ RZ_IPI RzCmdStatus rz_cmd_search_graph_path_follow_calls_handler(RzCore *core, i
 	const int depth = rz_config_get_i(core->config, "analysis.depth");
 	rz_core_analysis_paths(core, from, to, true, depth, state->mode == RZ_OUTPUT_MODE_JSON);
 	return RZ_CMD_STATUS_OK;
-}
-
-// "/h"
-RZ_IPI RzCmdStatus rz_cmd_search_hash_block_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
-	return pass_to_legacy_api(core, argc, argv, RZ_OUTPUT_MODE_STANDARD);
 }
 
 // "/m"
@@ -2658,11 +2531,6 @@ RZ_IPI RzCmdStatus rz_cmd_search_reference_write_handler(RzCore *core, int argc,
 
 // "/rx"
 RZ_IPI RzCmdStatus rz_cmd_search_reference_execute_handler(RzCore *core, int argc, const char **argv) {
-	return pass_to_legacy_api(core, argc, argv, RZ_OUTPUT_MODE_STANDARD);
-}
-
-// "/s"
-RZ_IPI RzCmdStatus rz_cmd_search_sections_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
 	return pass_to_legacy_api(core, argc, argv, RZ_OUTPUT_MODE_STANDARD);
 }
 

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -2074,18 +2074,35 @@ static void cmd_search_output_to_state(RzCmdStateOutput *state, RzSearchHit *hit
 	case RZ_OUTPUT_MODE_QUIET:
 		rz_cons_printf("0x%08" PFMT64x "\n", hit->address);
 		break;
-	case RZ_OUTPUT_MODE_STANDARD:
-		rz_cons_printf("0x%08" PFMT64x " %" PFMTSZu " %s\n", hit->address, hit->size, flag_name);
+	case RZ_OUTPUT_MODE_STANDARD: {
+		RzStrBuf *sb = rz_strbuf_new("");
+		rz_strbuf_appendf(sb, "0x%08" PFMT64x " %" PFMTSZu " %s", hit->address, hit->size, flag_name);
+		if (hit->detail_type != RZ_SEARCH_HIT_DETAIL_NONE) {
+			rz_strbuf_appendf(sb, " %s", rz_search_hit_detail_str(hit));
+		}
+		char *desc = rz_strbuf_drain(sb);
+		rz_cons_printf("%s\n", desc);
+		free(desc);
 		break;
+	}
 	case RZ_OUTPUT_MODE_JSON:
 		pj_o(state->d.pj);
 		pj_kn(state->d.pj, "address", hit->address);
 		pj_kn(state->d.pj, "size", hit->size);
 		pj_ks(state->d.pj, "flag", flag_name);
+		if (hit->detail_type != RZ_SEARCH_HIT_DETAIL_NONE) {
+			pj_ko(state->d.pj, "detail");
+			rz_search_hit_detail_json(hit, state->d.pj);
+			pj_end(state->d.pj);
+		}
 		pj_end(state->d.pj);
 		break;
 	case RZ_OUTPUT_MODE_TABLE:
-		rz_table_add_rowf(state->d.t, "xXs", hit->address, hit->size, flag_name);
+		if (hit->detail_type != RZ_SEARCH_HIT_DETAIL_NONE) {
+			rz_table_add_rowf(state->d.t, "xXss", hit->address, hit->size, flag_name, rz_search_hit_detail_str(hit));
+		} else {
+			rz_table_add_rowf(state->d.t, "xXs", hit->address, hit->size, flag_name);
+		}
 		break;
 	default:
 		rz_warn_if_reached();
@@ -2134,6 +2151,9 @@ static RzCmdStatus cmd_core_handle_search_hits(RzCore *core, RzCmdStateOutput *s
 		if (RZ_STR_ISNOTEMPTY(cmd_hit)) {
 			cmd_search_call_command(core, hit, cmd_hit);
 			continue;
+		}
+		if (state->mode == RZ_OUTPUT_MODE_TABLE && hit->detail_type != RZ_SEARCH_HIT_DETAIL_NONE) {
+			rz_table_add_column(state->d.t, rz_table_type("string"), "detail", 0);
 		}
 
 		// Only output & add flag when cmd.hit is not set.

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -2374,7 +2374,7 @@ RZ_IPI RzCmdStatus rz_cmd_search_cryptographic_material_handler(RzCore *core, in
 	}
 
 	bool is_all = !strcmp(argv[1], "all");
-	RzSearchCollectionCryptographicType type = RZ_SEARCH_COLLECTION_CRYPTOGRAPHIC_ENUM_SIZE;
+	RzSearchCollectionCryptographicType type = RZ_SEARCH_COLLECTION_CRYPTOGRAPHIC_ALL;
 
 	if (!is_all && !rz_search_collection_cryptographic_name_to_type(argv[1], &type)) {
 		RZ_LOG_ERROR("Failed to parse given type (%s).\n", argv[1]);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -15,9 +15,10 @@ static const RzCmdDescDetail oparen__details[2];
 static const RzCmdDescDetail pointer_details[2];
 static const RzCmdDescDetail interpret_macro_multiple_details[2];
 static const RzCmdDescDetail cmd_search_collision_details[2];
+static const RzCmdDescDetail cmd_search_hash_block_details[3];
+static const RzCmdDescDetail cmd_search_hash_entropy_details[3];
 static const RzCmdDescDetail cmd_search_cryptographic_material_details[2];
 static const RzCmdDescDetail cmd_search_file_details[2];
-static const RzCmdDescDetail cmd_search_hash_block_details[2];
 static const RzCmdDescDetail cmd_search_value_details[3];
 static const RzCmdDescDetail cmd_search_hex_details[2];
 static const RzCmdDescDetail cmd_search_hex_regex_details[2];
@@ -134,6 +135,8 @@ static const RzCmdDescArg cmd_search_assemble_sl_args[2];
 static const RzCmdDescArg cmd_search_assemble_t_args[2];
 static const RzCmdDescArg cmd_search_assemble_tl_args[2];
 static const RzCmdDescArg cmd_search_collision_args[4];
+static const RzCmdDescArg cmd_search_hash_block_args[4];
+static const RzCmdDescArg cmd_search_hash_entropy_args[3];
 static const RzCmdDescArg cmd_search_cryptographic_material_args[2];
 static const RzCmdDescArg cmd_search_deltified_args[2];
 static const RzCmdDescArg cmd_search_file_args[4];
@@ -141,10 +144,8 @@ static const RzCmdDescArg cmd_search_insn_offset_backwards_args[2];
 static const RzCmdDescArg cmd_search_insn_offset_backwards_fallback_args[2];
 static const RzCmdDescArg cmd_search_pattern_args[2];
 static const RzCmdDescArg cmd_search_blocks_args[2];
-static const RzCmdDescArg cmd_search_sections_args[2];
 static const RzCmdDescArg cmd_search_graph_path_args[3];
 static const RzCmdDescArg cmd_search_graph_path_follow_calls_args[3];
-static const RzCmdDescArg cmd_search_hash_block_args[3];
 static const RzCmdDescArg cmd_search_magic_const_args[2];
 static const RzCmdDescArg cmd_search_esil_args[2];
 static const RzCmdDescArg cmd_search_reference_args[2];
@@ -1775,6 +1776,80 @@ static const RzCmdDescHelp cmd_search_collision_help = {
 	.args = cmd_search_collision_args,
 };
 
+static const RzCmdDescDetailEntry cmd_search_hash_block_Usage_space_example_detail_entries[] = {
+	{ .text = "/ch md5 0bc8f8c426b74ffaedac8330a7464014 512", .arg_str = NULL, .comment = "MD5 hash search within blocks of 512 bytes." },
+	{ .text = "/ch entropy_fract 0.6 16k", .arg_str = NULL, .comment = "Find 16384 byte blocks with an entropy of 0.6 and above." },
+	{ 0 },
+};
+
+static const RzCmdDescDetailEntry cmd_search_hash_block_Tip_detail_entries[] = {
+	{ .text = "The command 'Lh' gives you a list of supported hash plugins.", .arg_str = NULL, .comment = "" },
+	{ 0 },
+};
+static const RzCmdDescDetail cmd_search_hash_block_details[] = {
+	{ .name = "Usage example", .entries = cmd_search_hash_block_Usage_space_example_detail_entries },
+	{ .name = "Tip", .entries = cmd_search_hash_block_Tip_detail_entries },
+	{ 0 },
+};
+static const RzCmdDescArg cmd_search_hash_block_args[] = {
+	{
+		.name = "algo",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+
+	},
+	{
+		.name = "hash",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+
+	},
+	{
+		.name = "block_size",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+		.default_value = "256",
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_search_hash_block_help = {
+	.summary = "Search for blocks that have the same hash.",
+	.details = cmd_search_hash_block_details,
+	.args = cmd_search_hash_block_args,
+};
+
+static const RzCmdDescDetailEntry cmd_search_hash_entropy_Usage_space_example_detail_entries[] = {
+	{ .text = "/ce 0.3 512", .arg_str = NULL, .comment = "Find 512 byte blocks with an entropy of 0.3 and above." },
+	{ 0 },
+};
+
+static const RzCmdDescDetailEntry cmd_search_hash_entropy_Tip_detail_entries[] = {
+	{ .text = "The command 'Lh' gives you a list of supported hash plugins.", .arg_str = NULL, .comment = "" },
+	{ 0 },
+};
+static const RzCmdDescDetail cmd_search_hash_entropy_details[] = {
+	{ .name = "Usage example", .entries = cmd_search_hash_entropy_Usage_space_example_detail_entries },
+	{ .name = "Tip", .entries = cmd_search_hash_entropy_Tip_detail_entries },
+	{ 0 },
+};
+static const RzCmdDescArg cmd_search_hash_entropy_args[] = {
+	{
+		.name = "entropy",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+
+	},
+	{
+		.name = "block_size",
+		.type = RZ_CMD_ARG_TYPE_NUM,
+		.default_value = "256",
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_search_hash_entropy_help = {
+	.summary = "Search for blocks above an entropy level (alias for: /ch entropy_fract <entropy> <block_size>).",
+	.details = cmd_search_hash_entropy_details,
+	.args = cmd_search_hash_entropy_args,
+};
+
 static const RzCmdDescDetailEntry cmd_search_cryptographic_material_Types_detail_entries[] = {
 	{ .text = "aes128", .arg_str = NULL, .comment = "Searches for expanded AES 128 keys." },
 	{ .text = "aes192", .arg_str = NULL, .comment = "Searches for expanded AES 192 keys." },
@@ -1916,20 +1991,6 @@ static const RzCmdDescHelp cmd_search_blocks_help = {
 	.args = cmd_search_blocks_args,
 };
 
-static const RzCmdDescArg cmd_search_sections_args[] = {
-	{
-		.name = "threshold",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
-
-	},
-	{ 0 },
-};
-static const RzCmdDescHelp cmd_search_sections_help = {
-	.summary = "Search sections by grouping blocks with similar entropy.",
-	.args = cmd_search_sections_args,
-};
-
 static const RzCmdDescHelp slash_g_help = {
 	.summary = "Search for all graph paths A to B.",
 };
@@ -1969,34 +2030,6 @@ static const RzCmdDescArg cmd_search_graph_path_follow_calls_args[] = {
 static const RzCmdDescHelp cmd_search_graph_path_follow_calls_help = {
 	.summary = "Search for all graph paths A to B (follows calls, see `search.count` and `analysis.depth`).",
 	.args = cmd_search_graph_path_follow_calls_args,
-};
-
-static const RzCmdDescDetailEntry cmd_search_hash_block_Usage_space_example_detail_entries[] = {
-	{ .text = "MD5 hash search within blocks of 512 bytes.", .arg_str = NULL, .comment = "/h md5 0bc8f8c426b74ffaedac8330a7464014 @! 512" },
-	{ 0 },
-};
-static const RzCmdDescDetail cmd_search_hash_block_details[] = {
-	{ .name = "Usage example", .entries = cmd_search_hash_block_Usage_space_example_detail_entries },
-	{ 0 },
-};
-static const RzCmdDescArg cmd_search_hash_block_args[] = {
-	{
-		.name = "algo",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-
-	},
-	{
-		.name = "hash",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
-
-	},
-	{ 0 },
-};
-static const RzCmdDescHelp cmd_search_hash_block_help = {
-	.summary = "Search for blocks that have the same hash (see also command `ph`).",
-	.details = cmd_search_hash_block_details,
-	.args = cmd_search_hash_block_args,
 };
 
 static const RzCmdDescHelp slash_m_help = {
@@ -21072,6 +21105,14 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *cmd_search_collision_cd = rz_cmd_desc_argv_new(core->rcmd, slash_c_cd, "/cc", rz_cmd_search_collision_handler, &cmd_search_collision_help);
 	rz_warn_if_fail(cmd_search_collision_cd);
 
+	RzCmdDesc *cmd_search_hash_block_cd = rz_cmd_desc_argv_state_new(core->rcmd, slash_c_cd, "/ch", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_TABLE, rz_cmd_search_hash_block_handler, &cmd_search_hash_block_help);
+	rz_warn_if_fail(cmd_search_hash_block_cd);
+	rz_cmd_desc_set_default_mode(cmd_search_hash_block_cd, RZ_OUTPUT_MODE_STANDARD);
+
+	RzCmdDesc *cmd_search_hash_entropy_cd = rz_cmd_desc_argv_state_new(core->rcmd, slash_c_cd, "/ce", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_TABLE, rz_cmd_search_hash_entropy_handler, &cmd_search_hash_entropy_help);
+	rz_warn_if_fail(cmd_search_hash_entropy_cd);
+	rz_cmd_desc_set_default_mode(cmd_search_hash_entropy_cd, RZ_OUTPUT_MODE_STANDARD);
+
 	RzCmdDesc *cmd_search_cryptographic_material_cd = rz_cmd_desc_argv_state_new(core->rcmd, slash_c_cd, "/cm", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_TABLE, rz_cmd_search_cryptographic_material_handler, &cmd_search_cryptographic_material_help);
 	rz_warn_if_fail(cmd_search_cryptographic_material_cd);
 	rz_cmd_desc_set_default_mode(cmd_search_cryptographic_material_cd, RZ_OUTPUT_MODE_STANDARD);
@@ -21100,20 +21141,12 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 	rz_warn_if_fail(cmd_search_blocks_cd);
 	rz_cmd_desc_set_default_mode(cmd_search_blocks_cd, RZ_OUTPUT_MODE_STANDARD);
 
-	RzCmdDesc *cmd_search_sections_cd = rz_cmd_desc_argv_state_new(core->rcmd, slash__cd, "/s", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_TABLE, rz_cmd_search_sections_handler, &cmd_search_sections_help);
-	rz_warn_if_fail(cmd_search_sections_cd);
-	rz_cmd_desc_set_default_mode(cmd_search_sections_cd, RZ_OUTPUT_MODE_STANDARD);
-
 	RzCmdDesc *slash_g_cd = rz_cmd_desc_group_state_new(core->rcmd, slash__cd, "/g", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_cmd_search_graph_path_handler, &cmd_search_graph_path_help, &slash_g_help);
 	rz_warn_if_fail(slash_g_cd);
 	rz_cmd_desc_set_default_mode(slash_g_cd, RZ_OUTPUT_MODE_STANDARD);
 	RzCmdDesc *cmd_search_graph_path_follow_calls_cd = rz_cmd_desc_argv_state_new(core->rcmd, slash_g_cd, "/gg", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_cmd_search_graph_path_follow_calls_handler, &cmd_search_graph_path_follow_calls_help);
 	rz_warn_if_fail(cmd_search_graph_path_follow_calls_cd);
 	rz_cmd_desc_set_default_mode(cmd_search_graph_path_follow_calls_cd, RZ_OUTPUT_MODE_STANDARD);
-
-	RzCmdDesc *cmd_search_hash_block_cd = rz_cmd_desc_argv_state_new(core->rcmd, slash__cd, "/h", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_TABLE, rz_cmd_search_hash_block_handler, &cmd_search_hash_block_help);
-	rz_warn_if_fail(cmd_search_hash_block_cd);
-	rz_cmd_desc_set_default_mode(cmd_search_hash_block_cd, RZ_OUTPUT_MODE_STANDARD);
 
 	RzCmdDesc *slash_m_cd = rz_cmd_desc_group_state_new(core->rcmd, slash__cd, "/m", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_TABLE, rz_cmd_search_magic_const_handler, &cmd_search_magic_const_help, &slash_m_help);
 	rz_warn_if_fail(slash_m_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -103,6 +103,10 @@ RZ_IPI RzCmdStatus rz_cmd_search_assemble_t_handler(RzCore *core, int argc, cons
 RZ_IPI RzCmdStatus rz_cmd_search_assemble_tl_handler(RzCore *core, int argc, const char **argv);
 // "/cc"
 RZ_IPI RzCmdStatus rz_cmd_search_collision_handler(RzCore *core, int argc, const char **argv);
+// "/ch"
+RZ_IPI RzCmdStatus rz_cmd_search_hash_block_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+// "/ce"
+RZ_IPI RzCmdStatus rz_cmd_search_hash_entropy_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "/cm"
 RZ_IPI RzCmdStatus rz_cmd_search_cryptographic_material_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "/d"
@@ -117,14 +121,10 @@ RZ_IPI RzCmdStatus rz_cmd_search_insn_offset_backwards_fallback_handler(RzCore *
 RZ_IPI RzCmdStatus rz_cmd_search_pattern_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "/P"
 RZ_IPI RzCmdStatus rz_cmd_search_blocks_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
-// "/s"
-RZ_IPI RzCmdStatus rz_cmd_search_sections_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "/g"
 RZ_IPI RzCmdStatus rz_cmd_search_graph_path_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "/gg"
 RZ_IPI RzCmdStatus rz_cmd_search_graph_path_follow_calls_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
-// "/h"
-RZ_IPI RzCmdStatus rz_cmd_search_hash_block_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "/m"
 RZ_IPI RzCmdStatus rz_cmd_search_magic_const_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "/mb"

--- a/librz/core/cmd_descs/cmd_search.yaml
+++ b/librz/core/cmd_descs/cmd_search.yaml
@@ -224,6 +224,60 @@ commands:
               comment: "printable (alpha + digit)"
             - text: b
               comment: "binary (any number is valid)"
+    - name: "/ch"
+      summary: Search for blocks that have the same hash.
+      cname: cmd_search_hash_block
+      type: RZ_CMD_DESC_TYPE_ARGV_STATE
+      default_mode: RZ_OUTPUT_MODE_STANDARD
+      modes:
+        - RZ_OUTPUT_MODE_STANDARD
+        - RZ_OUTPUT_MODE_JSON
+        - RZ_OUTPUT_MODE_QUIET
+        - RZ_OUTPUT_MODE_TABLE
+      args:
+        - name: algo
+          type: RZ_CMD_ARG_TYPE_STRING
+        - name: hash
+          type: RZ_CMD_ARG_TYPE_STRING
+        - name: "block_size"
+          type: RZ_CMD_ARG_TYPE_NUM
+          default_value: "256"
+      details:
+        - name: Usage example
+          entries:
+            - text: "/ch md5 0bc8f8c426b74ffaedac8330a7464014 512"
+              comment: "MD5 hash search within blocks of 512 bytes."
+            - text: /ch entropy_fract 0.6 16k
+              comment: "Find 16384 byte blocks with an entropy of 0.6 and above."
+        - name: Tip
+          entries:
+            - text: "The command 'Lh' gives you a list of supported hash plugins."
+              comment: ""
+    - name: "/ce"
+      summary: "Search for blocks above an entropy level (alias for: /ch entropy_fract <entropy> <block_size>)."
+      cname: cmd_search_hash_entropy
+      type: RZ_CMD_DESC_TYPE_ARGV_STATE
+      default_mode: RZ_OUTPUT_MODE_STANDARD
+      modes:
+        - RZ_OUTPUT_MODE_STANDARD
+        - RZ_OUTPUT_MODE_JSON
+        - RZ_OUTPUT_MODE_QUIET
+        - RZ_OUTPUT_MODE_TABLE
+      args:
+        - name: entropy
+          type: RZ_CMD_ARG_TYPE_NUM
+        - name: "block_size"
+          type: RZ_CMD_ARG_TYPE_NUM
+          default_value: "256"
+      details:
+        - name: Usage example
+          entries:
+            - text: /ce 0.3 512
+              comment: "Find 512 byte blocks with an entropy of 0.3 and above."
+        - name: Tip
+          entries:
+            - text: "The command 'Lh' gives you a list of supported hash plugins."
+              comment: ""
     - name: "/cm"
       summary: Search cryptographic material.
       cname: cmd_search_cryptographic_material
@@ -358,19 +412,6 @@ commands:
     args:
       - name: "patternsize"
         type: RZ_CMD_ARG_TYPE_NUM
-  - name: "/s"
-    summary: Search sections by grouping blocks with similar entropy.
-    cname: cmd_search_sections
-    type: RZ_CMD_DESC_TYPE_ARGV_STATE
-    default_mode: RZ_OUTPUT_MODE_STANDARD
-    modes:
-      - RZ_OUTPUT_MODE_STANDARD
-      - RZ_OUTPUT_MODE_JSON
-      - RZ_OUTPUT_MODE_QUIET
-      - RZ_OUTPUT_MODE_TABLE
-    args:
-      - name: "threshold"
-        type: RZ_CMD_ARG_TYPE_STRING
 
   - name: "/g"
     summary: Search for all graph paths A to B.
@@ -401,28 +442,6 @@ commands:
           type: RZ_CMD_ARG_TYPE_RZNUM
         - name: to
           type: RZ_CMD_ARG_TYPE_RZNUM
-
-  - name: "/h"
-    summary: Search for blocks that have the same hash (see also command `ph`).
-    cname: cmd_search_hash_block
-    type: RZ_CMD_DESC_TYPE_ARGV_STATE
-    default_mode: RZ_OUTPUT_MODE_STANDARD
-    modes:
-      - RZ_OUTPUT_MODE_STANDARD
-      - RZ_OUTPUT_MODE_JSON
-      - RZ_OUTPUT_MODE_QUIET
-      - RZ_OUTPUT_MODE_TABLE
-    args:
-      - name: algo
-        type: RZ_CMD_ARG_TYPE_STRING
-      - name: hash
-        type: RZ_CMD_ARG_TYPE_STRING
-    details:
-      - name: Usage example
-        entries:
-          - text: "MD5 hash search within blocks of 512 bytes."
-            comment: "/h md5 0bc8f8c426b74ffaedac8330a7464014 @! 512"
-
   - name: "/m"
     summary: Magic constants search.
     subcommands:

--- a/librz/core/csearch.c
+++ b/librz/core/csearch.c
@@ -58,7 +58,13 @@ RZ_API RZ_OWN RzList /*<RzIOMap *>*/ *rz_core_setup_io_search_parameters(RzCore 
 	if (!boundaries || rz_list_empty(boundaries)) {
 		ut64 from = rz_config_get_i(core->config, "search.from");
 		ut64 to = rz_config_get_i(core->config, "search.to");
-		RZ_LOG_ERROR("core: Failed to get search boundaries within [0x%" PFMT64x ", 0x%" PFMT64x "].\n", from, to);
+		if (!boundaries) {
+			RZ_LOG_ERROR("Failed to initialize boundaries within [0x%" PFMT64x ", 0x%" PFMT64x "].\n", from, to);
+		} else {
+			RZ_LOG_ERROR("The range [0x%" PFMT64x ", 0x%" PFMT64x "] doesn't overlap with a mapped memory region or\n"
+				     "the region is not included in search.in.\n",
+				from, to);
+		}
 		goto fail;
 	}
 

--- a/librz/core/csearch.c
+++ b/librz/core/csearch.c
@@ -371,6 +371,62 @@ quit:
 }
 
 /**
+ * \brief      Finds a hash material in the IO layer of the given core and core configuration.
+ *
+ * \param      core The RzCore core.
+ * \param      opt  The search options to apply. If it is NULL a default set of options is used.
+ * \param      data Optional additional search data. Some crytpographic searches require additional data (e.g. entropy search).
+ *
+ * \return     On success returns a pointer to the search hits, otherwise NULL
+ */
+RZ_API RZ_OWN RzList /*<RzSearchHit *>*/ *rz_core_search_hash_material(
+	RZ_NONNULL RzCore *core,
+	RZ_BORROW RZ_NULLABLE RzSearchOpt *user_opts,
+	RZ_NULLABLE RzSearchHashFindData *data) {
+	rz_return_val_if_fail(core && core->config, NULL);
+
+	RzList *hits = NULL;
+	RzList *boundaries = NULL;
+	RzSearchOpt *search_opts = NULL;
+
+	RzSearchCollection *collection = rz_search_collection_hash();
+	if (!collection) {
+		return NULL;
+	}
+
+	if (!rz_search_collection_hash_add(collection, data)) {
+		goto quit;
+	}
+
+	if (!user_opts) {
+		// override user_opts with default one
+		user_opts = search_opts = default_search_options();
+		if (!search_opts) {
+			goto quit;
+		}
+	}
+
+	if (!rz_search_opt_set_chunk_size(user_opts, rz_search_hash_get_element_size(collection))) {
+		RZ_LOG_ERROR("search: Failed to update chunk size in the search options.\n");
+		goto quit;
+	}
+
+	boundaries = rz_core_setup_io_search_parameters(core, user_opts);
+	if (!boundaries) {
+		RZ_LOG_ERROR("core: Setting up search from core failed.\n");
+		goto quit;
+	}
+
+	hits = perform_search_on_core_io(core, user_opts, boundaries, collection);
+
+quit:
+	rz_list_free(boundaries);
+	rz_search_opt_free(search_opts);
+	rz_search_collection_free(collection);
+	return hits;
+}
+
+/**
  * \brief Searches magics defined in \p magic_dir.
  *
  * \param core The core to use.

--- a/librz/core/csearch.c
+++ b/librz/core/csearch.c
@@ -322,21 +322,22 @@ quit:
  *
  * \return     On success returns a pointer to the search hits, otherwise NULL
  */
-RZ_API RZ_OWN RzList /*<RzSearchHit *>*/ *rz_core_search_cryptographic_material(RZ_NONNULL RzCore *core, RZ_BORROW RZ_NULLABLE RzSearchOpt *user_opts, RzSearchCollectionCryptographicType type) {
+RZ_API RZ_OWN RzList /*<RzSearchHit *>*/ *rz_core_search_cryptographic_material(
+	RZ_NONNULL RzCore *core,
+	RZ_BORROW RZ_NULLABLE RzSearchOpt *user_opts,
+	RzSearchCollectionCryptographicType type) {
 	rz_return_val_if_fail(core && core->config, NULL);
 
 	RzList *hits = NULL;
 	RzList *boundaries = NULL;
 	RzSearchOpt *search_opts = NULL;
-	bool add_all_methods = type >= RZ_SEARCH_COLLECTION_CRYPTOGRAPHIC_ENUM_SIZE;
 
-	RzSearchCollection *collection = rz_search_collection_cryptographic(add_all_methods);
+	RzSearchCollection *collection = rz_search_collection_cryptographic();
 	if (!collection) {
 		return NULL;
 	}
 
-	if (!add_all_methods &&
-		!rz_search_collection_cryptographic_add(collection, type)) {
+	if (!rz_search_collection_cryptographic_add(collection, type)) {
 		goto quit;
 	}
 

--- a/librz/hash/algorithms/entropy/entropy.c
+++ b/librz/hash/algorithms/entropy/entropy.c
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include "entropy.h"
-#include <stdlib.h>
 #include <math.h>
 #include <rz_util/rz_assert.h>
 

--- a/librz/hash/hash.c
+++ b/librz/hash/hash.c
@@ -215,7 +215,7 @@ static HashCfgConfig *hash_cfg_config_new(const RzHashPlugin *plugin) {
 	return mdc;
 }
 
-RZ_API RZ_BORROW const RzHashPlugin *rz_hash_plugin_by_name(RZ_NONNULL RzHash *rh, RZ_NONNULL const char *name) {
+RZ_API RZ_BORROW const RzHashPlugin *rz_hash_plugin_by_name(const RZ_NONNULL RzHash *rh, RZ_NONNULL const char *name) {
 	rz_return_val_if_fail(name && rh, NULL);
 
 	bool found = false;
@@ -226,7 +226,7 @@ RZ_API RZ_BORROW const RzHashPlugin *rz_hash_plugin_by_name(RZ_NONNULL RzHash *r
 	return NULL;
 }
 
-RZ_API RZ_OWN RzHashCfg *rz_hash_cfg_new(RZ_NONNULL RzHash *rh) {
+RZ_API RZ_OWN RzHashCfg *rz_hash_cfg_new(const RZ_NONNULL RzHash *rh) {
 	rz_return_val_if_fail(rh, NULL);
 
 	RzHashCfg *md = RZ_NEW0(RzHashCfg);
@@ -253,7 +253,7 @@ RZ_API RZ_OWN RzHashCfg *rz_hash_cfg_new(RZ_NONNULL RzHash *rh) {
  * with the given algorithm and runs also the algo init.
  * when fails to allocate or configure or initialize, returns NULL.
  * */
-RZ_API RZ_OWN RzHashCfg *rz_hash_cfg_new_with_algo(RZ_NONNULL RzHash *rh, RZ_NONNULL const char *name, RZ_NULLABLE const ut8 *key, ut64 key_size) {
+RZ_API RZ_OWN RzHashCfg *rz_hash_cfg_new_with_algo(const RZ_NONNULL RzHash *rh, RZ_NONNULL const char *name, RZ_NULLABLE const ut8 *key, ut64 key_size) {
 	rz_return_val_if_fail(rh && name, NULL);
 	RzHashCfg *md = rz_hash_cfg_new(rh);
 	if (!md) {
@@ -542,7 +542,7 @@ RZ_API bool rz_hash_cfg_iterate(RZ_NONNULL RzHashCfg *md, size_t iterate) {
  * RzHashCfg contains a list of configurations; this method will search
  * for the configuration with the given name and if found return the digest value.
  * */
-RZ_API RZ_BORROW const ut8 *rz_hash_cfg_get_result(RZ_NONNULL RzHashCfg *md, RZ_NONNULL const char *name, RZ_NONNULL ut32 *size) {
+RZ_API RZ_BORROW const ut8 *rz_hash_cfg_get_result(RZ_NONNULL RzHashCfg *md, RZ_NONNULL const char *name, RZ_NULLABLE ut32 *size) {
 	rz_return_val_if_fail(md && name && hash_cfg_has_finshed(md), false);
 
 	RzListIter *it = rz_list_find(md->configurations, name, hash_cfg_config_compare, NULL);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -1355,6 +1355,7 @@ RZ_API RZ_OWN RzList /*<RzSearchHit *>*/ *rz_core_search_bytes(RZ_NONNULL RzCore
 RZ_API RZ_OWN RzList /*<RzSearchHit *>*/ *rz_core_search_values(RZ_NONNULL RzCore *core, RZ_BORROW RZ_NULLABLE RzSearchOpt *user_opts, RZ_NONNULL RZ_OWN RzVector /*<RzSearchValueRange>*/ *vranges);
 RZ_API RZ_OWN RzList /*<RzSearchHit *>*/ *rz_core_search_string(RZ_NONNULL RzCore *core, RZ_BORROW RZ_NONNULL RzSearchOpt *user_opts, RZ_NONNULL const char *string, RzRegexFlags flags, RzStrEnc expected);
 RZ_API RZ_OWN RzList /*<RzSearchHit *>*/ *rz_core_search_cryptographic_material(RZ_NONNULL RzCore *core, RZ_BORROW RZ_NULLABLE RzSearchOpt *user_opts, RzSearchCollectionCryptographicType type);
+RZ_API RZ_OWN RzList /*<RzSearchHit *>*/ *rz_core_search_hash_material(RZ_NONNULL RzCore *core, RZ_BORROW RZ_NULLABLE RzSearchOpt *user_opts, RZ_NULLABLE RzSearchHashFindData *data);
 RZ_API RZ_OWN RzList /*<RzSearchHit *>*/ *rz_core_search_magic(RZ_NONNULL RzCore *core, RZ_BORROW RZ_NULLABLE RzSearchOpt *user_opts, RZ_NULLABLE const char *magic_dir);
 
 #endif

--- a/librz/include/rz_hash.h
+++ b/librz/include/rz_hash.h
@@ -47,7 +47,7 @@ typedef struct rz_hash_t {
 typedef struct rz_hash_cfg_t {
 	RzList /*<HashCfgConfig *>*/ *configurations;
 	RzHashStatus status;
-	RzHash *hash;
+	const RzHash *hash; ///< Immutable RzHash instance.
 } RzHashCfg;
 
 /**
@@ -70,10 +70,10 @@ RZ_API RzHash *rz_hash_new(void);
 RZ_API void rz_hash_free(RZ_NULLABLE RzHash *rh);
 RZ_API bool rz_hash_plugin_add(RZ_NONNULL RzHash *rh, RZ_NONNULL RZ_OWN RzHashPlugin *plugin);
 RZ_API bool rz_hash_plugin_del(RZ_NONNULL RzHash *rh, RZ_NONNULL RzHashPlugin *plugin);
-RZ_API RZ_BORROW const RzHashPlugin *rz_hash_plugin_by_name(RZ_NONNULL RzHash *rh, RZ_NONNULL const char *name);
+RZ_API RZ_BORROW const RzHashPlugin *rz_hash_plugin_by_name(const RZ_NONNULL RzHash *rh, RZ_NONNULL const char *name);
 
-RZ_API RZ_OWN RzHashCfg *rz_hash_cfg_new(RZ_NONNULL RzHash *rh);
-RZ_API RZ_OWN RzHashCfg *rz_hash_cfg_new_with_algo(RZ_NONNULL RzHash *rh, RZ_NONNULL const char *name, RZ_NULLABLE const ut8 *key, ut64 key_size);
+RZ_API RZ_OWN RzHashCfg *rz_hash_cfg_new(const RZ_NONNULL RzHash *rh);
+RZ_API RZ_OWN RzHashCfg *rz_hash_cfg_new_with_algo(const RZ_NONNULL RzHash *rh, RZ_NONNULL const char *name, RZ_NULLABLE const ut8 *key, ut64 key_size);
 #define rz_hash_cfg_new_with_algo2(rh, name) rz_hash_cfg_new_with_algo(rh, name, NULL, 0);
 RZ_API void rz_hash_cfg_free(RZ_NONNULL RzHashCfg *md);
 
@@ -83,7 +83,7 @@ RZ_API bool rz_hash_cfg_init(RZ_NONNULL RzHashCfg *md);
 RZ_API bool rz_hash_cfg_update(RZ_NONNULL RzHashCfg *md, RZ_NONNULL const ut8 *data, ut64 size);
 RZ_API bool rz_hash_cfg_final(RZ_NONNULL RzHashCfg *md);
 RZ_API bool rz_hash_cfg_iterate(RZ_NONNULL RzHashCfg *md, size_t iterate);
-RZ_API RZ_BORROW const ut8 *rz_hash_cfg_get_result(RZ_NONNULL RzHashCfg *md, RZ_NONNULL const char *name, RZ_NONNULL RzHashSize *size);
+RZ_API RZ_BORROW const ut8 *rz_hash_cfg_get_result(RZ_NONNULL RzHashCfg *md, RZ_NONNULL const char *name, RZ_NULLABLE RzHashSize *size);
 RZ_API RZ_OWN char *rz_hash_cfg_get_result_string(RZ_NONNULL RzHashCfg *md, RZ_NONNULL const char *name, RZ_NULLABLE ut32 *size, bool invert);
 RZ_API RzHashSize rz_hash_cfg_size(RZ_NONNULL RzHashCfg *md, RZ_NONNULL const char *name);
 RZ_API RZ_OWN ut8 *rz_hash_cfg_calculate_small_block(RZ_NONNULL RzHash *rh, RZ_NONNULL const char *name, RZ_NONNULL const ut8 *buffer, ut64 bsize, RZ_NONNULL RzHashSize *osize);

--- a/librz/include/rz_search.h
+++ b/librz/include/rz_search.h
@@ -2,6 +2,7 @@
 #define RZ_SEARCH_H
 
 #include <rz_types.h>
+#include <rz_hash.h>
 #include <rz_util.h>
 #include <rz_list.h>
 #include <rz_io.h>
@@ -146,6 +147,18 @@ typedef struct rz_search_interval_t RzSearchInterval;
 
 typedef struct rz_search_collection_t RzSearchCollection;
 
+/**
+ * \brief Data passed to hash search find() workers.
+ */
+typedef struct rz_search_hash_find_data_t RzSearchHashFindData;
+
+typedef struct {
+	char *algo; ///< The hash algorithm used for the.
+	ut8 *hash; ///< Calculated hash.
+	size_t hash_size; ///< Hash size in bytes.
+	char *hash_str; ///< The hash result as printable string.
+} RzSearchiHitDetailHash;
+
 typedef enum {
 	RZ_SEARCH_HIT_DETAIL_NONE = 0,
 	RZ_SEARCH_HIT_DETAIL_HASH,
@@ -232,6 +245,12 @@ typedef enum {
 RZ_API RZ_OWN RzSearchCollection *rz_search_collection_cryptographic();
 RZ_API bool rz_search_collection_cryptographic_add(RZ_NONNULL RzSearchCollection *col, RzSearchCollectionCryptographicType type);
 RZ_API bool rz_search_collection_cryptographic_name_to_type(RZ_NONNULL const char *name, RzSearchCollectionCryptographicType *type);
+
+RZ_API RZ_OWN RzSearchCollection *rz_search_collection_hash();
+RZ_API RZ_OWN RzSearchHashFindData *rz_search_hash_get_find_data(const RzHash *rz_hash, RZ_NONNULL const char *algo_name, RZ_NONNULL const char *expected_digits, const char *block_size_arg);
+RZ_API bool rz_search_collection_hash_add(RZ_NONNULL RzSearchCollection *col, RZ_OWN RZ_NONNULL RzSearchHashFindData *data);
+RZ_API bool rz_search_collection_hash_name_to_type(RZ_NONNULL const char *name);
+RZ_API ut64 rz_search_hash_get_element_size(RZ_NONNULL RzSearchCollection *collection);
 
 /**
  * \brief Maximum value width to search for is currently 64bits/8bytes.

--- a/librz/include/rz_search.h
+++ b/librz/include/rz_search.h
@@ -146,9 +146,16 @@ typedef struct rz_search_interval_t RzSearchInterval;
 
 typedef struct rz_search_collection_t RzSearchCollection;
 
+typedef enum {
+	RZ_SEARCH_HIT_DETAIL_NONE = 0,
+	RZ_SEARCH_HIT_DETAIL_HASH,
+} RzSearchHitDetailType;
+
 typedef struct rz_search_hit_t {
 	char *hit_desc; ///< Hit one word description. If set, it is added to the flag name of the hit. Optional, can be NULL.
 	char *comment; ///< A detailed comment about the hit. Set as flag comment. Optional, can be NULL.
+	void *details; ///< Search dependent details of the hit.
+	RzSearchHitDetailType detail_type; ///< The type of the detail, if any.
 	ut64 address; ///< Address/offset of the matched data.
 	size_t size; ///< Size of the matched data (can be 0), in bytes.
 } RzSearchHit;
@@ -159,6 +166,8 @@ typedef enum {
 } RzSearchCancelReason;
 
 RZ_API RZ_OWN char *rz_search_hit_flag_name(RZ_NONNULL const RzSearchHit *hit, size_t hit_id, RZ_NULLABLE const char *prefix);
+RZ_API RZ_OWN char *rz_search_hit_detail_str(RZ_BORROW RZ_NONNULL RzSearchHit *hit);
+RZ_API bool rz_search_hit_detail_json(RZ_BORROW RZ_NONNULL RzSearchHit *hit, RZ_OUT RZ_NONNULL PJ *pj);
 
 typedef struct rz_search_bytes_pattern_t RzSearchBytesPattern;
 

--- a/librz/include/rz_search.h
+++ b/librz/include/rz_search.h
@@ -213,11 +213,14 @@ typedef enum {
 	RZ_SEARCH_COLLECTION_CRYPTOGRAPHIC_ECC,
 	RZ_SEARCH_COLLECTION_CRYPTOGRAPHIC_SAFECURVES,
 	RZ_SEARCH_COLLECTION_CRYPTOGRAPHIC_X509,
+
 	// Always the last element to define enum size
 	RZ_SEARCH_COLLECTION_CRYPTOGRAPHIC_ENUM_SIZE,
 } RzSearchCollectionCryptographicType;
 
-RZ_API RZ_OWN RzSearchCollection *rz_search_collection_cryptographic(bool add_all_methods);
+#define RZ_SEARCH_COLLECTION_CRYPTOGRAPHIC_ALL RZ_SEARCH_COLLECTION_CRYPTOGRAPHIC_ENUM_SIZE
+
+RZ_API RZ_OWN RzSearchCollection *rz_search_collection_cryptographic();
 RZ_API bool rz_search_collection_cryptographic_add(RZ_NONNULL RzSearchCollection *col, RzSearchCollectionCryptographicType type);
 RZ_API bool rz_search_collection_cryptographic_name_to_type(RZ_NONNULL const char *name, RzSearchCollectionCryptographicType *type);
 

--- a/librz/search/cryptographic_search.c
+++ b/librz/search/cryptographic_search.c
@@ -102,25 +102,13 @@ static bool cryptographic_is_empty(void *user) {
 /**
  * \brief      Allocates and initialize a pkey RzSearchCollection
  *
- * \param[in]  add_all   If true, it adds all cryptographic methods to the search, otherwise none.
- *
  * \return     On success returns a valid pointer, otherwise NULL
  */
-RZ_API RZ_OWN RzSearchCollection *rz_search_collection_cryptographic(bool add_all_methods) {
+RZ_API RZ_OWN RzSearchCollection *rz_search_collection_cryptographic() {
 	RzPVector /*<CryptographicCallback *>*/ *pvec = rz_pvector_new(NULL);
 	if (!pvec) {
 		RZ_LOG_ERROR("search: cannot allocate internal data for cryptographic search collection\n");
 		return NULL;
-	}
-
-	for (size_t i = 0; add_all_methods && i < RZ_ARRAY_SIZE(cryptographic_methods); ++i) {
-		CryptographicCallback find = cryptographic_methods[i].find;
-		if (!rz_pvector_push(pvec, find)) {
-			const char *name = cryptographic_methods[i].name;
-			RZ_LOG_ERROR("search: cannot add %s to cryptographic search collection\n", name);
-			rz_pvector_free(pvec);
-			return NULL;
-		}
 	}
 
 	return rz_search_collection_new_bytes_space(cryptographic_find, cryptographic_is_empty, (RzSearchFreeCallback)rz_pvector_free, pvec);
@@ -142,8 +130,26 @@ RZ_API bool rz_search_collection_cryptographic_add(RZ_NONNULL RzSearchCollection
 		return false;
 	}
 
-	if (type >= RZ_SEARCH_COLLECTION_CRYPTOGRAPHIC_ENUM_SIZE) {
-		RZ_LOG_ERROR("search: cannot add cryptographic method when type value exceeds enum size\n");
+	if (type >= RZ_SEARCH_COLLECTION_CRYPTOGRAPHIC_ALL) {
+		RzPVector *pvec = col->user;
+		CryptographicCallback find_cb;
+		for (size_t i = 0; i < RZ_SEARCH_COLLECTION_CRYPTOGRAPHIC_ENUM_SIZE; ++i) {
+			find_cb = cryptographic_methods[i].find;
+			if (rz_pvector_contains(pvec, find_cb)) {
+				RZ_LOG_WARN("search: %s already in cryptographic search collection!\n", cryptographic_methods[i].name);
+				continue;
+			}
+			if (!rz_pvector_push(pvec, find_cb)) {
+				const char *name = cryptographic_methods[i].name;
+				RZ_LOG_ERROR("search: cannot add %s to cryptographic search collection\n", name);
+				return false;
+			}
+		}
+		return true;
+	}
+
+	if (!cryptographic_methods[type].find) {
+		RZ_LOG_ERROR("The crypto type has no search method defined.\n");
 		return false;
 	}
 

--- a/librz/search/hash_search.c
+++ b/librz/search/hash_search.c
@@ -1,0 +1,322 @@
+// SPDX-FileCopyrightText: 2025 RizinOrg <info@rizin.re>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_search.h>
+#include <rz_vector.h>
+#include <rz_util.h>
+
+#include <rz_endian.h>
+#include <rz_hash.h>
+#include <rz_types.h>
+#include "search_internal.h"
+
+static void rz_search_hash_data_free(RzSearchHashFindData *data) {
+	if (!data) {
+		return;
+	}
+	free(data->algo);
+	free(data->digits);
+	free(data);
+}
+
+static bool rz_search_hash_data_eq(const RzSearchHashFindData *a, const RzSearchHashFindData *b) {
+	if (!a && !b) {
+		return true;
+	} else if (!a || !b) {
+		return false;
+	}
+
+	if (!RZ_STR_EQ(a->algo, b->algo) || a->digits_len != b->digits_len) {
+		return false;
+	}
+
+	return rz_mem_eq(a->digits, b->digits, a->digits_len);
+}
+
+static ut8 *parse_digits(const char *algo, const char *expected_digits, ut32 digit_size) {
+	rz_return_val_if_fail(expected_digits, NULL);
+	ut8 *out = RZ_NEWS0(ut8, digit_size);
+	if (rz_str_startswith(algo, "entropy")) {
+		double entropy_threshold = rz_num_get_float(NULL, expected_digits);
+		if (entropy_threshold < 0.0) {
+			RZ_LOG_ERROR("Threshold '%02f' cannot be smaller than 0.0.\n", entropy_threshold);
+			goto error;
+		}
+		if (rz_str_startswith(algo, "entropy_fract") && entropy_threshold > 1.0) {
+			RZ_LOG_ERROR("Threshold '%02f' cannot be larger than 1.0.\n", entropy_threshold);
+			goto error;
+		}
+		rz_write_be_double(out, entropy_threshold);
+	} else if (rz_str_startswith(algo, "ssdeep")) {
+		rz_mem_copy(out, digit_size, expected_digits, strlen(expected_digits));
+	} else {
+		if (rz_regex_contains("[^a-fA-F0-9]+", expected_digits, RZ_REGEX_ZERO_TERMINATED, RZ_REGEX_EXTENDED, RZ_REGEX_DEFAULT)) {
+			RZ_LOG_ERROR("digits must be a hexadecimal string without spaces nor '0x' prefix. Got: '%s'\n", expected_digits);
+			goto error;
+		}
+		ut32 elen = strlen(expected_digits) / 2;
+		if (elen != digit_size || elen & 1) {
+			RZ_LOG_ERROR("Expected digits don't have the correct number of bytes. Expected: %" PFMT32u ", got: %" PFMT32u ".\n", digit_size, (elen / 2) + elen % 2);
+			goto error;
+		}
+		rz_hex_str2bin(expected_digits, out);
+	}
+	return out;
+
+error:
+	free(out);
+	return NULL;
+}
+
+RZ_API RZ_OWN RzSearchHashFindData *rz_search_hash_get_find_data(const RzHash *rz_hash, RZ_NONNULL const char *algo_name, RZ_NONNULL const char *expected_digits, const char *block_size_arg) {
+	rz_return_val_if_fail(algo_name && expected_digits, NULL);
+	ut64 block_size = rz_num_get(NULL, block_size_arg);
+	if (block_size & 1 || block_size == 0) {
+		RZ_LOG_ERROR("Odd or zero block sizes are not allowed.\n");
+		return NULL;
+	}
+
+	RzHashCfg *md = rz_hash_cfg_new(rz_hash);
+	if (!md || !rz_hash_cfg_configure(md, algo_name)) {
+		RZ_LOG_ERROR("The hash algorithm '%s' is not supported for the search. List supported with the command 'Lh'.\n", algo_name);
+		return NULL;
+	}
+	ut32 digit_size = rz_hash_cfg_size(md, algo_name);
+	if (digit_size == 0) {
+		RZ_LOG_ERROR("The hash algorithm '%s' is not supported for the search. List supported with the command 'Lh'.\n", algo_name);
+		return NULL;
+	}
+	rz_hash_cfg_free(md);
+
+	ut8 *digits = parse_digits(algo_name, expected_digits, digit_size);
+	if (!digits) {
+		RZ_LOG_ERROR("Failed to parse has search arguments.\n");
+		return NULL;
+	}
+	RzSearchHashFindData *data = RZ_NEW(RzSearchHashFindData);
+	if (!data) {
+		return NULL;
+	}
+	data->digits = digits;
+	data->digits_len = digit_size;
+	data->algo = rz_str_dup(algo_name);
+	data->block_size = block_size;
+	data->rz_hash = rz_hash;
+	return data;
+}
+
+static RzHashCfg *init_hash_config(RzPVector /*<RzSearchHashFindData *>*/ *pvec) {
+	void **it;
+	const RzSearchHashFindData *data = rz_pvector_at(pvec, 0);
+	if (!data) {
+		goto error;
+	}
+	RzHashCfg *cfg = rz_hash_cfg_new(data->rz_hash);
+	rz_pvector_foreach (pvec, it) {
+		data = *it;
+		if (!rz_hash_cfg_configure(cfg, data->algo)) {
+			RZ_LOG_ERROR("Failed to setup config for '%s'.\n", data->algo);
+			goto error;
+		}
+	}
+	return cfg;
+
+error:
+	return NULL;
+}
+
+static bool hashes_match(const RzSearchHashFindData *data, const ut8 *calculated_hash, ut32 hsize) {
+	rz_return_val_if_fail(data && calculated_hash && hsize != 0, false);
+	if (rz_str_startswith(data->algo, "entropy")) {
+		return hsize == sizeof(double) && rz_read_be_double(calculated_hash) >= rz_read_be_double(data->digits);
+	}
+	// All the others just compare digits in with memory compare.
+	return rz_mem_eq(data->digits, calculated_hash, hsize);
+}
+
+static RzSearchHit *hash_and_compare(RzHashCfg *cfg, const RzSearchHashFindData *data, ut64 address, const ut8 *buffer, size_t buf_size) {
+	rz_return_val_if_fail(cfg && data && buffer, NULL);
+	if (!rz_hash_cfg_init(cfg)) {
+		RZ_LOG_ERROR("Hash config init failed.\n");
+		return NULL;
+	}
+	if (!rz_hash_cfg_update(cfg, buffer, buf_size)) {
+		RZ_LOG_ERROR("Hash config update failed.\n");
+		return NULL;
+	}
+	if (!rz_hash_cfg_final(cfg)) {
+		RZ_LOG_ERROR("Hash config final failed.\n");
+		return NULL;
+	}
+	RzHashSize hsize;
+	const ut8 *calculated_hash = rz_hash_cfg_get_result(cfg, data->algo, &hsize);
+	if (hsize != data->digits_len) {
+		rz_warn_if_reached();
+		return NULL;
+	}
+	if (!hashes_match(data, calculated_hash, hsize)) {
+		return NULL;
+	}
+	RzSearchHit *hit = rz_search_hit_new(data->algo, address, buf_size, NULL);
+	if (!hit) {
+		return NULL;
+	}
+	if (!rz_str_startswith(data->algo, "entropy")) {
+		// No need to add the details for those. Because the user already passed the hash value
+		// as argument. So it is known.
+		return hit;
+	}
+	RzSearchiHitDetailHash *hd = RZ_NEW(RzSearchiHitDetailHash);
+
+	hd->hash = RZ_NEWS(ut8, hsize);
+	rz_mem_copy(hd->hash, hsize, calculated_hash, hsize);
+	hd->hash_size = hsize;
+	hd->algo = rz_str_dup(data->algo);
+	hd->hash_str = rz_hash_cfg_get_result_string(cfg, data->algo, NULL, false);
+	if (!rz_search_hit_add_details(hit, RZ_SEARCH_HIT_DETAIL_HASH, hd)) {
+		RZ_LOG_ERROR("Failed to add search it details. Omit hit.\n");
+		rz_search_hit_free(hit);
+		return NULL;
+	}
+	return hit;
+}
+
+static bool hash_find(RzSearchFindOpt *fopts, void *user, ut64 address, const RzBuffer *buffer,
+	RZ_OUT RzThreadQueue *hits, RZ_OUT size_t *n_hits) {
+	RzPVector /*<RzSearchHashFindData *>*/ *pvec = (RzPVector *)user;
+
+	RzHashCfg *hcfg = init_hash_config(pvec);
+	if (!hcfg) {
+		return false;
+	}
+
+	ut64 n_bytes = 0;
+	// Remove const classifier. Because the buffer API is not constified, unfortunately.
+	const ut8 *bytes = rz_buf_get_whole_hot_paths((RzBuffer *)buffer, &n_bytes);
+
+	*n_hits = 0;
+	for (size_t offset = 0; offset < n_bytes;) {
+		if (fopts->alignment > 1 && rz_mem_align_padding(address + offset, fopts->alignment) != 0) {
+			// Match has not the correct alignment in memory.
+			offset += rz_mem_align_padding(address + offset, fopts->alignment);
+			continue;
+		}
+		size_t leftovers = n_bytes - offset;
+		size_t match_len = UT64_MAX;
+		size_t i;
+		void **it;
+		const RzSearchHashFindData *data;
+		rz_pvector_enumerate (pvec, it, i) {
+			data = (RzSearchHashFindData *)*it;
+			RzSearchHit *hit = hash_and_compare(hcfg, data, address + offset, bytes + offset, RZ_MIN(leftovers, data->block_size));
+			if (!hit) {
+				continue;
+			} else if (!rz_th_queue_push(hits, hit, true)) {
+				rz_search_hit_free(hit);
+				return false;
+			}
+			(*n_hits)++;
+			if (!fopts->match_overlap) {
+				match_len = RZ_MIN(match_len, hit->size);
+				break;
+			}
+		}
+		if (fopts->match_overlap || !match_len || match_len >= n_bytes) {
+			offset++;
+		} else {
+			offset += match_len;
+		}
+	}
+	return true;
+}
+
+static bool hash_is_empty(void *user) {
+	return rz_vector_len((RzVector *)user) < 1;
+}
+
+static bool already_in_hash_collection(const RzPVector /*<RzSearchHashFindData *>*/ *vec, RzSearchHashFindData *data) {
+	void **it;
+	rz_pvector_foreach (vec, it) {
+		RzSearchHashFindData *in_coll_data = *it;
+		if (rz_search_hash_data_eq(in_coll_data, data)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * \brief      Adds a new hash method into a hash RzSearchCollection.
+ *
+ * \param[in]  col   The RzSearchCollection to use.
+ * \param[in]  data  The hash data to add and search for.
+ *
+ * \return     On success returns true, otherwise false.
+ */
+RZ_API bool rz_search_collection_hash_add(RZ_NONNULL RzSearchCollection *col, RZ_OWN RZ_NONNULL RzSearchHashFindData *data) {
+	rz_return_val_if_fail(col && data, false);
+
+	if (!rz_search_collection_has_find_callback(col, hash_find)) {
+		RZ_LOG_ERROR("search: cannot add hash method to non-hash search collection\n");
+		return false;
+	}
+
+	RzPVector /*<RzSearchHashFindData *>*/ *pvec = (RzPVector *)col->user;
+
+	if (already_in_hash_collection(pvec, data)) {
+		RZ_LOG_WARN("search: %s already in hash search collection!\n", data->algo);
+		return true;
+	}
+
+	if (!rz_pvector_push(pvec, data)) {
+		RZ_LOG_ERROR("search: failed to add %s to hash search collection\n", data->algo);
+		return false;
+	}
+	return true;
+}
+
+/**
+ * \brief      Allocates and initialize a pkey RzSearchCollection
+ *
+ * \param[in]  type The type of hash algorithm to initialize the collection for.
+ *
+ * \return     On success returns a valid pointer, otherwise NULL
+ */
+RZ_API RZ_OWN RzSearchCollection *rz_search_collection_hash() {
+	RzPVector /*<RzSearchHashFindData *>*/ *vec = rz_pvector_new((RzPVectorFree)rz_search_hash_data_free);
+	if (!vec) {
+		RZ_LOG_ERROR("search: cannot allocate internal data for hash search collection\n");
+		return NULL;
+	}
+
+	return rz_search_collection_new_bytes_space(hash_find, hash_is_empty, (RzSearchFreeCallback)rz_pvector_free, vec);
+}
+
+/**
+ * \brief Returns the element size required to satisfy the requirements of all hash algorithms
+ * in this collection.
+ *
+ * \param collection The collection to get the element size for.
+ *
+ * \return The element size or 0 in case of failure.
+ */
+RZ_API ut64 rz_search_hash_get_element_size(RZ_NONNULL RzSearchCollection *collection) {
+	rz_return_val_if_fail(collection, 0);
+	if (!rz_search_collection_has_find_callback(collection, hash_find)) {
+		RZ_LOG_ERROR("Requires a hash search collection. But the given collection isn't one.\n");
+		return 0;
+	}
+
+	RzPVector *pvec = collection->user;
+	if (!pvec || rz_pvector_empty(pvec)) {
+		RZ_LOG_ERROR("No hash algorithms added to search colleciton.\n");
+		return 0;
+	}
+	ut64 block_size = 0;
+	void **it;
+	rz_pvector_foreach (pvec, it) {
+		RzSearchHashFindData *data = *it;
+		block_size = RZ_MAX(block_size, data->block_size);
+	}
+	return block_size;
+}

--- a/librz/search/meson.build
+++ b/librz/search/meson.build
@@ -8,13 +8,14 @@ rz_search_sources = [
   'bytes_search.c',
   'value_search.c',
   'cryptographic_search.c',
+  'hash_search.c',
   'magic_search.c',
   'string_search.c',
 ]
 
 rz_search = library('rz_search', rz_search_sources,
   include_directories: [platform_inc],
-  dependencies: [rz_util_dep, rz_io_dep, rz_magic_dep, rz_crypto_dep],
+  dependencies: [rz_util_dep, rz_io_dep, rz_magic_dep, rz_crypto_dep, rz_hash_dep],
   install: true,
   implicit_include_directories: false,
   install_rpath: rpath_lib,
@@ -30,5 +31,5 @@ meson.override_dependency('rz_search', rz_search_dep)
 
 modules += { 'rz_search': {
     'target': rz_search,
-    'dependencies': ['rz_util', 'rz_io', 'rz_magic', 'rz_crypto']
+    'dependencies': ['rz_util', 'rz_io', 'rz_magic', 'rz_hash', 'rz_crypto']
 }}

--- a/librz/search/options.c
+++ b/librz/search/options.c
@@ -42,6 +42,7 @@ static bool set_chunk_size(RZ_NONNULL RzSearchOpt *opt, ut64 chunk_size) {
 }
 
 static bool element_chunk_ratio_ok(ut64 element_size, ut64 chunk_size) {
+	rz_return_val_if_fail(element_size != 0, false);
 	if (element_size >= chunk_size) {
 		return false;
 	}

--- a/librz/search/search.c
+++ b/librz/search/search.c
@@ -827,6 +827,15 @@ RZ_IPI void rz_search_hit_free(RZ_NULLABLE RzSearchHit *hit) {
 	switch (hit->detail_type) {
 	case RZ_SEARCH_HIT_DETAIL_NONE:
 		break;
+	case RZ_SEARCH_HIT_DETAIL_HASH:
+		if (hit->details) {
+			RzSearchiHitDetailHash *hdetails = hit->details;
+			free(hdetails->algo);
+			free(hdetails->hash);
+			free(hdetails->hash_str);
+		}
+		free(hit->details);
+	}
 	free(hit->hit_desc);
 	free(hit->comment);
 	free(hit);

--- a/librz/search/search.c
+++ b/librz/search/search.c
@@ -808,6 +808,13 @@ RZ_IPI RZ_OWN RzSearchHit *rz_search_hit_new(const char *hit_desc, ut64 address,
 	return hit;
 }
 
+RZ_IPI RZ_OWN bool rz_search_hit_add_details(RZ_NONNULL RzSearchHit *hit, RzSearchHitDetailType type, RZ_OWN void *details) {
+	rz_return_val_if_fail(hit && details, false);
+	hit->detail_type = type;
+	hit->details = details;
+	return true;
+}
+
 /**
  * \brief      Frees a RzSearchHit structure
  *
@@ -817,9 +824,79 @@ RZ_IPI void rz_search_hit_free(RZ_NULLABLE RzSearchHit *hit) {
 	if (!hit) {
 		return;
 	}
+	switch (hit->detail_type) {
+	case RZ_SEARCH_HIT_DETAIL_NONE:
+		break;
 	free(hit->hit_desc);
 	free(hit->comment);
 	free(hit);
+}
+
+/**
+ * \brief Get the string describing the search hit detail.
+ *
+ * \param hit The search hit to get the from
+ *
+ * \return Returns the pretty string.
+ * Or NULL in case of failure or if hit->detail_type is none.
+ */
+RZ_API RZ_OWN char *rz_search_hit_detail_str(RZ_BORROW RZ_NONNULL RzSearchHit *hit) {
+	rz_return_val_if_fail(hit, NULL);
+	if (hit->detail_type == RZ_SEARCH_HIT_DETAIL_NONE) {
+		return NULL;
+	}
+	RzStrBuf *str = rz_strbuf_new("");
+	if (!str) {
+		goto error;
+	}
+
+	switch (hit->detail_type) {
+	default:
+		goto error;
+	case RZ_SEARCH_HIT_DETAIL_HASH: {
+		if (hit->details) {
+			RzSearchiHitDetailHash *detail = hit->details;
+			rz_strbuf_appendf(str, "%s", detail->hash_str);
+		}
+		break;
+	}
+	}
+	return rz_strbuf_drain(str);
+
+error:
+	RZ_LOG_ERROR("Stringify of search hit detail failed.\n");
+	rz_strbuf_free(str);
+	return NULL;
+}
+
+/**
+ * \brief Extend a JSON object with the details of the search hit if any.
+ *
+ * \param hit The search hit to get the from
+ * \param pj The JSON object to extend.
+ *
+ * \return True if the detail was added, false otherwise.
+ */
+RZ_API bool rz_search_hit_detail_json(RZ_BORROW RZ_NONNULL RzSearchHit *hit, RZ_OUT RZ_NONNULL PJ *pj) {
+	rz_return_val_if_fail(hit && pj, NULL);
+	if (hit->detail_type == RZ_SEARCH_HIT_DETAIL_NONE) {
+		return false;
+	}
+
+	switch (hit->detail_type) {
+	default:
+		goto error;
+	case RZ_SEARCH_HIT_DETAIL_HASH: {
+		RzSearchiHitDetailHash *detail = hit->details;
+		pj_ks(pj, "hash", detail->hash_str);
+		break;
+	}
+	}
+	return true;
+
+error:
+	RZ_LOG_ERROR("Adding the search hit detail to the JSON object failed.\n");
+	return false;
 }
 
 /**

--- a/librz/search/search_internal.h
+++ b/librz/search/search_internal.h
@@ -143,8 +143,12 @@ struct rz_search_interval_t {
 	}
 
 RZ_IPI RZ_OWN RzSearchHit *rz_search_hit_new(const char *hit_desc, ut64 address, size_t size, const char *hit_comment);
+RZ_IPI RZ_OWN bool rz_search_hit_add_details(RZ_NONNULL RzSearchHit *hit, RzSearchHitDetailType type, RZ_OWN void *details);
 RZ_IPI void rz_search_hit_free(RZ_NULLABLE RzSearchHit *hit);
 RZ_IPI int rz_search_hit_cmp(RZ_NULLABLE RzSearchHit *a, RZ_NULLABLE RzSearchHit *b, void *user);
+
+RZ_IPI bool rz_search_hit_detail_str_entropy(RZ_NONNULL RzSearchHit *hit, RZ_OUT RzStrBuf *str);
+RZ_IPI bool rz_search_hit_detail_json_entropy(RZ_BORROW RZ_NONNULL RzSearchHit *hit, RZ_OUT RZ_NONNULL PJ *pj);
 
 RZ_IPI RZ_OWN RzSearchInterval *rz_search_interval_new(RzInterval interval, size_t n_hits);
 RZ_IPI void rz_search_interval_free(RZ_NULLABLE RzSearchInterval *interval);

--- a/librz/search/search_internal.h
+++ b/librz/search/search_internal.h
@@ -131,6 +131,14 @@ struct rz_search_interval_t {
 	size_t n_hits;
 };
 
+struct rz_search_hash_find_data_t {
+	char *algo; ///< The hash algorithm.
+	void *digits; ///< The expected hash digits the data block should match.
+	size_t digits_len; ///< Length of the expected digits.
+	ut64 block_size; ///< The data block size given as input to the hash function.
+	const RzHash *rz_hash; ///< Immutable RzHash instance with all registered plugins.
+};
+
 /**
  * \brief Checks of \p fopst->alignment is aligned.
  * If not, it increases \p offset by the required patting to align address + offset again and continues.

--- a/test/db/cmd/cmd_search
+++ b/test/db/cmd/cmd_search
@@ -960,3 +960,18 @@ from     to size perms
  0x0 0x2148 8520 rwx
 EOF
 RUN
+
+NAME=error - search unmapped region
+CMDS=<<EOF
+e search.from=0xf0000000000
+e search.to=0xf0000000020
+/cm
+EOF
+EXPECT=
+EXPECT_ERR=<<EOF
+ERROR: The range [0xf0000000000, 0xf0000000020] doesn't overlap with a mapped memory region or
+the region is not included in search.in.
+ERROR: core: Setting up search from core failed.
+ERROR: Failed to perform search.
+EOF
+RUN

--- a/test/db/cmd/cmd_search
+++ b/test/db/cmd/cmd_search
@@ -555,19 +555,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=search.from/to for /s
-FILE=bins/elf/analysis/x86-simple
-CMDS=<<EOF
-aeim
-aeip
-e search.in=raw
-e search.from=0x08048060
-e search.to=0x0804806b
-/s
-EOF
-EXPECT=
-RUN
-
 NAME=/x search seek
 FILE=bins/pe/standard.exe
 CMDS=<<EOF
@@ -965,7 +952,7 @@ NAME=error - search unmapped region
 CMDS=<<EOF
 e search.from=0xf0000000000
 e search.to=0xf0000000020
-/cm
+/ce 0.0 12
 EOF
 EXPECT=
 EXPECT_ERR=<<EOF
@@ -973,5 +960,29 @@ ERROR: The range [0xf0000000000, 0xf0000000020] doesn't overlap with a mapped me
 the region is not included in search.in.
 ERROR: core: Setting up search from core failed.
 ERROR: Failed to perform search.
+EOF
+RUN
+
+NAME=search hit detail output
+FILE==
+CMDS=<<EOF
+e search.from=0
+e search.to=0x10
+ws "hello world!"
+/ce 0.0 16
+/ceq 0.0 16
+/cej 0.0 16
+/cet 0.0 16
+EOF
+EXPECT=<<EOF
+0x00000000 16 hit.entropy_fract.0 0.82015977
+0x00000001 15 hit.entropy_fract.1 0.80359871
+0x00000000
+0x00000001
+[{"address":0,"size":16,"flag":"hit.entropy_fract.0","detail":{"hash":"0.82015977"}},{"address":1,"size":15,"flag":"hit.entropy_fract.1","detail":{"hash":"0.80359871"}}]
+offset       size flag                detail     
+-------------------------------------------------
+   0x0 0x00000010 hit.entropy_fract.0 0.82015977
+   0x1 0x0000000f hit.entropy_fract.1 0.80359871
 EOF
 RUN

--- a/test/db/cmd/cmd_search_crypto
+++ b/test/db/cmd/cmd_search_crypto
@@ -310,3 +310,115 @@ Algorithm:
 Signature: 256 bytes
 EOF
 RUN
+
+NAME=/ch not existing algo
+FILE=
+CMDS=<<EOF
+/ch asdasd 00
+EOF
+EXPECT_ERR=<<EOF
+ERROR: msg digest: 'asdasd' does not exists.
+ERROR: The hash algorithm 'asdasd' is not supported for the search. List supported with the command 'Lh'.
+ERROR: Failed to initialized search data.
+EOF
+RUN
+
+NAME=/ch entropy_fract error too large entropy limit
+FILE=
+CMDS=<<EOF
+/ch entropy_fract 2.0
+EOF
+EXPECT=
+EXPECT_ERR=<<EOF
+ERROR: Threshold '2.000000' cannot be larger than 1.0.
+ERROR: Failed to parse has search arguments.
+ERROR: Failed to initialized search data.
+EOF
+RUN
+
+NAME=/ch entropy_fract error too small entropy limit
+FILE=
+CMDS=<<EOF
+/ch entropy_fract -0.3
+EOF
+EXPECT=
+EXPECT_ERR=<<EOF
+ERROR: Threshold '-0.300000' cannot be smaller than 0.0.
+ERROR: Failed to parse has search arguments.
+ERROR: Failed to initialized search data.
+EOF
+RUN
+
+NAME=/ch entropy_fract error odd block size
+FILE=
+CMDS=<<EOF
+/ch entropy_fract 0.3 13
+EOF
+EXPECT=
+EXPECT_ERR=<<EOF
+ERROR: Odd or zero block sizes are not allowed.
+ERROR: Failed to initialized search data.
+EOF
+RUN
+
+NAME=/ch entropy_fract error 0 block size
+FILE=
+CMDS=<<EOF
+/ch entropy_fract 0.3 0
+EOF
+EXPECT=
+EXPECT_ERR=<<EOF
+ERROR: Odd or zero block sizes are not allowed.
+ERROR: Failed to initialized search data.
+EOF
+RUN
+
+NAME=/ch aligned
+FILE=bins/elf/analysis/x86-simple
+CMDS=<<EOF
+e search.align=0x20
+echo ----all----
+/ch entropy_fract 0.0 256
+echo ----0x20 block size----
+/ch entropy_fract 0.0 0x20
+echo ----above 0.5----
+/ch entropy_fract 0.5 0x20
+EOF
+EXPECT=<<EOF
+----all----
+0x08048000 114 hit.entropy_fract.0 0.36193749
+0x08048020 82 hit.entropy_fract.1 0.34642421
+----0x20 block size----
+0x08048000 32 hit.entropy_fract.0 0.51570707
+0x08048020 32 hit.entropy_fract.1 0.41100834
+0x08048040 32 hit.entropy_fract.2 0.26189747
+0x08048060 18 hit.entropy_fract.3 0.55742235
+----above 0.5----
+0x08048000 32 hit.entropy_fract.0 0.51570707
+0x08048060 18 hit.entropy_fract.1 0.55742235
+EOF
+RUN
+
+NAME=/ch entropy_fract 0.0
+FILE=
+CMDS=<<EOF
+/ch entropy_fract 0.0
+/ch entropy_fract 0.2
+EOF
+EXPECT=<<EOF
+0x00000000 256 hit.entropy_fract.0 0.00000000
+0x00000100 256 hit.entropy_fract.1 0.00000000
+EOF
+RUN
+
+NAME=/ce alias
+FILE=
+CMDS=<<EOF
+/ce 0.0
+/ce 0.2
+EOF
+EXPECT=<<EOF
+0x00000000 256 hit.entropy_fract.0 0.00000000
+0x00000100 256 hit.entropy_fract.1 0.00000000
+EOF
+RUN

--- a/test/db/cmd/hash
+++ b/test/db/cmd/hash
@@ -1,37 +1,39 @@
 NAME=search count
 FILE=bins/elf/analysis/x86-helloworld-gcc
 CMDS=<<EOF
-ph crc32 @ $$+10
-/h crc32 83618b8a
+ph crc32 @ 0x804830a
+/ch crc32 83618b8a
 EOF
 EXPECT=<<EOF
 83618b8a
-f hash.crc32.83618b8a @ 0x804830a
+0x0804830a 256 hit.crc32.0
 EOF
 RUN
 
-NAME=cmd.hit for /h
+NAME=cmd.hit for /ch
 FILE=malloc://1024
-BROKEN=1
 CMDS=<<EOF
-e cmd.hit = p8 1
-e search.in =raw
-/h md5 348a9791dc41b89796ec3808b5b5262f
+e search.in=raw
+ph md5 @ 0x0
+/ch md5 348a9791dc41b89796ec3808b5b5262f
 EOF
 EXPECT=<<EOF
-f hash.md5.348a9791dc41b89796ec3808b5b5262f @ 0x0
-00
+348a9791dc41b89796ec3808b5b5262f
+0x00000000 256 hit.md5.0
+0x00000100 256 hit.md5.1
+0x00000200 256 hit.md5.2
+0x00000300 256 hit.md5.3
 EOF
 RUN
 
-NAME=cmd.hit for /h sha256
+NAME=cmd.hit for /ch sha256
 FILE=bins/firmware/main.bin
 CMDS=<<EOF
-e cmd.hit="p8 1"
-e search.in=raw
-/h sha256 83264abaf298b9238ca63cb2fd9ff0f41a7a1520ee2a17c56df459fc806de1d6 512
+ph sha256 @! 512 @ 0x64
+/ch sha256 83264abaf298b9238ca63cb2fd9ff0f41a7a1520ee2a17c56df459fc806de1d6 512
 EOF
 EXPECT=<<EOF
-f hash.sha256.83264abaf298b9238ca63cb2fd9ff0f41a7a1520ee2a17c56df459fc806de1d6 @ 0x64
+83264abaf298b9238ca63cb2fd9ff0f41a7a1520ee2a17c56df459fc806de1d6
+0x00000064 512 hit.sha256.0
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Ports the `/s` (calculate blocks entropies and select those above a threshold) and `/h` to RzSearch and RzShell command `/ce`.

- Add `/ch` command for hash search and an `/ce` alias for `entropy_fract` search.
- Adds the block size as command to `/ch`. So the command no loner depends on `core->blocksize`.
- Extends `RzSearchHit` with `details`. They can be set arbitrary by the search and printed as well. For the entropy search this is the fractured entropy value.


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Added

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
