### PR TITLE
Fix meson build warning about empty config data.

### DIFF
--- a/subprojects/packagefiles/pcre2/meson.build
+++ b/subprojects/packagefiles/pcre2/meson.build
@@ -6,19 +6,17 @@ if cc.has_argument('--std=c99')
   add_project_arguments('--std=c99', language: ['c'])
 endif
 
-conf_data = configuration_data()
-
 pcre2_chartables = configure_file(input : 'src/pcre2_chartables.c.dist',
   output : 'pcre2_chartables.c',
-  configuration : conf_data)
+  copy : true)
 
 pcre2_h = configure_file(input : 'src/pcre2.h.generic',
   output : 'pcre2.h',
-  configuration : conf_data)
+  copy : true)
 
 config_h = configure_file(input : 'src/config.h.generic',
   output : 'config.h',
-  configuration : conf_data)
+  copy : true)
 
 libpcre2_c_args = [
   '-DHAVE_CONFIG_H', # Default values from config.h

--- a/subprojects/packagefiles/pcre2_cross_native/meson.build
+++ b/subprojects/packagefiles/pcre2_cross_native/meson.build
@@ -6,19 +6,17 @@ project('pcre2_cross_native', 'c', version: '10.47')
 
 cc = meson.get_compiler('c')
 
-conf_data = configuration_data()
-
 pcre2_chartables = configure_file(input : 'src/pcre2_chartables.c.dist',
   output : 'pcre2_chartables.c',
-  configuration : conf_data)
+  copy : true)
 
 pcre2_h = configure_file(input : 'src/pcre2.h.generic',
   output : 'pcre2.h',
-  configuration : conf_data)
+  copy : true)
 
 config_h = configure_file(input : 'src/config.h.generic',
   output : 'config.h',
-  configuration : conf_data)
+  copy : true)
 
 libpcre2_c_args = [
   '-DHAVE_CONFIG_H', # Default values from config.h


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Fixes

```
pcre2| Configuring pcre2_chartables.c using configuration
pcre2| subprojects/pcre2-10.47/meson.build:11: WARNING: Got an empty configuration_data() object and found no substitutions in the input file 'pcre2_chartables.c.dist'. If you want to copy a file to the build dir, use the 'copy:' keyword argument added in 0.47.0
pcre2| Configuring pcre2.h using configuration
pcre2| subprojects/pcre2-10.47/meson.build:15: WARNING: Got an empty configuration_data() object and found no substitutions in the input file 'pcre2.h.generic'. If you want to copy a file to the build dir, use the 'copy:' keyword argument added in 0.47.0
pcre2| Configuring config.h using configuration
pcre2| subprojects/pcre2-10.47/meson.build:19: WARNING: Got an empty configuration_data() object and found no substitutions in the input file 'config.h.generic'. If you want to copy a file to the build dir, use the 'copy:' keyword argument added in 0.47.0
```

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Error is no longer reported.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
