### PR TITLE
fix vec cleanup in analyze_gadget

### DIFF
--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -822,6 +822,7 @@ static bool analyze_gadget(RzCore *core, const RzCoreAsmHit *hit, RzGadgetInfo *
 	rz_config_set(core->config, "io.cache", "true");
 	rz_core_il_step(core, 1);
 
+	RzPVector vec = { 0 };
 	RzILVM *vm = il_vm->vm;
 	if (!vm) {
 		ret = false;
@@ -829,8 +830,8 @@ static bool analyze_gadget(RzCore *core, const RzCoreAsmHit *hit, RzGadgetInfo *
 	}
 	void **it;
 
-	RzPVector vec;
-	rz_pvector_init(&vec, (RzPVectorFree)rz_il_event_free);
+	// vec only borrows ptrs from vm->events.
+	rz_pvector_init(&vec, NULL);
 	rz_pvector_foreach (vm->events, it) {
 		RzILEvent *evt = *it;
 		if (!fill_gadget_info_from_events(core, gadget_info, NULL, evt,
@@ -840,7 +841,7 @@ static bool analyze_gadget(RzCore *core, const RzCoreAsmHit *hit, RzGadgetInfo *
 	}
 
 cleanup:
-	rz_pvector_flush(&vec);
+	rz_pvector_fini(&vec);
 	rz_core_seek(core, old_addr, true);
 	return ret;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
`analyze_gadget` uses a local `RzPVector` only as borrowed scratch storage for entries from `vm->events`, but it initialized the vector with `rz_il_event_free` and cleaned it up with `rz_pvector_flush()`.

This PR:
- treats the scratch vector entries as borrowed (`NULL` free callback)
- finalizes the vector instead of flushing it
- zero init vec so cleanup is safe on early exit paths (like !vm and !il_vm)

This fixes one of the temp storage leak (https://github.com/rizinorg/rizin/actions/runs/24354188848/job/71116621362?pr=6130#step:15:2859)

<img width="912" height="295" alt="image" src="https://github.com/user-attachments/assets/2eb31484-5a3c-4310-9800-a275e3ac6f8d" />

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
