### PR TITLE
meson: Fix duplicate checks for `-Wno-unused-result`

### DIFF
--- a/test/unit/auxiliary/meson.build
+++ b/test/unit/auxiliary/meson.build
@@ -6,10 +6,11 @@ files = [
 ]
 
 warn_unused_flag = '-Wno-unused-result'
+auxiliary_c_args = meson.get_compiler('c').has_argument(warn_unused_flag) ? [warn_unused_flag] : []
 auxiliaries = []
 foreach file : files
   auxiliaries += [executable(file, '@0@.c'.format(file),
-    c_args: meson.get_compiler('c').has_argument(warn_unused_flag) ? [warn_unused_flag] : [],
+    c_args: auxiliary_c_args,
     install: false,
   )]
 endforeach


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr removes the duplicate checks for `-Wno-unused-result`, exemplified below, from the build:

<img width="795" height="153" alt="dup-Wno-unused-result" src="https://github.com/user-attachments/assets/82d1ec79-dbac-450c-abb0-1548c5c64e01" />

(https://github.com/rizinorg/rizin/actions/runs/23245579736/job/67573011378#step:12:713)

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Only one check is done for `-Wno-unused-result`. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
