### PR TITLE
Feature: Highlight conditional gadgets in all modes

### DIFF
--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -238,7 +238,7 @@ static bool gadget_hitlist_print_quiet_mode(const RzCore *core, const RzCoreAsmH
 	return true;
 }
 
-static bool gadget_hitlist_print_standard_mode(const RzCore *core, const RzCoreAsmHit *hit, ut32 *size, RzGadgetSearchContext *context) {
+static bool gadget_hitlist_print_standard_mode(const RzCore *core, const RzCoreAsmHit *hit, ut32 *size, RzGadgetSearchContext *context, bool is_conditional) {
 	rz_return_val_if_fail(core && context, false);
 	RzAnalysisOp aop = RZ_EMPTY;
 	RzAsmOp *asmop = NULL;
@@ -910,14 +910,21 @@ cleanup:
 	return ret;
 }
 
-static void gadget_print_standard_mode(const RzCore *core, const RzGadgetInfo *gadget_info) {
+static void gadget_print_standard_mode(const RzCore *core, const RzGadgetInfo *gadget_info, bool is_conditional) {
 	rz_return_if_fail(core && core->analysis && gadget_info);
 	RzReg *rreg = rz_analysis_get_reg(core->analysis);
 	if (!rreg) {
 		return;
 	}
 
-	rz_cons_printf("Gadget 0x%" PFMT64x "\n", gadget_info->address);
+	const bool colorize = rz_config_get_i(core->config, "scr.color");
+	const char *highlight_color = colorize ? Color_CYAN : "";
+	const char *reset_color = colorize ? Color_RESET : "";
+	if (is_conditional) {
+		rz_cons_printf("%sGadget 0x%" PFMT64x " [Conditional Gadget]%s\n", highlight_color, gadget_info->address, reset_color);
+	} else {
+		rz_cons_printf("Gadget 0x%" PFMT64x "\n", gadget_info->address);
+	}
 	rz_cons_printf("Stack change: 0x%" PFMT64x "\n", gadget_info->stack_change);
 
 	rz_cons_printf("Changed registers: ");
@@ -953,7 +960,7 @@ static void gadget_print_standard_mode(const RzCore *core, const RzGadgetInfo *g
 	rz_cons_printf("\n");
 }
 
-static void gadget_print_json_mode(const RzCore *core, const RzGadgetInfo *gadget_info, PJ *pj) {
+static void gadget_print_json_mode(const RzCore *core, const RzGadgetInfo *gadget_info, PJ *pj, bool is_conditional) {
 	rz_return_if_fail(gadget_info && pj);
 
 	RzReg *rreg = rz_analysis_get_reg(core->analysis);
@@ -963,6 +970,9 @@ static void gadget_print_json_mode(const RzCore *core, const RzGadgetInfo *gadge
 	pj_o(pj);
 	pj_kn(pj, "address", gadget_info->address);
 	pj_kn(pj, "stack_change", gadget_info->stack_change);
+	if (is_conditional) {
+		pj_kb(pj, "is_conditional", true);
+	}
 
 	pj_k(pj, "modified_registers");
 	pj_a(pj);
@@ -1081,7 +1091,7 @@ static void print_gadget_long_info(const RzGadgetInfo *gadget_info, RzVector /*<
 	}
 }
 
-static void gadget_print_long_mode(const RzCore *core, const RzGadgetInfo *gadget_info, const RzGadgetSearchContext *context) {
+static void gadget_print_long_mode(const RzCore *core, const RzGadgetInfo *gadget_info, const RzGadgetSearchContext *context, bool is_conditional) {
 	rz_return_if_fail(core && core->analysis);
 
 	ut64 addr = gadget_info->address;
@@ -1102,7 +1112,13 @@ static void gadget_print_long_mode(const RzCore *core, const RzGadgetInfo *gadge
 	char *rep_str = NULL;
 	bool utf8 = rz_config_get_b(core->config, "scr.utf8");
 	const bool colorize = rz_config_get_i(core->config, "scr.color");
-	rz_cons_printf("Gadget 0x%" PFMT64x " (size %d bytes)\n", addr, size);
+	const char *highlight_color = colorize ? Color_CYAN : "";
+	const char *reset_color = colorize ? Color_RESET : "";
+	if (is_conditional) {
+		rz_cons_printf("%sGadget 0x%" PFMT64x " (size %d bytes) [Conditional Gadget]%s\n", highlight_color, addr, size, reset_color);
+	} else {
+		rz_cons_printf("Gadget 0x%" PFMT64x " (size %d bytes)\n", addr, size);
+	}
 	if (utf8) {
 		rep_str = rz_str_repeat("–", req_width);
 		rz_cons_printf("%s––%s\n", rep_str, rep_str);
@@ -1149,7 +1165,7 @@ static void gadget_print_long_mode(const RzCore *core, const RzGadgetInfo *gadge
 	rz_cons_newline();
 }
 
-static void print_gadget_info(const RzCore *core, const RzGadgetInfo *gadget_info, const RzGadgetSearchContext *context) {
+static void print_gadget_info(const RzCore *core, const RzGadgetInfo *gadget_info, const RzGadgetSearchContext *context, bool is_conditional) {
 	rz_return_if_fail(gadget_info && context);
 	if (!context->state) {
 		return;
@@ -1163,13 +1179,13 @@ static void print_gadget_info(const RzCore *core, const RzGadgetInfo *gadget_inf
 
 	switch (context->state->mode) {
 	case RZ_OUTPUT_MODE_JSON:
-		gadget_print_json_mode(core, gadget_info, context->state->d.pj);
+		gadget_print_json_mode(core, gadget_info, context->state->d.pj, is_conditional);
 		break;
 	case RZ_OUTPUT_MODE_STANDARD:
-		gadget_print_standard_mode(core, gadget_info);
+		gadget_print_standard_mode(core, gadget_info, is_conditional);
 		break;
 	case RZ_OUTPUT_MODE_LONG:
-		gadget_print_long_mode(core, gadget_info, context);
+		gadget_print_long_mode(core, gadget_info, context, is_conditional);
 		break;
 	default:
 		rz_warn_if_reached();
@@ -1177,7 +1193,7 @@ static void print_gadget_info(const RzCore *core, const RzGadgetInfo *gadget_inf
 	}
 }
 
-static bool print_gadget_hitlist(const RzCore *core, RzPVector /*<RzCoreAsmHit *>*/ *hitlist, size_t start_idx, RzGadgetSearchContext *context) {
+static bool print_gadget_hitlist(const RzCore *core, RzPVector /*<RzCoreAsmHit *>*/ *hitlist, size_t start_idx, RzGadgetSearchContext *context, bool is_conditional) {
 	rz_return_val_if_fail(core && hitlist && context, false);
 	RzCmdStateOutput *state = context->state;
 	if (!state) {
@@ -1188,14 +1204,24 @@ static bool print_gadget_hitlist(const RzCore *core, RzPVector /*<RzCoreAsmHit *
 	if (!hit) {
 		return false;
 	}
+
+	const bool colorize = rz_config_get_i(core->config, "scr.color");
 	if (state->mode == RZ_OUTPUT_MODE_JSON) {
 		pj_o(state->d.pj);
 		pj_ka(state->d.pj, "opcodes");
 	} else if (state->mode == RZ_OUTPUT_MODE_QUIET) {
+		const char *addr_color = "";
+		const char *reset_color = "";
+		if (is_conditional) {
+			if (colorize) {
+				addr_color = Color_CYAN;
+				reset_color = Color_RESET;
+			}
+		}
 		if (context->ret_val) {
-			rz_strbuf_appendf(context->buf, "0x%08" PFMT64x ":", hit->addr);
+			rz_strbuf_appendf(context->buf, "%s0x%08" PFMT64x "%s:", addr_color, hit->addr, reset_color);
 		} else {
-			rz_cons_printf("0x%08" PFMT64x ":", hit->addr);
+			rz_cons_printf("%s0x%08" PFMT64x "%s:", addr_color, hit->addr, reset_color);
 		}
 	}
 	const ut64 addr = hit->addr;
@@ -1218,7 +1244,7 @@ static bool print_gadget_hitlist(const RzCore *core, RzPVector /*<RzCoreAsmHit *
 				result = gadget_hitlist_print_quiet_mode(core, hit, &size, context);
 				break;
 			case RZ_OUTPUT_MODE_STANDARD:
-				result = gadget_hitlist_print_standard_mode(core, hit, &size, context);
+				result = gadget_hitlist_print_standard_mode(core, hit, &size, context, is_conditional);
 				break;
 			case RZ_OUTPUT_MODE_TABLE:
 				result = gadget_hitlist_print_table_mode(core, hit, hitlist, &size, &asmop_str, &asmop_hex_str, context);
@@ -1232,6 +1258,8 @@ static bool print_gadget_hitlist(const RzCore *core, RzPVector /*<RzCoreAsmHit *
 			}
 		}
 	}
+	const char *highlight_color = colorize ? Color_CYAN : "";
+	const char *reset_color = colorize ? Color_RESET : "";
 	switch (state->mode) {
 	case RZ_OUTPUT_MODE_JSON:
 		if (!state->d.pj) {
@@ -1244,19 +1272,34 @@ static bool print_gadget_hitlist(const RzCore *core, RzPVector /*<RzCoreAsmHit *
 		if (hit) {
 			pj_kn(state->d.pj, "retaddr", hit->addr);
 			pj_ki(state->d.pj, "size", size);
+			if (is_conditional) {
+				pj_kb(state->d.pj, "is_conditional", true);
+			}
 		}
 		pj_end(state->d.pj);
 		break;
 	case RZ_OUTPUT_MODE_QUIET:
-		if (context->ret_val) {
-			rz_strbuf_append(context->buf, "\n");
-			break;
+		if (is_conditional) {
+			if (context->ret_val) {
+				rz_strbuf_appendf(context->buf, " %s[Conditional Gadget]%s\n", highlight_color, reset_color);
+			} else {
+				rz_cons_printf(" %s[Conditional Gadget]%s\n", highlight_color, reset_color);
+			}
+		} else {
+			if (context->ret_val) {
+				rz_strbuf_appendf(context->buf, "\n");
+			} else {
+				rz_cons_newline();
+			}
 		}
-		rz_cons_newline();
 		break;
 	case RZ_OUTPUT_MODE_STANDARD:
 		if (hit) {
-			rz_cons_printf("Gadget size: %d\n", (int)size);
+			if (is_conditional) {
+				rz_cons_printf("%sGadget size: %d [Conditional Gadget]%s\n", highlight_color, (int)size, reset_color);
+			} else {
+				rz_cons_printf("Gadget size: %d\n", (int)size);
+			}
 		}
 		if (context->ret_val) {
 			break;
@@ -1264,6 +1307,11 @@ static bool print_gadget_hitlist(const RzCore *core, RzPVector /*<RzCoreAsmHit *
 		rz_cons_newline();
 		break;
 	case RZ_OUTPUT_MODE_TABLE:
+		if (is_conditional) {
+			char *new_str = rz_str_newf("%s[Conditional Gadget]%s %s", highlight_color, reset_color, asmop_str);
+			free(asmop_str);
+			asmop_str = new_str;
+		}
 		if (!context->ret_val) {
 			rz_table_add_rowf(state->d.t, "Xss", addr, asmop_hex_str, asmop_str);
 		}
@@ -1507,17 +1555,25 @@ static RzGadgetInfo *perform_gadget_analysis(const RzGadgetType type, RzCore *co
 RZ_API bool rz_core_handle_gadget_request_type(RZ_NONNULL RzCore *core, RZ_NONNULL RzGadgetSearchContext *context,
 	RZ_NONNULL RzPVector /*<RzCoreAsmHit *>*/ *hitlist, int delay_size) {
 	rz_return_val_if_fail(core && core->analysis && hitlist && context, false);
+
+	bool is_conditional = false;
+	if (context->allow_conditional) {
+		RzCoreAsmHit *terminator = find_gadget_terminator(hitlist, delay_size);
+		if (terminator) {
+			is_conditional = gadget_is_valid_terminator(context->type, core, terminator, true) && !gadget_is_valid_terminator(context->type, core, terminator, false);
+		}
+	}
 	if (context->mask & RZ_GADGET_PRINT) {
 		if (context->subchains) {
 			const size_t len = rz_pvector_len(hitlist);
 			const size_t limit = (len > 1) ? (len - 1) : 1;
 			for (size_t i = 0; i < limit; i++) {
-				if (!print_gadget_hitlist(core, hitlist, i, context)) {
+				if (!print_gadget_hitlist(core, hitlist, i, context, is_conditional)) {
 					return false;
 				}
 			}
 		} else {
-			if (!print_gadget_hitlist(core, hitlist, 0, context)) {
+			if (!print_gadget_hitlist(core, hitlist, 0, context, is_conditional)) {
 				return false;
 			}
 		}
@@ -1534,7 +1590,7 @@ RZ_API bool rz_core_handle_gadget_request_type(RZ_NONNULL RzCore *core, RZ_NONNU
 		if (!gadget_info && is_analysis) {
 			return false;
 		}
-		print_gadget_info(core, gadget_info, context);
+		print_gadget_info(core, gadget_info, context, is_conditional);
 	}
 	return true;
 }

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -1115,7 +1115,7 @@ static void gadget_print_long_mode(const RzCore *core, const RzGadgetInfo *gadge
 	const char *highlight_color = colorize ? Color_CYAN : "";
 	const char *reset_color = colorize ? Color_RESET : "";
 	if (is_conditional) {
-		rz_cons_printf("%sGadget 0x%" PFMT64x " (size %d bytes) [Conditional Gadget]%s\n", highlight_color, addr, size, reset_color);
+		rz_cons_printf("%sGadget 0x%" PFMT64x " (size %d bytes) [Conditional]%s\n", highlight_color, addr, size, reset_color);
 	} else {
 		rz_cons_printf("Gadget 0x%" PFMT64x " (size %d bytes)\n", addr, size);
 	}

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -921,7 +921,7 @@ static void gadget_print_standard_mode(const RzCore *core, const RzGadgetInfo *g
 	const char *highlight_color = colorize ? Color_CYAN : "";
 	const char *reset_color = colorize ? Color_RESET : "";
 	if (is_conditional) {
-		rz_cons_printf("%sGadget 0x%" PFMT64x " [Conditional Gadget]%s\n", highlight_color, gadget_info->address, reset_color);
+		rz_cons_printf("%sGadget 0x%" PFMT64x " [Conditional]%s\n", highlight_color, gadget_info->address, reset_color);
 	} else {
 		rz_cons_printf("Gadget 0x%" PFMT64x "\n", gadget_info->address);
 	}

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -1281,9 +1281,9 @@ static bool print_gadget_hitlist(const RzCore *core, RzPVector /*<RzCoreAsmHit *
 	case RZ_OUTPUT_MODE_QUIET:
 		if (is_conditional) {
 			if (context->ret_val) {
-				rz_strbuf_appendf(context->buf, " %s[Conditional Gadget]%s\n", highlight_color, reset_color);
+				rz_strbuf_appendf(context->buf, " %s[Conditional]%s\n", highlight_color, reset_color);
 			} else {
-				rz_cons_printf(" %s[Conditional Gadget]%s\n", highlight_color, reset_color);
+				rz_cons_printf(" %s[Conditional]%s\n", highlight_color, reset_color);
 			}
 		} else {
 			if (context->ret_val) {
@@ -1296,7 +1296,7 @@ static bool print_gadget_hitlist(const RzCore *core, RzPVector /*<RzCoreAsmHit *
 	case RZ_OUTPUT_MODE_STANDARD:
 		if (hit) {
 			if (is_conditional) {
-				rz_cons_printf("%sGadget size: %d [Conditional Gadget]%s\n", highlight_color, (int)size, reset_color);
+				rz_cons_printf("%sGadget size: %d [Conditional]%s\n", highlight_color, (int)size, reset_color);
 			} else {
 				rz_cons_printf("Gadget size: %d\n", (int)size);
 			}
@@ -1308,7 +1308,7 @@ static bool print_gadget_hitlist(const RzCore *core, RzPVector /*<RzCoreAsmHit *
 		break;
 	case RZ_OUTPUT_MODE_TABLE:
 		if (is_conditional) {
-			char *new_str = rz_str_newf("%s[Conditional Gadget]%s %s", highlight_color, reset_color, asmop_str);
+			char *new_str = rz_str_newf("%s[Conditional]%s %s", highlight_color, reset_color, asmop_str);
 			free(asmop_str);
 			asmop_str = new_str;
 		}

--- a/test/db/cmd/cmd_rop
+++ b/test/db/cmd/cmd_rop
@@ -3980,18 +3980,228 @@ CMDS=<<EOF
 e asm.arch=arm
 e asm.bits=32
 e cfg.bigendian=false
-wx 0080bd08
+wx 04e02de50000a0e10110a0e10080bd081eff2fe10220a0e100f020e3
 pi 1
+echo =========Without allow_conditional==============
 /R
-echo "==============================================="
+echo ===========With allow_conditional===============
 e gadget.conditional=true
+echo ======================/R========================
 /R
+echo ======================/Rq=======================
+/Rq
+echo ======================/Rg=======================
+/Rg
+echo ======================/Rt=======================
+/Rt
+echo ======================/Rj=======================
+/Rj
+echo ======================/Rgl======================
+/Rgl
 EOF
 EXPECT=<<EOF
-ldmeq sp!, {pc}
-===============================================
-  0x00000000           0080bd08  ldmeq sp!, {pc}
+str lr, [sp, -4]!
+=========Without allow_conditional==============
+  0x00000000           04e02de5  str lr, [sp, -4]!
+  0x00000004           0000a0e1  mov r0, r0
+  0x00000008           0110a0e1  mov r1, r1
+  0x0000000c           0080bd08  ldmeq sp!, {pc}
+  0x00000010           1eff2fe1  bx lr
+Gadget size: 20
+
+  0x00000004           0000a0e1  mov r0, r0
+  0x00000008           0110a0e1  mov r1, r1
+  0x0000000c           0080bd08  ldmeq sp!, {pc}
+  0x00000010           1eff2fe1  bx lr
+Gadget size: 16
+
+  0x00000008           0110a0e1  mov r1, r1
+  0x0000000c           0080bd08  ldmeq sp!, {pc}
+  0x00000010           1eff2fe1  bx lr
+Gadget size: 12
+
+  0x0000000c           0080bd08  ldmeq sp!, {pc}
+  0x00000010           1eff2fe1  bx lr
+Gadget size: 8
+
+  0x00000010           1eff2fe1  bx lr
 Gadget size: 4
+
+===========With allow_conditional===============
+======================/R========================
+  0x00000000           04e02de5  str lr, [sp, -4]!
+  0x00000004           0000a0e1  mov r0, r0
+  0x00000008           0110a0e1  mov r1, r1
+  0x0000000c           0080bd08  ldmeq sp!, {pc}
+Gadget size: 16 [Conditional Gadget]
+
+  0x00000004           0000a0e1  mov r0, r0
+  0x00000008           0110a0e1  mov r1, r1
+  0x0000000c           0080bd08  ldmeq sp!, {pc}
+Gadget size: 12 [Conditional Gadget]
+
+  0x00000008           0110a0e1  mov r1, r1
+  0x0000000c           0080bd08  ldmeq sp!, {pc}
+Gadget size: 8 [Conditional Gadget]
+
+  0x0000000c           0080bd08  ldmeq sp!, {pc}
+Gadget size: 4 [Conditional Gadget]
+
+  0x00000000           04e02de5  str lr, [sp, -4]!
+  0x00000004           0000a0e1  mov r0, r0
+  0x00000008           0110a0e1  mov r1, r1
+  0x0000000c           0080bd08  ldmeq sp!, {pc}
+  0x00000010           1eff2fe1  bx lr
+Gadget size: 20
+
+  0x00000004           0000a0e1  mov r0, r0
+  0x00000008           0110a0e1  mov r1, r1
+  0x0000000c           0080bd08  ldmeq sp!, {pc}
+  0x00000010           1eff2fe1  bx lr
+Gadget size: 16
+
+  0x00000008           0110a0e1  mov r1, r1
+  0x0000000c           0080bd08  ldmeq sp!, {pc}
+  0x00000010           1eff2fe1  bx lr
+Gadget size: 12
+
+  0x0000000c           0080bd08  ldmeq sp!, {pc}
+  0x00000010           1eff2fe1  bx lr
+Gadget size: 8
+
+  0x00000010           1eff2fe1  bx lr
+Gadget size: 4
+
+======================/Rq=======================
+0x00000000: str lr, [sp, -4]!; mov r0, r0; mov r1, r1; ldmeq sp!, {pc}; [Conditional Gadget]
+0x00000004: mov r0, r0; mov r1, r1; ldmeq sp!, {pc}; [Conditional Gadget]
+0x00000008: mov r1, r1; ldmeq sp!, {pc}; [Conditional Gadget]
+0x0000000c: ldmeq sp!, {pc}; [Conditional Gadget]
+0x00000000: str lr, [sp, -4]!; mov r0, r0; mov r1, r1; ldmeq sp!, {pc}; bx lr;
+0x00000004: mov r0, r0; mov r1, r1; ldmeq sp!, {pc}; bx lr;
+0x00000008: mov r1, r1; ldmeq sp!, {pc}; bx lr;
+0x0000000c: ldmeq sp!, {pc}; bx lr;
+0x00000010: bx lr;
+======================/Rg=======================
+Gadget 0x0 [Conditional Gadget]
+Stack change: 0xfffffffc
+Changed registers: sp r0 r1 
+Register dependencies:
+Memory Write: lr Initial Value: 0xffffffff New Value: 0x0
+Var Read: r0
+Var Read: r1
+
+Gadget 0x4 [Conditional Gadget]
+Stack change: 0x0
+Changed registers: r0 r1 
+Register dependencies:
+Var Read: r0
+Var Read: r1
+
+Gadget 0x8 [Conditional Gadget]
+Stack change: 0x0
+Changed registers: r1 
+Register dependencies:
+Var Read: r1
+
+Gadget 0xc [Conditional Gadget]
+Stack change: 0x0
+Changed registers: 
+Register dependencies:
+
+Gadget 0x0
+Stack change: 0xfffffffc
+Changed registers: sp r0 r1 
+Register dependencies:
+Memory Write: lr Initial Value: 0xffffffff New Value: 0x0
+Var Read: r0
+Var Read: r1
+
+Gadget 0x4
+Stack change: 0x0
+Changed registers: r0 r1 
+Register dependencies:
+Var Read: r0
+Var Read: r1
+
+Gadget 0x8
+Stack change: 0x0
+Changed registers: r1 
+Register dependencies:
+Var Read: r1
+
+Gadget 0xc
+Stack change: 0x0
+Changed registers: 
+Register dependencies:
+
+Gadget 0x10
+Stack change: 0x0
+Changed registers: 
+Register dependencies:
+
+======================/Rt=======================
+      addr                                    bytes disasm                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------
+0x00000000         04e02de50000a0e10110a0e10080bd08 [Conditional Gadget] str lr, [sp, -4]!; ; mov r0, r0; ; mov r1, r1; ; ldmeq sp!, {pc}; 
+0x00000004                 0000a0e10110a0e10080bd08 [Conditional Gadget] mov r0, r0; ; mov r1, r1; ; ldmeq sp!, {pc}; 
+0x00000008                         0110a0e10080bd08 [Conditional Gadget] mov r1, r1; ; ldmeq sp!, {pc}; 
+0x0000000c                                 0080bd08 [Conditional Gadget] ldmeq sp!, {pc}; 
+0x00000000 04e02de50000a0e10110a0e10080bd081eff2fe1 str lr, [sp, -4]!; ; mov r0, r0; ; mov r1, r1; ; ldmeq sp!, {pc}; ; bx lr; 
+0x00000004         0000a0e10110a0e10080bd081eff2fe1 mov r0, r0; ; mov r1, r1; ; ldmeq sp!, {pc}; ; bx lr; 
+0x00000008                 0110a0e10080bd081eff2fe1 mov r1, r1; ; ldmeq sp!, {pc}; ; bx lr; 
+0x0000000c                         0080bd081eff2fe1 ldmeq sp!, {pc}; ; bx lr; 
+0x00000010                                 1eff2fe1 bx lr; 
+======================/Rj=======================
+[{"opcodes":[{"offset":0,"size":4,"opcode":"str lr, [sp, -4]!","type":"store"},{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":16,"is_conditional":true},{"opcodes":[{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":12,"is_conditional":true},{"opcodes":[{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":8,"is_conditional":true},{"opcodes":[{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":4,"is_conditional":true},{"opcodes":[{"offset":0,"size":4,"opcode":"str lr, [sp, -4]!","type":"store"},{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":20},{"opcodes":[{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":16},{"opcodes":[{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":12},{"opcodes":[{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":8},{"opcodes":[{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":4}]
+======================/Rgl======================
+Gadget 0x0 (size 16 bytes) [Conditional Gadget]
+------------------------------------------------------------------------------------------------------
+  0x00000000  04e02de5         str lr, [sp, -4]! | Stack change: 0xfffffffc
+  0x00000004  0000a0e1         mov r0, r0        | Modified regs: sp r0 r1
+  0x00000008  0110a0e1         mov r1, r1        | Dependencies:  sp lr sp r0 r1
+  0x0000000c  0080bd08         ldmeq sp!, {pc}   | 
+
+Gadget 0x4 (size 12 bytes) [Conditional Gadget]
+------------------------------------------------------------------------------------------------------
+  0x00000004  0000a0e1         mov r0, r0      | Stack change: 0x0
+  0x00000008  0110a0e1         mov r1, r1      | Modified regs: r0 r1
+  0x0000000c  0080bd08         ldmeq sp!, {pc} | Dependencies:  r0 r1
+
+Gadget 0x8 (size 8 bytes) [Conditional Gadget]
+------------------------------------------------------------------------------------------------------
+  0x00000008  0110a0e1         mov r1, r1      | Stack change: 0x0
+  0x0000000c  0080bd08         ldmeq sp!, {pc} | Modified regs: r1
+
+Gadget 0xc (size 4 bytes) [Conditional Gadget]
+------------------------------------------------------------------------------------------------------
+  0x0000000c  0080bd08         ldmeq sp!, {pc} | Stack change: 0x0
+
+Gadget 0x0 (size 16 bytes)
+------------------------------------------------------------------------------------------------------
+  0x00000000  04e02de5         str lr, [sp, -4]! | Stack change: 0xfffffffc
+  0x00000004  0000a0e1         mov r0, r0        | Modified regs: sp r0 r1
+  0x00000008  0110a0e1         mov r1, r1        | Dependencies:  sp lr sp r0 r1
+  0x0000000c  0080bd08         ldmeq sp!, {pc}   | 
+
+Gadget 0x4 (size 12 bytes)
+------------------------------------------------------------------------------------------------------
+  0x00000004  0000a0e1         mov r0, r0      | Stack change: 0x0
+  0x00000008  0110a0e1         mov r1, r1      | Modified regs: r0 r1
+  0x0000000c  0080bd08         ldmeq sp!, {pc} | Dependencies:  r0 r1
+
+Gadget 0x8 (size 8 bytes)
+------------------------------------------------------------------------------------------------------
+  0x00000008  0110a0e1         mov r1, r1      | Stack change: 0x0
+  0x0000000c  0080bd08         ldmeq sp!, {pc} | Modified regs: r1
+
+Gadget 0xc (size 4 bytes)
+------------------------------------------------------------------------------------------------------
+  0x0000000c  0080bd08         ldmeq sp!, {pc} | Stack change: 0x0
+
+Gadget 0x10 (size 4 bytes)
+------------------------------------------------------------------------------------------------------
+  0x00000010  1eff2fe1         bx lr | Stack change: 0x0
 
 EOF
 RUN

--- a/test/db/cmd/cmd_rop
+++ b/test/db/cmd/cmd_rop
@@ -4033,19 +4033,19 @@ Gadget size: 4
   0x00000004           0000a0e1  mov r0, r0
   0x00000008           0110a0e1  mov r1, r1
   0x0000000c           0080bd08  ldmeq sp!, {pc}
-Gadget size: 16 [Conditional Gadget]
+Gadget size: 16 [Conditional]
 
   0x00000004           0000a0e1  mov r0, r0
   0x00000008           0110a0e1  mov r1, r1
   0x0000000c           0080bd08  ldmeq sp!, {pc}
-Gadget size: 12 [Conditional Gadget]
+Gadget size: 12 [Conditional]
 
   0x00000008           0110a0e1  mov r1, r1
   0x0000000c           0080bd08  ldmeq sp!, {pc}
-Gadget size: 8 [Conditional Gadget]
+Gadget size: 8 [Conditional]
 
   0x0000000c           0080bd08  ldmeq sp!, {pc}
-Gadget size: 4 [Conditional Gadget]
+Gadget size: 4 [Conditional]
 
   0x00000000           04e02de5  str lr, [sp, -4]!
   0x00000004           0000a0e1  mov r0, r0
@@ -4073,10 +4073,10 @@ Gadget size: 8
 Gadget size: 4
 
 ======================/Rq=======================
-0x00000000: str lr, [sp, -4]!; mov r0, r0; mov r1, r1; ldmeq sp!, {pc}; [Conditional Gadget]
-0x00000004: mov r0, r0; mov r1, r1; ldmeq sp!, {pc}; [Conditional Gadget]
-0x00000008: mov r1, r1; ldmeq sp!, {pc}; [Conditional Gadget]
-0x0000000c: ldmeq sp!, {pc}; [Conditional Gadget]
+0x00000000: str lr, [sp, -4]!; mov r0, r0; mov r1, r1; ldmeq sp!, {pc}; [Conditional]
+0x00000004: mov r0, r0; mov r1, r1; ldmeq sp!, {pc}; [Conditional]
+0x00000008: mov r1, r1; ldmeq sp!, {pc}; [Conditional]
+0x0000000c: ldmeq sp!, {pc}; [Conditional]
 0x00000000: str lr, [sp, -4]!; mov r0, r0; mov r1, r1; ldmeq sp!, {pc}; bx lr;
 0x00000004: mov r0, r0; mov r1, r1; ldmeq sp!, {pc}; bx lr;
 0x00000008: mov r1, r1; ldmeq sp!, {pc}; bx lr;
@@ -4141,12 +4141,12 @@ Changed registers:
 Register dependencies:
 
 ======================/Rt=======================
-      addr                                    bytes disasm                                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------
-0x00000000         04e02de50000a0e10110a0e10080bd08 [Conditional Gadget] str lr, [sp, -4]!; ; mov r0, r0; ; mov r1, r1; ; ldmeq sp!, {pc}; 
-0x00000004                 0000a0e10110a0e10080bd08 [Conditional Gadget] mov r0, r0; ; mov r1, r1; ; ldmeq sp!, {pc}; 
-0x00000008                         0110a0e10080bd08 [Conditional Gadget] mov r1, r1; ; ldmeq sp!, {pc}; 
-0x0000000c                                 0080bd08 [Conditional Gadget] ldmeq sp!, {pc}; 
+      addr                                    bytes disasm                                                                           
+-------------------------------------------------------------------------------------------------------------------------------------
+0x00000000         04e02de50000a0e10110a0e10080bd08 [Conditional] str lr, [sp, -4]!; ; mov r0, r0; ; mov r1, r1; ; ldmeq sp!, {pc}; 
+0x00000004                 0000a0e10110a0e10080bd08 [Conditional] mov r0, r0; ; mov r1, r1; ; ldmeq sp!, {pc}; 
+0x00000008                         0110a0e10080bd08 [Conditional] mov r1, r1; ; ldmeq sp!, {pc}; 
+0x0000000c                                 0080bd08 [Conditional] ldmeq sp!, {pc}; 
 0x00000000 04e02de50000a0e10110a0e10080bd081eff2fe1 str lr, [sp, -4]!; ; mov r0, r0; ; mov r1, r1; ; ldmeq sp!, {pc}; ; bx lr; 
 0x00000004         0000a0e10110a0e10080bd081eff2fe1 mov r0, r0; ; mov r1, r1; ; ldmeq sp!, {pc}; ; bx lr; 
 0x00000008                 0110a0e10080bd081eff2fe1 mov r1, r1; ; ldmeq sp!, {pc}; ; bx lr; 

--- a/test/db/cmd/cmd_rop
+++ b/test/db/cmd/cmd_rop
@@ -4083,7 +4083,7 @@ Gadget size: 4
 0x0000000c: ldmeq sp!, {pc}; bx lr;
 0x00000010: bx lr;
 ======================/Rg=======================
-Gadget 0x0 [Conditional Gadget]
+Gadget 0x0 [Conditional]
 Stack change: 0xfffffffc
 Changed registers: sp r0 r1 
 Register dependencies:
@@ -4091,20 +4091,20 @@ Memory Write: lr Initial Value: 0xffffffff New Value: 0x0
 Var Read: r0
 Var Read: r1
 
-Gadget 0x4 [Conditional Gadget]
+Gadget 0x4 [Conditional]
 Stack change: 0x0
 Changed registers: r0 r1 
 Register dependencies:
 Var Read: r0
 Var Read: r1
 
-Gadget 0x8 [Conditional Gadget]
+Gadget 0x8 [Conditional]
 Stack change: 0x0
 Changed registers: r1 
 Register dependencies:
 Var Read: r1
 
-Gadget 0xc [Conditional Gadget]
+Gadget 0xc [Conditional]
 Stack change: 0x0
 Changed registers: 
 Register dependencies:
@@ -4155,25 +4155,25 @@ Register dependencies:
 ======================/Rj=======================
 [{"opcodes":[{"offset":0,"size":4,"opcode":"str lr, [sp, -4]!","type":"store"},{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":16,"is_conditional":true},{"opcodes":[{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":12,"is_conditional":true},{"opcodes":[{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":8,"is_conditional":true},{"opcodes":[{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":4,"is_conditional":true},{"opcodes":[{"offset":0,"size":4,"opcode":"str lr, [sp, -4]!","type":"store"},{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":20},{"opcodes":[{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":16},{"opcodes":[{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":12},{"opcodes":[{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":8},{"opcodes":[{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":4}]
 ======================/Rgl======================
-Gadget 0x0 (size 16 bytes) [Conditional Gadget]
+Gadget 0x0 (size 16 bytes) [Conditional]
 ------------------------------------------------------------------------------------------------------
   0x00000000  04e02de5         str lr, [sp, -4]! | Stack change: 0xfffffffc
   0x00000004  0000a0e1         mov r0, r0        | Modified regs: sp r0 r1
   0x00000008  0110a0e1         mov r1, r1        | Dependencies:  sp lr sp r0 r1
   0x0000000c  0080bd08         ldmeq sp!, {pc}   | 
 
-Gadget 0x4 (size 12 bytes) [Conditional Gadget]
+Gadget 0x4 (size 12 bytes) [Conditional]
 ------------------------------------------------------------------------------------------------------
   0x00000004  0000a0e1         mov r0, r0      | Stack change: 0x0
   0x00000008  0110a0e1         mov r1, r1      | Modified regs: r0 r1
   0x0000000c  0080bd08         ldmeq sp!, {pc} | Dependencies:  r0 r1
 
-Gadget 0x8 (size 8 bytes) [Conditional Gadget]
+Gadget 0x8 (size 8 bytes) [Conditional]
 ------------------------------------------------------------------------------------------------------
   0x00000008  0110a0e1         mov r1, r1      | Stack change: 0x0
   0x0000000c  0080bd08         ldmeq sp!, {pc} | Modified regs: r1
 
-Gadget 0xc (size 4 bytes) [Conditional Gadget]
+Gadget 0xc (size 4 bytes) [Conditional]
 ------------------------------------------------------------------------------------------------------
   0x0000000c  0080bd08         ldmeq sp!, {pc} | Stack change: 0x0
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

As discussed with @notxvilka in mattermost, implemented highlighting of conditional gadgets in all modes (non-color mode too)

This applies when `e gadget.conditional=true` is set
Please let me know if you mean to highlight conditional terminator instruction in the output no matter what is the state of config : `gadget.conditional`

Just to be clear `is_conditional` is set by using a trick actually. We get to know if teminator is conditional or not, by the function in `gadget_[rjc]op.c` so what i did is : 
- if `gadget_is_valid_terminator` return true for `allow_conditional` is passed as `true`
-  `&&` 
- return `false` when `allow_conditional` is passed as false
-  = the gadget is conditional terminator. 

I did this hack so that it is same code for ROP/COP/JOP.

UI/UX and color choices may be slightly questionable, i may be bad at that :)
suggestions welcome...

Here are some ss (arm32)
<img width="472" height="693" alt="image" src="https://github.com/user-attachments/assets/5c961b2c-18a5-4932-ae70-1043b433f802" />
<img width="764" height="194" alt="image" src="https://github.com/user-attachments/assets/66224794-88c4-4d74-94ae-343cb2c1262a" />
<img width="514" height="775" alt="image" src="https://github.com/user-attachments/assets/68abddf0-c29f-4fcc-b7ba-91d059d06935" />
<img width="1170" height="232" alt="image" src="https://github.com/user-attachments/assets/ed4a0e63-e8d8-4ab7-b8c6-e3fcbc9aba11" />
<img width="844" height="680" alt="image" src="https://github.com/user-attachments/assets/3d1e6d18-5113-4914-b240-9ed022f25c44" />


I also injected `is_conditional` key in JSON output when it is, otherwise the key is not injected
an exerpt: 
```json
    {
        "opcodes": [
            {
                "offset": 0,
                "size": 4,
                "opcode": "str lr, [sp, -4]!",
                "type": "store"
            },
            {
                "offset": 4,
                "size": 4,
                "opcode": "mov r0, r0",
                "type": "mov"
            },
            {
                "offset": 8,
                "size": 4,
                "opcode": "mov r1, r1",
                "type": "mov"
            },
            {
                "offset": 12,
                "size": 4,
                "opcode": "ldmeq sp!, {pc}",
                "type": "cret"
            }
        ],
        "retaddr": 12,
        "size": 16,
        "is_conditional": true
    },
```



**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Added (updated) new tests for conditonal gadgets

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
