### PR TITLE
Revert `-Wno-error` cancel flag

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -335,7 +335,7 @@ if r.returncode() == 1 and get_option('subprojects_check')
   error(subproject_clean_error_msg)
 endif
 
-rizin_grammar_c_proj = subproject('rizin-grammar-c', default_options: ['default_library=static'])
+rizin_grammar_c_proj = subproject('rizin-grammar-c', default_options: ['default_library=static', 'werror=false'])
 rizin_grammar_c_dep = rizin_grammar_c_proj.get_variable('rizin_grammar_c_dep')
 # override done in rizin-grammar-c subproject
 

--- a/subprojects/packagefiles/libzip-1.11.3/meson.build
+++ b/subprojects/packagefiles/libzip-1.11.3/meson.build
@@ -3,9 +3,6 @@ project('libzip', 'c',
   license: 'BSD-3-clause',
   meson_version: '>=0.55.0',
 )
-if host_machine.system() != 'windows'
-  add_project_arguments('-Wno-error', language: ['c'])
-endif
 
 py3_exe = import('python').find_installation()
 cc = meson.get_compiler('c')

--- a/subprojects/packagefiles/rizin-grammar-c/meson.build
+++ b/subprojects/packagefiles/rizin-grammar-c/meson.build
@@ -2,9 +2,6 @@ project('rizin-grammar-c', 'c',
   license: 'MIT',
   meson_version: '>=0.55.0',
 )
-if host_machine.system() != 'windows'
-  add_project_arguments('-Wno-error', language: ['c'])
-endif
 
 cc = meson.get_compiler('c')
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr reverts the addition of the `-Wno-error` flag (which was cancelling a `-Werror` flag) that was done in #5327 since the addition is no longer needed with Meson 1.9.1.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
