### PR TITLE
Enable rz-test to test for multiple instructions in a single asm test case

### DIFF
--- a/binrz/rz-test/run.c
+++ b/binrz/rz-test/run.c
@@ -382,6 +382,7 @@ RZ_API RzAsmTestOutput *rz_test_run_asm_test(RzTestRunConfig *config, RzAsmTest 
 		}
 		char *disasm = (char *)crlf2lf(rz_subprocess_out(proc, NULL));
 		rz_str_trim(disasm);
+		rz_str_replace_char(disasm, '\n', ';');
 		out->disasm = disasm;
 	ship:
 		free(hex);
@@ -403,6 +404,7 @@ RZ_API RzAsmTestOutput *rz_test_run_asm_test(RzTestRunConfig *config, RzAsmTest 
 		} else {
 			char *il = (char *)crlf2lf(rz_subprocess_out(proc, NULL));
 			rz_str_trim(il);
+			rz_str_replace_char(il, '\n', ';');
 			char *il_err = (char *)crlf2lf(rz_subprocess_err(proc, NULL));
 			rz_str_trim(il_err);
 			out->il = il;

--- a/librz/main/rz-asm.c
+++ b/librz/main/rz-asm.c
@@ -331,6 +331,7 @@ static int rasm_disasm(RzAsmState *as, ut64 addr, const char *buf, int len, int 
 				break;
 			}
 			ret += aop.size;
+			addr += aop.size;
 			rz_analysis_op_fini(&aop);
 		}
 		break;
@@ -351,6 +352,7 @@ static int rasm_disasm(RzAsmState *as, ut64 addr, const char *buf, int len, int 
 				break;
 			}
 			ret += aop.size;
+			addr += aop.size;
 			rz_analysis_op_fini(&aop);
 		}
 		break;

--- a/test/README.md
+++ b/test/README.md
@@ -80,6 +80,22 @@ a "nop" 90 # Assembly is correct
 dB "nopppp" 90 # Disassembly test is broken
 ```
 
+#### Multiple instructions in a single test
+
+Some instructions change if they appear together with another instructions.
+To test two or more instructions in a single test
+the instructions' assembly text and IL representations can be concatinated with a simicolon.
+
+Example: Branch delay in Sparc:
+```
+dE "call g1;nop" 9fc0600001000000 0x40 (set o7 (bv 64 0x40));(seq nop (jmp (var g1)))
+```
+
+Example: ARM conditional blocks with `it`.
+```
+d "ite eq;moveq r0, 1" 0cbf0120 0x0 nop;(branch (var zf) (set r0 (bv 32 0x1)) nop)
+```
+
 #### IL
 
 To also test lifting an instruction to RzIL, you can append the readable IL

--- a/test/db/asm/arm_16
+++ b/test/db/asm/arm_16
@@ -1146,3 +1146,6 @@ ad "yield.w" aff30180
 d "add r1, pc" 7944 0x3ffd70ca (set r1 (+ (var r1) (bv 32 0x3ffd70ce)))
 d "adr.w r5, -0x27" aff22705 0x1000 (set r5 (bv 32 0xfdd))
 d "addw ip, ip, 0x604" 0cf2046c 0x0 (set r12 (+ (var r12) (bv 32 0x604)))
+d "ite eq;moveq r0, 1" 0cbf0120 0x0 nop;(branch (var zf) (set r0 (bv 32 0x1)) nop)
+d "ittte eq;moveq r1, 1;moveq r2, 2;moveq r2, 3;movne r1, 4" 03bf0121022203220421 0x0 nop;(branch (var zf) (set r1 (bv 32 0x1)) nop);(branch (var zf) (set r2 (bv 32 0x2)) nop);(branch (var zf) (set r2 (bv 32 0x3)) nop);(branch (! (var zf)) (set r1 (bv 32 0x4)) nop)
+d "b 0x14;b 0x16" 08e008e0 0x0 (jmp (bv 32 0x14));(jmp (bv 32 0x16))


### PR DESCRIPTION


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The change enabales the asm tests to disassemble multiple instructions in a single test case.

This allows to test for assembly characteristics which are only valid in a certain context. It also fixes a bug in rz-asm, which didn't incremented the address before disassembly.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Added.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
