### PR TITLE
librz/core: fix dpa command

### DIFF
--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -317,7 +317,7 @@ RZ_IPI void rz_core_debug_attach(RzCore *core, int pid) {
 		rz_strf(uri, "dbg://%d", pid);
 		RzCoreFile *cfile = rz_core_file_open(core, uri, RZ_PERM_RW, 0);
 		if (!cfile) {
-			RZ_LOG_ERROR("Failed to open file for pid %d\n", pid);
+			RZ_LOG_ERROR("core: Failed to open file for pid %d\n", pid);
 			return;
 		}
 		// Create an IO map covering the full address space so memory
@@ -325,7 +325,7 @@ RZ_IPI void rz_core_debug_attach(RzCore *core, int pid) {
 		RzIODesc *iod = core->io ? rz_io_desc_get(core->io, cfile->fd) : NULL;
 		rz_io_map_new(core->io, iod->fd, iod->perm, 0LL, 0LL, rz_io_desc_size(iod));
 	} else {
-		RZ_LOG_WARN("No pid provided and not attached to any file descriptor, IO mapping will not be set up\n");
+		RZ_LOG_WARN("core: No pid provided and not attached to any file descriptor, IO mapping will not be set up\n");
 	}
 	const char *debugbackend = rz_config_get(core->config, "dbg.backend");
 	rz_core_setup_debugger(core, debugbackend, true);

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -836,6 +836,7 @@ RZ_API bool rz_core_debug_process_close(RzCore *core) {
 			rz_debug_kill(dbg, dbg->pid, dbg->pid, SIGKILL);
 			rz_debug_detach(dbg, dbg->pid);
 		}
+		rz_list_free(list);
 	}
 	// Remove the target's registers from the flag list
 	rz_core_debug_clear_register_flags(core);
@@ -869,6 +870,7 @@ RZ_API bool rz_core_debug_process_detach(RzCore *core) {
 		} else {
 			rz_debug_detach(dbg, dbg->pid);
 		}
