### PR TITLE
librz/type: fix struct/union and RzCallable memory leaks

### DIFF
--- a/librz/arch/fcn.c
+++ b/librz/arch/fcn.c
@@ -1900,8 +1900,13 @@ RZ_API int rz_analysis_function_get_arg_count(RzAnalysis *analysis, RzAnalysisFu
 	if (!callable) {
 		return -1;
 	}
-	rz_type_func_save(analysis->typedb, callable);
-	return rz_pvector_len(callable->args);
+	int argc = rz_pvector_len(callable->args);
+	// rz_type_func_save() does not take ownership when a callable with the
+	// same name is already registered, so free the derived one in that case.
+	if (!rz_type_func_save(analysis->typedb, callable)) {
+		rz_type_callable_free(callable);
+	}
+	return argc;
 }
 
 // tfj and afsj call this function

--- a/librz/type/function.c
+++ b/librz/type/function.c
@@ -141,10 +141,15 @@ RZ_API RZ_OWN RzCallable *rz_type_func_new(RzTypeDB *typedb, RZ_NONNULL const ch
 }
 
 /**
- * \brief Stores RzCallable type in the types database
+ * \brief Stores the given RzCallable type in the types database
  *
- * \param typedb Type Database instance
- * \param callable RzCallable type to save
+ * \param typedb Types Database instance
+ * \param callable RzCallable to store; ownership is transferred only on success
+ * \return true if \p callable was stored, false if a callable with the same
+ *         name already exists or the arguments are invalid
+ *
+ * On failure the database does not take ownership of \p callable, so the
+ * caller remains responsible for freeing it with rz_type_callable_free().
  */
 RZ_API bool rz_type_func_save(RzTypeDB *typedb, RZ_NONNULL RzCallable *callable) {
 	rz_return_val_if_fail(typedb && callable && callable->name, false);

--- a/librz/type/parser/types_parser.c
+++ b/librz/type/parser/types_parser.c
@@ -597,6 +597,10 @@ int parse_struct_node(CParserState *state, TSNode node, const char *text, Parser
 			}
 			field_declarator = ts_node_next_named_sibling(field_declarator);
 		} while (!ts_node_is_null(field_declarator));
+		// The member type is cloned into each declarator above, so the
+		// type pair built for this field is no longer needed. Its btype
+		// is borrowed from the type database, only the type is owned.
+		rz_type_free(membtpair->type);
 		free(membtpair);
 	}
 	// If parsing successfull completed - we store the state
@@ -883,6 +887,10 @@ int parse_union_node(CParserState *state, TSNode node, const char *text, ParserT
 			}
 			field_declarator = ts_node_next_named_sibling(field_declarator);
 		} while (!ts_node_is_null(field_declarator));
