### PR TITLE
scripts/map_clean.rz: Use `.echo ${cmd}` instead of `$cmd`

### DIFF
--- a/test/scripts/map_clean.rz
+++ b/test/scripts/map_clean.rz
@@ -1,7 +1,7 @@
-# Partially cleans the map output of $cmd, towards making it invariant over different CI builds
-(map_clean; .(map_clean_i `di~exe[1] | sed 's,.*/rizin/test/bins/,,g;  s,/,\\2,g;  s/-/[-_]/g'`))
-(map_clean_i bin; $cmd | sed 's/[fe][0-9a-f]\{7\}/________/g;  s,[^[:space:]]*\(\([/_]\)rizin\2test\2bins\2${bin}\),...\1,g')
+# Partially cleans the map output of `cmd`, towards making it invariant over different CI builds
+(map_clean cmd; .(map_clean_i ${cmd} `di~exe[1] | sed 's,.*/rizin/test/bins/,,g;  s,/,\\2,g;  s/-/[-_]/g'`))
+(map_clean_i cmd bin; .echo ${cmd} | sed 's/[fe][0-9a-f]\{7\}/________/g;  s,[^[:space:]]*\(\([/_]\)rizin\2test\2bins\2${bin}\),...\1,g')
 
-(dm_clean; $cmd=dm; .(map_clean) | sed 's/1..\(K.*stack\)/1__\1/g')
-(fl_F_maps_clean; $cmd="fl@F:maps"; .(map_clean) | sed 's/1[0-9]\{5\}\(.*stack\)/1_____\1/g')
-(dm_star_clean; $cmd=dm*; .(map_clean) | sed 's/\(stack.*2\)[0-9]\{4\}/\1____/g')
+(dm_clean; .(map_clean dm) | sed 's/1..\(K.*stack\)/1__\1/g')
+(fl_F_maps_clean; .(map_clean "fl@F:maps") | sed 's/1[0-9]\{5\}\(.*stack\)/1_____\1/g')
+(dm_star_clean; .(map_clean dm*) | sed 's/\(stack.*2\)[0-9]\{4\}/\1____/g')


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr makes the scripts/map_clean.rz macros use `.echo ${cmd}` instead of `$cmd` for executing commands. This allows the commands to be passed via macro argument, which is more natural and less namespace-polluting than using an alias.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
