### PR TITLE
`?***`: Pass gutter size as parameter instead

### DIFF
--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -1082,7 +1082,7 @@ static void get_help_wrong_cmd(RzCore *core, const char *cmdname) {
 		goto cmdname_err;
 	}
 	bool use_color = core->print->flags & RZ_PRINT_FLAGS_COLOR;
-	char *help_msg = rz_cmd_get_help(core->rcmd, help_pra, use_color);
+	char *help_msg = rz_cmd_get_help(core->rcmd, help_pra, use_color, 0);
 	if (!help_msg) {
 		goto help_pra_err;
 	}
@@ -1412,7 +1412,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(help_stmt) {
 	// let's try first with the new auto-generated help, if
 	// something fails fallback to old behaviour
 	bool use_color = state->core->print->flags & RZ_PRINT_FLAGS_COLOR;
-	char *help_msg = rz_cmd_get_help(state->core->rcmd, pr_args, use_color);
+	char *help_msg = rz_cmd_get_help(state->core->rcmd, pr_args, use_color, 0);
 	if (help_msg) {
 		rz_cons_printf("%s", help_msg);
 		free(help_msg);

--- a/librz/core/cmd/cmd_api.c
+++ b/librz/core/cmd/cmd_api.c
@@ -109,7 +109,7 @@ RZ_IPI const char *rz_output_mode_to_summary(RzOutputMode mode) {
 #define NCMDS (sizeof(cmd->cmds) / sizeof(*cmd->cmds))
 RZ_LIB_VERSION(rz_cmd);
 
-static bool fill_details(RzCmd *cmd, RzCmdDesc *cd, RzStrBuf *sb, bool use_color);
+static bool fill_details(RzCmd *cmd, RzCmdDesc *cd, RzStrBuf *sb, bool use_color, int gutter_size);
 
 static int cd_sort(const void *a, const void *b, void *user) {
 	RzCmdDesc *ca = (RzCmdDesc *)a;
@@ -1006,7 +1006,7 @@ static size_t fill_args(RzStrBuf *sb, const RzCmdDesc *cd) {
 	return len;
 }
 
-static void fill_usage_strbuf(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, bool use_color) {
+static void fill_usage_strbuf(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, bool use_color, int gutter_size) {
 	const char *pal_label_color = "",
 		   *pal_args_color = "",
 		   *pal_input_color = "",
@@ -1022,7 +1022,7 @@ static void fill_usage_strbuf(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, bool use_
 		pal_reset = cons->context->pal.reset;
 	}
 
-	size_t columns = 0;
+	size_t columns = gutter_size;
 	rz_strbuf_append(sb, pal_label_color);
 	columns += strbuf_append_calc(sb, "Usage: ");
 	rz_strbuf_append(sb, pal_reset);
@@ -1132,17 +1132,18 @@ static void do_print_child_help(RzCmd *cmd, RzStrBuf *sb, const RzCmdDesc *cd, c
 	rz_strbuf_appendf(sb, "%s\n", pal_reset);
 }
 
-static void print_child_help(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, size_t max_len, const char *vertical_line, bool use_color) {
+static void print_child_help(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, size_t max_len, const char *vertical_line,
+	bool use_color, int gutter_size) {
 	do_print_child_help(cmd, sb, cd, cd->name, cd->help->summary ? cd->help->summary : "", vertical_line,
-		true, max_len, use_color, 0);
+		true, max_len, use_color, gutter_size);
 }
 
-static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
+static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color, int gutter_size) {
 	bool scr_utf8 = core_config_get_b(cmd->core, "scr.utf8");
 	bool scr_curvy = scr_utf8 && core_config_get_b(cmd->core, "scr.utf8.curvy");
 
 	RzStrBuf *sb = rz_strbuf_new(NULL);
-	fill_usage_strbuf(cmd, sb, cd, use_color);
+	fill_usage_strbuf(cmd, sb, cd, use_color, gutter_size);
 
 	void **it_cd;
 	size_t idx = 0;
@@ -1162,10 +1163,10 @@ static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
 	rz_cmd_desc_children_foreach_idx(cd, it_cd, idx) {
 		RzCmdDesc *child = *(RzCmdDesc **)it_cd;
 		const char *vertical_line = get_vertical_line(idx, n_descs, scr_curvy, scr_utf8);
-		print_child_help(cmd, sb, child, max_len, vertical_line, use_color);
+		print_child_help(cmd, sb, child, max_len, vertical_line, use_color, gutter_size);
 	}
 
-	bool details_filled = fill_details(cmd, cd, sb, use_color);
+	bool details_filled = fill_details(cmd, cd, sb, use_color, gutter_size);
 	if (!details_filled &&
 		cd->type == RZ_CMD_DESC_TYPE_GROUP &&
 		cd->d.group_data.exec_cd &&
@@ -1194,7 +1195,8 @@ static char *group_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
 	return rz_strbuf_drain(sb);
 }
 
-static void fill_argv_modes_help_strbuf(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, bool use_color) {
+static void fill_argv_modes_help_strbuf(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd, bool use_color,
+	int gutter_size) {
 	bool scr_utf8 = core_config_get_b(cmd->core, "scr.utf8");
 	const char *vertical_line = scr_utf8 ? RUNE_LINE_VERT " " : "| ";
 
@@ -1211,7 +1213,7 @@ static void fill_argv_modes_help_strbuf(RzCmd *cmd, RzStrBuf *sb, RzCmdDesc *cd,
 			char *name = rz_str_newf("%s%s", cd->name, argv_modes[i].suffix);
 			char *summary = rz_str_newf("%s%s", cd->help->summary, argv_modes[i].summary_suffix);
 			do_print_child_help(cmd, sb, cd, name, summary, vertical_line, false, max_len,
-				use_color, 0);
+				use_color, gutter_size);
 			free(name);
 			free(summary);
 		}
@@ -1239,7 +1241,9 @@ static RzCmdDescDetail *get_cd_details_cb(RzCmd *cmd, RzCmdDesc *cd) {
 	return NULL;
 }
 
-static void fill_details_do(RzCmd *cmd, const RzCmdDescDetail *detail_it, RzStrBuf *sb, bool use_color) {
+static void fill_details_do(RzCmd *cmd, const RzCmdDescDetail *detail_it, RzStrBuf *sb, bool use_color,
+	int gutter_size) {
+
 	const char *pal_help_color = "",
 		   *pal_input_color = "",
 		   *pal_label_color = "",
@@ -1284,7 +1288,7 @@ static void fill_details_do(RzCmd *cmd, const RzCmdDescDetail *detail_it, RzStrB
 				pal_args_color, arg_str,
 				padding, "",
 				pal_help_color);
-			size_t columns = strlen("| ") + strlen(entry_it->text) +
+			size_t columns = gutter_size + strlen("| ") + strlen(entry_it->text) +
 				strlen(" ") + strlen(arg_str) + padding;
 			fill_wrapped_comment(cmd, sb, entry_it->comment, columns, use_color);
 			rz_strbuf_appendf(sb, "%s\n", pal_reset);
@@ -1294,31 +1298,31 @@ static void fill_details_do(RzCmd *cmd, const RzCmdDescDetail *detail_it, RzStrB
 	}
 }
 
-static bool fill_details_static(RzCmd *cmd, RzCmdDesc *cd, RzStrBuf *sb, bool use_color) {
+static bool fill_details_static(RzCmd *cmd, RzCmdDesc *cd, RzStrBuf *sb, bool use_color, int gutter_size) {
 	const RzCmdDescDetail *detail_it = get_cd_details(cd);
 	if (!detail_it) {
 		return false;
 	}
-	fill_details_do(cmd, detail_it, sb, use_color);
+	fill_details_do(cmd, detail_it, sb, use_color, gutter_size);
 	return true;
 }
 
-static bool fill_details_cb(RzCmd *cmd, RzCmdDesc *cd, RzStrBuf *sb, bool use_color) {
+static bool fill_details_cb(RzCmd *cmd, RzCmdDesc *cd, RzStrBuf *sb, bool use_color, int gutter_size) {
 	RzCmdDescDetail *detail_it = get_cd_details_cb(cmd, cd);
 	if (!detail_it) {
 		return false;
 	}
-	fill_details_do(cmd, detail_it, sb, use_color);
+	fill_details_do(cmd, detail_it, sb, use_color, gutter_size);
 	rz_cmd_desc_details_free(detail_it);
 	return true;
 }
 
-static bool fill_details(RzCmd *cmd, RzCmdDesc *cd, RzStrBuf *sb, bool use_color) {
-	return (int)fill_details_static(cmd, cd, sb, use_color) |
-		(int)fill_details_cb(cmd, cd, sb, use_color);
+static bool fill_details(RzCmd *cmd, RzCmdDesc *cd, RzStrBuf *sb, bool use_color, int gutter_size) {
+	return (int)fill_details_static(cmd, cd, sb, use_color, gutter_size) |
+		(int)fill_details_cb(cmd, cd, sb, use_color, gutter_size);
 }
 
-static char *argv_get_help(RzCmd *cmd, RzCmdDesc *cd, size_t detail, bool use_color) {
+static char *argv_get_help(RzCmd *cmd, RzCmdDesc *cd, size_t detail, bool use_color, int gutter_size) {
 	RzStrBuf *sb = rz_strbuf_new(NULL);
 	const char *pal_reset = "";
 	if (cmd->has_cons && use_color) {
@@ -1326,10 +1330,10 @@ static char *argv_get_help(RzCmd *cmd, RzCmdDesc *cd, size_t detail, bool use_co
 		pal_reset = cons->context->pal.reset;
 	}
 
-	fill_usage_strbuf(cmd, sb, cd, use_color);
+	fill_usage_strbuf(cmd, sb, cd, use_color, gutter_size);
 
 	if (cd->type == RZ_CMD_DESC_TYPE_ARGV_MODES || cd->type == RZ_CMD_DESC_TYPE_ARGV_STATE) {
-		fill_argv_modes_help_strbuf(cmd, sb, cd, use_color);
+		fill_argv_modes_help_strbuf(cmd, sb, cd, use_color, gutter_size);
 	}
 
 	switch (detail) {
@@ -1340,7 +1344,7 @@ static char *argv_get_help(RzCmd *cmd, RzCmdDesc *cd, size_t detail, bool use_co
 			fill_colored_args(cmd, sb, cd->help->description, use_color, pal_reset);
 			rz_strbuf_append(sb, "\n");
 		}
-		fill_details(cmd, cd, sb, use_color);
+		fill_details(cmd, cd, sb, use_color, gutter_size);
 		break;
 	default:
 		rz_strbuf_free(sb);
@@ -1349,31 +1353,34 @@ static char *argv_get_help(RzCmd *cmd, RzCmdDesc *cd, size_t detail, bool use_co
 	return rz_strbuf_drain(sb);
 }
 
-static char *fake_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color) {
+static char *fake_get_help(RzCmd *cmd, RzCmdDesc *cd, bool use_color, int gutter_size) {
 	// abuse detail=2 of the argv help as they show essentially the same info
-	return argv_get_help(cmd, cd, 2, use_color);
+	return argv_get_help(cmd, cd, 2, use_color, gutter_size);
 }
 
-static char *get_help(RzCmd *cmd, RzCmdDesc *cd, const char *cmdid, RzCmdParsedArgs *args, bool use_color, size_t detail) {
+static char *get_help(RzCmd *cmd, RzCmdDesc *cd, const char *cmdid, RzCmdParsedArgs *args, bool use_color,
+	size_t detail, int gutter_size) {
+
 	switch (cd->type) {
 	case RZ_CMD_DESC_TYPE_GROUP:
 		if (cd->d.group_data.exec_cd && (detail > 1 || (detail == 1 && strcmp(cmdid, cd->name)))) {
-			return get_help(cmd, cd->d.group_data.exec_cd, cmdid, args, use_color, detail);
+			return get_help(cmd, cd->d.group_data.exec_cd, cmdid, args, use_color, detail,
+				gutter_size);
 		}
 		if (detail == 1) {
 			// show the group help only when doing <cmd>?
-			return group_get_help(cmd, cd, use_color);
+			return group_get_help(cmd, cd, use_color, gutter_size);
 		}
-		return argv_get_help(cmd, cd, detail, use_color);
+		return argv_get_help(cmd, cd, detail, use_color, gutter_size);
 	case RZ_CMD_DESC_TYPE_ARGV:
 	case RZ_CMD_DESC_TYPE_ARGV_MODES:
 	case RZ_CMD_DESC_TYPE_ARGV_STATE:
-		return argv_get_help(cmd, cd, detail, use_color);
+		return argv_get_help(cmd, cd, detail, use_color, gutter_size);
 	case RZ_CMD_DESC_TYPE_FAKE:
 		if (detail != 1) {
 			return NULL;
 		}
-		return fake_get_help(cmd, cd, use_color);
+		return fake_get_help(cmd, cd, use_color, gutter_size);
 	case RZ_CMD_DESC_TYPE_INNER:
 		rz_warn_if_reached();
 		return NULL;
@@ -1560,10 +1567,13 @@ RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_col
  * \param cmd reference to RzCmd
  * \param args reference to RzCmdParsedArgs
  * \param use_color output strings with color codes.
+ * \param gutter_size gutter size in chars
  *
  * \return returns NULL if invalid args are given, otherwise returns help message of the given args.
  */
-RZ_API RZ_OWN char *rz_cmd_get_help(RZ_BORROW RzCmd *cmd, RZ_BORROW RzCmdParsedArgs *args, bool use_color) {
+RZ_API RZ_OWN char *rz_cmd_get_help(RZ_BORROW RzCmd *cmd, RZ_BORROW RzCmdParsedArgs *args, bool use_color,
+	int gutter_size) {
+
 	char *cmdid = rz_str_dup(rz_cmd_parsed_args_cmd(args));
 	if (!cmdid) {
 		return NULL;
@@ -1587,7 +1597,7 @@ RZ_API RZ_OWN char *rz_cmd_get_help(RZ_BORROW RzCmd *cmd, RZ_BORROW RzCmdParsedA
 		goto err;
 	}
 
-	res = get_help(cmd, cd, cmdid, args, use_color, detail);
+	res = get_help(cmd, cd, cmdid, args, use_color, detail, gutter_size);
 err:
 	free(cmdid);
 	return res;

--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -57,6 +57,7 @@ static bool help_search_cmd_desc_details(RzCmd *cmd, const RzCmdDesc *cd, void *
 		return false;
 	}
 
+	const int hud_gutter_size = 3;
 	bool ret = true;
 	char *line_prefix = NULL;
 	char *detailed_help = NULL;
@@ -67,18 +68,7 @@ static bool help_search_cmd_desc_details(RzCmd *cmd, const RzCmdDesc *cd, void *
 		goto error;
 	}
 
-	int old_force_columns = 0;
-	RzCons *cons = NULL;
-	if (cmd->has_cons) {
-		cons = rz_cons_singleton();
-		old_force_columns = cons->force_columns;
-		int cons_cols = rz_cons_get_size(NULL);
-		cons->force_columns = cons_cols - (3 + strlen(line_prefix));
-	}
-	detailed_help = rz_cmd_get_help(cmd, pa, hs->color);
-	if (cmd->has_cons) {
-		cons->force_columns = old_force_columns;
-	}
+	detailed_help = rz_cmd_get_help(cmd, pa, hs->color, hud_gutter_size + strlen(line_prefix));
 	if (!detailed_help) {
 		goto error;
 	}
@@ -90,7 +80,21 @@ static bool help_search_cmd_desc_details(RzCmd *cmd, const RzCmdDesc *cd, void *
 
 	while (!rz_list_empty(help_lines)) {
 		char *line = (char *)rz_list_pop_head(help_lines);
-		char *prefixed_line = rz_str_newf("%s%s", line_prefix, line);
+		char *prefixed_line = NULL;
+		if (*line == ' ') {
+			prefixed_line = strdup(line);
+			if (strlen(prefixed_line) >= hud_gutter_size) {
+				// Currently, every line is handled separately by the hud, and this results
+				// in a hud gutter being attached to every line and increasing its length.
+				// However, wrapped lines already take the hud gutter into account and so
+				// they need to be moved backwards.
+				memmove(prefixed_line, prefixed_line + hud_gutter_size,
+					strlen(prefixed_line + hud_gutter_size) + 1);
+			}
+			memcpy(prefixed_line, line_prefix, strlen(line_prefix));
+		} else {
+			prefixed_line = rz_str_newf("%s%s", line_prefix, line);
+		}
 		if (!prefixed_line) {
 			goto error;
 		}

--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -83,13 +83,14 @@ static bool help_search_cmd_desc_details(RzCmd *cmd, const RzCmdDesc *cd, void *
 		char *prefixed_line = NULL;
 		if (*line == ' ') {
 			prefixed_line = strdup(line);
-			if (strlen(prefixed_line) >= hud_gutter_size) {
+			size_t prefixed_line_len = strlen(prefixed_line) + 1;
+			if (prefixed_line_len >= hud_gutter_size) {
 				// Currently, every line is handled separately by the hud, and this results
 				// in a hud gutter being attached to every line and increasing its length.
 				// However, wrapped lines already take the hud gutter into account and so
 				// they need to be moved backwards.
 				memmove(prefixed_line, prefixed_line + hud_gutter_size,
-					strlen(prefixed_line + hud_gutter_size) + 1);
+					prefixed_line_len - hud_gutter_size);
 			}
 			memcpy(prefixed_line, line_prefix, strlen(line_prefix));
 		} else {

--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -86,13 +86,14 @@ static bool help_search_cmd_desc_details(RzCmd *cmd, const RzCmdDesc *cd, void *
 			if (!prefixed_line) {
 				goto error;
 			}
-			if (strlen(prefixed_line) >= hud_gutter_size) {
+			size_t prefixed_line_len = strlen(prefixed_line);
+			if (prefixed_line_len >= hud_gutter_size) {
 				// Currently, every line is handled separately by the hud, and this results
 				// in a hud gutter being attached to every line and increasing its length.
 				// However, wrapped lines already take the hud gutter into account and so
 				// they need to be moved backwards.
 				memmove(prefixed_line, prefixed_line + hud_gutter_size,
-					strlen(prefixed_line + hud_gutter_size) + 1);
+					prefixed_line_len - hud_gutter_size + 1);
 			}
 			memcpy(prefixed_line, line_prefix, strlen(line_prefix));
 		} else {

--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -83,6 +83,9 @@ static bool help_search_cmd_desc_details(RzCmd *cmd, const RzCmdDesc *cd, void *
 		char *prefixed_line = NULL;
 		if (*line == ' ') {
 			prefixed_line = strdup(line);
+			if (!prefixed_line) {
+				goto error;
+			}
 			if (strlen(prefixed_line) >= hud_gutter_size) {
 				// Currently, every line is handled separately by the hud, and this results
 				// in a hud gutter being attached to every line and increasing its length.
@@ -94,9 +97,9 @@ static bool help_search_cmd_desc_details(RzCmd *cmd, const RzCmdDesc *cd, void *
 			memcpy(prefixed_line, line_prefix, strlen(line_prefix));
 		} else {
 			prefixed_line = rz_str_newf("%s%s", line_prefix, line);
-		}
-		if (!prefixed_line) {
-			goto error;
+			if (!prefixed_line) {
+				goto error;
+			}
 		}
 		rz_list_push(hs->detail_lines, prefixed_line);
 	}

--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -83,14 +83,13 @@ static bool help_search_cmd_desc_details(RzCmd *cmd, const RzCmdDesc *cd, void *
 		char *prefixed_line = NULL;
 		if (*line == ' ') {
 			prefixed_line = strdup(line);
-			size_t prefixed_line_len = strlen(prefixed_line) + 1;
-			if (prefixed_line_len >= hud_gutter_size) {
+			if (strlen(prefixed_line) >= hud_gutter_size) {
 				// Currently, every line is handled separately by the hud, and this results
 				// in a hud gutter being attached to every line and increasing its length.
 				// However, wrapped lines already take the hud gutter into account and so
 				// they need to be moved backwards.
 				memmove(prefixed_line, prefixed_line + hud_gutter_size,
-					prefixed_line_len - hud_gutter_size);
+					strlen(prefixed_line + hud_gutter_size) + 1);
 			}
 			memcpy(prefixed_line, line_prefix, strlen(line_prefix));
 		} else {

--- a/librz/include/rz_cmd.h
+++ b/librz/include/rz_cmd.h
@@ -512,7 +512,7 @@ RZ_API RzCmdStatus rz_cmd_call_parsed_args(RzCmd *cmd, RzCmdParsedArgs *args);
 RZ_API RzCmdDesc *rz_cmd_get_root(RzCmd *cmd);
 RZ_API RzCmdDesc *rz_cmd_get_desc(RzCmd *cmd, const char *cmd_identifier);
 RZ_API RzCmdDesc *rz_cmd_get_desc_best(RzCmd *cmd, const char *cmd_identifier);
-RZ_API RZ_OWN char *rz_cmd_get_help(RZ_BORROW RzCmd *cmd, RZ_BORROW RzCmdParsedArgs *args, bool use_color);
+RZ_API RZ_OWN char *rz_cmd_get_help(RZ_BORROW RzCmd *cmd, RZ_BORROW RzCmdParsedArgs *args, bool use_color, int gutter_size);
 RZ_API bool rz_cmd_get_help_json(RzCmd *cmd, const RzCmdDesc *cd, PJ *j);
 RZ_API bool rz_cmd_get_help_strbuf(RzCmd *cmd, const RzCmdDesc *cd, bool use_color, RzStrBuf *sb, int gutter_size);
 

--- a/test/db/cmd/cmd_interactive_modes
+++ b/test/db/cmd/cmd_interactive_modes
@@ -116,9 +116,9 @@ CMDS=<<EOF
 e scr.interactive=true
 e scr.utf8=true
 e scr.columns=100
-e scr.rows=5
+e scr.rows=6
 e scr.color=0
-< \n; ?***
+< %l\n; ?***
 echo
 EOF
 EXPECT=<<EOF
@@ -126,6 +126,17 @@ EXPECT=<<EOF
  - ! | Usage: !<command> [<args1> <args2> ...]   # Run command via system(3) with raw output.       
    ! |                                             Grepping via '~' automatically forces use of '!!'
    ! |                                             instead.                                         
-   ! | Examples:                                                                                    [?25h
+   ! | Examples:                                                                                    
+   ! | | !ls                     # Execute the 'ls' command via system(3)                           [0;0H0> %|                                                                                               [0;0H0> %|
+ - $ | Usage: $[alias[=cmd] [args...]]   # List all defined aliases / Define alias (see %$? for help
+   % | Usage: %[j] <expr>   # Evaluate numerical expression <expr>                                  
+   % | │ % <expr>     # Evaluate numerical expression <expr>                                        
+   % | │ %j <expr>    # Evaluate numerical expression <expr> (JSON mode)                            
+   %j | Usage: %j[j] <expr>   # Evaluate numerical expression <expr> (JSON mode)                    [0;0H0> %l|                                                                                              [0;0H0> %l|
+ - %L | Usage: %L[q] <str>   # Calculate length of string <str>. Quiet mode stores value in `$?`    
+   %L |                        register.                                                            
+   %L | │ %L <str>     # Calculate length of string <str>. Quiet mode stores value in `$?` register.
+   %L | │ %Lq <str>    # Calculate length of string <str>. Quiet mode stores value in `$?` register.
+   %L |                  (quiet mode)                                                               [?25h
 EOF
 RUN

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -159,13 +159,13 @@ bool test_cmd_descriptor_group(void) {
 	mu_assert_null(rz_cmd_get_desc(cmd, "afjb"), "nothing should be found for non-existing cmd");
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("a??");
-	char *h = rz_cmd_get_help(cmd, pa, false);
+	char *h = rz_cmd_get_help(cmd, pa, false, 0);
 	mu_assert_streq(h, "Usage: a   # a exec help\n", "detailed help for a is a_exec_help");
 	rz_cmd_parsed_args_free(pa);
 	free(h);
 
 	pa = rz_cmd_parsed_args_newcmd("a?");
-	h = rz_cmd_get_help(cmd, pa, false);
+	h = rz_cmd_get_help(cmd, pa, false, 0);
 	const char *exp_h = "Usage: a[b]   # a group help\n"
 			    "| a  # a exec help\n"
 			    "| ab # ab help\n";
@@ -350,7 +350,7 @@ bool test_cmd_help(void) {
 				 "| pd <num>                 # pd summary\n"
 				 "| px <verylongarg_str_num> # px summary\n";
 	RzCmdParsedArgs *a = rz_cmd_parsed_args_newcmd("p?");
-	char *h = rz_cmd_get_help(cmd, a, false);
+	char *h = rz_cmd_get_help(cmd, a, false, 0);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, p_help_exp, "wrong help for p?");
 	free(h);
@@ -363,14 +363,14 @@ bool test_cmd_help(void) {
 				       "Examples:\n"
 				       "| pd 10 # print 10 disassembled instructions\n";
 	a = rz_cmd_parsed_args_newcmd("pd??");
-	h = rz_cmd_get_help(cmd, a, false);
+	h = rz_cmd_get_help(cmd, a, false, 0);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, pd_long_help_exp, "wrong help for pd??");
 	free(h);
 	rz_cmd_parsed_args_free(a);
 
 	a = rz_cmd_parsed_args_newcmd("pd?");
-	h = rz_cmd_get_help(cmd, a, false);
+	h = rz_cmd_get_help(cmd, a, false, 0);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, pd_long_help_exp, "wrong help for pd?");
 	free(h);
@@ -415,7 +415,7 @@ bool test_cmd_group_help(void) {
 				 "| p        # p summary\n"
 				 "| pd <num> # pd summary\n";
 	RzCmdParsedArgs *a = rz_cmd_parsed_args_newcmd("p?");
-	char *h = rz_cmd_get_help(cmd, a, false);
+	char *h = rz_cmd_get_help(cmd, a, false, 0);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, p_help_exp, "wrong help for p?");
 	free(h);
@@ -460,7 +460,7 @@ bool test_cmd_group_exec_help(void) {
 				       "| p        # p summary\n"
 				       "| pd <num> # pd summary\n";
 	RzCmdParsedArgs *a = rz_cmd_parsed_args_newcmd("p?");
-	char *h = rz_cmd_get_help(cmd, a, false);
+	char *h = rz_cmd_get_help(cmd, a, false, 0);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, p_group_help_exp, "wrong help for p?");
 	free(h);
@@ -470,7 +470,7 @@ bool test_cmd_group_exec_help(void) {
 				 "\n"
 				 "This is p-command description\n";
 	a = rz_cmd_parsed_args_newcmd("p??");
-	h = rz_cmd_get_help(cmd, a, false);
+	h = rz_cmd_get_help(cmd, a, false, 0);
 	mu_assert_notnull(h, "help is not null");
 	mu_assert_streq(h, p_help_exp, "wrong help for p??");
 	free(h);
@@ -480,10 +480,10 @@ bool test_cmd_group_exec_help(void) {
 				  "\n"
 				  "pd long description\n";
 	a = rz_cmd_parsed_args_newcmd("pd?");
-	char *h1 = rz_cmd_get_help(cmd, a, false);
+	char *h1 = rz_cmd_get_help(cmd, a, false, 0);
 	rz_cmd_parsed_args_free(a);
 	a = rz_cmd_parsed_args_newcmd("pd??");
-	char *h2 = rz_cmd_get_help(cmd, a, false);
+	char *h2 = rz_cmd_get_help(cmd, a, false, 0);
 	rz_cmd_parsed_args_free(a);
 	mu_assert_streq(h1, h2, "pd? should be the same as pd?? because it is a terminal command");
 	mu_assert_streq(h1, pd_help_exp, "pd?/pd?? should print full help");
@@ -540,7 +540,7 @@ bool test_cmd_args(void) {
 	mu_assert_ptreq(rz_cmd_get_desc(cmd, "x"), x_cd, "x is found");
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("x??");
-	char *h = rz_cmd_get_help(cmd, pa, false);
+	char *h = rz_cmd_get_help(cmd, pa, false, 0);
 	mu_assert_streq(h, "Usage: x <c> [<from> <to> [<n>=5]]   # x summary\n", "arguments are considered");
 	rz_cmd_parsed_args_free(pa);
 	free(h);
@@ -570,7 +570,7 @@ bool test_cmd_argv_modes(void) {
 	mu_assert_null(rz_cmd_get_desc(cmd, "z*"), "z* was not defined");
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("?");
-	char *h = rz_cmd_get_help(cmd, pa, false);
+	char *h = rz_cmd_get_help(cmd, pa, false, 0);
 	char *exp_h = "Usage: [.][times][cmd][~grep][@[@iter]addr][|>pipe] ; ...\n"
 		      "| z[jqJ] # z summary\n";
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the help");
@@ -583,13 +583,13 @@ bool test_cmd_argv_modes(void) {
 		"| zq      # z summary (quiet mode)\n"
 		"| zJ      # z summary (verbose JSON mode)\n";
 	pa = rz_cmd_parsed_args_newcmd("z?");
-	h = rz_cmd_get_help(cmd, pa, false);
+	h = rz_cmd_get_help(cmd, pa, false, 0);
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the sub help");
 	free(h);
 	rz_cmd_parsed_args_free(pa);
 
 	pa = rz_cmd_parsed_args_newcmd("z??");
-	h = rz_cmd_get_help(cmd, pa, false);
+	h = rz_cmd_get_help(cmd, pa, false, 0);
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the sub help");
 	free(h);
 	rz_cmd_parsed_args_free(pa);
@@ -625,7 +625,7 @@ bool test_cmd_argv_state(void) {
 	mu_assert_null(rz_cmd_get_desc(cmd, "z*"), "z* was not defined");
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("?");
-	char *h = rz_cmd_get_help(cmd, pa, false);
+	char *h = rz_cmd_get_help(cmd, pa, false, 0);
 	char *exp_h = "Usage: [.][times][cmd][~grep][@[@iter]addr][|>pipe] ; ...\n"
 		      "| z[jqJ] # group summary\n";
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the help");
@@ -633,7 +633,7 @@ bool test_cmd_argv_state(void) {
 	rz_cmd_parsed_args_free(pa);
 
 	pa = rz_cmd_parsed_args_newcmd("z?");
-	h = rz_cmd_get_help(cmd, pa, false);
+	h = rz_cmd_get_help(cmd, pa, false, 0);
 	exp_h = "Usage: z[jqJ]   # group summary\n"
 		"| z[jqJ] # z summary\n";
 	mu_assert_streq(h, exp_h, "zj, zJ and zq are considered in the sub help");
@@ -673,7 +673,7 @@ bool test_cmd_group_argv_modes(void) {
 	mu_assert_ptreq(rz_cmd_get_desc(cmd, "zd"), zd_cd, "zd is handled by zd");
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_newcmd("?");
-	char *h = rz_cmd_get_help(cmd, pa, false);
+	char *h = rz_cmd_get_help(cmd, pa, false, 0);
 	char *exp_h = "Usage: [.][times][cmd][~grep][@[@iter]addr][|>pipe] ; ...\n"
 		      "| z[jqd] # z group summary\n";
 	mu_assert_streq(h, exp_h, "zd is considered in the help");
@@ -681,7 +681,7 @@ bool test_cmd_group_argv_modes(void) {
 	rz_cmd_parsed_args_free(pa);
 
 	pa = rz_cmd_parsed_args_newcmd("z?");
-	h = rz_cmd_get_help(cmd, pa, false);
+	h = rz_cmd_get_help(cmd, pa, false, 0);
 	exp_h = "Usage: z[jqd]   # z group summary\n"
 		"| z[jq] # z summary\n"
 		"| zd    # fake help\n";
@@ -965,7 +965,7 @@ bool test_parent_details(void) {
 	rz_cmd_desc_argv_new(cmd, z_cd, "zx", x_array_handler, &zx_help);
 
 	RzCmdParsedArgs *args = rz_cmd_parsed_args_new("zx??", 0, NULL);
-	char *h = rz_cmd_get_help(cmd, args, false);
+	char *h = rz_cmd_get_help(cmd, args, false, 0);
 	mu_assert_strcontains(h, "Examples", "zx help should include examples from parent z");
 	mu_assert_strcontains(h, "comment", "zx help should include examples from parent z");
 	free(h);
@@ -1239,7 +1239,7 @@ bool test_default_mode(void) {
 	rz_cmd_parsed_args_free(pa);
 
 	pa = rz_cmd_parsed_args_new("x?", 0, NULL);
-	char *h = rz_cmd_get_help(cmd, pa, false);
+	char *h = rz_cmd_get_help(cmd, pa, false, 0);
 	mu_assert_strcontains(h, "x[jqJ]   # x summary (JSON mode)", "x help should contain the default=json mode");
 	mu_assert_strcontains(h, "xj      # x summary (JSON mode)", "x help should contain the json mode");
 	mu_assert_strcontains(h, "xq      # x summary (quiet mode)", "x help should contain the quiet mode");
@@ -1276,7 +1276,7 @@ bool test_details_cb(void) {
 	rz_cmd_desc_argv_modes_new(cmd, root, "z", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_LONG_JSON, z_modes_handler, &z_help);
 
 	RzCmdParsedArgs *pa = rz_cmd_parsed_args_new("z?", 0, NULL);
-	char *h = rz_cmd_get_help(cmd, pa, false);
+	char *h = rz_cmd_get_help(cmd, pa, false, 0);
 	mu_assert_strcontains(h, "# dynamically generated detail", "z help should contain result of the details_cb");
 	mu_assert_strcontains(h, "Examples 2", "z help should contain result of the details_cb 2");
 	free(h);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr makes `?***` pass the gutter size as a parameter rather than through the RzCons singleton. This took longer than I thought. Basically, the gutter size needs to extend its influence to every call of fill_wrapped_comment().

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The changes make sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
