### PR TITLE
Replace dm* with dmt output in freebsd test

### DIFF
--- a/test/db/archos/freebsd-x64/dbg
+++ b/test/db/archos/freebsd-x64/dbg
@@ -63,15 +63,15 @@ FILE=bins/elf/hello-freebsd-x64
 ARGS=-d
 CMDS=<<EOF
 fl@F:maps~hello~[1-]
-dm*~hello~[0-2]
+dmt:name/cols/perms/size~hello
 EOF
 EXPECT=<<EOF
 4096 home_build_rizin_testbins_elf_hello_freebsd_x64.r
 4096 home_build_rizin_testbins_elf_hello_freebsd_x64.r_x
 4096 home_build_rizin_testbins_elf_hello_freebsd_x64.rwx
-f+ map.home_build_rizin_testbins_elf_hello_freebsd_x64.r 0x00001000
-f+ map.home_build_rizin_testbins_elf_hello_freebsd_x64.r_x 0x00001000
-f+ map.home_build_rizin_testbins_elf_hello_freebsd_x64.rwx 0x00001000
+/home/build/rizin-testbins/elf/hello-freebsd-x64 r--   4K
+/home/build/rizin-testbins/elf/hello-freebsd-x64 r-x   4K
+/home/build/rizin-testbins/elf/hello-freebsd-x64 rwx   4K
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Fixes the `dm` test on freebsd