### PR TITLE
support context-aware core plugins

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -3916,10 +3916,8 @@ static void core_analysis_using_plugins(RzCore *core) {
 	RzCorePlugin **val;
 	rz_iterator_foreach(it, val) {
 		RzCorePlugin *plugin = *val;
-		if (plugin->analysis_context) {
-			plugin->analysis_context(core, rz_core_plugin_context_get(core, plugin->name));
-		} else if (plugin->analysis) {
-			plugin->analysis(core);
+		if (plugin->analysis) {
+			plugin->analysis(core, rz_core_plugin_context_get(core, plugin));
 		}
 	}
 	rz_iterator_free(it);

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -3916,7 +3916,9 @@ static void core_analysis_using_plugins(RzCore *core) {
 	RzCorePlugin **val;
 	rz_iterator_foreach(it, val) {
 		RzCorePlugin *plugin = *val;
-		if (plugin->analysis) {
+		if (plugin->analysis_context) {
+			plugin->analysis_context(core, rz_core_plugin_context_get(core, plugin->name));
+		} else if (plugin->analysis) {
 			plugin->analysis(core);
 		}
 	}

--- a/librz/core/cplugin.c
+++ b/librz/core/cplugin.c
@@ -10,6 +10,27 @@
 
 static RzCorePlugin *core_static_plugins[] = { RZ_CORE_STATIC_PLUGINS };
 
+static bool core_plugin_init(RzCore *core, RzCorePlugin *plugin, void **user) {
+	if (plugin->init_context) {
+		return plugin->init_context(core, user);
+	}
+	return plugin->init ? plugin->init(core) : true;
+}
+
+static bool core_plugin_fini(RzCore *core, RzCorePlugin *plugin) {
+	void *user = rz_core_plugin_context_get(core, plugin->name);
+	bool res = true;
+	if (plugin->fini_context) {
+		res = plugin->fini_context(core, user);
+	} else if (plugin->fini) {
+		res = plugin->fini(core);
+	}
+	if (res && core->plugin_contexts) {
+		ht_sp_delete(core->plugin_contexts, plugin->name);
+	}
+	return res;
+}
+
 RZ_API bool rz_core_plugin_fini(RzCore *core) {
 	rz_return_val_if_fail(core->plugins, false);
 
@@ -17,25 +38,36 @@ RZ_API bool rz_core_plugin_fini(RzCore *core) {
 	RzCorePlugin **val;
 	rz_iterator_foreach(iter, val) {
 		RzCorePlugin *plugin = *val;
-		if (plugin->fini) {
-			plugin->fini(core);
-		}
+		core_plugin_fini(core, plugin);
 	}
 	rz_iterator_free(iter);
 	ht_sp_free(core->plugins);
+	RZ_FREE_CUSTOM(core->plugin_contexts, ht_sp_free);
 	ht_sp_free(core->plugin_configs);
 	core->plugins = NULL;
+	core->plugin_contexts = NULL;
 	return true;
 }
 
 RZ_API bool rz_core_plugin_add(RzCore *core, RZ_NONNULL RzCorePlugin *plugin) {
 	rz_return_val_if_fail(core, false);
-	rz_return_val_if_fail(plugin && plugin->init && plugin->name && plugin->author && plugin->license, false);
+	rz_return_val_if_fail(plugin && (plugin->init || plugin->init_context) && plugin->name && plugin->author && plugin->license, false);
 	// TODO: Add config from core plugin.
 	if (!ht_sp_insert(core->plugins, plugin->name, plugin)) {
 		RZ_LOG_WARN("Plugin '%s' was already added.\n", plugin->name);
 	}
-	if (!plugin->init(core)) {
+	void *user = NULL;
+	if (!core_plugin_init(core, plugin, &user)) {
+		if (plugin->fini_context && user) {
+			plugin->fini_context(core, user);
+		}
+		ht_sp_delete(core->plugins, plugin->name);
+		return false;
+	}
+	if (user && (!core->plugin_contexts || !ht_sp_insert(core->plugin_contexts, plugin->name, user))) {
+		if (plugin->fini_context) {
+			plugin->fini_context(core, user);
+		}
 		ht_sp_delete(core->plugins, plugin->name);
 		return false;
 	}
@@ -45,7 +77,7 @@ RZ_API bool rz_core_plugin_add(RzCore *core, RZ_NONNULL RzCorePlugin *plugin) {
 RZ_API bool rz_core_plugin_del(RzCore *core, RZ_NONNULL RzCorePlugin *plugin) {
 	rz_return_val_if_fail(core && plugin, false);
 	ht_sp_delete(core->plugin_configs, plugin->name);
-	if (plugin->fini && !plugin->fini(core)) {
+	if (!core_plugin_fini(core, plugin)) {
 		return false;
 	}
 	return ht_sp_delete(core->plugins, plugin->name);
@@ -55,6 +87,12 @@ RZ_API bool rz_core_plugin_init(RzCore *core) {
 	int i;
 	bool res = true;
 	core->plugins = ht_sp_new(HT_STR_DUP, NULL, NULL);
+	core->plugin_contexts = ht_sp_new(HT_STR_DUP, NULL, NULL);
+	if (!core->plugins || !core->plugin_contexts) {
+		RZ_FREE_CUSTOM(core->plugins, ht_sp_free);
+		RZ_FREE_CUSTOM(core->plugin_contexts, ht_sp_free);
+		return false;
+	}
 	for (i = 0; i < RZ_ARRAY_SIZE(core_static_plugins); i++) {
 		if (!rz_core_plugin_add(core, core_static_plugins[i])) {
 			RZ_LOG_ERROR("core: error loading core plugin '%s'\n", core_static_plugins[i]->name);
@@ -62,4 +100,9 @@ RZ_API bool rz_core_plugin_init(RzCore *core) {
 		}
 	}
 	return res;
+}
+
+RZ_API RZ_NULLABLE void *rz_core_plugin_context_get(RZ_NONNULL RzCore *core, RZ_NONNULL const char *name) {
+	rz_return_val_if_fail(core && name, NULL);
+	return core->plugin_contexts ? ht_sp_find(core->plugin_contexts, name, NULL) : NULL;
 }

--- a/librz/core/cplugin.c
+++ b/librz/core/cplugin.c
@@ -11,19 +11,15 @@
 static RzCorePlugin *core_static_plugins[] = { RZ_CORE_STATIC_PLUGINS };
 
 static bool core_plugin_init(RzCore *core, RzCorePlugin *plugin, void **user) {
-	if (plugin->init_context) {
-		return plugin->init_context(core, user);
-	}
-	return plugin->init ? plugin->init(core) : true;
+	*user = NULL;
+	return plugin->init(core, user);
 }
 
 static bool core_plugin_fini(RzCore *core, RzCorePlugin *plugin) {
-	void *user = rz_core_plugin_context_get(core, plugin->name);
+	void *user = rz_core_plugin_context_get(core, plugin);
 	bool res = true;
-	if (plugin->fini_context) {
-		res = plugin->fini_context(core, user);
-	} else if (plugin->fini) {
-		res = plugin->fini(core);
+	if (plugin->fini) {
+		res = plugin->fini(core, user);
 	}
 	if (res && core->plugin_contexts) {
 		ht_sp_delete(core->plugin_contexts, plugin->name);
@@ -51,7 +47,7 @@ RZ_API bool rz_core_plugin_fini(RzCore *core) {
 
 RZ_API bool rz_core_plugin_add(RzCore *core, RZ_NONNULL RzCorePlugin *plugin) {
 	rz_return_val_if_fail(core, false);
-	rz_return_val_if_fail(plugin && (plugin->init || plugin->init_context) && plugin->name && plugin->author && plugin->license, false);
+	rz_return_val_if_fail(plugin && plugin->init && plugin->name && plugin->author && plugin->license, false);
 	// TODO: Add config from core plugin.
 	bool found = false;
 	ht_sp_find(core->plugins, plugin->name, &found);
@@ -64,15 +60,15 @@ RZ_API bool rz_core_plugin_add(RzCore *core, RZ_NONNULL RzCorePlugin *plugin) {
 	}
 	void *user = NULL;
 	if (!core_plugin_init(core, plugin, &user)) {
-		if (plugin->fini_context && user) {
-			plugin->fini_context(core, user);
+		if (plugin->fini && user) {
+			plugin->fini(core, user);
 		}
 		ht_sp_delete(core->plugins, plugin->name);
 		return false;
 	}
 	if (user && (!core->plugin_contexts || !ht_sp_insert(core->plugin_contexts, plugin->name, user))) {
-		if (plugin->fini_context) {
-			plugin->fini_context(core, user);
+		if (plugin->fini) {
+			plugin->fini(core, user);
 		}
 		ht_sp_delete(core->plugins, plugin->name);
 		return false;
@@ -108,7 +104,29 @@ RZ_API bool rz_core_plugin_init(RzCore *core) {
 	return res;
 }
 
-RZ_API RZ_NULLABLE void *rz_core_plugin_context_get(RZ_NONNULL RzCore *core, RZ_NONNULL const char *name) {
-	rz_return_val_if_fail(core && name, NULL);
-	return core->plugin_contexts ? ht_sp_find(core->plugin_contexts, name, NULL) : NULL;
+RZ_API void *rz_core_plugin_context_get(RZ_NONNULL RzCore *core, RZ_NONNULL RzCorePlugin *plugin) {
+	rz_return_val_if_fail(core && plugin && plugin->name, NULL);
+	return core->plugin_contexts ? ht_sp_find(core->plugin_contexts, plugin->name, NULL) : NULL;
+}
+
+RZ_API RzCmdDesc *rz_core_plugin_cmd_desc_argv_new(RZ_NONNULL RzCore *core,
+	RZ_NONNULL const char *name, RZ_NONNULL RzCmdArgvCb cb,
+	RZ_NONNULL const RzCmdDescHelp *help) {
+	rz_return_val_if_fail(core && core->rcmd && name && cb && help, NULL);
+	RzCmdDesc *root_cd = rz_cmd_get_root(core->rcmd);
+	return root_cd ? rz_cmd_desc_argv_new(core->rcmd, root_cd, name, cb, help) : NULL;
+}
+
+RZ_API RzCmdDesc *rz_core_plugin_cmd_desc_group_new(RZ_NONNULL RzCore *core,
+	RZ_NONNULL const char *name, RZ_NULLABLE RzCmdArgvCb cb,
+	RZ_NULLABLE const RzCmdDescHelp *help,
+	RZ_NONNULL const RzCmdDescHelp *group_help) {
+	rz_return_val_if_fail(core && core->rcmd && name && group_help, NULL);
+	RzCmdDesc *root_cd = rz_cmd_get_root(core->rcmd);
+	return root_cd ? rz_cmd_desc_group_new(core->rcmd, root_cd, name, cb, help, group_help) : NULL;
+}
+
+RZ_API bool rz_core_plugin_cmd_desc_remove(RZ_NONNULL RzCore *core, RZ_NULLABLE RzCmdDesc *desc) {
+	rz_return_val_if_fail(core && core->rcmd, false);
+	return desc ? rz_cmd_desc_remove(core->rcmd, desc) : true;
 }

--- a/librz/core/cplugin.c
+++ b/librz/core/cplugin.c
@@ -53,8 +53,14 @@ RZ_API bool rz_core_plugin_add(RzCore *core, RZ_NONNULL RzCorePlugin *plugin) {
 	rz_return_val_if_fail(core, false);
 	rz_return_val_if_fail(plugin && (plugin->init || plugin->init_context) && plugin->name && plugin->author && plugin->license, false);
 	// TODO: Add config from core plugin.
-	if (!ht_sp_insert(core->plugins, plugin->name, plugin)) {
+	bool found = false;
+	ht_sp_find(core->plugins, plugin->name, &found);
+	if (found) {
 		RZ_LOG_WARN("Plugin '%s' was already added.\n", plugin->name);
+		return false;
+	}
+	if (!ht_sp_insert(core->plugins, plugin->name, plugin)) {
+		return false;
 	}
 	void *user = NULL;
 	if (!core_plugin_init(core, plugin, &user)) {

--- a/librz/core/p/core_dex.c
+++ b/librz/core/p/core_dex.c
@@ -26,6 +26,10 @@
 #define rz_cmd_desc_argv_modes_new_warn(rcmd, root, cmd, flags) \
 	rz_warn_if_fail(rz_cmd_desc_argv_state_new(rcmd, root, #cmd, flags, name_handler(cmd), &name_help(cmd)))
 
+typedef struct core_dex_context_t {
+	RzCmdDesc *cmd_desc;
+} CoreDexContext;
+
 static RzBinDex *core_dex_get_class(RzCore *core) {
 	if (!core) {
 		return NULL;
@@ -286,30 +290,40 @@ static const RzCmdDescHelp dex_usage = {
 static_description_without_args(dexs, "prints the dex structure");
 static_description_without_args(dexe, "prints the dex exported methods");
 
-static bool rz_cmd_dex_init_handler(RzCore *core) {
+static bool rz_cmd_dex_init_handler(RzCore *core, void **user) {
+	CoreDexContext *ctx = RZ_NEW0(CoreDexContext);
+	if (!ctx) {
+		return false;
+	}
+
 	RzCmd *rcmd = core->rcmd;
 	RzCmdDesc *root_cd = rz_cmd_get_root(rcmd);
 	if (!root_cd) {
+		free(ctx);
 		return false;
 	}
 
 	RzCmdDesc *dex = rz_cmd_desc_group_new(rcmd, root_cd, "dex", NULL, NULL, &dex_usage);
 	if (!dex) {
 		rz_warn_if_reached();
+		free(ctx);
 		return false;
 	}
+	ctx->cmd_desc = dex;
 
 	rz_cmd_desc_argv_modes_new_warn(rcmd, dex, dexs, RZ_OUTPUT_MODE_STANDARD);
 	rz_cmd_desc_argv_modes_new_warn(rcmd, dex, dexe, RZ_OUTPUT_MODE_STANDARD);
 
+	*user = ctx;
 	return true;
 }
 
-static bool rz_cmd_dex_fini_handler(RzCore *core) {
-	RzCmd *rcmd = core->rcmd;
-	RzCmdDesc *cd = rz_cmd_get_desc(rcmd, "dex");
-	rz_return_val_if_fail(cd, false);
-	return rz_cmd_desc_remove(rcmd, cd);
+static bool rz_cmd_dex_fini_handler(RzCore *core, void *user) {
+	CoreDexContext *ctx = user;
+	rz_return_val_if_fail(ctx && ctx->cmd_desc, false);
+	bool res = rz_cmd_desc_remove(core->rcmd, ctx->cmd_desc);
+	free(ctx);
+	return res;
 }
 
 RzCorePlugin rz_core_plugin_dex = {
@@ -318,8 +332,8 @@ RzCorePlugin rz_core_plugin_dex = {
 	.license = "LGPL-3.0-only",
 	.author = "deroad",
 	.version = "1.0",
-	.init = rz_cmd_dex_init_handler,
-	.fini = rz_cmd_dex_fini_handler,
+	.init_context = rz_cmd_dex_init_handler,
+	.fini_context = rz_cmd_dex_fini_handler,
 };
 
 #ifndef RZ_PLUGIN_INCORE

--- a/librz/core/p/core_dex.c
+++ b/librz/core/p/core_dex.c
@@ -297,13 +297,7 @@ static bool rz_cmd_dex_init_handler(RzCore *core, void **user) {
 	}
 
 	RzCmd *rcmd = core->rcmd;
-	RzCmdDesc *root_cd = rz_cmd_get_root(rcmd);
-	if (!root_cd) {
-		free(ctx);
-		return false;
-	}
-
-	RzCmdDesc *dex = rz_cmd_desc_group_new(rcmd, root_cd, "dex", NULL, NULL, &dex_usage);
+	RzCmdDesc *dex = rz_core_plugin_cmd_desc_group_new(core, "dex", NULL, NULL, &dex_usage);
 	if (!dex) {
 		rz_warn_if_reached();
 		free(ctx);
@@ -321,7 +315,7 @@ static bool rz_cmd_dex_init_handler(RzCore *core, void **user) {
 static bool rz_cmd_dex_fini_handler(RzCore *core, void *user) {
 	CoreDexContext *ctx = user;
 	rz_return_val_if_fail(ctx && ctx->cmd_desc, false);
-	bool res = rz_cmd_desc_remove(core->rcmd, ctx->cmd_desc);
+	bool res = rz_core_plugin_cmd_desc_remove(core, ctx->cmd_desc);
 	free(ctx);
 	return res;
 }
@@ -332,8 +326,8 @@ RzCorePlugin rz_core_plugin_dex = {
 	.license = "LGPL-3.0-only",
 	.author = "deroad",
 	.version = "1.0",
-	.init_context = rz_cmd_dex_init_handler,
-	.fini_context = rz_cmd_dex_fini_handler,
+	.init = rz_cmd_dex_init_handler,
+	.fini = rz_cmd_dex_fini_handler,
 };
 
 #ifndef RZ_PLUGIN_INCORE

--- a/librz/core/p/core_java.c
+++ b/librz/core/p/core_java.c
@@ -298,13 +298,7 @@ static bool rz_cmd_java_init_handler(RzCore *core, void **user) {
 	}
 
 	RzCmd *rcmd = core->rcmd;
-	RzCmdDesc *root_cd = rz_cmd_get_root(rcmd);
-	if (!root_cd) {
-		free(ctx);
-		return false;
-	}
-
-	RzCmdDesc *java = rz_cmd_desc_group_new(rcmd, root_cd, "java", NULL, NULL, &java_usage);
+	RzCmdDesc *java = rz_core_plugin_cmd_desc_group_new(core, "java", NULL, NULL, &java_usage);
 	if (!java) {
 		rz_warn_if_reached();
 		free(ctx);
@@ -327,7 +321,7 @@ static bool rz_cmd_java_init_handler(RzCore *core, void **user) {
 static bool rz_cmd_java_fini_handler(RzCore *core, void *user) {
 	CoreJavaContext *ctx = user;
 	rz_return_val_if_fail(ctx && ctx->cmd_desc, false);
-	bool res = rz_cmd_desc_remove(core->rcmd, ctx->cmd_desc);
+	bool res = rz_core_plugin_cmd_desc_remove(core, ctx->cmd_desc);
 	free(ctx);
 	return res;
 }
@@ -338,8 +332,8 @@ RzCorePlugin rz_core_plugin_java = {
 	.license = "LGPL-3.0-only",
 	.author = "deroad",
 	.version = "1.0",
-	.init_context = rz_cmd_java_init_handler,
-	.fini_context = rz_cmd_java_fini_handler,
+	.init = rz_cmd_java_init_handler,
+	.fini = rz_cmd_java_fini_handler,
 };
 
 #ifndef RZ_PLUGIN_INCORE

--- a/librz/core/p/core_java.c
+++ b/librz/core/p/core_java.c
@@ -29,6 +29,10 @@
 #define rz_cmd_desc_argv_new_warn(rcmd, root, cmd) \
 	rz_warn_if_fail(rz_cmd_desc_argv_new(rcmd, root, #cmd, name_handler(cmd), &name_help(cmd)))
 
+typedef struct core_java_context_t {
+	RzCmdDesc *cmd_desc;
+} CoreJavaContext;
+
 static RzBinJavaClass *core_java_get_class(RzCore *core) {
 	if (!core) {
 		return NULL;
@@ -287,18 +291,26 @@ static const RzCmdDescHelp name_help(javar) = {
 	.args = name_args(javar),
 };
 
-static bool rz_cmd_java_init_handler(RzCore *core) {
+static bool rz_cmd_java_init_handler(RzCore *core, void **user) {
+	CoreJavaContext *ctx = RZ_NEW0(CoreJavaContext);
+	if (!ctx) {
+		return false;
+	}
+
 	RzCmd *rcmd = core->rcmd;
 	RzCmdDesc *root_cd = rz_cmd_get_root(rcmd);
 	if (!root_cd) {
+		free(ctx);
 		return false;
 	}
 
 	RzCmdDesc *java = rz_cmd_desc_group_new(rcmd, root_cd, "java", NULL, NULL, &java_usage);
 	if (!java) {
 		rz_warn_if_reached();
+		free(ctx);
 		return false;
 	}
+	ctx->cmd_desc = java;
 
 	rz_cmd_desc_argv_modes_new_warn(rcmd, java, javac, RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON);
 	rz_cmd_desc_argv_modes_new_warn(rcmd, java, javaf, RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON);
@@ -308,14 +320,16 @@ static bool rz_cmd_java_init_handler(RzCore *core) {
 	rz_cmd_desc_argv_new_warn(rcmd, java, javas);
 	rz_cmd_desc_argv_new_warn(rcmd, java, javar);
 
+	*user = ctx;
 	return true;
 }
 
-static bool rz_cmd_java_fini_handler(RzCore *core) {
-	RzCmd *rcmd = core->rcmd;
-	RzCmdDesc *cd = rz_cmd_get_desc(rcmd, "java");
-	rz_return_val_if_fail(cd, false);
-	return rz_cmd_desc_remove(rcmd, cd);
+static bool rz_cmd_java_fini_handler(RzCore *core, void *user) {
+	CoreJavaContext *ctx = user;
+	rz_return_val_if_fail(ctx && ctx->cmd_desc, false);
+	bool res = rz_cmd_desc_remove(core->rcmd, ctx->cmd_desc);
+	free(ctx);
+	return res;
 }
 
 RzCorePlugin rz_core_plugin_java = {
@@ -324,8 +338,8 @@ RzCorePlugin rz_core_plugin_java = {
 	.license = "LGPL-3.0-only",
 	.author = "deroad",
 	.version = "1.0",
-	.init = rz_cmd_java_init_handler,
-	.fini = rz_cmd_java_fini_handler,
+	.init_context = rz_cmd_java_init_handler,
+	.fini_context = rz_cmd_java_fini_handler,
 };
 
 #ifndef RZ_PLUGIN_INCORE

--- a/librz/core/p/core_plugin_example.c
+++ b/librz/core/p/core_plugin_example.c
@@ -66,19 +66,15 @@ RZ_IPI RzCmdStatus rz_cmd_example_handler(RzCore *core, int argc, const char **a
 	return RZ_CMD_STATUS_OK;
 }
 
-static bool rz_cmd_example_init(RzCore *core) {
+static bool rz_cmd_example_init(RzCore *core, void **user) {
+	(void)user;
 	/* Here you can initialize any aspect of the
 	 * core plugin (like allocate memory or register
 	 * the core plugin on the shell or create a socket) */
 	eprintf("This init was called!\n");
-	RzCmd *rcmd = core->rcmd;
-	RzCmdDesc *root_cd = rz_cmd_get_root(rcmd);
-	if (!root_cd) {
-		return false;
-	}
 
 	/* Here you will add your custom command and add it into the root tree. */
-	RzCmdDesc *cd = rz_cmd_desc_argv_new(rcmd, root_cd, "example", rz_cmd_example_handler, &cmd_example_help);
+	RzCmdDesc *cd = rz_core_plugin_cmd_desc_argv_new(core, "example", rz_cmd_example_handler, &cmd_example_help);
 	if (!cd) {
 		rz_warn_if_reached();
 		return false;
@@ -87,7 +83,8 @@ static bool rz_cmd_example_init(RzCore *core) {
 	return true;
 }
 
-static bool rz_cmd_example_fini(RzCore *core) {
+static bool rz_cmd_example_fini(RzCore *core, void *user) {
+	(void)user;
 	/* Here you can end any aspect of the core
 	 * plugin (like free allocated memory, or
 	 * end sockets, etc..) */

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -94,9 +94,8 @@ typedef enum {
 	RZ_CORE_WRITE_OP_SHIFT_RIGHT, ///< Write the shift right of existing byte and argument value
 } RzCoreWriteOp;
 
-typedef bool (*RzCorePluginCallback)(RzCore *core);
-typedef bool (*RzCorePluginContextInitCallback)(RzCore *core, void **user);
-typedef bool (*RzCorePluginContextCallback)(RzCore *core, void *user);
+typedef bool (*RzCorePluginInitCallback)(RzCore *core, RZ_OUT void **user);
+typedef bool (*RzCorePluginCallback)(RzCore *core, RZ_NULLABLE void *user);
 
 typedef struct rz_core_plugin_t {
 	const char *name;
@@ -104,12 +103,9 @@ typedef struct rz_core_plugin_t {
 	const char *license;
 	const char *author;
 	const char *version;
-	RzCorePluginCallback init; ///< Is called when the plugin is loaded by rizin
-	RzCorePluginCallback fini; ///< Is called when the plugin is unloaded by rizin
-	RzCorePluginCallback analysis; ///< Is called when automatic analysis is performed.
-	RzCorePluginContextInitCallback init_context; ///< Is called when the plugin is loaded by rizin. Stores per-core plugin state in user.
-	RzCorePluginContextCallback fini_context; ///< Is called when the plugin is unloaded by rizin with the per-core plugin state.
-	RzCorePluginContextCallback analysis_context; ///< Is called when automatic analysis is performed with the per-core plugin state.
+	RzCorePluginInitCallback init; ///< Is called when the plugin is loaded by rizin. Stores per-core plugin state in user.
+	RzCorePluginCallback fini; ///< Is called when the plugin is unloaded by rizin with the per-core plugin state.
+	RzCorePluginCallback analysis; ///< Is called when automatic analysis is performed with the per-core plugin state.
 } RzCorePlugin;
 
 typedef struct rz_core_rtr_host_t RzCoreRtrHost;
@@ -300,7 +296,7 @@ struct rz_core_t {
 	// They are used in pointer passing hacks in rz_types.h.
 	RzIO *io;
 	HtSP /*<RzCorePlugin *>*/ *plugins; ///< List of registered core plugins
-	HtSP /*<plugin_name: plugin context>*/ *plugin_contexts; ///< Per-core state indexed by core plugin name.
+	HtSP /*<void *>*/ *plugin_contexts; ///< Per-core plugin state
 	RzConfig *config;
 	HtSP /*<plugin_name: RzConfig>*/ *plugin_configs; ///< Pointers to plugin configurations. Indexed by plugin name
 	ut64 offset; // current seek
@@ -469,7 +465,15 @@ RZ_API bool rz_core_plugin_init(RzCore *core);
 RZ_API bool rz_core_plugin_add(RzCore *core, RZ_NONNULL RzCorePlugin *plugin);
 RZ_API bool rz_core_plugin_del(RzCore *core, RZ_NONNULL RzCorePlugin *plugin);
 RZ_API bool rz_core_plugin_fini(RzCore *core);
-RZ_API RZ_NULLABLE void *rz_core_plugin_context_get(RZ_NONNULL RzCore *core, RZ_NONNULL const char *name);
+RZ_API void *rz_core_plugin_context_get(RZ_NONNULL RzCore *core, RZ_NONNULL RzCorePlugin *plugin);
+RZ_API RzCmdDesc *rz_core_plugin_cmd_desc_argv_new(RZ_NONNULL RzCore *core,
+	RZ_NONNULL const char *name, RZ_NONNULL RzCmdArgvCb cb,
+	RZ_NONNULL const RzCmdDescHelp *help);
+RZ_API RzCmdDesc *rz_core_plugin_cmd_desc_group_new(RZ_NONNULL RzCore *core,
+	RZ_NONNULL const char *name, RZ_NULLABLE RzCmdArgvCb cb,
+	RZ_NULLABLE const RzCmdDescHelp *help,
+	RZ_NONNULL const RzCmdDescHelp *group_help);
+RZ_API bool rz_core_plugin_cmd_desc_remove(RZ_NONNULL RzCore *core, RZ_NULLABLE RzCmdDesc *desc);
 
 // #define rz_core_ncast(x) (RzCore*)(size_t)(x)
 RZ_API RZ_OWN RzPVector /*<char *>*/ *rz_core_get_themes(RZ_NONNULL RzCore *core);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -95,6 +95,8 @@ typedef enum {
 } RzCoreWriteOp;
 
 typedef bool (*RzCorePluginCallback)(RzCore *core);
+typedef bool (*RzCorePluginContextInitCallback)(RzCore *core, void **user);
+typedef bool (*RzCorePluginContextCallback)(RzCore *core, void *user);
 
 typedef struct rz_core_plugin_t {
 	const char *name;
@@ -105,6 +107,9 @@ typedef struct rz_core_plugin_t {
 	RzCorePluginCallback init; ///< Is called when the plugin is loaded by rizin
 	RzCorePluginCallback fini; ///< Is called when the plugin is unloaded by rizin
 	RzCorePluginCallback analysis; ///< Is called when automatic analysis is performed.
+	RzCorePluginContextInitCallback init_context; ///< Is called when the plugin is loaded by rizin. Stores per-core plugin state in user.
+	RzCorePluginContextCallback fini_context; ///< Is called when the plugin is unloaded by rizin with the per-core plugin state.
+	RzCorePluginContextCallback analysis_context; ///< Is called when automatic analysis is performed with the per-core plugin state.
 } RzCorePlugin;
 
 typedef struct rz_core_rtr_host_t RzCoreRtrHost;
@@ -295,6 +300,7 @@ struct rz_core_t {
 	// They are used in pointer passing hacks in rz_types.h.
 	RzIO *io;
 	HtSP /*<RzCorePlugin *>*/ *plugins; ///< List of registered core plugins
+	HtSP /*<plugin_name: plugin context>*/ *plugin_contexts; ///< Per-core state indexed by core plugin name.
 	RzConfig *config;
 	HtSP /*<plugin_name: RzConfig>*/ *plugin_configs; ///< Pointers to plugin configurations. Indexed by plugin name
 	ut64 offset; // current seek
@@ -463,6 +469,7 @@ RZ_API bool rz_core_plugin_init(RzCore *core);
 RZ_API bool rz_core_plugin_add(RzCore *core, RZ_NONNULL RzCorePlugin *plugin);
 RZ_API bool rz_core_plugin_del(RzCore *core, RZ_NONNULL RzCorePlugin *plugin);
 RZ_API bool rz_core_plugin_fini(RzCore *core);
+RZ_API RZ_NULLABLE void *rz_core_plugin_context_get(RZ_NONNULL RzCore *core, RZ_NONNULL const char *name);
 
 // #define rz_core_ncast(x) (RzCore*)(size_t)(x)
 RZ_API RZ_OWN RzPVector /*<char *>*/ *rz_core_get_themes(RZ_NONNULL RzCore *core);

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -54,6 +54,7 @@ if get_option('enable_tests')
     'core_analysis_stats',
     'core_bin',
     'core_cmd',
+    'core_plugin',
     'core_seek',
     'core_task',
     'crypto',

--- a/test/unit/test_core_plugin.c
+++ b/test/unit/test_core_plugin.c
@@ -12,6 +12,7 @@ static int context_init_count = 0;
 static int context_fini_count = 0;
 static int legacy_init_count = 0;
 static int legacy_fini_count = 0;
+static int duplicate_init_count = 0;
 
 static bool test_context_init(RzCore *core, void **user) {
 	(void)core;
@@ -45,6 +46,12 @@ static bool test_legacy_init(RzCore *core) {
 static bool test_legacy_fini(RzCore *core) {
 	(void)core;
 	legacy_fini_count++;
+	return true;
+}
+
+static bool test_duplicate_init(RzCore *core) {
+	(void)core;
+	duplicate_init_count++;
 	return true;
 }
 
@@ -106,9 +113,47 @@ static bool test_core_plugin_legacy_lifecycle(void) {
 	mu_end;
 }
 
+static bool test_core_plugin_duplicate_name_is_rejected(void) {
+	RzCore *core = rz_core_new();
+	mu_assert_notnull(core, "core should be created");
+
+	RzCorePlugin first = {
+		.name = "duplicate-test",
+		.desc = "first duplicate test plugin",
+		.license = "LGPL-3.0-only",
+		.author = "RizinOrg",
+		.version = "1.0",
+		.init = test_legacy_init,
+		.fini = test_legacy_fini,
+	};
+	RzCorePlugin second = {
+		.name = "duplicate-test",
+		.desc = "second duplicate test plugin",
+		.license = "LGPL-3.0-only",
+		.author = "RizinOrg",
+		.version = "1.0",
+		.init = test_duplicate_init,
+	};
+
+	legacy_init_count = 0;
+	legacy_fini_count = 0;
+	duplicate_init_count = 0;
+	mu_assert_true(rz_core_plugin_add(core, &first), "first plugin should be added");
+	mu_assert_false(rz_core_plugin_add(core, &second), "duplicate plugin should be rejected");
+	mu_assert_eq(legacy_init_count, 1, "first plugin init should be called once");
+	mu_assert_eq(duplicate_init_count, 0, "duplicate plugin init should not be called");
+
+	mu_assert_true(rz_core_plugin_del(core, &first), "first plugin should remain registered");
+	mu_assert_eq(legacy_fini_count, 1, "first plugin fini should be called once");
+
+	rz_core_free(core);
+	mu_end;
+}
+
 int all_tests(void) {
 	mu_run_test(test_core_plugin_context_lifecycle);
 	mu_run_test(test_core_plugin_legacy_lifecycle);
+	mu_run_test(test_core_plugin_duplicate_name_is_rejected);
 	return tests_passed != tests_run;
 }
 

--- a/test/unit/test_core_plugin.c
+++ b/test/unit/test_core_plugin.c
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 RizinOrg <info@rizin.re>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_core.h>
+#include "minunit.h"
+
+typedef struct test_core_plugin_context_t {
+	int magic;
+} TestCorePluginContext;
+
+static int context_init_count = 0;
+static int context_fini_count = 0;
+static int legacy_init_count = 0;
+static int legacy_fini_count = 0;
+
+static bool test_context_init(RzCore *core, void **user) {
+	(void)core;
+	TestCorePluginContext *ctx = RZ_NEW0(TestCorePluginContext);
+	if (!ctx) {
+		return false;
+	}
+	ctx->magic = 0x1337;
+	*user = ctx;
+	context_init_count++;
+	return true;
+}
+
+static bool test_context_fini(RzCore *core, void *user) {
+	(void)core;
+	TestCorePluginContext *ctx = user;
+	if (!ctx || ctx->magic != 0x1337) {
+		return false;
+	}
+	free(ctx);
+	context_fini_count++;
+	return true;
+}
+
+static bool test_legacy_init(RzCore *core) {
+	(void)core;
+	legacy_init_count++;
+	return true;
+}
+
+static bool test_legacy_fini(RzCore *core) {
+	(void)core;
+	legacy_fini_count++;
+	return true;
+}
+
+static bool test_core_plugin_context_lifecycle(void) {
+	RzCore *core = rz_core_new();
+	mu_assert_notnull(core, "core should be created");
+
+	RzCorePlugin plugin = {
+		.name = "context-test",
+		.desc = "context test plugin",
+		.license = "LGPL-3.0-only",
+		.author = "RizinOrg",
+		.version = "1.0",
+		.init_context = test_context_init,
+		.fini_context = test_context_fini,
+	};
+
+	context_init_count = 0;
+	context_fini_count = 0;
+	mu_assert_true(rz_core_plugin_add(core, &plugin), "context plugin should be added");
+	mu_assert_eq(context_init_count, 1, "context init should be called once");
+
+	TestCorePluginContext *ctx = rz_core_plugin_context_get(core, "context-test");
+	mu_assert_notnull(ctx, "context should be stored on the core");
+	mu_assert_eq(ctx->magic, 0x1337, "context should preserve plugin state");
+
+	mu_assert_true(rz_core_plugin_del(core, &plugin), "context plugin should be deleted");
+	mu_assert_eq(context_fini_count, 1, "context fini should be called once");
+	mu_assert_null(rz_core_plugin_context_get(core, "context-test"), "context should be removed after plugin deletion");
+
+	rz_core_free(core);
+	mu_end;
+}
+
+static bool test_core_plugin_legacy_lifecycle(void) {
+	RzCore *core = rz_core_new();
+	mu_assert_notnull(core, "core should be created");
+
+	RzCorePlugin plugin = {
+		.name = "legacy-test",
+		.desc = "legacy test plugin",
+		.license = "LGPL-3.0-only",
+		.author = "RizinOrg",
+		.version = "1.0",
+		.init = test_legacy_init,
+		.fini = test_legacy_fini,
+	};
+
+	legacy_init_count = 0;
+	legacy_fini_count = 0;
+	mu_assert_true(rz_core_plugin_add(core, &plugin), "legacy plugin should be added");
+	mu_assert_eq(legacy_init_count, 1, "legacy init should be called once");
+	mu_assert_null(rz_core_plugin_context_get(core, "legacy-test"), "legacy plugin should not get implicit context");
+
+	mu_assert_true(rz_core_plugin_del(core, &plugin), "legacy plugin should be deleted");
+	mu_assert_eq(legacy_fini_count, 1, "legacy fini should be called once");
+
+	rz_core_free(core);
+	mu_end;
+}
+
+int all_tests(void) {
+	mu_run_test(test_core_plugin_context_lifecycle);
+	mu_run_test(test_core_plugin_legacy_lifecycle);
+	return tests_passed != tests_run;
+}
+
+mu_main(all_tests)

--- a/test/unit/test_core_plugin.c
+++ b/test/unit/test_core_plugin.c
@@ -37,23 +37,46 @@ static bool test_context_fini(RzCore *core, void *user) {
 	return true;
 }
 
-static bool test_legacy_init(RzCore *core) {
+static bool test_legacy_init(RzCore *core, void **user) {
 	(void)core;
+	(void)user;
 	legacy_init_count++;
 	return true;
 }
 
-static bool test_legacy_fini(RzCore *core) {
+static bool test_legacy_fini(RzCore *core, void *user) {
 	(void)core;
+	(void)user;
 	legacy_fini_count++;
 	return true;
 }
 
-static bool test_duplicate_init(RzCore *core) {
+static bool test_duplicate_init(RzCore *core, void **user) {
 	(void)core;
+	(void)user;
 	duplicate_init_count++;
 	return true;
 }
+
+static RzCmdStatus test_plugin_cmd_handler(RzCore *core, int argc, const char **argv) {
+	(void)core;
+	(void)argc;
+	(void)argv;
+	return RZ_CMD_STATUS_OK;
+}
+
+static const RzCmdDescArg test_plugin_cmd_args[] = {
+	{ 0 },
+};
+
+static const RzCmdDescHelp test_plugin_cmd_help = {
+	.summary = "test plugin command",
+	.args = test_plugin_cmd_args,
+};
+
+static const RzCmdDescHelp test_plugin_group_help = {
+	.summary = "test plugin command group",
+};
 
 static bool test_core_plugin_context_lifecycle(void) {
 	RzCore *core = rz_core_new();
@@ -65,8 +88,8 @@ static bool test_core_plugin_context_lifecycle(void) {
 		.license = "LGPL-3.0-only",
 		.author = "RizinOrg",
 		.version = "1.0",
-		.init_context = test_context_init,
-		.fini_context = test_context_fini,
+		.init = test_context_init,
+		.fini = test_context_fini,
 	};
 
 	context_init_count = 0;
@@ -74,13 +97,13 @@ static bool test_core_plugin_context_lifecycle(void) {
 	mu_assert_true(rz_core_plugin_add(core, &plugin), "context plugin should be added");
 	mu_assert_eq(context_init_count, 1, "context init should be called once");
 
-	TestCorePluginContext *ctx = rz_core_plugin_context_get(core, "context-test");
+	TestCorePluginContext *ctx = rz_core_plugin_context_get(core, &plugin);
 	mu_assert_notnull(ctx, "context should be stored on the core");
 	mu_assert_eq(ctx->magic, 0x1337, "context should preserve plugin state");
 
 	mu_assert_true(rz_core_plugin_del(core, &plugin), "context plugin should be deleted");
 	mu_assert_eq(context_fini_count, 1, "context fini should be called once");
-	mu_assert_null(rz_core_plugin_context_get(core, "context-test"), "context should be removed after plugin deletion");
+	mu_assert_null(rz_core_plugin_context_get(core, &plugin), "context should be removed after plugin deletion");
 
 	rz_core_free(core);
 	mu_end;
@@ -104,7 +127,7 @@ static bool test_core_plugin_legacy_lifecycle(void) {
 	legacy_fini_count = 0;
 	mu_assert_true(rz_core_plugin_add(core, &plugin), "legacy plugin should be added");
 	mu_assert_eq(legacy_init_count, 1, "legacy init should be called once");
-	mu_assert_null(rz_core_plugin_context_get(core, "legacy-test"), "legacy plugin should not get implicit context");
+	mu_assert_null(rz_core_plugin_context_get(core, &plugin), "legacy plugin should not get implicit context");
 
 	mu_assert_true(rz_core_plugin_del(core, &plugin), "legacy plugin should be deleted");
 	mu_assert_eq(legacy_fini_count, 1, "legacy fini should be called once");
@@ -150,10 +173,28 @@ static bool test_core_plugin_duplicate_name_is_rejected(void) {
 	mu_end;
 }
 
+static bool test_core_plugin_command_helpers(void) {
+	RzCore *core = rz_core_new();
+	mu_assert_notnull(core, "core should be created");
+
+	RzCmdDesc *cmd = rz_core_plugin_cmd_desc_argv_new(core, "plugtest", test_plugin_cmd_handler, &test_plugin_cmd_help);
+	mu_assert_notnull(cmd, "plugin argv command should be registered");
+	mu_assert_true(rz_core_plugin_cmd_desc_remove(core, cmd), "plugin argv command should be removed");
+
+	RzCmdDesc *group = rz_core_plugin_cmd_desc_group_new(core, "pluggrp", NULL, NULL, &test_plugin_group_help);
+	mu_assert_notnull(group, "plugin command group should be registered");
+	mu_assert_true(rz_core_plugin_cmd_desc_remove(core, group), "plugin command group should be removed");
+	mu_assert_true(rz_core_plugin_cmd_desc_remove(core, NULL), "plugin command remove should accept null descriptors");
+
+	rz_core_free(core);
+	mu_end;
+}
+
 int all_tests(void) {
 	mu_run_test(test_core_plugin_context_lifecycle);
 	mu_run_test(test_core_plugin_legacy_lifecycle);
 	mu_run_test(test_core_plugin_duplicate_name_is_rejected);
+	mu_run_test(test_core_plugin_command_helpers);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

This adds optional context-aware lifecycle hooks for `RzCorePlugin`.

Core plugins could keep per core pvt state through:

- `init_context`
- `fini_context`
- `analysis_context`

The stored context is owned by the plugin and indexed by plugin name on `RzCore`. Legacy `init`, `fini`, and `analysis` callbacks do work as expected.

This also converts the java & dex core plugins to use context aware init/fini so they can remove the exact cmd descriptor created during init.

## test

- `ninja -C build test/unit/test_core_plugin.exe test/unit/test_core_cmd.exe`
- `meson test -C build core_plugin core_cmd --print-errorlogs --no-rebuild`
- `ninja -C build`

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
