### PR TITLE
Fix(core): Resolve SIMD-driven OOB read in disassembly colorization

### DIFF
--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -878,6 +878,13 @@ static void __replaceImports(RzDisasmState *ds) {
 	}
 }
 
+static RZ_OWN char *rz_strbuf_drain_padded(RZ_OWN RZ_NONNULL RzStrBuf *sb) {
+	rz_return_val_if_fail(sb, NULL);
+	const size_t len = rz_strbuf_length(sb);
+	(void)rz_strbuf_reserve(sb, len + 16);
+	return rz_strbuf_drain(sb);
+}
+
 static void ds_opstr_try_colorize(RzDisasmState *ds, bool print_color) {
 	bool colorize_asm = print_color && ds->show_color && ds->colorop;
 	if (!colorize_asm) {
@@ -895,7 +902,10 @@ static void ds_opstr_try_colorize(RzDisasmState *ds, bool print_color) {
 	if (!colored_asm) {
 		return;
 	}
-	char *new_opstr = rz_strbuf_drain(colored_asm);
+	char *new_opstr = rz_strbuf_drain_padded(colored_asm);
+	if (!new_opstr) {
+		return;
+	}
 	free(ds->opstr);
 	ds->opstr = new_opstr;
 }


### PR DESCRIPTION
### Your checklist for this pull request

- [x] I've read the guidelines for contributing to this repository.
- [x] I made sure to follow the project's coding style.
- [ ] I've documented every RZ_API function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to RZ_API).
- [ ] I've updated the Rizin book with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

#Fix(core): Resolve SIMD-driven OOB read in disassembly colorization

## Summary

This PR fixes a Valgrind-reported invalid read in the disassembly colorization path.

The issue is triggered when printing disassembly (for example `pd 1`) and affects both command mode (`pd`) and visual mode (`v`) because they share the same opcode-string formatting/colorization pipeline.

The fix introduces a padded drain helper for colorized `RzStrBuf` output and uses it in `ds_opstr_try_colorize`.

## Environment

- Host: Linux (x86_64)
- Tool: Valgrind 3.18.1
- Build system: Meson + Ninja

## Build steps used

```bash
meson setup build --prefix=/goinfre/jbahmida/rizin-install
ninja -C build
ninja -C build install
```

## Reproducer (before fix)

```bash
valgrind --leak-check=full --track-origins=yes --show-leak-kinds=all ./build/binrz/rizin/rizin -a x86 -c "pd 1" ~/ctf_time/floor-is-lava/chal
```

### Observed failure

Valgrind reports:

- `Invalid read of size 16`
- stack trace rooted in:
    - `drain (strbuf.c:315)`
    - `rz_strbuf_drain (strbuf.c:327)`
    - `ds_opstr_try_colorize (disasm.c:898)`
    - `ds_build_op_str (disasm.c:1033)`

Key evidence from the failing run:

```text
==922104== Invalid read of size 16
==922104==    at 0x4C2A96B: ???
==922104==    by 0xBE965EF: ???
==922104==  Address 0xbe965ff is 15 bytes inside a block of size 27 alloc'd
==922104==    at 0x484A899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==922104==    by 0x4CD858E: strdup (strdup.c:42)
==922104==    by 0x490098C: drain (strbuf.c:315)
==922104==    by 0x490098C: rz_strbuf_drain (strbuf.c:327)
==922104==    by 0x8363B68: ds_opstr_try_colorize (disasm.c:898)
==922104==    by 0x835BC77: ds_build_op_str (disasm.c:1033)
```

## Root cause analysis

`ds_opstr_try_colorize` drains a colorized opcode string from `RzStrBuf` with `rz_strbuf_drain` and stores it in `ds->opstr`.

For short strings, downstream libc string operations may perform vectorized reads close to the end of the allocation. Valgrind flags this as an invalid read when there is no extra safe tail space beyond the logical string length.

This is a boundary-read issue in the colorized string ownership transfer path, not a semantic disassembly bug.

## Fix

Added helper:

```c
static RZ_OWN char *rz_strbuf_drain_padded(RZ_OWN RZ_NONNULL RzStrBuf *sb) {
	rz_return_val_if_fail(sb, NULL);
	const size_t len = rz_strbuf_length(sb);
	(void)rz_strbuf_reserve(sb, len + 16);
	return rz_strbuf_drain(sb);
}
```

Then updated `ds_opstr_try_colorize` to use:

```c
char *new_opstr = rz_strbuf_drain_padded(colored_asm);
if (!new_opstr) {
	return;
}
```

This preserves the existing ownership model and behavior while adding a small safety margin before draining.

## Validation (after fix)

Re-ran the same command:

```bash
valgrind --leak-check=full --track-origins=yes --show-leak-kinds=all ./build/binrz/rizin/rizin -a x86 -c "pd 1" ~/ctf_time/floor-is-lava/chal
```

Result:

- `ERROR SUMMARY: 0 errors from 0 contexts`
- no invalid read in `ds_opstr_try_colorize` path

Relevant tail from the successful run:

```text
==922282== LEAK SUMMARY:
==922282==    definitely lost: 0 bytes in 0 blocks
==922282==    indirectly lost: 0 bytes in 0 blocks
==922282==      possibly lost: 0 bytes in 0 blocks
==922282==    still reachable: 40 bytes in 1 blocks
==922282==         suppressed: 0 bytes in 0 blocks
==922282==
==922282== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

## About the remaining `still reachable` block

The remaining `40 bytes in 1 blocks` originates from logger lock initialization (`log_init`/`rz_th_lock_new`) and appears as `still reachable`, not `definitely lost`.

This is pre-existing and outside the scope of this fix.

## Impact

- Eliminates Valgrind invalid-read report in disassembly colorization path.
- Improves robustness for both `pd` and visual-mode disassembly rendering.
- Keeps functional output unchanged.

### Note on AI usage: 
I used Gemini (Google) primarily as a linguistic and structural consultant to ensure the PR description was polished, grammatically correct, and technically clear, as English is not my primary language. All technical analysis—including the Valgrind reproduction, the stack trace investigation, and the implementation of the rz_strbuf_drain_padded logic—was performed manually on my local environment to resolve the specific SIMD over-read issue identified
