### PR TITLE
Fix(fC): show correct comment when flags overlap

### DIFF
--- a/librz/core/cmd/cmd_flag.c
+++ b/librz/core/cmd/cmd_flag.c
@@ -881,12 +881,12 @@ RZ_IPI RzCmdStatus rz_flag_comment_handler(RzCore *core, int argc, const char **
 		}
 		return bool2status(flag_set_comment(item, argv[2]));
 	} else {
-		item = rz_flag_get_i(core->flags, rz_num_math(core->num, argv[1]));
-		if (item && item->comment) {
-			rz_cons_println(item->comment);
-		} else {
+		item = rz_flag_get(core->flags, argv[1]);
+		if (!item) {
 			RZ_LOG_ERROR("Cannot find the flag\n");
 			return RZ_CMD_STATUS_ERROR;
+		} else if (item->comment) {
+			rz_cons_println(item->comment);
 		}
 	}
 	return RZ_CMD_STATUS_OK;

--- a/test/db/cmd/cmd_flags
+++ b/test/db/cmd/cmd_flags
@@ -740,3 +740,15 @@ ERROR: Wrong number of arguments passed to `fO`, see its help with `fO?`
 ERROR: Usage: fO <glob>   # Flag as ordinals (sym.* func.* method.*)
 EOF
 RUN
+
+NAME=fC for overlapping flags
+FILE==
+CMDS=<<EOF
+f foo 0x10 first
+f+ bar 0x20 second
+fC foo
+EOF
+EXPECT=<<EOF
+first
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

`fC` was showing comment of wrong flag if two flags existed at the same offset. See issue #5316  
...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->
run test the provided test
OR, start rizin:
```bash
f foo 0x10 first
f+ bar 0x20 second
fC foo
``` 
the output will now be `first` instead of `second`, (the latter being incorrect)
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
closes #5316 
...
