### PR TITLE
Change `ht` string hash function to be endian agnostic

### DIFF
--- a/librz/include/rz_util/ht_inc.h
+++ b/librz/include/rz_util/ht_inc.h
@@ -129,25 +129,22 @@ static inline ut32 ht_default_hash_string(const char *key, ut32 len) {
 	ut64 result = 0xff51afd7ed558ccdULL;
 
 	while (len >= 16) {
-		ut64 blocks[2];
-		memcpy(blocks, key, sizeof(ut64) * 2);
-		result += (result << 5) ^ (blocks[0] * prime1);
-		result += (result << 5) ^ (blocks[1] * prime1);
+		ut128 block = rz_read_le128(key);
+		result += (result << 5) ^ (block.Low * prime1);
+		result += (result << 5) ^ (block.High * prime1);
 		len -= 16;
 		key += 16;
 	}
 
 	while (len >= 8) {
-		ut64 block = 0;
-		memcpy(&block, key, sizeof(ut64));
+		ut64 block = rz_read_le64(key);
 		result += (result << 5) ^ (block * prime1);
 		len -= 8;
 		key += 8;
 	}
 
 	while (len >= 4) {
-		ut32 block = 0;
-		memcpy(&block, key, sizeof(ut32));
+		ut32 block = rz_read_le32(key);
 		result += (result << 5) ^ (block * prime1);
 		len -= 4;
 		key += 4;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

The current `ht` default hash string function uses `memcpy` which generates different hash in big endian archs, and breaks tests relying on `ht` iteration order.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Existing tests should pass.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None
