### PR TITLE
Autocompletion of eco command

### DIFF
--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -102,7 +102,7 @@ static int compare_strings(const char *s1, const char *s2, RZ_UNUSED void *user)
  * \param core The RzCore struct to use
  * \return Pointer to a NULL terminated array of theme names or NULL in case of failure.
  */
-RZ_IPI char **rz_core_autocomplete_rotate_theme(RzCore *core) {
+RZ_IPI RZ_OWN char **rz_core_autocomplete_rotate_theme(RzCore *core) {
 	RzPVector *themes = rz_core_get_themes(core);
 	if (!themes) {
 		return NULL;

--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -97,6 +97,32 @@ static int compare_strings(const char *s1, const char *s2, RZ_UNUSED void *user)
 }
 
 /**
+ * \brief Returns themes for autocompletion.
+ *
+ * \param core The RzCore struct to use
+ * \return theme name of type char.
+ */
+RZ_IPI char **rz_core_autocomplete_rotate_theme(RzCore *core) {
+	RzPVector *themes = rz_core_get_themes(core);
+	if (!themes) {
+		return NULL;
+	}
+	size_t count = rz_pvector_len(themes);
+	char **theme_name = RZ_NEWS0(char *, count + 1);
+	if (!theme_name) {
+		rz_pvector_free(themes);
+		return NULL;
+	}
+
+	size_t i = 0;
+	void **iter;
+	rz_pvector_foreach (themes, iter) {
+		theme_name[i++] = rz_str_dup(*iter);
+	}
+	return theme_name;
+}
+
+/**
  * \brief Get names of available rizin themes.
  *
  * \param core The RzCore struct to use

--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -100,7 +100,7 @@ static int compare_strings(const char *s1, const char *s2, RZ_UNUSED void *user)
  * \brief Returns themes for autocompletion.
  *
  * \param core The RzCore struct to use
- * \return theme name of type char.
+ * \return Pointer to a NULL terminated array of theme names or NULL in case of failure.
  */
 RZ_IPI char **rz_core_autocomplete_rotate_theme(RzCore *core) {
 	RzPVector *themes = rz_core_get_themes(core);

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -11885,9 +11885,9 @@ static const RzCmdDescHelp eco_help = {
 static const RzCmdDescArg cmd_eval_color_load_theme_args[] = {
 	{
 		.name = "theme",
-		.type = RZ_CMD_ARG_TYPE_STRING,
-		.flags = RZ_CMD_ARG_FLAG_LAST,
+		.type = RZ_CMD_ARG_TYPE_CHOICES,
 		.optional = true,
+		.choices.choices_cb = rz_core_autocomplete_rotate_theme,
 
 	},
 	{ 0 },

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -1503,6 +1503,7 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_set_random_palette_handler(RzCore *core, in
 RZ_IPI RzCmdStatus rz_cmd_eval_color_set_colorful_palette_handler(RzCore *core, int argc, const char **argv);
 // "eco"
 RZ_IPI RzCmdStatus rz_cmd_eval_color_load_theme_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+RZ_IPI char **rz_core_autocomplete_rotate_theme(RzCore *core);
 // "eco."
 RZ_IPI RzCmdStatus rz_cmd_eval_color_list_current_theme_handler(RzCore *core, int argc, const char **argv);
 // "ecoo"

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -1503,7 +1503,7 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_set_random_palette_handler(RzCore *core, in
 RZ_IPI RzCmdStatus rz_cmd_eval_color_set_colorful_palette_handler(RzCore *core, int argc, const char **argv);
 // "eco"
 RZ_IPI RzCmdStatus rz_cmd_eval_color_load_theme_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
-RZ_IPI RZ_OWN char **rz_core_autocomplete_rotate_theme(RzCore *core);
+RZ_IPI char **rz_core_autocomplete_rotate_theme(RzCore *core);
 // "eco."
 RZ_IPI RzCmdStatus rz_cmd_eval_color_list_current_theme_handler(RzCore *core, int argc, const char **argv);
 // "ecoo"

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -1503,7 +1503,7 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_set_random_palette_handler(RzCore *core, in
 RZ_IPI RzCmdStatus rz_cmd_eval_color_set_colorful_palette_handler(RzCore *core, int argc, const char **argv);
 // "eco"
 RZ_IPI RzCmdStatus rz_cmd_eval_color_load_theme_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
-RZ_IPI char **rz_core_autocomplete_rotate_theme(RzCore *core);
+RZ_IPI RZ_OWN char **rz_core_autocomplete_rotate_theme(RzCore *core);
 // "eco."
 RZ_IPI RzCmdStatus rz_cmd_eval_color_list_current_theme_handler(RzCore *core, int argc, const char **argv);
 // "ecoo"

--- a/librz/core/cmd_descs/cmd_eval.yaml
+++ b/librz/core/cmd_descs/cmd_eval.yaml
@@ -283,7 +283,8 @@ commands:
             type: RZ_CMD_DESC_TYPE_ARGV_STATE
             args:
               - name: theme
-                type: RZ_CMD_ARG_TYPE_STRING
+                type: RZ_CMD_ARG_TYPE_CHOICES
+                choices_cb: rz_core_autocomplete_rotate_theme
                 optional: true
             modes:
               - RZ_OUTPUT_MODE_JSON

--- a/test/integration/test_autocmplt.c
+++ b/test/integration/test_autocmplt.c
@@ -687,6 +687,30 @@ static bool test_autocmplt_choices_cb_arg(void) {
 	mu_end;
 }
 
+static bool test_autocmplt_eco_themes(void) {
+	RzCore *core = rz_core_new();
+	mu_assert_notnull(core, "core should be created");
+
+	RzLineBuffer *buf = &core->cons->line->buffer;
+
+	const char *s = "eco ";
+	strcpy(buf->data, s);
+	buf->length = strlen(s);
+	buf->index = buf->length;
+
+	RzLineNSCompletionResult *r = rz_core_autocomplete_rzshell(core, buf, RZ_LINE_PROMPT_DEFAULT);
+	mu_assert_notnull(r, "Autocomplete result should not be NULL");
+
+	size_t count = rz_pvector_len(&r->options);
+
+	mu_assert_true(count > 0, "There should be at least one theme");
+	mu_assert_streq(rz_pvector_at(&r->options, 0), "ayu", "First theme should be ayu or similar");
+
+	rz_line_ns_completion_result_free(r);
+	rz_core_free(core);
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_autocmplt_cmdid);
 	mu_run_test(test_autocmplt_newcommand);
@@ -703,6 +727,7 @@ bool all_tests() {
 	mu_run_test(test_autocmplt_tmp_config);
 	mu_run_test(test_autocmplt_tmp_arch);
 	mu_run_test(test_autocmplt_choices_cb_arg);
+	mu_run_test(test_autocmplt_eco_themes);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

This PR adds autocompletion to the "eco" command when <TAB> is pressed and loops through the themes

...

**Test plan**

Run eco [TAB]

NOTE : [TAB] from keystroke

In console this shows the next available theme to change and autocomplete the command 
...

**Closing issues**

closes #5038

...
