### PR TITLE
Add iH header support for CGC format

### DIFF
--- a/librz/bin/p/bin_cgc.c
+++ b/librz/bin/p/bin_cgc.c
@@ -12,6 +12,13 @@ static bool check_buffer(RzBuffer *buf) {
 	return r > SCGCMAG && !memcmp(tmp, CGCMAG, SCGCMAG) && tmp[4] != 2;
 }
 
+static RzStructuredData *cgc_info_structure(RzBinFile *bf) {
+	rz_return_val_if_fail(bf && bf->o && bf->o->bin_obj, NULL);
+
+	ELFOBJ *bin = (ELFOBJ *)bf->o->bin_obj;
+	return elf_structure(bin);
+}
+
 static RzBuffer *create(RzBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen, RzBinArchOptions *opt) {
 	ut32 filesize, code_va, code_pa, phoff;
 	ut32 p_start, p_phoff, p_phdr;
@@ -118,6 +125,7 @@ RzBinPlugin rz_bin_plugin_cgc = {
 	.symbols = &elf_symbols,
 	.imports = &elf_imports,
 	.info = &elf_info,
+	.bin_structure = &cgc_info_structure,
 	.fields = &elf_fields,
 	.size = &elf_size,
 	.libs = &elf_libs,

--- a/test/db/formats/cgc
+++ b/test/db/formats/cgc
@@ -1,8 +1,67 @@
 NAME=CGC: Open/iI
 FILE=bins/cgc/CADET_00001
-CMDS=i~?format   cgc
+CMDS=<<EOF
+iI
+iH
+EOF
 EXPECT=<<EOF
-1
+arch     x86
+cpu      N/A
+features N/A
+baddr    0x08048000
+binsz    0x00014a45
+bintype  elf
+bits     32
+class    ELF32
+compiler clang-cgc version 3.4 (10208)
+dbg_file N/A
+endian   LE
+hdr.csum N/A
+guid     N/A
+intrp    N/A
+laddr    0x00000000
+lang     c
+machine  Intel 80386
+maxopsz  16
+minopsz  1
+os       linux
+cc       N/A
+pcalign  1
+rpath    NONE
+subsys   linux
+stripped true
+crypto   false
+havecode true
+va       true
+sanitiz  false
+static   true
+linenum  false
+lsyms    false
+canary   false
+PIE      false
+RELROCS  false
+NX       false
+elf:
+  e_ident:
+    bytes: "7f 43 47 43 01 01 01 43 01 4d 65 72 69 6e 6f 00"
+    ei_class: 1
+    ei_data: 1
+    ei_version: 1
+    ei_osabi: 67
+    ei_abiversion: 1
+  e_machine: 3
+  e_version: 1
+  e_entry: 0x80485fc
+  e_phoff: 0x34
+  e_shoff: 0x14a48
+  e_flags: 0x0
+  e_ehsize: 52
+  e_phentsize: 32
+  e_phnum: 3
+  e_shentsize: 40
+  e_shnum: 6
+  e_shstrndx: 5
+
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
Implemented iH header support for the CGC bin plugin by reusing the existing ELF structure function. 

**Screenshot**
<img width="1331" height="433" alt="image" src="https://github.com/user-attachments/assets/83d65f63-802c-4269-870b-199e60b006ed" />


**Test plan**
`./binrz/rizin/rizin -q -c 'iH' ../test/bins/cgc/CADET_00001
`

**Closes**
CGC for #5728 