### PR TITLE
util: Extend string search with user-defined printable characters

### DIFF
--- a/librz/bin/bfile_string.c
+++ b/librz/bin/bfile_string.c
@@ -23,6 +23,8 @@ typedef struct shared_data_t {
 	size_t min_str_length;
 	bool check_ascii_freq;
 	bool prefer_big_endian;
+	RzCodePoint *user_unprintable;
+	size_t user_unprintable_count;
 } SharedData;
 
 typedef struct search_thread_data_t {
@@ -233,6 +235,8 @@ static RzList /*<RzDetectedString *>*/ *string_scan_range(SharedData *shared, co
 		.min_str_length = shared->min_str_length,
 		.prefer_big_endian = shared->prefer_big_endian,
 		.check_ascii_freq = shared->check_ascii_freq,
+		.user_unprintable = shared->user_unprintable,
+		.user_unprintable_count = shared->user_unprintable_count,
 	};
 
 	ut8 *buf = calloc(interval_size, 1);
@@ -462,6 +466,8 @@ RZ_API void rz_bin_string_search_opt_init(RZ_NONNULL RzBinStringSearchOpt *opt) 
 	opt->raw_alignment = RZ_BIN_STRING_SEARCH_RAW_FILE_ALIGNMENT;
 	opt->string_encoding = RZ_STRING_ENC_GUESS;
 	opt->check_ascii_freq = RZ_BIN_STRING_SEARCH_CHECK_ASCII_FREQ;
+	opt->user_unprintable = NULL;
+	opt->user_unprintable_count = 0;
 	opt->mode = RZ_BIN_STRING_SEARCH_MODE_AUTO;
 }
 
