### PR TITLE
librz/type: fix parsing and pretty-printing memory leaks

### DIFF
--- a/librz/core/cpdb.c
+++ b/librz/core/cpdb.c
@@ -14,7 +14,9 @@ static void pdb_types_print_standard(const RzTypeDB *db, const RzPdb *pdb, const
 	RzBaseType *type;
 	RzStrBuf *buf = rz_strbuf_new(NULL);
 	rz_list_foreach (types, it, type) {
-		rz_strbuf_append(buf, rz_type_db_base_type_as_pretty_string(db, type, RZ_TYPE_PRINT_MULTILINE | RZ_TYPE_PRINT_END_NEWLINE, 1));
+		char *pretty = rz_type_db_base_type_as_pretty_string(db, type, RZ_TYPE_PRINT_MULTILINE | RZ_TYPE_PRINT_END_NEWLINE, 1);
+		rz_strbuf_append(buf, pretty);
+		free(pretty);
 	}
 	rz_cons_print(rz_strbuf_get(buf));
 	rz_strbuf_free(buf);

--- a/librz/type/base.c
+++ b/librz/type/base.c
@@ -321,7 +321,9 @@ RZ_API RZ_OWN char *rz_type_db_base_type_as_pretty_string(RZ_NONNULL const RzTyp
 	rz_return_val_if_fail(typedb && btype, NULL);
 
 	RzType *type = rz_type_identifier_of_base_type(typedb, btype, false);
-	return rz_type_as_pretty_string(typedb, type, NULL, opts, unfold_level);
+	char *ret = rz_type_as_pretty_string(typedb, type, NULL, opts, unfold_level);
+	rz_type_free(type);
+	return ret;
 }
 
 /**

--- a/librz/type/parser/types_parser.c
+++ b/librz/type/parser/types_parser.c
@@ -539,8 +539,9 @@ int parse_struct_node(CParserState *state, TSNode node, const char *text, Parser
 					result = -1;
 					goto srnexit;
 				}
-				const char *bits_str = ts_node_sub_string(field_bits, text);
+				char *bits_str = ts_node_sub_string(field_bits, text);
 				int bits = rz_num_get(NULL, bits_str);
+				free(bits_str);
 				parser_debug(state, "field type: %s field_identifier: %s bits: %d\n", real_type, real_identifier, bits);
 				// Then we augment resulting type field with the data from parsed declarator
 				char *membname = NULL;
@@ -593,7 +594,9 @@ int parse_struct_node(CParserState *state, TSNode node, const char *text, Parser
 				}
 				parser_debug(state, "Appended member \"%s\" into struct \"%s\"\n", membname, name);
 			} else {
-				parser_debug(state, "Struct field wrong: \"%s\"\n", ts_node_sub_string(field_declarator, text));
+				char *wrong = ts_node_sub_string(field_declarator, text);
+				parser_debug(state, "Struct field wrong: \"%s\"\n", wrong);
+				free(wrong);
 			}
 			field_declarator = ts_node_next_named_sibling(field_declarator);
 		} while (!ts_node_is_null(field_declarator));
@@ -832,8 +835,9 @@ int parse_union_node(CParserState *state, TSNode node, const char *text, ParserT
 					result = -1;
 					goto urnexit;
 				}
-				const char *bits_str = ts_node_sub_string(field_bits, text);
+				char *bits_str = ts_node_sub_string(field_bits, text);
 				int bits = rz_num_get(NULL, bits_str);
+				free(bits_str);
 				parser_debug(state, "field type: %s field_identifier: %s bits: %d\n", real_type, real_identifier, bits);
 				// Then we augment resulting type field with the data from parsed declarator
 				char *membname = NULL;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Some newly found leaks in the RzType parsing and pretty-printing code

**Test plan**

CI is green