### PR TITLE
Convert `%ll` format specifiers to PFMT64

### DIFF
--- a/librz/arch/isa/arm/armass.c
+++ b/librz/arch/isa/arm/armass.c
@@ -1153,7 +1153,7 @@ static st32 thumb_getoffset(char *label, ut64 cur) {
 	st32 res = rz_num_math(NULL, label);
 	res -= 4;
 	res -= cur; // possible integer underflow
-	// printf("thumb_getoffset: %s, %lld, %lld\n", label, res, cur);
+	// printf("thumb_getoffset: %s, %" PFMT64d ", %" PFMT64d "\n", label, res, cur);
 	return res;
 }
 

--- a/librz/arch/isa/arm/armass64.c
+++ b/librz/arch/isa/arm/armass64.c
@@ -330,7 +330,7 @@ static ut32 cb(ArmOp *op) {
 	} else {
 		return UT32_MAX;
 	}
-	// printf ("%s %d, %llu\n", op->mnemonic, op->operands[0].reg, op->operands[1].immediate);
+	// printf ("%s %d, %" PFMT64u "\n", op->mnemonic, op->operands[0].reg, op->operands[1].immediate);
 	ut32 imm = op->operands[1].immediate;
 	data = k | encode1reg(op) | ((imm & 0x1c) << 27) | ((imm & 0x1fe0) << 11);
 	data = data | ((imm & 0x1fe000) >> 5);

--- a/librz/arch/isa/hexagon/hexagon_arch.c
+++ b/librz/arch/isa/hexagon/hexagon_arch.c
@@ -854,7 +854,7 @@ static void print_state_pkt(const HexState *state, st32 index, HexBufferAction a
 		} else if (i == newest) {
 			time_ind = "new";
 		}
-		rz_strbuf_appendf(pkt_line, "│  %d  │ 0x%010x │ %s │ %016llu │ ", i, pkt->pkt_addr, time_ind, pkt->last_access);
+		rz_strbuf_appendf(pkt_line, "│  %d  │ 0x%010x │ %s │ %016" PFMT64u " │ ", i, pkt->pkt_addr, time_ind, pkt->last_access);
 		HexInsnContainer *hic = NULL;
 		for (int j = 0; j < 4; ++j) {
 			hic = rz_list_get_n(pkt->bin, j);

--- a/librz/arch/isa/luac/lua_arch.c
+++ b/librz/arch/isa/luac/lua_arch.c
@@ -683,7 +683,7 @@ RZ_IPI bool analysis_op_4_5(RzAnalysis *analysis, RzAnalysisOp *op, AnalysisLuac
 	      if not to run then pc+=Bx+1;			*/
 		op->type = RZ_ANALYSIS_OP_TYPE_CJMP;
 		JUMP_FAIL_ABS(addr + 4 + 4 * (bx + 1), addr + 4);
-		rz_strf(comment, "to 0x%" PFMT64x "", op->jump);
+		rz_strf(comment, "to 0x%" PFMT64x, op->jump);
 		break;
 	case OP_VARARG: /*	A C	R[A], R[A+1], ..., R[A+C-2] = vararg		*/ {
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_LOAD, a);

--- a/librz/arch/isa/luac/lua_arch.c
+++ b/librz/arch/isa/luac/lua_arch.c
@@ -683,7 +683,7 @@ RZ_IPI bool analysis_op_4_5(RzAnalysis *analysis, RzAnalysisOp *op, AnalysisLuac
 	      if not to run then pc+=Bx+1;			*/
 		op->type = RZ_ANALYSIS_OP_TYPE_CJMP;
 		JUMP_FAIL_ABS(addr + 4 + 4 * (bx + 1), addr + 4);
-		rz_strf(comment, "to 0x%llx", op->jump);
+		rz_strf(comment, "to 0x%" PFMT64x "", op->jump);
 		break;
 	case OP_VARARG: /*	A C	R[A], R[A+1], ..., R[A+C-2] = vararg		*/ {
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_LOAD, a);

--- a/librz/arch/isa/luac/v50/analysis_50.c
+++ b/librz/arch/isa/luac/v50/analysis_50.c
@@ -154,7 +154,7 @@ int lua50_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, AnalysisLuacContex
 	case OP_TFORPREP: /*  A sBx   if type(R(A)) == table then R(A+1):=R(A), R(A):=next; PC += sBx */
 		op->type = RZ_ANALYSIS_OP_TYPE_JMP;
 		JUMP_FAIL_ABS(addr + 4 + (sbx * 4), addr + 4);
-		rz_strf(comment, "to 0x%llx", op->jump);
+		rz_strf(comment, "to 0x%" PFMT64x "", op->jump);
 		break;
 	case OP_TFORLOOP: /*  A sBx   if R(A+1) ~= nil then { R(A)=R(A+1); pc += sBx }*/
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_CJMP, a);

--- a/librz/arch/isa/luac/v50/analysis_50.c
+++ b/librz/arch/isa/luac/v50/analysis_50.c
@@ -154,7 +154,7 @@ int lua50_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, AnalysisLuacContex
 	case OP_TFORPREP: /*  A sBx   if type(R(A)) == table then R(A+1):=R(A), R(A):=next; PC += sBx */
 		op->type = RZ_ANALYSIS_OP_TYPE_JMP;
 		JUMP_FAIL_ABS(addr + 4 + (sbx * 4), addr + 4);
-		rz_strf(comment, "to 0x%" PFMT64x "", op->jump);
+		rz_strf(comment, "to 0x%" PFMT64x, op->jump);
 		break;
 	case OP_TFORLOOP: /*  A sBx   if R(A+1) ~= nil then { R(A)=R(A+1); pc += sBx }*/
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_CJMP, a);

--- a/librz/arch/isa/luac/v51/analysis_51.c
+++ b/librz/arch/isa/luac/v51/analysis_51.c
@@ -175,7 +175,7 @@ int lua51_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, AnalysisLuacContex
 	case OP_TFORLOOP: /*  A sBx   if R(A+1) ~= nil then { R(A)=R(A+1); pc += sBx }*/
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_CJMP, a);
 		JUMP_FAIL_ABS(addr + 4 + (sbx * 4), addr + 4);
-		rz_strf(comment, "to 0x%llx", op->jump);
+		rz_strf(comment, "to 0x%" PFMT64x "", op->jump);
 		break;
 	case OP_VARARG: /*    A B     R(A), R(A+1), ..., R(A+B-2) = vararg            */
 		break;

--- a/librz/arch/isa/luac/v51/analysis_51.c
+++ b/librz/arch/isa/luac/v51/analysis_51.c
@@ -175,7 +175,7 @@ int lua51_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, AnalysisLuacContex
 	case OP_TFORLOOP: /*  A sBx   if R(A+1) ~= nil then { R(A)=R(A+1); pc += sBx }*/
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_CJMP, a);
 		JUMP_FAIL_ABS(addr + 4 + (sbx * 4), addr + 4);
-		rz_strf(comment, "to 0x%" PFMT64x "", op->jump);
+		rz_strf(comment, "to 0x%" PFMT64x, op->jump);
 		break;
 	case OP_VARARG: /*    A B     R(A), R(A+1), ..., R(A+B-2) = vararg            */
 		break;

--- a/librz/arch/isa/luac/v52/analysis_52.c
+++ b/librz/arch/isa/luac/v52/analysis_52.c
@@ -143,7 +143,7 @@ int lua52_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, AnalysisLuacContex
 	case OP_FORPREP: /*   A sBx   R(A)-=R(A+2); pc+=sBx                           */
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_CJMP, a);
 		JUMP_FAIL_ABS(addr + 4 + (sbx * 4), addr + 4);
-		rz_strf(comment, "to 0x%" PFMT64x "", op->jump);
+		rz_strf(comment, "to 0x%" PFMT64x, op->jump);
 		break;
 	case OP_LOADKX: /*    A       R(A) := Kst(extra arg)                          */
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_LOAD, a);
@@ -180,7 +180,7 @@ int lua52_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, AnalysisLuacContex
 	case OP_TFORLOOP: /*  A sBx   if R(A+1) ~= nil then { R(A)=R(A+1); pc += sBx }*/
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_CJMP, a);
 		JUMP_FAIL_ABS(addr + 4 + (sbx * 4), addr + 4);
-		rz_strf(comment, "to 0x%" PFMT64x "", op->jump);
+		rz_strf(comment, "to 0x%" PFMT64x, op->jump);
 		break;
 	case OP_VARARG: /*    A B     R(A), R(A+1), ..., R(A+B-2) = vararg            */
 	case OP_EXTRAARG: /*   Ax      extra (larger) argument for previous opcode     */

--- a/librz/arch/isa/luac/v52/analysis_52.c
+++ b/librz/arch/isa/luac/v52/analysis_52.c
@@ -143,7 +143,7 @@ int lua52_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, AnalysisLuacContex
 	case OP_FORPREP: /*   A sBx   R(A)-=R(A+2); pc+=sBx                           */
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_CJMP, a);
 		JUMP_FAIL_ABS(addr + 4 + (sbx * 4), addr + 4);
-		rz_strf(comment, "to 0x%llx", op->jump);
+		rz_strf(comment, "to 0x%" PFMT64x "", op->jump);
 		break;
 	case OP_LOADKX: /*    A       R(A) := Kst(extra arg)                          */
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_LOAD, a);
@@ -180,7 +180,7 @@ int lua52_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, AnalysisLuacContex
 	case OP_TFORLOOP: /*  A sBx   if R(A+1) ~= nil then { R(A)=R(A+1); pc += sBx }*/
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_CJMP, a);
 		JUMP_FAIL_ABS(addr + 4 + (sbx * 4), addr + 4);
