### PR TITLE
Fix illumos/solaris build [sysctl.h, *time_r signatures]

### DIFF
--- a/librz/debug/p/native/unsupported.c
+++ b/librz/debug/p/native/unsupported.c
@@ -138,6 +138,10 @@ static int rz_debug_native_bp(RzBreakpoint *bp, RzBreakpointItem *b, bool set) {
 	return -1;
 }
 
+RZ_API ut64 rz_debug_get_tls(RZ_NONNULL RzDebug *dbg, int tid) {
+	return 0;
+}
+
 RzDebugPlugin rz_debug_plugin_native = {
 	.name = "native",
 	.license = "LGPL3",

--- a/librz/io/meson.build
+++ b/librz/io/meson.build
@@ -103,6 +103,14 @@ rz_io_deps = [
   platform_deps,
 ]
 
+if host_machine.system() == 'sunos'
+  rz_io_deps += [
+    cc.find_library('socket'),
+    cc.find_library('nsl'),
+    cc.find_library('proc'),
+  ]
+endif
+
 if get_option('use_gpl')
   rz_io_deps += dependency('rzqnx')
   rz_io_sources += 'p/io_qnx.c'

--- a/librz/socket/meson.build
+++ b/librz/socket/meson.build
@@ -21,6 +21,13 @@ if host_machine.system() == 'haiku'
   ]
 endif
 
