### PR TITLE
`?**`: Show entire help string on match even if wrapped

### DIFF
--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -173,7 +173,7 @@ static char *cons_hud_help_string(const char *s) {
 				prev_null = &o[i];
 				os = prev_os;
 				if (os && *os) {
-					rz_list_pop(fl);
+					free(rz_list_pop(fl));
 					track = rz_str_dup(os);
 					if (!rz_list_append(fl, track)) {
 						free(track);

--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -174,10 +174,22 @@ static char *cons_hud_help_string(const char *s) {
 			}
 			prev_str_start = str_start;
 		} else {
+			if (!prev_null) {
+				RZ_LOG_ERROR("prev_null is NULL");
+				free(buf);
+				rz_list_free(fl);
+				return NULL;
+			}
 			*prev_null = '\n';
 			prev_null = &buf[i];
+			if (!prev_str_start) {
+				RZ_LOG_ERROR("prev_str_start is NULL");
+				free(buf);
+				rz_list_free(fl);
+				return NULL;
+			}
 			str_start = prev_str_start;
-			if (str_start && *str_start) {
+			if (*str_start) {
 				free(rz_list_pop(fl));
 				track = rz_str_dup(str_start);
 				if (!rz_list_append(fl, track)) {

--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -135,14 +135,14 @@ static char *cons_hud_help_string(const char *s) {
 		RZ_LOG_ERROR("Hud mode requires scr.interactive=true.\n");
 		return NULL;
 	}
-	char *os, *track, *ret, *o = rz_str_dup(s);
-	if (!o) {
+	char *str_start, *track, *ret, *buf = rz_str_dup(s);
+	if (!buf) {
 		return NULL;
 	}
 	RzList *fl = rz_list_newf(free);
 	int i;
 	if (!fl) {
-		free(o);
+		free(buf);
 		return NULL;
 	}
 
@@ -153,43 +153,43 @@ static char *cons_hud_help_string(const char *s) {
 	 */
 	bool line_has_hash = false;
 	char *prev_null = NULL;
-	char *prev_os = NULL;
-	for (os = o, i = 0; o[i]; i++) {
-		if (o[i] == '#') {
+	char *prev_str_start = NULL;
+	for (str_start = buf, i = 0; buf[i]; i++) {
+		if (buf[i] == '#') {
 			line_has_hash = true;
 		}
-		if (o[i] != '\n') {
+		if (buf[i] != '\n') {
 			continue;
 		}
-		o[i] = 0;
+		buf[i] = 0;
 		if (line_has_hash) {
 			line_has_hash = false;
-			prev_null = &o[i];
-			if (*os) {
-				track = rz_str_dup(os);
+			prev_null = &buf[i];
+			if (*str_start) {
+				track = rz_str_dup(str_start);
 				if (!rz_list_append(fl, track)) {
 					free(track);
 					break;
 				}
 			}
-			prev_os = os;
+			prev_str_start = str_start;
 		} else {
 			*prev_null = '\n';
-			prev_null = &o[i];
-			os = prev_os;
-			if (os && *os) {
+			prev_null = &buf[i];
+			str_start = prev_str_start;
+			if (str_start && *str_start) {
 				free(rz_list_pop(fl));
-				track = rz_str_dup(os);
+				track = rz_str_dup(str_start);
 				if (!rz_list_append(fl, track)) {
 					free(track);
 					break;
 				}
 			}
 		}
-		os = o + i + 1;
+		str_start = buf + i + 1;
 	}
 	ret = rz_cons_hud(fl, NULL);
-	free(o);
+	free(buf);
 	rz_list_free(fl);
 	return ret;
 }

--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -154,9 +154,9 @@ static char *cons_hud_help_string(const char *s) {
 			line_has_hash = true;
 		}
 		if (o[i] == '\n') {
+			o[i] = 0;
 			if (line_has_hash) {
 				line_has_hash = false;
-				o[i] = 0;
 				prev_null = &o[i];
 				if (*os) {
 					track = rz_str_dup(os);
@@ -166,9 +166,7 @@ static char *cons_hud_help_string(const char *s) {
 					}
 				}
 				prev_os = os;
-				os = o + i + 1;
 			} else {
-				o[i] = 0;
 				*prev_null = '\n';
 				prev_null = &o[i];
 				os = prev_os;
@@ -180,8 +178,8 @@ static char *cons_hud_help_string(const char *s) {
 						break;
 					}
 				}
-				os = o + i + 1;
 			}
+			os = o + i + 1;
 		}
 	}
 	ret = rz_cons_hud(fl, NULL);

--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -146,6 +146,12 @@ static char *cons_hud_help_string(const char *s) {
 		return NULL;
 	}
 	fl->free = free;
+
+	/* Reconstruct a help string list from the given string amalgamation `s`, assuming that
+	 * 1. Every command has a help string starting with '#'.
+	 * 2. The '#' is always on the first line.
+	 * It's probably better not to amalgamate the help strings in the first place, but this is a start.
+	 */
 	bool line_has_hash = false;
 	char *prev_null = NULL;
 	char *prev_os = NULL;

--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -132,7 +132,7 @@ exit_status:
 
 static char *cons_hud_help_string(const char *s) {
 	if (!rz_cons_is_interactive()) {
-		eprintf("Hud mode requires scr.interactive=true.\n");
+		RZ_LOG_ERROR("Hud mode requires scr.interactive=true.\n");
 		return NULL;
 	}
 	char *os, *track, *ret, *o = rz_str_dup(s);

--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -159,34 +159,35 @@ static char *cons_hud_help_string(const char *s) {
 		if (o[i] == '#') {
 			line_has_hash = true;
 		}
-		if (o[i] == '\n') {
-			o[i] = 0;
-			if (line_has_hash) {
-				line_has_hash = false;
-				prev_null = &o[i];
-				if (*os) {
-					track = rz_str_dup(os);
-					if (!rz_list_append(fl, track)) {
-						free(track);
-						break;
-					}
-				}
-				prev_os = os;
-			} else {
-				*prev_null = '\n';
-				prev_null = &o[i];
-				os = prev_os;
-				if (os && *os) {
-					free(rz_list_pop(fl));
-					track = rz_str_dup(os);
-					if (!rz_list_append(fl, track)) {
-						free(track);
-						break;
-					}
+		if (o[i] != '\n') {
+			continue;
+		}
+		o[i] = 0;
+		if (line_has_hash) {
+			line_has_hash = false;
+			prev_null = &o[i];
+			if (*os) {
+				track = rz_str_dup(os);
+				if (!rz_list_append(fl, track)) {
+					free(track);
+					break;
 				}
 			}
-			os = o + i + 1;
+			prev_os = os;
+		} else {
+			*prev_null = '\n';
+			prev_null = &o[i];
+			os = prev_os;
+			if (os && *os) {
+				free(rz_list_pop(fl));
+				track = rz_str_dup(os);
+				if (!rz_list_append(fl, track)) {
+					free(track);
+					break;
+				}
+			}
 		}
+		os = o + i + 1;
 	}
 	ret = rz_cons_hud(fl, NULL);
 	free(o);

--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -139,13 +139,12 @@ static char *cons_hud_help_string(const char *s) {
 	if (!o) {
 		return NULL;
 	}
-	RzList *fl = rz_list_new();
+	RzList *fl = rz_list_newf(free);
 	int i;
 	if (!fl) {
 		free(o);
 		return NULL;
 	}
-	fl->free = free;
 
 	/* Reconstruct a help string list from the given string amalgamation `s`, assuming that
 	 * 1. Every command has a help string starting with '#'.

--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -130,6 +130,66 @@ exit_status:
 	return status;
 }
 
+static char *cons_hud_help_string(const char *s) {
+	if (!rz_cons_is_interactive()) {
+		eprintf("Hud mode requires scr.interactive=true.\n");
+		return NULL;
+	}
+	char *os, *track, *ret, *o = rz_str_dup(s);
+	if (!o) {
+		return NULL;
+	}
+	RzList *fl = rz_list_new();
+	int i;
+	if (!fl) {
+		free(o);
+		return NULL;
+	}
+	fl->free = free;
+	bool line_has_hash = false;
+	char *prev_null = NULL;
+	char *prev_os = NULL;
+	for (os = o, i = 0; o[i]; i++) {
+		if (o[i] == '#') {
+			line_has_hash = true;
+		}
+		if (o[i] == '\n') {
+			if (line_has_hash) {
+				line_has_hash = false;
+				o[i] = 0;
+				prev_null = &o[i];
+				if (*os) {
+					track = rz_str_dup(os);
+					if (!rz_list_append(fl, track)) {
+						free(track);
+						break;
+					}
+				}
+				prev_os = os;
+				os = o + i + 1;
+			} else {
+				o[i] = 0;
+				*prev_null = '\n';
+				prev_null = &o[i];
+				os = prev_os;
+				if (os && *os) {
+					rz_list_pop(fl);
+					track = rz_str_dup(os);
+					if (!rz_list_append(fl, track)) {
+						free(track);
+						break;
+					}
+				}
+				os = o + i + 1;
+			}
+		}
+	}
+	ret = rz_cons_hud(fl, NULL);
+	free(o);
+	rz_list_free(fl);
+	return ret;
+}
+
 // "?**"
 RZ_IPI RzCmdStatus rz_cmd_help_search_interactive_handler(RzCore *core, int argc, const char **argv) {
 	RzHelpSearch hs = {
@@ -145,7 +205,7 @@ RZ_IPI RzCmdStatus rz_cmd_help_search_interactive_handler(RzCore *core, int argc
 	// Get all summary descriptions of commands.
 	rz_cmd_foreach_cmdname(core->rcmd, NULL, help_search_cmd_desc_summary, &hs);
 	// Run it in the hub.
-	free(rz_cons_hud_string(rz_strbuf_get(hs.sb)));
+	free(cons_hud_help_string(rz_strbuf_get(hs.sb)));
 
 	rz_strbuf_free(hs.sb);
 	return RZ_CMD_STATUS_OK;

--- a/test/db/cmd/cmd_interactive_modes
+++ b/test/db/cmd/cmd_interactive_modes
@@ -38,17 +38,17 @@ EOF
 EXPECT=<<EOF
 [?25l[0m[2J[0;0H0> |                                                                                                                   [0m[2J[0;0H0> |
  - │ !<command> [<args1> <args2> ...] # Run command via system(3) with raw output. Grepping via '~' automatically forces
-                                        use of '!!' instead.                                                            
+                                     use of '!!' instead.                                                               
    │ !!<command> [<args1> <args2> ...] # Run command via system(3) and pipe its stdout to rizin                         [?25h
 
 [?25l[0m[2J[0;0H0> |                                                                                                                   [0m[2J[0;0H0> |
  - | !<command> [<args1> <args2> ...] # Run command via system(3) with raw output. Grepping via '~' automatically forces
-                                        use of '!!' instead.                                                            
+                                     use of '!!' instead.                                                               
    | !!<command> [<args1> <args2> ...] # Run command via system(3) and pipe its stdout to rizin                         [?25h
 EOF
 RUN
 
-NAME=...
+NAME=?** entire help string on match
 FILE=--
 CMDS=<<EOF
 e scr.interactive=true
@@ -62,9 +62,9 @@ EOF
 EXPECT=<<EOF
 [?25l[0m[2J[0;0H0> |                                                                                               [0m[2J[0;0H0> |
  - │ !<command> [<args1> <args2> ...] # Run command via system(3) with raw output. Grepping via '~' 
-                                        automatically forces use of '!!' instead.                   [0;0H0> f|                                                                                               [0;0H0> f|
- -                                      automatically Forces use oF '!!' instead.                   
-   │ $[alias[=cmd] [args...]] # List all deFined aliases / DeFine alias (see %$? For help on        [?25h
+                                     automatically forces use of '!!' instead.                      [0;0H0> f|                                                                                               [0;0H0> f|
+ - │ !<command> [<args1> <args2> ...] # Run command via system(3) with raw output. Grepping via '~' 
+                                     automatically Forces use oF '!!' instead.                      [?25h
 EOF
 RUN
 

--- a/test/db/cmd/cmd_interactive_modes
+++ b/test/db/cmd/cmd_interactive_modes
@@ -48,6 +48,26 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=...
+FILE=--
+CMDS=<<EOF
+e scr.interactive=true
+e scr.utf8=true
+e scr.columns=100
+e scr.rows=3
+e scr.color=0
+< f\n; ?**
+echo
+EOF
+EXPECT=<<EOF
+[?25l[0m[2J[0;0H0> |                                                                                               [0m[2J[0;0H0> |
+ - │ !<command> [<args1> <args2> ...] # Run command via system(3) with raw output. Grepping via '~' 
+                                        automatically forces use of '!!' instead.                   [0;0H0> f|                                                                                               [0;0H0> f|
+ -                                      automatically Forces use oF '!!' instead.                   
+   │ $[alias[=cmd] [args...]] # List all deFined aliases / DeFine alias (see %$? For help on        [?25h
+EOF
+RUN
+
 NAME=?**e search
 FILE==
 CMDS=<<EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr makes `?**` show the entire help string on match, even if the match is on the wrapped part of the help string. For example with `scr.columns=100`:

Before
<img width="894" height="103" alt="ques_star_star-before-wrapped-match" src="https://github.com/user-attachments/assets/ce5debb1-789d-4753-ac81-476a14c52c5a" />

After
<img width="916" height="127" alt="ques_star_star-after-wrapped-match" src="https://github.com/user-attachments/assets/3444eccc-b010-425c-b914-8f23693f4f21" />

The alignment is off again, but fixing that isn't particularly trivial and it's not critical.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
