### PR TITLE
Allow virtual files to represent real files.

### DIFF
--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -1089,6 +1089,15 @@ RZ_API void rz_bin_map_free(RZ_NULLABLE RzBinMap *map) {
 	free(map);
 }
 
+RZ_API RZ_OWN RzBinMap *rz_bin_map_clone(RZ_NONNULL RzBinMap *map) {
+	rz_return_val_if_fail(map, NULL);
+	RzBinMap *clone = RZ_NEW0(RzBinMap);
+	rz_mem_copy(clone, sizeof(RzBinMap), map, sizeof(RzBinMap));
+	clone->name = rz_str_dup(map->name);
+	clone->vfile_name = map->vfile_name ? rz_str_dup(map->vfile_name) : NULL;
+	return clone;
+}
+
 /**
  * \brief Create a pvector of RzBinMap from RzBinSections queried from the given file
  *

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -1080,6 +1080,36 @@ RZ_API void rz_bin_virtual_file_free(RZ_NULLABLE RzBinVirtualFile *vfile) {
 	free(vfile);
 }
 
+/**
+ * \brief Clones a virtual file. Note, the buffer will never be cloned.
+ * This function will assign the buffer to of \p vfile but always sets buf_owned = false;
+ *
+ * \p vfile The virtual to clone.
+ *
+ * \return A clone of the vfile but with clone->buf_owned = false.
+ */
+RZ_API RZ_OWN RzBinVirtualFile *rz_bin_virtual_file_copy(RZ_BORROW RZ_NONNULL RzBinVirtualFile *vfile) {
+	rz_return_val_if_fail(vfile, NULL);
+	RzBinVirtualFile *clone = RZ_NEW0(RzBinVirtualFile);
+	if (!clone) {
+		return NULL;
+	}
+	clone->represents_real_file = vfile->represents_real_file;
+	clone->buf_owned = false;
+	clone->buf = vfile->buf;
+	if (!clone->buf) {
+		return NULL;
+	}
+	clone->name = rz_str_dup(vfile->name);
+	if (!clone->name) {
+		if (clone->buf_owned) {
+			rz_buf_free(clone->buf);
+		}
+		return NULL;
+	}
+	return clone;
+}
+
 RZ_API void rz_bin_map_free(RZ_NULLABLE RzBinMap *map) {
 	if (!map) {
 		return;

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -847,6 +847,25 @@ static bool io_create_mem_map(RzIO *io, RZ_NULLABLE RzCoreFile *cf, RzBinMap *ma
 	return true;
 }
 
+// If the map's virtual file is actually a real and distinct file, the delta offset is 0.
+// Because the IO layer will read from the file buffer of the virtual file.
+// Not of the file initially opened with Rizin.
+static bool bin_map_references_real_file(const RzBinFile *bf, const RzBinMap *map) {
+	if (!map->vfile_name) {
+		return false;
+	}
+	const RzBinVirtualFile *map_vf = NULL;
+	void **it;
+	rz_pvector_foreach(bf->o->vfiles, it) {
+		RzBinVirtualFile *vf = *it;
+		if (RZ_STR_EQ(vf->name, map->vfile_name)) {
+			map_vf = vf;
+			break;
+		}
+	}
+	return map_vf && map_vf->represents_real_file;
+}
+
 static void add_map(RzCore *core, RZ_NULLABLE RzCoreFile *cf, RzBinFile *bf, RzBinMap *map, ut64 addr, int fd) {
 	RzIODesc *io_desc = rz_io_desc_get(core->io, fd);
 	if (!io_desc || UT64_ADD_OVFCHK(map->psize, map->paddr) ||
@@ -906,8 +925,9 @@ static void add_map(RzCore *core, RZ_NULLABLE RzCoreFile *cf, RzBinFile *bf, RzB
 		perm |= RZ_PERM_X;
 	}
 
+	bool map_references_real_file = bin_map_references_real_file(bf, map);
 	if (size) {
-		RzIOMap *iomap = rz_io_map_add_batch(core->io, fd, perm, map->paddr, addr, size);
+		RzIOMap *iomap = rz_io_map_add_batch(core->io, fd, perm, map_references_real_file ? 0 : map->paddr, addr, size);
 		if (!iomap) {
 			free(map_name);
 			return;

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -856,7 +856,7 @@ static bool bin_map_references_real_file(const RzBinFile *bf, const RzBinMap *ma
 	}
 	const RzBinVirtualFile *map_vf = NULL;
 	void **it;
-	rz_pvector_foreach(bf->o->vfiles, it) {
+	rz_pvector_foreach (bf->o->vfiles, it) {
 		RzBinVirtualFile *vf = *it;
 		if (RZ_STR_EQ(vf->name, map->vfile_name)) {
 			map_vf = vf;

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -543,6 +543,12 @@ typedef struct rz_bin_virtual_file_t {
 	RZ_OWN RZ_NONNULL char *name;
 	RZ_NONNULL RzBuffer *buf;
 	bool buf_owned; ///< whether buf is owned and freed by this RzBinVirtualFile
+	/**
+	 * \brief Is set the virtual file represents a distinct file, not just a
+	 * memory region in another file.
+	 * This is useful for Rizin APIs which only accepts virtual files.
+	 */
+	bool represents_real_file;
 } RzBinVirtualFile;
 
 /// Description of a single memory mapping into virtual memory from a binary

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -809,6 +809,7 @@ RZ_API RzBinClassField *rz_bin_class_field_new(ut64 vaddr, ut64 paddr, const cha
 RZ_API void rz_bin_class_field_free(RZ_NULLABLE RzBinClassField *field);
 RZ_API void rz_bin_class_free(RZ_NULLABLE RzBinClass *k);
 
+RZ_API RZ_OWN RzBinVirtualFile *rz_bin_virtual_file_copy(RZ_BORROW RZ_NONNULL RzBinVirtualFile *vfile);
 RZ_API void rz_bin_virtual_file_free(RZ_NULLABLE RzBinVirtualFile *vfile);
 RZ_API RZ_OWN RzBinMap *rz_bin_map_clone(RZ_NONNULL RzBinMap *map);
 RZ_API void rz_bin_map_free(RZ_NULLABLE RzBinMap *map);

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -804,6 +804,7 @@ RZ_API void rz_bin_class_field_free(RZ_NULLABLE RzBinClassField *field);
 RZ_API void rz_bin_class_free(RZ_NULLABLE RzBinClass *k);
 
 RZ_API void rz_bin_virtual_file_free(RZ_NULLABLE RzBinVirtualFile *vfile);
+RZ_API RZ_OWN RzBinMap *rz_bin_map_clone(RZ_NONNULL RzBinMap *map);
 RZ_API void rz_bin_map_free(RZ_NULLABLE RzBinMap *map);
 RZ_API bool rz_bin_map_is_data(RZ_NONNULL const RzBinMap *map);
 RZ_API RZ_OWN RzPVector /*<RzBinMap *>*/ *rz_bin_maps_of_file_sections(RZ_NONNULL RzBinFile *binfile);

--- a/librz/include/rz_io.h
+++ b/librz/include/rz_io.h
@@ -147,7 +147,13 @@ typedef struct rz_io_map_t {
 	int perm;
 	ut32 id;
 	RzInterval itv;
-	ut64 delta; // paddr = itv.addr + delta
+	/**
+	 * \brief This delta is applied to the offset for reading.
+	 * If the map references a memory region at offset 0x100 in a file,
+	 * but this map is read at offset `o = 0x20`. The real reading offset within the
+	 * file is at: `o + delta = 0x120`.
+	 */
+	ut64 delta;
 	RZ_NULLABLE char *name;
 
 	/**


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This comes in handy if a bin-plugin has to load real, and more importantly, distinct files from the main one.
The bin plugin API only deals with virtual files. But the buffer of the virtual files, canstill point to a different file then the main one.

If this happened, the read offset calculation was wrong. Because when IOMaps are built the IO module just assumed `virtual file == some segment in the main file`. And to read properly, it increased the read offset by `map->delta`.
This `map->delta` should be 0 though, if the actual buffer read, belongs to a different file than the main file. 

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
