### PR TITLE
A command to show just strings that have code or data references to them

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -2946,7 +2946,7 @@ RZ_API bool rz_core_bin_whole_strings_print(RZ_NONNULL RzCore *core, RZ_NONNULL 
 	return res;
 }
 
-RZ_IPI bool rz_core_bin_xrefs_strings_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state) {
+RZ_API bool rz_core_bin_xrefs_strings_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state) {
 	rz_return_val_if_fail(core && state, false);
 
 	RzPVector *whole_strings = rz_core_bin_whole_strings(core, bf);

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -2946,6 +2946,36 @@ RZ_API bool rz_core_bin_whole_strings_print(RZ_NONNULL RzCore *core, RZ_NONNULL 
 	return res;
 }
 
+RZ_IPI bool rz_core_bin_xrefs_strings_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state) {
+	rz_return_val_if_fail(core && state, false);
+
+	RzPVector *l = rz_core_bin_whole_strings(core, bf);
+	RzPVector *ll = rz_pvector_new(NULL);
+	
+	void ** iter;
+	rz_pvector_foreach (l, iter) {
+		RzBinString* string = *iter;
+		RzList *list = rz_analysis_xrefs_get_to(core->analysis, string->paddr);
+		RzAnalysisXRef *xref;
+		RzListIter *iterator;
+		rz_list_foreach (list, iterator, xref) {
+			switch (xref->type) {
+				case RZ_ANALYSIS_XREF_TYPE_CODE:
+				case RZ_ANALYSIS_XREF_TYPE_DATA:
+					if(!rz_pvector_contains(ll,string)){
+						rz_pvector_push_front(ll,string);
+					}
+				default:
+					break;
+			}
+		}
+	}
+	bool res = strings_print(core, state, ll);
+	rz_pvector_free(l);
+	rz_pvector_free(ll);
+	return res;
+}
+
 static const char *get_filename(RzBinInfo *info, RzIODesc *desc) {
 	if (info && info->file) {
 		return info->file;

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -2950,6 +2950,11 @@ RZ_IPI bool rz_core_bin_xrefs_strings_print(RZ_NONNULL RzCore *core, RZ_NONNULL 
 	rz_return_val_if_fail(core && state, false);
 
 	RzPVector *whole_strings = rz_core_bin_whole_strings(core, bf);
+
+	if (!whole_strings) {
+		return false;
+	}
+
 	RzPVector *xrefs_strings = rz_pvector_new((RzPVectorFree)rz_bin_string_free);
 
 	void **iter;

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -25,14 +25,14 @@
 
 #define LOAD_BSS_MALLOC 0
 
-#define IS_MODE_SET(mode)       ((mode)&RZ_MODE_SET)
-#define IS_MODE_SIMPLE(mode)    ((mode)&RZ_MODE_SIMPLE)
-#define IS_MODE_SIMPLEST(mode)  ((mode)&RZ_MODE_SIMPLEST)
-#define IS_MODE_JSON(mode)      ((mode)&RZ_MODE_JSON)
-#define IS_MODE_RZCMD(mode)     ((mode)&RZ_MODE_RIZINCMD)
-#define IS_MODE_EQUAL(mode)     ((mode)&RZ_MODE_EQUAL)
+#define IS_MODE_SET(mode)       ((mode) & RZ_MODE_SET)
+#define IS_MODE_SIMPLE(mode)    ((mode) & RZ_MODE_SIMPLE)
+#define IS_MODE_SIMPLEST(mode)  ((mode) & RZ_MODE_SIMPLEST)
+#define IS_MODE_JSON(mode)      ((mode) & RZ_MODE_JSON)
+#define IS_MODE_RZCMD(mode)     ((mode) & RZ_MODE_RIZINCMD)
+#define IS_MODE_EQUAL(mode)     ((mode) & RZ_MODE_EQUAL)
 #define IS_MODE_NORMAL(mode)    (!(mode))
-#define IS_MODE_CLASSDUMP(mode) ((mode)&RZ_MODE_CLASSDUMP)
+#define IS_MODE_CLASSDUMP(mode) ((mode) & RZ_MODE_CLASSDUMP)
 
 // dup from cmd_info
 #define PAIR_WIDTH "9"
@@ -2951,22 +2951,22 @@ RZ_IPI bool rz_core_bin_xrefs_strings_print(RZ_NONNULL RzCore *core, RZ_NONNULL 
 
 	RzPVector *l = rz_core_bin_whole_strings(core, bf);
 	RzPVector *ll = rz_pvector_new(NULL);
-	
-	void ** iter;
+
+	void **iter;
 	rz_pvector_foreach (l, iter) {
-		RzBinString* string = *iter;
+		RzBinString *string = *iter;
 		RzList *list = rz_analysis_xrefs_get_to(core->analysis, string->paddr);
 		RzAnalysisXRef *xref;
 		RzListIter *iterator;
 		rz_list_foreach (list, iterator, xref) {
 			switch (xref->type) {
-				case RZ_ANALYSIS_XREF_TYPE_CODE:
-				case RZ_ANALYSIS_XREF_TYPE_DATA:
-					if(!rz_pvector_contains(ll,string)){
-						rz_pvector_push_front(ll,string);
-					}
-				default:
-					break;
+			case RZ_ANALYSIS_XREF_TYPE_CODE:
+			case RZ_ANALYSIS_XREF_TYPE_DATA:
+				if (!rz_pvector_contains(ll, string)) {
+					rz_pvector_push_front(ll, string);
+				}
+			default:
+				break;
 			}
 		}
 	}

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -25,14 +25,14 @@
 
 #define LOAD_BSS_MALLOC 0
 
-#define IS_MODE_SET(mode)       ((mode) & RZ_MODE_SET)
-#define IS_MODE_SIMPLE(mode)    ((mode) & RZ_MODE_SIMPLE)
-#define IS_MODE_SIMPLEST(mode)  ((mode) & RZ_MODE_SIMPLEST)
-#define IS_MODE_JSON(mode)      ((mode) & RZ_MODE_JSON)
-#define IS_MODE_RZCMD(mode)     ((mode) & RZ_MODE_RIZINCMD)
-#define IS_MODE_EQUAL(mode)     ((mode) & RZ_MODE_EQUAL)
+#define IS_MODE_SET(mode)       ((mode)&RZ_MODE_SET)
+#define IS_MODE_SIMPLE(mode)    ((mode)&RZ_MODE_SIMPLE)
+#define IS_MODE_SIMPLEST(mode)  ((mode)&RZ_MODE_SIMPLEST)
+#define IS_MODE_JSON(mode)      ((mode)&RZ_MODE_JSON)
+#define IS_MODE_RZCMD(mode)     ((mode)&RZ_MODE_RIZINCMD)
+#define IS_MODE_EQUAL(mode)     ((mode)&RZ_MODE_EQUAL)
 #define IS_MODE_NORMAL(mode)    (!(mode))
-#define IS_MODE_CLASSDUMP(mode) ((mode) & RZ_MODE_CLASSDUMP)
+#define IS_MODE_CLASSDUMP(mode) ((mode)&RZ_MODE_CLASSDUMP)
 
 // dup from cmd_info
 #define PAIR_WIDTH "9"
@@ -2949,30 +2949,31 @@ RZ_API bool rz_core_bin_whole_strings_print(RZ_NONNULL RzCore *core, RZ_NONNULL 
 RZ_IPI bool rz_core_bin_xrefs_strings_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state) {
 	rz_return_val_if_fail(core && state, false);
 
-	RzPVector *l = rz_core_bin_whole_strings(core, bf);
-	RzPVector *ll = rz_pvector_new(NULL);
+	RzPVector *whole_strings = rz_core_bin_whole_strings(core, bf);
+	RzPVector *xrefs_strings = rz_pvector_new((RzPVectorFree)rz_bin_string_free);
 
 	void **iter;
-	rz_pvector_foreach (l, iter) {
+	rz_pvector_foreach (whole_strings, iter) {
 		RzBinString *string = *iter;
-		RzList *list = rz_analysis_xrefs_get_to(core->analysis, string->paddr);
-		RzAnalysisXRef *xref;
-		RzListIter *iterator;
+		const RzList *list = rz_analysis_xrefs_get_to(core->analysis, string->paddr);
+		const RzAnalysisXRef *xref;
+		const RzListIter *iterator;
 		rz_list_foreach (list, iterator, xref) {
 			switch (xref->type) {
 			case RZ_ANALYSIS_XREF_TYPE_CODE:
 			case RZ_ANALYSIS_XREF_TYPE_DATA:
-				if (!rz_pvector_contains(ll, string)) {
-					rz_pvector_push_front(ll, string);
+				if (!rz_pvector_contains(xrefs_strings, string)) {
+					rz_pvector_remove_data(whole_strings, string);
+					rz_pvector_push_front(xrefs_strings, string);
 				}
 			default:
 				break;
 			}
 		}
 	}
-	bool res = strings_print(core, state, ll);
-	rz_pvector_free(l);
-	rz_pvector_free(ll);
+	bool res = strings_print(core, state, xrefs_strings);
+	rz_pvector_free(whole_strings);
+	rz_pvector_free(xrefs_strings);
 	return res;
 }
 

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -2958,6 +2958,7 @@ RZ_API bool rz_core_bin_xrefs_strings_print(RZ_NONNULL RzCore *core, RZ_NONNULL 
 	RzPVector *xrefs_strings = rz_pvector_new((RzPVectorFree)rz_bin_string_free);
 
 	if (!xrefs_strings) {
+		rz_pvector_free(whole_strings);
 		return false;
 	}
 

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -2957,6 +2957,10 @@ RZ_API bool rz_core_bin_xrefs_strings_print(RZ_NONNULL RzCore *core, RZ_NONNULL 
 
 	RzPVector *xrefs_strings = rz_pvector_new((RzPVectorFree)rz_bin_string_free);
 
+	if (!xrefs_strings) {
+		return false;
+	}
+
 	void **iter;
 	rz_pvector_foreach (whole_strings, iter) {
 		RzBinString *string = *iter;

--- a/librz/core/cmd/cmd_info.c
+++ b/librz/core/cmd/cmd_info.c
@@ -709,3 +709,8 @@ RZ_IPI RzCmdStatus rz_cmd_info_guess_size_handler(RzCore *core, int argc, const 
 	}
 	return bool2status(res);
 }
+
+RZ_IPI RzCmdStatus rz_cmd_info_xrefs_strings_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
+	RzBinFile *bf = rz_bin_cur(core->bin);
+	return bool2status(rz_core_bin_xrefs_strings_print(core, bf, state));
+}

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -13177,7 +13177,7 @@ static const RzCmdDescArg cmd_info_xrefs_strings_args[] = {
 	{ 0 },
 };
 static const RzCmdDescHelp cmd_info_xrefs_strings_help = {
-	.summary = "List strings in the whole binary with xrefs pointing to it.",
+	.summary = "List all strings which have xrefs to them.",
 	.args = cmd_info_xrefs_strings_args,
 };
 

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -13173,6 +13173,14 @@ static const RzCmdDescHelp cmd_info_guess_size_help = {
 	.args = cmd_info_guess_size_args,
 };
 
+static const RzCmdDescArg cmd_info_xrefs_strings_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_info_xrefs_strings_help = {
+	.summary = "List strings in the whole binary with xrefs pointing to it.",
+	.args = cmd_info_xrefs_strings_args,
+};
+
 static const RzCmdDescHelp k_help = {
 	.summary = "Run query (SDB)",
 };
@@ -23541,6 +23549,10 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *cmd_info_guess_size_cd = rz_cmd_desc_argv_state_new(core->rcmd, i_cd, "iZ", RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_RIZIN, rz_cmd_info_guess_size_handler, &cmd_info_guess_size_help);
 	rz_warn_if_fail(cmd_info_guess_size_cd);
+
+	RzCmdDesc *cmd_info_xrefs_strings_cd = rz_cmd_desc_argv_state_new(core->rcmd, i_cd, "izx", RZ_OUTPUT_MODE_TABLE | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_QUIETEST, rz_cmd_info_xrefs_strings_handler, &cmd_info_xrefs_strings_help);
+	rz_warn_if_fail(cmd_info_xrefs_strings_cd);
+	rz_cmd_desc_set_default_mode(cmd_info_xrefs_strings_cd, RZ_OUTPUT_MODE_TABLE);
 
 	RzCmdDesc *k_cd = rz_cmd_desc_group_new(core->rcmd, root_cd, "k", rz_query_sdb_get_set_handler, &query_sdb_get_set_help, &k_help);
 	rz_warn_if_fail(k_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -1732,6 +1732,8 @@ RZ_IPI RzCmdStatus rz_cmd_info_whole_strings_handler(RzCore *core, int argc, con
 RZ_IPI RzCmdStatus rz_cmd_info_purge_string_handler(RzCore *core, int argc, const char **argv);
 // "iZ"
 RZ_IPI RzCmdStatus rz_cmd_info_guess_size_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+// "izx"
+RZ_IPI RzCmdStatus rz_cmd_info_xrefs_strings_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "k"
 RZ_IPI RzCmdStatus rz_query_sdb_get_set_handler(RzCore *core, int argc, const char **argv);
 // "kj"

--- a/librz/core/cmd_descs/cmd_info.yaml
+++ b/librz/core/cmd_descs/cmd_info.yaml
@@ -491,7 +491,7 @@ commands:
     args: []
   - name: izx
     cname: cmd_info_xrefs_strings
-    summary: List strings in the whole binary with xrefs pointing to it.
+    summary: List all strings which have xrefs to them.
     type: RZ_CMD_DESC_TYPE_ARGV_STATE
     default_mode: RZ_OUTPUT_MODE_TABLE
     modes:

--- a/librz/core/cmd_descs/cmd_info.yaml
+++ b/librz/core/cmd_descs/cmd_info.yaml
@@ -489,3 +489,14 @@ commands:
       - RZ_OUTPUT_MODE_STANDARD
       - RZ_OUTPUT_MODE_RIZIN
     args: []
+  - name: izx
+    cname: cmd_info_xrefs_strings
+    summary: List strings in the whole binary with xrefs pointing to it.
+    type: RZ_CMD_DESC_TYPE_ARGV_STATE
+    default_mode: RZ_OUTPUT_MODE_TABLE
+    modes:
+      - RZ_OUTPUT_MODE_TABLE
+      - RZ_OUTPUT_MODE_JSON
+      - RZ_OUTPUT_MODE_QUIET
+      - RZ_OUTPUT_MODE_QUIETEST
+    args: []

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -1014,6 +1014,7 @@ RZ_API bool rz_core_bin_segments_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBin
 RZ_API bool rz_core_bin_strings_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state);
 RZ_API RZ_OWN RzPVector /*<RzBinString *>*/ *rz_core_bin_whole_strings(RZ_NONNULL RzCore *core, RZ_NULLABLE RzBinFile *bf);
 RZ_API bool rz_core_bin_whole_strings_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state);
+RZ_API bool rz_core_bin_xrefs_strings_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state);
 RZ_API bool rz_core_file_info_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state);
 RZ_API bool rz_core_bin_info_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state);
 RZ_API bool rz_core_bin_classes_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state);

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -4649,11 +4649,13 @@ EOF
 RUN
 
 NAME=izx
-FILE=bins/mach0/fatmach0-3true
-CMDS=izx
+FILE=bins/arm/elf/hello_world 
+CMDS=aaa;izx
 EXPECT=<<EOF
-nth paddr vaddr len size section type string 
----------------------------------------------
+nth      paddr      vaddr len size section type  string        
+---------------------------------------------------------------
+ 19 0x00000574 0x00000574  12   13 .rodata ascii Hello world!
+ 13 0x00000494 0x00000494  10   11 .text   ascii \bH\tKxD\tJ{D
 EOF
 RUN
 

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -4648,6 +4648,15 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=izx
+FILE=bins/mach0/fatmach0-3true
+CMDS=izx
+EXPECT=<<EOF
+nth paddr vaddr len size section type string 
+---------------------------------------------
+EOF
+RUN
+
 NAME=iT
 FILE==
 ARGS=-w

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -4650,12 +4650,10 @@ RUN
 
 NAME=izx
 FILE=bins/arm/elf/hello_world 
-CMDS=aaa;izx
+CMDS=aaa;izxq
 EXPECT=<<EOF
-nth      paddr      vaddr len size section type  string        
----------------------------------------------------------------
- 19 0x00000574 0x00000574  12   13 .rodata ascii Hello world!
- 13 0x00000494 0x00000494  10   11 .text   ascii \bH\tKxD\tJ{D
+0x574 13 12 Hello world!
+0x494 11 10 \bH\tKxD\tJ{D
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**
This PR solves issue #4702
Add new command `izx` responsible for fetching strings with data or code xrefs to them.
...

**Test plan**

Command `izx` using

![Screenshot from 2025-04-01 16-21-21](https://github.com/user-attachments/assets/373bb6a9-0c03-42c2-97ad-fa2718031f85)

`izxj` `izxq` `izxQ` `izxt`

![Screenshot from 2025-04-01 16-54-11](https://github.com/user-attachments/assets/6ebe0d7c-6944-4136-9169-bd48c6c769b0)

Complete view

![Screenshot from 2025-04-01 16-21-55](https://github.com/user-attachments/assets/55755417-4e22-46ad-9039-539a758f23e2)


...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
closes #4702 

...
