### PR TITLE
Enhance performance of `rz_bv_copy_nbits`

### DIFF
--- a/librz/include/rz_util/rz_bits.h
+++ b/librz/include/rz_util/rz_bits.h
@@ -136,10 +136,10 @@ static inline int rz_bits_leading_zeros(ut64 x) {
 static inline ut64 rz_bits_copy_ut64(ut64 src, ut8 src_pos, ut64 dst, ut8 dst_pos, ut8 size) {
 	if (size >= 64) {
 		return src;
-	} else {
-		ut64 mask = ((1ull) << size) - 1;
-		return (dst & ~(mask << dst_pos)) | (src >> src_pos & mask) << dst_pos;
 	}
+
+	ut64 mask = ((1ull) << size) - 1;
+	return (dst & ~(mask << dst_pos)) | (src >> src_pos & mask) << dst_pos;
 }
 
 /**
@@ -148,10 +148,10 @@ static inline ut64 rz_bits_copy_ut64(ut64 src, ut8 src_pos, ut64 dst, ut8 dst_po
 static inline ut8 rz_bits_copy_ut8(ut8 src, ut8 src_pos, ut8 dst, ut8 dst_pos, ut8 size) {
 	if (size >= 8) {
 		return src;
-	} else {
-		ut8 mask = ((1u) << size) - 1;
-		return (dst & ~(mask << dst_pos)) | (src >> src_pos & mask) << dst_pos;
 	}
+
+	ut8 mask = ((1u) << size) - 1;
+	return (dst & ~(mask << dst_pos)) | (src >> src_pos & mask) << dst_pos;
 }
 
 /**

--- a/librz/include/rz_util/rz_bits.h
+++ b/librz/include/rz_util/rz_bits.h
@@ -125,6 +125,36 @@ static inline int rz_bits_leading_zeros(ut64 x) {
 }
 
 /**
+ * \brief Copies a bit range from \p src to \p dst at specified positions
+ * \param src 64-bit unsigned integer to copy bits from
+ * \param src_pos bit position related to \p src
+ * \param dst 64-bit unsigned integer to copy bits to
+ * \param dst_pos bit position related to \p dst
+ * \param size number of bits to copy (needs to be <= 64)
+ * \return a new 64-bit unsigned integer with the specified bit range replaced
+ */
+static inline ut64 rz_bits_copy_ut64(ut64 src, ut8 src_pos, ut64 dst, ut8 dst_pos, ut8 size) {
+	if (size >= 64) {
+		return src;
+	} else {
+		ut64 mask = ((1ull) << size) - 1;
+		return (dst & ~(mask << dst_pos)) | (src >> src_pos & mask) << dst_pos;
+	}
+}
+
+/**
+ * \brief Similar to rz_bits_copy_ut64() but for 8-bit unsigned integers
+ */
+static inline ut8 rz_bits_copy_ut8(ut8 src, ut8 src_pos, ut8 dst, ut8 dst_pos, ut8 size) {
+	if (size >= 8) {
+		return src;
+	} else {
+		ut8 mask = ((1u) << size) - 1;
+		return (dst & ~(mask << dst_pos)) | (src >> src_pos & mask) << dst_pos;
+	}
+}
+
+/**
  * \brief Sign-extends a value from a specified bit-width to full width of type.
  *
  * This macro defines an inline function that performs sign extension on an

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -202,19 +202,8 @@ RZ_API ut32 rz_bv_copy(RZ_NONNULL const RzBitVector *src, RZ_NONNULL RzBitVector
 
 /**
  * \brief Optimized version of rz_bv_copy_nbits() for small bitvectors (64 or less bits)
- *
- * Copies `nbit` bits from `src_start_pos` to `dst_start_pos` using bitwise operations.
- * This function is intended for bitvectors that fit within 64 bits and performs the copy
- * in a single operation rather than bit-by-bit.
- *
- * \param src RzBitVector, data source (must be 64 or less bits)
- * \param src_start_pos ut32, start position in source bitvector of copy
- * \param dst RzBitVector, destination of copy (must be 64 or less bits)
- * \param dst_start_pos ut32, start position in destination bitvector
- * \param nbit ut32, control the size of copy (in bits)
- * \return copied_size ut32, Actual copied size
  */
-static ut32 rz_bv_copy_nbits_small(RZ_NONNULL const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
+static ut32 rz_bv_copy_nbits_small(const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
 	// Sanity check performed by caller
 	if (nbit == 64) {
 		dst->bits.small_u = src->bits.small_u;
@@ -229,23 +218,11 @@ static ut32 rz_bv_copy_nbits_small(RZ_NONNULL const RzBitVector *src, ut32 src_s
 
 /**
  * \brief Optimized version of rz_bv_copy_nbits() for large bitvectors (more than 64 bits) with aligned bit positions
- *
- * Copies `nbit` bits from `src_start_pos` to `dst_start_pos` where both positions are expected to
- * have the same bit offset within their respective bytes (not neccessarily aligned on byte boundary).
- * The function uses `memmove()`/`memcpy()` for the bulk of the data, only handling unaligned
- * start and end bits individually.
- *
- * \param src RzBitVector, data source (must be more than 64 bits)
- * \param src_start_pos ut32, start position in source bitvector of copy
- * \param dst RzBitVector, destination of copy (must be more than 64 bits)
- * \param dst_start_pos ut32, start position in destination bitvector
- * \param nbit ut32, control the size of copy (in bits)
- * \return copied_size ut32, Actual copied size
  */
-static ut32 rz_bv_copy_nbits_large_aligned(RZ_NONNULL const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
+static ut32 rz_bv_copy_nbits_large_aligned(const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
 	// Sanity check performed by caller
 	ut8 src_offset = src_start_pos % BV_ELEM_SIZE;
-	ut8 start_bits = RZ_MIN(BV_ELEM_SIZE - dst_start_pos % BV_ELEM_SIZE, nbit);
+	ut8 start_bits = RZ_MIN((BV_ELEM_SIZE - dst_start_pos) % BV_ELEM_SIZE, nbit);
 	ut8 trailing_bits = RZ_MIN((src_start_pos + nbit) % BV_ELEM_SIZE, nbit - start_bits);
 	ut32 middle_bytes = (nbit - start_bits) / BV_ELEM_SIZE;
 	ut32 src_byte = src_start_pos / BV_ELEM_SIZE;
@@ -285,19 +262,8 @@ static ut32 rz_bv_copy_nbits_large_aligned(RZ_NONNULL const RzBitVector *src, ut
 
 /**
  * \brief Optimized version of rz_bv_copy_nbits() for large bitvectors (more than 64 bits) with unaligned bit positions
- *
- * Copies `nbit` bits from `src_start_pos` to `dst_start_pos` when the positions have different bit offsets
- * within their respective bytes. The function processes bits byte-by-byte, extracting and inserting
- * partial bytes as needed to handle the misalignment.
- *
- * \param src RzBitVector, data source (must be more than 64 bits)
- * \param src_start_pos ut32, start position in source bitvector
- * \param dst RzBitVector, destination of copy (must be more than 64 bits)
- * \param dst_start_pos ut32, start position in destination bitvector
- * \param nbit ut32, control the size of copy (in bits)
- * \return copied_size ut32, Actual copied size
  */
-static ut32 rz_bv_copy_nbits_large_nonaligned(RZ_NONNULL const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
+static ut32 rz_bv_copy_nbits_large_nonaligned(const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
 	// Sanity check performed by caller
 	ut64 bits_remaining = nbit;
 

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -205,7 +205,6 @@ RZ_API ut32 rz_bv_copy(RZ_NONNULL const RzBitVector *src, RZ_NONNULL RzBitVector
  */
 static ut32 rz_bv_copy_nbits_large_aligned(const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
 	// Sanity check performed by caller
-	ut8 src_offset = src_start_pos % BV_ELEM_SIZE;
 	ut8 start_bits = RZ_MIN((BV_ELEM_SIZE - dst_start_pos) % BV_ELEM_SIZE, nbit);
 	ut8 trailing_bits = RZ_MIN((src_start_pos + nbit) % BV_ELEM_SIZE, nbit - start_bits);
 	ut32 middle_bytes = (nbit - start_bits) / BV_ELEM_SIZE;
@@ -214,6 +213,7 @@ static ut32 rz_bv_copy_nbits_large_aligned(const RzBitVector *src, ut32 src_star
 
 	// Handle starting bits
 	if (start_bits > 0) {
+		ut8 src_offset = src_start_pos % BV_ELEM_SIZE;
 		dst->bits.large_a[dst_byte] = rz_bits_copy_ut8(src->bits.large_a[src_byte], src_offset, dst->bits.large_a[dst_byte], src_offset, start_bits);
 		src_byte++;
 		dst_byte++;
@@ -249,22 +249,22 @@ static ut32 rz_bv_copy_nbits_large_nonaligned(const RzBitVector *src, ut32 src_s
 
 	while (bits_remaining > 0) {
 		ut32 src_offset = src_start_pos % BV_ELEM_SIZE;
-		ut32 src_byte_index = src_start_pos / BV_ELEM_SIZE;
+		ut32 src_byte = src_start_pos / BV_ELEM_SIZE;
 		ut32 dst_offset = dst_start_pos % BV_ELEM_SIZE;
-		ut32 dst_byte_index = dst_start_pos / BV_ELEM_SIZE;
+		ut32 dst_byte = dst_start_pos / BV_ELEM_SIZE;
 		ut8 bits_to_write = RZ_MIN(bits_remaining, BV_ELEM_SIZE - dst_offset);
 
 		ut16 buffer;
-		if (src_byte_index < dst->_elem_len - 1 && src_offset + bits_to_write > BV_ELEM_SIZE) {
+		if (src_byte < dst->_elem_len - 1 && src_offset + bits_to_write > BV_ELEM_SIZE) {
 			// If the bit subset spans across byte boundary, then read two bytes
-			buffer = src->bits.large_a[src_byte_index + 1] << BV_ELEM_SIZE | src->bits.large_a[src_byte_index];
+			buffer = src->bits.large_a[src_byte + 1] << BV_ELEM_SIZE | src->bits.large_a[src_byte];
 		} else {
 			// Otherwise 1 byte is enough
-			buffer = src->bits.large_a[src_byte_index];
+			buffer = src->bits.large_a[src_byte];
 		}
 
 		// Extract bits from the buffer
-		dst->bits.large_a[dst_byte_index] = rz_bits_copy_ut64(buffer, src_offset, dst->bits.large_a[dst_byte_index], dst_offset, bits_to_write);
+		dst->bits.large_a[dst_byte] = rz_bits_copy_ut8(buffer, src_offset, dst->bits.large_a[dst_byte], dst_offset, bits_to_write);
 
 		// Move positions
 		src_start_pos += bits_to_write;
@@ -304,7 +304,17 @@ RZ_API ut32 rz_bv_copy_nbits(RZ_NONNULL const RzBitVector *src, ut32 src_start_p
 		if (src_start_pos % BV_ELEM_SIZE == dst_start_pos % BV_ELEM_SIZE) {
 			return rz_bv_copy_nbits_large_aligned(src, src_start_pos, dst, dst_start_pos, nbit);
 		} else {
-			return rz_bv_copy_nbits_large_nonaligned(src, src_start_pos, dst, dst_start_pos, nbit);
+			if (src->bits.large_a != dst->bits.large_a) {
+				return rz_bv_copy_nbits_large_nonaligned(src, src_start_pos, dst, dst_start_pos, nbit);
+			} else {
+				// Use a temporary bitvector for same-vector copies
+				RzBitVector *temp = rz_bv_new(rz_bv_len(dst));
+				rz_bv_copy(dst, temp);
+				ut32 bits_copied = rz_bv_copy_nbits_large_nonaligned(src, src_start_pos, temp, dst_start_pos, nbit);
+				rz_bv_copy(temp, dst);
+				rz_bv_free(temp);
+				return bits_copied;
+			}
 		}
 	} else {
 		// Only one of the bitvectors is large

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -203,7 +203,7 @@ RZ_API ut32 rz_bv_copy(RZ_NONNULL const RzBitVector *src, RZ_NONNULL RzBitVector
 /**
  * \brief Optimized version of rz_bv_copy_nbits() for large bitvectors (more than 64 bits) with bit positions aligned to BV_ELEM_SIZE
  */
-static ut32 rz_bv_copy_nbits_large_aligned(const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
+static ut32 rz_bv_copy_nbits_large_aligned(const RzBitVector *src, ut32 src_start_pos, RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
 	// Sanity check performed by caller
 	ut8 start_bits = RZ_MIN((BV_ELEM_SIZE - dst_start_pos) % BV_ELEM_SIZE, nbit);
 	ut8 trailing_bits = RZ_MIN((src_start_pos + nbit) % BV_ELEM_SIZE, nbit - start_bits);
@@ -243,7 +243,7 @@ static ut32 rz_bv_copy_nbits_large_aligned(const RzBitVector *src, ut32 src_star
 /**
  * \brief Optimized version of rz_bv_copy_nbits() for large bitvectors (more than 64 bits) with unaligned bit positions
  */
-static ut32 rz_bv_copy_nbits_large_nonaligned(const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
+static ut32 rz_bv_copy_nbits_large_nonaligned(const RzBitVector *src, ut32 src_start_pos, RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
 	// Sanity check performed by caller
 	ut64 bits_remaining = nbit;
 
@@ -264,7 +264,7 @@ static ut32 rz_bv_copy_nbits_large_nonaligned(const RzBitVector *src, ut32 src_s
 		}
 
 		// Extract bits from the buffer
-		dst->bits.large_a[dst_byte] = rz_bits_copy_ut8(buffer, src_offset, dst->bits.large_a[dst_byte], dst_offset, bits_to_write);
+		dst->bits.large_a[dst_byte] = rz_bits_copy_ut64(buffer, src_offset, dst->bits.large_a[dst_byte], dst_offset, bits_to_write);
 
 		// Move positions
 		src_start_pos += bits_to_write;

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -299,30 +299,32 @@ RZ_API ut32 rz_bv_copy_nbits(RZ_NONNULL const RzBitVector *src, ut32 src_start_p
 		// Both src and dst are smaller than 64 bits
 		dst->bits.small_u = rz_bits_copy_ut64(src->bits.small_u, src_start_pos, dst->bits.small_u, dst_start_pos, nbit);
 		return nbit;
-	} else if (src->len > 64 && dst->len > 64) {
+	}
+
+	if (src->len > 64 && dst->len > 64) {
 		// Both src and dst are larger than 64 bits
 		if (src_start_pos % BV_ELEM_SIZE == dst_start_pos % BV_ELEM_SIZE) {
 			return rz_bv_copy_nbits_large_aligned(src, src_start_pos, dst, dst_start_pos, nbit);
-		} else {
-			if (src->bits.large_a != dst->bits.large_a) {
-				return rz_bv_copy_nbits_large_nonaligned(src, src_start_pos, dst, dst_start_pos, nbit);
-			}
+		}
 
-			// Use a temporary bitvector for same-vector copies
-			RzBitVector *temp = rz_bv_new(rz_bv_len(dst));
-			rz_bv_copy(dst, temp);
-			ut32 bits_copied = rz_bv_copy_nbits_large_nonaligned(src, src_start_pos, temp, dst_start_pos, nbit);
-			rz_bv_copy(temp, dst);
-			rz_bv_free(temp);
-			return bits_copied;
+		if (src->bits.large_a != dst->bits.large_a) {
+			return rz_bv_copy_nbits_large_nonaligned(src, src_start_pos, dst, dst_start_pos, nbit);
 		}
-	} else {
-		// Only one of the bitvectors is large
-		// TODO: add specialized functions for large to small and small to large bit copy
-		for (ut32 i = 0; i < nbit; ++i) {
-			bool c = rz_bv_get(src, src_start_pos + i);
-			rz_bv_set(dst, dst_start_pos + i, c);
-		}
+
+		// Use a temporary bitvector for same-vector copies
+		RzBitVector *temp = rz_bv_new(rz_bv_len(dst));
+		rz_bv_copy(dst, temp);
+		ut32 bits_copied = rz_bv_copy_nbits_large_nonaligned(src, src_start_pos, temp, dst_start_pos, nbit);
+		rz_bv_copy(temp, dst);
+		rz_bv_free(temp);
+		return bits_copied;
+	}
+
+	// Only one of the bitvectors is large
+	// TODO: add specialized functions for large to small and small to large bit copy
+	for (ut32 i = 0; i < nbit; ++i) {
+		bool c = rz_bv_get(src, src_start_pos + i);
+		rz_bv_set(dst, dst_start_pos + i, c);
 	}
 
 	return nbit;

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -201,6 +201,133 @@ RZ_API ut32 rz_bv_copy(RZ_NONNULL const RzBitVector *src, RZ_NONNULL RzBitVector
 }
 
 /**
+ * \brief Optimized version of rz_bv_copy_nbits() for small bitvectors (64 or less bits)
+ *
+ * Copies `nbit` bits from `src_start_pos` to `dst_start_pos` using bitwise operations.
+ * This function is intended for bitvectors that fit within 64 bits and performs the copy
+ * in a single operation rather than bit-by-bit.
+ *
+ * \param src RzBitVector, data source (must be 64 or less bits)
+ * \param src_start_pos ut32, start position in source bitvector of copy
+ * \param dst RzBitVector, destination of copy (must be 64 or less bits)
+ * \param dst_start_pos ut32, start position in destination bitvector
+ * \param nbit ut32, control the size of copy (in bits)
+ * \return copied_size ut32, Actual copied size
+ */
+static ut32 rz_bv_copy_nbits_small(RZ_NONNULL const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
+	// Sanity check performed by caller
+	ut64 mask = (1ull << nbit) - 1;
+	dst->bits.small_u &= ~(mask << dst_start_pos);
+	dst->bits.small_u |= ((src->bits.small_u >> src_start_pos) & mask) << dst_start_pos;
+
+	return nbit;
+}
+
+/**
+ * \brief Optimized version of rz_bv_copy_nbits() for large bitvectors (more than 64 bits) with aligned bit positions
+ *
+ * Copies `nbit` bits from `src_start_pos` to `dst_start_pos` where both positions are expected to
+ * have the same bit offset within their respective bytes (not neccessarily aligned on byte boundary).
+ * The function uses `memmove()`/`memcpy()` for the bulk of the data, only handling unaligned
+ * start and end bits individually.
+ *
+ * \param src RzBitVector, data source (must be more than 64 bits)
+ * \param src_start_pos ut32, start position in source bitvector of copy
+ * \param dst RzBitVector, destination of copy (must be more than 64 bits)
+ * \param dst_start_pos ut32, start position in destination bitvector
+ * \param nbit ut32, control the size of copy (in bits)
+ * \return copied_size ut32, Actual copied size
+ */
+static ut32 rz_bv_copy_nbits_large_aligned(RZ_NONNULL const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
+	// Sanity check performed by caller
+	ut8 src_offset = src_start_pos % BV_ELEM_SIZE;
+	ut8 start_bits = RZ_MIN((BV_ELEM_SIZE - dst_start_pos) % BV_ELEM_SIZE, nbit);
+	ut8 trailing_bits = RZ_MIN((src_start_pos + nbit) % BV_ELEM_SIZE, nbit - start_bits);
+	ut32 middle_bytes = (nbit - start_bits) / BV_ELEM_SIZE;
+	ut32 src_byte = src_start_pos / BV_ELEM_SIZE;
+	ut32 dst_byte = dst_start_pos / BV_ELEM_SIZE;
+
+	// Handle starting bits
+	if (start_bits > 0) {
+		ut8 mask = ((1u << start_bits) - 1) << src_offset;
+		dst->bits.large_a[dst_byte] &= ~mask;
+		dst->bits.large_a[dst_byte] |= src->bits.large_a[src_byte] & mask;
+		src_byte++;
+		dst_byte++;
+	}
+
+	// Handle middle bytes
+	if (middle_bytes > 0) {
+		if (src->bits.large_a == dst->bits.large_a) {
+			// Copy within the same vector
+			memmove(&dst->bits.large_a[dst_byte], &src->bits.large_a[src_byte], middle_bytes);
+		} else {
+			memcpy(&dst->bits.large_a[dst_byte], &src->bits.large_a[src_byte], middle_bytes);
+		}
+
+		src_byte += middle_bytes;
+		dst_byte += middle_bytes;
+	}
+
+	// Handle trailing bits
+	if (trailing_bits > 0) {
+		ut8 mask = (1u << trailing_bits) - 1;
+		dst->bits.large_a[dst_byte] &= ~mask;
+		dst->bits.large_a[dst_byte] |= (src->bits.large_a[src_byte] & mask);
+	}
+
+	return nbit;
+}
+
+/**
+ * \brief Optimized version of rz_bv_copy_nbits() for large bitvectors (more than 64 bits) with unaligned bit positions
+ *
+ * Copies `nbit` bits from `src_start_pos` to `dst_start_pos` when the positions have different bit offsets
+ * within their respective bytes. The function processes bits byte-by-byte, extracting and inserting
+ * partial bytes as needed to handle the misalignment.
+ *
+ * \param src RzBitVector, data source (must be more than 64 bits)
+ * \param src_start_pos ut32, start position in source bitvector
+ * \param dst RzBitVector, destination of copy (must be more than 64 bits)
+ * \param dst_start_pos ut32, start position in destination bitvector
+ * \param nbit ut32, control the size of copy (in bits)
+ * \return copied_size ut32, Actual copied size
+ */
+static ut32 rz_bv_copy_nbits_large_nonaligned(RZ_NONNULL const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
+	// Sanity check performed by caller
+	ut64 bits_remaining = nbit;
+
+	while (bits_remaining > 0) {
+		ut32 src_offset = src_start_pos % BV_ELEM_SIZE;
+		ut32 src_byte_index = src_start_pos / BV_ELEM_SIZE;
+		ut32 dst_offset = dst_start_pos % BV_ELEM_SIZE;
+		ut32 dst_byte_index = dst_start_pos / BV_ELEM_SIZE;
+		ut8 bits_to_write = RZ_MIN(bits_remaining, BV_ELEM_SIZE - dst_offset);
+
+		ut16 buffer;
+		if (src_byte_index < dst->_elem_len - 1 && src_offset + bits_to_write > BV_ELEM_SIZE) {
+			// If the bit subset spans across byte boundary, then read two bytes
+			buffer = src->bits.large_a[src_byte_index + 1] << BV_ELEM_SIZE | src->bits.large_a[src_byte_index];
+		} else {
+			// Otherwise 1 byte is enough
+			buffer = src->bits.large_a[src_byte_index];
+		}
+
+		// Extract bits from the buffer
+		ut8 extracted_bits = (buffer >> src_offset) & ((1u << bits_to_write) - 1);
+		ut8 mask = ((1u << bits_to_write) - 1) << dst_offset;
+		dst->bits.large_a[dst_byte_index] = (dst->bits.large_a[dst_byte_index] & ~mask) | (extracted_bits << dst_offset);
+
+		// Move positions
+		src_start_pos += bits_to_write;
+		dst_start_pos += bits_to_write;
+		bits_remaining -= bits_to_write;
+	}
+
+	return nbit;
+}
+
+/**
  * Copy n bits from start position of source to start position of dest, return num of copied bits
  * \param src RzBitVector, data source
  * \param src_start_pos ut32, start position in source bitvector of copy
@@ -220,10 +347,23 @@ RZ_API ut32 rz_bv_copy_nbits(RZ_NONNULL const RzBitVector *src, ut32 src_start_p
 		return 0;
 	}
 
-	// normal case here
-	for (ut32 i = 0; i < nbit; ++i) {
-		bool c = rz_bv_get(src, src_start_pos + i);
-		rz_bv_set(dst, dst_start_pos + i, c);
+	if (src->len <= 64 && dst->len <= 64) {
+		// Both src and dst are smaller than 64 bits
+		return rz_bv_copy_nbits_small(src, src_start_pos, dst, dst_start_pos, nbit);
+	} else if (src->len > 64 && dst->len > 64) {
+		// Both src and dst are larger than 64 bits
+		if (src_start_pos % BV_ELEM_SIZE == dst_start_pos % BV_ELEM_SIZE) {
+			return rz_bv_copy_nbits_large_aligned(src, src_start_pos, dst, dst_start_pos, nbit);
+		} else {
+			return rz_bv_copy_nbits_large_nonaligned(src, src_start_pos, dst, dst_start_pos, nbit);
+		}
+	} else {
+		// Only one of the bitvectors is large
+		// TODO: add specialized functions for large to small and small to large bit copy
+		for (ut32 i = 0; i < nbit; ++i) {
+			bool c = rz_bv_get(src, src_start_pos + i);
+			rz_bv_set(dst, dst_start_pos + i, c);
+		}
 	}
 
 	return nbit;

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -216,9 +216,13 @@ RZ_API ut32 rz_bv_copy(RZ_NONNULL const RzBitVector *src, RZ_NONNULL RzBitVector
  */
 static ut32 rz_bv_copy_nbits_small(RZ_NONNULL const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
 	// Sanity check performed by caller
-	ut64 mask = (1ull << nbit) - 1;
-	dst->bits.small_u &= ~(mask << dst_start_pos);
-	dst->bits.small_u |= ((src->bits.small_u >> src_start_pos) & mask) << dst_start_pos;
+	if (nbit == 64) {
+		dst->bits.small_u = src->bits.small_u;
+	} else {
+		ut64 mask = ((1ull) << nbit) - 1;
+		dst->bits.small_u &= ~(mask << dst_start_pos);
+		dst->bits.small_u |= ((src->bits.small_u >> src_start_pos) & mask) << dst_start_pos;
+	}
 
 	return nbit;
 }
@@ -241,7 +245,7 @@ static ut32 rz_bv_copy_nbits_small(RZ_NONNULL const RzBitVector *src, ut32 src_s
 static ut32 rz_bv_copy_nbits_large_aligned(RZ_NONNULL const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
 	// Sanity check performed by caller
 	ut8 src_offset = src_start_pos % BV_ELEM_SIZE;
-	ut8 start_bits = RZ_MIN((BV_ELEM_SIZE - dst_start_pos) % BV_ELEM_SIZE, nbit);
+	ut8 start_bits = RZ_MIN(BV_ELEM_SIZE - dst_start_pos % BV_ELEM_SIZE, nbit);
 	ut8 trailing_bits = RZ_MIN((src_start_pos + nbit) % BV_ELEM_SIZE, nbit - start_bits);
 	ut32 middle_bytes = (nbit - start_bits) / BV_ELEM_SIZE;
 	ut32 src_byte = src_start_pos / BV_ELEM_SIZE;
@@ -314,9 +318,9 @@ static ut32 rz_bv_copy_nbits_large_nonaligned(RZ_NONNULL const RzBitVector *src,
 		}
 
 		// Extract bits from the buffer
-		ut8 extracted_bits = (buffer >> src_offset) & ((1u << bits_to_write) - 1);
-		ut8 mask = ((1u << bits_to_write) - 1) << dst_offset;
-		dst->bits.large_a[dst_byte_index] = (dst->bits.large_a[dst_byte_index] & ~mask) | (extracted_bits << dst_offset);
+		ut8 mask = (1u << bits_to_write) - 1;
+		ut8 extracted_bits = (buffer >> src_offset) & mask;
+		dst->bits.large_a[dst_byte_index] = (dst->bits.large_a[dst_byte_index] & ~(mask << dst_offset)) | (extracted_bits << dst_offset);
 
 		// Move positions
 		src_start_pos += bits_to_write;

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -201,23 +201,7 @@ RZ_API ut32 rz_bv_copy(RZ_NONNULL const RzBitVector *src, RZ_NONNULL RzBitVector
 }
 
 /**
- * \brief Optimized version of rz_bv_copy_nbits() for small bitvectors (64 or less bits)
- */
-static ut32 rz_bv_copy_nbits_small(const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
-	// Sanity check performed by caller
-	if (nbit == 64) {
-		dst->bits.small_u = src->bits.small_u;
-	} else {
-		ut64 mask = ((1ull) << nbit) - 1;
-		dst->bits.small_u &= ~(mask << dst_start_pos);
-		dst->bits.small_u |= ((src->bits.small_u >> src_start_pos) & mask) << dst_start_pos;
-	}
-
-	return nbit;
-}
-
-/**
- * \brief Optimized version of rz_bv_copy_nbits() for large bitvectors (more than 64 bits) with aligned bit positions
+ * \brief Optimized version of rz_bv_copy_nbits() for large bitvectors (more than 64 bits) with bit positions aligned to BV_ELEM_SIZE
  */
 static ut32 rz_bv_copy_nbits_large_aligned(const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
 	// Sanity check performed by caller
@@ -230,9 +214,7 @@ static ut32 rz_bv_copy_nbits_large_aligned(const RzBitVector *src, ut32 src_star
 
 	// Handle starting bits
 	if (start_bits > 0) {
-		ut8 mask = ((1u << start_bits) - 1) << src_offset;
-		dst->bits.large_a[dst_byte] &= ~mask;
-		dst->bits.large_a[dst_byte] |= src->bits.large_a[src_byte] & mask;
+		dst->bits.large_a[dst_byte] = rz_bits_copy_ut8(src->bits.large_a[src_byte], src_offset, dst->bits.large_a[dst_byte], src_offset, start_bits);
 		src_byte++;
 		dst_byte++;
 	}
@@ -252,9 +234,7 @@ static ut32 rz_bv_copy_nbits_large_aligned(const RzBitVector *src, ut32 src_star
 
 	// Handle trailing bits
 	if (trailing_bits > 0) {
-		ut8 mask = (1u << trailing_bits) - 1;
-		dst->bits.large_a[dst_byte] &= ~mask;
-		dst->bits.large_a[dst_byte] |= (src->bits.large_a[src_byte] & mask);
+		dst->bits.large_a[dst_byte] = rz_bits_copy_ut8(src->bits.large_a[src_byte], 0, dst->bits.large_a[dst_byte], 0, trailing_bits);
 	}
 
 	return nbit;
@@ -284,9 +264,7 @@ static ut32 rz_bv_copy_nbits_large_nonaligned(const RzBitVector *src, ut32 src_s
 		}
 
 		// Extract bits from the buffer
-		ut8 mask = (1u << bits_to_write) - 1;
-		ut8 extracted_bits = (buffer >> src_offset) & mask;
-		dst->bits.large_a[dst_byte_index] = (dst->bits.large_a[dst_byte_index] & ~(mask << dst_offset)) | (extracted_bits << dst_offset);
+		dst->bits.large_a[dst_byte_index] = rz_bits_copy_ut64(buffer, src_offset, dst->bits.large_a[dst_byte_index], dst_offset, bits_to_write);
 
 		// Move positions
 		src_start_pos += bits_to_write;
@@ -319,7 +297,8 @@ RZ_API ut32 rz_bv_copy_nbits(RZ_NONNULL const RzBitVector *src, ut32 src_start_p
 
 	if (src->len <= 64 && dst->len <= 64) {
 		// Both src and dst are smaller than 64 bits
-		return rz_bv_copy_nbits_small(src, src_start_pos, dst, dst_start_pos, nbit);
+		dst->bits.small_u = rz_bits_copy_ut64(src->bits.small_u, src_start_pos, dst->bits.small_u, dst_start_pos, nbit);
+		return nbit;
 	} else if (src->len > 64 && dst->len > 64) {
 		// Both src and dst are larger than 64 bits
 		if (src_start_pos % BV_ELEM_SIZE == dst_start_pos % BV_ELEM_SIZE) {

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -306,15 +306,15 @@ RZ_API ut32 rz_bv_copy_nbits(RZ_NONNULL const RzBitVector *src, ut32 src_start_p
 		} else {
 			if (src->bits.large_a != dst->bits.large_a) {
 				return rz_bv_copy_nbits_large_nonaligned(src, src_start_pos, dst, dst_start_pos, nbit);
-			} else {
-				// Use a temporary bitvector for same-vector copies
-				RzBitVector *temp = rz_bv_new(rz_bv_len(dst));
-				rz_bv_copy(dst, temp);
-				ut32 bits_copied = rz_bv_copy_nbits_large_nonaligned(src, src_start_pos, temp, dst_start_pos, nbit);
-				rz_bv_copy(temp, dst);
-				rz_bv_free(temp);
-				return bits_copied;
 			}
+
+			// Use a temporary bitvector for same-vector copies
+			RzBitVector *temp = rz_bv_new(rz_bv_len(dst));
+			rz_bv_copy(dst, temp);
+			ut32 bits_copied = rz_bv_copy_nbits_large_nonaligned(src, src_start_pos, temp, dst_start_pos, nbit);
+			rz_bv_copy(temp, dst);
+			rz_bv_free(temp);
+			return bits_copied;
 		}
 	} else {
 		// Only one of the bitvectors is large

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -44,5 +44,6 @@ option('install_sigdb', type: 'boolean', value: false, description: 'Downloads a
 option('debugger', type: 'boolean', value: true)
 
 option('enable_tests', type: 'boolean', value: true, description: 'Build unit tests in test/unit')
+option('enable_benchmarks', type: 'boolean', value: false, description: 'Build micro-benchmarks in test/bench')
 option('enable_rz_test', type: 'boolean', value: true, description: 'Build rz-test executable for regression testing')
 option('regenerate_cmds', type: 'feature', value: 'auto', description: 'Regenerate the cmd_descs.[ch] files (requires PyYAML)')

--- a/test/bench/bench_bitvector.c
+++ b/test/bench/bench_bitvector.c
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2025 Anton Angelov <anton.angelov@protonmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include "bench_utils.h"
+#include <rz_util.h>
+
+/**
+ * \file bench_bitvector.c
+ * \brief Benchmark for `rz_bv_*` functions (currently `rz_bv_copy_nbits` only)
+ *
+ * Tests various copy scenarios to measure performance of optimized paths
+ */
+
+static void bench_bv_copy_small_60_bit(RzTable *t_out) {
+	RzBitVector *src = rz_bv_new_from_ut64(64, 0x1122334455667788ULL);
+	RzBitVector *dst = rz_bv_new_from_ut64(64, 0);
+
+	RZ_BENCH_RUN("rz_bv_copy_nbits: small to small (60 bit)", t_out, 1000000, {
+		rz_bv_copy_nbits(src, 2, dst, 2, 60);
+	});
+
+	rz_bv_free(src);
+	rz_bv_free(dst);
+}
+
+static void bench_bv_copy_large_100_bit_aligned(RzTable *t_out) {
+	RzBitVector *src = rz_bv_new_from_ut64(128, 0);
+	RzBitVector *dst = rz_bv_new_from_ut64(128, 0);
+
+	for (int i = 0; i < src->len; i++) {
+		rz_bv_set(src, i, i % 2 == 0 ? true : false);
+	}
+
+	RZ_BENCH_RUN("rz_bv_copy_nbits: large to large (100 bit) aligned", t_out, 1000000, {
+		rz_bv_copy_nbits(src, 0, dst, 0, 100);
+	});
+
+	rz_bv_free(src);
+	rz_bv_free(dst);
+}
+
+static void bench_bv_copy_large_100_bit_unaligned(RzTable *t_out) {
+	RzBitVector *src = rz_bv_new_from_ut64(128, 0);
+	RzBitVector *dst = rz_bv_new_from_ut64(128, 0);
+
+	for (int i = 0; i < src->len; i++) {
+		rz_bv_set(src, i, i % 2 == 0 ? true : false);
+	}
+
+	RZ_BENCH_RUN("rz_bv_copy_nbits: large to large (100 bit) unaligned", t_out, 1000000, {
+		rz_bv_copy_nbits(src, 2, dst, 3, 100);
+	});
+
+	rz_bv_free(src);
+	rz_bv_free(dst);
+}
+
+static void bench_bv_copy_small_to_large_60_bit(RzTable *t_out) {
+	RzBitVector *src = rz_bv_new_from_ut64(64, 0x1122334455667788ULL);
+	RzBitVector *dst = rz_bv_new_from_ut64(128, 0);
+
+	RZ_BENCH_RUN("rz_bv_copy_nbits: small to large (60 bit)", t_out, 1000000, {
+		rz_bv_copy_nbits(src, 2, dst, 3, 60);
+	});
+
+	rz_bv_free(src);
+	rz_bv_free(dst);
+}
+
+static void bench_bv_copy_large_to_small_60_bit(RzTable *t_out) {
+	RzBitVector *src = rz_bv_new_from_ut64(128, 0x1122334455667788ULL);
+	RzBitVector *dst = rz_bv_new_from_ut64(64, 0);
+
+	RZ_BENCH_RUN("rz_bv_copy_nbits: large to small (60 bit)", t_out, 1000000, {
+		rz_bv_copy_nbits(src, 2, dst, 3, 60);
+	});
+
+	rz_bv_free(src);
+	rz_bv_free(dst);
+}
+
+int main(RzTable *t_out) {
+	RzTable *t = rz_table_new();
+	rz_table_set_columnsf(t, "snnnn", "Benchmark", "Iterations", "Total time [ms]", "Average time [us/op]", "Throughput [ops/sec]");
+
+	// Micro benchmarks
+	bench_bv_copy_small_60_bit(t);
+	bench_bv_copy_large_100_bit_aligned(t);
+	bench_bv_copy_large_100_bit_unaligned(t);
+	bench_bv_copy_large_to_small_60_bit(t);
+	bench_bv_copy_small_to_large_60_bit(t);
+
+	// Print results
+	const char *out = rz_table_tostring(t);
+	printf("%s\n", out);
+
+	free(out);
+	rz_table_free(t);
+	return 0;
+}

--- a/test/bench/bench_utils.c
+++ b/test/bench/bench_utils.c
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2025 Anton Angelov <anton.angelov@protonmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include "bench_utils.h"
+#include <stdio.h>
+
+/**
+ * \brief Initialize benchmark context
+ */
+RZ_API void rz_bench_init(RZ_NONNULL RzBenchCtx *ctx, RZ_NONNULL const char *name, ut64 iterations) {
+	rz_return_if_fail(ctx && name);
+	ctx->name = name;
+	ctx->iterations = iterations;
+	ctx->start_time = 0;
+	ctx->total_time = 0;
+}
+
+/**
+ * \brief Start timing a benchmark
+ */
+RZ_API void rz_bench_start(RZ_NONNULL RzBenchCtx *ctx) {
+	rz_return_if_fail(ctx);
+	ctx->start_time = rz_time_now_mono();
+}
+
+/**
+ * \brief End timing a benchmark
+ */
+RZ_API void rz_bench_end(RZ_NONNULL RzBenchCtx *ctx) {
+	rz_return_if_fail(ctx);
+	ctx->total_time = rz_time_now_mono() - ctx->start_time;
+}
+
+/**
+ * \brief Print benchmark results
+ */
+RZ_API void rz_bench_report(RZ_NONNULL RzBenchCtx *ctx, RzTable *t) {
+	rz_return_if_fail(ctx);
+
+	double total_ms = ctx->total_time / 1000.0;
+	double avg_us = ctx->iterations != 0 ? (double)ctx->total_time / ctx->iterations : 0;
+	double ops_per_sec = ctx->total_time != 0 ? (ctx->iterations * 1000000.0) / ctx->total_time : 0;
+
+	rz_table_add_rowf(t, "sdfff", ctx->name, (int)ctx->iterations, total_ms, avg_us, ops_per_sec);
+}

--- a/test/bench/bench_utils.c
+++ b/test/bench/bench_utils.c
@@ -34,8 +34,8 @@ RZ_API void rz_bench_end(RZ_NONNULL RzBenchCtx *ctx) {
 /**
  * \brief Print benchmark results
  */
-RZ_API void rz_bench_report(RZ_NONNULL RzBenchCtx *ctx, RzTable *t) {
-	rz_return_if_fail(ctx);
+RZ_API void rz_bench_report(RZ_NONNULL RzBenchCtx *ctx, RZ_NONNULL RzTable *t) {
+	rz_return_if_fail(ctx && t);
 
 	double total_ms = ctx->total_time / 1000.0;
 	double avg_us = ctx->iterations != 0 ? (double)ctx->total_time / ctx->iterations : 0;

--- a/test/bench/bench_utils.h
+++ b/test/bench/bench_utils.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2025 Anton Angelov <anton.angelov@protonmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef BENCH_UTILS_H
+#define BENCH_UTILS_H
+
+#include <rz_types.h>
+#include <rz_util.h>
+
+typedef struct rz_bench_ctx_t {
+	const char *name;
+	ut64 iterations;
+	ut64 start_time;
+	ut64 total_time;
+} RzBenchCtx;
+
+RZ_API void rz_bench_init(RZ_NONNULL RzBenchCtx *ctx, RZ_NONNULL const char *name, ut64 iterations);
+RZ_API void rz_bench_start(RZ_NONNULL RzBenchCtx *ctx);
+RZ_API void rz_bench_end(RZ_NONNULL RzBenchCtx *ctx);
+RZ_API void rz_bench_report(RZ_NONNULL RzBenchCtx *ctx, RzTable *t);
+
+/**
+ * \brief Run a benchmark with the given code block
+ *
+ * Example usage:
+ * \code
+ * RZ_BENCH_RUN("my_function", table, 1000000, {
+ *     my_function(data);
+ * });
+ * \endcode
+ */
+#define RZ_BENCH_RUN(name, table, iterations, code) \
+	do { \
+		RzBenchCtx ctx; \
+		rz_bench_init(&ctx, name, iterations); \
+		rz_bench_start(&ctx); \
+		for (ut64 i = 0; i < iterations; i++) { \
+			code; \
+		} \
+		rz_bench_end(&ctx); \
+		rz_bench_report(&ctx, table); \
+	} while (0)
+
+#endif // BENCH_UTILS_H

--- a/test/bench/bench_utils.h
+++ b/test/bench/bench_utils.h
@@ -7,17 +7,21 @@
 #include <rz_types.h>
 #include <rz_util.h>
 
+
+/**
+ * \brief Description of the state of a micro benchmark
+ */
 typedef struct rz_bench_ctx_t {
-	const char *name;
-	ut64 iterations;
-	ut64 start_time;
-	ut64 total_time;
+	const char *name; ///< name of a micro benchmark
+	ut64 iterations; ///< number of iterations
+	ut64 start_time; ///< start time of the benchmark in microseconds
+	ut64 total_time; ///< total elapsed time of the benchmark in microseconds
 } RzBenchCtx;
 
 RZ_API void rz_bench_init(RZ_NONNULL RzBenchCtx *ctx, RZ_NONNULL const char *name, ut64 iterations);
 RZ_API void rz_bench_start(RZ_NONNULL RzBenchCtx *ctx);
 RZ_API void rz_bench_end(RZ_NONNULL RzBenchCtx *ctx);
-RZ_API void rz_bench_report(RZ_NONNULL RzBenchCtx *ctx, RzTable *t);
+RZ_API void rz_bench_report(RZ_NONNULL RzBenchCtx *ctx, RZ_NONNULL RzTable *t);
 
 /**
  * \brief Run a benchmark with the given code block

--- a/test/bench/meson.build
+++ b/test/bench/meson.build
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025
+# SPDX-License-Identifier: LGPL-3.0-only
+
+if get_option('enable_benchmarks')
+  # Build utility library for benchmarks
+  bench_utils = static_library('bench_utils',
+    'bench_utils.c',
+    include_directories: [platform_inc],
+    dependencies: [rz_util_dep],
+  )
+
+  bench_utils_dep = declare_dependency(
+    link_with: bench_utils,
+    include_directories: [include_directories('.')],
+  )
+
+  # List of benchmarks to build
+  benchmarks = [
+    'bitvector',
+  ]
+
+  # Create benchmark executables
+  foreach bench : benchmarks
+    exe = executable('bench_@0@'.format(bench),
+      'bench_@0@.c'.format(bench),
+      include_directories: [platform_inc, '.'],
+      dependencies: [
+        bench_utils_dep,
+        rz_util_dep,
+        rz_core_dep,
+      ],
+      install: false,
+      implicit_include_directories: false,
+    )
+    
+    # Register with meson test system (run with: meson test --benchmark)
+    benchmark(bench, exe, suite: 'bench', timeout: 120)
+  endforeach
+
+  message('Benchmarks enabled - build with "meson compile" and run with "meson test --benchmark"')
+endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,2 +1,6 @@
 subdir('unit')
 subdir('integration')
+
+if get_option('enable_benchmarks')
+  subdir('bench')
+endif

--- a/test/unit/test_bits.c
+++ b/test/unit/test_bits.c
@@ -59,10 +59,19 @@ bool test_rz_bits_spread(void) {
 	mu_end;
 }
 
+bool test_rz_bits_copy(void) {
+	mu_assert_eq(rz_bits_copy_ut64(0x1122334455667788, 24, 0x8877665544332211, 8, 16), 0x8877665544445511, "Incorrect bit copy");
+	mu_assert_eq(rz_bits_copy_ut64(0x1122334455667788, 0, 0x0, 1, 63), 0x22446688aaccef10, "Incorrect bit copy");
+	mu_assert_eq(rz_bits_copy_ut64(0x1122334455667788, 0, 0x8877665544332211, 0, 64), 0x1122334455667788, "Incorrect bit copy");
+
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_rz_bits_count);
 	mu_run_test(test_rz_bits_spread);
 	mu_run_test(test_rz_bits_trailing_zero);
+	mu_run_test(test_rz_bits_copy);
 
 	return tests_passed != tests_run;
 }

--- a/test/unit/test_bits.c
+++ b/test/unit/test_bits.c
@@ -63,6 +63,7 @@ bool test_rz_bits_copy(void) {
 	mu_assert_eq(rz_bits_copy_ut64(0x1122334455667788, 24, 0x8877665544332211, 8, 16), 0x8877665544445511, "Incorrect bit copy");
 	mu_assert_eq(rz_bits_copy_ut64(0x1122334455667788, 0, 0x0, 1, 63), 0x22446688aaccef10, "Incorrect bit copy");
 	mu_assert_eq(rz_bits_copy_ut64(0x1122334455667788, 0, 0x8877665544332211, 0, 64), 0x1122334455667788, "Incorrect bit copy");
+	mu_assert_eq(rz_bits_copy_ut8(0xAB, 0, 0xCD, 0, 8), 0xAB, "Incorrect bit copy");
 
 	mu_end;
 }

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -1208,6 +1208,12 @@ bool test_rz_bv_copy_nbits(void) {
 		mu_assert_eq(actual_copy, 127, "copy 127 bits");
 		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xfffffffffffffffffffffffffffffffe", "copy large aligned");
 
+		/// Copy bits within the same bitvector
+		rz_bv_set_from_ut64(b, 0xAAAABBBBCCCCDDDD);
+		actual_copy = rz_bv_copy_nbits(b, 8, b, 16, 32);
+		mu_assert_eq(actual_copy, 32, "copy 32 bits");
+		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xaaaabbccccdddddd", "copy large aligned");
+
 		rz_bv_free(a);
 		rz_bv_free(b);
 	}

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -1164,6 +1164,114 @@ bool test_rz_bv_copy_nbits(void) {
 	rz_bv_free(too_small);
 	rz_bv_free(a);
 	rz_bv_free(b);
+
+	/// copy large src to large dst with aligned offsets
+	{
+		RzBitVector *a = rz_bv_new(128);
+		RzBitVector *b = rz_bv_new_from_ut64(128, 0x0);
+
+		rz_bv_set_all(a, true);
+
+		/// copy same offset at same byte
+		rz_bv_set_all(b, false);
+		actual_copy = rz_bv_copy_nbits(a, 5, b, 5, 3);
+		mu_assert_eq(actual_copy, 3, "copy 3 bits");
+		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xe0", "copy large unaligned");
+
+		/// copy with front/end byte trailing bits, but no middle bytes
+		rz_bv_set_all(b, false);
+		actual_copy = rz_bv_copy_nbits(a, 3, b, 3, 7);
+		mu_assert_eq(actual_copy, 7, "copy 7 bits");
+		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0x3f8", "copy large aligned");
+
+		/// copy with front and end trailing bits and middle bytes
+		rz_bv_set_all(b, false);
+		actual_copy = rz_bv_copy_nbits(a, 3, b, 3, 16);
+		mu_assert_eq(actual_copy, 16, "copy 16 bits");
+		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0x7fff8", "copy large aligned");
+
+		/// copy without front/trailing bits
+		rz_bv_set_all(b, false);
+		actual_copy = rz_bv_copy_nbits(a, 8, b, 8, 32);
+		mu_assert_eq(actual_copy, 32, "copy 32 bits");
+		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xffffffff00", "copy large aligned");
+
+		/// copy 1 bit
+		rz_bv_set_all(b, false);
+		actual_copy = rz_bv_copy_nbits(a, 13, b, 13, 1);
+		mu_assert_eq(actual_copy, 1, "copy 1 bit");
+		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0x2000", "copy large aligned");
+
+		/// copy all except 1 bit
+		rz_bv_set_all(b, false);
+		actual_copy = rz_bv_copy_nbits(a, 1, b, 1, 127);
+		mu_assert_eq(actual_copy, 127, "copy 127 bits");
+		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xfffffffffffffffffffffffffffffffe", "copy large aligned");
+
+		rz_bv_free(a);
+		rz_bv_free(b);
+	}
+
+	/// copy large src to large dst with unaligned offsets
+	{
+		RzBitVector *a = rz_bv_new(128);
+		RzBitVector *b = rz_bv_new(128);
+
+		rz_bv_set_all(a, true);
+
+		/// copy different offset but same byte
+		rz_bv_set_all(b, false);
+		actual_copy = rz_bv_copy_nbits(a, 5, b, 2, 20);
+		mu_assert_eq(actual_copy, 20, "copy 20 bits");
+		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0x3ffffc", "copy large unaligned");
+
+		/// copy different offset and different byte
+		rz_bv_set_all(b, false);
+		actual_copy = rz_bv_copy_nbits(a, 10, b, 20, 10);
+		mu_assert_eq(actual_copy, 10, "copy 10 bits");
+		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0x3ff00000", "copy large unaligned");
+
+		/// copy at bit boundary
+		rz_bv_set_all(b, false);
+		actual_copy = rz_bv_copy_nbits(a, 48, b, 1, 22);
+		mu_assert_eq(actual_copy, 22, "copy 22 bits");
+		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0x7ffffe", "copy large unaligned");
+
+		/// copy 1 bit
+		rz_bv_set_all(b, false);
+		actual_copy = rz_bv_copy_nbits(a, 55, b, 13, 1);
+		mu_assert_eq(actual_copy, 1, "copy 1 bit");
+		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0x2000", "copy large unaligned");
+
+		/// copy all except 1 bit
+		rz_bv_set_all(b, false);
+		actual_copy = rz_bv_copy_nbits(a, 0, b, 1, 127);
+		mu_assert_eq(actual_copy, 127, "copy 127 bits");
+		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xfffffffffffffffffffffffffffffffe", "copy large unaligned");
+
+		rz_bv_free(a);
+		rz_bv_free(b);
+	}
+
+	/// copy small src to small dst
+	{
+		RzBitVector *a = rz_bv_new_from_ut64(64, 0x67452301);
+		RzBitVector *b = rz_bv_new_from_ut64(64, 0x0);
+		RzBitVector *c = rz_bv_new_from_ut64(32, 0x0);
+
+		actual_copy = rz_bv_copy_nbits(a, 1, b, 2, 62);
+		mu_assert_eq(actual_copy, 62, "copy 62 bits");
+		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xce8a4600", "copy 62 bits small to small");
+
+		actual_copy = rz_bv_copy_nbits(a, 0, c, 31, 1);
+		mu_assert_eq(actual_copy, 1, "copy 1 bit");
+		mu_assert_streq_free(rz_bv_as_hex_string(c, false), "0x80000000", "copy 1 bit at boundary small to small");
+
+		rz_bv_free(a);
+		rz_bv_free(b);
+		rz_bv_free(c);
+	}
+
 	mu_end;
 }
 

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -1255,6 +1255,12 @@ bool test_rz_bv_copy_nbits(void) {
 		mu_assert_eq(actual_copy, 127, "copy 127 bits");
 		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xfffffffffffffffffffffffffffffffe", "copy large unaligned");
 
+		/// Copy bits within the same bitvector
+		rz_bv_set_from_ut64(b, 0xAAAABBBBCCCCDDDD);
+		actual_copy = rz_bv_copy_nbits(b, 0, b, 2, 30);
+		mu_assert_eq(actual_copy, 30, "copy 30 bits");
+		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xaaaabbbb33337775", "copy large aligned");
+
 		rz_bv_free(a);
 		rz_bv_free(b);
 	}

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -1165,124 +1165,175 @@ bool test_rz_bv_copy_nbits(void) {
 	rz_bv_free(a);
 	rz_bv_free(b);
 
-	/// copy large src to large dst with aligned offsets
-	{
-		RzBitVector *a = rz_bv_new(128);
-		RzBitVector *b = rz_bv_new_from_ut64(128, 0x0);
+	mu_end;
+}
 
-		rz_bv_set_all(a, true);
+/**
+ * \brief Reference implementation of rz_bv_copy_nbits() to test against
+ */
+static ut32 rz_bv_copy_nbits_ref(const RzBitVector *src, ut32 src_start_pos, RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
+	rz_return_val_if_fail(src && dst, 0);
+	ut32 max_nbit = RZ_MIN((src->len - src_start_pos), (dst->len - dst_start_pos));
 
-		/// copy same offset at same byte
-		rz_bv_set_all(b, false);
-		actual_copy = rz_bv_copy_nbits(a, 5, b, 5, 3);
-		mu_assert_eq(actual_copy, 3, "copy 3 bits");
-		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xe0", "copy large unaligned");
-
-		/// copy with front/end byte trailing bits, but no middle bytes
-		rz_bv_set_all(b, false);
-		actual_copy = rz_bv_copy_nbits(a, 3, b, 3, 7);
-		mu_assert_eq(actual_copy, 7, "copy 7 bits");
-		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0x3f8", "copy large aligned");
-
-		/// copy with front and end trailing bits and middle bytes
-		rz_bv_set_all(b, false);
-		actual_copy = rz_bv_copy_nbits(a, 3, b, 3, 16);
-		mu_assert_eq(actual_copy, 16, "copy 16 bits");
-		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0x7fff8", "copy large aligned");
-
-		/// copy without front/trailing bits
-		rz_bv_set_all(b, false);
-		actual_copy = rz_bv_copy_nbits(a, 8, b, 8, 32);
-		mu_assert_eq(actual_copy, 32, "copy 32 bits");
-		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xffffffff00", "copy large aligned");
-
-		/// copy 1 bit
-		rz_bv_set_all(b, false);
-		actual_copy = rz_bv_copy_nbits(a, 13, b, 13, 1);
-		mu_assert_eq(actual_copy, 1, "copy 1 bit");
-		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0x2000", "copy large aligned");
-
-		/// copy all except 1 bit
-		rz_bv_set_all(b, false);
-		actual_copy = rz_bv_copy_nbits(a, 1, b, 1, 127);
-		mu_assert_eq(actual_copy, 127, "copy 127 bits");
-		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xfffffffffffffffffffffffffffffffe", "copy large aligned");
-
-		/// Copy bits within the same bitvector
-		rz_bv_set_from_ut64(b, 0xAAAABBBBCCCCDDDD);
-		actual_copy = rz_bv_copy_nbits(b, 8, b, 16, 32);
-		mu_assert_eq(actual_copy, 32, "copy 32 bits");
-		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xaaaabbccccdddddd", "copy large aligned");
-
-		rz_bv_free(a);
-		rz_bv_free(b);
+	// prevent overflow
+	if (max_nbit < nbit) {
+		return 0;
 	}
 
-	/// copy large src to large dst with unaligned offsets
-	{
-		RzBitVector *a = rz_bv_new(128);
-		RzBitVector *b = rz_bv_new(128);
-
-		rz_bv_set_all(a, true);
-
-		/// copy different offset but same byte
-		rz_bv_set_all(b, false);
-		actual_copy = rz_bv_copy_nbits(a, 5, b, 2, 20);
-		mu_assert_eq(actual_copy, 20, "copy 20 bits");
-		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0x3ffffc", "copy large unaligned");
-
-		/// copy different offset and different byte
-		rz_bv_set_all(b, false);
-		actual_copy = rz_bv_copy_nbits(a, 10, b, 20, 10);
-		mu_assert_eq(actual_copy, 10, "copy 10 bits");
-		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0x3ff00000", "copy large unaligned");
-
-		/// copy at bit boundary
-		rz_bv_set_all(b, false);
-		actual_copy = rz_bv_copy_nbits(a, 48, b, 1, 22);
-		mu_assert_eq(actual_copy, 22, "copy 22 bits");
-		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0x7ffffe", "copy large unaligned");
-
-		/// copy 1 bit
-		rz_bv_set_all(b, false);
-		actual_copy = rz_bv_copy_nbits(a, 55, b, 13, 1);
-		mu_assert_eq(actual_copy, 1, "copy 1 bit");
-		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0x2000", "copy large unaligned");
-
-		/// copy all except 1 bit
-		rz_bv_set_all(b, false);
-		actual_copy = rz_bv_copy_nbits(a, 0, b, 1, 127);
-		mu_assert_eq(actual_copy, 127, "copy 127 bits");
-		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xfffffffffffffffffffffffffffffffe", "copy large unaligned");
-
-		/// Copy bits within the same bitvector
-		rz_bv_set_from_ut64(b, 0xAAAABBBBCCCCDDDD);
-		actual_copy = rz_bv_copy_nbits(b, 0, b, 2, 30);
-		mu_assert_eq(actual_copy, 30, "copy 30 bits");
-		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xaaaabbbb33337775", "copy large aligned");
-
-		rz_bv_free(a);
-		rz_bv_free(b);
+	for (ut32 i = 0; i < nbit; ++i) {
+		rz_bv_set(dst, dst_start_pos + i, rz_bv_get(src, src_start_pos + i));
 	}
 
-	/// copy small src to small dst
-	{
-		RzBitVector *a = rz_bv_new_from_ut64(64, 0x67452301);
-		RzBitVector *b = rz_bv_new_from_ut64(64, 0x0);
-		RzBitVector *c = rz_bv_new_from_ut64(32, 0x0);
+	return nbit;
+}
 
-		actual_copy = rz_bv_copy_nbits(a, 1, b, 2, 62);
-		mu_assert_eq(actual_copy, 62, "copy 62 bits");
-		mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xce8a4600", "copy 62 bits small to small");
+/**
+ * \brief Performs rz_bv_copy_nbits() with actual and reference implementation and compares results
+ */
+static const char *test_rz_bv_copy_nbits_against_ref(const RzBitVector *src, ut32 src_pos, RzBitVector *dst, ut32 dst_pos, ut32 nbit) {
+	RzBitVector *src_copy = rz_bv_new(rz_bv_len(src));
+	RzBitVector *dst_copy = rz_bv_new(rz_bv_len(dst));
+	RzBitVector *dst_copy_ref = rz_bv_new(rz_bv_len(dst));
+	const char *error = NULL;
 
-		actual_copy = rz_bv_copy_nbits(a, 0, c, 31, 1);
-		mu_assert_eq(actual_copy, 1, "copy 1 bit");
-		mu_assert_streq_free(rz_bv_as_hex_string(c, false), "0x80000000", "copy 1 bit at boundary small to small");
+	rz_bv_copy(src, src_copy);
+	rz_bv_copy(dst, dst_copy);
+	rz_bv_copy(dst, dst_copy_ref);
 
-		rz_bv_free(a);
-		rz_bv_free(b);
-		rz_bv_free(c);
+	if (rz_bv_copy_nbits(src_copy, src_pos, dst_copy, dst_pos, nbit) != nbit) {
+		error = "rz_bv_copy_nbits() incorrect return";
+		goto finally;
 	}
+
+	if (rz_bv_copy_nbits_ref(src_copy, src_pos, dst_copy_ref, dst_pos, nbit) != nbit) {
+		error = "rz_bv_copy_nbits_ref() incorrect result";
+		goto finally;
+	}
+
+	if (rz_bv_cmp(dst_copy, dst_copy_ref)) {
+		error = "rz_bv_copy_nbits() result differs from reference";
+		goto finally;
+	}
+
+	// Test with inverted src/dst for extra certainty
+	rz_bv_copy(dst, dst_copy);
+	rz_bv_toggle_all(src_copy);
+	rz_bv_toggle_all(dst_copy);
+
+	if (rz_bv_copy_nbits(src_copy, src_pos, dst_copy, dst_pos, nbit) != nbit) {
+		error = "rz_bv_copy_nbits() incorrect result";
+		goto finally;
+	}
+
+	rz_bv_toggle_all(dst_copy);
+
+	if (rz_bv_cmp(dst_copy, dst_copy_ref)) {
+		error = "rz_bv_copy_nbits() result differs from reference";
+		goto finally;
+	}
+
+finally:
+	rz_bv_free(src_copy);
+	rz_bv_free(dst_copy);
+	rz_bv_free(dst_copy_ref);
+	return error;
+}
+
+bool test_rz_bv_copy_nbits_small(void) {
+	RzBitVector *a = rz_bv_new_from_ut64(64, 0x67452301);
+	RzBitVector *b = rz_bv_new_from_ut64(64, 0x0);
+	const char *error;
+
+	error = test_rz_bv_copy_nbits_against_ref(a, 1, b, 2, 62);
+	mu_assert_null(error, error);
+
+	error = test_rz_bv_copy_nbits_against_ref(a, 0, b, 63, 1);
+	mu_assert_null(error, error);
+
+	rz_bv_free(a);
+	rz_bv_free(b);
+
+	mu_end;
+}
+
+bool test_rz_bv_copy_nbits_large_aligned(void) {
+	RzBitVector *a = rz_bv_new(128);
+	RzBitVector *b = rz_bv_new_from_ut64(128, 0x0);
+	const char *error;
+
+	rz_bv_set_all(a, true);
+
+	/// copy same offset at same byte
+	error = test_rz_bv_copy_nbits_against_ref(a, 5, b, 5, 3);
+	mu_assert_null(error, error);
+
+	/// copy with front/end byte trailing bits, but no middle bytes
+	error = test_rz_bv_copy_nbits_against_ref(a, 3, b, 3, 7);
+	mu_assert_null(error, error);
+
+	/// copy with front and end trailing bits and middle bytes
+	error = test_rz_bv_copy_nbits_against_ref(a, 3, b, 3, 16);
+	mu_assert_null(error, error);
+
+	/// copy without front/trailing bits
+	error = test_rz_bv_copy_nbits_against_ref(a, 8, b, 8, 32);
+	mu_assert_null(error, error);
+
+	/// copy 1 bit
+	error = test_rz_bv_copy_nbits_against_ref(a, 13, b, 13, 1);
+	mu_assert_null(error, error);
+
+	/// copy all except 1 bit
+	error = test_rz_bv_copy_nbits_against_ref(a, 1, b, 1, 127);
+	mu_assert_null(error, error);
+
+	/// Copy bits within the same bitvector
+	rz_bv_set_from_ut64(b, 0xAAAABBBBCCCCDDDD);
+	ut32 actual_copy = rz_bv_copy_nbits(b, 8, b, 16, 32);
+	mu_assert_eq(actual_copy, 32, "copy 32 bits");
+	mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xaaaabbccccdddddd", "copy large aligned");
+
+	rz_bv_free(a);
+	rz_bv_free(b);
+
+	mu_end;
+}
+
+bool test_rz_bv_copy_nbits_large_unaligned(void) {
+	RzBitVector *a = rz_bv_new(128);
+	RzBitVector *b = rz_bv_new(128);
+	const char *error;
+
+	rz_bv_set_all(a, true);
+
+	/// copy different offset but same byte
+	error = test_rz_bv_copy_nbits_against_ref(a, 5, b, 2, 20);
+	mu_assert_null(error, error);
+
+	/// copy different offset and different byte
+	error = test_rz_bv_copy_nbits_against_ref(a, 10, b, 20, 10);
+	mu_assert_null(error, error);
+
+	/// copy at bit boundary
+	error = test_rz_bv_copy_nbits_against_ref(a, 48, b, 1, 22);
+	mu_assert_null(error, error);
+
+	/// copy 1 bit
+	error = test_rz_bv_copy_nbits_against_ref(a, 55, b, 13, 1);
+	mu_assert_null(error, error);
+
+	/// copy all except 1 bit
+	error = test_rz_bv_copy_nbits_against_ref(a, 0, b, 1, 127);
+	mu_assert_null(error, error);
+
+	/// Copy bits within the same bitvector
+	rz_bv_set_from_ut64(b, 0xAAAABBBBCCCCDDDD);
+	ut32 actual_copy = rz_bv_copy_nbits(b, 0, b, 2, 30);
+	mu_assert_eq(actual_copy, 30, "copy 30 bits");
+	mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xaaaabbbb33337775", "copy large aligned");
+
+	rz_bv_free(a);
+	rz_bv_free(b);
 
 	mu_end;
 }
@@ -1404,6 +1455,9 @@ bool all_tests() {
 	mu_run_test(test_rz_bv_set_operations);
 	mu_run_test(test_rz_bv_set_to_bytes_le);
 	mu_run_test(test_rz_bv_copy_nbits);
+	mu_run_test(test_rz_bv_copy_nbits_small);
+	mu_run_test(test_rz_bv_copy_nbits_large_aligned);
+	mu_run_test(test_rz_bv_copy_nbits_large_unaligned);
 	mu_run_test(test_rz_bv_extra_operations);
 
 	return tests_passed != tests_run;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Implemented additional functions optimized to handle specific cases of `rz_bv_copy_nbits`:

- Small (<=64 bit) to small bitvector copy
- Large (>64 bit) to large bitvector
  - Where source and target bit offsets match
  - Where source and target bit offsets are different

Not yet optimized:
 - Large to small bitvector copy
 - Small to large

This is an initial effort and there is still probably large room for other optimization iterations. Micro benchmarks added in order to measure execution time changes for different scenarios (can be deleted after PR if not needed). Current benchmarks suggest performance improvement of `~5` to `~48` times.

Before changes:
```
Benchmark                                            Iterations Total time [ms] Average time [us/op] Throughput [ops/sec] 
--------------------------------------------------------------------------------------------------------------------------
rz_bv_copy_nbits: small to small (60 bit)               1000000      362.633000             0.362633       2757608.932447
rz_bv_copy_nbits: large to large (100 bit) aligned      1000000      824.160000             0.824160       1213356.629781
rz_bv_copy_nbits: large to large (100 bit) unaligned    1000000      795.587000             0.795587       1256933.559749
rz_bv_copy_nbits: large to small (60 bit)               1000000      400.339000             0.400339       2497883.044120
rz_bv_copy_nbits: small to large (60 bit)               1000000      422.487000             0.422487       2366936.734148
```

After changes:
```
Benchmark                                            Iterations Total time [ms] Average time [us/op] Throughput [ops/sec] 
--------------------------------------------------------------------------------------------------------------------------
rz_bv_copy_nbits: small to small (60 bit)               1000000        7.427000             0.007427     134643866.971859
rz_bv_copy_nbits: large to large (100 bit) aligned      1000000       18.920000             0.018920      52854122.621564
rz_bv_copy_nbits: large to large (100 bit) unaligned    1000000      150.025000             0.150025       6665555.740710
rz_bv_copy_nbits: large to small (60 bit)               1000000      415.921000             0.415921       2404302.740184
rz_bv_copy_nbits: small to large (60 bit)               1000000      435.640000             0.435640       2295473.326600
```


AI tools used

- Claude Sonnet 4.5 for Doxygen comment drafts and benchmark boilerplate code.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Unit tests part of this PR should be able to cover all possible code paths.

Benchmark can be run via the following command line (can switch between first and last PR commits to compare):
```
meson setup build -Denable_benchmarks=true
meson test -C build bench_bitvector --benchmark
```


**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Partially closes https://github.com/rizinorg/rizin/issues/4716 (the PR doesn't cover `rz_bv_set_range`)
