### PR TITLE
bin/dol: remove RZ_PACKED and use offset-based buffer reading

### DIFF
--- a/librz/bin/p/bin_dol.c
+++ b/librz/bin/p/bin_dol.c
@@ -23,22 +23,19 @@
 
 #define N_TEXT 7
 #define N_DATA 11
+#define DOL_HDR_SIZE 0x100
 
-RZ_PACKED(
-	typedef struct {
-		ut32 text_paddr[N_TEXT];
-		ut32 data_paddr[N_DATA];
-		ut32 text_vaddr[N_TEXT];
-		ut32 data_vaddr[N_DATA];
-		ut32 text_size[N_TEXT];
-		ut32 data_size[N_DATA];
-		ut32 bss_addr;
-		ut32 bss_size;
-		ut32 entrypoint;
-		ut32 padding[10];
-		// 0x100 -- start of data section
-	})
-DolHeader;
+typedef struct {
+	ut32 text_paddr[N_TEXT];
+	ut32 data_paddr[N_DATA];
+	ut32 text_vaddr[N_TEXT];
+	ut32 data_vaddr[N_DATA];
+	ut32 text_size[N_TEXT];
+	ut32 data_size[N_DATA];
+	ut32 bss_addr;
+	ut32 bss_size;
+	ut32 entrypoint;
+} DolHeader;
 
 static bool check_buffer(RzBuffer *buf) {
 	ut8 tmp[6];
@@ -54,8 +51,30 @@ static bool check_buffer(RzBuffer *buf) {
 	return false;
 }
 
+static bool read_u32_array(RzBuffer *buf, ut64 *offset, ut32 *arr, size_t count) {
+	for (size_t i = 0; i < count; i++) {
+		if (!rz_buf_read_be32_offset(buf, offset, &arr[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool dol_parse_header(RzBuffer *buf, DolHeader *dol) {
+	ut64 off = 0;
+	return read_u32_array(buf, &off, dol->text_paddr, N_TEXT) &&
+		read_u32_array(buf, &off, dol->data_paddr, N_DATA) &&
+		read_u32_array(buf, &off, dol->text_vaddr, N_TEXT) &&
+		read_u32_array(buf, &off, dol->data_vaddr, N_DATA) &&
+		read_u32_array(buf, &off, dol->text_size, N_TEXT) &&
+		read_u32_array(buf, &off, dol->data_size, N_DATA) &&
+		rz_buf_read_be32_offset(buf, &off, &dol->bss_addr) &&
+		rz_buf_read_be32_offset(buf, &off, &dol->bss_size) &&
+		rz_buf_read_be32_offset(buf, &off, &dol->entrypoint);
+}
+
 static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb) {
-	if (rz_buf_size(buf) < sizeof(DolHeader)) {
+	if (rz_buf_size(buf) < DOL_HDR_SIZE) {
 		return false;
 	}
 	DolHeader *dol = RZ_NEW0(DolHeader);
@@ -72,7 +91,11 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb
 		goto lowername_err;
 	}
 	free(lowername);
-	rz_buf_fread_at(bf->buf, 0, (void *)dol, "67I", 1);
+
+	if (!dol_parse_header(buf, dol)) {
+		goto dol_err;
+	}
+
 	obj->bin_obj = dol;
 	return true;
 

--- a/test/db/formats/dol
+++ b/test/db/formats/dol
@@ -11,3 +11,125 @@ EXPECT=<<EOF
 2
 EOF
 RUN
+
+NAME=DOL: sqrxz4 - architecture detection
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=iI~arch
+EXPECT=<<EOF
+arch     ppc
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - endianness
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=iI~endian
+EXPECT=<<EOF
+endian   BE
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - bits
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=iI~bits
+EXPECT=<<EOF
+bits     32
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - machine
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=iI~machine
+EXPECT=<<EOF
+machine  Nintendo Wii
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - os
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=iI~^os
+EXPECT=<<EOF
+os       wii-ios
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - entry point
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=ie~program[0]
+EXPECT=<<EOF
+0x80003100
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - sections count
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=iS~?
+EXPECT=<<EOF
+5
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - text section
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=iS~text_0
+EXPECT=<<EOF
+0x00000100  0xcd960 0x80003100  0xcd960   0x0 -r-x text_0      
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - data section
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=iS~data_0
+EXPECT=<<EOF
+0x000cda80  0x2f200 0x800d0a60  0x2f200   0x0 -r-- data_0      
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - bss section
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=iS~bss
+EXPECT=<<EOF
+0x00000000 0x3468c0 0x800ffc60 0x3468c0   0x0 -rw- bss         
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - text section permissions
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=iS~text_0~r-x
+EXPECT=<<EOF
+0x00000100  0xcd960 0x80003100  0xcd960   0x0 -r-x text_0      
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - data section permissions
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=iS~data_0~r--
+EXPECT=<<EOF
+0x000cda80  0x2f200 0x800d0a60  0x2f200   0x0 -r-- data_0      
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - bss section permissions
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=iS~bss~rw-
+EXPECT=<<EOF
+0x00000000 0x3468c0 0x800ffc60 0x3468c0   0x0 -rw- bss         
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - disassembly at entry
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=pd 1 @ entry0
+EXPECT=<<EOF
+            ;-- entry0:
+            ;-- section.text_0:
+        ,=< 0x80003100      b     0x80003120                           ; [00] -r-x section size 842080 named text_0
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - base address
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=iI~baddr
+EXPECT=<<EOF
+baddr    0x80b00000
+EOF
+RUN

--- a/test/db/formats/dol
+++ b/test/db/formats/dol
@@ -4,51 +4,33 @@ CMDS=q!
 EXPECT=
 RUN
 
-NAME=DOL: sqrxz4 - iI
+NAME=DOL: sqrxz4 - file info
 FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iI~?wii
-EXPECT=<<EOF
-2
+CMDS=<<EOF
+iI~arch
+iI~endian
+iI~bits
+iI~machine
+iI~^os
+iI~baddr
 EOF
-RUN
-
-NAME=DOL: sqrxz4 - architecture detection
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iI~arch
 EXPECT=<<EOF
 arch     ppc
-EOF
-RUN
-
-NAME=DOL: sqrxz4 - endianness
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iI~endian
-EXPECT=<<EOF
 endian   BE
-EOF
-RUN
-
-NAME=DOL: sqrxz4 - bits
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iI~bits
-EXPECT=<<EOF
 bits     32
-EOF
-RUN
-
-NAME=DOL: sqrxz4 - machine
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iI~machine
-EXPECT=<<EOF
 machine  Nintendo Wii
+os       wii-ios
+baddr    0x80b00000
 EOF
 RUN
 
-NAME=DOL: sqrxz4 - os
+NAME=DOL: sqrxz4 - sections
 FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iI~^os
+CMDS=iS~0x
 EXPECT=<<EOF
-os       wii-ios
+0x00000100  0xcd960 0x80003100  0xcd960   0x0 -r-x text_0      
+0x000cda80  0x2f200 0x800d0a60  0x2f200   0x0 -r-- data_0      
+0x00000000 0x3468c0 0x800ffc60 0x3468c0   0x0 -rw- bss         
 EOF
 RUN
 
@@ -60,62 +42,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=DOL: sqrxz4 - sections count
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iS~?
-EXPECT=<<EOF
-5
-EOF
-RUN
-
-NAME=DOL: sqrxz4 - text section
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iS~text_0
-EXPECT=<<EOF
-0x00000100  0xcd960 0x80003100  0xcd960   0x0 -r-x text_0      
-EOF
-RUN
-
-NAME=DOL: sqrxz4 - data section
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iS~data_0
-EXPECT=<<EOF
-0x000cda80  0x2f200 0x800d0a60  0x2f200   0x0 -r-- data_0      
-EOF
-RUN
-
-NAME=DOL: sqrxz4 - bss section
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iS~bss
-EXPECT=<<EOF
-0x00000000 0x3468c0 0x800ffc60 0x3468c0   0x0 -rw- bss         
-EOF
-RUN
-
-NAME=DOL: sqrxz4 - text section permissions
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iS~text_0~r-x
-EXPECT=<<EOF
-0x00000100  0xcd960 0x80003100  0xcd960   0x0 -r-x text_0      
-EOF
-RUN
-
-NAME=DOL: sqrxz4 - data section permissions
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iS~data_0~r--
-EXPECT=<<EOF
-0x000cda80  0x2f200 0x800d0a60  0x2f200   0x0 -r-- data_0      
-EOF
-RUN
-
-NAME=DOL: sqrxz4 - bss section permissions
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iS~bss~rw-
-EXPECT=<<EOF
-0x00000000 0x3468c0 0x800ffc60 0x3468c0   0x0 -rw- bss         
-EOF
-RUN
-
 NAME=DOL: sqrxz4 - disassembly at entry
 FILE=bins/dol/sqrxz4-gc.dol
 CMDS=pd 1 @ entry0
@@ -123,13 +49,5 @@ EXPECT=<<EOF
             ;-- entry0:
             ;-- section.text_0:
         ,=< 0x80003100      b     0x80003120                           ; [00] -r-x section size 842080 named text_0
-EOF
-RUN
-
-NAME=DOL: sqrxz4 - base address
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iI~baddr
-EXPECT=<<EOF
-baddr    0x80b00000
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Hey! This is my first contribution to Rizin 👋

I've refactored the DOL plugin to fix #5813.


### What I changed:
- Removed the `RZ_PACKED` macro from the header struct
- Switched from `rz_buf_fread_at` to the newer `rz_buf_read_be32_offset` API
- Added a small helper function to keep the code clean
- Added tests since the plugin didn't have proper coverage before

Let me know if anything needs changes!

Fixes #5813
