### PR TITLE
Feature: Implement gadget cache 

### DIFF
--- a/librz/arch/analysis.c
+++ b/librz/arch/analysis.c
@@ -532,7 +532,7 @@ RZ_API void rz_analysis_set_xrefs_to(RZ_NONNULL RzAnalysis *analysis, HtUP *xref
  * \param type The RzGadgetType of gadget cache to retrieve.
  * \return A pointer to the requested RzGadgetCache, or NULL if the type is invalid.
  */
-RZ_API RZ_BORROW RzGadgetCache *rz_analysis_get_gadget_cache(RZ_NONNULL RzAnalysis *analysis, ut8 type) {
+RZ_API RZ_BORROW RzGadgetCache *rz_analysis_get_gadget_cache(RZ_NONNULL RzAnalysis *analysis, RzGadgetType type) {
 	rz_return_val_if_fail(analysis, NULL);
 	if (type >= 3) {
 		return NULL;
@@ -551,7 +551,7 @@ RZ_API RZ_BORROW RzGadgetCache *rz_analysis_get_gadget_cache(RZ_NONNULL RzAnalys
  * \param gadget_cache Pointer to the RzGadgetCache object to set.
  * \param type The RzGadgetType of gadget cache to set.
  */
-RZ_API void rz_analysis_set_gadget_cache(RZ_NONNULL RzAnalysis *analysis, RZ_NULLABLE RzGadgetCache *gadget_cache, ut8 type) {
+RZ_API void rz_analysis_set_gadget_cache(RZ_NONNULL RzAnalysis *analysis, RZ_NULLABLE RzGadgetCache *gadget_cache, RzGadgetType type) {
 	rz_return_if_fail(analysis);
 	if (type < 3) {
 		if (analysis->gadget_cache[type] == gadget_cache) {

--- a/librz/arch/analysis.c
+++ b/librz/arch/analysis.c
@@ -165,7 +165,9 @@ RZ_API RzAnalysis *rz_analysis_new(RZ_NULLABLE const char *sdb_types_path) {
 	}
 	analysis->ht_global_var = ht_sp_new(HT_STR_DUP, NULL, (HtSPFreeValue)rz_analysis_var_global_free);
 	analysis->ht_gadget_semantics = NULL;
-	analysis->ht_gadget = NULL;
+	analysis->gadget_cache[0] = (RzGadgetCache){ 0 };
+	analysis->gadget_cache[1] = (RzGadgetCache){ 0 };
+	analysis->gadget_cache[2] = (RzGadgetCache){ 0 };
 	analysis->global_var_tree = NULL;
 	analysis->il_vm = NULL;
 	analysis->hash = rz_hash_new();
@@ -221,6 +223,9 @@ RZ_API void rz_analysis_free(RZ_NULLABLE RzAnalysis *a) {
 	rz_str_constpool_fini(&a->constpool);
 	ht_sp_free(a->ht_global_var);
 	ht_up_free(a->ht_gadget_semantics);
+	rz_rbtree_free(a->gadget_cache[0].tree, a->gadget_cache[0].free, NULL);
+	rz_rbtree_free(a->gadget_cache[1].tree, a->gadget_cache[1].free, NULL);
+	rz_rbtree_free(a->gadget_cache[2].tree, a->gadget_cache[2].free, NULL);
 	ht_sp_free(a->plugins);
 	rz_analysis_debug_info_free(a->debug_info);
 	ht_sp_free(a->ht_virtual_xrefs);
@@ -511,6 +516,33 @@ RZ_API RZ_BORROW HtUP *rz_analysis_get_xrefs_to(RZ_NONNULL RzAnalysis *analysis)
 RZ_API void rz_analysis_set_xrefs_to(RZ_NONNULL RzAnalysis *analysis, HtUP *xrefs_to) {
 	rz_return_if_fail(analysis);
 	analysis->ht_xrefs_to = xrefs_to;
+}
+
+/**
+ * \brief Get the gadget cache for a specific gadget type.
+ * \param analysis Pointer to the RzAnalysis object.
+ * \param type The RzGadgetType of gadget cache to retrieve.
+ * \return A pointer to the requested RzGadgetCache, or NULL if the type is invalid.
+ */
+RZ_API RZ_BORROW RzGadgetCache *rz_analysis_get_gadget_cache(RZ_NONNULL RzAnalysis *analysis, ut8 type) {
+	rz_return_val_if_fail(analysis, NULL);
+	if (type >= 3) {
+		return NULL;
+	}
+	return &analysis->gadget_cache[type];
+}
+
+/**
+ * \brief Set the gadget cache in the analysis object for a specific gadget type.
+ * \param analysis Pointer to the RzAnalysis object.
+ * \param gadget_cache Pointer to the RzGadgetCache object to set.
+ * \param type The RzGadgetType of gadget cache to set.
+ */
+RZ_API void rz_analysis_set_gadget_cache(RZ_NONNULL RzAnalysis *analysis, RzGadgetCache *gadget_cache, ut8 type) {
+	rz_return_if_fail(analysis);
+	if (type < 3) {
+		analysis->gadget_cache[type] = *gadget_cache;
+	}
 }
 
 RZ_API RZ_BORROW HtUP *rz_analysis_get_gadget_semantics(RZ_NONNULL RzAnalysis *analysis) {

--- a/librz/arch/analysis.c
+++ b/librz/arch/analysis.c
@@ -165,9 +165,9 @@ RZ_API RzAnalysis *rz_analysis_new(RZ_NULLABLE const char *sdb_types_path) {
 	}
 	analysis->ht_global_var = ht_sp_new(HT_STR_DUP, NULL, (HtSPFreeValue)rz_analysis_var_global_free);
 	analysis->ht_gadget_semantics = NULL;
-	analysis->gadget_cache[0] = (RzGadgetCache){ 0 };
-	analysis->gadget_cache[1] = (RzGadgetCache){ 0 };
-	analysis->gadget_cache[2] = (RzGadgetCache){ 0 };
+	analysis->gadget_cache[0] = NULL;
+	analysis->gadget_cache[1] = NULL;
+	analysis->gadget_cache[2] = NULL;
 	analysis->global_var_tree = NULL;
 	analysis->il_vm = NULL;
 	analysis->hash = rz_hash_new();
@@ -185,6 +185,14 @@ RZ_API void plugin_fini(RzAnalysis *analysis) {
 		RZ_LOG_ERROR("analysis plugin '%s' failed to terminate.\n", p->name);
 	}
 	analysis->plugin_data = NULL;
+}
+
+static void gadget_cache_free(RzGadgetCache *gadget_cache) {
+	if (!gadget_cache) {
+		return;
+	}
+	rz_rbtree_free(gadget_cache->tree, gadget_cache->free, NULL);
+	free(gadget_cache);
 }
 
 void __block_free_rb(RBNode *node, void *user);
@@ -223,9 +231,9 @@ RZ_API void rz_analysis_free(RZ_NULLABLE RzAnalysis *a) {
 	rz_str_constpool_fini(&a->constpool);
 	ht_sp_free(a->ht_global_var);
 	ht_up_free(a->ht_gadget_semantics);
-	rz_rbtree_free(a->gadget_cache[0].tree, a->gadget_cache[0].free, NULL);
-	rz_rbtree_free(a->gadget_cache[1].tree, a->gadget_cache[1].free, NULL);
-	rz_rbtree_free(a->gadget_cache[2].tree, a->gadget_cache[2].free, NULL);
+	for (int i = 0; i < 3; i++) {
+		gadget_cache_free(a->gadget_cache[i]);
+	}
 	ht_sp_free(a->plugins);
 	rz_analysis_debug_info_free(a->debug_info);
 	ht_sp_free(a->ht_virtual_xrefs);
@@ -529,19 +537,33 @@ RZ_API RZ_BORROW RzGadgetCache *rz_analysis_get_gadget_cache(RZ_NONNULL RzAnalys
 	if (type >= 3) {
 		return NULL;
 	}
-	return &analysis->gadget_cache[type];
+	return analysis->gadget_cache[type];
 }
 
 /**
  * \brief Set the gadget cache in the analysis object for a specific gadget type.
+ *
+ * Takes ownership of `gadget_cache` pointer.
+ * The caller must not free it after passing it to this function.
+ * If a cache already exists for the given type, it will be freed before setting the new one.
+ *
  * \param analysis Pointer to the RzAnalysis object.
  * \param gadget_cache Pointer to the RzGadgetCache object to set.
  * \param type The RzGadgetType of gadget cache to set.
  */
-RZ_API void rz_analysis_set_gadget_cache(RZ_NONNULL RzAnalysis *analysis, RzGadgetCache *gadget_cache, ut8 type) {
+RZ_API void rz_analysis_set_gadget_cache(RZ_NONNULL RzAnalysis *analysis, RZ_NULLABLE RzGadgetCache *gadget_cache, ut8 type) {
 	rz_return_if_fail(analysis);
 	if (type < 3) {
-		analysis->gadget_cache[type] = *gadget_cache;
+		if (analysis->gadget_cache[type] == gadget_cache) {
+			return;
+		}
+
+		// delete old cache
+		if (analysis->gadget_cache[type]) {
+			gadget_cache_free(analysis->gadget_cache[type]);
+		}
+
+		analysis->gadget_cache[type] = gadget_cache;
 	}
 }
 

--- a/librz/arch/analysis_private.h
+++ b/librz/arch/analysis_private.h
@@ -88,7 +88,7 @@ struct rz_analysis_t {
 	RzPlatformTargetIndex *platform_target;
 	HtSP *ht_global_var; // global variables
 	HtUP *ht_gadget_semantics; ///< cache gadget semantic information
-	HtUP *ht_gadget; ///< cache gadget address list
+	RzGadgetCache gadget_cache[3]; ///< 3 separate caches 0=ROP, 1=JOP and 2=COP gadgets
 	RBTree global_var_tree; // global variables by address. must not overlap
 	RzHash *hash;
 	RzAnalysisDebugInfo *debug_info; ///< store all debug info parsed from DWARF, etc..

--- a/librz/arch/analysis_private.h
+++ b/librz/arch/analysis_private.h
@@ -88,7 +88,7 @@ struct rz_analysis_t {
 	RzPlatformTargetIndex *platform_target;
 	HtSP *ht_global_var; // global variables
 	HtUP *ht_gadget_semantics; ///< cache gadget semantic information
-	RzGadgetCache gadget_cache[3]; ///< 3 separate caches 0=ROP, 1=JOP and 2=COP gadgets
+	RzGadgetCache *gadget_cache[3]; ///< 3 separate caches 0=ROP, 1=JOP and 2=COP gadgets
 	RBTree global_var_tree; // global variables by address. must not overlap
 	RzHash *hash;
 	RzAnalysisDebugInfo *debug_info; ///< store all debug info parsed from DWARF, etc..

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3774,7 +3774,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 
 	/* gadget */
 	SETI("gadget.len", 5, "Maximum number of instructions per gadget");
-	SETBPREF("gadget.cache", "false", "Cache gadget results(experimental)");
+	SETBPREF("gadget.cache", "true", "Cache gadget search results");
 	SETBPREF("gadget.subchains", "false", "Display every length gadget from gadget.len=X to 2");
 	SETBPREF("gadget.conditional", "false", "Include conditional jump, calls and returns in gadget search");
 	SETBPREF("gadget.comments", "false", "Display comments in gadget search output");

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -204,6 +204,21 @@ RZ_IPI RzCmdStatus rz_cmd_jop_gadget_search_size_handler(RzCore *core, int argc,
 	return gadget_search_size(core, argc, argv, state, gadget_type);
 }
 
+RZ_IPI RzCmdStatus rz_cmd_clear_rop_gadget_cache_handler(RzCore *core, int argc, const char **argv) {
+	rz_analysis_set_gadget_cache(core->analysis, NULL, RZ_GADGET_TYPE_ROP);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_cmd_clear_cop_gadget_cache_handler(RzCore *core, int argc, const char **argv) {
+	rz_analysis_set_gadget_cache(core->analysis, NULL, RZ_GADGET_TYPE_COP);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_cmd_clear_jop_gadget_cache_handler(RzCore *core, int argc, const char **argv) {
+	rz_analysis_set_gadget_cache(core->analysis, NULL, RZ_GADGET_TYPE_JOP);
+	return RZ_CMD_STATUS_OK;
+}
+
 static void cmd_search_bin(RzCore *core, RzInterval itv) {
 	ut64 from = itv.addr, to = rz_itv_end(itv);
 	int size; // , sz = sizeof (buf);

--- a/librz/core/cmd/cmd_search_gadget.c
+++ b/librz/core/cmd/cmd_search_gadget.c
@@ -206,10 +206,10 @@ static bool gadget_constraint_set_regs(RzGadgetConstraint *rc,
 	}
 
 	rc->type = il_type;
-	rc->args[DST_REG] = rz_str_dup(dst->name);
-	rc->args[SRC_REG] = rz_str_dup(src0->name);
+	rc->args[RZ_GADGET_ARG_DST_REG] = rz_str_dup(dst->name);
+	rc->args[RZ_GADGET_ARG_SRC_REG] = rz_str_dup(src0->name);
 	if (src1) {
-		rc->args[SRC_REG_SECOND] = rz_str_dup(src1->name);
+		rc->args[RZ_GADGET_ARG_SRC_REG_SECOND] = rz_str_dup(src1->name);
 	}
 	return true;
 }
@@ -223,7 +223,7 @@ static bool gadget_constraint_set_op(RzGadgetConstraint *rc, RzILOpPureCode op) 
 	if (!op_str) {
 		return false;
 	}
-	rc->args[OP] = rz_str_dup(op_str);
+	rc->args[RZ_GADGET_ARG_OP] = rz_str_dup(op_str);
 	return true;
 }
 
@@ -238,11 +238,11 @@ static bool gadget_constraint_set_const(RzGadgetConstraint *rc,
 	}
 
 	rc->type = il_type;
-	rc->args[DST_REG] = rz_str_dup(dst->name);
+	rc->args[RZ_GADGET_ARG_DST_REG] = rz_str_dup(dst->name);
 	if (src0) {
-		rc->args[SRC_REG] = rz_str_dup(src0->name);
+		rc->args[RZ_GADGET_ARG_SRC_REG] = rz_str_dup(src0->name);
 	}
-	rc->args[SRC_CONST] = rz_str_newf("%" PFMT64u, const_value);
+	rc->args[RZ_GADGET_ARG_SRC_CONST] = rz_str_newf("%" PFMT64u, const_value);
 	return true;
 }
 
@@ -285,13 +285,13 @@ static bool parse_compound_op(const RzCore *core, const char *str, RzGadgetConst
 
 	if (constant_status && is_compound_op) {
 		// dst = dst (math op) num
-		return gadget_constraint_set_const(gadget_constraint, MOV_OP_CONST, dst_reg, dst_reg, const_value) &&
+		return gadget_constraint_set_const(gadget_constraint, RZ_GADGET_IL_INSTR_MOV_OP_CONST, dst_reg, dst_reg, const_value) &&
 			gadget_constraint_set_op(gadget_constraint, op);
 	}
 
 	if (src_reg && is_compound_op) {
 		// dst = dst (math op) src
-		return gadget_constraint_set_regs(gadget_constraint, MOV_OP_REG, dst_reg, dst_reg, src_reg) &&
+		return gadget_constraint_set_regs(gadget_constraint, RZ_GADGET_IL_INSTR_MOV_OP_REG, dst_reg, dst_reg, src_reg) &&
 			gadget_constraint_set_op(gadget_constraint, op);
 	}
 
@@ -302,7 +302,7 @@ static bool parse_compound_op(const RzCore *core, const char *str, RzGadgetConst
 	const_value = 1;
 	// dst (math op)= 1
 
-	return gadget_constraint_set_const(gadget_constraint, MOV_OP_CONST, dst_reg, dst_reg, const_value) &&
+	return gadget_constraint_set_const(gadget_constraint, RZ_GADGET_IL_INSTR_MOV_OP_CONST, dst_reg, dst_reg, const_value) &&
 		gadget_constraint_set_op(gadget_constraint, op);
 }
 
@@ -318,7 +318,7 @@ static bool parse_reg_to_const(const RzCore *core, const char *str, RzGadgetCons
 		return false;
 	}
 
-	return gadget_constraint_set_const(gadget_constraint, MOV_CONST, dst_reg, NULL, const_value);
+	return gadget_constraint_set_const(gadget_constraint, RZ_GADGET_IL_INSTR_MOV_CONST, dst_reg, NULL, const_value);
 }
 
 static bool parse_reg_to_reg(const RzCore *core, const char *str, RzGadgetConstraint *gadget_constraint) {
@@ -342,7 +342,7 @@ static bool parse_reg_to_reg(const RzCore *core, const char *str, RzGadgetConstr
 		return false;
 	}
 
-	return gadget_constraint_set_regs(gadget_constraint, MOV_REG, dst_reg, src_reg, NULL);
+	return gadget_constraint_set_regs(gadget_constraint, RZ_GADGET_IL_INSTR_MOV_REG, dst_reg, src_reg, NULL);
 }
 
 static bool parse_reg_op_const(const RzCore *core, const char *str, RzGadgetConstraint *gadget_constraint) {
@@ -361,7 +361,7 @@ static bool parse_reg_op_const(const RzCore *core, const char *str, RzGadgetCons
 		goto compound;
 	}
 
-	return gadget_constraint_set_const(gadget_constraint, MOV_OP_CONST, dst_reg, src_reg, const_value) &&
+	return gadget_constraint_set_const(gadget_constraint, RZ_GADGET_IL_INSTR_MOV_OP_CONST, dst_reg, src_reg, const_value) &&
 		gadget_constraint_set_op(gadget_constraint, op);
 
 compound:
@@ -392,7 +392,7 @@ static bool parse_reg_op_reg(const RzCore *core, const char *str, RzGadgetConstr
 		goto compound;
 	}
 
-	return gadget_constraint_set_regs(gadget_constraint, MOV_OP_REG, dst_reg, src_reg0, src_reg1) &&
+	return gadget_constraint_set_regs(gadget_constraint, RZ_GADGET_IL_INSTR_MOV_OP_REG, dst_reg, src_reg0, src_reg1) &&
 		gadget_constraint_set_op(gadget_constraint, op);
 
 compound:

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -1938,6 +1938,14 @@ static const RzCmdDescHelp cmd_info_cop_gadget_help = {
 	.args = cmd_info_cop_gadget_args,
 };
 
+static const RzCmdDescArg cmd_clear_cop_gadget_cache_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_clear_cop_gadget_cache_help = {
+	.summary = "Clear COP gadget cache",
+	.args = cmd_clear_cop_gadget_cache_args,
+};
+
 static const RzCmdDescArg cmd_search_cop_gadget_args[] = {
 	{
 		.name = "filter-by-regex",
@@ -2137,6 +2145,14 @@ static const RzCmdDescArg cmd_info_jop_gadget_args[] = {
 static const RzCmdDescHelp cmd_info_jop_gadget_help = {
 	.summary = "List JOP Gadgets",
 	.args = cmd_info_jop_gadget_args,
+};
+
+static const RzCmdDescArg cmd_clear_jop_gadget_cache_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_clear_jop_gadget_cache_help = {
+	.summary = "Clear JOP gadget cache",
+	.args = cmd_clear_jop_gadget_cache_args,
 };
 
 static const RzCmdDescArg cmd_search_jop_gadget_args[] = {
@@ -2468,6 +2484,14 @@ static const RzCmdDescArg cmd_info_rop_gadget_args[] = {
 static const RzCmdDescHelp cmd_info_rop_gadget_help = {
 	.summary = "List ROP Gadgets",
 	.args = cmd_info_rop_gadget_args,
+};
+
+static const RzCmdDescArg cmd_clear_rop_gadget_cache_args[] = {
+	{ 0 },
+};
+static const RzCmdDescHelp cmd_clear_rop_gadget_cache_help = {
+	.summary = "Clear ROP gadget cache",
+	.args = cmd_clear_rop_gadget_cache_args,
 };
 
 static const RzCmdDescArg cmd_search_rop_gadget_args[] = {
@@ -22117,6 +22141,9 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *slash_C_cd = rz_cmd_desc_group_state_new(core->rcmd, slash__cd, "/C", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_TABLE, rz_cmd_info_cop_gadget_handler, &cmd_info_cop_gadget_help, &slash_C_help);
 	rz_warn_if_fail(slash_C_cd);
+	RzCmdDesc *cmd_clear_cop_gadget_cache_cd = rz_cmd_desc_argv_new(core->rcmd, slash_C_cd, "/C-", rz_cmd_clear_cop_gadget_cache_handler, &cmd_clear_cop_gadget_cache_help);
+	rz_warn_if_fail(cmd_clear_cop_gadget_cache_cd);
+
 	RzCmdDesc *cmd_search_cop_gadget_cd = rz_cmd_desc_argv_state_new(core->rcmd, slash_C_cd, "/C/", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_TABLE, rz_cmd_search_cop_gadget_handler, &cmd_search_cop_gadget_help);
 	rz_warn_if_fail(cmd_search_cop_gadget_cd);
 
@@ -22140,6 +22167,9 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *slash_J_cd = rz_cmd_desc_group_state_new(core->rcmd, slash__cd, "/J", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_TABLE, rz_cmd_info_jop_gadget_handler, &cmd_info_jop_gadget_help, &slash_J_help);
 	rz_warn_if_fail(slash_J_cd);
+	RzCmdDesc *cmd_clear_jop_gadget_cache_cd = rz_cmd_desc_argv_new(core->rcmd, slash_J_cd, "/J-", rz_cmd_clear_jop_gadget_cache_handler, &cmd_clear_jop_gadget_cache_help);
+	rz_warn_if_fail(cmd_clear_jop_gadget_cache_cd);
+
 	RzCmdDesc *cmd_search_jop_gadget_cd = rz_cmd_desc_argv_state_new(core->rcmd, slash_J_cd, "/J/", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_TABLE, rz_cmd_search_jop_gadget_handler, &cmd_search_jop_gadget_help);
 	rz_warn_if_fail(cmd_search_jop_gadget_cd);
 
@@ -22196,6 +22226,9 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *slash_R_cd = rz_cmd_desc_group_state_new(core->rcmd, slash__cd, "/R", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_TABLE, rz_cmd_info_rop_gadget_handler, &cmd_info_rop_gadget_help, &slash_R_help);
 	rz_warn_if_fail(slash_R_cd);
+	RzCmdDesc *cmd_clear_rop_gadget_cache_cd = rz_cmd_desc_argv_new(core->rcmd, slash_R_cd, "/R-", rz_cmd_clear_rop_gadget_cache_handler, &cmd_clear_rop_gadget_cache_help);
+	rz_warn_if_fail(cmd_clear_rop_gadget_cache_cd);
+
 	RzCmdDesc *cmd_search_rop_gadget_cd = rz_cmd_desc_argv_state_new(core->rcmd, slash_R_cd, "/R/", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET | RZ_OUTPUT_MODE_TABLE, rz_cmd_search_rop_gadget_handler, &cmd_search_rop_gadget_help);
 	rz_warn_if_fail(cmd_search_rop_gadget_cd);
 

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -111,6 +111,8 @@ RZ_IPI RzCmdStatus rz_cmd_search_hash_entropy_fractional_handler(RzCore *core, i
 RZ_IPI RzCmdStatus rz_cmd_search_cryptographic_material_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "/C"
 RZ_IPI RzCmdStatus rz_cmd_info_cop_gadget_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+// "/C-"
+RZ_IPI RzCmdStatus rz_cmd_clear_cop_gadget_cache_handler(RzCore *core, int argc, const char **argv);
 // "/C/"
 RZ_IPI RzCmdStatus rz_cmd_search_cop_gadget_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "/Ck"
@@ -127,6 +129,8 @@ RZ_IPI RzCmdStatus rz_cmd_search_deltified_handler(RzCore *core, int argc, const
 RZ_IPI RzCmdStatus rz_cmd_search_file_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "/J"
 RZ_IPI RzCmdStatus rz_cmd_info_jop_gadget_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+// "/J-"
+RZ_IPI RzCmdStatus rz_cmd_clear_jop_gadget_cache_handler(RzCore *core, int argc, const char **argv);
 // "/J/"
 RZ_IPI RzCmdStatus rz_cmd_search_jop_gadget_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "/Jk"
@@ -167,6 +171,8 @@ RZ_IPI RzCmdStatus rz_cmd_search_reference_write_handler(RzCore *core, int argc,
 RZ_IPI RzCmdStatus rz_cmd_search_reference_execute_handler(RzCore *core, int argc, const char **argv);
 // "/R"
 RZ_IPI RzCmdStatus rz_cmd_info_rop_gadget_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+// "/R-"
+RZ_IPI RzCmdStatus rz_cmd_clear_rop_gadget_cache_handler(RzCore *core, int argc, const char **argv);
 // "/R/"
 RZ_IPI RzCmdStatus rz_cmd_search_rop_gadget_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
 // "/Rk"

--- a/librz/core/cmd_descs/cmd_search.yaml
+++ b/librz/core/cmd_descs/cmd_search.yaml
@@ -329,6 +329,10 @@ commands:
           - name: filter-by-string
             type: RZ_CMD_ARG_TYPE_STRING
             optional: true
+      - name: "/C-"
+        cname: cmd_clear_cop_gadget_cache
+        summary: Clear COP gadget cache
+        args: []
       - name: "/C/"
         cname: cmd_search_cop_gadget
         summary: List COP Gadgets [regular expression]
@@ -493,6 +497,10 @@ commands:
           - name: filter-by-string
             type: RZ_CMD_ARG_TYPE_STRING
             optional: true
+      - name: "/J-"
+        cname: cmd_clear_jop_gadget_cache
+        summary: Clear JOP gadget cache
+        args: []
       - name: "/J/"
         cname: cmd_search_jop_gadget
         summary: List JOP Gadgets [regular expression]
@@ -743,6 +751,10 @@ commands:
           - name: filter-by-string
             type: RZ_CMD_ARG_TYPE_STRING
             optional: true
+      - name: "/R-"
+        cname: cmd_clear_rop_gadget_cache
+        summary: Clear ROP gadget cache
+        args: []
       - name: "/R/"
         cname: cmd_search_rop_gadget
         summary: List ROP Gadgets [regular expression]

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -1404,7 +1404,7 @@ static void update_search_context(const RzGadgetSearchContext *context, const ch
 	}
 }
 
-static bool filter_gadget(RzCore *core, const ut8 *buf, int start_idx, RzGadgetSearchContext *context,
+static bool filter_gadget(RzCore *core, const ut8 *buf, RzGadgetSearchContext *context,
 	RzList /*<char *>*/ *rx_list, RzPVector /*<RzCoreAsmHit *>*/ *hitlist) {
 
 	bool is_greparg = !(context->mask & (RZ_GADGET_PRINT_DETAIL | RZ_GADGET_ANALYZE)) && !(context->detail_mask | RZ_GADGET_DETAIL_SEARCH_NON) && context->greparg;
@@ -1476,7 +1476,7 @@ static bool filter_gadget(RzCore *core, const ut8 *buf, int start_idx, RzGadgetS
 	return pass;
 }
 
-static RzPVector /*<RzCoreAsmHit *>*/ *build_gadget_hitlist_raw(RzCore *core, ut8 *buf, int idx,
+static RzPVector /*<RzCoreAsmHit *>*/ *build_gadget_hitlist_raw(RzCore *core, ut8 *buf, ssize_t idx,
 	RzGadgetSearchContext *context, RzGadgetEndListPair *end_gadget, RZ_OUT RzStrBuf **sb_out) {
 
 	RzPVector *hitlist = rz_pvector_new((RzPVectorFree)rz_core_asm_hit_free);
@@ -1595,7 +1595,7 @@ static RzPVector /*<RzCoreAsmHit *>*/ *deep_copy_hitlist(const RzPVector /*<RzCo
 	return new_hitlist;
 }
 
-static RzPVector /*<RzCoreAsmHit *>*/ *construct_gadget(RzCore *core, ut8 *buf, int idx, RzGadgetSearchContext *context,
+static RzPVector /*<RzCoreAsmHit *>*/ *construct_gadget(RzCore *core, ut8 *buf, ssize_t idx, RzGadgetSearchContext *context,
 	RzList /*<char *>*/ *rx_list, RzGadgetEndListPair *end_gadget) {
 
 	RzStrBuf *sb = NULL;
@@ -1626,7 +1626,7 @@ static RzPVector /*<RzCoreAsmHit *>*/ *construct_gadget(RzCore *core, ut8 *buf, 
 		}
 	}
 
-	if (!filter_gadget(core, buf, idx, context, rx_list, hitlist)) {
+	if (!filter_gadget(core, buf, context, rx_list, hitlist)) {
 		rz_pvector_free(hitlist);
 		return NULL;
 	}
@@ -2013,7 +2013,7 @@ static bool apply_post_build_filters(RzCore *core, RzGadgetSearchContext *contex
 	return true;
 }
 
-static bool process_disassembly(RzCore *core, ut8 *buf, const int idx, RzGadgetSearchContext *context,
+static bool process_disassembly(RzCore *core, ut8 *buf, const ssize_t idx, RzGadgetSearchContext *context,
 	RzList /*<char *>*/ *rx_list, RzGadgetEndListPair *end_gadget) {
 	RzAsmOp *asmop = rz_asm_op_new();
 	bool status = false;
@@ -2057,7 +2057,7 @@ fini:
 	return status;
 }
 
-static bool update_end_gadget(int *i, const int gadget_depth, RzGadgetEndListPair **end_gadget, const RzGadgetSearchContext *context) {
+static bool update_end_gadget(ssize_t *i, const int gadget_depth, RzGadgetEndListPair **end_gadget, const RzGadgetSearchContext *context) {
 	rz_return_val_if_fail(end_gadget && context, false);
 	if (*i > (*end_gadget)->instr_offset) {
 		// We've exhausted the first end-gadget section,
@@ -2095,8 +2095,7 @@ static bool print_gadgets_from_cache(RzCore *core, RzGadgetCache *gadget_cache, 
 			continue;
 		}
 
-		int start_idx = (int)(node->addr - context->from);
-		if (!filter_gadget(core, NULL, start_idx, context, rx_list, node->hitlist)) {
+		if (!filter_gadget(core, NULL, context, rx_list, node->hitlist)) {
 			rz_rbtree_iter_next(&iter);
 			continue;
 		}
@@ -2164,7 +2163,7 @@ static int handle_gadget_search_address(RzCore *core, RzGadgetSearchContext *con
 	RzGadgetEndListPair *end_gadget = rz_list_pop(context->end_list);
 	// Start at just before the first end gadget.
 	const int next = end_gadget->instr_offset;
-	for (int i = 0; i < delta && (context->cache || context->max_count); i += context->increment) {
+	for (ssize_t i = 0; i < delta && (context->cache || context->max_count); i += context->increment) {
 		// TODO: Test this and check if this line is needed in x86
 		const int prev = 0;
 		if (context->increment == 1 && i < prev - max_inst_size_x86) {

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -1557,6 +1557,9 @@ cleanup:
 }
 
 static void free_gadget_cache_node(RBNode *node, void *user) {
+	if (!node) {
+		return;
+	}
 	RzGadgetCacheNode *n = container_of(node, RzGadgetCacheNode, rb);
 	rz_pvector_free(n->hitlist);
 	free(n);
@@ -2039,6 +2042,8 @@ static bool process_disassembly(RzCore *core, ut8 *buf, const ssize_t idx, RzGad
 	RzList /*<char *>*/ *rx_list, RzGadgetEndListPair *end_gadget) {
 	RzAsmOp *asmop = rz_asm_op_new();
 	bool status = false;
+	ut64 orig_pc = rz_asm_get_pc(core->rasm);
+
 	const int ret = rz_asm_disassemble(core->rasm, asmop, buf + idx, context->to - context->from - idx);
 	if (!ret) {
 		goto fini;
@@ -2075,6 +2080,7 @@ static bool process_disassembly(RzCore *core, ut8 *buf, const ssize_t idx, RzGad
 	}
 
 fini:
+	rz_asm_set_pc(core->rasm, orig_pc);
 	rz_asm_op_free(asmop);
 	return status;
 }

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -2088,10 +2088,13 @@ RZ_API RzCmdStatus rz_core_gadget_search(RZ_NONNULL RzCore *core, RZ_NONNULL RzG
 	}
 	RzList /*<char *>*/ *rx_list = rz_core_gadget_handle_grep_args(context->greparg, context->regexp);
 	int status = 0;
-	// If specific address range is provided, scan that range for gadgets.
+
+	// If specific address range is provided, constrain the search interval.
+	// This path hits only when context->from/to is set using RZ_API
+	// in normal flow of /[RJC] commands this will never be hit
 	if (context->to || context->from) {
-		status = handle_gadget_search_address(core, context, rx_list);
-		goto cleanup;
+		RzInterval custom_itv = { context->from, context->to - context->from };
+		search_itv = rz_itv_intersect(search_itv, custom_itv);
 	}
 
 	RzList *boundaries = rz_core_get_boundaries_select(core, "search.from", "search.to", "search.in");

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -2272,26 +2272,32 @@ RZ_API RzCmdStatus rz_core_gadget_search(RZ_NONNULL RzCore *core, RZ_NONNULL RzG
 				RZ_LOG_INFO("core: Using gadget cache\n");
 				if (print_gadgets_from_cache(core, gadget_cache, context, rx_list)) {
 					status = 0;
-					goto cleanup;
+				} else {
+					RZ_LOG_ERROR("core: Failed to print gadgets from cache\n");
+					status = -1;
 				}
+				goto cleanup;
 			} else {
 				RZ_LOG_INFO("core: Parameters change detected, Rebuilding cache\n");
 			}
 		}
 
 		// cache miss
-		// delete old cache (if exist)
-		if (gadget_cache) {
-			rz_rbtree_free(gadget_cache->tree, free_gadget_cache_node, NULL);
+		RzGadgetCache *gadget_cache_new = RZ_NEW0(RzGadgetCache);
+		if (!gadget_cache_new) {
+			RZ_LOG_ERROR("core: Failed to allocate gadget cache\n");
+			status = -1;
+			goto cleanup;
 		}
 		RZ_LOG_DEBUG("core: Building gadget cache for address range 0x%" PFMT64x " - 0x%" PFMT64x "\n", context->from, context->to);
-		gadget_cache->tree = NULL;
-		gadget_cache->free = free_gadget_cache_node;
-		gadget_cache->from = rz_config_get_integer(core->config, "search.from");
-		gadget_cache->to = rz_config_get_integer(core->config, "search.to");
-		gadget_cache->max_instr = context->max_instr;
-		gadget_cache->allow_conditional = context->allow_conditional;
-		rz_analysis_set_gadget_cache(core->analysis, gadget_cache, context->type);
+		gadget_cache_new->tree = NULL;
+		gadget_cache_new->free = free_gadget_cache_node;
+		gadget_cache_new->from = context->from;
+		gadget_cache_new->to = context->to;
+		gadget_cache_new->max_instr = context->max_instr;
+		gadget_cache_new->allow_conditional = context->allow_conditional;
+
+		rz_analysis_set_gadget_cache(core->analysis, gadget_cache_new, context->type);
 	}
 
 	RzList *boundaries = rz_core_get_boundaries_select(core, "search.from", "search.to", "search.in");

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -1404,20 +1404,67 @@ static void update_search_context(const RzGadgetSearchContext *context, const ch
 	}
 }
 
-static RzPVector /*<RzCoreAsmHit *>*/ *construct_gadget(RzCore *core, ut8 *buf, int idx, RzGadgetSearchContext *context,
-	RzList /*<char *>*/ *rx_list, RzGadgetEndListPair *end_gadget) {
+static bool filter_gadget(RzCore *core, const ut8 *buf, int start_idx, RzGadgetSearchContext *context,
+	RzList /*<char *>*/ *rx_list, RzPVector /*<RzCoreAsmHit *>*/ *hitlist) {
+
+	bool is_greparg = !(context->mask & (RZ_GADGET_PRINT_DETAIL | RZ_GADGET_ANALYZE)) && !(context->detail_mask | RZ_GADGET_DETAIL_SEARCH_NON) && context->greparg;
+	if (!is_greparg) {
+		return true;
+	}
+
 	const char *start = NULL, *end = NULL;
 	int count = 0;
 	char *rx = NULL;
 	char *grep_str = NULL;
-	bool is_greparg = !(context->mask & (RZ_GADGET_PRINT_DETAIL | RZ_GADGET_ANALYZE)) && !(context->detail_mask | RZ_GADGET_DETAIL_SEARCH_NON) && context->greparg;
-	if (is_greparg) {
-		init_grep_context(context, &grep_str, &start, &end, rx_list, &rx, &count);
+	init_grep_context(context, &grep_str, &start, &end, rx_list, &rx, &count);
+
+	ut64 delta = context->to - context->from;
+	void **it;
+	rz_pvector_foreach (hitlist, it) {
+		RzCoreAsmHit *hit = *it;
+		int buf_offset = (int)(hit->addr - context->from);
+		if (buf_offset < 0 || (ut64)buf_offset >= delta) {
+			continue;
+		}
+		RzAnalysisOp aop = { 0 };
+		rz_analysis_op_init(&aop);
+		if (rz_analysis_op(core->analysis, &aop, hit->addr, buf + buf_offset,
+			    delta - buf_offset, RZ_ANALYSIS_OP_MASK_DISASM) < 0) {
+			rz_analysis_op_fini(&aop);
+			continue;
+		}
+		const char *opst = aop.mnemonic;
+		if (opst) {
+			bool search_hit = false;
+			if (rx) {
+				int grep_find = rz_regex_contains(rx, opst, RZ_REGEX_ZERO_TERMINATED, RZ_REGEX_EXTENDED, RZ_REGEX_DEFAULT);
+				search_hit = end && context->greparg && grep_find;
+			} else {
+				search_hit = end && context->greparg && strstr(opst, grep_str);
+			}
+			if (search_hit) {
+				update_search_context(context, &start, &end, &grep_str, rx_list, &rx, &count);
+			}
+		}
+		rz_analysis_op_fini(&aop);
 	}
+
+	bool pass = true;
+	if (context->regexp && rx) {
+		pass = false;
+	} else if (is_greparg && end) {
+		pass = false;
+	}
+
+	free(grep_str);
+	return pass;
+}
+
+static RzPVector /*<RzCoreAsmHit *>*/ *build_gadget_hitlist_raw(RzCore *core, ut8 *buf, int idx,
+	RzGadgetSearchContext *context, RzGadgetEndListPair *end_gadget, RZ_OUT RzStrBuf **sb_out) {
 
 	RzPVector *hitlist = rz_pvector_new((RzPVectorFree)rz_core_asm_hit_free);
 	if (!hitlist) {
-		free(grep_str);
 		return NULL;
 	}
 
@@ -1467,17 +1514,6 @@ static RzPVector /*<RzCoreAsmHit *>*/ *construct_gadget(RzCore *core, ut8 *buf, 
 		idx += aop.size;
 		addr += aop.size;
 
-		bool search_hit = false;
-		if (rx) {
-			int grep_find = rz_regex_contains(rx, opst, RZ_REGEX_ZERO_TERMINATED, RZ_REGEX_EXTENDED, RZ_REGEX_DEFAULT);
-			search_hit = end && context->greparg && grep_find;
-		} else if (is_greparg) {
-			search_hit = end && context->greparg && strstr(opst, grep_str);
-		}
-
-		if (search_hit) {
-			update_search_context(context, &start, &end, &grep_str, rx_list, &rx, &count);
-		}
 		if (end_gadget->instr_offset <= idx - aop.size) {
 			valid = end_gadget->instr_offset == idx - aop.size;
 			goto cleanup;
@@ -1485,21 +1521,46 @@ static RzPVector /*<RzCoreAsmHit *>*/ *construct_gadget(RzCore *core, ut8 *buf, 
 		rz_analysis_op_fini(&aop);
 		nb_instr++;
 	}
-
 cleanup:
 	rz_analysis_op_fini(&aop);
-	free(grep_str);
-	if ((context->regexp && rx) || (!valid || (is_greparg && end))) {
+
+	if (!valid) {
 		rz_pvector_free(hitlist);
 		rz_strbuf_free(sb);
+		if (sb_out) {
+			*sb_out = NULL;
+		}
 		return NULL;
 	}
+	if (sb_out) {
+		*sb_out = sb;
+	} else {
+		rz_strbuf_free(sb);
+	}
+	return hitlist;
+}
+
+static RzPVector /*<RzCoreAsmHit *>*/ *construct_gadget(RzCore *core, ut8 *buf, int idx, RzGadgetSearchContext *context,
+	RzList /*<char *>*/ *rx_list, RzGadgetEndListPair *end_gadget) {
+
+	RzStrBuf *sb = NULL;
+	RzPVector *hitlist = build_gadget_hitlist_raw(core, buf, idx, context, end_gadget, &sb);
+	if (!hitlist) {
+		return NULL;
+	}
+
 	if (!handle_gadget_list(sb, context, end_gadget, hitlist)) {
 		rz_pvector_free(hitlist);
 		rz_strbuf_free(sb);
 		return NULL;
 	}
 	rz_strbuf_free(sb);
+
+	if (!filter_gadget(core, buf, idx, context, rx_list, hitlist)) {
+		rz_pvector_free(hitlist);
+		return NULL;
+	}
+
 	return hitlist;
 }
 

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -1974,6 +1974,45 @@ static bool match_constraints(const RzGadgetInfo *gadget_info, const RzPVector /
 	return true;
 }
 
+static bool apply_post_build_filters(RzCore *core, RzGadgetSearchContext *context,
+	RzPVector /*<RzCoreAsmHit *>*/ *hitlist, int delay_size, ut64 gadget_addr) {
+
+	// constraint filtering
+	if (context->constraints && !rz_pvector_empty(context->constraints)) {
+		RzGadgetInfo *gadget_info = perform_gadget_analysis(context->type, core, context->allow_conditional, hitlist, delay_size);
+		if (!gadget_info || !match_constraints(gadget_info, context->constraints)) {
+			return false;
+		}
+	}
+
+	// detail mask filtering
+	if (context->detail_mask) {
+		RzGadgetInfo *gadget_info = perform_gadget_analysis(context->type, core, context->allow_conditional, hitlist, delay_size);
+		if (!gadget_info) {
+			return false;
+		}
+		if (context->detail_mask & (RZ_GADGET_DETAIL_SEARCH_STACK | RZ_GADGET_DETAIL_SEARCH_SIZE)) {
+			RzGadgetDetailSearchCmpOp cmp_op;
+			st64 target;
+			// RZ_GADGET_DETAIL_SEARCH_STACK -> stack_change, RZ_GADGET_DETAIL_SEARCH_SIZE -> size
+			ut64 search_val = context->detail_mask & RZ_GADGET_DETAIL_SEARCH_STACK ? gadget_info->stack_change : gadget_info->size;
+			if (!parse_detail_search_arg(core, context->greparg, &cmp_op, &target)) {
+				return false;
+			}
+			if (!match_detail_search(search_val, cmp_op, target)) {
+				return false;
+			}
+		}
+	}
+
+	// alignment check
+	if (core->search->align && gadget_addr % core->search->align != 0) {
+		return false;
+	}
+
+	return true;
+}
+
 static bool process_disassembly(RzCore *core, ut8 *buf, const int idx, RzGadgetSearchContext *context,
 	RzList /*<char *>*/ *rx_list, RzGadgetEndListPair *end_gadget) {
 	RzAsmOp *asmop = rz_asm_op_new();
@@ -1989,37 +2028,13 @@ static bool process_disassembly(RzCore *core, ut8 *buf, const int idx, RzGadgetS
 		goto fini;
 	}
 
-	if (context->constraints && !rz_pvector_empty(context->constraints)) {
-		RzGadgetInfo *gadget_info = perform_gadget_analysis(context->type, core, context->allow_conditional, hitlist, end_gadget->delay_size);
-		if (!gadget_info || !match_constraints(gadget_info, context->constraints)) {
-			rz_pvector_free(hitlist);
-			goto fini;
-		}
+	// when caching and max_count exhausts, skip output BUT continue building cache
+	if (context->cache && context->max_count == 0) {
+		rz_pvector_free(hitlist);
+		goto fini;
 	}
 
-	if (context->detail_mask) {
-		RzGadgetInfo *gadget_info = perform_gadget_analysis(context->type, core, context->allow_conditional, hitlist, end_gadget->delay_size);
-		if (!gadget_info) {
-			rz_pvector_free(hitlist);
-			goto fini;
-		}
-		if (context->detail_mask & (RZ_GADGET_DETAIL_SEARCH_STACK | RZ_GADGET_DETAIL_SEARCH_SIZE)) {
-			RzGadgetDetailSearchCmpOp cmp_op;
-			st64 target;
-			// RZ_GADGET_DETAIL_SEARCH_STACK -> stack_change, RZ_GADGET_DETAIL_SEARCH_SIZE -> size
-			ut64 search_val = context->detail_mask & RZ_GADGET_DETAIL_SEARCH_STACK ? gadget_info->stack_change : gadget_info->size;
-			if (!parse_detail_search_arg(core, context->greparg, &cmp_op, &target)) {
-				rz_pvector_free(hitlist);
-				goto fini;
-			}
-			if (!match_detail_search(search_val, cmp_op, target)) {
-				rz_pvector_free(hitlist);
-				goto fini;
-			}
-		}
-	}
-
-	if (core->search->align && (context->from + idx) % core->search->align != 0) {
+	if (!apply_post_build_filters(core, context, hitlist, end_gadget->delay_size, context->from + idx)) {
 		rz_pvector_free(hitlist);
 		goto fini;
 	}
@@ -2033,7 +2048,7 @@ static bool process_disassembly(RzCore *core, ut8 *buf, const int idx, RzGadgetS
 	if (context->max_count > 0) {
 		context->max_count--;
 		if (context->max_count < 1) {
-			status = true;
+			status = !context->cache;
 		}
 	}
 
@@ -2086,9 +2101,20 @@ static bool print_gadgets_from_cache(RzCore *core, RzGadgetCache *gadget_cache, 
 			continue;
 		}
 
+		if (!apply_post_build_filters(core, context, node->hitlist, node->delay_size, node->addr)) {
+			rz_rbtree_iter_next(&iter);
+			continue;
+		}
+
 		if (!rz_core_handle_gadget_request_type(core, context, node->hitlist, node->delay_size)) {
-			RZ_LOG_DEBUG("Fail at path 3");
 			return false;
+		}
+
+		if (context->max_count > 0) {
+			context->max_count--;
+			if (context->max_count < 1) {
+				break;
+			}
 		}
 		rz_rbtree_iter_next(&iter);
 	}
@@ -2138,7 +2164,7 @@ static int handle_gadget_search_address(RzCore *core, RzGadgetSearchContext *con
 	RzGadgetEndListPair *end_gadget = rz_list_pop(context->end_list);
 	// Start at just before the first end gadget.
 	const int next = end_gadget->instr_offset;
-	for (int i = 0; i < delta && context->max_count; i += context->increment) {
+	for (int i = 0; i < delta && (context->cache || context->max_count); i += context->increment) {
 		// TODO: Test this and check if this line is needed in x86
 		const int prev = 0;
 		if (context->increment == 1 && i < prev - max_inst_size_x86) {

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -1484,7 +1484,7 @@ static RzPVector /*<RzCoreAsmHit *>*/ *build_gadget_hitlist_raw(RzCore *core, ut
 		return NULL;
 	}
 
-	ut8 nb_instr = 0;
+	size_t nb_instr = 0;
 	ut64 addr = context->from + idx;
 	ut64 delta = context->to - context->from;
 	ut32 end_gadget_cnt = 0;

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -1427,7 +1427,7 @@ static bool filter_gadget(RzCore *core, const ut8 *buf, RzGadgetSearchContext *c
 		ut8 local_buf[32];
 
 		if (buf) {
-			int buf_offset = (int)(hit->addr - context->from);
+			st64 buf_offset = (st64)(hit->addr - context->from);
 			if (buf_offset < 0 || (ut64)buf_offset >= delta) {
 				continue;
 			}

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -1422,14 +1422,30 @@ static bool filter_gadget(RzCore *core, const ut8 *buf, int start_idx, RzGadgetS
 	void **it;
 	rz_pvector_foreach (hitlist, it) {
 		RzCoreAsmHit *hit = *it;
-		int buf_offset = (int)(hit->addr - context->from);
-		if (buf_offset < 0 || (ut64)buf_offset >= delta) {
-			continue;
+		const ut8 *op_buf;
+		ut64 op_size;
+		ut8 local_buf[32];
+
+		if (buf) {
+			int buf_offset = (int)(hit->addr - context->from);
+			if (buf_offset < 0 || (ut64)buf_offset >= delta) {
+				continue;
+			}
+			op_buf = buf + buf_offset;
+			op_size = delta - buf_offset;
+		} else {
+			// if buf is not provided, read 32bytes (sufficient for single instruction) from hit->addr
+			if (rz_io_nread_at(core->io, hit->addr, local_buf, sizeof(local_buf)) < 0) {
+				continue;
+			}
+			op_buf = local_buf;
+			op_size = sizeof(local_buf);
 		}
+
 		RzAnalysisOp aop = { 0 };
 		rz_analysis_op_init(&aop);
-		if (rz_analysis_op(core->analysis, &aop, hit->addr, buf + buf_offset,
-			    delta - buf_offset, RZ_ANALYSIS_OP_MASK_DISASM) < 0) {
+		if (rz_analysis_op(core->analysis, &aop, hit->addr, op_buf,
+			    op_size, RZ_ANALYSIS_OP_MASK_DISASM) < 0) {
 			rz_analysis_op_fini(&aop);
 			continue;
 		}
@@ -1540,6 +1556,45 @@ cleanup:
 	return hitlist;
 }
 
+static void free_gadget_cache_node(RBNode *node, void *user) {
+	RzGadgetCacheNode *n = container_of(node, RzGadgetCacheNode, rb);
+	rz_pvector_free(n->hitlist);
+	free(n);
+}
+
+static int gadget_cache_node_cmp(const void *data, const RBNode *x, void *user) {
+	const ut64 addr = *(const ut64 *)data;
+	const RzGadgetCacheNode *node = container_of(x, const RzGadgetCacheNode, rb);
+	return addr - node->addr;
+}
+
+static RzPVector /*<RzCoreAsmHit *>*/ *deep_copy_hitlist(const RzPVector /*<RzCoreAsmHit *>*/ *hitlist) {
+	if (!hitlist) {
+		return NULL;
+	}
+	RzPVector *new_hitlist = rz_pvector_new((RzPVectorFree)rz_core_asm_hit_free);
+	if (!new_hitlist) {
+		return NULL;
+	}
+	void **it;
+	rz_pvector_foreach (hitlist, it) {
+		const RzCoreAsmHit *hit = *it;
+		RzCoreAsmHit *new_hit = rz_core_asm_hit_new();
+		if (!new_hit) {
+			rz_pvector_free(new_hitlist);
+			return NULL;
+		}
+		new_hit->addr = hit->addr;
+		new_hit->len = hit->len;
+		new_hit->valid = hit->valid;
+		if (hit->code) {
+			new_hit->code = strdup(hit->code);
+		}
+		rz_pvector_push(new_hitlist, new_hit);
+	}
+	return new_hitlist;
+}
+
 static RzPVector /*<RzCoreAsmHit *>*/ *construct_gadget(RzCore *core, ut8 *buf, int idx, RzGadgetSearchContext *context,
 	RzList /*<char *>*/ *rx_list, RzGadgetEndListPair *end_gadget) {
 
@@ -1555,6 +1610,21 @@ static RzPVector /*<RzCoreAsmHit *>*/ *construct_gadget(RzCore *core, ut8 *buf, 
 		return NULL;
 	}
 	rz_strbuf_free(sb);
+
+	if (context->cache) {
+		ut64 gadget_addr = context->from + idx;
+		RzGadgetCache *gadget_cache = rz_analysis_get_gadget_cache(core->analysis, context->type);
+		RzGadgetCacheNode *node = RZ_NEW(RzGadgetCacheNode);
+		node->addr = gadget_addr;
+		node->hitlist = deep_copy_hitlist(hitlist);
+		node->delay_size = end_gadget->delay_size;
+		void *data = &node->addr;
+		if (!rz_rbtree_insert(&gadget_cache->tree, data, &node->rb, gadget_cache_node_cmp, NULL)) {
+			// TODO: should invalidate cache? idts as this path will rarely hit, dont deserve writing extra code?
+			RZ_LOG_ERROR("Failed to cache gadget for address 0x%" PFMT64x "\n", gadget_addr);
+			free_gadget_cache_node(&node->rb, NULL);
+		}
+	}
 
 	if (!filter_gadget(core, buf, idx, context, rx_list, hitlist)) {
 		rz_pvector_free(hitlist);
@@ -1993,6 +2063,51 @@ static bool update_end_gadget(int *i, const int gadget_depth, RzGadgetEndListPai
 	return true;
 }
 
+static bool print_gadgets_from_cache(RzCore *core, RzGadgetCache *gadget_cache, RzGadgetSearchContext *context, RzList /*<char *>*/ *rx_list) {
+	void *addr = &context->from;
+	RBIter iter = rz_rbtree_lower_bound_forward(gadget_cache->tree, addr, gadget_cache_node_cmp, NULL);
+	while (rz_rbtree_iter_has(&iter)) {
+		RzGadgetCacheNode *node = rz_rbtree_iter_get(&iter, RzGadgetCacheNode, rb);
+		if (!node) {
+			rz_rbtree_iter_next(&iter);
+			continue;
+		}
+		if (node->addr > context->to) {
+			break;
+		}
+		if (node->addr < context->from || node->addr >= context->to) {
+			rz_rbtree_iter_next(&iter);
+			continue;
+		}
+
+		int start_idx = (int)(node->addr - context->from);
+		if (!filter_gadget(core, NULL, start_idx, context, rx_list, node->hitlist)) {
+			rz_rbtree_iter_next(&iter);
+			continue;
+		}
+
+		if (!rz_core_handle_gadget_request_type(core, context, node->hitlist, node->delay_size)) {
+			RZ_LOG_DEBUG("Fail at path 3");
+			return false;
+		}
+		rz_rbtree_iter_next(&iter);
+	}
+	return true;
+}
+
+static bool is_gadget_cache_valid(RzCore *core, RzGadgetCache *gadget_cache, RzGadgetSearchContext *context) {
+	if (context->from < gadget_cache->from || context->to > gadget_cache->to) {
+		return false;
+	}
+	if (context->max_instr != gadget_cache->max_instr) {
+		return false;
+	}
+	if (context->allow_conditional != gadget_cache->allow_conditional) {
+		return false;
+	}
+	return true;
+}
+
 static int handle_gadget_search_address(RzCore *core, RzGadgetSearchContext *context, RzList /*<char *>*/ *rx_list) {
 	const ut64 delta = context->to - context->from;
 	ut8 *buf = RZ_NEWS0(ut8, delta);
@@ -2095,6 +2210,41 @@ RZ_API RzCmdStatus rz_core_gadget_search(RZ_NONNULL RzCore *core, RZ_NONNULL RzG
 	if (context->to || context->from) {
 		RzInterval custom_itv = { context->from, context->to - context->from };
 		search_itv = rz_itv_intersect(search_itv, custom_itv);
+	}
+
+	// if cache is enabled, try to print gadgets from cache first, if cache is valid, else rebuild cache
+	if (context->cache) {
+		RzGadgetCache *gadget_cache = rz_analysis_get_gadget_cache(core->analysis, context->type);
+
+		context->from = search_itv.addr;
+		context->to = search_itv.addr + search_itv.size;
+
+		// cache hit
+		if (gadget_cache) {
+			if (is_gadget_cache_valid(core, gadget_cache, context)) {
+				RZ_LOG_INFO("core: Using gadget cache\n");
+				if (print_gadgets_from_cache(core, gadget_cache, context, rx_list)) {
+					status = 0;
+					goto cleanup;
+				}
+			} else {
+				RZ_LOG_INFO("core: Parameters change detected, Rebuilding cache\n");
+			}
+		}
+
+		// cache miss
+		// delete old cache (if exist)
+		if (gadget_cache) {
+			rz_rbtree_free(gadget_cache->tree, free_gadget_cache_node, NULL);
+		}
+		RZ_LOG_DEBUG("core: Building gadget cache for address range 0x%" PFMT64x " - 0x%" PFMT64x "\n", context->from, context->to);
+		gadget_cache->tree = NULL;
+		gadget_cache->free = free_gadget_cache_node;
+		gadget_cache->from = rz_config_get_integer(core->config, "search.from");
+		gadget_cache->to = rz_config_get_integer(core->config, "search.to");
+		gadget_cache->max_instr = context->max_instr;
+		gadget_cache->allow_conditional = context->allow_conditional;
+		rz_analysis_set_gadget_cache(core->analysis, gadget_cache, context->type);
 	}
 
 	RzList *boundaries = rz_core_get_boundaries_select(core, "search.from", "search.to", "search.in");

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -1596,7 +1596,7 @@ static RzPVector /*<RzCoreAsmHit *>*/ *deep_copy_hitlist(const RzPVector /*<RzCo
 }
 
 static bool insert_gadget_in_cache(RzCore *core, RzGadgetSearchContext *context, ssize_t idx,
-	RzGadgetEndListPair *end_gadget, RzPVector *hitlist) {
+	RzGadgetEndListPair *end_gadget, RzPVector /*<RzCoreAsmHit *>*/ *hitlist) {
 
 	ut64 gadget_addr = context->from + idx;
 	RzGadgetCache *gadget_cache = rz_analysis_get_gadget_cache(core->analysis, context->type);

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -2209,6 +2209,44 @@ static int handle_gadget_search_address(RzCore *core, RzGadgetSearchContext *con
 	return 0;
 }
 
+static int handle_gadget_cache(RzCore *core, RzGadgetSearchContext *context, RzList /*<char *>*/ *rx_list) {
+
+	RzGadgetCache *gadget_cache = rz_analysis_get_gadget_cache(core->analysis, context->type);
+
+	// cache hit
+	if (gadget_cache) {
+		if (is_gadget_cache_valid(core, gadget_cache, context)) {
+			RZ_LOG_INFO("core: Using gadget cache\n");
+			if (print_gadgets_from_cache(core, gadget_cache, context, rx_list)) {
+				return 0;
+			} else {
+				RZ_LOG_ERROR("core: Failed to print gadgets from cache\n");
+				return -1;
+			}
+		} else {
+			RZ_LOG_INFO("core: Parameters change detected, Rebuilding cache\n");
+		}
+	}
+
+	// cache miss
+	RzGadgetCache *gadget_cache_new = RZ_NEW0(RzGadgetCache);
+	if (!gadget_cache_new) {
+		RZ_LOG_ERROR("core: Failed to allocate gadget cache\n");
+		return -1;
+	}
+	RZ_LOG_DEBUG("core: Building gadget cache for address range 0x%" PFMT64x " - 0x%" PFMT64x "\n", context->from, context->to);
+	gadget_cache_new->tree = NULL;
+	gadget_cache_new->free = free_gadget_cache_node;
+	gadget_cache_new->from = context->from;
+	gadget_cache_new->to = context->to;
+	gadget_cache_new->max_instr = context->max_instr;
+	gadget_cache_new->allow_conditional = context->allow_conditional;
+
+	rz_analysis_set_gadget_cache(core->analysis, gadget_cache_new, context->type);
+
+	return 1; // set gadget cache and continue normal flow to build cache and print gadgets
+}
+
 /**
  * \brief Search for gadgets.
  * \param core Pointer to the RzCore object.
@@ -2261,43 +2299,16 @@ RZ_API RzCmdStatus rz_core_gadget_search(RZ_NONNULL RzCore *core, RZ_NONNULL RzG
 
 	// if cache is enabled, try to print gadgets from cache first, if cache is valid, else rebuild cache
 	if (context->cache) {
-		RzGadgetCache *gadget_cache = rz_analysis_get_gadget_cache(core->analysis, context->type);
-
 		context->from = search_itv.addr;
 		context->to = search_itv.addr + search_itv.size;
-
-		// cache hit
-		if (gadget_cache) {
-			if (is_gadget_cache_valid(core, gadget_cache, context)) {
-				RZ_LOG_INFO("core: Using gadget cache\n");
-				if (print_gadgets_from_cache(core, gadget_cache, context, rx_list)) {
-					status = 0;
-				} else {
-					RZ_LOG_ERROR("core: Failed to print gadgets from cache\n");
-					status = -1;
-				}
-				goto cleanup;
-			} else {
-				RZ_LOG_INFO("core: Parameters change detected, Rebuilding cache\n");
-			}
-		}
-
-		// cache miss
-		RzGadgetCache *gadget_cache_new = RZ_NEW0(RzGadgetCache);
-		if (!gadget_cache_new) {
-			RZ_LOG_ERROR("core: Failed to allocate gadget cache\n");
+		int result = handle_gadget_cache(core, context, rx_list);
+		if (result == 0) {
+			status = 0;
+			goto cleanup;
+		} else if (result == -1) {
 			status = -1;
 			goto cleanup;
 		}
-		RZ_LOG_DEBUG("core: Building gadget cache for address range 0x%" PFMT64x " - 0x%" PFMT64x "\n", context->from, context->to);
-		gadget_cache_new->tree = NULL;
-		gadget_cache_new->free = free_gadget_cache_node;
-		gadget_cache_new->from = context->from;
-		gadget_cache_new->to = context->to;
-		gadget_cache_new->max_instr = context->max_instr;
-		gadget_cache_new->allow_conditional = context->allow_conditional;
-
-		rz_analysis_set_gadget_cache(core->analysis, gadget_cache_new, context->type);
 	}
 
 	RzList *boundaries = rz_core_get_boundaries_select(core, "search.from", "search.to", "search.in");

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -1595,6 +1595,36 @@ static RzPVector /*<RzCoreAsmHit *>*/ *deep_copy_hitlist(const RzPVector /*<RzCo
 	return new_hitlist;
 }
 
+static bool insert_gadget_in_cache(RzCore *core, RzGadgetSearchContext *context, ssize_t idx,
+	RzGadgetEndListPair *end_gadget, RzPVector *hitlist) {
+
+	ut64 gadget_addr = context->from + idx;
+	RzGadgetCache *gadget_cache = rz_analysis_get_gadget_cache(core->analysis, context->type);
+	if (!gadget_cache) {
+		return false;
+	}
+	RzPVector *hitlist_copy = deep_copy_hitlist(hitlist);
+	if (!hitlist_copy) {
+		return false;
+	}
+
+	RzGadgetCacheNode *node = RZ_NEW0(RzGadgetCacheNode);
+	if (!node) {
+		rz_pvector_free(hitlist_copy);
+		return false;
+	}
+	node->addr = gadget_addr;
+	node->hitlist = hitlist_copy;
+	node->delay_size = end_gadget->delay_size;
+	void *data = &node->addr;
+	if (!rz_rbtree_insert(&gadget_cache->tree, data, &node->rb, gadget_cache_node_cmp, NULL)) {
+		RZ_LOG_ERROR("Failed to cache gadget for address 0x%" PFMT64x "\n", gadget_addr);
+		free_gadget_cache_node(&node->rb, NULL);
+		return false;
+	}
+	return true;
+}
+
 static RzPVector /*<RzCoreAsmHit *>*/ *construct_gadget(RzCore *core, ut8 *buf, ssize_t idx, RzGadgetSearchContext *context,
 	RzList /*<char *>*/ *rx_list, RzGadgetEndListPair *end_gadget) {
 
@@ -1612,17 +1642,9 @@ static RzPVector /*<RzCoreAsmHit *>*/ *construct_gadget(RzCore *core, ut8 *buf, 
 	rz_strbuf_free(sb);
 
 	if (context->cache) {
-		ut64 gadget_addr = context->from + idx;
-		RzGadgetCache *gadget_cache = rz_analysis_get_gadget_cache(core->analysis, context->type);
-		RzGadgetCacheNode *node = RZ_NEW(RzGadgetCacheNode);
-		node->addr = gadget_addr;
-		node->hitlist = deep_copy_hitlist(hitlist);
-		node->delay_size = end_gadget->delay_size;
-		void *data = &node->addr;
-		if (!rz_rbtree_insert(&gadget_cache->tree, data, &node->rb, gadget_cache_node_cmp, NULL)) {
-			// TODO: should invalidate cache? idts as this path will rarely hit, dont deserve writing extra code?
-			RZ_LOG_ERROR("Failed to cache gadget for address 0x%" PFMT64x "\n", gadget_addr);
-			free_gadget_cache_node(&node->rb, NULL);
+		if (!insert_gadget_in_cache(core, context, idx, end_gadget, hitlist)) {
+			rz_pvector_free(hitlist);
+			return NULL;
 		}
 	}
 

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -1936,7 +1936,7 @@ static bool match_gadget_constraint(const RzGadgetInfo *gadget_info, const RzGad
 		return false;
 	}
 
-	const char *dst_reg = constraint->args[DST_REG];
+	const char *dst_reg = constraint->args[RZ_GADGET_ARG_DST_REG];
 	if (!dst_reg) {
 		return false;
 	}
@@ -1947,32 +1947,32 @@ static bool match_gadget_constraint(const RzGadgetInfo *gadget_info, const RzGad
 	}
 
 	switch (constraint->type) {
-	case MOV_CONST: {
-		const char *const_str = constraint->args[SRC_CONST];
+	case RZ_GADGET_IL_INSTR_MOV_CONST: {
+		const char *const_str = constraint->args[RZ_GADGET_ARG_SRC_CONST];
 		if (!const_str) {
 			return false;
 		}
 		ut64 expected_val = strtoull(const_str, NULL, 0);
 		return reg_info->new_val == expected_val;
 	}
-	case MOV_REG: {
-		const char *src_reg = constraint->args[SRC_REG];
+	case RZ_GADGET_IL_INSTR_MOV_REG: {
+		const char *src_reg = constraint->args[RZ_GADGET_ARG_SRC_REG];
 		if (!src_reg) {
 			return false;
 		}
 		return rz_core_gadget_reg_info_has_event(gadget_info, RZ_GADGET_EVENT_VAR_READ, src_reg);
 	}
-	case MOV_OP_CONST: {
-		const char *src_reg = constraint->args[SRC_REG];
-		const char *src_const = constraint->args[SRC_CONST];
+	case RZ_GADGET_IL_INSTR_MOV_OP_CONST: {
+		const char *src_reg = constraint->args[RZ_GADGET_ARG_SRC_REG];
+		const char *src_const = constraint->args[RZ_GADGET_ARG_SRC_CONST];
 		if (!src_reg || !src_const) {
 			return false;
 		}
 		return rz_core_gadget_reg_info_has_event(gadget_info, RZ_GADGET_EVENT_VAR_READ, src_reg);
 	}
-	case MOV_OP_REG: {
-		const char *src_reg = constraint->args[SRC_REG];
-		const char *src_reg_second = constraint->args[SRC_REG_SECOND];
+	case RZ_GADGET_IL_INSTR_MOV_OP_REG: {
+		const char *src_reg = constraint->args[RZ_GADGET_ARG_SRC_REG];
+		const char *src_reg_second = constraint->args[RZ_GADGET_ARG_SRC_REG_SECOND];
 		if (!src_reg || !src_reg_second) {
 			return false;
 		}
@@ -2386,7 +2386,7 @@ RZ_API void rz_core_gadget_constraint_free(RZ_NULLABLE void *data) {
 	if (!constraint) {
 		return;
 	}
-	for (size_t i = 0; i < NUM_ARGS; i++) {
+	for (size_t i = 0; i < RZ_GADGET_ARG_NUM_ARGS; i++) {
 		free(constraint->args[i]);
 	}
 	free(constraint);

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1390,7 +1390,7 @@ RZ_API void rz_analysis_set_xrefs_from(RZ_NONNULL RzAnalysis *analysis, HtUP *xr
 RZ_API RZ_BORROW HtUP *rz_analysis_get_xrefs_to(RZ_NONNULL RzAnalysis *analysis);
 RZ_API void rz_analysis_set_xrefs_to(RZ_NONNULL RzAnalysis *analysis, HtUP *xrefs_to);
 RZ_API RZ_BORROW RzGadgetCache *rz_analysis_get_gadget_cache(RZ_NONNULL RzAnalysis *analysis, ut8 type);
-RZ_API void rz_analysis_set_gadget_cache(RZ_NONNULL RzAnalysis *analysis, RzGadgetCache *gadget_cache, ut8 type);
+RZ_API void rz_analysis_set_gadget_cache(RZ_NONNULL RzAnalysis *analysis, RZ_NULLABLE RzGadgetCache *gadget_cache, ut8 type);
 RZ_API RZ_BORROW HtUP *rz_analysis_get_gadget_semantics(RZ_NONNULL RzAnalysis *analysis);
 RZ_API void rz_analysis_set_gadget_semantics(RZ_NONNULL RzAnalysis *analysis, HtUP *rop_semantics);
 RZ_API RZ_BORROW RzAnalysisCallbacks *rz_analysis_get_callbacks(RZ_NONNULL RzAnalysis *analysis);

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -43,6 +43,25 @@ typedef struct {
 	PJ *pj;
 } RzAnalysisMetaUserItem;
 
+/**
+ * \brief Gadget cache
+ *
+ * Stores a cache of discovered gadgets for a contiguous address range.
+ * The cache holds `RzGadgetCacheNode` nodes in an RB tree keyed by gadget start address.
+ * The cache is built for the given parameters (`from`, `to`, `max_instr`, `allow_conditional`)
+ * and is only valid for those parameters.
+ * When these parameters change, the cache must be rebuilt.
+ * The `free` callback is used to release per-node resources when the cache is cleared.
+ */
+typedef struct rz_gadget_cache_t {
+	RBTree tree; ///< root node
+	ut64 from; ///< cached address range start
+	ut64 to; ///< cached address range end
+	ut8 max_instr; ///< gadget.len used during cache build
+	bool allow_conditional; ///< gadget.conditional used during cache build
+	RBNodeFree free; ///< the custom free function that frees a RzGadgetCacheNode of the tree
+} RzGadgetCache;
+
 typedef enum {
 	RZ_ANALYSIS_DATA_INFO_TYPE_NULL = 0,
 	RZ_ANALYSIS_DATA_INFO_TYPE_UNKNOWN = 1,
@@ -1370,6 +1389,8 @@ RZ_API RZ_BORROW HtUP *rz_analysis_get_xrefs_from(RZ_NONNULL RzAnalysis *analysi
 RZ_API void rz_analysis_set_xrefs_from(RZ_NONNULL RzAnalysis *analysis, HtUP *xrefs_from);
 RZ_API RZ_BORROW HtUP *rz_analysis_get_xrefs_to(RZ_NONNULL RzAnalysis *analysis);
 RZ_API void rz_analysis_set_xrefs_to(RZ_NONNULL RzAnalysis *analysis, HtUP *xrefs_to);
+RZ_API RZ_BORROW RzGadgetCache *rz_analysis_get_gadget_cache(RZ_NONNULL RzAnalysis *analysis, ut8 type);
+RZ_API void rz_analysis_set_gadget_cache(RZ_NONNULL RzAnalysis *analysis, RzGadgetCache *gadget_cache, ut8 type);
 RZ_API RZ_BORROW HtUP *rz_analysis_get_gadget_semantics(RZ_NONNULL RzAnalysis *analysis);
 RZ_API void rz_analysis_set_gadget_semantics(RZ_NONNULL RzAnalysis *analysis, HtUP *rop_semantics);
 RZ_API RZ_BORROW RzAnalysisCallbacks *rz_analysis_get_callbacks(RZ_NONNULL RzAnalysis *analysis);

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -57,7 +57,7 @@ typedef struct rz_gadget_cache_t {
 	RBTree tree; ///< root node
 	ut64 from; ///< cached address range start
 	ut64 to; ///< cached address range end
-	ut8 max_instr; ///< gadget.len used during cache build
+	size_t max_instr; ///< gadget.len used during cache build
 	bool allow_conditional; ///< gadget.conditional used during cache build
 	RBNodeFree free; ///< the custom free function that frees a RzGadgetCacheNode of the tree
 } RzGadgetCache;

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -25,6 +25,7 @@
 #include <rz_platform.h>
 #include <rz_cmd.h>
 #include <rz_esil/rz_esil.h>
+#include <rz_gadget.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -1389,8 +1390,8 @@ RZ_API RZ_BORROW HtUP *rz_analysis_get_xrefs_from(RZ_NONNULL RzAnalysis *analysi
 RZ_API void rz_analysis_set_xrefs_from(RZ_NONNULL RzAnalysis *analysis, HtUP *xrefs_from);
 RZ_API RZ_BORROW HtUP *rz_analysis_get_xrefs_to(RZ_NONNULL RzAnalysis *analysis);
 RZ_API void rz_analysis_set_xrefs_to(RZ_NONNULL RzAnalysis *analysis, HtUP *xrefs_to);
-RZ_API RZ_BORROW RzGadgetCache *rz_analysis_get_gadget_cache(RZ_NONNULL RzAnalysis *analysis, ut8 type);
-RZ_API void rz_analysis_set_gadget_cache(RZ_NONNULL RzAnalysis *analysis, RZ_NULLABLE RzGadgetCache *gadget_cache, ut8 type);
+RZ_API RZ_BORROW RzGadgetCache *rz_analysis_get_gadget_cache(RZ_NONNULL RzAnalysis *analysis, RzGadgetType type);
+RZ_API void rz_analysis_set_gadget_cache(RZ_NONNULL RzAnalysis *analysis, RZ_NULLABLE RzGadgetCache *gadget_cache, RzGadgetType type);
 RZ_API RZ_BORROW HtUP *rz_analysis_get_gadget_semantics(RZ_NONNULL RzAnalysis *analysis);
 RZ_API void rz_analysis_set_gadget_semantics(RZ_NONNULL RzAnalysis *analysis, HtUP *rop_semantics);
 RZ_API RZ_BORROW RzAnalysisCallbacks *rz_analysis_get_callbacks(RZ_NONNULL RzAnalysis *analysis);

--- a/librz/include/rz_gadget.h
+++ b/librz/include/rz_gadget.h
@@ -60,6 +60,16 @@ typedef enum {
 } RzGadgetType;
 
 /**
+ * \brief Gadget cache node
+ */
+typedef struct rz_gadget_cache_node_t {
+	RBNode rb; ///< intrusive RBTree node
+	ut64 addr; ///< gadget start address
+	RzPVector /*<RzCoreAsmHit *>*/ *hitlist; ///< cached hitlist object for one gadget
+	int delay_size; ///< delay size for delay slot archs
+} RzGadgetCacheNode;
+
+/**
  * \brief Types of IL instructions for Gadget constraints.
  */
 typedef enum rz_gadget_il_instr_type {

--- a/librz/include/rz_gadget.h
+++ b/librz/include/rz_gadget.h
@@ -73,23 +73,23 @@ typedef struct rz_gadget_cache_node_t {
  * \brief Types of IL instructions for Gadget constraints.
  */
 typedef enum rz_gadget_il_instr_type {
-	MOV_CONST, ///< reg <- const
-	MOV_REG, ///< reg <- reg
-	MOV_OP_CONST, ///< reg <- reg OP const
-	MOV_OP_REG, ///< reg <- reg OP reg
-	SYSCALL, ///< syscall
+	RZ_GADGET_IL_INSTR_MOV_CONST, ///< reg <- const
+	RZ_GADGET_IL_INSTR_MOV_REG, ///< reg <- reg
+	RZ_GADGET_IL_INSTR_MOV_OP_CONST, ///< reg <- reg OP const
+	RZ_GADGET_IL_INSTR_MOV_OP_REG, ///< reg <- reg OP reg
+	RZ_GADGET_IL_INSTR_SYSCALL, ///< syscall
 } RzGadgetILInstructionType;
 
 /**
  * \brief Argument types for Gadget constraints.
  */
 typedef enum {
-	SRC_REG,
-	DST_REG,
-	SRC_CONST,
-	SRC_REG_SECOND,
-	OP,
-	NUM_ARGS
+	RZ_GADGET_ARG_SRC_REG,
+	RZ_GADGET_ARG_DST_REG,
+	RZ_GADGET_ARG_SRC_CONST,
+	RZ_GADGET_ARG_SRC_REG_SECOND,
+	RZ_GADGET_ARG_OP,
+	RZ_GADGET_ARG_NUM_ARGS
 } RzGadgetArgType;
 
 /**
@@ -137,7 +137,7 @@ typedef struct rz_gadget_endlist_pair_t {
  */
 typedef struct rz_gadget_constraint_t {
 	RzGadgetILInstructionType type; ///< IL instruction type.
-	char *args[NUM_ARGS]; ///< Arguments.
+	char *args[RZ_GADGET_ARG_NUM_ARGS]; ///< Arguments.
 } RzGadgetConstraint;
 
 /**

--- a/librz/include/rz_gadget.h
+++ b/librz/include/rz_gadget.h
@@ -145,7 +145,7 @@ typedef struct rz_gadget_constraint_t {
  */
 typedef struct rz_gadget_search_context_t {
 	RzGadgetType type; ///< Type of gadget to search for.
-	ut8 max_instr; ///< Gadget search max length.
+	size_t max_instr; ///< Gadget search max length.
 	bool subchains; ///< Display every length gadget from gadget.len=X to 2.
 	bool allow_conditional; ///< Include conditional jump, calls and returns in gadget search.
 	bool comments; ///< Display comments in gadget search output.

--- a/test/db/cmd/cmd_rop
+++ b/test/db/cmd/cmd_rop
@@ -4074,16 +4074,24 @@ Gadget size: 4
 
 ======================/Rq=======================
 0x00000000: str lr, [sp, -4]!; mov r0, r0; mov r1, r1; ldmeq sp!, {pc}; [Conditional]
-0x00000004: mov r0, r0; mov r1, r1; ldmeq sp!, {pc}; [Conditional]
-0x00000008: mov r1, r1; ldmeq sp!, {pc}; [Conditional]
-0x0000000c: ldmeq sp!, {pc}; [Conditional]
 0x00000000: str lr, [sp, -4]!; mov r0, r0; mov r1, r1; ldmeq sp!, {pc}; bx lr;
+0x00000004: mov r0, r0; mov r1, r1; ldmeq sp!, {pc}; [Conditional]
 0x00000004: mov r0, r0; mov r1, r1; ldmeq sp!, {pc}; bx lr;
+0x00000008: mov r1, r1; ldmeq sp!, {pc}; [Conditional]
 0x00000008: mov r1, r1; ldmeq sp!, {pc}; bx lr;
+0x0000000c: ldmeq sp!, {pc}; [Conditional]
 0x0000000c: ldmeq sp!, {pc}; bx lr;
 0x00000010: bx lr;
 ======================/Rg=======================
 Gadget 0x0 [Conditional]
+Stack change: 0xfffffffc
+Changed registers: sp r0 r1 
+Register dependencies:
+Memory Write: lr Initial Value: 0xffffffff New Value: 0x0
+Var Read: r0
+Var Read: r1
+
+Gadget 0x0
 Stack change: 0xfffffffc
 Changed registers: sp r0 r1 
 Register dependencies:
@@ -4098,7 +4106,20 @@ Register dependencies:
 Var Read: r0
 Var Read: r1
 
+Gadget 0x4
+Stack change: 0x0
+Changed registers: r0 r1 
+Register dependencies:
+Var Read: r0
+Var Read: r1
+
 Gadget 0x8 [Conditional]
+Stack change: 0x0
+Changed registers: r1 
+Register dependencies:
+Var Read: r1
+
+Gadget 0x8
 Stack change: 0x0
 Changed registers: r1 
 Register dependencies:
@@ -4108,27 +4129,6 @@ Gadget 0xc [Conditional]
 Stack change: 0x0
 Changed registers: 
 Register dependencies:
-
-Gadget 0x0
-Stack change: 0xfffffffc
-Changed registers: sp r0 r1 
-Register dependencies:
-Memory Write: lr Initial Value: 0xffffffff New Value: 0x0
-Var Read: r0
-Var Read: r1
-
-Gadget 0x4
-Stack change: 0x0
-Changed registers: r0 r1 
-Register dependencies:
-Var Read: r0
-Var Read: r1
-
-Gadget 0x8
-Stack change: 0x0
-Changed registers: r1 
-Register dependencies:
-Var Read: r1
 
 Gadget 0xc
 Stack change: 0x0
@@ -4144,18 +4144,25 @@ Register dependencies:
       addr                                    bytes disasm                                                                           
 -------------------------------------------------------------------------------------------------------------------------------------
 0x00000000         04e02de50000a0e10110a0e10080bd08 [Conditional] str lr, [sp, -4]!; ; mov r0, r0; ; mov r1, r1; ; ldmeq sp!, {pc}; 
-0x00000004                 0000a0e10110a0e10080bd08 [Conditional] mov r0, r0; ; mov r1, r1; ; ldmeq sp!, {pc}; 
-0x00000008                         0110a0e10080bd08 [Conditional] mov r1, r1; ; ldmeq sp!, {pc}; 
-0x0000000c                                 0080bd08 [Conditional] ldmeq sp!, {pc}; 
 0x00000000 04e02de50000a0e10110a0e10080bd081eff2fe1 str lr, [sp, -4]!; ; mov r0, r0; ; mov r1, r1; ; ldmeq sp!, {pc}; ; bx lr; 
+0x00000004                 0000a0e10110a0e10080bd08 [Conditional] mov r0, r0; ; mov r1, r1; ; ldmeq sp!, {pc}; 
 0x00000004         0000a0e10110a0e10080bd081eff2fe1 mov r0, r0; ; mov r1, r1; ; ldmeq sp!, {pc}; ; bx lr; 
+0x00000008                         0110a0e10080bd08 [Conditional] mov r1, r1; ; ldmeq sp!, {pc}; 
 0x00000008                 0110a0e10080bd081eff2fe1 mov r1, r1; ; ldmeq sp!, {pc}; ; bx lr; 
+0x0000000c                                 0080bd08 [Conditional] ldmeq sp!, {pc}; 
 0x0000000c                         0080bd081eff2fe1 ldmeq sp!, {pc}; ; bx lr; 
 0x00000010                                 1eff2fe1 bx lr; 
 ======================/Rj=======================
-[{"opcodes":[{"offset":0,"size":4,"opcode":"str lr, [sp, -4]!","type":"store"},{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":16,"is_conditional":true},{"opcodes":[{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":12,"is_conditional":true},{"opcodes":[{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":8,"is_conditional":true},{"opcodes":[{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":4,"is_conditional":true},{"opcodes":[{"offset":0,"size":4,"opcode":"str lr, [sp, -4]!","type":"store"},{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":20},{"opcodes":[{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":16},{"opcodes":[{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":12},{"opcodes":[{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":8},{"opcodes":[{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":4}]
+[{"opcodes":[{"offset":0,"size":4,"opcode":"str lr, [sp, -4]!","type":"store"},{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":16,"is_conditional":true},{"opcodes":[{"offset":0,"size":4,"opcode":"str lr, [sp, -4]!","type":"store"},{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":20},{"opcodes":[{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":12,"is_conditional":true},{"opcodes":[{"offset":4,"size":4,"opcode":"mov r0, r0","type":"mov"},{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":16},{"opcodes":[{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":8,"is_conditional":true},{"opcodes":[{"offset":8,"size":4,"opcode":"mov r1, r1","type":"mov"},{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":12},{"opcodes":[{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"}],"retaddr":12,"size":4,"is_conditional":true},{"opcodes":[{"offset":12,"size":4,"opcode":"ldmeq sp!, {pc}","type":"cret"},{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":8},{"opcodes":[{"offset":16,"size":4,"opcode":"bx lr","type":"ret"}],"retaddr":16,"size":4}]
 ======================/Rgl======================
 Gadget 0x0 (size 16 bytes) [Conditional]
+------------------------------------------------------------------------------------------------------
+  0x00000000  04e02de5         str lr, [sp, -4]! | Stack change: 0xfffffffc
+  0x00000004  0000a0e1         mov r0, r0        | Modified regs: sp r0 r1
+  0x00000008  0110a0e1         mov r1, r1        | Dependencies:  sp lr sp r0 r1
+  0x0000000c  0080bd08         ldmeq sp!, {pc}   | 
+
+Gadget 0x0 (size 16 bytes)
 ------------------------------------------------------------------------------------------------------
   0x00000000  04e02de5         str lr, [sp, -4]! | Stack change: 0xfffffffc
   0x00000004  0000a0e1         mov r0, r0        | Modified regs: sp r0 r1
@@ -4168,7 +4175,18 @@ Gadget 0x4 (size 12 bytes) [Conditional]
   0x00000008  0110a0e1         mov r1, r1      | Modified regs: r0 r1
   0x0000000c  0080bd08         ldmeq sp!, {pc} | Dependencies:  r0 r1
 
+Gadget 0x4 (size 12 bytes)
+------------------------------------------------------------------------------------------------------
+  0x00000004  0000a0e1         mov r0, r0      | Stack change: 0x0
+  0x00000008  0110a0e1         mov r1, r1      | Modified regs: r0 r1
+  0x0000000c  0080bd08         ldmeq sp!, {pc} | Dependencies:  r0 r1
+
 Gadget 0x8 (size 8 bytes) [Conditional]
+------------------------------------------------------------------------------------------------------
+  0x00000008  0110a0e1         mov r1, r1      | Stack change: 0x0
+  0x0000000c  0080bd08         ldmeq sp!, {pc} | Modified regs: r1
+
+Gadget 0x8 (size 8 bytes)
 ------------------------------------------------------------------------------------------------------
   0x00000008  0110a0e1         mov r1, r1      | Stack change: 0x0
   0x0000000c  0080bd08         ldmeq sp!, {pc} | Modified regs: r1
@@ -4176,24 +4194,6 @@ Gadget 0x8 (size 8 bytes) [Conditional]
 Gadget 0xc (size 4 bytes) [Conditional]
 ------------------------------------------------------------------------------------------------------
   0x0000000c  0080bd08         ldmeq sp!, {pc} | Stack change: 0x0
-
-Gadget 0x0 (size 16 bytes)
-------------------------------------------------------------------------------------------------------
-  0x00000000  04e02de5         str lr, [sp, -4]! | Stack change: 0xfffffffc
-  0x00000004  0000a0e1         mov r0, r0        | Modified regs: sp r0 r1
-  0x00000008  0110a0e1         mov r1, r1        | Dependencies:  sp lr sp r0 r1
-  0x0000000c  0080bd08         ldmeq sp!, {pc}   | 
-
-Gadget 0x4 (size 12 bytes)
-------------------------------------------------------------------------------------------------------
-  0x00000004  0000a0e1         mov r0, r0      | Stack change: 0x0
-  0x00000008  0110a0e1         mov r1, r1      | Modified regs: r0 r1
-  0x0000000c  0080bd08         ldmeq sp!, {pc} | Dependencies:  r0 r1
-
-Gadget 0x8 (size 8 bytes)
-------------------------------------------------------------------------------------------------------
-  0x00000008  0110a0e1         mov r1, r1      | Stack change: 0x0
-  0x0000000c  0080bd08         ldmeq sp!, {pc} | Modified regs: r1
 
 Gadget 0xc (size 4 bytes)
 ------------------------------------------------------------------------------------------------------

--- a/test/unit/test_rop.c
+++ b/test/unit/test_rop.c
@@ -16,6 +16,13 @@ static const char *x86_64_buf_str[] = {
 	"4889c3c3"
 };
 
+static const char *mips_buf_str[] = {
+	// addiu $t0, $zero, 1; jr $ra; nop
+	"2408000103e0000800000000",
+	// or $v0, $a0, $zero; jr $ra; nop
+	"0080102503e0000800000000"
+};
+
 static RzCoreAsmHit *setup_rop_hitasm(RzCore *core, int addr, ut8 *buf_str, int len, HtUP *ht_rop_analysis) {
 	RzCoreAsmHit *hit = rz_core_asm_hit_new();
 	if (!hit) {
@@ -68,13 +75,14 @@ setup_rop_hitlist(RzCore *core, ut8 *buf_str, int addr, int len, HtUP *ht_rop_an
 	return hitlist;
 }
 
-static RzCore *setup_rz_core(char *arch, int bits) {
+static RzCore *setup_rz_core(char *arch, int bits, bool bigendian) {
 	RzCore *core = rz_core_new();
 	if (!core) {
 		return NULL;
 	}
 	rz_io_open_at(core->io, "malloc://0x100", RZ_PERM_RX, 0644, 0, NULL);
-	rz_core_arch_configure(core, "x86", 64, NULL, NULL, NULL);
+	rz_core_arch_configure(core, arch, bits, NULL, NULL, NULL);
+	rz_config_set_b(core->config, "cfg.bigendian", bigendian);
 	rz_config_set_b(core->config, "asm.lines", false);
 	return core;
 }
@@ -113,9 +121,9 @@ static bool rop_gadget_info_cb(void *user, const ut64 k, const void *v) {
 }
 
 bool test_rz_direct_solver() {
-	RzCore *core = setup_rz_core("x86", 64);
+	RzCore *core = setup_rz_core("x86", 64, false);
 	mu_assert_notnull(core, "setup_rz_core failed");
-	int size = sizeof(x86_64_buf_str) / sizeof(x86_64_buf_str[0]);
+	int size = RZ_ARRAY_SIZE(x86_64_buf_str);
 	int addr = 0;
 	RzGadgetSearchContext *context = rz_core_gadget_search_context_new(
 		core, RZ_GADGET_TYPE_ROP, NULL, false, RZ_GADGET_PRINT_DETAIL | RZ_GADGET_ANALYZE, RZ_GADGET_DETAIL_SEARCH_NON,
@@ -143,8 +151,106 @@ bool test_rz_direct_solver() {
 	mu_end;
 }
 
+static bool run_gadget_cache_test(char *arch, int bits, bool bigendian,
+	const char **buf_strs, int buf_count) {
+	RzCore *core = setup_rz_core(arch, bits, bigendian);
+	mu_assert_notnull(core, "setup_rz_core failed");
+	int addr = 0;
+	RzCmdStateOutput state;
+
+	// searching in quiet mode, easier to compare cache content below
+	rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_QUIET, core);
+	RzGadgetSearchContext *context = rz_core_gadget_search_context_new(
+		core, RZ_GADGET_TYPE_ROP, NULL, false, RZ_GADGET_PRINT, RZ_GADGET_DETAIL_SEARCH_NON,
+		&state);
+	mu_assert_notnull(context, "rz_core_gadget_search_context_new failed");
+	for (int i = 0; i < buf_count; i++) {
+		ut8 buf[ROP_GADGET_MAX_SIZE] = { 0 };
+		int len = rz_hex_str2bin(buf_strs[i], buf);
+		rz_io_write_at(core->io, addr, buf, len);
+		addr += len;
+	}
+	context->from = 0;
+	context->to = addr;
+	context->cache = true;
+
+	RzGadgetCache *gadget_cache = rz_analysis_get_gadget_cache(core->analysis, RZ_GADGET_TYPE_ROP);
+	mu_assert_null(gadget_cache, "ROP gadget cache should be NULL for empty cache");
+
+	// first search, build cache
+	context->ret_val = true;
+	RzCmdStatus status = rz_core_gadget_search(core, context);
+	mu_assert_eq(status, RZ_CMD_STATUS_OK, "ROP gadget search failed");
+	gadget_cache = rz_analysis_get_gadget_cache(core->analysis, RZ_GADGET_TYPE_ROP);
+	mu_assert_notnull(gadget_cache, "ROP gadget cache should not be NULL after search");
+
+	// cnt cache nodes after first search
+	RBIter iter;
+	int cnt = 0;
+	RzGadgetCacheNode *node;
+	rz_rbtree_foreach (gadget_cache->tree, iter, node, RzGadgetCacheNode, rb) {
+		cnt++;
+	}
+	mu_assert("ROP gadget cache should not be empty", cnt > 0);
+	int first_cnt = cnt;
+
+	// store and sort lines
+	char *output1 = rz_strbuf_drain(context->buf);
+	context->buf = NULL;
+	mu_assert_notnull(output1, "first search output is NULL");
+	RzList *lines1 = rz_str_split_duplist(output1, "\n", true);
+	rz_list_sort(lines1, (RzListComparator)strcmp, NULL);
+	free(output1);
+
+	// second search, served from cache
+	cnt = 0;
+	status = rz_core_gadget_search(core, context);
+	mu_assert_eq(status, RZ_CMD_STATUS_OK, "ROP gadget search from cache failed");
+	rz_rbtree_foreach (gadget_cache->tree, iter, node, RzGadgetCacheNode, rb) {
+		cnt++;
+	}
+	mu_assert_eq(cnt, first_cnt, "ROP gadget cache size should not change on serving from cache");
+
+	char *output2 = rz_strbuf_drain(context->buf);
+	context->buf = NULL;
+	mu_assert_notnull(output2, "second search output is NULL");
+	RzList *lines2 = rz_str_split_duplist(output2, "\n", true);
+	rz_list_sort(lines2, (RzListComparator)strcmp, NULL);
+	free(output2);
+
+	// diff sorted outputs
+	mu_assert_eq(rz_list_length(lines1), rz_list_length(lines2),
+		"number of gadgets in cache differs from that of fresh search");
+
+	RzListIter *it1 = rz_list_head(lines1);
+	RzListIter *it2 = rz_list_head(lines2);
+	while (it1 && it2) {
+		mu_assert_streq((char *)it1->val, (char *)it2->val,
+			"gadget in cache differs from fresh search");
+		it1 = it1->next;
+		it2 = it2->next;
+	}
+
+	rz_list_free(lines1);
+	rz_list_free(lines2);
+	rz_cmd_state_output_fini(&state);
+	rz_core_gadget_search_context_free(context);
+	rz_core_free(core);
+	mu_end;
+}
+
+bool test_rz_gadget_cache_x86_64() {
+	return run_gadget_cache_test("x86", 64, false, x86_64_buf_str, RZ_ARRAY_SIZE(x86_64_buf_str));
+}
+
+bool test_rz_gadget_cache_mips() {
+	return run_gadget_cache_test("mips", 32, true, mips_buf_str, RZ_ARRAY_SIZE(mips_buf_str));
+}
+
 bool all_tests() {
 	mu_run_test(test_rz_direct_solver);
+	mu_run_test(test_rz_gadget_cache_x86_64);
+	mu_run_test(test_rz_gadget_cache_mips);
 	return tests_passed != tests_run;
 }
 

--- a/test/unit/test_rop_constraint.c
+++ b/test/unit/test_rop_constraint.c
@@ -48,10 +48,10 @@ bool test_parse_reg_to_const(void) {
 	char str1[] = " eax =    123 ";
 	RzGadgetConstraint *rop_constraint = rz_core_gadget_constraint_parse_args(core, str1);
 	mu_assert_notnull(rop_constraint, "parse_reg_constraints failed on valid input");
-	mu_assert_eq(rop_constraint->type, MOV_CONST, "Invalid constraint type");
-	mu_assert_streq(rop_constraint->args[DST_REG], "eax", "Invalid destination register");
-	mu_assert_null(rop_constraint->args[SRC_REG], "Source register should be NULL");
-	mu_assert_streq(rop_constraint->args[SRC_CONST], "123", "Invalid constant value");
+	mu_assert_eq(rop_constraint->type, RZ_GADGET_IL_INSTR_MOV_CONST, "Invalid constraint type");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_DST_REG], "eax", "Invalid destination register");
+	mu_assert_null(rop_constraint->args[RZ_GADGET_ARG_SRC_REG], "Source register should be NULL");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_SRC_CONST], "123", "Invalid constant value");
 	rz_core_gadget_constraint_free(rop_constraint);
 
 	// Test case 2: Invalid format
@@ -73,9 +73,9 @@ bool test_parse_reg_to_reg(void) {
 	char str1[] = "eax = ebx  ";
 	RzGadgetConstraint *rop_constraint = rz_core_gadget_constraint_parse_args(core, str1);
 	mu_assert_notnull(rop_constraint, "parse_reg_constraints failed on valid input");
-	mu_assert_eq(rop_constraint->type, MOV_REG, "Invalid constraint type");
-	mu_assert_streq(rop_constraint->args[DST_REG], "eax", "Invalid destination register");
-	mu_assert_streq(rop_constraint->args[SRC_REG], "ebx", "Invalid source register");
+	mu_assert_eq(rop_constraint->type, RZ_GADGET_IL_INSTR_MOV_REG, "Invalid constraint type");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_DST_REG], "eax", "Invalid destination register");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_SRC_REG], "ebx", "Invalid source register");
 	rz_core_gadget_constraint_free(rop_constraint);
 
 	// Test case 2: Invalid format
@@ -97,11 +97,11 @@ bool test_parse_reg_op_const(void) {
 	char str1[] = "eax=eax+3";
 	RzGadgetConstraint *rop_constraint = rz_core_gadget_constraint_parse_args(core, str1);
 	mu_assert_notnull(rop_constraint, "parse_reg_constraints failed on valid input");
-	mu_assert_eq(rop_constraint->type, MOV_OP_CONST, "Invalid constraint type");
-	mu_assert_streq(rop_constraint->args[DST_REG], "eax", "Invalid destination register");
-	mu_assert_streq(rop_constraint->args[SRC_REG], "eax", "Invalid source register");
-	mu_assert_streq(rop_constraint->args[OP], "add", "Invalid operator");
-	mu_assert_streq(rop_constraint->args[SRC_CONST], "3", "Invalid constant value");
+	mu_assert_eq(rop_constraint->type, RZ_GADGET_IL_INSTR_MOV_OP_CONST, "Invalid constraint type");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_DST_REG], "eax", "Invalid destination register");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_SRC_REG], "eax", "Invalid source register");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_OP], "add", "Invalid operator");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_SRC_CONST], "3", "Invalid constant value");
 	rz_core_gadget_constraint_free(rop_constraint);
 
 	// Test case 2: Invalid format
@@ -114,33 +114,33 @@ bool test_parse_reg_op_const(void) {
 	char str3[] = "eax++";
 	rop_constraint = rz_core_gadget_constraint_parse_args(core, str3);
 	mu_assert_notnull(rop_constraint, "parse_reg_constraints failed on valid input");
-	mu_assert_eq(rop_constraint->type, MOV_OP_CONST, "Invalid constraint type");
-	mu_assert_streq(rop_constraint->args[DST_REG], "eax", "Invalid destination register");
-	mu_assert_streq(rop_constraint->args[SRC_REG], "eax", "Invalid source register");
-	mu_assert_streq(rop_constraint->args[OP], "add", "Invalid operator");
-	mu_assert_streq(rop_constraint->args[SRC_CONST], "1", "Invalid constant value");
+	mu_assert_eq(rop_constraint->type, RZ_GADGET_IL_INSTR_MOV_OP_CONST, "Invalid constraint type");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_DST_REG], "eax", "Invalid destination register");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_SRC_REG], "eax", "Invalid source register");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_OP], "add", "Invalid operator");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_SRC_CONST], "1", "Invalid constant value");
 	rz_core_gadget_constraint_free(rop_constraint);
 
 	// Test case 4: Valid register operation with decrement operator
 	char str4[] = "eax--";
 	rop_constraint = rz_core_gadget_constraint_parse_args(core, str4);
 	mu_assert_notnull(rop_constraint, "parse_reg_constraints failed on valid input");
-	mu_assert_eq(rop_constraint->type, MOV_OP_CONST, "Invalid constraint type");
-	mu_assert_streq(rop_constraint->args[DST_REG], "eax", "Invalid destination register");
-	mu_assert_streq(rop_constraint->args[SRC_REG], "eax", "Invalid source register");
-	mu_assert_streq(rop_constraint->args[OP], "sub", "Invalid operator");
-	mu_assert_streq(rop_constraint->args[SRC_CONST], "1", "Invalid constant value");
+	mu_assert_eq(rop_constraint->type, RZ_GADGET_IL_INSTR_MOV_OP_CONST, "Invalid constraint type");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_DST_REG], "eax", "Invalid destination register");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_SRC_REG], "eax", "Invalid source register");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_OP], "sub", "Invalid operator");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_SRC_CONST], "1", "Invalid constant value");
 	rz_core_gadget_constraint_free(rop_constraint);
 
 	// Test case 5: Valid register operation with compound operator
 	char str5[] = "eax  *=   1";
 	rop_constraint = rz_core_gadget_constraint_parse_args(core, str5);
 	mu_assert_notnull(rop_constraint, "parse_reg_constraints failed on valid input");
-	mu_assert_eq(rop_constraint->type, MOV_OP_CONST, "Invalid constraint type");
-	mu_assert_streq(rop_constraint->args[DST_REG], "eax", "Invalid destination register");
-	mu_assert_streq(rop_constraint->args[SRC_REG], "eax", "Invalid source register");
-	mu_assert_streq(rop_constraint->args[OP], "mul", "Invalid operator");
-	mu_assert_streq(rop_constraint->args[SRC_CONST], "1", "Invalid constant value");
+	mu_assert_eq(rop_constraint->type, RZ_GADGET_IL_INSTR_MOV_OP_CONST, "Invalid constraint type");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_DST_REG], "eax", "Invalid destination register");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_SRC_REG], "eax", "Invalid source register");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_OP], "mul", "Invalid operator");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_SRC_CONST], "1", "Invalid constant value");
 	rz_core_gadget_constraint_free(rop_constraint);
 
 	rz_core_free(core);
@@ -156,11 +156,11 @@ bool test_parse_reg_op_reg(void) {
 	char str1[] = "eax=ebx-ecx";
 	RzGadgetConstraint *rop_constraint = rz_core_gadget_constraint_parse_args(core, str1);
 	mu_assert_notnull(rop_constraint, "parse_reg_constraints failed on valid input");
-	mu_assert_eq(rop_constraint->type, MOV_OP_REG, "Invalid constraint type");
-	mu_assert_streq(rop_constraint->args[DST_REG], "eax", "Invalid destination register");
-	mu_assert_streq(rop_constraint->args[SRC_REG], "ebx", "Invalid source register");
-	mu_assert_streq(rop_constraint->args[OP], "sub", "Invalid operator");
-	mu_assert_streq(rop_constraint->args[SRC_REG_SECOND], "ecx", "Invalid destination constant register");
+	mu_assert_eq(rop_constraint->type, RZ_GADGET_IL_INSTR_MOV_OP_REG, "Invalid constraint type");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_DST_REG], "eax", "Invalid destination register");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_SRC_REG], "ebx", "Invalid source register");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_OP], "sub", "Invalid operator");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_SRC_REG_SECOND], "ecx", "Invalid destination constant register");
 	rz_core_gadget_constraint_free(rop_constraint);
 
 	// Test case 2: Invalid format
@@ -173,11 +173,11 @@ bool test_parse_reg_op_reg(void) {
 	char str3[] = "eax  +=  ebx";
 	rop_constraint = rz_core_gadget_constraint_parse_args(core, str3);
 	mu_assert_notnull(rop_constraint, "parse_reg_constraints failed on valid input");
-	mu_assert_eq(rop_constraint->type, MOV_OP_REG, "Invalid constraint type");
-	mu_assert_streq(rop_constraint->args[DST_REG], "eax", "Invalid destination register");
-	mu_assert_streq(rop_constraint->args[SRC_REG], "eax", "Invalid source register");
-	mu_assert_streq(rop_constraint->args[SRC_REG_SECOND], "ebx", "Invalid destination constant register");
-	mu_assert_streq(rop_constraint->args[OP], "add", "Invalid operator");
+	mu_assert_eq(rop_constraint->type, RZ_GADGET_IL_INSTR_MOV_OP_REG, "Invalid constraint type");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_DST_REG], "eax", "Invalid destination register");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_SRC_REG], "eax", "Invalid source register");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_SRC_REG_SECOND], "ebx", "Invalid destination constant register");
+	mu_assert_streq(rop_constraint->args[RZ_GADGET_ARG_OP], "add", "Invalid operator");
 	rz_core_gadget_constraint_free(rop_constraint);
 
 	rz_core_free(core);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [X] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

ok so this required more work then i thought.
- [x] is there a leak of global_var_tree - NO
- [x]  try to solve 26  mem leaks (https://github.com/rizinorg/rizin/pull/6354)?

**a small flowchart :)**
<img width="1028" height="965" alt="screenshot_20260515_025706" src="https://github.com/user-attachments/assets/b6a8b6fc-f436-4751-8be7-4b60d99af451" />

**Commit-1:** Refactor - seperate search from filtering
   - seperated filter from building gadgets (first buidl then filter)
   - this needed to be done to allow caching, as we need to cache all gadgets without filtering

---

**Commit-2:** Fix custom search , constrain the interval instead of raw search
   - this seemed to be a mistake from OG dev, see:
   1. the first thing is that this path only hits when `context->from/to` is set using the RZ_API, normal flow when using `/R` command will not hit this ever, because from and to are both initialised to 0 when the new ` RzGadgetSearchContext` object is made.
   2. and when hit, it directly called the function on raw range instead of passing it to boundary fetching logic. 
    
   - So i fixed that and instead constraint the search interval and keep normal flow...

---

**Commit-3:**  Implemented cache hit + miss
   - Used RBTree and not Hashtable because we need to ITERATE when printing, hash table is not good here.
   - the Cache metadata lives in `RzGadgetCache` struct under `RzAnalysis` , which decides validity of cache
   - each node (representing a gadget) in tree contains:
       - gadget start address (key used to order tree)
       - the hitlist - which is `RzPVector` having pointers to `RzCoreAsmHit` objects which contains address of the instruction and length. **NOTE:** No code string is set during build either. So in short we still need to do disassembly on printing from cache which is apparently fine.
       - delay size and intrusive RB Node for left and right child pointers.

   - u can see flowchart above
    
   - Another problem was `filter_gadget()` function was passed a `io` buffer originally, which was determined while fetching boundaries for building gadgets. But since for printing from cache, we just have full range (`search.from/to`) which is by default 0 to `UINT64_MAX` we cant allocate that much buffer :0
   - so what i did is that if buffer is not provided to `filter_gadget()` function, i allocate a sufficient 32 bytes buffer in the function itself and read the instruction there.

---

**Commit-4:** Still the semantic filtering and detail filtering was broke for gadget cache path
   - Seperated semantic and detail filtering from building gadgets, I extracted them to a common function so that when i am printing gadgets from cache I can  directly call this filtering functions instead of `process_disassemly`.
   - call this common filter function in `print_gadget_from_cache()`
   - I also fixed `search.maxhits` (max_count) which stopped stoped search when limit reached. I kinda used a trick so that when cache is enabled, and maxhit reaches while iterating, Dont print gadget but continue to search and insert gadgets into tree. This allowed to make full tree instead of partial one. 
    
---
**Performance metric**: of single run though, not average :)

- Binary : `test/bins/elf/libstdc++.so.6` (14MB)
- command = `/R`

|  | cold start (initial search + cache build) | warm start (cached search) | del |
| :--- | :--- | :--- | :--- |
| **exe time** | 10.342648 s | 0.130789 s | **~98.7% reduction  (~79x speedup)** |
| **mem (RAM usage)** | 387 MB (before cache building) | 413 MB  (after cache building)| **+26 MB (~6.72% increase)** |
	
- time was measured by `time /R` command
- RAM usage of rizin session using `BTOP++` TUI

I did some maths for the space usage , as we have total 15788 ROP gadgets, the total comes to 4.58MB
the 26MB spike is may be heap fragmentation or somthing...

I think this much space trade off is tolerable.
 
---
**QUESTIONS**: @wargio @notxvilka @Rot127  
- ~should we enable cache by default, currently the default is false in config.~
- ~i added logs just for debugging purpose, i can remove them if u want...~
- ~Should we have an option for user to clear cache when he needs??~
- ~How am I supposed to write tests for this?~

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
closes #5544 