### PR TITLE
rz-find: print filename for symbol and import search

### DIFF
--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -295,6 +295,9 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 				rz_pvector_foreach (imports, vec_it) {
 					import = *vec_it;
 					if (!strcmp(import->name, kw)) {
+						if (!ro->quiet) {
+							printf("File: %s\n", file);
+						}
 						printf("ordinal: %d %s\n", import->ordinal, kw);
 					}
 				}
@@ -314,6 +317,9 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 					}
 
 					if (!strcmp(symbol->name, kw)) {
+						if (!ro->quiet) {
+							printf("File: %s\n", file);
+						}
 						printf("paddr: 0x%08" PFMT64x " vaddr: 0x%08" PFMT64x " type: %s %s\n", symbol->paddr, symbol->vaddr, symbol->type, symbol->name);
 					}
 				}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

Previously `rz-find -S` and `rz-find -I` weren't printing filename of the match when running on a directory. Now it prints.

**Test plan**

- `rz-find -S bla <dir>`
- `rz-find -I foo <dir>`