### PR TITLE
Add ppd/ shortcut to locate De Bruijn offsets

### DIFF
--- a/doc/rzshell.md
+++ b/doc/rzshell.md
@@ -178,11 +178,3 @@ Escape sequences:
 | \xhh # Byte in hexadecimal
 | \nnn # Byte in octal (eg. \033 for the escape char)
 ```
-### De Bruijn helpers
-
-| Command | Description |
-| --- | --- |
-| `ppd <len>` | Print the default De Bruijn pattern (same data used by `wD`). |
-| `ppd/<value>` | Show the offset where `<value>` occurs in the default pattern, honoring `cfg.bigendian`. |
-| `wD <len>` | Write the pattern into the current map. |
-| `wD/<value>` | Print the offset where `<value>` occurs, respecting `cfg.bigendian`. |

--- a/doc/rzshell.md
+++ b/doc/rzshell.md
@@ -178,3 +178,11 @@ Escape sequences:
 | \xhh # Byte in hexadecimal
 | \nnn # Byte in octal (eg. \033 for the escape char)
 ```
+### De Bruijn helpers
+
+| Command | Description |
+| --- | --- |
+| `ppd <len>` | Print the default De Bruijn pattern (same data used by `wD`). |
+| `ppd/<value>` | Show the offset where `<value>` occurs in the default pattern, honoring `cfg.bigendian`. |
+| `wD <len>` | Write the pattern into the current map. |
+| `wD/<value>` | Print the offset where `<value>` occurs, respecting `cfg.bigendian`. |

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -4061,10 +4061,6 @@ RZ_IPI RzCmdStatus rz_print_pattern_debrujin_handler(RzCore *core, int argc, con
 }
 
 RZ_IPI RzCmdStatus rz_print_pattern_debrujin_find_handler(RzCore *core, int argc, const char **argv) {
-	if (argc < 2) {
-		RZ_LOG_ERROR("Usage: ppd/<value>\n");
-		return RZ_CMD_STATUS_ERROR;
-	}
 	ut64 value = rz_num_math(core->num, argv[1]);
 	bool big_endian = rz_config_get_b(core->config, "cfg.bigendian");
 	int offset = rz_debruijn_offset(0, NULL, value, big_endian);

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -4060,6 +4060,22 @@ RZ_IPI RzCmdStatus rz_print_pattern_debrujin_handler(RzCore *core, int argc, con
 	return RZ_CMD_STATUS_OK;
 }
 
+RZ_IPI RzCmdStatus rz_print_pattern_debrujin_find_handler(RzCore *core, int argc, const char **argv) {
+	if (argc < 2) {
+		RZ_LOG_ERROR("Usage: ppd/<value>\n");
+		return RZ_CMD_STATUS_ERROR;
+	}
+	ut64 value = rz_num_math(core->num, argv[1]);
+	bool big_endian = rz_config_get_b(core->config, "cfg.bigendian");
+	int offset = rz_debruijn_offset(0, NULL, value, big_endian);
+	if (offset < 0) {
+		RZ_LOG_ERROR("Could not find value %" PFMT64x " in Debrujn sequence.\n", value);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_cons_printf("%d\n", offset);
+	return RZ_CMD_STATUS_OK;
+}
+
 RZ_IPI RzCmdStatus rz_print_pattern_oxff_handler(RzCore *core, int argc, const char **argv) {
 	st64 len = argc > 1 ? rz_num_math(core->num, argv[1]) : core->blocksize;
 	if (len < 1) {

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -739,6 +739,7 @@ static const RzCmdDescArg print_pattern4_args[2];
 static const RzCmdDescArg print_pattern8_args[2];
 static const RzCmdDescArg print_pattern_latin_alphabet_args[2];
 static const RzCmdDescArg print_pattern_debrujin_args[2];
+static const RzCmdDescArg print_pattern_debrujin_find_args[2];
 static const RzCmdDescArg print_pattern_oxff_args[2];
 static const RzCmdDescArg print_pattern_num_args[2];
 static const RzCmdDescArg print_key_randomart_args[2];
@@ -16132,6 +16133,21 @@ static const RzCmdDescHelp print_pattern_debrujin_help = {
 	.args = print_pattern_debrujin_args,
 };
 
+static const RzCmdDescArg print_pattern_debrujin_find_args[] = {
+	{
+		.name = "value",
+		.type = RZ_CMD_ARG_TYPE_RZNUM,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp print_pattern_debrujin_find_help = {
+	.summary = "Return the offset where <value> appears in the default De Bruijn pattern",
+	.description = "Honors cfg.bigendian to interpret <value> before searching through the ppd pattern",
+	.args = print_pattern_debrujin_find_args,
+};
+
 static const RzCmdDescArg print_pattern_oxff_args[] = {
 	{
 		.name = "len",
@@ -24490,6 +24506,9 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *print_pattern_debrujin_cd = rz_cmd_desc_argv_new(core->rcmd, pp_cd, "ppd", rz_print_pattern_debrujin_handler, &print_pattern_debrujin_help);
 	rz_warn_if_fail(print_pattern_debrujin_cd);
+
+	RzCmdDesc *print_pattern_debrujin_find_cd = rz_cmd_desc_argv_new(core->rcmd, pp_cd, "ppd/", rz_print_pattern_debrujin_find_handler, &print_pattern_debrujin_find_help);
+	rz_warn_if_fail(print_pattern_debrujin_find_cd);
 
 	RzCmdDesc *print_pattern_oxff_cd = rz_cmd_desc_argv_new(core->rcmd, pp_cd, "ppf", rz_print_pattern_oxff_handler, &print_pattern_oxff_help);
 	rz_warn_if_fail(print_pattern_oxff_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -2121,6 +2121,8 @@ RZ_IPI RzCmdStatus rz_print_pattern8_handler(RzCore *core, int argc, const char 
 RZ_IPI RzCmdStatus rz_print_pattern_latin_alphabet_handler(RzCore *core, int argc, const char **argv);
 // "ppd"
 RZ_IPI RzCmdStatus rz_print_pattern_debrujin_handler(RzCore *core, int argc, const char **argv);
+// "ppd/"
+RZ_IPI RzCmdStatus rz_print_pattern_debrujin_find_handler(RzCore *core, int argc, const char **argv);
 // "ppf"
 RZ_IPI RzCmdStatus rz_print_pattern_oxff_handler(RzCore *core, int argc, const char **argv);
 // "ppn"

--- a/librz/core/cmd_descs/cmd_print.yaml
+++ b/librz/core/cmd_descs/cmd_print.yaml
@@ -880,6 +880,13 @@ commands:
           - name: len
             type: RZ_CMD_ARG_TYPE_RZNUM
             optional: true
+      - name: "ppd/"
+        summary: Return the offset where <value> appears in the default De Bruijn pattern
+        description: Honors cfg.bigendian to interpret <value> before searching through the ppd pattern
+        cname: print_pattern_debrujin_find
+        args:
+          - name: value
+            type: RZ_CMD_ARG_TYPE_RZNUM
       - name: ppf
         summary: Print buffer filled with 0xFF
         cname: print_pattern_oxff

--- a/test/db/cmd/cmd_print
+++ b/test/db/cmd/cmd_print
@@ -121,24 +121,16 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=ppd/ little endian
+NAME=ppd/ endianness
 FILE==
 CMDS=<<EOF
 e cfg.bigendian=false
 ppd/ 0x41574141
-EOF
-EXPECT=<<EOF
-64
-EOF
-RUN
-
-NAME=ppd/ big endian
-FILE==
-CMDS=<<EOF
 e cfg.bigendian=true
 ppd/ 0x41574141
 EOF
 EXPECT=<<EOF
+64
 65
 EOF
 RUN

--- a/test/db/cmd/cmd_print
+++ b/test/db/cmd/cmd_print
@@ -121,6 +121,28 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=ppd/ little endian
+FILE==
+CMDS=<<EOF
+e cfg.bigendian=false
+ppd/ 0x41574141
+EOF
+EXPECT=<<EOF
+64
+EOF
+RUN
+
+NAME=ppd/ big endian
+FILE==
+CMDS=<<EOF
+e cfg.bigendian=true
+ppd/ 0x41574141
+EOF
+EXPECT=<<EOF
+65
+EOF
+RUN
+
 NAME=p=r 0.73 0.06
 FILE=bins/elf/arm1.bin
 ARGS=-n


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Adds a `ppd/<value>` shortcut so users can look up De Bruijn offsets directly from the print command group instead of juggling `wx`/`/x` or `wD/`. The new handler reuses `rz_debruijn_offset()` and respects `cfg.bigendian`, is advertised through the command descriptors/YAML help. Regression tests have been combined into a single test covering both endian modes to optimize CI time.

**Changes made based on review feedback:**
- Removed documentation from `doc/rzshell.md` as requested
- Combined separate little-endian and big-endian tests into one test to save CI computing power
- Documentation moved to the Rizin book at rizinorg/book#155

**Test plan**

```bash
meson compile -C build
meson devenv -C build
..\build\binrz\rz-test\rz-test.exe db/cmd/cmd_print
```

**Closing issues**

closes #5233