+if host_machine.system() == 'sunos'
+  dependencies += [
+    cc.find_library('socket'),
+    cc.find_library('nsl')
+  ]
+endif
+
 rz_socket = library('rz_socket', rz_socket_sources,
   include_directories: [platform_inc],
   dependencies: dependencies,

--- a/librz/util/thread.h
+++ b/librz/util/thread.h
@@ -55,7 +55,7 @@
 #include <mach/thread_policy.h>
 #endif
 
-#if __APPLE__ || __NetBSD__ || __FreeBSD__ || __OpenBSD__ || __DragonFly__ || __sun
+#if __APPLE__ || __NetBSD__ || __FreeBSD__ || __OpenBSD__ || __DragonFly__
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #endif

--- a/librz/util/time.c
+++ b/librz/util/time.c
@@ -303,6 +303,8 @@ RZ_API char *rz_asctime_r(RZ_NONNULL const struct tm *tm, RZ_NONNULL char *buf) 
 #if __WINDOWS__
 	errno_t err = asctime_s(buf, ASCTIME_BUF_MINLEN, tm);
 	return err ? NULL : buf;
+#elif __sun
+	return asctime_r(tm, buf, ASCTIME_BUF_MINLEN);
 #else
 	return asctime_r(tm, buf);
 #endif
@@ -313,6 +315,8 @@ RZ_API char *rz_ctime_r(RZ_NONNULL const time_t *timer, RZ_NONNULL char *buf) {
 #if __WINDOWS__
 	errno_t err = ctime_s(buf, ASCTIME_BUF_MINLEN, timer);
 	return err ? NULL : buf;
+#elif __sun
+	return ctime_r(timer, buf, ASCTIME_BUF_MINLEN);
 #else
 	return ctime_r(timer, buf);
 #endif

--- a/subprojects/rzwinkd/meson.build
+++ b/subprojects/rzwinkd/meson.build
@@ -31,6 +31,11 @@ if host_machine.system() == 'haiku'
   librzwinkd_deps += [
     cc.find_library('network')
   ]
+elif host_machine.system() == 'sunos'
+  librzwinkd_deps += [
+    cc.find_library('socket'),
+    cc.find_library('nsl')
+  ]
 endif
 
 librzwinkd = static_library('rzwinkd', winkd_files,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

While Solaris/illumos is documented as an officially supported operating system, support for it seems to have drifted a bit. Here's the output of `meson setup build && meson compile -C build` on a recent build of illumos (`SunOS basher 5.11 omnios-r151056-128de81dcd i86pc i386 i86pc`):

```
[1/478] Compiling C object librz/util/librz_util.so.0.9.0.p/thread_lock.c.o
FAILED: [code=1] librz/util/librz_util.so.0.9.0.p/thread_lock.c.o
cc -Ilibrz/util/librz_util.so.0.9.0.p -I. -I.. -Ilibrz -I../librz -Ilibrz/include -I../librz/include -Isubprojects/rzheap -I../subprojects/rzheap -Ilibrz/util/sdb/src -I../librz/util/sdb/src -Isubprojects/pcre2-10.47 -I../subprojects/pcre2-10.47 -I../su
bprojects/pcre2-10.47/src -I../subprojects/softfloat/include -Isubprojects/zlib-1.3.1 -I../subprojects/zlib-1.3.1 -I../subprojects/xz-5.8.1/src/liblzma/api -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O2 -g -DCC_SUPPORTS_W_ENUM
_CONVERION -DCC_SUPPORTS_W_ENUM_COMPARE -std=gnu99 -Werror=sizeof-pointer-memaccess -Wimplicit-fallthrough=3 -fvisibility=hidden -DRZ_PLUGIN_INCORE=1 -DSUPPORTS_PCRE2_JIT -DZYDIS_STATIC_BUILD -D_GNU_SOURCE -fPIC -DLZMA_API_STATIC -pthread -MD -MQ librz/
util/librz_util.so.0.9.0.p/thread_lock.c.o -MF librz/util/librz_util.so.0.9.0.p/thread_lock.c.o.d -o librz/util/librz_util.so.0.9.0.p/thread_lock.c.o -c ../librz/util/thread_lock.c
In file included from ../librz/util/thread_lock.c:5:
../librz/util/thread.h:60:10: fatal error: sys/sysctl.h: No such file or directory
   60 | #include <sys/sysctl.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
[2/478] Compiling C object librz/util/librz_util.so.0.9.0.p/thread_cond.c.o
FAILED: [code=1] librz/util/librz_util.so.0.9.0.p/thread_cond.c.o
cc -Ilibrz/util/librz_util.so.0.9.0.p -I. -I.. -Ilibrz -I../librz -Ilibrz/include -I../librz/include -Isubprojects/rzheap -I../subprojects/rzheap -Ilibrz/util/sdb/src -I../librz/util/sdb/src -Isubprojects/pcre2-10.47 -I../subprojects/pcre2-10.47 -I../su
bprojects/pcre2-10.47/src -I../subprojects/softfloat/include -Isubprojects/zlib-1.3.1 -I../subprojects/zlib-1.3.1 -I../subprojects/xz-5.8.1/src/liblzma/api -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O2 -g -DCC_SUPPORTS_W_ENUM
_CONVERION -DCC_SUPPORTS_W_ENUM_COMPARE -std=gnu99 -Werror=sizeof-pointer-memaccess -Wimplicit-fallthrough=3 -fvisibility=hidden -DRZ_PLUGIN_INCORE=1 -DSUPPORTS_PCRE2_JIT -DZYDIS_STATIC_BUILD -D_GNU_SOURCE -fPIC -DLZMA_API_STATIC -pthread -MD -MQ librz/
util/librz_util.so.0.9.0.p/thread_cond.c.o -MF librz/util/librz_util.so.0.9.0.p/thread_cond.c.o.d -o librz/util/librz_util.so.0.9.0.p/thread_cond.c.o -c ../librz/util/thread_cond.c
In file included from ../librz/util/thread_cond.c:5:
../librz/util/thread.h:60:10: fatal error: sys/sysctl.h: No such file or directory
   60 | #include <sys/sysctl.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
[3/478] Compiling C object librz/util/librz_util.so.0.9.0.p/thread_pool.c.o
FAILED: [code=1] librz/util/librz_util.so.0.9.0.p/thread_pool.c.o
cc -Ilibrz/util/librz_util.so.0.9.0.p -I. -I.. -Ilibrz -I../librz -Ilibrz/include -I../librz/include -Isubprojects/rzheap -I../subprojects/rzheap -Ilibrz/util/sdb/src -I../librz/util/sdb/src -Isubprojects/pcre2-10.47 -I../subprojects/pcre2-10.47 -I../su
bprojects/pcre2-10.47/src -I../subprojects/softfloat/include -Isubprojects/zlib-1.3.1 -I../subprojects/zlib-1.3.1 -I../subprojects/xz-5.8.1/src/liblzma/api -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O2 -g -DCC_SUPPORTS_W_ENUM
_CONVERION -DCC_SUPPORTS_W_ENUM_COMPARE -std=gnu99 -Werror=sizeof-pointer-memaccess -Wimplicit-fallthrough=3 -fvisibility=hidden -DRZ_PLUGIN_INCORE=1 -DSUPPORTS_PCRE2_JIT -DZYDIS_STATIC_BUILD -D_GNU_SOURCE -fPIC -DLZMA_API_STATIC -pthread -MD -MQ librz/
util/librz_util.so.0.9.0.p/thread_pool.c.o -MF librz/util/librz_util.so.0.9.0.p/thread_pool.c.o.d -o librz/util/librz_util.so.0.9.0.p/thread_pool.c.o -c ../librz/util/thread_pool.c
In file included from ../librz/util/thread_pool.c:5:
../librz/util/thread.h:60:10: fatal error: sys/sysctl.h: No such file or directory
   60 | #include <sys/sysctl.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
[4/478] Compiling C object librz/util/librz_util.so.0.9.0.p/thread_queue.c.o
FAILED: [code=1] librz/util/librz_util.so.0.9.0.p/thread_queue.c.o
cc -Ilibrz/util/librz_util.so.0.9.0.p -I. -I.. -Ilibrz -I../librz -Ilibrz/include -I../librz/include -Isubprojects/rzheap -I../subprojects/rzheap -Ilibrz/util/sdb/src -I../librz/util/sdb/src -Isubprojects/pcre2-10.47 -I../subprojects/pcre2-10.47 -I../su
bprojects/pcre2-10.47/src -I../subprojects/softfloat/include -Isubprojects/zlib-1.3.1 -I../subprojects/zlib-1.3.1 -I../subprojects/xz-5.8.1/src/liblzma/api -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O2 -g -DCC_SUPPORTS_W_ENUM
_CONVERION -DCC_SUPPORTS_W_ENUM_COMPARE -std=gnu99 -Werror=sizeof-pointer-memaccess -Wimplicit-fallthrough=3 -fvisibility=hidden -DRZ_PLUGIN_INCORE=1 -DSUPPORTS_PCRE2_JIT -DZYDIS_STATIC_BUILD -D_GNU_SOURCE -fPIC -DLZMA_API_STATIC -pthread -MD -MQ librz/
util/librz_util.so.0.9.0.p/thread_queue.c.o -MF librz/util/librz_util.so.0.9.0.p/thread_queue.c.o.d -o librz/util/librz_util.so.0.9.0.p/thread_queue.c.o -c ../librz/util/thread_queue.c
In file included from ../librz/util/thread_queue.c:5:
../librz/util/thread.h:60:10: fatal error: sys/sysctl.h: No such file or directory
   60 | #include <sys/sysctl.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
[5/478] Compiling C object librz/util/librz_util.so.0.9.0.p/thread_sem.c.o
FAILED: [code=1] librz/util/librz_util.so.0.9.0.p/thread_sem.c.o
cc -Ilibrz/util/librz_util.so.0.9.0.p -I. -I.. -Ilibrz -I../librz -Ilibrz/include -I../librz/include -Isubprojects/rzheap -I../subprojects/rzheap -Ilibrz/util/sdb/src -I../librz/util/sdb/src -Isubprojects/pcre2-10.47 -I../subprojects/pcre2-10.47 -I../su
bprojects/pcre2-10.47/src -I../subprojects/softfloat/include -Isubprojects/zlib-1.3.1 -I../subprojects/zlib-1.3.1 -I../subprojects/xz-5.8.1/src/liblzma/api -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O2 -g -DCC_SUPPORTS_W_ENUM
_CONVERION -DCC_SUPPORTS_W_ENUM_COMPARE -std=gnu99 -Werror=sizeof-pointer-memaccess -Wimplicit-fallthrough=3 -fvisibility=hidden -DRZ_PLUGIN_INCORE=1 -DSUPPORTS_PCRE2_JIT -DZYDIS_STATIC_BUILD -D_GNU_SOURCE -fPIC -DLZMA_API_STATIC -pthread -MD -MQ librz/
util/librz_util.so.0.9.0.p/thread_sem.c.o -MF librz/util/librz_util.so.0.9.0.p/thread_sem.c.o.d -o librz/util/librz_util.so.0.9.0.p/thread_sem.c.o -c ../librz/util/thread_sem.c
In file included from ../librz/util/thread_sem.c:5:
../librz/util/thread.h:60:10: fatal error: sys/sysctl.h: No such file or directory
   60 | #include <sys/sysctl.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
[7/478] Compiling C object librz/util/librz_util.so.0.9.0.p/thread.c.o
FAILED: [code=1] librz/util/librz_util.so.0.9.0.p/thread.c.o
cc -Ilibrz/util/librz_util.so.0.9.0.p -I. -I.. -Ilibrz -I../librz -Ilibrz/include -I../librz/include -Isubprojects/rzheap -I../subprojects/rzheap -Ilibrz/util/sdb/src -I../librz/util/sdb/src -Isubprojects/pcre2-10.47 -I../subprojects/pcre2-10.47 -I../su
bprojects/pcre2-10.47/src -I../subprojects/softfloat/include -Isubprojects/zlib-1.3.1 -I../subprojects/zlib-1.3.1 -I../subprojects/xz-5.8.1/src/liblzma/api -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O2 -g -DCC_SUPPORTS_W_ENUM
_CONVERION -DCC_SUPPORTS_W_ENUM_COMPARE -std=gnu99 -Werror=sizeof-pointer-memaccess -Wimplicit-fallthrough=3 -fvisibility=hidden -DRZ_PLUGIN_INCORE=1 -DSUPPORTS_PCRE2_JIT -DZYDIS_STATIC_BUILD -D_GNU_SOURCE -fPIC -DLZMA_API_STATIC -pthread -MD -MQ librz/
util/librz_util.so.0.9.0.p/thread.c.o -MF librz/util/librz_util.so.0.9.0.p/thread.c.o.d -o librz/util/librz_util.so.0.9.0.p/thread.c.o -c ../librz/util/thread.c
In file included from ../librz/util/thread.c:7:
../librz/util/thread.h:60:10: fatal error: sys/sysctl.h: No such file or directory
   60 | #include <sys/sysctl.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
[8/478] Compiling C object librz/util/librz_util.so.0.9.0.p/time.c.o
FAILED: [code=1] librz/util/librz_util.so.0.9.0.p/time.c.o
cc -Ilibrz/util/librz_util.so.0.9.0.p -I. -I.. -Ilibrz -I../librz -Ilibrz/include -I../librz/include -Isubprojects/rzheap -I../subprojects/rzheap -Ilibrz/util/sdb/src -I../librz/util/sdb/src -Isubprojects/pcre2-10.47 -I../subprojects/pcre2-10.47 -I../su
bprojects/pcre2-10.47/src -I../subprojects/softfloat/include -Isubprojects/zlib-1.3.1 -I../subprojects/zlib-1.3.1 -I../subprojects/xz-5.8.1/src/liblzma/api -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O2 -g -DCC_SUPPORTS_W_ENUM
_CONVERION -DCC_SUPPORTS_W_ENUM_COMPARE -std=gnu99 -Werror=sizeof-pointer-memaccess -Wimplicit-fallthrough=3 -fvisibility=hidden -DRZ_PLUGIN_INCORE=1 -DSUPPORTS_PCRE2_JIT -DZYDIS_STATIC_BUILD -D_GNU_SOURCE -fPIC -DLZMA_API_STATIC -pthread -MD -MQ librz/
util/librz_util.so.0.9.0.p/time.c.o -MF librz/util/librz_util.so.0.9.0.p/time.c.o.d -o librz/util/librz_util.so.0.9.0.p/time.c.o -c ../librz/util/time.c
../librz/util/time.c: In function 'rz_asctime_r':
../librz/util/time.c:307:16: error: too few arguments to function 'asctime_r'
  307 |         return asctime_r(tm, buf);
      |                ^~~~~~~~~
In file included from /usr/include/sys/time.h:489,
                 from /usr/include/sys/select.h:53,
                 from /usr/include/sys/types.h:687,
                 from ../librz/include/rz_types_base.h:5,
                 from ../librz/include/rz_types.h:180,
                 from ../librz/include/rz_util.h:7,
                 from ../librz/util/time.c:5:
/usr/include/time.h:280:14: note: declared here
  280 | extern char *asctime_r(const struct tm *, char *, int);
      |              ^~~~~~~~~
../librz/util/time.c: In function 'rz_ctime_r':
../librz/util/time.c:317:16: error: too few arguments to function 'ctime_r'
  317 |         return ctime_r(timer, buf);
      |                ^~~~~~~
/usr/include/time.h:281:14: note: declared here
  281 | extern char *ctime_r(const time_t *, char *, int);
      |              ^~~~~~~
../librz/util/time.c: In function 'rz_asctime_r':
../librz/util/time.c:309:1: warning: control reaches end of non-void function [-Wreturn-type]
  309 | }
      | ^
../librz/util/time.c: In function 'rz_ctime_r':
../librz/util/time.c:319:1: warning: control reaches end of non-void function [-Wreturn-type]
  319 | }
      | ^
```

**AI Warning**

To assist with the whack-a-mole process of fixing the C macros, I did work with Claude Code [Opus 4.5] to iterate through the errors. I've confirmed that the resulting binary works perfectly for reverse-engineering ELF and PE binaries, which was my goal.

I'm familiar with C and illumos, but not with rizin internals. The patch seems sane.

**Test plan**

1. Install OmniOS machine
2. Check out rizin with patch
3. `meson setup build && meson compile -C build`
4. `./build/binrz/rizin/rizin <target>`; confirm that basic commands like aa/ii/ij/ih work.

<img width="484" height="863" alt="Screenshot 2026-02-26 at 14 38 07" src="https://github.com/user-attachments/assets/71aa687a-21c3-486b-9dc3-e1886a34a0c7" />

NOTE: The "ERROR: unsupported platform" messages come from librz/debug/p/native/unsupported.c; this PR does not attempt to add live native debugging support (ala ptrace/DebugActiveProcess); this does, however, unblock static analysis and disassembly usecases.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
