### PR TITLE
rz-asm: print error for -m with unknown plugin name (gh-6367)

### DIFF
--- a/librz/core/casm.c
+++ b/librz/core/casm.c
@@ -284,23 +284,31 @@ RZ_API RzCmdStatus rz_core_cpu_descs_print(RZ_NONNULL RzCore *core, RZ_NONNULL c
 	rz_list_sort(plugin_list, (RzListComparator)rz_asm_plugin_cmp, NULL);
 	RzListIter *it;
 	RzAsmPlugin *ap;
+	bool found = false;
 	rz_list_foreach (plugin_list, it, ap) {
-		if (ap->cpus && ap->get_cpu_desc && RZ_STR_EQ(plugin, ap->name)) {
-			char **desc = ap->get_cpu_desc();
-			if (!desc) {
-				rz_iterator_free(iter);
-				rz_list_free(plugin_list);
-				return RZ_CMD_STATUS_ERROR;
-			}
-			for (size_t i = 0; desc[i] != NULL; i += 2) {
-				rz_cons_printf("%-15s %s", desc[i], desc[i + 1]);
-				rz_cons_newline();
+		if (RZ_STR_EQ(plugin, ap->name)) {
+			found = true;
+			if (ap->cpus && ap->get_cpu_desc) {
+				char **desc = ap->get_cpu_desc();
+				if (!desc) {
+					rz_iterator_free(iter);
+					rz_list_free(plugin_list);
+					return RZ_CMD_STATUS_ERROR;
+				}
+				for (size_t i = 0; desc[i] != NULL; i += 2) {
+					rz_cons_printf("%-15s %s", desc[i], desc[i + 1]);
+					rz_cons_newline();
+				}
 			}
 			break;
 		}
 	}
 	rz_iterator_free(iter);
 	rz_list_free(plugin_list);
+	if (!found) {
+		RZ_LOG_ERROR("Unknown assembly plugin: %s\n", plugin);
+		return RZ_CMD_STATUS_ERROR;
+	}
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -8,6 +8,15 @@ _dA__ 4          i4004       LGPL3   Intel 4004 disassembler
 EOF
 RUN
 
+NAME=rz-asm -m unknown plugin prints error (gh-6367)
+TOOL=rz-asm
+ARGS=-m bogusplugin
+EXPECT=
+EXPECT_ERR=<<EOF
+ERROR: Unknown assembly plugin: bogusplugin
+EOF
+RUN
+
 NAME=rz-asm arm32le assemble
 TOOL=rz-asm
 FILE=mov r0, 3


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


Closes #6367.

Right now `rz-asm -m bogus` prints nothing and exits cleanly, so you can't tell if you typo'd the plugin name or it's just an arch with no CPUs. `rz_core_cpu_descs_print` loops through plugins and only does anything when the name matches, but the match-not-found branch just returns OK.

Added a `found` flag so we know whether the loop ever hit. If it didn't, RZ_LOG_ERROR with the bad name and return ERROR. Also restructured the inner check so a plugin that exists but has no `cpus`/`get_cpu_desc` still counts as found (same behavior as before for those, just no spurious error message).

Test for the unknown-plugin case in test/db/tools/rz_asm.