### PR TITLE
Add GDB remote protocol download feature

### DIFF
--- a/librz/debug/p/debug_gdb.c
+++ b/librz/debug/p/debug_gdb.c
@@ -176,7 +176,7 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_gdb_map_get(RzDebug *dbg) { // TODO
 		gdbr_close_file(ctx->desc);
 		return NULL;
 	}
-	if ((ret = gdbr_read_file(ctx->desc, buf, buflen - 1)) <= 0) {
+	if ((ret = gdbr_read_file(ctx->desc, buf, buflen - 1, 0)) <= 0) {
 		gdbr_close_file(ctx->desc);
 		free(buf);
 		return NULL;

--- a/librz/io/p/io_gdb.c
+++ b/librz/io/p/io_gdb.c
@@ -228,7 +228,8 @@ static char *__system(RzIO *io, RzIODesc *fd, const char *cmd) {
 			" R!pktsz           - get max packet size used\n"
 			" R!pktsz bytes     - set max. packet size as 'bytes' bytes\n"
 			" R!exec_file [pid] - get file which was executed for"
-			" current/specified pid\n");
+			" current/specified pid\n"
+			" R!download <remote path> <local path> - download file\n");
 		return NULL;
 	}
 	libgdbr_t *desc = fd->data;
@@ -378,6 +379,61 @@ static char *__system(RzIO *io, RzIODesc *fd, const char *cmd) {
 		}
 		io->cb_printf("%s\n", file);
 		return file;
