### PR TITLE
Swap argument order of rz_bv_copy*

### DIFF
--- a/librz/il/il_reg.c
+++ b/librz/il/il_reg.c
@@ -250,7 +250,7 @@ RZ_API bool rz_il_vm_sync_to_reg(RZ_NONNULL RzILVM *vm, RZ_NONNULL RzILRegBindin
 			RzBitVector *pcbv = rz_bv_new_zero(ri->size);
 			if (pcbv) {
 				perfect &= rz_bv_len(pcbv) == rz_bv_len(vm->pc);
-				rz_bv_copy_nbits(vm->pc, 0, pcbv, 0, RZ_MIN(rz_bv_len(pcbv), rz_bv_len(vm->pc)));
+				rz_bv_copy_nbits(pcbv, 0, vm->pc, 0, RZ_MIN(rz_bv_len(pcbv), rz_bv_len(vm->pc)));
 				rz_reg_set_bv(reg, ri, pcbv);
 				rz_bv_free(pcbv);
 			} else {
@@ -293,7 +293,7 @@ RZ_API bool rz_il_vm_sync_to_reg(RZ_NONNULL RzILVM *vm, RZ_NONNULL RzILRegBindin
 					break;
 				}
 				if (ri->size > 1) {
-					rz_bv_copy_nbits(bv, 0, dupped, 0, RZ_MIN(rz_bv_len(bv), ri->size));
+					rz_bv_copy_nbits(dupped, 0, bv, 0, RZ_MIN(rz_bv_len(bv), ri->size));
 				} else {
 					rz_bv_set_from_ut64(dupped, rz_bv_is_zero_vector(bv) ? 0 : 1);
 				}
@@ -324,7 +324,7 @@ RZ_API void rz_il_vm_sync_from_reg(RZ_NONNULL RzILVM *vm, RZ_NONNULL RzILRegBind
 			rz_bv_set_all(vm->pc, 0);
 			RzBitVector *pcbv = rz_reg_get_bv(reg, ri);
 			if (pcbv) {
-				rz_bv_copy_nbits(pcbv, 0, vm->pc, 0, RZ_MIN(rz_bv_len(pcbv), rz_bv_len(vm->pc)));
+				rz_bv_copy_nbits(vm->pc, 0, pcbv, 0, RZ_MIN(rz_bv_len(pcbv), rz_bv_len(vm->pc)));
 				rz_bv_free(pcbv);
 			}
 		}
@@ -352,7 +352,7 @@ RZ_API void rz_il_vm_sync_from_reg(RZ_NONNULL RzILVM *vm, RZ_NONNULL RzILRegBind
 					rz_bv_free(bv);
 					break;
 				}
-				rz_bv_copy_nbits(bv, 0, nbv, 0, RZ_MIN(rz_bv_len(bv), item->size));
+				rz_bv_copy_nbits(nbv, 0, bv, 0, RZ_MIN(rz_bv_len(bv), item->size));
 				dupped = bv;
 				bv = nbv;
 			}

--- a/librz/il/theory_bitv.c
+++ b/librz/il/theory_bitv.c
@@ -358,7 +358,7 @@ void *rz_il_handler_cast(RzILVM *vm, RzILOpBitVector *op, RzILTypePure *type) {
 
 	RzBitVector *ret = rz_bv_new(op_cast->length);
 	rz_bv_set_all(ret, fill->b);
-	rz_bv_copy_nbits(bv, 0, ret, 0, RZ_MIN(bv->len, ret->len));
+	rz_bv_copy_nbits(ret, 0, bv, 0, RZ_MIN(bv->len, ret->len));
 
 	rz_il_bool_free(fill);
 	rz_bv_free(bv);

--- a/librz/include/rz_util/rz_bitvector.h
+++ b/librz/include/rz_util/rz_bitvector.h
@@ -40,10 +40,10 @@ RZ_API bool rz_bv_init(RZ_NONNULL RzBitVector *bv, ut32 length);
 RZ_API RZ_OWN RzBitVector *rz_bv_new(ut32 length);
 RZ_API RZ_OWN RzBitVector *rz_bv_dup(const RZ_NONNULL RzBitVector *bv);
 RZ_API RZ_OWN RzBitVector *rz_bv_append(RZ_NONNULL RzBitVector *bv1, RZ_NONNULL RzBitVector *bv2);
-RZ_API ut32 rz_bv_copy(RZ_NONNULL const RzBitVector *src, RZ_NONNULL RzBitVector *dst);
+RZ_API ut32 rz_bv_copy(RZ_NONNULL RzBitVector *dst, RZ_NONNULL const RzBitVector *src);
 RZ_API ut32 rz_bv_copy_nbits(
-	RZ_NONNULL const RzBitVector *src, ut32 src_start_pos,
 	RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos,
+	RZ_NONNULL const RzBitVector *src, ut32 src_start_pos,
 	ut32 nbit);
 RZ_API void rz_bv_fini(RZ_NONNULL RzBitVector *bv);
 RZ_API void rz_bv_free(RZ_NULLABLE RzBitVector *bv);

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -184,7 +184,7 @@ RZ_API RZ_OWN RzBitVector *rz_bv_dup(const RZ_NONNULL RzBitVector *bv) {
 	rz_return_val_if_fail(bv, NULL);
 
 	RzBitVector *new_bv = rz_bv_new(bv->len);
-	if (!new_bv || !rz_bv_copy(bv, new_bv)) {
+	if (!new_bv || !rz_bv_copy(new_bv, bv)) {
 		rz_bv_free(new_bv);
 		return NULL;
 	}
@@ -196,11 +196,11 @@ RZ_API RZ_OWN RzBitVector *rz_bv_dup(const RZ_NONNULL RzBitVector *bv) {
  * Copy from source bitvector to destination bitvector.
  * The bitvectors must have the same length.
  *
- * \param src RzBitVector, the source bitvector
  * \param dst RzBitVector, the destination bitvector
+ * \param src RzBitVector, the source bitvector
  * \return Actual size of copy
  */
-RZ_API ut32 rz_bv_copy(RZ_NONNULL const RzBitVector *src, RZ_NONNULL RzBitVector *dst) {
+RZ_API ut32 rz_bv_copy(RZ_NONNULL RzBitVector *dst, RZ_NONNULL const RzBitVector *src) {
 	rz_return_val_if_fail(src && dst, 0);
 
 	if (dst->len != src->len) {
@@ -220,7 +220,7 @@ RZ_API ut32 rz_bv_copy(RZ_NONNULL const RzBitVector *src, RZ_NONNULL RzBitVector
 /**
  * \brief Optimized version of rz_bv_copy_nbits() for large bitvectors (more than 64 bits) with bit positions aligned to BV_ELEM_SIZE
  */
-static ut32 bv_copy_nbits_large_aligned(const RzBitVector *src, ut32 src_start_pos, RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
+static ut32 bv_copy_nbits_large_aligned(RzBitVector *dst, ut32 dst_start_pos, const RzBitVector *src, ut32 src_start_pos, ut32 nbit) {
 	// Sanity check performed by caller
 	ut8 start_bits = RZ_MIN((BV_ELEM_SIZE - dst_start_pos) % BV_ELEM_SIZE, nbit);
 	ut8 trailing_bits = RZ_MIN((src_start_pos + nbit) % BV_ELEM_SIZE, nbit - start_bits);
@@ -260,7 +260,7 @@ static ut32 bv_copy_nbits_large_aligned(const RzBitVector *src, ut32 src_start_p
 /**
  * \brief Optimized version of rz_bv_copy_nbits() for copying bit range from a large bitvector to a small one
  */
-static ut32 bv_copy_nbits_large_to_small(const RzBitVector *src, ut32 src_start_pos, RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
+static ut32 bv_copy_nbits_large_to_small(RzBitVector *dst, ut32 dst_start_pos, const RzBitVector *src, ut32 src_start_pos, ut32 nbit) {
 	ut64 buffer = 0;
 	ut8 start_bits = RZ_MIN((BV_ELEM_SIZE - src_start_pos) % BV_ELEM_SIZE, nbit);
 	ut32 byte_index = (src_start_pos + start_bits) / BV_ELEM_SIZE;
@@ -309,7 +309,7 @@ static ut32 bv_copy_nbits_large_to_small(const RzBitVector *src, ut32 src_start_
 /**
  * \brief Optimized version of rz_bv_copy_nbits() for copying bit range from a small bitvector to a large one
  */
-static ut32 bv_copy_nbits_small_to_large(const RzBitVector *src, ut32 src_start_pos, RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
+static ut32 bv_copy_nbits_small_to_large(RzBitVector *dst, ut32 dst_start_pos, const RzBitVector *src, ut32 src_start_pos, ut32 nbit) {
 	ut64 byte_index = dst_start_pos / BV_ELEM_SIZE;
 	ut8 start_bits = RZ_MIN((BV_ELEM_SIZE - dst_start_pos) % BV_ELEM_SIZE, nbit);
 	ut8 trailing_bits = RZ_MIN((dst_start_pos + nbit) % BV_ELEM_SIZE, nbit - start_bits);
@@ -368,7 +368,7 @@ static ut32 bv_copy_nbits_small_to_large(const RzBitVector *src, ut32 src_start_
 /**
  * \brief Optimized version of rz_bv_copy_nbits() for large bitvectors (more than 64 bits) with unaligned bit positions
  */
-static ut32 bv_copy_nbits_large_unaligned(const RzBitVector *src, ut32 src_start_pos, RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
+static ut32 bv_copy_nbits_large_unaligned(RzBitVector *dst, ut32 dst_start_pos, const RzBitVector *src, ut32 src_start_pos, ut32 nbit) {
 	// Sanity check performed by caller
 	ut64 bits_remaining = nbit;
 
@@ -404,14 +404,14 @@ static ut32 bv_copy_nbits_large_unaligned(const RzBitVector *src, ut32 src_start
  * Copy n bits from start position of source to start position of dest, return num of copied bits
  * NOTE: src and dst can be the same bit vector pointer.
  *
- * \param src RzBitVector, data source
- * \param src_start_pos ut32, start position in source bitvector of copy
  * \param dst RzBitVector, destination of copy
  * \param dst_start_pos ut32, start position in destination bitvector
+ * \param src RzBitVector, data source
+ * \param src_start_pos ut32, start position in source bitvector of copy
  * \param nbit ut32, control the size of copy (in bits)
  * \return copied_size ut32, Actual copied size
  */
-RZ_API ut32 rz_bv_copy_nbits(RZ_NONNULL const RzBitVector *src, ut32 src_start_pos, RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
+RZ_API ut32 rz_bv_copy_nbits(RZ_NONNULL RzBitVector *dst, ut32 dst_start_pos, RZ_NONNULL const RzBitVector *src, ut32 src_start_pos, ut32 nbit) {
 	rz_return_val_if_fail(src && dst, 0);
 
 	ut32 max_nbit = RZ_MIN((src->len - src_start_pos),
@@ -431,29 +431,29 @@ RZ_API ut32 rz_bv_copy_nbits(RZ_NONNULL const RzBitVector *src, ut32 src_start_p
 	if (src->len > 64 && dst->len > 64) {
 		// Both src and dst are larger than 64 bits
 		if (src_start_pos % BV_ELEM_SIZE == dst_start_pos % BV_ELEM_SIZE) {
-			return bv_copy_nbits_large_aligned(src, src_start_pos, dst, dst_start_pos, nbit);
+			return bv_copy_nbits_large_aligned(dst, dst_start_pos, src, src_start_pos, nbit);
 		}
 
 		if (src->bits.large_a != dst->bits.large_a) {
-			return bv_copy_nbits_large_unaligned(src, src_start_pos, dst, dst_start_pos, nbit);
+			return bv_copy_nbits_large_unaligned(dst, dst_start_pos, src, src_start_pos, nbit);
 		}
 
 		// Use a temporary bitvector for same-vector copies
 		RzBitVector *temp = rz_bv_new(rz_bv_len(dst));
-		rz_bv_copy(dst, temp);
-		ut32 bits_copied = bv_copy_nbits_large_unaligned(src, src_start_pos, temp, dst_start_pos, nbit);
 		rz_bv_copy(temp, dst);
+		ut32 bits_copied = bv_copy_nbits_large_unaligned(temp, dst_start_pos, src, src_start_pos, nbit);
+		rz_bv_copy(dst, temp);
 		rz_bv_free(temp);
 		return bits_copied;
 	}
 
 	if (src->len > 64) {
 		// Large to small copy
-		return bv_copy_nbits_large_to_small(src, src_start_pos, dst, dst_start_pos, nbit);
+		return bv_copy_nbits_large_to_small(dst, dst_start_pos, src, src_start_pos, nbit);
 	}
 
 	// Small to large
-	return bv_copy_nbits_small_to_large(src, src_start_pos, dst, dst_start_pos, nbit);
+	return bv_copy_nbits_small_to_large(dst, dst_start_pos, src, src_start_pos, nbit);
 }
 
 /**
@@ -555,8 +555,8 @@ RZ_API RZ_OWN RzBitVector *rz_bv_cut_tail(RZ_NONNULL RzBitVector *bv, ut32 delta
 RZ_API RZ_OWN RzBitVector *rz_bv_append(RZ_NONNULL RzBitVector *high, RZ_NONNULL RzBitVector *low) {
 	rz_return_val_if_fail(high && low, NULL);
 	RzBitVector *ret = rz_bv_new(high->len + low->len);
-	rz_bv_copy_nbits(low, 0, ret, 0, low->len);
-	rz_bv_copy_nbits(high, 0, ret, low->len, high->len);
+	rz_bv_copy_nbits(ret, 0, low, 0, low->len);
+	rz_bv_copy_nbits(ret, low->len, high, 0, high->len);
 	return ret;
 }
 
@@ -715,13 +715,13 @@ RZ_API bool rz_bv_lshift_fill(RZ_NONNULL RzBitVector *bv, ut32 size, bool fill_b
 	}
 	rz_bv_set_all(&tmp, fill_bit);
 
-	int copied_size = rz_bv_copy_nbits(bv, 0, &tmp, size, bv->len - size);
+	int copied_size = rz_bv_copy_nbits(&tmp, size, bv, 0, bv->len - size);
 	if (copied_size == 0) {
 		rz_bv_fini(&tmp);
 		return false;
 	}
 
-	rz_bv_copy(&tmp, bv);
+	rz_bv_copy(bv, &tmp);
 	rz_bv_fini(&tmp);
 
 	return true;
@@ -754,13 +754,13 @@ RZ_API bool rz_bv_rshift_fill(RZ_NONNULL RzBitVector *bv, ut32 size, bool fill_b
 	}
 	rz_bv_set_all(&tmp, fill_bit);
 
-	int copied_size = rz_bv_copy_nbits(bv, size, &tmp, 0, bv->len - size);
+	int copied_size = rz_bv_copy_nbits(&tmp, 0, bv, size, bv->len - size);
 	if (copied_size == 0) {
 		rz_bv_fini(&tmp);
 		return false;
 	}
 
-	rz_bv_copy(&tmp, bv);
+	rz_bv_copy(bv, &tmp);
 	rz_bv_fini(&tmp);
 
 	return true;
@@ -1182,7 +1182,7 @@ RZ_API bool rz_bv_mul_inplace(RZ_NONNULL RZ_INOUT RzBitVector *x, const RZ_NONNU
 	rz_return_val_if_fail(x && y, false);
 	RzBitVector dup;
 	rz_bv_init(&dup, x->len);
-	rz_bv_copy(x, &dup);
+	rz_bv_copy(&dup, x);
 	rz_bv_set_all(x, false);
 
 	bool cur_bit = false;
@@ -1296,10 +1296,10 @@ RZ_API bool rz_bv_div_inplace(RZ_NONNULL RZ_INOUT RzBitVector *x, const RZ_NONNU
 	// do typical division by shift and subtract
 	RzBitVector dend;
 	rz_bv_init(&dend, x->len);
-	rz_bv_copy(x, &dend);
+	rz_bv_copy(&dend, x);
 	RzBitVector sor;
 	rz_bv_init(&sor, y->len);
-	rz_bv_copy(y, &sor);
+	rz_bv_copy(&sor, y);
 
 	// shift the divisor left to align both highest bits
 	ut32 sorlz = rz_bv_clz(&sor);
@@ -1314,7 +1314,7 @@ RZ_API bool rz_bv_div_inplace(RZ_NONNULL RZ_INOUT RzBitVector *x, const RZ_NONNU
 			// sub_inplace() negates sor_cpy
 			RzBitVector sor_cpy;
 			rz_bv_init(&sor_cpy, y->len);
-			rz_bv_copy(&sor, &sor_cpy);
+			rz_bv_copy(&sor_cpy, &sor);
 			rz_bv_sub_inplace(&dend, &sor_cpy, NULL);
 			rz_bv_fini(&sor_cpy);
 		}
@@ -1360,7 +1360,7 @@ RZ_API bool rz_bv_mod_inplace(RZ_NONNULL RZ_INOUT RzBitVector *x, const RZ_NONNU
 	}
 	RzBitVector remul;
 	rz_bv_init(&remul, rz_bv_len(x));
-	rz_bv_copy(x, &remul);
+	rz_bv_copy(&remul, x);
 
 	if (!rz_bv_div_inplace(&remul, y)) {
 		rz_bv_fini(&remul);
@@ -2177,7 +2177,7 @@ RZ_API RzBitVector *rz_bv_cast(RZ_NONNULL RzBitVector *bv, ut32 to_size, bool fi
 
 	RzBitVector *ret = rz_bv_new(to_size);
 	rz_bv_set_all(ret, fill_bit);
-	rz_bv_copy_nbits(bv, 0, ret, 0, RZ_MIN(bv->len, to_size));
+	rz_bv_copy_nbits(ret, 0, bv, 0, RZ_MIN(bv->len, to_size));
 
 	return ret;
 }

--- a/librz/util/float/float.c
+++ b/librz/util/float/float.c
@@ -753,7 +753,7 @@ RZ_API RZ_OWN RzFloat *rz_float_new_from_bv(RZ_NONNULL const RzBitVector *bv) {
 		return NULL;
 	}
 
-	rz_bv_copy(bv, f->s);
+	rz_bv_copy(f->s, bv);
 	return f;
 }
 
@@ -1641,7 +1641,7 @@ RZ_API RZ_OWN RzBitVector *rz_float_cast_sint(RZ_NONNULL RzFloat *f, ut32 length
 
 	// WARN: possible overflow if length < exp_no_bias
 	// WARN: higher bits may be cut off
-	rz_bv_copy_nbits(rounded, 0, ret, 0, rz_bv_len(rounded));
+	rz_bv_copy_nbits(ret, 0, rounded, 0, rz_bv_len(rounded));
 	rz_bv_free(rounded);
 	return ret;
 }

--- a/librz/util/float/float_internal.c
+++ b/librz/util/float/float_internal.c
@@ -139,7 +139,7 @@ static RZ_OWN RzBitVector *get_exp(RZ_NONNULL RzBitVector *bv, RzFloatFormat for
 		RZ_LOG_ERROR("rz_float : failed to create bitvector");
 		return NULL;
 	}
-	rz_bv_copy_nbits(bv, man_len, res, 0, exp_len);
+	rz_bv_copy_nbits(res, 0, bv, man_len, exp_len);
 
 	return res;
 }
@@ -160,7 +160,7 @@ static RZ_OWN RzBitVector *get_man(RZ_NONNULL RzBitVector *bv, RzFloatFormat for
 		RZ_LOG_ERROR("rz_float : failed to create bitvector");
 		return NULL;
 	}
-	rz_bv_copy_nbits(bv, 0, res, 0, man_len);
+	rz_bv_copy_nbits(res, 0, bv, 0, man_len);
 
 	return res;
 }
@@ -181,7 +181,7 @@ static RZ_OWN RzBitVector *get_man_stretched(RZ_NONNULL RzBitVector *bv, RzFloat
 		RZ_LOG_ERROR("rz_float : failed to create bitvector");
 		return NULL;
 	}
-	rz_bv_copy_nbits(bv, 0, res, 0, man_len);
+	rz_bv_copy_nbits(res, 0, bv, 0, man_len);
 
 	return res;
 }
@@ -202,7 +202,7 @@ static RZ_OWN RzBitVector *get_exp_squashed(RZ_NONNULL RzBitVector *bv, RzFloatF
 		RZ_LOG_ERROR("rz_float : failed to create bitvector");
 		return NULL;
 	}
-	rz_bv_copy_nbits(bv, man_len, res, 0, exp_len);
+	rz_bv_copy_nbits(res, 0, bv, man_len, exp_len);
 
 	return res;
 }
@@ -222,7 +222,7 @@ static RZ_OWN RzBitVector *get_man_squashed(RZ_NONNULL RzBitVector *bv, RzFloatF
 		RZ_LOG_ERROR("rz_float : failed to create bitvector");
 		return NULL;
 	}
-	rz_bv_copy_nbits(bv, 0, res, 0, man_len);
+	rz_bv_copy_nbits(res, 0, bv, 0, man_len);
 	return res;
 }
 
@@ -261,7 +261,7 @@ static RZ_OWN RzBitVector *pack_float_bv(bool sign, RZ_BORROW RZ_NONNULL const R
 	RzBitVector *ret = rz_bv_new(total);
 
 	// copy exp to ret
-	rz_bv_copy_nbits(exp, 0, ret, man_len, exp_len);
+	rz_bv_copy_nbits(ret, man_len, exp, 0, exp_len);
 
 	if (format == RZ_FLOAT_IEEE754_BIN_80) {
 		/* 80-bit floats have a special bit at position 63 (man_len) which is
@@ -269,9 +269,9 @@ static RZ_OWN RzBitVector *pack_float_bv(bool sign, RZ_BORROW RZ_NONNULL const R
 		 * branching here. See https://en.wikipedia.org/wiki/Extended_precision
 		 * for more. */
 		rz_bv_set(ret, man_len - 1, true);
-		rz_bv_copy_nbits(sig, 1, ret, 0, man_len - 1);
+		rz_bv_copy_nbits(ret, 0, sig, 1, man_len - 1);
 	} else {
-		rz_bv_copy_nbits(sig, 0, ret, 0, man_len);
+		rz_bv_copy_nbits(ret, 0, sig, 0, man_len);
 	}
 
 	rz_bv_set(ret, total - 1, sign);
@@ -309,7 +309,7 @@ static RzBitVector *round_significant(bool sign, RzBitVector *sig, ut32 precisio
 		// 1. copy bv from sig to ret
 		// 2. align `ret` to `1 MM..M 000` form by shifting left
 		ret = rz_bv_new(ret_len);
-		rz_bv_copy_nbits(sig, 0, ret, ret_len - sig_len, sig_len);
+		rz_bv_copy_nbits(ret, ret_len - sig_len, sig, 0, sig_len);
 	} else {
 		// if it's greater than `ret`, right shift and cut
 		// use jammed version of right shift to get sticky bit

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -1351,19 +1351,19 @@ bool test_rz_bv_copy_nbits(void) {
 
 	/// copy part of bv to a new one with the same size
 	RzBitVector *small = rz_bv_new(part_sz);
-	actual_copy = rz_bv_copy_nbits(src, 0, small, 0, part_sz);
+	actual_copy = rz_bv_copy_nbits(small, 0, src, 0, part_sz);
 	mu_assert_eq(actual_copy, part_sz, "copy part_sz to normal");
 	mu_assert_streq_free(rz_bv_as_string(small), "11111111", "copy nbits small bv");
 
 	/// copy part of bv to a new one which has more spaces
 	RzBitVector *normal = rz_bv_new(size);
-	actual_copy = rz_bv_copy_nbits(src, 0, normal, 0, part_sz);
+	actual_copy = rz_bv_copy_nbits(normal, 0, src, 0, part_sz);
 	mu_assert_eq(actual_copy, part_sz, "copy part_sz bits to normal");
 	mu_assert_streq_free(rz_bv_as_string(normal), "00000000000011111111", "copy nbits normal length bv");
 
 	/// copy part of bv to the medium
 	RzBitVector *res = rz_bv_new(size);
-	actual_copy = rz_bv_copy_nbits(src, 0, res, 8, part_sz);
+	actual_copy = rz_bv_copy_nbits(res, 8, src, 0, part_sz);
 	mu_assert_eq(actual_copy, part_sz, "copy part_sz bits to medium");
 	mu_assert_streq_free(rz_bv_as_string(res), "00001111111100000000", "copy nbits to medium");
 
@@ -1373,13 +1373,13 @@ bool test_rz_bv_copy_nbits(void) {
 	/// expect : 0011 0000 1101 ... = 0x30d45678
 	RzBitVector *a = rz_bv_new_from_ut64(32, 0x12345678);
 	RzBitVector *b = rz_bv_new_from_ut64(32, 0x1986);
-	actual_copy = rz_bv_copy_nbits(b, 0, a, a->len - 11, 11);
+	actual_copy = rz_bv_copy_nbits(a, a->len - 11, b, 0, 11);
 	mu_assert_eq(actual_copy, 11, "copy non-zero 11 bits");
 	mu_assert_streq_free(rz_bv_as_hex_string(a, false), "0x30d45678", "copy non zero");
 
 	/// would fail (do nothing) if copy overflow is possible
 	RzBitVector *too_small = rz_bv_new(part_sz);
-	actual_copy = rz_bv_copy_nbits(src, 0, too_small, 0, part_sz + 2);
+	actual_copy = rz_bv_copy_nbits(too_small, 0, src, 0, part_sz + 2);
 	mu_assert_eq(actual_copy, 0, "copy 0 bits");
 	mu_assert_true(rz_bv_is_zero_vector(too_small), "copy nothing");
 
@@ -1420,25 +1420,25 @@ bool test_rz_bv_copy_nbits_inplace(void) {
 	RzBitVector *small_20 = rz_bv_new_from_ut64(20, 0x01234);
 	RzBitVector *large_128 = rz_bv_new_from_bytes_be(array_128, 0, 128);
 
-	mu_assert_eq(rz_bv_copy_nbits(small_20, 5, small_20, 1, 7), 7, "wrong num bits copied");
+	mu_assert_eq(rz_bv_copy_nbits(small_20, 1, small_20, 5, 7), 7, "wrong num bits copied");
 	mu_assert_eq(rz_bv_to_ut64(small_20), 0x01222, "Mismatch in place copy");
 	mu_assert_eq(rz_bv_copy_nbits(small_20, 0, small_20, 0, 21), 0, "copy overflow");
 	mu_assert_eq(rz_bv_to_ut64(small_20), 0x01222, "Mismatch in place copy");
-	mu_assert_eq(rz_bv_copy_nbits(small_20, 0, small_20, 1, 20), 0, "copy overflow");
-	mu_assert_eq(rz_bv_to_ut64(small_20), 0x01222, "Mismatch in place copy");
 	mu_assert_eq(rz_bv_copy_nbits(small_20, 1, small_20, 0, 20), 0, "copy overflow");
 	mu_assert_eq(rz_bv_to_ut64(small_20), 0x01222, "Mismatch in place copy");
+	mu_assert_eq(rz_bv_copy_nbits(small_20, 0, small_20, 1, 20), 0, "copy overflow");
+	mu_assert_eq(rz_bv_to_ut64(small_20), 0x01222, "Mismatch in place copy");
 	mu_assert_eq(rz_bv_copy_nbits(small_20, 0, small_20, 0, 20), 20, "one to one copy");
 	mu_assert_eq(rz_bv_to_ut64(small_20), 0x01222, "Mismatch in place copy");
 	mu_assert_eq(rz_bv_copy_nbits(small_20, 0, small_20, 0, 20), 20, "one to one copy");
 	mu_assert_eq(rz_bv_to_ut64(small_20), 0x01222, "Mismatch in place copy");
 
-	mu_assert_eq(rz_bv_copy_nbits(large_128, 0, large_128, 112, 16), 16, "wrong num bits copied");
+	mu_assert_eq(rz_bv_copy_nbits(large_128, 112, large_128, 0, 16), 16, "wrong num bits copied");
 	mu_assert_streq_free(rz_bv_as_hex_string(large_128, true), large_exp_1, "copy to limits aligned");
-	mu_assert_eq(rz_bv_copy_nbits(large_128, 1, large_128, 2, 7), 7, "wrong num bits copied");
+	mu_assert_eq(rz_bv_copy_nbits(large_128, 2, large_128, 1, 7), 7, "wrong num bits copied");
 	mu_assert_streq_free(rz_bv_as_hex_string(large_128, true), large_exp_2, "copy overlap unaligned");
 
-	mu_assert_eq(rz_bv_copy_nbits(large_128, 0, large_128, 120, 16), 0, "wrong num bits copied");
+	mu_assert_eq(rz_bv_copy_nbits(large_128, 120, large_128, 0, 16), 0, "wrong num bits copied");
 
 	rz_bv_free(small_20);
 	rz_bv_free(large_128);
@@ -1531,7 +1531,7 @@ bool test_rz_bv_cast_inplace(void) {
 /**
  * \brief Reference implementation of rz_bv_copy_nbits() to test against
  */
-static ut32 rz_bv_copy_nbits_ref(const RzBitVector *src, ut32 src_start_pos, RzBitVector *dst, ut32 dst_start_pos, ut32 nbit) {
+static ut32 rz_bv_copy_nbits_ref(RzBitVector *dst, ut32 dst_start_pos, const RzBitVector *src, ut32 src_start_pos, ut32 nbit) {
 	rz_return_val_if_fail(src && dst, 0);
 	ut32 max_nbit = RZ_MIN((src->len - src_start_pos), (dst->len - dst_start_pos));
 
@@ -1556,16 +1556,16 @@ static const char *test_rz_bv_copy_nbits_against_ref(const RzBitVector *src, ut3
 	RzBitVector *dst_copy_ref = rz_bv_new(rz_bv_len(dst));
 	const char *error = NULL;
 
-	rz_bv_copy(src, src_copy);
-	rz_bv_copy(dst, dst_copy);
-	rz_bv_copy(dst, dst_copy_ref);
+	rz_bv_copy(src_copy, src);
+	rz_bv_copy(dst_copy, dst);
+	rz_bv_copy(dst_copy_ref, dst);
 
-	if (rz_bv_copy_nbits(src_copy, src_pos, dst_copy, dst_pos, nbit) != nbit) {
+	if (rz_bv_copy_nbits(dst_copy, dst_pos, src_copy, src_pos, nbit) != nbit) {
 		error = "rz_bv_copy_nbits() incorrect number of bits copied";
 		goto finally;
 	}
 
-	if (rz_bv_copy_nbits_ref(src_copy, src_pos, dst_copy_ref, dst_pos, nbit) != nbit) {
+	if (rz_bv_copy_nbits_ref(dst_copy_ref, dst_pos, src_copy, src_pos, nbit) != nbit) {
 		error = "rz_bv_copy_nbits_ref() incorrect number of bits copied";
 		goto finally;
 	}
@@ -1576,11 +1576,11 @@ static const char *test_rz_bv_copy_nbits_against_ref(const RzBitVector *src, ut3
 	}
 
 	// Test with inverted src/dst for extra certainty
-	rz_bv_copy(dst, dst_copy);
+	rz_bv_copy(dst_copy, dst);
 	rz_bv_toggle_all(src_copy);
 	rz_bv_toggle_all(dst_copy);
 
-	if (rz_bv_copy_nbits(src_copy, src_pos, dst_copy, dst_pos, nbit) != nbit) {
+	if (rz_bv_copy_nbits(dst_copy, dst_pos, src_copy, src_pos, nbit) != nbit) {
 		error = "rz_bv_copy_nbits() incorrect number of bits copied";
 		goto finally;
 	}
@@ -1649,7 +1649,7 @@ bool test_rz_bv_copy_nbits_large_aligned(void) {
 
 	/// Copy bits within the same bitvector
 	rz_bv_set_from_ut64(b, 0xAAAABBBBCCCCDDDD);
-	ut32 actual_copy = rz_bv_copy_nbits(b, 8, b, 16, 32);
+	ut32 actual_copy = rz_bv_copy_nbits(b, 16, b, 8, 32);
 	mu_assert_eq(actual_copy, 32, "copy 32 bits");
 	mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xaaaabbccccdddddd", "copy large aligned");
 
@@ -1688,7 +1688,7 @@ bool test_rz_bv_copy_nbits_large_unaligned(void) {
 
 	/// Copy bits within the same bitvector
 	rz_bv_set_from_ut64(b, 0xAAAABBBBCCCCDDDD);
-	ut32 actual_copy = rz_bv_copy_nbits(b, 0, b, 2, 30);
+	ut32 actual_copy = rz_bv_copy_nbits(b, 2, b, 0, 30);
 	mu_assert_eq(actual_copy, 30, "copy 30 bits");
 	mu_assert_streq_free(rz_bv_as_hex_string(b, false), "0xaaaabbbb33337775", "copy large aligned");
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

This brings these copy functions in line with the more common order of dst, src as used in memcpy and rz_bv_*_inplace functions. This is a breaking change and callers of rz_bv_copy() and rz_bv_copy_nbits() must adjust to the new order.

**Test plan**

Existing tests should cover the callers.