### PR TITLE
Show char in comment on aarch64 cmp instructions

### DIFF
--- a/librz/arch/p/analysis/analysis_arm_cs.c
+++ b/librz/arch/p/analysis/analysis_arm_cs.c
@@ -1082,8 +1082,8 @@ static void anop64(AnalysisArmCSContext *ctx, RzAnalysisOp *op, cs_insn *insn) {
 		} else {
 			op->type = RZ_ANALYSIS_OP_TYPE_ADD;
 		}
-		if (ISIMM64(1)) {
-			op->val = IMM64(1);
+		if (ISIMM64(2)) {
+			op->val = IMM64(2);
 		}
 		break;
 	case ARM64_INS_SUBS:
@@ -1092,8 +1092,8 @@ static void anop64(AnalysisArmCSContext *ctx, RzAnalysisOp *op, cs_insn *insn) {
 		} else {
 			op->type = RZ_ANALYSIS_OP_TYPE_SUB;
 		}
-		if (ISIMM64(1)) {
-			op->val = IMM64(1);
+		if (ISIMM64(2)) {
+			op->val = IMM64(2);
 		}
 		break;
 	case ARM64_INS_ANDS:
@@ -1102,8 +1102,8 @@ static void anop64(AnalysisArmCSContext *ctx, RzAnalysisOp *op, cs_insn *insn) {
 		} else {
 			op->type = RZ_ANALYSIS_OP_TYPE_AND;
 		}
-		if (ISIMM64(1)) {
-			op->val = IMM64(1);
+		if (ISIMM64(2)) {
+			op->val = IMM64(2);
 		}
 		break;
 	case ARM64_INS_ADDG:

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -3960,9 +3960,13 @@ static void ds_print_ptr(RzDisasmState *ds, int len, int idx) {
 		return;
 	}
 	const int opType = ds->analysis_op.type & RZ_ANALYSIS_OP_TYPE_MASK;
-	bool canHaveChar = opType == RZ_ANALYSIS_OP_TYPE_MOV;
-	if (!canHaveChar) {
-		canHaveChar = opType == RZ_ANALYSIS_OP_TYPE_PUSH;
+	bool canHaveChar = false;
+	switch (opType) {
+	case RZ_ANALYSIS_OP_TYPE_PUSH:
+	case RZ_ANALYSIS_OP_TYPE_MOV:
+	case RZ_ANALYSIS_OP_TYPE_CMP:
+		canHaveChar = true;
+		break;
 	}
 
 	ds->chref = 0;

--- a/test/db/analysis/arm64
+++ b/test/db/analysis/arm64
@@ -339,3 +339,18 @@ EXPECT=<<EOF
 \       ,=< 0x00401aea      jmp   fcn.00402f40
 EOF
 RUN
+
+NAME=aarch64 cmn/cmp/tst show char comment for printable immediate
+FILE=malloc://1024
+ARGS=-a arm -b 64
+CMDS=<<EOF
+e cfg.bigendian=false
+wx 3f0401b13f0401f13f1440f2
+pd 3
+EOF
+EXPECT=<<EOF
+            0x00000000      cmn   x1, 0x41                             ; 'A'
+            0x00000004      cmp   x1, 0x41                             ; 'A'
+            0x00000008      tst   x1, 0x3f                             ; '?'
+EOF
+RUN

--- a/test/db/formats/elf/reloc
+++ b/test/db/formats/elf/reloc
@@ -317,7 +317,7 @@ EXPECT=<<EOF
 |           0x08000040      movzx eax, byte [rdi]                      ; RELOC TARGET 32 .text @ 0x08000040 - 0x8004d08 ; arg1 ; [01] -r-x section size 6641 named .text
 |           0x08000043      and   eax, 0x7f                            ; 127
 |           0x08000046      sub   eax, 0x04
-|           0x08000049      cmp   al, 0x73                             ; 115
+|           0x08000049      cmp   al, 0x73                             ; 's' ; 115
 |       ,=< 0x0800004b      jnbe  case.0x800005e.5
 |       |   0x0800004d      lea   rdx, qword reloc.target..rodata      ; 0x8001a34 ; "4\xe6\xff\xff,\xe6\xff\xff4\xe6\xff\xff,\xe6\xff\xff4\xe6\xff\xffD\xe6\xff\xff4\xe6\xff\xffD\xe6\xff\xff4\xe6\xff\xff,\xe6\xff\x"; RELOC 32 .rodata @ 0x08001a34 - 0x8000054
 |       |   0x08000054      movzx eax, al


### PR DESCRIPTION
On aarch64 cmp instructions with a char byte were not commented with the char value:
Before:
```
[0x1000010a8]> pdb @ 0x10000110c
│           0x100001108      ldrb  w8, [x21]
│           0x10000110c      cmp   w8, 0x2d
│       ┌─< 0x100001110      b.ne  0x100001128
```
After:
```
[0x1000010a8]> pdb @ 0x10000110c
│           0x100001108      ldrb  w8, [x21]
│           0x10000110c      cmp   w8, 0x2d                            ; '-'
│       ┌─< 0x100001110      b.ne  0x100001128
```

There were 2 problems:
1. canHaveChar was not set for CMP instructions
2. analysis_arm_cs was checking the wrong value for immediates.

```
$ ./build/cstool -r -d aarch64 1fa10171
 0  1f a1 01 71  cmp    w8, #0x68
        ID: 1210 (subs)
        Is alias: 1542 (cmp) with REAL operand set
        op_count: 3
                operands[0].type: REG = wzr
                operands[0].access: WRITE
                operands[1].type: REG = w8
                operands[1].access: READ
                operands[2].type: IMM = 0x68
                operands[2].access: READ
        Update-flags: True
        Registers read: w8
        Registers modified: nzcv wzr

./build/cstool -r -d aarch64 20a80031
 0  20 a8 00 31  adds   w0, w1, #0x2a
        ID: 18 (adds)
        op_count: 3
                operands[0].type: REG = w0
                operands[0].access: WRITE
                operands[1].type: REG = w1
                operands[1].access: READ
                operands[2].type: IMM = 0x2a
                operands[2].access: READ
        Update-flags: True
        Registers read: w1
        Registers modified: nzcv w0
```