### PR TITLE
gdbclient: Read thread uid, gid and status from procfs

### DIFF
--- a/subprojects/rzgdb/include/gdbclient/commands.h
+++ b/subprojects/rzgdb/include/gdbclient/commands.h
@@ -130,7 +130,13 @@ int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 max_len);
 int gdbr_close_file(libgdbr_t *g);
 
 /*!
- * \brief get list of threads for given pid
+ * \brief Get a list of threads for the given pid.
+ * Attempts to read uid, gid and status from /proc/<pid>/task/<tid>/status
+ * via remote file access. Falls back to defaults if the remote target
+ * does not support it.
+ * \param g libgdbr instance
+ * \param pid process id to list threads for
+ * \return RzList of RzDebugPid or NULL on failure
  */
 RzList /*<RzDebugPid *>*/ *gdbr_threads_list(libgdbr_t *g, int pid);
 

--- a/subprojects/rzgdb/src/gdbclient/core.c
+++ b/subprojects/rzgdb/src/gdbclient/core.c
@@ -1858,6 +1858,44 @@ end:
 	return list;
 }
 
+/**
+ * \brief Read thread uid, gid and status from /proc/<pid>/task/<tid>/status via vFile.
+ * Falls back to defaults if the remote does not support vFile or is not Linux.
+ */
+static void gdbr_fill_thread_info(libgdbr_t *g, int pid, int tid, RzDebugPid *dpid) {
+	char proc_path[64];
+	rz_strf(proc_path, "/proc/%d/task/%d/status", pid, tid);
+	if (gdbr_open_file(g, proc_path, O_RDONLY, 0) != 0) {
+		return;
+	}
+	char status_buf[1024] = { 0 }; /* matches gdbr_parse_processes_xml buffer size */
+	if (gdbr_read_file(g, (ut8 *)status_buf, sizeof(status_buf) - 1) <= 0) {
+		gdbr_close_file(g);
+		return;
+	}
+	char *sptr = strstr(status_buf, "Uid:");
+	if (sptr) {
+		dpid->uid = atoi(sptr + 5);
+	}
+	sptr = strstr(status_buf, "Gid:");
+	if (sptr) {
+		dpid->gid = atoi(sptr + 5);
+	}
+	sptr = strstr(status_buf, "State:");
+	if (sptr) {
+		switch (*(sptr + 7)) {
+		case 'R': dpid->status = RZ_DBG_PROC_RUN; break;
+		case 'S': dpid->status = RZ_DBG_PROC_SLEEP; break;
+		case 'T':
+		case 't': dpid->status = RZ_DBG_PROC_STOP; break;
+		case 'Z': dpid->status = RZ_DBG_PROC_ZOMBIE; break;
+		case 'X': dpid->status = RZ_DBG_PROC_DEAD; break;
+		default: dpid->status = RZ_DBG_PROC_SLEEP; break;
+		}
+	}
+	gdbr_close_file(g);
+}
+
 RzList /*<RzDebugPid *>*/ *gdbr_threads_list(libgdbr_t *g, int pid) {
 	int ret = -1;
 	RzList *list = NULL;
@@ -1909,13 +1947,11 @@ RzList /*<RzDebugPid *>*/ *gdbr_threads_list(libgdbr_t *g, int pid) {
 				ret = -1;
 				goto end;
 			}
-			dpid->uid = dpid->gid = -1; // TODO
+			dpid->uid = dpid->gid = -1;
 			dpid->pid = ttid;
 			dpid->runnable = true;
-			// This is what linux native does as fallback, but
-			// probably not correct.
-			// TODO: Implement getting correct thread status from GDB
 			dpid->status = RZ_DBG_PROC_STOP;
+			gdbr_fill_thread_info(g, pid, ttid, dpid);
 			rz_list_append(list, dpid);
 			ptr = ptr2;
 		}

--- a/test/db/archos/linux-x64/dbg_gdbserver
+++ b/test/db/archos/linux-x64/dbg_gdbserver
@@ -26,3 +26,19 @@ EXPECT=<<EOF
 s bins/elf/analysis/pie
 EOF
 RUN
+
+NAME=gdbserver dpt threaded
+FILE=bins/elf/gdbserver/threaded
+CMDS=<<EOF
+!scripts/gdbserver.py --port 12348 --binary bins/elf/gdbserver/threaded
+oodf gdb://127.0.0.1:12348
+dc
+dptj
+doc
+EOF
+REGEXP_FILTER_OUT="status":"\w"
+EXPECT=<<EOF
+"status":"t"
+"status":"t"
+EOF
+RUN


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

`gdbr_threads_list` was hardcoding uid, gid and status to -1 and `RZ_DBG_PROC_STOP`. I noticed `gdbr_parse_processes_xml` already does this for processes by reading `/proc/<pid>/status` over vFile, so I did the same for threads using `/proc/<pid>/task/<tid>/status`. Falls back to defaults if the remote doesn't support vFile or isn't Linux.

**Test plan**

This change requires a Linux gdbserver with a multi-threaded binary and vFile support to verify. Open to suggestions on how to add a test for this.

**Closing issues**

N/A