### PR TITLE
Handle R_AARCH64_TLSDESC without emitting an error

### DIFF
--- a/librz/bin/format/elf/elf_relocs_conversion.c
+++ b/librz/bin/format/elf/elf_relocs_conversion.c
@@ -609,7 +609,7 @@ static RzBinReloc *reloc_convert_aarch64(ELFOBJ *bin, RzBinElfReloc *rel, ut64 G
 	case R_AARCH64_TLS_DTPMOD: UNHANDL("R_AARCH64_TLS_DTPMOD");
 	case R_AARCH64_TLS_DTPREL: UNHANDL("R_AARCH64_TLS_DTPREL");
 	case R_AARCH64_TLS_TPREL: UNHANDL("R_AARCH64_TLS_TPREL");
-	case R_AARCH64_TLSDESC: UNHANDL("R_AARCH64_TLSDESC");
+	case R_AARCH64_TLSDESC: ADD(64, 0, "R_AARCH64_TLSDESC"); // resolved at runtime
 	case R_AARCH64_IRELATIVE: UNHANDL("R_AARCH64_IRELATIVE");
 
 	// FIXME: Quite a few relocations missing here

--- a/librz/bin/format/elf/elf_relocs_patching.c
+++ b/librz/bin/format/elf/elf_relocs_patching.c
@@ -974,6 +974,10 @@ static void patch_reloc_arm64(RZ_INOUT RzBuffer *buf_patched, const ut64 patch_a
 		val = PG_OFFSET(fs->S + fs->A) >> 3;
 		rz_write_le32(buf, keep | ((val & RZ_BIT_MASK32(12, 0)) << 10));
 		break;
+	case R_AARCH64_TLSDESC:
+		// R_AARCH64_TLSDESC is a relocation type handled by the
+		// dynamic linker. We intentionally do not handle do anything.
+		break;
 	default:
 		UNHANDL_DEF("AArch64", rel->type);
 		return;


### PR DESCRIPTION
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [N/A ] I've documented every `RZ_API` function and struct this PR changes.
- [N/A] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [N/A] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [N/A] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->
Addresses: #5130

When ingesting a binary with a relocation type of `R_AARCH64_TLSDESC`, for example [libusb-1.0.so.rel_1031.zip](https://github.com/user-attachments/files/20038284/libusb-1.0.so.rel_1031.zip), this would generate an unimplemented error message.

This relocation type is handled by the dynamic linker, and therefore, we do very little to actually handle it.
...

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->
To verify that this patch works, one must do the following:
- Compile changes via `meson compile -C build`
- Download [libusb-1.0.so.rel_1031.zip](https://github.com/user-attachments/files/20038284/libusb-1.0.so.rel_1031.zip)
- Extract `libusb-1.0.so.rel_1031.zip` 
-  Run: `/path/to/built/rizin /path/to/libusb-1.0.so.rel_1031.zip`


...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
