### PR TITLE
fix const-discarding warnings from strchr/strstr

### DIFF
--- a/librz/arch/p/asm/asm_x86_nz.c
+++ b/librz/arch/p/asm/asm_x86_nz.c
@@ -4871,7 +4871,7 @@ static Register parseReg(RzAsm *a, const char *str, size_t *pos, ut32 *type) {
 static void parse_segment_offset(RzAsm *a, const char *str, size_t *pos,
 	Operand *op, int reg_index) {
 	int nextpos = *pos;
-	char *c = strchr(str + nextpos, ':');
+	const char *c = strchr(str + nextpos, ':');
 	if (c) {
 		nextpos++; // Skip the ':'
 		c = strchr(str + nextpos, '[');
@@ -4883,7 +4883,7 @@ static void parse_segment_offset(RzAsm *a, const char *str, size_t *pos,
 		op->regs[reg_index] = op->reg;
 		op->type |= OT_MEMORY;
 		op->offset_sign = 1;
-		char *p = strchr(str + nextpos, '-');
+		const char *p = strchr(str + nextpos, '-');
 		if (p) {
 			op->offset_sign = -1;
 			nextpos++;
@@ -5028,7 +5028,7 @@ static int parseOperand(RzAsm *a, const char *str, Operand *op, bool isrepop) {
 					op->type = 0; // Make the result invalid
 				}
 			} else {
-				char *p = strchr(str, '+');
+				const char *p = strchr(str, '+');
 				op->offset_sign = 1;
 				if (!p) {
 					p = strchr(str, '-');
@@ -5037,9 +5037,9 @@ static int parseOperand(RzAsm *a, const char *str, Operand *op, bool isrepop) {
 					}
 				}
 				// with SIB notation, we need to consider the right sign
-				char *plus = strchr(str, '+');
-				char *minus = strchr(str, '-');
-				char *closeB = strchr(str, ']');
+				const char *plus = strchr(str, '+');
+				const char *minus = strchr(str, '-');
+				const char *closeB = strchr(str, ']');
 				if (plus && minus && plus < closeB && minus < closeB) {
 					op->offset_sign = -1;
 				}
@@ -5087,7 +5087,7 @@ static int parseOperand(RzAsm *a, const char *str, Operand *op, bool isrepop) {
 				op->is_good_flag = true;
 			}
 
-			char *p = strchr(str, '-');
+			const char *p = strchr(str, '-');
 			if (p) {
 				op->sign = -1;
 				str = ++p;
@@ -5101,7 +5101,7 @@ static int parseOperand(RzAsm *a, const char *str, Operand *op, bool isrepop) {
 		// We don't know the size, so let's just set no size flag.
 		op->type = OT_CONSTANT;
 		op->sign = 1;
-		char *p = strchr(str, '-');
+		const char *p = strchr(str, '-');
 		if (p) {
 			op->sign = -1;
 			str = ++p;
@@ -5119,7 +5119,7 @@ static int parseOpcode(RzAsm *a, const char *op, Opcode *out) {
 		out->has_bnd = true;
 		op += 4;
 	}
-	char *args = strchr(op, ' ');
+	const char *args = strchr(op, ' ');
 	out->mnemonic = args ? rz_str_ndup(op, args - op) : rz_str_dup(op);
 	out->operands[0].type = out->operands[1].type = 0;
 	out->operands[0].extended = out->operands[1].extended = false;

--- a/librz/cons/grep.c
+++ b/librz/cons/grep.c
@@ -614,7 +614,7 @@ RZ_API void rz_cons_grepbuf(void) {
 	cons->lines = 0;
 	// used to count lines and change negative grep.line values
 	while ((int)(size_t)(in - buf) < len) {
-		char *p = strchr(in, '\n');
+		const char *p = strchr(in, '\n');
 		if (!p) {
 			break;
 		}
@@ -640,7 +640,7 @@ RZ_API void rz_cons_grepbuf(void) {
 	bool is_range_line_grep_only = grep->range_line != 2 && !*grep->str;
 	in = buf;
 	while ((int)(size_t)(in - buf) < len) {
-		char *p = strchr(in, '\n');
+		const char *p = strchr(in, '\n');
 		if (!p) {
 			break;
 		}

--- a/librz/cons/html.c
+++ b/librz/cons/html.c
@@ -140,14 +140,14 @@ RZ_API char *rz_cons_html_filter(const char *ptr, int *newlen) {
 				str = ptr;
 				continue;
 			} else if (!strncmp(ptr, "48;5;", 5) || !strncmp(ptr, "48;2;", 5)) {
-				char *end = strchr(ptr, 'm');
+				const char *end = strchr(ptr, 'm');
 				gethtmlrgb(ptr, background_color);
 				need_to_set = true;
 				ptr = end;
 				str = ptr + 1;
 				esc = 0;
 			} else if (!strncmp(ptr, "38;5;", 5) || !strncmp(ptr, "38;2;", 5)) {
-				char *end = strchr(ptr, 'm');
+				const char *end = strchr(ptr, 'm');
 				gethtmlrgb(ptr, text_color);
 				need_to_set = true;
 				ptr = end;

--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -3008,7 +3008,7 @@ RZ_API int rz_core_flush(RzCore *core, const char *cmd) {
 
 RZ_API char *rz_core_cmd_str_pipe(RzCore *core, const char *cmd) {
 	char *tmp = NULL;
-	char *p = (*cmd != '"') ? strchr(cmd, '|') : NULL;
+	const char *p = (*cmd != '"') ? strchr(cmd, '|') : NULL;
 	if (!p && *cmd != '!' && *cmd != '.') {
 		return rz_core_cmd_str(core, cmd);
 	}

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -824,7 +824,7 @@ static void do_asm_search(RzCore *core, struct search_parameters *param, const c
 	bool regexp = input[0] == '/'; // "/c/"
 	bool everyByte = regexp && input[1] == 'a';
 	char tmpbuf[128];
-	char *end_cmd = strchr(input, ' ');
+	const char *end_cmd = strchr(input, ' ');
 	switch ((end_cmd ? *(end_cmd - 1) : input[0])) {
 	case 'j':
 		param->outmode = RZ_OUTPUT_MODE_JSON;

--- a/librz/core/cmd/cmd_seek.c
+++ b/librz/core/cmd/cmd_seek.c
@@ -160,7 +160,7 @@ RZ_IPI RzCmdStatus rz_seek_handler(RzCore *core, int argc, const char **argv) {
 	rz_core_seek_mark(core);
 
 	// NOTE: hack to make it work with local function labels
-	char *ptr;
+	const char *ptr;
 	if ((ptr = strstr(argv[1], "+.")) != NULL) {
 		char *dup = rz_str_dup(argv[1]);
 		dup[ptr - argv[1]] = '\x00';

--- a/librz/core/cmd/cmd_shell.c
+++ b/librz/core/cmd/cmd_shell.c
@@ -121,7 +121,7 @@ static char *syscmd_ls(RZ_NONNULL const int argc, const char **argv) {
 	char *res = NULL;
 	const char *path = ".";
 	char *d = NULL;
-	char *p = NULL;
+	const char *p = NULL;
 	char *homepath = NULL;
 	char *pattern = NULL;
 	int printfmt = 0;
@@ -715,7 +715,7 @@ RZ_API RZ_OWN char *rz_core_clippy(RZ_NONNULL RzCore *core, RZ_NONNULL const cha
 	rz_return_val_if_fail(core && msg, NULL);
 	int type = RZ_AVATAR_CLIPPY;
 	if (*msg == '+' || *msg == '3') {
-		char *space = strchr(msg, ' ');
+		const char *space = strchr(msg, ' ');
 		if (!space) {
 			return NULL;
 		}

--- a/librz/core/cprint.c
+++ b/librz/core/cprint.c
@@ -719,7 +719,7 @@ RZ_API RZ_OWN char *rz_core_print_disasm_strings(RZ_NONNULL RzCore *core, RzCore
 		const char *linecolor = NULL;
 		char *string = NULL;
 		if (qo) {
-			char *qoe = strrchr(qo + 1, '"');
+			const char *qoe = strrchr(qo + 1, '"');
 			if (qoe) {
 				int raw_len = qoe - qo - 1;
 				int actual_len = 0;
@@ -758,7 +758,7 @@ RZ_API RZ_OWN char *rz_core_print_disasm_strings(RZ_NONNULL RzCore *core, RzCore
 		}
 		char *string2 = NULL;
 		if (ox) {
-			char *qoe = strchr(ox + 3, ' ');
+			const char *qoe = strchr(ox + 3, ' ');
 			if (!qoe) {
 				qoe = strchr(ox + 3, '\x1b');
 			}

--- a/librz/debug/p/native/linux/linux_debug.c
+++ b/librz/debug/p/native/linux/linux_debug.c
@@ -757,7 +757,7 @@ RzDebugPid *fill_pid_info(const char *info, const char *path, int tid) {
 	if (!pid_info) {
 		return NULL;
 	}
-	char *ptr = strstr(info, "State:");
+	const char *ptr = strstr(info, "State:");
 	if (ptr) {
 		switch (*(ptr + 7)) {
 		case 'R':

--- a/librz/egg/emit/x86.c
+++ b/librz/egg/emit/x86.c
@@ -365,7 +365,7 @@ static void emit_trap(RzEgg *egg) {
 static void emit_load_ptr(RzEgg *egg, const char *dst) {
 	int d = atoi(dst);
 	if (d == 0) { // hack to handle stackvarptrz
-		char *p = strchr(dst, '+');
+		const char *p = strchr(dst, '+');
 		if (p) {
 			d = atoi(p + 1);
 		}

--- a/librz/socket/socket_http.c
+++ b/librz/socket/socket_http.c
@@ -77,7 +77,7 @@ static char *socket_http_answer(RzSocket *s, int *code, int *rlen, ut32 redirect
 			goto exit;
 		}
 		p += strlen("Location:");
-		char *end_url = strchr(p, '\n');
+		const char *end_url = strchr(p, '\n');
 		if (end_url) {
 			int url_len = end_url - p;
 			char *url = rz_str_ndup(p, url_len);

--- a/librz/type/format.c
+++ b/librz/type/format.c
@@ -1833,10 +1833,10 @@ beach:
 
 static char *get_args_offset(const char *arg) {
 	char *args = strchr(arg, ' ');
-	char *sq_bracket = strchr(arg, '[');
+	const char *sq_bracket = strchr(arg, '[');
 	int max = 30;
 	if (args && sq_bracket) {
-		char *csq_bracket = strchr(arg, ']');
+		const char *csq_bracket = strchr(arg, ']');
 		while (args && csq_bracket && csq_bracket > args && max--) {
 			args = strchr(csq_bracket, ' ');
 		}
@@ -1959,7 +1959,8 @@ static int rz_type_format_data_internal(RZ_BORROW RzTypeDB *typedb, RzPrint *p, 
 	const char *formatname, int mode, const char *setval, char *ofield) {
 	int nargs, i, invalid, nexti, idx, times, otimes, endian, isptr = 0;
 	const int old_bits = typedb->target->bits;
-	char *args = NULL, *bracket, tmp, last = 0;
+	char *args = NULL, tmp, last = 0;
+	const char *bracket;
 	ut64 addr = 0, addr64 = 0, seeki = 0;
 	char namefmt[32], *field = NULL;
 	const char *arg = NULL;

--- a/librz/util/hex.c
+++ b/librz/util/hex.c
@@ -104,7 +104,7 @@ static const char *skip_comment_py(const char *code) {
 	if (*code != '#') {
 		return code;
 	}
-	char *end = strchr(code, '\n');
+	const char *end = strchr(code, '\n');
 	if (end) {
 		code = end;
 	}
@@ -118,7 +118,7 @@ RZ_API char *rz_hex_from_py_array(char *out, const char *code) {
 	}
 	code++;
 	for (; *code; code++) {
-		char *comma = strchr(code, ',');
+		const char *comma = strchr(code, ',');
 		if (!comma) {
 			comma = strchr(code, ']');
 		}
@@ -233,14 +233,14 @@ RZ_API char *rz_hex_from_c_str(char *out, const char **code) {
 
 const char *skip_comment_c(const char *code) {
 	if (!strncmp(code, "/*", 2)) {
-		char *end = strstr(code, "*/");
+		const char *end = strstr(code, "*/");
 		if (end) {
 			code = end + 2;
 		} else {
 			eprintf("Missing closing comment\n");
 		}
 	} else if (!strncmp(code, "//", 2)) {
-		char *end = strchr(code, '\n');
+		const char *end = strchr(code, '\n');
 		if (end) {
 			code = end + 2;
 		}
@@ -329,15 +329,15 @@ RZ_API char *rz_hex_from_c(const char *code) {
 }
 
 RZ_API char *rz_hex_from_js(const char *code) {
-	char *s1 = strchr(code, '\'');
-	char *s2 = strchr(code, '"');
+	const char *s1 = strchr(code, '\'');
+	const char *s2 = strchr(code, '"');
 
 	/* there are no strings in the input */
 	if (!(s1 || s2)) {
 		return NULL;
 	}
 
-	char *start, *end;
+	const char *start, *end;
 	if (s1 < s2) {
 		start = s1;
 		end = strchr(start + 1, '\'');

--- a/librz/util/sdb/src/array.c
+++ b/librz/util/sdb/src/array.c
@@ -93,7 +93,8 @@ RZ_API bool sdb_array_get_num(RZ_NONNULL RZ_BORROW Sdb *s, RZ_NONNULL const char
 RZ_API char *sdb_array_get(Sdb *s, const char *key, int idx) {
 	const char *str = sdb_const_get(s, key);
 	const char *p = str;
-	char *o, *n;
+	const char *n;
+	char *o;
 	int i, len;
 	if (!str || !*str) {
 		return NULL;

--- a/librz/util/sdb/src/fmt.c
+++ b/librz/util/sdb/src/fmt.c
@@ -64,7 +64,7 @@ RZ_API char *sdb_fmt_tostr(void *p, const char *fmt) {
 }
 
 static const char *sdb_anext2(const char *str, const char **next) {
-	char *nxt, *p = strchr(str, SDB_RS);
+	const char *nxt, *p = strchr(str, SDB_RS);
 	if (p) {
 		nxt = p + 1;
 	} else {

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -270,7 +270,7 @@ RZ_API ut64 rz_str_bits_from_string(const char *buf, const char *bitz) {
 	ut64 out = 0LL;
 	/* return the numeric value associated to a string (rflags) */
 	for (; *buf; buf++) {
-		char *ch = strchr(bitz, toupper((const unsigned char)*buf));
+		const char *ch = strchr(bitz, toupper((const unsigned char)*buf));
 		if (!ch) {
 			ch = strchr(bitz, tolower((const unsigned char)*buf));
 		}
@@ -2475,7 +2475,7 @@ RZ_API bool rz_str_glob(const char *str, const char *glob) {
 	if (!glob) {
 		return true;
 	}
-	char *begin = strchr(glob, '^');
+	const char *begin = strchr(glob, '^');
 	if (begin) {
 		glob = ++begin;
 	}
@@ -3249,14 +3249,14 @@ RZ_API char *rz_str_prefix_all(const char *s, const char *pfx) {
 #define HASCH(x) strchr(input_value, x)
 #define CAST     (void *)(size_t)
 RZ_API ut8 rz_str_contains_macro(const char *input_value) {
-	char *has_tilde = input_value ? HASCH('~') : NULL,
-	     *has_bang = input_value ? HASCH('!') : NULL,
-	     *has_brace = input_value ? CAST(HASCH('[') || HASCH(']')) : NULL,
-	     *has_paren = input_value ? CAST(HASCH('(') || HASCH(')')) : NULL,
-	     *has_cbrace = input_value ? CAST(HASCH('{') || HASCH('}')) : NULL,
-	     *has_qmark = input_value ? HASCH('?') : NULL,
-	     *has_colon = input_value ? HASCH(':') : NULL,
-	     *has_at = input_value ? strchr(input_value, '@') : NULL;
+	const char *has_tilde = input_value ? HASCH('~') : NULL,
+		   *has_bang = input_value ? HASCH('!') : NULL,
+		   *has_brace = input_value ? CAST(HASCH('[') || HASCH(']')) : NULL,
+		   *has_paren = input_value ? CAST(HASCH('(') || HASCH(')')) : NULL,
+		   *has_cbrace = input_value ? CAST(HASCH('{') || HASCH('}')) : NULL,
+		   *has_qmark = input_value ? HASCH('?') : NULL,
+		   *has_colon = input_value ? HASCH(':') : NULL,
+		   *has_at = input_value ? strchr(input_value, '@') : NULL;
 
 	return has_tilde || has_bang || has_brace || has_cbrace || has_qmark || has_paren || has_colon || has_at;
 }
@@ -3438,7 +3438,7 @@ RZ_API RZ_OWN char *rz_str_repeat(const char *str, ut16 times) {
 }
 
 RZ_API char *rz_str_between(const char *cmt, const char *prefix, const char *suffix) {
-	char *c0, *c1;
+	const char *c0, *c1;
 	if (!cmt || !prefix || !suffix || !*cmt) {
 		return NULL;
 	}
@@ -3741,7 +3741,7 @@ RZ_API bool rz_str_isnumber(const char *str) {
 
 /* TODO: optimize to start searching by the end of the string */
 RZ_API const char *rz_str_last(const char *str, const char *ch) {
-	char *ptr, *end = NULL;
+	const char *ptr, *end = NULL;
 	if (!str || !ch) {
 		return NULL;
 	}

--- a/librz/util/sys.c
+++ b/librz/util/sys.c
@@ -952,7 +952,7 @@ RZ_API void rz_sys_perror_str(const char *fun) {
 }
 
 RZ_API bool rz_sys_arch_match(const char *archstr, const char *arch) {
-	char *ptr;
+	const char *ptr;
 	if (!archstr || !arch || !*archstr || !*arch) {
 		return true;
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Fixes -Wdiscarded-qualifiers warnings across 15 files where strchr,
strstr, and strrchr return values were stored in non-const char*
pointers despite the pointed-to data never being modified.

Some cases were intentionally left unchanged, where pointers are used for
in-place string mutation.

Tested: 130 tests pass, 16 integration test failures are pre-existing
on dev and unrelated to these changes.