### PR TITLE
rzil/x86: Cast operands for AND and OR instructions to the correct width

### DIFF
--- a/librz/arch/isa/x86/il_ops.inc
+++ b/librz/arch/isa/x86/il_ops.inc
@@ -203,6 +203,10 @@ IL_LIFTER(add) {
 IL_LIFTER(and) {
 	RzILOpPure *op1 = x86_il_get_op(0);
 	RzILOpPure *op2 = x86_il_get_op(1);
+	if (ins->operands[0].size != ins->operands[1].size) {
+		op2 = CAST(ins->operands[0].size * BITS_PER_BYTE, IL_FALSE, op2);
+	}
+
 	RzILOpEffect *and = SETL("and_", LOGAND(op1, op2));
 
 	RzILOpEffect *set_dest = x86_il_set_op(0, VARL("and_"));
@@ -1501,6 +1505,10 @@ IL_LIFTER(not) {
 IL_LIFTER(or) {
 	RzILOpPure *op1 = x86_il_get_op(0);
 	RzILOpPure *op2 = x86_il_get_op(1);
+	if (ins->operands[0].size != ins->operands[1].size) {
+		op2 = CAST(ins->operands[0].size * BITS_PER_BYTE, IL_FALSE, op2);
+	}
+
 	RzILOpEffect * or = SETL("_or", LOGOR(op1, op2));
 
 	RzILOpEffect *set_dest = x86_il_set_op(0, VARL("_or"));

--- a/test/db/rzil/x86
+++ b/test/db/rzil/x86
@@ -105,3 +105,123 @@ EOF
 EXPECT=Hello from RzIL!
 EXPECT_ERR=
 RUN
+
+NAME=Missing casting of arguments and register write issue test
+FILE==
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+wx 4883e1f0
+pi 1
+aoip
+
+wx 4183c801
+pi 1
+aoip
+EOF
+EXPECT=<<EOF
+and rcx, 0xfffffffffffffff0
+0x0
+(seq
+  (set and_
+    (&
+      (var rcx)
+      (bv 64 0xfffffffffffffff0)))
+  (set rcx
+    (var and_))
+  (set of
+    false)
+  (set cf
+    false)
+  (set _result
+    (var and_))
+  (set pf
+    (!
+      (lsb
+        (let _val
+          (cast 8
+            false
+            (var _result))
+          (let _c4
+            (^
+              (var _val)
+              (>>
+                (var _val)
+                (bv 8 0x4)
+                false))
+            (let _c2
+              (^
+                (var _c4)
+                (>>
+                  (var _c4)
+                  (bv 8 0x2)
+                  false))
+              (^
+                (var _c2)
+                (>>
+                  (var _c2)
+                  (bv 8 0x1)
+                  false))))))))
+  (set zf
+    (is_zero
+      (var _result)))
+  (set sf
+    (msb
+      (var _result))))
+or r8d, 0x01
+0x0
+(seq
+  (set _or
+    (|
+      (cast 32
+        false
+        (var r8))
+      (cast 32
+        false
+        (bv 8 0x1))))
+  (set r8
+    (cast 64
+      false
+      (var _or)))
+  (set of
+    false)
+  (set cf
+    false)
+  (set _result
+    (var _or))
+  (set pf
+    (!
+      (lsb
+        (let _val
+          (cast 8
+            false
+            (var _result))
+          (let _c4
+            (^
+              (var _val)
+              (>>
+                (var _val)
+                (bv 8 0x4)
+                false))
+            (let _c2
+              (^
+                (var _c4)
+                (>>
+                  (var _c4)
+                  (bv 8 0x2)
+                  false))
+              (^
+                (var _c2)
+                (>>
+                  (var _c2)
+                  (bv 8 0x1)
+                  false))))))))
+  (set zf
+    (is_zero
+      (var _result)))
+  (set sf
+    (msb
+      (var _result))))
+EOF
+EXPECT_ERR=
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Cast operands to binary operations to the same width to avoid RzIL warnings.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Add integration tests.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Related to #5912.
