### PR TITLE
shell: handle unicode in emacs-style hotkeys

### DIFF
--- a/librz/cons/dietline.c
+++ b/librz/cons/dietline.c
@@ -1556,8 +1556,8 @@ RZ_API const char *rz_line_readline_cb(RZ_NONNULL RzLine *line, RzLineReadCallba
 	int prev_buflen = -1;
 	bool enable_yank_pop = false;
 	bool gcomp_is_rev = true;
-	RzEmacsModeModifyOpts em_opts;
-	rz_emacs_mode_modify_opts_reset(&em_opts);
+	RzEmacsModeOpts em_opts;
+	rz_emacs_mode_opts_reset(&em_opts);
 
 	RzCons *cons = rz_cons_singleton();
 
@@ -1837,7 +1837,13 @@ RZ_API const char *rz_line_readline_cb(RZ_NONNULL RzLine *line, RzLineReadCallba
 			buf[0] = rz_cons_readchar_timeout(50);
 			switch ((signed char)buf[0]) {
 			case 127: // alt+bkspace
-				backward_kill_word(line, MINOR_BREAK);
+				if (!em_opts.move_cursor) {
+					rz_emacs_mode_opts_reset(&em_opts);
+				} else {
+					em_opts.op = EMACS_MODIFY_KILL_WORD_BACKWARD;
+					rz_emacs_mode_action(&em_opts, line);
+					rz_emacs_mode_opts_reset(&em_opts);
+				}
 				break;
 			case -1: // escape key, goto vi mode
 				if (line->enable_vi_mode) {
@@ -1861,56 +1867,57 @@ RZ_API const char *rz_line_readline_cb(RZ_NONNULL RzLine *line, RzLineReadCallba
 				break;
 			case 'B':
 			case 'b':
-				for (i = line->buffer.index - 2; i >= 0; i--) {
-					if (is_word_break_char(line->buffer.data[i], MINOR_BREAK) && !is_word_break_char(line->buffer.data[i + 1], MINOR_BREAK)) {
-						line->buffer.index = i + 1;
-						break;
-					}
-				}
-				if (i < 0) {
-					line->buffer.index = 0;
+				if (!em_opts.move_cursor) {
+					rz_emacs_mode_opts_reset(&em_opts);
+				} else {
+					em_opts.op = EMACS_MOVE_BACKWARD;
+					rz_emacs_mode_action(&em_opts, line);
+					rz_emacs_mode_opts_reset(&em_opts);
 				}
 				break;
 			case 'D':
 			case 'd':
-				kill_word(line, MINOR_BREAK);
+				if (!em_opts.move_cursor) {
+					rz_emacs_mode_opts_reset(&em_opts);
+				} else {
+					em_opts.op = EMACS_MODIFY_KILL_WORD;
+					rz_emacs_mode_action(&em_opts, line);
+					rz_emacs_mode_opts_reset(&em_opts);
+				}
 				break;
 			case 'F':
 			case 'f':
-				// next word
-				for (i = line->buffer.index + 1; i < line->buffer.length; i++) {
-					if (!is_word_break_char(line->buffer.data[i], MINOR_BREAK) && is_word_break_char(line->buffer.data[i - 1], MINOR_BREAK)) {
-						line->buffer.index = i;
-						break;
-					}
-				}
-				if (i >= line->buffer.length) {
-					line->buffer.index = line->buffer.length;
+				if (!em_opts.move_cursor) {
+					rz_emacs_mode_opts_reset(&em_opts);
+				} else {
+					em_opts.op = EMACS_MOVE_FORWARD;
+					rz_emacs_mode_action(&em_opts, line);
+					rz_emacs_mode_opts_reset(&em_opts);
 				}
 				break;
 			case 'C':
 			case 'c':
 				em_opts.op = EMACS_MODIFY_CAPITALIZE;
-				rz_emacs_mode_modify(&em_opts, line);
-				rz_emacs_mode_modify_opts_reset(&em_opts);
+				rz_emacs_mode_action(&em_opts, line);
+				rz_emacs_mode_opts_reset(&em_opts);
 				break;
 			case 'L':
 			case 'l':
 				em_opts.op = EMACS_MODIFY_TOLOWER;
-				rz_emacs_mode_modify(&em_opts, line);
-				rz_emacs_mode_modify_opts_reset(&em_opts);
+				rz_emacs_mode_action(&em_opts, line);
+				rz_emacs_mode_opts_reset(&em_opts);
 				break;
 			case 'U':
 			case 'u':
 				em_opts.op = EMACS_MODIFY_TOUPPER;
-				rz_emacs_mode_modify(&em_opts, line);
-				rz_emacs_mode_modify_opts_reset(&em_opts);
+				rz_emacs_mode_action(&em_opts, line);
+				rz_emacs_mode_opts_reset(&em_opts);
 				break;
 			case '-':
 				em_opts.move_cursor = !em_opts.move_cursor;
 				if (em_opts.word_count_provided) {
 					// word count must be provided after '-'
-					rz_emacs_mode_modify_opts_reset(&em_opts);
+					rz_emacs_mode_opts_reset(&em_opts);
 				}
 				break;
 			case '0':

--- a/librz/cons/emacs_mode.c
+++ b/librz/cons/emacs_mode.c
@@ -8,6 +8,14 @@ static bool is_word_constituent(RzCodePoint cp) {
 	return iswalnum((wint_t)cp);
 }
 
+static bool is_word_constituent_index(const RzCodePoints *buffer, size_t index) {
+	if (index >= rz_vector_len(buffer)) {
+		return false;
+	}
+	RzCodePoint *cp = rz_vector_index_ptr(buffer, index);
+	return is_word_constituent(*cp);
+}
+
 static char *unicode_mapping_append_to_buf(RZ_NONNULL const RzUnicodeCaseMapping *um, RZ_NONNULL char *p, RZ_NONNULL const char *end) {
 	rz_return_val_if_fail(um && p && end, NULL);
 	if (rz_unicode_case_mapping_is_empty(um)) {
@@ -70,8 +78,7 @@ static RZ_OWN RZ_NULLABLE char *unicode_mapping_to_str(RZ_NONNULL RzUnicodeCaseM
 /**
  * \brief Find index of the first (unicode) character in the following word in \p buffer.
  */
-static ssize_t emacs_mode_find_word_start(RZ_NONNULL const RzCodePoints *buffer, ssize_t start) {
-	rz_return_val_if_fail(buffer && rz_vector_len(buffer), -1);
+static size_t emacs_mode_find_word_start(RZ_NONNULL const RzCodePoints *buffer, size_t start) {
 	while (start < rz_vector_len(buffer)) {
 		const RzCodePoint *cp = rz_vector_index_ptr(buffer, start);
 		if (is_word_constituent(*cp)) {
@@ -85,9 +92,8 @@ static ssize_t emacs_mode_find_word_start(RZ_NONNULL const RzCodePoints *buffer,
 /**
  * \brief Find index of the last (unicode) character in the following word in \p buffer.
  */
-static ssize_t emacs_mode_find_word_end(RZ_NONNULL const RzCodePoints *buffer, ssize_t start) {
-	rz_return_val_if_fail(buffer && rz_vector_len(buffer), -1);
-	ssize_t end = RZ_MIN(start + 1, rz_vector_len(buffer));
+static size_t emacs_mode_find_word_end(RZ_NONNULL const RzCodePoints *buffer, size_t start) {
+	size_t end = RZ_MIN(start + 1, rz_vector_len(buffer));
 	while (end < rz_vector_len(buffer)) {
 		const RzCodePoint *cp = rz_vector_index_ptr(buffer, end);
 		if (!is_word_constituent(*cp)) {
@@ -96,6 +102,28 @@ static ssize_t emacs_mode_find_word_end(RZ_NONNULL const RzCodePoints *buffer, s
 		++end;
 	}
 	return end;
+}
+
+static size_t emacs_mode_find_prev_word_start(const RzCodePoints *buffer, size_t index) {
+	while (index > 0) {
+		const RzCodePoint *cp = rz_vector_index_ptr(buffer, index - 1);
+		if (!is_word_constituent(*cp)) {
+			break;
+		}
+		--index;
+	}
+	return index;
+}
+
+static size_t emacs_mode_find_prev_word_end(const RzCodePoints *buffer, size_t index) {
+	while (index > 0) {
+		const RzCodePoint *cp = rz_vector_index_ptr(buffer, index);
+		if (is_word_constituent(*cp)) {
+			break;
+		}
+		--index;
+	}
+	return index;
 }
 
 /**
@@ -117,6 +145,52 @@ static ssize_t emacs_mode_find_byte_index(RZ_NONNULL const RzCodePoints *buffer,
 	return bytei;
 }
 
+static void line_delete_range(RzLine *line, size_t start, size_t end) {
+	if (start >= end || end > line->buffer.length) {
+		return;
+	}
+	char *line_buf = line->buffer.data;
+	memmove(line_buf + start, line_buf + end, line->buffer.length - end);
+	line->buffer.length -= end - start;
+	line->buffer.data[line->buffer.length] = '\0';
+}
+
+static bool emacs_mode_modify_kill(RzLine *line, const RzCodePoints *buffer, size_t word_count, size_t end) {
+	for (size_t i = 0; i < word_count && end < rz_vector_len(buffer); ++i) {
+		const size_t start = emacs_mode_find_word_start(buffer, end);
+		end = emacs_mode_find_word_end(buffer, start);
+	}
+	const ssize_t end_byte = emacs_mode_find_byte_index(buffer, end);
+	if (end_byte < 0) {
+		return false;
+	}
+	line_delete_range(line, line->buffer.index, end_byte);
+	return true;
+}
+
+static bool emacs_mode_modify_kill_backward(RzLine *line, const RzCodePoints *buffer, size_t word_count, size_t utf8_index) {
+	if (utf8_index < 1) {
+		return true;
+	}
+	size_t start = RZ_MIN(utf8_index, rz_vector_len(buffer) - 1);
+	if (start < utf8_index && is_word_constituent_index(buffer, start)) {
+		--word_count;
+	}
+
+	for (size_t wi = 0; wi < word_count && start > 0; ++wi) {
+		size_t end = emacs_mode_find_prev_word_end(buffer, start - 1);
+		start = emacs_mode_find_prev_word_start(buffer, end);
+	}
+
+	const ssize_t start_byte = emacs_mode_find_byte_index(buffer, start);
+	if (start_byte < 0) {
+		return false;
+	}
+	line_delete_range(line, start_byte, line->buffer.index);
+	line->buffer.index = start_byte;
+	return true;
+}
+
 /**
  * \brief Capitalize the current or next word in \p buffer.
  *
@@ -127,11 +201,11 @@ static ssize_t emacs_mode_find_byte_index(RZ_NONNULL const RzCodePoints *buffer,
  *
  * \return Capitalized word as UTF-8 encoded (null-terminated) string.
  */
-static RZ_OWN RZ_NULLABLE char *emacs_mode_capitalize(RZ_NONNULL const RzCodePoints *buffer, ssize_t start, ssize_t end, size_t utf8_len) {
+static RZ_OWN RZ_NULLABLE char *emacs_mode_capitalize(RZ_NONNULL const RzCodePoints *buffer, size_t start, size_t end, size_t utf8_len) {
 	rz_return_val_if_fail(buffer && rz_vector_len(buffer) > 0 && utf8_len > 0 && start <= end && end <= rz_vector_len(buffer), NULL);
 
 	RzUnicodeCaseMappings *map = rz_vector_new(sizeof(RzUnicodeCaseMapping), NULL, NULL);
-	ssize_t i = start;
+	size_t i = start;
 	for (; i < end; ++i) {
 		const RzCodePoint *cp = rz_vector_index_ptr(buffer, i);
 		if (iswalpha((wint_t)(*cp))) {
@@ -164,11 +238,11 @@ static RZ_OWN RZ_NULLABLE char *emacs_mode_capitalize(RZ_NONNULL const RzCodePoi
  *
  * \return Lowercase word as UTF-8 encoded (null-terminated) string.
  */
-static char *emacs_mode_tolower(RZ_NONNULL const RzCodePoints *buffer, ssize_t start, ssize_t end, size_t utf8_len) {
+static char *emacs_mode_tolower(RZ_NONNULL const RzCodePoints *buffer, size_t start, size_t end, size_t utf8_len) {
 	rz_return_val_if_fail(buffer && rz_vector_len(buffer) > 0 && utf8_len > 0 && start <= end && end <= rz_vector_len(buffer), NULL);
 
 	RzVector *map = rz_vector_new(sizeof(RzUnicodeCaseMapping), NULL, NULL);
-	for (ssize_t i = start; i < end; ++i) {
+	for (size_t i = start; i < end; ++i) {
 		const RzCodePoint *cp = rz_vector_index_ptr(buffer, i);
 		RzUnicodeCaseMapping um = rz_unicode_code_point_find_lower(*cp);
 		rz_vector_push(map, &um);
@@ -189,11 +263,11 @@ static char *emacs_mode_tolower(RZ_NONNULL const RzCodePoints *buffer, ssize_t s
  *
  * \return Uppercase word as UTF-8 encoded (null-terminated) string.
  */
-static RZ_OWN RZ_NULLABLE char *emacs_mode_toupper(RZ_NONNULL const RzCodePoints *buffer, ssize_t start, ssize_t end, size_t utf8_len) {
+static RZ_OWN RZ_NULLABLE char *emacs_mode_toupper(RZ_NONNULL const RzCodePoints *buffer, size_t start, size_t end, size_t utf8_len) {
 	rz_return_val_if_fail(buffer && rz_vector_len(buffer) > 0 && utf8_len > 0 && start <= end && end <= rz_vector_len(buffer), NULL);
 
 	RzVector *map = rz_vector_new(sizeof(RzUnicodeCaseMapping), NULL, NULL);
-	for (ssize_t i = start; i < end; ++i) {
+	for (size_t i = start; i < end; ++i) {
 		const RzCodePoint *cp = rz_vector_index_ptr(buffer, i);
 		RzUnicodeCaseMapping um = rz_unicode_code_point_find_upper(*cp);
 		rz_vector_push(map, &um);
@@ -227,8 +301,8 @@ static bool utf8_decode_buf(const ut8 *buf, size_t buflen, RZ_NONNULL RzCodePoin
 	return true;
 }
 
-static bool emacs_mode_modify_one(RzEmacsModeModifyOp op, RZ_NONNULL RzLine *line, RZ_NONNULL const RzCodePoints *cpbuffer, ssize_t start, size_t end) {
-	rz_return_val_if_fail(line && cpbuffer && start >= 0 && end >= 0, false);
+static bool emacs_mode_modify_case_single(RzEmacsModeOp op, RZ_NONNULL RzLine *line, RZ_NONNULL const RzCodePoints *cpbuffer, size_t start, size_t end) {
+	rz_return_val_if_fail(line && cpbuffer, false);
 	const ssize_t start_byte = emacs_mode_find_byte_index(cpbuffer, start);
 	const ssize_t end_byte = emacs_mode_find_byte_index(cpbuffer, end);
 	if (start_byte == -1 || end_byte == -1) {
@@ -259,6 +333,69 @@ static bool emacs_mode_modify_one(RzEmacsModeModifyOp op, RZ_NONNULL RzLine *lin
 	return true;
 }
 
+static bool emacs_mode_modify_case(RZ_NONNULL const RzEmacsModeOpts *opts, RZ_NONNULL RzLine *line, RZ_NONNULL const RzCodePoints *buffer, size_t word_count, size_t utf8_index) {
+	size_t start = 0, end = 0; ///< index of first/last unicode code point in the current word
+	start = emacs_mode_find_word_start(buffer, utf8_index);
+	end = emacs_mode_find_word_end(buffer, start);
+	for (size_t wi = 0; wi < word_count && start < end; ++wi) {
+		const bool failed = !emacs_mode_modify_case_single(opts->op, line, buffer, start, end);
+		if (failed) {
+			return false;
+		}
+		if (opts->move_cursor) {
+			line->buffer.index = emacs_mode_find_byte_index(buffer, end);
+		}
+		start = emacs_mode_find_word_start(buffer, end);
+		end = emacs_mode_find_word_end(buffer, start);
+	}
+	return true;
+}
+
+static bool emacs_mode_move_forward(RzLine *line, const RzCodePoints *buffer, size_t word_count, size_t utf8_index) {
+	size_t start = emacs_mode_find_word_start(buffer, utf8_index);
+	size_t end = emacs_mode_find_word_end(buffer, start);
+	ssize_t new_index = line->buffer.index;
+
+	RzCodePoint *curr_ch = rz_vector_index_ptr(buffer, utf8_index);
+	if (!is_word_constituent(*curr_ch)) {
+		new_index = emacs_mode_find_byte_index(buffer, start);
+		--word_count;
+	}
+
+	for (size_t wi = 0; wi < word_count && start < end; ++wi) {
+		start = emacs_mode_find_word_start(buffer, end);
+		end = emacs_mode_find_word_end(buffer, start);
+		new_index = emacs_mode_find_byte_index(buffer, start);
+		if (new_index < 0) {
+			return false;
+		}
+	}
+	line->buffer.index = new_index;
+	return true;
+}
+
+static bool emacs_mode_move_backward(RzLine *line, const RzCodePoints *buffer, size_t word_count, size_t utf8_index) {
+	size_t start = utf8_index;
+	if (start < 1) {
+		return true;
+	}
+	size_t end = emacs_mode_find_prev_word_end(buffer, start - 1);
+	ssize_t new_index = line->buffer.index;
+	for (size_t wi = 0; wi < word_count && end >= 0; ++wi) {
+		start = emacs_mode_find_prev_word_start(buffer, end);
+		new_index = emacs_mode_find_byte_index(buffer, start);
+		if (new_index < 0) {
+			return false;
+		}
+		if (start < 1) {
+			break;
+		}
+		end = emacs_mode_find_prev_word_end(buffer, start - 1);
+	}
+	line->buffer.index = new_index;
+	return true;
+}
+
 /**
  * \brief Capitalizes/lowercases/uppercases the current or next word(s).
  * Note: Optionally sets the cursor position to the end of the last word.
@@ -268,45 +405,49 @@ static bool emacs_mode_modify_one(RzEmacsModeModifyOp op, RZ_NONNULL RzLine *lin
  *
  * \return false on failure
  */
-RZ_IPI bool rz_emacs_mode_modify(RZ_NONNULL RzEmacsModeModifyOpts *opts, RZ_NONNULL RzLine *line) {
+RZ_IPI bool rz_emacs_mode_action(RZ_NONNULL RZ_BORROW const RzEmacsModeOpts *opts, RZ_NONNULL RZ_BORROW RzLine *line) {
 	rz_return_val_if_fail(line && opts, false);
 	if (line->buffer.length < 1) {
 		return true;
 	}
 
-	RzCodePoints *cpbuffer = rz_vector_new(sizeof(RzCodePoint), NULL, NULL);
+	RzCodePoints cpbuffer;
+	rz_vector_init(&cpbuffer, sizeof(RzCodePoint), NULL, NULL);
 	const ut8 *line_buf = (ut8 *)line->buffer.data;
-	const bool decoded = utf8_decode_buf(line_buf, line->buffer.length, cpbuffer);
-	if (!decoded || rz_vector_len(cpbuffer) < 1) {
-		goto cleanup_and_exit;
+	const bool decoded = utf8_decode_buf(line_buf, line->buffer.length, &cpbuffer);
+	if (!decoded || rz_vector_len(&cpbuffer) < 1) {
+		rz_vector_fini(&cpbuffer);
+		return false;
 	}
 
 	const size_t word_count = opts->word_count_provided ? opts->word_count : 1;
 	const size_t utf8_index = rz_utf8_strnlen(line_buf, line->buffer.index);
 
-	ssize_t start = 0, end = 0; ///< index of first/last unicode code point in the current word
-	start = emacs_mode_find_word_start(cpbuffer, utf8_index);
-	end = emacs_mode_find_word_end(cpbuffer, start);
-	for (size_t wi = 0; wi < word_count && start < end; ++wi) {
-		if (start == -1 || end == -1) {
-			goto cleanup_and_exit;
-		}
-		const bool failed = !emacs_mode_modify_one(opts->op, line, cpbuffer, start, end);
-		if (failed) {
-			goto cleanup_and_exit;
-		}
-		if (opts->move_cursor) {
-			line->buffer.index = emacs_mode_find_byte_index(cpbuffer, end);
-		}
-		start = emacs_mode_find_word_start(cpbuffer, end);
-		end = emacs_mode_find_word_end(cpbuffer, start);
+	bool ret = true;
+	switch (opts->op) {
+	default:
+		rz_return_val_if_reached(false);
+	case EMACS_MODIFY_CAPITALIZE:
+	case EMACS_MODIFY_TOLOWER:
+	case EMACS_MODIFY_TOUPPER:
+		ret = emacs_mode_modify_case(opts, line, &cpbuffer, word_count, utf8_index);
+		break;
+	case EMACS_MODIFY_KILL_WORD:
+		ret = emacs_mode_modify_kill(line, &cpbuffer, word_count, utf8_index);
+		break;
+	case EMACS_MODIFY_KILL_WORD_BACKWARD:
+		ret = emacs_mode_modify_kill_backward(line, &cpbuffer, word_count, utf8_index);
+		break;
+	case EMACS_MOVE_FORWARD:
+		ret = emacs_mode_move_forward(line, &cpbuffer, word_count, utf8_index);
+		break;
+	case EMACS_MOVE_BACKWARD:
+		ret = emacs_mode_move_backward(line, &cpbuffer, word_count, utf8_index);
+		break;
 	}
-	rz_vector_free(cpbuffer);
-	return true;
 
-cleanup_and_exit:
-	rz_vector_free(cpbuffer);
-	return false;
+	rz_vector_fini(&cpbuffer);
+	return ret;
 }
 
 /**
@@ -314,7 +455,7 @@ cleanup_and_exit:
  *
  * \param opts The modify options.
  */
-RZ_IPI void rz_emacs_mode_modify_opts_reset(RZ_NONNULL RzEmacsModeModifyOpts *opts) {
+RZ_IPI void rz_emacs_mode_opts_reset(RZ_NONNULL RZ_BORROW RzEmacsModeOpts *opts) {
 	rz_return_if_fail(opts);
 	opts->move_cursor = true;
 	opts->word_count_provided = false;

--- a/librz/cons/i/private.h
+++ b/librz/cons/i/private.h
@@ -11,20 +11,24 @@
 typedef enum {
 	EMACS_MODIFY_CAPITALIZE,
 	EMACS_MODIFY_TOLOWER,
-	EMACS_MODIFY_TOUPPER
-} RzEmacsModeModifyOp;
+	EMACS_MODIFY_TOUPPER,
+	EMACS_MODIFY_KILL_WORD,
+	EMACS_MODIFY_KILL_WORD_BACKWARD,
+	EMACS_MOVE_FORWARD,
+	EMACS_MOVE_BACKWARD
+} RzEmacsModeOp;
 
 typedef struct {
-	RzEmacsModeModifyOp op;
+	RzEmacsModeOp op;
 	bool move_cursor; ///< if true, cursor is moved to the end of the last word.
 	bool word_count_provided; ///< if true \p word_count is used, else a single word is modified.
 	size_t word_count; ///< number of words to modify.
-} RzEmacsModeModifyOpts;
+} RzEmacsModeOpts;
 
 typedef RzVector /*<RzCodePoint>*/ RzCodePoints;
 typedef RzVector /*<RzUnicodeCaseMapping>*/ RzUnicodeCaseMappings;
 
-RZ_IPI void rz_emacs_mode_modify_opts_reset(RZ_NONNULL RzEmacsModeModifyOpts *opts);
-RZ_IPI bool rz_emacs_mode_modify(RZ_NONNULL RzEmacsModeModifyOpts *opts, RZ_NONNULL RzLine *line);
+RZ_IPI void rz_emacs_mode_opts_reset(RZ_NONNULL RZ_BORROW RzEmacsModeOpts *opts);
+RZ_IPI bool rz_emacs_mode_action(RZ_NONNULL RZ_BORROW const RzEmacsModeOpts *opts, RZ_NONNULL RZ_BORROW RzLine *line);
 
 #endif


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Rizin shell does not handle unicode characters in some emacs-style hotkeys, e.g; `M-f`, `M-b`, `M-d` and `M-<BS>`. This conflicts with emacs-style case conversions introduced in #5898.
I will update the rizin book once this is completed.

...

**Test plan**

Rizin shell:

https://drive.google.com/file/d/1xO0dQNp5O5BXih9ENghjSGo9Jo2VEztD/view?usp=drive_link

Zsh (expected behavior):

https://drive.google.com/file/d/1sKKtvLD4ab6V57x2AxVE4i8enJPC1Tnw/view?usp=drive_link

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
