### PR TITLE
ci: macos-13 is deprecated, use macos-15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
             cflags: -DRZ_ASSERT_STDOUT=1
             allow_failure: false
           - name: macos-meson-clang-tests
-            os: macos-13
+            os: macos-15
             build_system: meson
             compiler: clang
             run_tests: true
@@ -599,7 +599,7 @@ jobs:
 
   build-osx-pkg:
     name: Build OSX package
-    runs-on: macos-13
+    runs-on: macos-15
     if: contains(github.head_ref, 'dist') || contains(github.head_ref, 'osx') || contains(github.head_ref, 'mac') || ((contains(github.ref, 'release-') || github.ref == 'refs/heads/stable') && github.event_name == 'push') || github.event_name == 'schedule'
     needs: [ build-and-test ]
     steps:
@@ -825,7 +825,7 @@ jobs:
     strategy:
       matrix:
         system:
-          - macos-13
+          - macos-15
     runs-on: ${{ matrix.system }}
     needs: [ build-osx-pkg ]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,9 +199,13 @@ jobs:
       - name: Install meson and ninja
         if: matrix.build_system == 'meson' && matrix.enabled
         run: pip3 install --user meson ninja PyYAML
+        env:
+          PIP_BREAK_SYSTEM_PACKAGES: 1
       - name: Install gcovr
         if: matrix.coverage && matrix.enabled
         run: pip3 install --user gcovr
+        env:
+          PIP_BREAK_SYSTEM_PACKAGES: 1
       - name: Checkout rzpipe
         if: matrix.enabled
         uses: actions/checkout@v5
@@ -211,6 +215,8 @@ jobs:
       - name: Install test dependencies
         if: matrix.run_tests && matrix.enabled
         run: pip3 install --user "file://$GITHUB_WORKSPACE/test/rz-pipe#egg=rzpipe&subdirectory=python" requests
+        env:
+          PIP_BREAK_SYSTEM_PACKAGES: 1
       - name: Install Linux test dependencies
         if: matrix.run_tests && matrix.enabled && contains(matrix.os, 'macos') != true
         run: |


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

MacOS 13 is deprecated by GitHub, switch to MacOS 15-based runners: https://github.com/actions/runner-images/issues/13046

**Test plan**

CI is green