### PR TITLE
Remove BROKEN=1 from globally fixed tests

### DIFF
--- a/test/db/cmd/bug_backtick
+++ b/test/db/cmd/bug_backtick
@@ -1,13 +1,15 @@
 NAME=t/bug_backtick
-FILE==
-BROKEN=1
+FILE=
 CMDS=p8 3`~`
 EXPECT=
+REGEXP_FILTER_ERR=Error while parsing command: .+
+EXPECT_ERR=Error while parsing command: `p8 3`~``
 RUN
 
 NAME=Invalid offset due invalid command
-FILE==
-BROKEN=1
+FILE=
 CMDS=fd @ `entry1`
 EXPECT=
+REGEXP_FILTER_ERR=Command '.+' does not exist.
+EXPECT_ERR=Command 'entry1' does not exist.
 RUN

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -4628,38 +4628,6 @@ CMDS=icqq
 EXPECT=
 RUN
 
-NAME=iqqc (file Java)
-BROKEN=1
-FILE=bins/java/Hello.class
-CMDS=iqqc
-EXPECT=<<EOF
-Hello
-EOF
-RUN
-
-NAME=iqqc (file x86)
-BROKEN=1
-FILE=bins/elf/ls
-CMDS=iqqc
-EXPECT=
-RUN
-
-NAME=iqcq (file Java)
-BROKEN=1
-FILE=bins/java/Hello.class
-CMDS=iqcq
-EXPECT=<<EOF
-Hello
-EOF
-RUN
-
-NAME=iqcq (file x86)
-BROKEN=1
-FILE=bins/elf/ls
-CMDS=iqcq
-EXPECT=
-RUN
-
 NAME=auto entry (lib)
 FILE=bins/elf/libverifyPass.so
 CMDS=<<EOF

--- a/test/db/cmd/cmd_pa
+++ b/test/db/cmd/cmd_pa
@@ -14,7 +14,6 @@ EOF
 RUN
 
 NAME=asm.assembler
-BROKEN=1
 FILE==
 CMDS=<<EOF
 e asm.arch=x86

--- a/test/db/cmd/feat_grep
+++ b/test/db/cmd/feat_grep
@@ -340,7 +340,6 @@ RUN
 
 NAME=escaped chars 2
 FILE==
-BROKEN=1
 CMDS=echo Hello\n\x3bWorld~\;
 EXPECT=<<EOF
 ;World

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -915,7 +915,6 @@ RUN
 
 NAME=tp blocksize
 FILE==
-BROKEN=1
 CMDS=<<EOF
 e asm.arch=x86
 wx 790a790a790a790a790a790a790a790a790a

--- a/test/db/formats/elf/mips
+++ b/test/db/formats/elf/mips
@@ -44,12 +44,10 @@ sw sp, 0x18(sp)
 cpu      mips32
 features noreorder cpic o32 n32
 EOF
-BROKEN=1
 RUN
 
 NAME=ELF: mipsbe-busybox
 FILE=bins/elf/analysis/mipsbe-busybox
-BROKEN=1
 CMDS=<<EOF
 af
 e asm.sub.var=false

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -49,7 +49,6 @@ EOF
 RUN
 
 NAME=rz-asm arm/thumb branch errors
-BROKEN=1 # Only on Windows
 FILE==
 CMDS=<<EOF
 !rz-asm -a arm -b 16 'b.n 8'
@@ -405,13 +404,6 @@ esil:     0,0xFF,|,DUP,!,SWAP,&,r0,SWAP,cpsr,&,|,cpsr,=
 stackptr: 0
 
 EOF
-RUN
-
-NAME=rz-asm -k
-BROKEN=1
-FILE==
-CMDS=!rz-asm -k darwin 0x90
-EXPECT=
 RUN
 
 NAME=rz-asm -a x86 -b 64 -E 0x55


### PR DESCRIPTION
Removes BROKEN=1 from some tests that are reported as fixed in all CI runners

related to #834