### PR TITLE
Convert opex to use RzStructuredData

### DIFF
--- a/librz/arch/isa/amd29k/amd29k.c
+++ b/librz/arch/isa/amd29k/amd29k.c
@@ -529,6 +529,63 @@ ut64 amd29k_instr_jump(amd29k_instr_t *instruction, ut64 address) {
 	return UT64_MAX;
 }
 
+static void amd29k_opex_add_reg(RzStructuredData *operands, int reg) {
+	RzStructuredData *operand = rz_structured_data_array_add_map(operands);
+	rz_structured_data_map_add_string(operand, "type", "reg");
+	rz_structured_data_map_add_string(operand, "value", amd29k_get_regname(reg));
+}
+
+static void amd29k_opex_add_signed(RzStructuredData *operands, st64 imm) {
+	RzStructuredData *operand = rz_structured_data_array_add_map(operands);
+	rz_structured_data_map_add_string(operand, "type", "imm");
+	rz_structured_data_map_add_signed(operand, "value", imm);
+}
+
+static void amd29k_opex_add_unsigned(RzStructuredData *operands, ut64 imm) {
+	RzStructuredData *operand = rz_structured_data_array_add_map(operands);
+	rz_structured_data_map_add_string(operand, "type", "imm");
+	rz_structured_data_map_add_unsigned(operand, "value", imm, false);
+}
+
+RzStructuredData *amd29k_instr_opex(amd29k_instr_t *instruction, ut64 address) {
+	if (!instruction) {
+		return NULL;
+	}
+
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
+	}
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
+	for (size_t i = 0; i < AMD29K_MAX_OPERANDS; ++i) {
+		int type = AMD29K_GET_TYPE(instruction, i);
+		int value = AMD29K_GET_VALUE(instruction, i);
+
+		switch (type) {
+		case AMD29K_TYPE_REG:
+			amd29k_opex_add_reg(operands, value);
+			break;
+		case AMD29K_TYPE_IMM:
+			amd29k_opex_add_signed(operands, value);
+			break;
+		case AMD29K_TYPE_JMP:
+			amd29k_opex_add_unsigned(operands, address + value);
+			break;
+		default:
+			return root;
+		}
+	}
+
+	return root;
+}
+
 void amd29k_instr_print(amd29k_instr_t *instruction, ut64 address, RzStrBuf *sb) {
 	if (!instruction || !sb) {
 		return;

--- a/librz/arch/isa/amd29k/amd29k.h
+++ b/librz/arch/isa/amd29k/amd29k.h
@@ -25,6 +25,7 @@ typedef struct amd29k_instr_s {
 bool amd29k_instr_decode(const ut8 *buffer, const ut32 buffer_size, amd29k_instr_t *instruction, const ut32 cpu_id);
 void amd29k_instr_print(amd29k_instr_t *instruction, ut64 address, RzStrBuf *sb);
 
+RzStructuredData *amd29k_instr_opex(amd29k_instr_t *instruction, ut64 address);
 bool amd29k_instr_is_ret(amd29k_instr_t *instruction);
 ut64 amd29k_instr_jump(amd29k_instr_t *instruction, ut64 address);
 

--- a/librz/arch/isa/tms320/c64x/c64x.c
+++ b/librz/arch/isa/tms320/c64x/c64x.c
@@ -118,46 +118,50 @@ char *tms320_c64x_mnemonics(RzAsm *a, int id, bool json, void *c64x) {
 	return rz_strbuf_drain(buf);
 }
 
-static void tms320_c64x_opex(RzStrBuf *buf, csh handle, cs_insn *insn) {
-	int i;
-	PJ *pj = pj_new();
-	if (!pj) {
-		return;
+static RzStructuredData *tms320_c64x_opex(csh handle, cs_insn *insn) {
+	if (!insn->detail) {
+		return NULL;
 	}
-	pj_o(pj);
-	pj_ka(pj, "operands");
+
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
+	}
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
 	cs_tms320c64x *x = &insn->detail->tms320c64x;
-	for (i = 0; i < x->op_count; i++) {
+	for (st32 i = 0; i < x->op_count; i++) {
 		cs_tms320c64x_op *op = x->operands + i;
-		pj_o(pj);
+		RzStructuredData *operand = rz_structured_data_array_add_map(operands);
 		switch (op->type) {
 		case TMS320C64X_OP_REG:
-			pj_ks(pj, "type", "reg");
-			pj_ks(pj, "value", cs_reg_name(handle, op->reg));
+			rz_structured_data_map_add_string(operand, "type", "reg");
+			rz_structured_data_map_add_string(operand, "value", cs_reg_name(handle, op->reg));
 			break;
 		case TMS320C64X_OP_IMM:
-			pj_ks(pj, "type", "imm");
-			pj_ki(pj, "value", op->imm);
+			rz_structured_data_map_add_string(operand, "type", "imm");
+			rz_structured_data_map_add_signed(operand, "value", op->imm);
 			break;
 		case TMS320C64X_OP_MEM:
-			pj_ks(pj, "type", "mem");
+			rz_structured_data_map_add_string(operand, "type", "mem");
 			if (op->mem.base != SPARC_REG_INVALID) {
-				pj_ks(pj, "base", cs_reg_name(handle, op->mem.base));
+				rz_structured_data_map_add_string(operand, "base", cs_reg_name(handle, op->mem.base));
 			}
-			pj_kN(pj, "disp", (st64)op->mem.disp);
+			rz_structured_data_map_add_signed(operand, "disp", (st64)op->mem.disp);
 			break;
 		default:
-			pj_ks(pj, "type", "invalid");
+			rz_structured_data_map_add_string(operand, "type", "invalid");
 			break;
 		}
-		pj_end(pj); /* o operand */
 	}
-	pj_end(pj); /* a operands */
-	pj_end(pj);
 
-	rz_strbuf_init(buf);
-	rz_strbuf_append(buf, pj_string(pj));
-	pj_free(pj);
+	return root;
 }
 
 int tms320_c64x_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask, void *c64x) {
@@ -184,7 +188,7 @@ int tms320_c64x_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, i
 		op->type = RZ_ANALYSIS_OP_TYPE_ILL;
 	} else {
 		if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
-			tms320_c64x_opex(&op->opex, ctx->handle, insn);
+			op->opex = tms320_c64x_opex(ctx->handle, insn);
 		}
 		op->size = insn->size;
 		op->id = insn->id;

--- a/librz/arch/op.c
+++ b/librz/arch/op.c
@@ -21,18 +21,19 @@ RZ_API RzList /*<RzAnalysisOp *>*/ *rz_analysis_op_list_new(void) {
 }
 
 RZ_API void rz_analysis_op_init(RzAnalysisOp *op) {
-	if (op) {
-		memset(op, 0, sizeof(*op));
-		op->addr = UT64_MAX;
-		op->jump = UT64_MAX;
-		op->fail = UT64_MAX;
-		op->ptr = UT64_MAX;
-		op->refptr = 0;
-		op->val = UT64_MAX;
-		op->disp = UT64_MAX;
-		op->mmio_address = UT64_MAX;
-		op->stackptr = RZ_ANALYSIS_OP_INVALID_STACKPTR;
+	if (!op) {
+		return;
 	}
+	memset(op, 0, sizeof(*op));
+	op->addr = UT64_MAX;
+	op->jump = UT64_MAX;
+	op->fail = UT64_MAX;
+	op->ptr = UT64_MAX;
+	op->refptr = 0;
+	op->val = UT64_MAX;
+	op->disp = UT64_MAX;
+	op->mmio_address = UT64_MAX;
+	op->stackptr = RZ_ANALYSIS_OP_INVALID_STACKPTR;
 }
 
 RZ_API bool rz_analysis_op_fini(RzAnalysisOp *op) {
@@ -49,7 +50,8 @@ RZ_API bool rz_analysis_op_fini(RzAnalysisOp *op) {
 	op->dst = NULL;
 	rz_list_free(op->access);
 	op->access = NULL;
-	rz_strbuf_fini(&op->opex);
+	rz_structured_data_free(op->opex);
+	op->opex = NULL;
 	rz_strbuf_fini(&op->esil);
 	rz_analysis_switch_op_free(op->switch_op);
 	op->switch_op = NULL;

--- a/librz/arch/p/analysis/analysis_alpha_cs.c
+++ b/librz/arch/p/analysis/analysis_alpha_cs.c
@@ -140,44 +140,43 @@ static void alpha_fillval(RzAsmAlphaContext *ctx, RzAnalysis *a, RzAnalysisOp *o
 	}
 }
 
-static void alpha_opex(RzAsmAlphaContext *ctx, RzStrBuf *ptr) {
+static RzStructuredData *alpha_opex(RzAsmAlphaContext *ctx) {
 	if (!ctx->insn->detail) {
-		return;
+		return NULL;
 	}
-	PJ *pj = pj_new();
-	if (!pj) {
-		return;
+
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
 	}
-	pj_o(pj);
-	pj_ka(pj, "operands");
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
 	cs_alpha *al = &ctx->insn->detail->alpha;
 	for (st32 i = 0; i < al->op_count; i++) {
 		cs_alpha_op *op = al->operands + i;
-		pj_o(pj);
+		RzStructuredData *operand = rz_structured_data_array_add_map(operands);
 		switch (op->type) {
-		case ALPHA_OP_INVALID: {
-			pj_ks(pj, "type", "invalid");
+		default:
+			rz_structured_data_map_add_string(operand, "type", "invalid");
+			break;
+		case ALPHA_OP_REG:
+			rz_structured_data_map_add_string(operand, "type", "reg");
+			rz_structured_data_map_add_string(operand, "value", cs_reg_name(ctx->h, op->reg));
+			break;
+		case ALPHA_OP_IMM:
+			rz_structured_data_map_add_string(operand, "type", "imm");
+			rz_structured_data_map_add_signed(operand, "value", op->imm);
 			break;
 		}
-		case ALPHA_OP_REG: {
-			pj_ks(pj, "type", "reg");
-			pj_ks(pj, "value", cs_reg_name(ctx->h, op->reg));
-			break;
-		}
-		case ALPHA_OP_IMM: {
-			pj_ks(pj, "type", "imm");
-			pj_ki(pj, "value", op->imm);
-			break;
-		}
-		}
-		pj_end(pj);
 	}
-	pj_end(pj);
-	pj_end(pj);
 
-	rz_strbuf_init(ptr);
-	rz_strbuf_append(ptr, pj_string(pj));
-	pj_free(pj);
+	return root;
 }
 
 static ut64 alpha_calc_64bit_jump(ut64 base, RzAsmAlphaContext *ctx, int idx) {
@@ -425,7 +424,7 @@ static int rz_analysis_alpha_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, cons
 	alpha_op_set_type(ctx, op);
 
 	if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
-		alpha_opex(ctx, &op->opex);
+		op->opex = alpha_opex(ctx);
 	}
 	if (mask & RZ_ANALYSIS_OP_MASK_VAL) {
 		alpha_fillval(ctx, a, op);

--- a/librz/arch/p/analysis/analysis_amd29k.c
+++ b/librz/arch/p/analysis/analysis_amd29k.c
@@ -339,6 +339,10 @@ static int amd29k_analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const u
 		op->mnemonic = rz_str_dup(instruction.mnemonic);
 	}
 
+	if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
+		op->opex = amd29k_instr_opex(&instruction, addr);
+	}
+
 	return op->size;
 }
 

--- a/librz/arch/p/analysis/analysis_arm_cs.c
+++ b/librz/arch/p/analysis/analysis_arm_cs.c
@@ -201,86 +201,95 @@ static bool cc_holds_cond(arm64_cc cc) {
 #endif
 }
 
-static void opex(RzStrBuf *buf, csh handle, cs_insn *insn) {
-	int i;
-	PJ *pj = pj_new();
-	if (!pj) {
-		return;
+static RzStructuredData *arm_opex(csh handle, cs_insn *insn) {
+	if (!insn->detail) {
+		return NULL;
 	}
-	pj_o(pj);
-	pj_ka(pj, "operands");
+
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
+	}
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
 	cs_arm *x = &insn->detail->arm;
-	for (i = 0; i < x->op_count; i++) {
+	for (st32 i = 0; i < x->op_count; i++) {
 		cs_arm_op *op = x->operands + i;
-		pj_o(pj);
+		RzStructuredData *operand = rz_structured_data_array_add_map(operands);
 		switch (op->type) {
 		case ARM_OP_REG:
-			pj_ks(pj, "type", "reg");
-			pj_ks(pj, "value", cs_reg_name(handle, op->reg));
+			rz_structured_data_map_add_string(operand, "type", "reg");
+			rz_structured_data_map_add_string(operand, "value", cs_reg_name(handle, op->reg));
 			break;
 		case ARM_OP_IMM:
-			pj_ks(pj, "type", "imm");
-			pj_ki(pj, "value", op->imm);
+			rz_structured_data_map_add_string(operand, "type", "imm");
+			rz_structured_data_map_add_signed(operand, "value", op->imm);
 			break;
 		case ARM_OP_MEM:
-			pj_ks(pj, "type", "mem");
+			rz_structured_data_map_add_string(operand, "type", "mem");
 			if (op->mem.base != ARM_REG_INVALID) {
-				pj_ks(pj, "base", cs_reg_name(handle, op->mem.base));
+				rz_structured_data_map_add_string(operand, "base", cs_reg_name(handle, op->mem.base));
 			}
 			if (op->mem.index != ARM_REG_INVALID) {
-				pj_ks(pj, "index", cs_reg_name(handle, op->mem.index));
+				rz_structured_data_map_add_string(operand, "index", cs_reg_name(handle, op->mem.index));
 			}
-			pj_ki(pj, "scale", op->mem.scale);
-			pj_ki(pj, "disp", op->mem.disp);
+			rz_structured_data_map_add_signed(operand, "scale", op->mem.scale);
+			rz_structured_data_map_add_signed(operand, "disp", op->mem.disp);
 			break;
 		case ARM_OP_FP:
-			pj_ks(pj, "type", "fp");
-			pj_kd(pj, "value", op->fp);
+			rz_structured_data_map_add_string(operand, "type", "fp");
+			rz_structured_data_map_add_double(operand, "value", op->fp);
 			break;
 		case ARM_OP_CIMM:
-			pj_ks(pj, "type", "cimm");
-			pj_ki(pj, "value", op->imm);
+			rz_structured_data_map_add_string(operand, "type", "cimm");
+			rz_structured_data_map_add_signed(operand, "value", op->imm);
 			break;
 		case ARM_OP_PIMM:
-			pj_ks(pj, "type", "pimm");
-			pj_ki(pj, "value", op->imm);
+			rz_structured_data_map_add_string(operand, "type", "pimm");
+			rz_structured_data_map_add_signed(operand, "value", op->imm);
 			break;
 		case ARM_OP_SETEND:
-			pj_ks(pj, "type", "setend");
+			rz_structured_data_map_add_string(operand, "type", "setend");
 			switch (op->setend) {
 			case ARM_SETEND_BE:
-				pj_ks(pj, "value", "be");
+				rz_structured_data_map_add_string(operand, "value", "be");
 				break;
 			case ARM_SETEND_LE:
-				pj_ks(pj, "value", "le");
+				rz_structured_data_map_add_string(operand, "value", "le");
 				break;
 			default:
-				pj_ks(pj, "value", "invalid");
+				rz_structured_data_map_add_string(operand, "value", "invalid");
 				break;
 			}
 			break;
 		case ARM_OP_SYSREG: {
-			pj_ks(pj, "type", "sysreg");
+			rz_structured_data_map_add_string(operand, "type", "sysreg");
 			const char *reg = cs_reg_name(handle, op->reg);
 			if (reg) {
-				pj_ks(pj, "value", reg);
+				rz_structured_data_map_add_string(operand, "value", reg);
 			}
 			break;
 		}
 		default:
-			pj_ks(pj, "type", "invalid");
+			rz_structured_data_map_add_string(operand, "type", "invalid");
 			break;
 		}
 		if (op->shift.type != ARM_SFT_INVALID) {
-			pj_ko(pj, "shift");
+			RzStructuredData *shift = rz_structured_data_map_add_map(operand, "shift");
 			switch (op->shift.type) {
 			case ARM_SFT_ASR:
 			case ARM_SFT_LSL:
 			case ARM_SFT_LSR:
 			case ARM_SFT_ROR:
 			case ARM_SFT_RRX:
-				pj_ks(pj, "type", shift_type_name(op->shift.type));
-				pj_kn(pj, "value", (ut64)op->shift.value);
+				rz_structured_data_map_add_string(shift, "type", shift_type_name(op->shift.type));
+				rz_structured_data_map_add_unsigned(shift, "value", (ut64)op->shift.value, false);
 				break;
 			case ARM_SFT_ASR_REG:
 			case ARM_SFT_LSL_REG:
@@ -289,65 +298,59 @@ static void opex(RzStrBuf *buf, csh handle, cs_insn *insn) {
 #if CS_NEXT_VERSION < 6
 			case ARM_SFT_RRX_REG:
 #endif
-				pj_ks(pj, "type", shift_type_name(op->shift.type));
-				pj_ks(pj, "value", cs_reg_name(handle, op->shift.value));
+				rz_structured_data_map_add_string(shift, "type", shift_type_name(op->shift.type));
+				rz_structured_data_map_add_string(shift, "value", cs_reg_name(handle, op->shift.value));
 				break;
 			default:
 				break;
 			}
-			pj_end(pj); /* o shift */
 		}
 		if (op->vector_index != -1) {
-			pj_ki(pj, "vector_index", op->vector_index);
+			rz_structured_data_map_add_signed(operand, "vector_index", op->vector_index);
 		}
 		if (op->subtracted) {
-			pj_kb(pj, "subtracted", true);
+			rz_structured_data_map_add_boolean(operand, "subtracted", true);
 		}
-		pj_end(pj); /* o operand */
 	}
-	pj_end(pj); /* a operands */
 	if (x->usermode) {
-		pj_kb(pj, "usermode", true);
+		rz_structured_data_map_add_boolean(opex, "usermode", true);
 	}
 	if (x->update_flags) {
-		pj_kb(pj, "update_flags", true);
+		rz_structured_data_map_add_boolean(opex, "update_flags", true);
 	}
 #if CS_NEXT_VERSION >= 6
 	if (insn->detail->writeback) {
 #else
 	if (x->writeback) {
 #endif
-		pj_kb(pj, "writeback", true);
+		rz_structured_data_map_add_boolean(opex, "writeback", true);
 	}
 	if (x->vector_size) {
-		pj_ki(pj, "vector_size", x->vector_size);
+		rz_structured_data_map_add_signed(opex, "vector_size", x->vector_size);
 	}
 	if (x->vector_data != ARM_VECTORDATA_INVALID) {
-		pj_ks(pj, "vector_data", vector_data_type_name(x->vector_data));
+		rz_structured_data_map_add_string(opex, "vector_data", vector_data_type_name(x->vector_data));
 	}
 	if (x->cps_mode != ARM_CPSMODE_INVALID) {
-		pj_ki(pj, "cps_mode", x->cps_mode);
+		rz_structured_data_map_add_signed(opex, "cps_mode", x->cps_mode);
 	}
 	if (x->cps_flag != ARM_CPSFLAG_INVALID) {
-		pj_ki(pj, "cps_flag", x->cps_flag);
+		rz_structured_data_map_add_signed(opex, "cps_flag", x->cps_flag);
 	}
 #if CS_NEXT_VERSION >= 6
 	if (x->cc != ARMCC_UNDEF && x->cc != ARMCC_AL) {
-		pj_ks(pj, "cc", ARMCondCodeToString(x->cc));
+		rz_structured_data_map_add_string(opex, "cc", ARMCondCodeToString(x->cc));
 	}
 #else
 	if (x->cc != ARM_CC_INVALID && x->cc != ARM_CC_AL) {
-		pj_ks(pj, "cc", ARMCondCodeToString(x->cc));
+		rz_structured_data_map_add_string(opex, "cc", ARMCondCodeToString(x->cc));
 	}
 #endif
 	if (x->mem_barrier != ARM_MB_RESERVED_0) {
-		pj_ki(pj, "mem_barrier", x->mem_barrier - 1);
+		rz_structured_data_map_add_signed(opex, "mem_barrier", x->mem_barrier - 1);
 	}
-	pj_end(pj);
 
-	rz_strbuf_init(buf);
-	rz_strbuf_append(buf, pj_string(pj));
-	pj_free(pj);
+	return root;
 }
 
 static const char *cc_name64(arm64_cc cc) {
@@ -462,187 +465,190 @@ static const char *vess_name(arm64_vess vess) {
 }
 #endif
 
-static void opex64(RzStrBuf *buf, csh handle, cs_insn *insn) {
-	int i;
-	PJ *pj = pj_new();
-	if (!pj) {
-		return;
+static RzStructuredData *aarch64_opex(csh handle, cs_insn *insn) {
+	if (!insn->detail) {
+		return NULL;
 	}
-	pj_o(pj);
-	pj_ka(pj, "operands");
+
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
+	}
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
 	cs_arm64 *x = &insn->detail->arm64;
-	for (i = 0; i < x->op_count; i++) {
+	for (st32 i = 0; i < x->op_count; i++) {
 		cs_arm64_op *op = x->operands + i;
-		pj_o(pj);
+		RzStructuredData *operand = rz_structured_data_array_add_map(operands);
 		switch (op->type) {
 		case ARM64_OP_REG:
-			pj_ks(pj, "type", "reg");
-			pj_ks(pj, "value", cs_reg_name(handle, op->reg));
+			rz_structured_data_map_add_string(operand, "type", "reg");
+			rz_structured_data_map_add_string(operand, "value", cs_reg_name(handle, op->reg));
 			break;
 		case ARM64_OP_REG_MRS:
-			pj_ks(pj, "type", "reg_mrs");
+			rz_structured_data_map_add_string(operand, "type", "reg_mrs");
 			// TODO value
 			break;
 		case ARM64_OP_REG_MSR:
-			pj_ks(pj, "type", "reg_msr");
+			rz_structured_data_map_add_string(operand, "type", "reg_msr");
 			// TODO value
 			break;
 		case ARM64_OP_IMM:
-			pj_ks(pj, "type", "imm");
-			pj_kN(pj, "value", op->imm);
+			rz_structured_data_map_add_string(operand, "type", "imm");
+			rz_structured_data_map_add_signed(operand, "value", op->imm);
 			break;
 		case ARM64_OP_MEM:
-			pj_ks(pj, "type", "mem");
+			rz_structured_data_map_add_string(operand, "type", "mem");
 			if (op->mem.base != ARM64_REG_INVALID) {
-				pj_ks(pj, "base", cs_reg_name(handle, op->mem.base));
+				rz_structured_data_map_add_string(operand, "base", cs_reg_name(handle, op->mem.base));
 			}
 			if (op->mem.index != ARM64_REG_INVALID) {
-				pj_ks(pj, "index", cs_reg_name(handle, op->mem.index));
+				rz_structured_data_map_add_string(operand, "index", cs_reg_name(handle, op->mem.index));
 			}
-			pj_ki(pj, "disp", op->mem.disp);
+			rz_structured_data_map_add_signed(operand, "disp", op->mem.disp);
 			break;
 		case ARM64_OP_FP:
-			pj_ks(pj, "type", "fp");
-			pj_kd(pj, "value", op->fp);
+			rz_structured_data_map_add_string(operand, "type", "fp");
+			rz_structured_data_map_add_double(operand, "value", op->fp);
 			break;
 		case ARM64_OP_CIMM:
-			pj_ks(pj, "type", "cimm");
-			pj_kN(pj, "value", op->imm);
+			rz_structured_data_map_add_string(operand, "type", "cimm");
+			rz_structured_data_map_add_signed(operand, "value", op->imm);
 			break;
 #if CS_NEXT_VERSION < 6
 		case ARM64_OP_PSTATE:
-			pj_ks(pj, "type", "pstate");
+			rz_structured_data_map_add_string(operand, "type", "pstate");
 			switch (op->pstate) {
 			case ARM64_PSTATE_SPSEL:
-				pj_ks(pj, "value", "spsel");
+				rz_structured_data_map_add_string(operand, "value", "spsel");
 				break;
 			case ARM64_PSTATE_DAIFSET:
-				pj_ks(pj, "value", "daifset");
+				rz_structured_data_map_add_string(operand, "value", "daifset");
 				break;
 			case ARM64_PSTATE_DAIFCLR:
-				pj_ks(pj, "value", "daifclr");
+				rz_structured_data_map_add_string(operand, "value", "daifclr");
 				break;
 			default:
-				pj_ki(pj, "value", op->pstate);
+				rz_structured_data_map_add_string(operand, "value", op->pstate);
 			}
 			break;
 		case ARM64_OP_SYS:
-			pj_ks(pj, "type", "sys");
-			pj_kn(pj, "value", (ut64)op->sys);
+			rz_structured_data_map_add_string(operand, "type", "sys");
+			rz_structured_data_map_add_unsigned(operand, "value", (ut64)op->sys, false);
 			break;
 		case ARM64_OP_PREFETCH:
-			pj_ks(pj, "type", "prefetch");
-			pj_ki(pj, "value", op->prefetch - 1);
+			rz_structured_data_map_add_string(operand, "type", "prefetch");
+			rz_structured_data_map_add_string(operand, "value", op->prefetch - 1);
 			break;
 		case ARM64_OP_BARRIER:
-			pj_ks(pj, "type", "prefetch");
-			pj_ki(pj, "value", op->barrier - 1);
+			rz_structured_data_map_add_string(operand, "type", "prefetch");
+			rz_structured_data_map_add_string(operand, "value", op->barrier - 1);
 			break;
 #else
 		case AARCH64_OP_SYSALIAS:
 			switch (op->sysop.sub_type) {
 			default:
-				pj_ks(pj, "type", "sys");
-				pj_kn(pj, "value", op->sysop.alias.raw_val);
+				rz_structured_data_map_add_string(operand, "type", "sys");
+				rz_structured_data_map_add_unsigned(operand, "value", op->sysop.alias.raw_val, false);
 				break;
 			case AARCH64_OP_PSTATEIMM0_1:
-				pj_ks(pj, "type", "pstate");
-				pj_ki(pj, "value", op->sysop.alias.pstateimm0_1);
+				rz_structured_data_map_add_string(operand, "type", "pstate");
+				rz_structured_data_map_add_signed(operand, "value", op->sysop.alias.pstateimm0_1);
 				break;
 			case AARCH64_OP_PSTATEIMM0_15:
-				pj_ks(pj, "type", "pstate");
+				rz_structured_data_map_add_string(operand, "type", "pstate");
 				switch (op->sysop.alias.pstateimm0_15) {
 				case AARCH64_PSTATEIMM0_15_SPSEL:
-					pj_ks(pj, "value", "spsel");
+					rz_structured_data_map_add_string(operand, "value", "spsel");
 					break;
 				case AARCH64_PSTATEIMM0_15_DAIFSET:
-					pj_ks(pj, "value", "daifset");
+					rz_structured_data_map_add_string(operand, "value", "daifset");
 					break;
 				case AARCH64_PSTATEIMM0_15_DAIFCLR:
-					pj_ks(pj, "value", "daifclr");
+					rz_structured_data_map_add_string(operand, "value", "daifclr");
 					break;
 				default:
-					pj_ki(pj, "value", op->sysop.alias.pstateimm0_15);
+					rz_structured_data_map_add_signed(operand, "value", op->sysop.alias.pstateimm0_15);
 				}
 				break;
 			case AARCH64_OP_PRFM:
-				pj_ks(pj, "type", "prefetch");
-				pj_ki(pj, "value", op->sysop.alias.prfm);
+				rz_structured_data_map_add_string(operand, "type", "prefetch");
+				rz_structured_data_map_add_signed(operand, "value", op->sysop.alias.prfm);
 				break;
 			case AARCH64_OP_DB:
-				pj_ks(pj, "type", "prefetch");
-				pj_ki(pj, "value", op->sysop.alias.db);
+				rz_structured_data_map_add_string(operand, "type", "prefetch");
+				rz_structured_data_map_add_signed(operand, "value", op->sysop.alias.db);
 				break;
 			}
 			break;
 #endif
 		default:
-			pj_ks(pj, "type", "invalid");
+			rz_structured_data_map_add_string(operand, "type", "invalid");
 			break;
 		}
 		if (op->shift.type != ARM64_SFT_INVALID) {
-			pj_ko(pj, "shift");
+			RzStructuredData *shift = rz_structured_data_map_add_map(operand, "shift");
 			switch (op->shift.type) {
 			case ARM64_SFT_LSL:
-				pj_ks(pj, "type", "lsl");
+				rz_structured_data_map_add_string(shift, "type", "lsl");
 				break;
 			case ARM64_SFT_MSL:
-				pj_ks(pj, "type", "msl");
+				rz_structured_data_map_add_string(shift, "type", "msl");
 				break;
 			case ARM64_SFT_LSR:
-				pj_ks(pj, "type", "lsr");
+				rz_structured_data_map_add_string(shift, "type", "lsr");
 				break;
 			case ARM64_SFT_ASR:
-				pj_ks(pj, "type", "asr");
+				rz_structured_data_map_add_string(shift, "type", "asr");
 				break;
 			case ARM64_SFT_ROR:
-				pj_ks(pj, "type", "ror");
+				rz_structured_data_map_add_string(shift, "type", "ror");
 				break;
 			default:
 				break;
 			}
-			pj_kn(pj, "value", (ut64)op->shift.value);
-			pj_end(pj);
+			rz_structured_data_map_add_unsigned(shift, "value", (ut64)op->shift.value, false);
 		}
 		if (op->ext != ARM64_EXT_INVALID) {
-			pj_ks(pj, "ext", extender_name(op->ext));
+			rz_structured_data_map_add_string(operand, "ext", extender_name(op->ext));
 		}
 		if (op->vector_index != -1) {
-			pj_ki(pj, "vector_index", op->vector_index);
+			rz_structured_data_map_add_signed(operand, "vector_index", op->vector_index);
 		}
 #if CS_NEXT_VERSION < 6
 		if (op->vas != ARM64_VAS_INVALID) {
 #else
 		if (op->vas != AARCH64LAYOUT_INVALID) {
 #endif
-			pj_ks(pj, "vas", vas_name(op->vas));
+			rz_structured_data_map_add_string(operand, "vas", vas_name(op->vas));
 		}
 #if CS_API_MAJOR == 4
 		if (op->vess != ARM64_VESS_INVALID) {
-			pj_ks(pj, "vess", vess_name(op->vess));
+			rz_structured_data_map_add_string(operand, "vess", vess_name(op->vess));
 		}
 #endif
-		pj_end(pj);
 	}
-	pj_end(pj);
 	if (x->update_flags) {
-		pj_kb(pj, "update_flags", true);
+		rz_structured_data_map_add_boolean(opex, "update_flags", true);
 	}
 #if CS_NEXT_VERSION < 6
 	if (x->writeback) {
 #else
 	if (insn->detail->writeback) {
 #endif
-		pj_kb(pj, "writeback", true);
+		rz_structured_data_map_add_boolean(opex, "writeback", true);
 	}
 	if (cc_holds_cond(x->cc)) {
-		pj_ks(pj, "cc", cc_name64(x->cc));
+		rz_structured_data_map_add_string(opex, "cc", cc_name64(x->cc));
 	}
-	pj_end(pj);
 
-	rz_strbuf_init(buf);
-	rz_strbuf_append(buf, pj_string(pj));
-	pj_free(pj);
+	return root;
 }
 
 static int cond_cs2rz_32(int cc) {
@@ -2139,7 +2145,7 @@ static int analysis_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *bu
 		if (a->bits == 64) {
 			anop64(ctx, op, insn);
 			if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
-				opex64(&op->opex, ctx->handle, insn);
+				op->opex = aarch64_opex(ctx->handle, insn);
 			}
 			if (mask & RZ_ANALYSIS_OP_MASK_ESIL) {
 				rz_arm_cs_analysis_op_64_esil(a, op, addr, buf, len, &ctx->handle, insn);
@@ -2150,7 +2156,7 @@ static int analysis_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *bu
 		} else {
 			anop32(a, ctx->handle, op, insn, thumb, (ut8 *)buf, len);
 			if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
-				opex(&op->opex, ctx->handle, insn);
+				op->opex = arm_opex(ctx->handle, insn);
 			}
 			if (mask & RZ_ANALYSIS_OP_MASK_ESIL) {
 				rz_arm_cs_analysis_op_32_esil(a, op, addr, buf, len, &ctx->handle, insn, thumb);

--- a/librz/arch/p/analysis/analysis_arm_cs.c
+++ b/librz/arch/p/analysis/analysis_arm_cs.c
@@ -551,6 +551,51 @@ static RzStructuredData *aarch64_opex(csh handle, cs_insn *insn) {
 			rz_structured_data_map_add_string(operand, "value", op->barrier - 1);
 			break;
 #else
+		case AARCH64_OP_SYSREG: {
+			rz_structured_data_map_add_string(operand, "type", "sysreg");
+			rz_structured_data_map_add_unsigned(operand, "sysreg", op->sysop.reg.sysreg, true);
+			rz_structured_data_map_add_unsigned(operand, "tlbi", op->sysop.reg.tlbi, true);
+			rz_structured_data_map_add_unsigned(operand, "ic", op->sysop.reg.ic, true);
+			break;
+		}
+		case AARCH64_OP_SYSIMM: {
+			rz_structured_data_map_add_string(operand, "type", "sysimm");
+			switch (op->sysop.imm.dbnxs) {
+			case AARCH64_DBNXS_ISHNXS:
+				rz_structured_data_map_add_string(operand, "dbnxs", "ishnxs");
+				break;
+			case AARCH64_DBNXS_NSHNXS:
+				rz_structured_data_map_add_string(operand, "dbnxs", "nshnxs");
+				break;
+			case AARCH64_DBNXS_OSHNXS:
+				rz_structured_data_map_add_string(operand, "dbnxs", "oshnxs");
+				break;
+			case AARCH64_DBNXS_SYNXS:
+				rz_structured_data_map_add_string(operand, "dbnxs", "synxs");
+				break;
+			default:
+				rz_structured_data_map_add_unsigned(operand, "dbnxs", op->sysop.imm.dbnxs, true);
+				break;
+			}
+			switch (op->sysop.imm.exactfpimm) {
+			case AARCH64_EXACTFPIMM_HALF:
+				rz_structured_data_map_add_string(operand, "exactfpimm", "half");
+				break;
+			case AARCH64_EXACTFPIMM_ONE:
+				rz_structured_data_map_add_string(operand, "exactfpimm", "one");
+				break;
+			case AARCH64_EXACTFPIMM_TWO:
+				rz_structured_data_map_add_string(operand, "exactfpimm", "two");
+				break;
+			case AARCH64_EXACTFPIMM_ZERO:
+				rz_structured_data_map_add_string(operand, "exactfpimm", "zero");
+				break;
+			default:
+				rz_structured_data_map_add_unsigned(operand, "exactfpimm", op->sysop.imm.exactfpimm, true);
+				break;
+			}
+			break;
+		}
 		case AARCH64_OP_SYSALIAS:
 			switch (op->sysop.sub_type) {
 			default:

--- a/librz/arch/p/analysis/analysis_loongarch_cs.c
+++ b/librz/arch/p/analysis/analysis_loongarch_cs.c
@@ -162,46 +162,50 @@ static void loongarch_fillval(RzAsmLoongArchContext *ctx, RzAnalysis *a, RzAnaly
 	}
 }
 
-static void loongarch_opex(RzAsmLoongArchContext *ctx, RzStrBuf *ptr) {
+static RzStructuredData *loongarch_opex(RzAsmLoongArchContext *ctx) {
 	if (!ctx->insn->detail) {
-		return;
+		return NULL;
 	}
-	PJ *pj = pj_new();
-	if (!pj) {
-		return;
+
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
 	}
-	pj_o(pj);
-	pj_ka(pj, "operands");
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
 	cs_loongarch *al = &ctx->insn->detail->loongarch;
 	for (st32 i = 0; i < al->op_count; i++) {
 		cs_loongarch_op *op = al->operands + i;
-		pj_o(pj);
+		RzStructuredData *operand = rz_structured_data_array_add_map(operands);
 		switch (op->type) {
-		default: // LOONGARCH_OP_MEM
+		case LOONGARCH_OP_MEM:
+			rz_structured_data_map_add_string(operand, "type", "mem");
+			if (op->mem.base != LOONGARCH_REG_INVALID) {
+				rz_structured_data_map_add_string(operand, "base", cs_reg_name(ctx->h, op->mem.base));
+			}
+			rz_structured_data_map_add_signed(operand, "disp", op->mem.disp);
 			break;
-		case LOONGARCH_OP_INVALID: {
-			pj_ks(pj, "type", "invalid");
+		case LOONGARCH_OP_REG:
+			rz_structured_data_map_add_string(operand, "type", "reg");
+			rz_structured_data_map_add_string(operand, "value", cs_reg_name(ctx->h, op->reg));
+			break;
+		case LOONGARCH_OP_IMM:
+			rz_structured_data_map_add_string(operand, "type", "imm");
+			rz_structured_data_map_add_signed(operand, "value", op->imm);
+			break;
+		default:
+			rz_structured_data_map_add_string(operand, "type", "invalid");
 			break;
 		}
-		case LOONGARCH_OP_REG: {
-			pj_ks(pj, "type", "reg");
-			pj_ks(pj, "value", cs_reg_name(ctx->h, op->reg));
-			break;
-		}
-		case LOONGARCH_OP_IMM: {
-			pj_ks(pj, "type", "imm");
-			pj_ki(pj, "value", op->imm);
-			break;
-		}
-		}
-		pj_end(pj);
 	}
-	pj_end(pj);
-	pj_end(pj);
 
-	rz_strbuf_init(ptr);
-	rz_strbuf_append(ptr, pj_string(pj));
-	pj_free(pj);
+	return root;
 }
 
 static void loongarch_op_set_type(RzAsmLoongArchContext *ctx, RzAnalysisOp *op) {
@@ -2400,7 +2404,7 @@ static int loongarch_analysis_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, con
 	loongarch_op_set_type(ctx, op);
 
 	if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
-		loongarch_opex(ctx, &op->opex);
+		op->opex = loongarch_opex(ctx);
 	}
 	if (mask & RZ_ANALYSIS_OP_MASK_VAL) {
 		loongarch_fillval(ctx, a, op);

--- a/librz/arch/p/analysis/analysis_m68k_cs.c
+++ b/librz/arch/p/analysis/analysis_m68k_cs.c
@@ -53,59 +53,63 @@ static inline void handle_jump_instruction(RzAnalysisOp *op, ut64 addr, cs_m68k 
 	op->fail = make_64bits_address(addr + op->size);
 }
 
-static void opex(RzStrBuf *buf, csh handle, cs_insn *insn) {
-	int i;
-	PJ *pj = pj_new();
-	if (!pj) {
-		return;
+static RzStructuredData *mk68_opex(csh handle, cs_insn *insn) {
+	if (!insn->detail) {
+		return NULL;
 	}
-	pj_o(pj);
+
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
+	}
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
 	cs_m68k *x = &insn->detail->m68k;
-	pj_ka(pj, "operands");
-	for (i = 0; i < x->op_count; i++) {
+	for (st32 i = 0; i < x->op_count; i++) {
 		cs_m68k_op *op = &x->operands[i];
-		pj_o(pj);
+		RzStructuredData *operand = rz_structured_data_array_add_map(operands);
 		switch (op->type) {
 		case M68K_OP_REG:
-			pj_ks(pj, "type", "reg");
-			pj_ks(pj, "value", cs_reg_name(handle, op->reg));
+			rz_structured_data_map_add_string(operand, "type", "reg");
+			rz_structured_data_map_add_string(operand, "value", cs_reg_name(handle, op->reg));
 			break;
 		case M68K_OP_IMM:
-			pj_ks(pj, "type", "imm");
-			pj_kN(pj, "value", (st64)op->imm);
+			rz_structured_data_map_add_string(operand, "type", "imm");
+			rz_structured_data_map_add_signed(operand, "value", (st64)op->imm);
 			break;
 		case M68K_OP_MEM:
-			pj_ks(pj, "type", "mem");
+			rz_structured_data_map_add_string(operand, "type", "mem");
 			if (op->mem.base_reg != M68K_REG_INVALID) {
-				pj_ks(pj, "base_reg", cs_reg_name(handle, op->mem.base_reg));
+				rz_structured_data_map_add_string(operand, "base_reg", cs_reg_name(handle, op->mem.base_reg));
 			}
 			if (op->mem.index_reg != M68K_REG_INVALID) {
-				pj_ks(pj, "index_reg", cs_reg_name(handle, op->mem.index_reg));
+				rz_structured_data_map_add_string(operand, "index_reg", cs_reg_name(handle, op->mem.index_reg));
 			}
 			if (op->mem.in_base_reg != M68K_REG_INVALID) {
-				pj_ks(pj, "in_base_reg", cs_reg_name(handle, op->mem.in_base_reg));
+				rz_structured_data_map_add_string(operand, "in_base_reg", cs_reg_name(handle, op->mem.in_base_reg));
 			}
-			pj_kN(pj, "in_disp", op->mem.in_disp);
-			pj_kN(pj, "out_disp", op->mem.out_disp);
-			pj_ki(pj, "disp", op->mem.disp);
-			pj_ki(pj, "scale", op->mem.scale);
-			pj_ki(pj, "bitfield", op->mem.bitfield);
-			pj_ki(pj, "width", op->mem.width);
-			pj_ki(pj, "offset", op->mem.offset);
-			pj_ki(pj, "index_size", op->mem.index_size);
+			rz_structured_data_map_add_signed(operand, "in_disp", op->mem.in_disp);
+			rz_structured_data_map_add_signed(operand, "out_disp", op->mem.out_disp);
+			rz_structured_data_map_add_signed(operand, "disp", op->mem.disp);
+			rz_structured_data_map_add_signed(operand, "scale", op->mem.scale);
+			rz_structured_data_map_add_signed(operand, "bitfield", op->mem.bitfield);
+			rz_structured_data_map_add_signed(operand, "width", op->mem.width);
+			rz_structured_data_map_add_signed(operand, "offset", op->mem.offset);
+			rz_structured_data_map_add_signed(operand, "index_size", op->mem.index_size);
 			break;
 		default:
-			pj_ks(pj, "type", "invalid");
+			rz_structured_data_map_add_string(operand, "type", "invalid");
 			break;
 		}
-		pj_end(pj); /* o operand */
 	}
-	pj_end(pj); /* a operands */
-	pj_end(pj);
 
-	rz_strbuf_init(buf);
-	rz_strbuf_append(buf, pj_string(pj));
-	pj_free(pj);
+	return root;
 }
 
 static int parse_reg_name(RzRegItem *reg, csh handle, cs_insn *insn, int reg_num) {
@@ -238,7 +242,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	op->id = insn->id;
 	opsize = op->size = insn->size;
 	if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
-		opex(&op->opex, ctx->handle, insn);
+		op->opex = mk68_opex(ctx->handle, insn);
 	}
 	switch (insn->id) {
 	case M68K_INS_INVALID:

--- a/librz/arch/p/analysis/analysis_mcs96.c
+++ b/librz/arch/p/analysis/analysis_mcs96.c
@@ -9,7 +9,7 @@
 #include <rz_util/rz_pj.h>
 #include "mcs96/mcs96.h"
 
-static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
+static int mcs96_archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
 	switch (query) {
 	case RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE:
 		return 1;
@@ -26,20 +26,20 @@ static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
 	}
 }
 
-static char *get_reg_profile(RzAnalysis *analysis) {
+static char *mcs96_get_reg_profile(RzAnalysis *analysis) {
 	const char *p =
-		"=PC pc\n"
-		"=SP sp\n"
-		"=SR psw\n"
-		"=A0	garbage\n"
-		"=A1	garbage\n"
-		"=A2	garbage\n"
-		"gpr pc  .16  0   0\n" // Program counter
-		"gpr sp  .16  2   0\n" // Stack pointer
-		"gpr psw .16  4   0\n" // Processor status word
-		"gpr garbage  .16  6   0\n"
-		"gpr garbage  .16  8   0\n"
-		"gpr garbage  .16  10  0\n";
+		"=PC   pc\n"
+		"=SP   sp\n"
+		"=SR   psw\n"
+		"=A0   garbage\n"
+		"=A1   garbage\n"
+		"=A2   garbage\n"
+		"gpr   pc       .16  0   0\n" // Program counter
+		"gpr   sp       .16  2   0\n" // Stack pointer
+		"gpr   psw      .16  4   0\n" // Processor status word
+		"gpr   garbage  .16  6   0\n"
+		"gpr   garbage  .16  8   0\n"
+		"gpr   garbage  .16  10  0\n";
 	return rz_str_dup(p);
 }
 
@@ -58,44 +58,47 @@ static inline void analyze_shift_count(RzAnalysisOp *op, ut8 byte) {
 	}
 }
 
-static void opex_add_reg(PJ *pj, ut8 reg) {
-	pj_o(pj);
-	pj_ks(pj, "type", "reg");
-	pj_kn(pj, "value", reg);
-	pj_end(pj);
+static void opex_add_reg(RzStructuredData *operands, ut64 reg) {
+	RzStructuredData *operand = rz_structured_data_array_add_map(operands);
+	rz_structured_data_map_add_string(operand, "type", "reg");
+	rz_structured_data_map_add_unsigned(operand, "value", reg, false);
 }
 
-static void opex_add_imm(PJ *pj, st64 imm) {
-	pj_o(pj);
-	pj_ks(pj, "type", "imm");
-	pj_kn(pj, "value", imm);
-	pj_end(pj);
+static void opex_add_imm(RzStructuredData *operands, st64 imm) {
+	RzStructuredData *operand = rz_structured_data_array_add_map(operands);
+	rz_structured_data_map_add_string(operand, "type", "imm");
+	rz_structured_data_map_add_signed(operand, "value", imm);
 }
 
-static void opex_add_mem(PJ *pj, ut8 base, st64 offset, bool autoincrement) {
-	pj_o(pj);
-	pj_ks(pj, "type", "mem");
-	pj_kn(pj, "base", base);
-	if (offset != 0) {
-		pj_kn(pj, "disp", offset);
+static void opex_add_mem(RzStructuredData *operands, ut64 base, st64 disp, bool autoincrement) {
+	RzStructuredData *operand = rz_structured_data_array_add_map(operands);
+	rz_structured_data_map_add_string(operand, "type", "mem");
+	rz_structured_data_map_add_unsigned(operand, "value", base, false);
+	if (disp) {
+		rz_structured_data_map_add_signed(operand, "disp", disp);
 	}
 	if (autoincrement) {
-		pj_kb(pj, "autoincrement", true);
+		rz_structured_data_map_add_boolean(operand, "autoincrement", true);
 	}
-	pj_end(pj);
 }
 
-static void mcs96_opex(RzStrBuf *opex, const ut8 *buf, int size, ut32 isa_bit) {
+static RzStructuredData *mcs96_opex(const ut8 *buf, const int size, ut32 isa_bit) {
 	if (size < 1) {
-		return;
+		return NULL;
 	}
 
-	PJ *pj = pj_new();
-	if (!pj) {
-		return;
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
 	}
-	pj_o(pj);
-	pj_ka(pj, "operands");
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
 
 	ut8 opcode = buf[0];
 	ut32 instr_fmt = mcs96_op[opcode].type;
@@ -103,87 +106,87 @@ static void mcs96_opex(RzStrBuf *opex, const ut8 *buf, int size, ut32 isa_bit) {
 
 	if (instr_fmt & MCS96_FMT_OPC_BYTEOPR && size == 2) {
 		ut8 operand = buf[1];
-		opex_add_reg(pj, operand);
+		opex_add_reg(operands, operand);
 	} else if (instr_fmt & MCS96_FMT_2_BYTE_NOP && size == 2) {
 		// No operands
 	} else if (instr_fmt & MCS96_FMT_OPC_IMM11 && size == 2) {
 		st16 imm11 = extract_disp11(opcode, buf[1]);
-		opex_add_imm(pj, imm11);
+		opex_add_imm(operands, imm11);
 	} else if (instr_fmt & MCS96_FMT_OPC_BYTEOPR_X2 && size == 3) {
 		ut8 opr0 = buf[2];
 		ut8 opr1 = buf[1];
-		opex_add_reg(pj, opr0);
-		opex_add_reg(pj, opr1);
+		opex_add_reg(operands, opr0);
+		opex_add_reg(operands, opr1);
 	} else if (instr_fmt & MCS96_FMT_OPC_IMM16 && size == 3) {
 		st16 imm = (st16)rz_read_le16(buf + 1);
-		opex_add_imm(pj, imm);
+		opex_add_imm(operands, imm);
 	} else if (instr_fmt & MCS96_FMT_TIJMP && size == 4) {
 		ut8 index = buf[1];
 		ut8 mask = buf[2];
 		ut8 tbase = buf[3];
-		opex_add_reg(pj, tbase);
-		opex_add_reg(pj, index);
-		opex_add_imm(pj, mask);
+		opex_add_reg(operands, tbase);
+		opex_add_reg(operands, index);
+		opex_add_imm(operands, mask);
 	} else if (instr_fmt & MCS96_FMT_OPC_IMM11_BYTEOPR && size == 3) {
 		st16 imm11 = extract_disp11(opcode, buf[2]);
 		ut8 reg = buf[1];
-		opex_add_reg(pj, reg);
-		opex_add_imm(pj, imm11);
+		opex_add_reg(operands, reg);
+		opex_add_imm(operands, imm11);
 	} else if (instr_fmt & MCS96_FMT_OPC_IMM24 && size == 4) {
 		ut32 imm = (ut32)rz_read_le24(buf + 1);
-		opex_add_imm(pj, imm);
+		opex_add_imm(operands, imm);
 	} else if (instr_fmt & MCS96_FMT_OPC_INDEX && size >= 1) {
 		ut8 reg = buf[1] & 0xFE; // erase lsb
 		if (size == 3) {
 			ut8 offset = buf[2];
-			opex_add_mem(pj, reg, offset, false);
+			opex_add_mem(operands, reg, offset, false);
 		} else if (size == 4) {
 			ut16 offset = rz_read_le16(buf + 2);
-			opex_add_mem(pj, reg, offset, false);
+			opex_add_mem(operands, reg, offset, false);
 		}
 	} else if (instr_fmt & MCS96_FMT_EXTENDED_INDEXED && size == 6) {
 		ut8 dst = buf[5];
 		ut8 base = buf[1];
 		st32 offset = (st32)rz_read_le24(buf + 2);
-		opex_add_reg(pj, dst);
-		opex_add_mem(pj, base, offset, false);
+		opex_add_reg(operands, dst);
+		opex_add_mem(operands, base, offset, false);
 	} else if (instr_fmt & MCS96_FMT_2OP) {
 		if (addr_mode == MCS96_ADDRESSING_REG_DIRECT && size == 3) {
 			ut8 dst = buf[2];
 			ut8 src_reg = buf[1];
-			opex_add_reg(pj, dst);
-			opex_add_reg(pj, src_reg);
+			opex_add_reg(operands, dst);
+			opex_add_reg(operands, src_reg);
 		} else if (addr_mode == MCS96_ADDRESSING_IMMEDIATE) {
 			if (size == 3) {
 				ut8 dst = buf[2];
 				ut8 src_imm8 = buf[1];
-				opex_add_reg(pj, dst);
-				opex_add_imm(pj, src_imm8);
+				opex_add_reg(operands, dst);
+				opex_add_imm(operands, src_imm8);
 			} else if (size == 4) {
 				ut8 dst = buf[3];
 				ut16 src_imm16 = rz_read_le16(buf + 1);
-				opex_add_reg(pj, dst);
-				opex_add_imm(pj, src_imm16);
+				opex_add_reg(operands, dst);
+				opex_add_imm(operands, src_imm16);
 			}
 		} else if (addr_mode == MCS96_ADDRESSING_INDIRECT && size == 3) {
 			ut8 dst = buf[2];
 			bool autoincrement = buf[1] & 0x1;
 			ut8 src_reg = buf[1] & 0xFE;
-			opex_add_reg(pj, dst);
-			opex_add_mem(pj, src_reg, 0, autoincrement);
+			opex_add_reg(operands, dst);
+			opex_add_mem(operands, src_reg, 0, autoincrement);
 		} else if (addr_mode == MCS96_ADDRESSING_INDEXED) {
 			if (size == 4) {
 				ut8 dst = buf[3];
 				ut8 offset = buf[2];
 				ut8 base = buf[1] & 0xFE; // erase lsb
-				opex_add_reg(pj, dst);
-				opex_add_mem(pj, base, offset, false);
+				opex_add_reg(operands, dst);
+				opex_add_mem(operands, base, offset, false);
 			} else if (size == 5) {
 				ut8 dst = buf[4];
 				ut16 offset = rz_read_le16(buf + 2);
 				ut8 base = buf[1] & 0xFE; // erase lsb
-				opex_add_reg(pj, dst);
-				opex_add_mem(pj, base, offset, false);
+				opex_add_reg(operands, dst);
+				opex_add_mem(operands, base, offset, false);
 			}
 		}
 	} else if (instr_fmt & MCS96_FMT_3OP) {
@@ -191,62 +194,58 @@ static void mcs96_opex(RzStrBuf *opex, const ut8 *buf, int size, ut32 isa_bit) {
 			ut8 dst = buf[3];
 			ut8 src0_reg = buf[2];
 			ut8 src1_reg = buf[1];
-			opex_add_reg(pj, dst);
-			opex_add_reg(pj, src0_reg);
-			opex_add_reg(pj, src1_reg);
+			opex_add_reg(operands, dst);
+			opex_add_reg(operands, src0_reg);
+			opex_add_reg(operands, src1_reg);
 		} else if (addr_mode == MCS96_ADDRESSING_IMMEDIATE) {
 			if (size == 4) {
 				ut8 dst = buf[3];
 				ut8 src0_reg = buf[2];
 				ut8 src_imm8 = buf[1];
-				opex_add_reg(pj, dst);
-				opex_add_reg(pj, src0_reg);
-				opex_add_imm(pj, src_imm8);
+				opex_add_reg(operands, dst);
+				opex_add_reg(operands, src0_reg);
+				opex_add_imm(operands, src_imm8);
 			} else if (size == 5) {
 				ut8 dst = buf[4];
 				ut8 src0_reg = buf[3];
 				ut16 src_imm16 = rz_read_le16(buf + 1);
-				opex_add_reg(pj, dst);
-				opex_add_reg(pj, src0_reg);
-				opex_add_imm(pj, src_imm16);
+				opex_add_reg(operands, dst);
+				opex_add_reg(operands, src0_reg);
+				opex_add_imm(operands, src_imm16);
 			}
 		} else if (addr_mode == MCS96_ADDRESSING_INDIRECT && size == 4) {
 			ut8 dst = buf[3];
 			ut8 src0_reg = buf[2];
 			ut8 src1_reg = buf[1] & 0xFE;
 			bool autoincrement = buf[1] & 0x1;
-			opex_add_reg(pj, dst);
-			opex_add_reg(pj, src0_reg);
-			opex_add_mem(pj, src1_reg, 0, autoincrement);
+			opex_add_reg(operands, dst);
+			opex_add_reg(operands, src0_reg);
+			opex_add_mem(operands, src1_reg, 0, autoincrement);
 		} else if (addr_mode == MCS96_ADDRESSING_INDEXED) {
 			if (size == 5) {
 				ut8 dst = buf[4];
 				ut8 src1_reg = buf[3];
 				ut8 offset = buf[2];
 				ut8 base = buf[1] & 0xFE; // erase lsb
-				opex_add_reg(pj, dst);
-				opex_add_reg(pj, src1_reg);
-				opex_add_mem(pj, base, offset, false);
+				opex_add_reg(operands, dst);
+				opex_add_reg(operands, src1_reg);
+				opex_add_mem(operands, base, offset, false);
 			} else if (size == 6) {
 				ut8 dst = buf[5];
 				ut8 src1_reg = buf[4];
 				ut16 offset = rz_read_le16(buf + 2);
 				ut8 base = buf[1] & 0xFE; // erase lsb
-				opex_add_reg(pj, dst);
-				opex_add_reg(pj, src1_reg);
-				opex_add_mem(pj, base, offset, false);
+				opex_add_reg(operands, dst);
+				opex_add_reg(operands, src1_reg);
+				opex_add_mem(operands, base, offset, false);
 			}
 		}
 	}
 
-	pj_end(pj); // operands array
-	pj_end(pj); // root object
-	rz_strbuf_init(opex);
-	rz_strbuf_append(opex, pj_string(pj));
-	pj_free(pj);
+	return root;
 }
 
-static int analyze_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask) {
+static int mcs96_analyze_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask) {
 	// Determine CPU variant from analysis->cpu
 	ut32 isa_bit = MCS96_8096; // default
 	if (analysis->cpu && *analysis->cpu) {
@@ -1078,8 +1077,13 @@ static int analyze_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const u
 		break;
 	}
 
+	if (mask & RZ_ANALYSIS_OP_MASK_DISASM) {
+		const char *mnemonic = decode_mnemonic(buf, op->size, isa_bit);
+		op->mnemonic = rz_str_dup(mnemonic);
+	}
+
 	if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
-		mcs96_opex(&op->opex, buf, size, isa_bit);
+		op->opex = mcs96_opex(buf, size, isa_bit);
 	}
 
 	return op->size;
@@ -1092,7 +1096,7 @@ RzAnalysisPlugin rz_analysis_plugin_mcs96 = {
 	.arch = "mcs96",
 	.author = "bubblepipe",
 	.bits = 16,
-	.archinfo = archinfo,
-	.get_reg_profile = get_reg_profile,
-	.op = analyze_op,
+	.archinfo = mcs96_archinfo,
+	.get_reg_profile = mcs96_get_reg_profile,
+	.op = mcs96_analyze_op,
 };

--- a/librz/arch/p/analysis/analysis_mips_cs.c
+++ b/librz/arch/p/analysis/analysis_mips_cs.c
@@ -53,46 +53,50 @@
 		SET_SRC_DST_3_REGS(op); \
 	}
 
-static void opex(RzStrBuf *buf, csh handle, cs_insn *insn) {
-	int i;
-	PJ *pj = pj_new();
-	if (!pj) {
-		return;
+static RzStructuredData *mips_opex(csh handle, cs_insn *insn) {
+	if (!insn->detail) {
+		return NULL;
 	}
-	pj_o(pj);
-	pj_ka(pj, "operands");
+
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
+	}
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
 	cs_mips *x = &insn->detail->mips;
-	for (i = 0; i < x->op_count; i++) {
+	for (st32 i = 0; i < x->op_count; i++) {
 		cs_mips_op *op = x->operands + i;
-		pj_o(pj);
+		RzStructuredData *operand = rz_structured_data_array_add_map(operands);
 		switch (op->type) {
 		case MIPS_OP_REG:
-			pj_ks(pj, "type", "reg");
-			pj_ks(pj, "value", cs_reg_name(handle, op->reg));
+			rz_structured_data_map_add_string(operand, "type", "reg");
+			rz_structured_data_map_add_string(operand, "value", cs_reg_name(handle, op->reg));
 			break;
 		case MIPS_OP_IMM:
-			pj_ks(pj, "type", "imm");
-			pj_kN(pj, "value", op->imm);
+			rz_structured_data_map_add_string(operand, "type", "imm");
+			rz_structured_data_map_add_signed(operand, "value", op->imm);
 			break;
 		case MIPS_OP_MEM:
-			pj_ks(pj, "type", "mem");
+			rz_structured_data_map_add_string(operand, "type", "mem");
 			if (op->mem.base != MIPS_REG_INVALID) {
-				pj_ks(pj, "base", cs_reg_name(handle, op->mem.base));
+				rz_structured_data_map_add_string(operand, "base", cs_reg_name(handle, op->mem.base));
 			}
-			pj_kN(pj, "disp", op->mem.disp);
+			rz_structured_data_map_add_signed(operand, "disp", op->mem.disp);
 			break;
 		default:
-			pj_ks(pj, "type", "invalid");
+			rz_structured_data_map_add_string(operand, "type", "invalid");
 			break;
 		}
-		pj_end(pj); /* o operand */
 	}
-	pj_end(pj); /* a operands */
-	pj_end(pj);
 
-	rz_strbuf_init(buf);
-	rz_strbuf_append(buf, pj_string(pj));
-	pj_free(pj);
+	return root;
 }
 
 static int parse_reg_name(RzRegItem *reg, csh handle, cs_insn *insn, int reg_num) {
@@ -893,7 +897,7 @@ static int mips_analyze_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, co
 beach:
 	set_opdir(op);
 	if (insn && mask & RZ_ANALYSIS_OP_MASK_OPEX) {
-		opex(&op->opex, hndl, insn);
+		op->opex = mips_opex(hndl, insn);
 	}
 	if (mask & RZ_ANALYSIS_OP_MASK_ESIL) {
 		if (analyze_op_esil(analysis, op, addr, buf, len, &hndl, insn) != 0) {

--- a/librz/arch/p/analysis/analysis_ppc_cs.c
+++ b/librz/arch/p/analysis/analysis_ppc_cs.c
@@ -186,46 +186,50 @@ static const char *getspr(RzAnalysis *a, struct Getarg *gop, int n) {
 	return ctx->cspr;
 }
 
-static void opex(RzStrBuf *buf, csh handle, cs_insn *insn) {
-	int i;
-	PJ *pj = pj_new();
-	if (!pj) {
-		return;
+static RzStructuredData *ppc_opex(csh handle, cs_insn *insn) {
+	if (!insn->detail) {
+		return NULL;
 	}
-	pj_o(pj);
-	pj_ka(pj, "operands");
+
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
+	}
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
 	cs_ppc *x = &insn->detail->ppc;
-	for (i = 0; i < x->op_count; i++) {
+	for (st32 i = 0; i < x->op_count; i++) {
 		cs_ppc_op *op = x->operands + i;
-		pj_o(pj);
+		RzStructuredData *operand = rz_structured_data_array_add_map(operands);
 		switch (op->type) {
 		case PPC_OP_REG:
-			pj_ks(pj, "type", "reg");
-			pj_ks(pj, "value", cs_reg_name(handle, op->reg));
+			rz_structured_data_map_add_string(operand, "type", "reg");
+			rz_structured_data_map_add_string(operand, "value", cs_reg_name(handle, op->reg));
 			break;
 		case PPC_OP_IMM:
-			pj_ks(pj, "type", "imm");
-			pj_kN(pj, "value", op->imm);
+			rz_structured_data_map_add_string(operand, "type", "imm");
+			rz_structured_data_map_add_signed(operand, "value", op->imm);
 			break;
 		case PPC_OP_MEM:
-			pj_ks(pj, "type", "mem");
+			rz_structured_data_map_add_string(operand, "type", "mem");
 			if (op->mem.base != PPC_REG_INVALID) {
-				pj_ks(pj, "base", cs_reg_name(handle, op->mem.base));
+				rz_structured_data_map_add_string(operand, "base", cs_reg_name(handle, op->mem.base));
 			}
-			pj_ki(pj, "disp", op->mem.disp);
+			rz_structured_data_map_add_signed(operand, "disp", op->mem.disp);
 			break;
 		default:
-			pj_ks(pj, "type", "invalid");
+			rz_structured_data_map_add_string(operand, "type", "invalid");
 			break;
 		}
-		pj_end(pj); /* o operand */
 	}
-	pj_end(pj); /* a operands */
-	pj_end(pj);
 
-	rz_strbuf_init(buf);
-	rz_strbuf_append(buf, pj_string(pj));
-	pj_free(pj);
+	return root;
 }
 
 #define PPCSPR(n)  getspr(a, &gop, n)
@@ -994,7 +998,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 			op->mnemonic = rz_str_dup(insn->mnemonic);
 		}
 		if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
-			opex(&op->opex, ctx->handle, insn);
+			op->opex = ppc_opex(ctx->handle, insn);
 		}
 		struct Getarg gop = {
 			.handle = ctx->handle,

--- a/librz/arch/p/analysis/analysis_riscv_cs.c
+++ b/librz/arch/p/analysis/analysis_riscv_cs.c
@@ -57,46 +57,50 @@
 		SET_SRC_DST_3_REGS(op); \
 	}
 
-static void opex(RzStrBuf *buf, csh handle, cs_insn *insn) {
-	int i;
-	PJ *pj = pj_new();
-	if (!pj) {
-		return;
+static RzStructuredData *riscv_opex(csh handle, cs_insn *insn) {
+	if (!insn->detail) {
+		return NULL;
 	}
-	pj_o(pj);
-	pj_ka(pj, "operands");
+
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
+	}
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
 	cs_riscv *x = &insn->detail->riscv;
-	for (i = 0; i < x->op_count; i++) {
+	for (st32 i = 0; i < x->op_count; i++) {
 		cs_riscv_op *op = x->operands + i;
-		pj_o(pj);
+		RzStructuredData *operand = rz_structured_data_array_add_map(operands);
 		switch (op->type) {
 		case RISCV_OP_REG:
-			pj_ks(pj, "type", "reg");
-			pj_ks(pj, "value", cs_reg_name(handle, op->reg));
+			rz_structured_data_map_add_string(operand, "type", "reg");
+			rz_structured_data_map_add_string(operand, "value", cs_reg_name(handle, op->reg));
 			break;
 		case RISCV_OP_IMM:
-			pj_ks(pj, "type", "imm");
-			pj_kN(pj, "value", op->imm);
+			rz_structured_data_map_add_string(operand, "type", "imm");
+			rz_structured_data_map_add_signed(operand, "value", op->imm);
 			break;
 		case RISCV_OP_MEM:
-			pj_ks(pj, "type", "mem");
+			rz_structured_data_map_add_string(operand, "type", "mem");
 			if (op->mem.base != RISCV_REG_INVALID) {
-				pj_ks(pj, "base", cs_reg_name(handle, op->mem.base));
+				rz_structured_data_map_add_string(operand, "base", cs_reg_name(handle, op->mem.base));
 			}
-			pj_kN(pj, "disp", op->mem.disp);
+			rz_structured_data_map_add_signed(operand, "disp", op->mem.disp);
 			break;
 		default:
-			pj_ks(pj, "type", "invalid");
+			rz_structured_data_map_add_string(operand, "type", "invalid");
 			break;
 		}
-		pj_end(pj); /* o operand */
 	}
-	pj_end(pj); /* a operands */
-	pj_end(pj);
 
-	rz_strbuf_init(buf);
-	rz_strbuf_append(buf, pj_string(pj));
-	pj_free(pj);
+	return root;
 }
 
 static int parse_reg_name(RzRegItem *reg, csh handle, cs_insn *insn, int reg_num) {
@@ -265,7 +269,7 @@ static int analyze_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const u
 beach:
 	set_opdir(op);
 	if (insn && mask & RZ_ANALYSIS_OP_MASK_OPEX) {
-		opex(&op->opex, ctx->hndl, insn);
+		op->opex = riscv_opex(ctx->hndl, insn);
 	}
 	if (mask & RZ_ANALYSIS_OP_MASK_VAL) {
 		op_fillval(analysis, op, &ctx->hndl, insn);

--- a/librz/arch/p/analysis/analysis_sparc_cs.c
+++ b/librz/arch/p/analysis/analysis_sparc_cs.c
@@ -10,46 +10,50 @@
 #include "rz_il/rz_il_opcodes.h"
 #include "rz_util/rz_assert.h"
 
-static void opex(RzStrBuf *buf, csh handle, cs_insn *insn) {
-	int i;
-	PJ *pj = pj_new();
-	if (!pj) {
-		return;
+static RzStructuredData *sparc_opex(csh handle, cs_insn *insn) {
+	if (!insn->detail) {
+		return NULL;
 	}
-	pj_o(pj);
-	pj_ka(pj, "operands");
+
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
+	}
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
 	cs_sparc *x = &insn->detail->sparc;
-	for (i = 0; i < x->op_count; i++) {
+	for (st32 i = 0; i < x->op_count; i++) {
 		cs_sparc_op *op = x->operands + i;
-		pj_o(pj);
+		RzStructuredData *operand = rz_structured_data_array_add_map(operands);
 		switch (op->type) {
 		case SPARC_OP_REG:
-			pj_ks(pj, "type", "reg");
-			pj_ks(pj, "value", cs_reg_name(handle, op->reg));
+			rz_structured_data_map_add_string(operand, "type", "reg");
+			rz_structured_data_map_add_string(operand, "value", cs_reg_name(handle, op->reg));
 			break;
 		case SPARC_OP_IMM:
-			pj_ks(pj, "type", "imm");
-			pj_kN(pj, "value", op->imm);
+			rz_structured_data_map_add_string(operand, "type", "imm");
+			rz_structured_data_map_add_signed(operand, "value", op->imm);
 			break;
 		case SPARC_OP_MEM:
-			pj_ks(pj, "type", "mem");
+			rz_structured_data_map_add_string(operand, "type", "mem");
 			if (op->mem.base != SPARC_REG_INVALID) {
-				pj_ks(pj, "base", cs_reg_name(handle, op->mem.base));
+				rz_structured_data_map_add_string(operand, "base", cs_reg_name(handle, op->mem.base));
 			}
-			pj_ki(pj, "disp", op->mem.disp);
+			rz_structured_data_map_add_signed(operand, "disp", op->mem.disp);
 			break;
 		default:
-			pj_ks(pj, "type", "invalid");
+			rz_structured_data_map_add_string(operand, "type", "invalid");
 			break;
 		}
-		pj_end(pj); /* o operand */
 	}
-	pj_end(pj); /* a operands */
-	pj_end(pj);
 
-	rz_strbuf_init(buf);
-	rz_strbuf_append(buf, pj_string(pj));
-	pj_free(pj);
+	return root;
 }
 
 static int parse_reg_name(RzRegItem *reg, csh handle, cs_insn *insn, int reg_num) {
@@ -169,7 +173,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	}
 #endif
 	if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
-		opex(&op->opex, sparc->handle, insn);
+		op->opex = sparc_opex(sparc->handle, insn);
 	}
 	op->size = insn->size;
 	op->id = insn->id;

--- a/librz/arch/p/analysis/analysis_sysz.c
+++ b/librz/arch/p/analysis/analysis_sysz.c
@@ -19,46 +19,50 @@
 
 #define INSOP(n) insn->detail->sysz.operands[n]
 
-static void opex(RzStrBuf *buf, csh handle, cs_insn *insn) {
-	int i;
-	PJ *pj = pj_new();
-	if (!pj) {
-		return;
+static RzStructuredData *sysz_opex(csh handle, cs_insn *insn) {
+	if (!insn->detail) {
+		return NULL;
 	}
-	pj_o(pj);
-	pj_ka(pj, "operands");
+
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
+	}
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
 	cs_sysz *x = &insn->detail->sysz;
-	for (i = 0; i < x->op_count; i++) {
+	for (st32 i = 0; i < x->op_count; i++) {
 		cs_sysz_op *op = x->operands + i;
-		pj_o(pj);
+		RzStructuredData *operand = rz_structured_data_array_add_map(operands);
 		switch (op->type) {
 		case SYSZ_OP_REG:
-			pj_ks(pj, "type", "reg");
-			pj_ks(pj, "value", cs_reg_name(handle, op->reg));
+			rz_structured_data_map_add_string(operand, "type", "reg");
+			rz_structured_data_map_add_string(operand, "value", cs_reg_name(handle, op->reg));
 			break;
 		case SYSZ_OP_IMM:
-			pj_ks(pj, "type", "imm");
-			pj_kN(pj, "value", op->imm);
+			rz_structured_data_map_add_string(operand, "type", "imm");
+			rz_structured_data_map_add_signed(operand, "value", op->imm);
 			break;
 		case SYSZ_OP_MEM:
-			pj_ks(pj, "type", "mem");
+			rz_structured_data_map_add_string(operand, "type", "mem");
 			if (op->mem.base != SYSZ_REG_INVALID) {
-				pj_ks(pj, "base", cs_reg_name(handle, op->mem.base));
+				rz_structured_data_map_add_string(operand, "base", cs_reg_name(handle, op->mem.base));
 			}
-			pj_kN(pj, "disp", op->mem.disp);
+			rz_structured_data_map_add_signed(operand, "disp", op->mem.disp);
 			break;
 		default:
-			pj_ks(pj, "type", "invalid");
+			rz_structured_data_map_add_string(operand, "type", "invalid");
 			break;
 		}
-		pj_end(pj); /* o operand */
 	}
-	pj_end(pj); /* a operands */
-	pj_end(pj);
 
-	rz_strbuf_init(buf);
-	rz_strbuf_append(buf, pj_string(pj));
-	pj_free(pj);
+	return root;
 }
 
 static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask) {
@@ -74,7 +78,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 			op->type = RZ_ANALYSIS_OP_TYPE_ILL;
 		} else {
 			if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
-				opex(&op->opex, handle, insn);
+				op->opex = sysz_opex(handle, insn);
 			}
 			op->size = insn->size;
 			switch (insn->id) {

--- a/librz/arch/p/analysis/analysis_tricore_cs.c
+++ b/librz/arch/p/analysis/analysis_tricore_cs.c
@@ -248,14 +248,13 @@ static char *tricore_reg_profile(RzAnalysis *_) {
 	return rz_str_dup(p);
 }
 
-static void tricore_opex(RzAsmTriCoreContext *ctx, RzStrBuf *sb);
+static RzStructuredData *tricore_opex(RzAsmTriCoreContext *ctx);
 
 static void tricore_fillvals(RzAsmTriCoreContext *ctx, RzAnalysis *a, RzAnalysisOp *op);
 
 static void tricore_op_set_type(RzAsmTriCoreContext *ctx, RzAnalysisOp *op);
 
-static int
-tricore_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *data, int len, RzAnalysisOpMask mask) {
+static int tricore_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *data, int len, RzAnalysisOpMask mask) {
 	if (!(a && op && data && len > 0)) {
 		return 0;
 	}
@@ -289,7 +288,7 @@ tricore_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *data, int len,
 	op->addr = ctx->insn->address;
 	tricore_op_set_type(ctx, op);
 	if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
-		tricore_opex(ctx, &op->opex);
+		op->opex = tricore_opex(ctx);
 	}
 	if (mask & RZ_ANALYSIS_OP_MASK_VAL) {
 		tricore_fillvals(ctx, a, op);
@@ -1194,47 +1193,50 @@ static void tricore_fillvals(RzAsmTriCoreContext *ctx, RzAnalysis *a, RzAnalysis
 	}
 }
 
-static void tricore_opex(RzAsmTriCoreContext *ctx, RzStrBuf *sb) {
-	PJ *pj = pj_new();
-	if (!pj) {
-		return;
+static RzStructuredData *tricore_opex(RzAsmTriCoreContext *ctx) {
+	if (!ctx->insn->detail) {
+		return NULL;
 	}
-	pj_o(pj);
-	pj_ka(pj, "operands");
+
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
+	}
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
 	cs_tricore *tc = &ctx->insn->detail->tricore;
 	for (st32 i = 0; i < tc->op_count; i++) {
 		cs_tricore_op *op = tc->operands + i;
-		pj_o(pj);
+		RzStructuredData *operand = rz_structured_data_array_add_map(operands);
 		switch (op->type) {
-		case TRICORE_OP_INVALID: {
-			pj_ks(pj, "type", "invalid");
+		case TRICORE_OP_REG:
+			rz_structured_data_map_add_string(operand, "type", "reg");
+			rz_structured_data_map_add_string(operand, "value", cs_reg_name(ctx->h, op->reg));
+			break;
+		case TRICORE_OP_IMM:
+			rz_structured_data_map_add_string(operand, "type", "imm");
+			rz_structured_data_map_add_signed(operand, "value", op->imm);
+			break;
+		case TRICORE_OP_MEM:
+			rz_structured_data_map_add_string(operand, "type", "mem");
+			if (op->mem.base != TRICORE_REG_INVALID) {
+				rz_structured_data_map_add_string(operand, "base", cs_reg_name(ctx->h, op->mem.base));
+			}
+			rz_structured_data_map_add_signed(operand, "disp", op->mem.disp);
+			break;
+		default:
+			rz_structured_data_map_add_string(operand, "type", "invalid");
 			break;
 		}
-		case TRICORE_OP_REG: {
-			pj_ks(pj, "type", "reg");
-			pj_ks(pj, "value", cs_reg_name(ctx->h, op->reg));
-			break;
-		}
-		case TRICORE_OP_IMM: {
-			pj_ks(pj, "type", "imm");
-			pj_ki(pj, "value", op->imm);
-			break;
-		}
-		case TRICORE_OP_MEM: {
-			pj_ks(pj, "type", "mem");
-			pj_ks(pj, "base", cs_reg_name(ctx->h, op->mem.base));
-			pj_ki(pj, "disp", op->mem.disp);
-			break;
-		}
-		}
-		pj_end(pj);
 	}
-	pj_end(pj);
-	pj_end(pj);
 
-	rz_strbuf_init(sb);
-	rz_strbuf_append(sb, pj_string(pj));
-	pj_free(pj);
+	return root;
 }
 
 static int tricore_archinfo(RzAnalysis *a, RzAnalysisInfoType query) {

--- a/librz/arch/p/analysis/analysis_x86_zydis.c
+++ b/librz/arch/p/analysis/analysis_x86_zydis.c
@@ -39,11 +39,10 @@
 #define ARG1_AR   1
 #define ARG2_AR   2
 
-#define opexprintf(op, fmt, ...) rz_strbuf_setf(&op->opex, fmt, ##__VA_ARGS__)
-#define INSOP(n)                 zydx->zydeop[n]
-#define INSOPS                   zydx->zydecode->operand_count_visible
-#define ISIMM(n)                 zydx->zydeop[n].type == X86_OP_IMM
-#define ISMEM(n)                 zydx->zydeop[n].type == X86_OP_MEM
+#define INSOP(n) zydx->zydeop[n]
+#define INSOPS   zydx->zydecode->operand_count_visible
+#define ISIMM(n) zydx->zydeop[n].type == X86_OP_IMM
+#define ISMEM(n) zydx->zydeop[n].type == X86_OP_MEM
 
 typedef struct zydis_x86_context_t {
 	char buf[AR_DIM][BUF_SZ];
@@ -106,76 +105,90 @@ static void hidden_op(const X86ZYDISContext *zydx, int mode) {
 	}
 }
 
-static void opex(RzStrBuf *buf, const X86ZYDISContext *zydx, int mode, int bitness) {
+static RzStructuredData *x86_opex(const X86ZYDISContext *zydx, int mode, int bitness) {
 	ZydisDecodedInstruction *zydecode = zydx->zydecode;
-	PJ *pj = pj_new();
-	if (!pj) {
-		return;
-	}
-	pj_o(pj);
 	if (zydecode->operand_count_visible == 0) {
 		hidden_op(zydx, mode);
 	}
-	pj_ka(pj, "operands");
+
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
+	}
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
 	for (size_t i = 0; i < zydecode->operand_count_visible; i++) {
 		ZydisDecodedOperand *op = &INSOP(i);
-		pj_o(pj);
-		pj_ki(pj, "size", op->size);
-		pj_ki(pj, "rw", op->actions);
+		RzStructuredData *operand = rz_structured_data_array_add_map(operands);
 		switch (op->type) {
 		case X86_OP_REG:
-			pj_ks(pj, "type", "reg");
-			pj_ks(pj, "value", ZydisRegisterGetString(op->reg.value));
+			rz_structured_data_map_add_string(operand, "type", "reg");
+			rz_structured_data_map_add_string(operand, "value", ZydisRegisterGetString(op->reg.value));
 			break;
 		case X86_OP_IMM:
-			pj_ks(pj, "type", "imm");
-			pj_kN(pj, "value", get_imm_reg_value(op, zydx->addr, zydx->zydecode->length, bitness));
+			rz_structured_data_map_add_string(operand, "type", "imm");
+			rz_structured_data_map_add_signed(operand, "value", get_imm_reg_value(op, zydx->addr, zydx->zydecode->length, bitness));
 			break;
 		case X86_OP_MEM:
-			pj_ks(pj, "type", "mem");
+			rz_structured_data_map_add_string(operand, "type", "mem");
 			if (op->mem.segment != X86_REG_NONE) {
-				pj_ks(pj, "segment", ZydisRegisterGetString(op->mem.segment));
+				rz_structured_data_map_add_string(operand, "segment", ZydisRegisterGetString(op->mem.segment));
 			}
 			if (op->mem.base != X86_REG_NONE) {
-				pj_ks(pj, "base", ZydisRegisterGetString(op->mem.base));
+				rz_structured_data_map_add_string(operand, "base", ZydisRegisterGetString(op->mem.base));
 			}
 			if (op->mem.index != X86_REG_NONE) {
-				pj_ks(pj, "index", ZydisRegisterGetString(op->mem.index));
+				rz_structured_data_map_add_string(operand, "index", ZydisRegisterGetString(op->mem.index));
 			}
-			pj_ki(pj, "scale", op->mem.scale);
-			pj_kN(pj, "disp", op->mem.disp.value);
+			rz_structured_data_map_add_signed(operand, "scale", op->mem.scale);
+			rz_structured_data_map_add_signed(operand, "disp", op->mem.disp.value);
 			break;
 		default:
-			pj_ks(pj, "type", "invalid");
+			rz_structured_data_map_add_string(operand, "type", "invalid");
 			break;
 		}
-		pj_end(pj);
+		if (op->actions & ZYDIS_OPERAND_ACTION_READ) {
+			rz_structured_data_map_add_boolean(operand, "read", true);
+		}
+		if (op->actions & ZYDIS_OPERAND_ACTION_WRITE) {
+			rz_structured_data_map_add_boolean(operand, "write", true);
+		}
+		if (op->actions & ZYDIS_OPERAND_ACTION_CONDREAD) {
+			rz_structured_data_map_add_boolean(operand, "cond_read", true);
+		}
+		if (op->actions & ZYDIS_OPERAND_ACTION_CONDWRITE) {
+			rz_structured_data_map_add_boolean(operand, "cond_write", true);
+		}
+		rz_structured_data_map_add_unsigned(operand, "nbits", op->size * 8, false);
 	}
-	pj_end(pj);
+
 	if (zydecode->attributes & ZYDIS_ATTRIB_HAS_REX) {
-		pj_kb(pj, "rex", true);
+		rz_structured_data_map_add_boolean(opex, "rex", true);
 	}
 	if (zydecode->raw.modrm.mod != 0) {
-		pj_kb(pj, "modrm", true);
+		rz_structured_data_map_add_boolean(opex, "modrm", true);
 	}
 	if (zydecode->raw.sib.scale != 0 || zydecode->raw.sib.index != 0 || zydecode->raw.sib.offset != 0 || zydecode->raw.sib.base != 0) {
-		pj_ki(pj, "sib", zydecode->raw.sib.base + (zydecode->raw.sib.index * zydecode->raw.sib.scale) + zydecode->raw.sib.offset);
+		rz_structured_data_map_add_signed(opex, "sib", zydecode->raw.sib.base + (zydecode->raw.sib.index * zydecode->raw.sib.scale) + zydecode->raw.sib.offset);
 	}
 	if (zydecode->raw.disp.value != 0) {
-		pj_ki(pj, "disp", zydecode->raw.disp.value);
+		rz_structured_data_map_add_signed(opex, "disp", zydecode->raw.disp.value);
 	}
 	if (zydecode->raw.sib.index != X86_REG_NONE) {
-		pj_ki(pj, "sib_scale", zydecode->raw.sib.scale);
-		pj_ks(pj, "sib_index", ZydisRegisterGetString(zydecode->raw.sib.index));
+		rz_structured_data_map_add_signed(opex, "sib_scale", zydecode->raw.sib.scale);
+		rz_structured_data_map_add_string(opex, "sib_index", ZydisRegisterGetString(zydecode->raw.sib.index));
 	}
 	if (zydecode->raw.sib.base != X86_REG_NONE) {
-		pj_ks(pj, "sib_base", ZydisRegisterGetString(zydecode->raw.sib.base));
+		rz_structured_data_map_add_string(opex, "sib_base", ZydisRegisterGetString(zydecode->raw.sib.base));
 	}
-	pj_end(pj);
 
-	rz_strbuf_init(buf);
-	rz_strbuf_append(buf, pj_string(pj));
-	pj_free(pj);
+	return root;
 }
 
 static bool is_xmm_reg(const ZydisDecodedOperand op) {
@@ -3251,7 +3264,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 		anop_esil(a, op, buf, len, zydx);
 	}
 	if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
-		opex(&op->opex, zydx, mode, a->bits);
+		op->opex = x86_opex(zydx, mode, a->bits);
 	}
 	if (mask & RZ_ANALYSIS_OP_MASK_VAL) {
 		op_fillval(a, op, mode, zydx);

--- a/librz/arch/p/analysis/analysis_xcore_cs.c
+++ b/librz/arch/p/analysis/analysis_xcore_cs.c
@@ -53,46 +53,50 @@ static char *xcore_get_reg_profile(RzAnalysis *analysis) {
 	return rz_str_dup(p);
 }
 
-static void xcore_opex(RzStrBuf *buf, csh handle, cs_insn *insn) {
-	int i;
-	PJ *pj = pj_new();
-	if (!pj) {
-		return;
+static RzStructuredData *xcore_opex(csh handle, cs_insn *insn) {
+	if (!insn->detail) {
+		return NULL;
 	}
-	pj_o(pj);
-	pj_ka(pj, "operands");
+
+	RzStructuredData *root = rz_structured_data_new_map();
+	if (!root) {
+		return NULL;
+	}
+
+	RzStructuredData *opex = rz_structured_data_map_add_map(root, "opex");
+	if (!opex) {
+		rz_structured_data_free(root);
+		return NULL;
+	}
+
+	RzStructuredData *operands = rz_structured_data_map_add_array(opex, "operands");
 	cs_xcore *x = &insn->detail->xcore;
-	for (i = 0; i < x->op_count; i++) {
+	for (st32 i = 0; i < x->op_count; i++) {
 		cs_xcore_op *op = x->operands + i;
-		pj_o(pj);
+		RzStructuredData *operand = rz_structured_data_array_add_map(operands);
 		switch (op->type) {
 		case XCORE_OP_REG:
-			pj_ks(pj, "type", "reg");
-			pj_ks(pj, "value", cs_reg_name(handle, op->reg));
+			rz_structured_data_map_add_string(operand, "type", "reg");
+			rz_structured_data_map_add_string(operand, "value", cs_reg_name(handle, op->reg));
 			break;
 		case XCORE_OP_IMM:
-			pj_ks(pj, "type", "imm");
-			pj_ki(pj, "value", op->imm);
+			rz_structured_data_map_add_string(operand, "type", "imm");
+			rz_structured_data_map_add_signed(operand, "value", op->imm);
 			break;
 		case XCORE_OP_MEM:
-			pj_ks(pj, "type", "mem");
+			rz_structured_data_map_add_string(operand, "type", "mem");
 			if (op->mem.base != XCORE_REG_INVALID) {
-				pj_ks(pj, "base", cs_reg_name(handle, op->mem.base));
+				rz_structured_data_map_add_string(operand, "base", cs_reg_name(handle, op->mem.base));
 			}
-			pj_ki(pj, "disp", op->mem.disp);
+			rz_structured_data_map_add_signed(operand, "disp", op->mem.disp);
 			break;
 		default:
-			pj_ks(pj, "type", "invalid");
+			rz_structured_data_map_add_string(operand, "type", "invalid");
 			break;
 		}
-		pj_end(pj); /* o operand */
 	}
-	pj_end(pj); /* a operands */
-	pj_end(pj);
 
-	rz_strbuf_init(buf);
-	rz_strbuf_append(buf, pj_string(pj));
-	pj_free(pj);
+	return root;
 }
 
 typedef struct {
@@ -143,7 +147,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	}
 
 	if (mask & RZ_ANALYSIS_OP_MASK_OPEX) {
-		xcore_opex(&op->opex, ctx->handle, insn);
+		op->opex = xcore_opex(ctx->handle, insn);
 	}
 
 	op->size = insn->size;

--- a/librz/arch/p/asm/asm_mcs96.c
+++ b/librz/arch/p/asm/asm_mcs96.c
@@ -180,7 +180,7 @@ static void decode_operands(RzAsmOp *op, const char *mnemonic, const ut8 *buf, i
 }
 
 static const char *decode_mnemonic(const ut8 *buf, int size, ut32 isa_bit) {
-	if (size <= 0) {
+	if (size < 1) {
 		return "invalid";
 	}
 
@@ -290,27 +290,18 @@ static const char *decode_mnemonic(const ut8 *buf, int size, ut32 isa_bit) {
 	}
 }
 
-static bool init(void **u) {
-	if (!u) {
+static bool mcs96_init(void **u) {
+	Mcs96Context *ctx = RZ_NEW0(Mcs96Context);
+	if (!ctx) {
 		return false;
-	}
-	Mcs96Context *ctx = NULL;
-	if (*u) {
-		rz_mem_memzero(*u, sizeof(Mcs96Context));
-		ctx = *u;
-	} else {
-		ctx = RZ_NEW0(Mcs96Context);
-		if (!ctx) {
-			return false;
-		}
-		*u = ctx;
 	}
 	ctx->token_patterns = get_token_patterns();
 	rz_asm_compile_token_patterns(ctx->token_patterns);
+	*u = ctx;
 	return true;
 }
 
-static bool fini(void *u) {
+static bool mcs96_fini(void *u) {
 	if (!u) {
 		return true;
 	}
@@ -320,7 +311,7 @@ static bool fini(void *u) {
 	return true;
 }
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int mcs96_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	if (len > 1 && !memcmp(buf, "\xff\xff", 2)) {
 		return -1;
 	}
@@ -356,7 +347,7 @@ RzAsmPlugin rz_asm_plugin_mcs96 = {
 	.author = "condret",
 	.bits = 16,
 	.endian = RZ_SYS_ENDIAN_LITTLE,
-	.init = &init,
-	.fini = &fini,
-	.disassemble = &disassemble
+	.init = &mcs96_init,
+	.fini = &mcs96_fini,
+	.disassemble = &mcs96_disassemble
 };

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -413,7 +413,6 @@ static void core_analysis_bytes_json(RzCore *core, const ut8 *buf, int len, int 
 		}
 		RzAnalysisOp *op = ab->op;
 		const char *esilstr = RZ_STRBUF_SAFEGET(&op->esil);
-		const char *opexstr = RZ_STRBUF_SAFEGET(&op->opex);
 		RzAnalysisHint *hint = ab->hint;
 
 		pj_o(pj);
@@ -438,9 +437,19 @@ static void core_analysis_bytes_json(RzCore *core, const ut8 *buf, int len, int 
 		pj_kb(pj, "sign", op->sign);
 		pj_kn(pj, "prefix", op->prefix);
 		pj_ki(pj, "id", op->id);
-		if (RZ_STR_ISNOTEMPTY(opexstr)) {
-			pj_k(pj, "opex");
-			pj_j(pj, opexstr);
+		if (op->opex) {
+			// this is a partial hack since PJ does not allow to join objects.
+			char *opex_json = rz_structured_data_to_json(op->opex);
+			if (RZ_STR_ISNOTEMPTY(opex_json)) {
+				size_t len = strlen(opex_json);
+				if (len > 1) {
+					// remove the last }
+					opex_json[len - 1] = 0;
+					// skip first {
+					pj_j(pj, opex_json + 1);
+				}
+			}
+			free(opex_json);
 		}
 		PJ_KN(pj, "addr", op->addr);
 		PJ_KS(pj, "bytes", ab->bytes);
@@ -548,6 +557,13 @@ static void core_analysis_bytes_standard(RzCore *core, const ut8 *buf, int len, 
 			rz_il_op_effect_stringify(op->il_op, sbil, false);
 			PRINTF_LN_STR("rzil", rz_strbuf_get(sbil));
 			rz_strbuf_free(sbil);
+		}
+		if (op->opex) {
+			char *opex_yaml = rz_structured_data_to_yaml(op->opex);
+			if (RZ_STR_ISNOTEMPTY(opex_yaml)) {
+				rz_cons_print(opex_yaml);
+			}
+			free(opex_yaml);
 		}
 		PRINTF_LN_NOT("jump", "0x%08" PFMT64x "\n", op->jump, UT64_MAX);
 		if (op->direction != 0) {

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -941,7 +941,7 @@ typedef struct rz_analysis_op_t {
 	RzAnalysisValue *dst;
 	RzList /*<RzAnalysisValue *>*/ *access; /* RzAnalysisValue access information */
 	RzStrBuf esil;
-	RzStrBuf opex;
+	RzStructuredData *opex;
 	RzAnalysisLiftedILOp il_op;
 	const char *reg; /* destination register */
 	const char *ireg; /* register used for indirect memory computation*/

--- a/librz/include/rz_util/rz_structured_data.h
+++ b/librz/include/rz_util/rz_structured_data.h
@@ -5,6 +5,7 @@
 #define RZ_STRUCTURED_DATA_H
 
 #include <rz_util/rz_strbuf.h>
+#include <rz_util/rz_pj.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -17,7 +18,7 @@ typedef enum rz_structured_data_block_t {
 
 typedef struct rz_structured_data_t RzStructuredData;
 
-typedef void (*RzStructuredDataIteratorNew)(RZ_NULLABLE void *user, RzStructuredDataBlock block);
+typedef void (*RzStructuredDataIteratorNew)(RZ_NULLABLE void *user, RzStructuredDataBlock block, size_t n_elems);
 typedef void (*RzStructuredDataIteratorEnd)(RZ_NULLABLE void *user);
 typedef void (*RzStructuredDataIteratorKey)(RZ_NULLABLE void *user, RZ_NONNULL const char *key);
 typedef void (*RzStructuredDataIteratorValueUnsigned)(RZ_NULLABLE void *user, ut64 n, bool hex);

--- a/librz/util/structured_data.c
+++ b/librz/util/structured_data.c
@@ -474,7 +474,8 @@ static void structured_data_iterate_over(StructuredDataIterOver *sdio, const RzS
 
 static void structured_data_iterate_over_map(StructuredDataIterOver *sdio, const RzStructuredData *sd) {
 	void **pit = NULL;
-	sdio->fit->new_struct(sdio->user, RZ_STRUCTURED_DATA_BLOCK_MAP);
+	size_t n_keys = rz_pvector_len(sd->v_array);
+	sdio->fit->new_struct(sdio->user, RZ_STRUCTURED_DATA_BLOCK_MAP, n_keys);
 	rz_pvector_foreach (sd->v_array, pit) {
 		const char *key = *pit;
 		const RzStructuredData *elem = (const RzStructuredData *)ht_sp_find(sd->v_map, key, NULL);
@@ -486,7 +487,8 @@ static void structured_data_iterate_over_map(StructuredDataIterOver *sdio, const
 
 static void structured_data_iterate_over_array(StructuredDataIterOver *sdio, const RzStructuredData *sd) {
 	void **pit = NULL;
-	sdio->fit->new_struct(sdio->user, RZ_STRUCTURED_DATA_BLOCK_ARRAY);
+	size_t array_len = rz_pvector_len(sd->v_array);
+	sdio->fit->new_struct(sdio->user, RZ_STRUCTURED_DATA_BLOCK_ARRAY, array_len);
 	rz_pvector_foreach (sd->v_array, pit) {
 		const RzStructuredData *elem = (const RzStructuredData *)*pit;
 		structured_data_iterate_over(sdio, elem);

--- a/librz/util/structured_data_json.c
+++ b/librz/util/structured_data_json.c
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 deroad <deroad@kumo.xn--q9jyb4c>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-static void builder_json_new_struct(RZ_NULLABLE void *user, RzStructuredDataBlock block) {
+static void builder_json_new_struct(RZ_NULLABLE void *user, RzStructuredDataBlock block, size_t n_elems) {
 	switch (block) {
 	case RZ_STRUCTURED_DATA_BLOCK_MAP:
 		pj_o((PJ *)user);

--- a/librz/util/structured_data_yaml.c
+++ b/librz/util/structured_data_yaml.c
@@ -36,11 +36,13 @@ static char *builder_yaml_fini_printer(StructYamlPrinter *yaml) {
 	return rz_strbuf_drain_nofree(&yaml->sb);
 }
 
-static void builder_yaml_new_struct(RZ_NULLABLE void *user, RzStructuredDataBlock block) {
+static void builder_yaml_new_struct(RZ_NULLABLE void *user, RzStructuredDataBlock block, size_t n_elems) {
 	StructYamlPrinter *yaml = (StructYamlPrinter *)user;
 
 	if (yaml->depth > 0) {
-		if (builder_yaml_is_array(yaml)) {
+		if (n_elems < 1) {
+			rz_strbuf_append(&yaml->sb, block == RZ_STRUCTURED_DATA_BLOCK_ARRAY ? " []\n" : " {}\n");
+		} else if (builder_yaml_is_array(yaml)) {
 			builder_yaml_add_padding(yaml);
 			rz_strbuf_append(&yaml->sb, "-");
 		} else {

--- a/test/db/analysis/alpha
+++ b/test/db/analysis/alpha
@@ -46,6 +46,12 @@ size: 4
 sign: false
 type: cjmp
 cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "$2"
+    - type: "imm"
+      value: 536982352
 jump: 0x12001b350
 fail: 0x12001b340
 cond: al

--- a/test/db/analysis/amd29k
+++ b/test/db/analysis/amd29k
@@ -42,6 +42,10 @@ size: 4
 sign: false
 type: jmp
 cycles: 0
+opex:
+  operands:
+    - type: "imm"
+      value: 66008
 jump: 0x000101d8
 delay: 1
 family: cpu

--- a/test/db/analysis/arm
+++ b/test/db/analysis/arm
@@ -230,7 +230,11 @@ EXPECT=<<EOF
 ldr ip, [0x00000028]
 ldr ip, [sl, ip]
 load
+type:
+type:
 load
+type:
+type:
 EOF
 RUN
 
@@ -348,7 +352,11 @@ EXPECT=<<EOF
 ldr ip, [0x00000028]
 ldr ip, [sl, ip]
 load
+type:
+type:
 load
+type:
+type:
 EOF
 RUN
 
@@ -920,6 +928,15 @@ type: push
 cycles: 1
 esil: r3,sp,-8,+,=[4],lr,sp,-4,+,=[4],-8,sp,+=,
 rzil: (seq (storew 0 (- (var sp) (bv 32 0x8)) (var r3)) (storew 0 (- (var sp) (bv 32 0x4)) (var lr)) (set sp (- (var sp) (bv 32 0x8))))
+opex:
+  operands:
+    - type: "reg"
+      value: "sp"
+    - type: "reg"
+      value: "r3"
+    - type: "reg"
+      value: "lr"
+  writeback: true
 direction: write
 family: cpu
 stackop: inc
@@ -942,6 +959,14 @@ type: add
 cycles: 1
 esil: 0,sp,+,0xffffffff,&,r7,=
 rzil: (set r7 (+ (var sp) (bv 32 0x0)))
+opex:
+  operands:
+    - type: "reg"
+      value: "r7"
+    - type: "reg"
+      value: "sp"
+    - type: "imm"
+      value: 0
 family: cpu
 EOF
 RUN

--- a/test/db/analysis/arm
+++ b/test/db/analysis/arm
@@ -224,7 +224,7 @@ e asm.bits=32
 # pd 2 - note different colors
 pi 2
 ao~type[1]
-ao@ 4~type[1]
+ao @ 4~type[1]
 EOF
 EXPECT=<<EOF
 ldr ip, [0x00000028]
@@ -1338,5 +1338,877 @@ EXPECT=<<EOF
             0x00000114      movs  r0, r0
 - offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
 0x0000019c  0c01 0000                                ....
+EOF
+RUN
+
+NAME=opex arm32 & aarch64
+FILE==
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+e cfg.bigendian=false
+wx 864860f44d0fe2f4edffffeb04e02de500000000e08322e5f102030e0000a0e30230c1e7000053e3000201f10540d0e8f4800000
+ao 13
+echo ---
+e asm.bits=64
+wx 090038d5bf4000d50c0513d52050020e20e43d0f0018a05fa200ae9e9f3703d5bf3303d5df3f03d5217c029b217c00530040214be10b40b9200481da2008028b105be83cfd7bbaa9fdc743f8
+ao 19
+EOF
+EXPECT=<<EOF
+address: 0x0
+opcode: vld2.32 {d20, d21}, [r0], r6
+disasm: vld2.32 {d20, d21}, [r0], r6
+pseudo: asm("vld2.32 {d20, d21}, [r0], r6")
+mnemonic: vld2.32
+mask: ffffffff
+prefix: 0
+id: 16
+bytes: 864860f4
+refptr: 0
+size: 4
+sign: false
+type: null
+cycles: 1
+rzil: (seq empty (set d20 (<< (cast 64 false (loadw 0 32 (var r0))) (bv 8 0x0) false)) (set d21 (<< (cast 64 false (loadw 0 32 (+ (var r0) (bv 32 0x4)))) (bv 8 0x0) false)) (set d20 (<< (cast 64 false (loadw 0 32 (+ (+ (var r0) (bv 32 0x4)) (bv 32 0x4)))) (bv 8 0x20) false)) (set d21 (<< (cast 64 false (loadw 0 32 (+ (+ (+ (var r0) (bv 32 0x4)) (bv 32 0x4)) (bv 32 0x4)))) (bv 8 0x20) false)) (set r0 (+ (var r0) (var r6))))
+opex:
+  operands:
+    - type: "reg"
+      value: "d20"
+    - type: "reg"
+      value: "d21"
+    - type: "mem"
+      base: "r0"
+      index: "r6"
+      scale: 0
+      disp: 0
+  writeback: true
+  vector_size: 32
+family: mmx
+address: 0x4
+opcode: vld4.16 {d16[], d17[], d18[], d19[]}, [r2]!
+disasm: vld4.16 {d16[], d17[], d18[], d19[]}, [r2]!
+pseudo: asm("vld4.16 {d16[], d17[], d18[], d19[]}, [r2]!")
+mnemonic: vld4.16
+mask: ffffffff
+prefix: 0
+id: 18
+bytes: 4d0fe2f4
+refptr: 0
+size: 4
+sign: false
+type: null
+cycles: 1
+rzil: (seq empty (set d16 (<< (cast 64 false (loadw 0 16 (var r2))) (bv 8 0x0) false)) (set d17 (<< (cast 64 false (loadw 0 16 (+ (var r2) (bv 32 0x2)))) (bv 8 0x0) false)) (set d18 (<< (cast 64 false (loadw 0 16 (+ (+ (var r2) (bv 32 0x2)) (bv 32 0x2)))) (bv 8 0x0) false)) (set d19 (<< (cast 64 false (loadw 0 16 (+ (+ (+ (var r2) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)))) (bv 8 0x0) false)) (set d16 (<< (cast 64 false (loadw 0 16 (+ (+ (+ (+ (var r2) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)))) (bv 8 0x10) false)) (set d17 (<< (cast 64 false (loadw 0 16 (+ (+ (+ (+ (+ (var r2) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)))) (bv 8 0x10) false)) (set d18 (<< (cast 64 false (loadw 0 16 (+ (+ (+ (+ (+ (+ (var r2) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)))) (bv 8 0x10) false)) (set d19 (<< (cast 64 false (loadw 0 16 (+ (+ (+ (+ (+ (+ (+ (var r2) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)))) (bv 8 0x10) false)) (set d16 (<< (cast 64 false (loadw 0 16 (+ (+ (+ (+ (+ (+ (+ (+ (var r2) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)))) (bv 8 0x20) false)) (set d17 (<< (cast 64 false (loadw 0 16 (+ (+ (+ (+ (+ (+ (+ (+ (+ (var r2) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)))) (bv 8 0x20) false)) (set d18 (<< (cast 64 false (loadw 0 16 (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (var r2) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)))) (bv 8 0x20) false)) (set d19 (<< (cast 64 false (loadw 0 16 (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (var r2) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)))) (bv 8 0x20) false)) (set d16 (<< (cast 64 false (loadw 0 16 (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (var r2) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)))) (bv 8 0x30) false)) (set d17 (<< (cast 64 false (loadw 0 16 (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (var r2) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)))) (bv 8 0x30) false)) (set d18 (<< (cast 64 false (loadw 0 16 (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (var r2) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)))) (bv 8 0x30) false)) (set d19 (<< (cast 64 false (loadw 0 16 (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (+ (var r2) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)) (bv 32 0x2)))) (bv 8 0x30) false)) (set r2 (+ (var r2) (bv 32 0x20))))
+opex:
+  operands:
+    - type: "reg"
+      value: "d16"
+    - type: "reg"
+      value: "d17"
+    - type: "reg"
+      value: "d18"
+    - type: "reg"
+      value: "d19"
+    - type: "mem"
+      base: "r2"
+      scale: 0
+      disp: 0
+  writeback: true
+  vector_size: 16
+family: mmx
+address: 0x8
+opcode: bl 0xffffffc4
+disasm: bl 0xffffffc4
+pseudo: 0xffffffc4 ()
+mnemonic: bl
+description: branches and link, similar to call in i386, set lr(r14) = pc, changes pc (r15) )
+mask: 0000f0ff
+prefix: 0
+id: 48
+bytes: edffffeb
+refptr: 0
+size: 4
+sign: false
+type: call
+cycles: 4
+esil: pc,0,+,lr,=,4294967236,pc,=
+rzil: (seq (set lr (bv 32 0xc)) (jmp (bv 32 0xffffffc4)))
+opex:
+  operands:
+    - type: "imm"
+      value: 4294967236
+jump: 0xffffffc4
+direction: exec
+fail: 0x0000000c
+family: cpu
+address: 0xc
+opcode: str lr, [sp, -4]!
+disasm: str lr, [sp, -4]!
+pseudo: [sp - 4]! = lr
+mnemonic: str
+description: store register into memory
+mask: ffffffff
+prefix: 0
+id: 31
+bytes: 04e02de5
+refptr: 0
+size: 4
+sign: false
+type: store
+cycles: 4
+esil: lr,0x4,sp,-,0xffffffff,&,=[4],4,sp,-,sp,=
+rzil: (seq (set sp (- (var sp) (bv 32 0x4))) (storew 0 (var sp) (var lr)))
+opex:
+  operands:
+    - type: "reg"
+      value: "lr"
+    - type: "mem"
+      base: "sp"
+      scale: 0
+      disp: 4
+      subtracted: true
+  writeback: true
+direction: write
+family: cpu
+address: 0x10
+opcode: andeq r0, r0, r0
+disasm: andeq r0, r0, r0
+pseudo: asm("andeq r0, r0, r0")
+mnemonic: andeq
+description: logical AND if Z set (equal)
+mask: ffffffff
+prefix: 0
+id: 39
+bytes: 00000000
+refptr: 0
+size: 4
+sign: false
+type: and
+cycles: 1
+esil: zf,?{,r0,r0,&,0xffffffff,&,r0,=,}
+rzil: (branch (var zf) (set r0 (& (var r0) (var r0))) nop)
+opex:
+  operands:
+    - type: "reg"
+      value: "r0"
+    - type: "reg"
+      value: "r0"
+    - type: "reg"
+      value: "r0"
+  cc: "eq"
+family: cpu
+address: 0x14
+opcode: str r8, [r2, -0x3e0]!
+disasm: str r8, [r2, -0x3e0]!
+pseudo: [r2 - 0x3e0]! = r8
+mnemonic: str
+description: store register into memory
+mask: ffffffff
+prefix: 0
+id: 31
+bytes: e08322e5
+refptr: 0
+size: 4
+sign: false
+type: store
+cycles: 4
+esil: r8,0x3e0,r2,-,0xffffffff,&,=[4],992,r2,-,r2,=
+rzil: (seq (set r2 (- (var r2) (bv 32 0x3e0))) (storew 0 (var r2) (var r8)))
+opex:
+  operands:
+    - type: "reg"
+      value: "r8"
+    - type: "mem"
+      base: "r2"
+      scale: 0
+      disp: 992
+      subtracted: true
+  writeback: true
+direction: write
+family: cpu
+address: 0x18
+opcode: mcreq p2, 0, r0, c3, c1, 7
+disasm: mcreq p2, 0, r0, c3, c1, 7
+pseudo: asm("mcreq p2, 0, r0, c3, c1, 7")
+mnemonic: mcreq
+mask: ffffffff
+prefix: 0
+id: 119
+bytes: f102030e
+refptr: 0
+size: 4
+sign: false
+type: null
+cycles: 1
+esil: zf,?{,,}
+opex:
+  operands:
+    - type: "pimm"
+      value: 2
+    - type: "imm"
+      value: 0
+    - type: "reg"
+      value: "r0"
+    - type: "cimm"
+      value: 3
+    - type: "cimm"
+      value: 1
+    - type: "imm"
+      value: 7
+  cc: "eq"
+family: priv
+address: 0x1c
+opcode: mov r0, 0
+disasm: mov r0, 0
+pseudo: r0 = 0
+mnemonic: mov
+description: move value between registers
+mask: ffffffff
+prefix: 0
+id: 28
+bytes: 0000a0e3
+val: 0x00000000
+refptr: 0
+size: 4
+sign: false
+type: mov
+cycles: 1
+esil: 0,r0,=
+rzil: (set r0 (bv 32 0x0))
+opex:
+  operands:
+    - type: "reg"
+      value: "r0"
+    - type: "imm"
+      value: 0
+family: cpu
+address: 0x20
+opcode: strb r3, [r1, r2]
+disasm: strb r3, [r1, r2]
+pseudo: [r1 + r2] = (byte) r3
+mnemonic: strb
+description: store byte value in register into memory
+mask: ffffffff
+prefix: 0
+id: 29
+bytes: 0230c1e7
+refptr: 0
+size: 4
+sign: false
+type: store
+cycles: 4
+esil: r3,r2,r1,+,0xffffffff,&,=[1]
+rzil: (store 0 (+ (var r1) (var r2)) (cast 8 false (var r3)))
+opex:
+  operands:
+    - type: "reg"
+      value: "r3"
+    - type: "mem"
+      base: "r1"
+      index: "r2"
+      scale: 1
+      disp: 0
+direction: write
+family: cpu
+address: 0x24
+opcode: cmp r3, 0
+disasm: cmp r3, 0
+pseudo: if (r3 == 0)
+mnemonic: cmp
+description: compares two registers
+mask: 0000f0ff
+prefix: 0
+id: 76
+bytes: 000053e3
+ptr: 0x00000000
+refptr: 0
+size: 4
+sign: false
+type: cmp
+cycles: 1
+reg: r3
+esil: 0,r3,==,$z,zf,:=,31,$s,nf,:=,32,$b,!,cf,:=,31,$o,vf,:=
+rzil: (seq (set a (var r3)) (set b (bv 32 0x0)) (set res (- (var a) (var b))) (set cf (ule (var b) (var a))) (set vf (&& (^^ (msb (var a)) (msb (var b))) (^^ (msb (var a)) (msb (var res))))) (set zf (is_zero (var res))) (set nf (msb (var res))))
+opex:
+  operands:
+    - type: "reg"
+      value: "r3"
+    - type: "imm"
+      value: 0
+  update_flags: true
+family: cpu
+address: 0x28
+opcode: setend be
+disasm: setend be
+pseudo: asm("setend be")
+mnemonic: setend
+mask: ffffffff
+prefix: 0
+id: 364
+bytes: 000201f1
+refptr: 0
+size: 4
+sign: false
+type: null
+cycles: 1
+opex:
+  operands:
+    - type: "setend"
+      value: "be"
+family: cpu
+address: 0x2c
+opcode: ldm r0, {r0, r2, lr} ^
+disasm: ldm r0, {r0, r2, lr} ^
+pseudo: asm("ldm r0, {r0, r2, lr} ^")
+mnemonic: ldm
+description: load to multiple registers from memory
+mask: ffffffff
+prefix: 0
+id: 112
+bytes: 0540d0e8
+refptr: 0
+size: 4
+sign: false
+type: load
+cycles: 2
+esil: r0,0,+,[4],r0,=,r0,4,+,[4],r2,=,r0,8,+,[4],lr,=,
+rzil: (seq (set base (var r0)) (set r0 (loadw 0 32 (+ (var base) (bv 32 0x0)))) (set r2 (loadw 0 32 (+ (var base) (bv 32 0x4)))) (set lr (loadw 0 32 (+ (var base) (bv 32 0x8)))))
+opex:
+  operands:
+    - type: "reg"
+      value: "r0"
+    - type: "reg"
+      value: "r0"
+    - type: "reg"
+      value: "r2"
+    - type: "reg"
+      value: "lr"
+direction: read
+family: cpu
+address: 0x30
+opcode: strdeq r8, sb, [r0], -r4
+disasm: strdeq r8, sb, [r0], -r4
+pseudo: asm("strdeq r8, sb, [r0], -r4")
+mnemonic: strdeq
+mask: ffffffff
+prefix: 0
+id: 443
+bytes: f4800000
+refptr: 0
+size: 4
+sign: false
+type: store
+cycles: 4
+esil: zf,?{,r8,r0,0xffffffff,&,=[4],sb,4,r0,+,0xffffffff,&,=[4],r4,r0,-=,}
+rzil: (branch (var zf) (seq (storew 0 (var r0) (var r8)) (storew 0 (+ (var r0) (bv 32 0x4)) (var r9)) (set r0 (+ (var r0) (var r4)))) nop)
+opex:
+  operands:
+    - type: "reg"
+      value: "r8"
+    - type: "reg"
+      value: "sb"
+    - type: "mem"
+      base: "r0"
+      index: "r4"
+      scale: -1
+      disp: 0
+      subtracted: true
+  writeback: true
+  cc: "eq"
+direction: write
+family: cpu
+---
+address: 0x0
+opcode: mrs x9, MIDR_EL1
+disasm: mrs x9, MIDR_EL1
+pseudo: asm("mrs x9, MIDR_EL1")
+mnemonic: mrs
+mask: ffffffff
+prefix: 0
+id: 752
+bytes: 090038d5
+refptr: 0
+size: 4
+sign: false
+type: mov
+cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "x9"
+    - type: "sysreg"
+      sysreg: 0xc000
+      tlbi: 0xc000
+      ic: 0xc000
+family: priv
+address: 0x4
+opcode: msr SPSel, 0
+disasm: msr SPSel, 0
+pseudo: asm("msr SPSel, 0")
+mnemonic: msr
+mask: ffffffff
+prefix: 0
+id: 754
+bytes: bf4000d5
+refptr: 0
+size: 4
+sign: false
+type: mov
+cycles: 0
+opex:
+  operands:
+    - type: "pstate"
+      value: "spsel"
+    - type: "imm"
+      value: 0
+family: priv
+address: 0x8
+opcode: msr DBGDTRTX_EL0, x12
+disasm: msr DBGDTRTX_EL0, x12
+pseudo: asm("msr DBGDTRTX_EL0, x12")
+mnemonic: msr
+mask: ffffffff
+prefix: 0
+id: 754
+bytes: 0c0513d5
+refptr: 0
+size: 4
+sign: false
+type: mov
+cycles: 0
+opex:
+  operands:
+    - type: "sysreg"
+      sysreg: 0x9828
+      tlbi: 0x9828
+      ic: 0x9828
+    - type: "reg"
+      value: "x12"
+family: priv
+address: 0xc
+opcode: tbx v0.8b, { v1.16b, v2.16b, v3.16b }, v2.8b
+disasm: tbx v0.8b, { v1.16b, v2.16b, v3.16b }, v2.8b
+pseudo: asm("tbx v0.8b, { v1.16b, v2.16b, v3.16b }, v2.8b")
+mnemonic: tbx
+mask: ffffffff
+prefix: 0
+id: 1249
+bytes: 2050020e
+refptr: 0
+size: 4
+sign: false
+type: null
+cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "d0"
+      vas: "8b"
+    - type: "reg"
+      value: "q1"
+      vas: "16b"
+    - type: "reg"
+      value: "q2"
+      vas: "16b"
+    - type: "reg"
+      value: "q3"
+      vas: "16b"
+    - type: "reg"
+      value: "d2"
+      vas: "8b"
+  writeback: true
+family: mmx
+address: 0x10
+opcode: scvtf v0.2s, v1.2s, 3
+disasm: scvtf v0.2s, v1.2s, 3
+pseudo: asm("scvtf v0.2s, v1.2s, 3")
+mnemonic: scvtf
+mask: ffffffff
+prefix: 0
+id: 941
+bytes: 20e43d0f
+refptr: 0
+size: 4
+sign: false
+type: null
+cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "d0"
+      vas: "2s"
+    - type: "reg"
+      value: "d1"
+      vas: "2s"
+    - type: "imm"
+      value: 3
+family: mmx
+address: 0x14
+opcode: fmla s0, s0, v0.s[3]
+disasm: fmla s0, s0, v0.s[3]
+pseudo: asm("fmla s0, s0, v0.s[3]")
+mnemonic: fmla
+mask: ffffffff
+prefix: 0
+id: 417
+bytes: 0018a05f
+refptr: 0
+size: 4
+sign: false
+type: null
+cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "s0"
+    - type: "reg"
+      value: "s0"
+    - type: "reg"
+      value: "q0"
+      vector_index: 3
+      vas: ""
+  writeback: true
+family: mmx
+address: 0x18
+opcode: fmov x2, v5.d[1]
+disasm: fmov x2, v5.d[1]
+pseudo: x2 = v5.d[1]
+mnemonic: fmov
+mask: ffffffff
+prefix: 0
+id: 426
+bytes: a200ae9e
+refptr: 0
+size: 4
+sign: false
+type: mov
+cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "x2"
+    - type: "reg"
+      value: "q5"
+      vector_index: 1
+      vas: ""
+family: fpu
+address: 0x1c
+opcode: dsb nsh
+disasm: dsb nsh
+pseudo: asm("dsb nsh")
+mnemonic: dsb
+description: data synchronization barrier.
+mask: ffffffff
+prefix: 0
+id: 301
+bytes: 9f3703d5
+refptr: 0
+size: 4
+sign: false
+type: sync
+cycles: 0
+opex:
+  operands:
+    - type: "prefetch"
+      value: 7
+family: thread
+address: 0x20
+opcode: dmb osh
+disasm: dmb osh
+pseudo: asm("dmb osh")
+mnemonic: dmb
+mask: ffffffff
+prefix: 0
+id: 299
+bytes: bf3303d5
+refptr: 0
+size: 4
+sign: false
+type: sync
+cycles: 0
+opex:
+  operands:
+    - type: "prefetch"
+      value: 3
+family: thread
+address: 0x24
+opcode: isb
+disasm: isb
+pseudo: asm("isb")
+mnemonic: isb
+description: instruction synchronization barrier.
+mask: ffffffff
+prefix: 0
+id: 509
+bytes: df3f03d5
+refptr: 0
+size: 4
+sign: false
+type: sync
+cycles: 0
+opex:
+  operands:
+    - type: "sys"
+      value: 15
+family: thread
+address: 0x28
+opcode: mul x1, x1, x2
+disasm: mul x1, x1, x2
+pseudo: x1 = x1 * x2
+mnemonic: mul
+description: multiply
+mask: ffffffff
+prefix: 0
+id: 731
+bytes: 217c029b
+refptr: 0
+size: 4
+sign: false
+type: add
+cycles: 0
+esil: x2,x1,*,xzr,+,x1,=
+rzil: (set x1 (* (var x1) (var x2)))
+opex:
+  operands:
+    - type: "reg"
+      value: "x1"
+    - type: "reg"
+      value: "x1"
+    - type: "reg"
+      value: "x2"
+    - type: "reg"
+      value: "xzr"
+family: cpu
+address: 0x2c
+opcode: lsr w1, w1, 0
+disasm: lsr w1, w1, 0
+pseudo: w1 = w1 >> 0
+mnemonic: lsr
+description: logical shift right
+mask: ffffffff
+prefix: 0
+id: 1281
+bytes: 217c0053
+refptr: 0
+size: 4
+sign: false
+type: mov
+cycles: 0
+esil: 0,w1,>>,w1,=
+rzil: (set x1 (cast 64 false (>> (cast 32 false (var x1)) (bv 6 0x0) false)))
+opex:
+  operands:
+    - type: "reg"
+      value: "w1"
+    - type: "reg"
+      value: "w1"
+    - type: "imm"
+      value: 0
+    - type: "imm"
+      value: 31
+family: cpu
+address: 0x30
+opcode: sub w0, w0, w1, uxtw
+disasm: sub w0, w0, w1, uxtw
+pseudo: w0 = w0 - w1
+mnemonic: sub
+description: substract two values
+mask: ffffffff
+prefix: 0
+id: 1211
+bytes: 0040214b
+refptr: 0
+size: 4
+sign: false
+type: sub
+cycles: 1
+esil: w1,w0,-,w0,=
+rzil: (set x0 (cast 64 false (- (cast 32 false (var x0)) (cast 32 false (var x1)))))
+opex:
+  operands:
+    - type: "reg"
+      value: "w0"
+    - type: "reg"
+      value: "w0"
+    - type: "reg"
+      value: "w1"
+      shift:
+        type: "lsl"
+        value: 0
+      ext: "uxtw"
+family: cpu
+address: 0x34
+opcode: ldr w1, [sp, 8]
+disasm: ldr w1, [sp, 8]
+pseudo: w1 = [sp + 8]
+mnemonic: ldr
+description: load from memory to register
+mask: ffffffff
+prefix: 0
+id: 634
+bytes: e10b40b9
+ptr: 0x00000008
+refptr: 4
+size: 4
+sign: false
+type: load
+cycles: 0
+esil: 8,sp,+,DUP,tmp,=,[4],w1,=
+rzil: (set x1 (cast 64 false (loadw 0 32 (+ (var sp) (bv 64 0x8)))))
+opex:
+  operands:
+    - type: "reg"
+      value: "w1"
+    - type: "mem"
+      base: "sp"
+      disp: 8
+direction: read
+family: cpu
+address: 0x38
+opcode: cneg x0, x1, ne
+disasm: cneg x0, x1, ne
+pseudo: asm("cneg x0, x1, ne")
+mnemonic: cneg
+mask: ffffffff
+prefix: 0
+id: 287
+bytes: 200481da
+refptr: 0
+size: 4
+sign: false
+type: null
+cycles: 0
+esil: zf,?{,,}
+rzil: (set x0 (ite (! (var zf)) (~- (var x1)) (var x1)))
+opex:
+  operands:
+    - type: "reg"
+      value: "x0"
+    - type: "reg"
+      value: "x1"
+    - type: "reg"
+      value: "x1"
+  cc: "eq"
+family: cpu
+address: 0x3c
+opcode: add x0, x1, x2, lsl 2
+disasm: add x0, x1, x2, lsl 2
+pseudo: x0 = x1 + x2
+mnemonic: add
+description: add two values
+mask: ffffffff
+prefix: 0
+id: 22
+bytes: 2008028b
+refptr: 0
+size: 4
+sign: false
+type: add
+cycles: 1
+esil: 2,x2,<<,x1,+,x0,=
+rzil: (set x0 (+ (var x1) (<< (var x2) (bv 6 0x2) false)))
+opex:
+  operands:
+    - type: "reg"
+      value: "x0"
+    - type: "reg"
+      value: "x1"
+    - type: "reg"
+      value: "x2"
+      shift:
+        type: "lsl"
+        value: 2
+family: cpu
+address: 0x40
+opcode: ldr q16, [x24, w8, uxtw 4]
+disasm: ldr q16, [x24, w8, uxtw 4]
+pseudo: q16 = [x24 + w8 + uxtw
+mnemonic: ldr
+description: load from memory to register
+mask: ffffffff
+prefix: 0
+id: 634
+bytes: 105be83c
+ptr: 0x00000000
+refptr: 4
+size: 4
+sign: false
+type: load
+cycles: 0
+esil: 4,w8,<<,x24,+,[16],q16,=
+opex:
+  operands:
+    - type: "reg"
+      value: "q16"
+    - type: "mem"
+      base: "x24"
+      index: "w8"
+      disp: 0
+      shift:
+        type: "lsl"
+        value: 4
+      ext: "uxtw"
+direction: read
+family: fpu
+address: 0x44
+opcode: stp fp, lr, [sp, -0x60]!
+disasm: stp fp, lr, [sp, -0x60]!
+pseudo: [sp - 0x60]! = (fp, lr)
+mnemonic: stp
+mask: ffffffff
+prefix: 0
+id: 1180
+bytes: fd7bbaa9
+refptr: 0
+size: 4
+sign: false
+type: store
+cycles: 0
+esil: 96,sp,-=,fp,sp,=[8],lr,sp,8,+,=[8]
+rzil: (seq (storew 0 (- (var sp) (bv 64 0x60)) (var x29)) (storew 0 (+ (- (var sp) (bv 64 0x60)) (bv 64 0x8)) (var x30)) (set sp (- (var sp) (bv 64 0x60))))
+opex:
+  operands:
+    - type: "reg"
+      value: "fp"
+    - type: "reg"
+      value: "lr"
+    - type: "mem"
+      base: "sp"
+      disp: -96
+  writeback: true
+direction: write
+family: cpu
+stackop: inc
+stackptr: 96
+address: 0x48
+opcode: ldr fp, [sp], 0x3c
+disasm: ldr fp, [sp], 0x3c
+pseudo: fp = [sp]
+mnemonic: ldr
+description: load from memory to register
+mask: ffffffff
+prefix: 0
+id: 634
+bytes: fdc743f8
+ptr: 0x0000003c
+refptr: 4
+size: 4
+sign: false
+type: load
+cycles: 0
+esil: 60,sp,+,DUP,tmp,=,[8],fp,=,tmp,60,+,sp,=
+rzil: (seq (set x29 (loadw 0 64 (var sp))) (set sp (+ (var sp) (bv 64 0x3c))))
+opex:
+  operands:
+    - type: "reg"
+      value: "fp"
+    - type: "mem"
+      base: "sp"
+      disp: 60
+  writeback: true
+direction: read
+family: cpu
+stackop: inc
+stackptr: -60
 EOF
 RUN

--- a/test/db/analysis/arm64
+++ b/test/db/analysis/arm64
@@ -16,7 +16,9 @@ echo --
 EOF
 EXPECT=<<EOF
 rcall
+type:
 call
+type:
 0x00000000 4 bl 0x4e3f84
 --
 --
@@ -113,6 +115,14 @@ size: 4
 sign: false
 type: mov
 cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "x8"
+    - type: "reg"
+      value: "sp"
+    - type: "reg"
+      value: "x8"
 family: sec
 --
 address: 0x100007f14
@@ -129,6 +139,16 @@ size: 4
 sign: false
 type: add
 cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "x9"
+    - type: "reg"
+      value: "x8"
+    - type: "imm"
+      value: 32
+    - type: "imm"
+      value: 0
 family: sec
 EOF
 RUN
@@ -159,6 +179,16 @@ size: 4
 sign: false
 type: add
 cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "x12"
+    - type: "reg"
+      value: "x8"
+    - type: "imm"
+      value: 512
+    - type: "imm"
+      value: 2
 family: sec
 ---
 address: 0x4
@@ -175,6 +205,16 @@ size: 4
 sign: false
 type: add
 cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "x9"
+    - type: "reg"
+      value: "x8"
+    - type: "imm"
+      value: 32
+    - type: "imm"
+      value: 0
 family: sec
 ---
 address: 0x8
@@ -191,6 +231,14 @@ size: 4
 sign: false
 type: mov
 cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "x8"
+    - type: "reg"
+      value: "sp"
+    - type: "reg"
+      value: "x8"
 family: sec
 EOF
 RUN

--- a/test/db/analysis/loongarch
+++ b/test/db/analysis/loongarch
@@ -40,6 +40,7 @@ iI~bits
 aaa
 pdf
 pdf @ fcn.00010208
+ao @ 0x00007538
 EOF
 EXPECT=<<EOF
 arch     loongarch
@@ -130,5 +131,26 @@ bits     64
 |       `-> 0x000102c4      pcalau12i t0, 0x24
 |           0x000102c8      ld.d  t0, t0, -0x4a8
 \           0x000102cc      jirl  ra, t0, 0
+address: 0x7538
+opcode: pcalau12i ra, -3
+disasm: pcalau12i ra, -3
+mnemonic: pcalau12i
+mask: ffffffff
+prefix: 0
+id: 397
+bytes: a1ffff1b
+val: 0xffffffffffff5ac8
+refptr: 0
+size: 4
+sign: false
+type: lea
+cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "ra"
+    - type: "imm"
+      value: -3
+family: cpu
 EOF
 RUN

--- a/test/db/analysis/mcs96
+++ b/test/db/analysis/mcs96
@@ -6,22 +6,31 @@ e asm.cpu=8096
 ar
 echo ----
 wx 2010
-ao 1~type,jump
+ao
+aoj~{}
 echo ----
 wx f0
-ao 1~type,stackptr
+ao
+aoj~{}
 echo ----
 wx cc10
-ao 1~type,stackptr
+ao
+aoj~{}
 echo ----
 wx a0010203
-ao 1~type,ptr
+ao
 echo ----
 wx a1123412
-ao 1~type,val
+ao
+aoj~{}
 echo ----
 wx 65123401
-ao 1~type,val
+ao
+aoj~{}
+echo ----
+wx a318041a
+ao
+aoj~{}
 EOF
 EXPECT=<<EOF
 pc = 0x0000
@@ -31,24 +40,346 @@ garbage = 0x0000
 garbage = 0x0000
 garbage = 0x0000
 ----
+address: 0x0
+opcode: sjmp 0x0010
+disasm: sjmp 0x0010
+mnemonic: sjmp
+mask: ff00
+prefix: 0
+id: 32
+bytes: 2010
+val: 0x00000010
+refptr: 0
+size: 2
+sign: false
 type: jmp
+cycles: 0
+opex:
+  operands:
+    - type: "imm"
+      value: 16
 jump: 0x00000012
+family: cpu
+[
+  {
+    "opcode": "sjmp 0x0010",
+    "disasm": "sjmp 0x0010",
+    "mnemonic": "sjmp",
+    "mask": "ff00",
+    "jump": 18,
+    "sign": false,
+    "prefix": 0,
+    "id": 32,
+    "opex": {
+      "operands": [
+        {
+          "type": "imm",
+          "value": 16
+        }
+      ]
+    },
+    "addr": 0,
+    "bytes": "2010",
+    "val": 16,
+    "size": 2,
+    "type": "jmp",
+    "scale": 0,
+    "refptr": 0,
+    "cycles": 0,
+    "failcycles": 0,
+    "delay": 0,
+    "stackptr": 0,
+    "family": "cpu"
+  }
+]
 ----
+address: 0x0
+opcode: ret
+disasm: ret
+mnemonic: ret
+mask: ff
+prefix: 0
+id: 240
+bytes: f0
+refptr: 0
+size: 1
+sign: false
 type: ret
+cycles: 0
+opex:
+  operands: []
+family: cpu
 stackptr: 2
+[
+  {
+    "opcode": "ret",
+    "disasm": "ret",
+    "mnemonic": "ret",
+    "mask": "ff",
+    "sign": false,
+    "prefix": 0,
+    "id": 240,
+    "opex": {
+      "operands": [
+        
+      ]
+    },
+    "addr": 0,
+    "bytes": "f0",
+    "size": 1,
+    "type": "ret",
+    "scale": 0,
+    "refptr": 0,
+    "cycles": 0,
+    "failcycles": 0,
+    "delay": 0,
+    "stackptr": 2,
+    "family": "cpu"
+  }
+]
 ----
+address: 0x0
+opcode: pop 0x10
+disasm: pop 0x10
+mnemonic: pop
+mask: ffff
+prefix: 0
+id: 204
+bytes: cc10
+refptr: 0
+size: 2
+sign: false
 type: pop
+cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: 16
+family: cpu
 stackptr: 2
+[
+  {
+    "opcode": "pop 0x10",
+    "disasm": "pop 0x10",
+    "mnemonic": "pop",
+    "mask": "ffff",
+    "sign": false,
+    "prefix": 0,
+    "id": 204,
+    "opex": {
+      "operands": [
+        {
+          "type": "reg",
+          "value": 16
+        }
+      ]
+    },
+    "addr": 0,
+    "bytes": "cc10",
+    "size": 2,
+    "type": "pop",
+    "scale": 0,
+    "refptr": 0,
+    "cycles": 0,
+    "failcycles": 0,
+    "delay": 0,
+    "stackptr": 2,
+    "family": "cpu"
+  }
+]
 ----
+address: 0x0
+opcode: ld 0x02 0x01
+disasm: ld 0x02 0x01
+mnemonic: ld
+mask: ff0000
+prefix: 0
+id: 160
+bytes: a00102
 ptr: 0x00000201
 refptr: 2
+size: 3
+sign: false
 type: load
+cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: 2
+    - type: "reg"
+      value: 1
+family: cpu
 ----
+address: 0x0
+opcode: ld 0x12 0x3412
+disasm: ld 0x12 0x3412
+mnemonic: ld
+mask: ffffffff
+prefix: 0
+id: 161
+bytes: a1123412
 val: 0x00003412
+refptr: 0
+size: 4
+sign: false
 type: load
+cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: 18
+    - type: "imm"
+      value: 13330
+family: cpu
+[
+  {
+    "opcode": "ld 0x12 0x3412",
+    "disasm": "ld 0x12 0x3412",
+    "mnemonic": "ld",
+    "mask": "ffffffff",
+    "sign": false,
+    "prefix": 0,
+    "id": 161,
+    "opex": {
+      "operands": [
+        {
+          "type": "reg",
+          "value": 18
+        },
+        {
+          "type": "imm",
+          "value": 13330
+        }
+      ]
+    },
+    "addr": 0,
+    "bytes": "a1123412",
+    "val": 13330,
+    "size": 4,
+    "type": "load",
+    "scale": 0,
+    "refptr": 0,
+    "cycles": 0,
+    "failcycles": 0,
+    "delay": 0,
+    "stackptr": 0,
+    "family": "cpu"
+  }
+]
 ----
+address: 0x0
+opcode: add 0x01 0x3412
+disasm: add 0x01 0x3412
+mnemonic: add
+mask: ffffffff
+prefix: 0
+id: 101
+bytes: 65123401
 val: 0x00003412
+refptr: 0
+size: 4
+sign: false
 type: add
+cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: 1
+    - type: "imm"
+      value: 13330
+family: cpu
+[
+  {
+    "opcode": "add 0x01 0x3412",
+    "disasm": "add 0x01 0x3412",
+    "mnemonic": "add",
+    "mask": "ffffffff",
+    "sign": false,
+    "prefix": 0,
+    "id": 101,
+    "opex": {
+      "operands": [
+        {
+          "type": "reg",
+          "value": 1
+        },
+        {
+          "type": "imm",
+          "value": 13330
+        }
+      ]
+    },
+    "addr": 0,
+    "bytes": "65123401",
+    "val": 13330,
+    "size": 4,
+    "type": "add",
+    "scale": 0,
+    "refptr": 0,
+    "cycles": 0,
+    "failcycles": 0,
+    "delay": 0,
+    "stackptr": 0,
+    "family": "cpu"
+  }
+]
+----
+address: 0x0
+opcode: ld 0x1a 0x04[0x18]
+disasm: ld 0x1a 0x04[0x18]
+mnemonic: ld
+mask: ffffffff
+prefix: 0
+id: 163
+bytes: a318041a
+refptr: 0
+size: 4
+sign: false
+type: load
+cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: 26
+    - type: "mem"
+      value: 24
+      disp: 4
+family: cpu
+[
+  {
+    "opcode": "ld 0x1a 0x04[0x18]",
+    "disasm": "ld 0x1a 0x04[0x18]",
+    "mnemonic": "ld",
+    "mask": "ffffffff",
+    "sign": false,
+    "prefix": 0,
+    "id": 163,
+    "opex": {
+      "operands": [
+        {
+          "type": "reg",
+          "value": 26
+        },
+        {
+          "type": "mem",
+          "value": 24,
+          "disp": 4
+        }
+      ]
+    },
+    "addr": 0,
+    "bytes": "a318041a",
+    "size": 4,
+    "type": "load",
+    "scale": 0,
+    "refptr": 0,
+    "cycles": 0,
+    "failcycles": 0,
+    "delay": 0,
+    "stackptr": 0,
+    "family": "cpu"
+  }
+]
 EOF
 RUN
 

--- a/test/db/analysis/mips
+++ b/test/db/analysis/mips
@@ -385,12 +385,36 @@ CMDS=<<EOF
 wx 01001104
 e asm.arch=mips
 e asm.bits=32
-e asm.arch=mips3
+e asm.cpu=mips3
 e asm.nbytes=4
-ao 1~type:[1]
+ao
 EOF
 EXPECT=<<EOF
-call
+address: 0x0
+opcode: bal 8
+disasm: bal 8
+pseudo: call 8
+mnemonic: bal
+description: branch and link
+mask: ff000000
+prefix: 0
+id: 225
+bytes: 01001104
+refptr: 0
+size: 4
+sign: false
+type: call
+cycles: 0
+esil: 0,1,8,<<<,1,&,==,$z,?{,pc,4,+,ra,=,,pc,=,}
+rzil: (seq (set ra (bv 64 0x8)) (jmp (bv 64 0x8)))
+opex:
+  operands:
+    - type: "imm"
+      value: 8
+jump: 0x00000008
+direction: exec
+delay: 1
+family: cpu
 EOF
 RUN
 
@@ -1274,6 +1298,14 @@ type: add
 cycles: 0
 esil: 30,0x80000000,t2,a0,^,&,>>,31,0x80000000,t2,a0,+,&,>>,|,1,==,$z,?{,$$,1,TRAP,}{,t2,a0,+,a0,=,}
 rzil: (set a0 (cast 32 (msb (+ (var t2) (var a0))) (+ (var t2) (var a0))))
+opex:
+  operands:
+    - type: "reg"
+      value: "a0"
+    - type: "reg"
+      value: "t2"
+    - type: "reg"
+      value: "a0"
 family: cpu
 ===============
 address: 0x0
@@ -1290,6 +1322,14 @@ size: 4
 sign: false
 type: null
 cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "ac3"
+    - type: "reg"
+      value: "s3"
+    - type: "reg"
+      value: "s2"
 family: mmx
 ===============
 address: 0x0
@@ -1306,6 +1346,12 @@ size: 4
 sign: false
 type: null
 cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "f10"
+    - type: "reg"
+      value: "f8"
 family: fpu
 ===============
 address: 0x0
@@ -1322,6 +1368,14 @@ size: 4
 sign: false
 type: null
 cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "f10"
+    - type: "reg"
+      value: "f18"
+    - type: "reg"
+      value: "f7"
 family: fpu
 ===============
 address: 0x0
@@ -1338,6 +1392,14 @@ size: 4
 sign: false
 type: mul
 cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "ac3"
+    - type: "reg"
+      value: "s2"
+    - type: "reg"
+      value: "a3"
 family: mmx
 ===============
 address: 0x0
@@ -1354,6 +1416,14 @@ size: 4
 sign: false
 type: mul
 cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "ac3"
+    - type: "reg"
+      value: "s2"
+    - type: "reg"
+      value: "a3"
 family: mmx
 ===============
 address: 0x0
@@ -1370,6 +1440,14 @@ size: 4
 sign: false
 type: mul
 cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "w4"
+    - type: "reg"
+      value: "w10"
+    - type: "reg"
+      value: "w7"
 family: mmx
 ===============
 address: 0x0
@@ -1386,6 +1464,8 @@ size: 4
 sign: false
 type: null
 cycles: 0
+opex:
+  operands: []
 family: virt
 ===============
 address: 0x0
@@ -1403,6 +1483,13 @@ sign: false
 type: null
 cycles: 0
 rzil: (set a0 (cast 32 (msb (loadw 0 8 (+ (var t2) (bv 32 0x5)))) (loadw 0 8 (+ (var t2) (bv 32 0x5)))))
+opex:
+  operands:
+    - type: "reg"
+      value: "a0"
+    - type: "mem"
+      base: "t2"
+      disp: 5
 family: virt
 ===============
 address: 0x0
@@ -1419,6 +1506,12 @@ size: 4
 sign: false
 type: null
 cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "a0"
+    - type: "reg"
+      value: "t2"
 family: thread
 ===============
 address: 0x0
@@ -1435,6 +1528,14 @@ size: 4
 sign: false
 type: null
 cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "a0"
+    - type: "reg"
+      value: "t2"
+    - type: "reg"
+      value: "a0"
 family: crpt
 EOF
 RUN

--- a/test/db/analysis/x86_16
+++ b/test/db/analysis/x86_16
@@ -484,10 +484,10 @@ EXPECT=<<EOF
     "opex": {
       "operands": [
         {
-          "size": 2,
-          "rw": 1,
           "type": "reg",
-          "value": "eflags"
+          "value": "eflags",
+          "read": true,
+          "nbits": 16
         }
       ]
     },

--- a/test/db/analysis/x86_32
+++ b/test/db/analysis/x86_32
@@ -3225,16 +3225,17 @@ EXPECT=<<EOF
     "opex": {
       "operands": [
         {
-          "size": 4,
-          "rw": 3,
           "type": "reg",
-          "value": "eax"
+          "value": "eax",
+          "read": true,
+          "write": true,
+          "nbits": 32
         },
         {
-          "size": 4,
-          "rw": 1,
           "type": "reg",
-          "value": "eax"
+          "value": "eax",
+          "read": true,
+          "nbits": 32
         }
       ],
       "modrm": true
@@ -3702,10 +3703,10 @@ EXPECT=<<EOF
     "opex": {
       "operands": [
         {
-          "size": 4,
-          "rw": 1,
           "type": "reg",
-          "value": "eflags"
+          "value": "eflags",
+          "read": true,
+          "nbits": 32
         }
       ]
     },
@@ -3937,7 +3938,7 @@ ao 1
 p8 1
 EOF
 EXPECT=<<EOF
-17
+19
 address: 0x0
 opcode: nop
 disasm: nop
@@ -3954,6 +3955,8 @@ type: nop
 cycles: 1
 esil: ,
 rzil: nop
+opex:
+  operands: []
 family: cpu
 90
 EOF

--- a/test/db/analysis/x86_64
+++ b/test/db/analysis/x86_64
@@ -858,12 +858,12 @@ CMDS=<<EOF
 e asm.bits=64
 e asm.arch=x86
 e analysis.arch=x86
-ao~?
+ao~esil
 ahe test
 ao~esil
 EOF
 EXPECT=<<EOF
-18
+esil: al,rax,+=[1],7,$o,of,:=,7,$s,sf,:=,$z,zf,:=,7,$c,cf,:=,$p,pf,:=,3,$c,af,:=
 esil: test
 EOF
 RUN
@@ -2418,10 +2418,10 @@ EXPECT=<<EOF
     "opex": {
       "operands": [
         {
-          "size": 8,
-          "rw": 1,
           "type": "reg",
-          "value": "eflags"
+          "value": "eflags",
+          "read": true,
+          "nbits": 64
         }
       ]
     },
@@ -3339,6 +3339,12 @@ type: rpush
 cycles: 1
 esil: rbp,8,rsp,-,=[8],8,rsp,-=
 rzil: (seq (set final (- (var rsp) (bv 64 0x8))) (storew 0 (var final) (cast 64 false (var rbp))) (set rsp (var final)))
+opex:
+  operands:
+    - type: "reg"
+      value: "rbp"
+      read: true
+      nbits: 64
 family: cpu
 stackop: inc
 stackptr: 8

--- a/test/db/analysis/xcore
+++ b/test/db/analysis/xcore
@@ -65,6 +65,12 @@ size: 2
 sign: false
 type: cjmp
 cycles: 0
+opex:
+  operands:
+    - type: "reg"
+      value: "r11"
+    - type: "imm"
+      value: 2
 jump: 0x0004035c
 fail: 0x0004035a
 cond: al

--- a/test/db/cmd/cmd_a8
+++ b/test/db/cmd/cmd_a8
@@ -7,6 +7,8 @@ a8 c745f400000000~type
 EOF
 EXPECT=<<EOF
 type: mov
+    - type: "mem"
+    - type: "imm"
 EOF
 RUN
 
@@ -18,6 +20,6 @@ e asm.bits=64
 a8j c745f400000000
 EOF
 EXPECT=<<EOF
-[{"opcode":"mov dword [rbp-0x0c], 0x00","disasm":"mov dword [rbp-0x0c], 0x00","pseudo":"dword [rbp-0x0c] = 0x00","description":"moves data from src to dst","mnemonic":"mov","mask":"ffffffffffffff","esil":"0,0xc,rbp,-,=[4]","rzil":{"opcode":"storew","mem":0,"key":{"opcode":"+","x":{"opcode":"var","value":"rbp"},"y":{"opcode":"bitv","bits":"0xfffffffffffffff4","len":64}},"value":{"opcode":"bitv","bits":"0x0","len":32}},"sign":false,"prefix":0,"id":436,"opex":{"operands":[{"size":4,"rw":2,"type":"mem","segment":"ss","base":"rbp","scale":0,"disp":-12},{"size":4,"rw":1,"type":"imm","value":0}],"modrm":true,"disp":-12},"addr":0,"bytes":"c745f400000000","val":0,"disp":18446744073709551604,"size":7,"type":"mov","scale":0,"refptr":4,"cycles":1,"failcycles":0,"delay":0,"stack":"set","stackptr":8,"family":"cpu"}]
+[{"opcode":"mov dword [rbp-0x0c], 0x00","disasm":"mov dword [rbp-0x0c], 0x00","pseudo":"dword [rbp-0x0c] = 0x00","description":"moves data from src to dst","mnemonic":"mov","mask":"ffffffffffffff","esil":"0,0xc,rbp,-,=[4]","rzil":{"opcode":"storew","mem":0,"key":{"opcode":"+","x":{"opcode":"var","value":"rbp"},"y":{"opcode":"bitv","bits":"0xfffffffffffffff4","len":64}},"value":{"opcode":"bitv","bits":"0x0","len":32}},"sign":false,"prefix":0,"id":436,"opex":{"operands":[{"type":"mem","segment":"ss","base":"rbp","scale":0,"disp":-12,"write":true,"nbits":32},{"type":"imm","value":0,"read":true,"nbits":32}],"modrm":true,"disp":-12},"addr":0,"bytes":"c745f400000000","val":0,"disp":18446744073709551604,"size":7,"type":"mov","scale":0,"refptr":4,"cycles":1,"failcycles":0,"delay":0,"stack":"set","stackptr":8,"family":"cpu"}]
 EOF
 RUN

--- a/test/db/cmd/cmd_ao
+++ b/test/db/cmd/cmd_ao
@@ -27,6 +27,21 @@ type: mov
 cycles: 1
 esil: 0,0xc,rbp,-,=[4]
 rzil: (storew 0 (+ (var rbp) (bv 64 0xfffffffffffffff4)) (bv 32 0x0))
+opex:
+  operands:
+    - type: "mem"
+      segment: "ss"
+      base: "rbp"
+      scale: 0
+      disp: -12
+      write: true
+      nbits: 32
+    - type: "imm"
+      value: 0
+      read: true
+      nbits: 32
+  modrm: true
+  disp: -12
 direction: write
 family: cpu
 stackop: set
@@ -67,19 +82,19 @@ stackptr: 8
     "opex": {
       "operands": [
         {
-          "size": 4,
-          "rw": 2,
           "type": "mem",
           "segment": "ss",
           "base": "rbp",
           "scale": 0,
-          "disp": -12
+          "disp": -12,
+          "write": true,
+          "nbits": 32
         },
         {
-          "size": 4,
-          "rw": 1,
           "type": "imm",
-          "value": 0
+          "value": 0,
+          "read": true,
+          "nbits": 32
         }
       ],
       "modrm": true,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Converts all the opex structures to RzStructuredData so we have the info also with `ao` command.

Also adds opex info on `amd29k` 

- requires first https://github.com/rizinorg/rizin/pull/5622