### PR TITLE
util: Extend string search with user-defined printable characters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
-# Hard requirements
+# Rizin Worktree Notes
 
-- If an agent was involved in ANY code changes the commit message MUST end with: `Co-authored-by agent: <AGENT_NAME>/<MODEL_NAME>`.
-  - Variables `<AGENT_NAME>` and `<MODEL_NAME>` MUST be set by the agent.
-- This file (AGENTS.md) MUST NOT be edited.
+- Start from the shared docs first, then follow the repo's own workflow docs.
+- Keep changes scoped to this worktree and branch.
+- Use `BUILDING.md`, `CONTRIBUTING.md`, and `DEVELOPERS.md` for repo-specific build, test, and commit guidance.
+- Do not add AI-specific commit footers or tracked artifacts unless explicitly requested.
+- Keep this file short; update it only when the repo workflow changes.

--- a/librz/bin/bfile_string.c
+++ b/librz/bin/bfile_string.c
@@ -23,6 +23,8 @@ typedef struct shared_data_t {
 	size_t min_str_length;
 	bool check_ascii_freq;
 	bool prefer_big_endian;
+	RzCodePoint *user_unprintable;
+	size_t user_unprintable_count;
 } SharedData;
 
 typedef struct search_thread_data_t {
@@ -233,6 +235,8 @@ static RzList /*<RzDetectedString *>*/ *string_scan_range(SharedData *shared, co
 		.min_str_length = shared->min_str_length,
 		.prefer_big_endian = shared->prefer_big_endian,
 		.check_ascii_freq = shared->check_ascii_freq,
+		.user_unprintable = shared->user_unprintable,
+		.user_unprintable_count = shared->user_unprintable_count,
 	};
 
 	ut8 *buf = calloc(interval_size, 1);
@@ -462,6 +466,8 @@ RZ_API void rz_bin_string_search_opt_init(RZ_NONNULL RzBinStringSearchOpt *opt) 
 	opt->raw_alignment = RZ_BIN_STRING_SEARCH_RAW_FILE_ALIGNMENT;
 	opt->string_encoding = RZ_STRING_ENC_GUESS;
 	opt->check_ascii_freq = RZ_BIN_STRING_SEARCH_CHECK_ASCII_FREQ;
+	opt->user_unprintable = NULL;
+	opt->user_unprintable_count = 0;
 	opt->mode = RZ_BIN_STRING_SEARCH_MODE_AUTO;
 }
 
