### PR TITLE
Fix assert, hit for memory operands without base register.

### DIFF
--- a/librz/arch/isa/arm/arm_esil64.c
+++ b/librz/arch/isa/arm/arm_esil64.c
@@ -18,7 +18,7 @@
 #include "arm_accessors64.h"
 
 #define REG64(x)      rz_str_get_null(cs_reg_name(*handle, insn->detail->arm64.operands[x].reg))
-#define MEMBASE64(x)  rz_str_get_null(cs_reg_name(*handle, insn->detail->arm64.operands[x].mem.base))
+#define MEMBASE64(x)  rz_str_get_null(insn->detail->arm64.operands[x].mem.base == AARCH64_REG_INVALID ? "0" : cs_reg_name(*handle, insn->detail->arm64.operands[x].mem.base))
 #define MEMINDEX64(x) rz_str_get_null(cs_reg_name(*handle, insn->detail->arm64.operands[x].mem.index))
 
 RZ_IPI const char *rz_arm64_cs_esil_prefix_cond(RzAnalysisOp *op, arm64_cc cond_type) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Newer AArch64 instructions can have memory operands without a base register (only an immediate absolute address).
The instruction '00000098: ldrsw x0, 0' is such a case. ESIL of course doesn't handle these, but also expects always a base register as string. We can't stringify the disponent in such a case, because the disp string either leaks or everything has to be refactored to free it for this case.
This is not worth it, because ESIL is soon gone.
The inaccuracy in analysis will be neglect able I assume.

RzIL handles this case btw:

```
rz-asm -I -a arm -b 64 00000098
(set x0 (cast 64 (msb (loadw 0 32 (bv 64 0x0))) (loadw 0 32 (bv 64 0x0))))
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Manually

Before
```
rz-asm -E -a arm -b 64 00000098
Hit assert: RegNo && RegNo < 703 && "Invalid register number!"
32,0,(null),+,DUP,tmp,=,[4],~,x0,=
```

After

```
rz-asm -E -a arm -b 64 00000098
32,0,0,+,DUP,tmp,=,[4],~,x0,=
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
