### PR TITLE
fix IL memory leak

### DIFF
--- a/librz/il/il_vm.c
+++ b/librz/il/il_vm.c
@@ -140,7 +140,7 @@ RZ_API ut32 rz_il_vm_get_pc_len(RzILVM *vm) {
  */
 RZ_API void rz_il_vm_add_mem(RzILVM *vm, RzILMemIndex index, RZ_OWN RzILMem *mem) {
 	if (index < rz_pvector_len(&vm->vm_memory)) {
-		rz_mem_free(rz_pvector_at(&vm->vm_memory, index));
+		rz_il_mem_free(rz_pvector_at(&vm->vm_memory, index));
 	}
 	rz_pvector_reserve(&vm->vm_memory, index + 1);
 	// Fill up with NULLs until the given index


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

In `rz_il_vm_add_mem`, `rz_mem_free` is called where `rz_il_mem_free` should be called. This does not cause UB but may cause memory leak since the refcount of the underlying buffer is not decremented.

...

**Test plan**

...

**Closing issues**

...
