### PR TITLE
Fix data in K64F-RIOT-SPI.elf not marked properly 

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4076,8 +4076,16 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 				stored_val = big_endian ? rz_read_be32(buf) : rz_read_le32(buf);
 			}
 			RzBinSection *val_sec = rz_bin_get_section_at(bo, stored_val, true);
-			if (!val_sec || (val_sec->perm & RZ_PERM_X)) {
+			if (val_sec && (val_sec->perm & RZ_PERM_X)) {
+				// stored value is a code pointer — skip
 				continue;
+			}
+			if (!val_sec) {
+				// address do not refer to a section in ELF
+				ut64 fcn_end = fcn_from->addr + rz_analysis_function_linear_size(fcn_from);
+				if (target < fcn_end) {
+					continue;
+				}
 			}
 		}
 		// skip if already annotated by any other analysis

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4050,9 +4050,9 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 		if (!fcn_from) {
 			continue;
 		}
-		// take bins/arm/elf/K64F-RIOT-SPI.elf for an exampls 
+		// take bins/arm/elf/K64F-RIOT-SPI.elf for an example
 		// the function dbg.sched_run at 0x00000490 has data xref with 0x000004e0
-		// we take the content of 0x000004e0 as address and check if it is in non-exec section. 
+		// we take the content of 0x000004e0 as address and check if it is in non-exec section.
 		// [0x000004be]> s 0x000004e0
 		// [0x000004e0]> pd 1
 		// ; DATA XREF from dbg.sched_run @ 0x490

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4087,7 +4087,7 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 					continue;
 				}
 				// not padding
-				if (target - fcn_end >= ptr_size){
+				if (target - fcn_end >= ptr_size) {
 					continue;
 				}
 			}

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4050,9 +4050,9 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 		if (!fcn_from) {
 			continue;
 		}
-		// take bins/arm/elf/K64F-RIOT-SPI.elf for an example
+		// take bins/arm/elf/K64F-RIOT-SPI.elf for an exampls 
 		// the function dbg.sched_run at 0x00000490 has data xref with 0x000004e0
-		// we take the content of 0x000004e0 as address and check if it is in non-exec section.
+		// we take the content of 0x000004e0 as address and check if it is in non-exec section. 
 		// [0x000004be]> s 0x000004e0
 		// [0x000004e0]> pd 1
 		// ; DATA XREF from dbg.sched_run @ 0x490

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4145,6 +4145,7 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 		}
 		ut64 upper = RZ_MIN(next_data, next_fcn);
 		ut64 size = (upper != UT64_MAX) ? upper - target : ptr_size;
+		// ut64 size = (upper != UT64_MAX) ? RZ_MIN(upper - target, ptr_size) : ptr_size;
 		rz_meta_set(core->analysis, RZ_META_TYPE_DATA, target, size, NULL);
 	}
 

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4036,6 +4036,14 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 		rz_list_free(all_xrefs);
 		return;
 	}
+	// subset of data_targets that are in exec sections (pool entries): size capped at ptr_size
+	RzSetU *exec_targets = rz_set_u_new();
+	if (!exec_targets) {
+		rz_set_u_free(data_targets);
+		rz_set_u_free(code_call_targets);
+		rz_list_free(all_xrefs);
+		return;
+	}
 	rz_list_foreach (all_xrefs, iter, xref) {
 		if (xref->type != RZ_ANALYSIS_XREF_TYPE_DATA &&
 			xref->type != RZ_ANALYSIS_XREF_TYPE_STRING) {
@@ -4063,7 +4071,8 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 			continue;
 		}
 		RzBinSection *sec = rz_bin_get_section_at(bo, target, true);
-		if (sec && (sec->perm & RZ_PERM_X)) {
+		bool target_in_exec = sec && (sec->perm & RZ_PERM_X);
+		if (target_in_exec) {
 			ut8 buf[8] = { 0 };
 			if (!rz_io_read_at_mapped(core->io, target, buf, ptr_size)) {
 				continue;
@@ -4100,11 +4109,15 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 			continue;
 		}
 		rz_set_u_add(data_targets, target);
+		if (target_in_exec) {
+			rz_set_u_add(exec_targets, target);
+		}
 	}
 	rz_list_free(all_xrefs);
 	rz_set_u_free(code_call_targets);
 
 	if (!rz_set_u_size(data_targets)) {
+		rz_set_u_free(exec_targets);
 		rz_set_u_free(data_targets);
 		return;
 	}
@@ -4112,6 +4125,7 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 	// convert set to sorted vector
 	RzVector *data_addrs = rz_vector_new(sizeof(ut64), NULL, NULL);
 	if (!data_addrs) {
+		rz_set_u_free(exec_targets);
 		rz_set_u_free(data_targets);
 		return;
 	}
@@ -4131,6 +4145,8 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 	}
 
 	// mark each target up to the nearest of: next data target, next function, or ptr_size
+	// for exec-section pool entries the size is capped at ptr_size to avoid consuming code;
+	// for data-section targets the natural boundary size is used.
 	size_t n = rz_vector_len(data_addrs);
 	for (size_t i = 0; i < n; i++) {
 		ut64 target = *(ut64 *)rz_vector_index_ptr(data_addrs, i);
@@ -4144,11 +4160,18 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 			}
 		}
 		ut64 upper = RZ_MIN(next_data, next_fcn);
