### PR TITLE
Use `--merge-mode-functions=separate` for gcovr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
         if: matrix.coverage && matrix.enabled
         run: |
           gcovr --version
-          gcovr --gcov-ignore-parse-errors=all --txt build/coverage.txt --cobertura build/coverage.xml --merge-mode-functions=MERGE_MODE build
+          gcovr --gcov-ignore-parse-errors=all --txt build/coverage.txt --cobertura build/coverage.xml --merge-mode-functions=separate build
       - name: Upload coverage to Codecov
         if: matrix.coverage && matrix.enabled
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Regarding codecov/codecov-action#1877, PCRE2 10.46 has indeed 2 versions of `do_utfreadchar_invalid()` at lines [4754](https://github.com/PCRE2Project/pcre2/blob/release/pcre2-10.46/src/pcre2_jit_compile.c#L4754) and [5273](https://github.com/PCRE2Project/pcre2/blob/release/pcre2-10.46/src/pcre2_jit_compile.c#L5273) of [src/pcre2_jit_compile.c](https://github.com/PCRE2Project/pcre2/blob/release/pcre2-10.46/src/pcre2_jit_compile.c). Both functions are `static` though. Since they are different functions with different code, the pr proposes `--merge-mode-functions=separate` for gcovr for no loss of information.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. The Codecov build is green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
