### PR TITLE
build: enable GNU C99 extension by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,7 +368,7 @@ jobs:
         working-directory: rizin
       - name: Build
         run: |
-          meson setup --prefix=/usr build && ninja -C build
+          meson setup -Dc_std=gnu99 --prefix=/usr build && ninja -C build
         working-directory: rizin
       - name: Install
         run: ninja -C build install
@@ -450,7 +450,7 @@ jobs:
         run: find subprojects -name '*.wrap' | xargs sed -i '/^depth = 1$/d'
         working-directory: rizin
       - name: Build with Meson + Ninja
-        run: meson setup --prefix=/usr build && ninja -C build
+        run: meson setup -Dc_std=gnu99 --prefix=/usr build && ninja -C build
         working-directory: rizin
       - name: Install with Ninja
         run: ninja -C build install

--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,6 @@ project('rizin', 'c',
   default_options: [
     'buildtype=debugoptimized',
     'b_vscrt=from_buildtype',
-    'c_std=c99',
     'warning_level=1',
   ]
 )
@@ -89,6 +88,16 @@ if cc.has_argument('-Wenum-conversion')
 endif
 if cc.has_argument('-Wenum-compare')
   add_project_arguments('-DCC_SUPPORTS_W_ENUM_COMPARE', language: ['c', 'cpp'])
+endif
+
+if cc.has_argument('-std=gnu99')
+  add_project_arguments('-std=gnu99', language: ['c', 'cpp'])
+elif cc.has_argument('--std=gnu99')
+  add_project_arguments('--std=gnu99', language: ['c', 'cpp'])
+elif cc.has_argument('-std=c99')
+  add_project_arguments('-std=c99', language: ['c', 'cpp'])
+elif cc.has_argument('--std=c99')
+  add_project_arguments('--std=c99', language: ['c', 'cpp'])
 endif
 
 # Sanitize correct usage of rz_strf()


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

To enable use of GNU-specific extensions by default, e.g. "constructor" and "destructor" attributes needed for `librz/include/rz_constructor.h` and `librz/include/path.c` for portable prefix support.

It partially reverts the changes done in https://github.com/rizinorg/rizin/commit/79814e46b635640a43e416593b3553f8a7a75174

The proper fix should be done separately and afterwards: https://github.com/rizinorg/rizin/issues/5100

**Test plan**

CI is green