### PR TITLE
 librz/bin: improve plugin descriptions

### DIFF
--- a/librz/bin/p/bin_any.c
+++ b/librz/bin/p/bin_any.c
@@ -61,7 +61,7 @@ static ut64 baddr(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_any = {
 	.name = "any",
-	.desc = "Dummy format rz_bin plugin",
+	.desc = "Dummy format binary",
 	.license = "LGPL3",
 	.author = "nibble",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_bf.c
+++ b/librz/bin/p/bin_bf.c
@@ -149,7 +149,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_bf = {
 	.name = "bf",
-	.desc = "brainfuck",
+	.desc = "Brainfuck",
 	.license = "LGPL3",
 	.author = "pancake",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_bflt.c
+++ b/librz/bin/p/bin_bflt.c
@@ -250,7 +250,7 @@ static void destroy(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_bflt = {
 	.name = "bflt",
-	.desc = "bFLT uClinux executable",
+	.desc = "bFLT uClinux binary",
 	.license = "LGPL3",
 	.author = "Oscar Salvador",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_bios.c
+++ b/librz/bin/p/bin_bios.c
@@ -134,7 +134,7 @@ static RzPVector /*<RzBinAddr *>*/ *entries(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_bios = {
 	.name = "bios",
-	.desc = "BIOS bin plugin",
+	.desc = "BIOS binary",
 	.license = "LGPL",
 	.author = "pancake",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_cgc.c
+++ b/librz/bin/p/bin_cgc.c
@@ -102,7 +102,7 @@ static RzBuffer *create(RzBin *bin, const ut8 *code, int codelen, const ut8 *dat
 
 RzBinPlugin rz_bin_plugin_cgc = {
 	.name = "cgc",
-	.desc = "CGC format rz_bin plugin",
+	.desc = "CGC (Cyber Grand Challenge)",
 	.license = "LGPL3",
 	.author = "ret2libc",
 	.get_sdb = &get_sdb,

--- a/librz/bin/p/bin_coff.c
+++ b/librz/bin/p/bin_coff.c
@@ -585,7 +585,7 @@ RzList /*<char *>*/ *coff_section_flag_to_rzlist(ut64 flag) {
 
 RzBinPlugin rz_bin_plugin_coff = {
 	.name = "coff",
-	.desc = "COFF format rz_bin plugin",
+	.desc = "COFF (Common Object File Format)",
 	.license = "LGPL3",
 	.author = "Fedor Sakharov",
 	.get_sdb = &get_sdb,

--- a/librz/bin/p/bin_dex.c
+++ b/librz/bin/p/bin_dex.c
@@ -231,7 +231,7 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_dex = {
 	.name = "dex",
-	.desc = "dex bin plugin",
+	.desc = "DEX (Dalvik Executable)",
 	.license = "LGPL3",
 	.author = "deroad",
 	.get_sdb = &get_sdb,

--- a/librz/bin/p/bin_dmp64.c
+++ b/librz/bin/p/bin_dmp64.c
@@ -271,7 +271,7 @@ static bool check_buffer(RzBuffer *b) {
 
 RzBinPlugin rz_bin_plugin_dmp64 = {
 	.name = "dmp64",
-	.desc = "Windows Crash Dump x64 rz_bin plugin",
+	.desc = "Windows x64 Crash Dump",
 	.license = "LGPL3",
 	.author = "abcSup",
 	.destroy = &destroy,

--- a/librz/bin/p/bin_dol.c
+++ b/librz/bin/p/bin_dol.c
@@ -169,7 +169,7 @@ static ut64 baddr(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_dol = {
 	.name = "dol",
-	.desc = "Nintendo Dolphin binary format",
+	.desc = "Nintendo Dolphin binary",
 	.license = "BSD",
 	.author = "pancake",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_dyldcache.c
+++ b/librz/bin/p/bin_dyldcache.c
@@ -734,7 +734,7 @@ beach:
 
 RzBinPlugin rz_bin_plugin_dyldcache = {
 	.name = "dyldcache",
-	.desc = "dyldcache bin plugin",
+	.desc = "Apple DYLD Cache",
 	.license = "LGPL3",
 	.author = "pancake",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_elf.c
+++ b/librz/bin/p/bin_elf.c
@@ -11,7 +11,7 @@ static bool check_buffer(RzBuffer *buf) {
 
 RzBinPlugin rz_bin_plugin_elf = {
 	.name = "elf",
-	.desc = "ELF format plugin",
+	.desc = "ELF (Executable and Linkable Format)",
 	.license = "LGPL3",
 	.author = "nibble",
 	.get_sdb = &get_sdb,

--- a/librz/bin/p/bin_elf64.c
+++ b/librz/bin/p/bin_elf64.c
@@ -17,7 +17,7 @@ static ut64 get_elf_vaddr64(RzBinFile *bf, ut64 baddr, ut64 paddr, ut64 vaddr) {
 
 RzBinPlugin rz_bin_plugin_elf64 = {
 	.name = "elf64",
-	.desc = "elf64 bin plugin",
+	.desc = "ELF64 (64-bit Executable and Linkable Format)",
 	.license = "LGPL3",
 	.author = "nibble",
 	.get_sdb = &get_sdb,

--- a/librz/bin/p/bin_elf64.c
+++ b/librz/bin/p/bin_elf64.c
@@ -17,7 +17,7 @@ static ut64 get_elf_vaddr64(RzBinFile *bf, ut64 baddr, ut64 paddr, ut64 vaddr) {
 
 RzBinPlugin rz_bin_plugin_elf64 = {
 	.name = "elf64",
-	.desc = "ELF64 (64-bit Executable and Linkable Format)",
+	.desc = "ELF64",
 	.license = "LGPL3",
 	.author = "nibble",
 	.get_sdb = &get_sdb,

--- a/librz/bin/p/bin_elf64.c
+++ b/librz/bin/p/bin_elf64.c
@@ -17,7 +17,7 @@ static ut64 get_elf_vaddr64(RzBinFile *bf, ut64 baddr, ut64 paddr, ut64 vaddr) {
 
 RzBinPlugin rz_bin_plugin_elf64 = {
 	.name = "elf64",
-	.desc = "ELF64",
+	.desc = "ELF64 (64-bit Executable and Linkable Format)",
 	.license = "LGPL3",
 	.author = "nibble",
 	.get_sdb = &get_sdb,

--- a/librz/bin/p/bin_java.c
+++ b/librz/bin/p/bin_java.c
@@ -203,7 +203,7 @@ static char *java_enrich_asm(RzBinFile *bf, const char *asm_str, int asm_len) {
 
 RzBinPlugin rz_bin_plugin_java = {
 	.name = "java",
-	.desc = "java bin plugin",
+	.desc = "Java binary",
 	.license = "LGPL3",
 	.author = "deroad",
 	.get_sdb = &java_get_sdb,

--- a/librz/bin/p/bin_le.c
+++ b/librz/bin/p/bin_le.c
@@ -118,7 +118,7 @@ static void le_header(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_le = {
 	.name = "le",
-	.desc = "LE/LX format plugin",
+	.desc = "LE/LX (Linear Executable / Linear eXtended)",
 	.author = "GustavoLCR",
 	.license = "LGPL3",
 	.check_buffer = &rz_bin_le_check_buffer,

--- a/librz/bin/p/bin_le.c
+++ b/librz/bin/p/bin_le.c
@@ -118,7 +118,7 @@ static void le_header(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_le = {
 	.name = "le",
-	.desc = "LE/LX (Linear Executable / Linear eXtended)",
+	.desc = "LE/LX",
 	.author = "GustavoLCR",
 	.license = "LGPL3",
 	.check_buffer = &rz_bin_le_check_buffer,

--- a/librz/bin/p/bin_luac.c
+++ b/librz/bin/p/bin_luac.c
@@ -159,7 +159,7 @@ static void destroy(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_luac = {
 	.name = "luac",
-	.desc = "LUA Compiled File",
+	.desc = "Lua compiled binary",
 	.license = "LGPL3",
 	.author = "Heersin",
 	.get_sdb = NULL,

--- a/librz/bin/p/bin_mach0.c
+++ b/librz/bin/p/bin_mach0.c
@@ -818,7 +818,7 @@ static ut64 size(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_mach0 = {
 	.name = "mach0",
-	.desc = "mach0 bin plugin",
+	.desc = "Mach-O (Mach Object)",
 	.license = "LGPL3",
 	.author = "pancake",
 	.get_sdb = &get_sdb,

--- a/librz/bin/p/bin_mach064.c
+++ b/librz/bin/p/bin_mach064.c
@@ -289,7 +289,7 @@ static RzBinAddr *binsym(RzBinFile *bf, RzBinSpecialSymbol sym) {
 
 RzBinPlugin rz_bin_plugin_mach064 = {
 	.name = "mach064",
-	.desc = "mach064 bin plugin",
+	.desc = "Mach-O 64-bit",
 	.license = "LGPL3",
 	.author = "nibble",
 	.get_sdb = &get_sdb,

--- a/librz/bin/p/bin_mbn.c
+++ b/librz/bin/p/bin_mbn.c
@@ -193,7 +193,7 @@ static RzPVector /*<RzBinString *>*/ *strings(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_mbn = {
 	.name = "mbn",
-	.desc = "MBN/SBL bootloader things",
+	.desc = "MBN/SBL bootloader binary",
 	.license = "LGPL3",
 	.author = "pancake",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_mdmp.c
+++ b/librz/bin/p/bin_mdmp.c
@@ -457,7 +457,7 @@ static bool mdmp_check_buffer(RzBuffer *b) {
 
 RzBinPlugin rz_bin_plugin_mdmp = {
 	.name = "mdmp",
-	.desc = "Windows MiniDump plugin",
+	.desc = "Windows MiniDump",
 	.license = "LGPL3",
 	.author = "Davis",
 	.destroy = &mdmp_destroy,

--- a/librz/bin/p/bin_menuet.c
+++ b/librz/bin/p/bin_menuet.c
@@ -200,7 +200,7 @@ static RzBuffer *create(RzBin *bin, const ut8 *code, int codelen, const ut8 *dat
 
 RzBinPlugin rz_bin_plugin_menuet = {
 	.name = "menuet",
-	.desc = "Menuet/KolibriOS bin plugin",
+	.desc = "Menuet/KolibriOS binary",
 	.license = "LGPL3",
 	.author = "pancake",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_mz.c
+++ b/librz/bin/p/bin_mz.c
@@ -258,7 +258,7 @@ static RzPVector /*<RzBinReloc *>*/ *relocs(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_mz = {
 	.name = "mz",
-	.desc = "MZ bin plugin",
+	.desc = "MZ (DOS MZ Executable)",
 	.license = "MIT",
 	.author = "nodepad",
 	.get_sdb = &get_sdb,

--- a/librz/bin/p/bin_ne.c
+++ b/librz/bin/p/bin_ne.c
@@ -117,7 +117,7 @@ RzPVector /*<RzBinReloc *>*/ *relocs(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_ne = {
 	.name = "ne",
-	.desc = "NE format plugin",
+	.desc = "NE (New Executable)",
 	.author = "GustavoLCR",
 	.license = "LGPL3",
 	.check_buffer = &check_buffer,

--- a/librz/bin/p/bin_nes.c
+++ b/librz/bin/p/bin_nes.c
@@ -221,7 +221,7 @@ static ut64 baddr(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_nes = {
 	.name = "nes",
-	.desc = "Nintendo NES (Nintendo Entertainment System)",
+	.desc = "Nintendo NES",
 	.license = "MIT",
 	.author = "maijin",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_nes.c
+++ b/librz/bin/p/bin_nes.c
@@ -221,7 +221,7 @@ static ut64 baddr(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_nes = {
 	.name = "nes",
-	.desc = "NES",
+	.desc = "Nintendo NES (Nintendo Entertainment System)",
 	.license = "MIT",
 	.author = "maijin",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_nin3ds.c
+++ b/librz/bin/p/bin_nin3ds.c
@@ -313,7 +313,7 @@ static RZ_OWN RzList /*<char *>*/ *n3ds_section_flag_to_rzlist(ut64 type) {
 
 RzBinPlugin rz_bin_plugin_nin3ds = {
 	.name = "nin3ds",
-	.desc = "Nintendo 3DS Firmware plugin",
+	.desc = "Nintendo 3DS Firmware",
 	.license = "LGPL3",
 	.author = "a0rtega",
 	.load_buffer = &n3ds_load_buffer,

--- a/librz/bin/p/bin_ninds.c
+++ b/librz/bin/p/bin_ninds.c
@@ -334,7 +334,7 @@ static RzBinInfo *nds_info(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_ninds = {
 	.name = "ninds",
-	.desc = "Nintendo DS plugin",
+	.desc = "Nintendo DS binary",
 	.license = "LGPL3",
 	.author = "a0rtega",
 	.load_buffer = &nds_load_buffer,

--- a/librz/bin/p/bin_ningb.c
+++ b/librz/bin/p/bin_ningb.c
@@ -321,7 +321,7 @@ RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_ningb = {
 	.name = "ningb",
-	.desc = "Nintendo Gameboy plugin",
+	.desc = "Nintendo Game Boy",
 	.license = "LGPL3",
 	.author = "condret",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_ningba.c
+++ b/librz/bin/p/bin_ningba.c
@@ -87,7 +87,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_ningba = {
 	.name = "ningba",
-	.desc = "Nintendo Gameboy Advance plugin",
+	.desc = "Nintendo Game Boy Advance",
 	.license = "LGPL3",
 	.author = "condret",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_nro.c
+++ b/librz/bin/p/bin_nro.c
@@ -334,7 +334,7 @@ static RzBinInfo *info(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_nro = {
 	.name = "nro",
-	.desc = "Nintendo Switch NRO0 binaries",
+	.desc = "Nintendo Switch NRO (Nintendo Relocatable Object)",
 	.license = "MIT",
 	.author = "pancake",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_nro.c
+++ b/librz/bin/p/bin_nro.c
@@ -334,7 +334,7 @@ static RzBinInfo *info(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_nro = {
 	.name = "nro",
-	.desc = "Nintendo Switch NRO (Nintendo Relocatable Object)",
+	.desc = "Nintendo Switch NRO",
 	.license = "MIT",
 	.author = "pancake",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_nso.c
+++ b/librz/bin/p/bin_nso.c
@@ -390,7 +390,7 @@ static RzBinInfo *info(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_nso = {
 	.name = "nso",
-	.desc = "Nintendo Switch NSO (Nintendo Static Object)",
+	.desc = "Nintendo Switch NSO",
 	.license = "MIT",
 	.author = "rkx1209",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_nso.c
+++ b/librz/bin/p/bin_nso.c
@@ -390,7 +390,7 @@ static RzBinInfo *info(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_nso = {
 	.name = "nso",
-	.desc = "Nintendo Switch NSO0 binaries",
+	.desc = "Nintendo Switch NSO (Nintendo Static Object)",
 	.license = "MIT",
 	.author = "rkx1209",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_omf.c
+++ b/librz/bin/p/bin_omf.c
@@ -164,7 +164,7 @@ static ut64 get_vaddr(RzBinFile *bf, ut64 baddr, ut64 paddr, ut64 vaddr) {
 
 RzBinPlugin rz_bin_plugin_omf = {
 	.name = "omf",
-	.desc = "omf bin plugin",
+	.desc = "OMF (Object Module Format)",
 	.license = "LGPL3",
 	.author = "ampotos",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_p9.c
+++ b/librz/bin/p/bin_p9.c
@@ -254,7 +254,7 @@ static RzBuffer *create(RzBin *bin, const ut8 *code, int codelen, const ut8 *dat
 
 RzBinPlugin rz_bin_plugin_p9 = {
 	.name = "p9",
-	.desc = "Plan9 bin plugin",
+	.desc = "Plan9 binary",
 	.license = "LGPL3",
 	.author = "pancake",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_pe.c
+++ b/librz/bin/p/bin_pe.c
@@ -460,7 +460,7 @@ static void header(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_pe = {
 	.name = "pe",
-	.desc = "PE bin plugin",
+	.desc = "PE (Portable Executable)",
 	.license = "LGPL3",
 	.author = "nibble",
 	.get_sdb = &get_sdb,

--- a/librz/bin/p/bin_pe64.c
+++ b/librz/bin/p/bin_pe64.c
@@ -579,7 +579,7 @@ static RzPVector /*<RzBinTrycatch *>*/ *trycatch(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_pe64 = {
 	.name = "pe64",
-	.desc = "PE64 (PE32+) bin plugin",
+	.desc = "PE64 (PE32+ / 64-bit Portable Executable)",
 	.license = "LGPL3",
 	.author = "nibble",
 	.get_sdb = &get_sdb,

--- a/librz/bin/p/bin_pe64.c
+++ b/librz/bin/p/bin_pe64.c
@@ -579,7 +579,7 @@ static RzPVector /*<RzBinTrycatch *>*/ *trycatch(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_pe64 = {
 	.name = "pe64",
-	.desc = "PE64 (PE32+ / 64-bit Portable Executable)",
+	.desc = "PE64 (PE32+) binary",
 	.license = "LGPL3",
 	.author = "nibble",
 	.get_sdb = &get_sdb,

--- a/librz/bin/p/bin_prg.c
+++ b/librz/bin/p/bin_prg.c
@@ -77,7 +77,7 @@ static RzPVector /*<RzBinAddr *>*/ *entries(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_prg = {
 	.name = "prg",
-	.desc = "C64 PRG",
+	.desc = "C64 PRG (Commodore 64)",
 	.license = "LGPL3",
 	.author = "thestr4ng3r",
 	.load_buffer = load_buffer,

--- a/librz/bin/p/bin_psxexe.c
+++ b/librz/bin/p/bin_psxexe.c
@@ -120,7 +120,7 @@ static RzPVector /*<RzBinString *>*/ *strings(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_psxexe = {
 	.name = "psxexe",
-	.desc = "Sony PlayStation 1 Executable",
+	.desc = "Sony PlayStation 1 executable",
 	.license = "LGPL3",
 	.author = "Dax89",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_pyc.c
+++ b/librz/bin/p/bin_pyc.c
@@ -169,7 +169,7 @@ static void destroy(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_pyc = {
 	.name = "pyc",
-	.desc = "Python byte-compiled file plugin",
+	.desc = "Python byte-compiled",
 	.license = "LGPL3",
 	.author = "c0riolis",
 	.info = &info,

--- a/librz/bin/p/bin_qnx.c
+++ b/librz/bin/p/bin_qnx.c
@@ -381,7 +381,7 @@ static ut64 get_vaddr(RzBinFile *bf, ut64 baddr, ut64 paddr, ut64 vaddr) {
 // Declaration of the plugin
 RzBinPlugin rz_bin_plugin_qnx = {
 	.name = "qnx",
-	.desc = "QNX executable file support",
+	.desc = "QNX executable",
 	.license = "LGPL3",
 	.load_buffer = &load_buffer,
 	.destroy = &destroy,

--- a/librz/bin/p/bin_sfc.c
+++ b/librz/bin/p/bin_sfc.c
@@ -272,7 +272,7 @@ static RzPVector /*<RzBinAddr *>*/ *entries(RzBinFile *bf) { // Should be 3 offs
 
 RzBinPlugin rz_bin_plugin_sfc = {
 	.name = "sfc",
-	.desc = "Super NES / Super Famicom ROM file",
+	.desc = "Super NES / Super Famicom ROM",
 	.license = "LGPL3",
 	.author = "usrshare",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_smd.c
+++ b/librz/bin/p/bin_smd.c
@@ -326,7 +326,7 @@ static RzPVector /*<RzBinString *>*/ *strings(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_smd = {
 	.name = "smd",
-	.desc = "SEGA Genesis/Megadrive",
+	.desc = "SEGA Genesis / MegaDrive ROM",
 	.license = "LGPL3",
 	.author = "pancake",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_sms.c
+++ b/librz/bin/p/bin_sms.c
@@ -110,7 +110,7 @@ static RzPVector /*<RzBinString *>*/ *strings(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_sms = {
 	.name = "sms",
-	.desc = "SEGA MasterSystem/GameGear",
+	.desc = "SEGA MasterSystem / GameGear ROM",
 	.license = "LGPL3",
 	.author = "shengdi",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_spc700.c
+++ b/librz/bin/p/bin_spc700.c
@@ -81,7 +81,7 @@ static RzPVector /*<RzBinAddr *>*/ *entries(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_spc700 = {
 	.name = "spc700",
-	.desc = "SNES-SPC700 Sound File Data",
+	.desc = "SNES SPC700 sound data",
 	.license = "LGPL3",
 	.author = "maijin",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_te.c
+++ b/librz/bin/p/bin_te.c
@@ -151,7 +151,7 @@ static bool check_buffer(RzBuffer *b) {
 
 RzBinPlugin rz_bin_plugin_te = {
 	.name = "te",
-	.desc = "TE bin plugin", // Terse Executable format
+	.desc = "TE (Terse Executable)", // Terse Executable format
 	.license = "LGPL3",
 	.author = "xvilka",
 	.get_sdb = &get_sdb,

--- a/librz/bin/p/bin_vsf.c
+++ b/librz/bin/p/bin_vsf.c
@@ -533,7 +533,7 @@ static RzPVector /*<RzBinAddr *>*/ *entries(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_vsf = {
 	.name = "vsf",
-	.desc = "VICE Snapshot File",
+	.desc = "VICE snapshot file",
 	.license = "LGPL3",
 	.author = "riq",
 	.get_sdb = &get_sdb,

--- a/librz/bin/p/bin_wasm.c
+++ b/librz/bin/p/bin_wasm.c
@@ -320,7 +320,7 @@ static RzBuffer *create(RzBin *bin, const ut8 *code, int codelen, const ut8 *dat
 
 RzBinPlugin rz_bin_plugin_wasm = {
 	.name = "wasm",
-	.desc = "WebAssembly bin plugin",
+	.desc = "WebAssembly",
 	.license = "MIT",
 	.author = "pancake",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_xbe.c
+++ b/librz/bin/p/bin_xbe.c
@@ -368,7 +368,7 @@ static ut64 baddr(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_xbe = {
 	.name = "xbe",
-	.desc = "Microsoft Xbox XBE plugin",
+	.desc = "Microsoft Xbox XBE (Xbox Executable)",
 	.license = "LGPL3",
 	.author = "LemonBoy",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_xnu_kernelcache.c
+++ b/librz/bin/p/bin_xnu_kernelcache.c
@@ -1913,7 +1913,7 @@ static void rz_rebase_info_free(RzXNUKernelCacheRebaseInfo *info) {
 
 RzBinPlugin rz_bin_plugin_xnu_kernelcache = {
 	.name = "kernelcache",
-	.desc = "kernelcache bin plugin",
+	.desc = "Apple Kernelcache",
 	.license = "LGPL3",
 	.author = "mrmacete",
 	.destroy = &destroy,

--- a/librz/bin/p/bin_xtr_fatmach0.c
+++ b/librz/bin/p/bin_xtr_fatmach0.c
@@ -150,7 +150,7 @@ static RzList /*<RzBinXtrData *>*/ *oneshotall_buffer(RzBin *bin, RzBuffer *b) {
 
 RzBinXtrPlugin rz_bin_xtr_plugin_fatmach0 = {
 	.name = "xtr.fatmach0",
-	.desc = "fat mach0 bin extractor plugin",
+	.desc = "Fat Mach-O binary extractor",
 	.license = "LGPL3",
 	.load = &load,
 	.size = &size,

--- a/librz/bin/p/bin_xtr_pemixed.c
+++ b/librz/bin/p/bin_xtr_pemixed.c
@@ -105,7 +105,7 @@ static RzBinXtrData *oneshot(RzBin *bin, const ut8 *buf, ut64 size, int sub_bin_
 
 RzBinXtrPlugin rz_bin_xtr_plugin_pemixed = {
 	.name = "xtr.pemixed",
-	.desc = "Extract sub-binaries in PE files",
+	.desc = "PE mixed binary extractor",
 	.load = NULL, // not yet implemented
 	.extract = NULL, // not yet implemented
 	.extractall = NULL, // not yet implemented

--- a/librz/bin/p/bin_xtr_sep64.c
+++ b/librz/bin/p/bin_xtr_sep64.c
@@ -522,7 +522,7 @@ static bool read_arm64_ins(RzBuffer *b, int idx, ut64 *result) {
 
 RzBinXtrPlugin rz_bin_xtr_plugin_sep64 = {
 	.name = "xtr.sep64",
-	.desc = "64-bit SEP bin extractor plugin",
+	.desc = "64-bit SEP binary extractor",
 	.license = "LGPL3",
 	.check_buffer = check_buffer,
 	.load = &load,

--- a/librz/bin/p/bin_z64.c
+++ b/librz/bin/p/bin_z64.c
@@ -149,7 +149,7 @@ static RzBinInfo *info(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_z64 = {
 	.name = "z64",
-	.desc = "Nintendo 64 Bin-BE plugin",
+	.desc = "Nintendo 64 Big-Endian binary",
 	.license = "LGPL3",
 	.author = "lowlyw",
 	.load_buffer = &load_buffer,

--- a/librz/bin/p/bin_zimg.c
+++ b/librz/bin/p/bin_zimg.c
@@ -56,7 +56,7 @@ static RzBinInfo *info(RzBinFile *bf) {
 
 RzBinPlugin rz_bin_plugin_zimg = {
 	.name = "zimg",
-	.desc = "zimg format bin plugin",
+	.desc = "ZIMG format binary",
 	.license = "LGPL3",
 	.author = "ninjahacker",
 	.get_sdb = &get_sdb,

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -4940,7 +4940,7 @@ out:
 RZ_IPI RzCmdStatus rz_core_bin_plugin_print(const RzBinPlugin *bp, RzCmdStateOutput *state) {
 	rz_return_val_if_fail(bp && state, RZ_CMD_STATUS_ERROR);
 
-	rz_cmd_state_output_set_columnsf(state, "sssss", "name", "license", "description", "author", "version");
+	rz_cmd_state_output_set_columnsf(state, "sssss", "name", "license", "author", "description", "version");
 
 	switch (state->mode) {
 	case RZ_OUTPUT_MODE_QUIET:
@@ -4962,17 +4962,17 @@ RZ_IPI RzCmdStatus rz_core_bin_plugin_print(const RzBinPlugin *bp, RzCmdStateOut
 		pj_end(state->d.pj);
 		break;
 	case RZ_OUTPUT_MODE_STANDARD:
-		rz_cons_printf("%-12s %-9s %-38s %-15s %s\n", bp->name,
+		rz_cons_printf("%-12s %-9s %-15s %-38s %s\n", bp->name,
 			bp->license ? bp->license : "???",
-			bp->desc,
 			bp->author ? bp->author : "",
+			bp->desc,
 			bp->version ? bp->version : "");
 		break;
 	case RZ_OUTPUT_MODE_TABLE:
 		rz_table_add_rowf(state->d.t, "sssss", bp->name,
 			bp->license ? bp->license : "",
-			bp->desc,
 			bp->author ? bp->author : "",
+			bp->desc,
 			bp->version ? bp->version : "");
 		break;
 	default:
@@ -4987,7 +4987,7 @@ RZ_IPI RzCmdStatus rz_core_binxtr_plugin_print(const RzBinXtrPlugin *bx, RzCmdSt
 
 	const char *name = NULL;
 
-	rz_cmd_state_output_set_columnsf(state, "sss", "name", "license", "description");
+	rz_cmd_state_output_set_columnsf(state, "ssss", "name", "license", "author", "description");
 	switch (state->mode) {
 	case RZ_OUTPUT_MODE_QUIET:
 		rz_cons_println(bx->name);
@@ -5001,12 +5001,16 @@ RZ_IPI RzCmdStatus rz_core_binxtr_plugin_print(const RzBinXtrPlugin *bx, RzCmdSt
 		break;
 	case RZ_OUTPUT_MODE_STANDARD:
 		name = strncmp(bx->name, "xtr.", 4) ? bx->name : bx->name + 3;
-		rz_cons_printf("%-12s %-9s %s\n", name,
+		rz_cons_printf("%-12s %-9s %-15s %s\n", name,
 			bx->license ? bx->license : "???",
+			"",
 			bx->desc);
 		break;
 	case RZ_OUTPUT_MODE_TABLE:
-		rz_table_add_rowf(state->d.t, "sss", bx->name, bx->license, bx->desc);
+		rz_table_add_rowf(state->d.t, "ssss", bx->name,
+			bx->license,
+			"",
+			bx->desc);
 		break;
 	default:
 		rz_warn_if_reached();

--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -188,119 +188,119 @@ Lit
 Liq
 EOF
 EXPECT=<<EOF
-any          LGPL3     Dummy format rz_bin plugin             nibble          
+any          LGPL3     Dummy format binary                    nibble          
 art          LGPL3     Android Runtime                        pancake         
 avr          LGPL3     ATmel AVR MCUs                         pancake         
-bf           LGPL3     brainfuck                              pancake         
-bflt         LGPL3     bFLT uClinux executable                Oscar Salvador  
-bios         LGPL      BIOS bin plugin                        pancake         
+bf           LGPL3     Brainfuck                              pancake         
+bflt         LGPL3     bFLT uClinux binary                    Oscar Salvador  
+bios         LGPL      BIOS binary                            pancake         
 bootimg      LGPL3     Android Boot Image                     pancake         
-cgc          LGPL3     CGC format rz_bin plugin               ret2libc        
-coff         LGPL3     COFF format rz_bin plugin              Fedor Sakharov  
-dex          LGPL3     dex bin plugin                         deroad          
-dmp64        LGPL3     Windows Crash Dump x64 rz_bin plugin   abcSup          
-dol          BSD       Nintendo Dolphin binary format         pancake         
-dyldcache    LGPL3     dyldcache bin plugin                   pancake         
-elf          LGPL3     ELF format plugin                      nibble          
-elf64        LGPL3     elf64 bin plugin                       nibble          
-java         LGPL3     java bin plugin                        deroad          
-kernelcache  LGPL3     kernelcache bin plugin                 mrmacete        
-le           LGPL3     LE/LX format plugin                    GustavoLCR      
-luac         LGPL3     LUA Compiled File                      Heersin         
-mach0        LGPL3     mach0 bin plugin                       pancake         
-mach064      LGPL3     mach064 bin plugin                     nibble          
-mbn          LGPL3     MBN/SBL bootloader things              pancake         
-mdmp         LGPL3     Windows MiniDump plugin                Davis           
-menuet       LGPL3     Menuet/KolibriOS bin plugin            pancake         
-mz           MIT       MZ bin plugin                          nodepad         
-ne           LGPL3     NE format plugin                       GustavoLCR      
-nes          MIT       NES                                    maijin          
-nin3ds       LGPL3     Nintendo 3DS Firmware plugin           a0rtega         
-ninds        LGPL3     Nintendo DS plugin                     a0rtega         
-ningb        LGPL3     Nintendo Gameboy plugin                condret         
-ningba       LGPL3     Nintendo Gameboy Advance plugin        condret         
-nro          MIT       Nintendo Switch NRO0 binaries          pancake         
-nso          MIT       Nintendo Switch NSO0 binaries          rkx1209         
-omf          LGPL3     omf bin plugin                         ampotos         
-p9           LGPL3     Plan9 bin plugin                       pancake         
-pe           LGPL3     PE bin plugin                          nibble          
-pe64         LGPL3     PE64 (PE32+) bin plugin                nibble          
+cgc          LGPL3     CGC (Cyber Grand Challenge)            ret2libc        
+coff         LGPL3     COFF (Common Object File Format)       Fedor Sakharov  
+dex          LGPL3     DEX (Dalvik Executable)                deroad          
+dmp64        LGPL3     Windows x64 Crash Dump                 abcSup          
+dol          BSD       Nintendo Dolphin binary                pancake         
+dyldcache    LGPL3     Apple DYLD Cache                       pancake         
+elf          LGPL3     ELF (Executable and Linkable Format)   nibble          
+elf64        LGPL3     ELF64                                  nibble          
+java         LGPL3     Java binary                            deroad          
+kernelcache  LGPL3     Apple Kernelcache                      mrmacete        
+le           LGPL3     LE/LX                                  GustavoLCR      
+luac         LGPL3     Lua compiled binary                    Heersin         
+mach0        LGPL3     Mach-O (Mach Object)                   pancake         
+mach064      LGPL3     Mach-O 64-bit                          nibble          
+mbn          LGPL3     MBN/SBL bootloader binary              pancake         
+mdmp         LGPL3     Windows MiniDump                       Davis           
+menuet       LGPL3     Menuet/KolibriOS binary                pancake         
+mz           MIT       MZ (DOS MZ Executable)                 nodepad         
+ne           LGPL3     NE (New Executable)                    GustavoLCR      
+nes          MIT       Nintendo NES                           maijin          
+nin3ds       LGPL3     Nintendo 3DS Firmware                  a0rtega         
+ninds        LGPL3     Nintendo DS binary                     a0rtega         
+ningb        LGPL3     Nintendo Game Boy                      condret         
+ningba       LGPL3     Nintendo Game Boy Advance              condret         
+nro          MIT       Nintendo Switch NRO                    pancake         
+nso          MIT       Nintendo Switch NSO                    rkx1209         
+omf          LGPL3     OMF (Object Module Format)             ampotos         
+p9           LGPL3     Plan9 binary                           pancake         
+pe           LGPL3     PE (Portable Executable)               nibble          
+pe64         LGPL3     PE64 (PE32+) binary                    nibble          
 pebble       LGPL      Pebble Watch App                       pancake         
-prg          LGPL3     C64 PRG                                thestr4ng3r     
-psxexe       LGPL3     Sony PlayStation 1 Executable          Dax89           
-pyc          LGPL3     Python byte-compiled file plugin       c0riolis        
-qnx          LGPL3     QNX executable file support            deepakchethan   
-sfc          LGPL3     Super NES / Super Famicom ROM file     usrshare        
-smd          LGPL3     SEGA Genesis/Megadrive                 pancake         
-sms          LGPL3     SEGA MasterSystem/GameGear             shengdi         
-spc700       LGPL3     SNES-SPC700 Sound File Data            maijin          
+prg          LGPL3     C64 PRG (Commodore 64)                 thestr4ng3r     
+psxexe       LGPL3     Sony PlayStation 1 executable          Dax89           
+pyc          LGPL3     Python byte-compiled                   c0riolis        
+qnx          LGPL3     QNX executable                         deepakchethan   
+sfc          LGPL3     Super NES / Super Famicom ROM          usrshare        
+smd          LGPL3     SEGA Genesis / MegaDrive ROM           pancake         
+sms          LGPL3     SEGA MasterSystem / GameGear ROM       shengdi         
+spc700       LGPL3     SNES SPC700 sound data                 maijin          
 symbols      MIT       Apple Symbols file                     pancake         
-te           LGPL3     TE bin plugin                          xvilka          
-vsf          LGPL3     VICE Snapshot File                     riq             
-wasm         MIT       WebAssembly bin plugin                 pancake         
-xbe          LGPL3     Microsoft Xbox XBE plugin              LemonBoy        
-z64          LGPL3     Nintendo 64 Bin-BE plugin              lowlyw          
-zimg         LGPL3     zimg format bin plugin                 ninjahacker     
-.fatmach0    LGPL3     fat mach0 bin extractor plugin
-.sep64       LGPL3     64-bit SEP bin extractor plugin
-[{"name":"any","description":"Dummy format rz_bin plugin","license":"LGPL3","author":"nibble"},{"name":"art","description":"Android Runtime","license":"LGPL3","author":"pancake"},{"name":"avr","description":"ATmel AVR MCUs","license":"LGPL3","author":"pancake"},{"name":"bf","description":"brainfuck","license":"LGPL3","author":"pancake"},{"name":"bflt","description":"bFLT uClinux executable","license":"LGPL3","author":"Oscar Salvador"},{"name":"bios","description":"BIOS bin plugin","license":"LGPL","author":"pancake"},{"name":"bootimg","description":"Android Boot Image","license":"LGPL3","author":"pancake"},{"name":"cgc","description":"CGC format rz_bin plugin","license":"LGPL3","author":"ret2libc"},{"name":"coff","description":"COFF format rz_bin plugin","license":"LGPL3","author":"Fedor Sakharov"},{"name":"dex","description":"dex bin plugin","license":"LGPL3","author":"deroad"},{"name":"dmp64","description":"Windows Crash Dump x64 rz_bin plugin","license":"LGPL3","author":"abcSup"},{"name":"dol","description":"Nintendo Dolphin binary format","license":"BSD","author":"pancake"},{"name":"dyldcache","description":"dyldcache bin plugin","license":"LGPL3","author":"pancake"},{"name":"elf","description":"ELF format plugin","license":"LGPL3","author":"nibble"},{"name":"elf64","description":"elf64 bin plugin","license":"LGPL3","author":"nibble"},{"name":"java","description":"java bin plugin","license":"LGPL3","author":"deroad"},{"name":"kernelcache","description":"kernelcache bin plugin","license":"LGPL3","author":"mrmacete"},{"name":"le","description":"LE/LX format plugin","license":"LGPL3","author":"GustavoLCR"},{"name":"luac","description":"LUA Compiled File","license":"LGPL3","author":"Heersin"},{"name":"mach0","description":"mach0 bin plugin","license":"LGPL3","author":"pancake"},{"name":"mach064","description":"mach064 bin plugin","license":"LGPL3","author":"nibble"},{"name":"mbn","description":"MBN/SBL bootloader things","license":"LGPL3","author":"pancake"},{"name":"mdmp","description":"Windows MiniDump plugin","license":"LGPL3","author":"Davis"},{"name":"menuet","description":"Menuet/KolibriOS bin plugin","license":"LGPL3","author":"pancake"},{"name":"mz","description":"MZ bin plugin","license":"MIT","author":"nodepad"},{"name":"ne","description":"NE format plugin","license":"LGPL3","author":"GustavoLCR"},{"name":"nes","description":"NES","license":"MIT","author":"maijin"},{"name":"nin3ds","description":"Nintendo 3DS Firmware plugin","license":"LGPL3","author":"a0rtega"},{"name":"ninds","description":"Nintendo DS plugin","license":"LGPL3","author":"a0rtega"},{"name":"ningb","description":"Nintendo Gameboy plugin","license":"LGPL3","author":"condret"},{"name":"ningba","description":"Nintendo Gameboy Advance plugin","license":"LGPL3","author":"condret"},{"name":"nro","description":"Nintendo Switch NRO0 binaries","license":"MIT","author":"pancake"},{"name":"nso","description":"Nintendo Switch NSO0 binaries","license":"MIT","author":"rkx1209"},{"name":"omf","description":"omf bin plugin","license":"LGPL3","author":"ampotos"},{"name":"p9","description":"Plan9 bin plugin","license":"LGPL3","author":"pancake"},{"name":"pe","description":"PE bin plugin","license":"LGPL3","author":"nibble"},{"name":"pe64","description":"PE64 (PE32+) bin plugin","license":"LGPL3","author":"nibble"},{"name":"pebble","description":"Pebble Watch App","license":"LGPL","author":"pancake"},{"name":"prg","description":"C64 PRG","license":"LGPL3","author":"thestr4ng3r"},{"name":"psxexe","description":"Sony PlayStation 1 Executable","license":"LGPL3","author":"Dax89"},{"name":"pyc","description":"Python byte-compiled file plugin","license":"LGPL3","author":"c0riolis"},{"name":"qnx","description":"QNX executable file support","license":"LGPL3","author":"deepakchethan"},{"name":"sfc","description":"Super NES / Super Famicom ROM file","license":"LGPL3","author":"usrshare"},{"name":"smd","description":"SEGA Genesis/Megadrive","license":"LGPL3","author":"pancake"},{"name":"sms","description":"SEGA MasterSystem/GameGear","license":"LGPL3","author":"shengdi"},{"name":"spc700","description":"SNES-SPC700 Sound File Data","license":"LGPL3","author":"maijin"},{"name":"symbols","description":"Apple Symbols file","license":"MIT","author":"pancake"},{"name":"te","description":"TE bin plugin","license":"LGPL3","author":"xvilka"},{"name":"vsf","description":"VICE Snapshot File","license":"LGPL3","author":"riq"},{"name":"wasm","description":"WebAssembly bin plugin","license":"MIT","author":"pancake"},{"name":"xbe","description":"Microsoft Xbox XBE plugin","license":"LGPL3","author":"LemonBoy"},{"name":"z64","description":"Nintendo 64 Bin-BE plugin","license":"LGPL3","author":"lowlyw"},{"name":"zimg","description":"zimg format bin plugin","license":"LGPL3","author":"ninjahacker"},{"name":"xtr.fatmach0","description":"fat mach0 bin extractor plugin","license":"LGPL3"},{"name":"xtr.sep64","description":"64-bit SEP bin extractor plugin","license":"LGPL3"}]
+te           LGPL3     TE (Terse Executable)                  xvilka          
+vsf          LGPL3     VICE snapshot file                     riq             
+wasm         MIT       WebAssembly                            pancake         
+xbe          LGPL3     Microsoft Xbox XBE (Xbox Executable)   LemonBoy        
+z64          LGPL3     Nintendo 64 Big-Endian binary          lowlyw          
+zimg         LGPL3     ZIMG format binary                     ninjahacker     
+.fatmach0    LGPL3     Fat Mach-O binary extractor
+.sep64       LGPL3     64-bit SEP binary extractor
+[{"name":"any","description":"Dummy format binary","license":"LGPL3","author":"nibble"},{"name":"art","description":"Android Runtime","license":"LGPL3","author":"pancake"},{"name":"avr","description":"ATmel AVR MCUs","license":"LGPL3","author":"pancake"},{"name":"bf","description":"Brainfuck","license":"LGPL3","author":"pancake"},{"name":"bflt","description":"bFLT uClinux binary","license":"LGPL3","author":"Oscar Salvador"},{"name":"bios","description":"BIOS binary","license":"LGPL","author":"pancake"},{"name":"bootimg","description":"Android Boot Image","license":"LGPL3","author":"pancake"},{"name":"cgc","description":"CGC (Cyber Grand Challenge)","license":"LGPL3","author":"ret2libc"},{"name":"coff","description":"COFF (Common Object File Format)","license":"LGPL3","author":"Fedor Sakharov"},{"name":"dex","description":"DEX (Dalvik Executable)","license":"LGPL3","author":"deroad"},{"name":"dmp64","description":"Windows x64 Crash Dump","license":"LGPL3","author":"abcSup"},{"name":"dol","description":"Nintendo Dolphin binary","license":"BSD","author":"pancake"},{"name":"dyldcache","description":"Apple DYLD Cache","license":"LGPL3","author":"pancake"},{"name":"elf","description":"ELF (Executable and Linkable Format)","license":"LGPL3","author":"nibble"},{"name":"elf64","description":"ELF64","license":"LGPL3","author":"nibble"},{"name":"java","description":"Java binary","license":"LGPL3","author":"deroad"},{"name":"kernelcache","description":"Apple Kernelcache","license":"LGPL3","author":"mrmacete"},{"name":"le","description":"LE/LX","license":"LGPL3","author":"GustavoLCR"},{"name":"luac","description":"Lua compiled binary","license":"LGPL3","author":"Heersin"},{"name":"mach0","description":"Mach-O (Mach Object)","license":"LGPL3","author":"pancake"},{"name":"mach064","description":"Mach-O 64-bit","license":"LGPL3","author":"nibble"},{"name":"mbn","description":"MBN/SBL bootloader binary","license":"LGPL3","author":"pancake"},{"name":"mdmp","description":"Windows MiniDump","license":"LGPL3","author":"Davis"},{"name":"menuet","description":"Menuet/KolibriOS binary","license":"LGPL3","author":"pancake"},{"name":"mz","description":"MZ (DOS MZ Executable)","license":"MIT","author":"nodepad"},{"name":"ne","description":"NE (New Executable)","license":"LGPL3","author":"GustavoLCR"},{"name":"nes","description":"Nintendo NES","license":"MIT","author":"maijin"},{"name":"nin3ds","description":"Nintendo 3DS Firmware","license":"LGPL3","author":"a0rtega"},{"name":"ninds","description":"Nintendo DS binary","license":"LGPL3","author":"a0rtega"},{"name":"ningb","description":"Nintendo Game Boy","license":"LGPL3","author":"condret"},{"name":"ningba","description":"Nintendo Game Boy Advance","license":"LGPL3","author":"condret"},{"name":"nro","description":"Nintendo Switch NRO","license":"MIT","author":"pancake"},{"name":"nso","description":"Nintendo Switch NSO","license":"MIT","author":"rkx1209"},{"name":"omf","description":"OMF (Object Module Format)","license":"LGPL3","author":"ampotos"},{"name":"p9","description":"Plan9 binary","license":"LGPL3","author":"pancake"},{"name":"pe","description":"PE (Portable Executable)","license":"LGPL3","author":"nibble"},{"name":"pe64","description":"PE64 (PE32+) binary","license":"LGPL3","author":"nibble"},{"name":"pebble","description":"Pebble Watch App","license":"LGPL","author":"pancake"},{"name":"prg","description":"C64 PRG (Commodore 64)","license":"LGPL3","author":"thestr4ng3r"},{"name":"psxexe","description":"Sony PlayStation 1 executable","license":"LGPL3","author":"Dax89"},{"name":"pyc","description":"Python byte-compiled","license":"LGPL3","author":"c0riolis"},{"name":"qnx","description":"QNX executable","license":"LGPL3","author":"deepakchethan"},{"name":"sfc","description":"Super NES / Super Famicom ROM","license":"LGPL3","author":"usrshare"},{"name":"smd","description":"SEGA Genesis / MegaDrive ROM","license":"LGPL3","author":"pancake"},{"name":"sms","description":"SEGA MasterSystem / GameGear ROM","license":"LGPL3","author":"shengdi"},{"name":"spc700","description":"SNES SPC700 sound data","license":"LGPL3","author":"maijin"},{"name":"symbols","description":"Apple Symbols file","license":"MIT","author":"pancake"},{"name":"te","description":"TE (Terse Executable)","license":"LGPL3","author":"xvilka"},{"name":"vsf","description":"VICE snapshot file","license":"LGPL3","author":"riq"},{"name":"wasm","description":"WebAssembly","license":"MIT","author":"pancake"},{"name":"xbe","description":"Microsoft Xbox XBE (Xbox Executable)","license":"LGPL3","author":"LemonBoy"},{"name":"z64","description":"Nintendo 64 Big-Endian binary","license":"LGPL3","author":"lowlyw"},{"name":"zimg","description":"ZIMG format binary","license":"LGPL3","author":"ninjahacker"},{"name":"xtr.fatmach0","description":"Fat Mach-O binary extractor","license":"LGPL3"},{"name":"xtr.sep64","description":"64-bit SEP binary extractor","license":"LGPL3"}]
 name         license description                          author         version 
 ---------------------------------------------------------------------------------
-any          LGPL3   Dummy format rz_bin plugin           nibble         
+any          LGPL3   Dummy format binary                  nibble         
 art          LGPL3   Android Runtime                      pancake        
 avr          LGPL3   ATmel AVR MCUs                       pancake        
-bf           LGPL3   brainfuck                            pancake        
-bflt         LGPL3   bFLT uClinux executable              Oscar Salvador 
-bios         LGPL    BIOS bin plugin                      pancake        
+bf           LGPL3   Brainfuck                            pancake        
+bflt         LGPL3   bFLT uClinux binary                  Oscar Salvador 
+bios         LGPL    BIOS binary                          pancake        
 bootimg      LGPL3   Android Boot Image                   pancake        
-cgc          LGPL3   CGC format rz_bin plugin             ret2libc       
-coff         LGPL3   COFF format rz_bin plugin            Fedor Sakharov 
-dex          LGPL3   dex bin plugin                       deroad         
-dmp64        LGPL3   Windows Crash Dump x64 rz_bin plugin abcSup         
-dol          BSD     Nintendo Dolphin binary format       pancake        
-dyldcache    LGPL3   dyldcache bin plugin                 pancake        
-elf          LGPL3   ELF format plugin                    nibble         
-elf64        LGPL3   elf64 bin plugin                     nibble         
-java         LGPL3   java bin plugin                      deroad         
-kernelcache  LGPL3   kernelcache bin plugin               mrmacete       
-le           LGPL3   LE/LX format plugin                  GustavoLCR     
-luac         LGPL3   LUA Compiled File                    Heersin        
-mach0        LGPL3   mach0 bin plugin                     pancake        
-mach064      LGPL3   mach064 bin plugin                   nibble         
-mbn          LGPL3   MBN/SBL bootloader things            pancake        
-mdmp         LGPL3   Windows MiniDump plugin              Davis          
-menuet       LGPL3   Menuet/KolibriOS bin plugin          pancake        
-mz           MIT     MZ bin plugin                        nodepad        
-ne           LGPL3   NE format plugin                     GustavoLCR     
-nes          MIT     NES                                  maijin         
-nin3ds       LGPL3   Nintendo 3DS Firmware plugin         a0rtega        
-ninds        LGPL3   Nintendo DS plugin                   a0rtega        
-ningb        LGPL3   Nintendo Gameboy plugin              condret        
-ningba       LGPL3   Nintendo Gameboy Advance plugin      condret        
-nro          MIT     Nintendo Switch NRO0 binaries        pancake        
-nso          MIT     Nintendo Switch NSO0 binaries        rkx1209        
-omf          LGPL3   omf bin plugin                       ampotos        
-p9           LGPL3   Plan9 bin plugin                     pancake        
-pe           LGPL3   PE bin plugin                        nibble         
-pe64         LGPL3   PE64 (PE32+) bin plugin              nibble         
+cgc          LGPL3   CGC (Cyber Grand Challenge)          ret2libc       
+coff         LGPL3   COFF (Common Object File Format)     Fedor Sakharov 
+dex          LGPL3   DEX (Dalvik Executable)              deroad         
+dmp64        LGPL3   Windows x64 Crash Dump               abcSup         
+dol          BSD     Nintendo Dolphin binary              pancake        
+dyldcache    LGPL3   Apple DYLD Cache                     pancake        
+elf          LGPL3   ELF (Executable and Linkable Format) nibble         
+elf64        LGPL3   ELF64                                nibble         
+java         LGPL3   Java binary                          deroad         
+kernelcache  LGPL3   Apple Kernelcache                    mrmacete       
+le           LGPL3   LE/LX                                GustavoLCR     
+luac         LGPL3   Lua compiled binary                  Heersin        
+mach0        LGPL3   Mach-O (Mach Object)                 pancake        
+mach064      LGPL3   Mach-O 64-bit                        nibble         
+mbn          LGPL3   MBN/SBL bootloader binary            pancake        
+mdmp         LGPL3   Windows MiniDump                     Davis          
+menuet       LGPL3   Menuet/KolibriOS binary              pancake        
+mz           MIT     MZ (DOS MZ Executable)               nodepad        
+ne           LGPL3   NE (New Executable)                  GustavoLCR     
+nes          MIT     Nintendo NES                         maijin         
+nin3ds       LGPL3   Nintendo 3DS Firmware                a0rtega        
+ninds        LGPL3   Nintendo DS binary                   a0rtega        
+ningb        LGPL3   Nintendo Game Boy                    condret        
+ningba       LGPL3   Nintendo Game Boy Advance            condret        
+nro          MIT     Nintendo Switch NRO                  pancake        
+nso          MIT     Nintendo Switch NSO                  rkx1209        
+omf          LGPL3   OMF (Object Module Format)           ampotos        
+p9           LGPL3   Plan9 binary                         pancake        
+pe           LGPL3   PE (Portable Executable)             nibble         
+pe64         LGPL3   PE64 (PE32+) binary                  nibble         
 pebble       LGPL    Pebble Watch App                     pancake        
-prg          LGPL3   C64 PRG                              thestr4ng3r    
-psxexe       LGPL3   Sony PlayStation 1 Executable        Dax89          
-pyc          LGPL3   Python byte-compiled file plugin     c0riolis       
-qnx          LGPL3   QNX executable file support          deepakchethan  
-sfc          LGPL3   Super NES / Super Famicom ROM file   usrshare       
-smd          LGPL3   SEGA Genesis/Megadrive               pancake        
-sms          LGPL3   SEGA MasterSystem/GameGear           shengdi        
-spc700       LGPL3   SNES-SPC700 Sound File Data          maijin         
+prg          LGPL3   C64 PRG (Commodore 64)               thestr4ng3r    
+psxexe       LGPL3   Sony PlayStation 1 executable        Dax89          
+pyc          LGPL3   Python byte-compiled                 c0riolis       
+qnx          LGPL3   QNX executable                       deepakchethan  
+sfc          LGPL3   Super NES / Super Famicom ROM        usrshare       
+smd          LGPL3   SEGA Genesis / MegaDrive ROM         pancake        
+sms          LGPL3   SEGA MasterSystem / GameGear ROM     shengdi        
+spc700       LGPL3   SNES SPC700 sound data               maijin         
 symbols      MIT     Apple Symbols file                   pancake        
-te           LGPL3   TE bin plugin                        xvilka         
-vsf          LGPL3   VICE Snapshot File                   riq            
-wasm         MIT     WebAssembly bin plugin               pancake        
-xbe          LGPL3   Microsoft Xbox XBE plugin            LemonBoy       
-z64          LGPL3   Nintendo 64 Bin-BE plugin            lowlyw         
-zimg         LGPL3   zimg format bin plugin               ninjahacker    
-xtr.fatmach0 LGPL3   fat mach0 bin extractor plugin
-xtr.sep64    LGPL3   64-bit SEP bin extractor plugin
+te           LGPL3   TE (Terse Executable)                xvilka         
+vsf          LGPL3   VICE snapshot file                   riq            
+wasm         MIT     WebAssembly                          pancake        
+xbe          LGPL3   Microsoft Xbox XBE (Xbox Executable) LemonBoy       
+z64          LGPL3   Nintendo 64 Big-Endian binary        lowlyw         
+zimg         LGPL3   ZIMG format binary                   ninjahacker    
+xtr.fatmach0 LGPL3   Fat Mach-O binary extractor
+xtr.sep64    LGPL3   64-bit SEP binary extractor
 any
 art
 avr

--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -188,119 +188,119 @@ Lit
 Liq
 EOF
 EXPECT=<<EOF
-any          LGPL3     Dummy format binary                    nibble          
-art          LGPL3     Android Runtime                        pancake         
-avr          LGPL3     ATmel AVR MCUs                         pancake         
-bf           LGPL3     Brainfuck                              pancake         
-bflt         LGPL3     bFLT uClinux binary                    Oscar Salvador  
-bios         LGPL      BIOS binary                            pancake         
-bootimg      LGPL3     Android Boot Image                     pancake         
-cgc          LGPL3     CGC (Cyber Grand Challenge)            ret2libc        
-coff         LGPL3     COFF (Common Object File Format)       Fedor Sakharov  
-dex          LGPL3     DEX (Dalvik Executable)                deroad          
-dmp64        LGPL3     Windows x64 Crash Dump                 abcSup          
-dol          BSD       Nintendo Dolphin binary                pancake         
-dyldcache    LGPL3     Apple DYLD Cache                       pancake         
-elf          LGPL3     ELF (Executable and Linkable Format)   nibble          
-elf64        LGPL3     ELF64                                  nibble          
-java         LGPL3     Java binary                            deroad          
-kernelcache  LGPL3     Apple Kernelcache                      mrmacete        
-le           LGPL3     LE/LX                                  GustavoLCR      
-luac         LGPL3     Lua compiled binary                    Heersin         
-mach0        LGPL3     Mach-O (Mach Object)                   pancake         
-mach064      LGPL3     Mach-O 64-bit                          nibble          
-mbn          LGPL3     MBN/SBL bootloader binary              pancake         
-mdmp         LGPL3     Windows MiniDump                       Davis           
-menuet       LGPL3     Menuet/KolibriOS binary                pancake         
-mz           MIT       MZ (DOS MZ Executable)                 nodepad         
-ne           LGPL3     NE (New Executable)                    GustavoLCR      
-nes          MIT       Nintendo NES                           maijin          
-nin3ds       LGPL3     Nintendo 3DS Firmware                  a0rtega         
-ninds        LGPL3     Nintendo DS binary                     a0rtega         
-ningb        LGPL3     Nintendo Game Boy                      condret         
-ningba       LGPL3     Nintendo Game Boy Advance              condret         
-nro          MIT       Nintendo Switch NRO                    pancake         
-nso          MIT       Nintendo Switch NSO                    rkx1209         
-omf          LGPL3     OMF (Object Module Format)             ampotos         
-p9           LGPL3     Plan9 binary                           pancake         
-pe           LGPL3     PE (Portable Executable)               nibble          
-pe64         LGPL3     PE64 (PE32+) binary                    nibble          
-pebble       LGPL      Pebble Watch App                       pancake         
-prg          LGPL3     C64 PRG (Commodore 64)                 thestr4ng3r     
-psxexe       LGPL3     Sony PlayStation 1 executable          Dax89           
-pyc          LGPL3     Python byte-compiled                   c0riolis        
-qnx          LGPL3     QNX executable                         deepakchethan   
-sfc          LGPL3     Super NES / Super Famicom ROM          usrshare        
-smd          LGPL3     SEGA Genesis / MegaDrive ROM           pancake         
-sms          LGPL3     SEGA MasterSystem / GameGear ROM       shengdi         
-spc700       LGPL3     SNES SPC700 sound data                 maijin          
-symbols      MIT       Apple Symbols file                     pancake         
-te           LGPL3     TE (Terse Executable)                  xvilka          
-vsf          LGPL3     VICE snapshot file                     riq             
-wasm         MIT       WebAssembly                            pancake         
-xbe          LGPL3     Microsoft Xbox XBE (Xbox Executable)   LemonBoy        
-z64          LGPL3     Nintendo 64 Big-Endian binary          lowlyw          
-zimg         LGPL3     ZIMG format binary                     ninjahacker     
-.fatmach0    LGPL3     Fat Mach-O binary extractor
-.sep64       LGPL3     64-bit SEP binary extractor
+any          LGPL3     nibble          Dummy format binary                    
+art          LGPL3     pancake         Android Runtime                        
+avr          LGPL3     pancake         ATmel AVR MCUs                         
+bf           LGPL3     pancake         Brainfuck                              
+bflt         LGPL3     Oscar Salvador  bFLT uClinux binary                    
+bios         LGPL      pancake         BIOS binary                            
+bootimg      LGPL3     pancake         Android Boot Image                     
+cgc          LGPL3     ret2libc        CGC (Cyber Grand Challenge)            
+coff         LGPL3     Fedor Sakharov  COFF (Common Object File Format)       
+dex          LGPL3     deroad          DEX (Dalvik Executable)                
+dmp64        LGPL3     abcSup          Windows x64 Crash Dump                 
+dol          BSD       pancake         Nintendo Dolphin binary                
+dyldcache    LGPL3     pancake         Apple DYLD Cache                       
+elf          LGPL3     nibble          ELF (Executable and Linkable Format)   
+elf64        LGPL3     nibble          ELF64                                  
+java         LGPL3     deroad          Java binary                            
+kernelcache  LGPL3     mrmacete        Apple Kernelcache                      
+le           LGPL3     GustavoLCR      LE/LX                                  
+luac         LGPL3     Heersin         Lua compiled binary                    
+mach0        LGPL3     pancake         Mach-O (Mach Object)                   
+mach064      LGPL3     nibble          Mach-O 64-bit                          
+mbn          LGPL3     pancake         MBN/SBL bootloader binary              
+mdmp         LGPL3     Davis           Windows MiniDump                       
+menuet       LGPL3     pancake         Menuet/KolibriOS binary                
+mz           MIT       nodepad         MZ (DOS MZ Executable)                 
+ne           LGPL3     GustavoLCR      NE (New Executable)                    
+nes          MIT       maijin          Nintendo NES                           
+nin3ds       LGPL3     a0rtega         Nintendo 3DS Firmware                  
+ninds        LGPL3     a0rtega         Nintendo DS binary                     
+ningb        LGPL3     condret         Nintendo Game Boy                      
+ningba       LGPL3     condret         Nintendo Game Boy Advance              
+nro          MIT       pancake         Nintendo Switch NRO                    
+nso          MIT       rkx1209         Nintendo Switch NSO                    
+omf          LGPL3     ampotos         OMF (Object Module Format)             
+p9           LGPL3     pancake         Plan9 binary                           
+pe           LGPL3     nibble          PE (Portable Executable)               
+pe64         LGPL3     nibble          PE64 (PE32+) binary                    
+pebble       LGPL      pancake         Pebble Watch App                       
+prg          LGPL3     thestr4ng3r     C64 PRG (Commodore 64)                 
+psxexe       LGPL3     Dax89           Sony PlayStation 1 executable          
+pyc          LGPL3     c0riolis        Python byte-compiled                   
+qnx          LGPL3     deepakchethan   QNX executable                         
+sfc          LGPL3     usrshare        Super NES / Super Famicom ROM          
+smd          LGPL3     pancake         SEGA Genesis / MegaDrive ROM           
+sms          LGPL3     shengdi         SEGA MasterSystem / GameGear ROM       
+spc700       LGPL3     maijin          SNES SPC700 sound data                 
+symbols      MIT       pancake         Apple Symbols file                     
+te           LGPL3     xvilka          TE (Terse Executable)                  
+vsf          LGPL3     riq             VICE snapshot file                     
+wasm         MIT       pancake         WebAssembly                            
+xbe          LGPL3     LemonBoy        Microsoft Xbox XBE (Xbox Executable)   
+z64          LGPL3     lowlyw          Nintendo 64 Big-Endian binary          
+zimg         LGPL3     ninjahacker     ZIMG format binary                     
+.fatmach0    LGPL3                     Fat Mach-O binary extractor
+.sep64       LGPL3                     64-bit SEP binary extractor
 [{"name":"any","description":"Dummy format binary","license":"LGPL3","author":"nibble"},{"name":"art","description":"Android Runtime","license":"LGPL3","author":"pancake"},{"name":"avr","description":"ATmel AVR MCUs","license":"LGPL3","author":"pancake"},{"name":"bf","description":"Brainfuck","license":"LGPL3","author":"pancake"},{"name":"bflt","description":"bFLT uClinux binary","license":"LGPL3","author":"Oscar Salvador"},{"name":"bios","description":"BIOS binary","license":"LGPL","author":"pancake"},{"name":"bootimg","description":"Android Boot Image","license":"LGPL3","author":"pancake"},{"name":"cgc","description":"CGC (Cyber Grand Challenge)","license":"LGPL3","author":"ret2libc"},{"name":"coff","description":"COFF (Common Object File Format)","license":"LGPL3","author":"Fedor Sakharov"},{"name":"dex","description":"DEX (Dalvik Executable)","license":"LGPL3","author":"deroad"},{"name":"dmp64","description":"Windows x64 Crash Dump","license":"LGPL3","author":"abcSup"},{"name":"dol","description":"Nintendo Dolphin binary","license":"BSD","author":"pancake"},{"name":"dyldcache","description":"Apple DYLD Cache","license":"LGPL3","author":"pancake"},{"name":"elf","description":"ELF (Executable and Linkable Format)","license":"LGPL3","author":"nibble"},{"name":"elf64","description":"ELF64","license":"LGPL3","author":"nibble"},{"name":"java","description":"Java binary","license":"LGPL3","author":"deroad"},{"name":"kernelcache","description":"Apple Kernelcache","license":"LGPL3","author":"mrmacete"},{"name":"le","description":"LE/LX","license":"LGPL3","author":"GustavoLCR"},{"name":"luac","description":"Lua compiled binary","license":"LGPL3","author":"Heersin"},{"name":"mach0","description":"Mach-O (Mach Object)","license":"LGPL3","author":"pancake"},{"name":"mach064","description":"Mach-O 64-bit","license":"LGPL3","author":"nibble"},{"name":"mbn","description":"MBN/SBL bootloader binary","license":"LGPL3","author":"pancake"},{"name":"mdmp","description":"Windows MiniDump","license":"LGPL3","author":"Davis"},{"name":"menuet","description":"Menuet/KolibriOS binary","license":"LGPL3","author":"pancake"},{"name":"mz","description":"MZ (DOS MZ Executable)","license":"MIT","author":"nodepad"},{"name":"ne","description":"NE (New Executable)","license":"LGPL3","author":"GustavoLCR"},{"name":"nes","description":"Nintendo NES","license":"MIT","author":"maijin"},{"name":"nin3ds","description":"Nintendo 3DS Firmware","license":"LGPL3","author":"a0rtega"},{"name":"ninds","description":"Nintendo DS binary","license":"LGPL3","author":"a0rtega"},{"name":"ningb","description":"Nintendo Game Boy","license":"LGPL3","author":"condret"},{"name":"ningba","description":"Nintendo Game Boy Advance","license":"LGPL3","author":"condret"},{"name":"nro","description":"Nintendo Switch NRO","license":"MIT","author":"pancake"},{"name":"nso","description":"Nintendo Switch NSO","license":"MIT","author":"rkx1209"},{"name":"omf","description":"OMF (Object Module Format)","license":"LGPL3","author":"ampotos"},{"name":"p9","description":"Plan9 binary","license":"LGPL3","author":"pancake"},{"name":"pe","description":"PE (Portable Executable)","license":"LGPL3","author":"nibble"},{"name":"pe64","description":"PE64 (PE32+) binary","license":"LGPL3","author":"nibble"},{"name":"pebble","description":"Pebble Watch App","license":"LGPL","author":"pancake"},{"name":"prg","description":"C64 PRG (Commodore 64)","license":"LGPL3","author":"thestr4ng3r"},{"name":"psxexe","description":"Sony PlayStation 1 executable","license":"LGPL3","author":"Dax89"},{"name":"pyc","description":"Python byte-compiled","license":"LGPL3","author":"c0riolis"},{"name":"qnx","description":"QNX executable","license":"LGPL3","author":"deepakchethan"},{"name":"sfc","description":"Super NES / Super Famicom ROM","license":"LGPL3","author":"usrshare"},{"name":"smd","description":"SEGA Genesis / MegaDrive ROM","license":"LGPL3","author":"pancake"},{"name":"sms","description":"SEGA MasterSystem / GameGear ROM","license":"LGPL3","author":"shengdi"},{"name":"spc700","description":"SNES SPC700 sound data","license":"LGPL3","author":"maijin"},{"name":"symbols","description":"Apple Symbols file","license":"MIT","author":"pancake"},{"name":"te","description":"TE (Terse Executable)","license":"LGPL3","author":"xvilka"},{"name":"vsf","description":"VICE snapshot file","license":"LGPL3","author":"riq"},{"name":"wasm","description":"WebAssembly","license":"MIT","author":"pancake"},{"name":"xbe","description":"Microsoft Xbox XBE (Xbox Executable)","license":"LGPL3","author":"LemonBoy"},{"name":"z64","description":"Nintendo 64 Big-Endian binary","license":"LGPL3","author":"lowlyw"},{"name":"zimg","description":"ZIMG format binary","license":"LGPL3","author":"ninjahacker"},{"name":"xtr.fatmach0","description":"Fat Mach-O binary extractor","license":"LGPL3"},{"name":"xtr.sep64","description":"64-bit SEP binary extractor","license":"LGPL3"}]
-name         license description                          author         version 
+name         license author         description                          version 
 ---------------------------------------------------------------------------------
-any          LGPL3   Dummy format binary                  nibble         
-art          LGPL3   Android Runtime                      pancake        
-avr          LGPL3   ATmel AVR MCUs                       pancake        
-bf           LGPL3   Brainfuck                            pancake        
-bflt         LGPL3   bFLT uClinux binary                  Oscar Salvador 
-bios         LGPL    BIOS binary                          pancake        
-bootimg      LGPL3   Android Boot Image                   pancake        
-cgc          LGPL3   CGC (Cyber Grand Challenge)          ret2libc       
-coff         LGPL3   COFF (Common Object File Format)     Fedor Sakharov 
-dex          LGPL3   DEX (Dalvik Executable)              deroad         
-dmp64        LGPL3   Windows x64 Crash Dump               abcSup         
-dol          BSD     Nintendo Dolphin binary              pancake        
-dyldcache    LGPL3   Apple DYLD Cache                     pancake        
-elf          LGPL3   ELF (Executable and Linkable Format) nibble         
-elf64        LGPL3   ELF64                                nibble         
-java         LGPL3   Java binary                          deroad         
-kernelcache  LGPL3   Apple Kernelcache                    mrmacete       
-le           LGPL3   LE/LX                                GustavoLCR     
-luac         LGPL3   Lua compiled binary                  Heersin        
-mach0        LGPL3   Mach-O (Mach Object)                 pancake        
-mach064      LGPL3   Mach-O 64-bit                        nibble         
-mbn          LGPL3   MBN/SBL bootloader binary            pancake        
-mdmp         LGPL3   Windows MiniDump                     Davis          
-menuet       LGPL3   Menuet/KolibriOS binary              pancake        
-mz           MIT     MZ (DOS MZ Executable)               nodepad        
-ne           LGPL3   NE (New Executable)                  GustavoLCR     
-nes          MIT     Nintendo NES                         maijin         
-nin3ds       LGPL3   Nintendo 3DS Firmware                a0rtega        
-ninds        LGPL3   Nintendo DS binary                   a0rtega        
-ningb        LGPL3   Nintendo Game Boy                    condret        
-ningba       LGPL3   Nintendo Game Boy Advance            condret        
-nro          MIT     Nintendo Switch NRO                  pancake        
-nso          MIT     Nintendo Switch NSO                  rkx1209        
-omf          LGPL3   OMF (Object Module Format)           ampotos        
-p9           LGPL3   Plan9 binary                         pancake        
-pe           LGPL3   PE (Portable Executable)             nibble         
-pe64         LGPL3   PE64 (PE32+) binary                  nibble         
-pebble       LGPL    Pebble Watch App                     pancake        
-prg          LGPL3   C64 PRG (Commodore 64)               thestr4ng3r    
-psxexe       LGPL3   Sony PlayStation 1 executable        Dax89          
-pyc          LGPL3   Python byte-compiled                 c0riolis       
-qnx          LGPL3   QNX executable                       deepakchethan  
-sfc          LGPL3   Super NES / Super Famicom ROM        usrshare       
-smd          LGPL3   SEGA Genesis / MegaDrive ROM         pancake        
-sms          LGPL3   SEGA MasterSystem / GameGear ROM     shengdi        
-spc700       LGPL3   SNES SPC700 sound data               maijin         
-symbols      MIT     Apple Symbols file                   pancake        
-te           LGPL3   TE (Terse Executable)                xvilka         
-vsf          LGPL3   VICE snapshot file                   riq            
-wasm         MIT     WebAssembly                          pancake        
-xbe          LGPL3   Microsoft Xbox XBE (Xbox Executable) LemonBoy       
-z64          LGPL3   Nintendo 64 Big-Endian binary        lowlyw         
-zimg         LGPL3   ZIMG format binary                   ninjahacker    
-xtr.fatmach0 LGPL3   Fat Mach-O binary extractor
-xtr.sep64    LGPL3   64-bit SEP binary extractor
+any          LGPL3   nibble         Dummy format binary                  
+art          LGPL3   pancake        Android Runtime                      
+avr          LGPL3   pancake        ATmel AVR MCUs                       
+bf           LGPL3   pancake        Brainfuck                            
+bflt         LGPL3   Oscar Salvador bFLT uClinux binary                  
+bios         LGPL    pancake        BIOS binary                          
+bootimg      LGPL3   pancake        Android Boot Image                   
+cgc          LGPL3   ret2libc       CGC (Cyber Grand Challenge)          
+coff         LGPL3   Fedor Sakharov COFF (Common Object File Format)     
+dex          LGPL3   deroad         DEX (Dalvik Executable)              
+dmp64        LGPL3   abcSup         Windows x64 Crash Dump               
+dol          BSD     pancake        Nintendo Dolphin binary              
+dyldcache    LGPL3   pancake        Apple DYLD Cache                     
+elf          LGPL3   nibble         ELF (Executable and Linkable Format) 
+elf64        LGPL3   nibble         ELF64                                
+java         LGPL3   deroad         Java binary                          
+kernelcache  LGPL3   mrmacete       Apple Kernelcache                    
+le           LGPL3   GustavoLCR     LE/LX                                
+luac         LGPL3   Heersin        Lua compiled binary                  
+mach0        LGPL3   pancake        Mach-O (Mach Object)                 
+mach064      LGPL3   nibble         Mach-O 64-bit                        
+mbn          LGPL3   pancake        MBN/SBL bootloader binary            
+mdmp         LGPL3   Davis          Windows MiniDump                     
+menuet       LGPL3   pancake        Menuet/KolibriOS binary              
+mz           MIT     nodepad        MZ (DOS MZ Executable)               
+ne           LGPL3   GustavoLCR     NE (New Executable)                  
+nes          MIT     maijin         Nintendo NES                         
+nin3ds       LGPL3   a0rtega        Nintendo 3DS Firmware                
+ninds        LGPL3   a0rtega        Nintendo DS binary                   
+ningb        LGPL3   condret        Nintendo Game Boy                    
+ningba       LGPL3   condret        Nintendo Game Boy Advance            
+nro          MIT     pancake        Nintendo Switch NRO                  
+nso          MIT     rkx1209        Nintendo Switch NSO                  
+omf          LGPL3   ampotos        OMF (Object Module Format)           
+p9           LGPL3   pancake        Plan9 binary                         
+pe           LGPL3   nibble         PE (Portable Executable)             
+pe64         LGPL3   nibble         PE64 (PE32+) binary                  
+pebble       LGPL    pancake        Pebble Watch App                     
+prg          LGPL3   thestr4ng3r    C64 PRG (Commodore 64)               
+psxexe       LGPL3   Dax89          Sony PlayStation 1 executable        
+pyc          LGPL3   c0riolis       Python byte-compiled                 
+qnx          LGPL3   deepakchethan  QNX executable                       
+sfc          LGPL3   usrshare       Super NES / Super Famicom ROM        
+smd          LGPL3   pancake        SEGA Genesis / MegaDrive ROM         
+sms          LGPL3   shengdi        SEGA MasterSystem / GameGear ROM     
+spc700       LGPL3   maijin         SNES SPC700 sound data               
+symbols      MIT     pancake        Apple Symbols file                   
+te           LGPL3   xvilka         TE (Terse Executable)                
+vsf          LGPL3   riq            VICE snapshot file                   
+wasm         MIT     pancake        WebAssembly                          
+xbe          LGPL3   LemonBoy       Microsoft Xbox XBE (Xbox Executable) 
+z64          LGPL3   lowlyw         Nintendo 64 Big-Endian binary        
+zimg         LGPL3   ninjahacker    ZIMG format binary                   
+xtr.fatmach0 LGPL3                  Fat Mach-O binary extractor
+xtr.sep64    LGPL3                  64-bit SEP binary extractor
 any
 art
 avr

--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -202,7 +202,7 @@ dmp64        LGPL3     abcSup          Windows x64 Crash Dump
 dol          BSD       pancake         Nintendo Dolphin binary                
 dyldcache    LGPL3     pancake         Apple DYLD Cache                       
 elf          LGPL3     nibble          ELF (Executable and Linkable Format)   
-elf64        LGPL3     nibble          ELF64                                  
+elf64        LGPL3     nibble          ELF64 (64-bit Executable and Linkable Format) 
 java         LGPL3     deroad          Java binary                            
 kernelcache  LGPL3     mrmacete        Apple Kernelcache                      
 le           LGPL3     GustavoLCR      LE/LX                                  
@@ -243,62 +243,62 @@ z64          LGPL3     lowlyw          Nintendo 64 Big-Endian binary
 zimg         LGPL3     ninjahacker     ZIMG format binary                     
 .fatmach0    LGPL3                     Fat Mach-O binary extractor
 .sep64       LGPL3                     64-bit SEP binary extractor
-[{"name":"any","description":"Dummy format binary","license":"LGPL3","author":"nibble"},{"name":"art","description":"Android Runtime","license":"LGPL3","author":"pancake"},{"name":"avr","description":"ATmel AVR MCUs","license":"LGPL3","author":"pancake"},{"name":"bf","description":"Brainfuck","license":"LGPL3","author":"pancake"},{"name":"bflt","description":"bFLT uClinux binary","license":"LGPL3","author":"Oscar Salvador"},{"name":"bios","description":"BIOS binary","license":"LGPL","author":"pancake"},{"name":"bootimg","description":"Android Boot Image","license":"LGPL3","author":"pancake"},{"name":"cgc","description":"CGC (Cyber Grand Challenge)","license":"LGPL3","author":"ret2libc"},{"name":"coff","description":"COFF (Common Object File Format)","license":"LGPL3","author":"Fedor Sakharov"},{"name":"dex","description":"DEX (Dalvik Executable)","license":"LGPL3","author":"deroad"},{"name":"dmp64","description":"Windows x64 Crash Dump","license":"LGPL3","author":"abcSup"},{"name":"dol","description":"Nintendo Dolphin binary","license":"BSD","author":"pancake"},{"name":"dyldcache","description":"Apple DYLD Cache","license":"LGPL3","author":"pancake"},{"name":"elf","description":"ELF (Executable and Linkable Format)","license":"LGPL3","author":"nibble"},{"name":"elf64","description":"ELF64","license":"LGPL3","author":"nibble"},{"name":"java","description":"Java binary","license":"LGPL3","author":"deroad"},{"name":"kernelcache","description":"Apple Kernelcache","license":"LGPL3","author":"mrmacete"},{"name":"le","description":"LE/LX","license":"LGPL3","author":"GustavoLCR"},{"name":"luac","description":"Lua compiled binary","license":"LGPL3","author":"Heersin"},{"name":"mach0","description":"Mach-O (Mach Object)","license":"LGPL3","author":"pancake"},{"name":"mach064","description":"Mach-O 64-bit","license":"LGPL3","author":"nibble"},{"name":"mbn","description":"MBN/SBL bootloader binary","license":"LGPL3","author":"pancake"},{"name":"mdmp","description":"Windows MiniDump","license":"LGPL3","author":"Davis"},{"name":"menuet","description":"Menuet/KolibriOS binary","license":"LGPL3","author":"pancake"},{"name":"mz","description":"MZ (DOS MZ Executable)","license":"MIT","author":"nodepad"},{"name":"ne","description":"NE (New Executable)","license":"LGPL3","author":"GustavoLCR"},{"name":"nes","description":"Nintendo NES","license":"MIT","author":"maijin"},{"name":"nin3ds","description":"Nintendo 3DS Firmware","license":"LGPL3","author":"a0rtega"},{"name":"ninds","description":"Nintendo DS binary","license":"LGPL3","author":"a0rtega"},{"name":"ningb","description":"Nintendo Game Boy","license":"LGPL3","author":"condret"},{"name":"ningba","description":"Nintendo Game Boy Advance","license":"LGPL3","author":"condret"},{"name":"nro","description":"Nintendo Switch NRO","license":"MIT","author":"pancake"},{"name":"nso","description":"Nintendo Switch NSO","license":"MIT","author":"rkx1209"},{"name":"omf","description":"OMF (Object Module Format)","license":"LGPL3","author":"ampotos"},{"name":"p9","description":"Plan9 binary","license":"LGPL3","author":"pancake"},{"name":"pe","description":"PE (Portable Executable)","license":"LGPL3","author":"nibble"},{"name":"pe64","description":"PE64 (PE32+) binary","license":"LGPL3","author":"nibble"},{"name":"pebble","description":"Pebble Watch App","license":"LGPL","author":"pancake"},{"name":"prg","description":"C64 PRG (Commodore 64)","license":"LGPL3","author":"thestr4ng3r"},{"name":"psxexe","description":"Sony PlayStation 1 executable","license":"LGPL3","author":"Dax89"},{"name":"pyc","description":"Python byte-compiled","license":"LGPL3","author":"c0riolis"},{"name":"qnx","description":"QNX executable","license":"LGPL3","author":"deepakchethan"},{"name":"sfc","description":"Super NES / Super Famicom ROM","license":"LGPL3","author":"usrshare"},{"name":"smd","description":"SEGA Genesis / MegaDrive ROM","license":"LGPL3","author":"pancake"},{"name":"sms","description":"SEGA MasterSystem / GameGear ROM","license":"LGPL3","author":"shengdi"},{"name":"spc700","description":"SNES SPC700 sound data","license":"LGPL3","author":"maijin"},{"name":"symbols","description":"Apple Symbols file","license":"MIT","author":"pancake"},{"name":"te","description":"TE (Terse Executable)","license":"LGPL3","author":"xvilka"},{"name":"vsf","description":"VICE snapshot file","license":"LGPL3","author":"riq"},{"name":"wasm","description":"WebAssembly","license":"MIT","author":"pancake"},{"name":"xbe","description":"Microsoft Xbox XBE (Xbox Executable)","license":"LGPL3","author":"LemonBoy"},{"name":"z64","description":"Nintendo 64 Big-Endian binary","license":"LGPL3","author":"lowlyw"},{"name":"zimg","description":"ZIMG format binary","license":"LGPL3","author":"ninjahacker"},{"name":"xtr.fatmach0","description":"Fat Mach-O binary extractor","license":"LGPL3"},{"name":"xtr.sep64","description":"64-bit SEP binary extractor","license":"LGPL3"}]
-name         license author         description                          version 
----------------------------------------------------------------------------------
-any          LGPL3   nibble         Dummy format binary                  
-art          LGPL3   pancake        Android Runtime                      
-avr          LGPL3   pancake        ATmel AVR MCUs                       
-bf           LGPL3   pancake        Brainfuck                            
-bflt         LGPL3   Oscar Salvador bFLT uClinux binary                  
-bios         LGPL    pancake        BIOS binary                          
-bootimg      LGPL3   pancake        Android Boot Image                   
-cgc          LGPL3   ret2libc       CGC (Cyber Grand Challenge)          
-coff         LGPL3   Fedor Sakharov COFF (Common Object File Format)     
-dex          LGPL3   deroad         DEX (Dalvik Executable)              
-dmp64        LGPL3   abcSup         Windows x64 Crash Dump               
-dol          BSD     pancake        Nintendo Dolphin binary              
-dyldcache    LGPL3   pancake        Apple DYLD Cache                     
-elf          LGPL3   nibble         ELF (Executable and Linkable Format) 
-elf64        LGPL3   nibble         ELF64                                
-java         LGPL3   deroad         Java binary                          
-kernelcache  LGPL3   mrmacete       Apple Kernelcache                    
-le           LGPL3   GustavoLCR     LE/LX                                
-luac         LGPL3   Heersin        Lua compiled binary                  
-mach0        LGPL3   pancake        Mach-O (Mach Object)                 
-mach064      LGPL3   nibble         Mach-O 64-bit                        
-mbn          LGPL3   pancake        MBN/SBL bootloader binary            
-mdmp         LGPL3   Davis          Windows MiniDump                     
-menuet       LGPL3   pancake        Menuet/KolibriOS binary              
-mz           MIT     nodepad        MZ (DOS MZ Executable)               
-ne           LGPL3   GustavoLCR     NE (New Executable)                  
-nes          MIT     maijin         Nintendo NES                         
-nin3ds       LGPL3   a0rtega        Nintendo 3DS Firmware                
-ninds        LGPL3   a0rtega        Nintendo DS binary                   
-ningb        LGPL3   condret        Nintendo Game Boy                    
-ningba       LGPL3   condret        Nintendo Game Boy Advance            
-nro          MIT     pancake        Nintendo Switch NRO                  
-nso          MIT     rkx1209        Nintendo Switch NSO                  
-omf          LGPL3   ampotos        OMF (Object Module Format)           
-p9           LGPL3   pancake        Plan9 binary                         
-pe           LGPL3   nibble         PE (Portable Executable)             
-pe64         LGPL3   nibble         PE64 (PE32+) binary                  
-pebble       LGPL    pancake        Pebble Watch App                     
-prg          LGPL3   thestr4ng3r    C64 PRG (Commodore 64)               
-psxexe       LGPL3   Dax89          Sony PlayStation 1 executable        
-pyc          LGPL3   c0riolis       Python byte-compiled                 
-qnx          LGPL3   deepakchethan  QNX executable                       
-sfc          LGPL3   usrshare       Super NES / Super Famicom ROM        
-smd          LGPL3   pancake        SEGA Genesis / MegaDrive ROM         
-sms          LGPL3   shengdi        SEGA MasterSystem / GameGear ROM     
-spc700       LGPL3   maijin         SNES SPC700 sound data               
-symbols      MIT     pancake        Apple Symbols file                   
-te           LGPL3   xvilka         TE (Terse Executable)                
-vsf          LGPL3   riq            VICE snapshot file                   
-wasm         MIT     pancake        WebAssembly                          
-xbe          LGPL3   LemonBoy       Microsoft Xbox XBE (Xbox Executable) 
-z64          LGPL3   lowlyw         Nintendo 64 Big-Endian binary        
-zimg         LGPL3   ninjahacker    ZIMG format binary                   
+[{"name":"any","description":"Dummy format binary","license":"LGPL3","author":"nibble"},{"name":"art","description":"Android Runtime","license":"LGPL3","author":"pancake"},{"name":"avr","description":"ATmel AVR MCUs","license":"LGPL3","author":"pancake"},{"name":"bf","description":"Brainfuck","license":"LGPL3","author":"pancake"},{"name":"bflt","description":"bFLT uClinux binary","license":"LGPL3","author":"Oscar Salvador"},{"name":"bios","description":"BIOS binary","license":"LGPL","author":"pancake"},{"name":"bootimg","description":"Android Boot Image","license":"LGPL3","author":"pancake"},{"name":"cgc","description":"CGC (Cyber Grand Challenge)","license":"LGPL3","author":"ret2libc"},{"name":"coff","description":"COFF (Common Object File Format)","license":"LGPL3","author":"Fedor Sakharov"},{"name":"dex","description":"DEX (Dalvik Executable)","license":"LGPL3","author":"deroad"},{"name":"dmp64","description":"Windows x64 Crash Dump","license":"LGPL3","author":"abcSup"},{"name":"dol","description":"Nintendo Dolphin binary","license":"BSD","author":"pancake"},{"name":"dyldcache","description":"Apple DYLD Cache","license":"LGPL3","author":"pancake"},{"name":"elf","description":"ELF (Executable and Linkable Format)","license":"LGPL3","author":"nibble"},{"name":"elf64","description":"ELF64 (64-bit Executable and Linkable Format)","license":"LGPL3","author":"nibble"},{"name":"java","description":"Java binary","license":"LGPL3","author":"deroad"},{"name":"kernelcache","description":"Apple Kernelcache","license":"LGPL3","author":"mrmacete"},{"name":"le","description":"LE/LX","license":"LGPL3","author":"GustavoLCR"},{"name":"luac","description":"Lua compiled binary","license":"LGPL3","author":"Heersin"},{"name":"mach0","description":"Mach-O (Mach Object)","license":"LGPL3","author":"pancake"},{"name":"mach064","description":"Mach-O 64-bit","license":"LGPL3","author":"nibble"},{"name":"mbn","description":"MBN/SBL bootloader binary","license":"LGPL3","author":"pancake"},{"name":"mdmp","description":"Windows MiniDump","license":"LGPL3","author":"Davis"},{"name":"menuet","description":"Menuet/KolibriOS binary","license":"LGPL3","author":"pancake"},{"name":"mz","description":"MZ (DOS MZ Executable)","license":"MIT","author":"nodepad"},{"name":"ne","description":"NE (New Executable)","license":"LGPL3","author":"GustavoLCR"},{"name":"nes","description":"Nintendo NES","license":"MIT","author":"maijin"},{"name":"nin3ds","description":"Nintendo 3DS Firmware","license":"LGPL3","author":"a0rtega"},{"name":"ninds","description":"Nintendo DS binary","license":"LGPL3","author":"a0rtega"},{"name":"ningb","description":"Nintendo Game Boy","license":"LGPL3","author":"condret"},{"name":"ningba","description":"Nintendo Game Boy Advance","license":"LGPL3","author":"condret"},{"name":"nro","description":"Nintendo Switch NRO","license":"MIT","author":"pancake"},{"name":"nso","description":"Nintendo Switch NSO","license":"MIT","author":"rkx1209"},{"name":"omf","description":"OMF (Object Module Format)","license":"LGPL3","author":"ampotos"},{"name":"p9","description":"Plan9 binary","license":"LGPL3","author":"pancake"},{"name":"pe","description":"PE (Portable Executable)","license":"LGPL3","author":"nibble"},{"name":"pe64","description":"PE64 (PE32+) binary","license":"LGPL3","author":"nibble"},{"name":"pebble","description":"Pebble Watch App","license":"LGPL","author":"pancake"},{"name":"prg","description":"C64 PRG (Commodore 64)","license":"LGPL3","author":"thestr4ng3r"},{"name":"psxexe","description":"Sony PlayStation 1 executable","license":"LGPL3","author":"Dax89"},{"name":"pyc","description":"Python byte-compiled","license":"LGPL3","author":"c0riolis"},{"name":"qnx","description":"QNX executable","license":"LGPL3","author":"deepakchethan"},{"name":"sfc","description":"Super NES / Super Famicom ROM","license":"LGPL3","author":"usrshare"},{"name":"smd","description":"SEGA Genesis / MegaDrive ROM","license":"LGPL3","author":"pancake"},{"name":"sms","description":"SEGA MasterSystem / GameGear ROM","license":"LGPL3","author":"shengdi"},{"name":"spc700","description":"SNES SPC700 sound data","license":"LGPL3","author":"maijin"},{"name":"symbols","description":"Apple Symbols file","license":"MIT","author":"pancake"},{"name":"te","description":"TE (Terse Executable)","license":"LGPL3","author":"xvilka"},{"name":"vsf","description":"VICE snapshot file","license":"LGPL3","author":"riq"},{"name":"wasm","description":"WebAssembly","license":"MIT","author":"pancake"},{"name":"xbe","description":"Microsoft Xbox XBE (Xbox Executable)","license":"LGPL3","author":"LemonBoy"},{"name":"z64","description":"Nintendo 64 Big-Endian binary","license":"LGPL3","author":"lowlyw"},{"name":"zimg","description":"ZIMG format binary","license":"LGPL3","author":"ninjahacker"},{"name":"xtr.fatmach0","description":"Fat Mach-O binary extractor","license":"LGPL3"},{"name":"xtr.sep64","description":"64-bit SEP binary extractor","license":"LGPL3"}]
+name         license author         description                                   version 
+------------------------------------------------------------------------------------------
+any          LGPL3   nibble         Dummy format binary                           
+art          LGPL3   pancake        Android Runtime                               
+avr          LGPL3   pancake        ATmel AVR MCUs                                
+bf           LGPL3   pancake        Brainfuck                                     
+bflt         LGPL3   Oscar Salvador bFLT uClinux binary                           
+bios         LGPL    pancake        BIOS binary                                   
+bootimg      LGPL3   pancake        Android Boot Image                            
+cgc          LGPL3   ret2libc       CGC (Cyber Grand Challenge)                   
+coff         LGPL3   Fedor Sakharov COFF (Common Object File Format)              
+dex          LGPL3   deroad         DEX (Dalvik Executable)                       
+dmp64        LGPL3   abcSup         Windows x64 Crash Dump                        
+dol          BSD     pancake        Nintendo Dolphin binary                       
+dyldcache    LGPL3   pancake        Apple DYLD Cache                              
+elf          LGPL3   nibble         ELF (Executable and Linkable Format)          
+elf64        LGPL3   nibble         ELF64 (64-bit Executable and Linkable Format) 
+java         LGPL3   deroad         Java binary                                   
+kernelcache  LGPL3   mrmacete       Apple Kernelcache                             
+le           LGPL3   GustavoLCR     LE/LX                                         
+luac         LGPL3   Heersin        Lua compiled binary                           
+mach0        LGPL3   pancake        Mach-O (Mach Object)                          
+mach064      LGPL3   nibble         Mach-O 64-bit                                 
+mbn          LGPL3   pancake        MBN/SBL bootloader binary                     
+mdmp         LGPL3   Davis          Windows MiniDump                              
+menuet       LGPL3   pancake        Menuet/KolibriOS binary                       
+mz           MIT     nodepad        MZ (DOS MZ Executable)                        
+ne           LGPL3   GustavoLCR     NE (New Executable)                           
+nes          MIT     maijin         Nintendo NES                                  
+nin3ds       LGPL3   a0rtega        Nintendo 3DS Firmware                         
+ninds        LGPL3   a0rtega        Nintendo DS binary                            
+ningb        LGPL3   condret        Nintendo Game Boy                             
+ningba       LGPL3   condret        Nintendo Game Boy Advance                     
+nro          MIT     pancake        Nintendo Switch NRO                           
+nso          MIT     rkx1209        Nintendo Switch NSO                           
+omf          LGPL3   ampotos        OMF (Object Module Format)                    
+p9           LGPL3   pancake        Plan9 binary                                  
+pe           LGPL3   nibble         PE (Portable Executable)                      
+pe64         LGPL3   nibble         PE64 (PE32+) binary                           
+pebble       LGPL    pancake        Pebble Watch App                              
+prg          LGPL3   thestr4ng3r    C64 PRG (Commodore 64)                        
+psxexe       LGPL3   Dax89          Sony PlayStation 1 executable                 
+pyc          LGPL3   c0riolis       Python byte-compiled                          
+qnx          LGPL3   deepakchethan  QNX executable                                
+sfc          LGPL3   usrshare       Super NES / Super Famicom ROM                 
+smd          LGPL3   pancake        SEGA Genesis / MegaDrive ROM                  
+sms          LGPL3   shengdi        SEGA MasterSystem / GameGear ROM              
+spc700       LGPL3   maijin         SNES SPC700 sound data                        
+symbols      MIT     pancake        Apple Symbols file                            
+te           LGPL3   xvilka         TE (Terse Executable)                         
+vsf          LGPL3   riq            VICE snapshot file                            
+wasm         MIT     pancake        WebAssembly                                   
+xbe          LGPL3   LemonBoy       Microsoft Xbox XBE (Xbox Executable)          
+z64          LGPL3   lowlyw         Nintendo 64 Big-Endian binary                 
+zimg         LGPL3   ninjahacker    ZIMG format binary                            
 xtr.fatmach0 LGPL3                  Fat Mach-O binary extractor
 xtr.sep64    LGPL3                  64-bit SEP binary extractor
 any


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
Changed bin plugins descriptions to be more uniform + updated tests
New output:
```
rz-bin -L                   
any          LGPL3     nibble          Dummy format binary                    
art          LGPL3     pancake         Android Runtime                        
avr          LGPL3     pancake         ATmel AVR MCUs                         
bf           LGPL3     pancake         Brainfuck                              
bflt         LGPL3     Oscar Salvador  bFLT uClinux binary                    
bios         LGPL      pancake         BIOS binary                            
bootimg      LGPL3     pancake         Android Boot Image                     
cgc          LGPL3     ret2libc        CGC (Cyber Grand Challenge)            
coff         LGPL3     Fedor Sakharov  COFF (Common Object File Format)       
dex          LGPL3     deroad          DEX (Dalvik Executable)                
dmp64        LGPL3     abcSup          Windows x64 Crash Dump                 
dol          BSD       pancake         Nintendo Dolphin binary                
dyldcache    LGPL3     pancake         Apple DYLD Cache                       
elf          LGPL3     nibble          ELF (Executable and Linkable Format)   
elf64        LGPL3     nibble          ELF64 (64-bit Executable and Linkable Format) 
java         LGPL3     deroad          Java binary                            
kernelcache  LGPL3     mrmacete        Apple Kernelcache                      
le           LGPL3     GustavoLCR      LE/LX                                  
luac         LGPL3     Heersin         Lua compiled binary                    
mach0        LGPL3     pancake         Mach-O (Mach Object)                   
mach064      LGPL3     nibble          Mach-O 64-bit                          
mbn          LGPL3     pancake         MBN/SBL bootloader binary              
mdmp         LGPL3     Davis           Windows MiniDump                       
menuet       LGPL3     pancake         Menuet/KolibriOS binary                
mz           MIT       nodepad         MZ (DOS MZ Executable)                 
ne           LGPL3     GustavoLCR      NE (New Executable)                    
nes          MIT       maijin          Nintendo NES                           
nin3ds       LGPL3     a0rtega         Nintendo 3DS Firmware                  
ninds        LGPL3     a0rtega         Nintendo DS binary                     
ningb        LGPL3     condret         Nintendo Game Boy                      
ningba       LGPL3     condret         Nintendo Game Boy Advance              
nro          MIT       pancake         Nintendo Switch NRO                    
nso          MIT       rkx1209         Nintendo Switch NSO                    
omf          LGPL3     ampotos         OMF (Object Module Format)             
p9           LGPL3     pancake         Plan9 binary                           
pe           LGPL3     nibble          PE (Portable Executable)               
pe64         LGPL3     nibble          PE64 (PE32+) binary                    
pebble       LGPL      pancake         Pebble Watch App                       
prg          LGPL3     thestr4ng3r     C64 PRG (Commodore 64)                 
psxexe       LGPL3     Dax89           Sony PlayStation 1 executable          
pyc          LGPL3     c0riolis        Python byte-compiled                   
qnx          LGPL3     deepakchethan   QNX executable                         
sfc          LGPL3     usrshare        Super NES / Super Famicom ROM          
smd          LGPL3     pancake         SEGA Genesis / MegaDrive ROM           
sms          LGPL3     shengdi         SEGA MasterSystem / GameGear ROM       
spc700       LGPL3     maijin          SNES SPC700 sound data                 
symbols      MIT       pancake         Apple Symbols file                     
te           LGPL3     xvilka          TE (Terse Executable)                  
vsf          LGPL3     riq             VICE snapshot file                     
wasm         MIT       pancake         WebAssembly                            
xbe          LGPL3     LemonBoy        Microsoft Xbox XBE (Xbox Executable)   
z64          LGPL3     lowlyw          Nintendo 64 Big-Endian binary          
zimg         LGPL3     ninjahacker     ZIMG format binary                     
.fatmach0    LGPL3                     Fat Mach-O binary extractor
.sep64       LGPL3                     64-bit SEP binary extractor
```
...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->
`rz-bin -L`
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
