### PR TITLE
ht_inc: Rename `slots` to `slots_`

### DIFF
--- a/librz/include/rz_util/ht_inc.h
+++ b/librz/include/rz_util/ht_inc.h
@@ -246,9 +246,9 @@ typedef struct Ht_(t) {
 	ut32 size; ///< Number of stored elements.
 	ut32 growth_left; ///< Number of empty slots.
 	RZ_BORROW ut8 *ctrl; ///< Control bytes (metadata) - point to the beginning of the `data` pointer.
-	RZ_BORROW HT_(Kv) *slots; ///< Main array (no buckets) - points to an offset after the `data` pointer.
+	RZ_BORROW HT_(Kv) *slots_; ///< Main array (no buckets) - points to an offset after the `data` pointer.
 	HT_(Options) opt; ///< Methods
-	ut8 *data; ///< Single allocation for `ctrl` and `slots` arrays.
+	ut8 *data; ///< Single allocation for `ctrl` and `slots_` arrays.
 } HtName_(Ht);
 
 typedef struct Ht_(iter_mut_t) {

--- a/librz/util/ht/ht_inc.c
+++ b/librz/util/ht/ht_inc.c
@@ -61,10 +61,10 @@ typedef ut64 group_t;
 // Slot addressing is different depending on whether custom elem_size is used
 #ifdef HT_ENABLE_CUSTOM_ELEM_SIZE
 #define HT_SLOT_AT(ht, index) \
-	((HT_(Kv) *)((ut8 *)(ht->slots) + index * ht->opt.elem_size))
+	((HT_(Kv) *)((ut8 *)(ht->slots_) + index * ht->opt.elem_size))
 #else
 #define HT_SLOT_AT(ht, index) \
-	(&(ht)->slots[(index)])
+	(&(ht)->slots_[(index)])
 #endif
 
 // Helper macro for implementing an unrolled foreach loop
@@ -319,7 +319,7 @@ static RZ_OWN HtName_(Ht) *internal_ht_new(ut32 requested_capacity, HT_(Options)
 	}
 
 	ht->ctrl = ht->data;
-	ht->slots = (HT_(Kv) *)(ht->data + ctrl_size);
+	ht->slots_ = (HT_(Kv) *)(ht->data + ctrl_size);
 
 	// Initialize all slots as empty
 	memset(ht->ctrl, H2_STATUS_EMPTY, ctrl_size);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr renames `slots` to `slots_` in `ht_inc` because `slots` is effectively a [reserved keyword in Qt](https://doc.qt.io/qt-6/signalsandslots.html#a-small-example) and so using it breaks the Cutter build with errors of the following form:

```c
In file included from /.../include/librz/rz_util/ht_ss.h:16,
                 from /.../include/librz/rz_util/rz_th_ht.h:14:
/.../librz/rz_util/ht_inc.h:249:33: error: expected unqualified-id before ‘;’ token
  249 |         RZ_BORROW HT_(Kv) *slots; ///< Main array (no buckets) - points to an offset after the `data` pointer.
```

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
