### PR TITLE
core: remove legacy output mode for tasks cmds

### DIFF
--- a/librz/core/cmd/cmd_tasks.c
+++ b/librz/core/cmd/cmd_tasks.c
@@ -5,6 +5,8 @@
 #include <rz_core.h>
 #include <cmd_descs.h>
 
+#include "../core_private.h"
+
 static int task_enqueue(RzCore *core, const char *cmd, bool transient) {
 	RzCoreTask *task = rz_core_cmd_task_new(core, cmd, NULL, NULL);
 	if (!task) {
@@ -46,7 +48,7 @@ static int task_break(RzCore *core, int tid) {
 
 RZ_IPI RzCmdStatus rz_tasks_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
 	if (argc == 1) {
-		rz_core_task_list(core, mode == RZ_OUTPUT_MODE_STANDARD ? '\0' : 'j');
+		rz_core_tasks_print(core, mode);
 		return RZ_CMD_STATUS_OK;
 	} else if (argc == 2) {
 		return rz_cmd_int2status(task_enqueue(core, argv[1], false));

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -177,6 +177,10 @@ RZ_IPI int rz_core_seek_opcode_forward(RzCore *core, int n, bool silent);
 RZ_IPI int rz_core_seek_opcode(RzCore *core, int numinstr, bool silent);
 RZ_IPI bool rz_core_seek_bb_instruction(RzCore *core, int index);
 
+/* cmd_task.c */
+RZ_IPI void rz_core_task_print(RzCore *core, RzCoreTask *task, RzOutputMode mode, PJ *j);
+RZ_IPI void rz_core_tasks_print(RzCore *core, RzOutputMode mode);
+
 /* cmd_meta.c */
 RZ_IPI void rz_core_meta_comment_add(RzCore *core, const char *comment, ut64 addr);
 

--- a/librz/core/task.c
+++ b/librz/core/task.c
@@ -759,8 +759,9 @@ RZ_API const char *rz_core_task_status(RzCoreTask *task) {
 	}
 }
 
-RZ_API void rz_core_task_print(RzCore *core, RzCoreTask *task, int mode, PJ *j) {
-	rz_return_if_fail(mode != 'j' || j);
+RZ_IPI void rz_core_task_print(RzCore *core, RzCoreTask *task, RzOutputMode mode, PJ *j) {
+	rz_return_if_fail(task);
+
 	if (task != core->tasks.main_task && task->runner != cmd_task_runner) {
 		// don't print tasks that are custom function-runners, which come from internal code.
 		// only main and command ones, which should be user-visible.
@@ -771,7 +772,7 @@ RZ_API void rz_core_task_print(RzCore *core, RzCoreTask *task, int mode, PJ *j) 
 		cmd = ((CmdTaskCtx *)task->runner_user)->cmd;
 	}
 	switch (mode) {
-	case 'j': {
+	case RZ_OUTPUT_MODE_JSON: {
 		pj_o(j);
 		pj_ki(j, "id", task->id);
 		const char *state;
@@ -812,11 +813,11 @@ RZ_API void rz_core_task_print(RzCore *core, RzCoreTask *task, int mode, PJ *j) 
 	}
 }
 
-RZ_API void rz_core_task_list(RzCore *core, int mode) {
+RZ_IPI void rz_core_tasks_print(RzCore *core, RzOutputMode mode) {
 	RzListIter *iter;
 	RzCoreTask *task;
 	PJ *j = NULL;
-	if (mode == 'j') {
+	if (mode == RZ_OUTPUT_MODE_JSON) {
 		j = pj_new();
 		pj_a(j);
 	}

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -1332,8 +1332,6 @@ typedef void *(*RzCoreTaskFunction)(RzCore *core, void *user);
 RZ_API RzCoreTask *rz_core_function_task_new(RzCore *core, RzCoreTaskFunction fcn, void *fcn_user);
 RZ_API void *rz_core_function_task_get_result(RzCoreTask *task);
 RZ_API const char *rz_core_task_status(RzCoreTask *task);
-RZ_API void rz_core_task_print(RzCore *core, RzCoreTask *task, int mode, PJ *j);
-RZ_API void rz_core_task_list(RzCore *core, int mode);
 RZ_API bool rz_core_task_is_cmd(RzCore *core, int id);
 RZ_API void rz_core_task_del_all_done(RzCore *core);
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Chipping off from https://github.com/rizinorg/rizin/issues/489

**Test plan**

CI is green