### PR TITLE
bin/nes: implement iH header structure

### DIFF
--- a/librz/bin/format/nes/nes_specs.h
+++ b/librz/bin/format/nes/nes_specs.h
@@ -10,7 +10,7 @@
 
 #define PRG_PAGE_SIZE 0x4000
 #define CHR_PAGE_SIZE 0x2000
-#define INES_HDR_SIZE sizeof(ines_hdr)
+#define INES_HDR_SIZE 16
 
 #define RAM_START_ADDRESS 0x0000
 #define RAM_SIZE          0x0800
@@ -65,16 +65,14 @@
 #define JOYPAD_PORT1 0x4016
 #define JOYPAD_PORT2 0x4017
 
-RZ_PACKED(
-	typedef struct {
-		char id[0x4]; // NES\x1A
-		ut8 prg_page_count_16k; // number of PRG-ROM pages
-		ut8 chr_page_count_8k; // number of CHR-ROM pages
-		ut8 rom_control_byte_0; // flags describing ROM image
-		ut8 rom_control_byte_1; // flags describing ROM image
-		ut8 ram_bank_count_8k; // size of PRG RAM
-		ut8 reserved[7]; // zero filled
-	})
-ines_hdr;
+typedef struct {
+	char id[0x4]; // NES\x1A
+	ut8 prg_page_count_16k; // number of PRG-ROM pages
+	ut8 chr_page_count_8k; // number of CHR-ROM pages
+	ut8 rom_control_byte_0; // flags describing ROM image
+	ut8 rom_control_byte_1; // flags describing ROM image
+	ut8 ram_bank_count_8k; // size of PRG RAM
+	ut8 reserved[7]; // zero filled
+} ines_hdr;
 
 #endif // _NES_H

--- a/librz/bin/format/nes/nes_specs.h
+++ b/librz/bin/format/nes/nes_specs.h
@@ -12,6 +12,12 @@
 #define CHR_PAGE_SIZE 0x2000
 #define INES_HDR_SIZE 16
 
+#define INES_MAPPER(cb0, cb1)        (((cb1) & 0xF0) | ((cb0) >> 4))
+#define INES_MIRROR(cb0)             ((cb0) & 1)
+#define INES_BATTERY(cb0)            ((cb0) & 2)
+#define INES_TRAINER(cb0)            ((cb0) & 4)
+#define INES_ALT_NAMETABLE(cb0)      ((cb0) & 8)
+
 #define RAM_START_ADDRESS 0x0000
 #define RAM_SIZE          0x0800
 

--- a/librz/bin/format/nes/nes_specs.h
+++ b/librz/bin/format/nes/nes_specs.h
@@ -12,11 +12,11 @@
 #define CHR_PAGE_SIZE 0x2000
 #define INES_HDR_SIZE 16
 
-#define INES_MAPPER(cb0, cb1)        (((cb1) & 0xF0) | ((cb0) >> 4))
-#define INES_MIRROR(cb0)             ((cb0) & 1)
-#define INES_BATTERY(cb0)            ((cb0) & 2)
-#define INES_TRAINER(cb0)            ((cb0) & 4)
-#define INES_ALT_NAMETABLE(cb0)      ((cb0) & 8)
+#define INES_MAPPER(cb0, cb1)   (((cb1) & 0xF0) | ((cb0) >> 4))
+#define INES_MIRROR(cb0)        ((cb0) & 1)
+#define INES_BATTERY(cb0)       ((cb0) & 2)
+#define INES_TRAINER(cb0)       ((cb0) & 4)
+#define INES_ALT_NAMETABLE(cb0) ((cb0) & 8)
 
 #define RAM_START_ADDRESS 0x0000
 #define RAM_SIZE          0x0800

