### PR TITLE
rz-test: Actually revert to cwd if `db/` dir not found

### DIFF
--- a/binrz/rz-test/rz-test.c
+++ b/binrz/rz-test/rz-test.c
@@ -313,18 +313,17 @@ int rz_test_main(int argc, const char **argv) {
 	}
 
 	cwd = rz_sys_getdir();
-	if (rz_test_dir) {
-		if (chdir(rz_test_dir) == -1) {
-			eprintf("Cannot find %s directory.\n", rz_test_dir);
-			ret = -1;
-			goto beach;
-		}
-	} else {
+	if (!rz_test_dir) {
 		bool dir_found = rz_test_chdir_fromtest(opt.ind < argc ? argv[opt.ind] : NULL);
 		if (!dir_found) {
-			eprintf("Cannot find db/ directory related to the given test. Assuming '-C .'.\n");
-			rz_test_dir = ".";
+			eprintf("Cannot find db/ directory related to the given tests. Assuming '-C .'.\n");
+			rz_test_dir = cwd;
 		}
+	}
+	if (rz_test_dir && chdir(rz_test_dir) == -1) {
+		eprintf("Cannot find %s directory.\n", rz_test_dir);
+		ret = -1;
+		goto beach;
 	}
 
 	if (fuzz_dir) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr makes rz-test, if a `db/` dir is not found, actually revert to the cwd in effect when the rz-test command is executed, overriding any directory changes made by rz_test_chdir_fromtest(). This is so I can remove the "`-C .`" at https://github.com/rizinorg/rz-bindgen/blob/d8565432535fde76e28a66b537671fa30d48fc85/.github/workflows/ci.yml#L132.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
