### PR TITLE
remove static variables from io_qnx.c

### DIFF
--- a/librz/io/p/io_qnx.c
+++ b/librz/io/p/io_qnx.c
@@ -16,39 +16,43 @@ static bool __plugin_open(RzIO *io, const char *file, bool many) {
 
 /* hacky cache to speedup io a bit */
 /* reading in a different place clears the previous cache */
-static ut64 c_addr = UT64_MAX;
-static ut32 c_size = UT32_MAX;
-static ut8 *c_buff = NULL;
 #define SILLY_CACHE 0
 
-static int debug_qnx_read_at(ut8 *buf, int sz, ut64 addr, libqnxr_t *desc) {
+typedef struct {
+	libqnxr_t desc;
+	ut64 c_addr;
+	ut32 c_size;
+	ut8 *c_buff;
+} RzIOQnx;
+
+static int debug_qnx_read_at(RzIOQnx *qnx, ut8 *buf, int sz, ut64 addr) {
 	ut32 size_max = 500;
 	ut32 packets = sz / size_max;
 	ut32 last = sz % size_max;
 	ut32 x;
-	if (c_buff && addr != UT64_MAX && addr == c_addr) {
-		memcpy(buf, c_buff, sz);
+	if (qnx->c_buff && addr != UT64_MAX && addr == qnx->c_addr) {
+		memcpy(buf, qnx->c_buff, sz);
 		return sz;
 	}
 	if (sz < 1 || addr >= UT64_MAX) {
 		return -1;
 	}
 	for (x = 0; x < packets; x++) {
-		qnxr_read_memory(desc, addr + x * size_max, (buf + x * size_max), size_max);
+		qnxr_read_memory(&qnx->desc, addr + x * size_max, (buf + x * size_max), size_max);
 	}
 	if (last) {
-		qnxr_read_memory(desc, addr + x * size_max, (buf + x * size_max), last);
+		qnxr_read_memory(&qnx->desc, addr + x * size_max, (buf + x * size_max), last);
 	}
-	c_addr = addr;
-	c_size = sz;
+	qnx->c_addr = addr;
+	qnx->c_size = sz;
 #if SILLY_CACHE
-	free(c_buff);
-	c_buff = rz_mem_dup(buf, sz);
+	free(qnx->c_buff);
+	qnx->c_buff = rz_mem_dup(buf, sz);
 #endif
 	return sz;
 }
 
-static int debug_qnx_write_at(const ut8 *buf, int sz, ut64 addr, libqnxr_t *desc) {
+static int debug_qnx_write_at(RzIOQnx *qnx, const ut8 *buf, int sz, ut64 addr) {
 	ut32 x, size_max = 500;
 	ut32 packets = sz / size_max;
 	ut32 last = sz % size_max;
@@ -56,16 +60,16 @@ static int debug_qnx_write_at(const ut8 *buf, int sz, ut64 addr, libqnxr_t *desc
 	if (sz < 1 || addr >= UT64_MAX) {
 		return -1;
 	}
-	if (c_addr != UT64_MAX && addr >= c_addr && c_addr + sz < (c_addr + c_size)) {
-		RZ_FREE(c_buff);
-		c_addr = UT64_MAX;
+	if (qnx->c_addr != UT64_MAX && addr >= qnx->c_addr && qnx->c_addr + sz < (qnx->c_addr + qnx->c_size)) {
+		RZ_FREE(qnx->c_buff);
+		qnx->c_addr = UT64_MAX;
 	}
 	for (x = 0; x < packets; x++) {
-		qnxr_write_memory(desc, addr + x * size_max,
+		qnxr_write_memory(&qnx->desc, addr + x * size_max,
 			(const uint8_t *)(buf + x * size_max), size_max);
 	}
 	if (last) {
-		qnxr_write_memory(desc, addr + x * size_max,
+		qnxr_write_memory(&qnx->desc, addr + x * size_max,
 			(buf + x * size_max), last);
 	}
 
@@ -73,7 +77,7 @@ static int debug_qnx_write_at(const ut8 *buf, int sz, ut64 addr, libqnxr_t *desc
 }
 
 static RzIODesc *__open(RzIO *io, const char *file, int rw, int mode) {
-	libqnxr_t *qnx_desc = NULL;
+	RzIOQnx *qnx = NULL;
 	RzIODesc *rioqnx = NULL;
 	char host[128], *port, *p;
 
@@ -95,23 +99,30 @@ static RzIODesc *__open(RzIO *io, const char *file, int rw, int mode) {
 		*p = 0;
 	}
 
-	qnxr_init(qnx_desc);
+	qnx = RZ_NEW0(RzIOQnx);
+	if (!qnx) {
+		return NULL;
+	}
+	qnx->c_addr = UT64_MAX;
+	qnx->c_size = UT32_MAX;
+	qnxr_init(&qnx->desc);
 	int i_port = atoi(port);
-	if (qnxr_connect(qnx_desc, host, i_port) == 0) {
-		rioqnx = rz_io_desc_new(io, &rz_io_plugin_qnx, file, rw, qnx_desc);
+	if (qnxr_connect(&qnx->desc, host, i_port) == 0) {
+		rioqnx = rz_io_desc_new(io, &rz_io_plugin_qnx, file, rw, qnx);
 		return rioqnx;
 	}
 	eprintf("qnx.io.open: Cannot connect to host.\n");
+	free(qnx);
 	return NULL;
 }
 
 static int __write(RzIO *io, RzIODesc *fd, const ut8 *buf, size_t count) {
-	libqnxr_t *qnx_desc = fd->data;
+	RzIOQnx *qnx = fd->data;
 	ut64 addr = io->off;
-	if (!qnx_desc) {
+	if (!qnx) {
 		return -1;
 	}
-	return debug_qnx_write_at(buf, count, addr, qnx_desc);
+	return debug_qnx_write_at(qnx, buf, count, addr);
 }
 
 static ut64 __lseek(RzIO *io, RzIODesc *fd, ut64 offset, int whence) {
@@ -120,25 +131,27 @@ static ut64 __lseek(RzIO *io, RzIODesc *fd, ut64 offset, int whence) {
 
 static int __read(RzIO *io, RzIODesc *fd, ut8 *buf, size_t count) {
 	memset(buf, 0xff, count);
-	libqnxr_t *qnx_desc = fd->data;
+	RzIOQnx *qnx = fd->data;
 	ut64 addr = io->off;
-	if (!qnx_desc) {
+	if (!qnx) {
 		return -1;
 	}
-	return debug_qnx_read_at(buf, count, addr, qnx_desc);
+	return debug_qnx_read_at(qnx, buf, count, addr);
 }
 
 static int __close(RzIODesc *fd) {
 	if (!fd) {
 		return -1;
 	}
-	libqnxr_t *qnx_desc = fd->data;
-	if (!qnx_desc) {
-		RZ_FREE(fd);
+	RzIOQnx *qnx = fd->data;
+	if (!qnx) {
 		return -1;
 	}
-	RZ_FREE(qnx_desc);
-	RZ_FREE(fd);
+	qnxr_disconnect(&qnx->desc);
+	qnxr_cleanup(&qnx->desc);
+	free(qnx->c_buff);
+	free(qnx);
+	fd->data = NULL;
 	return 0;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else. 

**Detailed description**

Move cache-related static variables (`c_addr`, `c_size`, `c_buff`) into the `RzIOQnx` struct stored in `fd->data`
Also fixed a minor NULL pointer bug: `qnxr_init()` was called on an unallocated pointer

...

**Test plan**
All Tests were passed 
...

**Closing issues**
partially linked to #4055 

...
