### PR TITLE
Log an error when endianness change is not compatible with arch

### DIFF
--- a/librz/arch/asm.c
+++ b/librz/arch/asm.c
@@ -560,6 +560,17 @@ RZ_API ut32 rz_asm_get_endianness(RzAsm *a) {
 	return a->cur->endian;
 }
 
+RZ_API bool rz_asm_support_endianness(RzAsm *a, ut32 endian) {
+	rz_return_val_if_fail(a && a->cur, false);
+
+	if (a->cur->endian == RZ_SYS_ENDIAN_NONE || a->cur->endian == RZ_SYS_ENDIAN_BI) {
+		// always return what the bin or default endianness of the system
+		return true;
+	}
+
+	return endian & a->cur->endian;
+}
+
 RZ_API bool rz_asm_set_big_endian(RzAsm *a, bool b) {
 	rz_return_val_if_fail(a && a->cur, false);
 	a->big_endian = false; // little endian by default

--- a/librz/bin/bfile_string.c
+++ b/librz/bin/bfile_string.c
@@ -643,7 +643,8 @@ RZ_API RZ_OWN RzPVector /*<RzBinString *>*/ *rz_bin_file_strings(RZ_NONNULL RzBi
 
 	if (bf->o) {
 		const RzBinInfo *binfo = rz_bin_object_get_info(bf->o);
-		prefer_big_endian = binfo ? binfo->big_endian : false;
+		// follow what RzBinInfo says only if the arch is set.
+		prefer_big_endian = binfo && binfo->arch ? binfo->big_endian : false;
 	}
 
 	SharedData shared = {

--- a/librz/bin/p/bin_any.c
+++ b/librz/bin/p/bin_any.c
@@ -8,6 +8,12 @@
 #include <rz_bin.h>
 #include <rz_magic.h>
 
+#if RZ_SYS_ENDIAN == RZ_SYS_ENDIAN_LITTLE
+#define ANY_DEFAULT_ENDIANNESS false
+#else
+#define ANY_DEFAULT_ENDIANNESS true
+#endif
+
 static char *get_filetype(RzBuffer *b) {
 	ut8 buf[4096] = { 0 };
 	char *res = NULL;
@@ -49,13 +55,8 @@ static RzBinInfo *info(RzBinFile *bf) {
 	ret->lang = "";
 	ret->file = rz_str_dup(bf->file);
 	ret->type = get_filetype(bf->buf);
-	ret->has_pi = 0;
-	ret->has_canary = 0;
 	ret->has_retguard = -1;
-	ret->big_endian = 0;
-	ret->has_va = 0;
-	ret->has_nx = 0;
-	ret->dbg_info = 0;
+	ret->big_endian = ANY_DEFAULT_ENDIANNESS;
 	return ret;
 }
 

--- a/librz/core/carch.c
+++ b/librz/core/carch.c
@@ -228,9 +228,7 @@ static bool core_arch_default_is_big_endian(RzCore *core) {
 	return false;
 }
 
-RZ_DEPRECATE static void core_update_endianness(RzCore *core) {
-	bool big_endian = core_arch_default_is_big_endian(core);
-
+RZ_DEPRECATE static void core_set_endianness(RzCore *core, bool big_endian) {
 	rz_asm_set_big_endian(core->rasm, big_endian);
 	rz_analysis_set_big_endian(core->analysis, big_endian);
 
@@ -245,6 +243,11 @@ RZ_DEPRECATE static void core_update_endianness(RzCore *core) {
 	if (core->dbg && core->dbg->bp) {
 		core->dbg->bp->endian = big_endian;
 	}
+}
+
+RZ_DEPRECATE static void core_update_endianness(RzCore *core) {
+	bool big_endian = core_arch_default_is_big_endian(core);
+	core_set_endianness(core, big_endian);
 }
 
 // most of this code is a copy from cconfig
@@ -554,5 +557,31 @@ RZ_DEPRECATE RZ_API bool rz_core_arch_configure(RZ_NONNULL RzCore *core, RZ_NULL
 	}
 
 	core_update_config_from_arch(core, is_new_arch);
+	return true;
+}
+
+/**
+ * \brief      Sets the endianness a given RzCore
+ *
+ * \param      core        The core
+ * \param[in]  big_endian  When true, tries to set the endianness to big endian, otherwise little endian
+ *
+ * \return     On success returns true, otherwise false
+ */
+RZ_DEPRECATE RZ_API bool rz_core_set_endianness(RZ_NONNULL RzCore *core, bool big_endian) {
+	rz_return_val_if_fail(core && core->config && core->bin && core->rasm && core->analysis && core->parser && core->dbg && core->egg, false);
+
+	ut32 endianness = big_endian ? RZ_SYS_ENDIAN_BIG : RZ_SYS_ENDIAN_LITTLE;
+
+	if (!rz_asm_support_endianness(core->rasm, endianness)) {
+		const char *arch = rz_core_get_arch(core);
+		const char *want = big_endian ? "big" : "little";
+		const char *supported = (!big_endian) ? "big" : "little";
+		RZ_LOG_ERROR("core: cannot change to %s endian (arch '%s' supports only %s endian)\n", want, arch, supported);
+		return false;
+	}
+
+	core_set_endianness(core, big_endian);
+	core_update_config_b(core, "cfg.bigendian", core->rasm->big_endian);
 	return true;
 }

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -547,8 +547,6 @@ static void sdb_concat_by_path(Sdb *s, const char *path) {
 
 RZ_API bool rz_core_bin_apply_config(RzCore *r, RzBinFile *binfile) {
 	rz_return_val_if_fail(r && binfile, false);
-	int v;
-	char str[RZ_FLAG_NAME_SIZE];
 	RzBinObject *obj = binfile->o;
 	if (!obj) {
 		return false;
@@ -558,38 +556,44 @@ RZ_API bool rz_core_bin_apply_config(RzCore *r, RzBinFile *binfile) {
 		return false;
 	}
 	rz_config_set(r->config, "file.type", rz_str_get(info->rclass));
-	rz_config_set(r->config, "cfg.bigendian",
-		info->big_endian ? "true" : "false");
-	if (info->lang) {
-		rz_config_set(r->config, "bin.lang", info->lang);
-	}
-	rz_config_set(r->config, "asm.os", info->os);
+	rz_config_set(r->config, "bin.lang", rz_str_get(info->lang));
 	if (info->rclass && !strcmp(info->rclass, "pe")) {
 		rz_config_set(r->config, "analysis.cpp.abi", "msvc");
 	} else {
 		rz_config_set(r->config, "analysis.cpp.abi", "itanium");
 	}
-	rz_config_set(r->config, "asm.arch", info->arch);
+	if (RZ_STR_ISNOTEMPTY(info->os)) {
+		rz_config_set(r->config, "asm.os", info->os);
+	}
+	if (RZ_STR_ISNOTEMPTY(info->arch)) {
+		// update the arch & bits only if really set.
+		rz_config_set(r->config, "asm.arch", info->arch);
+		rz_config_set_i(r->config, "asm.bits", info->bits);
+	}
 	if (RZ_STR_ISNOTEMPTY(info->cpu)) {
+		// update the CPU only if really set.
 		rz_config_set(r->config, "asm.cpu", info->cpu);
 	}
 	if (RZ_STR_ISNOTEMPTY(info->features)) {
+		// update the CPU features only if really set.
 		rz_config_set(r->config, "asm.features", info->features);
 	}
-	rz_config_set(r->config, "analysis.arch", info->arch);
-	snprintf(str, RZ_FLAG_NAME_SIZE, "%i", info->bits);
-	rz_config_set(r->config, "asm.bits", str);
-	rz_config_set(r->config, "asm.debuginfo",
-		(RZ_BIN_DBG_STRIPPED & info->dbg_info) ? "false" : "true");
-	v = rz_analysis_archinfo(r->analysis, RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN);
-	if (v != -1) {
-		rz_config_set_i(r->config, "asm.pcalign", v);
+	if (RZ_STR_ISNOTEMPTY(info->arch)) {
+		// update the endianness only if the arch value is set.
+		ut32 endianness = info->big_endian ? RZ_SYS_ENDIAN_BIG : RZ_SYS_ENDIAN_LITTLE;
+		if (rz_asm_support_endianness(r->rasm, endianness)) {
+			// change only if the current arch supports it.
+			rz_config_set_b(r->config, "cfg.bigendian", info->big_endian);
+		}
 	}
+	rz_config_set_b(r->config, "asm.debuginfo", (RZ_BIN_DBG_STRIPPED & info->dbg_info) ? false : true);
+
 	rz_core_analysis_type_init(r);
 	rz_core_analysis_cc_init(r);
 	if (info->default_cc && rz_analysis_cc_exist(r->analysis, info->default_cc)) {
 		rz_config_set(r->config, "analysis.cc", info->default_cc);
 	}
+
 	char *types_dir = rz_path_system(r->sys_path, RZ_SDB_TYPES);
 	if (!types_dir) {
 		return false;

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -13,6 +13,12 @@
 
 #include "core_private.h"
 
+#if RZ_SYS_ENDIAN == RZ_SYS_ENDIAN_LITTLE
+#define CFG_DEFAULT_ENDIANNESS "false"
+#else
+#define CFG_DEFAULT_ENDIANNESS "true"
+#endif
+
 typedef struct config_opt_descr {
 	const char *option;
 	const char *description;
@@ -790,21 +796,7 @@ static bool cb_asmsyntax(void *user, void *data) {
 static bool cb_bigendian(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
-	// Try to set endian based on preference, restrict by RzAsmPlugin
-	bool isbig = rz_asm_set_big_endian(core->rasm, node->i_value);
-	// Set analysis endianness the same as asm
-	rz_analysis_set_big_endian(core->analysis, isbig);
-	// While analysis sets endianess for TypesDB there might
-	// be cases when it isn't availble for the chosen analysis
-	// plugin but types and printing commands still need the
-	// corresponding endianness. Thus we set these explicitly:
-	rz_type_db_set_endian(core->analysis->typedb, node->i_value);
-	core->print->big_endian = node->i_value;
-	// the big endian should also be assigned to dbg->bp->endian
-	if (core->dbg && core->dbg->bp) {
-		core->dbg->bp->endian = isbig;
-	}
-	return true;
+	return rz_core_set_endianness(core, node->i_value);
 }
 
 static bool cb_cfgdatefmt(void *user, void *data) {
@@ -3197,7 +3189,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETBPREF("cfg.wseek", "false", "Seek after write");
 	SETICB("cfg.seek.histsize", 63, NULL, "Maximum size of the seek history");
 	SETCB("cfg.seek.silent", "false", NULL, "When true, seek movements are not logged in seek history");
-	SETCB("cfg.bigendian", "false", &cb_bigendian, "Use little (false) or big (true) endianness");
+	SETCB("cfg.bigendian", CFG_DEFAULT_ENDIANNESS, &cb_bigendian, "Use little (false) or big (true) endianness");
 	SETI("cfg.cpuaffinity", 0, "Run on cpuid");
 
 	/* log */

--- a/librz/include/rz_asm.h
+++ b/librz/include/rz_asm.h
@@ -178,6 +178,7 @@ RZ_API bool rz_asm_set_arch(RzAsm *a, const char *name, int bits);
 RZ_DEPRECATE RZ_API int rz_asm_set_bits(RzAsm *a, int bits);
 RZ_DEPRECATE RZ_API void rz_asm_set_cpu(RzAsm *a, const char *cpu);
 RZ_API ut32 rz_asm_get_endianness(RzAsm *a);
+RZ_API bool rz_asm_support_endianness(RzAsm *a, ut32 endian);
 RZ_API bool rz_asm_set_big_endian(RzAsm *a, bool big_endian);
 RZ_API bool rz_asm_set_syntax(RzAsm *a, int syntax);
 RZ_API int rz_asm_syntax_from_string(const char *name);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -785,6 +785,7 @@ typedef enum {
 	RZ_CORE_ANALYSIS_EXPERIMENTAL, ///< aaaa
 } RzCoreAnalysisType;
 
+RZ_DEPRECATE RZ_API bool rz_core_set_endianness(RZ_NONNULL RzCore *core, bool big_endian);
 RZ_DEPRECATE RZ_API bool rz_core_arch_configure(RZ_NONNULL RzCore *core, RZ_NULLABLE const char *arch, int bits, RZ_NULLABLE const char *cpu, RZ_NULLABLE const char *os, RZ_NULLABLE const char *platform);
 
 RZ_API RzAnalysisOp *rz_core_analysis_op(RzCore *core, ut64 addr, int mask);

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -110,6 +110,7 @@ static int main_help(RZ_BORROW RZ_NONNULL RzCore *core, int line) {
 			"-d",          "",          "Debug the executable 'file' or running process 'pid'",
 			"-D",          "backend",   "Enable debug mode (e cfg.debug=true)",
 			"-e",          "k=v",       "Evaluate config var",
+			"-E",          "endian",    "Endianness -E big or -E little",
 			"-f",          "",          "Block size = file size",
 			"-F",          "binplug",   "Force to use that rbin plugin",
 			"-h, -hh",     "",          "Show help message, -hh for long",
@@ -434,6 +435,7 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 	ut64 mapaddr = 0LL;
 	bool quiet = false;
 	int is_gdb = false;
+	ut32 endianness = RZ_SYS_ENDIAN_NONE;
 	const char *s_seek = NULL;
 	bool compute_hashes = true;
 	RzList *cmds = rz_list_new();
@@ -502,7 +504,7 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 	char *debugbackend = rz_str_dup("native");
 
 	RzGetopt opt;
-	rz_getopt_init(&opt, argc, argv, "=012AMCwxfF:H:hm:e:nk:NdqQs:p:b:B:a:Lui:I:l:R:r:c:D:vVSTzuXt");
+	rz_getopt_init(&opt, argc, argv, "=012AMCwxfF:H:hm:E:e:nk:NdqQs:p:b:B:a:Lui:I:l:R:r:c:D:vVSTzuXt");
 	while (argc >= 2 && (c = rz_getopt_next(&opt)) != -1) {
 		switch (c) {
 		case '-':
@@ -581,9 +583,36 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 		case 'e':
 			if (!strcmp(opt.arg, "q")) {
 				rz_core_cmd0(r, "eq");
+			} else if (rz_str_startswith(opt.arg, "asm.arch")) {
+				RZ_LOG_ERROR("use -a argument for setting the arch name\n");
+				ret = 1;
+				goto beach;
+			} else if (rz_str_startswith(opt.arg, "asm.bits")) {
+				RZ_LOG_ERROR("use -b argument for setting the arch bits\n");
+				ret = 1;
+				goto beach;
+			} else if (rz_str_startswith(opt.arg, "asm.os")) {
+				RZ_LOG_ERROR("use -k argument for setting the OS/kern\n");
+				ret = 1;
+				goto beach;
+			} else if (rz_str_startswith(opt.arg, "cfg.bigendian")) {
+				RZ_LOG_ERROR("use -E argument for setting the endianness\n");
+				ret = 1;
+				goto beach;
 			} else {
-				rz_config_eval(r->config, opt.arg);
+				rz_config_eval(r->config, (void *)opt.arg);
 				rz_list_append(evals, (void *)opt.arg);
+			}
+			break;
+		case 'E':
+			if (RZ_STR_EQ(opt.arg, "big")) {
+				endianness = RZ_SYS_ENDIAN_BIG;
+			} else if (RZ_STR_EQ(opt.arg, "little")) {
+				endianness = RZ_SYS_ENDIAN_LITTLE;
+			} else {
+				RZ_LOG_ERROR("Invalid endianness value '%s'\n", opt.arg);
+				ret = 1;
+				goto beach;
 			}
 			break;
 		case 'f':
@@ -956,6 +985,9 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 			if (asmos) {
 				rz_config_set(r->config, "asm.os", asmos);
 			}
+			if (endianness != RZ_SYS_ENDIAN_NONE) {
+				rz_config_set_b(r->config, "cfg.bigendian", endianness == RZ_SYS_ENDIAN_BIG);
+			}
 			// TODO: load rbin thing
 		} else {
 			RZ_LOG_ERROR("Cannot slurp from stdin\n");
@@ -1089,7 +1121,9 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 		if (asmos) {
 			rz_config_set(r->config, "asm.os", asmos);
 		}
-
+		if (endianness != RZ_SYS_ENDIAN_NONE) {
+			rz_config_set_b(r->config, "cfg.bigendian", endianness == RZ_SYS_ENDIAN_BIG);
+		}
 		if (!debug || debug == 2) {
 			const char *dbg_profile = rz_config_get(r->config, "dbg.profile");
 			if (opt.ind == argc && dbg_profile && *dbg_profile) {
@@ -1249,10 +1283,6 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 		if (mapaddr) {
 			rz_core_seek(r, mapaddr, true);
 		}
-		rz_list_foreach (evals, iter, cmdn) {
-			rz_config_eval(r->config, cmdn);
-			rz_cons_flush();
-		}
 		if (asmarch) {
 			rz_config_set(r->config, "asm.arch", asmarch);
 		}
@@ -1262,7 +1292,13 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 		if (asmos) {
 			rz_config_set(r->config, "asm.os", asmos);
 		}
-
+		if (endianness != RZ_SYS_ENDIAN_NONE) {
+			rz_config_set_b(r->config, "cfg.bigendian", endianness == RZ_SYS_ENDIAN_BIG);
+		}
+		rz_list_foreach (evals, iter, cmdn) {
+			rz_config_eval(r->config, cmdn);
+			rz_cons_flush();
+		}
 		debug = r->file && iod && (r->file->fd == iod->fd) && iod->plugin &&
 			(iod->plugin->isdbg || (debug == 2 && !strcmp(iod->plugin->name, "dmp")));
 		if (debug) {
@@ -1336,10 +1372,6 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 	} else {
 		rz_core_block_read(r);
 
-		rz_list_foreach (evals, iter, cmdn) {
-			rz_config_eval(r->config, cmdn);
-			rz_cons_flush();
-		}
 		if (asmarch) {
 			rz_config_set(r->config, "asm.arch", asmarch);
 		}
@@ -1348,6 +1380,13 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 		}
 		if (asmos) {
 			rz_config_set(r->config, "asm.os", asmos);
+		}
+		if (endianness != RZ_SYS_ENDIAN_NONE) {
+			rz_config_set_b(r->config, "cfg.bigendian", endianness == RZ_SYS_ENDIAN_BIG);
+		}
+		rz_list_foreach (evals, iter, cmdn) {
+			rz_config_eval(r->config, cmdn);
+			rz_cons_flush();
 		}
 	}
 	{

--- a/test/db/analysis/arm
+++ b/test/db/analysis/arm
@@ -165,11 +165,11 @@ NAME=arm 16 BE 4 bytes instruction
 FILE==
 ARGS=-a arm -b 16
 CMDS=<<EOF
-e cfg.bigendian=1
+e cfg.bigendian=true
 wa "blx 0x33b8"
 p8 4
 pi 1
-e cfg.bigendian=0
+e cfg.bigendian=false
 wa "blx 0x33b8"
 p8 4
 pi 1
@@ -1235,6 +1235,7 @@ NAME=aav thumb detection
 FILE=bins/firmware/armthumb.bin
 ARGS=-aarm -b32
 CMDS=<<EOF
+e cfg.bigendian=false
 aav
 fl
 EOF
@@ -1287,7 +1288,7 @@ RUN
 
 NAME=raw aac with maps (using a PIC bin)
 FILE=bins/elf/libmagic.so
-ARGS=-n -m 0x80000 -a arm -b 16 -e cfg.bigendian=false
+ARGS=-n -m 0x80000 -a arm -b 16 -E little
 CMDS=<<EOF
 aac
 e search.in=io.maps
@@ -1300,7 +1301,7 @@ RUN
 
 NAME=add/adc pc, pc issue #3965
 FILE==
-ARGS=-a arm -b 32 -e cfg.bigendian=false
+ARGS=-a arm -b 32 -E little
 CMDS=<<EOF
 wx ffff8f024fffaf02
 pd 2
@@ -1344,6 +1345,7 @@ NAME=Check MOV gets identified as JUMP if it moves to PC
 FILE==
 ARGS=-a arm -b 16
 CMDS=<<EOF
+e cfg.bigendian=false
 s 0x100
 wx bff36f8f2548874680bd000072b680bd
 s 0x19c

--- a/test/db/analysis/arm64
+++ b/test/db/analysis/arm64
@@ -157,7 +157,7 @@ RUN
 
 NAME=ao mte big endian
 FILE==
-ARGS=-a arm -b 64 -e cfg.bigendian=true
+ARGS=-a arm -b 64 -E big
 CMDS=<<EOF
 wx 91a0090c918201099ac813e8
 ao@ 0
@@ -249,6 +249,7 @@ NAME=Variable analysis with stp/preindexed str
 FILE=malloc://1024
 ARGS=-a arm -b 64
 CMDS=<<EOF
+e cfg.bigendian=false
 wx 00000000000000000000000000000000f30f1ef8fd7b01a9fd430091fd7b41a9e00313aaf30742f8c0035fd6
 aap
 s 0x10
@@ -286,6 +287,7 @@ NAME=pacibsp considered a valid function preamble
 FILE=malloc://1024
 ARGS=-a arm -b 64
 CMDS=<<EOF
+e cfg.bigendian=false
 wx 7f2303d5fc6fbaa9fa6701a9f85f02a9
 af
 pd 4
@@ -303,6 +305,7 @@ NAME=pacibsp identified as function prologue
 FILE=malloc://1024
 ARGS=-a arm -b 64
 CMDS=<<EOF
+e cfg.bigendian=false
 wx 7f2303d5fc6fbaa9fa6701a9f85f02a9ff0f5fd6
 aap
 pd 5

--- a/test/db/analysis/avr
+++ b/test/db/analysis/avr
@@ -314,6 +314,7 @@ FILE=malloc://16384
 ARGS=-s 0x3434 -a avr
 CMDS=<<EOF
 e asm.cpu=ATmega8
+e cfg.bigendian=false
 wx ffcf
 pi 1
 ao 1~^jump[1]
@@ -329,6 +330,7 @@ FILE=malloc://8192
 ARGS=-s 0x1000 -a avr
 CMDS=<<EOF
 e asm.cpu=ATmega1280
+e cfg.bigendian=false
 wx 00c8 01c8 7ec8 7fc8 80c8 81c8
 aoe 4
 pi 4
@@ -350,6 +352,7 @@ FILE=malloc://8192
 ARGS=-a avr
 CMDS=<<EOF
 e asm.cpu=ATmega1280
+e cfg.bigendian=false
 wx 00c8 01c8 7ec8 7fc8 80c8 81c8
 aoe 4
 pi 4

--- a/test/db/analysis/mips
+++ b/test/db/analysis/mips
@@ -366,6 +366,7 @@ NAME=mips pseudo sw + 0
 FILE=malloc://32
 ARGS=-a mips -m 0x80100000
 CMDS=<<EOF
+e cfg.bigendian=false
 e io.va=true
 e asm.bytes=true
 wx 0000beaf

--- a/test/db/analysis/vars
+++ b/test/db/analysis/vars
@@ -432,6 +432,7 @@ CMDS=<<EOF
 e asm.bytes=true
 e asm.flags=false
 e asm.comments=false
+e cfg.bigendian=false
 wx 80b483b000af78600b467b8013467b707b78002b03d07a887b689a6103e07b881a047b689a6100bf0c37bd465df8047b7047
 af
 aaef

--- a/test/db/archos/linux-x64/cmd_k
+++ b/test/db/archos/linux-x64/cmd_k
@@ -1,6 +1,9 @@
 NAME=1: k syscall/
 FILE=malloc://512
 CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+e asm.os=linux
 k syscall/0x80.4
 EOF
 EXPECT=<<EOF
@@ -11,6 +14,9 @@ RUN
 NAME=2: k syscall/
 FILE=malloc://512
 CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+e asm.os=linux
 k syscall/stat
 EOF
 EXPECT=<<EOF

--- a/test/db/cmd/cmd_ahi
+++ b/test/db/cmd/cmd_ahi
@@ -1,37 +1,3 @@
-NAME=ahi s + endian
-FILE==
-CMDS=<<EOF
-wx b8410d4300
-e asm.arch=x86
-ahi s
-e cfg.bigendian=false
-pi 1
-e cfg.bigendian=true
-pi 1
-EOF
-EXPECT=<<EOF
-mov eax, 'C\x0dA'
-mov eax, 'A\x0dC'
-EOF
-RUN
-
-NAME=ahi s + endian 2
-FILE==
-CMDS=<<EOF
-wx b841424300
-e asm.arch=x86
-ahi s
-e cfg.bigendian=false
-pi 1
-e cfg.bigendian=true
-pi 1
-EOF
-EXPECT=<<EOF
-mov eax, 'CBA'
-mov eax, 'ABC'
-EOF
-RUN
-
 NAME=1: ahi none
 FILE==
 CMDS=<<EOF

--- a/test/db/cmd/cmd_as
+++ b/test/db/cmd/cmd_as
@@ -1,6 +1,6 @@
 NAME=x86 openbsd syscalls asl ascii
 FILE==
-ARGS=-ax86 -b32 -easm.os=openbsd
+ARGS=-ax86 -b32 -k openbsd
 CMDS=asn read
 EXPECT=<<EOF
 3
@@ -9,7 +9,7 @@ RUN
 
 NAME=x86 openbsd syscalls asl ascii
 FILE==
-ARGS=-ax86 -b64 -easm.os=openbsd
+ARGS=-ax86 -b64 -k openbsd
 CMDS=asn accept
 EXPECT=<<EOF
 30
@@ -18,7 +18,7 @@ RUN
 
 NAME=x86 windows syscalls asl ascii
 FILE==
-ARGS=-ax86 -b32 -easm.os=windows
+ARGS=-ax86 -b32 -k windows
 CMDS=asn NtAllocateVirtualMemory
 EXPECT=<<EOF
 19
@@ -27,7 +27,7 @@ RUN
 
 NAME=x86 windows syscalls asl ascii
 FILE==
-ARGS=-ax86 -b64 -easm.os=windows
+ARGS=-ax86 -b64 -k windows
 CMDS=asn NtAllocateVirtualMemory
 EXPECT=<<EOF
 19
@@ -36,7 +36,7 @@ RUN
 
 NAME=x86 linux syscalls asl ascii
 FILE==
-ARGS=-ax86 -b64 -easm.os=linux
+ARGS=-ax86 -b64 -k linux
 CMDS=asn read
 EXPECT=<<EOF
 0
@@ -45,7 +45,7 @@ RUN
 
 NAME=x86 linux syscalls asl ascii
 FILE==
-ARGS=-ax86 -b64 -easm.os=linux
+ARGS=-ax86 -b64 -k linux
 CMDS=asr 0
 EXPECT=<<EOF
 read
@@ -54,7 +54,7 @@ RUN
 
 NAME=arm s110 syscalls asl ascii
 FILE==
-ARGS=-aarm -b16 -easm.os=s110
+ARGS=-aarm -b16 -k s110
 CMDS=asn sd_evt_get
 EXPECT=<<EOF
 81
@@ -63,7 +63,7 @@ RUN
 
 NAME=arm s110 syscalls asl num
 FILE==
-ARGS=-aarm -b16 -easm.os=s110
+ARGS=-aarm -b16 -k s110
 CMDS=asr 0x51
 EXPECT=<<EOF
 sd_evt_get
@@ -72,7 +72,7 @@ RUN
 
 NAME=arm s110 syscalls asc num
 FILE==
-ARGS=-aarm -b16 -easm.os=s110
+ARGS=-aarm -b16 -k s110
 CMDS=asc 0x51
 EXPECT=<<EOF
 #define SYS_sd_evt_get 81
@@ -81,7 +81,7 @@ RUN
 
 NAME=arm s110 syscalls asca num
 FILE==
-ARGS=-aarm -b16 -easm.os=s110
+ARGS=-aarm -b16 -k s110
 CMDS=asca 0x51
 EXPECT=<<EOF
 .equ SYS_sd_evt_get 81

--- a/test/db/cmd/cmd_c
+++ b/test/db/cmd/cmd_c
@@ -37,6 +37,9 @@ RUN
 NAME=cmd_cb
 FILE=bins/elf/ls
 CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=64
+e cfg.bigendian=false
 cb 0xf3f3 2
 cb 0xfa1e0ff2 4
 cb 0x8989898989898989 8
@@ -45,7 +48,7 @@ cb 0xf1f2fa1e0ff2 4
 cb 0x1a0ff2 3
 cb 0x33445566778899aa 8
 echo -- be
-e cfg.bigendian=1
+e cfg.bigendian=true
 cb 0x1a0ff2 3
 cb 0x33445566778899aa 8
 EOF
@@ -540,6 +543,9 @@ RUN
 NAME=cmd_cu_num
 FILE=bins/elf/ls
 CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=64
+e cfg.bigendian=false
 cu1 0x5ad0
 echo --------
 cu2 0x5ad0
@@ -548,7 +554,7 @@ cu4 0x5ad0
 echo --------
 cu8 0x5ad0
 echo -------- be
-cu4 0x5ad0 @e:cfg.bigendian=1
+cu4 0x5ad0 @e:cfg.bigendian=true
 EOF
 EXPECT=<<EOF
 0x00005ae0  0xf3 ! 0x15

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -92,148 +92,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=i (all) (malloc)
-FILE=malloc://1025
-ARGS=-a x86 -b 64
-CMDS=<<EOF
-i
-iI
-ia
-ii
-ie
-is
-iS
-iz
-EOF
-EXPECT=<<EOF
-fd      3
-file    malloc://1025
-size    0x401
-humansz 1.0K
-mode    rwx
-format  any
-iorw    true
-block   0x100
-type    
-arch     N/A
-cpu      N/A
-features N/A
-baddr    0x00000000
-binsz    0x00000401
-bintype  N/A
-bits     64
-class    N/A
-compiler N/A
-dbg_file N/A
-endian   LE
-hdr.csum N/A
-guid     N/A
-intrp    N/A
-laddr    0x00000000
-lang     N/A
-machine  N/A
-maxopsz  16
-minopsz  1
-os       N/A
-cc       N/A
-pcalign  1
-rpath    N/A
-subsys   
-stripped false
-crypto   false
-havecode false
-va       false
-sanitiz  false
-static   true
-linenum  false
-lsyms    false
-canary   false
-PIE      false
-RELROCS  false
-NX       false
-[Info]
-arch     N/A
-cpu      N/A
-features N/A
-baddr    0x00000000
-binsz    0x00000401
-bintype  N/A
-bits     64
-class    N/A
-compiler N/A
-dbg_file N/A
-endian   LE
-hdr.csum N/A
-guid     N/A
-intrp    N/A
-laddr    0x00000000
-lang     N/A
-machine  N/A
-maxopsz  16
-minopsz  1
-os       N/A
-cc       N/A
-pcalign  1
-rpath    N/A
-subsys   
-stripped false
-crypto   false
-havecode false
-va       false
-sanitiz  false
-static   true
-linenum  false
-lsyms    false
-canary   false
-PIE      false
-RELROCS  false
-NX       false
-
-[Imports]
-nth vaddr bind type lib name 
------------------------------
-
-[Entries]
-vaddr paddr hvaddr haddr type 
-------------------------------
-
-[Exports]
-nth paddr vaddr bind type size lib name 
-----------------------------------------
-
-[Classes]
-address min max name super 
----------------------------
-
-[Symbols]
-nth paddr vaddr bind type size lib name 
-----------------------------------------
-
-[Sections]
-paddr size vaddr vsize align perm name type flags 
---------------------------------------------------
-
-[Memory]
-name size address flags mirror 
--------------------------------
-
-[Strings]
-paddr vaddr len size section type string 
------------------------------------------
-
-nth vaddr bind type lib name 
------------------------------
-vaddr paddr hvaddr haddr type 
-------------------------------
-nth paddr vaddr bind type size lib name 
-----------------------------------------
-paddr size vaddr vsize align perm name type flags 
---------------------------------------------------
-paddr vaddr len size section type string 
------------------------------------------
-EOF
-RUN
-
 NAME=i (file x86)
 FILE=bins/elf/analysis/x86-helloworld-gcc
 CMDS=i~!file
@@ -3656,6 +3514,7 @@ RUN
 
 NAME=izz and str.encoding
 FILE==
+ARGS=-a x86 -b 32
 CMDS=<<EOF
 wz k\0i\0abcdefgh
 (izzenc enc; e str.encoding=${enc}; izz:quiet)
@@ -4315,17 +4174,10 @@ laddr    0x00000000
 EOF
 RUN
 
-NAME=ik-macho
-FILE=bins/mach0/fatmach0-3true
-CMDS=ik mach0.entry.vaddr~?0x100000ef8
-EXPECT=<<EOF
-1
-EOF
-RUN
-
 NAME=ik
 FILE=bins/mach0/fatmach0-3true
 CMDS=ik mach0.entry.vaddr
+ARGS=-a ppc -b 64
 EXPECT=<<EOF
 0x100000ef8
 EOF
@@ -4351,6 +4203,7 @@ RUN
 
 NAME=iSq.
 FILE=bins/mach0/fatmach0-3true
+ARGS=-a ppc -b 64
 CMDS=iS.:paddr/cols/vaddr/perm/name
 EXPECT=<<EOF
      paddr       vaddr perm name            
@@ -4492,6 +4345,7 @@ RUN
 
 NAME=iT2
 FILE=--
+ARGS=-a x86 -b 64
 CMDS=<<EOF
 mkdir .tmp
 cp bins/mach0/fatmach0-3true .tmp/it2-modfile

--- a/test/db/cmd/cmd_p_capital_c
+++ b/test/db/cmd/cmd_p_capital_c
@@ -40,6 +40,7 @@ NAME=pCd
 FILE==
 ARGS=-a arm -b 32
 CMDS=<<EOF
+e cfg.bigendian=false
 wx 55aa55aa909055aa9090ff20000ff34534ff55f45eaac0c0c0cdf534
 pCd 3
 EOF
@@ -54,6 +55,7 @@ NAME=pCd with flags
 FILE==
 ARGS=-a arm -b 32
 CMDS=<<EOF
+e cfg.bigendian=false
 wx 55aa55aa909055aa9090ff20000ff34534ff55f45eaac0c0c0cdf534
 f myflag
 pCd 3

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -36,6 +36,7 @@ NAME=pd V8 and Cortex-M profiles
 FILE=malloc://128
 ARGS=-a arm -b 16
 CMDS=<<EOF
+e cfg.bigendian=false
 echo
 pad fff7c0ea@e:asm.cpu=v8
 pad fff7c0ea@e:asm.cpu=cortexm
@@ -1872,6 +1873,7 @@ NAME=@b and @addr should coexist
 FILE=bins/firmware/armthumb.bin
 ARGS=-aarm -b32
 CMDS=<<EOF
+e cfg.bigendian=false
 e asm.bytes=true
 pd 1 @b:32 @ 0xc
 EOF
@@ -1884,6 +1886,7 @@ NAME=ahb should not be deleted with @b (#9751)
 FILE=bins/firmware/armthumb.bin
 ARGS=-aarm -b32
 CMDS=<<EOF
+e cfg.bigendian=false
 e asm.bytes=true
 ahb 16 @ 0xc
 ahl
@@ -1901,6 +1904,7 @@ NAME=ahb should not override @b
 FILE=bins/firmware/armthumb.bin
 ARGS=-aarm -b32
 CMDS=<<EOF
+e cfg.bigendian=false
 e asm.bytes=true
 ahb 16 @ 0xc
 pd 5 @b:32

--- a/test/db/cmd/cmd_pd_bugs
+++ b/test/db/cmd/cmd_pd_bugs
@@ -18,7 +18,11 @@ RUN
 NAME=pd arm cortex-m 0
 FILE==
 ARGS=-a arm -b 16
-CMDS=wx 80f30988; pi 1
+CMDS=<<EOF
+e cfg.bigendian=false
+wx 80f30988
+pi 1
+EOF
 EXPECT=<<EOF
 invalid
 EOF
@@ -28,7 +32,11 @@ RUN
 NAME=pd arm cortex-m 1
 FILE==
 ARGS=-a arm -b 16 -e asm.cpu=cortexm
-CMDS=wx 80f30988;pi 1
+CMDS=<<EOF
+e cfg.bigendian=false
+wx 80f30988
+pi 1
+EOF
 EXPECT=<<EOF
 msr psp, r0
 EOF
@@ -38,7 +46,12 @@ RUN
 NAME=pd arm cortex-m 2
 FILE==
 ARGS=-a arm -b 16
-CMDS=e asm.cpu=cortexm;wx 80f30988;pi 1
+CMDS=<<EOF
+e asm.cpu=cortexm
+e cfg.bigendian=false
+wx 80f30988
+pi 1
+EOF
 EXPECT=<<EOF
 msr psp, r0
 EOF

--- a/test/db/cmd/cmd_pi
+++ b/test/db/cmd/cmd_pi
@@ -1,7 +1,10 @@
 NAME=tbz
 FILE=bins/other/tbz.arm64
 ARGS=-a arm -b64 -m 0x100000000
-CMDS=pi 4
+CMDS=<<EOF
+e cfg.bigendian=false
+pi 4
+EOF
 EXPECT=<<EOF
 tbz x0, 0x20, 0x100004000
 tbz x0, 0x20, 0xffff8004

--- a/test/db/cmd/cmd_print
+++ b/test/db/cmd/cmd_print
@@ -172,6 +172,7 @@ RUN
 NAME=ppd/ endianness
 FILE==
 CMDS=<<EOF
+e asm.arch=arm
 e cfg.bigendian=false
 ppd/ 0x41574141
 e cfg.bigendian=true

--- a/test/db/cmd/cmd_pxw
+++ b/test/db/cmd/cmd_pxw
@@ -1,6 +1,8 @@
 NAME=pxw cfg.bigendian=true (elf64)
 FILE=bins/elf/analysis/hello-linux-x86_64
 CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=64
 e cfg.bigendian=true
 pxw 16
 EOF
@@ -34,6 +36,8 @@ RUN
 NAME=pxw cfg.bigendian=true (pe32)
 FILE=bins/pe/hello-mingw32
 CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=64
 e cfg.bigendian=true
 pxw 16
 EOF

--- a/test/db/cmd/cmd_search_a
+++ b/test/db/cmd/cmd_search_a
@@ -99,7 +99,7 @@ RUN
 
 NAME=/ad search - issue 4098
 FILE==
-ARGS=-e asm.arch=arm -e asm.bits=64
+ARGS=-a arm -b 64 -E little
 CMDS=<<EOF
 wx a0e1fe9000003b9141b8fe9021400f91
 pd 4

--- a/test/db/cmd/cmd_search_v
+++ b/test/db/cmd/cmd_search_v
@@ -204,6 +204,8 @@ RUN
 NAME=/V{2,4,8} alias
 FILE==
 CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=64
 e cfg.bigendian=true
 wx 0x12345678aabbccddeeff13345678
 /V2 0x7854 0x7858

--- a/test/db/cmd/cmd_w
+++ b/test/db/cmd/cmd_w
@@ -1,6 +1,7 @@
 NAME=wB
 FILE==
 CMDS=<<EOF
+e asm.arch=x86
 e cfg.bigendian=false
 wB 0x55
 pv1
@@ -38,7 +39,7 @@ RUN
 
 NAME=w[1234]
 FILE==
-ARGS=-e cfg.bigendian=false
+ARGS=-a x86 -b 64
 CMDS=<<EOF
 wx 0022
 w1+ 1

--- a/test/db/cmd/cmd_wD
+++ b/test/db/cmd/cmd_wD
@@ -1,22 +1,30 @@
 NAME=debruijn little endian
 FILE==
 CMDS=<<EOF
+e asm.arch=arm
 e cfg.bigendian=false
 wD/ 0x41574141
+echo ---
+e cfg.bigendian=true
+wD/ 0x41574141
+echo ---
+e asm.arch=x86
+wD/ 0x41417641
+echo ---
+wD/ 41417641
+echo ---
 EOF
 EXPECT=<<EOF
 64
-EOF
-RUN
-
-NAME=debruijn big endian
-FILE==
-CMDS=<<EOF
-e cfg.bigendian=true
-wD/ 0x41574141
-EOF
-EXPECT=<<EOF
+---
 65
+---
+140
+---
+---
+EOF
+EXPECT_ERR=<<EOF
+ERROR: Could not find value 277fba9 in Debruijn sequence.
 EOF
 RUN
 
@@ -29,21 +37,6 @@ EOF
 EXPECT=<<EOF
 41414142414143414144414145414146
 EOF
-RUN
-
-NAME=wD/ 0x41417641
-FILE==
-ARGS=-a x86
-CMDS=wD/ 0x41417641
-EXPECT=<<EOF
-140
-EOF
-RUN
-
-NAME=wD/ 41417641
-FILE==
-CMDS=wD/ 41417641
-EXPECT=
 RUN
 
 NAME=woE woD rc4

--- a/test/db/cmd/metadata
+++ b/test/db/cmd/metadata
@@ -697,7 +697,7 @@ RUN
 
 NAME=Csl
 FILE=bins/arm/crackme.arm32.bin
-ARGS=-A -a arm -b 32 -m 0x8000000
+ARGS=-A -a arm -b 32 -E little -m 0x8000000
 CMDS=<<EOF
 Csl
 EOF

--- a/test/db/cmd/write
+++ b/test/db/cmd/write
@@ -147,6 +147,7 @@ NAME=wao nop (arm)
 FILE=malloc://1024
 ARGS=-a arm -b 32
 CMDS=<<EOF
+e cfg.bigendian=false
 wx 24c09fe500b0a0e304109de40d20a0e1
 pi 4
 wao nop
@@ -168,6 +169,7 @@ NAME=wao trap (arm)
 FILE=malloc://1024
 ARGS=-a arm -b 32
 CMDS=<<EOF
+e cfg.bigendian=false
 wx 24c09fe500b0a0e304109de40d20a0e1
 pi 4
 wao trap
@@ -250,8 +252,9 @@ RUN
 NAME=endian tests: wv
 FILE==
 CMDS=<<EOF
-e asm.arch=x86
+e asm.arch=arm
 e asm.bits=32
+e cfg.bigendian=false
 wv4 3
 p8 4
 e cfg.bigendian=true

--- a/test/db/esil/arm_64
+++ b/test/db/esil/arm_64
@@ -78,6 +78,7 @@ NAME=ldrsw x9, [x8, 0x468]
 FILE=malloc://0x200
 ARGS=-a arm -b 64 -m 0x464
 CMDS=<<EOF
+e cfg.bigendian=false
 wx 096984b9@ 0x464
 wx 8877665544332211cacacacacaca@ 0x468
 aei

--- a/test/db/rzil/arm64
+++ b/test/db/rzil/arm64
@@ -78,6 +78,7 @@ NAME=arm64 cls
 FILE=malloc://0x100
 ARGS=-aarm -b64
 CMDS=<<EOF
+e cfg.bigendian=false
 wx 6214c0da
 aezi
 echo -- 0x00800000
@@ -116,6 +117,7 @@ NAME=arm clz
 FILE=malloc://0x100
 ARGS=-aarm -b64
 CMDS=<<EOF
+e cfg.bigendian=false
 wx 6210c0da
 aezi
 echo -- 0x00800000
@@ -154,6 +156,7 @@ NAME=arm64 sdiv 64-bit
 FILE=malloc://0x100
 ARGS=-aarm -b64
 CMDS=<<EOF
+e cfg.bigendian=false
 wx 200cc29a
 aezi
 ar x1=42
@@ -212,6 +215,7 @@ NAME=arm64 sdiv 32-bit
 FILE=malloc://0x100
 ARGS=-aarm -b64
 CMDS=<<EOF
+e cfg.bigendian=false
 wx 200cc21a
 aezi
 ar x1=42
@@ -270,6 +274,7 @@ NAME=arm udiv 64-bit
 FILE=malloc://0x100
 ARGS=-aarm -b64
 CMDS=<<EOF
+e cfg.bigendian=false
 wx 0008c19a
 aezi
 ar x0=42
@@ -328,6 +333,7 @@ NAME=arm udiv 32-bit
 FILE=malloc://0x100
 ARGS=-aarm -b64
 CMDS=<<EOF
+e cfg.bigendian=false
 wx 0008c11a
 aezi
 ar x0=42

--- a/test/db/rzil/vm
+++ b/test/db/rzil/vm
@@ -1,8 +1,7 @@
 NAME=Halt VM on exception
 FILE==
-ARGS=-a ppc -e cfg.bigendian=true -b 64
+ARGS=-a ppc -b 64 -E big
 CMDS=<<EOF
-
 # li	3, 4
 # li	4, 0
 # divdu 5, 3, 4

--- a/test/db/tools/rz
+++ b/test/db/tools/rz
@@ -268,6 +268,7 @@ EXPECT=<<EOF
  [32m-d[0m         [0mDebug the executable 'file' or running process 'pid'
  [32m-D[0m[33m backend [0m[0mEnable debug mode (e cfg.debug=true)
  [32m-e[0m[33m k=v [0m    [0mEvaluate config var
+ [32m-E[0m[33m endian [0m [0mEndianness -E big or -E little
  [32m-f[0m         [0mBlock size = file size
  [32m-F[0m[33m binplug [0m[0mForce to use that rbin plugin
  [32m-h, -hh[0m    [0mShow help message, -hh for long


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

This generates a log when the switch to a specific endianness fails.

```
[0x00000000]> e asm.arch=x86
[0x00000000]> e cfg.bigendian
false
[0x00000000]> e cfg.bigendian=true
ERROR: core: cannot change to big endian (arch 'x86' supports only little endian)
[0x00000000]> e asm.arch=sysz 
[0x00000000]> e cfg.bigendian
true
[0x00000000]> e cfg.bigendian=false
ERROR: core: cannot change to little endian (arch 'sysz' supports only big endian)
```