### PR TITLE
elf.c: Check `e_shstrndx` against `sections`' length, not capacity

### DIFF
--- a/librz/bin/format/elf/elf.c
+++ b/librz/bin/format/elf/elf.c
@@ -196,11 +196,12 @@ static bool init_shstrtab_aux(ELFOBJ *bin, RzVector /*<Elf_(Shdr)>*/ *sections) 
 		return true;
 	}
 
-	Elf_(Shdr) *section = rz_vector_index_ptr(sections, bin->ehdr.e_shstrndx);
-	if (!section) {
-		RZ_LOG_WARN("Invalid ELF header e_shstrndx value.\n");
+	if (bin->ehdr.e_shstrndx >= rz_vector_len(sections)) {
+		RZ_LOG_WARN("ELF header e_shstrndx value (%" PFMT32u ") >= number of sections (%" PFMTSZu ").\n",
+			bin->ehdr.e_shstrndx, rz_vector_len(sections));
 		return false;
 	}
+	Elf_(Shdr) *section = rz_vector_index_ptr(sections, bin->ehdr.e_shstrndx);
 
 	bin->shstrtab = Elf_(rz_bin_elf_strtab_new)(bin, section->sh_offset, section->sh_size);
 	if (!bin->shstrtab) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

In elf.c, this pr checks `e_shstrndx` against `sections`' length and not capacity since the former makes more sense, and `sections`' length should always be less than or equal its capacity so this is a tighter bound. The original check against capacity was done by `rz_vector_index_ptr()`'s precondition assertion.

This is a cherry-pick from #5102.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
