### PR TITLE
`?`: Fix misalignment when wrapping if vertical bar is U+2502

### DIFF
--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -819,7 +819,7 @@ static size_t strlen0(const char *s) {
 
 static size_t strbuf_append_calc(RzStrBuf *sb, const char *s) {
 	rz_strbuf_append(sb, s);
-	return strlen(s);
+	return rz_str_len_utf8(s);
 }
 
 static void fill_modes_children_chars(RzStrBuf *sb, const RzCmdDesc *cd) {

--- a/test/db/cmd/cmd_interactive_modes
+++ b/test/db/cmd/cmd_interactive_modes
@@ -38,7 +38,7 @@ EOF
 EXPECT=<<EOF
 [?25l[0m[2J[0;0H0> |                                                                                                                   [0m[2J[0;0H0> |
  - │ !<command> [<args1> <args2> ...] # Run command via system(3) with raw output. Grepping via '~' automatically forces
-                                          use of '!!' instead.                                                          
+                                        use of '!!' instead.                                                            
    │ !!<command> [<args1> <args2> ...] # Run command via system(3) and pipe its stdout to rizin                         [?25h
 
 [?25l[0m[2J[0;0H0> |                                                                                                                   [0m[2J[0;0H0> |


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr fixes the misalignment (see test) when wrapping help text if the vertical bar used is the UTF-8 character U+2502 (│).

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
