### PR TITLE
Optimise RzCoreAsmHit

### DIFF
--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -922,9 +922,9 @@ RZ_API void rz_core_analysis_type_match(RzCore *core, RzAnalysisFunction *fcn, H
 #define RZ_MIDFLAGS_SYMALIGN 3
 
 typedef struct rz_core_asm_hit {
+	ut64 addr;
 	char *code;
 	int len;
-	ut64 addr;
 	ut8 valid;
 } RzCoreAsmHit;
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

While doing the Math for total memory usage by 88000 gadgets by gadget cache in (https://github.com/rizinorg/rizin/pull/6328), (calculating bytes used by structs) :

I found that RzCoreAsmHit struct is having redundant paddings (for 64bit arch)

Because the fields were not ordered in Descending order of size

```c
typedef struct rz_core_asm_hit {
    char *code;
    int len;
    ut64 addr;
    ut8 valid;
} RzCoreAsmHit;
```

so the scene is like this :
_all in bytes_

- before padding

|| size | offset | 
| :--- | :--- | :--- |
|char*|8 | 0 |
| int | 4 | 8 |
| ut64 | 8 | 12 |
| ut8 | 1 | 20 |

`ut64` start at 12 so we need to add padding (4B) to `int` block

- after padding

|| size | offset | padding |
| :--- | :--- | :--- | :--- |
|char*| 8 | 0 | 0 |
| int | 4 | 8 | 4 |
| ut64 | 8 | 16 | 0 |
| ut8 | 1 | 24 | 7 | 

7B trailing padding for struct alignment

**Total = 32Bytes**
**Waste = 11 Bytes**

---

new :
```c
typedef struct rz_core_asm_hit {
    ut64 addr;
    char *code;
    int len;
    ut8 valid;
} RzCoreAsmHit;
```

- before padding

|| size | offset |
| :--- | :--- | :--- |
| ut64 | 8 | 0 | 
|char*|8 | 8 |
| int | 4 | 16 |
| ut8 | 1 | 20 |

20 is multiple of 1 so no padding needed to previous `int` block
only 3 byte padding 

- after padding

|| size | offset | padding |
| :--- | :--- | :--- | :--- |
| ut64 | 8 | 0 | 0 |
|char*|8 | 8 | 0 |
| int | 4 | 16 | 0 |
| ut8 | 1 | 20 | 3 |

**Total = 24 Bytes**
**Waste = 3 Bytes**

32 - 24 = 8
So **8 Bytes** are saved per instance of `RzCoreAsmHit`

---

Some test on GODBOLT Compiler Explorer

sample code : 
<img width="1283" height="500" alt="screenshot_20260516_180546" src="https://github.com/user-attachments/assets/d55e2c36-98cd-4bea-a31a-05ef7aecb114" />


- ARM64 GCC 16.1.0 = `hit1: .zero 32` | `hit2: .zero 24 ` (-8B)
- x86-64 Clang 22.1.0 = `hit1: .zero 32` | `hit2: .zero 24 ` (-8B)
- ARM(32) GCC 16.1.0 = `hit1: .zero 24` | `hit2: .zero 24 ` (Neutral)
- ARM(32) Clang 22.1.0 = `hit1: .zero 24` | `hit2: .zero 24 ` (Neutral)
- AVR GCC 16.1.0 = `hit1: .zero 13` | `hit2: .zero 13` (Neutral)
- llvm-mos commander x16 = `hit1: .zero 13` | `hit2: .zero 13` (Neutral)
- loongarch64 gcc 16.1.0 = `hit1: .zero 32` | `hit2: .zero 24 ` (-8B)
- MingGW clang 16.0.2 = `hit1: .zero 32` | `hit2: .zero 24 ` (-8B)
- MIPS GCC 16.1.0 = `hit1: .zero 24` | `hit2: .zero 24 ` (Neutral)
- MIPS64 GCC 16.1.0 = `hit1: .zero 32` | `hit2: .zero 24 ` (-8B)
- MSP430 GCC 15.2.0 = `hit1: .zero 14` | `hit2: .zero 14 ` (Neutral)
- ARM msvc v19.14 (ex-WINE) = `COMMON |hit1|, 0x18 | COMMON |hit2|, 0x18` (Neutral)
- ARM64 msvc v19.14 (ex-WINE) = `COMMON |hit1|, 0x20 | COMMON |hit2|, 0x18` (-8B)
- x86 msvc v19.latest = `COMM _hit1:BYTE:018H | COMM _hit2:BYTE:018H` (Neutral)
- x64 msvc v19.latest = `COMM _hit1:BYTE:020H | COMM _hit2:BYTE:018H` (-8B)
- RISC-V (32-bits) GCC 16.1.0 = `hit1: .zero 24` | `hit2: .zero 24 ` (Neutral)
- RISC-V (64-bits) GCC 16.1.0 = `hit1: .zero 32` | `hit2: .zero 24 ` (-8B)
- s390x GCC 16.1.0 = `hit1: .zero 32` | `hit2: .zero 24 ` (-8B)
- SPARC GCC 16.1.0 = `hit1: .zero 24` | `hit2: .zero 24 ` (Neutral)
- SPARC64 GCC 16.1.0 = `hit1: .zero 32` | `hit2: .zero 24 ` (-8B)
- XTENSA ESP32 GCC 14.2.0 = `hit1: .zero 24` | `hit2: .zero 24 ` (Neutral)


So Universally the optimisation works, It either reduce mem alloc by **8 Bytes** per instance for 64bit or **Neutral** for 32bit arch

...

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
