### PR TITLE
Enable basic blocks to have more than two successors

### DIFF
--- a/librz/arch/block.c
+++ b/librz/arch/block.c
@@ -57,6 +57,7 @@ static RzAnalysisBlock *block_new(RzAnalysis *a, ut64 addr, ut64 size) {
 	block->op_pos_size = DFLT_NINSTR;
 	block->sp_entry = ST32_MAX;
 	rz_vector_init(&block->sp_delta, sizeof(st16), NULL, NULL);
+	rz_vector_init(&block->_succ_addrs, sizeof(RzAnalysisSuccAddr), NULL, NULL);
 	block->cmpval = UT64_MAX;
 	block->fcns = rz_list_new();
 	if (size) {
@@ -75,8 +76,153 @@ static void block_free(RzAnalysisBlock *block) {
 	rz_list_free(block->fcns);
 	free(block->op_pos);
 	rz_vector_fini(&block->sp_delta);
+	rz_vector_fini(&block->_succ_addrs);
 	free(block->parent_reg_arena);
 	free(block);
+}
+
+/**
+ * \brief Returns the block's successor addresses.
+ *
+ * \param block The block to get the successors from.
+ *
+ * \return A vector with the successor addresses, or NULL in case of failure.
+ */
+RZ_API const RzVector /*<RzAnalysisSuccAddr>*/ *rz_analysis_block_succ(const RZ_NONNULL RzAnalysisBlock *block) {
+	rz_return_val_if_fail(block, NULL);
+	return &block->_succ_addrs;
+}
+
+/**
+ * \brief Returns the block's mutable successor addresses.
+ *
+ * \param block The block to get the successors from.
+ *
+ * \return A mutable vector with the successor addresses, or NULL in case of failure.
+ */
+RZ_API RZ_BORROW RzVector /*<RzAnalysisSuccAddr>*/ *rz_analysis_block_succ_mut(RZ_NONNULL RzAnalysisBlock *block) {
+	rz_return_val_if_fail(block, NULL);
+	return &block->_succ_addrs;
+}
+
+/**
+ * \brief Adds an successor address to block.
+ *
+ * \param block The block to add the successors to.
+ * \param addr The successor address.
+ * \param cond The condition under which this successor is followed.
+ *
+ * \return A vector with the successor addresses, or NULL in case of failure.
+ */
+RZ_API void rz_analysis_block_add_succ(RZ_BORROW RZ_NONNULL RzAnalysisBlock *block, ut64 addr, RzTypeCond cond) {
+	rz_return_if_fail(block);
+	RzAnalysisSuccAddr succ = { 0 };
+	succ.addr = addr;
+	succ.cond = cond;
+	rz_vector_push(&block->_succ_addrs, &succ);
+}
+
+/**
+ * \brief Sets the successor address of condition type SUCC to the given address.
+ *
+ * DEPRECATED:
+ * Use rz_analysis_block_add_succ()/rz_analysis_block_succ_mut() instead.
+ * This function is equivalent to legacy `RzAnalysisBlock.jump = addr`.
+ * If multiple addresses with a SUCC condition exist, it is undefined which one is set.
+ *
+ * \param block The block to add the successors to.
+ * \param addr The successor address.
+ */
+RZ_DEPRECATE RZ_API void rz_analysis_block_set_jump(RZ_BORROW RZ_NONNULL RzAnalysisBlock *block, ut64 addr) {
+	rz_return_if_fail(block);
+
+	RzAnalysisSuccAddr *succ;
+	rz_vector_foreach (&block->_succ_addrs, succ) {
+		if (succ->cond == RZ_TYPE_COND_SUCC) {
+			succ->addr = addr;
+			return;
+		}
+	}
+	RzAnalysisSuccAddr jump = { 0 };
+	jump.addr = addr;
+	jump.cond = RZ_TYPE_COND_SUCC;
+	rz_vector_push(&block->_succ_addrs, &jump);
+}
+
+/**
+ * \brief Sets the successor address of condition type FAIL to the given address.
+ *
+ * DEPRECATED:
+ * Use rz_analysis_block_add_succ()/rz_analysis_block_succ_mut() instead.
+ * This function is equivalent to legacy `RzAnalysisBlock.jump = addr`.
+ * If multiple addresses with a FAIL condition exist, it is undefined which one is set.
+ *
+ * \param block The block to add the successors to.
+ * \param addr The successor address.
+ */
+RZ_DEPRECATE RZ_API void rz_analysis_block_set_fail(RZ_BORROW RZ_NONNULL RzAnalysisBlock *block, ut64 addr) {
+	rz_return_if_fail(block);
+	RzAnalysisSuccAddr *succ;
+	rz_vector_foreach (&block->_succ_addrs, succ) {
+		if (succ->cond == RZ_TYPE_COND_FAIL) {
+			succ->addr = addr;
+			return;
+		}
+	}
+	RzAnalysisSuccAddr fail = { 0 };
+	fail.addr = addr;
+	fail.cond = RZ_TYPE_COND_FAIL;
+	rz_vector_push(&block->_succ_addrs, &fail);
+}
+
+/**
+ * \brief Returns the address a block jumps under an `SUCC` condition.
+ *
+ * DEPRECATED:
+ * Use rz_analysis_block_succ() instead.
+ * This function returns the equivalent address of the removed `RzAnalysisBlock.jump`.
+ * If multiple addresses with a SUCC condition exist, it is undefined which one is returned.
+ *
+ * \param block The block to get the successor address from.
+ *
+ * \return Returns successor address followed to under a true or always condition,
+ *         or UT64_MAX if no such successor exists.
+ */
+RZ_DEPRECATE RZ_API ut64 rz_analysis_block_jump(const RZ_NONNULL RzAnalysisBlock *block) {
+	rz_return_val_if_fail(block, UT64_MAX);
+
+	RzAnalysisSuccAddr *succ;
+	rz_vector_foreach (&block->_succ_addrs, succ) {
+		if (succ->cond == RZ_TYPE_COND_SUCC) {
+			return succ->addr;
+		}
+	}
+	return UT64_MAX;
+}
+
+/**
+ * \brief Returns the address a block jumps under an `FAIL` condition.
+ *
+ * DEPRECATED:
+ * Use rz_analysis_block_succ() instead.
+ * This function returns the equivalent address of the removed `RzAnalysisBlock.fail`.
+ * If multiple addresses with a FAIL condition exist, it is undefined which one is returned.
+ *
+ * \param block The block to get the successor address from.
+ *
+ * \return Returns successor address followed to under a `FAIL` condition,
+ *         or UT64_MAX if no such successor exists.
+ */
+RZ_DEPRECATE RZ_API ut64 rz_analysis_block_fail(const RZ_NONNULL RzAnalysisBlock *block) {
+	rz_return_val_if_fail(block, UT64_MAX);
+
+	RzAnalysisSuccAddr *succ;
+	rz_vector_foreach (&block->_succ_addrs, succ) {
+		if (succ->cond == RZ_TYPE_COND_FAIL) {
+			return succ->addr;
+		}
+	}
+	return UT64_MAX;
 }
 
 void __block_free_rb(RBNode *node, void *user) {
@@ -267,7 +413,7 @@ RZ_API RzAnalysisBlock *rz_analysis_block_split(RzAnalysisBlock *bbi, ut64 addr)
 	if (!bb) {
 		return NULL;
 	}
-	bb->jump = bbi->jump;
+	bb->jump = rz_analysis_block_jump(bbi);
 	bb->fail = bbi->fail;
 	bb->sp_entry = rz_analysis_block_get_sp_at(bbi, addr);
 	bb->switch_op = bbi->switch_op;
@@ -517,8 +663,8 @@ RZ_API bool rz_analysis_block_recurse_depth_first(RzAnalysisBlock *block, RzAnal
 	do {
 		RecurseDepthFirstCtx *cur_ctx = rz_vector_index_ptr(&path, path.len - 1);
 		cur_bb = cur_ctx->bb;
-		if (cur_bb->jump != UT64_MAX && !ht_up_find_kv(visited, cur_bb->jump, NULL)) {
-			cur_bb = rz_analysis_get_block_at(analysis, cur_bb->jump);
+		if (rz_analysis_block_jump(cur_bb) != UT64_MAX && !ht_up_find_kv(visited, cur_bb->jump, NULL)) {
+			cur_bb = rz_analysis_get_block_at(analysis, rz_analysis_block_jump(cur_bb));
 		} else if (cur_bb->fail != UT64_MAX && !ht_up_find_kv(visited, cur_bb->fail, NULL)) {
 			cur_bb = rz_analysis_get_block_at(analysis, cur_bb->fail);
 		} else {

--- a/librz/arch/block.c
+++ b/librz/arch/block.c
@@ -51,8 +51,6 @@ static RzAnalysisBlock *block_new(RzAnalysis *a, ut64 addr, ut64 size) {
 	block->size = size;
 	block->analysis = a;
 	block->ref = 1;
-	block->jump = UT64_MAX;
-	block->fail = UT64_MAX;
 	block->op_pos = RZ_NEWS0(ut16, DFLT_NINSTR);
 	block->op_pos_size = DFLT_NINSTR;
 	block->sp_entry = ST32_MAX;
@@ -413,15 +411,15 @@ RZ_API RzAnalysisBlock *rz_analysis_block_split(RzAnalysisBlock *bbi, ut64 addr)
 	if (!bb) {
 		return NULL;
 	}
-	bb->jump = rz_analysis_block_jump(bbi);
-	bb->fail = bbi->fail;
+	rz_analysis_block_set_jump(bb, rz_analysis_block_jump(bbi));
+	rz_analysis_block_set_fail(bb, rz_analysis_block_fail(bbi));
 	bb->sp_entry = rz_analysis_block_get_sp_at(bbi, addr);
 	bb->switch_op = bbi->switch_op;
 
 	// resize the first block
 	rz_analysis_block_set_size(bbi, addr - bbi->addr);
-	bbi->jump = addr;
-	bbi->fail = UT64_MAX;
+	rz_analysis_block_set_jump(bbi, addr);
+	rz_analysis_block_set_fail(bbi, UT64_MAX);
 	bbi->switch_op = NULL;
 	rz_analysis_block_update_hash(bbi);
 
@@ -499,8 +497,8 @@ RZ_API bool rz_analysis_block_merge(RzAnalysisBlock *a, RzAnalysisBlock *b) {
 
 	// merge everything else into a
 	a->size += b->size;
-	a->jump = b->jump;
-	a->fail = b->fail;
+	rz_analysis_block_set_jump(a, rz_analysis_block_jump(b));
+	rz_analysis_block_set_fail(a, rz_analysis_block_fail(b));
 	if (a->switch_op) {
 		RZ_LOG_DEBUG("Dropping switch table at 0x%" PFMT64x " of block at 0x%" PFMT64x "\n", a->switch_op->addr, a->addr);
 		rz_analysis_switch_op_free(a->switch_op);
@@ -545,8 +543,8 @@ RZ_API bool rz_analysis_block_successor_addrs_foreach(RzAnalysisBlock *block, Rz
 		} \
 	} while (0);
 
-	CB_ADDR(block->jump);
-	CB_ADDR(block->fail);
+	CB_ADDR(rz_analysis_block_jump(block));
+	CB_ADDR(rz_analysis_block_fail(block));
 	if (block->switch_op && block->switch_op->cases) {
 		RzListIter *iter;
 		RzAnalysisCaseOp *caseop;
@@ -663,10 +661,12 @@ RZ_API bool rz_analysis_block_recurse_depth_first(RzAnalysisBlock *block, RzAnal
 	do {
 		RecurseDepthFirstCtx *cur_ctx = rz_vector_index_ptr(&path, path.len - 1);
 		cur_bb = cur_ctx->bb;
-		if (rz_analysis_block_jump(cur_bb) != UT64_MAX && !ht_up_find_kv(visited, cur_bb->jump, NULL)) {
-			cur_bb = rz_analysis_get_block_at(analysis, rz_analysis_block_jump(cur_bb));
-		} else if (cur_bb->fail != UT64_MAX && !ht_up_find_kv(visited, cur_bb->fail, NULL)) {
-			cur_bb = rz_analysis_get_block_at(analysis, cur_bb->fail);
+		ut64 fail = rz_analysis_block_fail(cur_bb);
+		ut64 jump = rz_analysis_block_jump(cur_bb);
+		if (jump != UT64_MAX && !ht_up_find_kv(visited, jump, NULL)) {
+			cur_bb = rz_analysis_get_block_at(analysis, jump);
+		} else if (fail != UT64_MAX && !ht_up_find_kv(visited, fail, NULL)) {
+			cur_bb = rz_analysis_get_block_at(analysis, fail);
 		} else {
 			if (cur_bb->switch_op && !cur_ctx->switch_it) {
 				cur_ctx->switch_it = rz_list_head(cur_bb->switch_op->cases);
@@ -933,8 +933,8 @@ RZ_API RzAnalysisBlock *rz_analysis_block_chop_noreturn(RzAnalysisBlock *block, 
 	// Chop the block. Resize and remove all destination addrs
 	rz_analysis_block_set_size(block, addr - block->addr);
 	rz_analysis_block_update_hash(block);
-	block->jump = UT64_MAX;
-	block->fail = UT64_MAX;
+	rz_analysis_block_set_jump(block, UT64_MAX);
+	rz_analysis_block_set_fail(block, UT64_MAX);
 	rz_analysis_switch_op_free(block->switch_op);
 	block->switch_op = NULL;
 

--- a/librz/arch/block.c
+++ b/librz/arch/block.c
@@ -55,7 +55,7 @@ static RzAnalysisBlock *block_new(RzAnalysis *a, ut64 addr, ut64 size) {
 	block->op_pos_size = DFLT_NINSTR;
 	block->sp_entry = ST32_MAX;
 	rz_vector_init(&block->sp_delta, sizeof(st16), NULL, NULL);
-	rz_vector_init(&block->_succ_addrs, sizeof(RzAnalysisSuccAddr), NULL, NULL);
+	rz_vector_init(&block->succ_addrs, sizeof(RzAnalysisSuccAddr), NULL, NULL);
 	block->cmpval = UT64_MAX;
 	block->fcns = rz_list_new();
 	if (size) {
@@ -74,7 +74,7 @@ static void block_free(RzAnalysisBlock *block) {
 	rz_list_free(block->fcns);
 	free(block->op_pos);
 	rz_vector_fini(&block->sp_delta);
-	rz_vector_fini(&block->_succ_addrs);
+	rz_vector_fini(&block->succ_addrs);
 	free(block->parent_reg_arena);
 	free(block);
 }
@@ -88,7 +88,7 @@ static void block_free(RzAnalysisBlock *block) {
  */
 RZ_API const RzVector /*<RzAnalysisSuccAddr>*/ *rz_analysis_block_succ(const RZ_NONNULL RzAnalysisBlock *block) {
 	rz_return_val_if_fail(block, NULL);
-	return &block->_succ_addrs;
+	return &block->succ_addrs;
 }
 
 /**
@@ -100,7 +100,7 @@ RZ_API const RzVector /*<RzAnalysisSuccAddr>*/ *rz_analysis_block_succ(const RZ_
  */
 RZ_API RZ_BORROW RzVector /*<RzAnalysisSuccAddr>*/ *rz_analysis_block_succ_mut(RZ_NONNULL RzAnalysisBlock *block) {
 	rz_return_val_if_fail(block, NULL);
-	return &block->_succ_addrs;
+	return &block->succ_addrs;
 }
 
 /**
@@ -117,7 +117,7 @@ RZ_API void rz_analysis_block_add_succ(RZ_BORROW RZ_NONNULL RzAnalysisBlock *blo
 	RzAnalysisSuccAddr succ = { 0 };
 	succ.addr = addr;
 	succ.cond = cond;
-	rz_vector_push(&block->_succ_addrs, &succ);
+	rz_vector_push(&block->succ_addrs, &succ);
 }
 
 /**
@@ -135,7 +135,7 @@ RZ_DEPRECATE RZ_API void rz_analysis_block_set_jump(RZ_BORROW RZ_NONNULL RzAnaly
 	rz_return_if_fail(block);
 
 	RzAnalysisSuccAddr *succ;
-	rz_vector_foreach (&block->_succ_addrs, succ) {
+	rz_vector_foreach (&block->succ_addrs, succ) {
 		if (succ->cond == RZ_TYPE_COND_SUCC) {
 			succ->addr = addr;
 			return;
@@ -144,7 +144,7 @@ RZ_DEPRECATE RZ_API void rz_analysis_block_set_jump(RZ_BORROW RZ_NONNULL RzAnaly
 	RzAnalysisSuccAddr jump = { 0 };
 	jump.addr = addr;
 	jump.cond = RZ_TYPE_COND_SUCC;
-	rz_vector_push(&block->_succ_addrs, &jump);
+	rz_vector_push(&block->succ_addrs, &jump);
 }
 
 /**
@@ -161,7 +161,7 @@ RZ_DEPRECATE RZ_API void rz_analysis_block_set_jump(RZ_BORROW RZ_NONNULL RzAnaly
 RZ_DEPRECATE RZ_API void rz_analysis_block_set_fail(RZ_BORROW RZ_NONNULL RzAnalysisBlock *block, ut64 addr) {
 	rz_return_if_fail(block);
 	RzAnalysisSuccAddr *succ;
-	rz_vector_foreach (&block->_succ_addrs, succ) {
+	rz_vector_foreach (&block->succ_addrs, succ) {
 		if (succ->cond == RZ_TYPE_COND_FAIL) {
 			succ->addr = addr;
 			return;
@@ -170,7 +170,7 @@ RZ_DEPRECATE RZ_API void rz_analysis_block_set_fail(RZ_BORROW RZ_NONNULL RzAnaly
 	RzAnalysisSuccAddr fail = { 0 };
 	fail.addr = addr;
 	fail.cond = RZ_TYPE_COND_FAIL;
-	rz_vector_push(&block->_succ_addrs, &fail);
+	rz_vector_push(&block->succ_addrs, &fail);
 }
 
 /**
@@ -190,7 +190,7 @@ RZ_DEPRECATE RZ_API ut64 rz_analysis_block_jump(const RZ_NONNULL RzAnalysisBlock
 	rz_return_val_if_fail(block, UT64_MAX);
 
 	RzAnalysisSuccAddr *succ;
-	rz_vector_foreach (&block->_succ_addrs, succ) {
+	rz_vector_foreach (&block->succ_addrs, succ) {
 		if (succ->cond == RZ_TYPE_COND_SUCC) {
 			return succ->addr;
 		}
@@ -215,7 +215,7 @@ RZ_DEPRECATE RZ_API ut64 rz_analysis_block_fail(const RZ_NONNULL RzAnalysisBlock
 	rz_return_val_if_fail(block, UT64_MAX);
 
 	RzAnalysisSuccAddr *succ;
-	rz_vector_foreach (&block->_succ_addrs, succ) {
+	rz_vector_foreach (&block->succ_addrs, succ) {
 		if (succ->cond == RZ_TYPE_COND_FAIL) {
 			return succ->addr;
 		}

--- a/librz/arch/fcn.c
+++ b/librz/arch/fcn.c
@@ -103,11 +103,11 @@ RZ_API int rz_analysis_function_resize(RzAnalysisFunction *fcn, int newsize) {
 			rz_analysis_block_set_size(bb, eof - bb->addr);
 			rz_analysis_block_update_hash(bb);
 		}
-		if (bb->jump != UT64_MAX && bb->jump >= eof) {
-			bb->jump = UT64_MAX;
+		if (rz_analysis_block_jump(bb) != UT64_MAX && rz_analysis_block_jump(bb) >= eof) {
+			rz_analysis_block_set_jump(bb, UT64_MAX);
 		}
-		if (bb->fail != UT64_MAX && bb->fail >= eof) {
-			bb->fail = UT64_MAX;
+		if (rz_analysis_block_fail(bb) != UT64_MAX && rz_analysis_block_fail(bb) >= eof) {
+			rz_analysis_block_set_fail(bb, UT64_MAX);
 		}
 		i++;
 	}
@@ -250,7 +250,7 @@ static ut64 try_get_cmpval_from_parents(RzAnalysis *analysis, RzAnalysisFunction
 	void **it;
 	rz_pvector_foreach (fcn->bbs, it) {
 		tmp_bb = (RzAnalysisBlock *)*it;
-		if (tmp_bb->jump != my_bb->addr && tmp_bb->fail != my_bb->addr) {
+		if (rz_analysis_block_jump(tmp_bb) != my_bb->addr && rz_analysis_block_fail(tmp_bb) != my_bb->addr) {
 			continue;
 		}
 		if (tmp_bb->cmpreg != cmp_reg) {
@@ -540,8 +540,8 @@ static int analyze_function_locally(RzAnalysis *analysis, RzAnalysisFunction *fc
 }
 
 static inline void set_bb_branches(RZ_OUT RzAnalysisBlock *bb, const ut64 jump, const ut64 fail) {
-	bb->jump = jump;
-	bb->fail = fail;
+	rz_analysis_block_set_jump(bb, jump);
+	rz_analysis_block_set_fail(bb, fail);
 }
 
 /**
@@ -795,7 +795,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 		if (idx > 0 && !overlapped) {
 			bbg = bbget(analysis, at, can_jmpmid);
 			if (bbg && bbg != bb) {
-				bb->jump = at;
+				rz_analysis_block_set_jump(bb, at);
 				if (can_jmpmid) {
 					// This happens when we purposefully walked over another block and overlapped it
 					// and now we hit an offset where the instructions match again.
@@ -821,7 +821,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 				}
 				// If previous instruction was a jump there would already be a split.
 				// So setting jump here shouldn't overwrite any real jumps.
-				bb->jump = at;
+				rz_analysis_block_set_jump(bb, at);
 				item->block = bb = next;
 				next->sp_entry = sp;
 				newbbsize = bb->size + oplen;
@@ -845,16 +845,16 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 					if (filter_addr) {
 						rz_analysis_xrefs_set(analysis, op.addr, filter_addr, RZ_ANALYSIS_XREF_TYPE_CALL);
 					}
-					bb->jump = at + oplen;
+					rz_analysis_block_set_jump(bb, at + oplen);
 					if (from_addr != bb->addr) {
-						bb->fail = handle_addr;
+						rz_analysis_block_set_fail(bb, handle_addr);
 						ret = analyze_function_locally(analysis, fcn, handle_addr);
 						if (bb->size == 0) {
 							rz_analysis_function_remove_block(fcn, bb);
 						}
 						rz_analysis_block_update_hash(bb);
 						rz_analysis_block_unref(bb);
-						bb = fcn_append_basic_block(analysis, fcn, bb->jump);
+						bb = fcn_append_basic_block(analysis, fcn, rz_analysis_block_jump(bb));
 						if (!bb) {
 							gotoBeach(RZ_ANALYSIS_RET_ERROR);
 						}
@@ -1240,8 +1240,8 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 			if (!continue_after_jump) {
 				if (op.jump < fcn->addr) {
 					if (!overlapped) {
-						bb->jump = op.jump;
-						bb->fail = UT64_MAX;
+						rz_analysis_block_set_jump(bb, op.jump);
+						rz_analysis_block_set_fail(bb, UT64_MAX);
 					}
 					gotoBeach(RZ_ANALYSIS_RET_END);
 				}
@@ -1469,7 +1469,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 			if (last_is_push && analysis->opt.pushret) {
 				op.type = RZ_ANALYSIS_OP_TYPE_JMP;
 				op.jump = last_push_addr;
-				bb->jump = op.jump;
+				rz_analysis_block_set_jump(bb, op.jump);
 				rz_analysis_task_item_new(analysis, tasks, fcn, NULL, op.jump, sp);
 				goto beach;
 			}
@@ -1814,8 +1814,8 @@ RZ_API bool rz_analysis_fcn_add_bb(RzAnalysis *a, RzAnalysisFunction *fcn, ut64 
 	rz_analysis_block_analyze_ops(block);
 	rz_analysis_function_add_block(fcn, block);
 
-	block->jump = jump;
-	block->fail = fail;
+	rz_analysis_block_set_jump(block, jump);
+	rz_analysis_block_set_fail(block, fail);
 	rz_analysis_block_unref(block);
 	return true;
 }
@@ -1830,10 +1830,10 @@ RZ_API ut32 rz_analysis_function_loops(RzAnalysisFunction *fcn) {
 	void **it;
 	rz_pvector_foreach (fcn->bbs, it) {
 		bb = (RzAnalysisBlock *)*it;
-		if (bb->jump != UT64_MAX && bb->jump < bb->addr) {
+		if (rz_analysis_block_jump(bb) != UT64_MAX && rz_analysis_block_jump(bb) < bb->addr) {
 			loops++;
 		}
-		if (bb->fail != UT64_MAX && bb->fail < bb->addr) {
+		if (rz_analysis_block_fail(bb) != UT64_MAX && rz_analysis_block_fail(bb) < bb->addr) {
 			loops++;
 		}
 	}
@@ -1861,14 +1861,14 @@ RZ_API ut32 rz_analysis_function_complexity(RzAnalysisFunction *fcn) {
 	rz_pvector_foreach (fcn->bbs, it) {
 		bb = (RzAnalysisBlock *)*it;
 		N++; // nodes
-		if (!analysis && bb->jump == UT64_MAX && bb->fail != UT64_MAX) {
+		if (!analysis && rz_analysis_block_jump(bb) == UT64_MAX && rz_analysis_block_fail(bb) != UT64_MAX) {
 			RZ_LOG_DEBUG("invalid bb jump/fail pair at 0x%08" PFMT64x " (fcn 0x%08" PFMT64x "\n", bb->addr, fcn->addr);
 		}
-		if (bb->jump == UT64_MAX && bb->fail == UT64_MAX) {
+		if (rz_analysis_block_jump(bb) == UT64_MAX && rz_analysis_block_fail(bb) == UT64_MAX) {
 			P++; // exit nodes
 		} else {
 			E++; // edges
-			if (bb->fail != UT64_MAX) {
+			if (rz_analysis_block_fail(bb) != UT64_MAX) {
 				E++;
 			}
 		}
@@ -2190,13 +2190,13 @@ RZ_API ut32 rz_analysis_function_count_edges(const RzAnalysisFunction *fcn, RZ_N
 	void **it;
 	rz_pvector_foreach (fcn->bbs, it) {
 		bb = (RzAnalysisBlock *)*it;
-		if (ebbs && bb->jump == UT64_MAX && bb->fail == UT64_MAX) {
+		if (ebbs && rz_analysis_block_jump(bb) == UT64_MAX && rz_analysis_block_fail(bb) == UT64_MAX) {
 			*ebbs = *ebbs + 1;
 		} else {
-			if (bb->jump != UT64_MAX) {
+			if (rz_analysis_block_jump(bb) != UT64_MAX) {
 				edges++;
 			}
-			if (bb->fail != UT64_MAX) {
+			if (rz_analysis_block_fail(bb) != UT64_MAX) {
 				edges++;
 			}
 		}

--- a/librz/arch/jmptbl.c
+++ b/librz/arch/jmptbl.c
@@ -519,19 +519,20 @@ RZ_API bool rz_analysis_get_jmptbl_info(RZ_NONNULL RzAnalysis *analysis, RZ_NONN
 	void **iter;
 	rz_pvector_foreach (fcn->bbs, iter) {
 		tmp_bb = (RzAnalysisBlock *)*iter;
-		if (tmp_bb->jump == block->addr || tmp_bb->fail == block->addr) {
+		if (rz_analysis_block_jump(tmp_bb) == block->addr || rz_analysis_block_fail(tmp_bb) == block->addr) {
 			prev_bb = tmp_bb;
 			break;
 		}
 	}
 	// predecessor must be a conditional jump
-	if (!prev_bb || !prev_bb->jump || !prev_bb->fail) {
+	if (!prev_bb || !rz_analysis_block_jump(prev_bb) || !rz_analysis_block_fail(prev_bb)) {
 		RZ_LOG_DEBUG("Missing predecesessor on basic block conditional jump at 0x%08" PFMT64x ", required by jump table\n", jmp_address);
 		return false;
 	}
 
 	// default case is the jump target of the unconditional jump
-	params->default_case = prev_bb->jump == block->addr ? prev_bb->fail : prev_bb->jump;
+	ut64 jump = rz_analysis_block_jump(prev_bb);
+	params->default_case = jump == block->addr ? rz_analysis_block_fail(prev_bb) : jump;
 
 	RzAnalysisOp tmp_aop = { 0 };
 	ut8 *bb_buf = calloc(1, prev_bb->size);

--- a/librz/arch/luac_process.c
+++ b/librz/arch/luac_process.c
@@ -121,8 +121,8 @@ RZ_API bool rz_core_bin_apply_luac_debug(RzCore *core, RzBinFile *binfile) {
 			// fcn = rz_analysis_create_function(core->analysis, pname, meta_addr, RZ_ANALYSIS_FCN_TYPE_IMP);
 			// RzAnalysisFunction *fcn = rz_analysis_get_function_at(core->analysis, PROTO_VADDRESS(proto->index));
 			RzAnalysisBlock *bb = rz_analysis_create_block(core->analysis, faddr, proto->code_size - proto->code_skipped);
-			bb->jump = UT64_MAX;
-			bb->fail = UT64_MAX;
+			rz_analysis_block_set_jump(bb, UT64_MAX);
+			rz_analysis_block_set_fail(bb, UT64_MAX);
 
 			rz_analysis_function_add_block(fcn, bb);
 		}

--- a/librz/arch/serialize_analysis.c
+++ b/librz/arch/serialize_analysis.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include "analysis_private.h"
+#include "rz_analysis.h"
 #include <rz_core.h>
 
 #include <errno.h>
@@ -133,11 +134,11 @@ static void block_store(RZ_NONNULL Sdb *db, const char *key, RzAnalysisBlock *bl
 	pj_o(j);
 
 	pj_kn(j, "size", block->size);
-	if (block->jump != UT64_MAX) {
-		pj_kn(j, "jump", block->jump);
+	if (rz_analysis_block_jump(block) != UT64_MAX) {
+		pj_kn(j, "jump", rz_analysis_block_jump(block));
 	}
-	if (block->fail != UT64_MAX) {
-		pj_kn(j, "fail", block->fail);
+	if (rz_analysis_block_fail(block) != UT64_MAX) {
+		pj_kn(j, "fail", rz_analysis_block_fail(block));
 	}
 	if (block->traced) {
 		pj_kb(j, "traced", true);
@@ -245,8 +246,6 @@ static bool block_load_cb(void *user, const SdbKv *kv) {
 	}
 
 	RzAnalysisBlock proto = { 0 };
-	proto.jump = UT64_MAX;
-	proto.fail = UT64_MAX;
 	proto.size = UT64_MAX;
 	proto.sp_entry = RZ_STACK_ADDR_INVALID;
 	proto.cmpval = UT64_MAX;
@@ -262,13 +261,13 @@ static bool block_load_cb(void *user, const SdbKv *kv) {
 			if (child->type != RZ_JSON_INTEGER) {
 				break;
 			}
-			proto.jump = child->num.u_value;
+			rz_analysis_block_set_jump(&proto, child->num.u_value);
 			break;
 		case BLOCK_FIELD_FAIL:
 			if (child->type != RZ_JSON_INTEGER) {
 				break;
 			}
-			proto.fail = child->num.u_value;
+			rz_analysis_block_set_fail(&proto, child->num.u_value);
 			break;
 		case BLOCK_FIELD_TRACED:
 			if (child->type != RZ_JSON_BOOLEAN) {
@@ -364,8 +363,8 @@ static bool block_load_cb(void *user, const SdbKv *kv) {
 	if (!block) {
 		goto error;
 	}
-	block->jump = proto.jump;
-	block->fail = proto.fail;
+	rz_analysis_block_set_jump(block, rz_analysis_block_jump(&proto));
+	rz_analysis_block_set_fail(block, rz_analysis_block_fail(&proto));
 	block->traced = proto.traced;
 	block->colorize = proto.colorize;
 	block->switch_op = proto.switch_op;

--- a/librz/arch/serialize_analysis.c
+++ b/librz/arch/serialize_analysis.c
@@ -77,6 +77,38 @@ RZ_API void rz_serialize_analysis_switch_op_save(RZ_NONNULL PJ *j, RZ_NONNULL Rz
 	pj_end(j);
 }
 
+RZ_API void rz_serialize_analysis_succ_addr_save(RZ_NONNULL PJ *j, const RZ_NONNULL RzAnalysisSuccAddr *succ_addr) {
+	pj_o(j);
+	pj_kn(j, "addr", succ_addr->addr);
+	pj_kn(j, "cond", succ_addr->cond);
+	pj_end(j);
+}
+
+RZ_API bool rz_serialize_analysis_succ_addr_load(RZ_NONNULL const RzJson *json, RZ_OUT RZ_NONNULL RzAnalysisSuccAddr *succ_addr) {
+	rz_return_val_if_fail(json && succ_addr, false);
+	if (json->type != RZ_JSON_OBJECT) {
+		rz_warn_if_reached();
+		return false;
+	}
+	RzJson *child;
+	for (child = json->children.first; child; child = child->next) {
+		switch (child->type) {
+		default:
+			// Unhandled new field.
+			rz_warn_if_reached();
+			break;
+		case RZ_JSON_INTEGER:
+			if (RZ_STR_EQ(child->key, "addr")) {
+				succ_addr->addr = child->num.u_value;
+			} else if (RZ_STR_EQ(child->key, "cond")) {
+				succ_addr->cond = child->num.u_value;
+			}
+			break;
+		}
+	}
+	return true;
+}
+
 RZ_API RzAnalysisSwitchOp *rz_serialize_analysis_switch_op_load(RZ_NONNULL const RzJson *json) {
 	if (json->type != RZ_JSON_OBJECT) {
 		return NULL;
@@ -134,11 +166,14 @@ static void block_store(RZ_NONNULL Sdb *db, const char *key, RzAnalysisBlock *bl
 	pj_o(j);
 
 	pj_kn(j, "size", block->size);
-	if (rz_analysis_block_jump(block) != UT64_MAX) {
-		pj_kn(j, "jump", rz_analysis_block_jump(block));
-	}
-	if (rz_analysis_block_fail(block) != UT64_MAX) {
-		pj_kn(j, "fail", rz_analysis_block_fail(block));
+	if (rz_vector_len(&block->succ_addrs) > 0) {
+		pj_k(j, "succ_addrs");
+		pj_a(j);
+		RzAnalysisSuccAddr *sa;
+		rz_vector_foreach (&block->succ_addrs, sa) {
+			rz_serialize_analysis_succ_addr_save(j, sa);
+		}
+		pj_end(j);
 	}
 	if (block->traced) {
 		pj_kb(j, "traced", true);
@@ -214,8 +249,7 @@ RZ_API void rz_serialize_analysis_blocks_save(RZ_NONNULL Sdb *db, RZ_NONNULL RzA
 
 enum {
 	BLOCK_FIELD_SIZE,
-	BLOCK_FIELD_JUMP,
-	BLOCK_FIELD_FAIL,
+	BLOCK_FIELD_SUCC_ADDRS,
 	BLOCK_FIELD_TRACED,
 	BLOCK_FIELD_COLORIZE,
 	BLOCK_FIELD_SWITCH_OP,
@@ -249,6 +283,7 @@ static bool block_load_cb(void *user, const SdbKv *kv) {
 	proto.size = UT64_MAX;
 	proto.sp_entry = RZ_STACK_ADDR_INVALID;
 	proto.cmpval = UT64_MAX;
+	rz_vector_init(&proto.succ_addrs, sizeof(RzAnalysisSuccAddr), NULL, NULL);
 	rz_vector_init(&proto.sp_delta, sizeof(st16), NULL, NULL);
 	RZ_KEY_PARSER_JSON(ctx->parser, json, child, {
 		case BLOCK_FIELD_SIZE:
@@ -257,17 +292,21 @@ static bool block_load_cb(void *user, const SdbKv *kv) {
 			}
 			proto.size = child->num.u_value;
 			break;
-		case BLOCK_FIELD_JUMP:
-			if (child->type != RZ_JSON_INTEGER) {
+		case BLOCK_FIELD_SUCC_ADDRS:
+			if (child->type != RZ_JSON_ARRAY) {
 				break;
 			}
-			rz_analysis_block_set_jump(&proto, child->num.u_value);
-			break;
-		case BLOCK_FIELD_FAIL:
-			if (child->type != RZ_JSON_INTEGER) {
-				break;
+			rz_vector_clear(&proto.succ_addrs);
+			rz_vector_reserve(&proto.succ_addrs, child->children.count);
+			RzJson *baby;
+			for (baby = child->children.first; baby; baby = baby->next) {
+				if (baby->type != RZ_JSON_OBJECT) {
+					break;
+				}
+				RzAnalysisSuccAddr sa = { 0 };
+				rz_serialize_analysis_succ_addr_load(baby, &sa);
+				rz_vector_push(&proto.succ_addrs, &sa);
 			}
-			rz_analysis_block_set_fail(&proto, child->num.u_value);
 			break;
 		case BLOCK_FIELD_TRACED:
 			if (child->type != RZ_JSON_BOOLEAN) {
@@ -363,8 +402,11 @@ static bool block_load_cb(void *user, const SdbKv *kv) {
 	if (!block) {
 		goto error;
 	}
-	rz_analysis_block_set_jump(block, rz_analysis_block_jump(&proto));
-	rz_analysis_block_set_fail(block, rz_analysis_block_fail(&proto));
+	RzAnalysisSuccAddr *sa;
+	rz_vector_foreach (&proto.succ_addrs, sa) {
+		rz_vector_push(&block->succ_addrs, sa);
+	}
+	rz_vector_fini(&proto.succ_addrs);
 	block->traced = proto.traced;
 	block->colorize = proto.colorize;
 	block->switch_op = proto.switch_op;
@@ -395,8 +437,7 @@ RZ_API bool rz_serialize_analysis_blocks_load(RZ_NONNULL Sdb *db, RZ_NONNULL RzA
 		return false;
 	}
 	rz_key_parser_add(ctx.parser, "size", BLOCK_FIELD_SIZE);
-	rz_key_parser_add(ctx.parser, "jump", BLOCK_FIELD_JUMP);
-	rz_key_parser_add(ctx.parser, "fail", BLOCK_FIELD_FAIL);
+	rz_key_parser_add(ctx.parser, "succ_addrs", BLOCK_FIELD_SUCC_ADDRS);
 	rz_key_parser_add(ctx.parser, "traced", BLOCK_FIELD_TRACED);
 	rz_key_parser_add(ctx.parser, "colorize", BLOCK_FIELD_COLORIZE);
 	rz_key_parser_add(ctx.parser, "switch_op", BLOCK_FIELD_SWITCH_OP);

--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -2914,8 +2914,8 @@ static char *get_bb_body(RzCore *core, RzAnalysisBlock *b, int opts, RzAnalysisF
 		}
 	}
 	char *body = get_body(core, b->addr, b->size, opts);
-	if (b->jump != UT64_MAX && b->jump > b->addr) {
-		RzAnalysisBlock *jumpbb = rz_analysis_get_block_at(b->analysis, b->jump);
+	if (rz_analysis_block_jump(b) != UT64_MAX && rz_analysis_block_jump(b) > b->addr) {
+		RzAnalysisBlock *jumpbb = rz_analysis_get_block_at(b->analysis, rz_analysis_block_jump(b));
 		if (jumpbb && rz_list_contains(jumpbb->fcns, fcn)) {
 			ut8 *last_disasm_reg = rz_analysis_get_last_disasm_reg(core->analysis);
 			if (emu && last_disasm_reg != NULL && !jumpbb->parent_reg_arena) {
@@ -2923,8 +2923,8 @@ static char *get_bb_body(RzCore *core, RzAnalysisBlock *b, int opts, RzAnalysisF
 			}
 		}
 	}
-	if (b->fail != UT64_MAX && b->fail > b->addr) {
-		RzAnalysisBlock *failbb = rz_analysis_get_block_at(b->analysis, b->fail);
+	if (rz_analysis_block_fail(b) != UT64_MAX && rz_analysis_block_fail(b) > b->addr) {
+		RzAnalysisBlock *failbb = rz_analysis_get_block_at(b->analysis, rz_analysis_block_fail(b));
 		if (failbb && rz_list_contains(failbb->fcns, fcn)) {
 			ut8 *last_disasm_reg = rz_analysis_get_last_disasm_reg(core->analysis);
 			if (emu && last_disasm_reg != NULL && !failbb->parent_reg_arena) {
@@ -3066,7 +3066,7 @@ static void delete_dup_edges(RzAGraph *g) {
 }
 
 static bool isbbfew(RzAnalysisBlock *curbb, RzAnalysisBlock *bb) {
-	if (bb->addr == curbb->addr || bb->addr == curbb->jump || bb->addr == curbb->fail) {
+	if (bb->addr == curbb->addr || bb->addr == rz_analysis_block_jump(curbb) || bb->addr == rz_analysis_block_fail(curbb)) {
 		// do nothing
 		return true;
 	}
@@ -3153,20 +3153,20 @@ static int get_bbnodes(RzAGraph *g, RzCore *core, RzAnalysisFunction *fcn) {
 		RzANode *u = rz_agraph_get_node(g, title);
 		RzANode *v;
 		free(title);
-		if (bb->jump != UT64_MAX) {
-			title = get_title(bb->jump);
+		if (rz_analysis_block_jump(bb) != UT64_MAX) {
+			title = get_title(rz_analysis_block_jump(bb));
 			v = rz_agraph_get_node(g, title);
 			free(title);
 			rz_agraph_add_edge_at(g, u, v, 0);
 			set_edge_kind(agraph_find_graph_edge(g, u->gnode, v->gnode), AGRAPH_EDGE_KIND_TRUE);
 		}
-		if (bb->fail != UT64_MAX) {
-			title = get_title(bb->fail);
+		if (rz_analysis_block_fail(bb) != UT64_MAX) {
+			title = get_title(rz_analysis_block_fail(bb));
 			v = rz_agraph_get_node(g, title);
 			free(title);
 			rz_agraph_add_edge_at(g, u, v, 1);
 			set_edge_kind(agraph_find_graph_edge(g, u->gnode, v->gnode), AGRAPH_EDGE_KIND_FALSE);
-			if (bb->jump != UT64_MAX && u->title && v->title) {
+			if (rz_analysis_block_jump(bb) != UT64_MAX && u->title && v->title) {
 				char buf[384] = { 0 };
 				rz_strf(buf, "agraph.nodes.%s.neighbours", u->title);
 				char *db_val = rz_str_newf(",%s", v->title);

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -338,7 +338,7 @@ RZ_IPI void rz_core_analysis_fcn_returns(RzCore *core, RzAnalysisFunction *fcn) 
 	void **iter;
 	rz_pvector_foreach (fcn->bbs, iter) {
 		b = (RzAnalysisBlock *)*iter;
-		if (b->jump == UT64_MAX) {
+		if (rz_analysis_block_jump(b) == UT64_MAX) {
 			ut64 retaddr = rz_analysis_block_get_op_addr(b, b->ninstr - 1);
 			if (retaddr == UT64_MAX) {
 				break;
@@ -372,14 +372,14 @@ static ut64 __opaddr(RzAnalysisBlock *b, ut64 addr) {
 static void bb_info_print(RzCore *core, RzAnalysisFunction *fcn, RzAnalysisBlock *bb,
 	ut64 addr, RzOutputMode mode, PJ *pj, RzTable *t) {
 	RzDebugTracepoint *tp = NULL;
-	int outputs = (bb->jump != UT64_MAX) + (bb->fail != UT64_MAX);
+	int outputs = (rz_analysis_block_jump(bb) != UT64_MAX) + (rz_analysis_block_fail(bb) != UT64_MAX);
 	int inputs = 0;
 
 	void **iter;
 	RzAnalysisBlock *bb2;
 	rz_pvector_foreach (fcn->bbs, iter) {
 		bb2 = (RzAnalysisBlock *)*iter;
-		inputs += (bb2->jump == bb->addr) + (bb2->fail == bb->addr);
+		inputs += (rz_analysis_block_jump(bb2) == bb->addr) + (rz_analysis_block_fail(bb2) == bb->addr);
 	}
 	if (bb->switch_op) {
 		RzList *unique_cases = rz_list_uniq(bb->switch_op->cases, casecmp, NULL);
@@ -395,11 +395,11 @@ static void bb_info_print(RzCore *core, RzAnalysisFunction *fcn, RzAnalysisBlock
 			bb->addr, bb->addr + bb->size,
 			tp ? tp->times : 0, tp ? tp->count : 0,
 			bb->size);
-		if (bb->jump != UT64_MAX) {
-			rz_cons_printf(" j 0x%08" PFMT64x, bb->jump);
+		if (rz_analysis_block_jump(bb) != UT64_MAX) {
+			rz_cons_printf(" j 0x%08" PFMT64x, rz_analysis_block_jump(bb));
 		}
-		if (bb->fail != UT64_MAX) {
-			rz_cons_printf(" f 0x%08" PFMT64x, bb->fail);
+		if (rz_analysis_block_fail(bb) != UT64_MAX) {
+			rz_cons_printf(" f 0x%08" PFMT64x, rz_analysis_block_fail(bb));
 		}
 		if (bb->switch_op) {
 			RzAnalysisCaseOp *cop;
@@ -414,11 +414,11 @@ static void bb_info_print(RzCore *core, RzAnalysisFunction *fcn, RzAnalysisBlock
 		break;
 	case RZ_OUTPUT_MODE_JSON: {
 		pj_o(pj);
-		if (bb->jump != UT64_MAX) {
-			pj_kn(pj, "jump", bb->jump);
+		if (rz_analysis_block_jump(bb) != UT64_MAX) {
+			pj_kn(pj, "jump", rz_analysis_block_jump(bb));
 		}
-		if (bb->fail != UT64_MAX) {
-			pj_kn(pj, "fail", bb->fail);
+		if (rz_analysis_block_fail(bb) != UT64_MAX) {
+			pj_kn(pj, "fail", rz_analysis_block_fail(bb));
 		}
 		if (bb->switch_op) {
 			pj_k(pj, "switch_op");
@@ -454,17 +454,17 @@ static void bb_info_print(RzCore *core, RzAnalysisFunction *fcn, RzAnalysisBlock
 		break;
 	}
 	case RZ_OUTPUT_MODE_TABLE:
-		rz_table_add_rowf(t, "xdxx", bb->addr, bb->size, bb->jump, bb->fail);
+		rz_table_add_rowf(t, "xdxx", bb->addr, bb->size, rz_analysis_block_jump(bb), rz_analysis_block_fail(bb));
 		break;
 	case RZ_OUTPUT_MODE_QUIET:
 		rz_cons_printf("0x%08" PFMT64x "\n", bb->addr);
 		break;
 	case RZ_OUTPUT_MODE_LONG: {
-		if (bb->jump != UT64_MAX) {
-			rz_cons_printf("jump: 0x%08" PFMT64x "\n", bb->jump);
+		if (rz_analysis_block_jump(bb) != UT64_MAX) {
+			rz_cons_printf("jump: 0x%08" PFMT64x "\n", rz_analysis_block_jump(bb));
 		}
-		if (bb->fail != UT64_MAX) {
-			rz_cons_printf("fail: 0x%08" PFMT64x "\n", bb->fail);
+		if (rz_analysis_block_fail(bb) != UT64_MAX) {
+			rz_cons_printf("fail: 0x%08" PFMT64x "\n", rz_analysis_block_fail(bb));
 		}
 		rz_cons_printf("opaddr: 0x%08" PFMT64x "\n", opaddr);
 		rz_cons_printf("addr: 0x%08" PFMT64x "\nsize: %" PFMT64d "\ninputs: %d\noutputs: %d\nninstr: %d\ntraced: %s\n",
@@ -1648,12 +1648,12 @@ static bool analysis_path_exists(RzCore *core, ut64 from, ut64 to, RzList /*<RzA
 
 	// try to find the target in the current function
 	if (rz_analysis_block_contains(bb, to) ||
-		((!ht_up_find(avoid, bb->jump, NULL) &&
-			!ht_up_find(state, bb->jump, NULL) &&
-			analysis_path_exists(core, bb->jump, to, bbs, depth - 1, state, avoid))) ||
-		((!ht_up_find(avoid, bb->fail, NULL) &&
-			!ht_up_find(state, bb->fail, NULL) &&
-			analysis_path_exists(core, bb->fail, to, bbs, depth - 1, state, avoid)))) {
+		((!ht_up_find(avoid, rz_analysis_block_jump(bb), NULL) &&
+			!ht_up_find(state, rz_analysis_block_jump(bb), NULL) &&
+			analysis_path_exists(core, rz_analysis_block_jump(bb), to, bbs, depth - 1, state, avoid))) ||
+		((!ht_up_find(avoid, rz_analysis_block_fail(bb), NULL) &&
+			!ht_up_find(state, rz_analysis_block_fail(bb), NULL) &&
+			analysis_path_exists(core, rz_analysis_block_fail(bb), to, bbs, depth - 1, state, avoid)))) {
 		rz_list_prepend(bbs, bb);
 		return true;
 	}
@@ -3120,8 +3120,8 @@ static void analPaths(RzCoreAnalPaths *p, PJ *pj) {
 		}
 	} else {
 		RzAnalysisBlock *c = cur;
-		ut64 j = cur->jump;
-		ut64 f = cur->fail;
+		ut64 j = rz_analysis_block_jump(cur);
+		ut64 f = rz_analysis_block_fail(cur);
 		analPathFollow(p, j, pj);
 		cur = c;
 		analPathFollow(p, f, pj);

--- a/librz/core/cesil.c
+++ b/librz/core/cesil.c
@@ -1174,9 +1174,11 @@ static inline bool get_next_i(IterCtx *ctx, size_t *next_i) {
 					rz_list_push(ctx->switch_path, bb->switch_op->cases->head);
 				}
 			} else {
-				bbit = rz_list_find(ctx->bbl, &bb->jump, (RzListComparator)find_bb, NULL);
-				if (!bbit && bb->fail != UT64_MAX) {
-					bbit = rz_list_find(ctx->bbl, &bb->fail, (RzListComparator)find_bb, NULL);
+				ut64 jump = rz_analysis_block_jump(bb);
+				ut64 fail = rz_analysis_block_fail(bb);
+				bbit = rz_list_find(ctx->bbl, &jump, (RzListComparator)find_bb, NULL);
+				if (!bbit && fail != UT64_MAX) {
+					bbit = rz_list_find(ctx->bbl, &fail, (RzListComparator)find_bb, NULL);
 				}
 			}
 			if (!bbit) {
@@ -1185,8 +1187,9 @@ static inline bool get_next_i(IterCtx *ctx, size_t *next_i) {
 				do {
 					rz_reg_arena_pop(rreg);
 					prev_bb = rz_list_pop(ctx->path);
-					if (prev_bb->fail != UT64_MAX) {
-						bbit = rz_list_find(ctx->bbl, &prev_bb->fail, (RzListComparator)find_bb, NULL);
+					if (rz_analysis_block_fail(prev_bb) != UT64_MAX) {
+						ut64 fail = rz_analysis_block_fail(prev_bb);
+						bbit = rz_list_find(ctx->bbl, &fail, (RzListComparator)find_bb, NULL);
 						if (bbit) {
 							rz_reg_arena_push(rreg);
 							rz_list_push(ctx->path, prev_bb);

--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -202,11 +202,11 @@ static void __rebase_everything(RzCore *core, RzPVector /*<RzBinSection *>*/ *ol
 					continue;
 				}
 				rz_analysis_block_relocate(bb, bb->addr + diff, bb->size);
-				if (bb->jump != UT64_MAX) {
-					bb->jump += diff;
+				if (rz_analysis_block_jump(bb) != UT64_MAX) {
+					rz_analysis_block_set_jump(bb, rz_analysis_block_jump(bb) + diff);
 				}
-				if (bb->fail != UT64_MAX) {
-					bb->fail += diff;
+				if (rz_analysis_block_fail(bb) != UT64_MAX) {
+					rz_analysis_block_set_fail(bb, rz_analysis_block_fail(bb) + diff);
 				}
 			}
 			break;

--- a/librz/core/cgraph.c
+++ b/librz/core/cgraph.c
@@ -302,15 +302,15 @@ static void core_graph_fn_bbs(RzCore *core, RzAnalysisFunction *fcn, RzGraph /*<
 			continue;
 		}
 
-		if (bbi->jump != UT64_MAX) {
-			RzGraphNode *node = graph_add_cached(core, cache, NULL, bbi->jump, graph, body_fn);
+		if (rz_analysis_block_jump(bbi) != UT64_MAX) {
+			RzGraphNode *node = graph_add_cached(core, cache, NULL, rz_analysis_block_jump(bbi), graph, body_fn);
 			if (node) {
 				rz_graph_add_edge(graph, bb_node, node, NULL);
 			}
 		}
 
-		if (bbi->fail != UT64_MAX) {
-			RzGraphNode *node = graph_add_cached(core, cache, NULL, bbi->fail, graph, body_fn);
+		if (rz_analysis_block_fail(bbi) != UT64_MAX) {
+			RzGraphNode *node = graph_add_cached(core, cache, NULL, rz_analysis_block_fail(bbi), graph, body_fn);
 			if (node) {
 				rz_graph_add_edge(graph, bb_node, node, NULL);
 			}

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -5569,11 +5569,11 @@ RZ_IPI RzCmdStatus rz_analysis_basic_block_list_handler(RzCore *core, int argc, 
 			pj_kb(pj, "traced", block->traced);
 			pj_kn(pj, "ninstr", block->ninstr);
 			pj_kn(pj, "size", block->size);
-			if (block->jump != UT64_MAX) {
-				pj_kn(pj, "jump", block->jump);
+			if (rz_analysis_block_jump(block) != UT64_MAX) {
+				pj_kn(pj, "jump", rz_analysis_block_jump(block));
 			}
-			if (block->fail != UT64_MAX) {
-				pj_kn(pj, "fail", block->fail);
+			if (rz_analysis_block_fail(block) != UT64_MAX) {
+				pj_kn(pj, "fail", rz_analysis_block_fail(block));
 			}
 			if (xrefs) {
 				pj_ka(pj, "xrefs");
@@ -5603,8 +5603,8 @@ RZ_IPI RzCmdStatus rz_analysis_basic_block_list_handler(RzCore *core, int argc, 
 			pj_end(pj);
 			break;
 		case RZ_OUTPUT_MODE_TABLE: {
-			char *jump = block->jump != UT64_MAX ? rz_str_newf("0x%08" PFMT64x, block->jump) : rz_str_dup("");
-			char *fail = block->fail != UT64_MAX ? rz_str_newf("0x%08" PFMT64x, block->fail) : rz_str_dup("");
+			char *jump = rz_analysis_block_jump(block) != UT64_MAX ? rz_str_newf("0x%08" PFMT64x, rz_analysis_block_jump(block)) : rz_str_dup("");
+			char *fail = rz_analysis_block_fail(block) != UT64_MAX ? rz_str_newf("0x%08" PFMT64x, rz_analysis_block_fail(block)) : rz_str_dup("");
 			char *call = ut64join(calls);
 			char *xref = ut64join(calls);
 			char *fcns = fcnjoin(block->fcns);
@@ -5629,11 +5629,11 @@ RZ_IPI RzCmdStatus rz_analysis_basic_block_list_handler(RzCore *core, int argc, 
 			break;
 		case RZ_OUTPUT_MODE_STANDARD:
 			rz_cons_printf("0x%08" PFMT64x, block->addr);
-			if (block->jump != UT64_MAX) {
-				rz_cons_printf(" .j 0x%08" PFMT64x, block->jump);
+			if (rz_analysis_block_jump(block) != UT64_MAX) {
+				rz_cons_printf(" .j 0x%08" PFMT64x, rz_analysis_block_jump(block));
 			}
-			if (block->fail != UT64_MAX) {
-				rz_cons_printf(" .f 0x%08" PFMT64x, block->fail);
+			if (rz_analysis_block_fail(block) != UT64_MAX) {
+				rz_cons_printf(" .f 0x%08" PFMT64x, rz_analysis_block_fail(block));
 			}
 			if (xrefs) {
 				RzListIter *iter2;

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -1334,9 +1334,10 @@ static void pr_bb(RzCore *core, RzAnalysisFunction *fcn, RzAnalysisBlock *b, boo
 		: rz_core_cmdf(core, "pI %" PFMT64u " @ 0x%" PFMT64x, b->size, b->addr);
 	rz_config_set_b(core->config, "asm.bb.middle", orig_bb_middle);
 
-	if (b->jump != UT64_MAX) {
-		if (b->jump > b->addr) {
-			RzAnalysisBlock *jumpbb = rz_analysis_get_block_at(b->analysis, b->jump);
+	ut64 jump = rz_analysis_block_jump(b);
+	if (jump != UT64_MAX) {
+		if (jump > b->addr) {
+			RzAnalysisBlock *jumpbb = rz_analysis_get_block_at(core->analysis, jump);
 			if (jumpbb && rz_list_contains(jumpbb->fcns, fcn)) {
 				ut8 *last_disasm_reg = rz_analysis_get_last_disasm_reg(core->analysis);
 				if (emu && last_disasm_reg && !jumpbb->parent_reg_arena) {
@@ -1345,12 +1346,13 @@ static void pr_bb(RzCore *core, RzAnalysisFunction *fcn, RzAnalysisBlock *b, boo
 			}
 		}
 		if (p_type == 'D' && show_flags) {
-			rz_cons_printf("| ----------- true: 0x%08" PFMT64x, b->jump);
+			rz_cons_printf("| ----------- true: 0x%08" PFMT64x, jump);
 		}
 	}
-	if (b->fail != UT64_MAX) {
-		if (b->fail > b->addr) {
-			RzAnalysisBlock *failbb = rz_analysis_get_block_at(b->analysis, b->fail);
+	ut64 fail = rz_analysis_block_fail(b);
+	if (fail != UT64_MAX) {
+		if (fail > b->addr) {
+			RzAnalysisBlock *failbb = rz_analysis_get_block_at(core->analysis, fail);
 			if (failbb && rz_list_contains(failbb->fcns, fcn)) {
 				ut8 *last_disasm_reg = rz_analysis_get_last_disasm_reg(core->analysis);
 				if (emu && last_disasm_reg && !failbb->parent_reg_arena) {
@@ -1359,7 +1361,7 @@ static void pr_bb(RzCore *core, RzAnalysisFunction *fcn, RzAnalysisBlock *b, boo
 			}
 		}
 		if (p_type == 'D' && show_flags) {
-			rz_cons_printf("  false: 0x%08" PFMT64x, b->fail);
+			rz_cons_printf("  false: 0x%08" PFMT64x, fail);
 		}
 	}
 	if (p_type == 'D' && show_flags) {

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -543,7 +543,7 @@ static ut64 bbJump(RzAnalysisFunction *fcn, ut64 addr) {
 	rz_pvector_foreach (fcn->bbs, vit) {
 		bb = (RzAnalysisBlock *)*vit;
 		if (RZ_BETWEEN(bb->addr, addr, bb->addr + bb->size - 1)) {
-			return bb->jump;
+			return rz_analysis_block_jump(bb);
 		}
 	}
 	return UT64_MAX;
@@ -555,7 +555,7 @@ static ut64 bbFail(RzAnalysisFunction *fcn, ut64 addr) {
 	rz_pvector_foreach (fcn->bbs, vit) {
 		bb = (RzAnalysisBlock *)*vit;
 		if (RZ_BETWEEN(bb->addr, addr, bb->addr + bb->size - 1)) {
-			return bb->fail;
+			return rz_analysis_block_fail(bb);
 		}
 	}
 	return UT64_MAX;

--- a/librz/core/cprint.c
+++ b/librz/core/cprint.c
@@ -873,7 +873,7 @@ RZ_API RZ_OWN char *rz_core_print_disasm_strings(RZ_NONNULL RzCore *core, RzCore
 				RzAnalysisBlock *bb;
 				rz_pvector_foreach (fcn->bbs, vit) {
 					bb = (RzAnalysisBlock *)*vit;
-					if (addr == bb->jump) {
+					if (addr == rz_analysis_block_jump(bb)) {
 						if (show_offset) {
 							rz_strbuf_appendf(sb, "%s0x%08" PFMT64x ":\n", use_color ? Color_YELLOW : "", addr);
 						}
@@ -891,15 +891,15 @@ RZ_API RZ_OWN char *rz_core_print_disasm_strings(RZ_NONNULL RzCore *core, RzCore
 						if (addr >= bb->addr && addr < bb->addr + bb->size) {
 							const char *op;
 							if (use_color) {
-								op = (bb->fail == UT64_MAX) ? Color_GREEN "jmp" : Color_GREEN "cjmp";
+								op = (rz_analysis_block_fail(bb) == UT64_MAX) ? Color_GREEN "jmp" : Color_GREEN "cjmp";
 							} else {
-								op = (bb->fail == UT64_MAX) ? "jmp" : "cjmp";
+								op = (rz_analysis_block_fail(bb) == UT64_MAX) ? "jmp" : "cjmp";
 							}
 							if (show_offset) {
 								rz_strbuf_appendf(sb, "%s0x%08" PFMT64x " " Color_RESET, use_color ? pal->offset : "", addr);
 							}
 							rz_strbuf_appendf(sb, "%s 0x%08" PFMT64x "%s\n",
-								op, bb->jump, use_color ? Color_RESET : "");
+								op, rz_analysis_block_jump(bb), use_color ? Color_RESET : "");
 							break;
 						}
 					}

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -891,7 +891,7 @@ struct rz_analysis_bb_t {
 
 	ut64 addr;
 	ut64 size;
-	RzVector /*<RzAnalysisSuccAddr>*/ _succ_addrs;
+	RzVector /*<RzAnalysisSuccAddr>*/ succ_addrs;
 	bool traced;
 	ut32 colorize;
 	RzAnalysisCond *cond;
@@ -2164,6 +2164,8 @@ typedef struct {
 
 RZ_API void rz_serialize_analysis_case_op_save(RZ_NONNULL PJ *j, RZ_NONNULL RzAnalysisCaseOp *op);
 RZ_API void rz_serialize_analysis_switch_op_save(RZ_NONNULL PJ *j, RZ_NONNULL RzAnalysisSwitchOp *op);
+RZ_API void rz_serialize_analysis_succ_addr_save(RZ_NONNULL PJ *j, const RZ_NONNULL RzAnalysisSuccAddr *succ_addr);
+RZ_API bool rz_serialize_analysis_succ_addr_load(RZ_NONNULL const RzJson *json, RZ_OUT RZ_NONNULL RzAnalysisSuccAddr *succ_addr);
 RZ_API RzAnalysisSwitchOp *rz_serialize_analysis_switch_op_load(RZ_NONNULL const RzJson *json);
 
 RZ_API void rz_serialize_analysis_blocks_save(RZ_NONNULL Sdb *db, RZ_NONNULL RzAnalysis *analysis);

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -877,14 +877,21 @@ typedef struct rz_analysis_cond_t {
 	RzAnalysisValue *arg[2]; // filled by CMP opcode
 } RzAnalysisCond;
 
+/**
+ * \brief A successor address of a basic block.
+ */
+typedef struct rz_analysis_succ_addr_t {
+	ut64 addr; ///< The successor address.
+	RzTypeCond cond; ///< The condition under which the control flow changes to this address.
+} RzAnalysisSuccAddr;
+
 struct rz_analysis_bb_t {
 	RBNode _rb; // private, node in the RBTree
 	ut64 _max_end; // private, augmented value for RBTree
 
 	ut64 addr;
 	ut64 size;
-	ut64 jump;
-	ut64 fail;
+	RzVector /*<RzAnalysisSuccAddr>*/ _succ_addrs;
 	bool traced;
 	ut32 colorize;
 	RzAnalysisCond *cond;
@@ -1188,6 +1195,14 @@ RZ_API void rz_analysis_block_set_size(RzAnalysisBlock *block, ut64 size);
 // Set the address and size of the block.
 // This can fail (and return false) if there is already another block at the new address
 RZ_API bool rz_analysis_block_relocate(RzAnalysisBlock *block, ut64 addr, ut64 size);
+
+RZ_DEPRECATE RZ_API ut64 rz_analysis_block_fail(const RZ_NONNULL RzAnalysisBlock *block);
+RZ_DEPRECATE RZ_API ut64 rz_analysis_block_jump(const RZ_NONNULL RzAnalysisBlock *block);
+RZ_DEPRECATE RZ_API void rz_analysis_block_set_jump(RZ_BORROW RZ_NONNULL RzAnalysisBlock *block, ut64 addr);
+RZ_DEPRECATE RZ_API void rz_analysis_block_set_fail(RZ_BORROW RZ_NONNULL RzAnalysisBlock *block, ut64 addr);
+RZ_API void rz_analysis_block_add_succ(RZ_BORROW RZ_NONNULL RzAnalysisBlock *block, ut64 addr, RzTypeCond cond);
+RZ_API const RzVector /*<RzAnalysisSuccAddr>*/ *rz_analysis_block_succ(const RZ_NONNULL RzAnalysisBlock *block);
+RZ_API RZ_BORROW RzVector /*<RzAnalysisSuccAddr>*/ *rz_analysis_block_succ_mut(RZ_NONNULL RzAnalysisBlock *block);
 
 RZ_API RzAnalysisBlock *rz_analysis_get_block_at(RzAnalysis *analysis, ut64 addr);
 RZ_API bool rz_analysis_blocks_foreach_in(RzAnalysis *analysis, ut64 addr, RzAnalysisBlockCb cb, void *user);

--- a/librz/include/rz_type.h
+++ b/librz/include/rz_type.h
@@ -210,11 +210,16 @@ typedef enum {
 	RZ_TYPE_COND_VC, ///< No overflow                Not unordered
 	RZ_TYPE_COND_HI, ///< Unsigned higher            Greater than, or unordered
 	RZ_TYPE_COND_LS, ///< Unsigned lower or same     Less than or equal
+	RZ_TYPE_COND_EXCEPTION, ///< Condition is that an exception occurred.
+	RZ_TYPE_COND_SUCC, ///< If some previous condition succeeded.
+	RZ_TYPE_COND_FAIL, ///< If some previous condition failed.
+	RZ_TYPE_COND_RUNTIME_VAL, ///< If some previous value is only known during runtime (statically unknown).
+
+	// Architecture specific conditions
 	RZ_TYPE_COND_HEX_SCL_TRUE, // Hexagon only: Scalar instruction if(Pu)
 	RZ_TYPE_COND_HEX_SCL_FALSE, // Hexagon only: Scalar instruction if(!Pu)
 	RZ_TYPE_COND_HEX_VEC_TRUE, // Hexagon only: Vector instruction if(Pu)
 	RZ_TYPE_COND_HEX_VEC_FALSE, // Hexagon only: Vector instruction if(!Pu)
-	RZ_TYPE_COND_EXCEPTION, // when the jump is taken only during an exception
 } RzTypeCond;
 
 /**

--- a/librz/main/rz-diff.c
+++ b/librz/main/rz-diff.c
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2021 deroad <wargiof@libero.it>
 // SPDX-License-Identifier: LGPL-3.0-only
 
+#include "rz_analysis.h"
 #include <rz_core.h>
 #include <rz_io.h>
 #include <rz_bin.h>
@@ -1653,24 +1654,24 @@ static void graphviz_dot_edges(RzCore *core, RzAnalysisFunction *fcn) {
 
 	rz_pvector_foreach (fcn->bbs, iter) {
 		bbi = (RzAnalysisBlock *)*iter;
-		if (bbi->jump != UT64_MAX) {
+		if (rz_analysis_block_jump(bbi) != UT64_MAX) {
 			rz_cons_printf("\t\"0x%08" PFMT64x "\" -> \"0x%08" PFMT64x "\" [color=\"%s\"];\n",
-				bbi->addr, bbi->jump,
-				bbi->fail != UT64_MAX ? PAL_TRUE : PAL_JUMP);
+				bbi->addr, rz_analysis_block_jump(bbi),
+				rz_analysis_block_fail(bbi) != UT64_MAX ? PAL_TRUE : PAL_JUMP);
 			print_color_node(core, bbi);
 		}
-		if (bbi->fail != UT64_MAX) {
+		if (rz_analysis_block_fail(bbi) != UT64_MAX) {
 			rz_cons_printf("\t\"0x%08" PFMT64x "\" -> \"0x%08" PFMT64x "\" [color=\"" PAL_FAIL "\"];\n",
-				bbi->addr, bbi->fail);
+				bbi->addr, rz_analysis_block_fail(bbi));
 			print_color_node(core, bbi);
 		}
 		if (bbi->switch_op) {
 			RzAnalysisCaseOp *caseop;
 			RzListIter *iter2;
 
-			if (bbi->fail != UT64_MAX) {
+			if (rz_analysis_block_fail(bbi) != UT64_MAX) {
 				rz_cons_printf("\t\"0x%08" PFMT64x "\" -> \"0x%08" PFMT64x "\" [color=\"" PAL_FAIL "\"];\n",
-					bbi->addr, bbi->fail);
+					bbi->addr, rz_analysis_block_fail(bbi));
 				print_color_node(core, bbi);
 			}
 			rz_list_foreach (bbi->switch_op->cases, iter2, caseop) {
@@ -1699,11 +1700,11 @@ static void graphviz_dot_graph(RzCore *core_a, RzAnalysisFunction *fcn_a, RzCore
 static void graph_basic_block_json(const char *name, RzAnalysisBlock *bbi, PJ *pj) {
 	pj_ko(pj, name); // "<name>": { -- object begin
 	pj_kn(pj, "address", bbi->addr);
-	if (bbi->jump != UT64_MAX) {
-		pj_kn(pj, "jump", bbi->jump);
+	if (rz_analysis_block_jump(bbi) != UT64_MAX) {
+		pj_kn(pj, "jump", rz_analysis_block_jump(bbi));
 	}
-	if (bbi->fail != UT64_MAX) {
-		pj_kn(pj, "fail", bbi->fail);
+	if (rz_analysis_block_fail(bbi) != UT64_MAX) {
+		pj_kn(pj, "fail", rz_analysis_block_fail(bbi));
 	}
 	if (!bbi->switch_op) {
 		pj_end(pj); // } -- object end

--- a/librz/type/helpers.c
+++ b/librz/type/helpers.c
@@ -505,6 +505,9 @@ RZ_API RZ_BORROW const char *rz_type_cond_tostring(RzTypeCond cc) {
 	case RZ_TYPE_COND_HEX_VEC_TRUE: return "vec-t";
 	case RZ_TYPE_COND_HEX_VEC_FALSE: return "vec-f";
 	case RZ_TYPE_COND_EXCEPTION: return "excptn";
+	case RZ_TYPE_COND_SUCC: return "succ";
+	case RZ_TYPE_COND_FAIL: return "fail";
+	case RZ_TYPE_COND_RUNTIME_VAL: return "runtime";
 	}
 	return "??";
 }

--- a/test/integration/test_analysis_fcn.c
+++ b/test/integration/test_analysis_fcn.c
@@ -33,9 +33,9 @@ static bool test_analysis_fcn_large() {
 	RzAnalysisBlock *block = rz_analysis_fcn_bbget_at(core->analysis, f, 0);
 	while (block) {
 		end = RZ_MAX(end, block->addr + block->size);
-		if (block->jump != UT64_MAX) {
-			mu_assert_eq(block->jump, block->addr + block->size, "blocks aren't chained");
-			block = rz_analysis_fcn_bbget_at(core->analysis, f, block->jump);
+		if (rz_analysis_block_jump(block) != UT64_MAX) {
+			mu_assert_eq(rz_analysis_block_jump(block), block->addr + block->size, "blocks aren't chained");
+			block = rz_analysis_fcn_bbget_at(core->analysis, f, rz_analysis_block_jump(block));
 		} else {
 			block = NULL;
 		}

--- a/test/unit/test_analysis_block.c
+++ b/test/unit/test_analysis_block.c
@@ -227,8 +227,8 @@ bool test_rz_analysis_block_split() {
 	RzAnalysisBlock *block = rz_analysis_create_block(analysis, 0x1337, 42);
 	assert_block_invariants(analysis);
 	mu_assert_eq(blocks_count(analysis), 1, "count after create");
-	block->jump = 0xdeadbeef;
-	block->fail = 0xc0ffee;
+	rz_analysis_block_set_jump(block, 0xdeadbeef);
+	rz_analysis_block_set_fail(block, 0xc0ffee);
 	block->ninstr = 5;
 	rz_analysis_block_set_op_offset(block, 0, 0);
 	rz_analysis_block_set_op_offset(block, 1, 1);
@@ -259,10 +259,10 @@ bool test_rz_analysis_block_split() {
 	mu_assert_eq(second->addr, 0x1339, "first addr after split");
 	mu_assert_eq(second->size, 40, "first size after split");
 
-	mu_assert_eq(block->jump, second->addr, "first jump");
-	mu_assert_eq(block->fail, UT64_MAX, "first fail");
-	mu_assert_eq(second->jump, 0xdeadbeef, "second jump");
-	mu_assert_eq(second->fail, 0xc0ffee, "second fail");
+	mu_assert_eq(rz_analysis_block_jump(block), second->addr, "first jump");
+	mu_assert_eq(rz_analysis_block_fail(block), UT64_MAX, "first fail");
+	mu_assert_eq(rz_analysis_block_jump(second), 0xdeadbeef, "second jump");
+	mu_assert_eq(rz_analysis_block_fail(second), 0xc0ffee, "second fail");
 
 	mu_assert_eq(block->ninstr, 2, "first ninstr after split");
 	mu_assert_eq(rz_analysis_block_get_op_offset(block, 0), 0, "first op_pos[0]");
@@ -336,8 +336,8 @@ bool test_rz_analysis_block_merge() {
 	RzAnalysisBlock *second = rz_analysis_create_block(analysis, 0x1337 + 42, 624);
 	assert_block_invariants(analysis);
 	mu_assert_eq(blocks_count(analysis), 2, "count after create");
-	second->jump = 0xdeadbeef;
-	second->fail = 0xc0ffee;
+	rz_analysis_block_set_jump(second, 0xdeadbeef);
+	rz_analysis_block_set_fail(second, 0xc0ffee);
 
 	first->ninstr = 3;
 	rz_analysis_block_set_op_offset(first, 0, 0);
@@ -356,8 +356,8 @@ bool test_rz_analysis_block_merge() {
 	mu_assert_eq(blocks_count(analysis), 1, "count after merge");
 	mu_assert_eq(first->addr, 0x1337, "addr after merge");
 	mu_assert_eq(first->size, 666, "size after merge");
-	mu_assert_eq(first->jump, 0xdeadbeef, "jump after merge");
-	mu_assert_eq(first->fail, 0xc0ffee, "fail after merge");
+	mu_assert_eq(rz_analysis_block_jump(first), 0xdeadbeef, "jump after merge");
+	mu_assert_eq(rz_analysis_block_fail(first), 0xc0ffee, "fail after merge");
 
 	mu_assert_eq(first->ninstr, 3 + 4, "ninstr after merge");
 	mu_assert_eq(rz_analysis_block_get_op_offset(first, 0), 0, "offset 0 after merge");
@@ -675,11 +675,11 @@ bool test_rz_analysis_block_successors() {
 	blocks[9] = rz_analysis_create_block(analysis, 0xc0, 0x10);
 	assert_block_invariants(analysis);
 
-	blocks[0]->jump = 0x30;
-	blocks[0]->fail = 0x50;
-	blocks[1]->jump = 0x10;
-	blocks[1]->fail = 0x50;
-	blocks[2]->jump = 0x10;
+	rz_analysis_block_set_jump(blocks[0], 0x30);
+	rz_analysis_block_set_fail(blocks[0], 0x50);
+	rz_analysis_block_set_jump(blocks[1], 0x10);
+	rz_analysis_block_set_fail(blocks[1], 0x50);
+	rz_analysis_block_set_jump(blocks[2], 0x10);
 
 	RzAnalysisSwitchOp *sop = rz_analysis_switch_op_new(0x55, 0x13, 0x15, 0x42);
 	mu_assert_eq(sop->addr, 0x55, "addr");
@@ -748,20 +748,20 @@ bool test_rz_analysis_block_automerge() {
 		RzAnalysisBlock *a = rz_analysis_create_block(analysis, 0x100, 0x10);
 
 		RzAnalysisBlock *b = rz_analysis_create_block(analysis, 0x110, 0x10);
-		a->jump = b->addr;
+		rz_analysis_block_set_jump(a, b->addr);
 
 		RzAnalysisBlock *c = rz_analysis_create_block(analysis, 0x120, 0x10);
-		b->jump = c->addr;
-		c->fail = b->addr;
+		rz_analysis_block_set_jump(b, c->addr);
+		rz_analysis_block_set_fail(c, b->addr);
 
 		RzAnalysisBlock *d = rz_analysis_create_block(analysis, 0x130, 0x10);
-		c->jump = d->addr;
+		rz_analysis_block_set_jump(c, d->addr);
 
 		RzAnalysisBlock *e = rz_analysis_create_block(analysis, 0x140, 0x10);
-		d->jump = e->addr;
+		rz_analysis_block_set_jump(d, e->addr);
 
 		RzAnalysisBlock *f = rz_analysis_create_block(analysis, 0x150, 0x10);
-		e->jump = f->addr;
+		rz_analysis_block_set_jump(e, f->addr);
 
 		RzAnalysisFunction *fa = rz_analysis_create_function(analysis, "fcn", 0x100, RZ_ANALYSIS_FCN_TYPE_FCN);
 		rz_analysis_function_add_block(fa, a);
@@ -825,8 +825,8 @@ bool test_rz_analysis_block_chop_noreturn(void) {
 	RzAnalysisBlock *a = rz_analysis_create_block(analysis, 0x100, 0x10);
 	RzAnalysisBlock *b = rz_analysis_create_block(analysis, 0x110, 0x10);
 	RzAnalysisBlock *c = rz_analysis_create_block(analysis, 0x120, 0x10);
-	a->jump = c->addr;
-	b->jump = c->addr;
+	rz_analysis_block_set_jump(a, c->addr);
+	rz_analysis_block_set_jump(b, c->addr);
 
 	RzAnalysisFunction *fa = rz_analysis_create_function(analysis, "fcn", 0x100, RZ_ANALYSIS_FCN_TYPE_FCN);
 	rz_analysis_function_add_block(fa, a);

--- a/test/unit/test_serialize_analysis.c
+++ b/test/unit/test_serialize_analysis.c
@@ -80,8 +80,8 @@ bool test_analysis_block_save() {
 	rz_analysis_create_block(analysis, 1337, 42);
 
 	RzAnalysisBlock *block = rz_analysis_create_block(analysis, 1234, 32);
-	block->jump = 0x1313;
-	block->fail = 0x4213;
+	rz_analysis_block_set_jump(block, 0x1313);
+	rz_analysis_block_set_fail(block, 0x4213);
 	block->traced = true;
 	block->colorize = 0xff0000;
 	block->switch_op = rz_analysis_switch_op_new(49232, 3, 5, 7);
@@ -132,8 +132,8 @@ bool test_analysis_block_load() {
 
 	mu_assert_notnull(a, "block a");
 	mu_assert_eq(a->size, 42, "size");
-	mu_assert_eq(a->jump, UT64_MAX, "jump");
-	mu_assert_eq(a->fail, UT64_MAX, "fail");
+	mu_assert_eq(rz_analysis_block_jump(a), UT64_MAX, "jump");
+	mu_assert_eq(rz_analysis_block_fail(a), UT64_MAX, "fail");
 	mu_assert("traced", !a->traced);
 	mu_assert_eq(a->colorize, 0, "colorize");
 	mu_assert_null(a->switch_op, "switch op");
@@ -144,8 +144,8 @@ bool test_analysis_block_load() {
 
 	mu_assert_notnull(b, "block b");
 	mu_assert_eq(b->size, 32, "size");
-	mu_assert_eq(b->jump, 0x1313, "jump");
-	mu_assert_eq(b->fail, 0x4213, "fail");
+	mu_assert_eq(rz_analysis_block_jump(b), 0x1313, "jump");
+	mu_assert_eq(rz_analysis_block_fail(b), 0x4213, "fail");
 	mu_assert("traced", b->traced);
 	mu_assert_eq(b->colorize, 0xff0000, "colorize");
 	mu_assert_notnull(b->switch_op, "switch op");

--- a/test/unit/test_serialize_analysis.c
+++ b/test/unit/test_serialize_analysis.c
@@ -70,7 +70,7 @@ bool test_analysis_switch_op_load() {
 Sdb *blocks_ref_db() {
 	Sdb *db = sdb_new0();
 	sdb_set(db, "0x539", "{\"size\":42}");
-	sdb_set(db, "0x4d2", "{\"size\":32,\"jump\":4883,\"fail\":16915,\"traced\":true,\"colorize\":16711680,\"switch_op\":{\"addr\":49232,\"min\":3,\"max\":5,\"def\":7,\"cases\":[]},\"ninstr\":3,\"op_pos\":[4,7],\"sp_delta\":[8,-8,16],\"sp\":256,\"cmpval\":262254561,\"cmpreg\":\"rax\"}");
+	sdb_set(db, "0x4d2", "{\"size\":32,\"succ_addrs\":[{\"addr\":4883,\"cond\":17},{\"addr\":16915,\"cond\":18}],\"traced\":true,\"colorize\":16711680,\"switch_op\":{\"addr\":49232,\"min\":3,\"max\":5,\"def\":7,\"cases\":[]},\"ninstr\":3,\"op_pos\":[4,7],\"sp_delta\":[8,-8,16],\"sp\":256,\"cmpval\":262254561,\"cmpreg\":\"rax\"}");
 	return db;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Removes the `jump` and `fail` members of basic blocks, and replaces them with a vector of successors.
The successors now can have several different conditions under which they are taken.

This should finally allow to have basic blocks with more than two outgoing edges.
Like indirect jumps (or calls in case of procedure CFG).

One commit implements the change, one is the renaming and API usage.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All green

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
