### PR TITLE
rz-find: clarify -E semantics and add regression test

### DIFF
--- a/binrz/man/rz-find.1
+++ b/binrz/man/rz-find.1
@@ -39,7 +39,8 @@ Set block size
 .It Fl e Ar regex
 Search for regex matches (can be used multiple times)
 .It Fl E Ar cmd
-Execute shell command for each file found.
+Execute system shell command for each search hit.
+The current filename is appended as an argument to the command.
 .It Fl R Ar cmd
 Execute Rizin command for each search hit.
 .It Fl f Ar from

--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -231,7 +231,7 @@ static int show_help(const char *argv0, int line) {
 		"-a",    "align",   "Only accept aligned hits",
 		"-b",    "size",    "Set block size",
 		"-e",    "regex",   "Search for regex matches (can be used multiple times)",
-		"-E",    "cmd",     "Execute shell command for each file found.",
+		"-E",    "cmd",     "Execute system shell command for each search hit (appends the current filename as an argument).",
 		"-R",    "cmd",     "Execute Rizin command for each search hit.",
 		"-f",    "from",    "Start searching from address 'from'",
 		"-F",    "file",    "Read the contents of the file and use it as keyword",

--- a/test/db/tools/rz_find_exec
+++ b/test/db/tools/rz_find_exec
@@ -1,0 +1,14 @@
+NAME=rz-find -E executes once per hit (filename appended)
+TOOL=rz-find
+ARGS=-s GCC -E echo files/rz_find_exec_input.txt
+REGEXP_FILTER_OUT=rz_find_exec_input.txt
+EXPECT=<<EOF
+rz_find_exec_input.txt
+rz_find_exec_input.txt
+rz_find_exec_input.txt
+rz_find_exec_input.txt
+rz_find_exec_input.txt
+rz_find_exec_input.txt
+rz_find_exec_input.txt
+EOF
+RUN

--- a/test/files/rz_find_exec_input.txt
+++ b/test/files/rz_find_exec_input.txt
@@ -1,0 +1,7 @@
+GCC
+GCC
+GCC
+GCC
+GCC
+GCC
+GCC


### PR DESCRIPTION
## Summary
- Clarify rz-find -E help/man text: runs a system command once per hit and appends filename.
- Add a small fixture-based rz-test to lock behavior.

## Test plan
- Ran: rz-test db/tools/rz_find_exec