### PR TITLE
test: fix ASan-detected memory leaks in mark API tests

### DIFF
--- a/test/integration/test_analysis_il.c
+++ b/test/integration/test_analysis_il.c
@@ -53,7 +53,13 @@ static bool test_analysis_il_vm_step() {
 static bool test_analysis_il() {
 	RzCore *core = rz_core_new();
 	mu_assert_notnull(core, "init core");
-	RzCoreFile *cf = rz_core_file_open(core, "bins/elf/emulateme.arm64", RZ_PERM_RWX, 0);
+	char *tb = rz_sys_getenv("RZ_TESTBINS");
+	mu_assert_notnull(tb, "RZ_TESTBINS not set");
+
+	char *path = rz_str_newf("%s/elf/emulateme.arm64", tb);
+	rz_mem_free(tb);
+	RzCoreFile *cf = rz_core_file_open(core, path, RZ_PERM_RWX, 0);
+	rz_mem_free(path);
 	mu_assert_notnull(cf, "open file");
 	mu_assert("load file", rz_core_bin_load(core, NULL, 0));
 	mu_assert("il vm setup", rz_analysis_il_vm_setup(core->analysis));
@@ -76,7 +82,10 @@ static bool test_analysis_il() {
 	RzILVal *v = rz_il_vm_get_var_value(core->analysis->il_vm->vm, RZ_IL_VAR_KIND_GLOBAL, "sp");
 	mu_assert_notnull(v, "RzIL vm var value");
 	mu_assert_eq(v->type, RZ_IL_TYPE_PURE_BITVECTOR, "var type");
+	rz_strbuf_fini(&sb);
+	rz_analysis_op_fini(&op);
 	mu_assert_eq(rz_bv_to_ut64(v->data.bv), -0x20, "var value");
+	rz_analysis_op_init(&op);
 
 	// extract and evaluate a whole function
 	RzAnalysisFunction *f = rz_analysis_get_function_byname(core->analysis, "sym.decrypt");
@@ -124,6 +133,7 @@ static bool test_analysis_il() {
 	}
 	mu_assert_eq(count, 69, "il op count of function");
 	rz_iterator_free(iter);
+	rz_strbuf_fini(&sb);
 
 	// extract and evaluate a chunk of instructions
 	count = 0;
@@ -145,10 +155,12 @@ static bool test_analysis_il() {
 	}
 	mu_assert_eq(count, 30, "il op count of function");
 	rz_iterator_free(iter);
+	rz_strbuf_fini(&sb);
 
 	rz_core_seek(core, 0x918, true);
 	rz_core_analysis_il_reinit(core);
 	mu_assert("eval rzil", rz_core_il_step(core, 3));
+	rz_analysis_op_fini(&op);
 
 	rz_core_free(core);
 	mu_end;


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added or updated tests that prove my changes are effective.
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

LeakSanitizer was reporting leaks in the mark unit tests when running
`test_rz_mark_get_all_off()` and `test_rz_mark_all_list()`.

Both functions return owned `RzList` objects, but the tests were not freeing them, which caused the leaks. This change updates the tests to release those lists properly so ASan runs are clean.

Also fixes a memory leak in `test_analysis_il` where the value returned by `rz_sys_getenv()` was not freed.

**Test plan**

Built and tested using AddressSanitizer:

meson setup build-asan -Db_sanitize=address,undefined
ninja -C build-asan
ASAN_OPTIONS=abort_on_error=1:print_stacktrace=1 \
UBSAN_OPTIONS=abort_on_error=1:print_stacktrace=1 \
./build-asan/test/unit/test_marks

Output after the fix:

test_rz_mark_get_at OK
test_rz_mark_get_all_off OK
test_rz_mark_all_list OK
test_rz_mark_unset OK
test_rz_mark_set_properties OK
test_rz_mark_rename OK
test_rz_mark_count_and_starts_or_ends OK

No ASan/LSan errors reported.

test/integration/test_analysis_il also passes cleanly under ASan.

**Closing issues**