### PR TITLE
Fix for stacking mixed output redirects.

### DIFF
--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -3404,6 +3404,8 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(redirect_stmt) {
 	} else {
 		rz_cons_flush();
 		RZ_LOG_DEBUG("redirect_stmt: fdn = %d, is_append = %d\n", fdn, is_append);
+		rz_cons_push();
+		rz_cons_set_flush(true);
 		RzConsPipe *cpipe = rz_cons_pipe_open(arg_str, fdn, is_append);
 		if (cpipe) {
 			if (!pipecolor) {
@@ -3416,6 +3418,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(redirect_stmt) {
 		} else {
 			RZ_LOG_WARN("Could not open pipe to %d\n", fdn);
 		}
+		rz_cons_pop();
 	}
 	free(arg_str);
 fail:

--- a/test/db/cmd/feat_redirect
+++ b/test/db/cmd/feat_redirect
@@ -37,3 +37,25 @@ Hello
 World
 EOF
 RUN
+
+NAME=stacked redirect
+FILE==
+CMDS=<<EOF
+# inner redirect to file
+(mac1; echo a>.rz-stacked-redirect.txt; echo b)
+# outer redirect to alias, any other feature which redirects output to buffer like the builtin grep ~ would also work
+.(mac1) > $al1
+echo "---"
+cat .rz-stacked-redirect.txt
+echo "---"
+$**
+rm .rz-stacked-redirect.txt
+EOF
+EXPECT=<<EOF
+---
+a
+---
+$al1=$b
+
+EOF
+RUN


### PR DESCRIPTION
That is redirect to file + redirect to buffer which happens when calling rz_core_cmd_str .

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

Problem discovered while investigating https://github.com/rizinorg/cutter/issues/3426  but as shown by testcase it's possible to trigger it purely within rizin as well.

In case of cutter it could be simply triggered by running `cmd > outputfile` in console widget.

**Test plan**

In addition to command test, I also tested the patch fixes basic redirect case in Cutter.

**Closing issues**

