### PR TITLE
rz_assert: Add rz_break_if_reached/fail()

### DIFF
--- a/librz/bin/format/pe/pe_clr.c
+++ b/librz/bin/format/pe/pe_clr.c
@@ -51,7 +51,7 @@ RZ_OWN RzList /*<RzBinSymbol *>*/ *PE_(rz_bin_pe_get_clr_symbols)(RzBinPEObj *bi
 		Pe_image_metadata_methoddef *methoddef = *it;
 
 		if ((type_name || type_namespace) && i >= type_methods_start && i >= type_methods_end) {
-			rz_goto_if_fail(type_it, loop_end);
+			rz_break_if_fail(type_it);
 
 			// Update class and namespace
 			free(type_name);
@@ -97,7 +97,6 @@ RZ_OWN RzList /*<RzBinSymbol *>*/ *PE_(rz_bin_pe_get_clr_symbols)(RzBinPEObj *bi
 		rz_list_append(methods, sym);
 		i++;
 	}
-loop_end:
 
 	// Cleanup class / namespace strings
 	free(type_name);

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -1769,7 +1769,7 @@ static ut32 fold_variables(RzCore *core, RzDisasmState *ds, RzListIter /*<RzAnal
 	// fold_var = hide -> group the first two var with ellipsis in tail
 	ut32 group_num = strcmp(ds->fold_var, "group") ? 2 : 3;
 	while (iter_mov < group_num) {
-		rz_goto_if_fail(iter, loop_end);
+		rz_break_if_fail(iter);
 		RzAnalysisVar *temp_var = rz_list_iter_get_data(iter);
 		const RzStackAddr off = temp_var->storage.stack_off;
 		const char sign = off >= 0 ? '+' : '-';
@@ -1777,7 +1777,6 @@ static ut32 fold_variables(RzCore *core, RzDisasmState *ds, RzListIter /*<RzAnal
 		iter_mov++;
 		iter = rz_list_next(iter);
 	}
-loop_end:
 	// remove extra "; " in tail
 	rz_strbuf_slice(sb, 0, sb->len - 2);
 	if (!strcmp(ds->fold_var, "hide")) {
@@ -1830,10 +1829,9 @@ static void ds_show_fn_vars_lines(
 		if (iter_mov > 0) {
 			int cnt = 0;
 			while (cnt++ < iter_mov - 1) {
-				rz_goto_if_fail(iter, loop_end);
+				rz_break_if_fail(iter);
 				iter = rz_list_next(iter);
 			}
-		loop_end:
 			continue;
 		}
 		ds_show_fn_var_line(ds, f, var);

--- a/librz/include/rz_util/rz_assert.h
+++ b/librz/include/rz_util/rz_assert.h
@@ -41,7 +41,7 @@ RZ_API void rz_assert_log(RzLogLevel level, const char *fmt, ...) RZ_PRINTF_CHEC
 	} while (0)
 
 /*
- * RZ_CHECKS_LEVEL determines the behaviour of the rz_return/goto_* set of functions.
+ * RZ_CHECKS_LEVEL determines the behaviour of the rz_return/goto/break_* set of functions.
  *
  * 0: completely disable every function and make them like no-operation
  * 1: silently enable checks. Check expressions and do return, but do not log anything
@@ -70,16 +70,25 @@ RZ_API void rz_assert_log(RzLogLevel level, const char *fmt, ...) RZ_PRINTF_CHEC
 	do { \
 		return (val); \
 	} while (0)
+
 #define rz_goto_if_reached(where) \
 	do { \
 		goto where; \
 	} while (0)
-
 #define rz_goto_if_fail(expr, where) \
 	do { \
 		if (!(expr)) { \
 			goto where; \
 		} \
+	} while (0)
+
+#define rz_break_if_reached() \
+	{ \
+		break; \
+	}
+#define rz_break_if_fail(expr) \
+	do { \
+		; \
 	} while (0)
 
 #elif RZ_CHECKS_LEVEL == 1 || RZ_CHECKS_LEVEL == 2 // RZ_CHECKS_LEVEL
@@ -150,6 +159,20 @@ RZ_API void rz_assert_log(RzLogLevel level, const char *fmt, ...) RZ_PRINTF_CHEC
 		} \
 	} while (0)
 
+#define rz_break_if_reached() \
+	{ \
+		H_LOG_(RZ_LOGLVL_ERROR, "file %s: line %d (%s): should not be reached; exiting loop\n", __FILE__, __LINE__, RZ_FUNCTION); \
+		break; \
+	}
+
+#define rz_break_if_fail(expr) \
+	{ \
+		if (!(expr)) { \
+			H_LOG_(RZ_LOGLVL_WARN, "%s: assertion '%s' failed (line %d); exiting loop\n", RZ_FUNCTION, #expr, __LINE__); \
+			break; \
+		} \
+	}
+
 #else // RZ_CHECKS_LEVEL
 
 #include <assert.h>
@@ -170,12 +193,12 @@ RZ_API void rz_assert_log(RzLogLevel level, const char *fmt, ...) RZ_PRINTF_CHEC
 	do { \
 		assert(false); \
 	} while (0)
+
 #define rz_goto_if_reached(where) \
 	do { \
 		assert(false); \
 		goto where; \
 	} while (0)
-
 #define rz_goto_if_fail(expr, where) \
 	do { \
 		assert(expr); \
@@ -183,6 +206,19 @@ RZ_API void rz_assert_log(RzLogLevel level, const char *fmt, ...) RZ_PRINTF_CHEC
 			goto where; \
 		} \
 	} while (0)
+
+#define rz_break_if_reached() \
+	{ \
+		assert(false); \
+		break; \
+	}
+#define rz_break_if_fail(expr) \
+	{ \
+		assert(expr); \
+		if (!(expr)) { \
+			break; \
+		} \
+	}
 
 #endif // RZ_CHECKS_LEVEL
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr adds the `rz_break_if_reached()` and `rz_break_if_fail()` macros to rz_assert, and uses `rz_break_if_fail()` instead of `rz_goto_if_fail()` for exiting loops. The advantage of the former over the latter is that one does not need to figure out where to place the goto label.

Unfortunately, the `do ... while (0)` construct can't be used with `break` because it is a loop. I see 2 reasons why the `do ... while (0)`  construct is used. Both have to do with the `if ... else ...` statement as shown in https://github.com/radareorg/radare2/pull/11286#issuecomment-421272260:

1. The macro body has to be a single statement that is not an `if` statement. This is important for `if ... else ...` statements that do not use braces, since otherwise the semantics of the `if ... else ...` statement will not be as expected. Fortunately, a compound statement i.e. multiple statements enclosed with curly braces `{` `}` is considered a single statement, and that is what is used here.
2. The end-of-statement semicolon `;` has to be eaten. Unfortunately, apparently this cannot be done by macros here that have a `break` statement in their body, but the implications are only that there will be a compilation error if the macro is used in `if ... else ...` statements without curly braces as noted in https://github.com/radareorg/radare2/pull/11286#issuecomment-421272260.

Since it's unlikely in Rizin that the macros here will be used in `if ... else ...` statements without curly braces, the possible compilation error above is unlikely to be an issue, and even if there is an issue, the problematic code will not enter dev.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The addition makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