-		rz_strf(comment, "to 0x%llx", op->jump);
+		rz_strf(comment, "to 0x%" PFMT64x "", op->jump);
 		break;
 	case OP_VARARG: /*    A B     R(A), R(A+1), ..., R(A+B-2) = vararg            */
 	case OP_EXTRAARG: /*   Ax      extra (larger) argument for previous opcode     */

--- a/librz/arch/isa/luac/v53/analysis_53.c
+++ b/librz/arch/isa/luac/v53/analysis_53.c
@@ -144,7 +144,7 @@ int lua53_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, AnalysisLuacContex
 	case OP_FORPREP: /*   A sBx   R(A)-=R(A+2); pc+=sBx                           */
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_CJMP, a);
 		JUMP_FAIL_ABS(addr + 4 + (sbx * 4), addr + 4);
-		rz_strf(comment, "to 0x%" PFMT64x "", op->jump);
+		rz_strf(comment, "to 0x%" PFMT64x, op->jump);
 		break;
 	case OP_LOADKX: /*    A       R(A) := Kst(extra arg)                          */
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_LOAD, a);
@@ -197,7 +197,7 @@ int lua53_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, AnalysisLuacContex
 	case OP_TFORLOOP: /*  A sBx   if R(A+1) ~= nil then { R(A)=R(A+1); pc += sBx }*/
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_CJMP, a);
 		JUMP_FAIL_ABS(addr + 4 + (sbx * 4), addr + 4);
-		rz_strf(comment, "to 0x%" PFMT64x "", op->jump);
+		rz_strf(comment, "to 0x%" PFMT64x, op->jump);
 		break;
 	case OP_VARARG: /*    A B     R(A), R(A+1), ..., R(A+B-2) = vararg            */
 	case OP_EXTRAARG: /*   Ax      extra (larger) argument for previous opcode     */

--- a/librz/arch/isa/luac/v53/analysis_53.c
+++ b/librz/arch/isa/luac/v53/analysis_53.c
@@ -144,7 +144,7 @@ int lua53_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, AnalysisLuacContex
 	case OP_FORPREP: /*   A sBx   R(A)-=R(A+2); pc+=sBx                           */
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_CJMP, a);
 		JUMP_FAIL_ABS(addr + 4 + (sbx * 4), addr + 4);
-		rz_strf(comment, "to 0x%llx", op->jump);
+		rz_strf(comment, "to 0x%" PFMT64x "", op->jump);
 		break;
 	case OP_LOADKX: /*    A       R(A) := Kst(extra arg)                          */
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_LOAD, a);
@@ -197,7 +197,7 @@ int lua53_analysis_op(RzAnalysis *analysis, RzAnalysisOp *op, AnalysisLuacContex
 	case OP_TFORLOOP: /*  A sBx   if R(A+1) ~= nil then { R(A)=R(A+1); pc += sBx }*/
 		TYPE_DST_REG(RZ_ANALYSIS_OP_TYPE_CJMP, a);
 		JUMP_FAIL_ABS(addr + 4 + (sbx * 4), addr + 4);
-		rz_strf(comment, "to 0x%llx", op->jump);
+		rz_strf(comment, "to 0x%" PFMT64x "", op->jump);
 		break;
 	case OP_VARARG: /*    A B     R(A), R(A+1), ..., R(A+B-2) = vararg            */
 	case OP_EXTRAARG: /*   Ax      extra (larger) argument for previous opcode     */

--- a/librz/arch/isa/v850/v850_disas.c
+++ b/librz/arch/isa/v850/v850_disas.c
@@ -400,7 +400,7 @@ static bool decode_formatIII(V850_Inst *inst) {
 	}
 
 	INSTR("b%s", cond_s);
-	OPERANDS("0x%" PFMT64x "", (st64)(inst->addr) + (st32)inst->disp);
+	OPERANDS("0x%" PFMT64x, (st64)(inst->addr) + (st32)inst->disp);
 	inst->format = III_conditional_branch;
 	return true;
 }
