### PR TITLE
Rewrite of existing ESIL-based analysis passes with RzIL

### DIFF
--- a/librz/arch/fcn.c
+++ b/librz/arch/fcn.c
@@ -573,6 +573,18 @@ static bool is_unknown_call_from_plt(RzAnalysis *analysis, ut64 op_address) {
 }
 
 /**
+ * Assuming arm, detect if op is "mov lr, pc"
+ */
+static bool op_is_arm_mov_lr_pc(RzAnalysisOp *op) {
+	RzAnalysisLiftedILOp il = op->il_op;
+	if (!il || il->code != RZ_IL_OP_SET || il->op.set.is_local || strcmp(il->op.set.v, "lr")) {
+		return false;
+	}
+	RzILOpPure *src = il->op.set.x;
+	return src->code == RZ_IL_OP_BITV && rz_bv_to_ut64(src->op.bitv.value) == op->addr + 2 * op->size;
+}
+
+/**
  * \brief Analyses the given task item \p item for branches.
  *
  * Analysis starts for all instructions from \p item->start_address. If a branch is
@@ -943,11 +955,8 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 		case RZ_ANALYSIS_OP_TYPE_CMOV:
 		case RZ_ANALYSIS_OP_TYPE_MOV:
 			last_is_reg_mov_lea = false;
-			if (is_arm) { // mov lr, pc
-				const char *esil = rz_strbuf_get(&op.esil);
-				if (!rz_str_cmp(esil, "pc,lr,=", -1)) {
-					last_is_mov_lr_pc = true;
-				}
+			if (is_arm && op_is_arm_mov_lr_pc(&op)) { // mov lr, pc
+				last_is_mov_lr_pc = true;
 			}
 			if (has_stack_regs && op_is_set_bp(&op, bp_reg, sp_reg)) {
 				fcn->bp_off = -sp;

--- a/librz/arch/fcn.c
+++ b/librz/arch/fcn.c
@@ -755,7 +755,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 		}
 		rz_analysis_op_fini(&op);
 		rz_analysis_op_init(&op);
-		if ((oplen = rz_analysis_op(analysis, &op, at, buf, bytes_read, RZ_ANALYSIS_OP_MASK_ESIL | RZ_ANALYSIS_OP_MASK_VAL | RZ_ANALYSIS_OP_MASK_HINT)) < 1) {
+		if ((oplen = rz_analysis_op(analysis, &op, at, buf, bytes_read, RZ_ANALYSIS_OP_MASK_ESIL | RZ_ANALYSIS_OP_MASK_IL | RZ_ANALYSIS_OP_MASK_VAL | RZ_ANALYSIS_OP_MASK_HINT)) < 1) {
 			RZ_LOG_DEBUG("Invalid instruction at 0x%" PFMT64x " with %d bits\n", at, analysis->bits);
 			// gotoBeach (RZ_ANALYSIS_RET_ERROR);
 			// RET_END causes infinite loops somehow

--- a/librz/arch/var.c
+++ b/librz/arch/var.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Florian Märkl <info@florianmaerkl.de>
+// SPDX-FileCopyrightText: 2022-2026 Florian Märkl <info@florianmaerkl.de>
 // SPDX-FileCopyrightText: 2010-2020 pancake <pancake@nopcode.org>
 // SPDX-FileCopyrightText: 2010-2020 oddcoder <ahmedsoliman@oddcoder.com>
 // SPDX-License-Identifier: LGPL-3.0-only
@@ -9,6 +9,13 @@
 #include <rz_cons.h>
 
 #define ACCESS_CMP(x, y) ((st64)((ut64)(x) - (ut64)((RzAnalysisVarAccess *)y)->offset))
+
+#if 0
+#define P(...) eprintf(__VA_ARGS__)
+#define PRINTING
+#else
+#define P(...)
+#endif
 
 /**
  * \brief Compare two RzAnalysisVarAccess objects.
@@ -350,6 +357,14 @@ RZ_API RZ_BORROW RzAnalysisVar *rz_analysis_function_set_var(
 	RZ_NONNULL const char *name) {
 	rz_return_val_if_fail(fcn && name, NULL);
 	RzAnalysisVar *var = rz_analysis_function_get_var_byname(fcn, name);
+	if (stor->type == RZ_ANALYSIS_VAR_STORAGE_STACK) {
+		P("SET VAR @ stack + %"PFMT64d" with name %s\n", stor->stack_off, name);
+#ifdef PRINTING
+		rz_sys_backtrace();
+#endif
+	} else {
+		P("SET OTHER VAR\n");
+	}
 	if (var) {
 		if (!rz_analysis_var_storage_equals(&var->storage, stor)) {
 			// var name already exists at a different kind+delta
@@ -1087,6 +1102,138 @@ static inline bool is_not_read_nor_write(const RzAnalysisOpDirection direction) 
 	return direction != RZ_ANALYSIS_OP_DIR_READ && direction != RZ_ANALYSIS_OP_DIR_WRITE;
 }
 
+typedef struct {
+	const char *reg;
+	const char *sign;
+	st64 *addend_out;
+} ExtractRegBasedVarCtx;
+
+static RzILRecurseCont extract_reg_based_variable_cb_pure(RzILOpPure *op, void *user) {
+	ExtractRegBasedVarCtx *ctx = user;
+
+	// Pattern matching for any of:
+	// (+ (var <reg>)  (bv <const>))
+	// (+ (bv <const>) (var <reg>))
+	// (- (var <reg>)  (bv <const>))
+
+	RzILOpBitVector *reg_op;
+	RzILOpBitVector *const_op;
+	if (op->code == RZ_IL_OP_ADD) {
+		// add is commutative
+		reg_op = op->op.add.x->code == RZ_IL_OP_VAR ? op->op.add.x : op->op.add.y;
+		const_op = op->op.add.x->code == RZ_IL_OP_VAR ? op->op.add.y : op->op.add.x;
+	} else if (op->code == RZ_IL_OP_SUB) {
+		reg_op = op->op.sub.x;
+		const_op = op->op.sub.y;
+	} else {
+		return RZ_IL_RECURSE_STEP_INTO;
+	}
+
+	if (reg_op->code != RZ_IL_OP_VAR || const_op->code != RZ_IL_OP_BITV || strcmp(reg_op->op.var.v, ctx->reg)) {
+		return RZ_IL_RECURSE_STEP_INTO;
+	}
+	RzBitVector *const_val = const_op->op.bitv.value;
+	bool op_is_subtracting = rz_bv_msb(const_val) != (op->code == RZ_IL_OP_SUB);
+	if (op_is_subtracting != (*ctx->sign == '-')) {
+		return RZ_IL_RECURSE_STEP_INTO;
+	}
+	RzBitVector val;
+	rz_bv_init_copy(&val, const_val);
+	if (op->code == RZ_IL_OP_SUB) {
+		rz_bv_neg_inplace(&val);
+	}
+	char *s = rz_bv_as_hex_string(&val, true);
+	rz_bv_signed_cast_inplace(&val, 64);
+	P("bv: %s\n", s);
+	*ctx->addend_out = (st64)rz_bv_to_ut64(&val);
+	return RZ_IL_RECURSE_BREAK;
+}
+
+static RzILRecurseCont extract_reg_bases_variable_cb_effect(RzILOpEffect *op, void *user) {
+	ExtractRegBasedVarCtx *ctx = user;
+	if (op->code == RZ_IL_OP_SET && !strcmp(op->op.set.v, ctx->reg)) {
+		// skip assignments like
+		//   rsp += 8
+		// as encountered for example during function return
+		return RZ_IL_RECURSE_STEP_OVER;
+	}
+	return RZ_IL_RECURSE_STEP_INTO;
+}
+
+static bool extract_reg_based_variable_access(RzILOpEffect *op, const char *reg, const char *sign, st64 *addend_out) {
+	ExtractRegBasedVarCtx ctx = {
+		.reg = reg,
+		.sign = sign,
+		.addend_out = addend_out
+	};
+	return !rz_il_op_effect_recurse(op, extract_reg_bases_variable_cb_effect, &ctx, extract_reg_based_variable_cb_pure, &ctx);
+}
+
+static bool extract_reg_based_variable_access_esil(RzAnalysis *analysis, RzAnalysisOp *op, const char *reg, const char *sign, st64 *addend_out) {
+	char *esil_buf = NULL;
+	const char *op_esil = rz_strbuf_get(&op->esil);
+	if (!op_esil) {
+		return false;
+	}
+	esil_buf = rz_str_dup(op_esil);
+	if (!esil_buf) {
+		return false;
+	}
+	char *tmp = rz_str_newf(",%s,%s,", reg, sign);
+	char *ptr_end = tmp ? strstr(esil_buf, tmp) : NULL;
+	free(tmp);
+	if (!ptr_end) {
+		free(esil_buf);
+		return false;
+	}
+	P("occurence: %s       in         %s\n", ptr_end, op_esil);
+	*ptr_end = 0;
+	char *addr = ptr_end;
+	while ((addr[0] != '0' || addr[1] != 'x') && addr >= esil_buf + 1 && *addr != ',') {
+		addr--;
+	}
+	P("   => addr = %s\n", addr);
+	if (strncmp(addr, "0x", 2)) {
+		P("  " Color_RED "ESIL going into WORKAROUND!\n" Color_RESET);
+		// XXX: This is a workaround for inconsistent esil
+		if (!op->stackop && op->dst) {
+			const char *sp = rz_reg_get_name(analysis->reg, RZ_REG_NAME_SP);
+			const char *bp = rz_reg_get_name(analysis->reg, RZ_REG_NAME_BP);
+			const char *rn = op->dst->reg ? op->dst->reg->name : NULL;
+			if (rn && ((bp && !strcmp(bp, rn)) || (sp && !strcmp(sp, rn)))) {
+				RZ_LOG_DEBUG("Analysis didn't fill op->stackop for instruction that alters stack at 0x%" PFMT64x ".\n", op->addr);
+				goto beach;
+			}
+		}
+		if (*addr == ',') {
+			addr++;
+		}
+		if (!op->stackop && op->type != RZ_ANALYSIS_OP_TYPE_PUSH && op->type != RZ_ANALYSIS_OP_TYPE_POP && op->type != RZ_ANALYSIS_OP_TYPE_RET && rz_str_isnumber(addr)) {
+			*addend_out = (st64)rz_num_get(NULL, addr);
+			if (*addend_out && op->src[0] && *addend_out == op->src[0]->imm) {
+				goto beach;
+			}
+		} else if ((op->stackop == RZ_ANALYSIS_STACK_SET) || (op->stackop == RZ_ANALYSIS_STACK_GET)) {
+			if (op->ptr % 4) {
+				goto beach;
+			}
+			*addend_out = op->ptr;
+		} else {
+			goto beach;
+		}
+	} else {
+		*addend_out = (st64)rz_num_get(NULL, addr);
+	}
+	if (*sign == '-') {
+		*addend_out = -*addend_out;
+	}
+	free(esil_buf);
+	return true;
+beach:
+	free(esil_buf);
+	return false;
+}
+
 /**
  * \brief Try to extract any args from a single op
  *
@@ -1098,6 +1245,7 @@ static void extract_stack_var(RzAnalysis *analysis, RzAnalysisFunction *fcn, RzA
 	st64 addend = 0;
 	bool found_addend = false;
 	size_t i;
+#define PRINTEND P("^ 0x%"PFMT64x" ----\n", op->addr);
 	for (i = 0; i < RZ_ARRAY_SIZE(op->src); i++) {
 		if (!op->src[i] || !op->src[i]->reg || !op->src[i]->reg->name) {
 			continue;
@@ -1119,65 +1267,48 @@ static void extract_stack_var(RzAnalysis *analysis, RzAnalysisFunction *fcn, RzA
 		break;
 	}
 
-	char *esil_buf = NULL;
 	if (!found_addend) {
-		const char *op_esil = rz_strbuf_get(&op->esil);
-		if (!op_esil) {
+		st64 addend_from_esil = 0;
+		bool from_esil = extract_reg_based_variable_access_esil(analysis, op, reg, sign, &addend_from_esil);
+
+		RzAnalysisLiftedILOp il = op->il_op;
+		found_addend = il && extract_reg_based_variable_access(il, reg, sign, &addend);
+
+		if (!from_esil && !found_addend) {
+			PRINTEND
 			return;
 		}
-		esil_buf = rz_str_dup(op_esil);
-		if (!esil_buf) {
-			return;
-		}
-		char *tmp = rz_str_newf(",%s,%s,", reg, sign);
-		char *ptr_end = tmp ? strstr(esil_buf, tmp) : NULL;
-		free(tmp);
-		if (!ptr_end) {
-			free(esil_buf);
-			return;
-		}
-		*ptr_end = 0;
-		char *addr = ptr_end;
-		while ((addr[0] != '0' || addr[1] != 'x') && addr >= esil_buf + 1 && *addr != ',') {
-			addr--;
-		}
-		if (strncmp(addr, "0x", 2)) {
-			// XXX: This is a workaround for inconsistent esil
-			if (!op->stackop && op->dst) {
-				const char *sp = rz_reg_get_name(analysis->reg, RZ_REG_NAME_SP);
-				const char *bp = rz_reg_get_name(analysis->reg, RZ_REG_NAME_BP);
-				const char *rn = op->dst->reg ? op->dst->reg->name : NULL;
-				if (rn && ((bp && !strcmp(bp, rn)) || (sp && !strcmp(sp, rn)))) {
-					RZ_LOG_DEBUG("Analysis didn't fill op->stackop for instruction that alters stack at 0x%" PFMT64x ".\n", op->addr);
-					goto beach;
-				}
-			}
-			if (*addr == ',') {
-				addr++;
-			}
-			if (!op->stackop && op->type != RZ_ANALYSIS_OP_TYPE_PUSH && op->type != RZ_ANALYSIS_OP_TYPE_POP && op->type != RZ_ANALYSIS_OP_TYPE_RET && rz_str_isnumber(addr)) {
-				addend = (st64)rz_num_get(NULL, addr);
-				if (addend && op->src[0] && addend == op->src[0]->imm) {
-					goto beach;
-				}
-			} else if ((op->stackop == RZ_ANALYSIS_STACK_SET) || (op->stackop == RZ_ANALYSIS_STACK_GET)) {
-				if (op->ptr % 4) {
-					goto beach;
-				}
-				addend = op->ptr;
-			} else {
-				goto beach;
-			}
-		} else {
-			addend = (st64)rz_num_get(NULL, addr);
-		}
-		if (*sign == '-') {
-			addend = -addend;
-		}
+
 		if (addend == 0 && is_not_read_nor_write(op->direction)) {
 			// avoid creating variables for just `mov rbp, rsp`, which would otherwise detect a var at rsp+0
 			// so for addend == 0, we only consider actual memory operations for now
-			goto beach;
+			PRINTEND
+			return;
+		}
+
+		if (from_esil || found_addend) {
+			P("  0x%" PFMT64x "    reg is %s, sign is %s\n", op->addr, reg, sign);
+			if (from_esil) {
+				P("  ESIL extracted: %" PFMT64d "\n", addend_from_esil);
+			}
+			if (found_addend) {
+				P("  RzIL extracted: %" PFMT64d "\n", addend);
+			}
+			if (found_addend != from_esil) {
+				P("  esil was %s\n", rz_strbuf_get(&op->esil));
+				if (il) {
+					RzStrBuf buf;
+					rz_strbuf_init(&buf);
+					rz_il_op_effect_stringify(op->il_op, &buf, true);
+					P("  rzil was %s\n", rz_strbuf_get(&buf));
+					rz_strbuf_fini(&buf);
+				} else {
+					P("  rzil was NOT LIFTED\n");
+				}
+#ifdef PRINTING
+				rz_sys_backtrace();
+#endif
+			}
 		}
 	}
 
@@ -1193,7 +1324,7 @@ static void extract_stack_var(RzAnalysis *analysis, RzAnalysisFunction *fcn, RzA
 	}
 	if (!stack_off) {
 		// Do not create a var/arg for the return address
-		free(esil_buf);
+		PRINTEND
 		return;
 	}
 
@@ -1204,7 +1335,8 @@ static void extract_stack_var(RzAnalysis *analysis, RzAnalysisFunction *fcn, RzA
 		RzAnalysisVar *var = rz_analysis_function_get_stack_var_at(fcn, stack_off);
 		if (var) {
 			rz_analysis_var_set_access(var, reg, op->addr, rw, addend);
-			goto beach;
+			PRINTEND
+			return;
 		}
 		char *varname = NULL;
 		RzType *vartype = NULL;
@@ -1262,7 +1394,8 @@ static void extract_stack_var(RzAnalysis *analysis, RzAnalysisFunction *fcn, RzA
 		RzAnalysisVar *var = rz_analysis_function_get_stack_var_at(fcn, stor.stack_off);
 		if (var) {
 			rz_analysis_var_set_access(var, reg, op->addr, rw, addend);
-			goto beach;
+			PRINTEND
+			return;
 		}
 		char *varname = rz_str_newf("%s_%" PFMT64x "h", VARPREFIX, RZ_ABS(stor.stack_off));
 		if (varname) {
@@ -1273,8 +1406,7 @@ static void extract_stack_var(RzAnalysis *analysis, RzAnalysisFunction *fcn, RzA
 			free(varname);
 		}
 	}
-beach:
-	free(esil_buf);
+	PRINTEND
 }
 
 static bool is_reg_in_src(const char *regname, RzAnalysis *analysis, RzAnalysisOp *op);

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -1577,7 +1577,7 @@ static bool analysis_block_cb(RzAnalysisBlock *bb, BlockRecurseCtx *ctx) {
 		if (rz_cons_is_breaked()) {
 			break;
 		}
-		RzAnalysisOp *op = rz_core_analysis_op(core, pos, RZ_ANALYSIS_OP_MASK_ESIL | RZ_ANALYSIS_OP_MASK_VAL | RZ_ANALYSIS_OP_MASK_HINT);
+		RzAnalysisOp *op = rz_core_analysis_op(core, pos, RZ_ANALYSIS_OP_MASK_ESIL | RZ_ANALYSIS_OP_MASK_IL | RZ_ANALYSIS_OP_MASK_VAL | RZ_ANALYSIS_OP_MASK_HINT);
 		if (!op) {
 			// eprintf ("Cannot get op\n");
 			break;

--- a/librz/il/il_traverse.c
+++ b/librz/il/il_traverse.c
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: 2026 Florian Märkl <info@florianmaerkl.de>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_il/rz_il_traverse.h>
+
+/**
+ * \brief Recurse into \p op, pre-order, depth-first
+ *
+ * \param op the op to traverse
+ * \param cb callback to be called with each node encountered
+ * \param user passed to \p cb
+ * \return false if cb returned RZ_IL_RECURSE_BREAK at some point, true otherwise
+ */
+RZ_API bool rz_il_op_pure_recurse(RZ_NONNULL RzILOpPure *op, RZ_NONNULL RzILRecursePureCB cb, void *user) {
+#define RECURSE(child_op) rz_il_op_pure_recurse(child_op, cb, user)
+	RzILRecurseCont cont = cb(op, user);
+	if (cont == RZ_IL_RECURSE_BREAK) {
+		return false;
+	}
+	if (cont == RZ_IL_RECURSE_STEP_OVER) {
+		return true;
+	}
+	switch (op->code) {
+	case RZ_IL_OP_ITE:
+		return RECURSE(op->op.ite.condition) && RECURSE(op->op.ite.x) && RECURSE(op->op.ite.y);
+	case RZ_IL_OP_LET:
+		return RECURSE(op->op.let.exp) && RECURSE(op->op.let.body);
+	case RZ_IL_OP_INV:
+		return RECURSE(op->op.boolinv.x);
+	case RZ_IL_OP_AND:
+		return RECURSE(op->op.booland.x) && RECURSE(op->op.booland.y);
+	case RZ_IL_OP_OR:
+		return RECURSE(op->op.boolor.x) && RECURSE(op->op.boolor.y);
+	case RZ_IL_OP_XOR:
+		return RECURSE(op->op.boolxor.x) && RECURSE(op->op.boolxor.y);
+	case RZ_IL_OP_MSB:
+		return RECURSE(op->op.msb.bv);
+	case RZ_IL_OP_LSB:
+		return RECURSE(op->op.lsb.bv);
+	case RZ_IL_OP_IS_ZERO:
+		return RECURSE(op->op.is_zero.bv);
+	case RZ_IL_OP_NEG:
+		return RECURSE(op->op.neg.bv);
+	case RZ_IL_OP_LOGNOT:
+		return RECURSE(op->op.lognot.bv);
+	case RZ_IL_OP_ADD:
+		return RECURSE(op->op.add.x) && RECURSE(op->op.add.y);
+	case RZ_IL_OP_SUB:
+		return RECURSE(op->op.sub.x) && RECURSE(op->op.sub.y);
+	case RZ_IL_OP_MUL:
+		return RECURSE(op->op.mul.x) && RECURSE(op->op.mul.y);
+	case RZ_IL_OP_DIV:
+		return RECURSE(op->op.div.x) && RECURSE(op->op.div.y);
+	case RZ_IL_OP_SDIV:
+		return RECURSE(op->op.sdiv.x) && RECURSE(op->op.sdiv.y);
+	case RZ_IL_OP_MOD:
+		return RECURSE(op->op.mod.x) && RECURSE(op->op.mod.y);
+	case RZ_IL_OP_SMOD:
+		return RECURSE(op->op.smod.x) && RECURSE(op->op.smod.y);
+	case RZ_IL_OP_LOGAND:
+		return RECURSE(op->op.logand.x) && RECURSE(op->op.logand.y);
+	case RZ_IL_OP_LOGOR:
+		return RECURSE(op->op.logor.x) && RECURSE(op->op.logor.y);
+	case RZ_IL_OP_LOGXOR:
+		return RECURSE(op->op.logxor.x) && RECURSE(op->op.logxor.y);
+	case RZ_IL_OP_SHIFTR:
+		return RECURSE(op->op.shiftr.x) && RECURSE(op->op.shiftr.y);
+	case RZ_IL_OP_SHIFTL:
+		return RECURSE(op->op.shiftl.x) && RECURSE(op->op.shiftl.y);
+	case RZ_IL_OP_EQ:
+		return RECURSE(op->op.eq.x) && RECURSE(op->op.eq.y);
+	case RZ_IL_OP_SLE:
+		return RECURSE(op->op.sle.x) && RECURSE(op->op.sle.y);
+	case RZ_IL_OP_ULE:
+		return RECURSE(op->op.ule.x) && RECURSE(op->op.ule.y);
+	case RZ_IL_OP_CAST:
+		return RECURSE(op->op.cast.val) && RECURSE(op->op.cast.fill);
+	case RZ_IL_OP_APPEND:
+		return RECURSE(op->op.append.high) && RECURSE(op->op.append.low);
+	case RZ_IL_OP_FLOAT:
+		return RECURSE(op->op.float_.bv);
+	case RZ_IL_OP_FBITS:
+		return RECURSE(op->op.fbits.f);
+	case RZ_IL_OP_IS_FINITE:
+		return RECURSE(op->op.is_finite.f);
+	case RZ_IL_OP_IS_NAN:
+		return RECURSE(op->op.is_nan.f);
+	case RZ_IL_OP_IS_INF:
+		return RECURSE(op->op.is_inf.f);
+	case RZ_IL_OP_IS_FZERO:
+		return RECURSE(op->op.is_fzero.f);
+	case RZ_IL_OP_IS_FNEG:
+		return RECURSE(op->op.is_fneg.f);
+	case RZ_IL_OP_IS_FPOS:
+		return RECURSE(op->op.is_fpos.f);
+	case RZ_IL_OP_FNEG:
+		return RECURSE(op->op.fneg.f);
+	case RZ_IL_OP_FABS:
+		return RECURSE(op->op.fabs.f);
+	case RZ_IL_OP_FCAST_INT:
+		return RECURSE(op->op.fcast_int.f);
+	case RZ_IL_OP_FCAST_SINT:
+		return RECURSE(op->op.fcast_sint.f);
+	case RZ_IL_OP_FCAST_FLOAT:
+		return RECURSE(op->op.fcast_float.bv);
+	case RZ_IL_OP_FCAST_SFLOAT:
+		return RECURSE(op->op.fcast_sfloat.bv);
+	case RZ_IL_OP_FCONVERT:
+		return RECURSE(op->op.fconvert.f);
+	case RZ_IL_OP_FSUCC:
+		return RECURSE(op->op.fsucc.f);
+	case RZ_IL_OP_FPRED:
+		return RECURSE(op->op.fpred.f);
+	case RZ_IL_OP_FORDER:
+		return RECURSE(op->op.forder.x) && RECURSE(op->op.forder.y);
+	case RZ_IL_OP_FROUND:
+		return RECURSE(op->op.fround.f);
+	case RZ_IL_OP_FSQRT:
+		return RECURSE(op->op.fsqrt.f);
+	case RZ_IL_OP_FRSQRT:
+		return RECURSE(op->op.frsqrt.f);
+	case RZ_IL_OP_FADD:
+		return RECURSE(op->op.fadd.x) && RECURSE(op->op.fadd.y);
+	case RZ_IL_OP_FSUB:
+		return RECURSE(op->op.fsub.x) && RECURSE(op->op.fsub.y);
+	case RZ_IL_OP_FMUL:
+		return RECURSE(op->op.fmul.x) && RECURSE(op->op.fmul.y);
+	case RZ_IL_OP_FDIV:
+		return RECURSE(op->op.fdiv.x) && RECURSE(op->op.fdiv.y);
+	case RZ_IL_OP_FMOD:
+		return RECURSE(op->op.fmod.x) && RECURSE(op->op.fmod.y);
+	case RZ_IL_OP_FHYPOT:
+		return RECURSE(op->op.fhypot.x) && RECURSE(op->op.fhypot.y);
+	case RZ_IL_OP_FPOW:
+		return RECURSE(op->op.fpow.x) && RECURSE(op->op.fpow.y);
+	case RZ_IL_OP_FMAD:
+		return RECURSE(op->op.fmad.x) && RECURSE(op->op.fmad.y) && RECURSE(op->op.fmad.z);
+	case RZ_IL_OP_FROOTN:
+		return RECURSE(op->op.frootn.f) && RECURSE(op->op.frootn.n);
+	case RZ_IL_OP_FPOWN:
+		return RECURSE(op->op.fpown.f) && RECURSE(op->op.fpown.n);
+	case RZ_IL_OP_FCOMPOUND:
+		return RECURSE(op->op.fcompound.f) && RECURSE(op->op.fcompound.n);
+	case RZ_IL_OP_FEXCEPT:
+		return RECURSE(op->op.fexcept.x);
+	case RZ_IL_OP_LOAD:
+		return RECURSE(op->op.load.key);
+	case RZ_IL_OP_LOADW:
+		return RECURSE(op->op.loadw.key);
+	default:
+		return true;
+	}
+#undef RECURSE
+}
+
+/**
+ * \brief Recurse into \p op, pre-order, depth-first
+ *
+ * \param op the op to traverse
+ * \param effect_cb callback to be called with each effect node encountered. If NULL, RZ_IL_RECURSE_STEP_INTO is assumed.
+ * \param effect_user passed to \p effect_cb
+ * \param pure_cb callback to be called with each effect node encountered. If NULL, no recursion into pure ops is done.
+ * \param pure_user passed to \p pure_cb
+ * \return false if any of the two callbacks returned RZ_IL_RECURSE_BREAK at some point, true otherwise
+ */
+RZ_API bool rz_il_op_effect_recurse(RZ_NONNULL RzILOpEffect *op,
+	RZ_NULLABLE RzILRecurseEffectCB effect_cb, void *effect_user,
+	RZ_NULLABLE RzILRecursePureCB pure_cb, void *pure_user) {
+#define RECURSE(child_op)      rz_il_op_effect_recurse(child_op, effect_cb, effect_user, pure_cb, pure_user)
+#define RECURSE_PURE(child_op) (!pure_cb || rz_il_op_pure_recurse(child_op, pure_cb, pure_user))
+	if (effect_cb) {
+		RzILRecurseCont cont = effect_cb(op, effect_user);
+		if (cont == RZ_IL_RECURSE_BREAK) {
+			return false;
+		}
+		if (cont == RZ_IL_RECURSE_STEP_OVER) {
+			return true;
+		}
+	}
+	switch (op->code) {
+	case RZ_IL_OP_STORE:
+		return RECURSE_PURE(op->op.store.value) && RECURSE_PURE(op->op.store.key);
+	case RZ_IL_OP_STOREW:
+		return RECURSE_PURE(op->op.storew.value) && RECURSE_PURE(op->op.storew.key);
+	case RZ_IL_OP_SET:
+		return RECURSE_PURE(op->op.set.x);
+	case RZ_IL_OP_SEQ:
+		return RECURSE(op->op.seq.x) && RECURSE(op->op.seq.y);
+	case RZ_IL_OP_BLK:
+		return RECURSE(op->op.blk.data_eff) && RECURSE(op->op.blk.ctrl_eff);
+	case RZ_IL_OP_REPEAT:
+		return RECURSE_PURE(op->op.repeat.condition) && RECURSE(op->op.repeat.data_eff);
+	case RZ_IL_OP_BRANCH:
+		return RECURSE_PURE(op->op.branch.condition) && RECURSE(op->op.branch.true_eff) && RECURSE(op->op.branch.false_eff);
+	default:
+		return true;
+	}
+#undef RECURSE
+#undef RECURSE_PURE
+}

