### PR TITLE
Improve RzList memory handling and speed.

### DIFF
--- a/librz/core/casm.c
+++ b/librz/core/casm.c
@@ -413,8 +413,8 @@ RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_strsearch(RzCore *core, const ch
 				}
 				if (match) {
 					if (!(hit = rz_core_asm_hit_new())) {
-						rz_list_purge(hits);
-						RZ_FREE(hits);
+						rz_list_free(hits);
+						hits = NULL;
 						rz_analysis_op_fini(&aop);
 						goto beach;
 					}
@@ -488,8 +488,8 @@ RZ_API RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_strsearch(RzCore *core, const ch
 						tidx = idx;
 					}
 					if (!(hit = rz_core_asm_hit_new())) {
-						rz_list_purge(hits);
-						RZ_FREE(hits);
+						rz_list_free(hits);
+						hits = NULL;
 						goto beach;
 					}
 					hit->addr = tokcount == 1 ? addr : tidx;
@@ -810,17 +810,13 @@ static RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_back_disassemble_all(RzCore *cor
 	memset(&dummy_value, 0, sizeof(RzCoreAsmHit));
 
 	if (!hits || !buf) {
-		if (hits) {
-			rz_list_purge(hits);
-			free(hits);
-		}
+		rz_list_free(hits);
 		free(buf);
 		return NULL;
 	}
 
 	if (!rz_io_read_at_mapped(core->io, addr - (len + extra_padding), buf, len + extra_padding)) {
-		rz_list_purge(hits);
-		free(hits);
+		rz_list_free(hits);
 		free(buf);
 		return NULL;
 	}
@@ -875,17 +871,13 @@ static RzList /*<RzCoreAsmHit *>*/ *rz_core_asm_back_disassemble(RzCore *core, u
 	hits = rz_core_asm_hit_list_new();
 	buf = malloc(len + extra_padding);
 	if (!hits || !buf) {
-		if (hits) {
-			rz_list_purge(hits);
-			free(hits);
-		}
+		rz_list_free(hits);
 		free(buf);
 		return NULL;
 	}
 
 	if (!rz_io_read_at_mapped(core->io, (addr + extra_padding) - len, buf, len + extra_padding)) {
-		rz_list_purge(hits);
-		free(hits);
+		rz_list_free(hits);
 		free(buf);
 		return NULL;
 	}

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -899,7 +899,6 @@ static void do_asm_search(RzCore *core, struct search_parameters *param, const c
 			const char *cmdhit = rz_config_get(core->config, "cmd.hit");
 			rz_list_foreach (hits, iter, hit) {
 				if (rz_cons_is_breaked()) {
-					rz_list_free(hits);
 					break;
 				}
 				if (cmdhit && *cmdhit) {
@@ -938,7 +937,6 @@ static void do_asm_search(RzCore *core, struct search_parameters *param, const c
 				}
 				count++;
 			}
-			rz_list_purge(hits);
 			rz_list_free(hits);
 		}
 	}
@@ -1228,6 +1226,7 @@ static void __core_cmd_search_asm_infinite(RzCore *core, const char *arg) {
 		}
 		free(buf);
 	}
+	rz_list_free(boundaries);
 }
 
 static void __core_cmd_search_asm_byteswap(RzCore *core, int nth) {

--- a/librz/core/project_migrate.c
+++ b/librz/core/project_migrate.c
@@ -65,6 +65,7 @@ RZ_API bool rz_project_migrate_v1_v2(RzProject *prj, RzSerializeResultInfo *res)
 		.noreturn_db = sdb_ns(analysis_db, "noreturn", true)
 	};
 	if (!ctx.moved_keys || !ctx.noreturn_db) {
+		rz_list_free(ctx.moved_keys);
 		return false;
 	}
 	sdb_foreach(types_db, v1_v2_types_foreach_cb, &ctx);
@@ -125,6 +126,7 @@ RZ_API bool rz_project_migrate_v2_v3(RzProject *prj, RzSerializeResultInfo *res)
 		.typelinks_db = sdb_ns(analysis_db, "typelinks", true)
 	};
 	if (!ctx.moved_keys || !ctx.callables_db || !ctx.typelinks_db) {
+		rz_list_free(ctx.moved_keys);
 		return false;
 	}
 	sdb_foreach(types_db, v2_v3_types_foreach_cb, &ctx);
@@ -525,6 +527,7 @@ RZ_API bool rz_project_migrate_v12_v13(RzProject *prj, RzSerializeResultInfo *re
 	};
 
 	if (!ctx.moved_keys || !ctx.global_vars_db) {
+		rz_list_free(ctx.moved_keys);
 		return false;
 	}
 	Sdb *typelinks_db = sdb_ns(analysis_db, "typelinks", true);

