### PR TITLE
librz/magic: Fix rz_magic_buffer parameter types for sys magic

### DIFF
--- a/librz/magic/magic.c
+++ b/librz/magic/magic.c
@@ -39,7 +39,7 @@ RZ_API const char *rz_magic_file(RzMagic *m, const char *f) {
 RZ_API const char *rz_magic_descriptor(RzMagic *m, int fd) {
 	return magic_descriptor(m, fd);
 }
-RZ_API const char *rz_magic_buffer(RzMagic *m, const void *b, size_t s) {
+RZ_API const char *rz_magic_buffer(RzMagic *m, const ut8 *b, size_t s) {
 	return magic_buffer(m, b, s);
 }
 RZ_API const char *rz_magic_error(RzMagic *m) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

Declaration in header was changed in
83a26bd07e12cf14a0e2cb9c7b0d84fa6f5204f5 but the definition itself was not adjusted when system libmagic is used.

**Test plan**

Build on Gentoo/amd64 with `-Duse_sys_magic=enabled`
