### PR TITLE
librz/core: fix OMF debug type error

### DIFF
--- a/librz/arch/omf_process.c
+++ b/librz/arch/omf_process.c
@@ -70,7 +70,10 @@ static RzBaseType *create_new_primitive_type(const RzTypeDB *typedb, const char 
 	bt->name = rz_str_dup(name);
 	bt->size = size;
 	const bool result = rz_type_db_save_base_type(typedb, bt);
-	rz_return_val_if_fail(result, NULL);
+	if (!result) {
+		rz_type_base_type_free(bt);
+		return NULL;
+	}
 	return bt;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

```
../librz/arch/omf_process.c:72:13: error: unused variable 'result' [-Werror,-Wunused-variable]
   72 |         const bool result = rz_type_db_save_base_type(typedb, bt);
      |                    ^~~~~~
```

**Test plan**

CI is green