### PR TITLE
rz_list.h: Use `static inline` funcs instead of macros

### DIFF
--- a/librz/include/rz_list.h
+++ b/librz/include/rz_list.h
@@ -51,14 +51,37 @@ typedef int (*RzListComparator)(const void *value, const void *list_data, void *
 #define rz_list_foreach_prev_safe(list, it, tmp, var) \
 	for (it = list->tail; it && (var = it->val, tmp = it->prev, 1); it = tmp)
 
-#define rz_list_empty(x)    (!(x) || !(x)->length)
-#define rz_list_head(x)     ((x) ? (x)->head : NULL)
-#define rz_list_tail(x)     ((x) ? (x)->tail : NULL)
-#define rz_list_prev(x)     ((x)->prev)
-#define rz_list_next(x)     ((x)->next)
-#define rz_list_get(x)      ((x)->val)
-#define rz_list_has_prev(x) ((x)->prev != NULL)
-#define rz_list_has_next(x) ((x)->next != NULL)
+static inline bool rz_list_empty(RZ_NULLABLE const RzList *list) {
+	return !list || !list->length;
+}
+
+static inline RZ_BORROW RzListIter *rz_list_head(RZ_NULLABLE const RzList *list) {
+	return list ? list->head : NULL;
+}
+
+static inline RZ_BORROW RzListIter *rz_list_tail(RZ_NULLABLE const RzList *list) {
+	return list ? list->tail : NULL;
+}
+
+static inline RZ_BORROW RzListIter *rz_list_prev(RZ_NONNULL const RzListIter *iter) {
+	return iter->prev;
+}
+
+static inline RZ_BORROW RzListIter *rz_list_next(RZ_NONNULL const RzListIter *iter) {
+	return iter->next;
+}
+
+static inline RZ_BORROW void *rz_list_get(RZ_NONNULL const RzListIter *iter) {
+	return iter->val;
+}
+
+static inline bool rz_list_has_prev(RZ_NONNULL const RzListIter *iter) {
+	return iter->prev != NULL;
+}
+
+static inline bool rz_list_has_next(RZ_NONNULL const RzListIter *iter) {
+	return iter->next != NULL;
+}
 
 RZ_API RZ_OWN RzList *rz_list_new(void);
 RZ_API RZ_OWN RzList *rz_list_newf(RZ_NULLABLE RzListFree f);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr makes rz_list.h declare `static inline` functions instead of macro functions due to the following reasons:

1. There is better type-checking for arguments and return values.
2. rz-bindgen can generate bindings for them like normal functions, so there is no need for tedious and possibly error-prone manual bindings.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
