### PR TITLE
Avoid overlapping memcpy in rz_vector_sort()

### DIFF
--- a/librz/util/vector.c
+++ b/librz/util/vector.c
@@ -580,17 +580,23 @@ static void vector_quick_sort(void *a, size_t elem_size, size_t len, RzVectorCom
 	}
 
 	memcpy(pivot, VEC_INDEX(a, i), elem_size);
-	memcpy(VEC_INDEX(a, i), VEC_INDEX(a, len - 1), elem_size);
+	if (i != len - 1) {
+		memcpy(VEC_INDEX(a, i), VEC_INDEX(a, len - 1), elem_size);
+	}
 	for (i = 0; i < len - 1; i++) {
 		if ((cmp(VEC_INDEX(a, i), pivot, user) < 0 && !reverse) ||
 			(cmp(VEC_INDEX(a, i), pivot, user) > 0 && reverse)) {
-			memcpy(t, VEC_INDEX(a, i), elem_size);
-			memcpy(VEC_INDEX(a, i), VEC_INDEX(a, j), elem_size);
-			memcpy(VEC_INDEX(a, j), t, elem_size);
+			if (j != i) {
+				memcpy(t, VEC_INDEX(a, i), elem_size);
+				memcpy(VEC_INDEX(a, i), VEC_INDEX(a, j), elem_size);
+				memcpy(VEC_INDEX(a, j), t, elem_size);
+			}
 			j++;
 		}
 	}
-	memcpy(VEC_INDEX(a, len - 1), VEC_INDEX(a, j), elem_size);
+	if (j != len - 1) {
+		memcpy(VEC_INDEX(a, len - 1), VEC_INDEX(a, j), elem_size);
+	}
 	memcpy(VEC_INDEX(a, j), pivot, elem_size);
 	RZ_FREE(t);
 	RZ_FREE(pivot);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Detected with valgrind, some element assignments could memcpy with identical addresses. This is usually a no-op in practice, but theoretically undefined behavior.

**Test plan**

* tests should still pass, no change in behavior
* `test_vector` should yield no warnings in valgrind/memcheck