### PR TITLE
Add LLM checking workflow again.

### DIFF
--- a/.github/workflows/get_real_pr_shas.yml
+++ b/.github/workflows/get_real_pr_shas.yml
@@ -29,6 +29,7 @@
 #
 # Use `${{ needs.real_pr_shas.outputs.BASE_SHA }}` to get the real base sha.
 # Use `${{ needs.real_pr_shas.outputs.HEAD_SHA }}` to get the PR head commit sha.
+# Use `${{ needs.real_pr_shas.outputs.COMMIT_MSGS }}` to get the commit messages of git log --pretty=%B BASE_SHA..HEAD_SHA
 #
 # This workflow is copied from https://github.com/JensDll/should-run/blob/main/.github/workflows/main.yaml#L54
 #
@@ -47,6 +48,9 @@ on:
       HEAD_SHA:
         description: "The real PR commit HEAD sha"
         value: ${{ jobs.get_real_pr_shas.outputs.output_head }}
+      COMMIT_MSGS:
+        description: "The commit messages of BASE_SHA..HEAD_SHA"
+        value: ${{ jobs.get_real_pr_shas.outputs.output_msgs }}
 
 jobs:
   get_real_pr_shas:
@@ -54,6 +58,7 @@ jobs:
     outputs:
       output_base: ${{ steps.get_shas.outputs.BASE_SHA }}
       output_head: ${{ steps.get_shas.outputs.HEAD_SHA }}
+      output_msgs: ${{ steps.get_shas.outputs.COMMIT_MSGS }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -68,10 +73,18 @@ jobs:
             git fetch --no-tags --prune --no-recurse-submodules --deepen=10 origin ${{ github.event.pull_request.base.sha }}
           done
 
-          base=$(git rev-list ${{ github.event.pull_request.head.sha }} ^${{ github.event.pull_request.base.sha }} | tail --lines 1 | xargs -I {} git rev-parse {}~1)
+          BASE_SHA=$(git rev-list ${{ github.event.pull_request.head.sha }} ^${{ github.event.pull_request.base.sha }} | tail --lines 1 | xargs -I {} git rev-parse {}~1)
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          COMMIT_MSGS=$(git log --pretty=%B "$BASE_SHA".."$HEAD_SHA")
+          if [[ $? -eq 128 ]]; then
+          	echo "Failed to get log"
+          	exit 2
+          fi
 
-          echo "BASE_SHA=$base"
-          echo "HEAD_SHA=${{ github.event.pull_request.head.sha }}"
+          echo "BASE_SHA=$BASE_SHA"
+          echo "HEAD_SHA=$HEAD_SHA"
+          echo -e "COMMIT_MSGS:\n$COMMIT_MSGS"
 
-          echo "BASE_SHA=$base" >> $GITHUB_OUTPUT
-          echo "HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          echo "BASE_SHA=$BASE_SHA" >> $GITHUB_OUTPUT
+          echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_OUTPUT
+          echo "COMMIT_MSGS=$COMMIT_MSGS" >> $GITHUB_OUTPUT

--- a/.github/workflows/llm_checks.yml
+++ b/.github/workflows/llm_checks.yml
@@ -1,0 +1,77 @@
+# SECURITY:
+#
+# This workflow runs on pull_request_target and has write privileges.
+# Those are used to add labels to the PR.
+#
+# **IF a user can run code in here, they would be able to extract our secrets.**
+#
+# This is why it doesn't run external scripts.
+# The exception is the get_real_pr_shas.yml workflow.
+# The input of it is santized.
+
+name: AI/LLM Checks
+
+on:
+  pull_request_target:
+
+jobs:
+  real_pr_shas:
+    uses: rizinorg/rizin/.github/workflows/get_real_pr_shas.yml@dev
+
+  ai_checks:
+    name: LLM checks
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    needs: real_pr_shas
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Full history needed for commit scanning
+
+      - name: Validate input hashes
+        env:
+          BASE_SHA: ${{ needs.real_pr_shas.outputs.BASE_SHA }}
+          HEAD_SHA: ${{ needs.real_pr_shas.outputs.HEAD_SHA }}
+        run: |
+          if echo "$BASE_SHA" | grep -q "[^a-f0-9]"; then
+            echo "BASE_SHA is malformed: $BASE_SHA"
+            exit 1
+          fi
+          if echo "$HEAD_SHA" | grep -q "[^a-f0-9]"; then
+            echo "HEAD_SHA is malformed: $HEAD_SHA"
+            exit 1
+          fi
+
+      - name: Check AGENT.md is unchanged
+        env:
+          BASE_SHA: ${{ needs.real_pr_shas.outputs.BASE_SHA }}
+        run: |
+          diff=$(git diff --name-status "$BASE_SHA" AGENTS.md)
+          if [[ $? -eq 128 ]]; then
+          	echo "Failed to diff"
+          	exit 1
+          fi
+
+          if [[ -n "$diff" ]]; then
+          	echo "Edits to 'AGENT.md' are not allowed!"
+          	exit 1
+          fi
+
+      - name: Check for AI usage and label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}
+          BASE_SHA: ${{ needs.real_pr_shas.outputs.BASE_SHA }}
+          HEAD_SHA: ${{ needs.real_pr_shas.outputs.HEAD_SHA }}
+          COMMIT_MSGS: ${{ needs.real_pr_shas.outputs.COMMIT_MSGS }}
+        run: |
+          LABEL_NAME="AI/LLM"
+          NEEDLE="Co-authored-by agent"
+
+          if echo "$COMMIT_MSGS" | grep -q "$NEEDLE"; then
+            echo "Authored by AI agent"
+            gh pr --repo $REPO edit $NUMBER --add-label "$LABEL_NAME"
+          fi


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Adds the LLM check workflow again which was removed in https://github.com/rizinorg/rizin/pull/6032 due to security concerns.

