### PR TITLE
Add RS08 and HCS12X as new M680X CPU types

### DIFF
--- a/librz/arch/p/analysis/analysis_m680x_cs.c
+++ b/librz/arch/p/analysis/analysis_m680x_cs.c
@@ -12,34 +12,30 @@ static int m680xmode(const char *str) {
 		return CS_MODE_M680X_6800;
 	}
 	// replace this with the asm.features?
-	if (str && (strstr(str, "6800") || strstr(str, "6802") || strstr(str, "6808"))) {
+	else if (str && (strstr(str, "6800") || strstr(str, "6802") || strstr(str, "6808"))) {
 		return CS_MODE_M680X_6800;
-	}
-	if (str && (strstr(str, "6801") || strstr(str, "6803"))) {
+	} else if (str && (strstr(str, "6801") || strstr(str, "6803"))) {
 		return CS_MODE_M680X_6801;
 	} else if (str && strstr(str, "6805")) {
 		return CS_MODE_M680X_6805;
 	} else if (str && strstr(str, "68HC08")) {
 		return CS_MODE_M680X_6808;
-	} else if (strstr(str, "6808")) {
-		return CS_MODE_M680X_6800;
 	} else if (str && strstr(str, "6809")) {
 		return CS_MODE_M680X_6809;
 	} else if (str && strstr(str, "6811")) {
 		return CS_MODE_M680X_6811;
-	}
-	//
-	if (str && strstr(str, "cpu12")) {
+	} else if (str && strstr(str, "cpu12")) {
 		return CS_MODE_M680X_CPU12;
-	}
-	if (str && strstr(str, "6301")) {
+	} else if (str && strstr(str, "6301")) {
 		return CS_MODE_M680X_6301;
-	}
-	if (str && strstr(str, "6309")) {
+	} else if (str && strstr(str, "6309")) {
 		return CS_MODE_M680X_6309;
-	}
-	if (str && strstr(str, "hcs08")) {
+	} else if (str && strstr(str, "hcs08")) {
 		return CS_MODE_M680X_HCS08;
+	} else if (str && strstr(str, "rs08")) {
+		return CS_MODE_M680X_RS08;
+	} else if (strstr(str, "hcs12x")) {
+		return CS_MODE_M680X_HCS12X;
 	}
 	return CS_MODE_M680X_6800;
 }
@@ -120,26 +116,45 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_ADDF:
 	case M680X_INS_ADDR:
 	case M680X_INS_ADDW:
+	case M680X_INS_ADDX:
+	case M680X_INS_ADDY:
+	case M680X_INS_ADED:
+	case M680X_INS_ADEX:
+	case M680X_INS_ADEY:
 		op->type = RZ_ANALYSIS_OP_TYPE_ADD;
 		break;
 	case M680X_INS_AIM:
 	case M680X_INS_AIS:
 	case M680X_INS_AIX:
+		break;
 	case M680X_INS_AND:
 	case M680X_INS_ANDA:
 	case M680X_INS_ANDB:
 	case M680X_INS_ANDCC:
 	case M680X_INS_ANDD:
 	case M680X_INS_ANDR:
+	case M680X_INS_ANDX:
+	case M680X_INS_ANDY:
+		op->type = RZ_ANALYSIS_OP_TYPE_AND;
+		break;
 	case M680X_INS_ASL:
 	case M680X_INS_ASLA:
 	case M680X_INS_ASLB:
 	case M680X_INS_ASLD: ///< or LSLD
+	case M680X_INS_ASLW:
+	case M680X_INS_ASLX:
+	case M680X_INS_ASLY:
+		op->type = RZ_ANALYSIS_OP_TYPE_SAL;
+		break;
 	case M680X_INS_ASR:
 	case M680X_INS_ASRA:
 	case M680X_INS_ASRB:
 	case M680X_INS_ASRD:
+	case M680X_INS_ASRW:
 	case M680X_INS_ASRX:
+	case M680X_INS_ASRY:
+		op->type = RZ_ANALYSIS_OP_TYPE_SAR;
+		break;
 	case M680X_INS_BAND:
 	case M680X_INS_BCC: ///< or BHS
 	case M680X_INS_BCLR:
@@ -156,6 +171,12 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_BITB:
 	case M680X_INS_BITD:
 	case M680X_INS_BITMD:
