### PR TITLE
rz-find: show full surrounding string for -Z hits (gh-6289)

### DIFF
--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -87,6 +87,8 @@ static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 	char _str[128];
 	char *str = _str;
 	*_str = 0;
+	RzStrBuf full_str;
+	rz_strbuf_init(&full_str);
 	if (ro->showstr) {
 		if (ro->widestr) {
 			str = _str;
@@ -112,18 +114,32 @@ static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 			}
 			str[j] = 0;
 		} else {
-			size_t i;
-			for (i = 0; i < sizeof(_str) - 1; i++) {
-				char ch = ro->buf[delta + i];
+			// Walk back to the start of the printable run so we surface the
+			// whole string the hit lives inside, not just the suffix from
+			// the match position. Matches how `izz` reports strings.
+			size_t start = delta;
+			while (start > 0) {
+				char ch = ro->buf[start - 1];
+				if (!ch || !IS_PRINTABLE(ch)) {
+					break;
+				}
+				start--;
+			}
+			for (size_t i = start; i < ro->bsize; i++) {
+				char ch = ro->buf[i];
 				if (ch == '"' || ch == '\\') {
 					ch = '\'';
 				}
 				if (!ch || !IS_PRINTABLE(ch)) {
 					break;
 				}
-				str[i] = ch;
+				rz_strbuf_append_n(&full_str, &ch, 1);
 			}
-			str[i] = 0;
+			str = (char *)rz_strbuf_get(&full_str);
+			if (!str) {
+				str = _str;
+				*_str = 0;
+			}
 		}
 	} else {
 		size_t i;
@@ -165,6 +181,7 @@ static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 			RZ_LOG_ERROR("Failed to execute command: %s\n", command);
 		}
 		free(command);
+		rz_strbuf_fini(&full_str);
 		return 1;
 	}
 	if (ro->rizin_command && ctx->core) {
@@ -174,8 +191,10 @@ static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 			printf("%s", output);
 			free(output);
 		}
+		rz_strbuf_fini(&full_str);
 		return 1;
 	}
+	rz_strbuf_fini(&full_str);
 	return 1;
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


Closes #6289.

The reporter pointed out that `rz-find -s Android -Z file` shows truncated strings while `izz` on the same file shows the whole thing. Two problems were combining: rz-find started printing at the hit offset (so a search for "Android" inside a long mangled C++ symbol like `_ZNSt8_Rb_treeIjSt4pairIKjN4LIEF7Android16...` only showed the suffix from "Android" onwards), and the output buffer was a fixed 128 bytes (so anything past that got cut).

Walked back from the hit to the first non-printable byte to find the actual string start, then used RzStrBuf to copy the full printable run forward. The user gets the same string `izz` would have surfaced, with the hit address unchanged so they still know where the match was.

Kept the diff to the narrow showstr branch. The widestr path has its own quirks (the `j > 80` early truncation and the double `i++` look pre-existing) that I didn't bundle in here.

`hit()` is a static callback, not RZ_API, so no test was strictly required. I left one out because `bins/elf/ioli/crackme0x00` (the existing rz-find fixture) has no printable run long enough to exercise the truncation. Can add a synthetic fixture if you want coverage.