### PR TITLE
Show RZ_LOG_WARN warnings by default for all build opt levels

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -331,6 +331,9 @@ message('USE_PTRACE_WRAP: @0@'.format(use_ptrace_wrap))
 
 checks_level = get_option('checks_level')
 message('RZ_CHECKS_LEVEL: @0@'.format(checks_level))
+if checks_level < 0 or checks_level > 3
+  error('`checks_level` must be between 0 and 3.')
+endif
 
 userconf = configuration_data()
 ccs = [[cc, userconf, host_machine, false]]

--- a/meson.build
+++ b/meson.build
@@ -330,14 +330,6 @@ message('HAVE_PTRACE: @0@'.format(have_ptrace))
 message('USE_PTRACE_WRAP: @0@'.format(use_ptrace_wrap))
 
 checks_level = get_option('checks_level')
-if checks_level == 9999
-  if get_option('buildtype') == 'release'
-    checks_level = 1
-  else
-    checks_level = 2
-  endif
-endif
-
 message('RZ_CHECKS_LEVEL: @0@'.format(checks_level))
 
 userconf = configuration_data()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,7 +19,7 @@ option('rizin_hud', type: 'string', value: '', description: 'Install path for hu
 option('rizin_plugins', type: 'string', value: '', description: 'Path where plugins are expected to be found')
 option('rizin_bindings', type: 'string', value: '', description: 'Path where rizin bindings are expected to be found')
 
-option('checks_level', type: 'integer', value: 9999, description: 'Value between 0 and 3 to enable different level of assert (see RZ_CHECKS_LEVEL). By default its value depends on buildtype (2 on debug, 1 on release).')
+option('checks_level', type: 'integer', value: 2, description: 'Value between 0 and 3 to enable different level of assert (see RZ_CHECKS_LEVEL)')
 option('use_sys_capstone', type: 'feature', value: 'disabled')
 option('use_capstone_version', type: 'combo', choices: ['v4', 'v5', 'v6', 'next'], value: 'next', description: 'Specify which version of capstone to use')
 option('use_sys_magic', type: 'feature', value: 'disabled')

--- a/test/db/archos/linux-x64/dbg_oo
+++ b/test/db/archos/linux-x64/dbg_oo
@@ -108,7 +108,6 @@ RUN
 
 NAME=ood check for ptrace errors
 FILE=bins/elf/analysis/x86-helloworld-gcc
-ARGS=-e log.level=3
 CMDS=<<EOF
 ood
 EOF

--- a/test/db/cmd/cmd_flags
+++ b/test/db/cmd/cmd_flags
@@ -301,7 +301,6 @@ RUN
 
 NAME=f.lj
 FILE=bins/elf/analysis/main
-ARGS=-e log.level=3
 CMDS=<<EOF
 af
 f. patata
@@ -328,7 +327,6 @@ RUN
 
 NAME=f.-
 FILE=bins/elf/analysis/main
-ARGS=-e log.level=3
 CMDS=<<EOF
 af
 f. patata

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -1379,7 +1379,6 @@ NAME=String search - warn if |search literal| < search.str.min_length
 FILE==
 ARGS=-1
 CMDS=<<EOF
-e log.level=3
 w ab @ 0x10
 w abc @ 0x20
 w abcd @ 0x30

--- a/test/db/formats/elf/main
+++ b/test/db/formats/elf/main
@@ -1,7 +1,6 @@
 NAME=ELF: endbr-main-mov
 FILE=bins/elf/endbr-main
 CMDS=%v main
-ARGS=-e log.level=3
 EXPECT=<<EOF
 0x401126
 EOF

--- a/test/db/formats/elf/sections
+++ b/test/db/formats/elf/sections
@@ -100,7 +100,7 @@ RUN
 
 NAME=disable sections load
 FILE=bins/elf/analysis/hello-linux-x86_64
-ARGS=-e log.level=3 -e elf.load.sections=false
+ARGS=-e elf.load.sections=false
 CMDS=iS
 EXPECT=<<EOF
      paddr size      vaddr vsize align perm name      type flags 
@@ -113,7 +113,7 @@ RUN
 
 NAME=disable sections checks
 FILE=bins/elf/libmemalloc-dump-mem
-ARGS=-e log.level=3 -e elf.checks.sections=false
+ARGS=-e elf.checks.sections=false
 CMDS=iS
 EXPECT=<<EOF
      paddr       size      vaddr      vsize align perm name      type              flags                                                                    
@@ -150,7 +150,7 @@ RUN
 
 NAME=disable segments checks
 FILE=bins/elf/analysis/tiny.elf
-ARGS=-e log.level=3 -e elf.checks.segments=false
+ARGS=-e elf.checks.segments=false
 CMDS=iS
 EXPECT=<<EOF
 paddr size vaddr vsize align perm name type flags 

--- a/test/db/tools/rz_bin
+++ b/test/db/tools/rz_bin
@@ -68,7 +68,6 @@ RUN
 NAME=rz-bin -k file
 FILE=bins/elf/analysis/hello-linux-x86_64
 CMDS=!rz-bin -k ${RZ_FILE}
-ARGS=-e log.level=3
 EXPECT=
 EXPECT_ERR=<<EOF
 WARNING: Neither hash nor gnu_hash exist. Falling back to heuristics for deducing the number of dynamic symbols...

--- a/test/db/tools/rz_test
+++ b/test/db/tools/rz_test
@@ -35,7 +35,6 @@ RUN
 NAME=bin with space in filename
 FILE=bins/elf/_Exit (42)
 CMDS=i~^file
-ARGS=-e log.level=3
 EXPECT=<<EOF
 file     bins/elf/_Exit (42)
 EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr enables RZ_LOG_WARN warnings for all build optimization levels, since to me, it doesn't make much sense for them to be treated differently in release builds -- they may not be based on C-like assertions that get optimized out. This pr does that by fixing the Meson option `check_levels` to 2. If the warnings become annoying, one can always use `-e log.level=4`, but one should be aware of any warnings first before doing that.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
