### PR TITLE
librz/core+bin: Remove obr (bin rebase command)

### DIFF
--- a/librz/bin/bobj_process.c
+++ b/librz/bin/bobj_process.c
@@ -136,14 +136,14 @@ RZ_IPI void rz_bin_process_swift(RzBinObject *o, char *classname, char *demangle
 #endif /* WITH_SWIFT_DEMANGLER */
 
 /**
- * \brief      Reset and initialize the data of the given RzBinObject using the defined RzBinPlugin
+ * \brief      Initialize the data of the given RzBinObject using the defined RzBinPlugin
  *
  * \param      bf    The RzBinFile to use
  * \param      o     The RzBinObject to initialize
  *
  * \return     On success returns true
  */
-RZ_API bool rz_bin_object_process_plugin_data(RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzBinObject *o) {
+RZ_IPI bool rz_bin_object_process_plugin_data(RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzBinObject *o) {
 	rz_return_val_if_fail(bf && bf->rbin && o && o->plugin, false);
 	const RzDemanglerPlugin *demangler = NULL;
 

--- a/librz/bin/i/private.h
+++ b/librz/bin/i/private.h
@@ -47,6 +47,7 @@ RZ_IPI void rz_bin_process_cxx(RzBinObject *o, char *demangled, ut64 paddr, ut64
 #if WITH_SWIFT_DEMANGLER
 RZ_IPI void rz_bin_process_swift(RzBinObject *o, char *classname, char *demangled, ut64 paddr, ut64 vaddr);
 #endif /* WITH_SWIFT_DEMANGLER */
+RZ_IPI bool rz_bin_object_process_plugin_data(RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzBinObject *o);
 
 RZ_IPI const RzDemanglerPlugin *rz_bin_process_get_demangler_plugin_from_lang(RzBin *bin, RzBinLanguage language);
 

--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -812,25 +812,6 @@ RZ_API bool rz_core_file_loadlib(RzCore *core, const char *lib, ut64 libaddr) {
 	return ret;
 }
 
-/**
- * \brief      Rebase the current RzBinFile and its RzBinObject
- *
- * \param[in]  RzCore  The RzCore structure to use
- * \param[in]  baddr   The new base address
- *
- * \return     On success returns true, otherwise false.
- */
-RZ_API bool rz_core_bin_rebase(RZ_NONNULL RzCore *core, ut64 baddr) {
-	rz_return_val_if_fail(core && core->bin && core->bin->cur, false);
-	if (baddr == UT64_MAX) {
-		return false;
-	}
-	RzBinFile *bf = core->bin->cur;
-	bf->o->opts.baseaddr = baddr;
-	bf->o->opts.loadaddr = baddr;
-	return rz_bin_object_process_plugin_data(bf, bf->o);
-}
-
 static void load_scripts_for(RzCore *core, const char *name) {
 	char *file;
 	RzListIter *iter;

--- a/librz/core/cmd/cmd_open.c
+++ b/librz/core/cmd/cmd_open.c
@@ -755,12 +755,6 @@ RZ_IPI RzCmdStatus rz_open_binary_file_handler(RzCore *core, int argc, const cha
 	return RZ_CMD_STATUS_OK;
 }
 
-RZ_IPI RzCmdStatus rz_open_binary_rebase_handler(RzCore *core, int argc, const char **argv) {
-	rz_core_bin_rebase(core, rz_num_math(core->num, argv[1]));
-	rz_core_bin_apply_all_info(core, rz_bin_cur(core->bin));
-	return RZ_CMD_STATUS_OK;
-}
-
 RZ_IPI RzCmdStatus rz_open_binary_reload_handler(RzCore *core, int argc, const char **argv) {
 	// XXX: this will reload the bin using the buffer.
 	// An assumption is made that assumes there is an underlying

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -633,7 +633,6 @@ static const RzCmdDescArg open_binary_select_fd_args[2];
 static const RzCmdDescArg open_binary_del_args[2];
 static const RzCmdDescArg open_binary_add_args[2];
 static const RzCmdDescArg open_binary_file_args[2];
-static const RzCmdDescArg open_binary_rebase_args[2];
 static const RzCmdDescArg open_binary_reload_args[2];
 static const RzCmdDescArg open_use_args[2];
 static const RzCmdDescArg open_prioritize_args[2];
@@ -13832,20 +13831,6 @@ static const RzCmdDescHelp open_binary_file_help = {
 	.args = open_binary_file_args,
 };
 
-static const RzCmdDescArg open_binary_rebase_args[] = {
-	{
-		.name = "baddr",
-		.type = RZ_CMD_ARG_TYPE_RZNUM,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
-
-	},
-	{ 0 },
-};
-static const RzCmdDescHelp open_binary_rebase_help = {
-	.summary = "Rebase current bin object",
-	.args = open_binary_rebase_args,
-};
-
 static const RzCmdDescArg open_binary_reload_args[] = {
 	{
 		.name = "baddr",
@@ -23673,9 +23658,6 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *open_binary_file_cd = rz_cmd_desc_argv_new(core->rcmd, ob_cd, "obf", rz_open_binary_file_handler, &open_binary_file_help);
 	rz_warn_if_fail(open_binary_file_cd);
-
-	RzCmdDesc *open_binary_rebase_cd = rz_cmd_desc_argv_new(core->rcmd, ob_cd, "obr", rz_open_binary_rebase_handler, &open_binary_rebase_help);
-	rz_warn_if_fail(open_binary_rebase_cd);
 
 	RzCmdDesc *open_binary_reload_cd = rz_cmd_desc_argv_new(core->rcmd, ob_cd, "obR", rz_open_binary_reload_handler, &open_binary_reload_help);
 	rz_warn_if_fail(open_binary_reload_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -1834,8 +1834,6 @@ RZ_IPI RzCmdStatus rz_open_binary_show_handler(RzCore *core, int argc, const cha
 RZ_IPI RzCmdStatus rz_open_binary_add_handler(RzCore *core, int argc, const char **argv);
 // "obf"
 RZ_IPI RzCmdStatus rz_open_binary_file_handler(RzCore *core, int argc, const char **argv);
-// "obr"
-RZ_IPI RzCmdStatus rz_open_binary_rebase_handler(RzCore *core, int argc, const char **argv);
 // "obR"
 RZ_IPI RzCmdStatus rz_open_binary_reload_handler(RzCore *core, int argc, const char **argv);
 // "ou"

--- a/librz/core/cmd_descs/cmd_open.yaml
+++ b/librz/core/cmd_descs/cmd_open.yaml
@@ -256,12 +256,6 @@ commands:
           - name: file
             type: RZ_CMD_ARG_TYPE_FILE
             optional: true
-      - name: obr
-        cname: open_binary_rebase
-        summary: Rebase current bin object
-        args:
-          - name: baddr
-            type: RZ_CMD_ARG_TYPE_RZNUM
       - name: obR
         cname: open_binary_reload
         summary: Reload the current buffer for setting of the bin (use once only)

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -964,7 +964,6 @@ static inline bool rz_bin_file_rclass_is(RzBinFile *bf, const char *x) {
 }
 
 // binobject functions
-RZ_API bool rz_bin_object_process_plugin_data(RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzBinObject *o);
 RZ_API ut64 rz_bin_object_addr_with_base(RzBinObject *o, ut64 addr);
 RZ_API ut64 rz_bin_object_get_vaddr(RzBinObject *o, ut64 paddr, ut64 vaddr);
 RZ_API const RzBinAddr *rz_bin_object_get_special_symbol(RzBinObject *o, RzBinSpecialSymbol sym);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -907,7 +907,6 @@ RZ_API bool rz_core_bin_apply_all_info(RzCore *r, RzBinFile *binfile);
 RZ_API int rz_core_bin_set_by_fd(RzCore *core, ut64 bin_fd);
 RZ_API int rz_core_bin_set_by_name(RzCore *core, const char *name);
 RZ_API bool rz_core_bin_load(RZ_NONNULL RzCore *core, RZ_NULLABLE const char *file_uri, ut64 base_addr);
-RZ_API bool rz_core_bin_rebase(RZ_NONNULL RzCore *core, ut64 baddr);
 RZ_API void rz_core_bin_export_info(RzCore *core, int mode);
 RZ_API bool rz_core_binfiles_print(RzCore *core, RzCmdStateOutput *state);
 RZ_API bool rz_core_binfiles_delete(RzCore *core, RzBinFile *bf);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

Rebase done by obr freed all vfiles in the RzBinObject, but did not free
the entire RzBinFile, so core was not notified about it, and it may
still have had references to vfiles in vfile:// mappings, thus causing
UAFs.
Unfortunately the entire obr command was not working properly, so we
remove it with obR (also not entirely working) and rb being possible
replacements depending on the use-case.
The possibly dangerous RzBin apis have been made private in the module
to prevent future misuse.

**Test plan**

The following crashed before:
```
rz -c 'obl;obr 0x100000;obl' test/bins/elf/libmagic.so
```
