### PR TITLE
ROP: Add long output mode (/Rgl) for combined gadget listing and details

### DIFF
--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -80,7 +80,7 @@ RZ_IPI RzCmdStatus rz_cmd_search_gadget_handler(RzCore *core, int argc, const ch
 	if (!input) {
 		return RZ_CMD_STATUS_ERROR;
 	}
-	RzRopSearchContext *context = rz_core_rop_search_context_new(core, input, true, RZ_ROP_GADGET_PRINT, RZ_ROP_DETAIL_SEARCH_NON, state);
+	RzRopSearchContext *context = rz_core_rop_search_context_new(core, input, true, (state->mode == RZ_OUTPUT_MODE_LONG) ? (RZ_ROP_GADGET_PRINT | RZ_ROP_GADGET_PRINT_DETAIL) : RZ_ROP_GADGET_PRINT, RZ_ROP_DETAIL_SEARCH_NON, state);
 	RzCmdStatus status = rz_core_rop_search(core, context);
 	rz_core_rop_search_context_free(context);
 	return status;

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -21610,7 +21610,7 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *cmd_query_gadget_cd = rz_cmd_desc_argv_state_new(core->rcmd, slash_R_cd, "/Rk", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_TABLE, rz_cmd_query_gadget_handler, &cmd_query_gadget_help);
 	rz_warn_if_fail(cmd_query_gadget_cd);
 
-	RzCmdDesc *cmd_detail_gadget_cd = rz_cmd_desc_argv_state_new(core->rcmd, slash_R_cd, "/Rg", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_cmd_detail_gadget_handler, &cmd_detail_gadget_help);
+	RzCmdDesc *cmd_detail_gadget_cd = rz_cmd_desc_argv_state_new(core->rcmd, slash_R_cd, "/Rg", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_LONG, rz_cmd_detail_gadget_handler, &cmd_detail_gadget_help);
 	rz_warn_if_fail(cmd_detail_gadget_cd);
 
 	RzCmdDesc *cmd_rop_search_stack_cd = rz_cmd_desc_argv_state_new(core->rcmd, slash_R_cd, "/Rs", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_cmd_rop_search_stack_handler, &cmd_rop_search_stack_help);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Currently, Rizin provides two commands for working with ROP gadgets:

- `/R` searches for gadgets and prints their addresses, raw bytes, and disassembly.
- `/Rg` prints detailed semantic analysis for a single gadget at a given address.


This pull request improves the gadget output workflow by adding support for a
long output mode to the `/R` command. When invoked as `/Rgl`, the command prints
the regular gadget disassembly output and additionally prints the detailed
gadget analysis for each matched gadget.

The implementation extends the existing `/R` search handler to include
`RZ_ROP_GADGET_PRINT_DETAIL` only when `RZ_OUTPUT_MODE_LONG` is requested. This
preserves the existing behavior and semantics of both `/R` and `/Rg`, avoids
violating internal ROP printing invariants, and does not introduce any
regressions. The `/Rg` command itself remains unchanged.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

Closes #5389.

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->


