### PR TITLE
meson: Fix include_directories sandbox violation

### DIFF
--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -32,7 +32,6 @@
 #include <rz_crypto.h>
 #include <rz_bind.h>
 #include <rz_util/rz_annotated_code.h>
-#include <rz_heap_glibc.h>
 #include <rz_windows_heap.h>
 #include <rz_mark.h>
 
@@ -1004,16 +1003,6 @@ RZ_API void rz_core_sysenv_begin(RzCore *core);
 RZ_API void rz_core_sysenv_end(RzCore *core);
 
 RZ_API void rz_core_recover_vars(RzCore *core, RzAnalysisFunction *fcn, bool argonly);
-
-/* heap_glibc.c */
-RZ_API RzList /*<RzHeapChunkListItem *>*/ *rz_heap_chunks_list(RzCore *core, ut64 m_arena);
-RZ_API RzList /*<RzArenaListItem *>*/ *rz_heap_arenas_list(RzCore *core);
-RZ_API RzHeapChunkSimple *rz_heap_chunk(RzCore *core, ut64 addr);
-RZ_API RzHeapBin *rz_heap_bin_content(RzCore *core, MallocState *arena, int bin_num, ut64 m_arena);
-RZ_API RzHeapBin *rz_heap_fastbin_content(RzCore *core, MallocState *arena, int bin_num);
-RZ_API MallocState *rz_heap_get_arena(RzCore *core, ut64 m_state);
-RZ_API RzList /*<RzHeapBin *>*/ *rz_heap_tcache_content(RzCore *core, ut64 arena_base);
-RZ_API bool rz_heap_write_chunk(RzCore *core, RzHeapChunkSimple *chunk_simple);
 
 /* cmd_windows_heap.c */
 RZ_API RZ_OWN RzList /*<RzWindowsHeapBlock *>*/ *rz_heap_windows_blocks_list(RzCore *core);

--- a/librz/include/rz_heap_glibc.h
+++ b/librz/include/rz_heap_glibc.h
@@ -35,6 +35,7 @@ RZ_LIB_VERSION_HEADER(rz_heap_glibc);
 
 RZ_API RzHeapChunkSimple *rz_heap_chunk(RzCore *core, ut64 addr);
 RZ_API RzHeapChunk *rz_heap_get_chunk_at_addr(RzCore *core, ut64 addr);
+RZ_API RzList /*<RzHeapChunkListItem *>*/ *rz_heap_chunks_list(RzCore *core, ut64 m_arena);
 RZ_API RzList /*<RzArenaListItem *>*/ *rz_heap_arenas_list(RzCore *core);
 RZ_API bool rz_heap_resolve_main_arena(RzCore *core, ut64 *m_arena);
 RZ_API double rz_get_glibc_version(RzCore *core, const char *libc_path, ut8 *banner);
@@ -44,10 +45,6 @@ RZ_API RzList /*<RzHeapBin *>*/ *rz_heap_tcache_content(RzCore *core, ut64 arena
 RZ_API MallocState *rz_heap_get_arena(RzCore *core, ut64 m_state);
 RZ_API RzHeapBin *rz_heap_fastbin_content(RzCore *core, MallocState *main_arena, int bin_num);
 RZ_API RzHeapBin *rz_heap_bin_content(RzCore *core, MallocState *main_arena, int bin_num, ut64 m_arena);
-RZ_API RzList /*<RzHeapChunkListItem *>*/ *rz_heap_chunks(RzCore *core, ut64 m_state);
-RZ_API RzList /*<RzArenaListItem *>*/ *rz_heap_arena_list(RzCore *core);
-RZ_IPI RzCmdStatus rz_cmd_heap_fastbins_print_handler(RzCore *core, int argc, const char **argv);
-RZ_IPI RzCmdStatus rz_cmd_heap_bins_list_print_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 RZ_API void rz_heap_bin_free(RzHeapBin *bin);
 
 #ifdef __cplusplus

--- a/meson.build
+++ b/meson.build
@@ -44,7 +44,7 @@ cc = meson.get_compiler('c')
 cc_native = meson.get_compiler('c', native: true)
 
 platform_deps = []
-platform_inc = ['.', 'librz', 'librz/include', 'subprojects/rzheap']
+platform_inc = ['.', 'librz', 'librz/include']
 if host_machine.system() == 'windows'
   add_project_arguments('-DPSAPI_VERSION=1', language: 'c')
   platform_deps = [

--- a/test/integration/meson.build
+++ b/test/integration/meson.build
@@ -60,6 +60,7 @@ if get_option('enable_tests') and cli_enabled
         rz_hash_dep,
         rz_crypto_dep,
         rz_magic_dep,
+        rzheap_dep,
         lrt,
       ],
       install: false,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr fixes the following warning:

<img width="872" height="521" alt="include_directories-sandbox-violation" src="https://github.com/user-attachments/assets/4b07450d-7f93-4707-a71b-9a09c15bc1ea" />

(https://github.com/rizinorg/rizin/actions/runs/23667881571/job/68954325405#step:12:35)

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The warning doesn't appear anymore. The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
