### PR TITLE
Add a check to verify whether M680X HSC12X/RS08 is present in Capstone

### DIFF
--- a/librz/arch/p/analysis/analysis_m680x_cs.c
+++ b/librz/arch/p/analysis/analysis_m680x_cs.c
@@ -32,11 +32,14 @@ static int m680xmode(const char *str) {
 		return CS_MODE_M680X_6309;
 	} else if (str && strstr(str, "hcs08")) {
 		return CS_MODE_M680X_HCS08;
-	} else if (str && strstr(str, "rs08")) {
+	}
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+	else if (strstr(str, "rs08")) {
 		return CS_MODE_M680X_RS08;
 	} else if (strstr(str, "hcs12x")) {
-		return CS_MODE_M680X_HCS12X;
+		return RZ_CAPSTONE_HAS_M680X_HCS12X;
 	}
+#endif
 	return CS_MODE_M680X_6800;
 }
 
@@ -116,11 +119,13 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_ADDF:
 	case M680X_INS_ADDR:
 	case M680X_INS_ADDW:
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
 	case M680X_INS_ADDX:
 	case M680X_INS_ADDY:
 	case M680X_INS_ADED:
 	case M680X_INS_ADEX:
 	case M680X_INS_ADEY:
+#endif
 		op->type = RZ_ANALYSIS_OP_TYPE_ADD;
 		break;
 	case M680X_INS_AIM:
@@ -133,26 +138,32 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_ANDCC:
 	case M680X_INS_ANDD:
 	case M680X_INS_ANDR:
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
 	case M680X_INS_ANDX:
 	case M680X_INS_ANDY:
+#endif
 		op->type = RZ_ANALYSIS_OP_TYPE_AND;
 		break;
 	case M680X_INS_ASL:
 	case M680X_INS_ASLA:
 	case M680X_INS_ASLB:
 	case M680X_INS_ASLD: ///< or LSLD
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
 	case M680X_INS_ASLW:
 	case M680X_INS_ASLX:
 	case M680X_INS_ASLY:
+#endif
 		op->type = RZ_ANALYSIS_OP_TYPE_SAL;
 		break;
 	case M680X_INS_ASR:
 	case M680X_INS_ASRA:
 	case M680X_INS_ASRB:
 	case M680X_INS_ASRD:
-	case M680X_INS_ASRW:
 	case M680X_INS_ASRX:
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+	case M680X_INS_ASRW:
 	case M680X_INS_ASRY:
+#endif
 		op->type = RZ_ANALYSIS_OP_TYPE_SAR;
 		break;
 	case M680X_INS_BAND:
@@ -171,11 +182,13 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_BITB:
 	case M680X_INS_BITD:
 	case M680X_INS_BITMD:
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
 	case M680X_INS_BITX:
 	case M680X_INS_BITY:
 	case M680X_INS_BTAS:
 	case M680X_INS_ORX:
 	case M680X_INS_ORY:
+#endif
 		op->type = RZ_ANALYSIS_OP_TYPE_OR;
 		break;
 	case M680X_INS_BRA:
@@ -243,10 +256,12 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_CPS:
 	case M680X_INS_CPX: ///< M6800/1/2/3
 	case M680X_INS_CPY:
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
 	case M680X_INS_CPED:
 	case M680X_INS_CPES:
 	case M680X_INS_CPEX:
 	case M680X_INS_CPEY:
+#endif
 		op->type = RZ_ANALYSIS_OP_TYPE_CMP;
 		break;
 	case M680X_INS_COM:
@@ -298,8 +313,10 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_EORB:
 	case M680X_INS_EORD:
 	case M680X_INS_EORR:
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
 	case M680X_INS_EORX:
 	case M680X_INS_EORY:
+#endif
 		op->type = RZ_ANALYSIS_OP_TYPE_XOR;
 		break;
 	case M680X_INS_ETBL:
@@ -322,7 +339,9 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_INCF:
 	case M680X_INS_INCW:
 	case M680X_INS_INCX:
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
 	case M680X_INS_INCY:
+#endif
 		op->type = RZ_ANALYSIS_OP_TYPE_ADD;
 		break;
 	case M680X_INS_INS: ///< M6800/1/2/3
@@ -385,7 +404,9 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_MOV:
 	case M680X_INS_MOVB:
 	case M680X_INS_MOVW:
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
 	case M680X_INS_CLRY:
+#endif
 		op->type = RZ_ANALYSIS_OP_TYPE_MOV;
 		break;
 	case M680X_INS_MUL:
@@ -396,10 +417,12 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_NEGA:
 	case M680X_INS_NEGB:
 	case M680X_INS_NEGD:
-	case M680X_INS_NEGW:
 	case M680X_INS_NEGX:
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+	case M680X_INS_NEGW:
 	case M680X_INS_NEGY:
 	case M680X_INS_COMY:
+#endif
 		op->type = RZ_ANALYSIS_OP_TYPE_NOT;
 		break;
 	case M680X_INS_NOP:
@@ -458,9 +481,6 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_SBC:
 	case M680X_INS_SBCA:
 	case M680X_INS_SBCB:
-	case M680X_INS_SBED:
-	case M680X_INS_SBEX:
-	case M680X_INS_SBEY:
 	case M680X_INS_SBCD:
 	case M680X_INS_SBCR:
 	case M680X_INS_SEC:
