### PR TITLE
Fix NULL dereference in `rz_analysis_var_clear_accesses()`

### DIFF
--- a/librz/arch/var.c
+++ b/librz/arch/var.c
@@ -901,7 +901,7 @@ RZ_API void rz_analysis_var_remove_access_at(RzAnalysisVar *var, ut64 address) {
 RZ_API void rz_analysis_var_clear_accesses(RzAnalysisVar *var) {
 	rz_return_if_fail(var);
 	RzAnalysisFunction *fcn = var->fcn;
-	if (fcn->inst_vars) {
+	if (fcn && fcn->inst_vars) {
 		// remove all inverse references to the var's accesses
 		RzAnalysisVarAccess *acc;
 		rz_vector_foreach (&var->accesses, acc) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Currently, `rz_analysis_var_clear_accesses()` assumes that every `RzAnalysisVar` is permanently linked to a function (var->fcn != NULL). However, when using APIs that generate temporary or caller-owned variables like dynamically parsing return types, `var->fcn` is intentionally left as NULL to prevent modifying the function's internal state. Freeing these temporary variables causes an immediate crash when the API`(rz_analysis_var_clear_accesses())` attempts to read `fcn->inst_vars`.

**Test plan**

CI is green

**Closing issues**