### PR TITLE
Fix LE calling rz_bin_reloc_free when list values are LE_reloc

### DIFF
--- a/librz/bin/format/le/le.c
+++ b/librz/bin/format/le/le.c
@@ -1308,9 +1308,7 @@ static bool le_append_fixup(rz_bin_le_obj_t *bin, LE_reloc *reloc, RzList /*<RzB
 	return false;
 }
 
-static bool le_load_fixup_record(rz_bin_le_obj_t *bin, RzList /*<RzBinReloc *>*/ *relocs_out,
-	ut32 page_i, ut64 *offset, ut64 offset_end) {
-
+static bool le_load_fixup_record(rz_bin_le_obj_t *bin, RzList /*<RzBinReloc *>*/ *relocs_out, ut32 page_i, ut64 *offset, ut64 offset_end) {
 	LE_header *h = bin->header;
 	ut64 start_offset = *offset;
 	if (false) {
@@ -1459,8 +1457,8 @@ static bool le_load_fixup_record(rz_bin_le_obj_t *bin, RzList /*<RzBinReloc *>*/
 				if (src_off < 0 || src_off + 4 > h->pagesize || cnt > h->pagesize) {
 					RZ_LOG_WARN("LE: malformed or circular fixup chain at 0x%" PFMT64x ".\n",
 						start_paddr);
-					while (relocs_out->tail != prev_tail) {
-						rz_bin_reloc_free(rz_list_pop(relocs_out));
+					while (rz_list_tail(relocs_out) != prev_tail) {
+						free(rz_list_pop(relocs_out));
 					}
 					break;
 				}

--- a/librz/bin/format/le/le.c
+++ b/librz/bin/format/le/le.c
@@ -1282,7 +1282,7 @@ static bool le_patch_relocs(rz_bin_le_obj_t *bin) {
 	return true;
 }
 
-static bool le_append_fixup(rz_bin_le_obj_t *bin, LE_reloc *reloc, RzList /*<RzBinReloc *>*/ *out, bool skip_fixup) {
+static bool le_append_fixup(rz_bin_le_obj_t *bin, LE_reloc *reloc, RzList /*<LE_reloc *>*/ *out, bool skip_fixup) {
 	if (skip_fixup) {
 		return true; // Fixup has been parsed but contains invalid data, ignore and proceed
 	}
@@ -1308,7 +1308,7 @@ static bool le_append_fixup(rz_bin_le_obj_t *bin, LE_reloc *reloc, RzList /*<RzB
 	return false;
 }
 
-static bool le_load_fixup_record(rz_bin_le_obj_t *bin, RzList /*<RzBinReloc *>*/ *relocs_out, ut32 page_i, ut64 *offset, ut64 offset_end) {
+static bool le_load_fixup_record(rz_bin_le_obj_t *bin, RzList /*<LE_reloc *>*/ *relocs_out, ut32 page_i, ut64 *offset, ut64 offset_end) {
 	LE_header *h = bin->header;
 	ut64 start_offset = *offset;
 	if (false) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

The code called `rz_bin_reloc_free` when the type of data is `LE_reloc` and not `RzBinReloc`.

Caller is initialize the list as `rz_list_newf(free)`
```c
static RZ_OWN RzList /*<LE_reloc *>*/ *le_load_relocs(rz_bin_le_obj_t *bin) {
	RzList *relocs = rz_list_newf(free);
	if (!relocs) {
		return NULL;
	}
	for (ut32 pi = 0; pi < bin->header->mpages; pi++) {
		LE_page *page = &bin->le_pages[pi];
		ut64 off = page->fixup_page_start, end = page->fixup_page_end;
		while (off < end) {
			if (!le_load_fixup_record(bin, relocs, pi, &off, end)) {
				break; // malformed page, continue reading from the next page
			}
		}
	}
	return relocs;
}
```

Fix #5753