### PR TITLE
Console: Escape reverse-search and forward search from escape key

### DIFF
--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -1846,6 +1846,9 @@ RZ_API const char *rz_line_readline_cb(RZ_NONNULL RzLine *line, RzLineReadCallba
 				if (line->sel_widget) {
 					selection_widget_erase(line);
 				}
+				line->buffer.index = line->buffer.length = line->gcomp = 0;
+				*line->buffer.data = '\0';
+				goto _end;
 				break;
 			case 1: // begin
 				line->buffer.index = 0;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Generally `Esc` key is only used in visual mode of rizin, here when in backward-search or in forward search if `Esc` key is pressed it exits from either of the search in which you be in.

**Test plan**

Try to enter backward-search in rizin console by `ctrl+R` and then hit `Esc` key it exits from the search mode.

**Closing issues**

Closes #573
