### PR TITLE
Perf: use binary search in `rz_vector_insert_sorted`

### DIFF
--- a/librz/util/vector.c
+++ b/librz/util/vector.c
@@ -277,21 +277,32 @@ RZ_API void *rz_vector_insert_sorted(RZ_NONNULL RzVector *vec, RZ_NONNULL void *
 	if (rz_vector_empty(vec)) {
 		return rz_vector_push(vec, elem);
 	}
-	size_t i = vec->reverse_sorted ? rz_vector_len(vec) - 1 : 0;
-	int inc = vec->reverse_sorted ? -1 : 1;
 
-	do {
-		void *velem = ((char *)vec->a) + (vec->elem_size * i);
-		if (cmp(velem, elem, user) >= 0) {
-			return rz_vector_insert(vec, vec->reverse_sorted ? i + 1 : i, elem);
+	size_t left = 0;
+	size_t right = rz_vector_len(vec);
+
+	while (left < right) {
+		size_t mid = left + (right - left) / 2;
+
+		void *velem = ((char *)vec->a) + (vec->elem_size * mid);
+
+		int cmp_res = cmp(velem, elem, user);
+
+		if (vec->reverse_sorted) {
+			if (cmp_res > 0) {
+				left = mid + 1;
+			} else {
+				right = mid;
+			}
+		} else {
+			if (cmp_res < 0) {
+				left = mid + 1;
+			} else {
+				right = mid;
+			}
 		}
-		if (i == 0 && inc == -1) {
-			// Overflow is undefined. So lets not depend on it.
-			break;
-		}
-		i += inc;
-	} while (i >= 0 && i < rz_vector_len(vec));
-	return vec->reverse_sorted ? rz_vector_push_front(vec, elem) : rz_vector_push(vec, elem);
+	}
+	return rz_vector_insert(vec, left, elem);
 }
 
 static bool bin_search_range(RZ_NONNULL RzVector *vec, RZ_NONNULL void *elem, RzVectorComparator cmp, void *user, RZ_OUT size_t *i) {

--- a/librz/util/vector.c
+++ b/librz/util/vector.c
@@ -259,6 +259,44 @@ RZ_API void *rz_vector_insert_range(RzVector *vec, size_t index, RZ_NULLABLE voi
 	return p;
 }
 
+static bool bin_search_range(RZ_NONNULL RzVector *vec, RZ_NONNULL void *elem, RzVectorComparator cmp, void *user, RZ_OUT size_t *i) {
+	size_t vlen = rz_vector_len(vec);
+	if (vlen == 0) {
+		*i = 0;
+		return false;
+	}
+
+	size_t left = 0;
+	size_t right = vlen;
+
+	while (left < right) {
+		size_t mid = left + (right - left) / 2;
+		int cmp_res = cmp(elem, rz_vector_index_ptr(vec, mid), user);
+
+		if (cmp_res == 0) {
+			*i = mid;
+			return true;
+		}
+
+		if (vec->reverse_sorted) {
+			if (cmp_res > 0) {
+				right = mid;
+			} else {
+				left = mid + 1;
+			}
+		} else {
+			if (cmp_res > 0) {
+				left = mid + 1;
+			} else {
+				right = mid;
+			}
+		}
+	}
+
+	*i = left;
+	return false;
+}
+
 /**
  * \brief Inserts an element into a sorted vector keeping the order.
  * NOTE: This function assumes the vector is already sorted!
@@ -278,61 +316,11 @@ RZ_API void *rz_vector_insert_sorted(RZ_NONNULL RzVector *vec, RZ_NONNULL void *
 		return rz_vector_push(vec, elem);
 	}
 
-	size_t left = 0;
-	size_t right = rz_vector_len(vec);
+	size_t insert_index = 0;
 
-	while (left < right) {
-		size_t mid = left + (right - left) / 2;
+	bin_search_range(vec, elem, cmp, user, &insert_index);
 
-		void *velem = ((char *)vec->a) + (vec->elem_size * mid);
-
-		int cmp_res = cmp(velem, elem, user);
-
-		if (vec->reverse_sorted) {
-			if (cmp_res > 0) {
-				left = mid + 1;
-			} else {
-				right = mid;
-			}
-		} else {
-			if (cmp_res < 0) {
-				left = mid + 1;
-			} else {
-				right = mid;
-			}
-		}
-	}
-	return rz_vector_insert(vec, left, elem);
-}
-
-static bool bin_search_range(RZ_NONNULL RzVector *vec, RZ_NONNULL void *elem, RzVectorComparator cmp, void *user, RZ_OUT size_t *i) {
-	size_t vlen = rz_vector_len(vec);
-	if (vlen == 0) {
-		return false;
-	}
-
-	int inc = vec->reverse_sorted ? -1 : 1;
-	ssize_t low = vec->reverse_sorted ? vlen - 1 : 0;
-	ssize_t hi = vec->reverse_sorted ? 0 : vlen - 1;
-
-	do {
-		size_t mid = (low + hi) >> 1;
-		if (cmp(elem, rz_vector_index_ptr(vec, mid), user) == 0) {
-			*i = mid;
-			return true;
-		}
-		if (low == hi) {
-			break;
-		}
-		if (cmp(elem, rz_vector_index_ptr(vec, mid), user) > 0) {
-			low = mid + inc;
-		}
-		if (cmp(elem, rz_vector_index_ptr(vec, mid), user) < 0) {
-			hi = mid - inc;
-		}
-	} while (vec->reverse_sorted ? hi <= low : low <= hi);
-
-	return false;
+	return rz_vector_insert(vec, insert_index, elem);
 }
 
 /**


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

This pull request was made to replace linear scan in `rz_vector_insert_sorted` with binary search, reducing the runtime complexity from O(n/2) to O(log n).
The function signature and external behavior remain unchanged.

Note: `rz_vector_find_sorted` was not found in the current codebase
(verified with git grep), so the binary search was implemented inline.
Documentation was not updated since the behavior is identical.

**Test plan**
Build and run the unit tests:

  ninja -C build test/unit/test_vector
  ./build/test/unit/test_vector

All tests pass, including `test_vector_insert_sorted`.

**Closing issues**

Closes #6201