+	}
+	if (rz_str_startswith(cmd, "download")) {
+		RzList *args = rz_str_split_duplist(cmd, " ", true);
+		if (!args || rz_list_length(args) != 3) {
+			eprintf("R!download <remote path> <local path>\n");
+			rz_list_free(args);
+			return NULL;
+		}
+
+		char *remote_path = (char *)rz_list_get_n(args, 1);
+		char *local_path = (char *)rz_list_get_n(args, 2);
+
+		if (gdbr_open_file(desc, remote_path, 0, 0) < 0) {
+			eprintf("Failed to open remote file: %s\n", remote_path);
+			rz_list_free(args);
+			return NULL;
+		}
+
+		const ut64 chunk_sz = 1024 * 1024;
+		ut8 *buf = RZ_NEWS(ut8, chunk_sz);
+		if (!buf) {
+			eprintf("Failed to allocate memory for download\n");
+			gdbr_close_file(desc);
+			rz_list_free(args);
+			return NULL;
+		}
+
+		io->cb_printf("downloaing %s to %s\n", remote_path, local_path);
+
+		ut64 offset = 0;
+		bool write_error = false;
+		while (true) {
+			int nbytes = gdbr_read_file(desc, buf, chunk_sz, offset);
+			if (nbytes < 0) {
+				eprintf("Error reading remote file at offset %" PFMT64d ".\n", offset);
+				break;
+			} else if (nbytes == 0) { // EOF
+				break;
+			}
+			if (!rz_file_dump(local_path, buf, nbytes, offset != 0)) {
+				eprintf("Failed to write to local file: %s\n", local_path);
+				write_error = true;
+				break;
+			}
+			offset += nbytes;
+		}
+
+		if (!write_error) {
+			io->cb_printf("downloaded %" PFMT64d " bytes.\n", offset);
+		}
+
+		RZ_FREE(buf);
+		gdbr_close_file(desc);
+		rz_list_free(args);
+		return NULL;
 	}
 	// These are internal, not available to user directly
 	if (rz_str_startswith(cmd, "retries")) {

--- a/subprojects/rzgdb/include/gdbclient/commands.h
+++ b/subprojects/rzgdb/include/gdbclient/commands.h
@@ -126,7 +126,7 @@ int gdbr_remove_hwa(libgdbr_t *g, ut64 address, int sizebp);
  * File read from remote target (only one file open at a time for now)
  */
 int gdbr_open_file(libgdbr_t *g, const char *filename, int flags, int mode);
-int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 max_len);
+int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 max_len, ut64 offset);
 int gdbr_close_file(libgdbr_t *g);
 
 /*!

--- a/subprojects/rzgdb/src/gdbclient/core.c
+++ b/subprojects/rzgdb/src/gdbclient/core.c
@@ -1484,7 +1484,7 @@ end:
 	return ret;
 }
 
-int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 max_len) {
+int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 max_len, ut64 offset) {
 	int ret, ret1;
 	char command[64];
 	ut64 data_sz;
@@ -1511,7 +1511,7 @@ int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 max_len) {
 		if (snprintf(command, sizeof(command) - 1,
 			    "vFile:pread:%x,%" PFMT64x ",%" PFMT64x,
 			    (int)g->remote_file_fd, (ut64)RZ_MIN(data_sz, max_len - ret),
-			    (ut64)ret) < 0) {
+			    (ut64)(offset + ret)) < 0) {
 			ret = -1;
 			goto end;
 		}

--- a/subprojects/rzgdb/src/gdbclient/xml.c
+++ b/subprojects/rzgdb/src/gdbclient/xml.c
@@ -415,7 +415,7 @@ static int gdbr_parse_processes_xml(libgdbr_t *g, char *xml_data, ut64 len, int 
 		// correct pid and cmdline from the xml with everything else set to default
 		proc_filename = rz_str_newf("/proc/%d/status", ipid);
 		if (gdbr_open_file(g, proc_filename, O_RDONLY, 0) == 0) {
-			if (gdbr_read_file(g, (unsigned char *)status, sizeof(status)) != -1) {
+			if (gdbr_read_file(g, (unsigned char *)status, sizeof(status), 0) != -1) {
 				pid_info = _extract_pid_info(status, cmdline, ipid);
 			} else {
 				eprintf("Failed to read from data from procfs file of pid (%d)\n", ipid);

--- a/subprojects/rzgdb/src/packet.c
+++ b/subprojects/rzgdb/src/packet.c
@@ -77,6 +77,7 @@ static int unpack(libgdbr_t *g, struct parse_ctx *ctx, int len) {
 				return -1;
 			}
 			ctx->flags &= ~ESC;
+			ctx->last = cur;
 			continue;
 		}
 		if (ctx->flags & DUP) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`). (**TODO**)
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed). (**TODO**)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Allows downloading files and symbols using the GDB remote server protocol. 

Issues:

- The `gdbr_read_file` function does not allow for offsets, meaning the entire file has to be downloaded and loaded into memory at once. Couldn't find an existing issue for this.
- The `unpack` function does not decode RLE properly. The problem is explained in [this comment](https://github.com/rizinorg/rizin/issues/3975#issuecomment-4062793107).
- #3975 

Changes:

1. Modified file reading function to allow for offsets. The existing callers have the offset value set to `0`.
2. Fixed packet reading to decode RLE with escaped characters properly, just updating the last byte when facing escaped bytes (`ctx->last = cur`) fixes this.
3. Added a download command to download arbitrary files by specifying the remote and local paths.
4. (**TODO**) Download the target binary by default (path is already found by `R! exec_file`)
5. (**TODO**) If the symbols are stored separately in a `.debug` file, (somehow) find that file and download it and load the symbols (this is probably too difficult but I am ready to do it with some help)
...

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

1. `gdbr_read_file` offsets: **TODO** (need help here)
2. packet RLE fix
    1. Create a small test binary using python: `python3 -c "import sys; sys.stdout.buffer.write(b'A'*16 + b'\x23' + b'\x03'*4 + b'B'*16)" > test.bin`
    2. Host the gdbserver (`gdbserver :1234 /bin/ls`) and connect to it (`rizin -d gdb://localhost:1234`)
    3. Download the file `R! download test.bin test1.bin`
    4. Check the difference between the files: `sha256sum test*.bin` or `diff <(hexdump -C test.bin) <(hexdump -C test1.bin)`
3. download command
    1. Host a gdbserver: `gdbserver :1234 /bin/ls`
    2. Connect to it using rizin: `rizin -d gdb://localhost:1234`
    3. Download any file: `R! download /bin/ls ./ls`

**Closing issues**

closes #3975 

**Pending Issues**

- When downloading fails due to a writing issue, the `downloading` message is printed after the error:
```
[0x7ffff7fe42c0]> R! download /bin/ls ./wow/ls
Cannot open './wow/ls' for writing
Failed to write to local file: ./wow/ls
downloaing /bin/ls to ./wow/ls
```

- The download command's help is not aligned with other commands' help:
```
 -- Add comments using the ';' key in visual mode or the 'CC' command from the riz[0x7ffff7fe42c0]> R! ?
Usage: R!<cmd> [args]
 R!pid             - show targeted pid
 R!pkt s           - send packet 's'
 R!rd              - show reverse debugging availability
 R!dsb             - step backwards
 R!dcb             - continue backwards
 R!monitor cmd     - hex-encode monitor command and pass to target interpreter
 R!detach [pid]    - detach from remote/detach specific pid
 R!inv.reg         - invalidate reg cache
 R!pktsz           - get max packet size used
 R!pktsz bytes     - set max. packet size as 'bytes' bytes
 R!exec_file [pid] - get file which was executed for current/specified pid
 R!download <remote path> <local path> - download file
```
