### PR TITLE
analysis: render flag-enum operands as an OR of members (#2344)

### DIFF
--- a/librz/arch/filter.c
+++ b/librz/arch/filter.c
@@ -53,7 +53,17 @@ static bool replace_enum_hint(RzParse *p, RzAnalysisHint *hint, ut64 off, char *
 	const char *member = rz_type_db_enum_member_by_val(
 		p->analb.analysis->typedb, hint->enum_name, off);
 	if (!member) {
-		return false;
+		// Not an exact member: the value may be the bitwise OR of several flag
+		// members (e.g. the access(2) mode R_OK|W_OK == 6). Render it as the OR
+		// of the matching members when it decomposes cleanly.
+		char *bitfield = rz_type_db_enum_get_bitfield(
+			p->analb.analysis->typedb, hint->enum_name, off);
+		if (!bitfield) {
+			return false;
+		}
+		replace_number_token(out, out_len, data, num_start, num_end, bitfield);
+		free(bitfield);
+		return true;
 	}
 
 	char ename[512] = "";

--- a/librz/type/type.c
+++ b/librz/type/type.c
@@ -566,47 +566,57 @@ RZ_API RZ_OWN RzList /*<char *>*/ *rz_type_db_find_enums_by_val(const RzTypeDB *
 }
 
 /**
- * \brief Returns all matching bitfields as an OR mask given the resulting value
+ * \brief Renders a value as the OR of the flag-enum members that compose it
+ *
+ * Each set bit of \p val is looked up among the members of the bitfield (flag)
+ * enum \p name; the matching member names, each qualified with the enum name,
+ * are joined by " | " into a newly-allocated string, for example
+ * "access_def.W_OK | access_def.R_OK". \p val is decomposed bit by bit, so a
+ * member whose value is not a single bit is never matched against the whole
+ * value -- use rz_type_db_enum_member_by_val() for that exact-match case (the
+ * disassembly filter tries it first).
  *
  * \param typedb Types Database instance
- * \param name The name of the bitfield enum
- * \param val The value to search for
+ * \param name The name of the bitfield (flag) enum
+ * \param val The value to decompose
+ * \return The qualified OR mask, or NULL if \p name is not an enum, \p val is 0,
+ *         or any set bit of \p val has no matching member (so \p val is not
+ *         cleanly a combination of the enum's flag members).
  */
 RZ_API RZ_OWN char *rz_type_db_enum_get_bitfield(const RzTypeDB *typedb, RZ_NONNULL const char *name, ut64 val) {
 	rz_return_val_if_fail(typedb && name, NULL);
-	char *res = NULL;
-	int i;
-	bool isFirst = true;
 
 	RzBaseType *btype = rz_type_db_get_base_type(typedb, name);
-	if (!btype) {
+	if (!btype || btype->kind != RZ_BASE_TYPE_KIND_ENUM) {
 		return NULL;
 	}
-	if (btype->kind != RZ_BASE_TYPE_KIND_ENUM) {
+	if (!val) {
 		return NULL;
 	}
-	char *ret = rz_str_newf("0x%08" PFMT64x " : ", val);
-	for (i = 0; i < 32; i++) {
-		ut32 n = 1ULL << i;
+	char *ret = NULL;
+	for (int i = 0; i < 64; i++) {
+		ut64 n = 1ULL << i;
 		if (!(val & n)) {
 			continue;
 		}
+		const char *member = NULL;
 		RzTypeEnumCase *cas;
 		rz_vector_foreach (&btype->enum_data.cases, cas) {
 			if (cas->val == n) {
-				res = cas->name;
+				member = cas->name;
 				break;
 			}
 		}
-		if (isFirst) {
-			isFirst = false;
-		} else {
-			ret = rz_str_append(ret, " | ");
+		if (!member) {
+			// a set bit with no matching member: not a clean flag combination
+			RZ_LOG_ERROR("Can't find matching enum \"%s\" member for %d bit\n", name, i);
+			free(ret);
+			return NULL;
 		}
-		if (res) {
-			ret = rz_str_append(ret, res);
+		if (ret) {
+			ret = rz_str_appendf(ret, " | %s.%s", name, member);
 		} else {
-			ret = rz_str_appendf(ret, "0x%x", n);
+			ret = rz_str_newf("%s.%s", name, member);
 		}
 	}
 	return ret;

--- a/test/db/cmd/cmd_ahi
+++ b/test/db/cmd/cmd_ahi
@@ -464,3 +464,31 @@ or d0, d0, #E.MASK
 [   allocframe(SP,#E.EIGHT):raw
 EOF
 RUN
+
+NAME=ahie flag enum OR operands
+FILE==
+CMDS=<<EOF
+o malloc://256
+td "enum access_def { F_OK = 0, X_OK = 1, W_OK = 2, R_OK = 4 };"
+e asm.arch=x86
+e asm.bits=64
+e cfg.bigendian=false
+s 0
+wx b806000000
+ahie access_def
+pi 1
+s 0x10
+wx b804000000
+ahie access_def
+pi 1
+s 0x20
+wx b808000000
+ahie access_def
+pi 1
+EOF
+EXPECT=<<EOF
+mov eax, access_def.W_OK | access_def.R_OK
+mov eax, access_def.R_OK
+mov eax, 0x08
+EOF
+RUN

--- a/test/unit/test_type.c
+++ b/test/unit/test_type.c
@@ -416,6 +416,51 @@ static bool test_enum_types(void) {
 	mu_end;
 }
 
+static bool test_enum_get_bitfield(void) {
+	RzTypeDB *typedb = rz_type_db_new();
+	mu_assert_notnull(typedb, "Couldn't create new RzTypeDB");
+	const char *types_dir = TEST_BUILD_TYPES_DIR;
+	rz_type_db_init(typedb, types_dir, "x86", 64, "linux");
+
+	// A flag enum modeled on access(2)'s mode argument, plus a member above bit
+	// 32 to exercise 64-bit handling.
+	RzBaseType *e = rz_type_base_type_new(RZ_BASE_TYPE_KIND_ENUM);
+	mu_assert_notnull(e, "new enum base type");
+	e->name = strdup("access_def");
+	RzTypeEnumCase cases[] = {
+		{ .name = strdup("F_OK"), .val = 0x0 },
+		{ .name = strdup("X_OK"), .val = 0x1 },
+		{ .name = strdup("W_OK"), .val = 0x2 },
+		{ .name = strdup("R_OK"), .val = 0x4 },
+		{ .name = strdup("HIGH"), .val = 0x100000000LL },
+	};
+	for (size_t i = 0; i < RZ_ARRAY_SIZE(cases); i++) {
+		rz_vector_push(&e->enum_data.cases, &cases[i]);
+	}
+	mu_assert_true(rz_type_db_save_base_type(typedb, e), "register enum");
+
+	// The issue #2344 case: access(2) mode 6 == R_OK | W_OK decomposes to the OR
+	// of its flag members (bits are visited low-to-high).
+	mu_assert_streq_free(rz_type_db_enum_get_bitfield(typedb, "access_def", 6),
+		"access_def.W_OK | access_def.R_OK", "OR of two flag members");
+	// A single set bit still resolves to that one (qualified) member.
+	mu_assert_streq_free(rz_type_db_enum_get_bitfield(typedb, "access_def", 4),
+		"access_def.R_OK", "single flag member");
+	// 64-bit: a member above bit 32 is matched (regression for the old 32-bit cap).
+	mu_assert_streq_free(rz_type_db_enum_get_bitfield(typedb, "access_def", 0x100000004LL),
+		"access_def.R_OK | access_def.HIGH", "64-bit flag member");
+	// A value with a set bit that has no matching member does not decompose.
+	mu_assert_null(rz_type_db_enum_get_bitfield(typedb, "access_def", 8), "no member for bit 3");
+	// Zero never decomposes (the exact F_OK=0 case belongs to enum_member_by_val).
+	mu_assert_null(rz_type_db_enum_get_bitfield(typedb, "access_def", 0), "zero value");
+	// A non-enum type, and an unknown type, both yield NULL.
+	mu_assert_null(rz_type_db_enum_get_bitfield(typedb, "int", 6), "non-enum type");
+	mu_assert_null(rz_type_db_enum_get_bitfield(typedb, "no_such_type", 6), "unknown type");
+
+	rz_type_db_free(typedb);
+	mu_end;
+}
+
 static bool test_enum_underlying_type(void) {
 	RzTypeDB *typedb = rz_type_db_new();
 	mu_assert_notnull(typedb, "Couldn't create new RzTypeDB");
@@ -2092,6 +2137,7 @@ int all_tests() {
 	mu_run_test(test_type_as_string);
 	mu_run_test(test_type_as_pretty_string);
 	mu_run_test(test_enum_types);
+	mu_run_test(test_enum_get_bitfield);
 	mu_run_test(test_enum_underlying_type);
 	mu_run_test(test_const_types);
 	mu_run_test(test_array_types);


### PR DESCRIPTION

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

An enum type hint set on an operand (`ahie`) only replaced the immediate when its value matched an enum member exactly, via `rz_type_db_enum_member_by_val()`. A value that is the bitwise OR of several flag members -- e.g. the access(2) mode R_OK|W_OK == 6 from the issue -- matched no single member and was left as a raw number.

`replace_enum_hint()` in `rz_parse` now falls back to` rz_type_db_enum_get_bitfield()` when there is no exact member, so the value is rendered as the OR of the matching members, e.g. "access_def.W_OK | access_def.R_OK".

`rz_type_db_enum_get_bitfield()` is reworked along the way: it was unused and buggy (capped at 32 bits, reused a stale match for bits without a member, and emitted a "0x.. : " debug prefix). It now walks all 64 bits, returns the matching members qualified with the enum name and joined by " | ", and returns NULL when the value is 0, the type is not an enum, or any set bit has no member (so a value that is not cleanly a combination of flags stays a number).

**Test plan**

CI is green

**Closing issues**

Closes #2344
