### PR TITLE
Install missing rz_math.h header

### DIFF
--- a/librz/include/meson.build
+++ b/librz/include/meson.build
@@ -91,6 +91,7 @@ rz_util_files = [
   'rz_util/rz_lang_byte_array.h',
   'rz_util/rz_log.h',
   'rz_util/rz_luhn.h',
+  'rz_util/rz_math.h',
   'rz_util/rz_mem.h',
   'rz_util/rz_name.h',
   'rz_util/rz_num.h',


### PR DESCRIPTION
Added in 702250eb4f6ba41e587dbcf09c30320da5e7c3fd but not installed
Causes build failures in external projects otherwise