### PR TITLE
Measure standard deviation for benchmarks

### DIFF
--- a/librz/include/rz_math.h
+++ b/librz/include/rz_math.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Rot127 <rot127@posteo.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef RZ_MATH_H
+#define RZ_MATH_H
+
+#include <rz_types.h>
+
+/**
+ * \brief A Welford Variance implementation taken from
+ * https://www.johndcook.com/blog/standard_deviation/
+ */
+typedef struct {
+	ut64 n; ///< Number of variables
+	double old_mean; ///< The mean before a variable is added.
+	double new_mean; ///< The mean after a variable was added.
+	double oldS; ///< Sum of squares before a variable is added.
+	double newS; ///< Sum of squares after a variable was added.
+} RzMathWelfordSums;
+
+RZ_API void rz_math_welford_init(RZ_BORROW RzMathWelfordSums *wf);
+RZ_API void rz_math_welford_clear(RZ_BORROW RzMathWelfordSums *wf);
+RZ_API void rz_math_welford_push(RZ_BORROW RzMathWelfordSums *wf, double var);
+RZ_API ut64 rz_math_welford_n(const RzMathWelfordSums *wf);
+RZ_API double rz_math_welford_mean(const RzMathWelfordSums *wf);
+RZ_API double rz_math_welford_variance(const RzMathWelfordSums *wf);
+RZ_API double rz_math_welford_std_deviation(const RzMathWelfordSums *wf);
+RZ_API double rz_math_welford_sum_of_squares(const RzMathWelfordSums *wf);
+
+#endif // RZ_MATH_H

--- a/librz/include/rz_util.h
+++ b/librz/include/rz_util.h
@@ -48,6 +48,7 @@
 #include <rz_util/rz_lang_byte_array.h>
 #include <rz_util/rz_log.h>
 #include <rz_util/rz_luhn.h>
+#include <rz_util/rz_math.h>
 #include <rz_util/rz_mem.h>
 #include <rz_util/rz_name.h>
 #include <rz_util/rz_num.h>

