### PR TITLE
rz_str_trim_tail: Declare `RZ_INOUT` on both parameter and return value

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -376,7 +376,7 @@ In Rizin code, there are some conventions to help developers use pointers more s
 ```c
 #define RZ_IN        /* do not use, implicit */
 #define RZ_OUT       /* parameter is written, not read */
-#define RZ_INOUT     /* parameter is read and written */
+#define RZ_INOUT     /* parameter is read and written / return value is copy of RZ_INOUT parameter */
 #define RZ_OWN       /* pointer ownership is transferred */
 #define RZ_BORROW    /* pointer ownership is not transferred, it must not be freed by the receiver */
 #define RZ_NONNULL   /* pointer cannot be null */

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -35,7 +35,7 @@ extern "C" {
 
 #define RZ_IN    /* do not use, implicit */
 #define RZ_OUT   /* parameter is written, not read */
-#define RZ_INOUT /* parameter is read and written */
+#define RZ_INOUT /* parameter is read and written / return value is copy of RZ_INOUT parameter */
 
 #ifdef RZ_BINDINGS
 #define RZ_OWN    __attribute__((annotate("RZ_OWN")))

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -181,7 +181,7 @@ RZ_API void rz_str_trim_head(RZ_NONNULL RZ_INOUT char *str);
 RZ_API void rz_str_trim_head_char(RZ_NONNULL RZ_INOUT char *str, const char c);
 RZ_API const char *rz_str_trim_head_ro(RZ_NONNULL const char *str);
 RZ_API const char *rz_str_trim_head_wp(RZ_NONNULL const char *str);
-RZ_API RZ_BORROW char *rz_str_trim_tail(RZ_NONNULL char *str);
+RZ_API RZ_INOUT char *rz_str_trim_tail(RZ_NONNULL RZ_INOUT char *str);
 RZ_API void rz_str_trim_tail_char(RZ_NONNULL RZ_INOUT char *str, const char c);
 RZ_API ut64 rz_str_djb2_hash(const char *str);
 RZ_API char *rz_str_trim_nc(char *str);

--- a/librz/util/str_trim.c
+++ b/librz/util/str_trim.c
@@ -126,9 +126,9 @@ RZ_API void rz_str_trim_head(RZ_NONNULL RZ_INOUT char *str) {
  * The string is changed in place.
  *
  * \param str The string to trim.
- * \return The edited string.
+ * \return The `str` pointer.
  */
-RZ_API RZ_BORROW char *rz_str_trim_tail(RZ_NONNULL char *str) {
+RZ_API RZ_INOUT char *rz_str_trim_tail(RZ_NONNULL RZ_INOUT char *str) {
 	rz_return_val_if_fail(str, NULL);
 	size_t length = strlen(str);
 	while (length-- > 0) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr declares `RZ_INOUT` on both the parameter and return value of rz_str_trim_tail(). The return value declaration of `RZ_INOUT` is to indicate that the return value is a copy of an `RZ_INOUT` pointer parameter, returning it to allow function chaining.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
