### PR TITLE
Add order ignoring remove_at version with better performance.

### DIFF
--- a/librz/include/rz_vector.h
+++ b/librz/include/rz_vector.h
@@ -120,6 +120,8 @@ static inline void *rz_vector_tail(RzVector *vec) {
 
 RZ_API void *rz_vector_assign_at(RZ_BORROW RzVector *vec, size_t index, RZ_NULLABLE const void *elem);
 
+RZ_API void rz_vector_remove_at_unsorted(RZ_BORROW RzVector *vec, size_t index, RZ_NULLABLE RZ_OUT void *into);
+
 // remove the element at the given index and write the content to into.
 // It is the caller's responsibility to free potential resources associated with the element.
 RZ_API void rz_vector_remove_at(RzVector *vec, size_t index, void *into);
@@ -335,6 +337,7 @@ RZ_API void *rz_pvector_assign_at(RZ_BORROW RZ_NONNULL RzPVector *vec, size_t in
 
 // removes and returns the pointer at the given index. Does not call free.
 RZ_API void *rz_pvector_remove_at(RzPVector *vec, size_t index);
+RZ_API void *rz_pvector_remove_at_unsorted(RZ_BORROW RzPVector *vec, size_t index);
 
 /**
  * \brief Deletes all pointers in the vector. Capacity stays the same.

--- a/librz/util/vector.c
+++ b/librz/util/vector.c
@@ -246,6 +246,28 @@ RZ_API void *rz_vector_assign_at(RZ_BORROW RzVector *vec, size_t index, RZ_NULLA
 	return p;
 }
 
+/**
+ * \brief Removes the element at the given index.
+ * This function will not keep the order of the elements.
+ * Due to this, it won't use memmove and has much better
+ * performance than rz_vector_remove_at().
+ *
+ * \param vec The vector to remove the element from.
+ * \param index The index of the element to remove.
+ * \param into Optional pointer to copy the removed element into.
+ */
+RZ_API void rz_vector_remove_at_unsorted(RZ_BORROW RzVector *vec, size_t index, RZ_OUT RZ_NULLABLE void *into) {
+	rz_return_if_fail(vec);
+	if (rz_vector_empty(vec)) {
+		return;
+	}
+	size_t l = rz_vector_len(vec) - 1;
+	if (index < l) {
+		rz_vector_swap(vec, index, l);
+	}
+	rz_vector_pop(vec, into);
+}
+
 RZ_API void rz_vector_remove_at(RzVector *vec, size_t index, void *into) {
 	if (rz_vector_empty(vec)) {
 		return;
@@ -740,6 +762,24 @@ RZ_API void *rz_pvector_assign_at(RZ_BORROW RZ_NONNULL RzPVector *vec, size_t in
 	void *prev = !p || increased_len ? NULL : *p;
 	rz_vector_assign_at(&vec->v, index, &ptr);
 	return prev;
+}
+
+/**
+ * \brief Removes the element at the given index.
+ * This function will not keep the order of the elements.
+ * Due to this, it won't use memmove and has much better
+ * performance than rz_pvector_remove_at().
+ *
+ * \param vec The vector to remove the element from.
+ * \param index The index of the element to remove.
+ *
+ * \return The removed pointer. Or NULL in case of failure.
+ */
+RZ_API void *rz_pvector_remove_at_unsorted(RZ_BORROW RzPVector *vec, size_t index) {
+	rz_return_val_if_fail(vec, NULL);
+	void *r = rz_pvector_at(vec, index);
+	rz_vector_remove_at_unsorted(&vec->v, index, NULL);
+	return r;
 }
 
 RZ_API void *rz_pvector_remove_at(RzPVector *vec, size_t index) {

--- a/librz/util/vector.c
+++ b/librz/util/vector.c
@@ -34,6 +34,8 @@
 #define RESIZE_OR_RETURN_NULL(next_capacity)  RESIZE_OR_RETURN_VAL(next_capacity, NULL)
 #define RESIZE_OR_RETURN_FALSE(next_capacity) RESIZE_OR_RETURN_VAL(next_capacity, false)
 
+#define RZ_VECTOR_SWAP_TMP_SIZE 256
+
 RZ_API void rz_vector_init(RzVector *vec, size_t elem_size, RzVectorFree free, void *free_user) {
 	rz_return_if_fail(vec);
 	vec->a = NULL;
@@ -492,18 +494,37 @@ RZ_API bool rz_vector_contains(const RZ_NONNULL RzVector *vec, const RZ_NONNULL 
 	return false;
 }
 
+/**
+ * \brief Swaps two elements in the vector.
+ *
+ * \param vec The vector to swap elements in.
+ * \param index_a The index of an element.
+ * \param index_b The index of another element.
+ *
+ * \return True if elements were swapped. False in case of error.
+ */
 RZ_API bool rz_vector_swap(RzVector *vec, size_t index_a, size_t index_b) {
 	rz_return_val_if_fail(vec && index_a < vec->len && index_b < vec->len, false);
-	ut8 *tmp = malloc(vec->elem_size);
-	if (!tmp) {
-		return false;
+	if (index_a == index_b) {
+		return true;
 	}
 	void *elem_a = rz_vector_index_ptr(vec, index_a);
 	void *elem_b = rz_vector_index_ptr(vec, index_b);
+
+	ut8 stack_tmp[RZ_VECTOR_SWAP_TMP_SIZE];
+	void *tmp = vec->elem_size <= sizeof(stack_tmp) ? stack_tmp : malloc(vec->elem_size);
+	if (RZ_UNLIKELY(!tmp)) {
+		rz_warn_if_reached();
+		return false;
+	}
+
 	memcpy(tmp, elem_a, vec->elem_size);
 	memcpy(elem_a, elem_b, vec->elem_size);
 	memcpy(elem_b, tmp, vec->elem_size);
-	free(tmp);
+
+	if (tmp != stack_tmp) {
+		free(tmp);
+	}
 	return true;
 }
 

--- a/test/bench/bench_vector.c
+++ b/test/bench/bench_vector.c
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Rot127 <rot127@posteo.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_util/rz_table.h>
+#include <rz_util/rz_graph.h>
+
+#include "bench_utils.h"
+#include "rz_util/rz_num.h"
+#include "rz_vector.h"
+
+/**
+ * \file bench_vector.c
+ * \brief Benchmark for graph functions
+ */
+
+#define ITERATION_COUNT 200000
+
+static void bench_rz_vector_remove_at(RzTable *t_out) {
+	RzVector *v = rz_vector_new(sizeof(ut64), NULL, NULL);
+
+	for (size_t i = 0; i < ITERATION_COUNT; ++i) {
+		rz_vector_push(v, &i);
+	}
+
+	{
+		RZ_BENCH_RUN_I("[RzVector] rz_vector_remove_at_unsorted", i, t_out, ITERATION_COUNT, {
+			size_t index = rz_num_rand32(ITERATION_COUNT - 1 - i);
+			rz_vector_remove_at_unsorted(v, index, NULL);
+		});
+	}
+
+	rz_vector_clear(v);
+	for (size_t i = 0; i < ITERATION_COUNT; ++i) {
+		rz_vector_push(v, &i);
+	}
+
+	{
+		RZ_BENCH_RUN_I("[RzVector] rz_vector_remove_at", i, t_out, ITERATION_COUNT, {
+			size_t index = rz_num_rand32(ITERATION_COUNT - 1 - i);
+			rz_vector_remove_at(v, index, NULL);
+		});
+	}
+	rz_vector_free(v);
+}
+
+int main() {
+	RzTable *t = rz_table_new();
+	RZ_BENCH_TABLE_INIT(t);
+
+	// Micro benchmarks
+	bench_rz_vector_remove_at(t);
+
+	// Print results
+	RZ_BENCH_TABLE_PRINT_AND_FREE(t);
+	return 0;
+}

--- a/test/bench/bench_vector.c
+++ b/test/bench/bench_vector.c
@@ -43,12 +43,31 @@ static void bench_rz_vector_remove_at(RzTable *t_out) {
 	rz_vector_free(v);
 }
 
+static void bench_rz_vector_swap(RzTable *t_out) {
+	RzVector *v = rz_vector_new(sizeof(ut64), NULL, NULL);
+
+	for (size_t i = 0; i < ITERATION_COUNT; ++i) {
+		rz_vector_push(v, &i);
+	}
+
+	{
+		RZ_BENCH_RUN_I("[RzVector] rz_vector_swap", i, t_out, ITERATION_COUNT, {
+			size_t index_a = rz_num_rand32(ITERATION_COUNT - 1);
+			size_t index_b = rz_num_rand32(ITERATION_COUNT - 1);
+			rz_vector_swap(v, index_a, index_b);
+		});
+	}
+
+	rz_vector_free(v);
+}
+
 int main() {
 	RzTable *t = rz_table_new();
 	RZ_BENCH_TABLE_INIT(t);
 
 	// Micro benchmarks
 	bench_rz_vector_remove_at(t);
+	bench_rz_vector_swap(t);
 
 	// Print results
 	RZ_BENCH_TABLE_PRINT_AND_FREE(t);

--- a/test/bench/meson.build
+++ b/test/bench/meson.build
@@ -23,6 +23,7 @@ if get_option('enable_benchmarks')
     'il',
     'ht',
     'util',
+    'vector',
     'list'
   ]
 

--- a/test/unit/test_vector.c
+++ b/test/unit/test_vector.c
@@ -425,6 +425,36 @@ static bool test_vector_remove_at(void) {
 	mu_end;
 }
 
+static bool test_vector_remove_at_unsorted(void) {
+	RzVector v = { 0 };
+	// Check it doesn't read/writes OOB.
+	rz_vector_remove_at_unsorted(&v, 0, NULL);
+
+	init_test_vector(&v, 5, 0, NULL, NULL);
+
+	ut32 e;
+	rz_vector_remove_at_unsorted(&v, 2, &e);
+	mu_assert_eq(e, 2, "rz_vector_remove_at_unsorted => into");
+	mu_assert_eq(v.len, 4UL, "rz_vector_remove_at_unsorted => len");
+
+	mu_assert_eq(((ut32 *)v.a)[0], 0, "rz_vector_remove_at_unsorted => remaining elements");
+	mu_assert_eq(((ut32 *)v.a)[1], 1, "rz_vector_remove_at_unsorted => remaining elements");
+	mu_assert_eq(((ut32 *)v.a)[2], 4, "rz_vector_remove_at_unsorted => remaining elements");
+	mu_assert_eq(((ut32 *)v.a)[3], 3, "rz_vector_remove_at_unsorted => remaining elements");
+
+	rz_vector_remove_at_unsorted(&v, 3, &e);
+	mu_assert_eq(e, 3, "rz_vector_remove_at_unsorted (end) => into");
+	mu_assert_eq(v.len, 3UL, "rz_vector_remove_at_unsorted (end) => len");
+
+	mu_assert_eq(((ut32 *)v.a)[0], 0, "rz_vector_remove_at_unsorted (end) => remaining elements");
+	mu_assert_eq(((ut32 *)v.a)[1], 1, "rz_vector_remove_at_unsorted (end) => remaining elements");
+	mu_assert_eq(((ut32 *)v.a)[2], 4, "rz_vector_remove_at_unsorted (end) => remaining elements");
+
+	rz_vector_clear(&v);
+
+	mu_end;
+}
+
 static bool test_vector_remove_range(void) {
 	RzVector v;
 	init_test_vector(&v, 5, 0, NULL, NULL);
@@ -1177,6 +1207,31 @@ static bool test_pvector_remove_at(void) {
 	mu_end;
 }
 
+static bool test_pvector_remove_at_unsorted(void) {
+	RzPVector v;
+	init_test_pvector(&v, 5, 0);
+
+	ut32 *e = rz_pvector_remove_at_unsorted(&v, 0);
+	mu_assert_eq(*e, 0, "remove_at_unsorted ret");
+	free(e);
+	mu_assert_eq(v.v.len, 4UL, "remove_at_unsorted => len");
+	mu_assert_eq(*((ut32 **)v.v.a)[0], 4, "remove_at_unsorted => remaining content");
+	mu_assert_eq(*((ut32 **)v.v.a)[1], 1, "remove_at_unsorted => remaining content");
+	mu_assert_eq(*((ut32 **)v.v.a)[2], 2, "remove_at_unsorted => remaining content");
+	mu_assert_eq(*((ut32 **)v.v.a)[3], 3, "remove_at_unsorted => remaining content");
+
+	e = rz_pvector_remove_at_unsorted(&v, 3);
+	mu_assert_eq(*e, 3, "remove_at_unsorted ret");
+	free(e);
+	mu_assert_eq(v.v.len, 3UL, "remove_at_unsorted => len");
+	mu_assert_eq(*((ut32 **)v.v.a)[0], 4, "remove_at_unsorted => remaining content");
+	mu_assert_eq(*((ut32 **)v.v.a)[1], 1, "remove_at_unsorted => remaining content");
+	mu_assert_eq(*((ut32 **)v.v.a)[2], 2, "remove_at_unsorted => remaining content");
+
+	rz_pvector_clear(&v);
+	mu_end;
+}
+
 // clang-format off
 static bool test_pvector_insert(void) {
 	RzPVector v;
@@ -1653,6 +1708,7 @@ static int all_tests(void) {
 	mu_run_test(test_vector_clone);
 	mu_run_test(test_vector_empty);
 	mu_run_test(test_vector_remove_at);
+	mu_run_test(test_vector_remove_at_unsorted);
 	mu_run_test(test_vector_sort);
 	mu_run_test(test_vector_remove_range);
 	mu_run_test(test_vector_insert);
@@ -1683,6 +1739,7 @@ static int all_tests(void) {
 	mu_run_test(test_pvector_join);
 	mu_run_test(test_pvector_contains);
 	mu_run_test(test_pvector_remove_at);
+	mu_run_test(test_pvector_remove_at_unsorted);
 	mu_run_test(test_pvector_assign_at);
 	mu_run_test(test_pvector_insert);
 	mu_run_test(test_pvector_insert_range);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Pretty obviously better:

```
Benchmark                               Iterations Total time [ms] Avg iter time [us/iteration] Throughput [iterations/sec] 
----------------------------------------------------------------------------------------------------------------------------
[RzVector] rz_vector_remove_at_unsorted     200000       17.537000                     0.087685             11404459.143525
[RzVector] rz_vector_remove_at              200000     1686.951000                     8.434755               118557.089092
```

The `swap` improvements bring nothing. I guess the super small allocations are simply done in the CPU cache. But I'd like to run them again with https://github.com/rizinorg/rizin/pull/6390 merged to see what how the SD changes.

New:

```
./build_release/test/bench/bench_vector
Benchmark                               Iterations Total time [ms] Avg iter time [us/iteration] Throughput [iterations/sec] 
----------------------------------------------------------------------------------------------------------------------------
[RzVector] rz_vector_swap                   200000       17.387000                     0.086935             11502846.954621
```

Old:

```
./build_release/test/bench/bench_vector
Benchmark                               Iterations Total time [ms] Avg iter time [us/iteration] Throughput [iterations/sec] 
----------------------------------------------------------------------------------------------------------------------------
[RzVector] rz_vector_swap                   200000       19.473000                     0.097365             10270631.130283
```

Funnily enough the AI didn't suggest it in https://github.com/rizinorg/rizin/issues/6096
But only in https://github.com/rizinorg/rizin/issues/6181 in respect to graphs. And suggesting a graph specific implementation.

Guess our AI overlords need a little more time and access to the bigger picture to do the overlording.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Added

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