--- a/librz/il/meson.build
+++ b/librz/il/meson.build
@@ -22,6 +22,7 @@ rz_il_sources = [
    'il_validate.c',
    'il_vm.c',
    'il_vm_eval.c',
+   'il_traverse.c'
 ]
 
 rz_il_inc = [

--- a/librz/include/meson.build
+++ b/librz/include/meson.build
@@ -160,7 +160,8 @@ rz_il_files = [
   'rz_il/rz_il_events.h',
   'rz_il/rz_il_reg.h',
   'rz_il/rz_il_validate.h',
-  'rz_il/rz_il_vm.h'
+  'rz_il/rz_il_vm.h',
+  'rz_il/rz_il_traverse.h'
 ]
 install_headers(rz_il_files, install_dir: join_paths(rizin_incdir, 'rz_il'))
 

--- a/librz/include/rz_il.h
+++ b/librz/include/rz_il.h
@@ -5,5 +5,6 @@
 #include <rz_il/rz_il_vm.h>
 #include <rz_il/rz_il_opcodes.h>
 #include <rz_il/rz_il_reg.h>
+#include <rz_il/rz_il_traverse.h>
 
 #endif // RZ_IL_H

--- a/librz/include/rz_il/rz_il_traverse.h
+++ b/librz/include/rz_il/rz_il_traverse.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Florian Märkl <info@florianmaerkl.de>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef RZ_IL_TRAVERSE_H
+#define RZ_IL_TRAVERSE_H
+
+#include <rz_il/rz_il_opcodes.h>
+
+typedef enum rz_il_recurse_cont {
+	RZ_IL_RECURSE_BREAK,
+	RZ_IL_RECURSE_STEP_INTO,
+	RZ_IL_RECURSE_STEP_OVER
+} RzILRecurseCont;
+
+typedef RzILRecurseCont (*RzILRecursePureCB)(RzILOpPure *op, void *user);
+typedef RzILRecurseCont (*RzILRecurseEffectCB)(RzILOpEffect *op, void *user);
+
+RZ_API bool rz_il_op_pure_recurse(RZ_NONNULL RzILOpPure *op, RZ_NONNULL RzILRecursePureCB cb, void *user);
+RZ_API bool rz_il_op_effect_recurse(RZ_NONNULL RzILOpEffect *op,
+	RZ_NULLABLE RzILRecurseEffectCB effect_cb, void *effect_user,
+	RZ_NULLABLE RzILRecursePureCB pure_cb, void *pure_user);
+
+#endif // RZ_IL_TRAVERSE_H

--- a/librz/include/rz_util/rz_bitvector.h
+++ b/librz/include/rz_util/rz_bitvector.h
@@ -38,6 +38,7 @@ typedef struct bitvector_t {
 
 // init
 RZ_API bool rz_bv_init(RZ_NONNULL RzBitVector *bv, ut32 length);
+RZ_API bool rz_bv_init_copy(RZ_NONNULL RzBitVector *bv, RZ_NONNULL const RzBitVector *src);
 RZ_API RZ_OWN RzBitVector *rz_bv_new(ut32 length);
 RZ_API RZ_OWN RzBitVector *rz_bv_dup(const RZ_NONNULL RzBitVector *bv);
 RZ_API RZ_OWN RzBitVector *rz_bv_append(RZ_NONNULL RzBitVector *bv1, RZ_NONNULL RzBitVector *bv2);

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -68,6 +68,25 @@ RZ_API bool rz_bv_init(RZ_NONNULL RzBitVector *bv, ut32 length) {
 }
 
 /**
+ * \brief Initialize \p bv, assigning the value of \p src
+ * \param bv uninitialized RzBitVector structure
+ * \param src value to copy into the newly initialized bitvector
+ * \return true if succeeded
+ */
+RZ_API bool rz_bv_init_copy(RZ_NONNULL RzBitVector *bv, RZ_NONNULL const RzBitVector *src) {
+	rz_return_val_if_fail(bv && src, false);
+	bool r = rz_bv_init(bv, rz_bv_len(src));
+	if (!r) {
+		return false;
+	}
+	if (!rz_bv_copy(bv, src)) {
+		rz_bv_fini(bv);
+		return false;
+	}
+	return true;
+}
+
+/**
  * \brief Clear a RzBitVector structure
  */
 RZ_API void rz_bv_fini(RZ_NONNULL RzBitVector *bv) {
@@ -1181,8 +1200,9 @@ RZ_API RZ_OWN RzBitVector *rz_bv_sub(RZ_NONNULL RzBitVector *x, RZ_NONNULL RzBit
 RZ_API bool rz_bv_mul_inplace(RZ_NONNULL RZ_INOUT RzBitVector *x, const RZ_NONNULL RzBitVector *y) {
 	rz_return_val_if_fail(x && y, false);
 	RzBitVector dup;
-	rz_bv_init(&dup, x->len);
-	rz_bv_copy(&dup, x);
+	if (!rz_bv_init_copy(&dup, x)) {
+		return false;
+	}
 	rz_bv_set_all(x, false);
 
 	bool cur_bit = false;
@@ -1295,11 +1315,13 @@ RZ_API bool rz_bv_div_inplace(RZ_NONNULL RZ_INOUT RzBitVector *x, const RZ_NONNU
 	// dividend > divisor
 	// do typical division by shift and subtract
 	RzBitVector dend;
-	rz_bv_init(&dend, x->len);
-	rz_bv_copy(&dend, x);
+	if (!rz_bv_init_copy(&dend, x)) {
+		return false;
+	}
 	RzBitVector sor;
-	rz_bv_init(&sor, y->len);
-	rz_bv_copy(&sor, y);
+	if (!rz_bv_init_copy(&sor, y)) {
+		goto err_dend;
+	}
 
 	// shift the divisor left to align both highest bits
 	ut32 sorlz = rz_bv_clz(&sor);
@@ -1313,15 +1335,18 @@ RZ_API bool rz_bv_div_inplace(RZ_NONNULL RZ_INOUT RzBitVector *x, const RZ_NONNU
 
 			// sub_inplace() negates sor_cpy
 			RzBitVector sor_cpy;
-			rz_bv_init(&sor_cpy, y->len);
-			rz_bv_copy(&sor_cpy, &sor);
+			if (!rz_bv_init_copy(&sor_cpy, &sor)) {
+				goto err_sor;
+			}
 			rz_bv_sub_inplace(&dend, &sor_cpy, NULL);
 			rz_bv_fini(&sor_cpy);
 		}
 		rz_bv_rshift(&sor, 1);
 	}
-	rz_bv_fini(&dend);
+err_sor:
 	rz_bv_fini(&sor);
+err_dend:
+	rz_bv_fini(&dend);
 	return true;
 }
 
@@ -1359,8 +1384,9 @@ RZ_API bool rz_bv_mod_inplace(RZ_NONNULL RZ_INOUT RzBitVector *x, const RZ_NONNU
 		return true;
 	}
 	RzBitVector remul;
-	rz_bv_init(&remul, rz_bv_len(x));
-	rz_bv_copy(&remul, x);
+	if (!rz_bv_init_copy(&remul, x)) {
+		return false;
+	}
 
 	if (!rz_bv_div_inplace(&remul, y)) {
 		rz_bv_fini(&remul);

--- a/test/db/analysis/x86_64
+++ b/test/db/analysis/x86_64
@@ -4249,7 +4249,7 @@ arg int64_t arg4 @ rcx
 arg int64_t arg1 @ rdi
 arg int64_t arg3 @ rdx
 arg int64_t arg2 @ rsi
-void fcn.00010270(int64_t arg1, int64_t arg2, const char **s, int64_t arg4, int64_t arg5);
+void fcn.00010270(int64_t arg1, const char *arg2, const char **s, int64_t arg4, int64_t arg5);
 var const char *s2 @ stack - 0xc8
 var void *s1 @ stack - 0xc0
 var unsigned long var_b8h @ stack - 0xb8
@@ -4266,7 +4266,7 @@ arg int64_t arg5 @ r8
 arg int64_t arg4 @ rcx
 arg int64_t arg1 @ rdi
 arg const char **s @ rdx
-arg int64_t arg2 @ rsi
+arg const char *arg2 @ rsi
 EOF
 RUN
 

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -83,6 +83,7 @@ if get_option('enable_tests')
     'il_validate',
     'il_vm',
     'il_helpers',
+    'il_traverse',
     'intervaltree',
     'io',
     'io_ihex',

--- a/test/unit/test_bitvector.c
+++ b/test/unit/test_bitvector.c
@@ -187,6 +187,17 @@ bool test_rz_bv_init_signed(void) {
 	mu_end;
 }
 
+bool test_rz_bv_init_copy(void) {
+	RzBitVector *src = rz_bv_new_from_ut64(43, 0x1234);
+	RzBitVector a;
+	bool r = rz_bv_init_copy(&a, src);
+	mu_assert_true(r, "init_copy return");
+	mu_assert_eq(rz_bv_len(&a), 43, "copied len");
+	mu_assert_eq(rz_bv_to_ut64(&a), 0x1234, "copied value");
+	rz_bv_fini(&a);
+	mu_end;
+}
+
 bool test_rz_bv_logic_large(void) {
 	RzBitVector *x, *y, *z;
 	RzBitVector *result;
@@ -1980,6 +1991,7 @@ bool all_tests() {
 	mu_run_test(test_rz_bv_init128);
 	mu_run_test(test_rz_bv_init70);
 	mu_run_test(test_rz_bv_init_signed);
+	mu_run_test(test_rz_bv_init_copy);
 	mu_run_test(test_rz_bv_cmp);
 	mu_run_test(test_rz_bv_eq);
 	mu_run_test(test_rz_bv_cast);

--- a/test/unit/test_il_traverse.c
+++ b/test/unit/test_il_traverse.c
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: 2026 Florian Märkl <info@florianmaerkl.de>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_il.h>
+#include <rz_util.h>
+#include "minunit.h"
+
+#include <rz_il/rz_il_opbuilder_begin.h>
+
+static RzILOpPure *build_op_pure() {
+	return ITE(
+		ULE(LOAD(U32(42)), VARG("r0")),
+		ADD(U32(123), VARG("r1")),
+		LET("tmp", U32(13), VARL("tmp")));
+}
+
+static RzILOpEffect *build_op_effect() {
+	return BRANCH(
+		IL_TRUE,
+		SETG("r0", build_op_pure()),
+		REPEAT(IL_FALSE, STOREW(U32(42), U32(123))));
+}
+
+#include <rz_il/rz_il_opbuilder_end.h>
+
+static RzILRecurseCont pure_rec_cb(RzILOpPure *op, void *user) {
+	RzVector *vec = user;
+	ut64 code = op->code;
+	rz_vector_push(vec, &code);
+	return RZ_IL_RECURSE_STEP_INTO;
+}
+
+static RzILRecurseCont pure_rec_cb_break(RzILOpPure *op, void *user) {
+	RzVector *vec = user;
+	ut64 code = op->code;
+	rz_vector_push(vec, &code);
+	if (op->code == RZ_IL_OP_LOAD) {
+		return RZ_IL_RECURSE_BREAK;
+	}
+	return RZ_IL_RECURSE_STEP_INTO;
+}
+
+static RzILRecurseCont pure_rec_cb_step_over(RzILOpPure *op, void *user) {
+	RzVector *vec = user;
+	ut64 code = op->code;
+	rz_vector_push(vec, &code);
+	if (op->code == RZ_IL_OP_LOAD || op->code == RZ_IL_OP_LET) {
+		return RZ_IL_RECURSE_STEP_OVER;
+	}
+	return RZ_IL_RECURSE_STEP_INTO;
+}
+
+static bool test_il_pure_recurse() {
+	RzILOpPure *op = build_op_pure();
+	RzVector vec;
+	rz_vector_init(&vec, sizeof(ut64), NULL, NULL);
+	rz_il_op_pure_recurse(op, pure_rec_cb, &vec);
+	mu_assert_eq(rz_vector_len(&vec), 11, "traversed length");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 0), RZ_IL_OP_ITE, "op 0");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 1), RZ_IL_OP_ULE, "op 1");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 2), RZ_IL_OP_LOAD, "op 2");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 3), RZ_IL_OP_BITV, "op 3");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 4), RZ_IL_OP_VAR, "op 4");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 5), RZ_IL_OP_ADD, "op 5");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 6), RZ_IL_OP_BITV, "op 6");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 7), RZ_IL_OP_VAR, "op 7");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 8), RZ_IL_OP_LET, "op 8");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 9), RZ_IL_OP_BITV, "op 9");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 10), RZ_IL_OP_VAR, "op 10");
+	rz_vector_fini(&vec);
+	mu_end;
+}
+
+static bool test_il_pure_recurse_break() {
+	RzILOpPure *op = build_op_pure();
+	RzVector vec;
+	rz_vector_init(&vec, sizeof(ut64), NULL, NULL);
+	rz_il_op_pure_recurse(op, pure_rec_cb_break, &vec);
+	mu_assert_eq(rz_vector_len(&vec), 3, "traversed length");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 0), RZ_IL_OP_ITE, "op 0");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 1), RZ_IL_OP_ULE, "op 1");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 2), RZ_IL_OP_LOAD, "op 2");
+	rz_vector_fini(&vec);
+	mu_end;
+}
+
+static bool test_il_pure_recurse_step_over() {
+	RzILOpPure *op = build_op_pure();
+	RzVector vec;
+	rz_vector_init(&vec, sizeof(ut64), NULL, NULL);
+	rz_il_op_pure_recurse(op, pure_rec_cb_step_over, &vec);
+	mu_assert_eq(rz_vector_len(&vec), 8, "traversed length");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 0), RZ_IL_OP_ITE, "op 0");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 1), RZ_IL_OP_ULE, "op 1");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 2), RZ_IL_OP_LOAD, "op 2");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 3), RZ_IL_OP_VAR, "op 3");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 4), RZ_IL_OP_ADD, "op 4");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 5), RZ_IL_OP_BITV, "op 5");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 6), RZ_IL_OP_VAR, "op 6");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 7), RZ_IL_OP_LET, "op 7");
+	rz_vector_fini(&vec);
+	mu_end;
+}
+
+static RzILRecurseCont effect_rec_cb(RzILOpEffect *op, void *user) {
+	RzVector *vec = user;
+	ut64 code = (1ull << 63) | (ut64)op->code;
+	rz_vector_push(vec, &code);
+	return RZ_IL_RECURSE_STEP_INTO;
+}
+
+static RzILRecurseCont effect_rec_cb_break(RzILOpEffect *op, void *user) {
+	RzVector *vec = user;
+	ut64 code = (1ull << 63) | (ut64)op->code;
+	rz_vector_push(vec, &code);
+	if (op->code == RZ_IL_OP_SET) {
+		return RZ_IL_RECURSE_BREAK;
+	}
+	return RZ_IL_RECURSE_STEP_INTO;
+}
+
+static RzILRecurseCont effect_rec_cb_step_over(RzILOpEffect *op, void *user) {
+	RzVector *vec = user;
+	ut64 code = (1ull << 63) | (ut64)op->code;
+	rz_vector_push(vec, &code);
+	if (op->code == RZ_IL_OP_SET || op->code == RZ_IL_OP_REPEAT) {
+		return RZ_IL_RECURSE_STEP_OVER;
+	}
+	return RZ_IL_RECURSE_STEP_INTO;
+}
+
+static bool test_il_effect_recurse() {
+	RzILOpEffect *op = build_op_effect();
+	RzVector vec;
+	rz_vector_init(&vec, sizeof(ut64), NULL, NULL);
+	rz_il_op_effect_recurse(op, effect_rec_cb, &vec, pure_rec_cb, &vec);
+	mu_assert_eq(rz_vector_len(&vec), 19, "traversed length");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 0), (1ull << 63) | (ut64)RZ_IL_OP_BRANCH, "op 0");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 1), RZ_IL_OP_B1, "op 1");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 2), (1ull << 63) | (ut64)RZ_IL_OP_SET, "op 2");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 3), RZ_IL_OP_ITE, "op 3");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 4), RZ_IL_OP_ULE, "op 4");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 5), RZ_IL_OP_LOAD, "op 5");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 6), RZ_IL_OP_BITV, "op 6");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 7), RZ_IL_OP_VAR, "op 7");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 8), RZ_IL_OP_ADD, "op 8");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 9), RZ_IL_OP_BITV, "op 9");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 10), RZ_IL_OP_VAR, "op 10");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 11), RZ_IL_OP_LET, "op 11");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 12), RZ_IL_OP_BITV, "op 12");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 13), RZ_IL_OP_VAR, "op 13");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 14), (1ull << 63) | (ut64)RZ_IL_OP_REPEAT, "op 14");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 15), RZ_IL_OP_B0, "op 15");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 16), (1ull << 63) | (ut64)RZ_IL_OP_STOREW, "op 16");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 17), RZ_IL_OP_BITV, "op 17");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 18), RZ_IL_OP_BITV, "op 18");
+	rz_vector_fini(&vec);
+
+	rz_vector_init(&vec, sizeof(ut64), NULL, NULL);
+	rz_il_op_effect_recurse(op, NULL, NULL, pure_rec_cb, &vec);
+	mu_assert_eq(rz_vector_len(&vec), 15, "traversed length");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 0), RZ_IL_OP_B1, "op 0");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 1), RZ_IL_OP_ITE, "op 1");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 2), RZ_IL_OP_ULE, "op 2");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 3), RZ_IL_OP_LOAD, "op 3");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 4), RZ_IL_OP_BITV, "op 4");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 5), RZ_IL_OP_VAR, "op 5");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 6), RZ_IL_OP_ADD, "op 6");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 7), RZ_IL_OP_BITV, "op 7");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 8), RZ_IL_OP_VAR, "op 8");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 9), RZ_IL_OP_LET, "op 9");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 10), RZ_IL_OP_BITV, "op 10");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 11), RZ_IL_OP_VAR, "op 11");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 12), RZ_IL_OP_B0, "op 12");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 13), RZ_IL_OP_BITV, "op 13");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 14), RZ_IL_OP_BITV, "op 14");
+	rz_vector_fini(&vec);
+
+	rz_vector_init(&vec, sizeof(ut64), NULL, NULL);
+	rz_il_op_effect_recurse(op, effect_rec_cb, &vec, NULL, NULL);
+	mu_assert_eq(rz_vector_len(&vec), 4, "traversed length");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 0), (1ull << 63) | (ut64)RZ_IL_OP_BRANCH, "op 0");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 1), (1ull << 63) | (ut64)RZ_IL_OP_SET, "op 1");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 2), (1ull << 63) | (ut64)RZ_IL_OP_REPEAT, "op 2");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 3), (1ull << 63) | (ut64)RZ_IL_OP_STOREW, "op 3");
+	rz_vector_fini(&vec);
+	mu_end;
+}
+
+static bool test_il_effect_recurse_break() {
+	RzILOpEffect *op = build_op_effect();
+	RzVector vec;
+	rz_vector_init(&vec, sizeof(ut64), NULL, NULL);
+	rz_il_op_effect_recurse(op, effect_rec_cb_break, &vec, pure_rec_cb, &vec);
+	mu_assert_eq(rz_vector_len(&vec), 3, "traversed length");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 0), (1ull << 63) | (ut64)RZ_IL_OP_BRANCH, "op 0");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 1), RZ_IL_OP_B1, "op 1");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 2), (1ull << 63) | (ut64)RZ_IL_OP_SET, "op 2");
+	rz_vector_fini(&vec);
+
+	rz_vector_init(&vec, sizeof(ut64), NULL, NULL);
+	rz_il_op_effect_recurse(op, effect_rec_cb, &vec, pure_rec_cb_break, &vec);
+	mu_assert_eq(rz_vector_len(&vec), 6, "traversed length");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 0), (1ull << 63) | (ut64)RZ_IL_OP_BRANCH, "op 0");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 1), RZ_IL_OP_B1, "op 1");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 2), (1ull << 63) | (ut64)RZ_IL_OP_SET, "op 2");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 3), RZ_IL_OP_ITE, "op 3");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 4), RZ_IL_OP_ULE, "op 4");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 5), RZ_IL_OP_LOAD, "op 5");
+	rz_vector_fini(&vec);
+	mu_end;
+}
+
+static bool test_il_effect_recurse_step_over() {
+	RzILOpEffect *op = build_op_effect();
+	RzVector vec;
+	rz_vector_init(&vec, sizeof(ut64), NULL, NULL);
+	rz_il_op_effect_recurse(op, effect_rec_cb_step_over, &vec, pure_rec_cb, &vec);
+	mu_assert_eq(rz_vector_len(&vec), 4, "traversed length");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 0), (1ull << 63) | (ut64)RZ_IL_OP_BRANCH, "op 0");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 1), RZ_IL_OP_B1, "op 1");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 2), (1ull << 63) | (ut64)RZ_IL_OP_SET, "op 2");
+	mu_assert_eq(*(ut64 *)rz_vector_index_ptr(&vec, 3), (1ull << 63) | (ut64)RZ_IL_OP_REPEAT, "op 3");
+	rz_vector_fini(&vec);
+	mu_end;
+}
+
+bool all_tests() {
+	mu_run_test(test_il_pure_recurse);
+	mu_run_test(test_il_pure_recurse_break);
+	mu_run_test(test_il_pure_recurse_step_over);
+	mu_run_test(test_il_effect_recurse);
+	mu_run_test(test_il_effect_recurse_break);
+	mu_run_test(test_il_effect_recurse_step_over);
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

This aims to provide direct rewrites of analysis passes without changing the actual algorithms, but only using RzIL instead of ESIL. The benefits are that dependencies on ESIL can be removed and the resulting code will be much cleaner and easier to extend and adjust due to the nature of both ILs.

As long as after a certain point where instructions are disassembled, there is still ESIL-based analysis present, both RzIL and ESIL have to be lifted, which will have a performance penalty. So it can make sense to not merge this before lifting ESIL can be disabled entirely at the points where RzIL has been added.

Analysis passes included (checked means conversion finished):
- [x] arm `mov lr, pc` check
- [ ] Variable extraction

**Test plan**

Existing tests should all pass without out changes, or only with changes that have been validated to make sense, e.g. when the RzIL lifter covers more instructions than ESIL.