### PR TITLE
Add support for multiple paths in rz-find

### DIFF
--- a/binrz/man/rz-find.1
+++ b/binrz/man/rz-find.1
@@ -11,12 +11,21 @@
 .Op Fl f/t Ar from/to
 .Op Fl  Ar [e|s|w|S|I] str
 .Op Fl x Ar hex
-.Op Fl  Ar |file|dir ..
+.Ar file|dir
+.Op Ar file|dir ...
 .Sh DESCRIPTION
 This command is part of the Rizin project.
 .Pp
 .Nm rz-find
-Searches for specified byte patterns, strings, or hexpairs in the given files.
+searches for specified byte patterns, strings, or hexpairs in the given files.
+Multiple files and/or directories can be specified as arguments.
+When a directory is provided, it is searched recursively.
+.Pp
+When searching a single file, quiet mode is enabled by default (no filename headers).
+When searching multiple files or directories, each result is prefixed with the filename
+unless
+.Fl q
+is specified.
 .Pp
 The options are:
 .Bl -tag -width Fl
@@ -37,13 +46,13 @@ Show usage help message
 .It Fl i
 Identify filetype (rizin -nqcpm file)
 .It Fl j
-Output in JSON
+Output in JSON format. Results are returned as a JSON array of objects.
 .It Fl m
 Magic search, file-type carver
 .It Fl M Ar str
 Set a binary mask to be applied on keywords
 .It Fl n
-Do not stop the search when a read error occurs
+Do not stop the search when a read error occurs. Continue to next block or file.
 .It Fl r
 Print using rizin commands
 .It Fl s Ar str
@@ -60,6 +69,10 @@ Stop search at address 'to'
 Quiet mode - do not show headings (filenames) above matching contents (default for searching a single file)
 .It Fl v
 Show version information
+.It Fl V
+Verbose mode - show each file being scanned. When combined with
+.Fl j ,
+verbose output is written to stderr to preserve stdout for JSON results.
 .It Fl x Ar hex
 Search for an hexpair string (can be used multiple times)
 .It Fl X
@@ -68,6 +81,64 @@ Show hexdump of search results
 Search for zero-terminated strings
 .It Fl Z
 Show string found on each search hit
+.El
+.Sh MULTIPLE FILES AND DIRECTORIES
+.Nm rz-find
+supports searching across multiple files and directories in a single invocation.
+.Pp
+When multiple paths are provided:
+.Bl -bullet -compact
+.It
+Each file is searched in the order specified.
+.It
+Directories are searched recursively (hidden files starting with '.' are skipped).
+.It
+If any file cannot be opened or read, an error is printed but processing continues with remaining files.
+.It
+The exit code reflects whether all files were processed successfully (0) or if any errors occurred (1).
+.El
+.Sh EXIT STATUS
+.Bl -tag -width Ds
+.It 0
+All files were processed successfully.
+.It 1
+One or more files could not be opened or had read errors, or invalid arguments were provided.
+.El
+.Sh EXAMPLES
+Search for a string in a single file:
+.Bd -literal -offset indent
+rz-find -s "password" firmware.bin
+.Ed
+.Pp
+Search for a hex pattern in multiple files:
+.Bd -literal -offset indent
+rz-find -x "cafebabe" file1.bin file2.bin file3.bin
+.Ed
+.Pp
+Recursively search a directory for a string:
+.Bd -literal -offset indent
+rz-find -s "secret" /path/to/firmware/
+.Ed
+.Pp
+Search multiple directories and files with JSON output:
+.Bd -literal -offset indent
+rz-find -j -s "config" dir1/ dir2/ standalone.bin
+.Ed
+.Pp
+Search for zero-terminated strings in a binary with JSON output:
+.Bd -literal -offset indent
+rz-find -z -j firmware.bin
+.Ed
+.Pp
+Verbose search showing files being scanned:
+.Bd -literal -offset indent
+rz-find -V -s "pattern" *.bin
+.Ed
+.Pp
+Search with aligned hits (power of 2):
+.Bd -literal -offset indent
+rz-find -a 4 -x "00000000" memory.dump
+.Ed
 .Pp
 .Sh SEE ALSO
 .Pp

--- a/binrz/man/rz-find.1
+++ b/binrz/man/rz-find.1
@@ -44,7 +44,7 @@ Read the contents of the file and use it as a keyword
 .It Fl h
 Show usage help message
 .It Fl i
-Identify filetype (rizin -nqcpm file)
+Identify filetype (magic signatures)
 .It Fl j
 Output in JSON format. Results are returned as a JSON array of objects.
 .It Fl m

--- a/librz/main/main.c
+++ b/librz/main/main.c
@@ -20,7 +20,7 @@ static MainEntry main_prog[] = {
 	{ "rz-ax", rz_main_rz_ax },
 	{ "rz-bin", rz_main_rz_bin },
 	{ "rz-diff", rz_main_rz_diff },
-	{ "rz-find", rz_main_rz_ax },
+	{ "rz-find", rz_main_rz_find },
 	{ "rz-gg", rz_main_rz_gg },
 	{ "rz-hash", rz_main_rz_hash },
 	{ "rz-run", rz_main_rz_run },

--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -621,7 +621,7 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 					char *flag = rz_search_hit_flag_name(hit, i, "hit");
 					char *detail = rz_search_hit_detail_as_string(hit);
 					printf("0x%08" PFMT64x " %" PFMTSZu " %s %s\n",
-						hit->address, hit->size, flag ? flag : "", detail ? detail : "");
+						hit->address, hit->size, rz_str_get(flag), rz_str_get(detail));
 					free(flag);
 					free(detail);
 					i++;

--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -66,80 +66,6 @@ typedef struct {
 	const char *filename;
 } RzfindContext;
 
-static char *rzfind_resolve_rizin_path(void) {
-	char *path = rz_file_path("rizin");
-	if (path && rz_file_exists(path)) {
-		return path;
-	}
-	free(path);
-
-	char *self_path = rz_sys_pid_to_path(rz_sys_getpid());
-	if (!self_path) {
-		return rz_str_dup("rizin");
-	}
-	char *self_dir = rz_file_dirname(self_path);
-	free(self_path);
-	if (!self_dir) {
-		return rz_str_dup("rizin");
-	}
-
-#if __WINDOWS__
-	const char *rizin_exe = "rizin.exe";
-#else
-	const char *rizin_exe = "rizin";
-#endif
-
-	char *cand = rz_file_path_join(self_dir, rizin_exe);
-	if (cand && rz_file_exists(cand)) {
-		free(self_dir);
-		return cand;
-	}
-	free(cand);
-
-	char *parent = rz_file_path_join(self_dir, "..");
-	char *rizin_dir = parent ? rz_file_path_join(parent, "rizin") : NULL;
-	cand = rizin_dir ? rz_file_path_join(rizin_dir, rizin_exe) : NULL;
-	free(parent);
-	free(rizin_dir);
-	free(self_dir);
-
-	if (cand && rz_file_exists(cand)) {
-		return cand;
-	}
-	free(cand);
-	return rz_str_dup("rizin");
-}
-
-static int rzfind_run_subprocess(const char *file, const char *args[], size_t args_size) {
-	RzSubprocessOpt opt = {
-		.file = file,
-		.args = args,
-		.args_size = args_size,
-		.envvars = NULL,
-		.envvals = NULL,
-		.env_size = 0,
-		.stdin_pipe = RZ_SUBPROCESS_PIPE_NONE,
-		.stdout_pipe = RZ_SUBPROCESS_PIPE_NONE,
-		.stderr_pipe = RZ_SUBPROCESS_PIPE_NONE,
-		.pty = NULL,
-		.make_raw = false,
-	};
-
-	if (!rz_subprocess_init()) {
-		return -1;
-	}
-	RzSubprocess *proc = rz_subprocess_start_opt(&opt);
-	if (!proc) {
-		rz_subprocess_fini();
-		return -1;
-	}
-	rz_subprocess_wait(proc, UT64_MAX);
-	int ret = rz_subprocess_ret(proc);
-	rz_subprocess_free(proc);
-	rz_subprocess_fini();
-	return ret;
-}
-
 static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 	RzfindContext *ctx = (RzfindContext *)user;
 	RzfindOptions *ro = ctx->opt;
@@ -251,25 +177,25 @@ static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 static void print_bin_string(RzBinFile *bf, RzBinString *string, RzfindOptions *ro) {
 	rz_return_if_fail(bf && string);
 
-	RzBinSection *s = rz_bin_get_section_at(bf->o, string->paddr, false);
+	RzBinSection *s = bf->o ? rz_bin_get_section_at(bf->o, string->paddr, false) : NULL;
 	if (s) {
 		string->vaddr = s->vaddr + (string->paddr - s->paddr);
 	}
 	string->vaddr = bf->o ? rz_bin_object_get_vaddr(bf->o, string->paddr, string->vaddr) : UT64_MAX;
 
 	if (ro && ro->json) {
-		const char *section_name = s ? s->name : "";
+		const char *section_name = (s && s->name) ? s->name : "";
 		const char *type_string = rz_str_enc_as_string(string->type);
 		// Escape all string fields for JSON safety
 		char *escaped_section = rz_str_escape_utf8_for_json(section_name, -1);
-		char *escaped_type = rz_str_escape_utf8_for_json(type_string, -1);
-		char *escaped_string = rz_str_escape_utf8_for_json(string->string, -1);
+		char *escaped_type = rz_str_escape_utf8_for_json(rz_str_get(type_string), -1);
+		char *escaped_string = rz_str_escape_utf8_for_json(rz_str_get(string->string), -1);
 		printf("%s{\"vaddr\":%" PFMT64u ",\"paddr\":%" PFMT64u ",\"size\":%" PFMT64u ",\"length\":%" PFMT64u ",\"section\":\"%s\",\"type\":\"%s\",\"string\":\"%s\"}",
 			ro->comma ? ro->comma : "",
 			string->vaddr, string->paddr, (ut64)string->size, (ut64)string->length,
 			rz_str_get(escaped_section),
-			escaped_type ? escaped_type : "",
-			escaped_string ? escaped_string : "");
+			rz_str_get(escaped_type),
+			rz_str_get(escaped_string));
 		free(escaped_section);
 		free(escaped_type);
 		free(escaped_string);
@@ -278,7 +204,7 @@ static void print_bin_string(RzBinFile *bf, RzBinString *string, RzfindOptions *
 		if (ro && !ro->quiet) {
 			printf("File: %s\n", ro->curfile ? ro->curfile : "");
 		}
-		printf("%s\n", string->string);
+		printf("%s\n", rz_str_get(string->string));
 	}
 }
 
