### PR TITLE
Update shellcodes from Exploit-DB

### DIFF
--- a/doxygen_correction.py
+++ b/doxygen_correction.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+file_paths = [
+    "subprojects/rzwinkd/iob_net.c",
+    "librz/debug/p/native/linux/linux_debug.c",
+    "librz/debug/trace.c",
+    "librz/include/rz_core.h",
+    "librz/include/rz_util/rz_annotated_code.h",
+    "librz/include/rz_util/rz_spaces.h",
+    "librz/include/rz_util/rz_graph_drawable.h",
+    "librz/include/rz_project.h",
+    "librz/config/serialize_config.c",
+    "librz/bin/dwarf.c",
+    "librz/bin/p/bin_qnx.c",
+    "librz/analysis/p/analysis_x86_cs.c",
+    "librz/analysis/class.c",
+    "librz/analysis/rtti_itanium.c",
+    "librz/core/cannotated_code.c"
+]
+
+def update_param_tags(file_path):
+    try:
+        file = Path(file_path)
+        if not file.exists():
+            print(f"❌ File not found: {file_path}")
+            return
+
+        lines = file.read_text().splitlines()
+        modified = False
+
+        updated_lines = []
+        for line in lines:
+            if "@param" in line:
+                line = line.replace("@param", r"\param")
+                modified = True
+            updated_lines.append(line)
+
+        if modified:
+            file.write_text("\n".join(updated_lines) + "\n")
+            print(f"✅ Updated: {file_path}")
+        else:
+            print(f"➖ No changes: {file_path}")
+
+    except Exception as e:
+        print(f"❌ Error processing {file_path}: {e}")
+
+# Run on all files
+for path in file_paths:
+    update_param_tags(path)

--- a/subprojects/update_shellcodes.py
+++ b/subprojects/update_shellcodes.py
@@ -1,0 +1,89 @@
+from pathlib  import Path
+import os
+import shutil
+import subprocess
+
+
+GITLAB_REPO = "https://gitlab.com/exploit-database/exploitdb.git"
+CLONE_DIR = "exploitdb"
+OUTPUT_DIR = "rizin_shellcodes"
+SHELLCODE_DIR = f"{CLONE_DIR}/shellcodes"
+
+def run(cmd, cwd=None):
+    return subprocess.run(cmd, shell=True, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def git_clone_or_pull():
+    if not os.path.exists(CLONE_DIR):
+        print("[*] Cloning Gitlab ExploitDB...")
+        run(f"git clone {GITLAB_REPO}")
+    else:
+        print("[*] Pulling latest from Gitlab...")
+        run("git pull", cwd=CLONE_DIR)
+
+
+
+def find_asm_files():
+    return list(Path(SHELLCODE_DIR).rglob("*.nasm")) + list(Path(SHELLCODE_DIR).rglob("*.asm"))
+    
+def assemble_shellcode(asm_file: Path, tmp_dir: Path):
+    base = asm_file.stem
+    obj = tmp_dir / f"{base}.o"
+    binfile = tmp_dir / f"{base}.bin"
+    rawfile = tmp_dir / f"{base}.raw"
+
+    arch_flag = "-f elf32" if "x86" in asm_file.parts else "-f elf"
+
+    res = run(f"nasm {arch_flag} '{asm_file}' -o '{obj}")
+    if res.returncode != 0:
+        print(f"[!] NASM failed: {asm_file.name}")
+        return None
+
+    run(f"ld -m elf_i386 -o '{binfile}' '{obj}'")
+
+    run(f"objcopy -O binary '{binfile}' '{rawfile}'")
+    if not rawfile.exists():
+        return None
+    
+    return rawfile.read_bytes()
+
+def write_sc(path: Path, name: str, arch: str, hexdata: bytes):
+    with open(path, 'w') as f:
+        f.write(f"name={name}\n")
+        f.write(f"arch={arch}\n")
+        f.write(f"os=linux\n")
+        f.write(f"bytes={hexdata.hex()}\n")
+
+def update_shellcodes():
+    tmp = Path("/tmp/rzsc_gitlab")
+    if tmp.exists(): shutil.rmtree(tmp)
+    tmp.mkdir()
+
+    if os.path.exists(OUTPUT_DIR): shutil.rmtree(OUTPUT_DIR)
+    os.makedirs(OUTPUT_DIR)
+
+    git_clone_or_pull()
+
+    asm_files = find_asm_files()
+
+    print(f"[*] Found {len(asm_files)} shellcodes.")
+
+    for asm in asm_files:
+        arch = asm.parts[2]
+        name = asm.stem
+        data = assemble_shellcode(asm, tmp)
+        if data is None:
+            continue
+
+        out_dir = Path(OUTPUT_DIR) / arch
+        out_dir.mkdir(parents=True, exists_ok=True)
+        out_path = out_dir / f"{name}.sc"
+        write_sc(out_path, name, arch, data)
+        print(f"[+] Saved: {out_path}")
+
+    shutil.rmtree(tmp)
+    print(f"Done! Shellcodes saved in {OUTPUT_DIR}")
+    
+
+if __name__ == "__main__":
+    update_shellcodes()


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

---

**📝 Detailed description**

This PR introduces a Python-based tool to automatically update Rizin’s shellcode database by cloning shellcodes from the official [ExploitDB GitLab repository](https://gitlab.com/exploit-database/exploitdb/-/tree/main/shellcodes).

Key features:
- Shellcodes are downloaded and extracted to a structured directory inside the Rizin project.
- Existing shellcodes can now be refreshed easily by running a single command.
- Prepares the ground for adding more metadata or parsing in the future (e.g., shellcode arch/OS detection).

This improves maintainability and ensures Rizin’s shellcode support stays up to date with one of the most active public exploit collections.

---

**🧪 Test plan**

To verify the script and update the shellcodes:

```bash
sudo apt install nasm binutils -y
python3 update_shellcodes.py
```

Fix #4939
