### PR TITLE
Reduce verbose error messages from unsupported native debugger

### DIFF
--- a/librz/debug/p/native/unsupported.c
+++ b/librz/debug/p/native/unsupported.c
@@ -10,131 +10,129 @@
 #include <rz_debug.h>
 
 static bool rz_debug_native_init(RzDebug *dbg, void **user) {
-	RZ_LOG_ERROR("Unsupported platform\n");
 	return false;
 }
 
 static void rz_debug_native_fini(RzDebug *debug, void *user) {
-	RZ_LOG_ERROR("Unsupported platform\n");
 }
 
 static bool rz_debug_native_step(RzDebug *dbg) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return false;
 }
 
 static int rz_debug_native_continue(RzDebug *dbg, int pid, int tid, int sig) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return -1;
 }
 
 static int rz_debug_native_stop(RzDebug *dbg) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return -1;
 }
 
 static int rz_debug_native_continue_syscall(RzDebug *dbg, int pid, int sc) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return -1;
 }
 
 static int rz_debug_native_attach(RzDebug *dbg, int pid) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return -1;
 }
 
 static int rz_debug_native_detach(RzDebug *dbg, int pid) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return -1;
 }
 
 static int rz_debug_native_select(RzDebug *dbg, int pid, int tid) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return -1;
 }
 
 static RzList *rz_debug_native_pids(RzDebug *dbg, int pid) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return NULL;
 }
 
 RzList *rz_debug_native_threads(RzDebug *dbg, int pid) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return NULL;
 }
 
 static RzDebugReasonType rz_debug_native_wait(RzDebug *dbg, int pid) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return RZ_DEBUG_REASON_UNKNOWN;
 }
 
 static bool rz_debug_native_kill(RzDebug *dbg, int pid, int tid, int sig) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return false;
 }
 
 static RzList *rz_debug_native_frames(RzDebug *dbg, ut64 at) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return NULL;
 }
 
 static char *rz_debug_native_reg_profile(RzDebug *dbg) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return NULL;
 }
 
 static int rz_debug_native_reg_read(RzDebug *dbg, int type, ut8 *buf, int size) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return -1;
 }
 
 static RzDebugInfo *rz_debug_native_info(RzDebug *dbg, const char *arg) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return NULL;
 }
 
 static int rz_debug_native_reg_write(RzDebug *dbg, int type, const ut8 *buf, int size) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return -1;
 }
 
 static RzDebugMap *rz_debug_native_map_alloc(RzDebug *dbg, ut64 addr, int size, bool thp) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return NULL;
 }
 
 static int rz_debug_native_map_dealloc(RzDebug *dbg, ut64 addr, int size) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return -1;
 }
 
 static RzList *rz_debug_native_map_get(RzDebug *dbg) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return NULL;
 }
 
 static RzList *rz_debug_native_modules_get(RzDebug *dbg) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return NULL;
 }
 
 static int rz_debug_native_map_protect(RzDebug *dbg, ut64 addr, int size, int perms) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return -1;
 }
 
 static int rz_debug_native_drx(RzDebug *dbg, int n, ut64 addr, int size, int rwx, int g, int api_type) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return -1;
 }
 
 static bool rz_debug_gcore(RzDebug *dbg, char *path, RzBuffer *dest) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return false;
 }
 
 static int rz_debug_native_bp(RzBreakpoint *bp, RzBreakpointItem *b, bool set) {
-	RZ_LOG_ERROR("Unsupported platform\n");
+	RZ_LOG_ERROR("Unsupported platform for native debugger\n");
 	return -1;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

init and fini are called on regular rizin start, even if not debugging. These errors were distracting and not very meaningful there. They do however make sense when executing any actual debug operation.

**Test plan**

E.g. on OpenBSD/sparc64, compile rizin with enabled debugger and start it. It should not print "Unsupported platform".