### PR TITLE
Back up and reset flag space on RzBinObject switching.

### DIFF
--- a/librz/core/cmd/cmd_open.c
+++ b/librz/core/cmd/cmd_open.c
@@ -791,8 +791,18 @@ RZ_IPI RzCmdStatus rz_open_binary_select_handler(RzCore *core, int argc, const c
 				return RZ_CMD_STATUS_ERROR;
 			}
 			if (xtr_selection_matches(selection, xtr_data->metadata)) {
+				// Backup and reset flag spaces with object flags (sections and such).
+				char bak_file[128] = { 0 };
+				rz_strf(bak_file, "flags.%s.sdb", argv[1]);
+				if (!rz_flag_reset_obj_flags(core->flags, bak_file)) {
+					RZ_LOG_ERROR("Failed to backup and reset flag spaces. Refusing to switch object.\n");
+					return RZ_CMD_STATUS_ERROR;
+				}
+				rz_cons_printf("Backed up flag space into '%s'. You can restore the flags with the 'ko' command.\n", bak_file);
+
 				bits = xtr_data->metadata->bits;
 				const char *mach = rz_list_length(selection) > 2 ? rz_list_get_n(selection, 2) : NULL;
+
 				if (!rz_bin_select(bin, rz_list_get_n(selection, 0), bits, mach, NULL)) {
 					rz_list_free(selection);
 					return RZ_CMD_STATUS_ERROR;

--- a/librz/flag/flag.c
+++ b/librz/flag/flag.c
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2007-2020 ret2libc <sirmy15@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
+#include <sdb.h>
 #include <rz_flag.h>
 #include <rz_util.h>
 #include <rz_cons.h>
@@ -305,6 +306,52 @@ RZ_API RzFlagItem *rz_flag_get(RzFlag *f, const char *name) {
 	rz_return_val_if_fail(f, NULL);
 	RzFlagItem *r = ht_sp_find(f->ht_name, name, NULL);
 	return r ? evalFlag(f, r) : NULL;
+}
+
+/**
+ * \brief Resets all flag spaces associated with object files.
+ * These are:
+ * - classes
+ * - imports
+ * - relocs
+ * - sections
+ * - segments
+ * - strings
+ * - symbols
+ * - globals
+ * - maps
+ *
+ * \param flags The RzFlag instance to use.
+ * \param backup_filename If not NULL, the RzFlag instance will
+ * be backed up into the file before the reset.
+ *
+ * \return True on success, false othewise.
+ */
+RZ_API bool rz_flag_reset_obj_flags(RZ_NONNULL RZ_BORROW RzFlag *flags, RZ_NULLABLE const char *backup_filename) {
+	rz_return_val_if_fail(flags, false);
+	bool backup_succeeded = !backup_filename;
+	if (backup_filename) {
+		Sdb *sdb = sdb_new0();
+		if (!sdb) {
+			return false;
+		}
+		rz_serialize_flag_save(sdb, flags);
+		backup_succeeded = sdb_text_save(sdb, backup_filename, false);
+	}
+	if (!backup_succeeded) {
+		RZ_LOG_WARN("Could not backup RzFlag before resetting flag space. Abort flag space reset.\n");
+		return false;
+	}
+	rz_flag_unset_all_in_space(flags, "classes");
+	rz_flag_unset_all_in_space(flags, "imports");
+	rz_flag_unset_all_in_space(flags, "relocs");
+	rz_flag_unset_all_in_space(flags, "sections");
+	rz_flag_unset_all_in_space(flags, "segments");
+	rz_flag_unset_all_in_space(flags, "strings");
+	rz_flag_unset_all_in_space(flags, "symbols");
+	rz_flag_unset_all_in_space(flags, "globals");
+	rz_flag_unset_all_in_space(flags, "maps");
+	return true;
 }
 
 /* return the first flag item that can be found at offset "off", or NULL otherwise */

--- a/librz/include/rz_flag.h
+++ b/librz/include/rz_flag.h
@@ -105,6 +105,7 @@ RZ_API RzFlagItem *rz_flag_get_at(RzFlag *f, ut64 off, bool closest);
 RZ_API RZ_BORROW RzFlagItem *rz_flag_get_at_by_spaces(RZ_NONNULL RzFlag *f, bool closest, ut64 off, ...);
 RZ_API RzList /*<RzFlagItem *>*/ *rz_flag_all_list(RzFlag *f, bool by_space);
 RZ_API const RzList /*<RzFlagItem *>*/ *rz_flag_get_list(RzFlag *f, ut64 off);
+RZ_API bool rz_flag_reset_obj_flags(RZ_NONNULL RZ_BORROW RzFlag *flags, RZ_NULLABLE const char *backup_filename);
 RZ_API char *rz_flag_get_liststr(RzFlag *f, ut64 off);
 RZ_API bool rz_flag_unset(RzFlag *f, RzFlagItem *item);
 RZ_API bool rz_flag_unset_name(RzFlag *f, const char *name);

--- a/test/db/cmd/cmd_open
+++ b/test/db/cmd/cmd_open
@@ -781,6 +781,7 @@ true
             0x000049da      addq.l 0x1, d0
             0x000049dc      asl.l 0x2, d0
             0x000049de      adda.l d0, a0
+Backed up flag space into 'flags.hppa_32_hppa7100.sdb'. You can restore the flags with the 'ko' command.
 hppa
 hppa7100
 32
@@ -796,6 +797,7 @@ true
             0x00003a04      stw   r4,-7c(sp)
             0x00003a08      stw   r3,-78(sp)
             0x00003a0c      copy  r26,r4
+Backed up flag space into 'flags.sparc_32_all.sdb'. You can restore the flags with the 'ko' command.
 sparc
 all
 32
@@ -811,6 +813,7 @@ true
             0x00004438      sethi 0x20, o2
             0x0000443c      st    o1, [o2+8]
             0x00004440      ld    [i0+0x40], o0
+Backed up flag space into 'flags.x86_32_386.sdb'. You can restore the flags with the 'ko' command.
 x86
 386
 32
@@ -826,6 +829,7 @@ false
             0x00002a2f      mov   dword [0x6004], edx
             0x00002a35      lea   eax, dword [esi+0x04]
             0x00002a38      mov   dword [0x6008], eax
+Backed up flag space into 'flags.m68k_32_mc68030.sdb'. You can restore the flags with the 'ko' command.
 m68k
 mc68030
 32
@@ -852,10 +856,6 @@ NAME=Switch between same archs, with different bits and machine
 FILE=bins/mach0/AppIOSEntitlements.ios
 CMDS=<<EOF
 obs
-echo "# default"
-e asm.arch
-e asm.bits
-e asm.cpu
 
 obs arm_64_all
 echo "# arm_64_all"
@@ -872,14 +872,12 @@ EOF
 EXPECT=<<EOF
 arm_32_v7
 arm_64_all
-# default
-arm
-32
-v7
+Backed up flag space into 'flags.arm_64_all.sdb'. You can restore the flags with the 'ko' command.
 # arm_64_all
 arm
 64
 all
+Backed up flag space into 'flags.arm_32_v7.sdb'. You can restore the flags with the 'ko' command.
 # arm_32_v7
 arm
 32

--- a/test/db/formats/mach0/imports
+++ b/test/db/formats/mach0/imports
@@ -116,11 +116,12 @@ CMDS=<<EOF
 obs arm_64_arm64e
 ii
 ir
-pxr 0x10 @ section.15.__DATA.__objc_classrefs
-pD 0x10 @ section.15.__DATA.__objc_classrefs
+pxr 0x10 @ section.13.__DATA.__objc_classrefs
+pD 0x10 @ section.13.__DATA.__objc_classrefs
 ic
 EOF
 EXPECT=<<EOF
+Backed up flag space into 'flags.arm_64_arm64e.sdb'. You can restore the flags with the 'ko' command.
 nth       vaddr bind type           lib name                     
 -----------------------------------------------------------------
   0  ---------- NONE OBJC_CLASS         NSString
@@ -157,14 +158,12 @@ nth       vaddr bind type           lib name
 0x100008108 0x00008108 0x100010048 SET_64 NSObject
 0x100008110 0x00008110 0x100010040 SET_64 _objc_empty_cache
 0x100008120 0x00008120  0x00000000 SET_64 
-0x1000080e0 0x0000000100010038   8....... @ reloc.NSObject.1000080e0 4295032888 NSObject R 0x0
-0x1000080e8 0x0000000100010040   @....... @ reloc._objc_empty_cache.1000080e8 4295032896 _objc_empty_cache R 0x0
-            ;-- section.15.__DATA.__objc_classrefs:
-            ;-- NSObject:
-            0x1000080e0      .qword 0x0000000100010038 ; reloc.target.NSObject; RELOC 64 NSObject ; [15] -rw- section size 16 named 15.__DATA.__objc_classrefs
+0x1000080c0 0x0000000100008100   ........ @ section.13.__DATA.__objc_classrefs 4295000320 15.__DATA.__objc_data class Stub R 0x1000080d8
+0x1000080c8 0x0000000100010030   0....... @ reloc.NSString 4295032880 NSString R 0x0
+            ;-- section.13.__DATA.__objc_classrefs:
+            0x1000080c0      .qword 0x0000000100008100 ; sym.class_Stub; RELOC 64  ; [13] -rw- section size 16 named 13.__DATA.__objc_classrefs
             ;-- NSString:
-            ;-- _objc_empty_cache:
-            0x1000080e8      .qword 0x0000000100010040 ; reloc.target._objc_empty_cache; RELOC 64 _objc_empty_cache
+            0x1000080c8      .qword 0x0000000100010030 ; reloc.target.NSString; RELOC 64 NSString
     address         min         max name super    
 --------------------------------------------------
 0x1000080d8 0x1000080d8 0x1000080d8 Stub NSObject
@@ -174,6 +173,7 @@ RUN
 NAME=mach0 arm64e chained imports
 FILE=bins/mach0/imports-arm64e-chained
 CMDS=<<EOF
+obs arm_64_arm64e
 ii
 pd 3 @ 0x100003f48
 ir
@@ -182,21 +182,22 @@ pD 0x10 @ section.13.__DATA.__objc_classrefs
 ic
 EOF
 EXPECT=<<EOF
+Backed up flag space into 'flags.arm_64_arm64e.sdb'. You can restore the flags with the 'ko' command.
 nth       vaddr bind type           lib name                     
 -----------------------------------------------------------------
-  0 0x100003f30 NONE FUNC               objc_alloc
-  1 0x100003f3c NONE FUNC               objc_alloc_init
-  2 0x100003f48 NONE FUNC               objc_autoreleasePoolPop
-  3 0x100003f54 NONE FUNC               objc_autoreleasePoolPush
+  0 0x100003f20 NONE FUNC               objc_alloc
+  1 0x100003f30 NONE FUNC               objc_alloc_init
+  2 0x100003f40 NONE FUNC               objc_autoreleasePoolPop
+  3 0x100003f50 NONE FUNC               objc_autoreleasePoolPush
   4  ---------- NONE FUNC               objc_msgSend
   5  ---------- NONE OBJC_CLASS         NSString
   6  ---------- NONE FUNC               _objc_empty_cache
   7  ---------- NONE OBJC_METACLASS     NSObject
   8  ---------- NONE OBJC_CLASS         NSObject
-            ;-- objc_autoreleasePoolPop:
-            0x100003f48      adrp  x16, reloc.objc_alloc               ; 0x100004000
-            0x100003f4c      ldr   x16, [x16, 0x10]                    ; [0x10:4]=0x400000
-            0x100003f50      br    x16
+            0x100003f48      ldr   x16, [x17]
+            0x100003f4c      braa  x16, x17
+            ;-- objc_autoreleasePoolPush:
+            0x100003f50      adrp  x17, reloc.objc_alloc               ; 0x100004000
       vaddr      paddr      target type   name                     
 -------------------------------------------------------------------
 0x100004000 0x00004000 0x100010008 SET_64 objc_alloc


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

On changing the object file with `obs` the flags were not reset. So after switching the object the flags of the old object were still there.

This broke tests on AArch64 platforms which selected a different object by default from a fat binary. I don't really know how the flags got applied or not, but it lead to the tests failing because some flags were not there.

In any case, the flags are now partly reset and the old ones backed up. So no user flags are deleted by accident.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All green (succeeds on AArch64 machines).

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
