### PR TITLE
Fix jump addressing when resolving 64bit addr on alpha

### DIFF
--- a/librz/arch/p/analysis/analysis_alpha_cs.c
+++ b/librz/arch/p/analysis/analysis_alpha_cs.c
@@ -180,6 +180,19 @@ static void alpha_opex(RzAsmAlphaContext *ctx, RzStrBuf *ptr) {
 	pj_free(pj);
 }
 
+static ut64 alpha_calc_64bit_jump(ut64 base, RzAsmAlphaContext *ctx, int idx) {
+	ut64 hi32 = base & UT64_32U;
+	ut64 jump = alpha_op_as_imm(ctx, idx);
+	if (!hi32) {
+		// does not need any fix since upper 32 bits are zero
+		return jump;
+	}
+
+	// keep only the lower 32 bits.
+	jump &= UT32_MAX;
+	return hi32 | jump;
+}
+
 static void alpha_op_set_type(RzAsmAlphaContext *ctx, RzAnalysisOp *op) {
 	switch (ctx->insn->id) {
 	default: {
@@ -195,16 +208,16 @@ static void alpha_op_set_type(RzAsmAlphaContext *ctx, RzAnalysisOp *op) {
 	case Alpha_INS_BLT:
 	case Alpha_INS_BNE:
 		op->type = RZ_ANALYSIS_OP_TYPE_CJMP;
-		op->jump = (ut32)alpha_op_as_imm(ctx, 1);
+		op->jump = alpha_calc_64bit_jump(op->addr, ctx, 1);
 		op->fail = op->addr + op->size;
 		break;
 	case Alpha_INS_BR:
 		op->type = RZ_ANALYSIS_OP_TYPE_JMP;
-		op->jump = (ut32)alpha_op_as_imm(ctx, 0);
+		op->jump = alpha_calc_64bit_jump(op->addr, ctx, 0);
 		break;
 	case Alpha_INS_BSR:
 		op->type = RZ_ANALYSIS_OP_TYPE_CALL;
-		op->jump = (ut32)alpha_op_as_imm(ctx, 0);
+		op->jump = alpha_calc_64bit_jump(op->addr, ctx, 0);
 		op->fail = op->addr + op->size;
 		break;
 	case Alpha_INS_RET:

--- a/test/db/analysis/alpha
+++ b/test/db/analysis/alpha
@@ -1,0 +1,54 @@
+NAME=Alpha
+FILE=bins/alpha/test-instr_alpha
+CMDS=<<EOF
+af @ sym.strlen
+pdf @ sym.strlen
+ao @ 0x12001b33c
+EOF
+EXPECT=<<EOF
+/ size_t sym.strlen(const char *s);
+|           0x12001b320      ldq_u $1,0($23)
+|           0x12001b324      lda   $2,0xffff($31)
+|           0x12001b328      insqh $2,$23,$2
+|           0x12001b32c      bic   $23,7,$0
+|           0x12001b330      bis   $2,$1,$1
+|           0x12001b334      bis   $31,$31,$31
+|           0x12001b338      cmpbge $31,$1,$2
+|       ,=< 0x12001b33c      bne   $2,0x12001b350
+|      .--> 0x12001b340      ldq   $1,8($0)
+|      :|   0x12001b344      addq  $0,8,$0
+|      :|   0x12001b348      cmpbge $31,$1,$2
+|      `==< 0x12001b34c      beq   $2,0x12001b340
+|       `-> 0x12001b350      subq  $31,$2,$3
+|           0x12001b354      and   $2,$3,$2
+|           0x12001b358      and   $2,0xf0,$3
+|           0x12001b35c      and   $2,0xcc,$4
+|           0x12001b360      and   $2,0xaa,$5
+|           0x12001b364      cmovne $3,4,$3
+|           0x12001b368      cmovne $4,2,$4
+|           0x12001b36c      cmovne $5,1,$5
+|           0x12001b370      addq  $3,$4,$3
+|           0x12001b374      addq  $0,$5,$0
+|           0x12001b378      addq  $0,$3,$0
+|           0x12001b37c      bis   $31,$31,$31
+|           0x12001b380      subq  $0,$23,$0
+\           0x12001b384      ret   $31,($26),1
+address: 0x12001b33c
+opcode: bne $2,0x12001b350
+disasm: bne $2,0x12001b350
+mnemonic: bne
+mask: ff000000
+prefix: 0
+id: 15
+bytes: 040040f4
+refptr: 0
+size: 4
+sign: false
+type: cjmp
+cycles: 0
+jump: 0x12001b350
+fail: 0x12001b340
+cond: al
+family: cpu
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Fixes some wrong limitations of alpha on capstone