### PR TITLE
Remove RzConfig.lock and re-introduce rz_config_lock for compatibility

### DIFF
--- a/librz/config/old_config.c
+++ b/librz/config/old_config.c
@@ -334,9 +334,6 @@ RZ_API RZ_BORROW RzConfigNode *rz_config_set_b(RZ_BORROW RzConfig *cfg, RZ_NONNU
 		}
 		node = &entry->node;
 	} else {
-		if (cfg->lock) {
-			return NULL;
-		}
 		RzConfigEntry new_entry = { 0 };
 		if (!config_node_init(&new_entry.node, name, rz_str_bool(value))) {
 			rz_config_node_fini(&new_entry.node);
@@ -370,9 +367,6 @@ RZ_API RZ_BORROW RzConfigNode *rz_config_set(RZ_BORROW RzConfig *cfg, RZ_NONNULL
 		}
 		node = &entry->node;
 	} else {
-		if (cfg->lock) {
-			return NULL;
-		}
 		RzConfigEntry new_entry = { 0 };
 		if (!config_node_init(&new_entry.node, name, value)) {
 			rz_config_node_fini(&new_entry.node);
@@ -423,6 +417,14 @@ RZ_API void rz_config_node_value_format_i(RZ_OUT char *buf, size_t buf_size, con
 }
 
 /**
+ * Only exists for temporary compatibility with external plugins using the old RzConfig API.
+ * It is a no-op now.
+ */
+RZ_DEPRECATE RZ_API void rz_config_lock(RZ_BORROW RzConfig *cfg, int l) {
+	(void)cfg, (void)l;
+}
+
+/**
  * Writes the integer \p value in the config variable of \p name only and only if
  * the variable is integer.
  */
@@ -438,9 +440,6 @@ RZ_API RZ_BORROW RzConfigNode *rz_config_set_i(RZ_BORROW RzConfig *cfg, RZ_NONNU
 		}
 		node = &entry->node;
 	} else {
-		if (cfg->lock) {
-			return NULL;
-		}
 		char buf[128];
 		RzConfigEntry new_entry = { 0 };
 		rz_config_node_value_format_i(buf, sizeof(buf), i, NULL);

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3862,7 +3862,6 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETB("flirt.sigdb.load.extra", true, "Load signatures from the extra path");
 	SETB("flirt.sigdb.load.home", true, "Load signatures from the home path");
 
-	cfg->lock = 1;
 	return true;
 }
 

--- a/librz/include/rz_config.h
+++ b/librz/include/rz_config.h
@@ -103,7 +103,6 @@ typedef struct rz_config_entry_t {
 
 typedef struct rz_config_t {
 	void *user; ///< DEPRECATED
-	bool lock; ///< DEPRECATED
 	RzVector /*<RzConfigEntry>*/ sorted_vars; ///< Sorted owned variables
 } RzConfig;
 
@@ -192,6 +191,7 @@ RZ_API RZ_OWN char *rz_config_entry_get_as_string(RZ_NONNULL const RzConfigEntry
 /* old apis, deprecated */
 
 RZ_API const char *rz_config_node_type(RzConfigNode *node);
+RZ_DEPRECATE RZ_API void rz_config_lock(RZ_BORROW RzConfig *cfg, int l);
 RZ_API RZ_BORROW RzConfigNode *rz_config_set_i(RZ_BORROW RzConfig *cfg, RZ_NONNULL const char *name, const ut64 i);
 RZ_API RZ_BORROW RzConfigNode *rz_config_set_b(RZ_BORROW RzConfig *cfg, RZ_NONNULL const char *name, bool value);
 RZ_API RZ_BORROW RzConfigNode *rz_config_set_cb(RZ_BORROW RzConfig *cfg, const char *name, const char *value, bool (*callback)(void *user, void *data));


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

rz_config_lock() is still in use by some external plugins. It should be removed completely once plugins have migrated to the new API. For now, it is a no-op to not break compilation of plugins.

**Test plan**

Compile e.g. rz-ghidra