### PR TITLE
allow wildcard in rz-hash for linux

### DIFF
--- a/librz/main/rz-hash.c
+++ b/librz/main/rz-hash.c
@@ -403,9 +403,6 @@ static void hash_parse_cmdline(int argc, const char **argv, RzHashContext *ctx) 
 			if (IS_NULLSTR(argv[i])) {
 				rz_hash_error(ctx, RZ_HASH_OP_ERROR, "cannot open a file without a name.\n");
 			}
-			if (rz_file_is_directory(argv[i])) {
-				rz_hash_error(ctx, RZ_HASH_OP_ERROR, "cannot open directories (%s).\n", argv[i]);
-			}
 			ctx->files[ctx->nfiles++] = argv[i];
 		}
 	}
@@ -652,6 +649,10 @@ static bool hash_context_run(RzHashContext *ctx, RzHashRun run) {
 		}
 	} else {
 		for (ut32 i = 0; i < ctx->nfiles; ++i) {
+			if (rz_file_is_directory(ctx->files[i])) {
+				eprintf("rz-hash: %s: Is a directory\n", ctx->files[i]);
+				continue;
+			}
 			desc = rz_io_open_nomap(io, ctx->files[i], RZ_PERM_R, 0);
 			if (!desc) {
 				RZ_LOG_ERROR("rz-hash: error, cannot open file '%s'\n", ctx->files[i]);


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

The `rz-hash` tool currently cannot compute of files in a directory as discussed in #5869. This PR leverages shell's built-in wildcard expansions to process all files that match a pattern.
This way, the api remains consistent with other shell utilities.

...

**Test plan**

The expected behavior is same as `sha256sum`:

<img width="1478" height="140" alt="image" src="https://github.com/user-attachments/assets/44d224a6-4649-42ac-8902-268c1d82eef5" />

<img width="1469" height="273" alt="image" src="https://github.com/user-attachments/assets/9fb6aca5-d4ec-4f6c-b80e-cf2224652acf" />

<img width="1280" height="240" alt="image" src="https://github.com/user-attachments/assets/2cfc4e8c-502e-4ab9-a2fb-2c6608f82f0d" />

<img width="382" height="110" alt="image" src="https://github.com/user-attachments/assets/f195f181-28a1-4b7e-8741-067c12364f51" />

<img width="1305" height="246" alt="image" src="https://github.com/user-attachments/assets/98de05fa-5774-48ae-9ae3-ff22077ebd98" />

...

**Closing issues**

closes #5869

...
