### PR TITLE
Fix some memory leaks and overflow in util, core, and rz-diff

### DIFF
--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -2706,7 +2706,6 @@ static void ds_print_lines_right(RzDisasmState *ds) {
 }
 
 static void printCol(RzDisasmState *ds, char *sect, int cols, const char *color) {
-	int pre;
 	if (cols < 8) {
 		cols = 8;
 	}
@@ -2725,14 +2724,21 @@ static void printCol(RzDisasmState *ds, char *sect, int cols, const char *color)
 		sect[cols] = 0;
 	}
 	if (ds->show_color) {
-		pre = strlen(color) + 1;
-		snprintf(out, outsz - pre, "%s %s", color, sect);
-		strcat(out, COLOR_RESET(ds));
-		out[outsz - 1] = 0;
+		int written = snprintf(out, outsz, "%s %s", color, sect);
+		// append the reset seq with the remaining capacity.
+		if (written > 0 && written < outsz) {
+			snprintf(out + written, outsz - written, "%s", COLOR_RESET(ds));
+		}
 	} else {
 		rz_str_ncpy(out + 1, sect, outsz - 2);
 	}
-	strcat(out, " ");
+	char *tmp = rz_str_appendch(out, ' ');
+	// keep the actual buffer alive if the helper cant extend it.
+	if (!tmp) {
+		free(out);
+		return;
+	}
+	out = tmp;
 	rz_cons_strcat(out);
 	free(out);
 }

