### PR TITLE
Fix FreeBSD build: Always fallback to subproject if use_sys_pcre2 is unset.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -236,7 +236,7 @@ if (pcre2_dep_opt.enabled() or pcre2_dep_opt.auto()) and not meson.is_cross_buil
     pcre2_dep = cc.find_library('pcre2', required: true, static: true)
   endif
 else
-  pcre2_dep = dependency('pcre2', version: '>=10.42', required: true, static: true)
+  pcre2_dep = dependency('pcre2', version: '>=10.42', required: true, static: true, allow_fallback: true)
 endif
 
 if meson.is_cross_build()


### PR DESCRIPTION


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This should prevent dependency confusions if an OS (FreeBSD in this case) has multiple different PCRE2 libraries.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

FreeBSD build is green

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
