### PR TITLE
Motorola SREC IO plugin: fix incorrect error message on write

### DIFF
--- a/librz/io/p/io_srec.c
+++ b/librz/io/p/io_srec.c
@@ -98,7 +98,7 @@ static st32 __write(RzIO *io, RzIODesc *fd, const ut8 *buf, size_t count) {
 	fprintf(out, "S70500000000FA\n");
 	fclose(out);
 	out = NULL;
-	return 0;
+	return count;
 }
 
 static st32 __read(RzIO *io, RzIODesc *fd, ut8 *buf, size_t count) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

The write function of the Motorola SREC plugin returns `0` on success instead of the number of written bytes, which causes this error to appear even if the write was successful
```
ERROR: Could not write 'xxxx' at Y
```
The PR changes the function so it returns number of bytes

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tested it manually, but can add an integration test if needed

Before:
<img width="507" height="223" alt="image" src="https://github.com/user-attachments/assets/b7e187ef-d063-4215-9ca7-e9759313af91" />

After:
<img width="517" height="214" alt="image" src="https://github.com/user-attachments/assets/3ca20c8c-178c-4561-8553-d9c30b9a8aab" />

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
None