+		rz_list_free(list);
 	}
 	// Remove the target's registers from the flag list
 	rz_core_debug_clear_register_flags(core);

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -293,18 +293,30 @@ RZ_API void rz_core_debug_bp_add_noreturn_func(RzCore *core) {
 }
 
 RZ_IPI void rz_core_debug_attach(RzCore *core, int pid) {
-	char uri[64];
-	rz_strf(uri, "dbg://%d", pid);
-	RzCoreFile *cfile = rz_core_file_open(core, uri, RZ_PERM_RW, 0);
-	if (!cfile) {
-		RZ_LOG_ERROR("Failed to open file for pid %d\n", pid);
+	RzIODesc *fd = core->file ? rz_io_desc_get(core->io, core->file->fd) : NULL;
+	pid = pid == 0 && fd ? rz_io_desc_pid(fd) : pid;
+	if (pid <= 0) {
+		RZ_LOG_ERROR("core: cannot attach to pid %d\n", pid);
 		return;
 	}
-	// Create an IO map covering the full address space so memory
-	// reads/writes are routed through this debug descriptor.
-	RzIODesc *iod = core->io ? rz_io_desc_get(core->io, cfile->fd) : NULL;
-	rz_io_map_new(core->io, iod->fd, iod->perm, 0LL, 0LL, rz_io_desc_size(iod));
+	if (fd && rz_io_desc_pid(fd) != pid) {
+		rz_core_debug_detach(core);
+	}
 
+	// TODO: fix
+	if (!fd || rz_io_desc_pid(fd) != pid) {
+		char uri[64];
+		rz_strf(uri, "dbg://%d", pid);
+		RzCoreFile *cfile = rz_core_file_open(core, uri, RZ_PERM_RW, 0);
+		if (!cfile) {
+			RZ_LOG_ERROR("Failed to open file for pid %d\n", pid);
+			return;
+		}
+		// Create an IO map covering the full address space so memory
+		// reads/writes are routed through this debug descriptor.
+		RzIODesc *iod = core->io ? rz_io_desc_get(core->io, cfile->fd) : NULL;
+		rz_io_map_new(core->io, iod->fd, iod->perm, 0LL, 0LL, rz_io_desc_size(iod));
+	}
 	const char *debugbackend = rz_config_get(core->config, "dbg.backend");
 	rz_core_setup_debugger(core, debugbackend, true);
 }

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -294,18 +294,25 @@ RZ_API void rz_core_debug_bp_add_noreturn_func(RzCore *core) {
 
 RZ_IPI void rz_core_debug_attach(RzCore *core, int pid) {
 	RzIODesc *fd = core->file ? rz_io_desc_get(core->io, core->file->fd) : NULL;
-	pid = pid == 0 && fd ? rz_io_desc_pid(fd) : pid;
-	if (pid <= 0) {
-		RZ_LOG_ERROR("core: cannot attach to pid %d\n", pid);
-		return;
-	}
-	if (fd && rz_io_desc_pid(fd) != pid) {
-		rz_core_debug_detach(core);
+	char uri[64];
+	int fd_pid = -1;
+	if (pid == 0) {
+		// When pid is not provided, get it from the file descriptor.
+		if (!fd) {
+			RZ_LOG_ERROR("core: no pid provided and not attached to any file descriptor\n");
+			return;
+		}
+		fd_pid = rz_io_desc_get_pid(fd);
+		if (fd_pid == pid) {
+			RZ_LOG_ERROR("core: already attached to pid %d\n", pid);
+			return;
+		}
 	}
 
-	// TODO: fix
-	if (!fd || rz_io_desc_pid(fd) != pid) {
-		char uri[64];
+	rz_core_debug_process_detach(core);
+
+	pid = pid > 0 ? pid : fd_pid;
+	if (pid > 0) {
 		rz_strf(uri, "dbg://%d", pid);
 		RzCoreFile *cfile = rz_core_file_open(core, uri, RZ_PERM_RW, 0);
 		if (!cfile) {
@@ -316,6 +323,8 @@ RZ_IPI void rz_core_debug_attach(RzCore *core, int pid) {
 		// reads/writes are routed through this debug descriptor.
 		RzIODesc *iod = core->io ? rz_io_desc_get(core->io, cfile->fd) : NULL;
 		rz_io_map_new(core->io, iod->fd, iod->perm, 0LL, 0LL, rz_io_desc_size(iod));
+	} else {
+		RZ_LOG_WARN("No pid provided and not attached to any file descriptor, IO mapping will not be set up\n");
 	}
 	const char *debugbackend = rz_config_get(core->config, "dbg.backend");
 	rz_core_setup_debugger(core, debugbackend, true);
@@ -831,6 +840,37 @@ RZ_API bool rz_core_debug_process_close(RzCore *core) {
 	rz_core_debug_clear_register_flags(core);
 	// Reopen and rebase the original file
 	rz_core_io_file_open(core, core->io->desc->fd);
+	return true;
+}
+
+/**
+ * \brief Detach debug process (Detach debugee and all child processes)
+ * \param core The RzCore instance
+ * \return success
+ */
+RZ_API bool rz_core_debug_process_detach(RzCore *core) {
+	rz_return_val_if_fail(core && core->dbg, false);
+	RzDebug *dbg = core->dbg;
+	// Stop trace session
+	if (dbg->session) {
+		rz_debug_session_free(dbg->session);
+		dbg->session = NULL;
+	}
+	// Detach debugee and all child processes
+	if (dbg->cur && dbg->cur->pids && dbg->pid != -1) {
+		RzList *list = dbg->cur->pids(dbg, dbg->pid);
+		RzListIter *iter;
+		RzDebugPid *p;
+		if (list) {
+			rz_list_foreach (list, iter, p) {
+				rz_debug_detach(dbg, p->pid);
+			}
+		} else {
+			rz_debug_detach(dbg, dbg->pid);
+		}
+	}
+	// Remove the target's registers from the flag list
+	rz_core_debug_clear_register_flags(core);
 	return true;
 }
 

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -293,18 +293,19 @@ RZ_API void rz_core_debug_bp_add_noreturn_func(RzCore *core) {
 }
 
 RZ_IPI void rz_core_debug_attach(RzCore *core, int pid) {
-	char buf[20];
-
-	if (pid > 0) {
-		rz_debug_attach(core->dbg, pid);
-	} else {
-		if (core->file && core->io) {
-			rz_debug_attach(core->dbg, rz_io_fd_get_pid(core->io, core->file->fd));
-		}
+	char uri[64];
+	rz_strf(uri, "dbg://%d", pid);
+	RzCoreFile *cfile = rz_core_file_open(core, uri, RZ_PERM_RW, 0);
+	if (!cfile) {
+		RZ_LOG_ERROR("Failed to open file for pid %d\n", pid);
+		return;
 	}
-	rz_debug_select(core->dbg, core->dbg->pid, core->dbg->tid);
-	rz_config_set_i(core->config, "dbg.swstep", (core->dbg->cur && !core->dbg->cur->canstep));
-	rz_io_system(core->io, rz_strf(buf, "pid %d", core->dbg->pid));
+	// Create an IO map covering the full address space so memory
+	// reads/writes are routed through this debug descriptor.
+	rz_io_map_add(core->io, cfile->fd, RZ_PERM_RW, 0LL, 0LL, UT64_MAX);
+
+	const char *debugbackend = rz_config_get(core->config, "dbg.backend");
+	rz_core_setup_debugger(core, debugbackend, true);
 }
 
 static void bits_to_string(ut32 bits, char output[32]) {

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -310,6 +310,7 @@ RZ_IPI void rz_core_debug_attach(RzCore *core, int pid) {
 	}
 
 	rz_core_debug_process_detach(core);
+	rz_debug_use(core->dbg, NULL);
 
 	pid = pid > 0 ? pid : fd_pid;
 	if (pid > 0) {

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -302,7 +302,8 @@ RZ_IPI void rz_core_debug_attach(RzCore *core, int pid) {
 	}
 	// Create an IO map covering the full address space so memory
 	// reads/writes are routed through this debug descriptor.
-	rz_io_map_add(core->io, cfile->fd, RZ_PERM_RW, 0LL, 0LL, UT64_MAX);
+	RzIODesc *iod = core->io ? rz_io_desc_get(core->io, cfile->fd) : NULL;
+	rz_io_map_new(core->io, iod->fd, iod->perm, 0LL, 0LL, rz_io_desc_size(iod));
 
 	const char *debugbackend = rz_config_get(core->config, "dbg.backend");
 	rz_core_setup_debugger(core, debugbackend, true);

--- a/librz/core/cio.c
+++ b/librz/core/cio.c
@@ -4,22 +4,10 @@
 #include "rz_core.h"
 #include "core_private.h"
 
-static void setup_debugger_attach(RzCore *r, int pid) {
-	char buf[20];
-
-	if (pid > 0) {
-		rz_debug_attach(r->dbg, pid);
-	} else if (r->file && r->io) {
-		rz_debug_attach(r->dbg, rz_io_fd_get_pid(r->io, r->file->fd));
-	}
-	rz_debug_select(r->dbg, r->dbg->pid, r->dbg->tid);
-	rz_config_set_i(r->config, "dbg.swstep", (r->dbg->cur && !r->dbg->cur->canstep));
-	rz_io_system(r->io, rz_strf(buf, "pid %d", r->dbg->pid));
-}
-
 RZ_API int rz_core_setup_debugger(RzCore *r, const char *debugbackend, bool attach) {
 	int pid, *p = NULL;
 	RzIODesc *fd = r->file ? rz_io_desc_get(r->io, r->file->fd) : NULL;
+	char buf[20];
 
 	p = fd ? fd->data : NULL;
 	if (!p) {
@@ -31,11 +19,18 @@ RZ_API int rz_core_setup_debugger(RzCore *r, const char *debugbackend, bool atta
 	rz_config_set_b(r->config, "io.ff", true);
 	rz_config_set(r->config, "dbg.backend", debugbackend);
 	pid = rz_io_desc_get_pid(fd);
-	rz_debug_select(r->dbg, pid, r->dbg->tid);
+	// NOTE: pid could be negative here, but it must be passed to the debug
+	// plugin as is, so we don't check it here. The plugin should handle it and
+	// return an error if it's invalid.
 	r->dbg->main_pid = pid;
+	rz_debug_select(r->dbg, pid, r->dbg->tid);
 	if (attach) {
-		setup_debugger_attach(r, pid);
+		rz_debug_attach(r->dbg, pid);
+		rz_debug_select(r->dbg, r->dbg->pid, r->dbg->tid);
 	}
+	rz_config_set_i(r->config, "dbg.swstep", (r->dbg->cur && !r->dbg->cur->canstep));
+	rz_io_system(r->io, rz_strf(buf, "pid %d", r->dbg->pid));
+
 	// this makes to attach twice showing warnings in the output
 	// we get "resource busy" so it seems isn't an issue
 	rz_core_reg_update_flags(r);

--- a/librz/core/cio.c
+++ b/librz/core/cio.c
@@ -4,6 +4,19 @@
 #include "rz_core.h"
 #include "core_private.h"
 
+static void setup_debugger_attach(RzCore *r, int pid) {
+	char buf[20];
+
+	if (pid > 0) {
+		rz_debug_attach(r->dbg, pid);
+	} else if (r->file && r->io) {
+		rz_debug_attach(r->dbg, rz_io_fd_get_pid(r->io, r->file->fd));
+	}
+	rz_debug_select(r->dbg, r->dbg->pid, r->dbg->tid);
+	rz_config_set_i(r->config, "dbg.swstep", (r->dbg->cur && !r->dbg->cur->canstep));
+	rz_io_system(r->io, rz_strf(buf, "pid %d", r->dbg->pid));
+}
+
 RZ_API int rz_core_setup_debugger(RzCore *r, const char *debugbackend, bool attach) {
 	int pid, *p = NULL;
 	RzIODesc *fd = r->file ? rz_io_desc_get(r->io, r->file->fd) : NULL;
@@ -21,18 +34,7 @@ RZ_API int rz_core_setup_debugger(RzCore *r, const char *debugbackend, bool atta
 	rz_debug_select(r->dbg, pid, r->dbg->tid);
 	r->dbg->main_pid = pid;
 	if (attach) {
-		char buf[20];
-
-		if (pid > 0) {
-			rz_debug_attach(r->dbg, pid);
-		} else {
-			if (r->file && r->io) {
-				rz_debug_attach(r->dbg, rz_io_fd_get_pid(r->io, r->file->fd));
-			}
-		}
-		rz_debug_select(r->dbg, r->dbg->pid, r->dbg->tid);
-		rz_config_set_i(r->config, "dbg.swstep", (r->dbg->cur && !r->dbg->cur->canstep));
-		rz_io_system(r->io, rz_strf(buf, "pid %d", r->dbg->pid));
+		setup_debugger_attach(r, pid);
 	}
 	// this makes to attach twice showing warnings in the output
 	// we get "resource busy" so it seems isn't an issue

--- a/librz/core/cio.c
+++ b/librz/core/cio.c
@@ -21,7 +21,18 @@ RZ_API int rz_core_setup_debugger(RzCore *r, const char *debugbackend, bool atta
 	rz_debug_select(r->dbg, pid, r->dbg->tid);
 	r->dbg->main_pid = pid;
 	if (attach) {
-		rz_core_debug_attach(r, pid);
+		char buf[20];
+
+		if (pid > 0) {
+			rz_debug_attach(r->dbg, pid);
+		} else {
+			if (r->file && r->io) {
+				rz_debug_attach(r->dbg, rz_io_fd_get_pid(r->io, r->file->fd));
+			}
+		}
+		rz_debug_select(r->dbg, r->dbg->pid, r->dbg->tid);
+		rz_config_set_i(r->config, "dbg.swstep", (r->dbg->cur && !r->dbg->cur->canstep));
+		rz_io_system(r->io, rz_strf(buf, "pid %d", r->dbg->pid));
 	}
 	// this makes to attach twice showing warnings in the output
 	// we get "resource busy" so it seems isn't an issue

--- a/librz/core/cmd/cmd_debug.c
+++ b/librz/core/cmd/cmd_debug.c
@@ -3102,12 +3102,11 @@ RZ_IPI RzCmdStatus rz_cmd_debug_pid_attach_handler(RzCore *core, int argc, const
 		RZ_LOG_ERROR("Invalid PID %d\n", pid);
 		return RZ_CMD_STATUS_ERROR;
 	}
-	if (rz_core_is_debug(core) || (core->dbg->cur && core->dbg->cur->pids && core->dbg->pid != -1)) {
-		if (rz_cons_is_interactive()) {
-			if (!rz_cons_yesno('n', "core: A debug session is already active. Do you want to attach to another process? (y/N) ")) {
-				return RZ_CMD_STATUS_ERROR;
-			}
-		}
+	bool has_active_session = rz_core_is_debug(core) ||
+		(core->dbg->cur && core->dbg->cur->pids && core->dbg->pid != -1);
+	if (has_active_session && rz_cons_is_interactive() &&
+		!rz_cons_yesno('n', "core: A debug session is already active. Do you want to attach to another process? (y/N) ")) {
+		return RZ_CMD_STATUS_ERROR;
 	}
 	rz_core_debug_attach(core, pid);
 	return RZ_CMD_STATUS_OK;

--- a/librz/core/cmd/cmd_debug.c
+++ b/librz/core/cmd/cmd_debug.c
@@ -3103,8 +3103,10 @@ RZ_IPI RzCmdStatus rz_cmd_debug_pid_attach_handler(RzCore *core, int argc, const
 		return RZ_CMD_STATUS_ERROR;
 	}
 	if (rz_core_is_debug(core) || (core->dbg->cur && core->dbg->cur->pids && core->dbg->pid != -1)) {
-		if (!rz_cons_yesno('n', "core: A debug session is already active. Do you want to attach to another process? (y/N) ")) {
-			return RZ_CMD_STATUS_ERROR;
+		if (rz_cons_is_interactive()) {
+			if (!rz_cons_yesno('n', "core: A debug session is already active. Do you want to attach to another process? (y/N) ")) {
+				return RZ_CMD_STATUS_ERROR;
+			}
 		}
 	}
 	rz_core_debug_attach(core, pid);

--- a/librz/core/cmd/cmd_debug.c
+++ b/librz/core/cmd/cmd_debug.c
@@ -3098,6 +3098,10 @@ RZ_IPI RzCmdStatus rz_cmd_debug_thread_list_handler(RzCore *core, int argc, cons
 
 RZ_IPI RzCmdStatus rz_cmd_debug_pid_attach_handler(RzCore *core, int argc, const char **argv) {
 	int pid = argc > 1 ? rz_num_math(core->num, argv[1]) : 0;
+	if (pid < 0) {
+		RZ_LOG_ERROR("Invalid PID %d\n", pid);
+		return RZ_CMD_STATUS_ERROR;
+	}
 	rz_core_debug_attach(core, pid);
 	return RZ_CMD_STATUS_OK;
 }

--- a/librz/core/cmd/cmd_debug.c
+++ b/librz/core/cmd/cmd_debug.c
@@ -3102,6 +3102,11 @@ RZ_IPI RzCmdStatus rz_cmd_debug_pid_attach_handler(RzCore *core, int argc, const
 		RZ_LOG_ERROR("Invalid PID %d\n", pid);
 		return RZ_CMD_STATUS_ERROR;
 	}
+	if (rz_core_is_debug(core) || (core->dbg->cur && core->dbg->cur->pids && core->dbg->pid != -1)) {
+		if (!rz_cons_yesno('n', "core: A debug session is already active. Do you want to attach to another process? (y/N) ")) {
+			return RZ_CMD_STATUS_ERROR;
+		}
+	}
 	rz_core_debug_attach(core, pid);
 	return RZ_CMD_STATUS_OK;
 }

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -623,6 +623,7 @@ RZ_API void rz_core_debug_set_register_flags(RzCore *core);
 RZ_API void rz_core_debug_clear_register_flags(RzCore *core);
 
 RZ_API bool rz_core_debug_process_close(RzCore *core);
+RZ_API bool rz_core_debug_process_detach(RzCore *core);
 RZ_API bool rz_core_debug_step_until_frame(RzCore *core);
 RZ_API bool rz_core_debug_step_back(RzCore *core, int steps);
 RZ_API bool rz_core_debug_step_over(RzCore *core, int steps);

--- a/test/db/archos/darwin-arm64/dbg
+++ b/test/db/archos/darwin-arm64/dbg
@@ -43,14 +43,10 @@ FILE=bins/mach0/hello-macos-arm64
 CMDS=<<EOF
 !sh -c "sleep 100 >/dev/null 2>&1 &"
 dpa $(!pgrep sleep)
-dr pc
 pi 3 @ pc
 !pkill sleep
 EOF
-REGEXP_FILTER_OUT=((pc\s=)|(0x0000000186f6f308)|(b\.lo\s0x186f6f328)|(pacibsp)|(stp\sfp,\slr,\s\[sp,\s-0x10\]!))
 EXPECT=<<EOF
-pc =
-0x0000000186f6f308
 b.lo 0x186f6f328
 pacibsp
 stp fp, lr, [sp, -0x10]!

--- a/test/db/archos/darwin-arm64/dbg
+++ b/test/db/archos/darwin-arm64/dbg
@@ -38,16 +38,17 @@ c88
 EOF
 RUN
 
-NAME=dpa cross-process attach reads code (#3397)
-FILE=bins/mach0/hello-macos-arm64
+NAME=dpa issue
+FILE==
 CMDS=<<EOF
-!sh -c "sleep 100 >/dev/null 2>&1 &"
-dpa $(!pgrep sleep)
+!sh -c "./bins/mach0/sleep-macos-arm64 100 >/dev/null 2>&1 &"
+dpa $(!pgrep sleep-macos-arm64)
 pi 3 @ pc
-!pkill sleep
+!pkill sleep-macos-arm64
 EOF
+REGEXP_FILTER_OUT=((b\.lo)|(pacibsp)|(stp fp, lr, \[sp, -0x10\]!))
 EXPECT=<<EOF
-b.lo 0x186f6f328
+b.lo
 pacibsp
 stp fp, lr, [sp, -0x10]!
 EOF

--- a/test/db/archos/darwin-arm64/dbg
+++ b/test/db/archos/darwin-arm64/dbg
@@ -41,11 +41,11 @@ RUN
 NAME=dpa cross-process attach reads code (#3397)
 FILE=bins/mach0/hello-macos-arm64
 CMDS=<<EOF
-!sh -c "sleep 30 >/dev/null 2>&1 & echo \$! > /tmp/rzpid3397"
-dpa `!cat /tmp/rzpid3397`
+!sh -c "sleep 100 >/dev/null 2>&1 &"
+dpa $(!pgrep sleep)
 dr pc
 pi 3 @ pc
-!sh -c "kill \$(cat /tmp/rzpid3397) >/dev/null 2>&1 || true; rm -f /tmp/rzpid3397"
+!pkill sleep
 EOF
 REGEXP_FILTER_OUT=((pc\s=)|(0x0000000186f6f308)|(b\.lo\s0x186f6f328)|(pacibsp)|(stp\sfp,\slr,\s\[sp,\s-0x10\]!))
 EXPECT=<<EOF

--- a/test/db/archos/darwin-arm64/dbg
+++ b/test/db/archos/darwin-arm64/dbg
@@ -38,6 +38,25 @@ c88
 EOF
 RUN
 
+NAME=dpa cross-process attach reads code (#3397)
+FILE=bins/mach0/hello-macos-arm64
+CMDS=<<EOF
+!sh -c "sleep 30 >/dev/null 2>&1 & echo \$! > /tmp/rzpid3397"
+dpa `!cat /tmp/rzpid3397`
+dr pc
+pi 3 @ pc
+!sh -c "kill \$(cat /tmp/rzpid3397) >/dev/null 2>&1 || true; rm -f /tmp/rzpid3397"
+EOF
+REGEXP_FILTER_OUT=((pc\s=)|(0x0000000186f6f308)|(b\.lo\s0x186f6f328)|(pacibsp)|(stp\sfp,\slr,\s\[sp,\s-0x10\]!))
+EXPECT=<<EOF
+pc =
+0x0000000186f6f308
+b.lo 0x186f6f328
+pacibsp
+stp fp, lr, [sp, -0x10]!
+EOF
+RUN
+
 NAME=maps
 FILE=bins/mach0/hello-macos-arm64
 ARGS=-d


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
Since `rz_core_setup_debugger` (used when you do `rizin -d dbg://<pid>`) was working well, this PR reuses that function for `dpa` but prepares the right RzCoreFile before calling it.

**Test plan**
See the issue

**Closing issues**
Closes https://github.com/rizinorg/rizin/issues/3397