### PR TITLE
Fix duplicate "Dependency rzheap found" messages

### DIFF
--- a/librz/core/meson.build
+++ b/librz/core/meson.build
@@ -167,7 +167,7 @@ rz_core_deps = [
   rz_mark_dep,
   platform_deps,
   dependency('rzgdb'),
-  dependency('rzheap'),
+  rzheap_dep,
   shell_parser_dep,
   lrt,
   mth,

--- a/meson.build
+++ b/meson.build
@@ -713,6 +713,10 @@ endif
 yxml_proj = subproject('yxml', default_options: ['default_library=static'])
 yxml_dep = yxml_proj.get_variable('yxml_dep')
 
+# handle rzheap dependency
+rzheap_proj = subproject('rzheap', default_options: ['default_library=static'])
+rzheap_dep = rzheap_proj.get_variable('rzheap_dep')
+
 use_rpath = false
 use_rpath_absolute = false
 if host_machine.system() != 'windows' and get_option('default_library') == 'shared'

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -168,7 +168,7 @@ if get_option('enable_tests')
         rz_magic_dep,
         rz_il_dep,
         rz_mark_dep,
-        dependency('rzheap'),
+        rzheap_dep,
         lrt,
       ],
       install: false,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr fixes the duplicate "Dependency rzheap found: YES undefined (overridden)" Meson messages, e.g.:

<img width="499" height="424" alt="dep_rzheap_repeat" src="https://github.com/user-attachments/assets/a270eedc-9bfb-405f-a277-507dc483ea79" />

https://github.com/rizinorg/rizin/actions/runs/21919590016/job/63295909636#step:12:707

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. The aforementioned messages are not duplicated. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
