### PR TITLE
librz/debug: clean core->dbg fields when rz_debug_use errors

### DIFF
--- a/librz/debug/debug.c
+++ b/librz/debug/debug.c
@@ -442,6 +442,7 @@ RZ_API void rz_debug_free(RzDebug *dbg) {
 	rz_debug_trace_free(dbg->trace);
 	rz_debug_session_free(dbg->session);
 	rz_analysis_op_free(dbg->cur_op);
+	rz_debug_use(dbg, NULL);
 	dbg->trace = NULL;
 	rz_egg_free(dbg->egg);
 	rz_reg_free(dbg->reg);

--- a/librz/debug/plugin.c
+++ b/librz/debug/plugin.c
@@ -37,17 +37,27 @@ RZ_API bool rz_debug_use(RzDebug *dbg, const char *name) {
 		return true;
 	}
 	if (dbg->analysis && dbg->analysis->cur) {
-		rz_debug_set_arch(dbg, dbg->analysis->cur->arch, dbg->bits);
+		if (!rz_debug_set_arch(dbg, dbg->analysis->cur->arch, dbg->bits)) {
+			goto err;
+		}
 	}
 	dbg->bp->breakpoint = dbg->cur->breakpoint;
 	dbg->bp->user = dbg;
-	if (dbg->cur->init) {
-		dbg->cur->init(dbg, &dbg->plugin_data);
+	if (dbg->cur->init && !dbg->cur->init(dbg, &dbg->plugin_data)) {
+		goto err;
 	}
 	// Syncing the reg profile here may fail if the plugin is not ready, but it should
 	// at least clean up the old RzReg contents.
-	rz_debug_reg_profile_sync(dbg);
+	if (!rz_debug_reg_profile_sync(dbg)) {
+		goto err;
+	}
 	return true;
+
+err:
+	dbg->plugin_data = NULL;
+	dbg->cur = NULL;
+	dbg->bp->breakpoint = NULL;
+	return false;
 }
 
 RZ_API bool rz_debug_plugin_add(RzDebug *dbg, RZ_NONNULL RzDebugPlugin *plugin) {

--- a/librz/debug/plugin.c
+++ b/librz/debug/plugin.c
@@ -54,9 +54,12 @@ RZ_API bool rz_debug_use(RzDebug *dbg, const char *name) {
 	return true;
 
 err:
+	if (dbg->cur && dbg->cur->fini) {
+		dbg->cur->fini(dbg, dbg->plugin_data);
+	}
 	dbg->plugin_data = NULL;
-	dbg->cur = NULL;
 	dbg->bp->breakpoint = NULL;
+	dbg->cur = NULL;
 	return false;
 }
 


### PR DESCRIPTION
Reproduce with:
```
$ rizin                                                                                                                                 22s
 -- Add comments using the ';' key in visual mode or the 'CC' command from the rizin shell
[0x00000000]> iH
ERROR: No binary object currently selected.
[0x00000000]> dl dmp
[0x00000000]> dbt
[1]    46420 segmentation fault  rizin
```

Essentially the `dl` calls the `rz_debug_use` which tries to initialise the debug plugin, but fails to setup it correctly. I believe at that point the function should return an error (false) instead of silently eating the error and moving forward.