### PR TITLE
librz/main/rz-ax: fix bug of stdin mode unworking

### DIFF
--- a/librz/main/rz-ax.c
+++ b/librz/main/rz-ax.c
@@ -747,10 +747,10 @@ dotherax:
 RZ_API int rz_main_rz_ax(int argc, const char **argv) {
 	int i, fm = 0;
 	RzNum *num = rz_num_new(NULL, NULL, NULL);
+	ut64 flags = 0;
 	if (argc == 1) {
-		use_stdin(num, 0, &fm);
+		use_stdin(num, &flags, &fm);
 	} else {
-		ut64 flags = 0;
 		for (i = 1; i < argc; i++) {
 			char *argv_i = rz_str_dup(argv[i]);
 			rz_str_unescape(argv_i);

--- a/test/db/tools/rz_ax
+++ b/test/db/tools/rz_ax
@@ -579,3 +579,11 @@ EXPECT=<<EOF
 [5-6]: 1
 EOF
 RUN
+
+NAME=rz-ax stdin input
+FILE==
+CMDS=!echo 0xff | rz-ax
+EXPECT=<<EOF
+255
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This PR fixes a bug in which when launching `rz-ax` with no arguments returns immediately while the expected behavior is that it enters CLI mode as described in the book, ref: https://book.rizin.re/src/introduction/overview.html#rz-ax

The reason this happens is that 0 is passed for the flags pointer which causes the function responsible to return immediately to avoid dereferencing zero. This seems to be a mistake, while the intention was to pass a pointer to a `flags = 0` variable.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Run `rz-ax` with no args.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None
