### PR TITLE
doc: expand gdb.md with supported packets and commands

### DIFF
--- a/doc/gdb.md
+++ b/doc/gdb.md
@@ -35,32 +35,66 @@ Supported Commands
 
 - read registers
 
-  Reading registers is currently implemented through the <g> packet of the gdb protocol.
-  It returns the whole register profile at once. 
+  Reading registers is currently implemented through the `g` packet of the gdb protocol.
+  It returns the whole register profile at once.
 
 - write registers
 
-  There are two ways of writing registers. The first one is through the P packet.
+  There are two ways of writing registers. The first one is through the `P` packet.
   It works like this: `P<register_index>=<register_value>`
-  The second one is the G packet, that writes the whole register Profile at once.
-  The implementation first tries to use the newer P packet and if it receives a $00# packet (that says not implemented), it tries to write through the G packet.
+  The second one is the `G` packet, that writes the whole register profile at once.
+  The implementation first tries to use the newer `P` packet and if it receives a `$00#`
+  packet (not implemented), it falls back to the `G` packet.
 
--- stepping (but this is still the softstep mode and for an unknown reason it still does not call the gdb_write_register function)
+- stepping
 
-Supported Packets:
+  Single-stepping is implemented through the `vCont;s` packet when vCont is supported,
+  falling back to the `s` packet otherwise.
 
-- `g` : Reads the whole register Profile at once
-- `G` : Writes the whole register Profile at once
-- `m` : Reads memory 
-- `M` : Writes memory
-- `vCont,v` : continues execution of the binary
-- `P` : Write one register
+- breakpoints
 
-TODO
-----
+  Software breakpoints are set and removed using the `Z0`/`z0` packets.
+  Hardware breakpoints use `Z1`/`z1`. Watchpoints (read, write, access) use
+  `Z2`/`z2`, `Z3`/`z3`, and `Z4`/`z4` respectively.
 
-- Implement GDBserver to allow other apps use rizin debugger 
-- Fix that uses the gdb internal stepping version
-- Fix softstep, that it finally recoils correct (it just have to reset the eip/rip)
-- Add Breakpoints (should be an easy add of the function, because its already implemented in the gdb lib)
+- attach/detach
 
+  Attaching to a running process uses the `vAttach` packet. Detaching uses the `D` packet.
+  Multiprocess detach uses `D;<pid>`.
+
+- file access
+
+  Remote file operations (open, read, close) are supported through the `vFile` packet,
+  allowing rizin to read files (e.g. `/proc/<pid>/maps`) directly from the remote target.
+
+- thread and process listing
+
+  Thread and process enumeration is supported via XML target descriptions and the
+  `qXfer:threads:read` packet.
+
+Supported Packets
+-----------------
+
+- `?`  : Query stop reason
+- `g`  : Read all registers at once
+- `G`  : Write all registers at once
+- `p`  : Read a single register
+- `P`  : Write a single register
+- `m`  : Read memory
+- `M`  : Write memory
+- `s`  : Single step
+- `c`  : Continue execution
+- `vCont` : Continue or step with optional signal, per-thread control
+- `vAttach` : Attach to a process by PID
+- `D`  : Detach from target
+- `k`  : Kill the remote process
+- `Z0`/`z0` : Set/remove software breakpoint
+- `Z1`/`z1` : Set/remove hardware breakpoint
+- `Z2`/`z2` : Set/remove write watchpoint
+- `Z3`/`z3` : Set/remove read watchpoint
+- `Z4`/`z4` : Set/remove access watchpoint
+- `qSupported` : Query supported features
+- `qRcmd` : Send a command to the remote target's interpreter
+- `qOffsets` : Get load offsets for sections
+- `vFile` : Remote file I/O operations
+- `qXfer:threads:read` : Read thread list via XML


### PR DESCRIPTION
## Your checklist for this pull request
- [x] I've read the guidelines for contributing to this repository.
- [x] I made sure to follow the project's coding style.
- [ ] I've documented every `RZ_API` function and struct this PR changes. (N/A - documentation only)
- [ ] I've added tests that prove my changes are effective. (N/A - documentation only)
- [ ] I've updated the Rizin book with the relevant information. (N/A - not required for this change)
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

## Detailed description
The gdb.md documentation was incomplete. The Supported Commands section was missing stepping, breakpoints, attach/detach, file access, and thread listing. The Supported Packets list only had 6 entries despite many more being implemented in rzgdb.

Changes:
- Adds missing command descriptions verified against rzgdb source
- Expands Supported Packets list to reflect actual implementation
- Fixes formatting: backtick-formats packet names, fixes capitalization
- Removes outdated TODO items that have since been implemented

Note: AI (Claude, Anthropic) was used to help format this PR description. The documentation content itself was written and verified manually against the rzgdb source code.

## Test plan
Documentation-only change, no code modified. Packet names verified against `subprojects/rzgdb/include/gdbclient/commands.h` and `subprojects/rzgdb/src/gdbclient/core.c`.

## Closing issues
N/A