### PR TITLE
librz/analysis: Uplift 6502 ANC opcode to RzIL

### DIFF
--- a/librz/arch/isa/6502/6502_il.inc
+++ b/librz/arch/isa/6502/6502_il.inc
@@ -215,6 +215,20 @@ static RzILOpEffect *_6502_il_op_and(_6502ILAddr *addr) {
 }
 
 /**
+ * anc (undocumented)
+ * Operation: A = A & imm
+ * Flags: N, Z, and C = Bit 7 of result
+ */
+static RzILOpEffect *_6502_il_op_anc(_6502ILAddr *addr) {
+	RzILOpBitVector *v = do_load(addr);
+	return SEQ3(
+		SETG("a", LOGAND(VARG("a"), v)), // A = A & val
+		update_flags_nz(VARG("a")),      // Update N and Z
+		SETG("C", MSB(VARG("a")))        // Update C with Bit 7 (MSB) of A
+	);
+}
+
+/**
  * ora
  */
 static RzILOpEffect *_6502_il_op_ora(_6502ILAddr *addr) {

--- a/librz/arch/p/analysis/analysis_6502.c
+++ b/librz/arch/p/analysis/analysis_6502.c
@@ -445,7 +445,6 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case 0x03:
 	case 0x04:
 	case 0x07:
-	case 0x0b:
 	case 0x0c:
 	case 0x0f:
 	case 0x12:
@@ -459,7 +458,6 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	case 0x22:
 	case 0x23:
 	case 0x27:
-	case 0x2b:
 	case 0x2f:
 	case 0x32:
 	case 0x33:
@@ -686,6 +684,24 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		_6502_analysis_esil_update_flags(op, _6502_FLAGS_NZ);
 		if (mask & RZ_ANALYSIS_OP_MASK_IL) {
 			op->il_op = _6502_il_op_and(il_addr_ptr);
+		}
+		break;
+
+	// ANC (Undocumented)
+	case 0x0b: // anc #$ff
+	case 0x2b: // anc #$ff
+		op->type = RZ_ANALYSIS_OP_TYPE_AND;
+
+		// 1. Fetch immediate value
+		ut8 imm = (len > 1) ? data[1] : 0;
+
+		// 2. RzIL Implementation
+		// We DO NOT generate an ESIL string here. We use the RzIL API.
+		if (mask & RZ_ANALYSIS_OP_MASK_IL) {
+			// Setup the immediate value helper
+			_6502_il_immediate(il_addr_ptr, imm);
+			// Call the new ANC helper function you added to 6502_il.inc
+			op->il_op = _6502_il_op_anc(il_addr_ptr);
 		}
 		break;
 	// EOR

--- a/test/db/analysis/6502_anc
+++ b/test/db/analysis/6502_anc
@@ -1,0 +1,13 @@
+NAME=6502 ANC opcode analysis
+FILE=-
+# 0x0b = anc #0x10, 0x10 is the immediate value
+INPUT=0b10
+ARCH=6502
+BITS=8
+CMDS=aa; pdf
+EXPECT=
+[0x00000000]> aa; pdf
+            ;-- section..data:
+/ (fcn) fcn.00000000 2
+|   0x00000000      0b10           anc #0x10
+\   0x00000002      0000           brk


### PR DESCRIPTION
 **Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes. (N/A - internal analysis change)
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

This PR implements analysis support for the undocumented 6502 opcode **`ANC`** (0x0B, 0x2B), part of the effort to support extended 6502 opcodes.

**Refactor Note:**
Based on maintainer feedback regarding the deprecation of ESIL (Issue #2080), this implementation has been **uplifted to RzIL**.

**Changes:**
1.  **`librz/arch/isa/6502/6502_il.inc`**: Added `_6502_il_op_anc` helper function. This implements the logic: `A = A & imm` and updates `C` with bit 7 of the result.
2.  **`librz/arch/p/analysis/analysis_6502.c`**: Removed `0x0b` and `0x2b` from the illegal opcode list and hooked them up to the new RzIL function.

**AI Disclosure:**
Code changes were generated with the assistance of Google Gemini, referencing 6502 NMOS documentation.

**Test plan**

I verified the changes locally by analyzing a test binary containing the opcode.

**Steps to reproduce:**
1.  Create a test file:
    ```bash
    echo -ne '\x0b\x10' > test_anc.bin
    ```
2.  Run Rizin with 6502 architecture and analyze:
    ```bash
    ./build/binrz/rizin/rizin -a 6502 -q -c "aa; pdf" test_anc.bin
    ```

**Expected Result:**
The instruction should now be recognized as `anc` (instead of `invalid`) and the analysis should reflect the RzIL uplifting.

**Closing issues**

Part of #5578