### PR TITLE
make visual resize state replacement alloc safe

### DIFF
--- a/librz/main/rz-diff.c
+++ b/librz/main/rz-diff.c
@@ -2869,18 +2869,41 @@ static void rz_diff_resize_buffer(DiffHexView *hview) {
 	st64 video_size = width;
 	video_size *= height;
 
-	hview->line = realloc(hview->line, video_size);
-	hview->buffer_a = realloc(hview->buffer_a, size_a);
-	hview->buffer_b = realloc(hview->buffer_b, size_b);
+	// build the replacement view state first so resize is like all-or-nothing.
+	char *new_line = malloc(video_size);
+	ut8 *new_buf_a = malloc(size_a);
+	ut8 *new_buf_b = malloc(size_b);
+	if (!new_line || !new_buf_a || !new_buf_b) {
+		free(new_line);
+		free(new_buf_a);
+		free(new_buf_b);
+		return;
+	}
+
+	RzConsCanvas *new_canvas = rz_cons_canvas_new(width, height);
+	if (!new_canvas) {
+		free(new_line);
+		free(new_buf_a);
+		free(new_buf_b);
+		return;
+	}
+
+	new_canvas->color = true;
+	new_canvas->linemode = 1;
+
+	// swap only after every replacement alloc succeeded.
+	free(hview->line);
+	free(hview->buffer_a);
+	free(hview->buffer_b);
+	rz_cons_canvas_free(hview->canvas);
+	hview->line = new_line;
+	hview->buffer_a = new_buf_a;
+	hview->buffer_b = new_buf_b;
 	hview->size_a = size_a;
 	hview->size_b = size_b;
 	hview->screen.width = width;
 	hview->screen.height = height;
-
-	rz_cons_canvas_free(hview->canvas);
-	hview->canvas = rz_cons_canvas_new(width, height);
-	hview->canvas->color = true;
-	hview->canvas->linemode = 1;
+	hview->canvas = new_canvas;
 
 	rz_diff_draw_tui(hview, false);
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
allocates the replacement line buffers and canvas first, and only swaps them into the view after all allocs succeed, avoiding partial updates to the visual state when a resize time alloc fails

split from https://github.com/rizinorg/rizin/pull/6215

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
