### PR TITLE
Remove RZ_PACKED from DOL parser

### DIFF
--- a/librz/bin/p/bin_dol.c
+++ b/librz/bin/p/bin_dol.c
@@ -110,15 +110,13 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
 
 	DolHeader *dol = bf->o->bin_obj;
-	RzPVector *ret = rz_pvector_new((RzPVectorFree)free);
+	RzPVector *ret = rz_pvector_new(free);
 	if (!ret) {
 		return NULL;
 	}
 
 	for (int i = 0; i < N_TEXT; i++) {
-		if (!dol->text_paddr[i] ||
-			!dol->text_vaddr[i] ||
-			!dol->text_size[i]) {
+		if (!dol->text_paddr[i] || !dol->text_vaddr[i] || !dol->text_size[i]) {
 			continue;
 		}
 		RzBinSection *s = RZ_NEW0(RzBinSection);
@@ -136,9 +134,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	}
 
 	for (int i = 0; i < N_DATA; i++) {
-		if (!dol->data_paddr[i] ||
-			!dol->data_vaddr[i] ||
-			!dol->data_size[i]) {
+		if (!dol->data_paddr[i] || !dol->data_vaddr[i] || !dol->data_size[i]) {
 			continue;
 		}
 		RzBinSection *s = RZ_NEW0(RzBinSection);
@@ -175,7 +171,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 static RzPVector /*<RzBinAddr *>*/ *entries(RzBinFile *bf) {
 	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
 	DolHeader *dol = bf->o->bin_obj;
-	RzPVector *ret = rz_pvector_new((RzPVectorFree)free);
+	RzPVector *ret = rz_pvector_new(free);
 	if (!ret) {
 		return NULL;
 	}

--- a/librz/bin/p/bin_dol.c
+++ b/librz/bin/p/bin_dol.c
@@ -8,18 +8,18 @@
 #include <string.h>
 
 /*
-	Start	End	Length	Description
-	0x0	0x3	4	File offset to start of Text0
-	0x04	0x1b	24	File offsets for Text1..6
-	0x1c	0x47	44	File offsets for Data0..10
-	0x48	0x4B	4	Loading address for Text0
-	0x4C	0x8F	68	Loading addresses for Text1..6, Data0..10
-	0x90	0xD7	72	Section sizes for Text0..6, Data0..10
-	0xD8	0xDB	4	BSS address
-	0xDC	0xDF	4	BSS size
-	0xE0	0xE3	4	Entry point
-	0xE4	0xFF		padding
-*/
+   Start	End	Length	Description
+   0x0	0x3	4	File offset to start of Text0
+   0x04	0x1b	24	File offsets for Text1..6
+   0x1c	0x47	44	File offsets for Data0..10
+   0x48	0x4B	4	Loading address for Text0
+   0x4C	0x8F	68	Loading addresses for Text1..6, Data0..10
+   0x90	0xD7	72	Section sizes for Text0..6, Data0..10
+   0xD8	0xDB	4	BSS address
+   0xDC	0xDF	4	BSS size
+   0xE0	0xE3	4	Entry point
+   0xE4	0xFF		padding
+ */
 
 #define N_TEXT       7
 #define N_DATA       11
@@ -106,7 +106,7 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb
 	return true;
 }
 
-static RzPVector *sections(RzBinFile *bf) {
+static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
 
 	DolHeader *dol = bf->o->bin_obj;
@@ -122,6 +122,9 @@ static RzPVector *sections(RzBinFile *bf) {
 			continue;
 		}
 		RzBinSection *s = RZ_NEW0(RzBinSection);
+		if (!s) {
+			return NULL;
+		}
 		s->name = rz_str_newf("text_%d", i);
 		s->paddr = dol->text_paddr[i];
 		s->vaddr = dol->text_vaddr[i];
@@ -138,6 +141,9 @@ static RzPVector *sections(RzBinFile *bf) {
 			continue;
 		}
 		RzBinSection *s = RZ_NEW0(RzBinSection);
+		if (!s) {
+			return NULL;
+		}
 		s->name = rz_str_newf("data_%d", i);
 		s->paddr = dol->data_paddr[i];
 		s->vaddr = dol->data_vaddr[i];
@@ -149,6 +155,9 @@ static RzPVector *sections(RzBinFile *bf) {
 
 	if (dol->bss_size) {
 		RzBinSection *bss = RZ_NEW0(RzBinSection);
+		if (!s) {
+			return NULL;
+		}
 		bss->name = rz_str_dup("bss");
 		bss->paddr = UT64_MAX;
 		bss->vaddr = dol->bss_addr;

--- a/librz/bin/p/bin_dol.c
+++ b/librz/bin/p/bin_dol.c
@@ -172,7 +172,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	return ret;
 }
 
-static RzPVector *entries(RzBinFile *bf) {
+static RzPVector /*<RzBinAddr *>*/ *entries(RzBinFile *bf) {
 	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
 	DolHeader *dol = bf->o->bin_obj;
 	RzPVector *ret = rz_pvector_new((RzPVectorFree)free);

--- a/librz/bin/p/bin_dol.c
+++ b/librz/bin/p/bin_dol.c
@@ -8,21 +8,21 @@
 #include <string.h>
 
 /*
-Start	End	Length	Description
-0x0	0x3	4	File offset to start of Text0
-0x04	0x1b	24	File offsets for Text1..6
-0x1c	0x47	44	File offsets for Data0..10
-0x48	0x4B	4	Loading address for Text0
-0x4C	0x8F	68	Loading addresses for Text1..6, Data0..10
-0x90	0xD7	72	Section sizes for Text0..6, Data0..10
-0xD8	0xDB	4	BSS address
-0xDC	0xDF	4	BSS size
-0xE0	0xE3	4	Entry point
-0xE4	0xFF		padding
+	Start	End	Length	Description
+	0x0	0x3	4	File offset to start of Text0
+	0x04	0x1b	24	File offsets for Text1..6
+	0x1c	0x47	44	File offsets for Data0..10
+	0x48	0x4B	4	Loading address for Text0
+	0x4C	0x8F	68	Loading addresses for Text1..6, Data0..10
+	0x90	0xD7	72	Section sizes for Text0..6, Data0..10
+	0xD8	0xDB	4	BSS address
+	0xDC	0xDF	4	BSS size
+	0xE0	0xE3	4	Entry point
+	0xE4	0xFF		padding
 */
 
-#define N_TEXT 7
-#define N_DATA 11
+#define N_TEXT       7
+#define N_DATA       11
 #define DOL_HDR_SIZE 0x100
 
 typedef struct dol_header_s {
@@ -38,7 +38,21 @@ typedef struct dol_header_s {
 	ut32 padding[10];
 } DolHeader;
 
-static bool check_buffer(RzBuffer *buf) {
+/*
+	Performs a check on the buffer to verify if is a DOL header.
+	The DOL format does not have a magic, thus requires some heuristics to detect it.
+	The size is always 0x100 and thus we expect the text0 offset to alway start after 0x100.
+
+	On the Broadway the executable range starts from 0x80000000 till 0x80003F00 for iOS and for applications between the 0x80003F00 and 0x81330000.
+	Thus, we expect the entrypoint for these files to always have the MSB to 1.
+
+	Reference:
+		https://wiki.tockdom.com/wiki/DOL_(File_Format)
+		https://wiibrew.org/wiki/Memory_map
+ */
+
+static bool
+check_buffer(RzBuffer *buf) {
 	if (!buf || rz_buf_size(buf) < DOL_HDR_SIZE) {
 		return false;
 	}
@@ -49,33 +63,12 @@ static bool check_buffer(RzBuffer *buf) {
 	if (!rz_buf_read_be32_at(buf, 0xE0, &entry)) {
 		return false;
 	}
-	
+
 	bool text0_valid = (text0_off >= DOL_HDR_SIZE) && (text0_off < rz_buf_size(buf)) && (text0_off % 4 == 0);
 	bool entry_valid = (entry & 0xF0000000) == 0x80000000;
 	return text0_valid && entry_valid;
 }
-/*
-dol Header:
---> The dol header have a fixed size of 0x100. But in the dol_parse_header when you add all the memory space it would be 0xE4, this is okay as rest all of the space is considered as padding.
 
-	0x100 - 0xE4 = padding 
-
-Generally this padding is ignored.
-dol header entrypoint:
---> Previously, we validated whether a file was a DOL file by comparing the first 6 bytes with a magic value. This method was weak and unreliable.
-
---> We have now introduced a more robust validation method based on the entrypoint address range.
-
---> A valid DOL entrypoint must fall within the memory range:
-
-      (0x80004000 <–> 0x81200000)
-
---> By verifying that the entrypoint lies within this range, we can more confidently determine whether the file is a valid DOL  file. This also improves the overall reliability of DOL file detection.
-
---> Reference:
-	https://wiki.tockdom.com/wiki/DOL_(File_Format)
-	https://wiibrew.org/wiki/Memory_map
-*/
 static bool read_u32_array(RzBuffer *b, ut64 *off, ut32 *dst, int n) {
 	for (int i = 0; i < n; i++) {
 		if (!rz_buf_read_be32_offset(b, off, &dst[i])) {
@@ -121,7 +114,7 @@ static RzPVector *sections(RzBinFile *bf) {
 	if (!ret) {
 		return NULL;
 	}
-		
+
 	for (int i = 0; i < N_TEXT; i++) {
 		if (!dol->text_paddr[i] ||
 			!dol->text_vaddr[i] ||
@@ -132,11 +125,11 @@ static RzPVector *sections(RzBinFile *bf) {
 		s->name = rz_str_newf("text_%d", i);
 		s->paddr = dol->text_paddr[i];
 		s->vaddr = dol->text_vaddr[i];
-		s->size  = dol->text_size[i];
+		s->size = dol->text_size[i];
 		s->vsize = s->size;
-		s->perm  = rz_str_rwx("r-x");
+		s->perm = rz_str_rwx("r-x");
 		rz_pvector_push(ret, s);
-}
+	}
 
 	for (int i = 0; i < N_DATA; i++) {
 		if (!dol->data_paddr[i] ||
@@ -148,44 +141,38 @@ static RzPVector *sections(RzBinFile *bf) {
 		s->name = rz_str_newf("data_%d", i);
 		s->paddr = dol->data_paddr[i];
 		s->vaddr = dol->data_vaddr[i];
-		s->size  = dol->data_size[i];
+		s->size = dol->data_size[i];
 		s->vsize = s->size;
-		s->perm  = rz_str_rwx("r--");
+		s->perm = rz_str_rwx("r--");
 		rz_pvector_push(ret, s);
 	}
 
 	if (dol->bss_size) {
 		RzBinSection *bss = RZ_NEW0(RzBinSection);
-		bss->name  = rz_str_dup("bss");
+		bss->name = rz_str_dup("bss");
 		bss->paddr = UT64_MAX;
 		bss->vaddr = dol->bss_addr;
-		bss->size  = dol->bss_size;
+		bss->size = dol->bss_size;
 		bss->vsize = bss->size;
-		bss->perm  = rz_str_rwx("rw-");
+		bss->perm = rz_str_rwx("rw-");
 		rz_pvector_push(ret, bss);
 	}
-
 	return ret;
 }
-
 static RzPVector *entries(RzBinFile *bf) {
 	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
-
 	DolHeader *dol = bf->o->bin_obj;
 	RzPVector *ret = rz_pvector_new(NULL);
 	if (!ret) {
 		return NULL;
 	}
-
 	RzBinAddr *addr = RZ_NEW0(RzBinAddr);
 	if (!addr) {
 		rz_pvector_free(ret);
 		return NULL;
 	}
-
 	addr->vaddr = dol->entrypoint;
-	addr->paddr = UT64_MAX; 
-
+	addr->paddr = UT64_MAX;
 	rz_pvector_push(ret, addr);
 	return ret;
 }

--- a/librz/bin/p/bin_dol.c
+++ b/librz/bin/p/bin_dol.c
@@ -23,39 +23,62 @@
 
 #define N_TEXT 7
 #define N_DATA 11
+#define DOL_HDR_SIZE 0x100           
 
-RZ_PACKED(
-	typedef struct {
-		ut32 text_paddr[N_TEXT];
-		ut32 data_paddr[N_DATA];
-		ut32 text_vaddr[N_TEXT];
-		ut32 data_vaddr[N_DATA];
-		ut32 text_size[N_TEXT];
-		ut32 data_size[N_DATA];
-		ut32 bss_addr;
-		ut32 bss_size;
-		ut32 entrypoint;
-		ut32 padding[10];
-		// 0x100 -- start of data section
-	})
+
+typedef struct {
+	ut32 text_paddr[N_TEXT];
+	ut32 data_paddr[N_DATA];
+	ut32 text_vaddr[N_TEXT];
+	ut32 data_vaddr[N_DATA];
+	ut32 text_size[N_TEXT];
+	ut32 data_size[N_DATA];
+	ut32 bss_addr;
+	ut32 bss_size;
+	ut32 entrypoint;
+	}
 DolHeader;
 
-static bool check_buffer(RzBuffer *buf) {
-	ut8 tmp[6];
-	int r = rz_buf_read_at(buf, 0, tmp, sizeof(tmp));
-	bool one = r == sizeof(tmp) && !memcmp(tmp, "\x00\x00\x01\x00\x00\x00", sizeof(tmp));
-	if (one) {
-		int r = rz_buf_read_at(buf, 6, tmp, sizeof(tmp));
-		if (r != 6) {
+static bool read_u32_array(RzBuffer *buf, ut64 *offset, ut32 *arr, size_t count) {
+	for (size_t i = 0; i < count; i++) {
+		if (!rz_buf_read_be32_offset(buf, offset, &arr[i])) {
 			return false;
 		}
-		return sizeof(tmp) && !memcmp(tmp, "\x00\x00\x00\x00\x00\x00", sizeof(tmp));
 	}
-	return false;
+	return true;
 }
 
+static bool dol_parse_header(RzBuffer *buf, DolHeader *dol) {
+	ut64 off = 0;
+	return read_u32_array(buf, &off, dol->text_paddr, N_TEXT) &&
+		read_u32_array(buf, &off, dol->data_paddr, N_DATA) &&
+		read_u32_array(buf, &off, dol->text_vaddr, N_TEXT) &&
+		read_u32_array(buf, &off, dol->data_vaddr, N_DATA) &&
+		read_u32_array(buf, &off, dol->text_size, N_TEXT) &&
+		read_u32_array(buf, &off, dol->data_size, N_DATA) &&
+		rz_buf_read_be32_offset(buf, &off, &dol->bss_addr) &&
+		rz_buf_read_be32_offset(buf, &off, &dol->bss_size) &&
+		rz_buf_read_be32_offset(buf, &off, &dol->entrypoint);
+}
+
+static bool check_buffer(RzBuffer *buf) { 
+	if (!buf || rz_buf_size(buf) < DOL_HDR_SIZE) {
+		 return false;
+	 } 
+	ut32 text0_off, entry;
+    if (!rz_buf_read_be32_at(buf, 0x00, &text0_off)) { 
+		return false; 
+	} 
+	if (!rz_buf_read_be32_at(buf, 0xE0, &entry)) { 
+		return false; 
+	}  
+	bool text0_valid = (text0_off >= 0x100) && (text0_off % 4 == 0);
+	bool entry_valid = (entry & 0xF0000000) == 0x80000000;
+
+	return text0_valid && entry_valid;
+}
 static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb) {
-	if (rz_buf_size(buf) < sizeof(DolHeader)) {
+	if (rz_buf_size(buf) < DOL_HDR_SIZE) {
 		return false;
 	}
 	DolHeader *dol = RZ_NEW0(DolHeader);
@@ -72,12 +95,16 @@ static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb
 		goto lowername_err;
 	}
 	free(lowername);
-	rz_buf_fread_at(bf->buf, 0, (void *)dol, "67I", 1);
+	if (!dol_parse_header(buf, dol)) {
+		goto dol_err;
+	}
 	obj->bin_obj = dol;
 	return true;
 
 lowername_err:
 	free(lowername);
+	free(dol);
+	return false;
 dol_err:
 	free(dol);
 	return false;

--- a/librz/bin/p/bin_dol.c
+++ b/librz/bin/p/bin_dol.c
@@ -155,7 +155,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 
 	if (dol->bss_size) {
 		RzBinSection *bss = RZ_NEW0(RzBinSection);
-		if (!s) {
+		if (!bss) {
 			return NULL;
 		}
 		bss->name = rz_str_dup("bss");

--- a/librz/bin/p/bin_dol.c
+++ b/librz/bin/p/bin_dol.c
@@ -47,8 +47,8 @@ typedef struct dol_header_s {
    Thus, we expect the entrypoint for these files to always have the MSB to 1.
 
    Reference:
-   	https://wiki.tockdom.com/wiki/DOL_(File_Format)
-   	https://wiibrew.org/wiki/Memory_map
+    https://wiki.tockdom.com/wiki/DOL_(File_Format)
+    https://wiibrew.org/wiki/Memory_map
  */
 
 static bool check_buffer(RzBuffer *buf) {

--- a/librz/bin/p/bin_dol.c
+++ b/librz/bin/p/bin_dol.c
@@ -1,59 +1,59 @@
-	// SPDX-FileCopyrightText: 2015-2019 pancake <pancake@nopcode.org>
-	// SPDX-License-Identifier: LGPL-3.0-only
+// SPDX-FileCopyrightText: 2015-2019 pancake <pancake@nopcode.org>
+// SPDX-License-Identifier: LGPL-3.0-only
 
-	#include <rz_types.h>
-	#include <rz_util.h>
-	#include <rz_lib.h>
-	#include <rz_bin.h>
-	#include <string.h>
+#include <rz_types.h>
+#include <rz_util.h>
+#include <rz_lib.h>
+#include <rz_bin.h>
+#include <string.h>
 
-	/*
-	Start	End	Length	Description
-	0x0	0x3	4	File offset to start of Text0
-	0x04	0x1b	24	File offsets for Text1..6
-	0x1c	0x47	44	File offsets for Data0..10
-	0x48	0x4B	4	Loading address for Text0
-	0x4C	0x8F	68	Loading addresses for Text1..6, Data0..10
-	0x90	0xD7	72	Section sizes for Text0..6, Data0..10
-	0xD8	0xDB	4	BSS address
-	0xDC	0xDF	4	BSS size
-	0xE0	0xE3	4	Entry point
-	0xE4	0xFF		padding
-	*/
+/*
+Start	End	Length	Description
+0x0	0x3	4	File offset to start of Text0
+0x04	0x1b	24	File offsets for Text1..6
+0x1c	0x47	44	File offsets for Data0..10
+0x48	0x4B	4	Loading address for Text0
+0x4C	0x8F	68	Loading addresses for Text1..6, Data0..10
+0x90	0xD7	72	Section sizes for Text0..6, Data0..10
+0xD8	0xDB	4	BSS address
+0xDC	0xDF	4	BSS size
+0xE0	0xE3	4	Entry point
+0xE4	0xFF		padding
+*/
 
-	#define N_TEXT 7
-	#define N_DATA 11
-	#define DOL_HDR_SIZE 0x100
+#define N_TEXT 7
+#define N_DATA 11
+#define DOL_HDR_SIZE 0x100
 
-	typedef struct dol_header_s {
-		ut32 text_paddr[N_TEXT];
-		ut32 data_paddr[N_DATA];
-		ut32 text_vaddr[N_TEXT];
-		ut32 data_vaddr[N_DATA];
-		ut32 text_size[N_TEXT];
-		ut32 data_size[N_DATA];
-		ut32 bss_addr;
-		ut32 bss_size;
-		ut32 entrypoint;
-		ut32 padding[10];
-	} DolHeader;
+typedef struct dol_header_s {
+	ut32 text_paddr[N_TEXT];
+	ut32 data_paddr[N_DATA];
+	ut32 text_vaddr[N_TEXT];
+	ut32 data_vaddr[N_DATA];
+	ut32 text_size[N_TEXT];
+	ut32 data_size[N_DATA];
+	ut32 bss_addr;
+	ut32 bss_size;
+	ut32 entrypoint;
+	ut32 padding[10];
+} DolHeader;
 
-	static bool check_buffer(RzBuffer *buf) {
-		if (!buf || rz_buf_size(buf) < DOL_HDR_SIZE) {
-			return false;
-		}
-		ut32 text0_off, entry;
-		if (!rz_buf_read_be32_at(buf, 0x00, &text0_off)) {
-			return false;
-		}
-		if (!rz_buf_read_be32_at(buf, 0xE0, &entry)) {
-			return false;
-		}
-
-		bool text0_valid = (text0_off >= DOL_HDR_SIZE) && (text0_off < rz_buf_size(buf)) && (text0_off % 4 == 0);
-		bool entry_valid = (entry >= 0x80004000 && entry <  0x81200000);
-		return text0_valid && entry_valid;
+static bool check_buffer(RzBuffer *buf) {
+	if (!buf || rz_buf_size(buf) < DOL_HDR_SIZE) {
+		return false;
 	}
+	ut32 text0_off, entry;
+	if (!rz_buf_read_be32_at(buf, 0x00, &text0_off)) {
+		return false;
+	}
+	if (!rz_buf_read_be32_at(buf, 0xE0, &entry)) {
+		return false;
+	}
+	
+	bool text0_valid = (text0_off >= DOL_HDR_SIZE) && (text0_off < rz_buf_size(buf)) && (text0_off % 4 == 0);
+	bool entry_valid = (entry & 0xF0000000) == 0x80000000;
+	return text0_valid && entry_valid;
+}
 /*
 dol Header:
 --> The dol header have a fixed size of 0x100. But in the dol_parse_header when you add all the memory space it would be 0xE4, this is okay as rest all of the space is considered as padding.
@@ -76,160 +76,160 @@ dol header entrypoint:
 	https://wiki.tockdom.com/wiki/DOL_(File_Format)
 	https://wiibrew.org/wiki/Memory_map
 */
-	static bool read_u32_array(RzBuffer *b, ut64 *off, ut32 *dst, int n) {
-		for (int i = 0; i < n; i++) {
-			if (!rz_buf_read_be32_offset(b, off, &dst[i])) {
-				return false;
-			}
-		}
-		return true;
-	}
-	static bool dol_parse_header(RzBuffer *buf, DolHeader *dol) {
-		ut64 off = 0;
-		return read_u32_array(buf, &off, dol->text_paddr, N_TEXT) &&
-			read_u32_array(buf, &off, dol->data_paddr, N_DATA) &&
-			read_u32_array(buf, &off, dol->text_vaddr, N_TEXT) &&
-			read_u32_array(buf, &off, dol->data_vaddr, N_DATA) &&
-			read_u32_array(buf, &off, dol->text_size, N_TEXT) &&
-			read_u32_array(buf, &off, dol->data_size, N_DATA) &&
-			rz_buf_read_be32_offset(buf, &off, &dol->bss_addr) &&
-			rz_buf_read_be32_offset(buf, &off, &dol->bss_size) &&
-			rz_buf_read_be32_offset(buf, &off, &dol->entrypoint);
-	}
-
-	static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb) {
-		if (!bf || !obj || !buf || rz_buf_size(buf) < DOL_HDR_SIZE) {
+static bool read_u32_array(RzBuffer *b, ut64 *off, ut32 *dst, int n) {
+	for (int i = 0; i < n; i++) {
+		if (!rz_buf_read_be32_offset(b, off, &dst[i])) {
 			return false;
 		}
-		DolHeader *dol = RZ_NEW0(DolHeader);
-		if (!dol) {
-			return false;
-		}
-		if (!dol_parse_header(buf, dol)) {
-			free(dol);
-			return false;
-		}
-		obj->bin_obj = dol;
-		return true;
 	}
+	return true;
+}
+static bool dol_parse_header(RzBuffer *buf, DolHeader *dol) {
+	ut64 off = 0;
+	return read_u32_array(buf, &off, dol->text_paddr, N_TEXT) &&
+		read_u32_array(buf, &off, dol->data_paddr, N_DATA) &&
+		read_u32_array(buf, &off, dol->text_vaddr, N_TEXT) &&
+		read_u32_array(buf, &off, dol->data_vaddr, N_DATA) &&
+		read_u32_array(buf, &off, dol->text_size, N_TEXT) &&
+		read_u32_array(buf, &off, dol->data_size, N_DATA) &&
+		rz_buf_read_be32_offset(buf, &off, &dol->bss_addr) &&
+		rz_buf_read_be32_offset(buf, &off, &dol->bss_size) &&
+		rz_buf_read_be32_offset(buf, &off, &dol->entrypoint);
+}
 
-	static RzPVector *sections(RzBinFile *bf) {
-		rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
+static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb) {
+	if (!bf || !obj || !buf || rz_buf_size(buf) < DOL_HDR_SIZE) {
+		return false;
+	}
+	DolHeader *dol = RZ_NEW0(DolHeader);
+	if (!dol) {
+		return false;
+	}
+	if (!dol_parse_header(buf, dol)) {
+		free(dol);
+		return false;
+	}
+	obj->bin_obj = dol;
+	return true;
+}
 
-		DolHeader *dol = bf->o->bin_obj;
-		RzPVector *ret = rz_pvector_new(NULL);
-		if (!ret) {
-			return NULL;
-		}
+static RzPVector *sections(RzBinFile *bf) {
+	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
+
+	DolHeader *dol = bf->o->bin_obj;
+	RzPVector *ret = rz_pvector_new(NULL);
+	if (!ret) {
+		return NULL;
+	}
 		
-		for (int i = 0; i < N_TEXT; i++) {
-			if (!dol->text_paddr[i] ||
-				!dol->text_vaddr[i] ||
-				!dol->text_size[i]) {
-				continue;
-			}
-			RzBinSection *s = RZ_NEW0(RzBinSection);
-			s->name = rz_str_newf("text_%d", i);
-			s->paddr = dol->text_paddr[i];
-			s->vaddr = dol->text_vaddr[i];
-			s->size  = dol->text_size[i];
-			s->vsize = s->size;
-			s->perm  = rz_str_rwx("r-x");
-			rz_pvector_push(ret, s);
+	for (int i = 0; i < N_TEXT; i++) {
+		if (!dol->text_paddr[i] ||
+			!dol->text_vaddr[i] ||
+			!dol->text_size[i]) {
+			continue;
 		}
+		RzBinSection *s = RZ_NEW0(RzBinSection);
+		s->name = rz_str_newf("text_%d", i);
+		s->paddr = dol->text_paddr[i];
+		s->vaddr = dol->text_vaddr[i];
+		s->size  = dol->text_size[i];
+		s->vsize = s->size;
+		s->perm  = rz_str_rwx("r-x");
+		rz_pvector_push(ret, s);
+}
 
-		for (int i = 0; i < N_DATA; i++) {
-			if (!dol->data_paddr[i] ||
-				!dol->data_vaddr[i] ||
-				!dol->data_size[i]) {
-				continue;
-			}
-			RzBinSection *s = RZ_NEW0(RzBinSection);
-			s->name = rz_str_newf("data_%d", i);
-			s->paddr = dol->data_paddr[i];
-			s->vaddr = dol->data_vaddr[i];
-			s->size  = dol->data_size[i];
-			s->vsize = s->size;
-			s->perm  = rz_str_rwx("r--");
-			rz_pvector_push(ret, s);
+	for (int i = 0; i < N_DATA; i++) {
+		if (!dol->data_paddr[i] ||
+			!dol->data_vaddr[i] ||
+			!dol->data_size[i]) {
+			continue;
 		}
-
-		if (dol->bss_size) {
-			RzBinSection *bss = RZ_NEW0(RzBinSection);
-			bss->name  = rz_str_dup("bss");
-			bss->paddr = UT64_MAX;
-			bss->vaddr = dol->bss_addr;
-			bss->size  = dol->bss_size;
-			bss->vsize = bss->size;
-			bss->perm  = rz_str_rwx("rw-");
-			rz_pvector_push(ret, bss);
-		}
-
-		return ret;
+		RzBinSection *s = RZ_NEW0(RzBinSection);
+		s->name = rz_str_newf("data_%d", i);
+		s->paddr = dol->data_paddr[i];
+		s->vaddr = dol->data_vaddr[i];
+		s->size  = dol->data_size[i];
+		s->vsize = s->size;
+		s->perm  = rz_str_rwx("r--");
+		rz_pvector_push(ret, s);
 	}
 
-	static RzPVector *entries(RzBinFile *bf) {
-		rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
-
-		DolHeader *dol = bf->o->bin_obj;
-		RzPVector *ret = rz_pvector_new(NULL);
-		if (!ret) {
-			return NULL;
-		}
-
-		RzBinAddr *addr = RZ_NEW0(RzBinAddr);
-		if (!addr) {
-			rz_pvector_free(ret);
-			return NULL;
-		}
-
-		addr->vaddr = dol->entrypoint;
-		addr->paddr = UT64_MAX; 
-
-		rz_pvector_push(ret, addr);
-		return ret;
+	if (dol->bss_size) {
+		RzBinSection *bss = RZ_NEW0(RzBinSection);
+		bss->name  = rz_str_dup("bss");
+		bss->paddr = UT64_MAX;
+		bss->vaddr = dol->bss_addr;
+		bss->size  = dol->bss_size;
+		bss->vsize = bss->size;
+		bss->perm  = rz_str_rwx("rw-");
+		rz_pvector_push(ret, bss);
 	}
 
-	static RzBinInfo *info(RzBinFile *bf) {
-		RzBinInfo *ret = RZ_NEW0(RzBinInfo);
-		if (!ret) {
-			return NULL;
-		}
+	return ret;
+}
 
-		ret->file = rz_str_dup(bf->file);
-		ret->big_endian = true;
-		ret->type = rz_str_dup("ROM");
-		ret->machine = rz_str_dup("Nintendo Wii");
-		ret->os = rz_str_dup("wii-ios");
-		ret->arch = rz_str_dup("ppc");
-		ret->bits = 32;
-		ret->has_va = true;
+static RzPVector *entries(RzBinFile *bf) {
+	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
 
-		return ret;
+	DolHeader *dol = bf->o->bin_obj;
+	RzPVector *ret = rz_pvector_new(NULL);
+	if (!ret) {
+		return NULL;
 	}
 
-	static ut64 baddr(RzBinFile *bf) {
-		return 0x80004000;
+	RzBinAddr *addr = RZ_NEW0(RzBinAddr);
+	if (!addr) {
+		rz_pvector_free(ret);
+		return NULL;
 	}
 
-	RzBinPlugin rz_bin_plugin_dol = {
-		.name = "dol",
-		.desc = "Nintendo Dolphin binary",
-		.license = "BSD",
-		.author = "pancake",
-		.check_buffer = &check_buffer,
-		.load_buffer = &load_buffer,
-		.entries = &entries,
-		.sections = &sections,
-		.maps = &rz_bin_maps_of_file_sections,
-		.info = &info,
-		.baddr = &baddr,
-	};
+	addr->vaddr = dol->entrypoint;
+	addr->paddr = UT64_MAX; 
 
-	#ifndef RZ_PLUGIN_INCORE
-	RZ_API RzLibStruct rizin_plugin = {
-		.type = RZ_LIB_TYPE_BIN,
-		.data = &rz_bin_plugin_dol,
-		.version = RZ_VERSION
-	};
-	#endif
+	rz_pvector_push(ret, addr);
+	return ret;
+}
+
+static RzBinInfo *info(RzBinFile *bf) {
+	RzBinInfo *ret = RZ_NEW0(RzBinInfo);
+	if (!ret) {
+		return NULL;
+	}
+
+	ret->file = rz_str_dup(bf->file);
+	ret->big_endian = true;
+	ret->type = rz_str_dup("ROM");
+	ret->machine = rz_str_dup("Nintendo Wii");
+	ret->os = rz_str_dup("wii-ios");
+	ret->arch = rz_str_dup("ppc");
+	ret->bits = 32;
+	ret->has_va = true;
+
+	return ret;
+}
+
+static ut64 baddr(RzBinFile *bf) {
+	return 0x80004000;
+}
+
+RzBinPlugin rz_bin_plugin_dol = {
+	.name = "dol",
+	.desc = "Nintendo Dolphin binary",
+	.license = "BSD",
+	.author = "pancake",
+	.check_buffer = &check_buffer,
+	.load_buffer = &load_buffer,
+	.entries = &entries,
+	.sections = &sections,
+	.maps = &rz_bin_maps_of_file_sections,
+	.info = &info,
+	.baddr = &baddr,
+};
+
+#ifndef RZ_PLUGIN_INCORE
+RZ_API RzLibStruct rizin_plugin = {
+	.type = RZ_LIB_TYPE_BIN,
+	.data = &rz_bin_plugin_dol,
+	.version = RZ_VERSION
+};
+#endif

--- a/librz/bin/p/bin_dol.c
+++ b/librz/bin/p/bin_dol.c
@@ -1,217 +1,235 @@
-// SPDX-FileCopyrightText: 2015-2019 pancake <pancake@nopcode.org>
-// SPDX-License-Identifier: LGPL-3.0-only
+	// SPDX-FileCopyrightText: 2015-2019 pancake <pancake@nopcode.org>
+	// SPDX-License-Identifier: LGPL-3.0-only
 
-#include <rz_types.h>
-#include <rz_util.h>
-#include <rz_lib.h>
-#include <rz_bin.h>
-#include <string.h>
+	#include <rz_types.h>
+	#include <rz_util.h>
+	#include <rz_lib.h>
+	#include <rz_bin.h>
+	#include <string.h>
 
-/*
-   Start	End	Length	Description
-   0x0	0x3	4	File offset to start of Text0
-   0x04	0x1b	24	File offsets for Text1..6
-   0x1c	0x47	44	File offsets for Data0..10
-   0x48	0x4B	4	Loading address for Text0
-   0x4C	0x8F	68	Loading addresses for Text1..6, Data0..10
-   0x90	0xD7	72	Section sizes for Text0..6, Data0..10
-   0xD8	0xDB	4	BSS address
-   0xDC	0xDF	4	BSS size
-   0xE0	0xE3	4	Entry point
-   0xE4	0xFF		padding
- */
+	/*
+	Start	End	Length	Description
+	0x0	0x3	4	File offset to start of Text0
+	0x04	0x1b	24	File offsets for Text1..6
+	0x1c	0x47	44	File offsets for Data0..10
+	0x48	0x4B	4	Loading address for Text0
+	0x4C	0x8F	68	Loading addresses for Text1..6, Data0..10
+	0x90	0xD7	72	Section sizes for Text0..6, Data0..10
+	0xD8	0xDB	4	BSS address
+	0xDC	0xDF	4	BSS size
+	0xE0	0xE3	4	Entry point
+	0xE4	0xFF		padding
+	*/
 
-#define N_TEXT 7
-#define N_DATA 11
-#define DOL_HDR_SIZE 0x100           
+	#define N_TEXT 7
+	#define N_DATA 11
+	#define DOL_HDR_SIZE 0x100
 
+	typedef struct dol_header_s {
+		ut32 text_paddr[N_TEXT];
+		ut32 data_paddr[N_DATA];
+		ut32 text_vaddr[N_TEXT];
+		ut32 data_vaddr[N_DATA];
+		ut32 text_size[N_TEXT];
+		ut32 data_size[N_DATA];
+		ut32 bss_addr;
+		ut32 bss_size;
+		ut32 entrypoint;
+		ut32 padding[10];
+	} DolHeader;
 
-typedef struct {
-	ut32 text_paddr[N_TEXT];
-	ut32 data_paddr[N_DATA];
-	ut32 text_vaddr[N_TEXT];
-	ut32 data_vaddr[N_DATA];
-	ut32 text_size[N_TEXT];
-	ut32 data_size[N_DATA];
-	ut32 bss_addr;
-	ut32 bss_size;
-	ut32 entrypoint;
-	}
-DolHeader;
-
-static bool read_u32_array(RzBuffer *buf, ut64 *offset, ut32 *arr, size_t count) {
-	for (size_t i = 0; i < count; i++) {
-		if (!rz_buf_read_be32_offset(buf, offset, &arr[i])) {
+	static bool check_buffer(RzBuffer *buf) {
+		if (!buf || rz_buf_size(buf) < DOL_HDR_SIZE) {
 			return false;
 		}
-	}
-	return true;
-}
-
-static bool dol_parse_header(RzBuffer *buf, DolHeader *dol) {
-	ut64 off = 0;
-	return read_u32_array(buf, &off, dol->text_paddr, N_TEXT) &&
-		read_u32_array(buf, &off, dol->data_paddr, N_DATA) &&
-		read_u32_array(buf, &off, dol->text_vaddr, N_TEXT) &&
-		read_u32_array(buf, &off, dol->data_vaddr, N_DATA) &&
-		read_u32_array(buf, &off, dol->text_size, N_TEXT) &&
-		read_u32_array(buf, &off, dol->data_size, N_DATA) &&
-		rz_buf_read_be32_offset(buf, &off, &dol->bss_addr) &&
-		rz_buf_read_be32_offset(buf, &off, &dol->bss_size) &&
-		rz_buf_read_be32_offset(buf, &off, &dol->entrypoint);
-}
-
-static bool check_buffer(RzBuffer *buf) { 
-	if (!buf || rz_buf_size(buf) < DOL_HDR_SIZE) {
-		 return false;
-	 } 
-	ut32 text0_off, entry;
-    if (!rz_buf_read_be32_at(buf, 0x00, &text0_off)) { 
-		return false; 
-	} 
-	if (!rz_buf_read_be32_at(buf, 0xE0, &entry)) { 
-		return false; 
-	}  
-	bool text0_valid = (text0_off >= 0x100) && (text0_off % 4 == 0);
-	bool entry_valid = (entry & 0xF0000000) == 0x80000000;
-
-	return text0_valid && entry_valid;
-}
-static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb) {
-	if (rz_buf_size(buf) < DOL_HDR_SIZE) {
-		return false;
-	}
-	DolHeader *dol = RZ_NEW0(DolHeader);
-	if (!dol) {
-		return false;
-	}
-	char *lowername = rz_str_dup(bf->file);
-	if (!lowername) {
-		goto dol_err;
-	}
-	rz_str_case(lowername, 0);
-	char *ext = strstr(lowername, ".dol");
-	if (!ext || ext[4] != 0) {
-		goto lowername_err;
-	}
-	free(lowername);
-	if (!dol_parse_header(buf, dol)) {
-		goto dol_err;
-	}
-	obj->bin_obj = dol;
-	return true;
-
-lowername_err:
-	free(lowername);
-	free(dol);
-	return false;
-dol_err:
-	free(dol);
-	return false;
-}
-
-static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
-	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
-	int i;
-	RzPVector *ret;
-	RzBinSection *s;
-	DolHeader *dol = bf->o->bin_obj;
-	if (!(ret = rz_pvector_new(NULL))) {
-		return NULL;
-	}
-
-	/* text sections */
-	for (i = 0; i < N_TEXT; i++) {
-		if (!dol->text_paddr[i] || !dol->text_vaddr[i]) {
-			continue;
+		ut32 text0_off, entry;
+		if (!rz_buf_read_be32_at(buf, 0x00, &text0_off)) {
+			return false;
 		}
-		s = RZ_NEW0(RzBinSection);
-		s->name = rz_str_newf("text_%d", i);
-		s->paddr = dol->text_paddr[i];
-		s->vaddr = dol->text_vaddr[i];
-		s->size = dol->text_size[i];
-		s->vsize = s->size;
-		s->perm = rz_str_rwx("r-x");
-		rz_pvector_push(ret, s);
-	}
-	/* data sections */
-	for (i = 0; i < N_DATA; i++) {
-		if (!dol->data_paddr[i] || !dol->data_vaddr[i]) {
-			continue;
+		if (!rz_buf_read_be32_at(buf, 0xE0, &entry)) {
+			return false;
 		}
-		s = RZ_NEW0(RzBinSection);
-		s->name = rz_str_newf("data_%d", i);
-		s->paddr = dol->data_paddr[i];
-		s->vaddr = dol->data_vaddr[i];
-		s->size = dol->data_size[i];
-		s->vsize = s->size;
-		s->perm = rz_str_rwx("r--");
-		rz_pvector_push(ret, s);
+
+		bool text0_valid = (text0_off >= DOL_HDR_SIZE) && (text0_off < rz_buf_size(buf)) && (text0_off % 4 == 0);
+		bool entry_valid = (entry >= 0x80004000 && entry <  0x81200000);
+		return text0_valid && entry_valid;
 	}
-	/* bss section */
-	s = RZ_NEW0(RzBinSection);
-	s->name = rz_str_dup("bss");
-	s->paddr = 0;
-	s->vaddr = dol->bss_addr;
-	s->size = dol->bss_size;
-	s->vsize = s->size;
-	s->perm = rz_str_rwx("rw-");
-	rz_pvector_push(ret, s);
+/*
+dol Header:
+--> The dol header have a fixed size of 0x100. But in the dol_parse_header when you add all the memory space it would be 0xE4, this is okay as rest all of the space is considered as padding.
 
-	return ret;
-}
+	0x100 - 0xE4 = padding 
 
-static RzPVector /*<RzBinAddr *>*/ *entries(RzBinFile *bf) {
-	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
-	RzPVector *ret = rz_pvector_new(NULL);
-	RzBinAddr *addr = RZ_NEW0(RzBinAddr);
-	DolHeader *dol = bf->o->bin_obj;
-	addr->vaddr = (ut64)dol->entrypoint;
-	addr->paddr = addr->vaddr & 0xFFFF;
-	rz_pvector_push(ret, addr);
-	return ret;
-}
+Generally this padding is ignored.
+dol header entrypoint:
+--> Previously, we validated whether a file was a DOL file by comparing the first 6 bytes with a magic value. This method was weak and unreliable.
 
-static RzBinInfo *info(RzBinFile *bf) {
-	rz_return_val_if_fail(bf && bf->buf, NULL);
-	RzBinInfo *ret = RZ_NEW0(RzBinInfo);
-	if (!ret) {
-		return NULL;
+--> We have now introduced a more robust validation method based on the entrypoint address range.
+
+--> A valid DOL entrypoint must fall within the memory range:
+
+      (0x80004000 <–> 0x81200000)
+
+--> By verifying that the entrypoint lies within this range, we can more confidently determine whether the file is a valid DOL  file. This also improves the overall reliability of DOL file detection.
+
+--> Reference:
+	https://wiki.tockdom.com/wiki/DOL_(File_Format)
+	https://wiibrew.org/wiki/Memory_map
+*/
+	static bool read_u32_array(RzBuffer *b, ut64 *off, ut32 *dst, int n) {
+		for (int i = 0; i < n; i++) {
+			if (!rz_buf_read_be32_offset(b, off, &dst[i])) {
+				return false;
+			}
+		}
+		return true;
 	}
-	ret->file = rz_str_dup(bf->file);
-	ret->big_endian = true;
-	ret->type = rz_str_dup("ROM");
-	ret->machine = rz_str_dup("Nintendo Wii");
-	ret->os = rz_str_dup("wii-ios");
-	ret->arch = rz_str_dup("ppc");
-	ret->has_va = true;
-	ret->bits = 32;
+	static bool dol_parse_header(RzBuffer *buf, DolHeader *dol) {
+		ut64 off = 0;
+		return read_u32_array(buf, &off, dol->text_paddr, N_TEXT) &&
+			read_u32_array(buf, &off, dol->data_paddr, N_DATA) &&
+			read_u32_array(buf, &off, dol->text_vaddr, N_TEXT) &&
+			read_u32_array(buf, &off, dol->data_vaddr, N_DATA) &&
+			read_u32_array(buf, &off, dol->text_size, N_TEXT) &&
+			read_u32_array(buf, &off, dol->data_size, N_DATA) &&
+			rz_buf_read_be32_offset(buf, &off, &dol->bss_addr) &&
+			rz_buf_read_be32_offset(buf, &off, &dol->bss_size) &&
+			rz_buf_read_be32_offset(buf, &off, &dol->entrypoint);
+	}
 
-	return ret;
-}
+	static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb) {
+		if (!bf || !obj || !buf || rz_buf_size(buf) < DOL_HDR_SIZE) {
+			return false;
+		}
+		DolHeader *dol = RZ_NEW0(DolHeader);
+		if (!dol) {
+			return false;
+		}
+		if (!dol_parse_header(buf, dol)) {
+			free(dol);
+			return false;
+		}
+		obj->bin_obj = dol;
+		return true;
+	}
 
-static ut64 baddr(RzBinFile *bf) {
-	return 0x80b00000; // XXX
-}
+	static RzPVector *sections(RzBinFile *bf) {
+		rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
 
-RzBinPlugin rz_bin_plugin_dol = {
-	.name = "dol",
-	.desc = "Nintendo Dolphin binary",
-	.license = "BSD",
-	.author = "pancake",
-	.load_buffer = &load_buffer,
-	.baddr = &baddr,
-	.check_buffer = &check_buffer,
-	.entries = &entries,
-	.maps = &rz_bin_maps_of_file_sections,
-	.sections = &sections,
-	.info = &info,
-};
+		DolHeader *dol = bf->o->bin_obj;
+		RzPVector *ret = rz_pvector_new(NULL);
+		if (!ret) {
+			return NULL;
+		}
+		
+		for (int i = 0; i < N_TEXT; i++) {
+			if (!dol->text_paddr[i] ||
+				!dol->text_vaddr[i] ||
+				!dol->text_size[i]) {
+				continue;
+			}
+			RzBinSection *s = RZ_NEW0(RzBinSection);
+			s->name = rz_str_newf("text_%d", i);
+			s->paddr = dol->text_paddr[i];
+			s->vaddr = dol->text_vaddr[i];
+			s->size  = dol->text_size[i];
+			s->vsize = s->size;
+			s->perm  = rz_str_rwx("r-x");
+			rz_pvector_push(ret, s);
+		}
 
-#ifndef RZ_PLUGIN_INCORE
-RZ_API RzLibStruct rizin_plugin = {
-	.type = RZ_LIB_TYPE_BIN,
-	.data = &rz_bin_plugin_dol,
-	.version = RZ_VERSION
-};
-#endif
+		for (int i = 0; i < N_DATA; i++) {
+			if (!dol->data_paddr[i] ||
+				!dol->data_vaddr[i] ||
+				!dol->data_size[i]) {
+				continue;
+			}
+			RzBinSection *s = RZ_NEW0(RzBinSection);
+			s->name = rz_str_newf("data_%d", i);
+			s->paddr = dol->data_paddr[i];
+			s->vaddr = dol->data_vaddr[i];
+			s->size  = dol->data_size[i];
+			s->vsize = s->size;
+			s->perm  = rz_str_rwx("r--");
+			rz_pvector_push(ret, s);
+		}
+
+		if (dol->bss_size) {
+			RzBinSection *bss = RZ_NEW0(RzBinSection);
+			bss->name  = rz_str_dup("bss");
+			bss->paddr = UT64_MAX;
+			bss->vaddr = dol->bss_addr;
+			bss->size  = dol->bss_size;
+			bss->vsize = bss->size;
+			bss->perm  = rz_str_rwx("rw-");
+			rz_pvector_push(ret, bss);
+		}
+
+		return ret;
+	}
+
+	static RzPVector *entries(RzBinFile *bf) {
+		rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
+
+		DolHeader *dol = bf->o->bin_obj;
+		RzPVector *ret = rz_pvector_new(NULL);
+		if (!ret) {
+			return NULL;
+		}
+
+		RzBinAddr *addr = RZ_NEW0(RzBinAddr);
+		if (!addr) {
+			rz_pvector_free(ret);
+			return NULL;
+		}
+
+		addr->vaddr = dol->entrypoint;
+		addr->paddr = UT64_MAX; 
+
+		rz_pvector_push(ret, addr);
+		return ret;
+	}
+
+	static RzBinInfo *info(RzBinFile *bf) {
+		RzBinInfo *ret = RZ_NEW0(RzBinInfo);
+		if (!ret) {
+			return NULL;
+		}
+
+		ret->file = rz_str_dup(bf->file);
+		ret->big_endian = true;
+		ret->type = rz_str_dup("ROM");
+		ret->machine = rz_str_dup("Nintendo Wii");
+		ret->os = rz_str_dup("wii-ios");
+		ret->arch = rz_str_dup("ppc");
+		ret->bits = 32;
+		ret->has_va = true;
+
+		return ret;
+	}
+
+	static ut64 baddr(RzBinFile *bf) {
+		return 0x80004000;
+	}
+
+	RzBinPlugin rz_bin_plugin_dol = {
+		.name = "dol",
+		.desc = "Nintendo Dolphin binary",
+		.license = "BSD",
+		.author = "pancake",
+		.check_buffer = &check_buffer,
+		.load_buffer = &load_buffer,
+		.entries = &entries,
+		.sections = &sections,
+		.maps = &rz_bin_maps_of_file_sections,
+		.info = &info,
+		.baddr = &baddr,
+	};
+
+	#ifndef RZ_PLUGIN_INCORE
+	RZ_API RzLibStruct rizin_plugin = {
+		.type = RZ_LIB_TYPE_BIN,
+		.data = &rz_bin_plugin_dol,
+		.version = RZ_VERSION
+	};
+	#endif

--- a/librz/bin/p/bin_dol.c
+++ b/librz/bin/p/bin_dol.c
@@ -39,20 +39,19 @@ typedef struct dol_header_s {
 } DolHeader;
 
 /*
-	Performs a check on the buffer to verify if is a DOL header.
-	The DOL format does not have a magic, thus requires some heuristics to detect it.
-	The size is always 0x100 and thus we expect the text0 offset to alway start after 0x100.
+   Performs a check on the buffer to verify if is a DOL header.
+   The DOL format does not have a magic, thus requires some heuristics to detect it.
+   The size is always 0x100 and thus we expect the text0 offset to alway start after 0x100.
 
-	On the Broadway the executable range starts from 0x80000000 till 0x80003F00 for iOS and for applications between the 0x80003F00 and 0x81330000.
-	Thus, we expect the entrypoint for these files to always have the MSB to 1.
+   On the Broadway the executable range starts from 0x80000000 till 0x80003F00 for iOS and for applications between the 0x80003F00 and 0x81330000.
+   Thus, we expect the entrypoint for these files to always have the MSB to 1.
 
-	Reference:
-		https://wiki.tockdom.com/wiki/DOL_(File_Format)
-		https://wiibrew.org/wiki/Memory_map
+   Reference:
+   	https://wiki.tockdom.com/wiki/DOL_(File_Format)
+   	https://wiibrew.org/wiki/Memory_map
  */
 
-static bool
-check_buffer(RzBuffer *buf) {
+static bool check_buffer(RzBuffer *buf) {
 	if (!buf || rz_buf_size(buf) < DOL_HDR_SIZE) {
 		return false;
 	}
@@ -77,6 +76,7 @@ static bool read_u32_array(RzBuffer *b, ut64 *off, ut32 *dst, int n) {
 	}
 	return true;
 }
+
 static bool dol_parse_header(RzBuffer *buf, DolHeader *dol) {
 	ut64 off = 0;
 	return read_u32_array(buf, &off, dol->text_paddr, N_TEXT) &&
@@ -110,7 +110,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
 
 	DolHeader *dol = bf->o->bin_obj;
-	RzPVector *ret = rz_pvector_new(NULL);
+	RzPVector *ret = rz_pvector_new((RzPVectorFree)free);
 	if (!ret) {
 		return NULL;
 	}
@@ -123,6 +123,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		}
 		RzBinSection *s = RZ_NEW0(RzBinSection);
 		if (!s) {
+			rz_pvector_free(ret);
 			return NULL;
 		}
 		s->name = rz_str_newf("text_%d", i);
@@ -142,6 +143,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		}
 		RzBinSection *s = RZ_NEW0(RzBinSection);
 		if (!s) {
+			rz_pvector_free(ret);
 			return NULL;
 		}
 		s->name = rz_str_newf("data_%d", i);
@@ -156,6 +158,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	if (dol->bss_size) {
 		RzBinSection *bss = RZ_NEW0(RzBinSection);
 		if (!bss) {
+			rz_pvector_free(ret);
 			return NULL;
 		}
 		bss->name = rz_str_dup("bss");
@@ -168,10 +171,11 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	}
 	return ret;
 }
+
 static RzPVector *entries(RzBinFile *bf) {
 	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
 	DolHeader *dol = bf->o->bin_obj;
-	RzPVector *ret = rz_pvector_new(NULL);
+	RzPVector *ret = rz_pvector_new((RzPVectorFree)free);
 	if (!ret) {
 		return NULL;
 	}

--- a/test/db/formats/dol
+++ b/test/db/formats/dol
@@ -6,16 +6,13 @@ RUN
 
 NAME=DOL: sqrxz4 - iI
 FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iI~?wii
+CMDS=<<EOF
+iI~?wii
+iI
+ie~program[0]
+EOF
 EXPECT=<<EOF
 2
-EOF
-RUN
-
-NAME=DOL: sqrxz4 - iI
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=iI
-EXPECT=<<EOF
 arch     ppc
 cpu      N/A
 features N/A
@@ -52,6 +49,7 @@ canary   false
 PIE      false
 RELROCS  false
 NX       false
+0x80003100
 EOF
 RUN
 
@@ -74,14 +72,3 @@ addr,size,space,name,realname
 0x800ffc60,3434688,sections,section.bss,section.bss
 EOF
 RUN
-
-NAME=DOL: sqrxz4 - entry point
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=ie~program[0]
-EXPECT=<<EOF
-0x80003100
-EOF
-RUN
-
-
-

--- a/test/db/formats/dol
+++ b/test/db/formats/dol
@@ -4,6 +4,12 @@ CMDS=q!
 EXPECT=
 RUN
 
+NAME=DOL: sqrxz4 - aa
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=aa
+EXPECT=
+RUN
+
 NAME=DOL: sqrxz4 - iI
 FILE=bins/dol/sqrxz4-gc.dol
 CMDS=<<EOF

--- a/test/db/formats/dol
+++ b/test/db/formats/dol
@@ -51,8 +51,8 @@ NX       false
 0x000cda80  0x2f200 0x800d0a60  0x2f200   0x0 -r-- data_0      
 ---------- 0x3468c0 0x800ffc60 0x3468c0   0x0 -rw- bss         
 ---
-     vaddr      paddr     hvaddr      haddr type
-------------------------------------------------------------
+     vaddr      paddr     hvaddr      haddr type    
+----------------------------------------------------
 0x80003100 ---------- ---------- ---------- program
 EOF
 RUN

--- a/test/db/formats/dol
+++ b/test/db/formats/dol
@@ -4,6 +4,8 @@ CMDS=<<EOF
 iI
 echo ---
 iS
+echo ---
+ie
 EOF
 EXPECT=<<EOF
 arch     ppc
@@ -29,7 +31,7 @@ minopsz  4
 os       wii-ios
 cc       N/A
 rpath    N/A
-subsys
+subsys   
 stripped false
 crypto   false
 havecode true
@@ -43,10 +45,14 @@ PIE      false
 RELROCS  false
 NX       false
 ---
-     paddr     size      vaddr    vsize align perm name   type flags
+     paddr     size      vaddr    vsize align perm name   type flags 
 ---------------------------------------------------------------------
-0x00000100  0xcd960 0x80003100  0xcd960   0x0 -r-x text_0
-0x000cda80  0x2f200 0x800d0a60  0x2f200   0x0 -r-- data_0
----------- 0x3468c0 0x800ffc60 0x3468c0   0x0 -rw- bss
+0x00000100  0xcd960 0x80003100  0xcd960   0x0 -r-x text_0      
+0x000cda80  0x2f200 0x800d0a60  0x2f200   0x0 -r-- data_0      
+---------- 0x3468c0 0x800ffc60 0x3468c0   0x0 -rw- bss         
+---
+     vaddr      paddr     hvaddr      haddr type
+------------------------------------------------------------
+0x80003100 ---------- ---------- ---------- program
 EOF
 RUN

--- a/test/db/formats/dol
+++ b/test/db/formats/dol
@@ -11,3 +11,77 @@ EXPECT=<<EOF
 2
 EOF
 RUN
+
+NAME=DOL: sqrxz4 - iI
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=iI
+EXPECT=<<EOF
+arch     ppc
+cpu      N/A
+features N/A
+baddr    0x80b00000
+binsz    0x000fcc80
+bintype  N/A
+bits     32
+retguard false
+class    N/A
+compiler N/A
+dbg_file N/A
+endian   BE
+hdr.csum N/A
+guid     N/A
+intrp    N/A
+laddr    0x00000000
+lang     N/A
+machine  Nintendo Wii
+maxopsz  4
+minopsz  4
+os       wii-ios
+cc       N/A
+rpath    N/A
+subsys
+stripped false
+crypto   false
+havecode true
+va       true
+sanitiz  false
+static   true
+linenum  false
+lsyms    false
+canary   false
+PIE      false
+RELROCS  false
+NX       false
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - aflt 
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=aflt:json
+EXPECT=<<EOF
+[{"addr":2147496192,"name":"entry0","size":2384,"xrefsTo":7,"xrefsFrom":64,"calls":42,"nbbs":63,"edges":94,"cc":33,"noreturn":"false"}]
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - flt csv
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=flt:csv
+EXPECT=<<EOF
+addr,size,space,name,realname
+0x80003100,550176,symbols,entry0,entry0
+0x80003100,842080,sections,section.text_0,section.text_0
+0x800d0a60,193024,sections,section.data_0,section.data_0
+0x800ffc60,3434688,sections,section.bss,section.bss
+EOF
+RUN
+
+NAME=DOL: sqrxz4 - entry point
+FILE=bins/dol/sqrxz4-gc.dol
+CMDS=ie~program[0]
+EXPECT=<<EOF
+0x80003100
+EOF
+RUN
+
+
+

--- a/test/db/formats/dol
+++ b/test/db/formats/dol
@@ -1,28 +1,15 @@
-NAME=DOL: sqrxz4 - open
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=q!
-EXPECT=
-RUN
-
 NAME=DOL: sqrxz4 - aa
 FILE=bins/dol/sqrxz4-gc.dol
-CMDS=aa
-EXPECT=
-RUN
-
-NAME=DOL: sqrxz4 - iI
-FILE=bins/dol/sqrxz4-gc.dol
 CMDS=<<EOF
-iI~?wii
 iI
-ie~program[0]
+echo ---
+iS
 EOF
 EXPECT=<<EOF
-2
 arch     ppc
 cpu      N/A
 features N/A
-baddr    0x80b00000
+baddr    0x80004000
 binsz    0x000fcc80
 bintype  N/A
 bits     32
@@ -55,26 +42,11 @@ canary   false
 PIE      false
 RELROCS  false
 NX       false
-0x80003100
-EOF
-RUN
-
-NAME=DOL: sqrxz4 - aflt 
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=aflt:json
-EXPECT=<<EOF
-[{"addr":2147496192,"name":"entry0","size":2384,"xrefsTo":7,"xrefsFrom":64,"calls":42,"nbbs":63,"edges":94,"cc":33,"noreturn":"false"}]
-EOF
-RUN
-
-NAME=DOL: sqrxz4 - flt csv
-FILE=bins/dol/sqrxz4-gc.dol
-CMDS=flt:csv
-EXPECT=<<EOF
-addr,size,space,name,realname
-0x80003100,550176,symbols,entry0,entry0
-0x80003100,842080,sections,section.text_0,section.text_0
-0x800d0a60,193024,sections,section.data_0,section.data_0
-0x800ffc60,3434688,sections,section.bss,section.bss
+---
+     paddr     size      vaddr    vsize align perm name   type flags
+---------------------------------------------------------------------
+0x00000100  0xcd960 0x80003100  0xcd960   0x0 -r-x text_0
+0x000cda80  0x2f200 0x800d0a60  0x2f200   0x0 -r-- data_0
+---------- 0x3468c0 0x800ffc60 0x3468c0   0x0 -rw- bss
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Refactored `librz/bin/p/bin_dol.c ` to remove the use of RZ_PACKED structs for dol files. Using a function dol_parse_header to read through all the values.
check_buffer updated to remove memcpy usage.
Added some documentation too for the change in validation of dol files.
In the last pull request i by mistake commited some random junk in it. i am sorry i had to close it and make new.

...

**Test plan**

I have added a test file too. By which you can test my code.
...

**Closing issues**

closes #5813

...
