### PR TITLE
Add horizontal histogram ruler

### DIFF
--- a/librz/cons/histogram.c
+++ b/librz/cons/histogram.c
@@ -51,6 +51,7 @@ RZ_API RZ_OWN RzStrBuf *rz_histogram_horizontal(RZ_NONNULL RzHistogramOptions *o
 		for (i = 0; i < rows; i++) {
 			size_t threshold = i * (0xff / rows);
 			size_t koli = i * 5 / rows;
+			rz_strbuf_appendf(buf, " %3zu%s", (255 - threshold), vline);
 			for (j = 0; j < cols; j++) {
 				int realJ = j * width / cols;
 				if (255 - data[realJ] < threshold || (i + 1 == rows)) {
@@ -70,6 +71,7 @@ RZ_API RZ_OWN RzStrBuf *rz_histogram_horizontal(RZ_NONNULL RzHistogramOptions *o
 
 	for (i = 0; i < rows; i++) {
 		size_t threshold = i * (0xff / rows);
+		rz_strbuf_appendf(buf, " %3zu%s", (255 - threshold), vline);
 		for (j = 0; j < cols; j++) {
 			size_t realJ = j * width / cols;
 			if (255 - data[realJ] < threshold) {

--- a/librz/cons/histogram.c
+++ b/librz/cons/histogram.c
@@ -8,7 +8,7 @@
 #define ZOOM_DEFAULT  1
 
 /**
- * \brief Create the string buffer with the horisontal histogram
+ * \brief Create the string buffer with the horizontal histogram
  *
  *		 █    ██      █             █                                        █
  *		 █    ██      █             █                                       ██
@@ -51,7 +51,9 @@ RZ_API RZ_OWN RzStrBuf *rz_histogram_horizontal(RZ_NONNULL RzHistogramOptions *o
 		for (i = 0; i < rows; i++) {
 			size_t threshold = i * (0xff / rows);
 			size_t koli = i * 5 / rows;
-			rz_strbuf_appendf(buf, " %3zu%s", (255 - threshold), vline);
+			if (opts->ruler) {
+				rz_strbuf_appendf(buf, " %3zu%s", (255 - threshold), vline);
+			}
 			for (j = 0; j < cols; j++) {
 				int realJ = j * width / cols;
 				if (255 - data[realJ] < threshold || (i + 1 == rows)) {
@@ -71,7 +73,9 @@ RZ_API RZ_OWN RzStrBuf *rz_histogram_horizontal(RZ_NONNULL RzHistogramOptions *o
 
 	for (i = 0; i < rows; i++) {
 		size_t threshold = i * (0xff / rows);
-		rz_strbuf_appendf(buf, " %3zu%s", (255 - threshold), vline);
+		if (opts->ruler) {
+			rz_strbuf_appendf(buf, " %3zu%s", (255 - threshold), vline);
+		}
 		for (j = 0; j < cols; j++) {
 			size_t realJ = j * width / cols;
 			if (255 - data[realJ] < threshold) {
@@ -267,7 +271,7 @@ RZ_API void rz_histogram_interactive_zoom_out(RzHistogramInteractive *hist) {
 }
 
 /**
- * \brief Create the string buffer with the horisontal histogram
+ * \brief Create the string buffer with the horizontal histogram
  *
  *		 █    ██      █             █                                        █
  *		 █    ██      █             █                                       ██

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3762,6 +3762,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETBPREF("scr.prompt.flag.only", "false", "Show the flag name only in the prompt");
 	SETBPREF("scr.prompt.sect", "false", "Show section name in the prompt");
 	SETCB("scr.hist.block", "true", &cb_scr_histblock, "Use blocks for histogram");
+	SETBPREF("scr.hist.ruler", "true", "Show histogram ruler");
 	SETCB("scr.prompt", "true", &cb_scrprompt, "Show user prompt (used by rizin -q)");
 	SETCB("scr.tee", "", &cb_teefile, "Pipe output to file of this name");
 	SETPREF("scr.seek", "", "Seek to the specified address on startup");

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -5178,6 +5178,7 @@ static bool print_histogram(RzCore *core, RZ_NULLABLE RzHistogramOptions *opts, 
 		RzHistogramOptions default_opts = {
 			.unicode = rz_config_get_b(core->config, "scr.utf8"),
 			.thinline = !rz_config_get_b(core->config, "scr.hist.block"),
+			.ruler = rz_config_get_b(core->config, "scr.hist.ruler"),
 			.legend = false,
 			.offset = rz_config_get_b(core->config, "hex.offset"),
 			.offpos = offset,

--- a/librz/include/rz_cons.h
+++ b/librz/include/rz_cons.h
@@ -829,6 +829,7 @@ typedef struct rz_cons_canvas_line_style_t {
 typedef struct rz_histogram_options_t {
 	bool unicode; //<< Use Unicode characters instead of ASCII
 	bool thinline; //<< Use thin lines instead of block lines
+	bool ruler; //<< Show ruler
 	bool legend; //<< Show axes and legend
 	bool offset; //<< Show offsets
 	ut64 offpos; //<< Starting offset value


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [X] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

This PR is based on #4776. It enables by default a vertical ruler for the `p==` command. As indicated in #4776, the ruler is placed on the left side of the histogram, and can be disabled by setting `src.hist.ruler` to `false`.
P.S. This is my first contribution. :smile: 

**Test plan**

The commands used for testing were the following:

```
$ rinzin /usr/bin/ls
```

After that, we show the histogram:

```
p==
```
<img width="1708" height="1300" alt="image" src="https://github.com/user-attachments/assets/c439d691-19e4-4b3d-8f42-48010becb65f" />

Then we disable the ruler, and print again the histogram:

```
e scr.hist.ruler=false
p==
```
<img width="1708" height="1300" alt="image" src="https://github.com/user-attachments/assets/8ff4cbbc-3010-4e12-9fb2-5fc1a6d64d77" />

If `scr.utf8` is disabled, the ruler will show the non UTF-8 char assigned by `vline`.
<img width="1708" height="1300" alt="image" src="https://github.com/user-attachments/assets/e44b5b21-7dac-47c7-a114-52905d27ebe3" />

Please let me know if this requires further changes, or if any modifications are suggested.  Also, any guidance on the horizontal ruler (`p=`) would be appreciated. :smile: 

**Closing issues**

Addresses #129 