### PR TITLE
fix: free RzMark in core cleanup

### DIFF
--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -1894,6 +1894,7 @@ RZ_API void rz_core_fini(RzCore *c) {
 	RZ_FREE_CUSTOM(c->visual, rz_core_visual_free);
 	RZ_FREE_CUSTOM(c->warnings_after, rz_list_free);
 	RZ_FREE_CUSTOM(c->sys_path, rz_path_free);
+	RZ_FREE_CUSTOM(c->marks, rz_mark_free);
 }
 
 RZ_API void rz_core_free(RzCore *c) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**
Fixed memory leaks caused by an unfreed RzMark object

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**
Build rizin with Asan
Run some basic mark commands (`m?`)
Exit rizin. There should no longer be leaks related to marks

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
