### PR TITLE
`?***`: Fix wrapping

### DIFF
--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -57,17 +57,37 @@ static bool help_search_cmd_desc_details(RzCmd *cmd, const RzCmdDesc *cd, void *
 		return false;
 	}
 
-	char *detailed_help = rz_cmd_get_help(cmd, pa, hs->color);
-	if (!detailed_help) {
-		rz_cmd_parsed_args_free(pa);
-		return false;
-	}
-	RzList *help_lines = rz_str_split_list_regex(detailed_help, "\\n+", 0);
+	bool ret = true;
+	char *line_prefix = NULL;
+	char *detailed_help = NULL;
+	RzList *help_lines = NULL;
 
-	char *line_prefix = rz_str_newf("%s | ", cd->name);
-	if (!help_lines || !line_prefix) {
+	line_prefix = rz_str_newf("%s | ", cd->name);
+	if (!line_prefix) {
 		goto error;
 	}
+
+	int old_force_columns = 0;
+	RzCons *cons = NULL;
+	if (cmd->has_cons) {
+		cons = rz_cons_singleton();
+		old_force_columns = cons->force_columns;
+		int cons_cols = rz_cons_get_size(NULL);
+		cons->force_columns = cons_cols - (3 + strlen(line_prefix));
+	}
+	detailed_help = rz_cmd_get_help(cmd, pa, hs->color);
+	if (cmd->has_cons) {
+		cons->force_columns = old_force_columns;
+	}
+	if (!detailed_help) {
+		goto error;
+	}
+
+	help_lines = rz_str_split_list_regex(detailed_help, "\\n+", 0);
+	if (!help_lines) {
+		goto error;
+	}
+
 	while (!rz_list_empty(help_lines)) {
 		char *line = (char *)rz_list_pop_head(help_lines);
 		char *prefixed_line = rz_str_newf("%s%s", line_prefix, line);
@@ -77,18 +97,16 @@ static bool help_search_cmd_desc_details(RzCmd *cmd, const RzCmdDesc *cd, void *
 		rz_list_push(hs->detail_lines, prefixed_line);
 	}
 
-	free(detailed_help);
+beach:
 	rz_list_free(help_lines);
-	rz_cmd_parsed_args_free(pa);
+	free(detailed_help);
 	free(line_prefix);
-	return true;
+	rz_cmd_parsed_args_free(pa);
+	return ret;
 
 error:
-	free(detailed_help);
-	free(help_lines);
-	free(line_prefix);
-	rz_cmd_parsed_args_free(pa);
-	return false;
+	ret = false;
+	goto beach;
 }
 
 // "?*"

--- a/test/db/cmd/cmd_interactive_modes
+++ b/test/db/cmd/cmd_interactive_modes
@@ -116,15 +116,16 @@ CMDS=<<EOF
 e scr.interactive=true
 e scr.utf8=true
 e scr.columns=100
-e scr.rows=4
+e scr.rows=5
 e scr.color=0
 < \n; ?***
 echo
 EOF
 EXPECT=<<EOF
 [?25l[0m[2J[0;0H0> |                                                                                               [0m[2J[0;0H0> |
- - ! | Usage: !<command> [<args1> <args2> ...]   # Run command via system(3) with raw output. Greppi[0J[0m
-   ! |                                             '~' automatically forces use of '!!' instead.    
+ - ! | Usage: !<command> [<args1> <args2> ...]   # Run command via system(3) with raw output.       
+   ! |                                             Grepping via '~' automatically forces use of '!!'
+   ! |                                             instead.                                         
    ! | Examples:                                                                                    [?25h
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr fixes the help string wrapping for `?***` as exemplified below, with `scr.columns=100`:

Before:
<img width="942" height="210" alt="ques_star_star_star-before" src="https://github.com/user-attachments/assets/ce8ef0f0-df4b-4e9c-965d-97de15f052ef" />

After:
<img width="940" height="249" alt="ques_star_star_star-after" src="https://github.com/user-attachments/assets/dea67aa5-73a1-41f6-a375-4112be9adbbe" />

This is somewhat of an ugly hack and yes, information is being passed via global variable, but it works.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The changes make sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
