### PR TITLE
Remove RzAsm struct from the public APIs.

### DIFF
--- a/librz/arch/acode.c
+++ b/librz/arch/acode.c
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2009-2019 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
+#include "asm_private.h"
 #include <rz_asm.h>
 
 RZ_API RzAsmCode *rz_asm_code_new(void) {

--- a/librz/arch/analysis.c
+++ b/librz/arch/analysis.c
@@ -403,9 +403,7 @@ RZ_API void rz_analysis_set_cpu(RzAnalysis *analysis, const char *cpu) {
 	free(analysis->cpu);
 	analysis->cpu = rz_str_dup(cpu);
 	int v = rz_analysis_archinfo(analysis, RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN);
-	if (v > 0) {
-		analysis->pcalign = v;
-	}
+	analysis->pcalign = RZ_MAX(1, v);
 	rz_analysis_set_reg_profile(analysis);
 	if (RZ_STR_EQ(cpu, analysis->typedb->target->cpu)) {
 		return;
@@ -550,6 +548,10 @@ RZ_API int rz_analysis_archinfo(RzAnalysis *analysis, RzAnalysisInfoType query) 
 	rz_return_val_if_fail(analysis && query < RZ_ANALYSIS_ARCHINFO_ENUM_SIZE, -1);
 	if (!analysis->cur || !analysis->cur->archinfo) {
 		switch (query) {
+		case RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN:
+			/* fall-thru */
+		case RZ_ANALYSIS_ARCHINFO_DATA_ALIGN:
+			/* fall-thru */
 		case RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE:
 			return 1;
 		case RZ_ANALYSIS_ARCHINFO_CAN_USE_POINTERS:
@@ -561,6 +563,10 @@ RZ_API int rz_analysis_archinfo(RzAnalysis *analysis, RzAnalysisInfoType query) 
 
 	int value = analysis->cur->archinfo(analysis, query);
 	switch (query) {
+	case RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN:
+		/* fall-thru */
+	case RZ_ANALYSIS_ARCHINFO_DATA_ALIGN:
+		/* fall-thru */
 	case RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE:
 		// Always consume at least 1 byte
 		return value > 0 ? value : 1;

--- a/librz/arch/aop.c
+++ b/librz/arch/aop.c
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2018-2020 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
+#include "asm_private.h"
 #include <rz_asm.h>
 
 RZ_API RZ_OWN RzAsmOp *rz_asm_op_new(void) {

--- a/librz/arch/asm.c
+++ b/librz/arch/asm.c
@@ -2,19 +2,16 @@
 // SPDX-FileCopyrightText: 2009-2021 nibble <nibble.ds@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include "rz_util/rz_print.h"
-#include <rz_vector.h>
-#include <rz_util/rz_strbuf.h>
-#include <rz_util/rz_regex.h>
-#include <rz_util/rz_assert.h>
-#include <rz_util/rz_path.h>
-#include <rz_list.h>
-#include <stdio.h>
+#include <rz_asm.h>
 #include <rz_core.h>
+#include <rz_lib.h>
+#include <rz_list.h>
 #include <rz_types.h>
 #include <rz_util.h>
-#include <rz_lib.h>
-#include <rz_asm.h>
+#include <rz_util.h>
+#include <rz_vector.h>
+#include "asm_private.h"
+
 #define USE_RZ_UTIL 1
 #include <spp.h>
 
@@ -280,7 +277,6 @@ RZ_API RzAsm *rz_asm_new(void) {
 	if (!a) {
 		return NULL;
 	}
-	a->dataalign = 1;
 	a->bits = RZ_SYS_BITS << 3;
 	a->bitshift = 0;
 	a->syntax = RZ_ASM_SYNTAX_INTEL;
@@ -384,6 +380,26 @@ RZ_API bool rz_asm_plugin_del(RzAsm *a, RZ_NONNULL RzAsmPlugin *p) {
 	return ht_sp_delete(a->plugins, p->name);
 }
 
+RZ_API const RzAsmPlugin *rz_asm_plugin_current(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, false);
+	return a->cur;
+}
+
+RZ_API RZ_OWN RzIterator *rz_asm_plugin_iterator(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, false);
+	return ht_sp_as_iter(a->plugins);
+}
+
+RZ_API const RzAsmPlugin *rz_asm_plugin_find(RZ_NONNULL RzAsm *a, RZ_NONNULL const char *name) {
+	rz_return_val_if_fail(a && RZ_STR_ISNOTEMPTY(name), NULL);
+	bool found = false;
+	RzAsmPlugin *plugin = ht_sp_find(a->plugins, name, &found);
+	if (found) {
+		return plugin;
+	}
+	return NULL;
+}
+
 RZ_API bool rz_asm_is_valid(RzAsm *a, const char *name) {
 	if (!name || !*name) {
 		return false;
@@ -424,31 +440,6 @@ RZ_API bool rz_asm_use_assembler(RzAsm *a, const char *name) {
 	return false;
 }
 
-/**
- * \brief Appends the plugin configuration \p pcfg to the core plugin_config vector.
- *
- * \param rz_asm Pointer to RzAsm struct.
- * \param pcfg Pointer to the plugins RzConfig struct.
- */
-static void set_plugin_configs(RZ_BORROW RzCore *core, const char *plugin_name, RZ_OWN RzConfig *pcfg) {
-	rz_return_if_fail(pcfg && core);
-	rz_config_lock(pcfg, 1);
-	if (!ht_sp_insert(core->plugin_configs, plugin_name, pcfg)) {
-		RZ_LOG_WARN("Plugin '%s' was already added.\n", plugin_name);
-	}
-}
-
-/**
- * \brief Deletes all copies of \p pcfg nodes in the RzConfig from \p rz_asm.
- *
- * \param rz_asm Pointer to RzAsm struct.
- * \param pcfg Pointer to the plugins RzConfig struct.
- */
-static void remove_plugin_config(RZ_BORROW RzCore *core, const char *plugin_name) {
-	rz_return_if_fail(core && plugin_name);
-	ht_sp_delete(core->plugin_configs, plugin_name);
-}
-
 static ut32 asm_get_first_default_bits(RzAsmPlugin *h) {
 	if (!h) {
 		return RZ_SYS_BITS << 3;
@@ -465,6 +456,34 @@ static ut32 asm_get_first_default_bits(RzAsmPlugin *h) {
 	}
 
 	return RZ_SYS_BITS << 3;
+}
+
+/**
+ * \brief      Returns the RzConfig of the arch
+ *
+ * \param      RzAsm  The RzAsm struct to use
+ *
+ * \return     If the get_config callback is set, then must return a non-NULL value
+ */
+RZ_API RZ_OWN RzConfig *rz_asm_get_new_config(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, NULL);
+	if (!a->cur || !a->cur->get_config) {
+		return NULL;
+	}
+	return a->cur->get_config(a->plugin_data);
+}
+
+/**
+ * \brief      Returns the opcode path of the arch
+ *
+ * \param      a     The RzAsm struct to use
+ * \param      path  The requested sys path
+ *
+ * \return     On success returns a valid pointer, otherwise NULL.
+ */
+RZ_API RZ_OWN char *rz_asm_get_sys_opcode_path(RZ_NONNULL RzAsm *a, RZ_NONNULL const char *path) {
+	rz_return_val_if_fail(a && path, NULL);
+	return rz_path_system(a->sdb_opcodes_path, path);
 }
 
 // TODO: this can be optimized using rz_str_hash()
@@ -486,7 +505,6 @@ RZ_API bool rz_asm_use(RzAsm *a, RZ_NULLABLE const char *name) {
 	}
 	RzIterator *iter = ht_sp_as_iter(a->plugins);
 	RzAsmPlugin **val;
-	RzCore *core = a->core;
 	rz_iterator_foreach(iter, val) {
 		RzAsmPlugin *h = *val;
 		if (h->arch && h->name && !strcmp(h->name, name)) {
@@ -513,13 +531,6 @@ RZ_API bool rz_asm_use(RzAsm *a, RZ_NULLABLE const char *name) {
 				rz_iterator_free(iter);
 				return false;
 			}
-
-			if (a->cur && a->cur->get_config && core) {
-				remove_plugin_config(core, a->cur->name);
-			}
-			if (h->get_config && core) {
-				set_plugin_configs(core, h->name, h->get_config(a->plugin_data));
-			}
 			a->cur = h;
 			rz_iterator_free(iter);
 			RZ_FREE(a->features);
@@ -535,14 +546,127 @@ RZ_API bool rz_asm_use(RzAsm *a, RZ_NULLABLE const char *name) {
 }
 
 RZ_DEPRECATE RZ_API void rz_asm_set_cpu(RzAsm *a, const char *cpu) {
-	if (a) {
-		free(a->cpu);
-		a->cpu = rz_str_dup(cpu);
+	if (!a) {
+		return;
 	}
+
+	free(a->cpu);
+	a->cpu = rz_str_dup(cpu);
+}
+
+RZ_API const char *rz_asm_get_cpu(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, "");
+	return a->cpu;
+}
+
+RZ_API const char *rz_asm_get_platforms(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, "");
+	return rz_str_get(a->platforms);
+}
+
+RZ_API void rz_asm_set_platforms(RZ_NONNULL RzAsm *a, RZ_NULLABLE const char *platforms) {
+	rz_return_if_fail(a);
+
+	free(a->platforms);
+	a->platforms = rz_str_dup(platforms);
+}
+
+RZ_API void rz_asm_set_features(RZ_NONNULL RzAsm *a, RZ_NULLABLE const char *features) {
+	rz_return_if_fail(a);
+
+	free(a->features);
+	a->features = rz_str_dup(features);
+}
+
+RZ_API const char *rz_asm_get_features(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, "");
+	return rz_str_get(a->features);
+}
+
+RZ_API void rz_asm_set_pseudo(RZ_NONNULL RzAsm *a, bool enable) {
+	rz_return_if_fail(a);
+
+	a->pseudo = enable;
+}
+
+RZ_API bool rz_asm_get_pseudo(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, "");
+	return a->pseudo;
+}
+
+RZ_API void rz_asm_set_utf8(RZ_NONNULL RzAsm *a, bool utf8) {
+	rz_return_if_fail(a);
+	a->utf8 = utf8;
+}
+
+RZ_API bool rz_asm_get_utf8(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, false);
+	return a->utf8;
+}
+
+RZ_API void rz_asm_set_segment_granularity(RZ_NONNULL RzAsm *a, int seggrn) {
+	rz_return_if_fail(a);
+	a->seggrn = seggrn;
+}
+
+RZ_API int rz_asm_get_segment_granularity(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, false);
+	return a->seggrn;
+}
+
+RZ_API void rz_asm_set_pc_align(RZ_NONNULL RzAsm *a, ut32 pc_align) {
+	rz_return_if_fail(a);
+	if (pc_align < 2) {
+		pc_align = 1;
+	}
+	a->pcalign = pc_align;
+}
+
+RZ_API ut32 rz_asm_get_pc_align(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, 1);
+	if (a->pcalign < 2) {
+		return 1;
+	}
+	return a->pcalign;
+}
+
+RZ_API void rz_asm_set_syscall(RZ_NONNULL RzAsm *a, RzSyscall *syscall) {
+	rz_return_if_fail(a);
+	a->syscall = syscall;
+}
+
+RZ_API RzSyscall *rz_asm_get_syscall(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, NULL);
+	return a->syscall;
+}
+
+RZ_API void rz_asm_set_invalid_as_hex_flag(RZ_NONNULL RzAsm *a, bool invhex) {
+	rz_return_if_fail(a);
+	a->invhex = invhex;
+}
+
+RZ_API bool rz_asm_get_invalid_as_hex_flag(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, false);
+	return a->invhex;
+}
+
+RZ_API void rz_asm_set_show_immediate_hashtag(RZ_NONNULL RzAsm *a, bool show) {
+	rz_return_if_fail(a);
+	a->immdisp = show;
+}
+
+RZ_API bool rz_asm_get_show_immediate_hashtag(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, false);
+	return a->immdisp;
 }
 
 static bool has_bits(RzAsmPlugin *h, int bits) {
 	return (h && h->bits && (bits & h->bits));
+}
+
+RZ_DEPRECATE RZ_API RZ_BORROW RzBinBind *rz_asm_get_bin_bind(RzAsm *a) {
+	rz_return_val_if_fail(a, NULL);
+	return &a->binb;
 }
 
 RZ_DEPRECATE RZ_API int rz_asm_set_bits(RzAsm *a, int bits) {
@@ -555,9 +679,44 @@ RZ_DEPRECATE RZ_API int rz_asm_set_bits(RzAsm *a, int bits) {
 	return false;
 }
 
+RZ_DEPRECATE RZ_API int rz_asm_get_bits(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, 0);
+	return a->bits;
+}
+
+RZ_DEPRECATE RZ_API bool rz_asm_is_bits(RzAsm *a, int bits) {
+	rz_return_val_if_fail(a, false);
+	return a->bits == bits;
+}
+
+RZ_DEPRECATE RZ_API int rz_asm_get_plugin_bits(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, 0);
+	return a->cur ? a->cur->bits : 0;
+}
+
+RZ_DEPRECATE RZ_API const char *rz_asm_get_plugin_cpus(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, NULL);
+	return a->cur ? rz_str_get(a->cur->cpus) : "";
+}
+
+RZ_DEPRECATE RZ_API const char *rz_asm_get_plugin_platforms(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, NULL);
+	return a->cur ? rz_str_get(a->cur->platforms) : "";
+}
+
+RZ_DEPRECATE RZ_API const char *rz_asm_get_plugin_features(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, NULL);
+	return a->cur ? rz_str_get(a->cur->features) : "";
+}
+
 RZ_API ut32 rz_asm_get_endianness(RzAsm *a) {
 	rz_return_val_if_fail(a && a->cur, RZ_SYS_ENDIAN_NONE);
 	return a->cur->endian;
+}
+
+RZ_API bool rz_asm_is_big_endian_set(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, false);
+	return a->big_endian;
 }
 
 RZ_API bool rz_asm_support_endianness(RzAsm *a, ut32 endian) {
@@ -593,24 +752,29 @@ RZ_API bool rz_asm_set_big_endian(RzAsm *a, bool b) {
 	return a->big_endian;
 }
 
-RZ_API bool rz_asm_set_syntax(RzAsm *a, int syntax) {
-	// TODO: move into rz_arch ?
-	switch (syntax) {
-	case RZ_ASM_SYNTAX_REGNUM:
-	case RZ_ASM_SYNTAX_INTEL:
-	case RZ_ASM_SYNTAX_MASM:
-	case RZ_ASM_SYNTAX_ATT:
-	case RZ_ASM_SYNTAX_JZ:
-		a->syntax = syntax;
-		return true;
-	default:
-		return false;
-	}
+RZ_API void rz_asm_set_syntax(RZ_NONNULL RzAsm *a, RzAsmSyntax syntax) {
+	rz_return_if_fail(a && syntax < RZ_ASM_ENUM_SIZE);
+	a->syntax = syntax;
 }
 
-RZ_API int rz_asm_set_pc(RzAsm *a, ut64 pc) {
+RZ_API RzAsmSyntax rz_asm_get_syntax(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, RZ_ASM_SYNTAX_NONE);
+	return a->syntax;
+}
+
+RZ_API bool rz_asm_is_syntax(RZ_NONNULL RzAsm *a, RzAsmSyntax syntax) {
+	rz_return_val_if_fail(a, false);
+	return a->syntax == syntax;
+}
+
+RZ_API ut64 rz_asm_get_pc(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, 0);
+	return a->pc;
+}
+
+RZ_API void rz_asm_set_pc(RZ_NONNULL RzAsm *a, ut64 pc) {
+	rz_return_if_fail(a);
 	a->pc = pc;
-	return true;
 }
 
 static bool __isInvalid(RzAsmOp *op) {
@@ -1285,6 +1449,11 @@ RZ_API char *rz_asm_describe(RzAsm *a, const char *str) {
 	return (a && a->pair) ? sdb_get(a->pair, str) : NULL;
 }
 
+RZ_API void rz_asm_describe_iterate(RZ_NONNULL RzAsm *a, RZ_NONNULL SdbForeachCallback cb, RZ_NULLABLE void *user) {
+	rz_return_if_fail(a);
+	sdb_foreach(a->pair, cb, user);
+}
+
 RZ_API RZ_BORROW HtSP /*<RzAsmPlugin *>*/ *rz_asm_get_plugins(RZ_BORROW RZ_NONNULL RzAsm *a) {
 	rz_return_val_if_fail(a, NULL);
 	return a->plugins;
@@ -1292,6 +1461,16 @@ RZ_API RZ_BORROW HtSP /*<RzAsmPlugin *>*/ *rz_asm_get_plugins(RZ_BORROW RZ_NONNU
 
 RZ_API bool rz_asm_set_arch(RzAsm *a, const char *name, int bits) {
 	return rz_asm_use(a, name) ? rz_asm_set_bits(a, bits) : false;
+}
+
+RZ_API const char *rz_asm_get_arch(RZ_NONNULL RzAsm *a) {
+	rz_return_val_if_fail(a, RZ_SYS_ARCH);
+	return a->cur ? a->cur->name : RZ_SYS_ARCH;
+}
+
+RZ_API bool rz_asm_is_arch(RZ_NONNULL RzAsm *a, RZ_NONNULL const char *name) {
+	rz_return_val_if_fail(a && RZ_STR_ISNOTEMPTY(name), false);
+	return a->cur && RZ_STR_EQ(a->cur->name, name);
 }
 
 /* to ease the use of the native bindings (not used in rizin) */

--- a/librz/arch/asm.c
+++ b/librz/arch/asm.c
@@ -854,7 +854,7 @@ RZ_API int rz_asm_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	return ret;
 }
 
-typedef int (*Ase)(RzAsm *a, RzAsmOp *op, const char *buf);
+typedef int (*Ase)(const RzAsm *a, RzAsmOp *op, const char *buf);
 
 static bool assemblerMatches(RzAsm *a, RzAsmPlugin *h) {
 	if (!a || !h->arch || !h->assemble || !has_bits(h, a->bits)) {

--- a/librz/arch/asm.c
+++ b/librz/arch/asm.c
@@ -664,6 +664,11 @@ static bool has_bits(RzAsmPlugin *h, int bits) {
 	return (h && h->bits && (bits & h->bits));
 }
 
+RZ_DEPRECATE RZ_API void rz_asm_set_core(RZ_NONNULL RzAsm *a, RZ_NULLABLE void *core) {
+	rz_return_if_fail(a);
+	a->core = core;
+}
+
 RZ_DEPRECATE RZ_API RZ_BORROW RzBinBind *rz_asm_get_bin_bind(RzAsm *a) {
 	rz_return_val_if_fail(a, NULL);
 	return &a->binb;

--- a/librz/arch/asm_private.h
+++ b/librz/arch/asm_private.h
@@ -10,7 +10,7 @@
 #include <rz_asm.h>
 
 struct rz_asm_t {
-	void *not_core;
+	void *core; /// should not be used.
 	ut8 ptr_alignment_I;
 	void *plugin_data;
 	ut8 ptr_alignment_II;

--- a/librz/arch/asm_private.h
+++ b/librz/arch/asm_private.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2009-2020 nibble <nibble.ds@gmail.com>
+// SPDX-FileCopyrightText: 2009-2020 pancake <pancake@nopcode.org>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef RZ_ASM_PRIVATE_H
+#define RZ_ASM_PRIVATE_H
+
+#include <rz_types.h>
+#include <rz_util.h>
+#include <rz_asm.h>
+
+struct rz_asm_t {
+	void *not_core;
+	ut8 ptr_alignment_I;
+	void *plugin_data;
+	ut8 ptr_alignment_II;
+	// NOTE: Do not change the order of fields above!
+	// They are used in pointer passing hacks in rz_types.h.
+	char *cpu;
+	int bits;
+	int big_endian;
+	int syntax;
+	ut64 pc;
+	RzAsmPlugin *cur;
+	RzAsmPlugin *acur;
+	HtSP /*<RzAsmPlugin *>*/ *plugins;
+	RzBinBind binb;
+	RzParse *ifilter;
+	RzParse *ofilter;
+	Sdb *pair;
+	RzSyscall *syscall;
+	RzPath *sdb_opcodes_path; ///< pointer to RzPath, contains path prefix of the system
+	char *features;
+	char *platforms;
+	int invhex; // invalid instructions displayed in hex
+	int pcalign;
+	int bitshift;
+	bool immsign; // Print signed immediates as negative values, not their unsigned representation.
+	bool immdisp; // Display immediates with # symbol (for arm architectures). false = show hashs
+	bool utf8; // Flag for plugins: Use utf-8 characters.
+	HtSS *flags;
+	int seggrn;
+	bool pseudo;
+};
+
+#endif // RZ_ASM_PRIVATE_H

--- a/librz/arch/binutils_as.c
+++ b/librz/arch/binutils_as.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include "binutils_as.h"
+#include "asm_private.h"
 
 int binutils_assemble(RzAsm *a, RzAsmOp *op, const char *buf, const char *as, const char *env, const char *header, const char *cmd_opt) {
 	char *user_as = rz_sys_getenv(env);

--- a/librz/arch/binutils_as.c
+++ b/librz/arch/binutils_as.c
@@ -5,7 +5,7 @@
 #include "binutils_as.h"
 #include "asm_private.h"
 
-int binutils_assemble(RzAsm *a, RzAsmOp *op, const char *buf, const char *as, const char *env, const char *header, const char *cmd_opt) {
+int binutils_assemble(const RzAsm *a, RzAsmOp *op, const char *buf, const char *as, const char *env, const char *header, const char *cmd_opt) {
 	char *user_as = rz_sys_getenv(env);
 	if (user_as) {
 		as = user_as;

--- a/librz/arch/binutils_as.h
+++ b/librz/arch/binutils_as.h
@@ -7,6 +7,6 @@
 #include <rz_types.h>
 #include <rz_asm.h>
 
-int binutils_assemble(RzAsm *a, RzAsmOp *op, const char *buf, const char *as, const char *env, const char *header, const char *cmd_opt);
+int binutils_assemble(const RzAsm *a, RzAsmOp *op, const char *buf, const char *as, const char *env, const char *header, const char *cmd_opt);
 
 #endif

--- a/librz/arch/deprecated_arch_helper.h
+++ b/librz/arch/deprecated_arch_helper.h
@@ -6,6 +6,7 @@
 #define DEPRECATED_ARCH_HELPER_H
 
 #include <rz_arch.h>
+#include "asm_private.h"
 
 #define DEPRECATED_OLD_ARCH_PLUGIN(name) \
 	RzArchPlugin rz_arch_plugin_##name = { \

--- a/librz/arch/isa/8051/8051_ass.c
+++ b/librz/arch/isa/8051/8051_ass.c
@@ -1180,8 +1180,8 @@ static parse_mnem_args mnemonic(char const *user_asm, int *nargs) {
  * ## Section 7: rizin glue and mnemonic tokenization
 		 --------------------------------------*/
 
-int assemble_8051(RzAsm *a, RzAsmOp *op, char const *user_asm) {
-	if (!a || !op || !user_asm) {
+RZ_IPI int assemble_8051(RzAsmOp *op, ut64 pc, char const *user_asm) {
+	if (!op || !user_asm) {
 		return 0;
 	}
 	rz_strbuf_set(&op->buf_asm, user_asm);
@@ -1216,7 +1216,7 @@ int assemble_8051(RzAsm *a, RzAsmOp *op, char const *user_asm) {
 	}
 	ut8 instr[4] = { 0 };
 	ut8 *binp = instr;
-	if (!mnem(carg, a->pc, &binp)) {
+	if (!mnem(carg, pc, &binp)) {
 		free(arg[0]);
 		arg[0] = 0;
 		carg[2] = 0;

--- a/librz/arch/isa/8051/8051_ass.h
+++ b/librz/arch/isa/8051/8051_ass.h
@@ -6,6 +6,6 @@
 
 #include <rz_asm.h>
 
-int assemble_8051(RzAsm *a, RzAsmOp *op, char const *user_asm);
+RZ_IPI int assemble_8051(RzAsmOp *op, ut64 pc, char const *user_asm);
 
 #endif /* ASSEMBLE_8051_H */

--- a/librz/arch/isa/gb/gb.h
+++ b/librz/arch/isa/gb/gb.h
@@ -69,5 +69,5 @@ enum {
 };
 
 int gbDisass(RzAsmOp *op, const ut8 *buf, int len);
-int gbAsm(RzAsm *a, RzAsmOp *op, const char *buf);
+int gbAsm(const RzAsm *a, RzAsmOp *op, const char *buf);
 #endif

--- a/librz/arch/isa/gb/gbasm.c
+++ b/librz/arch/isa/gb/gbasm.c
@@ -203,7 +203,7 @@ static bool gb_parse_ld3(ut8 *buf, char *buf_asm) {
 	return true;
 }
 
-int gbAsm(RzAsm *a, RzAsmOp *op, const char *buf) {
+RZ_IPI int gbAsm(const RzAsm *a, RzAsmOp *op, const char *buf) {
 	int mn_len, j, len = 1;
 	ut32 mn = 0;
 	ut64 num;

--- a/librz/arch/isa/gb/gbdis.c
+++ b/librz/arch/isa/gb/gbdis.c
@@ -150,7 +150,7 @@ static void gb_hardware_register_name(char *reg, ut8 offset) {
 	}
 }
 
-int gbDisass(RzAsmOp *op, const ut8 *buf, int len) {
+RZ_IPI int gbDisass(RzAsmOp *op, const ut8 *buf, int len) {
 	int foo = gbOpLength(gb_op[buf[0]].type);
 	if (len < foo) {
 		return 0;

--- a/librz/arch/isa/hexagon/hexagon_arch.c
+++ b/librz/arch/isa/hexagon/hexagon_arch.c
@@ -9,15 +9,15 @@
 // Do not edit. Repository of code generator:
 // https://github.com/rizinorg/rz-hexagon
 
-#include "rz_types.h"
-#include <rz_util/rz_log.h>
-#include <rz_util/rz_buf.h>
+#include <rz_types.h>
+#include <rz_util.h>
 #include <rz_list.h>
-#include <rz_util/rz_assert.h>
 #include <rz_asm.h>
 #include <rz_analysis.h>
 #include <rz_util.h>
 #include <rz_vector.h>
+#include "asm_private.h"
+
 #include <hexagon/hexagon.h>
 #include <hexagon/hexagon_insn.h>
 #include <hexagon/hexagon_arch.h>

--- a/librz/arch/isa/hexagon/hexagon_arch.c
+++ b/librz/arch/isa/hexagon/hexagon_arch.c
@@ -1209,7 +1209,7 @@ static ut64 get_pre_decoding_start(RZ_BORROW RzBuffer *buffer, ut64 addr) {
  */
 static void perform_hacks(RZ_NONNULL HexState **state,
 	RZ_NONNULL RzBuffer **buffer,
-	RZ_NONNULL RzAsm **rz_asm,
+	RZ_NONNULL const RzAsm **rz_asm,
 	RZ_NONNULL RzAnalysis **rz_analysis,
 	RZ_NONNULL HexReversedOpcode *rz_reverse) {
 	if (*rz_analysis) {
@@ -1257,7 +1257,7 @@ static inline bool do_decoding_loop(ut64 current_addr, ut64 requested_addr, cons
  * \param addr The address of the current opcode.
  * \param copy_result If set, it copies the result. Otherwise it only buffers it in the internal state.
  */
-RZ_API void hexagon_reverse_opcode(HexReversedOpcode *rz_reverse, const ut64 addr, RzAsm *rz_asm, RzAnalysis *rz_analysis) {
+RZ_API void hexagon_reverse_opcode(HexReversedOpcode *rz_reverse, const ut64 addr, const RzAsm *rz_asm, RzAnalysis *rz_analysis) {
 	rz_return_if_fail(rz_reverse);
 	HexState *state;
 	RzBuffer *buffer;

--- a/librz/arch/isa/hexagon/hexagon_arch.h
+++ b/librz/arch/isa/hexagon/hexagon_arch.h
@@ -75,7 +75,7 @@ RZ_API void hex_insn_container_free(RZ_NULLABLE HexInsnContainer *c);
 RZ_API void hex_const_ext_free(RZ_NULLABLE HexConstExt *ce);
 RZ_IPI RZ_OWN HexState *hexagon_state_new();
 RZ_IPI void hexagon_state_fini(RZ_NULLABLE HexState *state);
-RZ_API void hexagon_reverse_opcode(HexReversedOpcode *rz_reverse, const ut64 addr, RzAsm *rz_asm, RzAnalysis *rz_analysis);
+RZ_API void hexagon_reverse_opcode(HexReversedOpcode *rz_reverse, const ut64 addr, const RzAsm *rz_asm, RzAnalysis *rz_analysis);
 RZ_API ut8 hexagon_get_pkt_index_of_addr(const ut32 addr, const HexPkt *p);
 RZ_API HexLoopAttr hex_get_loop_flag(const HexPkt *p);
 RZ_API const HexOp *hex_isa_to_reg(const HexInsn *hi, const char isa_id, bool new_reg);

--- a/librz/arch/isa/pic/pic_highend.c
+++ b/librz/arch/isa/pic/pic_highend.c
@@ -590,10 +590,10 @@ bool pic_highend_disasm_op(PicHighendOp *op, ut64 addr, const ut8 *buff, ut64 le
 	return true;
 }
 
-int pic_highend_disassemble(RzAsm *a, RzAsmOp *asm_op, const ut8 *b, int blen) {
+int pic_highend_disassemble(RzAsmOp *asm_op, ut64 addr, const ut8 *b, int blen) {
 	asm_op->size = 2;
 	PicHighendOp op = { 0 };
-	if (!pic_highend_disasm_op(&op, a->pc, b, blen) ||
+	if (!pic_highend_disasm_op(&op, addr, b, blen) ||
 		op.code == PIC_HIGHEND_OPCODE_INVALID) {
 		rz_asm_op_set_asm(asm_op, "invalid");
 		return -1;

--- a/librz/arch/isa/pic/pic_highend.h
+++ b/librz/arch/isa/pic/pic_highend.h
@@ -146,7 +146,7 @@ ut8 pic_highend_status(const char *name);
 ut8 pic_highend_rcon(const char *name);
 ut8 pic_highend_intcon(const char *name);
 bool pic_highend_disasm_op(PicHighendOp *op, ut64 addr, const ut8 *buff, ut64 len);
-int pic_highend_disassemble(RzAsm *a, RzAsmOp *asm_op, const ut8 *b, int l);
+int pic_highend_disassemble(RzAsmOp *asm_op, ut64 addr, const ut8 *b, int l);
 
 int pic_highend_op(RzAnalysis *analysis, RzAnalysisOp *aop, ut64 addr,
 	const ut8 *buf, int len, RzAnalysisOpMask mask);

--- a/librz/arch/isa/tms320/c64x/c64x.c
+++ b/librz/arch/isa/tms320/c64x/c64x.c
@@ -33,7 +33,7 @@ void tms320_c64x_free(void *p) {
 	free(ctx);
 }
 
-int tms320_c64x_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len, void *c64x) {
+int tms320_c64x_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len, void *c64x) {
 	TMSContext *ctx = (TMSContext *)c64x;
 
 	cs_insn *insn;
@@ -82,7 +82,7 @@ fin:
 	return ret;
 }
 
-char *tms320_c64x_mnemonics(RzAsm *a, int id, bool json, void *c64x) {
+char *tms320_c64x_mnemonics(const RzAsm *a, int id, bool json, void *c64x) {
 	TMSContext *ctx = (TMSContext *)c64x;
 	a->cur->disassemble(a, NULL, NULL, -1);
 	if (id != -1) {

--- a/librz/arch/isa/tms320/c64x/c64x.h
+++ b/librz/arch/isa/tms320/c64x/c64x.h
@@ -14,8 +14,8 @@
 
 void *tms320_c64x_new();
 void tms320_c64x_free(void *p);
-int tms320_c64x_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len, void *c64x);
-char *tms320_c64x_mnemonics(RzAsm *a, int id, bool json, void *c64x);
+int tms320_c64x_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len, void *c64x);
+char *tms320_c64x_mnemonics(const RzAsm *a, int id, bool json, void *c64x);
 int tms320_c64x_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask, void *c64x);
 
 #else

--- a/librz/arch/isa/tms320/c64x/c64x.h
+++ b/librz/arch/isa/tms320/c64x/c64x.h
@@ -5,6 +5,7 @@
 #define TMS320_C64X_CAPSTONE_H
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_util.h>
 #include <rz_analysis.h>
 #include <capstone/capstone.h>

--- a/librz/arch/p/analysis/analysis_6502.c
+++ b/librz/arch/p/analysis/analysis_6502.c
@@ -1824,7 +1824,7 @@ static int _6502_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8
 	return op->size;
 }
 
-static char *get_reg_profile(RzAnalysis *analysis) {
+static char *_6502_get_reg_profile(RzAnalysis *analysis) {
 	char *p =
 		"=PC	pc\n"
 		"=SP	sp\n"
@@ -1849,7 +1849,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 	return rz_str_dup(p);
 }
 
-static int esil_6502_init(RzAnalysisEsil *esil) {
+static int _6502_esil_init(RzAnalysisEsil *esil) {
 	if (esil->analysis && esil->analysis->reg) { // initial values
 		rz_reg_set_value(esil->analysis->reg, rz_reg_get(esil->analysis->reg, "pc", -1), 0x0000);
 		rz_reg_set_value(esil->analysis->reg, rz_reg_get(esil->analysis->reg, "sp", -1), 0xff);
@@ -1861,11 +1861,11 @@ static int esil_6502_init(RzAnalysisEsil *esil) {
 	return true;
 }
 
-static int esil_6502_fini(RzAnalysisEsil *esil) {
+static int _6502_esil_fini(RzAnalysisEsil *esil) {
 	return true;
 }
 
-static int address_bits(RzAnalysis *analysis, int bits) {
+static int _6502_address_bits(RzAnalysis *analysis, int bits) {
 	return 16;
 }
 
@@ -1880,18 +1880,35 @@ static RzAnalysisILConfig *_6502_il_config(RzAnalysis *analysis) {
 	return rz_analysis_il_config_new(16, false, 16);
 }
 
+static int _6502_archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
+	switch (query) {
+	case RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_MAX_OP_SIZE:
+		return 4;
+	case RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_DATA_ALIGN:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_CAN_USE_POINTERS:
+		return true;
+	default:
+		return -1;
+	}
+}
+
 RzAnalysisPlugin rz_analysis_plugin_6502 = {
 	.name = "6502",
 	.desc = "6502/NES analysis plugin",
 	.license = "LGPL3",
 	.arch = "6502",
 	.bits = 8,
-	.address_bits = address_bits,
+	.address_bits = _6502_address_bits,
 	.op = &_6502_op,
-	.get_reg_profile = &get_reg_profile,
+	.get_reg_profile = &_6502_get_reg_profile,
 	.esil = true,
-	.esil_init = esil_6502_init,
-	.esil_fini = esil_6502_fini,
-	.il_config = _6502_il_config
-
+	.esil_init = _6502_esil_init,
+	.esil_fini = _6502_esil_fini,
+	.il_config = _6502_il_config,
+	.archinfo = _6502_archinfo,
 };

--- a/librz/arch/p/analysis/analysis_alpha_cs.c
+++ b/librz/arch/p/analysis/analysis_alpha_cs.c
@@ -441,8 +441,11 @@ static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
 	case RZ_ANALYSIS_ARCHINFO_MAX_OP_SIZE:
 		return 4;
 	case RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN:
+		return 4;
 	case RZ_ANALYSIS_ARCHINFO_DATA_ALIGN:
+		return 1;
 	case RZ_ANALYSIS_ARCHINFO_CAN_USE_POINTERS:
+		return true;
 	default:
 		return -1;
 	}

--- a/librz/arch/p/analysis/analysis_gb.c
+++ b/librz/arch/p/analysis/analysis_gb.c
@@ -1963,7 +1963,7 @@ static int gb_anop(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 
 	the mbc can be seen as a register but it isn't. For the Gameboy the mbc is invisble.
 */
 
-static char *get_reg_profile(RzAnalysis *analysis) {
+static char *gb_get_reg_profile(RzAnalysis *analysis) {
 	const char *p =
 		"=PC	mpc\n"
 		"=SP	sp\n"
@@ -2005,7 +2005,7 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 	return rz_str_dup(p);
 }
 
-static int esil_gb_init(RzAnalysisEsil *esil) {
+static int gb_esil_init(RzAnalysisEsil *esil) {
 	GBUser *user = RZ_NEW0(GBUser);
 	rz_analysis_esil_set_op(esil, "daa", gb_custom_daa, 1, 1, RZ_ANALYSIS_ESIL_OP_TYPE_MATH | RZ_ANALYSIS_ESIL_OP_TYPE_CUSTOM);
 	if (user) {
@@ -2028,7 +2028,7 @@ static int esil_gb_init(RzAnalysisEsil *esil) {
 	return true;
 }
 
-static int esil_gb_fini(RzAnalysisEsil *esil) {
+static int gb_esil_fini(RzAnalysisEsil *esil) {
 	RZ_FREE(esil->cb.user);
 	return true;
 }
@@ -2037,10 +2037,27 @@ static const char *gb_regs_bound[] = {
 	"a", "b", "c", "d", "e", "h", "l", "sp", "Z", "N", "H", "C", "ime", NULL
 };
 
-static RzAnalysisILConfig *il_config(RzAnalysis *analysis) {
+static RzAnalysisILConfig *gb_il_config(RzAnalysis *analysis) {
 	RzAnalysisILConfig *r = rz_analysis_il_config_new(32, false, 16);
 	r->reg_bindings = gb_regs_bound;
 	return r;
+}
+
+static int gb_archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
+	switch (query) {
+	case RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_MAX_OP_SIZE:
+		return 3;
+	case RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_DATA_ALIGN:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_CAN_USE_POINTERS:
+		return true;
+	default:
+		return -1;
+	}
 }
 
 RzAnalysisPlugin rz_analysis_plugin_gb = {
@@ -2051,8 +2068,9 @@ RzAnalysisPlugin rz_analysis_plugin_gb = {
 	.esil = true,
 	.bits = 16,
 	.op = &gb_anop,
-	.get_reg_profile = &get_reg_profile,
-	.esil_init = esil_gb_init,
-	.esil_fini = esil_gb_fini,
-	.il_config = il_config
+	.get_reg_profile = &gb_get_reg_profile,
+	.esil_init = gb_esil_init,
+	.esil_fini = gb_esil_fini,
+	.il_config = gb_il_config,
+	.archinfo = gb_archinfo,
 };

--- a/librz/arch/p/analysis/analysis_h8300.c
+++ b/librz/arch/p/analysis/analysis_h8300.c
@@ -493,6 +493,23 @@ static RzList /*<RzSearchKeyword *>*/ *h8300_preludes(RzAnalysis *analysis) {
 	return kws;
 }
 
+static int h8300_archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
+	switch (query) {
+	case RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE:
+		return 2;
+	case RZ_ANALYSIS_ARCHINFO_MAX_OP_SIZE:
+		return 4;
+	case RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN:
+		return 2;
+	case RZ_ANALYSIS_ARCHINFO_DATA_ALIGN:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_CAN_USE_POINTERS:
+		return true;
+	default:
+		return -1;
+	}
+}
+
 RzAnalysisPlugin rz_analysis_plugin_h8300 = {
 	.name = "h8300",
 	.desc = "H8300 code analysis plugin",
@@ -504,4 +521,5 @@ RzAnalysisPlugin rz_analysis_plugin_h8300 = {
 	.get_reg_profile = get_reg_profile,
 	.il_config = h8300_il_config,
 	.preludes = h8300_preludes,
+	.archinfo = h8300_archinfo,
 };

--- a/librz/arch/p/analysis/analysis_hexagon.c
+++ b/librz/arch/p/analysis/analysis_hexagon.c
@@ -24,9 +24,6 @@ RZ_API int hexagon_v6_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, cons
 	if (len < HEX_INSN_SIZE) {
 		return -1;
 	}
-	if (analysis->pcalign != HEX_PC_ALIGNMENT) {
-		analysis->pcalign = HEX_PC_ALIGNMENT;
-	}
 
 	// Disassemble as many instructions as possible from the buffer.
 	HexReversedOpcode rev = { .action = HEXAGON_ANALYSIS, .ana_op = op, .asm_op = NULL, .state = NULL, .pkt_fully_decoded = false, .bytes_buf = buf, .bytes_buf_len = len };
@@ -42,7 +39,7 @@ RZ_API int hexagon_v6_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, cons
 	return op->size;
 }
 
-static RzAnalysisILConfig *rz_hexagon_il_config(RzAnalysis *a) {
+static RzAnalysisILConfig *hexagon_il_config(RzAnalysis *a) {
 	rz_return_val_if_fail(a, NULL);
 	// Hacky getter for the plugin data until RzArch is implemented
 	RzAsm *rasm = rz_analysis_to_rz_asm(a);
@@ -53,7 +50,7 @@ static RzAnalysisILConfig *rz_hexagon_il_config(RzAnalysis *a) {
 	return rz_analysis_il_config_new(32, a->big_endian, 32);
 }
 
-RZ_API char *get_reg_profile(RzAnalysis *analysis) {
+RZ_API char *hexagon_get_reg_profile(RzAnalysis *analysis) {
 	const char *p =
 		"=PC	C9\n"
 		"=SP	R29\n"
@@ -743,6 +740,23 @@ RZ_API char *get_reg_profile(RzAnalysis *analysis) {
 	return rz_str_dup(p);
 }
 
+static int hexagon_archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
+	switch (query) {
+	case RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE:
+		return HEX_INSN_SIZE;
+	case RZ_ANALYSIS_ARCHINFO_MAX_OP_SIZE:
+		return HEX_INSN_SIZE * HEX_MAX_INSN_PER_PKT;
+	case RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN:
+		return HEX_PC_ALIGNMENT;
+	case RZ_ANALYSIS_ARCHINFO_DATA_ALIGN:
+		return 4;
+	case RZ_ANALYSIS_ARCHINFO_CAN_USE_POINTERS:
+		return true;
+	default:
+		return -1;
+	}
+}
+
 RzAnalysisPlugin rz_analysis_plugin_hexagon = {
 	.name = "hexagon",
 	.desc = "Qualcomm Hexagon (QDSP6) V6",
@@ -750,7 +764,8 @@ RzAnalysisPlugin rz_analysis_plugin_hexagon = {
 	.arch = "hexagon",
 	.bits = 32,
 	.op = hexagon_v6_op,
+	.archinfo = hexagon_archinfo,
 	.esil = false,
-	.get_reg_profile = get_reg_profile,
-	.il_config = rz_hexagon_il_config,
+	.get_reg_profile = hexagon_get_reg_profile,
+	.il_config = hexagon_il_config,
 };

--- a/librz/arch/p/analysis/analysis_m68k_cs.c
+++ b/librz/arch/p/analysis/analysis_m68k_cs.c
@@ -790,6 +790,23 @@ static bool m68k_fini(void *user) {
 	return true;
 }
 
+static int m68k_archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
+	switch (query) {
+	case RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE:
+		return 2;
+	case RZ_ANALYSIS_ARCHINFO_MAX_OP_SIZE:
+		return 4;
+	case RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN:
+		return 2;
+	case RZ_ANALYSIS_ARCHINFO_DATA_ALIGN:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_CAN_USE_POINTERS:
+		return true;
+	default:
+		return -1;
+	}
+}
+
 RzAnalysisPlugin rz_analysis_plugin_m68k_cs = {
 	.name = "m68k",
 	.desc = "Capstone M68K analyzer",
@@ -801,7 +818,9 @@ RzAnalysisPlugin rz_analysis_plugin_m68k_cs = {
 	.op = &m68k_analyze_op,
 	.init = m68k_init,
 	.fini = m68k_fini,
+	.archinfo = m68k_archinfo,
 };
+
 #else
 RzAnalysisPlugin rz_analysis_plugin_m68k_cs = {
 	.name = "m68k (unsupported)",

--- a/librz/arch/p/analysis/analysis_ppc_cs.c
+++ b/librz/arch/p/analysis/analysis_ppc_cs.c
@@ -237,7 +237,7 @@ static RzStructuredData *ppc_opex(csh handle, cs_insn *insn) {
 #define ARG(n)     getarg2(a, &gop, n, "")
 #define ARG2(n, m) getarg2(a, &gop, n, m)
 
-static char *get_reg_profile(RzAnalysis *analysis) {
+static char *ppc_get_reg_profile(RzAnalysis *analysis) {
 	const char *p = NULL;
 	if (analysis->bits == 64) {
 		p =
@@ -946,7 +946,7 @@ static char *shrink(char *op) {
 	return op;
 }
 
-static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask) {
+static int ppc_analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf, int len, RzAnalysisOpMask mask) {
 	PPCContext *ctx = (PPCContext *)a->plugin_data;
 	int n, ret;
 	cs_insn *insn;
@@ -1751,7 +1751,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	return op->size;
 }
 
-static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
+static int ppc_archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
 	bool is_vle = a && a->cpu && !strncmp(a->cpu, "vle", 3);
 
 	switch (query) {
@@ -1759,6 +1759,10 @@ static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
 		return is_vle ? 2 : 4;
 	case RZ_ANALYSIS_ARCHINFO_MAX_OP_SIZE:
 		return 4;
+	case RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN:
+		return is_vle ? 2 : 4;
+	case RZ_ANALYSIS_ARCHINFO_DATA_ALIGN:
+		return 1;
 	case RZ_ANALYSIS_ARCHINFO_CAN_USE_POINTERS:
 		return true;
 	default:
@@ -1766,14 +1770,14 @@ static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
 	}
 }
 
-static RzList /*<RzSearchKeyword *>*/ *analysis_preludes(RzAnalysis *analysis) {
+static RzList /*<RzSearchKeyword *>*/ *ppc_analysis_preludes(RzAnalysis *analysis) {
 #define KW(d, ds, m, ms) rz_list_append(l, rz_search_keyword_new((const ut8 *)d, ds, (const ut8 *)m, ms, NULL))
 	RzList *l = rz_list_newf((RzListFree)rz_search_keyword_free);
 	KW("\x7c\x08\x02\xa6", 4, NULL, 0);
 	return l;
 }
 
-static RzAnalysisILConfig *il_config(RzAnalysis *analysis) {
+static RzAnalysisILConfig *ppc_il_config(RzAnalysis *analysis) {
 	if (analysis->bits == 64) {
 		return rz_ppc_cs_64_il_config(analysis->big_endian);
 	}
@@ -1796,13 +1800,13 @@ RzAnalysisPlugin rz_analysis_plugin_ppc_cs = {
 	.esil = true,
 	.arch = "ppc",
 	.bits = 32 | 64,
-	.archinfo = archinfo,
-	.preludes = analysis_preludes,
-	.op = &analyze_op,
+	.archinfo = ppc_archinfo,
+	.preludes = ppc_analysis_preludes,
+	.op = &ppc_analyze_op,
 	.init = ppc_init,
 	.fini = ppc_fini,
-	.get_reg_profile = &get_reg_profile,
-	.il_config = il_config,
+	.get_reg_profile = &ppc_get_reg_profile,
+	.il_config = ppc_il_config,
 };
 
 #ifndef RZ_PLUGIN_INCORE

--- a/librz/arch/p/analysis/analysis_riscv_cs.c
+++ b/librz/arch/p/analysis/analysis_riscv_cs.c
@@ -781,7 +781,6 @@ int analyze_op(RzAnalysis *analysis, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 		ctx->omode = mode;
 		ctx->obits = analysis->bits;
 	}
-	analysis->pcalign = 2;
 	op->addr = addr;
 	if (len < 2) {
 		return -1;

--- a/librz/arch/p/analysis/analysis_rl78.c
+++ b/librz/arch/p/analysis/analysis_rl78.c
@@ -256,6 +256,23 @@ static char *get_reg_profile(RzAnalysis *analysis) {
 	return rz_str_dup(p);
 }
 
+static int rl78_archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
+	switch (query) {
+	case RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_MAX_OP_SIZE:
+		return 5;
+	case RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_DATA_ALIGN:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_CAN_USE_POINTERS:
+		return true;
+	default:
+		return -1;
+	}
+}
+
 RzAnalysisPlugin rz_analysis_plugin_rl78 = {
 	.name = "rl78",
 	.desc = "Renesas RL78 analysis plugin",
@@ -263,5 +280,6 @@ RzAnalysisPlugin rz_analysis_plugin_rl78 = {
 	.arch = "rl78",
 	.bits = 16,
 	.op = &rl78_op,
+	.archinfo = rl78_archinfo,
 	.get_reg_profile = &get_reg_profile
 };

--- a/librz/arch/p/analysis/analysis_rx.c
+++ b/librz/arch/p/analysis/analysis_rx.c
@@ -376,6 +376,23 @@ static char *analysis_rx_reg_profile(RzAnalysis *analysis) {
 	return rz_str_dup(p);
 }
 
+static int analysis_rx_archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
+	switch (query) {
+	case RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_MAX_OP_SIZE:
+		return 8;
+	case RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN:
+		/* fall-thru */
+	case RZ_ANALYSIS_ARCHINFO_DATA_ALIGN:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_CAN_USE_POINTERS:
+		return true;
+	default:
+		return -1;
+	}
+}
+
 RzAnalysisPlugin rz_analysis_plugin_rx = {
 	.name = "rx",
 	.arch = "rx",
@@ -383,5 +400,6 @@ RzAnalysisPlugin rz_analysis_plugin_rx = {
 	.license = "LGPL3",
 	.bits = 32,
 	.op = &analysis_rx_op,
+	.archinfo = analysis_rx_archinfo,
 	.get_reg_profile = &analysis_rx_reg_profile,
 };

--- a/librz/arch/p/analysis/analysis_sh.c
+++ b/librz/arch/p/analysis/analysis_sh.c
@@ -1174,7 +1174,7 @@ static RZ_OWN char *sh_get_reg_profile(RzAnalysis *analysis) {
 	return rz_str_dup(p);
 }
 
-static int archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
+static int sh_archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
 	switch (query) {
 	case RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE:
 		/* fall-thru */
@@ -1196,7 +1196,7 @@ RzAnalysisPlugin rz_analysis_plugin_sh = {
 	.desc = "SH-4 code analysis plugin",
 	.license = "LGPL3",
 	.arch = "sh",
-	.archinfo = archinfo,
+	.archinfo = sh_archinfo,
 	.bits = 32,
 	.op = &sh_op,
 	.get_reg_profile = &sh_get_reg_profile,

--- a/librz/arch/p/analysis/analysis_snes.c
+++ b/librz/arch/p/analysis/analysis_snes.c
@@ -390,6 +390,23 @@ static bool snes_analysis_fini(void *user) {
 	return true;
 }
 
+static int snes_archinfo(RzAnalysis *a, RzAnalysisInfoType query) {
+	switch (query) {
+	case RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_MAX_OP_SIZE:
+		return 4;
+	case RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_DATA_ALIGN:
+		return 1;
+	case RZ_ANALYSIS_ARCHINFO_CAN_USE_POINTERS:
+		return true;
+	default:
+		return -1;
+	}
+}
+
 RzAnalysisPlugin rz_analysis_plugin_snes = {
 	.name = "snes",
 	.desc = "SNES analysis plugin",
@@ -399,4 +416,5 @@ RzAnalysisPlugin rz_analysis_plugin_snes = {
 	.init = snes_analysis_init,
 	.fini = snes_analysis_fini,
 	.op = &snes_anop,
+	.archinfo = snes_archinfo,
 };

--- a/librz/arch/p/asm/asm_6502.c
+++ b/librz/arch/p/asm/asm_6502.c
@@ -10,7 +10,7 @@
 #include <rz_lib.h>
 #include <6502/6502dis.h>
 
-static int _6520_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int _6520_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	int dlen = disass_6502(a->pc, op, buf, len);
 	return op->size = RZ_MAX(dlen, 0);
 }

--- a/librz/arch/p/asm/asm_6502.c
+++ b/librz/arch/p/asm/asm_6502.c
@@ -6,6 +6,7 @@
 #include <rz_types.h>
 #include <rz_util.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include <6502/6502dis.h>
 

--- a/librz/arch/p/asm/asm_8051.c
+++ b/librz/arch/p/asm/asm_8051.c
@@ -2,18 +2,16 @@
 // SPDX-FileCopyrightText: 2013-2019 astuder <github@adrianstuder.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
-#include <stdarg.h>
-#include <string.h>
 #include <rz_types.h>
 #include <rz_util.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 
 #include <8051/8051_ass.h>
 #include <8051/8051_disas.h>
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int _8051_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	int dlen = 0;
 	char *s = rz_8051_disas(a->pc, buf, len, &dlen);
 	if (dlen < 0) {
@@ -27,14 +25,18 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	return dlen;
 }
 
+static int _8051_assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
+	return assemble_8051(op, a->pc, buf);
+}
+
 RzAsmPlugin rz_asm_plugin_8051 = {
 	.name = "8051",
 	.arch = "8051",
 	.bits = 8,
 	.endian = RZ_SYS_ENDIAN_NONE,
 	.desc = "Intel 8051 disassembler",
-	.disassemble = &disassemble,
-	.assemble = &assemble_8051,
+	.disassemble = &_8051_disassemble,
+	.assemble = &_8051_assemble,
 	.license = "PD",
 	.cpus =
 		"8051-generic," // First one is default

--- a/librz/arch/p/asm/asm_8051.c
+++ b/librz/arch/p/asm/asm_8051.c
@@ -11,7 +11,7 @@
 #include <8051/8051_ass.h>
 #include <8051/8051_disas.h>
 
-static int _8051_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int _8051_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	int dlen = 0;
 	char *s = rz_8051_disas(a->pc, buf, len, &dlen);
 	if (dlen < 0) {
@@ -25,7 +25,7 @@ static int _8051_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	return dlen;
 }
 
-static int _8051_assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
+static int _8051_assemble(const RzAsm *a, RzAsmOp *op, const char *buf) {
 	return assemble_8051(op, a->pc, buf);
 }
 

--- a/librz/arch/p/asm/asm_alpha_cs.c
+++ b/librz/arch/p/asm/asm_alpha_cs.c
@@ -6,7 +6,7 @@
 #include <rz_lib.h>
 #include <capstone/capstone.h>
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	if (!buf || !op || !a->plugin_data) {
 		return -1;
 	}

--- a/librz/arch/p/asm/asm_alpha_cs.c
+++ b/librz/arch/p/asm/asm_alpha_cs.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include <capstone/capstone.h>
 

--- a/librz/arch/p/asm/asm_amd29k.c
+++ b/librz/arch/p/asm/asm_amd29k.c
@@ -7,7 +7,7 @@
 #include "asm_private.h"
 #include "amd29k/amd29k.h"
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	if (!a || !op || !buf || len < 4) {
 		return -1;
 	}

--- a/librz/arch/p/asm/asm_amd29k.c
+++ b/librz/arch/p/asm/asm_amd29k.c
@@ -1,11 +1,10 @@
 // SPDX-FileCopyrightText: 2019 deroad <wargio@libero.it>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
-#include <string.h>
 #include <rz_types.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include "amd29k/amd29k.h"
 
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {

--- a/librz/arch/p/asm/asm_arm_as.c
+++ b/librz/arch/p/asm/asm_arm_as.c
@@ -5,6 +5,7 @@
 #include <rz_util.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include "../binutils_as.h"
 
 #define ASSEMBLER32 "RZ_ARM32_AS"

--- a/librz/arch/p/asm/asm_arm_as.c
+++ b/librz/arch/p/asm/asm_arm_as.c
@@ -11,7 +11,7 @@
 #define ASSEMBLER32 "RZ_ARM32_AS"
 #define ASSEMBLER64 "RZ_ARM64_AS"
 
-static int assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
+static int assemble(const RzAsm *a, RzAsmOp *op, const char *buf) {
 	int bits = a->bits;
 	char *as = "";
 #if __arm__

--- a/librz/arch/p/asm/asm_arm_cs.c
+++ b/librz/arch/p/asm/asm_arm_cs.c
@@ -32,7 +32,7 @@ typedef struct asm_arm_cs_context_t {
 
 bool arm64ass(const char *str, ut64 addr, ut32 *op);
 
-static bool check_features(RzAsm *a, cs_insn *insn) {
+static bool check_features(const RzAsm *a, cs_insn *insn) {
 	AsmArmCSContext *ctx = (AsmArmCSContext *)a->plugin_data;
 	int i;
 	if (!insn || !insn->detail) {
@@ -67,7 +67,7 @@ static bool check_features(RzAsm *a, cs_insn *insn) {
 	return true;
 }
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	AsmArmCSContext *ctx = (AsmArmCSContext *)a->plugin_data;
 
 	bool disp_hash = a->immdisp;
@@ -178,7 +178,7 @@ beach:
 	return ret;
 }
 
-static int assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
+static int assemble(const RzAsm *a, RzAsmOp *op, const char *buf) {
 	const bool is_thumb = (a->bits == 16);
 	int opsize;
 	ut32 opcode;
@@ -249,7 +249,7 @@ static bool arm_fini(void *user) {
 	return true;
 }
 
-static char *mnemonics(RzAsm *a, int id, bool json) {
+static char *mnemonics(const RzAsm *a, int id, bool json) {
 	AsmArmCSContext *ctx = (AsmArmCSContext *)a->plugin_data;
 	int i;
 	a->cur->disassemble(a, NULL, NULL, -1);
@@ -298,7 +298,7 @@ static char **arm_cpu_descriptions() {
 	return cpu_desc;
 }
 
-static bool arm_sw_breakpoint(RzAsm *a, RzAsmOp *op) {
+static bool arm_sw_breakpoint(const RzAsm *a, RzAsmOp *op) {
 	if (a->bits == 64) {
 		// arm64/aarch64
 		// { 64, 4, 0, "\x00\x00\x20\xd4" }, // le - arm64 brk0

--- a/librz/arch/p/asm/asm_arm_cs.c
+++ b/librz/arch/p/asm/asm_arm_cs.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include <rz_util/ht_uu.h>
 

--- a/librz/arch/p/asm/asm_arm_hacks.inc
+++ b/librz/arch/p/asm/asm_arm_hacks.inc
@@ -220,7 +220,7 @@ static char *hack_handle_ldst_asm(ut32 insn) {
 	return NULL;
 }
 
-static int hackyArmAsm(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int hackyArmAsm(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	char *buf_asm = NULL;
 	// Hacky support for ARMv8.5
 	if (a->bits == 64 && len >= 4) {

--- a/librz/arch/p/asm/asm_avr.c
+++ b/librz/arch/p/asm/asm_avr.c
@@ -1,14 +1,11 @@
 // SPDX-FileCopyrightText: 2021 deroad <wargio@libero.it>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
-#include <stdarg.h>
-#include <string.h>
-
 #include <rz_types.h>
 #include <rz_util.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 
 #include "avr/assembler.h"
 #include "avr/disassembler.h"

--- a/librz/arch/p/asm/asm_avr.c
+++ b/librz/arch/p/asm/asm_avr.c
@@ -10,7 +10,7 @@
 #include "avr/assembler.h"
 #include "avr/disassembler.h"
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	AVROp aop = { 0 };
 	op->size = avr_disassembler(buf, len, a->pc, a->big_endian, &aop, &op->buf_asm);
 	if (!op->size) {
@@ -20,7 +20,7 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	return op->size;
 }
 
-static int assemble(RzAsm *a, RzAsmOp *ao, const char *str) {
+static int assemble(const RzAsm *a, RzAsmOp *ao, const char *str) {
 	st32 slen = strlen(str);
 
 	ut8 buffer[16];

--- a/librz/arch/p/asm/asm_bf.c
+++ b/librz/arch/p/asm/asm_bf.c
@@ -10,7 +10,7 @@ typedef struct {
 	RzPVector /*<RzAsmTokenPattern *>*/ *token_patterns;
 } BfContext;
 
-static RZ_OWN RzPVector /*<RzAsmTokenPattern *>*/ *get_token_patterns(RzAsm *a) {
+static RZ_OWN RzPVector /*<RzAsmTokenPattern *>*/ *get_token_patterns(const RzAsm *a) {
 	BfContext *ctx = (BfContext *)a->plugin_data;
 	RzPVector *pvec = ctx->token_patterns;
 	if (pvec) {
@@ -52,7 +52,7 @@ static RZ_OWN RzPVector /*<RzAsmTokenPattern *>*/ *get_token_patterns(RzAsm *a) 
 	return pvec;
 }
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	const char *buf_asm = "invalid";
 	ut32 op_type;
 	switch (*buf) {
@@ -121,7 +121,7 @@ static bool _write_asm(RzAsmOp *op, int value, int n) {
 	return false;
 }
 
-static int assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
+static int assemble(const RzAsm *a, RzAsmOp *op, const char *buf) {
 	int n = 0;
 	if (buf[0] && buf[1] == ' ') {
 		buf += 2;
@@ -188,7 +188,7 @@ static bool bf_fini(void *user) {
 	return true;
 }
 
-static bool bf_sw_breakpoint(RzAsm *a, RzAsmOp *op) {
+static bool bf_sw_breakpoint(const RzAsm *a, RzAsmOp *op) {
 	// { 0, 1, 0, (const ut8 *)"\xff" },
 	// { 0, 1, 0, (const ut8 *)"\x00" },
 	rz_asm_op_set_buf(op, (const ut8 *)"\xff", 1);

--- a/librz/arch/p/asm/asm_bf.c
+++ b/librz/arch/p/asm/asm_bf.c
@@ -4,6 +4,7 @@
 
 #include <rz_analysis.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 
 typedef struct {
 	RzPVector /*<RzAsmTokenPattern *>*/ *token_patterns;

--- a/librz/arch/p/asm/asm_cbpf_cs.c
+++ b/librz/arch/p/asm/asm_cbpf_cs.c
@@ -7,7 +7,7 @@
 
 CAPSTONE_DEFINE_PLUGIN_FUNCTIONS(cbpf_asm);
 
-static int cbpf_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int cbpf_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	CapstoneContext *ctx = (CapstoneContext *)a->plugin_data;
 	cs_insn *insn;
 	int n;

--- a/librz/arch/p/asm/asm_chip8.c
+++ b/librz/arch/p/asm/asm_chip8.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 
 static int chip8_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *b, int l) {

--- a/librz/arch/p/asm/asm_chip8.c
+++ b/librz/arch/p/asm/asm_chip8.c
@@ -5,7 +5,7 @@
 #include "asm_private.h"
 #include <rz_lib.h>
 
-static int chip8_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *b, int l) {
+static int chip8_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *b, int l) {
 	ut16 opcode = rz_read_be16(b);
 	uint8_t x = (opcode >> 8) & 0x0F;
 	uint8_t y = (opcode >> 4) & 0x0F;

--- a/librz/arch/p/asm/asm_cil.c
+++ b/librz/arch/p/asm/asm_cil.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include "cil/cil_dis.h"
 
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {

--- a/librz/arch/p/asm/asm_cil.c
+++ b/librz/arch/p/asm/asm_cil.c
@@ -5,7 +5,7 @@
 #include "asm_private.h"
 #include "cil/cil_dis.h"
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	CILOp cilop = { { { 0 } } };
 	if (cil_dis(&cilop, buf, len)) {
 		return 0;

--- a/librz/arch/p/asm/asm_cr16.c
+++ b/librz/arch/p/asm/asm_cr16.c
@@ -7,7 +7,7 @@
 #include "asm_private.h"
 #include <cr16/cr16_disas.h>
 
-static int cr16_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int cr16_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	struct cr16_cmd cmd = { 0 };
 	int ret = cr16_decode_command(buf, &cmd, len);
 	if (ret > -1) {

--- a/librz/arch/p/asm/asm_cr16.c
+++ b/librz/arch/p/asm/asm_cr16.c
@@ -1,11 +1,10 @@
 // SPDX-FileCopyrightText: 2014-2018 fedor.sakharov <fedor.sakharov@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
-#include <string.h>
 #include <rz_types.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <cr16/cr16_disas.h>
 
 static int cr16_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {

--- a/librz/arch/p/asm/asm_dalvik.c
+++ b/librz/arch/p/asm/asm_dalvik.c
@@ -3,12 +3,10 @@
 // SPDX-FileCopyrightText: 2009-2019 h4ng3r
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
-#include <string.h>
-
 #include <rz_types.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 
 #include <dalvik/opcode.h>
 
@@ -20,7 +18,6 @@ static int dalvik_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	char str[1024], *strasm = NULL;
 	ut64 offset = 0;
 	char *flag_str = NULL;
-	a->dataalign = 2;
 
 	if (buf[0] == 0x00) { /* nop */
 		if (len < 2) {
@@ -527,21 +524,18 @@ static int dalvik_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 
 // TODO
 static int dalvik_assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
-	int i;
-	char *p = strchr(buf, ' ');
-	if (p) {
-		*p = 0;
-	}
-	// TODO: use a hashtable here
-	for (i = 0; i < 256; i++) {
-		if (!strcmp(dalvik_opcodes[i].name, buf)) {
-			ut8 buf[4];
-			rz_write_ble32(buf, i, a->big_endian);
-			rz_strbuf_setbin(&op->buf, buf, sizeof(buf));
-			op->size = dalvik_opcodes[i].len;
-			return op->size;
+	ut8 temp[4];
+	for (ut32 i = 0; i < 256; i++) {
+		if (strcmp(dalvik_opcodes[i].name, buf)) {
+			continue;
 		}
+
+		rz_write_ble32(temp, i, a->big_endian);
+		rz_strbuf_setbin(&op->buf, temp, sizeof(temp));
+		op->size = dalvik_opcodes[i].len;
+		return op->size;
 	}
+
 	return 0;
 }
 

--- a/librz/arch/p/asm/asm_dalvik.c
+++ b/librz/arch/p/asm/asm_dalvik.c
@@ -10,7 +10,7 @@
 
 #include <dalvik/opcode.h>
 
-static int dalvik_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int dalvik_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	rz_return_val_if_fail(a && op && buf && len > 0, -1);
 
 	int vA, vB, vC, vD, vE, vF, vG, vH, payload = 0, i = (int)buf[0];
@@ -523,7 +523,7 @@ static int dalvik_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 }
 
 // TODO
-static int dalvik_assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
+static int dalvik_assemble(const RzAsm *a, RzAsmOp *op, const char *buf) {
 	ut8 temp[4];
 	for (ut32 i = 0; i < 256; i++) {
 		if (strcmp(dalvik_opcodes[i].name, buf)) {

--- a/librz/arch/p/asm/asm_dcpu16.c
+++ b/librz/arch/p/asm/asm_dcpu16.c
@@ -1,13 +1,11 @@
 // SPDX-FileCopyrightText: 2012-2018 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
-#include <stdarg.h>
-#include <string.h>
 #include <rz_types.h>
 #include <rz_util.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <dcpu16/dcpu16.h>
 
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {

--- a/librz/arch/p/asm/asm_dcpu16.c
+++ b/librz/arch/p/asm/asm_dcpu16.c
@@ -8,7 +8,7 @@
 #include "asm_private.h"
 #include <dcpu16/dcpu16.h>
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	char buf_asm[96];
 	if (len < 2) {
 		return -1; // at least 2 bytes!
@@ -18,7 +18,7 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	return op->size;
 }
 
-static int assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
+static int assemble(const RzAsm *a, RzAsmOp *op, const char *buf) {
 	int len = dcpu16_assemble((ut8 *)rz_strbuf_get(&op->buf), buf);
 	op->buf.len = len;
 	return len;

--- a/librz/arch/p/asm/asm_ebc.c
+++ b/librz/arch/p/asm/asm_ebc.c
@@ -2,11 +2,10 @@
 // SPDX-FileCopyrightText: 2012-2018 fedor sakharov <fedor.sakharov@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
-#include <string.h>
 #include <rz_types.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <ebc/ebc_disas.h>
 
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {

--- a/librz/arch/p/asm/asm_ebc.c
+++ b/librz/arch/p/asm/asm_ebc.c
@@ -8,7 +8,7 @@
 #include "asm_private.h"
 #include <ebc/ebc_disas.h>
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	ebc_command_t cmd = { { 0 }, { 0 } };
 	int ret = ebc_decode_command(buf, len, &cmd);
 	if (cmd.operands[0]) {

--- a/librz/arch/p/asm/asm_gb.c
+++ b/librz/arch/p/asm/asm_gb.c
@@ -8,12 +8,12 @@
 #include "asm_private.h"
 #include <rz_lib.h>
 
-static int disassemble(RzAsm *a, RzAsmOp *rz_op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *rz_op, const ut8 *buf, int len) {
 	int dlen = gbDisass(rz_op, buf, len);
 	return rz_op->size = RZ_MAX(0, dlen);
 }
 
-static int assemble(RzAsm *a, RzAsmOp *rz_op, const char *buf) {
+static int assemble(const RzAsm *a, RzAsmOp *rz_op, const char *buf) {
 	return gbAsm(a, rz_op, buf);
 }
 

--- a/librz/arch/p/asm/asm_gb.c
+++ b/librz/arch/p/asm/asm_gb.c
@@ -5,6 +5,7 @@
 #include <rz_types.h>
 #include <rz_util.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 
 static int disassemble(RzAsm *a, RzAsmOp *rz_op, const ut8 *buf, int len) {

--- a/librz/arch/p/asm/asm_h8300.c
+++ b/librz/arch/p/asm/asm_h8300.c
@@ -2,11 +2,10 @@
 // SPDX-FileCopyrightText: 2025 Billow <billow.fun@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
-#include <string.h>
 #include <rz_types.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <h8300/h8300_disas.h>
 
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {

--- a/librz/arch/p/asm/asm_h8300.c
+++ b/librz/arch/p/asm/asm_h8300.c
@@ -8,7 +8,7 @@
 #include "asm_private.h"
 #include <h8300/h8300_disas.h>
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	H8300Instruction cmd = { 0 };
 	op->size = -1;
 	int ret = h8300_decode_command(buf, len, &cmd, a->pc, a->cpu);

--- a/librz/arch/p/asm/asm_h8500.c
+++ b/librz/arch/p/asm/asm_h8500.c
@@ -7,7 +7,7 @@
 #include "asm_private.h"
 #include <h8500/h8500.h>
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	H8500Instruction ins = { 0 };
 	if (!h8500_instruction_parse(buf, len, &ins)) {
 		return -1;

--- a/librz/arch/p/asm/asm_h8500.c
+++ b/librz/arch/p/asm/asm_h8500.c
@@ -1,11 +1,10 @@
 // SPDX-FileCopyrightText: 2025 billow <billow.fun@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
-#include <string.h>
 #include <rz_types.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <h8500/h8500.h>
 
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {

--- a/librz/arch/p/asm/asm_hexagon.c
+++ b/librz/arch/p/asm/asm_hexagon.c
@@ -170,7 +170,7 @@ RZ_API RZ_OWN RzConfig *hexagon_get_config(void *plugin_data) {
  * \param l The size to read from the buffer.
  * \return int Size of the reversed opcode.
  */
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int l) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int l) {
 	rz_return_val_if_fail(a && op, -1);
 	if (l < HEX_INSN_SIZE) {
 		return -1;

--- a/librz/arch/p/asm/asm_hexagon.c
+++ b/librz/arch/p/asm/asm_hexagon.c
@@ -12,8 +12,8 @@
 #include <rz_types.h>
 #include <rz_util.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
-#include <rz_util/rz_print.h>
 #include <rz_vector.h>
 #include <hexagon/hexagon.h>
 #include <hexagon/hexagon_insn.h>

--- a/librz/arch/p/asm/asm_hppa_cs.c
+++ b/librz/arch/p/asm/asm_hppa_cs.c
@@ -6,7 +6,7 @@
 #include <rz_lib.h>
 #include <capstone/capstone.h>
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	if (!buf || !op || !a->plugin_data) {
 		return -1;
 	}

--- a/librz/arch/p/asm/asm_hppa_cs.c
+++ b/librz/arch/p/asm/asm_hppa_cs.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include <capstone/capstone.h>
 

--- a/librz/arch/p/asm/asm_i4004.c
+++ b/librz/arch/p/asm/asm_i4004.c
@@ -9,7 +9,7 @@
 #include <rz_lib.h>
 #include <i4004/i4004dis.h>
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	return i4004dis(op, buf, len);
 }
 

--- a/librz/arch/p/asm/asm_i4004.c
+++ b/librz/arch/p/asm/asm_i4004.c
@@ -5,6 +5,7 @@
 #include <rz_types.h>
 #include <rz_util.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include <i4004/i4004dis.h>
 

--- a/librz/arch/p/asm/asm_i8080.c
+++ b/librz/arch/p/asm/asm_i8080.c
@@ -5,6 +5,7 @@
 #include <rz_util.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <i8080/i8080dis.h>
 
 static int do_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {

--- a/librz/arch/p/asm/asm_i8080.c
+++ b/librz/arch/p/asm/asm_i8080.c
@@ -8,7 +8,7 @@
 #include "asm_private.h"
 #include <i8080/i8080dis.h>
 
-static int do_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int do_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	int dlen = i8080_disasm(buf, rz_strbuf_get(&op->buf_asm), len);
 	return op->size = RZ_MAX(0, dlen);
 }

--- a/librz/arch/p/asm/asm_java.c
+++ b/librz/arch/p/asm/asm_java.c
@@ -5,6 +5,7 @@
 #include <rz_util.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_core.h>
 
 #include "java/jvm.h"

--- a/librz/arch/p/asm/asm_java.c
+++ b/librz/arch/p/asm/asm_java.c
@@ -29,7 +29,7 @@ static void java_asm_update_context(JavaAsmContext *ctx) {
 	}
 }
 
-static ut64 java_asm_find_method(RzAsm *a) {
+static ut64 java_asm_find_method(const RzAsm *a) {
 	ut64 addr = a->pc;
 	if (!a->binb.bin) {
 		return addr;
@@ -53,7 +53,7 @@ static ut64 java_asm_find_method(RzAsm *a) {
 	return addr;
 }
 
-static int java_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int java_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	JavaAsmContext *ctx = (JavaAsmContext *)a->plugin_data;
 	rz_strbuf_set(&op->buf_asm, "invalid");
 
@@ -140,7 +140,7 @@ static bool java_asm_fini(void *user) {
 	return true;
 }
 
-static int java_assemble(RzAsm *a, RzAsmOp *ao, const char *str) {
+static int java_assemble(const RzAsm *a, RzAsmOp *ao, const char *str) {
 	ut8 buffer[128];
 	st32 written = 0;
 	st32 slen = strlen(str);

--- a/librz/arch/p/asm/asm_lh5801.c
+++ b/librz/arch/p/asm/asm_lh5801.c
@@ -7,7 +7,7 @@
 #include <rz_lib.h>
 #include <lh5801/lh5801.h>
 
-static int disassemble(RzAsm *as, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *as, RzAsmOp *op, const ut8 *buf, int len) {
 	struct lh5801_insn insn = { 0 };
 	if (!op) {
 		return 0;

--- a/librz/arch/p/asm/asm_lh5801.c
+++ b/librz/arch/p/asm/asm_lh5801.c
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2014-2015 jn
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <rz_asm.h>
 #include <rz_types.h>
+#include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include <lh5801/lh5801.h>
 

--- a/librz/arch/p/asm/asm_lm32.c
+++ b/librz/arch/p/asm/asm_lm32.c
@@ -5,6 +5,7 @@
 #include <rz_util.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include "lm32/lm32_isa.h"
 
 #define LM32_UNUSED 0

--- a/librz/arch/p/asm/asm_lm32.c
+++ b/librz/arch/p/asm/asm_lm32.c
@@ -409,19 +409,17 @@ static int rz_asm_lm32_stringify(RzAsmLm32Instruction *instr, char *str) {
 	return 0;
 }
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	RzAsmLm32Instruction instr = { 0 };
 	instr.value = buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3];
 	instr.addr = a->pc;
 	if (rz_asm_lm32_decode(&instr)) {
 		rz_strbuf_set(&op->buf_asm, "invalid");
-		a->invhex = 1;
 		return -1;
 	}
 	// op->buf_asm is 256 chars long, which is more than sufficient
 	if (rz_asm_lm32_stringify(&instr, rz_strbuf_get(&op->buf_asm))) {
 		rz_strbuf_set(&op->buf_asm, "invalid");
-		a->invhex = 1;
 		return -1;
 	}
 	return 4;

--- a/librz/arch/p/asm/asm_loongarch_cs.c
+++ b/librz/arch/p/asm/asm_loongarch_cs.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {

--- a/librz/arch/p/asm/asm_loongarch_cs.c
+++ b/librz/arch/p/asm/asm_loongarch_cs.c
@@ -5,7 +5,7 @@
 #include "asm_private.h"
 #include <rz_lib.h>
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	if (!buf || !op || !a->plugin_data) {
 		return -1;
 	}

--- a/librz/arch/p/asm/asm_luac.c
+++ b/librz/arch/p/asm/asm_luac.c
@@ -4,7 +4,7 @@
 #include "asm_private.h"
 #include <luac/lua_arch.h>
 
-int rz_luac_disasm(RzAsm *a, RzAsmOp *opstruct, const ut8 *buf, int len) {
+int rz_luac_disasm(const RzAsm *a, RzAsmOp *opstruct, const ut8 *buf, int len) {
 	LuaOpNameList oplist = NULL;
 	int r = 0;
 
@@ -29,7 +29,7 @@ int rz_luac_disasm(RzAsm *a, RzAsmOp *opstruct, const ut8 *buf, int len) {
 	return r;
 }
 
-int rz_luac_asm(RzAsm *a, RzAsmOp *opstruct, const char *str) {
+int rz_luac_asm(const RzAsm *a, RzAsmOp *opstruct, const char *str) {
 	int str_len = strlen(str);
 	ut32 instruction = 0;
 	ut8 buffer[4];

--- a/librz/arch/p/asm/asm_luac.c
+++ b/librz/arch/p/asm/asm_luac.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 // SPDX-FileCopyrightText: 2021 Heersin <teablearcher@gmail.com>
 
+#include "asm_private.h"
 #include <luac/lua_arch.h>
 
 int rz_luac_disasm(RzAsm *a, RzAsmOp *opstruct, const ut8 *buf, int len) {

--- a/librz/arch/p/asm/asm_m680x_cs.c
+++ b/librz/arch/p/asm/asm_m680x_cs.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include "cs_helper.h"
 

--- a/librz/arch/p/asm/asm_m680x_cs.c
+++ b/librz/arch/p/asm/asm_m680x_cs.c
@@ -42,7 +42,7 @@ static cs_mode m680x_mode(const char *str) {
 	return CS_MODE_M680X_6800;
 }
 
-static int m680x_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int m680x_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	CapstoneContext *ctx = (CapstoneContext *)a->plugin_data;
 
 	int n, ret;

--- a/librz/arch/p/asm/asm_m68k_cs.c
+++ b/librz/arch/p/asm/asm_m68k_cs.c
@@ -13,7 +13,7 @@ CAPSTONE_DEFINE_PLUGIN_FUNCTIONS(m68k_asm);
 // Size of the longest instruction in bytes
 #define M68K_LONGEST_INSTRUCTION 10
 
-static int m68k_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int m68k_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	if (!buf) {
 		return -1;
 	}

--- a/librz/arch/p/asm/asm_m68k_cs.c
+++ b/librz/arch/p/asm/asm_m68k_cs.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include <capstone/capstone.h>
 

--- a/librz/arch/p/asm/asm_malbolge.c
+++ b/librz/arch/p/asm/asm_malbolge.c
@@ -23,7 +23,7 @@ static const char *mal_dis(ut64 c, const ut8 *buf, ut64 len) {
 	return NULL;
 }
 
-static int __disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int __disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	const char *opstr = mal_dis(a->pc, buf, len);
 	return op->size = opstr ? 1 : 0;
 }

--- a/librz/arch/p/asm/asm_malbolge.c
+++ b/librz/arch/p/asm/asm_malbolge.c
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_types.h>
 #include <rz_lib.h>
-#include <string.h>
 
 static const char *mal_dis(ut64 c, const ut8 *buf, ut64 len) {
 	if (len) {

--- a/librz/arch/p/asm/asm_mcore.c
+++ b/librz/arch/p/asm/asm_mcore.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include "mcore/mcore.h"
 

--- a/librz/arch/p/asm/asm_mcore.c
+++ b/librz/arch/p/asm/asm_mcore.c
@@ -8,7 +8,7 @@
 
 static mcore_handle handle = { 0 };
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	mcore_t *instr = NULL;
 	char tmp[256];
 	if (!op || mcore_init(&handle, buf, len)) {

--- a/librz/arch/p/asm/asm_mcs96.c
+++ b/librz/arch/p/asm/asm_mcs96.c
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_types.h>
-#include <string.h>
+#include <rz_util.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include "mcs96/mcs96.h"
 #include "rz_analysis.h"
-#include "rz_util/rz_pj.h"
 
 typedef struct {
 	RzPVector /*<RzAsmTokenPattern *>*/ *token_patterns;

--- a/librz/arch/p/asm/asm_mcs96.c
+++ b/librz/arch/p/asm/asm_mcs96.c
@@ -311,7 +311,7 @@ static bool mcs96_fini(void *u) {
 	return true;
 }
 
-static int mcs96_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int mcs96_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	if (len > 1 && !memcmp(buf, "\xff\xff", 2)) {
 		return -1;
 	}

--- a/librz/arch/p/asm/asm_mips_cs.c
+++ b/librz/arch/p/asm/asm_mips_cs.c
@@ -11,7 +11,7 @@
 
 CAPSTONE_DEFINE_PLUGIN_FUNCTIONS(mips_asm);
 
-static int mips_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int mips_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	CapstoneContext *ctx = (CapstoneContext *)a->plugin_data;
 
 	cs_insn *insn;
@@ -79,7 +79,7 @@ fin:
 	return op->size;
 }
 
-static int mips_assemble(RzAsm *a, RzAsmOp *op, const char *str) {
+static int mips_assemble(const RzAsm *a, RzAsmOp *op, const char *str) {
 	return mips_assemble_opcode(str, a->pc, &op->buf, a->big_endian);
 }
 
@@ -122,7 +122,7 @@ static char **mips_cpu_descriptions() {
 	return cpu_desc;
 }
 
-static bool mips_sw_breakpoint(RzAsm *a, RzAsmOp *op) {
+static bool mips_sw_breakpoint(const RzAsm *a, RzAsmOp *op) {
 	// mips32/64
 	// { 32, 4, 0, "\x0d\x00\x00\x00" },
 	// { 32, 4, 1, "\x00\x00\x00\x0d" },

--- a/librz/arch/p/asm/asm_mips_cs.c
+++ b/librz/arch/p/asm/asm_mips_cs.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include <mips/mips_internal.h>
 #include <capstone/capstone.h>

--- a/librz/arch/p/asm/asm_msp430.c
+++ b/librz/arch/p/asm/asm_msp430.c
@@ -8,7 +8,7 @@
 
 #include <msp430/msp430_disas.h>
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	struct msp430_cmd cmd;
 	int ret = msp430_decode_command(buf, len, &cmd);
 	if (ret < 1) {

--- a/librz/arch/p/asm/asm_msp430.c
+++ b/librz/arch/p/asm/asm_msp430.c
@@ -1,11 +1,10 @@
 // SPDX-FileCopyrightText: 2014-2015 fedor.sakharov <fedor.sakharov@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
-#include <string.h>
 #include <rz_types.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 
 #include <msp430/msp430_disas.h>
 

--- a/librz/arch/p/asm/asm_null.c
+++ b/librz/arch/p/asm/asm_null.c
@@ -6,14 +6,14 @@
 #include <rz_asm.h>
 #include "asm_private.h"
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	int opsz = 0;
 	rz_strbuf_set(&op->buf_asm, "");
 	op->size = opsz;
 	return opsz;
 }
 
-static int assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
+static int assemble(const RzAsm *a, RzAsmOp *op, const char *buf) {
 	return 0;
 }
 

--- a/librz/arch/p/asm/asm_null.c
+++ b/librz/arch/p/asm/asm_null.c
@@ -1,11 +1,10 @@
 // SPDX-FileCopyrightText: 2019 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
-#include <string.h>
 #include <rz_types.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	int opsz = 0;

--- a/librz/arch/p/asm/asm_or1k.c
+++ b/librz/arch/p/asm/asm_or1k.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include <or1k/or1k_disas.h>
 

--- a/librz/arch/p/asm/asm_or1k.c
+++ b/librz/arch/p/asm/asm_or1k.c
@@ -6,7 +6,7 @@
 #include <rz_lib.h>
 #include <or1k/or1k_disas.h>
 
-static int insn_to_str(RzAsm *a, char **line, insn_t *descr, insn_extra_t *extra, ut32 insn) {
+static int insn_to_str(const RzAsm *a, char **line, insn_t *descr, insn_extra_t *extra, ut32 insn) {
 	struct operands o = { 0 };
 	char *name;
 	insn_type_t type = type_of_opcode(descr, extra);
@@ -93,7 +93,7 @@ static int insn_to_str(RzAsm *a, char **line, insn_t *descr, insn_extra_t *extra
 	return 4;
 }
 
-static int or1k_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int or1k_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	ut32 insn, opcode;
 	ut8 opcode_idx;
 	char *line = NULL;

--- a/librz/arch/p/asm/asm_pic.c
+++ b/librz/arch/p/asm/asm_pic.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 
 #include "pic/pic_baseline.h"
@@ -24,7 +25,7 @@ static int asm_pic_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *b, int l) {
 		}
 		return op->size;
 	} else if (is_pic_highend(a->cpu)) {
-		return pic_highend_disassemble(a, op, b, l);
+		return pic_highend_disassemble(op, a->pc, b, l);
 	}
 	return -1;
 }

--- a/librz/arch/p/asm/asm_pic.c
+++ b/librz/arch/p/asm/asm_pic.c
@@ -10,7 +10,7 @@
 #include "pic/pic_midrange.h"
 #include "pic/pic_highend.h"
 
-static int asm_pic_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *b, int l) {
+static int asm_pic_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *b, int l) {
 	if (is_pic_baseline_or_pic_midrange(a->cpu)) {
 		PicMidrangeOp x = { 0 };
 		if (!(is_pic_baseline(a->cpu) ? pic_baseline_decode_op : pic_midrange_decode_op)(&x, a->pc, b, l)) {

--- a/librz/arch/p/asm/asm_ppc_as.c
+++ b/librz/arch/p/asm/asm_ppc_as.c
@@ -7,7 +7,7 @@
 
 #define ASSEMBLER "RZ_PPC_AS"
 
-static int assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
+static int assemble(const RzAsm *a, RzAsmOp *op, const char *buf) {
 #if __powerpc__
 	char *as = "as";
 #else

--- a/librz/arch/p/asm/asm_ppc_as.c
+++ b/librz/arch/p/asm/asm_ppc_as.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_lib.h>
+#include "asm_private.h"
 #include "../binutils_as.h"
 
 #define ASSEMBLER "RZ_PPC_AS"

--- a/librz/arch/p/asm/asm_ppc_cs.c
+++ b/librz/arch/p/asm/asm_ppc_cs.c
@@ -11,7 +11,7 @@
 
 CAPSTONE_DEFINE_PLUGIN_FUNCTIONS(ppc_asm);
 
-static int decompile_vle(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int decompile_vle(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	vle_t *instr = 0;
 	vle_handle handle = { 0 };
 	if (len < 2) {
@@ -31,7 +31,7 @@ static int decompile_vle(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	return op->size;
 }
 
-static int decompile_ps(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int decompile_ps(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	ppcps_t instr = { 0 };
 	if (len < 4) {
 		return -1;
@@ -48,7 +48,7 @@ static int decompile_ps(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	return op->size;
 }
 
-static int ppc_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int ppc_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	CapstoneContext *ctx = (CapstoneContext *)a->plugin_data;
 	int n, ret;
 	ut64 off = a->pc;
@@ -128,7 +128,7 @@ static char **ppc_cpu_descriptions() {
 	return cpu_desc;
 }
 
-static bool ppc_sw_breakpoint(RzAsm *a, RzAsmOp *op) {
+static bool ppc_sw_breakpoint(const RzAsm *a, RzAsmOp *op) {
 	// ppc | tw 31, 0, 0 | trap
 	// { 0x7f, 0xe0, 0x00, 0x08 } | big endian
 	// { 0x08, 0x00, 0xe0, 0x7f } | little endian

--- a/librz/arch/p/asm/asm_ppc_cs.c
+++ b/librz/arch/p/asm/asm_ppc_cs.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include "ppc/libvle/vle.h"
 #include "ppc/libps/libps.h"

--- a/librz/arch/p/asm/asm_propeller.c
+++ b/librz/arch/p/asm/asm_propeller.c
@@ -1,11 +1,10 @@
 // SPDX-FileCopyrightText: 2014 fedor.sakharov <fedor.sakharov@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
-#include <string.h>
 #include <rz_types.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 
 #include <propeller/propeller_disas.h>
 

--- a/librz/arch/p/asm/asm_propeller.c
+++ b/librz/arch/p/asm/asm_propeller.c
@@ -8,7 +8,7 @@
 
 #include <propeller/propeller_disas.h>
 
-static int propeller_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int propeller_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	rz_return_val_if_fail(a && op && buf && len >= 4, -1);
 	struct propeller_cmd cmd;
 	int ret = propeller_decode_command(buf, &cmd);

--- a/librz/arch/p/asm/asm_pyc.c
+++ b/librz/arch/p/asm/asm_pyc.c
@@ -10,7 +10,7 @@
 
 #include "pyc/pyc_dis.h"
 
-static int pyc_asm_disassemble(RzAsm *a, RzAsmOp *aop, const ut8 *buf, int len) {
+static int pyc_asm_disassemble(const RzAsm *a, RzAsmOp *aop, const ut8 *buf, int len) {
 	pyc_context_t *ctx = (pyc_context_t *)a->plugin_data;
 	RzList *shared = NULL;
 

--- a/librz/arch/p/asm/asm_pyc.c
+++ b/librz/arch/p/asm/asm_pyc.c
@@ -6,6 +6,7 @@
 #include <rz_lib.h>
 #include <rz_util.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 
 #include "pyc/pyc_dis.h"
 

--- a/librz/arch/p/asm/asm_riscv_cs.c
+++ b/librz/arch/p/asm/asm_riscv_cs.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include <capstone/capstone.h>
 #include "cs_helper.h"

--- a/librz/arch/p/asm/asm_riscv_cs.c
+++ b/librz/arch/p/asm/asm_riscv_cs.c
@@ -10,7 +10,7 @@
 
 CAPSTONE_DEFINE_PLUGIN_FUNCTIONS(riscv_asm);
 
-static int riscv_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int riscv_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	CapstoneContext *ctx = (CapstoneContext *)a->plugin_data;
 
 	int ret = -1;

--- a/librz/arch/p/asm/asm_rl78.c
+++ b/librz/arch/p/asm/asm_rl78.c
@@ -9,11 +9,11 @@
 
 #include "rl78/rl78.h"
 
-static int assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
+static int assemble(const RzAsm *a, RzAsmOp *op, const char *buf) {
 	return 0x69;
 }
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	RL78Instr instr = { 0 };
 	size_t bytes_read = 0;
 	if (!rl78_dis(&instr, &bytes_read, buf, len)) {

--- a/librz/arch/p/asm/asm_rl78.c
+++ b/librz/arch/p/asm/asm_rl78.c
@@ -5,6 +5,7 @@
 #include <rz_util.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 
 #include "rl78/rl78.h"
 

--- a/librz/arch/p/asm/asm_rsp.c
+++ b/librz/arch/p/asm/asm_rsp.c
@@ -13,7 +13,7 @@
 
 #include <rsp/rsp_idec.h>
 
-static int rsp_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int rsp_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	rsp_instruction rz_instr;
 	int i;
 

--- a/librz/arch/p/asm/asm_rsp.c
+++ b/librz/arch/p/asm/asm_rsp.c
@@ -5,6 +5,7 @@
 #include <rz_types.h>
 #include <rz_util.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 
 #include <stdarg.h>

--- a/librz/arch/p/asm/asm_rx.c
+++ b/librz/arch/p/asm/asm_rx.c
@@ -5,6 +5,7 @@
 #include <rz_util.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rx/rx.h>
 
 static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {

--- a/librz/arch/p/asm/asm_rx.c
+++ b/librz/arch/p/asm/asm_rx.c
@@ -8,7 +8,7 @@
 #include "asm_private.h"
 #include <rx/rx.h>
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	RxInst inst = { 0 };
 	st32 bytes_read;
 

--- a/librz/arch/p/asm/asm_sh.c
+++ b/librz/arch/p/asm/asm_sh.c
@@ -9,7 +9,7 @@
 #include "sh/disassembler.h"
 #include "sh/assembler.h"
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	SHOp *dis_op = sh_disassembler(rz_read_ble16(buf, a->big_endian));
 	op->size = 2;
 	if (!dis_op) {
@@ -23,7 +23,7 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	return op->size;
 }
 
-static int assemble(RzAsm *a, RzAsmOp *ao, const char *str) {
+static int assemble(const RzAsm *a, RzAsmOp *ao, const char *str) {
 	bool success;
 	ut16 opcode = sh_assembler(str, a->pc, &success);
 	if (!success) {
@@ -36,7 +36,7 @@ static int assemble(RzAsm *a, RzAsmOp *ao, const char *str) {
 	return 2;
 }
 
-static bool sh_sw_breakpoint(RzAsm *a, RzAsmOp *op) {
+static bool sh_sw_breakpoint(const RzAsm *a, RzAsmOp *op) {
 	// 	{ 32, 2, 1, "\xc3\x20" }, // Big endian
 	// 	{ 32, 2, 0, "\x20\xc3" }, // Little endian
 	rz_asm_op_set_buf(op, a->big_endian ? (const ut8 *)"\xc3\x20" : (const ut8 *)"\x20\xc3", 2);

--- a/librz/arch/p/asm/asm_sh.c
+++ b/librz/arch/p/asm/asm_sh.c
@@ -5,6 +5,7 @@
 #include <rz_lib.h>
 #include <rz_util.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include "sh/disassembler.h"
 #include "sh/assembler.h"
 

--- a/librz/arch/p/asm/asm_snes.c
+++ b/librz/arch/p/asm/asm_snes.c
@@ -10,7 +10,7 @@
 #include <snes/snes_op_table.h>
 #include <snes/snes.h>
 
-static int dis(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int dis(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	struct snes_asm_flags *snesflags = (struct snes_asm_flags *)a->plugin_data;
 	int dlen = snesDisass(snesflags->M, snesflags->X, a->pc, op, buf, len);
 	if (dlen < 0) {

--- a/librz/arch/p/asm/asm_snes.c
+++ b/librz/arch/p/asm/asm_snes.c
@@ -5,6 +5,7 @@
 #include <rz_types.h>
 #include <rz_util.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include <snes/snes_op_table.h>
 #include <snes/snes.h>

--- a/librz/arch/p/asm/asm_sparc_cs.c
+++ b/librz/arch/p/asm/asm_sparc_cs.c
@@ -8,7 +8,7 @@
 
 CAPSTONE_DEFINE_PLUGIN_FUNCTIONS(sparc_asm);
 
-static int sparc_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int sparc_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	CapstoneContext *ctx = (CapstoneContext *)a->plugin_data;
 
 	cs_insn *insn;

--- a/librz/arch/p/asm/asm_sparc_cs.c
+++ b/librz/arch/p/asm/asm_sparc_cs.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include "cs_helper.h"
 

--- a/librz/arch/p/asm/asm_spc700.c
+++ b/librz/arch/p/asm/asm_spc700.c
@@ -5,6 +5,7 @@
 #include <rz_types.h>
 #include <rz_util.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include <spc700/spc700dis.h>
 

--- a/librz/arch/p/asm/asm_spc700.c
+++ b/librz/arch/p/asm/asm_spc700.c
@@ -9,7 +9,7 @@
 #include <rz_lib.h>
 #include <spc700/spc700dis.h>
 
-static int disassemble(RzAsm *a, RzAsmOp *rz_op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *rz_op, const ut8 *buf, int len) {
 	size_t dlen = spc700_disas(&rz_op->buf_asm, a->pc, buf, len);
 	rz_op->size = dlen;
 	return (int)dlen;

--- a/librz/arch/p/asm/asm_sysz.c
+++ b/librz/arch/p/asm/asm_sysz.c
@@ -12,7 +12,7 @@
 
 CAPSTONE_DEFINE_PLUGIN_FUNCTIONS(sysz);
 
-static int sysz_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int sysz_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	CapstoneContext *ctx = (CapstoneContext *)a->plugin_data;
 	int n, ret;
 	ut64 off = a->pc;

--- a/librz/arch/p/asm/asm_sysz.c
+++ b/librz/arch/p/asm/asm_sysz.c
@@ -4,6 +4,7 @@
 // instruction set : http://www.tachyonsoft.com/inst390m.htm
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 
 #include "cs_helper.h"

--- a/librz/arch/p/asm/asm_tms320.c
+++ b/librz/arch/p/asm/asm_tms320.c
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2014 Ilya V. Matveychikov <i.matveychikov@milabs.ru>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
 #include <rz_types.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <tms320/tms320_dasm.h>
 #include <tms320/c64x/c64x.h>
 

--- a/librz/arch/p/asm/asm_tms320.c
+++ b/librz/arch/p/asm/asm_tms320.c
@@ -13,7 +13,7 @@ typedef struct tms_cs_context_t {
 	tms320_dasm_t engine;
 } TmsContext;
 
-static int tms320_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int tms320_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	TmsContext *ctx = (TmsContext *)a->plugin_data;
 	if (a->cpu && rz_str_casecmp(a->cpu, "c54x") == 0) {
 		tms320_f_set_cpu(&ctx->engine, TMS320_F_CPU_C54X);
@@ -53,7 +53,7 @@ static bool tms320_fini(void *user) {
 	return true;
 }
 
-static char *tms320_mnemonics(RzAsm *a, int id, bool json) {
+static char *tms320_mnemonics(const RzAsm *a, int id, bool json) {
 	TmsContext *ctx = (TmsContext *)a->plugin_data;
 	if (!a->cpu || rz_str_casecmp(a->cpu, "c64x")) {
 		return NULL;

--- a/librz/arch/p/asm/asm_tricore_cs.c
+++ b/librz/arch/p/asm/asm_tricore_cs.c
@@ -11,7 +11,7 @@
 #define TRICORE_LONGEST_INSTRUCTION  4
 #define TRICORE_SHORTEST_INSTRUCTION 2
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	if (!buf || len < TRICORE_SHORTEST_INSTRUCTION || !a->plugin_data) {
 		return -1;
 	}

--- a/librz/arch/p/asm/asm_tricore_cs.c
+++ b/librz/arch/p/asm/asm_tricore_cs.c
@@ -1,12 +1,11 @@
 // SPDX-FileCopyrightText: 2023 billow <billow.fun@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <string.h>
-
 #include <rz_types.h>
 #include <rz_lib.h>
 #include <rz_util.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <capstone/capstone.h>
 
 #define TRICORE_LONGEST_INSTRUCTION  4

--- a/librz/arch/p/asm/asm_v810.c
+++ b/librz/arch/p/asm/asm_v810.c
@@ -1,11 +1,10 @@
 // SPDX-FileCopyrightText: 2012-2018 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
-#include <string.h>
 #include <rz_types.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 
 #include "v810/v810_disas.h"
 

--- a/librz/arch/p/asm/asm_v810.c
+++ b/librz/arch/p/asm/asm_v810.c
@@ -8,7 +8,7 @@
 
 #include "v810/v810_disas.h"
 
-static int v810_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int v810_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	struct v810_cmd cmd = {
 		.instr = "",
 		.operands = ""

--- a/librz/arch/p/asm/asm_v850.c
+++ b/librz/arch/p/asm/asm_v850.c
@@ -1,11 +1,10 @@
 // SPDX-FileCopyrightText: 2012-2018 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
-#include <string.h>
 #include <rz_types.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 
 #include <v850/v850_disas.h>
 

--- a/librz/arch/p/asm/asm_v850.c
+++ b/librz/arch/p/asm/asm_v850.c
@@ -8,7 +8,7 @@
 
 #include <v850/v850_disas.h>
 
-static int v850_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int v850_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	V850_Inst inst = { 0 };
 	inst.addr = a->pc;
 	if (len < 2) {

--- a/librz/arch/p/asm/asm_wasm.c
+++ b/librz/arch/p/asm/asm_wasm.c
@@ -4,11 +4,10 @@
 
 // http://webassembly.org/docs/binary-encoding/#module-structure
 
-#include <stdio.h>
-#include <string.h>
 #include <rz_types.h>
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 
 #include <wasm/wasm.h>
 

--- a/librz/arch/p/asm/asm_wasm.c
+++ b/librz/arch/p/asm/asm_wasm.c
@@ -11,7 +11,7 @@
 
 #include <wasm/wasm.h>
 
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	WasmOp wop = { { 0 } };
 	int ret = wasm_dis(&wop, buf, len);
 	rz_asm_op_set_asm(op, wop.txt);
@@ -20,7 +20,7 @@ static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	return op->size;
 }
 
-static int assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
+static int assemble(const RzAsm *a, RzAsmOp *op, const char *buf) {
 	ut8 *opbuf = (ut8 *)rz_strbuf_get(&op->buf);
 	op->size = wasm_asm(buf, opbuf, 32); // XXX hardcoded opsize
 	return op->size;

--- a/librz/arch/p/asm/asm_x86_as.c
+++ b/librz/arch/p/asm/asm_x86_as.c
@@ -8,7 +8,7 @@
 
 #define ASSEMBLER "RZ_X86_AS"
 
-static int assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
+static int assemble(const RzAsm *a, RzAsmOp *op, const char *buf) {
 #if __i386__ || __x86_64__
 	const char *as = "as";
 #else

--- a/librz/arch/p/asm/asm_x86_as.c
+++ b/librz/arch/p/asm/asm_x86_as.c
@@ -3,6 +3,7 @@
 
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include "../binutils_as.h"
 
 #define ASSEMBLER "RZ_X86_AS"

--- a/librz/arch/p/asm/asm_x86_cs.c
+++ b/librz/arch/p/asm/asm_x86_cs.c
@@ -12,7 +12,7 @@ CAPSTONE_DEFINE_PLUGIN_FUNCTIONS(x86_asm);
 
 #include "asm_x86_vm.c"
 
-static bool check_features(RzAsm *a, cs_insn *insn) {
+static bool check_features(const RzAsm *a, cs_insn *insn) {
 	if (RZ_STR_ISEMPTY(a->features)) {
 		return true;
 	}
@@ -44,7 +44,7 @@ static bool check_features(RzAsm *a, cs_insn *insn) {
 	return true;
 }
 
-static int x86_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int x86_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	CapstoneContext *ctx = (CapstoneContext *)a->plugin_data;
 	int ret, n;
 	ut64 off = a->pc;
@@ -132,7 +132,7 @@ static int x86_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	return op->size;
 }
 
-static bool x86_sw_breakpoint(RzAsm *a, RzAsmOp *op) {
+static bool x86_sw_breakpoint(const RzAsm *a, RzAsmOp *op) {
 	// { 0, 1, 0, "\xcc" }, // valid for 16, 32, 64
 	// { 0, 2, 0, "\xcd\x03" },
 	rz_asm_op_set_buf(op, (const ut8 *)"\xcc", 1);

--- a/librz/arch/p/asm/asm_x86_cs.c
+++ b/librz/arch/p/asm/asm_x86_cs.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include <capstone/capstone.h>
 

--- a/librz/arch/p/asm/asm_x86_nasm.c
+++ b/librz/arch/p/asm/asm_x86_nasm.c
@@ -5,7 +5,7 @@
 #include <rz_asm.h>
 #include "asm_private.h"
 
-static int assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
+static int assemble(const RzAsm *a, RzAsmOp *op, const char *buf) {
 	char *ipath, *opath;
 	if (a->syntax != RZ_ASM_SYNTAX_INTEL) {
 		RZ_LOG_ERROR("assembler: x86.nasm: the assembler does not support non-intel syntax\n");

--- a/librz/arch/p/asm/asm_x86_nasm.c
+++ b/librz/arch/p/asm/asm_x86_nasm.c
@@ -3,6 +3,7 @@
 
 #include <rz_lib.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 
 static int assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
 	char *ipath, *opath;

--- a/librz/arch/p/asm/asm_x86_nz.c
+++ b/librz/arch/p/asm/asm_x86_nz.c
@@ -6,10 +6,9 @@
 #include <rz_flag.h>
 #include <rz_core.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 #include <rz_types.h>
-#include <stdio.h>
-#include <string.h>
 
 static ut64 getnum(RzAsm *a, const char *s);
 
@@ -1885,9 +1884,6 @@ static int opmov(RzAsm *a, ut8 *data, const Opcode *op) {
 	ut64 immediate = 0;
 	if (op->operands[1].type & OT_CONSTANT) {
 		if (!op->operands[1].is_good_flag) {
-			return -1;
-		}
-		if (op->operands[1].immediate == -1 && a->num && a->num->nc.errors > 0) {
 			return -1;
 		}
 		immediate = op->operands[1].immediate * op->operands[1].sign;
@@ -5077,22 +5073,7 @@ static int parseOperand(RzAsm *a, const char *str, Operand *op, bool isrepop) {
 			return nextpos;
 		}
 		if (op->reg == X86R_UNDEFINED) {
-			op->is_good_flag = false;
-			if (a->num && a->num->value == 0) {
-				return nextpos;
-			}
-			op->type = OT_CONSTANT;
-			RzCore *core = a->num ? (RzCore *)(a->num->userptr) : NULL;
-			if (core && rz_flag_get(core->flags, str)) {
-				op->is_good_flag = true;
-			}
-
-			char *p = strchr(str, '-');
-			if (p) {
-				op->sign = -1;
-				str = ++p;
-			}
-			op->immediate = getnum(a, str);
+			return nextpos;
 		} else if (op->reg < X86R_UNDEFINED) {
 			strncpy(op->rep_op, str, MAX_REPOP_LENGTH - 1);
 			op->rep_op[MAX_REPOP_LENGTH - 1] = '\0';
@@ -5163,7 +5144,7 @@ static ut64 getnum(RzAsm *a, const char *s) {
 	if (*s == '$') {
 		s++;
 	}
-	return rz_num_math(a->num, s);
+	return rz_num_math(NULL, s);
 }
 
 static int oprep(RzAsm *a, ut8 *data, const Opcode *op) {

--- a/librz/arch/p/asm/asm_x86_nz.c
+++ b/librz/arch/p/asm/asm_x86_nz.c
@@ -10,7 +10,7 @@
 #include <rz_lib.h>
 #include <rz_types.h>
 
-static ut64 getnum(RzAsm *a, const char *s);
+static ut64 getnum(const RzAsm *a, const char *s);
 
 #define ENCODING_SHIFT 0
 #define OPTYPE_SHIFT   6
@@ -215,9 +215,9 @@ static int is_al_reg(const Operand *op) {
 	return 0;
 }
 
-static int oprep(RzAsm *a, ut8 *data, const Opcode *op);
+static int oprep(const RzAsm *a, ut8 *data, const Opcode *op);
 
-static int process_16bit_group_1(RzAsm *a, ut8 *data, const Opcode *op, int op1) {
+static int process_16bit_group_1(const RzAsm *a, ut8 *data, const Opcode *op, int op1) {
 	is_valid_registers(op);
 	int l = 0;
 	int immediate = op->operands[1].immediate * op->operands[1].sign;
@@ -242,7 +242,7 @@ static int process_16bit_group_1(RzAsm *a, ut8 *data, const Opcode *op, int op1)
 	return l;
 }
 
-static int process_group_1(RzAsm *a, ut8 *data, const Opcode *op) {
+static int process_group_1(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	int modrm = 0;
@@ -336,7 +336,7 @@ static int process_group_1(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int process_group_2(RzAsm *a, ut8 *data, const Opcode *op) {
+static int process_group_2(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	int modrm = 0;
@@ -413,7 +413,7 @@ static int process_group_2(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int process_1byte_op(RzAsm *a, ut8 *data, const Opcode *op, int op1) {
+static int process_1byte_op(const RzAsm *a, ut8 *data, const Opcode *op, int op1) {
 	is_valid_registers(op);
 	int l = 0;
 	int mod_byte = 0;
@@ -560,7 +560,7 @@ static int process_1byte_op(RzAsm *a, ut8 *data, const Opcode *op, int op1) {
 	return l;
 }
 
-static int opadc(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opadc(const RzAsm *a, ut8 *data, const Opcode *op) {
 	if (op->operands[1].type & OT_CONSTANT) {
 		if (op->operands[0].type & OT_GPREG &&
 			op->operands[0].type & OT_WORD) {
@@ -573,7 +573,7 @@ static int opadc(RzAsm *a, ut8 *data, const Opcode *op) {
 	return process_1byte_op(a, data, op, 0x10);
 }
 
-static int opadd(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opadd(const RzAsm *a, ut8 *data, const Opcode *op) {
 	if (op->operands[1].type & OT_CONSTANT) {
 		if (op->operands[0].type & OT_GPREG &&
 			op->operands[0].type & OT_WORD) {
@@ -586,7 +586,7 @@ static int opadd(RzAsm *a, ut8 *data, const Opcode *op) {
 	return process_1byte_op(a, data, op, 0x00);
 }
 
-static int opand(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opand(const RzAsm *a, ut8 *data, const Opcode *op) {
 	if (op->operands[1].type & OT_CONSTANT) {
 		if (op->operands[0].type & OT_GPREG &&
 			op->operands[0].type & OT_WORD) {
@@ -599,7 +599,7 @@ static int opand(RzAsm *a, ut8 *data, const Opcode *op) {
 	return process_1byte_op(a, data, op, 0x20);
 }
 
-static int opcmp(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opcmp(const RzAsm *a, ut8 *data, const Opcode *op) {
 	if (op->operands[1].type & OT_CONSTANT) {
 		if (op->operands[0].type & OT_GPREG &&
 			op->operands[0].type & OT_WORD) {
@@ -612,7 +612,7 @@ static int opcmp(RzAsm *a, ut8 *data, const Opcode *op) {
 	return process_1byte_op(a, data, op, 0x38);
 }
 
-static int opsub(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opsub(const RzAsm *a, ut8 *data, const Opcode *op) {
 	if (op->operands[1].type & OT_CONSTANT) {
 		if (op->operands[0].type & OT_GPREG &&
 			op->operands[0].type & OT_WORD) {
@@ -625,7 +625,7 @@ static int opsub(RzAsm *a, ut8 *data, const Opcode *op) {
 	return process_1byte_op(a, data, op, 0x28);
 }
 
-static int opor(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opor(const RzAsm *a, ut8 *data, const Opcode *op) {
 	if (op->operands[1].type & OT_CONSTANT) {
 		if (op->operands[0].type & OT_GPREG &&
 			op->operands[0].type & OT_WORD) {
@@ -638,7 +638,7 @@ static int opor(RzAsm *a, ut8 *data, const Opcode *op) {
 	return process_1byte_op(a, data, op, 0x08);
 }
 
-static int opxadd(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opxadd(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int i = 0;
 	if (op->operands_count < 2) {
@@ -663,7 +663,7 @@ static int opxadd(RzAsm *a, ut8 *data, const Opcode *op) {
 	return i;
 }
 
-static int opxor(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opxor(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	if (op->operands_count < 2) {
 		return -1;
@@ -686,7 +686,7 @@ static int opxor(RzAsm *a, ut8 *data, const Opcode *op) {
 	return process_1byte_op(a, data, op, 0x30);
 }
 
-static int opneg(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opneg(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 
@@ -708,17 +708,17 @@ static int opneg(RzAsm *a, ut8 *data, const Opcode *op) {
 	return -1;
 }
 
-static int endbr64(RzAsm *a, ut8 *data, const Opcode *op) {
+static int endbr64(const RzAsm *a, ut8 *data, const Opcode *op) {
 	memcpy(data, "\xf3\x0f\x1e\xfa", 4);
 	return 4;
 }
 
-static int endbr32(RzAsm *a, ut8 *data, const Opcode *op) {
+static int endbr32(const RzAsm *a, ut8 *data, const Opcode *op) {
 	memcpy(data, "\xf3\x0f\x1e\xfb", 4);
 	return 4;
 }
 
-static int opnot(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opnot(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 
@@ -751,7 +751,7 @@ static int opnot(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opsbb(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opsbb(const RzAsm *a, ut8 *data, const Opcode *op) {
 	if (op->operands[1].type & OT_CONSTANT) {
 		if (op->operands[0].type & OT_GPREG &&
 			op->operands[0].type & OT_WORD) {
@@ -764,7 +764,7 @@ static int opsbb(RzAsm *a, ut8 *data, const Opcode *op) {
 	return process_1byte_op(a, data, op, 0x18);
 }
 
-static int opbs(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opbs(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	if (a->bits >= 32 && op->operands[1].type & OT_MEMORY && op->operands[1].reg_size & OT_WORD) {
 		return -1;
@@ -805,7 +805,7 @@ static int opbs(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opbswap(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opbswap(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	if (op->operands[0].type & OT_REGALL) {
 		is_valid_registers(op);
@@ -834,7 +834,7 @@ static int opbswap(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opcall(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opcall(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	int immediate = 0;
@@ -885,7 +885,7 @@ static int opcall(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opcmov(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opcmov(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	int mod_byte = 0;
@@ -1014,7 +1014,7 @@ static int opcmov(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opmovx(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opmovx(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	int word = 0;
@@ -1041,7 +1041,7 @@ static int opmovx(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opaam(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opaam(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	int immediate = op->operands[0].immediate * op->operands[0].sign;
@@ -1054,7 +1054,7 @@ static int opaam(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opaad(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opaad(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	int immediate = op->operands[0].immediate * op->operands[0].sign;
@@ -1068,7 +1068,7 @@ static int opaad(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opdec(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opdec(const RzAsm *a, ut8 *data, const Opcode *op) {
 	if (op->operands[1].type) {
 		RZ_LOG_ERROR("assembler: x86.nz: %s: invalid operands\n", op->mnemonic);
 		return -1;
@@ -1215,7 +1215,7 @@ static int opdec(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opidiv(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opidiv(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 
@@ -1244,7 +1244,7 @@ static int opidiv(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opdiv(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opdiv(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 
@@ -1273,7 +1273,7 @@ static int opdiv(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opimul(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opimul(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	int offset = 0;
@@ -1413,7 +1413,7 @@ static int opimul(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opin(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opin(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	st32 immediate = 0;
@@ -1455,7 +1455,7 @@ static int opin(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opclflush(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opclflush(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	int offset = 0;
@@ -1485,7 +1485,7 @@ static int opclflush(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opinc(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opinc(const RzAsm *a, ut8 *data, const Opcode *op) {
 	if (op->operands[1].type) {
 		RZ_LOG_ERROR("assembler: x86.nz: %s: invalid operands\n", op->mnemonic);
 		return -1;
@@ -1631,7 +1631,7 @@ static int opinc(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opint(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opint(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	if (op->operands[0].type & OT_CONSTANT) {
 		st32 immediate = op->operands[0].immediate * op->operands[0].sign;
@@ -1643,7 +1643,7 @@ static int opint(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opjc(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opjc(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	bool is_short = op->is_short;
@@ -1774,7 +1774,7 @@ static int opjc(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int oplea(RzAsm *a, ut8 *data, const Opcode *op) {
+static int oplea(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	int mod = 0;
 	st32 offset = 0;
@@ -1839,7 +1839,7 @@ static int oplea(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int oples(RzAsm *a, ut8 *data, const Opcode *op) {
+static int oples(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	int offset = 0;
 	int mod = 0;
@@ -1875,7 +1875,7 @@ static int oples(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opmov(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opmov(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	st64 offset = 0;
 	int mod = 0;
@@ -2382,7 +2382,7 @@ static int opmov(RzAsm *a, ut8 *data, const Opcode *op) {
 }
 
 // Only for MOV r64, imm64
-static int opmovabs(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opmovabs(const RzAsm *a, ut8 *data, const Opcode *op) {
 	if (!(a->bits == 64 && (op->operands[0].type & OT_GPREG) && !(op->operands[0].type & OT_MEMORY) &&
 		    (op->operands[0].type & OT_QWORD) && (op->operands[1].type & OT_CONSTANT))) {
 		return -1;
@@ -2403,7 +2403,7 @@ static int opmovabs(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opmul(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opmul(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 
@@ -2432,7 +2432,7 @@ static int opmul(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int oppop(RzAsm *a, ut8 *data, const Opcode *op) {
+static int oppop(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	int offset = 0;
@@ -2485,7 +2485,7 @@ static int oppop(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int oppush(RzAsm *a, ut8 *data, const Opcode *op) {
+static int oppush(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	int mod = 0;
@@ -2554,7 +2554,7 @@ static int oppush(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opout(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opout(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	st32 immediate = 0;
@@ -2594,7 +2594,7 @@ static int opout(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int oploop(RzAsm *a, ut8 *data, const Opcode *op) {
+static int oploop(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	data[l++] = 0xe2;
@@ -2603,7 +2603,7 @@ static int oploop(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opret(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opret(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	int immediate = 0;
 	if (a->bits == 16) {
@@ -2621,7 +2621,7 @@ static int opret(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opretf(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opretf(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	st32 immediate = 0;
 	if (op->operands[0].type & OT_CONSTANT) {
@@ -2635,7 +2635,7 @@ static int opretf(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opstos(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opstos(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	if (!strcmp(op->mnemonic, "stosw")) {
@@ -2651,7 +2651,7 @@ static int opstos(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opset(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opset(const RzAsm *a, ut8 *data, const Opcode *op) {
 	if (!(op->operands[0].type & (OT_GPREG | OT_BYTE))) {
 		return -1;
 	}
@@ -2717,7 +2717,7 @@ static int opset(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int optest(RzAsm *a, ut8 *data, const Opcode *op) {
+static int optest(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	if (!op->operands[0].type || !op->operands[1].type) {
@@ -2783,7 +2783,7 @@ static int optest(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opxchg(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opxchg(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	int mod_byte = 0;
@@ -2880,7 +2880,7 @@ static int opxchg(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opcdqe(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opcdqe(const RzAsm *a, ut8 *data, const Opcode *op) {
 	is_valid_registers(op);
 	int l = 0;
 	if (a->bits == 64) {
@@ -2890,7 +2890,7 @@ static int opcdqe(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfcmov(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfcmov(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	char *fcmov = op->mnemonic + strlen("fcmov");
 	switch (op->operands_count) {
@@ -2934,7 +2934,7 @@ static int opfcmov(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opffree(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opffree(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -2951,7 +2951,7 @@ static int opffree(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfrstor(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfrstor(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -2968,7 +2968,7 @@ static int opfrstor(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfxch(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfxch(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 0:
@@ -2989,7 +2989,7 @@ static int opfxch(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfucom(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfucom(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3010,7 +3010,7 @@ static int opfucom(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfucomp(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfucomp(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3031,7 +3031,7 @@ static int opfucomp(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfaddp(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfaddp(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 2:
@@ -3053,7 +3053,7 @@ static int opfaddp(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfiadd(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfiadd(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3077,7 +3077,7 @@ static int opfiadd(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfadd(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfadd(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3114,7 +3114,7 @@ static int opfadd(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opficom(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opficom(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3138,7 +3138,7 @@ static int opficom(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opficomp(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opficomp(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3162,7 +3162,7 @@ static int opficomp(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfild(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfild(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3189,7 +3189,7 @@ static int opfild(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfldcw(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfldcw(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3207,7 +3207,7 @@ static int opfldcw(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfldenv(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfldenv(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3224,7 +3224,7 @@ static int opfldenv(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfbld(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfbld(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3242,7 +3242,7 @@ static int opfbld(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfbstp(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfbstp(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3260,7 +3260,7 @@ static int opfbstp(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfxrstor(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfxrstor(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3278,7 +3278,7 @@ static int opfxrstor(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfxsave(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfxsave(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3296,7 +3296,7 @@ static int opfxsave(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfist(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfist(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3320,7 +3320,7 @@ static int opfist(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfistp(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfistp(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3347,7 +3347,7 @@ static int opfistp(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfisttp(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfisttp(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3374,7 +3374,7 @@ static int opfisttp(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfstenv(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfstenv(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3392,7 +3392,7 @@ static int opfstenv(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfnstenv(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfnstenv(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3409,7 +3409,7 @@ static int opfnstenv(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfdiv(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfdiv(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3446,7 +3446,7 @@ static int opfdiv(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfdivp(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfdivp(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 0:
@@ -3468,7 +3468,7 @@ static int opfdivp(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfidiv(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfidiv(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3492,7 +3492,7 @@ static int opfidiv(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfdivr(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfdivr(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3529,7 +3529,7 @@ static int opfdivr(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfdivrp(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfdivrp(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 0:
@@ -3551,7 +3551,7 @@ static int opfdivrp(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfidivr(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfidivr(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3575,7 +3575,7 @@ static int opfidivr(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfmul(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfmul(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3612,7 +3612,7 @@ static int opfmul(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfmulp(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfmulp(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 0:
@@ -3634,7 +3634,7 @@ static int opfmulp(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfimul(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfimul(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3658,7 +3658,7 @@ static int opfimul(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfsub(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfsub(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3695,7 +3695,7 @@ static int opfsub(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfsubp(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfsubp(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 0:
@@ -3717,7 +3717,7 @@ static int opfsubp(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfisub(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfisub(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3741,7 +3741,7 @@ static int opfisub(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfsubr(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfsubr(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3778,7 +3778,7 @@ static int opfsubr(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfsubrp(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfsubrp(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 0:
@@ -3800,7 +3800,7 @@ static int opfsubrp(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfisubr(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfisubr(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3824,7 +3824,7 @@ static int opfisubr(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfnstcw(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfnstcw(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3842,7 +3842,7 @@ static int opfnstcw(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfstcw(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfstcw(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3861,7 +3861,7 @@ static int opfstcw(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfnstsw(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfnstsw(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3884,7 +3884,7 @@ static int opfnstsw(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfstsw(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfstsw(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3909,7 +3909,7 @@ static int opfstsw(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfnsave(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfnsave(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3927,7 +3927,7 @@ static int opfnsave(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opfsave(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opfsave(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3946,7 +3946,7 @@ static int opfsave(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int oplldt(RzAsm *a, ut8 *data, const Opcode *op) {
+static int oplldt(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3968,7 +3968,7 @@ static int oplldt(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int oplmsw(RzAsm *a, ut8 *data, const Opcode *op) {
+static int oplmsw(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -3990,7 +3990,7 @@ static int oplmsw(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int oplgdt(RzAsm *a, ut8 *data, const Opcode *op) {
+static int oplgdt(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -4008,7 +4008,7 @@ static int oplgdt(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int oplidt(RzAsm *a, ut8 *data, const Opcode *op) {
+static int oplidt(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -4026,7 +4026,7 @@ static int oplidt(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opsgdt(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opsgdt(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -4044,7 +4044,7 @@ static int opsgdt(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opstmxcsr(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opstmxcsr(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -4063,7 +4063,7 @@ static int opstmxcsr(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opstr(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opstr(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -4087,7 +4087,7 @@ static int opstr(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opsidt(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opsidt(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -4105,7 +4105,7 @@ static int opsidt(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opsldt(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opsldt(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -4126,7 +4126,7 @@ static int opsldt(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opsmsw(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opsmsw(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -4147,7 +4147,7 @@ static int opsmsw(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opverr(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opverr(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -4169,7 +4169,7 @@ static int opverr(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opverw(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opverw(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -4191,7 +4191,7 @@ static int opverw(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opvmclear(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opvmclear(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -4211,7 +4211,7 @@ static int opvmclear(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opvmon(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opvmon(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -4231,7 +4231,7 @@ static int opvmon(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opvmptrld(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opvmptrld(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -4250,7 +4250,7 @@ static int opvmptrld(RzAsm *a, ut8 *data, const Opcode *op) {
 	return l;
 }
 
-static int opvmptrst(RzAsm *a, ut8 *data, const Opcode *op) {
+static int opvmptrst(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	switch (op->operands_count) {
 	case 1:
@@ -4272,7 +4272,7 @@ static int opvmptrst(RzAsm *a, ut8 *data, const Opcode *op) {
 typedef struct lookup_t {
 	char mnemonic[12];
 	int only_x32;
-	int (*opdo)(RzAsm *, ut8 *, const Opcode *);
+	int (*opdo)(const RzAsm *, ut8 *, const Opcode *);
 	ut64 opcode;
 	int size;
 } LookupTable;
@@ -4720,7 +4720,7 @@ static bool is_st_register(const char *token) {
 /**
  * Get the register at position pos in str. Increase pos afterwards.
  */
-static Register parseReg(RzAsm *a, const char *str, size_t *pos, ut32 *type) {
+static Register parseReg(const RzAsm *a, const char *str, size_t *pos, ut32 *type) {
 	int i;
 	// Must be the same order as in enum register_t
 	const char *regs[] = { "eax", "ecx", "edx", "ebx", "esp", "ebp", "esi", "edi", "eip", NULL };
@@ -4799,23 +4799,18 @@ static Register parseReg(RzAsm *a, const char *str, size_t *pos, ut32 *type) {
 		for (i = 0; regs64[i]; i++) {
 			if (!rz_str_ncasecmp(regs64[i], token, length)) {
 				*type = (OT_GPREG & OT_REG(i)) | OT_QWORD;
-				a->bits = 64;
 				return i;
 			}
 		}
 		for (i = 0; regs64ext[i]; i++) {
 			if (!rz_str_ncasecmp(regs64ext[i], token, length)) {
 				*type = (OT_GPREG & OT_REG(i)) | OT_QWORD;
-				a->bits = 64;
 				return i + 9;
 			}
 		}
 		for (i = 0; regsext[i]; i++) {
 			if (!rz_str_ncasecmp(regsext[i], token, length)) {
 				*type = (OT_GPREG & OT_REG(i)) | OT_DWORD;
-				if (a->bits < 32) {
-					a->bits = 32;
-				}
 				return i + 9;
 			}
 		}
@@ -4864,7 +4859,7 @@ static Register parseReg(RzAsm *a, const char *str, size_t *pos, ut32 *type) {
 	return X86R_UNDEFINED;
 }
 
-static void parse_segment_offset(RzAsm *a, const char *str, size_t *pos,
+static void parse_segment_offset(const RzAsm *a, const char *str, size_t *pos,
 	Operand *op, int reg_index) {
 	int nextpos = *pos;
 	char *c = strchr(str + nextpos, ':');
@@ -4889,7 +4884,7 @@ static void parse_segment_offset(RzAsm *a, const char *str, size_t *pos,
 	}
 }
 // Parse operand
-static int parseOperand(RzAsm *a, const char *str, Operand *op, bool isrepop) {
+static int parseOperand(const RzAsm *a, const char *str, Operand *op, bool isrepop) {
 	size_t pos, nextpos = 0;
 	x86newTokenType last_type;
 	int size_token = 1;
@@ -5093,7 +5088,7 @@ static int parseOperand(RzAsm *a, const char *str, Operand *op, bool isrepop) {
 	return nextpos;
 }
 
-static int parseOpcode(RzAsm *a, const char *op, Opcode *out) {
+static int parseOpcode(const RzAsm *a, const char *op, Opcode *out) {
 	out->has_bnd = false;
 	bool isrepop = false;
 	if (!strncmp(op, "bnd ", 4)) {
@@ -5137,7 +5132,7 @@ static int parseOpcode(RzAsm *a, const char *op, Opcode *out) {
 	return 0;
 }
 
-static ut64 getnum(RzAsm *a, const char *s) {
+static ut64 getnum(const RzAsm *a, const char *s) {
 	if (!s) {
 		return 0;
 	}
@@ -5147,7 +5142,7 @@ static ut64 getnum(RzAsm *a, const char *s) {
 	return rz_num_math(NULL, s);
 }
 
-static int oprep(RzAsm *a, ut8 *data, const Opcode *op) {
+static int oprep(const RzAsm *a, ut8 *data, const Opcode *op) {
 	int l = 0;
 	LookupTable *lt_ptr;
 	int retval;
@@ -5201,7 +5196,7 @@ static int oprep(RzAsm *a, ut8 *data, const Opcode *op) {
 	return -1;
 }
 
-static int assemble(RzAsm *a, RzAsmOp *ao, const char *str) {
+static int assemble(const RzAsm *a, RzAsmOp *ao, const char *str) {
 	ut8 __data[32] = { 0 };
 	ut8 *data = __data;
 	char op[128];

--- a/librz/arch/p/asm/asm_x86_vm.c
+++ b/librz/arch/p/asm/asm_x86_vm.c
@@ -28,7 +28,7 @@
 
 #define VPCEXT2(y, x) ((y)[2] == (x))
 
-static inline void decompile_vm(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static inline void decompile_vm(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	if (len > 3 && buf[0] == 0x0F && buf[1] == 0x3F && (VPCEXT2(buf, 0x01) || VPCEXT2(buf, 0x05) || VPCEXT2(buf, 0x07) || VPCEXT2(buf, 0x0D) || VPCEXT2(buf, 0x10))) {
 		if (a->syntax == RZ_ASM_SYNTAX_ATT) {
 			rz_asm_op_setf_asm(op, "vpcext $0x%x, $0x%x", buf[3], buf[2]);

--- a/librz/arch/p/asm/asm_x86_zydis.c
+++ b/librz/arch/p/asm/asm_x86_zydis.c
@@ -40,7 +40,7 @@ static bool x86_zydis_asm_fini(void *p) {
 	return true;
 }
 
-static char *x86_zydis_asm_mnemonics(RzAsm *a, int id, bool json) {
+static char *x86_zydis_asm_mnemonics(const RzAsm *a, int id, bool json) {
 	rz_return_val_if_fail(a && a->cur, NULL);
 	if (!a->plugin_data) {
 		return NULL;
@@ -79,7 +79,7 @@ static char *x86_zydis_asm_mnemonics(RzAsm *a, int id, bool json) {
 	return rz_strbuf_drain(buf);
 }
 
-static int x86_zydis_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int x86_zydis_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	rz_return_val_if_fail(a, 0);
 	ZydisContext *zydx = (ZydisContext *)a->plugin_data;
 	ut64 off = a->pc;
@@ -142,7 +142,7 @@ static int x86_zydis_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len)
 	return op->size;
 }
 
-static bool x86_sw_breakpoint(RzAsm *a, RzAsmOp *op) {
+static bool x86_sw_breakpoint(const RzAsm *a, RzAsmOp *op) {
 	// { 0, 1, 0, "\xcc" }, // valid for 16, 32, 64
 	// { 0, 2, 0, "\xcd\x03" },
 	rz_asm_op_set_buf(op, (const ut8 *)"\xcc", 1);

--- a/librz/arch/p/asm/asm_x86_zydis.c
+++ b/librz/arch/p/asm/asm_x86_zydis.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 
 #if USE_SYS_ZYDIS

--- a/librz/arch/p/asm/asm_xap.c
+++ b/librz/arch/p/asm/asm_xap.c
@@ -19,7 +19,7 @@ static int arch_xap_disasm(RzStrBuf *asm_buf, const unsigned char *buf, ut64 add
 
 	return 0;
 }
-static int disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	arch_xap_disasm(&op->buf_asm, buf, a->pc);
 	return (op->size = 2);
 }

--- a/librz/arch/p/asm/asm_xap.c
+++ b/librz/arch/p/asm/asm_xap.c
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2009-2014 nibble <nibble.ds@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#include <stdio.h>
 #include <rz_types.h>
 #include <rz_lib.h>
 #include <rz_util.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 
 static int arch_xap_disasm(RzStrBuf *asm_buf, const unsigned char *buf, ut64 addr) {
 	xap_state_t s = { 0 };

--- a/librz/arch/p/asm/asm_xcore_cs.c
+++ b/librz/arch/p/asm/asm_xcore_cs.c
@@ -9,7 +9,7 @@
 
 CAPSTONE_DEFINE_PLUGIN_FUNCTIONS(xcore_asm);
 
-static int xcore_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int xcore_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	CapstoneContext *ctx = (CapstoneContext *)a->plugin_data;
 	cs_insn *insn;
 	int n, ret = -1;

--- a/librz/arch/p/asm/asm_xcore_cs.c
+++ b/librz/arch/p/asm/asm_xcore_cs.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <rz_lib.h>
 
 #include "cs_helper.h"

--- a/librz/arch/p/asm/asm_xtensa_cs.c
+++ b/librz/arch/p/asm/asm_xtensa_cs.c
@@ -6,7 +6,7 @@
 #include "asm_private.h"
 #include <xtensa/xtensa.h>
 
-static int asm_xtensa_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int asm_xtensa_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	XtensaContext *ctx = a->plugin_data;
 	if (!xtensa_open(ctx, a->cpu, a->big_endian)) {
 		goto beach;

--- a/librz/arch/p/asm/asm_xtensa_cs.c
+++ b/librz/arch/p/asm/asm_xtensa_cs.c
@@ -3,6 +3,7 @@
 
 #include <rz_types.h>
 #include <rz_asm.h>
+#include "asm_private.h"
 #include <xtensa/xtensa.h>
 
 static int asm_xtensa_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {

--- a/librz/arch/p/asm/cs_helper.h
+++ b/librz/arch/p/asm/cs_helper.h
@@ -48,7 +48,7 @@ typedef struct {
 	}
 
 #define CAPSTONE_PLUGIN_MNEMONICS(name) \
-	static char *name##_mnemonics(RzAsm *a, int id, bool json) { \
+	static char *name##_mnemonics(const RzAsm *a, int id, bool json) { \
 		if (!a->plugin_data) { \
 			return NULL; \
 		} \

--- a/librz/arch/p_gnu/asm/asm_arc_gnu.c
+++ b/librz/arch/p_gnu/asm/asm_arc_gnu.c
@@ -66,7 +66,7 @@ static int generic_fprintf_func(void *stream, void *data, const char *format, ..
 	return ret;
 }
 
-static int arc_gnu_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int arc_gnu_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	ArcContext *ctx = (ArcContext *)a->plugin_data;
 	if (len < 2) {
 		return -1;

--- a/librz/arch/p_gnu/asm/asm_cris_gnu.c
+++ b/librz/arch/p_gnu/asm/asm_cris_gnu.c
@@ -71,7 +71,7 @@ int print_insn_cris_without_register_prefix(bfd_vma vma, disassemble_info *info,
 int print_insn_crisv32_with_register_prefix(bfd_vma vma, disassemble_info *info, void *data);
 int print_insn_crisv32_without_register_prefix(bfd_vma vma, disassemble_info *info, void *data);
 
-static int cris_gnu_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int cris_gnu_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	CrisContext *ctx = (CrisContext *)a->plugin_data;
 	struct disassemble_info disasm_obj;
 	int mode = 2;

--- a/librz/arch/p_gnu/asm/asm_lanai_gnu.c
+++ b/librz/arch/p_gnu/asm/asm_lanai_gnu.c
@@ -58,7 +58,7 @@ static int generic_fprintf_func(void *stream, void *data, const char *format, ..
 	return ret;
 }
 
-static int lanai_gnu_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int lanai_gnu_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	LanaiContext *ctx = (LanaiContext *)a->plugin_data;
 	struct disassemble_info disasm_obj;
 	if (len < 4) {

--- a/librz/arch/p_gnu/asm/asm_vax_gnu.c
+++ b/librz/arch/p_gnu/asm/asm_vax_gnu.c
@@ -64,7 +64,7 @@ static int generic_fprintf_func(void *stream, void *data, const char *format, ..
 	return ret;
 }
 
-static int vax_gnu_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int vax_gnu_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	VaxContext *ctx = (VaxContext *)a->plugin_data;
 	struct disassemble_info disasm_obj;
 	if (len < 4) {

--- a/librz/arch/p_gnu/asm/asm_z80_gnu.c
+++ b/librz/arch/p_gnu/asm/asm_z80_gnu.c
@@ -6,11 +6,11 @@
 #include <rz_lib.h>
 #include <rz_asm.h>
 
-static int z80_gnu_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
+static int z80_gnu_disassemble(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len) {
 	return op->size = z80Disass(op, buf, len);
 }
 
-static int z80_gnu_assemble(RzAsm *a, RzAsmOp *op, const char *buf) {
+static int z80_gnu_assemble(const RzAsm *a, RzAsmOp *op, const char *buf) {
 	return op->size = z80asm((ut8 *)rz_strbuf_get(&op->buf), buf);
 }
 

--- a/librz/core/analysis_objc.c
+++ b/librz/core/analysis_objc.c
@@ -175,7 +175,7 @@ static RzCoreObjc *core_objc_new(RzCore *core) {
 	}
 	RzCoreObjc *o = RZ_NEW0(RzCoreObjc);
 	o->core = core;
-	o->word_size = (core->rasm->bits == 64) ? 8 : 4;
+	o->word_size = rz_asm_is_bits(core->rasm, 64) ? 8 : 4;
 	if (o->word_size != 8) {
 		RZ_LOG_WARN("aao is experimental on 32bit binaries\n");
 	}

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -3987,7 +3987,8 @@ RZ_API bool rz_core_analysis_everything(RzCore *core, bool experimental, char *d
 		return false;
 	}
 
-	if (!rz_str_startswith(rz_config_get(core->config, "asm.arch"), "x86")) {
+	if (!rz_asm_is_arch(core->rasm, "x86") &&
+		!rz_asm_is_arch(core->rasm, "hexagon")) {
 		rz_core_analysis_value_pointers(core, RZ_OUTPUT_MODE_STANDARD);
 		rz_core_task_yield(&core->tasks);
 		bool pcache = rz_config_get_b(core->config, "io.pcache");

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -1775,11 +1775,9 @@ RZ_API int rz_core_analysis_search(RzCore *core, ut64 from, ut64 to, ut64 ref, i
 	RzAnalysisOp op = { 0 };
 	ut64 at;
 	int arch = -1;
-	if (core->rasm->bits == 64) {
+	if (rz_asm_is_arch(core->rasm, "arm") && rz_asm_is_bits(core->rasm, 64)) {
 		// speedup search
-		if (!strncmp(core->rasm->cur->name, "arm", 3)) {
-			arch = RZ_ARCH_ARM64;
-		}
+		arch = RZ_ARCH_ARM64;
 	}
 	if (core->file) {
 		rz_io_use_fd(core->io, core->file->fd);
@@ -2241,11 +2239,11 @@ static bool isSkippable(RzBinSymbol *s) {
 }
 
 static bool arch_is(RzCore *core, const char *x) {
-	RzAsm *as = core ? core->rasm : NULL;
-	if (as && as->cur && as->bits <= 32 && as->cur->name) {
-		return strstr(as->cur->name, x);
+	if (!core || !core->rasm || rz_asm_get_bits(core->rasm) > 32) {
+		return false;
 	}
-	return false;
+
+	return rz_asm_is_arch(core->rasm, x);
 }
 
 static bool archIsThumbable(RzCore *core) {
@@ -2367,7 +2365,8 @@ RZ_API void rz_core_analysis_data(RZ_NONNULL RzCore *core, ut64 addr, ut32 count
 	ut32 old_len = core->blocksize;
 	ut64 old_offset = core->offset;
 	rz_core_seek_arch_bits(core, addr);
-	int word = wordsize ? wordsize : core->rasm->bits / 8;
+	int bits = rz_asm_get_bits(core->rasm);
+	int word = wordsize ? wordsize : bits / 8;
 	char *str = NULL;
 	RzConsPrintablePalette *pal = rz_config_get_i(core->config, "scr.color") ? &rz_cons_singleton()->context->pal : NULL;
 
@@ -3600,8 +3599,7 @@ RZ_API void rz_core_analysis_propagate_noreturn_relocs(RzCore *core, ut64 addr) 
 	// Processing every reference calls rz_analysis_op() which sometimes changes the
 	// state of `asm.bits` variable, thus we save it to restore after the processing
 	// is finished.
-	int bits1 = core->analysis->bits;
-	int bits2 = core->rasm->bits;
+	int bits = rz_asm_get_bits(core->rasm);
 	// find known noreturn functions to propagate
 	RzList *noretl = rz_analysis_noreturn_functions(core->analysis);
 	// List of the potentially noreturn functions
@@ -3609,8 +3607,8 @@ RZ_API void rz_core_analysis_propagate_noreturn_relocs(RzCore *core, ut64 addr) 
 	struct core_noretl u = { core, noretl, todo };
 	ht_up_foreach(core->analysis->ht_xrefs_to, process_refs_cb, &u);
 	rz_list_free(noretl);
-	core->analysis->bits = bits1;
-	core->rasm->bits = bits2;
+	rz_asm_set_bits(core->rasm, bits);
+	core->analysis->bits = bits;
 	// For every function in todo list analyze if it's potentially become noreturn
 	ht_up_foreach(todo, reanalyze_fcns_cb, core);
 	rz_set_u_free(todo);
@@ -4684,7 +4682,8 @@ RZ_IPI void rz_core_analysis_value_pointers(RzCore *core, RzOutputMode mode) {
 	}
 
 	int vsize = 4; // 32bit dword
-	if (core->rasm->bits == 64) {
+	int bits = rz_asm_get_bits(core->rasm);
+	if (bits == 64) {
 		vsize = 8;
 	}
 
@@ -4787,7 +4786,7 @@ RZ_API int rz_core_get_stacksz(RzCore *core, ut64 from, ut64 to) {
 
 RZ_API void rz_core_analysis_type_init(RzCore *core) {
 	rz_return_if_fail(core && core->analysis);
-	int bits = core->rasm->bits;
+	int bits = rz_asm_get_bits(core->rasm);
 	const char *analysis_arch = rz_config_get(core->config, "analysis.arch");
 	const char *os = rz_config_get(core->config, "asm.os");
 	char *types_dir = rz_path_system(core->sys_path, RZ_SDB_TYPES);
@@ -5666,6 +5665,7 @@ static void _analysis_calls(RzCore *core, ut64 addr, ut64 addr_end, bool imports
 	int depth = rz_config_get_i(core->config, "analysis.depth");
 	const int bsz = 4096;
 	int bufi = 0;
+	int archbits = rz_asm_get_bits(core->rasm);
 	int bufi_max = bsz - 16;
 	if (addr_end - addr > UT32_MAX) {
 		return;
@@ -5705,7 +5705,7 @@ static void _analysis_calls(RzCore *core, ut64 addr, ut64 addr_end, bool imports
 			setBits = hint->bits;
 		}
 		rz_analysis_hint_free(hint);
-		if (setBits != core->rasm->bits) {
+		if (setBits != archbits) {
 			rz_config_set_i(core->config, "asm.bits", setBits);
 		}
 		rz_analysis_op_init(&op);

--- a/librz/core/carch.c
+++ b/librz/core/carch.c
@@ -23,36 +23,30 @@
 
 RZ_DEPRECATE RZ_IPI const char *rz_core_get_arch(RzCore *core) {
 	rz_return_val_if_fail(core && core->rasm, CORE_DEFAULT_ARCH);
-
-	if (core->rasm->cur && RZ_STR_ISNOTEMPTY(core->rasm->cur->name)) {
-		return core->rasm->cur->name;
-	}
-	return CORE_DEFAULT_ARCH;
+	return rz_asm_get_arch(core->rasm);
 }
 
 RZ_DEPRECATE RZ_IPI ut32 rz_core_get_bits(RzCore *core) {
 	rz_return_val_if_fail(core && core->rasm, CORE_DEFAULT_BITS);
 
-	if (core->rasm->bits > 0) {
-		return core->rasm->bits;
+	ut32 bits = rz_asm_get_bits(core->rasm);
+	if (bits > 0) {
+		return bits;
 	}
 	return CORE_DEFAULT_BITS;
 }
 
 RZ_DEPRECATE RZ_IPI ut32 rz_core_get_pc_align(RzCore *core) {
 	rz_return_val_if_fail(core && core->rasm, 1);
-
-	if (core->rasm->pcalign > 0) {
-		return core->rasm->pcalign;
-	}
-	return 1;
+	return rz_asm_get_pc_align(core->rasm);
 }
 
 RZ_DEPRECATE RZ_IPI const char *rz_core_get_cpu(RzCore *core) {
 	rz_return_val_if_fail(core && core->rasm, CORE_DEFAULT_ARCH);
 
-	if (RZ_STR_ISNOTEMPTY(core->rasm->cpu)) {
-		return core->rasm->cpu;
+	const char *cpu = rz_asm_get_cpu(core->rasm);
+	if (RZ_STR_ISNOTEMPTY(cpu)) {
+		return cpu;
 	}
 	return rz_core_get_arch(core);
 }
@@ -60,19 +54,13 @@ RZ_DEPRECATE RZ_IPI const char *rz_core_get_cpu(RzCore *core) {
 RZ_DEPRECATE RZ_IPI const char *rz_core_get_platform(RzCore *core) {
 	rz_return_val_if_fail(core && core->rasm, CORE_DEFAULT_PLATFORM);
 
-	if (RZ_STR_ISNOTEMPTY(core->rasm->platforms)) {
-		return core->rasm->platforms;
-	}
-	return CORE_DEFAULT_PLATFORM;
+	return rz_asm_get_platforms(core->rasm);
 }
 
 RZ_DEPRECATE RZ_IPI const char *rz_core_get_features(RzCore *core) {
 	rz_return_val_if_fail(core && core->rasm, CORE_DEFAULT_FEATURES);
 
-	if (RZ_STR_ISNOTEMPTY(core->rasm->features)) {
-		return core->rasm->features;
-	}
-	return CORE_DEFAULT_FEATURES;
+	return rz_asm_get_features(core->rasm);
 }
 
 RZ_DEPRECATE RZ_IPI const char *rz_core_get_os(RzCore *core) {
@@ -98,16 +86,15 @@ RZ_DEPRECATE static void core_update_config_bits_options(RzCore *core, const cha
 	RzConfigNode *node = rz_config_node_get(core->config, name);
 	if (!node) {
 		return;
-	} else if (!core->rasm->cur) {
-		node->options->free = free;
-		rz_list_purge(node->options);
-		return;
 	}
 
 	node->options->free = free;
 	rz_list_purge(node->options);
+	if (!core->rasm) {
+		return;
+	}
 
-	ut32 bits = core->rasm->cur->bits;
+	ut32 bits = rz_asm_get_plugin_bits(core->rasm);
 	for (ut32 i = 1; i <= bits; i <<= 1) {
 		if (i & bits) {
 			rz_list_append(node->options, rz_str_newf("%u", i));
@@ -116,26 +103,14 @@ RZ_DEPRECATE static void core_update_config_bits_options(RzCore *core, const cha
 }
 
 RZ_DEPRECATE static void core_update_config_options(RzConfigNode *node, const char *list_comma_sep) {
-	node->options->free = free;
-	rz_list_purge(node->options);
-
 	if (RZ_STR_ISEMPTY(list_comma_sep)) {
+		node->options->free = free;
+		rz_list_purge(node->options);
 		return;
 	}
 
-	char *c = rz_str_dup(list_comma_sep);
-	if (!c) {
-		return;
-	}
-
-	size_t n = rz_str_split(c, ',');
-	for (size_t i = 0; i < n; i++) {
-		const char *word = rz_str_word_get0(c, i);
-		if (RZ_STR_ISNOTEMPTY(word)) {
-			rz_list_append(node->options, rz_str_dup(word));
-		}
-	}
-	free(c);
+	rz_list_free(node->options);
+	node->options = rz_str_split_duplist(list_comma_sep, ",", true);
 }
 
 // copied from cconfig.c & cleaned
@@ -143,13 +118,14 @@ RZ_DEPRECATE static void core_update_config_cpu_options(RzCore *core, const char
 	RzConfigNode *node = rz_config_node_get(core->config, name);
 	if (!node) {
 		return;
-	} else if (!core->rasm->cur) {
+	} else if (!core->rasm) {
 		node->options->free = free;
 		rz_list_purge(node->options);
 		return;
 	}
 
-	core_update_config_options(node, core->rasm->cur->cpus);
+	const char *list = rz_asm_get_plugin_cpus(core->rasm);
+	core_update_config_options(node, list);
 }
 
 // copied from cconfig.c & cleaned
@@ -157,13 +133,14 @@ static void core_update_config_platform_options(RzCore *core, const char *name) 
 	RzConfigNode *node = rz_config_node_get(core->config, name);
 	if (!node) {
 		return;
-	} else if (!core->rasm->cur) {
+	} else if (!core->rasm) {
 		node->options->free = free;
 		rz_list_purge(node->options);
 		return;
 	}
 
-	core_update_config_options(node, core->rasm->cur->platforms);
+	const char *list = rz_asm_get_plugin_platforms(core->rasm);
+	core_update_config_options(node, list);
 }
 
 // copied from cconfig.c & cleaned
@@ -171,13 +148,14 @@ static void core_update_config_features_options(RzCore *core, const char *name) 
 	RzConfigNode *node = rz_config_node_get(core->config, name);
 	if (!node) {
 		return;
-	} else if (!core->rasm->cur) {
+	} else if (!core->rasm) {
 		node->options->free = free;
 		rz_list_purge(node->options);
 		return;
 	}
 
-	core_update_config_options(node, core->rasm->cur->features);
+	const char *list = rz_asm_get_plugin_features(core->rasm);
+	core_update_config_options(node, list);
 }
 
 RZ_DEPRECATE static const RzBinInfo *core_arch_find_bin_info(RzCore *core, const char *arch) {
@@ -202,7 +180,7 @@ RZ_DEPRECATE static const RzBinInfo *core_arch_find_bin_info(RzCore *core, const
 }
 
 static bool core_arch_default_is_big_endian(RzCore *core) {
-	bool big_endian = core->rasm->big_endian;
+	bool big_endian = rz_asm_is_big_endian_set(core->rasm);
 	const char *arch = rz_core_get_arch(core);
 
 	const RzBinInfo *info = core_arch_find_bin_info(core, arch);
@@ -280,12 +258,12 @@ RZ_DEPRECATE static bool core_arch_set_os(RzCore *core, const char *arch, ut32 b
 }
 
 RZ_DEPRECATE static void core_update_text_align(RzCore *core) {
-	int align = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN);
+	ut32 align = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_TEXT_ALIGN);
 	if (align < 1) {
 		align = 1;
 	}
 
-	core->rasm->pcalign = align;
+	rz_asm_set_pc_align(core->rasm, align);
 	core->analysis->pcalign = align;
 }
 
@@ -308,8 +286,7 @@ RZ_DEPRECATE static bool core_arch_set_cpu(RzCore *core, const char *arch, const
 	free(cpus_dir);
 
 	if (RZ_STR_ISNOTEMPTY(platform)) {
-		free(core->rasm->platforms);
-		core->rasm->platforms = rz_str_dup(platform);
+		rz_asm_set_platforms(core->rasm, platform);
 	} else {
 		platform = rz_core_get_platform(core);
 	}
@@ -328,23 +305,47 @@ RZ_DEPRECATE static bool core_arch_set_cpu(RzCore *core, const char *arch, const
 static ut32 core_arch_get_default_bits(RzCore *core, const char *arch) {
 	const RzBinInfo *info = core_arch_find_bin_info(core, arch);
 	if (!info || info->bits < 1) {
-		return core->rasm->bits;
+		return rz_asm_get_bits(core->rasm);
 	}
 	return info->bits;
+}
+
+static void core_set_asm_plugin_configs(RZ_BORROW RzCore *core) {
+	rz_return_if_fail(core && core->rasm);
+
+	const char *arch = rz_core_get_arch(core);
+	RzConfig *pcfg = rz_asm_get_new_config(core->rasm);
+	if (!pcfg) {
+		return;
+	}
+
+	rz_config_lock(pcfg, 1);
+	if (!ht_sp_insert(core->plugin_configs, arch, pcfg)) {
+		RZ_LOG_WARN("core: plugin '%s' was already added.\n", arch);
+	}
+}
+
+static void core_remove_asm_plugin_config(RZ_BORROW RzCore *core) {
+	const char *plugin_name = rz_core_get_arch(core);
+	ht_sp_delete(core->plugin_configs, plugin_name);
 }
 
 RZ_DEPRECATE static bool core_update_arch(RzCore *core, const char *arch, ut32 bits, const char *cpu, const char *os, const char *platform) {
 	char asmparser[32] = { 0 };
 
 	if (RZ_STR_ISNOTEMPTY(arch)) {
+		core_remove_asm_plugin_config(core);
 		rz_strf(asmparser, "%s.pseudo", arch);
 		if (!rz_asm_use(core->rasm, arch)) {
+			core_set_asm_plugin_configs(core);
 			RZ_LOG_ERROR("core: asm.arch: cannot set '%s'\n", arch);
 			return false;
 		} else if (!rz_analysis_use(core->analysis, arch)) {
 			RZ_LOG_INFO("core: analysis.arch: cannot set '%s'\n", arch);
 			// there are some plugins like the m68k which do not have a valid analysis plugin.
 		}
+
+		core_set_asm_plugin_configs(core);
 
 		if (!bits) {
 			bits = core_arch_get_default_bits(core, arch);
@@ -479,7 +480,7 @@ RZ_DEPRECATE static void core_update_config_from_arch(RzCore *core, bool new_arc
 	core_update_config_s(core, "analysis.arch", arch);
 	core_update_config_s(core, "analysis.cpu", cpu);
 	core_update_config_i(core, "analysis.bits", bits);
-	core_update_config_b(core, "cfg.bigendian", core->rasm->big_endian);
+	core_update_config_b(core, "cfg.bigendian", rz_asm_is_big_endian_set(core->rasm));
 
 	if (new_arch) {
 		core_update_config_bits_options(core, "asm.bits");
@@ -582,6 +583,6 @@ RZ_DEPRECATE RZ_API bool rz_core_set_endianness(RZ_NONNULL RzCore *core, bool bi
 	}
 
 	core_set_endianness(core, big_endian);
-	core_update_config_b(core, "cfg.bigendian", core->rasm->big_endian);
+	core_update_config_b(core, "cfg.bigendian", rz_asm_is_big_endian_set(core->rasm));
 	return true;
 }

--- a/librz/core/casm.c
+++ b/librz/core/casm.c
@@ -201,9 +201,8 @@ RZ_API RzCmdStatus rz_core_asm_cpu_plugin_print(RZ_NONNULL RZ_BORROW RzCore *cor
 		return RZ_CMD_STATUS_WRONG_ARGS;
 	}
 
-	bool found = false;
-	RzAsmPlugin *plugin = ht_sp_find(a->plugins, arch_name, &found);
-	if (!found || !plugin) {
+	const RzAsmPlugin *plugin = rz_asm_plugin_find(a, arch_name);
+	if (!plugin) {
 		return RZ_CMD_STATUS_WRONG_ARGS;
 	}
 
@@ -216,7 +215,7 @@ RZ_API RzCmdStatus rz_core_asm_cpu_plugin_print(RZ_NONNULL RZ_BORROW RzCore *cor
 
 	const char *name;
 	RzListIter *it;
-	RzList *list = rz_str_split_duplist_n(plugin->cpus, ",", 0, true);
+	RzList *list = rz_str_split_duplist(plugin->cpus, ",", true);
 	if (!list) {
 		return RZ_CMD_STATUS_ERROR;
 	}
@@ -245,7 +244,7 @@ RZ_API RzCmdStatus rz_core_asm_plugins_print(RZ_NONNULL RZ_BORROW RzCore *core, 
 	rz_return_val_if_fail(core && state, RZ_CMD_STATUS_ERROR);
 	RzAsm *a = core->rasm;
 
-	RzIterator *iter = ht_sp_as_iter(a->plugins);
+	RzIterator *iter = rz_asm_plugin_iterator(a);
 	RzList *plugin_list = rz_list_new_from_iterator(iter);
 	if (!plugin_list) {
 		rz_iterator_free(iter);
@@ -276,7 +275,7 @@ RZ_API RzCmdStatus rz_core_asm_plugins_print(RZ_NONNULL RZ_BORROW RzCore *core, 
 RZ_API RzCmdStatus rz_core_cpu_descs_print(RZ_NONNULL RzCore *core, RZ_NONNULL const char *plugin) {
 	rz_return_val_if_fail(core && plugin && core->rasm, RZ_CMD_STATUS_ERROR);
 	RzAsm *a = core->rasm;
-	RzIterator *iter = ht_sp_as_iter(a->plugins);
+	RzIterator *iter = rz_asm_plugin_iterator(a);
 	RzList *plugin_list = rz_list_new_from_iterator(iter);
 	if (!plugin_list) {
 		rz_iterator_free(iter);

--- a/librz/core/cautocmpl.c
+++ b/librz/core/cautocmpl.c
@@ -177,12 +177,12 @@ static void autocmplt_at_op(RzCore *core, RzLineNSCompletionResult *res, const c
 	res->end_string = "";
 }
 
-static void autocmplt_bits_plugin(RzAsmPlugin *plugin, RzLineNSCompletionResult *res, const char *s, size_t len) {
-	int bits = plugin->bits;
-	int i;
-	char sbits[5];
-	for (i = 1; i <= bits; i <<= 1) {
-		if (i & bits && !strncmp(rz_strf(sbits, "%d", i), s, len)) {
+static void autocmplt_bits_plugin(const RzAsmPlugin *plugin, RzLineNSCompletionResult *res, const char *s, size_t len) {
+	char sbits[16];
+	ut32 bits = plugin->bits;
+	for (ut32 i = 1; i <= bits; i <<= 1) {
+		rz_strf(sbits, "%u", i);
+		if (i & bits && !strncmp(sbits, s, len)) {
 			rz_line_ns_completion_result_add(res, sbits);
 		}
 	}
@@ -191,8 +191,7 @@ static void autocmplt_bits_plugin(RzAsmPlugin *plugin, RzLineNSCompletionResult 
 static void autocmplt_arch(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
 	rz_return_if_fail(core->rasm);
 
-	HtSP *asm_plugins = rz_asm_get_plugins(core->rasm);
-	RzIterator *it = ht_sp_as_iter(asm_plugins);
+	RzIterator *it = rz_asm_plugin_iterator(core->rasm);
 	RzAsmPlugin **val;
 
 	// @a: can either be used with @a:arch or @a:arch:bits
@@ -222,9 +221,9 @@ static void autocmplt_arch(RzCore *core, RzLineNSCompletionResult *res, const ch
 }
 
 static void autocmplt_bits(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
-	rz_return_if_fail(core->rasm && core->rasm->cur);
-
-	autocmplt_bits_plugin(core->rasm->cur, res, s, len);
+	rz_return_if_fail(core->rasm);
+	const RzAsmPlugin *plugin = rz_asm_plugin_current(core->rasm);
+	autocmplt_bits_plugin(plugin, res, s, len);
 }
 
 static void autocmplt_flag_space(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -4740,10 +4740,8 @@ RZ_API int rz_core_bin_update_arch_bits(RzCore *r) {
 		return 0;
 	}
 	if (r->rasm) {
-		bits = r->rasm->bits;
-		if (r->rasm->cur) {
-			arch = r->rasm->cur->arch;
-		}
+		bits = rz_asm_get_bits(r->rasm);
+		arch = rz_asm_get_arch(r->rasm);
 	}
 	binfile = rz_bin_cur(r->bin);
 	name = binfile ? binfile->file : NULL;

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -92,70 +92,63 @@ static int compareSize(const RzAnalysisFunction *a, const RzAnalysisFunction *b,
 }
 
 static void update_asmarch_options(RzCore *core, RzConfigNode *node) {
-	RzIterator *it = ht_sp_as_iter(core->rasm->plugins);
+	if (!core || !node) {
+		return;
+	}
+
 	RzAsmPlugin **val;
-	if (core && node && core->rasm) {
-		rz_list_purge(node->options);
-		rz_iterator_foreach(it, val) {
-			RzAsmPlugin *h = *val;
-			SETOPTIONS(node, h->name, NULL);
-		}
+	RzIterator *it = rz_asm_plugin_iterator(core->rasm);
+	rz_list_purge(node->options);
+	rz_iterator_foreach(it, val) {
+		RzAsmPlugin *h = *val;
+		SETOPTIONS(node, h->name, NULL);
 	}
 	rz_iterator_free(it);
 }
 
 static void update_asmbits_options(RzCore *core, RzConfigNode *node) {
-	if (core && core->rasm && core->rasm->cur && node) {
-		int bits = core->rasm->cur->bits;
-		int i;
-		node->options->free = free;
-		rz_list_purge(node->options);
-		for (i = 1; i <= bits; i <<= 1) {
-			if (i & bits) {
-				SETOPTIONS(node, rz_str_newf("%d", i), NULL);
-			}
+	if (!core || !node) {
+		return;
+	}
+
+	int bits = rz_asm_get_plugin_bits(core->rasm);
+	node->options->free = free;
+	rz_list_purge(node->options);
+	for (int i = 1; i <= bits; i <<= 1) {
+		if (i & bits) {
+			SETOPTIONS(node, rz_str_newf("%d", i), NULL);
 		}
 	}
 }
 
 static void update_asmfeatures_options(RzCore *core, RzConfigNode *node) {
-	int i, argc;
-
-	if (core && core->rasm && core->rasm->cur) {
-		if (core->rasm->cur->features) {
-			char *features = rz_str_dup(core->rasm->cur->features);
-			rz_list_purge(node->options);
-			argc = rz_str_split(features, ',');
-			for (i = 0; i < argc; i++) {
-				node->options->free = free;
-				const char *feature = rz_str_word_get0(features, i);
-				if (feature) {
-					rz_list_append(node->options, rz_str_dup(feature));
-				}
-			}
-			free(features);
-		}
+	if (!core || !node) {
+		return;
 	}
+
+	const char *features = rz_asm_get_plugin_features(core->rasm);
+	if (RZ_STR_ISEMPTY(features)) {
+		rz_list_purge(node->options);
+		return;
+	}
+
+	rz_list_free(node->options);
+	node->options = rz_str_split_duplist(features, ",", true);
 }
 
 static void update_asmplatforms_options(RzCore *core, RzConfigNode *node) {
-	int i, argc;
-
-	if (core && core->rasm && core->rasm->cur) {
-		if (core->rasm->cur->platforms) {
-			char *platforms = rz_str_dup(core->rasm->cur->platforms);
-			rz_list_purge(node->options);
-			argc = rz_str_split(platforms, ',');
-			for (i = 0; i < argc; i++) {
-				node->options->free = free;
-				const char *feature = rz_str_word_get0(platforms, i);
-				if (feature) {
-					rz_list_append(node->options, rz_str_dup(feature));
-				}
-			}
-			free(platforms);
-		}
+	if (!core || !node) {
+		return;
 	}
+
+	const char *platforms = rz_asm_get_plugin_platforms(core->rasm);
+	if (RZ_STR_ISEMPTY(platforms)) {
+		rz_list_purge(node->options);
+		return;
+	}
+
+	rz_list_free(node->options);
+	node->options = rz_str_split_duplist(platforms, ",", true);
 }
 
 static void update_asmparser_options(RzCore *core, RzConfigNode *node) {
@@ -172,29 +165,14 @@ static void update_asmparser_options(RzCore *core, RzConfigNode *node) {
 static void update_asmcpu_options(RzCore *core, RzConfigNode *node) {
 	rz_return_if_fail(core && core->rasm);
 
-	RzIterator *it = ht_sp_as_iter(core->rasm->plugins);
-	RzAsmPlugin **val;
-	const char *arch = rz_config_get(core->config, "asm.arch");
-	if (!arch || !*arch) {
+	const char *cpus = rz_asm_get_plugin_cpus(core->rasm);
+	if (RZ_STR_ISEMPTY(cpus)) {
+		rz_list_purge(node->options);
 		return;
 	}
-	rz_list_purge(node->options);
-	rz_iterator_foreach(it, val) {
-		RzAsmPlugin *h = *val;
-		if (h->cpus && !strcmp(arch, h->name)) {
-			char *c = rz_str_dup(h->cpus);
-			int i, n = rz_str_split(c, ',');
-			for (i = 0; i < n; i++) {
-				const char *word = rz_str_word_get0(c, i);
-				if (word && *word) {
-					node->options->free = free;
-					SETOPTIONS(node, rz_str_dup(word), NULL);
-				}
-			}
-			free(c);
-		}
-	}
-	rz_iterator_free(it);
+
+	rz_list_free(node->options);
+	node->options = rz_str_split_duplist(cpus, ",", true);
 }
 
 static bool cb_search_case_sensitive(void *_core, void *_node) {
@@ -249,10 +227,7 @@ static bool cb_asm_features_set(void *user, void *data) {
 		print_node_options(node);
 		return 0;
 	}
-	RZ_FREE(core->rasm->features);
-	if (node->value[0]) {
-		core->rasm->features = rz_str_dup(node->value);
-	}
+	rz_asm_set_features(core->rasm, node->value);
 	return 1;
 }
 
@@ -543,7 +518,7 @@ static bool cb_scr_wideoff(void *user, void *data) {
 static bool cb_asmpseudo(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
-	core->rasm->pseudo = node->i_value;
+	rz_asm_set_pseudo(core->rasm, node->i_value);
 	return true;
 }
 
@@ -628,14 +603,14 @@ static bool cb_emuskip(void *user, void *data) {
 static bool cb_asm_immhash(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
-	core->rasm->immdisp = node->i_value ? true : false;
+	rz_asm_set_show_immediate_hashtag(core->rasm, node->i_value ? true : false);
 	return true;
 }
 
 static bool cb_asm_invhex(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
-	core->rasm->invhex = node->i_value;
+	rz_asm_set_invalid_as_hex_flag(core->rasm, node->i_value);
 	return true;
 }
 
@@ -647,7 +622,7 @@ static bool cb_asm_pcalign(void *user, void *data) {
 		RZ_LOG_ERROR("Alignment is only defined for '>0' and 'n^2'. Is = %" PFMT64d "\n", node->i_value);
 		return false;
 	}
-	core->rasm->pcalign = align;
+	rz_asm_set_pc_align(core->rasm, align);
 	core->analysis->pcalign = align;
 	return true;
 }
@@ -2213,7 +2188,7 @@ static bool cb_segoff(void *user, void *data) {
 static bool cb_seggrn(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
-	core->rasm->seggrn = node->i_value;
+	rz_asm_set_segment_granularity(core->rasm, node->i_value);
 	core->analysis->seggrn = node->i_value;
 	core->print->seggrn = node->i_value;
 	return true;
@@ -2270,7 +2245,7 @@ static bool cb_tracetag(void *user, void *data) {
 static bool cb_utf8(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
-	core->rasm->utf8 = (bool)node->i_value;
+	rz_asm_set_utf8(core->rasm, (bool)node->i_value);
 	rz_cons_set_utf8((bool)node->i_value);
 	return true;
 }

--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -83,7 +83,7 @@ RZ_IPI void rz_core_file_free(RzCoreFile *cf) {
 }
 
 static bool __isMips(RzAsm *a) {
-	return a && a->cur && a->cur->arch && strstr(a->cur->arch, "mips");
+	return a && rz_asm_is_arch(a, "mips");
 }
 
 static void loadGP(RzCore *core) {
@@ -288,7 +288,7 @@ RZ_API void rz_core_file_reopen_remote_debug(RzCore *core, const char *uri, ut64
 	core->dbg->main_arena_resolved = false;
 	RzPVector *old_sections = __save_old_sections(core);
 	ut64 old_base = core->bin->cur->o->baddr_shift;
-	int bits = core->rasm->bits;
+	int bits = rz_asm_get_bits(core->rasm);
 	rz_config_set_i(core->config, "asm.bits", bits);
 	rz_config_set_b(core->config, "cfg.debug", true);
 	// Set referer as the original uri so we could return to it with `oo`
@@ -355,7 +355,7 @@ RZ_API void rz_core_file_reopen_debug(RzCore *core, const char *args) {
 	core->dbg->main_arena_resolved = false;
 	RzPVector *old_sections = __save_old_sections(core);
 	ut64 old_base = core->bin->cur->o->baddr_shift;
-	int bits = core->rasm->bits;
+	int bits = rz_asm_get_bits(core->rasm);
 	char *bin_abspath = rz_file_abspath(binpath);
 	char *escaped_path = rz_str_arg_escape(bin_abspath);
 	char *newfile = RZ_STR_ISEMPTY(args) ? rz_str_newf("dbg://%s", escaped_path)
@@ -603,7 +603,7 @@ RZ_API void rz_core_sysenv_begin(RzCore *core) {
 	}
 	rz_sys_setenv("RZ_OFFSET", rz_strf(tmpbuf, "%" PFMT64d, core->offset));
 	rz_sys_setenv("RZ_XOFFSET", rz_strf(tmpbuf, "0x%08" PFMT64x, core->offset));
-	rz_sys_setenv("RZ_ENDIAN", core->rasm->big_endian ? "big" : "little");
+	rz_sys_setenv("RZ_ENDIAN", rz_asm_is_big_endian_set(core->rasm) ? "big" : "little");
 	rz_sys_setenv("RZ_BSIZE", rz_strf(tmpbuf, "%d", core->blocksize));
 
 	// dump current config file so other r2 tools can use the same options
@@ -792,7 +792,7 @@ static bool core_file_do_load_for_io_plugin(RzCore *r, ut64 baseaddr, ut64 loada
 		if (!info) {
 			return false;
 		}
-		info->bits = r->rasm->bits;
+		info->bits = rz_asm_get_bits(r->rasm);
 		rz_core_bin_set_arch_bits(r, binfile->file, info->arch, info->bits);
 	} else if (binfile) {
 		RzBinObject *obj = rz_bin_cur_object(r->bin);
@@ -1232,7 +1232,7 @@ RZ_API RZ_BORROW RzCoreFile *rz_core_file_open(RZ_NONNULL RzCore *r, RZ_NONNULL 
 	if (!flags) {
 		flags = RZ_PERM_R;
 	}
-	r->io->bits = r->rasm->bits; // TODO: we need an api for this
+	r->io->bits = rz_asm_get_bits(r->rasm); // TODO: we need an api for this
 	RzIODesc *fd = rz_io_open_nomap(r->io, file, flags, 0644);
 	if (rz_cons_is_breaked()) {
 		goto beach;

--- a/librz/core/cil.c
+++ b/librz/core/cil.c
@@ -1083,7 +1083,8 @@ static int esilbreak_reg_write(RzAnalysisEsil *esil, const char *name, ut64 *val
 			}
 		}
 	}
-	if (core->rasm->bits == 32 && strstr(core->rasm->cur->name, "arm")) {
+
+	if (rz_asm_get_bits(core->rasm) == 32 && rz_asm_is_arch(core->rasm, "arm")) {
 		if ((!(at & 1)) && rz_io_is_valid_offset(analysis->iob.io, at, 0)) { //  !core->analysis->opt.noncode)) {
 			rz_core_add_string_ref(analysis->coreb.core, esil->address, at);
 		}

--- a/librz/core/cmd/cmd.c
+++ b/librz/core/cmd/cmd.c
@@ -355,7 +355,9 @@ static RzCmdStatus pointer_read(RzCore *core, const char *expr) {
 		RZ_LOG_ERROR("core: RzNum ERROR: Division by Zero\n");
 		return RZ_CMD_STATUS_ERROR;
 	}
-	if (!rz_io_read_i(core->io, n, &n, core->rasm->bits / 8, core->print->big_endian)) {
+	const bool big_endian = rz_asm_is_big_endian_set(core->rasm);
+	int arch_bits = rz_asm_get_bits(core->rasm);
+	if (!rz_io_read_i(core->io, n, &n, arch_bits / 8, big_endian)) {
 		return RZ_CMD_STATUS_ERROR;
 	}
 	rz_cons_printf("0x%" PFMT64x "\n", n);
@@ -381,7 +383,7 @@ static RzCmdStatus pointer_write(RzCore *core, const char *addr_arg, const char 
 			return RZ_CMD_STATUS_ERROR;
 		}
 
-		ok = rz_core_write_value_at(core, addr, value, core->rasm->bits / 8);
+		ok = rz_core_write_value_at(core, addr, value, rz_asm_get_bits(core->rasm) / 8);
 	}
 
 	return bool2status(ok);

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -5315,7 +5315,7 @@ RZ_IPI RzCmdStatus rz_analyze_opcode_handler(RzCore *core, int argc, const char 
 }
 
 RZ_IPI RzCmdStatus rz_display_opcode_handler(RzCore *core, int argc, const char **argv) {
-	sdb_foreach(core->rasm->pair, listOpDescriptions, core);
+	rz_asm_describe_iterate(core->rasm, listOpDescriptions, core);
 	return RZ_CMD_STATUS_OK;
 }
 
@@ -6129,7 +6129,7 @@ RZ_IPI RzCmdStatus rz_analysis_data_function_gaps_handler(RzCore *core, int argc
 	ut64 end = UT64_MAX;
 	RzAnalysisFunction *fcn;
 	RzListIter *iter;
-	int i, wordsize = core->rasm->bits / 8;
+	int i, wordsize = rz_asm_get_bits(core->rasm) / 8;
 	rz_list_sort(core->analysis->fcns, cmpaddr, NULL);
 	rz_list_foreach (core->analysis->fcns, iter, fcn) {
 		if (end != UT64_MAX) {

--- a/librz/core/cmd/cmd_debug.c
+++ b/librz/core/cmd/cmd_debug.c
@@ -2322,9 +2322,7 @@ RZ_IPI RzCmdStatus rz_cmd_debug_toggle_bp_trace_index_handler(RzCore *core, int 
 // dbh
 RZ_IPI RzCmdStatus rz_cmd_debug_bp_plugin_handler(RzCore *core, int argc, const char **argv) {
 	rz_return_val_if_fail(core, RZ_CMD_STATUS_ERROR);
-	RzAsm *a = core->rasm;
-
-	RzIterator *iter = ht_sp_as_iter(a->plugins);
+	RzIterator *iter = rz_asm_plugin_iterator(core->rasm);
 	RzList *plugin_list = rz_list_new_from_iterator(iter);
 	if (!plugin_list) {
 		rz_iterator_free(iter);
@@ -2333,7 +2331,7 @@ RZ_IPI RzCmdStatus rz_cmd_debug_bp_plugin_handler(RzCore *core, int argc, const 
 
 	rz_list_sort(plugin_list, (RzListComparator)rz_asm_plugin_cmp, NULL);
 	RzListIter *it;
-	RzAsmPlugin *ap;
+	const RzAsmPlugin *ap;
 
 	rz_list_foreach (plugin_list, it, ap) {
 		if (!ap->sw_breakpoint) {

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -425,14 +425,6 @@ static ut64 findClassBounds(RzCore *core, int *len) {
 	return 0;
 }
 
-RZ_API void rz_core_set_asm_configs(RzCore *core, char *arch, ut32 bits, int segoff) {
-	rz_config_set(core->config, "asm.arch", arch);
-	rz_config_set_i(core->config, "asm.bits", bits);
-	// XXX - this needs to be done here, because
-	// if arch == x86 and bits == 16, segoff automatically changes
-	rz_config_set_i(core->config, "asm.segoff", segoff);
-}
-
 RZ_IPI RzCmdStatus rz_cmd_print_timestamp_unix_handler(RzCore *core, int argc, const char **argv) {
 	char *date = NULL;
 	const ut8 *block = core->block;
@@ -3324,7 +3316,7 @@ RZ_IPI RzCmdStatus rz_cmd_disassemble_ropchain_handler(RzCore *core, int argc, c
 		RZ_LOG_ERROR("the limit value exceeds the max value (1024).\n");
 		return RZ_CMD_STATUS_ERROR;
 	}
-	ut64 asm_bits = core->rasm->bits;
+	ut64 asm_bits = rz_asm_get_bits(core->rasm);
 	bool big_endian = rz_config_get_b(core->config, "cfg.bigendian");
 	bool src_color = rz_config_get_i(core->config, "scr.color") > 0;
 
@@ -3899,15 +3891,15 @@ static bool print_value(RzCore *core, PrintValueOptions *opts, RzCmdStateOutput 
 			break;
 		case 0:
 			v = rz_read_ble64(block, big_endian);
-			opts->size = core->rasm->bits / 8;
-			switch (core->rasm->bits / 8) {
+			opts->size = rz_asm_get_bits(core->rasm) / 8;
+			switch (opts->size) {
 			case 1: v &= UT8_MAX; break;
 			case 2: v &= UT16_MAX; break;
 			case 4: v &= UT32_MAX; break;
 			case 8: v &= UT64_MAX; break;
 			default: break;
 			}
-			block += core->rasm->bits / 8;
+			block += opts->size;
 			break;
 		}
 		print_value_single(core, opts, at, v, state);
@@ -4742,9 +4734,9 @@ static void print_stack(RzCore *core) {
 			return; // TODO: free stuff
 		}
 		rz_cons_print(string);
-	} else if (core->rasm->bits == 64) {
+	} else if (rz_asm_is_bits(core->rasm, 64)) {
 		rz_core_print_dump(core, RZ_OUTPUT_MODE_STANDARD, sp_addr, 8, 128, RZ_CORE_PRINT_FORMAT_TYPE_HEXADECIMAL);
-	} else if (core->rasm->bits == 32) {
+	} else if (rz_asm_is_bits(core->rasm, 32)) {
 		rz_core_print_dump(core, RZ_OUTPUT_MODE_STANDARD, sp_addr, 4, 128, RZ_CORE_PRINT_FORMAT_TYPE_HEXADECIMAL);
 	}
 	rz_cmd_state_output_init(&so, RZ_OUTPUT_MODE_STANDARD, core);

--- a/librz/core/cmd/cmd_regs.c
+++ b/librz/core/cmd/cmd_regs.c
@@ -437,7 +437,7 @@ RZ_IPI void rz_regs_show_valgroup(RzCore *core, RzReg *reg, RzCmdRegSync sync_cb
 	RzRegItem *r;
 	HtUP *db = ht_up_new(NULL, NULL);
 	rz_list_foreach (list, iter, r) {
-		if (r->size != core->rasm->bits) {
+		if (!rz_asm_is_bits(core->rasm, r->size)) {
 			continue;
 		}
 		ut64 value = rz_reg_get_value(reg, r);

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -1098,15 +1098,12 @@ static void search_similar_pattern(RzCore *core, int count, struct search_parame
 }
 
 static bool isArm(RzCore *core) {
-	RzAsm *as = core ? core->rasm : NULL;
-	if (as && as->cur && as->cur->arch) {
-		if (rz_str_startswith(as->cur->arch, "arm")) {
-			if (as->cur->bits < 64) {
-				return true;
-			}
-		}
+	if (!core || !core->rasm) {
+		return false;
 	}
-	return false;
+
+	return rz_asm_is_arch(core->rasm, "arm") &&
+		rz_asm_get_bits(core->rasm) < 64;
 }
 
 void _CbInRangeSearchV(RzCore *core, ut64 from, ut64 to, int vsize, void *user) {
@@ -1443,7 +1440,7 @@ reread:
 			int ochunksize;
 			int i, len, chunksize = rz_config_get_i(core->config, "search.chunk");
 			if (chunksize < 1) {
-				chunksize = core->rasm->bits / 8;
+				chunksize = rz_asm_get_bits(core->rasm) / 8;
 			}
 			len = rz_str_unescape(str);
 			ochunksize = chunksize = RZ_MIN(len, chunksize);
@@ -1746,10 +1743,6 @@ RZ_IPI RzCmdStatus rz_cmd_search_str_chunk_handler(RzCore *core, int argc, const
 // "/a"
 RZ_IPI RzCmdStatus rz_cmd_search_assemble_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
 	rz_return_val_if_fail(core && core->rasm, RZ_CMD_STATUS_ERROR);
-	if (!core->rasm->cur) {
-		RZ_LOG_ERROR("Not RzArch plugin set up.\n");
-		return RZ_CMD_STATUS_ERROR;
-	}
 
 	RzAsmCode *acode;
 	if (!(acode = rz_asm_massemble(core->rasm, argv[1]))) {

--- a/librz/core/cmd/cmd_system.c
+++ b/librz/core/cmd/cmd_system.c
@@ -64,7 +64,7 @@ static int system_exec(RzCore *core, int argc, const char **argv, char **output,
 	const char *io_va = rz_config_get(core->config, "io.va");
 	const char *pdb_server = rz_config_get(core->config, "pdb.server");
 	const char *scr_color = rz_config_get(core->config, "scr.color");
-	const char *endian = rz_str_bool(core->rasm->big_endian);
+	const char *endian = rz_str_bool(rz_asm_is_big_endian_set(core->rasm));
 	char *cfg_path = config_path(core);
 
 	rz_strf(file_size, "%" PFMT64u, core->file ? rz_io_fd_size(core->io, core->file->fd) : 0);

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -1706,6 +1706,7 @@ RZ_API bool rz_core_init(RzCore *core) {
 	rz_lang_define(core->lang, "RzCore", "core", core);
 	rz_lang_set_user_ptr(core->lang, core);
 	core->rasm = rz_asm_new();
+	rz_asm_set_core(core->rasm, core);
 	// initialize path
 	core->sys_path = rz_path_new();
 	char *sdb_types_path = rz_path_system(core->sys_path, RZ_SDB_TYPES);

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -637,7 +637,7 @@ static ut64 num_callback(RzNum *userptr, const char *str, int *ok) {
 		break;
 	case '[': {
 		ut64 n = 0LL;
-		int refsz = core->rasm->bits / 8;
+		int refsz = rz_asm_get_bits(core->rasm) / 8;
 		const char *p = NULL;
 		if (strlen(str) > 5) {
 			p = strchr(str + 5, ':');
@@ -1052,8 +1052,9 @@ static void update_sdb(RzCore *core) {
 	// sdb_ns_set (core->sdb, "flags", core->flags->sdb);
 	// sdb_ns_set (core->sdb, "bin", core->bin->sdb);
 	// SDB// syscall/
-	if (core->rasm && core->rasm->syscall && core->rasm->syscall->db) {
-		sdb_ns_set(DB, "syscall", core->rasm->syscall->db);
+	RzSyscall *syscall = rz_asm_get_syscall(core->rasm);
+	if (core->rasm && syscall && syscall->db) {
+		sdb_ns_set(DB, "syscall", syscall->db);
 	}
 	d = sdb_ns(DB, "debug", 1);
 	if (core->dbg->sgnls) {
@@ -1129,7 +1130,7 @@ static char *getvalue(ut64 value, int bits) {
  * no json support
 */
 RZ_API char *rz_core_analysis_hasrefs_to_depth(RzCore *core, ut64 value, PJ *pj, int depth) {
-	const int bits = core->rasm->bits;
+	const int bits = rz_asm_get_bits(core->rasm);
 	const bool big_endian = rz_config_get_b(core->config, "cfg.bigendian");
 	rz_return_val_if_fail(core, NULL);
 	RzStrBuf *s = rz_strbuf_new(NULL);
@@ -1705,8 +1706,6 @@ RZ_API bool rz_core_init(RzCore *core) {
 	rz_lang_define(core->lang, "RzCore", "core", core);
 	rz_lang_set_user_ptr(core->lang, core);
 	core->rasm = rz_asm_new();
-	core->rasm->num = core->num;
-	core->rasm->core = core;
 	// initialize path
 	core->sys_path = rz_path_new();
 	char *sdb_types_path = rz_path_system(core->sys_path, RZ_SDB_TYPES);
@@ -1720,7 +1719,7 @@ RZ_API bool rz_core_init(RzCore *core) {
 	core->analysis->cb.on_fcn_new = on_fcn_new;
 	core->analysis->cb.on_fcn_delete = on_fcn_delete;
 	core->analysis->cb.on_fcn_rename = on_fcn_rename;
-	core->rasm->syscall = rz_syscall_ref(core->analysis->syscall); // BIND syscall analysis/asm
+	rz_asm_set_syscall(core->rasm, rz_syscall_ref(core->analysis->syscall)); // BIND syscall analysis/asm
 	core->analysis->core = core;
 	core->parser = rz_parse_new();
 	rz_analysis_bind(core->analysis, &(core->parser->analb));
@@ -1753,8 +1752,7 @@ RZ_API bool rz_core_init(RzCore *core) {
 	}
 	core->hash = rz_hash_new();
 
-	rz_bin_bind(core->bin, &(core->rasm->binb));
-	rz_bin_bind(core->bin, &(core->analysis->binb));
+	rz_bin_bind(core->bin, rz_asm_get_bin_bind(core->rasm));
 	rz_bin_bind(core->bin, &(core->analysis->binb));
 
 	rz_io_bind(core->io, &(core->search->iob));
@@ -2247,7 +2245,7 @@ RZ_API RzBuffer *rz_core_syscall(RzCore *core, const char *name, const char *arg
 	}
 
 	// bits check
-	switch (core->rasm->bits) {
+	switch (rz_asm_get_bits(core->rasm)) {
 	case 32:
 		if (strcmp(name, "setup") && !num) {
 			RZ_LOG_ERROR("core: syscall not found!\n");

--- a/librz/core/cprint.c
+++ b/librz/core/cprint.c
@@ -491,7 +491,7 @@ RZ_IPI RZ_OWN char *rz_core_print_hexdump_refs(RZ_NONNULL RzCore *core, ut64 add
 	}
 
 	const int ocols = core->print->cols;
-	int bitsize = core->rasm->bits;
+	int bitsize = rz_asm_get_bits(core->rasm);
 	/* Thumb is 16bit arm but handles 32bit data */
 	if (bitsize == 16) {
 		bitsize = 32;
@@ -540,10 +540,10 @@ RZ_API RZ_OWN char *rz_core_print_bytes_with_inst(RZ_NONNULL RzCore *core, RZ_NO
 }
 
 static void core_handle_call(RzCore *core, char *line, char **str) {
-	rz_return_if_fail(core && line && str && core->rasm && core->rasm->cur);
-	if (strstr(core->rasm->cur->arch, "x86")) {
+	rz_return_if_fail(core && line && str && core->rasm);
+	if (rz_asm_is_arch(core->rasm, "x86")) {
 		*str = strstr(line, "call ");
-	} else if (strstr(core->rasm->cur->arch, "arm")) {
+	} else if (rz_asm_is_arch(core->rasm, "arm")) {
 		*str = strstr(line, " b ");
 		if (*str && strstr(*str, " 0x")) {
 			/*
@@ -972,7 +972,7 @@ RZ_IPI const char *rz_core_print_stack_command(RZ_NONNULL RzCore *core) {
 	if (rz_config_get_b(core->config, "stack.bytes")) {
 		return "px";
 	}
-	switch (core->rasm->bits) {
+	switch (rz_asm_get_bits(core->rasm)) {
 	case 64: return "pxq"; break;
 	case 32: return "pxw"; break;
 	}

--- a/librz/core/csyscall.c
+++ b/librz/core/csyscall.c
@@ -24,9 +24,10 @@ static const char *syscallNumberFmt(int n) {
  * \param addr address of the syscall
  */
 RZ_API RZ_OWN char *rz_core_syscall_as_string(RzCore *core, st64 n, ut64 addr) {
-	int i;
-	char str[64];
+	char str[64] = { 0 };
 	char tmpbuf[32] = { 0 };
+	bool is_x86 = rz_asm_is_arch(core->rasm, "x86");
+	int bits = rz_asm_get_bits(core->rasm);
 	st64 N = n;
 	int defVector = rz_syscall_get_swi(core->analysis->syscall);
 	if (defVector > 0) {
@@ -52,11 +53,11 @@ RZ_API RZ_OWN char *rz_core_syscall_as_string(RzCore *core, st64 n, ut64 addr) {
 	// TODO: move this to rz_syscall
 	const char *cc = rz_analysis_syscc_default(core->analysis);
 	// TODO replace the hardcoded CC with the sdb ones
-	for (i = 0; i < item->args; i++) {
+	for (int i = 0; i < item->args; i++) {
 		// XXX this is a hack to make syscall args work on x86-32 and x86-64
 		// we need to shift sn first.. which is bad, but needs to be redesigned
 		int regidx = i;
-		if (core->rasm->bits == 32 && core->rasm->cur && !strcmp(core->rasm->cur->arch, "x86")) {
+		if (bits == 32 && is_x86) {
 			regidx++;
 		}
 		ut64 arg = rz_core_arg_get(core, cc, regidx); // TODO here

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -13,8 +13,6 @@
 #include "rz_asm.h"
 #include <rz_util/rz_strbuf.h>
 
-#define HASRETRY      1
-#define HAVE_LOCALS   1
 #define DEFAULT_NARGS 4
 #define FLAG_PREFIX   ";-- "
 
@@ -411,9 +409,9 @@ static void ds_print_ref_lines(char *line, char *line_col, RzDisasmState *ds) {
 }
 
 static void get_bits_comment(RzCore *core, RzAnalysisFunction *f, char *cmt, int cmt_size) {
-	if (core && f && cmt && cmt_size > 0 && f->bits && f->bits != core->rasm->bits) {
-		const char *asm_arch = rz_config_get(core->config, "asm.arch");
-		if (asm_arch && *asm_arch && strstr(asm_arch, "arm")) {
+	int arch_bits = rz_asm_get_bits(core->rasm);
+	if (core && f && cmt && cmt_size > 0 && f->bits && f->bits != arch_bits) {
+		if (rz_asm_is_arch(core->rasm, "arm")) {
 			switch (f->bits) {
 			case 16: strcpy(cmt, " (thumb)"); break;
 			case 32: strcpy(cmt, " (arm)"); break;
@@ -1024,7 +1022,7 @@ static void ds_build_op_str(RzDisasmState *ds, bool print_color) {
 		if (core->parser->subrel && ds->analysis_op.refptr) {
 			if (core->parser->subrel_addr == 0) {
 				ut64 sub_address = UT64_MAX;
-				const int be = core->rasm->big_endian;
+				const int be = rz_asm_is_big_endian_set(core->rasm);
 				rz_io_read_i(core->io, ds->analysis_op.ptr, &sub_address, ds->analysis_op.refptr, be);
 				core->parser->subrel_addr = sub_address;
 			}
@@ -2559,15 +2557,13 @@ static int ds_disassemble(RzDisasmState *ds, ut8 *buf, int len) {
 
 	if (ret < 1) {
 		ret = -1;
-#if HASRETRY
 		if (!ds->cbytes && ds->tries > 0) {
-			ds->addr = core->rasm->pc;
+			ds->addr = rz_asm_get_pc(core->rasm);
 			ds->tries--;
 			ds->idx = 0;
 			ds->retry = true;
 			return ret;
 		}
-#endif
 		ds->lastfail = 1;
 		ds->asmop.size = (ds->hint && ds->hint->size) ? ds->hint->size : 1;
 		ds->oplen = ds->asmop.size;
@@ -3525,7 +3521,7 @@ static ut64 get_ptr(RzDisasmState *ds, ut64 addr) {
 	ut8 buf[sizeof(ut64)] = { 0 };
 	rz_io_read_at_mapped(ds->core->io, addr, buf, sizeof(buf));
 	ut64 n64_32;
-	if (ds->core->rasm->bits == 64) {
+	if (rz_asm_is_bits(ds->core->rasm, 64)) {
 		n64_32 = rz_read_ble64(buf, 0);
 	} else {
 		n64_32 = rz_read_ble32(buf, 0);
@@ -3535,10 +3531,10 @@ static ut64 get_ptr(RzDisasmState *ds, ut64 addr) {
 
 static ut64 get_ptr_ble(RzDisasmState *ds, ut64 addr) {
 	ut8 buf[sizeof(ut64)] = { 0 };
-	int endian = ds->core->rasm->big_endian;
+	const bool endian = rz_asm_get_endianness(ds->core->rasm);
 	ut64 n64_32;
 	rz_io_read_at_mapped(ds->core->io, addr, buf, sizeof(buf));
-	if (ds->core->rasm->bits == 64) {
+	if (rz_asm_is_bits(ds->core->rasm, 64)) {
 		n64_32 = rz_read_ble64(buf, endian);
 	} else {
 		n64_32 = rz_read_ble32(buf, endian);
@@ -3573,10 +3569,10 @@ static bool ds_print_core_vmode(RzDisasmState *ds, int pos) {
 		ut64 size;
 		RzAnalysisMetaItem *mi = rz_meta_get_at(ds->core->analysis, ds->at, RZ_META_TYPE_ANY, &size);
 		if (mi) {
-			int obits = ds->core->rasm->bits;
-			ds->core->rasm->bits = size * 8;
+			int obits = rz_asm_get_bits(ds->core->rasm);
+			rz_asm_set_bits(ds->core->rasm, size * 8);
 			slen = ds_print_shortcut(ds, get_ptr(ds, ds->at), pos);
-			ds->core->rasm->bits = obits;
+			rz_asm_set_bits(ds->core->rasm, obits);
 			gotShortcut = true;
 		}
 	}
@@ -3744,7 +3740,8 @@ static void ds_print_asmop_payload(RzDisasmState *ds, const ut8 *buf) {
 	if (ds->asmop.payload != 0) {
 		rz_cons_printf("\n; .. payload of %d byte(s)", ds->asmop.payload);
 		if (ds->showpayloads) {
-			int mod = ds->asmop.payload % ds->core->rasm->dataalign;
+			int dataalign = rz_analysis_archinfo(ds->core->analysis, RZ_ANALYSIS_ARCHINFO_DATA_ALIGN);
+			int mod = ds->asmop.payload % dataalign;
 			int x;
 			for (x = 0; x < ds->asmop.payload; x++) {
 				rz_cons_printf("\n        0x%02x", buf[ds->oplen + x]);
@@ -3834,7 +3831,7 @@ static void ds_print_str(RzDisasmState *ds, const char *str, int len, ut64 refad
 	}
 	// do not resolve strings on arm64 pointed with ADRP
 	if (ds->analysis_op.type == RZ_ANALYSIS_OP_TYPE_LEA) {
-		if (ds->core->rasm->bits == 64 && rz_str_startswith(rz_config_get(ds->core->config, "asm.arch"), "arm")) {
+		if (rz_asm_is_bits(ds->core->rasm, 64) && rz_asm_is_arch(ds->core->rasm, "arm")) {
 			return;
 		}
 	}
@@ -4330,7 +4327,7 @@ static int myregwrite(RzAnalysisEsil *esil, const char *name, ut64 *val) {
 				ignored = true;
 				break;
 			case RZ_ANALYSIS_OP_TYPE_LEA:
-				if (ds->core->rasm->bits == 64 && rz_str_startswith(rz_config_get(ds->core->config, "asm.arch"), "arm")) {
+				if (rz_asm_is_bits(ds->core->rasm, 64) && rz_asm_is_arch(ds->core->rasm, "arm")) {
 					ignored = true;
 				}
 				break;
@@ -5024,7 +5021,7 @@ static void ds_asmop_fixup(RzDisasmState *ds) {
 	default:
 		return;
 	}
-	if (rz_str_cmp(ds->core->rasm->cur->arch, "tricore", -1) == 0) {
+	if (rz_asm_is_arch(ds->core->rasm, "tricore")) {
 		rz_asm_op_tricore_fixup(&ds->asmop);
 	}
 }
@@ -5298,7 +5295,6 @@ toro:
 		rz_analysis_op(core->analysis, &ds->analysis_op, ds->at, buf + idx, (int)(len - idx), DS_ANALYSIS_OP_MASK);
 		if (ds_must_strip(ds)) {
 			inc = ds->analysis_op.size;
-			// inc = ds->asmop.payload + (ds->asmop.payload % ds->core->rasm->dataalign);
 			rz_analysis_op_fini(&ds->analysis_op);
 			continue;
 		}
@@ -5455,13 +5451,13 @@ toro:
 			ret = ds_print_middle(ds, ret);
 
 			ds_print_asmop_payload(ds, buf + idx);
-			if (core->rasm->syntax != RZ_ASM_SYNTAX_INTEL) {
+			if (!rz_asm_is_syntax(core->rasm, RZ_ASM_SYNTAX_INTEL)) {
 				RzAsmOp ao = { 0 }; /* disassemble for the vm .. */
-				int os = core->rasm->syntax;
+				RzAsmSyntax old_value = rz_asm_get_syntax(core->rasm);
 				rz_asm_set_syntax(core->rasm, RZ_ASM_SYNTAX_INTEL);
 				rz_asm_op_fini(&ds->asmop);
 				rz_asm_disassemble(core->rasm, &ao, buf + idx, len - idx + 5);
-				rz_asm_set_syntax(core->rasm, os);
+				rz_asm_set_syntax(core->rasm, old_value);
 			}
 			if (mi_type == RZ_META_TYPE_FORMAT) {
 				if ((ds->show_comments || ds->show_usercomments) && ds->show_comment_right) {
@@ -5495,13 +5491,13 @@ toro:
 			ret = ds_print_middle(ds, ret);
 
 			ds_print_asmop_payload(ds, buf + idx);
-			if (core->rasm->syntax != RZ_ASM_SYNTAX_INTEL) {
+			if (!rz_asm_is_syntax(core->rasm, RZ_ASM_SYNTAX_INTEL)) {
 				RzAsmOp ao = { 0 }; /* disassemble for the vm .. */
-				int os = core->rasm->syntax;
+				RzAsmSyntax old_value = rz_asm_get_syntax(core->rasm);
 				rz_asm_set_syntax(core->rasm, RZ_ASM_SYNTAX_INTEL);
 				rz_asm_op_fini(&ds->asmop);
 				rz_asm_disassemble(core->rasm, &ao, buf + idx, len - idx + 5);
-				rz_asm_set_syntax(core->rasm, os);
+				rz_asm_set_syntax(core->rasm, old_value);
 			}
 			if (ds->show_bytes_right && ds->show_bytes) {
 				ds_comment(ds, true, "");
@@ -5557,14 +5553,14 @@ toro:
 		if (inc < 1) {
 			inc = min_op_size;
 		}
-		inc += ds->asmop.payload + (ds->asmop.payload % ds->core->rasm->dataalign);
+		int dataalign = rz_analysis_archinfo(ds->core->analysis, RZ_ANALYSIS_ARCHINFO_DATA_ALIGN);
+		inc += ds->asmop.payload + (ds->asmop.payload % dataalign);
 	}
 	rz_analysis_op_fini(&ds->analysis_op);
 
 	RZ_FREE(nbuf);
 	rz_cons_break_pop();
 
-#if HASRETRY
 	if (!ds->cbytes && ds->lines < ds->nlines) {
 		ds->addr = ds->at + inc;
 	retry:
@@ -5590,7 +5586,6 @@ toro:
 		}
 		RZ_FREE(nbuf);
 	}
-#endif
 	if (!ds->vec && ds->pj) {
 		rz_cons_pop();
 		if (!pj) {

--- a/librz/core/hack.c
+++ b/librz/core/hack.c
@@ -3,12 +3,14 @@
 
 #include <rz_core.h>
 
+typedef bool (*hack_cb_t)(RzCore *core, const char *op, const RzAnalysisOp *aop);
+
 /* We can not use some kind of structure type with
  * a string for each case, because some architectures (like ARM)
  * have several modes/alignment requirements.
  */
 
-RZ_API bool rz_core_hack_dalvik(RzCore *core, const char *op, const RzAnalysisOp *aop) {
+static bool core_hack_dalvik(RzCore *core, const char *op, const RzAnalysisOp *aop) {
 	if (!strcmp(op, "nop")) {
 		rz_core_write_hexpair(core, core->offset, "0000");
 	} else if (!strcmp(op, "ret2")) {
@@ -26,7 +28,7 @@ RZ_API bool rz_core_hack_dalvik(RzCore *core, const char *op, const RzAnalysisOp
 	return true;
 }
 
-RZ_API bool rz_core_hack_arm64(RzCore *core, const char *op, const RzAnalysisOp *aop) {
+static bool core_hack_arm64(RzCore *core, const char *op, const RzAnalysisOp *aop) {
 	if (!strcmp(op, "nop")) {
 		rz_core_write_hexpair(core, core->offset, "1f2003d5");
 	} else if (!strcmp(op, "ret")) {
@@ -48,13 +50,13 @@ RZ_API bool rz_core_hack_arm64(RzCore *core, const char *op, const RzAnalysisOp 
 	return true;
 }
 
-RZ_API bool rz_core_hack_arm(RzCore *core, const char *op, const RzAnalysisOp *aop) {
-	const int bits = core->rasm->bits;
+static bool core_hack_arm(RzCore *core, const char *op, const RzAnalysisOp *aop) {
+	const bool is_thumb = rz_asm_is_bits(core->rasm, 16);
 	const ut8 *b = core->block;
 
 	if (!strcmp(op, "nop")) {
-		const int nopsize = (bits == 16) ? 2 : 4;
-		const char *nopcode = (bits == 16) ? "00bf" : "0000a0e1";
+		const int nopsize = is_thumb ? 2 : 4;
+		const char *nopcode = is_thumb ? "00bf" : "0000a0e1";
 		const int len = aop->size;
 		char *str;
 		int i;
@@ -75,11 +77,11 @@ RZ_API bool rz_core_hack_arm(RzCore *core, const char *op, const RzAnalysisOp *a
 		rz_core_write_hexpair(core, core->offset, str);
 		free(str);
 	} else if (!strcmp(op, "jinf")) {
-		rz_core_write_hexpair(core, core->offset, (bits == 16) ? "fee7" : "feffffea");
+		rz_core_write_hexpair(core, core->offset, is_thumb ? "fee7" : "feffffea");
 	} else if (!strcmp(op, "trap")) {
-		rz_core_write_hexpair(core, core->offset, (bits == 16) ? "bebe" : "fedeffe7");
+		rz_core_write_hexpair(core, core->offset, is_thumb ? "bebe" : "fedeffe7");
 	} else if (!strcmp(op, "jz")) {
-		if (bits == 16) {
+		if (is_thumb) {
 			switch (b[1]) {
 			case 0xb9: // CBNZ
 				rz_core_write_hexpair(core, core->offset + 1, "b1"); // CBZ
@@ -99,7 +101,7 @@ RZ_API bool rz_core_hack_arm(RzCore *core, const char *op, const RzAnalysisOp *a
 			return false;
 		}
 	} else if (!strcmp(op, "jnz")) {
-		if (bits == 16) {
+		if (is_thumb) {
 			switch (b[1]) {
 			case 0xb1: // CBZ
 				rz_core_write_hexpair(core, core->offset + 1, "b9"); // CBNZ
@@ -120,7 +122,7 @@ RZ_API bool rz_core_hack_arm(RzCore *core, const char *op, const RzAnalysisOp *a
 		}
 	} else if (!strcmp(op, "nocj")) {
 		// TODO: drop conditional bit instead of that hack
-		if (bits == 16) {
+		if (is_thumb) {
 			switch (b[1]) {
 			case 0xb1: // CBZ
 			case 0xb3: // CBZ
@@ -142,19 +144,19 @@ RZ_API bool rz_core_hack_arm(RzCore *core, const char *op, const RzAnalysisOp *a
 		RZ_LOG_ERROR("core: hack: please, use jnz or jz\n");
 		return false;
 	} else if (!strcmp(op, "ret1")) {
-		if (bits == 16) {
+		if (is_thumb) {
 			rz_core_write_hexpair(core, core->offset, "01207047"); // mov r0, 1; bx lr
 		} else {
 			rz_core_write_hexpair(core, core->offset, "0100b0e31eff2fe1"); // movs r0, 1; bx lr
 		}
 	} else if (!strcmp(op, "ret0")) {
-		if (bits == 16) {
+		if (is_thumb) {
 			rz_core_write_hexpair(core, core->offset, "00207047"); // mov r0, 0; bx lr
 		} else {
 			rz_core_write_hexpair(core, core->offset, "0000a0e31eff2fe1"); // movs r0, 0; bx lr
 		}
 	} else if (!strcmp(op, "retn")) {
-		if (bits == 16) {
+		if (is_thumb) {
 			rz_core_write_hexpair(core, core->offset, "ff207047"); // mov r0, -1; bx lr
 		} else {
 			rz_core_write_hexpair(core, core->offset, "ff00a0e31eff2fe1"); // movs r0, -1; bx lr
@@ -166,7 +168,7 @@ RZ_API bool rz_core_hack_arm(RzCore *core, const char *op, const RzAnalysisOp *a
 	return true;
 }
 
-RZ_API bool rz_core_hack_x86(RzCore *core, const char *op, const RzAnalysisOp *aop) {
+static bool core_hack_x86(RzCore *core, const char *op, const RzAnalysisOp *aop) {
 	const ut8 *b = core->block;
 	int i, size = aop->size;
 	if (!strcmp(op, "nop")) {
@@ -249,37 +251,32 @@ RZ_API bool rz_core_hack_x86(RzCore *core, const char *op, const RzAnalysisOp *a
 RZ_API bool rz_core_hack(RzCore *core, const char *op) {
 	// TODO: op should not be an unstructered string
 	// TODO: asm/analysis plugins should provide the operations, instead of doing this here
-	bool (*hack)(RzCore *core, const char *op, const RzAnalysisOp *aop) = NULL;
-	const char *asmarch = rz_config_get(core->config, "asm.arch");
-	const int asmbits = core->rasm->bits;
+	hack_cb_t hack = NULL;
 
-	if (!asmarch) {
+	if (rz_asm_is_arch(core->rasm, "x86")) {
+		hack = core_hack_x86;
+	} else if (rz_asm_is_arch(core->rasm, "dalvik")) {
+		hack = core_hack_dalvik;
+	} else if (rz_asm_is_arch(core->rasm, "arm")) {
+		if (rz_asm_is_bits(core->rasm, 64)) {
+			hack = core_hack_arm64;
+		} else {
+			hack = core_hack_arm;
+		}
+	}
+	if (!hack) {
 		return false;
 	}
-	if (strstr(asmarch, "x86")) {
-		hack = rz_core_hack_x86;
-	} else if (strstr(asmarch, "dalvik")) {
-		hack = rz_core_hack_dalvik;
-	} else if (strstr(asmarch, "arm")) {
-		if (asmbits == 64) {
-			hack = rz_core_hack_arm64;
-		} else {
-			hack = rz_core_hack_arm;
-		}
-	} else {
-		RZ_LOG_ERROR("core: hack: write hacks are only supported on x86 arch\n");
-	}
-	if (hack) {
-		RzAnalysisOp aop = { 0 };
-		rz_analysis_op_init(&aop);
-		if (rz_analysis_op(core->analysis, &aop, core->offset, core->block, core->blocksize, RZ_ANALYSIS_OP_MASK_BASIC) < 1) {
-			rz_analysis_op_fini(&aop);
-			RZ_LOG_ERROR("core: hack: analysis op fail\n");
-			return false;
-		}
-		bool ret = hack(core, op, &aop);
+
+	RzAnalysisOp aop = { 0 };
+	rz_analysis_op_init(&aop);
+	if (rz_analysis_op(core->analysis, &aop, core->offset, core->block, core->blocksize, RZ_ANALYSIS_OP_MASK_BASIC) < 1) {
 		rz_analysis_op_fini(&aop);
-		return ret;
+		RZ_LOG_ERROR("core: hack: analysis op fail\n");
+		return false;
 	}
-	return false;
+
+	bool ret = hack(core, op, &aop);
+	rz_analysis_op_fini(&aop);
+	return ret;
 }

--- a/librz/core/heap_glibc.c
+++ b/librz/core/heap_glibc.c
@@ -34,7 +34,7 @@ RzList /*<RzArenaListItem *>*/ *rz_heap_arenas_list_internal(RzCore *core, ut64 
 bool rz_heap_update_main_arena_internal(RzCore *core, ut64 m_arena, MallocState *main_arena, const RzHeapConfig *config);
 
 static inline ut8 rz_heap_ptr_size(RzCore *core) {
-	ut8 bits = (ut8)core->rasm->bits;
+	ut8 bits = (ut8)rz_asm_get_bits(core->rasm);
 	if (!bits) {
 		bits = (ut8)core->dbg->bits;
 	}

--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -355,14 +355,15 @@ RZ_IPI const char **rz_core_visual_get_fcn_help() {
 
 static void rotateAsmBits(RzCore *core) {
 	RzAnalysisHint *hint = rz_analysis_hint_get(core->analysis, core->offset);
-	int bits = hint ? hint->bits : rz_config_get_i(core->config, "asm.bits");
+	int bits = hint ? hint->bits : rz_asm_get_bits(core->rasm);
+	int plugin_bits = rz_asm_get_plugin_bits(core->rasm);
 	int retries = 4;
 	while (retries > 0) {
 		int nb = bits == 64 ? 8 : bits == 32 ? 64
 			: bits == 16                 ? 32
 			: bits == 8                  ? 16
 						     : bits;
-		if ((core->rasm->cur->bits & nb) == nb) {
+		if ((plugin_bits & nb) == nb) {
 			rz_analysis_hint_set_bits(core->analysis, core->offset, nb);
 			break;
 		}

--- a/librz/include/rz_asm.h
+++ b/librz/include/rz_asm.h
@@ -105,14 +105,14 @@ typedef struct rz_asm_plugin_t {
 	int endian;
 	bool (*init)(void **user);
 	bool (*fini)(void *user);
-	int (*disassemble)(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len);
-	int (*assemble)(RzAsm *a, RzAsmOp *op, const char *buf);
-	char *(*mnemonics)(RzAsm *a, int id, bool json);
+	int (*disassemble)(const RzAsm *a, RzAsmOp *op, const ut8 *buf, int len);
+	int (*assemble)(const RzAsm *a, RzAsmOp *op, const char *buf);
+	char *(*mnemonics)(const RzAsm *a, int id, bool json);
 	RZ_OWN RzConfig *(*get_config)(void *plugin_data);
 	const char *features;
 	const char *platforms;
 	char **(*get_cpu_desc)();
-	bool (*sw_breakpoint)(RzAsm *a, RzAsmOp *op);
+	bool (*sw_breakpoint)(const RzAsm *a, RzAsmOp *op);
 } RzAsmPlugin;
 
 /**

--- a/librz/include/rz_asm.h
+++ b/librz/include/rz_asm.h
@@ -147,6 +147,7 @@ RZ_API bool rz_asm_use_assembler(RzAsm *a, const char *name);
 RZ_API bool rz_asm_set_arch(RzAsm *a, const char *name, int bits);
 RZ_API const char *rz_asm_get_arch(RZ_NONNULL RzAsm *a);
 RZ_API bool rz_asm_is_arch(RZ_NONNULL RzAsm *a, RZ_NONNULL const char *name);
+RZ_DEPRECATE RZ_API void rz_asm_set_core(RZ_NONNULL RzAsm *a, RZ_NULLABLE void *core);
 RZ_DEPRECATE RZ_API RZ_BORROW RzBinBind *rz_asm_get_bin_bind(RzAsm *a);
 RZ_DEPRECATE RZ_API int rz_asm_set_bits(RzAsm *a, int bits);
 RZ_DEPRECATE RZ_API int rz_asm_get_bits(RZ_NONNULL RzAsm *a);

--- a/librz/include/rz_asm.h
+++ b/librz/include/rz_asm.h
@@ -44,14 +44,16 @@ extern "C" {
 #define RZ_ASM_GET_NAME(x, y, z) \
 	(x && x->binb.bin && x->binb.get_name) ? x->binb.get_name(x->binb.bin, y, z) : NULL
 
-enum {
+typedef enum {
 	RZ_ASM_SYNTAX_NONE = 0,
 	RZ_ASM_SYNTAX_INTEL,
 	RZ_ASM_SYNTAX_ATT,
 	RZ_ASM_SYNTAX_MASM,
 	RZ_ASM_SYNTAX_REGNUM, // alias for capstone's NOREGNAME
 	RZ_ASM_SYNTAX_JZ, // hack to use jz instead of je on x86
-};
+	/* The value below is used for runtime checks */
+	RZ_ASM_ENUM_SIZE
+} RzAsmSyntax;
 
 enum {
 	RZ_ASM_MOD_RAWVALUE = 'r',
@@ -89,42 +91,7 @@ typedef struct {
 	char *value;
 } RzAsmEqu;
 
-#define _RzAsmPlugin struct rz_asm_plugin_t
-typedef struct rz_asm_t {
-	void *core;
-	ut8 ptr_alignment_I;
-	void *plugin_data;
-	ut8 ptr_alignment_II;
-	// NOTE: Do not change the order of fields above!
-	// They are used in pointer passing hacks in rz_types.h.
-	char *cpu;
-	int bits;
-	int big_endian;
-	int syntax;
-	ut64 pc;
-	_RzAsmPlugin *cur;
-	_RzAsmPlugin *acur;
-	HtSP /*<RzAsmPlugin *>*/ *plugins;
-	RzBinBind binb;
-	RzParse *ifilter;
-	RzParse *ofilter;
-	Sdb *pair;
-	RzSyscall *syscall;
-	RzNum *num;
-	RzPath *sdb_opcodes_path; ///< pointer to RzPath, contains path prefix of the system
-	char *features;
-	char *platforms;
-	int invhex; // invalid instructions displayed in hex
-	int pcalign;
-	int dataalign;
-	int bitshift;
-	bool immsign; // Print signed immediates as negative values, not their unsigned representation.
-	bool immdisp; // Display immediates with # symbol (for arm architectures). false = show hashs
-	bool utf8; // Flag for plugins: Use utf-8 characters.
-	HtSS *flags;
-	int seggrn;
-	bool pseudo;
-} RzAsm;
+typedef struct rz_asm_t RzAsm;
 
 typedef struct rz_asm_plugin_t {
 	const char *name;
@@ -170,19 +137,56 @@ RZ_API char *rz_asm_mnemonics(RzAsm *a, int id, bool json);
 RZ_API int rz_asm_mnemonics_byname(RzAsm *a, const char *name);
 RZ_API bool rz_asm_plugin_add(RzAsm *a, RZ_NONNULL RzAsmPlugin *foo);
 RZ_API bool rz_asm_plugin_del(RzAsm *a, RZ_NONNULL RzAsmPlugin *foo);
+RZ_API RZ_OWN RzIterator *rz_asm_plugin_iterator(RZ_NONNULL RzAsm *a);
+RZ_API const RzAsmPlugin *rz_asm_plugin_current(RZ_NONNULL RzAsm *a);
+RZ_API const RzAsmPlugin *rz_asm_plugin_find(RZ_NONNULL RzAsm *a, RZ_NONNULL const char *name);
 RZ_API bool rz_asm_setup(RzAsm *a, const char *arch, int bits, int big_endian);
 RZ_API bool rz_asm_is_valid(RzAsm *a, const char *name);
 RZ_API bool rz_asm_use(RzAsm *a, RZ_NULLABLE const char *name);
 RZ_API bool rz_asm_use_assembler(RzAsm *a, const char *name);
 RZ_API bool rz_asm_set_arch(RzAsm *a, const char *name, int bits);
+RZ_API const char *rz_asm_get_arch(RZ_NONNULL RzAsm *a);
+RZ_API bool rz_asm_is_arch(RZ_NONNULL RzAsm *a, RZ_NONNULL const char *name);
+RZ_DEPRECATE RZ_API RZ_BORROW RzBinBind *rz_asm_get_bin_bind(RzAsm *a);
 RZ_DEPRECATE RZ_API int rz_asm_set_bits(RzAsm *a, int bits);
+RZ_DEPRECATE RZ_API int rz_asm_get_bits(RZ_NONNULL RzAsm *a);
+RZ_DEPRECATE RZ_API bool rz_asm_is_bits(RzAsm *a, int bits);
+RZ_DEPRECATE RZ_API int rz_asm_get_plugin_bits(RZ_NONNULL RzAsm *a);
+RZ_DEPRECATE RZ_API const char *rz_asm_get_plugin_cpus(RZ_NONNULL RzAsm *a);
+RZ_DEPRECATE RZ_API const char *rz_asm_get_plugin_platforms(RZ_NONNULL RzAsm *a);
+RZ_DEPRECATE RZ_API const char *rz_asm_get_plugin_features(RZ_NONNULL RzAsm *a);
+RZ_API RZ_OWN RzConfig *rz_asm_get_new_config(RZ_NONNULL RzAsm *a);
+RZ_API RZ_OWN char *rz_asm_get_sys_opcode_path(RZ_NONNULL RzAsm *a, RZ_NONNULL const char *path);
 RZ_DEPRECATE RZ_API void rz_asm_set_cpu(RzAsm *a, const char *cpu);
+RZ_API const char *rz_asm_get_cpu(RZ_NONNULL RzAsm *a);
+RZ_API void rz_asm_set_platforms(RZ_NONNULL RzAsm *a, RZ_NULLABLE const char *platforms);
+RZ_API const char *rz_asm_get_platforms(RZ_NONNULL RzAsm *a);
+RZ_API void rz_asm_set_features(RZ_NONNULL RzAsm *a, RZ_NULLABLE const char *features);
+RZ_API const char *rz_asm_get_features(RZ_NONNULL RzAsm *a);
+RZ_API void rz_asm_set_pseudo(RZ_NONNULL RzAsm *a, bool enable);
+RZ_API bool rz_asm_get_pseudo(RZ_NONNULL RzAsm *a);
+RZ_API void rz_asm_set_utf8(RZ_NONNULL RzAsm *a, bool utf8);
+RZ_API bool rz_asm_get_utf8(RZ_NONNULL RzAsm *a);
+RZ_API void rz_asm_set_segment_granularity(RZ_NONNULL RzAsm *a, int seggrn);
+RZ_API int rz_asm_get_segment_granularity(RZ_NONNULL RzAsm *a);
+RZ_API void rz_asm_set_pc_align(RZ_NONNULL RzAsm *a, ut32 pc_align);
+RZ_API ut32 rz_asm_get_pc_align(RZ_NONNULL RzAsm *a);
+RZ_API void rz_asm_set_syscall(RZ_NONNULL RzAsm *a, RzSyscall *syscall);
+RZ_API RzSyscall *rz_asm_get_syscall(RZ_NONNULL RzAsm *a);
+RZ_API void rz_asm_set_invalid_as_hex_flag(RZ_NONNULL RzAsm *a, bool invhex);
+RZ_API bool rz_asm_get_invalid_as_hex_flag(RZ_NONNULL RzAsm *a);
+RZ_API void rz_asm_set_show_immediate_hashtag(RZ_NONNULL RzAsm *a, bool show);
+RZ_API bool rz_asm_get_show_immediate_hashtag(RZ_NONNULL RzAsm *a);
 RZ_API ut32 rz_asm_get_endianness(RzAsm *a);
+RZ_API bool rz_asm_is_big_endian_set(RZ_NONNULL RzAsm *a);
 RZ_API bool rz_asm_support_endianness(RzAsm *a, ut32 endian);
 RZ_API bool rz_asm_set_big_endian(RzAsm *a, bool big_endian);
-RZ_API bool rz_asm_set_syntax(RzAsm *a, int syntax);
+RZ_API void rz_asm_set_syntax(RZ_NONNULL RzAsm *a, RzAsmSyntax syntax);
+RZ_API RzAsmSyntax rz_asm_get_syntax(RZ_NONNULL RzAsm *a);
+RZ_API bool rz_asm_is_syntax(RZ_NONNULL RzAsm *a, RzAsmSyntax syntax);
 RZ_API int rz_asm_syntax_from_string(const char *name);
-RZ_API int rz_asm_set_pc(RzAsm *a, ut64 pc);
+RZ_API void rz_asm_set_pc(RZ_NONNULL RzAsm *a, ut64 pc);
+RZ_API ut64 rz_asm_get_pc(RZ_NONNULL RzAsm *a);
 RZ_API int rz_asm_disassemble(RzAsm *a, RzAsmOp *op, const ut8 *buf, int len);
 RZ_API int rz_asm_assemble(RzAsm *a, RzAsmOp *op, const char *buf);
 RZ_API bool rz_asm_software_breakpoint(RZ_NONNULL RzAsm *a, RZ_NONNULL RzAsmOp *op);
@@ -196,6 +200,7 @@ RZ_API ut8 *rz_asm_from_string(RzAsm *a, ut64 addr, const char *b, int *l);
 RZ_API int rz_asm_sub_names_input(RzAsm *a, const char *f);
 RZ_API int rz_asm_sub_names_output(RzAsm *a, const char *f);
 RZ_API char *rz_asm_describe(RzAsm *a, const char *str);
+RZ_API void rz_asm_describe_iterate(RZ_NONNULL RzAsm *a, RZ_NONNULL SdbForeachCallback cb, RZ_NULLABLE void *user);
 RZ_API RZ_BORROW HtSP /*<RzAsmPlugin *>*/ *rz_asm_get_plugins(RZ_BORROW RZ_NONNULL RzAsm *a);
 RZ_API void rz_asm_list_directives(void);
 

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -930,7 +930,6 @@ RZ_API RzBuffer *rz_core_syscallf(RzCore *core, const char *name, const char *fm
 RZ_API RzCoreAsmHit *rz_core_asm_hit_new(void);
 RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_hit_list_new(void);
 RZ_API void rz_core_asm_hit_free(void *_hit);
-RZ_API void rz_core_set_asm_configs(RzCore *core, char *arch, ut32 bits, int segoff);
 RZ_API char *rz_core_asm_search(RzCore *core, const char *input);
 RZ_API RzCmdStatus rz_core_asm_plugins_print(RZ_NONNULL RZ_BORROW RzCore *core, RZ_OUT RzCmdStateOutput *state, RZ_NULLABLE const char *flags);
 RZ_API RzCmdStatus rz_core_asm_cpu_plugin_print(RZ_NONNULL RZ_BORROW RzCore *core, RZ_OUT RzCmdStateOutput *state, RZ_NULLABLE const char *arch_name);

--- a/librz/include/rz_types.h
+++ b/librz/include/rz_types.h
@@ -745,7 +745,7 @@ static inline void /*<RzAsm>*/ *rz_analysis_to_rz_asm(RZ_NONNULL void /*<RzAnaly
  * \brief The hacky way to get the RzAnalysis pointer from RzAsm.
  * Will be removed with the RzArch refactor.
  */
-static inline void /*<RzAnalysis>*/ *rz_asm_to_rz_analysis(RZ_NONNULL void /*<RzAsm>*/ *rz_asm) {
+static inline void /*<RzAnalysis>*/ *rz_asm_to_rz_analysis(RZ_NONNULL const void /*<RzAsm>*/ *rz_asm) {
 	assert(rz_asm && "This function can only be used if RzAnalysis and RzAsm were set up before.");
 	struct dummy_rz_asm_t *rasm = (struct dummy_rz_asm_t *)rz_asm;
 	struct dummy_rz_core_t *core = (struct dummy_rz_core_t *)rasm->core;

--- a/librz/main/rz-asm.c
+++ b/librz/main/rz-asm.c
@@ -17,6 +17,7 @@ typedef struct {
 	RzLib *l;
 	RzAsm *a;
 	RzAnalysis *analysis;
+	RzPath *sys_path;
 	bool oneliner;
 	bool coutput;
 	bool json;
@@ -35,26 +36,23 @@ static void __as_set_archbits(RzAsmState *as) {
 
 static RzAsmState *__as_new(void) {
 	RzAsmState *as = RZ_NEW0(RzAsmState);
-	if (as) {
-		as->l = rz_lib_new(NULL, NULL);
-		as->a = rz_asm_new();
-		if (as->a) {
-			as->a->num = rz_num_new(NULL, NULL, NULL);
-		}
-		as->analysis = rz_analysis_new(NULL);
-		__load_plugins(as);
-		__as_set_archbits(as);
+	if (!as) {
+		return NULL;
 	}
+	as->l = rz_lib_new(NULL, NULL);
+	as->a = rz_asm_new();
+	as->analysis = rz_analysis_new(NULL);
+	as->sys_path = rz_path_new();
+	__load_plugins(as);
+	__as_set_archbits(as);
 	return as;
 }
 
 static void __as_free(RzAsmState *as) {
-	if (as->a) {
-		rz_num_free(as->a->num);
-	}
 	rz_asm_free(as->a);
 	rz_analysis_free(as->analysis);
 	rz_lib_free(as->l);
+	rz_path_free(as->sys_path);
 	free(as);
 }
 
@@ -69,7 +67,7 @@ static char *stackop2str(int type) {
 	return rz_str_dup("unknown");
 }
 
-static void showanalysis(RzAsmState *as, RzAnalysisOp *op, ut64 offset, ut8 *buf, int len, PJ *pj) {
+static void print_analysis_info(RzAsmState *as, RzAnalysisOp *op, ut64 offset, ut8 *buf, int len, PJ *pj) {
 	char *stackop = stackop2str(op->stackop);
 	const char *optype = rz_analysis_optype_to_string(op->type);
 	char *bytes = rz_hex_bin2strdup(buf, RZ_MIN(len, op->size));
@@ -120,7 +118,7 @@ static void showanalysis(RzAsmState *as, RzAnalysisOp *op, ut64 offset, ut8 *buf
 }
 
 // TODO: add israw/len
-static int show_analinfo(RzAsmState *as, const char *arg, ut64 offset) {
+static int show_analisys_info(RzAsmState *as, const char *arg, ut64 offset) {
 	ut8 *buf = (ut8 *)rz_str_dup((const char *)arg);
 	int ret, len = rz_hex_str2bin((char *)buf, buf);
 	PJ *pj = NULL;
@@ -155,7 +153,7 @@ static int show_analinfo(RzAsmState *as, const char *arg, ut64 offset) {
 			}
 			break;
 		}
-		showanalysis(as, &aop, offset, buf + ret, len - ret, pj);
+		print_analysis_info(as, &aop, offset, buf + ret, len - ret, pj);
 		ret += aop.size;
 		rz_analysis_op_fini(&aop);
 	}
@@ -274,12 +272,12 @@ error_vm:
 	return ret;
 }
 
-static int rasm_disasm(RzAsmState *as, ut64 addr, const char *buf, int len, int bits, int bin, DisasmMode mode) {
+static int print_disassembly_output(RzAsmState *as, ut64 addr, const char *buf, int len, int bin, DisasmMode mode) {
 	RzAsmCode *acode;
 	ut8 *data = NULL;
 	int ret = 0;
 	ut64 clen = 0;
-	if (bits == 1) {
+	if (rz_asm_is_bits(as->a, 1)) {
 		len /= 8;
 	}
 	if (bin) {
@@ -353,8 +351,9 @@ static int rasm_disasm(RzAsmState *as, ut64 addr, const char *buf, int len, int 
 				rz_asm_op_set_asm(&op, "invalid");
 			}
 			char *op_hex = rz_asm_op_get_hex(&op);
+			ut64 pc = rz_asm_get_pc(as->a);
 			printf("0x%08" PFMT64x "  %2d %24s  %s\n",
-				as->a->pc, op.size, op_hex,
+				pc, op.size, op_hex,
 				rz_asm_op_get_asm(&op));
 			free(op_hex);
 			ret += op.size;
@@ -403,7 +402,7 @@ static void print_buf(RzAsmState *as, char *str) {
 	}
 }
 
-static int rasm_asm(RzAsmState *as, const char *buf, ut64 offset, ut64 len, int bits, int bin, bool use_spp, bool hexwords) {
+static int print_assembly_output(RzAsmState *as, const char *buf, ut64 offset, ut64 len, int bin, bool use_spp, bool hexwords) {
 	RzAsmCode *acode;
 	int i, j, ret = 0;
 	rz_asm_set_pc(as->a, offset);
@@ -420,7 +419,7 @@ static int rasm_asm(RzAsmState *as, const char *buf, ut64 offset, ut64 len, int 
 			}
 		} else {
 			int b = acode->len;
-			if (bits == 1) {
+			if (rz_asm_is_bits(as->a, 1)) {
 				int bytes = (b / 8) + 1;
 				for (i = 0; i < bytes; i++) {
 					for (j = 0; j < 8 && b--; j++) {
@@ -487,11 +486,6 @@ static bool lib_arch_cb(RzLibPlugin *pl, void *user, void *data) {
 	return true;
 }
 
-static int print_assembly_output(RzAsmState *as, const char *buf, ut64 offset, ut64 len, int bits,
-	int bin, bool use_spp, bool hexwords, const char *arch) {
-	return rasm_asm(as, (char *)buf, offset, len, as->a->bits, bin, use_spp, hexwords);
-}
-
 static void __load_plugins(RzAsmState *as) {
 	char *tmp = rz_sys_getenv("RZ_NOPLUGINS");
 	if (tmp) {
@@ -508,7 +502,7 @@ static void __load_plugins(RzAsmState *as) {
 	}
 
 	char *homeplugindir = rz_path_home_prefix(RZ_PLUGINS);
-	char *sysplugindir = rz_path_system(as->a->sdb_opcodes_path, RZ_PLUGINS);
+	char *sysplugindir = rz_asm_get_sys_opcode_path(as->a, RZ_PLUGINS);
 	char *extraplugindir = rz_path_extra(RZ_PLUGINS);
 	rz_lib_opendir(as->l, homeplugindir, false);
 	rz_lib_opendir(as->l, sysplugindir, false);
@@ -683,12 +677,7 @@ RZ_API int rz_main_rz_asm(int argc, const char *argv[]) {
 			if (as->quiet) {
 				printf("%s\n", RZ_VERSION);
 			} else {
-				RzPath *sys_path = rz_path_new();
-				if (!sys_path) {
-					goto beach;
-				}
-				ret = rz_main_version_print(sys_path, "rz-asm");
-				rz_path_free(sys_path);
+				ret = rz_main_version_print(as->sys_path, "rz-asm");
 			}
 			goto beach;
 		}
@@ -731,8 +720,9 @@ RZ_API int rz_main_rz_asm(int argc, const char *argv[]) {
 	rz_analysis_set_cpu(as->analysis, cpu);
 	rz_asm_set_bits(as->a, (env_bits && *env_bits) ? atoi(env_bits) : bits);
 	rz_analysis_set_bits(as->analysis, (env_bits && *env_bits) ? atoi(env_bits) : bits);
-	as->a->syscall = rz_syscall_new();
-	rz_syscall_setup(as->a->syscall, as->a->sdb_opcodes_path, arch, bits, cpu, kernel);
+	RzSyscall *sysc = rz_syscall_new();
+	rz_syscall_setup(sysc, as->sys_path, arch, bits, cpu, kernel);
+	rz_asm_set_syscall(as->a, sysc);
 	{
 		bool canbebig = rz_asm_set_big_endian(as->a, isbig);
 		if (isbig && !canbebig) {
@@ -787,12 +777,12 @@ RZ_API int rz_main_rz_asm(int argc, const char *argv[]) {
 						length -= skip;
 					}
 				}
-				ret = rasm_disasm(as, offset, (char *)buf, len, as->a->bits, bin, dis);
+				ret = print_disassembly_output(as, offset, (char *)buf, len, bin, dis);
 			} else if (analinfo) {
-				ret = show_analinfo(as, (const char *)buf, offset);
+				ret = show_analisys_info(as, (const char *)buf, offset);
 			} else {
 				ret = print_assembly_output(as, (char *)buf, offset, len,
-					as->a->bits, bin, use_spp, hexwords, arch);
+					bin, use_spp, hexwords);
 			}
 			ret = !ret;
 			free(buf);
@@ -814,13 +804,12 @@ RZ_API int rz_main_rz_asm(int argc, const char *argv[]) {
 						}
 					}
 					if (dis) {
-						ret = rasm_disasm(as, offset, content,
-							length, as->a->bits, bin, dis);
+						ret = print_disassembly_output(as, offset, content, length, bin, dis);
 					} else if (analinfo) {
-						ret = show_analinfo(as, (const char *)content, offset);
+						ret = show_analisys_info(as, (const char *)content, offset);
 					} else {
 						ret = print_assembly_output(as, content, offset, length,
-							as->a->bits, bin, use_spp, hexwords, arch);
+							bin, use_spp, hexwords);
 					}
 					ret = !ret;
 				}
@@ -859,11 +848,11 @@ RZ_API int rz_main_rz_asm(int argc, const char *argv[]) {
 					}
 				}
 				if (dis) {
-					ret = rasm_disasm(as, offset, (char *)buf, length, as->a->bits, bin, dis);
+					ret = print_disassembly_output(as, offset, (char *)buf, length, bin, dis);
 				} else if (analinfo) {
-					ret = show_analinfo(as, (const char *)buf, offset);
+					ret = show_analisys_info(as, (const char *)buf, offset);
 				} else {
-					ret = rasm_asm(as, (const char *)buf, offset, length, as->a->bits, bin, use_spp, hexwords);
+					ret = print_assembly_output(as, (const char *)buf, offset, length, bin, use_spp, hexwords);
 				}
 				idx += ret;
 				offset += ret;
@@ -899,13 +888,13 @@ RZ_API int rz_main_rz_asm(int argc, const char *argv[]) {
 			if (!strncmp(usrstr, "0x", 2)) {
 				memmove(usrstr, usrstr + 2, strlen(usrstr + 2) + 1);
 			}
-			ret = rasm_disasm(as, offset, (char *)usrstr, len, as->a->bits, bin, dis);
+			ret = print_disassembly_output(as, offset, (char *)usrstr, len, bin, dis);
 			free(usrstr);
 		} else if (analinfo) {
-			ret = show_analinfo(as, (const char *)opt.argv[opt.ind], offset);
+			ret = show_analisys_info(as, (const char *)opt.argv[opt.ind], offset);
 		} else {
-			ret = print_assembly_output(as, opt.argv[opt.ind], offset, len, as->a->bits,
-				bin, use_spp, hexwords, arch);
+			ret = print_assembly_output(as, opt.argv[opt.ind], offset, len,
+				bin, use_spp, hexwords);
 		}
 		ret = !ret;
 	}

--- a/test/db/analysis/arm
+++ b/test/db/analysis/arm
@@ -1295,7 +1295,7 @@ e search.in=io.maps
 afl~?
 EOF
 EXPECT=<<EOF
-94
+115
 EOF
 RUN
 

--- a/test/db/analysis/h8300
+++ b/test/db/analysis/h8300
@@ -89,8 +89,7 @@ EXPECT=<<EOF
 0x00000834    3 40           dbg.st_led_is_on
 0x0000085c    4 42           dbg.st_led_color
 0x00000886    6 142          dbg.st_ssu_out
-0x00000914    1 31           dbg.st_ssu_out_singleton
-0x00000933    3 63           fcn.00000933
+0x00000914    3 94           dbg.st_ssu_out_singleton
 0x00000972    1 18           dbg.st_init
 offset: 0x00000478
 name: dbg.main
@@ -358,8 +357,7 @@ EXPECT=<<EOF
 0x00000834    3 40           loc._st_led_is_on
 0x0000085c    4 42           loc._st_led_color
 0x00000886    6 142          loc._st_ssu_out
-0x00000914    1 31           loc._st_ssu_out_singleton
-0x00000933    3 63           fcn.00000933
+0x00000914    3 94           loc._st_ssu_out_singleton
 0x00000972    1 18           loc._st_init
 offset: 0x00000478
 name: entry0

--- a/test/db/analysis/loongarch
+++ b/test/db/analysis/loongarch
@@ -61,7 +61,7 @@ bits     64
 |           0x00007530      move  a4, zero
 |           0x00007534      move  a6, sp
 |           0x00007538      pcalau12i ra, -3
-|           0x0000753c      addi.d t0, zero, 0x340
+|           0x0000753c      addi.d t0, zero, aav.0x00000340
 |           0x00007540      lu32i.d t0, 0
 |           ; DATA XREF from fcn.00016abc @ 0x16abc
 |           0x00007544      lu52i.d t0, t0, 0

--- a/test/db/analysis/m68k
+++ b/test/db/analysis/m68k
@@ -30,9 +30,11 @@ intrp    N/A
 laddr    0x00000000
 lang     N/A
 machine  Sega Megadrive
-minopsz  1
+maxopsz  4
+minopsz  2
 os       smd
 cc       N/A
+pcalign  2
 rpath    N/A
 subsys   
 stripped false

--- a/test/db/analysis/rl78
+++ b/test/db/analysis/rl78
@@ -29,9 +29,11 @@ intrp    N/A
 laddr    0x00000000
 lang     c
 machine  Renesas RL78 family
+maxopsz  5
 minopsz  1
 os       linux
 cc       N/A
+pcalign  1
 rpath    NONE
 subsys   linux
 stripped false

--- a/test/db/analysis/rx
+++ b/test/db/analysis/rx
@@ -35,9 +35,11 @@ intrp    N/A
 laddr    0x00000000
 lang     c
 machine  Renesas RX family
+maxopsz  8
 minopsz  1
 os       linux
 cc       N/A
+pcalign  1
 rpath    NONE
 subsys   linux
 stripped false

--- a/test/db/analysis/snes
+++ b/test/db/analysis/snes
@@ -82,7 +82,7 @@ EXPECT=<<EOF
       addr name         size xrefsTo xrefsFrom calls nbbs edges cc cost noreturn 
 ---------------------------------------------------------------------------------
 0x00008000 entry0        305       0        28    12   12    17  5    0 false
-0x00008131 fcn.00008131   30       1         0     0    5     6  3    0 false
+0x00008131 fcn.00008131   30       1         1     0    5     6  3    0 false
 0x0000814f fcn.0000814f   12       7         1     1    3     3  2    0 false
 0x0000815b fcn.0000815b   62       1         0     0   11    16  7    0 false
 0x00008199 fcn.00008199   24       1         0     0    6     9  5    0 false
@@ -94,7 +94,7 @@ EXPECT=<<EOF
 0x000082ba fcn.000082ba   48       1         0     0    2     2  2    0 false
 0x000082ea fcn.000082ea   28      14         2     0    5     6  3    0 false
 0x00008306 fcn.00008306   45       1         0     0    5     6  3    0 false
-0x00808131 fcn.00808131   30       1         0     0    5     6  3    0 false
+0x00808131 fcn.00808131   30       1         1     0    5     6  3    0 false
 0x0080814f fcn.0080814f   12       7         1     1    3     3  2    0 false
 0x0080815b fcn.0080815b   62       1         0     0   11    16  7    0 false
 0x00808199 fcn.00808199   24       1         0     0    6     9  5    0 false

--- a/test/db/analysis/x86_32
+++ b/test/db/analysis/x86_32
@@ -4072,7 +4072,7 @@ e io.cache=true
 $orig_end=echo `omlt:va_end:quiet`
 omr 1 `omlt:size:quiet`+2
 s `$orig_end`
-wa "jmp entry0"
+wa "jmp 0x08048054"
 aF
 aae
 agf

--- a/test/db/cmd/cmd_pa
+++ b/test/db/cmd/cmd_pa
@@ -9,7 +9,7 @@ pa call test
 EOF
 EXPECT=<<EOF
 ffd0
-e81c000000
+e8fbffffff
 EOF
 RUN
 

--- a/test/db/formats/bflt
+++ b/test/db/formats/bflt
@@ -317,9 +317,11 @@ intrp    N/A
 laddr    0x00000000
 lang     N/A
 machine  unknown
-minopsz  1
+maxopsz  4
+minopsz  2
 os       Linux
 cc       N/A
+pcalign  2
 rpath    N/A
 subsys   uClinux
 stripped false

--- a/test/db/formats/dol
+++ b/test/db/formats/dol
@@ -32,6 +32,7 @@ maxopsz  4
 minopsz  4
 os       wii-ios
 cc       N/A
+pcalign  4
 rpath    N/A
 subsys   
 stripped false

--- a/test/db/formats/ecoff
+++ b/test/db/formats/ecoff
@@ -13464,6 +13464,7 @@ maxopsz  4
 minopsz  4
 os       any
 cc       N/A
+pcalign  4
 rpath    N/A
 subsys   any
 stripped true

--- a/test/db/formats/gbc
+++ b/test/db/formats/gbc
@@ -21,9 +21,11 @@ intrp    N/A
 laddr    0x00000000
 lang     N/A
 machine  GameBoy
+maxopsz  3
 minopsz  1
 os       any
 cc       N/A
+pcalign  1
 rpath    N/A
 subsys   
 stripped false

--- a/test/db/formats/hunk
+++ b/test/db/formats/hunk
@@ -21,9 +21,11 @@ intrp    N/A
 laddr    0x00000000
 lang     N/A
 machine  68000
-minopsz  1
+maxopsz  4
+minopsz  2
 os       AmigaOS
 cc       N/A
+pcalign  2
 rpath    N/A
 subsys   
 stripped false

--- a/test/db/formats/pef
+++ b/test/db/formats/pef
@@ -30,6 +30,7 @@ maxopsz  4
 minopsz  4
 os       Mac OS
 cc       N/A
+pcalign  4
 rpath    N/A
 subsys   
 stripped false

--- a/test/db/formats/prg
+++ b/test/db/formats/prg
@@ -24,9 +24,11 @@ intrp    N/A
 laddr    0x00000000
 lang     N/A
 machine  Commodore 64
+maxopsz  4
 minopsz  1
 os       c64
 cc       N/A
+pcalign  1
 rpath    N/A
 subsys   
 stripped false

--- a/test/db/formats/sfc
+++ b/test/db/formats/sfc
@@ -26,9 +26,11 @@ intrp    N/A
 laddr    0x00000000
 lang     N/A
 machine  Super NES / Super Famicom
+maxopsz  4
 minopsz  1
 os       snes
 cc       N/A
+pcalign  1
 rpath    N/A
 subsys   
 stripped false
@@ -645,9 +647,11 @@ intrp    N/A
 laddr    0x00000000
 lang     N/A
 machine  Super NES / Super Famicom
+maxopsz  4
 minopsz  1
 os       snes
 cc       N/A
+pcalign  1
 rpath    N/A
 subsys   
 stripped false

--- a/test/db/formats/smd
+++ b/test/db/formats/smd
@@ -38,9 +38,11 @@ intrp    N/A
 laddr    0x00000000
 lang     N/A
 machine  Sega Megadrive
-minopsz  1
+maxopsz  4
+minopsz  2
 os       smd
 cc       N/A
+pcalign  2
 rpath    N/A
 subsys   
 stripped false
@@ -75,9 +77,11 @@ intrp    N/A
 laddr    0x00000000
 lang     N/A
 machine  Sega Megadrive
-minopsz  1
+maxopsz  4
+minopsz  2
 os       smd
 cc       N/A
+pcalign  2
 rpath    N/A
 subsys   
 stripped false

--- a/test/db/rzil/xtensa
+++ b/test/db/rzil/xtensa
@@ -11,6 +11,7 @@ aezsu 0x400238
 ps @ obj.seckrit
 EOF
 EXPECT=<<EOF
+            ; UNKNOWN XREF from section..text @ +0x8
             ; DATA XREF from entry0 @ 0x4000d1
 / int main(int argc, char **argv, char **envp);
 |           ; arg int argc @ a2

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -486,10 +486,10 @@ NAME=rz-asm x86_64 overlarge operand
 TOOL=rz-asm
 FILE=mov rax, 0x112233445566778899
 ARGS=-a x86 -b 64
-EXIT_STATUS=1
-EXPECT=
+EXPECT=<<EOF
+48c7c0ffffffff
+EOF
 EXPECT_ERR=<<EOF
-ERROR: Cannot assemble 'mov rax, 0x112233445566778899' at line 3
 EOF
 RUN
 

--- a/test/db/tools/rz_bin
+++ b/test/db/tools/rz_bin
@@ -1360,10 +1360,11 @@ intrp    N/A
 laddr    0x00000000
 lang     c
 machine  mc68030
-minopsz  1
+maxopsz  4
+minopsz  2
 os       darwin
 cc       N/A
-pcalign  1
+pcalign  2
 rpath    N/A
 subsys   unknown
 stripped false

--- a/test/db/tools/rz_bin
+++ b/test/db/tools/rz_bin
@@ -1363,6 +1363,7 @@ machine  mc68030
 minopsz  1
 os       darwin
 cc       N/A
+pcalign  1
 rpath    N/A
 subsys   unknown
 stripped false

--- a/test/unit/test_analysis_op.c
+++ b/test/unit/test_analysis_op.c
@@ -107,7 +107,8 @@ bool test_rz_analysis_op_val() {
 
 bool test_rz_core_analysis_bytes() {
 	RzCore *core = rz_core_new();
-	rz_core_set_asm_configs(core, "x86", 64, 0);
+	rz_core_arch_configure(core, "x86", 64, NULL, NULL, NULL);
+
 	ut8 buf[128];
 	int len = rz_hex_str2bin("554889e5897dfc", buf);
 	RzIterator *iter = rz_core_analysis_bytes(core, core->offset, buf, len, 0);
@@ -132,7 +133,8 @@ bool test_rz_core_analysis_bytes() {
 bool test_rz_core_print_disasm() {
 	RzCore *core = rz_core_new();
 	rz_io_open_at(core->io, "malloc://0x100", RZ_PERM_RX, 0644, 0, NULL); // needed to get arrow info (is_valid_offset checks)
-	rz_core_set_asm_configs(core, "x86", 64, 0);
+	rz_core_arch_configure(core, "x86", 64, NULL, NULL, NULL);
+
 	rz_config_set_b(core->config, "asm.lines", false); // arrow info in struct, but not in textual disasm
 	ut8 buf[128];
 	int len = rz_hex_str2bin("554889e5897dfcebf8", buf);

--- a/test/unit/test_rop.c
+++ b/test/unit/test_rop.c
@@ -73,7 +73,7 @@ static RzCore *setup_rz_core(char *arch, int bits) {
 		return NULL;
 	}
 	rz_io_open_at(core->io, "malloc://0x100", RZ_PERM_RX, 0644, 0, NULL);
-	rz_core_set_asm_configs(core, arch, bits, 0);
+	rz_core_arch_configure(core, "x86", 64, NULL, NULL, NULL);
 	rz_config_set_b(core->config, "asm.lines", false);
 	return core;
 }

--- a/test/unit/test_tokens.c
+++ b/test/unit/test_tokens.c
@@ -316,6 +316,7 @@ static bool test_rz_tokenize_generic_4(void) {
 static bool test_rz_tokenize_custom_hexagon_0(void) {
 	RzAsm *a = setup_hexagon_asm();
 	hexagon_set_next_pc(a);
+	const RzAsmPlugin *cur = rz_asm_plugin_current(a);
 
 	const ut8 buf[] = "\x0c\xc0\x00\x54"; // "[   trap0(#0x3)"
 	RzAsmToken tokens[7] = {
@@ -328,7 +329,7 @@ static bool test_rz_tokenize_custom_hexagon_0(void) {
 		{ .start = 14, .len = 1, .type = RZ_ASM_TOKEN_SEPARATOR, .val.number = 0 } // )
 	};
 	RzAsmOp *op = RZ_NEW0(RzAsmOp);
-	a->cur->disassemble(a, op, buf, sizeof(buf));
+	cur->disassemble(a, op, buf, sizeof(buf));
 	if (!op->asm_toks) {
 		mu_fail("NULL check failed.\n");
 	}
@@ -354,11 +355,12 @@ static bool test_rz_tokenize_custom_hexagon_0(void) {
 static bool test_rz_tokenize_custom_hexagon_issues_tilde(void) {
 	RzAsm *a = setup_hexagon_asm();
 	hexagon_set_next_pc(a);
+	const RzAsmPlugin *cur = rz_asm_plugin_current(a);
 
 	// Check if ~ is an operator
 	const ut8 buf[] = "\x00\xc0\x81\xf1"; // [   R0 = and(R0,~R1)
 	RzAsmOp *op = RZ_NEW0(RzAsmOp);
-	a->cur->disassemble(a, op, buf, sizeof(buf));
+	cur->disassemble(a, op, buf, sizeof(buf));
 	if (!op->asm_toks) {
 		mu_fail("NULL check failed.\n");
 	}
@@ -378,11 +380,12 @@ static bool test_rz_tokenize_custom_hexagon_issues_tilde(void) {
 static bool test_rz_tokenize_custom_hexagon_issues_long_reg(void) {
 	RzAsm *a = setup_hexagon_asm();
 	hexagon_set_next_pc(a);
+	const RzAsmPlugin *cur = rz_asm_plugin_current(a);
 
 	// Check if BRKPTPC0 is a register
 	const ut8 buf[] = "\x24\xc0\x01\x67"; // [   BRKPTPC0 = R1
 	RzAsmOp *op = RZ_NEW0(RzAsmOp);
-	a->cur->disassemble(a, op, buf, sizeof(buf));
+	cur->disassemble(a, op, buf, sizeof(buf));
 	if (!op->asm_toks) {
 		mu_fail("NULL check failed.\n");
 	}
@@ -615,9 +618,6 @@ static bool test_rz_colorize_generic_4(void) {
 
 static bool test_rz_colorize_custom_hexagon_0(void) {
 	RzAsm *d = setup_hexagon_asm();
-	struct dummy_rz_core_t core = { 0 };
-	core.rasm = d;
-	d->core = &core;
 
 	RzPrint *p = setup_print();
 	RzAsmOp *asmop = rz_asm_op_new();
@@ -647,9 +647,6 @@ static bool test_rz_colorize_custom_hexagon_0(void) {
 
 static bool test_rz_colorize_custom_hexagon_1(void) {
 	RzAsm *d = setup_hexagon_asm();
-	struct dummy_rz_core_t core = { 0 };
-	core.rasm = d;
-	d->core = &core;
 
 	RzPrint *p = setup_print();
 	RzAsmOp *asmop = rz_asm_op_new();
@@ -677,10 +674,7 @@ static bool test_rz_colorize_custom_hexagon_1(void) {
 
 static bool test_rz_colorize_custom_hexagon_2(void) {
 	RzAsm *d = setup_hexagon_asm();
-	d->utf8 = true;
-	struct dummy_rz_core_t core = { 0 };
-	core.rasm = d;
-	d->core = &core;
+	rz_asm_set_utf8(d, true);
 
 	RzPrint *p = setup_print();
 	RzAsmOp asmop = { 0 };
@@ -721,10 +715,7 @@ static bool test_rz_colorize_custom_hexagon_2(void) {
 
 static bool test_rz_colorize_custom_hexagon_3(void) {
 	RzAsm *d = setup_hexagon_asm();
-	d->utf8 = true;
-	struct dummy_rz_core_t core = { 0 };
-	core.rasm = d;
-	d->core = &core;
+	rz_asm_set_utf8(d, true);
 
 	RzPrint *p = setup_print();
 	RzAsmOp asmop = { 0 };
@@ -817,6 +808,7 @@ static bool test_rz_tokenize_custom_bf_0(void) {
 
 static bool test_rz_tokenize_custom_mcs96_0(void) {
 	RzAsm *a = setup_mcs96_asm(NULL);
+	const RzAsmPlugin *cur = rz_asm_plugin_current(a);
 
 	// "add 0x03 0x02 0x01"
 	const ut8 buf[] = "\x44\x01\x02\x03";
@@ -831,7 +823,7 @@ static bool test_rz_tokenize_custom_mcs96_0(void) {
 	};
 
 	RzAsmOp *op = RZ_NEW0(RzAsmOp);
-	a->cur->disassemble(a, op, buf, sizeof(buf));
+	cur->disassemble(a, op, buf, sizeof(buf));
 	if (!op->asm_toks) {
 		mu_fail("NULL check failed.\n");
 	}
@@ -855,6 +847,7 @@ static bool test_rz_tokenize_custom_mcs96_0(void) {
 
 static bool test_rz_tokenize_custom_mcs96_1(void) {
 	RzAsm *a = setup_mcs96_asm(NULL);
+	const RzAsmPlugin *cur = rz_asm_plugin_current(a);
 
 	// "add 0x02 [0x00]" - indirect addressing with brackets
 	const ut8 buf[] = "\x66\x00\x02";
@@ -869,7 +862,7 @@ static bool test_rz_tokenize_custom_mcs96_1(void) {
 	};
 
 	RzAsmOp *op = RZ_NEW0(RzAsmOp);
-	a->cur->disassemble(a, op, buf, sizeof(buf));
+	cur->disassemble(a, op, buf, sizeof(buf));
 	if (!op->asm_toks) {
 		mu_fail("NULL check failed.\n");
 	}
@@ -893,6 +886,7 @@ static bool test_rz_tokenize_custom_mcs96_1(void) {
 
 static bool test_rz_tokenize_custom_mcs96_2(void) {
 	RzAsm *a = setup_mcs96_asm(NULL);
+	const RzAsmPlugin *cur = rz_asm_plugin_current(a);
 
 	// "add 0x02 [0x00]+" - indirect addressing with brackets
 	const ut8 buf[] = "\x66\x01\x02";
@@ -908,7 +902,7 @@ static bool test_rz_tokenize_custom_mcs96_2(void) {
 	};
 
 	RzAsmOp *op = RZ_NEW0(RzAsmOp);
-	a->cur->disassemble(a, op, buf, sizeof(buf));
+	cur->disassemble(a, op, buf, sizeof(buf));
 	if (!op->asm_toks) {
 		mu_fail("NULL check failed.\n");
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

To move towards RzArch we need to make the code less dependant on RzAsm internals and instead define the API to get/set internal values.