### PR TITLE
Use ht_xx_size() instead of reading ht internal state

### DIFF
--- a/librz/arch/serialize_analysis.c
+++ b/librz/arch/serialize_analysis.c
@@ -1141,7 +1141,7 @@ static void function_store(RZ_NONNULL Sdb *db, const char *key, RzAnalysisFuncti
 		pj_end(j);
 	}
 
-	if (function->labels->count) {
+	if (ht_up_size(function->labels)) {
 		pj_ko(j, "labels");
 		ht_up_foreach(function->labels, store_label_cb, j);
 		pj_end(j);

--- a/librz/arch/xrefs.c
+++ b/librz/arch/xrefs.c
@@ -256,7 +256,7 @@ RZ_API bool rz_analysis_xrefs_init(RzAnalysis *analysis) {
 }
 
 static bool count_cb(void *user, const ut64 k, const void *v) {
-	(*(ut64 *)user) += ((HtUP *)v)->count;
+	(*(ut64 *)user) += ht_up_size((HtUP *)v);
 	return true;
 }
 

--- a/librz/bin/dwarf/abbrev.c
+++ b/librz/bin/dwarf/abbrev.c
@@ -253,7 +253,7 @@ RZ_API void rz_core_bin_dwarf_abbrevs_dump(
 	RZ_NONNULL RZ_BORROW const RzBinDwarfAbbrev *abbrevs,
 	RZ_NONNULL RZ_BORROW RzStrBuf *sb) {
 	rz_return_if_fail(abbrevs && sb);
-	if (abbrevs->by_offset->count > 0) {
+	if (ht_up_size(abbrevs->by_offset) > 0) {
 		rz_strbuf_append(sb, ".debug_abbrevs content:\n");
 	}
 	ht_up_foreach(abbrevs->by_offset, cb_abbrev_table_dump, sb);

--- a/librz/bin/dwarf/loclists.c
+++ b/librz/bin/dwarf/loclists.c
@@ -451,7 +451,7 @@ RZ_API void rz_bin_dwarf_loclists_dump(
 	RZ_NONNULL RZ_BORROW RzBinDWARF *dw,
 	RZ_NONNULL RZ_BORROW RzStrBuf *sb) {
 	rz_return_if_fail(dw && loclists && loclists->by_offset && sb);
-	if (loclists->by_offset->count > 0) {
+	if (ht_up_size(loclists->by_offset) > 0) {
 		rz_strbuf_append(sb, ".debug_loclists content:\n");
 	}
 	DumpContext ctx = {

--- a/librz/bin/dwarf/rnglists.c
+++ b/librz/bin/dwarf/rnglists.c
@@ -342,7 +342,7 @@ RZ_API void rz_bin_dwarf_rnglists_dump(
 	RZ_NONNULL RZ_BORROW RzBinDwarfRngLists *rnglists,
 	RZ_NONNULL RZ_BORROW RzStrBuf *sb) {
 	rz_return_if_fail(rnglists && rnglists->by_offset && sb);
-	if (rnglists->by_offset->count > 0) {
+	if (ht_up_size(rnglists->by_offset) > 0) {
 		rz_strbuf_append(sb, ".debug_loclists content:\n");
 	}
 	ht_up_foreach(rnglists->by_offset, cb_rnglist_dump, sb);

--- a/librz/bin/format/coff/coff_reloc.c
+++ b/librz/bin/format/coff/coff_reloc.c
@@ -256,7 +256,7 @@ RZ_API RzPVector /*<RzBinReloc *>*/ *rz_coff_get_relocs(struct rz_bin_coff_obj *
 /// size of the artificial reloc target vfile
 RZ_API ut64 rz_coff_get_reloc_targets_vfile_size(struct rz_bin_coff_obj *obj) {
 	rz_return_val_if_fail(obj, 0);
-	ut64 count = obj->imp_index ? obj->imp_index->count : 0;
+	ut64 count = obj->imp_index ? ht_uu_size(obj->imp_index) : 0;
 	return count * RZ_COFF_RELOC_TARGET_SIZE;
 }
 

--- a/librz/bin/p/bin_coff.c
+++ b/librz/bin/p/bin_coff.c
@@ -326,7 +326,7 @@ static RzPVector /*<RzBinSection *>*/ *coff_sections(RzBinFile *bf) {
 }
 
 static void coff_populate_imports(struct rz_bin_coff_obj *obj) {
-	if (obj->imp_index->count || !obj->symbols) {
+	if (ht_uu_size(obj->imp_index) || !obj->symbols) {
 		return;
 	}
 	int ord = 0;
@@ -345,7 +345,7 @@ static void coff_populate_imports(struct rz_bin_coff_obj *obj) {
 
 static void coff_populate_symbols(RzBinFile *bf) {
 	struct rz_bin_coff_obj *obj = (struct rz_bin_coff_obj *)bf->o->bin_obj;
-	if (obj->sym_ht->count || !obj->symbols) {
+	if (ht_up_size(obj->sym_ht) || !obj->symbols) {
 		return;
 	}
 	coff_populate_imports(obj);

--- a/librz/core/analysis_tp.c
+++ b/librz/core/analysis_tp.c
@@ -929,7 +929,7 @@ RZ_API void rz_core_analysis_type_match(RzCore *core, RzAnalysisFunction *fcn, H
 			rz_list_free(fcns);
 			// Recreate op_cache if it grows too large to avoid
 			// excessive memory usage.
-			if (op_cache->count > OP_CACHE_LIMIT) {
+			if (ht_up_size(op_cache) > OP_CACHE_LIMIT) {
 				ht_up_free(op_cache);
 				op_cache = ht_up_new(NULL, (HtUPFreeValue)rz_analysis_op_free);
 				if (!op_cache) {

--- a/librz/core/basefind.c
+++ b/librz/core/basefind.c
@@ -182,7 +182,7 @@ static HtUU *basefind_create_pointer_map(RzCore *core, ut32 pointer_size) {
 		ut64 value = ht_uu_find(map, address, NULL) + 1;
 		ht_uu_insert(map, address, value);
 	}
-	RZ_LOG_INFO("basefind: located %u pointers\n", map->count);
+	RZ_LOG_INFO("basefind: located %u pointers\n", ht_uu_size(map));
 
 	return map;
 }

--- a/librz/core/cmd/cmd_flag.c
+++ b/librz/core/cmd/cmd_flag.c
@@ -271,7 +271,7 @@ RZ_IPI RzCmdStatus rz_flag_local_list_all_handler(RzCore *core, int argc, const 
 	RzListIter *it;
 	rz_cmd_state_output_array_start(state);
 	rz_list_foreach (core->analysis->fcns, it, fcn) {
-		if (!fcn->labels->count) {
+		if (!ht_up_size(fcn->labels)) {
 			continue;
 		}
 		if (state->mode == RZ_OUTPUT_MODE_JSON) {

--- a/librz/core/tui/panels.c
+++ b/librz/core/tui/panels.c
@@ -5730,7 +5730,7 @@ static bool key_to_vec_cb(void *user, const char *k, const void *v) {
  */
 static RZ_OWN RzPVector /*<const char *>*/ *get_HtSP_key_list(HtSP *ht) {
 	RzPVector *vec = rz_pvector_new(NULL);
-	if (!vec || !rz_pvector_reserve(vec, ht->count)) {
+	if (!vec || !rz_pvector_reserve(vec, ht_sp_size(ht))) {
 		rz_pvector_free(vec);
 		return NULL;
 	}
@@ -5744,7 +5744,7 @@ void __update_modal(RzCore *core, HtSP *menu_db, RModal *modal) {
 	RzPanelsTab *tab = visual->panels_root->active_tab;
 	RzConsCanvas *can = tab->can;
 	modal->data = rz_strbuf_new(NULL);
-	int count = menu_db->count;
+	int count = ht_sp_size(menu_db);
 	if (modal->idx >= count) {
 		modal->idx = 0;
 		modal->offset = 0;

--- a/librz/io/serialize_io.c
+++ b/librz/io/serialize_io.c
@@ -74,7 +74,7 @@ static bool file_save_cb(void *user, void *data, ut32 id) {
 	sdb_set(db, key, pj_string(j));
 	pj_free(j);
 
-	if (desc->cache->count) {
+	if (ht_up_size(desc->cache)) {
 		PCacheSaveCtx ctx = {
 			.fd = desc->fd,
 			.db = sdb_ns(db, "pcache", true)

--- a/librz/util/set.c
+++ b/librz/util/set.c
@@ -61,7 +61,7 @@ RZ_API RZ_OWN RzPVector /*<char *>*/ *rz_set_s_to_vector(RZ_NONNULL RzSetS *set)
 	rz_return_val_if_fail(set, NULL);
 
 	RzPVector *vec = rz_pvector_new(set->opt.finiKV ? free : NULL);
-	if (!vec || !rz_pvector_reserve(vec, set->count)) {
+	if (!vec || !rz_pvector_reserve(vec, ht_sp_size((HtSP *)set))) {
 		rz_pvector_free(vec);
 		return NULL;
 	}

--- a/test/unit/test_ht.c
+++ b/test/unit/test_ht.c
@@ -766,7 +766,7 @@ bool test_set_u(void) {
 	// Add an address as key which is far away from the heap addresses.
 	rz_set_u_add(set_u, 100000000);
 	mu_assert_true(rz_set_u_contains(set_u, 100000000), "Not contained.");
-	mu_assert_eq(set_u->count, 5, "count");
+	mu_assert_eq(rz_set_u_size(set_u), 5, "count");
 	mu_assert_false(rz_set_u_contains(set_u, 6), "should not be here.");
 
 	x = 0;

--- a/test/unit/test_il_validate.c
+++ b/test/unit/test_il_validate.c
@@ -1002,7 +1002,7 @@ static bool test_il_validate_effect_repeat() {
 	mu_assert_eq(t, RZ_IL_TYPE_EFFECT_DATA, "effect type");
 	mu_assert_null(report, "no report");
 	mu_assert_notnull(local_var_sorts, "local var sorts");
-	mu_assert_eq(local_var_sorts->count, 1, "local var sorts count");
+	mu_assert_eq(ht_sp_size(local_var_sorts), 1, "local var sorts count");
 	RzILSortPure *sort = ht_sp_find(local_var_sorts, "x", NULL);
 	mu_assert_notnull(sort, "local var sort");
 	mu_assert_true(rz_il_sort_pure_eq(*sort, rz_il_sort_pure_bv(14)), "local var sort");
@@ -1019,7 +1019,7 @@ static bool test_il_validate_effect_repeat() {
 	mu_assert_true(val, "valid");
 	mu_assert_null(report, "no report");
 	mu_assert_notnull(local_var_sorts, "local var sorts");
-	mu_assert_eq(local_var_sorts->count, 2, "local var sorts count");
+	mu_assert_eq(ht_sp_size(local_var_sorts), 2, "local var sorts count");
 	sort = ht_sp_find(local_var_sorts, "x", NULL);
 	mu_assert_notnull(sort, "local var sort");
 	mu_assert_true(rz_il_sort_pure_eq(*sort, rz_il_sort_pure_bv(14)), "local var sort");
@@ -1039,7 +1039,7 @@ static bool test_il_validate_effect_repeat() {
 	mu_assert_true(val, "valid");
 	mu_assert_null(report, "no report");
 	mu_assert_notnull(local_var_sorts, "local var sorts");
-	mu_assert_eq(local_var_sorts->count, 2, "local var sorts count");
+	mu_assert_eq(ht_sp_size(local_var_sorts), 2, "local var sorts count");
 	sort = ht_sp_find(local_var_sorts, "x", NULL);
 	mu_assert_notnull(sort, "local var sort");
 	mu_assert_true(rz_il_sort_pure_eq(*sort, rz_il_sort_pure_bv(14)), "local var sort");
@@ -1144,7 +1144,7 @@ static bool test_il_validate_effect_branch() {
 	mu_assert_true(val, "valid");
 	mu_assert_null(report, "no report");
 	mu_assert_notnull(local_var_sorts, "local var sorts");
-	mu_assert_eq(local_var_sorts->count, 2, "local var sorts count");
+	mu_assert_eq(ht_sp_size(local_var_sorts), 2, "local var sorts count");
 	RzILSortPure *sort = ht_sp_find(local_var_sorts, "x", NULL);
 	mu_assert_notnull(sort, "local var sort");
 	mu_assert_true(rz_il_sort_pure_eq(*sort, rz_il_sort_pure_bv(14)), "local var sort");
@@ -1165,7 +1165,7 @@ static bool test_il_validate_effect_branch() {
 	mu_assert_eq(t, RZ_IL_TYPE_EFFECT_DATA, "effect type");
 	mu_assert_null(report, "no report");
 	mu_assert_notnull(local_var_sorts, "local var sorts");
-	mu_assert_eq(local_var_sorts->count, 1, "local var sorts count");
+	mu_assert_eq(ht_sp_size(local_var_sorts), 1, "local var sorts count");
 	sort = ht_sp_find(local_var_sorts, "y", NULL);
 	mu_assert_notnull(sort, "local var sort");
 	mu_assert_true(rz_il_sort_pure_eq(*sort, rz_il_sort_pure_bool()), "local var sort");
@@ -1182,7 +1182,7 @@ static bool test_il_validate_effect_branch() {
 	mu_assert_true(val, "valid");
 	mu_assert_null(report, "no report");
 	mu_assert_notnull(local_var_sorts, "local var sorts");
-	mu_assert_eq(local_var_sorts->count, 2, "local var sorts count");
+	mu_assert_eq(ht_sp_size(local_var_sorts), 2, "local var sorts count");
 	sort = ht_sp_find(local_var_sorts, "x", NULL);
 	mu_assert_notnull(sort, "local var sort");
 	mu_assert_true(rz_il_sort_pure_eq(*sort, rz_il_sort_pure_bv(14)), "local var sort");
@@ -1201,7 +1201,7 @@ static bool test_il_validate_effect_branch() {
 	mu_assert_true(val, "valid");
 	mu_assert_null(report, "no report");
 	mu_assert_notnull(local_var_sorts, "local var sorts");
-	mu_assert_eq(local_var_sorts->count, 2, "local var sorts count");
+	mu_assert_eq(ht_sp_size(local_var_sorts), 2, "local var sorts count");
 	sort = ht_sp_find(local_var_sorts, "x", NULL);
 	mu_assert_notnull(sort, "local var sort");
 	mu_assert_true(rz_il_sort_pure_eq(*sort, rz_il_sort_pure_bv(14)), "local var sort");
@@ -1223,7 +1223,7 @@ static bool test_il_validate_effect_branch() {
 	mu_assert_true(val, "valid");
 	mu_assert_null(report, "no report");
 	mu_assert_notnull(local_var_sorts, "local var sorts");
-	mu_assert_eq(local_var_sorts->count, 2, "local var sorts count");
+	mu_assert_eq(ht_sp_size(local_var_sorts), 2, "local var sorts count");
 	sort = ht_sp_find(local_var_sorts, "x", NULL);
 	mu_assert_notnull(sort, "local var sort");
 	mu_assert_true(rz_il_sort_pure_eq(*sort, rz_il_sort_pure_bv(14)), "local var sort");

--- a/test/unit/test_rop.c
+++ b/test/unit/test_rop.c
@@ -134,7 +134,7 @@ bool test_rz_direct_solver() {
 
 	HtUP *rop_semantics = core->analysis->ht_rop_semantics;
 	mu_assert_notnull(rop_semantics, "ROP semantics hashtable is NULL");
-	mu_assert_eq(rop_semantics->count, 2, "ROP semantics hashtable count is not 2");
+	mu_assert_eq(ht_up_size(rop_semantics), 2, "ROP semantics hashtable count is not 2");
 	ht_up_foreach(rop_semantics, rop_gadget_info_cb, ht_rop_analysis);
 	rz_core_rop_search_context_free(context);
 	cleanup_test(core, ht_rop_analysis);

--- a/test/unit/test_serialize_analysis.c
+++ b/test/unit/test_serialize_analysis.c
@@ -280,7 +280,7 @@ bool test_analysis_function_load() {
 	mu_assert_eq(rz_list_length(f->imports), 2, "imports count");
 	mu_assert_streq(rz_list_get_n(f->imports, 0), "earth", "import");
 	mu_assert_streq(rz_list_get_n(f->imports, 1), "rise", "import");
-	mu_assert_eq(f->labels->count, 3, "labels count");
+	mu_assert_eq(ht_up_size(f->labels), 3, "labels count");
 	mu_assert_eq(rz_analysis_function_get_label(f, "beach"), 1400, "label");
 	mu_assert_eq(rz_analysis_function_get_label(f, "another"), 1450, "label");
 	mu_assert_eq(rz_analysis_function_get_label(f, "year"), 1440, "label");
@@ -301,7 +301,7 @@ bool test_analysis_function_load() {
 	mu_assert("bp_frame", f->bp_frame);
 	mu_assert_eq(f->bp_off, 0, "bp off");
 	mu_assert_null(f->imports, "imports");
-	mu_assert_eq(f->labels->count, 0, "labels count");
+	mu_assert_eq(ht_up_size(f->labels), 0, "labels count");
 
 	f = rz_analysis_get_function_at(analysis, 4242);
 	mu_assert_notnull(f, "function");
@@ -317,7 +317,7 @@ bool test_analysis_function_load() {
 	mu_assert("noreturn", !f->is_noreturn);
 	mu_assert("bp_frame", !f->bp_frame);
 	mu_assert_null(f->imports, "imports");
-	mu_assert_eq(f->labels->count, 0, "labels count");
+	mu_assert_eq(ht_up_size(f->labels), 0, "labels count");
 
 	f = rz_analysis_get_function_at(analysis, 424242);
 	mu_assert_notnull(f, "function");
@@ -333,31 +333,31 @@ bool test_analysis_function_load() {
 	mu_assert("noreturn", f->is_noreturn);
 	mu_assert("bp_frame", f->bp_frame);
 	mu_assert_null(f->imports, "imports");
-	mu_assert_eq(f->labels->count, 0, "labels count");
+	mu_assert_eq(ht_up_size(f->labels), 0, "labels count");
 
 	f = rz_analysis_get_function_at(analysis, 0xdead);
 	mu_assert_notnull(f, "function");
 	mu_assert_streq(f->name, "agnosie", "name");
 	mu_assert_eq(f->type, RZ_ANALYSIS_FCN_TYPE_IMP, "type");
-	mu_assert_eq(f->labels->count, 0, "labels count");
+	mu_assert_eq(ht_up_size(f->labels), 0, "labels count");
 
 	f = rz_analysis_get_function_at(analysis, 0xbeef);
 	mu_assert_notnull(f, "function");
 	mu_assert_streq(f->name, "eskapist", "name");
 	mu_assert_eq(f->type, RZ_ANALYSIS_FCN_TYPE_INT, "type");
-	mu_assert_eq(f->labels->count, 0, "labels count");
+	mu_assert_eq(ht_up_size(f->labels), 0, "labels count");
 
 	f = rz_analysis_get_function_at(analysis, 0xc0ffee);
 	mu_assert_notnull(f, "function");
 	mu_assert_streq(f->name, "lifnej", "name");
 	mu_assert_eq(f->type, RZ_ANALYSIS_FCN_TYPE_ROOT, "type");
-	mu_assert_eq(f->labels->count, 0, "labels count");
+	mu_assert_eq(ht_up_size(f->labels), 0, "labels count");
 
 	f = rz_analysis_get_function_at(analysis, 0x31337);
 	mu_assert_notnull(f, "function");
 	mu_assert_streq(f->name, "aldebaran", "name");
 	mu_assert_eq(f->type, RZ_ANALYSIS_FCN_TYPE_ANY, "type");
-	mu_assert_eq(f->labels->count, 0, "labels count");
+	mu_assert_eq(ht_up_size(f->labels), 0, "labels count");
 
 	assert_block_invariants(analysis);
 	assert_block_leaks(analysis);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Use `ht_xx_size()` instead of reading `ht->count` directly. Related to [the ht refactoring](https://github.com/rizinorg/rizin/pull/5860).

**Test plan**
Should be already covered by existing tests

**Closing issues**
None

