### PR TITLE
Add option to hide string block information

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -2735,7 +2735,8 @@ static void collect_string_xrefs_and_flags(RzCore *core, ut64 paddr, char **xref
 }
 
 static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzPVector /*<RzBinString *>*/ *vec, bool print_xref) {
-	bool b64str = rz_config_get_i(core->config, "bin.b64str");
+	bool b64str = rz_config_get_b(core->config, "bin.b64str");
+	bool show_blocks = rz_config_get_b(core->config, "bin.show.blocks");
 	int va = (core->io->va || core->bin->is_debugger) ? VA_TRUE : VA_FALSE;
 	RzBinObject *obj = rz_bin_cur_object(core->bin);
 
@@ -2868,36 +2869,41 @@ static bool strings_print(RzCore *core, RzCmdStateOutput *state, const RzPVector
 				}
 			}
 
-			RzStrBuf *buf = rz_strbuf_new(str);
-			switch (string->type) {
-			case RZ_STRING_ENC_UTF8:
-			case RZ_STRING_ENC_MUTF8:
-			case RZ_STRING_ENC_UTF16LE:
-			case RZ_STRING_ENC_UTF32LE:
-				block_list = rz_utf_block_list((const ut8 *)string->string, -1, NULL);
-				if (block_list) {
-					if (block_list[0] == 0 && block_list[1] == -1) {
-						/* Don't show block list if
-						   just Basic Latin (0x00 - 0x7F) */
-						free(block_list);
-						break;
-					}
-					int *block_ptr = block_list;
-					rz_strbuf_append(buf, " blocks=");
-					for (; *block_ptr != -1; block_ptr++) {
-						if (block_ptr != block_list) {
-							rz_strbuf_append(buf, ",");
+			char *bufstr = NULL;
+			if (show_blocks) {
+				RzStrBuf *buf = rz_strbuf_new(str);
+				switch (string->type) {
+				case RZ_STRING_ENC_UTF8:
+				case RZ_STRING_ENC_MUTF8:
+				case RZ_STRING_ENC_UTF16LE:
+				case RZ_STRING_ENC_UTF32LE:
+					block_list = rz_utf_block_list((const ut8 *)string->string, -1, NULL);
+					if (block_list) {
+						if (block_list[0] == 0 && block_list[1] == -1) {
+							/* Don't show block list if
+							   just Basic Latin (0x00 - 0x7F) */
+							free(block_list);
+							break;
 						}
-						const char *name = rz_utf_block_name(*block_ptr);
-						rz_strbuf_appendf(buf, "%s", name ? name : "");
+						int *block_ptr = block_list;
+						rz_strbuf_append(buf, " blocks=");
+						for (; *block_ptr != -1; block_ptr++) {
+							if (block_ptr != block_list) {
+								rz_strbuf_append(buf, ",");
+							}
+							const char *name = rz_utf_block_name(*block_ptr);
+							rz_strbuf_appendf(buf, "%s", name ? name : "");
+						}
+						free(block_list);
 					}
-					free(block_list);
+					break;
+				default:
+					break;
 				}
-				break;
-			default:
-				break;
+				bufstr = rz_strbuf_drain(buf);
+			} else {
+				bufstr = rz_str_dup(str);
 			}
-			char *bufstr = rz_strbuf_drain(buf);
 			if (print_xref) {
 				rz_table_add_rowf(state->d.t, "XXsddssss", paddr, vaddr, flag_name_str,
 					(int)string->length, (int)string->size, section_name,

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3386,6 +3386,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETCB("bin.usextr", "true", &cb_usextr, "Use extract plugins when loading files");
 	SETCB("bin.str.purge", "", &cb_strpurge, "Purge strings (e bin.str.purge=? provides more detail)");
 	SETBPREF("bin.b64str", "false", "Try to debase64 the strings");
+	SETBPREF("bin.show.blocks", "true", "When true, appends the block type information to the string.");
 	SETCB("bin.at", "false", &cb_binat, "RzBin.cur depends on RzCore.offset");
 	SETBPREF("bin.libs", "false", "Try to load libraries after loading main binary");
 	n = NODECB("bin.str.filter", "", &cb_strfilter);

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -3745,10 +3745,13 @@ CMDS=<<EOF
 e str.escbslash=true
 iz~green
 iz~wall
+e bin.show.blocks=false
+iz~green
 EOF
 EXPECT=<<EOF
 0x00002248 0x00402248  57  118 .rodata utf16le \nutf16le> \\u00a2\\u20ac\\U00010348 in green:\e[32m ¢€𐍈 \e[0m\n blocks=Basic Latin,Latin-1 Supplement,Currency Symbols,Gothic
 0x000022c8 0x004022c8  33   68 .rodata utf16le is a wall with no embedded zeros\n
+0x00002248 0x00402248  57  118 .rodata utf16le \nutf16le> \\u00a2\\u20ac\\U00010348 in green:\e[32m ¢€𐍈 \e[0m\n
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

The block information is always appended to the string, but sometimes you may not want to have it.
This PR adds the option `bin.show.blocks` and by setting it to false, removes the ` block=XXX` information from `iz[z]`