### PR TITLE
test/bench: add benchmark for RzDiff

### DIFF
--- a/test/bench/bench_diff.c
+++ b/test/bench/bench_diff.c
@@ -1,0 +1,902 @@
+// SPDX-FileCopyrightText: 2026 RizinOrg <info@rizin.re>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include "bench_utils.h"
+#include <rz_diff.h>
+#include <rz_util.h>
+
+/**
+ * \file bench_diff.c
+ * \brief Micro-benchmarks for the RzDiff subsystem (librz/diff)
+ *
+ * The benchmarks fall into several groups:
+ *
+ *   1. Construction:           rz_diff_bytes_new / rz_diff_lines_new
+ *                              These populate the internal `b_hits` hashmap
+ *                              and dominate setup cost.
+ *
+ *   2. Core diffing:           rz_diff_matches_new / rz_diff_opcodes_new /
+ *                              rz_diff_opcodes_grouped_new -- the
+ *                              Ratcliff/Obershelp inner loop.
+ *
+ *   3. End-to-end output:      rz_diff_unified_text -- everything above
+ *                              plus formatting cost.
+ *
+ *   4. Similarity:             rz_diff_ratio / rz_diff_sizes_ratio.
+ *
+ *   5. Distance algorithms:    rz_diff_myers_distance /
+ *                              rz_diff_levenshtein_distance.
+ *
+ * For each, we cover both "similar" (mostly equal) and "divergent" (largely
+ * different) inputs because the two cases have very different behavior in
+ * the hit-map / longest-match search.
+ */
+
+#define BUF_SMALL   256
+#define BUF_MEDIUM  4096
+#define BUF_LARGE   32768
+
+#define ITER_HEAVY  64
+#define ITER_MEDIUM 1024
+#define ITER_LIGHT  8192
+#define ITER_TINY   200000
+
+// ------------------------------------------------------------
+// Input generators
+// ------------------------------------------------------------
+
+/* Deterministic, fast LCG so benchmarks are reproducible across runs and
+ * platforms without depending on libc rand() quality. */
+static ut32 lcg_state;
+
+static void lcg_seed(ut32 s) {
+	lcg_state = s ? s : 0xdeadbeefu;
+}
+
+static ut32 lcg_next(void) {
+	lcg_state = lcg_state * 1103515245u + 12345u;
+	return lcg_state;
+}
+
+/* Fill `buf` with `size` pseudo-random bytes (printable, so the same buffer
+ * doubles as a string for line-diff benchmarks if needed). */
+static void fill_random(ut8 *buf, ut32 size, ut32 seed) {
+	lcg_seed(seed);
+	for (ut32 i = 0; i < size; i++) {
+		/* keep it printable so line/byte diff trees behave similarly */
+		buf[i] = 0x20 + (lcg_next() % (0x7f - 0x20));
+	}
+}
+
+/* Build two buffers `a` and `b` that share most content but differ in a few
+ * scattered windows. `divergence_pct` is the approximate percentage of bytes
+ * in `b` that are mutated relative to `a`. */
+static void make_pair_similar(ut8 *a, ut8 *b, ut32 size, ut32 divergence_pct) {
+	fill_random(a, size, 0xc0ffee);
+	memcpy(b, a, size);
+	lcg_seed(0xfeedface);
+	ut32 changes = (size * divergence_pct) / 100;
+	for (ut32 i = 0; i < changes; i++) {
+		ut32 idx = lcg_next() % size;
+		b[idx] ^= (ut8)(lcg_next() | 1);
+	}
+}
+
+/* Build two completely unrelated buffers (worst-case for the longest-match
+ * search). */
+static void make_pair_divergent(ut8 *a, ut8 *b, ut32 size) {
+	fill_random(a, size, 0xa5a5a5a5u);
+	fill_random(b, size, 0x5a5a5a5au);
+}
+
+/* Build a multi-line string of `n_lines` lines, each ~`line_len` bytes,
+ * pseudo-random within an alphabet that produces realistic line diversity. */
+static char *make_lines(ut32 n_lines, ut32 line_len, ut32 seed) {
+	ut32 total = n_lines * (line_len + 1) + 1;
+	char *out = malloc(total);
+	if (!out) {
+		return NULL;
+	}
+	lcg_seed(seed);
+	ut32 pos = 0;
+	for (ut32 i = 0; i < n_lines; i++) {
+		for (ut32 j = 0; j < line_len; j++) {
+			out[pos++] = 'a' + (lcg_next() % 26);
+		}
+		out[pos++] = '\n';
+	}
+	out[pos] = '\0';
+	return out;
+}
+
+/* Build a "modified" version of `src` where roughly `mod_pct` % of lines are
+ * altered. Lines are simply replaced with a fresh random line of the same
+ * length, so byte-for-byte similarity is preserved at the structural level. */
+static char *make_lines_modified(const char *src, ut32 mod_pct, ut32 seed) {
+	size_t len = strlen(src);
+	char *out = malloc(len + 1);
+	if (!out) {
+		return NULL;
+	}
+	memcpy(out, src, len + 1);
+	lcg_seed(seed);
+	/* Walk lines and rewrite some of them in place */
+	size_t i = 0;
+	while (i < len) {
+		size_t j = i;
+		while (j < len && out[j] != '\n') {
+			j++;
+		}
+		if ((lcg_next() % 100) < mod_pct) {
+			for (size_t k = i; k < j; k++) {
+				out[k] = 'a' + (lcg_next() % 26);
+			}
+		}
+		i = j + 1;
+	}
+	return out;
+}
+
+// ------------------------------------------------------------
+// Bytes-diff benchmarks
+// ------------------------------------------------------------
+
+static void bench_bytes_new_similar_medium(RzTable *t_out) {
+	ut8 *a = malloc(BUF_MEDIUM);
+	ut8 *b = malloc(BUF_MEDIUM);
+	make_pair_similar(a, b, BUF_MEDIUM, 5);
+
+	RZ_BENCH_RUN("[RzDiff] rz_diff_bytes_new (similar, 4KB)", t_out, ITER_MEDIUM, {
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_bytes_new_divergent_medium(RzTable *t_out) {
+	ut8 *a = malloc(BUF_MEDIUM);
+	ut8 *b = malloc(BUF_MEDIUM);
+	make_pair_divergent(a, b, BUF_MEDIUM);
+
+	RZ_BENCH_RUN("[RzDiff] rz_diff_bytes_new (divergent, 4KB)", t_out, ITER_MEDIUM, {
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_bytes_matches_similar_small(RzTable *t_out) {
+	ut8 *a = malloc(BUF_SMALL);
+	ut8 *b = malloc(BUF_SMALL);
+	make_pair_similar(a, b, BUF_SMALL, 5);
+
+	RZ_BENCH_RUN("[RzDiff] rz_diff_matches_new (similar, 256B)", t_out, ITER_LIGHT, {
+		RzDiff *d = rz_diff_bytes_new(a, BUF_SMALL, b, BUF_SMALL, NULL);
+		RzList *m = rz_diff_matches_new(d);
+		rz_list_free(m);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_bytes_matches_similar_medium(RzTable *t_out) {
+	ut8 *a = malloc(BUF_MEDIUM);
+	ut8 *b = malloc(BUF_MEDIUM);
+	make_pair_similar(a, b, BUF_MEDIUM, 5);
+
+	RZ_BENCH_RUN("[RzDiff] rz_diff_matches_new (similar, 4KB)", t_out, ITER_HEAVY, {
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		RzList *m = rz_diff_matches_new(d);
+		rz_list_free(m);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_bytes_matches_divergent_medium(RzTable *t_out) {
+	ut8 *a = malloc(BUF_MEDIUM);
+	ut8 *b = malloc(BUF_MEDIUM);
+	make_pair_divergent(a, b, BUF_MEDIUM);
+
+	/* Divergent case is the pathological one for the inner loop; keep iter
+	 * count modest. */
+	RZ_BENCH_RUN("[RzDiff] rz_diff_matches_new (divergent, 4KB)", t_out, ITER_HEAVY, {
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		RzList *m = rz_diff_matches_new(d);
+		rz_list_free(m);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_bytes_opcodes_similar_medium(RzTable *t_out) {
+	ut8 *a = malloc(BUF_MEDIUM);
+	ut8 *b = malloc(BUF_MEDIUM);
+	make_pair_similar(a, b, BUF_MEDIUM, 5);
+
+	RZ_BENCH_RUN("[RzDiff] rz_diff_opcodes_new (similar, 4KB)", t_out, ITER_HEAVY, {
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		RzList *ops = rz_diff_opcodes_new(d);
+		rz_list_free(ops);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_bytes_opcodes_grouped_similar_medium(RzTable *t_out) {
+	ut8 *a = malloc(BUF_MEDIUM);
+	ut8 *b = malloc(BUF_MEDIUM);
+	make_pair_similar(a, b, BUF_MEDIUM, 5);
+
+	RZ_BENCH_RUN("[RzDiff] rz_diff_opcodes_grouped_new (similar, 4KB)", t_out, ITER_HEAVY, {
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		RzList *g = rz_diff_opcodes_grouped_new(d, RZ_DIFF_DEFAULT_N_GROUPS);
+		rz_list_free(g);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_bytes_ratio_similar_medium(RzTable *t_out) {
+	ut8 *a = malloc(BUF_MEDIUM);
+	ut8 *b = malloc(BUF_MEDIUM);
+	make_pair_similar(a, b, BUF_MEDIUM, 5);
+
+	RZ_BENCH_RUN("[RzDiff] rz_diff_ratio (similar, 4KB)", t_out, ITER_HEAVY, {
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		double r = 0.0;
+		rz_diff_ratio(d, &r);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_bytes_unified_similar_medium(RzTable *t_out) {
+	ut8 *a = malloc(BUF_MEDIUM);
+	ut8 *b = malloc(BUF_MEDIUM);
+	make_pair_similar(a, b, BUF_MEDIUM, 5);
+
+	RZ_BENCH_RUN("[RzDiff] rz_diff_unified_text bytes (similar, 4KB)", t_out, ITER_HEAVY, {
+		RzDiff *d = rz_diff_bytes_new(a, BUF_MEDIUM, b, BUF_MEDIUM, NULL);
+		char *s = rz_diff_unified_text(d, NULL, NULL, false, false);
+		free(s);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+// ------------------------------------------------------------
+// Lines-diff benchmarks
+// ------------------------------------------------------------
+
+static void bench_lines_matches_similar(RzTable *t_out) {
+	char *a = make_lines(200, 40, 0x1111);
+	char *b = make_lines_modified(a, 10, 0x2222);
+
+	RZ_BENCH_RUN("[RzDiff] rz_diff_matches_new lines (~200 lines, 10% changed)", t_out, ITER_HEAVY, {
+		RzDiff *d = rz_diff_lines_new(a, b, NULL);
+		RzList *m = rz_diff_matches_new(d);
+		rz_list_free(m);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_lines_unified_similar(RzTable *t_out) {
+	char *a = make_lines(200, 40, 0x1111);
+	char *b = make_lines_modified(a, 10, 0x2222);
+
+	RZ_BENCH_RUN("[RzDiff] rz_diff_unified_text lines (~200 lines, 10% changed)", t_out, ITER_HEAVY, {
+		RzDiff *d = rz_diff_lines_new(a, b, NULL);
+		char *s = rz_diff_unified_text(d, NULL, NULL, false, false);
+		free(s);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+// ------------------------------------------------------------
+// Distance benchmarks
+// ------------------------------------------------------------
+
+static void bench_myers_distance_similar(RzTable *t_out) {
+	ut8 *a = malloc(BUF_SMALL);
+	ut8 *b = malloc(BUF_SMALL);
+	make_pair_similar(a, b, BUF_SMALL, 5);
+
+	RZ_BENCH_RUN("[RzDiff] rz_diff_myers_distance (similar, 256B)", t_out, ITER_MEDIUM, {
+		ut32 dist = 0;
+		rz_diff_myers_distance(a, BUF_SMALL, b, BUF_SMALL, &dist, NULL);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_myers_distance_divergent(RzTable *t_out) {
+	ut8 *a = malloc(BUF_SMALL);
+	ut8 *b = malloc(BUF_SMALL);
+	make_pair_divergent(a, b, BUF_SMALL);
+
+	/* O(ND) blows up when D ~ N; keep iter count modest. */
+	RZ_BENCH_RUN("[RzDiff] rz_diff_myers_distance (divergent, 256B)", t_out, ITER_HEAVY, {
+		ut32 dist = 0;
+		rz_diff_myers_distance(a, BUF_SMALL, b, BUF_SMALL, &dist, NULL);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_levenshtein_distance_similar(RzTable *t_out) {
+	ut8 *a = malloc(BUF_SMALL);
+	ut8 *b = malloc(BUF_SMALL);
+	make_pair_similar(a, b, BUF_SMALL, 5);
+
+	RZ_BENCH_RUN("[RzDiff] rz_diff_levenshtein_distance (similar, 256B)", t_out, ITER_MEDIUM, {
+		ut32 dist = 0;
+		rz_diff_levenshtein_distance(a, BUF_SMALL, b, BUF_SMALL, &dist, NULL);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_levenshtein_distance_divergent(RzTable *t_out) {
+	ut8 *a = malloc(BUF_SMALL);
+	ut8 *b = malloc(BUF_SMALL);
+	make_pair_divergent(a, b, BUF_SMALL);
+
+	/* Levenshtein is O(N*M) regardless of similarity, so size is the only
+	 * knob. */
+	RZ_BENCH_RUN("[RzDiff] rz_diff_levenshtein_distance (divergent, 256B)", t_out, ITER_HEAVY, {
+		ut32 dist = 0;
+		rz_diff_levenshtein_distance(a, BUF_SMALL, b, BUF_SMALL, &dist, NULL);
+	});
+
+	free(a);
+	free(b);
+}
+
+// ------------------------------------------------------------
+// Hash helper benchmark (the building block used by elem_hash)
+// ------------------------------------------------------------
+
+static void bench_hash_data_64B(RzTable *t_out) {
+	ut8 *a = malloc(64);
+	fill_random(a, 64, 0xbadc0de);
+
+	RZ_BENCH_RUN("[RzDiff] rz_diff_hash_data (64B)", t_out, ITER_TINY, {
+		ut32 h = rz_diff_hash_data(a, 64);
+		RZ_DONT_OPTIMIZE(ut32, h);
+	});
+
+	free(a);
+}
+
+static void bench_hash_data_1KB(RzTable *t_out) {
+	ut8 *a = malloc(1024);
+	fill_random(a, 1024, 0xbadc0de);
+
+	RZ_BENCH_RUN("[RzDiff] rz_diff_hash_data (1KB)", t_out, ITER_TINY, {
+		ut32 h = rz_diff_hash_data(a, 1024);
+		RZ_DONT_OPTIMIZE(ut32, h);
+	});
+
+	free(a);
+}
+
+// ------------------------------------------------------------
+// Larger end-to-end scenario (gated to a small iter count)
+// ------------------------------------------------------------
+
+static void bench_bytes_unified_large_similar(RzTable *t_out) {
+	ut8 *a = malloc(BUF_LARGE);
+	ut8 *b = malloc(BUF_LARGE);
+	make_pair_similar(a, b, BUF_LARGE, 2);
+
+	/* 32KB end-to-end is the heaviest non-torture scenario. Iteration count
+	 * is kept low so the whole bench suite still fits comfortably inside the
+	 * `benchmark()` timeout configured in test/bench/meson.build. */
+	RZ_BENCH_RUN("[RzDiff] rz_diff_unified_text bytes (similar, 32KB)", t_out, 8, {
+		RzDiff *d = rz_diff_bytes_new(a, BUF_LARGE, b, BUF_LARGE, NULL);
+		char *s = rz_diff_unified_text(d, NULL, NULL, false, false);
+		free(s);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+// ------------------------------------------------------------
+// Real-world "torture" scenarios
+//
+// These reproduce, on small (~16-128 KB) buffers, the structural patterns
+// the algorithm sees on real binaries. They are kept compact -- each one
+// runs only a handful of iterations -- but their *shape* matches what users
+// actually hit when they `rz-diff` two firmware images or two builds of the
+// same executable.
+//
+// Buffer sizes were chosen so the suite still finishes comfortably inside
+// the meson `benchmark()` timeout, even on the worst-case scenarios
+// where Ratcliff/Obershelp degrades.
+// ------------------------------------------------------------
+
+/* "Firmware" image generator.
+ *
+ * Real firmware images for the same device differ in characteristic ways:
+ *   - a fixed bootloader region that almost never changes,
+ *   - a vector / interrupt table (small, occasional pointer changes),
+ *   - a large code region with a handful of changed functions,
+ *   - a constant / string pool that grows or shrinks slightly,
+ *   - large stretches of 0xFF erased flash padding.
+ *
+ * We synthesize both versions in a single pass so they share the structure
+ * by construction. `delta_seed` controls how V2 diverges from V1. */
+static void make_firmware_pair(ut8 *v1, ut8 *v2, ut32 size, ut32 delta_seed) {
+	/* Layout, scaled to `size`:
+	 *   [0, 1/16)        bootloader  -- byte-identical between v1 and v2
+	 *   [1/16, 2/16)     vector table -- a few 4-byte slots differ
+	 *   [2/16, 12/16)    code region  -- handful of small "patched functions"
+	 *   [12/16, 14/16)   const pool   -- minor edits, plus 16-byte shift
+	 *   [14/16, 16/16)   0xFF erase padding -- identical
+	 */
+	ut32 s1 = size / 16;
+	ut32 s2 = size * 2 / 16;
+	ut32 s12 = size * 12 / 16;
+	ut32 s14 = size * 14 / 16;
+
+	/* Common substrate -- realistic-ish ARM-like instruction byte
+	 * distribution: mostly low entropy, lots of recurring opcodes. */
+	lcg_seed(0xb0071ea0u);
+	for (ut32 i = 0; i < size; i++) {
+		ut32 r = lcg_next();
+		/* 70% "common opcode" bytes in {0x00, 0x01, 0x20, 0x46, 0x47, 0x68,
+		 * 0xB5, 0xBD, 0xE7, 0xF0}, 30% noisy. This produces realistic
+		 * collision rates in the elem_hash map. */
+		static const ut8 common[] = { 0x00, 0x01, 0x20, 0x46, 0x47, 0x68, 0xB5, 0xBD, 0xE7, 0xF0 };
+		v1[i] = (r % 100) < 70 ? common[(r >> 8) % sizeof(common)] : (ut8)(r >> 16);
+	}
+	/* 0xFF flash erase region. */
+	memset(v1 + s14, 0xff, size - s14);
+
+	/* v2 starts as a byte-identical copy. */
+	memcpy(v2, v1, size);
+
+	lcg_seed(delta_seed);
+
+	/* Vector table: change ~6 four-byte pointers. */
+	for (int i = 0; i < 6; i++) {
+		ut32 off = s1 + (lcg_next() % ((s2 - s1) / 4)) * 4;
+		ut32 patch = lcg_next();
+		memcpy(v2 + off, &patch, 4);
+	}
+
+	/* Code region: 8 "patched functions", each a 16-64 byte rewrite at a
+	 * random aligned offset. */
+	for (int i = 0; i < 8; i++) {
+		ut32 off = s2 + ((lcg_next() % ((s12 - s2) / 16)) * 16);
+		ut32 patch_len = 16 + (lcg_next() % 49);
+		if (off + patch_len > s12) {
+			patch_len = s12 - off;
+		}
+		for (ut32 k = 0; k < patch_len; k++) {
+			v2[off + k] = (ut8)lcg_next();
+		}
+	}
+
+	/* Const pool: shift everything after a midpoint by 16 bytes (simulates
+	 * a string being lengthened). This is the slide pattern that defeats
+	 * naive byte-wise comparisons. */
+	ut32 slide_at = s12 + (s14 - s12) / 2;
+	if (slide_at + 16 < s14) {
+		memmove(v2 + slide_at + 16, v2 + slide_at, s14 - slide_at - 16);
+		for (ut32 k = 0; k < 16; k++) {
+			v2[slide_at + k] = (ut8)('A' + (lcg_next() % 26));
+		}
+	}
+}
+
+/* "Big executable" generator (think mid-size ELF / PE / Mach-O):
+ *   - identical headers,
+ *   - large .text region heavily churned (every ~64 bytes a small patch),
+ *   - identical .rodata,
+ *   - .bss is all zeros in both.
+ *
+ * Stresses the hit-map traversal because the .bss zeros all hash to the
+ * same value (every elem_hash collision in B gets visited per byte of A). */
+static void make_big_exec_pair(ut8 *a, ut8 *b, ut32 size, ut32 delta_seed) {
+	ut32 hdr = 1024;
+	ut32 text = (size - hdr) * 6 / 10;
+	ut32 rodata = (size - hdr) * 2 / 10;
+	/* tail (after hdr+text+rodata) is .bss */
+
+	/* Header: small, identical. */
+	lcg_seed(0xe1f00000u);
+	for (ut32 i = 0; i < hdr; i++) {
+		a[i] = (ut8)lcg_next();
+	}
+	/* Text: dense pseudo-instructions. */
+	lcg_seed(0x7e71u);
+	for (ut32 i = 0; i < text; i++) {
+		a[hdr + i] = (ut8)lcg_next();
+	}
+	/* Rodata: ASCII strings mostly. */
+	lcg_seed(0x0d0d04u);
+	for (ut32 i = 0; i < rodata; i++) {
+		a[hdr + text + i] = (ut8)(0x20 + (lcg_next() % 0x60));
+	}
+	/* Bss: zeros. */
+	memset(a + hdr + text + rodata, 0, size - hdr - text - rodata);
+
+	memcpy(b, a, size);
+
+	/* Heavily churn .text: ~20% of 16-byte basic-block-sized windows are
+	 * fully rewritten in B. */
+	lcg_seed(delta_seed);
+	for (ut32 off = hdr; off + 16 < hdr + text; off += 16) {
+		if ((lcg_next() % 100) < 20) {
+			for (ut32 k = 0; k < 16; k++) {
+				b[off + k] = (ut8)lcg_next();
+			}
+		}
+	}
+}
+
+/* "Memory dump / disk image" generator (think 64+ MB blob, but synthesized
+ * at 64-128 KB so the suite stays fast):
+ *
+ *   - 80% zero-filled (sparse regions, free pages, etc.),
+ *   - 15% structured data (page-aligned 4 KB blocks with low-entropy headers),
+ *   - 5% high-entropy data (compressed / encrypted regions).
+ *
+ * The diff between v1 and v2 only touches a handful of 4 KB pages -- the
+ * realistic "snapshot N vs snapshot N+1" case. The pathology here is that
+ * the zero pages make every zero byte a hash collision in B. */
+static void make_memdump_pair(ut8 *a, ut8 *b, ut32 size, ut32 delta_seed) {
+	memset(a, 0, size);
+
+	/* Drop in a few structured 4 KB pages at random aligned offsets. */
+	lcg_seed(0x9a9eu);
+	ut32 n_pages = size / 4096;
+	for (ut32 i = 0; i < n_pages; i++) {
+		ut32 r = lcg_next() % 100;
+		ut32 page = i * 4096;
+		if (r < 15) {
+			/* Structured page: low-entropy header + body. */
+			ut32 hdr_seed = lcg_next();
+			for (ut32 k = 0; k < 64; k++) {
+				a[page + k] = (ut8)(hdr_seed >> ((k & 3) * 8));
+			}
+			for (ut32 k = 64; k < 4096 && page + k < size; k++) {
+				/* Repeating pattern: lots of intra-page redundancy. */
+				a[page + k] = (ut8)('A' + ((k - 64) % 26));
+			}
+		} else if (r < 20) {
+			/* High-entropy page. */
+			for (ut32 k = 0; k < 4096 && page + k < size; k++) {
+				a[page + k] = (ut8)lcg_next();
+			}
+		}
+		/* else: stays zero */
+	}
+
+	memcpy(b, a, size);
+
+	/* Modify a handful of pages in B -- the realistic snapshot diff case. */
+	lcg_seed(delta_seed);
+	int n_modified = 4;
+	for (int i = 0; i < n_modified; i++) {
+		ut32 page = ((lcg_next() % n_pages)) * 4096;
+		if (page + 4096 > size) {
+			continue;
+		}
+		/* Replace the page body. */
+		for (ut32 k = 0; k < 4096; k++) {
+			b[page + k] = (ut8)lcg_next();
+		}
+	}
+}
+
+/* Adversarial: every byte in B hashes to the same bucket (all 0x00). This
+ * is the pathological input for the longest-match search, since every
+ * position in A finds a hit list of length B_size in the hit map. */
+static void make_all_zeros_pair(ut8 *a, ut8 *b, ut32 size) {
+	memset(a, 0, size);
+	memset(b, 0, size);
+	/* Tiny perturbation so the diff isn't trivially identical: flip one
+	 * byte in the middle of B. */
+	if (size > 1) {
+		b[size / 2] = 0x01;
+	}
+}
+
+/* Adversarial: short repeating pattern. Every elem_hash bucket collects
+ * size/period entries, and many overlapping matches are found and rejected. */
+static void make_repeating_pattern_pair(ut8 *a, ut8 *b, ut32 size) {
+	for (ut32 i = 0; i < size; i++) {
+		a[i] = (ut8)('A' + (i & 3));
+	}
+	memcpy(b, a, size);
+	/* Inject a couple of small disturbances so we don't trivially match. */
+	if (size > 100) {
+		b[size / 4] = 'Z';
+		b[size / 2] = 'Z';
+		b[size * 3 / 4] = 'Z';
+	}
+}
+
+/* "Block shift" -- A and B are byte-identical except a 1 KB block is moved
+ * from one position to another. This is the classic case where a chunked /
+ * hashed comparison should still detect both halves of the shift as matches,
+ * but a naive byte-by-byte loop has to rediscover them. */
+static void make_block_shift_pair(ut8 *a, ut8 *b, ut32 size) {
+	lcg_seed(0xb10cu);
+	for (ut32 i = 0; i < size; i++) {
+		a[i] = (ut8)('a' + (lcg_next() % 26));
+	}
+	memcpy(b, a, size);
+	if (size > 4096) {
+		ut32 src = size / 4;
+		ut32 dst = size * 3 / 4;
+		ut32 blk = 1024;
+		ut8 tmp[1024];
+		memcpy(tmp, a + src, blk);
+		/* Slide the region between src+blk and dst left by blk, then place
+		 * tmp at dst-blk. */
+		memmove(b + src, a + src + blk, dst - src - blk);
+		memcpy(b + dst - blk, tmp, blk);
+	}
+}
+
+// ------------------------------------------------------------
+// Torture benchmarks
+//
+// Each one runs few iterations -- these are the heavyweight cases. They
+// exercise the full pipeline (matches + opcodes + unified_text), since
+// that's what real users invoke and that's where regressions are visible.
+// ------------------------------------------------------------
+
+/* NOTE: Ratcliff/Obershelp scales worse than quadratic in practice on
+ * "similar" inputs because every common byte's hit-list grows with the
+ * buffer size and is walked for every position in A. Measured on the
+ * current `dev` (May 2026): firmware-like 4 KB ~0.7 s/iter, 8 KB ~3.5 s/iter,
+ * 16 KB ~13 s/iter, 32 KB > 60 s/iter. Sizes here are picked so each
+ * scenario finishes in a few seconds per iteration -- enough to make the
+ * std. deviation meaningful while keeping the whole bench suite under the
+ * meson `benchmark()` timeout (120 s). Once PR #6385's chunked
+ * comparison lands, these can be cranked back up.
+ */
+#define TORTURE_FW_SIZE      (8 * 1024)   /* synthesized firmware              */
+#define TORTURE_EXEC_SIZE    (8 * 1024)   /* synthesized executable             */
+#define TORTURE_MEMDUMP_SIZE (8 * 1024)   /* synthesized memdump-shape blob     */
+#define TORTURE_BLOCKSHIFT   (16 * 1024)  /* block-shift -- few matches, fast   */
+#define TORTURE_ADVERSARY    (2 * 1024)   /* pathological hash distributions    */
+#define ITER_TORTURE         3            /* must be >= 3 for useful stddev     */
+#define ITER_TORTURE_LIGHT   8
+
+static void bench_torture_firmware_pair(RzTable *t_out) {
+	ut8 *v1 = malloc(TORTURE_FW_SIZE);
+	ut8 *v2 = malloc(TORTURE_FW_SIZE);
+	make_firmware_pair(v1, v2, TORTURE_FW_SIZE, 0xa11dau);
+
+	RZ_BENCH_RUN("[RzDiff] torture: firmware v1 vs v2 (8KB, mostly identical)", t_out, ITER_TORTURE, {
+		RzDiff *d = rz_diff_bytes_new(v1, TORTURE_FW_SIZE, v2, TORTURE_FW_SIZE, NULL);
+		char *s = rz_diff_unified_text(d, NULL, NULL, false, false);
+		free(s);
+		rz_diff_free(d);
+	});
+
+	/* Also measure the matches phase in isolation -- the place chunked /
+	 * hashed byte comparison primarily speeds up. */
+	RZ_BENCH_RUN("[RzDiff] torture: firmware v1 vs v2 (8KB, matches only)", t_out, ITER_TORTURE, {
+		RzDiff *d = rz_diff_bytes_new(v1, TORTURE_FW_SIZE, v2, TORTURE_FW_SIZE, NULL);
+		RzList *m = rz_diff_matches_new(d);
+		rz_list_free(m);
+		rz_diff_free(d);
+	});
+
+	free(v1);
+	free(v2);
+}
+
+static void bench_torture_big_exec(RzTable *t_out) {
+	ut8 *a = malloc(TORTURE_EXEC_SIZE);
+	ut8 *b = malloc(TORTURE_EXEC_SIZE);
+	make_big_exec_pair(a, b, TORTURE_EXEC_SIZE, 0xbabeu);
+
+	/* With the new stddev / geometric-mean reporting introduced by
+	 * rizinorg/rizin#6390 and #6403, we need at least 3 iterations for
+	 * those statistics to be meaningful. */
+	RZ_BENCH_RUN("[RzDiff] torture: big exec (8KB, .text churn)", t_out, ITER_TORTURE, {
+		RzDiff *d = rz_diff_bytes_new(a, TORTURE_EXEC_SIZE, b, TORTURE_EXEC_SIZE, NULL);
+		RzList *ops = rz_diff_opcodes_new(d);
+		rz_list_free(ops);
+		rz_diff_free(d);
+	});
+
+	/* Ratio-only is significantly cheaper than full unified, and is what
+	 * binary-similarity tooling typically wants. */
+	RZ_BENCH_RUN("[RzDiff] torture: big exec ratio (8KB)", t_out, ITER_TORTURE, {
+		RzDiff *d = rz_diff_bytes_new(a, TORTURE_EXEC_SIZE, b, TORTURE_EXEC_SIZE, NULL);
+		double r = 0.0;
+		rz_diff_ratio(d, &r);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_torture_memdump(RzTable *t_out) {
+	ut8 *a = malloc(TORTURE_MEMDUMP_SIZE);
+	ut8 *b = malloc(TORTURE_MEMDUMP_SIZE);
+	make_memdump_pair(a, b, TORTURE_MEMDUMP_SIZE, 0xd09e7u);
+
+	/* Memdumps are dominated by huge zero regions, which create a single
+	 * giant hit list in b_hits and stress the longest-match search far more
+	 * than a uniformly-random buffer of the same size. */
+	RZ_BENCH_RUN("[RzDiff] torture: memdump (8KB, sparse, few pages changed)", t_out, ITER_TORTURE, {
+		RzDiff *d = rz_diff_bytes_new(a, TORTURE_MEMDUMP_SIZE, b, TORTURE_MEMDUMP_SIZE, NULL);
+		RzList *ops = rz_diff_opcodes_new(d);
+		rz_list_free(ops);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_torture_all_zeros(RzTable *t_out) {
+	/* Pathological: every byte of A hits a hit-list of length |B| in the
+	 * b_hits map. This is the case where any chunked / hashed comparison
+	 * scheme has to be careful not to lose to the original on small N. */
+	ut8 *a = malloc(TORTURE_ADVERSARY);
+	ut8 *b = malloc(TORTURE_ADVERSARY);
+	make_all_zeros_pair(a, b, TORTURE_ADVERSARY);
+
+	RZ_BENCH_RUN("[RzDiff] torture: all-zeros adversary (2KB)", t_out, ITER_TORTURE, {
+		RzDiff *d = rz_diff_bytes_new(a, TORTURE_ADVERSARY, b, TORTURE_ADVERSARY, NULL);
+		RzList *m = rz_diff_matches_new(d);
+		rz_list_free(m);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_torture_repeating_pattern(RzTable *t_out) {
+	/* Short repeating alphabet -> dense hit map, many overlapping matches. */
+	ut8 *a = malloc(TORTURE_ADVERSARY);
+	ut8 *b = malloc(TORTURE_ADVERSARY);
+	make_repeating_pattern_pair(a, b, TORTURE_ADVERSARY);
+
+	RZ_BENCH_RUN("[RzDiff] torture: short repeating pattern (2KB)", t_out, ITER_TORTURE_LIGHT, {
+		RzDiff *d = rz_diff_bytes_new(a, TORTURE_ADVERSARY, b, TORTURE_ADVERSARY, NULL);
+		RzList *m = rz_diff_matches_new(d);
+		rz_list_free(m);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+static void bench_torture_block_shift(RzTable *t_out) {
+	/* Two large equal halves separated by a 1 KB block-shift. The matcher
+	 * has to find both halves separately. Block-shift is the fastest of the
+	 * torture scenarios per byte (very few but very long matches), so we
+	 * keep it larger than the other scenarios. */
+	ut8 *a = malloc(TORTURE_BLOCKSHIFT);
+	ut8 *b = malloc(TORTURE_BLOCKSHIFT);
+	make_block_shift_pair(a, b, TORTURE_BLOCKSHIFT);
+
+	RZ_BENCH_RUN("[RzDiff] torture: block shift (16KB, 1KB moved)", t_out, ITER_TORTURE, {
+		RzDiff *d = rz_diff_bytes_new(a, TORTURE_BLOCKSHIFT, b, TORTURE_BLOCKSHIFT, NULL);
+		RzList *ops = rz_diff_opcodes_new(d);
+		rz_list_free(ops);
+		rz_diff_free(d);
+	});
+
+	free(a);
+	free(b);
+}
+
+/* Distance-only torture for the same firmware shape. Distance algorithms
+ * are O(N*D) / O(N*M), so they're the limiting factor on bigger inputs and
+ * they live in a totally different code path from matches/opcodes. */
+static void bench_torture_distances_firmware(RzTable *t_out) {
+	const ut32 size = 8 * 1024;
+	ut8 *v1 = malloc(size);
+	ut8 *v2 = malloc(size);
+	make_firmware_pair(v1, v2, size, 0xd157u);
+
+	RZ_BENCH_RUN("[RzDiff] torture: myers distance firmware-like (4KB)", t_out, ITER_TORTURE, {
+		ut32 dist = 0;
+		rz_diff_myers_distance(v1, size, v2, size, &dist, NULL);
+	});
+	RZ_BENCH_RUN("[RzDiff] torture: levenshtein distance firmware-like (4KB)", t_out, ITER_TORTURE, {
+		ut32 dist = 0;
+		rz_diff_levenshtein_distance(v1, size, v2, size, &dist, NULL);
+	});
+
+	free(v1);
+	free(v2);
+}
+
+// ------------------------------------------------------------
+// Main
+// ------------------------------------------------------------
+
+int main(void) {
+	RzTable *t = rz_table_new();
+	RZ_BENCH_TABLE_INIT(t);
+
+	/* Construction-only -- isolates set_b() + b_hits build cost. */
+	bench_bytes_new_similar_medium(t);
+	bench_bytes_new_divergent_medium(t);
+
+	/* Core diffing pipeline. */
+	bench_bytes_matches_similar_small(t);
+	bench_bytes_matches_similar_medium(t);
+	bench_bytes_matches_divergent_medium(t);
+	bench_bytes_opcodes_similar_medium(t);
+	bench_bytes_opcodes_grouped_similar_medium(t);
+
+	/* Ratio. */
+	bench_bytes_ratio_similar_medium(t);
+
+	/* End-to-end with formatting. */
+	bench_bytes_unified_similar_medium(t);
+	bench_bytes_unified_large_similar(t);
+
+	/* Line-diff variants. */
+	bench_lines_matches_similar(t);
+	bench_lines_unified_similar(t);
+
+	/* Distance algorithms. */
+	bench_myers_distance_similar(t);
+	bench_myers_distance_divergent(t);
+	bench_levenshtein_distance_similar(t);
+	bench_levenshtein_distance_divergent(t);
+
+	/* Internal helpers. */
+	bench_hash_data_64B(t);
+	bench_hash_data_1KB(t);
+
+	/* Real-world torture scenarios. */
+	bench_torture_firmware_pair(t);
+	bench_torture_big_exec(t);
+	bench_torture_memdump(t);
+	bench_torture_block_shift(t);
+	bench_torture_repeating_pattern(t);
+	bench_torture_all_zeros(t);
+	bench_torture_distances_firmware(t);
+
+	RZ_BENCH_TABLE_PRINT_AND_FREE(t);
+	return 0;
+}

--- a/test/bench/meson.build
+++ b/test/bench/meson.build
@@ -20,6 +20,7 @@ if get_option('enable_benchmarks')
   # List of benchmarks to build
   benchmarks = [
     'bitvector',
+    'diff',
     'il',
     'ht',
     'util',
@@ -35,6 +36,7 @@ if get_option('enable_benchmarks')
       dependencies: [
         bench_utils_dep,
         rz_util_dep,
+        rz_diff_dep,
         rz_core_dep,
       ],
       install: false,
@@ -42,7 +44,7 @@ if get_option('enable_benchmarks')
     )
     
     # Register with meson test system (run with: meson test --benchmark)
-    benchmark(bench, exe, suite: 'bench', timeout: 120)
+    benchmark(bench, exe, suite: 'bench', timeout: 1024)
   endforeach
 
   message('Benchmarks enabled - build with "meson compile" and run with "meson test --benchmark"')

--- a/test/unit/test_diff.c
+++ b/test/unit/test_diff.c
@@ -257,10 +257,934 @@ bool test_rz_diff_unified_bytes(void) {
 	mu_end;
 }
 
+// ------------------------------------------------------------
+// Additional tests covering the rest of the RzDiff public API.
+//
+// These tests exercise the matches, opcodes, opcodes-grouped,
+// ratio, sizes-ratio, generic-methods and JSON output paths,
+// plus edge cases (empty, identical, single byte, NULL guard)
+// and the ignore-callback hooks.
+// ------------------------------------------------------------
+
+// ------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------
+
+static bool ignore_whitespace_byte(const ut64 b) {
+	return b == ' ' || b == '\t';
+}
+
+static bool ignore_blank_line(const char *line) {
+	if (!line) {
+		return true;
+	}
+	for (const char *p = line; *p; p++) {
+		if (*p != ' ' && *p != '\t' && *p != '\n' && *p != '\r') {
+			return false;
+		}
+	}
+	return true;
+}
+
+// ------------------------------------------------------------
+// rz_diff_hash_data
+// ------------------------------------------------------------
+
+bool test_rz_diff_hash_data(void) {
+	// Empty / NULL input must return the documented seed (5381).
+	mu_assert_eq(rz_diff_hash_data(NULL, 0), 5381u, "hash on NULL returns seed");
+	mu_assert_eq(rz_diff_hash_data((const ut8 *)"", 0), 5381u, "hash on size 0 returns seed");
+
+	// Determinism: equal inputs must hash to equal values.
+	const ut8 *a = (const ut8 *)"rizin";
+	const ut8 *b = (const ut8 *)"rizin";
+	mu_assert_eq(rz_diff_hash_data(a, 5), rz_diff_hash_data(b, 5), "deterministic hash");
+
+	// Different inputs of the same size should generally differ (probabilistic,
+	// but these two clearly do under the DJB-XOR mix used here).
+	const ut8 *c = (const ut8 *)"radar";
+	mu_assert_neq(rz_diff_hash_data(a, 5), rz_diff_hash_data(c, 5), "different inputs hash differently");
+
+	mu_end;
+}
+
+// ------------------------------------------------------------
+// Construction / accessors / NULL guards
+// ------------------------------------------------------------
+
+bool test_rz_diff_get_a_b(void) {
+	const ut8 *a = (const ut8 *)"AAAA";
+	const ut8 *b = (const ut8 *)"BBBB";
+	RzDiff *d = rz_diff_bytes_new(a, 4, b, 4, NULL);
+	mu_assert_notnull(d, "diff created");
+	mu_assert_ptreq(rz_diff_get_a(d), a, "get_a returns the original A pointer");
+	mu_assert_ptreq(rz_diff_get_b(d), b, "get_b returns the original B pointer");
+	rz_diff_free(d);
+	mu_end;
+}
+
+bool test_rz_diff_null_inputs(void) {
+	// rz_diff_free is documented RZ_NULLABLE -- it must accept NULL as a
+	// no-op. This is the only NULL-input case we can portably test: the
+	// `_new` constructors are RZ_NONNULL on their data pointers, so passing
+	// NULL there is undefined behavior by contract and aborts when the
+	// build is configured with RZ_CHECKS_LEVEL=3 (used by the codecov CI
+	// job, see .github/workflows/ci.yml: `-Dchecks_level=3`).
+	rz_diff_free(NULL);
+	mu_end;
+}
+
+bool test_rz_diff_empty_buffers(void) {
+	// Diff of two empty buffers: should succeed, ratio = 1.0, no opcodes,
+	// no matches besides the synthetic end sentinel.
+	const ut8 empty[1] = { 0 };
+	RzDiff *d = rz_diff_bytes_new(empty, 0, empty, 0, NULL);
+	mu_assert_notnull(d, "diff on (empty, empty) created");
+
+	double r = -1.0;
+	mu_assert_true(rz_diff_ratio(d, &r), "ratio on empty returns true");
+	mu_assert_eqf(r, 1.0, "ratio on (empty, empty) is 1.0");
+
+	double sr = -1.0;
+	mu_assert_true(rz_diff_sizes_ratio(d, &sr), "sizes_ratio on empty returns true");
+	mu_assert_eqf(sr, 1.0, "sizes_ratio on (empty, empty) is 1.0");
+
+	RzList *ops = rz_diff_opcodes_new(d);
+	mu_assert_notnull(ops, "opcodes_new on empty returns a list");
+	mu_assert_eq(rz_list_length(ops), 0, "no opcodes between two empty buffers");
+	rz_list_free(ops);
+
+	rz_diff_free(d);
+	mu_end;
+}
+
+bool test_rz_diff_identical_buffers(void) {
+	// For identical inputs we expect a single EQUAL opcode spanning the whole
+	// buffer, ratio == 1.0, and exactly one non-sentinel match.
+	const ut8 *s = (const ut8 *)"abcdefghij";
+	RzDiff *d = rz_diff_bytes_new(s, 10, s, 10, NULL);
+	mu_assert_notnull(d, "diff on identical created");
+
+	double r = 0.0;
+	mu_assert_true(rz_diff_ratio(d, &r), "ratio returns true");
+	mu_assert_eqf(r, 1.0, "ratio on identical == 1.0");
+
+	RzList *ops = rz_diff_opcodes_new(d);
+	mu_assert_notnull(ops, "opcodes_new on identical not null");
+	mu_assert_eq(rz_list_length(ops), 1, "exactly one opcode on identical");
+	RzDiffOp *op = rz_list_first_val(ops);
+	mu_assert_notnull(op, "first opcode not null");
+	mu_assert_eq((int)op->type, (int)RZ_DIFF_OP_EQUAL, "opcode type is EQUAL");
+	mu_assert_eq(op->a_beg, 0, "EQUAL spans from 0");
+	mu_assert_eq(op->a_end, 10, "EQUAL spans up to a_size");
+	mu_assert_eq(op->b_beg, 0, "EQUAL spans from 0 (b)");
+	mu_assert_eq(op->b_end, 10, "EQUAL spans up to b_size");
+	rz_list_free(ops);
+
+	rz_diff_free(d);
+	mu_end;
+}
+
+bool test_rz_diff_completely_different(void) {
+	// Two strings that share no characters at all -> no equal matches,
+	// ratio should be 0.0, single REPLACE opcode covering the full ranges.
+	const ut8 *a = (const ut8 *)"AAAAA";
+	const ut8 *b = (const ut8 *)"BBBBB";
+	RzDiff *d = rz_diff_bytes_new(a, 5, b, 5, NULL);
+	mu_assert_notnull(d, "diff created");
+
+	double r = -1.0;
+	mu_assert_true(rz_diff_ratio(d, &r), "ratio call ok");
+	mu_assert_eqf(r, 0.0, "ratio is 0.0 for disjoint alphabets");
+
+	double sr = -1.0;
+	mu_assert_true(rz_diff_sizes_ratio(d, &sr), "sizes_ratio call ok");
+	mu_assert_eqf(sr, 1.0, "sizes ratio is 1.0 for equal lengths");
+
+	RzList *ops = rz_diff_opcodes_new(d);
+	mu_assert_notnull(ops, "opcodes not null");
+	mu_assert_eq(rz_list_length(ops), 1, "one REPLACE opcode");
+	RzDiffOp *op = rz_list_first_val(ops);
+	mu_assert_eq((int)op->type, (int)RZ_DIFF_OP_REPLACE, "single REPLACE opcode");
+	mu_assert_eq(RZ_DIFF_OP_SIZE_A(op), 5, "REPLACE covers all of A");
+	mu_assert_eq(RZ_DIFF_OP_SIZE_B(op), 5, "REPLACE covers all of B");
+	rz_list_free(ops);
+
+	rz_diff_free(d);
+	mu_end;
+}
+
+bool test_rz_diff_pure_insert_and_delete(void) {
+	// Pure insert: A is empty, B has content -> single INSERT, ratio 0.
+	{
+		const ut8 *a = (const ut8 *)"";
+		const ut8 *b = (const ut8 *)"hello";
+		RzDiff *d = rz_diff_bytes_new(a, 0, b, 5, NULL);
+		mu_assert_notnull(d, "diff(empty A) created");
+
+		RzList *ops = rz_diff_opcodes_new(d);
+		mu_assert_notnull(ops, "ops not null");
+		mu_assert_eq(rz_list_length(ops), 1, "one INSERT opcode");
+		RzDiffOp *op = rz_list_first_val(ops);
+		mu_assert_eq((int)op->type, (int)RZ_DIFF_OP_INSERT, "type INSERT");
+		mu_assert_eq(op->a_beg, 0, "a_beg 0");
+		mu_assert_eq(op->a_end, 0, "a_end 0");
+		mu_assert_eq(op->b_beg, 0, "b_beg 0");
+		mu_assert_eq(op->b_end, 5, "b_end 5");
+		rz_list_free(ops);
+
+		double r = -1.0;
+		mu_assert_true(rz_diff_ratio(d, &r), "ratio ok");
+		mu_assert_eqf(r, 0.0, "ratio 0 for pure insert");
+		rz_diff_free(d);
+	}
+
+	// Pure delete: A has content, B is empty -> single DELETE.
+	{
+		const ut8 *a = (const ut8 *)"hello";
+		const ut8 *b = (const ut8 *)"";
+		RzDiff *d = rz_diff_bytes_new(a, 5, b, 0, NULL);
+		mu_assert_notnull(d, "diff(empty B) created");
+
+		RzList *ops = rz_diff_opcodes_new(d);
+		mu_assert_notnull(ops, "ops not null");
+		mu_assert_eq(rz_list_length(ops), 1, "one DELETE opcode");
+		RzDiffOp *op = rz_list_first_val(ops);
+		mu_assert_eq((int)op->type, (int)RZ_DIFF_OP_DELETE, "type DELETE");
+		mu_assert_eq(op->a_beg, 0, "a_beg 0");
+		mu_assert_eq(op->a_end, 5, "a_end 5");
+		mu_assert_eq(op->b_beg, 0, "b_beg 0");
+		mu_assert_eq(op->b_end, 0, "b_end 0");
+		rz_list_free(ops);
+		rz_diff_free(d);
+	}
+
+	mu_end;
+}
+
+// ------------------------------------------------------------
+// rz_diff_matches_new
+// ------------------------------------------------------------
+
+bool test_rz_diff_matches_basic(void) {
+	// Inputs reproducing the README example "ABCDEFGHI" vs "YZBCDLZNHI":
+	// matches should be (B..D, H..I) plus the synthetic end sentinel.
+	const ut8 *a = (const ut8 *)"ABCDEFGHI";
+	const ut8 *b = (const ut8 *)"YZBCDLZNHI";
+	RzDiff *d = rz_diff_bytes_new(a, 9, b, 10, NULL);
+	mu_assert_notnull(d, "diff created");
+
+	RzList *matches = rz_diff_matches_new(d);
+	mu_assert_notnull(matches, "matches not null");
+	// At least 2 real matches plus the (a_size, b_size, 0) sentinel.
+	mu_assert_true(rz_list_length(matches) >= 3, "at least two real matches + sentinel");
+
+	// All non-sentinel matches must point to byte-identical sub-strings of A and B.
+	RzListIter *it = NULL;
+	RzDiffMatch *m = NULL;
+	rz_list_foreach (matches, it, m) {
+		if (m->size == 0) {
+			continue;
+		}
+		mu_assert_eq(memcmp(a + m->a, b + m->b, m->size), 0, "match content equal in A and B");
+	}
+
+	// The very last entry is the synthetic end sentinel at (a_size, b_size, 0).
+	RzDiffMatch *last = rz_list_last_val(matches);
+	mu_assert_eq(last->size, 0u, "last match is sentinel with size 0");
+	mu_assert_eq(last->a, 9u, "sentinel a == a_size");
+	mu_assert_eq(last->b, 10u, "sentinel b == b_size");
+
+	rz_list_free(matches);
+	rz_diff_free(d);
+	mu_end;
+}
+
+// ------------------------------------------------------------
+// rz_diff_opcodes_grouped_new
+// ------------------------------------------------------------
+
+bool test_rz_diff_opcodes_grouped_identical(void) {
+	// Identical inputs: documented behavior is that a single trivial EQUAL
+	// opcode group is produced.
+	const ut8 *s = (const ut8 *)"identical content";
+	ut32 n = (ut32)strlen((const char *)s);
+	RzDiff *d = rz_diff_bytes_new(s, n, s, n, NULL);
+	mu_assert_notnull(d, "diff created");
+
+	RzList *groups = rz_diff_opcodes_grouped_new(d, RZ_DIFF_DEFAULT_N_GROUPS);
+	mu_assert_notnull(groups, "groups not null");
+	// Per the source, when the only opcode is a single EQUAL the empty group
+	// is dropped, so we may get zero groups; either way we must not crash.
+	rz_list_free(groups);
+	rz_diff_free(d);
+	mu_end;
+}
+
+bool test_rz_diff_opcodes_grouped_replace(void) {
+	const ut8 *a = (const ut8 *)"AAAAAAAA";
+	const ut8 *b = (const ut8 *)"BBBBBBBB";
+	RzDiff *d = rz_diff_bytes_new(a, 8, b, 8, NULL);
+	mu_assert_notnull(d, "diff created");
+
+	RzList *groups = rz_diff_opcodes_grouped_new(d, RZ_DIFF_DEFAULT_N_GROUPS);
+	mu_assert_notnull(groups, "groups not null");
+	mu_assert_true(rz_list_length(groups) >= 1, "at least one group for non-trivial diff");
+
+	// Every group must contain at least one op, and every op's ranges must be
+	// in-bounds.
+	RzListIter *itg = NULL;
+	RzList *group = NULL;
+	rz_list_foreach (groups, itg, group) {
+		mu_assert_true(rz_list_length(group) >= 1, "non-empty group");
+		RzListIter *ito = NULL;
+		RzDiffOp *op = NULL;
+		rz_list_foreach (group, ito, op) {
+			mu_assert_true(op->a_beg >= 0 && op->a_end <= 8, "a-range in bounds");
+			mu_assert_true(op->b_beg >= 0 && op->b_end <= 8, "b-range in bounds");
+			mu_assert_true(op->a_end >= op->a_beg, "a-range valid");
+			mu_assert_true(op->b_end >= op->b_beg, "b-range valid");
+		}
+	}
+
+	rz_list_free(groups);
+	rz_diff_free(d);
+	mu_end;
+}
+
+// ------------------------------------------------------------
+// rz_diff_ratio / rz_diff_sizes_ratio
+// ------------------------------------------------------------
+
+bool test_rz_diff_ratio_bounds(void) {
+	const ut8 *a = (const ut8 *)"the quick brown fox";
+	const ut8 *b = (const ut8 *)"the quirky brown ox";
+	RzDiff *d = rz_diff_bytes_new(a, (ut32)strlen((const char *)a),
+		b, (ut32)strlen((const char *)b), NULL);
+	mu_assert_notnull(d, "diff created");
+
+	double r = -1.0;
+	mu_assert_true(rz_diff_ratio(d, &r), "ratio call ok");
+	mu_assert_true(r > 0.0 && r < 1.0, "ratio strictly in (0, 1) for partial overlap");
+
+	double sr = -1.0;
+	mu_assert_true(rz_diff_sizes_ratio(d, &sr), "sizes_ratio call ok");
+	mu_assert_true(sr > 0.0 && sr <= 1.0, "sizes_ratio in (0, 1]");
+
+	rz_diff_free(d);
+	mu_end;
+}
+
+bool test_rz_diff_sizes_ratio_skewed(void) {
+	// A is 4x the size of B: sizes ratio = 2*min/(a+b) = 2*1/(4+1) = 0.4
+	const ut8 *a = (const ut8 *)"aaaa";
+	const ut8 *b = (const ut8 *)"a";
+	RzDiff *d = rz_diff_bytes_new(a, 4, b, 1, NULL);
+	mu_assert_notnull(d, "diff created");
+
+	double sr = 0.0;
+	mu_assert_true(rz_diff_sizes_ratio(d, &sr), "sizes_ratio call ok");
+	mu_assert_true(fabs(sr - 0.4) < 1e-9, "sizes_ratio is 2*min/(a+b)");
+
+	rz_diff_free(d);
+	mu_end;
+}
+
+// ------------------------------------------------------------
+// Ignore callbacks
+// ------------------------------------------------------------
+
+bool test_rz_diff_ignore_byte(void) {
+	// The `ignore` callback in librz/diff has Python-difflib `isjunk`
+	// semantics: ignored bytes in B are not registered as anchors in the
+	// hit map, so matches are never *started* on them. They are NOT
+	// treated as equivalent to other bytes for the purpose of compare().
+	//
+	// So "ab cd" vs "ab\tcd" with whitespace ignored still produces a
+	// REPLACE for the differing byte at position 2 -- the ratio is the
+	// same as without the callback. We assert (1) the ignore call
+	// succeeds, (2) the result is in [0, 1], and (3) the ratio is no
+	// worse than the plain ratio.
+	const ut8 *a = (const ut8 *)"ab cd";
+	const ut8 *b = (const ut8 *)"ab\tcd";
+
+	RzDiff *plain = rz_diff_bytes_new(a, 5, b, 5, NULL);
+	mu_assert_notnull(plain, "plain diff created");
+	double r_plain = -1.0;
+	mu_assert_true(rz_diff_ratio(plain, &r_plain), "plain ratio ok");
+	rz_diff_free(plain);
+
+	RzDiff *ign = rz_diff_bytes_new(a, 5, b, 5, ignore_whitespace_byte);
+	mu_assert_notnull(ign, "ignore diff created");
+	double r_ign = -1.0;
+	mu_assert_true(rz_diff_ratio(ign, &r_ign), "ignore ratio ok");
+	rz_diff_free(ign);
+
+	mu_assert_true(r_ign >= 0.0 && r_ign <= 1.0, "ignore ratio is a valid ratio");
+	mu_assert_true(r_ign >= r_plain, "ignoring whitespace does not decrease the ratio");
+
+	// Sanity case: when the same whitespace appears at the same offset in
+	// both buffers, the ratio is exactly 1.0 -- with or without ignore.
+	const ut8 *a2 = (const ut8 *)"ab cd";
+	const ut8 *b2 = (const ut8 *)"ab cd";
+	RzDiff *same = rz_diff_bytes_new(a2, 5, b2, 5, ignore_whitespace_byte);
+	mu_assert_notnull(same, "same-bytes diff created");
+	double r_same = -1.0;
+	mu_assert_true(rz_diff_ratio(same, &r_same), "same ratio ok");
+	mu_assert_eqf(r_same, 1.0, "ignore-whitespace on identical buffers: ratio 1.0");
+	rz_diff_free(same);
+
+	mu_end;
+}
+
+bool test_rz_diff_ignore_line(void) {
+	const char *a =
+		"one\n"
+		"\n"
+		"two\n";
+	const char *b =
+		"one\n"
+		"   \n"
+		"two\n";
+
+	RzDiff *plain = rz_diff_lines_new(a, b, NULL);
+	mu_assert_notnull(plain, "plain lines diff");
+	double r_plain = -1.0;
+	mu_assert_true(rz_diff_ratio(plain, &r_plain), "plain ratio ok");
+	rz_diff_free(plain);
+
+	RzDiff *ign = rz_diff_lines_new(a, b, ignore_blank_line);
+	mu_assert_notnull(ign, "ignore-blank lines diff");
+	double r_ign = -1.0;
+	mu_assert_true(rz_diff_ratio(ign, &r_ign), "ignore-blank ratio ok");
+	rz_diff_free(ign);
+
+	mu_assert_true(r_ign >= r_plain, "ignoring blank lines can only raise ratio");
+
+	mu_end;
+}
+
+// ------------------------------------------------------------
+// rz_diff_generic_new -- exercise the user-defined methods path on an
+// array of integers.
+// ------------------------------------------------------------
+
+static const void *int_elem_at(const void *array, ut32 index) {
+	const ut32 *arr = array;
+	return &arr[index];
+}
+
+static ut32 int_elem_hash(const void *elem) {
+	const ut32 *v = elem;
+	return rz_diff_hash_data((const ut8 *)v, sizeof(ut32));
+}
+
+static int int_compare(const void *a_elem, const void *b_elem) {
+	const ut32 *a = a_elem;
+	const ut32 *b = b_elem;
+	return (*a == *b) ? 0 : 1;
+}
+
+static void int_stringify(const void *elem, RzStrBuf *sb) {
+	const ut32 *v = elem;
+	rz_strbuf_setf(sb, "%u", *v);
+}
+
+bool test_rz_diff_generic_ints(void) {
+	const ut32 a[] = { 1, 2, 3, 4, 5, 6 };
+	const ut32 b[] = { 1, 2, 3, 4, 5, 6 };
+	RzDiffMethods methods = {
+		.elem_at = int_elem_at,
+		.elem_hash = int_elem_hash,
+		.compare = int_compare,
+		.stringify = int_stringify,
+		.ignore = NULL,
+	};
+	RzDiff *d = rz_diff_generic_new(a, 6, b, 6, &methods);
+	mu_assert_notnull(d, "generic diff created");
+
+	double r = 0.0;
+	mu_assert_true(rz_diff_ratio(d, &r), "ratio call ok");
+	mu_assert_eqf(r, 1.0, "ratio of identical int arrays is 1.0");
+
+	RzList *ops = rz_diff_opcodes_new(d);
+	mu_assert_notnull(ops, "opcodes not null");
+	mu_assert_eq(rz_list_length(ops), 1, "single EQUAL on identical");
+	rz_list_free(ops);
+
+	rz_diff_free(d);
+	mu_end;
+}
+
+bool test_rz_diff_generic_ints_modified(void) {
+	const ut32 a[] = { 10, 20, 30, 40, 50 };
+	const ut32 b[] = { 10, 99, 30, 40, 50 };
+	RzDiffMethods methods = {
+		.elem_at = int_elem_at,
+		.elem_hash = int_elem_hash,
+		.compare = int_compare,
+		.stringify = int_stringify,
+		.ignore = NULL,
+	};
+	RzDiff *d = rz_diff_generic_new(a, 5, b, 5, &methods);
+	mu_assert_notnull(d, "generic diff created");
+
+	RzList *ops = rz_diff_opcodes_new(d);
+	mu_assert_notnull(ops, "ops not null");
+	mu_assert_true(rz_list_length(ops) >= 2, "at least EQUAL+REPLACE+EQUAL");
+
+	// Look for the REPLACE op at index 1 of A (where 20 -> 99).
+	bool found_replace = false;
+	RzListIter *it = NULL;
+	RzDiffOp *op = NULL;
+	rz_list_foreach (ops, it, op) {
+		if (op->type == RZ_DIFF_OP_REPLACE && op->a_beg == 1 && op->a_end == 2 && op->b_beg == 1 && op->b_end == 2) {
+			found_replace = true;
+			break;
+		}
+	}
+	mu_assert_true(found_replace, "REPLACE at position 1 found");
+
+	rz_list_free(ops);
+	rz_diff_free(d);
+	mu_end;
+}
+
+// Note: there's no test for `rz_diff_generic_new(..., NULL)` or for a
+// RzDiffMethods with missing required callbacks -- those inputs are
+// RZ_NONNULL by contract (see librz/include/rz_diff.h), and passing NULL
+// triggers an `assert()` under RZ_CHECKS_LEVEL=3 (used by the codecov CI
+// job). The successful-creation paths above already exercise every
+// callback field.
+
+// ------------------------------------------------------------
+// rz_diff_unified_json -- sanity-check the JSON output skeleton.
+// ------------------------------------------------------------
+
+bool test_rz_diff_unified_json_smoke(void) {
+	const char *a = "alpha\nbeta\ngamma\n";
+	const char *b = "alpha\nBETA\ngamma\n";
+	RzDiff *d = rz_diff_lines_new(a, b, NULL);
+	mu_assert_notnull(d, "lines diff created");
+
+	PJ *pj = rz_diff_unified_json(d, "a.txt", "b.txt", false);
+	mu_assert_notnull(pj, "unified_json returned a PJ");
+
+	const char *out = pj_string(pj);
+	mu_assert_notnull(out, "pj_string returned non-null");
+	// JSON must contain the file labels and the "diff" array key.
+	mu_assert_strcontains(out, "a.txt", "from label present");
+	mu_assert_strcontains(out, "b.txt", "to label present");
+	mu_assert_strcontains(out, "\"diff\":", "diff key present");
+
+	pj_free(pj);
+	rz_diff_free(d);
+	mu_end;
+}
+
+// ------------------------------------------------------------
+// Equivalence test: same content via bytes-diff and via lines-diff should
+// produce the same ratio (within float epsilon) when there are no line
+// boundary effects.
+// ------------------------------------------------------------
+
+bool test_rz_diff_ratio_byte_line_agree_on_identical(void) {
+	const char *s = "alpha\nbeta\ngamma\n";
+	RzDiff *db = rz_diff_bytes_new((const ut8 *)s, (ut32)strlen(s),
+		(const ut8 *)s, (ut32)strlen(s), NULL);
+	RzDiff *dl = rz_diff_lines_new(s, s, NULL);
+	mu_assert_notnull(db, "bytes diff created");
+	mu_assert_notnull(dl, "lines diff created");
+
+	double rb = 0.0, rl = 0.0;
+	mu_assert_true(rz_diff_ratio(db, &rb), "bytes ratio ok");
+	mu_assert_true(rz_diff_ratio(dl, &rl), "lines ratio ok");
+	mu_assert_eqf(rb, 1.0, "bytes ratio == 1.0 on identical");
+	mu_assert_eqf(rl, 1.0, "lines ratio == 1.0 on identical");
+
+	rz_diff_free(db);
+	rz_diff_free(dl);
+	mu_end;
+}
+
+// ------------------------------------------------------------
+// Single-byte / single-line buffers.
+// ------------------------------------------------------------
+
+bool test_rz_diff_single_element(void) {
+	// Single-byte identical.
+	{
+		const ut8 *a = (const ut8 *)"x";
+		RzDiff *d = rz_diff_bytes_new(a, 1, a, 1, NULL);
+		mu_assert_notnull(d, "diff 1-byte identical");
+		double r = 0.0;
+		mu_assert_true(rz_diff_ratio(d, &r), "ratio ok");
+		mu_assert_eqf(r, 1.0, "1-byte identical ratio 1.0");
+		rz_diff_free(d);
+	}
+
+	// Single-byte different.
+	{
+		const ut8 *a = (const ut8 *)"x";
+		const ut8 *b = (const ut8 *)"y";
+		RzDiff *d = rz_diff_bytes_new(a, 1, b, 1, NULL);
+		mu_assert_notnull(d, "diff 1-byte different");
+		double r = 1.0;
+		mu_assert_true(rz_diff_ratio(d, &r), "ratio ok");
+		mu_assert_eqf(r, 0.0, "1-byte different ratio 0.0");
+
+		RzList *ops = rz_diff_opcodes_new(d);
+		mu_assert_notnull(ops, "ops not null");
+		mu_assert_eq(rz_list_length(ops), 1, "single REPLACE");
+		RzDiffOp *op = rz_list_first_val(ops);
+		mu_assert_eq((int)op->type, (int)RZ_DIFF_OP_REPLACE, "REPLACE");
+		rz_list_free(ops);
+		rz_diff_free(d);
+	}
+
+	mu_end;
+}
+
+// ------------------------------------------------------------
+// Stress / regression smoke test: a larger pseudo-random pair.
+//
+// This isn't a benchmark, but it does ensure that the full pipeline
+// (matches -> opcodes -> grouped -> unified) survives a realistic size
+// without errors. It uses a deterministic LCG so failures reproduce.
+// ------------------------------------------------------------
+
+bool test_rz_diff_stress_medium(void) {
+	const ut32 size = 2048;
+	ut8 *a = malloc(size);
+	ut8 *b = malloc(size);
+	mu_assert_notnull(a, "alloc a");
+	mu_assert_notnull(b, "alloc b");
+
+	ut32 s = 0x12345678u;
+	for (ut32 i = 0; i < size; i++) {
+		s = s * 1103515245u + 12345u;
+		a[i] = 0x20 + (s % (0x7f - 0x20));
+	}
+	memcpy(b, a, size);
+	// Flip every 64th byte.
+	for (ut32 i = 0; i < size; i += 64) {
+		b[i] ^= 0xff;
+	}
+
+	RzDiff *d = rz_diff_bytes_new(a, size, b, size, NULL);
+	mu_assert_notnull(d, "stress diff created");
+
+	RzList *matches = rz_diff_matches_new(d);
+	mu_assert_notnull(matches, "stress matches not null");
+	mu_assert_true(rz_list_length(matches) > 1, "stress: more than one match");
+	rz_list_free(matches);
+
+	RzList *ops = rz_diff_opcodes_new(d);
+	mu_assert_notnull(ops, "stress ops not null");
+	mu_assert_true(rz_list_length(ops) > 1, "stress: more than one op");
+	rz_list_free(ops);
+
+	char *u = rz_diff_unified_text(d, NULL, NULL, false, false);
+	mu_assert_notnull(u, "stress unified_text not null");
+	free(u);
+
+	rz_diff_free(d);
+	free(a);
+	free(b);
+	mu_end;
+}
+
+// ------------------------------------------------------------
+// Structural edge cases that mirror the "torture" benchmark
+// scenarios in test/bench/bench_diff.c. Each one checks the
+// shape of the produced opcodes for a recognizable real-world
+// binary pattern.
+// ------------------------------------------------------------
+
+bool test_rz_diff_all_zeros_pathological(void) {
+	// Pathological hash distribution: every byte in B hashes to the same
+	// bucket. The diff must still succeed and the ratio must reflect that
+	// the two buffers are almost equal (one byte changed).
+	const ut32 size = 512;
+	ut8 *a = malloc(size);
+	ut8 *b = malloc(size);
+	mu_assert_notnull(a, "alloc a");
+	mu_assert_notnull(b, "alloc b");
+	memset(a, 0, size);
+	memset(b, 0, size);
+	b[size / 2] = 0x01;
+
+	RzDiff *d = rz_diff_bytes_new(a, size, b, size, NULL);
+	mu_assert_notnull(d, "all-zeros diff created");
+
+	double r = 0.0;
+	mu_assert_true(rz_diff_ratio(d, &r), "ratio ok");
+	mu_assert_true(r > 0.99, "all-zeros: ratio nearly 1.0");
+
+	RzList *ops = rz_diff_opcodes_new(d);
+	mu_assert_notnull(ops, "ops not null");
+	// The exact opcode shape depends on which length-256 match the matcher
+	// picks first -- on this input there are many length-256 matches with
+	// the same score (every (a_pos, b_pos) where a_pos == b_pos +/- the
+	// flipped byte's offset works), and the algorithm is free to pick any.
+	// We've observed two valid encodings of "the two buffers differ by one
+	// byte":
+	//   - a single REPLACE op (one byte differs at the same position), or
+	//   - one INSERT plus one DELETE (B has one extra byte at some
+	//     position, A has one extra byte at the end -- equivalent).
+	// Both have total non-EQUAL byte coverage of at most one byte in each
+	// of A and B, which is the real invariant we want to lock down.
+	RzListIter *it = NULL;
+	RzDiffOp *op = NULL;
+	int seen_diff = 0;
+	int seen_equal = 0;
+	ut32 total_a_changed = 0;
+	ut32 total_b_changed = 0;
+	rz_list_foreach (ops, it, op) {
+		if (op->type == RZ_DIFF_OP_EQUAL) {
+			seen_equal++;
+		} else {
+			seen_diff++;
+			ut32 a_sz = RZ_DIFF_OP_SIZE_A(op);
+			ut32 b_sz = RZ_DIFF_OP_SIZE_B(op);
+			total_a_changed += a_sz;
+			total_b_changed += b_sz;
+		}
+	}
+	mu_assert_true(seen_diff >= 1 && seen_diff <= 2, "1 or 2 non-EQUAL ops");
+	mu_assert_eq(total_a_changed, 1, "exactly one byte of A is in non-EQUAL ops");
+	mu_assert_eq(total_b_changed, 1, "exactly one byte of B is in non-EQUAL ops");
+	mu_assert_true(seen_equal >= 1, "at least one EQUAL surrounding the diff");
+	rz_list_free(ops);
+
+	rz_diff_free(d);
+	free(a);
+	free(b);
+	mu_end;
+}
+
+bool test_rz_diff_repeating_pattern(void) {
+	// Short repeating pattern: every elem_hash bucket accumulates a lot of
+	// candidates. The algorithm should still terminate quickly and produce
+	// the right shape -- which is "almost entirely equal" with point
+	// disturbances.
+	const ut32 size = 1024;
+	ut8 *a = malloc(size);
+	ut8 *b = malloc(size);
+	mu_assert_notnull(a, "alloc a");
+	mu_assert_notnull(b, "alloc b");
+	for (ut32 i = 0; i < size; i++) {
+		a[i] = (ut8)('A' + (i & 3));
+	}
+	memcpy(b, a, size);
+	b[size / 4] = 'Z';
+	b[size / 2] = 'Z';
+	b[size * 3 / 4] = 'Z';
+
+	RzDiff *d = rz_diff_bytes_new(a, size, b, size, NULL);
+	mu_assert_notnull(d, "repeating-pattern diff");
+
+	double r = 0.0;
+	mu_assert_true(rz_diff_ratio(d, &r), "ratio ok");
+	mu_assert_true(r > 0.99, "repeating-pattern: ratio nearly 1.0");
+
+	rz_diff_free(d);
+	free(a);
+	free(b);
+	mu_end;
+}
+
+bool test_rz_diff_firmware_like_structure(void) {
+	// Miniature firmware: identical bootloader prefix (32 B), changed
+	// middle (16 B), identical tail (32 B). The opcode sequence must
+	// reflect that prefix and suffix are EQUAL and only the middle
+	// differs as a REPLACE.
+	const ut32 prefix = 32, mid = 16, suffix = 32;
+	const ut32 size = prefix + mid + suffix;
+	ut8 *v1 = malloc(size);
+	ut8 *v2 = malloc(size);
+	mu_assert_notnull(v1, "alloc v1");
+	mu_assert_notnull(v2, "alloc v2");
+	for (ut32 i = 0; i < size; i++) {
+		v1[i] = (ut8)(i ^ 0x5a);
+	}
+	memcpy(v2, v1, size);
+	// Re-write the middle 16 bytes in v2.
+	for (ut32 i = 0; i < mid; i++) {
+		v2[prefix + i] = (ut8)(0xff - i);
+	}
+
+	RzDiff *d = rz_diff_bytes_new(v1, size, v2, size, NULL);
+	mu_assert_notnull(d, "firmware-like diff");
+
+	RzList *ops = rz_diff_opcodes_new(d);
+	mu_assert_notnull(ops, "ops not null");
+	mu_assert_eq(rz_list_length(ops), 3, "EQUAL, REPLACE, EQUAL");
+
+	RzDiffOp *first = rz_list_first_val(ops);
+	RzDiffOp *last = rz_list_last_val(ops);
+	mu_assert_eq((int)first->type, (int)RZ_DIFF_OP_EQUAL, "first op EQUAL");
+	mu_assert_eq(first->a_beg, 0, "first op starts at 0");
+	mu_assert_eq(first->a_end, (st32)prefix, "first op ends at prefix");
+	mu_assert_eq((int)last->type, (int)RZ_DIFF_OP_EQUAL, "last op EQUAL");
+	mu_assert_eq(last->a_end, (st32)size, "last op ends at size");
+
+	rz_list_free(ops);
+	rz_diff_free(d);
+	free(v1);
+	free(v2);
+	mu_end;
+}
+
+bool test_rz_diff_block_shift(void) {
+	// A and B are byte-identical except a 64-byte block has been moved
+	// from one position to another. Ratio should be high (most content
+	// equal), and the opcode sequence should not be "single REPLACE on
+	// the full range" -- the matcher must find the shifted block.
+	const ut32 size = 512;
+	ut8 *a = malloc(size);
+	ut8 *b = malloc(size);
+	mu_assert_notnull(a, "alloc a");
+	mu_assert_notnull(b, "alloc b");
+	for (ut32 i = 0; i < size; i++) {
+		a[i] = (ut8)('a' + (i % 26));
+	}
+	// Make the moved block distinctive so it's actually findable.
+	for (ut32 i = 0; i < 64; i++) {
+		a[100 + i] = (ut8)(0x80 + i);
+	}
+	// In B, the same distinctive block lives at offset 300 and the
+	// region between is shifted left.
+	memcpy(b, a, 100);
+	memcpy(b + 100, a + 100 + 64, 300 - 100 - 64);
+	memcpy(b + 300 - 64, a + 100, 64);
+	memcpy(b + 300, a + 300, size - 300);
+
+	RzDiff *d = rz_diff_bytes_new(a, size, b, size, NULL);
+	mu_assert_notnull(d, "block-shift diff");
+
+	double r = 0.0;
+	mu_assert_true(rz_diff_ratio(d, &r), "ratio ok");
+	mu_assert_true(r > 0.5, "block-shift: most content matches");
+
+	RzList *ops = rz_diff_opcodes_new(d);
+	mu_assert_notnull(ops, "ops not null");
+	// More than one EQUAL means the matcher found more than just the
+	// common prefix or suffix.
+	int equal_ops = 0;
+	RzListIter *it = NULL;
+	RzDiffOp *op = NULL;
+	rz_list_foreach (ops, it, op) {
+		if (op->type == RZ_DIFF_OP_EQUAL) {
+			equal_ops++;
+		}
+	}
+	mu_assert_true(equal_ops >= 2, "block-shift produced multiple EQUAL ops");
+	rz_list_free(ops);
+
+	rz_diff_free(d);
+	free(a);
+	free(b);
+	mu_end;
+}
+
+bool test_rz_diff_growing_buffer(void) {
+	// B is a strict superset of A with content inserted in the middle --
+	// the "string got longer" pattern that produces a slide of the const
+	// pool in real binaries. We expect a single INSERT opcode.
+	const ut8 *a = (const ut8 *)"prefix_middle_suffix";
+	const ut8 *b = (const ut8 *)"prefix_middle_INSERTED_suffix";
+	RzDiff *d = rz_diff_bytes_new(a, (ut32)strlen((const char *)a),
+		b, (ut32)strlen((const char *)b), NULL);
+	mu_assert_notnull(d, "growing-buffer diff");
+
+	RzList *ops = rz_diff_opcodes_new(d);
+	mu_assert_notnull(ops, "ops not null");
+
+	bool found_insert = false;
+	RzListIter *it = NULL;
+	RzDiffOp *op = NULL;
+	rz_list_foreach (ops, it, op) {
+		if (op->type == RZ_DIFF_OP_INSERT) {
+			found_insert = true;
+			mu_assert_eq(RZ_DIFF_OP_SIZE_A(op), 0, "INSERT has zero A-range");
+			mu_assert_true(RZ_DIFF_OP_SIZE_B(op) > 0, "INSERT has positive B-range");
+		}
+	}
+	mu_assert_true(found_insert, "growing-buffer produces an INSERT op");
+	rz_list_free(ops);
+
+	rz_diff_free(d);
+	mu_end;
+}
+
+bool test_rz_diff_long_common_prefix(void) {
+	// Long common prefix, then total divergence. After the matcher peels
+	// off the prefix as EQUAL, the rest must come out as a single
+	// REPLACE / DELETE / INSERT depending on lengths.
+	const ut32 prefix_len = 256;
+	const ut32 tail_len = 64;
+	ut8 *a = malloc(prefix_len + tail_len);
+	ut8 *b = malloc(prefix_len + tail_len);
+	mu_assert_notnull(a, "alloc a");
+	mu_assert_notnull(b, "alloc b");
+	for (ut32 i = 0; i < prefix_len; i++) {
+		a[i] = b[i] = (ut8)('A' + (i % 26));
+	}
+	for (ut32 i = 0; i < tail_len; i++) {
+		a[prefix_len + i] = 0x10;
+		b[prefix_len + i] = 0x20;
+	}
+
+	RzDiff *d = rz_diff_bytes_new(a, prefix_len + tail_len, b, prefix_len + tail_len, NULL);
+	mu_assert_notnull(d, "long-prefix diff");
+
+	RzList *ops = rz_diff_opcodes_new(d);
+	mu_assert_notnull(ops, "ops not null");
+
+	// First op must be EQUAL and must cover the entire prefix.
+	RzDiffOp *first = rz_list_first_val(ops);
+	mu_assert_eq((int)first->type, (int)RZ_DIFF_OP_EQUAL, "first op EQUAL");
+	mu_assert_eq(first->a_beg, 0, "EQUAL starts at 0");
+	mu_assert_eq(first->a_end, (st32)prefix_len, "EQUAL covers full prefix");
+
+	rz_list_free(ops);
+	rz_diff_free(d);
+	free(a);
+	free(b);
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test(test_rz_diff_distances);
 	mu_run_test(test_rz_diff_unified_lines);
 	mu_run_test(test_rz_diff_unified_bytes);
+	mu_run_test(test_rz_diff_hash_data);
+	mu_run_test(test_rz_diff_get_a_b);
+	mu_run_test(test_rz_diff_null_inputs);
+	mu_run_test(test_rz_diff_empty_buffers);
+	mu_run_test(test_rz_diff_identical_buffers);
+	mu_run_test(test_rz_diff_completely_different);
+	mu_run_test(test_rz_diff_pure_insert_and_delete);
+	mu_run_test(test_rz_diff_matches_basic);
+	mu_run_test(test_rz_diff_opcodes_grouped_identical);
+	mu_run_test(test_rz_diff_opcodes_grouped_replace);
+	mu_run_test(test_rz_diff_ratio_bounds);
+	mu_run_test(test_rz_diff_sizes_ratio_skewed);
+	mu_run_test(test_rz_diff_ignore_byte);
+	mu_run_test(test_rz_diff_ignore_line);
+	mu_run_test(test_rz_diff_generic_ints);
+	mu_run_test(test_rz_diff_generic_ints_modified);
+	mu_run_test(test_rz_diff_unified_json_smoke);
+	mu_run_test(test_rz_diff_ratio_byte_line_agree_on_identical);
+	mu_run_test(test_rz_diff_single_element);
+	mu_run_test(test_rz_diff_stress_medium);
+	mu_run_test(test_rz_diff_all_zeros_pathological);
+	mu_run_test(test_rz_diff_repeating_pattern);
+	mu_run_test(test_rz_diff_firmware_like_structure);
+	mu_run_test(test_rz_diff_block_shift);
+	mu_run_test(test_rz_diff_growing_buffer);
+	mu_run_test(test_rz_diff_long_common_prefix);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Added real-life-like unit tests and benchmarks for the rz-diff. 

Generated with the Claude AI Opus 4.7 Max - asked for the "torture"-like style tests to cover real life scenarios when comparing binaries, and some edge cases.

It should help measuring the performance of the diffing algorithms, in particularly like https://github.com/rizinorg/rizin/pull/6385

**Test plan**

- CI is green
- `meson test -C build diff --benchmark -v`
