### PR TITLE
Fix endless loop caused by < \x12asd\n (push_escaped)

### DIFF
--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -1197,6 +1197,70 @@ err:
 	return res;
 }
 
+static bool is_push_stmt(TSNode node, const char *in) {
+	if (ts_node_is_null(node) || strcmp(ts_node_type(node), "arged_stmt")) {
+		return false;
+	}
+	TSNode cmd = ts_node_child_by_field_name(node, "command", strlen("command"));
+	if (ts_node_is_null(cmd)) {
+		return false;
+	}
+	TSNode extra = ts_node_child_by_field_name(cmd, "extra", strlen("extra"));
+	char *s = NULL;
+	if (!ts_node_is_null(extra)) {
+		ut32 start = ts_node_start_byte(cmd);
+		ut32 end = ts_node_start_byte(extra);
+		s = rz_str_newf("%.*s", end - start, in + start);
+	} else {
+		s = ts_node_sub_string(cmd, in);
+	}
+	if (!s) {
+		return false;
+	}
+	rz_str_unescape(s);
+	bool ret = !strcmp(s, "<");
+	free(s);
+	return ret;
+}
+
+static bool has_push(TSNode node, const char *in) {
+	if (is_push_stmt(node, in)) {
+		return true;
+	}
+	uint32_t n = ts_node_named_child_count(node);
+	for (uint32_t i = 0; i < n; i++) {
+		if (has_push(ts_node_named_child(node, i), in)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+RZ_IPI bool rz_core_cmd_has_push(const char *cstr) {
+	if (RZ_STR_ISEMPTY(cstr)) {
+		return false;
+	}
+	TSParser *parser = ts_parser_new();
+	if (!parser) {
+		return false;
+	}
+	bool ok = ts_parser_set_language(parser, tree_sitter_rzcmd());
+	if (!ok) {
+		ts_parser_delete(parser);
+		return false;
+	}
+	TSTree *tree = ts_parser_parse_string(parser, NULL, cstr, strlen(cstr));
+	if (!tree) {
+		ts_parser_delete(parser);
+		return false;
+	}
+	TSNode root = ts_tree_root_node(tree);
+	bool ret = !ts_node_has_error(root) && has_push(root, cstr);
+	ts_tree_delete(tree);
+	ts_parser_delete(parser);
+	return ret;
+}
+
 DEFINE_HANDLE_TS_FCN_AND_SYMBOL(macro_stmt) {
 	RzCmdStatus res = RZ_CMD_STATUS_ERROR;
 	char *macro_name_str = NULL;
@@ -2868,7 +2932,7 @@ static RzCmdStatus core_cmd_tsrzcmd(RzCore *core, const char *cstr, bool split_l
 	rz_pvector_init(&state.saved_input, NULL);
 	rz_pvector_init(&state.saved_tree, NULL);
 
-	if (state.log) {
+	if (state.log && !has_push(root, state.input)) {
 		rz_line_hist_add(line, state.input);
 	}
 

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -28,6 +28,34 @@ static ut64 letter_divs[RZ_CORE_ASMQJMPS_LEN_LETTERS - 1] = {
 };
 
 extern bool rz_core_is_project(RzCore *core, const char *name);
+RZ_IPI bool rz_core_cmd_has_push(const char *s);
+
+static void hist_drop_push(RzLine *line) {
+	RzLineHistory *hist = &line->history;
+	if (!hist->data) {
+		return;
+	}
+	int top = hist->top;
+	int j = 0;
+	for (int i = 0; i < top; i++) {
+		char *s = hist->data[i];
+		if (!s) {
+			continue;
+		}
+		if (rz_core_cmd_has_push(s)) {
+			free(s);
+			continue;
+		}
+		hist->data[j++] = s;
+	}
+	for (int i = j; i < top; i++) {
+		hist->data[i] = NULL;
+	}
+	hist->top = j;
+	if (hist->index > hist->top) {
+		hist->index = hist->top;
+	}
+}
 
 /**
  * \brief  Prints a message definining the beginning of a task
@@ -1662,6 +1690,7 @@ RZ_API bool rz_core_init(RzCore *core) {
 #endif
 		char *history = rz_path_home_history();
 		rz_line_hist_load(core->cons->line, history);
+		hist_drop_push(core->cons->line);
 		free(history);
 	}
 	core->print->cons = core->cons;

--- a/test/unit/test_core_cmd.c
+++ b/test/unit/test_core_cmd.c
@@ -123,11 +123,134 @@ static bool test_arg_cmd_last_opt(void) {
 	mu_end;
 }
 
+static bool test_hist_push(void) {
+	RzCore *core = rz_core_new();
+	RzLine *line = core->cons->line;
+	const char *mark = "i5824";
+	const char *cmd = "echo i5824";
+
+	rz_line_hist_add(line, cmd);
+	int history_top = line->history.top;
+	rz_cons_readflush();
+
+	free(core->cmdqueue);
+	core->cmdqueue = rz_str_newf("< \\x12%s\\n", mark);
+	mu_assert_notnull(core->cmdqueue, "cmdqueue should be allocated");
+
+	mu_assert_eq(rz_core_prompt_exec(core), 0, "push_escaped prompt command should execute");
+	mu_assert_eq(line->history.top, history_top, "push_escaped should not be added to history");
+	mu_assert_streq(rz_line_hist_get(line, history_top), cmd, "last history entry should remain the preexisting matching command");
+
+	const char *res = rz_line_readline(line);
+	mu_assert_notnull(res, "reverse-search result should not be null");
+	mu_assert_streq(res, cmd, "reverse-search should resolve to prior history, not the injector command");
+
+	rz_cons_readflush();
+	rz_core_free(core);
+	mu_end;
+}
+
+static bool test_hist_push_seq(void) {
+	RzCore *core = rz_core_new();
+	RzLine *line = core->cons->line;
+	const char *mark = "i5824s";
+	const char *cmd = "echo i5824s";
+
+	rz_line_hist_add(line, cmd);
+	int history_top = line->history.top;
+	rz_cons_readflush();
+
+	free(core->cmdqueue);
+	core->cmdqueue = rz_str_newf("echo %s; < \\x12%s\\n", mark, mark);
+	mu_assert_notnull(core->cmdqueue, "cmdqueue should be allocated");
+
+	mu_assert_eq(rz_core_prompt_exec(core), 0, "push_escaped prompt command should execute");
+	mu_assert_eq(line->history.top, history_top, "command lines containing push_escaped should not be added to history");
+	mu_assert_streq(rz_line_hist_get(line, history_top), cmd, "last history entry should remain the preexisting matching command");
+
+	const char *res = rz_line_readline(line);
+	mu_assert_notnull(res, "reverse-search result should not be null");
+	mu_assert_streq(res, cmd, "reverse-search should resolve to prior history, not the injector command");
+
+	rz_cons_readflush();
+	rz_core_free(core);
+	mu_end;
+}
+
+static bool test_hist_push_load(void) {
+	int retval = MU_PASSED;
+	const char *cmd = "echo i5824l";
+	const char *data = "< \\x12i5824l\\n\necho i5824l\n";
+	char *old = rz_sys_getenv(RZ_SYS_HOME);
+	char *home = rz_file_temp("rz5824");
+	char *hist = NULL;
+	char *dir = NULL;
+	char *cache = NULL;
+	RzCore *core = NULL;
+
+	if (!home) {
+		mu_cleanup_fail(beach, "home path should be available");
+	}
+	if (!rz_sys_mkdirp(home)) {
+		mu_cleanup_fail(beach, "home dir should be created");
+	}
+	rz_sys_setenv(RZ_SYS_HOME, home);
+	hist = rz_path_home_history();
+	if (!hist) {
+		mu_cleanup_fail(beach, "history path should be available");
+	}
+	dir = rz_file_dirname(hist);
+	if (!dir) {
+		mu_cleanup_fail(beach, "history dir should be available");
+	}
+	cache = rz_file_dirname(dir);
+	if (!cache) {
+		mu_cleanup_fail(beach, "cache dir should be available");
+	}
+	if (!rz_sys_mkdirp(dir)) {
+		mu_cleanup_fail(beach, "history dir should be created");
+	}
+	if (!rz_file_dump(hist, (const ut8 *)data, (int)strlen(data), false)) {
+		mu_cleanup_fail(beach, "history file should be written");
+	}
+	core = rz_core_new();
+	if (!core) {
+		mu_cleanup_fail(beach, "core should be created");
+	}
+	mu_assert_streq(rz_line_hist_get(core->cons->line, 1), cmd, "loaded history should keep only normal commands");
+	mu_assert_null(rz_line_hist_get(core->cons->line, 2), "loaded push_escaped entry should be removed");
+
+beach:
+	rz_core_free(core);
+	rz_sys_setenv(RZ_SYS_HOME, old);
+	if (hist) {
+		rz_file_rm(hist);
+	}
+	if (dir) {
+		rz_file_rm(dir);
+	}
+	if (cache) {
+		rz_file_rm(cache);
+	}
+	if (home) {
+		rz_file_rm(home);
+	}
+	free(old);
+	free(cache);
+	free(dir);
+	free(hist);
+	free(home);
+	mu_cleanup_end;
+}
+
 int all_tests() {
 	mu_run_test(test_arg_cmd);
 	mu_run_test(test_arg_cmd_last);
 	mu_run_test(test_arg_cmd_last_with_at);
 	mu_run_test(test_arg_cmd_last_opt);
+	mu_run_test(test_hist_push);
+	mu_run_test(test_hist_push_seq);
+	mu_run_test(test_hist_push_load);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

The problem was that the core shell logged the full input line to history before executing it. For inputs such as `< \x12asd\n`, the injected `Ctrl-R ... Enter` sequence could immediately find that same history entry and execute it again, causing the endless loop. The same could also happen with already-saved history from older runs.

Changes:

- `librz/core/cmd/cmd.c` now uses the parsed command tree to detect whether the input line contains `push_escaped`, and skips adding those lines to core history.
- `librz/core/core.c` drops already-saved history entries containing `push_escaped` when core history is loaded, so old history files do not keep triggering the loop.
- `test/unit/test_core_cmd.c` adds regressions for:
  - the original standalone reproducer
  - a command sequence that contains `push_escaped`
  - loading an old polluted history file

This doesn't change generic `RzLine` history handling.

**Test plan**

Local tests I ran:

```sh
meson test -C build --suite unit --print-errorlogs
```

Result: `124/127` passed.

The remaining 3 failures are unchanged Windows-local failures outside this patch:
- `cons_pipe`
- `rz_test`
- `analysis_op`

Manual check for the fix:

1. Launch the local build inside the Meson environment so the build DLLs are used.
2. Run:
```text
H-
echo asd5824
< \x12asd5824\n
echo asd5824; < \x12asd5824\n
```
3. Expected:
- no endless loop
- reverse-search resolves to the earlier `echo asd5824`
- the `push_escaped` line is not replayable from history

**Closing issues**

closes #5824