### PR TITLE
Fix wrong check on max_count of chained segments.

### DIFF
--- a/librz/bin/format/mach0/mach0_chained_fixups.c
+++ b/librz/bin/format/mach0/mach0_chained_fixups.c
@@ -197,7 +197,10 @@ RZ_IPI bool MACH0_(parse_chained_fixups)(struct MACH0_(obj_t) * bin, ut32 offset
 		return false;
 	}
 	ut64 cursor = starts_at + sizeof(ut32);
-	size_t max_count = RZ_MAX(bin->nsegs, cf->starts_count);
+	size_t max_count = bin->nsegs;
+	if (max_count > cf->starts_count) {
+		max_count = cf->starts_count;
+	}
 	for (size_t i = 0; i < max_count; i++) {
 		ut32 seg_off = 0;
 		if (!rz_buf_read_le32_at(bin->b, cursor, &seg_off)) {


### PR DESCRIPTION
max_count should be nsegs but it must be limited to to what is allocated

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Fixes #5768