### PR TITLE
rz_assert: Restore control flow to rz_return assert-based macros

### DIFF
--- a/librz/include/rz_util/rz_assert.h
+++ b/librz/include/rz_util/rz_assert.h
@@ -178,18 +178,26 @@ RZ_API void rz_assert_log(RzLogLevel level, const char *fmt, ...) RZ_PRINTF_CHEC
 #define rz_return_if_fail(expr) \
 	do { \
 		assert(expr); \
+		if (!(expr)) { \
+			return; \
+		} \
 	} while (0)
 #define rz_return_val_if_fail(expr, val) \
 	do { \
 		assert(expr); \
+		if (!(expr)) { \
+			return (val); \
+		} \
 	} while (0)
 #define rz_return_if_reached() \
 	do { \
 		assert(false); \
+		return; \
 	} while (0)
 #define rz_return_val_if_reached(val) \
 	do { \
 		assert(false); \
+		return (val); \
 	} while (0)
 
 #define rz_goto_if_fail(expr, where) \


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

A C `assert()` can disappear if `NDEBUG` is (accidentally) set. This pr makes sure that control flow isn't changed in that situation, regarding the rz_assert `assert()`-based macros.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
