### PR TITLE
doc/fortunes: fix incorrect syntax of command layout

### DIFF
--- a/doc/fortunes.tips
+++ b/doc/fortunes.tips
@@ -16,7 +16,7 @@ Use +,-,*,/ to change the size of the block
 Change the block size with 'b <block-size>'. In visual mode you can also enter rizin command pressing the ':' key (like vi does)
 If you want to open the file in read-write mode, invoke rizin with '-w'
 Print the contents of the current block with the 'p' command
-Command layout is: <repeat><command><bytes>@<offset>.  For example: 3x20@0x33 will show 3 hexdumps of 20 bytes at 0x33
+Command layout is: '<repeat><command> <bytes> @ <offset>'.  For example: '3x 20 @ 0x33' will show 3 hexdumps of 20 bytes at 0x33
 Press 'c' in visual mode to toggle the cursor mode
 Press 'C' in visual mode to toggle colors
 You can 'copy/paste' bytes using the cursor in visual mode 'c' and using the 'y' and 'Y' keys


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This PR fixes the syntax of the command layout fortune, which presents the format as having no spaces, even though Rizin doesn't support that

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The following is an excerpt from my session demonstrating the correct and incorrect syntax, as presented in the fortune:

```
[0x00000000]> 3x 20 @ 0x33
- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0x00000033  ffff ffff ffff ffff ffff ffff ffff ffff  ................
[...]
[0x00000000]> 3x20@0x50
ERROR: core: Error while parsing command: `3x20@0x50`
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None