@@ -656,6 +662,8 @@ RZ_API RZ_OWN RzPVector /*<RzBinString *>*/ *rz_bin_file_strings(RZ_NONNULL RzBi
 		.min_str_length = opt->min_length,
 		.check_ascii_freq = opt->check_ascii_freq,
 		.prefer_big_endian = prefer_big_endian,
+		.user_unprintable = opt->user_unprintable,
+		.user_unprintable_count = opt->user_unprintable_count,
 	};
 
 	if (shared.min_str_length < 1) {

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -525,6 +525,7 @@ RZ_API void rz_bin_free(RZ_NULLABLE RzBin *bin) {
 	bin->file = NULL;
 	free(bin->force);
 	free(bin->srcdir);
+	free(bin->str_search_cfg.user_unprintable);
 	// rz_bin_free_bin_files (bin);
 	rz_list_free(bin->binfiles);
 

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -79,6 +79,8 @@ static bool find_string_at(RzCore *core, RzBinObject *bobj, ut64 pointer, char *
 		.min_str_length = bin->str_search_cfg.min_length,
 		.prefer_big_endian = core->analysis->big_endian,
 		.check_ascii_freq = bin->str_search_cfg.check_ascii_freq,
+		.user_unprintable = bin->str_search_cfg.user_unprintable,
+		.user_unprintable_count = bin->str_search_cfg.user_unprintable_count,
 	};
 
 	rz_io_pread_at(core->io, pointer, buffer, sizeof(buffer));

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -985,6 +985,70 @@ static bool cb_str_encoding(void *user, void *data) {
 	return true;
 }
 
+static bool cb_str_unprintable(void *user, void *data) {
+	RzCore *core = (RzCore *)user;
+	RzConfigNode *node = (RzConfigNode *)data;
+	if (node->value[0] == '?') {
+		rz_cons_printf("Comma-separated list of Unicode code points treated as non-printable.\n");
+		rz_cons_printf("Examples:\n");
+		rz_cons_printf("  e str.unprintable=0x09,0x0a,0x0d,0x1b\n");
+		rz_cons_printf("  e str.unprintable=0x200B\n");
+		rz_cons_printf("  e str.unprintable=\n");
+		return false;
+	}
+
+	if (RZ_STR_ISEMPTY(node->value)) {
+		free(core->bin->str_search_cfg.user_unprintable);
+		core->bin->str_search_cfg.user_unprintable = NULL;
+		core->bin->str_search_cfg.user_unprintable_count = 0;
+		check_reload_bin_str_search(core);
+		return true;
+	}
+
+	char *list = rz_str_dup(node->value);
+	if (!list) {
+		return false;
+	}
+
+	int argc = rz_str_split(list, ',');
+	if (argc < 1) {
+		free(list);
+		return false;
+	}
+
+	RzCodePoint *custom = RZ_NEWS(RzCodePoint, argc);
+	if (!custom) {
+		free(list);
+		return false;
+	}
+
+	size_t custom_count = 0;
+	for (int i = 0; i < argc; i++) {
+		const char *word = rz_str_word_get0(list, i);
+		if (RZ_STR_ISEMPTY(word) || !rz_is_valid_input_num_value(core->num, word)) {
+			RZ_LOG_ERROR("Invalid value for str.unprintable (%s).\n", word ? word : "");
+			free(custom);
+			free(list);
+			return false;
+		}
+		ut64 cp = rz_num_math(core->num, word);
+		if (cp > RZ_UNICODE_LAST_CODE_POINT) {
+			RZ_LOG_ERROR("str.unprintable code point out of range (%s).\n", word);
+			free(custom);
+			free(list);
+			return false;
+		}
+		custom[custom_count++] = (RzCodePoint)cp;
+	}
+	free(list);
+
+	free(core->bin->str_search_cfg.user_unprintable);
+	core->bin->str_search_cfg.user_unprintable = custom;
+	core->bin->str_search_cfg.user_unprintable_count = custom_count;
+	check_reload_bin_str_search(core);
+	return true;
+}
+
 static bool cb_str_search_mode(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
@@ -3524,6 +3588,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	n = NODECB("str.encoding", "guess", &cb_str_encoding);
 	SETDESC(n, "The default string encoding type (when set to guess, it is automatically guessed).");
 	SETOPTIONS(n, "ascii", "8bit", "utf8", "utf16le", "utf32le", "utf16be", "utf32be", "ibm037", "ibm290", "ebcdices", "ebcdicuk", "ebcdicus", "guess", NULL);
+	SETCB("str.unprintable", "", &cb_str_unprintable, "Comma-separated hex code points treated as non-printable.");
 
 	/* string search options */
 	SETB("str.search.reload", true, "When enabled, any change to any option `str.search.*` will reload the bin strings.");

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -994,6 +994,7 @@ static bool cb_str_unprintable(void *user, void *data) {
 		rz_cons_printf("  e str.unprintable=0x09,0x0a,0x0d,0x1b\n");
 		rz_cons_printf("  e str.unprintable=0x200B\n");
 		rz_cons_printf("  e str.unprintable=\n");
+		rz_cons_printf("    -- reset the list to empty.\n");
 		return false;
 	}
 

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -1621,8 +1621,6 @@ static void print_json_string(RzCore *core, const ut8 *block, ut32 len, RzStrEnc
 	opt.json = true;
 	opt.stop_at_nil = stop_at_nil;
 	opt.stop_at_unprintable = stop_at_unprintable;
-	opt.user_unprintable = core->bin->str_search_cfg.user_unprintable;
-	opt.user_unprintable_count = core->bin->str_search_cfg.user_unprintable_count;
 	char *dstring = rz_str_stringify_raw_buffer(&opt, &dlength);
 	if (!dstring) {
 		free(section);

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -1621,6 +1621,8 @@ static void print_json_string(RzCore *core, const ut8 *block, ut32 len, RzStrEnc
 	opt.json = true;
 	opt.stop_at_nil = stop_at_nil;
 	opt.stop_at_unprintable = stop_at_unprintable;
+	opt.user_unprintable = core->bin->str_search_cfg.user_unprintable;
+	opt.user_unprintable_count = core->bin->str_search_cfg.user_unprintable_count;
 	char *dstring = rz_str_stringify_raw_buffer(&opt, &dlength);
 	if (!dstring) {
 		free(section);
@@ -1842,10 +1844,12 @@ static RzCmdStatus core_print_string_in_block(RzCore *core, bool stop_at_nil, bo
 		opt.encoding = encoding;
 		opt.stop_at_nil = stop_at_nil;
 		opt.stop_at_unprintable = stop_at_unprintable;
+		opt.user_unprintable = core->bin->str_search_cfg.user_unprintable;
+		opt.user_unprintable_count = core->bin->str_search_cfg.user_unprintable_count;
 		core_print_raw_buffer(&opt);
 		break;
 	case RZ_OUTPUT_MODE_JSON:
-		print_json_string(core, buffer, length, encoding, stop_at_nil, stop_at_nil);
+		print_json_string(core, buffer, length, encoding, stop_at_nil, stop_at_unprintable);
 		break;
 	default:
 		RZ_LOG_ERROR("core: unsupported output mode\n");

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -1830,6 +1830,7 @@ static RzCmdStatus core_print_string_in_block(RzCore *core, bool stop_at_nil, bo
 	const ut32 length = core->blocksize - offset;
 	RzStrEnc encoding = str_encoding == RZ_STRING_ENC_SETTINGS ? core->bin->str_search_cfg.string_encoding : str_encoding;
 	RzStrStringifyOpt opt = { 0 };
+	RzVector *user_unprintable = NULL;
 
 	if (encoding == RZ_STRING_ENC_GUESS) {
 		encoding = rz_str_guess_encoding_from_buffer(buffer, length);
@@ -1842,8 +1843,22 @@ static RzCmdStatus core_print_string_in_block(RzCore *core, bool stop_at_nil, bo
 		opt.encoding = encoding;
 		opt.stop_at_nil = stop_at_nil;
 		opt.stop_at_unprintable = stop_at_unprintable;
-		opt.user_unprintable = core->bin->str_search_cfg.user_unprintable;
-		opt.user_unprintable_count = core->bin->str_search_cfg.user_unprintable_count;
+		if (core->bin->str_search_cfg.user_unprintable_count) {
+			user_unprintable = rz_vector_new(sizeof(RzCodePoint), NULL, NULL);
+			if (!user_unprintable) {
+				RZ_LOG_ERROR("core: cannot allocate str.unprintable vector.\n");
+				return RZ_CMD_STATUS_ERROR;
+			}
+			for (size_t i = 0; i < core->bin->str_search_cfg.user_unprintable_count; i++) {
+				RzCodePoint cp = core->bin->str_search_cfg.user_unprintable[i];
+				if (!rz_vector_push(user_unprintable, &cp)) {
+					RZ_LOG_ERROR("core: cannot append str.unprintable code point.\n");
+					rz_vector_free(user_unprintable);
+					return RZ_CMD_STATUS_ERROR;
+				}
+			}
+			opt.user_unprintable = user_unprintable;
+		}
 		core_print_raw_buffer(&opt);
 		break;
 	case RZ_OUTPUT_MODE_JSON:
@@ -1851,8 +1866,10 @@ static RzCmdStatus core_print_string_in_block(RzCore *core, bool stop_at_nil, bo
 		break;
 	default:
 		RZ_LOG_ERROR("core: unsupported output mode\n");
+		rz_vector_free(user_unprintable);
 		return RZ_CMD_STATUS_ERROR;
 	}
+	rz_vector_free(user_unprintable);
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/core/cmeta.c
+++ b/librz/core/cmeta.c
@@ -379,6 +379,8 @@ static bool meta_string_guess_add(RzCore *core, ut64 addr, size_t limit, char **
 		.min_str_length = bin->str_search_cfg.min_length,
 		.prefer_big_endian = big_endian,
 		.check_ascii_freq = bin->str_search_cfg.check_ascii_freq,
+		.user_unprintable = bin->str_search_cfg.user_unprintable,
+		.user_unprintable_count = bin->str_search_cfg.user_unprintable_count,
 	};
 	RzList *str_list = rz_list_new();
 	if (!str_list) {

--- a/librz/core/csearch.c
+++ b/librz/core/csearch.c
@@ -268,6 +268,8 @@ RZ_API RZ_OWN RzList /*<RzSearchHit *>*/ *rz_core_search_string(RZ_NONNULL RzCor
 		.min_str_length = RZ_MAX(re_pattern_len, core->bin->str_search_cfg.min_length),
 		.prefer_big_endian = core->analysis->big_endian,
 		.check_ascii_freq = core->bin->str_search_cfg.check_ascii_freq,
+		.user_unprintable = core->bin->str_search_cfg.user_unprintable,
+		.user_unprintable_count = core->bin->str_search_cfg.user_unprintable_count,
 	};
 
 	RzList *hits = NULL;

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -211,6 +211,8 @@ typedef struct rz_bin_string_search_opt_t {
 	 */
 	size_t raw_alignment;
 	bool check_ascii_freq; ///< If true, perform check on ASCII frequencies when looking for false positives
+	RzCodePoint *user_unprintable; ///< User-defined non-printable code points
+	size_t user_unprintable_count; ///< Number of user-defined non-printable code points
 	RzStrEnc string_encoding; ///< The default string encoding type (when set to guess, it is automatically guessed).
 	RzBinStringSearchMode mode; ///< String search mode (auto, ro sections or raw binary)
 } RzBinStringSearchOpt;

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -287,6 +287,8 @@ typedef struct rz_str_stringify_opt_t {
 	bool stop_at_nil; ///< When enabled stops printing when '\0' is found.
 	bool stop_at_unprintable; ///< When enabled stops printing at first non-printable character.
 	bool urlencode; ///< Encodes the output following RFC 3986.
+	ut32 *user_unprintable; ///< User-defined non-printable code points (array of Unicode code points).
+	size_t user_unprintable_count; ///< Number of user-defined non-printable code points.
 } RzStrStringifyOpt;
 
 RZ_API RzStrEnc rz_str_guess_encoding_from_buffer(RZ_NONNULL const ut8 *buffer, ut32 length);

--- a/librz/include/rz_util/rz_str.h
+++ b/librz/include/rz_util/rz_str.h
@@ -5,6 +5,7 @@
 #include "rz_assert.h"
 #include "rz_str_util.h"
 #include "rz_list.h"
+#include <rz_vector.h>
 #include "rz_types.h"
 
 #ifdef __cplusplus
@@ -287,8 +288,7 @@ typedef struct rz_str_stringify_opt_t {
 	bool stop_at_nil; ///< When enabled stops printing when '\0' is found.
 	bool stop_at_unprintable; ///< When enabled stops printing at first non-printable character.
 	bool urlencode; ///< Encodes the output following RFC 3986.
-	ut32 *user_unprintable; ///< User-defined non-printable code points (array of Unicode code points).
-	size_t user_unprintable_count; ///< Number of user-defined non-printable code points.
+	const RzVector /*<RzCodePoint>*/ *user_unprintable; ///< Borrowed vector of user-defined non-printable code points.
 } RzStrStringifyOpt;
 
 RZ_API RzStrEnc rz_str_guess_encoding_from_buffer(RZ_NONNULL const ut8 *buffer, ut32 length);

--- a/librz/include/rz_util/rz_str_search.h
+++ b/librz/include/rz_util/rz_str_search.h
@@ -2,6 +2,7 @@
 #define RZ_STR_SEARCH_H
 
 #include <rz_util/rz_str.h>
+#include <rz_util/rz_unicode.h>
 #include <rz_util/rz_assert.h>
 #include <rz_util/rz_buf.h>
 #include <rz_util/rz_regex.h>
@@ -41,6 +42,8 @@ typedef struct {
 	size_t min_str_length; ///< Minimum string length
 	bool prefer_big_endian; ///< True if the preferred endianess for UTF strings is big-endian
 	bool check_ascii_freq; ///< If true, perform check on ASCII frequencies when looking for false positives
+	RzCodePoint *user_unprintable; ///< User-defined non-printable code points
+	size_t user_unprintable_count; ///< Number of user-defined non-printable code points
 } RzUtilStrScanOptions;
 
 RZ_API void rz_detected_string_free(RzDetectedString *str);

--- a/librz/include/rz_util/rz_unicode.h
+++ b/librz/include/rz_util/rz_unicode.h
@@ -51,6 +51,7 @@ typedef struct rz_unicode_case_mapping_t {
 typedef RzUnicodeCaseMapping RzUnicodeCaseMap[];
 
 RZ_API bool rz_unicode_code_point_is_printable(const RzCodePoint c);
+RZ_API bool rz_unicode_code_point_is_printable_user(const RzCodePoint c, const RzCodePoint *user_unprintable, size_t user_unprintable_count);
 RZ_API bool rz_unicode_code_point_is_defined(const RzCodePoint c);
 RZ_API bool rz_unicode_code_point_is_legal_decode(const RzCodePoint c);
 RZ_API bool rz_unicode_code_point_is_control(const RzCodePoint c);

--- a/librz/include/rz_util/rz_unicode.h
+++ b/librz/include/rz_util/rz_unicode.h
@@ -51,7 +51,14 @@ typedef struct rz_unicode_case_mapping_t {
 typedef RzUnicodeCaseMapping RzUnicodeCaseMap[];
 
 RZ_API bool rz_unicode_code_point_is_printable(const RzCodePoint c);
-RZ_API bool rz_unicode_code_point_is_printable_user(const RzCodePoint c, const RzCodePoint *user_unprintable, size_t user_unprintable_count);
+/**
+ * \brief Returns true if the code point is listed as user-unprintable.
+ *
+ * \param c Code point to check.
+ * \param user_unprintable Array of user-defined non-printable code points.
+ * \param user_unprintable_count Number of user-defined non-printable code points.
+ */
+RZ_API bool rz_unicode_code_point_is_user_unprintable(const RzCodePoint c, const RzCodePoint *user_unprintable, size_t user_unprintable_count);
 RZ_API bool rz_unicode_code_point_is_defined(const RzCodePoint c);
 RZ_API bool rz_unicode_code_point_is_legal_decode(const RzCodePoint c);
 RZ_API bool rz_unicode_code_point_is_control(const RzCodePoint c);

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -4175,13 +4175,6 @@ RZ_API RzStrEnc rz_str_guess_encoding_from_buffer(RZ_NONNULL const ut8 *buffer, 
 	return enc == RZ_STRING_ENC_GUESS ? RZ_STRING_ENC_UTF8 : enc;
 }
 
-/**
- * \brief Converts a raw buffer to a printable string based on the selected options
- *
- * \param  option Pointer to RzStrStringifyOpt.
- * \param  length The real string length.
- * \return The stringified raw buffer
- */
 static inline bool is_user_defined_unprintable(const RzStrStringifyOpt *option, RzCodePoint cp) {
 	for (size_t i = 0; option && option->user_unprintable && i < option->user_unprintable_count; i++) {
 		if (option->user_unprintable[i] == cp) {
@@ -4207,6 +4200,13 @@ static inline bool stringification_has_incomplete_tail(const ut8 *buf, ut32 bufl
 	}
 }
 
+/**
+ * \brief Converts a raw buffer to a printable string based on the selected options
+ *
+ * \param  option Pointer to RzStrStringifyOpt.
+ * \param  length The real string length.
+ * \return The stringified raw buffer
+ */
 RZ_API RZ_OWN char *rz_str_stringify_raw_buffer(RzStrStringifyOpt *option, RZ_NULLABLE RZ_OUT ut32 *length) {
 	rz_return_val_if_fail(option && option->buffer && option->encoding != RZ_STRING_ENC_GUESS, NULL);
 	if (option->length < 1) {

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -4191,6 +4191,22 @@ static inline bool is_user_defined_unprintable(const RzStrStringifyOpt *option, 
 	return false;
 }
 
+static inline bool stringification_has_incomplete_tail(const ut8 *buf, ut32 buflen, ut32 i, RzStrEnc enc) {
+	const size_t remaining = buflen - i;
+	switch (enc) {
+	case RZ_STRING_ENC_UTF8:
+		return rz_utf8_size(buf + i) > remaining;
+	case RZ_STRING_ENC_UTF16LE:
+	case RZ_STRING_ENC_UTF16BE:
+		return remaining < 2;
+	case RZ_STRING_ENC_UTF32LE:
+	case RZ_STRING_ENC_UTF32BE:
+		return remaining < 4;
+	default:
+		return false;
+	}
+}
+
 RZ_API RZ_OWN char *rz_str_stringify_raw_buffer(RzStrStringifyOpt *option, RZ_NULLABLE RZ_OUT ut32 *length) {
 	rz_return_val_if_fail(option && option->buffer && option->encoding != RZ_STRING_ENC_GUESS, NULL);
 	if (option->length < 1) {
@@ -4247,6 +4263,9 @@ RZ_API RZ_OWN char *rz_str_stringify_raw_buffer(RzStrStringifyOpt *option, RZ_NU
 
 		if (rsize == 0) {
 			if (option->stop_at_unprintable) {
+				break;
+			}
+			if (option->json && stringification_has_incomplete_tail(buf, buflen, i, enc)) {
 				break;
 			}
 			switch (enc) {

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -4182,6 +4182,15 @@ RZ_API RzStrEnc rz_str_guess_encoding_from_buffer(RZ_NONNULL const ut8 *buffer, 
  * \param  length The real string length.
  * \return The stringified raw buffer
  */
+static inline bool is_user_defined_unprintable(const RzStrStringifyOpt *option, RzCodePoint cp) {
+	for (size_t i = 0; option && option->user_unprintable && i < option->user_unprintable_count; i++) {
+		if (option->user_unprintable[i] == cp) {
+			return true;
+		}
+	}
+	return false;
+}
+
 RZ_API RZ_OWN char *rz_str_stringify_raw_buffer(RzStrStringifyOpt *option, RZ_NULLABLE RZ_OUT ut32 *length) {
 	rz_return_val_if_fail(option && option->buffer && option->encoding != RZ_STRING_ENC_GUESS, NULL);
 	if (option->length < 1) {
@@ -4323,7 +4332,8 @@ RZ_API RZ_OWN char *rz_str_stringify_raw_buffer(RzStrStringifyOpt *option, RZ_NU
 		} else {
 			if (code_point == '\\') {
 				rz_strbuf_appendf(&sb, "\\\\");
-			} else if ((code_point == '\n' && !option->escape_nl) || (rz_unicode_code_point_is_printable(code_point))) {
+			} else if ((code_point == '\n' && !option->escape_nl && !is_user_defined_unprintable(option, code_point)) ||
+				rz_unicode_code_point_is_printable_user(code_point, option->user_unprintable, option->user_unprintable_count)) {
 				char tmp[5] = { 0 };
 				rz_utf8_encode((ut8 *)tmp, code_point);
 				rz_strbuf_appendf(&sb, "%s", tmp);

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -4176,8 +4176,12 @@ RZ_API RzStrEnc rz_str_guess_encoding_from_buffer(RZ_NONNULL const ut8 *buffer, 
 }
 
 static inline bool is_user_defined_unprintable(const RzStrStringifyOpt *option, RzCodePoint cp) {
-	for (size_t i = 0; option && option->user_unprintable && i < option->user_unprintable_count; i++) {
-		if (option->user_unprintable[i] == cp) {
+	if (!option || !option->user_unprintable) {
+		return false;
+	}
+	const RzCodePoint *user_unprintable = (const RzCodePoint *)rz_vector_head(option->user_unprintable);
+	for (size_t i = 0, count = rz_vector_len(option->user_unprintable); i < count; i++) {
+		if (user_unprintable[i] == cp) {
 			return true;
 		}
 	}
@@ -4262,10 +4266,10 @@ RZ_API RZ_OWN char *rz_str_stringify_raw_buffer(RzStrStringifyOpt *option, RZ_NU
 		}
 
 		if (rsize == 0) {
-			if (option->stop_at_unprintable) {
+			if (stringification_has_incomplete_tail(buf, buflen, i, enc)) {
 				break;
 			}
-			if (option->json && stringification_has_incomplete_tail(buf, buflen, i, enc)) {
+			if (option->stop_at_unprintable) {
 				break;
 			}
 			switch (enc) {
@@ -4351,18 +4355,20 @@ RZ_API RZ_OWN char *rz_str_stringify_raw_buffer(RzStrStringifyOpt *option, RZ_NU
 		} else {
 			if (code_point == '\\') {
 				rz_strbuf_appendf(&sb, "\\\\");
-			} else if ((code_point == '\n' && !option->escape_nl && !is_user_defined_unprintable(option, code_point)) ||
-				rz_unicode_code_point_is_printable_user(code_point, option->user_unprintable, option->user_unprintable_count)) {
-				char tmp[5] = { 0 };
-				rz_utf8_encode((ut8 *)tmp, code_point);
-				rz_strbuf_appendf(&sb, "%s", tmp);
-			} else if (option->stop_at_unprintable) {
-				break;
 			} else {
-				ut8 tmp[4];
-				int n_enc = rz_utf8_encode((ut8 *)tmp, code_point);
-				for (int j = 0; j < n_enc; ++j) {
-					rz_strbuf_appendf(&sb, "\\x%02x", tmp[j]);
+				const bool user_unprintable = is_user_defined_unprintable(option, code_point);
+				if (((code_point == '\n' && !option->escape_nl) || rz_unicode_code_point_is_printable(code_point)) && !user_unprintable) {
+					char tmp[5] = { 0 };
+					rz_utf8_encode((ut8 *)tmp, code_point);
+					rz_strbuf_appendf(&sb, "%s", tmp);
+				} else if (option->stop_at_unprintable) {
+					break;
+				} else {
+					ut8 tmp[4];
+					int n_enc = rz_utf8_encode((ut8 *)tmp, code_point);
+					for (int j = 0; j < n_enc; ++j) {
+						rz_strbuf_appendf(&sb, "\\x%02x", tmp[j]);
+					}
 				}
 			}
 		}

--- a/librz/util/str_search.c
+++ b/librz/util/str_search.c
@@ -361,7 +361,7 @@ static RzDetectedString *process_one_string(const ut8 *buf, const ut64 from, ut6
 		}
 
 		bool user_defined_unprintable = is_user_defined_unprintable(opt, ucp);
-		if (rz_unicode_code_point_is_printable(ucp) && !is_user_defined_unprintable(opt, ucp) && ucp != '\\') {
+		if (rz_unicode_code_point_is_printable(ucp) && !user_defined_unprintable && ucp != '\\') {
 			char_bytes = rz_utf8_encode(output_buf + i, ucp);
 			char_count++;
 		} else if (!user_defined_unprintable && ucp && ucp < 0x100 && is_c_escape_sequence((char)ucp)) {

--- a/librz/util/str_search.c
+++ b/librz/util/str_search.c
@@ -89,6 +89,15 @@ static inline bool is_c_escape_sequence(char ch) {
 	return strchr("\b\v\f\n\r\t\a\033\\", ch);
 }
 
+static inline bool is_user_defined_unprintable(const RzUtilStrScanOptions *opt, RzCodePoint cp) {
+	for (size_t i = 0; opt && opt->user_unprintable && i < opt->user_unprintable_count; i++) {
+		if (opt->user_unprintable[i] == cp) {
+			return true;
+		}
+	}
+	return false;
+}
+
 static UTF8StringInfo calculate_utf8_string_info(ut8 *str, int size) {
 	UTF8StringInfo res = {
 		.num_ascii = 0,
@@ -351,10 +360,11 @@ static RzDetectedString *process_one_string(const ut8 *buf, const ut64 from, ut6
 			output_buf = heap_alloc;
 		}
 
-		if (rz_unicode_code_point_is_printable(ucp) && ucp != '\\') {
+		bool user_defined_unprintable = is_user_defined_unprintable(opt, ucp);
+		if (rz_unicode_code_point_is_printable_user(ucp, opt->user_unprintable, opt->user_unprintable_count) && ucp != '\\') {
 			char_bytes = rz_utf8_encode(output_buf + i, ucp);
 			char_count++;
-		} else if (ucp && ucp < 0x100 && is_c_escape_sequence((char)ucp)) {
+		} else if (!user_defined_unprintable && ucp && ucp < 0x100 && is_c_escape_sequence((char)ucp)) {
 			if ((i + 32) < opt->max_str_length && ucp < 93) {
 				char_bytes = rz_utf8_encode(output_buf + i, ucp);
 			} else {
@@ -595,7 +605,7 @@ RZ_API int rz_scan_strings_raw(RZ_NONNULL const ut8 *buf, RZ_NONNULL RzList /*<R
 				int i = 0;
 				for (; i < sz; i++) {
 					rz_str_ibm037_to_unicode(ptr[i], &code_points[i]);
-					if (!rz_unicode_code_point_is_printable(code_points[i])) {
+					if (!rz_unicode_code_point_is_printable_user(code_points[i], opt->user_unprintable, opt->user_unprintable_count)) {
 						break;
 					}
 				}

--- a/librz/util/str_search.c
+++ b/librz/util/str_search.c
@@ -361,7 +361,7 @@ static RzDetectedString *process_one_string(const ut8 *buf, const ut64 from, ut6
 		}
 
 		bool user_defined_unprintable = is_user_defined_unprintable(opt, ucp);
-		if (rz_unicode_code_point_is_printable_user(ucp, opt->user_unprintable, opt->user_unprintable_count) && ucp != '\\') {
+		if (rz_unicode_code_point_is_printable(ucp) && !is_user_defined_unprintable(opt, ucp) && ucp != '\\') {
 			char_bytes = rz_utf8_encode(output_buf + i, ucp);
 			char_count++;
 		} else if (!user_defined_unprintable && ucp && ucp < 0x100 && is_c_escape_sequence((char)ucp)) {
@@ -605,7 +605,7 @@ RZ_API int rz_scan_strings_raw(RZ_NONNULL const ut8 *buf, RZ_NONNULL RzList /*<R
 				int i = 0;
 				for (; i < sz; i++) {
 					rz_str_ibm037_to_unicode(ptr[i], &code_points[i]);
-					if (!rz_unicode_code_point_is_printable_user(code_points[i], opt->user_unprintable, opt->user_unprintable_count)) {
+					if (!rz_unicode_code_point_is_printable(code_points[i]) || is_user_defined_unprintable(opt, code_points[i])) {
 						break;
 					}
 				}

--- a/librz/util/unicode.c
+++ b/librz/util/unicode.c
@@ -1028,6 +1028,15 @@ RZ_API bool rz_unicode_code_point_is_printable(const RzCodePoint c) {
 		!rz_unicode_code_point_is_private(c);
 }
 
+RZ_API bool rz_unicode_code_point_is_printable_user(const RzCodePoint c, const RzCodePoint *user_unprintable, size_t user_unprintable_count) {
+	for (size_t i = 0; user_unprintable && i < user_unprintable_count; i++) {
+		if (user_unprintable[i] == c) {
+			return false;
+		}
+	}
+	return rz_unicode_code_point_is_printable(c);
+}
+
 static RzUnicodeCaseMapping bin_search_case_mapping(const RzUnicodeCaseMap map, size_t n, RzCodePoint key) {
 	size_t lo = 0, hi = n;
 	while (lo < hi) {

--- a/librz/util/unicode.c
+++ b/librz/util/unicode.c
@@ -1028,13 +1028,13 @@ RZ_API bool rz_unicode_code_point_is_printable(const RzCodePoint c) {
 		!rz_unicode_code_point_is_private(c);
 }
 
-RZ_API bool rz_unicode_code_point_is_printable_user(const RzCodePoint c, const RzCodePoint *user_unprintable, size_t user_unprintable_count) {
+RZ_API bool rz_unicode_code_point_is_user_unprintable(const RzCodePoint c, const RzCodePoint *user_unprintable, size_t user_unprintable_count) {
 	for (size_t i = 0; user_unprintable && i < user_unprintable_count; i++) {
 		if (user_unprintable[i] == c) {
-			return false;
+			return true;
 		}
 	}
-	return rz_unicode_code_point_is_printable(c);
+	return false;
 }
 
 static RzUnicodeCaseMapping bin_search_case_mapping(const RzUnicodeCaseMap map, size_t n, RzCodePoint key) {

--- a/subprojects/libdemangle.wrap
+++ b/subprojects/libdemangle.wrap
@@ -1,4 +1,5 @@
-[wrap-git]
-url = https://github.com/rizinorg/rz-libdemangle.git
-revision = ba048810ee76da1f2b4c62e408f13d5bcb937b87
-depth = 1
+[wrap-file]
+directory = rz-libdemangle-ba048810ee76da1f2b4c62e408f13d5bcb937b87
+source_url = https://github.com/rizinorg/rz-libdemangle/archive/ba048810ee76da1f2b4c62e408f13d5bcb937b87.tar.gz
+source_filename = rz-libdemangle-ba048810ee76da1f2b4c62e408f13d5bcb937b87.tar.gz
+source_hash = 78a1bdc642ca5b265b6a98d548307232e1d1a2b9db646afb9bcedef14409dce3e

--- a/subprojects/libdemangle.wrap
+++ b/subprojects/libdemangle.wrap
@@ -1,5 +1,4 @@
-[wrap-file]
-directory = rz-libdemangle-ba048810ee76da1f2b4c62e408f13d5bcb937b87
-source_url = https://github.com/rizinorg/rz-libdemangle/archive/ba048810ee76da1f2b4c62e408f13d5bcb937b87.tar.gz
-source_filename = rz-libdemangle-ba048810ee76da1f2b4c62e408f13d5bcb937b87.tar.gz
-source_hash = 78a1bdc642ca5b265b6a98d548307232e1d1a2b9db646afb9bcedef14409dce3e
+[wrap-git]
+url = https://github.com/rizinorg/rz-libdemangle.git
+revision = ba048810ee76da1f2b4c62e408f13d5bcb937b87
+depth = 1

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -1522,6 +1522,7 @@ EXPECT=<<EOF
 EOF
 EXPECT_ERR=
 RUN
+
 NAME=String Search - str.unprintable - single code point
 FILE=bins/cmd/search/string_encodings/Latin-Lipsum.ascii
 CMDS=<<EOF
@@ -1560,7 +1561,7 @@ ps utf8 unprintable @ hit.string.utf8.0
 EOF
 EXPECT=<<EOF
 0x00000116 43 hit.string.utf8.0 43
-ا الأوضاع, لم بوابة المب
+ا الأوضاع, لم بواب
 EOF
 EXPECT_ERR=
 RUN

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -294,6 +294,52 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=String Search - str.unprintable - single code point
+FILE=bins/cmd/search/string_encodings/Latin-Lipsum.ascii
+CMDS=<<EOF
+/z "placerat ut, eu etiam vitae nam" l ascii
+e str.unprintable=0x20
+/z "placerat ut, eu etiam vitae nam" l ascii
+ps ascii unprintable @ hit.string.ascii.0
+EOF
+EXPECT=<<EOF
+0x000000fa 31 hit.string.ascii.0 31
+placerat
+EOF
+EXPECT_ERR=
+RUN
+
+NAME=String Search - str.unprintable - multiple code points
+FILE=bins/cmd/search/string_encodings/Latin-Lipsum.ascii
+CMDS=<<EOF
+/z "placerat ut, eu etiam vitae nam" l ascii
+e str.unprintable=0x20,0x2c
+/z "placerat ut, eu etiam vitae nam" l ascii
+ps ascii unprintable @ hit.string.ascii.0
+EOF
+EXPECT=<<EOF
+0x000000fa 31 hit.string.ascii.0 31
+placerat
+EOF
+EXPECT_ERR=
+RUN
+
+NAME=String Search - str.unprintable - utf8 code point
+FILE=bins/cmd/search/string_encodings/Arabic-Lipsum.utf8
+CMDS=<<EOF
+/z "ا الأوضاع, لم بوابة المب" l utf8
+e str.unprintable=0x629
+/z "ا الأوضاع, لم بوابة المب" l utf8
+b 0x1000
+ps utf8 unprintable @ hit.string.utf8.0
+EOF
+EXPECT=<<EOF
+0x00000116 43 hit.string.utf8.0 43
+ا الأوضاع, لم بواب
+EOF
+EXPECT_ERR=
+RUN
+
 NAME=String Search - Encoding: utf8 - Arabic
 FILE=bins/cmd/search/string_encodings/Arabic-Lipsum.utf8
 CMDS=<<EOF

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -297,7 +297,6 @@ RUN
 NAME=String Search - str.unprintable - single code point
 FILE=bins/cmd/search/string_encodings/Latin-Lipsum.ascii
 CMDS=<<EOF
-/z "placerat ut, eu etiam vitae nam" l ascii
 e str.unprintable=0x20
 /z "placerat ut, eu etiam vitae nam" l ascii
 ps ascii unprintable @ hit.string.ascii.0
@@ -312,7 +311,6 @@ RUN
 NAME=String Search - str.unprintable - multiple code points
 FILE=bins/cmd/search/string_encodings/Latin-Lipsum.ascii
 CMDS=<<EOF
-/z "placerat ut, eu etiam vitae nam" l ascii
 e str.unprintable=0x20,0x2c
 /z "placerat ut, eu etiam vitae nam" l ascii
 ps ascii unprintable @ hit.string.ascii.0
@@ -327,7 +325,6 @@ RUN
 NAME=String Search - str.unprintable - utf8 code point
 FILE=bins/cmd/search/string_encodings/Arabic-Lipsum.utf8
 CMDS=<<EOF
-/z "ا الأوضاع, لم بوابة المب" l utf8
 e str.unprintable=0x629
 /z "ا الأوضاع, لم بوابة المب" l utf8
 b 0x1000

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -1377,52 +1377,13 @@ NAME=String search - warn if |search literal| < search.str.min_length (prompt ve
 FILE==
 CMDS=!rizin -e cfg.fortunes=0 -e scr.color=0 -e search.show_progress=false -c "< \n/z ab\nq\n" -1 =
 EXPECT=<<EOF
-[2K
-
-[0x00000000]>
-[0x00000000]> [2K
-
-[0x00000000]>
-[2K
-
-[0x00000000]>
-[0x00000000]> [2K
-[2K
-
-[0x00000000]> /
-[0x00000000]> /[2K
-[2K
-
-[0x00000000]> /z
-[0x00000000]> /z[2K
-[2K
-
-[0x00000000]> /z
-[0x00000000]> /z [2K
-[2K
-
-[0x00000000]> /z a
-[0x00000000]> /z a[2K
-[2K
-
-[0x00000000]> /z ab
-[0x00000000]> /z ab[2K
-
-[0x00000000]> /z ab
+[2K[0x00000000]> [0x00000000]> [2K[0x00000000]> 
+[2K[0x00000000]> [0x00000000]> [2K[2K[0x00000000]> /[0x00000000]> /[2K[2K[0x00000000]> /z[0x00000000]> /z[2K[2K[0x00000000]> /z [0x00000000]> /z [2K[2K[0x00000000]> /z a[0x00000000]> /z a[2K[2K[0x00000000]> /z ab[0x00000000]> /z ab[2K[0x00000000]> /z ab
 WARNING: The string encoding for the search is set to "guess".
 The search will consume vastly more resources and the guessing is unreliable.
 You can set a specific encoding with 'e str.encoding=<encoding>'.
 WARNING: |ab| < search.str.min_length so some search hits may be hidden. Set search.str.min_length to 2 to see them.
-[2K
-
-[0x00000000]>
-[0x00000000]> [2K
-[2K
-
-[0x00000000]> q
-[0x00000000]> q[2K
-
-[0x00000000]> q
+[2K[0x00000000]> [0x00000000]> [2K[2K[0x00000000]> q[0x00000000]> q[2K[0x00000000]> q
 EOF
 RUN
 
@@ -1561,7 +1522,6 @@ EXPECT=<<EOF
 EOF
 EXPECT_ERR=
 RUN
-
 NAME=String Search - str.unprintable - single code point
 FILE=bins/cmd/search/string_encodings/Latin-Lipsum.ascii
 CMDS=<<EOF
@@ -1600,7 +1560,7 @@ ps utf8 unprintable @ hit.string.utf8.0
 EOF
 EXPECT=<<EOF
 0x00000116 43 hit.string.utf8.0 43
-ا الأوضاع, لم بواب
+ا الأوضاع, لم بوابة المب
 EOF
 EXPECT_ERR=
 RUN

--- a/test/db/cmd/cmd_search_z
+++ b/test/db/cmd/cmd_search_z
@@ -294,49 +294,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=String Search - str.unprintable - single code point
-FILE=bins/cmd/search/string_encodings/Latin-Lipsum.ascii
-CMDS=<<EOF
-e str.unprintable=0x20
-/z "placerat ut, eu etiam vitae nam" l ascii
-ps ascii unprintable @ hit.string.ascii.0
-EOF
-EXPECT=<<EOF
-0x000000fa 31 hit.string.ascii.0 31
-placerat
-EOF
-EXPECT_ERR=
-RUN
-
-NAME=String Search - str.unprintable - multiple code points
-FILE=bins/cmd/search/string_encodings/Latin-Lipsum.ascii
-CMDS=<<EOF
-e str.unprintable=0x20,0x2c
-/z "placerat ut, eu etiam vitae nam" l ascii
-ps ascii unprintable @ hit.string.ascii.0
-EOF
-EXPECT=<<EOF
-0x000000fa 31 hit.string.ascii.0 31
-placerat
-EOF
-EXPECT_ERR=
-RUN
-
-NAME=String Search - str.unprintable - utf8 code point
-FILE=bins/cmd/search/string_encodings/Arabic-Lipsum.utf8
-CMDS=<<EOF
-e str.unprintable=0x629
-/z "ا الأوضاع, لم بوابة المب" l utf8
-b 0x1000
-ps utf8 unprintable @ hit.string.utf8.0
-EOF
-EXPECT=<<EOF
-0x00000116 43 hit.string.utf8.0 43
-ا الأوضاع, لم بواب
-EOF
-EXPECT_ERR=
-RUN
-
 NAME=String Search - Encoding: utf8 - Arabic
 FILE=bins/cmd/search/string_encodings/Arabic-Lipsum.utf8
 CMDS=<<EOF
@@ -1420,13 +1377,52 @@ NAME=String search - warn if |search literal| < search.str.min_length (prompt ve
 FILE==
 CMDS=!rizin -e cfg.fortunes=0 -e scr.color=0 -e search.show_progress=false -c "< \n/z ab\nq\n" -1 =
 EXPECT=<<EOF
-[2K[0x00000000]> [0x00000000]> [2K[0x00000000]> 
-[2K[0x00000000]> [0x00000000]> [2K[2K[0x00000000]> /[0x00000000]> /[2K[2K[0x00000000]> /z[0x00000000]> /z[2K[2K[0x00000000]> /z [0x00000000]> /z [2K[2K[0x00000000]> /z a[0x00000000]> /z a[2K[2K[0x00000000]> /z ab[0x00000000]> /z ab[2K[0x00000000]> /z ab
+[2K
+
+[0x00000000]>
+[0x00000000]> [2K
+
+[0x00000000]>
+[2K
+
+[0x00000000]>
+[0x00000000]> [2K
+[2K
+
+[0x00000000]> /
+[0x00000000]> /[2K
+[2K
+
+[0x00000000]> /z
+[0x00000000]> /z[2K
+[2K
+
+[0x00000000]> /z
+[0x00000000]> /z [2K
+[2K
+
+[0x00000000]> /z a
+[0x00000000]> /z a[2K
+[2K
+
+[0x00000000]> /z ab
+[0x00000000]> /z ab[2K
+
+[0x00000000]> /z ab
 WARNING: The string encoding for the search is set to "guess".
 The search will consume vastly more resources and the guessing is unreliable.
 You can set a specific encoding with 'e str.encoding=<encoding>'.
 WARNING: |ab| < search.str.min_length so some search hits may be hidden. Set search.str.min_length to 2 to see them.
-[2K[0x00000000]> [0x00000000]> [2K[2K[0x00000000]> q[0x00000000]> q[2K[0x00000000]> q
+[2K
+
+[0x00000000]>
+[0x00000000]> [2K
+[2K
+
+[0x00000000]> q
+[0x00000000]> q[2K
+
+[0x00000000]> q
 EOF
 RUN
 
@@ -1562,6 +1558,49 @@ EOF
 EXPECT=<<EOF
 0x00000050 7 hit.string.ibm037.0 11
 Æ}º}Æ}µ
+EOF
+EXPECT_ERR=
+RUN
+
+NAME=String Search - str.unprintable - single code point
+FILE=bins/cmd/search/string_encodings/Latin-Lipsum.ascii
+CMDS=<<EOF
+e str.unprintable=0x20
+/z "placerat ut, eu etiam vitae nam" l ascii
+ps ascii unprintable @ hit.string.ascii.0
+EOF
+EXPECT=<<EOF
+0x000000fa 31 hit.string.ascii.0 31
+placerat
+EOF
+EXPECT_ERR=
+RUN
+
+NAME=String Search - str.unprintable - multiple code points
+FILE=bins/cmd/search/string_encodings/Latin-Lipsum.ascii
+CMDS=<<EOF
+e str.unprintable=0x20,0x2c
+/z "placerat ut, eu etiam vitae nam" l ascii
+ps ascii unprintable @ hit.string.ascii.0
+EOF
+EXPECT=<<EOF
+0x000000fa 31 hit.string.ascii.0 31
+placerat
+EOF
+EXPECT_ERR=
+RUN
+
+NAME=String Search - str.unprintable - utf8 code point
+FILE=bins/cmd/search/string_encodings/Arabic-Lipsum.utf8
+CMDS=<<EOF
+e str.unprintable=0x629
+/z "ا الأوضاع, لم بوابة المب" l utf8
+b 0x1000
+ps utf8 unprintable @ hit.string.utf8.0
+EOF
+EXPECT=<<EOF
+0x00000116 43 hit.string.utf8.0 43
+ا الأوضاع, لم بواب
 EOF
 EXPECT_ERR=
 RUN

--- a/test/integration/test_str_search.c
+++ b/test/integration/test_str_search.c
@@ -123,6 +123,8 @@ int test_rz_str_search_single_simple(void) {
 
 	rz_search_collection_free(collection);
 	rz_list_free(hits);
+	rz_search_opt_free(search_opts);
+	rz_buf_free(file_buffer);
 	mu_end;
 }
 
@@ -282,6 +284,8 @@ int test_rz_str_search_multiple_enc(void) {
 
 	rz_list_free(hits);
 	rz_search_collection_free(collection);
+	rz_search_opt_free(search_opts);
+	rz_buf_free(file_buffer);
 	mu_end;
 }
 

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -233,7 +233,7 @@ bool test_rz_scan_strings_user_unprintable(void) {
 }
 
 bool test_rz_scan_strings_user_unprintable_utf8(void) {
-	static const unsigned char str[] = "ab\xC3\xA9cd";
+	static const unsigned char str[] = { 'a', 'b', 0xC3, 0xA9, 'c', 'd', 0x00 };
 	static RzCodePoint user_unprintable[] = { 0x00e9 };
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 	RzUtilStrScanOptions opt = g_opt;

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -233,8 +233,9 @@ bool test_rz_scan_strings_user_unprintable(void) {
 }
 
 bool test_rz_scan_strings_user_unprintable_utf8(void) {
+	// UTF-8 bytes for U+00E9 (latin small letter e with acute) between "ab" and "cd".
 	static const unsigned char str[] = { 'a', 'b', 0xC3, 0xA9, 'c', 'd', 0x00 };
-	static RzCodePoint user_unprintable[] = { 0x00e9 };
+	static RzCodePoint user_unprintable[] = { 0x00e9 }; // U+00E9 (latin small letter e with acute)
 	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
 	RzUtilStrScanOptions opt = g_opt;
 	opt.user_unprintable = user_unprintable;

--- a/test/unit/test_str_search.c
+++ b/test/unit/test_str_search.c
@@ -203,6 +203,60 @@ bool test_rz_scan_strings_detect_utf16_le_special_chars(void) {
 	mu_end;
 }
 
+bool test_rz_scan_strings_user_unprintable(void) {
+	// ASCII/UTF-8 string: "hello\tworld\ntest\0"
+	// With \t (0x09) and \n (0x0a) as user-defined non-printable,
+	// the scanner should produce: "hello", "world", "test"
+	static const unsigned char str[] = "hello\tworld\ntest";
+	static RzCodePoint user_unprintable[] = { 0x09, 0x0a };
+	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
+	RzUtilStrScanOptions opt = g_opt;
+	opt.user_unprintable = user_unprintable;
+	opt.user_unprintable_count = RZ_ARRAY_SIZE(user_unprintable);
+	opt.min_str_length = 4;
+
+	RzList *str_list = rz_list_newf((RzListFree)rz_detected_string_free);
+	int n = rz_scan_strings(buf, str_list, &opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_8BIT);
+	mu_assert_eq(n, 3, "rz_scan_strings user_unprintable, number of strings");
+
+	RzDetectedString *s0 = rz_list_get_n(str_list, 0);
+	RzDetectedString *s1 = rz_list_get_n(str_list, 1);
+	RzDetectedString *s2 = rz_list_get_n(str_list, 2);
+	mu_assert_streq(s0->string, "hello", "rz_scan_strings user_unprintable, first string");
+	mu_assert_streq(s1->string, "world", "rz_scan_strings user_unprintable, second string");
+	mu_assert_streq(s2->string, "test", "rz_scan_strings user_unprintable, third string");
+
+	rz_list_free(str_list);
+	rz_buf_free(buf);
+
+	mu_end;
+}
+
+bool test_rz_scan_strings_user_unprintable_utf8(void) {
+	static const unsigned char str[] = "ab\xC3\xA9cd";
+	static RzCodePoint user_unprintable[] = { 0x00e9 };
+	RzBuffer *buf = rz_buf_new_with_bytes(str, sizeof(str));
+	RzUtilStrScanOptions opt = g_opt;
+	opt.user_unprintable = user_unprintable;
+	opt.user_unprintable_count = RZ_ARRAY_SIZE(user_unprintable);
+	opt.min_str_length = 2;
+	opt.check_ascii_freq = false;
+
+	RzList *str_list = rz_list_newf((RzListFree)rz_detected_string_free);
+	int n = rz_scan_strings(buf, str_list, &opt, 0, buf->methods->get_size(buf) - 1, RZ_STRING_ENC_UTF8);
+	mu_assert_eq(n, 2, "rz_scan_strings user_unprintable utf8, number of strings");
+
+	RzDetectedString *s0 = rz_list_get_n(str_list, 0);
+	RzDetectedString *s1 = rz_list_get_n(str_list, 1);
+	mu_assert_streq(s0->string, "ab", "rz_scan_strings user_unprintable utf8, first string");
+	mu_assert_streq(s1->string, "cd", "rz_scan_strings user_unprintable utf8, second string");
+
+	rz_list_free(str_list);
+	rz_buf_free(buf);
+
+	mu_end;
+}
+
 bool test_rz_scan_strings_detect_utf16_be(void) {
 	static const unsigned char str[] =
 		"\xff\xff\xff\x00\x49\x00\x20\x00\x61\x00\x6d\x00\x20\x00\x61"
@@ -455,6 +509,8 @@ bool all_tests() {
 	mu_run_test(test_rz_scan_strings_detect_utf8);
 	mu_run_test(test_rz_scan_strings_detect_utf16_le);
 	mu_run_test(test_rz_scan_strings_detect_utf16_le_special_chars);
+	mu_run_test(test_rz_scan_strings_user_unprintable);
+	mu_run_test(test_rz_scan_strings_user_unprintable_utf8);
 	mu_run_test(test_rz_scan_strings_detect_utf16_be);
 	mu_run_test(test_rz_scan_strings_detect_utf32_le);
 	mu_run_test(test_rz_scan_strings_detect_utf32_be);


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the guidelines for contributing to this repository.
- [x] I made sure to follow the project's coding style.
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the Rizin book with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Closes #4930.

Extend string search to support user-defined unprintable characters via `str.unprintable` (comma-separated hex code points).

Changes include:
- user-defined unprintable handling in Unicode/string scan paths
- propagation into print/search call sites
- unit/integration/regression tests (including UTF-8 split behavior and `cmd_search_z` coverage)

**Test plan**

- Unit tests in `test/unit/test_str_search.c`
- Integration/regression tests in `test/integration/test_str_search.c` and `test/db/cmd/cmd_search_z`
- Existing CI matrix on this PR

**Closing issues**

closes #4930