### PR TITLE
Return successfully for bit vector shift of 0.

### DIFF
--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -701,7 +701,7 @@ RZ_API bool rz_bv_lshift_fill(RZ_NONNULL RzBitVector *bv, ut32 size, bool fill_b
 
 	// left shift
 	if (size == 0) {
-		return false;
+		return true;
 	}
 
 	if (size >= bv->len) {
@@ -740,7 +740,7 @@ RZ_API bool rz_bv_rshift_fill(RZ_NONNULL RzBitVector *bv, ut32 size, bool fill_b
 
 	// left shift
 	if (size == 0) {
-		return false;
+		return true;
 	}
 
 	if (size >= bv->len) {

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -327,26 +327,34 @@ bool test_rz_bv_logic(void) {
 	rz_bv_free(neg);
 
 	result = rz_bv_dup(y);
-	rz_bv_lshift(result, 3);
+	mu_assert_true(rz_bv_lshift(result, 3), "Shift failed");
 	mu_assert("left shift y", is_equal_bv(result, ls));
 	rz_bv_free(result);
 	rz_bv_free(ls);
 
 	result = rz_bv_dup(y);
-	rz_bv_lshift_fill(result, 3, true);
+	mu_assert_true(rz_bv_lshift_fill(result, 3, true), "Shift failed");
 	mu_assert("left shift y filling 1", is_equal_bv(result, ls_fill));
 	rz_bv_free(result);
 	rz_bv_free(ls_fill);
 
 	result = rz_bv_dup(y);
-	rz_bv_rshift(result, 3);
+	mu_assert_true(rz_bv_rshift(result, 3), "Shift failed");
 	mu_assert("right shift y", is_equal_bv(result, rs));
 	rz_bv_free(result);
 	rz_bv_free(rs);
 
 	result = rz_bv_dup(y);
-	rz_bv_rshift_fill(result, 3, true);
+	mu_assert_true(rz_bv_rshift_fill(result, 3, true), "Shift failed");
 	mu_assert("right shift y", is_equal_bv(result, rs_fill));
+
+	ut64 before = rz_bv_to_ut64(result);
+	mu_assert_true(rz_bv_rshift_fill(result, 0, true), "Shift failed");
+	mu_assert_eq(rz_bv_to_ut64(result), before, "right shift 0 failed");
+
+	mu_assert_true(rz_bv_lshift_fill(result, 0, true), "Shift failed");
+	mu_assert_eq(rz_bv_to_ut64(result), before, "left shift 0 failed");
+
 	rz_bv_free(result);
 	rz_bv_free(rs_fill);
 
@@ -994,7 +1002,7 @@ bool test_rz_bv_div(void) {
 	TEST_DIV(rz_bv_new_from_ut64(70, 0xffffffd6), rz_bv_new_from_ut64(70, 42), "0x6186185");
 	TEST_DIV(rz_bv_new_from_ut64(70, 42), rz_bv_new_from_ut64(70, 42), "0x1");
 	RzBitVector *superbig = rz_bv_new_from_ut64(80, 42);
-	rz_bv_lshift(superbig, 70);
+	mu_assert_true(rz_bv_lshift(superbig, 70), "Shift failed");
 	TEST_DIV(superbig, rz_bv_new_from_ut64(80, 2), "0x5400000000000000000");
 
 #undef TEST_DIV
@@ -1029,7 +1037,7 @@ bool test_rz_bv_mod(void) {
 	TEST_MOD(rz_bv_new_from_ut64(70, 0xffffffd6), rz_bv_new_from_ut64(70, 42), "0x4");
 	TEST_MOD(rz_bv_new_from_ut64(70, 42), rz_bv_new_from_ut64(70, 42), "0x0");
 	RzBitVector *superbig = rz_bv_new_from_ut64(80, 42);
-	rz_bv_lshift(superbig, 70);
+	mu_assert_true(rz_bv_lshift(superbig, 70), "Shift failed");
 	TEST_MOD(rz_bv_dup(superbig), rz_bv_new_from_ut64(80, 2), "0x0");
 	rz_bv_set(superbig, 0, true);
 	rz_bv_set(superbig, 1, true);
@@ -1187,7 +1195,7 @@ static bool test_rz_bv_set_to_bytes_le(void) {
 	{
 		ut8 buf9[9] = { 0 };
 		RzBitVector *bv = rz_bv_new_from_ut64(64 + 8, 0xc0ffee4200000000);
-		rz_bv_lshift_fill(bv, 8, true);
+		mu_assert_true(rz_bv_lshift_fill(bv, 8, true), "Shift failed");
 		rz_bv_set_to_bytes_le(bv, buf9);
 		const ut8 expect9[9] = { 0xff, 0x00, 0x00, 0x00, 0x00, 0x42, 0xee, 0xff, 0xc0 };
 		mu_assert_memeq(buf9, expect9, sizeof(expect9), "set to bytes le");
@@ -1197,7 +1205,7 @@ static bool test_rz_bv_set_to_bytes_le(void) {
 		ut8 buf9[9] = { 0 };
 		buf9[8] = 0xff; // make sure these trailing bits are not overwritten
 		RzBitVector *bv = rz_bv_new_from_ut64(64 + 6, 0xffffee00000000);
-		rz_bv_lshift_fill(bv, 8, true);
+		mu_assert_true(rz_bv_lshift_fill(bv, 8, true), "Shift failed");
 		rz_bv_set_to_bytes_le(bv, buf9);
 		const ut8 expect9[9] = { 0xff, 0x00, 0x00, 0x00, 0x00, 0xee, 0xff, 0xff, 0xc0 };
 		mu_assert_memeq(buf9, expect9, sizeof(expect9), "set to bytes le");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

I'd argue that `x << 0` or `x >> 0` is a well defined value of `x`.
Hence, the shift operation should return true (success) and not false.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Added

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
