### PR TITLE
[stable] backport CVE-2026-45613: OOB read in OMF rz_bin_omf_get_entry

### DIFF
--- a/librz/bin/format/omf/omf.c
+++ b/librz/bin/format/omf/omf.c
@@ -706,12 +706,13 @@ bool rz_bin_omf_get_entry(rz_bin_omf_obj *obj, RzBinAddr *addr) {
 	}
 	while (ct_sym < obj->nb_symbol) {
 		if (!strcmp(obj->symbols[ct_sym]->name, "_start")) {
-			if (obj->symbols[ct_sym]->seg_idx - 1 > obj->nb_section) {
+			size_t sec_arr_offset = obj->symbols[ct_sym]->seg_idx - 1;
+			if (sec_arr_offset >= obj->nb_section) {
 				RZ_LOG_ERROR("Invalid segment index for symbol _start\n");
 				return false;
 			}
-			addr->vaddr = obj->sections[obj->symbols[ct_sym]->seg_idx - 1]->vaddr + obj->symbols[ct_sym]->offset + OMF_BASE_ADDR;
-			data = obj->sections[obj->symbols[ct_sym]->seg_idx - 1]->data;
+			addr->vaddr = obj->sections[sec_arr_offset]->vaddr + obj->symbols[ct_sym]->offset + OMF_BASE_ADDR;
+			data = obj->sections[sec_arr_offset]->data;
 			while (data) {
 				offset += data->size;
 				if (obj->symbols[ct_sym]->offset < offset) {


### PR DESCRIPTION
the fix `e6d0937c8a08` for the OMF out-of-bounds read isn't on stable yet. the bounds check `seg_idx - 1 > nb_section` lets an index equal to `nb_section` (one past the end) through, so a crafted OMF file with a bogus `_start` segment index reads past the sections array. upstream switches it to `>= nb_section`.

asan harness around the check with `seg_idx-1 == nb_section`: pre-fix reads one element past the array (heap-buffer-overflow), post-fix rejects cleanly. cherry-pick applied clean to stable.

upstream: https://github.com/rizinorg/rizin/commit/e6d0937c8a08
CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-45613

no full test run locally.