### PR TITLE
Fix dyldcache reading tests with optimization (Fix #3459)

### DIFF
--- a/test/unit/test_bin_mach0.c
+++ b/test/unit/test_bin_mach0.c
@@ -42,7 +42,8 @@ static void memset_rand(ut8 *dst, size_t size) {
 \
 			/* Parse with our endian-independent function */ \
 			struct name s; \
-			ut##size *s_direct = (ut##size *)&s; \
+			/* some compilers incorrectly optimized the following without volatile */ \
+			volatile ut##size *s_direct = (ut##size *)&s; \
 			*s_direct = rand_ut64(); /* init with garbage */ \
 			name##_read(&s, raw_val); \
 \


### PR DESCRIPTION


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

The pointer contents could be assumed to not change during the test by the compiler with certain optimization levels, leading to instant failure.
This became visible on Gentoo/amd64 with all-default meson options.

**Test plan**

```
meson setup build
ninja -Cbuild
build/test/unit/test_bin_mach0
```
should succeed on Gentoo/amd64

**Closing issues**

Fix #3459