### PR TITLE
[Feature] Colorize 'el' output (Fixes #5463)

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -1914,20 +1914,19 @@ static void config_print_node(RzConfig *cfg, RzConfigNode *node, RzCmdStateOutpu
 		free(es);
 		break;
 	case RZ_OUTPUT_MODE_STANDARD: {
-		char alphaChar = node->name[0];
-		const char *color;
+		bool color_enabled = rz_config_get_i(cfg, "scr.color");
+		char color_str[32], reset_str[32];
 
-		switch (alphaChar % 6) {
-			case 0: color = Color_BWHITE; break;
-			case 1: color = Color_BGREEN; break;
-			case 2: color = Color_BYELLOW; break;
-			case 3: color = Color_BBLUE; break;
-			case 4: color = Color_BMAGENTA; break;
-			default: color = Color_BCYAN; break;
+		if (color_enabled) {
+			RzColor color_val = rz_cons_pal_get("label");
+			RzColor reset_val = rz_cons_pal_get("help");
+			rz_cons_rgb_str(color_str, sizeof(color_str), &color_val);
+			rz_cons_rgb_str(reset_str, sizeof(reset_str), &reset_val);
+		} else {
+			color_str[0] = reset_str[0] = '\0';
 		}
 
-		rz_cons_printf("%s%20s" Color_RESET ": " Color_CYAN "%s" Color_RESET "\n",
-			color, node->name, node->desc ? node->desc : "");
+		rz_cons_printf("%s%20s: %s%s\n", color_str, node->name, reset_str, node->desc ? node->desc : "");
 		break;
 	}
 	case RZ_OUTPUT_MODE_STR_BUF:

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -1914,7 +1914,7 @@ static void config_print_node(RzConfig *cfg, RzConfigNode *node, RzCmdStateOutpu
 		free(es);
 		break;
 	case RZ_OUTPUT_MODE_STANDARD: {
-		bool color_enabled = rz_config_get_i(cfg, "scr.color");
+		bool color_enabled = rz_config_get_i(cfg, "scr.color") > 0;
 		char color_str[32], reset_str[32];
 
 		if (color_enabled) {

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -1913,10 +1913,23 @@ static void config_print_node(RzConfig *cfg, RzConfigNode *node, RzCmdStateOutpu
 		rz_cons_printf("e %s=%s\n", node->name, es);
 		free(es);
 		break;
-	case RZ_OUTPUT_MODE_STANDARD:
-		rz_cons_printf("%20s: %s\n", node->name,
-			node->desc ? node->desc : "");
+	case RZ_OUTPUT_MODE_STANDARD: {
+		char alphaChar = node->name[0];
+		const char *color;
+
+		switch (alphaChar % 6) {
+			case 0: color = Color_BWHITE; break;
+			case 1: color = Color_BGREEN; break;
+			case 2: color = Color_BYELLOW; break;
+			case 3: color = Color_BBLUE; break;
+			case 4: color = Color_BMAGENTA; break;
+			default: color = Color_BCYAN; break;
+		}
+
+		rz_cons_printf("%s%20s" Color_RESET ": " Color_CYAN "%s" Color_RESET "\n",
+			color, node->name, node->desc ? node->desc : "");
 		break;
+	}
 	case RZ_OUTPUT_MODE_STR_BUF:
 		rz_strbuf_appendf(state->d.sbuf, "%20s: %10s - %s\n", node->name,
 			rz_config_node_type(node),


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
-  I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- I've documented every `RZ_API` function and struct this PR changes. [Not required for this PR]
- I've added tests that prove my changes are effective (required for changes to `RZ_API`). [Not Relevant in this case]
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

I have colorised the output of `el` command. In `librz/core/cconfig.c` I have added the support for the colorized output. Normally, `RZ_OUTPUT_MODE_STANDARD` this is the output mode, so I decided to change update this case.  

<img width="968" height="681" alt="image" src="https://github.com/user-attachments/assets/89ed331f-815b-48a6-8901-d65563ca21b2" />


**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
