### PR TITLE
Added new API to get storage information of function return

### DIFF
--- a/librz/arch/var.c
+++ b/librz/arch/var.c
@@ -574,6 +574,108 @@ RZ_API RZ_BORROW RzAnalysisVar *rz_analysis_function_get_var_byname(RzAnalysisFu
 	return NULL;
 }
 
+static void piece_storage_fini(void *p, void *user) {
+	RzAnalysisVarStoragePiece *piece = (RzAnalysisVarStoragePiece *)p;
+	rz_return_if_fail(piece);
+	free(piece->storage);
+}
+
+static void build_stack_storage(RzAnalysisVarStorage *str, const char *ret_location) {
+	str->type = RZ_ANALYSIS_VAR_STORAGE_STACK;
+	st64 offset = 0;
+	if (rz_str_ansi_len(ret_location) > 5 && ret_location[5] == '+') {
+		offset = (st64)rz_num_math(NULL, ret_location + 5);
+	}
+	str->stack_off = offset;
+}
+
+static ut32 build_reg_storage(RzAnalysis *analysis, RzAnalysisVarStorage *str, const char *ret_location) {
+	str->type = RZ_ANALYSIS_VAR_STORAGE_REG;
+	RzRegItem *reg = rz_reg_get(analysis->reg, ret_location, -1);
+	if (reg) {
+		str->reg = reg->name;
+		return reg->size;
+	}
+	str->reg = rz_str_constpool_get(&analysis->constpool, ret_location);
+	return analysis->bits;
+}
+
+static RzAnalysisVarStoragePiece build_storage_piece(RzAnalysis *analysis, const char *token_var, ut32 offset_bits) {
+	RzAnalysisVarStoragePiece str_piece = RZ_EMPTY;
+	str_piece.storage = RZ_NEW0(RzAnalysisVarStorage);
+	rz_return_val_if_fail(str_piece.storage, str_piece);
+	str_piece.offset_in_bits = offset_bits;
+	ut32 piece_size_bits = 0;
+	if (rz_str_startswith(token_var, "stack")) {
+		build_stack_storage(str_piece.storage, token_var);
+		piece_size_bits = analysis->bits;
+	} else {
+		piece_size_bits = build_reg_storage(analysis, str_piece.storage, token_var);
+	}
+	str_piece.size_in_bits = piece_size_bits;
+	return str_piece;
+}
+
+static RzVector /*<RzAnalysisVarStoragePiece>*/ *parse_composite_storage(RzAnalysis *analysis, const char *ret_location) {
+	RzVector *composite = rz_vector_new(sizeof(RzAnalysisVarStoragePiece), piece_storage_fini, NULL);
+	char *local_ret_loc = rz_str_dup(ret_location);
+	RzList *tokens = rz_str_split_list(local_ret_loc, ",", 0);
+	RzListIter *it;
+	char *token_var;
+	ut32 current_offset_bits = 0;
+
+	rz_list_foreach (tokens, it, token_var) {
+		RzAnalysisVarStoragePiece str_piece = build_storage_piece(analysis, token_var, current_offset_bits);
+		if (!str_piece.storage) {
+			break;
+		}
+		current_offset_bits += str_piece.size_in_bits;
+		rz_vector_push(composite, &str_piece);
+	}
+	rz_list_free(tokens);
+	free(local_ret_loc);
+	return composite;
+}
+
+static RzAnalysisVarStorage build_ret_var_storage(RzAnalysis *analysis, const char *ret_location) {
+	RzAnalysisVarStorage str = RZ_EMPTY;
+
+	if (rz_str_strchr(ret_location, ",")) {
+		str.type = RZ_ANALYSIS_VAR_STORAGE_COMPOSITE;
+		str.composite = parse_composite_storage(analysis, ret_location);
+	} else if (rz_str_startswith(ret_location, "stack")) {
+		build_stack_storage(&str, ret_location);
+	} else {
+		build_reg_storage(analysis, &str, ret_location);
+	}
+	return str;
+}
+
+/**
+ * \brief Retrieves the storage info of a function's return value.
+ * \param fcn The analysis function to inspect
+ *
+ * \return type RzAnalysisVar with function return info in it or NULL on fail.
+ */
+RZ_API RZ_OWN RzAnalysisVar *rz_analysis_function_get_ret_var(RzAnalysisFunction *fcn) {
+	rz_return_val_if_fail(fcn && fcn->analysis, NULL);
+
+	if (!fcn->cc) {
+		return NULL;
+	}
+
+	const char *ret_location = rz_analysis_cc_ret(fcn->analysis, fcn->cc);
+	if (!ret_location) {
+		return NULL;
+	}
+	RzAnalysisVar *var = rz_analysis_var_new();
+	rz_return_val_if_fail(var, NULL);
+	var->kind = RZ_ANALYSIS_VAR_KIND_VARIABLE;
+	RzAnalysisVarStorage str = build_ret_var_storage(fcn->analysis, ret_location);
+	var->storage = str;
+	return var;
+}
+
 /**
  * \return the variable that is located exactly at \p stor, or NULL if no such variable exists
  */

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1554,6 +1554,7 @@ RZ_API RZ_BORROW RzAnalysisVar *rz_analysis_function_get_stack_var_at(RzAnalysis
 RZ_API RZ_BORROW RzAnalysisVar *rz_analysis_function_get_reg_var_at(RzAnalysisFunction *fcn, RZ_NONNULL const char *reg);
 RZ_API RZ_BORROW RzAnalysisVar *rz_analysis_function_get_stack_var_in(RzAnalysisFunction *fcn, RzStackAddr stack_off);
 RZ_API RZ_BORROW RzAnalysisVar *rz_analysis_function_get_var_byname(RzAnalysisFunction *fcn, const char *name);
+RZ_API RZ_OWN RzAnalysisVar *rz_analysis_function_get_ret_var(RzAnalysisFunction *fcn);
 RZ_API void rz_analysis_function_delete_vars_by_storage_type(RzAnalysisFunction *fcn, RzAnalysisVarStorageType stor);
 RZ_API void rz_analysis_function_delete_arg_vars(RzAnalysisFunction *fcn);
 RZ_API void rz_analysis_function_delete_all_vars(RzAnalysisFunction *fcn);

--- a/test/unit/test_analysis_function.c
+++ b/test/unit/test_analysis_function.c
@@ -551,6 +551,123 @@ bool test_rz_analysis_function_set_cc() {
 	mu_end;
 }
 
+bool test_rz_analysis_function_get_ret_var() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	rz_analysis_use(analysis, "x86");
+	rz_analysis_set_bits(analysis, 32);
+
+	// x86 standard cases
+	rz_analysis_cc_set(analysis, "eax test_reg()");
+	rz_analysis_cc_set(analysis, "stack+8 test_stack()");
+	rz_analysis_cc_set(analysis, "eax,edx,stack+8 test_comp()");
+
+	// ARM64
+	rz_analysis_cc_set(analysis, "x0 test_arm64()");
+
+	// fcn Return multiple locations
+	rz_analysis_cc_set(analysis, "eax,ebx test_mul_reg()");
+	rz_analysis_cc_set(analysis, "stack+8,stack+16 test_mul_stack()");
+
+	// Register pairs
+	rz_analysis_cc_set(analysis, "d2,d3 test_tricore()");
+
+	RzAnalysisFunction *fcn = rz_analysis_create_function(analysis, "testfunc", 0x100, RZ_ANALYSIS_FCN_TYPE_FCN);
+	mu_assert_notnull(fcn, "function should be created");
+
+	bool cc_set1 = rz_analysis_function_set_cc(analysis, fcn, "test_reg");
+	mu_assert_true(cc_set1, "failed to set test_reg cc");
+	RzAnalysisVar *var_reg_ret = rz_analysis_function_get_ret_var(fcn);
+	mu_assert_notnull(var_reg_ret, "should get ret var for reg cc");
+	mu_assert_eq(var_reg_ret->storage.type, RZ_ANALYSIS_VAR_STORAGE_REG, "storage type should be REG");
+	mu_assert_streq(var_reg_ret->storage.reg, "eax", "reg should be eax");
+	rz_analysis_var_free(var_reg_ret);
+
+	bool cc_set2 = rz_analysis_function_set_cc(analysis, fcn, "test_stack");
+	mu_assert_true(cc_set2, "failed to set test_stack cc");
+	RzAnalysisVar *var_stack = rz_analysis_function_get_ret_var(fcn);
+	mu_assert_notnull(var_stack, "should get ret var for stack cc");
+	mu_assert_eq(var_stack->storage.type, RZ_ANALYSIS_VAR_STORAGE_STACK, "storage type should be STACK");
+	mu_assert_eq(var_stack->storage.stack_off, 8, "stack offset should be 8");
+	rz_analysis_var_free(var_stack);
+
+	bool cc_set3 = rz_analysis_function_set_cc(analysis, fcn, "test_comp");
+	mu_assert_true(cc_set3, "failed to set test_comp cc");
+	RzAnalysisVar *var_comp = rz_analysis_function_get_ret_var(fcn);
+	mu_assert_notnull(var_comp, "should get ret var for composite cc");
+	mu_assert_eq(var_comp->storage.type, RZ_ANALYSIS_VAR_STORAGE_COMPOSITE, "storage type should be COMPOSITE");
+	mu_assert_eq((int)rz_vector_len(var_comp->storage.composite), 3, "composite should have 3 pieces");
+
+	RzAnalysisVarStoragePiece *p0 = (RzAnalysisVarStoragePiece *)rz_vector_index_ptr(var_comp->storage.composite, 0);
+	mu_assert_eq(p0->storage->type, RZ_ANALYSIS_VAR_STORAGE_REG, "piece 0 storage should be REG");
+	mu_assert_streq(p0->storage->reg, "eax", "piece 0 reg should be eax");
+
+	RzAnalysisVarStoragePiece *p1 = (RzAnalysisVarStoragePiece *)rz_vector_index_ptr(var_comp->storage.composite, 1);
+	mu_assert_eq(p1->storage->type, RZ_ANALYSIS_VAR_STORAGE_REG, "piece 1 storage should be REG");
+	mu_assert_streq(p1->storage->reg, "edx", "piece 1 reg should be edx");
+
+	RzAnalysisVarStoragePiece *p2 = (RzAnalysisVarStoragePiece *)rz_vector_index_ptr(var_comp->storage.composite, 2);
+	mu_assert_eq(p2->storage->type, RZ_ANALYSIS_VAR_STORAGE_STACK, "piece 2 storage should be STACK");
+	mu_assert_eq(p2->storage->stack_off, 8, "piece 2 stack offset should be 8");
+	rz_analysis_var_free(var_comp);
+
+	bool cc_set4 = rz_analysis_function_set_cc(analysis, fcn, "test_arm64");
+	mu_assert_true(cc_set4, "failed to set test_arm64 cc");
+	RzAnalysisVar *var_arm64 = rz_analysis_function_get_ret_var(fcn);
+	mu_assert_notnull(var_arm64, "should get ret var for arm64 cc");
+	mu_assert_streq(var_arm64->storage.reg, "x0", "reg should be x0");
+	rz_analysis_var_free(var_arm64);
+
+	bool cc_set5 = rz_analysis_function_set_cc(analysis, fcn, "test_mul_reg");
+	mu_assert_true(cc_set5, "failed to set test_mul_reg cc");
+	RzAnalysisVar *var_mul_reg = rz_analysis_function_get_ret_var(fcn);
+	mu_assert_notnull(var_mul_reg, "should get ret var for mul reg cc");
+	mu_assert_eq(var_mul_reg->storage.type, RZ_ANALYSIS_VAR_STORAGE_COMPOSITE, "storage type should be COMPOSITE");
+	mu_assert_eq((int)rz_vector_len(var_mul_reg->storage.composite), 2, "reg should have 2 pieces");
+
+	RzAnalysisVarStoragePiece *p_r0 = (RzAnalysisVarStoragePiece *)rz_vector_index_ptr(var_mul_reg->storage.composite, 0);
+	mu_assert_streq(p_r0->storage->reg, "eax", "piece 0 should be eax");
+	mu_assert_eq(p_r0->offset_in_bits, 0, "piece 0 offset should be 0");
+
+	RzAnalysisVarStoragePiece *p_r1 = (RzAnalysisVarStoragePiece *)rz_vector_index_ptr(var_mul_reg->storage.composite, 1);
+	mu_assert_streq(p_r1->storage->reg, "ebx", "piece 1 should be ebx");
+	mu_assert_eq(p_r1->offset_in_bits, 32, "piece 1 offset should be 32"); // Assuming 32-bit fallback
+	rz_analysis_var_free(var_mul_reg);
+
+	bool cc_set6 = rz_analysis_function_set_cc(analysis, fcn, "test_mul_stack");
+	mu_assert_true(cc_set6, "failed to set test_mul_stack cc");
+	RzAnalysisVar *var_mul_stack = rz_analysis_function_get_ret_var(fcn);
+	mu_assert_notnull(var_mul_stack, "should get ret var for stack cc");
+	mu_assert_eq((int)rz_vector_len(var_mul_stack->storage.composite), 2, "stack should have 2 pieces");
+
+	RzAnalysisVarStoragePiece *p_mul_s0 = (RzAnalysisVarStoragePiece *)rz_vector_index_ptr(var_mul_stack->storage.composite, 0);
+	mu_assert_eq(p_mul_s0->storage->stack_off, 8, "stack piece 0 offset 8");
+
+	RzAnalysisVarStoragePiece *p_mul_s1 = (RzAnalysisVarStoragePiece *)rz_vector_index_ptr(var_mul_stack->storage.composite, 1);
+	mu_assert_eq(p_mul_s1->storage->stack_off, 16, "stack piece 1 offset 16");
+	rz_analysis_var_free(var_mul_stack);
+
+	bool cc_set7 = rz_analysis_function_set_cc(analysis, fcn, "test_tricore");
+	mu_assert_true(cc_set7, "failed to set test_tricore cc");
+	RzAnalysisVar *var_tricore = rz_analysis_function_get_ret_var(fcn);
+	mu_assert_notnull(var_tricore, "should get ret var for tricore cc");
+	mu_assert_eq(var_tricore->storage.type, RZ_ANALYSIS_VAR_STORAGE_COMPOSITE, "storage type should be COMPOSITE");
+
+	RzAnalysisVarStoragePiece *p_tri0 = (RzAnalysisVarStoragePiece *)rz_vector_index_ptr(var_tricore->storage.composite, 0);
+	mu_assert_streq(p_tri0->storage->reg, "d2", "tricore piece 0 should be d2");
+
+	RzAnalysisVarStoragePiece *p_tri1 = (RzAnalysisVarStoragePiece *)rz_vector_index_ptr(var_tricore->storage.composite, 1);
+	mu_assert_streq(p_tri1->storage->reg, "d3", "tricore piece 1 should be d3");
+	rz_analysis_var_free(var_tricore);
+
+	rz_analysis_function_set_cc(analysis, fcn, NULL);
+	RzAnalysisVar *var_null = rz_analysis_function_get_ret_var(fcn);
+	mu_assert_null(var_null, "should safely return NULL when CC is not set");
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test(test_rz_analysis_function_relocate);
 	mu_run_test(test_rz_analysis_function_labels);
@@ -564,6 +681,7 @@ int all_tests() {
 	mu_run_test(test_noreturn_functions_list);
 	mu_run_test(test_analysis_function_rename);
 	mu_run_test(test_analysis_function_force_rename);
+	mu_run_test(test_rz_analysis_function_get_ret_var);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Currently, there is  no API for retrieving function return information, this PR adds a new API which returns a variable with return storage information of the provided function. The API parses the function's calling convention and returns an RzAnalysisVar with the required storage layout.

**Test plan**

A unit test has been added to validate the new API

**Closing issues**

closes #4047 

