### PR TITLE
Fix: wrong access of the config scr.color

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -6053,7 +6053,7 @@ RZ_API RZ_OWN char *rz_core_analysis_var_to_string(RZ_NONNULL RzCore *core, RZ_N
 		return NULL;
 	}
 
-	bool color = rz_config_get_b(core->config, "scr.color");
+	bool color = rz_config_get_i(core->config, "scr.color") > 0;
 	bool color_arg = color && rz_config_get_b(core->config, "scr.color.args");
 	RzConsPrintablePalette *pal = &core->cons->context->pal;
 

--- a/librz/include/rz_heap_glibc.h
+++ b/librz/include/rz_heap_glibc.h
@@ -12,18 +12,18 @@ extern "C" {
 RZ_LIB_VERSION_HEADER(rz_heap_glibc);
 
 #define PRINTF_A(color, fmt, ...) rz_cons_printf("%s" fmt "%s", \
-	rz_config_get_b(core->config, "scr.color") ? color : "", \
+	rz_config_get_i(core->config, "scr.color") > 0 ? color : "", \
 	__VA_ARGS__, \
-	rz_config_get_b(core->config, "scr.color") ? Color_RESET : "")
+	rz_config_get_i(core->config, "scr.color") > 0 ? Color_RESET : "")
 #define PRINTF_YA(fmt, ...) PRINTF_A(pal->offset, fmt, __VA_ARGS__)
 #define PRINTF_GA(fmt, ...) PRINTF_A(pal->args, fmt, __VA_ARGS__)
 #define PRINTF_BA(fmt, ...) PRINTF_A(pal->num, fmt, __VA_ARGS__)
 #define PRINTF_RA(fmt, ...) PRINTF_A(pal->invalid, fmt, __VA_ARGS__)
 
 #define PRINT_A(color, msg) rz_cons_printf("%s%s%s", \
-	rz_config_get_b(core->config, "scr.color") ? color : "", \
+	rz_config_get_i(core->config, "scr.color") > 0 ? color : "", \
 	msg, \
-	rz_config_get_b(core->config, "scr.color") ? Color_RESET : "")
+	rz_config_get_i(core->config, "scr.color") > 0 ? Color_RESET : "")
 #define PRINT_YA(msg) PRINT_A(pal->offset, msg)
 #define PRINT_GA(msg) PRINT_A(pal->args, msg)
 #define PRINT_BA(msg) PRINT_A(pal->num, msg)

--- a/librz/include/rz_heap_jemalloc.h
+++ b/librz/include/rz_heap_jemalloc.h
@@ -28,18 +28,18 @@
 #undef PRINTF_RA
 
 #define PRINTF_A(color, fmt, ...) rz_cons_printf("%s" fmt "%s", \
-	rz_config_get_b(core->config, "scr.color") ? color : "", \
+	rz_config_get_i(core->config, "scr.color") > 0 ? color : "", \
 	__VA_ARGS__, \
-	rz_config_get_b(core->config, "scr.color") ? Color_RESET : "")
+	rz_config_get_i(core->config, "scr.color") > 0 ? Color_RESET : "")
 #define PRINTF_YA(fmt, ...) PRINTF_A(pal->offset, fmt, __VA_ARGS__)
 #define PRINTF_GA(fmt, ...) PRINTF_A(pal->args, fmt, __VA_ARGS__)
 #define PRINTF_BA(fmt, ...) PRINTF_A(pal->num, fmt, __VA_ARGS__)
 #define PRINTF_RA(fmt, ...) PRINTF_A(pal->invalid, fmt, __VA_ARGS__)
 
 #define PRINT_A(color, msg) rz_cons_printf("%s%s%s", \
-	rz_config_get_b(core->config, "scr.color") ? color : "", \
+	rz_config_get_i(core->config, "scr.color") > 0 ? color : "", \
 	msg, \
-	rz_config_get_b(core->config, "scr.color") ? Color_RESET : "")
+	rz_config_get_i(core->config, "scr.color") > 0 ? Color_RESET : "")
 #define PRINT_YA(msg) PRINT_A(pal->offset, msg)
 #define PRINT_GA(msg) PRINT_A(pal->args, msg)
 #define PRINT_BA(msg) PRINT_A(pal->num, msg)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

`scr.color` should be accessed by `rz_config_get_i` instead of `rz_config_get_b`.

One left `bool color_arg = (rz_config_get_b(core->config, "scr.color") && rz_config_get_b(core->config, "scr.color.args"));` is changed in another pr (colorize afi output).

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

CI is green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
