### PR TITLE
Add iH command support for OMF, PYC, LUAC, CGC, XBE, and Plan9

### DIFF
--- a/librz/bin/p/bin_cgc.c
+++ b/librz/bin/p/bin_cgc.c
@@ -99,6 +99,13 @@ static RzBuffer *create(RzBin *bin, const ut8 *code, int codelen, const ut8 *dat
 	return buf;
 }
 
+static RzStructuredData *cgc_structure(RzBinFile *bf) {
+	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
+
+	ELFOBJ *bin = (ELFOBJ *)bf->o->bin_obj;
+	return elf_structure(bin);
+}
+
 RzBinPlugin rz_bin_plugin_cgc = {
 	.name = "cgc",
 	.desc = "CGC (Cyber Grand Challenge)",
@@ -118,6 +125,7 @@ RzBinPlugin rz_bin_plugin_cgc = {
 	.symbols = &elf_symbols,
 	.imports = &elf_imports,
 	.info = &elf_info,
+	.bin_structure = &cgc_structure,
 	.fields = &elf_fields,
 	.size = &elf_size,
 	.libs = &elf_libs,

--- a/librz/bin/p/bin_luac.c
+++ b/librz/bin/p/bin_luac.c
@@ -157,6 +157,43 @@ static void destroy(RzBinFile *bf) {
 	luac_build_info_free(bin_info_obj);
 }
 
+static RzStructuredData *luac_structure(RzBinFile *bf) {
+	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj && bf->buf, NULL);
+
+	LuacBinInfo *bin_info_obj = GET_INTERNAL_BIN_INFO_OBJ(bf);
+	RzBuffer *buffer = bf->buf;
+
+	RzStructuredData *info = rz_structured_data_new_map();
+	if (!info) {
+		return NULL;
+	}
+
+	RzStructuredData *luac = rz_structured_data_map_add_map(info, "luac");
+	if (!luac) {
+		rz_structured_data_free(info);
+		return NULL;
+	}
+
+	ut8 magic[LUAC_MAGIC_SIZE];
+	rz_buf_read_at(buffer, LUAC_MAGIC_OFFSET, magic, LUAC_MAGIC_SIZE);
+	char *magic_hex = rz_hex_bin2strdup(magic, LUAC_MAGIC_SIZE);
+	rz_structured_data_map_add_string(luac, "magic", rz_str_get(magic_hex));
+	free(magic_hex);
+
+	char version_str[8];
+	rz_strf(version_str, "%d.%d", bin_info_obj->major, bin_info_obj->minor);
+	rz_structured_data_map_add_string(luac, "version", version_str);
+	rz_structured_data_map_add_unsigned(luac, "major", bin_info_obj->major, false);
+	rz_structured_data_map_add_unsigned(luac, "minor", bin_info_obj->minor, false);
+
+	ut8 format;
+	if (rz_buf_read8_at(buffer, 0x05, &format)) {
+		rz_structured_data_map_add_unsigned(luac, "format", format, false);
+	}
+
+	return info;
+}
+
 RzBinPlugin rz_bin_plugin_luac = {
 	.name = "luac",
 	.desc = "Lua compiled binary",
@@ -173,6 +210,7 @@ RzBinPlugin rz_bin_plugin_luac = {
 	.symbols = &symbols,
 	.info = &info,
 	.strings = &strings,
+	.bin_structure = &luac_structure,
 };
 
 #ifndef RZ_PLUGIN_INCORE

--- a/librz/bin/p/bin_omf.c
+++ b/librz/bin/p/bin_omf.c
@@ -162,6 +162,31 @@ static ut64 get_vaddr(RzBinFile *bf, ut64 baddr, ut64 paddr, ut64 vaddr) {
 	return vaddr;
 }
 
+static RzStructuredData *omf_structure(RzBinFile *bf) {
+	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
+
+	rz_bin_omf_obj *obj = bf->o->bin_obj;
+
+	RzStructuredData *info = rz_structured_data_new_map();
+	if (!info) {
+		return NULL;
+	}
+
+	RzStructuredData *omf = rz_structured_data_map_add_map(info, "omf");
+	if (!omf) {
+		rz_structured_data_free(info);
+		return NULL;
+	}
+
+	int bits = rz_bin_omf_get_bits(obj);
+	rz_structured_data_map_add_unsigned(omf, "bits", bits, false);
+	rz_structured_data_map_add_unsigned(omf, "num_names", obj->nb_name, false);
+	rz_structured_data_map_add_unsigned(omf, "num_sections", obj->nb_section, false);
+	rz_structured_data_map_add_unsigned(omf, "num_symbols", obj->nb_symbol, false);
+
+	return info;
+}
+
 RzBinPlugin rz_bin_plugin_omf = {
 	.name = "omf",
 	.desc = "OMF (Object Module Format)",
@@ -176,6 +201,7 @@ RzBinPlugin rz_bin_plugin_omf = {
 	.sections = &sections,
 	.symbols = &symbols,
 	.info = &info,
+	.bin_structure = &omf_structure,
 	.get_vaddr = &get_vaddr,
 };
 

--- a/librz/bin/p/bin_p9.c
+++ b/librz/bin/p/bin_p9.c
@@ -230,6 +230,57 @@ static ut64 size(RzBinFile *bf) {
 	return text + data + syms + spsz + (6 * 4);
 }
 
+static RzStructuredData *p9_structure(RzBinFile *bf) {
+	rz_return_val_if_fail(bf && bf->buf, NULL);
+
+	if (rz_buf_size(bf->buf) < 32) {
+		return NULL;
+	}
+
+	RzStructuredData *info = rz_structured_data_new_map();
+	if (!info) {
+		return NULL;
+	}
+
+	RzStructuredData *p9 = rz_structured_data_map_add_map(info, "plan9");
+	if (!p9) {
+		rz_structured_data_free(info);
+		return NULL;
+	}
+
+	ut32 magic, text, data, bss, syms, entry, spsz, pcsz;
+	if (!rz_buf_read_le32_at(bf->buf, 0, &magic) ||
+		!rz_buf_read_le32_at(bf->buf, 4, &text) ||
+		!rz_buf_read_le32_at(bf->buf, 8, &data) ||
+		!rz_buf_read_le32_at(bf->buf, 12, &bss) ||
+		!rz_buf_read_le32_at(bf->buf, 16, &syms) ||
+		!rz_buf_read_le32_at(bf->buf, 20, &entry) ||
+		!rz_buf_read_le32_at(bf->buf, 24, &spsz) ||
+		!rz_buf_read_le32_at(bf->buf, 28, &pcsz)) {
+		rz_structured_data_free(info);
+		return NULL;
+	}
+
+	rz_structured_data_map_add_unsigned(p9, "magic", magic, true);
+	rz_structured_data_map_add_unsigned(p9, "text_size", text, true);
+	rz_structured_data_map_add_unsigned(p9, "data_size", data, true);
+	rz_structured_data_map_add_unsigned(p9, "bss_size", bss, true);
+	rz_structured_data_map_add_unsigned(p9, "syms_size", syms, true);
+	rz_structured_data_map_add_unsigned(p9, "entry", entry, true);
+	rz_structured_data_map_add_unsigned(p9, "spsz", spsz, true);
+	rz_structured_data_map_add_unsigned(p9, "pcsz", pcsz, true);
+
+	int bits = 32, big_endian = 0;
+	int arch = rz_bin_p9_get_arch(bf->buf, &bits, &big_endian);
+	if (arch) {
+		rz_structured_data_map_add_string(p9, "arch", rz_sys_arch_str(arch));
+		rz_structured_data_map_add_unsigned(p9, "bits", bits, false);
+		rz_structured_data_map_add_boolean(p9, "big_endian", big_endian);
+	}
+
+	return info;
+}
+
 /* inspired in http://www.phreedom.org/solar/code/tinype/tiny.97/tiny.asm */
 static RzBuffer *create(RzBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen, RzBinArchOptions *opt) {
 	RzBuffer *buf = rz_buf_new_with_bytes(NULL, 0);
@@ -268,6 +319,7 @@ RzBinPlugin rz_bin_plugin_p9 = {
 	.imports = &imports,
 	.info = &info,
 	.libs = &libs,
+	.bin_structure = &p9_structure,
 	.create = &create,
 };
 

--- a/librz/bin/p/bin_pyc.c
+++ b/librz/bin/p/bin_pyc.c
@@ -167,6 +167,30 @@ static void destroy(RzBinFile *bf) {
 	RZ_FREE(bf->o->bin_obj);
 }
 
+static RzStructuredData *pyc_structure(RzBinFile *bf) {
+	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
+
+	RzBinPycObj *ctx = bf->o->bin_obj;
+
+	RzStructuredData *info = rz_structured_data_new_map();
+	if (!info) {
+		return NULL;
+	}
+
+	RzStructuredData *pyc = rz_structured_data_map_add_map(info, "pyc");
+	if (!pyc) {
+		rz_structured_data_free(info);
+		return NULL;
+	}
+
+	rz_structured_data_map_add_unsigned(pyc, "magic", ctx->version.magic, true);
+	rz_structured_data_map_add_string(pyc, "version", rz_str_get(ctx->version.version));
+	rz_structured_data_map_add_string(pyc, "revision", rz_str_get(ctx->version.revision));
+	rz_structured_data_map_add_unsigned(pyc, "code_start_offset", ctx->code_start_offset, true);
+
+	return info;
+}
+
 RzBinPlugin rz_bin_plugin_pyc = {
 	.name = "pyc",
 	.desc = "Python byte-compiled",
@@ -180,7 +204,8 @@ RzBinPlugin rz_bin_plugin_pyc = {
 	.baddr = &baddr,
 	.symbols = &symbols,
 	.strings = &strings,
-	.destroy = &destroy
+	.destroy = &destroy,
+	.bin_structure = &pyc_structure,
 };
 
 #ifndef RZ_PLUGIN_INCORE

--- a/librz/bin/p/bin_xbe.c
+++ b/librz/bin/p/bin_xbe.c
@@ -366,6 +366,64 @@ static ut64 baddr(RzBinFile *bf) {
 	return obj->header.base;
 }
 
+static RzStructuredData *xbe_structure(RzBinFile *bf) {
+	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
+
+	rz_bin_xbe_obj_t *obj = bf->o->bin_obj;
+	xbe_header *h = &obj->header;
+
+	RzStructuredData *info = rz_structured_data_new_map();
+	if (!info) {
+		return NULL;
+	}
+
+	RzStructuredData *xbe = rz_structured_data_map_add_map(info, "xbe");
+	if (!xbe) {
+		rz_structured_data_free(info);
+		return NULL;
+	}
+
+	char magic[5] = { 0 };
+	memcpy(magic, h->magic, 4);
+	rz_structured_data_map_add_string(xbe, "magic", magic);
+
+	char *signature_hex = rz_hex_bin2strdup(h->signature, sizeof(h->signature));
+	rz_structured_data_map_add_string(xbe, "signature", rz_str_get(signature_hex));
+	free(signature_hex);
+
+	rz_structured_data_map_add_unsigned(xbe, "base_address", h->base, true);
+	rz_structured_data_map_add_unsigned(xbe, "headers_size", h->headers_size, true);
+	rz_structured_data_map_add_unsigned(xbe, "image_size", h->image_size, true);
+	rz_structured_data_map_add_unsigned(xbe, "image_header_size", h->image_header_size, true);
+	rz_structured_data_map_add_unsigned(xbe, "timestamp", h->timestamp, true);
+	rz_structured_data_map_add_unsigned(xbe, "certificate_address", h->cert_addr, true);
+	rz_structured_data_map_add_unsigned(xbe, "num_sections", h->sections, false);
+	rz_structured_data_map_add_unsigned(xbe, "section_headers_address", h->sechdr_addr, true);
+	rz_structured_data_map_add_unsigned(xbe, "init_flags", h->init_flags, true);
+	rz_structured_data_map_add_unsigned(xbe, "entry_point_encrypted", h->ep, true);
+	rz_structured_data_map_add_unsigned(xbe, "entry_point", h->ep ^ obj->ep_key, true);
+	rz_structured_data_map_add_unsigned(xbe, "tls_address", h->tls_addr, true);
+	rz_structured_data_map_add_unsigned(xbe, "debug_path_address", h->debug_path_addr, true);
+	rz_structured_data_map_add_unsigned(xbe, "debug_name_address", h->debug_name_addr, true);
+	rz_structured_data_map_add_unsigned(xbe, "kernel_thunk_address_encrypted", h->kernel_thunk_addr, true);
+	rz_structured_data_map_add_unsigned(xbe, "kernel_thunk_address", h->kernel_thunk_addr ^ obj->kt_key, true);
+	rz_structured_data_map_add_unsigned(xbe, "nonkernel_import_dir_address", h->nonkernel_import_dir_addr, true);
+	rz_structured_data_map_add_unsigned(xbe, "num_library_versions", h->lib_versions, false);
+	rz_structured_data_map_add_unsigned(xbe, "library_versions_address", h->lib_versions_addr, true);
+	rz_structured_data_map_add_unsigned(xbe, "kernel_library_address", h->kernel_lib_addr, true);
+	rz_structured_data_map_add_unsigned(xbe, "xapi_library_address", h->xapi_lib_addr, true);
+
+	const char *xbe_type = "retail";
+	if ((h->ep & 0xf0000000) == 0x40000000) {
+		xbe_type = "chihiro";
+	} else if ((h->ep ^ XBE_EP_RETAIL) > 0x1000000) {
+		xbe_type = "debug";
+	}
+	rz_structured_data_map_add_string(xbe, "xbe_type", xbe_type);
+
+	return info;
+}
+
 RzBinPlugin rz_bin_plugin_xbe = {
 	.name = "xbe",
 	.desc = "Microsoft Xbox XBE (Xbox Executable)",
@@ -382,6 +440,7 @@ RzBinPlugin rz_bin_plugin_xbe = {
 	.symbols = &symbols,
 	.info = &info,
 	.libs = &libs,
+	.bin_structure = &xbe_structure,
 };
 
 #ifndef RZ_PLUGIN_INCORE

--- a/test/db/formats/cgc
+++ b/test/db/formats/cgc
@@ -6,6 +6,15 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=CGC: structured data (iH)
+FILE=bins/cgc/CADET_00001
+CMDS=iH~ei_osabi,ei_class
+EXPECT=<<EOF
+    ei_class: 1
+    ei_osabi: 67
+EOF
+RUN
+
 NAME=CGC: Create
 FILE==
 CMDS=<<EOF

--- a/test/db/formats/luac/luac
+++ b/test/db/formats/luac/luac
@@ -1,3 +1,17 @@
+NAME=LUAC: structured data (iH)
+FILE=bins/luac/none.luac
+CMDS=iH
+EXPECT=<<EOF
+luac:
+  magic: "1b4c7561"
+  version: "5.4"
+  major: 5
+  minor: 4
+  format: 0
+
+EOF
+RUN
+
 NAME=LUAC: plugin load
 FILE=bins/luac/none.luac
 CMDS=<<EOF

--- a/test/db/formats/omf
+++ b/test/db/formats/omf
@@ -1,3 +1,29 @@
+NAME=omf structured data (iH) 16 bits
+FILE=bins/omf/hello_world
+CMDS=iH
+EXPECT=<<EOF
+omf:
+  bits: 16
+  num_names: 3
+  num_sections: 2
+  num_symbols: 1
+
+EOF
+RUN
+
+NAME=omf structured data (iH) 32 bits
+FILE=bins/omf/hello_world32
+CMDS=iH
+EXPECT=<<EOF
+omf:
+  bits: 32
+  num_names: 7
+  num_sections: 2
+  num_symbols: 1
+
+EOF
+RUN
+
 NAME=load 16 bits omf
 FILE=bins/omf/hello_world
 CMDS=iI~bits

--- a/test/db/formats/plan9
+++ b/test/db/formats/plan9
@@ -1,3 +1,23 @@
+NAME=Plan9: structured data (iH)
+FILE=bins/plan9/bin
+CMDS=iH 2>/dev/null
+EXPECT=<<EOF
+plan9:
+  magic: 0xeb010000
+  text_size: 0x364a0701
+  data_size: 0x408a0500
+  bss_size: 0x609d0100
+  syms_size: 0x0
+  entry: 0x40ee0400
+  spsz: 0x0
+  pcsz: 0x0
+  arch: "x86"
+  bits: 32
+  big_endian: false
+
+EOF
+RUN
+
 NAME=Plan9: Open/iI
 FILE=bins/plan9/bin
 CMDS=iI~?plan9

--- a/test/db/formats/pyc
+++ b/test/db/formats/pyc
@@ -1,3 +1,16 @@
+NAME=pyc structured data (iH)
+FILE=bins/pyc/py37.pyc
+CMDS=iH 2>/dev/null
+EXPECT=<<EOF
+pyc:
+  magic: 0xa0d0d42
+  version: "v3.7.0"
+  revision: "ae1f6af15f3e4110616801e235873e47fd7d1977"
+  code_start_offset: 0x0
+
+EOF
+RUN
+
 NAME=pyc load version314
 FILE=bins/pyc/pyc314.pyc
 CMDS=<<EOF

--- a/test/db/formats/xbe
+++ b/test/db/formats/xbe
@@ -1,3 +1,36 @@
+NAME=xbe structured data (iH)
+FILE=bins/xbe/default.xbe
+CMDS=iH
+EXPECT=<<EOF
+xbe:
+  magic: "XBEH"
+  signature: "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+  base_address: 0x10000
+  headers_size: 0x742
+  image_size: 0x134ac4
+  image_header_size: 0x178
+  timestamp: 0x3dd817da
+  certificate_address: 0x10178
+  num_sections: 5
+  section_headers_address: 0x10348
+  init_flags: 0x0
+  entry_point_encrypted: 0xa8fd47ab
+  entry_point: 0x11000
+  tls_address: 0x0
+  debug_path_address: 0x1048b
+  debug_name_address: 0x1048b
+  kernel_thunk_address_encrypted: 0x5b6c5676
+  kernel_thunk_address: 0x116c0
+  nonkernel_import_dir_address: 0x0
+  num_library_versions: 0
+  library_versions_address: 0x0
+  kernel_library_address: 0x0
+  xapi_library_address: 0x0
+  xbe_type: "retail"
+
+EOF
+RUN
+
 NAME=loading an xbe file
 FILE=bins/xbe/default.xbe
 CMDS=q!


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else. 

**Note:** AI tools were used to help study and understand the binary format specifications and header structures, but all code was written by me manually.

**Detailed description**

I've added the missing `iH` (bin_structure) command support for six binary formats: OMF, PYC, LUAC, CGC, XBE, and Plan 9. Each format now properly exports its header information as structured data that can be displayed with the `iH` command. The implementations follow the existing patterns in Rizin and include appropriate test coverage.

**Test plan**

All tests pass successfully on my local machine

**Run the specific format tests:**

```cd test
../build/binrz/rz-test/rz-test -r ../build/binrz/rizin/rizin -e "structured data" \
  db/formats/omf db/formats/pyc db/formats/luac/luac \
  db/formats/cgc db/formats/xbe db/formats/plan9
```
Expected output: All 7 tests pass (OK: 86, XX: 0, FX: 0)

**Closing issues**

closes #5728

