### PR TITLE
Analysis support for GCC's `__gnu_thumb1_case_uqi` jump tables on ARM / Thumb-1

### DIFF
--- a/librz/arch/analysis.c
+++ b/librz/arch/analysis.c
@@ -159,6 +159,7 @@ RZ_API RzAnalysis *rz_analysis_new(RZ_NULLABLE const char *sdb_types_path) {
 	analysis->debug_info = rz_analysis_debug_info_new();
 	analysis->cmpval = UT64_MAX;
 	analysis->lea_jmptbl_ip = UT64_MAX;
+	analysis->gnu_thumb1_case_uqi_addr = 0;
 	analysis->ht_virtual_xrefs = ht_sp_new(HT_STR_DUP, NULL, (HtSPFreeValue)rz_set_u_free);
 	return analysis;
 }

--- a/librz/arch/fcn.c
+++ b/librz/arch/fcn.c
@@ -1275,6 +1275,19 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 				}
 				gotoBeach(RZ_ANALYSIS_RET_END);
 			}
+
+			if (analysis->gnu_thumb1_case_uqi_addr && op.jump == analysis->gnu_thumb1_case_uqi_addr && analysis->opt.jmptbl) {
+				RzAnalysisJmpTableParams params = {
+					.jmp_address = op.addr,
+					.entry_size = 1,
+					.jmptbl_loc = op.addr + op.size,
+					.jmptbl_off = op.addr + op.size,
+					.sp = sp,
+					.tasks = tasks
+				};
+				ret = rz_analysis_walkthrough_arm_thumb1_case_uqi_table(analysis, fcn, bb, &params);
+				gotoBeach(RZ_ANALYSIS_RET_BRANCH);
+			}
 			break;
 		case RZ_ANALYSIS_OP_TYPE_UJMP:
 		case RZ_ANALYSIS_OP_TYPE_RJMP:

