### PR TITLE
Fix leaks of RzILMem buffers and clarify ownership of buffer.

### DIFF
--- a/librz/arch/il/analysis_il.c
+++ b/librz/arch/il/analysis_il.c
@@ -226,7 +226,7 @@ static void setup_vm_from_config(RzAnalysis *analysis, RzAnalysisILVM *vm, RzAna
 		vm->vm = NULL;
 		return;
 	}
-	rz_il_vm_add_mem(vm->vm, 0, rz_il_mem_new(vm->io_buf, cfg->mem_key_size));
+	rz_il_vm_add_mem(vm->vm, 0, rz_il_mem_new_borrowed(vm->io_buf, cfg->mem_key_size));
 	void **it;
 	rz_pvector_foreach (&cfg->labels, it) {
 		RzILEffectLabel *lbl = *it;

--- a/librz/arch/isa/sparc/sparc_il.c
+++ b/librz/arch/isa/sparc/sparc_il.c
@@ -82,7 +82,7 @@ static void sparc_il_init(RzAnalysisILVM *vm, RzReg *reg, size_t addr_width) {
 	if (!buf) {
 		return;
 	}
-	RzILMem *mem = rz_il_mem_new(buf, addr_width);
+	RzILMem *mem = rz_il_mem_new_owned(buf, addr_width);
 	if (!mem) {
 		rz_buf_free(buf);
 		return;

--- a/librz/arch/isa/xtensa/xtensa_il.c
+++ b/librz/arch/isa/xtensa/xtensa_il.c
@@ -2127,7 +2127,7 @@ void xtensa_il_init_cb(RzAnalysisILVM *vm, RzReg *reg) {
 	if (!buf) {
 		return;
 	}
-	RzILMem *mem = rz_il_mem_new(buf, 32);
+	RzILMem *mem = rz_il_mem_new_owned(buf, 32);
 	if (!mem) {
 		rz_buf_free(buf);
 		return;

--- a/librz/il/definitions/mem.c
+++ b/librz/il/definitions/mem.c
@@ -7,15 +7,7 @@
 
 #define KEY_LEN_MAX 64 // because RzBuffer uses ut64 addresses
 
-/**
- * Create a memory for accessing the given buffer.
- *
- * \param buf The buffer of the memory.
- * \param key_len The number of bits a memory key requires.
- *
- * \return The new RzILMem object, or NULL in case of failure.
- */
-RZ_API RZ_OWN RzILMem *rz_il_mem_new(RZ_NONNULL RZ_BORROW RzBuffer *buf, ut32 key_len) {
+static RzILMem *mem_new(RZ_NONNULL RzBuffer *buf, ut32 key_len, bool take_buf_ownerhip) {
 	rz_return_val_if_fail(buf && key_len, NULL);
 	if (key_len > KEY_LEN_MAX) {
 		// no assertion because it's not stricly a programming error to call this
@@ -26,12 +18,44 @@ RZ_API RZ_OWN RzILMem *rz_il_mem_new(RZ_NONNULL RZ_BORROW RzBuffer *buf, ut32 ke
 	if (!ret) {
 		return NULL;
 	}
-	// Increment reference count to ensure it is not freed by the owner while
-	// this object still uses it.
-	rz_buf_ref(buf);
+	if (!take_buf_ownerhip) {
+		// Increment reference count to ensure it is not freed by the owner while
+		// this object still uses it.
+		rz_buf_ref(buf);
+	}
 	ret->buf = buf;
 	ret->key_len = key_len;
 	return ret;
+}
+
+/**
+ * Create a memory for accessing the given buffer.
+ * The buffer ownership is transferred to the RzILMem object.
+ *
+ * \param buf The buffer of the memory.
+ * \param key_len The number of bits a memory key requires.
+ * \param take_buf_ownerhip If set, RzILMem takes ownership of the buffer.
+ *
+ * \return The new RzILMem object, or NULL in case of failure.
+ */
+RZ_API RZ_OWN RzILMem *rz_il_mem_new_owned(RZ_NONNULL RZ_OWN RzBuffer *buf, ut32 key_len) {
+	rz_return_val_if_fail(buf && key_len, NULL);
+	return mem_new(buf, key_len, true);
+}
+
+/**
+ * Create a memory for accessing the given buffer.
+ * The buffer is borrowed to the RzILMem object.
+ *
+ * \param buf The buffer of the memory.
+ * \param key_len The number of bits a memory key requires.
+ * \param take_buf_ownerhip If set, RzILMem takes ownership of the buffer.
+ *
+ * \return The new RzILMem object, or NULL in case of failure.
+ */
+RZ_API RZ_OWN RzILMem *rz_il_mem_new_borrowed(RZ_NONNULL RZ_BORROW RzBuffer *buf, ut32 key_len) {
+	rz_return_val_if_fail(buf && key_len, NULL);
+	return mem_new(buf, key_len, false);
 }
 
 /**

--- a/librz/include/rz_il/definitions/mem.h
+++ b/librz/include/rz_il/definitions/mem.h
@@ -28,7 +28,8 @@ typedef struct rz_il_mem_t {
 	ut32 key_len;
 } RzILMem;
 
-RZ_API RZ_OWN RzILMem *rz_il_mem_new(RZ_NONNULL RZ_BORROW RzBuffer *buf, ut32 key_len);
+RZ_API RZ_OWN RzILMem *rz_il_mem_new_owned(RZ_NONNULL RZ_OWN RzBuffer *buf, ut32 key_len);
+RZ_API RZ_OWN RzILMem *rz_il_mem_new_borrowed(RZ_NONNULL RZ_BORROW RzBuffer *buf, ut32 key_len);
 RZ_API void rz_il_mem_free(RzILMem *mem);
 RZ_API ut32 rz_il_mem_key_len(RzILMem *mem);
 RZ_API ut32 rz_il_mem_value_len(RzILMem *mem);

--- a/test/unit/test_il_definitions.c
+++ b/test/unit/test_il_definitions.c
@@ -90,8 +90,7 @@ static bool test_il_mem_load() {
 	ut8 data[] = { 0x0, 0x0, 0x0, 0x0, 0x0, 0x42, 0x0, 0x0 };
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
 	rz_buf_set_overflow_byte(buf, 0xaa);
-	RzILMem *mem = rz_il_mem_new(buf, 16);
-	rz_buf_free(buf); // buf is refcounted
+	RzILMem *mem = rz_il_mem_new_owned(buf, 16);
 	mu_assert_notnull(mem, "Create mem");
 
 	// valid read
@@ -125,8 +124,7 @@ static bool test_il_mem_load() {
 static bool test_il_mem_store() {
 	ut8 data[] = { 0x0, 0x0, 0x0, 0x0, 0x0, 0x42, 0x0, 0x0 };
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
-	RzILMem *mem = rz_il_mem_new(buf, 16);
-	rz_buf_free(buf); // buf is refcounted
+	RzILMem *mem = rz_il_mem_new_owned(buf, 16);
 	mu_assert_notnull(mem, "Create mem");
 
 	RzBitVector *addr = rz_bv_new_from_ut64(16, 1);
@@ -164,8 +162,7 @@ static bool test_il_mem_loadw() {
 	ut8 data[] = { 0x0, 0x0, 0x0, 0x0, 0x13, 0x37, 0x0, 0x0 };
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
 	rz_buf_set_overflow_byte(buf, 0xaa);
-	RzILMem *mem = rz_il_mem_new(buf, 16);
-	rz_buf_free(buf); // buf is refcounted
+	RzILMem *mem = rz_il_mem_new_owned(buf, 16);
 	mu_assert_notnull(mem, "Create mem");
 
 	// valid read (le)
@@ -207,8 +204,7 @@ static bool test_il_mem_loadw() {
 static bool test_il_mem_storew() {
 	ut8 data[] = { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
-	RzILMem *mem = rz_il_mem_new(buf, 32);
-	rz_buf_free(buf); // buf is refcounted
+	RzILMem *mem = rz_il_mem_new_owned(buf, 32);
 	mu_assert_notnull(mem, "Create mem");
 
 	// valid write (le)

--- a/test/unit/test_il_vm.c
+++ b/test/unit/test_il_vm.c
@@ -595,8 +595,7 @@ static bool test_rzil_vm_op_load() {
 	RzILVM *vm = rz_il_vm_new(0, 12, false, RZ_IL_EVENT_EXC_NONE);
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
 	rz_buf_set_overflow_byte(buf, 0xaa);
-	rz_il_vm_add_mem(vm, 0, rz_il_mem_new(buf, 16));
-	rz_buf_free(buf);
+	rz_il_vm_add_mem(vm, 0, rz_il_mem_new_owned(buf, 16));
 
 	RzILOpPure *op = rz_il_op_new_load(0, rz_il_op_new_bitv_from_ut64(16, 3));
 	RzBitVector *res = rz_il_evaluate_bitv(vm, op);
@@ -644,8 +643,7 @@ static bool test_rzil_vm_op_store() {
 	ut8 data[] = { 0x10, 0x11, 0x12, 0x42, 0x14, 0x15 };
 	RzILVM *vm = rz_il_vm_new(0, 12, false, RZ_IL_EVENT_EXC_NONE);
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
-	rz_il_vm_add_mem(vm, 0, rz_il_mem_new(buf, 16));
-	rz_buf_free(buf);
+	rz_il_vm_add_mem(vm, 0, rz_il_mem_new_owned(buf, 16));
 
 	RzILOpEffect *op = rz_il_op_new_store(0, rz_il_op_new_bitv_from_ut64(16, 2), rz_il_op_new_bitv_from_ut64(8, 0xab));
 	bool succ = rz_il_evaluate_effect(vm, op);
@@ -676,8 +674,7 @@ static bool test_rzil_vm_op_loadw_le() {
 	RzILVM *vm = rz_il_vm_new(0, 12, false, RZ_IL_EVENT_EXC_NONE);
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
 	rz_buf_set_overflow_byte(buf, 0xaa);
-	rz_il_vm_add_mem(vm, 0, rz_il_mem_new(buf, 16));
-	rz_buf_free(buf);
+	rz_il_vm_add_mem(vm, 0, rz_il_mem_new_owned(buf, 16));
 
 	RzILOpPure *op = rz_il_op_new_loadw(0, rz_il_op_new_bitv_from_ut64(16, 3), 16);
 	RzBitVector *res = rz_il_evaluate_bitv(vm, op);
@@ -706,8 +703,7 @@ static bool test_rzil_vm_op_storew_le() {
 	ut8 data[] = { 0x0, 0x1, 0x2, 0x42, 0x4, 0x5 };
 	RzILVM *vm = rz_il_vm_new(0, 12, false, RZ_IL_EVENT_EXC_NONE);
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
-	rz_il_vm_add_mem(vm, 0, rz_il_mem_new(buf, 16));
-	rz_buf_free(buf);
+	rz_il_vm_add_mem(vm, 0, rz_il_mem_new_owned(buf, 16));
 
 	RzILOpEffect *op = rz_il_op_new_storew(0, rz_il_op_new_bitv_from_ut64(16, 2), rz_il_op_new_bitv_from_ut64(16, 0xabcd));
 	bool succ = rz_il_evaluate_effect(vm, op);
@@ -738,8 +734,7 @@ static bool test_rzil_vm_op_loadw_be() {
 	RzILVM *vm = rz_il_vm_new(0, 12, true, RZ_IL_EVENT_EXC_NONE);
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
 	rz_buf_set_overflow_byte(buf, 0xaa);
-	rz_il_vm_add_mem(vm, 0, rz_il_mem_new(buf, 16));
-	rz_buf_free(buf);
+	rz_il_vm_add_mem(vm, 0, rz_il_mem_new_owned(buf, 16));
 
 	RzILOpPure *op = rz_il_op_new_loadw(0, rz_il_op_new_bitv_from_ut64(16, 3), 16);
 	RzBitVector *res = rz_il_evaluate_bitv(vm, op);
@@ -768,8 +763,7 @@ static bool test_rzil_vm_op_storew_be() {
 	ut8 data[] = { 0x0, 0x1, 0x2, 0x42, 0x4, 0x5 };
 	RzILVM *vm = rz_il_vm_new(0, 8, true, RZ_IL_EVENT_EXC_NONE);
 	RzBuffer *buf = rz_buf_new_with_pointers(data, sizeof(data), false);
-	rz_il_vm_add_mem(vm, 0, rz_il_mem_new(buf, 16));
-	rz_buf_free(buf);
+	rz_il_vm_add_mem(vm, 0, rz_il_mem_new_owned(buf, 16));
 
 	RzILOpEffect *op = rz_il_op_new_storew(0, rz_il_op_new_bitv_from_ut64(16, 2), rz_il_op_new_bitv_from_ut64(16, 0xabcd));
 	bool succ = rz_il_evaluate_effect(vm, op);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

The previous assumption of `RzILMem` was that the buffer is not owned by it. This made sense, because in the beginning it only held an `RzIO` buffer.

But the Xtensa and Sparc `RzAnalysisILInitCallback` definition initializes an additional `RzILMem` object. This additional `RzILMem` has a sparse buffer in both cases. The Xtensa and Sparc plugin pass the sparse buffer to `RzILMem` with the assumption that it is owned. They have to, because there is no `fini()` version of `RzAnalysisILInitCallback` in which they could free the buffer. There are also no API functions to free the buffer in `RzILMem`. So the plugins don't have a nice way to clean it up in a theoretical `fini()` callback.

This commit fixes the leak by adding a flag to `rz_il_mem_new()` to mark the ownership of the given buffer.
This seems the most natural solution, because buffers can abstract from all kind of backends (`RzIO`, a file, some memory etc.). Each time the ownership of the buffer is different. So the creator of `rz_il_mem_new()` can decide what buffer with what ownership they pass.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All green no crashes.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