@@ -468,8 +488,10 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_SEV:
 	case M680X_INS_SEX:
 	case M680X_INS_SEXW:
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
 	case M680X_INS_SHA: ///< RS08
 	case M680X_INS_SLA: ///< RS08
+#endif
 	case M680X_INS_SLP:
 	case M680X_INS_STA:
 	case M680X_INS_STAA: ///< M6800/1/2/3
@@ -488,20 +510,27 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_SUBA:
 	case M680X_INS_SUBB:
 	case M680X_INS_SUBD:
-	case M680X_INS_SUBX:
-	case M680X_INS_SUBY:
 	case M680X_INS_SUBE:
 	case M680X_INS_SUBF:
 	case M680X_INS_SUBR:
 	case M680X_INS_SUBW:
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+	case M680X_INS_SUBX:
+	case M680X_INS_SUBY:
 	case M680X_INS_TSTY:
 	case M680X_INS_DECY:
+	case M680X_INS_SBED:
+	case M680X_INS_SBEX:
+	case M680X_INS_SBEY:
+#endif
 		op->type = RZ_ANALYSIS_OP_TYPE_SUB;
 		break;
 	case M680X_INS_SWI:
 	case M680X_INS_SWI2:
 	case M680X_INS_SWI3:
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
 	case M680X_INS_SYS:
+#endif
 		op->type = RZ_ANALYSIS_OP_TYPE_SWI;
 		break;
 	case M680X_INS_SYNC:
@@ -540,6 +569,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_XGDX: ///< HD6301
 	case M680X_INS_XGDY:
 		break;
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
 	case M680X_INS_TRAP:
 		op->type = RZ_ANALYSIS_OP_TYPE_TRAP;
 		break;
@@ -549,6 +579,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_GLDS:
 	case M680X_INS_GLDX:
 	case M680X_INS_GLDY:
+#endif
 	case M680X_INS_LDS:
 	case M680X_INS_LDW:
 	case M680X_INS_LDX:
@@ -556,21 +587,28 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_LEAX:
 	case M680X_INS_LEAY:
 	case M680X_INS_LEAS:
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
 	case M680X_INS_PULCW:
 		op->type = RZ_ANALYSIS_OP_TYPE_LOAD;
 		break;
+#endif
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
 	case M680X_INS_GSTS:
 	case M680X_INS_GSTD:
 	case M680X_INS_GSTX:
 	case M680X_INS_GSTY:
+#endif
 	case M680X_INS_STS:
 	case M680X_INS_STX:
 	case M680X_INS_STY:
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
 	case M680X_INS_PSHCW:
 	case M680X_INS_GSTAB:
 	case M680X_INS_GSTAA:
+#endif
 		op->type = RZ_ANALYSIS_OP_TYPE_STORE;
 		break;
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
 	case M680X_INS_RORY:
 		op->type = RZ_ANALYSIS_OP_TYPE_ROR;
 		break;
@@ -580,6 +618,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_LSRY:
 		op->type = RZ_ANALYSIS_OP_TYPE_SHR;
 		break;
+#endif
 	}
 beach:
 	cs_free(insn, n);

--- a/librz/arch/p/asm/asm_m680x_cs.c
+++ b/librz/arch/p/asm/asm_m680x_cs.c
@@ -33,11 +33,14 @@ static cs_mode m680x_mode(const char *str) {
 		return CS_MODE_M680X_6309;
 	} else if (strstr(str, "hcs08")) {
 		return CS_MODE_M680X_HCS08;
-	} else if (strstr(str, "rs08")) {
+	}
+#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+	else if (strstr(str, "rs08")) {
 		return CS_MODE_M680X_RS08;
 	} else if (strstr(str, "hcs12x")) {
 		return CS_MODE_M680X_HCS12X;
 	}
+#endif
 	return CS_MODE_M680X_6800;
 }
 

--- a/meson.build
+++ b/meson.build
@@ -230,6 +230,21 @@ if has_capstone_m68k_cpu32
   add_project_arguments(['-DRZ_CAPSTONE_HAS_M68K_CPU32'], language: 'c')
 endif
 
+has_capstone_m680x_hcs12x = cc.compiles('''
+#include <capstone/capstone.h>
+int main(void) {
+        cs_mode mode = CS_MODE_M680X_HCS12X;
+        return mode == 0;
+}
+''',
+  dependencies: capstone_check_deps,
+  include_directories: capstone_check_includes,
+  name: 'Capstone has M680X HCS12X mode'
+)
+if has_capstone_m680x_hcs12x
+  add_project_arguments(['-DRZ_CAPSTONE_HAS_M680X_HCS12X'], language: 'c')
+endif
+
 # Handle PCRE2
 cpu_jit_supported = [ 'aarch64', 'arm', 'mips', 'mips64', 'ppc', 'ppc64', 'riscv32', 'riscv64', 's390x', 'x86', 'x86_64' ]
 pcre2_jit_supported = target_machine.cpu_family() in cpu_jit_supported and cc.get_id() != 'tcc' and target_machine.system() not in ['darwin', 'serenity']


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
Added a check in `meson.build` for `CS_MODE_M680X_HCS12X` compatibility, similar to what was done for `CS_MODE_M68K_CPU32` in https://github.com/rizinorg/rizin/pull/6314.

A separate check wasnt added for RS08 since if the HCS12x check passes the RS08 will too

Both capstone next and v6 have the same `CS_NEXT_VERSION` so it isnt possible to differentiate between them with this flag.

**Test plan**
none

**Closing issues**
none