### PR TITLE
Update hexdump & breakpoint list visual panel commands.

### DIFF
--- a/librz/core/tui/panels.c
+++ b/librz/core/tui/panels.c
@@ -36,7 +36,7 @@
 #define PANEL_CMD_FUNCTION      "afl"
 #define PANEL_CMD_GRAPH         "agf"
 #define PANEL_CMD_TINYGRAPH     "agft"
-#define PANEL_CMD_HEXDUMP       "xc"
+#define PANEL_CMD_HEXDUMP       "px"
 #define PANEL_CMD_CONSOLE       "$console"
 
 #define PANEL_CONFIG_MENU_MAX    64
@@ -4969,7 +4969,7 @@ void __init_sdb(RzCore *core) {
 	ht_ss_insert(db, "Info", "i");
 	ht_ss_insert(db, "Database", "k ***");
 	ht_ss_insert(db, "Console", "$console");
-	ht_ss_insert(db, "Hexdump", "xc $r*16");
+	ht_ss_insert(db, "Hexdump", "px");
 	ht_ss_insert(db, "Xrefs", "axl");
 	ht_ss_insert(db, "Functions", "afl");
 	ht_ss_insert(db, "Function Calls", "aflm");
@@ -4984,7 +4984,7 @@ void __init_sdb(RzCore *core) {
 	ht_ss_insert(db, "Maps", "dm");
 	ht_ss_insert(db, "Modules", "dmm");
 	ht_ss_insert(db, "Backtrace", "dbt");
-	ht_ss_insert(db, "Breakpoints", "db");
+	ht_ss_insert(db, "Breakpoints", "dbl");
 	ht_ss_insert(db, "Imports", "iiq");
 	ht_ss_insert(db, "Clipboard", "yx");
 	ht_ss_insert(db, "New", "o");


### PR DESCRIPTION
- Update hardcoded command strings in `panels.c`.

**Your checklist for this pull request**
- [V] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [V] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [V] I've documented every `RZ_API` function and struct this PR changes.
- [V] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [V] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

Rizin hardcodes commands passed to the predefined panels in visual panel mode. For the `hexdump` and `breakpoints` panels outdated commands are used:

- Hexdump: rizin prints `ERROR: Usage: [...]` into the panel instead of a hexdump.
- Breakpoints: The panel is empty even if breakpoints are set.

This PR simply updates the commands for the hexdump and breakpoints panel:

- Hexdump now uses `px` to dump 256 bytes, just like the stack panel.
- Breakpoint panel now uses `dbl` instead of `db`. The previous `db` panel was particularly inappropriate as it may have been setting breakpoints unexpectedly.
...

**Test plan**

```
$ rizin -d a.out
> s main
> db
[enter visual mode and open the hexdump & breakpoints panels]
```
...

**Closing issues**

N/A
...
