### PR TITLE
Fix Windows debugger compilation warnings

### DIFF
--- a/librz/debug/p/native/windows/windows_message.c
+++ b/librz/debug/p/native/windows/windows_message.c
@@ -422,7 +422,6 @@ static DWORD get_msg_type(char *name) {
 	if (!msg_types) {
 		init_msg_types(&msg_types);
 	}
-	ut32 found;
 	const char *type_str = sdb_const_get(msg_types, name);
 	if (type_str) {
 		int type = rz_num_get(NULL, type_str);
@@ -501,7 +500,6 @@ RZ_API bool rz_w32_add_winmsg_breakpoint(RzDebug *dbg, const char *msg_name, con
 		free(name);
 		return false;
 	}
-	char *cond;
 	if (window_id) {
 		char *reg;
 		if (!strcmp(dbg->arch, "arm")) {
@@ -513,7 +511,7 @@ RZ_API bool rz_w32_add_winmsg_breakpoint(RzDebug *dbg, const char *msg_name, con
 		} else {
 			reg = "edx";
 		}
-		b->cond = rz_str_newf("%= `ae %s,%d,-`", reg, type);
+		b->cond = rz_str_newf("%%= `ae %s,%lu,-`", reg, type);
 	} else {
 		char *reg;
 		if (!strcmp(dbg->arch, "arm")) {
@@ -529,7 +527,7 @@ RZ_API bool rz_w32_add_winmsg_breakpoint(RzDebug *dbg, const char *msg_name, con
 				reg = "ecx";
 			}
 		}
-		b->cond = rz_str_newf("%= `ae %lu,%s,%d,+,[4],-`", type, reg, dbg->bits);
+		b->cond = rz_str_newf("%%= `ae %lu,%s,%d,+,[4],-`", type, reg, dbg->bits);
 	}
 	free(name);
 	return true;


### PR DESCRIPTION
## Summary

Fixes 5 compilation warnings in `windows_message.c` reported in #6105: two unused variables, one wrong format specifier, and two unescaped percent signs in format strings.

## Changes

**File:** `librz/debug/p/native/windows/windows_message.c`

- Removed unused `ut32 found` variable in `get_msg_type()`
- Removed unused `char *cond` variable in `rz_w32_add_winmsg_breakpoint()`
- Changed `%d` to `%lu` for `DWORD type` argument (matches the pattern already used on the other format string at line 532)
- Escaped literal `%` in ESIL format strings (`%= ` -> `%%= `) to silence `-Wformat-invalid-specifier`

## Testing

- Verified the format string output is unchanged: `%%=` produces literal `%=` via `vsnprintf`, matching the original ESIL breakpoint condition syntax

Closes #6105

This contribution was developed with AI assistance (Claude Code).