### PR TITLE
Remove unused deprecated RZ_MODE_* constants

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -25,14 +25,12 @@
 
 #define LOAD_BSS_MALLOC 0
 
-#define IS_MODE_SET(mode)       ((mode)&RZ_MODE_SET)
-#define IS_MODE_SIMPLE(mode)    ((mode)&RZ_MODE_SIMPLE)
-#define IS_MODE_SIMPLEST(mode)  ((mode)&RZ_MODE_SIMPLEST)
-#define IS_MODE_JSON(mode)      ((mode)&RZ_MODE_JSON)
-#define IS_MODE_RZCMD(mode)     ((mode)&RZ_MODE_RIZINCMD)
-#define IS_MODE_EQUAL(mode)     ((mode)&RZ_MODE_EQUAL)
-#define IS_MODE_NORMAL(mode)    (!(mode))
-#define IS_MODE_CLASSDUMP(mode) ((mode)&RZ_MODE_CLASSDUMP)
+#define IS_MODE_SET(mode)      ((mode)&RZ_MODE_SET)
+#define IS_MODE_SIMPLE(mode)   ((mode)&RZ_MODE_SIMPLE)
+#define IS_MODE_SIMPLEST(mode) ((mode)&RZ_MODE_SIMPLEST)
+#define IS_MODE_JSON(mode)     ((mode)&RZ_MODE_JSON)
+#define IS_MODE_RZCMD(mode)    ((mode)&RZ_MODE_RIZINCMD)
+#define IS_MODE_NORMAL(mode)   (!(mode))
 
 // dup from cmd_info
 #define PAIR_WIDTH "9"

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -26,15 +26,12 @@ extern "C" {
 #undef __WINDOWS__
 
 // TODO: these modes should be dropped when oldshell is removed in favour of RzOutputMode.
-#define RZ_MODE_PRINT     0x000
-#define RZ_MODE_RIZINCMD  0x001
-#define RZ_MODE_SET       0x002
-#define RZ_MODE_SIMPLE    0x004
-#define RZ_MODE_JSON      0x008
-#define RZ_MODE_ARRAY     0x010
-#define RZ_MODE_SIMPLEST  0x020
-#define RZ_MODE_CLASSDUMP 0x040
-#define RZ_MODE_EQUAL     0x080
+#define RZ_MODE_PRINT    0x000
+#define RZ_MODE_RIZINCMD 0x001
+#define RZ_MODE_SET      0x002
+#define RZ_MODE_SIMPLE   0x004
+#define RZ_MODE_JSON     0x008
+#define RZ_MODE_SIMPLEST 0x020
 
 #define RZ_IN    /* do not use, implicit */
 #define RZ_OUT   /* parameter is written, not read */


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

Remove dead code to help addressing https://github.com/rizinorg/rizin/issues/489 in the future

**Test plan**

CI is green