### PR TITLE
Fix RzILOpEffect leak in arm_il64.c

### DIFF
--- a/librz/arch/isa/arm/arm_il64.c
+++ b/librz/arch/isa/arm/arm_il64.c
@@ -1262,6 +1262,7 @@ static RzILOpEffect *ldr(cs_insn *insn) {
 	}
 	RzILOpEffect *eff1 = load_effect(loadsz, is_signed, dst_reg, addr);
 	if (!eff1) {
+		rz_il_op_effect_free(eff);
 		return NULL;
 	}
 	eff = eff ? SEQ2(eff, eff1) : eff1;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

after so many hours of finding the cause of stubborn 16leaks in https://github.com/rizinorg/rizin/pull/6108#issuecomment-4299106756

finally found the leak

[CI trace](https://github.com/rizinorg/rizin/actions/runs/24785988456/job/72530039542)  -ignore the first leak its already fixed in https://github.com/rizinorg/rizin/pull/6278

<img width="704" height="169" alt="image" src="https://github.com/user-attachments/assets/75f9a8e0-eb50-4899-83b1-ab1ac558022e" />

see all 16leaks are from `ldr` instructions rzil lifting

trace shows that `rz_il_op_new_set` is leaking (=SETL )
```c
	RzILOpEffect *eff = NULL;
	if (pair) {
		eff = SETL("addr", addr);
		addr = VARL("addr");
	}
	RzILOpEffect *eff1 = load_effect(loadsz, is_signed, dst_reg, addr);
	if (!eff1) {
		return NULL;
	}
	eff = eff ? SEQ2(eff, eff1) : eff1;
```

which means RzILOpEffect is leaking

when `eff1` is null, `eff` is not freed :)


...

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
