### PR TITLE
Add inplace variants for rz_bv_(un)signed_cast()

### DIFF
--- a/librz/include/rz_util/rz_bitvector.h
+++ b/librz/include/rz_util/rz_bitvector.h
@@ -144,7 +144,9 @@ RZ_API ut32 rz_bv_hash(RZ_NULLABLE RzBitVector *x);
 RZ_API RZ_OWN RzBitVector *rz_bv_pred(RZ_NONNULL RzBitVector *bv);
 RZ_API RZ_OWN RzBitVector *rz_bv_succ(RZ_NONNULL RzBitVector *bv);
 RZ_API bool rz_bv_arshift(RZ_NONNULL RzBitVector *bv, ut32 dist);
+RZ_API bool rz_bv_signed_cast_inplace(RZ_INOUT RZ_NONNULL RzBitVector *bv, ut32 to_size);
 RZ_API RZ_OWN RzBitVector *rz_bv_signed_cast(RZ_NONNULL RzBitVector *bv, ut32 to_size);
+RZ_API bool rz_bv_unsigned_cast_inplace(RZ_INOUT RZ_NONNULL RzBitVector *bv, ut32 to_size);
 RZ_API RZ_OWN RzBitVector *rz_bv_unsigned_cast(RZ_NONNULL RzBitVector *bv, ut32 to_size);
 
 RZ_API bool rz_bv_slt(RZ_NONNULL RzBitVector *x, RZ_NONNULL RzBitVector *y);

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -2314,12 +2314,32 @@ RZ_API RzBitVector *rz_bv_cast(RZ_NONNULL RzBitVector *bv, ut32 to_size, bool fi
 
 /**
  * signed cast of bv, (signed_cast x n) = (cast x n (msb x))
+ * \param bv The vector which is cast in place. Its length changes.
+ * \param to_size cast bitvector length
+ * \return True if casting succeeded, false in case of failure.
+ */
+RZ_API bool rz_bv_signed_cast_inplace(RZ_INOUT RZ_NONNULL RzBitVector *bv, ut32 to_size) {
+	return rz_bv_cast_inplace(bv, to_size, rz_bv_msb(bv));
+}
+
+/**
+ * signed cast of bv, (signed_cast x n) = (cast x n (msb x))
  * \param bv
  * \param to_size cast bitvector length
  * \return new bv with length (to_size)
  */
 RZ_API RZ_OWN RzBitVector *rz_bv_signed_cast(RZ_NONNULL RzBitVector *bv, ut32 to_size) {
 	return rz_bv_cast(bv, to_size, rz_bv_msb(bv));
+}
+
+/**
+ * unsigned cast of bv, (signed_cast x n) = (cast x n 0)
+ * \param bv The vector which is cast in place. Its length changes.
+ * \param to_size cast bitvector length
+ * \return True if casting succeeded, false in case of failure.
+ */
+RZ_API bool rz_bv_unsigned_cast_inplace(RZ_INOUT RZ_NONNULL RzBitVector *bv, ut32 to_size) {
+	return rz_bv_cast_inplace(bv, to_size, false);
 }
 
 /**

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -1603,6 +1603,31 @@ bool test_rz_bv_cast_inplace(void) {
 
 	rz_bv_free(small);
 	rz_bv_free(large);
+
+	small = rz_bv_new_from_ut64(20, 0xe1234);
+	mu_assert_true(rz_bv_unsigned_cast_inplace(small, 24), "Cast failed");
+	mu_assert_eq(small->len, 24, "new size");
+	mu_assert_streq_free(rz_bv_as_hex_string(small, false), "0xe1234", "unsigned cast inplace result");
+	rz_bv_free(small);
+
+	small = rz_bv_new_from_ut64(20, 0x31234);
+	mu_assert_true(rz_bv_unsigned_cast_inplace(small, 24), "Cast failed");
+	mu_assert_eq(small->len, 24, "new size");
+	mu_assert_streq_free(rz_bv_as_hex_string(small, false), "0x31234", "unsigned cast inplace result");
+	rz_bv_free(small);
+
+	small = rz_bv_new_from_ut64(20, 0xe1234);
+	mu_assert_true(rz_bv_signed_cast_inplace(small, 24), "Cast failed");
+	mu_assert_eq(small->len, 24, "new size");
+	mu_assert_streq_free(rz_bv_as_hex_string(small, false), "0xfe1234", "signed cast inplace result");
+	rz_bv_free(small);
+
+	small = rz_bv_new_from_ut64(20, 0x31234);
+	mu_assert_true(rz_bv_signed_cast_inplace(small, 24), "Cast failed");
+	mu_assert_eq(small->len, 24, "new size");
+	mu_assert_streq_free(rz_bv_as_hex_string(small, false), "0x31234", "signed cast inplace result");
+	rz_bv_free(small);
+
 	mu_end;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

These shortcuts for inplace sign extension and zero extension were still missing.

**Test plan**

see the added unit tests
