### PR TITLE
debug: remove globals from XNU native debugger

### DIFF
--- a/librz/debug/p/native/xnu/xnu_debug.c
+++ b/librz/debug/p/native/xnu/xnu_debug.c
@@ -798,7 +798,6 @@ static void xnu_collect_thread_state(thread_t port, void *tirp) {
 	struct thread_command *tc;
 	vm_offset_t header;
 	ut64 hoffset;
-	int i;
 
 	header = tir->header;
 	hoffset = tir->hoffset;
@@ -810,8 +809,8 @@ static void xnu_collect_thread_state(thread_t port, void *tirp) {
 	tc->cmdsize = sizeof(struct thread_command) + tir->tstate_size;
 	hoffset += sizeof(struct thread_command);
 
-	for (i = 0; i < coredump_nflavors; i++) {
-		eprintf("[DEBUG] %d/%d\n", i + 1, coredump_nflavors);
+	for (size_t i = 0; i < COREDUMP_FLAVORS_ARRAY_SIZE; i++) {
+		eprintf("[DEBUG] %zu/%d\n", i + 1, COREDUMP_FLAVORS_ARRAY_SIZE);
 		*(coredump_thread_state_flavor_t *)(header + hoffset) = flavors[i];
 		hoffset += sizeof(coredump_thread_state_flavor_t);
 		xnu_get_thread_status(port, flavors[i].flavor,
@@ -845,7 +844,7 @@ static uid_t uidFromPid(pid_t pid) {
 bool xnu_generate_corefile(RzDebug *dbg, RzBuffer *dest) {
 	rz_return_val_if_fail(dbg && dbg->plugin_data, false);
 	RzXnuDebug *ctx = dbg->plugin_data;
-	int error = 0, i;
+	int error = 0;
 	int tstate_size;
 	int segment_count;
 	int command_size;
@@ -877,7 +876,7 @@ bool xnu_generate_corefile(RzDebug *dbg, RzBuffer *dest) {
 	memcpy(thread_flavor_array, &flavors, sizeof(thread_flavor_array));
 	tstate_size = 0;
 
-	for (i = 0; i < coredump_nflavors; i++) {
+	for (size_t i = 0; i < COREDUMP_FLAVORS_ARRAY_SIZE; i++) {
 		tstate_size += sizeof(coredump_thread_state_flavor_t) +
 			(flavors[i].count * sizeof(int));
 	}

--- a/librz/debug/p/native/xnu/xnu_debug.h
+++ b/librz/debug/p/native/xnu/xnu_debug.h
@@ -193,7 +193,7 @@ static coredump_thread_state_flavor_t
 		{ PPC_VECTOR_STATE, PPC_VECTOR_STATE_COUNT },
 	};
 
-static int coredump_nflavors = 4;
+#define COREDUMP_FLAVORS_ARRAY_SIZE 4
 
 #elif defined(__ppc64__)
 
@@ -205,7 +205,7 @@ coredump_thread_state_flavor_t
 		{ PPC_VECTOR_STATE, PPC_VECTOR_STATE_COUNT },
 	};
 
-static int coredump_nflavors = 4;
+#define COREDUMP_FLAVORS_ARRAY_SIZE 4
 
 #elif defined(__i386__)
 
@@ -216,7 +216,7 @@ static coredump_thread_state_flavor_t
 		{ x86_EXCEPTION_STATE32, x86_EXCEPTION_STATE32_COUNT },
 	};
 
-static int coredump_nflavors = 3;
+#define COREDUMP_FLAVORS_ARRAY_SIZE 3
 
 #elif defined(__x86_64__)
 
@@ -227,7 +227,7 @@ static coredump_thread_state_flavor_t
 		{ x86_EXCEPTION_STATE64, x86_EXCEPTION_STATE64_COUNT },
 	};
 
-static int coredump_nflavors = 3;
+#define COREDUMP_FLAVORS_ARRAY_SIZE 3
 
 #elif defined(__aarch64__) || defined(__arm64__)
 
@@ -236,7 +236,7 @@ static coredump_thread_state_flavor_t
 		{ ARM_UNIFIED_THREAD_STATE, ARM_UNIFIED_THREAD_STATE_COUNT }
 	};
 
-static int coredump_nflavors = 1;
+#define COREDUMP_FLAVORS_ARRAY_SIZE 1
 
 #elif defined(__arm__)
 
@@ -245,7 +245,7 @@ static coredump_thread_state_flavor_t
 		{ ARM_THREAD_STATE64, ARM_THREAD_STATE64_COUNT }
 	};
 
-static int coredump_nflavors = 1;
+#define COREDUMP_FLAVORS_ARRAY_SIZE 1
 
 #else
 // XXX: Add __arm__ for iOS devices?


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Just chipping off from https://github.com/rizinorg/rizin/issues/4055

**Test plan**

CI is green