### PR TITLE
Macos coredump

### DIFF
--- a/librz/debug/p/native/xnu/xnu_debug.c
+++ b/librz/debug/p/native/xnu/xnu_debug.c
@@ -299,13 +299,13 @@ int xnu_reg_write(RzDebug *dbg, int type, const ut8 *buf, int size) {
 		memcpy(&th->drx.uds.ds32, buf, RZ_MIN(size, sizeof(th->drx)));
 #elif __i386__
 		memcpy(&th->drx.uds.ds64, buf, RZ_MIN(size, sizeof(th->drx)));
-#elif __arm64 || __aarch64
+#elif __arm64__ || __aarch64__
 		if (dbg->bits == RZ_SYS_BITS_64) {
 			memcpy(&th->debug.drx64, buf, RZ_MIN(size, sizeof(th->debug.drx64)));
 		} else {
 			memcpy(&th->debug.drx32, buf, RZ_MIN(size, sizeof(th->debug.drx32)));
 		}
-#elif __arm || __armv7 || __arm__ || __armv7__
+#elif __arm__ || __armv7__
 		memcpy(&th->debug.drx, buf, RZ_MIN(size, sizeof(th->debug.drx)));
 #endif
 		ret = rz_xnu_thread_set_drx(ctx, th);
@@ -470,7 +470,7 @@ static void xnu_free_threads_ports (RzDebugPid *p) {
 RzList *xnu_thread_list(RzDebug *dbg, int pid, RzList *list) {
 	rz_return_val_if_fail(dbg && dbg->plugin_data, NULL);
 	RzXnuDebug *ctx = dbg->plugin_data;
-#if __arm__ || __arm64__ || __aarch_64__
+#if __arm__ || __arm64__ || __aarch64__
 #define CPU_PC (dbg->bits == RZ_SYS_BITS_64) ? state.arm64.__pc : state.arm32.__pc
 #elif __POWERPC__
 #if __DARWIN_UNIX03
@@ -590,15 +590,14 @@ int xnu_get_vmmap_entries_for_pid(RzXnuDebug *ctx, pid_t pid) {
 
 static void get_mach_header_sizes(size_t *mach_header_sz,
 	size_t *segment_command_sz) {
-#if __ppc64__ || __x86_64__
+#if __ppc64__ || __x86_64__ || __arm64__ || __aarch64__
 	*mach_header_sz = sizeof(struct mach_header_64);
 	*segment_command_sz = sizeof(struct segment_command_64);
-#elif __i386__ || __ppc__ || __POWERPC__
+#elif __i386__ || __ppc__ || __POWERPC__ || __arm__ || __armv7__
 	*mach_header_sz = sizeof(struct mach_header);
 	*segment_command_sz = sizeof(struct segment_command);
 #else
 #endif
-	// XXX: What about arm?
 }
 
 /**
@@ -639,7 +638,7 @@ static cpu_subtype_t xnu_get_cpu_subtype(void) {
 
 static void xnu_build_corefile_header(vm_offset_t header,
 	int segment_count, int thread_count, int command_size, pid_t pid) {
-#if __ppc64__ || __x86_64__ || (defined(TARGET_OS_MAC) && defined(__aarch64__))
+#if __ppc64__ || __x86_64__ || __arm64__ || __aarch64__
 	struct mach_header_64 *mh64;
 	mh64 = (struct mach_header_64 *)header;
 	mh64->magic = MH_MAGIC_64;
@@ -649,7 +648,7 @@ static void xnu_build_corefile_header(vm_offset_t header,
 	mh64->ncmds = segment_count + thread_count;
 	mh64->sizeofcmds = command_size;
 	mh64->reserved = 0; // 8-byte alignment
-#elif __i386__ || __ppc__ || __POWERPC__
+#elif __i386__ || __ppc__ || __POWERPC__ || __arm__ || __armv7__
 	struct mach_header *mh;
 	mh = (struct mach_header *)header;
 	mh->magic = MH_MAGIC;
@@ -686,18 +685,18 @@ static int xnu_dealloc_threads(RzXnuDebug *ctx, RzList *threads) {
 /* XXX Maybe this function needs refactoring, but I haven't come up with */
 /* XXX a better way to do it yet. */
 static int xnu_write_mem_maps_to_buffer(RzXnuDebug *ctx, RzBuffer *buffer, RzList *mem_maps, int start_offset,
-	vm_offset_t header, int header_end, int segment_command_sz, int *hoffset_out) {
+	vm_offset_t header, size_t header_end, size_t segment_command_sz, size_t *hoffset_out) {
 	RzListIter *iter, *iter2;
 	RzDebugMap *curr_map;
-	int hoffset = header_end;
+	size_t hoffset = header_end;
 	kern_return_t kr = KERN_SUCCESS;
 	int error = 0;
 	ssize_t rc = 0;
 
 #define CAST_DOWN(type, addr) (((type)((uintptr_t)(addr))))
-#if __ppc64__ || __x86_64__ || (defined(TARGET_OS_MAC) && defined(__aarch64__))
+#if __ppc64__ || __x86_64__ || __arm64__ || __aarch64__
 	struct segment_command_64 *sc64;
-#elif __i386__ || __ppc__ || __POWERPC__
+#elif __i386__ || __ppc__ || __POWERPC__ || __arm__ || __armv7__
 	struct segment_command *sc;
 	int foffset = 0; // start_offset;
 #endif
@@ -706,7 +705,7 @@ static int xnu_write_mem_maps_to_buffer(RzXnuDebug *ctx, RzBuffer *buffer, RzLis
 			curr_map->addr, curr_map->addr_end, curr_map->size);
 
 		vm_map_offset_t vmoffset = curr_map->addr;
-#if __ppc64__ || __x86_64__ || (defined(TARGET_OS_MAC) && defined(__aarch64__))
+#if __ppc64__ || __x86_64__ || __arm64__ || __aarch64__
 		sc64 = (struct segment_command_64 *)(header + hoffset);
 		sc64->cmd = LC_SEGMENT_64;
 		sc64->cmdsize = sizeof(struct segment_command_64);
@@ -716,7 +715,7 @@ static int xnu_write_mem_maps_to_buffer(RzXnuDebug *ctx, RzBuffer *buffer, RzLis
 		sc64->maxprot = xwrz_testwx(curr_map->user);
 		sc64->initprot = xwrz_testwx(curr_map->perm);
 		sc64->nsects = 0;
-#elif __i386__ || __ppc__ || __POWERPC__
+#elif __i386__ || __ppc__ || __POWERPC__ || __arm__ || __armv7__
 		sc = (struct segment_command *)(header + hoffset);
 		sc->cmd = LC_SEGMENT;
 		sc->cmdsize = sizeof(struct segment_command);
@@ -869,7 +868,7 @@ bool xnu_generate_corefile(RzDebug *dbg, RzBuffer *dest) {
 	size_t mach_header_sz;
 	size_t segment_command_sz;
 	size_t padding_sz;
-	int hoffset;
+	size_t hoffset;
 
 	RzBuffer *mem_maps_buffer;
 	vm_offset_t header;

--- a/librz/debug/p/native/xnu/xnu_debug.c
+++ b/librz/debug/p/native/xnu/xnu_debug.c
@@ -555,7 +555,7 @@ int xnu_get_vmmap_entries_for_pid(RzXnuDebug *ctx, pid_t pid) {
 	kern_return_t kr = KERN_SUCCESS;
 	vm_address_t address = 0;
 	vm_size_t size = 0;
-	int n = 1;
+	int n = 0;
 
 	for (;;) {
 		mach_msg_type_number_t count;

--- a/test/db/archos/darwin-arm64/dbg
+++ b/test/db/archos/darwin-arm64/dbg
@@ -54,6 +54,31 @@ stp fp, lr, [sp, -0x10]!
 EOF
 RUN
 
+NAME=dg gcore issue 3054
+FILE=bins/mach0/hello-macos-arm64
+ARGS=-d
+BROKEN=1
+TIMEOUT=10
+CMDS=<<EOF
+!rm -f .tmp/core.issue3054
+dg .tmp/core.issue3054
+!RZ_NOPLUGINS=1 rz-bin -I .tmp/core.issue3054
+!rm -f .tmp/core.issue3054
+EOF
+REGEXP_FILTER_OUT=(\[Info\]|arch\s+arm|bintype\s+mach0|bits\s+64|class\s+MACH064|os\s+darwin)
+EXPECT=<<EOF
+[Info]
+arch     arm
+bintype  mach0
+bits     64
+class    MACH064
+os       darwin
+EOF
+EXPECT_ERR=<<EOF
+WARNING: core: Writing to file '.tmp/core.issue3054'
+EOF
+RUN
+
 NAME=maps
 FILE=bins/mach0/hello-macos-arm64
 ARGS=-d


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

- some `size_t` converted to `int` and viceversa
- missed handling of arm64
- number of segment counts was wrong 

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Expected output:
```
$ ./build-xnu/binrz/rizin/rizin -d $(which rz-ax)
[0x102e6c9c0]> dg
WARNING: core: Writing to file 'core.98610'
Writing section from 0x102d20000 to 0x102d24000 (16384)
Writing section from 0x102d24000 to 0x102d28000 (16384)
Writing section from 0x102d28000 to 0x102d2c000 (16384)
Writing section from 0x102e68000 to 0x102f10000 (688128)
Writing section from 0x102f10000 to 0x102f14000 (16384)
Writing section from 0x102f14000 to 0x102f1c000 (32768)
Writing section from 0x102f1c000 to 0x102f20000 (16384)
Writing section from 0x102f20000 to 0x102f24000 (16384)
Writing section from 0x102f24000 to 0x102f48000 (147456)
Writing section from 0x102f48000 to 0x102fa8000 (393216)
Writing section from 0x1690e0000 to 0x16c8e4000 (58736640)
Writing section from 0x16c8e4000 to 0x16d0e0000 (8372224)
Writing section from 0x180000000 to 0x300000000 (6442450944)
Writing section from 0xfc0000000 to 0x1000000000 (1073741824)
Writing section from 0x1000000000 to 0x7000000000 (412316860416)
[DEBUG] tc location: 0x458
[DEBUG] 1/1
[0x102e6c9c0]>
```

```
$ ./build-xnu/binrz/rizin/rizin core.98610
[0x102d20000]> oml
 1 fd: 3 +0x00000000 0x102d20000 * 0x102d23fff r-x fmap.
 2 fd: 3 +0x00000000 0x102d24000 - 0x102d27fff r-- fmap.
 3 fd: 3 +0x00000000 0x102d28000 - 0x102d2bfff r-- fmap.
 4 fd: 3 +0x00000000 0x102e68000 - 0x102f0ffff r-x fmap.
 5 fd: 3 +0x00000000 0x102f10000 - 0x102f13fff r-- fmap.
 6 fd: 3 +0x00000000 0x102f14000 - 0x102f1bfff r-- fmap.
 7 fd: 3 +0x00000000 0x102f1c000 - 0x102f1ffff r-- fmap.
 8 fd: 3 +0x00000000 0x102f20000 - 0x102f23fff r-- fmap.
 9 fd: 3 +0x00000000 0x102f24000 - 0x102f47fff r-- fmap.
10 fd: 3 +0x00000000 0x102f48000 - 0x102fa7fff r-- fmap.
11 fd: 3 +0x00000000 0x16c8e4000 - 0x16d0dffff r-- fmap.
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes https://github.com/rizinorg/rizin/issues/3054
