### PR TITLE
Remove "not" from rz_path(_set)_prefix func comments

### DIFF
--- a/librz/util/path.c
+++ b/librz/util/path.c
@@ -84,11 +84,11 @@ err:
  * \brief Return \p path prefixed by the Rizin install prefix
  *
  * The install prefix is taken from the build-time configuration RZ_PREFIX,
- * unless Rizin was not compiled as "portable". In such a case the prefix is
- * either discovered from the path of the executable calling this function or
- * stored via the path variable
+ * unless Rizin was compiled as "portable". In such a case the prefix is either
+ * provided via the path argument or discovered from the path of the executable
+ * calling this function.
  *
- * \param path Path to use when to prefix or NULL to use the binary location
+ * \param path Path to use when prefixing or NULL to use the executable location
  */
 RZ_API void rz_path_set_prefix(RZ_NONNULL const char *path) {
 #if RZ_IS_PORTABLE
@@ -108,7 +108,7 @@ RZ_API void rz_path_set_prefix(RZ_NONNULL const char *path) {
  * \brief Return \p path prefixed by the Rizin install prefix
  *
  * The install prefix is taken from the build-time configuration RZ_PREFIX,
- * unless Rizin was not compiled as "portable". In such a case the prefix is
+ * unless Rizin was compiled as "portable". In such a case the prefix is
  * discovered from the path of the executable calling this function.
  *
  * \param path Path to put in the install prefix context or NULL to just get the install prefix


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr basically just removes "not" from the rz_path_set_prefix() and rz_path_prefix() function header comments so that they make sense (and also does some minor editing).

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The changes make sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
