### PR TITLE
Merge `graph.offset` into `asm.offset`

### DIFF
--- a/doc/fortunes.tips
+++ b/doc/fortunes.tips
@@ -42,7 +42,6 @@ Execute a command on the visual prompt with cmd.vprompt
 Reduce the delta where flag resolving by address is used with cfg.delta
 Disable these messages with 'e cfg.fortunes=false' in your ~/.rizinrc
 Change your fortune types with 'e cfg.fortunes.file=fun,tips' in your ~/.rizinrc
-Show offsets in graphs with 'e graph.offset=true'
 Execute a command every time a breakpoint is hit with 'e cmd.bp=!my-program'
 Disassemble in intel syntax with 'e asm.syntax=intel'.
 Change the UID of the debugged process with child.uid (requires root)

--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -2159,7 +2159,7 @@ static char *get_body(RzCore *core, ut64 addr, int size, int opts) {
 	rz_config_set_i(core->config, "asm.bb.middle", false);
 	core->print->cur_enabled = false;
 
-	rz_config_set_i(core->config, "asm.offset",
+	rz_config_set_b(core->config, "asm.offset",
 		(opts & BODY_OFFSETS) || (opts & BODY_SUMMARY) || o_asm_offset);
 
 	bool html = rz_config_get_i(core->config, "scr.html");

--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -2131,7 +2131,7 @@ static char *get_body(RzCore *core, ut64 addr, int size, int opts) {
 	const bool o_cmtright = rz_config_get_i(core->config, "graph.cmtright");
 	const bool o_bytes = rz_config_get_i(core->config, "graph.bytes");
 	const bool o_flags_in_bytes = rz_config_get_i(core->config, "asm.flags.inbytes");
-	const bool o_graph_offset = rz_config_get_i(core->config, "graph.offset");
+	const bool o_asm_offset = rz_config_get_i(core->config, "asm.offset");
 	int o_cursor = core->print->cur_enabled;
 	if (opts & BODY_COMMENTS) {
 		rz_core_visual_toggle_decompiler_disasm(core, true, false);
@@ -2159,11 +2159,8 @@ static char *get_body(RzCore *core, ut64 addr, int size, int opts) {
 	rz_config_set_i(core->config, "asm.bb.middle", false);
 	core->print->cur_enabled = false;
 
-	if (opts & BODY_OFFSETS || opts & BODY_SUMMARY || o_graph_offset) {
-		rz_config_set_i(core->config, "asm.offset", true);
-	} else {
-		rz_config_set_i(core->config, "asm.offset", false);
-	}
+	rz_config_set_i(core->config, "asm.offset",
+		(opts & BODY_OFFSETS) || (opts & BODY_SUMMARY) || o_asm_offset);
 
 	bool html = rz_config_get_i(core->config, "scr.html");
 	rz_config_set_i(core->config, "scr.html", 0);

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3687,7 +3687,6 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETI("graph.layout", 0, "Graph layout (0=vertical, 1=horizontal)");
 	SETI("graph.linemode", 1, "Graph edges (0=diagonal, 1=square)");
 	SETPREF("graph.font", "Courier", "Font for dot graphs");
-	SETBPREF("graph.offset", "false", "Show offsets in graphs");
 	SETBPREF("graph.bytes", "false", "Show opcode bytes in graphs");
 	SETI("graph.from", UT64_MAX, "Lower bound address when drawing global graphs");
 	SETI("graph.to", UT64_MAX, "Upper bound address when drawing global graphs");

--- a/test/db/cmd/cmd_visual
+++ b/test/db/cmd/cmd_visual
@@ -204,6 +204,7 @@ CMDS=<<EOF
 e scr.interactive=true
 e scr.columns=80
 e scr.rows=12
+e asm.offset=false
 aF
 < qq; VV
 echo


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Remove `graph.offset` and use `asm.offset` for graph offsets.
Related to [#3527](https://github.com/rizinorg/cutter/pull/3527)
...

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Initially `asm.offset` is set to true
Set it to false using `e asm.offset=false`
run: `VV`
Offsets will no longer be shown in graphs view
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
