### PR TITLE
help, scr.utf8.curvy=true: Add 1 space after curve

### DIFF
--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -34,9 +34,9 @@
 // Based on Config and Line order choses the vertical line shape
 static inline const char *get_vertical_line(size_t idx, size_t len, bool scr_curvy, bool scr_utf8) {
 	if (scr_curvy && !idx) {
-		return RUNE_CURVE_CORNER_TL;
+		return RUNE_CURVE_CORNER_TL " ";
 	} else if (scr_curvy && (idx == len - 1)) {
-		return RUNE_CURVE_CORNER_BL;
+		return RUNE_CURVE_CORNER_BL " ";
 	} else if (scr_utf8) {
 		return RUNE_LINE_VERT " ";
 	}

--- a/test/db/cmd/cmd_help
+++ b/test/db/cmd/cmd_help
@@ -136,6 +136,37 @@ Usage: aa[?]   # Analysis commands
 EOF
 RUN
 
+NAME=help with scr.utf8.curvy=true
+FILE=--
+CMDS=e scr.utf8=true scr.utf8.curvy=true; w?
+EXPECT=<<EOF
+Usage: w[?]   # Write commands
+╭w <string>        # Write string
+│ wB[-]             # Set or unset bits with given value
+│ wv[1248]          # Write value of given size
+│ w0 <len>          # Write <len> bytes with value 0x00
+│ w<1248><+-> [<n>] # Increment/decrement byte, word, ...
+│ w6<de>            # Write base64 [d]ecoded or [e]ncoded string
+│ we<nsx>           # Extend write operations (insert bytes instead of replacing)
+│ wu <file>         # Apply unified hex patch (see output of cu)
+│ wr <len>          # Write <len> random bytes
+│ wc[j*-+ip?]       # Write cache commands
+│ wz <string>       # Write zero-terminated string
+│ wf[xfs]           # Write data from file, socket, offset
+│ ww <string>       # Write wide (16-bit) little-endian string
+│ wx[f]             # Write hexadecimal data
+│ wa[ifo]           # Write opcodes
+│ wb <hex>          # Write in current block a hexstring cyclically
+│ wm[-]             # Set binary mask hexpair to be used as cyclic write mask
+│ wo<?>             # Write a block with a special operation
+│ wD[/]             # Write de Bruijn pattern
+│ wd <src> <len>    # Duplicate <len> bytes from <src> offset to current seek
+╰ws <string>       # Write 1 byte for length and then the string
+
+Detailed help for w <string> is provided by w??.
+EOF
+RUN
+
 NAME=recursive help json (old style)
 FILE==
 CMDS=<<EOF

--- a/test/db/cmd/cmd_help
+++ b/test/db/cmd/cmd_help
@@ -141,7 +141,7 @@ FILE=--
 CMDS=e scr.utf8=true scr.utf8.curvy=true; w?
 EXPECT=<<EOF
 Usage: w[?]   # Write commands
-╭w <string>        # Write string
+╭ w <string>        # Write string
 │ wB[-]             # Set or unset bits with given value
 │ wv[1248]          # Write value of given size
 │ w0 <len>          # Write <len> bytes with value 0x00
@@ -161,7 +161,7 @@ Usage: w[?]   # Write commands
 │ wo<?>             # Write a block with a special operation
 │ wD[/]             # Write de Bruijn pattern
 │ wd <src> <len>    # Duplicate <len> bytes from <src> offset to current seek
-╰ws <string>       # Write 1 byte for length and then the string
+╰ ws <string>       # Write 1 byte for length and then the string
 
 Detailed help for w <string> is provided by w??.
 EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

With `scr.utf8.curvy=true`, this pr adds 1 space after the top and bottom curve. Example of new output is below. Example of old output is in #5464.

<img width="764" height="494" alt="1 space after help curve" src="https://github.com/user-attachments/assets/b5f4f08e-4a37-4890-9ee4-d1ae5a5f3993" />


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Fixes #5464.
