### PR TITLE
Fix M680x aliases

### DIFF
--- a/librz/arch/p/analysis/analysis_m680x_cs.c
+++ b/librz/arch/p/analysis/analysis_m680x_cs.c
@@ -12,15 +12,17 @@ static int m680xmode(const char *str) {
 		return CS_MODE_M680X_6800;
 	}
 	// replace this with the asm.features?
-	if (str && strstr(str, "6800")) {
+	if (str && (strstr(str, "6800") || strstr(str, "6802") || strstr(str, "6808"))) {
 		return CS_MODE_M680X_6800;
 	}
-	if (str && strstr(str, "6801")) {
+	if (str && (strstr(str, "6801") || strstr(str, "6803"))) {
 		return CS_MODE_M680X_6801;
 	} else if (str && strstr(str, "6805")) {
 		return CS_MODE_M680X_6805;
-	} else if (str && strstr(str, "6808")) {
+	} else if (str && strstr(str, "68HC08")) {
 		return CS_MODE_M680X_6808;
+	} else if (strstr(str, "6808")) {
+		return CS_MODE_M680X_6800;
 	} else if (str && strstr(str, "6809")) {
 		return CS_MODE_M680X_6809;
 	} else if (str && strstr(str, "6811")) {

--- a/librz/arch/p/asm/asm_m680x_cs.c
+++ b/librz/arch/p/asm/asm_m680x_cs.c
@@ -12,15 +12,17 @@ static cs_mode m680x_mode(const char *str) {
 		return CS_MODE_M680X_6800;
 	}
 	// replace this with the asm.features?
-	if (strstr(str, "6800")) {
+	if (strstr(str, "6800") || strstr(str, "6802") || strstr(str, "6808")) {
 		return CS_MODE_M680X_6800;
 	}
-	if (strstr(str, "6801")) {
+	if (strstr(str, "6801") || strstr(str, "6803")) {
 		return CS_MODE_M680X_6801;
 	} else if (strstr(str, "6805")) {
 		return CS_MODE_M680X_6805;
-	} else if (strstr(str, "6808")) {
+	} else if (strstr(str, "68HC08")) {
 		return CS_MODE_M680X_6808;
+	} else if (strstr(str, "6808")) {
+		return CS_MODE_M680X_6800;
 	} else if (strstr(str, "6809")) {
 		return CS_MODE_M680X_6809;
 	} else if (strstr(str, "6811")) {
@@ -83,8 +85,11 @@ static char **m680x_cpu_descriptions() {
 	static char *cpu_desc[] = {
 		"6800", "Motorola 6800: 8-bit microprocessor launched in 1974",
 		"6801", "Motorola 6801: Enhanced version of the 6800 with additional features like on-chip RAM and timers.",
+		"6802", "Motorola 6802: Enhanced version of the 6800 with 128 bytes of on-chip RAM and internal clock",
+		"6803", "Motorola 6803: Version of 6801 without internal ROM",
 		"6805", "Motorola 68HC05: 8-bit microcontroller",
 		"6808", "Motorola 6808: Variant of the 6800 microprocessor",
+		"68HC08", "Motorola 68HC08: 8-bit microcontroller (abbreviated as HC08)",
 		"6809", "Motorola 6809: Advanced 8-bit microprocessor",
 		"6811", "Motorola 68HC11: 8-bit microcontroller (also abbreviated as 6811 or HC11)",
 		"cpu12", "Motorola 68HC12: 16-bit microcontroller (also abbreviated as 6812 or HC12)",
@@ -98,7 +103,7 @@ static char **m680x_cpu_descriptions() {
 
 RzAsmPlugin rz_asm_plugin_m680x_cs = {
 	.name = "m680x",
-	.cpus = "6800,6801,6805,6808,6809,6811,cpu12,6301,6309,hcs08",
+	.cpus = "6800,6801,6802,6803,6805,6808,68HC08,6809,6811,cpu12,6301,6309,hcs08",
 	.desc = "Motorola 680X Capstone-based disassembler",
 	.license = "BSD",
 	.arch = "m680x",

--- a/test/db/cmd/cmd_aL
+++ b/test/db/cmd/cmd_aL
@@ -143,8 +143,11 @@ ATTiny48        8-bit AVR microcontroller with 4KB Flash, 256B SRAM
 ATTiny88        8-bit AVR microcontroller with 8KB Flash, 512B SRAM
 6800            Motorola 6800: 8-bit microprocessor launched in 1974
 6801            Motorola 6801: Enhanced version of the 6800 with additional features like on-chip RAM and timers.
+6802            Motorola 6802: Enhanced version of the 6800 with 128 bytes of on-chip RAM and internal clock
+6803            Motorola 6803: Version of 6801 without internal ROM
 6805            Motorola 68HC05: 8-bit microcontroller
 6808            Motorola 6808: Variant of the 6800 microprocessor
+68HC08          Motorola 68HC08: 8-bit microcontroller (abbreviated as HC08)
 6809            Motorola 6809: Advanced 8-bit microprocessor
 6811            Motorola 68HC11: 8-bit microcontroller (also abbreviated as 6811 or HC11)
 cpu12           Motorola 68HC12: 16-bit microcontroller (also abbreviated as 6812 or HC12)

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -667,8 +667,11 @@ ATTiny48        8-bit AVR microcontroller with 4KB Flash, 256B SRAM
 ATTiny88        8-bit AVR microcontroller with 8KB Flash, 512B SRAM
 6800            Motorola 6800: 8-bit microprocessor launched in 1974
 6801            Motorola 6801: Enhanced version of the 6800 with additional features like on-chip RAM and timers.
+6802            Motorola 6802: Enhanced version of the 6800 with 128 bytes of on-chip RAM and internal clock
+6803            Motorola 6803: Version of 6801 without internal ROM
 6805            Motorola 68HC05: 8-bit microcontroller
 6808            Motorola 6808: Variant of the 6800 microprocessor
+68HC08          Motorola 68HC08: 8-bit microcontroller (abbreviated as HC08)
 6809            Motorola 6809: Advanced 8-bit microprocessor
 6811            Motorola 68HC11: 8-bit microcontroller (also abbreviated as 6811 or HC11)
 cpu12           Motorola 68HC12: 16-bit microcontroller (also abbreviated as 6812 or HC12)


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
- Now `HC08` maps to `CS_MODE_M680X_6808`, and `6808` maps to `CS_MODE_M680X_6800`
- Added CPU aliases for 6802, 6803, 6808

**Test plan**
Updated the tests in `test/db/tools/rz_asm` and `test/db/cmd/cmd_aL`

**Closing issues**
partially addresses #5933