### PR TITLE
docker: update to Debian 11 (Bullseye)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@
 # $ rizin -d /bin/true
 #
 
-FROM debian:10
+FROM debian:11
 
 # rz-pipe python version
 ARG RZ_PIPE_PY_VERSION=master
@@ -85,7 +85,7 @@ RUN git clone --recurse-submodules -b "$RZ_GHIDRA_VERSION" https://github.com/ri
 WORKDIR /tmp/rz-ghidra
 RUN cmake -DCMAKE_PREFIX_PATH=/tmp/rizin-install/usr -DCMAKE_INSTALL_PREFIX=/usr -B build && cmake --build build && DESTDIR=/tmp/rizin-install cmake --build build --target install
 
-FROM debian:10
+FROM debian:11
 ENV RZ_ARM64_AS=${with_arm64_as:+aarch64-linux-gnu-as}
 ENV RZ_ARM32_AS=${with_arm32_as:+arm-linux-gnueabi-as}
 ENV RZ_PPC_AS=${with_ppc_as:+powerpc64le-linux-gnu-as}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

To solve the following error:
```
 > [linux/amd64 stage-0  3/15] RUN apt-get update:
0.237 Err:4 http://deb.debian.org/debian buster Release
0.237   404  Not Found [IP: 151.101.162.132 80]
0.253 Err:5 http://deb.debian.org/debian-security buster/updates Release
0.253   404  Not Found [IP: 151.101.162.132 80]
0.268 Err:6 http://deb.debian.org/debian buster-updates Release
0.268   404  Not Found [IP: 151.101.162.132 80]
0.274 Reading package lists...
0.290 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
0.290 E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
0.290 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
```

See also https://endoflife.date/debian

**Test plan**

CI is green