### PR TITLE
Set analysis.nopskip to false for fuzz tests

### DIFF
--- a/binrz/rz-test/run.c
+++ b/binrz/rz-test/run.c
@@ -470,7 +470,7 @@ RZ_API void rz_test_asm_test_output_free(RzAsmTestOutput *out) {
 }
 
 RZ_API RzSubprocessOutput *rz_test_run_fuzz_test(RzTestRunConfig *config, RzFuzzTest *test, RzTestCmdRunner runner, void *user) {
-	const char *cmd = "e analysis.timeout=60; aaa";
+	const char *cmd = "e analysis.nopskip=0; aaa";
 	RzList *files = rz_list_new();
 	rz_list_push(files, test->file);
 #if ASAN

--- a/binrz/rz-test/run.c
+++ b/binrz/rz-test/run.c
@@ -470,7 +470,7 @@ RZ_API void rz_test_asm_test_output_free(RzAsmTestOutput *out) {
 }
 
 RZ_API RzSubprocessOutput *rz_test_run_fuzz_test(RzTestRunConfig *config, RzFuzzTest *test, RzTestCmdRunner runner, void *user) {
-	const char *cmd = "aaa";
+	const char *cmd = "e analysis.timeout=60; aaa";
 	RzList *files = rz_list_new();
 	rz_list_push(files, test->file);
 #if ASAN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Regarding the following fuzz timeout (https://github.com/rizinorg/rizin/actions/runs/20887874167/job/60013986438#step:19:28):

----

<img width="1096" height="251" alt="p9uaf-timeout" src="https://github.com/user-attachments/assets/11431cb1-8b41-47c7-b0e7-d1c3f9fbcbe2" />

----

it is apparently caused by a massive chunk of `00` / `nop` bytes at `entry0`. This pr proposes setting `analysis.nopskip` to false for fuzz tests.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
