### PR TITLE
Fix divide by zero in visual open list command

### DIFF
--- a/librz/core/cmd/cmd_open.c
+++ b/librz/core/cmd/cmd_open.c
@@ -57,7 +57,9 @@ static bool desc_list_visual_cb(void *user, void *data, ut32 id) {
 		.curpos = 0,
 		.color = rz_config_get_i(core->config, "scr.color")
 	};
-	RzStrBuf *strbuf = rz_progressbar(&opts, sz * 100 / u->fdsz, rz_cons_get_size(NULL) - 40);
+	// avoid divide-by-zero error when the total file size is zero.
+	int percent = u->fdsz == 0 ? 0 : sz * 100 / u->fdsz;
+	RzStrBuf *strbuf = rz_progressbar(&opts, percent, rz_cons_get_size(NULL) - 40);
 	if (!strbuf) {
 		RZ_LOG_ERROR("Cannot generate progressbar\n");
 	} else {


### PR DESCRIPTION
* This occurs when opening an executable with `winedbg://` and then listing the open files with `o=`.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

This pull request fixes a bug where running the following commands will result in a divide by zero exception:

```console
> o winedbg://hello.exe
> o=
```

It fixes it by setting the width of the bar to zero:

```console
~/Downloads/games/Basilisk 2000 Build Tool> ~/Downloads/software/rizinorg/rizin/meson_out/bin/rizin winedbg://`Basilisk 2000 Build Tool.exe`~/Downloads/g~/Downloads/games/Basilisk 2000 Build Tool> ~/Downloads/software/rizinorg/rizin/build/binrz/rizin/rizin winedbg://`Basilisk 2000 Build Tool.exe`
ERROR: rz-run: connected
Wine-dbg is ready to go!
[0x00000000]> o=
 3 * rwx 0x00000000  3 * rwx 0x00000000 [―――――――――――――――――――――――――――――――――] winedbg://Basilisk 2000 Build Tool.exe
[0x00000000]> 
```
