### PR TITLE
Fix leaks in `serialize_analysis.c` and 2 tests

### DIFF
--- a/librz/arch/serialize_analysis.c
+++ b/librz/arch/serialize_analysis.c
@@ -1396,6 +1396,7 @@ beach:
 	rz_key_parser_free(ctx.parser);
 	rz_serialize_analysis_var_parser_free(ctx.var_parser);
 	rz_key_parser_free(ctx.storage_parser);
+	rz_key_parser_free(ctx.piece_parser);
 	return ret;
 }
 

--- a/librz/core/rop.c
+++ b/librz/core/rop.c
@@ -573,7 +573,7 @@ RZ_API RZ_OWN RzPVector /*<RzRopRegInfo *>*/ *rz_core_rop_gadget_get_reg_info_by
 	RzRopRegInfo *reg_info;
 	rz_list_foreach (gadget_info->dependencies, iter, reg_info) {
 		if (rz_rop_event_functions[event](reg_info)) {
-			rz_pvector_push(matches, reg_info);
+			rz_pvector_push(matches, rz_core_rop_reg_info_dup(reg_info));
 		}
 	}
 	return matches;

--- a/test/integration/test_str_search.c
+++ b/test/integration/test_str_search.c
@@ -134,7 +134,6 @@ int test_rz_str_search_single_simple(void) {
 int test_rz_str_search_io_simple(void) {
 	RzCore *core = rz_core_new();
 	mu_assert_notnull(core, "NULL check failed");
-	rz_core_init(core);
 	mu_assert_true(rz_core_file_open_load(core, files[1], 0, RZ_PERM_R, false), "Loading file failed");
 
 	// Setup search options. These are _not_ specific for the string search.

--- a/test/unit/test_rop.c
+++ b/test/unit/test_rop.c
@@ -105,6 +105,7 @@ static bool rop_gadget_info_cb(void *user, const ut64 k, const void *v) {
 		mu_assert_eq(rz_pvector_len(reg_info_vector), 2, "ROP gadget register item count mismatch");
 		RzRopRegInfo *reg_info_analysis_reg = rz_pvector_at(reg_info_vector, 0);
 		mu_assert_streq(src->reg->name, reg_info_analysis_reg->name, "ROP gadget modified register value mismatch");
+		rz_pvector_free(reg_info_vector);
 	}
 
 	return true;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->
This PR fixes a couple of leaks in order to reduce the noise in the memory leak report of the [HT refactoring](https://github.com/rizinorg/rizin/pull/5860).

**Test plan**
Existing tests should pass

**Closing issues**
None