### PR TITLE
Feat unicode lines

### DIFF
--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -33,7 +33,7 @@
 
 // Based on Config and Line order choses the vertical line shape
 static inline const char *get_vertical_line(int idx, int len, bool scr_curvy, bool scr_utf8) {
-	return (((idx == 0) && (scr_curvy == true)) ? RUNE_CURVE_CORNER_TL : (((idx == len - 1) && (scr_curvy == true)) ? RUNE_CURVE_CORNER_BL : ((scr_utf8 == true) ? RUNE_LINE_VERT : "|")));
+	return (((idx == 0) && (scr_curvy == true)) ? RUNE_CURVE_CORNER_TL : (((idx == len - 1) && (scr_curvy == true)) ? RUNE_CURVE_CORNER_BL : ((scr_utf8 == true) ? RUNE_LINE_VERT : "| ")));
 }
 
 // NOTE: this should be in sync with SPECIAL_CHARACTERS in
@@ -1120,8 +1120,8 @@ static void print_child_help(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, size_t max
 }
 
 static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
-	bool scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
-	bool scr_curvy = rz_config_get_b(cmd->core->config, "scr.utf8.curvy") && scr_utf8;
+	bool scr_utf8 = cmd->core ? cmd->core->config ? rz_config_get_b(cmd->core->config, "scr.utf8") : false : false;
+	bool scr_curvy = scr_utf8 && rz_config_get_b(cmd->core->config, "scr.utf8.curvy");
 
 	RzStrBuf *sb = rz_strbuf_new(NULL);
 	fill_usage_strbuf(cmd, sb, cd, use_color);
