### PR TITLE
feat: add unicode-based lines in commands help

### DIFF
--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -1082,7 +1082,7 @@ static void get_help_wrong_cmd(RzCore *core, const char *cmdname) {
 		goto cmdname_err;
 	}
 	bool use_color = core->print->flags & RZ_PRINT_FLAGS_COLOR;
-	char *help_msg = rz_cmd_get_help(core->rcmd, help_pra, use_color);
+	char *help_msg = rz_cmd_get_help(core->rcmd, core->config, help_pra, use_color);
 	if (!help_msg) {
 		goto help_pra_err;
 	}
@@ -1463,7 +1463,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(help_stmt) {
 	// let's try first with the new auto-generated help, if
 	// something fails fallback to old behaviour
 	bool use_color = state->core->print->flags & RZ_PRINT_FLAGS_COLOR;
-	char *help_msg = rz_cmd_get_help(state->core->rcmd, pr_args, use_color);
+	char *help_msg = rz_cmd_get_help(state->core->rcmd, state->core->config, pr_args, use_color);
 	if (help_msg) {
 		rz_cons_printf("%s", help_msg);
 		free(help_msg);

--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -1082,7 +1082,7 @@ static void get_help_wrong_cmd(RzCore *core, const char *cmdname) {
 		goto cmdname_err;
 	}
 	bool use_color = core->print->flags & RZ_PRINT_FLAGS_COLOR;
-	char *help_msg = rz_cmd_get_help(core->rcmd, core->config, help_pra, use_color);
+	char *help_msg = rz_cmd_get_help(core->rcmd, help_pra, use_color);
 	if (!help_msg) {
 		goto help_pra_err;
 	}
@@ -1463,7 +1463,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(help_stmt) {
 	// let's try first with the new auto-generated help, if
 	// something fails fallback to old behaviour
 	bool use_color = state->core->print->flags & RZ_PRINT_FLAGS_COLOR;
-	char *help_msg = rz_cmd_get_help(state->core->rcmd, state->core->config, pr_args, use_color);
+	char *help_msg = rz_cmd_get_help(state->core->rcmd, pr_args, use_color);
 	if (help_msg) {
 		rz_cons_printf("%s", help_msg);
 		free(help_msg);

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -1120,8 +1120,8 @@ static void print_child_help(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, size_t max
 }
 
 static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
-	bool scr_utf8 = rz_config_get_b(cmd->core->config,"scr.utf8");
-	bool scr_curvy = rz_config_get_b(cmd->core->config,"scr.utf8.curvy") && scr_utf8;
+	bool scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
+	bool scr_curvy = rz_config_get_b(cmd->core->config, "scr.utf8.curvy") && scr_utf8;
 
 	RzStrBuf *sb = rz_strbuf_new(NULL);
 	fill_usage_strbuf(cmd, sb, cd, use_color);
@@ -1179,7 +1179,7 @@ static void fill_argv_modes_help_strbuf(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd,
 	if (max_len - min_len > MAX_RIGHT_ALIGHNMENT) {
 		max_len = min_len + MAX_RIGHT_ALIGHNMENT;
 	}
-	bool scr_utf8 = rz_config_get_b(cmd->core->config,"scr.utf8");
+	bool scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
 	size_t i;
 	for (i = 0; i < RZ_ARRAY_SIZE(argv_modes); i++) {
 		if (cd->d.argv_modes_data.modes & argv_modes[i].mode) {
@@ -1492,7 +1492,7 @@ RZ_API bool rz_cmd_get_help_json(RzCmd *cmd, const RzCmdDesc *cd, PJ *j) {
  */
 RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_color, RzStrBuf *sb) {
 	rz_return_val_if_fail(cmd && cd && sb, false);
-	bool scr_utf8 = rz_config_get_b(cmd->core->config,"scr.utf8");
+	bool scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
 	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary, scr_utf8 ? "\xE2\x94\x82" : "|", false, MAX_RIGHT_ALIGHNMENT, use_color);
 	return true;
 }

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -1110,15 +1110,15 @@ static void do_print_child_help(RzCmd *cmd, RzStrBuf *sb, const RzCmdDesc *cd, c
 	rz_strbuf_appendf(sb, "%s\n", pal_reset);
 }
 
-static void print_child_help(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, size_t max_len,const char *vertical_line, bool use_color) {
+static void print_child_help(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, size_t max_len, const char *vertical_line, bool use_color) {
 	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary ? cd->help->summary : "", vertical_line, true, max_len, use_color);
 }
 
-static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, RzConfig *config,  bool use_color) {
+static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, RzConfig *config, bool use_color) {
 
 	bool scr_utf8 = config ? (strcmp(rz_config_get(config, "scr.utf8"), "true") == 0) : false;
 	bool scr_curvy = config ? (strcmp(rz_config_get(config, "scr.utf8.curvy"), "true") == 0) && scr_utf8 : false;
-	
+
 	RzStrBuf *sb = rz_strbuf_new(NULL);
 	fill_usage_strbuf(cmd, sb, cd, use_color);
 
@@ -1136,8 +1136,8 @@ static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, RzConfig *config,  bool u
 
 	rz_cmd_desc_children_foreach_idx(cd, it_cd, idx) {
 		RzCmdDesc *child = *(RzCmdDesc **)it_cd;
-		// Based on Config and Line order choses the vertical line shape 
-		const char * vertical_line  = (((idx == 0) && (scr_curvy == true)) ? "\xE2\x95\xAD" : (((idx == cd->children.v.len - 1) && (scr_curvy == true))? "\xE2\x95\xB0" : ( (scr_utf8 == true) ? "\xE2\x94\x82" : "|")));
+		// Based on Config and Line order choses the vertical line shape
+		const char *vertical_line = (((idx == 0) && (scr_curvy == true)) ? "\xE2\x95\xAD" : (((idx == cd->children.v.len - 1) && (scr_curvy == true)) ? "\xE2\x95\xB0" : ((scr_utf8 == true) ? "\xE2\x94\x82" : "|")));
 		// const char * vertical_line  = ((idx == 0) && (scr_curvy == true)) ? "\xE2\x95\xAD" : "|";
 		print_child_help(cmd, sb, child, max_len, vertical_line, use_color);
 	}

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -31,6 +31,11 @@
 #define MIN_SUMMARY_WIDTH    6
 #define MAX_RIGHT_ALIGHNMENT 20
 
+// Based on Config and Line order choses the vertical line shape
+static inline const char *get_vertical_line(int idx, int len, bool scr_curvy, bool scr_utf8) {
+	return (((idx == 0) && (scr_curvy == true)) ? "\xE2\x95\xAD" : (((idx == len - 1) && (scr_curvy == true)) ? "\xE2\x95\xB0" : ((scr_utf8 == true) ? "\xE2\x94\x82" : "|")));
+}
+
 // NOTE: this should be in sync with SPECIAL_CHARACTERS in
 //       rizin-shell-parser grammar, except for ", ' and
 //       whitespaces, because we let cmd_substitution_arg create
@@ -1136,10 +1141,7 @@ static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, RzConfig *config, bool us
 
 	rz_cmd_desc_children_foreach_idx(cd, it_cd, idx) {
 		RzCmdDesc *child = *(RzCmdDesc **)it_cd;
-		// Based on Config and Line order choses the vertical line shape
-		const char *vertical_line = (((idx == 0) && (scr_curvy == true)) ? "\xE2\x95\xAD" : (((idx == cd->children.v.len - 1) && (scr_curvy == true)) ? "\xE2\x95\xB0" : ((scr_utf8 == true) ? "\xE2\x94\x82" : "|")));
-		// const char * vertical_line  = ((idx == 0) && (scr_curvy == true)) ? "\xE2\x95\xAD" : "|";
-		print_child_help(cmd, sb, child, max_len, vertical_line, use_color);
+		print_child_help(cmd, sb, child, max_len, get_vertical_line(idx, cd->children.v.len, scr_curvy, scr_utf8), use_color);
 	}
 
 	bool details_filled = fill_details(cmd, cd, sb, use_color);

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -1119,10 +1119,9 @@ static void print_child_help(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, size_t max
 	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary ? cd->help->summary : "", vertical_line, true, max_len, use_color);
 }
 
-static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, RzConfig *config, bool use_color) {
-
-	bool scr_utf8 = config ? (strcmp(rz_config_get(config, "scr.utf8"), "true") == 0) : false;
-	bool scr_curvy = config ? (strcmp(rz_config_get(config, "scr.utf8.curvy"), "true") == 0) && scr_utf8 : false;
+static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
+	bool scr_utf8 = rz_config_get_b(cmd->core->config,"scr.utf8");
+	bool scr_curvy = rz_config_get_b(cmd->core->config,"scr.utf8.curvy") && scr_utf8;
 
 	RzStrBuf *sb = rz_strbuf_new(NULL);
 	fill_usage_strbuf(cmd, sb, cd, use_color);
@@ -1180,13 +1179,13 @@ static void fill_argv_modes_help_strbuf(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd,
 	if (max_len - min_len > MAX_RIGHT_ALIGHNMENT) {
 		max_len = min_len + MAX_RIGHT_ALIGHNMENT;
 	}
-
+	bool scr_utf8 = rz_config_get_b(cmd->core->config,"scr.utf8");
 	size_t i;
 	for (i = 0; i < RZ_ARRAY_SIZE(argv_modes); i++) {
 		if (cd->d.argv_modes_data.modes & argv_modes[i].mode) {
 			char *name = rz_str_newf("%s%s", cd->name, argv_modes[i].suffix);
 			char *summary = rz_str_newf("%s%s", cd->help->summary, argv_modes[i].summary_suffix);
-			do_print_child_help(cmd, sb, cd, name, summary, "|", false, max_len, use_color);
+			do_print_child_help(cmd, sb, cd, name, summary, scr_utf8 ? "\xE2\x94\x82" : "|", false, max_len, use_color);
 			free(name);
 			free(summary);
 		}
@@ -1329,15 +1328,15 @@ static char *fake_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
 	return argv_get_help(cmd, cd, 2, use_color);
 }
 
-static char *get_help(RzCmd *cmd, RzCmdDesc *cd, RzConfig *config, const char *cmdid, RzCmdParsedArgs *args, bool use_color, size_t detail) {
+static char *get_help(RzCmd *cmd, RzCmdDesc *cd, const char *cmdid, RzCmdParsedArgs *args, bool use_color, size_t detail) {
 	switch (cd->type) {
 	case RZ_CMD_DESC_TYPE_GROUP:
 		if (cd->d.group_data.exec_cd && (detail > 1 || (detail == 1 && strcmp(cmdid, cd->name)))) {
-			return get_help(cmd, cd->d.group_data.exec_cd, config, cmdid, args, use_color, detail);
+			return get_help(cmd, cd->d.group_data.exec_cd, cmdid, args, use_color, detail);
 		}
 		if (detail == 1) {
 			// show the group help only when doing <cmd>?
-			return group_get_help(cmd, cd, config, use_color);
+			return group_get_help(cmd, cd, use_color);
 		}
 		return argv_get_help(cmd, cd, detail, use_color);
 	case RZ_CMD_DESC_TYPE_ARGV:
@@ -1493,11 +1492,12 @@ RZ_API bool rz_cmd_get_help_json(RzCmd *cmd, const RzCmdDesc *cd, PJ *j) {
  */
 RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_color, RzStrBuf *sb) {
 	rz_return_val_if_fail(cmd && cd && sb, false);
-	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary, "|", false, MAX_RIGHT_ALIGHNMENT, use_color);
+	bool scr_utf8 = rz_config_get_b(cmd->core->config,"scr.utf8");
+	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary, scr_utf8 ? "\xE2\x94\x82" : "|", false, MAX_RIGHT_ALIGHNMENT, use_color);
 	return true;
 }
 
-RZ_API char *rz_cmd_get_help(RzCmd *cmd, RzConfig *config, RzCmdParsedArgs *args, bool use_color) {
+RZ_API char *rz_cmd_get_help(RzCmd *cmd, RzCmdParsedArgs *args, bool use_color) {
 	char *cmdid = rz_str_dup(rz_cmd_parsed_args_cmd(args));
 	if (!cmdid) {
 		return NULL;
@@ -1521,7 +1521,7 @@ RZ_API char *rz_cmd_get_help(RzCmd *cmd, RzConfig *config, RzCmdParsedArgs *args
 		goto err;
 	}
 
-	res = get_help(cmd, cd, config, cmdid, args, use_color, detail);
+	res = get_help(cmd, cd, cmdid, args, use_color, detail);
 err:
 	free(cmdid);
 	return res;

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -1070,7 +1070,7 @@ static void update_minmax_len(RzCmdDesc *cd, size_t *max_len, size_t *min_len, b
 	*min_len = val < *min_len ? val : *min_len;
 }
 
-static void do_print_child_help(RzCmd *cmd, RzStrBuf *sb, const RzCmdDesc *cd, const char *name, const char *summary, bool show_children, size_t max_len, bool use_color) {
+static void do_print_child_help(RzCmd *cmd, RzStrBuf *sb, const RzCmdDesc *cd, const char *name, const char *summary, const char *vertical_line, bool show_children, size_t max_len, bool use_color) {
 	size_t str_len = calc_padding_len(cd, name, show_children);
 	int padding = str_len < max_len ? max_len - str_len : 0;
 	const char *pal_args_color = "",
@@ -1089,7 +1089,7 @@ static void do_print_child_help(RzCmd *cmd, RzStrBuf *sb, const RzCmdDesc *cd, c
 	}
 
 	size_t columns = 0;
-	columns += strbuf_append_calc(sb, "| ");
+	columns += strbuf_append_calc(sb, vertical_line);
 	rz_strbuf_append(sb, pal_input_color);
 	columns += strbuf_append_calc(sb, name);
 	if (show_children && show_children_shortcut(cd)) {
@@ -1110,15 +1110,20 @@ static void do_print_child_help(RzCmd *cmd, RzStrBuf *sb, const RzCmdDesc *cd, c
 	rz_strbuf_appendf(sb, "%s\n", pal_reset);
 }
 
-static void print_child_help(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, size_t max_len, bool use_color) {
-	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary ? cd->help->summary : "", true, max_len, use_color);
+static void print_child_help(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, size_t max_len,const char *vertical_line, bool use_color) {
+	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary ? cd->help->summary : "", vertical_line, true, max_len, use_color);
 }
 
-static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
+static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, RzConfig *config,  bool use_color) {
+
+	bool scr_utf8 = config ? (strcmp(rz_config_get(config, "scr.utf8"), "true") == 0) : false;
+	bool scr_curvy = config ? (strcmp(rz_config_get(config, "scr.utf8.curvy"), "true") == 0) && scr_utf8 : false;
+	
 	RzStrBuf *sb = rz_strbuf_new(NULL);
 	fill_usage_strbuf(cmd, sb, cd, use_color);
 
 	void **it_cd;
+	int idx;
 	size_t max_len = 0, min_len = SIZE_MAX;
 
 	rz_cmd_desc_children_foreach(cd, it_cd) {
@@ -1129,9 +1134,12 @@ static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
 		max_len = min_len + MAX_RIGHT_ALIGHNMENT;
 	}
 
-	rz_cmd_desc_children_foreach(cd, it_cd) {
+	rz_cmd_desc_children_foreach_idx(cd, it_cd, idx) {
 		RzCmdDesc *child = *(RzCmdDesc **)it_cd;
-		print_child_help(cmd, sb, child, max_len, use_color);
+		// Based on Config and Line order choses the vertical line shape 
+		const char * vertical_line  = (((idx == 0) && (scr_curvy == true)) ? "\xE2\x95\xAD" : (((idx == cd->children.v.len - 1) && (scr_curvy == true))? "\xE2\x95\xB0" : ( (scr_utf8 == true) ? "\xE2\x94\x82" : "|")));
+		// const char * vertical_line  = ((idx == 0) && (scr_curvy == true)) ? "\xE2\x95\xAD" : "|";
+		print_child_help(cmd, sb, child, max_len, vertical_line, use_color);
 	}
 
 	bool details_filled = fill_details(cmd, cd, sb, use_color);
@@ -1176,7 +1184,7 @@ static void fill_argv_modes_help_strbuf(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd,
 		if (cd->d.argv_modes_data.modes & argv_modes[i].mode) {
 			char *name = rz_str_newf("%s%s", cd->name, argv_modes[i].suffix);
 			char *summary = rz_str_newf("%s%s", cd->help->summary, argv_modes[i].summary_suffix);
-			do_print_child_help(cmd, sb, cd, name, summary, false, max_len, use_color);
+			do_print_child_help(cmd, sb, cd, name, summary, "|", false, max_len, use_color);
 			free(name);
 			free(summary);
 		}
@@ -1319,15 +1327,15 @@ static char *fake_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
 	return argv_get_help(cmd, cd, 2, use_color);
 }
 
-static char *get_help(RzCmd *cmd, RzCmdDesc *cd, const char *cmdid, RzCmdParsedArgs *args, bool use_color, size_t detail) {
+static char *get_help(RzCmd *cmd, RzCmdDesc *cd, RzConfig *config, const char *cmdid, RzCmdParsedArgs *args, bool use_color, size_t detail) {
 	switch (cd->type) {
 	case RZ_CMD_DESC_TYPE_GROUP:
 		if (cd->d.group_data.exec_cd && (detail > 1 || (detail == 1 && strcmp(cmdid, cd->name)))) {
-			return get_help(cmd, cd->d.group_data.exec_cd, cmdid, args, use_color, detail);
+			return get_help(cmd, cd->d.group_data.exec_cd, config, cmdid, args, use_color, detail);
 		}
 		if (detail == 1) {
 			// show the group help only when doing <cmd>?
-			return group_get_help(cmd, cd, use_color);
+			return group_get_help(cmd, cd, config, use_color);
 		}
 		return argv_get_help(cmd, cd, detail, use_color);
 	case RZ_CMD_DESC_TYPE_ARGV:
@@ -1483,11 +1491,11 @@ RZ_API bool rz_cmd_get_help_json(RzCmd *cmd, const RzCmdDesc *cd, PJ *j) {
  */
 RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_color, RzStrBuf *sb) {
 	rz_return_val_if_fail(cmd && cd && sb, false);
-	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary, false, MAX_RIGHT_ALIGHNMENT, use_color);
+	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary, "|", false, MAX_RIGHT_ALIGHNMENT, use_color);
 	return true;
 }
 
-RZ_API char *rz_cmd_get_help(RzCmd *cmd, RzCmdParsedArgs *args, bool use_color) {
+RZ_API char *rz_cmd_get_help(RzCmd *cmd, RzConfig *config, RzCmdParsedArgs *args, bool use_color) {
 	char *cmdid = rz_str_dup(rz_cmd_parsed_args_cmd(args));
 	if (!cmdid) {
 		return NULL;
@@ -1511,7 +1519,7 @@ RZ_API char *rz_cmd_get_help(RzCmd *cmd, RzCmdParsedArgs *args, bool use_color) 
 		goto err;
 	}
 
-	res = get_help(cmd, cd, cmdid, args, use_color, detail);
+	res = get_help(cmd, cd, config, cmdid, args, use_color, detail);
 err:
 	free(cmdid);
 	return res;

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -33,7 +33,7 @@
 
 // Based on Config and Line order choses the vertical line shape
 static inline const char *get_vertical_line(int idx, int len, bool scr_curvy, bool scr_utf8) {
-	return (((idx == 0) && (scr_curvy == true)) ? "\xE2\x95\xAD" : (((idx == len - 1) && (scr_curvy == true)) ? "\xE2\x95\xB0" : ((scr_utf8 == true) ? "\xE2\x94\x82" : "|")));
+	return (((idx == 0) && (scr_curvy == true)) ? RUNE_CURVE_CORNER_TL : (((idx == len - 1) && (scr_curvy == true)) ? RUNE_CURVE_CORNER_BL : ((scr_utf8 == true) ? RUNE_LINE_VERT : "|")));
 }
 
 // NOTE: this should be in sync with SPECIAL_CHARACTERS in
@@ -1185,7 +1185,7 @@ static void fill_argv_modes_help_strbuf(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd,
 		if (cd->d.argv_modes_data.modes & argv_modes[i].mode) {
 			char *name = rz_str_newf("%s%s", cd->name, argv_modes[i].suffix);
 			char *summary = rz_str_newf("%s%s", cd->help->summary, argv_modes[i].summary_suffix);
-			do_print_child_help(cmd, sb, cd, name, summary, scr_utf8 ? "\xE2\x94\x82" : "|", false, max_len, use_color);
+			do_print_child_help(cmd, sb, cd, name, summary, scr_utf8 ? RUNE_LINE_VERT : "|", false, max_len, use_color);
 			free(name);
 			free(summary);
 		}
@@ -1493,7 +1493,7 @@ RZ_API bool rz_cmd_get_help_json(RzCmd *cmd, const RzCmdDesc *cd, PJ *j) {
 RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_color, RzStrBuf *sb) {
 	rz_return_val_if_fail(cmd && cd && sb, false);
 	bool scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
-	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary, scr_utf8 ? "\xE2\x94\x82" : "|", false, MAX_RIGHT_ALIGHNMENT, use_color);
+	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary, scr_utf8 ? RUNE_LINE_VERT : "|", false, MAX_RIGHT_ALIGHNMENT, use_color);
 	return true;
 }
 

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -558,8 +558,8 @@ RZ_API bool rz_cmd_desc_remove(RzCmd *cmd, RzCmdDesc *cd);
 RZ_API void rz_cmd_foreach_cmdname(RzCmd *cmd, RzCmdDesc *begin, RzCmdForeachNameCb cb, void *user);
 RZ_API const RzCmdDescArg *rz_cmd_desc_get_arg(const RzCmdDesc *cd, size_t i);
 
-#define rz_cmd_desc_children_foreach(root, it_cd) rz_pvector_foreach (&root->children, it_cd)
-#define rz_cmd_desc_children_foreach_idx(root, it_cd, idx) rz_pvector_enumerate(&root->children, it_cd, idx)
+#define rz_cmd_desc_children_foreach(root, it_cd)          rz_pvector_foreach (&root->children, it_cd)
+#define rz_cmd_desc_children_foreach_idx(root, it_cd, idx) rz_pvector_enumerate (&root->children, it_cd, idx)
 
 RZ_API void rz_cmd_desc_details_free(RzCmdDescDetail *details);
 

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -512,7 +512,7 @@ RZ_API RzCmdStatus rz_cmd_call_parsed_args(RzCmd *cmd, RzCmdParsedArgs *args);
 RZ_API RzCmdDesc *rz_cmd_get_root(RzCmd *cmd);
 RZ_API RzCmdDesc *rz_cmd_get_desc(RzCmd *cmd, const char *cmd_identifier);
 RZ_API RzCmdDesc *rz_cmd_get_desc_best(RzCmd *cmd, const char *cmd_identifier);
-RZ_API char *rz_cmd_get_help(RzCmd *cmd, RzConfig *config, RzCmdParsedArgs *args, bool use_color);
+RZ_API char *rz_cmd_get_help(RzCmd *cmd, RzCmdParsedArgs *args, bool use_color);
 RZ_API bool rz_cmd_get_help_json(RzCmd *cmd, const RzCmdDesc *cd, PJ *j);
 RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_color, RzStrBuf *sb);
 

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -4,6 +4,7 @@
 #include <rz_types.h>
 #include <rz_util.h>
 #include <rz_bind.h>
+#include "rz_config.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -511,7 +512,7 @@ RZ_API RzCmdStatus rz_cmd_call_parsed_args(RzCmd *cmd, RzCmdParsedArgs *args);
 RZ_API RzCmdDesc *rz_cmd_get_root(RzCmd *cmd);
 RZ_API RzCmdDesc *rz_cmd_get_desc(RzCmd *cmd, const char *cmd_identifier);
 RZ_API RzCmdDesc *rz_cmd_get_desc_best(RzCmd *cmd, const char *cmd_identifier);
-RZ_API char *rz_cmd_get_help(RzCmd *cmd, RzCmdParsedArgs *args, bool use_color);
+RZ_API char *rz_cmd_get_help(RzCmd *cmd, RzConfig *config, RzCmdParsedArgs *args, bool use_color);
 RZ_API bool rz_cmd_get_help_json(RzCmd *cmd, const RzCmdDesc *cd, PJ *j);
 RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_color, RzStrBuf *sb);
 
@@ -558,6 +559,7 @@ RZ_API void rz_cmd_foreach_cmdname(RzCmd *cmd, RzCmdDesc *begin, RzCmdForeachNam
 RZ_API const RzCmdDescArg *rz_cmd_desc_get_arg(const RzCmdDesc *cd, size_t i);
 
 #define rz_cmd_desc_children_foreach(root, it_cd) rz_pvector_foreach (&root->children, it_cd)
+#define rz_cmd_desc_children_foreach_idx(root, it_cd, idx) rz_pvector_enumerate(&root->children, it_cd, idx)
 
 RZ_API void rz_cmd_desc_details_free(RzCmdDescDetail *details);
 

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -159,13 +159,13 @@ bool test_cmd_descriptor_group(void) {
 	mu_assert_null(rz_cmd_get_desc(cmd, "afjb"), "nothing should be found for non-existing cmd");
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("a??");
-	char *h = rz_cmd_get_help(cmd, NULL, pa, false);
+	char *h = rz_cmd_get_help(cmd, pa, false);
 	mu_assert_streq(h, "Usage: a   # a exec help\n", "detailed help for a is a_exec_help");
 	rz_cmd_parsed_args_free(pa);
 	free(h);
 
 	pa = rz_cmd_parsed_args_newcmd("a?");
-	h = rz_cmd_get_help(cmd, NULL, pa, false);
+	h = rz_cmd_get_help(cmd, pa, false);
 	const char *exp_h = "Usage: a[b]   # a group help\n"
 			    "| a  # a exec help\n"
 			    "| ab # ab help\n";
@@ -350,7 +350,7 @@ bool test_cmd_help(void) {
 				 "| pd <num>                 # pd summary\n"
 				 "| px <verylongarg_str_num> # px summary\n";
 	RzCmdParsedArgs *a = rz_cmd_parsed_args_newcmd("p?");
-	char *h = rz_cmd_get_help(cmd, NULL, NULL, false);
+	char *h = rz_cmd_get_help(cmd, NULL, false);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, p_help_exp, "wrong help for p?");
 	free(h);
@@ -363,14 +363,14 @@ bool test_cmd_help(void) {
 				       "Examples:\n"
 				       "| pd 10 # print 10 disassembled instructions\n";
 	a = rz_cmd_parsed_args_newcmd("pd??");
-	h = rz_cmd_get_help(cmd, NULL, NULL, false);
+	h = rz_cmd_get_help(cmd, NULL, false);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, pd_long_help_exp, "wrong help for pd??");
 	free(h);
 	rz_cmd_parsed_args_free(a);
 
 	a = rz_cmd_parsed_args_newcmd("pd?");
-	h = rz_cmd_get_help(cmd, NULL, NULL, false);
+	h = rz_cmd_get_help(cmd, NULL, false);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, pd_long_help_exp, "wrong help for pd?");
 	free(h);
@@ -415,7 +415,7 @@ bool test_cmd_group_help(void) {
 				 "| p        # p summary\n"
 				 "| pd <num> # pd summary\n";
 	RzCmdParsedArgs *a = rz_cmd_parsed_args_newcmd("p?");
-	char *h = rz_cmd_get_help(cmd, NULL, NULL, false);
+	char *h = rz_cmd_get_help(cmd, NULL, false);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, p_help_exp, "wrong help for p?");
 	free(h);
@@ -460,7 +460,7 @@ bool test_cmd_group_exec_help(void) {
 				       "| p        # p summary\n"
 				       "| pd <num> # pd summary\n";
 	RzCmdParsedArgs *a = rz_cmd_parsed_args_newcmd("p?");
-	char *h = rz_cmd_get_help(cmd, NULL, NULL, false);
+	char *h = rz_cmd_get_help(cmd, NULL, false);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, p_group_help_exp, "wrong help for p?");
 	free(h);
@@ -470,7 +470,7 @@ bool test_cmd_group_exec_help(void) {
 				 "\n"
 				 "This is p-command description\n";
 	a = rz_cmd_parsed_args_newcmd("p??");
-	h = rz_cmd_get_help(cmd, NULL, NULL, false);
+	h = rz_cmd_get_help(cmd, NULL, false);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, p_help_exp, "wrong help for p??");
 	free(h);
@@ -480,10 +480,10 @@ bool test_cmd_group_exec_help(void) {
 				  "\n"
 				  "pd long description\n";
 	a = rz_cmd_parsed_args_newcmd("pd?");
-	char *h1 = rz_cmd_get_help(cmd, NULL, NULL, false);
+	char *h1 = rz_cmd_get_help(cmd, NULL, false);
 	rz_cmd_parsed_args_free(a);
 	a = rz_cmd_parsed_args_newcmd("pd??");
-	char *h2 = rz_cmd_get_help(cmd, NULL, NULL, false);
+	char *h2 = rz_cmd_get_help(cmd, NULL, false);
 	rz_cmd_parsed_args_free(a);
 	mu_assert_streq(h1, h2, "pd? should be the same as pd?? because it is a terminal command");
 	mu_assert_streq(h1, pd_help_exp, "pd?/pd?? should print full help");
@@ -540,7 +540,7 @@ bool test_cmd_args(void) {
 	mu_assert_ptreq(rz_cmd_get_desc(cmd, "x"), x_cd, "x is found");
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("x??");
-	char *h = rz_cmd_get_help(cmd, NULL, pa, false);
+	char *h = rz_cmd_get_help(cmd, pa, false);
 	mu_assert_streq(h, "Usage: x <c> [<from> <to> [<n>=5]]   # x summary\n", "arguments are considered");
 	rz_cmd_parsed_args_free(pa);
 	free(h);
@@ -570,7 +570,7 @@ bool test_cmd_argv_modes(void) {
 	mu_assert_null(rz_cmd_get_desc(cmd, "z*"), "z* was not defined");
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("?");
-	char *h = rz_cmd_get_help(cmd, NULL, pa, false);
+	char *h = rz_cmd_get_help(cmd, pa, false);
 	char *exp_h = "Usage: [.][times][cmd][~grep][@[@iter]addr][|>pipe] ; ...\n"
 		      "| z[jqJ] # z summary\n";
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the help");
@@ -583,13 +583,13 @@ bool test_cmd_argv_modes(void) {
 		"| zq      # z summary (quiet mode)\n"
 		"| zJ      # z summary (verbose JSON mode)\n";
 	pa = rz_cmd_parsed_args_newcmd("z?");
-	h = rz_cmd_get_help(cmd, NULL, pa, false);
+	h = rz_cmd_get_help(cmd, pa, false);
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the sub help");
 	free(h);
 	rz_cmd_parsed_args_free(pa);
 
 	pa = rz_cmd_parsed_args_newcmd("z??");
-	h = rz_cmd_get_help(cmd, NULL, pa, false);
+	h = rz_cmd_get_help(cmd, pa, false);
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the sub help");
 	free(h);
 	rz_cmd_parsed_args_free(pa);
@@ -625,7 +625,7 @@ bool test_cmd_argv_state(void) {
 	mu_assert_null(rz_cmd_get_desc(cmd, "z*"), "z* was not defined");
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("?");
-	char *h = rz_cmd_get_help(cmd, NULL, pa, false);
+	char *h = rz_cmd_get_help(cmd, pa, false);
 	char *exp_h = "Usage: [.][times][cmd][~grep][@[@iter]addr][|>pipe] ; ...\n"
 		      "| z[jqJ] # group summary\n";
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the help");
@@ -633,7 +633,7 @@ bool test_cmd_argv_state(void) {
 	rz_cmd_parsed_args_free(pa);
 
 	pa = rz_cmd_parsed_args_newcmd("z?");
-	h = rz_cmd_get_help(cmd, NULL, pa, false);
+	h = rz_cmd_get_help(cmd, pa, false);
 	exp_h = "Usage: z[jqJ]   # group summary\n"
 		"| z[jqJ] # z summary\n";
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the sub help");
@@ -673,7 +673,7 @@ bool test_cmd_group_argv_modes(void) {
 	mu_assert_ptreq(rz_cmd_get_desc(cmd, "zd"), zd_cd, "zd is handled by zd");
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("?");
-	char *h = rz_cmd_get_help(cmd, NULL, pa, false);
+	char *h = rz_cmd_get_help(cmd, pa, false);
 	char *exp_h = "Usage: [.][times][cmd][~grep][@[@iter]addr][|>pipe] ; ...\n"
 		      "| z[jqd] # z group summary\n";
 	mu_assert_streq(h, exp_h, "zd is considered in the help");
@@ -681,7 +681,7 @@ bool test_cmd_group_argv_modes(void) {
 	rz_cmd_parsed_args_free(pa);
 
 	pa = rz_cmd_parsed_args_newcmd("z?");
-	h = rz_cmd_get_help(cmd, NULL, pa, false);
+	h = rz_cmd_get_help(cmd, pa, false);
 	exp_h = "Usage: z[jqd]   # z group summary\n"
 		"| z[jq] # z summary\n"
 		"| zd    # fake help\n";
@@ -965,7 +965,7 @@ bool test_parent_details(void) {
 	rz_cmd_desc_argv_new(cmd, z_cd, "zx", x_array_handler, &zx_help);
 
 	RzCmdParsedArgs *args = rz_cmd_parsed_args_new("zx??", 0, NULL);
-	char *h = rz_cmd_get_help(cmd, NULL, args, false);
+	char *h = rz_cmd_get_help(cmd, args, false);
 	mu_assert_strcontains(h, "Examples", "zx help should include examples from parent z");
 	mu_assert_strcontains(h, "comment", "zx help should include examples from parent z");
 	free(h);
@@ -1239,7 +1239,7 @@ bool test_default_mode(void) {
 	rz_cmd_parsed_args_free(pa);
 
 	pa = rz_cmd_parsed_args_new("x?", 0, NULL);
-	char *h = rz_cmd_get_help(cmd, NULL, pa, false);
+	char *h = rz_cmd_get_help(cmd, pa, false);
 	mu_assert_strcontains(h, "x[jqJ]   # x summary (JSON mode)", "x help should contain the default=json mode");
 	mu_assert_strcontains(h, "xj      # x summary (JSON mode)", "x help should contain the json mode");
 	mu_assert_strcontains(h, "xq      # x summary (quiet mode)", "x help should contain the quiet mode");
@@ -1276,7 +1276,7 @@ bool test_details_cb(void) {
 	rz_cmd_desc_argv_modes_new(cmd, root, "z", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_LONG_JSON, z_modes_handler, &z_help);
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_new("z?", 0, NULL);
-	char *h = rz_cmd_get_help(cmd, NULL, pa, false);
+	char *h = rz_cmd_get_help(cmd, pa, false);
 	mu_assert_strcontains(h, "# dynamically generated detail", "z help should contain result of the details_cb");
 	mu_assert_strcontains(h, "Examples 2", "z help should contain result of the details_cb 2");
 	free(h);

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -159,13 +159,13 @@ bool test_cmd_descriptor_group(void) {
 	mu_assert_null(rz_cmd_get_desc(cmd, "afjb"), "nothing should be found for non-existing cmd");
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("a??");
-	char *h = rz_cmd_get_help(cmd, pa, false);
+	char *h = rz_cmd_get_help(cmd, NULL, pa, false);
 	mu_assert_streq(h, "Usage: a   # a exec help\n", "detailed help for a is a_exec_help");
 	rz_cmd_parsed_args_free(pa);
 	free(h);
 
 	pa = rz_cmd_parsed_args_newcmd("a?");
-	h = rz_cmd_get_help(cmd, pa, false);
+	h = rz_cmd_get_help(cmd, NULL, pa, false);
 	const char *exp_h = "Usage: a[b]   # a group help\n"
 			    "| a  # a exec help\n"
 			    "| ab # ab help\n";
@@ -350,7 +350,7 @@ bool test_cmd_help(void) {
 				 "| pd <num>                 # pd summary\n"
 				 "| px <verylongarg_str_num> # px summary\n";
 	RzCmdParsedArgs *a = rz_cmd_parsed_args_newcmd("p?");
-	char *h = rz_cmd_get_help(cmd, a, false);
+	char *h = rz_cmd_get_help(cmd, NULL, NULL, false);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, p_help_exp, "wrong help for p?");
 	free(h);
@@ -363,14 +363,14 @@ bool test_cmd_help(void) {
 				       "Examples:\n"
 				       "| pd 10 # print 10 disassembled instructions\n";
 	a = rz_cmd_parsed_args_newcmd("pd??");
-	h = rz_cmd_get_help(cmd, a, false);
+	h = rz_cmd_get_help(cmd, NULL, NULL, false);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, pd_long_help_exp, "wrong help for pd??");
 	free(h);
 	rz_cmd_parsed_args_free(a);
 
 	a = rz_cmd_parsed_args_newcmd("pd?");
-	h = rz_cmd_get_help(cmd, a, false);
+	h = rz_cmd_get_help(cmd, NULL, NULL, false);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, pd_long_help_exp, "wrong help for pd?");
 	free(h);
@@ -415,7 +415,7 @@ bool test_cmd_group_help(void) {
 				 "| p        # p summary\n"
 				 "| pd <num> # pd summary\n";
 	RzCmdParsedArgs *a = rz_cmd_parsed_args_newcmd("p?");
-	char *h = rz_cmd_get_help(cmd, a, false);
+	char *h = rz_cmd_get_help(cmd, NULL, NULL, false);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, p_help_exp, "wrong help for p?");
 	free(h);
@@ -460,7 +460,7 @@ bool test_cmd_group_exec_help(void) {
 				       "| p        # p summary\n"
 				       "| pd <num> # pd summary\n";
 	RzCmdParsedArgs *a = rz_cmd_parsed_args_newcmd("p?");
-	char *h = rz_cmd_get_help(cmd, a, false);
+	char *h = rz_cmd_get_help(cmd, NULL, NULL, false);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, p_group_help_exp, "wrong help for p?");
 	free(h);
@@ -470,7 +470,7 @@ bool test_cmd_group_exec_help(void) {
 				 "\n"
 				 "This is p-command description\n";
 	a = rz_cmd_parsed_args_newcmd("p??");
-	h = rz_cmd_get_help(cmd, a, false);
+	h = rz_cmd_get_help(cmd, NULL, NULL, false);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, p_help_exp, "wrong help for p??");
 	free(h);
@@ -480,10 +480,10 @@ bool test_cmd_group_exec_help(void) {
 				  "\n"
 				  "pd long description\n";
 	a = rz_cmd_parsed_args_newcmd("pd?");
-	char *h1 = rz_cmd_get_help(cmd, a, false);
+	char *h1 = rz_cmd_get_help(cmd, NULL, NULL, false);
 	rz_cmd_parsed_args_free(a);
 	a = rz_cmd_parsed_args_newcmd("pd??");
-	char *h2 = rz_cmd_get_help(cmd, a, false);
+	char *h2 = rz_cmd_get_help(cmd, NULL, NULL, false);
 	rz_cmd_parsed_args_free(a);
 	mu_assert_streq(h1, h2, "pd? should be the same as pd?? because it is a terminal command");
 	mu_assert_streq(h1, pd_help_exp, "pd?/pd?? should print full help");
@@ -540,7 +540,7 @@ bool test_cmd_args(void) {
 	mu_assert_ptreq(rz_cmd_get_desc(cmd, "x"), x_cd, "x is found");
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("x??");
-	char *h = rz_cmd_get_help(cmd, pa, false);
+	char *h = rz_cmd_get_help(cmd, NULL, pa, false);
 	mu_assert_streq(h, "Usage: x <c> [<from> <to> [<n>=5]]   # x summary\n", "arguments are considered");
 	rz_cmd_parsed_args_free(pa);
 	free(h);
@@ -570,7 +570,7 @@ bool test_cmd_argv_modes(void) {
 	mu_assert_null(rz_cmd_get_desc(cmd, "z*"), "z* was not defined");
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("?");
-	char *h = rz_cmd_get_help(cmd, pa, false);
+	char *h = rz_cmd_get_help(cmd, NULL, pa, false);
 	char *exp_h = "Usage: [.][times][cmd][~grep][@[@iter]addr][|>pipe] ; ...\n"
 		      "| z[jqJ] # z summary\n";
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the help");
@@ -583,13 +583,13 @@ bool test_cmd_argv_modes(void) {
 		"| zq      # z summary (quiet mode)\n"
 		"| zJ      # z summary (verbose JSON mode)\n";
 	pa = rz_cmd_parsed_args_newcmd("z?");
-	h = rz_cmd_get_help(cmd, pa, false);
+	h = rz_cmd_get_help(cmd, NULL, pa, false);
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the sub help");
 	free(h);
 	rz_cmd_parsed_args_free(pa);
 
 	pa = rz_cmd_parsed_args_newcmd("z??");
-	h = rz_cmd_get_help(cmd, pa, false);
+	h = rz_cmd_get_help(cmd, NULL, pa, false);
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the sub help");
 	free(h);
 	rz_cmd_parsed_args_free(pa);
@@ -625,7 +625,7 @@ bool test_cmd_argv_state(void) {
 	mu_assert_null(rz_cmd_get_desc(cmd, "z*"), "z* was not defined");
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("?");
-	char *h = rz_cmd_get_help(cmd, pa, false);
+	char *h = rz_cmd_get_help(cmd, NULL, pa, false);
 	char *exp_h = "Usage: [.][times][cmd][~grep][@[@iter]addr][|>pipe] ; ...\n"
 		      "| z[jqJ] # group summary\n";
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the help");
@@ -633,7 +633,7 @@ bool test_cmd_argv_state(void) {
 	rz_cmd_parsed_args_free(pa);
 
 	pa = rz_cmd_parsed_args_newcmd("z?");
-	h = rz_cmd_get_help(cmd, pa, false);
+	h = rz_cmd_get_help(cmd, NULL, pa, false);
 	exp_h = "Usage: z[jqJ]   # group summary\n"
 		"| z[jqJ] # z summary\n";
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the sub help");
@@ -673,7 +673,7 @@ bool test_cmd_group_argv_modes(void) {
 	mu_assert_ptreq(rz_cmd_get_desc(cmd, "zd"), zd_cd, "zd is handled by zd");
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("?");
-	char *h = rz_cmd_get_help(cmd, pa, false);
+	char *h = rz_cmd_get_help(cmd, NULL, pa, false);
 	char *exp_h = "Usage: [.][times][cmd][~grep][@[@iter]addr][|>pipe] ; ...\n"
 		      "| z[jqd] # z group summary\n";
 	mu_assert_streq(h, exp_h, "zd is considered in the help");
@@ -681,7 +681,7 @@ bool test_cmd_group_argv_modes(void) {
 	rz_cmd_parsed_args_free(pa);
 
 	pa = rz_cmd_parsed_args_newcmd("z?");
-	h = rz_cmd_get_help(cmd, pa, false);
+	h = rz_cmd_get_help(cmd, NULL, pa, false);
 	exp_h = "Usage: z[jqd]   # z group summary\n"
 		"| z[jq] # z summary\n"
 		"| zd    # fake help\n";
@@ -965,7 +965,7 @@ bool test_parent_details(void) {
 	rz_cmd_desc_argv_new(cmd, z_cd, "zx", x_array_handler, &zx_help);
 
 	RzCmdParsedArgs *args = rz_cmd_parsed_args_new("zx??", 0, NULL);
-	char *h = rz_cmd_get_help(cmd, args, false);
+	char *h = rz_cmd_get_help(cmd, NULL, args, false);
 	mu_assert_strcontains(h, "Examples", "zx help should include examples from parent z");
 	mu_assert_strcontains(h, "comment", "zx help should include examples from parent z");
 	free(h);
@@ -1239,7 +1239,7 @@ bool test_default_mode(void) {
 	rz_cmd_parsed_args_free(pa);
 
 	pa = rz_cmd_parsed_args_new("x?", 0, NULL);
-	char *h = rz_cmd_get_help(cmd, pa, false);
+	char *h = rz_cmd_get_help(cmd, NULL, pa, false);
 	mu_assert_strcontains(h, "x[jqJ]   # x summary (JSON mode)", "x help should contain the default=json mode");
 	mu_assert_strcontains(h, "xj      # x summary (JSON mode)", "x help should contain the json mode");
 	mu_assert_strcontains(h, "xq      # x summary (quiet mode)", "x help should contain the quiet mode");
@@ -1276,7 +1276,7 @@ bool test_details_cb(void) {
 	rz_cmd_desc_argv_modes_new(cmd, root, "z", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_LONG_JSON, z_modes_handler, &z_help);
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_new("z?", 0, NULL);
-	char *h = rz_cmd_get_help(cmd, pa, false);
+	char *h = rz_cmd_get_help(cmd, NULL, pa, false);
 	mu_assert_strcontains(h, "# dynamically generated detail", "z help should contain result of the details_cb");
 	mu_assert_strcontains(h, "Examples 2", "z help should contain result of the details_cb 2");
 	free(h);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**
for adding this change in `help` section for commands , changes in the following files are made:
- `librz/core/cmd/cmd.c` : passing configuration to `rz_cmd_get_help` function.
- `librz/core/cmd/cmd_api.c`: adding some logic to handle our feature based on the configuration
- `librz/include/rz_cmd.h`: change declaration of `rz_cmd_get_help` function.
- `test/unit/test_cmd.c`

I tried to do the minimal change within the code, there is an ability to extend to more configurations/more shapes with justing changing the `get_vertical_line` inline fucntion.
...

**Test plan**
- when `utf8` is enabled

![Screenshot from 2025-03-23 02-07-33](https://github.com/user-attachments/assets/8871fb28-f206-4c85-b7e4-0fb2ed6e8f43)

- `utf8` and `utf8.curvy` are enabled

![Screenshot from 2025-03-23 02-07-58](https://github.com/user-attachments/assets/0cbeda9a-aa18-4074-bc61-1d5508f39789)
- `utf8` is disabled

![Screenshot from 2025-03-23 02-08-11](https://github.com/user-attachments/assets/51ae046c-489d-4e56-8eb2-d1f7c394963b)

...

**Closing issues**

closes #4965 

...
