### PR TITLE
Fix rz_vector_set() behavior to match the rz_pvector version one.

### DIFF
--- a/librz/include/rz_vector.h
+++ b/librz/include/rz_vector.h
@@ -185,11 +185,16 @@ static inline size_t rz_vector_capacity(RzVector *vec) {
 
 /**
  * \brief Set element at \p index.
+ * This is a simple memcpy. Vector length is not updated.
+ * Use rz_vector_assign_at() if this is needed.
+ *
  * \param vec The vector to update.
+ * \param index Index where to write the element to.
+ * \param elem Pointer to the element to copy.
  */
 static inline void rz_vector_set(RZ_BORROW RzVector *vec, size_t index, const RZ_NONNULL void *elem) {
 	rz_return_if_fail(vec && index < rz_vector_capacity(vec) && elem);
-	rz_vector_assign_at(vec, index, elem);
+	memcpy((ut8 *)vec->a + (index * vec->elem_size), elem, vec->elem_size);
 }
 
 /*

--- a/librz/include/rz_vector.h
+++ b/librz/include/rz_vector.h
@@ -183,19 +183,7 @@ static inline size_t rz_vector_capacity(RzVector *vec) {
 	return vec->capacity;
 }
 
-/**
- * \brief Set element at \p index.
- * This is a simple memcpy. Vector length is not updated.
- * Use rz_vector_assign_at() if this is needed.
- *
- * \param vec The vector to update.
- * \param index Index where to write the element to.
- * \param elem Pointer to the element to copy.
- */
-static inline void rz_vector_set(RZ_BORROW RzVector *vec, size_t index, const RZ_NONNULL void *elem) {
-	rz_return_if_fail(vec && index < rz_vector_capacity(vec) && elem);
-	memcpy((ut8 *)vec->a + (index * vec->elem_size), elem, vec->elem_size);
-}
+RZ_API void rz_vector_set(RZ_BORROW RzVector *vec, size_t index, const RZ_NONNULL void *elem);
 
 /*
  * example:

--- a/librz/util/vector.c
+++ b/librz/util/vector.c
@@ -96,6 +96,22 @@ static void rz_vector_assign(RzVector *vec, void *p, const void *elem) {
 }
 
 /**
+ * \brief Set element at \p index.
+ * This is a simple memcpy. Vector length is not updated.
+ * Use rz_vector_assign_at() if this is needed.
+ *
+ * \param vec The vector to update.
+ * \param index Index where to write the element to.
+ * \param elem Pointer to the element to copy.
+ */
+RZ_API void rz_vector_set(RZ_BORROW RzVector *vec, size_t index, const RZ_NONNULL void *elem) {
+	rz_return_if_fail(vec && index < rz_vector_capacity(vec) && elem);
+	void *p = rz_vector_index_ptr(vec, index);
+	rz_return_if_fail(p);
+	rz_vector_assign(vec, p, elem);
+}
+
+/**
  * \brief Set \p n elements, starting at element \p i to \p c.
  */
 static void rz_vector_zeroize(RzVector *vec, size_t i, size_t n) {

--- a/test/unit/test_vector.c
+++ b/test/unit/test_vector.c
@@ -166,6 +166,18 @@ static bool test_vector_free(void) {
 	mu_end;
 }
 
+static bool test_vector_set(void) {
+	RzVector *v = rz_vector_new(sizeof(ut32), NULL, NULL);
+	rz_vector_reserve(v, 10);
+	mu_assert_eq(rz_vector_len(v), 0, "Should be empty");
+	ut32 data = 0xffeeddcc;
+	rz_vector_set(v, 5, &data);
+	mu_assert_memeq((ut8 *)v->a + (v->elem_size * 5), (ut8 *)&data, sizeof(ut32), "Data was not written");
+	mu_assert_eq(rz_vector_len(v), 0, "_set should not change the length");
+	rz_vector_free(v);
+	mu_end;
+}
+
 static bool test_vector_clone(void) {
 	RzVector v;
 	init_test_vector(&v, 5, 0, NULL, NULL);
@@ -1640,6 +1652,7 @@ static int all_tests(void) {
 	mu_run_test(test_vector_fini);
 	mu_run_test(test_vector_clear);
 	mu_run_test(test_vector_free);
+	mu_run_test(test_vector_set);
 	mu_run_test(test_vector_clone);
 	mu_run_test(test_vector_empty);
 	mu_run_test(test_vector_remove_at);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

`rz_pvector_set` does:

```c
static inline void rz_pvector_set(RzPVector *vec, size_t index, void *e) {
	rz_return_if_fail(vec && index < rz_pvector_capacity(vec));
	((void **)vec->v.a)[index] = e;
}
```

But the `rz_vector` version didn't.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
