### PR TITLE
librz/arch: add type-indexed xref queries

### DIFF
--- a/librz/arch/analysis.c
+++ b/librz/arch/analysis.c
@@ -222,6 +222,8 @@ RZ_API void rz_analysis_free(RZ_NULLABLE RzAnalysis *a) {
 	rz_reg_free(a->reg);
 	ht_up_free(a->ht_xrefs_from);
 	ht_up_free(a->ht_xrefs_to);
+	ht_up_free(a->ht_xrefs_from_by_type);
+	ht_up_free(a->ht_xrefs_to_by_type);
 	rz_list_free(a->leaddrs);
 	rz_type_db_free(a->typedb);
 	sdb_free(a->sdb);

--- a/librz/arch/analysis_private.h
+++ b/librz/arch/analysis_private.h
@@ -60,6 +60,8 @@ struct rz_analysis_t {
 	Sdb *sdb_fmts;
 	HtUP *ht_xrefs_from;
 	HtUP *ht_xrefs_to;
+	HtUP *ht_xrefs_from_by_type; ///< type -> from -> to -> xref* (non-owning)
+	HtUP *ht_xrefs_to_by_type; ///< type -> to -> from -> xref* (non-owning)
 	bool recursive_noreturn; // analysis.rnr
 	// moved from RzAnalysisFcn
 	Sdb *sdb; // root

--- a/librz/arch/xrefs.c
+++ b/librz/arch/xrefs.c
@@ -231,6 +231,14 @@ RZ_API bool rz_analysis_xrefs_deln(RzAnalysis *analysis, ut64 from, ut64 to, RzA
 	}
 	HtUP *ht1 = ht_up_find(analysis->ht_xrefs_from, from, NULL);
 	if (ht1) {
+		// The primary tables drop the (from, to) xref no matter which <type> was
+		// passed. Resolve the stored xref's actual type before it is freed below,
+		// so the type index entries are removed for the right type even when
+		// <type> doesn't match (otherwise they would keep a dangling pointer).
+		RzAnalysisXRef *xref = ht_up_find(ht1, to, NULL);
+		if (xref) {
+			type = xref->type;
+		}
 		ht_up_delete(ht1, to);
 	}
 	HtUP *ht2 = ht_up_find(analysis->ht_xrefs_to, to, NULL);

--- a/librz/arch/xrefs.c
+++ b/librz/arch/xrefs.c
@@ -17,8 +17,6 @@ xrefs 20->[10 C] 10 -> [16 J, 20 C]
 
 10 : call 20 16 : jmp 10 20 : call 10
 */
-// TODO: is it possible to have multiple type for the same (from, to) pair?
-//       if it is, things need to be adjusted
 
 static RzAnalysisXRef *rz_analysis_xref_new(ut64 from, ut64 to, ut64 type) {
 	RzAnalysisXRef *xref = RZ_NEW(RzAnalysisXRef);
@@ -177,36 +175,50 @@ RZ_API bool rz_analysis_xrefs_set(RzAnalysis *analysis, ut64 from, ut64 to, RzAn
 	if (!xref) {
 		return false;
 	}
-	// Clean up old type index entries if a different-typed xref existed before.
-	if (analysis->ht_xrefs_to_by_type) {
-		HtUP *ht = ht_up_find(analysis->ht_xrefs_to, to, NULL);
-		if (ht) {
-			RzAnalysisXRef *old = ht_up_find(ht, from, NULL);
-			if (old && old->type != type) {
-				del_xref_by_type(analysis->ht_xrefs_from_by_type, from, to, old->type, true);
-				del_xref_by_type(analysis->ht_xrefs_to_by_type, from, to, old->type, false);
-			}
+	// Remember whether a xref for the same (from, to) pair exists with a different
+	// type. Its type index entries are removed only after the new xref was inserted
+	// into the primary tables, so the old xref stays fully indexed if any insertion
+	// below fails.
+	bool drop_old_type = false;
+	RzAnalysisXRefType old_type = RZ_ANALYSIS_XREF_TYPE_NULL;
+	HtUP *ht = ht_up_find(analysis->ht_xrefs_to, to, NULL);
+	if (ht) {
+		RzAnalysisXRef *old = ht_up_find(ht, from, NULL);
+		if (old && old->type != type) {
+			drop_old_type = true;
+			old_type = old->type;
 		}
 	}
 	if (!set_xref(analysis->ht_xrefs_from, xref, true)) {
+		// Pointer isn't added to <ht_xrefs_from> so we have to release it
 		rz_analysis_xref_free(xref);
 		return false;
 	}
 	if (!set_xref(analysis->ht_xrefs_to, xref, false)) {
+		// Delete the entry in <ht_xrefs_from>. This also destroys a pre-existing
+		// xref for this (from, to) pair, so its type index entries are dropped too.
 		rz_analysis_xrefs_deln(analysis, from, to, type);
+		if (drop_old_type) {
+			del_xref_by_type(analysis->ht_xrefs_from_by_type, from, to, old_type, true);
+			del_xref_by_type(analysis->ht_xrefs_to_by_type, from, to, old_type, false);
+		}
+		// Pointer isn't added to <ht_xrefs_to> so we have to release it
 		rz_analysis_xref_free(xref);
 		return false;
 	}
-	if (analysis->ht_xrefs_from_by_type &&
-		!set_xref_by_type(analysis->ht_xrefs_from_by_type, xref, true)) {
+	// The old xref was replaced (and freed) by the updates above, so its type
+	// index entries have to be removed now.
+	if (drop_old_type) {
+		del_xref_by_type(analysis->ht_xrefs_from_by_type, from, to, old_type, true);
+		del_xref_by_type(analysis->ht_xrefs_to_by_type, from, to, old_type, false);
+	}
+	// rz_analysis_xrefs_deln() removes the primary entries (freeing the xref) and
+	// the type index entries of <type>, keeping all tables consistent on failure.
+	if (!set_xref_by_type(analysis->ht_xrefs_from_by_type, xref, true)) {
 		rz_analysis_xrefs_deln(analysis, from, to, type);
 		return false;
 	}
-	if (analysis->ht_xrefs_to_by_type &&
-		!set_xref_by_type(analysis->ht_xrefs_to_by_type, xref, false)) {
-		if (analysis->ht_xrefs_from_by_type) {
-			del_xref_by_type(analysis->ht_xrefs_from_by_type, from, to, type, true);
-		}
+	if (!set_xref_by_type(analysis->ht_xrefs_to_by_type, xref, false)) {
 		rz_analysis_xrefs_deln(analysis, from, to, type);
 		return false;
 	}

--- a/librz/arch/xrefs.c
+++ b/librz/arch/xrefs.c
@@ -104,9 +104,65 @@ static bool set_xref(HtUP *m, RzAnalysisXRef *xref, bool from2to) {
 	return ht_up_update(ht, key2, xref);
 }
 
-// Set a cross reference from FROM to TO.
+static bool set_xref_by_type(HtUP *type_ht, RzAnalysisXRef *xref, bool from2to) {
+	ut64 type_key = (ut64)xref->type;
+	HtUP *addr_ht = ht_up_find(type_ht, type_key, NULL);
+	if (!addr_ht) {
+		addr_ht = ht_up_new(NULL, (HtUPFreeValue)ht_up_free);
+		if (!addr_ht) {
+			return false;
+		}
+		if (!ht_up_insert(type_ht, type_key, addr_ht)) {
+			ht_up_free(addr_ht);
+			return false;
+		}
+	}
+	ut64 key1 = from2to ? xref->from : xref->to;
+	HtUP *inner = ht_up_find(addr_ht, key1, NULL);
+	if (!inner) {
+		inner = ht_up_new(NULL, NULL);
+		if (!inner) {
+			return false;
+		}
+		if (!ht_up_insert(addr_ht, key1, inner)) {
+			ht_up_free(inner);
+			return false;
+		}
+	}
+	ut64 key2 = from2to ? xref->to : xref->from;
+	return ht_up_update(inner, key2, xref);
+}
+
+static void del_xref_by_type(HtUP *type_ht, ut64 from, ut64 to,
+	RzAnalysisXRefType type, bool from2to) {
+	HtUP *addr_ht = ht_up_find(type_ht, (ut64)type, NULL);
+	if (!addr_ht) {
+		return;
+	}
+	ut64 key1 = from2to ? from : to;
+	HtUP *inner = ht_up_find(addr_ht, key1, NULL);
+	if (!inner) {
+		return;
+	}
+	ut64 key2 = from2to ? to : from;
+	ht_up_delete(inner, key2);
+}
+
+/**
+ * \brief Set a cross reference from \p from to \p to.
+ *
+ * If a xref for the same (from, to) pair already exists with a different type,
+ * the old xref is replaced with the new one. Type indices are updated accordingly.
+ *
+ * \param analysis RzAnalysis instance.
+ * \param from Source address.
+ * \param to Target address.
+ * \param type Xref type.
+ * \return true if the xref was set successfully, false otherwise.
+ */
 RZ_API bool rz_analysis_xrefs_set(RzAnalysis *analysis, ut64 from, ut64 to, RzAnalysisXRefType type) {
-	if (!analysis || from == to) {
+	rz_return_val_if_fail(analysis && analysis->ht_xrefs_to_by_type && analysis->ht_xrefs_from_by_type, false);
+	if (from == to) {
 		return false;
 	}
 	if (analysis->iob.is_valid_offset) {
@@ -121,16 +177,37 @@ RZ_API bool rz_analysis_xrefs_set(RzAnalysis *analysis, ut64 from, ut64 to, RzAn
 	if (!xref) {
 		return false;
 	}
+	// Clean up old type index entries if a different-typed xref existed before.
+	if (analysis->ht_xrefs_to_by_type) {
+		HtUP *ht = ht_up_find(analysis->ht_xrefs_to, to, NULL);
+		if (ht) {
+			RzAnalysisXRef *old = ht_up_find(ht, from, NULL);
+			if (old && old->type != type) {
+				del_xref_by_type(analysis->ht_xrefs_from_by_type, from, to, old->type, true);
+				del_xref_by_type(analysis->ht_xrefs_to_by_type, from, to, old->type, false);
+			}
+		}
+	}
 	if (!set_xref(analysis->ht_xrefs_from, xref, true)) {
-		// Pointer isn't added to <ht_xrefs_from> so we have to release it
 		rz_analysis_xref_free(xref);
 		return false;
 	}
 	if (!set_xref(analysis->ht_xrefs_to, xref, false)) {
-		// Delete the entry in <ht_xrefs_from>
 		rz_analysis_xrefs_deln(analysis, from, to, type);
-		// Pointer isn't added to <ht_xrefs_to> so we have to release it
 		rz_analysis_xref_free(xref);
+		return false;
+	}
+	if (analysis->ht_xrefs_from_by_type &&
+		!set_xref_by_type(analysis->ht_xrefs_from_by_type, xref, true)) {
+		rz_analysis_xrefs_deln(analysis, from, to, type);
+		return false;
+	}
+	if (analysis->ht_xrefs_to_by_type &&
+		!set_xref_by_type(analysis->ht_xrefs_to_by_type, xref, false)) {
+		if (analysis->ht_xrefs_from_by_type) {
+			del_xref_by_type(analysis->ht_xrefs_from_by_type, from, to, type, true);
+		}
+		rz_analysis_xrefs_deln(analysis, from, to, type);
 		return false;
 	}
 	return true;
@@ -147,6 +224,12 @@ RZ_API bool rz_analysis_xrefs_deln(RzAnalysis *analysis, ut64 from, ut64 to, RzA
 	HtUP *ht2 = ht_up_find(analysis->ht_xrefs_to, to, NULL);
 	if (ht2) {
 		ht_up_delete(ht2, from);
+	}
+	if (analysis->ht_xrefs_from_by_type) {
+		del_xref_by_type(analysis->ht_xrefs_from_by_type, from, to, type, true);
+	}
+	if (analysis->ht_xrefs_to_by_type) {
+		del_xref_by_type(analysis->ht_xrefs_to_by_type, from, to, type, false);
 	}
 	return true;
 }
@@ -238,21 +321,48 @@ RZ_API bool rz_analysis_xrefs_init(RzAnalysis *analysis) {
 	analysis->ht_xrefs_from = NULL;
 	ht_up_free(analysis->ht_xrefs_to);
 	analysis->ht_xrefs_to = NULL;
+	ht_up_free(analysis->ht_xrefs_from_by_type);
+	analysis->ht_xrefs_from_by_type = NULL;
+	ht_up_free(analysis->ht_xrefs_to_by_type);
+	analysis->ht_xrefs_to_by_type = NULL;
 
-	HtUP *tmp = ht_up_new(NULL, (HtUPFreeValue)ht_up_free);
+	HtUP *tmp;
+	tmp = ht_up_new(NULL, (HtUPFreeValue)ht_up_free);
 	if (!tmp) {
-		return false;
+		goto err;
 	}
 	analysis->ht_xrefs_from = tmp;
 
 	tmp = ht_up_new(NULL, (HtUPFreeValue)ht_up_free);
 	if (!tmp) {
-		ht_up_free(analysis->ht_xrefs_from);
-		analysis->ht_xrefs_from = NULL;
-		return false;
+		goto err_free_from;
 	}
 	analysis->ht_xrefs_to = tmp;
+
+	tmp = ht_up_new(NULL, (HtUPFreeValue)ht_up_free);
+	if (!tmp) {
+		goto err_free_to;
+	}
+	analysis->ht_xrefs_from_by_type = tmp;
+
+	tmp = ht_up_new(NULL, (HtUPFreeValue)ht_up_free);
+	if (!tmp) {
+		goto err_free_from_by_type;
+	}
+	analysis->ht_xrefs_to_by_type = tmp;
 	return true;
+
+err_free_from_by_type:
+	ht_up_free(analysis->ht_xrefs_from_by_type);
+	analysis->ht_xrefs_from_by_type = NULL;
+err_free_to:
+	ht_up_free(analysis->ht_xrefs_to);
+	analysis->ht_xrefs_to = NULL;
+err_free_from:
+	ht_up_free(analysis->ht_xrefs_from);
+	analysis->ht_xrefs_from = NULL;
+err:
+	return false;
 }
 
 static bool count_cb(void *user, const ut64 k, const void *v) {
@@ -308,4 +418,300 @@ RZ_API const char *rz_analysis_ref_type_tostring(RzAnalysisXRefType t) {
 		return "string";
 	}
 	return "unknown";
+}
+
+typedef struct {
+	RzIterator *outer; ///< iterates addr_ht, yields HtUP **
+	RzIterator *inner; ///< iterates current inner HtUP, yields RzAnalysisXRef **
+} XrefTypeAllState;
+
+static void *xref_type_all_next(RzIterator *it) {
+	XrefTypeAllState *st = it->u;
+	if (st->inner) {
+		void *next = rz_iterator_next(st->inner);
+		if (next) {
+			return next;
+		}
+		rz_iterator_free(st->inner);
+		st->inner = NULL;
+	}
+	while (true) {
+		void *outer_val = rz_iterator_next(st->outer);
+		if (!outer_val) {
+			return NULL;
+		}
+		HtUP *inner_ht = *(HtUP **)outer_val;
+		if (!inner_ht || !ht_up_size(inner_ht)) {
+			continue;
+		}
+		st->inner = ht_up_as_iter(inner_ht);
+		if (!st->inner) {
+			continue;
+		}
+		void *next = rz_iterator_next(st->inner);
+		if (next) {
+			return next;
+		}
+		rz_iterator_free(st->inner);
+		st->inner = NULL;
+	}
+}
+
+static void xref_type_all_free_state(XrefTypeAllState *st) {
+	if (!st) {
+		return;
+	}
+	rz_iterator_free(st->inner);
+	rz_iterator_free(st->outer);
+	free(st);
+}
+
+/**
+ * \brief Get all xrefs of a given type.
+ *
+ * Uses the type-indexed storage for efficient O(k) access where k is
+ * the number of xrefs of the requested type, instead of scanning all xrefs.
+ * Returns an RzIterator yielding RzAnalysisXRef ** pointers.
+ *
+ * \param analysis RzAnalysis instance.
+ * \param type The xref type to filter by.
+ * \return RzIterator yielding RzAnalysisXRef **, or NULL if none found.
+ */
+RZ_API RZ_OWN RzIterator *rz_analysis_xrefs_get_all_of_type(
+	RzAnalysis *analysis, RzAnalysisXRefType type) {
+	rz_return_val_if_fail(analysis, NULL);
+	if (!analysis->ht_xrefs_from_by_type) {
+		return NULL;
+	}
+	HtUP *addr_ht = ht_up_find(analysis->ht_xrefs_from_by_type, (ut64)type, NULL);
+	if (!addr_ht || !ht_up_size(addr_ht)) {
+		return NULL;
+	}
+	XrefTypeAllState *st = RZ_NEW(XrefTypeAllState);
+	if (!st) {
+		return NULL;
+	}
+	st->inner = NULL;
+	st->outer = ht_up_as_iter(addr_ht);
+	if (!st->outer) {
+		free(st);
+		return NULL;
+	}
+	RzIterator *it = rz_iterator_new(
+		xref_type_all_next, NULL,
+		(rz_iterator_free_cb)xref_type_all_free_state, st);
+	if (!it) {
+		return NULL;
+	}
+	return it;
+}
+
+/**
+ * \brief Get xrefs pointing TO a given address, filtered by type.
+ *
+ * Returns an RzIterator yielding RzAnalysisXRef ** pointers.
+ *
+ * \param analysis RzAnalysis instance.
+ * \param addr The target address.
+ * \param type The xref type to filter by.
+ * \return RzIterator yielding RzAnalysisXRef **, or NULL if none found.
+ */
+RZ_API RZ_OWN RzIterator *rz_analysis_xrefs_get_to_type(
+	RzAnalysis *analysis, ut64 addr, RzAnalysisXRefType type) {
+	rz_return_val_if_fail(analysis, NULL);
+	if (!analysis->ht_xrefs_to_by_type) {
+		return NULL;
+	}
+	HtUP *addr_ht = ht_up_find(analysis->ht_xrefs_to_by_type, (ut64)type, NULL);
+	if (!addr_ht) {
+		return NULL;
+	}
+	HtUP *inner = ht_up_find(addr_ht, addr, NULL);
+	if (!inner) {
+		return NULL;
+	}
+	return ht_up_as_iter(inner);
+}
+
+/**
+ * \brief Get xrefs FROM a given address, filtered by type.
+ *
+ * Returns an RzIterator yielding RzAnalysisXRef ** pointers.
+ *
+ * \param analysis RzAnalysis instance.
+ * \param addr The source address.
+ * \param type The xref type to filter by.
+ * \return RzIterator yielding RzAnalysisXRef **, or NULL if none found.
+ */
+RZ_API RZ_OWN RzIterator *rz_analysis_xrefs_get_from_type(
+	RzAnalysis *analysis, ut64 addr, RzAnalysisXRefType type) {
+	rz_return_val_if_fail(analysis, NULL);
+	if (!analysis->ht_xrefs_from_by_type) {
+		return NULL;
+	}
+	HtUP *addr_ht = ht_up_find(analysis->ht_xrefs_from_by_type, (ut64)type, NULL);
+	if (!addr_ht) {
+		return NULL;
+	}
+	HtUP *inner = ht_up_find(addr_ht, addr, NULL);
+	if (!inner) {
+		return NULL;
+	}
+	return ht_up_as_iter(inner);
+}
+
+static bool count_type_cb(void *user, const ut64 k, const void *v) {
+	(*(ut64 *)user) += ht_up_size((HtUP *)v);
+	return true;
+}
+
+/**
+ * \brief Count xrefs of a given type.
+ * \param analysis RzAnalysis instance.
+ * \param type The xref type to count.
+ * \return Number of xrefs of the given type.
+ */
+RZ_API ut64 rz_analysis_xrefs_count_type(RzAnalysis *analysis, RzAnalysisXRefType type) {
+	rz_return_val_if_fail(analysis, 0);
+	if (!analysis->ht_xrefs_to_by_type) {
+		return 0;
+	}
+	HtUP *addr_ht = ht_up_find(analysis->ht_xrefs_to_by_type, (ut64)type, NULL);
+	if (!addr_ht) {
+		return 0;
+	}
+	ut64 ret = 0;
+	ht_up_foreach(addr_ht, count_type_cb, &ret);
+	return ret;
+}
+
+typedef struct {
+	HtUP *ht; ///< outer hashtable to look up keys in
+	RzIterator *keys; ///< iterates over outer ht keys
+	RzIterator *inner; ///< iterates over current inner ht
+	ut64 range_from;
+	ut64 range_to;
+} XrefRangeState;
+
+static void *xref_range_next(RzIterator *it) {
+	XrefRangeState *st = it->u;
+	if (st->inner) {
+		void *next = rz_iterator_next(st->inner);
+		if (next) {
+			return next;
+		}
+		rz_iterator_free(st->inner);
+		st->inner = NULL;
+	}
+	while (true) {
+		void *keyp = rz_iterator_next(st->keys);
+		if (!keyp) {
+			return NULL;
+		}
+		ut64 key = *(const ut64 *)keyp;
+		if (key < st->range_from || key > st->range_to) {
+			continue;
+		}
+		HtUP *inner_ht = ht_up_find(st->ht, key, NULL);
+		if (!inner_ht || !ht_up_size(inner_ht)) {
+			continue;
+		}
+		st->inner = ht_up_as_iter(inner_ht);
+		if (!st->inner) {
+			continue;
+		}
+		void *next = rz_iterator_next(st->inner);
+		if (next) {
+			return next;
+		}
+		rz_iterator_free(st->inner);
+		st->inner = NULL;
+	}
+}
+
+static void xref_range_free_state(XrefRangeState *st) {
+	if (!st) {
+		return;
+	}
+	rz_iterator_free(st->inner);
+	rz_iterator_free(st->keys);
+	free(st);
+}
+
+/**
+ * \brief Get xrefs pointing TO addresses in a given range.
+ *
+ * Returns an RzIterator yielding RzAnalysisXRef ** pointers.
+ * Xrefs where the target address falls within [addr_from, addr_to] are included.
+ *
+ * \param analysis RzAnalysis instance.
+ * \param addr_from Start of the address range (inclusive).
+ * \param addr_to End of the address range (inclusive).
+ * \return RzIterator yielding RzAnalysisXRef **, or NULL if none found.
+ */
+RZ_API RZ_OWN RzIterator *rz_analysis_xrefs_get_to_range(
+	RzAnalysis *analysis, ut64 addr_from, ut64 addr_to) {
+	rz_return_val_if_fail(analysis, NULL);
+	if (!analysis->ht_xrefs_to) {
+		return NULL;
+	}
+	XrefRangeState *st = RZ_NEW(XrefRangeState);
+	if (!st) {
+		return NULL;
+	}
+	st->ht = analysis->ht_xrefs_to;
+	st->inner = NULL;
+	st->range_from = addr_from;
+	st->range_to = addr_to;
+	st->keys = ht_up_as_iter_keys(analysis->ht_xrefs_to);
+	if (!st->keys) {
+		free(st);
+		return NULL;
+	}
+	RzIterator *it = rz_iterator_new(
+		xref_range_next, NULL,
+		(rz_iterator_free_cb)xref_range_free_state, st);
+	if (!it) {
+		return NULL;
+	}
+	return it;
+}
+
+/**
+ * \brief Get xrefs FROM addresses in a given range.
+ *
+ * Returns an RzIterator yielding RzAnalysisXRef ** pointers.
+ * Xrefs where the source address falls within [addr_from, addr_to] are included.
+ *
+ * \param analysis RzAnalysis instance.
+ * \param addr_from Start of the address range (inclusive).
+ * \param addr_to End of the address range (inclusive).
+ * \return RzIterator yielding RzAnalysisXRef **, or NULL if none found.
+ */
+RZ_API RZ_OWN RzIterator *rz_analysis_xrefs_get_from_range(
+	RzAnalysis *analysis, ut64 addr_from, ut64 addr_to) {
+	rz_return_val_if_fail(analysis, NULL);
+	if (!analysis->ht_xrefs_from) {
+		return NULL;
+	}
+	XrefRangeState *st = RZ_NEW(XrefRangeState);
+	if (!st) {
+		return NULL;
+	}
+	st->ht = analysis->ht_xrefs_from;
+	st->inner = NULL;
+	st->range_from = addr_from;
+	st->range_to = addr_to;
+	st->keys = ht_up_as_iter_keys(analysis->ht_xrefs_from);
+	if (!st->keys) {
+		free(st);
+		return NULL;
+	}
+	RzIterator *it = rz_iterator_new(
+		xref_range_next, NULL,
+		(rz_iterator_free_cb)xref_range_free_state, st);
+	if (!it) {
+		return NULL;
+	}
+	return it;
 }

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -3568,28 +3568,15 @@ static void relocation_noreturn_process(RzCore *core, RzList /*<char *>*/ *noret
 
 #define CALL_BUF_SIZE 32
 
-struct core_noretl {
-	RzCore *core;
-	RzList /*<char *>*/ *noretl;
-	RzSetU *todo;
-};
-
-static bool process_reference_noreturn_cb(void *u, const ut64 addr, const void *v) {
-	RzCore *core = ((struct core_noretl *)u)->core;
-	RzList *noretl = ((struct core_noretl *)u)->noretl;
-	RzSetU *todo = ((struct core_noretl *)u)->todo;
-	RzAnalysisXRef *xref = (RzAnalysisXRef *)v;
-	if (xref->type != RZ_ANALYSIS_XREF_TYPE_CALL && xref->type != RZ_ANALYSIS_XREF_TYPE_CODE) {
-		return true;
-	}
-
+static void process_reference_noreturn(RzCore *core, RzList /*<char *>*/ *noretl, RzSetU *todo, const RzAnalysisXRef *xref) {
+	const ut64 addr = xref->from;
 	// At first we check if there are any relocations that override the call address
 	// Note, that the relocation overrides only the part of the instruction
 	ut8 buf[CALL_BUF_SIZE] = { 0 };
 	RzAnalysisOp op = { 0 };
 	if (!rz_io_read_at_mapped(core->io, addr, buf, sizeof(buf))) {
 		RZ_LOG_INFO("analysis: Fail to load %d bytes of data at 0x%08" PFMT64x "\n", CALL_BUF_SIZE, addr);
-		return true;
+		return;
 	}
 
 	rz_analysis_op_init(&op);
@@ -3600,19 +3587,12 @@ static bool process_reference_noreturn_cb(void *u, const ut64 addr, const void *
 			RzAnalysisBlock *block = find_block_at_xref_addr(core, addr);
 			if (!block) {
 				rz_analysis_op_fini(&op);
-				return true;
+				return;
 			}
 			relocation_noreturn_process(core, noretl, todo, block, rel, op.size, addr);
 		}
 	}
 	rz_analysis_op_fini(&op);
-	return true;
-}
-
-static bool process_refs_cb(void *u, const ut64 k, const void *v) {
-	HtUP *ht = (HtUP *)v;
-	ht_up_foreach(ht, process_reference_noreturn_cb, u);
-	return true;
 }
 
 static bool reanalyze_fcns_cb(void *u, const ut64 k, const void *v) {
@@ -3634,9 +3614,20 @@ RZ_API void rz_core_analysis_propagate_noreturn_relocs(RzCore *core, ut64 addr) 
 	RzList *noretl = rz_analysis_noreturn_functions(core->analysis);
 	// List of the potentially noreturn functions
 	RzSetU *todo = rz_set_u_new();
-	struct core_noretl u = { core, noretl, todo };
-	HtUP *ht_xrefs_to = rz_analysis_get_xrefs_to(core->analysis);
-	ht_up_foreach(ht_xrefs_to, process_refs_cb, &u);
+	// Only CALL and CODE xrefs are relevant here, so iterate over the
+	// type-indexed xref storage instead of scanning all xrefs.
+	const RzAnalysisXRefType reloc_xref_types[] = { RZ_ANALYSIS_XREF_TYPE_CALL, RZ_ANALYSIS_XREF_TYPE_CODE };
+	for (size_t i = 0; i < RZ_ARRAY_SIZE(reloc_xref_types); i++) {
+		RzIterator *it = rz_analysis_xrefs_get_all_of_type(core->analysis, reloc_xref_types[i]);
+		if (!it) {
+			continue;
+		}
+		RzAnalysisXRef **pxref;
+		rz_iterator_foreach(it, pxref) {
+			process_reference_noreturn(core, noretl, todo, *pxref);
+		}
+		rz_iterator_free(it);
+	}
 	rz_list_free(noretl);
 	rz_asm_set_bits(core->rasm, bits);
 	rz_analysis_set_bits(core->analysis, bits);

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -5730,16 +5730,40 @@ RZ_IPI RzCmdStatus rz_analyze_all_function_calls_to_imports_handler(RzCore *core
 	return RZ_CMD_STATUS_OK;
 }
 
+static int xref_addr_cmp(const void *a, const void *b, void *user) {
+	const RzAnalysisXRef *xref_a = a;
+	const RzAnalysisXRef *xref_b = b;
+	if (xref_a->from != xref_b->from) {
+		return xref_a->from < xref_b->from ? -1 : 1;
+	}
+	if (xref_a->to != xref_b->to) {
+		return xref_a->to < xref_b->to ? -1 : 1;
+	}
+	return 0;
+}
+
 RZ_IPI RzCmdStatus rz_analyze_all_data_references_to_code_handler(RzCore *core, int argc, const char **argv) {
-	RzListIter *iter;
+	// Snapshot the DATA xrefs first, because rz_core_analysis_fcn() below adds
+	// new xrefs and the xref storage must not change while iterating over it.
+	RzVector xrefs;
+	rz_vector_init(&xrefs, sizeof(RzAnalysisXRef), NULL, NULL);
+	RzIterator *it = rz_analysis_xrefs_get_all_of_type(core->analysis, RZ_ANALYSIS_XREF_TYPE_DATA);
+	if (it) {
+		RzAnalysisXRef **pxref;
+		rz_iterator_foreach(it, pxref) {
+			rz_vector_push(&xrefs, *pxref);
+		}
+		rz_iterator_free(it);
+	}
+	// Keep the deterministic processing order rz_analysis_xrefs_get_from() provided.
+	rz_vector_sort(&xrefs, xref_addr_cmp, false, NULL);
 	RzAnalysisXRef *xref;
-	RzList *list = rz_analysis_xrefs_get_from(core->analysis, UT64_MAX);
-	rz_list_foreach (list, iter, xref) {
-		if (xref->type == RZ_ANALYSIS_XREF_TYPE_DATA && rz_io_is_valid_offset(core->io, xref->to, false)) {
+	rz_vector_foreach (&xrefs, xref) {
+		if (rz_io_is_valid_offset(core->io, xref->to, false)) {
 			rz_core_analysis_fcn(core, xref->from, xref->to, RZ_ANALYSIS_XREF_TYPE_NULL, 1);
 		}
 	}
-	rz_list_free(list);
+	rz_vector_fini(&xrefs);
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/core/tui/vmenus_graph.c
+++ b/librz/core/tui/vmenus_graph.c
@@ -69,15 +69,25 @@ static char *print_item(void *_core, void *_item, bool selected) {
 	return rz_str_newf("%c 0x%08" PFMT64x "\n", selected ? '>' : ' ', item->addr);
 }
 
+static int __graph_item_addr_cmp(const void *a, const void *b, void *user) {
+	const RzCoreVisualViewGraphItem *item_a = a;
+	const RzCoreVisualViewGraphItem *item_b = b;
+	if (item_a->addr != item_b->addr) {
+		return item_a->addr < item_b->addr ? -1 : 1;
+	}
+	return 0;
+}
+
 static RzList /*<RzCoreVisualViewGraphItem *>*/ *__xrefs(RzCore *core, ut64 addr) {
 	RzList *r = rz_list_newf(free);
-	RzListIter *iter;
-	RzAnalysisXRef *xref;
-	RzList *xrefs = rz_analysis_xrefs_get_to(core->analysis, addr);
-	rz_list_foreach (xrefs, iter, xref) {
-		if (xref->type != RZ_ANALYSIS_XREF_TYPE_CALL) {
-			continue;
-		}
+	// Only CALL xrefs are displayed, so use the type-indexed xref lookup.
+	RzIterator *it = rz_analysis_xrefs_get_to_type(core->analysis, addr, RZ_ANALYSIS_XREF_TYPE_CALL);
+	if (!it) {
+		return r;
+	}
+	RzAnalysisXRef **pxref;
+	rz_iterator_foreach(it, pxref) {
+		RzAnalysisXRef *xref = *pxref;
 		RzCoreVisualViewGraphItem *item = RZ_NEW0(RzCoreVisualViewGraphItem);
 		RzFlagItem *f = rz_flag_get_at(core->flags, xref->from, 0);
 		item->addr = xref->from;
@@ -89,7 +99,9 @@ static RzList /*<RzCoreVisualViewGraphItem *>*/ *__xrefs(RzCore *core, ut64 addr
 		}
 		rz_list_append(r, item);
 	}
-	rz_list_free(xrefs);
+	rz_iterator_free(it);
+	// Keep the items sorted by address like rz_analysis_xrefs_get_to() did.
+	rz_list_sort(r, __graph_item_addr_cmp, NULL);
 	return r;
 }
 

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1564,6 +1564,18 @@ RZ_API RZ_OWN RzList /*<RzAnalysisXRef *>*/ *rz_analysis_function_get_xrefs_to(c
 RZ_API bool rz_analysis_xrefs_set(RzAnalysis *analysis, ut64 from, ut64 to, RzAnalysisXRefType type);
 RZ_API bool rz_analysis_xrefs_deln(RzAnalysis *analysis, ut64 from, ut64 to, RzAnalysisXRefType type);
 RZ_API bool rz_analysis_xref_del(RzAnalysis *analysis, ut64 from, ut64 to);
+RZ_API RZ_OWN RzIterator *rz_analysis_xrefs_get_to_type(
+	RzAnalysis *analysis, ut64 addr, RzAnalysisXRefType type);
+RZ_API RZ_OWN RzIterator *rz_analysis_xrefs_get_from_type(
+	RzAnalysis *analysis, ut64 addr, RzAnalysisXRefType type);
+RZ_API RZ_OWN RzIterator *rz_analysis_xrefs_get_all_of_type(
+	RzAnalysis *analysis, RzAnalysisXRefType type);
+RZ_API ut64 rz_analysis_xrefs_count_type(
+	RzAnalysis *analysis, RzAnalysisXRefType type);
+RZ_API RZ_OWN RzIterator *rz_analysis_xrefs_get_to_range(
+	RzAnalysis *analysis, ut64 addr_from, ut64 addr_to);
+RZ_API RZ_OWN RzIterator *rz_analysis_xrefs_get_from_range(
+	RzAnalysis *analysis, ut64 addr_from, ut64 addr_to);
 
 /* var.c */
 RZ_API RZ_BORROW RzAnalysisVar *rz_analysis_function_set_var(

--- a/test/db/cmd/cmd_aad
+++ b/test/db/cmd/cmd_aad
@@ -1,0 +1,20 @@
+NAME=aad creates functions from data refs to code
+FILE=bins/elf/analysis/x86-helloworld-gcc
+CMDS=<<EOF
+af @ entry0
+aad
+aflq
+axl~DATA
+EOF
+EXPECT=<<EOF
+0x080482f0 sym.imp.__libc_start_main
+0x08048300 entry0
+0x0804830b fcn.0804830b
+0x08048310 fcn.08048310
+0x08048317 fcn.08048317
+               sym.imp.__libc_start_main 0x80482f0 ->      DATA -> 0x80496a8 reloc.__libc_start_main
+                            fcn.0804830b 0x804830b ->      DATA -> 0x8048490 sym.__libc_csu_fini
+                            fcn.08048310 0x8048310 ->      DATA -> 0x8048420 sym.__libc_csu_init
+                            fcn.08048317 0x8048317 ->      DATA -> 0x8048400 main
+EOF
+RUN

--- a/test/db/cmd/cmd_aad
+++ b/test/db/cmd/cmd_aad
@@ -4,7 +4,7 @@ CMDS=<<EOF
 af @ entry0
 aad
 aflq
-axl~DATA
+axl
 EOF
 EXPECT=<<EOF
 0x080482f0 sym.imp.__libc_start_main
@@ -16,22 +16,6 @@ EXPECT=<<EOF
                             fcn.0804830b 0x804830b ->      DATA -> 0x8048490 sym.__libc_csu_fini
                             fcn.08048310 0x8048310 ->      DATA -> 0x8048420 sym.__libc_csu_init
                             fcn.08048317 0x8048317 ->      DATA -> 0x8048400 main
-EOF
-RUN
-
-NAME=axl xref type counts after aa
-FILE=bins/elf/analysis/x86-helloworld-gcc
-CMDS=<<EOF
-aa
-axl~?
-axl~CALL~?
-axl~DATA~?
-axl~CODE~?
-EOF
-EXPECT=<<EOF
-26
-8
-16
-2
+                          fcn.08048317+5 0x804831c ->      CALL -> 0x80482f0 sym.imp.__libc_start_main
 EOF
 RUN

--- a/test/db/cmd/cmd_aad
+++ b/test/db/cmd/cmd_aad
@@ -18,3 +18,20 @@ EXPECT=<<EOF
                             fcn.08048317 0x8048317 ->      DATA -> 0x8048400 main
 EOF
 RUN
+
+NAME=axl xref type counts after aa
+FILE=bins/elf/analysis/x86-helloworld-gcc
+CMDS=<<EOF
+aa
+axl~?
+axl~CALL~?
+axl~DATA~?
+axl~CODE~?
+EOF
+EXPECT=<<EOF
+26
+8
+16
+2
+EOF
+RUN

--- a/test/db/cmd/cmd_ax
+++ b/test/db/cmd/cmd_ax
@@ -50,6 +50,23 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=axl xref type counts after aa
+FILE=bins/elf/analysis/x86-helloworld-gcc
+CMDS=<<EOF
+aa
+axl~?
+axl~CALL~?
+axl~DATA~?
+axl~CODE~?
+EOF
+EXPECT=<<EOF
+26
+8
+16
+2
+EOF
+RUN
+
 NAME=axtl
 FILE=bins/elf/vim
 CMDS=<<EOF

--- a/test/db/cmd/cmd_ax
+++ b/test/db/cmd/cmd_ax
@@ -50,23 +50,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=axl xref type counts after aa
-FILE=bins/elf/analysis/x86-helloworld-gcc
-CMDS=<<EOF
-aa
-axl~?
-axl~CALL~?
-axl~DATA~?
-axl~CODE~?
-EOF
-EXPECT=<<EOF
-26
-8
-16
-2
-EOF
-RUN
-
 NAME=axtl
 FILE=bins/elf/vim
 CMDS=<<EOF

--- a/test/unit/test_analysis_xrefs.c
+++ b/test/unit/test_analysis_xrefs.c
@@ -298,6 +298,34 @@ static bool test_rz_analysis_xrefs_deln_nonexistent() {
 	mu_end;
 }
 
+static bool test_rz_analysis_xrefs_deln_wrong_type() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	mu_assert_eq(rz_analysis_xrefs_count_type(
+			     analysis, RZ_ANALYSIS_XREF_TYPE_CALL),
+		1, "call count before del");
+
+	// deln ignores <type> for the primary tables, so the xref is removed
+	// and the CALL type index must be cleaned up despite the DATA argument.
+	rz_analysis_xrefs_deln(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_DATA);
+	mu_assert_eq(rz_analysis_xrefs_count(analysis), 0, "count after del");
+	mu_assert_eq(rz_analysis_xrefs_count_type(
+			     analysis, RZ_ANALYSIS_XREF_TYPE_CALL),
+		0, "call count after del");
+
+	// The CALL bucket may still exist but must not yield stale entries.
+	RzIterator *calls = rz_analysis_xrefs_get_all_of_type(
+		analysis, RZ_ANALYSIS_XREF_TYPE_CALL);
+	if (calls) {
+		mu_assert_eq(count_iter(calls), 0, "no stale call xrefs in type index");
+		rz_iterator_free(calls);
+	}
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
 static bool test_rz_analysis_xref_del_mixed_types() {
 	RzAnalysis *analysis = rz_analysis_new(NULL);
 
@@ -396,6 +424,7 @@ int all_tests() {
 	mu_run_test(test_rz_analysis_xrefs_set_no_self_ref);
 	mu_run_test(test_rz_analysis_xrefs_set_update);
 	mu_run_test(test_rz_analysis_xrefs_deln_nonexistent);
+	mu_run_test(test_rz_analysis_xrefs_deln_wrong_type);
 	mu_run_test(test_rz_analysis_xref_del_mixed_types);
 	mu_run_test(test_rz_analysis_xrefs_get_to_range);
 	mu_run_test(test_rz_analysis_xrefs_get_from_range);

--- a/test/unit/test_analysis_xrefs.c
+++ b/test/unit/test_analysis_xrefs.c
@@ -4,7 +4,16 @@
 #include <rz_analysis.h>
 #include "minunit.h"
 
-bool test_rz_analysis_xrefs_count() {
+static int count_iter(RzIterator *iter) {
+	int count = 0;
+	RzAnalysisXRef **xrefp;
+	rz_iterator_foreach(iter, xrefp) {
+		count++;
+	}
+	return count;
+}
+
+static bool test_rz_analysis_xrefs_count() {
 	RzAnalysis *analysis = rz_analysis_new(NULL);
 
 	mu_assert_eq(rz_analysis_xrefs_count(analysis), 0, "xrefs count");
@@ -21,8 +30,375 @@ bool test_rz_analysis_xrefs_count() {
 	mu_end;
 }
 
+static bool test_rz_analysis_xrefs_count_type() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+	mu_assert_eq(rz_analysis_xrefs_count_type(analysis,
+			     RZ_ANALYSIS_XREF_TYPE_CALL),
+		0, "call count empty");
+	mu_assert_eq(rz_analysis_xrefs_count_type(analysis,
+			     RZ_ANALYSIS_XREF_TYPE_CODE),
+		0, "code count empty");
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x100, 0x300, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x100, 0x400, RZ_ANALYSIS_XREF_TYPE_CODE);
+	rz_analysis_xrefs_set(analysis, 0x100, 0x500, RZ_ANALYSIS_XREF_TYPE_DATA);
+	rz_analysis_xrefs_set(analysis, 0x100, 0x600, RZ_ANALYSIS_XREF_TYPE_STRING);
+
+	mu_assert_eq(rz_analysis_xrefs_count(analysis), 5, "total count");
+	mu_assert_eq(rz_analysis_xrefs_count_type(analysis,
+			     RZ_ANALYSIS_XREF_TYPE_CALL),
+		2, "call count");
+	mu_assert_eq(rz_analysis_xrefs_count_type(analysis,
+			     RZ_ANALYSIS_XREF_TYPE_CODE),
+		1, "code count");
+	mu_assert_eq(rz_analysis_xrefs_count_type(analysis,
+			     RZ_ANALYSIS_XREF_TYPE_DATA),
+		1, "data count");
+	mu_assert_eq(rz_analysis_xrefs_count_type(analysis,
+			     RZ_ANALYSIS_XREF_TYPE_STRING),
+		1, "string count");
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
+static bool test_rz_analysis_xrefs_get_all_of_type() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	RzIterator *empty = rz_analysis_xrefs_get_all_of_type(
+		analysis, RZ_ANALYSIS_XREF_TYPE_CALL);
+	mu_assert_null(empty, "no xrefs of type when empty");
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x300, 0x400, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x100, 0x500, RZ_ANALYSIS_XREF_TYPE_CODE);
+
+	RzIterator *calls = rz_analysis_xrefs_get_all_of_type(
+		analysis, RZ_ANALYSIS_XREF_TYPE_CALL);
+	mu_assert_notnull(calls, "call xrefs iter");
+	mu_assert_eq(count_iter(calls), 2, "call xrefs count");
+	rz_iterator_free(calls);
+
+	RzIterator *codes = rz_analysis_xrefs_get_all_of_type(
+		analysis, RZ_ANALYSIS_XREF_TYPE_CODE);
+	mu_assert_notnull(codes, "code xrefs iter");
+	mu_assert_eq(count_iter(codes), 1, "code xrefs count");
+	rz_iterator_free(codes);
+
+	RzIterator *data = rz_analysis_xrefs_get_all_of_type(
+		analysis, RZ_ANALYSIS_XREF_TYPE_DATA);
+	mu_assert_null(data, "no data xrefs");
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
+static bool test_rz_analysis_xrefs_get_to_type() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x300, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x400, 0x200, RZ_ANALYSIS_XREF_TYPE_DATA);
+
+	RzIterator *call_to = rz_analysis_xrefs_get_to_type(
+		analysis, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	mu_assert_notnull(call_to, "call xrefs to addr");
+	mu_assert_eq(count_iter(call_to), 2, "call xrefs to count");
+	rz_iterator_free(call_to);
+
+	RzIterator *data_to = rz_analysis_xrefs_get_to_type(
+		analysis, 0x200, RZ_ANALYSIS_XREF_TYPE_DATA);
+	mu_assert_notnull(data_to, "data xrefs to addr");
+	mu_assert_eq(count_iter(data_to), 1, "data xrefs to count");
+	rz_iterator_free(data_to);
+
+	RzIterator *none = rz_analysis_xrefs_get_to_type(
+		analysis, 0x200, RZ_ANALYSIS_XREF_TYPE_STRING);
+	mu_assert_null(none, "no string xrefs to addr");
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
+static bool test_rz_analysis_xrefs_get_from_type() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x100, 0x300, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x100, 0x400, RZ_ANALYSIS_XREF_TYPE_DATA);
+
+	RzIterator *call_from = rz_analysis_xrefs_get_from_type(
+		analysis, 0x100, RZ_ANALYSIS_XREF_TYPE_CALL);
+	mu_assert_notnull(call_from, "call xrefs from addr");
+	mu_assert_eq(count_iter(call_from), 2, "call xrefs from count");
+	rz_iterator_free(call_from);
+
+	RzIterator *data_from = rz_analysis_xrefs_get_from_type(
+		analysis, 0x100, RZ_ANALYSIS_XREF_TYPE_DATA);
+	mu_assert_notnull(data_from, "data xrefs from addr");
+	mu_assert_eq(count_iter(data_from), 1, "data xrefs from count");
+	rz_iterator_free(data_from);
+
+	RzIterator *none = rz_analysis_xrefs_get_from_type(
+		analysis, 0x100, RZ_ANALYSIS_XREF_TYPE_STRING);
+	mu_assert_null(none, "no string xrefs from addr");
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
+static bool test_rz_analysis_xrefs_deln_updates_type_index() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x100, 0x300, RZ_ANALYSIS_XREF_TYPE_CALL);
+	mu_assert_eq(rz_analysis_xrefs_count_type(
+			     analysis, RZ_ANALYSIS_XREF_TYPE_CALL),
+		2, "before del");
+
+	rz_analysis_xrefs_deln(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	mu_assert_eq(rz_analysis_xrefs_count_type(
+			     analysis, RZ_ANALYSIS_XREF_TYPE_CALL),
+		1, "after del");
+
+	RzIterator *calls = rz_analysis_xrefs_get_all_of_type(
+		analysis, RZ_ANALYSIS_XREF_TYPE_CALL);
+	mu_assert_notnull(calls, "remaining call xrefs");
+	mu_assert_eq(count_iter(calls), 1, "remaining count");
+	rz_iterator_free(calls);
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
+static bool test_rz_analysis_xrefs_init_resets_type_index() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	mu_assert_eq(rz_analysis_xrefs_count(analysis), 1, "before init");
+	mu_assert_eq(rz_analysis_xrefs_count_type(
+			     analysis, RZ_ANALYSIS_XREF_TYPE_CALL),
+		1, "type count before init");
+
+	rz_analysis_xrefs_init(analysis);
+	mu_assert_eq(rz_analysis_xrefs_count(analysis), 0, "after init");
+	mu_assert_eq(rz_analysis_xrefs_count_type(
+			     analysis, RZ_ANALYSIS_XREF_TYPE_CALL),
+		0, "type count after init");
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
+static bool test_rz_analysis_xrefs_get_to() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	RzList *empty = rz_analysis_xrefs_get_to(analysis, 0x100);
+	mu_assert_null(empty, "no xrefs when empty");
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x300, 0x200, RZ_ANALYSIS_XREF_TYPE_DATA);
+
+	RzList *to = rz_analysis_xrefs_get_to(analysis, 0x200);
+	mu_assert_notnull(to, "xrefs to addr");
+	mu_assert_eq(rz_list_length(to), 2, "xrefs to count");
+	rz_list_free(to);
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
+static bool test_rz_analysis_xrefs_get_from() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x100, 0x300, RZ_ANALYSIS_XREF_TYPE_DATA);
+
+	RzList *from = rz_analysis_xrefs_get_from(analysis, 0x100);
+	mu_assert_notnull(from, "xrefs from addr");
+	mu_assert_eq(rz_list_length(from), 2, "xrefs from count");
+	rz_list_free(from);
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
+static bool test_rz_analysis_xrefs_list() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x300, 0x400, RZ_ANALYSIS_XREF_TYPE_DATA);
+	rz_analysis_xrefs_set(analysis, 0x500, 0x600, RZ_ANALYSIS_XREF_TYPE_CODE);
+
+	RzList *all = rz_analysis_xrefs_list(analysis);
+	mu_assert_notnull(all, "all xrefs list");
+	mu_assert_eq(rz_list_length(all), 3, "all xrefs count");
+	rz_list_free(all);
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
+static bool test_rz_analysis_xref_del() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	mu_assert_eq(rz_analysis_xrefs_count(analysis), 1, "before del");
+
+	rz_analysis_xref_del(analysis, 0x100, 0x200);
+	mu_assert_eq(rz_analysis_xrefs_count(analysis), 0, "after del");
+	mu_assert_eq(rz_analysis_xrefs_count_type(
+			     analysis, RZ_ANALYSIS_XREF_TYPE_CALL),
+		0, "type count after del");
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
+static bool test_rz_analysis_xrefs_set_no_self_ref() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	bool res = rz_analysis_xrefs_set(
+		analysis, 0x100, 0x100, RZ_ANALYSIS_XREF_TYPE_CALL);
+	mu_assert_false(res, "self-ref rejected");
+	mu_assert_eq(rz_analysis_xrefs_count(analysis), 0, "no xref added");
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
+static bool test_rz_analysis_xrefs_set_update() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	mu_assert_eq(rz_analysis_xrefs_count(analysis), 1, "count after first set");
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	mu_assert_eq(rz_analysis_xrefs_count(analysis), 1, "count stays 1 after update");
+
+	RzIterator *calls = rz_analysis_xrefs_get_all_of_type(
+		analysis, RZ_ANALYSIS_XREF_TYPE_CALL);
+	mu_assert_notnull(calls, "call xrefs after update");
+	mu_assert_eq(count_iter(calls), 1, "call xrefs after update count");
+	rz_iterator_free(calls);
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
+static bool test_rz_analysis_xrefs_deln_nonexistent() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_deln(analysis, 0x999, 0x888, RZ_ANALYSIS_XREF_TYPE_CALL);
+	mu_assert_eq(rz_analysis_xrefs_count(analysis), 1, "del nonexistent addr");
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
+static bool test_rz_analysis_xref_del_mixed_types() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_DATA);
+	mu_assert_eq(rz_analysis_xrefs_count(analysis), 1, "same pair replaces");
+	mu_assert_eq(rz_analysis_xrefs_count_type(
+			     analysis, RZ_ANALYSIS_XREF_TYPE_CALL),
+		0, "call type cleaned");
+	mu_assert_eq(rz_analysis_xrefs_count_type(
+			     analysis, RZ_ANALYSIS_XREF_TYPE_DATA),
+		1, "data type set");
+
+	RzIterator *data = rz_analysis_xrefs_get_all_of_type(
+		analysis, RZ_ANALYSIS_XREF_TYPE_DATA);
+	mu_assert_notnull(data, "data xrefs after replace");
+	mu_assert_eq(count_iter(data), 1, "data xrefs count");
+	rz_iterator_free(data);
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
+static bool test_rz_analysis_xrefs_get_to_range() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x200, 0x300, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x300, 0x400, RZ_ANALYSIS_XREF_TYPE_DATA);
+	rz_analysis_xrefs_set(analysis, 0x400, 0x100, RZ_ANALYSIS_XREF_TYPE_CALL);
+
+	RzIterator *to_range = rz_analysis_xrefs_get_to_range(
+		analysis, 0x200, 0x400);
+	mu_assert_notnull(to_range, "to range iter");
+	mu_assert_eq(count_iter(to_range), 3, "to range count");
+	rz_iterator_free(to_range);
+
+	RzIterator *single = rz_analysis_xrefs_get_to_range(
+		analysis, 0x200, 0x200);
+	mu_assert_notnull(single, "to range single iter");
+	mu_assert_eq(count_iter(single), 1, "to range single count");
+	rz_iterator_free(single);
+
+	RzIterator *none = rz_analysis_xrefs_get_to_range(
+		analysis, 0x500, 0x600);
+	mu_assert_notnull(none, "to range empty iter");
+	mu_assert_eq(count_iter(none), 0, "to range no match");
+	rz_iterator_free(none);
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
+static bool test_rz_analysis_xrefs_get_from_range() {
+	RzAnalysis *analysis = rz_analysis_new(NULL);
+
+	rz_analysis_xrefs_set(analysis, 0x100, 0x200, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x200, 0x300, RZ_ANALYSIS_XREF_TYPE_CALL);
+	rz_analysis_xrefs_set(analysis, 0x300, 0x400, RZ_ANALYSIS_XREF_TYPE_DATA);
+	rz_analysis_xrefs_set(analysis, 0x400, 0x100, RZ_ANALYSIS_XREF_TYPE_CALL);
+
+	RzIterator *from_range = rz_analysis_xrefs_get_from_range(
+		analysis, 0x100, 0x300);
+	mu_assert_notnull(from_range, "from range iter");
+	mu_assert_eq(count_iter(from_range), 3, "from range count");
+	rz_iterator_free(from_range);
+
+	RzIterator *single = rz_analysis_xrefs_get_from_range(
+		analysis, 0x400, 0x400);
+	mu_assert_notnull(single, "from range single iter");
+	mu_assert_eq(count_iter(single), 1, "from range single count");
+	rz_iterator_free(single);
+
+	RzIterator *none = rz_analysis_xrefs_get_from_range(
+		analysis, 0x500, 0x600);
+	mu_assert_notnull(none, "from range empty iter");
+	mu_assert_eq(count_iter(none), 0, "from range no match");
+	rz_iterator_free(none);
+
+	rz_analysis_free(analysis);
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test(test_rz_analysis_xrefs_count);
+	mu_run_test(test_rz_analysis_xrefs_count_type);
+	mu_run_test(test_rz_analysis_xrefs_get_all_of_type);
+	mu_run_test(test_rz_analysis_xrefs_get_to_type);
+	mu_run_test(test_rz_analysis_xrefs_get_from_type);
+	mu_run_test(test_rz_analysis_xrefs_deln_updates_type_index);
+	mu_run_test(test_rz_analysis_xrefs_init_resets_type_index);
+	mu_run_test(test_rz_analysis_xrefs_get_to);
+	mu_run_test(test_rz_analysis_xrefs_get_from);
+	mu_run_test(test_rz_analysis_xrefs_list);
+	mu_run_test(test_rz_analysis_xref_del);
+	mu_run_test(test_rz_analysis_xrefs_set_no_self_ref);
+	mu_run_test(test_rz_analysis_xrefs_set_update);
+	mu_run_test(test_rz_analysis_xrefs_deln_nonexistent);
+	mu_run_test(test_rz_analysis_xref_del_mixed_types);
+	mu_run_test(test_rz_analysis_xrefs_get_to_range);
+	mu_run_test(test_rz_analysis_xrefs_get_from_range);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

adds per-type hashtables next to the existing ht_xrefs_from/ht_xrefs_to so
type-filtered lookups (e.g. all CALL xrefs) skip the full scan.
also adds range-based query apis for xrefs from/to an address range.

new apis:
- rz_analysis_xrefs_get_all_of_type
- rz_analysis_xrefs_get_to_type
- rz_analysis_xrefs_get_from_type
- rz_analysis_xrefs_count_type
- rz_analysis_xrefs_get_to_range
- rz_analysis_xrefs_get_from_range

all existing apis unchanged. 17 unit tests added.

closes #6438