### PR TITLE
Allow null on rz_vector_empty & rz_vector_len

### DIFF
--- a/librz/include/rz_vector.h
+++ b/librz/include/rz_vector.h
@@ -85,17 +85,15 @@ RZ_API bool rz_vector_clone_into(
 RZ_API RZ_OWN RzVector *rz_vector_clone(
 	RZ_NONNULL RZ_BORROW RZ_IN const RzVector *vec);
 
-static inline bool rz_vector_empty(const RzVector *vec) {
-	rz_return_val_if_fail(vec, false);
-	return vec->len == 0;
+static inline bool rz_vector_empty(RZ_NULLABLE const RzVector *vec) {
+	return vec ? vec->len == 0 : true;
 }
 
 RZ_API void rz_vector_clear(RzVector *vec);
 
 // returns the length of the vector
-static inline size_t rz_vector_len(const RzVector *vec) {
-	rz_return_val_if_fail(vec, 0);
-	return vec->len;
+static inline size_t rz_vector_len(RZ_NULLABLE const RzVector *vec) {
+	return vec ? vec->len : 0;
 }
 
 // returns a pointer to the offset inside the array where the element of the index lies.


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Allow null pointer for `rz_vector_empty` & `rz_vector_len`