### PR TITLE
Add analysis pass to make `avgl` command show global variables

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -3942,6 +3942,53 @@ static void core_analysis_analyze_local_var_and_arg(RzCore *core) {
 	}
 }
 
+static void analysis_global_vars_from_symbols(RzCore *core) {
+	// DWARF/PDB already enumerate globals with accurate types; only fall back
+	// to symbol-table inference when no debug info is present.
+	RzAnalysisDebugInfo *dbg_info = rz_analysis_get_debug_info(core->analysis);
+	if (dbg_info && dbg_info->dw) {
+		return;
+	}
+	RzBinObject *obj = rz_bin_cur_object(core->bin);
+	if (!obj) {
+		return;
+	}
+	RzTypeDB *typedb = rz_analysis_get_type_db(core->analysis);
+	RzPVector *symbols = (RzPVector *)rz_bin_object_get_symbols(obj);
+	if (!symbols) {
+		return;
+	}
+	bool virt_addr = rz_config_get_b(core->config, "io.va");
+	void **it;
+	rz_pvector_foreach (symbols, it) {
+		RzBinSymbol *sym = *it;
+		if (!sym->name || sym->is_imported) {
+			continue;
+		}
+		if (!sym->type || strcmp(sym->type, RZ_BIN_TYPE_OBJECT_STR)) {
+			continue;
+		}
+		if (!sym->size) {
+			continue;
+		}
+		ut64 addr = virt_addr ? rz_bin_object_get_vaddr(obj, sym->paddr, sym->vaddr) : sym->paddr;
+		if (addr == UT64_MAX || addr == 0) {
+			continue;
+		}
+		if (rz_analysis_var_global_get_byaddr_in(core->analysis, addr)) {
+			continue;
+		}
+		RzType *type = sym->size == 1
+			? rz_type_identifier_of_base_type_str(typedb, "uint8_t")
+			: rz_type_array_of_base_type_str(typedb, "uint8_t", sym->size);
+		if (!type) {
+			continue;
+		}
+		// rz_analysis_var_global_create takes effective ownership of type
+		rz_analysis_var_global_create(core->analysis, sym->name, type, addr);
+	}
+}
+
 /**
  * Runs all the steps of the deep analysis.
  *
@@ -4112,6 +4159,15 @@ RZ_API bool rz_core_analysis_everything(RzCore *core, bool experimental, char *d
 		rz_core_notify_begin(core, "%s", notify);
 		rz_analysis_dwarf_integrate_functions(core->analysis, core->flags);
 		rz_core_notify_done(core, "%s", notify);
+	}
+
+	notify = "Recover global variables from symbols";
+	rz_core_notify_begin(core, "%s", notify);
+	analysis_global_vars_from_symbols(core);
+	rz_core_notify_done(core, "%s", notify);
+	rz_core_task_yield(&core->tasks);
+	if (rz_cons_is_breaked()) {
+		return false;
 	}
 
 	if (rz_config_get_b(core->config, "analysis.resolve.pointers")) {

--- a/test/db/analysis/x86_64
+++ b/test/db/analysis/x86_64
@@ -4420,3 +4420,15 @@ EXPECT=<<EOF
 |           0x001b9b32      push  r14
 EOF
 RUN
+NAME=global variables populated from ELF OBJ symbols without DWARF
+FILE=bins/elf/dectest64
+CMDS=<<EOF
+aaa
+avgl~global_var
+avgl~global_array
+EOF
+EXPECT=<<EOF
+global uint8_t [4] global_var @ 0x404050
+global uint8_t [8] global_array @ 0x404058
+EOF
+RUN

--- a/test/db/cmd/cmd_flags
+++ b/test/db/cmd/cmd_flags
@@ -207,7 +207,8 @@ NAME=flj shows demangled symbols
 FILE=bins/elf/demangle-test-cpp
 CMDS=<<EOF
 aaa
-flj~{214}
+s reloc.operator_delete_void
+fl.j~{0}
 EOF
 EXPECT=<<EOF
 {"name":"reloc.operator_delete_void","realname":"operator delete(void*)","size":8,"offset":16432}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

I added an analysis pass that detects and registers global symbols. 

**Test plan**

1. The issue mentioned the `bins/elf/dectest64` binary. I have added a test for it inside `test/db/analysis/x86_64`. 

2. For the existing test `db/cmd/cmd_flags flj shows demangled symbols`, I changed from absolute indexing `flj~{214}` to relative indexing `s reloc.operator_delete_void ; fl.j~{0}`

**Closing issues**

https://github.com/rizinorg/rizin/issues/5730

