### PR TITLE
librz/util/vector: fix pointer size calculation

### DIFF
--- a/librz/util/vector.c
+++ b/librz/util/vector.c
@@ -100,7 +100,7 @@ static void rz_vector_assign(RzVector *vec, void *p, const void *elem) {
  */
 static void rz_vector_zeroize(RzVector *vec, size_t i, size_t n) {
 	rz_return_if_fail(vec);
-	memset(vec->a + (vec->elem_size * i), 0, vec->elem_size * n);
+	memset((ut8 *)vec->a + (vec->elem_size * i), 0, vec->elem_size * n);
 }
 
 /**

--- a/test/unit/test_vector.c
+++ b/test/unit/test_vector.c
@@ -1128,9 +1128,9 @@ static bool test_pvector_assign_at(void) {
 	mu_assert_eq(rz_pvector_len(&v), 7, "Length was not updated.");
 
 	ut32 *zeroed[1] = { 0 };
-	mu_assert_memeq(v.v.a + sizeof(ut32 *) * 5, (ut8 *)zeroed, sizeof(ut32 *), "Memory was not zeroed");
+	mu_assert_memeq((ut8 *)v.v.a + sizeof(ut32 *) * 5, (ut8 *)zeroed, sizeof(ut32 *), "Memory was not zeroed");
 	// If this line fails on a machine, it might be because NULL != 0 on it.
-	mu_assert_memeq(v.v.a + sizeof(ut32 *) * 6, (ut8 *)zeroed, sizeof(ut32 *), "Memory was not zeroed");
+	mu_assert_memeq((ut8 *)v.v.a + sizeof(ut32 *) * 6, (ut8 *)zeroed, sizeof(ut32 *), "Memory was not zeroed");
 
 	x = malloc(sizeof(ut32));
 	*x = 9;
@@ -1139,8 +1139,8 @@ static bool test_pvector_assign_at(void) {
 	mu_assert_eq(rz_pvector_len(&v), 10, "Length was not updated.");
 	mu_assert_eq(*((ut32 **)v.v.a)[9], 9, "Value was not set.");
 
-	mu_assert_memeq(v.v.a + sizeof(ut32 *) * 7, (ut8 *)zeroed, sizeof(ut32 *), "Memory was not zeroed");
-	mu_assert_memeq(v.v.a + sizeof(ut32 *) * 8, (ut8 *)zeroed, sizeof(ut32 *), "Memory was not zeroed");
+	mu_assert_memeq((ut8 *)v.v.a + sizeof(ut32 *) * 7, (ut8 *)zeroed, sizeof(ut32 *), "Memory was not zeroed");
+	mu_assert_memeq((ut8 *)v.v.a + sizeof(ut32 *) * 8, (ut8 *)zeroed, sizeof(ut32 *), "Memory was not zeroed");
 
 	rz_pvector_purge(&v);
 	mu_assert_eq(rz_pvector_len(&v), 0, "Length after purge.");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Fixes this MSVC error:
```
523/2515] Compiling C object librz/util/rz_util.lib.p/vector.c.obj
FAILED: [code=2] librz/util/rz_util.lib.p/vector.c.obj 
"cl" "-Ilibrz\util\rz_util.lib.p" "-I." "-I.." "-Ilibrz" "-I..\librz" "-Ilibrz\include" "-I..\librz\include" "-Ilibrz\util\sdb\src" "-I..\librz\util\sdb\src" "-Isubprojects\pcre2-10.47" "-I..\subprojects\pcre2-10.47" "-I..\subprojects\pcre2-10.47\src" "-I..\subprojects\softfloat\include" "-Isubprojects\zlib-1.3.1" "-I..\subprojects\zlib-1.3.1" "-I..\subprojects\xz-5.8.1\src\liblzma\api" "/MT" "/nologo" "/showIncludes" "/utf-8" "/W2" "/O2" "/Gw" "-DPSAPI_VERSION=1" "-DRZ_PLUGIN_INCORE=1" "-DSUPPORTS_PCRE2_JIT" "-DZYDIS_STATIC_BUILD" "/arch:SSE2" "-DLZMA_API_STATIC" "/Fdlibrz\util\rz_util.lib.p\vector.c.pdb" /Folibrz/util/rz_util.lib.p/vector.c.obj "/c" ../librz/util/vector.c
cl : Command line warning D9002 : ignoring unknown option '/arch:SSE2'
../librz/util/vector.c(103): error C2036: 'void *': unknown size
../librz/util/vector.c(686): warning C4047: 'return': 'bool' differs in levels of indirection from 'void *'
[524/2515] Compiling C object librz/util/rz_util.lib.p/version.c.obj
cl : Command line warning D9002 : ignoring unknown option '/arch:SSE2'
[525/2515] Compiling C object librz/util/rz_util.lib.p/utf8.c.obj
cl : Command line warning D9002 : ignoring unknown option '/arch:SSE2'
ninja: build stopped: subcommand failed.
```

**Test plan**

CI is green