### PR TITLE
Fix: Seek to entry point by default, if the binary provides one.

### DIFF
--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -958,6 +958,46 @@ RZ_API const char *rz_bin_entry_type_string(int etype) {
 	return NULL;
 }
 
+/**
+ * \brief Returns a first possible entry point address of the object.
+ * If no entry point could be determined, it just returns 0, which is also a valid address.
+ *
+ * If the object has entry points defined, it returns the first one.
+ * If it doesn't it returns the start address of the first executable section.
+ * Otherwise 0.
+ *
+ * It always prioritizes virtual addresses.
+ *
+ * \param obj The object file to get the entry point from.
+ *
+ * \return The entry point address of the binary.
+ */
+RZ_API ut64 rz_bin_get_first_entrypoint(RZ_NULLABLE RzBinObject *obj) {
+	if (!obj) {
+		return 0;
+	} else if (obj->entries && rz_pvector_len(obj->entries) > 0) {
+		// The binary loader specified entry points. Use the first one.
+		const RzBinAddr *entry = rz_pvector_at(obj->entries, 0);
+		ut64 addr = entry->vaddr ? entry->vaddr : entry->paddr;
+		return addr;
+	}
+	const RzPVector *sections = rz_bin_object_get_sections_all(obj);
+	if (!sections) {
+		return 0;
+	}
+	// The binary loader did not specify entry points.
+	// Fall back to the first executable section.
+	void **iter;
+	rz_pvector_foreach (sections, iter) {
+		RzBinSection *s = *iter;
+		if (s->perm & RZ_PERM_X) {
+			ut64 addr = s->vaddr ? s->vaddr : s->paddr;
+			return addr;
+		}
+	}
+	return 0;
+}
+
 RZ_API void rz_bin_load_filter(RzBin *bin, ut64 rules) {
 	bin->filter_rules = rules;
 }

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -987,6 +987,7 @@ RZ_API bool rz_bin_use_arch(RzBin *bin, const char *arch, int bits, const char *
 RZ_API RzBuffer *rz_bin_create(RzBin *bin, const char *plugin_name, const ut8 *code, int codelen, const ut8 *data, int datalen, RzBinArchOptions *opt);
 
 RZ_API const char *rz_bin_entry_type_string(int etype);
+RZ_API ut64 rz_bin_get_first_entrypoint(RZ_NULLABLE RzBinObject *obj);
 
 RZ_API bool rz_bin_file_object_new_from_xtr_data(RzBin *bin, RzBinFile *bf, RzBinObjectLoadOptions *opts, RzBinXtrData *data);
 

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -1305,24 +1305,11 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 		RZ_FREE(debugbackend);
 		RzBinObject *o = rz_bin_cur_object(r->bin);
 		if (!debug && o && !o->regstate) {
-			RzFlagItem *fi = rz_flag_get(r->flags, "entry0");
-			if (fi) {
-				rz_core_seek(r, fi->offset, true);
+			const RzFlagItem *entry0 = rz_flag_get(r->flags, "entry0");
+			if (entry0) {
+				rz_core_seek(r, entry0->offset, true);
 			} else {
-				if (o) {
-					RzBinObject *obj = rz_bin_cur_object(r->bin);
-					const RzPVector *sections = obj ? rz_bin_object_get_sections_all(obj) : NULL;
-					void **iter;
-					RzBinSection *s;
-					rz_pvector_foreach (sections, iter) {
-						s = *iter;
-						if (s->perm & RZ_PERM_X) {
-							ut64 addr = s->vaddr ? s->vaddr : s->paddr;
-							rz_core_seek(r, addr, true);
-							break;
-						}
-					}
-				}
+				rz_core_seek(r, rz_bin_get_first_entrypoint(o), true);
 			}
 		}
 		if (o && o->info && compute_hashes) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Required by raw firmware images. They don't necessarily define `entry0`.
Besides, not taking the entries provided by the loader as default seek is really impolite.
As if `rizin.c::main` knew it better.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
