### PR TITLE
Removed printing function from public RZ_API

### DIFF
--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -4341,37 +4341,6 @@ RZ_API bool rz_core_bin_fields_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFi
 	return true;
 }
 
-RZ_API bool rz_core_bin_structured_data_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RzOutputMode mode) {
-	rz_return_val_if_fail(core && bf, false);
-
-	RzBinObject *obj = rz_bin_cur_object(core->bin);
-	const RzStructuredData *sf = obj ? rz_bin_object_get_structured_data(obj) : NULL;
-	if (!sf) {
-		if (mode == RZ_OUTPUT_MODE_JSON) {
-			rz_cons_print("{}\n");
-		}
-		return true;
-	}
-
-	char *output = NULL;
-	switch (mode) {
-	case RZ_OUTPUT_MODE_JSON:
-		output = rz_structured_data_to_json(sf);
-		break;
-	case RZ_OUTPUT_MODE_STANDARD:
-		output = rz_structured_data_to_yaml(sf);
-		break;
-	default:
-		rz_warn_if_reached();
-		break;
-	}
-
-	rz_cons_printf("%s\n", output);
-	free(output);
-
-	return true;
-}
-
 static void bin_pe_versioninfo(RzCore *r, PJ *pj, RzOutputMode mode) {
 	Sdb *sdb = NULL;
 	int num_version = 0;

--- a/librz/core/cmd/cmd_info.c
+++ b/librz/core/cmd/cmd_info.c
@@ -135,6 +135,38 @@ static bool print_source_info(RzCore *core, PrintSourceInfoType type, RzCmdState
 	return true;
 }
 
+static bool core_bin_structured_data_print(RZ_NONNULL RzCore *core, RzOutputMode mode) {
+	rz_return_val_if_fail(core, false);
+
+	RzBinObject *obj = rz_bin_cur_object(core->bin);
+	const RzStructuredData *sf = obj ? rz_bin_object_get_structured_data(obj) : NULL;
+	if (!sf) {
+		if (mode == RZ_OUTPUT_MODE_JSON) {
+			rz_cons_print("{}\n");
+		}
+		return true;
+	}
+
+	char *output = NULL;
+	switch (mode) {
+	case RZ_OUTPUT_MODE_JSON:
+		output = rz_structured_data_to_json(sf);
+		break;
+	case RZ_OUTPUT_MODE_STANDARD:
+		output = rz_structured_data_to_yaml(sf);
+		break;
+	default:
+		rz_warn_if_reached();
+		break;
+	}
+
+	rz_return_val_if_fail(output, false);
+	rz_cons_printf("%s\n", output);
+	free(output);
+
+	return true;
+}
+
 RZ_IPI RzCmdStatus rz_cmd_info_query_handler(RzCore *core, int argc, const char **argv) {
 	RzBinObject *obj = rz_bin_cur_object(core->bin);
 	if (!obj || !obj->kv) {
@@ -418,7 +450,7 @@ RZ_IPI RzCmdStatus rz_cmd_info_fields_handler(RzCore *core, int argc, const char
 
 RZ_IPI RzCmdStatus rz_cmd_info_structured_data_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode) {
 	GET_CHECK_CUR_BINFILE(core);
-	return bool2status(rz_core_bin_structured_data_print(core, bf, mode));
+	return bool2status(core_bin_structured_data_print(core, mode));
 }
 
 RZ_IPI RzCmdStatus rz_cmd_info_binary_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -1101,7 +1101,6 @@ RZ_API RzCmdStatus rz_core_bin_class_apply_print(RZ_NONNULL RzCore *core, RZ_NON
 RZ_API bool rz_core_bin_classes_to_struct(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf);
 RZ_API bool rz_core_bin_signatures_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state);
 RZ_API bool rz_core_bin_fields_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state);
-RZ_API bool rz_core_bin_structured_data_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RzOutputMode mode);
 RZ_API bool rz_core_bin_dwarf_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state);
 RZ_API bool rz_core_bin_memory_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state);
 RZ_API bool rz_core_bin_resources_print(RZ_NONNULL RzCore *core, RZ_NONNULL RzBinFile *bf, RZ_NONNULL RzCmdStateOutput *state, RZ_NULLABLE RzList /*<char *>*/ *hashes);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

This PR removes a public API function from `librz/core/cbin.c` that was only responsible for printing binary structured data to the console, as there is no practical reason to expose this functionality publicly.

**Test plan**

Related to #5791 