### PR TITLE
Use memcpy in endian read/write function for native endianness

### DIFF
--- a/librz/include/rz_endian.h
+++ b/librz/include/rz_endian.h
@@ -215,9 +215,15 @@ static inline ut32 rz_read_be32(const void *src) {
 	if (!src) {
 		return UT32_MAX;
 	}
+#if RZ_HOST_IS_BIG_ENDIAN
+	ut32 val = 0;
+	memcpy(&val, src, sizeof(val));
+	return val;
+#else
 	const ut8 *s = (const ut8 *)src;
 	return (((ut32)s[0]) << 24) | (((ut32)s[1]) << 16) |
 		(((ut32)s[2]) << 8) | (((ut32)s[3]) << 0);
+#endif
 }
 
 /**
@@ -241,8 +247,12 @@ static inline ut32 rz_read_at_be32(const void *src, size_t offset) {
  * \param val The written 32-bit value.
  */
 static inline void rz_write_be32(void *dest, ut32 val) {
+#if RZ_HOST_IS_BIG_ENDIAN
+	memcpy(dest, &val, sizeof(val));
+#else
 	rz_write_be16(dest, val >> 16);
 	rz_write_at_be16(dest, val, sizeof(ut16));
+#endif
 }
 
 /**
@@ -266,9 +276,15 @@ static inline ut64 rz_read_be64(const void *src) {
 	if (!src) {
 		return UT64_MAX;
 	}
+#if RZ_HOST_IS_BIG_ENDIAN
+	ut64 val = 0;
+	memcpy(&val, src, sizeof(val));
+	return val;
+#else
 	ut64 val = ((ut64)(rz_read_be32(src))) << 32;
 	val |= rz_read_at_be32(src, sizeof(ut32));
 	return val;
+#endif
 }
 
 /**
@@ -292,8 +308,12 @@ static inline ut64 rz_read_at_be64(const void *src, size_t offset) {
  * \param val The written 64-bit value.
  */
 static inline void rz_write_be64(void *dest, ut64 val) {
+#if RZ_HOST_IS_BIG_ENDIAN
+	memcpy(dest, &val, sizeof(val));
+#else
 	rz_write_be32(dest, val >> 32);
 	rz_write_at_be32(dest, (ut32)val, sizeof(ut32));
+#endif
 }
 
 /**
@@ -321,9 +341,14 @@ static inline ut128 rz_read_be128(const void *src) {
 		val.Low = UT64_MAX;
 		return val;
 	}
+#if RZ_HOST_IS_BIG_ENDIAN
+	memcpy(&val, src, sizeof(val));
+	return val;
+#else
 	val.High = rz_read_be64(src);
 	val.Low = rz_read_at_be64(src, sizeof(ut64));
 	return val;
+#endif
 }
 
 /**
@@ -351,8 +376,12 @@ static inline ut128 rz_read_at_be128(const void *src, size_t offset) {
  * \param val The written 128-bit value.
  */
 static inline void rz_write_be128(void *dest, ut128 val) {
+#if RZ_HOST_IS_BIG_ENDIAN
+	memcpy(dest, &val, sizeof(val));
+#else
 	rz_write_be64(dest, val.High);
 	rz_write_at_be64(dest, val.Low, sizeof(ut64));
+#endif
 }
 
 /**
@@ -638,9 +667,15 @@ static inline ut32 rz_read_le32(const void *src) {
 	if (!src) {
 		return UT32_MAX;
 	}
+#if RZ_HOST_IS_LITTLE_ENDIAN
+	ut32 val = 0;
+	memcpy(&val, src, sizeof(val));
+	return val;
+#else
 	const ut8 *s = (const ut8 *)src;
 	return (((ut32)s[3]) << 24) | (((ut32)s[2]) << 16) |
 		(((ut32)s[1]) << 8) | (((ut32)s[0]) << 0);
+#endif
 }
 
 /**
@@ -664,8 +699,12 @@ static inline ut32 rz_read_at_le32(const void *src, size_t offset) {
  * \param val The written 32-bit value.
  */
 static inline void rz_write_le32(void *dest, ut32 val) {
+#if RZ_HOST_IS_LITTLE_ENDIAN
+	memcpy(dest, &val, sizeof(val));
+#else
 	rz_write_le16(dest, val);
 	rz_write_at_le16(dest, val >> 16, sizeof(ut16));
+#endif
 }
 
 /**
@@ -689,9 +728,15 @@ static inline ut64 rz_read_le64(const void *src) {
 	if (!src) {
 		return UT64_MAX;
 	}
+#if RZ_HOST_IS_LITTLE_ENDIAN
+	ut64 val = 0;
+	memcpy(&val, src, sizeof(val));
+	return val;
+#else
 	ut64 val = ((ut64)(rz_read_at_le32(src, sizeof(ut32)))) << 32;
 	val |= rz_read_le32(src);
 	return val;
+#endif
 }
 
 /**
@@ -715,8 +760,12 @@ static inline ut64 rz_read_at_le64(const void *src, size_t offset) {
  * \param val The written 64-bit value.
  */
 static inline void rz_write_le64(void *dest, ut64 val) {
+#if RZ_HOST_IS_LITTLE_ENDIAN
+	memcpy(dest, &val, sizeof(val));
+#else
 	rz_write_le32(dest, (ut32)val);
 	rz_write_at_le32(dest, val >> 32, sizeof(ut32));
+#endif
 }
 
 /**
@@ -744,9 +793,14 @@ static inline ut128 rz_read_le128(const void *src) {
 		val.Low = UT64_MAX;
 		return val;
 	}
+#if RZ_HOST_IS_LITTLE_ENDIAN
+	memcpy(&val, src, sizeof(val));
+	return val;
+#else
 	val.High = rz_read_at_le64(src, sizeof(ut64));
 	val.Low = rz_read_le64(src);
 	return val;
+#endif
 }
 
 /**
@@ -774,8 +828,12 @@ static inline ut128 rz_read_at_le128(const void *src, size_t offset) {
  * \param val The written 128-bit value.
  */
 static inline void rz_write_le128(void *dest, ut128 val) {
+#if RZ_HOST_IS_LITTLE_ENDIAN
+	memcpy(dest, &val, sizeof(val));
+#else
 	rz_write_le64(dest, val.Low);
 	rz_write_at_le64(dest, val.High, sizeof(ut64));
+#endif
 }
 
 /**

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -183,6 +183,151 @@ extern "C" {
 #undef _GNU_SOURCE
 #define _GNU_SOURCE
 
+// clang-format off
+#if __APPLE__
+	#if __i386__
+		#define RZ_SYS_BASE ((ut64)0x1000)
+	#elif __x86_64__
+		#define RZ_SYS_BASE ((ut64)0x100000000)
+	#else
+		#define RZ_SYS_BASE ((ut64)0x1000)
+	#endif
+#elif __WINDOWS__
+	#define RZ_SYS_BASE ((ut64)0x01001000)
+#else // linux, bsd, ...
+	#if __arm__ || __arm64__
+		#define RZ_SYS_BASE ((ut64)0x4000)
+	#else
+		#define RZ_SYS_BASE ((ut64)0x8048000)
+	#endif
+#endif
+
+static const ut32 rz_endianness_one = 1;
+
+#define RZ_SYS_ENDIAN_NONE   0
+#define RZ_SYS_ENDIAN_LITTLE 1
+#define RZ_SYS_ENDIAN_BIG    2
+#define RZ_SYS_ENDIAN_BI     3
+
+/* arch */
+#if __i386__
+	#define RZ_SYS_ARCH   "x86"
+	#define RZ_SYS_BITS   RZ_SYS_BITS_32
+	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
+#elif __EMSCRIPTEN__
+	#define RZ_SYS_ARCH   "wasm"
+	#define RZ_SYS_BITS   (RZ_SYS_BITS_32 | RZ_SYS_BITS_64)
+	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
+#elif __x86_64__
+	#define RZ_SYS_ARCH   "x86"
+	#define RZ_SYS_BITS   (RZ_SYS_BITS_32 | RZ_SYS_BITS_64)
+	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
+#elif __POWERPC__
+	#define RZ_SYS_ARCH "ppc"
+	#ifdef __powerpc64__
+		#define RZ_SYS_BITS (RZ_SYS_BITS_32 | RZ_SYS_BITS_64)
+	#else
+		#define RZ_SYS_BITS RZ_SYS_BITS_32
+	#endif
+
+	#if defined(__BYTE_ORDER__)
+		#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
+		#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_BIG
+		#else
+			#error "Unsupported endianness"
+		#endif
+	#else
+		#define RZ_SYS_ENDIAN ((*((char *)&(rz_endianness_one)) == 1) ? RZ_SYS_ENDIAN_LITTLE : RZ_SYS_ENDIAN_BIG)
+	#endif
+#elif __arm__
+	#define RZ_SYS_ARCH   "arm"
+	#define RZ_SYS_BITS   RZ_SYS_BITS_32
+	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
+#elif __arm64__ || __aarch64__
+	#define RZ_SYS_ARCH   "arm"
+	#define RZ_SYS_BITS   (RZ_SYS_BITS_32 | RZ_SYS_BITS_64)
+	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
+#elif __arc__
+	#define RZ_SYS_ARCH   "arc"
+	#define RZ_SYS_BITS   RZ_SYS_BITS_32
+	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
+#elif __s390x__
+	#define RZ_SYS_ARCH   "sysz"
+	#define RZ_SYS_BITS   RZ_SYS_BITS_64
+	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_BIG
+#elif __sparc__
+	#define RZ_SYS_ARCH   "sparc"
+	#define RZ_SYS_BITS   RZ_SYS_BITS_32
+	#if defined(__BYTE_ORDER__)
+		#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
+		#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_BIG
+		#else
+			#error "Unsupported endianness"
+		#endif
+	#else
+		#define RZ_SYS_ENDIAN ((*((char *)&(rz_endianness_one)) == 1) ? RZ_SYS_ENDIAN_LITTLE : RZ_SYS_ENDIAN_BIG)
+	#endif
+#elif __mips__
+	#define RZ_SYS_ARCH   "mips"
+	#define RZ_SYS_BITS   RZ_SYS_BITS_32
+	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_BIG
+#elif __EMSCRIPTEN__
+	/* we should default to wasm when ready */
+	#define RZ_SYS_ARCH "x86"
+	#define RZ_SYS_BITS RZ_SYS_BITS_32
+#elif __riscv__ || __riscv
+	#define RZ_SYS_ARCH   "riscv"
+	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
+	#if __riscv_xlen == 32
+		#define RZ_SYS_BITS RZ_SYS_BITS_32
+	#else
+		#define RZ_SYS_BITS (RZ_SYS_BITS_32 | RZ_SYS_BITS_64)
+	#endif
+#else
+	#ifdef _MSC_VER
+		#if defined(_M_X64) || defined(_M_AMD64)
+			#define RZ_SYS_ARCH   "x86"
+			#define RZ_SYS_BITS   (RZ_SYS_BITS_32 | RZ_SYS_BITS_64)
+			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
+			#define __x86_64__    1
+		#elif defined(_M_IX86)
+			#define RZ_SYS_ARCH   "x86"
+			#define RZ_SYS_BITS   (RZ_SYS_BITS_32)
+			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
+			#define __i386__      1
+		#elif defined(_M_ARM64)
+			#define RZ_SYS_ARCH   "arm"
+			#define RZ_SYS_BITS   (RZ_SYS_BITS_32 | RZ_SYS_BITS_64)
+			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
+			#define __arm64__     1
+		#elif defined(_M_ARM)
+			#define RZ_SYS_ARCH   "arm"
+			#define RZ_SYS_BITS   RZ_SYS_BITS_32
+			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
+			#define __arm__       1
+		#else
+			#error "Unhandled Windows architecture."
+		#endif
+	#else
+		#error "Unhandled bits and edianness definitions for this architecture."
+	#endif
+#endif
+
+#ifndef RZ_SYS_ENDIAN
+	#error "Endianness for this architecture is not defined. This is no longer valid."
+#elif (RZ_SYS_ENDIAN == RZ_SYS_ENDIAN_BI || RZ_SYS_ENDIAN == RZ_SYS_ENDIAN_NONE)
+	#error "RZ_SYS_ENDIAN_BI or RZ_SYS_ENDIAN_NONE are invalid values for the architecture endianness."
+#endif
+
+// clang-format on
+
+#define RZ_HOST_IS_LITTLE_ENDIAN (RZ_SYS_ENDIAN == RZ_SYS_ENDIAN_LITTLE)
+#define RZ_HOST_IS_BIG_ENDIAN    (RZ_SYS_ENDIAN == RZ_SYS_ENDIAN_BIG)
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -398,151 +543,6 @@ static inline void *rz_new_copy(int size, const void *data) {
 #ifndef O_BINARY
 #define O_BINARY 0
 #endif
-
-// clang-format off
-#if __APPLE__
-	#if __i386__
-		#define RZ_SYS_BASE ((ut64)0x1000)
-	#elif __x86_64__
-		#define RZ_SYS_BASE ((ut64)0x100000000)
-	#else
-		#define RZ_SYS_BASE ((ut64)0x1000)
-	#endif
-#elif __WINDOWS__
-	#define RZ_SYS_BASE ((ut64)0x01001000)
-#else // linux, bsd, ...
-	#if __arm__ || __arm64__
-		#define RZ_SYS_BASE ((ut64)0x4000)
-	#else
-		#define RZ_SYS_BASE ((ut64)0x8048000)
-	#endif
-#endif
-
-static const ut32 rz_endianness_one = 1;
-
-#define RZ_SYS_ENDIAN_NONE   0
-#define RZ_SYS_ENDIAN_LITTLE 1
-#define RZ_SYS_ENDIAN_BIG    2
-#define RZ_SYS_ENDIAN_BI     3
-
-/* arch */
-#if __i386__
-	#define RZ_SYS_ARCH   "x86"
-	#define RZ_SYS_BITS   RZ_SYS_BITS_32
-	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
-#elif __EMSCRIPTEN__
-	#define RZ_SYS_ARCH   "wasm"
-	#define RZ_SYS_BITS   (RZ_SYS_BITS_32 | RZ_SYS_BITS_64)
-	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
-#elif __x86_64__
-	#define RZ_SYS_ARCH   "x86"
-	#define RZ_SYS_BITS   (RZ_SYS_BITS_32 | RZ_SYS_BITS_64)
-	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
-#elif __POWERPC__
-	#define RZ_SYS_ARCH "ppc"
-	#ifdef __powerpc64__
-		#define RZ_SYS_BITS (RZ_SYS_BITS_32 | RZ_SYS_BITS_64)
-	#else
-		#define RZ_SYS_BITS RZ_SYS_BITS_32
-	#endif
-
-	#if defined(__BYTE_ORDER__)
-		#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
-		#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_BIG
-		#else
-			#error "Unsupported endianness"
-		#endif
-	#else
-		#define RZ_SYS_ENDIAN ((*((char *)&(rz_endianness_one)) == 1) ? RZ_SYS_ENDIAN_LITTLE : RZ_SYS_ENDIAN_BIG)
-	#endif
-#elif __arm__
-	#define RZ_SYS_ARCH   "arm"
-	#define RZ_SYS_BITS   RZ_SYS_BITS_32
-	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
-#elif __arm64__ || __aarch64__
-	#define RZ_SYS_ARCH   "arm"
-	#define RZ_SYS_BITS   (RZ_SYS_BITS_32 | RZ_SYS_BITS_64)
-	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
-#elif __arc__
-	#define RZ_SYS_ARCH   "arc"
-	#define RZ_SYS_BITS   RZ_SYS_BITS_32
-	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
-#elif __s390x__
-	#define RZ_SYS_ARCH   "sysz"
-	#define RZ_SYS_BITS   RZ_SYS_BITS_64
-	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_BIG
-#elif __sparc__
-	#define RZ_SYS_ARCH   "sparc"
-	#define RZ_SYS_BITS   RZ_SYS_BITS_32
-	#if defined(__BYTE_ORDER__)
-		#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
-		#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_BIG
-		#else
-			#error "Unsupported endianness"
-		#endif
-	#else
-		#define RZ_SYS_ENDIAN ((*((char *)&(rz_endianness_one)) == 1) ? RZ_SYS_ENDIAN_LITTLE : RZ_SYS_ENDIAN_BIG)
-	#endif
-#elif __mips__
-	#define RZ_SYS_ARCH   "mips"
-	#define RZ_SYS_BITS   RZ_SYS_BITS_32
-	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_BIG
-#elif __EMSCRIPTEN__
-	/* we should default to wasm when ready */
-	#define RZ_SYS_ARCH "x86"
-	#define RZ_SYS_BITS RZ_SYS_BITS_32
-#elif __riscv__ || __riscv
-	#define RZ_SYS_ARCH   "riscv"
-	#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
-	#if __riscv_xlen == 32
-		#define RZ_SYS_BITS RZ_SYS_BITS_32
-	#else
-		#define RZ_SYS_BITS (RZ_SYS_BITS_32 | RZ_SYS_BITS_64)
-	#endif
-#else
-	#ifdef _MSC_VER
-		#if defined(_M_X64) || defined(_M_AMD64)
-			#define RZ_SYS_ARCH   "x86"
-			#define RZ_SYS_BITS   (RZ_SYS_BITS_32 | RZ_SYS_BITS_64)
-			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
-			#define __x86_64__    1
-		#elif defined(_M_IX86)
-			#define RZ_SYS_ARCH   "x86"
-			#define RZ_SYS_BITS   (RZ_SYS_BITS_32)
-			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
-			#define __i386__      1
-		#elif defined(_M_ARM64)
-			#define RZ_SYS_ARCH   "arm"
-			#define RZ_SYS_BITS   (RZ_SYS_BITS_32 | RZ_SYS_BITS_64)
-			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
-			#define __arm64__     1
-		#elif defined(_M_ARM)
-			#define RZ_SYS_ARCH   "arm"
-			#define RZ_SYS_BITS   RZ_SYS_BITS_32
-			#define RZ_SYS_ENDIAN RZ_SYS_ENDIAN_LITTLE
-			#define __arm__       1
-		#else
-			#error "Unhandled Windows architecture."
-		#endif
-	#else
-		#error "Unhandled bits and edianness definitions for this architecture."
-	#endif
-#endif
-
-#ifndef RZ_SYS_ENDIAN
-	#error "Endianness for this architecture is not defined. This is no longer valid."
-#elif (RZ_SYS_ENDIAN == RZ_SYS_ENDIAN_BI || RZ_SYS_ENDIAN == RZ_SYS_ENDIAN_NONE)
-	#error "RZ_SYS_ENDIAN_BI or RZ_SYS_ENDIAN_NONE are invalid values for the architecture endianness."
-#endif
-
-// clang-format on
-
-#define RZ_HOST_IS_LITTLE_ENDIAN (RZ_SYS_ENDIAN == RZ_SYS_ENDIAN_LITTLE)
-#define RZ_HOST_IS_BIG_ENDIAN    (RZ_SYS_ENDIAN == RZ_SYS_ENDIAN_BIG)
 
 typedef enum {
 	RZ_SYS_ARCH_NONE = 0,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

The PR modifies some endian read/write function to use `memcpy()` when the requested endianness matches the host endianness.

The following functions are modified:
- `rz_read_le32`
- `rz_write_le32`
- `rz_read_le64`
- `rz_write_le64`
- `rz_read_le128`
- `rz_write_le128`
- `rz_read_be32`
- `rz_write_be32`
- `rz_read_be64`
- `rz_write_be64`
- `rz_read_be128`
- `rz_write_be128`

Part of `rz_types.h` code is reordered so the necessary preprocessor defines are visible to `rz_endian.h`

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Assuming existing tests already cover the changes

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None
