### PR TITLE
librz/io: fix book link in io_mach

### DIFF
--- a/librz/io/p/io_mach.c
+++ b/librz/io/p/io_mach.c
@@ -387,7 +387,7 @@ static RzIODesc *__open(RzIO *io, const char *file, int rw, int mode) {
 			perror("ptrace: Cannot attach");
 			eprintf("\n\nPlease ensure your rizin binary is signed and it has the right entitlements to make debugger work. ");
 			eprintf("Be aware that binaries signed by Apple cannot be debugged due to the Apple System Integrity Protection (SIP).\n");
-			eprintf("\nFor more info look at: https://book.rizin.re/debugger/apple.html#sign-rizin-binary\n\n");
+			eprintf("\nFor more info look at: https://book.rizin.re/src/debugger/apple.html#sign-rizin-binary\n\n");
 			eprintf("ERRNO: %d (EINVAL)\n", errno);
 			break;
 		default:


### PR DESCRIPTION
The existing link is not working anymore.