### PR TITLE
Remove arg for `-X` in `rz-gg -h`

### DIFF
--- a/binrz/man/rz-gg.1
+++ b/binrz/man/rz-gg.1
@@ -94,7 +94,7 @@ Show version information
 Patch hexpairs at given offset
 .It Fl x
 Execute
-.It Fl X Ar hexpairs
+.It Fl X
 Execute rop chain, using the stack provided
 .It Fl z
 Output in C string syntax

--- a/librz/main/rz-gg.c
+++ b/librz/main/rz-gg.c
@@ -46,7 +46,7 @@ static int usage(int v) {
 			"-v",		""              ,"Show version information",
 			"-w",		"[off:hex]"     ,"Patch hexpairs at given offset",
 			"-x",		""              ,"Execute",
-			"-X",		"[hexpairs]"    ,"Execute rop chain, using the stack provided",
+			"-X",		""              ,"Execute rop chain, using the stack provided",
 			"-z",		""              ,"Output in C string syntax",
 			// clang-format on
 		};

--- a/test/db/tools/rz
+++ b/test/db/tools/rz
@@ -557,7 +557,7 @@ ec diff.unmatch red    | mismatch color
  [32m-v[0m             [0mShow version information
  [32m-w[0m[33m [off:hex] [0m  [0mPatch hexpairs at given offset
  [32m-x[0m             [0mExecute
- [32m-X[0m[33m [hexpairs] [0m [0mExecute rop chain, using the stack provided
+ [32m-X[0m             [0mExecute rop chain, using the stack provided
  [32m-z[0m             [0mOutput in C string syntax
 
 [36mUsage: [0mrz-hash [-vhBkjLq] [-b S] [-a A] [-c H] [-E A] [-D A] [-s S] [-x S] [-f O] [-t O] [files|-] ...


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr removes the argument for `-X` in `rz-gg -h` since apparently there is no code that obtains that argument. The stack is seemingly provided inside the egg itself but I'm not entirely sure about that.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
