### PR TITLE
rz_vector_insert_range: If count is 0, bypass rz_vector_index_ptr() in returning insert addr

### DIFF
--- a/librz/include/rz_vector.h
+++ b/librz/include/rz_vector.h
@@ -142,7 +142,7 @@ RZ_API void rz_vector_remove_range(RzVector *vec, size_t index, size_t count, vo
 RZ_API void *rz_vector_insert(RzVector *vec, size_t index, void *x);
 
 // insert count values of size vec->elem_size into vec starting at the given index.
-RZ_API void *rz_vector_insert_range(RzVector *vec, size_t index, void *first, size_t count);
+RZ_API void *rz_vector_insert_range(RzVector *vec, size_t index, RZ_NULLABLE void *first, size_t count);
 
 // like rz_vector_remove_at for the last element
 RZ_API void rz_vector_pop(RzVector *vec, void *into);

--- a/librz/util/vector.c
+++ b/librz/util/vector.c
@@ -226,6 +226,9 @@ RZ_API void *rz_vector_insert(RzVector *vec, size_t index, void *x) {
 
 RZ_API void *rz_vector_insert_range(RzVector *vec, size_t index, void *first, size_t count) {
 	rz_return_val_if_fail(vec && index <= vec->len, NULL);
+	if (count == 0) {
+		return (char *)vec->a + vec->elem_size * index;
+	}
 	if (vec->len + count > vec->capacity) {
 		RESIZE_OR_RETURN_NULL(RZ_MAX(NEXT_VECTOR_CAPACITY, vec->len + count));
 	}

--- a/librz/util/vector.c
+++ b/librz/util/vector.c
@@ -224,7 +224,16 @@ RZ_API void *rz_vector_insert(RzVector *vec, size_t index, void *x) {
 	return p;
 }
 
-RZ_API void *rz_vector_insert_range(RzVector *vec, size_t index, void *first, size_t count) {
+/**
+ * \brief Inserts \p count elements from \p first in vector \p vec at index \p index, shifting elements if necessary.
+ *
+ * \param vec The vector to insert in.
+ * \param index The index to insert the new elements. It can be equal to vector length which means insert-at-the-end.
+ * \param first The array containing the new elements. If NULL, \p count empty elements will be inserted.
+ * \param count The number of elements from \p first to be inserted, or number of empty elements if \p first is NULL.
+ * \return A pointer to the inserted elements.
+ */
+RZ_API void *rz_vector_insert_range(RzVector *vec, size_t index, RZ_NULLABLE void *first, size_t count) {
 	rz_return_val_if_fail(vec && index <= vec->len, NULL);
 	if (count == 0) {
 		return (char *)vec->a + vec->elem_size * index;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr makes `rz_vector_insert_range()` determine the insert address without going through `rz_vector_index_ptr()` if count is 0 (fortunately getting the address of the memory location one past the end of an array is not UB). The reason for this change is that if `index == vec->len == vec->capacity` and count is 0, the call to `rz_vector_index_ptr()` at the following line:
https://github.com/rizinorg/rizin/blob/d809a19937364e71a3fa709dda047dc1148fed18/librz/util/vector.c#L233
will fail due to the assert inside `rz_vector_index_ptr()`:
https://github.com/rizinorg/rizin/blob/d809a19937364e71a3fa709dda047dc1148fed18/librz/include/rz_vector.h#L103

Hopefully this will fix the test fails plaguing the clang-cl AppVeyor build ([example](https://ci.appveyor.com/project/rizinorg/rizin/builds/52814799/job/j4oi1e20r5psp6i8#L14430)). Even if it doesn't, I think the change should be implemented anyway.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