@@ -472,7 +472,7 @@ static bool decode_formatV(V850_Inst *inst) {
 	ut8 reg2 = get_reg2(inst);
 	if (reg2 == 0) {
 		inst->id = V850_JR;
-		OPERANDS("0x%" PFMT64x "", target);
+		OPERANDS("0x%" PFMT64x, target);
 	} else {
 		inst->id = V850_JARL;
 		OPERANDS("0x%" PFMT64x ", %s", target, R2);
@@ -601,7 +601,7 @@ static bool decode_formatVII(V850_Inst *inst) {
 			ut8 cond = get_cond(inst);
 			inst->disp = sext32(((inst->disp >> 1) | (((V850_word(inst, 1) >> 4) & 1) << 15)) << 1, 17);
 			INSTR("b%s", conds[cond]);
-			OPERANDS("0x%" PFMT64x "", (st64)inst->addr + (st32)inst->disp);
+			OPERANDS("0x%" PFMT64x, (st64)inst->addr + (st32)inst->disp);
 			goto ok;
 		}
 		if (sub1) {

--- a/librz/arch/isa/v850/v850_disas.c
+++ b/librz/arch/isa/v850/v850_disas.c
@@ -400,7 +400,7 @@ static bool decode_formatIII(V850_Inst *inst) {
 	}
 
 	INSTR("b%s", cond_s);
-	OPERANDS("0x%llx", (st64)(inst->addr) + (st32)inst->disp);
+	OPERANDS("0x%" PFMT64x "", (st64)(inst->addr) + (st32)inst->disp);
 	inst->format = III_conditional_branch;
 	return true;
 }
@@ -472,10 +472,10 @@ static bool decode_formatV(V850_Inst *inst) {
 	ut8 reg2 = get_reg2(inst);
 	if (reg2 == 0) {
 		inst->id = V850_JR;
-		OPERANDS("0x%llx", target);
+		OPERANDS("0x%" PFMT64x "", target);
 	} else {
 		inst->id = V850_JARL;
-		OPERANDS("0x%llx, %s", target, R2);
+		OPERANDS("0x%" PFMT64x ", %s", target, R2);
 	}
 
 	PRINT_INSTR;
@@ -601,7 +601,7 @@ static bool decode_formatVII(V850_Inst *inst) {
 			ut8 cond = get_cond(inst);
 			inst->disp = sext32(((inst->disp >> 1) | (((V850_word(inst, 1) >> 4) & 1) << 15)) << 1, 17);
 			INSTR("b%s", conds[cond]);
-			OPERANDS("0x%llx", (st64)inst->addr + (st32)inst->disp);
+			OPERANDS("0x%" PFMT64x "", (st64)inst->addr + (st32)inst->disp);
 			goto ok;
 		}
 		if (sub1) {

--- a/librz/arch/isa/v850/v850_esil.inc
+++ b/librz/arch/isa/v850/v850_esil.inc
@@ -195,7 +195,7 @@ static void v850_esil(RzStrBuf *out, V850_Inst *x) {
 			rz_strbuf_appendf(out, "s,ov,^,z,|,!");
 			break;
 		}
-		rz_strbuf_appendf(out, ",?{,$$,%llu,+,pc,=,}", x->addr + x->disp);
+		rz_strbuf_appendf(out, ",?{,$$,%" PFMT64u ",+,pc,=,}", x->addr + x->disp);
 		break;
 	case V850_CLR1:
 		bitmask = (1 << viii_bit(x));

--- a/librz/arch/luac_process.c
+++ b/librz/arch/luac_process.c
@@ -103,7 +103,7 @@ RZ_API bool rz_core_bin_apply_luac_debug(RzCore *core, RzBinFile *binfile) {
 		const LuaProto *proto = *it_p;
 		rz_pvector_foreach (proto->const_entries, it_c) {
 			const LuaConstEntry *current_entry = *it_c;
-			RZ_LOG_DEBUG("[LuaConstEntry] proto: %d, offset: 0x%llx === tag: %d, offset: 0x%llx, prev_offset: 0x%llx, string_start: 0x%llx, current_entry->voffset: 0x%llx, `%s` (%d)\n",
+			RZ_LOG_DEBUG("[LuaConstEntry] proto: %d, offset: 0x%" PFMT64x " === tag: %d, offset: 0x%" PFMT64x ", prev_offset: 0x%" PFMT64x ", string_start: 0x%" PFMT64x ", current_entry->voffset: 0x%" PFMT64x ", `%s` (%d)\n",
 				proto->index, proto->offset, current_entry->tag, current_entry->offset, current_entry->prev_offset,
 				current_entry->string_start,
 				current_entry->voffset, (char *)current_entry->data, current_entry->data_len);
@@ -133,7 +133,7 @@ RZ_API bool rz_core_bin_apply_luac_debug(RzCore *core, RzBinFile *binfile) {
 		int i = 0;
 		rz_pvector_foreach (proto->local_var_info_entries, it_v) {
 			const LuaLocalVarEntry *var = *it_v;
-			RZ_LOG_DEBUG("[LuaLocalVarEntry] [%d] params: %d, pname: `%s` proto->is_vararg: %d, reg_offset: %d ---- %d === varname: `%s`, offset: 0x%llx, voffset: 0x%llx, start_pc: %d, end_pc: %d, varname_len: %d\n",
+			RZ_LOG_DEBUG("[LuaLocalVarEntry] [%d] params: %d, pname: `%s` proto->is_vararg: %d, reg_offset: %d ---- %d === varname: `%s`, offset: 0x%" PFMT64x ", voffset: 0x%" PFMT64x ", start_pc: %d, end_pc: %d, varname_len: %d\n",
 				i, proto->num_params, pname, proto->is_vararg, reg_offset,
 				proto->index, (char *)var->varname, var->offset, var->voffset, var->start_pc, var->end_pc, var->varname_len);
 
@@ -181,7 +181,7 @@ RZ_API bool rz_core_bin_apply_luac_debug(RzCore *core, RzBinFile *binfile) {
 		const LuaProto *proto = *it_p;
 		rz_pvector_foreach (proto->upvalue_entries, it_u) {
 			const LuaUpvalueEntry *upvalue = *it_u;
-			RZ_LOG_DEBUG("[LuaUpvalueEntry] proto: %d, offset: 0x%llx === idx: `%d`, upvalue->poffset: 0x%llx, voffset: 0x%llx, instack: %d, kind: %d, upvalue_name: `%s`, offset: 0x%llx, upvalue_len: %d\n",
+			RZ_LOG_DEBUG("[LuaUpvalueEntry] proto: %d, offset: 0x%" PFMT64x " === idx: `%d`, upvalue->poffset: 0x%" PFMT64x ", voffset: 0x%" PFMT64x ", instack: %d, kind: %d, upvalue_name: `%s`, offset: 0x%" PFMT64x ", upvalue_len: %d\n",
 				proto->index, proto->offset, upvalue->idx, upvalue->offset, upvalue->voffset, upvalue->instack, upvalue->kind,
 				(char *)upvalue->upvalue_name, upvalue->name_offset, upvalue->name_len);
 			rz_meta_set(core->analysis, RZ_META_TYPE_DATA, upvalue->voffset, sizeof(upvalue), "LuaUpvalue");
@@ -194,7 +194,7 @@ RZ_API bool rz_core_bin_apply_luac_debug(RzCore *core, RzBinFile *binfile) {
 		rz_pvector_foreach (proto->dbg_upvalue_entries, it_u) {
 			const LuaDbgUpvalueEntry *upvalue = *it_u;
 			(void)upvalue;
-			RZ_LOG_DEBUG("[LuaUpvalueEntry] proto: %d, offset: 0x%llx === dbg_upvalue_name: `%s`, offset: 0x%llx, upvalue_len: %d\n",
+			RZ_LOG_DEBUG("[LuaUpvalueEntry] proto: %d, offset: 0x%" PFMT64x " === dbg_upvalue_name: `%s`, offset: 0x%" PFMT64x ", upvalue_len: %d\n",
 				proto->index, proto->offset, (char *)upvalue->upvalue_name, upvalue->offset, upvalue->name_len);
 		}
 	}

--- a/librz/arch/p/analysis/analysis_ppc_cs.c
+++ b/librz/arch/p/analysis/analysis_ppc_cs.c
@@ -72,7 +72,7 @@ static const char *cmask64(RzAnalysis *a, const char *mb_c, const char *me_c) {
 	if (me_c) {
 		me = strtol(me_c, NULL, 16);
 	}
-	snprintf(ctx->cmask1, sizeof(ctx->cmask1), "0x%" PFMT64x "", mask64(mb, me));
+	snprintf(ctx->cmask1, sizeof(ctx->cmask1), "0x%" PFMT64x, mask64(mb, me));
 	return ctx->cmask1;
 }
 

--- a/librz/arch/p/analysis/analysis_ppc_cs.c
+++ b/librz/arch/p/analysis/analysis_ppc_cs.c
@@ -1314,7 +1314,7 @@ static int ppc_analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 
 				op->type = RZ_ANALYSIS_OP_TYPE_MOV;
 				op->val = IMM(2);
 				op->val <<= 16;
-				esilprintf(op, "0x%llx0000,%s,=", IMM(2), ARG(0));
+				esilprintf(op, "0x%" PFMT64x "0000,%s,=", IMM(2), ARG(0));
 				break;
 			}
 #else

--- a/librz/arch/p/analysis/analysis_x86_zydis.c
+++ b/librz/arch/p/analysis/analysis_x86_zydis.c
@@ -924,7 +924,7 @@ static void anop_esil(RzAnalysis *a, RzAnalysisOp *op, const ut8 *buf, int len, 
 		src = getarg(a, &gop, 1, 0, NULL, SRC_AR, NULL, zydx->addr);
 		dst = getarg(a, &gop, 0, 0, NULL, DST_AR, NULL, zydx->addr);
 		dst2 = getarg(a, &gop, 0, 1, "<<", DST2_AR, &bitsize, zydx->addr);
-		esilprintf(op, "0,%s,!,!,?{,1,%s,-,%s,<<,0x%llx,&,!,!,^,},%s,%s,$z,zf,:=,$p,pf,:=,%" PFMT32d ",$s,sf,:=,cf,=",
+		esilprintf(op, "0,%s,!,!,?{,1,%s,-,%s,<<,0x%" PFMT64x ",&,!,!,^,},%s,%s,$z,zf,:=,$p,pf,:=,%" PFMT32d ",$s,sf,:=,cf,=",
 			src, src, dst, val, src, dst2, bitsize - 1);
 	} break;
 	case X86_INS_SALC:

--- a/librz/arch/p/parse/parse_ppc_pseudo.c
+++ b/librz/arch/p/parse/parse_ppc_pseudo.c
@@ -1482,26 +1482,26 @@ static int replace(int argc, const char *argv[], char *newstr) {
 							// MASK(MB+32, ME+32)
 							ut64 MB = PPC_UT64(argv[4]) + 32;
 							ut64 ME = PPC_UT64(argv[5]) + 32;
-							snprintf(ppc_mask, sizeof(ppc_mask), "0x%" PFMT64x "", mask64(MB, ME));
+							snprintf(ppc_mask, sizeof(ppc_mask), "0x%" PFMT64x, mask64(MB, ME));
 						} else if (letter == 4 && (!strncmp(argv[0], "rldcl", 5) || !strncmp(argv[0], "rldicl", 6))) {
 							// { "rld[i]cl", "A = rol64(B, C) & D", 4},
 							w = ppc_mask;
 							// MASK(MB, 63)
 							ut64 MB = PPC_UT64(argv[4]);
-							snprintf(ppc_mask, sizeof(ppc_mask), "0x%" PFMT64x "", mask64(MB, 63));
+							snprintf(ppc_mask, sizeof(ppc_mask), "0x%" PFMT64x, mask64(MB, 63));
 						} else if (letter == 4 && !strncmp(argv[0], "rldic", 5)) {
 							// { "rldic", "A = rol64(B, C) & D", 4},
 							w = ppc_mask;
 							// MASK(MB, 63 - SH)
 							ut64 MB = PPC_UT64(argv[4]);
 							ut64 ME = 63 - PPC_UT64(argv[3]);
-							snprintf(ppc_mask, sizeof(ppc_mask), "0x%" PFMT64x "", mask64(MB, ME));
+							snprintf(ppc_mask, sizeof(ppc_mask), "0x%" PFMT64x, mask64(MB, ME));
 						} else if (letter == 4 && (!strncmp(argv[0], "rldcr", 5) || !strncmp(argv[0], "rldicr", 6))) {
 							// { "rld[i]cr", "A = rol64(B, C) & D", 4},
 							w = ppc_mask;
 							// MASK(0, ME)
 							ut64 ME = PPC_UT64(argv[4]);
-							snprintf(ppc_mask, sizeof(ppc_mask), "0x%" PFMT64x "", mask64(0, ME));
+							snprintf(ppc_mask, sizeof(ppc_mask), "0x%" PFMT64x, mask64(0, ME));
 						} else if (letter == 4 && !strncmp(argv[0], "rldimi", 6)) {
 							// { "rldimi", "A = (rol64(B, C) & D) | (A & E)", 5}, //32
 							// first mask (normal)
@@ -1509,7 +1509,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 							// MASK(MB, 63 - SH)
 							ut64 MB = PPC_UT64(argv[4]);
 							ut64 ME = 63 - PPC_UT64(argv[3]);
-							snprintf(ppc_mask, sizeof(ppc_mask), "0x%" PFMT64x "", mask64(MB, ME));
+							snprintf(ppc_mask, sizeof(ppc_mask), "0x%" PFMT64x, mask64(MB, ME));
 						} else if (letter == 5 && !strncmp(argv[0], "rldimi", 6)) {
 							// { "rldimi", "A = (rol64(B, C) & D) | (A & E)", 5}, //32
 							// second mask (inverted)
@@ -1518,7 +1518,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 							ut64 MB = PPC_UT64(argv[4]);
 							ut64 ME = 63 - PPC_UT64(argv[3]);
 							ut64 inverted = ~(mask64(MB, ME));
-							snprintf(ppc_mask, sizeof(ppc_mask), "0x%" PFMT64x "", inverted);
+							snprintf(ppc_mask, sizeof(ppc_mask), "0x%" PFMT64x, inverted);
 						} else if (letter == 4 && !strncmp(argv[0], "rlwimi", 6)) {
 							// { "rlwimi", "A = (rol64(B, C) & D) | (A & E)", 5}, //32
 							// first mask (normal)

--- a/librz/arch/var.c
+++ b/librz/arch/var.c
@@ -1058,22 +1058,22 @@ RZ_API char *rz_analysis_var_get_constraints_readable(RzAnalysisVar *var) {
 			if (high) {
 				rz_strbuf_append(&sb, " && ");
 			}
-			rz_strbuf_appendf(&sb, "<= 0x%" PFMT64x "", constr->val);
+			rz_strbuf_appendf(&sb, "<= 0x%" PFMT64x, constr->val);
 			low = true;
 			break;
 		case RZ_TYPE_COND_LT:
 			if (high) {
 				rz_strbuf_append(&sb, " && ");
 			}
-			rz_strbuf_appendf(&sb, "< 0x%" PFMT64x "", constr->val);
+			rz_strbuf_appendf(&sb, "< 0x%" PFMT64x, constr->val);
 			low = true;
 			break;
 		case RZ_TYPE_COND_GE:
-			rz_strbuf_appendf(&sb, ">= 0x%" PFMT64x "", constr->val);
+			rz_strbuf_appendf(&sb, ">= 0x%" PFMT64x, constr->val);
 			high = true;
 			break;
 		case RZ_TYPE_COND_GT:
-			rz_strbuf_appendf(&sb, "> 0x%" PFMT64x "", constr->val);
+			rz_strbuf_appendf(&sb, "> 0x%" PFMT64x, constr->val);
 			high = true;
 			break;
 		default:

--- a/librz/arch/var_global.c
+++ b/librz/arch/var_global.c
@@ -403,22 +403,22 @@ RZ_API RZ_OWN char *rz_analysis_var_global_get_constraints_readable(RzAnalysisVa
 			if (high) {
 				rz_strbuf_append(&sb, " && ");
 			}
-			rz_strbuf_appendf(&sb, "<= 0x%" PFMT64x "", constr->val);
+			rz_strbuf_appendf(&sb, "<= 0x%" PFMT64x, constr->val);
 			low = true;
 			break;
 		case RZ_TYPE_COND_LT:
 			if (high) {
 				rz_strbuf_append(&sb, " && ");
 			}
-			rz_strbuf_appendf(&sb, "< 0x%" PFMT64x "", constr->val);
+			rz_strbuf_appendf(&sb, "< 0x%" PFMT64x, constr->val);
 			low = true;
 			break;
 		case RZ_TYPE_COND_GE:
-			rz_strbuf_appendf(&sb, ">= 0x%" PFMT64x "", constr->val);
+			rz_strbuf_appendf(&sb, ">= 0x%" PFMT64x, constr->val);
 			high = true;
 			break;
 		case RZ_TYPE_COND_GT:
-			rz_strbuf_appendf(&sb, "> 0x%" PFMT64x "", constr->val);
+			rz_strbuf_appendf(&sb, "> 0x%" PFMT64x, constr->val);
 			high = true;
 			break;
 		default:

--- a/librz/bin/dwarf/attr.c
+++ b/librz/bin/dwarf/attr.c
@@ -290,16 +290,16 @@ RZ_API void rz_bin_dwarf_attr_dump(
 	case DW_FORM_data4:
 	case DW_FORM_data8:
 	case DW_FORM_data16:
-		rz_strbuf_appendf(sb, "%" PFMT64u "", rz_bin_dwarf_attr_udata(attr));
+		rz_strbuf_appendf(sb, "%" PFMT64u, rz_bin_dwarf_attr_udata(attr));
 		break;
 	case DW_FORM_flag:
 		rz_strbuf_appendf(sb, "%u", rz_bin_dwarf_attr_flag(attr));
 		break;
 	case DW_FORM_sdata:
-		rz_strbuf_appendf(sb, "%" PFMT64d "", rz_bin_dwarf_attr_sdata(attr));
+		rz_strbuf_appendf(sb, "%" PFMT64d, rz_bin_dwarf_attr_sdata(attr));
 		break;
 	case DW_FORM_udata:
-		rz_strbuf_appendf(sb, "%" PFMT64u "", rz_bin_dwarf_attr_udata(attr));
+		rz_strbuf_appendf(sb, "%" PFMT64u, rz_bin_dwarf_attr_udata(attr));
 		break;
 	case DW_FORM_ref_addr:
 	case DW_FORM_ref1:
@@ -351,10 +351,10 @@ RZ_API void rz_bin_dwarf_attr_dump(
 	case DW_FORM_addrx4:
 	case DW_FORM_loclistx:
 	case DW_FORM_rnglistx:
-		rz_strbuf_appendf(sb, "0x%" PFMT64x "", rz_bin_dwarf_attr_udata(attr));
+		rz_strbuf_appendf(sb, "0x%" PFMT64x, rz_bin_dwarf_attr_udata(attr));
 		break;
 	case DW_FORM_implicit_const:
-		rz_strbuf_appendf(sb, "0x%" PFMT64d "", rz_bin_dwarf_attr_udata(attr));
+		rz_strbuf_appendf(sb, "0x%" PFMT64d, rz_bin_dwarf_attr_udata(attr));
 		break;
 	default:
 		rz_strbuf_appendf(sb, "Unknown attr value form %s\n", rz_bin_dwarf_form(attr->form));

--- a/librz/bin/format/elf/elf_info.c
+++ b/librz/bin/format/elf/elf_info.c
@@ -807,7 +807,7 @@ static riscv_attr_type get_riscv_attribute_from_section(RzBuffer *sec, ut64 attr
 		curr += num_bytes_read;
 
 		if (num_bytes_read > 8) {
-			RZ_LOG_WARN("Can't interpret tag value between offsets %llu-%llu: "
+			RZ_LOG_WARN("Can't interpret tag value between offsets %" PFMT64u "-%" PFMT64u ": "
 				    "tag is too large at %d bytes, parser can only represent 64-bit tags (skipped)\n",
 				curr - num_bytes_read, curr, num_bytes_read);
 			continue;
@@ -829,7 +829,7 @@ static riscv_attr_type get_riscv_attribute_from_section(RzBuffer *sec, ut64 attr
 			while (curr < rz_buf_size(sec) && result_curr < result_maxlen) {
 				bool succeeded = rz_buf_read8_offset(sec, &curr, &result[result_curr++]);
 				if (!succeeded) {
-					RZ_LOG_ERROR("Can't read the null-terminated string for tag %lld, starting at offset %d\n", tag, string_starts_at);
+					RZ_LOG_ERROR("Can't read the null-terminated string for tag %" PFMT64d ", starting at offset %d\n", tag, string_starts_at);
 					break;
 				}
 				// done
@@ -852,7 +852,7 @@ static riscv_attr_type get_riscv_attribute_from_section(RzBuffer *sec, ut64 attr
 			while (curr < rz_buf_size(sec) && result_curr < result_maxlen) {
 				bool succeeded = rz_buf_read8_offset(sec, &curr, &result[result_curr++]);
 				if (!succeeded) {
-					RZ_LOG_ERROR("Can't read the ULEB128 value for tag %lld, starting at offset %d\n", tag, uleb_starts_at);
+					RZ_LOG_ERROR("Can't read the ULEB128 value for tag %" PFMT64d ", starting at offset %d\n", tag, uleb_starts_at);
 					break;
 				}
 				// last byte in the variable encoding, most-significant bit not set

--- a/librz/bin/format/elf/elf_relocs_patching.c
+++ b/librz/bin/format/elf/elf_relocs_patching.c
@@ -2346,7 +2346,7 @@ static const ut16 RISCV_CI_TYPE_IMM_MASK = (1 << 12) | (0x1f << 2);
 
 #define RISCV_CHECK_SUCCESS_RET_IF_FAIL(success, type) \
 	if (!success) { \
-		RZ_LOG_ERROR("Failed to successfully patch a %s reloc at %llx (S: %llx, A: %llx, B: %llx, P: %llx)", type, patch_addr, S, A, B, P); \
+		RZ_LOG_ERROR("Failed to successfully patch a %s reloc at %" PFMT64x " (S: %" PFMT64x ", A: %" PFMT64x ", B: %" PFMT64x ", P: %" PFMT64x ")", type, patch_addr, S, A, B, P); \
 		return; \
 	}
 

--- a/librz/bin/format/luac/luac_bin.c
+++ b/librz/bin/format/luac/luac_bin.c
@@ -204,7 +204,7 @@ void _luac_build_info(LuaProto *proto, LuacBinInfo *info) {
 	// 1.0 set section name as function_name.code
 	current_offset = proto->code_offset + proto->code_skipped;
 	current_size = proto->code_size;
-	proto_name = rz_str_newf("fcn.%08" PFMT64x "", (ut64)proto_vaddr);
+	proto_name = rz_str_newf("fcn.%08" PFMT64x, (ut64)proto_vaddr);
 	section_name = rz_str_newf("%s.code", proto_name);
 	luac_add_section(info->section_vec, section_name, current_offset, proto_vaddr, current_size, true);
 

--- a/librz/bin/format/luac/luac_bin.c
+++ b/librz/bin/format/luac/luac_bin.c
@@ -204,7 +204,7 @@ void _luac_build_info(LuaProto *proto, LuacBinInfo *info) {
 	// 1.0 set section name as function_name.code
 	current_offset = proto->code_offset + proto->code_skipped;
 	current_size = proto->code_size;
-	proto_name = rz_str_newf("fcn.%08llx", (ut64)proto_vaddr);
+	proto_name = rz_str_newf("fcn.%08" PFMT64x "", (ut64)proto_vaddr);
 	section_name = rz_str_newf("%s.code", proto_name);
 	luac_add_section(info->section_vec, section_name, current_offset, proto_vaddr, current_size, true);
 

--- a/librz/bin/format/luac/parse.c
+++ b/librz/bin/format/luac/parse.c
@@ -100,7 +100,7 @@ static ut64 lua_parse_number(RzBuffer *buffer, st32 *size, ut64 offset, ut64 dat
 	if (minor <= 3) {
 		const size_t size_offset = sizeof(LUA_INT);
 		if (size_offset + offset > data_size) {
-			RZ_LOG_ERROR("file truncated, offset: %llu, data size: %llu\n", offset, data_size);
+			RZ_LOG_ERROR("file truncated, offset: %" PFMT64u ", data size: %" PFMT64u "\n", offset, data_size);
 			return 0;
 		}
 		*size = (st32)lua_load_int(buffer, offset);
@@ -219,7 +219,7 @@ static ut64 lua_parse_code(LuaProto *proto, RzBuffer *buffer, ut64 offset, ut64 
 	const ut8 instruction_size = (minor == 0) ? 8 : 4;
 	const ut64 total_size = code_size * instruction_size + size_offset;
 	if (total_size + offset > data_size) {
-		RZ_LOG_ERROR("Truncated Code at [0x%llx]\n", offset);
+		RZ_LOG_ERROR("Truncated Code at [0x%" PFMT64x "]\n", offset);
 		return 0;
 	}
 
@@ -471,7 +471,7 @@ static ut64 lua_parse_debug(LuaProto *proto, RzBuffer *buffer, ut64 offset, ut64
 		/* parse absline info */
 		delta_offset = lua_parse_szint(buffer, &entries_cnt, offset, data_size, minor);
 		lua_check_error_offset(delta_offset);
-		RZ_LOG_DEBUG("abs_info_entry entries_cnt: %d (offset: 0x%llx)\n", entries_cnt, offset);
+		RZ_LOG_DEBUG("abs_info_entry entries_cnt: %d (offset: 0x%" PFMT64x ")\n", entries_cnt, offset);
 		offset += delta_offset;
 		for (int i = 0; i < entries_cnt; ++i) {
 			LuaAbsLineinfoEntry *abs_info_entry = lua_new_abs_lineinfo_entry();

--- a/librz/bin/format/mach0/mach0.c
+++ b/librz/bin/format/mach0/mach0.c
@@ -1471,7 +1471,7 @@ static int init_items(struct MACH0_(obj_t) * bin) {
 		}
 
 		if (lc.cmdsize < 1 || off + lc.cmdsize > bin->size) {
-			bprintf("Warning: mach0_header %" PFMT64u " = cmdsize<1. (0x%llx vs 0x%llx)\n", i,
+			bprintf("Warning: mach0_header %" PFMT64u " = cmdsize<1. (0x%" PFMT64x " vs 0x%" PFMT64x ")\n", i,
 				(ut64)(off + lc.cmdsize), (ut64)(bin->size));
 			break;
 		}
@@ -1746,7 +1746,7 @@ static int init_items(struct MACH0_(obj_t) * bin) {
 		}
 
 		if (lc.cmdsize < 1 || off + lc.cmdsize > bin->size) {
-			bprintf("Warning: mach0_header %" PFMT64u " = cmdsize<1. (0x%llx vs 0x%llx)\n", i,
+			bprintf("Warning: mach0_header %" PFMT64u " = cmdsize<1. (0x%" PFMT64x " vs 0x%" PFMT64x ")\n", i,
 				(ut64)(off + lc.cmdsize), (ut64)(bin->size));
 			break;
 		}

--- a/librz/bin/format/pyc/marshal.c
+++ b/librz/bin/format/pyc/marshal.c
@@ -156,7 +156,7 @@ static pyc_object *get_int64_object(RzBuffer *buffer) {
 		return NULL;
 	}
 	ret->type = TYPE_INT64;
-	ret->data = rz_str_newf("%" PFMT64d "", i);
+	ret->data = rz_str_newf("%" PFMT64d, i);
 	if (!ret->data) {
 		RZ_FREE(ret);
 	}

--- a/librz/bin/format/pyc/marshal.c
+++ b/librz/bin/format/pyc/marshal.c
@@ -156,7 +156,7 @@ static pyc_object *get_int64_object(RzBuffer *buffer) {
 		return NULL;
 	}
 	ret->type = TYPE_INT64;
-	ret->data = rz_str_newf("%lld", i);
+	ret->data = rz_str_newf("%" PFMT64d "", i);
 	if (!ret->data) {
 		RZ_FREE(ret);
 	}

--- a/librz/bin/format/xnu/rz_cf_dict.c
+++ b/librz/bin/format/xnu/rz_cf_dict.c
@@ -595,7 +595,7 @@ static void rz_cf_value_integer_free(RzCFValueInteger *integer) {
 }
 
 static void rz_cf_value_integer_print(RzCFValueInteger *integer) {
-	printf("%" PFMT64u "", integer->value);
+	printf("%" PFMT64u, integer->value);
 }
 
 static RzCFValueData *rz_cf_value_data_new(char *string) {

--- a/librz/bin/format/xnu/rz_cf_dict.c
+++ b/librz/bin/format/xnu/rz_cf_dict.c
@@ -595,7 +595,7 @@ static void rz_cf_value_integer_free(RzCFValueInteger *integer) {
 }
 
 static void rz_cf_value_integer_print(RzCFValueInteger *integer) {
-	printf("%llu", integer->value);
+	printf("%" PFMT64u "", integer->value);
 }
 
 static RzCFValueData *rz_cf_value_data_new(char *string) {

--- a/librz/bin/p/bin_dyldcache.c
+++ b/librz/bin/p/bin_dyldcache.c
@@ -472,7 +472,7 @@ static RzPVector /*<RzBinClass *>*/ *dyldcache_classes(RzBinFile *bf) {
 				bf->o->bin_obj = cache;
 
 				if (!klass->name) {
-					RZ_LOG_ERROR("CLASS ERROR AT 0x%llx, is_classlist %d\n", pointer_to_class, is_classlist);
+					RZ_LOG_ERROR("CLASS ERROR AT 0x%" PFMT64x ", is_classlist %d\n", pointer_to_class, is_classlist);
 					klass->name = rz_str_newf("UnnamedClass%u", num_of_unnamed_class);
 					if (!klass->name) {
 						RZ_FREE(klass);

--- a/librz/bin/p/bin_luac.c
+++ b/librz/bin/p/bin_luac.c
@@ -162,7 +162,7 @@ static RzStructuredData *get_structured_data_protos(RzStructuredData *parent, Lu
 	const size_t const_length = rz_pvector_len(proto->const_entries);
 #ifndef RZ_DEBUG
 	char name[16] = { 0 };
-	rz_strf(name, "fcn.%08" PFMT64x "", proto->offset);
+	rz_strf(name, "fcn.%08" PFMT64x, proto->offset);
 
 	char pnd[16] = { 0 };
 	rz_strf(pnd, "%s", proto->proto_name ? (char *)proto->proto_name + 1 : name);

--- a/librz/bin/p/bin_luac.c
+++ b/librz/bin/p/bin_luac.c
@@ -162,7 +162,7 @@ static RzStructuredData *get_structured_data_protos(RzStructuredData *parent, Lu
 	const size_t const_length = rz_pvector_len(proto->const_entries);
 #ifndef RZ_DEBUG
 	char name[16] = { 0 };
-	rz_strf(name, "fcn.%08llx", proto->offset);
+	rz_strf(name, "fcn.%08" PFMT64x "", proto->offset);
 
 	char pnd[16] = { 0 };
 	rz_strf(pnd, "%s", proto->proto_name ? (char *)proto->proto_name + 1 : name);

--- a/librz/config/config.c
+++ b/librz/config/config.c
@@ -403,9 +403,9 @@ RZ_API void rz_config_node_value_format_i(RZ_OUT char *buf, size_t buf_size, con
 		return;
 	}
 	if (i < 1024) {
-		snprintf(buf, buf_size, "%" PFMT64d "", i);
+		snprintf(buf, buf_size, "%" PFMT64d, i);
 	} else {
-		snprintf(buf, buf_size, "0x%08" PFMT64x "", i);
+		snprintf(buf, buf_size, "0x%08" PFMT64x, i);
 	}
 }
 

--- a/librz/core/cesil.c
+++ b/librz/core/cesil.c
@@ -442,7 +442,7 @@ static void initialize_stack(RzCore *core, ut64 addr, ut64 size) {
 		ut64 i;
 		for (i = 0; i < size; i += bs) {
 			ut64 left = RZ_MIN(bs, size - i);
-			//	rz_core_cmdf (core, "wx 10203040 @ 0x%" PFMT64x "", addr);
+			//	rz_core_cmdf (core, "wx 10203040 @ 0x%" PFMT64x, addr);
 			switch (*mode) {
 			case 'd': { // "debrujn"
 				ut8 *buf = (ut8 *)rz_debruijn_pattern(left, 0, NULL);

--- a/librz/core/cesil.c
+++ b/librz/core/cesil.c
@@ -221,7 +221,7 @@ repeat:
 		tail_return_value = 1;
 	}
 	// esil->verbose ?
-	// eprintf ("REPE 0x%llx %s => 0x%llx\n", addr, RZ_STRBUF_SAFEGET (&op.esil), rz_reg_getv (rreg, "PC"));
+	// eprintf ("REPE 0x%" PFMT64x " %s => 0x%" PFMT64x "\n", addr, RZ_STRBUF_SAFEGET (&op.esil), rz_reg_getv (rreg, "PC"));
 
 	ut64 pc = rz_reg_getv(rreg, name);
 	int pcalign = rz_analysis_get_pc_align(core->analysis);
@@ -442,7 +442,7 @@ static void initialize_stack(RzCore *core, ut64 addr, ut64 size) {
 		ut64 i;
 		for (i = 0; i < size; i += bs) {
 			ut64 left = RZ_MIN(bs, size - i);
-			//	rz_core_cmdf (core, "wx 10203040 @ 0x%llx", addr);
+			//	rz_core_cmdf (core, "wx 10203040 @ 0x%" PFMT64x "", addr);
 			switch (*mode) {
 			case 'd': { // "debrujn"
 				ut8 *buf = (ut8 *)rz_debruijn_pattern(left, 0, NULL);
@@ -726,7 +726,7 @@ RZ_IPI void rz_core_analysis_esil_emulate(RzCore *core, ut64 addr, ut64 until_ad
 			rz_reg_setv(rreg, "PC", aop.addr + aop.size);
 			const char *e = RZ_STRBUF_SAFEGET(&aop.esil);
 			if (e && *e) {
-				// eprintf ("   0x%08llx %d  %s\n", aop.addr, ret, aop.mnemonic);
+				// eprintf ("   0x%08" PFMT64x " %d  %s\n", aop.addr, ret, aop.mnemonic);
 				(void)rz_analysis_esil_parse(esil, e);
 			}
 		}

--- a/librz/core/cmd/cmd_debug.c
+++ b/librz/core/cmd/cmd_debug.c
@@ -1534,7 +1534,7 @@ static void asciiart_backtrace(RzCore *core, RzList /*<RzDebugFrame *>*/ *frames
 		rz_cons_printf("                    |            ...         |\n");
 		rz_cons_printf("0x%016" PFMT64x "  |%4s 0x%016" PFMT64x " | %s\n", b, bp, f->addr, "; return address");
 		rz_cons_printf("                    )------------------------(\n");
-		// eprintf ("0x%08llx 0x%08llx 0x%08llx\n", f->addr, s, b);
+		// eprintf ("0x%08" PFMT64x " 0x%08" PFMT64x " 0x%08" PFMT64x "\n", f->addr, s, b);
 		n++;
 	}
 	rz_cons_printf("                    |           ...          |\n");

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -1374,10 +1374,10 @@ static void handle_default_disasm_print_mode(const RzCore *core, const ut64 addr
 	if (show_color) {
 		const char *offsetColor = rz_cons_singleton()->context->pal.offset;
 		if (!ret_val) {
-			rz_cons_printf("%s0x%08" PFMT64x "" Color_RESET "  %10s %s\n",
+			rz_cons_printf("%s0x%08" PFMT64x Color_RESET "  %10s %s\n",
 				offsetColor, addr, "", m_intr);
 		} else {
-			rz_strbuf_appendf(buf, "%s0x%08" PFMT64x "" Color_RESET "  %10s %s\n",
+			rz_strbuf_appendf(buf, "%s0x%08" PFMT64x Color_RESET "  %10s %s\n",
 				offsetColor, addr, "", m_intr);
 		}
 	} else {

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -1443,7 +1443,7 @@ reread:
 				RzListIter *iter;
 				RzIOMap *map;
 				rz_list_foreach (param.boundaries, iter, map) {
-					eprintf("-- %llx %llx\n", map->itv.addr, rz_itv_end(map->itv));
+					eprintf("-- %" PFMT64x " %" PFMT64x "\n", map->itv.addr, rz_itv_end(map->itv));
 					rz_cons_break_push(NULL, NULL);
 					rz_search_pattern_size(core->search, ps);
 					rz_search_pattern(core->search, map->itv.addr, rz_itv_end(map->itv));
@@ -2156,7 +2156,7 @@ RZ_IPI RzCmdStatus rz_cmd_search_pattern_handler(RzCore *core, int argc, const c
 	RzListIter *iter;
 	RzIOMap *map;
 	rz_list_foreach (param.boundaries, iter, map) {
-		eprintf("-- %llx %llx\n", map->itv.addr, rz_itv_end(map->itv));
+		eprintf("-- %" PFMT64x " %" PFMT64x "\n", map->itv.addr, rz_itv_end(map->itv));
 		rz_cons_break_push(NULL, NULL);
 		rz_search_pattern_size(core->search, ps);
 		if (!rz_search_pattern(core->search, map->itv.addr, rz_itv_end(map->itv))) {

--- a/librz/core/csyscall.c
+++ b/librz/core/csyscall.c
@@ -67,10 +67,10 @@ RZ_API RZ_OWN char *rz_core_syscall_as_string(RzCore *core, st64 n, ut64 addr) {
 		if (item->sargs) {
 			switch (item->sargs[i]) {
 			case 'p': // pointer
-				res = rz_str_appendf(res, "0x%08" PFMT64x "", arg);
+				res = rz_str_appendf(res, "0x%08" PFMT64x, arg);
 				break;
 			case 'i':
-				res = rz_str_appendf(res, "%" PFMT64u "", arg);
+				res = rz_str_appendf(res, "%" PFMT64u, arg);
 				break;
 			case 'z':
 				memset(str, 0, sizeof(str));
@@ -91,11 +91,11 @@ RZ_API RZ_OWN char *rz_core_syscall_as_string(RzCore *core, st64 n, ut64 addr) {
 				res = rz_str_appendf(res, "\"%s\"", str);
 			} break;
 			default:
-				res = rz_str_appendf(res, "0x%08" PFMT64x "", arg);
+				res = rz_str_appendf(res, "0x%08" PFMT64x, arg);
 				break;
 			}
 		} else {
-			res = rz_str_appendf(res, "0x%08" PFMT64x "", arg);
+			res = rz_str_appendf(res, "0x%08" PFMT64x, arg);
 		}
 		if (i + 1 < item->args) {
 			res = rz_str_appendf(res, ", ");

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -3292,7 +3292,7 @@ static void ds_cdiv_optimization(RzDisasmState *ds) {
 			if (comma && comma == end) {
 				divisor = revert_cdiv_magic(imm);
 				if (divisor) {
-					rz_cons_printf(" ; CDIV: %lld * 2^n", divisor);
+					rz_cons_printf(" ; CDIV: %" PFMT64d " * 2^n", divisor);
 					break;
 				}
 			}
@@ -4383,7 +4383,7 @@ static int myregwrite(RzAnalysisEsil *esil, const char *name, ut64 *val) {
 				}
 				(void)rz_io_read_at_mapped(core->io, addr,
 					(ut8 *)str, sizeof(str) - 1);
-				//	eprintf ("IS CSTRING 0x%llx %s\n", addr, str);
+				//	eprintf ("IS CSTRING 0x%" PFMT64x " %s\n", addr, str);
 				type = rz_str_newf("(cstr 0x%08" PFMT64x ") ", addr);
 				ds->printed_str_addr = mem_2;
 			} else if (rz_io_is_valid_offset(core->io, addr, 0)) {
@@ -4391,7 +4391,7 @@ static int myregwrite(RzAnalysisEsil *esil, const char *name, ut64 *val) {
 				type = rz_str_newf("(pstr 0x%08" PFMT64x ") ", addr);
 				(void)rz_io_read_at_mapped(core->io, addr,
 					(ut8 *)str, sizeof(str) - 1);
-				//	eprintf ("IS PSTRING 0x%llx %s\n", addr, str);
+				//	eprintf ("IS PSTRING 0x%" PFMT64x " %s\n", addr, str);
 			}
 		}
 

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -1313,7 +1313,7 @@ static void ds_show_refs(RzDisasmState *ds) {
 				if (fcn) {
 					ds_comment(ds, true, "; %s", fcn->name);
 				} else {
-					ds_comment(ds, true, "; 0x%" PFMT64x "", xref->to);
+					ds_comment(ds, true, "; 0x%" PFMT64x, xref->to);
 				}
 			}
 		}

--- a/librz/core/tui/vmenus.c
+++ b/librz/core/tui/vmenus.c
@@ -169,7 +169,7 @@ static ut64 var_functions_show(RzCore *core, int idx, int show, int cols) {
 			if (show) {
 				char *tmp;
 				if (color) {
-					var_functions = rz_str_newf("%c%c %s0x%08" PFMT64x "" Color_RESET " %4" PFMT64d " %s%s" Color_RESET "",
+					var_functions = rz_str_newf("%c%c %s0x%08" PFMT64x Color_RESET " %4" PFMT64d " %s%s" Color_RESET "",
 						(seek == fcn->addr) ? '>' : ' ',
 						(idx == i) ? '*' : ' ',
 						color_addr, fcn->addr, rz_analysis_function_realsize(fcn),
@@ -424,7 +424,7 @@ static ut64 rz_core_visual_analysis_refresh(RzCore *core) {
 		if (color) {
 			rz_cons_strcat(core->cons->context->pal.prompt);
 		}
-		rz_cons_printf("-[ variables ]----- 0x%08" PFMT64x "", addr);
+		rz_cons_printf("-[ variables ]----- 0x%08" PFMT64x, addr);
 		if (color) {
 			rz_cons_strcat("\n" Color_RESET);
 		}

--- a/librz/core/tui/vmenus_graph.c
+++ b/librz/core/tui/vmenus_graph.c
@@ -235,7 +235,7 @@ RZ_IPI int __core_visual_view_graph_update(RzCore *core, RzCoreVisualViewGraph *
 	/* 	__reset_status (status); */
 	/* } */
 
-	char *title = rz_str_newf("[rz-visual-browser] addr=0x%08" PFMT64x " faddr=0x%08" PFMT64x "", status->addr, status->fcn ? status->fcn->addr : 0);
+	char *title = rz_str_newf("[rz-visual-browser] addr=0x%08" PFMT64x " faddr=0x%08" PFMT64x, status->addr, status->fcn ? status->fcn->addr : 0);
 	if (title) {
 		rz_cons_strcat_at(title, 0, 0, w - 1, 2);
 		free(title);

--- a/librz/core/windows_heap_live_debug.c
+++ b/librz/core/windows_heap_live_debug.c
@@ -1338,7 +1338,7 @@ static void w32_list_heaps_blocks(RzCore *core, RzOutputMode mode, bool flag) {
 				ut64 address = (ut64)block->dwAddress - granularity;
 				ut64 unusedBytes = block->extraInfo ? block->extraInfo->unusedBytes : 0;
 				if (flag) {
-					char *name = rz_str_newf("alloc.%" PFMT64x "", address);
+					char *name = rz_str_newf("alloc.%" PFMT64x, address);
 					if (!rz_flag_set(core->flags, name, address, block->dwSize)) {
 						RZ_LOG_ERROR("core: flag cannot be set for block at 0x%" PFMT64x, address);
 					}

--- a/librz/debug/p/native/bt/fuzzy-all.c
+++ b/librz/debug/p/native/bt/fuzzy-all.c
@@ -107,7 +107,7 @@ static RzList /*<RzDebugFrame *>*/ *backtrace_fuzzy(RzDebug *dbg, ut64 at) {
 			frame->size = cursp - oldsp;
 			frame->sp = cursp;
 			frame->bp = oldsp; // addr + (i * wordsize); // -4 || -8
-			// eprintf ("--------------> 0x%llx (%d)\n", addr, frame->size);
+			// eprintf ("--------------> 0x%" PFMT64x " (%d)\n", addr, frame->size);
 			rz_list_append(list, frame);
 			oldsp = cursp;
 		}

--- a/librz/debug/p/native/windows/windows_message.c
+++ b/librz/debug/p/native/windows/windows_message.c
@@ -300,7 +300,7 @@ static RzTable *create_window_table(void) {
 
 static void add_window_to_table(RzTable *tbl, window *win) {
 	rz_return_if_fail(tbl && win);
-	char *handle = rz_str_newf("0x%08" PFMT64x "", (ut64)win->h);
+	char *handle = rz_str_newf("0x%08" PFMT64x, (ut64)win->h);
 	char *pid = rz_str_newf("%lu", win->pid);
 	char *tid = rz_str_newf("%lu", win->tid);
 	rz_table_add_row(tbl, handle, pid, tid, win->name, NULL);

--- a/librz/il/il_vm_eval.c
+++ b/librz/il/il_vm_eval.c
@@ -265,7 +265,7 @@ RZ_API void rz_il_vm_mem_storew(RzILVM *vm, RzILMemIndex index, RzBitVector *key
 	}
 	RzBitVector *old_value = rz_il_mem_loadw(mem, key, rz_bv_len(value), vm->big_endian);
 	if (!rz_il_mem_storew(mem, key, value, vm->big_endian)) {
-		RZ_LOG_ERROR("StoreW mem %u 0x%llx failed\n", (unsigned int)index, rz_bv_to_ut64(key));
+		RZ_LOG_ERROR("StoreW mem %u 0x%" PFMT64x " failed\n", (unsigned int)index, rz_bv_to_ut64(key));
 		goto end;
 	}
 	rz_il_vm_event_add(vm, rz_il_event_mem_write_new(index, key, old_value, value));

--- a/librz/magic/magic-test.c
+++ b/librz/magic/magic-test.c
@@ -494,7 +494,7 @@ static int magic_test_type_quad(RzMagicLine *ml, RzMagicState *ms) {
 
 	result = magic_test_signed(ml, value, (int64_t)ml->test_signed);
 	if (result == !ml->test_not && ml->result != NULL) {
-		magic_add_result(ms, ml, "%" PFMT64d "", (long long)value);
+		magic_add_result(ms, ml, "%" PFMT64d, (long long)value);
 		ms->offset += sizeof value;
 	}
 	return (result);
@@ -626,7 +626,7 @@ static int magic_test_type_uquad(RzMagicLine *ml, RzMagicState *ms) {
 
 	result = magic_test_unsigned(ml, value, (uint64_t)ml->test_unsigned);
 	if (result == !ml->test_not && ml->result != NULL) {
-		magic_add_result(ms, ml, "%" PFMT64u "", (unsigned long long)value);
+		magic_add_result(ms, ml, "%" PFMT64u, (unsigned long long)value);
 		ms->offset += sizeof value;
 	}
 	return (result);

--- a/librz/magic/magic-test.c
+++ b/librz/magic/magic-test.c
@@ -494,7 +494,7 @@ static int magic_test_type_quad(RzMagicLine *ml, RzMagicState *ms) {
 
 	result = magic_test_signed(ml, value, (int64_t)ml->test_signed);
 	if (result == !ml->test_not && ml->result != NULL) {
-		magic_add_result(ms, ml, "%lld", (long long)value);
+		magic_add_result(ms, ml, "%" PFMT64d "", (long long)value);
 		ms->offset += sizeof value;
 	}
 	return (result);
@@ -626,7 +626,7 @@ static int magic_test_type_uquad(RzMagicLine *ml, RzMagicState *ms) {
 
 	result = magic_test_unsigned(ml, value, (uint64_t)ml->test_unsigned);
 	if (result == !ml->test_not && ml->result != NULL) {
-		magic_add_result(ms, ml, "%llu", (unsigned long long)value);
+		magic_add_result(ms, ml, "%" PFMT64u "", (unsigned long long)value);
 		ms->offset += sizeof value;
 	}
 	return (result);

--- a/librz/main/rz-asm.c
+++ b/librz/main/rz-asm.c
@@ -879,7 +879,7 @@ RZ_API int rz_main_rz_asm(int argc, const char *argv[]) {
 					free(usrstr);
 					goto beach;
 				}
-				// eprintf ("SKIP (%s) (%lld)\n", usrstr, skip);
+				// eprintf ("SKIP (%s) (%" PFMT64d ")\n", usrstr, skip);
 				memmove(usrstr, usrstr + skip, len - skip);
 				len -= skip;
 				usrstr[len] = 0;

--- a/librz/sign/flirt.c
+++ b/librz/sign/flirt.c
@@ -892,7 +892,7 @@ static bool read_node_variant_mask(RzFlirtNode *node, ParseStatus *b) {
 		}
 	}
 
-	sig_dbg("dbg: variant_mask %08llx\n", node->variant_mask);
+	sig_dbg("dbg: variant_mask %08" PFMT64x "\n", node->variant_mask);
 	return true;
 }
 

--- a/librz/type/format.c
+++ b/librz/type/format.c
@@ -80,10 +80,10 @@ static void rz_type_format_u128(RzStrBuf *outbuf, int endian, int mode,
 		rz_strbuf_appendf(outbuf, "0x%08" PFMT64x " = (uint128_t)", seeki);
 	}
 	if (endian) {
-		rz_strbuf_appendf(outbuf, "0x%016" PFMT64x "", low);
+		rz_strbuf_appendf(outbuf, "0x%016" PFMT64x, low);
 		rz_strbuf_appendf(outbuf, "%016" PFMT64x, hig);
 	} else {
-		rz_strbuf_appendf(outbuf, "0x%016" PFMT64x "", hig);
+		rz_strbuf_appendf(outbuf, "0x%016" PFMT64x, hig);
 		rz_strbuf_appendf(outbuf, "%016" PFMT64x, low);
 	}
 	if (MUSTSEEJSON) {

--- a/librz/type/function.c
+++ b/librz/type/function.c
@@ -502,7 +502,7 @@ static inline char *callable_name_or_ptr(RZ_NONNULL const RzCallable *callable, 
 				if (array_len == 0) {
 					array_str = rz_str_newf("[%s]", zero_vla ? "0" : "");
 				} else {
-					array_str = rz_str_newf("[%lld]", array_len);
+					array_str = rz_str_newf("[%" PFMT64d "]", array_len);
 				}
 
 				rz_return_val_if_fail(array_str, NULL);

--- a/librz/type/serialize_types.c
+++ b/librz/type/serialize_types.c
@@ -483,10 +483,10 @@ static void save_enum(const RzTypeDB *typedb, Sdb *sdb, const RzBaseType *type) 
 		char *case_sname = rz_str_sanitize_sdb_key(cas->name);
 		sdb_set(sdb,
 			rz_strbuf_setf(&param_key, "enum.%s.%s", sname, case_sname),
-			rz_strbuf_setf(&param_val, "0x%" PFMT64x "", cas->val));
+			rz_strbuf_setf(&param_val, "0x%" PFMT64x, cas->val));
 
 		sdb_set(sdb,
-			rz_strbuf_setf(&param_key, "enum.%s.0x%" PFMT64x "", sname, cas->val),
+			rz_strbuf_setf(&param_key, "enum.%s.0x%" PFMT64x, sname, cas->val),
 			case_sname);
 		free(case_sname);
 
@@ -522,7 +522,7 @@ static void save_atomic_type(const RzTypeDB *typedb, Sdb *sdb, const RzBaseType 
 
 	sdb_set(sdb,
 		rz_strbuf_setf(&key, "type.%s.size", sname),
-		rz_strbuf_setf(&val, "%" PFMT64u "", type->size));
+		rz_strbuf_setf(&val, "%" PFMT64u, type->size));
 	sdb_set(sdb,
 		rz_strbuf_setf(&key, "type.%s.typeclass", sname),
 		rz_type_typeclass_as_string(get_base_type_typeclass(type)));

--- a/librz/util/graph_impl.c
+++ b/librz/util/graph_impl.c
@@ -531,7 +531,7 @@ static bool rz_graph_matrix_impl_require_capacity(RzGraphMatrixImpl *impl, ut64 
 
 	RzGraphEdge **new_matrix = RZ_NEWS0(RzGraphEdge *, new_cap * new_cap);
 	if (!new_matrix) {
-		RZ_LOG_WARN("Failed to adjust matrix capacity to %" PFMT64u "", new_cap);
+		RZ_LOG_WARN("Failed to adjust matrix capacity to %" PFMT64u, new_cap);
 		return false;
 	}
 
@@ -839,7 +839,7 @@ static RzGraphMatrixImpl *rz_graph_matrix_impl_init(ut64 capacity) {
 	impl->capacity = capacity ? capacity : MATRIX_DEFAULT_CAPACITY;
 	impl->matrix = RZ_NEWS0(RzGraphEdge *, impl->capacity * impl->capacity);
 	if (!impl->matrix) {
-		RZ_LOG_WARN("Failed to init graph matrix with capacity %" PFMT64u "", impl->capacity)
+		RZ_LOG_WARN("Failed to init graph matrix with capacity %" PFMT64u, impl->capacity)
 		rz_matrix_fini(impl);
 		return NULL;
 	}

--- a/librz/util/graph_impl.c
+++ b/librz/util/graph_impl.c
@@ -531,7 +531,7 @@ static bool rz_graph_matrix_impl_require_capacity(RzGraphMatrixImpl *impl, ut64 
 
 	RzGraphEdge **new_matrix = RZ_NEWS0(RzGraphEdge *, new_cap * new_cap);
 	if (!new_matrix) {
-		RZ_LOG_WARN("Failed to adjust matrix capacity to %llu", new_cap);
+		RZ_LOG_WARN("Failed to adjust matrix capacity to %" PFMT64u "", new_cap);
 		return false;
 	}
 
@@ -839,7 +839,7 @@ static RzGraphMatrixImpl *rz_graph_matrix_impl_init(ut64 capacity) {
 	impl->capacity = capacity ? capacity : MATRIX_DEFAULT_CAPACITY;
 	impl->matrix = RZ_NEWS0(RzGraphEdge *, impl->capacity * impl->capacity);
 	if (!impl->matrix) {
-		RZ_LOG_WARN("Failed to init graph matrix with capacity %llu", impl->capacity)
+		RZ_LOG_WARN("Failed to init graph matrix with capacity %" PFMT64u "", impl->capacity)
 		rz_matrix_fini(impl);
 		return NULL;
 	}

--- a/subprojects/rzqnx/src/core.c
+++ b/subprojects/rzqnx/src/core.c
@@ -175,7 +175,7 @@ int qnxr_connect(libqnxr_t *g, const char *host, int port) {
 	nto_send(g, sizeof(g->tran.pkt.connect), 0);
 
 	if (g->recv.pkt.hdr.cmd == DSrMsg_err) {
-		eprintf("%s: connection failed: %lld\n", __func__,
+		eprintf("%s: connection failed: %" PFMT64d "\n", __func__,
 			EXTRACT_SIGNED_INTEGER(&g->recv.pkt.err.err, 4));
 		return -1;
 	}
@@ -195,7 +195,7 @@ int qnxr_connect(libqnxr_t *g, const char *host, int port) {
 		g->target_proto_major = (g->target_proto_major >> 8) & DSMSG_PROTOVER_MAJOR;
 		g->target_proto_minor = g->target_proto_minor & DSMSG_PROTOVER_MINOR;
 	} else {
-		eprintf("Connection failed (Protocol Version Query): %lld\n",
+		eprintf("Connection failed (Protocol Version Query): %" PFMT64d "\n",
 			EXTRACT_SIGNED_INTEGER(&g->recv.pkt.err.err, 4));
 		return -1;
 	}

--- a/test/unit/test_annotated_code.c
+++ b/test/unit/test_annotated_code.c
@@ -277,17 +277,17 @@ static bool test_rz_annotated_code_line_offsets(void) {
 	mu_assert_eq(offsets->len, 6, "Number of offsets not expected");
 
 	ut64 *off = rz_vector_index_ptr(offsets, 0);
-	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%" PFMT64u "");
+	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%" PFMT64u);
 	off = rz_vector_index_ptr(offsets, 1);
-	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%" PFMT64u "");
+	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%" PFMT64u);
 	off = rz_vector_index_ptr(offsets, 2);
-	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%" PFMT64u "");
+	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%" PFMT64u);
 	off = rz_vector_index_ptr(offsets, 3);
-	mu_assert_eq_fmt(*off, (ut64)4440, "Unexpected offset", "%" PFMT64u "");
+	mu_assert_eq_fmt(*off, (ut64)4440, "Unexpected offset", "%" PFMT64u);
 	off = rz_vector_index_ptr(offsets, 4);
-	mu_assert_eq_fmt(*off, (ut64)4447, "Unexpected offset", "%" PFMT64u "");
+	mu_assert_eq_fmt(*off, (ut64)4447, "Unexpected offset", "%" PFMT64u);
 	off = rz_vector_index_ptr(offsets, 5);
-	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%" PFMT64u "");
+	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%" PFMT64u);
 
 	rz_vector_free(offsets);
 	rz_annotated_code_free(code);

--- a/test/unit/test_annotated_code.c
+++ b/test/unit/test_annotated_code.c
@@ -277,17 +277,17 @@ static bool test_rz_annotated_code_line_offsets(void) {
 	mu_assert_eq(offsets->len, 6, "Number of offsets not expected");
 
 	ut64 *off = rz_vector_index_ptr(offsets, 0);
-	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%llu");
+	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%" PFMT64u "");
 	off = rz_vector_index_ptr(offsets, 1);
-	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%llu");
+	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%" PFMT64u "");
 	off = rz_vector_index_ptr(offsets, 2);
-	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%llu");
+	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%" PFMT64u "");
 	off = rz_vector_index_ptr(offsets, 3);
-	mu_assert_eq_fmt(*off, (ut64)4440, "Unexpected offset", "%llu");
+	mu_assert_eq_fmt(*off, (ut64)4440, "Unexpected offset", "%" PFMT64u "");
 	off = rz_vector_index_ptr(offsets, 4);
-	mu_assert_eq_fmt(*off, (ut64)4447, "Unexpected offset", "%llu");
+	mu_assert_eq_fmt(*off, (ut64)4447, "Unexpected offset", "%" PFMT64u "");
 	off = rz_vector_index_ptr(offsets, 5);
-	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%llu");
+	mu_assert_eq_fmt(*off, UT64_MAX, "Unexpected offset", "%" PFMT64u "");
 
 	rz_vector_free(offsets);
 	rz_annotated_code_free(code);

--- a/test/unit/test_buf.c
+++ b/test/unit/test_buf.c
@@ -1442,7 +1442,7 @@ bool test_rz_buf_negative(bool use_slice) {
 
 int all_tests() {
 	time_t seed = time(0);
-	printf("Jamie Seed: %llu\n", (unsigned long long)seed);
+	printf("Jamie Seed: %" PFMT64u "\n", (unsigned long long)seed);
 	srand(seed);
 	mu_run_test(test_rz_buf_file);
 	mu_run_test(test_rz_buf_bytes);

--- a/test/unit/test_endian.c
+++ b/test/unit/test_endian.c
@@ -487,14 +487,14 @@ const ut8 blu64[32] = {
 // clang-format on
 #define check_offset(endianness, size, offset, prev_offset, expected) \
 	ut##size val##size = rz_read_##endianness##size##_offset(blu64, &offset); \
-	mu_assert_eq_fmt(val##size, expected, "wrong value of read " #endianness #size, "0x%04llx"); \
+	mu_assert_eq_fmt(val##size, expected, "wrong value of read " #endianness #size, "0x%04" PFMT64x ""); \
 	prev_offset += sizeof(val##size); \
 	mu_assert_eq(offset, prev_offset, "wrong offset after read " #endianness #size);
 
 #define check_offset128(endianness, offset, prev_offset, expected) \
 	ut128 val128 = rz_read_##endianness##128_offset(blu64, &offset); \
-	mu_assert_eq_fmt(val128.High, expected.High, "wrong High value of read " #endianness "128", "0x%04llx"); \
-	mu_assert_eq_fmt(val128.Low, expected.Low, "wrong Low value of read " #endianness "128", "0x%04llx"); \
+	mu_assert_eq_fmt(val128.High, expected.High, "wrong High value of read " #endianness "128", "0x%04" PFMT64x ""); \
+	mu_assert_eq_fmt(val128.Low, expected.Low, "wrong Low value of read " #endianness "128", "0x%04" PFMT64x ""); \
 	prev_offset += sizeof(val128); \
 	mu_assert_eq(offset, prev_offset, "wrong offset after read " #endianness "128");
 

--- a/test/unit/test_endian.c
+++ b/test/unit/test_endian.c
@@ -487,14 +487,14 @@ const ut8 blu64[32] = {
 // clang-format on
 #define check_offset(endianness, size, offset, prev_offset, expected) \
 	ut##size val##size = rz_read_##endianness##size##_offset(blu64, &offset); \
-	mu_assert_eq_fmt(val##size, expected, "wrong value of read " #endianness #size, "0x%04" PFMT64x ""); \
+	mu_assert_eq_fmt(val##size, expected, "wrong value of read " #endianness #size, "0x%04" PFMT64x); \
 	prev_offset += sizeof(val##size); \
 	mu_assert_eq(offset, prev_offset, "wrong offset after read " #endianness #size);
 
 #define check_offset128(endianness, offset, prev_offset, expected) \
 	ut128 val128 = rz_read_##endianness##128_offset(blu64, &offset); \
-	mu_assert_eq_fmt(val128.High, expected.High, "wrong High value of read " #endianness "128", "0x%04" PFMT64x ""); \
-	mu_assert_eq_fmt(val128.Low, expected.Low, "wrong Low value of read " #endianness "128", "0x%04" PFMT64x ""); \
+	mu_assert_eq_fmt(val128.High, expected.High, "wrong High value of read " #endianness "128", "0x%04" PFMT64x); \
+	mu_assert_eq_fmt(val128.Low, expected.Low, "wrong Low value of read " #endianness "128", "0x%04" PFMT64x); \
 	prev_offset += sizeof(val128); \
 	mu_assert_eq(offset, prev_offset, "wrong offset after read " #endianness "128");
 

--- a/test/unit/test_vector.c
+++ b/test/unit/test_vector.c
@@ -1603,7 +1603,7 @@ static bool test_array_bounds_fuzz(void) {
 
 static int all_tests(void) {
 	time_t seed = time(0);
-	printf("Gillian Seed: %llu\n", (unsigned long long)seed);
+	printf("Gillian Seed: %" PFMT64u "\n", (unsigned long long)seed);
 	srand(seed);
 	mu_run_test(test_vector_init);
 	mu_run_test(test_vector_new);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr converts `%ll` format specifiers in the code to PFMT64. The bash commands used were:

```bash
REGEX='\(%[-+ *#.[:digit:]]*\)ll\([xudo]\)' bash -c 'git grep -l "$REGEX" -- *.c *.inc | xargs -n 1 sed -i "s/$REGEX/\1\" PFMT64\2 \"/g"'
REGEX='\(PFMT64[xudo]\) ""' bash -c 'git grep -l "$REGEX" -- *.c *.inc | xargs -n 1 sed -i "s/$REGEX/\1/g"'
```

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
