### PR TITLE
Add pfa and ica commands to replace removed pf* and ic* functionality

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -3854,6 +3854,55 @@ static void classdump_java(RzBinClass *c) {
 	rz_cons_printf("}\n\n");
 }
 
+RZ_API bool rz_core_bin_class_apply_to_types(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf) {
+	rz_return_val_if_fail(core && bf, false);
+
+	const RzPVector *cs = rz_bin_object_get_classes(bf->o);
+	if (!cs) {
+		return false;
+	}
+
+	RzBinClass *c;
+	void **iter;
+	RzListIter *iter2;
+	RzBinClassField *f;
+
+	// Apply classes to type database
+	rz_pvector_foreach (cs, iter) {
+		c = *iter;
+		if (!c->name) {
+			continue;
+		}
+
+		// Only handle C/C++/ObjC classes
+		if (!(bf->o->lang == RZ_BIN_LANGUAGE_C || bf->o->lang == RZ_BIN_LANGUAGE_CXX || bf->o->lang == RZ_BIN_LANGUAGE_OBJC)) {
+			continue;
+		}
+
+		// Build struct definition
+		RzStrBuf *sb = rz_strbuf_new("");
+		rz_strbuf_appendf(sb, "struct %s {", c->name);
+
+		rz_list_foreach (c->fields, iter2, f) {
+			char *n = objc_name_toc(f->name);
+			char *t = objc_type_toc(f->type);
+			rz_strbuf_appendf(sb, " %s %s;", t, n);
+			free(t);
+			free(n);
+		}
+
+		rz_strbuf_append(sb, "};");
+
+		// Apply type definition using td command
+		char *cmd = rz_str_newf("td \"%s\"", rz_strbuf_get(sb));
+		rz_core_cmd0(core, cmd);
+		free(cmd);
+		rz_strbuf_free(sb);
+	}
+
+	return true;
+}
+
 RZ_API bool rz_core_bin_class_as_source_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, const char *class_name) {
 	rz_return_val_if_fail(core && bf, false);
 

--- a/librz/core/cmd/cmd_info.c
+++ b/librz/core/cmd/cmd_info.c
@@ -378,6 +378,11 @@ RZ_IPI RzCmdStatus rz_cmd_info_classes_handler(RzCore *core, int argc, const cha
 	return bool2status(rz_core_bin_classes_print(core, bf, state));
 }
 
+RZ_IPI RzCmdStatus rz_cmd_info_class_apply_handler(RzCore *core, int argc, const char **argv) {
+	GET_CHECK_CUR_BINFILE(core);
+	return bool2status(rz_core_bin_class_apply_to_types(core, bf));
+}
+
 RZ_IPI RzCmdStatus rz_cmd_info_class_as_source_handler(RzCore *core, int argc, const char **argv) {
 	GET_CHECK_CUR_BINFILE(core);
 	return bool2status(rz_core_bin_class_as_source_print(core, bf, argv[1]));

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -6251,6 +6251,18 @@ RZ_IPI RzCmdStatus rz_cmd_print_format_named_handler(RzCore *core, int argc, con
 	return RZ_CMD_STATUS_OK;
 }
 
+RZ_IPI RzCmdStatus rz_cmd_print_format_apply_handler(RzCore *core, int argc, const char **argv) {
+	int mode = RZ_PRINT_SEEFLAGS | RZ_PRINT_MUSTSEE | RZ_PRINT_ISFIELD;
+	char *format = rz_core_print_format(core, argv[1], mode, core->offset);
+	if (!format) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+	// Execute the generated commands
+	rz_core_cmd0(core, format);
+	free(format);
+	return RZ_CMD_STATUS_OK;
+}
+
 RZ_IPI RzCmdStatus rz_cmd_print_format_c_handler(RzCore *core, int argc, const char **argv) {
 	int mode = RZ_PRINT_STRUCT;
 	return print_format(core, argv[1], mode, NULL);

--- a/librz/core/cmd_descs/cmd_info.yaml
+++ b/librz/core/cmd_descs/cmd_info.yaml
@@ -46,6 +46,10 @@ commands:
           - RZ_OUTPUT_MODE_QUIET
           - RZ_OUTPUT_MODE_QUIETEST
         args: []
+      - name: ica
+        summary: Apply classes to type database (replacement for .ic*)
+        cname: cmd_info_class_apply
+        args: []
       - name: icc
         summary: Prints class, fields and methods as source code
         cname: cmd_info_class_as_source

--- a/librz/core/cmd_descs/cmd_print.yaml
+++ b/librz/core/cmd_descs/cmd_print.yaml
@@ -484,6 +484,12 @@ commands:
         summary: Remove all named formats
         cname: cmd_print_format_delete_all
         args: []
+      - name: pfa
+        summary: Apply format string at current offset (create flags)
+        cname: cmd_print_format_apply
+        args:
+          - name: format
+            type: RZ_CMD_ARG_TYPE_STRING
       - name: pfc
         summary: Show data using given format string with C syntax
         cname: cmd_print_format_c

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -1023,6 +1023,7 @@ RZ_API bool rz_core_bin_xrefs_strings_print(RZ_NONNULL RzCore *core, RZ_NONNULL 
 RZ_API bool rz_core_file_info_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state);
 RZ_API bool rz_core_bin_info_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state);
 RZ_API bool rz_core_bin_classes_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state);
+RZ_API bool rz_core_bin_class_apply_to_types(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf);
 RZ_API bool rz_core_bin_class_as_source_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, const char *class_name);
 RZ_API bool rz_core_bin_class_fields_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state, const char *class_name);
 RZ_API bool rz_core_bin_class_methods_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state, const char *class_name);

