### PR TITLE
fix(io): unify R! command usage formatting

### DIFF
--- a/librz/io/p/io_gdb.c
+++ b/librz/io/p/io_gdb.c
@@ -215,7 +215,7 @@ static char *__system(RzIO *io, RzIODesc *fd, const char *cmd) {
 		return NULL;
 	}
 	if (cmd[0] == '?' || !strcmp(cmd, "help")) {
-		eprintf("Usage: R!cmd args\n"
+		eprintf("Usage: R!<cmd> [args]\n"
 			" R!pid             - show targeted pid\n"
 			" R!pkt s           - send packet 's'\n"
 			" R!rd              - show reverse debugging availability\n"

--- a/librz/io/p/io_ptrace.c
+++ b/librz/io/p/io_ptrace.c
@@ -305,7 +305,7 @@ static char *__system(RzIO *io, RzIODesc *fd, const char *cmd) {
 		return NULL;
 	}
 	if (!strcmp(cmd, "help")) {
-		eprintf("Usage: R!cmd args\n"
+		eprintf("Usage: R!<cmd> [args]\n"
 			" R!ptrace   - use ptrace io\n"
 			" R!mem      - use /proc/pid/mem io if possible\n"
 			" R!pid      - show targeted pid\n"

--- a/librz/io/p/io_self.c
+++ b/librz/io/p/io_self.c
@@ -498,16 +498,16 @@ static char *__system(RzIO *io, RzIODesc *fd, const char *cmd) {
 				io_self->self_sections[i].name);
 		}
 	} else {
-		eprintf("|Usage: R![cmd] [args]\n");
-		eprintf("| R!pid               show getpid()\n");
-		eprintf("| R!maps              show map regions\n");
-		eprintf("| R!kill              commit suicide\n");
+		eprintf("Usage: R!<cmd> [args]\n");
+		eprintf(" R!pid               show getpid()\n");
+		eprintf(" R!maps              show map regions\n");
+		eprintf(" R!kill              commit suicide\n");
 #if !defined(__WINDOWS__)
-		eprintf("| R!alarm [secs]      setup alarm signal to raise rizin prompt\n");
+		eprintf(" R!alarm [secs]      setup alarm signal to raise rizin prompt\n");
 #endif
-		eprintf("| R!dlsym [sym]       dlopen\n");
-		eprintf("| R!call [sym] [...]  nativelly call a function\n");
-		eprintf("| R!mameio            enter mame IO mode\n");
+		eprintf(" R!dlsym [sym]       dlopen\n");
+		eprintf(" R!call [sym] [...]  nativelly call a function\n");
+		eprintf(" R!mameio            enter mame IO mode\n");
 	}
 	return NULL;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Fix inconsistent usage output of 'R!' commands in rz_io_system.

- Standardized all 'R!' help messages to use '<cmd> [args]' format
- Removed the pipe '|' from the output to be consistent
- Ensured all 'R!' commands now have uniform usage text

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

- Build 'rizin' with your branch
- Run 'rizin ./<bin> and enter commands:
   - 'R!'
   - 'R!?'
   - 'R!pid'
3. Verify that usage messages are consistent and show '<cmd> [args]' properly
4. Check that no pipe characters '|' remain in the output

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #5881 
