### PR TITLE
Add missing quote marks to `rizin -h`

### DIFF
--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -95,7 +95,7 @@ static int main_help(RZ_BORROW RZ_NONNULL RzCore *core, int line) {
 		const char *options[] = {
 			// clang-format off
 			"--",          "",          "Run rizin without opening any file",
-			"=",           "",          "Same as 'rizin malloc://512",
+			"=",           "",          "Same as 'rizin malloc://512'",
 			"- ",          "",          "Read file from stdin",
 			"-=",          "",          "Perform R=! command to run all commands remotely",
 			"-0",          "",          "Print \\x00 after init and every command",
@@ -107,7 +107,7 @@ static int main_help(RZ_BORROW RZ_NONNULL RzCore *core, int line) {
 			"-B",          "baddr",     "Set base address for PIE binaries",
 			"-c",          "'cmd..'",   "Execute rizin command",
 			"-C",          "",          "File is host:port (alias for -cR+http://%%s/cmd/)",
-			"-d",          "",          "Debug the executable 'file' or running process 'pid",
+			"-d",          "",          "Debug the executable 'file' or running process 'pid'",
 			"-D",          "backend",   "Enable debug mode (e cfg.debug=true)",
 			"-e",          "k=v",       "Evaluate config var",
 			"-f",          "",          "Block size = file size",


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [X] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed). rizinorg/book#143

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr adds a couple of missing single quotation marks to `rizin -h`. This is probably the reason why the `rizin -h` output in https://book.rizin.re/src/first_steps/commandline_options.html has inconsistent syntax coloring.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
