### PR TITLE
Fix condition for libproc in xnu_debug.h

### DIFF
--- a/librz/debug/p/native/xnu/xnu_debug.h
+++ b/librz/debug/p/native/xnu/xnu_debug.h
@@ -42,8 +42,9 @@
 #define PT_FIRSTMACH   32 /* for machine-specific requests */
 int ptrace(int _request, pid_t _pid, caddr_t _addr, int _data);
 #else
+#include <AvailabilityMacros.h>
 #include <sys/ptrace.h>
-#if !__POWERPC__
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
 #include <sys/proc_info.h>
 #include <libproc.h>
 #define HAS_LIBPROC


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

`libproc` exists since 10.5, it is supported for powerpc in 10.5-10.6. `xnu_threads.c` uses `PROC_PIDTHREADINFO` which needs libproc header. This fixes the build on 10.6 for ppc.
See: https://github.com/rizinorg/rizin/blob/171172efccbf7b65ed8cdbfab00f1307e5b24217/librz/debug/p/native/xnu/xnu_threads.c#L250-L252

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Reproducing will require to run the build on 10.6 ppc natively or on 10.6 x86_64 via Rosetta.
Alternatively, just consult SDK headers, since the fix is trivial.