### PR TITLE
Fixed CID 900521 and CID 900519 memory leaks.

### DIFF
--- a/librz/bin/p/bin_wasm.c
+++ b/librz/bin/p/bin_wasm.c
@@ -405,6 +405,7 @@ static RzStructuredData *wasm_types_structure(RzBinFile *bf) {
 			RzStructuredData *params = rz_structured_data_new_array();
 			if (!params) {
 				rz_structured_data_free(arr);
+				rz_structured_data_free(m);
 				return NULL;
 			}
 			for (ut32 i = 0; i < type->param_count; i++) {
@@ -631,6 +632,7 @@ static RzStructuredData *wasm_elements_structure(RzBinFile *bf) {
 			RzStructuredData *elems = rz_structured_data_new_array();
 			if (!elems) {
 				rz_structured_data_free(arr);
+				rz_structured_data_free(m);
 				return NULL;
 			}
 			for (ut32 i = 0; i < element->num_elem; i++) {


### PR DESCRIPTION
**Your checklist for this pull request**

- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
Added `rz_structured_data_free(m);` before freeing `arr` in both error paths.

**Test plan**


**Closing issues**