--- a/librz/include/rz_util/rz_math.h
+++ b/librz/include/rz_util/rz_math.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Rot127 <rot127@posteo.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef RZ_MATH_H
+#define RZ_MATH_H
+
+#include <rz_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief A Welford Variance implementation take from
+ * https://www.johndcook.com/blog/standard_deviation/
+ */
+typedef struct {
+	ut64 n; ///< Number of variables
+	double old_mean; ///< The mean before a variable is added.
+	double new_mean; ///< The mean after a variable was added.
+	double oldS; ///< Sum of squares before a variable is added.
+	double newS; ///< Sum of squares after a variable was added.
+} RzMathWelfordSums;
+
+RZ_API void rz_math_welford_init(RZ_BORROW RzMathWelfordSums *wf);
+RZ_API void rz_math_welford_clear(RZ_BORROW RzMathWelfordSums *wf);
+RZ_API void rz_math_welford_push(RZ_BORROW RzMathWelfordSums *wf, double var);
+RZ_API ut64 rz_math_welford_n(const RzMathWelfordSums *wf);
+RZ_API double rz_math_welford_mean(const RzMathWelfordSums *wf);
+RZ_API double rz_math_welford_variance(const RzMathWelfordSums *wf);
+RZ_API double rz_math_welford_std_deviation(const RzMathWelfordSums *wf);
+RZ_API double rz_math_welford_sum_of_squares(const RzMathWelfordSums *wf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RZ_MATH_H

--- a/librz/include/rz_util/rz_math.h
+++ b/librz/include/rz_util/rz_math.h
@@ -11,23 +11,31 @@ extern "C" {
 #endif
 
 /**
- * \brief A Welford Variance implementation take from
+ * \brief A Welford Sums of Squares implementation take from
  * https://www.johndcook.com/blog/standard_deviation/
+ * doi: http://dx.doi.org/10.1080/00401706.1962.10490022
  */
 typedef struct {
 	ut64 n; ///< Number of variables
 	double amean; ///< The arithmetic mean of the variables.
-	double sums; ///< Sum of squares.
+	double asums; ///< Sum of squares.
+	double gmean; ///< Geometric mean
+	double ln_v_sums; ///< Geometric sum of ln(x_i)
+	double gsums; ///< Geometric sums of squares
 } RzMathWelfordSums;
 
 RZ_API void rz_math_welford_init(RZ_BORROW RzMathWelfordSums *wf);
 RZ_API void rz_math_welford_clear(RZ_BORROW RzMathWelfordSums *wf);
 RZ_API void rz_math_welford_push(RZ_BORROW RzMathWelfordSums *wf, double var);
 RZ_API ut64 rz_math_welford_n(const RzMathWelfordSums *wf);
-RZ_API double rz_math_welford_mean(const RzMathWelfordSums *wf);
-RZ_API double rz_math_welford_variance(const RzMathWelfordSums *wf);
-RZ_API double rz_math_welford_std_deviation(const RzMathWelfordSums *wf);
-RZ_API double rz_math_welford_sum_of_squares(const RzMathWelfordSums *wf);
+RZ_API double rz_math_welford_amean(const RzMathWelfordSums *wf);
+RZ_API double rz_math_welford_avar(const RzMathWelfordSums *wf);
+RZ_API double rz_math_welford_astddev(const RzMathWelfordSums *wf);
+RZ_API double rz_math_welford_asums(const RzMathWelfordSums *wf);
+
+RZ_API double rz_math_welford_gmean(const RzMathWelfordSums *wf);
+RZ_API double rz_math_welford_gvar(const RzMathWelfordSums *wf);
+RZ_API double rz_math_welford_gstddev(const RzMathWelfordSums *wf);
 
 #ifdef __cplusplus
 }

--- a/librz/include/rz_util/rz_math.h
+++ b/librz/include/rz_util/rz_math.h
@@ -16,10 +16,8 @@ extern "C" {
  */
 typedef struct {
 	ut64 n; ///< Number of variables
-	double old_mean; ///< The mean before a variable is added.
-	double new_mean; ///< The mean after a variable was added.
-	double oldS; ///< Sum of squares before a variable is added.
-	double newS; ///< Sum of squares after a variable was added.
+	double amean; ///< The arithmetic mean of the variables.
+	double sums; ///< Sum of squares.
 } RzMathWelfordSums;
 
 RZ_API void rz_math_welford_init(RZ_BORROW RzMathWelfordSums *wf);

--- a/librz/util/math.c
+++ b/librz/util/math.c
@@ -18,16 +18,16 @@ RZ_API void rz_math_welford_push(RZ_BORROW RzMathWelfordSums *wf, double var) {
 	wf->n++;
 
 	// See Knuth TAOCP vol 2, 3rd edition, page 232
+	double old_mean;
+	double oldS;
 	if (wf->n == 1) {
-		wf->old_mean = wf->new_mean = var;
-		wf->oldS = 0.0;
+		old_mean = wf->amean = var;
+		wf->sums = 0.0;
 	} else {
-		wf->new_mean = wf->old_mean + (var - wf->old_mean) / wf->n;
-		wf->newS = wf->oldS + (var - wf->old_mean) * (var - wf->new_mean);
-
-		// set up for next iteration
-		wf->old_mean = wf->new_mean;
-		wf->oldS = wf->newS;
+		old_mean = wf->amean;
+		oldS = wf->sums;
+		wf->amean = old_mean + (var - old_mean) / wf->n;
+		wf->sums = oldS + (var - old_mean) * (var - wf->amean);
 	}
 }
 
@@ -38,12 +38,12 @@ RZ_API ut64 rz_math_welford_n(const RzMathWelfordSums *wf) {
 
 RZ_API double rz_math_welford_mean(const RzMathWelfordSums *wf) {
 	rz_return_val_if_fail(wf, 0.0);
-	return (wf->n > 0) ? wf->new_mean : 0.0;
+	return (wf->n > 0) ? wf->amean : 0.0;
 }
 
 RZ_API double rz_math_welford_variance(const RzMathWelfordSums *wf) {
 	rz_return_val_if_fail(wf, 0.0);
-	return ((wf->n > 1) ? wf->newS / (wf->n - 1) : 0.0);
+	return ((wf->n > 1) ? wf->sums / (wf->n - 1) : 0.0);
 }
 
 RZ_API double rz_math_welford_std_deviation(const RzMathWelfordSums *wf) {
@@ -53,5 +53,5 @@ RZ_API double rz_math_welford_std_deviation(const RzMathWelfordSums *wf) {
 
 RZ_API double rz_math_welford_sum_of_squares(const RzMathWelfordSums *wf) {
 	rz_return_val_if_fail(wf, 0.0);
-	return wf->newS;
+	return wf->sums;
 }

--- a/librz/util/math.c
+++ b/librz/util/math.c
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Rot127 <rot127@posteo.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_util.h>
+
+RZ_API void rz_math_welford_init(RZ_BORROW RzMathWelfordSums *wf) {
+	rz_return_if_fail(wf);
+	memset(wf, 0, sizeof(RzMathWelfordSums));
+}
+
+RZ_API void rz_math_welford_clear(RZ_BORROW RzMathWelfordSums *wf) {
+	rz_return_if_fail(wf);
+	memset(wf, 0, sizeof(RzMathWelfordSums));
+}
+
+RZ_API void rz_math_welford_push(RZ_BORROW RzMathWelfordSums *wf, double var) {
+	rz_return_if_fail(wf);
+	wf->n++;
+
+	// See Knuth TAOCP vol 2, 3rd edition, page 232
+	if (wf->n == 1) {
+		wf->old_mean = wf->new_mean = var;
+		wf->oldS = 0.0;
+	} else {
+		wf->new_mean = wf->old_mean + (var - wf->old_mean) / wf->n;
+		wf->newS = wf->oldS + (var - wf->old_mean) * (var - wf->new_mean);
+
+		// set up for next iteration
+		wf->old_mean = wf->new_mean;
+		wf->oldS = wf->newS;
+	}
+}
+
+RZ_API ut64 rz_math_welford_n(const RzMathWelfordSums *wf) {
+	rz_return_val_if_fail(wf, 0);
+	return wf->n;
+}
+
+RZ_API double rz_math_welford_mean(const RzMathWelfordSums *wf) {
+	rz_return_val_if_fail(wf, 0.0);
+	return (wf->n > 0) ? wf->new_mean : 0.0;
+}
+
+RZ_API double rz_math_welford_variance(const RzMathWelfordSums *wf) {
+	rz_return_val_if_fail(wf, 0.0);
+	return ((wf->n > 1) ? wf->newS / (wf->n - 1) : 0.0);
+}
+
+RZ_API double rz_math_welford_std_deviation(const RzMathWelfordSums *wf) {
+	rz_return_val_if_fail(wf, 0.0);
+	return sqrt(rz_math_welford_variance(wf));
+}
+
+RZ_API double rz_math_welford_sum_of_squares(const RzMathWelfordSums *wf) {
+	rz_return_val_if_fail(wf, 0.0);
+	return wf->newS;
+}

--- a/librz/util/math.c
+++ b/librz/util/math.c
@@ -18,16 +18,24 @@ RZ_API void rz_math_welford_push(RZ_BORROW RzMathWelfordSums *wf, double var) {
 	wf->n++;
 
 	// See Knuth TAOCP vol 2, 3rd edition, page 232
-	double old_mean;
-	double oldS;
 	if (wf->n == 1) {
-		old_mean = wf->amean = var;
-		wf->sums = 0.0;
+		wf->amean = var;
+		wf->asums = 0.0;
+		wf->gmean = var;
+		wf->ln_v_sums = log(var);
+		wf->gsums = 0.0;
 	} else {
-		old_mean = wf->amean;
-		oldS = wf->sums;
-		wf->amean = old_mean + (var - old_mean) / wf->n;
-		wf->sums = oldS + (var - old_mean) * (var - wf->amean);
+		// Arithmetic
+		double old_amean = wf->amean;
+		wf->amean = old_amean + (var - old_amean) / wf->n;
+		wf->asums += (var - old_amean) * (var - wf->amean);
+
+		// Geometric
+		double old_gmean = wf->gmean;
+		wf->ln_v_sums += log(var);
+		wf->gmean = exp(wf->ln_v_sums / wf->n);
+
+		wf->gsums += log(var / old_gmean) * log(var / wf->gmean);
 	}
 }
 
@@ -36,22 +44,27 @@ RZ_API ut64 rz_math_welford_n(const RzMathWelfordSums *wf) {
 	return wf->n;
 }
 
-RZ_API double rz_math_welford_mean(const RzMathWelfordSums *wf) {
+RZ_API double rz_math_welford_amean(const RzMathWelfordSums *wf) {
 	rz_return_val_if_fail(wf, 0.0);
 	return (wf->n > 0) ? wf->amean : 0.0;
 }
 
-RZ_API double rz_math_welford_variance(const RzMathWelfordSums *wf) {
+RZ_API double rz_math_welford_gmean(const RzMathWelfordSums *wf) {
 	rz_return_val_if_fail(wf, 0.0);
-	return ((wf->n > 1) ? wf->sums / (wf->n - 1) : 0.0);
+	return (wf->n > 0) ? wf->gmean : 0.0;
 }
 
-RZ_API double rz_math_welford_std_deviation(const RzMathWelfordSums *wf) {
+RZ_API double rz_math_welford_avar(const RzMathWelfordSums *wf) {
 	rz_return_val_if_fail(wf, 0.0);
-	return sqrt(rz_math_welford_variance(wf));
+	return ((wf->n > 1) ? wf->asums / wf->n : 0.0);
 }
 
-RZ_API double rz_math_welford_sum_of_squares(const RzMathWelfordSums *wf) {
+RZ_API double rz_math_welford_astddev(const RzMathWelfordSums *wf) {
 	rz_return_val_if_fail(wf, 0.0);
-	return wf->sums;
+	return sqrt(rz_math_welford_avar(wf));
+}
+
+RZ_API double rz_math_welford_gstddev(const RzMathWelfordSums *wf) {
+	rz_return_val_if_fail(wf, 0.0);
+	return (wf->n > 1) ? exp(sqrt(wf->gsums / (wf->n - 1))) : 0.0;
 }

--- a/librz/util/meson.build
+++ b/librz/util/meson.build
@@ -35,6 +35,7 @@ rz_util_common_sources = [
   'list.c',
   'log.c',
   'luhn.c',
+  'math.c',
   'mem.c',
   'name.c',
   'path.c',

--- a/test/bench/bench_utils.c
+++ b/test/bench/bench_utils.c
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include "bench_utils.h"
-#include <stdio.h>
 
 /**
  * \brief Initialize benchmark context
@@ -38,8 +37,7 @@ RZ_API void rz_bench_report(RZ_NONNULL RzBenchCtx *ctx, RZ_NONNULL RzTable *t) {
 	rz_return_if_fail(ctx && t);
 
 	double total_ms = ctx->total_time / 1000.0;
-	double avg_us = ctx->iterations != 0 ? (double)ctx->total_time / ctx->iterations : 0;
 	double ops_per_sec = ctx->total_time != 0 ? (ctx->iterations * 1000000.0) / ctx->total_time : 0;
 
-	rz_table_add_rowf(t, "sdfff", ctx->name, (int)ctx->iterations, total_ms, avg_us, ops_per_sec);
+	rz_table_add_rowf(t, "sdffff", ctx->name, (int)ctx->iterations, total_ms, ctx->mean_us, ops_per_sec, ctx->std_dev);
 }

--- a/test/bench/bench_utils.c
+++ b/test/bench/bench_utils.c
@@ -39,5 +39,5 @@ RZ_API void rz_bench_report(RZ_NONNULL RzBenchCtx *ctx, RZ_NONNULL RzTable *t) {
 	double total_ms = ctx->total_time / 1000.0;
 	double ops_per_sec = ctx->total_time != 0 ? (ctx->iterations * 1000000.0) / ctx->total_time : 0;
 
-	rz_table_add_rowf(t, "sdffff", ctx->name, (int)ctx->iterations, total_ms, ctx->mean_us, ops_per_sec, ctx->std_dev);
+	rz_table_add_rowf(t, "sdffff", ctx->name, (int)ctx->iterations, total_ms, ctx->arith_mean_us, ops_per_sec, ctx->arith_std_dev);
 }

--- a/test/bench/bench_utils.h
+++ b/test/bench/bench_utils.h
@@ -15,8 +15,10 @@ typedef struct rz_bench_ctx_t {
 	ut64 iterations; ///< number of iterations
 	ut64 start_time; ///< start time of the benchmark in microseconds
 	ut64 total_time; ///< total elapsed time of the benchmark in microseconds
-	double mean_us; ///< The average time needed per iteration in microseconds.
-	double std_dev; ///< Standard deviation of benchmark samples in microseconds.
+	double arith_mean_us; ///< The average time needed per iteration in microseconds (arithmetic mean).
+	double arith_std_dev; ///< Arithmetic standard deviation of benchmark samples in microseconds.
+	double geo_mean_us; ///< The average time needed per iteration in microseconds (geometric mean).
+	double geo_std_dev; ///< Geometric standard deviation of benchmark samples.
 } RzBenchCtx;
 
 RZ_API void rz_bench_init(RZ_NONNULL RzBenchCtx *ctx, RZ_NONNULL const char *name, ut64 iterations);
@@ -45,8 +47,10 @@ RZ_API void rz_bench_report(RZ_NONNULL RzBenchCtx *ctx, RZ_NONNULL RzTable *t);
 			code; \
 			rz_math_welford_push(&wf, (double)(rz_time_now_mono() - spl)); \
 		} \
-		ctx.std_dev = rz_math_welford_std_deviation(&wf); \
-		ctx.mean_us = rz_math_welford_mean(&wf); \
+		ctx.arith_std_dev = rz_math_welford_astddev(&wf); \
+		ctx.arith_mean_us = rz_math_welford_amean(&wf); \
+		ctx.geo_std_dev = rz_math_welford_gstddev(&wf); \
+		ctx.geo_mean_us = rz_math_welford_gmean(&wf); \
 		rz_bench_end(&ctx); \
 		rz_bench_report(&ctx, table); \
 	} while (0)
@@ -63,8 +67,10 @@ RZ_API void rz_bench_report(RZ_NONNULL RzBenchCtx *ctx, RZ_NONNULL RzTable *t);
 			rz_math_welford_push(&wf, (double)(rz_time_now_mono() - spl)); \
 		} \
 		rz_bench_end(&ctx); \
-		ctx.std_dev = rz_math_welford_std_deviation(&wf); \
-		ctx.mean_us = rz_math_welford_mean(&wf); \
+		ctx.arith_std_dev = rz_math_welford_astddev(&wf); \
+		ctx.arith_mean_us = rz_math_welford_amean(&wf); \
+		ctx.geo_std_dev = rz_math_welford_gstddev(&wf); \
+		ctx.geo_mean_us = rz_math_welford_gmean(&wf); \
 		rz_bench_report(&ctx, table); \
 	} while (0)
 

--- a/test/bench/bench_utils.h
+++ b/test/bench/bench_utils.h
@@ -15,6 +15,8 @@ typedef struct rz_bench_ctx_t {
 	ut64 iterations; ///< number of iterations
 	ut64 start_time; ///< start time of the benchmark in microseconds
 	ut64 total_time; ///< total elapsed time of the benchmark in microseconds
+	double mean_us; ///< The average time needed per iteration in microseconds.
+	double std_dev; ///< Standard deviation of benchmark samples in microseconds.
 } RzBenchCtx;
 
 RZ_API void rz_bench_init(RZ_NONNULL RzBenchCtx *ctx, RZ_NONNULL const char *name, ut64 iterations);
@@ -34,25 +36,35 @@ RZ_API void rz_bench_report(RZ_NONNULL RzBenchCtx *ctx, RZ_NONNULL RzTable *t);
  */
 #define RZ_BENCH_RUN(name, table, iterations, code) \
 	do { \
+		RzMathWelfordSums wf = { 0 }; \
 		RzBenchCtx ctx; \
 		rz_bench_init(&ctx, name, iterations); \
 		rz_bench_start(&ctx); \
 		for (ut64 i = 0; i < iterations; i++) { \
+			ut64 spl = rz_time_now_mono(); \
 			code; \
+			rz_math_welford_push(&wf, (double)(rz_time_now_mono() - spl)); \
 		} \
+		ctx.std_dev = rz_math_welford_std_deviation(&wf); \
+		ctx.mean_us = rz_math_welford_mean(&wf); \
 		rz_bench_end(&ctx); \
 		rz_bench_report(&ctx, table); \
 	} while (0)
 
 #define RZ_BENCH_RUN_I(name, i, table, iterations, code) \
 	do { \
+		RzMathWelfordSums wf = { 0 }; \
 		RzBenchCtx ctx; \
 		rz_bench_init(&ctx, name, iterations); \
 		rz_bench_start(&ctx); \
 		for (ut64(i) = 0; (i) < iterations; (i)++) { \
+			ut64 spl = rz_time_now_mono(); \
 			code; \
+			rz_math_welford_push(&wf, (double)(rz_time_now_mono() - spl)); \
 		} \
 		rz_bench_end(&ctx); \
+		ctx.std_dev = rz_math_welford_std_deviation(&wf); \
+		ctx.mean_us = rz_math_welford_mean(&wf); \
 		rz_bench_report(&ctx, table); \
 	} while (0)
 
@@ -61,7 +73,7 @@ RZ_API void rz_bench_report(RZ_NONNULL RzBenchCtx *ctx, RZ_NONNULL RzTable *t);
  * \param T table to initialize.
  */
 #define RZ_BENCH_TABLE_INIT(T) \
-	rz_table_set_columnsf(T, "snnnn", "Benchmark", "Iterations", "Total time [ms]", "Avg iter time [us/iteration]", "Throughput [iterations/sec]");
+	rz_table_set_columnsf(T, "sdnnnn", "Benchmark", "Iterations", "Total time [ms]", "Avg iter time [us/iteration]", "Throughput [iterations/sec]", "Std Deviation");
 
 /**
  * \brief Prints microbenchmark results and frees the RzTable \p T. Should be called at end of a benchmark suite.

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -94,6 +94,7 @@ if get_option('enable_tests')
     'list',
     'log',
     'lzma',
+    'math',
     'mem',
     'ovf',
     'pj',

--- a/test/unit/test_math.c
+++ b/test/unit/test_math.c
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Rot127 <rot127@posteo.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_util.h>
+#include <rz_vector.h>
+#include "minunit.h"
+
+static bool test_welford(void) {
+	RzMathWelfordSums wf = { 0 };
+	rz_math_welford_init(&wf);
+	rz_math_welford_push(&wf, 10.0);
+	rz_math_welford_push(&wf, 17.0);
+	rz_math_welford_push(&wf, 37.0);
+	rz_math_welford_push(&wf, 45.0);
+	rz_math_welford_push(&wf, 76.0);
+	rz_math_welford_push(&wf, 98.0);
+	rz_math_welford_push(&wf, 99.0);
+	rz_math_welford_push(&wf, 100.0);
+
+	mu_assert_eq(rz_math_welford_n(&wf), 8, "n");
+	char val[16] = { 0 };
+	rz_strf(val, "%.4f", rz_math_welford_variance(&wf));
+	mu_assert_streq(val, "1417.6429", "variance");
+
+	rz_strf(val, "%.4f", rz_math_welford_std_deviation(&wf));
+	mu_assert_streq(val, "37.6516", "std deviation");
+
+	rz_strf(val, "%.4f", rz_math_welford_mean(&wf));
+	mu_assert_streq(val, "60.2500", "mean");
+
+	rz_strf(val, "%.4f", rz_math_welford_sum_of_squares(&wf));
+	mu_assert_streq(val, "9923.5000", "sum of squares");
+
+	rz_math_welford_clear(&wf);
+
+	mu_end;
+}
+
+static int all_tests(void) {
+
+	mu_run_test(test_welford);
+
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests)

--- a/test/unit/test_math.c
+++ b/test/unit/test_math.c
@@ -5,31 +5,80 @@
 #include <rz_vector.h>
 #include "minunit.h"
 
-static bool test_welford(void) {
+static bool test_welford_arithmetic(void) {
 	RzMathWelfordSums wf = { 0 };
 	rz_math_welford_init(&wf);
-	rz_math_welford_push(&wf, 10.0);
-	rz_math_welford_push(&wf, 17.0);
-	rz_math_welford_push(&wf, 37.0);
-	rz_math_welford_push(&wf, 45.0);
-	rz_math_welford_push(&wf, 76.0);
-	rz_math_welford_push(&wf, 98.0);
-	rz_math_welford_push(&wf, 99.0);
-	rz_math_welford_push(&wf, 100.0);
+	rz_math_welford_push(&wf, 0.49671415);
+	rz_math_welford_push(&wf, -0.1382643);
+	rz_math_welford_push(&wf, 0.64768854);
+	rz_math_welford_push(&wf, 1.52302986);
+	rz_math_welford_push(&wf, -0.23415337);
+	rz_math_welford_push(&wf, -0.23413696);
+	rz_math_welford_push(&wf, 1.57921282);
+	rz_math_welford_push(&wf, 0.76743473);
+	rz_math_welford_push(&wf, -0.46947439);
+	rz_math_welford_push(&wf, 0.54256004);
+	rz_math_welford_push(&wf, -0.46341769);
+	rz_math_welford_push(&wf, -0.46572975);
+	rz_math_welford_push(&wf, 0.24196227);
+	rz_math_welford_push(&wf, -1.91328024);
+	rz_math_welford_push(&wf, -1.72491783);
+	rz_math_welford_push(&wf, -0.56228753);
+	rz_math_welford_push(&wf, -1.01283112);
+	rz_math_welford_push(&wf, 0.31424733);
+	rz_math_welford_push(&wf, -0.90802408);
+	rz_math_welford_push(&wf, -1.4123037);
 
-	mu_assert_eq(rz_math_welford_n(&wf), 8, "n");
+	mu_assert_eq(rz_math_welford_n(&wf), 20, "n");
+
 	char val[16] = { 0 };
-	rz_strf(val, "%.4f", rz_math_welford_variance(&wf));
-	mu_assert_streq(val, "1417.6429", "variance");
+	rz_strf(val, "%.6f", rz_math_welford_avar(&wf));
+	mu_assert_streq(val, "0.875572", "variance");
 
-	rz_strf(val, "%.4f", rz_math_welford_std_deviation(&wf));
-	mu_assert_streq(val, "37.6516", "std deviation");
+	rz_strf(val, "%.6f", rz_math_welford_astddev(&wf));
+	mu_assert_streq(val, "0.935720", "std deviation");
 
-	rz_strf(val, "%.4f", rz_math_welford_mean(&wf));
-	mu_assert_streq(val, "60.2500", "mean");
+	rz_strf(val, "%.6f", rz_math_welford_amean(&wf));
+	mu_assert_streq(val, "-0.171299", "mean");
 
-	rz_strf(val, "%.4f", rz_math_welford_sum_of_squares(&wf));
-	mu_assert_streq(val, "9923.5000", "sum of squares");
+	rz_math_welford_clear(&wf);
+
+	mu_end;
+}
+
+static bool test_welford_geometric(void) {
+	RzMathWelfordSums wf = { 0 };
+	rz_math_welford_init(&wf);
+
+	rz_math_welford_push(&wf, 131.5502965);
+	rz_math_welford_push(&wf, 47.68105836);
+	rz_math_welford_push(&wf, 56.85572523);
+	rz_math_welford_push(&wf, 23.22318396);
+	rz_math_welford_push(&wf, 39.38442231);
+	rz_math_welford_push(&wf, 58.35549654);
+	rz_math_welford_push(&wf, 27.36880479);
+	rz_math_welford_push(&wf, 68.40314554);
+	rz_math_welford_push(&wf, 38.0772422);
+	rz_math_welford_push(&wf, 45.8320556);
+	rz_math_welford_push(&wf, 38.05285189);
+	rz_math_welford_push(&wf, 165.8969663);
+	rz_math_welford_push(&wf, 54.15778147);
+	rz_math_welford_push(&wf, 28.94430432);
+	rz_math_welford_push(&wf, 89.43632748);
+	rz_math_welford_push(&wf, 26.24548069);
+	rz_math_welford_push(&wf, 61.88749606);
+	rz_math_welford_push(&wf, 16.84742668);
+	rz_math_welford_push(&wf, 24.60841286);
+	rz_math_welford_push(&wf, 61.4434194);
+
+	mu_assert_eq(rz_math_welford_n(&wf), 20, "n");
+
+	char val[16] = { 0 };
+	rz_strf(val, "%.6f", rz_math_welford_gmean(&wf));
+	mu_assert_streq(val, "46.544783", "mean");
+
+	rz_strf(val, "%.6f", rz_math_welford_gstddev(&wf));
+	mu_assert_streq(val, "1.787509", "std deviation");
 
 	rz_math_welford_clear(&wf);
 
@@ -38,7 +87,8 @@ static bool test_welford(void) {
 
 static int all_tests(void) {
 
-	mu_run_test(test_welford);
+	mu_run_test(test_welford_arithmetic);
+	mu_run_test(test_welford_geometric);
 
 	return tests_passed != tests_run;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

Since I run all my stuff in VMs it is sometimes hard to say how much my results stray.
This PR adds code to calculate the standard deviation and prints it in the benchmarks.

These are the results.

NOTE: There are some very very high values for some measurements (like for the hash table inserts).
This suggests that this specific function can be very slow at times and fast at others. The runtime spreads.
No idea why this specific function. Heavy cache misses? Or the scheduler just says no?
I don't have the slightest clue.

Also, I don't know how the distribution looks like, but this might be a nice task for later.

```
>./build_release/test/bench/bench_il
Benchmark                                      Iterations Total time [ms] Avg iter time [us/iteration] Throughput [iterations/sec] Std Deviation 
-------------------------------------------------------------------------------------------------------------------------------------------------
bench_rz_il_mem_loadw: big endian (64 bit)        1000000       82.174000                     0.047290             12169299.291747      0.264151
bench_rz_il_mem_loadw: little endian (64 bit)     1000000       75.507000                     0.043300             13243805.210113      0.208344
bench_rz_il_mem_loadw: big endian (256 bit)       1000000       92.982000                     0.059430             10754769.740380      0.240504
bench_rz_il_mem_loadw: little endian (256 bit)    1000000       85.781000                     0.052255             11657593.173313      0.226143

>./build_release/test/bench/bench_list
Benchmark               Iterations Total time [ms] Avg iter time [us/iteration] Throughput [iterations/sec] Std Deviation 
--------------------------------------------------------------------------------------------------------------------------
purge_v1_empty               10000        1.240000                     0.055600              8064516.129032      0.865900
purge_v2_empty               10000        1.089000                     0.045800              9182736.455464      0.260210
purge_v3_empty               10000        1.046000                     0.042300              9560229.445507      0.201283
purge_v4_empty               10000        1.063000                     0.042700              9407337.723424      0.203669
purge_v1_1k_no_free           1000       19.756000                    19.710000                50617.533914      6.413972
purge_v2_1k_no_free           1000        9.885000                     9.844000               101163.378857      5.200453
purge_v3_1k_no_free           1000       10.973000                    10.937000                91132.780461      2.303983
purge_v4_1k_no_free           1000       10.864000                    10.834000                92047.128130      3.767046
purge_v1_100k_no_free          100      160.756000                  1607.540000                  622.060763    160.147244
purge_v2_100k_no_free          100      127.660000                  1276.490000                  783.330722     51.286184
purge_v3_100k_no_free          100      128.020000                  1280.110000                  781.127949     59.766700
purge_v4_100k_no_free          100      130.178000                  1301.680000                  768.178955    132.585012
purge_v1_1m_no_free             10      178.871000                 17886.300000                   55.906212   4108.530314
purge_v2_1m_no_free             10      136.077000                 13607.200000                   73.487805    592.416858
purge_v3_1m_no_free             10      133.953000                 13394.900000                   74.653050    470.140747
purge_v4_1m_no_free             10      136.003000                 13599.900000                   73.527790    385.530933
purge_v1_100k_with_free        100      276.610000                  2766.000000                  361.519829    151.859185
purge_v2_100k_with_free        100      241.943000                  2419.280000                  413.320493    137.771666
purge_v3_100k_with_free        100      245.249000                  2452.340000                  407.748859    136.704372
purge_v4_100k_with_free        100      241.945000                  2419.330000                  413.317076    129.957495
purge_v1_1m_with_free           10      290.863000                 29086.100000                   34.380447   5250.598600
purge_v2_1m_with_free           10      239.016000                 23901.100000                   41.838203    383.588162
purge_v3_1m_with_free           10      240.150000                 24014.500000                   41.640641    342.854115
purge_v4_1m_with_free           10      242.776000                 24277.200000                   41.190233    545.832249

>./build_release/test/bench/bench_bitvector
Benchmark                                            Iterations Total time [ms] Avg iter time [us/iteration] Throughput [iterations/sec] Std Deviation 
-------------------------------------------------------------------------------------------------------------------------------------------------------
rz_bv_copy_nbits: small to small (60 bit)               1000000       88.265000                     0.039378             11329519.061916      0.605952
rz_bv_copy_nbits: large to large (100 bit) aligned      1000000       53.368000                     0.025119             18737820.416729      0.163530
rz_bv_copy_nbits: large to large (100 bit) unaligned    1000000      142.999000                     0.095042              6993055.895496      0.503326
rz_bv_copy_nbits: large to small (60 bit)               1000000       75.885000                     0.036660             13177834.881729      0.362055
rz_bv_copy_nbits: small to large (60 bit)               1000000       82.420000                     0.039748             12132977.432662      0.229883
rz_bv_set_range (60 bit)                                1000000       88.258000                     0.037854             11330417.639194      0.254553
rz_bv_set_range (100 bit)                               1000000       67.940000                     0.031761             14718869.590815      0.204383
rz_bv_add(a, b, NULL) - (64 bit)                        1000000       65.508000                     0.033910             15265311.107040      0.185532
rz_bv_add_inplace(a, b, NULL) - (64 bit)                1000000       74.574000                     0.031966             13409499.289297      0.287987
rz_bv_add_inplace(a, b, NULL) - (256 bit)               1000000       90.567000                     0.044621             11041549.350205      0.336788
rz_bv_sub(a, b, NULL)                                   1000000      402.505000                     0.359640              2484441.187066      0.833938
rz_bv_sub_inplace(a, b, NULL)                           1000000      440.594000                     0.395124              2269663.227370      0.677451

> ./build_release/test/bench/bench_ht
Benchmark                     Iterations Total time [ms] Avg iter time [us/iteration] Throughput [iterations/sec] Std Deviation 
--------------------------------------------------------------------------------------------------------------------------------
[HtPU] insert                    2000000      695.188000                     0.304894              2876919.624620    164.158957
[HtPU] delete                    2000000      646.474000                     0.276485              3093705.237952      0.749421
[HtPU] iterate (100 elements)    2000000      490.967000                     0.200383              4073593.540910      0.593664
[HtPU] lookup (100 elements)     2000000      155.855000                     0.039325             12832440.409355      0.288947
[HtPU] lookup (1k elements)      2000000      168.282000                     0.043093             11884812.398236      0.283032
[HtPU] lookup (10k elements)     2000000      182.959000                     0.050819             10931410.862543      0.330674
[HtPU] lookup (100k elements)    2000000      166.934000                     0.053544             11980782.824350      0.259622
[HtPU] lookup (1M elements)      2000000      695.152000                     0.297156              2877068.612332      0.778133
[HtSU] insert                    2000000      465.822000                     0.202296              4293485.494459     77.342624
[HtSU] delete                    2000000      355.788000                     0.147624              5621325.058743      0.398895
[HtSU] iterate (100 elements)    2000000      376.097000                     0.152606              5317777.062832      0.385802
[HtSU] lookup (100 elements)     2000000      141.503000                     0.040110             14133975.958107      0.202415
[HtSU] lookup (1k elements)      2000000      147.298000                     0.042897             13577916.875993      0.208530
[HtSU] lookup (10k elements)     2000000      162.397000                     0.050540             12315498.439011      0.250406
[HtSU] lookup (100k elements)    2000000      248.785000                     0.093968              8039069.879615      0.323793
[HtSU] lookup (1M elements)      2000000      676.621000                     0.309003              2955864.509083      0.514356
[HtUU] insert                    2000000      310.887000                     0.123794              6433205.634201     33.836836
[HtUU] delete                    2000000      424.222000                     0.182549              4714512.684396      0.406522
[HtUU] iterate (100 elements)    2000000      372.962000                     0.150657              5362476.606196      0.399540
[HtUU] lookup (100 elements)     2000000      130.003000                     0.034169             15384260.363222      0.190377
[HtUU] lookup (1k elements)      2000000      129.341000                     0.033989             15463000.904586      0.185234
[HtUU] lookup (10k elements)     2000000      131.517000                     0.035100             15207159.530707      0.187790
[HtUU] lookup (100k elements)    2000000      136.284000                     0.037275             14675237.005078      0.195792
[HtUU] lookup (1M elements)      2000000      268.998000                     0.104797              7434999.516725      0.366221
```

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Added

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
