### PR TITLE
Replace rz_core_warn_after_output function with RZ_LOG_WARN_AFTER macro

### DIFF
--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -2782,9 +2782,9 @@ static RzCmdStatus cmd_string_search_generic(RzCore *core, const char *string, c
 	if (flags & RZ_REGEX_LITERAL) {
 		search_str_len = rz_utf8_strlen((const ut8 *)search_str);
 		if (search_str_len < core->bin->str_search_cfg.min_length) {
-			rz_core_warn_after_output(core, rz_str_newf("|%s| < search.str.min_length so some search hits may be hidden. Set "
-								    "search.str.min_length to %" PFMTSZu " to see them.\n",
-								search_str, search_str_len));
+			RZ_LOG_WARN_AFTER(core, "|%s| < search.str.min_length so some search hits may be hidden."
+						" Set search.str.min_length to %" PFMTSZu " to see them.\n",
+				search_str, search_str_len);
 		}
 	}
 

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -144,20 +144,25 @@ RZ_API void rz_core_notify_error_str(RZ_NONNULL RzCore *core, RZ_NONNULL const c
  * \param  funcname Contains the function name of the calling function
  * \param  filename Contains the filename that funcname is defined in
  * \param  lineno   The line number that this log call is being made from in filename
+ * \param  level    Logging level for output
  * \param  fmtstr   A printf like string
 
-  This function is used by the RZ_LOG_WARN_AFTER preprocessor macro for logging.
+  This function is used by the RZ_LOG_*_AFTER preprocessor macro for logging.
 */
-RZ_API void rz_core_log_warn_after(RZ_NONNULL RzCore *core, const char *funcname, const char *filename,
-	ut32 lineno, const char *fmtstr, ...) {
+RZ_API void rz_core_log_after(RZ_NONNULL RzCore *core, const char *funcname, const char *filename,
+	ut32 lineno, RzLogLevel level, const char *fmtstr, ...) {
 	va_list args;
-	const char *warning;
+	const char *msg;
 
 	rz_return_if_fail(core);
 	va_start(args, fmtstr);
-	rz_vlog(funcname, filename, lineno, RZ_LOGLVL_WARN, "", &warning, fmtstr, args);
+	rz_vlog(funcname, filename, lineno, level, "", &msg, fmtstr, args);
 	va_end(args);
-	rz_list_append(core->warnings_after, (char *)warning);
+	if (level == RZ_LOGLVL_WARN) {
+		rz_list_append(core->warnings_after, (char *)msg);
+	} else {
+		RZ_LOG_ERROR("rz_core_log_after: Not implemented");
+	}
 }
 
 RZ_IPI void rz_core_print_warnings_after(RZ_NONNULL RzCore *core) {

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -139,13 +139,24 @@ RZ_API void rz_core_notify_error_str(RZ_NONNULL RzCore *core, RZ_NONNULL const c
 }
 
 /**
- * \brief  Delays printing of a warning until after command output
- *
- * \param  core    The RzCore to use
- * \param  warning The message to warn about (must be heap-allocated)
- */
-RZ_API void rz_core_warn_after_output(RZ_NONNULL RzCore *core, RZ_NONNULL const char *warning) {
-	rz_return_if_fail(core && warning);
+ * \brief  Internal logging function used by preprocessor macros
+ * \param  core     The RzCore to use
+ * \param  funcname Contains the function name of the calling function
+ * \param  filename Contains the filename that funcname is defined in
+ * \param  lineno   The line number that this log call is being made from in filename
+ * \param  fmtstr   A printf like string
+
+  This function is used by the RZ_LOG_WARN_AFTER preprocessor macro for logging.
+*/
+RZ_API void rz_core_log_warn_after(RZ_NONNULL RzCore *core, const char *funcname, const char *filename,
+	ut32 lineno, const char *fmtstr, ...) {
+	va_list args;
+	const char *warning;
+
+	rz_return_if_fail(core);
+	va_start(args, fmtstr);
+	rz_vlog(funcname, filename, lineno, RZ_LOGLVL_WARN, "", &warning, fmtstr, args);
+	va_end(args);
 	rz_list_append(core->warnings_after, (char *)warning);
 }
 

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -410,11 +410,11 @@ RZ_API void rz_core_notify_begin_str(RZ_NONNULL RzCore *core, RZ_NONNULL const c
 RZ_API void rz_core_notify_done_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
 RZ_API void rz_core_notify_error_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
 
-RZ_API void rz_core_log_warn_after(RZ_NONNULL RzCore *core, const char *funcname, const char *filename,
-	ut32 lineno, const char *fmtstr, ...) RZ_PRINTF_CHECK(5, 6);
+RZ_API void rz_core_log_after(RZ_NONNULL RzCore *core, const char *funcname, const char *filename,
+	ut32 lineno, RzLogLevel level, const char *fmtstr, ...) RZ_PRINTF_CHECK(6, 7);
 
-#define RZ_LOG_WARN_AFTER(core, fmtstr, ...) rz_core_log_warn_after(core, MACRO_LOG_FUNC, __FILE__, \
-	__LINE__, fmtstr, ##__VA_ARGS__);
+#define RZ_LOG_WARN_AFTER(core, fmtstr, ...) rz_core_log_after(core, MACRO_LOG_FUNC, __FILE__, \
+	__LINE__, RZ_LOGLVL_WARN, fmtstr, ##__VA_ARGS__);
 
 /**
  * \brief APIs to handle Visual Gadgets

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -410,7 +410,11 @@ RZ_API void rz_core_notify_begin_str(RZ_NONNULL RzCore *core, RZ_NONNULL const c
 RZ_API void rz_core_notify_done_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
 RZ_API void rz_core_notify_error_str(RZ_NONNULL RzCore *core, RZ_NONNULL const char *text);
 
-RZ_API void rz_core_warn_after_output(RZ_NONNULL RzCore *core, RZ_NONNULL const char *warning);
+RZ_API void rz_core_log_warn_after(RZ_NONNULL RzCore *core, const char *funcname, const char *filename,
+	ut32 lineno, const char *fmtstr, ...) RZ_PRINTF_CHECK(5, 6);
+
+#define RZ_LOG_WARN_AFTER(core, fmtstr, ...) rz_core_log_warn_after(core, MACRO_LOG_FUNC, __FILE__, \
+	__LINE__, fmtstr, ##__VA_ARGS__);
 
 /**
  * \brief APIs to handle Visual Gadgets

--- a/librz/include/rz_util/rz_log.h
+++ b/librz/include/rz_util/rz_log.h
@@ -31,7 +31,7 @@ typedef void (*RzLogCallback)(const char *output, const char *funcname, const ch
 	ut32 lineno, RzLogLevel level, const char *tag, const char *fmtstr, ...) RZ_PRINTF_CHECK(7, 8);
 
 #define RZ_VLOG(lvl, tag, fmtstr, args) rz_vlog(MACRO_LOG_FUNC, __FILE__, \
-	__LINE__, lvl, tag, fmtstr, args);
+	__LINE__, lvl, tag, NULL, fmtstr, args);
 
 #define RZ_LOG(lvl, tag, fmtstr, ...) rz_log(MACRO_LOG_FUNC, __FILE__, \
 	__LINE__, lvl, tag, fmtstr, ##__VA_ARGS__);
@@ -78,7 +78,8 @@ RZ_API void rz_log(const char *funcname, const char *filename,
 	ut32 lineno, RzLogLevel level, const char *tag, const char *fmtstr, ...) RZ_PRINTF_CHECK(6, 7);
 
 RZ_API void rz_vlog(const char *funcname, const char *filename,
-	ut32 lineno, RzLogLevel level, const char *tag, const char *fmtstr, va_list args);
+	ut32 lineno, RzLogLevel level, const char *tag, RZ_OWN RZ_NULLABLE const char **out,
+	const char *fmtstr, va_list args);
 
 RZ_API void rz_log_str(const char *funcname, const char *filename,
 	ut32 lineno, RzLogLevel level, const char *tag, const char *msg);

--- a/librz/util/log.c
+++ b/librz/util/log.c
@@ -191,7 +191,8 @@ RZ_API void rz_log_del_callback(RZ_NULLABLE RzLogCallback cbfunc) {
 #endif /* RZ_BUILD_DEBUG */
 
 RZ_API void rz_vlog(const char *funcname, const char *filename,
-	ut32 lineno, RzLogLevel level, const char *tag, const char *fmtstr, va_list args) {
+	ut32 lineno, RzLogLevel level, const char *tag, RZ_OWN RZ_NULLABLE const char **out,
+	const char *fmtstr, va_list args) {
 	log_init();
 
 	if (is_log_quiet(level)) {
@@ -212,7 +213,9 @@ RZ_API void rz_vlog(const char *funcname, const char *filename,
 		tag = RZ_BETWEEN(0, level, (RZ_LOGLVL_SIZE - 1)) ? logcfg.tags[level] : "";
 	}
 	rz_strbuf_append(&sb, tag);
-	rz_strbuf_append(&sb, ": ");
+	if (*tag) {
+		rz_strbuf_append(&sb, ": ");
+	}
 	if (logcfg.show_sources) {
 		rz_strbuf_appendf(&sb, "%s in %s:%i: ", funcname, filename, lineno);
 	}
@@ -222,7 +225,9 @@ RZ_API void rz_vlog(const char *funcname, const char *filename,
 
 	// critical section
 	rz_th_lock_enter(logcfg.lock);
-	if (rz_list_length(logcfg.callbacks) > 0) {
+	if (out) {
+		*out = strdup(output_buf);
+	} else if (rz_list_length(logcfg.callbacks) > 0) {
 		// Print the log using the callbacks
 		RzListIter *it;
 		RzLogCallback cb;
@@ -270,7 +275,7 @@ RZ_API void rz_log(const char *funcname, const char *filename,
 	va_list args;
 
 	va_start(args, fmtstr);
-	rz_vlog(funcname, filename, lineno, level, tag, fmtstr, args);
+	rz_vlog(funcname, filename, lineno, level, tag, NULL, fmtstr, args);
 	va_end(args);
 }
 

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -1389,9 +1389,6 @@ echo
 w ¢€𐍈 @ 0x40
 w ¢€𐍈a @ 0x50
 /z ¢€𐍈
-e log.show.sources=1
-/z ¢€𐍈
-e log.show.sources=0
 echo ----
 /z ¢€𐍈 @e:search.str.min_length=3
 EOF
@@ -1405,8 +1402,6 @@ WARNING: |ab| < search.str.min_length so some search hits may be hidden. Set sea
 
 0x00000050 9 hit.string.utf8.0
 WARNING: |¢€𐍈| < search.str.min_length so some search hits may be hidden. Set search.str.min_length to 3 to see them.
-0x00000050 9 hit.string.utf8.0
-WARNING: rz_core_print_warnings_after in ../librz/core/core.c:167: cmd_string_search_generic in ../librz/core/cmd/cmd_search.c:2785: |¢€𐍈| < search.str.min_length so some search hits may be hidden. Set search.str.min_length to 3 to see them.
 ----
 0x00000040 9 hit.string.utf8.0
 0x00000050 9 hit.string.utf8.1

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -1389,6 +1389,9 @@ echo
 w ¢€𐍈 @ 0x40
 w ¢€𐍈a @ 0x50
 /z ¢€𐍈
+e log.show.sources=1
+/z ¢€𐍈
+e log.show.sources=0
 echo ----
 /z ¢€𐍈 @e:search.str.min_length=3
 EOF
@@ -1402,6 +1405,8 @@ WARNING: |ab| < search.str.min_length so some search hits may be hidden. Set sea
 
 0x00000050 9 hit.string.utf8.0
 WARNING: |¢€𐍈| < search.str.min_length so some search hits may be hidden. Set search.str.min_length to 3 to see them.
+0x00000050 9 hit.string.utf8.0
+WARNING: rz_core_print_warnings_after in ../librz/core/core.c:167: cmd_string_search_generic in ../librz/core/cmd/cmd_search.c:2785: |¢€𐍈| < search.str.min_length so some search hits may be hidden. Set search.str.min_length to 3 to see them.
 ----
 0x00000040 9 hit.string.utf8.0
 0x00000050 9 hit.string.utf8.1


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Continuing on from https://github.com/rizinorg/rizin/pull/5094#issuecomment-2832115449, this pr replaces the `rz_core_warn_after_output()` function call in #5094 with a `RZ_LOG_WARN_AFTER()` macro call. It also integrates #5094 better into the existing log infrastructure.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The changes make sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
