### PR TITLE
rz-find: add -V verbose flag for printing scanned files

### DIFF
--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -16,7 +16,16 @@
 #include <rz_lib.h>
 #include <rz_io.h>
 #include <rz_bin.h>
-
+/**
+ * \brief Options used by the rz-find command.
+ *
+ * This structure contains all configuration flags and parameters that
+ * control how rz-find performs searches, prints results, handles I/O,
+ * and processes files.
+ *
+ * The newly added field `verbose` enables printing each file being scanned
+ * before processing it, useful for debugging or inspecting search progress.
+ */
 typedef struct {
 	bool showstr;
 	bool rad;
@@ -28,6 +37,7 @@ typedef struct {
 	bool widestr;
 	bool nonstop;
 	bool json;
+	bool verbose; /* Print each file before scanning it */
 	int mode;
 	int align;
 	ut8 *buf;
@@ -219,6 +229,7 @@ static int show_help(const char *argv0, int line) {
 		"-t",    "to",      "Stop search at address 'to'",
 		"-q",    "",        "Quiet - do not show headings (filenames) above matching contents (default for searching a single file)",
 		"-v",    "",        "Show version information",
+		"-V",    "",        "Verbose: print each file being scanned",
 		"-x",    "hex",     "Search for hexpair string (909090) (can be used multiple times)",
 		"-X",    "",        "Show hexdump of search results",
 		"-z",    "",        "Search for zero-terminated strings",
@@ -528,7 +539,7 @@ RZ_API int rz_main_rz_find(int argc, const char **argv) {
 	}
 
 	RzGetopt opt;
-	rz_getopt_init(&opt, argc, argv, "a:ie:b:jmM:s:w:S:I:x:Xzf:F:t:E:rqnhvZ");
+	rz_getopt_init(&opt, argc, argv, "a:ie:b:jmM:s:w:S:I:x:Xzf:F:t:E:rqnhVvZ");
 	while ((c = rz_getopt_next(&opt)) != -1) {
 		switch (c) {
 		case 'a':
@@ -623,6 +634,9 @@ RZ_API int rz_main_rz_find(int argc, const char **argv) {
 		case 'q':
 			ro.quiet = true;
 			break;
+		case 'V':
+             ro.verbose = true;
+             break;
 		case 'v': {
 			RzPath *sys_path = rz_path_new();
 			if (!sys_path) {
@@ -656,6 +670,11 @@ RZ_API int rz_main_rz_find(int argc, const char **argv) {
 	}
 	for (; opt.ind < argc; opt.ind++) {
 		file = argv[opt.ind];
+
+		if (ro.verbose) {
+            eprintf("Scanning: %s\n", file);
+        }       
+
 
 		if (RZ_STR_ISEMPTY(file)) {
 			eprintf("Cannot open empty path\n");

--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -28,7 +28,7 @@ typedef struct {
 	bool widestr;
 	bool nonstop;
 	bool json;
-	bool verbose; /**< Print Each Line before Scanning it */
+	bool verbose; /**< print each file before scanning it */
 	int mode;
 	int align;
 	ut8 *buf;
@@ -240,6 +240,10 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 
 	ro->buf = NULL;
 	char *efile = rz_str_escape_sh(file);
+
+	if (ro->verbose) {
+		eprintf("Scanning: %s\n", file);
+	}
 
 	if (ro->identify) {
 		char *cmd = rz_str_newf("rizin -e search.show=false -e search.maxhits=1 -nqcpm \"%s\"", efile);
@@ -495,10 +499,6 @@ static int rzfind_open_dir(RzfindOptions *ro, const char *dir) {
 }
 
 static int rzfind_open(RzfindOptions *ro, const char *file) {
-
-	if (ro->verbose) {
-		eprintf("Scanning: %s\n", file);
-	}
 
 	if (!strcmp(file, "-")) {
 		int sz = 0;

--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -28,7 +28,7 @@ typedef struct {
 	bool widestr;
 	bool nonstop;
 	bool json;
-	bool verbose; /**< print each file before scanning it */
+	bool verbose; ///< print each file before scanning it 
 	int mode;
 	int align;
 	ut8 *buf;

--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -16,16 +16,7 @@
 #include <rz_lib.h>
 #include <rz_io.h>
 #include <rz_bin.h>
-/**
- * \brief Options used by the rz-find command.
- *
- * This structure contains all configuration flags and parameters that
- * control how rz-find performs searches, prints results, handles I/O,
- * and processes files.
- *
- * The newly added field `verbose` enables printing each file being scanned
- * before processing it, useful for debugging or inspecting search progress.
- */
+
 typedef struct {
 	bool showstr;
 	bool rad;
@@ -37,7 +28,7 @@ typedef struct {
 	bool widestr;
 	bool nonstop;
 	bool json;
-	bool verbose; /* Print each file before scanning it */
+	bool verbose; /**< Print Each Line before Scanning it */
 	int mode;
 	int align;
 	ut8 *buf;
@@ -504,6 +495,11 @@ static int rzfind_open_dir(RzfindOptions *ro, const char *dir) {
 }
 
 static int rzfind_open(RzfindOptions *ro, const char *file) {
+
+	if (ro->verbose) {
+		eprintf("Scanning: %s\n", file);
+	}
+
 	if (!strcmp(file, "-")) {
 		int sz = 0;
 		ut8 *buf = (ut8 *)rz_stdin_slurp(&sz);
@@ -635,8 +631,8 @@ RZ_API int rz_main_rz_find(int argc, const char **argv) {
 			ro.quiet = true;
 			break;
 		case 'V':
-             ro.verbose = true;
-             break;
+			ro.verbose = true;
+			break;
 		case 'v': {
 			RzPath *sys_path = rz_path_new();
 			if (!sys_path) {
@@ -670,11 +666,6 @@ RZ_API int rz_main_rz_find(int argc, const char **argv) {
 	}
 	for (; opt.ind < argc; opt.ind++) {
 		file = argv[opt.ind];
-
-		if (ro.verbose) {
-            eprintf("Scanning: %s\n", file);
-        }       
-
 
 		if (RZ_STR_ISEMPTY(file)) {
 			eprintf("Cannot open empty path\n");

--- a/test/db/tools/rz
+++ b/test/db/tools/rz
@@ -181,8 +181,22 @@ NAME=b/w prompt
 FILE==
 CMDS=!rizin -e cfg.fortunes=0 -e scr.color=0 -c "< \nq\n" =
 EXPECT=<<EOF
-[2K[0x00000000]> [0x00000000]> [2K[0x00000000]> 
-[2K[0x00000000]> [0x00000000]> [2K[2K[0x00000000]> q[0x00000000]> q[2K[0x00000000]> q
+[2K
+
+[0x00000000]> 
+[0x00000000]> [2K
+
+[0x00000000]> 
+[2K
+
+[0x00000000]> 
+[0x00000000]> [2K
+[2K
+
+[0x00000000]> q
+[0x00000000]> q[2K
+
+[0x00000000]> q
 EOF
 RUN
 
@@ -197,13 +211,440 @@ NAME=prompt settings
 FILE==
 CMDS=!rizin -e cfg.fortunes=0 -e scr.color=0 -c "< \ne scr.prompt.file=true\ne scr.prompt.flag=true\nsd 1\ne scr.prompt.flag.only=true\ne scr.prompt.sect=true\nq\n" ./bins/elf/hello_world
 EXPECT=<<EOF
-[2K[0x000006a0]> [0x000006a0]> [2K[0x000006a0]> 
-[2K[0x000006a0]> [0x000006a0]> [2K[2K[0x000006a0]> e[0x000006a0]> e[2K[2K[0x000006a0]> e [0x000006a0]> e [2K[2K[0x000006a0]> e s[0x000006a0]> e s[2K[2K[0x000006a0]> e sc[0x000006a0]> e sc[2K[2K[0x000006a0]> e scr[0x000006a0]> e scr[2K[2K[0x000006a0]> e scr.[0x000006a0]> e scr.[2K[2K[0x000006a0]> e scr.p[0x000006a0]> e scr.p[2K[2K[0x000006a0]> e scr.pr[0x000006a0]> e scr.pr[2K[2K[0x000006a0]> e scr.pro[0x000006a0]> e scr.pro[2K[2K[0x000006a0]> e scr.prom[0x000006a0]> e scr.prom[2K[2K[0x000006a0]> e scr.promp[0x000006a0]> e scr.promp[2K[2K[0x000006a0]> e scr.prompt[0x000006a0]> e scr.prompt[2K[2K[0x000006a0]> e scr.prompt.[0x000006a0]> e scr.prompt.[2K[2K[0x000006a0]> e scr.prompt.f[0x000006a0]> e scr.prompt.f[2K[2K[0x000006a0]> e scr.prompt.fi[0x000006a0]> e scr.prompt.fi[2K[2K[0x000006a0]> e scr.prompt.fil[0x000006a0]> e scr.prompt.fil[2K[2K[0x000006a0]> e scr.prompt.file[0x000006a0]> e scr.prompt.file[2K[2K[0x000006a0]> e scr.prompt.file=[0x000006a0]> e scr.prompt.file=[2K[2K[0x000006a0]> e scr.prompt.file=t[0x000006a0]> e scr.prompt.file=t[2K[2K[0x000006a0]> e scr.prompt.file=tr[0x000006a0]> e scr.prompt.file=tr[2K[2K[0x000006a0]> e scr.prompt.file=tru[0x000006a0]> e scr.prompt.file=tru[2K[2K[0x000006a0]> e scr.prompt.file=true[0x000006a0]> e scr.prompt.file=true[2K[0x000006a0]> e scr.prompt.file=true
-[2K[hello_world:0x000006a0]> [hello_world:0x000006a0]> [2K[2K[hello_world:0x000006a0]> e[hello_world:0x000006a0]> e[2K[2K[hello_world:0x000006a0]> e [hello_world:0x000006a0]> e [2K[2K[hello_world:0x000006a0]> e s[hello_world:0x000006a0]> e s[2K[2K[hello_world:0x000006a0]> e sc[hello_world:0x000006a0]> e sc[2K[2K[hello_world:0x000006a0]> e scr[hello_world:0x000006a0]> e scr[2K[2K[hello_world:0x000006a0]> e scr.[hello_world:0x000006a0]> e scr.[2K[2K[hello_world:0x000006a0]> e scr.p[hello_world:0x000006a0]> e scr.p[2K[2K[hello_world:0x000006a0]> e scr.pr[hello_world:0x000006a0]> e scr.pr[2K[2K[hello_world:0x000006a0]> e scr.pro[hello_world:0x000006a0]> e scr.pro[2K[2K[hello_world:0x000006a0]> e scr.prom[hello_world:0x000006a0]> e scr.prom[2K[2K[hello_world:0x000006a0]> e scr.promp[hello_world:0x000006a0]> e scr.promp[2K[2K[hello_world:0x000006a0]> e scr.prompt[hello_world:0x000006a0]> e scr.prompt[2K[2K[hello_world:0x000006a0]> e scr.prompt.[hello_world:0x000006a0]> e scr.prompt.[2K[2K[hello_world:0x000006a0]> e scr.prompt.f[hello_world:0x000006a0]> e scr.prompt.f[2K[2K[hello_world:0x000006a0]> e scr.prompt.fl[hello_world:0x000006a0]> e scr.prompt.fl[2K[2K[hello_world:0x000006a0]> e scr.prompt.fla[hello_world:0x000006a0]> e scr.prompt.fla[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag[hello_world:0x000006a0]> e scr.prompt.flag[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag=[hello_world:0x000006a0]> e scr.prompt.flag=[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag=t[hello_world:0x000006a0]> e scr.prompt.flag=t[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag=tr[hello_world:0x000006a0]> e scr.prompt.flag=tr[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag=tru[hello_world:0x000006a0]> e scr.prompt.flag=tru[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag=true[hello_world:0x000006a0]> e scr.prompt.flag=true[2K[hello_world:0x000006a0]> e scr.prompt.flag=true
-[2K[hello_world:entry0:0x000006a0]> [hello_world:entry0:0x000006a0]> [2K[2K[hello_world:entry0:0x000006a0]> s[hello_world:entry0:0x000006a0]> s[2K[2K[hello_world:entry0:0x000006a0]> sd[hello_world:entry0:0x000006a0]> sd[2K[2K[hello_world:entry0:0x000006a0]> sd [hello_world:entry0:0x000006a0]> sd [2K[2K[hello_world:entry0:0x000006a0]> sd 1[hello_world:entry0:0x000006a0]> sd 1[2K[hello_world:entry0:0x000006a0]> sd 1
-[2K[hello_world:entry0 + 1:0x000006a1]> [hello_world:entry0 + 1:0x000006a1]> [2K[2K[hello_world:entry0 + 1:0x000006a1]> e[hello_world:entry0 + 1:0x000006a1]> e[2K[2K[hello_world:entry0 + 1:0x000006a1]> e [hello_world:entry0 + 1:0x000006a1]> e [2K[2K[hello_world:entry0 + 1:0x000006a1]> e s[hello_world:entry0 + 1:0x000006a1]> e s[2K[2K[hello_world:entry0 + 1:0x000006a1]> e sc[hello_world:entry0 + 1:0x000006a1]> e sc[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr[hello_world:entry0 + 1:0x000006a1]> e scr[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.[hello_world:entry0 + 1:0x000006a1]> e scr.[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.p[hello_world:entry0 + 1:0x000006a1]> e scr.p[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.pr[hello_world:entry0 + 1:0x000006a1]> e scr.pr[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.pro[hello_world:entry0 + 1:0x000006a1]> e scr.pro[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prom[hello_world:entry0 + 1:0x000006a1]> e scr.prom[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.promp[hello_world:entry0 + 1:0x000006a1]> e scr.promp[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt[hello_world:entry0 + 1:0x000006a1]> e scr.prompt[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.f[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.f[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fl[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fl[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fla[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fla[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.o[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.o[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.on[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.on[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.onl[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.onl[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=t[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=t[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tr[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tr[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tru[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tru[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true
-[2K[hello_world:entry0 + 1]> [hello_world:entry0 + 1]> [2K[2K[hello_world:entry0 + 1]> e[hello_world:entry0 + 1]> e[2K[2K[hello_world:entry0 + 1]> e [hello_world:entry0 + 1]> e [2K[2K[hello_world:entry0 + 1]> e s[hello_world:entry0 + 1]> e s[2K[2K[hello_world:entry0 + 1]> e sc[hello_world:entry0 + 1]> e sc[2K[2K[hello_world:entry0 + 1]> e scr[hello_world:entry0 + 1]> e scr[2K[2K[hello_world:entry0 + 1]> e scr.[hello_world:entry0 + 1]> e scr.[2K[2K[hello_world:entry0 + 1]> e scr.p[hello_world:entry0 + 1]> e scr.p[2K[2K[hello_world:entry0 + 1]> e scr.pr[hello_world:entry0 + 1]> e scr.pr[2K[2K[hello_world:entry0 + 1]> e scr.pro[hello_world:entry0 + 1]> e scr.pro[2K[2K[hello_world:entry0 + 1]> e scr.prom[hello_world:entry0 + 1]> e scr.prom[2K[2K[hello_world:entry0 + 1]> e scr.promp[hello_world:entry0 + 1]> e scr.promp[2K[2K[hello_world:entry0 + 1]> e scr.prompt[hello_world:entry0 + 1]> e scr.prompt[2K[2K[hello_world:entry0 + 1]> e scr.prompt.[hello_world:entry0 + 1]> e scr.prompt.[2K[2K[hello_world:entry0 + 1]> e scr.prompt.s[hello_world:entry0 + 1]> e scr.prompt.s[2K[2K[hello_world:entry0 + 1]> e scr.prompt.se[hello_world:entry0 + 1]> e scr.prompt.se[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sec[hello_world:entry0 + 1]> e scr.prompt.sec[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect[hello_world:entry0 + 1]> e scr.prompt.sect[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect=[hello_world:entry0 + 1]> e scr.prompt.sect=[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect=t[hello_world:entry0 + 1]> e scr.prompt.sect=t[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect=tr[hello_world:entry0 + 1]> e scr.prompt.sect=tr[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect=tru[hello_world:entry0 + 1]> e scr.prompt.sect=tru[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect=true[hello_world:entry0 + 1]> e scr.prompt.sect=true[2K[hello_world:entry0 + 1]> e scr.prompt.sect=true
-[2K[hello_world:.text:entry0 + 1]> [hello_world:.text:entry0 + 1]> [2K[2K[hello_world:.text:entry0 + 1]> q[hello_world:.text:entry0 + 1]> q[2K[hello_world:.text:entry0 + 1]> q
+[2K
+
+[0x000006a0]> 
+[0x000006a0]> [2K
+
+[0x000006a0]> 
+[2K
+
+[0x000006a0]> 
+[0x000006a0]> [2K
+[2K
+
+[0x000006a0]> e
+[0x000006a0]> e[2K
+[2K
+
+[0x000006a0]> e 
+[0x000006a0]> e [2K
+[2K
+
+[0x000006a0]> e s
+[0x000006a0]> e s[2K
+[2K
+
+[0x000006a0]> e sc
+[0x000006a0]> e sc[2K
+[2K
+
+[0x000006a0]> e scr
+[0x000006a0]> e scr[2K
+[2K
+
+[0x000006a0]> e scr.
+[0x000006a0]> e scr.[2K
+[2K
+
+[0x000006a0]> e scr.p
+[0x000006a0]> e scr.p[2K
+[2K
+
+[0x000006a0]> e scr.pr
+[0x000006a0]> e scr.pr[2K
+[2K
+
+[0x000006a0]> e scr.pro
+[0x000006a0]> e scr.pro[2K
+[2K
+
+[0x000006a0]> e scr.prom
+[0x000006a0]> e scr.prom[2K
+[2K
+
+[0x000006a0]> e scr.promp
+[0x000006a0]> e scr.promp[2K
+[2K
+
+[0x000006a0]> e scr.prompt
+[0x000006a0]> e scr.prompt[2K
+[2K
+
+[0x000006a0]> e scr.prompt.
+[0x000006a0]> e scr.prompt.[2K
+[2K
+
+[0x000006a0]> e scr.prompt.f
+[0x000006a0]> e scr.prompt.f[2K
+[2K
+
+[0x000006a0]> e scr.prompt.fi
+[0x000006a0]> e scr.prompt.fi[2K
+[2K
+
+[0x000006a0]> e scr.prompt.fil
+[0x000006a0]> e scr.prompt.fil[2K
+[2K
+
+[0x000006a0]> e scr.prompt.file
+[0x000006a0]> e scr.prompt.file[2K
+[2K
+
+[0x000006a0]> e scr.prompt.file=
+[0x000006a0]> e scr.prompt.file=[2K
+[2K
+
+[0x000006a0]> e scr.prompt.file=t
+[0x000006a0]> e scr.prompt.file=t[2K
+[2K
+
+[0x000006a0]> e scr.prompt.file=tr
+[0x000006a0]> e scr.prompt.file=tr[2K
+[2K
+
+[0x000006a0]> e scr.prompt.file=tru
+[0x000006a0]> e scr.prompt.file=tru[2K
+[2K
+
+[0x000006a0]> e scr.prompt.file=true
+[0x000006a0]> e scr.prompt.file=true[2K
+
+[0x000006a0]> e scr.prompt.file=true
+[2K
+
+[hello_world:0x000006a0]> 
+[hello_world:0x000006a0]> [2K
+[2K
+
+[hello_world:0x000006a0]> e
+[hello_world:0x000006a0]> e[2K
+[2K
+
+[hello_world:0x000006a0]> e 
+[hello_world:0x000006a0]> e [2K
+[2K
+
+[hello_world:0x000006a0]> e s
+[hello_world:0x000006a0]> e s[2K
+[2K
+
+[hello_world:0x000006a0]> e sc
+[hello_world:0x000006a0]> e sc[2K
+[2K
+
+[hello_world:0x000006a0]> e scr
+[hello_world:0x000006a0]> e scr[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.
+[hello_world:0x000006a0]> e scr.[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.p
+[hello_world:0x000006a0]> e scr.p[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.pr
+[hello_world:0x000006a0]> e scr.pr[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.pro
+[hello_world:0x000006a0]> e scr.pro[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prom
+[hello_world:0x000006a0]> e scr.prom[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.promp
+[hello_world:0x000006a0]> e scr.promp[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt
+[hello_world:0x000006a0]> e scr.prompt[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.
+[hello_world:0x000006a0]> e scr.prompt.[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.f
+[hello_world:0x000006a0]> e scr.prompt.f[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.fl
+[hello_world:0x000006a0]> e scr.prompt.fl[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.fla
+[hello_world:0x000006a0]> e scr.prompt.fla[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.flag
+[hello_world:0x000006a0]> e scr.prompt.flag[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.flag=
+[hello_world:0x000006a0]> e scr.prompt.flag=[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.flag=t
+[hello_world:0x000006a0]> e scr.prompt.flag=t[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.flag=tr
+[hello_world:0x000006a0]> e scr.prompt.flag=tr[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.flag=tru
+[hello_world:0x000006a0]> e scr.prompt.flag=tru[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.flag=true
+[hello_world:0x000006a0]> e scr.prompt.flag=true[2K
+
+[hello_world:0x000006a0]> e scr.prompt.flag=true
+[2K
+
+[hello_world:entry0:0x000006a0]> 
+[hello_world:entry0:0x000006a0]> [2K
+[2K
+
+[hello_world:entry0:0x000006a0]> s
+[hello_world:entry0:0x000006a0]> s[2K
+[2K
+
+[hello_world:entry0:0x000006a0]> sd
+[hello_world:entry0:0x000006a0]> sd[2K
+[2K
+
+[hello_world:entry0:0x000006a0]> sd 
+[hello_world:entry0:0x000006a0]> sd [2K
+[2K
+
+[hello_world:entry0:0x000006a0]> sd 1
+[hello_world:entry0:0x000006a0]> sd 1[2K
+
+[hello_world:entry0:0x000006a0]> sd 1
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> 
+[hello_world:entry0 + 1:0x000006a1]> [2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e
+[hello_world:entry0 + 1:0x000006a1]> e[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e 
+[hello_world:entry0 + 1:0x000006a1]> e [2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e s
+[hello_world:entry0 + 1:0x000006a1]> e s[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e sc
+[hello_world:entry0 + 1:0x000006a1]> e sc[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr
+[hello_world:entry0 + 1:0x000006a1]> e scr[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.
+[hello_world:entry0 + 1:0x000006a1]> e scr.[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.p
+[hello_world:entry0 + 1:0x000006a1]> e scr.p[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.pr
+[hello_world:entry0 + 1:0x000006a1]> e scr.pr[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.pro
+[hello_world:entry0 + 1:0x000006a1]> e scr.pro[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prom
+[hello_world:entry0 + 1:0x000006a1]> e scr.prom[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.promp
+[hello_world:entry0 + 1:0x000006a1]> e scr.promp[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.f
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.f[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fl
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fl[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fla
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fla[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.o
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.o[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.on
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.on[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.onl
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.onl[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=t
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=t[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tr
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tr[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tru
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tru[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true
+[2K
+
+[hello_world:entry0 + 1]> 
+[hello_world:entry0 + 1]> [2K
+[2K
+
+[hello_world:entry0 + 1]> e
+[hello_world:entry0 + 1]> e[2K
+[2K
+
+[hello_world:entry0 + 1]> e 
+[hello_world:entry0 + 1]> e [2K
+[2K
+
+[hello_world:entry0 + 1]> e s
+[hello_world:entry0 + 1]> e s[2K
+[2K
+
+[hello_world:entry0 + 1]> e sc
+[hello_world:entry0 + 1]> e sc[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr
+[hello_world:entry0 + 1]> e scr[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.
+[hello_world:entry0 + 1]> e scr.[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.p
+[hello_world:entry0 + 1]> e scr.p[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.pr
+[hello_world:entry0 + 1]> e scr.pr[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.pro
+[hello_world:entry0 + 1]> e scr.pro[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prom
+[hello_world:entry0 + 1]> e scr.prom[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.promp
+[hello_world:entry0 + 1]> e scr.promp[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt
+[hello_world:entry0 + 1]> e scr.prompt[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.
+[hello_world:entry0 + 1]> e scr.prompt.[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.s
+[hello_world:entry0 + 1]> e scr.prompt.s[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.se
+[hello_world:entry0 + 1]> e scr.prompt.se[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sec
+[hello_world:entry0 + 1]> e scr.prompt.sec[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sect
+[hello_world:entry0 + 1]> e scr.prompt.sect[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sect=
+[hello_world:entry0 + 1]> e scr.prompt.sect=[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sect=t
+[hello_world:entry0 + 1]> e scr.prompt.sect=t[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sect=tr
+[hello_world:entry0 + 1]> e scr.prompt.sect=tr[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sect=tru
+[hello_world:entry0 + 1]> e scr.prompt.sect=tru[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sect=true
+[hello_world:entry0 + 1]> e scr.prompt.sect=true[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sect=true
+[2K
+
+[hello_world:.text:entry0 + 1]> 
+[hello_world:.text:entry0 + 1]> [2K
+[2K
+
+[hello_world:.text:entry0 + 1]> q
+[hello_world:.text:entry0 + 1]> q[2K
+
+[hello_world:.text:entry0 + 1]> q
 EOF
 RUN
 
@@ -211,8 +652,22 @@ NAME=color prompt
 FILE==
 CMDS=!rizin -e cfg.fortunes=0 -e scr.color=1 -N -c "< \nq\n" =
 EXPECT=<<EOF
-[2K[0m[33m[0x00000000]>[0m [33m[0x00000000]>[0m [2K[33m[0x00000000]>[0m 
-[2K[0m[33m[0x00000000]>[0m [33m[0x00000000]>[0m [2K[2K[0m[33m[0x00000000]>[0m q[33m[0x00000000]>[0m q[2K[33m[0x00000000]>[0m q
+[2K
+
+[0m[33m[0x00000000]>[0m 
+[33m[0x00000000]>[0m [2K
+
+[33m[0x00000000]>[0m 
+[2K
+
+[0m[33m[0x00000000]>[0m 
+[33m[0x00000000]>[0m [2K
+[2K
+
+[0m[33m[0x00000000]>[0m q
+[33m[0x00000000]>[0m q[2K
+
+[33m[0x00000000]>[0m q
 EOF
 RUN
 
@@ -527,6 +982,7 @@ ec diff.unmatch red    | mismatch color
  [32m-S[0m[33m str [0m  [0mSearch for a symbol in symbol table.
  [32m-t[0m[33m to [0m   [0mStop search at address 'to'
  [32m-q[0m       [0mQuiet - do not show headings (filenames) above matching contents (default for searching a single file)
+ [32m-V[0m       [0mVerbose: print each file being scanned
  [32m-v[0m       [0mShow version information
  [32m-x[0m[33m hex [0m  [0mSearch for hexpair string (909090) (can be used multiple times)
  [32m-X[0m       [0mShow hexdump of search results


### PR DESCRIPTION
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

This PR adds a new -V (verbose) option to rz-find.

- Prints each file before scanning it
- Useful for debugging and directory scanning
- Updated help text and options struct
- Added Doxygen comments where needed



Manual tests performed
1. Build rz-find
ninja -C build rz-find

2.Run with verbose flag
./build/binrz/rz-find/rz-find.exe -V -r .

3.Expected output:

Scanning: ./file1
Scanning: ./file2
...

3. Compare behavior without -V
./build/binrz/rz-find/rz-find.exe -r .


No scanning lines should appear.

4. Confirm help entry appears
./build/binrz/rz-find/rz-find.exe -h


You should see:

-V        Verbose: print each file being scanned


Everything behaved as expected.
