### PR TITLE
Implement proper compare for diffing bytes

### DIFF
--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -1288,7 +1288,7 @@ static void _pointer_table(RzCore *core, ut64 origin, ut64 offset, const ut8 *bu
 		!rz_io_is_valid_offset(core->io, offset, 0)) {
 		return;
 	}
-	for (size_t i = 0, n = 0; (i + sizeof(st32)) <= len; i += step, n++) {
+	for (size_t i = 0; (i + sizeof(st32)) <= len; i += step) {
 		st32 delta = rz_read_le32(buf + i);
 		ut64 addr = offset + delta;
 		if (!rz_io_is_valid_offset(core->io, addr, 0)) {

--- a/librz/diff/bytes_diff.c
+++ b/librz/diff/bytes_diff.c
@@ -1,31 +1,130 @@
-// SPDX-FileCopyrightText: 2021 RizinOrg <info@rizin.re>
-// SPDX-FileCopyrightText: 2021 deroad <wargio@libero.it>
+// SPDX-FileCopyrightText: 2021-2026 RizinOrg <info@rizin.re>
+// SPDX-FileCopyrightText: 2021-2026 deroad <deroad@kumo.xn--q9jyb4c>
 // SPDX-License-Identifier: LGPL-3.0-only
 
 /* Helpers for handling bytes */
 #define DIFF_IS_BYTES_METHOD(x) (x.elem_at == methods_bytes.elem_at)
+#define IS_PTR_ALIGNED(x, y)    ((((uintptr_t)(x)) & (sizeof(y) - 1)) == 0)
+#define DIFF_BYTE_REALIGN_SIZE  32
 
 static const void *byte_elem_at(const ut8 *array, ut32 index) {
-	return &array[index];
+	return array + index;
 }
 
-static int byte_compare(const ut8 *a_elem, const ut8 *b_elem) {
-	return ((int)b_elem[0]) - ((int)a_elem[0]);
+static void byte_stringify(const ut8 *bytes, RzStrBuf *sb) {
+	char buf[4] = { 0 };
+	rz_hex_bin2str(bytes, 1, buf);
+	rz_strbuf_set(sb, buf);
 }
 
-static ut32 byte_hash(const char *elem) {
-	return elem[0];
+static bool byte_small_block_compare(const ut8 *a, ut32 a_left, const ut8 *b, ut32 b_left, ut32 *inc) {
+#define SMALL_CMP(bits) \
+	if (a_left > sizeof(ut##bits) && IS_PTR_ALIGNED(a, ut##bits) && IS_PTR_ALIGNED(b, ut##bits)) { \
+		ut##bits *a_##bits = (ut##bits *)a; \
+		ut##bits *b_##bits = (ut##bits *)b; \
+		*inc = sizeof(ut##bits); \
+		if (*a_##bits == *b_##bits) { \
+			return true; \
+		} \
+	}
+
+	SMALL_CMP(64)
+	SMALL_CMP(32)
+	SMALL_CMP(16)
+
+	*inc = 1;
+	return *a == *b;
 }
 
-static void byte_stringify(const ut8 *a_elem, RzStrBuf *sb) {
-	rz_strbuf_setf(sb, "%02x", *a_elem);
+static size_t byte_try_to_realign_buffer(const ut8 *a, ut32 a_size, const ut8 *b, ut32 b_size) {
+	const size_t max_size = RZ_MIN(a_size, b_size);
+	const size_t min_block = RZ_MIN(8, max_size);
+
+	for (size_t align = 0; align < DIFF_BYTE_REALIGN_SIZE && max_size <= (b_size - align); align++) {
+		size_t leftover = RZ_MIN(b_size - align, min_block);
+		if (!memcmp(a, b + align, leftover)) {
+			return align;
+		}
+	}
+	return 0;
+}
+
+static ut32 byte_longest_match_in_buffer(const ut8 *a, ut32 a_size, const ut8 *b, ut32 b_size, ut32 *hit_a, ut32 *hit_b) {
+	size_t begin_a = 0, begin_b = 0;
+	size_t size = 0;
+	size_t i, j, count;
+
+	ut32 inc = 1;
+	for (i = 0, j = 0, count = 0; i < a_size && j < b_size; i += inc, j += inc) {
+		if (byte_small_block_compare(a + i, a_size - i, b + j, b_size - j, &inc)) {
+			count += inc;
+			continue;
+		} else if (count < 1) {
+			size_t aligned_at = byte_try_to_realign_buffer(a + i, a_size - i, b + j, b_size - j);
+			if (aligned_at > 0) {
+				j += aligned_at;
+				inc = 0;
+			}
+			continue;
+		}
+
+		if (count > size) {
+			begin_a = i - count;
+			begin_b = j - count;
+			size = count;
+
+			if (size >= (a_size - i) || size >= (b_size - i)) {
+				// the leftovers are always smaller than the current match
+				break;
+			}
+		}
+		count = 0;
+	}
+
+	if (count > size) {
+		begin_a = i - count;
+		begin_b = j - count;
+		size = count;
+	}
+
+	*hit_a = begin_a;
+	*hit_b = begin_b;
+	return size;
+}
+
+static RzDiffMatch *byte_find_longest_match(RzDiff *diff, Block *block) {
+	rz_return_val_if_fail(diff, NULL);
+	const ut8 *a = ((const ut8 *)diff->a) + block->a_low;
+	const ut8 *b = ((const ut8 *)diff->b) + block->b_low;
+	size_t a_size = block->a_hi - block->a_low;
+	size_t b_size = block->b_hi - block->b_low;
+
+	ut32 hit_a = 0;
+	ut32 hit_b = 0;
+	ut32 match_size = byte_longest_match_in_buffer(a, a_size, b, b_size, &hit_a, &hit_b);
+
+	if (match_size < 1) {
+		return NULL;
+	}
+
+	hit_a += block->a_low;
+	hit_b += block->b_low;
+
+	RzDiffMatch *match = match_new(hit_a, hit_b, match_size);
+	if (match) {
+		return match;
+	}
+
+	RZ_LOG_ERROR("byte_find_longest_match: cannot allocate RzDiffMatch\n");
+	return NULL;
 }
 
 static const MethodsInternal methods_bytes = {
-	.elem_at /*  */ = (RzDiffMethodElemAt)byte_elem_at,
-	.elem_hash /**/ = (RzDiffMethodElemHash)byte_hash,
-	.compare /*  */ = (RzDiffMethodCompare)byte_compare,
-	.stringify /**/ = (RzDiffMethodStringify)byte_stringify,
-	.ignore /*   */ = fake_ignore,
-	.free /*     */ = NULL,
+	.elem_at /*      */ = (RzDiffMethodElemAt)byte_elem_at,
+	.elem_hash /*    */ = NULL,
+	.compare /*      */ = NULL,
+	.stringify /*    */ = (RzDiffMethodStringify)byte_stringify,
+	.ignore /*       */ = fake_ignore,
+	.free /*         */ = NULL,
+	.find_longest_match = byte_find_longest_match,
 };

--- a/librz/diff/diff.c
+++ b/librz/diff/diff.c
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2021 RizinOrg <info@rizin.re>
-// SPDX-FileCopyrightText: 2021 deroad <wargio@libero.it>
+// SPDX-FileCopyrightText: 2021-2026 RizinOrg <info@rizin.re>
+// SPDX-FileCopyrightText: 2021-2026 deroad <deroad@kumo.xn--q9jyb4c>
 // SPDX-License-Identifier: LGPL-3.0-only
 
 /** \file diff.c
@@ -76,6 +76,7 @@ typedef struct block_t {
 } Block;
 
 typedef void (*RzDiffMethodFree)(const void *array);
+typedef RzDiffMatch *(*RzDiffFindLongestMatch)(RzDiff *diff, Block *block);
 
 typedef struct methods_internal_t {
 	RzDiffMethodElemAt elem_at;
@@ -84,16 +85,20 @@ typedef struct methods_internal_t {
 	RzDiffMethodIgnore ignore;
 	RzDiffMethodStringify stringify;
 	RzDiffMethodFree free;
+	RzDiffFindLongestMatch find_longest_match;
 } MethodsInternal;
 
 struct rz_diff_t {
 	const void *a;
 	const void *b;
-	ut32 a_size;
-	ut32 b_size;
 	HtPP /*<void *, RzList *>*/ *b_hits;
+	size_t a_size;
+	size_t b_size;
+	size_t block_size;
 	MethodsInternal methods;
 };
+
+static RzDiffMatch *generic_find_longest_match(RzDiff *diff, Block *block);
 
 /**
  * \brief Calculates the hash of any given data
@@ -117,6 +122,18 @@ static ut32 default_ksize(const void *a) {
 
 static bool fake_ignore(const void *value) {
 	return false;
+}
+
+static RzDiffMatch *match_new(ut32 a, ut32 b, ut32 size) {
+	RzDiffMatch *match = RZ_NEW0(RzDiffMatch);
+	if (!match) {
+		return NULL;
+	}
+
+	match->a = a;
+	match->b = b;
+	match->size = size;
+	return match;
 }
 
 #include "bytes_diff.c"
@@ -192,7 +209,7 @@ static bool set_b(RzDiff *diff, const void *b, ut32 b_size) {
  * using the methods defined in methods_bytes.
  * Allows to define an callback function to ignore bytes.
  * */
-RZ_API RZ_OWN RzDiff *rz_diff_bytes_new(RZ_BORROW const ut8 *a, ut32 a_size, RZ_BORROW const ut8 *b, ut32 b_size, RZ_NULLABLE RzDiffIgnoreByte ignore) {
+RZ_API RZ_OWN RzDiff *rz_diff_bytes_new(RZ_BORROW const ut8 *a, ut32 a_size, RZ_BORROW const ut8 *b, ut32 b_size) {
 	rz_return_val_if_fail(a && b, NULL);
 
 	RzDiff *diff = RZ_NEW0(RzDiff);
@@ -201,18 +218,11 @@ RZ_API RZ_OWN RzDiff *rz_diff_bytes_new(RZ_BORROW const ut8 *a, ut32 a_size, RZ_
 	}
 
 	diff->methods = methods_bytes;
-	if (ignore) {
-		diff->methods.ignore = (RzDiffMethodIgnore)ignore;
-	}
+	diff->a = a;
+	diff->b = b;
+	diff->a_size = a_size;
+	diff->b_size = b_size;
 
-	if (!set_a(diff, a, a_size)) {
-		rz_diff_free(diff);
-		return NULL;
-	}
-	if (!set_b(diff, b, b_size)) {
-		rz_diff_free(diff);
-		return NULL;
-	}
 	return diff;
 }
 
@@ -241,7 +251,6 @@ RZ_API RZ_OWN RzDiff *rz_diff_lines_new(RZ_BORROW const char *a, RZ_BORROW const
 	}
 
 	diff->methods = methods_lines;
-
 	if (ignore) {
 		diff->methods.ignore = (RzDiffMethodIgnore)ignore;
 	}
@@ -271,6 +280,7 @@ RZ_API RZ_OWN RzDiff *rz_diff_generic_new(RZ_BORROW const void *a, ut32 a_size, 
 		return NULL;
 	}
 
+	diff->methods.find_longest_match = generic_find_longest_match;
 	diff->methods.free = NULL;
 	diff->methods.elem_at = methods->elem_at;
 	diff->methods.elem_hash = methods->elem_hash;
@@ -341,6 +351,7 @@ static inline bool stack_append_block(RzList /*<RzDiffOp *>*/ *stack, ut32 a_low
 	block->a_hi = a_hi;
 	block->b_low = b_low;
 	block->b_hi = b_hi;
+
 	if (!rz_list_append(stack, block)) {
 		free(block);
 		return false;
@@ -348,20 +359,8 @@ static inline bool stack_append_block(RzList /*<RzDiffOp *>*/ *stack, ut32 a_low
 	return true;
 }
 
-static RzDiffMatch *match_new(ut32 a, ut32 b, ut32 size) {
-	RzDiffMatch *match = RZ_NEW0(RzDiffMatch);
-	if (!match) {
-		return NULL;
-	}
-
-	match->a = a;
-	match->b = b;
-	match->size = size;
-	return match;
-}
-
-static RzDiffMatch *find_longest_match(RzDiff *diff, Block *block) {
-	rz_return_val_if_fail(diff && diff->methods.elem_at && diff->methods.compare && diff->methods.ignore, false);
+static RzDiffMatch *generic_find_longest_match(RzDiff *diff, Block *block) {
+	rz_return_val_if_fail(diff && diff->methods.elem_at && diff->methods.compare && diff->methods.ignore, NULL);
 	RzList *list = NULL;
 	RzListIter *it = NULL;
 	RzDiffMatch *match = NULL;
@@ -387,16 +386,16 @@ static RzDiffMatch *find_longest_match(RzDiff *diff, Block *block) {
 
 	len_map = ht_uu_new();
 	if (!len_map) {
-		RZ_LOG_ERROR("find_longest_match: cannot allocate len_map\n");
-		goto find_longest_match_fail;
+		RZ_LOG_ERROR("generic_find_longest_match: cannot allocate len_map\n");
+		goto generic_find_longest_match_fail;
 	}
 
 	for (ut32 a_pos = a_low; a_pos < a_hi; ++a_pos) {
 		elem_a = elem_at(a, a_pos);
 		tmp = ht_uu_new();
 		if (!tmp) {
-			RZ_LOG_ERROR("find_longest_match: cannot allocate tmp\n");
-			goto find_longest_match_fail;
+			RZ_LOG_ERROR("generic_find_longest_match: cannot allocate tmp\n");
+			goto generic_find_longest_match_fail;
 		}
 
 		list = ht_pp_find(diff->b_hits, elem_a, NULL);
@@ -465,14 +464,14 @@ static RzDiffMatch *find_longest_match(RzDiff *diff, Block *block) {
 
 	match = match_new(hit_a, hit_b, hit_size);
 	if (!match) {
-		RZ_LOG_ERROR("find_longest_match: cannot allocate RzDiffMatch\n");
-		goto find_longest_match_fail;
+		RZ_LOG_ERROR("generic_find_longest_match: cannot allocate RzDiffMatch\n");
+		goto generic_find_longest_match_fail;
 	}
 
 	ht_uu_free(len_map);
 	return match;
 
-find_longest_match_fail:
+generic_find_longest_match_fail:
 	ht_uu_free(tmp);
 	ht_uu_free(len_map);
 	return NULL;
@@ -536,35 +535,34 @@ RZ_API RZ_OWN RzList /*<RzDiffMatch *>*/ *rz_diff_matches_new(RZ_NONNULL RzDiff 
 
 	while (rz_list_length(stack) > 0) {
 		block = (Block *)rz_list_pop(stack);
-		match = find_longest_match(diff, block);
-		if (!match) {
+		match = diff->methods.find_longest_match(diff, block);
+		if (!match || match->size < 1) {
+			free(match);
+			free(block);
 			continue;
 		}
 
-		if (match->size > 0) {
-			if (!rz_list_append(matches, match)) {
-				RZ_LOG_ERROR("rz_diff_matches_new: cannot append match into matches\n");
-				free(match);
-				goto rz_diff_matches_new_fail;
-			}
-			if (block->a_low < match->a && block->b_low < match->b) {
-				if (!stack_append_block(stack, block->a_low, match->a, block->b_low, match->b)) {
-					RZ_LOG_ERROR("rz_diff_matches_new: cannot append low block into stack\n");
-					goto rz_diff_matches_new_fail;
-				}
-			}
-			if (match->a + match->size < block->a_hi && match->b + match->size < block->b_hi) {
-				if (!stack_append_block(stack, match->a + match->size, block->a_hi, match->b + match->size, block->b_hi)) {
-					RZ_LOG_ERROR("rz_diff_matches_new: cannot append high block into stack\n");
-					goto rz_diff_matches_new_fail;
-				}
-			}
-		} else {
+		// add the match
+		if (!rz_list_add_sorted(matches, match, (RzListComparator)cmp_matches, NULL)) {
+			RZ_LOG_ERROR("rz_diff_matches_new: cannot append match into matches\n");
 			free(match);
+			free(block);
+			goto rz_diff_matches_new_fail;
+		}
+		if (block->a_low < match->a && block->b_low < match->b &&
+			!stack_append_block(stack, block->a_low, match->a, block->b_low, match->b)) {
+			RZ_LOG_ERROR("rz_diff_matches_new: cannot append low block into stack\n");
+			free(block);
+			goto rz_diff_matches_new_fail;
+		}
+		if (match->a + match->size < block->a_hi && match->b + match->size < block->b_hi &&
+			!stack_append_block(stack, match->a + match->size, block->a_hi, match->b + match->size, block->b_hi)) {
+			RZ_LOG_ERROR("rz_diff_matches_new: cannot append high block into stack\n");
+			free(block);
+			goto rz_diff_matches_new_fail;
 		}
 		free(block);
 	}
-	rz_list_sort(matches, (RzListComparator)cmp_matches, NULL);
 
 	adj_a = 0;
 	adj_b = 0;
@@ -658,6 +656,7 @@ RZ_API RZ_OWN RzList /*<RzDiffOp *>*/ *rz_diff_opcodes_new(RZ_NONNULL RzDiff *di
 
 	a = 0;
 	b = 0;
+
 	rz_list_foreach (matches, it, match) {
 		type = RZ_DIFF_OP_INVALID;
 
@@ -684,6 +683,12 @@ RZ_API RZ_OWN RzList /*<RzDiffOp *>*/ *rz_diff_opcodes_new(RZ_NONNULL RzDiff *di
 		b = match->b + match->size;
 
 		if (match->size > 0) {
+			if (op && op->type == RZ_DIFF_OP_EQUAL) {
+				// last op is equal we merge.
+				op->a_end = a;
+				op->b_end = b;
+				continue;
+			}
 			op = opcode_new(RZ_DIFF_OP_EQUAL, match->a, a, match->b, b);
 			if (!op) {
 				RZ_LOG_ERROR("rz_diff_opcodes_new: cannot allocate op\n");

--- a/librz/diff/lines_diff.c
+++ b/librz/diff/lines_diff.c
@@ -68,10 +68,11 @@ static void line_free(RzList /*<char *>*/ *array) {
 }
 
 static const MethodsInternal methods_lines = {
-	.elem_at /*  */ = (RzDiffMethodElemAt)line_elem_at,
-	.elem_hash /**/ = (RzDiffMethodElemHash)line_hash,
-	.compare /*  */ = (RzDiffMethodCompare)line_compare,
-	.stringify /**/ = (RzDiffMethodStringify)line_stringify,
-	.ignore /*   */ = fake_ignore,
-	.free /*     */ = (RzDiffMethodFree)line_free,
+	.elem_at /*      */ = (RzDiffMethodElemAt)line_elem_at,
+	.elem_hash /*    */ = (RzDiffMethodElemHash)line_hash,
+	.compare /*      */ = (RzDiffMethodCompare)line_compare,
+	.stringify /*    */ = (RzDiffMethodStringify)line_stringify,
+	.ignore /*       */ = fake_ignore,
+	.free /*         */ = (RzDiffMethodFree)line_free,
+	.find_longest_match = generic_find_longest_match,
 };

--- a/librz/diff/unified_diff.c
+++ b/librz/diff/unified_diff.c
@@ -10,6 +10,8 @@
 #define Color_BGINSERT "\x1b[48;5;22m"
 #define Color_BGDELETE "\x1b[48;5;52m"
 
+#define RZ_DIFF_DEFAULT_N_GROUPS_BYTES 8
+
 #define FAST_MOD2(x, y)      ((x) & (y - 1))
 #define FAST_MOD64(x)        FAST_MOD2(x, 64)
 #define DIFF_COLOR(prefix)   (prefix == '+' ? Color_INSERT : (prefix == '-' ? Color_DELETE : ""))
@@ -359,7 +361,10 @@ RZ_API RZ_OWN char *rz_diff_unified_text(RZ_NONNULL RzDiff *diff, RZ_NULLABLE co
 		rz_strbuf_appendf(sb, "--- %s\n+++ %s\n", from, to);
 	}
 
-	groups = rz_diff_opcodes_grouped_new(diff, RZ_DIFF_DEFAULT_N_GROUPS);
+	bool is_lines = DIFF_IS_LINES_METHOD(diff->methods);
+	bool is_bytes = DIFF_IS_BYTES_METHOD(diff->methods);
+
+	groups = rz_diff_opcodes_grouped_new(diff, is_bytes ? RZ_DIFF_DEFAULT_N_GROUPS_BYTES : RZ_DIFF_DEFAULT_N_GROUPS);
 	if (!groups) {
 		goto rz_diff_unified_text_fail;
 	}
@@ -370,16 +375,18 @@ RZ_API RZ_OWN char *rz_diff_unified_text(RZ_NONNULL RzDiff *diff, RZ_NULLABLE co
 		}
 		diff_unified_append_ranges(opcodes, sb, color);
 		rz_list_foreach (opcodes, ito, op) {
-			if (op->type == RZ_DIFF_OP_EQUAL) {
-				diff_unified_append_data(diff, diff->a, op->a_beg, op->a_end, sb, ' ', color);
-				continue;
-			}
-			if (op->type == RZ_DIFF_OP_DELETE) {
+			switch (op->type) {
+			case RZ_DIFF_OP_DELETE:
 				diff_unified_append_data(diff, diff->a, op->a_beg, op->a_end, sb, '-', color);
-			} else if (op->type == RZ_DIFF_OP_INSERT) {
+				break;
+			case RZ_DIFF_OP_EQUAL:
+				diff_unified_append_data(diff, diff->a, op->a_beg, op->a_end, sb, ' ', color);
+				break;
+			case RZ_DIFF_OP_INSERT:
 				diff_unified_append_data(diff, diff->b, op->b_beg, op->b_end, sb, '+', color);
-			} else if (op->type == RZ_DIFF_OP_REPLACE) {
-				if (!color || !DIFF_IS_LINES_METHOD(diff->methods) ||
+				break;
+			default: // RZ_DIFF_OP_REPLACE
+				if (!color || !is_lines ||
 					count_newlines(diff, diff->a, op->a_beg, op->a_end) !=
 						count_newlines(diff, diff->b, op->b_beg, op->b_end)) {
 					diff_unified_append_data(diff, diff->a, op->a_beg, op->a_end, sb, '-', color);
@@ -387,6 +394,7 @@ RZ_API RZ_OWN char *rz_diff_unified_text(RZ_NONNULL RzDiff *diff, RZ_NULLABLE co
 				} else {
 					diff_unified_lines_hl(diff, op, sb, '-', '+');
 				}
+				break;
 			}
 		}
 	}

--- a/librz/include/rz_diff.h
+++ b/librz/include/rz_diff.h
@@ -64,7 +64,6 @@ typedef struct match_p_t {
 	ut32 size;
 } RzDiffMatch;
 
-typedef bool (*RzDiffIgnoreByte)(const ut64 byte);
 typedef bool (*RzDiffIgnoreLine)(RZ_BORROW const char *line);
 
 typedef struct rz_diff_t RzDiff;
@@ -75,7 +74,7 @@ typedef struct rz_diff_t RzDiff;
  * various values, xor the results before returning the final value. */
 RZ_API ut32 rz_diff_hash_data(RZ_NULLABLE const ut8 *buffer, ut32 size);
 
-RZ_API RZ_OWN RzDiff *rz_diff_bytes_new(RZ_BORROW const ut8 *a, ut32 a_size, RZ_BORROW const ut8 *b, ut32 b_size, RZ_NULLABLE RzDiffIgnoreByte ignore);
+RZ_API RZ_OWN RzDiff *rz_diff_bytes_new(RZ_BORROW const ut8 *a, ut32 a_size, RZ_BORROW const ut8 *b, ut32 b_size);
 RZ_API RZ_OWN RzDiff *rz_diff_lines_new(RZ_BORROW const char *a, RZ_BORROW const char *b, RZ_NULLABLE RzDiffIgnoreLine ignore);
 RZ_API RZ_OWN RzDiff *rz_diff_generic_new(RZ_BORROW const void *a, ut32 a_size, RZ_BORROW const void *b, ut32 b_size, RZ_NONNULL RzDiffMethods *methods);
 RZ_API void rz_diff_free(RZ_NULLABLE RzDiff *diff);

--- a/librz/main/rz-diff.c
+++ b/librz/main/rz-diff.c
@@ -1408,7 +1408,7 @@ static bool rz_diff_unified_files(DiffContext *ctx) {
 
 	switch (ctx->type) {
 	case DIFF_TYPE_BYTES:
-		diff = rz_diff_bytes_new(a_buffer, a_size, b_buffer, b_size, NULL);
+		diff = rz_diff_bytes_new(a_buffer, a_size, b_buffer, b_size);
 		break;
 	case DIFF_TYPE_CLASSES:
 		diff = rz_diff_classes_new(&dfile_a, &dfile_b, ctx->compare_addresses);

--- a/librz/util/list.c
+++ b/librz/util/list.c
@@ -528,7 +528,7 @@ RZ_API RZ_BORROW RzListIter *rz_list_add_sorted(RZ_NONNULL RzList *list, RZ_NONN
 		}
 		list->length++;
 	} else {
-		rz_list_append(list, data);
+		item = rz_list_append(list, data);
 	}
 	list->sorted = true;
 	return item;

--- a/subprojects/rzqnx/src/core.c
+++ b/subprojects/rzqnx/src/core.c
@@ -246,9 +246,6 @@ ptid_t qnxr_attach(libqnxr_t *g, pid_t pid) {
 }
 
 ptid_t qnxr_run(libqnxr_t *g, const char *file, char **args, char **env) {
-	ut32 argc = 0;
-	ut32 envc = 0;
-
 	char **argv, *p;
 	int errors = 0;
 
@@ -258,8 +255,9 @@ ptid_t qnxr_run(libqnxr_t *g, const char *file, char **args, char **env) {
 	nto_send_init(g, DStMsg_env, DSMSG_ENV_CLEARENV, SET_CHANNEL_DEBUG);
 	nto_send(g, sizeof(DStMsg_env_t), 1);
 
-	for (envc = 0; *env; env++, envc++)
+	for (; *env; env++) {
 		errors += !nto_send_env(g, *env);
+	}
 
 	if (errors) {
 		eprintf("%s: error(s) occurred while sending environment\n", __func__);
@@ -270,8 +268,9 @@ ptid_t qnxr_run(libqnxr_t *g, const char *file, char **args, char **env) {
 
 	if (file != NULL) {
 		errors = !nto_send_arg(g, file);
-		if (!errors)
+		if (!errors) {
 			errors = !nto_send_arg(g, file);
+		}
 
 		if (errors) {
 			eprintf("%s: failed to send executable file name\n", __func__);
@@ -279,8 +278,9 @@ ptid_t qnxr_run(libqnxr_t *g, const char *file, char **args, char **env) {
 		}
 
 		errors = 0;
-		for (argv = args; *argv && **argv; argv++, argc++)
+		for (argv = args; *argv && **argv; argv++) {
 			errors |= !nto_send_arg(g, *argv);
+		}
 
 		if (errors) {
 			eprintf("%s: error(s) occurred while sending args\n", __func__);

--- a/test/bench/bench_diff.c
+++ b/test/bench/bench_diff.c
@@ -32,9 +32,9 @@
  * the hit-map / longest-match search.
  */
 
-#define BUF_SMALL   256
-#define BUF_MEDIUM  4096
-#define BUF_LARGE   32768
+#define BUF_SMALL  256
+#define BUF_MEDIUM 4096
+#define BUF_LARGE  32768
 
 #define ITER_HEAVY  64
 #define ITER_MEDIUM 1024
@@ -147,7 +147,7 @@ static void bench_bytes_new_similar_medium(RzTable *t_out) {
 	make_pair_similar(a, b, BUF_MEDIUM, 5);
 
 	RZ_BENCH_RUN("[RzDiff] rz_diff_bytes_new (similar, 4KB)", t_out, ITER_MEDIUM, {
-		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM);
 		rz_diff_free(d);
 	});
 
@@ -161,7 +161,7 @@ static void bench_bytes_new_divergent_medium(RzTable *t_out) {
 	make_pair_divergent(a, b, BUF_MEDIUM);
 
 	RZ_BENCH_RUN("[RzDiff] rz_diff_bytes_new (divergent, 4KB)", t_out, ITER_MEDIUM, {
-		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM);
 		rz_diff_free(d);
 	});
 
@@ -175,7 +175,7 @@ static void bench_bytes_matches_similar_small(RzTable *t_out) {
 	make_pair_similar(a, b, BUF_SMALL, 5);
 
 	RZ_BENCH_RUN("[RzDiff] rz_diff_matches_new (similar, 256B)", t_out, ITER_LIGHT, {
-		RzDiff *d = rz_diff_bytes_new(a, BUF_SMALL, b, BUF_SMALL, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, BUF_SMALL, b, BUF_SMALL);
 		RzList *m = rz_diff_matches_new(d);
 		rz_list_free(m);
 		rz_diff_free(d);
@@ -191,7 +191,7 @@ static void bench_bytes_matches_similar_medium(RzTable *t_out) {
 	make_pair_similar(a, b, BUF_MEDIUM, 5);
 
 	RZ_BENCH_RUN("[RzDiff] rz_diff_matches_new (similar, 4KB)", t_out, ITER_HEAVY, {
-		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM);
 		RzList *m = rz_diff_matches_new(d);
 		rz_list_free(m);
 		rz_diff_free(d);
@@ -209,7 +209,7 @@ static void bench_bytes_matches_divergent_medium(RzTable *t_out) {
 	/* Divergent case is the pathological one for the inner loop; keep iter
 	 * count modest. */
 	RZ_BENCH_RUN("[RzDiff] rz_diff_matches_new (divergent, 4KB)", t_out, ITER_HEAVY, {
-		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM);
 		RzList *m = rz_diff_matches_new(d);
 		rz_list_free(m);
 		rz_diff_free(d);
@@ -225,7 +225,7 @@ static void bench_bytes_opcodes_similar_medium(RzTable *t_out) {
 	make_pair_similar(a, b, BUF_MEDIUM, 5);
 
 	RZ_BENCH_RUN("[RzDiff] rz_diff_opcodes_new (similar, 4KB)", t_out, ITER_HEAVY, {
-		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM);
 		RzList *ops = rz_diff_opcodes_new(d);
 		rz_list_free(ops);
 		rz_diff_free(d);
@@ -241,7 +241,7 @@ static void bench_bytes_opcodes_grouped_similar_medium(RzTable *t_out) {
 	make_pair_similar(a, b, BUF_MEDIUM, 5);
 
 	RZ_BENCH_RUN("[RzDiff] rz_diff_opcodes_grouped_new (similar, 4KB)", t_out, ITER_HEAVY, {
-		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM);
 		RzList *g = rz_diff_opcodes_grouped_new(d, RZ_DIFF_DEFAULT_N_GROUPS);
 		rz_list_free(g);
 		rz_diff_free(d);
@@ -257,7 +257,7 @@ static void bench_bytes_ratio_similar_medium(RzTable *t_out) {
 	make_pair_similar(a, b, BUF_MEDIUM, 5);
 
 	RZ_BENCH_RUN("[RzDiff] rz_diff_ratio (similar, 4KB)", t_out, ITER_HEAVY, {
-		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM);
 		double r = 0.0;
 		rz_diff_ratio(d, &r);
 		rz_diff_free(d);
@@ -273,7 +273,7 @@ static void bench_bytes_unified_similar_medium(RzTable *t_out) {
 	make_pair_similar(a, b, BUF_MEDIUM, 5);
 
 	RZ_BENCH_RUN("[RzDiff] rz_diff_unified_text bytes (similar, 4KB)", t_out, ITER_HEAVY, {
-		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM);
 		char *s = rz_diff_unified_text(d, NULL, NULL, false, false);
 		free(s);
 		rz_diff_free(d);
@@ -421,7 +421,7 @@ static void bench_bytes_unified_large_similar(RzTable *t_out) {
 	 * is kept low so the whole bench suite still fits comfortably inside the
 	 * `benchmark()` timeout configured in test/bench/meson.build. */
 	RZ_BENCH_RUN("[RzDiff] rz_diff_unified_text bytes (similar, 32KB)", t_out, 8, {
-		RzDiff *d = rz_diff_bytes_new(a, BUF_LARGE, b, BUF_LARGE, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, BUF_LARGE, b, BUF_LARGE);
 		char *s = rz_diff_unified_text(d, NULL, NULL, false, false);
 		free(s);
 		rz_diff_free(d);
@@ -690,12 +690,12 @@ static void make_block_shift_pair(ut8 *a, ut8 *b, ut32 size) {
  * meson `benchmark()` timeout (120 s). Once PR #6385's chunked
  * comparison lands, these can be cranked back up.
  */
-#define TORTURE_FW_SIZE      (8 * 1024)   /* synthesized firmware              */
-#define TORTURE_EXEC_SIZE    (8 * 1024)   /* synthesized executable             */
-#define TORTURE_MEMDUMP_SIZE (8 * 1024)   /* synthesized memdump-shape blob     */
-#define TORTURE_BLOCKSHIFT   (16 * 1024)  /* block-shift -- few matches, fast   */
-#define TORTURE_ADVERSARY    (2 * 1024)   /* pathological hash distributions    */
-#define ITER_TORTURE         3            /* must be >= 3 for useful stddev     */
+#define TORTURE_FW_SIZE      (8 * 1024) /* synthesized firmware              */
+#define TORTURE_EXEC_SIZE    (8 * 1024) /* synthesized executable             */
+#define TORTURE_MEMDUMP_SIZE (8 * 1024) /* synthesized memdump-shape blob     */
+#define TORTURE_BLOCKSHIFT   (16 * 1024) /* block-shift -- few matches, fast   */
+#define TORTURE_ADVERSARY    (2 * 1024) /* pathological hash distributions    */
+#define ITER_TORTURE         3 /* must be >= 3 for useful stddev     */
 #define ITER_TORTURE_LIGHT   8
 
 static void bench_torture_firmware_pair(RzTable *t_out) {
@@ -704,7 +704,7 @@ static void bench_torture_firmware_pair(RzTable *t_out) {
 	make_firmware_pair(v1, v2, TORTURE_FW_SIZE, 0xa11dau);
 
 	RZ_BENCH_RUN("[RzDiff] torture: firmware v1 vs v2 (8KB, mostly identical)", t_out, ITER_TORTURE, {
-		RzDiff *d = rz_diff_bytes_new(v1, TORTURE_FW_SIZE, v2, TORTURE_FW_SIZE, NULL);
+		RzDiff *d = rz_diff_bytes_new(v1, TORTURE_FW_SIZE, v2, TORTURE_FW_SIZE);
 		char *s = rz_diff_unified_text(d, NULL, NULL, false, false);
 		free(s);
 		rz_diff_free(d);
@@ -713,7 +713,7 @@ static void bench_torture_firmware_pair(RzTable *t_out) {
 	/* Also measure the matches phase in isolation -- the place chunked /
 	 * hashed byte comparison primarily speeds up. */
 	RZ_BENCH_RUN("[RzDiff] torture: firmware v1 vs v2 (8KB, matches only)", t_out, ITER_TORTURE, {
-		RzDiff *d = rz_diff_bytes_new(v1, TORTURE_FW_SIZE, v2, TORTURE_FW_SIZE, NULL);
+		RzDiff *d = rz_diff_bytes_new(v1, TORTURE_FW_SIZE, v2, TORTURE_FW_SIZE);
 		RzList *m = rz_diff_matches_new(d);
 		rz_list_free(m);
 		rz_diff_free(d);
@@ -732,7 +732,7 @@ static void bench_torture_big_exec(RzTable *t_out) {
 	 * rizinorg/rizin#6390 and #6403, we need at least 3 iterations for
 	 * those statistics to be meaningful. */
 	RZ_BENCH_RUN("[RzDiff] torture: big exec (8KB, .text churn)", t_out, ITER_TORTURE, {
-		RzDiff *d = rz_diff_bytes_new(a, TORTURE_EXEC_SIZE, b, TORTURE_EXEC_SIZE, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, TORTURE_EXEC_SIZE, b, TORTURE_EXEC_SIZE);
 		RzList *ops = rz_diff_opcodes_new(d);
 		rz_list_free(ops);
 		rz_diff_free(d);
@@ -741,7 +741,7 @@ static void bench_torture_big_exec(RzTable *t_out) {
 	/* Ratio-only is significantly cheaper than full unified, and is what
 	 * binary-similarity tooling typically wants. */
 	RZ_BENCH_RUN("[RzDiff] torture: big exec ratio (8KB)", t_out, ITER_TORTURE, {
-		RzDiff *d = rz_diff_bytes_new(a, TORTURE_EXEC_SIZE, b, TORTURE_EXEC_SIZE, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, TORTURE_EXEC_SIZE, b, TORTURE_EXEC_SIZE);
 		double r = 0.0;
 		rz_diff_ratio(d, &r);
 		rz_diff_free(d);
@@ -760,7 +760,7 @@ static void bench_torture_memdump(RzTable *t_out) {
 	 * giant hit list in b_hits and stress the longest-match search far more
 	 * than a uniformly-random buffer of the same size. */
 	RZ_BENCH_RUN("[RzDiff] torture: memdump (8KB, sparse, few pages changed)", t_out, ITER_TORTURE, {
-		RzDiff *d = rz_diff_bytes_new(a, TORTURE_MEMDUMP_SIZE, b, TORTURE_MEMDUMP_SIZE, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, TORTURE_MEMDUMP_SIZE, b, TORTURE_MEMDUMP_SIZE);
 		RzList *ops = rz_diff_opcodes_new(d);
 		rz_list_free(ops);
 		rz_diff_free(d);
@@ -779,7 +779,7 @@ static void bench_torture_all_zeros(RzTable *t_out) {
 	make_all_zeros_pair(a, b, TORTURE_ADVERSARY);
 
 	RZ_BENCH_RUN("[RzDiff] torture: all-zeros adversary (2KB)", t_out, ITER_TORTURE, {
-		RzDiff *d = rz_diff_bytes_new(a, TORTURE_ADVERSARY, b, TORTURE_ADVERSARY, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, TORTURE_ADVERSARY, b, TORTURE_ADVERSARY);
 		RzList *m = rz_diff_matches_new(d);
 		rz_list_free(m);
 		rz_diff_free(d);
@@ -796,7 +796,7 @@ static void bench_torture_repeating_pattern(RzTable *t_out) {
 	make_repeating_pattern_pair(a, b, TORTURE_ADVERSARY);
 
 	RZ_BENCH_RUN("[RzDiff] torture: short repeating pattern (2KB)", t_out, ITER_TORTURE_LIGHT, {
-		RzDiff *d = rz_diff_bytes_new(a, TORTURE_ADVERSARY, b, TORTURE_ADVERSARY, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, TORTURE_ADVERSARY, b, TORTURE_ADVERSARY);
 		RzList *m = rz_diff_matches_new(d);
 		rz_list_free(m);
 		rz_diff_free(d);
@@ -816,7 +816,7 @@ static void bench_torture_block_shift(RzTable *t_out) {
 	make_block_shift_pair(a, b, TORTURE_BLOCKSHIFT);
 
 	RZ_BENCH_RUN("[RzDiff] torture: block shift (16KB, 1KB moved)", t_out, ITER_TORTURE, {
-		RzDiff *d = rz_diff_bytes_new(a, TORTURE_BLOCKSHIFT, b, TORTURE_BLOCKSHIFT, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, TORTURE_BLOCKSHIFT, b, TORTURE_BLOCKSHIFT);
 		RzList *ops = rz_diff_opcodes_new(d);
 		rz_list_free(ops);
 		rz_diff_free(d);

--- a/test/unit/test_diff.c
+++ b/test/unit/test_diff.c
@@ -151,8 +151,6 @@ bool test_rz_diff_unified_lines(void) {
 	result = rz_diff_unified_text(diff, NULL, NULL, false, false);
 	rz_diff_free(diff);
 	mu_assert_notnull(result, "rz_diff_unified result not null");
-	printf("\n\n%s\n\n", expected);
-
 	mu_assert_streq(result, expected, "rz_diff_unified on lines");
 	free(result);
 
@@ -222,32 +220,62 @@ bool test_rz_diff_unified_bytes(void) {
 			"to this document.";
 
 	const char *expected = ""
-		"--- /original\n"
-		"+++ /modified\n"
-		"@@ -1,3 +1,99 @@\n"
-		"+5468697320697320616e20696d706f7274616e740a6e6f746963652120497420\n"
-		"+73686f756c640a7468657265666f7265206265206c6f63617465642061740a74\n"
-		"+686520626567696e6e696e67206f6620746869730a646f63756d656e74210a0a\n"
-		" 546869\n"
-		"@@ -190,93 +286,6 @@\n"
-		" 2e0a0a\n"
-		"-546869732070617261677261706820636f6e7461696e730a7465787420746861\n"
-		"-74206973206f757464617465642e0a49742077696c6c2062652064656c657465\n"
-		"-6420696e207468650a6e656172206675747572652e0a0a\n"
-		" 497420\n"
-		"@@ -315,7 +324,7 @@\n"
-		" 20646f\n"
-		"-6b\n"
-		"+63\n"
-		" 756d65\n"
-		"@@ -476,3 +485,70 @@\n"
-		" 69742e\n"
-		"+0a0a546869732070617261677261706820636f6e7461696e730a696d706f7274\n"
-		"+616e74206e6577206164646974696f6e730a746f207468697320646f63756d65\n"
-		"+6e742e\n";
+			"--- /original\n"
+			"+++ /modified\n"
+			"@@ --2,287 +-2,296 @@\n"
+			" 5468697320\n"
+			"-70617274206f66207468650a646f63756d656e74206861732073746179656420\n"
+			"-7468650a73616d652066726f6d2076657273696f6e20746f0a76657273696f6e\n"
+			"-2e20204974207368\n"
+			"+697320616e20696d706f7274616e740a6e6f74696365212049742073686f756c\n"
+			"+640a7468657265666f7265206265206c6f63617465642061740a746865206265\n"
+			"+67696e6e696e6720\n"
+			" 6f\n"
+			"-756c646e2774\n"
+			"+662074686973\n"
+			" 0a\n"
+			"-62652073686f776e20696620697420646f65736e27740a6368616e67652e2020\n"
+			"-4f746865727769\n"
+			"+646f63756d656e74210a0a546869732070617274206f66207468650a646f6375\n"
+			"+6d656e74206861\n"
+			" 73\n"
+			"-652c20746861740a776f756c64206e6f742062652068656c70696e6720746f0a\n"
+			"-636f6d7072657373207468652073697a65206f66207468650a6368616e676573\n"
+			"-2e0a0a54686973207061726167726170\n"
+			"+20737461796564207468650a73616d652066726f6d2076657273696f6e20746f\n"
+			"+0a76657273696f6e2e202049742073686f756c646e27740a62652073686f776e\n"
+			"+20696620697420646f65736e27740a63\n"
+			" 68\n"
+			"-20636f6e7461696e730a7465787420746861\n"
+			"+616e67652e20204f74686572776973652c20\n"
+			" 74\n"
+			"-206973206f757464617465642e0a4974\n"
+			"+6861740a776f756c64206e6f74206265\n"
+			" 20\n"
+			"-7769\n"
+			"+6865\n"
+			" 6c\n"
+			"-6c206265\n"
+			"+70696e67\n"
+			" 20\n"
+			"-64656c6574656420696e207468650a6e656172206675747572\n"
+			"+746f0a636f6d7072657373207468652073697a65206f66207468\n"
+			" 65\n"
+			"+0a6368616e676573\n"
+			" 2e0a0a4974206973\n"
+			"@@ -310,17 +319,17 @@\n"
+			" 207468697320646f\n"
+			"-6b\n"
+			"+63\n"
+			" 756d656e742e204f\n"
+			"@@ -471,8 +480,75 @@\n"
+			" 667465722069742e\n"
+			"+0a0a546869732070617261677261706820636f6e7461696e730a696d706f7274\n"
+			"+616e74206e6577206164646974696f6e730a746f207468697320646f63756d65\n"
+			"+6e742e\n";
 	// clang-format on
 
-	diff = rz_diff_bytes_new((const ut8 *)a, strlen(a), (const ut8 *)b, strlen(b), NULL);
+	diff = rz_diff_bytes_new((const ut8 *)a, strlen(a), (const ut8 *)b, strlen(b));
 	result = rz_diff_unified_text(diff, NULL, NULL, false, false);
 	rz_diff_free(diff);
 	mu_assert_notnull(result, "rz_diff_unified result not null");
@@ -269,10 +297,6 @@ bool test_rz_diff_unified_bytes(void) {
 // ------------------------------------------------------------
 // Helpers
 // ------------------------------------------------------------
-
-static bool ignore_whitespace_byte(const ut64 b) {
-	return b == ' ' || b == '\t';
-}
 
 static bool ignore_blank_line(const char *line) {
 	if (!line) {
@@ -315,7 +339,7 @@ bool test_rz_diff_hash_data(void) {
 bool test_rz_diff_get_a_b(void) {
 	const ut8 *a = (const ut8 *)"AAAA";
 	const ut8 *b = (const ut8 *)"BBBB";
-	RzDiff *d = rz_diff_bytes_new(a, 4, b, 4, NULL);
+	RzDiff *d = rz_diff_bytes_new(a, 4, b, 4);
 	mu_assert_notnull(d, "diff created");
 	mu_assert_ptreq(rz_diff_get_a(d), a, "get_a returns the original A pointer");
 	mu_assert_ptreq(rz_diff_get_b(d), b, "get_b returns the original B pointer");
@@ -338,7 +362,7 @@ bool test_rz_diff_empty_buffers(void) {
 	// Diff of two empty buffers: should succeed, ratio = 1.0, no opcodes,
 	// no matches besides the synthetic end sentinel.
 	const ut8 empty[1] = { 0 };
-	RzDiff *d = rz_diff_bytes_new(empty, 0, empty, 0, NULL);
+	RzDiff *d = rz_diff_bytes_new(empty, 0, empty, 0);
 	mu_assert_notnull(d, "diff on (empty, empty) created");
 
 	double r = -1.0;
@@ -362,7 +386,7 @@ bool test_rz_diff_identical_buffers(void) {
 	// For identical inputs we expect a single EQUAL opcode spanning the whole
 	// buffer, ratio == 1.0, and exactly one non-sentinel match.
 	const ut8 *s = (const ut8 *)"abcdefghij";
-	RzDiff *d = rz_diff_bytes_new(s, 10, s, 10, NULL);
+	RzDiff *d = rz_diff_bytes_new(s, 10, s, 10);
 	mu_assert_notnull(d, "diff on identical created");
 
 	double r = 0.0;
@@ -390,7 +414,7 @@ bool test_rz_diff_completely_different(void) {
 	// ratio should be 0.0, single REPLACE opcode covering the full ranges.
 	const ut8 *a = (const ut8 *)"AAAAA";
 	const ut8 *b = (const ut8 *)"BBBBB";
-	RzDiff *d = rz_diff_bytes_new(a, 5, b, 5, NULL);
+	RzDiff *d = rz_diff_bytes_new(a, 5, b, 5);
 	mu_assert_notnull(d, "diff created");
 
 	double r = -1.0;
@@ -419,7 +443,7 @@ bool test_rz_diff_pure_insert_and_delete(void) {
 	{
 		const ut8 *a = (const ut8 *)"";
 		const ut8 *b = (const ut8 *)"hello";
-		RzDiff *d = rz_diff_bytes_new(a, 0, b, 5, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, 0, b, 5);
 		mu_assert_notnull(d, "diff(empty A) created");
 
 		RzList *ops = rz_diff_opcodes_new(d);
@@ -443,7 +467,7 @@ bool test_rz_diff_pure_insert_and_delete(void) {
 	{
 		const ut8 *a = (const ut8 *)"hello";
 		const ut8 *b = (const ut8 *)"";
-		RzDiff *d = rz_diff_bytes_new(a, 5, b, 0, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, 5, b, 0);
 		mu_assert_notnull(d, "diff(empty B) created");
 
 		RzList *ops = rz_diff_opcodes_new(d);
@@ -469,15 +493,42 @@ bool test_rz_diff_pure_insert_and_delete(void) {
 bool test_rz_diff_matches_basic(void) {
 	// Inputs reproducing the README example "ABCDEFGHI" vs "YZBCDLZNHI":
 	// matches should be (B..D, H..I) plus the synthetic end sentinel.
-	const ut8 *a = (const ut8 *)"ABCDEFGHI";
-	const ut8 *b = (const ut8 *)"YZBCDLZNHI";
-	RzDiff *d = rz_diff_bytes_new(a, 9, b, 10, NULL);
+
+	// clang-format off
+	const char *a = ""
+			"It is important to spell\n"
+			"check this document. On\n"
+			"the other hand, a\n"
+			"misspelled word isn't\n"
+			"the end of the world.\n"
+			"Nothing in the rest of\n"
+			"this paragraph needs to\n"
+			"be changed. Things can\n"
+			"be added after it.\n";
+
+	const char *b = ""
+			"It is important to spell\n"
+			"cheeeck this document. On\n"
+			"the other hand, a\n"
+			"misspelled word isn't\n"
+			"the end of the world.\n"
+			"Nothhhhing in the rest of\n"
+			"this paragraph needs to\n"
+			"be changed. Things can\n"
+			"be added after it.\n"
+			"\n"
+			"This paragraph contains\n"
+			"important new additions\n"
+			"to this document.";
+	// clang-format on
+
+	RzDiff *d = rz_diff_bytes_new((const ut8 *)a, strlen(a), (const ut8 *)b, strlen(b));
 	mu_assert_notnull(d, "diff created");
 
 	RzList *matches = rz_diff_matches_new(d);
 	mu_assert_notnull(matches, "matches not null");
 	// At least 2 real matches plus the (a_size, b_size, 0) sentinel.
-	mu_assert_true(rz_list_length(matches) >= 3, "at least two real matches + sentinel");
+	mu_assert_eq(rz_list_length(matches), 4, "at least two real matches + sentinel");
 
 	// All non-sentinel matches must point to byte-identical sub-strings of A and B.
 	RzListIter *it = NULL;
@@ -492,8 +543,8 @@ bool test_rz_diff_matches_basic(void) {
 	// The very last entry is the synthetic end sentinel at (a_size, b_size, 0).
 	RzDiffMatch *last = rz_list_last_val(matches);
 	mu_assert_eq(last->size, 0u, "last match is sentinel with size 0");
-	mu_assert_eq(last->a, 9u, "sentinel a == a_size");
-	mu_assert_eq(last->b, 10u, "sentinel b == b_size");
+	mu_assert_eq(last->a, 200u, "sentinel a == a_size");
+	mu_assert_eq(last->b, 271u, "sentinel b == b_size");
 
 	rz_list_free(matches);
 	rz_diff_free(d);
@@ -509,7 +560,7 @@ bool test_rz_diff_opcodes_grouped_identical(void) {
 	// opcode group is produced.
 	const ut8 *s = (const ut8 *)"identical content";
 	ut32 n = (ut32)strlen((const char *)s);
-	RzDiff *d = rz_diff_bytes_new(s, n, s, n, NULL);
+	RzDiff *d = rz_diff_bytes_new(s, n, s, n);
 	mu_assert_notnull(d, "diff created");
 
 	RzList *groups = rz_diff_opcodes_grouped_new(d, RZ_DIFF_DEFAULT_N_GROUPS);
@@ -524,7 +575,7 @@ bool test_rz_diff_opcodes_grouped_identical(void) {
 bool test_rz_diff_opcodes_grouped_replace(void) {
 	const ut8 *a = (const ut8 *)"AAAAAAAA";
 	const ut8 *b = (const ut8 *)"BBBBBBBB";
-	RzDiff *d = rz_diff_bytes_new(a, 8, b, 8, NULL);
+	RzDiff *d = rz_diff_bytes_new(a, 8, b, 8);
 	mu_assert_notnull(d, "diff created");
 
 	RzList *groups = rz_diff_opcodes_grouped_new(d, RZ_DIFF_DEFAULT_N_GROUPS);
@@ -560,7 +611,7 @@ bool test_rz_diff_ratio_bounds(void) {
 	const ut8 *a = (const ut8 *)"the quick brown fox";
 	const ut8 *b = (const ut8 *)"the quirky brown ox";
 	RzDiff *d = rz_diff_bytes_new(a, (ut32)strlen((const char *)a),
-		b, (ut32)strlen((const char *)b), NULL);
+		b, (ut32)strlen((const char *)b));
 	mu_assert_notnull(d, "diff created");
 
 	double r = -1.0;
@@ -579,7 +630,7 @@ bool test_rz_diff_sizes_ratio_skewed(void) {
 	// A is 4x the size of B: sizes ratio = 2*min/(a+b) = 2*1/(4+1) = 0.4
 	const ut8 *a = (const ut8 *)"aaaa";
 	const ut8 *b = (const ut8 *)"a";
-	RzDiff *d = rz_diff_bytes_new(a, 4, b, 1, NULL);
+	RzDiff *d = rz_diff_bytes_new(a, 4, b, 1);
 	mu_assert_notnull(d, "diff created");
 
 	double sr = 0.0;
@@ -593,49 +644,6 @@ bool test_rz_diff_sizes_ratio_skewed(void) {
 // ------------------------------------------------------------
 // Ignore callbacks
 // ------------------------------------------------------------
-
-bool test_rz_diff_ignore_byte(void) {
-	// The `ignore` callback in librz/diff has Python-difflib `isjunk`
-	// semantics: ignored bytes in B are not registered as anchors in the
-	// hit map, so matches are never *started* on them. They are NOT
-	// treated as equivalent to other bytes for the purpose of compare().
-	//
-	// So "ab cd" vs "ab\tcd" with whitespace ignored still produces a
-	// REPLACE for the differing byte at position 2 -- the ratio is the
-	// same as without the callback. We assert (1) the ignore call
-	// succeeds, (2) the result is in [0, 1], and (3) the ratio is no
-	// worse than the plain ratio.
-	const ut8 *a = (const ut8 *)"ab cd";
-	const ut8 *b = (const ut8 *)"ab\tcd";
-
-	RzDiff *plain = rz_diff_bytes_new(a, 5, b, 5, NULL);
-	mu_assert_notnull(plain, "plain diff created");
-	double r_plain = -1.0;
-	mu_assert_true(rz_diff_ratio(plain, &r_plain), "plain ratio ok");
-	rz_diff_free(plain);
-
-	RzDiff *ign = rz_diff_bytes_new(a, 5, b, 5, ignore_whitespace_byte);
-	mu_assert_notnull(ign, "ignore diff created");
-	double r_ign = -1.0;
-	mu_assert_true(rz_diff_ratio(ign, &r_ign), "ignore ratio ok");
-	rz_diff_free(ign);
-
-	mu_assert_true(r_ign >= 0.0 && r_ign <= 1.0, "ignore ratio is a valid ratio");
-	mu_assert_true(r_ign >= r_plain, "ignoring whitespace does not decrease the ratio");
-
-	// Sanity case: when the same whitespace appears at the same offset in
-	// both buffers, the ratio is exactly 1.0 -- with or without ignore.
-	const ut8 *a2 = (const ut8 *)"ab cd";
-	const ut8 *b2 = (const ut8 *)"ab cd";
-	RzDiff *same = rz_diff_bytes_new(a2, 5, b2, 5, ignore_whitespace_byte);
-	mu_assert_notnull(same, "same-bytes diff created");
-	double r_same = -1.0;
-	mu_assert_true(rz_diff_ratio(same, &r_same), "same ratio ok");
-	mu_assert_eqf(r_same, 1.0, "ignore-whitespace on identical buffers: ratio 1.0");
-	rz_diff_free(same);
-
-	mu_end;
-}
 
 bool test_rz_diff_ignore_line(void) {
 	const char *a =
@@ -791,7 +799,7 @@ bool test_rz_diff_unified_json_smoke(void) {
 bool test_rz_diff_ratio_byte_line_agree_on_identical(void) {
 	const char *s = "alpha\nbeta\ngamma\n";
 	RzDiff *db = rz_diff_bytes_new((const ut8 *)s, (ut32)strlen(s),
-		(const ut8 *)s, (ut32)strlen(s), NULL);
+		(const ut8 *)s, (ut32)strlen(s));
 	RzDiff *dl = rz_diff_lines_new(s, s, NULL);
 	mu_assert_notnull(db, "bytes diff created");
 	mu_assert_notnull(dl, "lines diff created");
@@ -815,7 +823,7 @@ bool test_rz_diff_single_element(void) {
 	// Single-byte identical.
 	{
 		const ut8 *a = (const ut8 *)"x";
-		RzDiff *d = rz_diff_bytes_new(a, 1, a, 1, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, 1, a, 1);
 		mu_assert_notnull(d, "diff 1-byte identical");
 		double r = 0.0;
 		mu_assert_true(rz_diff_ratio(d, &r), "ratio ok");
@@ -827,7 +835,7 @@ bool test_rz_diff_single_element(void) {
 	{
 		const ut8 *a = (const ut8 *)"x";
 		const ut8 *b = (const ut8 *)"y";
-		RzDiff *d = rz_diff_bytes_new(a, 1, b, 1, NULL);
+		RzDiff *d = rz_diff_bytes_new(a, 1, b, 1);
 		mu_assert_notnull(d, "diff 1-byte different");
 		double r = 1.0;
 		mu_assert_true(rz_diff_ratio(d, &r), "ratio ok");
@@ -871,7 +879,7 @@ bool test_rz_diff_stress_medium(void) {
 		b[i] ^= 0xff;
 	}
 
-	RzDiff *d = rz_diff_bytes_new(a, size, b, size, NULL);
+	RzDiff *d = rz_diff_bytes_new(a, size, b, size);
 	mu_assert_notnull(d, "stress diff created");
 
 	RzList *matches = rz_diff_matches_new(d);
@@ -914,7 +922,7 @@ bool test_rz_diff_all_zeros_pathological(void) {
 	memset(b, 0, size);
 	b[size / 2] = 0x01;
 
-	RzDiff *d = rz_diff_bytes_new(a, size, b, size, NULL);
+	RzDiff *d = rz_diff_bytes_new(a, size, b, size);
 	mu_assert_notnull(d, "all-zeros diff created");
 
 	double r = 0.0;
@@ -981,7 +989,7 @@ bool test_rz_diff_repeating_pattern(void) {
 	b[size / 2] = 'Z';
 	b[size * 3 / 4] = 'Z';
 
-	RzDiff *d = rz_diff_bytes_new(a, size, b, size, NULL);
+	RzDiff *d = rz_diff_bytes_new(a, size, b, size);
 	mu_assert_notnull(d, "repeating-pattern diff");
 
 	double r = 0.0;
@@ -1014,7 +1022,7 @@ bool test_rz_diff_firmware_like_structure(void) {
 		v2[prefix + i] = (ut8)(0xff - i);
 	}
 
-	RzDiff *d = rz_diff_bytes_new(v1, size, v2, size, NULL);
+	RzDiff *d = rz_diff_bytes_new(v1, size, v2, size);
 	mu_assert_notnull(d, "firmware-like diff");
 
 	RzList *ops = rz_diff_opcodes_new(d);
@@ -1060,7 +1068,7 @@ bool test_rz_diff_block_shift(void) {
 	memcpy(b + 300 - 64, a + 100, 64);
 	memcpy(b + 300, a + 300, size - 300);
 
-	RzDiff *d = rz_diff_bytes_new(a, size, b, size, NULL);
+	RzDiff *d = rz_diff_bytes_new(a, size, b, size);
 	mu_assert_notnull(d, "block-shift diff");
 
 	double r = 0.0;
@@ -1095,7 +1103,7 @@ bool test_rz_diff_growing_buffer(void) {
 	const ut8 *a = (const ut8 *)"prefix_middle_suffix";
 	const ut8 *b = (const ut8 *)"prefix_middle_INSERTED_suffix";
 	RzDiff *d = rz_diff_bytes_new(a, (ut32)strlen((const char *)a),
-		b, (ut32)strlen((const char *)b), NULL);
+		b, (ut32)strlen((const char *)b));
 	mu_assert_notnull(d, "growing-buffer diff");
 
 	RzList *ops = rz_diff_opcodes_new(d);
@@ -1136,7 +1144,7 @@ bool test_rz_diff_long_common_prefix(void) {
 		b[prefix_len + i] = 0x20;
 	}
 
-	RzDiff *d = rz_diff_bytes_new(a, prefix_len + tail_len, b, prefix_len + tail_len, NULL);
+	RzDiff *d = rz_diff_bytes_new(a, prefix_len + tail_len, b, prefix_len + tail_len);
 	mu_assert_notnull(d, "long-prefix diff");
 
 	RzList *ops = rz_diff_opcodes_new(d);
@@ -1171,7 +1179,6 @@ int all_tests() {
 	mu_run_test(test_rz_diff_opcodes_grouped_replace);
 	mu_run_test(test_rz_diff_ratio_bounds);
 	mu_run_test(test_rz_diff_sizes_ratio_skewed);
-	mu_run_test(test_rz_diff_ignore_byte);
 	mu_run_test(test_rz_diff_ignore_line);
 	mu_run_test(test_rz_diff_generic_ints);
 	mu_run_test(test_rz_diff_generic_ints_modified);


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

## Before

```
Benchmark                                                     | Iterations | Total time [ms] | Throughput [iterations/sec] | Mean [us/iteration] | Standard Deviation | Mean (geometric) | Std. Dev (geometric) 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[RzDiff] rz_diff_bytes_new (similar, 4KB)                             1024        245.968000                   4163.143173            240.087891            15.826454         239.592368               1.065986
[RzDiff] rz_diff_bytes_new (divergent, 4KB)                           1024        227.153000                   4507.974801            221.745117            11.226907         221.481846               1.049092
[RzDiff] rz_diff_matches_new (similar, 256B)                          8192        682.802000                  11997.621565             83.270630             6.737990          83.035619               1.075715
[RzDiff] rz_diff_matches_new (similar, 4KB)                             64       1118.692000                     57.209670          17479.406250           348.253263       17475.822331               1.020797
[RzDiff] rz_diff_matches_new (divergent, 4KB)                           64        871.504000                     73.436267          13617.156250           152.716569       13616.302370               1.011343
[RzDiff] rz_diff_opcodes_new (similar, 4KB)                             64       1116.658000                     57.313878          17447.656250           180.929045       17446.717591               1.010512
[RzDiff] rz_diff_opcodes_grouped_new (similar, 4KB)                     64       1120.524000                     57.116135          17508.000000           281.855792       17505.781302               1.016087
[RzDiff] rz_diff_ratio (similar, 4KB)                                   64       1098.424000                     58.265296          17162.718750           474.287277       17156.102063               1.028458
[RzDiff] rz_diff_unified_text bytes (similar, 4KB)                      64       1100.616000                     58.149255          17197.031250           632.701622       17185.871426               1.036595
[RzDiff] rz_diff_unified_text bytes (similar, 32KB)                      8      10667.380000                      0.749950        1333421.125000         17960.257915     1333299.520343               1.014563
[RzDiff] rz_diff_matches_new lines (~200 lines, 10% changed)            64         18.011000                   3553.384043            281.328125            14.151032         280.983093               1.050818
[RzDiff] rz_diff_unified_text lines (~200 lines, 10% changed)           64         19.170000                   3338.549817            299.453125             4.447365         299.420654               1.014891
[RzDiff] rz_diff_myers_distance (similar, 256B)                       1024          0.674000                1519287.833828              0.633008             0.454904           0.387992               3.116630
[RzDiff] rz_diff_myers_distance (divergent, 256B)                       64          8.737000                   7325.168822            136.437500             5.012095         136.346661               1.037347
[RzDiff] rz_diff_levenshtein_distance (similar, 256B)                 1024        154.556000                   6625.430265            150.875977             9.459270         150.591704               1.062727
[RzDiff] rz_diff_levenshtein_distance (divergent, 256B)                 64         10.022000                   6385.950908            156.562500             3.872479         156.516061               1.024665
[RzDiff] rz_diff_hash_data (64B)                                    200000         21.431000                9332275.675423              0.150798             0.208137           0.113863               1.701048
[RzDiff] rz_diff_hash_data (1KB)                                    200000        154.734000                1292540.747347              0.744516             0.414458           0.518209               2.833861
[RzDiff] torture: firmware v1 vs v2 (8KB, mostly identical)              3       1021.658000                      2.936403         340551.666667           474.465547      340551.335974               1.001708
[RzDiff] torture: firmware v1 vs v2 (8KB, matches only)                  3       1017.927000                      2.947166         339308.333333          1278.180304      339305.923951               1.004627
[RzDiff] torture: big exec (8KB, .text churn)                            3        289.637000                     10.357793          96545.666667           112.221012       96545.601410               1.001425
[RzDiff] torture: big exec ratio (8KB)                                   3        289.338000                     10.368496          96445.666667           391.483787       96444.871353               1.004987
[RzDiff] torture: memdump (8KB, sparse, few pages changed)               3        606.764000                      4.944262         202254.000000           734.566993      202252.663961               1.004463
[RzDiff] torture: block shift (16KB, 1KB moved)                          3       1598.180000                      1.877135         532726.333333          2178.307039      532721.880732               1.005020
[RzDiff] torture: short repeating pattern (2KB)                          8        674.488000                     11.860849          84310.875000           180.830333       84310.680997               1.002296
[RzDiff] torture: all-zeros adversary (2KB)                              3        710.431000                      4.222789         236809.666667           870.963196      236808.067765               1.004509
[RzDiff] torture: myers distance firmware-like (4KB)                     3          2.207000                   1359.311282            735.333333             7.930252         735.290697               1.013267
[RzDiff] torture: levenshtein distance firmware-like (4KB)               3        255.579000                     11.738054          85192.666667           148.919068       85192.536428               1.002144
```

## After

```
Benchmark                                                     | Iterations | Total time [ms] | Throughput [iterations/sec] | Mean [us/iteration] | Standard Deviation | Mean (geometric) | Std. Dev (geometric) 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[RzDiff] rz_diff_bytes_new (similar, 4KB)                             1024          0.101000               10138613.861386              0.135254             0.179836           0.109240               1.560267
[RzDiff] rz_diff_bytes_new (divergent, 4KB)                           1024          0.090000               11377777.777778              0.126367             0.151774           0.106979               1.474755
[RzDiff] rz_diff_matches_new (similar, 256B)                          8192         18.923000                 432912.328912              2.244507             3.410463           2.157369               1.221087
[RzDiff] rz_diff_matches_new (similar, 4KB)                             64          3.085000                  20745.542950             48.109375             4.905727          47.905353               1.092619
[RzDiff] rz_diff_matches_new (divergent, 4KB)                           64         29.550000                   2165.820643            461.203125            25.889899         460.543917               1.054080
[RzDiff] rz_diff_opcodes_new (similar, 4KB)                             64          3.934000                  16268.429080             61.421875             4.602325          61.260442               1.074839
[RzDiff] rz_diff_opcodes_grouped_new (similar, 4KB)                     64          6.032000                  10610.079576             94.171875             6.672131          93.956494               1.069015
[RzDiff] rz_diff_ratio (similar, 4KB)                                   64          2.983000                  21454.911163             46.500000             4.475628          46.312187               1.091717
[RzDiff] rz_diff_unified_text bytes (similar, 4KB)                      64         19.814000                   3230.039366            309.484375            11.370181         309.283652               1.036630
[RzDiff] rz_diff_unified_text bytes (similar, 32KB)                      8         10.623000                    753.082933           1327.625000            44.757506        1326.879803               1.036364
[RzDiff] rz_diff_matches_new lines (~200 lines, 10% changed)            64         16.852000                   3797.768811            263.218750             7.833160         263.105011               1.029904
[RzDiff] rz_diff_unified_text lines (~200 lines, 10% changed)           64         19.288000                   3318.125259            301.218750             7.525932         301.125052               1.025444
[RzDiff] rz_diff_myers_distance (similar, 256B)                       1024          0.660000                1551515.151515              0.620020             0.465341           0.373798               3.140281
[RzDiff] rz_diff_myers_distance (divergent, 256B)                       64          8.032000                   7968.127490            125.375000             5.660996         125.254079               1.044671
[RzDiff] rz_diff_levenshtein_distance (similar, 256B)                 1024        156.856000                   6528.280716            153.084961            13.526075         152.473120               1.094397
[RzDiff] rz_diff_levenshtein_distance (divergent, 256B)                 64          9.664000                   6622.516556            150.906250            11.061926         150.517531               1.074276
[RzDiff] rz_diff_hash_data (64B)                                    200000         20.649000                9685699.065330              0.148178             0.202888           0.113106               1.678981
[RzDiff] rz_diff_hash_data (1KB)                                    200000        160.651000                1244934.672053              0.755326             0.409725           0.532437               2.797215
[RzDiff] torture: firmware v1 vs v2 (8KB, mostly identical)              3          0.617000                   4862.236629            205.666667            27.108834         203.977122               1.167869
[RzDiff] torture: firmware v1 vs v2 (8KB, matches only)                  3          0.171000                  17543.859649             57.000000             0.816497          56.994151               1.017701
[RzDiff] torture: big exec (8KB, .text churn)                            3          0.120000                  25000.000000             40.000000             0.816497          39.991665               1.025321
[RzDiff] torture: big exec ratio (8KB)                                   3          0.122000                  24590.163934             40.666667             4.496913          40.429130               1.140083
[RzDiff] torture: memdump (8KB, sparse, few pages changed)               3          3.530000                    849.858357           1176.666667             2.867442        1176.663172               1.002990
[RzDiff] torture: block shift (16KB, 1KB moved)                          3          3.777000                    794.281176           1259.000000             8.286535        1258.972687               1.008103
[RzDiff] torture: short repeating pattern (2KB)                          8          0.012000                 666666.666667              1.500000             0.500000           1.414214               1.448463
[RzDiff] torture: all-zeros adversary (2KB)                              3          0.002000                1500000.000000              0.700000             0.424264           0.464159               3.778768
[RzDiff] torture: myers distance firmware-like (4KB)                     3          2.075000                   1445.783133            691.666667             6.599663         691.635120               1.011772
[RzDiff] torture: levenshtein distance firmware-like (4KB)               3        241.552000                     12.419686          80517.000000           218.088667       80516.704432               1.003325
```