### PR TITLE
fix: `pxf` command prints function hexdump

### DIFF
--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -2581,7 +2581,34 @@ RZ_IPI RzCmdStatus rz_print_hexdump_emoji_handler(RzCore *core, int argc, const 
 }
 
 RZ_IPI RzCmdStatus rz_print_hexdump_function_handler(RzCore *core, int argc, const char **argv) {
-	return RZ_CMD_STATUS_ERROR;
+	RzAnalysisFunction *function = rz_analysis_get_fcn_in(core->analysis, core->offset, RZ_ANALYSIS_FCN_TYPE_ROOT);
+	if (!function) {
+		function = rz_analysis_get_fcn_in(core->analysis, core->offset, 0);
+	}
+	if (!function) {
+		RZ_LOG_ERROR("Cannot find function at 0x%08" PFMT64x "\n", core->offset);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	// Disable printing header for RzPrint
+	int old_flags = core->print->flags;
+	core->print->flags &= ~RZ_PRINT_FLAGS_HEADER;
+
+	RzAnalysisBlock *b;
+	void **iter;
+	rz_pvector_foreach (function->bbs, iter) {
+		b = (RzAnalysisBlock *)*iter;
+		ut8 *buf = malloc(b->size);
+		if (!buf) {
+			RZ_LOG_ERROR("core: cannot allocate %" PFMT64u " byte(s)\n", b->size);
+			core->print->flags = old_flags;
+			return RZ_CMD_STATUS_ERROR;
+		}
+		rz_io_read_at(core->io, b->addr, buf, b->size);
+		rz_core_print_hexdump(core, b->addr, buf, b->size, 0, 16, 0);
+		free(buf);
+	}
+	core->print->flags = old_flags;
+	return RZ_CMD_STATUS_OK;
 }
 
 RZ_IPI RzCmdStatus rz_print_hexdump_hexii_handler(RzCore *core, int argc, const char **argv) {

--- a/test/db/cmd/cmd_print
+++ b/test/db/cmd/cmd_print
@@ -991,3 +991,18 @@ EXPECT=<<EOF
 ++++++    _|  10
 EOF
 RUN
+
+NAME=pxf
+FILE=bins/elf/analysis/main
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+aaa
+pxf
+EOF
+EXPECT=<<EOF
+0x00400410  31ed 4989 d15e 4889 e248 83e4 f050 5449  1.I..^H..H...PTI
+0x00400420  c7c0 b005 4000 48c7 c120 0540 0048 c7c7  ....@.H.. .@.H..
+EOF
+RUN
+


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

Previously `pxf` was unimplemented. Implement the basic variant of it, more modes could arrive after some use of this command.

**Test plan**

- CI is green
- Try this command on functions with non-linear structure, the output should make sense

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/5107