+	case M680X_INS_BITX:
+	case M680X_INS_BITY:
+	case M680X_INS_BTAS:
+	case M680X_INS_ORX:
+	case M680X_INS_ORY:
+		op->type = RZ_ANALYSIS_OP_TYPE_OR;
 		break;
 	case M680X_INS_BRA:
 		op->type = RZ_ANALYSIS_OP_TYPE_JMP;
@@ -219,6 +240,13 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_CMPW:
 	case M680X_INS_CMPX:
 	case M680X_INS_CMPY:
+	case M680X_INS_CPS:
+	case M680X_INS_CPX: ///< M6800/1/2/3
+	case M680X_INS_CPY:
+	case M680X_INS_CPED:
+	case M680X_INS_CPES:
+	case M680X_INS_CPEX:
+	case M680X_INS_CPEY:
 		op->type = RZ_ANALYSIS_OP_TYPE_CMP;
 		break;
 	case M680X_INS_COM:
@@ -231,9 +259,6 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_COMX:
 	case M680X_INS_CPD:
 	case M680X_INS_CPHX:
-	case M680X_INS_CPS:
-	case M680X_INS_CPX: ///< M6800/1/2/3
-	case M680X_INS_CPY:
 	case M680X_INS_CWAI:
 	case M680X_INS_DAA:
 	case M680X_INS_DBEQ:
@@ -273,6 +298,8 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_EORB:
 	case M680X_INS_EORD:
 	case M680X_INS_EORR:
+	case M680X_INS_EORX:
+	case M680X_INS_EORY:
 		op->type = RZ_ANALYSIS_OP_TYPE_XOR;
 		break;
 	case M680X_INS_ETBL:
@@ -295,6 +322,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_INCF:
 	case M680X_INS_INCW:
 	case M680X_INS_INCX:
+	case M680X_INS_INCY:
 		op->type = RZ_ANALYSIS_OP_TYPE_ADD;
 		break;
 	case M680X_INS_INS: ///< M6800/1/2/3
@@ -335,15 +363,8 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_LDHX:
 	case M680X_INS_LDMD:
 	case M680X_INS_LDQ:
-	case M680X_INS_LDS:
 	case M680X_INS_LDU:
-	case M680X_INS_LDW:
-	case M680X_INS_LDX:
-	case M680X_INS_LDY:
-	case M680X_INS_LEAS:
 	case M680X_INS_LEAU:
-	case M680X_INS_LEAX:
-	case M680X_INS_LEAY:
 	case M680X_INS_LSL:
 	case M680X_INS_LSLA:
 	case M680X_INS_LSLB:
@@ -364,6 +385,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_MOV:
 	case M680X_INS_MOVB:
 	case M680X_INS_MOVW:
+	case M680X_INS_CLRY:
 		op->type = RZ_ANALYSIS_OP_TYPE_MOV;
 		break;
 	case M680X_INS_MUL:
@@ -374,7 +396,10 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_NEGA:
 	case M680X_INS_NEGB:
 	case M680X_INS_NEGD:
+	case M680X_INS_NEGW:
 	case M680X_INS_NEGX:
+	case M680X_INS_NEGY:
+	case M680X_INS_COMY:
 		op->type = RZ_ANALYSIS_OP_TYPE_NOT;
 		break;
 	case M680X_INS_NOP:
@@ -433,6 +458,9 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_SBC:
 	case M680X_INS_SBCA:
 	case M680X_INS_SBCB:
+	case M680X_INS_SBED:
+	case M680X_INS_SBEX:
+	case M680X_INS_SBEY:
 	case M680X_INS_SBCD:
 	case M680X_INS_SBCR:
 	case M680X_INS_SEC:
@@ -440,6 +468,8 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_SEV:
 	case M680X_INS_SEX:
 	case M680X_INS_SEXW:
+	case M680X_INS_SHA: ///< RS08
+	case M680X_INS_SLA: ///< RS08
 	case M680X_INS_SLP:
 	case M680X_INS_STA:
 	case M680X_INS_STAA: ///< M6800/1/2/3
@@ -452,24 +482,26 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_STOP:
 	case M680X_INS_STHX:
 	case M680X_INS_STQ:
-	case M680X_INS_STS:
 	case M680X_INS_STU:
 	case M680X_INS_STW:
-	case M680X_INS_STX:
-	case M680X_INS_STY:
 	case M680X_INS_SUB:
 	case M680X_INS_SUBA:
 	case M680X_INS_SUBB:
 	case M680X_INS_SUBD:
+	case M680X_INS_SUBX:
+	case M680X_INS_SUBY:
 	case M680X_INS_SUBE:
 	case M680X_INS_SUBF:
 	case M680X_INS_SUBR:
 	case M680X_INS_SUBW:
