### PR TITLE
Adding RzIL unicode/enriched lines api for cutter

### DIFF
--- a/librz/core/cil.c
+++ b/librz/core/cil.c
@@ -562,21 +562,39 @@ static void core_colorify_il_statement_unicode_to_strbuf(RzConsContext *ctx, con
  * \param unicode - whether enable unicode formatting or not
  * \param colorize - color the text
  */
-RZ_API void rz_core_il_print_rzil(RZ_NONNULL RzCore *core, RZ_NONNULL RzPVector *vec, ut64 addr, int n_lines, bool pretty, bool unicode, bool colorize) {
-	rz_return_if_fail(core && vec);
+RZ_API int rz_core_il_print_rzil(RZ_NONNULL RzCore *core, ut64 addr, RZ_NONNULL ut8 *buf, int len, int n_lines, RZ_NULLABLE RzCoreILPrintOptions *options) {
+	rz_return_val_if_fail(core && buf && (n_lines || len), 0);
+	RzPVector *vec = NULL;
+	bool pretty = false;
+	bool unicode = false;
+	bool colorize = false;
+	if (options) {
+		pretty = options->pretty;
+		colorize = options->colorize;
+		unicode = options->unicode;
+		vec = options->vec;
+	}
+	if (!vec) {
+		return 0;
+	}
+	if (!n_lines) {
+		n_lines = core->blocksize;
+	}
 	const char *il_stmt = NULL;
 	const char delim = pretty ? '\n' : ' ';
 	RzStrBuf sb;
+	RzPVector *reflines;
 	RzAnalysisOp op;
-	RzPVector *reflines = rz_analysis_reflines_get(core->analysis,
-		addr, core->block, core->blocksize, n_lines,
+	int ops_count = 0, inc = 0, idx;
+	ut64 current = addr, vat;
+	ut8 *nbuf = NULL;
+	ut8 min_op_size = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE);
+complete:
+	reflines = rz_analysis_reflines_get(core->analysis,
+		addr, buf, len, n_lines,
 		rz_config_get_i(core->config, "asm.lines.out"),
 		rz_config_get_b(core->config, "asm.lines") ? rz_config_get_b(core->config, "asm.lines.call") : false);
 	rz_analysis_set_reflines(core->analysis, reflines);
-	int ops_count = 0;
-	ut64 current = addr, vat;
-	ut8 bytes[256];
-	ut8 min_op_size = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE);
 	if (!core->keep_asmqjmps) { // hack
 		core->asmqjmps_count = 0;
 		ut64 *p = realloc(core->asmqjmps, RZ_CORE_ASMQJMPS_NUM * sizeof(ut64));
@@ -588,22 +606,27 @@ RZ_API void rz_core_il_print_rzil(RZ_NONNULL RzCore *core, RZ_NONNULL RzPVector 
 			}
 		}
 	}
-	while (ops_count < n_lines) {
-		rz_core_seek_arch_bits(core, current);
+	for (idx = 0; ops_count < n_lines && idx < len; ops_count++, idx += inc) {
+		current = addr + idx;
 		RzAnalysisDisasmText *dst = RZ_NEW0(RzAnalysisDisasmText);
 		dst->arrow = UT64_MAX;
 		vat = rz_core_pava(core, current);
 		rz_strbuf_init(&sb);
-		int read = rz_io_nread_at(core->io, current, bytes, sizeof(bytes));
-		if (read < 1) {
-			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%creaderror", current, delim);
-			goto finish_str;
+		if (core->print->flags & RZ_PRINT_FLAGS_UNALLOC) {
+			if (!rz_io_is_valid_offset(core->io, current, 0)) {
+				rz_strbuf_appendf(&sb, "0x%" PFMT64x "%cunmapped", current, delim);
+				inc = 1;
+				goto finish_str;
+			}
 		}
+		rz_core_seek_arch_bits(core, current);
 		rz_analysis_op_init(&op);
-		if (rz_analysis_op(core->analysis, &op, current, bytes, read, RZ_ANALYSIS_OP_MASK_IL) < 1) {
+		if (rz_analysis_op(core->analysis, &op, current, buf + idx, (int)(len - idx), RZ_ANALYSIS_OP_MASK_IL) < 1) {
 			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%cinvalid", current, delim);
+			inc = 1;
 			goto finalize;
 		}
+		inc = op.size;
 		if (!op.il_op) {
 			RZ_LOG_DEBUG("Empty IL at 0x%08" PFMT64x "...", op.addr);
 			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%cempty il", op.addr, delim);
@@ -633,7 +656,7 @@ RZ_API void rz_core_il_print_rzil(RZ_NONNULL RzCore *core, RZ_NONNULL RzPVector 
 		} else {
 			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%c%s", op.addr, delim, il_stmt);
 		}
-		free((void *)il_stmt);
+		RZ_FREE(il_stmt)
 		if (reflines) {
 			void **iter;
 			rz_pvector_foreach (reflines, iter) {
@@ -649,8 +672,7 @@ RZ_API void rz_core_il_print_rzil(RZ_NONNULL RzCore *core, RZ_NONNULL RzPVector 
 	finish_str:
 		dst->offset = rz_core_pava(core, current);
 		dst->text = rz_str_dup(rz_strbuf_get(&sb));
-		current += op.size > 0 ? op.size : min_op_size;
-		ops_count++;
+		inc = inc ? inc : RZ_MAX(1, min_op_size);
 		if (!rz_pvector_push(vec, dst)) {
 			free(dst->text);
 			free(dst);
@@ -659,6 +681,20 @@ RZ_API void rz_core_il_print_rzil(RZ_NONNULL RzCore *core, RZ_NONNULL RzPVector 
 	}
 	rz_analysis_set_reflines(core->analysis, NULL);
 	rz_pvector_free(reflines);
+	if (!options->cbytes && ops_count < n_lines) {
+		addr = current + inc;
+		if (len < 16) {
+			len = 16;
+		}
+		free(nbuf);
+		buf = nbuf = malloc(len);
+		if (nbuf) {
+			rz_io_read_at_mapped(core->io, addr, buf, len);
+			goto complete;
+		}
+	}
+	RZ_FREE(nbuf);
+	return ops_count;
 }
 
 RZ_IPI void rz_core_il_cons_print(RZ_NONNULL RzCore *core, RZ_NONNULL RZ_BORROW RzIterator *iter, bool pretty, bool unicode) {

--- a/librz/core/cil.c
+++ b/librz/core/cil.c
@@ -351,15 +351,27 @@ static inline void emit_span(const char *s, size_t n, const char *color) {
 	}
 }
 
-/**
- * \brief Colorize a stringified RzIL effect body to the cons buffer.
- *
- * Emits only the body (no address prefix, no newline) with the same palette
- * as \c plf. A NULL or empty \p il_stmt emits nothing.
- */
-RZ_IPI void rz_core_il_colorize_body(RZ_NONNULL RzConsContext *ctx, RZ_NULLABLE const char *il_stmt) {
-	rz_return_if_fail(ctx);
+static inline void emit_span_to_strbuf(const char *s, size_t n, const char *color, RzStrBuf *sb) {
+	if (n < 1) {
+		return;
+	}
+	if (color) {
+		rz_strbuf_appendf(sb, "%s%.*s" Color_RESET, color, (int)n, s);
+	} else {
+		rz_strbuf_appendf(sb, "%.*s", (int)n, s);
+	}
+}
+
+static void core_colorify_il_statement(RzConsContext *ctx, const char *il_stmt, const char delim, ut64 addr) {
+	rz_cons_printf("%s0x%" PFMT64x Color_RESET "%c", ctx->pal.label, addr, delim);
+	rz_core_il_colorize_body(ctx, il_stmt);
+	rz_cons_newline();
+}
+
+static void core_colorify_il_statement_to_strbuf(RzConsContext *ctx, const char *il_stmt, const char delim, ut64 addr, RzStrBuf *sb) {
+	rz_strbuf_appendf(sb, "%s0x%" PFMT64x Color_RESET "%c", ctx->pal.label, addr, delim);
 	if (RZ_STR_ISEMPTY(il_stmt)) {
+		rz_strbuf_appendf(sb, "\n");
 		return;
 	}
 
@@ -370,13 +382,13 @@ RZ_IPI void rz_core_il_colorize_body(RZ_NONNULL RzConsContext *ctx, RZ_NULLABLE 
 		const char ch = il_stmt[i];
 
 		if (ch == '(' || ch == ')') {
-			emit_span(il_stmt + prev, i - prev, color);
-			rz_cons_printf("%s%c" Color_RESET, ctx->pal.meta, ch);
+			emit_span_to_strbuf(il_stmt + prev, i - prev, color, sb);
+			rz_strbuf_appendf(sb, "%s%c" Color_RESET, ctx->pal.meta, ch);
 			prev = i + 1;
 			color = (ch == '(') ? ctx->pal.flow : NULL;
 		} else if (ch == ' ') {
-			emit_span(il_stmt + prev, i - prev, color);
-			rz_cons_printf(" ");
+			emit_span_to_strbuf(il_stmt + prev, i - prev, color, sb);
+			rz_strbuf_appendf(sb, " ");
 			prev = i + 1;
 			color = NULL;
 		} else if (i == prev && prev > 0 && il_stmt[prev - 1] == ' ') {
@@ -384,13 +396,8 @@ RZ_IPI void rz_core_il_colorize_body(RZ_NONNULL RzConsContext *ctx, RZ_NULLABLE 
 		}
 	}
 
-	emit_span(il_stmt + prev, len - prev, color);
-}
-
-static void core_colorify_il_statement(RzConsContext *ctx, const char *il_stmt, const char delim, ut64 addr) {
-	rz_cons_printf("%s0x%" PFMT64x Color_RESET "%c", ctx->pal.label, addr, delim);
-	rz_core_il_colorize_body(ctx, il_stmt);
-	rz_cons_newline();
+	emit_span_to_strbuf(il_stmt + prev, len - prev, color, sb);
+	rz_strbuf_appendf(sb, "\n");
 }
 
 static bool unicode_colorify_state_is_varname(RzILUnicodeColorifyState state) {
@@ -489,11 +496,77 @@ static void core_colorify_il_statement_unicode(RzConsContext *ctx, const char *i
 	rz_cons_newline();
 }
 
-RZ_API void rz_core_il_print_rzil(RZ_NONNULL RzCore *core, RZ_NONNULL RzPVector *vec, bool pretty, bool unicode, bool colorize) {
-	RzAnalysisFunction *f = rz_analysis_first_function_in(core->analysis, core->offset);
-	rz_return_if_fail(f);
-	RzIterator *iter = rz_core_analysis_op_function_iter(core, f, RZ_ANALYSIS_OP_MASK_IL);
-	rz_return_if_fail(core && iter);
+static void core_colorify_il_statement_unicode_to_strbuf(RzConsContext *ctx, const char *il_stmt, const char delim, ut64 addr, RzStrBuf *sb) {
+	rz_return_if_fail(sb);
+	rz_strbuf_appendf(sb, "%s0x%" PFMT64x Color_RESET "%c", ctx->pal.label, addr, delim);
+	if (RZ_STR_ISEMPTY(il_stmt)) {
+		rz_strbuf_appendf(sb, "\n");
+		return;
+	}
+	size_t prev_i = 0;
+	const size_t len = strlen(il_stmt);
+	const char *color = NULL;
+	RzILUnicodeColorifyState prev_state = UNICODE_COLORIFY_STATE_DEFAULT;
+	for (size_t i = 0; i < len;) {
+		RzCodePoint cp = 0;
+		const size_t utf_size = rz_utf8_decode((const ut8 *)il_stmt + i, len - i, &cp, false);
+		RzILUnicodeColorifyState state = unicode_colorify_state_next(prev_state, cp);
+		if (state != prev_state) {
+			const int plen = i - prev_i;
+			if (color) {
+				rz_strbuf_appendf(sb, "%s%.*s" Color_RESET, color, plen, il_stmt + prev_i);
+			} else {
+				rz_strbuf_appendf(sb, "%.*s", plen, il_stmt + prev_i);
+			}
+			switch (state) {
+			default: break;
+			case UNICODE_COLORIFY_STATE_DEFAULT:
+				color = NULL;
+				break;
+			case UNICODE_COLORIFY_STATE_PARENTHESIS:
+				color = ctx->pal.meta;
+				break;
+			case UNICODE_COLORIFY_STATE_VARNAME:
+				color = ctx->pal.comment;
+				break;
+			case UNICODE_COLORIFY_STATE_NUMBER:
+				color = ctx->pal.num;
+				break;
+			case UNICODE_COLORIFY_STATE_IL_OP:
+				color = ctx->pal.flow;
+				break;
+			}
+
+			prev_state = state;
+			prev_i = i;
+		}
+		i += utf_size > 0 ? utf_size : 1;
+	}
+	if (prev_i < len) {
+		const int plen = len - prev_i;
+		if (color) {
+			rz_strbuf_appendf(sb, "%s%.*s" Color_RESET, color, plen, il_stmt + prev_i);
+		} else {
+			rz_strbuf_appendf(sb, "%.*s", plen, il_stmt + prev_i);
+		}
+	}
+	rz_strbuf_appendf(sb, "\n");
+}
+
+/* @brief formatted rzil from a starting RVA to a RzPVector of DisasmTexts
+ * @param core - rz core
+ * @param vec - allocated rzpvector pointer with free function for disasm_text
+ * @param addr - starting address of instructions
+ * @param n_lines - number of lines to be represented as rzil
+ * @param pretty - whether add delimitter or not
+ * @param unicode - whether enable unicode formatting or not
+ * @param colorize - color the text
+ */
+
+RZ_API void rz_core_il_print_rzil(RZ_NONNULL RzCore *core, RZ_NONNULL RzPVector *vec, ut64 addr, int n_lines, bool pretty, bool unicode, bool colorize) {
+	rz_return_if_fail(core && vec);
+	RzIterator *iter = rz_core_analysis_op_chunk_iter(core, addr, 0, n_lines, RZ_ANALYSIS_OP_MASK_IL);
+	rz_return_if_fail(iter);
 	const char *il_stmt = NULL;
 	const char delim = pretty ? '\n' : ' ';
 	RzStrBuf sb;
@@ -504,48 +577,52 @@ RZ_API void rz_core_il_print_rzil(RZ_NONNULL RzCore *core, RZ_NONNULL RzPVector 
 
 	RzAnalysisOp *op = NULL;
 	rz_iterator_foreach(iter, op) {
+		rz_strbuf_init(&sb);
 		RzAnalysisDisasmText *dst = RZ_NEW0(RzAnalysisDisasmText);
 		if (!op->il_op) {
 			RZ_LOG_DEBUG("Empty IL at 0x%08" PFMT64x "...\n", op->addr);
-			break;
+			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%cempty il\n", op->addr, delim);
+			goto togo;
 		}
 
-		rz_strbuf_init(&sb);
 		if (unicode) {
 			const int addr_len = snprintf(NULL, 0, "0x%" PFMT64x, op->addr);
 			RzILStringifyCtx ctx = { .indent = addr_len + 1, .indent_inc = 2 };
 			if (!rz_il_op_effect_stringify_unicode(&ctx, op->il_op, &sb)) {
 				RZ_LOG_ERROR("Failed to stringify IL at 0x%08" PFMT64x "\n", op->addr);
-				rz_strbuf_fini(&sb);
-				break;
+				rz_strbuf_appendf(&sb, "0x%" PFMT64x "%cstringify failed\n", op->addr, delim);
+				goto togo;
 			}
 		} else {
 			rz_il_op_effect_stringify(op->il_op, &sb, pretty);
 		}
 
-		il_stmt = rz_strbuf_get(&sb);
+		il_stmt = rz_str_dup(rz_strbuf_get(&sb));
+		rz_strbuf_fini(&sb);
+		rz_strbuf_init(&sb);
 		if (colorize) {
 			if (unicode) {
-				core_colorify_il_statement_unicode(core->cons->context, il_stmt, delim, op->addr);
+				core_colorify_il_statement_unicode_to_strbuf(core->cons->context, il_stmt, delim, op->addr, &sb);
 			} else {
-				core_colorify_il_statement(core->cons->context, il_stmt, delim, op->addr);
+				core_colorify_il_statement_to_strbuf(core->cons->context, il_stmt, delim, op->addr, &sb);
 			}
 		} else {
-			rz_cons_printf("0x%" PFMT64x "%c%s\n", op->addr, delim, il_stmt);
+			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%c%s\n", op->addr, delim, il_stmt);
 		}
 
-		if (ctx) {
-			RzILTypeEffect t;
-			char *report;
-			rz_il_validate_effect(op->il_op, ctx, NULL, &t, &report);
-			if (report) {
-				rz_cons_println(report);
-				free(report);
-			}
-		}
+	// if (ctx) {
+	// 	RzILTypeEffect t;
+	// 	char *report;
+	// 	rz_il_validate_effect(op->il_op, ctx, NULL, &t, &report);
+	// 	if (report) {
+	// 		rz_cons_println(report);
+	// 		free(report);
+	// 	}
+	// }
+	togo:
 		dst->offset = op->addr;
 		dst->arrow = UT64_MAX;
-		dst->text = rz_str_dup(rz_cons_get_buffer());
+		dst->text = rz_str_dup(rz_strbuf_get(&sb));
 		rz_pvector_push(vec, dst);
 		rz_cons_reset();
 		rz_strbuf_fini(&sb);

--- a/librz/core/cil.c
+++ b/librz/core/cil.c
@@ -358,7 +358,7 @@ static inline void emit_span_to_strbuf(const char *s, size_t n, const char *colo
 	if (color) {
 		rz_strbuf_appendf(sb, "%s%.*s" Color_RESET, color, (int)n, s);
 	} else {
-		rz_strbuf_appendf(sb, "%.*s", (int)n, s);
+		rz_strbuf_append_n(sb, s, n);
 	}
 }
 
@@ -397,7 +397,6 @@ static void core_colorify_il_statement_to_strbuf(RzConsContext *ctx, const char 
 	}
 
 	emit_span_to_strbuf(il_stmt + prev, len - prev, color, sb);
-	rz_strbuf_appendf(sb, "\n");
 }
 
 static bool unicode_colorify_state_is_varname(RzILUnicodeColorifyState state) {
@@ -437,6 +436,29 @@ RzILUnicodeColorifyState unicode_colorify_state_next(RzILUnicodeColorifyState st
 	}
 	return UNICODE_COLORIFY_STATE_IL_OP;
 }
+static const char *core_il_get_token_color(RzILUnicodeColorifyState state, const char *prev_color, RZ_NONNULL RzConsContext *ctx) {
+	rz_return_val_if_fail(ctx, NULL);
+	const char *color = prev_color;
+	switch (state) {
+	default: break;
+	case UNICODE_COLORIFY_STATE_DEFAULT:
+		color = NULL;
+		break;
+	case UNICODE_COLORIFY_STATE_PARENTHESIS:
+		color = ctx->pal.meta;
+		break;
+	case UNICODE_COLORIFY_STATE_VARNAME:
+		color = ctx->pal.comment;
+		break;
+	case UNICODE_COLORIFY_STATE_NUMBER:
+		color = ctx->pal.num;
+		break;
+	case UNICODE_COLORIFY_STATE_IL_OP:
+		color = ctx->pal.flow;
+		break;
+	}
+	return color;
+}
 
 static void core_colorify_il_statement_unicode(RzConsContext *ctx, const char *il_stmt, const char delim, ut64 addr) {
 	rz_cons_printf("%s0x%" PFMT64x Color_RESET "%c", ctx->pal.label, addr, delim);
@@ -461,24 +483,7 @@ static void core_colorify_il_statement_unicode(RzConsContext *ctx, const char *i
 				rz_cons_printf("%.*s", plen, il_stmt + prev_i);
 			}
 
-			switch (state) {
-			default: break;
-			case UNICODE_COLORIFY_STATE_DEFAULT:
-				color = NULL;
-				break;
-			case UNICODE_COLORIFY_STATE_PARENTHESIS:
-				color = ctx->pal.meta;
-				break;
-			case UNICODE_COLORIFY_STATE_VARNAME:
-				color = ctx->pal.comment;
-				break;
-			case UNICODE_COLORIFY_STATE_NUMBER:
-				color = ctx->pal.num;
-				break;
-			case UNICODE_COLORIFY_STATE_IL_OP:
-				color = ctx->pal.flow;
-				break;
-			}
+			color = core_il_get_token_color(state, color, ctx);
 
 			prev_state = state;
 			prev_i = i;
@@ -518,24 +523,8 @@ static void core_colorify_il_statement_unicode_to_strbuf(RzConsContext *ctx, con
 			} else {
 				rz_strbuf_appendf(sb, "%.*s", plen, il_stmt + prev_i);
 			}
-			switch (state) {
-			default: break;
-			case UNICODE_COLORIFY_STATE_DEFAULT:
-				color = NULL;
-				break;
-			case UNICODE_COLORIFY_STATE_PARENTHESIS:
-				color = ctx->pal.meta;
-				break;
-			case UNICODE_COLORIFY_STATE_VARNAME:
-				color = ctx->pal.comment;
-				break;
-			case UNICODE_COLORIFY_STATE_NUMBER:
-				color = ctx->pal.num;
-				break;
-			case UNICODE_COLORIFY_STATE_IL_OP:
-				color = ctx->pal.flow;
-				break;
-			}
+
+			color = core_il_get_token_color(state, color, ctx);
 
 			prev_state = state;
 			prev_i = i;
@@ -551,6 +540,18 @@ static void core_colorify_il_statement_unicode_to_strbuf(RzConsContext *ctx, con
 		}
 	}
 	rz_strbuf_appendf(sb, "\n");
+}
+
+static ut64 core_il_get_refline_at(ut64 vat, RZ_NONNULL RzPVector /*<RzAnalysisRefline *>*/ *reflines) {
+	rz_return_val_if_fail(reflines, UT64_MAX);
+	void **iter;
+	rz_pvector_foreach (reflines, iter) {
+		RzAnalysisRefline *ref = *iter;
+		if (ref->from == vat) {
+			return ref->to;
+		}
+	}
+	return UT64_MAX;
 }
 
 /* \brief formatted rzil from a starting RVA to a RzPVector of DisasmTexts
@@ -583,7 +584,7 @@ RZ_API int rz_core_il_print_rzil(RZ_NONNULL RzCore *core, ut64 addr, RZ_NONNULL 
 	const char *il_stmt = NULL;
 	const char delim = pretty ? '\n' : ' ';
 	RzStrBuf sb;
-	RzPVector *reflines;
+	RzPVector /*<RzAnalysisRefline *>*/ *reflines;
 	RzAnalysisOp op;
 	int ops_count = 0, inc = 0, idx;
 	ut64 current = addr, vat;
@@ -601,16 +602,13 @@ complete:
 		if (p) {
 			core->asmqjmps_size = RZ_CORE_ASMQJMPS_NUM;
 			core->asmqjmps = p;
-			for (int i = 0; i < RZ_CORE_ASMQJMPS_NUM; i++) {
-				core->asmqjmps[i] = UT64_MAX;
-			}
+			memset(core->asmqjmps, 0xff, RZ_CORE_ASMQJMPS_NUM * sizeof(ut64));
 		}
 	}
 	for (idx = 0; ops_count < n_lines && idx < len; ops_count++, idx += inc) {
 		current = addr + idx;
 		RzAnalysisDisasmText *dst = RZ_NEW0(RzAnalysisDisasmText);
 		dst->arrow = UT64_MAX;
-		vat = rz_core_pava(core, current);
 		rz_strbuf_init(&sb);
 		if (core->print->flags & RZ_PRINT_FLAGS_UNALLOC) {
 			if (!rz_io_is_valid_offset(core->io, current, 0)) {
@@ -636,16 +634,15 @@ complete:
 			const int addr_len = snprintf(NULL, 0, "0x%" PFMT64x, op.addr);
 			RzILStringifyCtx ctx = { .indent = addr_len + 1, .indent_inc = 2 };
 			if (!rz_il_op_effect_stringify_unicode(&ctx, op.il_op, &sb)) {
-				RZ_LOG_ERROR("Failed to stringify IL at 0x%08" PFMT64x "\n", op.addr);
-				rz_strbuf_appendf(&sb, "0x%" PFMT64x "%cstringify failed", op.addr, delim);
+				RZ_LOG_ERROR("Failed to stringify unicode IL at 0x%08" PFMT64x "\n", op.addr);
+				rz_strbuf_appendf(&sb, "0x%" PFMT64x "%c ustringify failed", op.addr, delim);
 				goto finalize;
 			}
 		} else {
 			rz_il_op_effect_stringify(op.il_op, &sb, pretty);
 		}
 
-		il_stmt = rz_str_dup(rz_strbuf_get(&sb));
-		rz_strbuf_fini(&sb);
+		il_stmt = rz_strbuf_drain_nofree(&sb);
 		rz_strbuf_init(&sb);
 		if (colorize) {
 			if (unicode) {
@@ -656,28 +653,20 @@ complete:
 		} else {
 			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%c%s", op.addr, delim, il_stmt);
 		}
-		RZ_FREE(il_stmt)
-		if (reflines) {
-			void **iter;
-			rz_pvector_foreach (reflines, iter) {
-				RzAnalysisRefline *ref = *iter;
-				if (ref->from == vat) {
-					dst->arrow = ref->to;
-					break;
-				}
-			}
-		}
+		RZ_FREE(il_stmt);
+		vat = rz_core_pava(core, current);
+		dst->arrow = core_il_get_refline_at(vat, reflines);
+
 	finalize:
 		rz_analysis_op_fini(&op);
 	finish_str:
 		dst->offset = rz_core_pava(core, current);
-		dst->text = rz_str_dup(rz_strbuf_get(&sb));
+		dst->text = rz_strbuf_drain_nofree(&sb);
 		inc = inc ? inc : RZ_MAX(1, min_op_size);
 		if (!rz_pvector_push(vec, dst)) {
 			free(dst->text);
 			free(dst);
 		}
-		rz_strbuf_fini(&sb);
 	}
 	rz_analysis_set_reflines(core->analysis, NULL);
 	rz_pvector_free(reflines);

--- a/librz/core/cil.c
+++ b/librz/core/cil.c
@@ -17,6 +17,7 @@ typedef struct il_print_t {
 	const char *name;
 	void *ptr;
 } ILPrint;
+
 #define p_sb(x)  ((RzStrBuf *)x)
 #define p_tbl(x) ((RzTable *)x)
 #define p_pj(x)  ((PJ *)x)
@@ -436,6 +437,7 @@ RzILUnicodeColorifyState unicode_colorify_state_next(RzILUnicodeColorifyState st
 	}
 	return UNICODE_COLORIFY_STATE_IL_OP;
 }
+
 static const char *core_il_get_token_color(RzILUnicodeColorifyState state, const char *prev_color, RZ_NONNULL RzConsContext *ctx) {
 	rz_return_val_if_fail(ctx, NULL);
 	const char *color = prev_color;
@@ -516,28 +518,32 @@ static void core_colorify_il_statement_unicode_to_strbuf(RzConsContext *ctx, con
 		RzCodePoint cp = 0;
 		const size_t utf_size = rz_utf8_decode((const ut8 *)il_stmt + i, len - i, &cp, false);
 		RzILUnicodeColorifyState state = unicode_colorify_state_next(prev_state, cp);
-		if (state != prev_state) {
-			const int plen = i - prev_i;
-			if (color) {
-				rz_strbuf_appendf(sb, "%s%.*s" Color_RESET, color, plen, il_stmt + prev_i);
-			} else {
-				rz_strbuf_appendf(sb, "%.*s", plen, il_stmt + prev_i);
-			}
-
-			color = core_il_get_token_color(state, color, ctx);
-
-			prev_state = state;
-			prev_i = i;
+		if (state == prev_state) {
+			i += utf_size > 0 ? utf_size : 1;
+			continue;
 		}
-		i += utf_size > 0 ? utf_size : 1;
-	}
-	if (prev_i < len) {
-		const int plen = len - prev_i;
+		const int plen = i - prev_i;
 		if (color) {
 			rz_strbuf_appendf(sb, "%s%.*s" Color_RESET, color, plen, il_stmt + prev_i);
 		} else {
 			rz_strbuf_appendf(sb, "%.*s", plen, il_stmt + prev_i);
 		}
+
+		color = core_il_get_token_color(state, color, ctx);
+
+		prev_state = state;
+		prev_i = i;
+		i += utf_size > 0 ? utf_size : 1;
+	}
+	if (prev_i >= len){
+		rz_strbuf_appendf(sb, "\n");
+		return;
+	}
+	const int plen = len - prev_i;
+	if (color) {
+		rz_strbuf_appendf(sb, "%s%.*s" Color_RESET, color, plen, il_stmt + prev_i);
+	} else {
+		rz_strbuf_appendf(sb, "%.*s", plen, il_stmt + prev_i);
 	}
 	rz_strbuf_appendf(sb, "\n");
 }
@@ -554,135 +560,220 @@ static ut64 core_il_get_refline_at(ut64 vat, RZ_NONNULL RzPVector /*<RzAnalysisR
 	return UT64_MAX;
 }
 
-/* \brief formatted rzil from a starting RVA to a RzPVector of DisasmTexts
- * \param core - rz core
- * \param vec - allocated rzpvector pointer with free function for disasm_text
- * \param addr - starting address of instructions
- * \param n_lines - number of lines to be represented as rzil
- * \param pretty - whether add delimitter or not
- * \param unicode - whether enable unicode formatting or not
- * \param colorize - color the text
- */
-RZ_API int rz_core_il_print_rzil(RZ_NONNULL RzCore *core, ut64 addr, RZ_NONNULL ut8 *buf, int len, int n_lines, RZ_NULLABLE RzCoreILPrintOptions *options) {
-	rz_return_val_if_fail(core && buf && (n_lines || len), 0);
-	RzPVector *vec = NULL;
-	bool pretty = false;
-	bool unicode = false;
-	bool colorize = false;
-	if (options) {
-		pretty = options->pretty;
-		colorize = options->colorize;
-		unicode = options->unicode;
-		vec = options->vec;
+static void init_asmqjmps(RZ_NONNULL RzCore *core) {
+	rz_return_if_fail(core);
+    if (core->keep_asmqjmps) {
+        return;
+    }
+    core->asmqjmps_count = 0;
+    ut64 *p = realloc(core->asmqjmps, RZ_CORE_ASMQJMPS_NUM * sizeof(ut64));
+    if (p) {
+        core->asmqjmps_size = RZ_CORE_ASMQJMPS_NUM;
+        core->asmqjmps = p;
+        memset(core->asmqjmps, 0xff, RZ_CORE_ASMQJMPS_NUM * sizeof(ut64));
+    }
+}
+
+typedef struct il_state_t {
+	RzCore *core;
+	RzCoreILPrintOptions *options;
+
+	ut64 addr;
+	ut64 current;
+	ut64 vat;
+
+	ut8 *buf;
+	ut8 *addbuf;
+	int len;
+
+	int idx;
+	int inc;
+	int ops_count;
+	int n_lines;
+	ut8 min_op_size;
+
+	RzStrBuf *sb;
+	RzAnalysisDisasmText *dst;
+
+	RzPVector /*<RzAnalysisRefline *>*/ *reflines;
+} RzILState;
+
+static RzILState *il_state_init(RZ_NONNULL RzCore *core){
+	RzILState *ils = RZ_NEW0(RzILState);
+	ils->core = core;
+	ils->sb = RZ_NEW0(RzStrBuf);
+	rz_strbuf_init(ils->sb);
+	return ils;
+}
+
+static void il_state_init_reflines(RzILState *ils){
+	rz_return_if_fail(ils && ils->core && ils->buf && (ils->len || ils->n_lines));
+	ils->reflines = rz_analysis_reflines_get(ils->core->analysis,
+		ils->addr, ils->buf, ils->len, ils->n_lines,
+		rz_config_get_i(ils->core->config, "asm.lines.out"),
+		rz_config_get_b(ils->core->config, "asm.lines") ? rz_config_get_b(ils->core->config, "asm.lines.call") : false);
+	rz_analysis_set_reflines(ils->core->analysis, ils->reflines);
+}
+
+static void core_il_stringify_single_il(RzILState *ils){
+	const char *il_stmt = NULL;
+	const char delim = ils->options->pretty ? '\n' : ' ';
+	RzAnalysisOp op;
+
+	ils->current = ils->addr + ils->idx;
+	ils->vat = rz_core_pava(ils->core, ils->current);
+
+	ils->dst = RZ_NEW0(RzAnalysisDisasmText);
+	ils->dst->arrow = UT64_MAX;
+
+	rz_strbuf_fini(ils->sb);
+	rz_strbuf_init(ils->sb);
+	if (ils->core->print->flags & RZ_PRINT_FLAGS_UNALLOC) {
+		if (!rz_io_is_valid_offset(ils->core->io, ils->current, 0)) {
+			rz_strbuf_appendf(ils->sb, "0x%" PFMT64x "%cunmapped", ils->current, delim);
+			ils->inc = 1;
+			goto finish_str;
+		}
 	}
-	if (!vec) {
+	rz_core_seek_arch_bits(ils->core, ils->current);
+	rz_analysis_op_init(&op);
+	if (rz_analysis_op(ils->core->analysis, &op, ils->current, ils->buf + ils->idx, (int)(ils->len - ils->idx), RZ_ANALYSIS_OP_MASK_IL) < 1) {
+		rz_strbuf_appendf(ils->sb, "0x%" PFMT64x "%cinvalid", ils->current, delim);
+		ils->inc = 1;
+		goto finalize;
+	}
+	ils->inc = op.size;
+	if (!op.il_op) {
+		RZ_LOG_DEBUG("Empty IL at 0x%08" PFMT64x "...", op.addr);
+		rz_strbuf_appendf(ils->sb, "0x%" PFMT64x "%cempty il", op.addr, delim);
+		goto finalize;
+	}
+	if (ils->options->unicode) {
+		const int addr_len = snprintf(NULL, 0, "0x%" PFMT64x, op.addr);
+		RzILStringifyCtx ctx = { .indent = addr_len + 1, .indent_inc = 2 };
+		if (!rz_il_op_effect_stringify_unicode(&ctx, op.il_op, ils->sb)) {
+			RZ_LOG_ERROR("Failed to stringify unicode IL at 0x%08" PFMT64x "\n", op.addr);
+			rz_strbuf_appendf(ils->sb, "0x%" PFMT64x "%c ustringify failed", op.addr, delim);
+			goto finalize;
+		}
+	} else {
+		rz_il_op_effect_stringify(op.il_op, ils->sb, ils->options->pretty);
+	}
+
+	il_stmt = rz_strbuf_drain_nofree(ils->sb);
+	rz_strbuf_init(ils->sb);
+	if (ils->options->colorize) {
+		if (ils->options->unicode) {
+			core_colorify_il_statement_unicode_to_strbuf(ils->core->cons->context, il_stmt, delim, op.addr, ils->sb);
+		} else {
+			core_colorify_il_statement_to_strbuf(ils->core->cons->context, il_stmt, delim, op.addr, ils->sb);
+		}
+	} else {
+		rz_strbuf_appendf(ils->sb, "0x%" PFMT64x "%c%s", op.addr, delim, il_stmt);
+	}
+	RZ_FREE(il_stmt);
+	ils->dst->arrow = core_il_get_refline_at(ils->vat, ils->reflines);
+finalize:
+	rz_analysis_op_fini(&op);
+finish_str:
+	ils->dst->offset = ils->vat;
+	ils->dst->text = rz_strbuf_drain_nofree(ils->sb);
+	if(!ils->inc) ils->inc = RZ_MAX(1, ils->min_op_size);
+}
+
+static void il_state_fini_reflines(RzILState *ils){
+	if(ils){
+		rz_analysis_set_reflines(ils->core->analysis, NULL);
+		rz_pvector_free(ils->reflines);
+		ils->reflines = NULL;
+	}
+}
+
+static void il_state_free(RzILState *ils){
+	rz_strbuf_free(ils->sb);
+	il_state_fini_reflines(ils);
+	RZ_FREE(ils->addbuf);
+	free(ils);
+}
+
+static bool il_state_complete(RzILState *ils){
+	if (!ils->options->cbytes && ils->ops_count < ils->n_lines) {
+		ils->addr = ils->current + ils->inc;
+		if (ils->len < 16) {
+			ils->len = 16;
+		}
+		free(ils->addbuf);
+		ils->buf = ils->addbuf = malloc(ils->len);
+		if (ils->addbuf) {
+			rz_io_read_at_mapped(ils->core->io, ils->addr, ils->buf, ils->len);
+			return false;
+		}
+	}
+	return true;
+}
+
+/* \brief Generate formatted RzIL output and append it to a vector of disassembly text entries.
+ *
+ * Decodes instructions starting at the given address, converts their
+ * corresponding RzIL representations into printable text, optionally
+ * applying pretty-printing, Unicode formatting, and syntax coloring.
+ * The resulting strings are stored as RzAnalysisDisasmText entries in
+ * the supplied vector.
+ *
+ * \param core      RzCore instance.
+ * \param addr      Starting address of the instruction stream.
+ * \param buf       Buffer containing instruction bytes.
+ * \param len       Size of \p buf in bytes.
+ * \param n_lines   Maximum number of instructions to process. If zero,
+ *                  core->blocksize is used.
+ * \param options   Output formatting options and destination vector.
+ *
+ * \return Number of instructions successfully processed.
+ */
+RZ_API int rz_core_il_print_rzil(RZ_NONNULL RzCore *core, ut64 addr,
+	RZ_NONNULL ut8 *buf, int len, int n_lines,
+	RZ_NULLABLE RzCoreILPrintOptions *options) {
+	rz_return_val_if_fail(core && buf && (n_lines || len), 0);
+
+	if (!options->vec) {
 		return 0;
 	}
 	if (!n_lines) {
 		n_lines = core->blocksize;
 	}
-	const char *il_stmt = NULL;
-	const char delim = pretty ? '\n' : ' ';
-	RzStrBuf sb;
-	RzPVector /*<RzAnalysisRefline *>*/ *reflines;
-	RzAnalysisOp op;
-	int ops_count = 0, inc = 0, idx;
-	ut64 current = addr, vat;
-	ut8 *nbuf = NULL;
-	ut8 min_op_size = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE);
-complete:
-	reflines = rz_analysis_reflines_get(core->analysis,
-		addr, buf, len, n_lines,
-		rz_config_get_i(core->config, "asm.lines.out"),
-		rz_config_get_b(core->config, "asm.lines") ? rz_config_get_b(core->config, "asm.lines.call") : false);
-	rz_analysis_set_reflines(core->analysis, reflines);
-	if (!core->keep_asmqjmps) { // hack
-		core->asmqjmps_count = 0;
-		ut64 *p = realloc(core->asmqjmps, RZ_CORE_ASMQJMPS_NUM * sizeof(ut64));
-		if (p) {
-			core->asmqjmps_size = RZ_CORE_ASMQJMPS_NUM;
-			core->asmqjmps = p;
-			memset(core->asmqjmps, 0xff, RZ_CORE_ASMQJMPS_NUM * sizeof(ut64));
-		}
-	}
-	for (idx = 0; ops_count < n_lines && idx < len; ops_count++, idx += inc) {
-		current = addr + idx;
-		RzAnalysisDisasmText *dst = RZ_NEW0(RzAnalysisDisasmText);
-		dst->arrow = UT64_MAX;
-		rz_strbuf_init(&sb);
-		if (core->print->flags & RZ_PRINT_FLAGS_UNALLOC) {
-			if (!rz_io_is_valid_offset(core->io, current, 0)) {
-				rz_strbuf_appendf(&sb, "0x%" PFMT64x "%cunmapped", current, delim);
-				inc = 1;
-				goto finish_str;
+
+	RzILState *ils = il_state_init(core);
+	ils->addr = addr;
+	ils->buf = buf;
+	ils->len = len;
+	ils->n_lines = n_lines;
+	ils->options = options;
+	ils->min_op_size = rz_analysis_archinfo(core->analysis,
+		RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE);
+
+	do {
+		il_state_init_reflines(ils);
+		init_asmqjmps(core);
+
+		for (ils->idx = 0;
+			ils->ops_count < ils->n_lines && ils->idx < ils->len;
+			ils->ops_count++, ils->idx += ils->inc) {
+
+			core_il_stringify_single_il(ils);
+
+			if (!rz_pvector_push(ils->options->vec, ils->dst)) {
+				free(ils->dst->text);
+				free(ils->dst);
+				ils->dst = NULL;
 			}
-		}
-		rz_core_seek_arch_bits(core, current);
-		rz_analysis_op_init(&op);
-		if (rz_analysis_op(core->analysis, &op, current, buf + idx, (int)(len - idx), RZ_ANALYSIS_OP_MASK_IL) < 1) {
-			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%cinvalid", current, delim);
-			inc = 1;
-			goto finalize;
-		}
-		inc = op.size;
-		if (!op.il_op) {
-			RZ_LOG_DEBUG("Empty IL at 0x%08" PFMT64x "...", op.addr);
-			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%cempty il", op.addr, delim);
-			goto finalize;
-		}
-		if (unicode) {
-			const int addr_len = snprintf(NULL, 0, "0x%" PFMT64x, op.addr);
-			RzILStringifyCtx ctx = { .indent = addr_len + 1, .indent_inc = 2 };
-			if (!rz_il_op_effect_stringify_unicode(&ctx, op.il_op, &sb)) {
-				RZ_LOG_ERROR("Failed to stringify unicode IL at 0x%08" PFMT64x "\n", op.addr);
-				rz_strbuf_appendf(&sb, "0x%" PFMT64x "%c ustringify failed", op.addr, delim);
-				goto finalize;
-			}
-		} else {
-			rz_il_op_effect_stringify(op.il_op, &sb, pretty);
 		}
 
-		il_stmt = rz_strbuf_drain_nofree(&sb);
-		rz_strbuf_init(&sb);
-		if (colorize) {
-			if (unicode) {
-				core_colorify_il_statement_unicode_to_strbuf(core->cons->context, il_stmt, delim, op.addr, &sb);
-			} else {
-				core_colorify_il_statement_to_strbuf(core->cons->context, il_stmt, delim, op.addr, &sb);
-			}
-		} else {
-			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%c%s", op.addr, delim, il_stmt);
-		}
-		RZ_FREE(il_stmt);
-		vat = rz_core_pava(core, current);
-		dst->arrow = core_il_get_refline_at(vat, reflines);
+		il_state_fini_reflines(ils);
+	} while (!il_state_complete(ils));
 
-	finalize:
-		rz_analysis_op_fini(&op);
-	finish_str:
-		dst->offset = rz_core_pava(core, current);
-		dst->text = rz_strbuf_drain_nofree(&sb);
-		inc = inc ? inc : RZ_MAX(1, min_op_size);
-		if (!rz_pvector_push(vec, dst)) {
-			free(dst->text);
-			free(dst);
-		}
-	}
-	rz_analysis_set_reflines(core->analysis, NULL);
-	rz_pvector_free(reflines);
-	if (!options->cbytes && ops_count < n_lines) {
-		addr = current + inc;
-		if (len < 16) {
-			len = 16;
-		}
-		free(nbuf);
-		buf = nbuf = malloc(len);
-		if (nbuf) {
-			rz_io_read_at_mapped(core->io, addr, buf, len);
-			goto complete;
-		}
-	}
-	RZ_FREE(nbuf);
+	const int ops_count = ils->ops_count;
+
+	il_state_free(ils);
 	return ops_count;
 }
 

--- a/librz/core/cil.c
+++ b/librz/core/cil.c
@@ -553,48 +553,72 @@ static void core_colorify_il_statement_unicode_to_strbuf(RzConsContext *ctx, con
 	rz_strbuf_appendf(sb, "\n");
 }
 
-/* @brief formatted rzil from a starting RVA to a RzPVector of DisasmTexts
- * @param core - rz core
- * @param vec - allocated rzpvector pointer with free function for disasm_text
- * @param addr - starting address of instructions
- * @param n_lines - number of lines to be represented as rzil
- * @param pretty - whether add delimitter or not
- * @param unicode - whether enable unicode formatting or not
- * @param colorize - color the text
+/* \brief formatted rzil from a starting RVA to a RzPVector of DisasmTexts
+ * \param core - rz core
+ * \param vec - allocated rzpvector pointer with free function for disasm_text
+ * \param addr - starting address of instructions
+ * \param n_lines - number of lines to be represented as rzil
+ * \param pretty - whether add delimitter or not
+ * \param unicode - whether enable unicode formatting or not
+ * \param colorize - color the text
  */
-
 RZ_API void rz_core_il_print_rzil(RZ_NONNULL RzCore *core, RZ_NONNULL RzPVector *vec, ut64 addr, int n_lines, bool pretty, bool unicode, bool colorize) {
 	rz_return_if_fail(core && vec);
-	RzIterator *iter = rz_core_analysis_op_chunk_iter(core, addr, 0, n_lines, RZ_ANALYSIS_OP_MASK_IL);
-	rz_return_if_fail(iter);
 	const char *il_stmt = NULL;
 	const char delim = pretty ? '\n' : ' ';
 	RzStrBuf sb;
-
-	RzAnalysisILVM *vm = rz_analysis_il_vm_new(core->analysis, NULL);
-	RzILValidateGlobalContext *ctx = vm ? rz_il_validate_global_context_new_from_vm(vm->vm)
-					    : NULL;
-
-	RzAnalysisOp *op = NULL;
-	rz_iterator_foreach(iter, op) {
-		rz_strbuf_init(&sb);
-		RzAnalysisDisasmText *dst = RZ_NEW0(RzAnalysisDisasmText);
-		if (!op->il_op) {
-			RZ_LOG_DEBUG("Empty IL at 0x%08" PFMT64x "...\n", op->addr);
-			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%cempty il\n", op->addr, delim);
-			goto togo;
+	RzAnalysisOp op;
+	RzPVector *reflines = rz_analysis_reflines_get(core->analysis,
+		addr, core->block, core->blocksize, n_lines,
+		rz_config_get_i(core->config, "asm.lines.out"),
+		rz_config_get_b(core->config, "asm.lines") ? rz_config_get_b(core->config, "asm.lines.call") : false);
+	rz_analysis_set_reflines(core->analysis, reflines);
+	int ops_count = 0;
+	ut64 current = addr, vat;
+	ut8 bytes[256];
+	ut8 min_op_size = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE);
+	if (!core->keep_asmqjmps) { // hack
+		core->asmqjmps_count = 0;
+		ut64 *p = realloc(core->asmqjmps, RZ_CORE_ASMQJMPS_NUM * sizeof(ut64));
+		if (p) {
+			core->asmqjmps_size = RZ_CORE_ASMQJMPS_NUM;
+			core->asmqjmps = p;
+			for (int i = 0; i < RZ_CORE_ASMQJMPS_NUM; i++) {
+				core->asmqjmps[i] = UT64_MAX;
+			}
 		}
-
+	}
+	while (ops_count < n_lines) {
+		rz_core_seek_arch_bits(core, current);
+		RzAnalysisDisasmText *dst = RZ_NEW0(RzAnalysisDisasmText);
+		dst->arrow = UT64_MAX;
+		vat = rz_core_pava(core, current);
+		rz_strbuf_init(&sb);
+		int read = rz_io_nread_at(core->io, current, bytes, sizeof(bytes));
+		if (read < 1) {
+			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%creaderror", current, delim);
+			goto finish_str;
+		}
+		rz_analysis_op_init(&op);
+		if (rz_analysis_op(core->analysis, &op, current, bytes, read, RZ_ANALYSIS_OP_MASK_IL) < 1) {
+			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%cinvalid", current, delim);
+			goto finalize;
+		}
+		if (!op.il_op) {
+			RZ_LOG_DEBUG("Empty IL at 0x%08" PFMT64x "...", op.addr);
+			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%cempty il", op.addr, delim);
+			goto finalize;
+		}
 		if (unicode) {
-			const int addr_len = snprintf(NULL, 0, "0x%" PFMT64x, op->addr);
+			const int addr_len = snprintf(NULL, 0, "0x%" PFMT64x, op.addr);
 			RzILStringifyCtx ctx = { .indent = addr_len + 1, .indent_inc = 2 };
-			if (!rz_il_op_effect_stringify_unicode(&ctx, op->il_op, &sb)) {
-				RZ_LOG_ERROR("Failed to stringify IL at 0x%08" PFMT64x "\n", op->addr);
-				rz_strbuf_appendf(&sb, "0x%" PFMT64x "%cstringify failed\n", op->addr, delim);
-				goto togo;
+			if (!rz_il_op_effect_stringify_unicode(&ctx, op.il_op, &sb)) {
+				RZ_LOG_ERROR("Failed to stringify IL at 0x%08" PFMT64x "\n", op.addr);
+				rz_strbuf_appendf(&sb, "0x%" PFMT64x "%cstringify failed", op.addr, delim);
+				goto finalize;
 			}
 		} else {
-			rz_il_op_effect_stringify(op->il_op, &sb, pretty);
+			rz_il_op_effect_stringify(op.il_op, &sb, pretty);
 		}
 
 		il_stmt = rz_str_dup(rz_strbuf_get(&sb));
@@ -602,34 +626,39 @@ RZ_API void rz_core_il_print_rzil(RZ_NONNULL RzCore *core, RZ_NONNULL RzPVector 
 		rz_strbuf_init(&sb);
 		if (colorize) {
 			if (unicode) {
-				core_colorify_il_statement_unicode_to_strbuf(core->cons->context, il_stmt, delim, op->addr, &sb);
+				core_colorify_il_statement_unicode_to_strbuf(core->cons->context, il_stmt, delim, op.addr, &sb);
 			} else {
-				core_colorify_il_statement_to_strbuf(core->cons->context, il_stmt, delim, op->addr, &sb);
+				core_colorify_il_statement_to_strbuf(core->cons->context, il_stmt, delim, op.addr, &sb);
 			}
 		} else {
-			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%c%s\n", op->addr, delim, il_stmt);
+			rz_strbuf_appendf(&sb, "0x%" PFMT64x "%c%s", op.addr, delim, il_stmt);
 		}
-
-	// if (ctx) {
-	// 	RzILTypeEffect t;
-	// 	char *report;
-	// 	rz_il_validate_effect(op->il_op, ctx, NULL, &t, &report);
-	// 	if (report) {
-	// 		rz_cons_println(report);
-	// 		free(report);
-	// 	}
-	// }
-	togo:
-		dst->offset = op->addr;
-		dst->arrow = UT64_MAX;
+		free((void *)il_stmt);
+		if (reflines) {
+			void **iter;
+			rz_pvector_foreach (reflines, iter) {
+				RzAnalysisRefline *ref = *iter;
+				if (ref->from == vat) {
+					dst->arrow = ref->to;
+					break;
+				}
+			}
+		}
+	finalize:
+		rz_analysis_op_fini(&op);
+	finish_str:
+		dst->offset = rz_core_pava(core, current);
 		dst->text = rz_str_dup(rz_strbuf_get(&sb));
-		rz_pvector_push(vec, dst);
-		rz_cons_reset();
+		current += op.size > 0 ? op.size : min_op_size;
+		ops_count++;
+		if (!rz_pvector_push(vec, dst)) {
+			free(dst->text);
+			free(dst);
+		}
 		rz_strbuf_fini(&sb);
 	}
-	rz_analysis_il_vm_free(vm);
-	rz_il_validate_global_context_free(ctx);
-	rz_iterator_free(iter);
+	rz_analysis_set_reflines(core->analysis, NULL);
+	rz_pvector_free(reflines);
 }
 
 RZ_IPI void rz_core_il_cons_print(RZ_NONNULL RzCore *core, RZ_NONNULL RZ_BORROW RzIterator *iter, bool pretty, bool unicode) {

--- a/librz/core/cil.c
+++ b/librz/core/cil.c
@@ -489,6 +489,72 @@ static void core_colorify_il_statement_unicode(RzConsContext *ctx, const char *i
 	rz_cons_newline();
 }
 
+RZ_API void rz_core_il_print_rzil(RZ_NONNULL RzCore *core, RZ_NONNULL RzPVector *vec, bool pretty, bool unicode, bool colorize) {
+	RzAnalysisFunction *f = rz_analysis_first_function_in(core->analysis, core->offset);
+	rz_return_if_fail(f);
+	RzIterator *iter = rz_core_analysis_op_function_iter(core, f, RZ_ANALYSIS_OP_MASK_IL);
+	rz_return_if_fail(core && iter);
+	const char *il_stmt = NULL;
+	const char delim = pretty ? '\n' : ' ';
+	RzStrBuf sb;
+
+	RzAnalysisILVM *vm = rz_analysis_il_vm_new(core->analysis, NULL);
+	RzILValidateGlobalContext *ctx = vm ? rz_il_validate_global_context_new_from_vm(vm->vm)
+					    : NULL;
+
+	RzAnalysisOp *op = NULL;
+	rz_iterator_foreach(iter, op) {
+		RzAnalysisDisasmText *dst = RZ_NEW0(RzAnalysisDisasmText);
+		if (!op->il_op) {
+			RZ_LOG_DEBUG("Empty IL at 0x%08" PFMT64x "...\n", op->addr);
+			break;
+		}
+
+		rz_strbuf_init(&sb);
+		if (unicode) {
+			const int addr_len = snprintf(NULL, 0, "0x%" PFMT64x, op->addr);
+			RzILStringifyCtx ctx = { .indent = addr_len + 1, .indent_inc = 2 };
+			if (!rz_il_op_effect_stringify_unicode(&ctx, op->il_op, &sb)) {
+				RZ_LOG_ERROR("Failed to stringify IL at 0x%08" PFMT64x "\n", op->addr);
+				rz_strbuf_fini(&sb);
+				break;
+			}
+		} else {
+			rz_il_op_effect_stringify(op->il_op, &sb, pretty);
+		}
+
+		il_stmt = rz_strbuf_get(&sb);
+		if (colorize) {
+			if (unicode) {
+				core_colorify_il_statement_unicode(core->cons->context, il_stmt, delim, op->addr);
+			} else {
+				core_colorify_il_statement(core->cons->context, il_stmt, delim, op->addr);
+			}
+		} else {
+			rz_cons_printf("0x%" PFMT64x "%c%s\n", op->addr, delim, il_stmt);
+		}
+
+		if (ctx) {
+			RzILTypeEffect t;
+			char *report;
+			rz_il_validate_effect(op->il_op, ctx, NULL, &t, &report);
+			if (report) {
+				rz_cons_println(report);
+				free(report);
+			}
+		}
+		dst->offset = op->addr;
+		dst->arrow = UT64_MAX;
+		dst->text = rz_str_dup(rz_cons_get_buffer());
+		rz_pvector_push(vec, dst);
+		rz_cons_reset();
+		rz_strbuf_fini(&sb);
+	}
+	rz_analysis_il_vm_free(vm);
+	rz_il_validate_global_context_free(ctx);
+	rz_iterator_free(iter);
+}
+
 RZ_IPI void rz_core_il_cons_print(RZ_NONNULL RzCore *core, RZ_NONNULL RZ_BORROW RzIterator *iter, bool pretty, bool unicode) {
 	rz_return_if_fail(core && iter);
 	bool colorize = rz_config_get_i(core->config, "scr.color") > 0;

--- a/librz/core/cil.c
+++ b/librz/core/cil.c
@@ -363,6 +363,42 @@ static inline void emit_span_to_strbuf(const char *s, size_t n, const char *colo
 	}
 }
 
+/**
+ * \brief Colorize a stringified RzIL effect body to the cons buffer.
+ *
+ * Emits only the body (no address prefix, no newline) with the same palette
+ * as \c plf. A NULL or empty \p il_stmt emits nothing.
+ */
+RZ_IPI void rz_core_il_colorize_body(RZ_NONNULL RzConsContext *ctx, RZ_NULLABLE const char *il_stmt) {
+	rz_return_if_fail(ctx);
+	if (RZ_STR_ISEMPTY(il_stmt)) {
+		return;
+	}
+
+	const char *color = NULL;
+	size_t prev = 0, len = strlen(il_stmt);
+
+	for (size_t i = 0; i < len; ++i) {
+		const char ch = il_stmt[i];
+
+		if (ch == '(' || ch == ')') {
+			emit_span(il_stmt + prev, i - prev, color);
+			rz_cons_printf("%s%c" Color_RESET, ctx->pal.meta, ch);
+			prev = i + 1;
+			color = (ch == '(') ? ctx->pal.flow : NULL;
+		} else if (ch == ' ') {
+			emit_span(il_stmt + prev, i - prev, color);
+			rz_cons_printf(" ");
+			prev = i + 1;
+			color = NULL;
+		} else if (i == prev && prev > 0 && il_stmt[prev - 1] == ' ') {
+			color = IS_DIGIT(ch) ? ctx->pal.num : ctx->pal.comment;
+		}
+	}
+
+	emit_span(il_stmt + prev, len - prev, color);
+}
+
 static void core_colorify_il_statement(RzConsContext *ctx, const char *il_stmt, const char delim, ut64 addr) {
 	rz_cons_printf("%s0x%" PFMT64x Color_RESET "%c", ctx->pal.label, addr, delim);
 	rz_core_il_colorize_body(ctx, il_stmt);
@@ -535,7 +571,7 @@ static void core_colorify_il_statement_unicode_to_strbuf(RzConsContext *ctx, con
 		prev_i = i;
 		i += utf_size > 0 ? utf_size : 1;
 	}
-	if (prev_i >= len){
+	if (prev_i >= len) {
 		rz_strbuf_appendf(sb, "\n");
 		return;
 	}
@@ -562,16 +598,16 @@ static ut64 core_il_get_refline_at(ut64 vat, RZ_NONNULL RzPVector /*<RzAnalysisR
 
 static void init_asmqjmps(RZ_NONNULL RzCore *core) {
 	rz_return_if_fail(core);
-    if (core->keep_asmqjmps) {
-        return;
-    }
-    core->asmqjmps_count = 0;
-    ut64 *p = realloc(core->asmqjmps, RZ_CORE_ASMQJMPS_NUM * sizeof(ut64));
-    if (p) {
-        core->asmqjmps_size = RZ_CORE_ASMQJMPS_NUM;
-        core->asmqjmps = p;
-        memset(core->asmqjmps, 0xff, RZ_CORE_ASMQJMPS_NUM * sizeof(ut64));
-    }
+	if (core->keep_asmqjmps) {
+		return;
+	}
+	core->asmqjmps_count = 0;
+	ut64 *p = realloc(core->asmqjmps, RZ_CORE_ASMQJMPS_NUM * sizeof(ut64));
+	if (p) {
+		core->asmqjmps_size = RZ_CORE_ASMQJMPS_NUM;
+		core->asmqjmps = p;
+		memset(core->asmqjmps, 0xff, RZ_CORE_ASMQJMPS_NUM * sizeof(ut64));
+	}
 }
 
 typedef struct il_state_t {
@@ -584,12 +620,12 @@ typedef struct il_state_t {
 
 	ut8 *buf;
 	ut8 *addbuf;
-	int len;
+	size_t len;
 
-	int idx;
-	int inc;
-	int ops_count;
-	int n_lines;
+	size_t idx;
+	size_t inc;
+	size_t ops_count;
+	size_t n_lines;
 	ut8 min_op_size;
 
 	RzStrBuf *sb;
@@ -598,7 +634,7 @@ typedef struct il_state_t {
 	RzPVector /*<RzAnalysisRefline *>*/ *reflines;
 } RzILState;
 
-static RzILState *il_state_init(RZ_NONNULL RzCore *core){
+static RzILState *il_state_init(RZ_NONNULL RzCore *core) {
 	RzILState *ils = RZ_NEW0(RzILState);
 	ils->core = core;
 	ils->sb = RZ_NEW0(RzStrBuf);
@@ -606,7 +642,7 @@ static RzILState *il_state_init(RZ_NONNULL RzCore *core){
 	return ils;
 }
 
-static void il_state_init_reflines(RzILState *ils){
+static void il_state_reflines_init(RzILState *ils) {
 	rz_return_if_fail(ils && ils->core && ils->buf && (ils->len || ils->n_lines));
 	ils->reflines = rz_analysis_reflines_get(ils->core->analysis,
 		ils->addr, ils->buf, ils->len, ils->n_lines,
@@ -615,7 +651,7 @@ static void il_state_init_reflines(RzILState *ils){
 	rz_analysis_set_reflines(ils->core->analysis, ils->reflines);
 }
 
-static void core_il_stringify_single_il(RzILState *ils){
+static void core_il_stringify_single_il(RzILState *ils) {
 	const char *il_stmt = NULL;
 	const char delim = ils->options->pretty ? '\n' : ' ';
 	RzAnalysisOp op;
@@ -678,25 +714,26 @@ finalize:
 finish_str:
 	ils->dst->offset = ils->vat;
 	ils->dst->text = rz_strbuf_drain_nofree(ils->sb);
-	if(!ils->inc) ils->inc = RZ_MAX(1, ils->min_op_size);
+	if (!ils->inc)
+		ils->inc = RZ_MAX(1, ils->min_op_size);
 }
 
-static void il_state_fini_reflines(RzILState *ils){
-	if(ils){
+static void il_state_reflines_fini(RzILState *ils) {
+	if (ils) {
 		rz_analysis_set_reflines(ils->core->analysis, NULL);
 		rz_pvector_free(ils->reflines);
 		ils->reflines = NULL;
 	}
 }
 
-static void il_state_free(RzILState *ils){
+static void il_state_free(RzILState *ils) {
 	rz_strbuf_free(ils->sb);
-	il_state_fini_reflines(ils);
+	il_state_reflines_fini(ils);
 	RZ_FREE(ils->addbuf);
 	free(ils);
 }
 
-static bool il_state_complete(RzILState *ils){
+static bool il_state_complete(RzILState *ils) {
 	if (!ils->options->cbytes && ils->ops_count < ils->n_lines) {
 		ils->addr = ils->current + ils->inc;
 		if (ils->len < 16) {
@@ -712,27 +749,24 @@ static bool il_state_complete(RzILState *ils){
 	return true;
 }
 
-/* \brief Generate formatted RzIL output and append it to a vector of disassembly text entries.
+/* \brief Format instructions and add generated RzIL code to an analysis text vector.
  *
- * Decodes instructions starting at the given address, converts their
- * corresponding RzIL representations into printable text, optionally
- * applying pretty-printing, Unicode formatting, and syntax coloring.
- * The resulting strings are stored as RzAnalysisDisasmText entries in
- * the supplied vector.
+ * Decode instructions starting at the specified address, format their
+ * RzIL equivalents into printable strings, using optional pretty printing,
+ * unicode conversion and syntax highlighting, then store the strings as
+ * RzAnalysisDisasmText entries in the vector provided.
  *
- * \param core      RzCore instance.
- * \param addr      Starting address of the instruction stream.
- * \param buf       Buffer containing instruction bytes.
- * \param len       Size of \p buf in bytes.
- * \param n_lines   Maximum number of instructions to process. If zero,
- *                  core->blocksize is used.
- * \param options   Output formatting options and destination vector.
+ * \param core      Pointer to the current RzCore instance.
+ * \param addr      Starting address for instruction decoding.
+ * \param buf       Pointer to memory buffer that contains instructions.
+ * \param len       Length of \p buf in bytes.
+ * \param n_lines   Maximum number of instructions to decode. Uses
+ *                  core->blocksize if value is 0.
+ * \param options   Formatting parameters and vector for storing results.
  *
- * \return Number of instructions successfully processed.
+ * \return Number of instructions decoded successfully.
  */
-RZ_API int rz_core_il_print_rzil(RZ_NONNULL RzCore *core, ut64 addr,
-	RZ_NONNULL ut8 *buf, int len, int n_lines,
-	RZ_NULLABLE RzCoreILPrintOptions *options) {
+RZ_API int rz_core_il_print_rzil(RZ_NONNULL RzCore *core, ut64 addr, RZ_NONNULL ut8 *buf, size_t len, size_t n_lines, RZ_NULLABLE RzCoreILPrintOptions *options) {
 	rz_return_val_if_fail(core && buf && (n_lines || len), 0);
 
 	if (!options->vec) {
@@ -748,16 +782,13 @@ RZ_API int rz_core_il_print_rzil(RZ_NONNULL RzCore *core, ut64 addr,
 	ils->len = len;
 	ils->n_lines = n_lines;
 	ils->options = options;
-	ils->min_op_size = rz_analysis_archinfo(core->analysis,
-		RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE);
+	ils->min_op_size = rz_analysis_archinfo(core->analysis, RZ_ANALYSIS_ARCHINFO_MIN_OP_SIZE);
 
 	do {
-		il_state_init_reflines(ils);
+		il_state_reflines_init(ils);
 		init_asmqjmps(core);
 
-		for (ils->idx = 0;
-			ils->ops_count < ils->n_lines && ils->idx < ils->len;
-			ils->ops_count++, ils->idx += ils->inc) {
+		for (ils->idx = 0; ils->ops_count < ils->n_lines && ils->idx < ils->len; ils->ops_count++, ils->idx += ils->inc) {
 
 			core_il_stringify_single_il(ils);
 
@@ -767,8 +798,7 @@ RZ_API int rz_core_il_print_rzil(RZ_NONNULL RzCore *core, ut64 addr,
 				ils->dst = NULL;
 			}
 		}
-
-		il_state_fini_reflines(ils);
+		il_state_reflines_fini(ils);
 	} while (!il_state_complete(ils));
 
 	const int ops_count = ils->ops_count;

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -965,6 +965,8 @@ RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_bwdisassemble(RzCore *core, ut64
 RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_back_disassemble_instr(RzCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_back_disassemble_byte(RzCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 RZ_API ut32 rz_core_asm_bwdis_len(RzCore *core, int *len, ut64 *start_addr, ut32 l);
+RZ_API void rz_core_il_print_rzil(RZ_NONNULL RzCore *core, RZ_NONNULL RzPVector *vec, bool pretty, bool unicode, bool colorize);
+
 RZ_API int rz_core_print_disasm(RZ_NONNULL RzCore *core, ut64 addr, RZ_NONNULL ut8 *buf, int len, int nlines, RZ_NULLABLE RzCmdStateOutput *state, RZ_NULLABLE RzCoreDisasmOptions *options);
 RZ_API int rz_core_print_disasm_json(RzCore *core, ut64 addr, ut8 *buf, int len, int lines, PJ *pj);
 RZ_API int rz_core_print_disasm_instructions_with_buf(RzCore *core, ut64 address, ut8 *buf, int nb_bytes, int nb_opcodes);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -750,7 +750,6 @@ RZ_API RzCmdStatus rz_core_lang_plugins_print(RzLang *lang, RzCmdStateOutput *st
 /* ccore.c */
 RZ_API RzCmdStatus rz_core_core_plugins_print(RzCore *core, RzCmdStateOutput *state);
 
-/* cil.c */
 RZ_API void rz_core_analysis_esil(RzCore *core, ut64 addr, ut64 size, RZ_NULLABLE RzAnalysisFunction *fcn);
 RZ_API bool rz_core_esil_cmd(RzAnalysisEsil *esil, const char *cmd, ut64 a1, ut64 a2);
 RZ_API int rz_core_esil_step(RzCore *core, ut64 until_addr, const char *until_expr, ut64 *prev_addr, bool stepOver);
@@ -928,15 +927,14 @@ RZ_API void rz_core_analysis_type_match(RzCore *core, RzAnalysisFunction *fcn, H
 
 /* cil.c */
 /**
- * \brief Options for printing rzil instructions.
+ * \brief Options for printing RzIL instructions.
  */
 typedef struct rz_core_il_print_options {
-	int invbreak;
-	int cbytes; ///< set false to ignore the constraint of \p len and print \p nlines instructions in rz_core_print_disasm
-	int pretty; ///< set true to enable printing delimeter after address
-	int colorize; ///< set false to disable coloring
-	int unicode; ///< set true to enable unicode formatted rzil
-	RzPVector /*<RzAnalysisDisasmText *>*/ *vec; ///< Not print, but append as RzPVector<RzAnalysisDisasmText>
+	bool cbytes; ///< If false, ignore the \p len byte limit and print exactly \p n_lines instructions in rz_core_print_disasm().
+	bool pretty; ///< If true, use delimiter(\n).
+	bool colorize; ///< If false, disable colorized output.
+	bool unicode; ///< If true, print RzIL using unicode formatting.
+	RzPVector /*<RzAnalysisDisasmText *>*/ *vec; ///< Output vector;
 } RzCoreILPrintOptions;
 
 /* asm.c */
@@ -978,7 +976,7 @@ RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_bwdisassemble(RzCore *core, ut64
 RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_back_disassemble_instr(RzCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_back_disassemble_byte(RzCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 RZ_API ut32 rz_core_asm_bwdis_len(RzCore *core, int *len, ut64 *start_addr, ut32 l);
-RZ_API int rz_core_il_print_rzil(RZ_NONNULL RzCore *core, ut64 addr, RZ_NONNULL ut8 *buf, int len, int n_lines, RZ_NULLABLE RzCoreILPrintOptions *options);
+RZ_API int rz_core_il_print_rzil(RZ_NONNULL RzCore *core, ut64 addr, RZ_NONNULL ut8 *buf, size_t len, size_t n_lines, RZ_NULLABLE RzCoreILPrintOptions *options);
 RZ_API int rz_core_print_disasm(RZ_NONNULL RzCore *core, ut64 addr, RZ_NONNULL ut8 *buf, int len, int nlines, RZ_NULLABLE RzCmdStateOutput *state, RZ_NULLABLE RzCoreDisasmOptions *options);
 RZ_API int rz_core_print_disasm_json(RzCore *core, ut64 addr, ut8 *buf, int len, int lines, PJ *pj);
 RZ_API int rz_core_print_disasm_instructions_with_buf(RzCore *core, ut64 address, ut8 *buf, int nb_bytes, int nb_opcodes);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -926,6 +926,19 @@ RZ_API RZ_OWN char *rz_core_graph_to_sdb_str(RZ_NONNULL RzCore *core, RZ_NONNULL
 /*tp.c*/
 RZ_API void rz_core_analysis_type_match(RzCore *core, RzAnalysisFunction *fcn, HtUU *addr_loop_table);
 
+/* cil.c */
+/**
+ * \brief Options for printing rzil instructions.
+ */
+typedef struct rz_core_il_print_options {
+	int invbreak;
+	int cbytes; ///< set false to ignore the constraint of \p len and print \p nlines instructions in rz_core_print_disasm
+	int pretty; ///< set true to enable printing delimeter after address
+	int colorize; ///< set false to disable coloring
+	int unicode; ///< set true to enable unicode formatted rzil
+	RzPVector /*<RzAnalysisDisasmText *>*/ *vec; ///< Not print, but append as RzPVector<RzAnalysisDisasmText>
+} RzCoreILPrintOptions;
+
 /* asm.c */
 #define RZ_MIDFLAGS_HIDE     0
 #define RZ_MIDFLAGS_SHOW     1
@@ -965,7 +978,7 @@ RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_bwdisassemble(RzCore *core, ut64
 RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_back_disassemble_instr(RzCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_back_disassemble_byte(RzCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 RZ_API ut32 rz_core_asm_bwdis_len(RzCore *core, int *len, ut64 *start_addr, ut32 l);
-RZ_API void rz_core_il_print_rzil(RZ_NONNULL RzCore *core, RZ_NONNULL RzPVector *vec, ut64 addr, int n_lines, bool pretty, bool unicode, bool colorize);
+RZ_API int rz_core_il_print_rzil(RZ_NONNULL RzCore *core, ut64 addr, RZ_NONNULL ut8 *buf, int len, int n_lines, RZ_NULLABLE RzCoreILPrintOptions *options);
 RZ_API int rz_core_print_disasm(RZ_NONNULL RzCore *core, ut64 addr, RZ_NONNULL ut8 *buf, int len, int nlines, RZ_NULLABLE RzCmdStateOutput *state, RZ_NULLABLE RzCoreDisasmOptions *options);
 RZ_API int rz_core_print_disasm_json(RzCore *core, ut64 addr, ut8 *buf, int len, int lines, PJ *pj);
 RZ_API int rz_core_print_disasm_instructions_with_buf(RzCore *core, ut64 address, ut8 *buf, int nb_bytes, int nb_opcodes);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -965,8 +965,7 @@ RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_bwdisassemble(RzCore *core, ut64
 RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_back_disassemble_instr(RzCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_back_disassemble_byte(RzCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 RZ_API ut32 rz_core_asm_bwdis_len(RzCore *core, int *len, ut64 *start_addr, ut32 l);
-RZ_API void rz_core_il_print_rzil(RZ_NONNULL RzCore *core, RZ_NONNULL RzPVector *vec, bool pretty, bool unicode, bool colorize);
-
+RZ_API void rz_core_il_print_rzil(RZ_NONNULL RzCore *core, RZ_NONNULL RzPVector *vec, ut64 addr, int n_lines, bool pretty, bool unicode, bool colorize);
 RZ_API int rz_core_print_disasm(RZ_NONNULL RzCore *core, ut64 addr, RZ_NONNULL ut8 *buf, int len, int nlines, RZ_NULLABLE RzCmdStateOutput *state, RZ_NULLABLE RzCoreDisasmOptions *options);
 RZ_API int rz_core_print_disasm_json(RzCore *core, ut64 addr, ut8 *buf, int len, int lines, PJ *pj);
 RZ_API int rz_core_print_disasm_instructions_with_buf(RzCore *core, ut64 address, ut8 *buf, int nb_bytes, int nb_opcodes);

--- a/test/unit/test_analysis_op.c
+++ b/test/unit/test_analysis_op.c
@@ -236,9 +236,7 @@ bool test_rz_core_il_print_rzil() {
 	RzCore *core = rz_core_new();
 	rz_io_open_at(core->io, "malloc://0x100", RZ_PERM_RX, 0644, 0, NULL); // needed to get arrow info (is_valid_offset checks)
 	rz_core_arch_configure(core, "x86", 64, NULL, NULL, NULL);
-	rz_config_set(core->config, "scr.color", "true");
-	rz_core_theme_load(core, "default");
-
+	rz_config_set(core->config, "scr.color", "1");
 	ut8 buf[128];
 	int len = rz_hex_str2bin("554889e5897dfcebf8", buf);
 	RzPVector *vec = rz_pvector_new((RzPVectorFree)rz_analysis_disasm_text_free);

--- a/test/unit/test_analysis_op.c
+++ b/test/unit/test_analysis_op.c
@@ -232,11 +232,60 @@ bool test_rz_core_print_disasm_resolve_aav_symbols() {
 	mu_end;
 }
 
+bool test_rz_core_il_print_rzil() {
+	RzCore *core = rz_core_new();
+	rz_io_open_at(core->io, "malloc://0x100", RZ_PERM_RX, 0644, 0, NULL); // needed to get arrow info (is_valid_offset checks)
+	rz_core_arch_configure(core, "x86", 64, NULL, NULL, NULL);
+	rz_config_set(core->config, "scr.color", "true");
+	rz_core_theme_load(core, "default");
+
+	ut8 buf[128];
+	int len = rz_hex_str2bin("554889e5897dfcebf8", buf);
+	RzPVector *vec = rz_pvector_new((RzPVectorFree)rz_analysis_disasm_text_free);
+	RzCoreILPrintOptions options = { .cbytes = 1, .pretty = 0, .colorize = 1, .unicode = 1, .vec = vec };
+	mu_assert_notnull(vec, "rz_core_il_print_rzil vec not null");
+	rz_core_il_print_rzil(core, 0, buf, len, len, &options);
+
+	mu_assert_eq(rz_pvector_len(vec), 4, "rz_core_il_print_rzil len");
+	RzAnalysisDisasmText *t = rz_pvector_at(vec, 0);
+	mu_assert_eq(t->offset, 0, "rz_core_il_print_rzil offset");
+	mu_assert_eq(t->arrow, UT64_MAX, "rz_core_il_print_rzil arrow");
+	mu_assert_streq_free(rz_str_trim_dup(t->text),
+		"\x1B[36m0x0\x1B[0m \x1B[90m((\x1B[0m\x1B[31mfinal\x1B[0m \x1B[36m\xE2\x86\x90\x1B[0m \x1B[90m(\x1B[0m\x1B[31mrsp\x1B[0m \x1B[36m-\x1B[0m \x1B[33m0x8\xE2\x82\x86\xE2\x82\x84\x1B[0m\x1B[90m))\x1B[0m\n    \x1B[90m(\x1B[0m\x1B[36m\xEA\x9C\xB1\xE1\xB4\x9B\xE2\x82\x80\x1B[0m \x1B[90m(\x1B[0m\x1B[31mrbp\x1B[0m \x1B[36m\xE2\x89\x88\xE2\x82\x86\xE2\x82\x84\x1B[0m \x1B[36m\xE2\x8A\xA5\x1B[0m\x1B[90m)\x1B[0m \x1B[31mfinal\x1B[0m\x1B[90m)\x1B[0m \x1B[90m(\x1B[0m\x1B[31mrsp\x1B[0m \x1B[36m\xE2\x86\x90\x1B[0m \x1B[31mfinal\x1B[0m\x1B[90m))\x1B[0m",
+		"rz_core_il_print_rzil text");
+
+	t = rz_pvector_at(vec, 1);
+	mu_assert_eq(t->offset, 1, "rz_core_il_print_rzil offset");
+	mu_assert_eq(t->arrow, UT64_MAX, "rz_core_il_print_rzil arrow");
+	mu_assert_streq_free(rz_str_trim_dup(t->text),
+		"\x1B[36m0x1\x1B[0m \x1B[90m(\x1B[0m\x1B[31mrbp\x1B[0m \x1B[36m\xE2\x86\x90\x1B[0m \x1B[31mrsp\x1B[0m\x1B[90m)\x1B[0m",
+		"rz_core_il_print_rzil text");
+
+	t = rz_pvector_at(vec, 2);
+	mu_assert_eq(t->offset, 4, "rz_core_il_print_rzil offset");
+	mu_assert_eq(t->arrow, UT64_MAX, "rz_core_il_print_rzil arrow");
+	mu_assert_streq_free(rz_str_trim_dup(t->text),
+		"\x1B[36m0x4\x1B[0m \x1B[90m(\x1B[0m\x1B[36m\xEA\x9C\xB1\xE1\xB4\x9B\xE2\x82\x80\x1B[0m \x1B[90m(\x1B[0m\x1B[31mrdi\x1B[0m \x1B[36m\xE2\x89\x88\xE2\x82\x83\xE2\x82\x82\x1B[0m \x1B[36m\xE2\x8A\xA5\x1B[0m\x1B[90m)\x1B[0m \x1B[90m(\x1B[0m\x1B[31mrbp\x1B[0m \x1B[36m+\x1B[0m \x1B[33m0xfffffffffffffffc\xE2\x82\x86\xE2\x82\x84\x1B[0m\x1B[90m))\x1B[0m",
+		"rz_core_il_print_rzil text");
+
+	t = rz_pvector_at(vec, 3);
+	mu_assert_eq(t->offset, 7, "rz_core_il_print_rzil offset");
+	mu_assert_eq(t->arrow, 1, "rz_core_il_print_rzil arrow");
+	mu_assert_streq_free(rz_str_trim_dup(t->text),
+		"\x1B[36m0x7\x1B[0m \x1B[36m\xE2\x86\xB7\x1B[0m \x1B[90m(\x1B[0m\x1B[33m0x1\xE2\x82\x86\xE2\x82\x84\x1B[0m \x1B[36m\xE2\x89\x88\xE2\x82\x86\xE2\x82\x84\x1B[0m \x1B[36m\xE2\x8A\xA5\x1B[0m\x1B[90m)\x1B[0m",
+		"rz_core_il_print_rzil text");
+
+	rz_core_free(core);
+	rz_pvector_free(vec);
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test(test_rz_analysis_op_val);
 	mu_run_test(test_rz_core_analysis_bytes);
 	mu_run_test(test_rz_core_print_disasm);
 	mu_run_test(test_rz_core_print_disasm_resolve_aav_symbols);
+	mu_run_test(test_rz_core_il_print_rzil);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


**Detailed Description**
This PR introduces `rz_core_il_print_rzil` API wihch returns RzIL lines for given address and number of lines or all RzIL ops in the given chunk similar to 'rz_core_print_disasm' for printing disassembly lines. This was introduced as a helper API for accessing rzil lines from rizin to cutter [rizinorg/cutter#3196](https://github.com/rizinorg/cutter/issues/3196) but can be scaled to RzIL enriched in the future. The function returns a RzPVector or RzAnalysisDisasmText where the 
text-> field corresponds to formatted RzIL text
arrow-> corresponds to the reflines
offset-> corresponds to the vaddress of the line

Structs added

```c
typedef struct il_state_t RzILState;
typedef struct rz_core_il_print_options RzCoreILPrintOptions;
```

Functions added

```c
/* \brief Format instructions and add generated RzIL code to an analysis text vector.
 *
 * Decode instructions starting at the specified address, format their
 * RzIL equivalents into printable strings, using optional pretty printing,
 * unicode conversion and syntax highlighting, then store the strings as
 * RzAnalysisDisasmText entries in the vector provided.
 *
 * \param core      Pointer to the current RzCore instance.
 * \param addr      Starting address for instruction decoding.
 * \param buf       Pointer to memory buffer that contains instructions.
 * \param len       Length of \p buf in bytes.
 * \param n_lines   Maximum number of instructions to decode. Uses
 *                  core->blocksize if value is 0.
 * \param options   Formatting parameters and vector for storing results.
 *
 * \return Number of instructions decoded successfully.
 */
RZ_API int rz_core_il_print_rzil(RZ_NONNULL RzCore *core, ut64 addr, RZ_NONNULL ut8 *buf, size_t len, size_t n_lines, RZ_NULLABLE RzCoreILPrintOptions *options) ;

// static functions
static inline void emit_span_to_strbuf(const char *s, size_t n, const char *color, RzStrBuf *sb) ;
static void core_colorify_il_statement_to_strbuf(RzConsContext *ctx, const char *il_stmt, const char delim, ut64 addr, RzStrBuf *sb) ;
static const char *core_il_get_token_color(RzILUnicodeColorifyState state, const char *prev_color, RZ_NONNULL RzConsContext *ctx) ;
static void core_colorify_il_statement_unicode_to_strbuf(RzConsContext *ctx, const char *il_stmt, const char delim, ut64 addr, RzStrBuf *sb) ;
static ut64 core_il_get_refline_at(ut64 vat, RZ_NONNULL RzPVector /*<RzAnalysisRefline *>*/ *reflines)
static void init_asmqjmps(RZ_NONNULL RzCore *core);
static RzILState *il_state_init(RZ_NONNULL RzCore *core);
static void il_state_reflines_init(RzILState *ils);
static void core_il_stringify_single_il(RzILState *ils);
static void il_state_reflines_fini(RzILState *ils);
static bool il_state_complete(RzILState *ils);
static void il_state_free(RzILState *ils);

```


...

**Test plan**

Build and compile
Pass `test_rz_core_il_print_rzil` in tests

https://github.com/user-attachments/assets/e614a76b-691c-4e11-b343-d3b19d409288



...

**Closing issues**
None

...
