### PR TITLE
bin/pe: Add missing relocation type 15 (HIGH3ADJ)

### DIFF
--- a/librz/bin/format/pe/pe_specs.h
+++ b/librz/bin/format/pe/pe_specs.h
@@ -544,8 +544,7 @@ typedef struct {
 #define PE_IMAGE_REL_BASED_RISCV_LOW12S_LOONGARCH32_MARK_LA 8
 #define PE_IMAGE_REL_BASED_MIPS_JMPADDR16                   9
 #define PE_IMAGE_REL_BASED_DIR64                            10
-#define PE_IMAGE_REL_BASED_HIGH3ADJ                         15
-
+#define PE_IMAGE_REL_BASED_HIGH3ADJ 15
 #define STRINGFILEINFO_TEXT  "StringFileInfo"
 #define TRANSLATION_TEXT     "Translation"
 #define VARFILEINFO_TEXT     "VarFileInfo"

--- a/librz/bin/format/pe/pe_specs.h
+++ b/librz/bin/format/pe/pe_specs.h
@@ -546,8 +546,6 @@ typedef struct {
 #define PE_IMAGE_REL_BASED_DIR64                            10
 #define PE_IMAGE_REL_BASED_HIGH3ADJ                         15
 
-
-
 #define STRINGFILEINFO_TEXT  "StringFileInfo"
 #define TRANSLATION_TEXT     "Translation"
 #define VARFILEINFO_TEXT     "VarFileInfo"

--- a/librz/bin/format/pe/pe_specs.h
+++ b/librz/bin/format/pe/pe_specs.h
@@ -544,6 +544,9 @@ typedef struct {
 #define PE_IMAGE_REL_BASED_RISCV_LOW12S_LOONGARCH32_MARK_LA 8
 #define PE_IMAGE_REL_BASED_MIPS_JMPADDR16                   9
 #define PE_IMAGE_REL_BASED_DIR64                            10
+#define PE_IMAGE_REL_BASED_HIGH3ADJ                         15
+
+
 
 #define STRINGFILEINFO_TEXT  "StringFileInfo"
 #define TRANSLATION_TEXT     "Translation"

--- a/librz/bin/p/bin_pe.inc
+++ b/librz/bin/p/bin_pe.inc
@@ -691,7 +691,7 @@ static RzBinInfo *pe_info(RzBinFile *bf) {
 	} else {
 		ret->type = rz_str_dup("EXEC (Executable file)");
 	}
-	
+
 	claimed_checksum = PE_(bin_pe_get_claimed_checksum)(bf->o->bin_obj);
 	actual_checksum = PE_(bin_pe_get_actual_checksum)(bf->o->bin_obj);
 	pe_overlay = sdb_num_get(bf->sdb, "pe_overlay.size");

--- a/librz/bin/p/bin_pe.inc
+++ b/librz/bin/p/bin_pe.inc
@@ -537,6 +537,8 @@ static const char *get_reloc_type_name(const ut8 reloc_type, const ut32 machine_
 		}
 	case PE_IMAGE_REL_BASED_DIR64:
 		return "IMAGE_REL_BASED_DIR64";
+	case PE_IMAGE_REL_BASED_HIGH3ADJ:
+		return "IMAGE_REL_BASED_HIGH3ADJ";
 	default:
 		RZ_LOG_WARN("Unknown PE relocation type number: %d\n", reloc_type);
 		return "IMAGE_REL_BASED_UNKNOWN";
@@ -689,6 +691,7 @@ static RzBinInfo *pe_info(RzBinFile *bf) {
 	} else {
 		ret->type = rz_str_dup("EXEC (Executable file)");
 	}
+	
 	claimed_checksum = PE_(bin_pe_get_claimed_checksum)(bf->o->bin_obj);
 	actual_checksum = PE_(bin_pe_get_actual_checksum)(bf->o->bin_obj);
 	pe_overlay = sdb_num_get(bf->sdb, "pe_overlay.size");

--- a/librz/bin/p/bin_pe.inc
+++ b/librz/bin/p/bin_pe.inc
@@ -688,9 +688,9 @@ static RzBinInfo *pe_info(RzBinFile *bf) {
 
 	if (PE_(rz_bin_pe_is_dll)(bf->o->bin_obj)) {
 		ret->type = rz_str_dup("DLL (Dynamic Link Library)");
-	} else {
+	} else{
 		ret->type = rz_str_dup("EXEC (Executable file)");
-	}
+	}			
 
 	claimed_checksum = PE_(bin_pe_get_claimed_checksum)(bf->o->bin_obj);
 	actual_checksum = PE_(bin_pe_get_actual_checksum)(bf->o->bin_obj);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [X ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Adds the missing PE base relocation type 15 (IMAGE_REL_BASED_HIGH3ADJ).

Two changes made:
- Added `PE_IMAGE_REL_BASED_HIGH3ADJ` define with value 15 to pe_specs.h
- Added corresponding case in get_reloc_type_name() in bin_pe.inc

Previously Rizin would fall through to the default case and print an Unknown PE relocation type number warning when encountering type 15.

If you have used AI tools to generate these code changes, please disclose software used, model name. -->
Used Claude (claude.ai, free version) as a learning aid while exploring the codebase for the first time. Specifically used it 
to understand what PE base relocations are and how the reloc type switch works in bin_pe.inc.
I have not done much of open source contributions so i had to use these tools. 

...

**Test plan**
The get_reloc_type_name() function now correctly returns "IMAGE_REL_BASED_HIGH3ADJ" for relocation type 15 instead of falling through to the unknown default case.
...

**Closing issues**
Closes #5683
...