+	case M680X_INS_TSTY:
+	case M680X_INS_DECY:
 		op->type = RZ_ANALYSIS_OP_TYPE_SUB;
 		break;
 	case M680X_INS_SWI:
 	case M680X_INS_SWI2:
 	case M680X_INS_SWI3:
+	case M680X_INS_SYS:
 		op->type = RZ_ANALYSIS_OP_TYPE_SWI;
 		break;
 	case M680X_INS_SYNC:
@@ -507,6 +539,46 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_WAVR:
 	case M680X_INS_XGDX: ///< HD6301
 	case M680X_INS_XGDY:
+		break;
+	case M680X_INS_TRAP:
+		op->type = RZ_ANALYSIS_OP_TYPE_TRAP;
+		break;
+	case M680X_INS_GLDAA:
+	case M680X_INS_GLDAB:
+	case M680X_INS_GLDD:
+	case M680X_INS_GLDS:
+	case M680X_INS_GLDX:
+	case M680X_INS_GLDY:
+	case M680X_INS_LDS:
+	case M680X_INS_LDW:
+	case M680X_INS_LDX:
+	case M680X_INS_LDY:
+	case M680X_INS_LEAX:
+	case M680X_INS_LEAY:
+	case M680X_INS_LEAS:
+	case M680X_INS_PULCW:
+		op->type = RZ_ANALYSIS_OP_TYPE_LOAD;
+		break;
+	case M680X_INS_GSTS:
+	case M680X_INS_GSTD:
+	case M680X_INS_GSTX:
+	case M680X_INS_GSTY:
+	case M680X_INS_STS:
+	case M680X_INS_STX:
+	case M680X_INS_STY:
+	case M680X_INS_PSHCW:
+	case M680X_INS_GSTAB:
+	case M680X_INS_GSTAA:
+		op->type = RZ_ANALYSIS_OP_TYPE_STORE;
+		break;
+	case M680X_INS_RORY:
+		op->type = RZ_ANALYSIS_OP_TYPE_ROR;
+		break;
+	case M680X_INS_ROLY:
+		op->type = RZ_ANALYSIS_OP_TYPE_ROL;
+		break;
+	case M680X_INS_LSRY:
+		op->type = RZ_ANALYSIS_OP_TYPE_SHR;
 		break;
 	}
 beach:

