### PR TITLE
test: fix avr/c166 detection test on SystemZ

### DIFF
--- a/test/db/analysis/avr
+++ b/test/db/analysis/avr
@@ -15,6 +15,7 @@ RUN
 NAME=avr or c166 check - DISasm: [fac08400 => jump in c166]
 FILE=bins/c166/measure_raw.bin
 CMDS=<<EOF
+e asm.arch=avr
 e cfg.bigendian=false
 ao 1~^jump[1]
 iA

--- a/test/db/analysis/avr
+++ b/test/db/analysis/avr
@@ -24,11 +24,6 @@ REGEXP_FILTER_OUT=(0x00000000\s+7958\s+unk_0)
 EXPECT=<<EOF
 0x00000000 7958 unk_0
 EOF
-EXPECT=<<EOF
-    offset size arch  bits machine big_endian 
-----------------------------------------------
-0x00000000 7958 unk_0   64         false
-EOF
 RUN
 
 NAME=avr DISasm: [0e940b10 => call] - jump check

--- a/test/db/analysis/avr
+++ b/test/db/analysis/avr
@@ -20,6 +20,10 @@ e cfg.bigendian=false
 ao 1~^jump[1]
 iA
 EOF
+REGEXP_FILTER_OUT=(0x00000000\s+7958\s+unk_0)
+EXPECT=<<EOF
+0x00000000 7958 unk_0
+EOF
 EXPECT=<<EOF
     offset size arch  bits machine big_endian 
 ----------------------------------------------


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

To fix this:
```
[XX] 00h00m00s135ms db/analysis/avr avr or c166 check - DISasm: [fac08400 => jump in c166]
RZ_COLOR=0 RZ_UTF8=0 RZ_NOPLUGINS=1 /home/travis/build/rizinorg/rizin/install/bin/rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -eflirt.sigdb.load.system=false -esearch.show_progress=false -eflirt.sigdb.load.home=false -N -qc 'e cfg.bigendian=false
ao 1~^jump[1]
iA
' bins/c166/measure_raw.bin
-- stdout
--- expected
+++ actual
@@ -0,4 +0,4 @@
     offset size arch  bits machine big_endian 
 ----------------------------------------------
-0x00000000 7958 unk_0   64         false
+0x00000000 7958 unk_0   64         true
-- stderr
ERROR: core: cannot change to little endian (arch 'sysz' supports only big endian)
```
**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
