### PR TITLE
test: add CRLF FLIRT .pat regression test

### DIFF
--- a/test/db/cmd/cmd_signature
+++ b/test/db/cmd/cmd_signature
@@ -394,6 +394,17 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=FLIRT apply pat signature with CRLF line endings
+FILE=bins/flirt/elf-x86/curl-example
+CMDS=<<EOF
+aaa
+Fs bins/flirt/elf-x86/libcurl.a.crlf.pat
+EOF
+EXPECT=<<EOF
+Found 148 FLIRT signatures via bins/flirt/elf-x86/libcurl.a.crlf.pat
+EOF
+RUN
+
 NAME=FLIRT verify correctness of main (PAT)
 FILE=bins/flirt/elf-x86/test.stripped
 CMDS=<<EOF


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

IDA can emit FLIRT `.pat` files using Windows-style CRLF (`\r\n`) line endings.
While the FLIRT parser already handles trimming carriage returns, there was no
command-based regression test ensuring this behavior remains correct.

This pull request extends the existing FLIRT command tests by adding a new case
that loads and applies a CRLF-encoded `.pat` file. The test verifies that FLIRT
signatures are parsed and applied successfully when pattern files use CRLF line
endings, helping prevent future regressions.

**Test plan**

- Located the existing FLIRT command tests in `test/db/cmd/cmd_signature`
- Added a new test case that loads a CRLF-encoded FLIRT `.pat` file
- Verified that the expected number of FLIRT signatures is reported
- Confirmed the change is limited to test coverage only and does not affect
  core parsing logic

**Closing issues**

closes #4443
