### PR TITLE
Refactor output mode to use type `RzOutputMode` and removed unused parts

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -25,12 +25,6 @@
 
 #define LOAD_BSS_MALLOC 0
 
-#define IS_MODE_SET(mode)      ((mode) & RZ_MODE_SET)
-#define IS_MODE_SIMPLE(mode)   ((mode) & RZ_MODE_SIMPLE)
-#define IS_MODE_SIMPLEST(mode) ((mode) & RZ_MODE_SIMPLEST)
-#define IS_MODE_JSON(mode)     ((mode) & RZ_MODE_JSON)
-#define IS_MODE_NORMAL(mode)   (!(mode))
-
 // dup from cmd_info
 #define PAIR_WIDTH "9"
 
@@ -78,20 +72,30 @@ RZ_API int rz_core_bin_set_by_fd(RzCore *core, ut64 bin_fd) {
 	return false;
 }
 
-RZ_API void rz_core_bin_export_info(RzCore *core, int mode) {
-	char *flagname = NULL, *offset = NULL;
+static Sdb *get_sdb_db(RzCore *core) {
 	RzBinFile *bf = rz_bin_cur(core->bin);
 	if (!bf) {
-		return;
+		return NULL;
 	}
 	Sdb *db = sdb_ns(bf->sdb, "info", 0);
 	if (!db) {
+		return NULL;
+	}
+	return db;
+}
+
+/**
+ * \brief Prints structured data formats.
+ *
+ * \param core A non null Pointer to the RzCore instance
+ */
+RZ_API void rz_core_bin_print_format(RZ_NONNULL RzCore *core) {
+	char *flagname = NULL;
+	Sdb *db;
+	db = get_sdb_db(core);
+	if (!db) {
 		return;
 	}
-	if (IS_MODE_SET(mode)) {
-		rz_flag_space_push(core->flags, "format");
-	}
-	// iterate over all keys
 	void **iter;
 	RzPVector *items = sdb_get_items(db, false);
 	rz_pvector_foreach (items, iter) {
@@ -99,65 +103,14 @@ RZ_API void rz_core_bin_export_info(RzCore *core, int mode) {
 		const char *k = sdbkv_key(kv);
 		const char *v = sdbkv_value(kv);
 		char *dup = rz_str_dup(k);
-		if ((flagname = strstr(dup, ".offset"))) {
-			*flagname = 0;
-			flagname = dup;
-			if (IS_MODE_SET(mode)) {
-				ut64 nv = rz_num_math(core->num, v);
-				rz_flag_set(core->flags, flagname, nv, 0);
-			}
-			free(offset);
-			offset = rz_str_dup(v);
-		}
-		if (strstr(dup, ".cparse")) {
-			if (IS_MODE_SET(mode)) {
-				char *code = rz_str_newf("%s;", v);
-				char *error_msg = NULL;
-				RzTypeDB *typedb = core->analysis->typedb;
-				int result = rz_type_parse_string_stateless(typedb->parser, code, &error_msg);
-				if (result && error_msg) {
-					rz_str_trim_tail(error_msg);
-					RZ_LOG_ERROR("core: %s\n", error_msg);
-					free(error_msg);
-				}
-			}
-		}
-		free(dup);
-	}
-	RZ_FREE(offset);
-	rz_pvector_foreach (items, iter) {
-		SdbKv *kv = *iter;
-		const char *k = sdbkv_key(kv);
-		const char *v = sdbkv_value(kv);
-		char *dup = rz_str_dup(k);
 		if ((flagname = strstr(dup, ".format"))) {
 			*flagname = 0;
-			if (!offset) {
-				offset = rz_str_dup("0");
-			}
-			flagname = dup;
-			if (IS_MODE_SET(mode)) {
-				rz_type_db_format_set(core->analysis->typedb, flagname, v);
-			}
-		}
-		free(dup);
-	}
-	rz_pvector_foreach (items, iter) {
-		SdbKv *kv = *iter;
-		const char *k = sdbkv_key(kv);
-		const char *v = sdbkv_value(kv);
-		char *dup = rz_str_dup(k);
-		if ((flagname = strstr(dup, ".format"))) {
-			*flagname = 0;
-			if (!offset) {
-				offset = rz_str_dup("0");
-			}
 			flagname = dup;
 			int fmtsize = rz_type_format_struct_size(core->analysis->typedb, v, 0, 0);
 			char *offset_key = rz_str_newf("%s.offset", flagname);
 			const char *off = sdb_const_get(db, offset_key);
 			free(offset_key);
-			if (off && IS_MODE_SET(mode)) {
+			if (off) {
 				ut64 addr = rz_num_get(NULL, off);
 				ut8 *buf = malloc(fmtsize);
 				if (buf) {
@@ -174,25 +127,82 @@ RZ_API void rz_core_bin_export_info(RzCore *core, int mode) {
 				}
 			}
 		}
+		free(dup);
+	}
+	rz_pvector_free(items);
+}
+
+/**
+ * \brief Export binary information from sdb to the core environment in set mode.
+ *
+ * \param core A non null Pointer to the RzCore instance
+ */
+RZ_API void rz_core_bin_set_export_info(RZ_NONNULL RzCore *core) {
+	char *flagname = NULL;
+	Sdb *db;
+	db = get_sdb_db(core);
+	if (!db) {
+		return;
+	}
+	rz_flag_space_push(core->flags, "format");
+	void **iter;
+	RzPVector *items = sdb_get_items(db, false);
+	rz_pvector_foreach (items, iter) {
+		SdbKv *kv = *iter;
+		const char *k = sdbkv_key(kv);
+		const char *v = sdbkv_value(kv);
+		char *dup = rz_str_dup(k);
+		if ((flagname = strstr(dup, ".offset"))) {
+			*flagname = 0;
+			flagname = dup;
+			ut64 nv = rz_num_math(core->num, v);
+			rz_flag_set(core->flags, flagname, nv, 0);
+		}
+		if (strstr(dup, ".cparse")) {
+			char *code = rz_str_newf("%s;", v);
+			char *error_msg = NULL;
+			RzTypeDB *typedb = core->analysis->typedb;
+			int result = rz_type_parse_string_stateless(typedb->parser, code, &error_msg);
+			if (result && error_msg) {
+				rz_str_trim_tail(error_msg);
+				RZ_LOG_ERROR("core: %s\n", error_msg);
+				free(error_msg);
+			}
+			free(code);
+		}
+		free(dup);
+	}
+	rz_pvector_foreach (items, iter) {
+		SdbKv *kv = *iter;
+		const char *k = sdbkv_key(kv);
+		const char *v = sdbkv_value(kv);
+		char *dup = rz_str_dup(k);
+		if ((flagname = strstr(dup, ".format"))) {
+			*flagname = 0;
+			flagname = dup;
+			rz_type_db_format_set(core->analysis->typedb, flagname, v);
+		}
+		free(dup);
+	}
+	rz_pvector_foreach (items, iter) {
+		SdbKv *kv = *iter;
+		const char *k = sdbkv_key(kv);
+		const char *v = sdbkv_value(kv);
+		char *dup = rz_str_dup(k);
 		if ((flagname = strstr(dup, ".size"))) {
 			*flagname = 0;
 			flagname = dup;
-			if (IS_MODE_SET(mode)) {
-				RzFlagItem *fi = rz_flag_get(core->flags, flagname);
-				if (fi) {
-					fi->size = rz_num_math(core->num, v);
-				} else {
-					RZ_LOG_ERROR("core: cannot find flag named '%s'\n", flagname);
-				}
+			RzFlagItem *fi = rz_flag_get(core->flags, flagname);
+			if (fi) {
+				fi->size = rz_num_math(core->num, v);
+			} else {
+				RZ_LOG_ERROR("core: cannot find flag named '%s'\n", flagname);
 			}
 		}
 		free(dup);
 	}
-	free(offset);
 	rz_pvector_free(items);
-	if (IS_MODE_SET(mode)) {
-		rz_flag_space_pop(core->flags);
-	}
+	rz_flag_space_pop(core->flags);
 }
 
 RZ_API bool rz_core_bin_load_structs(RZ_NONNULL RzCore *core, RZ_NONNULL const char *file) {
@@ -207,7 +217,7 @@ RZ_API bool rz_core_bin_load_structs(RZ_NONNULL RzCore *core, RZ_NONNULL const c
 		RZ_LOG_ERROR("core: cannot open bin '%s'\n", file);
 		return false;
 	}
-	rz_core_bin_export_info(core, RZ_MODE_SET);
+	rz_core_bin_set_export_info(core);
 	rz_bin_file_delete(core->bin, bf);
 	return true;
 }
@@ -4006,7 +4016,7 @@ RZ_API bool rz_core_bin_class_fields_print(RZ_NONNULL RzCore *core, RZ_NONNULL R
 		switch (state->mode) {
 		case RZ_OUTPUT_MODE_QUIET:
 			rz_list_foreach (c->fields, iter2, f) {
-				char *mflags = rz_core_bin_method_flags_str(f->flags, 0);
+				char *mflags = rz_core_bin_method_flags_str(f->flags, RZ_OUTPUT_MODE_STANDARD);
 				rz_cons_printf("0x%08" PFMT64x " field  %d %s %s %s\n", f->vaddr, m, c->name, mflags, f->name);
 				free(mflags);
 				m++;
@@ -4034,7 +4044,7 @@ RZ_API bool rz_core_bin_class_fields_print(RZ_NONNULL RzCore *core, RZ_NONNULL R
 			break;
 		case RZ_OUTPUT_MODE_TABLE:
 			rz_list_foreach (c->fields, iter2, f) {
-				char *mflags = rz_core_bin_method_flags_str(f->flags, 0);
+				char *mflags = rz_core_bin_method_flags_str(f->flags, RZ_OUTPUT_MODE_STANDARD);
 				rz_table_add_rowf(state->d.t, "Xissss", f->vaddr, m, c->name, mflags, f->name, f->type);
 				free(mflags);
 				m++;
@@ -4074,7 +4084,7 @@ RZ_API bool rz_core_bin_class_methods_print(RZ_NONNULL RzCore *core, RZ_NONNULL 
 
 		rz_list_foreach (c->methods, iter2, sym) {
 			const char *name = sym->dname ? sym->dname : sym->name;
-			char *mflags = rz_core_bin_method_flags_str(sym->method_flags, 0);
+			char *mflags = rz_core_bin_method_flags_str(sym->method_flags, RZ_OUTPUT_MODE_STANDARD);
 
 			switch (state->mode) {
 			case RZ_OUTPUT_MODE_QUIET:
@@ -4410,7 +4420,7 @@ RZ_API bool rz_core_bin_structured_data_print(RZ_NONNULL RzCore *core, RZ_NONNUL
 	return true;
 }
 
-static void bin_pe_versioninfo(RzCore *r, PJ *pj, int mode) {
+static void bin_pe_versioninfo(RzCore *r, PJ *pj, RzOutputMode mode) {
 	Sdb *sdb = NULL;
 	int num_version = 0;
 	int num_stringtable = 0;
@@ -4419,7 +4429,7 @@ static void bin_pe_versioninfo(RzCore *r, PJ *pj, int mode) {
 	const char *format_version = "bin/cur/info/vs_version_info/VS_VERSIONINFO%d";
 	const char *format_stringtable = "%s/string_file_info/stringtable%d";
 	const char *format_string = "%s/string%d";
-	if (!IS_MODE_JSON(mode)) {
+	if (mode != RZ_OUTPUT_MODE_JSON) {
 		rz_cons_printf("=== VS_VERSIONINFO ===\n\n");
 	} else {
 		pj_o(pj);
@@ -4429,14 +4439,14 @@ static void bin_pe_versioninfo(RzCore *r, PJ *pj, int mode) {
 		if (!sdb_ns_path(r->sdb, path_version, 0)) {
 			break;
 		}
-		if (IS_MODE_JSON(mode)) {
+		if (mode == RZ_OUTPUT_MODE_JSON) {
 			pj_ko(pj, "VS_FIXEDFILEINFO");
 		} else {
 			rz_cons_printf("# VS_FIXEDFILEINFO\n\n");
 		}
 		char *path_fixedfileinfo = rz_str_newf("%s/fixed_file_info", path_version);
 		if (!(sdb = sdb_ns_path(r->sdb, path_fixedfileinfo, 0))) {
-			if (IS_MODE_JSON(mode)) {
+			if (mode == RZ_OUTPUT_MODE_JSON) {
 				pj_end(pj);
 			}
 			free(path_fixedfileinfo);
@@ -4451,7 +4461,7 @@ static void bin_pe_versioninfo(RzCore *r, PJ *pj, int mode) {
 		ut32 product_version_ls = sdb_num_get(sdb, "ProductVersionLS");
 		char *product_version = rz_str_newf("%u.%u.%u.%u", product_version_ms >> 16, product_version_ms & 0xFFFF,
 			product_version_ls >> 16, product_version_ls & 0xFFFF);
-		if (IS_MODE_JSON(mode)) {
+		if (mode == RZ_OUTPUT_MODE_JSON) {
 			pj_kn(pj, "Signature", sdb_num_get(sdb, "Signature"));
 			pj_kn(pj, "StrucVersion", sdb_num_get(sdb, "StrucVersion"));
 			pj_ks(pj, "FileVersion", file_version);
@@ -4483,7 +4493,7 @@ static void bin_pe_versioninfo(RzCore *r, PJ *pj, int mode) {
 			sdb_num_get (sdb, "FileDateLS", 0) >> 16,
 			sdb_num_get (sdb, "FileDateLS", 0) & 0xFFFF);
 #endif
-		if (IS_MODE_JSON(mode)) {
+		if (mode == RZ_OUTPUT_MODE_JSON) {
 			pj_ko(pj, "StringTable");
 		} else {
 			rz_cons_printf("# StringTable\n\n");
@@ -4503,7 +4513,7 @@ static void bin_pe_versioninfo(RzCore *r, PJ *pj, int mode) {
 					ut8 *val_utf8 = rz_str_utf16_to_utf8(val_utf16, lenval, false);
 					if (!key_utf8 || !val_utf8 || !key_utf16 || !val_utf16) {
 						RZ_LOG_WARN("core: cannot decode utf16 to utf8\n");
-					} else if (IS_MODE_JSON(mode)) {
+					} else if (mode == RZ_OUTPUT_MODE_JSON) {
 						pj_ks(pj, (char *)key_utf8, (char *)val_utf8);
 					} else {
 						rz_cons_printf("  %s: %s\n", (char *)key_utf8, (char *)val_utf8);
@@ -4517,23 +4527,23 @@ static void bin_pe_versioninfo(RzCore *r, PJ *pj, int mode) {
 			}
 			free(path_stringtable);
 		}
-		if (IS_MODE_JSON(mode)) {
+		if (mode == RZ_OUTPUT_MODE_JSON) {
 			pj_end(pj);
 		}
 		num_version++;
 	} while (sdb);
-	if (IS_MODE_JSON(mode)) {
+	if (mode == RZ_OUTPUT_MODE_JSON) {
 		pj_end(pj);
 	}
 }
 
-static void bin_elf_versioninfo_versym(RzCore *r, PJ *pj, int mode) {
+static void bin_elf_versioninfo_versym(RzCore *r, PJ *pj, RzOutputMode mode) {
 	Sdb *sdb = sdb_ns_path(r->sdb, "bin/cur/info/versioninfo/versym", 0);
 	if (!sdb) {
 		return;
 	}
 
-	if (IS_MODE_JSON(mode)) {
+	if (mode == RZ_OUTPUT_MODE_JSON) {
 		pj_ka(pj, "versym"); // "versym": [
 	}
 
@@ -4541,7 +4551,7 @@ static void bin_elf_versioninfo_versym(RzCore *r, PJ *pj, int mode) {
 	const ut64 offset = sdb_num_get(sdb, "offset");
 	const ut64 num_entries = sdb_num_get(sdb, "num_entries");
 
-	if (IS_MODE_JSON(mode)) {
+	if (mode == RZ_OUTPUT_MODE_JSON) {
 		pj_o(pj); // {
 		pj_kn(pj, "address", addr);
 		pj_kn(pj, "offset", offset);
@@ -4561,7 +4571,7 @@ static void bin_elf_versioninfo_versym(RzCore *r, PJ *pj, int mode) {
 			continue;
 		}
 
-		if (IS_MODE_JSON(mode)) {
+		if (mode == RZ_OUTPUT_MODE_JSON) {
 			pj_o(pj);
 			pj_kn(pj, "idx", (ut64)i);
 			pj_ks(pj, "value", value);
@@ -4572,7 +4582,7 @@ static void bin_elf_versioninfo_versym(RzCore *r, PJ *pj, int mode) {
 		}
 	}
 
-	if (IS_MODE_JSON(mode)) {
+	if (mode == RZ_OUTPUT_MODE_JSON) {
 		pj_end(pj); // ] entries
 		pj_end(pj); // }
 		pj_end(pj); // ] versym
@@ -4581,7 +4591,7 @@ static void bin_elf_versioninfo_versym(RzCore *r, PJ *pj, int mode) {
 	}
 }
 
-static void bin_elf_versioninfo_verneed(RzCore *r, PJ *pj, int mode) {
+static void bin_elf_versioninfo_verneed(RzCore *r, PJ *pj, RzOutputMode mode) {
 	char tmpbuf[512] = { 0 };
 
 	Sdb *sdb = sdb_ns_path(r->sdb, "bin/cur/info/versioninfo/verneed", 0);
@@ -4589,14 +4599,14 @@ static void bin_elf_versioninfo_verneed(RzCore *r, PJ *pj, int mode) {
 		return;
 	}
 
-	if (IS_MODE_JSON(mode)) {
+	if (mode == RZ_OUTPUT_MODE_JSON) {
 		pj_ka(pj, "verneed"); // "verneed": 1[
 	}
 
 	const ut64 address = sdb_num_get(sdb, "addr");
 	const ut64 offset = sdb_num_get(sdb, "offset");
 
-	if (IS_MODE_JSON(mode)) {
+	if (mode == RZ_OUTPUT_MODE_JSON) {
 		pj_o(pj); // 1{
 		pj_kn(pj, "address", address);
 		pj_kn(pj, "offset", offset);
@@ -4621,7 +4631,7 @@ static void bin_elf_versioninfo_verneed(RzCore *r, PJ *pj, int mode) {
 			break;
 		}
 
-		if (IS_MODE_JSON(mode)) {
+		if (mode == RZ_OUTPUT_MODE_JSON) {
 			pj_o(pj); // 2{
 			pj_kn(pj, "idx", sdb_num_get(sdb, "idx"));
 			pj_ki(pj, "vn_version", (int)sdb_num_get(sdb, "vn_version"));
@@ -4631,7 +4641,7 @@ static void bin_elf_versioninfo_verneed(RzCore *r, PJ *pj, int mode) {
 		}
 
 		if ((filename = sdb_const_get(sdb, "file_name"))) {
-			if (IS_MODE_JSON(mode)) {
+			if (mode == RZ_OUTPUT_MODE_JSON) {
 				pj_ks(pj, "file_name", filename);
 			} else {
 				rz_cons_printf("  File: %s", filename);
@@ -4640,13 +4650,13 @@ static void bin_elf_versioninfo_verneed(RzCore *r, PJ *pj, int mode) {
 
 		const int cnt = (int)sdb_num_get(sdb, "cnt");
 
-		if (IS_MODE_JSON(mode)) {
+		if (mode == RZ_OUTPUT_MODE_JSON) {
 			pj_ki(pj, "cnt", cnt);
 		} else {
 			rz_cons_printf("  Cnt: %d\n", cnt);
 		}
 
-		if (IS_MODE_JSON(mode)) {
+		if (mode == RZ_OUTPUT_MODE_JSON) {
 			pj_ka(pj, "vernaux"); // "vernaux": 3[
 		}
 
@@ -4665,7 +4675,7 @@ static void bin_elf_versioninfo_verneed(RzCore *r, PJ *pj, int mode) {
 			const char *const flags = sdb_const_get(sdb, "flags");
 			const int version = (int)sdb_num_get(sdb, "version");
 
-			if (IS_MODE_JSON(mode)) {
+			if (mode == RZ_OUTPUT_MODE_JSON) {
 				pj_o(pj);
 				pj_kn(pj, "idx", idx);
 				pj_ks(pj, "name", name);
@@ -4678,39 +4688,39 @@ static void bin_elf_versioninfo_verneed(RzCore *r, PJ *pj, int mode) {
 			}
 		} while (sdb);
 
-		if (IS_MODE_JSON(mode)) {
+		if (mode == RZ_OUTPUT_MODE_JSON) {
 			pj_end(pj); // 3] vernaux
 			pj_end(pj); // 2}
 		}
 	}
 
-	if (IS_MODE_JSON(mode)) {
+	if (mode == RZ_OUTPUT_MODE_JSON) {
 		pj_end(pj); // 2] entries
 		pj_end(pj); // 1}
 		pj_end(pj); // 1] verneed
 	}
 }
 
-static void bin_elf_versioninfo(RzCore *r, PJ *pj, int mode) {
-	if (IS_MODE_JSON(mode)) {
+static void bin_elf_versioninfo(RzCore *r, PJ *pj, RzOutputMode mode) {
+	if (mode == RZ_OUTPUT_MODE_JSON) {
 		pj_o(pj);
 	}
 	bin_elf_versioninfo_versym(r, pj, mode);
 	bin_elf_versioninfo_verneed(r, pj, mode);
-	if (IS_MODE_JSON(mode)) {
+	if (mode == RZ_OUTPUT_MODE_JSON) {
 		pj_end(pj);
 	}
 }
 
-static void bin_mach0_versioninfo(RzCore *r, PJ *pj, int mode) {
+static void bin_mach0_versioninfo(RzCore *r, PJ *pj, RzOutputMode mode) {
 	/* TODO */
-	if (IS_MODE_JSON(mode)) {
+	if (mode == RZ_OUTPUT_MODE_JSON) {
 		pj_o(pj);
 		pj_end(pj);
 	}
 }
 
-static int bin_versioninfo(RzCore *r, PJ *pj, int mode) {
+static int bin_versioninfo(RzCore *r, PJ *pj, RzOutputMode mode) {
 	RzBinObject *obj = rz_bin_cur_object(r->bin);
 	const RzBinInfo *info = obj ? rz_bin_object_get_info(obj) : NULL;
 	if (!info || !info->rclass) {
@@ -4723,7 +4733,7 @@ static int bin_versioninfo(RzCore *r, PJ *pj, int mode) {
 	} else if (!strncmp("mach0", info->rclass, 5)) {
 		bin_mach0_versioninfo(r, pj, mode);
 	} else {
-		if (IS_MODE_JSON(mode)) {
+		if (mode == RZ_OUTPUT_MODE_JSON) {
 			pj_o(pj);
 			pj_end(pj);
 		} else {
@@ -4999,12 +5009,20 @@ RZ_API RZ_OWN char *rz_core_bin_field_build_flag_name(RZ_NONNULL RzBinClass *cls
 	return ret;
 }
 
-RZ_API char *rz_core_bin_method_flags_str(ut64 flags, int mode) {
+/**
+ * \brief Generates a string representation of flags
+ *
+ * \param flags Bitmasked Binary Method flags.
+ * \param mode Type to print output
+ *
+ * \return identified flag in string format
+ */
+RZ_API char *rz_core_bin_method_flags_str(ut64 flags, RzOutputMode mode) {
 	int i;
 	char tmpbuf[16];
 
 	RzStrBuf *buf = rz_strbuf_new("");
-	if (IS_MODE_JSON(mode)) {
+	if (mode == RZ_OUTPUT_MODE_JSON) {
 		if (!flags) {
 			rz_strbuf_append(buf, "[]");
 			goto out;
@@ -5394,10 +5412,10 @@ RZ_API bool rz_core_bin_versions_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBin
 	// TODO: add rz_bin_object_get_versions and switch to table + json output
 	switch (state->mode) {
 	case RZ_OUTPUT_MODE_STANDARD:
-		bin_versioninfo(core, NULL, RZ_MODE_PRINT);
+		bin_versioninfo(core, NULL, RZ_OUTPUT_MODE_STANDARD);
 		break;
 	case RZ_OUTPUT_MODE_JSON:
-		bin_versioninfo(core, state->d.pj, RZ_MODE_JSON);
+		bin_versioninfo(core, state->d.pj, RZ_OUTPUT_MODE_JSON);
 		break;
 	default:
 		rz_warn_if_reached();

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -85,55 +85,7 @@ static Sdb *get_sdb_db(RzCore *core) {
 }
 
 /**
- * \brief Prints structured data formats.
- *
- * \param core A non null Pointer to the RzCore instance
- */
-RZ_API void rz_core_bin_print_format(RZ_NONNULL RzCore *core) {
-	char *flagname = NULL;
-	Sdb *db;
-	db = get_sdb_db(core);
-	if (!db) {
-		return;
-	}
-	void **iter;
-	RzPVector *items = sdb_get_items(db, false);
-	rz_pvector_foreach (items, iter) {
-		SdbKv *kv = *iter;
-		const char *k = sdbkv_key(kv);
-		const char *v = sdbkv_value(kv);
-		char *dup = rz_str_dup(k);
-		if ((flagname = strstr(dup, ".format"))) {
-			*flagname = 0;
-			flagname = dup;
-			int fmtsize = rz_type_format_struct_size(core->analysis->typedb, v, 0, 0);
-			char *offset_key = rz_str_newf("%s.offset", flagname);
-			const char *off = sdb_const_get(db, offset_key);
-			free(offset_key);
-			if (off) {
-				ut64 addr = rz_num_get(NULL, off);
-				ut8 *buf = malloc(fmtsize);
-				if (buf) {
-					rz_io_read_at_mapped(core->io, addr, buf, fmtsize);
-					char *format = rz_type_format_data(core->analysis->typedb, core->print, addr, buf,
-						fmtsize, v, 0, NULL, NULL);
-					free(buf);
-					if (!format) {
-						RZ_LOG_WARN("core: cannot register invalid format (%s)\n", v);
-					} else {
-						rz_cons_print(format);
-						free(format);
-					}
-				}
-			}
-		}
-		free(dup);
-	}
-	rz_pvector_free(items);
-}
-
-/**
- * \brief Export binary information from sdb to the core environment in set mode.
+ * \brief Imports binary metadata from the sdb and sets the RzCore flag and RzTypeDB database
  *
  * \param core A non null Pointer to the RzCore instance
  */

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -1509,7 +1509,7 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_set_random_palette_handler(RzCore *core, in
 RZ_IPI RzCmdStatus rz_cmd_eval_color_set_colorful_palette_handler(RzCore *core, int argc, const char **argv);
 // "eco"
 RZ_IPI RzCmdStatus rz_cmd_eval_color_load_theme_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
-RZ_IPI RZ_OWN char **rz_core_autocomplete_rotate_theme(RzCore *core);
+RZ_IPI char **rz_core_autocomplete_rotate_theme(RzCore *core);
 // "eco."
 RZ_IPI RzCmdStatus rz_cmd_eval_color_list_current_theme_handler(RzCore *core, int argc, const char **argv);
 // "ecoo"

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -1509,7 +1509,7 @@ RZ_IPI RzCmdStatus rz_cmd_eval_color_set_random_palette_handler(RzCore *core, in
 RZ_IPI RzCmdStatus rz_cmd_eval_color_set_colorful_palette_handler(RzCore *core, int argc, const char **argv);
 // "eco"
 RZ_IPI RzCmdStatus rz_cmd_eval_color_load_theme_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
-RZ_IPI char **rz_core_autocomplete_rotate_theme(RzCore *core);
+RZ_IPI RZ_OWN char **rz_core_autocomplete_rotate_theme(RzCore *core);
 // "eco."
 RZ_IPI RzCmdStatus rz_cmd_eval_color_list_current_theme_handler(RzCore *core, int argc, const char **argv);
 // "ecoo"

--- a/librz/core/tui/classes.c
+++ b/librz/core/tui/classes.c
@@ -162,7 +162,7 @@ static void *show_class(RzCore *core, TuiClassMode mode, int *idx, RzBinClass *_
 				}
 			}
 
-			mflags = rz_core_bin_method_flags_str(m->method_flags, 0);
+			mflags = rz_core_bin_method_flags_str(m->method_flags, RZ_OUTPUT_MODE_STANDARD);
 
 			if (show_color) {
 				if (rz_str_startswith(name, _c->name)) {

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -990,7 +990,8 @@ RZ_API bool rz_core_bin_apply_all_info(RzCore *r, RzBinFile *binfile);
 RZ_API int rz_core_bin_set_by_fd(RzCore *core, ut64 bin_fd);
 RZ_API int rz_core_bin_set_by_name(RzCore *core, const char *name);
 RZ_API bool rz_core_bin_load(RZ_NONNULL RzCore *core, RZ_NULLABLE const char *file_uri, ut64 base_addr);
-RZ_API void rz_core_bin_export_info(RzCore *core, int mode);
+RZ_API void rz_core_bin_print_format(RZ_NONNULL RzCore *core);
+RZ_API void rz_core_bin_set_export_info(RZ_NONNULL RzCore *core);
 RZ_API bool rz_core_binfiles_print(RzCore *core, RzCmdStateOutput *state);
 RZ_API bool rz_core_binfiles_delete(RzCore *core, RzBinFile *bf);
 RZ_API RZ_OWN HtSS *rz_core_bin_create_digests(RzCore *core, ut64 paddr, ut64 size, RzList /*<char *>*/ *digests);
@@ -1075,7 +1076,7 @@ RZ_API RZ_OWN char *rz_core_bin_class_build_flag_name(RZ_NONNULL RzBinClass *cls
 RZ_API RZ_OWN char *rz_core_bin_super_build_flag_name(RZ_NONNULL RzBinClass *cls);
 RZ_API RZ_OWN char *rz_core_bin_method_build_flag_name(RZ_NONNULL RzBinClass *cls, RZ_NONNULL RzBinSymbol *meth);
 RZ_API RZ_OWN char *rz_core_bin_field_build_flag_name(RZ_NONNULL RzBinClass *cls, RZ_NONNULL RzBinClassField *field);
-RZ_API char *rz_core_bin_method_flags_str(ut64 flags, int mode);
+RZ_API char *rz_core_bin_method_flags_str(ut64 flags, RzOutputMode mode);
 RZ_API RZ_OWN char *rz_core_bin_pdb_get_filename(RZ_NONNULL RzCore *core);
 RZ_API bool rz_core_bin_pdb_load(RZ_NONNULL RzCore *core, RZ_NONNULL const char *filename);
 RZ_API RzPdb *rz_core_pdb_load_info(RZ_NONNULL RzCore *core, RZ_NONNULL const char *file);

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -25,13 +25,6 @@ extern "C" {
 #undef __UNIX__
 #undef __WINDOWS__
 
-// TODO: these modes should be dropped when oldshell is removed in favour of RzOutputMode.
-#define RZ_MODE_PRINT    0x000
-#define RZ_MODE_SET      0x002
-#define RZ_MODE_SIMPLE   0x004
-#define RZ_MODE_JSON     0x008
-#define RZ_MODE_SIMPLEST 0x020
-
 #define RZ_IN    /* do not use, implicit */
 #define RZ_OUT   /* parameter is written, not read */
 #define RZ_INOUT /* parameter is read and written / return value is copy of RZ_INOUT parameter */

--- a/librz/main/rz-bin.c
+++ b/librz/main/rz-bin.c
@@ -60,20 +60,6 @@ static void classes_as_source_print(RzCore *core, RzCmdStateOutput *state) {
 	}
 }
 
-static RzOutputMode rad2outputmode(int rad) {
-	switch (rad) {
-	case RZ_MODE_JSON:
-		return RZ_OUTPUT_MODE_JSON;
-	case RZ_MODE_SIMPLE:
-		return RZ_OUTPUT_MODE_QUIET;
-	case RZ_MODE_SIMPLEST:
-		return RZ_OUTPUT_MODE_QUIETEST;
-	case RZ_MODE_PRINT:
-	default:
-		return RZ_OUTPUT_MODE_STANDARD;
-	}
-}
-
 static ut32 actions2mask(ut64 action) {
 	ut32 res = 0;
 	if (action & RZ_BIN_REQ_SECTIONS) {
@@ -478,7 +464,7 @@ static bool __dumpSections(RzBin *bin, const char *scnname, const char *output, 
 	return true;
 }
 
-static int rzbin_do_operation(RzBin *bin, const char *op, int rad, const char *output, const char *file) {
+static int rzbin_do_operation(RzBin *bin, const char *op, const char *output, const char *file, RzOutputMode rad) {
 	char *arg = NULL, *ptr = NULL, *ptr2 = NULL;
 	bool rc = true;
 
@@ -549,7 +535,7 @@ static int rzbin_do_operation(RzBin *bin, const char *op, int rad, const char *o
 			}
 		}
 		if (plg && plg->signature) {
-			char *sign = plg->signature(cur, rad == RZ_MODE_JSON);
+			char *sign = plg->signature(cur, rad == RZ_OUTPUT_MODE_JSON);
 			if (sign) {
 				rz_cons_println(sign);
 				rz_cons_flush();
@@ -618,10 +604,10 @@ static bool lib_bin_xtr_dt(RzLibPlugin *pl, void *user, void *data) {
 	return rz_bin_xtr_plugin_del(user, (RzBinXtrPlugin *)data);
 }
 
-static void __listPlugins(RzBin *bin, const char *plugin_name, PJ *pj, int rad) {
+static void __listPlugins(RzBin *bin, const char *plugin_name, PJ *pj, RzOutputMode rad) {
 	int format = 0;
 	RzCmdStateOutput state = { 0 };
-	if (rad == RZ_MODE_JSON) {
+	if (rad == RZ_OUTPUT_MODE_JSON) {
 		format = 'j';
 		rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_JSON, NULL);
 	} else if (rad) {
@@ -647,7 +633,7 @@ static bool print_demangler_info(const RzDemanglerPlugin *plugin, RzDemanglerFla
 	return true;
 }
 
-static void print_string(RzBinFile *bf, RzBinString *string, PJ *pj, int mode) {
+static void print_string(RzBinFile *bf, RzBinString *string, PJ *pj, RzOutputMode mode) {
 	rz_return_if_fail(bf && string);
 
 	ut64 vaddr;
@@ -660,7 +646,7 @@ static void print_string(RzBinFile *bf, RzBinString *string, PJ *pj, int mode) {
 	const char *section_name = s ? s->name : "";
 
 	switch (mode) {
-	case RZ_MODE_JSON:
+	case RZ_OUTPUT_MODE_JSON:
 		pj_o(pj);
 		pj_kn(pj, "vaddr", vaddr);
 		pj_kn(pj, "paddr", string->paddr);
@@ -671,13 +657,13 @@ static void print_string(RzBinFile *bf, RzBinString *string, PJ *pj, int mode) {
 		pj_ks(pj, "string", string->string);
 		pj_end(pj);
 		break;
-	case RZ_MODE_SIMPLEST:
+	case RZ_OUTPUT_MODE_QUIETEST:
 		printf("%s\n", string->string);
 		break;
-	case RZ_MODE_SIMPLE:
+	case RZ_OUTPUT_MODE_QUIET:
 		printf("0x%" PFMT64x " %u %u %s\n", vaddr, string->size, string->length, string->string);
 		break;
-	case RZ_MODE_PRINT:
+	case RZ_OUTPUT_MODE_STANDARD:
 		printf("0x%08" PFMT64x " 0x%08" PFMT64x " %" PFMT32u " %" PFMT32u " (%s) %s %s\n",
 			string->paddr, vaddr,
 			string->length, string->size,
@@ -694,7 +680,7 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 	const char *name = NULL;
 	const char *file = NULL;
 	const char *output = NULL;
-	int out_mode = RZ_MODE_PRINT;
+	RzOutputMode out_mode = RZ_OUTPUT_MODE_STANDARD;
 	ut64 laddr = UT64_MAX;
 	ut64 baddr = UT64_MAX;
 	const char *do_demangle = NULL;
@@ -827,9 +813,9 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 		case 'T': set_action(RZ_BIN_REQ_SIGNATURE); break;
 		case 'w': set_action(RZ_BIN_REQ_TRYCATCH); break;
 		case 'q':
-			out_mode = (out_mode & RZ_MODE_SIMPLE ? RZ_MODE_SIMPLEST : RZ_MODE_SIMPLE);
+			out_mode = (out_mode & RZ_OUTPUT_MODE_QUIET ? RZ_OUTPUT_MODE_QUIETEST : RZ_OUTPUT_MODE_QUIET);
 			break;
-		case 'j': out_mode = RZ_MODE_JSON; break;
+		case 'j': out_mode = RZ_OUTPUT_MODE_JSON; break;
 		case 'A': set_action(RZ_BIN_REQ_LISTARCHS); break;
 		case 'a': arch = opt.arg; break;
 		case 'C':
@@ -1008,7 +994,7 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 			return 1;
 		}
 		__listPlugins(bin, plugin_name, pj, out_mode);
-		if (out_mode == RZ_MODE_JSON) {
+		if (out_mode == RZ_OUTPUT_MODE_JSON) {
 			rz_cons_println(pj_string(pj));
 			rz_cons_flush();
 		}
@@ -1216,7 +1202,7 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 
 	if (rawstr) {
 		PJ *pj = NULL;
-		if (out_mode == RZ_MODE_JSON) {
+		if (out_mode == RZ_OUTPUT_MODE_JSON) {
 			pj = pj_new();
 			if (!pj) {
 				eprintf("rz-bin: Cannot allocate buffer for json array\n");
@@ -1245,23 +1231,18 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 		rz_bin_object_reset_strings(bin, bf, bf->o);
 	}
 	if (query) {
-		if (out_mode) {
-			rz_core_bin_export_info(&core, RZ_MODE_PRINT);
-			rz_cons_flush();
+		if (!strcmp(query, "-")) {
+			__sdb_prompt(bin->cur->sdb);
 		} else {
-			if (!strcmp(query, "-")) {
-				__sdb_prompt(bin->cur->sdb);
-			} else {
-				sdb_query(bin->cur->sdb, query);
-			}
+			sdb_query(bin->cur->sdb, query);
 		}
 		result = 0;
 		goto err;
 	}
-#define ismodejson (out_mode == RZ_MODE_JSON && actions > 0)
+#define ismodejson (out_mode == RZ_OUTPUT_MODE_JSON && actions > 0)
 #define run_action(n, x, y) \
 	if (action & (x)) { \
-		RzCmdStateOutput *st = add_header(&state, mode, n, &core); \
+		RzCmdStateOutput *st = add_header(&state, out_mode, n, &core); \
 		y(&core, st); \
 		add_footer(&state, st); \
 	}
@@ -1281,8 +1262,7 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 	rz_cons_new()->context->is_interactive = false;
 
 	RzCmdStateOutput state;
-	RzOutputMode mode = rad2outputmode(out_mode);
-	if (!rz_cmd_state_output_init(&state, mode, &core)) {
+	if (!rz_cmd_state_output_init(&state, out_mode, &core)) {
 		result = 1;
 		goto chksum_err;
 	}
@@ -1290,7 +1270,7 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 
 	// List fatmach0 sub-binaries, etc
 	if (action & RZ_BIN_REQ_LISTARCHS || (arch && bits && !rz_bin_select(bin, arch, bits, machine, NULL))) {
-		RzCmdStateOutput *st = add_header(&state, mode == RZ_OUTPUT_MODE_STANDARD ? RZ_OUTPUT_MODE_TABLE : mode, "archs", &core);
+		RzCmdStateOutput *st = add_header(&state, out_mode == RZ_OUTPUT_MODE_STANDARD ? RZ_OUTPUT_MODE_TABLE : out_mode, "archs", &core);
 		rz_core_bin_archs_print(bin, st);
 		add_footer(&state, st);
 	}
@@ -1341,7 +1321,7 @@ RZ_API int rz_main_rz_bin(int argc, const char **argv) {
 		}
 	}
 	if (op && action & RZ_BIN_REQ_OPERATION) {
-		rzbin_do_operation(bin, op, out_mode, output, file);
+		rzbin_do_operation(bin, op, output, file, out_mode);
 	}
 	end_state(&state);
 	rz_cmd_state_output_fini(&state);

--- a/librz/main/rz-bin.c
+++ b/librz/main/rz-bin.c
@@ -464,7 +464,7 @@ static bool __dumpSections(RzBin *bin, const char *scnname, const char *output, 
 	return true;
 }
 
-static int rzbin_do_operation(RzBin *bin, const char *op, const char *output, const char *file, RzOutputMode rad) {
+static int rzbin_do_operation(RzBin *bin, const char *op, const char *output, const char *file, RzOutputMode mode) {
 	char *arg = NULL, *ptr = NULL, *ptr2 = NULL;
 	bool rc = true;
 
@@ -535,7 +535,7 @@ static int rzbin_do_operation(RzBin *bin, const char *op, const char *output, co
 			}
 		}
 		if (plg && plg->signature) {
-			char *sign = plg->signature(cur, rad == RZ_OUTPUT_MODE_JSON);
+			char *sign = plg->signature(cur, mode == RZ_OUTPUT_MODE_JSON);
 			if (sign) {
 				rz_cons_println(sign);
 				rz_cons_flush();
@@ -604,13 +604,13 @@ static bool lib_bin_xtr_dt(RzLibPlugin *pl, void *user, void *data) {
 	return rz_bin_xtr_plugin_del(user, (RzBinXtrPlugin *)data);
 }
 
-static void __listPlugins(RzBin *bin, const char *plugin_name, PJ *pj, RzOutputMode rad) {
+static void __listPlugins(RzBin *bin, const char *plugin_name, PJ *pj, RzOutputMode mode) {
 	int format = 0;
 	RzCmdStateOutput state = { 0 };
-	if (rad == RZ_OUTPUT_MODE_JSON) {
+	if (mode == RZ_OUTPUT_MODE_JSON) {
 		format = 'j';
 		rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_JSON, NULL);
-	} else if (rad) {
+	} else if (mode == RZ_OUTPUT_MODE_QUIET || mode == RZ_OUTPUT_MODE_QUIETEST) {
 		format = 'q';
 		rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_QUIET, NULL);
 	} else {

--- a/test/unit/test_core_bin.c
+++ b/test/unit/test_core_bin.c
@@ -602,6 +602,35 @@ bool test_cfile_close_manual_cfile_map_multiple(void) {
 	mu_end;
 }
 
+bool test_bin_set_export_info(void) {
+	RzCore *core = rz_core_new();
+	rz_bin_plugin_add(core->bin, &mock_plugin);
+
+	RzCoreFile *f = rz_core_file_open(core, "hex://424213374242", RZ_PERM_R, 0);
+	mu_assert_notnull(f, "load core file");
+
+	bool r = rz_core_bin_load(core, NULL, 0);
+	mu_assert_true(r, "core bin load");
+
+	RzBinFile *bf = rz_bin_cur(core->bin);
+	Sdb *sdb = sdb_ns(bf->sdb, "info", 0);
+
+	sdb_set(sdb, "my_item.offset", "0x200");
+	sdb_set(sdb, "my_item.format", "test_struct");
+	sdb_set(sdb, "my_item.size", "8");
+
+	rz_core_bin_set_export_info(core);
+
+	rz_flag_space_set(core->flags, "format");
+	RzFlagItem *fi = rz_flag_get(core->flags, "my_item");
+	mu_assert_notnull(fi, "flag 'my_item' should exist");
+	mu_assert_eq(fi->offset, 0x200, "flag offset");
+	mu_assert_eq(fi->size, 8, "flag size");
+
+	rz_core_free(core);
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_map);
 	mu_run_test(test_cfile_close);
@@ -611,6 +640,7 @@ bool all_tests() {
 	mu_run_test(test_cfile_close_manual_vfile_fd);
 	mu_run_test(test_cfile_close_manual_vfile_map);
 	mu_run_test(test_cfile_close_manual_cfile_map_multiple);
+	mu_run_test(test_bin_set_export_info);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

The `int mode` types are replaced with the `RzOutputMode mode` type in the below file , this PR also removes the hardcoded macro's used instead of `RzOutputMode mode`

[/librz/core/cbin.c](https://github.com/Arya-1-HR/rizin/blob/dev/librz/core/cbin.c)
[/librz/main/rz-bin.c](https://github.com/rizinorg/rizin/blob/dev/librz/main/rz-bin.c)

**Test plan**
Unit test has been added to validate new API addition (rz_core_bin_set_export_info) in `test/unit/test_core_bin.c`.

**Closing issues**

closes #489 