### PR TITLE
Improve oml= command colors unicode

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -321,8 +321,14 @@ RZ_IPI void rz_core_analysis_bbs_asciiart(RzCore *core, RzAnalysisFunction *fcn)
 		rz_list_append(flist, info);
 	}
 	RzTable *table = rz_core_table(core);
+	RzTableVisualOptions opts = {
+		.unicode = rz_config_get_b(core->config, "scr.utf8"),
+		.color = rz_config_get_i(core->config, "scr.color"),
+		.va = core->io->va,
+		.pal = &core->cons->context->pal
+	};
 	rz_table_visual_list(table, flist, core->offset, core->blocksize,
-		rz_cons_get_size(NULL), rz_config_get_i(core->config, "scr.color"));
+		rz_cons_get_size(NULL), &opts);
 	rz_cons_printf("\n%s\n", rz_table_tostring(table));
 	rz_table_free(table);
 	rz_list_free(flist);

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -777,8 +777,13 @@ RZ_API void rz_debug_traces_ascii(RzDebug *dbg, ut64 offset) {
 	RzList *info_list = rz_debug_traces_info(dbg, offset);
 	RzTable *table = rz_table_new();
 	table->cons = rz_cons_singleton();
-	rz_table_visual_list(table, info_list, offset, 1,
-		rz_cons_get_size(NULL), dbg->iob.io->va);
+	RzTableVisualOptions opts = {
+		.unicode = rz_cons_singleton()->use_utf8,
+		.color = false, // Disabled color for this call site
+		.va = dbg->iob.io->va,
+		.pal = &rz_cons_singleton()->context->pal
+	};
+	rz_table_visual_list(table, info_list, offset, 1, rz_cons_get_size(NULL), &opts);
 	char *s = rz_table_tostring(table);
 	rz_cons_printf("\n%s\n", s);
 	free(s);

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -3646,8 +3646,13 @@ RZ_IPI RzCmdStatus rz_analysis_function_list_ascii_handler(RzCore *core, int arg
 		rz_list_append(flist, info);
 	}
 	RzTable *table = rz_core_table(core);
-	rz_table_visual_list(table, flist, core->offset, core->blocksize,
-		rz_cons_get_size(NULL), rz_config_get_i(core->config, "scr.color"));
+	RzTableVisualOptions opts = {
+		.unicode = rz_config_get_b(core->config, "scr.utf8"),
+		.color = rz_config_get_i(core->config, "scr.color"),
+		.va = core->io->va,
+		.pal = &core->cons->context->pal
+	};
+	rz_table_visual_list(table, flist, core->offset, core->blocksize, rz_cons_get_size(NULL), &opts);
 	char *tablestr = rz_table_tostring(table);
 	rz_cons_printf("\n%s\n", tablestr);
 	free(tablestr);

--- a/librz/core/cmd/cmd_info.c
+++ b/librz/core/cmd/cmd_info.c
@@ -302,7 +302,13 @@ RZ_IPI RzCmdStatus rz_cmd_info_section_bars_handler(RzCore *core, int argc, cons
 		RZ_LOG_ERROR("Cannot print section bars\n");
 		goto list_err;
 	}
-	rz_table_visual_list(table, list, core->offset, 1, cols, core->io->va);
+	RzTableVisualOptions opts = {
+		.unicode = rz_config_get_b(core->config, "scr.utf8"),
+		.color = rz_config_get_i(core->config, "scr.color"),
+		.va = core->io->va,
+		.pal = &core->cons->context->pal
+	};
+	rz_table_visual_list(table, list, core->offset, 1, cols, &opts);
 
 	char *s = rz_table_tostring(table);
 	if (!s) {

--- a/librz/core/cmd/cmd_open.c
+++ b/librz/core/cmd/cmd_open.c
@@ -261,8 +261,13 @@ RZ_IPI RzCmdStatus rz_open_maps_list_ascii_handler(RzCore *core, int argc, const
 		rz_list_append(list, info);
 	}
 	RzTable *table = rz_core_table(core);
-	rz_table_visual_list(table, list, core->offset, core->blocksize,
-		rz_cons_get_size(NULL), rz_config_get_i(core->config, "scr.color"));
+	RzTableVisualOptions opts = {
+		.unicode = rz_config_get_b(core->config, "scr.utf8"),
+		.color = rz_config_get_i(core->config, "scr.color"),
+		.va = core->io->va,
+		.pal = &core->cons->context->pal
+	};
+	rz_table_visual_list(table, list, core->offset, core->blocksize, rz_cons_get_size(NULL), &opts);
 	char *tablestr = rz_table_tostring(table);
 	rz_cons_printf("%s", tablestr);
 	rz_table_free(table);
@@ -694,8 +699,13 @@ RZ_IPI RzCmdStatus rz_open_binary_list_ascii_handler(RzCore *core, int argc, con
 		rz_list_append(list, info);
 	}
 	RzTable *table = rz_core_table(core);
-	rz_table_visual_list(table, list, core->offset, core->blocksize,
-		rz_cons_get_size(NULL), rz_config_get_i(core->config, "scr.color"));
+	RzTableVisualOptions opts = {
+		.unicode = rz_config_get_b(core->config, "scr.utf8"),
+		.color = rz_config_get_i(core->config, "scr.color"),
+		.va = core->io->va,
+		.pal = &core->cons->context->pal
+	};
+	rz_table_visual_list(table, list, core->offset, core->blocksize, rz_cons_get_size(NULL), &opts);
 	char *table_text = rz_table_tostring(table);
 	rz_cons_printf("\n%s\n", table_text);
 	free(table_text);

--- a/librz/include/rz_util/rz_table.h
+++ b/librz/include/rz_util/rz_table.h
@@ -61,7 +61,7 @@ struct rz_cons_printable_palette_t;
  * \brief Visual rendering options for \ref rz_table_visual_list
  */
 typedef struct rz_table_visual_options_t {
-	bool unicode; ///< Use Unicode runes for lines/blocks when true
+	bool unicode; ///< Use Unicode characters for lines/blocks when true
 	bool color; ///< Enable ANSI colors for bars and permission strings
 	bool va; ///< Use virtual addresses when true; physical otherwise
 	struct rz_cons_printable_palette_t *pal; ///< Palette for colors; required if color is true

--- a/librz/include/rz_util/rz_table.h
+++ b/librz/include/rz_util/rz_table.h
@@ -55,8 +55,6 @@ typedef struct {
 
 typedef void (*RzTableSelector)(RzTableRow *acc, RzTableRow *new_row, int nth);
 
-struct rz_cons_printable_palette_t;
-
 /**
  * \brief Visual rendering options for \ref rz_table_visual_list
  */

--- a/librz/include/rz_util/rz_table.h
+++ b/librz/include/rz_util/rz_table.h
@@ -101,12 +101,12 @@ RZ_API bool rz_table_align(RzTable *t, int nth, int align);
 /**
  * \brief Render a visual list (bars) into an RzTable
  *
- * \param table Output table (columns are set internally)
- * \param list  Items to visualize (each entry is an RzListInfo with name/intervals/perms)
- * \param seek  Current seek address used to mark the cursor region
- * \param len   Cursor span length (0 to hide cursor line)
- * \param width Console width used to compute bar columns
- * \param opts  Rendering options (must be non-NULL)
+ * \param table Output table.
+ * \param list  Items to visualize (each entry is an RzListInfo with name/intervals/perms).
+ * \param seek  Current seek address used to mark the cursor region.
+ * \param len   Cursor span length (0 to hide cursor line).
+ * \param width Console width used to compute bar columns.
+ * \param opts  Rendering options.
  */
 RZ_API void rz_table_visual_list(RzTable *table, RzList /*<RzListInfo *>*/ *list, ut64 seek, ut64 len, int width, RzTableVisualOptions *opts);
 RZ_API RZ_OWN RzTable *rz_table_transpose(RZ_NONNULL RzTable *t);

--- a/librz/include/rz_util/rz_table.h
+++ b/librz/include/rz_util/rz_table.h
@@ -106,7 +106,7 @@ RZ_API bool rz_table_align(RzTable *t, int nth, int align);
  * \param width Console width used to compute bar columns.
  * \param opts  Rendering options.
  */
-RZ_API void rz_table_visual_list(RzTable *table, RzList /*<RzListInfo *>*/ *list, ut64 seek, ut64 len, int width, RzTableVisualOptions *opts);
+RZ_API void rz_table_visual_list(RZ_NONNULL RzTable *table, RZ_NONNULL RzList /*<RzListInfo *>*/ *list, ut64 seek, ut64 len, int width, RZ_NONNULL RzTableVisualOptions *opts);
 RZ_API RZ_OWN RzTable *rz_table_transpose(RZ_NONNULL RzTable *t);
 RZ_API void rz_table_columns(RzTable *t, RzList /*<char *>*/ *cols); // const char *name, ...);
 #ifdef __cplusplus

--- a/librz/include/rz_util/rz_table.h
+++ b/librz/include/rz_util/rz_table.h
@@ -55,6 +55,18 @@ typedef struct {
 
 typedef void (*RzTableSelector)(RzTableRow *acc, RzTableRow *new_row, int nth);
 
+struct rz_cons_printable_palette_t;
+
+/**
+ * \brief Visual rendering options for \ref rz_table_visual_list
+ */
+typedef struct rz_table_visual_options_t {
+	bool unicode; ///< Use Unicode runes for lines/blocks when true
+	bool color; ///< Enable ANSI colors for bars and permission strings
+	bool va; ///< Use virtual addresses when true; physical otherwise
+	struct rz_cons_printable_palette_t *pal; ///< Palette for colors; required if color is true
+} RzTableVisualOptions;
+
 RZ_API RzListInfo *rz_listinfo_new(const char *name, RzInterval pitv, RzInterval vitv, int perm, const char *extra);
 RZ_API void rz_listinfo_free(RzListInfo *info);
 
@@ -86,7 +98,17 @@ RZ_API void rz_table_group(RzTable *t, int nth, RzTableSelector fcn);
 RZ_API bool rz_table_query(RzTable *t, const char *q);
 RZ_API void rz_table_hide_header(RzTable *t);
 RZ_API bool rz_table_align(RzTable *t, int nth, int align);
-RZ_API void rz_table_visual_list(RzTable *table, RzList /*<RzListInfo *>*/ *list, ut64 seek, ut64 len, int width, bool va);
+/**
+ * \brief Render a visual list (bars) into an RzTable
+ *
+ * \param table Output table (columns are set internally)
+ * \param list  Items to visualize (each entry is an RzListInfo with name/intervals/perms)
+ * \param seek  Current seek address used to mark the cursor region
+ * \param len   Cursor span length (0 to hide cursor line)
+ * \param width Console width used to compute bar columns
+ * \param opts  Rendering options (must be non-NULL)
+ */
+RZ_API void rz_table_visual_list(RzTable *table, RzList /*<RzListInfo *>*/ *list, ut64 seek, ut64 len, int width, RzTableVisualOptions *opts);
 RZ_API RZ_OWN RzTable *rz_table_transpose(RZ_NONNULL RzTable *t);
 RZ_API void rz_table_columns(RzTable *t, RzList /*<char *>*/ *cols); // const char *name, ...);
 #ifdef __cplusplus

--- a/librz/util/table.c
+++ b/librz/util/table.c
@@ -1286,7 +1286,7 @@ RZ_API void rz_listinfo_free(RzListInfo *info) {
 	free(info);
 }
 
-RZ_API void rz_table_visual_list(RzTable *table, RzList /*<RzListInfo *>*/ *list, ut64 seek, ut64 len, int width, bool va) {
+RZ_API void rz_table_visual_list(RzTable *table, RzList /*<RzListInfo *>*/ *list, ut64 seek, ut64 len, int width, RzTableVisualOptions *opts) {
 	ut64 mul, min = -1, max = -1;
 	RzListIter *iter;
 	RzListInfo *info;
@@ -1324,7 +1324,7 @@ RZ_API void rz_table_visual_list(RzTable *table, RzList /*<RzListInfo *>*/ *list
 			}
 			char *b = rz_strbuf_drain(buf);
 			char no[64];
-			if (va) {
+			if (opts->va) {
 				rz_table_add_rowf(table, "sxsxsss",
 					rz_strf(no, "%d%c", i, rz_itv_contain(info->vitv, seek) ? '*' : ' '),
 					info->vitv.addr,

--- a/librz/util/table.c
+++ b/librz/util/table.c
@@ -1286,14 +1286,16 @@ RZ_API void rz_listinfo_free(RzListInfo *info) {
 	free(info);
 }
 
-RZ_API void rz_table_visual_list(RzTable *table, RzList /*<RzListInfo *>*/ *list, ut64 seek, ut64 len, int width, RzTableVisualOptions *opts) {
+RZ_API void rz_table_visual_list(RZ_NONNULL RzTable *table, RZ_NONNULL RzList /*<RzListInfo *>*/ *list, ut64 seek, ut64 len, int width, RZ_NONNULL RzTableVisualOptions *opts) {
+	rz_return_if_fail(table && list && opts);
+
 	ut64 mul, min = -1, max = -1;
 	RzListIter *iter;
 	RzListInfo *info;
-	RzCons *cons = (RzCons *)table->cons;
 	table->showHeader = false;
-	const char *h_line = cons->use_utf8 ? RUNE_LONG_LINE_HORIZ : "-";
-	const char *block = cons->use_utf8 ? UTF_BLOCK : "#";
+	const char *h_line = opts->unicode ? RUNE_LONG_LINE_HORIZ : "-";
+	const char *block = opts->unicode ? UTF_BLOCK : "#";
+	bool colors = opts->color && opts->pal;
 	int j, i;
 	width -= 80;
 	if (width < 1) {
@@ -1313,24 +1315,55 @@ RZ_API void rz_table_visual_list(RzTable *table, RzList /*<RzListInfo *>*/ *list
 	if (min != -1 && mul > 0) {
 		i = 0;
 		rz_list_foreach (list, iter, info) {
+			const char *bar_color = "";
+			const char *perm_color = "";
+			if (colors && info->perm != -1) {
+				if ((info->perm & RZ_PERM_W) && (info->perm & RZ_PERM_X)) {
+					bar_color = opts->pal->widget_sel;
+					perm_color = opts->pal->widget_sel;
+				} else if (info->perm & RZ_PERM_X) {
+					bar_color = opts->pal->ai_exec;
+					perm_color = opts->pal->ai_exec;
+				} else if (info->perm & RZ_PERM_W) {
+					bar_color = opts->pal->ai_write;
+					perm_color = opts->pal->ai_write;
+				} else if (info->perm & RZ_PERM_R) {
+					bar_color = opts->pal->ai_read;
+					perm_color = opts->pal->ai_read;
+				}
+			}
 			RzStrBuf *buf = rz_strbuf_new("");
 			for (j = 0; j < width; j++) {
 				ut64 pos = min + j * mul;
 				ut64 npos = min + (j + 1) * mul;
-				const char *arg = (info->pitv.addr < npos && (info->pitv.addr + info->pitv.size) > pos)
-					? block
-					: h_line;
-				rz_strbuf_append(buf, arg);
+				bool is_block = (info->pitv.addr < npos && (info->pitv.addr + info->pitv.size) > pos);
+				const char *arg = is_block ? block : h_line;
+				if (colors && is_block && bar_color && bar_color[0]) {
+					rz_strbuf_append(buf, bar_color);
+					rz_strbuf_append(buf, arg);
+					rz_strbuf_append(buf, Color_RESET);
+				} else {
+					rz_strbuf_append(buf, arg);
+				}
 			}
 			char *b = rz_strbuf_drain(buf);
 			char no[64];
+			char *perm_str = NULL;
+			if (info->perm != -1) {
+				const char *perm = rz_str_rwx_i(info->perm);
+				if (colors && perm_color && perm_color[0]) {
+					perm_str = rz_str_newf("%s%s%s", perm_color, perm, Color_RESET);
+				} else {
+					perm_str = rz_str_dup(perm);
+				}
+			}
 			if (opts->va) {
 				rz_table_add_rowf(table, "sxsxsss",
 					rz_strf(no, "%d%c", i, rz_itv_contain(info->vitv, seek) ? '*' : ' '),
 					info->vitv.addr,
 					b,
 					rz_itv_end(info->vitv),
-					(info->perm != -1) ? rz_str_rwx_i(info->perm) : "",
+					perm_str ? perm_str : "",
 					(info->extra) ? info->extra : "",
 					(info->name) ? info->name : "");
 			} else {
@@ -1339,11 +1372,12 @@ RZ_API void rz_table_visual_list(RzTable *table, RzList /*<RzListInfo *>*/ *list
 					info->pitv.addr,
 					b,
 					rz_itv_end(info->pitv),
-					(info->perm != -1) ? rz_str_rwx_i(info->perm) : "",
+					perm_str ? perm_str : "",
 					(info->extra) ? info->extra : "",
 					(info->name) ? info->name : "");
 			}
 			free(b);
+			free(perm_str);
 			i++;
 		}
 		RzStrBuf *buf = rz_strbuf_new("");


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md).
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`). See note under Test plan.
- [ ] I've updated the Rizin book with the relevant information (if needed). N/A.
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

---

### Detailed description

Goal: make `oml=` visually closer to `dm=` while keeping `rz_table` generic and safe across call sites.

- Introduced `RzTableVisualOptions` in `librz/include/rz_util/rz_table.h`
  - fields: `unicode`, `color`, `va`, `pal` (`RzConsPrintablePalette *`).
  - follows the `RzHistogramOptions` pattern; avoids implicit global `RzCons` state in table code.

- Updated signature:
  - `rz_table_visual_list(RzTable *table, RzList *list, ut64 seek, ut64 len, int width, RzTableVisualOptions *opts)`

- `rz_table_visual_list()` changes:
  - Unicode bars/lines via `UTF_BLOCK` and `RUNE_LINE_HORIZ` when `opts->unicode`.
  - Permission-based colors for the visual bar and permissions string:
    - RWX → `widget_sel`
    - X → `ai_exec`
    - W → `ai_write`
    - R → `ai_read`
  - Numeric columns remain uncolored to preserve `RzTable`’s numeric formatter (it strips ANSI and controls padding).

- Updated all call sites to build `RzTableVisualOptions` from runtime config:
  - `unicode = scr.utf8`, `color = scr.color`, `va = io.va`, `pal = &core->cons->context->pal`.

- Documentation:
  - Added Doxygen for `RzTableVisualOptions` and the updated `rz_table_visual_list()`.
  
 ## screenshot-
<img width="1699" height="164" alt="image" src="https://github.com/user-attachments/assets/a8bcb94f-c68d-4e24-bff7-53a2a6ea9ecd" />



- Notes on tests:
  - Unit tests pass locally. Several integration tests depend on sample binaries not present in minimal local setups.
  - We intentionally did not add ANSI “golden output” tests because terminal output varies by environment (similar `dm=` tests were removed upstream for this reason).

---


### Closing issues

- closes #5480 

---


### AI disclosure

Used a Gemini 2.5pro for syntax fix and approach discussion, Brainstorm, and GitHub Copilot to study the codebase in a more in-depth manner and to draft docs; final changes were reviewed, formatted, and rebased by me.