-		ut64 size = (upper != UT64_MAX) ? upper - target : ptr_size;
-		// ut64 size = (upper != UT64_MAX) ? RZ_MIN(upper - target, ptr_size) : ptr_size;
+		ut64 size;
+		if (upper != UT64_MAX) {
+			size = rz_set_u_contains(exec_targets, target)
+				? RZ_MIN(upper - target, ptr_size)
+				: upper - target;
+		} else {
+			size = ptr_size;
+		}
 		rz_meta_set(core->analysis, RZ_META_TYPE_DATA, target, size, NULL);
 	}
 
+	rz_set_u_free(exec_targets);
 	rz_vector_free(data_addrs);
 	rz_vector_free(fcn_starts);
 }

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4086,6 +4086,10 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 				if (target < fcn_end) {
 					continue;
 				}
+				// not padding
+				if (target - fcn_end >= ptr_size){
+					continue;
+				}
 			}
 		}
 		// skip if already annotated by any other analysis

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4005,6 +4005,11 @@ static bool collect_ht_keys_cb(void *user, const ut64 k, const void *v) {
 	return true;
 }
 
+static bool addr_in_exec_section(RzBinObject *bo, ut64 addr) {
+	RzBinSection *sec = rz_bin_get_section_at(bo, addr, true);
+	return sec && (sec->perm & RZ_PERM_X);
+}
+
 static void analysis_mark_xrefs_as_data(RzCore *core) {
 	int bits = rz_asm_get_bits(core->rasm);
 	ut64 ptr_size = bits == 64 ? 8 : 4;
@@ -4070,8 +4075,7 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 		if (!bo) {
 			continue;
 		}
-		RzBinSection *sec = rz_bin_get_section_at(bo, target, true);
-		bool target_in_exec = sec && (sec->perm & RZ_PERM_X);
+		bool target_in_exec = addr_in_exec_section(bo, target);
 		if (target_in_exec) {
 			ut8 buf[8] = { 0 };
 			if (!rz_io_read_at_mapped(core->io, target, buf, ptr_size)) {

--- a/test/db/analysis/arm
+++ b/test/db/analysis/arm
@@ -2297,7 +2297,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=ARM Thumb literal pool after function marked as data (pool entry points to ELF section)
+NAME=ARM Thumb literal pool after function marked as data
 FILE=bins/arm/elf/K64F-RIOT-SPI.elf
 CMDS=<<EOF
 aaa

--- a/test/db/analysis/arm
+++ b/test/db/analysis/arm
@@ -2297,16 +2297,21 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=ARM Thumb literal pool after function marked as data
+NAME=ARM Thumb literal pool after function marked as data (pool entry points to ELF section)
 FILE=bins/arm/elf/K64F-RIOT-SPI.elf
 CMDS=<<EOF
 aaa
 s 0x4e0
+pd 1
+s 0xd50
 pd 1
 EOF
 EXPECT=<<EOF
             ; DATA XREF from dbg.sched_run @ 0x490
             ;-- data.000004e0:
             0x000004e0      .dword 0x1fff0274 ; runqueue_bitcache ; section..bss ; sym..bss ; obj.runqueue_bitcache ; loc._sbss ; loc._szero ; loc._erelocate ; sched.c:135
+            ; DATA XREF from dbg.bit_clear8 @ 0xd34
+            ;-- data.00000d50:
+            0x00000d50      .dword 0x01ffffe0
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Patched corner cases for xref data marking.

**Test plan**

I have added one more entry in `test/db/analysis/arm` 

**Closing issues**

https://github.com/rizinorg/rizin/issues/3641