### PR TITLE
rz-find: do not print filenames without match

### DIFF
--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -57,8 +57,14 @@ static void rzfind_options_init(RzfindOptions *ro) {
 
 static int rzfind_open(RzfindOptions *ro, const char *file);
 
+typedef struct {
+	RzfindOptions *opt;
+	const char *filename;
+} RzfindContext;
+
 static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
-	RzfindOptions *ro = (RzfindOptions *)user;
+	RzfindContext *ctx = (RzfindContext *)user;
+	RzfindOptions *ro = ctx->opt;
 	int delta = addr - ro->cur;
 	if (ro->cur > addr && (ro->cur - addr == kw->keyword_length - 1)) {
 		// This case occurs when there is hit in search left over
@@ -67,6 +73,9 @@ static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 	if (delta < 0 || delta >= ro->bsize) {
 		eprintf("Invalid delta\n");
 		return 0;
+	}
+	if (!ro->quiet) {
+		printf("File: %s\n", ctx->filename);
 	}
 	char _str[128];
 	char *str = _str;
@@ -240,10 +249,6 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 	int ret, result = 0;
 
 	ro->buf = NULL;
-	if (!ro->quiet) {
-		printf("File: %s\n", file);
-	}
-
 	char *efile = rz_str_escape_sh(file);
 
 	if (ro->identify) {
@@ -353,7 +358,8 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 		goto err;
 	}
 	rs->align = ro->align;
-	rz_search_set_callback(rs, &hit, ro);
+	RzfindContext ctx = { .opt = ro, .filename = file };
+	rz_search_set_callback(rs, &hit, &ctx);
 	ut64 to = ro->to;
 	if (to == -1) {
 		to = rz_io_size(io);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

Before it was printing a file always, not only if there is a match, which made interpreting results quite difficult

**Test plan**

`rz-find -s serial rizin-testbins/elf/analysis` should not print filenames without matches

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/5108
