### PR TITLE
Fix multi-line commit messages in "get-real-pr-shas" workflow

### DIFF
--- a/.github/workflows/get_real_pr_shas.yml
+++ b/.github/workflows/get_real_pr_shas.yml
@@ -87,4 +87,12 @@ jobs:
 
           echo "BASE_SHA=$BASE_SHA" >> $GITHUB_OUTPUT
           echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_OUTPUT
-          echo "COMMIT_MSGS=$COMMIT_MSGS" >> $GITHUB_OUTPUT
+          # Multi-line strings must be surrounded by some EOF indicator.
+          # https://stackoverflow.com/questions/74137120/how-to-fix-or-avoid-error-unable-to-process-file-command-output-successfully
+          # EOF value must be random because otherwise it could occur in
+          # the commit messages to end the early:
+          # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#multiline-strings
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "COMMIT_MSGS<<$EOF" >> $GITHUB_OUTPUT
+          echo "$COMMIT_MSGS" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Multi-line strings must be surrounded by some EOF indicator.
https://stackoverflow.com/questions/74137120/how-to-fix-or-avoid-error-unable-to-process-file-command-output-successfully
EOF value must be random because otherwise it could occur in
the commit messages to end the early:
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#multiline-strings

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

https://github.com/Rot127/rizin/pull/6

This PR compared to the base branch of PR 6

https://github.com/rizinorg/rizin/compare/4f2b7f0755d1cb71a323a46eef66746958a48f6a...rot127:98e4f9916b32e7faa8894a1f54bcc1164ac87d0a

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
