### PR TITLE
Fix h8300 cpu detection

### DIFF
--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -753,6 +753,13 @@ static bool arch_is_mips(ELFOBJ *bin) {
 		arch_is_nanomips(bin);
 }
 
+static bool arch_is_h8xx(ELFOBJ *bin) {
+	return bin->ehdr.e_machine == EM_H8_300 ||
+		bin->ehdr.e_machine == EM_H8_300H ||
+		bin->ehdr.e_machine == EM_H8S ||
+		bin->ehdr.e_machine == EM_H8_500;
+}
+
 static bool arch_is_sparc(ELFOBJ *bin) {
 	return bin->ehdr.e_machine == EM_SPARC ||
 		bin->ehdr.e_machine == EM_SPARC32PLUS ||
@@ -1340,7 +1347,30 @@ static char *get_cpu_hppa(ELFOBJ *bin) {
 		}
 	}
 
-	return strdup(" Unknown HP PARISC ISA");
+	return strdup("Unknown HP PARISC ISA");
+}
+
+static char *get_cpu_h8xx(ELFOBJ *bin) {
+	if (bin->ehdr.e_machine == EM_H8_300H) {
+		return rz_str_dup("h8300h");
+	} else if (bin->ehdr.e_machine == EM_H8S) {
+		return rz_str_dup("h8300s");
+	} else if (bin->ehdr.e_machine == EM_H8_500) {
+		return rz_str_dup("h8500");
+	}
+
+	/// Reference:
+	/// https://gem5.googlesource.com/arm/linux/+/b24413180f5600bcb3bb70fbed5cf186b60864bd/arch/h8300/include/asm/elf.h#29
+	if (bin->ehdr.e_flags == 0x810000) {
+		return rz_str_dup("h8300h");
+	} else if (bin->ehdr.e_flags == 0x820000) {
+		// H8S
+		return rz_str_dup("h8300s");
+	} else if (bin->ehdr.e_flags == 0x830000) {
+		// cannot find this anywhere but is not H8300
+		return rz_str_dup("h8300h");
+	}
+	return rz_str_dup("h8300");
 }
 
 /**
@@ -1934,8 +1964,9 @@ RZ_OWN char *Elf_(rz_bin_elf_get_cpu)(RZ_NONNULL ELFOBJ *bin) {
 		return get_cpu_hppa(bin);
 	} else if (arch_is_arm(bin)) {
 		return get_cpu_arm(bin);
+	} else if (arch_is_h8xx(bin)) {
+		return get_cpu_h8xx(bin);
 	}
-
 	return NULL;
 }
 
@@ -2211,6 +2242,10 @@ int Elf_(rz_bin_elf_get_bits)(RZ_NONNULL ELFOBJ *bin) {
 	/* Hack for Ps2 */
 	if (arch_is_mips(bin)) {
 		return get_bits_mips(bin);
+	}
+
+	if (arch_is_h8xx(bin)) {
+		return 16;
 	}
 
 	/* Hack for Thumb */

--- a/test/db/analysis/h8300
+++ b/test/db/analysis/h8300
@@ -101,7 +101,7 @@ stackframe: 8
 cyclomatic-cost: 0
 cyclomatic-complexity: 5
 loops: 3
-bits: 32
+bits: 16
 type: fcn
 num-bbs: 8
 edges: 13
@@ -115,9 +115,9 @@ out-degree: 26
 data-xrefs:
 locals: 3
 args: 0
-var int a @ stack - 0x6
-var int j @ stack - 0x4
-var int i @ stack - 0x2
+var int a @ stack - 0x8
+var int j @ stack - 0x6
+var int i @ stack - 0x4
             ; CODE XREF from loc.start_bss_loop @ +0xa
             ;-- entry0:
             ;-- .LFB23:
@@ -125,9 +125,9 @@ var int i @ stack - 0x2
             ;-- _main:
             ;-- pc:
 / int main()
-|           ; var int i @ stack - 0x2
-|           ; var int j @ stack - 0x4
-|           ; var int a @ stack - 0x6
+|           ; var int i @ stack - 0x4
+|           ; var int j @ stack - 0x6
+|           ; var int a @ stack - 0x8
 |           0x00000478      push.l er6                                 ; main.c:186
 |           0x0000047c      mov.l er7,er6
 |           0x0000047e      sub.l #0x8,er7
@@ -261,8 +261,8 @@ var int i @ stack - 0x2
 |   ;-- .LM25:                        |
 |   ;-- _test_branch:                 |
 | void test_branch()                  |
-| ; var int a @ stack - 0x6           |
-| ; var int b @ stack - 0x8           |
+| ; var int a @ stack - 0x8           |
+| ; var int b @ stack - 0xa           |
 | push.l er6                          |
 | mov.l er7,er6                       |
 | subs #0x4,er7                       |
@@ -370,7 +370,7 @@ stackframe: 8
 cyclomatic-cost: 0
 cyclomatic-complexity: 5
 loops: 3
-bits: 32
+bits: 16
 type: fcn
 num-bbs: 8
 edges: 13


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Cherrypicked from another PR.

The CPU detection can be tricky when `e_machine == EM_H8_300` but the CPU is like `h8300h|s`.

I have discovered that the `e_flags` are set to specific values depending on the CPU