### PR TITLE
Do immutable release from v0.9 onwards (#6037)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -978,7 +978,7 @@ jobs:
           tag_name: ${{ steps.extract_version.outputs.branch }}
           name: Release ${{ steps.extract_version.outputs.branch }}
           draft: true
-          prerelease: false
+          prerelease: true
           files: |
             rizin-src-${{ steps.extract_version.outputs.branch }}.tar.xz
             rizin-${{ steps.extract_version.outputs.branch }}-static-x86_64.tar.xz


### PR DESCRIPTION

<!-- Filling this template is mandatory -->

- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

In response to GitHub's new "immutable releases" feature (released October 28, 2025), this PR updates the automated CI release workflow to publish releases as "pre-releases". This allows maintainers to verify the release and its assets before finalizing them, which is critical since immutable releases prevent any modification once published.

- Modified `.github/workflows/ci.yml` to set `prerelease: true` in the `create-release` job.

**Test plan**

Checked the CI workflow configuration manually to ensure the `prerelease` flag is correctly set to `true`. This change affects how the `softprops/action-gh-release@v2` action behaves when a tag is pushed to the `stable` or `release-*` branches.

**Closing issues**

Closes #6037
