### PR TITLE
Add confirmation to large hexdump reads.

### DIFF
--- a/librz/core/cprint.c
+++ b/librz/core/cprint.c
@@ -261,7 +261,7 @@ static inline void len_fixup(RzCore *core, ut64 *addr, int *len) {
 	bool is_positive = *len > 0;
 	if (RZ_ABS(*len) > core->blocksize_max) {
 		RZ_LOG_ERROR("this <len> is too big (0x%" PFMT32x
-			     " < 0x%" PFMT32x ").",
+			     " < 0x%" PFMT32x ").\n",
 			*len, core->blocksize_max);
 		*len = (int)core->blocksize_max;
 	}
@@ -351,7 +351,6 @@ RZ_API RZ_OWN char *rz_core_print_hexdump_or_hexdiff_str(RZ_NONNULL RzCore *core
 	ut64 from = rz_config_get_i(core->config, "diff.from");
 	ut64 to = rz_config_get_i(core->config, "diff.to");
 	if (from == to && !from) {
-		len_fixup(core, &addr, &len);
 		ut8 *buffer = malloc(len);
 		if (!buffer) {
 			return NULL;
@@ -387,6 +386,11 @@ RZ_API RZ_OWN char *rz_core_print_hexdump_or_hexdiff_str(RZ_NONNULL RzCore *core
 
 RZ_IPI bool rz_core_print_hexdump_or_hexdiff(RZ_NONNULL RzCore *core, RZ_NULLABLE RzOutputMode mode, ut64 addr, int len,
 	bool use_comment) {
+	len_fixup(core, &addr, &len);
+	if (len > 0x1000
+		&& !rz_cons_yesno('n', "Do you want to read 0x%x bytes? (y/N)", len)) {
+		return true;
+	}
 	char *string = rz_core_print_hexdump_or_hexdiff_str(core, mode, addr, len, use_comment);
 	if (!string) {
 		RZ_LOG_ERROR("fail to print hexdump at 0x%" PFMT64x "\n", addr);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

If you mistakenly provide a very large length parameter to `px` (in my case, `px rsp`), rizin will continue the read until it is complete. This can take several minutes, and can't be cancelled with SIGINT.

This PR adds a check via `rz_cons_yesno()`, requesting the user to confirm hexdumps above some threshhold. For now, this threshhold is 0x1000.

If a `rz_core_print_hexdump_or_hexdiff_str()` returns NULL, an additional error message is printed. To avoid this message in case the user answers `n` to the confirmation, the length is now normalised and confirmed before calling `rz_core_print_hexdump_or_hexdiff_str()`.

I imagine the real solution here is to register a temporary SIGINT handler that would cancel the read. I'm inclined to say that an even better solution is probably to register a generic SIGINT handler, and have it call a callback for whichever operation is currently ongoing. I'm not sure how feasible that is given the current architecture. I'm also not familiar with the codebase enough yet to implement something like this.

...

**Test plan**

```
$ rizin -d a.out
> s main
> px 0x40000000
[attempt both y & n paths]
```
I'd be happy to define some tests for this if you'd like.

...

**Closing issues**

N/A
...
