### PR TITLE
[c166] Fix format errors and if_fail macroses (PFMTSZu)

### DIFF
--- a/librz/bin/format/omf/omf166.c
+++ b/librz/bin/format/omf/omf166.c
@@ -641,7 +641,7 @@ static int load_omf_unk1(const rz_bin_omf166_obj *obj, const ut8 *buf, const siz
 	size_t offset = 9;
 	dip->n = rz_read_le8_offset(buf, &offset);
 	rz_str_ncpy(dip->name, (const char *)&buf[offset], dip->n + 1);
-	RZ_LOG_DEBUG("load_omf = INCLUDES  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%10" PFMT64u ")\t `%s`\n",
+	RZ_LOG_DEBUG("load_omf = INCLUDES  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%10" PFMTSZu ")\t `%s`\n",
 		record->size, global_ct, record->type, buf_size, dip->name);
 	rz_pvector_push(obj->includes_vec, dip);
 
@@ -655,7 +655,7 @@ static int load_omf_unk2(const ut8 *buf, const size_t buf_size, const OMF_record
 	size_t offset = 7;
 	const ut8 n = rz_read_le8_offset(buf, &offset);
 	rz_str_ncpy(name, (const char *)&buf[offset], n + 1);
-	RZ_LOG_DEBUG("load_omf = UNKNOWN2  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%10" PFMT64u ")\t 0x%02x 0x%02x 0x%02x 0x%02x  `%s`\n",
+	RZ_LOG_DEBUG("load_omf = UNKNOWN2  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%10" PFMTSZu ")\t 0x%02x 0x%02x 0x%02x 0x%02x  `%s`\n",
 		record->size, global_ct,
 		record->type, buf_size,
 		buf[3], buf[4], buf[5], buf[6],
@@ -670,7 +670,7 @@ static int load_omf_unk3(const ut8 *buf, const size_t buf_size, const OMF_record
 	size_t offset = 7;
 	const ut8 n = rz_read_le8_offset(buf, &offset);
 	rz_str_ncpy(name, (const char *)&buf[offset], n + 1); // cct = 12
-	RZ_LOG_DEBUG("load_omf = UNKNOWN3  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%10" PFMT64u ")\t `%s`\n",
+	RZ_LOG_DEBUG("load_omf = UNKNOWN3  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%10" PFMTSZu ")\t `%s`\n",
 		record->size, global_ct, record->type, buf_size, name);
 	RZ_LOG_DEBUG("%02x %02x %02x \n%02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x\n",
 		buf[0], buf[1], buf[2],
@@ -683,7 +683,7 @@ static int load_omf_unk3(const ut8 *buf, const size_t buf_size, const OMF_record
 
 static int load_omf_unk4(const ut8 *buf, const size_t buf_size, const OMF_record *record, const ut64 global_ct) {
 #if RZ_BUILD_DEBUG
-	RZ_LOG_DEBUG("load_omf = UNKNOWN4  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%10" PFMT64u ")\n", record->size, global_ct, record->type, buf_size);
+	RZ_LOG_DEBUG("load_omf = UNKNOWN4  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%10" PFMTSZu ")\n", record->size, global_ct, record->type, buf_size);
 	size_t ct = 3;
 	const ut16 count = rz_read_le16_offset(buf, &ct);
 
@@ -969,12 +969,12 @@ static int rz_bin_format_omf166_load_content(rz_bin_omf166_obj *obj, OMF_record 
 		return load_omf_modinf(obj, buf, record);
 	}
 	case OMF166_MODEND: {
-		RZ_LOG_DEBUG("load_omf = MODEND  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%" PFMT64u ")\n",
+		RZ_LOG_DEBUG("load_omf = MODEND  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%" PFMTSZu ")\n",
 			record->size, global_ct, record->type, buf_size);
 		return true;
 	}
 	case OMF166_BLKEND: {
-		RZ_LOG_DEBUG("load_omf = BLKEND  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%" PFMT64u ")\n",
+		RZ_LOG_DEBUG("load_omf = BLKEND  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%" PFMTSZu ")\n",
 			record->size, global_ct, record->type, buf_size);
 		return true;
 	}
@@ -987,7 +987,7 @@ static int rz_bin_format_omf166_load_content(rz_bin_omf166_obj *obj, OMF_record 
 		 *      E3    0F 00    00 00     FC    07   INTREGS            FF FF      00         F1
 		 *      E3    18 00    00 20     FC    10   ?C_MAINREGISTERS   FF FF      00         1D
 		 */
-		RZ_LOG_DEBUG("load_omf = REGDEF  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%" PFMT64u ")\n",
+		RZ_LOG_DEBUG("load_omf = REGDEF  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%" PFMTSZu ")\n",
 			record->size, global_ct, record->type, buf_size);
 		return true;
 	}
@@ -1050,7 +1050,7 @@ static int rz_bin_format_omf166_load_content(rz_bin_omf166_obj *obj, OMF_record 
 		return load_omf_unk4(buf, buf_size, record, global_ct);
 	}
 	default: {
-		RZ_LOG_DEBUG("load_omf: [%05d] [0x%08" PFMT64x "] 0x%02x (%" PFMT64u ")\t",
+		RZ_LOG_DEBUG("load_omf: [%05d] [0x%08" PFMT64x "] 0x%02x (%" PFMTSZu ")\t",
 			record->size, global_ct, record->type, buf_size);
 		rz_warn_if_reached();
 		break;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->
From https://github.com/rizinorg/rizin/pull/6362

```
[419/1605] Compiling C object librz/bin/librz_bin.0.9.dylib.p/format_omf_omf166.c.o
../librz/bin/format/omf/omf166.c:645:42: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
  644 |         RZ_LOG_DEBUG("load_omf = INCLUDES  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%10" PFMT64u ")\t `%s`\n",
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  645 |                 record->size, global_ct, record->type, buf_size, dip->name);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
../librz/include/rz_util/rz_log.h:42:45: note: expanded from macro 'RZ_LOG_DEBUG'
   42 |         __LINE__, RZ_LOGLVL_DEBUG, NULL, fmtstr, ##__VA_ARGS__);
      |                                          ~~~~~~    ^~~~~~~~~~~
../librz/bin/format/omf/omf166.c:660:17: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
  658 |         RZ_LOG_DEBUG("load_omf = UNKNOWN2  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%10" PFMT64u ")\t 0x%02x 0x%02x 0x%02x 0x%02x  `%s`\n",
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  659 |                 record->size, global_ct,
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~
  660 |                 record->type, buf_size,
      |                 ~~~~~~~~~~~~~~^~~~~~~~~
  661 |                 buf[3], buf[4], buf[5], buf[6],
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  662 |                 name);
      |                 ~~~~~
../librz/include/rz_util/rz_log.h:42:45: note: expanded from macro 'RZ_LOG_DEBUG'
   42 |         __LINE__, RZ_LOGLVL_DEBUG, NULL, fmtstr, ##__VA_ARGS__);
      |                                          ~~~~~~    ^~~~~~~~~~~
../librz/bin/format/omf/omf166.c:674:42: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
  673 |         RZ_LOG_DEBUG("load_omf = UNKNOWN3  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%10" PFMT64u ")\t `%s`\n",
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  674 |                 record->size, global_ct, record->type, buf_size, name);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
../librz/include/rz_util/rz_log.h:42:45: note: expanded from macro 'RZ_LOG_DEBUG'
   42 |         __LINE__, RZ_LOGLVL_DEBUG, NULL, fmtstr, ##__VA_ARGS__);
      |                                          ~~~~~~    ^~~~~~~~~~~
../librz/bin/format/omf/omf166.c:686:133: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
  686 |         RZ_LOG_DEBUG("load_omf = UNKNOWN4  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%10" PFMT64u ")\n", record->size, global_ct, record->type, buf_size);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
../librz/include/rz_util/rz_log.h:42:45: note: expanded from macro 'RZ_LOG_DEBUG'
   42 |         __LINE__, RZ_LOGLVL_DEBUG, NULL, fmtstr, ##__VA_ARGS__);
      |                                          ~~~~~~    ^~~~~~~~~~~
../librz/bin/format/omf/omf166.c:973:43: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
  972 |                 RZ_LOG_DEBUG("load_omf = MODEND  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%" PFMT64u ")\n",
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  973 |                         record->size, global_ct, record->type, buf_size);
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
../librz/include/rz_util/rz_log.h:42:45: note: expanded from macro 'RZ_LOG_DEBUG'
   42 |         __LINE__, RZ_LOGLVL_DEBUG, NULL, fmtstr, ##__VA_ARGS__);
      |                                          ~~~~~~    ^~~~~~~~~~~
../librz/bin/format/omf/omf166.c:978:43: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
  977 |                 RZ_LOG_DEBUG("load_omf = BLKEND  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%" PFMT64u ")\n",
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  978 |                         record->size, global_ct, record->type, buf_size);
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
../librz/include/rz_util/rz_log.h:42:45: note: expanded from macro 'RZ_LOG_DEBUG'
   42 |         __LINE__, RZ_LOGLVL_DEBUG, NULL, fmtstr, ##__VA_ARGS__);
      |                                          ~~~~~~    ^~~~~~~~~~~
../librz/bin/format/omf/omf166.c:991:43: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
  990 |                 RZ_LOG_DEBUG("load_omf = REGDEF  =  [%05d] [0x%08" PFMT64x "] 0x%02x (%" PFMT64u ")\n",
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  991 |                         record->size, global_ct, record->type, buf_size);
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
../librz/include/rz_util/rz_log.h:42:45: note: expanded from macro 'RZ_LOG_DEBUG'
   42 |         __LINE__, RZ_LOGLVL_DEBUG, NULL, fmtstr, ##__VA_ARGS__);
      |                                          ~~~~~~    ^~~~~~~~~~~
../librz/bin/format/omf/omf166.c:1054:43: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
 1053 |                 RZ_LOG_DEBUG("load_omf: [%05d] [0x%08" PFMT64x "] 0x%02x (%" PFMT64u ")\t",
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1054 |                         record->size, global_ct, record->type, buf_size);
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
../librz/include/rz_util/rz_log.h:42:45: note: expanded from macro 'RZ_LOG_DEBUG'
   42 |         __LINE__, RZ_LOGLVL_DEBUG, NULL, fmtstr, ##__VA_ARGS__);
      |                                          ~~~~~~    ^~~~~~~~~~~
8 warnings generated.
```
**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

...

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
