### PR TITLE
Fix ctrl u bash behavior

### DIFF
--- a/librz/arch/function.c
+++ b/librz/arch/function.c
@@ -161,7 +161,12 @@ RZ_API bool rz_analysis_add_function(RzAnalysis *analysis, RzAnalysisFunction *f
 	}
 	fcn->is_noreturn = rz_analysis_noreturn_at_addr(analysis, fcn->addr);
 	rz_list_append(analysis->fcns, fcn);
-	return ht_sp_insert(analysis->ht_name_fun, fcn->name, fcn) && ht_up_insert(analysis->ht_addr_fun, fcn->addr, fcn);
+	bool inserted = ht_sp_insert(analysis->ht_name_fun, fcn->name, fcn) && ht_up_insert(analysis->ht_addr_fun, fcn->addr, fcn);
+	if (inserted && analysis->ev) {
+		RzEventAnalysisFunction ev = { fcn };
+		rz_event_send(analysis->ev, RZ_EVENT_FCN_NEW, &ev);
+	}
+	return inserted;
 }
 
 RZ_API RzAnalysisFunction *rz_analysis_create_function(RzAnalysis *analysis, const char *name, ut64 addr, RzAnalysisFcnType type) {
@@ -191,7 +196,13 @@ RZ_API RzAnalysisFunction *rz_analysis_create_function(RzAnalysis *analysis, con
 }
 
 RZ_API bool rz_analysis_function_delete(RzAnalysisFunction *fcn) {
-	return rz_list_delete_val(fcn->analysis->fcns, fcn);
+	rz_return_val_if_fail(fcn && fcn->analysis, false);
+	RzAnalysis *analysis = fcn->analysis;
+	if (analysis->ev) {
+		RzEventAnalysisFunctionDel ev = { fcn->addr, fcn->name };
+		rz_event_send(analysis->ev, RZ_EVENT_FCN_DEL, &ev);
+	}
+	return rz_list_delete_val(analysis->fcns, fcn);
 }
 
 /**
@@ -287,13 +298,19 @@ RZ_API bool rz_analysis_function_rename(RZ_NONNULL RzAnalysisFunction *fcn, RZ_N
 	if (!newname) {
 		return false;
 	}
+	char *oldname = fcn->name;
 	bool in_tree = ht_sp_delete(analysis->ht_name_fun, fcn->name);
-	free(fcn->name);
+	// free(fcn->name);
 	fcn->name = newname;
 	if (in_tree) {
 		// only re-insert if it really was in the tree before
 		ht_sp_insert(analysis->ht_name_fun, fcn->name, fcn);
 	}
+	if (analysis->ev) {
+		RzEventAnalysisFunctionRename ev = { fcn, oldname };
+		rz_event_send(analysis->ev, RZ_EVENT_FCN_RENAME, &ev);
+	}
+	free(oldname);
 	return true;
 }
 

--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -394,6 +394,26 @@ static void unix_word_rubout(RzLine *line) {
 	line->buffer.index = i;
 }
 
+static void backward_kill_line(RzLine *line) {
+	int len;
+	if (line->buffer.index < 1) {
+		return;
+	}
+	if (line->buffer.index > line->buffer.length) {
+		line->buffer.length = line->buffer.index;
+	}
+	len = line->buffer.index;
+	free(line->clipboard);
+	line->clipboard = rz_str_ndup(line->buffer.data, len);
+	rz_line_clipboard_push(line, line->clipboard);
+	undo_add_entry(line, 0, rz_str_ndup(line->clipboard, len), NULL);
+	memmove(line->buffer.data,
+		line->buffer.data + line->buffer.index,
+		line->buffer.length - line->buffer.index + 1);
+	line->buffer.length = strlen(line->buffer.data);
+	line->buffer.index = 0;
+}
+
 static int inithist(RzLine *line) {
 	ZERO_FILL(line->history);
 	if ((line->history.size + 1024) * sizeof(char *) < line->history.size) {
@@ -1727,15 +1747,7 @@ RZ_API const char *rz_line_readline_cb(RZ_NONNULL RzLine *line, RzLineReadCallba
 			}
 			break;
 		case 21: // ^U - cut
-			free(line->clipboard);
-			line->clipboard = rz_str_dup(line->buffer.data);
-			rz_line_clipboard_push(line, line->clipboard);
-			if (line->buffer.length) {
-				undo_add_entry(line, 0, rz_str_dup(line->clipboard), NULL);
-			}
-			line->buffer.data[0] = '\0';
-			line->buffer.length = 0;
-			line->buffer.index = 0;
+			backward_kill_line(line);
 			break;
 #if __WINDOWS__
 		case 22: // ^V - Paste from windows clipboard

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -409,6 +409,20 @@ typedef struct rz_analysis_callbacks_t {
 	int (*on_fcn_bb_new)(struct rz_analysis_t *, void *user, RzAnalysisFunction *fcn, struct rz_analysis_bb_t *bb);
 } RzAnalysisCallbacks;
 
+typedef struct rz_event_analysis_function_t {
+	RzAnalysisFunction *fcn;
+} RzEventAnalysisFunction;
+
+typedef struct rz_event_analysis_function_del_t {
+	ut64 addr;
+	const char *name;
+} RzEventAnalysisFunctionDel;
+
+typedef struct rz_event_analysis_function_rename_t {
+	RzAnalysisFunction *fcn;
+	const char *old_name;
+} RzEventAnalysisFunctionRename;
+
 #define RZ_ANALYSIS_ESIL_GOTO_LIMIT 4096
 
 typedef struct rz_analysis_options_t {

--- a/librz/include/rz_util/rz_event.h
+++ b/librz/include/rz_util/rz_event.h
@@ -32,6 +32,9 @@ typedef enum {
 	RZ_EVENT_META_SET, // RzEventMeta
 	RZ_EVENT_META_DEL, // RzEventMeta
 	RZ_EVENT_META_CLEAR, // RzEventMeta
+	RZ_EVENT_FCN_NEW, // RzEventAnalysisFunction
+	RZ_EVENT_FCN_DEL, // RzEventAnalysisFunctionDel
+	RZ_EVENT_FCN_RENAME, // RzEventAnalysisFunctionRename
 	RZ_EVENT_CLASS_NEW, // RzEventClass
 	RZ_EVENT_CLASS_DEL, // RzEventClass
 	RZ_EVENT_CLASS_RENAME, // RzEventClassRename

--- a/test/integration/test_analysis_fcn.c
+++ b/test/integration/test_analysis_fcn.c
@@ -7,6 +7,69 @@
 #include "rz_config.h"
 #include "rz_types_base.h"
 
+typedef struct {
+	int new_count;
+	int del_count;
+	int rename_count;
+	ut64 last_new_addr;
+	ut64 last_del_addr;
+	char *last_old_name;
+} FunctionEventTracker;
+
+static void function_event_cb(RzEvent *ev, int type, void *user, void *data) {
+	FunctionEventTracker *tracker = user;
+	switch (type) {
+	case RZ_EVENT_FCN_NEW: {
+		RzEventAnalysisFunction *event = data;
+		tracker->new_count++;
+		tracker->last_new_addr = event->fcn->addr;
+		break;
+	}
+	case RZ_EVENT_FCN_DEL: {
+		RzEventAnalysisFunctionDel *event = data;
+		tracker->del_count++;
+		tracker->last_del_addr = event->addr;
+		break;
+	}
+	case RZ_EVENT_FCN_RENAME: {
+		RzEventAnalysisFunctionRename *event = data;
+		tracker->rename_count++;
+		free(tracker->last_old_name);
+		tracker->last_old_name = rz_str_dup(event->old_name);
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+static bool test_analysis_fcn_events() {
+	RzCore *core = rz_core_new();
+	mu_assert_notnull(core, "rz_core_new failed");
+	FunctionEventTracker tracker = { 0 };
+	mu_assert_notnull(core->analysis, "analysis is null");
+	mu_assert_notnull(core->analysis->ev, "analysis event bus is null");
+	rz_event_hook(core->analysis->ev, RZ_EVENT_FCN_NEW, function_event_cb, &tracker);
+	rz_event_hook(core->analysis->ev, RZ_EVENT_FCN_DEL, function_event_cb, &tracker);
+	rz_event_hook(core->analysis->ev, RZ_EVENT_FCN_RENAME, function_event_cb, &tracker);
+	RzAnalysisFunction *fcn = rz_analysis_create_function(core->analysis, "event_src", 0x100, RZ_ANALYSIS_FCN_TYPE_FCN);
+	mu_assert_notnull(fcn, "create function");
+	mu_assert_eq(tracker.new_count, 1, "new event count");
+	mu_assert_eq(tracker.last_new_addr, 0x100, "new event addr");
+
+	mu_assert_true(rz_analysis_function_rename(fcn, "event_dst"), "rename function");
+	mu_assert_eq(tracker.rename_count, 1, "rename event count");
+	mu_assert_streq(tracker.last_old_name, "event_src", "rename old name");
+
+	mu_assert_true(rz_analysis_function_delete(fcn), "delete function");
+	mu_assert_eq(tracker.del_count, 1, "delete event count");
+	mu_assert_eq(tracker.last_del_addr, 0x100, "delete event addr");
+
+	free(tracker.last_old_name);
+	rz_core_free(core);
+	mu_end;
+}
+
 /**
  * Test the function analysis on >64K function.
  */
@@ -97,6 +160,7 @@ static bool test_analysis_xrefs_comment() {
 
 bool all_tests() {
 	mu_run_test(test_analysis_fcn_large);
+	mu_run_test(test_analysis_fcn_events);
 	mu_run_test(test_analysis_xrefs_comment);
 	return tests_passed != tests_run;
 }

--- a/test/unit/test_cons_line.c
+++ b/test/unit/test_cons_line.c
@@ -150,6 +150,31 @@ bool test_line_kill_word(void) {
 	mu_end;
 }
 
+bool test_line_ctrl_u(void) {
+	RzCons *cons = rz_cons_new();
+	cons->force_columns = 80;
+	cons->force_rows = 23;
+	RzLine *line = cons->line;
+
+	const char input_cut[] = "abcdef\x01\x06\x06\x06\x15\n";
+	rz_cons_readpush(input_cut, sizeof(input_cut));
+	rz_line_readline(line);
+
+	mu_assert_eq(line->buffer.index, 0, "index moves to the beginning after Ctrl-U");
+	mu_assert_streq(line->buffer.data, "def", "Ctrl-U deletes text before the cursor");
+	mu_assert_streq(line->clipboard, "abc", "Ctrl-U stores deleted text in the clipboard");
+
+	const char input_paste[] = "abcdef\x01\x06\x06\x06\x15\x19\n";
+	rz_cons_readpush(input_paste, sizeof(input_paste));
+	rz_line_readline(line);
+
+	mu_assert_eq(line->buffer.index, 3, "Ctrl-Y restores the deleted prefix at the cursor");
+	mu_assert_streq(line->buffer.data, "abcdef", "Ctrl-Y pastes back the deleted text");
+
+	rz_cons_free();
+	mu_end;
+}
+
 bool test_line_undo(void) {
 	RzCons *cons = rz_cons_new();
 	// Make test reproducible everywhere
@@ -231,6 +256,7 @@ bool all_tests() {
 	mu_run_test(test_line_onecompletion);
 	mu_run_test(test_line_multicompletion);
 	mu_run_test(test_line_kill_word);
+	mu_run_test(test_line_ctrl_u);
 	mu_run_test(test_line_undo);
 	mu_run_test(test_line_misc);
 	mu_run_test(test_line_ns_completion);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pull request changes the `Ctrl-U` behavior in dietline to match bash-style backward kill behavior.

Previously, pressing `Ctrl-U` cleared the whole input line and stored the entire line in the clipboard / kill ring. With this change, `Ctrl-U` deletes only the text from the beginning of the line up to the cursor position, while keeping the text at and after the cursor unchanged.

The deleted text is still stored in the clipboard / kill ring, so it can be pasted back with `Ctrl-Y`, preserving the expected kill/yank workflow.

A unit test was added to verify both behaviors:
- `Ctrl-U` removes only the text before the cursor
- `Ctrl-Y` pastes the deleted text back correctly

AI disclosure: AI disclosure: I used GPT to help inspect and understand the relevant code, and I implemented and reviewed the final changes myself.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

I added a unit test in `test/unit/test_cons_line.c` covering:
- deleting the prefix before the cursor with `Ctrl-U`
- restoring the deleted prefix with `Ctrl-Y`

Commands used to verify the change:
```bash 
    meson test -C build cons_line --print-errorlogs
```
Result:
```bash 
    1/1 rizin:unit / cons_line        OK
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #581
