### PR TITLE
Fix memory leak in RzMagicLine

### DIFF
--- a/librz/include/rz_magic.h
+++ b/librz/include/rz_magic.h
@@ -343,7 +343,7 @@ struct rz_magic_line_t {
 	char indirect_operator;
 	int64_t indirect_operand;
 
-	const char *name;
+	char *name;
 
 	enum magic_type type;
 	char *type_string;
@@ -352,7 +352,7 @@ struct rz_magic_line_t {
 
 	char test_operator;
 	int test_not;
-	const char *test_string;
+	char *test_string;
 	size_t test_string_size;
 	ut64 test_unsigned;
 	int64_t test_signed;

--- a/librz/magic/magic-test.c
+++ b/librz/magic/magic-test.c
@@ -92,7 +92,7 @@ int file_printf(char **s, const char *fmt, ...) {
 
 static int magic_test_line(RzMagicLine *, RzMagicState *);
 
-static RzMagicLine *magic_get_named(RzMagic *m, const char *name) {
+static RzMagicLine *magic_get_named(RzMagic *m, char *name) {
 	RzMagicLine ml;
 
 	ml.name = name;

--- a/librz/magic/magic.c
+++ b/librz/magic/magic.c
@@ -143,5 +143,7 @@ void rz_magic_line_free(RZ_OWN RZ_NULLABLE RzMagicLine *ml) {
 	free(ml->type_string);
 	free(ml->result);
 	free(ml->mimetype);
+	free(ml->name);
+	free(ml->test_string);
 	free(ml);
 }


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Fixes a memory leak where dynamically allocated strings for `ml->name` and `ml->test_string` in `magic_parse_value() ` were never freed. These strings are allocated via `malloc()` and assigned to the `RzMagicLine` structure, but `rz_magic_line_free() `was missing the corresponding `free()` calls.

**Test plan**
The change is very minimal just added a free() to fix the memory leak.Though i have Verified the fix by building locally and runing the test suits.

**Closing issues**