--- a/librz/bin/p/bin_nes.c
+++ b/librz/bin/p/bin_nes.c
@@ -35,7 +35,7 @@ static void nes_destroy(RzBinFile *bf) {
 	if (!bf || !bf->o || !bf->o->bin_obj) {
 		return;
 	}
-	RZ_FREE(bf->o->bin_obj);
+	free(bf->o->bin_obj);
 }
 
 static RzBinInfo *nes_info(RzBinFile *bf) {
@@ -209,6 +209,7 @@ static RzPVector /*<RzBinMem *>*/ *nes_mem(RzBinFile *bf) {
 	return ret;
 }
 
+// Should be 3 offsets pointed by NMI, RESET, IRQ after mapping && default = 1st CHR
 static RzPVector /*<RzBinAddr *>*/ *nes_entries(RzBinFile *bf) {
 	RzPVector *ret;
 	RzBinAddr *ptr = NULL;

--- a/librz/bin/p/bin_nes.c
+++ b/librz/bin/p/bin_nes.c
@@ -249,7 +249,7 @@ static RzStructuredData *nes_structure(RzBinFile *bf) {
 	rz_structured_data_map_add_unsigned(nes, "prg_size", (ut64)hdr->prg_page_count_16k * PRG_PAGE_SIZE, true);
 	rz_structured_data_map_add_unsigned(nes, "chr_size", (ut64)hdr->chr_page_count_8k * CHR_PAGE_SIZE, true);
 	rz_structured_data_map_add_unsigned(nes, "mapper", INES_MAPPER(hdr->rom_control_byte_0, hdr->rom_control_byte_1), true);
-	rz_structured_data_map_add_boolean(nes, "mirror", INES_MIRROR(hdr->rom_control_byte_0) != 0);
+	rz_structured_data_map_add_string(nes, "mirroring", INES_MIRROR(hdr->rom_control_byte_0) ? "vertical" : "horizontal");
 	rz_structured_data_map_add_boolean(nes, "battery", INES_BATTERY(hdr->rom_control_byte_0) != 0);
 	rz_structured_data_map_add_boolean(nes, "trainer", INES_TRAINER(hdr->rom_control_byte_0) != 0);
 	rz_structured_data_map_add_boolean(nes, "alternative_nametable_layout", INES_ALT_NAMETABLE(hdr->rom_control_byte_0) != 0);

--- a/librz/bin/p/bin_nes.c
+++ b/librz/bin/p/bin_nes.c
@@ -248,11 +248,11 @@ static RzStructuredData *nes_structure(RzBinFile *bf) {
 	rz_structured_data_map_add_unsigned(nes, "chr_pages", hdr->chr_page_count_8k, false);
 	rz_structured_data_map_add_unsigned(nes, "prg_size", (ut64)hdr->prg_page_count_16k * PRG_PAGE_SIZE, true);
 	rz_structured_data_map_add_unsigned(nes, "chr_size", (ut64)hdr->chr_page_count_8k * CHR_PAGE_SIZE, true);
-	rz_structured_data_map_add_unsigned(nes, "mapper", ((hdr->rom_control_byte_1 & 0xF0) | (hdr->rom_control_byte_0 >> 4)), true);
-	rz_structured_data_map_add_boolean(nes, "mirror", (hdr->rom_control_byte_0 & 1) != 0);
-	rz_structured_data_map_add_boolean(nes, "battery", (hdr->rom_control_byte_0 & 2) != 0);
-	rz_structured_data_map_add_boolean(nes, "trainer", (hdr->rom_control_byte_0 & 4) != 0);
-	rz_structured_data_map_add_boolean(nes, "four_screen", (hdr->rom_control_byte_0 & 8) != 0);
+	rz_structured_data_map_add_unsigned(nes, "mapper", INES_MAPPER(hdr->rom_control_byte_0, hdr->rom_control_byte_1), true);
+	rz_structured_data_map_add_boolean(nes, "mirror", INES_MIRROR(hdr->rom_control_byte_0) != 0);
+	rz_structured_data_map_add_boolean(nes, "battery", INES_BATTERY(hdr->rom_control_byte_0) != 0);
+	rz_structured_data_map_add_boolean(nes, "trainer", INES_TRAINER(hdr->rom_control_byte_0) != 0);
+	rz_structured_data_map_add_boolean(nes, "alternative_nametable_layout", INES_ALT_NAMETABLE(hdr->rom_control_byte_0) != 0);
 	rz_structured_data_map_add_unsigned(nes, "ram_banks", hdr->ram_bank_count_8k, false);
 	return info;
 }

--- a/librz/bin/p/bin_nes.c
+++ b/librz/bin/p/bin_nes.c
@@ -5,7 +5,7 @@
 #include <rz_lib.h>
 #include "nes/nes_specs.h"
 
-static bool check_buffer(RzBuffer *b) {
+static bool nes_check_buffer(RzBuffer *b) {
 	if (rz_buf_size(b) > 4) {
 		ut8 buf[4];
 		rz_buf_read_at(b, 0, buf, sizeof(buf));
@@ -14,20 +14,33 @@ static bool check_buffer(RzBuffer *b) {
 	return false;
 }
 
-static bool load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb) {
-	return check_buffer(buf);
+static bool nes_load_buffer(RzBinFile *bf, RzBinObject *obj, RzBuffer *buf, Sdb *sdb) {
+	ines_hdr *hdr = RZ_NEW0(ines_hdr);
+	if (!hdr) {
+		return false;
+	}
+	if (rz_buf_read_at(buf, 0, (ut8 *)hdr, INES_HDR_SIZE) != INES_HDR_SIZE) {
+		free(hdr);
+		return false;
+	}
+	if (memcmp(hdr->id, INES_MAGIC, 4)) {
+		free(hdr);
+		return false;
+	}
+	obj->bin_obj = hdr;
+	return true;
 }
 
-static RzBinInfo *info(RzBinFile *bf) {
-	RzBinInfo *ret = NULL;
-	ines_hdr ihdr;
-	memset(&ihdr, 0, INES_HDR_SIZE);
-	int reat = rz_buf_read_at(bf->buf, 0, (ut8 *)&ihdr, INES_HDR_SIZE);
-	if (reat != INES_HDR_SIZE) {
-		RZ_LOG_ERROR("Truncated Header\n");
-		return NULL;
+static void nes_destroy(RzBinFile *bf) {
+	if (!bf || !bf->o || !bf->o->bin_obj) {
+		return;
 	}
-	if (!(ret = RZ_NEW0(RzBinInfo))) {
+	RZ_FREE(bf->o->bin_obj);
+}
+
+static RzBinInfo *nes_info(RzBinFile *bf) {
+	RzBinInfo *ret = RZ_NEW0(RzBinInfo);
+	if (!ret) {
 		return NULL;
 	}
 	ret->file = rz_str_dup(bf->file);
@@ -52,7 +65,7 @@ static void addsym(RzPVector /*<RzBinSymbol *>*/ *ret, const char *name, ut64 ad
 	rz_pvector_push(ret, ptr);
 }
 
-static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
+static RzPVector /*<RzBinSymbol *>*/ *nes_symbols(RzBinFile *bf) {
 	RzPVector *ret = NULL;
 	if (!(ret = rz_pvector_new((RzPVectorFree)rz_bin_symbol_free))) {
 		return NULL;
@@ -82,28 +95,25 @@ static RzPVector /*<RzBinSymbol *>*/ *symbols(RzBinFile *bf) {
 	return ret;
 }
 
-static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
-	RzPVector *ret = NULL;
-	RzBinSection *ptr = NULL;
-	ines_hdr ihdr;
-	memset(&ihdr, 0, INES_HDR_SIZE);
-	int reat = rz_buf_read_at(bf->buf, 0, (ut8 *)&ihdr, INES_HDR_SIZE);
-	if (reat != INES_HDR_SIZE) {
-		RZ_LOG_ERROR("Truncated Header\n");
+static RzPVector /*<RzBinSection *>*/ *nes_sections(RzBinFile *bf) {
+	const ines_hdr *hdr = bf->o->bin_obj;
+	if (!hdr) {
 		return NULL;
 	}
-	if (!(ret = rz_pvector_new(NULL))) {
+	RzPVector *ret = rz_pvector_new(NULL);
+	if (!ret) {
 		return NULL;
 	}
-	if (!(ptr = RZ_NEW0(RzBinSection))) {
+	RzBinSection *ptr = RZ_NEW0(RzBinSection);
+	if (!ptr) {
 		return ret;
 	}
 	ptr->name = rz_str_dup("ROM");
 	ptr->paddr = INES_HDR_SIZE;
-	ptr->size = ihdr.prg_page_count_16k * PRG_PAGE_SIZE;
-	bool mirror = ROM_START_ADDRESS + ptr->size <= ROM_MIRROR_ADDRESS; // not a 256bit ROM, mapper 0 mirrors the complete ROM in this case
+	ptr->size = hdr->prg_page_count_16k * PRG_PAGE_SIZE;
+	bool mirror = ROM_START_ADDRESS + ptr->size <= ROM_MIRROR_ADDRESS;
 	ptr->vaddr = ROM_START_ADDRESS;
-	ptr->vsize = mirror ? ROM_MIRROR_ADDRESS - ROM_START_ADDRESS : ROM_SIZE; // make sure the ROM zero excess does not overlap the mirror
+	ptr->vsize = mirror ? ROM_MIRROR_ADDRESS - ROM_START_ADDRESS : ROM_SIZE;
 	ptr->perm = RZ_PERM_RX;
 	rz_pvector_push(ret, ptr);
 	if (mirror) {
@@ -112,7 +122,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 		}
 		ptr->name = rz_str_dup("ROM_MIRROR");
 		ptr->paddr = INES_HDR_SIZE;
-		ptr->size = ihdr.prg_page_count_16k * PRG_PAGE_SIZE;
+		ptr->size = hdr->prg_page_count_16k * PRG_PAGE_SIZE;
 		ptr->vaddr = ROM_MIRROR_ADDRESS;
 		ptr->vsize = ROM_MIRROR_SIZE;
 		ptr->perm = RZ_PERM_RX;
@@ -121,7 +131,7 @@ static RzPVector /*<RzBinSection *>*/ *sections(RzBinFile *bf) {
 	return ret;
 }
 
-static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
+static RzPVector /*<RzBinMem *>*/ *nes_mem(RzBinFile *bf) {
 	RzPVector *ret;
 	RzBinMem *m, *n;
 	if (!(ret = rz_pvector_new(rz_bin_mem_free))) {
@@ -199,7 +209,7 @@ static RzPVector /*<RzBinMem *>*/ *mem(RzBinFile *bf) {
 	return ret;
 }
 
-static RzPVector /*<RzBinAddr *>*/ *entries(RzBinFile *bf) { // Should be 3 offsets pointed by NMI, RESET, IRQ after mapping && default = 1st CHR
+static RzPVector /*<RzBinAddr *>*/ *nes_entries(RzBinFile *bf) {
 	RzPVector *ret;
 	RzBinAddr *ptr = NULL;
 	if (!(ret = rz_pvector_new(NULL))) {
@@ -214,9 +224,36 @@ static RzPVector /*<RzBinAddr *>*/ *entries(RzBinFile *bf) { // Should be 3 offs
 	return ret;
 }
 
-static ut64 baddr(RzBinFile *bf) {
-	// having this we make rz -B work, otherwise it doesnt works :??
+static ut64 nes_baddr(RzBinFile *bf) {
 	return 0;
+}
+
+static RzStructuredData *nes_structure(RzBinFile *bf) {
+	const ines_hdr *hdr = bf->o->bin_obj;
+	if (!hdr) {
+		return NULL;
+	}
+	RzStructuredData *info = rz_structured_data_new_map();
+	if (!info) {
+		return NULL;
+	}
+	RzStructuredData *nes = rz_structured_data_map_add_map(info, "nes");
+	if (!nes) {
+		rz_structured_data_free(info);
+		return NULL;
+	}
+	rz_structured_data_map_add_bytes(nes, "magic", (const ut8 *)hdr->id, sizeof(hdr->id), RZ_STRUCTURED_DATA_FORMAT_DEFAULT);
+	rz_structured_data_map_add_unsigned(nes, "prg_pages", hdr->prg_page_count_16k, false);
+	rz_structured_data_map_add_unsigned(nes, "chr_pages", hdr->chr_page_count_8k, false);
+	rz_structured_data_map_add_unsigned(nes, "prg_size", (ut64)hdr->prg_page_count_16k * PRG_PAGE_SIZE, true);
+	rz_structured_data_map_add_unsigned(nes, "chr_size", (ut64)hdr->chr_page_count_8k * CHR_PAGE_SIZE, true);
+	rz_structured_data_map_add_unsigned(nes, "mapper", ((hdr->rom_control_byte_1 & 0xF0) | (hdr->rom_control_byte_0 >> 4)), true);
+	rz_structured_data_map_add_boolean(nes, "mirror", (hdr->rom_control_byte_0 & 1) != 0);
+	rz_structured_data_map_add_boolean(nes, "battery", (hdr->rom_control_byte_0 & 2) != 0);
+	rz_structured_data_map_add_boolean(nes, "trainer", (hdr->rom_control_byte_0 & 4) != 0);
+	rz_structured_data_map_add_boolean(nes, "four_screen", (hdr->rom_control_byte_0 & 8) != 0);
+	rz_structured_data_map_add_unsigned(nes, "ram_banks", hdr->ram_bank_count_8k, false);
+	return info;
 }
 
 RzBinPlugin rz_bin_plugin_nes = {
@@ -224,15 +261,17 @@ RzBinPlugin rz_bin_plugin_nes = {
 	.desc = "Nintendo NES",
 	.license = "MIT",
 	.author = "maijin",
-	.load_buffer = &load_buffer,
-	.baddr = &baddr,
-	.check_buffer = &check_buffer,
-	.entries = &entries,
+	.load_buffer = &nes_load_buffer,
+	.baddr = &nes_baddr,
+	.check_buffer = &nes_check_buffer,
+	.entries = &nes_entries,
 	.maps = &rz_bin_maps_of_file_sections,
-	.sections = sections,
-	.symbols = &symbols,
-	.info = &info,
-	.mem = &mem,
+	.sections = &nes_sections,
+	.symbols = &nes_symbols,
+	.info = &nes_info,
+	.mem = &nes_mem,
+	.destroy = &nes_destroy,
+	.bin_structure = &nes_structure,
 };
 
 #ifndef RZ_PLUGIN_INCORE

--- a/test/db/formats/nes
+++ b/test/db/formats/nes
@@ -31,7 +31,7 @@ nes:
   mirror: true
   battery: false
   trainer: false
-  four_screen: false
+  alternative_nametable_layout: false
   ram_banks: 0
 EOF
 RUN

--- a/test/db/formats/nes
+++ b/test/db/formats/nes
@@ -22,12 +22,12 @@ os       nes
  3 fd: 3 +0x00000010 0x0000c000 - 0x0000ffff r-x fmap.ROM_MIRROR
 ---
 nes:
-  magic: 4e45531a
+  magic: "4e45531a"
   prg_pages: 1
-  chr_pages: 0
+  chr_pages: 1
   prg_size: 0x4000
-  chr_size: 0x0
-  mapper: 0x0
+  chr_size: 0x2000
+  mapper: 0x1
   mirroring: "horizontal"
   battery: false
   trainer: false

--- a/test/db/formats/nes
+++ b/test/db/formats/nes
@@ -33,5 +33,6 @@ nes:
   trainer: false
   alternative_nametable_layout: false
   ram_banks: 0
+
 EOF
 RUN

--- a/test/db/formats/nes
+++ b/test/db/formats/nes
@@ -28,7 +28,7 @@ nes:
   prg_size: 0x4000
   chr_size: 0x0
   mapper: 0x0
-  mirroring: horizontal
+  mirroring: "horizontal"
   battery: false
   trainer: false
   alternative_nametable_layout: false

--- a/test/db/formats/nes
+++ b/test/db/formats/nes
@@ -22,3 +22,22 @@ EXPECT=<<EOF
  3 fd: 3 +0x00000010 0x0000c000 - 0x0000ffff r-x fmap.ROM_MIRROR
 EOF
 RUN
+
+NAME=NES: Pong - iH
+FILE=bins/nes/Pong.nes
+CMDS=iH
+EXPECT=<<EOF
+nes:
+  magic: 4e45531a
+  prg_pages: 1
+  chr_pages: 0
+  prg_size: 0x4000
+  chr_size: 0x0
+  mapper: 0x0
+  mirror: true
+  battery: false
+  trainer: false
+  four_screen: false
+  ram_banks: 0
+EOF
+RUN

--- a/test/db/formats/nes
+++ b/test/db/formats/nes
@@ -28,7 +28,7 @@ nes:
   prg_size: 0x4000
   chr_size: 0x0
   mapper: 0x0
-  mirror: true
+  mirroring: horizontal
   battery: false
   trainer: false
   alternative_nametable_layout: false

--- a/test/db/formats/nes
+++ b/test/db/formats/nes
@@ -5,28 +5,22 @@ CMDS=q!
 EXPECT=
 RUN
 
-NAME=NES: Pong - detection
+NAME=NES: Pong - detection, mapping and iH
 FILE=bins/nes/Pong.nes
-CMDS=iI~os
+CMDS=<<EOF
+iI~os
+echo ---
+oml
+echo ---
+iH
+EOF
 EXPECT=<<EOF
 os       nes
-EOF
-RUN
-
-NAME=NES: Mapping
-FILE=bins/nes/Pong.nes
-CMDS=oml
-EXPECT=<<EOF
+---
  1 fd: 3 +0x00000010 0x00008000 * 0x0000bfff r-x fmap.ROM
  2 fd: 4 +0x00000000 0x00010000 - 0x00013fff r-x mmap.ROM_MIRROR
  3 fd: 3 +0x00000010 0x0000c000 - 0x0000ffff r-x fmap.ROM_MIRROR
-EOF
-RUN
-
-NAME=NES: Pong - iH
-FILE=bins/nes/Pong.nes
-CMDS=iH
-EXPECT=<<EOF
+---
 nes:
   magic: 4e45531a
   prg_pages: 1


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Add `iH` header structure output for the NES bin format plugin. Implements the `bin_structure` callback following the SMD/PYC pattern.

Changes:
- Refactor `load_buffer` to parse and store `ines_hdr` in `obj->bin_obj`
- Add `nes_destroy` to free parsed header on cleanup
- Refactor `info`, `sections`, `entries` to use stored header instead of repeated buffer reads
- Add `nes_structure` function that exposes header fields as `RzStructuredData`
- Prefix all functions with `nes_` for consistency

The `iH` output includes decoded fields: magic, prg/chr page counts and sizes, mapper number, mirroring mode, battery, trainer, four-screen flags, and RAM bank count.

**Test plan**

```
$ rizin test/bins/nes/Pong.nes -qc iH
nes:
  magic: 4e45531a
  prg_pages: 1
  chr_pages: 0
  prg_size: 0x4000
  chr_size: 0x0
  mapper: 0x0
  mirror: true
  battery: false
  trainer: false
  four_screen: false
  ram_banks: 0
```

**Closing issues**

Closes part of #5728