--- a/librz/arch/p/asm/asm_m680x_cs.c
+++ b/librz/arch/p/asm/asm_m680x_cs.c
@@ -15,15 +15,12 @@ static cs_mode m680x_mode(const char *str) {
 	// replace this with the asm.features?
 	if (strstr(str, "6800") || strstr(str, "6802") || strstr(str, "6808")) {
 		return CS_MODE_M680X_6800;
-	}
-	if (strstr(str, "6801") || strstr(str, "6803")) {
+	} else if (strstr(str, "6801") || strstr(str, "6803")) {
 		return CS_MODE_M680X_6801;
 	} else if (strstr(str, "6805")) {
 		return CS_MODE_M680X_6805;
 	} else if (strstr(str, "68HC08")) {
 		return CS_MODE_M680X_6808;
-	} else if (strstr(str, "6808")) {
-		return CS_MODE_M680X_6800;
 	} else if (strstr(str, "6809")) {
 		return CS_MODE_M680X_6809;
 	} else if (strstr(str, "6811")) {
@@ -32,12 +29,14 @@ static cs_mode m680x_mode(const char *str) {
 		return CS_MODE_M680X_CPU12;
 	} else if (strstr(str, "6301")) {
 		return CS_MODE_M680X_6301;
-	}
-	if (strstr(str, "6309")) {
+	} else if (strstr(str, "6309")) {
 		return CS_MODE_M680X_6309;
-	}
-	if (strstr(str, "hcs08")) {
+	} else if (strstr(str, "hcs08")) {
 		return CS_MODE_M680X_HCS08;
+	} else if (strstr(str, "rs08")) {
+		return CS_MODE_M680X_RS08;
+	} else if (strstr(str, "hcs12x")) {
+		return CS_MODE_M680X_HCS12X;
 	}
 	return CS_MODE_M680X_6800;
 }
@@ -97,6 +96,8 @@ static char **m680x_cpu_descriptions() {
 		"6301", "Hitachi 6301: 8-bit microcontroller, CMOS version of 6800",
 		"6309", "Hitachi 6309: CMOS version of 6809",
 		"hcs08", "Freescale HCS08: 8-bit microcontroller family",
+		"RS08", "Freescale RS08: Reduced-resource version of HCS08",
+		"HCS12X", "Freescale HCS12X: 16-bit microcontroller (upwards compatible with cpu12)",
 		NULL
 	};
 	return cpu_desc;
@@ -104,7 +105,7 @@ static char **m680x_cpu_descriptions() {
 
 RzAsmPlugin rz_asm_plugin_m680x_cs = {
 	.name = "m680x",
-	.cpus = "6800,6801,6802,6803,6805,6808,68HC08,6809,6811,cpu12,6301,6309,hcs08",
+	.cpus = "6800,6801,6802,6803,6805,6808,68HC08,6809,6811,cpu12,6301,6309,hcs08,rs08,hcs12x",
 	.desc = "Motorola 680X Capstone-based disassembler",
 	.license = "BSD",
 	.arch = "m680x",

--- a/subprojects/capstone-next.wrap
+++ b/subprojects/capstone-next.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/capstone-engine/capstone.git
-revision = d4e5fa01626adbd347057c0506c8a5230e8d61ac
+revision = 808aee0d225fd75af9162b0e37c8e7982a77b3b5
 directory = capstone-next
 patch_directory = capstone-next
 depth = 1

--- a/test/db/analysis/m680x
+++ b/test/db/analysis/m680x
@@ -29,3 +29,49 @@ a0 = 0x0000
 a1 = 0x0000
 EOF
 RUN
+
+NAME=rs08 and hcs12x
+FILE=malloc://1024
+CMDS=<<EOF
+echo rs08
+e asm.arch=m680x
+e asm.cpu=rs08
+wx 2F5A663E1480738B98DDF6C945424E2080BFAEED
+pi 16
+echo ---
+echo hcs12x
+e asm.cpu=hcs12x
+wx 1892DD18B612341839183512184218A718C0111118C21111188A1111
+pi 9
+EOF
+EXPECT=<<EOF
+rs08
+inc $0f
+dec $0a
+add $06
+mov #20, $80
+sub $03
+clr $0b
+clr $18
+lda $1d
+sta $16
+lda $09
+sha
+sla
+mov $20, $80
+bgnd
+stop
+sta $0d
+---
+hcs12x
+sbex $dd
+gldaa $1234
+pshcw
+btas $12
+incx
+sys
+suby #4369
+sbey $1111
+orx #17
+EOF
+RUN

--- a/test/db/cmd/cmd_aL
+++ b/test/db/cmd/cmd_aL
@@ -155,6 +155,8 @@ cpu12           Motorola 68HC12: 16-bit microcontroller (also abbreviated as 681
 6301            Hitachi 6301: 8-bit microcontroller, CMOS version of 6800
 6309            Hitachi 6309: CMOS version of 6809
 hcs08           Freescale HCS08: 8-bit microcontroller family
+RS08            Freescale RS08: Reduced-resource version of HCS08
+HCS12X          Freescale HCS12X: 16-bit microcontroller (upwards compatible with cpu12)
 68000           Motorola 68000: 16/32-bit CISC microprocessor
 68010           Motorola 68010: 16/32-bit microprocessors. Successor to Motoroloa 68000
 68020           Motorola 68020: 32-bit microprocessor with added instructions and additional addressing modes

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -601,6 +601,8 @@ cpu12           Motorola 68HC12: 16-bit microcontroller (also abbreviated as 681
 6301            Hitachi 6301: 8-bit microcontroller, CMOS version of 6800
 6309            Hitachi 6309: CMOS version of 6809
 hcs08           Freescale HCS08: 8-bit microcontroller family
+RS08            Freescale RS08: Reduced-resource version of HCS08
+HCS12X          Freescale HCS12X: 16-bit microcontroller (upwards compatible with cpu12)
 EOF
 RUN
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
This propagates the changes of https://github.com/capstone-engine/capstone/pull/2872 and https://github.com/capstone-engine/capstone/pull/2898 into rizin.

I have replaced the if statements with else if statements to avoid unnecessary checks once a matching mode is found.

The instruction ids to operations mapping is incomplete and wrong at many places. I will open a separate PR to address them. However, I have correctly mapped them for the `RS08` and `HCS12X` specific instructions.

**Test plan**
Added a test in `test/db/analysis/m680x`
Updated the tests in `test/db/tools/rz_asm` and `test/db/cmd/cmd_aL`

**Closing issues**
Partially addresses #5933 