### PR TITLE
Fix test_vector_contains() test for s390x

### DIFF
--- a/test/unit/test_vector.c
+++ b/test/unit/test_vector.c
@@ -706,9 +706,9 @@ static bool test_vector_push_front(void) {
 static bool test_vector_contains(void) {
 	RzVector v;
 	init_test_vector(&v, 6, 0, NULL, NULL);
-	ut64 a = 0;
-	ut64 b = 5;
-	ut64 c = 6;
+	ut32 a = 0;
+	ut32 b = 5;
+	ut32 c = 6;
 	mu_assert_true(rz_vector_contains(&v, &a), "Should contain");
 	mu_assert_true(rz_vector_contains(&v, &b), "Should contain");
 	mu_assert_false(rz_vector_contains(&v, &c), "Should not contain");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr fixes the following ERR in the Travis s390x build:

<img width="553" height="36" alt="test_vector_contains-s390x-err" src="https://github.com/user-attachments/assets/1f8306a7-7bda-42ac-ad27-554666df9686" />

https://app.travis-ci.com/github/rizinorg/rizin/jobs/637910172#L4397

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
