### PR TITLE
Don't show `; -1` comment if `ahi` is used

### DIFF
--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -4224,7 +4224,7 @@ static void ds_print_ptr(RzDisasmState *ds, int len, int idx) {
 				ds->printed_flag_addr = refaddr;
 			}
 		} else {
-			if (refaddr == UT64_MAX || refaddr == UT32_MAX) {
+			if ((refaddr == UT64_MAX || refaddr == UT32_MAX) && (!ds->hint || !ds->hint->immbase)) {
 				ds_begin_comment(ds);
 				ds_comment(ds, true, "; -1");
 			} else if (((char)refaddr > 0) && refaddr >= '!' && refaddr <= '~') {

--- a/test/db/cmd/cmd_ahi
+++ b/test/db/cmd/cmd_ahi
@@ -345,8 +345,8 @@ pd 1
 EOF
 EXPECT=<<EOF
             0x00000000      cmp   eax, 0xffffffff                      ; -1
-            0x00000000      cmp   eax, -1                              ; -1
-            0x00000000      cmp   eax, 4294967295                      ; -1
+            0x00000000      cmp   eax, -1
+            0x00000000      cmp   eax, 4294967295
 EOF
 RUN
 
@@ -372,8 +372,8 @@ pd 1
 EOF
 EXPECT=<<EOF
             0x00000000      cmp   eax, 0xffffffff                      ; -1
-            0x00000000      cmp   eax, -1                              ; -1
-            0x00000000      cmp   eax, 4294967295                      ; -1
+            0x00000000      cmp   eax, -1
+            0x00000000      cmp   eax, 4294967295
 
             0x00000000      cmp   rax, 0xffffffffffffffff
             0x00000000      cmp   rax, -1


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [X] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

This pr removes the `; -1` comment if `ahi` is used.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The change makes sense. All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
