### PR TITLE
Update Rizin C grammar to tree-sitter-0.25.3

### DIFF
--- a/subprojects/rizin-grammar-c.wrap
+++ b/subprojects/rizin-grammar-c.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/rizinorg/rizin-grammar-c
-revision = 81d96d8822b4ae5983a1c6bae0f9fe764b666581
+revision = 815845762d59f727d79e7aa6f810688b2e1e35d2
 patch_directory = rizin-grammar-c
 directory = rizin-grammar-c
 depth = 1

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1320,21 +1320,26 @@ FILE==
 CMDS=<<EOF
 td "struct bla {int foo,bar; void *b};"
 td "union foo {float a,b; int c,d;};"
-td "typedef struct {char *a; void *b;} ts, *pts;"
+td "typedef struct {char *a; void *b;} qs, *pts;"
 tsc bla
 tuc foo
-ttc ts
+ttc qs
 tsc "anonymous struct 0"
 ttc pts
 EOF
 EXPECT=<<EOF
+struct bla {
+	int foo;
+	int bar;
+	void *b;
+};
 union foo {
 	float a;
 	float b;
 	int c;
 	int d;
 };
-typedef struct anonymous struct 0 ts;
+typedef struct anonymous struct 0 qs;
 struct anonymous struct 0 {
 	char *a;
 	void *b;
@@ -2218,10 +2223,9 @@ td "stract"
 td "struct crash __attribute__((packed)) { };"
 EOF
 EXPECT_ERR=<<EOF
-ERROR: core: Unsupported type definition: struct;;
+ERROR: core: Unsupported type definition: struct
 ERROR: core: Unsupported type definition: stract;
 ERROR: core: Unsupported type definition: { }
-Unsupported type definition: ;;
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

Update https://github.com/rizinorg/rizin-grammar-c to the latest version of the original C grammar and the latest Tree-Sitter 0.25.3 generator and runtime:

https://github.com/rizinorg/rizin-grammar-c/commits/bare-types-update/

Also fixes the parsing of `struct bla {int foo,bar; void *b}`

**Test plan**

CI is green

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/4623