@@ -297,7 +223,7 @@ static int show_help(const char *argv0, int line) {
 		"-f",    "from",    "Start searching from address 'from'",
 		"-F",    "file",    "Read the contents of the file and use it as keyword",
 		"-h",    "",        "Show this help",
-		"-i",    "",        "Identify filetype (rizin -nqcpm file)",
+		"-i",    "",        "Identify filetype (magic signatures)",
 		"-j",    "",        "Output in JSON",
 		"-m",    "",        "Magic search, file-type carver",
 		"-M",    "str",     "Set a binary mask to be applied on keywords",
@@ -337,19 +263,119 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 	char *efile = rz_str_escape_sh(file);
 
 	if (ro->identify) {
-		char *rizin_path = rzfind_resolve_rizin_path();
-		const char *args[] = {
-			"-e",
-			"search.show=false",
-			"-e",
-			"search.maxhits=1",
-			"-nqcpm",
-			file,
-		};
-		rzfind_run_subprocess(rizin_path, args, RZ_ARRAY_SIZE(args));
-		free(rizin_path);
+		ut64 to = ro->to;
+		int identify_result = 1;
+
+		RzBuffer *buffer = rz_buf_new_file(file, O_RDONLY, 0);
+		if (!buffer) {
+			eprintf("Cannot open file as buffer: '%s'\n", file);
+			free(efile);
+			return 1;
+		}
+
+		char *magic_dir = rz_path_system(NULL, RZ_SDB_MAGIC);
+		if (!magic_dir) {
+			eprintf("Cannot find magic directory\n");
+			rz_buf_free(buffer);
+			free(efile);
+			return 1;
+		}
+
+		RzSearchCollection *collection = rz_search_collection_magic(magic_dir);
+		if (!collection) {
+			eprintf("Cannot initialize magic search\n");
+			free(magic_dir);
+			rz_buf_free(buffer);
+			free(efile);
+			return 1;
+		}
+
+		RzSearchOpt *search_opts = rz_search_opt_new();
+		if (!search_opts) {
+			eprintf("Cannot create search options\n");
+			rz_search_collection_free(collection);
+			free(magic_dir);
+			rz_buf_free(buffer);
+			free(efile);
+			return 1;
+		}
+
+		rz_search_opt_set_max_threads(search_opts, 1);
+		rz_search_opt_set_max_hits(search_opts, 1);
+		rz_search_opt_set_show_progress_from_str(search_opts, "no");
+		if (!rz_search_opt_set_chunk_size(search_opts, RZ_MAGIC_BUF_SIZE)) {
+			eprintf("Cannot set chunk size\n");
+			rz_search_opt_free(search_opts);
+			rz_search_collection_free(collection);
+			free(magic_dir);
+			rz_buf_free(buffer);
+			free(efile);
+			return 1;
+		}
+
+		RzSearchFindOpt *find_opts = rz_search_find_opt_new();
+		if (!find_opts) {
+			eprintf("Cannot create find options\n");
+			rz_search_opt_free(search_opts);
+			rz_search_collection_free(collection);
+			free(magic_dir);
+			rz_buf_free(buffer);
+			free(efile);
+			return 1;
+		}
+		rz_search_find_opt_set_alignment(find_opts, ro->align < 1 ? 1 : ro->align);
+		rz_search_find_opt_set_overlap_match(find_opts, false);
+		rz_search_opt_set_find_options(search_opts, find_opts);
+
+		if (to == -1) {
+			to = rz_buf_size(buffer);
+		}
+		RzList *ranges = NULL;
+		if (ro->from > 0 || (to && to != UT64_MAX && to != rz_buf_size(buffer))) {
+			ranges = rz_list_newf(free);
+			if (ranges) {
+				RzInterval *itv = RZ_NEW0(RzInterval);
+				if (itv) {
+					itv->addr = ro->from;
+					itv->size = (to && to != UT64_MAX) ? (to - ro->from) : (rz_buf_size(buffer) - ro->from);
+					rz_list_append(ranges, itv);
+				}
+			}
+		}
+
+		RzList *hits = rz_search_on_buffer(search_opts, collection, buffer, ranges);
+		rz_list_free(ranges);
+		if (hits) {
+			RzListIter *it;
+			RzSearchHit *hit;
+			rz_list_foreach (hits, it, hit) {
+				char *detail = rz_search_hit_detail_as_string(hit);
+				if (ro->json) {
+					char *escaped = rz_str_escape_utf8_for_json(rz_str_get(detail), -1);
+					printf("%s{\"address\":%" PFMT64u ",\"magic\":\"%s\"}",
+						ro->comma ? ro->comma : "",
+						hit->address,
+						rz_str_get(escaped));
+					free(escaped);
+					ro->comma = ",";
+				} else {
+					printf("0x%08" PFMT64x " %s\n", hit->address, rz_str_get(detail));
+				}
+				free(detail);
+				identify_result = 0;
+				break;
+			}
+			rz_list_free(hits);
+		} else {
+			eprintf("Cannot identify file '%s'\n", file);
+		}
+
+		rz_search_opt_free(search_opts);
+		rz_search_collection_free(collection);
+		free(magic_dir);
+		rz_buf_free(buffer);
 		free(efile);
-		return 0;
+		return identify_result;
 	}
 
 	if (ro->import || ro->symbol) {
@@ -576,12 +602,16 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 				rz_list_foreach (hits, it, hit) {
 					char *flag = rz_search_hit_flag_name(hit, i, "hit");
 					char *detail = rz_search_hit_detail_as_string(hit);
+					char *escaped_flag = rz_str_escape_utf8_for_json(rz_str_get(flag), -1);
+					char *escaped_detail = rz_str_escape_utf8_for_json(rz_str_get(detail), -1);
 					printf("%s{\"offset\":%" PFMT64u ",\"size\":%" PFMTSZu ",\"flag\":\"%s\",\"detail\":\"%s\"}",
 						ro->comma ? ro->comma : "",
 						hit->address, hit->size,
-						flag ? flag : "",
-						detail ? detail : "");
+						rz_str_get(escaped_flag),
+						rz_str_get(escaped_detail));
 					ro->comma = ",";
+					free(escaped_flag);
+					free(escaped_detail);
 					free(flag);
 					free(detail);
 					i++;

--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -139,7 +139,7 @@ static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 	if (ro->json) {
 		const char *type = "string";
 		printf("%s{\"offset\":%" PFMT64d ",\"type\":\"%s\",\"data\":\"%s\"}",
-			ro->comma ? ro->comma : "", addr, type, str);
+			rz_str_get(ro->comma), addr, type, str);
 		ro->comma = ",";
 	} else if (ro->rad) {
 		printf("f hit%d_%d @ 0x%08" PFMT64x " ; %s\n", 0, kw->count, addr, ro->curfile);
@@ -184,14 +184,14 @@ static void print_bin_string(RzBinFile *bf, RzBinString *string, RzfindOptions *
 	string->vaddr = bf->o ? rz_bin_object_get_vaddr(bf->o, string->paddr, string->vaddr) : UT64_MAX;
 
 	if (ro && ro->json) {
-		const char *section_name = (s && s->name) ? s->name : "";
+		const char *section_name = rz_str_get(s ? s->name : NULL);
 		const char *type_string = rz_str_enc_as_string(string->type);
 		// Escape all string fields for JSON safety
 		char *escaped_section = rz_str_escape_utf8_for_json(section_name, -1);
 		char *escaped_type = rz_str_escape_utf8_for_json(rz_str_get(type_string), -1);
 		char *escaped_string = rz_str_escape_utf8_for_json(rz_str_get(string->string), -1);
 		printf("%s{\"vaddr\":%" PFMT64u ",\"paddr\":%" PFMT64u ",\"size\":%" PFMT64u ",\"length\":%" PFMT64u ",\"section\":\"%s\",\"type\":\"%s\",\"string\":\"%s\"}",
-			ro->comma ? ro->comma : "",
+			rz_str_get(ro->comma),
 			string->vaddr, string->paddr, (ut64)string->size, (ut64)string->length,
 			rz_str_get(escaped_section),
 			rz_str_get(escaped_type),
@@ -202,7 +202,7 @@ static void print_bin_string(RzBinFile *bf, RzBinString *string, RzfindOptions *
 		ro->comma = ",";
 	} else {
 		if (ro && !ro->quiet) {
-			printf("File: %s\n", ro->curfile ? ro->curfile : "");
+			printf("File: %s\n", rz_str_get(ro->curfile));
 		}
 		printf("%s\n", rz_str_get(string->string));
 	}
@@ -353,7 +353,7 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 				if (ro->json) {
 					char *escaped = rz_str_escape_utf8_for_json(rz_str_get(detail), -1);
 					printf("%s{\"address\":%" PFMT64u ",\"magic\":\"%s\"}",
-						ro->comma ? ro->comma : "",
+						rz_str_get(ro->comma),
 						hit->address,
 						rz_str_get(escaped));
 					free(escaped);
@@ -605,7 +605,7 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 					char *escaped_flag = rz_str_escape_utf8_for_json(rz_str_get(flag), -1);
 					char *escaped_detail = rz_str_escape_utf8_for_json(rz_str_get(detail), -1);
 					printf("%s{\"offset\":%" PFMT64u ",\"size\":%" PFMTSZu ",\"flag\":\"%s\",\"detail\":\"%s\"}",
-						ro->comma ? ro->comma : "",
+						rz_str_get(ro->comma),
 						hit->address, hit->size,
 						rz_str_get(escaped_flag),
 						rz_str_get(escaped_detail));

--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -16,6 +16,7 @@
 #include <rz_lib.h>
 #include <rz_io.h>
 #include <rz_bin.h>
+#include <rz_magic.h>
 
 typedef struct {
 	bool showstr;
@@ -64,6 +65,80 @@ typedef struct {
 	RzfindOptions *opt;
 	const char *filename;
 } RzfindContext;
+
+static char *rzfind_resolve_rizin_path(void) {
+	char *path = rz_file_path("rizin");
+	if (path && rz_file_exists(path)) {
+		return path;
+	}
+	free(path);
+
+	char *self_path = rz_sys_pid_to_path(rz_sys_getpid());
+	if (!self_path) {
+		return rz_str_dup("rizin");
+	}
+	char *self_dir = rz_file_dirname(self_path);
+	free(self_path);
+	if (!self_dir) {
+		return rz_str_dup("rizin");
+	}
+
+#if __WINDOWS__
+	const char *rizin_exe = "rizin.exe";
+#else
+	const char *rizin_exe = "rizin";
+#endif
+
+	char *cand = rz_file_path_join(self_dir, rizin_exe);
+	if (cand && rz_file_exists(cand)) {
+		free(self_dir);
+		return cand;
+	}
+	free(cand);
+
+	char *parent = rz_file_path_join(self_dir, "..");
+	char *rizin_dir = parent ? rz_file_path_join(parent, "rizin") : NULL;
+	cand = rizin_dir ? rz_file_path_join(rizin_dir, rizin_exe) : NULL;
+	free(parent);
+	free(rizin_dir);
+	free(self_dir);
+
+	if (cand && rz_file_exists(cand)) {
+		return cand;
+	}
+	free(cand);
+	return rz_str_dup("rizin");
+}
+
+static int rzfind_run_subprocess(const char *file, const char *args[], size_t args_size) {
+	RzSubprocessOpt opt = {
+		.file = file,
+		.args = args,
+		.args_size = args_size,
+		.envvars = NULL,
+		.envvals = NULL,
+		.env_size = 0,
+		.stdin_pipe = RZ_SUBPROCESS_PIPE_NONE,
+		.stdout_pipe = RZ_SUBPROCESS_PIPE_NONE,
+		.stderr_pipe = RZ_SUBPROCESS_PIPE_NONE,
+		.pty = NULL,
+		.make_raw = false,
+	};
+
+	if (!rz_subprocess_init()) {
+		return -1;
+	}
+	RzSubprocess *proc = rz_subprocess_start_opt(&opt);
+	if (!proc) {
+		rz_subprocess_fini();
+		return -1;
+	}
+	rz_subprocess_wait(proc, UT64_MAX);
+	int ret = rz_subprocess_ret(proc);
+	rz_subprocess_free(proc);
+	rz_subprocess_fini();
+	return ret;
+}
 
 static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 	RzfindContext *ctx = (RzfindContext *)user;
@@ -262,9 +337,17 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 	char *efile = rz_str_escape_sh(file);
 
 	if (ro->identify) {
-		char *cmd = rz_str_newf("rizin -e search.show=false -e search.maxhits=1 -nqcpm \"%s\"", efile);
-		rz_sys_xsystem(cmd);
-		free(cmd);
+		char *rizin_path = rzfind_resolve_rizin_path();
+		const char *args[] = {
+			"-e",
+			"search.show=false",
+			"-e",
+			"search.maxhits=1",
+			"-nqcpm",
+			file,
+		};
+		rzfind_run_subprocess(rizin_path, args, RZ_ARRAY_SIZE(args));
+		free(rizin_path);
 		free(efile);
 		return 0;
 	}
@@ -411,15 +494,116 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 	}
 
 	if (ro->mode == RZ_SEARCH_MAGIC) {
-		/* TODO: implement using api */
-		char *tostr = (to && to != UT64_MAX) ? rz_str_newf("-e search.to=%" PFMT64d, to) : rz_str_dup("");
-		rz_sys_cmdf("rizin"
-			    " -e search.in=range"
-			    " -e search.align=%d"
-			    " -e search.from=%" PFMT64d
-			    " %s -qnc/m%s \"%s\"",
-			ro->align < 1 ? 1 : ro->align, ro->from, tostr, ro->json ? "j" : "", efile);
-		free(tostr);
+		char *magic_dir = rz_path_system(NULL, RZ_SDB_MAGIC);
+		if (!magic_dir) {
+			eprintf("Cannot find magic directory\n");
+			result = 1;
+			goto err;
+		}
+
+		RzSearchCollection *collection = rz_search_collection_magic(magic_dir);
+		if (!collection) {
+			eprintf("Cannot initialize magic search\n");
+			free(magic_dir);
+			result = 1;
+			goto err;
+		}
+
+		RzSearchOpt *search_opts = rz_search_opt_new();
+		if (!search_opts) {
+			eprintf("Cannot create search options\n");
+			rz_search_collection_free(collection);
+			free(magic_dir);
+			result = 1;
+			goto err;
+		}
+
+		rz_search_opt_set_max_threads(search_opts, 1);
+		rz_search_opt_set_show_progress_from_str(search_opts, "no");
+		if (!rz_search_opt_set_chunk_size(search_opts, RZ_MAGIC_BUF_SIZE)) {
+			eprintf("Cannot set chunk size\n");
+			rz_search_opt_free(search_opts);
+			rz_search_collection_free(collection);
+			free(magic_dir);
+			result = 1;
+			goto err;
+		}
+
+		RzSearchFindOpt *find_opts = rz_search_find_opt_new();
+		if (!find_opts) {
+			eprintf("Cannot create find options\n");
+			rz_search_opt_free(search_opts);
+			rz_search_collection_free(collection);
+			free(magic_dir);
+			result = 1;
+			goto err;
+		}
+		rz_search_find_opt_set_alignment(find_opts, ro->align < 1 ? 1 : ro->align);
+		rz_search_find_opt_set_overlap_match(find_opts, false);
+		rz_search_opt_set_find_options(search_opts, find_opts);
+
+		RzBuffer *buffer = rz_buf_new_file(file, O_RDONLY, 0);
+		if (!buffer) {
+			eprintf("Cannot open file as buffer: '%s'\n", file);
+			rz_search_opt_free(search_opts);
+			rz_search_collection_free(collection);
+			free(magic_dir);
+			result = 1;
+			goto err;
+		}
+
+		RzList *ranges = NULL;
+		if (ro->from > 0 || (to && to != UT64_MAX && to != rz_buf_size(buffer))) {
+			ranges = rz_list_newf(free);
+			if (ranges) {
+				RzInterval *itv = RZ_NEW0(RzInterval);
+				if (itv) {
+					itv->addr = ro->from;
+					itv->size = (to && to != UT64_MAX) ? (to - ro->from) : (rz_buf_size(buffer) - ro->from);
+					rz_list_append(ranges, itv);
+				}
+			}
+		}
+
+		RzList *hits = rz_search_on_buffer(search_opts, collection, buffer, ranges);
+		rz_list_free(ranges);
+
+		if (hits) {
+			RzListIter *it;
+			RzSearchHit *hit;
+			size_t i = 0;
+			if (ro->json) {
+				rz_list_foreach (hits, it, hit) {
+					char *flag = rz_search_hit_flag_name(hit, i, "hit");
+					char *detail = rz_search_hit_detail_as_string(hit);
+					printf("%s{\"offset\":%" PFMT64u ",\"size\":%" PFMTSZu ",\"flag\":\"%s\",\"detail\":\"%s\"}",
+						ro->comma ? ro->comma : "",
+						hit->address, hit->size,
+						flag ? flag : "",
+						detail ? detail : "");
+					ro->comma = ",";
+					free(flag);
+					free(detail);
+					i++;
+				}
+			} else {
+				rz_list_foreach (hits, it, hit) {
+					char *flag = rz_search_hit_flag_name(hit, i, "hit");
+					char *detail = rz_search_hit_detail_as_string(hit);
+					printf("0x%08" PFMT64x " %" PFMTSZu " %s %s\n",
+						hit->address, hit->size, flag ? flag : "", detail ? detail : "");
+					free(flag);
+					free(detail);
+					i++;
+				}
+			}
+			rz_list_free(hits);
+		}
+
+		rz_buf_free(buffer);
+		rz_search_opt_free(search_opts);
+		rz_search_collection_free(collection);
+		free(magic_dir);
 		goto done;
 	}
 	if (ro->mode == RZ_SEARCH_KEYWORD) {

--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -267,7 +267,7 @@ static void print_bin_string(RzBinFile *bf, RzBinString *string, RzfindOptions *
 		printf("%s{\"vaddr\":%" PFMT64u ",\"paddr\":%" PFMT64u ",\"size\":%" PFMT64u ",\"length\":%" PFMT64u ",\"section\":\"%s\",\"type\":\"%s\",\"string\":\"%s\"}",
 			ro->comma ? ro->comma : "",
 			string->vaddr, string->paddr, (ut64)string->size, (ut64)string->length,
-			escaped_section ? escaped_section : "",
+			rz_str_get(escaped_section),
 			escaped_type ? escaped_type : "",
 			escaped_string ? escaped_string : "");
 		free(escaped_section);

--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -77,7 +77,7 @@ static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 		eprintf("Invalid delta\n");
 		return 0;
 	}
-	if (!ro->quiet) {
+	if (!ro->quiet && !ro->json) {
 		printf("File: %s\n", ctx->filename);
 	}
 	char _str[128];
@@ -138,7 +138,7 @@ static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 	if (ro->json) {
 		const char *type = "string";
 		printf("%s{\"offset\":%" PFMT64d ",\"type\":\"%s\",\"data\":\"%s\"}",
-			ro->comma, addr, type, str);
+			ro->comma ? ro->comma : "", addr, type, str);
 		ro->comma = ",";
 	} else if (ro->rad) {
 		printf("f hit%d_%d @ 0x%08" PFMT64x " ; %s\n", 0, kw->count, addr, ro->curfile);
@@ -166,7 +166,14 @@ static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 	return 1;
 }
 
-static void print_bin_string(RzBinFile *bf, RzBinString *string, PJ *pj) {
+/**
+ * \brief Print a binary string result in the appropriate output format.
+ * \param bf The binary file containing the string.
+ * \param string The string to print.
+ * \param ro Options containing output format settings (JSON mode, comma state, quiet mode).
+ *            If NULL, prints as plain text.
+ */
+static void print_bin_string(RzBinFile *bf, RzBinString *string, RzfindOptions *ro) {
 	rz_return_if_fail(bf && string);
 
 	RzBinSection *s = rz_bin_get_section_at(bf->o, string->paddr, false);
@@ -175,19 +182,27 @@ static void print_bin_string(RzBinFile *bf, RzBinString *string, PJ *pj) {
 	}
 	string->vaddr = bf->o ? rz_bin_object_get_vaddr(bf->o, string->paddr, string->vaddr) : UT64_MAX;
 
-	if (pj) {
+	if (ro && ro->json) {
 		const char *section_name = s ? s->name : "";
 		const char *type_string = rz_str_enc_as_string(string->type);
-		pj_o(pj);
-		pj_kn(pj, "vaddr", string->vaddr);
-		pj_kn(pj, "paddr", string->paddr);
-		pj_kn(pj, "size", string->size);
-		pj_kn(pj, "length", string->length);
-		pj_ks(pj, "section", section_name);
-		pj_ks(pj, "type", type_string);
-		pj_ks(pj, "string", string->string);
-		pj_end(pj);
+		// Escape all string fields for JSON safety
+		char *escaped_section = rz_str_escape_utf8_for_json(section_name, -1);
+		char *escaped_type = rz_str_escape_utf8_for_json(type_string, -1);
+		char *escaped_string = rz_str_escape_utf8_for_json(string->string, -1);
+		printf("%s{\"vaddr\":%" PFMT64u ",\"paddr\":%" PFMT64u ",\"size\":%" PFMT64u ",\"length\":%" PFMT64u ",\"section\":\"%s\",\"type\":\"%s\",\"string\":\"%s\"}",
+			ro->comma ? ro->comma : "",
+			string->vaddr, string->paddr, (ut64)string->size, (ut64)string->length,
+			escaped_section ? escaped_section : "",
+			escaped_type ? escaped_type : "",
+			escaped_string ? escaped_string : "");
+		free(escaped_section);
+		free(escaped_type);
+		free(escaped_string);
+		ro->comma = ",";
 	} else {
+		if (ro && !ro->quiet) {
+			printf("File: %s\n", ro->curfile ? ro->curfile : "");
+		}
 		printf("%s\n", string->string);
 	}
 }
@@ -239,7 +254,8 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 	int ret, result = 0;
 
 	if (ro->verbose) {
-		printf("Scanning: %s\n", file);
+		FILE *stream = ro->json ? stderr : stdout;
+		fprintf(stream, "Scanning: %s\n", file);
 	}
 
 	ro->buf = NULL;
@@ -289,7 +305,7 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 				rz_pvector_foreach (imports, vec_it) {
 					import = *vec_it;
 					if (!strcmp(import->name, kw)) {
-						if (!ro->quiet) {
+						if (!ro->quiet && !ro->json) {
 							printf("File: %s\n", file);
 						}
 						printf("ordinal: %d %s\n", import->ordinal, kw);
@@ -311,7 +327,7 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 					}
 
 					if (!strcmp(symbol->name, kw)) {
-						if (!ro->quiet) {
+						if (!ro->quiet && !ro->json) {
 							printf("File: %s\n", file);
 						}
 						printf("paddr: 0x%08" PFMT64x " vaddr: 0x%08" PFMT64x " type: %s %s\n", symbol->paddr, symbol->vaddr, symbol->type, symbol->name);
@@ -378,34 +394,19 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 	RzBinFile *bf = rz_bin_open(bin, file, &opt);
 
 	if (ro->mode == RZ_SEARCH_STRING) {
-		PJ *pj = NULL;
-		if (ro->json) {
-			pj = pj_new();
-			if (!pj) {
-				eprintf("rz-bin: Cannot allocate buffer for json array\n");
-				result = 1;
-				goto err;
-			}
-			pj_a(pj);
-		}
-
-		RzBinStringSearchOpt opt = bin->str_search_cfg;
+		RzBinStringSearchOpt search_opt = bin->str_search_cfg;
 		// enforce raw binary search
-		opt.mode = RZ_BIN_STRING_SEARCH_MODE_RAW_BINARY;
+		search_opt.mode = RZ_BIN_STRING_SEARCH_MODE_RAW_BINARY;
 
-		RzPVector *vec = rz_bin_file_strings(bf, &opt);
+		ro->curfile = file;
+		RzPVector *vec = rz_bin_file_strings(bf, &search_opt);
 		void **it;
 		RzBinString *string;
 		rz_pvector_foreach (vec, it) {
 			string = *it;
-			print_bin_string(bf, string, pj);
+			print_bin_string(bf, string, ro);
 		}
 		rz_pvector_free(vec);
-		if (pj) {
-			pj_end(pj);
-			printf("%s", pj_string(pj));
-			pj_free(pj);
-		}
 		goto done;
 	}
 
@@ -480,6 +481,7 @@ static int rzfind_open_dir(RzfindOptions *ro, const char *dir) {
 	RzListIter *iter;
 	char *fullpath;
 	char *fname = NULL;
+	int result = 0;
 
 	RzList *files = rz_sys_dir(dir);
 
@@ -490,12 +492,15 @@ static int rzfind_open_dir(RzfindOptions *ro, const char *dir) {
 				continue;
 			}
 			fullpath = rz_file_path_join(dir, fname);
-			(void)rzfind_open(ro, fullpath);
+			int res = rzfind_open(ro, fullpath);
+			if (res != 0) {
+				result = 1;
+			}
 			free(fullpath);
 		}
 		rz_list_free(files);
 	}
-	return 0;
+	return result;
 }
 
 static int rzfind_open(RzfindOptions *ro, const char *file) {
@@ -663,21 +668,26 @@ RZ_API int rz_main_rz_find(int argc, const char **argv) {
 		}
 	}
 	if (ro.json) {
+		ro.comma = "";
 		printf("[");
 	}
+	int overall_result = 0;
 	for (; opt.ind < argc; opt.ind++) {
 		file = argv[opt.ind];
 
 		if (RZ_STR_ISEMPTY(file)) {
 			eprintf("Cannot open empty path\n");
-			rz_list_free(ro.keywords);
-			return 1;
+			overall_result = 1;
+			continue;
 		}
-		rzfind_open(&ro, file);
+		int res = rzfind_open(&ro, file);
+		if (res != 0) {
+			overall_result = 1;
+		}
 	}
 	rz_list_free(ro.keywords);
 	if (ro.json) {
 		printf("]\n");
 	}
-	return 0;
+	return overall_result;
 }

--- a/test/db/tools/rz
+++ b/test/db/tools/rz
@@ -181,22 +181,8 @@ NAME=b/w prompt
 FILE==
 CMDS=!rizin -e cfg.fortunes=0 -e scr.color=0 -c "< \nq\n" =
 EXPECT=<<EOF
-[2K
-
-[0x00000000]> 
-[0x00000000]> [2K
-
-[0x00000000]> 
-[2K
-
-[0x00000000]> 
-[0x00000000]> [2K
-[2K
-
-[0x00000000]> q
-[0x00000000]> q[2K
-
-[0x00000000]> q
+[2K[0x00000000]> [0x00000000]> [2K[0x00000000]> 
+[2K[0x00000000]> [0x00000000]> [2K[2K[0x00000000]> q[0x00000000]> q[2K[0x00000000]> q
 EOF
 RUN
 
@@ -211,440 +197,13 @@ NAME=prompt settings
 FILE==
 CMDS=!rizin -e cfg.fortunes=0 -e scr.color=0 -c "< \ne scr.prompt.file=true\ne scr.prompt.flag=true\nsd 1\ne scr.prompt.flag.only=true\ne scr.prompt.sect=true\nq\n" ./bins/elf/hello_world
 EXPECT=<<EOF
-[2K
-
-[0x000006a0]> 
-[0x000006a0]> [2K
-
-[0x000006a0]> 
-[2K
-
-[0x000006a0]> 
-[0x000006a0]> [2K
-[2K
-
-[0x000006a0]> e
-[0x000006a0]> e[2K
-[2K
-
-[0x000006a0]> e 
-[0x000006a0]> e [2K
-[2K
-
-[0x000006a0]> e s
-[0x000006a0]> e s[2K
-[2K
-
-[0x000006a0]> e sc
-[0x000006a0]> e sc[2K
-[2K
-
-[0x000006a0]> e scr
-[0x000006a0]> e scr[2K
-[2K
-
-[0x000006a0]> e scr.
-[0x000006a0]> e scr.[2K
-[2K
-
-[0x000006a0]> e scr.p
-[0x000006a0]> e scr.p[2K
-[2K
-
-[0x000006a0]> e scr.pr
-[0x000006a0]> e scr.pr[2K
-[2K
-
-[0x000006a0]> e scr.pro
-[0x000006a0]> e scr.pro[2K
-[2K
-
-[0x000006a0]> e scr.prom
-[0x000006a0]> e scr.prom[2K
-[2K
-
-[0x000006a0]> e scr.promp
-[0x000006a0]> e scr.promp[2K
-[2K
-
-[0x000006a0]> e scr.prompt
-[0x000006a0]> e scr.prompt[2K
-[2K
-
-[0x000006a0]> e scr.prompt.
-[0x000006a0]> e scr.prompt.[2K
-[2K
-
-[0x000006a0]> e scr.prompt.f
-[0x000006a0]> e scr.prompt.f[2K
-[2K
-
-[0x000006a0]> e scr.prompt.fi
-[0x000006a0]> e scr.prompt.fi[2K
-[2K
-
-[0x000006a0]> e scr.prompt.fil
-[0x000006a0]> e scr.prompt.fil[2K
-[2K
-
-[0x000006a0]> e scr.prompt.file
-[0x000006a0]> e scr.prompt.file[2K
-[2K
-
-[0x000006a0]> e scr.prompt.file=
-[0x000006a0]> e scr.prompt.file=[2K
-[2K
-
-[0x000006a0]> e scr.prompt.file=t
-[0x000006a0]> e scr.prompt.file=t[2K
-[2K
-
-[0x000006a0]> e scr.prompt.file=tr
-[0x000006a0]> e scr.prompt.file=tr[2K
-[2K
-
-[0x000006a0]> e scr.prompt.file=tru
-[0x000006a0]> e scr.prompt.file=tru[2K
-[2K
-
-[0x000006a0]> e scr.prompt.file=true
-[0x000006a0]> e scr.prompt.file=true[2K
-
-[0x000006a0]> e scr.prompt.file=true
-[2K
-
-[hello_world:0x000006a0]> 
-[hello_world:0x000006a0]> [2K
-[2K
-
-[hello_world:0x000006a0]> e
-[hello_world:0x000006a0]> e[2K
-[2K
-
-[hello_world:0x000006a0]> e 
-[hello_world:0x000006a0]> e [2K
-[2K
-
-[hello_world:0x000006a0]> e s
-[hello_world:0x000006a0]> e s[2K
-[2K
-
-[hello_world:0x000006a0]> e sc
-[hello_world:0x000006a0]> e sc[2K
-[2K
-
-[hello_world:0x000006a0]> e scr
-[hello_world:0x000006a0]> e scr[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.
-[hello_world:0x000006a0]> e scr.[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.p
-[hello_world:0x000006a0]> e scr.p[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.pr
-[hello_world:0x000006a0]> e scr.pr[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.pro
-[hello_world:0x000006a0]> e scr.pro[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.prom
-[hello_world:0x000006a0]> e scr.prom[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.promp
-[hello_world:0x000006a0]> e scr.promp[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.prompt
-[hello_world:0x000006a0]> e scr.prompt[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.prompt.
-[hello_world:0x000006a0]> e scr.prompt.[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.prompt.f
-[hello_world:0x000006a0]> e scr.prompt.f[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.prompt.fl
-[hello_world:0x000006a0]> e scr.prompt.fl[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.prompt.fla
-[hello_world:0x000006a0]> e scr.prompt.fla[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.prompt.flag
-[hello_world:0x000006a0]> e scr.prompt.flag[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.prompt.flag=
-[hello_world:0x000006a0]> e scr.prompt.flag=[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.prompt.flag=t
-[hello_world:0x000006a0]> e scr.prompt.flag=t[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.prompt.flag=tr
-[hello_world:0x000006a0]> e scr.prompt.flag=tr[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.prompt.flag=tru
-[hello_world:0x000006a0]> e scr.prompt.flag=tru[2K
-[2K
-
-[hello_world:0x000006a0]> e scr.prompt.flag=true
-[hello_world:0x000006a0]> e scr.prompt.flag=true[2K
-
-[hello_world:0x000006a0]> e scr.prompt.flag=true
-[2K
-
-[hello_world:entry0:0x000006a0]> 
-[hello_world:entry0:0x000006a0]> [2K
-[2K
-
-[hello_world:entry0:0x000006a0]> s
-[hello_world:entry0:0x000006a0]> s[2K
-[2K
-
-[hello_world:entry0:0x000006a0]> sd
-[hello_world:entry0:0x000006a0]> sd[2K
-[2K
-
-[hello_world:entry0:0x000006a0]> sd 
-[hello_world:entry0:0x000006a0]> sd [2K
-[2K
-
-[hello_world:entry0:0x000006a0]> sd 1
-[hello_world:entry0:0x000006a0]> sd 1[2K
-
-[hello_world:entry0:0x000006a0]> sd 1
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> 
-[hello_world:entry0 + 1:0x000006a1]> [2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e
-[hello_world:entry0 + 1:0x000006a1]> e[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e 
-[hello_world:entry0 + 1:0x000006a1]> e [2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e s
-[hello_world:entry0 + 1:0x000006a1]> e s[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e sc
-[hello_world:entry0 + 1:0x000006a1]> e sc[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr
-[hello_world:entry0 + 1:0x000006a1]> e scr[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.
-[hello_world:entry0 + 1:0x000006a1]> e scr.[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.p
-[hello_world:entry0 + 1:0x000006a1]> e scr.p[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.pr
-[hello_world:entry0 + 1:0x000006a1]> e scr.pr[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.pro
-[hello_world:entry0 + 1:0x000006a1]> e scr.pro[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prom
-[hello_world:entry0 + 1:0x000006a1]> e scr.prom[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.promp
-[hello_world:entry0 + 1:0x000006a1]> e scr.promp[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.f
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.f[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fl
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fl[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fla
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fla[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.o
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.o[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.on
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.on[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.onl
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.onl[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=t
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=t[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tr
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tr[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tru
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tru[2K
-[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true[2K
-
-[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true
-[2K
-
-[hello_world:entry0 + 1]> 
-[hello_world:entry0 + 1]> [2K
-[2K
-
-[hello_world:entry0 + 1]> e
-[hello_world:entry0 + 1]> e[2K
-[2K
-
-[hello_world:entry0 + 1]> e 
-[hello_world:entry0 + 1]> e [2K
-[2K
-
-[hello_world:entry0 + 1]> e s
-[hello_world:entry0 + 1]> e s[2K
-[2K
-
-[hello_world:entry0 + 1]> e sc
-[hello_world:entry0 + 1]> e sc[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr
-[hello_world:entry0 + 1]> e scr[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.
-[hello_world:entry0 + 1]> e scr.[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.p
-[hello_world:entry0 + 1]> e scr.p[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.pr
-[hello_world:entry0 + 1]> e scr.pr[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.pro
-[hello_world:entry0 + 1]> e scr.pro[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.prom
-[hello_world:entry0 + 1]> e scr.prom[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.promp
-[hello_world:entry0 + 1]> e scr.promp[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.prompt
-[hello_world:entry0 + 1]> e scr.prompt[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.prompt.
-[hello_world:entry0 + 1]> e scr.prompt.[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.prompt.s
-[hello_world:entry0 + 1]> e scr.prompt.s[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.prompt.se
-[hello_world:entry0 + 1]> e scr.prompt.se[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.prompt.sec
-[hello_world:entry0 + 1]> e scr.prompt.sec[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.prompt.sect
-[hello_world:entry0 + 1]> e scr.prompt.sect[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.prompt.sect=
-[hello_world:entry0 + 1]> e scr.prompt.sect=[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.prompt.sect=t
-[hello_world:entry0 + 1]> e scr.prompt.sect=t[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.prompt.sect=tr
-[hello_world:entry0 + 1]> e scr.prompt.sect=tr[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.prompt.sect=tru
-[hello_world:entry0 + 1]> e scr.prompt.sect=tru[2K
-[2K
-
-[hello_world:entry0 + 1]> e scr.prompt.sect=true
-[hello_world:entry0 + 1]> e scr.prompt.sect=true[2K
-
-[hello_world:entry0 + 1]> e scr.prompt.sect=true
-[2K
-
-[hello_world:.text:entry0 + 1]> 
-[hello_world:.text:entry0 + 1]> [2K
-[2K
-
-[hello_world:.text:entry0 + 1]> q
-[hello_world:.text:entry0 + 1]> q[2K
-
-[hello_world:.text:entry0 + 1]> q
+[2K[0x000006a0]> [0x000006a0]> [2K[0x000006a0]> 
+[2K[0x000006a0]> [0x000006a0]> [2K[2K[0x000006a0]> e[0x000006a0]> e[2K[2K[0x000006a0]> e [0x000006a0]> e [2K[2K[0x000006a0]> e s[0x000006a0]> e s[2K[2K[0x000006a0]> e sc[0x000006a0]> e sc[2K[2K[0x000006a0]> e scr[0x000006a0]> e scr[2K[2K[0x000006a0]> e scr.[0x000006a0]> e scr.[2K[2K[0x000006a0]> e scr.p[0x000006a0]> e scr.p[2K[2K[0x000006a0]> e scr.pr[0x000006a0]> e scr.pr[2K[2K[0x000006a0]> e scr.pro[0x000006a0]> e scr.pro[2K[2K[0x000006a0]> e scr.prom[0x000006a0]> e scr.prom[2K[2K[0x000006a0]> e scr.promp[0x000006a0]> e scr.promp[2K[2K[0x000006a0]> e scr.prompt[0x000006a0]> e scr.prompt[2K[2K[0x000006a0]> e scr.prompt.[0x000006a0]> e scr.prompt.[2K[2K[0x000006a0]> e scr.prompt.f[0x000006a0]> e scr.prompt.f[2K[2K[0x000006a0]> e scr.prompt.fi[0x000006a0]> e scr.prompt.fi[2K[2K[0x000006a0]> e scr.prompt.fil[0x000006a0]> e scr.prompt.fil[2K[2K[0x000006a0]> e scr.prompt.file[0x000006a0]> e scr.prompt.file[2K[2K[0x000006a0]> e scr.prompt.file=[0x000006a0]> e scr.prompt.file=[2K[2K[0x000006a0]> e scr.prompt.file=t[0x000006a0]> e scr.prompt.file=t[2K[2K[0x000006a0]> e scr.prompt.file=tr[0x000006a0]> e scr.prompt.file=tr[2K[2K[0x000006a0]> e scr.prompt.file=tru[0x000006a0]> e scr.prompt.file=tru[2K[2K[0x000006a0]> e scr.prompt.file=true[0x000006a0]> e scr.prompt.file=true[2K[0x000006a0]> e scr.prompt.file=true
+[2K[hello_world:0x000006a0]> [hello_world:0x000006a0]> [2K[2K[hello_world:0x000006a0]> e[hello_world:0x000006a0]> e[2K[2K[hello_world:0x000006a0]> e [hello_world:0x000006a0]> e [2K[2K[hello_world:0x000006a0]> e s[hello_world:0x000006a0]> e s[2K[2K[hello_world:0x000006a0]> e sc[hello_world:0x000006a0]> e sc[2K[2K[hello_world:0x000006a0]> e scr[hello_world:0x000006a0]> e scr[2K[2K[hello_world:0x000006a0]> e scr.[hello_world:0x000006a0]> e scr.[2K[2K[hello_world:0x000006a0]> e scr.p[hello_world:0x000006a0]> e scr.p[2K[2K[hello_world:0x000006a0]> e scr.pr[hello_world:0x000006a0]> e scr.pr[2K[2K[hello_world:0x000006a0]> e scr.pro[hello_world:0x000006a0]> e scr.pro[2K[2K[hello_world:0x000006a0]> e scr.prom[hello_world:0x000006a0]> e scr.prom[2K[2K[hello_world:0x000006a0]> e scr.promp[hello_world:0x000006a0]> e scr.promp[2K[2K[hello_world:0x000006a0]> e scr.prompt[hello_world:0x000006a0]> e scr.prompt[2K[2K[hello_world:0x000006a0]> e scr.prompt.[hello_world:0x000006a0]> e scr.prompt.[2K[2K[hello_world:0x000006a0]> e scr.prompt.f[hello_world:0x000006a0]> e scr.prompt.f[2K[2K[hello_world:0x000006a0]> e scr.prompt.fl[hello_world:0x000006a0]> e scr.prompt.fl[2K[2K[hello_world:0x000006a0]> e scr.prompt.fla[hello_world:0x000006a0]> e scr.prompt.fla[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag[hello_world:0x000006a0]> e scr.prompt.flag[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag=[hello_world:0x000006a0]> e scr.prompt.flag=[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag=t[hello_world:0x000006a0]> e scr.prompt.flag=t[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag=tr[hello_world:0x000006a0]> e scr.prompt.flag=tr[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag=tru[hello_world:0x000006a0]> e scr.prompt.flag=tru[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag=true[hello_world:0x000006a0]> e scr.prompt.flag=true[2K[hello_world:0x000006a0]> e scr.prompt.flag=true
+[2K[hello_world:entry0:0x000006a0]> [hello_world:entry0:0x000006a0]> [2K[2K[hello_world:entry0:0x000006a0]> s[hello_world:entry0:0x000006a0]> s[2K[2K[hello_world:entry0:0x000006a0]> sd[hello_world:entry0:0x000006a0]> sd[2K[2K[hello_world:entry0:0x000006a0]> sd [hello_world:entry0:0x000006a0]> sd [2K[2K[hello_world:entry0:0x000006a0]> sd 1[hello_world:entry0:0x000006a0]> sd 1[2K[hello_world:entry0:0x000006a0]> sd 1
+[2K[hello_world:entry0 + 1:0x000006a1]> [hello_world:entry0 + 1:0x000006a1]> [2K[2K[hello_world:entry0 + 1:0x000006a1]> e[hello_world:entry0 + 1:0x000006a1]> e[2K[2K[hello_world:entry0 + 1:0x000006a1]> e [hello_world:entry0 + 1:0x000006a1]> e [2K[2K[hello_world:entry0 + 1:0x000006a1]> e s[hello_world:entry0 + 1:0x000006a1]> e s[2K[2K[hello_world:entry0 + 1:0x000006a1]> e sc[hello_world:entry0 + 1:0x000006a1]> e sc[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr[hello_world:entry0 + 1:0x000006a1]> e scr[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.[hello_world:entry0 + 1:0x000006a1]> e scr.[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.p[hello_world:entry0 + 1:0x000006a1]> e scr.p[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.pr[hello_world:entry0 + 1:0x000006a1]> e scr.pr[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.pro[hello_world:entry0 + 1:0x000006a1]> e scr.pro[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prom[hello_world:entry0 + 1:0x000006a1]> e scr.prom[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.promp[hello_world:entry0 + 1:0x000006a1]> e scr.promp[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt[hello_world:entry0 + 1:0x000006a1]> e scr.prompt[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.f[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.f[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fl[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fl[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fla[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fla[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.o[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.o[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.on[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.on[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.onl[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.onl[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=t[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=t[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tr[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tr[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tru[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tru[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true
+[2K[hello_world:entry0 + 1]> [hello_world:entry0 + 1]> [2K[2K[hello_world:entry0 + 1]> e[hello_world:entry0 + 1]> e[2K[2K[hello_world:entry0 + 1]> e [hello_world:entry0 + 1]> e [2K[2K[hello_world:entry0 + 1]> e s[hello_world:entry0 + 1]> e s[2K[2K[hello_world:entry0 + 1]> e sc[hello_world:entry0 + 1]> e sc[2K[2K[hello_world:entry0 + 1]> e scr[hello_world:entry0 + 1]> e scr[2K[2K[hello_world:entry0 + 1]> e scr.[hello_world:entry0 + 1]> e scr.[2K[2K[hello_world:entry0 + 1]> e scr.p[hello_world:entry0 + 1]> e scr.p[2K[2K[hello_world:entry0 + 1]> e scr.pr[hello_world:entry0 + 1]> e scr.pr[2K[2K[hello_world:entry0 + 1]> e scr.pro[hello_world:entry0 + 1]> e scr.pro[2K[2K[hello_world:entry0 + 1]> e scr.prom[hello_world:entry0 + 1]> e scr.prom[2K[2K[hello_world:entry0 + 1]> e scr.promp[hello_world:entry0 + 1]> e scr.promp[2K[2K[hello_world:entry0 + 1]> e scr.prompt[hello_world:entry0 + 1]> e scr.prompt[2K[2K[hello_world:entry0 + 1]> e scr.prompt.[hello_world:entry0 + 1]> e scr.prompt.[2K[2K[hello_world:entry0 + 1]> e scr.prompt.s[hello_world:entry0 + 1]> e scr.prompt.s[2K[2K[hello_world:entry0 + 1]> e scr.prompt.se[hello_world:entry0 + 1]> e scr.prompt.se[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sec[hello_world:entry0 + 1]> e scr.prompt.sec[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect[hello_world:entry0 + 1]> e scr.prompt.sect[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect=[hello_world:entry0 + 1]> e scr.prompt.sect=[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect=t[hello_world:entry0 + 1]> e scr.prompt.sect=t[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect=tr[hello_world:entry0 + 1]> e scr.prompt.sect=tr[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect=tru[hello_world:entry0 + 1]> e scr.prompt.sect=tru[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect=true[hello_world:entry0 + 1]> e scr.prompt.sect=true[2K[hello_world:entry0 + 1]> e scr.prompt.sect=true
+[2K[hello_world:.text:entry0 + 1]> [hello_world:.text:entry0 + 1]> [2K[2K[hello_world:.text:entry0 + 1]> q[hello_world:.text:entry0 + 1]> q[2K[hello_world:.text:entry0 + 1]> q
 EOF
 RUN
 
@@ -652,22 +211,8 @@ NAME=color prompt
 FILE==
 CMDS=!rizin -e cfg.fortunes=0 -e scr.color=1 -N -c "< \nq\n" =
 EXPECT=<<EOF
-[2K
-
-[0m[33m[0x00000000]>[0m 
-[33m[0x00000000]>[0m [2K
-
-[33m[0x00000000]>[0m 
-[2K
-
-[0m[33m[0x00000000]>[0m 
-[33m[0x00000000]>[0m [2K
-[2K
-
-[0m[33m[0x00000000]>[0m q
-[33m[0x00000000]>[0m q[2K
-
-[33m[0x00000000]>[0m q
+[2K[0m[33m[0x00000000]>[0m [33m[0x00000000]>[0m [2K[33m[0x00000000]>[0m 
+[2K[0m[33m[0x00000000]>[0m [33m[0x00000000]>[0m [2K[2K[0m[33m[0x00000000]>[0m q[33m[0x00000000]>[0m q[2K[33m[0x00000000]>[0m q
 EOF
 RUN
 

--- a/test/db/tools/rz
+++ b/test/db/tools/rz
@@ -181,8 +181,22 @@ NAME=b/w prompt
 FILE==
 CMDS=!rizin -e cfg.fortunes=0 -e scr.color=0 -c "< \nq\n" =
 EXPECT=<<EOF
-[2K[0x00000000]> [0x00000000]> [2K[0x00000000]> 
-[2K[0x00000000]> [0x00000000]> [2K[2K[0x00000000]> q[0x00000000]> q[2K[0x00000000]> q
+[2K
+
+[0x00000000]> 
+[0x00000000]> [2K
+
+[0x00000000]> 
+[2K
+
+[0x00000000]> 
+[0x00000000]> [2K
+[2K
+
+[0x00000000]> q
+[0x00000000]> q[2K
+
+[0x00000000]> q
 EOF
 RUN
 
@@ -197,13 +211,440 @@ NAME=prompt settings
 FILE==
 CMDS=!rizin -e cfg.fortunes=0 -e scr.color=0 -c "< \ne scr.prompt.file=true\ne scr.prompt.flag=true\nsd 1\ne scr.prompt.flag.only=true\ne scr.prompt.sect=true\nq\n" ./bins/elf/hello_world
 EXPECT=<<EOF
-[2K[0x000006a0]> [0x000006a0]> [2K[0x000006a0]> 
-[2K[0x000006a0]> [0x000006a0]> [2K[2K[0x000006a0]> e[0x000006a0]> e[2K[2K[0x000006a0]> e [0x000006a0]> e [2K[2K[0x000006a0]> e s[0x000006a0]> e s[2K[2K[0x000006a0]> e sc[0x000006a0]> e sc[2K[2K[0x000006a0]> e scr[0x000006a0]> e scr[2K[2K[0x000006a0]> e scr.[0x000006a0]> e scr.[2K[2K[0x000006a0]> e scr.p[0x000006a0]> e scr.p[2K[2K[0x000006a0]> e scr.pr[0x000006a0]> e scr.pr[2K[2K[0x000006a0]> e scr.pro[0x000006a0]> e scr.pro[2K[2K[0x000006a0]> e scr.prom[0x000006a0]> e scr.prom[2K[2K[0x000006a0]> e scr.promp[0x000006a0]> e scr.promp[2K[2K[0x000006a0]> e scr.prompt[0x000006a0]> e scr.prompt[2K[2K[0x000006a0]> e scr.prompt.[0x000006a0]> e scr.prompt.[2K[2K[0x000006a0]> e scr.prompt.f[0x000006a0]> e scr.prompt.f[2K[2K[0x000006a0]> e scr.prompt.fi[0x000006a0]> e scr.prompt.fi[2K[2K[0x000006a0]> e scr.prompt.fil[0x000006a0]> e scr.prompt.fil[2K[2K[0x000006a0]> e scr.prompt.file[0x000006a0]> e scr.prompt.file[2K[2K[0x000006a0]> e scr.prompt.file=[0x000006a0]> e scr.prompt.file=[2K[2K[0x000006a0]> e scr.prompt.file=t[0x000006a0]> e scr.prompt.file=t[2K[2K[0x000006a0]> e scr.prompt.file=tr[0x000006a0]> e scr.prompt.file=tr[2K[2K[0x000006a0]> e scr.prompt.file=tru[0x000006a0]> e scr.prompt.file=tru[2K[2K[0x000006a0]> e scr.prompt.file=true[0x000006a0]> e scr.prompt.file=true[2K[0x000006a0]> e scr.prompt.file=true
-[2K[hello_world:0x000006a0]> [hello_world:0x000006a0]> [2K[2K[hello_world:0x000006a0]> e[hello_world:0x000006a0]> e[2K[2K[hello_world:0x000006a0]> e [hello_world:0x000006a0]> e [2K[2K[hello_world:0x000006a0]> e s[hello_world:0x000006a0]> e s[2K[2K[hello_world:0x000006a0]> e sc[hello_world:0x000006a0]> e sc[2K[2K[hello_world:0x000006a0]> e scr[hello_world:0x000006a0]> e scr[2K[2K[hello_world:0x000006a0]> e scr.[hello_world:0x000006a0]> e scr.[2K[2K[hello_world:0x000006a0]> e scr.p[hello_world:0x000006a0]> e scr.p[2K[2K[hello_world:0x000006a0]> e scr.pr[hello_world:0x000006a0]> e scr.pr[2K[2K[hello_world:0x000006a0]> e scr.pro[hello_world:0x000006a0]> e scr.pro[2K[2K[hello_world:0x000006a0]> e scr.prom[hello_world:0x000006a0]> e scr.prom[2K[2K[hello_world:0x000006a0]> e scr.promp[hello_world:0x000006a0]> e scr.promp[2K[2K[hello_world:0x000006a0]> e scr.prompt[hello_world:0x000006a0]> e scr.prompt[2K[2K[hello_world:0x000006a0]> e scr.prompt.[hello_world:0x000006a0]> e scr.prompt.[2K[2K[hello_world:0x000006a0]> e scr.prompt.f[hello_world:0x000006a0]> e scr.prompt.f[2K[2K[hello_world:0x000006a0]> e scr.prompt.fl[hello_world:0x000006a0]> e scr.prompt.fl[2K[2K[hello_world:0x000006a0]> e scr.prompt.fla[hello_world:0x000006a0]> e scr.prompt.fla[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag[hello_world:0x000006a0]> e scr.prompt.flag[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag=[hello_world:0x000006a0]> e scr.prompt.flag=[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag=t[hello_world:0x000006a0]> e scr.prompt.flag=t[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag=tr[hello_world:0x000006a0]> e scr.prompt.flag=tr[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag=tru[hello_world:0x000006a0]> e scr.prompt.flag=tru[2K[2K[hello_world:0x000006a0]> e scr.prompt.flag=true[hello_world:0x000006a0]> e scr.prompt.flag=true[2K[hello_world:0x000006a0]> e scr.prompt.flag=true
-[2K[hello_world:entry0:0x000006a0]> [hello_world:entry0:0x000006a0]> [2K[2K[hello_world:entry0:0x000006a0]> s[hello_world:entry0:0x000006a0]> s[2K[2K[hello_world:entry0:0x000006a0]> sd[hello_world:entry0:0x000006a0]> sd[2K[2K[hello_world:entry0:0x000006a0]> sd [hello_world:entry0:0x000006a0]> sd [2K[2K[hello_world:entry0:0x000006a0]> sd 1[hello_world:entry0:0x000006a0]> sd 1[2K[hello_world:entry0:0x000006a0]> sd 1
-[2K[hello_world:entry0 + 1:0x000006a1]> [hello_world:entry0 + 1:0x000006a1]> [2K[2K[hello_world:entry0 + 1:0x000006a1]> e[hello_world:entry0 + 1:0x000006a1]> e[2K[2K[hello_world:entry0 + 1:0x000006a1]> e [hello_world:entry0 + 1:0x000006a1]> e [2K[2K[hello_world:entry0 + 1:0x000006a1]> e s[hello_world:entry0 + 1:0x000006a1]> e s[2K[2K[hello_world:entry0 + 1:0x000006a1]> e sc[hello_world:entry0 + 1:0x000006a1]> e sc[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr[hello_world:entry0 + 1:0x000006a1]> e scr[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.[hello_world:entry0 + 1:0x000006a1]> e scr.[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.p[hello_world:entry0 + 1:0x000006a1]> e scr.p[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.pr[hello_world:entry0 + 1:0x000006a1]> e scr.pr[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.pro[hello_world:entry0 + 1:0x000006a1]> e scr.pro[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prom[hello_world:entry0 + 1:0x000006a1]> e scr.prom[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.promp[hello_world:entry0 + 1:0x000006a1]> e scr.promp[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt[hello_world:entry0 + 1:0x000006a1]> e scr.prompt[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.f[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.f[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fl[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fl[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fla[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fla[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.o[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.o[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.on[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.on[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.onl[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.onl[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=t[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=t[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tr[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tr[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tru[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tru[2K[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true[2K[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true
-[2K[hello_world:entry0 + 1]> [hello_world:entry0 + 1]> [2K[2K[hello_world:entry0 + 1]> e[hello_world:entry0 + 1]> e[2K[2K[hello_world:entry0 + 1]> e [hello_world:entry0 + 1]> e [2K[2K[hello_world:entry0 + 1]> e s[hello_world:entry0 + 1]> e s[2K[2K[hello_world:entry0 + 1]> e sc[hello_world:entry0 + 1]> e sc[2K[2K[hello_world:entry0 + 1]> e scr[hello_world:entry0 + 1]> e scr[2K[2K[hello_world:entry0 + 1]> e scr.[hello_world:entry0 + 1]> e scr.[2K[2K[hello_world:entry0 + 1]> e scr.p[hello_world:entry0 + 1]> e scr.p[2K[2K[hello_world:entry0 + 1]> e scr.pr[hello_world:entry0 + 1]> e scr.pr[2K[2K[hello_world:entry0 + 1]> e scr.pro[hello_world:entry0 + 1]> e scr.pro[2K[2K[hello_world:entry0 + 1]> e scr.prom[hello_world:entry0 + 1]> e scr.prom[2K[2K[hello_world:entry0 + 1]> e scr.promp[hello_world:entry0 + 1]> e scr.promp[2K[2K[hello_world:entry0 + 1]> e scr.prompt[hello_world:entry0 + 1]> e scr.prompt[2K[2K[hello_world:entry0 + 1]> e scr.prompt.[hello_world:entry0 + 1]> e scr.prompt.[2K[2K[hello_world:entry0 + 1]> e scr.prompt.s[hello_world:entry0 + 1]> e scr.prompt.s[2K[2K[hello_world:entry0 + 1]> e scr.prompt.se[hello_world:entry0 + 1]> e scr.prompt.se[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sec[hello_world:entry0 + 1]> e scr.prompt.sec[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect[hello_world:entry0 + 1]> e scr.prompt.sect[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect=[hello_world:entry0 + 1]> e scr.prompt.sect=[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect=t[hello_world:entry0 + 1]> e scr.prompt.sect=t[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect=tr[hello_world:entry0 + 1]> e scr.prompt.sect=tr[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect=tru[hello_world:entry0 + 1]> e scr.prompt.sect=tru[2K[2K[hello_world:entry0 + 1]> e scr.prompt.sect=true[hello_world:entry0 + 1]> e scr.prompt.sect=true[2K[hello_world:entry0 + 1]> e scr.prompt.sect=true
-[2K[hello_world:.text:entry0 + 1]> [hello_world:.text:entry0 + 1]> [2K[2K[hello_world:.text:entry0 + 1]> q[hello_world:.text:entry0 + 1]> q[2K[hello_world:.text:entry0 + 1]> q
+[2K
+
+[0x000006a0]> 
+[0x000006a0]> [2K
+
+[0x000006a0]> 
+[2K
+
+[0x000006a0]> 
+[0x000006a0]> [2K
+[2K
+
+[0x000006a0]> e
+[0x000006a0]> e[2K
+[2K
+
+[0x000006a0]> e 
+[0x000006a0]> e [2K
+[2K
+
+[0x000006a0]> e s
+[0x000006a0]> e s[2K
+[2K
+
+[0x000006a0]> e sc
+[0x000006a0]> e sc[2K
+[2K
+
+[0x000006a0]> e scr
+[0x000006a0]> e scr[2K
+[2K
+
+[0x000006a0]> e scr.
+[0x000006a0]> e scr.[2K
+[2K
+
+[0x000006a0]> e scr.p
+[0x000006a0]> e scr.p[2K
+[2K
+
+[0x000006a0]> e scr.pr
+[0x000006a0]> e scr.pr[2K
+[2K
+
+[0x000006a0]> e scr.pro
+[0x000006a0]> e scr.pro[2K
+[2K
+
+[0x000006a0]> e scr.prom
+[0x000006a0]> e scr.prom[2K
+[2K
+
+[0x000006a0]> e scr.promp
+[0x000006a0]> e scr.promp[2K
+[2K
+
+[0x000006a0]> e scr.prompt
+[0x000006a0]> e scr.prompt[2K
+[2K
+
+[0x000006a0]> e scr.prompt.
+[0x000006a0]> e scr.prompt.[2K
+[2K
+
+[0x000006a0]> e scr.prompt.f
+[0x000006a0]> e scr.prompt.f[2K
+[2K
+
+[0x000006a0]> e scr.prompt.fi
+[0x000006a0]> e scr.prompt.fi[2K
+[2K
+
+[0x000006a0]> e scr.prompt.fil
+[0x000006a0]> e scr.prompt.fil[2K
+[2K
+
+[0x000006a0]> e scr.prompt.file
+[0x000006a0]> e scr.prompt.file[2K
+[2K
+
+[0x000006a0]> e scr.prompt.file=
+[0x000006a0]> e scr.prompt.file=[2K
+[2K
+
+[0x000006a0]> e scr.prompt.file=t
+[0x000006a0]> e scr.prompt.file=t[2K
+[2K
+
+[0x000006a0]> e scr.prompt.file=tr
+[0x000006a0]> e scr.prompt.file=tr[2K
+[2K
+
+[0x000006a0]> e scr.prompt.file=tru
+[0x000006a0]> e scr.prompt.file=tru[2K
+[2K
+
+[0x000006a0]> e scr.prompt.file=true
+[0x000006a0]> e scr.prompt.file=true[2K
+
+[0x000006a0]> e scr.prompt.file=true
+[2K
+
+[hello_world:0x000006a0]> 
+[hello_world:0x000006a0]> [2K
+[2K
+
+[hello_world:0x000006a0]> e
+[hello_world:0x000006a0]> e[2K
+[2K
+
+[hello_world:0x000006a0]> e 
+[hello_world:0x000006a0]> e [2K
+[2K
+
+[hello_world:0x000006a0]> e s
+[hello_world:0x000006a0]> e s[2K
+[2K
+
+[hello_world:0x000006a0]> e sc
+[hello_world:0x000006a0]> e sc[2K
+[2K
+
+[hello_world:0x000006a0]> e scr
+[hello_world:0x000006a0]> e scr[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.
+[hello_world:0x000006a0]> e scr.[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.p
+[hello_world:0x000006a0]> e scr.p[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.pr
+[hello_world:0x000006a0]> e scr.pr[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.pro
+[hello_world:0x000006a0]> e scr.pro[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prom
+[hello_world:0x000006a0]> e scr.prom[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.promp
+[hello_world:0x000006a0]> e scr.promp[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt
+[hello_world:0x000006a0]> e scr.prompt[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.
+[hello_world:0x000006a0]> e scr.prompt.[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.f
+[hello_world:0x000006a0]> e scr.prompt.f[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.fl
+[hello_world:0x000006a0]> e scr.prompt.fl[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.fla
+[hello_world:0x000006a0]> e scr.prompt.fla[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.flag
+[hello_world:0x000006a0]> e scr.prompt.flag[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.flag=
+[hello_world:0x000006a0]> e scr.prompt.flag=[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.flag=t
+[hello_world:0x000006a0]> e scr.prompt.flag=t[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.flag=tr
+[hello_world:0x000006a0]> e scr.prompt.flag=tr[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.flag=tru
+[hello_world:0x000006a0]> e scr.prompt.flag=tru[2K
+[2K
+
+[hello_world:0x000006a0]> e scr.prompt.flag=true
+[hello_world:0x000006a0]> e scr.prompt.flag=true[2K
+
+[hello_world:0x000006a0]> e scr.prompt.flag=true
+[2K
+
+[hello_world:entry0:0x000006a0]> 
+[hello_world:entry0:0x000006a0]> [2K
+[2K
+
+[hello_world:entry0:0x000006a0]> s
+[hello_world:entry0:0x000006a0]> s[2K
+[2K
+
+[hello_world:entry0:0x000006a0]> sd
+[hello_world:entry0:0x000006a0]> sd[2K
+[2K
+
+[hello_world:entry0:0x000006a0]> sd 
+[hello_world:entry0:0x000006a0]> sd [2K
+[2K
+
+[hello_world:entry0:0x000006a0]> sd 1
+[hello_world:entry0:0x000006a0]> sd 1[2K
+
+[hello_world:entry0:0x000006a0]> sd 1
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> 
+[hello_world:entry0 + 1:0x000006a1]> [2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e
+[hello_world:entry0 + 1:0x000006a1]> e[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e 
+[hello_world:entry0 + 1:0x000006a1]> e [2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e s
+[hello_world:entry0 + 1:0x000006a1]> e s[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e sc
+[hello_world:entry0 + 1:0x000006a1]> e sc[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr
+[hello_world:entry0 + 1:0x000006a1]> e scr[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.
+[hello_world:entry0 + 1:0x000006a1]> e scr.[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.p
+[hello_world:entry0 + 1:0x000006a1]> e scr.p[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.pr
+[hello_world:entry0 + 1:0x000006a1]> e scr.pr[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.pro
+[hello_world:entry0 + 1:0x000006a1]> e scr.pro[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prom
+[hello_world:entry0 + 1:0x000006a1]> e scr.prom[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.promp
+[hello_world:entry0 + 1:0x000006a1]> e scr.promp[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.f
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.f[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fl
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fl[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fla
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.fla[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.o
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.o[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.on
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.on[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.onl
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.onl[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=t
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=t[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tr
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tr[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tru
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=tru[2K
+[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true[2K
+
+[hello_world:entry0 + 1:0x000006a1]> e scr.prompt.flag.only=true
+[2K
+
+[hello_world:entry0 + 1]> 
+[hello_world:entry0 + 1]> [2K
+[2K
+
+[hello_world:entry0 + 1]> e
+[hello_world:entry0 + 1]> e[2K
+[2K
+
+[hello_world:entry0 + 1]> e 
+[hello_world:entry0 + 1]> e [2K
+[2K
+
+[hello_world:entry0 + 1]> e s
+[hello_world:entry0 + 1]> e s[2K
+[2K
+
+[hello_world:entry0 + 1]> e sc
+[hello_world:entry0 + 1]> e sc[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr
+[hello_world:entry0 + 1]> e scr[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.
+[hello_world:entry0 + 1]> e scr.[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.p
+[hello_world:entry0 + 1]> e scr.p[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.pr
+[hello_world:entry0 + 1]> e scr.pr[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.pro
+[hello_world:entry0 + 1]> e scr.pro[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prom
+[hello_world:entry0 + 1]> e scr.prom[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.promp
+[hello_world:entry0 + 1]> e scr.promp[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt
+[hello_world:entry0 + 1]> e scr.prompt[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.
+[hello_world:entry0 + 1]> e scr.prompt.[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.s
+[hello_world:entry0 + 1]> e scr.prompt.s[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.se
+[hello_world:entry0 + 1]> e scr.prompt.se[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sec
+[hello_world:entry0 + 1]> e scr.prompt.sec[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sect
+[hello_world:entry0 + 1]> e scr.prompt.sect[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sect=
+[hello_world:entry0 + 1]> e scr.prompt.sect=[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sect=t
+[hello_world:entry0 + 1]> e scr.prompt.sect=t[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sect=tr
+[hello_world:entry0 + 1]> e scr.prompt.sect=tr[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sect=tru
+[hello_world:entry0 + 1]> e scr.prompt.sect=tru[2K
+[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sect=true
+[hello_world:entry0 + 1]> e scr.prompt.sect=true[2K
+
+[hello_world:entry0 + 1]> e scr.prompt.sect=true
+[2K
+
+[hello_world:.text:entry0 + 1]> 
+[hello_world:.text:entry0 + 1]> [2K
+[2K
+
+[hello_world:.text:entry0 + 1]> q
+[hello_world:.text:entry0 + 1]> q[2K
+
+[hello_world:.text:entry0 + 1]> q
 EOF
 RUN
 
@@ -211,8 +652,22 @@ NAME=color prompt
 FILE==
 CMDS=!rizin -e cfg.fortunes=0 -e scr.color=1 -N -c "< \nq\n" =
 EXPECT=<<EOF
-[2K[0m[33m[0x00000000]>[0m [33m[0x00000000]>[0m [2K[33m[0x00000000]>[0m 
-[2K[0m[33m[0x00000000]>[0m [33m[0x00000000]>[0m [2K[2K[0m[33m[0x00000000]>[0m q[33m[0x00000000]>[0m q[2K[33m[0x00000000]>[0m q
+[2K
+
+[0m[33m[0x00000000]>[0m 
+[33m[0x00000000]>[0m [2K
+
+[33m[0x00000000]>[0m 
+[2K
+
+[0m[33m[0x00000000]>[0m 
+[33m[0x00000000]>[0m [2K
+[2K
+
+[0m[33m[0x00000000]>[0m q
+[33m[0x00000000]>[0m q[2K
+
+[33m[0x00000000]>[0m q
 EOF
 RUN
 

--- a/test/db/tools/rz
+++ b/test/db/tools/rz
@@ -516,7 +516,7 @@ ec diff.unmatch red    | mismatch color
  [32m-f[0m[33m from [0m [0mStart searching from address 'from'
  [32m-F[0m[33m file [0m [0mRead the contents of the file and use it as keyword
  [32m-h[0m       [0mShow this help
- [32m-i[0m       [0mIdentify filetype (rizin -nqcpm file)
+ [32m-i[0m       [0mIdentify filetype (magic signatures)
  [32m-j[0m       [0mOutput in JSON
  [32m-m[0m       [0mMagic search, file-type carver
  [32m-M[0m[33m str [0m  [0mSet a binary mask to be applied on keywords

--- a/test/db/tools/rz_find
+++ b/test/db/tools/rz_find
@@ -60,17 +60,19 @@ RUN
 
 NAME=rz-find -h
 FILE==
-CMDS=!rz-find -h | grep -c Usage
+REGEXP_FILTER_OUT=(Usage:)
+CMDS=!rz-find -h
 EXPECT=<<EOF
-1
+Usage:
 EOF
 RUN
 
 NAME=rz-find -v
 FILE==
-CMDS=!rz-find -v | grep -c commit
+REGEXP_FILTER_OUT=(commit:)
+CMDS=!rz-find -v
 EXPECT=<<EOF
-1
+commit:
 EOF
 RUN
 
@@ -92,7 +94,7 @@ RUN
 
 NAME=rz-find -i
 FILE==
-CMDS=!!rz-find -i bins/elf/ioli/crackme0x00
+CMDS=!rz-find -i bins/elf/ioli/crackme0x00
 EXPECT=<<EOF
 0x00000000 ELF 32-bit LSB executable, Intel 80386, version 1
 EOF
@@ -100,7 +102,7 @@ RUN
 
 NAME=rz-find -m
 FILE==
-CMDS=!!rz-find -m bins/elf/ioli/crackme0x00
+CMDS=!rz-find -m bins/elf/ioli/crackme0x00
 EXPECT=<<EOF
 0x00000000 0 hit.magic.0 ELF 32-bit LSB executable, Intel 80386, version 1
 EOF
@@ -284,8 +286,11 @@ RUN
 
 NAME=rz-find -V verbose flag multiple files
 FILE==
-CMDS=!rz-find -V -s README bins/arm/README bins/arm/README | head -3
+CMDS=!rz-find -V -s README bins/arm/README bins/arm/README
 EXPECT=<<EOF
+Scanning: bins/arm/README
+File: bins/arm/README
+0x0
 Scanning: bins/arm/README
 File: bins/arm/README
 0x0
@@ -294,26 +299,27 @@ RUN
 
 NAME=rz-find -V with -q still shows scanning
 FILE==
-CMDS=!rz-find -V -q -s 250382 bins/elf/ioli/crackme0x00 | head -1
+CMDS=!rz-find -V -q -s 250382 bins/elf/ioli/crackme0x00
 EXPECT=<<EOF
 Scanning: bins/elf/ioli/crackme0x00
+0x58f
 EOF
 RUN
 
 NAME=rz-find -V overrides auto-quiet for single file
 FILE==
-CMDS=!rz-find -V -s 250382 bins/elf/ioli/crackme0x00 | grep -c "File:"
+REGEXP_FILTER_OUT=(File: bins/elf/ioli/crackme0x00)
+CMDS=!rz-find -V -s 250382 bins/elf/ioli/crackme0x00
 EXPECT=<<EOF
-1
+File: bins/elf/ioli/crackme0x00
 EOF
 RUN
 
 NAME=rz-find without -V no scanning output
 FILE==
-CMDS=!rz-find -s 250382 bins/elf/ioli/crackme0x00 | grep -c "Scanning:"
-EXPECT=<<EOF
-0
-EOF
+REGEXP_FILTER_OUT=(Scanning:)
+CMDS=!rz-find -s 250382 bins/elf/ioli/crackme0x00
+EXPECT=
 RUN
 
 NAME=rz-find multi-file continues on error

--- a/test/db/tools/rz_find
+++ b/test/db/tools/rz_find
@@ -315,3 +315,78 @@ EXPECT=<<EOF
 0
 EOF
 RUN
+
+NAME=rz-find multi-file continues on error
+FILE==
+CMDS=!rz-find -s README nonexistent_file.bin bins/arm/README
+EXPECT=<<EOF
+File: bins/arm/README
+0x0
+EOF
+EXPECT_ERR=<<EOF
+Cannot open file 'nonexistent_file.bin'
+EOF
+RUN
+
+NAME=rz-find multi-file error exit code
+FILE==
+CMDS=<<EOF
+!rz-find -s README nonexistent_file.bin bins/arm/README
+%v $?
+EOF
+EXPECT=<<EOF
+File: bins/arm/README
+0x0
+0x1
+EOF
+EXPECT_ERR=<<EOF
+Cannot open file 'nonexistent_file.bin'
+EOF
+RUN
+
+NAME=rz-find multi-file all success exit code
+FILE==
+CMDS=<<EOF
+!rz-find -q -s README bins/arm/README bins/arm/README
+%v $?
+EOF
+EXPECT=<<EOF
+0x0
+0x0
+0x0
+EOF
+RUN
+
+NAME=rz-find empty path continues to next
+FILE==
+CMDS=<<EOF
+!rz-find -q -s README "" bins/arm/README
+%v $?
+EOF
+EXPECT=<<EOF
+0x0
+0x1
+EOF
+EXPECT_ERR=<<EOF
+Cannot open empty path
+EOF
+RUN
+
+NAME=rz-find JSON multiple files keyword search
+FILE==
+CMDS=!rz-find -j -s 250382 bins/elf/ioli/crackme0x00 bins/elf/ioli/crackme0x00
+EXPECT=<<EOF
+[{"offset":1423,"type":"string","data":"250382"},{"offset":1423,"type":"string","data":"250382"}]
+EOF
+RUN
+
+NAME=rz-find verbose with JSON outputs scanning to stderr
+FILE==
+CMDS=!rz-find -V -j -s 250382 bins/elf/ioli/crackme0x00
+EXPECT=<<EOF
+[{"offset":1423,"type":"string","data":"250382"}]
+EOF
+EXPECT_ERR=<<EOF
+Scanning: bins/elf/ioli/crackme0x00
+EOF
+RUN

--- a/test/db/tools/rz_find
+++ b/test/db/tools/rz_find
@@ -334,46 +334,32 @@ Cannot open file 'nonexistent_file.bin'
 EOF
 RUN
 
-NAME=rz-find multi-file error exit code
+NAME=rz-find multi-file exit codes
 FILE==
 CMDS=<<EOF
 !rz-find -s README nonexistent_file.bin bins/arm/README
+%v $?
+!echo ---
+!rz-find -q -s README bins/arm/README bins/arm/README
+%v $?
+!echo ---
+!rz-find -q -s README "" bins/arm/README
 %v $?
 EOF
 EXPECT=<<EOF
 File: bins/arm/README
 0x0
 0x1
-EOF
-EXPECT_ERR=<<EOF
-Cannot open file 'nonexistent_file.bin'
-EOF
-RUN
-
-NAME=rz-find multi-file all success exit code
-FILE==
-CMDS=<<EOF
-!rz-find -q -s README bins/arm/README bins/arm/README
-%v $?
-EOF
-EXPECT=<<EOF
+---
 0x0
 0x0
 0x0
-EOF
-RUN
-
-NAME=rz-find empty path continues to next
-FILE==
-CMDS=<<EOF
-!rz-find -q -s README "" bins/arm/README
-%v $?
-EOF
-EXPECT=<<EOF
+---
 0x0
 0x1
 EOF
 EXPECT_ERR=<<EOF
+Cannot open file 'nonexistent_file.bin'
 Cannot open empty path
 EOF
 RUN


### PR DESCRIPTION
 **Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes. *(No `RZ_API` interfaces were changed.)*
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`). *(Tests added/updated for `rz-find`; no `RZ_API` changes.)*
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed). *(Not needed for this change.)*
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

---

## Detailed description

This PR enhances **`rz-find`** to support **multiple input paths** (multiple files and/or directories) in a single invocation, similar to how coreutils `find` accepts multiple starting points.

### What this changes
- Accept and process `rz-find ... [path1] [path2] ...` where each path may be a file or a directory.
- Continue scanning subsequent paths even if one path fails to open or scan (error is reported, but the tool keeps going).
- Return an aggregated exit status: success only if all provided paths were processed successfully.
- Make output consistent across multi-path use:
  - Non-JSON output prints per-file headers when needed (so results remain attributable).
  - Verbose “Scanning:” diagnostics are emitted in a way that does not corrupt JSON output. (Earlier was getting an extra "[" :sad )

### Implementation notes
- Adjusted the main iteration logic to properly handle multiple independent paths (files/dirs), including edge cases like empty paths and partial failures.
- Fixed JSON framing/comma handling so multi-path output remains valid JSON.
- Updated/added tests and updated `rz-find` documentation accordingly.

---

## Test plan

Commands (Windows / PowerShell example, on which it was tested):

1. Configure + build:
````powershell
meson setup build --buildtype=debug
ninja -C build
````

2. Run `rz-find` regression tests:
````powershell
cd test
..\build\binrz\rz-test\rz-test.exe -j 1 db/tools/rz_find
````

3. Spot-check multi-path behavior manually (examples):
````powershell
..\build\binrz\rz-find\rz-find.exe -s README bins\arm\README bins\arm
..\build\binrz\rz-find\rz-find.exe -j -s README bins\arm\README bins\arm\README
..\build\binrz\rz-find\rz-find.exe -V -j -s README bins\arm\README bins\arm\README
````

(If JSON validation is desired, parse stdout with a JSON parser; ensure verbose output does not break JSON.)

---

## Closing issues

closes #5253
