### PR TITLE
Add SerenityOS Support

### DIFF
--- a/librz/core/heap_glibc.c
+++ b/librz/core/heap_glibc.c
@@ -890,6 +890,7 @@ static void resolve_tcache_perthread(RZ_NONNULL RzCore *core, const RzHeapConfig
 	}
 }
 
+#if !defined(__serenity__)
 RZ_API RZ_OWN bool resolve_heap_tcache(RZ_NONNULL RzCore *core, ut64 arena_base, const RzHeapConfig *config) {
 	RzDebug *dbg = core->dbg;
 
@@ -904,6 +905,7 @@ RZ_API RZ_OWN bool resolve_heap_tcache(RZ_NONNULL RzCore *core, ut64 arena_base,
 
 	return true;
 }
+#endif
 
 void print_heap_chunk(RzCore *core, ut64 chunk, const RzHeapConfig *config) {
 	RzConsPrintablePalette *pal = &rz_cons_singleton()->context->pal;
@@ -2534,9 +2536,11 @@ RZ_IPI RzCmdStatus rz_cmd_heap_tcache_print_handler(RzCore *core, int argc, cons
 		return RZ_CMD_STATUS_ERROR;
 	}
 
+#if !defined(__serenity__)
 	if (!resolve_heap_tcache(core, m_arena, &config)) {
 		return RZ_CMD_STATUS_ERROR;
 	}
+#endif
 
 	return RZ_CMD_STATUS_OK;
 }

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -127,7 +127,7 @@ extern "C" {
 #define __WINDOWS__ 1
 #endif
 
-#if defined(EMSCRIPTEN) || defined(__linux__) || defined(__APPLE__) || defined(__GNU__) || defined(__ANDROID__) || defined(__QNX__) || defined(__sun) || defined(__HAIKU__)
+#if defined(EMSCRIPTEN) || defined(__linux__) || defined(__APPLE__) || defined(__GNU__) || defined(__ANDROID__) || defined(__QNX__) || defined(__sun) || defined(__HAIKU__) || defined(__serenity__)
 #define __BSD__  0
 #define __UNIX__ 1
 #endif
@@ -601,6 +601,8 @@ typedef enum {
 #define RZ_SYS_OS "freebsd"
 #elif defined(__HAIKU__)
 #define RZ_SYS_OS "haiku"
+#elif defined(__serenity__)
+#define RZ_SYS_OS "serenity"
 #else
 #define RZ_SYS_OS "unknown"
 #endif

--- a/librz/include/rz_util/rz_sys.h
+++ b/librz/include/rz_util/rz_sys.h
@@ -57,6 +57,9 @@ RZ_API int rz_sys_getpid(void);
 #if !HAVE_PIPE || (__UNIX__ && HAVE_PIPE)
 RZ_API int rz_sys_pipe(int pipefd[2], bool close_on_exec);
 RZ_API int rz_sys_pipe_close(int fd);
+#elif defined(__serenity__)
+#define rz_sys_pipe       pipe2
+#define rz_sys_pipe_close close
 #else
 #define rz_sys_pipe       pipe
 #define rz_sys_pipe_close close

--- a/meson.build
+++ b/meson.build
@@ -679,6 +679,13 @@ if not libzip_dep.found()
   libzip_dep = libzip_proj.get_variable('libzip_dep')
 endif
 
+if host_machine.system() == 'serenity' and libzip_dep.found()
+  zlib_dep = dependency('zlib', required: true, static: is_static_build)
+  libzip_dep = declare_dependency(
+    dependencies: [libzip_dep, zlib_dep]
+  )
+endif
+
 # handle zstd dependency
 r = run_command(py3_exe, check_meson_subproject_py, 'zstd', check: false)
 if r.returncode() == 1 and get_option('subprojects_check')

--- a/meson.build
+++ b/meson.build
@@ -213,7 +213,7 @@ endif
 
 # Handle PCRE2
 cpu_jit_supported = [ 'aarch64', 'arm', 'mips', 'mips64', 'ppc', 'ppc64', 'riscv32', 'riscv64', 's390x', 'x86', 'x86_64' ]
-pcre2_jit_supported = target_machine.cpu_family() in cpu_jit_supported and cc.get_id() != 'tcc' and target_machine.system() != 'darwin'
+pcre2_jit_supported = target_machine.cpu_family() in cpu_jit_supported and cc.get_id() != 'tcc' and target_machine.system() not in ['darwin', 'serenity']
 if pcre2_jit_supported
   add_project_arguments(['-DSUPPORTS_PCRE2_JIT'], language: 'c')
 endif

--- a/meson.build
+++ b/meson.build
@@ -399,7 +399,7 @@ foreach it : ccs
   if not it_cc.has_function('clock_gettime', prefix: '#include <time.h>') and it_cc.has_header_symbol('features.h', '__GLIBC__')
     it_lrt = it_cc.find_library('rt', required: true, static: is_static_build)
   endif
-  have_lrt = not ['windows', 'darwin', 'openbsd', 'android', 'haiku'].contains(it_machine.system())
+  have_lrt = not ['windows', 'darwin', 'openbsd', 'android', 'haiku', 'serenity'].contains(it_machine.system())
   if have_lrt and not it_lrt.found()
     it_lrt = it_cc.find_library('rt', required: true, static: is_static_build)
   endif

--- a/subprojects/packagefiles/pcre2/meson.build
+++ b/subprojects/packagefiles/pcre2/meson.build
@@ -66,7 +66,7 @@ cpu_jit_supported = [ 'aarch64', 'arm', 'mips', 'mips64', 'ppc', 'ppc64', 'riscv
 # tcc doesn't support the MSVC asm syntax PCRE2 uses (`__asm { ... }`).
 # Darwin kernel not as well, because of forbidden wx memory.
 # It is used in the JIT compiler code.
-if cc.get_id() != 'tcc' and target_machine.cpu_family() in cpu_jit_supported and target_machine.system() != 'darwin'
+if cc.get_id() != 'tcc' and target_machine.cpu_family() in cpu_jit_supported and target_machine.system() not in ['darwin', 'serenity']
   libpcre2_c_args += ['-DSUPPORT_JIT']
   pcre2_files += ['src/pcre2_jit_compile.c']
 endif

--- a/subprojects/packagefiles/pcre2_cross_native/meson.build
+++ b/subprojects/packagefiles/pcre2_cross_native/meson.build
@@ -66,7 +66,7 @@ cpu_jit_supported = [ 'aarch64', 'arm', 'mips', 'mips64', 'ppc', 'ppc64', 'riscv
 # tcc doesn't support the MSVC asm syntax PCRE2 uses (`__asm { ... }`).
 # Darwin kernel not as well, because of forbidden wx memory.
 # It is used in the JIT compiler code.
-if cc.get_id() != 'tcc' and target_machine.cpu_family() in cpu_jit_supported and target_machine.system() != 'darwin'
+if cc.get_id() != 'tcc' and target_machine.cpu_family() in cpu_jit_supported and target_machine.system() not in ['darwin', 'serenity']
   libpcre2_c_args += ['-DSUPPORT_JIT']
   pcre2_files += ['src/pcre2_jit_compile.c']
 endif


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
This PR introduces initial support for SerenityOS. Since no native debugger is implemented as of yet, debugger is disabled while building rizin. [SerenityOS/serenity#26589](https://github.com/SerenityOS/serenity/pull/26589)

Patches:
1. Add serenity to librt whitelist
2. Disable PCRE2 JIT compilation
3. Remove resolve_heap_tcache implementation
4. Define rz_sys_pipe as pipe2 for serenity
5. Add serenity identifier to rz_types.h
6. Add zlib dependency for libzip

(tree-sitter had issues running on serenity, so created a port for that as well [SerenityOS/serenity#26583](https://github.com/SerenityOS/serenity/pull/26583) )

**Test plan**
Builds and compiles successfully on serenity


**Closing issues**
[rizinorg/ideas#39](https://github.com/rizinorg/ideas/issues/39)