### PR TITLE
doc: fix typos in fortunes tips

### DIFF
--- a/doc/fortunes.tips
+++ b/doc/fortunes.tips
@@ -6,7 +6,7 @@ You can debug a program from the graph view ('ag') using standard rizin commands
 Use the '[' and ']' keys in visual mode to adjust the screen width
 Select your architecture with: 'e asm.arch=<arch>' or rizin -a from the shell
 Move between your search hits in visual mode using the 'f' and 'F' keys
-Save your projects with 'Ps <project-filename>' and restore then with 'Po <project-filename>'
+Save your projects with 'Ps <project-filename>' and restore them with 'Po <project-filename>'
 Enable asm.trace to see the tracing information inside the disassembly
 Change the registers of the child process in this way: 'dr eax=0x333'
 Check your IO plugins with 'rizin -L'
@@ -50,12 +50,12 @@ Control the height of the terminal on serial consoles with e scr.height
 Use `rizin -B 0x123456 /bin/ls` option to set the base address of a PIE file.
 Bindiff two files with '$ rz-diff -H /bin/true /bin/false'
 Execute commands on a temporary offset by appending '@ offset' to your command.
-Temporally drop the verbosity prefixing the commands with ':'
+Temporarily drop verbosity by prefixing commands with ':'
 Change the graph block definition with graph.callblocks, graph.jmpblocks, graph.flagblocks
 Use scr.accel to browse the file faster!
 Use the 'id' command to see the source line related to the current seek
 Analyze socket connections with the socket plugin: 'rizin socket://www.foo.com:80'. Use 'w' to send data
-Setup dbg.fpregs to true to visualize the fpu registers in the debugger view.
+Set dbg.fpregs to true to visualize the FPU registers in the debugger view.
 To debug a program, you can call rizin with 'dbg://<path-to-program>' or '-d <path..>'
 Use 'e' and 't' in Visual mode to edit configuration and track flags.
 Use 'rz-bin -ris' to get the import/export symbols of any binary.
@@ -68,18 +68,18 @@ Rename a function using the 'afr <newname> @ <offset>' command.
 You can redefine descriptive commands in the hud file and using the 'V_' command.
 Pass '-j' to rz-bin to get the information of the binary in JSON format.
 Use rz-run to launch your programs with a predefined environment.
-You are probably using an old version of rizin, go checkout the git!
+You are probably using an old version of rizin, go check out the git!
 Use '-e bin.strings=false' to disable automatic string search when loading the binary.
 The unix-like reverse engineering framework.
 This code was intentionally left blank, try 'e asm.arch=ws'
 Thanks for using rizin!
-give | and > a try piping and redirection
+Give `|` and `>` a try: piping and redirection
 Run .dmm* to load the flags of the symbols of all modules loaded in the debugger
 Use V! to enter into the visual panels mode (dwm style)
 Toggle between disasm and graph with the space key
 The more 'a' you add after 'aa' the more analysis steps are executed.
 Review all the subcommands of aa to see better ways to analyze your targets.
-Use /m to carve for known magic headers. speedup with search.
+Use /m to carve for known magic headers. Speed it up with search settings.
 You can use registers in math expressions. For example: 'wx 1234 @ esp - 2'
 For HTTP authentication 'e http.auth=1', 'e http.authfile=<path>'
 Save your project in compressed format with 'e prj.compress=true'


### PR DESCRIPTION
Small cleanup of `doc/fortunes.tips` to fix a few typos/grammar issues and improve readability.

Related: #5209 (incremental improvements).

AI usage disclosure: I used an AI assistant for proofreading/wording suggestions; all edits were reviewed and applied manually.