### PR TITLE
Implemented iH header for BF format

### DIFF
--- a/librz/bin/p/bin_bf.c
+++ b/librz/bin/p/bin_bf.c
@@ -6,6 +6,9 @@
 #include <rz_lib.h>
 #include <rz_bin.h>
 
+#define BF_DATA_AREA_VADDR 0x10000
+#define BF_DATA_AREA_SIZE  30000
+
 static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb) {
 	return true;
 }
@@ -138,13 +141,106 @@ static RzPVector /*<RzBinMap *>*/ *maps(RzBinFile *bf) {
 		return NULL;
 	}
 	map->paddr = 0;
-	map->vaddr = 0x10000;
+	map->vaddr = BF_DATA_AREA_VADDR;
 	map->psize = 0;
-	map->vsize = 30000;
+	map->vsize = BF_DATA_AREA_SIZE;
 	map->perm = RZ_PERM_RW;
 	map->name = rz_str_dup("mem");
 	rz_pvector_push(ret, map);
 	return ret;
+}
+
+typedef struct {
+	ut64 increment;
+	ut64 decrement;
+	ut64 move_right;
+	ut64 move_left;
+	ut64 loop_start;
+	ut64 loop_end;
+	ut64 input;
+	ut64 output;
+} BfInstrStats;
+
+static void bf_count_instructions(RzBinFile *bf, BfInstrStats *stats) {
+	if (!bf->buf) {
+		return;
+	}
+
+	ut64 size = rz_buf_size(bf->buf);
+	for (ut64 i = 0; i < size; i++) {
+		ut8 c;
+		if (rz_buf_read_at(bf->buf, i, &c, 1) != 1) {
+			break;
+		}
+		switch (c) {
+		case '+': stats->increment++; break;
+		case '-': stats->decrement++; break;
+		case '>': stats->move_right++; break;
+		case '<': stats->move_left++; break;
+		case '[': stats->loop_start++; break;
+		case ']': stats->loop_end++; break;
+		case ',': stats->input++; break;
+		case '.': stats->output++; break;
+		default: break;
+		}
+	}
+}
+
+static void bf_structure_add_instructions(RzStructuredData *parent, const BfInstrStats *stats) {
+	RzStructuredData *instr = rz_structured_data_map_add_map(parent, "instructions");
+	if (!instr) {
+		return;
+	}
+
+	rz_structured_data_map_add_unsigned(instr, "increment", stats->increment, false);
+	rz_structured_data_map_add_unsigned(instr, "decrement", stats->decrement, false);
+	rz_structured_data_map_add_unsigned(instr, "move_right", stats->move_right, false);
+	rz_structured_data_map_add_unsigned(instr, "move_left", stats->move_left, false);
+	rz_structured_data_map_add_unsigned(instr, "loop_start", stats->loop_start, false);
+	rz_structured_data_map_add_unsigned(instr, "loop_end", stats->loop_end, false);
+	rz_structured_data_map_add_unsigned(instr, "input", stats->input, false);
+	rz_structured_data_map_add_unsigned(instr, "output", stats->output, false);
+}
+
+static void bf_structure_add_memory_layout(RzStructuredData *parent) {
+	RzStructuredData *mem = rz_structured_data_map_add_map(parent, "memory");
+	if (!mem) {
+		return;
+	}
+
+	rz_structured_data_map_add_unsigned(mem, "data_area", BF_DATA_AREA_VADDR, true);
+	rz_structured_data_map_add_unsigned(mem, "data_size", BF_DATA_AREA_SIZE, false);
+}
+
+static RzStructuredData *bf_structure(RzBinFile *bf) {
+	rz_return_val_if_fail(bf, NULL);
+
+	RzStructuredData *info = rz_structured_data_new_map();
+	if (!info) {
+		return NULL;
+	}
+
+	RzStructuredData *root = rz_structured_data_map_add_map(info, "bf");
+	if (!root) {
+		rz_structured_data_free(info);
+		return NULL;
+	}
+
+	rz_structured_data_map_add_unsigned(root, "file_size", bf->size, false);
+	rz_structured_data_map_add_unsigned(root, "entry_point", 0, true);
+
+	BfInstrStats stats = { 0 };
+	bf_count_instructions(bf, &stats);
+
+	ut64 total = stats.increment + stats.decrement + stats.move_right +
+		stats.move_left + stats.loop_start + stats.loop_end +
+		stats.input + stats.output;
+	rz_structured_data_map_add_unsigned(root, "total_instructions", total, false);
+
+	bf_structure_add_instructions(root, &stats);
+	bf_structure_add_memory_layout(root);
+
+	return info;
 }
 
 RzBinPlugin rz_bin_plugin_bf = {
@@ -161,6 +257,7 @@ RzBinPlugin rz_bin_plugin_bf = {
 	.strings = &strings,
 	.maps = &maps,
 	.info = &info,
+	.bin_structure = &bf_structure,
 };
 
 #ifndef RZ_PLUGIN_INCORE

--- a/test/db/formats/bf
+++ b/test/db/formats/bf
@@ -1,8 +1,12 @@
-NAME=bf with comments
+NAME=bf with comments and 30,000 nulls
 FILE=bins/bf/2+5.bf
-CMDS=i~^format
+CMDS=<<EOF
+i~^format
+ol~null
+EOF
 EXPECT=<<EOF
 format   bf
+ 4 - rw- 0x00007530 null://30000
 EOF
 RUN
 
@@ -19,10 +23,26 @@ size     0x2af
 EOF
 RUN
 
-NAME=30,000 nulls
-FILE=bins/bf/2+5.bf
-CMDS=ol~null
+NAME=bf iH
+FILE=bins/bf/hello-ok.bf
+CMDS=iH
 EXPECT=<<EOF
- 4 - rw- 0x00007530 null://30000
+bf:
+  file_size: 111
+  entry_point: 0x0
+  total_instructions: 111
+  instructions:
+    increment: 65
+    decrement: 15
+    move_right: 10
+    move_left: 6
+    loop_start: 1
+    loop_end: 1
+    input: 0
+    output: 13
+  memory:
+    data_area: 0x10000
+    data_size: 30000
+
 EOF
 RUN


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Adds `iH` (header structure) support for the BF bin plugin . The implementation exposes file size, entry point, instruction counts (increment, decrement, move_right, move_left, loop_start, loop_end, input, output), total instructions, and memory layout (data_area, data_size).

Merged tests which uses same binary file.

**Screenshot**
<img width="1144" height="429" alt="image" src="https://github.com/user-attachments/assets/21c6069c-4f25-4de6-9015-5df90276511c" />


**Test plan**

`./build/binrz/rizin/rizin -q -c 'iH' test/bins/bf/hello-ok.bf
`

**Closing issues**
 BF format for #5728 