### PR TITLE
ctrl G: For soft escape 

### DIFF
--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -1681,6 +1681,13 @@ RZ_API const char *rz_line_readline_cb(RZ_NONNULL RzLine *line, RzLineReadCallba
 				__delete_next_char(line);
 			}
 			break;
+		case 7: // ^G
+			line->gcomp = 0;
+			line->buffer.data[0] = 0;
+			line->buffer.length = 0;
+			line->buffer.index = 0;
+			goto _end;
+			break;
 		case 11: // ^K
 			if (line->buffer.index != line->buffer.length) {
 				undo_add_entry(line, line->buffer.index, rz_str_dup(line->buffer.data + line->buffer.index), NULL);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

`ctrl+G` is used in zsh/bash alias of `ctrl+C` , `ctrl+G` will be useful for escaping backward-search more softly compared to `ctrl+C`

**Test plan**

Go for backward-search `ctrl+R` and then try `ctrl+G` it exits the backward-search

**Closing issues**

closes #573

