### PR TITLE
ROP search - fix invalid 32-bit stack change output

### DIFF
--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -651,7 +651,9 @@ static void gadget_info_add_dependency(const RzCore *core, RzGadgetInfo *gadget_
 		}
 		reg_info_dup->new_val = rz_bv_to_ut64(new_val);
 		if (rz_reg_is_role(rreg, reg_info->name, RZ_REG_NAME_SP)) {
-			gadget_info->stack_change += rz_bv_to_ut64(new_val) - rz_bv_to_ut64(init_val);
+			RzBitVector *temp = rz_bv_sub(new_val, init_val, NULL);
+			gadget_info->stack_change += rz_bv_to_ut64(temp);
+			rz_bv_free(temp);
 		}
 		rz_bv_free(init_val);
 		rz_bv_free(new_val);

--- a/test/db/cmd/cmd_rop
+++ b/test/db/cmd/cmd_rop
@@ -3248,7 +3248,7 @@ Gadget 0x8048342 (size 17 bytes)
 
 Gadget 0x8048345 (size 14 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x08048345  0000             add byte [eax], al | Stack change: 0xffffffff00000008
+  0x08048345  0000             add byte [eax], al | Stack change: 0x8
   0x08048347  e804010000       call 0x8048450     | Modified regs: esp ebp
   0x0804834c  e8cf020000       call 0x8048620     | Dependencies:  eax eax eax esp esp ebp esp esp esp esp
   0x08048351  c9               leave              | 
@@ -3263,7 +3263,7 @@ Gadget 0x8048347 (size 12 bytes)
 
 Gadget 0x8048348 (size 11 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x08048348  0401             add al, 0x01       | Stack change: 0xffffffff00000008
+  0x08048348  0401             add al, 0x01       | Stack change: 0x8
   0x0804834a  0000             add byte [eax], al | Modified regs: eax esp ebp
   0x0804834c  e8cf020000       call 0x8048620     | Dependencies:  eax eax eax eax esp ebp esp esp esp esp
   0x08048351  c9               leave              | 
@@ -3302,7 +3302,7 @@ Gadget 0x804840a (size 11 bytes)
 
 Gadget 0x804840c (size 9 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x0804840c  c07402ffd0       shl byte [edx+eax*1-0x01], 0xd0 | Stack change: 0xffffffff00000010
+  0x0804840c  c07402ffd0       shl byte [edx+eax*1-0x01], 0xd0 | Stack change: 0x10
   0x08048411  58               pop eax                         | Modified regs: eax esp ebx ebp
   0x08048412  5b               pop ebx                         | Dependencies:  eax edx eax edx esp esp esp esp ebp esp esp esp esp
   0x08048413  c9               leave                           | 
@@ -3325,7 +3325,7 @@ Gadget 0x804840f (size 6 bytes)
 
 Gadget 0x8048410 (size 5 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x08048410  d0585b           rcr byte [eax+0x5b], 0x01 | Stack change: 0xffffffff00000008
+  0x08048410  d0585b           rcr byte [eax+0x5b], 0x01 | Stack change: 0x8
   0x08048413  c9               leave                     | Modified regs: esp ebp
   0x08048414  c3               ret                       | Dependencies:  eax eax ebp esp esp esp esp
 
@@ -3367,7 +3367,7 @@ Gadget 0x8048442 (size 13 bytes)
 
 Gadget 0x8048443 (size 12 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x08048443  d275eb           shl byte [ebp-0x15], cl    | Stack change: 0xffffffff00000008
+  0x08048443  d275eb           shl byte [ebp-0x15], cl    | Stack change: 0x8
   0x08048446  c60524a0040801   mov byte [0x804a024], 0x01 | Modified regs: esp ebp
   0x0804844d  c9               leave                      | Dependencies:  ebp ebp ecx ebp esp esp esp esp
   0x0804844e  c3               ret                        | 
@@ -3429,7 +3429,7 @@ Gadget 0x804844c (size 3 bytes)
 
 Gadget 0x804846f (size 19 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x0804846f  e88c7bfbf7       call 0x0             | Stack change: 0xffffffff00000008
+  0x0804846f  e88c7bfbf7       call 0x0             | Stack change: 0x8
   0x08048474  8db600000000     lea esi, dword [esi] | Modified regs: esp esi edi ebp
   0x0804847a  8dbf00000000     lea edi, dword [edi] | Dependencies:  esp esi edi ebp esp esp esp esp
   0x08048480  c9               leave                | 
@@ -3503,7 +3503,7 @@ Gadget 0x8048479 (size 9 bytes)
 
 Gadget 0x804847a (size 8 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x0804847a  8dbf00000000     lea edi, dword [edi] | Stack change: 0xffffffff00000008
+  0x0804847a  8dbf00000000     lea edi, dword [edi] | Stack change: 0x8
   0x08048480  c9               leave                | Modified regs: edi esp ebp
   0x08048481  c3               ret                  | Dependencies:  edi ebp esp esp esp esp
 
@@ -3536,7 +3536,7 @@ Gadget 0x80484b5 (size 19 bytes)
 
 Gadget 0x80484ba (size 14 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x080484ba  c7042400000000   mov dword [esp], 0x00 | Stack change: 0xffffffff00000008
+  0x080484ba  c7042400000000   mov dword [esp], 0x00 | Stack change: 0x8
   0x080484c1  e8eefeffff       call 0x80483b4        | Modified regs: esp ebp
   0x080484c6  c9               leave                 | Dependencies:  esp esp ebp esp esp esp esp
   0x080484c7  c3               ret                   | 
@@ -3577,7 +3577,7 @@ Gadget 0x8048530 (size 16 bytes)
 
 Gadget 0x8048531 (size 15 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x08048531  aa               stosb                      | Stack change: 0xffffffff00000008
+  0x08048531  aa               stosb                      | Stack change: 0x8
   0x08048532  c7042479860408   mov dword [esp], 0x8048679 | Modified regs: edi esp ebp
   0x08048539  e856feffff       call 0x8048394             | Dependencies:  eax edi edi esp esp ebp esp esp esp esp
   0x0804853e  c9               leave                      | 
@@ -3615,7 +3615,7 @@ Gadget 0x8048536 (size 10 bytes)
 
 Gadget 0x8048537 (size 9 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x08048537  0408             add al, 0x08   | Stack change: 0xffffffff00000008
+  0x08048537  0408             add al, 0x08   | Stack change: 0x8
   0x08048539  e856feffff       call 0x8048394 | Modified regs: eax esp ebp
   0x0804853e  c9               leave          | Dependencies:  eax esp ebp esp esp esp esp
   0x0804853f  c3               ret            | 
@@ -3669,7 +3669,7 @@ Gadget 0x80485fa (size 9 bytes)
 
 Gadget 0x80485fc (size 7 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x080485fc  c41c5b           les ebx, fword [ebx+ebx*2] | Stack change: 0xffffffff00000010
+  0x080485fc  c41c5b           les ebx, fword [ebx+ebx*2] | Stack change: 0x10
   0x080485ff  5e               pop esi                    | Modified regs: ebx esi esp edi ebp
   0x08048600  5f               pop edi                    | Dependencies:  ebx esp esp esp esp ebp esp esp esp esp
   0x08048601  c9               leave                      | 
@@ -3728,7 +3728,7 @@ Gadget 0x804860d (size 8 bytes)
 
 Gadget 0x804860e (size 7 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x0804860e  0000             add byte [eax], al | Stack change: 0xffffffffaa6f6fa3
+  0x0804860e  0000             add byte [eax], al | Stack change: 0xaa6f6fa3
   0x08048610  55               push ebp           | Modified regs: esp ebp
   0x08048611  89e5             mov ebp, esp       | Dependencies:  eax eax eax ebp esp esp ebp esp esp esp esp
   0x08048613  c9               leave              | 
@@ -3742,14 +3742,14 @@ Gadget 0x804860f (size 6 bytes)
 
 Gadget 0x8048610 (size 5 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x08048610  55               push ebp     | Stack change: 0xffffffff0000003c
+  0x08048610  55               push ebp     | Stack change: 0x3c
   0x08048611  89e5             mov ebp, esp | Modified regs: esp ebp
   0x08048613  c9               leave        | Dependencies:  ebp esp esp ebp esp esp esp esp
   0x08048614  c3               ret          | 
 
 Gadget 0x8048611 (size 4 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x08048611  89e5             mov ebp, esp | Stack change: 0xffffffff00000044
+  0x08048611  89e5             mov ebp, esp | Stack change: 0x44
   0x08048613  c9               leave        | Modified regs: ebp esp
   0x08048614  c3               ret          | Dependencies:  esp ebp esp esp esp esp
 
@@ -3820,7 +3820,7 @@ Gadget 0x8048641 (size 2 bytes)
 
 Gadget 0x8048655 (size 9 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x08048655  e8c6fdffff       call 0x8048420 | Stack change: 0xffffffff00000010
+  0x08048655  e8c6fdffff       call 0x8048420 | Stack change: 0x10
   0x0804865a  59               pop ecx        | Modified regs: esp ecx ebx ebp
   0x0804865b  5b               pop ebx        | Dependencies:  esp esp esp esp esp ebp esp esp esp esp
   0x0804865c  c9               leave          | 
@@ -3852,7 +3852,7 @@ Gadget 0x8048677 (size 4 bytes)
 
 Gadget 0x804868d (size 9 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x0804868d  00494f           add byte [ecx+0x4f], cl | Stack change: 0xffffffffffffffff
+  0x0804868d  00494f           add byte [ecx+0x4f], cl | Stack change: 0xffffffff
   0x08048690  4c               dec esp                 | Modified regs: esp ecx
   0x08048691  49               dec ecx                 | Dependencies:  ecx ecx ecx esp ecx ebx ebx eax
   0x08048692  204372           and byte [ebx+0x72], al | 
@@ -3860,7 +3860,7 @@ Gadget 0x804868d (size 9 bytes)
 
 Gadget 0x804868f (size 7 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x0804868f  4f               dec edi                 | Stack change: 0xffffffffffffffff
+  0x0804868f  4f               dec edi                 | Stack change: 0xffffffff
   0x08048690  4c               dec esp                 | Modified regs: edi esp ecx
   0x08048691  49               dec ecx                 | Dependencies:  edi esp ecx ebx ebx eax
   0x08048692  204372           and byte [ebx+0x72], al | 
@@ -3868,7 +3868,7 @@ Gadget 0x804868f (size 7 bytes)
 
 Gadget 0x8048690 (size 6 bytes)
 ------------------------------------------------------------------------------------------------------
-  0x08048690  4c               dec esp                 | Stack change: 0xffffffffffffffff
+  0x08048690  4c               dec esp                 | Stack change: 0xffffffff
   0x08048691  49               dec ecx                 | Modified regs: esp ecx
   0x08048692  204372           and byte [ebx+0x72], al | Dependencies:  esp ecx ebx ebx eax
   0x08048695  61               popad                   | 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

[This PR be merged after [PR6108](https://github.com/rizinorg/rizin/pull/6108), i will update the `cmd_rop` test once that gets merged]

As discussed in https://github.com/rizinorg/rizin/pull/6108#discussion_r3087880772

Fixed stack change calculation in `gadget.c` causing invalid 32bit output

the line causing issue:
```c
gadget_info->stack_change += rz_bv_to_ut64(new_val) - rz_bv_to_ut64(init_val);
```

The issue was subtraction AFTER converting bitvector to ut64 : 

in 32bitness, when `new_val` < `init_val`, the delta wraps modulo 2^64
this causes the 32bit delta to wrap into 64bit and show that erroneous output inside 32bit env

So first subtract using bitvector (which use Stack Pointer's length instead of 64bit)
then convert it to `ut64`

---
**NOTE**
Currently the Stack change is shown in `ut64`,  [means negative stack change is shown in 2's complement]
Just want to confirm if this is fine, or if we should show stack change with sign (`st64`): 

like `push` = negative (as stack grows downwards)
and `pop` = positive

---

- strangely this also reduced 15 leaks [down to 40440 from 40455]
...

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The changes done in `cmd_rop` are  sufficient.
you can see that `0xffffffff00000008` is now `0x8`
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
