### PR TITLE
Improve performance of utf string processing and `io_memory_read`

### DIFF
--- a/librz/io/io_memory.c
+++ b/librz/io/io_memory.c
@@ -95,12 +95,13 @@ bool io_memory_resize(RzIO *io, RzIODesc *fd, ut64 count) {
 }
 
 int io_memory_read(RzIO *io, RzIODesc *fd, ut8 *buf, size_t count) {
-	memset(buf, 0xff, count);
 	if (!fd || !fd->data) {
+		memset(buf, 0xff, count);
 		return -1;
 	}
 	ut32 mallocsz = _io_malloc_sz(fd);
 	if (_io_malloc_off(fd) > mallocsz) {
+		memset(buf, 0xff, count);
 		return -1;
 	}
 	if (_io_malloc_off(fd) + count >= mallocsz) {

--- a/librz/io/io_memory.c
+++ b/librz/io/io_memory.c
@@ -105,7 +105,9 @@ int io_memory_read(RzIO *io, RzIODesc *fd, ut8 *buf, size_t count) {
 		return -1;
 	}
 	if (_io_malloc_off(fd) + count >= mallocsz) {
-		count = mallocsz - _io_malloc_off(fd);
+		size_t new_count = mallocsz - _io_malloc_off(fd);
+		memset(buf + new_count, 0xff, count - new_count);
+		count = new_count;
 	}
 	memcpy(buf, _io_malloc_buf(fd) + _io_malloc_off(fd), count);
 	_io_malloc_set_off(fd, _io_malloc_off(fd) + count);

--- a/librz/util/str_search.c
+++ b/librz/util/str_search.c
@@ -240,13 +240,18 @@ static inline size_t buf_look_ahead(const RzUtilStrScanOptions *opt, RzStrEnc en
 #define SCANNING_STACK_BUF_CHARS 16
 #define SCANNING_STACK_BUF_SIZE  (RZ_UNICODE_MAX_BYTES_PER_CHAR * SCANNING_STACK_BUF_CHARS)
 
-static void add_byte_mem_mapping(ut64 **byte_mem_map, size_t *byte_mem_map_size, size_t utf8_char_offset, size_t mem_offset) {
-	size_t size = *byte_mem_map_size;
-	if (!*byte_mem_map) {
-		*byte_mem_map = RZ_NEWS0(ut64, SCANNING_STACK_BUF_SIZE);
-		*byte_mem_map_size += SCANNING_STACK_BUF_SIZE;
-	} else if (utf8_char_offset >= size) {
-		*byte_mem_map = realloc(*byte_mem_map, (size + SCANNING_STACK_BUF_SIZE) * sizeof(ut64));
+static void add_byte_mem_mapping(ut64 **byte_mem_map, ut64 *byte_mm_stack_alloc, size_t *byte_mem_map_size, size_t utf8_char_offset, size_t mem_offset) {
+	size_t current_size = *byte_mem_map_size;
+	if (utf8_char_offset >= current_size) {
+		ut32 new_size = current_size + SCANNING_STACK_BUF_SIZE;
+		if (*byte_mem_map == byte_mm_stack_alloc) {
+			// Switch from stack-allocated to heap-allocated memory map
+			*byte_mem_map = RZ_NEWS0(ut64, new_size);
+			rz_mem_copy(*byte_mem_map, new_size * sizeof(ut64), byte_mm_stack_alloc, current_size * sizeof(ut64));
+		} else {
+			// Extend the heap-allocated memory map
+			*byte_mem_map = realloc(*byte_mem_map, new_size * sizeof(ut64));
+		}
 		*byte_mem_map_size += SCANNING_STACK_BUF_SIZE;
 	}
 	if (utf8_char_offset >= *byte_mem_map_size) {
@@ -271,8 +276,9 @@ static RzDetectedString *process_one_string(const ut8 *buf, const ut64 from, ut6
 	// Gets only set if the stack buffer is full.
 	ut8 *heap_alloc = NULL;
 	ut8 *output_buf = stack_alloc;
-	ut64 *byte_mem_map = NULL;
-	size_t byte_mem_map_size = 0;
+	ut64 byte_mm_stack_alloc[SCANNING_STACK_BUF_SIZE] = { 0 };
+	ut64 *byte_mem_map = byte_mm_stack_alloc;
+	size_t byte_mem_map_size = SCANNING_STACK_BUF_SIZE;
 
 	ut64 str_addr = needle;
 	// Bytes of a decoded/encoded character/code point.
@@ -335,7 +341,7 @@ static RzDetectedString *process_one_string(const ut8 *buf, const ut64 from, ut6
 		}
 
 		if (!rz_string_enc_same_char_width_as_utf8(str_type)) {
-			add_byte_mem_mapping(&byte_mem_map, &byte_mem_map_size, i, needle);
+			add_byte_mem_mapping(&byte_mem_map, byte_mm_stack_alloc, &byte_mem_map_size, i, needle);
 		}
 
 		needle += char_bytes;
@@ -368,7 +374,7 @@ static RzDetectedString *process_one_string(const ut8 *buf, const ut64 from, ut6
 			break;
 		}
 	}
-	add_byte_mem_mapping(&byte_mem_map, &byte_mem_map_size, i, needle);
+	add_byte_mem_mapping(&byte_mem_map, byte_mm_stack_alloc, &byte_mem_map_size, i, needle);
 
 	int strbuf_size = i;
 	if (char_count >= opt->min_str_length && char_count <= opt->max_str_length) {
@@ -378,7 +384,9 @@ static RzDetectedString *process_one_string(const ut8 *buf, const ut64 from, ut6
 				goto error;
 			} else if (false_positive_result == RETRY_ASCII) {
 				free(heap_alloc);
-				free(byte_mem_map);
+				if (byte_mem_map != byte_mm_stack_alloc) {
+					free(byte_mem_map);
+				}
 				return process_one_string(buf, from, str_addr, to, str_type, true, opt, false);
 			}
 		}
@@ -397,7 +405,12 @@ static RzDetectedString *process_one_string(const ut8 *buf, const ut64 from, ut6
 			ds->size -= char_bytes;
 		}
 		ds->addr = str_addr;
-		ds->byte_mem_map = byte_mem_map;
+		if (byte_mem_map == byte_mm_stack_alloc) {
+			ds->byte_mem_map = RZ_NEWS0(ut64, byte_mem_map_size);
+			rz_mem_copy(ds->byte_mem_map, byte_mem_map_size * sizeof(ut64), byte_mm_stack_alloc, sizeof(byte_mm_stack_alloc));
+		} else {
+			ds->byte_mem_map = byte_mem_map;
+		}
 
 		ut64 off_adj = adjust_offset(str_type, buf, ds->addr - from);
 		ds->addr -= off_adj;
@@ -408,7 +421,9 @@ static RzDetectedString *process_one_string(const ut8 *buf, const ut64 from, ut6
 	}
 
 error:
-	free(byte_mem_map);
+	if (byte_mem_map != byte_mm_stack_alloc) {
+		free(byte_mem_map);
+	}
 	free(heap_alloc);
 	return NULL;
 }

--- a/librz/util/str_search.c
+++ b/librz/util/str_search.c
@@ -237,7 +237,7 @@ static inline size_t buf_look_ahead(const RzUtilStrScanOptions *opt, RzStrEnc en
  * it is copied to the heap.
  * Used to save unnecessary memory allocations.
  */
-#define SCANNING_STACK_BUF_CHARS 16
+#define SCANNING_STACK_BUF_CHARS 8
 #define SCANNING_STACK_BUF_SIZE  (RZ_UNICODE_MAX_BYTES_PER_CHAR * SCANNING_STACK_BUF_CHARS)
 
 static void add_byte_mem_mapping(ut64 **byte_mem_map, ut64 *byte_mm_stack_alloc, size_t *byte_mem_map_size, size_t utf8_char_offset, size_t mem_offset) {

--- a/librz/util/unicode.c
+++ b/librz/util/unicode.c
@@ -903,6 +903,50 @@ static const RzUnicodeCaseMap uppercase_mapping = {
 };
 
 // clang-format on
+static ut64 *undefined_ranges_bitmap = NULL;
+static ut32 undefined_ranges_bitmap_size = 0;
+static ut32 undefined_ranges_skip_entries = 0;
+
+#ifdef RZ_DEFINE_CONSTRUCTOR_NEEDS_PRAGMA
+#pragma RZ_DEFINE_CONSTRUCTOR_PRAGMA_ARGS(undefined_ranges_bitmap_bake)
+#endif
+RZ_DEFINE_CONSTRUCTOR(undefined_ranges_bitmap_bake)
+static void undefined_ranges_bitmap_bake(void) {
+	const ut32 bits_per_element = sizeof(undefined_ranges_bitmap[0]) * 8;
+	undefined_ranges_bitmap_size = 0x110000;
+	undefined_ranges_bitmap = RZ_NEWS0(ut64, (undefined_ranges_bitmap_size + (bits_per_element - 1)) / bits_per_element);
+
+	for (ut32 table_index = 0; table_index < RZ_ARRAY_SIZE(undefined_ranges); table_index++) {
+		ut32 from = undefined_ranges[table_index].from;
+		ut32 to = RZ_MIN(undefined_ranges[table_index].to + 1, undefined_ranges_bitmap_size);
+
+		for (RzCodePoint code = from; code < to; code++) { // todo: confirm range inclusion/exclusion
+			undefined_ranges_bitmap[code / bits_per_element] |= 1ull << (code % bits_per_element);
+		}
+
+		if (undefined_ranges[table_index].to >= undefined_ranges_bitmap_size) {
+			// For table entries not covered by the bitmap, fallback to binary search but skip the already covered entries
+			undefined_ranges_skip_entries = table_index;
+			break;
+		}
+	}
+}
+
+#ifdef RZ_DEFINE_DESTRUCTOR_NEEDS_PRAGMA
+#pragma RZ_DEFINE_DESTRUCTOR_PRAGMA_ARGS(undefined_ranges_bitmap_fini)
+#endif
+RZ_DEFINE_DESTRUCTOR(undefined_ranges_bitmap_fini)
+static void undefined_ranges_bitmap_fini(void) {
+	free(undefined_ranges_bitmap);
+}
+
+/**
+ * Note: undefined for `code_point` >= `undefined_ranges_bitmap_size`. Caller should do proper checks.
+ */
+static inline bool undefined_ranges_bitmap_at(RzCodePoint index) {
+	const ut32 bits_per_element = sizeof(undefined_ranges_bitmap[0]) * 8;
+	return (undefined_ranges_bitmap[index / bits_per_element] & (1ull << (index % bits_per_element))) != 0;
+}
 
 static bool bin_search_range(RzCodePoint cp, const RzUnicodeRangeTable table, size_t table_size) {
 	size_t low = 0;
@@ -938,7 +982,10 @@ RZ_API bool rz_unicode_code_point_is_defined(const RzCodePoint c) {
 	if (c > RZ_UNICODE_LAST_CODE_POINT) {
 		return false;
 	}
-	return !bin_search_range(c, undefined_ranges, RZ_ARRAY_SIZE(undefined_ranges));
+	if (c < undefined_ranges_bitmap_size) {
+		return !undefined_ranges_bitmap_at(c);
+	}
+	return !bin_search_range(c, undefined_ranges + undefined_ranges_skip_entries, RZ_ARRAY_SIZE(undefined_ranges) - undefined_ranges_skip_entries);
 }
 
 /**

--- a/librz/util/unicode.c
+++ b/librz/util/unicode.c
@@ -907,9 +907,10 @@ static ut64 *undefined_ranges_bitmap = NULL;
 static ut32 undefined_ranges_bitmap_size = 0;
 static ut32 undefined_ranges_skip_entries = 0;
 
+#ifdef RZ_HAS_CONSTRUCTORS
 #ifdef RZ_DEFINE_CONSTRUCTOR_NEEDS_PRAGMA
 #pragma RZ_DEFINE_CONSTRUCTOR_PRAGMA_ARGS(undefined_ranges_bitmap_bake)
-#endif
+#endif // RZ_DEFINE_CONSTRUCTOR_NEEDS_PRAGMA
 RZ_DEFINE_CONSTRUCTOR(undefined_ranges_bitmap_bake)
 static void undefined_ranges_bitmap_bake(void) {
 	const ut32 bits_per_element = sizeof(undefined_ranges_bitmap[0]) * 8;
@@ -934,11 +935,12 @@ static void undefined_ranges_bitmap_bake(void) {
 
 #ifdef RZ_DEFINE_DESTRUCTOR_NEEDS_PRAGMA
 #pragma RZ_DEFINE_DESTRUCTOR_PRAGMA_ARGS(undefined_ranges_bitmap_fini)
-#endif
+#endif // RZ_DEFINE_DESTRUCTOR_NEEDS_PRAGMA
 RZ_DEFINE_DESTRUCTOR(undefined_ranges_bitmap_fini)
 static void undefined_ranges_bitmap_fini(void) {
 	free(undefined_ranges_bitmap);
 }
+#endif // RZ_HAS_CONSTRUCTORS
 
 /**
  * Note: undefined for `code_point` >= `undefined_ranges_bitmap_size`. Caller should do proper checks.

--- a/librz/util/unicode.c
+++ b/librz/util/unicode.c
@@ -920,7 +920,7 @@ static void undefined_ranges_bitmap_bake(void) {
 		ut32 from = undefined_ranges[table_index].from;
 		ut32 to = RZ_MIN(undefined_ranges[table_index].to + 1, undefined_ranges_bitmap_size);
 
-		for (RzCodePoint code = from; code < to; code++) { // todo: confirm range inclusion/exclusion
+		for (RzCodePoint code = from; code < to; code++) {
 			undefined_ranges_bitmap[code / bits_per_element] |= 1ull << (code % bits_per_element);
 		}
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This PR introduces a few performance improvement (based on profiling, these parts of the code were taking noticable time):

 - Add a bitmap to speed up [undefined_ranges](https://github.com/antonangeloff/rizin/blob/85620596c728e79902693000c09ca4a5033a5b85/librz/util/unicode.c#L89) lookup when checking [whether an UTF code page is defined](https://github.com/antonangeloff/rizin/blob/85620596c728e79902693000c09ca4a5033a5b85/librz/util/unicode.c#L983)
 - Try to reduce heap allocations (when possible) when processing UTF strings
 - Avoid setting output buffer to `0xff` in the success path of [io_memory_read](https://github.com/rizinorg/rizin/pull/6035/changes#diff-965d7435f1166906d2dd57500cb154497d25683447982b3e695ed26051689815R97).

I've run parts of the regression test suite to measure execution time changes:
| Tests | Before (s) | After (s) | Change ratio (`after / before`) |
|---|---:|---:|---:|
| `rz-test db/format` | 38.682 | 27.497 | 141% |
| `rz-test db/analysis` | 67.495 | 46.924 | 143% |
| `o bins/dmp/bmp.dmp` | 2.942 | 2.482 | 118% |

Some other parts of the test suite, that I've check, don't seem to be affected much.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Existing tests should pass.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes https://github.com/rizinorg/rizin/issues/4386
