### PR TITLE
Fix double-free in byte_pattern_search error handling

### DIFF
--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -1904,6 +1904,7 @@ static RzCmdStatus byte_pattern_search(RzCore *core, RZ_OWN RzSearchBytesPattern
 	RzSearchOpt *search_opts = setup_search_options(core);
 	RzList *hits = NULL;
 	if (!search_opts) {
+		rz_search_bytes_pattern_free(pattern);
 		goto error;
 	}
 
@@ -1917,6 +1918,7 @@ static RzCmdStatus byte_pattern_search(RzCore *core, RZ_OWN RzSearchBytesPattern
 	bool progress = rz_search_opt_get_show_progress(search_opts) != RZ_SEARCH_PROGRESS_DISABLED;
 	if (!rz_search_opt_set_cancel_cb(search_opts, cmd_search_progress_cancel, progress ? state : NULL)) {
 		RZ_LOG_ERROR("code: Failed to setup default search options.\n");
+		rz_search_bytes_pattern_free(pattern);
 		goto error;
 	}
 	hits = rz_core_search_bytes(core, search_opts, pattern);
@@ -1930,7 +1932,6 @@ static RzCmdStatus byte_pattern_search(RzCore *core, RZ_OWN RzSearchBytesPattern
 	return cmd_core_handle_search_hits(core, state, hits);
 
 error:
-	rz_search_bytes_pattern_free(pattern);
 	rz_list_free(hits);
 	rz_search_opt_free(search_opts);
 	CMD_SEARCH_END();


### PR DESCRIPTION

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

This PR fixes a double-free memory corruption bug (CID 898818, USE_AFTER_FREE) in the `byte_pattern_search()` function located in `librz/core/cmd/cmd_search.c`.

**Problem:**
The function was unconditionally freeing the `pattern` pointer at the `error` label, even after ownership had been transferred to `rz_core_search_bytes()`. This caused a double-free when:
1. `rz_core_search_bytes()` was successfully called (ownership transferred)
2. The function later failed and jumped to the `error` label
3. The `error` label attempted to free `pattern` again, causing a double-free

**Fix**

Free `pattern` in early-failure branches (before calling `rz_core_search_bytes`) to ensure we release the owned `RZ_OWN` resource on local errors.
Remove the `pattern` free from the shared error: path because ownership is transferred to `rz_core_search_bytes` and freeing there risked double-free.


No additional tests are required as this is a bug fix that corrects memory management without changing functionality. The existing test suite validates the behavior.