### PR TITLE
PE: Add support for relocation types 7, 9, and 15 (#5683)

### DIFF
--- a/librz/bin/format/pe/pe_specs.h
+++ b/librz/bin/format/pe/pe_specs.h
@@ -542,8 +542,10 @@ typedef struct {
 // ... 6 is reserved
 #define PE_IMAGE_REL_BASED_THUMB_MOV32_RISCV_LOW12I         7
 #define PE_IMAGE_REL_BASED_RISCV_LOW12S_LOONGARCH32_MARK_LA 8
-#define PE_IMAGE_REL_BASED_MIPS_JMPADDR16                   9
+#define PE_IMAGE_REL_BASED_MIPS_JMPADDR16_IA64_IMM64        9
 #define PE_IMAGE_REL_BASED_DIR64                            10
+// ... 11-14 are reserved or machine-specific
+#define PE_IMAGE_REL_BASED_RESERVED_15                      15
 
 #define STRINGFILEINFO_TEXT  "StringFileInfo"
 #define TRANSLATION_TEXT     "Translation"

--- a/librz/bin/p/bin_pe.inc
+++ b/librz/bin/p/bin_pe.inc
@@ -500,6 +500,8 @@ static const char *get_reloc_type_name(const ut8 reloc_type, const ut32 machine_
 
 	case PE_IMAGE_REL_BASED_THUMB_MOV32_RISCV_LOW12I:
 		switch (machine_type) {
+		case PE_IMAGE_FILE_MACHINE_ARM:
+		case PE_IMAGE_FILE_MACHINE_ARMNT:
 		case PE_IMAGE_FILE_MACHINE_THUMB:
 			return "IMAGE_REL_BASED_THUMB_MOV32";
 		case PE_IMAGE_FILE_MACHINE_RISCV32:
@@ -523,7 +525,7 @@ static const char *get_reloc_type_name(const ut8 reloc_type, const ut32 machine_
 			RZ_LOG_WARN("Unknown machine type for PE relocation type number: %d\n", reloc_type);
 			return "IMAGE_REL_BASED_UNKNOWN";
 		}
-	case PE_IMAGE_REL_BASED_MIPS_JMPADDR16:
+	case PE_IMAGE_REL_BASED_MIPS_JMPADDR16_IA64_IMM64:
 		switch (machine_type) {
 		case PE_IMAGE_FILE_MACHINE_MIPS16:
 		case PE_IMAGE_FILE_MACHINE_MIPSFPU:
@@ -531,12 +533,16 @@ static const char *get_reloc_type_name(const ut8 reloc_type, const ut32 machine_
 		case PE_IMAGE_FILE_MACHINE_R4000:
 		case PE_IMAGE_FILE_MACHINE_WCEMIPSV2:
 			return "IMAGE_REL_BASED_MIPS_JMPADDR16";
+		case PE_IMAGE_FILE_MACHINE_IA64:
+			return "IMAGE_REL_BASED_IA64_IMM64";
 		default:
-			RZ_LOG_WARN("Unknown machine type for PE relocation type number: %d\n", reloc_type);
-			return "IMAGE_REL_BASED_UNKNOWN";
+			// Type 9 is machine-specific, return generic name for unsupported machines
+			return "IMAGE_REL_BASED_MACHINE_SPECIFIC_9";
 		}
 	case PE_IMAGE_REL_BASED_DIR64:
 		return "IMAGE_REL_BASED_DIR64";
+	case PE_IMAGE_REL_BASED_RESERVED_15:
+		return "IMAGE_REL_BASED_RESERVED_15";
 	default:
 		RZ_LOG_WARN("Unknown PE relocation type number: %d\n", reloc_type);
 		return "IMAGE_REL_BASED_UNKNOWN";


### PR DESCRIPTION
  - Add ARM and ARMNT machine types to type 7 (THUMB_MOV32) handler
  - Add IA64 support for type 9 and provide generic fallback for unsupported machines
  - Add handler for type 15 (RESERVED_15)

  Fixes warnings when loading PE files with these relocation types.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**


```
rizin pe/relocOSdet.exe
 -- You can debug a program from the graph view ('ag') using standard rizin commands
[0xffff10f0]> 
```

```
rizin pe/badlogger.exe
 -- In visual mode press 'c' to toggle the cursor mode. Use tab to navigate
[0x004017e0]> 

```



**Closing issues**
closes #5683
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
