### PR TITLE
Fix vv mode theme refresh

### DIFF
--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -367,6 +367,7 @@ typedef struct rz_core_visual_view_t {
 	bool hide_legend;
 	bool is_inputing; // whether the user is inputing
 	char *inputing; // for filter on the go in Vv mode
+	char *curtheme; // track current theme to invalidate cache on change
 } RzCoreVisualView;
 
 typedef struct rz_core_visual_t {

--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -28,6 +28,7 @@ RZ_IPI RZ_OWN RzCoreVisual *rz_core_visual_new() {
 	visual->view->output_mode = -1;
 	visual->view->output_addr = -1;
 	visual->view->selectPanel = false;
+	visual->view->curtheme = NULL;
 	memset(&visual->util, 0, sizeof(RzVisualUtil));
 	visual->util.oseek = UT64_MAX;
 	return visual;
@@ -41,6 +42,7 @@ RZ_IPI void rz_core_visual_free(RZ_NULLABLE RzCoreVisual *visual) {
 	rz_config_hold_free(visual->util.hold);
 	rz_list_free(visual->tabs);
 	free(visual->view->inputing);
+	free(visual->view->curtheme);
 	free(visual->view);
 	free(visual);
 }

--- a/librz/core/tui/vmenus.c
+++ b/librz/core/tui/vmenus.c
@@ -259,6 +259,16 @@ static void rz_core_visual_analysis_refresh_column(RzCore *core, int colpos) {
 	if (view->printMode == 1) { // px $r
 		addr += view->delta * 16;
 	}
+	const char *current_theme = rz_core_theme_get(core);
+	if (RZ_STR_NE(view->curtheme, current_theme)) {
+		RZ_FREE(view->output);
+		view->output_mode = -1;
+		view->output_addr = -1;
+	}
+	if (!view->curtheme || !current_theme || RZ_STR_NE(view->curtheme, current_theme)) {
+		free(view->curtheme);
+		view->curtheme = current_theme ? rz_str_dup(current_theme) : NULL;
+	}
 	if (view->output_mode != view->printMode || view->output_addr != addr) {
 		const char *cmd;
 		if (view->printMode > 0 && view->printMode < lastPrintMode) {

--- a/librz/core/tui/vmenus.c
+++ b/librz/core/tui/vmenus.c
@@ -259,6 +259,16 @@ static void rz_core_visual_analysis_refresh_column(RzCore *core, int colpos) {
 	if (view->printMode == 1) { // px $r
 		addr += view->delta * 16;
 	}
+	const char *current_theme = rz_core_theme_get(core);
+	if (view->curtheme && current_theme && strcmp(view->curtheme, current_theme)) {
+		RZ_FREE(view->output);
+		view->output_mode = -1;
+		view->output_addr = -1;
+	}
+	if (!view->curtheme || !current_theme || (view->curtheme && current_theme && strcmp(view->curtheme, current_theme))) {
+		free(view->curtheme);
+		view->curtheme = current_theme ? rz_str_dup(current_theme) : NULL;
+	}
 	if (view->output_mode != view->printMode || view->output_addr != addr) {
 		const char *cmd;
 		if (view->printMode > 0 && view->printMode < lastPrintMode) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else. ( Used AI just to study the issue, the code is written by my own)

**Detailed description**

This PR fixes issue #5045 where changing the color theme using `:eco <theme>` in Vv mode on Linux terminals would update the function roster theme but not the function body disassembly theme until navigating to another function.

The function body disassembly output is cached in `view->output` to avoid redundant analysis when scrolling. The cache is only invalidated when `output_mode` or `output_addr` changes, but not when the theme changes. When `:eco <theme>` is executed, the palette colors update via `rz_cons_pal_update_event()`, but the cached output still contains ANSI color codes from the old theme.

**Test plan**

***Screen Recording***

After the fix, changing the theme using eco <theme> now immediately updates both the function roster and the function disassembly view.

https://github.com/user-attachments/assets/b187d6dd-9e8f-45f8-a7a9-52bab51c9cfc


**Closing issues**

closes #5045