### PR TITLE
librz/arch: Remove globals from or1k, ppc and pyc

### DIFF
--- a/librz/arch/isa/pyc/opcode.c
+++ b/librz/arch/isa/pyc/opcode.c
@@ -267,41 +267,40 @@ static version_opcode version_op[] = {
 	{ "v3.14.0", opcode_314 },
 	{ "v3.14.1", opcode_314 },
 	{ "v3.14.2", opcode_314 },
-	{ NULL, NULL },
 };
 
-bool pyc_opcodes_equal(pyc_opcodes *op, const char *version) {
-	if (version == NULL || op == NULL) {
-		return false;
-	}
-	version_opcode *vop = version_op;
-
-	while (vop->version) {
-		if (!strcmp(vop->version, version)) {
-			if (vop->opcode_func == (pyc_opcodes * (*)())(op->version_sig)) {
-				return true;
-			}
-		}
-		vop++;
+void pyc_context_free(pyc_context_t *ctx) {
+	if (!ctx) {
+		return;
 	}
 
-	return false;
+	free_opcode(ctx->cache);
+	free(ctx);
 }
 
-pyc_opcodes *get_opcode_by_version(char *version) {
-	if (version == NULL) {
-		return NULL;
+bool pyc_context_set_opcode_by_version(const char *version, pyc_context_t *ctx) {
+	if (!version) {
+		return false;
 	}
-	version_opcode *vop = version_op;
 
-	while (vop->version) {
-		if (!strcmp(vop->version, version)) {
-			return vop->opcode_func();
+	for (size_t i = 0; i < RZ_ARRAY_SIZE(version_op); ++i) {
+		version_opcode *vop = &version_op[i];
+		if (RZ_STR_NE(vop->version, version)) {
+			continue;
 		}
-		vop++;
+
+		free_opcode(ctx->cache);
+		ctx->cache = vop->opcode_func();
+		if (!ctx->cache) {
+			// fail to alloc
+			return false;
+		}
+		ctx->version = vop->version;
+		return true;
 	}
 
-	return NULL; // No match version
+	// No match version
+	return false;
 }
 
 pyc_opcodes *new_pyc_opcodes() {
@@ -338,14 +337,11 @@ pyc_opcodes *new_pyc_opcodes() {
 }
 
 void free_opcode(pyc_opcodes *opcodes) {
-	size_t i;
-	if (opcodes == NULL || opcodes->opcodes == NULL) {
+	if (!opcodes) {
 		return;
 	}
-	for (i = 0; i < 256; i++) {
-		if (opcodes->opcodes[i].op_name) {
-			free(opcodes->opcodes[i].op_name);
-		}
+	for (size_t i = 0; i < 256 && opcodes->opcodes; i++) {
+		free(opcodes->opcodes[i].op_name);
 	}
 	free(opcodes->opcodes);
 	if (opcodes->opcode_arg_fmt) {

--- a/librz/arch/isa/pyc/opcode.h
+++ b/librz/arch/isa/pyc/opcode.h
@@ -71,6 +71,11 @@ typedef struct {
 
 void analysis_pyc_op(RzAnalysisOp *op, pyc_opcode_object *op_obj, ut32 oparg);
 
+typedef struct {
+	const char *version;
+	pyc_opcodes *cache;
+} pyc_context_t;
+
 pyc_opcodes *opcode_2x(void);
 pyc_opcodes *opcode_3x(void);
 pyc_opcodes *opcode_10(void);
@@ -104,11 +109,11 @@ pyc_opcodes *opcode_312(void);
 pyc_opcodes *opcode_313(void);
 pyc_opcodes *opcode_314(void);
 
-pyc_opcodes *get_opcode_by_version(char *version);
+bool pyc_context_set_opcode_by_version(const char *version, pyc_context_t *ctx);
+void pyc_context_free(pyc_context_t *ctx);
 
 pyc_opcodes *new_pyc_opcodes();
 void free_opcode(pyc_opcodes *opcodes);
-bool pyc_opcodes_equal(pyc_opcodes *op, const char *version);
 
 void add_arg_fmt(pyc_opcodes *ret, char *op_name, const char *(*formatter)(ut32 oparg));
 

--- a/librz/arch/p/analysis/analysis_or1k.c
+++ b/librz/arch/p/analysis/analysis_or1k.c
@@ -6,9 +6,10 @@
 #include <rz_lib.h>
 #include <or1k/or1k_disas.h>
 
-static ut32 cpu[32] = { 0 }; /* register contents */
-static ut32 cpu_enable; /* allows to treat only registers with known value as
-	valid */
+typedef struct {
+	ut32 cpu[32]; ///< register contents
+	ut32 cpu_enable; ///< allows to treat only registers with known value as valid
+} or1k_context_t;
 
 /**
  * \brief Convert raw N operand to complete address
@@ -27,6 +28,7 @@ static ut64 n_oper_to_addr(ut32 n, ut32 mask, ut64 addr) {
 }
 
 static int insn_to_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, insn_t *descr, insn_extra_t *extra, ut32 insn) {
+	or1k_context_t *ctx = (or1k_context_t *)a->plugin_data;
 	struct operands o = { 0 };
 	insn_type_t type = type_of_opcode(descr, extra);
 	insn_type_descr_t *type_descr = &types[INSN_X];
@@ -76,16 +78,16 @@ static int insn_to_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, insn_t *descr,
 	case 0x11: /* l.jr */
 		o.rb = get_operand_value(insn, type_descr, INSN_OPER_B);
 		op->eob = true;
-		if (cpu_enable & (1 << o.rb)) {
-			op->jump = cpu[o.rb];
+		if (ctx->cpu_enable & (1 << o.rb)) {
+			op->jump = ctx->cpu[o.rb];
 		}
 		op->delay = 1;
 		break;
 	case 0x12: /* l.jalr */
 		o.rb = get_operand_value(insn, type_descr, INSN_OPER_B);
 		op->eob = true;
-		if (cpu_enable & (1 << o.rb)) {
-			op->jump = cpu[o.rb];
+		if (ctx->cpu_enable & (1 << o.rb)) {
+			op->jump = ctx->cpu[o.rb];
 		}
 		op->delay = 1;
 		break;
@@ -94,8 +96,8 @@ static int insn_to_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, insn_t *descr,
 		case 0: /* l.movhi */
 			o.rd = get_operand_value(insn, type_descr, INSN_OPER_D);
 			o.k = get_operand_value(insn, type_descr, INSN_OPER_K);
-			cpu[o.rd] = o.k << 16;
-			cpu_enable |= (1 << o.rd);
+			ctx->cpu[o.rd] = o.k << 16;
+			ctx->cpu_enable |= (1 << o.rd);
 			break;
 		case 1: /* l.macrc */
 			break;
@@ -105,10 +107,10 @@ static int insn_to_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, insn_t *descr,
 		o.rd = get_operand_value(insn, type_descr, INSN_OPER_D);
 		o.ra = get_operand_value(insn, type_descr, INSN_OPER_A);
 		o.i = get_operand_value(insn, type_descr, INSN_OPER_I);
-		if (cpu_enable & (1 << o.ra) & cpu_enable & (1 << o.rd)) {
-			cpu[o.rd] = cpu[o.ra] | o.i;
-			cpu_enable |= (1 << o.rd);
-			op->ptr = cpu[o.rd];
+		if (ctx->cpu_enable & (1 << o.ra) & ctx->cpu_enable & (1 << o.rd)) {
+			ctx->cpu[o.rd] = ctx->cpu[o.ra] | o.i;
+			ctx->cpu_enable |= (1 << o.rd);
+			op->ptr = ctx->cpu[o.rd];
 			op->direction = 8; /* reference */
 		}
 		break;
@@ -116,22 +118,22 @@ static int insn_to_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, insn_t *descr,
 		o.rd = get_operand_value(insn, type_descr, INSN_OPER_D);
 		o.ra = get_operand_value(insn, type_descr, INSN_OPER_A);
 		o.i = get_operand_value(insn, type_descr, INSN_OPER_I);
-		if (cpu_enable & (1 << o.ra)) {
-			cpu[o.rd] = cpu[o.ra] | o.i;
-			cpu_enable |= (1 << o.rd);
-			op->ptr = cpu[o.rd];
+		if (ctx->cpu_enable & (1 << o.ra)) {
+			ctx->cpu[o.rd] = ctx->cpu[o.ra] | o.i;
+			ctx->cpu_enable |= (1 << o.rd);
+			op->ptr = ctx->cpu[o.rd];
 			op->direction = 8; /* reference */
 		}
 		break;
 	default:
 		/* if unknown instruction encountered, better forget state */
-		cpu_enable = 0;
+		ctx->cpu_enable = 0;
 	}
 
 	/* temporary solution to prevent using wrong register values */
 	if ((op->type & RZ_ANALYSIS_OP_TYPE_JMP) == RZ_ANALYSIS_OP_TYPE_JMP) {
 		/* FIXME: handle delay slot after branches */
-		cpu_enable = 0;
+		ctx->cpu_enable = 0;
 	}
 	return 4;
 }
@@ -174,6 +176,21 @@ static int or1k_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *data, 
 	return op->size;
 }
 
+static bool or1k_init(void **user) {
+	or1k_context_t *ctx = RZ_NEW0(or1k_context_t);
+	if (!ctx) {
+		return false;
+	}
+
+	*user = ctx;
+	return true;
+}
+
+static bool or1k_fini(void *user) {
+	free(user);
+	return true;
+}
+
 RzAnalysisPlugin rz_analysis_plugin_or1k = {
 	.name = "or1k",
 	.desc = "OpenRISC 1000",
@@ -182,4 +199,6 @@ RzAnalysisPlugin rz_analysis_plugin_or1k = {
 	.arch = "or1k",
 	.esil = false,
 	.op = &or1k_op,
+	.init = &or1k_init,
+	.fini = &or1k_fini,
 };

--- a/librz/arch/p/analysis/analysis_ppc_cs.c
+++ b/librz/arch/p/analysis/analysis_ppc_cs.c
@@ -47,6 +47,7 @@ typedef struct {
 	csh handle;
 	int omode;
 	int obits;
+	RzRegItem base_regs[4];
 } PPCContext;
 
 static bool ppc_init(void **user) {
@@ -869,22 +870,20 @@ static int parse_reg_name(RzRegItem *reg, csh handle, cs_insn *insn, int reg_num
 	return 0;
 }
 
-static RzRegItem base_regs[4];
-
-static void create_src_dst(RzAnalysisOp *op) {
+static void create_src_dst(RzAnalysisOp *op, PPCContext *ctx) {
 	op->src[0] = rz_analysis_value_new();
 	op->src[1] = rz_analysis_value_new();
 	op->src[2] = rz_analysis_value_new();
 	op->dst = rz_analysis_value_new();
-	ZERO_FILL(base_regs[0]);
-	ZERO_FILL(base_regs[1]);
-	ZERO_FILL(base_regs[2]);
-	ZERO_FILL(base_regs[3]);
+	ZERO_FILL(ctx->base_regs[0]);
+	ZERO_FILL(ctx->base_regs[1]);
+	ZERO_FILL(ctx->base_regs[2]);
+	ZERO_FILL(ctx->base_regs[3]);
 }
 
-static void set_src_dst(RzAnalysisValue *val, csh *handle, cs_insn *insn, int x) {
+static void set_src_dst(RzAnalysisValue *val, csh *handle, cs_insn *insn, int x, PPCContext *ctx) {
 	cs_ppc_op ppcop = INSOP(x);
-	parse_reg_name(&base_regs[x], *handle, insn, x);
+	parse_reg_name(&ctx->base_regs[x], *handle, insn, x);
 	switch (ppcop.type) {
 	case PPC_OP_REG:
 		break;
@@ -897,11 +896,11 @@ static void set_src_dst(RzAnalysisValue *val, csh *handle, cs_insn *insn, int x)
 	default:
 		break;
 	}
-	val->reg = &base_regs[x];
+	val->reg = &ctx->base_regs[x];
 }
 
-static void op_fillval(RzAnalysisOp *op, csh handle, cs_insn *insn) {
-	create_src_dst(op);
+static void op_fillval(RzAnalysisOp *op, csh handle, cs_insn *insn, PPCContext *ctx) {
+	create_src_dst(op, ctx);
 	switch (op->type & RZ_ANALYSIS_OP_TYPE_MASK) {
 	case RZ_ANALYSIS_OP_TYPE_MOV:
 	case RZ_ANALYSIS_OP_TYPE_CMP:
@@ -923,14 +922,14 @@ static void op_fillval(RzAnalysisOp *op, csh handle, cs_insn *insn) {
 	case RZ_ANALYSIS_OP_TYPE_ROR:
 	case RZ_ANALYSIS_OP_TYPE_ROL:
 	case RZ_ANALYSIS_OP_TYPE_CAST:
-		set_src_dst(op->src[2], &handle, insn, 3);
-		set_src_dst(op->src[1], &handle, insn, 2);
-		set_src_dst(op->src[0], &handle, insn, 1);
-		set_src_dst(op->dst, &handle, insn, 0);
+		set_src_dst(op->src[2], &handle, insn, 3, ctx);
+		set_src_dst(op->src[1], &handle, insn, 2, ctx);
+		set_src_dst(op->src[0], &handle, insn, 1, ctx);
+		set_src_dst(op->dst, &handle, insn, 0, ctx);
 		break;
 	case RZ_ANALYSIS_OP_TYPE_STORE:
-		set_src_dst(op->dst, &handle, insn, 1);
-		set_src_dst(op->src[0], &handle, insn, 0);
+		set_src_dst(op->dst, &handle, insn, 1, ctx);
+		set_src_dst(op->src[0], &handle, insn, 0, ctx);
 		break;
 	}
 }
@@ -1742,7 +1741,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 			break;
 		}
 		if (mask & RZ_ANALYSIS_OP_MASK_VAL) {
-			op_fillval(op, ctx->handle, insn);
+			op_fillval(op, ctx->handle, insn, ctx);
 		}
 		if (!(mask & RZ_ANALYSIS_OP_MASK_ESIL)) {
 			rz_strbuf_fini(&op->esil);

--- a/librz/arch/p/analysis/analysis_pyc.c
+++ b/librz/arch/p/analysis/analysis_pyc.c
@@ -52,7 +52,7 @@ static RzList /*<RzList<void *> *>*/ *get_pyc_code_obj(RzAnalysis *analysis) {
 }
 
 static int pyc_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *data, int len, RzAnalysisOpMask mask) {
-	pyc_opcodes *ops = (pyc_opcodes *)a->plugin_data;
+	pyc_context_t *ctx = (pyc_context_t *)a->plugin_data;
 	RzList *cobjs = rz_list_get_n(get_pyc_code_obj(a), 0);
 	RzListIter *iter = NULL;
 	pyc_code_object *func = NULL, *t = NULL;
@@ -74,28 +74,25 @@ static int pyc_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *data, i
 	op->type = RZ_ANALYSIS_OP_TYPE_ILL;
 	op->id = op_code;
 
-	if (!pyc_opcodes_equal(ops, a->cpu)) {
-		free_opcode(ops);
-		ops = NULL;
-	}
-
-	if (!ops) {
-		if (!(ops = get_opcode_by_version(a->cpu))) {
+	if (!ctx->cache || RZ_STR_NE(ctx->version, a->cpu)) {
+		if (!pyc_context_set_opcode_by_version(a->cpu, ctx)) {
+			RZ_LOG_ERROR("analysis: pyc: unsupported pyc opcode cpu/version (analysis.cpu=%s).\n", a->cpu);
 			return -1;
 		}
-		a->plugin_data = ops;
+		ctx->cache->bits = a->bits;
 	}
+
 	bool is_python36 = a->bits == 8;
-	pyc_opcode_object *op_obj = &ops->opcodes[op_code];
+	pyc_opcode_object *op_obj = &ctx->cache->opcodes[op_code];
 	if (!op_obj->op_name) {
 		op->type = RZ_ANALYSIS_OP_TYPE_ILL;
 		op->size = 1;
 		goto analysis_end;
 	}
 
-	op->size = is_python36 ? 2 : ((op_code >= ops->have_argument) ? 3 : 1);
+	op->size = is_python36 ? 2 : ((op_code >= ctx->cache->have_argument) ? 3 : 1);
 
-	if (op_code >= ops->have_argument) {
+	if (op_code >= ctx->cache->have_argument) {
 		if (!is_python36) {
 			oparg = data[1] + data[2] * 256 + extended_arg;
 		} else {
@@ -105,7 +102,7 @@ static int pyc_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *data, i
 
 	if (op_obj->type & HASJABS) {
 		op->type = RZ_ANALYSIS_OP_TYPE_JMP;
-		op->jump = func_base + JMP_OFFSET(ops, oparg);
+		op->jump = func_base + JMP_OFFSET(ctx->cache, oparg);
 
 		if (op_obj->type & HASCONDITION) {
 			op->type = RZ_ANALYSIS_OP_TYPE_CJMP;
@@ -115,7 +112,7 @@ static int pyc_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *data, i
 	}
 	if (op_obj->type & HASJREL) {
 		op->type = RZ_ANALYSIS_OP_TYPE_JMP;
-		op->jump = addr + ((is_python36) ? 2 : 3) + JMP_OFFSET(ops, oparg);
+		op->jump = addr + ((is_python36) ? 2 : 3) + JMP_OFFSET(ctx->cache, oparg);
 		op->fail = addr + ((is_python36) ? 2 : 3);
 
 		if (op_obj->type & HASCONDITION) {
@@ -136,9 +133,18 @@ analysis_end:
 	return op->size;
 }
 
-static bool pyc_analysis_finish(void *user) {
-	pyc_opcodes *ops = (user);
-	free_opcode(ops);
+static bool pyc_analysis_fini(void *user) {
+	pyc_context_free((pyc_context_t *)user);
+	return true;
+}
+
+static bool pyc_analysis_init(void **user) {
+	pyc_context_t *context = RZ_NEW0(pyc_context_t);
+	if (!context) {
+		return false;
+	}
+
+	*user = context;
 	return true;
 }
 
@@ -152,5 +158,6 @@ RzAnalysisPlugin rz_analysis_plugin_pyc = {
 	.get_reg_profile = get_reg_profile,
 	.op = &pyc_op,
 	.esil = false,
-	.fini = &pyc_analysis_finish,
+	.init = &pyc_analysis_init,
+	.fini = &pyc_analysis_fini,
 };

--- a/librz/arch/p/asm/asm_pyc.c
+++ b/librz/arch/p/asm/asm_pyc.c
@@ -9,9 +9,8 @@
 
 #include "pyc/pyc_dis.h"
 
-static pyc_opcodes *opcodes_cache = NULL;
-
-static int pyc_asm_disassemble(RzAsm *a, RzAsmOp *opstruct, const ut8 *buf, int len) {
+static int pyc_asm_disassemble(RzAsm *a, RzAsmOp *aop, const ut8 *buf, int len) {
+	pyc_context_t *ctx = (pyc_context_t *)a->plugin_data;
 	RzList *shared = NULL;
 
 	RzBin *bin = a->binb.bin;
@@ -19,10 +18,8 @@ static int pyc_asm_disassemble(RzAsm *a, RzAsmOp *opstruct, const ut8 *buf, int 
 
 	RzBinPlugin *plugin = bin && bin->cur && bin->cur->o ? bin->cur->o->plugin : NULL;
 
-	if (plugin) {
-		if (!strcmp(plugin->name, "pyc")) {
-			shared = ((RzBinPycObj *)bin->cur->o->bin_obj)->shared;
-		}
+	if (plugin && !strcmp(plugin->name, "pyc")) {
+		shared = ((RzBinPycObj *)bin->cur->o->bin_obj)->shared;
 	}
 
 	RzList *cobjs = NULL;
@@ -31,24 +28,30 @@ static int pyc_asm_disassemble(RzAsm *a, RzAsmOp *opstruct, const ut8 *buf, int 
 		cobjs = rz_list_get_n(shared, 0);
 	}
 
-	if (!opcodes_cache || !pyc_opcodes_equal(opcodes_cache, a->cpu)) {
-		opcodes_cache = get_opcode_by_version(a->cpu);
-		if (opcodes_cache == NULL) {
+	if (!ctx->cache || RZ_STR_NE(ctx->version, a->cpu)) {
+		if (!pyc_context_set_opcode_by_version(a->cpu, ctx)) {
 			RZ_LOG_ERROR("disassembler: pyc: unsupported pyc opcode cpu/version (asm.cpu=%s).\n", a->cpu);
-			return len;
+			return -1;
 		}
-		opcodes_cache->bits = a->bits;
+		ctx->cache->bits = a->bits;
 	}
-	int r = rz_pyc_disasm(opstruct, buf, cobjs, pc, opcodes_cache);
-	opstruct->size = r;
+	int r = rz_pyc_disasm(aop, buf, cobjs, pc, ctx->cache);
+	aop->size = r;
 	return r;
 }
 
-static bool pyc_asm_finish(void *user) {
-	if (opcodes_cache) {
-		free_opcode(opcodes_cache);
-		opcodes_cache = NULL;
+static bool pyc_asm_fini(void *user) {
+	pyc_context_free((pyc_context_t *)user);
+	return true;
+}
+
+static bool pyc_asm_init(void **user) {
+	pyc_context_t *context = RZ_NEW0(pyc_context_t);
+	if (!context) {
+		return false;
 	}
+
+	*user = context;
 	return true;
 }
 
@@ -59,7 +62,8 @@ RzAsmPlugin rz_asm_plugin_pyc = {
 	.bits = 16 | 8,
 	.desc = "Python bytecode (PYC) disassembler",
 	.disassemble = &pyc_asm_disassemble,
-	.fini = &pyc_asm_finish,
+	.init = &pyc_asm_init,
+	.fini = &pyc_asm_fini,
 };
 
 #ifndef RZ_PLUGIN_INCORE


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Removes globals from or1k, ppc and pyc

Related to #4055