### PR TITLE
Use `arg_str` instead with some search cmds' detailed help

### DIFF
--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -1797,7 +1797,7 @@ static const RzCmdDescHelp cmd_search_collision_help = {
 };
 
 static const RzCmdDescDetailEntry cmd_search_hash_block_Usage_space_example_detail_entries[] = {
-	{ .text = "/ch md5 0bc8f8c426b74ffaedac8330a7464014 512", .arg_str = NULL, .comment = "MD5 hash search within blocks of 512 bytes." },
+	{ .text = "/ch", .arg_str = " md5 0bc8f8c426b74ffaedac8330a7464014 512", .comment = "MD5 hash search within blocks of 512 bytes." },
 	{ 0 },
 };
 
@@ -1837,7 +1837,7 @@ static const RzCmdDescHelp cmd_search_hash_block_help = {
 };
 
 static const RzCmdDescDetailEntry cmd_search_hash_entropy_Usage_space_example_detail_entries[] = {
-	{ .text = "/ce 2.5 7.4 512", .arg_str = NULL, .comment = "Find 512 byte long blocks with an entropy between 2.5 and 7.4 (inclusive min & max)." },
+	{ .text = "/ce", .arg_str = " 2.5 7.4 512", .comment = "Find 512 byte long blocks with an entropy between 2.5 and 7.4 (inclusive min & max)." },
 	{ 0 },
 };
 static const RzCmdDescDetail cmd_search_hash_entropy_details[] = {
@@ -1871,7 +1871,7 @@ static const RzCmdDescHelp cmd_search_hash_entropy_help = {
 };
 
 static const RzCmdDescDetailEntry cmd_search_hash_entropy_fractional_Usage_space_example_detail_entries[] = {
-	{ .text = "/cef 0.3 0.8 512", .arg_str = NULL, .comment = "Find 512 byte long blocks with a fractional entropy between 0.3 and 0.8 (inclusive min & max)." },
+	{ .text = "/cef", .arg_str = " 0.3 0.8 512", .comment = "Find 512 byte long blocks with a fractional entropy between 0.3 and 0.8 (inclusive min & max)." },
 	{ 0 },
 };
 static const RzCmdDescDetail cmd_search_hash_entropy_fractional_details[] = {
@@ -2293,10 +2293,10 @@ static const RzCmdDescDetailEntry cmd_search_value_Arguments_detail_entries[] = 
 };
 
 static const RzCmdDescDetailEntry cmd_search_value_Usage_space_example_detail_entries[] = {
-	{ .text = "/v 4be 512", .arg_str = NULL, .comment = "Search 512 represented in 4 bytes big endian order." },
-	{ .text = "/v 8le \"[0x80000000,0x80001000]\"", .arg_str = NULL, .comment = "Search values in the closed range '[0x80000000,0x80001000]' represented in 8 bytes little endian order." },
-	{ .text = "/v 2a \"(0x1000,0xff0)\"", .arg_str = NULL, .comment = "Search values in the open range '(0x1000,0xff0)' represented in 2 bytes order of cfg.bigendian." },
-	{ .text = "/v 1 \"[0x20,0x10)\", 0x55, \"[0xf0,0xff]\"", .arg_str = NULL, .comment = "Search values in the right open range '[0x20,0x10)', value '0x55' and closed range values '[0xf0,0xff]' represented in 1 byte." },
+	{ .text = "/v", .arg_str = " 4be 512", .comment = "Search 512 represented in 4 bytes big endian order." },
+	{ .text = "/v", .arg_str = " 8le \"[0x80000000,0x80001000]\"", .comment = "Search values in the closed range '[0x80000000,0x80001000]' represented in 8 bytes little endian order." },
+	{ .text = "/v", .arg_str = " 2a \"(0x1000,0xff0)\"", .comment = "Search values in the open range '(0x1000,0xff0)' represented in 2 bytes order of cfg.bigendian." },
+	{ .text = "/v", .arg_str = " 1 \"[0x20,0x10)\", 0x55, \"[0xf0,0xff]\"", .comment = "Search values in the right open range '[0x20,0x10)', value '0x55' and closed range values '[0xf0,0xff]' represented in 1 byte." },
 	{ 0 },
 };
 static const RzCmdDescDetail cmd_search_value_details[] = {
@@ -2533,10 +2533,10 @@ static const RzCmdDescDetailEntry slash_z_Regex_space_Flags_detail_entries[] = {
 };
 
 static const RzCmdDescDetailEntry slash_z_Examples_detail_entries[] = {
-	{ .text = "/z (ABC*)", .arg_str = NULL, .comment = "Search the exact string \"(ABC*)\"." },
-	{ .text = "/z (ABC*)D li", .arg_str = NULL, .comment = "Search the exact string \"(ABC*)D\" but case insensitive." },
-	{ .text = "/z \\\\d\\\\sC*\\\\w ri", .arg_str = NULL, .comment = "Search the regular expression \"\\d\\sC*\\w\" but case insensitive." },
-	{ .text = "/z \"и.{3}м\" ei", .arg_str = NULL, .comment = "Search the extended regular expression \"и.{3}м\" but case insensitive." },
+	{ .text = "/z", .arg_str = " (ABC*)", .comment = "Search the exact string \"(ABC*)\"." },
+	{ .text = "/z", .arg_str = " (ABC*)D li", .comment = "Search the exact string \"(ABC*)D\" but case insensitive." },
+	{ .text = "/z", .arg_str = " \\\\d\\\\sC*\\\\w ri", .comment = "Search the regular expression \"\\d\\sC*\\w\" but case insensitive." },
+	{ .text = "/z", .arg_str = " \"и.{3}м\" ei", .comment = "Search the extended regular expression \"и.{3}м\" but case insensitive." },
 	{ 0 },
 };
 static const RzCmdDescDetail slash_z_details[] = {

--- a/librz/core/cmd_descs/cmd_search.yaml
+++ b/librz/core/cmd_descs/cmd_search.yaml
@@ -243,7 +243,8 @@ commands:
       details:
         - name: Usage example
           entries:
-            - text: "/ch md5 0bc8f8c426b74ffaedac8330a7464014 512"
+            - text: "/ch"
+              arg_str: " md5 0bc8f8c426b74ffaedac8330a7464014 512"
               comment: "MD5 hash search within blocks of 512 bytes."
         - name: Tip
           entries:
@@ -272,7 +273,8 @@ commands:
       details:
         - name: Usage example
           entries:
-            - text: /ce 2.5 7.4 512
+            - text: "/ce"
+              arg_str: " 2.5 7.4 512"
               comment: "Find 512 byte long blocks with an entropy between 2.5 and 7.4 (inclusive min & max)."
     - name: "/cef"
       summary: "Search for blocks above an fractional entropy level."
@@ -295,7 +297,8 @@ commands:
       details:
         - name: Usage example
           entries:
-            - text: /cef 0.3 0.8 512
+            - text: "/cef"
+              arg_str: " 0.3 0.8 512"
               comment: "Find 512 byte long blocks with a fractional entropy between 0.3 and 0.8 (inclusive min & max)."
     - name: "/cm"
       summary: Search cryptographic material.
@@ -632,15 +635,19 @@ commands:
                 Can be single values or range descriptions. Must be wrapped in '\"'."
         - name: Usage example
           entries:
-            - text: "/v 4be 512"
+            - text: "/v"
+              arg_str: " 4be 512"
               comment: "Search 512 represented in 4 bytes big endian order."
-            - text: "/v 8le \"[0x80000000,0x80001000]\""
+            - text: "/v"
+              arg_str: " 8le \"[0x80000000,0x80001000]\""
               comment: "Search values in the closed range '[0x80000000,0x80001000]'
                 represented in 8 bytes little endian order."
-            - text: "/v 2a \"(0x1000,0xff0)\""
+            - text: "/v"
+              arg_str: " 2a \"(0x1000,0xff0)\""
               comment: "Search values in the open range '(0x1000,0xff0)' represented
                 in 2 bytes order of cfg.bigendian."
-            - text: "/v 1 \"[0x20,0x10)\", 0x55, \"[0xf0,0xff]\""
+            - text: "/v"
+              arg_str: " 1 \"[0x20,0x10)\", 0x55, \"[0xf0,0xff]\""
               comment: "Search values in the right open range '[0x20,0x10)', value '0x55'
                 and closed range values '[0xf0,0xff]' represented in 1 byte."
     - name: "/v1"
@@ -844,13 +851,17 @@ commands:
           comment: "Dot matches any one character, without exception (equivalent flag: PCRE2_DOTALL)"
     - name: "Examples"
       entries:
-        - text: "/z (ABC*)"
+        - text: "/z"
+          arg_str: " (ABC*)"
           comment: "Search the exact string \"(ABC*)\"."
-        - text: "/z (ABC*)D li"
+        - text: "/z"
+          arg_str: " (ABC*)D li"
           comment: "Search the exact string \"(ABC*)D\" but case insensitive."
-        - text: "/z \\\\d\\\\sC*\\\\w ri"
+        - text: "/z"
+          arg_str: " \\\\d\\\\sC*\\\\w ri"
           comment: "Search the regular expression \"\\d\\sC*\\w\" but case insensitive."
-        - text: "/z \"и.{3}м\" ei"
+        - text: "/z"
+          arg_str: " \"и.{3}м\" ei"
           comment: "Search the extended regular expression \"и.{3}м\" but case insensitive."
     subcommands:
     - name: "/z"


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

For consistency, this pr uses `arg_str` instead for the parameters of some search commands' detailed help examples. Example of output change:

Before:
<img width="828" height="97" alt="slash_z_2xques-before" src="https://github.com/user-attachments/assets/b0d6fe75-26b8-4093-ab34-803d0b9797bb" />

After:
<img width="829" height="95" alt="slash_z_2xques-after" src="https://github.com/user-attachments/assets/f2107b6e-f5b6-426b-a815-82d5a11e7b56" />

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The changes make sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
