### PR TITLE
Fix: Count meta size in code coverage

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -5604,6 +5604,7 @@ RZ_API st64 rz_core_analysis_coverage_count(RZ_NONNULL RzCore *core) {
 RZ_API st64 rz_core_analysis_code_count(RZ_NONNULL RzCore *core) {
 	rz_return_val_if_fail(core, ST64_MAX);
 	st64 code = 0;
+	code += (st64)rz_meta_get_size(core->analysis, RZ_META_TYPE_DATA);
 	void **it;
 	RzPVector *maps = rz_io_maps(core->io);
 	rz_pvector_foreach (maps, it) {

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -15,6 +15,7 @@ if get_option('enable_tests')
     'analysis_block',
     'analysis_cc',
     'analysis_class_graph',
+    'analysis_coverage',
     'analysis_function',
     'analysis_hints',
     'analysis_meta',

--- a/test/unit/test_analysis_coverage.c
+++ b/test/unit/test_analysis_coverage.c
@@ -1,0 +1,40 @@
+#include <rz_io.h>
+#include <rz_analysis.h>
+#include <rz_core.h>
+
+#include "minunit.h"
+
+bool test_code_size_vs_coverage(void) {
+	RzCore* r = rz_core_new();
+	bool io_open1 = rz_io_open(r->io, "malloc://0x100", RZ_PERM_R, 0);
+	bool io_open2 = rz_io_open(r->io, "malloc://0x50", RZ_PERM_X | RZ_PERM_RW, 0);
+	mu_assert("Failed to open read-only memory region", io_open1);
+	mu_assert("Failed to open executable memory region", io_open2);
+
+	ut8 codes[] = { 0x90, 0x90, 0x90, 0xC3 }; // NOP NOP NOP RET (simple function)
+	bool written = rz_io_write_at(r->io, 0x10, codes, sizeof(codes));
+	mu_assert("Failed to write instructions to memory", written);
+
+	bool meta_set = rz_meta_set(r->analysis, RZ_META_TYPE_DATA, 0x10, 0x60, "some random data");
+	mu_assert("Failed to set metadata", meta_set);
+
+	rz_core_analysis_all(r);
+
+	long long int code = rz_core_analysis_code_count(r);
+	mu_assert("Code size should be non-negative", code >= 0);
+
+	long long int cov = rz_core_analysis_coverage_count(r);
+	mu_assert("Coverage should be non-negative", cov >= 0);
+
+	mu_assert("Coverage exceeded code size", cov <= code);
+
+	rz_core_free(r);
+	mu_end;
+}
+
+bool all_tests(void){
+	mu_run_test(test_code_size_vs_coverage);
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

Handles the **Inconsistent Analysis Coverage** issue

**Fixed Problem:**

The **code size** calculation in `rz_core_analysis_code_count()` was incorrect because it did not count `meta size`. This made **analysis coverage** inconsistent in cases where `meta size` is larger than size of **executable sections**.

**How This Fix Solves the Problem:**

Adds `meta size` to `code count` in `rz_core_analysis_code_count()` so the **percentage covered** does not go beyond **100%** 

**Changes Implemented:**
- Modified `rz_core_analysis_code_count()` in `librz/core/canalysis.c` to include `meta size` in the **code size** calculation
- Added a **test** in `test/unit/test_analysis_coverage.c` to verify that the **fix** correctly calculates **analysis coverage**.
- Added `analysis coverage` entry in `test/unit/meson.build` to run the **test**

**Before:**
![before](https://github.com/user-attachments/assets/e67634f9-fc2e-491a-8892-fb579e674ad7)

**After:**
![after](https://github.com/user-attachments/assets/cb1c50db-c036-472e-a1d0-552f5b9a0c26)

**Note:**
- This **PR** does not modify the functionality or behavior of any `RZ_API` function or struct.  
- The only change is adding a `meta size` to a `code size` in `rz_core_analysis_code_count()`
- So no changes required in **API documentation**.  
...

**Test plan**

1. **Verify the Fix Works:**  
   - Run the `test_analysis_coverage.c` test using:  
     ```sh
     meson test -C build analysis_coverage
     ```
   - Ensure the test **passes** with the changes applied.  

2. **Verify the Issue Before the Fix:**  
   - Revert the changes made to `rz_core_analysis_code_count()` in `librz/core/canalysis.c`.  
   - Run the test again using:  
     ```sh
     meson test -C build analysis_coverage
     ```
   - The test should **fail**, confirming that the **issue** existed before this **fix**.
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
closes #5050 
...
