### PR TITLE
Make 6502 magic constant configurable

### DIFF
--- a/librz/arch/isa/6502/6502_il.inc
+++ b/librz/arch/isa/6502/6502_il.inc
@@ -615,12 +615,11 @@ static RzILOpEffect *_6502_il_op_lax(_6502ILAddr *addr) {
 /**
  * LAX #imm
  */
-static RzILOpEffect *_6502_il_op_laximm(_6502ILAddr *addr) {
+static RzILOpEffect *_6502_il_op_laximm(_6502ILAddr *addr, ut8 magic) {
 	RzILOpEffect *tax = _6502_il_op_transfer("x", "a", false);
-	RzILOpBitVector *magic_constant = U8(0xee);
+	RzILOpBitVector *magic_constant = U8(magic);
 	// magic_constant's value is highy unpredictable (dependent on time & temperature)
 	// Some common values are 0xff, 0xef, 0x00, ...
-	// FIXME: Should the value be assigned here randomly?
 
 	return SEQ3(
 		SETG("a", LOGAND(LOGOR(VARG("a"), magic_constant), UNSIGNED(8, addr->addr))),
@@ -751,11 +750,10 @@ static RzILOpEffect *_6502_il_op_tas(_6502ILAddr *addr) {
 /**
  * ANE
  */
-static RzILOpEffect *_6502_il_op_ane(_6502ILAddr *addr) {
-	RzILOpBitVector *magic_constant = U8(0xee);
+static RzILOpEffect *_6502_il_op_ane(_6502ILAddr *addr, ut8 magic) {
+	RzILOpBitVector *magic_constant = U8(magic);
 	// magic_constant's value is highy unpredictable (dependent on time & temperature)
 	// Some common values are 0xff, 0xef, 0x00, ...
-	// FIXME: Should the value be assigned here randomly?
 
 	return SEQ2(
 		SETG("a", LOGAND(LOGOR(VARG("a"), magic_constant), LOGAND(VARG("x"), UNSIGNED(8, addr->addr)))),

--- a/librz/arch/isa/6502/6502dis.c
+++ b/librz/arch/isa/6502/6502dis.c
@@ -8,6 +8,7 @@
 #include <rz_lib.h>
 #include <string.h>
 #include <snes/snes.h>
+#include "6502dis.h"
 
 static struct {
 	ut8 op;
@@ -181,4 +182,13 @@ int disass_6502(ut64 pc, RzAsmOp *op, const ut8 *buf, ut64 len) {
 	}
 beach:
 	return snesDisass(1, 1, pc, op, buf, len);
+}
+
+_6502State *_6502_state_new() {
+	_6502State *state = RZ_NEW0(_6502State);
+	if (!state) {
+		RZ_LOG_ERROR("Could not allocate memory for _6502State!");
+		return NULL;
+	}
+	return state;
 }

--- a/librz/arch/isa/6502/6502dis.h
+++ b/librz/arch/isa/6502/6502dis.h
@@ -4,8 +4,6 @@
 #ifndef DISASSEMBLE_6502_H
 #define DISASSEMBLE_6502_H
 
-#include <rz_asm.h>
-
 typedef struct {
 	RzConfig *cfg;
 } _6502State;

--- a/librz/arch/isa/6502/6502dis.h
+++ b/librz/arch/isa/6502/6502dis.h
@@ -6,6 +6,11 @@
 
 #include <rz_asm.h>
 
+typedef struct {
+	RzConfig *cfg;
+} _6502State;
+
+_6502State *_6502_state_new();
 int disass_6502(ut64 pc, RzAsmOp *op, const ut8 *buf, ut64 len);
 
 #endif /* DISASSEMBLE_6502_H */

--- a/librz/arch/p/analysis/analysis_6502.c
+++ b/librz/arch/p/analysis/analysis_6502.c
@@ -19,7 +19,7 @@
 #include "snes/snes_op_table.h"
 #include "6502/6502_il.inc"
 #include <6502/6502dis.h>
-#include <rz_core.h>
+#include <rz_config.h>
 
 enum {
 	_6502_FLAGS_C = (1 << 0),

--- a/librz/arch/p/analysis/analysis_6502.c
+++ b/librz/arch/p/analysis/analysis_6502.c
@@ -843,9 +843,13 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		op->cycles = 2;
 		op->size = 2;
 		if (mask & RZ_ANALYSIS_OP_MASK_IL) {
+			ut8 magic = 0xee;
 			_6502ILAddr addr;
 			_6502_il_immediate(&addr, data[1]);
-			op->il_op = _6502_il_op_laximm(&addr, (ut8)rz_config_get_i(cfg_state->cfg, "plugins.6502.magic"));
+			if (cfg_state && cfg_state->cfg) {
+				magic = (ut8)rz_config_get_i(cfg_state->cfg, "plugins.6502.magic");
+			}
+			op->il_op = _6502_il_op_laximm(&addr, magic);
 		}
 		break;
 
@@ -1133,9 +1137,13 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		op->size = 2;
 		op->cycles = 2;
 		if (mask & RZ_ANALYSIS_OP_MASK_IL) {
+			ut8 magic = 0xee;
 			_6502ILAddr addr;
 			_6502_il_immediate(&addr, data[1]);
-			op->il_op = _6502_il_op_ane(&addr, (ut8)rz_config_get_i(cfg_state->cfg, "plugins.6502.magic"));
+			if (cfg_state && cfg_state->cfg) {
+				magic = (ut8)rz_config_get_i(cfg_state->cfg, "plugins.6502.magic");
+			}
+			op->il_op = _6502_il_op_ane(&addr, magic);
 		}
 		break;
 
@@ -1863,8 +1871,12 @@ static int address_bits(RzAnalysis *analysis, int bits) {
 
 static RzAnalysisILConfig *_6502_il_config(RzAnalysis *analysis) {
 	rz_return_val_if_fail(analysis, NULL);
-	analysis->plugin_data = (_6502State *)rz_asm_plugin_data_from_rz_analysis(analysis);
-	rz_return_val_if_fail(analysis->plugin_data, NULL);
+	if (!analysis->plugin_data && analysis->core) {
+		RzAsm *rasm = rz_analysis_to_rz_asm(analysis);
+		if (rasm && rasm->plugin_data) {
+			analysis->plugin_data = rasm->plugin_data;
+		}
+	}
 	return rz_analysis_il_config_new(16, false, 16);
 }
 

--- a/librz/arch/p/analysis/analysis_6502.c
+++ b/librz/arch/p/analysis/analysis_6502.c
@@ -18,6 +18,8 @@
 #include <rz_analysis.h>
 #include "snes/snes_op_table.h"
 #include "6502/6502_il.inc"
+#include <6502/6502dis.h>
+#include <rz_core.h>
 
 enum {
 	_6502_FLAGS_C = (1 << 0),
@@ -441,6 +443,8 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	rz_strbuf_init(&op->esil);
 	_6502ILAddr il_addr = { 0 };
 	_6502ILAddr *il_addr_ptr = (mask & RZ_ANALYSIS_OP_MASK_IL) ? &il_addr : NULL;
+	_6502State *cfg_state = (_6502State *)analysis->plugin_data;
+
 	switch (data[0]) {
 	// SLO
 	case 0x07: // slo $ff
@@ -841,7 +845,7 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		if (mask & RZ_ANALYSIS_OP_MASK_IL) {
 			_6502ILAddr addr;
 			_6502_il_immediate(&addr, data[1]);
-			op->il_op = _6502_il_op_laximm(&addr);
+			op->il_op = _6502_il_op_laximm(&addr, (ut8)rz_config_get_i(cfg_state->cfg, "plugins.6502.magic"));
 		}
 		break;
 
@@ -1130,8 +1134,8 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 		op->cycles = 2;
 		if (mask & RZ_ANALYSIS_OP_MASK_IL) {
 			_6502ILAddr addr;
-			_6502_il_addr_indirect_y(&addr, data[1]);
-			op->il_op = _6502_il_op_ane(&addr);
+			_6502_il_immediate(&addr, data[1]);
+			op->il_op = _6502_il_op_ane(&addr, (ut8)rz_config_get_i(cfg_state->cfg, "plugins.6502.magic"));
 		}
 		break;
 
@@ -1857,7 +1861,10 @@ static int address_bits(RzAnalysis *analysis, int bits) {
 	return 16;
 }
 
-static RzAnalysisILConfig *il_config(RzAnalysis *analysis) {
+static RzAnalysisILConfig *_6502_il_config(RzAnalysis *analysis) {
+	rz_return_val_if_fail(analysis, NULL);
+	analysis->plugin_data = (_6502State *)rz_asm_plugin_data_from_rz_analysis(analysis);
+	rz_return_val_if_fail(analysis->plugin_data, NULL);
 	return rz_analysis_il_config_new(16, false, 16);
 }
 
@@ -1873,6 +1880,6 @@ RzAnalysisPlugin rz_analysis_plugin_6502 = {
 	.esil = true,
 	.esil_init = esil_6502_init,
 	.esil_fini = esil_6502_fini,
-	.il_config = il_config
+	.il_config = _6502_il_config
 
 };

--- a/librz/arch/p/asm/asm_6502.c
+++ b/librz/arch/p/asm/asm_6502.c
@@ -9,9 +9,59 @@
 #include <rz_lib.h>
 #include <6502/6502dis.h>
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int _6520_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	int dlen = disass_6502(a->pc, op, buf, len);
 	return op->size = RZ_MAX(dlen, 0);
+}
+
+RzConfig *_6502_get_config(void *plugin_data) {
+	rz_return_val_if_fail(plugin_data, NULL);
+	_6502State *state = (_6502State *)plugin_data;
+	return rz_config_clone(state->cfg);
+}
+
+static bool _6502_cfg_set(void *user, void *data) {
+	rz_return_val_if_fail(user && data, false);
+	_6502State *state = user;
+	RzConfig *pcfg = state->cfg;
+
+	RzConfigNode *cnode = (RzConfigNode *)data; // Config node from core.
+	RzConfigNode *pnode = rz_config_node_get(pcfg, cnode->name); // Config node of plugin.
+	if (pnode == cnode) {
+		return true;
+	}
+	if (cnode) {
+		pnode->i_value = cnode->i_value;
+		free(pnode->value);
+		pnode->value = rz_str_dup(cnode->value);
+		return true;
+	}
+	return false;
+}
+
+static bool _6502_init(void **user) {
+	_6502State *state = _6502_state_new();
+	rz_return_val_if_fail(state, false);
+	RzConfig *cfg = state->cfg = rz_config_new(state);
+	rz_return_val_if_fail(state->cfg, false);
+
+	SETICB("plugins.6502.magic", 0xee, &_6502_cfg_set, "Determines the magic number certain illegal opcodes use.");
+	*user = state;
+	return true;
+}
+
+void _6502State_fini(_6502State *state) {
+	if (!state) {
+		return;
+	}
+	rz_config_free(state->cfg);
+	return;
+}
+
+static bool _6502_fini(void *user) {
+	_6502State_fini(user);
+	free(user);
+	return true;
 }
 
 RzAsmPlugin rz_asm_plugin_6502 = {
@@ -21,5 +71,8 @@ RzAsmPlugin rz_asm_plugin_6502 = {
 	.bits = 8 | 16,
 	.endian = RZ_SYS_ENDIAN_LITTLE,
 	.license = "LGPL3",
-	.disassemble = &disassemble,
+	.disassemble = &_6520_disassemble,
+	.init = _6502_init,
+	.get_config = _6502_get_config,
+	.fini = _6502_fini
 };

--- a/test/db/asm/6502
+++ b/test/db/asm/6502
@@ -224,7 +224,7 @@ d "sha 0xcafe,y" 9ffeca 0x0 (seq (set tmp (& (& (var a) (var x)) (+ (cast 8 fals
 d "shx 0xcafe,y" 9efeca 0x0 (seq (set tmp (& (var x) (+ (cast 8 false (>> (+ (bv 16 0xcafe) (cast 16 false (var y))) (bv 8 0x8) false)) (bv 8 0x1)))) (store 0 (+ (bv 16 0xcafe) (cast 16 false (var y))) (var tmp)))
 d "shy 0xcafe,x" 9cfeca 0x0 (seq (set tmp (& (var y) (+ (cast 8 false (>> (+ (bv 16 0xcafe) (cast 16 false (var x))) (bv 8 0x8) false)) (bv 8 0x1)))) (store 0 (+ (bv 16 0xcafe) (cast 16 false (var x))) (var tmp)))
 d "shs 0xcafe,y" 9bfeca 0x0 (seq (set sp (& (var a) (var x))) (set tmp (& (& (var a) (var x)) (+ (cast 8 false (>> (+ (bv 16 0xcafe) (cast 16 false (var y))) (bv 8 0x8) false)) (bv 8 0x1)))) (store 0 (+ (bv 16 0xcafe) (cast 16 false (var y))) (var tmp)))
-d "ane #0x42" 8b42 0x0 (seq (set a (& (| (var a) (bv 8 0xee)) (& (var x) (cast 8 false (+ (append (load 0 (cast 16 false (+ (bv 8 0x42) (bv 8 0x1)))) (load 0 (cast 16 false (bv 8 0x42)))) (cast 16 false (var y))))))) (set Z (is_zero (var a))) (set N (msb (var a))))
+d "ane #0x42" 8b42 0x0 (seq (set a (& (| (var a) (bv 8 0xee)) (& (var x) (cast 8 false (bv 8 0x42))))) (set Z (is_zero (var a))) (set N (msb (var a))))
 d "nop #0x42" 8042 0x0 nop
 d "nop #0x42" 8242 0x0 nop
 d "nop #0x42" c242 0x0 nop

--- a/test/db/rzil/6502
+++ b/test/db/rzil/6502
@@ -505,6 +505,19 @@ ar a=0x50
 ar flags=0x01
 aezs
 ar
+# Reset and LAX imm with config
+s 0
+ar a=0
+ar x=0
+ar y=0
+ar sp=0
+ar flags=0
+wx ab0f
+aezi
+ar a=0x12
+e plugins.6502.magic=255
+aezs
+ar
 EOF
 EXPECT=<<EOF
 c2
@@ -514,10 +527,10 @@ flags = 0x00
 13
 13
 11
-a = 0x00
+a = 0x0e
 x = 0xff
 y = 0x00
-flags = 0x02
+flags = 0x00
 sp = 0x00
 pc = 0x0002
 a = 0x0e
@@ -538,5 +551,11 @@ y = 0x00
 flags = 0x01
 sp = 0x00
 pc = 0x0001
+a = 0x0f
+x = 0x0f
+y = 0x00
+flags = 0x00
+sp = 0x00
+pc = 0x0002
 EOF
 RUN


### PR DESCRIPTION
 **Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
- Fixed incorrect logic for the opcode `ane #$ff`
- Added a new config to set the magic number used by 2 opcodes, `ane #$ff` and `lax #$ff`. Default value is set to `0xee`
- Added and corrected appropriate tests

**Test plan**
- Corrected the test for `ane #$ff` in `test/db/asm/6502`
- Added a test in `test/db/rzil/6502`

**Closing issues**
Closes #5798 