### PR TITLE
Split very large basic blocks

### DIFF
--- a/librz/arch/analysis.c
+++ b/librz/arch/analysis.c
@@ -93,6 +93,8 @@ RZ_API RzAnalysis *rz_analysis_new(void) {
 	analysis->cpp_abi = RZ_ANALYSIS_CPP_ABI_ITANIUM;
 	analysis->opt.depth = 32;
 	analysis->opt.noncode = false; // do not analyze data by default
+	analysis->opt.bb_max_size = UT16_MAX;
+	analysis->opt.fcn_max_size = 256 * 1024;
 	rz_spaces_init(&analysis->meta_spaces, "CS");
 	rz_event_hook(analysis->meta_spaces.event, RZ_SPACE_EVENT_UNSET, meta_unset_for, NULL);
 	rz_event_hook(analysis->meta_spaces.event, RZ_SPACE_EVENT_COUNT, meta_count_for, NULL);

--- a/librz/arch/analysis.c
+++ b/librz/arch/analysis.c
@@ -93,7 +93,7 @@ RZ_API RzAnalysis *rz_analysis_new(void) {
 	analysis->cpp_abi = RZ_ANALYSIS_CPP_ABI_ITANIUM;
 	analysis->opt.depth = 32;
 	analysis->opt.noncode = false; // do not analyze data by default
-	analysis->opt.bb_max_size = UT16_MAX;
+	analysis->opt.bb_max_size = RZ_ANALYSIS_BLOCK_MAX_SIZE;
 	analysis->opt.fcn_max_size = 256 * 1024;
 	rz_spaces_init(&analysis->meta_spaces, "CS");
 	rz_event_hook(analysis->meta_spaces.event, RZ_SPACE_EVENT_UNSET, meta_unset_for, NULL);

--- a/librz/arch/block.c
+++ b/librz/arch/block.c
@@ -336,6 +336,10 @@ RZ_API bool rz_analysis_block_merge(RzAnalysisBlock *a, RzAnalysisBlock *b) {
 		}
 	}
 
+	if (a->size + b->size > a->analysis->opt.bb_max_size) {
+		return false;
+	}
+
 	// Keep a ref to b, but remove all references of b from its functions
 	rz_analysis_block_ref(b);
 	while (!rz_list_empty(b->fcns)) {

--- a/librz/arch/fcn.c
+++ b/librz/arch/fcn.c
@@ -560,7 +560,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 	RzAnalysisFunction *fcn = item->fcn;
 	RzStackAddr sp = item->sp;
 	ut64 addr = item->start_address;
-	ut64 len = RZ_MIN(analysis->opt.bb_max_size, UT16_MAX);
+	ut64 len = RZ_MIN(analysis->opt.bb_max_size, RZ_ANALYSIS_BLOCK_MAX_SIZE);
 	ReadAhead read_ahead_cache = { 0 };
 	const int continue_after_jump = analysis->opt.afterjmp;
 	const int addrbytes = analysis->iob.io ? analysis->iob.io->addrbytes : 1;
@@ -789,7 +789,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 			if (newbbsize >= len) {
 				// Instruction offsets are stored in u16,
 				// artificially introduce bb split to keep the offsets within limits.
-				RzAnalysisBlock* next = fcn_append_basic_block(analysis, fcn, at);
+				RzAnalysisBlock *next = fcn_append_basic_block(analysis, fcn, at);
 				if (!next) {
 					gotoBeach(RZ_ANALYSIS_RET_ERROR);
 				}

--- a/librz/arch/fcn.c
+++ b/librz/arch/fcn.c
@@ -18,10 +18,6 @@
 // 16 KB is the maximum size for a basic block
 #define MAX_FLG_NAME_SIZE 64
 
-// 64KB max size
-// 256KB max function size
-#define MAX_FCN_SIZE (1024 * 256)
-
 #define DB             a->sdb_fcns
 #define EXISTS(x, ...) snprintf(key, sizeof(key) - 1, x, ##__VA_ARGS__), sdb_exists(DB, key)
 #define SETKEY(x, ...) snprintf(key, sizeof(key) - 1, x, ##__VA_ARGS__);
@@ -564,7 +560,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 	RzAnalysisFunction *fcn = item->fcn;
 	RzStackAddr sp = item->sp;
 	ut64 addr = item->start_address;
-	ut64 len = analysis->opt.bb_max_size;
+	ut64 len = RZ_MIN(analysis->opt.bb_max_size, UT16_MAX);
 	ReadAhead read_ahead_cache = { 0 };
 	const int continue_after_jump = analysis->opt.afterjmp;
 	const int addrbytes = analysis->iob.io ? analysis->iob.io->addrbytes : 1;
@@ -698,11 +694,12 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 		}
 	}
 	if ((maxlen - (addrbytes * idx)) > MAX_SCAN_SIZE) {
+		// XXX idx is always 0 here, and maxlen comes from amalysis.bb.maxsize. This makes no sense.
 		RZ_LOG_DEBUG("Skipping large memory region during basic block analysis.\n");
 		maxlen = 0;
 	}
 
-	while (addrbytes * idx < maxlen) {
+	while (true) {
 		ut32 at_delta;
 		ut64 at;
 		if (!last_is_reg_mov_lea) {
@@ -719,7 +716,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 			rz_analysis_task_item_new(analysis, tasks, fcn, bb, at, sp);
 			break;
 		}
-		ut64 bytes_read = RZ_MIN(len - at_delta, sizeof(buf));
+		ut64 bytes_read = sizeof(buf);
 		ret = read_ahead(&read_ahead_cache, analysis, at, buf, bytes_read);
 
 		if (ret < 0) {
@@ -786,8 +783,22 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 		}
 		if (!overlapped) {
 			ut64 newbbsize = bb->size + oplen;
-			if (newbbsize > MAX_FCN_SIZE) {
+			if (fcn->ninstr >= analysis->opt.fcn_max_size) {
 				gotoBeach(RZ_ANALYSIS_RET_ERROR);
+			}
+			if (newbbsize >= len) {
+				// Instruction offsets are stored in u16,
+				// artificially introduce bb split to keep the offsets within limits.
+				RzAnalysisBlock* next = fcn_append_basic_block(analysis, fcn, at);
+				if (!next) {
+					gotoBeach(RZ_ANALYSIS_RET_ERROR);
+				}
+				// If previous instruction was a jump there would already be a split.
+				// So setting jump here shouldn't overwrite any real jumps.
+				bb->jump = at;
+				item->block = bb = next;
+				next->sp_entry = sp;
+				newbbsize = bb->size + oplen;
 			}
 			bb->ninstr++;
 			rz_analysis_block_set_op_offset(bb, bb->ninstr - 1, at - bb->addr);

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -984,7 +984,7 @@ error:
 				rz_flag_space_pop(core->flags);
 			}
 			rz_analysis_add_function(core->analysis, fcn);
-			if (has_next && next != UT64_MAX) {
+			if (has_next) {
 				ut64 newaddr = rz_analysis_function_max_addr(fcn);
 				RzIOMap *map = rz_io_map_get(core->io, newaddr);
 				if (!map || (map && (map->perm & RZ_PERM_X))) {

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -640,17 +640,6 @@ RZ_API void rz_core_analysis_function_strings_print(RZ_NONNULL RzCore *core, RZ_
 	rz_list_free(xrefs);
 }
 
-static ut64 *next_append(ut64 *next, int *nexti, ut64 v) {
-	ut64 *tmp_next = realloc(next, sizeof(ut64) * (1 + *nexti));
-	if (!tmp_next) {
-		return NULL;
-	}
-	next = tmp_next;
-	next[*nexti] = v;
-	(*nexti)++;
-	return next;
-}
-
 static void rz_analysis_set_stringrefs(RzCore *core, RzAnalysisFunction *fcn) {
 	bool is_va = core->io->va;
 	RzBinObject *bobj = rz_bin_cur_object(core->bin);
@@ -826,8 +815,7 @@ static int __core_analysis_fcn(RzCore *core, ut64 at, ut64 from, int reftype, in
 	}
 	int has_next = rz_config_get_i(core->config, "analysis.hasnext");
 	RzAnalysisHint *hint = NULL;
-	int i, nexti = 0;
-	ut64 *next = NULL;
+	ut64 next = UT64_MAX;
 	int fcnlen;
 	RzAnalysisFunction *fcn = rz_analysis_function_new(core->analysis);
 	const char *fcnpfx = rz_config_get(core->config, "analysis.fcnprefix");
@@ -863,11 +851,12 @@ static int __core_analysis_fcn(RzCore *core, ut64 at, ut64 from, int reftype, in
 			break;
 		}
 		fcnlen = rz_analysis_fcn(core->analysis, fcn, at + delta, core->analysis->opt.bb_max_size, reftype);
+		at = fcn->addr; // potentially shifted by nopskip
 		if (core->analysis->opt.searchstringrefs) {
 			rz_analysis_set_stringrefs(core, fcn);
 		}
 		if (fcnlen == 0) {
-			RZ_LOG_DEBUG("Analyzed function has size of 0 at 0x%08" PFMT64x "\n", at + delta);
+			RZ_LOG_DEBUG("Analyzed function has size of 0 at 0x%08" PFMT64x "\n", fcn->addr);
 			goto error;
 		}
 		if (fcnlen < 0) {
@@ -938,27 +927,23 @@ static int __core_analysis_fcn(RzCore *core, ut64 at, ut64 from, int reftype, in
 				RzIOMap *map = rz_io_map_get(core->io, addr);
 				// only get next if found on an executable section
 				if (!map || (map && map->perm & RZ_PERM_X)) {
-					for (i = 0; i < nexti; i++) {
-						if (next[i] == addr) {
+					ut64 at = rz_analysis_function_max_addr(fcn);
+					while (true) {
+						ut64 size;
+						RzAnalysisMetaItem *mi = rz_meta_get_at(core->analysis, at, RZ_META_TYPE_ANY, &size);
+						if (!mi) {
 							break;
 						}
+						at += size;
 					}
-					if (i == nexti) {
-						ut64 at = rz_analysis_function_max_addr(fcn);
-						while (true) {
-							ut64 size;
-							RzAnalysisMetaItem *mi = rz_meta_get_at(core->analysis, at, RZ_META_TYPE_ANY, &size);
-							if (!mi) {
-								break;
-							}
-							at += size;
-						}
-						// TODO: ensure next address is function after padding (nop or trap or wat)
-						// XXX noisy for test cases because we want to clear the stderr
-						rz_cons_clear_line(stderr);
-						loganalysis(fcn->addr, at, 10000 - depth);
-						next = next_append(next, &nexti, at);
-					}
+					// TODO: ensure next address is function after padding (nop or trap or wat)
+					// nopskip already does that in run_basic_block_analysis, but it might make sense
+					// to move it here
+
+					// XXX noisy for test cases because we want to clear the stderr
+					rz_cons_clear_line(stderr);
+					loganalysis(fcn->addr, at, 10000 - depth);
+					next = at;
 				}
 			}
 			if (!rz_analysis_analyze_fcn_refs(core, fcn, depth)) {
@@ -968,14 +953,8 @@ static int __core_analysis_fcn(RzCore *core, ut64 at, ut64 from, int reftype, in
 	} while (fcnlen != RZ_ANALYSIS_RET_END);
 	rz_list_free(core->analysis->leaddrs);
 	core->analysis->leaddrs = NULL;
-	if (has_next) {
-		for (i = 0; i < nexti; i++) {
-			if (!next[i] || rz_analysis_get_fcn_in(core->analysis, next[i], 0)) {
-				continue;
-			}
-			rz_core_analysis_fcn(core, next[i], from, 0, depth - 1);
-		}
-		free(next);
+	if (has_next && next != UT64_MAX && !rz_analysis_get_fcn_in(core->analysis, next, 0)) {
+		rz_core_analysis_fcn(core, next, from, 0, depth - 1);
 	}
 	if (core->analysis->cur && core->analysis->cur->arch && !strcmp(core->analysis->cur->arch, "x86")) {
 		rz_analysis_function_check_bp_use(fcn);
@@ -1005,24 +984,18 @@ error:
 				rz_flag_space_pop(core->flags);
 			}
 			rz_analysis_add_function(core->analysis, fcn);
-		}
-		if (fcn && has_next) {
-			ut64 newaddr = rz_analysis_function_max_addr(fcn);
-			RzIOMap *map = rz_io_map_get(core->io, newaddr);
-			if (!map || (map && (map->perm & RZ_PERM_X))) {
-				next = next_append(next, &nexti, newaddr);
-				for (i = 0; i < nexti; i++) {
-					if (!next[i]) {
-						continue;
-					}
-					rz_core_analysis_fcn(core, next[i], next[i], 0, depth - 1);
+			if (has_next && next != UT64_MAX) {
+				ut64 newaddr = rz_analysis_function_max_addr(fcn);
+				RzIOMap *map = rz_io_map_get(core->io, newaddr);
+				if (!map || (map && (map->perm & RZ_PERM_X))) {
+					next = newaddr;
+					rz_core_analysis_fcn(core, next, next, 0, depth - 1);
 				}
-				free(next);
+			}
+			if (core->analysis->cur && core->analysis->cur->arch && !strcmp(core->analysis->cur->arch, "x86")) {
+				rz_analysis_function_check_bp_use(fcn);
 			}
 		}
-	}
-	if (fcn && core->analysis->cur && core->analysis->cur->arch && !strcmp(core->analysis->cur->arch, "x86")) {
-		rz_analysis_function_check_bp_use(fcn);
 	}
 	rz_analysis_hint_free(hint);
 	return false;

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -2879,6 +2879,13 @@ static bool cb_analysis_bb_max_size(void *user, void *data) {
 	return true;
 }
 
+static bool cb_analysis_fcn_max_size(void *user, void *data) {
+	RzCore *core = (RzCore *)user;
+	RzConfigNode *node = (RzConfigNode *)data;
+	core->analysis->opt.fcn_max_size = node->i_value;
+	return true;
+}
+
 static bool cb_analysis_cpp_abi(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
@@ -3102,7 +3109,8 @@ RZ_API int rz_core_config_init(RzCore *core) {
 
 	SETCB("analysis.refstr", "false", &cb_analysis_searchstringrefs, "Search string references in data references");
 	SETCB("analysis.trycatch", "false", &cb_analysis_trycatch, "Honor try.X.Y.{from,to,catch} flags");
-	SETCB("analysis.bb.maxsize", "512K", &cb_analysis_bb_max_size, "Maximum basic block size");
+	SETCB("analysis.bb.maxsize", "63K", &cb_analysis_bb_max_size, "Maximum basic block size");
+	SETCB("analysis.max_fcn_size", "256K", &cb_analysis_fcn_max_size, "Maximum function size (unspecified units)");
 	SETCB("analysis.pushret", "false", &cb_analysis_pushret, "Analyze push+ret as jmp");
 
 	n = NODECB("analysis.cpp.abi", "itanium", &cb_analysis_cpp_abi);

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3110,7 +3110,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETCB("analysis.refstr", "false", &cb_analysis_searchstringrefs, "Search string references in data references");
 	SETCB("analysis.trycatch", "false", &cb_analysis_trycatch, "Honor try.X.Y.{from,to,catch} flags");
 	SETCB("analysis.bb.maxsize", "63K", &cb_analysis_bb_max_size, "Maximum basic block size");
-	SETCB("analysis.max_fcn_size", "256K", &cb_analysis_fcn_max_size, "Maximum function size (unspecified units)");
+	SETCB("analysis.fcn_max_size", "256K", &cb_analysis_fcn_max_size, "Maximum function size (unspecified units)");
 	SETCB("analysis.pushret", "false", &cb_analysis_pushret, "Analyze push+ret as jmp");
 
 	n = NODECB("analysis.cpp.abi", "itanium", &cb_analysis_cpp_abi);

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -2875,7 +2875,7 @@ static bool cb_analysis_trycatch(void *user, void *data) {
 static bool cb_analysis_bb_max_size(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
-	core->analysis->opt.bb_max_size = node->i_value;
+	core->analysis->opt.bb_max_size = RZ_MIN(node->i_value, RZ_ANALYSIS_BLOCK_MAX_SIZE);
 	return true;
 }
 

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -999,6 +999,8 @@ typedef struct rz_analysis_bb_t {
 	int ref;
 } RzAnalysisBlock;
 
+#define RZ_ANALYSIS_BLOCK_MAX_SIZE UT16_MAX
+
 typedef struct rz_analysis_task_item {
 	RzAnalysisFunction *fcn; ///< current function
 	RzAnalysisBlock *block; ///< block being analyzed

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -419,6 +419,7 @@ typedef struct rz_analysis_options_t {
 	int searchstringrefs;
 	int followbrokenfcnsrefs;
 	int bb_max_size;
+	int fcn_max_size;
 	bool trycatch;
 	bool norevisit;
 	int afterjmp; // continue analysis after jmp eax or forward jmp // option

--- a/test/integration/meson.build
+++ b/test/integration/meson.build
@@ -9,6 +9,7 @@ if get_option('enable_tests') and cli_enabled
   )
 
   tests = [
+    'analysis_fcn',
     'analysis_global_var',
     'analysis_graph',
     'analysis_il',

--- a/test/integration/test_analysis_fcn.c
+++ b/test/integration/test_analysis_fcn.c
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2024 KarlisS <karlis3p70l1ij@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_core.h>
+#include "../unit/minunit.h"
+#include "rz_analysis.h"
+#include "rz_config.h"
+#include "rz_types_base.h"
+
+/**
+ * Test the function analysis on >64K function.
+ */
+static bool test_analysis_fcn_large() {
+	RzCore *core = rz_core_new();
+	mu_assert_notnull(core, "init core");
+	RzCoreFile *cf = rz_core_file_open(core, "malloc://240000", RZ_PERM_RWX, 0);
+	mu_assert_notnull(cf, "open 0 file");
+	rz_core_bin_load(core, NULL, 0);
+	rz_config_set(core->config, "asm.arch", "x86");
+	rz_config_set_i(core->config, "asm.bits", 64);
+
+	rz_core_analysis_fcn(core, 0, -1, RZ_ANALYSIS_XREF_TYPE_NULL, 5);
+
+	RzAnalysisFunction *f = rz_analysis_get_function_at(core->analysis, 0);
+	mu_assert_notnull(f, "Function not found");
+
+	// no point in rest of test if some sanity check limited function size smaller than this
+	mu_assert_eq(rz_analysis_function_linear_size(f), 240000, "function cut short");
+
+	mu_assert_eq(rz_core_prevop_addr_force(core, 0x22202, 1), 0x22200, "Prev not working");
+
+	ut64 end = 0;
+	RzAnalysisBlock *block = rz_analysis_fcn_bbget_at(core->analysis, f, 0);
+	while (block) {
+		end = RZ_MAX(end, block->addr + block->size);
+		if (block->jump != UT64_MAX) {
+			mu_assert_eq(block->jump, block->addr + block->size, "blocks aren't chained");
+			block = rz_analysis_fcn_bbget_at(core->analysis, f, block->jump);
+		} else {
+			block = NULL;
+		}
+	}
+	mu_assert_eq(end, 240000, "Blocks don't cover whole function");
+
+	rz_core_free(core);
+	mu_end;
+}
+
+bool all_tests() {
+	mu_run_test(test_analysis_fcn_large);
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests)

--- a/test/integration/test_analysis_fcn.c
+++ b/test/integration/test_analysis_fcn.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 KarlisS <karlis3p70l1ij@gmail.com>
+// SPDX-FileCopyrightText: 2025 KarlisS <karlis3p70l1ij@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_core.h>


### PR DESCRIPTION
Ensure instruction offset fits in uint16.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed). rizinorg/book#140

**Detailed description**

Basic block instruction offsets are stored in 16bit integers. Artificially split basic blocks during analysis to ensure the technical limit isn't broken.

Slightly changes meaning of `analysis.bb.maxsize`. Previously setting it to:
* <64k split blocks into disconnected chunks
* 64k-256k split into chunks but incorrectly stored instruction positions causing all kind of bugs
* \>256k does nothing since MAX_FCN_SIZE check would return error first

Previous default was 512k making it useless. After the changes split blocks are connected using jump field.

Introduce `analysis.fnc_max_size` as a replacement limit in case when executable contains something weird or the function analysis fails to stop for some other reason. Currently using `ninstr` since it was the beast easily available size metric. Linear size could potentially be much bigger (especially if function does something like hot/cold code split), and the other size function iterates through all the basic blocks to add up size.


Rest of the changes

read_ahead limit in fcn.c `bytes_read = sizeof(buf);` . The old limit was purely a sanity check so no need to do exact limit when reading bytes for instruction. Reading as much max potential instruction size ensures that it reads whole intstruction and doesn't try to parse partial instruction bytes near the boundary of block split.

canalysis.c next refactoring,  the code adding new item was inside

```
do {
    if (fcnlen == fcnlen == RZ_ANALYSIS_RET_END) {
       ...
        addNext(...);
    }
} while (fcnlen != RZ_ANALYSIS_RET_END);
```
So it would never have more than single entry. Simplify by replacing custom dynamic array code with single variable for single address. That and rest of changes in `__core_analysis_fcn` is from when I attempted to get it working the way `analysis.bb.maxsize` resumed analysis previously.



**Test plan**

Beside the the added test.

* open ~300K file containing 0 (as raw x64 binary)
* `aaa`
* `s 0x23000`
* visual mode
* try to move up

**Closing issues**

Closes #5086
