### PR TITLE
doc/fortunes: fix incorrect hash calculation command

### DIFF
--- a/doc/fortunes.tips
+++ b/doc/fortunes.tips
@@ -11,7 +11,7 @@ Enable asm.trace to see the tracing information inside the disassembly
 Change the registers of the child process in this way: 'dr eax=0x333'
 Check your IO plugins with 'rizin -L'
 Change the size of the file with the 'r' (resize) command
-Calculate checksums for the current block with the commands starting with '#' (#md5, #crc32, #all, ..)
+Calculate checksums for the current block with the commands starting with 'ph' ('ph md5', 'ph crc32', ..)
 Use +,-,*,/ to change the size of the block
 Change the block size with 'b <block-size>'. In visual mode you can also enter rizin command pressing the ':' key (like vi does)
 If you want to open the file in read-write mode, invoke rizin with '-w'


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The current hash calculation command suggested in the fortune does not have any affect (is treated as a comment), probably some kind of legacy. This corrects the command to `ph`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