@@ -1179,13 +1179,13 @@ static void fill_argv_modes_help_strbuf(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd,
 	if (max_len - min_len > MAX_RIGHT_ALIGHNMENT) {
 		max_len = min_len + MAX_RIGHT_ALIGHNMENT;
 	}
-	bool scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
+	bool scr_utf8 = cmd->core ? cmd->core->config ? rz_config_get_b(cmd->core->config, "scr.utf8") : false : false;
 	size_t i;
 	for (i = 0; i < RZ_ARRAY_SIZE(argv_modes); i++) {
 		if (cd->d.argv_modes_data.modes & argv_modes[i].mode) {
 			char *name = rz_str_newf("%s%s", cd->name, argv_modes[i].suffix);
 			char *summary = rz_str_newf("%s%s", cd->help->summary, argv_modes[i].summary_suffix);
-			do_print_child_help(cmd, sb, cd, name, summary, scr_utf8 ? RUNE_LINE_VERT : "|", false, max_len, use_color);
+			do_print_child_help(cmd, sb, cd, name, summary, scr_utf8 ? RUNE_LINE_VERT : "| ", false, max_len, use_color);
 			free(name);
 			free(summary);
 		}
@@ -1492,18 +1492,18 @@ RZ_API bool rz_cmd_get_help_json(RzCmd *cmd, const RzCmdDesc *cd, PJ *j) {
  */
 RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_color, RzStrBuf *sb) {
 	rz_return_val_if_fail(cmd && cd && sb, false);
-	bool scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
-	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary, scr_utf8 ? RUNE_LINE_VERT : "|",false, MAX_RIGHT_ALIGHNMENT, use_color);
+	bool scr_utf8 = cmd->core ? cmd->core->config ? rz_config_get_b(cmd->core->config, "scr.utf8") : false : false;
+	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary, scr_utf8 ? RUNE_LINE_VERT : "| ", false, MAX_RIGHT_ALIGHNMENT, use_color);
 	return true;
 }
 
 /**
  * \brief Generates a text output of the help message for given args
- * 
+ *
  * \param cmd reference to RzCmd
  * \param args reference to RzCmdParsedArgs
  * \param use_color output strings with color codes.
- * 
+ *
  * \return returns NULL if invalid args are given, otherwise returns help message of the given args.
  */
 RZ_API char *rz_cmd_get_help(RzCmd *cmd, RzCmdParsedArgs *args, bool use_color) {

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -32,8 +32,21 @@
 #define MAX_RIGHT_ALIGHNMENT 20
 
 // Based on Config and Line order choses the vertical line shape
-static inline const char *get_vertical_line(int idx, int len, bool scr_curvy, bool scr_utf8) {
-	return (((idx == 0) && (scr_curvy == true)) ? RUNE_CURVE_CORNER_TL : (((idx == len - 1) && (scr_curvy == true)) ? RUNE_CURVE_CORNER_BL : ((scr_utf8 == true) ? RUNE_LINE_VERT : "| ")));
+static inline const char *get_vertical_line(size_t idx, size_t len, bool scr_curvy, bool scr_utf8) {
+	if (scr_curvy && !idx) {
+		return RUNE_CURVE_CORNER_TL;
+	} else if (scr_curvy && (idx == len - 1)) {
+		return RUNE_CURVE_CORNER_BL;
+	} else if (scr_utf8) {
+		return RUNE_LINE_VERT;
+	} else {
+		return "| ";
+	}
+}
+
+// return true if core and core->config aren't NULL, else false
+static inline bool is_core_and_config(RzCore *core) {
+	return (core && core->config);
 }
 
 // NOTE: this should be in sync with SPECIAL_CHARACTERS in
@@ -1120,14 +1133,18 @@ static void print_child_help(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, size_t max
 }
 
 static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
-	bool scr_utf8 = cmd->core ? cmd->core->config ? rz_config_get_b(cmd->core->config, "scr.utf8") : false : false;
-	bool scr_curvy = scr_utf8 && rz_config_get_b(cmd->core->config, "scr.utf8.curvy");
+	bool scr_utf8 = false, scr_curvy = false;
+	if (is_core_and_config(cmd->core)) {
+		scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
+		scr_curvy = scr_utf8 && rz_config_get_b(cmd->core->config, "scr.utf8.curvy");
+	}
 
 	RzStrBuf *sb = rz_strbuf_new(NULL);
 	fill_usage_strbuf(cmd, sb, cd, use_color);
 
 	void **it_cd;
-	int idx;
+	size_t idx = 0;
+
 	size_t max_len = 0, min_len = SIZE_MAX;
 
 	rz_cmd_desc_children_foreach(cd, it_cd) {
@@ -1138,9 +1155,12 @@ static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
 		max_len = min_len + MAX_RIGHT_ALIGHNMENT;
 	}
 
+	size_t n_descs = rz_pvector_len(&cd->children);
+
 	rz_cmd_desc_children_foreach_idx(cd, it_cd, idx) {
 		RzCmdDesc *child = *(RzCmdDesc **)it_cd;
-		print_child_help(cmd, sb, child, max_len, get_vertical_line(idx, cd->children.v.len, scr_curvy, scr_utf8), use_color);
+		const char *vertical_line = get_vertical_line(idx, n_descs, scr_curvy, scr_utf8);
+		print_child_help(cmd, sb, child, max_len, vertical_line, use_color);
 	}
 
 	bool details_filled = fill_details(cmd, cd, sb, use_color);
@@ -1173,19 +1193,25 @@ static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
 }
 
 static void fill_argv_modes_help_strbuf(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, bool use_color) {
+	bool scr_utf8 = false;
+	if (is_core_and_config(cmd->core)) {
+		scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
+	}
+	const char *vertical_line = scr_utf8 ? RUNE_LINE_VERT : "| ";
+
 	size_t max_len = 0, min_len = SIZE_MAX;
 	update_minmax_len(cd, &max_len, &min_len, true);
 	max_len++; // consider the suffix letter
 	if (max_len - min_len > MAX_RIGHT_ALIGHNMENT) {
 		max_len = min_len + MAX_RIGHT_ALIGHNMENT;
 	}
-	bool scr_utf8 = cmd->core ? cmd->core->config ? rz_config_get_b(cmd->core->config, "scr.utf8") : false : false;
 	size_t i;
+
 	for (i = 0; i < RZ_ARRAY_SIZE(argv_modes); i++) {
 		if (cd->d.argv_modes_data.modes & argv_modes[i].mode) {
 			char *name = rz_str_newf("%s%s", cd->name, argv_modes[i].suffix);
 			char *summary = rz_str_newf("%s%s", cd->help->summary, argv_modes[i].summary_suffix);
-			do_print_child_help(cmd, sb, cd, name, summary, scr_utf8 ? RUNE_LINE_VERT : "| ", false, max_len, use_color);
+			do_print_child_help(cmd, sb, cd, name, summary, vertical_line, false, max_len, use_color);
 			free(name);
 			free(summary);
 		}
@@ -1492,8 +1518,14 @@ RZ_API bool rz_cmd_get_help_json(RzCmd *cmd, const RzCmdDesc *cd, PJ *j) {
  */
 RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_color, RzStrBuf *sb) {
 	rz_return_val_if_fail(cmd && cd && sb, false);
-	bool scr_utf8 = cmd->core ? cmd->core->config ? rz_config_get_b(cmd->core->config, "scr.utf8") : false : false;
-	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary, scr_utf8 ? RUNE_LINE_VERT : "| ", false, MAX_RIGHT_ALIGHNMENT, use_color);
+
+	bool scr_utf8 = false;
+	if (is_core_and_config(cmd->core)) {
+		scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
+	}
+	const char *vertical_line = scr_utf8 ? RUNE_LINE_VERT : "| ";
+
+	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary, vertical_line, false, MAX_RIGHT_ALIGHNMENT, use_color);
 	return true;
 }
 

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -31,6 +31,11 @@
 #define MIN_SUMMARY_WIDTH    6
 #define MAX_RIGHT_ALIGHNMENT 20
 
+// Based on Config and Line order choses the vertical line shape
+static inline const char *get_vertical_line(int idx, int len, bool scr_curvy, bool scr_utf8) {
+	return (((idx == 0) && (scr_curvy == true)) ? RUNE_CURVE_CORNER_TL : (((idx == len - 1) && (scr_curvy == true)) ? RUNE_CURVE_CORNER_BL : ((scr_utf8 == true) ? RUNE_LINE_VERT : "|")));
+}
+
 // NOTE: this should be in sync with SPECIAL_CHARACTERS in
 //       rizin-shell-parser grammar, except for ", ' and
 //       whitespaces, because we let cmd_substitution_arg create
@@ -1070,7 +1075,7 @@ static void update_minmax_len(RzCmdDesc *cd, size_t *max_len, size_t *min_len, b
 	*min_len = val < *min_len ? val : *min_len;
 }
 
-static void do_print_child_help(RzCmd *cmd, RzStrBuf *sb, const RzCmdDesc *cd, const char *name, const char *summary, bool show_children, size_t max_len, bool use_color) {
+static void do_print_child_help(RzCmd *cmd, RzStrBuf *sb, const RzCmdDesc *cd, const char *name, const char *summary, const char *vertical_line, bool show_children, size_t max_len, bool use_color) {
 	size_t str_len = calc_padding_len(cd, name, show_children);
 	int padding = str_len < max_len ? max_len - str_len : 0;
 	const char *pal_args_color = "",
@@ -1089,7 +1094,7 @@ static void do_print_child_help(RzCmd *cmd, RzStrBuf *sb, const RzCmdDesc *cd, c
 	}
 
 	size_t columns = 0;
-	columns += strbuf_append_calc(sb, "| ");
+	columns += strbuf_append_calc(sb, vertical_line);
 	rz_strbuf_append(sb, pal_input_color);
 	columns += strbuf_append_calc(sb, name);
 	if (show_children && show_children_shortcut(cd)) {
@@ -1110,15 +1115,19 @@ static void do_print_child_help(RzCmd *cmd, RzStrBuf *sb, const RzCmdDesc *cd, c
 	rz_strbuf_appendf(sb, "%s\n", pal_reset);
 }
 
-static void print_child_help(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, size_t max_len, bool use_color) {
-	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary ? cd->help->summary : "", true, max_len, use_color);
+static void print_child_help(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, size_t max_len, const char *vertical_line, bool use_color) {
+	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary ? cd->help->summary : "", vertical_line, true, max_len, use_color);
 }
 
 static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
+	bool scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
+	bool scr_curvy = rz_config_get_b(cmd->core->config, "scr.utf8.curvy") && scr_utf8;
+
 	RzStrBuf *sb = rz_strbuf_new(NULL);
 	fill_usage_strbuf(cmd, sb, cd, use_color);
 
 	void **it_cd;
+	int idx;
 	size_t max_len = 0, min_len = SIZE_MAX;
 
 	rz_cmd_desc_children_foreach(cd, it_cd) {
@@ -1129,9 +1138,9 @@ static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
 		max_len = min_len + MAX_RIGHT_ALIGHNMENT;
 	}
 
-	rz_cmd_desc_children_foreach(cd, it_cd) {
+	rz_cmd_desc_children_foreach_idx(cd, it_cd, idx) {
 		RzCmdDesc *child = *(RzCmdDesc **)it_cd;
-		print_child_help(cmd, sb, child, max_len, use_color);
+		print_child_help(cmd, sb, child, max_len, get_vertical_line(idx, cd->children.v.len, scr_curvy, scr_utf8), use_color);
 	}
 
 	bool details_filled = fill_details(cmd, cd, sb, use_color);
@@ -1170,13 +1179,13 @@ static void fill_argv_modes_help_strbuf(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd,
 	if (max_len - min_len > MAX_RIGHT_ALIGHNMENT) {
 		max_len = min_len + MAX_RIGHT_ALIGHNMENT;
 	}
-
+	bool scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
 	size_t i;
 	for (i = 0; i < RZ_ARRAY_SIZE(argv_modes); i++) {
 		if (cd->d.argv_modes_data.modes & argv_modes[i].mode) {
 			char *name = rz_str_newf("%s%s", cd->name, argv_modes[i].suffix);
 			char *summary = rz_str_newf("%s%s", cd->help->summary, argv_modes[i].summary_suffix);
-			do_print_child_help(cmd, sb, cd, name, summary, false, max_len, use_color);
+			do_print_child_help(cmd, sb, cd, name, summary, scr_utf8 ? RUNE_LINE_VERT : "|", false, max_len, use_color);
 			free(name);
 			free(summary);
 		}
@@ -1483,7 +1492,8 @@ RZ_API bool rz_cmd_get_help_json(RzCmd *cmd, const RzCmdDesc *cd, PJ *j) {
  */
 RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_color, RzStrBuf *sb) {
 	rz_return_val_if_fail(cmd && cd && sb, false);
-	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary, false, MAX_RIGHT_ALIGHNMENT, use_color);
+	bool scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
+	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary, scr_utf8 ? RUNE_LINE_VERT : "|",false, MAX_RIGHT_ALIGHNMENT, use_color);
 	return true;
 }
 

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -1528,7 +1528,7 @@ RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_col
  *
  * \return returns NULL if invalid args are given, otherwise returns help message of the given args.
  */
-RZ_API char *rz_cmd_get_help(RzCmd *cmd, RzCmdParsedArgs *args, bool use_color) {
+RZ_API RZ_OWN char *rz_cmd_get_help(RzCmd *cmd, RzCmdParsedArgs *args, bool use_color) {
 	char *cmdid = rz_str_dup(rz_cmd_parsed_args_cmd(args));
 	if (!cmdid) {
 		return NULL;

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -1497,6 +1497,15 @@ RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_col
 	return true;
 }
 
+/**
+ * \brief Generates a text output of the help message for given args
+ * 
+ * \param cmd reference to RzCmd
+ * \param args reference to RzCmdParsedArgs
+ * \param use_color output strings with color codes.
+ * 
+ * \return returns NULL if invalid args are given, otherwise returns help message of the given args.
+ */
 RZ_API char *rz_cmd_get_help(RzCmd *cmd, RzCmdParsedArgs *args, bool use_color) {
 	char *cmdid = rz_str_dup(rz_cmd_parsed_args_cmd(args));
 	if (!cmdid) {

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -1528,7 +1528,7 @@ RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_col
  *
  * \return returns NULL if invalid args are given, otherwise returns help message of the given args.
  */
-RZ_API RZ_OWN char *rz_cmd_get_help(RzCmd *cmd, RzCmdParsedArgs *args, bool use_color) {
+RZ_API RZ_OWN char *rz_cmd_get_help(RZ_BORROW RzCmd *cmd, RZ_BORROW RzCmdParsedArgs *args, bool use_color) {
 	char *cmdid = rz_str_dup(rz_cmd_parsed_args_cmd(args));
 	if (!cmdid) {
 		return NULL;

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -39,14 +39,13 @@ static inline const char *get_vertical_line(size_t idx, size_t len, bool scr_cur
 		return RUNE_CURVE_CORNER_BL;
 	} else if (scr_utf8) {
 		return RUNE_LINE_VERT;
-	} else {
-		return "| ";
 	}
+	return "| ";
 }
 
-// return true if core and core->config aren't NULL, else false
-static inline bool is_core_and_config(RzCore *core) {
-	return (core && core->config);
+// return rz_config_get_b if core and core->config aren't NULL else false
+static inline bool core_config_get_b(RzCore *core, const char *option) {
+	return core && core->config ? rz_config_get_b(core->config, option) : false;
 }
 
 // NOTE: this should be in sync with SPECIAL_CHARACTERS in
@@ -1133,11 +1132,8 @@ static void print_child_help(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, size_t max
 }
 
 static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
-	bool scr_utf8 = false, scr_curvy = false;
-	if (is_core_and_config(cmd->core)) {
-		scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
-		scr_curvy = scr_utf8 && rz_config_get_b(cmd->core->config, "scr.utf8.curvy");
-	}
+	bool scr_utf8 = core_config_get_b(cmd->core, "scr.utf8");
+	bool scr_curvy = scr_utf8 && core_config_get_b(cmd->core, "scr.utf8.curvy");
 
 	RzStrBuf *sb = rz_strbuf_new(NULL);
 	fill_usage_strbuf(cmd, sb, cd, use_color);
@@ -1193,10 +1189,7 @@ static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
 }
 
 static void fill_argv_modes_help_strbuf(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, bool use_color) {
-	bool scr_utf8 = false;
-	if (is_core_and_config(cmd->core)) {
-		scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
-	}
+	bool scr_utf8 = core_config_get_b(cmd->core, "scr.utf8");
 	const char *vertical_line = scr_utf8 ? RUNE_LINE_VERT : "| ";
 
 	size_t max_len = 0, min_len = SIZE_MAX;
@@ -1519,10 +1512,7 @@ RZ_API bool rz_cmd_get_help_json(RzCmd *cmd, const RzCmdDesc *cd, PJ *j) {
 RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_color, RzStrBuf *sb) {
 	rz_return_val_if_fail(cmd && cd && sb, false);
 
-	bool scr_utf8 = false;
-	if (is_core_and_config(cmd->core)) {
-		scr_utf8 = rz_config_get_b(cmd->core->config, "scr.utf8");
-	}
+	bool scr_utf8 = core_config_get_b(cmd->core, "scr.utf8");
 	const char *vertical_line = scr_utf8 ? RUNE_LINE_VERT : "| ";
 
 	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary, vertical_line, false, MAX_RIGHT_ALIGHNMENT, use_color);

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -511,7 +511,7 @@ RZ_API RzCmdStatus rz_cmd_call_parsed_args(RzCmd *cmd, RzCmdParsedArgs *args);
 RZ_API RzCmdDesc *rz_cmd_get_root(RzCmd *cmd);
 RZ_API RzCmdDesc *rz_cmd_get_desc(RzCmd *cmd, const char *cmd_identifier);
 RZ_API RzCmdDesc *rz_cmd_get_desc_best(RzCmd *cmd, const char *cmd_identifier);
-RZ_API char *rz_cmd_get_help(RzCmd *cmd, RzCmdParsedArgs *args, bool use_color);
+RZ_API RZ_OWN char *rz_cmd_get_help(RzCmd *cmd, RzCmdParsedArgs *args, bool use_color);
 RZ_API bool rz_cmd_get_help_json(RzCmd *cmd, const RzCmdDesc *cd, PJ *j);
 RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_color, RzStrBuf *sb);
 

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -511,7 +511,7 @@ RZ_API RzCmdStatus rz_cmd_call_parsed_args(RzCmd *cmd, RzCmdParsedArgs *args);
 RZ_API RzCmdDesc *rz_cmd_get_root(RzCmd *cmd);
 RZ_API RzCmdDesc *rz_cmd_get_desc(RzCmd *cmd, const char *cmd_identifier);
 RZ_API RzCmdDesc *rz_cmd_get_desc_best(RzCmd *cmd, const char *cmd_identifier);
-RZ_API RZ_OWN char *rz_cmd_get_help(RzCmd *cmd, RzCmdParsedArgs *args, bool use_color);
+RZ_API RZ_OWN char *rz_cmd_get_help(RZ_BORROW RzCmd *cmd, RZ_BORROW RzCmdParsedArgs *args, bool use_color);
 RZ_API bool rz_cmd_get_help_json(RzCmd *cmd, const RzCmdDesc *cd, PJ *j);
 RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_color, RzStrBuf *sb);
 

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -558,6 +558,7 @@ RZ_API void rz_cmd_foreach_cmdname(RzCmd *cmd, RzCmdDesc *begin, RzCmdForeachNam
 RZ_API const RzCmdDescArg *rz_cmd_desc_get_arg(const RzCmdDesc *cd, size_t i);
 
 #define rz_cmd_desc_children_foreach(root, it_cd) rz_pvector_foreach (&root->children, it_cd)
+#define rz_cmd_desc_children_foreach_idx(root, it_cd, idx) rz_pvector_enumerate (&root->children, it_cd, idx)
 
 RZ_API void rz_cmd_desc_details_free(RzCmdDescDetail *details);
 

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -557,7 +557,7 @@ RZ_API bool rz_cmd_desc_remove(RzCmd *cmd, RzCmdDesc *cd);
 RZ_API void rz_cmd_foreach_cmdname(RzCmd *cmd, RzCmdDesc *begin, RzCmdForeachNameCb cb, void *user);
 RZ_API const RzCmdDescArg *rz_cmd_desc_get_arg(const RzCmdDesc *cd, size_t i);
 
-#define rz_cmd_desc_children_foreach(root, it_cd) rz_pvector_foreach (&root->children, it_cd)
+#define rz_cmd_desc_children_foreach(root, it_cd)          rz_pvector_foreach (&root->children, it_cd)
 #define rz_cmd_desc_children_foreach_idx(root, it_cd, idx) rz_pvector_enumerate (&root->children, it_cd, idx)
 
 RZ_API void rz_cmd_desc_details_free(RzCmdDescDetail *details);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**
for adding this change in `help` section for commands , changes in the following files are made:
- `librz/core/cmd/cmd_api.c`: adding some logic to handle our feature based on the configuration
- `librz/include/rz_cmd.h`: adding new define `rz_cmd_desc_children_foreach_idx`

Add documentation for `rz_cmd_get_help`

I tried to do the minimal change within the code, there is an ability to extend to more configurations/more shapes with justing changing the `get_vertical_line` inline function.
...

**Test plan**
- when `utf8` is enabled

![Screenshot from 2025-03-23 02-07-33](https://github.com/user-attachments/assets/8871fb28-f206-4c85-b7e4-0fb2ed6e8f43)

- `utf8` and `utf8.curvy` are enabled

![Screenshot from 2025-03-23 02-07-58](https://github.com/user-attachments/assets/0cbeda9a-aa18-4074-bc61-1d5508f39789)
- `utf8` is disabled

![Screenshot from 2025-03-23 02-08-11](https://github.com/user-attachments/assets/51ae046c-489d-4e56-8eb2-d1f7c394963b)

...

**Closing issues**

closes #4965 

...
