### PR TITLE
fix(rz-asm): show error for unknown -m architecture

### DIFF
--- a/librz/main/rz-asm.c
+++ b/librz/main/rz-asm.c
@@ -634,6 +634,11 @@ RZ_API int rz_main_rz_asm(int argc, const char *argv[]) {
 			goto beach;
 		}
 		case 'm': {
+			if (!rz_asm_plugin_find(as->a, opt.arg)) {
+				RZ_LOG_ERROR("rz-asm: unknown architecture '%s'\nUse 'rz-asm -L' to list all available architectures.\n", opt.arg);
+				ret = 1;
+				goto beach;
+			}
 			RzCore *core = rz_core_new();
 			RzAsm *tmp_asm = core->rasm;
 			core->rasm = as->a;

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -668,3 +668,14 @@ EXPECT=<<EOF
 tricore         Generic TriCore CPU family by Infineon
 EOF
 RUN
+
+NAME=rz-asm unknown -m arch shows error
+TOOL=rz-asm
+ARGS=-m invalidarch
+EXIT_STATUS=1
+EXPECT=
+EXPECT_ERR=<<EOF
+ERROR: rz-asm: unknown architecture 'invalidarch'
+Use 'rz-asm -L' to list all available architectures.
+EOF
+RUN


### PR DESCRIPTION
Fixes #6367

## Problem
When an invalid architecture name is passed to `rz-asm -m`, the tool
silently exits with code 0 instead of showing an error.

## Root Cause
The `case 'm':` block in `librz/main/rz-asm.c` called
`rz_core_cpu_descs_print()` without first validating that the
architecture name is known to the plugin registry.

## Fix
Added a call to `rz_asm_plugin_find()` before proceeding. If the
architecture is not found, `RZ_LOG_ERROR` prints a descriptive message
to stderr and the tool exits with code 1.

## Before
$ rz-asm -m ic
$ echo $?
0

## After
$ rz-asm -m ic
ERROR: rz-asm: unknown architecture 'ic'
Use 'rz-asm -L' to list all available architectures.
$ echo $?
1

## Testing
Added regression test in `test/db/tools/rz_asm`. All 57 existing tests
still pass.