### PR TITLE
Enable SSE2 explictly on all targets which support it

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -520,11 +520,17 @@ foreach it : ccs
   endforeach
 
   # Try to compile a basic SSE2 code snippet to discover if SSE2 is supported for the target arch
+  sse2_compiler_flag = it_cc.get_id() == 'msvc' ? '/arch:SSE2' : '-msse2'
   sse2_code = '''#include <emmintrin.h>
     int main (int argc, char *argv[]) { __m128i v = _mm_set_epi32(2, 3, 0, 1); return 0; }
   '''
-  has_sse2 = it_cc.compiles(sse2_code, args : '-msse2', name: 'SSE2 code snippet')
+  has_sse2 = it_cc.compiles(sse2_code, args : [sse2_compiler_flag], name: 'SSE2 code snippet')
   it_userconf.set10('HAVE_SSE2', has_sse2)
+
+  # Enable SSE2 compiler support since it may not be enabled by default
+  if has_sse2 and it_machine.cpu_family() in ['x86', 'x86_64']
+    add_project_arguments([sse2_compiler_flag], language: 'c', native: it_native)
+  endif
 
   foreach item : [
       ['linux/ashmem.h', '', []],


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Meson passes `-msse2` flag when testing for SSE2 support, but not when doing the actual build, which causes the build to fail for targets which support SSE2, but it's not enabled by default.

This PR changes the build file to pass the SSE2 flag explicitly.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Existing tests should pass.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None
