### PR TITLE
Fix possible null deref when malloc fails in crypto

### DIFF
--- a/librz/crypto/crypto.c
+++ b/librz/crypto/crypto.c
@@ -113,13 +113,13 @@ RZ_API RZ_OWN RzCrypto *rz_crypto_new(void) {
 	}
 
 	cry->plugins = ht_sp_new(HT_STR_DUP, NULL, NULL);
+	if (!cry->plugins) {
+		goto rz_crypto_new_bad;
+	}
 	for (size_t i = 0; i < RZ_ARRAY_SIZE(crypto_static_plugins); ++i) {
 		if (!ht_sp_insert(cry->plugins, crypto_static_plugins[i]->name, crypto_static_plugins[i])) {
 			RZ_LOG_WARN("Plugin '%s' was already added.\n", crypto_static_plugins[i]->name);
 		}
-	}
-	if (!cry->plugins) {
-		goto rz_crypto_new_bad;
 	}
 	return cry;
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

Fix a possible null deref.