### PR TITLE
Rename `RzBinMap->paddr` and `RzBinSection->paddr` to `offset`.

### DIFF
--- a/librz/arch/p/analysis/analysis_java.c
+++ b/librz/arch/p/analysis/analysis_java.c
@@ -41,7 +41,7 @@ static ut64 java_analysis_find_method(RzAnalysis *a, ut64 addr) {
 		if (!(sec->perm & RZ_PERM_X) || addr < from || addr > to) {
 			continue;
 		}
-		return sec->paddr;
+		return sec->offset;
 	}
 
 	return addr;

--- a/librz/arch/p/asm/asm_java.c
+++ b/librz/arch/p/asm/asm_java.c
@@ -46,7 +46,7 @@ static ut64 java_asm_find_method(RzAsm *a) {
 		if (!(sec->perm & RZ_PERM_X) || addr < from || addr > to) {
 			continue;
 		}
-		return sec->paddr;
+		return sec->offset;
 	}
 
 	return addr;

--- a/librz/bin/bfile_string.c
+++ b/librz/bin/bfile_string.c
@@ -240,7 +240,7 @@ static void string_scan_range_cfstring(RzBinFile *bf, HtUP *strings_db, RzPVecto
 		return;
 	}
 
-	rz_buf_read_at(bf->buf, section->paddr + cfstr_offs, sbuf, section->size);
+	rz_buf_read_at(bf->buf, section->offset + cfstr_offs, sbuf, section->size);
 	for (ut64 i = 0; i < section->size; i += cfstr_size) {
 		ut8 *buf = sbuf;
 		ut8 *p = buf + i;
@@ -287,7 +287,7 @@ static void scan_cfstring_table(RzBinFile *bf, HtUP *strings_db, RzPVector /*<Rz
 	}
 	rz_pvector_foreach (o->sections, iter) {
 		section = *iter;
-		if (!section->name || section->paddr >= bf->size) {
+		if (!section->name || section->offset >= bf->size) {
 			continue;
 		} else if (max_region_size && section->size > max_region_size) {
 			RZ_LOG_WARN("bin_file_strings: search interval size (0x%" PFMT64x
@@ -415,7 +415,7 @@ RZ_API RZ_OWN RzPVector /*<RzBinString *>*/ *rz_bin_file_strings(RZ_NONNULL RzBi
 		RzBinObject *o = bf->o;
 		rz_pvector_foreach (o->sections, iter) {
 			section = *iter;
-			if (section->paddr >= bf->size) {
+			if (section->offset >= bf->size) {
 				continue;
 			} else if (opt->max_region_size && section->size > opt->max_region_size) {
 				RZ_LOG_WARN("bin_file_strings: search interval size (0x%" PFMT64x
@@ -434,7 +434,7 @@ RZ_API RZ_OWN RzPVector /*<RzBinString *>*/ *rz_bin_file_strings(RZ_NONNULL RzBi
 				goto fail;
 			}
 
-			itv->paddr = section->paddr;
+			itv->paddr = section->offset;
 			itv->psize = section->size;
 			if ((itv->paddr + itv->psize) > bf->size) {
 				itv->psize = bf->size - itv->paddr;

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -620,7 +620,7 @@ RZ_API RZ_BORROW RzBinSection *rz_bin_get_section_at(RZ_NONNULL RzBinObject *o, 
 		if (section->is_segment) {
 			continue;
 		}
-		from = va ? rz_bin_object_addr_with_base(o, section->vaddr) : section->paddr;
+		from = va ? rz_bin_object_addr_with_base(o, section->vaddr) : section->offset;
 		to = from + (va ? section->vsize : section->size);
 		if (off >= from && off < to) {
 			return section;
@@ -649,7 +649,7 @@ RZ_API RZ_BORROW RzBinSection *rz_bin_get_segment_at(RZ_NONNULL RzBinObject *o, 
 		if (!section->is_segment) {
 			continue;
 		}
-		from = va ? rz_bin_object_addr_with_base(o, section->vaddr) : section->paddr;
+		from = va ? rz_bin_object_addr_with_base(o, section->vaddr) : section->offset;
 		to = from + (va ? section->vsize : section->size);
 		if (off >= from && off < to) {
 			return section;
@@ -1119,7 +1119,7 @@ RZ_API RZ_OWN RzPVector /*<RzBinMap *>*/ *rz_bin_maps_of_file_sections(RZ_NONNUL
 			goto hcf;
 		}
 		map->name = rz_str_dup(sec->name);
-		map->offset = sec->paddr;
+		map->offset = sec->offset;
 		map->psize = sec->size;
 		map->vaddr = sec->vaddr;
 		map->vsize = sec->vsize;
@@ -1157,7 +1157,7 @@ RZ_API RzPVector /*<RzBinSection *>*/ *rz_bin_sections_of_maps(RzPVector /*<RzBi
 			break;
 		}
 		sec->name = rz_str_dup(map->name);
-		sec->paddr = map->offset;
+		sec->offset = map->offset;
 		sec->size = map->psize;
 		sec->vaddr = map->vaddr;
 		sec->vsize = map->vsize;

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -679,7 +679,7 @@ RZ_API RZ_BORROW RzBinMap *rz_bin_object_get_map_at(RZ_NONNULL RzBinObject *o, u
 
 	rz_pvector_foreach_prev(o->maps, iter) {
 		map = *iter;
-		from = va ? rz_bin_object_addr_with_base(o, map->vaddr) : map->paddr;
+		from = va ? rz_bin_object_addr_with_base(o, map->vaddr) : map->offset;
 		to = from + (va ? map->vsize : map->psize);
 		if (off >= from && off < to) {
 			return map;
@@ -742,7 +742,7 @@ RZ_API RZ_OWN RzPVector /*<RzBinMap *>*/ *rz_bin_object_get_maps_at(RzBinObject 
 
 	rz_pvector_foreach (o->maps, iter) {
 		map = *iter;
-		from = va ? rz_bin_object_addr_with_base(o, map->vaddr) : map->paddr;
+		from = va ? rz_bin_object_addr_with_base(o, map->vaddr) : map->offset;
 		to = from + (va ? map->vsize : map->psize);
 		if (off >= from && off < to) {
 			rz_pvector_push(res, map);
@@ -1119,7 +1119,7 @@ RZ_API RZ_OWN RzPVector /*<RzBinMap *>*/ *rz_bin_maps_of_file_sections(RZ_NONNUL
 			goto hcf;
 		}
 		map->name = rz_str_dup(sec->name);
-		map->paddr = sec->paddr;
+		map->offset = sec->paddr;
 		map->psize = sec->size;
 		map->vaddr = sec->vaddr;
 		map->vsize = sec->vsize;
@@ -1157,7 +1157,7 @@ RZ_API RzPVector /*<RzBinSection *>*/ *rz_bin_sections_of_maps(RzPVector /*<RzBi
 			break;
 		}
 		sec->name = rz_str_dup(map->name);
-		sec->paddr = map->paddr;
+		sec->paddr = map->offset;
 		sec->size = map->psize;
 		sec->vaddr = map->vaddr;
 		sec->vsize = map->vsize;

--- a/librz/bin/bobj.c
+++ b/librz/bin/bobj.c
@@ -891,7 +891,7 @@ err:
 }
 
 static ut64 map_p2v(RzBinMap *m, ut64 paddr) {
-	ut64 delta = paddr - m->paddr;
+	ut64 delta = paddr - m->offset;
 	if (delta >= m->vsize) {
 		return UT64_MAX;
 	}
@@ -961,7 +961,7 @@ RZ_API ut64 rz_bin_object_v2p(RZ_NONNULL RzBinObject *obj, ut64 vaddr) {
 	if (delta >= m->psize) {
 		return UT64_MAX;
 	}
-	return m->paddr + delta;
+	return m->offset + delta;
 }
 
 /**

--- a/librz/bin/bobj_process_map.c
+++ b/librz/bin/bobj_process_map.c
@@ -18,6 +18,6 @@ RZ_IPI void rz_bin_set_and_process_maps(RzBinFile *bf, RzBinObject *o) {
 	rz_pvector_foreach (o->maps, it) {
 		element = *it;
 		// rebase physical address
-		element->paddr += o->opts.loadaddr;
+		element->offset += o->opts.loadaddr;
 	}
 }

--- a/librz/bin/bobj_process_section.c
+++ b/librz/bin/bobj_process_section.c
@@ -6,7 +6,7 @@
 
 static void process_handle_section(RzBinSection *section, RzBinObject *o, HtSP *filter_db) {
 	// rebase physical address
-	section->paddr += o->opts.loadaddr;
+	section->offset += o->opts.loadaddr;
 
 	if (!filter_db) {
 		// we do not have to filter the names.
@@ -19,7 +19,7 @@ static void process_handle_section(RzBinSection *section, RzBinObject *o, HtSP *
 		return;
 	}
 
-	char *name = rz_str_newf("%s_0x%" PFMT64x, section->name, section->paddr);
+	char *name = rz_str_newf("%s_0x%" PFMT64x, section->name, section->offset);
 	free(section->name);
 	section->name = name;
 }

--- a/librz/bin/dwarf/endian_reader.c
+++ b/librz/bin/dwarf/endian_reader.c
@@ -76,16 +76,16 @@ RZ_IPI RZ_OWN RzBinEndianReader *rz_bin_dwarf_section_reader(
 	RZ_BORROW RZ_NONNULL RzBinFile *binfile,
 	RZ_BORROW RZ_NONNULL RzBinSection *section) {
 	rz_return_val_if_fail(binfile && section, NULL);
-	if (section->paddr >= binfile->size) {
+	if (section->offset >= binfile->size) {
 		return NULL;
 	}
 	RzBinEndianReader *R = NULL;
 
-	ut64 len = RZ_MIN(section->size, binfile->size - section->paddr);
+	ut64 len = RZ_MIN(section->size, binfile->size - section->offset);
 	bool is_zlib_gnu = rz_str_startswith(section->name, ".zdebug");
 
 	ut8 *sh_buf = malloc(len);
-	if (!(sh_buf && (rz_buf_read_at(binfile->buf, section->paddr, sh_buf, len) == len))) {
+	if (!(sh_buf && (rz_buf_read_at(binfile->buf, section->offset, sh_buf, len) == len))) {
 		goto err;
 	}
 	bool bigendian = bf_bigendian(binfile);

--- a/librz/bin/format/dex/dex.c
+++ b/librz/bin/format/dex/dex.c
@@ -1203,7 +1203,7 @@ static RzBinSection *section_new(const char *name, ut32 perm, ut32 size, ut64 pa
 		return NULL;
 	}
 	section->name = rz_str_dup(name);
-	section->paddr = paddr;
+	section->offset = paddr;
 	section->vaddr = vaddr;
 	section->size = section->vsize = size;
 	section->perm = perm;

--- a/librz/bin/format/java/class_bin.c
+++ b/librz/bin/format/java/class_bin.c
@@ -1745,7 +1745,7 @@ static RzBinSection *new_section(const char *name, ut64 start, ut64 end, ut32 pe
 		free(section);
 		return NULL;
 	}
-	section->paddr = start;
+	section->offset = start;
 	section->vaddr = start;
 	section->size = end - start;
 	section->vsize = section->size;

--- a/librz/bin/format/le/le.c
+++ b/librz/bin/format/le/le.c
@@ -1638,7 +1638,7 @@ RZ_OWN RzPVector /*<RzBinSection *>*/ *rz_bin_le_get_sections(RzBinFile *bf) {
 		sec->size = le_map->size;
 		sec->vsize = le_map->vsize;
 		sec->vaddr = le_map->vaddr;
-		sec->paddr = le_map->paddr;
+		sec->offset = le_map->paddr;
 
 		LE_object *obj = &bin->objects[obj_num - 1];
 		sec->perm = le_obj_perm(obj);

--- a/librz/bin/format/le/le.c
+++ b/librz/bin/format/le/le.c
@@ -1853,10 +1853,10 @@ RZ_OWN RzPVector /*<RzBinMap *>*/ *rz_bin_le_get_maps(RzBinFile *bf) {
 		map->vsize = le_map->vsize;
 		CHECK(map->name = rz_str_newf("obj%u_map%u", obj_num, map_num));
 		if (le_map->is_physical) {
-			map->paddr = le_map->paddr;
+			map->offset = le_map->paddr;
 			CHECK(map->vfile_name = rz_str_dup(VFILE_NAME_PATCHED));
 		} else {
-			map->paddr = 0;
+			map->offset = 0;
 			if (map->psize != 0) {
 				CHECK(map->vfile_name = rz_str_dup(le_map->vfile_name));
 			}

--- a/librz/bin/format/luac/luac_bin.c
+++ b/librz/bin/format/luac/luac_bin.c
@@ -11,7 +11,7 @@ void luac_add_section(RzPVector /*<RzBinSection *>*/ *section_vec, char *name, u
 	}
 
 	bin_sec->name = rz_str_dup(name);
-	bin_sec->vaddr = bin_sec->paddr = offset;
+	bin_sec->vaddr = bin_sec->offset = offset;
 	bin_sec->size = bin_sec->vsize = size;
 	bin_sec->is_data = false;
 	bin_sec->bits = is_func ? sizeof(LUA_INSTRUCTION) * 8 : 8;

--- a/librz/bin/format/mach0/mach0.c
+++ b/librz/bin/format/mach0/mach0.c
@@ -2007,8 +2007,8 @@ RzPVector /*<RzBinSection *>*/ *MACH0_(get_segments)(RzBinFile *bf) {
 			s->vaddr = seg->vmaddr;
 			s->vsize = seg->vmsize;
 			s->size = seg->vmsize;
-			s->paddr = seg->fileoff;
-			s->paddr += bf->o->boffset;
+			s->offset = seg->fileoff;
+			s->offset += bf->o->boffset;
 			// TODO s->flags = seg->flags;
 			s->name = rz_str_ndup(seg->segname, 16);
 			s->is_segment = true;
@@ -2033,7 +2033,7 @@ RzPVector /*<RzBinSection *>*/ *MACH0_(get_segments)(RzBinFile *bf) {
 			s->type = bin->sects[i].flags & 0xFF;
 			s->flags = bin->sects[i].flags & 0xFFFFFF00;
 			// XXX flags
-			s->paddr = (ut64)bin->sects[i].offset;
+			s->offset = (ut64)bin->sects[i].offset;
 			int segment_index = 0;
 			// s->perm =prot2perm (bin->segs[j].initprot);
 			for (j = 0; j < bin->nsegs; j++) {

--- a/librz/bin/format/mach0/mach0.c
+++ b/librz/bin/format/mach0/mach0.c
@@ -1964,7 +1964,7 @@ RzPVector /*<RzBinMap *>*/ *MACH0_(get_maps_unpatched)(RzBinFile *bf) {
 		map->perm = prot2perm(seg->initprot);
 		// boffset is relevant for fatmach0 where the mach0 is located boffset into the whole file
 		// the rebasing vfile above however is based at the mach0 already
-		map->paddr = seg->fileoff + bf->o->boffset;
+		map->offset = seg->fileoff + bf->o->boffset;
 		rz_pvector_push(ret, map);
 	}
 	return ret;

--- a/librz/bin/format/mdmp/mdmp_pe.c
+++ b/librz/bin/format/mdmp/mdmp_pe.c
@@ -159,7 +159,7 @@ RzPVector /*<RzBinSection *>*/ *PE_(rz_bin_mdmp_pe_get_sections)(struct PE_(rz_b
 		if (!ptr->vsize && ptr->size) {
 			ptr->vsize = ptr->size;
 		}
-		ptr->paddr = sections[i].paddr + pe_bin->paddr;
+		ptr->offset = sections[i].paddr + pe_bin->paddr;
 		ptr->vaddr = sections[i].vaddr + ba;
 		ptr->perm = 0;
 		if (RZ_BIN_PE_SCN_IS_EXECUTABLE(sections[i].perm)) {

--- a/librz/bin/format/mz/mz.c
+++ b/librz/bin/format/mz/mz.c
@@ -155,7 +155,7 @@ RzPVector /*<RzBinSection *>*/ *rz_bin_mz_get_segments(const struct rz_bin_mz_ob
 			p_section->vsize = p_section->size;
 		}
 		section->vsize = section->size;
-		section->paddr = rz_bin_mz_la_to_pa(bin, section->vaddr);
+		section->offset = rz_bin_mz_la_to_pa(bin, section->vaddr);
 		section->perm = rz_str_rwx("rwx");
 		section_number++;
 	}

--- a/librz/bin/format/ne/ne.c
+++ b/librz/bin/format/ne/ne.c
@@ -96,8 +96,8 @@ RzPVector /*<RzBinSection *>*/ *rz_bin_ne_get_segments(rz_bin_ne_obj_t *bin) {
 		bs->bits = RZ_SYS_BITS_16;
 		bs->is_data = se->flags & IS_DATA;
 		bs->perm = __translate_perms(se->flags);
-		bs->paddr = (ut64)se->offset * bin->alignment;
-		bs->name = rz_str_newf("%s.%" PFMT64d, se->flags & IS_MOVEABLE ? "MOVEABLE" : "FIXED", bs->paddr);
+		bs->offset = (ut64)se->offset * bin->alignment;
+		bs->name = rz_str_newf("%s.%" PFMT64d, se->flags & IS_MOVEABLE ? "MOVEABLE" : "FIXED", bs->offset);
 		bs->is_segment = true;
 		rz_pvector_push(segments, bs);
 	}
@@ -451,7 +451,7 @@ RzPVector /*<RzBinAddr *>*/ *rz_bin_ne_get_entrypoints(rz_bin_ne_obj_t *bin) {
 		}
 		entry->bits = 16;
 		RzBinSection *s = (RzBinSection *)rz_pvector_at(segments, bin->ne_header->csEntryPoint - 1);
-		entry->paddr = bin->ne_header->ipEntryPoint + (s ? s->paddr : 0);
+		entry->paddr = bin->ne_header->ipEntryPoint + (s ? s->offset : 0);
 		rz_pvector_push(entries, entry);
 	}
 	ut32 off = 0;
@@ -551,7 +551,7 @@ RzPVector /*<RzBinReloc *>*/ *rz_bin_ne_get_relocs(rz_bin_ne_obj_t *bin) {
 		if (!(bin->segment_entries[index].flags & RELOCINFO)) {
 			continue;
 		}
-		ut32 off, start = off = seg->paddr + seg->size;
+		ut32 off, start = off = seg->offset + seg->size;
 		if ((ut64)off + 2 > bufsz) {
 			continue;
 		}
@@ -576,7 +576,7 @@ RzPVector /*<RzBinReloc *>*/ *rz_bin_ne_get_relocs(rz_bin_ne_obj_t *bin) {
 			rz_buf_read_le16_offset(bin->buf, &offset, &rel.offset);
 			rz_buf_read_le16_offset(bin->buf, &offset, &rel.align1);
 			rz_buf_read_le16_offset(bin->buf, &offset, &rel.func_ord);
-			reloc->paddr = seg->paddr + rel.offset;
+			reloc->paddr = seg->offset + rel.offset;
 			reloc->print_name = get_reloc_type_name(rel.type & NE_RELOC_SRC_MASK, rel.flags & NE_RELOC_TARGET_MASK);
 
 			if (rel.flags & (IMPORTED_ORD | IMPORTED_NAME)) {
@@ -610,7 +610,7 @@ RzPVector /*<RzBinReloc *>*/ *rz_bin_ne_get_relocs(rz_bin_ne_obj_t *bin) {
 				if (strstr(seg->name, "FIXED")) {
 					RzBinSection *s = (RzBinSection *)rz_pvector_at(segments, rel.segnum - 1);
 					if (s) {
-						offset = s->paddr + rel.segoff;
+						offset = s->offset + rel.segoff;
 					} else {
 						offset = -1;
 					}
@@ -654,7 +654,7 @@ RzPVector /*<RzBinReloc *>*/ *rz_bin_ne_get_relocs(rz_bin_ne_obj_t *bin) {
 						break;
 					}
 					*reloc = *tmp;
-					reloc->paddr = seg->paddr + offset;
+					reloc->paddr = seg->offset + offset;
 				} while (offset != 0xFFFF);
 				free(reloc);
 			}

--- a/librz/bin/format/objc/mach0_classes.c
+++ b/librz/bin/format/objc/mach0_classes.c
@@ -167,7 +167,7 @@ static mach0_ut va2pa(mach0_ut p, ut32 *offset, ut32 *left, RzBinFile *bf) {
 			if (left) {
 				*left = s->vsize - (addr - s->vaddr);
 			}
-			r = (s->paddr - obj->boffset + (addr - s->vaddr));
+			r = (s->offset - obj->boffset + (addr - s->vaddr));
 			return r;
 		}
 	}

--- a/librz/bin/format/omf/omf.c
+++ b/librz/bin/format/omf/omf.c
@@ -760,7 +760,7 @@ int rz_bin_omf_send_sections(RzPVector /*<RzBinSection *>*/ *vec, OMF_segment *s
 
 		new->size = data->size;
 		new->vsize = data->size;
-		new->paddr = data->paddr;
+		new->offset = data->paddr;
 		new->vaddr = section->vaddr + data->offset + OMF_BASE_ADDR;
 		new->perm = RZ_PERM_RWX;
 		rz_pvector_push(vec, new);

--- a/librz/bin/format/pyc/marshal.c
+++ b/librz/bin/format/pyc/marshal.c
@@ -1299,7 +1299,7 @@ static bool extract_sections_symbols(RzBinPycObj *pyc, pyc_object *obj, RzPVecto
 		goto fail;
 	}
 	section->has_strings = false;
-	section->paddr = cobj->start_offset;
+	section->offset = cobj->start_offset;
 	section->vaddr = cobj->start_offset;
 	section->size = cobj->end_offset - cobj->start_offset;
 	section->vsize = cobj->end_offset - cobj->start_offset;

--- a/librz/bin/golang.c
+++ b/librz/bin/golang.c
@@ -248,7 +248,7 @@ static ut64 scan_go_build_info(const ut8 *buf, ut64 len, void *user) {
 	struct scan_go_info_s *ctx = user;
 	for (ut64 pos = 0; pos <= len - build_info_align; pos += build_info_align) {
 		if (is_go_build_info(buf + pos)) {
-			parse_go_build_info(ctx->bf, ctx->go_info, ctx->section->paddr + pos);
+			parse_go_build_info(ctx->bf, ctx->go_info, ctx->section->offset + pos);
 			return 0;
 		}
 	}
@@ -257,7 +257,7 @@ static ut64 scan_go_build_info(const ut8 *buf, ut64 len, void *user) {
 
 static void find_go_build_info(RzBinFile *bf, GoBuildInfo *go_info, RzBinSection *section) {
 	struct scan_go_info_s ctx = { bf, go_info, section };
-	rz_buf_fwd_scan(bf->buf, section->paddr, section->size, scan_go_build_info, &ctx);
+	rz_buf_fwd_scan(bf->buf, section->offset, section->size, scan_go_build_info, &ctx);
 }
 
 /**
@@ -295,7 +295,7 @@ RZ_IPI RZ_OWN char *rz_bin_file_golang_compiler(RZ_NONNULL RzBinFile *bf) {
 		if (is_pe && strstr(section->name, "data") && section->size > 16) {
 			find_go_build_info(bf, &go_info, section);
 		} else if (!is_pe && (strstr(section->name, "go_buildinfo") || strstr(section->name, "go.buildinfo"))) {
-			parse_go_build_info(bf, &go_info, section->paddr);
+			parse_go_build_info(bf, &go_info, section->offset);
 		}
 		if (go_info.version) {
 			break;

--- a/librz/bin/p/bin_art.c
+++ b/librz/bin/p/bin_art.c
@@ -164,7 +164,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	ptr->name = rz_str_dup("load");
 	ptr->size = rz_buf_size(bf->buf);
 	ptr->vsize = art.image_size; // TODO: align?
-	ptr->paddr = 0;
+	ptr->offset = 0;
 	ptr->vaddr = art.image_base;
 	ptr->perm = RZ_PERM_R; // r--
 	rz_pvector_push(ret, ptr);
@@ -175,7 +175,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	ptr->name = rz_str_dup("bitmap");
 	ptr->size = art.bitmap_size;
 	ptr->vsize = art.bitmap_size;
-	ptr->paddr = art.bitmap_offset;
+	ptr->offset = art.bitmap_offset;
 	ptr->vaddr = art.image_base + art.bitmap_offset;
 	ptr->perm = RZ_PERM_RX; // r-x
 	rz_pvector_push(ret, ptr);
@@ -184,7 +184,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		return ret;
 	}
 	ptr->name = rz_str_dup("oat");
-	ptr->paddr = art.bitmap_offset;
+	ptr->offset = art.bitmap_offset;
 	ptr->vaddr = art.oat_file_begin;
 	ptr->size = art.oat_file_end - art.oat_file_begin;
 	ptr->vsize = ptr->size;
@@ -195,7 +195,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		return ret;
 	}
 	ptr->name = rz_str_dup("oat_data");
-	ptr->paddr = art.bitmap_offset;
+	ptr->offset = art.bitmap_offset;
 	ptr->vaddr = art.oat_data_begin;
 	ptr->size = art.oat_data_end - art.oat_data_begin;
 	ptr->vsize = ptr->size;

--- a/librz/bin/p/bin_bf.c
+++ b/librz/bin/p/bin_bf.c
@@ -124,7 +124,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	map->paddr = 0;
+	map->offset = 0;
 	map->vaddr = 0;
 	map->psize = bf->size;
 	map->vsize = bf->size;
@@ -137,7 +137,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	map->paddr = 0;
+	map->offset = 0;
 	map->vaddr = 0x10000;
 	map->psize = 0;
 	map->vsize = 30000;

--- a/librz/bin/p/bin_bflt.c
+++ b/librz/bin/p/bin_bflt.c
@@ -45,7 +45,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	map->paddr = 0;
+	map->offset = 0;
 	map->vaddr = rz_bflt_get_text_base(obj);
 	map->psize = obj->hdr.data_start;
 	map->vsize = obj->hdr.data_start;
@@ -59,7 +59,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-	map->paddr = obj->hdr.data_start;
+	map->offset = obj->hdr.data_start;
 	map->vaddr = rz_bflt_get_data_base(obj);
 	map->psize = obj->hdr.data_end - obj->hdr.data_start;
 	map->vsize = rz_bflt_get_data_vsize(obj);

--- a/librz/bin/p/bin_bflt.c
+++ b/librz/bin/p/bin_bflt.c
@@ -84,7 +84,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!sec) {
 		goto beach;
 	}
-	sec->paddr = 0;
+	sec->offset = 0;
 	sec->vaddr = rz_bflt_get_text_base(obj);
 	sec->size = obj->hdr.data_start;
 	sec->vsize = obj->hdr.data_start;
@@ -97,7 +97,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!sec) {
 		goto beach;
 	}
-	sec->paddr = obj->hdr.data_start;
+	sec->offset = obj->hdr.data_start;
 	sec->vaddr = rz_bflt_get_data_base(obj);
 	sec->size = obj->hdr.data_start;
 	sec->vsize = rz_bflt_get_data_vsize(obj);
@@ -112,7 +112,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!sec) {
 		goto beach;
 	}
-	sec->paddr = 0;
+	sec->offset = 0;
 	sec->vaddr = rz_bflt_get_text_base(obj);
 	sec->size = BFLT_HDR_SIZE;
 	sec->vsize = BFLT_HDR_SIZE;
@@ -124,7 +124,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!sec) {
 		goto beach;
 	}
-	sec->paddr = BFLT_HDR_SIZE;
+	sec->offset = BFLT_HDR_SIZE;
 	sec->vaddr = rz_bflt_get_text_base(obj) + BFLT_HDR_SIZE;
 	sec->size = obj->hdr.data_start - BFLT_HDR_SIZE;
 	sec->vsize = obj->hdr.data_start - BFLT_HDR_SIZE;
@@ -136,7 +136,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!sec) {
 		goto beach;
 	}
-	sec->paddr = obj->hdr.data_start;
+	sec->offset = obj->hdr.data_start;
 	sec->vaddr = rz_bflt_get_data_base(obj);
 	sec->size = obj->hdr.data_end - obj->hdr.data_start;
 	sec->vsize = obj->hdr.data_end - obj->hdr.data_start;
@@ -149,7 +149,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (!sec) {
 		goto beach;
 	}
-	sec->paddr = obj->hdr.data_end;
+	sec->offset = obj->hdr.data_end;
 	sec->vaddr = rz_bflt_get_data_base(obj) + obj->hdr.data_end - obj->hdr.data_start;
 	sec->size = 0;
 	sec->vsize = obj->hdr.bss_end - obj->hdr.data_end;

--- a/librz/bin/p/bin_bios.c
+++ b/librz/bin/p/bin_bios.c
@@ -98,7 +98,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	}
 	ptr->name = rz_str_dup("bootblk"); // Maps to 0xF000:0000 segment
 	ptr->vsize = ptr->size = 0x10000;
-	ptr->paddr = rz_buf_size(bf->buf) - ptr->size;
+	ptr->offset = rz_buf_size(bf->buf) - ptr->size;
 	ptr->vaddr = 0xf0000;
 	ptr->perm = RZ_PERM_RWX;
 	rz_pvector_push(ret, ptr);
@@ -109,7 +109,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		}
 		ptr->name = rz_str_dup("_e000"); // Maps to 0xE000:0000 segment
 		ptr->vsize = ptr->size = 0x10000;
-		ptr->paddr = rz_buf_size(obj) - 2 * ptr->size;
+		ptr->offset = rz_buf_size(obj) - 2 * ptr->size;
 		ptr->vaddr = 0xe0000;
 		ptr->perm = RZ_PERM_RWX;
 		rz_pvector_push(ret, ptr);

--- a/librz/bin/p/bin_bootimg.c
+++ b/librz/bin/p/bin_bootimg.c
@@ -192,7 +192,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	ptr->name = rz_str_dup("header");
 	ptr->size = sizeof(BootImage);
 	ptr->vsize = bi->page_size;
-	ptr->paddr = 0;
+	ptr->offset = 0;
 	ptr->vaddr = 0;
 	ptr->perm = RZ_PERM_R; // r--
 	rz_pvector_push(ret, ptr);
@@ -203,7 +203,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	ptr->name = rz_str_dup("kernel");
 	ptr->size = bi->kernel_size;
 	ptr->vsize = ADD_REMAINDER(ptr->size, bi->page_size);
-	ptr->paddr = bi->page_size;
+	ptr->offset = bi->page_size;
 	ptr->vaddr = bi->kernel_addr;
 	ptr->perm = RZ_PERM_R; // r--
 	rz_pvector_push(ret, ptr);
@@ -216,7 +216,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		ptr->name = rz_str_dup("ramdisk");
 		ptr->size = bi->ramdisk_size;
 		ptr->vsize = ADD_REMAINDER(bi->ramdisk_size, bi->page_size);
-		ptr->paddr = ROUND_DOWN(base, bi->page_size);
+		ptr->offset = ROUND_DOWN(base, bi->page_size);
 		ptr->vaddr = bi->ramdisk_addr;
 		ptr->perm = RZ_PERM_RX; // r-x
 		rz_pvector_push(ret, ptr);
@@ -230,7 +230,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		ptr->name = rz_str_dup("second");
 		ptr->size = bi->second_size;
 		ptr->vsize = ADD_REMAINDER(bi->second_size, bi->page_size);
-		ptr->paddr = ROUND_DOWN(base, bi->page_size);
+		ptr->offset = ROUND_DOWN(base, bi->page_size);
 		ptr->vaddr = bi->second_addr;
 		ptr->perm = RZ_PERM_RX; // r-x
 		rz_pvector_push(ret, ptr);

--- a/librz/bin/p/bin_coff.c
+++ b/librz/bin/p/bin_coff.c
@@ -241,7 +241,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		ptr->name = rz_coff_symbol_name(obj, (const ut8 *)hdr->s_name);
 		ptr->psize = hdr->s_size;
 		ptr->vsize = hdr->s_size;
-		ptr->paddr = hdr->s_scnptr;
+		ptr->offset = hdr->s_scnptr;
 		if (obj->scn_va) {
 			ptr->vaddr = obj->scn_va[i];
 		}
@@ -259,7 +259,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 			return ret;
 		}
 		map->name = rz_str_dup("reloc-targets");
-		map->paddr = 0;
+		map->offset = 0;
 		map->psize = rtmsz;
 		map->vaddr = rz_coff_get_reloc_targets_map_base(obj);
 		map->vsize = rtmsz;

--- a/librz/bin/p/bin_coff.c
+++ b/librz/bin/p/bin_coff.c
@@ -290,7 +290,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		}
 		ptr->size = obj->scn_hdrs[i].s_size;
 		ptr->vsize = obj->scn_hdrs[i].s_size;
-		ptr->paddr = obj->scn_hdrs[i].s_scnptr;
+		ptr->offset = obj->scn_hdrs[i].s_scnptr;
 		ptr->flags = obj->scn_hdrs[i].s_flags;
 		if (obj->scn_va) {
 			ptr->vaddr = obj->scn_va[i];

--- a/librz/bin/p/bin_dmp64.c
+++ b/librz/bin/p/bin_dmp64.c
@@ -198,7 +198,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 			return ret;
 		}
 		map->name = rz_str_newf("page.0x%" PFMT64x, page->start);
-		map->paddr = page->file_offset;
+		map->offset = page->file_offset;
 		map->psize = page->size;
 		map->vaddr = page->start;
 		map->vsize = page->size;
@@ -212,7 +212,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 			return ret;
 		}
 		map->name = rz_str_newf("kernel.0x%" PFMT64x, datablock->virtualAddress);
-		map->paddr = datablock->offset;
+		map->offset = datablock->offset;
 		map->psize = datablock->size;
 		map->vaddr = datablock->virtualAddress;
 		map->vsize = datablock->size;

--- a/librz/bin/p/bin_dol.c
+++ b/librz/bin/p/bin_dol.c
@@ -100,7 +100,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		}
 		s = RZ_NEW0(RzBinSection);
 		s->name = rz_str_newf("text_%d", i);
-		s->paddr = dol->text_paddr[i];
+		s->offset = dol->text_paddr[i];
 		s->vaddr = dol->text_vaddr[i];
 		s->size = dol->text_size[i];
 		s->vsize = s->size;
@@ -114,7 +114,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		}
 		s = RZ_NEW0(RzBinSection);
 		s->name = rz_str_newf("data_%d", i);
-		s->paddr = dol->data_paddr[i];
+		s->offset = dol->data_paddr[i];
 		s->vaddr = dol->data_vaddr[i];
 		s->size = dol->data_size[i];
 		s->vsize = s->size;
@@ -124,7 +124,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	/* bss section */
 	s = RZ_NEW0(RzBinSection);
 	s->name = rz_str_dup("bss");
-	s->paddr = 0;
+	s->offset = 0;
 	s->vaddr = dol->bss_addr;
 	s->size = dol->bss_size;
 	s->vsize = s->size;

--- a/librz/bin/p/bin_dyldcache.c
+++ b/librz/bin/p/bin_dyldcache.c
@@ -288,12 +288,12 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 			return NULL;
 		}
 		map->name = rz_str_newf("cache_map.%d", i);
-		map->paddr = cache->maps[i].fileOffset;
+		map->offset = cache->maps[i].fileOffset;
 		map->psize = cache->maps[i].size;
 		map->vsize = map->psize;
 		map->vaddr = cache->maps[i].address + slide;
 		map->perm = prot2perm(cache->maps[i].initProt);
-		if (rz_dyldcache_range_needs_rebasing(cache, map->paddr, map->psize)) {
+		if (rz_dyldcache_range_needs_rebasing(cache, map->offset, map->psize)) {
 			map->vfile_name = rz_str_dup(RZ_DYLDCACHE_VFILE_NAME_REBASED);
 		}
 		rz_pvector_push(ret, map);

--- a/librz/bin/p/bin_dyldcache.c
+++ b/librz/bin/p/bin_dyldcache.c
@@ -226,9 +226,9 @@ static void sections_from_bin(RzPVector /*<RzBinSection *>*/ *ret, RzBinFile *bf
 		ptr->size = sections[i].size;
 		ptr->vsize = sections[i].vsize;
 		ptr->vaddr = sections[i].addr;
-		ptr->paddr = rz_dyldcache_va2pa(cache, sections[i].addr, NULL, NULL);
+		ptr->offset = rz_dyldcache_va2pa(cache, sections[i].addr, NULL, NULL);
 		if (!ptr->vaddr) {
-			ptr->vaddr = ptr->paddr;
+			ptr->vaddr = ptr->offset;
 		}
 		ptr->perm = sections[i].perm;
 		rz_pvector_push(ret, ptr);

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -679,7 +679,7 @@ static RzPVector /*<RzBinMap *>*/ *maps_unpatched(RzBinFile *bf) {
 				break;
 			}
 
-			map->paddr = iter->data.p_offset;
+			map->offset = iter->data.p_offset;
 			map->psize = iter->data.p_filesz;
 			map->vsize = iter->data.p_memsz;
 			map->vaddr = iter->data.p_vaddr;
@@ -712,7 +712,7 @@ static RzPVector /*<RzBinMap *>*/ *maps_unpatched(RzBinFile *bf) {
 			}
 
 			map->name = rz_str_dup(section->name);
-			map->paddr = section->offset;
+			map->offset = section->offset;
 			map->psize = section->type != SHT_NOBITS ? section->size : 0;
 			map->vsize = section->size;
 			map->vaddr = section->rva;
@@ -727,7 +727,7 @@ static RzPVector /*<RzBinMap *>*/ *maps_unpatched(RzBinFile *bf) {
 			return ret;
 		}
 		map->name = rz_str_dup("uphdr");
-		map->paddr = 0;
+		map->offset = 0;
 		map->psize = bf->size;
 		map->vaddr = 0x10000;
 		map->vsize = bf->size;
@@ -745,7 +745,7 @@ static RzPVector /*<RzBinMap *>*/ *maps_unpatched(RzBinFile *bf) {
 			ehdr_size = bf->size;
 		}
 		map->name = rz_str_dup("ehdr");
-		map->paddr = 0;
+		map->offset = 0;
 		map->psize = ehdr_size;
 		map->vaddr = obj->baddr;
 		map->vsize = ehdr_size;

--- a/librz/bin/p/bin_elf.inc
+++ b/librz/bin/p/bin_elf.inc
@@ -1772,7 +1772,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		}
 		ptr->size = section->type != SHT_NOBITS ? section->size : 0;
 		ptr->vsize = section->size;
-		ptr->paddr = section->offset;
+		ptr->offset = section->offset;
 		ptr->vaddr = section->rva;
 		ptr->type = section->type;
 		ptr->flags = section->flags;
@@ -1792,7 +1792,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 
 		ptr->size = iter->data.p_filesz;
 		ptr->vsize = iter->data.p_memsz;
-		ptr->paddr = iter->data.p_offset;
+		ptr->offset = iter->data.p_offset;
 		ptr->vaddr = iter->data.p_vaddr;
 		ptr->perm = iter->data.p_flags;
 		ptr->align = iter->data.p_align;
@@ -1859,7 +1859,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 			ehdr_size = bf->size;
 		}
 		ptr->name = rz_str_dup("ehdr");
-		ptr->paddr = 0;
+		ptr->offset = 0;
 		ptr->vaddr = obj->baddr;
 		ptr->size = ehdr_size;
 		ptr->vsize = ehdr_size;
@@ -2204,8 +2204,8 @@ static ut64 size(RzBinFile *bf) {
 		bf->o->sections = sections(bf);
 		rz_pvector_foreach (bf->o->sections, iter) {
 			section = *iter;
-			if (section->paddr > off) {
-				off = section->paddr;
+			if (section->offset > off) {
+				off = section->offset;
 				len = section->size;
 			}
 		}

--- a/librz/bin/p/bin_mach0.c
+++ b/librz/bin/p/bin_mach0.c
@@ -112,7 +112,7 @@ static void process_constructors(RzBinFile *bf, RzPVector /*<RzBinAddr *>*/ *ret
 			if (!buf) {
 				continue;
 			}
-			int read = rz_buf_read_at(bf->buf, sec->paddr, buf, sec->size);
+			int read = rz_buf_read_at(bf->buf, sec->offset, buf, sec->size);
 			if (read < sec->size) {
 				RZ_LOG_ERROR("process_constructors: cannot process section %s\n", sec->name);
 				continue;
@@ -120,7 +120,7 @@ static void process_constructors(RzBinFile *bf, RzPVector /*<RzBinAddr *>*/ *ret
 			if (bits == 32) {
 				for (i = 0; i + 3 < sec->size; i += 4) {
 					ut32 addr32 = rz_read_le32(buf + i);
-					RzBinAddr *ba = newEntry(sec->paddr + i, (ut64)addr32, type, bits);
+					RzBinAddr *ba = newEntry(sec->offset + i, (ut64)addr32, type, bits);
 					if (ba) {
 						rz_pvector_push(ret, ba);
 					}
@@ -128,7 +128,7 @@ static void process_constructors(RzBinFile *bf, RzPVector /*<RzBinAddr *>*/ *ret
 			} else {
 				for (i = 0; i + 7 < sec->size; i += 8) {
 					ut64 addr64 = rz_read_le64(buf + i);
-					RzBinAddr *ba = newEntry(sec->paddr + i, addr64, type, bits);
+					RzBinAddr *ba = newEntry(sec->offset + i, addr64, type, bits);
 					if (ba) {
 						rz_pvector_push(ret, ba);
 					}

--- a/librz/bin/p/bin_mbn.c
+++ b/librz/bin/p/bin_mbn.c
@@ -114,7 +114,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	ptr->name = rz_str_dup("text");
 	ptr->size = sb->psize;
 	ptr->vsize = sb->psize;
-	ptr->paddr = sb->paddr + 40;
+	ptr->offset = sb->paddr + 40;
 	ptr->vaddr = sb->vaddr;
 	ptr->perm = RZ_PERM_RX; // r-x
 	ptr->has_strings = true;
@@ -126,7 +126,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	ptr->name = rz_str_dup("sign");
 	ptr->size = sb->sign_sz;
 	ptr->vsize = sb->sign_sz;
-	ptr->paddr = sb->sign_va - sb->vaddr;
+	ptr->offset = sb->sign_va - sb->vaddr;
 	ptr->vaddr = sb->sign_va;
 	ptr->perm = RZ_PERM_R; // r--
 	ptr->has_strings = true;
@@ -139,7 +139,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		ptr->name = rz_str_dup("cert");
 		ptr->size = sb->cert_sz;
 		ptr->vsize = sb->cert_sz;
-		ptr->paddr = sb->cert_va - sb->vaddr;
+		ptr->offset = sb->cert_va - sb->vaddr;
 		ptr->vaddr = sb->cert_va;
 		ptr->perm = RZ_PERM_R; // r--
 		ptr->has_strings = true;

--- a/librz/bin/p/bin_mdmp.c
+++ b/librz/bin/p/bin_mdmp.c
@@ -273,7 +273,7 @@ static RzPVector /*<RzBinSection *>*/ *mdmp_sections(RzBinFile *bf) {
 		rz_str_utf16_to_utf8((ut8 *)ptr->name, str_length * 4, str_buffer, str_length, true);
 		ptr->vaddr = module->base_of_image;
 		ptr->vsize = module->size_of_image;
-		ptr->paddr = rz_bin_mdmp_get_paddr(obj, ptr->vaddr);
+		ptr->offset = rz_bin_mdmp_get_paddr(obj, ptr->vaddr);
 		ptr->size = module->size_of_image;
 		ptr->has_strings = false;
 		/* As this is an encompassing section we will set the RWX to 0 */

--- a/librz/bin/p/bin_mdmp.c
+++ b/librz/bin/p/bin_mdmp.c
@@ -192,7 +192,7 @@ static RzPVector /*<RzBinMap *>*/ *mdmp_maps(RzBinFile *bf) {
 		if (!map) {
 			return ret;
 		}
-		map->paddr = (memory->memory).rva;
+		map->offset = (memory->memory).rva;
 		map->psize = (memory->memory).data_size;
 		map->vaddr = memory->start_of_memory_range;
 		map->vsize = (memory->memory).data_size;
@@ -208,7 +208,7 @@ static RzPVector /*<RzBinMap *>*/ *mdmp_maps(RzBinFile *bf) {
 		if (!map) {
 			return ret;
 		}
-		map->paddr = index;
+		map->offset = index;
 		map->psize = memory64->data_size;
 		map->vaddr = memory64->start_of_memory_range;
 		map->vsize = memory64->data_size;

--- a/librz/bin/p/bin_menuet.c
+++ b/librz/bin/p/bin_menuet.c
@@ -124,8 +124,8 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	ptr->name = rz_str_dup("text");
 	ptr->size = rz_read_ble32(buf + 16, false);
 	ptr->vsize = ptr->size + (ptr->size % 4096);
-	ptr->paddr = rz_read_ble32(buf + 12, false);
-	ptr->vaddr = ptr->paddr + baddr(bf);
+	ptr->offset = rz_read_ble32(buf + 12, false);
+	ptr->vaddr = ptr->offset + baddr(bf);
 	ptr->perm = RZ_PERM_RX; // r-x
 	rz_pvector_push(ret, ptr);
 
@@ -139,8 +139,8 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		const ut32 idata_end = rz_read_ble32(buf + 44, false);
 		ptr->size = idata_end - idata_start;
 		ptr->vsize = ptr->size + (ptr->size % 4096);
-		ptr->paddr = rz_read_ble32(buf + 40, false);
-		ptr->vaddr = ptr->paddr + baddr(bf);
+		ptr->offset = rz_read_ble32(buf + 40, false);
+		ptr->vaddr = ptr->offset + baddr(bf);
 		ptr->perm = RZ_PERM_R; // r--
 		rz_pvector_push(ret, ptr);
 	}

--- a/librz/bin/p/bin_nes.c
+++ b/librz/bin/p/bin_nes.c
@@ -99,7 +99,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		return ret;
 	}
 	ptr->name = rz_str_dup("ROM");
-	ptr->paddr = INES_HDR_SIZE;
+	ptr->offset = INES_HDR_SIZE;
 	ptr->size = ihdr.prg_page_count_16k * PRG_PAGE_SIZE;
 	bool mirror = ROM_START_ADDRESS + ptr->size <= ROM_MIRROR_ADDRESS; // not a 256bit ROM, mapper 0 mirrors the complete ROM in this case
 	ptr->vaddr = ROM_START_ADDRESS;
@@ -111,7 +111,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 			return ret;
 		}
 		ptr->name = rz_str_dup("ROM_MIRROR");
-		ptr->paddr = INES_HDR_SIZE;
+		ptr->offset = INES_HDR_SIZE;
 		ptr->size = ihdr.prg_page_count_16k * PRG_PAGE_SIZE;
 		ptr->vaddr = ROM_MIRROR_ADDRESS;
 		ptr->vsize = ROM_MIRROR_SIZE;

--- a/librz/bin/p/bin_nin3ds.c
+++ b/librz/bin/p/bin_nin3ds.c
@@ -127,7 +127,7 @@ static RzBinSection *n3ds_firm_section_new(N3DSFirmSectHdr *shdr) {
 
 	section->size = shdr->size;
 	section->vsize = shdr->size;
-	section->paddr = shdr->offset;
+	section->offset = shdr->offset;
 	section->vaddr = shdr->address;
 	section->name = n3ds_section_name(shdr);
 	section->perm = RZ_PERM_RWX;

--- a/librz/bin/p/bin_ninds.c
+++ b/librz/bin/p/bin_ninds.c
@@ -221,7 +221,7 @@ static RzPVector /*<RzBinSection *>*/ *nds_sections(RzBinFile *bf) {
 	ptr9->name = rz_str_dup("arm9");
 	ptr9->size = hdr->arm9_size;
 	ptr9->vsize = hdr->arm9_size;
-	ptr9->paddr = hdr->arm9_rom_offset;
+	ptr9->offset = hdr->arm9_rom_offset;
 	ptr9->vaddr = hdr->arm9_ram_address;
 	ptr9->perm = perm_rwx;
 	rz_pvector_push(ret, ptr9);
@@ -229,7 +229,7 @@ static RzPVector /*<RzBinSection *>*/ *nds_sections(RzBinFile *bf) {
 	ptr7->name = rz_str_dup("arm7");
 	ptr7->size = hdr->arm7_size;
 	ptr7->vsize = hdr->arm7_size;
-	ptr7->paddr = hdr->arm7_rom_offset;
+	ptr7->offset = hdr->arm7_rom_offset;
 	ptr7->vaddr = hdr->arm7_ram_address;
 	ptr7->perm = perm_rwx;
 	rz_pvector_push(ret, ptr7);
@@ -252,7 +252,7 @@ static RzPVector /*<RzBinSection *>*/ *nds_sections(RzBinFile *bf) {
 		overlay->name = rz_str_newf("arm7_overlay_%" PFMT32u, ovl_entry->id);
 		overlay->size = fat_entry->file_end_offset - fat_entry->file_start_offset;
 		overlay->vsize = ovl_entry->ram_size;
-		overlay->paddr = fat_entry->file_start_offset;
+		overlay->offset = fat_entry->file_start_offset;
 		overlay->vaddr = ovl_entry->load_address;
 		overlay->perm = perm_rwx;
 		rz_pvector_push(ret, overlay);
@@ -274,7 +274,7 @@ static RzPVector /*<RzBinSection *>*/ *nds_sections(RzBinFile *bf) {
 		overlay->name = rz_str_newf("arm9_overlay_%" PFMT32u, ovl_entry->id);
 		overlay->size = fat_entry->file_end_offset - fat_entry->file_start_offset;
 		overlay->vsize = ovl_entry->ram_size;
-		overlay->paddr = fat_entry->file_start_offset;
+		overlay->offset = fat_entry->file_start_offset;
 		overlay->vaddr = ovl_entry->load_address;
 		overlay->perm = perm_rwx;
 		rz_pvector_push(ret, overlay);

--- a/librz/bin/p/bin_ningb.c
+++ b/librz/bin/p/bin_ningb.c
@@ -141,7 +141,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	for (size_t i = 0; i < banks_count; i++) {
 		RzBinSection *section = RZ_NEW0(RzBinSection);
 		section->name = rz_str_newf("rombank%02x", (unsigned int)i);
-		section->paddr = i * 0x4000;
+		section->offset = i * 0x4000;
 		section->vaddr = i ? (i * 0x10000 - 0xc000) : 0;
 		section->size = section->vsize = 0x4000;
 		section->perm = rz_str_rwx("rx");

--- a/librz/bin/p/bin_ningba.c
+++ b/librz/bin/p/bin_ningba.c
@@ -75,7 +75,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		return NULL;
 	}
 	s->name = rz_str_dup("ROM");
-	s->paddr = 0;
+	s->offset = 0;
 	s->vaddr = 0x8000000;
 	s->size = sz;
 	s->vsize = 0x2000000;

--- a/librz/bin/p/bin_nro.c
+++ b/librz/bin/p/bin_nro.c
@@ -130,7 +130,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		}
 
 		map->name = rz_str_dup("sig0");
-		map->paddr = sig0;
+		map->offset = sig0;
 		map->psize = sig0sz;
 		map->vsize = sig0sz;
 		map->vaddr = sig0 + ba;
@@ -149,7 +149,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	if (!rz_buf_read_le32_at(b, NRO_OFF(text_memoffset), &tmp)) {
 		goto maps_err;
 	}
-	map->paddr = tmp;
+	map->offset = tmp;
 
 	if (!rz_buf_read_le32_at(b, NRO_OFF(text_size), &tmp)) {
 		goto maps_err;
@@ -157,7 +157,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	map->psize = tmp;
 
 	map->vsize = map->psize;
-	map->vaddr = map->paddr + ba;
+	map->vaddr = map->offset + ba;
 	map->perm = RZ_PERM_RX;
 	rz_pvector_push(ret, map);
 
@@ -169,7 +169,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	if (!rz_buf_read_le32_at(b, NRO_OFF(ro_memoffset), &tmp)) {
 		goto maps_err;
 	}
-	map->paddr = tmp;
+	map->offset = tmp;
 
 	if (!rz_buf_read_le32_at(b, NRO_OFF(ro_size), &tmp)) {
 		goto maps_err;
@@ -177,7 +177,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	map->psize = tmp;
 
 	map->vsize = map->psize;
-	map->vaddr = map->paddr + ba;
+	map->vaddr = map->offset + ba;
 	map->perm = RZ_PERM_R;
 	rz_pvector_push(ret, map);
 
@@ -189,7 +189,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	if (!rz_buf_read_le32_at(b, NRO_OFF(data_memoffset), &tmp)) {
 		goto maps_err;
 	}
-	map->paddr = tmp;
+	map->offset = tmp;
 
 	if (!rz_buf_read_le32_at(b, NRO_OFF(data_size), &tmp)) {
 		goto maps_err;
@@ -197,7 +197,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 	map->psize = tmp;
 
 	map->vsize = map->psize;
-	map->vaddr = map->paddr + ba;
+	map->vaddr = map->offset + ba;
 	map->perm = RZ_PERM_RW;
 	rz_pvector_push(ret, map);
 	return ret;

--- a/librz/bin/p/bin_nro.c
+++ b/librz/bin/p/bin_nro.c
@@ -222,7 +222,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	ptr->name = rz_str_dup("header");
 	ptr->size = 0x80;
 	ptr->vsize = 0x80;
-	ptr->paddr = 0;
+	ptr->offset = 0;
 	ptr->vaddr = 0;
 	ptr->perm = RZ_PERM_R;
 	rz_pvector_push(ret, ptr);
@@ -247,7 +247,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		ptr->name = rz_str_dup("mod0");
 		ptr->size = mod0sz;
 		ptr->vsize = mod0sz;
-		ptr->paddr = mod0;
+		ptr->offset = mod0;
 		ptr->vaddr = mod0 + ba;
 		ptr->perm = RZ_PERM_R; // rw-
 		rz_pvector_push(ret, ptr);

--- a/librz/bin/p/bin_nso.c
+++ b/librz/bin/p/bin_nso.c
@@ -333,7 +333,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	}
 	ptr->vsize = tmp;
 
-	ptr->paddr = 0;
+	ptr->offset = 0;
 	ptr->vaddr = 0;
 	ptr->perm = RZ_PERM_R;
 	rz_pvector_push(ret, ptr);

--- a/librz/bin/p/bin_nso.c
+++ b/librz/bin/p/bin_nso.c
@@ -273,7 +273,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		return ret;
 	}
 	map->name = rz_str_dup("text");
-	map->paddr = bin->decompressed ? 0 : hdr->text_memoffset;
+	map->offset = bin->decompressed ? 0 : hdr->text_memoffset;
 	map->vsize = map->psize = hdr->text_size;
 	map->vaddr = hdr->text_loc + ba;
 	map->perm = RZ_PERM_RX;
@@ -286,7 +286,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		return ret;
 	}
 	map->name = rz_str_dup("ro");
-	map->paddr = bin->decompressed ? hdr->text_size : hdr->ro_memoffset;
+	map->offset = bin->decompressed ? hdr->text_size : hdr->ro_memoffset;
 	map->vsize = map->psize = hdr->ro_size;
 	map->vaddr = hdr->ro_loc + ba;
 	map->perm = RZ_PERM_R;
@@ -299,7 +299,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		return ret;
 	}
 	map->name = rz_str_dup("data");
-	map->paddr = bin->decompressed ? hdr->text_size + hdr->ro_size : hdr->data_memoffset;
+	map->offset = bin->decompressed ? hdr->text_size + hdr->ro_size : hdr->data_memoffset;
 	map->vsize = map->psize = hdr->data_size;
 	map->vaddr = hdr->data_loc + ba;
 	map->perm = RZ_PERM_RW;

--- a/librz/bin/p/bin_p9.c
+++ b/librz/bin/p/bin_p9.c
@@ -71,8 +71,8 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	ptr->name = rz_str_dup("text");
 	ptr->size = textsize;
 	ptr->vsize = textsize + (textsize % 4096);
-	ptr->paddr = 8 * 4;
-	ptr->vaddr = ptr->paddr;
+	ptr->offset = 8 * 4;
+	ptr->vaddr = ptr->offset;
 	ptr->perm = RZ_PERM_RX; // r-x
 	rz_pvector_push(ret, ptr);
 	// add data segment
@@ -88,8 +88,8 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		ptr->name = rz_str_dup("data");
 		ptr->size = datasize;
 		ptr->vsize = datasize + (datasize % 4096);
-		ptr->paddr = textsize + (8 * 4);
-		ptr->vaddr = ptr->paddr;
+		ptr->offset = textsize + (8 * 4);
+		ptr->vaddr = ptr->offset;
 		ptr->perm = RZ_PERM_RW;
 		rz_pvector_push(ret, ptr);
 	}
@@ -108,8 +108,8 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		ptr->name = rz_str_dup("syms");
 		ptr->size = symssize;
 		ptr->vsize = symssize + (symssize % 4096);
-		ptr->paddr = datasize + textsize + (8 * 4);
-		ptr->vaddr = ptr->paddr;
+		ptr->offset = datasize + textsize + (8 * 4);
+		ptr->vaddr = ptr->offset;
 		ptr->perm = RZ_PERM_R; // r--
 		rz_pvector_push(ret, ptr);
 	}
@@ -126,8 +126,8 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		ptr->name = rz_str_dup("spsz");
 		ptr->size = spszsize;
 		ptr->vsize = spszsize + (spszsize % 4096);
-		ptr->paddr = symssize + datasize + textsize + (8 * 4);
-		ptr->vaddr = ptr->paddr;
+		ptr->offset = symssize + datasize + textsize + (8 * 4);
+		ptr->vaddr = ptr->offset;
 		ptr->perm = RZ_PERM_R; // r--
 		rz_pvector_push(ret, ptr);
 	}
@@ -146,8 +146,8 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		ptr->name = rz_str_dup("pcsz");
 		ptr->size = pcszsize;
 		ptr->vsize = pcszsize + (pcszsize % 4096);
-		ptr->paddr = spszsize + symssize + datasize + textsize + (8 * 4);
-		ptr->vaddr = ptr->paddr;
+		ptr->offset = spszsize + symssize + datasize + textsize + (8 * 4);
+		ptr->vaddr = ptr->offset;
 		ptr->perm = RZ_PERM_R; // r--
 		rz_pvector_push(ret, ptr);
 	}

--- a/librz/bin/p/bin_pe.inc
+++ b/librz/bin/p/bin_pe.inc
@@ -156,7 +156,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		return ret;
 	}
 	map->name = rz_str_dup("header");
-	map->paddr = 0;
+	map->offset = 0;
 	ut32 aligned_hdr_size = UT32_MAX;
 	if (bin->nt_headers->optional_header.FileAlignment != 0) {
 		aligned_hdr_size = RZ_ROUND(bin->nt_headers->optional_header.SizeOfHeaders, bin->nt_headers->optional_header.FileAlignment);
@@ -173,7 +173,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		if (!map) {
 			break;
 		}
-		map->paddr = sections[i].paddr;
+		map->offset = sections[i].paddr;
 		map->name = rz_str_dup((char *)sections[i].name);
 		map->psize = sections[i].size;
 		if (map->psize > bin->size) {

--- a/librz/bin/p/bin_pe.inc
+++ b/librz/bin/p/bin_pe.inc
@@ -220,7 +220,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		ptr->size = sections[i].size;
 		ptr->vsize = sections[i].vsize;
 		ptr->flags = sections[i].flags;
-		ptr->paddr = sections[i].paddr;
+		ptr->offset = sections[i].paddr;
 		ptr->vaddr = sections[i].vaddr + ba;
 		ptr->perm = perm_of_section_perm(sections[i].perm);
 		if ((ptr->perm & RZ_PERM_R) && !(ptr->perm & RZ_PERM_X) && ptr->size > 0) {

--- a/librz/bin/p/bin_pebble.c
+++ b/librz/bin/p/bin_pebble.c
@@ -131,7 +131,7 @@ static RzPVector /*<RzBinSection *>*/ *pebble_sections(RzBinFile *bf) {
 	}
 	ptr->name = rz_str_dup("relocs");
 	ptr->vsize = ptr->size = ((ut64)pai->num_reloc_entries) * sizeof(ut32);
-	ptr->vaddr = ptr->paddr = pai->reloc_list_start;
+	ptr->vaddr = ptr->offset = pai->reloc_list_start;
 	ptr->perm = RZ_PERM_RW;
 	rz_pvector_push(ret, ptr);
 	if (ptr->vaddr < textsize) {
@@ -144,7 +144,7 @@ static RzPVector /*<RzBinSection *>*/ *pebble_sections(RzBinFile *bf) {
 	}
 	ptr->name = rz_str_dup("symtab");
 	ptr->vsize = ptr->size = 0;
-	ptr->vaddr = ptr->paddr = pai->sym_table_addr;
+	ptr->vaddr = ptr->offset = pai->sym_table_addr;
 	ptr->perm = RZ_PERM_R;
 	rz_pvector_push(ret, ptr);
 	if (ptr->vaddr < textsize) {
@@ -155,8 +155,8 @@ static RzPVector /*<RzBinSection *>*/ *pebble_sections(RzBinFile *bf) {
 		return ret;
 	}
 	ptr->name = rz_str_dup("text");
-	ptr->vaddr = ptr->paddr = 0x80;
-	ptr->vsize = ptr->size = textsize - ptr->paddr;
+	ptr->vaddr = ptr->offset = 0x80;
+	ptr->vsize = ptr->size = textsize - ptr->offset;
 	ptr->perm = RZ_PERM_RWX;
 	rz_pvector_push(ret, ptr);
 
@@ -165,7 +165,7 @@ static RzPVector /*<RzBinSection *>*/ *pebble_sections(RzBinFile *bf) {
 	}
 	ptr->name = rz_str_dup("header");
 	ptr->vsize = ptr->size = sizeof(PebbleAppInfo);
-	ptr->vaddr = ptr->paddr = 0;
+	ptr->vaddr = ptr->offset = 0;
 	ptr->perm = RZ_PERM_R;
 	rz_pvector_push(ret, ptr);
 

--- a/librz/bin/p/bin_prg.c
+++ b/librz/bin/p/bin_prg.c
@@ -51,7 +51,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		return ret;
 	}
 	section->name = rz_str_dup("prg");
-	section->paddr = 2;
+	section->offset = 2;
 	section->size = sz - 2;
 	section->vaddr = baddr(bf);
 	section->vsize = sz - 2;

--- a/librz/bin/p/bin_psxexe.c
+++ b/librz/bin/p/bin_psxexe.c
@@ -70,7 +70,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	sz = rz_buf_size(bf->buf);
 
 	sect->name = rz_str_dup("TEXT");
-	sect->paddr = PSXEXE_TEXTSECTION_OFFSET;
+	sect->offset = PSXEXE_TEXTSECTION_OFFSET;
 	sect->size = sz - PSXEXE_TEXTSECTION_OFFSET;
 	sect->vaddr = psxheader.t_addr;
 	sect->vsize = psxheader.t_size;

--- a/librz/bin/p/bin_qnx.c
+++ b/librz/bin/p/bin_qnx.c
@@ -135,7 +135,7 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb
 				goto beach;
 			}
 			map->name = rz_str_dup(ptr->name);
-			map->paddr = ptr->paddr;
+			map->offset = ptr->paddr;
 			map->psize = ptr->size;
 			map->vsize = ptr->vsize;
 			rz_pvector_push(maps, map);
@@ -165,7 +165,7 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb
 				goto beach;
 			}
 			map->name = rz_str_dup(ptr->name);
-			map->paddr = ptr->paddr;
+			map->offset = ptr->paddr;
 			map->psize = ptr->size;
 			map->vsize = ptr->vsize;
 			rz_pvector_push(maps, map);

--- a/librz/bin/p/bin_qnx.c
+++ b/librz/bin/p/bin_qnx.c
@@ -125,7 +125,7 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb
 				goto beach;
 			}
 			ptr->name = rz_str_dup("LMF_RESOURCE");
-			ptr->paddr = offset;
+			ptr->offset = offset;
 			ptr->vsize = lrec.data_nbytes - LMF_RESOURCE_SIZE;
 			ptr->size = ptr->vsize;
 			rz_pvector_push(sections, ptr);
@@ -135,7 +135,7 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb
 				goto beach;
 			}
 			map->name = rz_str_dup(ptr->name);
-			map->offset = ptr->paddr;
+			map->offset = ptr->offset;
 			map->psize = ptr->size;
 			map->vsize = ptr->vsize;
 			rz_pvector_push(maps, map);
@@ -154,7 +154,7 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb
 				goto beach;
 			}
 			ptr->name = rz_str_dup("LMF_LOAD");
-			ptr->paddr = offset;
+			ptr->offset = offset;
 			ptr->vaddr = ldata.offset;
 			ptr->vsize = lrec.data_nbytes - LMF_DATA_SIZE;
 			ptr->size = ptr->vsize;
@@ -165,7 +165,7 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb
 				goto beach;
 			}
 			map->name = rz_str_dup(ptr->name);
-			map->offset = ptr->paddr;
+			map->offset = ptr->offset;
 			map->psize = ptr->size;
 			map->vsize = ptr->vsize;
 			rz_pvector_push(maps, map);

--- a/librz/bin/p/bin_sfc.c
+++ b/librz/bin/p/bin_sfc.c
@@ -101,7 +101,7 @@ static void addrom(RzPVector /*<RzBinSection *>*/ *ret, const char *name, int i,
 		return;
 	}
 	ptr->name = rz_str_newf("%s_%02x", name, i);
-	ptr->paddr = paddr;
+	ptr->offset = paddr;
 	ptr->vaddr = vaddr;
 	ptr->size = ptr->vsize = size;
 	ptr->perm = RZ_PERM_RX;

--- a/librz/bin/p/bin_smd.c
+++ b/librz/bin/p/bin_smd.c
@@ -262,7 +262,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		return ret;
 	}
 	ptr->name = rz_str_dup("vtable");
-	ptr->paddr = ptr->vaddr = 0;
+	ptr->offset = ptr->vaddr = 0;
 	ptr->size = ptr->vsize = 0x100;
 	ptr->perm = RZ_PERM_R;
 	rz_pvector_push(ret, ptr);
@@ -271,7 +271,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		return ret;
 	}
 	ptr->name = rz_str_dup("header");
-	ptr->paddr = ptr->vaddr = 0x100;
+	ptr->offset = ptr->vaddr = 0x100;
 	ptr->size = ptr->vsize = sizeof(SMD_Header);
 	ptr->perm = RZ_PERM_R;
 	rz_pvector_push(ret, ptr);
@@ -280,14 +280,14 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		return ret;
 	}
 	ptr->name = rz_str_dup("text");
-	ptr->paddr = ptr->vaddr = 0x100 + sizeof(SMD_Header);
+	ptr->offset = ptr->vaddr = 0x100 + sizeof(SMD_Header);
 	{
 		SMD_Header hdr = { { 0 } };
 		rz_buf_read_at(bf->buf, 0x100, (ut8 *)&hdr, sizeof(hdr));
 		ut64 baddr = rz_read_be32(&hdr.RomStart);
 		ptr->vaddr += baddr;
 	}
-	ptr->size = ptr->vsize = rz_buf_size(bf->buf) - ptr->paddr;
+	ptr->size = ptr->vsize = rz_buf_size(bf->buf) - ptr->offset;
 	ptr->perm = RZ_PERM_RX;
 	rz_pvector_push(ret, ptr);
 	return ret;

--- a/librz/bin/p/bin_spc700.c
+++ b/librz/bin/p/bin_spc700.c
@@ -57,7 +57,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		return NULL;
 	}
 	ptr->name = rz_str_dup("RAM");
-	ptr->paddr = RAM_START_ADDRESS;
+	ptr->offset = RAM_START_ADDRESS;
 	ptr->size = RAM_SIZE;
 	ptr->vaddr = 0x0;
 	ptr->vsize = RAM_SIZE;

--- a/librz/bin/p/bin_symbols.c
+++ b/librz/bin/p/bin_symbols.c
@@ -138,7 +138,7 @@ static RzBinSection *bin_section_from_section(RzCoreSymCacheElementSection *sect
 	s->name = rz_str_ndup(sect->name, 256);
 	s->size = sect->size;
 	s->vsize = s->size;
-	s->paddr = sect->paddr;
+	s->offset = sect->paddr;
 	s->vaddr = sect->vaddr;
 	s->perm = strstr(s->name, "TEXT") ? 5 : 4;
 	s->is_segment = false;
@@ -156,7 +156,7 @@ static RzBinSection *bin_section_from_segment(RzCoreSymCacheElementSegment *seg)
 	s->name = rz_str_ndup(seg->name, 16);
 	s->size = seg->size;
 	s->vsize = seg->vsize;
-	s->paddr = seg->paddr;
+	s->offset = seg->paddr;
 	s->vaddr = seg->vaddr;
 	s->perm = strstr(s->name, "TEXT") ? 5 : 4;
 	s->is_segment = true;

--- a/librz/bin/p/bin_te.c
+++ b/librz/bin/p/bin_te.c
@@ -91,7 +91,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		ptr->name = rz_str_dup((char *)sections[i].name);
 		ptr->size = sections[i].size;
 		ptr->vsize = sections[i].vsize;
-		ptr->paddr = sections[i].paddr;
+		ptr->offset = sections[i].paddr;
 		ptr->vaddr = sections[i].vaddr;
 		ptr->perm = 0;
 		if (RZ_BIN_TE_SCN_IS_EXECUTABLE(sections[i].flags)) {

--- a/librz/bin/p/bin_vsf.c
+++ b/librz/bin/p/bin_vsf.c
@@ -161,7 +161,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 				return ret;
 			}
 			ptr->name = rz_str_dup("BASIC");
-			ptr->paddr = vsf_obj->rom + rz_offsetof(struct vsf_c64rom, basic);
+			ptr->offset = vsf_obj->rom + rz_offsetof(struct vsf_c64rom, basic);
 			ptr->size = 1024 * 8; // (8k)
 			ptr->vaddr = 0xa000;
 			ptr->vsize = 1024 * 8; // BASIC size (8k)
@@ -173,7 +173,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 				return ret;
 			}
 			ptr->name = rz_str_dup("KERNAL");
-			ptr->paddr = vsf_obj->rom + rz_offsetof(struct vsf_c64rom, kernal);
+			ptr->offset = vsf_obj->rom + rz_offsetof(struct vsf_c64rom, kernal);
 			ptr->size = 1024 * 8; // (8k)
 			ptr->vaddr = 0xe000;
 			ptr->vsize = 1024 * 8; // KERNAL size (8k)
@@ -188,7 +188,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 				return ret;
 			}
 			ptr->name = rz_str_dup("BASIC");
-			ptr->paddr = vsf_obj->rom + rz_offsetof(struct vsf_c128rom, basic);
+			ptr->offset = vsf_obj->rom + rz_offsetof(struct vsf_c128rom, basic);
 			ptr->size = 1024 * 28; // (28k)
 			ptr->vaddr = 0x4000;
 			ptr->vsize = 1024 * 28; // BASIC size (28k)
@@ -201,7 +201,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 			}
 			ptr->name = rz_str_dup("MONITOR");
 			// skip first 28kb  since "BASIC" and "MONITOR" share the same section in VSF
-			ptr->paddr = vsf_obj->rom + rz_offsetof(struct vsf_c128rom, basic) + 1024 * 28;
+			ptr->offset = vsf_obj->rom + rz_offsetof(struct vsf_c128rom, basic) + 1024 * 28;
 			ptr->size = 1024 * 4; // (4k)
 			ptr->vaddr = 0xb000;
 			ptr->vsize = 1024 * 4; // BASIC size (4k)
@@ -213,7 +213,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 				return ret;
 			}
 			ptr->name = rz_str_dup("EDITOR");
-			ptr->paddr = vsf_obj->rom + rz_offsetof(struct vsf_c128rom, editor);
+			ptr->offset = vsf_obj->rom + rz_offsetof(struct vsf_c128rom, editor);
 			ptr->size = 1024 * 4; // (4k)
 			ptr->vaddr = 0xc000;
 			ptr->vsize = 1024 * 4; // BASIC size (4k)
@@ -225,7 +225,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 				return ret;
 			}
 			ptr->name = rz_str_dup("KERNAL");
-			ptr->paddr = vsf_obj->rom + rz_offsetof(struct vsf_c128rom, kernal);
+			ptr->offset = vsf_obj->rom + rz_offsetof(struct vsf_c128rom, kernal);
 			ptr->size = 1024 * 8; // (8k)
 			ptr->vaddr = 0xe000;
 			ptr->vsize = 1024 * 8; // KERNAL size (8k)
@@ -245,7 +245,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 				return ret;
 			}
 			ptr->name = rz_str_dup("RAM");
-			ptr->paddr = vsf_obj->mem + offset;
+			ptr->offset = vsf_obj->mem + offset;
 			ptr->size = size;
 			ptr->vaddr = 0x0;
 			ptr->vsize = size;
@@ -261,7 +261,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 				return ret;
 			}
 			ptr->name = rz_str_dup("RAM BANK 0");
-			ptr->paddr = vsf_obj->mem + offset;
+			ptr->offset = vsf_obj->mem + offset;
 			ptr->size = size;
 			ptr->vaddr = 0x0;
 			ptr->vsize = size;
@@ -272,7 +272,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 				return ret;
 			}
 			ptr->name = rz_str_dup("RAM BANK 1");
-			ptr->paddr = vsf_obj->mem + offset + size;
+			ptr->offset = vsf_obj->mem + offset + size;
 			ptr->size = size;
 			ptr->vaddr = 0x0;
 			ptr->vsize = size;

--- a/librz/bin/p/bin_wasm.c
+++ b/librz/bin/p/bin_wasm.c
@@ -111,7 +111,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		ptr->size = sec->payload_len;
 		ptr->vsize = sec->payload_len;
 		ptr->vaddr = sec->offset;
-		ptr->paddr = sec->offset;
+		ptr->offset = sec->offset;
 		// TODO permissions
 		ptr->perm = 0;
 		rz_pvector_push(ret, ptr);

--- a/librz/bin/p/bin_xbe.c
+++ b/librz/bin/p/bin_xbe.c
@@ -190,7 +190,7 @@ static RzPVector /*<RzBinAddr *>*/ *sections(RzBinFile *bf) {
 		}
 		tmp[sizeof(tmp) - 1] = 0;
 		item->name = rz_str_newf("%s.%i", tmp, i);
-		item->paddr = sect.offset;
+		item->offset = sect.offset;
 		item->vaddr = sect.vaddr;
 		item->size = sect.size;
 		item->vsize = sect.vsize;

--- a/librz/bin/p/bin_xnu_kernelcache.c
+++ b/librz/bin/p/bin_xnu_kernelcache.c
@@ -1092,11 +1092,11 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		ptr->name = rz_str_newf("%d.%s", i, segname);
 		ptr->size = seg->vmsize;
 		ptr->vsize = seg->vmsize;
-		ptr->paddr = seg->fileoff + bf->o->boffset;
+		ptr->offset = seg->fileoff + bf->o->boffset;
 		ptr->vaddr = seg->vmaddr;
 		ptr->is_segment = true;
 		if (!ptr->vaddr) {
-			ptr->vaddr = ptr->paddr;
+			ptr->vaddr = ptr->offset;
 		}
 		ptr->perm = prot2perm(seg->initprot);
 		rz_pvector_push(ret, ptr);
@@ -1139,10 +1139,10 @@ static void sections_from_mach0(RzPVector /*<RzBinSection *>*/ *ret, struct MACH
 		handle_data_sections(ptr);
 		ptr->size = sections[i].size;
 		ptr->vsize = sections[i].vsize;
-		ptr->paddr = sections[i].offset + bf->o->boffset + paddr;
+		ptr->offset = sections[i].offset + bf->o->boffset + paddr;
 		ptr->vaddr = K_PPTR(sections[i].addr);
 		if (!ptr->vaddr) {
-			ptr->vaddr = ptr->paddr;
+			ptr->vaddr = ptr->offset;
 		}
 		ptr->perm = sections[i].perm;
 		if (!ptr->perm && strstr(sections[i].name, "__TEXT_EXEC.__text")) {

--- a/librz/bin/p/bin_xnu_kernelcache.c
+++ b/librz/bin/p/bin_xnu_kernelcache.c
@@ -1030,12 +1030,12 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		rz_str_ncpy(segname, seg->segname, 17);
 		rz_str_filter(segname);
 		map->name = rz_str_newf("%d.%s", i, segname);
-		map->paddr = seg->fileoff + bf->o->boffset;
+		map->offset = seg->fileoff + bf->o->boffset;
 		map->psize = seg->vmsize;
 		map->vsize = seg->vmsize;
 		map->vaddr = seg->vmaddr;
 		if (!map->vaddr) {
-			map->vaddr = map->paddr;
+			map->vaddr = map->offset;
 		}
 		map->perm = prot2perm(seg->initprot);
 		map->vfile_name = kobj->patched_buf ? rz_str_dup(VFILE_NAME_PATCHED) : NULL;

--- a/librz/bin/p/bin_z64.c
+++ b/librz/bin/p/bin_z64.c
@@ -116,7 +116,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	text->name = rz_str_dup("text");
 	text->size = rz_buf_size(bf->buf) - N64_ROM_START;
 	text->vsize = text->size;
-	text->paddr = N64_ROM_START;
+	text->offset = N64_ROM_START;
 	text->vaddr = baddr(bf);
 	text->perm = RZ_PERM_RX;
 	rz_pvector_push(ret, text);

--- a/librz/bin/relocs_patch.c
+++ b/librz/bin/relocs_patch.c
@@ -101,13 +101,13 @@ RZ_API void rz_bin_relocs_patch_maps(RZ_NONNULL RzPVector /*<RzBinMap *>*/ *maps
 				// But as far as we can tell, these two features are mutually exclusive in practice.
 				continue;
 			}
-			ut64 buf_addr = map->paddr - buf_patched_offset;
+			ut64 buf_addr = map->offset - buf_patched_offset;
 			if (!map->psize || !rz_buf_sparse_populated_in(buf_patched, buf_addr, buf_addr + map->psize - 1)) {
 				// avoid using the patched file if there is nothing different in this range
 				continue;
 			}
 			map->vfile_name = rz_str_dup(vfile_name_patched);
-			map->paddr = buf_addr;
+			map->offset = buf_addr;
 		}
 	}
 
@@ -118,7 +118,7 @@ RZ_API void rz_bin_relocs_patch_maps(RZ_NONNULL RzPVector /*<RzBinMap *>*/ *maps
 			return;
 		}
 		map->name = rz_str_dup("reloc-targets");
-		map->paddr = 0;
+		map->offset = 0;
 		map->psize = target_vfile_size;
 		map->vaddr = target_vfile_base;
 		map->vsize = target_vfile_size;

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4571,7 +4571,7 @@ RZ_API bool rz_analysis_add_device_peripheral_map(RzBinObject *o, RzAnalysis *an
 	s->vaddr = rom_address;
 	s->vsize = rom_size;
 	s->size = rom_size;
-	s->paddr = rom_address;
+	s->offset = rom_address;
 	s->perm = RZ_PERM_RX;
 	rz_pvector_push(o->sections, s);
 	return true;

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -849,7 +849,7 @@ static bool io_create_mem_map(RzIO *io, RZ_NULLABLE RzCoreFile *cf, RzBinMap *ma
 
 static void add_map(RzCore *core, RZ_NULLABLE RzCoreFile *cf, RzBinFile *bf, RzBinMap *map, ut64 addr, int fd) {
 	RzIODesc *io_desc = rz_io_desc_get(core->io, fd);
-	if (!io_desc || UT64_ADD_OVFCHK(map->psize, map->paddr) ||
+	if (!io_desc || UT64_ADD_OVFCHK(map->psize, map->offset) ||
 		UT64_ADD_OVFCHK(map->vsize, addr) || !map->vsize) {
 		return;
 	}
@@ -907,7 +907,7 @@ static void add_map(RzCore *core, RZ_NULLABLE RzCoreFile *cf, RzBinFile *bf, RzB
 	}
 
 	if (size) {
-		RzIOMap *iomap = rz_io_map_add_batch(core->io, fd, perm, map->paddr, addr, size);
+		RzIOMap *iomap = rz_io_map_add_batch(core->io, fd, perm, map->offset, addr, size);
 		if (!iomap) {
 			free(map_name);
 			return;
@@ -946,7 +946,7 @@ RZ_API bool rz_core_bin_apply_maps(RzCore *core, RzBinFile *binfile, bool va) {
 		if (va && !(map->perm & RZ_PERM_R)) {
 			va_map = VA_NOREBASE;
 		}
-		ut64 addr = rva(o, map->paddr, map->vaddr, va_map);
+		ut64 addr = rva(o, map->offset, map->vaddr, va_map);
 		add_map(core, cf, binfile, map, addr, binfile->fd);
 	}
 	return true;

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -994,10 +994,10 @@ RZ_API bool rz_core_bin_apply_sections(RzCore *core, RzBinFile *binfile, bool va
 		if (va && !(section->perm & RZ_PERM_R)) {
 			va_sect = VA_NOREBASE;
 		}
-		if (is_invalid_address_va2(va_sect, section->vaddr, section->paddr)) {
+		if (is_invalid_address_va2(va_sect, section->vaddr, section->offset)) {
 			continue;
 		}
-		ut64 addr = rva(o, section->paddr, section->vaddr, va_sect);
+		ut64 addr = rva(o, section->offset, section->vaddr, va_sect);
 
 		rz_name_filter(section->name, strlen(section->name) + 1, false);
 
@@ -2349,7 +2349,7 @@ static ut64 get_section_addr(RzCore *core, RzBinObject *o, RzBinSection *section
 	if (va && !(section->perm & RZ_PERM_R)) {
 		va = VA_NOREBASE;
 	}
-	return rva(o, section->paddr, section->vaddr, va);
+	return rva(o, section->offset, section->vaddr, va);
 }
 
 static bool digests_pj_cb(void *user, const char *k, const char *v) {
@@ -2389,13 +2389,13 @@ static void sections_print_json(RzCore *core, PJ *pj, RzBinObject *o, RzBinSecti
 		}
 		rz_list_free(flags);
 	}
-	pj_kn(pj, "paddr", section->paddr);
+	pj_kn(pj, "paddr", section->offset);
 	pj_kn(pj, "vaddr", addr);
 	if (section->align > 1) {
 		pj_kn(pj, "align", section->align);
 	}
 	if (hashes && section->size > 0) {
-		HtSS *digests = rz_core_bin_create_digests(core, section->paddr, section->size, hashes);
+		HtSS *digests = rz_core_bin_create_digests(core, section->offset, section->size, hashes);
 		if (!digests) {
 			pj_end(pj);
 			return;
@@ -2429,13 +2429,13 @@ static bool sections_print_table(RzCore *core, RzTable *t, RzBinObject *o, RzBin
 		section_name = rz_str_newf("%s.%s", core->bin->prefix, section_name);
 	}
 
-	rz_table_add_rowf(t, "XxXxxss", section->paddr, section->size, addr, section->vsize, section->align, perms, section_name);
+	rz_table_add_rowf(t, "XxXxxss", section->offset, section->size, addr, section->vsize, section->align, perms, section_name);
 	if (!section->is_segment) {
 		rz_table_add_row_columnsf(t, "ss", section_type, section_flags_str);
 	}
 	bool result = false;
 	if (hashes && section->size > 0) {
-		HtSS *digests = rz_core_bin_create_digests(core, section->paddr, section->size, hashes);
+		HtSS *digests = rz_core_bin_create_digests(core, section->offset, section->size, hashes);
 		if (!digests) {
 			goto cleanup;
 		}
@@ -2504,7 +2504,7 @@ RZ_API bool rz_core_bin_sections_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBin
 		section = *iter;
 		if (filter && filter->offset != UT64_MAX) {
 			if (!is_in_symbol_range(section->vaddr, section->vsize, filter->offset) &&
-				!is_in_symbol_range(section->paddr, section->size, filter->offset)) {
+				!is_in_symbol_range(section->offset, section->size, filter->offset)) {
 				continue;
 			}
 		}
@@ -2664,7 +2664,7 @@ RZ_API bool rz_core_bin_segments_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBin
 		segment = *it;
 		if (filter && filter->offset != UT64_MAX) {
 			if (!is_in_symbol_range(segment->vaddr, segment->vsize, filter->offset) &&
-				!is_in_symbol_range(segment->paddr, segment->size, filter->offset)) {
+				!is_in_symbol_range(segment->offset, segment->size, filter->offset)) {
 				continue;
 			}
 		}

--- a/librz/core/cbounds.c
+++ b/librz/core/cbounds.c
@@ -193,7 +193,7 @@ RZ_API RZ_OWN RzList /*<RzIOMap *>*/ *rz_core_get_boundaries_current_bin_section
 		return core_get_boundaries_generic(core, elem->vaddr, elem->vsize, interval, elem->perm);
 	}
 	// physical
-	return core_get_boundaries_generic(core, elem->paddr, elem->size, interval, elem->perm);
+	return core_get_boundaries_generic(core, elem->offset, elem->size, interval, elem->perm);
 }
 
 /**
@@ -221,7 +221,7 @@ RZ_API RZ_OWN RzList /*<RzIOMap *>*/ *rz_core_get_boundaries_current_bin_segment
 		return core_get_boundaries_generic(core, elem->vaddr, elem->vsize, interval, elem->perm);
 	}
 	// physical
-	return core_get_boundaries_generic(core, elem->paddr, elem->size, interval, elem->perm);
+	return core_get_boundaries_generic(core, elem->offset, elem->size, interval, elem->perm);
 }
 
 /**
@@ -345,7 +345,7 @@ RZ_API RZ_OWN RzList /*<RzIOMap *>*/ *rz_core_get_boundaries_bin_segments(RZ_NON
 			boundaries.size = elem->vsize;
 		} else {
 			// physical
-			boundaries.addr = elem->paddr;
+			boundaries.addr = elem->offset;
 			boundaries.size = elem->size;
 		}
 
@@ -404,7 +404,7 @@ RZ_API RZ_OWN RzList /*<RzIOMap *>*/ *rz_core_get_boundaries_bin_sections(RZ_NON
 			boundaries.size = elem->vsize;
 		} else {
 			// physical
-			boundaries.addr = elem->paddr;
+			boundaries.addr = elem->offset;
 			boundaries.size = elem->size;
 		}
 
@@ -461,7 +461,7 @@ RZ_API RZ_OWN RzList /*<RzIOMap *>*/ *rz_core_get_boundaries_code_only(RZ_NONNUL
 			boundaries.size = elem->vsize;
 		} else {
 			// physical
-			boundaries.addr = elem->paddr;
+			boundaries.addr = elem->offset;
 			boundaries.size = elem->size;
 		}
 

--- a/librz/core/cmd/cmd_info.c
+++ b/librz/core/cmd/cmd_info.c
@@ -286,7 +286,7 @@ RZ_IPI RzCmdStatus rz_cmd_info_section_bars_handler(RzCore *core, int argc, cons
 	rz_pvector_foreach (sections, iter) {
 		section = *iter;
 		char humansz[8];
-		RzInterval pitv = (RzInterval){ section->paddr, section->size };
+		RzInterval pitv = (RzInterval){ section->offset, section->size };
 		RzInterval vitv = (RzInterval){ section->vaddr, section->vsize };
 
 		rz_num_units(humansz, sizeof(humansz), section->size);

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -797,7 +797,7 @@ static ut64 num_callback(RzNum *userptr, const char *str, int *ok) {
 			return str[2] == '$' ? core->prompt_offset : core->offset;
 		case 'o': { // $o
 			RzBinSection *s = rz_bin_get_section_at(rz_bin_cur_object(core->bin), core->offset, true);
-			return s ? core->offset - s->vaddr + s->paddr : core->offset;
+			return s ? core->offset - s->vaddr + s->offset : core->offset;
 			break;
 		}
 		case 'O': // $O

--- a/librz/core/linux_heap_glibc.c
+++ b/librz/core/linux_heap_glibc.c
@@ -166,7 +166,7 @@ static ut8 *GH(get_glibc_banner)(RzCore *core, const char *section_name,
 			continue;
 		}
 		buf = calloc(rz_section->size, 1);
-		GHT read_size = rz_buf_read_at(libc_buf->buf, rz_section->paddr, buf, rz_section->size);
+		GHT read_size = rz_buf_read_at(libc_buf->buf, rz_section->offset, buf, rz_section->size);
 		if (read_size != rz_section->size) {
 			free(buf);
 			buf = NULL;

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -569,7 +569,7 @@ typedef struct rz_bin_section_t {
 	ut64 size;
 	ut64 vsize;
 	ut64 vaddr;
-	ut64 paddr;
+	ut64 offset;
 	ut32 perm;
 	ut64 align;
 	// per section platform info

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -545,14 +545,16 @@ typedef struct rz_bin_virtual_file_t {
 	bool buf_owned; ///< whether buf is owned and freed by this RzBinVirtualFile
 } RzBinVirtualFile;
 
-/// Description of a single memory mapping into virtual memory from a binary
+/**
+ * \brief A single memory mapping from a binary file into virtual memory.
+ */
 typedef struct rz_bin_map_t {
-	ut64 paddr; ///< address of the map inside the file
-	ut64 psize; ///< size of the data inside the file
-	ut64 vaddr; ///< address in the destination address space to map to
-	ut64 vsize; ///< size to map in the destination address space. If vsize > psize, excessive bytes are meant to be filled with 0
-	RZ_NULLABLE char *name;
-	ut32 perm;
+	ut64 offset; ///< Offset into the binary file where the map starts.
+	ut64 psize; ///< Size of the map inside the file.
+	ut64 vaddr; ///< Address where the map is located in address space.
+	ut64 vsize; ///< Size of map in the address space. If vsize > psize, excessive bytes are meant to be filled with 0
+	RZ_NULLABLE char *name; ///< Optional name of the map.
+	ut32 perm; ///< Map permissions (PF_R, PF_W, PF_X).
 
 	/**
 	 * If not NULL, the data will be taken from the virtual file returned by the

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -1317,7 +1317,7 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 					rz_pvector_foreach (sections, iter) {
 						s = *iter;
 						if (s->perm & RZ_PERM_X) {
-							ut64 addr = s->vaddr ? s->vaddr : s->paddr;
+							ut64 addr = s->vaddr ? s->vaddr : s->offset;
 							rz_core_seek(r, addr, true);
 							break;
 						}

--- a/librz/main/rz-bin.c
+++ b/librz/main/rz-bin.c
@@ -465,13 +465,13 @@ static bool __dumpSections(RzBin *bin, const char *scnname, const char *output, 
 				free(buf);
 				return false;
 			}
-			if (section->paddr > rz_buf_size(bin->cur->buf) ||
-				section->paddr + section->size > rz_buf_size(bin->cur->buf)) {
+			if (section->offset > rz_buf_size(bin->cur->buf) ||
+				section->offset + section->size > rz_buf_size(bin->cur->buf)) {
 				free(buf);
 				free(ret);
 				return false;
 			}
-			r = rz_buf_read_at(bin->cur->buf, section->paddr,
+			r = rz_buf_read_at(bin->cur->buf, section->offset,
 				buf, section->size);
 			if (r < 1) {
 				free(buf);
@@ -668,7 +668,7 @@ static void print_string(RzBinFile *bf, RzBinString *string, PJ *pj, int mode) {
 	ut64 vaddr;
 	RzBinSection *s = rz_bin_get_section_at(bf->o, string->paddr, false);
 	if (s) {
-		string->vaddr = s->vaddr + (string->paddr - s->paddr);
+		string->vaddr = s->vaddr + (string->paddr - s->offset);
 	}
 	vaddr = bf->o ? rz_bin_object_get_vaddr(bf->o, string->paddr, string->vaddr) : UT64_MAX;
 	const char *type_string = rz_str_enc_as_string(string->type);

--- a/librz/main/rz-diff.c
+++ b/librz/main/rz-diff.c
@@ -1148,8 +1148,8 @@ static ut32 section_hash_addr(const RzBinSection *elem) {
 	hash ^= (ut32)elem->size;
 	hash ^= (ut32)(elem->vaddr >> 32);
 	hash ^= (ut32)elem->vaddr;
-	hash ^= (ut32)(elem->paddr >> 32);
-	hash ^= (ut32)elem->paddr;
+	hash ^= (ut32)(elem->offset >> 32);
+	hash ^= (ut32)elem->offset;
 	return hash;
 }
 
@@ -1164,7 +1164,7 @@ static int section_compare_addr(const RzBinSection *a, const RzBinSection *b) {
 	if (ret) {
 		return ret;
 	}
-	ret = ((st64)b->paddr) - ((st64)a->paddr);
+	ret = ((st64)b->offset) - ((st64)a->offset);
 	if (ret) {
 		return ret;
 	}
@@ -1189,7 +1189,7 @@ static void section_stringify_addr(const RzBinSection *elem, RzStrBuf *sb) {
 	perm[4] = 0;
 
 	rz_strbuf_setf(sb, "virt: 0x%016" PFMT64x ":0x%04" PFMT64x " phys: 0x%016" PFMT64x ":0x%04" PFMT64x " align: 0x%08" PFMT64x " %s %s\n",
-		elem->vaddr, elem->vsize, elem->paddr, elem->size, elem->align, perm, elem->name);
+		elem->vaddr, elem->vsize, elem->offset, elem->size, elem->align, perm, elem->name);
 }
 
 static ut32 section_hash(const RzBinSection *elem) {

--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -159,7 +159,7 @@ static void print_bin_string(RzBinFile *bf, RzBinString *string, PJ *pj) {
 
 	RzBinSection *s = rz_bin_get_section_at(bf->o, string->paddr, false);
 	if (s) {
-		string->vaddr = s->vaddr + (string->paddr - s->paddr);
+		string->vaddr = s->vaddr + (string->paddr - s->offset);
 	}
 	string->vaddr = bf->o ? rz_bin_object_get_vaddr(bf->o, string->paddr, string->vaddr) : UT64_MAX;
 

--- a/test/unit/test_core_bin.c
+++ b/test/unit/test_core_bin.c
@@ -48,7 +48,7 @@ static RzPVector *maps(RzBinFile *bf) {
 
 	RzBinMap *map = RZ_NEW0(RzBinMap);
 	map->name = strdup("direct map");
-	map->paddr = 2;
+	map->offset = 2;
 	map->vaddr = 0x100;
 	map->psize = 2;
 	map->vsize = 2;
@@ -57,7 +57,7 @@ static RzPVector *maps(RzBinFile *bf) {
 
 	map = RZ_NEW0(RzBinMap);
 	map->name = strdup("direct map with zeroes");
-	map->paddr = 2;
+	map->offset = 2;
 	map->vaddr = 0x200;
 	map->psize = 2;
 	map->vsize = 0x30;
@@ -66,7 +66,7 @@ static RzPVector *maps(RzBinFile *bf) {
 
 	map = RZ_NEW0(RzBinMap);
 	map->name = strdup("vfile map");
-	map->paddr = 4;
+	map->offset = 4;
 	map->vaddr = 0x300;
 	map->psize = 4;
 	map->vsize = 4;
@@ -76,7 +76,7 @@ static RzPVector *maps(RzBinFile *bf) {
 
 	map = RZ_NEW0(RzBinMap);
 	map->name = strdup("vfile map with zeroes");
-	map->paddr = 0;
+	map->offset = 0;
 	map->vaddr = 0x400;
 	map->psize = 3;
 	map->vsize = 4;


### PR DESCRIPTION
# Do not squash

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This name change is an attempt to be more precise what the member actually does.

The paddr member was effectively used as an offset into the binary file.
It holds the offset where the map starts.

The name "paddr" is commonly used for "physical address" though.
But a file offset is not the same as a physical address in most contexts.

A physical address commonly refers to a memory space which has some kind of address
translation unit, which manages the memory space by giving out virtual addresses to
memory users.
The physical address refers then to the actual offset into the memory space
(while the virtual addresses don't need fixed to the same physical memory location).

In the context of RzBinMap the paddr is an offset into the binary file.
Not into a memory space. One could argue that the binary file itself is a "physical memory space",
but this is a rather uncommon interpretation.

More so, if RzBinMap is used in context of binary formats which have the concept of mapping (ELF, PE etc)
this naming can be a source of confusion. Because physical address in those binary formats refers to
actual physical addresses as described above. And offsets into files are referred as offset.
For example ELF has for program headers: p_paddr, p_vaddr and p_offset.
For sections only: sh_offset, sh_addr (sh_addr is virtual or physical depending what the machine supports).

The name change from paddr to offset attempts to fix this potential source of confusion.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All green

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