--- a/librz/debug/p/native/bt/generic-x64.c
+++ b/librz/debug/p/native/bt/generic-x64.c
@@ -28,8 +28,7 @@ static RzList /*<RzDebugFrame *>*/ *backtrace_x86_64(RzDebug *dbg, ut64 at) {
 	if (!memcmp(buf, "\x55\x89\xe5", 3) || !memcmp(buf, "\x89\xe5\x57", 3)) {
 		if (!bio->read_at(bio->io, _rsp, (ut8 *)&ptr, 8)) {
 			eprintf("read error at 0x%08" PFMT64x "\n", _rsp);
-			rz_list_purge(list);
-			free(list);
+			rz_list_free(list);
 			return false;
 		}
 		frame = RZ_NEW0(RzDebugFrame);

--- a/librz/debug/trace.c
+++ b/librz/debug/trace.c
@@ -29,8 +29,7 @@ RZ_API void rz_debug_trace_free(RzDebugTrace *trace) {
 	if (!trace) {
 		return;
 	}
-	rz_list_purge(trace->traces);
-	free(trace->traces);
+	rz_list_free(trace->traces);
 	ht_sp_free(trace->ht);
 	RZ_FREE(trace);
 }
@@ -279,11 +278,10 @@ RZ_API RzDebugTracepoint *rz_debug_trace_add(RzDebug *dbg, ut64 addr, int size) 
 
 RZ_API void rz_debug_trace_reset(RzDebug *dbg) {
 	RzDebugTrace *t = dbg->trace;
-	rz_list_purge(t->traces);
+	rz_list_free(t->traces);
 	ht_sp_free(t->ht);
 	t->ht = ht_sp_new(HT_STR_DUP, NULL, NULL);
-	t->traces = rz_list_new();
-	t->traces->free = free;
+	t->traces = rz_list_newf(free);
 }
 
 RZ_API RZ_OWN RzDbgListInfo *rz_debug_listinfo_new(RZ_NULLABLE const char *name, RzInterval pitv, RzInterval vitv, int perm, RZ_NULLABLE const char *extra) {

--- a/librz/include/rz_list.h
+++ b/librz/include/rz_list.h
@@ -2,6 +2,7 @@
 #define RZ_LIST_H
 
 #include <rz_util/rz_iterator.h>
+#include <rz_vector.h>
 #include <rz_types.h>
 
 #ifdef __cplusplus
@@ -9,8 +10,6 @@ extern "C" {
 #endif
 
 typedef void (*RzListFree)(void *ptr);
-
-#define RZ_LIST_SLAB_SIZE 256
 
 typedef struct rz_list_iter_t RzListIter;
 
@@ -20,23 +19,16 @@ struct rz_list_iter_t {
 	RzListIter *prev;
 };
 
-typedef struct rz_list_slab_t {
-	RzListIter nodes[RZ_LIST_SLAB_SIZE];
-	struct rz_list_slab_t *next_slab;
-} RzListSlab;
-
-typedef struct rz_list_pool_t {
-	RzListSlab *slabs;
-	RzListIter *freelist;
-} RzListPool;
+typedef struct rz_list_slab_t RzListSlab;
 
 typedef struct rz_list_t {
-	RzListIter *head;
-	RzListIter *tail;
-	RzListFree free;
-	ut32 length;
-	bool sorted;
-	RzListPool *pool;
+	RzListIter *head; ///< List head/first element.
+	RzListIter *tail; ///< List tail/last element.
+	RzListSlab *slab; ///< Owner of all the elements.
+	RzListIter *unused; ///< List of nodes recently freed.
+	RzListFree free; ///< Free function to call when an element is removed from the list.
+	bool sorted; ///< When true, the list is sorted.
+	size_t length; ///< Number of elements in list.
 } RzList;
 
 // RzListComparator should return -1, 0, 1 to indicate "value < list_data", "value == list_data", "value > list_data".
@@ -64,9 +56,7 @@ typedef int (*RzListComparator)(const void *value, const void *list_data, void *
 #define rz_list_foreach_prev_safe(list, it, tmp, var) \
 	for (it = list->tail; it && (var = it->val, tmp = it->prev, 1); it = tmp)
 
-static inline bool rz_list_empty(RZ_NULLABLE const RzList *list) {
-	return !list || !list->length;
-}
+#define rz_list_empty(list) (rz_list_length(list) < 1)
 
 static inline RZ_BORROW RzListIter *rz_list_head(RZ_NULLABLE const RzList *list) {
 	return list ? list->head : NULL;
@@ -104,6 +94,8 @@ RZ_API RZ_OWN RzList *rz_list_new(void);
 RZ_API RZ_OWN RzList *rz_list_newf(RZ_NULLABLE RzListFree f);
 RZ_API RZ_OWN RzList *rz_list_new_from_array(const void **arr, size_t arr_size);
 RZ_API RZ_OWN RzList *rz_list_new_from_iterator(RZ_BORROW RZ_NONNULL RzIterator *iter);
+RZ_API void rz_list_set_free(RZ_NONNULL RzList *list, RZ_NULLABLE RzListFree f);
+RZ_API RzListFree rz_list_get_free(RZ_NONNULL RzList *list);
 RZ_API RZ_BORROW void *rz_list_iter_get_prev_data(RZ_NONNULL RzListIter *iter);
 RZ_API RZ_BORROW void *rz_list_iter_get_next_data(RZ_NONNULL RzListIter *iter);
 RZ_API ut32 rz_list_set_n(RZ_NONNULL RzList *list, ut32 n, RZ_NONNULL void *data);
@@ -120,22 +112,21 @@ RZ_API void rz_list_merge_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListCompara
 RZ_API void rz_list_insertion_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListComparator cmp, void *user);
 RZ_API RZ_OWN RzList *rz_list_uniq(RZ_NONNULL const RzList *list, RZ_NONNULL RzListComparator cmp, void *user);
 RZ_API void rz_list_sorted_uniq(RZ_NONNULL RzList *list, RZ_NONNULL RzListComparator cmp, void *user);
-RZ_API void rz_list_init(RZ_NONNULL RzList *list);
 RZ_API void rz_list_delete(RZ_NONNULL RzList *list, RZ_OWN RZ_NONNULL RzListIter *iter);
 RZ_API bool rz_list_delete_val(RZ_NONNULL RzList *list, void *val);
 RZ_API void rz_list_purge(RZ_NONNULL RzList *list);
 RZ_API void rz_list_free(RZ_NULLABLE RzList *list);
-RZ_API RZ_OWN RzListIter *rz_list_item_new(RZ_NULLABLE void *data);
-RZ_API bool rz_list_join(RZ_NONNULL RzList *list1, RZ_NONNULL RzList *list2);
+RZ_API bool rz_list_join(RZ_NONNULL RzList *dst_list, RZ_NONNULL RzList *src_list);
 RZ_API RZ_BORROW void *rz_list_get_n(RZ_NONNULL const RzList *list, ut32 n);
 RZ_API ut32 rz_list_del_n(RZ_NONNULL RzList *list, ut32 n);
 RZ_API RZ_BORROW RzListIter *rz_list_iterator(RZ_NONNULL const RzList *list);
-RZ_API RZ_BORROW RzListIter *rz_list_push(RZ_NONNULL RzList *list, void *item);
 RZ_API RZ_OWN void *rz_list_pop(RZ_NONNULL RzList *list);
 RZ_API RZ_OWN void *rz_list_pop_head(RZ_NONNULL RzList *list);
 RZ_API void rz_list_reverse(RZ_NONNULL RzList *list);
 RZ_API RZ_OWN RzList *rz_list_clone(RZ_NONNULL const RzList *list);
 RZ_API RZ_OWN char *rz_list_to_str(RZ_NONNULL RzList /*<const char *>*/ *list, char ch, bool append_last);
+
+#define rz_list_push rz_list_append
 
 /* hashlike api */
 RZ_API RZ_BORROW bool rz_list_contains(RZ_NONNULL const RzList *list, RZ_NONNULL const void *val);

--- a/librz/util/list.c
+++ b/librz/util/list.c
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include <rz_util.h>
 
-#define RZ_LIST_SLAB_SIZE 1024
+#define RZ_LIST_SLAB_SIZE 128
 
 struct rz_list_slab_t {
 	RzListIter elements[RZ_LIST_SLAB_SIZE];

--- a/librz/util/list.c
+++ b/librz/util/list.c
@@ -5,76 +5,96 @@
 #include <stdio.h>
 #include <rz_util.h>
 
-static void rz_list_pool_free(RzListPool *pool) {
-	if (!pool) {
-		return;
+#define RZ_LIST_SLAB_SIZE 1024
+
+struct rz_list_slab_t {
+	RzListIter elements[RZ_LIST_SLAB_SIZE];
+	size_t e_current; ///< Index of the next new element
+	RzListSlab *next_slab; ///< Next slab
+};
+
+static inline RzListSlab *list_slab_new(void) {
+	RzListSlab *slab = RZ_NEW(RzListSlab);
+	if (!slab) {
+		return NULL;
 	}
-	RzListSlab *slab = pool->slabs;
-	while (slab) {
-		RzListSlab *next = slab->next_slab;
-		free(slab);
-		slab = next;
-	}
-	free(pool);
+	slab->e_current = 0;
+	slab->next_slab = NULL;
+	return slab;
 }
 
-/**
- * \brief Allocates an RzListIter from the pool, growing by one slab if needed.
- *        If \p pool is NULL, falls back to a plain heap allocation.
- */
-static inline RzListIter *pool_alloc_node(RzListPool *pool) {
-	if (!pool) {
-		return RZ_NEW0(RzListIter);
+static inline RzListIter *list_slab_first_unused(RzListSlab *slab) {
+	RzListIter *elem = NULL;
+	// if we have used all the elements, if return NULL.
+	if (slab->e_current >= RZ_LIST_SLAB_SIZE) {
+		return NULL;
 	}
-	if (!pool->freelist) {
-		RzListSlab *slab = RZ_NEW0(RzListSlab);
-		if (!slab) {
+
+	elem = &slab->elements[slab->e_current];
+	slab->e_current++;
+	return elem;
+}
+
+static inline void list_value_free_and_set(RzList *list, RzListIter *elem, void *new_val) {
+	if (list->free) {
+		list->free(elem->val);
+	}
+	elem->val = new_val;
+}
+
+static inline void list_free_elem(RzList *list, RzListIter *elem) {
+	list_value_free_and_set(list, elem, NULL);
+
+	elem->next = list->unused;
+	list->unused = elem;
+	list->length--;
+}
+
+static inline RzListIter *list_new_elem_from_slab(RzList *list) {
+	RzListIter *elem = list_slab_first_unused(list->slab);
+	if (elem) {
+		return elem;
+	}
+
+	RzListSlab *slab = list_slab_new();
+	if (!slab) {
+		return NULL;
+	}
+	slab->next_slab = list->slab;
+	list->slab = slab;
+
+	return list_slab_first_unused(list->slab);
+}
+
+static RzListIter *list_new_elem(RzList *list) {
+	RzListIter *elem = NULL;
+	// we check first if we have any elements that has been
+	// recently freed, and we reuse them first.
+	if (list->unused) {
+		elem = list->unused;
+		list->unused = elem->next;
+	} else {
+		// if not we need one from the slab
+		elem = list_new_elem_from_slab(list);
+		if (!elem) {
+			rz_warn_if_reached();
 			return NULL;
 		}
-		slab->next_slab = pool->slabs;
-		pool->slabs = slab;
-		for (int i = 0; i < RZ_LIST_SLAB_SIZE - 1; i++) {
-			slab->nodes[i].next = &slab->nodes[i + 1];
-		}
-		slab->nodes[RZ_LIST_SLAB_SIZE - 1].next = NULL;
-		pool->freelist = &slab->nodes[0];
 	}
-	RzListIter *n = pool->freelist;
-	pool->freelist = n->next;
-	n->next = NULL;
-	n->prev = NULL;
-	n->val = NULL;
-	return n;
-}
 
-/**
- * \brief Returns an RzListIter node back to the pool freelist so it can be
- *        reused, without freeing any heap memory.
- *        If \p pool is NULL, the node was heap-allocated and is freed directly.
- */
-static inline void pool_return_node(RzListPool *pool, RzListIter *node) {
-	if (!node) {
-		return;
-	}
-	if (!pool) {
-		free(node);
-		return;
-	}
-	node->val = NULL;
-	node->prev = NULL;
-	node->next = pool->freelist;
-	pool->freelist = node;
+	list->length++;
+	return elem;
 }
 
 /**
  * \brief Returns the RzListIter at position \p n, traversing from whichever
  *        end is closer. Returns NULL if \p n is out of bounds.
  **/
-static inline RzListIter *rz_list_iter_at(const RzList *list, ut32 n) {
+static inline RzListIter *list_iter_at(const RzList *list, ut32 n) {
 	if (n >= list->length) {
 		return NULL;
 	}
-	RzListIter *it;
+	RzListIter *it = NULL;
 	if (n < list->length / 2) {
 		it = list->head;
 		for (ut32 i = 0; i < n; i++) {
@@ -137,14 +157,6 @@ RZ_API RZ_BORROW RzListIter *rz_list_iterator(RZ_NONNULL const RzList *list) {
 }
 
 /**
- * \brief Alias for rz_list_append
- *
- **/
-RZ_API RZ_BORROW RzListIter *rz_list_push(RZ_NONNULL RzList *list, void *item) {
-	return rz_list_append(list, item);
-}
-
-/**
  * \brief Returns the value stored in the first node of the list.
  *
  **/
@@ -163,21 +175,6 @@ RZ_API RZ_BORROW void *rz_list_last_val(RZ_NONNULL const RzList *list) {
 }
 
 /**
- * \brief Initializes the RzList pointer
- *
- **/
-RZ_API void rz_list_init(RZ_NONNULL RzList *list) {
-	rz_return_if_fail(list);
-
-	list->head = NULL;
-	list->tail = NULL;
-	list->free = NULL;
-	list->length = 0;
-	list->sorted = false;
-	list->pool = RZ_NEW0(RzListPool);
-}
-
-/**
  * \brief Returns the length of the list
  *
  **/
@@ -188,28 +185,6 @@ RZ_API ut32 rz_list_length(RZ_NONNULL const RzList *list) {
 	return list->length;
 }
 
-static void _list_purge_with_free(RzList *list) {
-	RzListPool *pool = list->pool;
-	RzListIter *it = list->head;
-	RzListFree fn = list->free;
-	while (it) {
-		RzListIter *next = it->next;
-		fn(it->val);
-		pool_return_node(pool, it);
-		it = next;
-	}
-}
-
-static void _list_purge_no_free(RzList *list) {
-	RzListPool *pool = list->pool;
-	RzListIter *it = list->head;
-	while (it) {
-		RzListIter *next = it->next;
-		pool_return_node(pool, it);
-		it = next;
-	}
-}
-
 /**
  * \brief Empties the list without freeing the list pointer
  *
@@ -218,12 +193,21 @@ RZ_API void rz_list_purge(RZ_NONNULL RzList *list) {
 	rz_return_if_fail(list);
 
 	if (list->free) {
-		_list_purge_with_free(list);
-	} else {
-		_list_purge_no_free(list);
+		// we need to free each element one by one.
+		while (list->head) {
+			rz_list_delete(list, list->head);
+		}
 	}
+	// we need to free only the slabs.
+	while (list->slab) {
+		RzListSlab *slab = list->slab;
+		list->slab = slab->next_slab;
+		free(slab);
+	}
+	list->slab = list_slab_new();
 	list->head = NULL;
 	list->tail = NULL;
+	list->unused = NULL;
 	list->length = 0;
 }
 
@@ -236,7 +220,7 @@ RZ_API void rz_list_free(RZ_NULLABLE RzList *list) {
 		return;
 	}
 	rz_list_purge(list);
-	rz_list_pool_free(list->pool);
+	free(list->slab);
 	free(list);
 }
 
@@ -272,80 +256,34 @@ RZ_API void rz_list_delete(RZ_NONNULL RzList *list, RZ_OWN RZ_NONNULL RzListIter
 	if (iter->next) {
 		iter->next->prev = iter->prev;
 	}
-	list->length--;
-	if (list->free && iter->val) {
-		list->free(iter->val);
-	}
-	iter->val = NULL;
-	pool_return_node(list->pool, iter);
+
+	list_free_elem(list, iter);
 }
 
 /**
- * \brief Joins list2 into list1 by copying all values; list2 is left empty
+ * \brief Joins src_list into dst_list by copying all values; src_list is left empty
  *        but its structure (pool, free pointer) is preserved.
- *        The caller is responsible for freeing list2 afterward.
+ *        The caller is responsible for freeing src_list afterward.
  *
- * \note  list2's free callback is NOT called during the join so that values
- *        transferred to list1 are not prematurely destroyed.
+ * \note  src_list's free callback is NOT called during the join so that values
+ *        transferred to dst_list are not prematurely destroyed.
  **/
-RZ_API bool rz_list_join(RZ_NONNULL RzList *list1, RZ_NONNULL RzList *list2) {
-	rz_return_val_if_fail(list1 && list2, false);
-	if (!list2->length) {
+RZ_API bool rz_list_join(RZ_NONNULL RzList *dst_list, RZ_NONNULL RzList *src_list) {
+	rz_return_val_if_fail(dst_list && src_list, false);
+	if (rz_list_length(src_list) < 1) {
 		return false;
 	}
 
-	RzListPool *pool1 = list1->pool;
-	RzListIter *it = list2->head;
-	while (it) {
-		RzListIter *n = pool_alloc_node(pool1);
-		if (!n) {
-			return false;
-		}
-		n->val = it->val;
-		n->prev = list1->tail;
-		n->next = NULL;
-		if (list1->tail) {
-			list1->tail->next = n;
-		}
-		list1->tail = n;
-		if (!list1->head) {
-			list1->head = n;
-		}
-		list1->length++;
-		it = it->next;
+	void *data;
+	RzListIter *iter;
+	rz_list_foreach (src_list, iter, data) {
+		rz_list_append(dst_list, data);
+		iter->val = NULL;
 	}
+	dst_list->sorted = false;
 
-	list1->sorted = false;
-
-	/*
-	 * Walk list2's nodes and return each one to list2's pool (or free them
-	 * if list2 has no pool).  We must NOT call list2->free on the values
-	 * because ownership of the values has just been transferred to list1.
-	 */
-	RzListIter *cur = list2->head;
-	while (cur) {
-		RzListIter *next = cur->next;
-		pool_return_node(list2->pool, cur);
-		cur = next;
-	}
-	list2->head = NULL;
-	list2->tail = NULL;
-	list2->length = 0;
-
+	rz_list_purge(src_list);
 	return true;
-}
-
-/**
- * \brief Returns a new initialized RzList pointer (free method is not initialized)
- *
- **/
-RZ_API RZ_OWN RzList *rz_list_new(void) {
-	RzList *list = RZ_NEW0(RzList);
-	if (!list) {
-		return NULL;
-	}
-	rz_list_init(list);
-	return list;
 }
 
 /**
@@ -353,11 +291,25 @@ RZ_API RZ_OWN RzList *rz_list_new(void) {
  *
  **/
 RZ_API RZ_OWN RzList *rz_list_newf(RZ_NULLABLE RzListFree f) {
-	RzList *l = rz_list_new();
-	if (l) {
-		l->free = f;
+	RzList *list = RZ_NEW0(RzList);
+	if (!list) {
+		return NULL;
 	}
-	return l;
+	list->free = f;
+	list->slab = list_slab_new();
+	if (!list->slab) {
+		rz_list_free(list);
+		return NULL;
+	}
+	return list;
+}
+
+/**
+ * \brief Returns a new initialized RzList pointer (free method is not initialized)
+ *
+ **/
+RZ_API RZ_OWN RzList *rz_list_new(void) {
+	return rz_list_newf(NULL);
 }
 
 /**
@@ -365,18 +317,15 @@ RZ_API RZ_OWN RzList *rz_list_newf(RZ_NULLABLE RzListFree f) {
  *
  **/
 RZ_API RZ_OWN RzList *rz_list_new_from_array(const void **arr, size_t arr_size) {
-	RzList *l = rz_list_new();
-	if (!l) {
-		return NULL;
+	RzList *list = rz_list_new();
+	if (!list || !arr) {
+		return list;
 	}
-	if (!arr) {
-		return l;
+
+	for (size_t i = 0; i < arr_size; i++) {
+		rz_list_append(list, (void *)arr[i]);
 	}
-	size_t i;
-	for (i = 0; i < arr_size; i++) {
-		rz_list_append(l, (void *)arr[i]);
-	}
-	return l;
+	return list;
 }
 
 /**
@@ -387,27 +336,40 @@ RZ_API RZ_OWN RzList *rz_list_new_from_array(const void **arr, size_t arr_size) 
  **/
 RZ_API RZ_OWN RzList *rz_list_new_from_iterator(RZ_BORROW RZ_NONNULL RzIterator *iter) {
 	rz_return_val_if_fail(iter, NULL);
-	RzList *l = rz_list_new();
-	if (!l) {
+	RzList *list = rz_list_new();
+	if (!list) {
 		return NULL;
 	}
 	void **val;
 	rz_iterator_foreach(iter, val) {
-		rz_list_append(l, (void *)*val);
+		rz_list_append(list, (void *)*val);
 	}
-	return l;
+	return list;
 }
 
 /**
- * \brief Creates a RzListIter element that can be inserted into a RzList
+ * \brief      Sets the RzListFree function to use
  *
- **/
-RZ_API RZ_OWN RzListIter *rz_list_item_new(RZ_NULLABLE void *data) {
-	RzListIter *item = pool_alloc_node(NULL);
-	if (item) {
-		item->val = data;
-	}
-	return item;
+ * \param      list  The list to modify
+ * \param[in]  f     RzListFree function to set
+ */
+RZ_API void rz_list_set_free(RZ_NONNULL RzList *list, RZ_NULLABLE RzListFree f) {
+	rz_return_if_fail(list);
+
+	list->free = f;
+}
+
+/**
+ * \brief      Gets the used RzListFree function
+ *
+ * \param      list  The list to modify
+ *
+ * \return     The RzListFree function (can be NULL).
+ */
+RZ_API RzListFree rz_list_get_free(RZ_NONNULL RzList *list) {
+	rz_return_val_if_fail(list, NULL);
+
+	return list->free;
 }
 
 /**
@@ -415,13 +377,10 @@ RZ_API RZ_OWN RzListIter *rz_list_item_new(RZ_NULLABLE void *data) {
  *
  **/
 RZ_API RZ_BORROW RzListIter *rz_list_append(RZ_NONNULL RzList *list, RZ_NONNULL void *data) {
-	RzListIter *item = NULL;
-
 	rz_return_val_if_fail(list, NULL);
-
-	item = pool_alloc_node(list->pool);
+	RzListIter *item = list_new_elem(list);
 	if (!item) {
-		return item;
+		return NULL;
 	}
 	if (list->tail) {
 		list->tail->next = item;
@@ -433,7 +392,6 @@ RZ_API RZ_BORROW RzListIter *rz_list_append(RZ_NONNULL RzList *list, RZ_NONNULL 
 	if (!list->head) {
 		list->head = item;
 	}
-	list->length++;
 	list->sorted = false;
 	return item;
 }
@@ -445,7 +403,7 @@ RZ_API RZ_BORROW RzListIter *rz_list_append(RZ_NONNULL RzList *list, RZ_NONNULL 
 RZ_API RZ_BORROW RzListIter *rz_list_prepend(RZ_NONNULL RzList *list, RZ_NONNULL void *data) {
 	rz_return_val_if_fail(list, NULL);
 
-	RzListIter *item = pool_alloc_node(list->pool);
+	RzListIter *item = list_new_elem(list);
 	if (!item) {
 		return NULL;
 	}
@@ -459,8 +417,7 @@ RZ_API RZ_BORROW RzListIter *rz_list_prepend(RZ_NONNULL RzList *list, RZ_NONNULL
 	if (!list->tail) {
 		list->tail = item;
 	}
-	list->length++;
-	list->sorted = true;
+	list->sorted = false;
 	return item;
 }
 
@@ -470,14 +427,16 @@ RZ_API RZ_BORROW RzListIter *rz_list_prepend(RZ_NONNULL RzList *list, RZ_NONNULL
  **/
 RZ_API RZ_BORROW RzListIter *rz_list_insert(RZ_NONNULL RzList *list, ut32 n, RZ_NONNULL void *data) {
 	rz_return_val_if_fail(list, NULL);
-	if (!list->head || !n) {
+	if (!n) {
 		return rz_list_prepend(list, data);
 	}
-	RzListIter *it = rz_list_iter_at(list, n);
+
+	RzListIter *it = list_iter_at(list, n);
 	if (!it) {
 		return rz_list_append(list, data);
 	}
-	RzListIter *item = pool_alloc_node(list->pool);
+
+	RzListIter *item = list_new_elem(list);
 	if (!item) {
 		return NULL;
 	}
@@ -490,7 +449,6 @@ RZ_API RZ_BORROW RzListIter *rz_list_insert(RZ_NONNULL RzList *list, ut32 n, RZ_
 		list->head = item;
 	}
 	it->prev = item;
-	list->length++;
 	list->sorted = false;
 	return item;
 }
@@ -500,23 +458,24 @@ RZ_API RZ_BORROW RzListIter *rz_list_insert(RZ_NONNULL RzList *list, ut32 n, RZ_
  *
  **/
 RZ_API RZ_OWN void *rz_list_pop(RZ_NONNULL RzList *list) {
-	void *data = NULL;
-	RzListIter *iter;
-
 	rz_return_val_if_fail(list, NULL);
-
-	if (list->tail) {
-		iter = list->tail;
-		if (list->head == list->tail) {
-			list->head = list->tail = NULL;
-		} else {
-			list->tail = iter->prev;
-			list->tail->next = NULL;
-		}
-		data = iter->val;
-		pool_return_node(list->pool, iter);
-		list->length--;
+	if (!list->tail) {
+		return NULL;
 	}
+	void *data = rz_list_last_val(list);
+	rz_list_set_val(list->tail, NULL);
+	rz_list_delete(list, list->tail);
+	return data;
+}
+
+RZ_API RZ_OWN void *rz_list_pop_head(RZ_NONNULL RzList *list) {
+	rz_return_val_if_fail(list, NULL);
+	if (!list->head) {
+		return NULL;
+	}
+	void *data = rz_list_first_val(list);
+	rz_list_set_val(list->head, NULL);
+	rz_list_delete(list, list->head);
 	return data;
 }
 
@@ -524,23 +483,14 @@ RZ_API RZ_OWN void *rz_list_pop(RZ_NONNULL RzList *list) {
  * \brief Removes and returns the first element of the list
  *
  **/
-RZ_API RZ_OWN void *rz_list_pop_head(RZ_NONNULL RzList *list) {
-	void *data = NULL;
-
+RZ_API RZ_OWN void *rz_list_pop_first(RZ_NONNULL RzList *list) {
 	rz_return_val_if_fail(list, NULL);
-
-	if (list->head) {
-		RzListIter *iter = list->head;
-		if (list->head == list->tail) {
-			list->head = list->tail = NULL;
-		} else {
-			list->head = iter->next;
-			list->head->prev = NULL;
-		}
-		data = iter->val;
-		pool_return_node(list->pool, iter);
-		list->length--;
+	if (!list->head) {
+		return NULL;
 	}
+	void *data = rz_list_first_val(list);
+	rz_list_set_val(list->head, NULL);
+	rz_list_delete(list, list->head);
 	return data;
 }
 
@@ -550,7 +500,7 @@ RZ_API RZ_OWN void *rz_list_pop_head(RZ_NONNULL RzList *list) {
  **/
 RZ_API ut32 rz_list_del_n(RZ_NONNULL RzList *list, ut32 n) {
 	rz_return_val_if_fail(list, false);
-	RzListIter *it = rz_list_iter_at(list, n);
+	RzListIter *it = list_iter_at(list, n);
 	if (!it) {
 		return false;
 	}
@@ -563,10 +513,9 @@ RZ_API ut32 rz_list_del_n(RZ_NONNULL RzList *list, ut32 n) {
  *
  **/
 RZ_API void rz_list_reverse(RZ_NONNULL RzList *list) {
-	RzListIter *it, *tmp;
-
 	rz_return_if_fail(list);
 
+	RzListIter *it, *tmp;
 	for (it = list->head; it; it = it->prev) {
 		tmp = it->prev;
 		it->prev = it->next;
@@ -575,28 +524,28 @@ RZ_API void rz_list_reverse(RZ_NONNULL RzList *list) {
 	tmp = list->head;
 	list->head = list->tail;
 	list->tail = tmp;
+	list->sorted = false;
 }
 
 /**
  * \brief Shallow copies of the list (but doesn't free its elements)
  *
  **/
-RZ_API RZ_OWN RzList *rz_list_clone(RZ_NONNULL const RzList *list) {
-	RzListIter *iter;
-	void *data;
-
-	rz_return_val_if_fail(list, NULL);
-
-	RzList *l = rz_list_new();
-	if (!l) {
+RZ_API RZ_OWN RzList *rz_list_clone(RZ_NONNULL const RzList *orig) {
+	rz_return_val_if_fail(orig, NULL);
+	RzList *list = rz_list_new();
+	if (!list) {
 		return NULL;
 	}
-	l->free = NULL;
-	rz_list_foreach (list, iter, data) {
-		rz_list_append(l, data);
+
+	void *data;
+	RzListIter *iter;
+	rz_list_foreach (orig, iter, data) {
+		rz_list_append(list, data);
 	}
-	l->sorted = list->sorted;
-	return l;
+
+	list->sorted = orig->sorted;
+	return list;
 }
 
 /**
@@ -606,26 +555,35 @@ RZ_API RZ_OWN RzList *rz_list_clone(RZ_NONNULL const RzList *list) {
 RZ_API RZ_BORROW RzListIter *rz_list_add_sorted(RZ_NONNULL RzList *list, RZ_NONNULL void *data, RZ_NONNULL RzListComparator cmp, void *user) {
 	rz_return_val_if_fail(list && data && cmp, NULL);
 
+	if (!list->sorted) {
+		// if not sorted we must sort it.
+		rz_list_sort(list, cmp, user);
+	}
+
 	RzListIter *it, *item = NULL;
 	for (it = list->head; it && it->val && cmp(data, it->val, user) > 0; it = it->next) {
 	}
-	if (it) {
-		item = pool_alloc_node(list->pool);
-		if (!item) {
-			return NULL;
-		}
-		item->next = it;
-		item->prev = it->prev;
-		item->val = data;
-		item->next->prev = item;
-		if (!item->prev) {
-			list->head = item;
-		} else {
-			item->prev->next = item;
-		}
-		list->length++;
+
+	if (!it) {
+		item = rz_list_append(list, data);
+		list->sorted = true;
+		return item;
+	}
+
+	item = list_new_elem(list);
+	if (!item) {
+		return NULL;
+	}
+
+	item->next = it;
+	item->prev = it->prev;
+	item->val = data;
+	item->next->prev = item;
+
+	if (!item->prev) {
+		list->head = item;
 	} else {
-		rz_list_append(list, data);
+		item->prev->next = item;
 	}
 	list->sorted = true;
 	return item;
@@ -637,14 +595,12 @@ RZ_API RZ_BORROW RzListIter *rz_list_add_sorted(RZ_NONNULL RzList *list, RZ_NONN
  **/
 RZ_API ut32 rz_list_set_n(RZ_NONNULL RzList *list, ut32 n, RZ_NONNULL void *data) {
 	rz_return_val_if_fail(list, false);
-	RzListIter *it = rz_list_iter_at(list, n);
-	if (!it) {
+	RzListIter *iter = list_iter_at(list, n);
+	if (!iter) {
 		return false;
 	}
-	if (list->free) {
-		list->free(it->val);
-	}
-	it->val = data;
+
+	list_value_free_and_set(list, iter, data);
 	list->sorted = false;
 	return true;
 }
@@ -655,7 +611,7 @@ RZ_API ut32 rz_list_set_n(RZ_NONNULL RzList *list, ut32 n, RZ_NONNULL void *data
  **/
 RZ_API RZ_BORROW void *rz_list_get_n(RZ_NONNULL const RzList *list, ut32 n) {
 	rz_return_val_if_fail(list, NULL);
-	RzListIter *it = rz_list_iter_at(list, n);
+	RzListIter *it = list_iter_at(list, n);
 	return it ? it->val : NULL;
 }
 
@@ -704,7 +660,7 @@ RZ_API RZ_BORROW RzListIter *rz_list_find(RZ_NONNULL const RzList *list, const v
 	return NULL;
 }
 
-static RzListIter *_merge(RzListIter *first, RzListIter *second, RzListComparator cmp, void *user) {
+static RzListIter *list_merge(RzListIter *first, RzListIter *second, RzListComparator cmp, void *user) {
 	RzListIter *next = NULL, *result = NULL, *head = NULL;
 	while (first || second) {
 		if (!second) {
@@ -735,7 +691,7 @@ static RzListIter *_merge(RzListIter *first, RzListIter *second, RzListComparato
 	return head;
 }
 
-static RzListIter *_r_list_half_split(RzListIter *head) {
+static RzListIter *list_half_split(RzListIter *head) {
 	RzListIter *tmp;
 	RzListIter *fast;
 	RzListIter *slow;
@@ -753,15 +709,15 @@ static RzListIter *_r_list_half_split(RzListIter *head) {
 	return tmp;
 }
 
-static RzListIter *_merge_sort(RzListIter *head, RzListComparator cmp, void *user) {
+static RzListIter *list_merge_sort(RzListIter *head, RzListComparator cmp, void *user) {
 	RzListIter *second;
 	if (!head || !head->next) {
 		return head;
 	}
-	second = _r_list_half_split(head);
-	head = _merge_sort(head, cmp, user);
-	second = _merge_sort(second, cmp, user);
-	return _merge(head, second, cmp, user);
+	second = list_half_split(head);
+	head = list_merge_sort(head, cmp, user);
+	second = list_merge_sort(second, cmp, user);
+	return list_merge(head, second, cmp, user);
 }
 
 /**
@@ -773,8 +729,8 @@ RZ_API void rz_list_merge_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListCompara
 
 	if (!list->sorted && list->head && cmp) {
 		RzListIter *iter;
-		list->head = _merge_sort(list->head, cmp, user);
-		// update tail reference
+		list->head = list_merge_sort(list->head, cmp, user);
+		// update last reference
 		iter = list->head;
 		while (iter && iter->next) {
 			iter = iter->next;
@@ -814,7 +770,7 @@ RZ_API void rz_list_insertion_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListCom
  **/
 RZ_API void rz_list_sort(RZ_NONNULL RzList *list, RZ_NONNULL RzListComparator cmp, void *user) {
 	rz_return_if_fail(list && cmp);
-	if (list->length > 43) {
+	if (rz_list_length(list) > 43) {
 		rz_list_merge_sort(list, cmp, user);
 	} else {
 		rz_list_insertion_sort(list, cmp, user);

--- a/librz/util/list.c
+++ b/librz/util/list.c
@@ -14,7 +14,7 @@ struct rz_list_slab_t {
 };
 
 static inline RzListSlab *list_slab_new(void) {
-	RzListSlab *slab = RZ_NEW(RzListSlab);
+	RzListSlab *slab = RZ_NEW0(RzListSlab);
 	if (!slab) {
 		return NULL;
 	}

--- a/test/bench/bench_list.c
+++ b/test/bench/bench_list.c
@@ -9,8 +9,8 @@
  * \brief Benchmarks for core RzList operations.
  */
 
-static void _fill(RzList *l, int count) {
-	for (int j = 0; j < count; j++) {
+static void _fill(RzList *l, size_t count) {
+	for (size_t j = 0; j < count; j++) {
 		rz_list_append(l, (void *)(intptr_t)j);
 	}
 }

--- a/test/db/formats/dyldcache
+++ b/test/db/formats/dyldcache
@@ -368,8 +368,8 @@ objc_arc true
 0x18206a0f0 0x18003cfc4 0x18003d788 NSObject                      NSObject
     address index class flags name                  type                
 ------------------------------------------------------------------------
- ----------     0 Test        isa                   struct objc_class *
-0x182068038     1 Test        Test::(ivar)someField i
+0x182068038     0 Test        Test::(ivar)someField i
+ ----------     1 Test        isa                   struct objc_class *
     address index class flags name                         
 -----------------------------------------------------------
 0x1800189f8     0 Test        init
@@ -459,8 +459,8 @@ objc_arc true
 0x184079160 0x180040eb8 0x180042ac4 NSObject                      NSObject
     address index class flags name                  type                
 ------------------------------------------------------------------------
- ----------     0 Test        isa                   struct objc_class *
-0x18206c038     1 Test        Test::(ivar)someField i
+0x18206c038     0 Test        Test::(ivar)someField i
+ ----------     1 Test        isa                   struct objc_class *
     address index class flags name                         
 -----------------------------------------------------------
 0x180018a14     0 Test        init

--- a/test/unit/test_list.c
+++ b/test/unit/test_list.c
@@ -63,7 +63,7 @@ bool test_rz_list_join(void) {
 
 bool test_rz_list_free(void) {
 	RzList *list = rz_list_newf((void *)0x9999);
-	mu_assert_eq((int)(intptr_t)list->free, 0x9999, "rz_list_newf function gets set properly");
+	mu_assert_eq((int)(intptr_t)rz_list_get_free(list), 0x9999, "rz_list_newf function gets set properly");
 	rz_list_free(list);
 	mu_end;
 }
@@ -164,41 +164,41 @@ bool test_rz_list_length(void) {
 		count++;
 		iter = iter->next;
 	}
-	mu_assert_eq(list->length, 3, "First length check");
+	mu_assert_eq(rz_list_length(list), 3, "First length check");
 
 	rz_list_delete_val(list, (void *)&test1);
-	mu_assert_eq(list->length, 2, "Second length check");
+	mu_assert_eq(rz_list_length(list), 2, "Second length check");
 
 	rz_list_append(list, (void *)&test1);
-	mu_assert_eq(list->length, 3, "Third length check");
+	mu_assert_eq(rz_list_length(list), 3, "Third length check");
 
 	rz_list_pop(list);
-	mu_assert_eq(list->length, 2, "Fourth length check");
+	mu_assert_eq(rz_list_length(list), 2, "Fourth length check");
 
 	rz_list_pop_head(list);
-	mu_assert_eq(list->length, 1, "Fifth length check");
+	mu_assert_eq(rz_list_length(list), 1, "Fifth length check");
 
 	rz_list_insert(list, 2, (void *)&test2);
-	mu_assert_eq(list->length, 2, "Sixth length check");
+	mu_assert_eq(rz_list_length(list), 2, "Sixth length check");
 
 	rz_list_prepend(list, (void *)&test3);
-	mu_assert_eq(list->length, 3, "Seventh length check");
+	mu_assert_eq(rz_list_length(list), 3, "Seventh length check");
 
 	rz_list_del_n(list, 2);
-	mu_assert_eq(list->length, 2, "Eighth length check");
+	mu_assert_eq(rz_list_length(list), 2, "Eighth length check");
 
 	rz_list_append(list2, (void *)&test1);
 	rz_list_append(list2, (void *)&test3);
 	rz_list_append(list2, (void *)&test2);
 	rz_list_join(list, list2);
-	mu_assert_eq(list->length, 5, "Ninth length check");
+	mu_assert_eq(rz_list_length(list), 5, "Ninth length check");
 	iter = list->head;
 	count = 0;
 	while (iter) {
 		count++;
 		iter = iter->next;
 	}
-	mu_assert_eq(list->length, count, "Tenth length check");
+	mu_assert_eq(rz_list_length(list), count, "Tenth length check");
 	rz_list_free(list);
 	rz_list_free(list2);
 	mu_end;
@@ -551,8 +551,8 @@ bool test_rz_list_set_n_free(void) {
 	RzList *list = rz_list_newf(dummy_free);
 	rz_list_append(list, (void *)0x111);
 	rz_list_append(list, (void *)0x222);
-	mu_assert_eq(rz_list_set_n(list, 1, (void *)0x333), true, "set_n failed");
-	mu_assert_ptreq(rz_list_get_n(list, 1), (void *)0x333, "val not updated");
+	mu_assert_eq(rz_list_set_n(list, 1, (void *)0x333), true, "rz_list_set_n failed");
+	mu_assert_ptreq(rz_list_get_n(list, 1), (void *)0x333, "rz_list_get_n not updated");
 	rz_list_free(list);
 	mu_end;
 }


### PR DESCRIPTION
# New implementation with working slabs

```
Benchmark                 Iterations Total time [ms] Avg iter time [us/iteration] Throughput [iterations/sec] 
--------------------------------------------------------------------------------------------------------------
[append] 10k                    1000       58.463000                    58.463000                17104.835537
[append] 100k                    100       95.023000                   950.230000                 1052.376793
[append] 1m                       10      106.046000                 10604.600000                   94.298701
[prepend] 10k                   1000       54.219000                    54.219000                18443.718991
[prepend] 100k                   100       81.438000                   814.380000                 1227.927994
[prepend] 1m                      10       99.960000                  9996.000000                  100.040016
[pop] 1k                        1000        7.022000                     7.022000               142409.569923
[pop] 100k                       100      130.597000                  1305.970000                  765.714373
[pop] 1m                          10      147.895000                 14789.500000                   67.615538
[pop_head] 1k                   1000        4.690000                     4.690000               213219.616205
[pop_head] 100k                  100      112.814000                  1128.140000                  886.414807
[pop_head] 1m                     10      137.015000                 13701.500000                   72.984710
[del_n@0] 1k                    1000        4.319000                     4.319000               231535.077564
[del_n@0] 100k                    10       10.965000                  1096.500000                  911.992704
[del_n@0] 1m                       1       15.586000                 15586.000000                   64.160144
[del_n@tail] 100k                 10       13.615000                  1361.500000                  734.484025
[del_n@mid] 10k                   10      291.974000                 29197.400000                   34.249625
[purge] 10k                     1000       52.334000                    52.334000                19108.036840
[purge] 100k                     100       86.080000                   860.800000                 1161.710037
[purge] 1m                        10      100.323000                 10032.300000                   99.678040
[mixed append+pop] 100k          100       91.759000                   917.590000                 1089.811354
[mixed append+pop] 1m             10      101.017000                 10101.700000                   98.993239
[mixed purge+refill] 10k         500       54.991000                   109.982000                 9092.396938
[mixed purge+refill] 100k         50       79.000000                  1580.000000                  632.911392
```

# Current implementation with slabs `d3a97d5`

```
Benchmark                 Iterations Total time [ms] Avg iter time [us/iteration] Throughput [iterations/sec] 
--------------------------------------------------------------------------------------------------------------
[append] 10k                    1000      104.727000                   104.727000                 9548.635977
[append] 100k                    100      151.510000                  1515.100000                  660.022441
[append] 1m                       10      163.168000                 16316.800000                   61.286527
[prepend] 10k                   1000       88.102000                    88.102000                11350.480125
[prepend] 100k                   100      139.613000                  1396.130000                  716.265677
[prepend] 1m                      10      160.689000                 16068.900000                   62.232013
[pop] 1k                        1000        4.029000                     4.029000               248200.546041
[pop] 100k                       100      138.487000                  1384.870000                  722.089438
[pop] 1m                          10      184.107000                 18410.700000                   54.316240
[pop_head] 1k                   1000        4.759000                     4.759000               210128.178189
[pop_head] 100k                  100      163.720000                  1637.200000                  610.798925
[pop_head] 1m                     10      188.979000                 18897.900000                   52.915932
[del_n@0] 1k                    1000        5.903000                     5.903000               169405.387091
[del_n@0] 100k                    10       17.409000                  1740.900000                  574.415532
[del_n@0] 1m                       1       19.324000                 19324.000000                   51.749120
[del_n@tail] 100k                 10       17.422000                  1742.200000                  573.986913
[del_n@mid] 10k                   10      292.265000                 29226.500000                   34.215524
[purge] 10k                     1000       86.591000                    86.591000                11548.544306
[purge] 100k                     100      138.243000                  1382.430000                  723.363932
[purge] 1m                        10      158.637000                 15863.700000                   63.036996
[mixed append+pop] 100k          100       87.452000                   874.520000                 1143.484426
[mixed append+pop] 1m             10       98.273000                  9827.300000                  101.757349
[mixed purge+refill] 10k         500       61.405000                   122.810000                 8142.659393
[mixed purge+refill] 100k         50       92.982000                  1859.640000                  537.738487
```

Also resolves some memory issues