### PR TITLE
Implement backup on overwriting migrated file (#5533)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ peda-session-*
 .cache/
 test/.tmp/*
 test/.sync_disk_db
+test/prj/.*.BAK
 subprojects/.wraplock
 subprojects/capstone-*/
 subprojects/pcre2*/

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -1885,6 +1885,7 @@ RZ_API void rz_core_fini(RzCore *c) {
 	RZ_FREE_CUSTOM(c->warnings_after, rz_list_free);
 	RZ_FREE_CUSTOM(c->sys_path, rz_path_free);
 	RZ_FREE_CUSTOM(c->marks, rz_mark_free);
+	RZ_FREE_CUSTOM(c->backup, sdb_free);
 }
 
 RZ_API void rz_core_free(RzCore *c) {

--- a/librz/core/project.c
+++ b/librz/core/project.c
@@ -40,6 +40,92 @@ RZ_API RzProjectErr rz_project_save(RzCore *core, RzProject *prj, const char *fi
 	return RZ_PROJECT_ERR_SUCCESS;
 }
 
+static unsigned long rz_project_get_version(RzProject *prj) {
+	const char *version_str = sdb_const_get(prj, RZ_PROJECT_KEY_VERSION);
+	if (!version_str) {
+		return ULONG_MAX;
+	}
+	return strtoul(version_str, NULL, 0);
+}
+
+/**
+ * \brief Write the backup-database to a backup file.
+ *
+ * The backup-file will be created with the following name-scheme:
+ * `.${FileBasename}_${OriginalVersion}.BAK`
+ *
+ * \param core[in,out] RzCore instance
+ * \param file[in] A string representing the path to the original file. This is not the backup-file-path!
+ * \param compress[in] Indiates if the database was originally compressed (backup file will also be compressed)
+ * \return An error code, indicating the state of the operation
+ * \retval RZ_PROJECT_ERR_SUCCESS If the backup was written correctly, or no backup was necessary
+ * \retval RZ_PROJECT_ERR_INVALID_VERSION If the backup has a corrupted version number
+ * \retval RZ_PROJECT_ERR_FILE If the backup could not be written, due to file operation errors
+ * \retval RZ_PROJECT_ERR_UNKNOWN If a memory allocation failed
+ * \retval RZ_PROJECT_ERR_COMPRESSION_FAILED If the deflate operation failed
+ */
+RZ_API RzProjectErr rz_project_save_backup_file(RzCore *core, const char *file, bool compress) {
+	char *tmp_file = NULL;
+	if (!core->backup) {
+		/* No backup necessary */
+		return RZ_PROJECT_ERR_SUCCESS;
+	}
+
+	if (compress) {
+		int mkstemp_fd = rz_file_mkstemp("svprjbu", &tmp_file);
+		if (mkstemp_fd == -1 || !tmp_file) {
+			return RZ_PROJECT_ERR_FILE;
+		}
+		close(mkstemp_fd);
+	}
+
+	char *dst_path = NULL;
+	const char *basename = rz_file_basename(file);
+	char *dirname = rz_file_dirname(file);
+	unsigned long version = rz_project_get_version(core->backup);
+	if (!version || version == ULONG_MAX) {
+		free(dirname);
+		return RZ_PROJECT_ERR_INVALID_VERSION;
+	}
+
+	int dst_path_len = snprintf(NULL, 0, "%s/.%s_%ld.BAK", dirname, basename, version);
+	if (dst_path_len < 0) {
+		free(dirname);
+		return RZ_PROJECT_ERR_UNKNOWN;
+	}
+
+	dst_path_len++;
+	dst_path = calloc(dst_path_len, 1);
+	if (dst_path == NULL) {
+		free(dirname);
+		return RZ_PROJECT_ERR_UNKNOWN;
+	}
+
+	if (strlen(dirname) > 0) {
+		snprintf(dst_path, dst_path_len, "%s/.%s_%ld.BAK", dirname, basename, version);
+	} else {
+		snprintf(dst_path, dst_path_len, ".%s_%ld.BAK", basename, version);
+	}
+
+	free(dirname);
+
+	const char *save_file = compress ? tmp_file : dst_path;
+	RzProjectErr err = RZ_PROJECT_ERR_SUCCESS;
+
+	if (!sdb_text_save(core->backup, save_file, true)) {
+		err = RZ_PROJECT_ERR_FILE;
+		goto tmp_file_err;
+	}
+
+	if (compress && !rz_file_deflate(tmp_file, dst_path)) {
+		err = RZ_PROJECT_ERR_COMPRESSION_FAILED;
+	}
+
+tmp_file_err:
+	free(dst_path);
+	return err;
+}
+
 RZ_API RzProjectErr rz_project_save_file(RzCore *core, const char *file, bool compress) {
 	char *tmp_file = NULL;
 
@@ -137,11 +223,7 @@ RZ_API RzProjectErr rz_project_load(RzCore *core, RzProject *prj, bool load_bin_
 	if (!type || strcmp(type, RZ_PROJECT_TYPE) != 0) {
 		return RZ_PROJECT_ERR_INVALID_TYPE;
 	}
-	const char *version_str = sdb_const_get(prj, RZ_PROJECT_KEY_VERSION);
-	if (!version_str) {
-		return RZ_PROJECT_ERR_INVALID_VERSION;
-	}
-	unsigned long version = strtoul(version_str, NULL, 0);
+	unsigned long version = rz_project_get_version(prj);
 	if (!version || version == ULONG_MAX) {
 		return RZ_PROJECT_ERR_INVALID_VERSION;
 	}
@@ -159,6 +241,11 @@ RZ_API RzProjectErr rz_project_load(RzCore *core, RzProject *prj, bool load_bin_
 	}
 	if (!rz_serialize_core_load(core_db, core, load_bin_io, file, res)) {
 		return RZ_PROJECT_ERR_INVALID_CONTENTS;
+	}
+
+	if (prj->backup) {
+		prj->backup->refs++;
+		core->backup = prj->backup;
 	}
 
 	rz_config_set(core->config, "prj.file", file);

--- a/librz/core/project_migrate.c
+++ b/librz/core/project_migrate.c
@@ -757,8 +757,16 @@ static bool (*const migrations[])(RzProject *prj, RzSerializeResultInfo *res) = 
 };
 
 /// Migrate the given project to the current version in-place
+//
+// Also: will set the backup pointer to a copy of prj, before the database was migrated
 RZ_API bool rz_project_migrate(RzProject *prj, unsigned long version, RzSerializeResultInfo *res) {
 	RZ_STATIC_ASSERT(RZ_ARRAY_SIZE(migrations) + 1 == RZ_PROJECT_VERSION);
+
+	if (prj->backup == NULL) {
+		prj->backup = sdb_new0();
+		sdb_copy(prj, prj->backup);
+	}
+
 	while (version < RZ_PROJECT_VERSION) {
 		bool succ = migrations[version - 1](prj, res);
 		if (!succ) {

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -398,6 +398,8 @@ struct rz_core_t {
 	int (*rz_main_rz_gg)(int argc, const char **argv);
 	int (*rz_main_rz_asm)(int argc, const char **argv);
 	int (*rz_main_rz_ax)(int argc, const char **argv);
+
+	Sdb *backup;
 };
 
 // maybe move into RzAnalysis

--- a/librz/include/rz_project.h
+++ b/librz/include/rz_project.h
@@ -30,6 +30,7 @@ typedef enum rz_project_err {
 
 RZ_API RZ_NONNULL const char *rz_project_err_message(RzProjectErr err);
 RZ_API RzProjectErr rz_project_save(RzCore *core, RzProject *prj, const char *file);
+RZ_API RzProjectErr rz_project_save_backup_file(RzCore *core, const char *file, bool compress);
 RZ_API RzProjectErr rz_project_save_file(RzCore *core, const char *file, bool compress);
 RZ_API RzProject *rz_project_load_file_raw(const char *file);
 RZ_API void rz_project_free(RzProject *prj);

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -1444,11 +1444,13 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 			if (no_question_save) {
 				if (prj && *prj && y_save_project) {
 					prj_err = rz_project_save_file(r, prj, compress);
+					rz_project_save_backup_file(r, prj, compress);
 				}
 			} else {
 				question = rz_str_newf("Do you want to save the '%s' project? (Y/n)", prj);
 				if (prj && *prj && rz_cons_yesno('y', "%s", question)) {
 					prj_err = rz_project_save_file(r, prj, compress);
+					rz_project_save_backup_file(r, prj, compress);
 				}
 				free(question);
 			}

--- a/librz/util/sdb/src/sdb.c
+++ b/librz/util/sdb/src/sdb.c
@@ -193,6 +193,9 @@ static void sdb_fini(Sdb *s, int donull) {
 	}
 	free(s->ndump);
 	free(s->dir);
+	if (s->backup) {
+		sdb_free(s->backup);
+	};
 	if (donull) {
 		memset(s, 0, sizeof(Sdb));
 	}

--- a/librz/util/sdb/src/sdb.h
+++ b/librz/util/sdb/src/sdb.h
@@ -81,6 +81,7 @@ typedef struct sdb_t {
 	int ns_lock; // TODO: merge into options?
 	RzList /*<SdbNs *>*/ *ns;
 	ut32 depth;
+	struct sdb_t *backup;
 } Sdb;
 
 typedef struct sdb_ns_t {

--- a/test/integration/meson.build
+++ b/test/integration/meson.build
@@ -25,6 +25,7 @@ if get_option('enable_tests') and cli_enabled
     'dwarf_integration',
     'glibc_version',
     'open_analyse_save_load_project',
+    'open_migrate_backup_compare_project',
     'pdb',
     'project_migrate',
     'rzpipe',

--- a/test/integration/test_open_migrate_backup_compare_project.c
+++ b/test/integration/test_open_migrate_backup_compare_project.c
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 Ami Branch <Amira.Branch@protonmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_core.h>
+#include <rz_project.h>
+
+#include "../unit/minunit.h"
+
+// Returns true if files are identical
+static bool compare_files(const char *a, const char *b) {
+	FILE *fa = fopen(a, "rb");
+	if (!fa)
+		return false;
+
+	FILE *fb = fopen(b, "rb");
+	if (!fb) {
+		fclose(fa);
+		return false;
+	}
+
+	unsigned char buf_a[4096];
+	unsigned char buf_b[4096];
+	bool ret = false;
+
+	for (;;) {
+		size_t na = fread(buf_a, 1, sizeof(buf_a), fa);
+		size_t nb = fread(buf_b, 1, sizeof(buf_b), fb);
+
+		if (na != nb) {
+			goto end;
+		}
+
+		if (na == 0)
+			break;
+
+		if (memcmp(buf_a, buf_b, na) != 0) {
+			goto end;
+		}
+	}
+
+	ret = true;
+
+end:
+	fclose(fa);
+	fclose(fb);
+	return ret;
+}
+
+bool test_open_migrate_backup_compare() {
+	// 1. Cleanup potential backup file from previous run
+	const char *back_path = "prj/.v2-typelink-callables.rzdb_2.BAK";
+	if (rz_file_exists(back_path)) {
+		rz_file_rm(back_path);
+	}
+	mu_assert_eq(rz_file_exists(back_path), false, "backup file exists");
+
+	// 2. Open project and load core (will implicitly migrate sdb inside)
+	RzCore *core = rz_core_new();
+	const char *proj_path = "prj/v2-typelink-callables.rzdb";
+	// const char *proj_path = "prj/v16-flags-base.rzdb";
+	mu_assert_eq(rz_core_project_load_for_cli(core, proj_path, false), true, "load core");
+
+	// 3. Save backup
+	RzProjectErr err = rz_project_save_backup_file(core, proj_path, false);
+	mu_assert_eq(err, RZ_PROJECT_ERR_SUCCESS, "save backup");
+	rz_core_free(core);
+
+	// 4. Compare files
+	mu_assert_eq(rz_file_exists(back_path), true, "backup file created");
+	mu_assert_eq(rz_file_size(back_path), rz_file_size(proj_path), "file size");
+	mu_assert_eq(compare_files(back_path, proj_path), 1, "file compare");
+
+	mu_end;
+}
+
+int all_tests() {
+	mu_run_test(test_open_migrate_backup_compare);
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This PR will add a backup-mechanism. This is done to preserve a project before it is migrated, in case the side-effects of a migration are not intended by a user.

Please NOTE:
* The API-changes were not really intended in the first place - they were just an easy solution. Feel free to reach out to me, how to avoid them or what needs to be considered
* Further discussions should also take place in the linked issue (to avoid spreading the discussions across multiple places).
* The free version of ChatGPT was used to create the `compare_files`-function, used in the integration test.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

To test this:
* Load a project file with a dated version (e.g. from `test/prj/...`) into rizin (e.g. via `./binrz/rizin/rizin  -p ../test/prj/v1-noreturn.rzdb` from build-dir)
* Verify that it is migrated accordingly (`project migrated from version X to Y.`)
* Save the file (e.g. while exiting rizin)
* Now, there should be a backup file next to the original file with the original version (e.g. `.v1-noreturn.rzdb_1.BAK`)
* This backup-file must be identical to the originally loaded project file - reloading it, must again trigger a migration!

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

https://github.com/rizinorg/rizin/issues/5533