--- a/librz/core/tui/panels.c
+++ b/librz/core/tui/panels.c
@@ -1152,11 +1152,13 @@ char *__apply_filter_cmd(RzCore *core, RzPanel *panel) {
 		char *tmp = rz_str_append(out, "~");
 		// stop there itself if dyn cmd growth fails.
 		if (!tmp) {
+			free(out);
 			return NULL;
 		}
 		out = tmp;
 		tmp = rz_str_append(out, filter);
 		if (!tmp) {
+			free(out);
 			return NULL;
 		}
 		out = tmp;

--- a/librz/core/tui/panels.c
+++ b/librz/core/tui/panels.c
@@ -1137,12 +1137,11 @@ char *__find_cmd_str_cache(RzCore *core, RzPanel *panel) {
 }
 
 char *__apply_filter_cmd(RzCore *core, RzPanel *panel) {
-	char *out = malloc(strlen(panel->model->cmd) + 1024);
+	char *out = rz_str_dup(panel->model->cmd);
 	if (!out) {
 		RZ_LOG_ERROR("Fail to allocate the memory\n");
-		return out;
+		return NULL;
 	}
-	strcpy(out, panel->model->cmd);
 	void **iter;
 	rz_pvector_foreach (&panel->model->filter, iter) {
 		char *filter = *iter;
@@ -1150,14 +1149,27 @@ char *__apply_filter_cmd(RzCore *core, RzPanel *panel) {
 			(void)__show_status(core, "filter is too big.");
 			return out;
 		}
-		strcat(out, "~");
-		strcat(out, filter);
+		char *tmp = rz_str_append(out, "~");
+		// stop there itself if dyn cmd growth fails.
+		if (!tmp) {
+			return NULL;
+		}
+		out = tmp;
+		tmp = rz_str_append(out, filter);
+		if (!tmp) {
+			return NULL;
+		}
+		out = tmp;
 	}
 	return out;
 }
 
 char *__handle_cmd_str_cache(RzCore *core, RzPanel *panel, bool force_cache) {
 	char *cmd = __apply_filter_cmd(core, panel);
+	// avoid failed cmd build into rz_core_cmd_str.
+	if (!cmd) {
+		return NULL;
+	}
 	RzCoreVisual *visual = core->visual;
 	RzPanelsTab *tab = visual->panels_root->active_tab;
 	bool b = core->print->cur_enabled && __get_cur_panel(tab) != panel;

--- a/librz/main/rz-diff.c
+++ b/librz/main/rz-diff.c
@@ -2869,18 +2869,41 @@ static void rz_diff_resize_buffer(DiffHexView *hview) {
 	st64 video_size = width;
 	video_size *= height;
 
-	hview->line = realloc(hview->line, video_size);
-	hview->buffer_a = realloc(hview->buffer_a, size_a);
-	hview->buffer_b = realloc(hview->buffer_b, size_b);
+	// build the replacement view state first so resize is like all-or-nothing.
+	char *new_line = malloc(video_size);
+	ut8 *new_buf_a = malloc(size_a);
+	ut8 *new_buf_b = malloc(size_b);
+	if (!new_line || !new_buf_a || !new_buf_b) {
+		free(new_line);
+		free(new_buf_a);
+		free(new_buf_b);
+		return;
+	}
+
+	RzConsCanvas *new_canvas = rz_cons_canvas_new(width, height);
+	if (!new_canvas) {
+		free(new_line);
+		free(new_buf_a);
+		free(new_buf_b);
+		return;
+	}
+
+	new_canvas->color = true;
+	new_canvas->linemode = 1;
+
+	// swap only after every replacement alloc succeeded.
+	free(hview->line);
+	free(hview->buffer_a);
+	free(hview->buffer_b);
+	rz_cons_canvas_free(hview->canvas);
+	hview->line = new_line;
+	hview->buffer_a = new_buf_a;
+	hview->buffer_b = new_buf_b;
 	hview->size_a = size_a;
 	hview->size_b = size_b;
 	hview->screen.width = width;
 	hview->screen.height = height;
-
-	rz_cons_canvas_free(hview->canvas);
-	hview->canvas = rz_cons_canvas_new(width, height);
-	hview->canvas->color = true;
-	hview->canvas->linemode = 1;
+	hview->canvas = new_canvas;
 
 	rz_diff_draw_tui(hview, false);
 }

--- a/librz/util/bitvector.c
+++ b/librz/util/bitvector.c
@@ -32,16 +32,29 @@ ut8 reverse_lt_8bits(ut8 x, ut8 w) {
 /**
  * \brief Resize or allocate bv->large_a to \p new_size bytes.
  */
-static void resize_large_a(RzBitVector *bv, size_t n_bytes) {
+static bool resize_large_a(RzBitVector *bv, size_t n_bytes) {
 	if (bv->stack_alloc) {
-		bv->bits.large_a = RZ_NEWS0(ut8, n_bytes);
+		ut8 *tmp = RZ_NEWS0(ut8, n_bytes);
+		// dont drop stack backed contents unless heap alloc succeeded.
+		if (!tmp) {
+			return false;
+		}
+		bv->bits.large_a = tmp;
 		bv->stack_alloc = false;
 	} else if (!bv->bits.large_a) {
 		bv->bits.large_a = RZ_NEWS0(ut8, n_bytes);
+		if (!bv->bits.large_a) {
+			return false;
+		}
 	} else {
-		bv->bits.large_a = realloc(bv->bits.large_a, n_bytes);
+		ut8 *tmp = realloc(bv->bits.large_a, n_bytes);
+		if (!tmp) {
+			return false;
+		}
+		bv->bits.large_a = tmp;
 	}
 	bv->_elem_len = n_bytes;
+	return true;
 }
 
 /**
@@ -2269,7 +2282,10 @@ RZ_API bool rz_bv_cast_inplace(RZ_INOUT RZ_NONNULL RzBitVector *bv, ut32 to_size
 	}
 	if (NELEM(to_size, BV_ELEM_SIZE) > bv->_elem_len) {
 		// The bit vector needs a larger buffer.
-		resize_large_a(bv, NELEM(to_size, BV_ELEM_SIZE));
+		// abort the cast if storage couldnt be extended, esle resize as needed.
+		if (!resize_large_a(bv, NELEM(to_size, BV_ELEM_SIZE))) {
+			return false;
+		}
 	}
 	size_t old_size = bv->len;
 	if (bv->len <= 64) {

--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -1090,12 +1090,13 @@ RZ_API RZ_OWN char *rz_print_hexdump_str(RZ_NONNULL RzPrint *p, ut64 addr, RZ_NO
 static const char *getbytediff(RzPrint *p, char *fmt, ut8 a, ut8 b) {
 	if (*fmt) {
 		if (a == b) {
-			sprintf(fmt, "%s%02x" Color_RESET, p->cons->context->pal.graph_true, a);
+			// fmt[64] is known at call, so just preventing overflow.
+			snprintf(fmt, 64, "%s%02x" Color_RESET, p->cons->context->pal.graph_true, a);
 		} else {
-			sprintf(fmt, "%s%02x" Color_RESET, p->cons->context->pal.graph_false, a);
+			snprintf(fmt, 64, "%s%02x" Color_RESET, p->cons->context->pal.graph_false, a);
 		}
 	} else {
-		sprintf(fmt, "%02x", a);
+		snprintf(fmt, 64, "%02x", a);
 	}
 	return fmt;
 }
@@ -1104,14 +1105,13 @@ static const char *getchardiff(RzPrint *p, char *fmt, ut8 a, ut8 b) {
 	char ch = IS_PRINTABLE(a) ? a : '.';
 	if (*fmt) {
 		if (a == b) {
-			sprintf(fmt, "%s%c" Color_RESET, p->cons->context->pal.graph_true, ch);
+			snprintf(fmt, 64, "%s%c" Color_RESET, p->cons->context->pal.graph_true, ch);
 		} else {
-			sprintf(fmt, "%s%c" Color_RESET, p->cons->context->pal.graph_false, ch);
+			snprintf(fmt, 64, "%s%c" Color_RESET, p->cons->context->pal.graph_false, ch);
 		}
 	} else {
-		sprintf(fmt, "%c", ch);
+		snprintf(fmt, 64, "%c", ch);
 	}
-	// else { fmt[0] = ch; fmt[1]=0; }
 	return fmt;
 }
 
@@ -1322,18 +1322,29 @@ RZ_API void rz_print_set_rowoff(RzPrint *p, int i, ut32 offset, bool overwrite) 
 		return;
 	}
 	if (!p->row_offsets || !p->row_offsets_sz) {
-		p->row_offsets_sz = RZ_MAX(i + 1, DFLT_ROWS);
-		p->row_offsets = RZ_NEWS(ut32, p->row_offsets_sz);
+		const int initial_size = RZ_MAX(i + 1, DFLT_ROWS);
+		ut32 *row_offsets = RZ_NEWS(ut32, initial_size);
+		// keep the row offset state unchanged if first alloc fails.
+		if (!row_offsets) {
+			return;
+		}
+		p->row_offsets = row_offsets;
+		p->row_offsets_sz = initial_size;
 	}
 	if (i >= p->row_offsets_sz) {
-		size_t new_size;
-		p->row_offsets_sz *= 2;
+		int new_row_offsets_sz = p->row_offsets_sz;
 		// XXX dangerous
-		while (i >= p->row_offsets_sz) {
-			p->row_offsets_sz *= 2;
+		while (i >= new_row_offsets_sz) {
+			new_row_offsets_sz *= 2;
 		}
-		new_size = sizeof(ut32) * p->row_offsets_sz;
-		p->row_offsets = realloc(p->row_offsets, new_size);
+		size_t new_size = sizeof(ut32) * new_row_offsets_sz;
+		ut32 *tmp = realloc(p->row_offsets, new_size);
+		// only grow the metadata after the backing arr was resized successfully.
+		if (!tmp) {
+			return;
+		}
+		p->row_offsets = tmp;
+		p->row_offsets_sz = new_row_offsets_sz;
 	}
 	p->row_offsets[i] = offset;
 }

--- a/librz/util/str.c
+++ b/librz/util/str.c
@@ -2627,7 +2627,9 @@ RZ_API char *rz_str_arg_escape(const char *arg) {
 		}
 	}
 	str[dest_i] = '\0';
-	return realloc(str, (strlen(str) + 1) * sizeof(char));
+	char *trimmed = realloc(str, (strlen(str) + 1) * sizeof(char));
+	// keep the valid oversized buffer if realloc fails.
+	return trimmed ? trimmed : str;
 }
 
 // Unescape the string arg to its original format
@@ -2678,7 +2680,9 @@ RZ_API char *rz_str_path_escape(const char *path) {
 	}
 
 	str[dest_i] = '\0';
-	return realloc(str, (strlen(str) + 1) * sizeof(char));
+	char *trimmed = realloc(str, (strlen(str) + 1) * sizeof(char));
+	// same as above, logic is similar to rz_str_uri_encode.
+	return trimmed ? trimmed : str;
 }
 
 RZ_API int rz_str_path_unescape(char *path) {

--- a/librz/util/strbuf.c
+++ b/librz/util/strbuf.c
@@ -239,6 +239,10 @@ RZ_API bool rz_strbuf_append_n(RzStrBuf *sb, const char *s, size_t l) {
 			}
 			newlen *= 2;
 			p = realloc(sb->ptr, newlen);
+			// preserve the existing buffer on OOM
+			if (!p) {
+				return false;
+			}
 			memset((char *)p + sb->ptrlen, 0, newlen - sb->ptrlen);
 		} else {
 			allocated = false;

--- a/librz/util/vector.c
+++ b/librz/util/vector.c
@@ -167,6 +167,9 @@ RZ_API bool rz_vector_clone_into(
 RZ_API RZ_OWN RzVector *rz_vector_clone(
 	RZ_NONNULL RZ_BORROW RZ_IN const RzVector *vec) {
 	RzVector *dst = rz_vector_clonef(vec, NULL);
+	if (!dst) {
+		return NULL;
+	}
 	dst->free = NULL;
 	dst->free_user = NULL;
 	return dst;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

just fixes few memory-safety issues in util/core paths, and keep state updates fail safe on alloc failure.

## brief

- checks alloc results before dereference in `rz_strbuf_append_n` and `rz_vector_clone`
- replaces unsafe fixed-buff formatting with bounded writes in `print.c` and `disasm.c`
- keeps `rz_print_set_rowoff` metadata consistent when growth fails
- switches panel filter cmd construction to helper based dyn growth and propagates alloc failure cleanly
- makes bitvector growth report failure so in-place casts dont continue on undersized storage
- avoids leaking the original escaped string buff when the trimmed `realloc()` fails
- makes the `rz-diff` resize path allocate replacement state first and only swap after all allocs succeed
...

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
