### PR TITLE
Add helper to check if a thread terminated.

### DIFF
--- a/librz/include/rz_th.h
+++ b/librz/include/rz_th.h
@@ -46,6 +46,7 @@ typedef struct rz_atomic_bool_t RzAtomicBool;
 RZ_API RZ_OWN RzThread *rz_th_new(RZ_NONNULL RzThreadFunction function, RZ_NULLABLE void *user);
 RZ_API RZ_OWN void *rz_th_get_user(RZ_NONNULL RzThread *th);
 RZ_API RZ_OWN void *rz_th_get_retv(RZ_NONNULL RzThread *th);
+RZ_API bool rz_th_terminated(const RZ_NONNULL RzThread *th);
 RZ_API bool rz_th_wait(RZ_NONNULL RzThread *th);
 RZ_API void rz_th_free(RZ_NULLABLE RzThread *th);
 RZ_API bool rz_th_set_name(RZ_NONNULL RzThread *th, RZ_NONNULL const char *name);

--- a/librz/util/thread.c
+++ b/librz/util/thread.c
@@ -18,7 +18,9 @@ static RZ_TH_RET_T thread_main_function(void *_th) {
 #endif
 #endif
 	RzThread *th = (RzThread *)_th;
+	th->terminated = false;
 	th->retv = th->function(th->user);
+	th->terminated = true;
 	return (RZ_TH_RET_T)0;
 }
 
@@ -275,6 +277,18 @@ RZ_API RZ_OWN void *rz_th_get_user(RZ_NONNULL RzThread *th) {
 RZ_API RZ_OWN void *rz_th_get_retv(RZ_NONNULL RzThread *th) {
 	rz_return_val_if_fail(th, NULL);
 	return th->retv;
+}
+
+/**
+ * \brief Checks if a thread returned. This function is non-blocking.
+ *
+ * \param th The thread to check.
+ *
+ * \return True if the thread terminated. False otherwise,
+ */
+RZ_API bool rz_th_terminated(const RZ_NONNULL RzThread *th) {
+	rz_return_val_if_fail(th, false);
+	return th->terminated;
 }
 
 /**

--- a/librz/util/thread.h
+++ b/librz/util/thread.h
@@ -86,6 +86,7 @@ struct rz_th_t {
 	RzThreadFunction function; ///< User defined thread function.
 	void *user; ///< User defined thread data to pass (can be NULL).
 	void *retv; ///< Thread return value.
+	bool terminated; ///< Set to true if the thread exited.
 };
 
 RZ_IPI RZ_TH_TID rz_th_self(void);

--- a/test/unit/test_threads.c
+++ b/test/unit/test_threads.c
@@ -83,11 +83,13 @@ bool test_thread_queue(void) {
 	// test queue
 	queue = rz_th_queue_new(RZ_THREAD_QUEUE_UNLIMITED, NULL);
 	RzThread *th = rz_th_new((RzThreadFunction)thread_queue_push_timed, queue);
+	mu_assert_false(rz_th_terminated(th), "Thread should still sleep and count as running.");
 	mu_assert_notnull(th, "rz_th_new(thread_queue_push_timed, queue) null check");
 	ut64 start = rz_time_now();
 	tail = rz_th_queue_wait_pop(queue, true);
 	ut64 diff = rz_time_now() - start;
 	rz_th_wait(th);
+	mu_assert_true(rz_th_terminated(th), "Thread should count as terminated.");
 	mu_assert_ptreq(tail, queue, "rz_th_queue_wait_pop(queue, true) is queue");
 	mu_assert_true(diff >= 1500000, "queue did wait for value.");
 	mu_assert_ptreq(rz_th_get_retv(th), queue, "verify it returned queue");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This is an additional helper to simply check if a thread terminated yet or not.
It is necessary because `rz_th_get_retv` (getter for return code of the thread) returns a `void *`. But if the thread returns `true/false`, `false` cannot be distinguished from `NULL`.

In general a thread would set a atmoic variable to signal it is done. But this is not always comfortably possible. E.g. with assertions of the form `rz_ret_val_if_fail(..., false)`. 

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Added, all green

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
