### PR TITLE
fix null reference when calling uninitialized cpu descriptions getter

### DIFF
--- a/librz/core/casm.c
+++ b/librz/core/casm.c
@@ -286,7 +286,7 @@ RZ_API RzCmdStatus rz_core_cpu_descs_print(RZ_NONNULL RzCore *core, RZ_NONNULL c
 	RzListIter *it;
 	RzAsmPlugin *ap;
 	rz_list_foreach (plugin_list, it, ap) {
-		if (ap->cpus && RZ_STR_EQ(plugin, ap->name)) {
+		if (ap->cpus && RZ_STR_EQ(plugin, ap->name) && ap->get_cpu_desc) {
 			char **desc = ap->get_cpu_desc();
 			if (!desc) {
 				rz_iterator_free(iter);

--- a/librz/core/casm.c
+++ b/librz/core/casm.c
@@ -286,7 +286,7 @@ RZ_API RzCmdStatus rz_core_cpu_descs_print(RZ_NONNULL RzCore *core, RZ_NONNULL c
 	RzListIter *it;
 	RzAsmPlugin *ap;
 	rz_list_foreach (plugin_list, it, ap) {
-		if (ap->cpus && RZ_STR_EQ(plugin, ap->name) && ap->get_cpu_desc) {
+		if (ap->cpus && ap->get_cpu_desc && RZ_STR_EQ(plugin, ap->name)) {
 			char **desc = ap->get_cpu_desc();
 			if (!desc) {
 				rz_iterator_free(iter);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

This is a null check to make sure that `get_cpu_desc` (`RzAsmPlugin` struct) is non-null before calling it. 

Without this check `rz-asm -m hexagon` crashes with a SIGSEGV, and so does any architecture that doesn't define a `get_cpu_desc` member (only 11 out of 70+ do).

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

No AI tool was used, the check is straightforward.

**Test plan**

No automated test.

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Run `rz-asm -m hexagon` on dev, it crashes, run it on this branch, it no longer crashes

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
