### PR TITLE
[test] Fix memory leak in test_analysis_op unit tests (test/unit/test_analysis_op.c)

### DIFF
--- a/test/unit/test_analysis_op.c
+++ b/test/unit/test_analysis_op.c
@@ -116,14 +116,17 @@ bool test_rz_core_analysis_bytes() {
 
 	RzAnalysisBytes *ab = rz_iterator_next(iter);
 	mu_assert_streq(ab->opcode, "push rbp", "rz_core_analysis_bytes opcode");
+	free(ab->pseudo);
 
 	ab = rz_iterator_next(iter);
 	mu_assert_streq(ab->opcode, "mov rbp, rsp", "rz_core_analysis_bytes opcode");
 	mu_assert_streq(ab->pseudo, "rbp = rsp", "rz_core_analysis_bytes pseudo");
+	free(ab->pseudo);
 
 	ab = rz_iterator_next(iter);
 	mu_assert_streq(ab->opcode, "mov dword [rbp-0x04], edi", "rz_core_analysis_bytes opcode");
 	mu_assert_streq(ab->pseudo, "dword [rbp-0x04] = edi", "rz_core_analysis_bytes pseudo");
+	free(ab->pseudo);
 
 	rz_iterator_free(iter);
 	rz_core_free(core);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
This PR addresses several memory leaks in test/unit/test_analysis_op.c by ensuring the `pseudo` field of the RzAnalysisBytes structure is properly freed after each assertion.
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->
**Changes**
- test/unit/test_analysis_op.c: Added free(ab->pseudo) calls after each test step in test_rz_core_analysis_bytes.

**Technical Details**
The rz_iterator_next(iter) function populates the RzAnalysisBytes structure, including a dynamically allocated string for the pseudo field (which contains the high-level representation of the instruction, e.g., rbp = rsp).

Previously, this string was leaked in every iteration of the test loop, leading to a "dirty" test environment. While it didn't affect the test logic directly, it caused noise in memory leak detection tools used during CI.

**Validation**

- Verified that the unit tests still pass (make test).
- Confirmed via AddressSanitizer (ASAN) that these specific leak points are now resolved.

...

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
