### PR TITLE
fix endless loop when Ctrl+R received in non-interactive mode (#5824)

### DIFF
--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -1707,11 +1707,13 @@ RZ_API const char *rz_line_readline_cb(RZ_NONNULL RzLine *line, RzLineReadCallba
 			fflush(stdout);
 			break;
 		case 18: // ^R -- reverse-search
-			if (line->gcomp) {
-				line->gcomp_idx++;
+			if (rz_cons_is_interactive()) {
+				if (line->gcomp) {
+					line->gcomp_idx++;
+				}
+				gcomp_is_rev = true;
+				line->gcomp = 1;
 			}
-			gcomp_is_rev = true;
-			line->gcomp = 1;
 			break;
 		case 19: // ^S -- forward-search
 			if (line->gcomp) {

--- a/test/unit/test_cons_line.c
+++ b/test/unit/test_cons_line.c
@@ -226,6 +226,20 @@ bool test_line_ns_completion(void) {
 	mu_end;
 }
 
+bool test_line_ctrl_r_noninteractive(void) {
+	RzCons *cons = rz_cons_new();
+	cons->context->is_interactive = false; // Simulate non-interactive input
+	RzLine *line = cons->line;
+	const char instr[] = "< \x12"
+	                     "asd\n";
+	rz_cons_readpush(instr, sizeof(instr));
+	const char *result = rz_line_readline(line);
+	mu_assert_eq(line->gcomp, 0, "unexpected gcomp activation");
+	mu_assert_notnull(result, "readline returned NULL");
+	rz_cons_free();
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_line_nocompletion);
 	mu_run_test(test_line_onecompletion);
@@ -234,6 +248,7 @@ bool all_tests() {
 	mu_run_test(test_line_undo);
 	mu_run_test(test_line_misc);
 	mu_run_test(test_line_ns_completion);
+	mu_run_test(test_line_ctrl_r_noninteractive);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->
When ctrl+R was received from non-interactive input it would activate "reverse-i-search" mode and the prompt repeats infinitely.
So I added "rz_cons_is_interactive()" check in the ctrl+ R handler to handle non interactive input
...

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->
Added a unit test
Create a new console -> Set `is_interactive = false` -> Push input `"< \x12asd\n"` -> Call `rz_line_readline()` -> Assert `line->gcomp == 0` -> result is not null.
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
closes #5824 

...
