### PR TITLE
librz/cons: fix defragger theme

### DIFF
--- a/librz/cons/d/defragger
+++ b/librz/cons/d/defragger
@@ -45,7 +45,7 @@ ec ai.write rgb:0000ff
 ec ai.exec rgb:ff0000
 ec ai.seq rgb:ff00ff
 ec ai.ascii rgb:ffff00
-ec graph.box=rgb:9e9e9e
+ec graph.box rgb:9e9e9e
 ec graph.box2 rgb:5f87d7
 ec graph.box3 rgb:af5f87
 ec graph.box4 rgb:303030


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

Fixes the following error:
```
[0x100003a58]> eco defragger
(graph.box=rgb:9e9e9e)(COLOR)
[0x100003a58]>
```