### PR TITLE
Fix bb refcount when bb is overlength

### DIFF
--- a/librz/arch/fcn.c
+++ b/librz/arch/fcn.c
@@ -827,6 +827,7 @@ static RzAnalysisBBEndCause run_basic_block_analysis(RzAnalysisTaskItem *item, R
 				// If previous instruction was a jump there would already be a split.
 				// So setting jump here shouldn't overwrite any real jumps.
 				bb->jump = at;
+				rz_analysis_block_unref(bb);
 				item->block = bb = next;
 				next->sp_entry = sp;
 				newbbsize = bb->size + oplen;

--- a/test/db/formats/elf/tiny
+++ b/test/db/formats/elf/tiny
@@ -72,8 +72,12 @@ WARNING: Failed to read chunk of size 0x101 at 0x10020 from io.
 0x0001fc1e 0x00020020 00:0000 1026
 -- 6 --
 -- 7 --
-ERROR: core: Cannot add basic block at 0x10020 to fcn at 0x10020
+0x00010020 0x00010027 00:0000 7
 -- 8 --
-ERROR: Cannot find function at 0x00010020
+/ entry0();
+|           0x00010020      b32a           mov   bl, 0x2a              ; '*' ; 42
+|           0x00010022      31c0           xor   eax, eax
+|           0x00010024      40             inc   eax
+\           0x00010025      cd80           int   0x80
 EOF
 RUN

--- a/test/db/formats/elf/tiny
+++ b/test/db/formats/elf/tiny
@@ -20,6 +20,11 @@ afb
 echo -- 6 --
 afb-*
 afb
+echo -- 7 --
+afb+ entry0 entry0 `aos 4`
+afb
+echo -- 8 --
+pdf
 EOF
 EXPECT=<<EOF
 WARNING: Failed to read ELF header (e_phnum).
@@ -66,5 +71,9 @@ WARNING: Failed to read chunk of size 0x101 at 0x10020 from io.
 0x00010020 0x0001fc1e 00:0000 64510 j 0x0001fc1e
 0x0001fc1e 0x00020020 00:0000 1026
 -- 6 --
+-- 7 --
+ERROR: core: Cannot add basic block at 0x10020 to fcn at 0x10020
+-- 8 --
+ERROR: Cannot find function at 0x00010020
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

The pr fixes a split basic block's reference count when the basic block is overlength.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