--- a/test/db/cmd/cmd_tc
+++ b/test/db/cmd/cmd_tc
@@ -82,9 +82,8 @@ RUN
 
 NAME=tc4
 FILE=bins/mach0/objc-employee
-BROKEN=1
 CMDS=<<EOF
-.ic*
+ica
 tc Employee
 tc NSString
 EOF
@@ -111,9 +110,8 @@ RUN
 
 NAME=tc iOS14 arm64
 FILE=bins/mach0/objc-employee-ios14-arm64
-BROKEN=1
 CMDS=<<EOF
-.ic*
+ica
 tsc Employee
 tsc NSString
 EOF
@@ -209,9 +207,8 @@ RUN
 
 NAME=tc4 iOS14 arm64
 FILE=bins/mach0/objc-employee-ios14-arm64
-BROKEN=1
 CMDS=<<EOF
-.ic*
+ica
 tc Employee
 tc NSString
 EOF
@@ -238,9 +235,8 @@ RUN
 
 NAME=tc iOS14 arm64e
 FILE=bins/mach0/objc-employee-ios14-arm64e
-BROKEN=1
 CMDS=<<EOF
-.ic*
+ica
 tsc Employee
 tsc NSString
 EOF
@@ -336,9 +332,8 @@ RUN
 
 NAME=tc4 iOS14 arm64e
 FILE=bins/mach0/objc-employee-ios14-arm64e
-BROKEN=1
 CMDS=<<EOF
-.ic*
+ica
 tc Employee
 tc NSString
 EOF
@@ -387,9 +382,8 @@ RUN
 
 NAME=test cmd tsc
 FILE=bins/mach0/objc-employee
-BROKEN=1
 CMDS=<<EOF
-.ic*
+ica
 tsc Employee
 EOF
 EXPECT=<<EOF


### PR DESCRIPTION
Your checklist for this pull request
 I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.

 I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).

 -I've documented every RZ_API function and struct this PR changes.

 -I've added tests that prove my changes are effective (required for changes to RZ_API).

 -I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).

Detailed description Adds pfa and ica commands to replace removed pf and ic functionality after PR #5540.
-pfa <format>: Apply format string at current offset (replaces .pf)
-ica: Load classes into type database (replaces .ic)

Both commands execute directly in C instead of generating rizin commands. Test plan Fixed 6 broken tests in test/db/cmd/cmd_tc by replacing .ic with ica. Tests will be verified by CI. 

Closing issues Closes #5560