+		// The member type is cloned into each declarator above, so the
+		// type pair built for this field is no longer needed. Its btype
+		// is borrowed from the type database, only the type is owned.
+		rz_type_free(membtpair->type);
 		free(membtpair);
 	}
 	// If parsing successfull completed - we store the state


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Fixes these leaks:
```
Memory leaks detected in changed lines:
--------------------------------

  cmd_type.c:391

  Direct leak of 128 byte(s) in 4 object(s) allocated from:
      #0 0x7fe41e417f77 in calloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:90
      #1 0x7fe41a694764 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:217
      #2 0x7fe41a689492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #3 0x7fe41a68facb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #4 0x7fe41a68b53a in parse_struct_node ../librz/type/parser/types_parser.c:487
      #5 0x7fe41a693aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #6 0x7fe41a687738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #7 0x7fe41a687992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #8 0x7fe41a05ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #9 0x7fe41a035e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #10 0x7fe41a036112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #11 0x7fe41a0361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #12 0x7fe41a0256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #13 0x7fe41a02502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #14 0x7fe41a031565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #15 0x7fe41a031a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #16 0x7fe41a0317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #17 0x7fe41a03217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #18 0x7fe41a032315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #19 0x7fe41ea3d7a5 in run_commands ../librz/main/rizin.c:337
      #20 0x7fe41ea42007 in rz_main_rizin ../librz/main/rizin.c:1430
      #21 0x55ca05315a23 in main ../binrz/rizin/rizin.c:57
      #22 0x7fe41dc2a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #23 0x7fe41dc2a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #24 0x55ca05315504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Indirect leak of 32 byte(s) in 4 object(s) allocated from:
      #0 0x7fe41e418132 in malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:75
      #1 0x7fe41dcb437e in strdup (/lib/x86_64-linux-gnu/libc.so.6+0xb437e) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #2 0x7fe41e0b376e in rz_str_dup ../librz/util/str.c:1112
      #3 0x7fe41a694797 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:223
      #4 0x7fe41a689492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #5 0x7fe41a68facb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #6 0x7fe41a68b53a in parse_struct_node ../librz/type/parser/types_parser.c:487
      #7 0x7fe41a693aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #8 0x7fe41a687738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #9 0x7fe41a687992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #10 0x7fe41a05ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #11 0x7fe41a035e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #12 0x7fe41a036112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #13 0x7fe41a0361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #14 0x7fe41a0256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #15 0x7fe41a02502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #16 0x7fe41a031565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #17 0x7fe41a031a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #18 0x7fe41a0317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #19 0x7fe41a03217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #20 0x7fe41a032315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #21 0x7fe41ea3d7a5 in run_commands ../librz/main/rizin.c:337
      #22 0x7fe41ea42007 in rz_main_rizin ../librz/main/rizin.c:1430
      #23 0x55ca05315a23 in main ../binrz/rizin/rizin.c:57
      #24 0x7fe41dc2a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #25 0x7fe41dc2a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #26 0x55ca05315504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Direct leak of 64 byte(s) in 2 object(s) allocated from:
      #0 0x7f8008817f77 in calloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:90
      #1 0x7f8004aa8764 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:217
      #2 0x7f8004a9d492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #3 0x7f8004aa3acb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #4 0x7f8004a9f53a in parse_struct_node ../librz/type/parser/types_parser.c:487
      #5 0x7f8004aa7aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #6 0x7f8004a9b738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #7 0x7f8004a9b992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #8 0x7f800445ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #9 0x7f8004435e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #10 0x7f8004436112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #11 0x7f80044361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #12 0x7f80044256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #13 0x7f800442502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #14 0x7f8004431565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #15 0x7f8004431a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #16 0x7f80044317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #17 0x7f800443217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #18 0x7f8004432315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #19 0x7f8008e4b7a5 in run_commands ../librz/main/rizin.c:337
      #20 0x7f8008e50007 in rz_main_rizin ../librz/main/rizin.c:1430
      #21 0x56469d59ba23 in main ../binrz/rizin/rizin.c:57
      #22 0x7f800802a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #23 0x7f800802a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #24 0x56469d59b504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Indirect leak of 16 byte(s) in 2 object(s) allocated from:
      #0 0x7f8008818132 in malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:75
      #1 0x7f80080b437e in strdup (/lib/x86_64-linux-gnu/libc.so.6+0xb437e) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #2 0x7f80084b376e in rz_str_dup ../librz/util/str.c:1112
      #3 0x7f8004aa8797 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:223
      #4 0x7f8004a9d492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #5 0x7f8004aa3acb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #6 0x7f8004a9f53a in parse_struct_node ../librz/type/parser/types_parser.c:487
      #7 0x7f8004aa7aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #8 0x7f8004a9b738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #9 0x7f8004a9b992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #10 0x7f800445ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #11 0x7f8004435e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #12 0x7f8004436112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #13 0x7f80044361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #14 0x7f80044256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #15 0x7f800442502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #16 0x7f8004431565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #17 0x7f8004431a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #18 0x7f80044317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #19 0x7f800443217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #20 0x7f8004432315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #21 0x7f8008e4b7a5 in run_commands ../librz/main/rizin.c:337
      #22 0x7f8008e50007 in rz_main_rizin ../librz/main/rizin.c:1430
      #23 0x56469d59ba23 in main ../binrz/rizin/rizin.c:57
      #24 0x7f800802a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #25 0x7f800802a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #26 0x56469d59b504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Direct leak of 128 byte(s) in 4 object(s) allocated from:
      #0 0x7fe143c17f77 in calloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:90
      #1 0x7fe13ff16764 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:217
      #2 0x7fe13ff0b492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #3 0x7fe13ff11acb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #4 0x7fe13ff0d53a in parse_struct_node ../librz/type/parser/types_parser.c:487
      #5 0x7fe13ff15aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #6 0x7fe13ff09738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #7 0x7fe13ff09992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #8 0x7fe13f85ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #9 0x7fe13f835e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #10 0x7fe13f836112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #11 0x7fe13f8361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #12 0x7fe13f8256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #13 0x7fe13f82502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #14 0x7fe13f831565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #15 0x7fe13f831a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #16 0x7fe13f8317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #17 0x7fe13f83217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #18 0x7fe13f832315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #19 0x7fe1442f57a5 in run_commands ../librz/main/rizin.c:337
      #20 0x7fe1442fa007 in rz_main_rizin ../librz/main/rizin.c:1430
      #21 0x55918f622a23 in main ../binrz/rizin/rizin.c:57
      #22 0x7fe14342a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #23 0x7fe14342a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #24 0x55918f622504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Indirect leak of 32 byte(s) in 4 object(s) allocated from:
      #0 0x7fe143c18132 in malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:75
      #1 0x7fe1434b437e in strdup (/lib/x86_64-linux-gnu/libc.so.6+0xb437e) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #2 0x7fe1438b376e in rz_str_dup ../librz/util/str.c:1112
      #3 0x7fe13ff16797 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:223
      #4 0x7fe13ff0b492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #5 0x7fe13ff11acb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #6 0x7fe13ff0d53a in parse_struct_node ../librz/type/parser/types_parser.c:487
      #7 0x7fe13ff15aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #8 0x7fe13ff09738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #9 0x7fe13ff09992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #10 0x7fe13f85ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #11 0x7fe13f835e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #12 0x7fe13f836112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #13 0x7fe13f8361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #14 0x7fe13f8256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #15 0x7fe13f82502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #16 0x7fe13f831565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #17 0x7fe13f831a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #18 0x7fe13f8317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #19 0x7fe13f83217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #20 0x7fe13f832315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #21 0x7fe1442f57a5 in run_commands ../librz/main/rizin.c:337
      #22 0x7fe1442fa007 in rz_main_rizin ../librz/main/rizin.c:1430
      #23 0x55918f622a23 in main ../binrz/rizin/rizin.c:57
      #24 0x7fe14342a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #25 0x7fe14342a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #26 0x55918f622504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Direct leak of 96 byte(s) in 3 object(s) allocated from:
      #0 0x7fe94ac17f77 in calloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:90
      #1 0x7fe946d16764 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:217
      #2 0x7fe946d0b492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #3 0x7fe946d11acb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #4 0x7fe946d0ef3d in parse_union_node ../librz/type/parser/types_parser.c:777
      #5 0x7fe946d15b1e in parse_type_nodes_save ../librz/type/parser/types_parser.c:1933
      #6 0x7fe946d09738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #7 0x7fe946d09992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #8 0x7fe94665ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #9 0x7fe946635e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #10 0x7fe946636112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #11 0x7fe9466361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #12 0x7fe9466256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #13 0x7fe94662502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #14 0x7fe946631565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #15 0x7fe946631a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #16 0x7fe9466317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #17 0x7fe94663217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #18 0x7fe946632315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #19 0x7fe94a7c87a5 in run_commands ../librz/main/rizin.c:337
      #20 0x7fe94a7cd007 in rz_main_rizin ../librz/main/rizin.c:1430
      #21 0x55a01fbeba23 in main ../binrz/rizin/rizin.c:57
      #22 0x7fe94a42a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #23 0x7fe94a42a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #24 0x55a01fbeb504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Indirect leak of 24 byte(s) in 3 object(s) allocated from:
      #0 0x7fe94ac18132 in malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:75
      #1 0x7fe94a4b437e in strdup (/lib/x86_64-linux-gnu/libc.so.6+0xb437e) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #2 0x7fe94a8b376e in rz_str_dup ../librz/util/str.c:1112
      #3 0x7fe946d16797 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:223
      #4 0x7fe946d0b492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #5 0x7fe946d11acb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #6 0x7fe946d0ef3d in parse_union_node ../librz/type/parser/types_parser.c:777
      #7 0x7fe946d15b1e in parse_type_nodes_save ../librz/type/parser/types_parser.c:1933
      #8 0x7fe946d09738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #9 0x7fe946d09992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #10 0x7fe94665ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #11 0x7fe946635e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #12 0x7fe946636112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #13 0x7fe9466361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #14 0x7fe9466256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #15 0x7fe94662502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #16 0x7fe946631565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #17 0x7fe946631a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #18 0x7fe9466317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #19 0x7fe94663217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #20 0x7fe946632315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #21 0x7fe94a7c87a5 in run_commands ../librz/main/rizin.c:337
      #22 0x7fe94a7cd007 in rz_main_rizin ../librz/main/rizin.c:1430
      #23 0x55a01fbeba23 in main ../binrz/rizin/rizin.c:57
      #24 0x7fe94a42a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #25 0x7fe94a42a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #26 0x55a01fbeb504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Direct leak of 32 byte(s) in 1 object(s) allocated from:
      #0 0x7fe293217f77 in calloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:90
      #1 0x7fe28f513d1f in parse_type_declarator_node ../librz/type/parser/types_parser.c:1630
      #2 0x7fe28f50ddb8 in parse_struct_node ../librz/type/parser/types_parser.c:574
      #3 0x7fe28f515aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #4 0x7fe28f509738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #5 0x7fe28f509992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #6 0x7fe28ee5ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #7 0x7fe28ee35e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #8 0x7fe28ee36112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #9 0x7fe28ee361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #10 0x7fe28ee256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #11 0x7fe28ee2502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #12 0x7fe28ee31565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #13 0x7fe28ee31a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #14 0x7fe28ee317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #15 0x7fe28ee3217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #16 0x7fe28ee32315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #17 0x7fe29392a7a5 in run_commands ../librz/main/rizin.c:337
      #18 0x7fe29392f007 in rz_main_rizin ../librz/main/rizin.c:1430
      #19 0x5582b4723a23 in main ../binrz/rizin/rizin.c:57
      #20 0x7fe292a2a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #21 0x7fe292a2a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #22 0x5582b4723504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Indirect leak of 32 byte(s) in 1 object(s) allocated from:
      #0 0x7fe293217f77 in calloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:90
      #1 0x7fe28f516764 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:217
      #2 0x7fe28f50b492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #3 0x7fe28f511acb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #4 0x7fe28f50d53a in parse_struct_node ../librz/type/parser/types_parser.c:487
      #5 0x7fe28f515aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #6 0x7fe28f509738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #7 0x7fe28f509992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #8 0x7fe28ee5ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #9 0x7fe28ee35e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #10 0x7fe28ee36112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #11 0x7fe28ee361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #12 0x7fe28ee256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #13 0x7fe28ee2502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #14 0x7fe28ee31565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #15 0x7fe28ee31a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #16 0x7fe28ee317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #17 0x7fe28ee3217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #18 0x7fe28ee32315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #19 0x7fe29392a7a5 in run_commands ../librz/main/rizin.c:337
      #20 0x7fe29392f007 in rz_main_rizin ../librz/main/rizin.c:1430
      #21 0x5582b4723a23 in main ../binrz/rizin/rizin.c:57
      #22 0x7fe292a2a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #23 0x7fe292a2a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #24 0x5582b4723504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Indirect leak of 8 byte(s) in 1 object(s) allocated from:
      #0 0x7fe293218132 in malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:75
      #1 0x7fe292ab437e in strdup (/lib/x86_64-linux-gnu/libc.so.6+0xb437e) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #2 0x7fe292eb376e in rz_str_dup ../librz/util/str.c:1112
      #3 0x7fe28f516797 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:223
      #4 0x7fe28f50b492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #5 0x7fe28f511acb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #6 0x7fe28f50d53a in parse_struct_node ../librz/type/parser/types_parser.c:487
      #7 0x7fe28f515aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #8 0x7fe28f509738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #9 0x7fe28f509992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #10 0x7fe28ee5ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #11 0x7fe28ee35e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #12 0x7fe28ee36112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #13 0x7fe28ee361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #14 0x7fe28ee256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #15 0x7fe28ee2502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #16 0x7fe28ee31565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #17 0x7fe28ee31a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #18 0x7fe28ee317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #19 0x7fe28ee3217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #20 0x7fe28ee32315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #21 0x7fe29392a7a5 in run_commands ../librz/main/rizin.c:337
      #22 0x7fe29392f007 in rz_main_rizin ../librz/main/rizin.c:1430
      #23 0x5582b4723a23 in main ../binrz/rizin/rizin.c:57
      #24 0x7fe292a2a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #25 0x7fe292a2a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #26 0x5582b4723504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Direct leak of 224 byte(s) in 7 object(s) allocated from:
      #0 0x7f44cbe17f77 in calloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:90
      #1 0x7f44c7f16764 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:217
      #2 0x7f44c7f0b492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #3 0x7f44c7f11acb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #4 0x7f44c7f0d53a in parse_struct_node ../librz/type/parser/types_parser.c:487
      #5 0x7f44c7f15aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #6 0x7f44c7f09738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #7 0x7f44c7f09992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #8 0x7f44c785ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #9 0x7f44c7835e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #10 0x7f44c7836112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #11 0x7f44c78361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #12 0x7f44c78256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #13 0x7f44c782502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #14 0x7f44c7831565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #15 0x7f44c7831a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #16 0x7f44c78317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #17 0x7f44c783217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #18 0x7f44c7832315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #19 0x7f44cc3cd7a5 in run_commands ../librz/main/rizin.c:337
      #20 0x7f44cc3d2007 in rz_main_rizin ../librz/main/rizin.c:1430
      #21 0x55a0a0edaa23 in main ../binrz/rizin/rizin.c:57
      #22 0x7f44cb62a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #23 0x7f44cb62a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #24 0x55a0a0eda504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Direct leak of 64 byte(s) in 2 object(s) allocated from:
      #0 0x7f44cbe17f77 in calloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:90
      #1 0x7f44c7f139cf in parse_type_declarator_node ../librz/type/parser/types_parser.c:1592
      #2 0x7f44c7f0ddb8 in parse_struct_node ../librz/type/parser/types_parser.c:574
      #3 0x7f44c7f15aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #4 0x7f44c7f09738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #5 0x7f44c7f09992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #6 0x7f44c785ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #7 0x7f44c7835e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #8 0x7f44c7836112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #9 0x7f44c78361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #10 0x7f44c78256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #11 0x7f44c782502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #12 0x7f44c7831565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #13 0x7f44c7831a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #14 0x7f44c78317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #15 0x7f44c783217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #16 0x7f44c7832315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #17 0x7f44cc3cd7a5 in run_commands ../librz/main/rizin.c:337
      #18 0x7f44cc3d2007 in rz_main_rizin ../librz/main/rizin.c:1430
      #19 0x55a0a0edaa23 in main ../binrz/rizin/rizin.c:57
      #20 0x7f44cb62a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #21 0x7f44cb62a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #22 0x55a0a0eda504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Direct leak of 32 byte(s) in 1 object(s) allocated from:
      #0 0x7f44cbe17f77 in calloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:90
      #1 0x7f44c7f13d1f in parse_type_declarator_node ../librz/type/parser/types_parser.c:1630
      #2 0x7f44c7f0ddb8 in parse_struct_node ../librz/type/parser/types_parser.c:574
      #3 0x7f44c7f15aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #4 0x7f44c7f09738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #5 0x7f44c7f09992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #6 0x7f44c785ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #7 0x7f44c7835e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #8 0x7f44c7836112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #9 0x7f44c78361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #10 0x7f44c78256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #11 0x7f44c782502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #12 0x7f44c7831565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #13 0x7f44c7831a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #14 0x7f44c78317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #15 0x7f44c783217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #16 0x7f44c7832315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #17 0x7f44cc3cd7a5 in run_commands ../librz/main/rizin.c:337
      #18 0x7f44cc3d2007 in rz_main_rizin ../librz/main/rizin.c:1430
      #19 0x55a0a0edaa23 in main ../binrz/rizin/rizin.c:57
      #20 0x7f44cb62a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #21 0x7f44cb62a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #22 0x55a0a0eda504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Indirect leak of 96 byte(s) in 3 object(s) allocated from:
      #0 0x7f44cbe17f77 in calloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:90
      #1 0x7f44c7f16764 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:217
      #2 0x7f44c7f0b492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #3 0x7f44c7f11acb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #4 0x7f44c7f0d53a in parse_struct_node ../librz/type/parser/types_parser.c:487
      #5 0x7f44c7f15aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #6 0x7f44c7f09738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #7 0x7f44c7f09992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #8 0x7f44c785ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #9 0x7f44c7835e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #10 0x7f44c7836112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #11 0x7f44c78361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #12 0x7f44c78256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #13 0x7f44c782502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #14 0x7f44c7831565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #15 0x7f44c7831a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #16 0x7f44c78317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #17 0x7f44c783217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #18 0x7f44c7832315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #19 0x7f44cc3cd7a5 in run_commands ../librz/main/rizin.c:337
      #20 0x7f44cc3d2007 in rz_main_rizin ../librz/main/rizin.c:1430
      #21 0x55a0a0edaa23 in main ../binrz/rizin/rizin.c:57
      #22 0x7f44cb62a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #23 0x7f44cb62a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #24 0x55a0a0eda504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Indirect leak of 72 byte(s) in 10 object(s) allocated from:
      #0 0x7f44cbe18132 in malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:75
      #1 0x7f44cb6b437e in strdup (/lib/x86_64-linux-gnu/libc.so.6+0xb437e) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #2 0x7f44cbab376e in rz_str_dup ../librz/util/str.c:1112
      #3 0x7f44c7f16797 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:223
      #4 0x7f44c7f0b492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #5 0x7f44c7f11acb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #6 0x7f44c7f0d53a in parse_struct_node ../librz/type/parser/types_parser.c:487
      #7 0x7f44c7f15aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #8 0x7f44c7f09738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #9 0x7f44c7f09992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #10 0x7f44c785ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #11 0x7f44c7835e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #12 0x7f44c7836112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #13 0x7f44c78361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #14 0x7f44c78256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #15 0x7f44c782502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #16 0x7f44c7831565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #17 0x7f44c7831a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #18 0x7f44c78317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #19 0x7f44c783217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #20 0x7f44c7832315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #21 0x7f44cc3cd7a5 in run_commands ../librz/main/rizin.c:337
      #22 0x7f44cc3d2007 in rz_main_rizin ../librz/main/rizin.c:1430
      #23 0x55a0a0edaa23 in main ../binrz/rizin/rizin.c:57
      #24 0x7f44cb62a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #25 0x7f44cb62a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #26 0x55a0a0eda504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Direct leak of 128 byte(s) in 4 object(s) allocated from:
      #0 0x7efec7e17f77 in calloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:90
      #1 0x7efec4081764 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:217
      #2 0x7efec4076492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #3 0x7efec407cacb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #4 0x7efec407853a in parse_struct_node ../librz/type/parser/types_parser.c:487
      #5 0x7efec4080aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #6 0x7efec4074738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #7 0x7efec4074992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #8 0x7efec3a5ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #9 0x7efec3a35e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #10 0x7efec3a36112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #11 0x7efec3a361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #12 0x7efec3a256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #13 0x7efec3a2502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #14 0x7efec3a31565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #15 0x7efec3a31a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #16 0x7efec3a317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #17 0x7efec3a3217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #18 0x7efec3a32315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #19 0x7efec84317a5 in run_commands ../librz/main/rizin.c:337
      #20 0x7efec8436007 in rz_main_rizin ../librz/main/rizin.c:1430
      #21 0x55dc8cc95a23 in main ../binrz/rizin/rizin.c:57
      #22 0x7efec762a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #23 0x7efec762a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #24 0x55dc8cc95504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  cmd_type.c:391

  Indirect leak of 32 byte(s) in 4 object(s) allocated from:
      #0 0x7efec7e18132 in malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:75
      #1 0x7efec76b437e in strdup (/lib/x86_64-linux-gnu/libc.so.6+0xb437e) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #2 0x7efec7ab376e in rz_str_dup ../librz/util/str.c:1112
      #3 0x7efec4081797 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:223
      #4 0x7efec4076492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #5 0x7efec407cacb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #6 0x7efec407853a in parse_struct_node ../librz/type/parser/types_parser.c:487
      #7 0x7efec4080aa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #8 0x7efec4074738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #9 0x7efec4074992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #10 0x7efec3a5ba56 in rz_type_define_from_format_handler ../librz/core/cmd/cmd_type.c:391
      #11 0x7efec3a35e2b in argv_call_cb ../librz/core/cmd/cmd_api.c:743
      #12 0x7efec3a36112 in call_cd ../librz/core/cmd/cmd_api.c:799
      #13 0x7efec3a361ab in rz_cmd_call_parsed_args ../librz/core/cmd/cmd_api.c:812
      #14 0x7efec3a256fa in handle_ts_arged_stmt_internal ../librz/core/cmd/cmd.c:1169
      #15 0x7efec3a2502a in handle_ts_arged_stmt ../librz/core/cmd/cmd.c:1117
      #16 0x7efec3a31565 in handle_ts_stmt ../librz/core/cmd/cmd.c:2773
      #17 0x7efec3a31a77 in handle_ts_statements_internal ../librz/core/cmd/cmd.c:2830
      #18 0x7efec3a317bd in handle_ts_statements ../librz/core/cmd/cmd.c:2795
      #19 0x7efec3a3217e in core_cmd_tsrzcmd ../librz/core/cmd/cmd.c:2945
      #20 0x7efec3a32315 in rz_core_cmd_lines ../librz/core/cmd/cmd.c:2973
      #21 0x7efec84317a5 in run_commands ../librz/main/rizin.c:337
      #22 0x7efec8436007 in rz_main_rizin ../librz/main/rizin.c:1430
      #23 0x55dc8cc95a23 in main ../binrz/rizin/rizin.c:57
      #24 0x7efec762a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #25 0x7efec762a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #26 0x55dc8cc95504 in _start (/home/runner/bin/rizin+0x2504) (BuildId: ae8724244d0ea757937b19bdad4d5b665e7772a5)

--------------------------------

  test_type.c:1935

  Direct leak of 64 byte(s) in 2 object(s) allocated from:
      #0 0x7fae96a17f77 in calloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:90
      #1 0x7fae9700d764 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:217
      #2 0x7fae97002492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #3 0x7fae97008acb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #4 0x7fae9700453a in parse_struct_node ../librz/type/parser/types_parser.c:487
      #5 0x7fae9700caa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #6 0x7fae97000738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #7 0x7fae97000992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #8 0x55c41362e681 in test_type_format_to_c_declaration_registers_base_type ../test/unit/test_type.c:1935
      #9 0x55c41362f0cf in all_tests ../test/unit/test_type.c:1960
      #10 0x55c41362fc18 in main ../test/unit/test_type.c:1995
      #11 0x7fae9622a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #12 0x7fae9622a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #13 0x55c4135ff7e4 in _start (/home/runner/work/rizin/rizin/build/test/unit/test_type+0x27e4) (BuildId: 3abb3af76a276ce90756ead907de85711d080a6c)

--------------------------------

  test_type.c:1935

  Indirect leak of 16 byte(s) in 2 object(s) allocated from:
      #0 0x7fae96a18132 in malloc ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:75
      #1 0x7fae962b437e in strdup (/lib/x86_64-linux-gnu/libc.so.6+0xb437e) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #2 0x7fae966b376e in rz_str_dup ../librz/util/str.c:1112
      #3 0x7fae9700d797 in c_parser_get_primitive_type ../librz/type/parser/types_storage.c:223
      #4 0x7fae97002492 in parse_primitive_type ../librz/type/parser/types_parser.c:112
      #5 0x7fae97008acb in parse_type_node_single ../librz/type/parser/types_parser.c:1243
      #6 0x7fae9700453a in parse_struct_node ../librz/type/parser/types_parser.c:487
      #7 0x7fae9700caa1 in parse_type_nodes_save ../librz/type/parser/types_parser.c:1928
      #8 0x7fae97000738 in type_parse_string ../librz/type/parser/c_cpp_parser.c:190
      #9 0x7fae97000992 in rz_type_parse_string_stateless ../librz/type/parser/c_cpp_parser.c:228
      #10 0x55c41362e681 in test_type_format_to_c_declaration_registers_base_type ../test/unit/test_type.c:1935
      #11 0x55c41362f0cf in all_tests ../test/unit/test_type.c:1960
      #12 0x55c41362fc18 in main ../test/unit/test_type.c:1995
      #13 0x7fae9622a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #14 0x7fae9622a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
      #15 0x55c4135ff7e4 in _start (/home/runner/work/rizin/rizin/build/test/unit/test_type+0x27e4) (BuildId: 3abb3af76a276ce90756ead907de85711d080a6c)
```

**Test plan**

- CI is green
- No new memory leaks or double frees

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/3767
