### PR TITLE
Use `rz_buf_new_file` when loading PDB & FLIRT files.

### DIFF
--- a/librz/bin/pdb/pdb.c
+++ b/librz/bin/pdb/pdb.c
@@ -305,7 +305,7 @@ bool is_compressed_pdb(RzBuffer *buf) {
  */
 RZ_API RZ_OWN RzPdb *rz_bin_pdb_parse_from_file(RZ_NONNULL const char *filename) {
 	rz_return_val_if_fail(filename, NULL);
-	RzBuffer *buf = rz_buf_new_slurp(filename);
+	RzBuffer *buf = rz_buf_new_file(filename, O_RDONLY, 0);
 	if (!buf) {
 		RZ_LOG_ERROR("%s: Error reading file \"%s\"\n", __FUNCTION__, filename);
 		return false;

--- a/librz/core/csign.c
+++ b/librz/core/csign.c
@@ -384,7 +384,7 @@ RZ_API bool rz_core_flirt_dump_file(RZ_NONNULL const char *flirt_file) {
 	RzBuffer *buffer = NULL;
 	RzFlirtNode *node = NULL;
 
-	if (!(buffer = rz_buf_new_slurp(flirt_file))) {
+	if (!(buffer = rz_buf_new_file(flirt_file, O_RDONLY, 0))) {
 		RZ_LOG_ERROR("FLIRT: cannot open %s (read mode)\n", flirt_file);
 		return false;
 	} else if (!strcmp(extension, ".pat")) {
@@ -539,7 +539,7 @@ RZ_API bool rz_core_flirt_convert_file(RZ_NONNULL RzCore *core, RZ_NONNULL const
 		return false;
 	}
 
-	if (!(buffer = rz_buf_new_slurp(input_file))) {
+	if (!(buffer = rz_buf_new_file(input_file, O_RDONLY, 0))) {
 		RZ_LOG_ERROR("FLIRT: cannot open %s (read mode)\n", input_file);
 		return false;
 	} else if (!strcmp(in_extension, ".pat")) {

--- a/librz/sign/flirt.c
+++ b/librz/sign/flirt.c
@@ -1326,7 +1326,7 @@ RZ_API bool rz_sign_flirt_apply(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL cons
 		return false;
 	}
 
-	if (!(flirt_buf = rz_buf_new_slurp(flirt_file))) {
+	if (!(flirt_buf = rz_buf_new_file(flirt_file, O_RDONLY, 0))) {
 		RZ_LOG_ERROR("FLIRT: Can't open %s\n", flirt_file);
 		return false;
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

Use `rz_buf_new_file` instead of `rz_buf_new_slurp` for pdb

This ensures that pdb files with size beyond 4gb are able to be parsed.