### PR TITLE
rz_core_warn_after_output: Print warnings after command output

### DIFF
--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -2792,6 +2792,7 @@ DEFINE_HANDLE_TS_FCN(statements) {
 		RzCmdStatus cmd_res = handle_ts_stmt(state, command);
 		if (state->split_lines) {
 			rz_cons_flush();
+			rz_core_print_warnings_after(core);
 			rz_core_task_yield(&core->tasks);
 		}
 		core->cons->context->cmd_depth++;

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -2782,9 +2782,9 @@ static RzCmdStatus cmd_string_search_generic(RzCore *core, const char *string, c
 	if (flags & RZ_REGEX_LITERAL) {
 		search_str_len = rz_utf8_strlen((const ut8 *)search_str);
 		if (search_str_len < core->bin->str_search_cfg.min_length) {
-			RZ_LOG_WARN("|%s| < search.str.min_length so some search hits may be hidden. Set "
-				    "search.str.min_length to %" PFMTSZu " to see them.\n",
-				search_str, search_str_len);
+			rz_core_warn_after_output(core, rz_str_newf("|%s| < search.str.min_length so some search hits may be hidden. Set "
+								    "search.str.min_length to %" PFMTSZu " to see them.\n",
+								search_str, search_str_len));
 		}
 	}
 

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -138,6 +138,26 @@ RZ_API void rz_core_notify_error_str(RZ_NONNULL RzCore *core, RZ_NONNULL const c
 	rz_core_notify_error(core, "%s", text);
 }
 
+/**
+ * \brief  Delays printing of a warning until after command output
+ *
+ * \param  core    The RzCore to use
+ * \param  warning The message to warn about (must be heap-allocated)
+ */
+RZ_API void rz_core_warn_after_output(RZ_NONNULL RzCore *core, RZ_NONNULL const char *warning) {
+	rz_return_if_fail(core && warning);
+	rz_list_append(core->warnings_after, (char *)warning);
+}
+
+RZ_IPI void rz_core_print_warnings_after(RZ_NONNULL RzCore *core) {
+	rz_return_if_fail(core);
+	for (ut32 i = 0; i < rz_list_length(core->warnings_after); i++) {
+		char *warn_str = rz_list_pop_head(core->warnings_after);
+		RZ_LOG_WARN("%s", warn_str);
+		free(warn_str);
+	}
+}
+
 static int on_fcn_new(RzAnalysis *_analysis, void *_user, RzAnalysisFunction *fcn) {
 	RzCore *core = (RzCore *)_user;
 	const char *cmd = rz_config_get(core->config, "cmd.fcn.new");
@@ -1541,6 +1561,7 @@ RZ_API bool rz_core_init(RzCore *core) {
 	core->egg = rz_egg_new();
 	rz_egg_setup(core->egg, RZ_SYS_ARCH, RZ_SYS_BITS, 0, RZ_SYS_OS);
 	core->crypto = rz_crypto_new();
+	core->warnings_after = rz_list_newf((RzListFree)free);
 
 	core->fixedarch = false;
 	core->fixedbits = false;
@@ -1778,6 +1799,7 @@ RZ_API void rz_core_fini(RzCore *c) {
 	RZ_FREE(c->rtr_host);
 	RZ_FREE(c->curtheme);
 	RZ_FREE_CUSTOM(c->visual, rz_core_visual_free);
+	RZ_FREE_CUSTOM(c->warnings_after, rz_list_free);
 }
 
 RZ_API void rz_core_free(RzCore *c) {
@@ -1937,6 +1959,7 @@ RZ_API int rz_core_prompt_exec(RzCore *r) {
 	if (r->cons && r->cons->line && r->cons->line->zerosep) {
 		rz_cons_zero();
 	}
+	rz_core_print_warnings_after(r);
 	return ret;
 }
 

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -10,7 +10,7 @@
 
 RZ_IPI void rz_core_kuery_print(RzCore *core, const char *k);
 RZ_IPI int rz_output_mode_to_char(RzOutputMode mode);
-RZ_IPI void rz_core_print_warnings_after(RzCore *core);
+RZ_IPI void rz_core_print_warnings_after(RZ_NONNULL RzCore *core);
 
 RZ_IPI int bb_cmpaddr(const void *_a, const void *_b, void *user);
 RZ_IPI int fcn_cmpaddr(const void *_a, const void *_b, void *user);

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -10,6 +10,7 @@
 
 RZ_IPI void rz_core_kuery_print(RzCore *core, const char *k);
 RZ_IPI int rz_output_mode_to_char(RzOutputMode mode);
+RZ_IPI void rz_core_print_warnings_after(RzCore *core);
 
 RZ_IPI int bb_cmpaddr(const void *_a, const void *_b, void *user);
 RZ_IPI int fcn_cmpaddr(const void *_a, const void *_b, void *user);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -338,6 +338,7 @@ struct rz_core_t {
 	RzList /*<char *>*/ *ropchain;
 	RzCoreSeekHistory seek_history;
 	RzHash *hash;
+	RzList /*<char *>*/ *warnings_after;
 
 	bool marks_init;
 	ut64 marks[UT8_MAX + 1];
@@ -407,6 +408,8 @@ RZ_API void rz_core_notify_error(RZ_NONNULL RzCore *core, RZ_NONNULL const char 
 RZ_API void rz_core_notify_begin_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
 RZ_API void rz_core_notify_done_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
 RZ_API void rz_core_notify_error_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
+
+RZ_API void rz_core_warn_after_output(RZ_NONNULL RzCore *core, RZ_NONNULL const char *warning);
 
 /**
  * \brief APIs to handle Visual Gadgets

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -1393,17 +1393,28 @@ echo ----
 /z ¢€𐍈 @e:search.str.min_length=3
 EOF
 EXPECT=<<EOF
-WARNING: |ab| < search.str.min_length so some search hits may be hidden. Set search.str.min_length to 2 to see them.
 0x00000030 2 hit.string.ascii.0
+WARNING: |ab| < search.str.min_length so some search hits may be hidden. Set search.str.min_length to 2 to see them.
 ----
 0x00000010 2 hit.string.ascii.0
 0x00000020 2 hit.string.ascii.1
 0x00000030 2 hit.string.ascii.2
 
-WARNING: |¢€𐍈| < search.str.min_length so some search hits may be hidden. Set search.str.min_length to 3 to see them.
 0x00000050 9 hit.string.utf8.0
+WARNING: |¢€𐍈| < search.str.min_length so some search hits may be hidden. Set search.str.min_length to 3 to see them.
 ----
 0x00000040 9 hit.string.utf8.0
 0x00000050 9 hit.string.utf8.1
+EOF
+RUN
+
+NAME=String search - warn if |search literal| < search.str.min_length (prompt version)
+FILE==
+CMDS=!rizin -e cfg.fortunes=0 -e scr.color=0 -c "< \n/z ab\nq\n" -1 =
+EXPECT=<<EOF
+[2K[0x00000000]> [0x00000000]> [2K[0x00000000]> 
+[2K[0x00000000]> [0x00000000]> [2K[2K[0x00000000]> /[0x00000000]> /[2K[2K[0x00000000]> /z[0x00000000]> /z[2K[2K[0x00000000]> /z [0x00000000]> /z [2K[2K[0x00000000]> /z a[0x00000000]> /z a[2K[2K[0x00000000]> /z ab[0x00000000]> /z ab[2K[0x00000000]> /z ab
+[2KWARNING: |ab| < search.str.min_length so some search hits may be hidden. Set search.str.min_length to 2 to see them.
+[2K[0x00000000]> [0x00000000]> [2K[2K[0x00000000]> q[0x00000000]> q[2K[0x00000000]> q
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [X] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr adds a facility to rz_core that allows warnings to be printed after command output. This is specifically done for `/z` since there is the possibility that there are so many hits, one has to scroll up to see the warnings.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The addition makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