@@ -656,6 +662,8 @@ RZ_API RZ_OWN RzPVector /*<RzBinString *>*/ *rz_bin_file_strings(RZ_NONNULL RzBi
 		.min_str_length = opt->min_length,
 		.check_ascii_freq = opt->check_ascii_freq,
 		.prefer_big_endian = prefer_big_endian,
+		.user_unprintable = opt->user_unprintable,
+		.user_unprintable_count = opt->user_unprintable_count,
 	};
 
 	if (shared.min_str_length < 1) {

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -525,6 +525,7 @@ RZ_API void rz_bin_free(RZ_NULLABLE RzBin *bin) {
 	bin->file = NULL;
 	free(bin->force);
 	free(bin->srcdir);
+	free(bin->str_search_cfg.user_unprintable);
 	// rz_bin_free_bin_files (bin);
 	rz_list_free(bin->binfiles);
 

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -79,6 +79,8 @@ static bool find_string_at(RzCore *core, RzBinObject *bobj, ut64 pointer, char *
 		.min_str_length = bin->str_search_cfg.min_length,
 		.prefer_big_endian = core->analysis->big_endian,
 		.check_ascii_freq = bin->str_search_cfg.check_ascii_freq,
+		.user_unprintable = bin->str_search_cfg.user_unprintable,
+		.user_unprintable_count = bin->str_search_cfg.user_unprintable_count,
 	};
 
 	rz_io_pread_at(core->io, pointer, buffer, sizeof(buffer));

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -1017,6 +1017,7 @@ static bool cb_str_unprintable(void *user, void *data) {
 		rz_cons_printf("Comma-separated list of Unicode code points treated as non-printable.\n");
 		rz_cons_printf("Examples:\n");
 		rz_cons_printf("  e str.unprintable=0x09,0x0a,0x0d,0x1b\n");
+		rz_cons_printf("  e str.unprintable=0x200B\n");
 		rz_cons_printf("  e str.unprintable=\n");
 		return false;
 	}

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -1010,6 +1010,69 @@ static bool cb_str_encoding(void *user, void *data) {
 	return true;
 }
 
+static bool cb_str_unprintable(void *user, void *data) {
+	RzCore *core = (RzCore *)user;
+	RzConfigNode *node = (RzConfigNode *)data;
+	if (node->value[0] == '?') {
+		rz_cons_printf("Comma-separated list of Unicode code points treated as non-printable.\n");
+		rz_cons_printf("Examples:\n");
+		rz_cons_printf("  e str.unprintable=0x09,0x0a,0x0d,0x1b\n");
+		rz_cons_printf("  e str.unprintable=\n");
+		return false;
+	}
+
+	if (RZ_STR_ISEMPTY(node->value)) {
+		free(core->bin->str_search_cfg.user_unprintable);
+		core->bin->str_search_cfg.user_unprintable = NULL;
+		core->bin->str_search_cfg.user_unprintable_count = 0;
+		check_reload_bin_str_search(core);
+		return true;
+	}
+
+	char *list = rz_str_dup(node->value);
+	if (!list) {
+		return false;
+	}
+
+	int argc = rz_str_split(list, ',');
+	if (argc < 1) {
+		free(list);
+		return false;
+	}
+
+	RzCodePoint *custom = RZ_NEWS(RzCodePoint, argc);
+	if (!custom) {
+		free(list);
+		return false;
+	}
+
+	size_t custom_count = 0;
+	for (int i = 0; i < argc; i++) {
+		const char *word = rz_str_word_get0(list, i);
+		if (RZ_STR_ISEMPTY(word) || !rz_is_valid_input_num_value(core->num, word)) {
+			RZ_LOG_ERROR("Invalid value for str.unprintable (%s).\n", word ? word : "");
+			free(custom);
+			free(list);
+			return false;
+		}
+		ut64 cp = rz_num_math(core->num, word);
+		if (cp > RZ_UNICODE_LAST_CODE_POINT) {
+			RZ_LOG_ERROR("str.unprintable code point out of range (%s).\n", word);
+			free(custom);
+			free(list);
+			return false;
+		}
+		custom[custom_count++] = (RzCodePoint)cp;
+	}
+	free(list);
+
+	free(core->bin->str_search_cfg.user_unprintable);
+	core->bin->str_search_cfg.user_unprintable = custom;
+	core->bin->str_search_cfg.user_unprintable_count = custom_count;
+	check_reload_bin_str_search(core);
+	return true;
+}
+
 static bool cb_str_search_mode(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
@@ -3549,6 +3612,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	n = NODECB("str.encoding", "guess", &cb_str_encoding);
 	SETDESC(n, "The default string encoding type (when set to guess, it is automatically guessed).");
 	SETOPTIONS(n, "ascii", "8bit", "utf8", "utf16le", "utf32le", "utf16be", "utf32be", "ibm037", "ibm290", "ebcdices", "ebcdicuk", "ebcdicus", "guess", NULL);
+	SETCB("str.unprintable", "", &cb_str_unprintable, "Comma-separated hex code points treated as non-printable.");
 
 	/* string search options */
 	SETB("str.search.reload", true, "When enabled, any change to any option `str.search.*` will reload the bin strings.");

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -1629,6 +1629,8 @@ static void print_json_string(RzCore *core, const ut8 *block, ut32 len, RzStrEnc
 	opt.json = true;
 	opt.stop_at_nil = stop_at_nil;
 	opt.stop_at_unprintable = stop_at_unprintable;
+	opt.user_unprintable = core->bin->str_search_cfg.user_unprintable;
+	opt.user_unprintable_count = core->bin->str_search_cfg.user_unprintable_count;
 	char *dstring = rz_str_stringify_raw_buffer(&opt, &dlength);
 	if (!dstring) {
 		free(section);
@@ -1850,10 +1852,12 @@ static RzCmdStatus core_print_string_in_block(RzCore *core, bool stop_at_nil, bo
 		opt.encoding = encoding;
 		opt.stop_at_nil = stop_at_nil;
 		opt.stop_at_unprintable = stop_at_unprintable;
+		opt.user_unprintable = core->bin->str_search_cfg.user_unprintable;
+		opt.user_unprintable_count = core->bin->str_search_cfg.user_unprintable_count;
 		core_print_raw_buffer(&opt);
 		break;
 	case RZ_OUTPUT_MODE_JSON:
-		print_json_string(core, buffer, length, encoding, stop_at_nil, stop_at_nil);
+		print_json_string(core, buffer, length, encoding, stop_at_nil, stop_at_unprintable);
 		break;
 	default:
 		RZ_LOG_ERROR("core: unsupported output mode\n");

--- a/librz/core/cmeta.c
+++ b/librz/core/cmeta.c
@@ -379,6 +379,8 @@ static bool meta_string_guess_add(RzCore *core, ut64 addr, size_t limit, char **
 		.min_str_length = bin->str_search_cfg.min_length,
 		.prefer_big_endian = big_endian,
 		.check_ascii_freq = bin->str_search_cfg.check_ascii_freq,
+		.user_unprintable = bin->str_search_cfg.user_unprintable,
+		.user_unprintable_count = bin->str_search_cfg.user_unprintable_count,
 	};
 	RzList *str_list = rz_list_new();
 	if (!str_list) {

--- a/librz/core/csearch.c
+++ b/librz/core/csearch.c
@@ -268,6 +268,8 @@ RZ_API RZ_OWN RzList /*<RzSearchHit *>*/ *rz_core_search_string(RZ_NONNULL RzCor
 		.min_str_length = RZ_MAX(re_pattern_len, core->bin->str_search_cfg.min_length),
 		.prefer_big_endian = core->analysis->big_endian,
 		.check_ascii_freq = core->bin->str_search_cfg.check_ascii_freq,
+		.user_unprintable = core->bin->str_search_cfg.user_unprintable,
+		.user_unprintable_count = core->bin->str_search_cfg.user_unprintable_count,
 	};
 
 	RzList *hits = NULL;

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -211,6 +211,8 @@ typedef struct rz_bin_string_search_opt_t {
 	 */
 	size_t raw_alignment;
 	bool check_ascii_freq; ///< If true, perform check on ASCII frequencies when looking for false positives
+	RzCodePoint *user_unprintable; ///< User-defined non-printable code points
+	size_t user_unprintable_count; ///< Number of user-defined non-printable code points
 	RzStrEnc string_encoding; ///< The default string encoding type (when set to guess, it is automatically guessed).
 	RzBinStringSearchMode mode; ///< String search mode (auto, ro sections or raw binary)
 } RzBinStringSearchOpt;

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -287,6 +287,8 @@ typedef struct rz_str_stringify_opt_t {
 	bool stop_at_nil; ///< When enabled stops printing when '\0' is found.
 	bool stop_at_unprintable; ///< When enabled stops printing at first non-printable character.
 	bool urlencode; ///< Encodes the output following RFC 3986.
+	ut32 *user_unprintable; ///< User-defined non-printable code points.
+	size_t user_unprintable_count; ///< Number of user-defined non-printable code points.
 } RzStrStringifyOpt;
 
 RZ_API RzStrEnc rz_str_guess_encoding_from_buffer(RZ_NONNULL const ut8 *buffer, ut32 length);

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -287,7 +287,7 @@ typedef struct rz_str_stringify_opt_t {
 	bool stop_at_nil; ///< When enabled stops printing when '\0' is found.
 	bool stop_at_unprintable; ///< When enabled stops printing at first non-printable character.
 	bool urlencode; ///< Encodes the output following RFC 3986.
-	ut32 *user_unprintable; ///< User-defined non-printable code points.
+	RzCodePoint *user_unprintable; ///< User-defined non-printable code points.
 	size_t user_unprintable_count; ///< Number of user-defined non-printable code points.
 } RzStrStringifyOpt;
 

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -287,7 +287,7 @@ typedef struct rz_str_stringify_opt_t {
 	bool stop_at_nil; ///< When enabled stops printing when '\0' is found.
 	bool stop_at_unprintable; ///< When enabled stops printing at first non-printable character.
 	bool urlencode; ///< Encodes the output following RFC 3986.
-	RzCodePoint *user_unprintable; ///< User-defined non-printable code points.
+	ut32 *user_unprintable; ///< User-defined non-printable code points (array of Unicode code points).
 	size_t user_unprintable_count; ///< Number of user-defined non-printable code points.
 } RzStrStringifyOpt;
 

--- a/librz/include/rz_util/rz_str_search.h
+++ b/librz/include/rz_util/rz_str_search.h
@@ -21,7 +21,6 @@ typedef struct {
 	ut64 addr; ///< Address/offset of the string in the RzBuffer
 	ut32 size; ///< Size of buffer containing the string in bytes
 	ut32 length; ///< Length of string in chars
-	ut32 grapheme_length; ///< Length of string in grapheme clusters
 	RzStrEnc encoding; ///< String encoding in memory.
 	size_t alignment; ///< The address alignment a matched string must have. If search.align is set, both must match.
 	/**

--- a/librz/include/rz_util/rz_str_search.h
+++ b/librz/include/rz_util/rz_str_search.h
@@ -2,6 +2,7 @@
 #define RZ_STR_SEARCH_H
 
 #include <rz_util/rz_str.h>
+#include <rz_util/rz_unicode.h>
 #include <rz_util/rz_assert.h>
 #include <rz_util/rz_buf.h>
 #include <rz_util/rz_regex.h>
@@ -20,6 +21,7 @@ typedef struct {
 	ut64 addr; ///< Address/offset of the string in the RzBuffer
 	ut32 size; ///< Size of buffer containing the string in bytes
 	ut32 length; ///< Length of string in chars
+	ut32 grapheme_length; ///< Length of string in grapheme clusters
 	RzStrEnc encoding; ///< String encoding in memory.
 	size_t alignment; ///< The address alignment a matched string must have. If search.align is set, both must match.
 	/**
@@ -41,6 +43,8 @@ typedef struct {
 	size_t min_str_length; ///< Minimum string length
 	bool prefer_big_endian; ///< True if the preferred endianess for UTF strings is big-endian
 	bool check_ascii_freq; ///< If true, perform check on ASCII frequencies when looking for false positives
+	RzCodePoint *user_unprintable; ///< User-defined non-printable code points
+	size_t user_unprintable_count; ///< Number of user-defined non-printable code points
 } RzUtilStrScanOptions;
 
 RZ_API void rz_detected_string_free(RzDetectedString *str);

--- a/librz/include/rz_util/rz_unicode.h
+++ b/librz/include/rz_util/rz_unicode.h
@@ -51,6 +51,7 @@ typedef struct rz_unicode_case_mapping_t {
 typedef RzUnicodeCaseMapping RzUnicodeCaseMap[];
 
 RZ_API bool rz_unicode_code_point_is_printable(const RzCodePoint c);
+RZ_API bool rz_unicode_code_point_is_printable_user(const RzCodePoint c, const RzCodePoint *user_unprintable, size_t user_unprintable_count);
 RZ_API bool rz_unicode_code_point_is_defined(const RzCodePoint c);
 RZ_API bool rz_unicode_code_point_is_legal_decode(const RzCodePoint c);
 RZ_API bool rz_unicode_code_point_is_control(const RzCodePoint c);

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -4182,6 +4182,15 @@ RZ_API RzStrEnc rz_str_guess_encoding_from_buffer(RZ_NONNULL const ut8 *buffer, 
  * \param  length The real string length.
  * \return The stringified raw buffer
  */
+static inline bool is_user_defined_unprintable(const RzStrStringifyOpt *option, RzCodePoint cp) {
+	for (size_t i = 0; option && option->user_unprintable && i < option->user_unprintable_count; i++) {
+		if (option->user_unprintable[i] == cp) {
+			return true;
+		}
+	}
+	return false;
+}
+
 RZ_API RZ_OWN char *rz_str_stringify_raw_buffer(RzStrStringifyOpt *option, RZ_NULLABLE RZ_OUT ut32 *length) {
 	rz_return_val_if_fail(option && option->buffer && option->encoding != RZ_STRING_ENC_GUESS, NULL);
 	if (option->length < 1) {
@@ -4323,7 +4332,8 @@ RZ_API RZ_OWN char *rz_str_stringify_raw_buffer(RzStrStringifyOpt *option, RZ_NU
 		} else {
 			if (code_point == '\\') {
 				rz_strbuf_appendf(&sb, "\\\\");
-			} else if ((code_point == '\n' && !option->escape_nl) || (rz_unicode_code_point_is_printable(code_point))) {
+			} else if ((code_point == '\n' && !option->escape_nl && !is_user_defined_unprintable(option, code_point)) ||
+				rz_unicode_code_point_is_printable_user(code_point, option->user_unprintable, option->user_unprintable_count)) {
 				char tmp[5] = { 0 };
 				rz_utf8_encode((ut8 *)tmp, code_point);
 				rz_strbuf_appendf(&sb, "%s", tmp);

--- a/librz/util/str_search.c
+++ b/librz/util/str_search.c
@@ -89,6 +89,46 @@ static inline bool is_c_escape_sequence(char ch) {
 	return strchr("\b\v\f\n\r\t\a\033\\", ch);
 }
 
+static inline bool is_combining_mark(RzCodePoint cp) {
+	return (cp >= 0x0300u && cp <= 0x036Fu) ||
+		(cp >= 0x1AB0u && cp <= 0x1AFFu) ||
+		(cp >= 0x1DC0u && cp <= 0x1DFFu) ||
+		(cp >= 0x20D0u && cp <= 0x20FFu) ||
+		(cp >= 0xFE20u && cp <= 0xFE2Fu);
+}
+
+static ut32 count_graphemes(const char *utf8_str, int byte_len) {
+	if (!utf8_str || byte_len <= 0) {
+		return 0;
+	}
+
+	ut32 grapheme_count = 0;
+	for (int i = 0; i < byte_len;) {
+		RzCodePoint cp = 0;
+		int cp_bytes = rz_utf8_decode((const ut8 *)utf8_str + i, byte_len - i, &cp, false);
+		if (!cp_bytes) {
+			// If an invalid sequence slips in, consume one byte and keep progress.
+			grapheme_count++;
+			i++;
+			continue;
+		}
+		if (!is_combining_mark(cp) || grapheme_count == 0) {
+			grapheme_count++;
+		}
+		i += cp_bytes;
+	}
+	return grapheme_count;
+}
+
+static inline bool is_user_defined_unprintable(const RzUtilStrScanOptions *opt, RzCodePoint cp) {
+	for (size_t i = 0; opt && opt->user_unprintable && i < opt->user_unprintable_count; i++) {
+		if (opt->user_unprintable[i] == cp) {
+			return true;
+		}
+	}
+	return false;
+}
+
 static UTF8StringInfo calculate_utf8_string_info(ut8 *str, int size) {
 	UTF8StringInfo res = {
 		.num_ascii = 0,
@@ -351,10 +391,11 @@ static RzDetectedString *process_one_string(const ut8 *buf, const ut64 from, ut6
 			output_buf = heap_alloc;
 		}
 
-		if (rz_unicode_code_point_is_printable(ucp) && ucp != '\\') {
+		bool user_defined_unprintable = is_user_defined_unprintable(opt, ucp);
+		if (rz_unicode_code_point_is_printable_user(ucp, opt->user_unprintable, opt->user_unprintable_count) && ucp != '\\') {
 			char_bytes = rz_utf8_encode(output_buf + i, ucp);
 			char_count++;
-		} else if (ucp && ucp < 0x100 && is_c_escape_sequence((char)ucp)) {
+		} else if (!user_defined_unprintable && ucp && ucp < 0x100 && is_c_escape_sequence((char)ucp)) {
 			if ((i + 32) < opt->max_str_length && ucp < 93) {
 				char_bytes = rz_utf8_encode(output_buf + i, ucp);
 			} else {
@@ -389,6 +430,7 @@ static RzDetectedString *process_one_string(const ut8 *buf, const ut64 from, ut6
 		}
 		ds->encoding = str_type;
 		ds->length = char_count;
+		ds->grapheme_length = count_graphemes((const char *)output_buf, strbuf_size);
 		ds->size = needle - str_addr;
 		if (stopped_with_undef_cp) {
 			// The decoding stops if a byte sequence is an undefined unicode code point.
@@ -595,7 +637,7 @@ RZ_API int rz_scan_strings_raw(RZ_NONNULL const ut8 *buf, RZ_NONNULL RzList /*<R
 				int i = 0;
 				for (; i < sz; i++) {
 					rz_str_ibm037_to_unicode(ptr[i], &code_points[i]);
-					if (!rz_unicode_code_point_is_printable(code_points[i])) {
+					if (!rz_unicode_code_point_is_printable_user(code_points[i], opt->user_unprintable, opt->user_unprintable_count)) {
 						break;
 					}
 				}

--- a/librz/util/str_search.c
+++ b/librz/util/str_search.c
@@ -89,37 +89,6 @@ static inline bool is_c_escape_sequence(char ch) {
 	return strchr("\b\v\f\n\r\t\a\033\\", ch);
 }
 
-static inline bool is_combining_mark(RzCodePoint cp) {
-	return (cp >= 0x0300u && cp <= 0x036Fu) ||
-		(cp >= 0x1AB0u && cp <= 0x1AFFu) ||
-		(cp >= 0x1DC0u && cp <= 0x1DFFu) ||
-		(cp >= 0x20D0u && cp <= 0x20FFu) ||
-		(cp >= 0xFE20u && cp <= 0xFE2Fu);
-}
-
-static ut32 count_graphemes(const char *utf8_str, int byte_len) {
-	if (!utf8_str || byte_len <= 0) {
-		return 0;
-	}
-
-	ut32 grapheme_count = 0;
-	for (int i = 0; i < byte_len;) {
-		RzCodePoint cp = 0;
-		int cp_bytes = rz_utf8_decode((const ut8 *)utf8_str + i, byte_len - i, &cp, false);
-		if (!cp_bytes) {
-			// If an invalid sequence slips in, consume one byte and keep progress.
-			grapheme_count++;
-			i++;
-			continue;
-		}
-		if (!is_combining_mark(cp) || grapheme_count == 0) {
-			grapheme_count++;
-		}
-		i += cp_bytes;
-	}
-	return grapheme_count;
-}
-
 static inline bool is_user_defined_unprintable(const RzUtilStrScanOptions *opt, RzCodePoint cp) {
 	for (size_t i = 0; opt && opt->user_unprintable && i < opt->user_unprintable_count; i++) {
 		if (opt->user_unprintable[i] == cp) {
@@ -430,7 +399,6 @@ static RzDetectedString *process_one_string(const ut8 *buf, const ut64 from, ut6
 		}
 		ds->encoding = str_type;
 		ds->length = char_count;
-		ds->grapheme_length = count_graphemes((const char *)output_buf, strbuf_size);
 		ds->size = needle - str_addr;
 		if (stopped_with_undef_cp) {
 			// The decoding stops if a byte sequence is an undefined unicode code point.

--- a/librz/util/unicode.c
+++ b/librz/util/unicode.c
@@ -1028,6 +1028,15 @@ RZ_API bool rz_unicode_code_point_is_printable(const RzCodePoint c) {
 		!rz_unicode_code_point_is_private(c);
 }
 
+RZ_API bool rz_unicode_code_point_is_printable_user(const RzCodePoint c, const RzCodePoint *user_unprintable, size_t user_unprintable_count) {
+	for (size_t i = 0; user_unprintable && i < user_unprintable_count; i++) {
+		if (user_unprintable[i] == c) {
+			return false;
+		}
+	}
+	return rz_unicode_code_point_is_printable(c);
+}
+
 static RzUnicodeCaseMapping bin_search_case_mapping(const RzUnicodeCaseMap map, size_t n, RzCodePoint key) {
 	size_t lo = 0, hi = n;
 	while (lo < hi) {

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -334,6 +334,7 @@ ps utf8 unprintable @ hit.string.utf8.0
 EOF
 EXPECT=<<EOF
 0x00000116 43 hit.string.utf8.0 43
+
 EOF
 EXPECT_ERR=
 RUN

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -294,6 +294,45 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=String Search - str.unprintable - single code point
+FILE=bins/cmd/search/string_encodings/Latin-Lipsum.ascii
+CMDS=<<EOF
+/z "placerat ut, eu etiam vitae nam" l ascii
+e str.unprintable=0x20
+/z "placerat ut, eu etiam vitae nam" l ascii
+EOF
+EXPECT=<<EOF
+0x000000fa 31 hit.string.ascii.0 31
+EOF
+EXPECT_ERR=
+RUN
+
+NAME=String Search - str.unprintable - multiple code points
+FILE=bins/cmd/search/string_encodings/Latin-Lipsum.ascii
+CMDS=<<EOF
+/z "placerat ut, eu etiam vitae nam" l ascii
+e str.unprintable=0x20,0x2c
+/z "placerat ut, eu etiam vitae nam" l ascii
+EOF
+EXPECT=<<EOF
+0x000000fa 31 hit.string.ascii.0 31
+EOF
+EXPECT_ERR=
+RUN
+
+NAME=String Search - str.unprintable - utf8 code point
+FILE=bins/cmd/search/string_encodings/Arabic-Lipsum.utf8
+CMDS=<<EOF
+/z "ا الأوضاع, لم بوابة المب" l utf8
+e str.unprintable=0x627
+/z "ا الأوضاع, لم بوابة المب" l utf8
+EOF
+EXPECT=<<EOF
+0x00000116 43 hit.string.utf8.0 43
+EOF
+EXPECT_ERR=
+RUN
+
 NAME=String Search - Encoding: utf8 - Arabic
 FILE=bins/cmd/search/string_encodings/Arabic-Lipsum.utf8
 CMDS=<<EOF

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -335,7 +335,7 @@ ps utf8 unprintable @ hit.string.utf8.0
 EOF
 EXPECT=<<EOF
 0x00000116 43 hit.string.utf8.0 43
-ا الأوضاع, لم بوا
+ا الأوضاع, لم بواب
 EOF
 EXPECT_ERR=
 RUN

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -328,13 +328,14 @@ NAME=String Search - str.unprintable - utf8 code point
 FILE=bins/cmd/search/string_encodings/Arabic-Lipsum.utf8
 CMDS=<<EOF
 /z "ا الأوضاع, لم بوابة المب" l utf8
-e str.unprintable=0x627
+e str.unprintable=0x629
 /z "ا الأوضاع, لم بوابة المب" l utf8
+b 0x1000
 ps utf8 unprintable @ hit.string.utf8.0
 EOF
 EXPECT=<<EOF
 0x00000116 43 hit.string.utf8.0 43
-
+ا الأوضاع, لم بوا
 EOF
 EXPECT_ERR=
 RUN

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -300,9 +300,11 @@ CMDS=<<EOF
 /z "placerat ut, eu etiam vitae nam" l ascii
 e str.unprintable=0x20
 /z "placerat ut, eu etiam vitae nam" l ascii
+ps ascii unprintable @ hit.string.ascii.0
 EOF
 EXPECT=<<EOF
 0x000000fa 31 hit.string.ascii.0 31
+placerat
 EOF
 EXPECT_ERR=
 RUN
@@ -313,9 +315,11 @@ CMDS=<<EOF
 /z "placerat ut, eu etiam vitae nam" l ascii
 e str.unprintable=0x20,0x2c
 /z "placerat ut, eu etiam vitae nam" l ascii
+ps ascii unprintable @ hit.string.ascii.0
 EOF
 EXPECT=<<EOF
 0x000000fa 31 hit.string.ascii.0 31
+placerat
 EOF
 EXPECT_ERR=
 RUN
@@ -326,6 +330,7 @@ CMDS=<<EOF
 /z "ا الأوضاع, لم بوابة المب" l utf8
 e str.unprintable=0x627
 /z "ا الأوضاع, لم بوابة المب" l utf8
+ps utf8 unprintable @ hit.string.utf8.0
 EOF
 EXPECT=<<EOF
 0x00000116 43 hit.string.utf8.0 43

--- a/test/integration/test_str_search.c
+++ b/test/integration/test_str_search.c
@@ -123,6 +123,8 @@ int test_rz_str_search_single_simple(void) {
 
 	rz_search_collection_free(collection);
 	rz_list_free(hits);
+	rz_search_opt_free(search_opts);
+	rz_buf_free(file_buffer);
 	mu_end;
 }
 
@@ -282,6 +284,8 @@ int test_rz_str_search_multiple_enc(void) {
 
 	rz_list_free(hits);
 	rz_search_collection_free(collection);
+	rz_search_opt_free(search_opts);
+	rz_buf_free(file_buffer);
 	mu_end;
 }
 

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -233,7 +233,7 @@ bool test_rz_scan_strings_user_unprintable(void) {
 }
 
 bool test_rz_scan_strings_user_unprintable_utf8(void) {
-	static const unsigned char str[] = "ab\xc3\xa9" "cd";
+	static const unsigned char str[] = "ab\xC3\xA9cd";
 	static RzCodePoint user_unprintable[] = { 0x00e9 };
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 	RzUtilStrScanOptions opt = g_opt;

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -233,7 +233,7 @@ bool test_rz_scan_strings_user_unprintable(void) {
 }
 
 bool test_rz_scan_strings_user_unprintable_utf8(void) {
-	static const unsigned char str[] = "ab\xc3\xa9cd";
+	static const unsigned char str[] = "ab\xc3\xa9" "cd";
 	static RzCodePoint user_unprintable[] = { 0x00e9 };
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 	RzUtilStrScanOptions opt = g_opt;

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -232,21 +232,24 @@ bool test_rz_scan_strings_user_unprintable(void) {
 	mu_end;
 }
 
-bool test_rz_scan_strings_grapheme_length(void) {
-	static const unsigned char str[] = "e\xcc\x81x\x00";
+bool test_rz_scan_strings_user_unprintable_utf8(void) {
+	static const unsigned char str[] = "ab\xc3\xa9cd";
+	static RzCodePoint user_unprintable[] = { 0x00e9 };
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 	RzUtilStrScanOptions opt = g_opt;
-	opt.min_str_length = 1;
+	opt.user_unprintable = user_unprintable;
+	opt.user_unprintable_count = RZ_ARRAY_SIZE(user_unprintable);
+	opt.min_str_length = 2;
 	opt.check_ascii_freq = false;
 
 	RzList *str_list = rz_list_newf((RzListFree)rz_detected_string_free);
 	int n = rz_scan_strings(buf, str_list, &opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_UTF8);
-	mu_assert_eq(n, 1, "rz_scan_strings grapheme length, number of strings");
+	mu_assert_eq(n, 2, "rz_scan_strings user_unprintable utf8, number of strings");
 
-	RzDetectedString *s = rz_list_get_n(str_list, 0);
-	mu_assert_streq(s->string, "e\xcc\x81x", "rz_scan_strings grapheme length, string");
-	mu_assert_eq(s->length, 3, "rz_scan_strings grapheme length, code point length");
-	mu_assert_eq(s->grapheme_length, 2, "rz_scan_strings grapheme length, grapheme length");
+	RzDetectedString *s0 = rz_list_get_n(str_list, 0);
+	RzDetectedString *s1 = rz_list_get_n(str_list, 1);
+	mu_assert_streq(s0->string, "ab", "rz_scan_strings user_unprintable utf8, first string");
+	mu_assert_streq(s1->string, "cd", "rz_scan_strings user_unprintable utf8, second string");
 
 	rz_list_free(str_list);
 	rz_buf_free(buf);
@@ -507,7 +510,7 @@ bool all_tests() {
 	mu_run_test(test_rz_scan_strings_detect_utf16_le);
 	mu_run_test(test_rz_scan_strings_detect_utf16_le_special_chars);
 	mu_run_test(test_rz_scan_strings_user_unprintable);
-	mu_run_test(test_rz_scan_strings_grapheme_length);
+	mu_run_test(test_rz_scan_strings_user_unprintable_utf8);
 	mu_run_test(test_rz_scan_strings_detect_utf16_be);
 	mu_run_test(test_rz_scan_strings_detect_utf32_le);
 	mu_run_test(test_rz_scan_strings_detect_utf32_be);

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -203,6 +203,57 @@ bool test_rz_scan_strings_detect_utf16_le_special_chars(void) {
 	mu_end;
 }
 
+bool test_rz_scan_strings_user_unprintable(void) {
+	// ASCII/UTF-8 string: "hello\tworld\ntest\0"
+	// With \t (0x09) and \n (0x0a) as user-defined non-printable,
+	// the scanner should produce: "hello", "world", "test"
+	static const unsigned char str[] = "hello\tworld\ntest";
+	static RzCodePoint user_unprintable[] = { 0x09, 0x0a };
+	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
+	RzUtilStrScanOptions opt = g_opt;
+	opt.user_unprintable = user_unprintable;
+	opt.user_unprintable_count = RZ_ARRAY_SIZE(user_unprintable);
+	opt.min_str_length = 4;
+
+	RzList *str_list = rz_list_newf((RzListFree)rz_detected_string_free);
+	int n = rz_scan_strings(buf, str_list, &opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_8BIT);
+	mu_assert_eq(n, 3, "rz_scan_strings user_unprintable, number of strings");
+
+	RzDetectedString *s0 = rz_list_get_n(str_list, 0);
+	RzDetectedString *s1 = rz_list_get_n(str_list, 1);
+	RzDetectedString *s2 = rz_list_get_n(str_list, 2);
+	mu_assert_streq(s0->string, "hello", "rz_scan_strings user_unprintable, first string");
+	mu_assert_streq(s1->string, "world", "rz_scan_strings user_unprintable, second string");
+	mu_assert_streq(s2->string, "test", "rz_scan_strings user_unprintable, third string");
+
+	rz_list_free(str_list);
+	rz_buf_free(buf);
+
+	mu_end;
+}
+
+bool test_rz_scan_strings_grapheme_length(void) {
+	static const unsigned char str[] = "e\xcc\x81x\x00";
+	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
+	RzUtilStrScanOptions opt = g_opt;
+	opt.min_str_length = 1;
+	opt.check_ascii_freq = false;
+
+	RzList *str_list = rz_list_newf((RzListFree)rz_detected_string_free);
+	int n = rz_scan_strings(buf, str_list, &opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_UTF8);
+	mu_assert_eq(n, 1, "rz_scan_strings grapheme length, number of strings");
+
+	RzDetectedString *s = rz_list_get_n(str_list, 0);
+	mu_assert_streq(s->string, "e\xcc\x81x", "rz_scan_strings grapheme length, string");
+	mu_assert_eq(s->length, 3, "rz_scan_strings grapheme length, code point length");
+	mu_assert_eq(s->grapheme_length, 2, "rz_scan_strings grapheme length, grapheme length");
+
+	rz_list_free(str_list);
+	rz_buf_free(buf);
+
+	mu_end;
+}
+
 bool test_rz_scan_strings_detect_utf16_be(void) {
 	static const unsigned char str[] =
 		"\xff\xff\xff\x00\x49\x00\x20\x00\x61\x00\x6d\x00\x20\x00\x61"
@@ -455,6 +506,8 @@ bool all_tests() {
 	mu_run_test(test_rz_scan_strings_detect_utf8);
 	mu_run_test(test_rz_scan_strings_detect_utf16_le);
 	mu_run_test(test_rz_scan_strings_detect_utf16_le_special_chars);
+	mu_run_test(test_rz_scan_strings_user_unprintable);
+	mu_run_test(test_rz_scan_strings_grapheme_length);
 	mu_run_test(test_rz_scan_strings_detect_utf16_be);
 	mu_run_test(test_rz_scan_strings_detect_utf32_le);
 	mu_run_test(test_rz_scan_strings_detect_utf32_be);


### PR DESCRIPTION
## Your checklist for this pull request

- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository
- [x] I made sure to follow the project's coding style
- [x] I've documented or updated the documentation of every function and struct/union this PR changes (Doxygen-style inline docs)
- [x] I've added tests that prove my fix is effective or that my feature works
- [x] I've updated the relevant documentation or made a note that it needs updating

## Description

Closes #4930

Extend string search to support **user-defined non-printable characters** via a new `str.unprintable` config option (comma-separated hex code points).

A new `rz_unicode_code_point_is_printable_user()` function checks user overrides before falling back to the standard printability check. When a code point in that list is encountered during string scanning, it acts as a string terminator.

### Changes made

* Add `rz_unicode_code_point_is_printable_user()` in `librz/util/unicode.c`
* Add `str.unprintable` config option in `librz/core/cconfig.c` (with UTF-8 formatting-char example)
* Add `user_unprintable` / `user_unprintable_count` to `RzUtilStrScanOptions` and `RzStrStringifyOpt`
* Wire user-defined unprintable through all callers including `core_print_string_in_block` and `print_json_string`
* Add unit tests for ASCII and UTF-8 user-defined unprintable split behaviour
* Add `cmd_search_z` regression tests confirming search stops at the configured code point