### PR TITLE
librz/util/subprocess: fix inability run .com exes without extension

### DIFF
--- a/librz/util/subprocess.c
+++ b/librz/util/subprocess.c
@@ -262,7 +262,6 @@ RZ_API RZ_OWN RzSubprocess *rz_subprocess_start_opt(RZ_NONNULL const RzSubproces
 	HANDLE stdin_read = curr_stdin_handle;
 	HANDLE stdout_write = curr_stdout_handle;
 	HANDLE stderr_write = curr_stderr_handle;
-	LPWSTR lpFilePart;
 	PWCHAR cmd_exe = RZ_NEWS0(WCHAR, MAX_PATH);
 #if NTDDI_VERSION >= NTDDI_VISTA
 	LPPROC_THREAD_ATTRIBUTE_LIST attr_list = NULL;
@@ -276,10 +275,12 @@ RZ_API RZ_OWN RzSubprocess *rz_subprocess_start_opt(RZ_NONNULL const RzSubproces
 
 	if (!rz_file_exists(opt->file)) {
 		DWORD len;
-		if ((len = SearchPathW(NULL, file, L".exe", MAX_PATH, cmd_exe, &lpFilePart)) < 1) {
-			RZ_LOG_DEBUG("SearchPath failed for %s\n", opt->file);
-			free(file);
-			return NULL;
+		if ((len = SearchPathW(NULL, file, L".exe", MAX_PATH, cmd_exe, NULL)) < 1) {
+			if ((len = SearchPathW(NULL, file, L".com", MAX_PATH, cmd_exe, NULL)) < 1) {
+				RZ_LOG_DEBUG("SearchPath failed for %s\n", opt->file);
+				free(file);
+				return NULL;
+			}
 		}
 		if (len > MAX_PATH) {
 			PWCHAR tmp = realloc(cmd_exe, sizeof(WCHAR) * len);
@@ -289,7 +290,7 @@ RZ_API RZ_OWN RzSubprocess *rz_subprocess_start_opt(RZ_NONNULL const RzSubproces
 				return NULL;
 			}
 			cmd_exe = tmp;
-			SearchPathW(NULL, file, L".exe", len, cmd_exe, &lpFilePart);
+			SearchPathW(NULL, file, L".exe", len, cmd_exe, NULL);
 		}
 		free(file);
 	} else {


### PR DESCRIPTION
…ables

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

When piping Rizin command output on Windows, using `more` is convenient, however Rizin only tries appending `.exe` automatically and Windows uses the `.com` extension for the `more` program. Hence the following error is encountered when running for example `? | more`:
```
[0x00000000]> ? | more
ERROR: Cannot start subprocess.
```

The way to solve it currently is to run explicitly `more.com`:
```
[0x00000000]> ? | more.com
Usage: [.][times][cmd][~grep][@[@iter]addr][|>pipe] ; ...
[...]
```

This PR solves this issue by also trying to append the `.com` extension, and not giving up after trying `.exe`.

Also, I did a minor refactor, passing NULL in the last argument of `SearchPathW` instead of the variable, since it was not used in the code, and according to the Win32 docs, it is an optional parameter, ref: https://learn.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-searchpathw

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Explained above

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None
