### PR TITLE
Fix unit tests on 32-bit platforms

### DIFF
--- a/test/unit/test_mem.c
+++ b/test/unit/test_mem.c
@@ -106,7 +106,7 @@ bool test_rz_mem_align_byte(void) {
 bool test_rz_mem_ptr_alignment(void) {
 	mu_assert_eq(rz_mem_ptr_alignment(NULL), UT64_MAX, "Error case failed.");
 	mu_assert_eq(rz_mem_ptr_alignment((void *)0), UT64_MAX, "Error case failed.");
-	for (ut64 i = 1; i != 0; i <<= 1) {
+	for (ut64 i = 1; i != 0 && i <= (ut64)SIZE_MAX; i <<= 1) {
 		mu_assert_eq(rz_mem_ptr_alignment((void *)i), i, "Pointer alignment mismatches.");
 	}
 

--- a/test/unit/test_vector.c
+++ b/test/unit/test_vector.c
@@ -319,7 +319,7 @@ static bool test_vector_insert_sorted(void) {
 
 static bool test_vector_find_sorted(void) {
 	RzVector *v = rz_vector_new(sizeof(ut64), NULL, NULL);
-	for (size_t i = 1; i < 13; i++) {
+	for (ut64 i = 1; i < 13; i++) {
 		rz_vector_push(v, &i);
 	}
 	ut64 i = UT64_MAX;
@@ -1065,7 +1065,7 @@ static bool test_pvector_find(void) {
 	int num = 77;
 	ut32 e_val = 3;
 	void **p = rz_pvector_find(&v, &e_val, compare_int, &num);
-	mu_assert_eq(*p, e, "find");
+	mu_assert_ptreq(*p, e, "find");
 	mu_assert_eq(num, 44, "ensure user is passed");
 	rz_pvector_clear(&v);
 	mu_end;
@@ -1584,9 +1584,6 @@ static bool test_pvector_uniq(void) {
 		rz_pvector_push(&v, (void *)&arr[i]);
 	}
 	RzPVector *uv = rz_pvector_uniq(&v, compare_int, &num);
-	mu_assert_eq(uv->v.capacity, 8, "uniq values capacity before shrink");
-	rz_pvector_shrink(uv);
-	mu_assert_eq(uv->v.capacity, 6, "uniq values capacity after shrink");
 	mu_assert_eq(rz_pvector_len(uv), 6, "uniq values count");
 	rz_pvector_clear(&v);
 	rz_pvector_free(uv);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Various issues related to pointer size and RzVector behavior. Testing rz_pvector_shrink() at the place removed here is not necessary as it has its own dedicated tests.

**Test plan**

Tests should pass on e.g. 32-bit PowerPC and in CI.