--- a/librz/arch/jmptbl.c
+++ b/librz/arch/jmptbl.c
@@ -433,6 +433,54 @@ RZ_API bool rz_analysis_walkthrough_arm_jmptbl_style(RZ_NONNULL RzAnalysis *anal
 }
 
 /**
+ * \brief Marks for analysis an ARM/Thumb-1 specific jump table (GCC's `__gnu_thumb1_case_uqi` format)
+ *
+ * This function works similarly to `rz_analysis_walkthrough_jmptbl`, but handles the compact
+ * byte-offset format used by the GCC's `__gnu_thumb1_case_uqi` helper function for size-optimized
+ * switch statements
+ *
+ * \param analysis Pointer to RzAnalysis instance
+ * \param fcn Pointer to RzAnalysisFunction to add the new cases
+ * \param block Pointer to RzAnalysisBlock that originates the switch table
+ * \param params Pointer to RzAnalysisJmpTableParams necessary to analyze the jump table
+ */
+RZ_API bool rz_analysis_walkthrough_arm_thumb1_case_uqi_table(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL RzAnalysisFunction *fcn, RZ_NONNULL RzAnalysisBlock *block, RZ_NONNULL RzAnalysisJmpTableParams *params) {
+	rz_return_val_if_fail(analysis && analysis->read_at && fcn && block && params, false);
+	ut8 table_size = 0;
+
+	if (params->table_count == 0) {
+		params->table_count = analysis->opt.jmptbl_maxcount;
+	}
+
+	for (table_size = 0; table_size < params->table_count; table_size++) {
+		ut8 offs;
+
+		if (!analysis->read_at(analysis, params->jmptbl_loc + table_size, &offs, 1)) {
+			return false;
+		}
+
+		if (offs == 0) {
+			break;
+		}
+
+		ut64 jmp_ptr = params->jmptbl_loc + offs * 2;
+		apply_case(analysis, block, params->jmp_address, params->entry_size, jmp_ptr, table_size, params->jmptbl_loc + table_size);
+		rz_analysis_task_item_new(analysis, params->tasks, fcn, NULL, jmp_ptr, params->sp);
+	}
+
+	if (table_size <= 1) {
+		return false;
+	}
+
+	if (params->default_case == 0 || params->default_case == UT32_MAX) {
+		params->default_case = UT64_MAX;
+	}
+
+	apply_switch(analysis, params->jmp_address, params->jmptbl_loc, table_size, params->default_case);
+	return true;
+}
+
+/**
  * \brief Gets some necessary information about a jump table to perform analysis on
  *
  * Gets amount of cases inside a jump table, the default case address and the case shift amount

--- a/librz/arch/jmptbl.c
+++ b/librz/arch/jmptbl.c
@@ -453,7 +453,7 @@ RZ_API bool rz_analysis_walkthrough_arm_thumb1_case_uqi_table(RZ_NONNULL RzAnaly
 	}
 
 	for (table_size = 0; table_size < params->table_count; table_size++) {
-		ut8 offs;
+		ut8 offs = 0;
 
 		if (!analysis->read_at(analysis, params->jmptbl_loc + table_size, &offs, 1)) {
 			return false;

--- a/librz/arch/jmptbl.c
+++ b/librz/arch/jmptbl.c
@@ -468,7 +468,7 @@ RZ_API bool rz_analysis_walkthrough_arm_thumb1_case_uqi_table(RZ_NONNULL RzAnaly
 		rz_analysis_task_item_new(analysis, params->tasks, fcn, NULL, jmp_ptr, params->sp);
 	}
 
-	if (table_size <= 1) {
+	if (table_size == 0) {
 		return false;
 	}
 

--- a/librz/arch/jmptbl.c
+++ b/librz/arch/jmptbl.c
@@ -448,7 +448,7 @@ RZ_API bool rz_analysis_walkthrough_arm_thumb1_case_uqi_table(RZ_NONNULL RzAnaly
 	rz_return_val_if_fail(analysis && analysis->read_at && fcn && block && params, false);
 	ut8 table_size = 0;
 
-	if (params->table_count == 0) {
+	if (!params->table_count) {
 		params->table_count = analysis->opt.jmptbl_maxcount;
 	}
 
@@ -459,7 +459,7 @@ RZ_API bool rz_analysis_walkthrough_arm_thumb1_case_uqi_table(RZ_NONNULL RzAnaly
 			return false;
 		}
 
-		if (offs == 0) {
+		if (!offs) {
 			break;
 		}
 
@@ -468,11 +468,11 @@ RZ_API bool rz_analysis_walkthrough_arm_thumb1_case_uqi_table(RZ_NONNULL RzAnaly
 		rz_analysis_task_item_new(analysis, params->tasks, fcn, NULL, jmp_ptr, params->sp);
 	}
 
-	if (table_size == 0) {
+	if (!table_size) {
 		return false;
 	}
 
-	if (params->default_case == 0 || params->default_case == UT32_MAX) {
+	if (!params->default_case || params->default_case == UT32_MAX) {
 		params->default_case = UT64_MAX;
 	}
 

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -2263,6 +2263,22 @@ static bool isSkippable(RzBinSymbol *s) {
 	return false;
 }
 
+static bool arch_is(RzCore *core, const char *x) {
+	RzAsm *as = core ? core->rasm : NULL;
+	if (as && as->cur && as->bits <= 32 && as->cur->name) {
+		return strstr(as->cur->name, x);
+	}
+	return false;
+}
+
+static bool archIsThumbable(RzCore *core) {
+	return arch_is(core, "arm");
+}
+
+static int compare_symbol_names(const char *s1, RzBinSymbol *sym, RZ_UNUSED void *user) {
+	return strcmp(s1, sym->name);
+}
+
 RZ_API int rz_core_analysis_all(RzCore *core) {
 	RzPVector *vector;
 	RzListIter *iter;
@@ -2293,6 +2309,12 @@ RZ_API int rz_core_analysis_all(RzCore *core) {
 	/* Symbols (Imports are already analyzed by rz_bin on init) */
 	void **it;
 	if (o && (vector = o->symbols) != NULL) {
+		// Find address of `__gnu_thumb1_case_uqi` GCC helper function on ARM (Thumb-1 mode)
+		if (archIsThumbable(core) && (it = rz_pvector_find(vector, "__gnu_thumb1_case_uqi", (RzPVectorComparator)compare_symbol_names, NULL))) {
+			RzBinSymbol *symbol = *it;
+			core->analysis->gnu_thumb1_case_uqi_addr = isValidSymbol(symbol) ? rz_bin_object_get_vaddr(o, symbol->paddr, symbol->vaddr) : 0;
+		}
+
 		rz_pvector_foreach (vector, it) {
 			symbol = *it;
 			if (rz_cons_is_breaked()) {
@@ -4625,18 +4647,6 @@ RZ_IPI void rz_core_analysis_function_until(RzCore *core, ut64 addr_end) {
 	rz_config_set_i(core->config, "analysis.from", a);
 	rz_config_set_i(core->config, "analysis.to", b);
 	rz_config_set(core->config, "analysis.limits", c ? c : "");
-}
-
-static bool arch_is(RzCore *core, const char *x) {
-	RzAsm *as = core ? core->rasm : NULL;
-	if (as && as->cur && as->bits <= 32 && as->cur->name) {
-		return strstr(as->cur->name, x);
-	}
-	return false;
-}
-
-static bool archIsThumbable(RzCore *core) {
-	return arch_is(core, "arm");
 }
 
 static void cb_in_range_aav(RzCore *core, ut64 from, ut64 to, int vsize, void *user) {

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -548,6 +548,7 @@ typedef struct rz_analysis_t {
 	char *sdb_types_path; ///<  system path prefix, whether created in initialization or passed by RzCore.
 	ut64 cmpval; ///< last compare value for jump table.
 	ut64 lea_jmptbl_ip; ///< jump table x86 lea ip
+	ut64 gnu_thumb1_case_uqi_addr; ///< address of a `__gnu_thumb1_case_uqi_addr` function (specific to ARM / Thumb-1)
 	HtSP /*<const char *, RzSetU *>*/ *ht_virtual_xrefs; ///< addresses of virtual function calls
 } RzAnalysis;
 
@@ -2037,6 +2038,7 @@ RZ_API bool rz_analysis_get_jmptbl_info(RZ_NONNULL RzAnalysis *analysis, RZ_NONN
 RZ_API bool rz_analysis_walkthrough_jmptbl(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL RzAnalysisFunction *fcn, RZ_NONNULL RzAnalysisBlock *block, RZ_NONNULL RzAnalysisJmpTableParams *params);
 RZ_API bool rz_analysis_walkthrough_casetbl(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL RzAnalysisFunction *fcn, RZ_NONNULL RzAnalysisBlock *block, RZ_NONNULL RzAnalysisJmpTableParams *params);
 RZ_API bool rz_analysis_walkthrough_arm_jmptbl_style(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL RzAnalysisFunction *fcn, RZ_NONNULL RzAnalysisBlock *block, RZ_NONNULL RzAnalysisJmpTableParams *params);
+RZ_API bool rz_analysis_walkthrough_arm_thumb1_case_uqi_table(RZ_NONNULL RzAnalysis *analysis, RZ_NONNULL RzAnalysisFunction *fcn, RZ_NONNULL RzAnalysisBlock *block, RZ_NONNULL RzAnalysisJmpTableParams *params);
 
 /* reflines.c */
 RZ_API RZ_OWN RzPVector /*<RzAnalysisRefline *>*/ *rz_analysis_reflines_get(RZ_NONNULL RzAnalysis *analysis, ut64 addr, RZ_NONNULL const ut8 *buf, ut64 len, int nlines, int linesout, int linescall);

--- a/test/db/analysis/arm
+++ b/test/db/analysis/arm
@@ -2212,3 +2212,50 @@ stackop: inc
 stackptr: -60
 EOF
 RUN
+
+NAME=arm thumb-1: parse gcc __gnu_thumb1_case_uqi jump table
+FILE=bins/elf/libmagic.so
+CMDS=<<EOF
+aa
+pdf @ sym._Unwind_VRS_Get
+EOF
+EXPECT=<<EOF
+            ; CALL XREF from fcn.000080de @ 0x80ea
+            ; CALL XREFS from sym.__gnu_unwind_execute @ 0x812a, 0x815c, 0x81d6, 0x8240
+/ sym._Unwind_VRS_Get(int16_t arg1, int16_t arg2);
+|           ; arg int16_t arg1 @ r0
+|           ; arg int16_t arg2 @ r1
+|           0x000078ea      push  {r4, lr}
+|           0x000078ec      adds  r4, r0, 0                            ; arg1
+|           0x000078ee      cmp   r1, 4                                ; arg2
+|       ,=< 0x000078f0      bhi   case.0x78f4.2
+|       |   0x000078f2      adds  r0, r1, 0                            ; arg2
+|       |   ;-- switch
+|       |   0x000078f4      bl    sym.__gnu_thumb1_case_uqi            ; switch table (5 cases) at 0x78f8
+..
+|       |   ; CODE XREF from sym._Unwind_VRS_Get @ 0x78f4
+|       |   ;-- case 1:                                                ; from 0x78f4
+|       |   ;-- case 4:                                                ; from 0x78f4
+|       |   0x000078fe      movs  r0, 1
+|      ,==< 0x00007900      b     0x791c
+|      ||   ; CODE XREF from sym._Unwind_VRS_Get @ 0x78f4
+|      ||   ;-- case 0:                                                ; from 0x78f4
+|      ||   0x00007902      movs  r0, 2
+|      ||   0x00007904      cmp   r3, 0
+|     ,===< 0x00007906      bne   0x791c
+|     |||   0x00007908      cmp   r2, 0xf
+|    ,====< 0x0000790a      bhi   0x791c
+|    ||||   0x0000790c      lsls  r2, r0
+|    ||||   0x0000790e      adds  r4, r4, r2
+|    ||||   0x00007910      ldr   r2, [sp, 8]
+|    ||||   0x00007912      ldr   r1, [r4, 4]
+|    ||||   0x00007914      str   r1, [r2]
+|    ||||   0x00007916      adds  r0, r3, 0
+|   ,=====< 0x00007918      b     0x791c
+|   |||||   ; CODE XREF from sym._Unwind_VRS_Get @ 0x78f4
+|   |||||   ;-- case 2:                                                ; from 0x78f4
+|   ||||`-> 0x0000791a      movs  r0, 2
+|   ||||    ; CODE XREFS from sym._Unwind_VRS_Get @ 0x7900, 0x7918
+\   ````--> 0x0000791c      pop   {r4, pc}
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [X] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

When targeting ARM (Thumb-1 mode) and optimizing for size, GCC uses a runtime helper function `__gnu_thumb1_case_uqi` for jumping to switch case blocks.

Currently the analysis code considers `bl __gnu_thumb1_case_uqi` as a standard function call and therefore skips analysis/indexing of basic blocks corresponding to the referenced switch cases. This PR adds analysis support for that kind of jump table which allows analyzing the case-related basic blocks.

Regarding https://github.com/rizinorg/rizin/issues/3568 - there are no refline glitches after indexing all of the function's basic blocks although the refline glitch itself is probably a separate issue, not fixed by this PR. The glitch can still be reproduced if `e analysis.jmp.tbl=false` is set before analysis.

Before:
<img width="724" height="873" alt="image" src="https://github.com/user-attachments/assets/b7e24a92-7c1b-4601-8a4f-e42ada8632fb" />

After:
<img width="1216" height="938" alt="image" src="https://github.com/user-attachments/assets/7d21e12e-00f1-49af-aa54-ebc5d21fd3b8" />

This is how it looks around `0x00007da6`:
<img width="645" height="255" alt="image" src="https://github.com/user-attachments/assets/7a47a035-3d41-446a-bd04-b87920dcad53" />



**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Added integration test

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
None
