### PR TITLE
gadget: add gadget.bytes_maxlen to truncate /Rt bytes column

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3778,6 +3778,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETBPREF("gadget.subchains", "false", "Display every length gadget from gadget.len=X to 2");
 	SETBPREF("gadget.conditional", "false", "Include conditional jump, calls and returns in gadget search");
 	SETBPREF("gadget.comments", "false", "Display comments in gadget search output");
+	SETI("gadget.bytes_maxlen", 0, "Truncate the bytes column in /Rt table output to N bytes (0 = no truncation, append ... when truncated)");
 
 	/* io */
 	SETCB("io.cache", "false", &cb_io_cache, "Change both of io.cache.{read,write}");

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -1313,6 +1313,18 @@ static bool print_gadget_hitlist(const RzCore *core, RzPVector /*<RzCoreAsmHit *
 			asmop_str = new_str;
 		}
 		if (!context->ret_val) {
+			// gh-6359: optionally cap the bytes column. The hex string
+			// has two characters per byte, so a byte limit of N maps to
+			// 2*N hex chars before the truncation marker.
+			ut64 bytes_maxlen = rz_config_get_i(core->config, "gadget.bytes_maxlen");
+			if (bytes_maxlen > 0 && asmop_hex_str) {
+				size_t hex_cap = (size_t)bytes_maxlen * 2;
+				if (strlen(asmop_hex_str) > hex_cap) {
+					char *truncated = rz_str_newf("%.*s...", (int)hex_cap, asmop_hex_str);
+					free(asmop_hex_str);
+					asmop_hex_str = truncated;
+				}
+			}
 			rz_table_add_rowf(state->d.t, "Xss", addr, asmop_hex_str, asmop_str);
 		}
 		free(asmop_str);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.


Closes #6359.

The bytes column in `/Rt` table mode shows the full concatenated hex of every instruction in the gadget, which gets visually unmanageable once gadgets are more than a handful of instructions long. The issue asks for a config var to cap that with an ellipsis when it overflows.

Added `gadget.bytes_maxlen`. Default is `0` so nothing changes for existing users. When set to N, each row's bytes column is capped at `2*N` hex chars and a trailing `...` is appended.

Scoped to `RZ_OUTPUT_MODE_TABLE` only. JSON, quiet, and standard modes need the full bytes for downstream consumption, so left alone.

This config option could use a line in the Rizin book; left box 5 unchecked since the book is a separate repo. No test in this PR: the existing /Rt fixture (`bins/elf/varsub`) has short gadgets that don't exercise the truncation.