### PR TITLE
rz_print_colored_help: Add guard condition to check `options` length

### DIFF
--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -1545,12 +1545,11 @@ static void print_colored_help_option(RZ_NULLABLE const char *flag, RZ_NULLABLE 
  *        4th string for each option that contains an example.
  */
 RZ_API void rz_print_colored_help(const char **options, size_t options_len, bool have_examples) {
+	rz_return_if_fail(options_len % (have_examples ? 4 : 3) == 0);
 	size_t max_desc_len = 0;
 	size_t max_flag_n_arg_len = options_get_max_len(options, options_len, have_examples ? &max_desc_len : NULL);
 	for (int i = 0; i < options_len; i += have_examples ? 4 : 3) {
-		if (i + 1 < options_len) {
-			print_colored_help_option(options[i], options[i + 1], options[i + 2], max_flag_n_arg_len,
-				have_examples ? options[i + 3] : NULL, max_desc_len);
-		}
+		print_colored_help_option(options[i], options[i + 1], options[i + 2], max_flag_n_arg_len,
+			have_examples ? options[i + 3] : NULL, max_desc_len);
 	}
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr basically adds a guard condition to `rz_print_colored_help()` that checks whether the `options` array length is of the correct multiple.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
