### PR TITLE
Move cmd_search_z prompt test to not-windows-any

### DIFF
--- a/test/db/archos/not-windows-any/cmd_search_z
+++ b/test/db/archos/not-windows-any/cmd_search_z
@@ -1,0 +1,10 @@
+NAME=String search - warn if |search literal| < search.str.min_length (prompt version)
+FILE==
+CMDS=!rizin -e cfg.fortunes=0 -e scr.color=0 -c "< \n/z ab\nq\n" -1 =
+EXPECT=<<EOF
+[2K[0x00000000]> [0x00000000]> [2K[0x00000000]> 
+[2K[0x00000000]> [0x00000000]> [2K[2K[0x00000000]> /[0x00000000]> /[2K[2K[0x00000000]> /z[0x00000000]> /z[2K[2K[0x00000000]> /z [0x00000000]> /z [2K[2K[0x00000000]> /z a[0x00000000]> /z a[2K[2K[0x00000000]> /z ab[0x00000000]> /z ab[2K[0x00000000]> /z ab
+[2KWARNING: |ab| < search.str.min_length so some search hits may be hidden. Set search.str.min_length to 2 to see them.
+[2K[0x00000000]> [0x00000000]> [2K[2K[0x00000000]> q[0x00000000]> q[2K[0x00000000]> q
+EOF
+RUN

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -1407,14 +1407,3 @@ WARNING: |¢€𐍈| < search.str.min_length so some search hits may be hidden. 
 0x00000050 9 hit.string.utf8.1
 EOF
 RUN
-
-NAME=String search - warn if |search literal| < search.str.min_length (prompt version)
-FILE==
-CMDS=!rizin -e cfg.fortunes=0 -e scr.color=0 -c "< \n/z ab\nq\n" -1 =
-EXPECT=<<EOF
-[2K[0x00000000]> [0x00000000]> [2K[0x00000000]> 
-[2K[0x00000000]> [0x00000000]> [2K[2K[0x00000000]> /[0x00000000]> /[2K[2K[0x00000000]> /z[0x00000000]> /z[2K[2K[0x00000000]> /z [0x00000000]> /z [2K[2K[0x00000000]> /z a[0x00000000]> /z a[2K[2K[0x00000000]> /z ab[0x00000000]> /z ab[2K[0x00000000]> /z ab
-[2KWARNING: |ab| < search.str.min_length so some search hits may be hidden. Set search.str.min_length to 2 to see them.
-[2K[0x00000000]> [0x00000000]> [2K[2K[0x00000000]> q[0x00000000]> q[2K[0x00000000]> q
-EOF
-RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The cmd_search_z prompt test has been causing intermittent failures of Windows builds so this pr moves it to `archos/not-windows-any` for now.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
