### PR TITLE
refactor(tui): add enum variables in define

### DIFF
--- a/librz/core/tui/define.c
+++ b/librz/core/tui/define.c
@@ -30,7 +30,7 @@ static void define_data_ntimes(RzCore *core, ut64 off, int times, int type) {
 	}
 }
 
-static bool isDisasmPrint(int mode) {
+static bool is_visual_mode_disasm(RzCoreVisualMode mode) {
 	return (mode == 1 || mode == 2);
 }
 

--- a/librz/core/tui/define.c
+++ b/librz/core/tui/define.c
@@ -31,7 +31,7 @@ static void define_data_ntimes(RzCore *core, ut64 off, int times, int type) {
 }
 
 static bool is_visual_mode_disasm(RzCoreVisualMode mode) {
-	return (mode == 1 || mode == 2);
+	return (mode == RZ_CORE_VISUAL_MODE_PD || mode == RZ_CORE_VISUAL_MODE_DB);
 }
 
 static void handleHints(RzCore *core) {


### PR DESCRIPTION
**Checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

The PR refactors the visual define mode implementation in `librz/core/tui/define.c`. The file used mode in the `isDisasmPrint` function and compared `mode` with 0 and 1 for which the enum values were already defined in the `librz/core/core_private.h` enum `RzCoreVisualMode`. I simply replaced the 0 and 1 with those types.

https://github.com/rizinorg/rizin/blob/383636a5b269ac2230b3ed8f1a72414cf6d956ae/librz/core/core_private.h#L247-L253

**Test plan**

- Compilation: Verified that the project compiles successfully with `meson compile -C build`.


**Closing issues**

Related to #489 (Refactored tui/define.c
...
