### PR TITLE
harden diff formatting and row offset growth

### DIFF
--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -1090,12 +1090,13 @@ RZ_API RZ_OWN char *rz_print_hexdump_str(RZ_NONNULL RzPrint *p, ut64 addr, RZ_NO
 static const char *getbytediff(RzPrint *p, char *fmt, ut8 a, ut8 b) {
 	if (*fmt) {
 		if (a == b) {
-			sprintf(fmt, "%s%02x" Color_RESET, p->cons->context->pal.graph_true, a);
+			// fmt[64] is known at call, so just preventing overflow.
+			snprintf(fmt, 64, "%s%02x" Color_RESET, p->cons->context->pal.graph_true, a);
 		} else {
-			sprintf(fmt, "%s%02x" Color_RESET, p->cons->context->pal.graph_false, a);
+			snprintf(fmt, 64, "%s%02x" Color_RESET, p->cons->context->pal.graph_false, a);
 		}
 	} else {
-		sprintf(fmt, "%02x", a);
+		snprintf(fmt, 64, "%02x", a);
 	}
 	return fmt;
 }
@@ -1104,14 +1105,13 @@ static const char *getchardiff(RzPrint *p, char *fmt, ut8 a, ut8 b) {
 	char ch = IS_PRINTABLE(a) ? a : '.';
 	if (*fmt) {
 		if (a == b) {
-			sprintf(fmt, "%s%c" Color_RESET, p->cons->context->pal.graph_true, ch);
+			snprintf(fmt, 64, "%s%c" Color_RESET, p->cons->context->pal.graph_true, ch);
 		} else {
-			sprintf(fmt, "%s%c" Color_RESET, p->cons->context->pal.graph_false, ch);
+			snprintf(fmt, 64, "%s%c" Color_RESET, p->cons->context->pal.graph_false, ch);
 		}
 	} else {
-		sprintf(fmt, "%c", ch);
+		snprintf(fmt, 64, "%c", ch);
 	}
-	// else { fmt[0] = ch; fmt[1]=0; }
 	return fmt;
 }
 
@@ -1322,18 +1322,29 @@ RZ_API void rz_print_set_rowoff(RzPrint *p, int i, ut32 offset, bool overwrite) 
 		return;
 	}
 	if (!p->row_offsets || !p->row_offsets_sz) {
-		p->row_offsets_sz = RZ_MAX(i + 1, DFLT_ROWS);
-		p->row_offsets = RZ_NEWS(ut32, p->row_offsets_sz);
+		const int initial_size = RZ_MAX(i + 1, DFLT_ROWS);
+		ut32 *row_offsets = RZ_NEWS(ut32, initial_size);
+		// keep the row offset state unchanged if first alloc fails.
+		if (!row_offsets) {
+			return;
+		}
+		p->row_offsets = row_offsets;
+		p->row_offsets_sz = initial_size;
 	}
 	if (i >= p->row_offsets_sz) {
-		size_t new_size;
-		p->row_offsets_sz *= 2;
+		int new_row_offsets_sz = p->row_offsets_sz;
 		// XXX dangerous
-		while (i >= p->row_offsets_sz) {
-			p->row_offsets_sz *= 2;
+		while (i >= new_row_offsets_sz) {
+			new_row_offsets_sz *= 2;
 		}
-		new_size = sizeof(ut32) * p->row_offsets_sz;
-		p->row_offsets = realloc(p->row_offsets, new_size);
+		size_t new_size = sizeof(ut32) * new_row_offsets_sz;
+		ut32 *tmp = realloc(p->row_offsets, new_size);
+		// only grow the metadata after the backing arr was resized successfully.
+		if (!tmp) {
+			return;
+		}
+		p->row_offsets = tmp;
+		p->row_offsets_sz = new_row_offsets_sz;
 	}
 	p->row_offsets[i] = offset;
 }

--- a/librz/util/print.c
+++ b/librz/util/print.c
@@ -1087,36 +1087,35 @@ RZ_API RZ_OWN char *rz_print_hexdump_str(RZ_NONNULL RzPrint *p, ut64 addr, RZ_NO
 	return rz_strbuf_drain(sb);
 }
 
-static const char *getbytediff(RzPrint *p, char *fmt, ut8 a, ut8 b) {
+static const char *getbytediff(RzPrint *p, char *fmt, size_t fmt_sz, ut8 a, ut8 b) {
 	if (*fmt) {
 		if (a == b) {
-			// fmt[64] is known at call, so just preventing overflow.
-			snprintf(fmt, 64, "%s%02x" Color_RESET, p->cons->context->pal.graph_true, a);
+			snprintf(fmt, fmt_sz, "%s%02x" Color_RESET, p->cons->context->pal.graph_true, a);
 		} else {
-			snprintf(fmt, 64, "%s%02x" Color_RESET, p->cons->context->pal.graph_false, a);
+			snprintf(fmt, fmt_sz, "%s%02x" Color_RESET, p->cons->context->pal.graph_false, a);
 		}
 	} else {
-		snprintf(fmt, 64, "%02x", a);
+		snprintf(fmt, fmt_sz, "%02x", a);
 	}
 	return fmt;
 }
 
-static const char *getchardiff(RzPrint *p, char *fmt, ut8 a, ut8 b) {
+static const char *getchardiff(RzPrint *p, char *fmt, size_t fmt_sz, ut8 a, ut8 b) {
 	char ch = IS_PRINTABLE(a) ? a : '.';
 	if (*fmt) {
 		if (a == b) {
-			snprintf(fmt, 64, "%s%c" Color_RESET, p->cons->context->pal.graph_true, ch);
+			snprintf(fmt, fmt_sz, "%s%c" Color_RESET, p->cons->context->pal.graph_true, ch);
 		} else {
-			snprintf(fmt, 64, "%s%c" Color_RESET, p->cons->context->pal.graph_false, ch);
+			snprintf(fmt, fmt_sz, "%s%c" Color_RESET, p->cons->context->pal.graph_false, ch);
 		}
 	} else {
-		snprintf(fmt, 64, "%c", ch);
+		snprintf(fmt, fmt_sz, "%c", ch);
 	}
 	return fmt;
 }
 
-#define BD(a, b) getbytediff(p, fmt, (a)[i + j], (b)[i + j])
-#define CD(a, b) getchardiff(p, fmt, (a)[i + j], (b)[i + j])
+#define BD(a, b) getbytediff(p, fmt, sizeof(fmt), (a)[i + j], (b)[i + j])
+#define CD(a, b) getchardiff(p, fmt, sizeof(fmt), (a)[i + j], (b)[i + j])
 
 static ut8 *M(const ut8 *b, int len) {
 	ut8 *r = malloc(len + 16);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

harden bounded formatting in `rz_print` and keep row offset growth state consistent on alloc failure.

- replaces `sprintf()` with `snprintf()` in the hexdiff byte/chr formatting helpers
- updates `rz_print_set_rowoff` to only grow `row_offsets` metadata after the backing alloc succeeds

split from https://github.com/rizinorg/rizin/pull/6215

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
