### PR TITLE
Remove `dc` from archos/netbsd-x64/dbg maps test

### DIFF
--- a/test/db/archos/netbsd-x64/dbg
+++ b/test/db/archos/netbsd-x64/dbg
@@ -19,10 +19,7 @@ RUN
 NAME=maps
 FILE=bins/elf/netbsd-hello-x64
 ARGS=-d
-CMDS=<<EOF
-dm~hello~[3-9]
-dc
-EOF
+CMDS=dm~hello~[3-9]
 REGEXP_FILTER_OUT=(?:(\-\susr\s4K\ss\sr-x)|(?:\s[0-9]+\s(?=\d))|(\/home\/build\/rizin-testbins\/elf\/netbsd-hello-x64))
 EXPECT=<<EOF
 - usr 4K s r-x


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr just removes `dc` from the `archos/netbsd-x64/dbg` "maps" test since its output is no longer being checked.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