This PR adds a fixed and cleaned up version of the workflow again.
The commit messages from `git log` are now generated in `get_real_pr_sha.yml` where the relevant git history was fetched.
This is necessary, because using `git log` in the llm workflow will fail, since everything is a shallow checkout.


> The security concern was that a user can insert the env variable of a secret (e.g. `$GITHUB_TOKEN` in their commit message, and the workflow could somehow echo it into the log.
> This is not possible. Because all commit messages are stored in a `$COMMIT_MSGS` variable.
> If `echo "$COMMIT_MSGS"` is run, `echo` won't resolve variable names in the string. It just emits `$GITHUB_TOKEN` (or however they might be named).
> 
> This makes sense in retrospect of course, but better safe than sorry.
> 
> Here is the use case tested:
> https://github.com/Rot127/rizin/actions/runs/23072737264/job/67026748454?pr=2
> 
> ```
>   VAR_WITH_SECRET='$ROT127_SECRET'
>   echo "Try $ROT127_SECRET"
>   echo "Try indirect $VAR_WITH_SECRET"
>   LABEL_NAME="AI/LLM"
>   NEEDLE="Co-authored-by agent"
>   echo "$COMMIT_MSGS"
>   
>   if echo "$COMMIT_MSGS" | grep "$NEEDLE"; then
>     echo "Authored by AI agent"
>     gh pr --repo $REPO edit $NUMBER --add-label "$LABEL_NAME"
>   fi
>   shell: /usr/bin/bash -e {0}
>   env:
>     ROT127_SECRET: ***
>     GH_TOKEN: ***
>     REPO: Rot127/rizin
>     NUMBER: 2
>     BASE_SHA: ff63bc03da7af01f940526ed846a16c4fbdb0585
>     HEAD_SHA: 8317383b0b3f32519249acd3feacdd3aecca6555
>     COMMIT_MSGS: Co-authored-by agent: GitHub Copilot/GPT-5.1-Codex-Max $ROT127_SECRET
> Try ***
> Try indirect $ROT127_SECRET
> Co-authored-by agent: GitHub Copilot/GPT-5.1-Codex-Max $ROT127_SECRET
> Co-authored-by agent: GitHub Copilot/GPT-5.1-Codex-Max $ROT127_SECRET
> Authored by AI agent
> https://github.com/Rot127/rizin/pull/2
> ```

Related:
- https://github.com/rizinorg/rizin/pull/6025
- https://github.com/rizinorg/rizin/pull/6032

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Here the PR in the for showing that the script works:

https://github.com/Rot127/rizin/pull/4

And to ensure the workflow files are the same:
the difference between this commit, and the commit of the base branch (`llm-workflow-v2-test`) the PR https://github.com/Rot127/rizin/pull/4 merges into.
https://github.com/rizinorg/rizin/compare/f50be9ed0aae755ba0a842529aec400afc20494f...rot127:f4e3634fd7dbda4eced2af564d0f2624d828e09f

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
