### PR TITLE
fix(rz-asm): show error for unknown -m architecture

### DIFF
--- a/librz/main/rz-asm.c
+++ b/librz/main/rz-asm.c
@@ -634,6 +634,11 @@ RZ_API int rz_main_rz_asm(int argc, const char *argv[]) {
 			goto beach;
 		}
 		case 'm': {
+			if (!rz_asm_plugin_find(as->a, opt.arg)) {
+				RZ_LOG_ERROR("rz-asm: unknown architecture '%s'\nUse 'rz-asm -L' to list all available architectures.\n", opt.arg);
+				ret = 1;
+				goto beach;
+			}
 			RzCore *core = rz_core_new();
 			RzAsm *tmp_asm = core->rasm;
 			core->rasm = as->a;

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -668,3 +668,14 @@ EXPECT=<<EOF
 tricore         Generic TriCore CPU family by Infineon
 EOF
 RUN
+
+NAME=rz-asm unknown -m arch shows error
+TOOL=rz-asm
+ARGS=-m invalidarch
+EXIT_STATUS=1
+EXPECT=
+EXPECT_ERR=<<EOF
+ERROR: rz-asm: unknown architecture 'invalidarch'
+Use 'rz-asm -L' to list all available architectures.
+EOF
+RUN


### PR DESCRIPTION

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

### Problem
When an invalid architecture name is passed to `rz-asm` using the `-m` option, the tool exits silently with status `0` instead of alerting the user or throwing an error.

### Root Cause
In `librz/main/rz-asm.c`, the execution logic inside `case 'm':` invokes `rz_core_cpu_descs_print()` directly without validating whether the user-supplied architecture token exists in the assembly plugin registry. As a result, the backend function executes and returns cleanly without matching any plugins, missing an explicit error pathway.

### Fix
Added a validation check using `rz_asm_plugin_find()` right at the entry of the `-m` parsing block. If the architecture lookup returns `NULL`, the tool explicitly logs an error prefix with `RZ_LOG_ERROR` pointing out the unknown architecture and guides the user to use `rz-asm -L` for valid targets before cleanly branching to `goto beach;` with an exit status of `1`.

**Test plan**

### Manual Verification
Compiled the code locally and checked both the exit code and stderr output for standard and non-existent architecture scenarios.

```bash
# Verify the fix with an invalid architecture string
$ ./build/binrz/rz-asm/rz-asm -m invalidarch
ERROR: rz-asm: unknown architecture 'invalidarch'
Use 'rz-asm -L' to list all available architectures.

$ echo $?
1

```

### Automated Testing

Added a regression test within `test/db/tools/rz_asm` verifying the command-line utility error message schema and confirming it evaluates cleanly to an exit status of `1`.

```text
NAME=rz-asm unknown -m arch shows error
TOOL=rz-asm
ARGS=-m invalidarch
EXIT_STATUS=1
EXPECT=
EXPECT_ERR=<<EOF #6367 'invalidarch' 'rz-asm 
```
fixes #6367 