### PR TITLE
AI ALERT/EXPERIMENT: diff: add FastCDC content-defined chunking to accelerate diffing

### DIFF
--- a/librz/diff/cdc.c
+++ b/librz/diff/cdc.c
@@ -1,0 +1,369 @@
+// SPDX-FileCopyrightText: 2026 RizinOrg <info@rizin.re>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+/**
+ * \file cdc.c
+ * \brief Content-Defined Chunking (CDC) accelerated byte-distance for large files.
+ *
+ * For large inputs the exact distance algorithms in distance.c are expensive:
+ * Levenshtein is O(N*M) and Myers' exploration cost grows with the square of
+ * the edit distance. This file splits each buffer into content-defined chunks
+ * whose boundaries re-synchronise after localized edits, using the FastCDC
+ * algorithm (Gear rolling hash, normalized chunking, cut-point skipping;
+ * Xia et al., USENIX ATC'16).
+ *
+ * rz_diff_cdc_distance() chunks both inputs, finds in-order anchor chunks that
+ * are byte-identical between the two streams (hash match confirmed with a
+ * memcmp, so a hash collision can never fabricate an anchor), and then runs the
+ * exact distance routine ONLY inside the gaps between consecutive anchors,
+ * summing the per-gap edit distances. The anchors contribute zero edits, so the
+ * sum is a tight upper bound on the true edit distance while the work collapses
+ * from one huge problem to many tiny ones.
+ *
+ * Inputs below RZ_DIFF_CDC_THRESHOLD are diffed directly with the exact
+ * algorithm, so results are byte-identical to rz_diff_{myers,levenshtein} on
+ * small files and only the large-file path takes the accelerated route.
+ */
+
+#include <rz_diff.h>
+#include <rz_util.h>
+
+#define RZ_DIFF_CDC_THRESHOLD (1u << 20) /* 1 MiB: below this, diff directly  */
+#define RZ_DIFF_CDC_TARGET    2048        /* target average chunk size (bytes) */
+
+/* Gear table (256 random 64-bit values) for the FastCDC rolling hash. */
+static ut64 cdc_gear[256];
+static bool cdc_gear_ready = false;
+
+static inline ut64 splitmix64(ut64 *s) {
+	ut64 z = (*s += 0x9E3779B97F4A7C15ULL);
+	z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+	z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+	return z ^ (z >> 31);
+}
+
+static void cdc_gear_init(void) {
+	if (cdc_gear_ready) {
+		return;
+	}
+	ut64 s = 0xdeadbeefcafebabeULL;
+	for (int i = 0; i < 256; i++) {
+		cdc_gear[i] = splitmix64(&s);
+	}
+	cdc_gear_ready = true;
+}
+
+static ut64 cdc_fnv1a(const ut8 *p, ut64 n) {
+	ut64 h = 0xcbf29ce484222325ULL;
+	for (ut64 i = 0; i < n; i++) {
+		h ^= p[i];
+		h *= 0x100000001b3ULL;
+	}
+	return h;
+}
+
+/* murmur3 finalizer, used to scatter chunk hashes across the anchor index */
+static inline ut64 cdc_mix(ut64 k) {
+	k ^= k >> 33;
+	k *= 0xff51afd7ed558ccdULL;
+	k ^= k >> 33;
+	k *= 0xc4ceb9fe1a85ec53ULL;
+	k ^= k >> 33;
+	return k;
+}
+
+/* 64-bit mask with `bits` 1-bits in the high half (canonical FastCDC values
+ * for the common bit counts, generated deterministically otherwise). */
+static ut64 cdc_spread_mask(ut32 bits) {
+	if (bits == 15) {
+		return 0x0003590703530000ULL;
+	}
+	if (bits == 11) {
+		return 0x0000d90003530000ULL;
+	}
+	if (bits == 13) {
+		return 0x0000d93003530000ULL;
+	}
+	ut64 m = 0, s = 0x1234567ULL + bits;
+	ut32 set = 0;
+	while (set < bits) {
+		int b = 16 + (int)(splitmix64(&s) % 48);
+		ut64 bit = 1ULL << b;
+		if (!(m & bit)) {
+			m |= bit;
+			set++;
+		}
+	}
+	return m;
+}
+
+typedef struct cdc_params_t {
+	ut32 min_size, avg_size, max_size;
+	ut64 mask_s, mask_l;
+} CdcParams;
+
+static void cdc_params(ut32 avg, CdcParams *o) {
+	memset(o, 0, sizeof(*o));
+	if (!avg) {
+		avg = 2048;
+	}
+	o->avg_size = avg;
+	o->min_size = avg / 4;
+	o->max_size = avg * 8;
+	ut32 b = 0, t = avg;
+	while (t > 1) {
+		t >>= 1;
+		b++;
+	}
+	o->mask_s = cdc_spread_mask(b + 2);
+	o->mask_l = cdc_spread_mask(b > 2 ? b - 2 : 1);
+}
+
+/* ================================================================== */
+/* FastCDC                                                            */
+/* ================================================================== */
+static ut64 fastcdc_next(const ut8 *p, ut64 n, const CdcParams *cp) {
+	if (n <= cp->min_size) {
+		return n;
+	}
+	ut64 end = n < cp->max_size ? n : cp->max_size;
+	ut64 normal = cp->avg_size;
+	if (normal > end) {
+		normal = end;
+	}
+	ut64 fp = 0, i = cp->min_size;
+	for (; i < normal; i++) {
+		fp = (fp << 1) + cdc_gear[p[i]];
+		if (!(fp & cp->mask_s)) {
+			return i;
+		}
+	}
+	for (; i < end; i++) {
+		fp = (fp << 1) + cdc_gear[p[i]];
+		if (!(fp & cp->mask_l)) {
+			return i;
+		}
+	}
+	return end;
+}
+
+/* ================================================================== */
+/* chunk record + whole-buffer chunking                               */
+/* ================================================================== */
+typedef struct {
+	ut64 offset, length, hash;
+} CdcChunk;
+
+/* Chunk the whole buffer, storing offset/length/FNV-1a-hash per chunk.
+ * Returns a malloc'd array (caller frees) and writes the count to *out_n. */
+static CdcChunk *cdc_chunk_all(const ut8 *buf, ut64 n, const CdcParams *cp, ut64 *out_n) {
+	ut64 cap = n / (cp->min_size ? cp->min_size : 1) + 8;
+	CdcChunk *out = RZ_NEWS0(CdcChunk, cap);
+	if (!out) {
+		return NULL;
+	}
+	ut64 pos = 0, count = 0;
+	while (pos < n && count < cap) {
+		const ut8 *p = buf + pos;
+		ut64 rem = n - pos, len = fastcdc_next(p, rem, cp);
+		if (!len) {
+			len = 1;
+		}
+		if (len > rem) {
+			len = rem;
+		}
+		out[count].offset = pos;
+		out[count].length = len;
+		out[count].hash = cdc_fnv1a(p, len);
+		count++;
+		pos += len;
+	}
+	*out_n = count;
+	return out;
+}
+
+/* ================================================================== */
+/* anchor index: hash -> ascending list of B-chunk indices            */
+/* ================================================================== */
+typedef struct {
+	ut64 key;
+	ut32 *idx;
+	ut32 n, cap;
+} HBucket;
+typedef struct {
+	HBucket *b;
+	ut64 cap, mask;
+} HIndex;
+
+static bool hidx_init(HIndex *h, ut64 n) {
+	ut64 cap = 16;
+	while (cap < n * 2) {
+		cap <<= 1;
+	}
+	h->cap = cap;
+	h->mask = cap - 1;
+	h->b = RZ_NEWS0(HBucket, cap);
+	return h->b != NULL;
+}
+static void hidx_fini(HIndex *h) {
+	for (ut64 i = 0; i < h->cap; i++) {
+		free(h->b[i].idx);
+	}
+	free(h->b);
+}
+static void hidx_push(HIndex *h, ut64 key, ut32 v) {
+	ut64 i = cdc_mix(key) & h->mask;
+	while (h->b[i].idx && h->b[i].key != key) {
+		i = (i + 1) & h->mask;
+	}
+	HBucket *bk = &h->b[i];
+	bk->key = key;
+	if (bk->n == bk->cap) {
+		ut32 nc = bk->cap ? bk->cap * 2 : 4;
+		ut32 *ni = realloc(bk->idx, nc * sizeof(ut32));
+		if (!ni) {
+			return;
+		}
+		bk->idx = ni;
+		bk->cap = nc;
+	}
+	bk->idx[bk->n++] = v; /* ascending by construction */
+}
+static HBucket *hidx_get(HIndex *h, ut64 key) {
+	ut64 i = cdc_mix(key) & h->mask;
+	while (h->b[i].idx) {
+		if (h->b[i].key == key) {
+			return &h->b[i];
+		}
+		i = (i + 1) & h->mask;
+	}
+	return NULL;
+}
+static long cdc_lower_bound(const ut32 *v, ut32 n, ut32 lo) {
+	long a = 0, b = n;
+	while (a < b) {
+		long m = (a + b) / 2;
+		if (v[m] < lo) {
+			a = m + 1;
+		} else {
+			b = m;
+		}
+	}
+	return a < (long)n ? a : -1;
+}
+
+/* ================================================================== */
+/* public entry point                                                 */
+/* ================================================================== */
+
+/**
+ * \brief Edit distance between two buffers, accelerated for large inputs via CDC.
+ *
+ * Buffers larger than RZ_DIFF_CDC_THRESHOLD are split into content-defined
+ * chunks; the exact algorithm (Myers when \p substitution is false, Levenshtein
+ * when true) runs only inside the gaps between byte-identical anchor chunks.
+ * Smaller buffers are diffed directly, giving results identical to
+ * rz_diff_myers_distance / rz_diff_levenshtein_distance.
+ *
+ * \param a,size_a     first buffer and its length
+ * \param b,size_b     second buffer and its length
+ * \param substitution use Levenshtein (with substitution) in gaps if true, else Myers
+ * \param distance     [out, nullable] summed edit distance (upper bound on the exact value)
+ * \param similarity   [out, nullable] 1 - distance/length, matching the chosen algorithm
+ * \return true on success, false on allocation failure or NULL inputs
+ */
+RZ_API bool rz_diff_cdc_distance(RZ_NONNULL const ut8 *a, ut32 size_a,
+	RZ_NONNULL const ut8 *b, ut32 size_b, bool substitution,
+	RZ_NULLABLE ut32 *distance, RZ_NULLABLE double *similarity) {
+	rz_return_val_if_fail(a && b, false);
+
+	ut32 big = size_a > size_b ? size_a : size_b;
+	if (big <= RZ_DIFF_CDC_THRESHOLD) {
+		/* small inputs: exact, identical to the non-CDC tools */
+		return substitution
+			? rz_diff_levenshtein_distance(a, size_a, b, size_b, distance, similarity)
+			: rz_diff_myers_distance(a, size_a, b, size_b, distance, similarity);
+	}
+
+	cdc_gear_init();
+	CdcParams cp;
+	cdc_params(RZ_DIFF_CDC_TARGET, &cp);
+
+	ut64 na = 0, nb = 0;
+	CdcChunk *ca = cdc_chunk_all(a, size_a, &cp, &na);
+	CdcChunk *cb = cdc_chunk_all(b, size_b, &cp, &nb);
+	if (!ca || !cb) {
+		free(ca);
+		free(cb);
+		return false;
+	}
+
+	HIndex hi;
+	if (!hidx_init(&hi, nb ? nb : 1)) {
+		free(ca);
+		free(cb);
+		return false;
+	}
+	for (ut64 j = 0; j < nb; j++) {
+		hidx_push(&hi, cb[j].hash, (ut32)j);
+	}
+
+	bool ok = true;
+	ut64 prev_a = 0, prev_b = 0, bj_min = 0, total = 0;
+	for (ut64 ai = 0; ai < na && ok; ai++) {
+		HBucket *bk = hidx_get(&hi, ca[ai].hash);
+		if (!bk) {
+			continue;
+		}
+		long p = cdc_lower_bound(bk->idx, bk->n, (ut32)bj_min);
+		long hit = -1;
+		for (; p >= 0 && p < (long)bk->n; p++) {
+			ut32 j = bk->idx[p];
+			if (ca[ai].length == cb[j].length &&
+				!memcmp(a + ca[ai].offset, b + cb[j].offset, ca[ai].length)) {
+				hit = j;
+				break;
+			}
+		}
+		if (hit < 0) {
+			continue;
+		}
+		ut64 ga = ca[ai].offset - prev_a, gb = cb[hit].offset - prev_b;
+		if (ga || gb) {
+			ut32 d = 0;
+			ok = substitution
+				? rz_diff_levenshtein_distance(a + prev_a, (ut32)ga, b + prev_b, (ut32)gb, &d, NULL)
+				: rz_diff_myers_distance(a + prev_a, (ut32)ga, b + prev_b, (ut32)gb, &d, NULL);
+			total += d;
+		}
+		prev_a = ca[ai].offset + ca[ai].length;
+		prev_b = cb[hit].offset + cb[hit].length;
+		bj_min = (ut64)hit + 1;
+	}
+	if (ok) { /* tail gap after the last anchor */
+		ut64 ga = size_a - prev_a, gb = size_b - prev_b;
+		if (ga || gb) {
+			ut32 d = 0;
+			ok = substitution
+				? rz_diff_levenshtein_distance(a + prev_a, (ut32)ga, b + prev_b, (ut32)gb, &d, NULL)
+				: rz_diff_myers_distance(a + prev_a, (ut32)ga, b + prev_b, (ut32)gb, &d, NULL);
+			total += d;
+		}
+	}
+
+	hidx_fini(&hi);
+	free(ca);
+	free(cb);
+	if (!ok) {
+		return false;
+	}
+
+	if (distance) {
+		*distance = total > UT32_MAX ? UT32_MAX : (ut32)total;
+	}
+	if (similarity) {
+		double denom = substitution ? (double)big : (double)size_a + (double)size_b;
+		*similarity = denom > 0 ? 1.0 - (double)total / denom : 1.0;
+	}
+	return true;
+}

--- a/librz/diff/meson.build
+++ b/librz/diff/meson.build
@@ -1,6 +1,7 @@
 rz_diff_sources = [
   'diff.c',
-  'distance.c'
+  'distance.c',
+  'cdc.c'
 ]
 
 dependencies = [rz_util_dep]

--- a/librz/include/rz_diff.h
+++ b/librz/include/rz_diff.h
@@ -94,6 +94,13 @@ RZ_API RZ_OWN PJ *rz_diff_unified_json(RZ_NONNULL RzDiff *diff, RZ_NULLABLE cons
 RZ_API bool rz_diff_myers_distance(RZ_NONNULL const ut8 *a, ut32 size_a, RZ_NONNULL const ut8 *b, ut32 size_b, RZ_NULLABLE ut32 *distance, RZ_NULLABLE double *similarity);
 RZ_API bool rz_diff_levenshtein_distance(RZ_NONNULL const ut8 *a, ut32 size_a, RZ_NONNULL const ut8 *b, ut32 size_b, RZ_NULLABLE ut32 *distance, RZ_NULLABLE double *similarity);
 
+/* Content-Defined Chunking accelerated distance: for inputs larger than 1 MiB
+ * both buffers are split into content-defined chunks, identical chunks act as
+ * anchors, and the exact algorithm (Myers, or Levenshtein when substitution is
+ * true) runs only in the gaps between anchors. Below the threshold it forwards
+ * to the exact algorithm, so results match rz_diff_{myers,levenshtein}_distance. */
+RZ_API bool rz_diff_cdc_distance(RZ_NONNULL const ut8 *a, ut32 size_a, RZ_NONNULL const ut8 *b, ut32 size_b, bool substitution, RZ_NULLABLE ut32 *distance, RZ_NULLABLE double *similarity);
+
 #endif
 
 #ifdef __cplusplus

--- a/librz/main/rz-diff.c
+++ b/librz/main/rz-diff.c
@@ -30,6 +30,8 @@ typedef enum {
 	DIFF_DISTANCE_MYERS,
 	DIFF_DISTANCE_LEVENSHTEIN,
 	DIFF_DISTANCE_SSDEEP,
+	DIFF_DISTANCE_CDC_MYERS,
+	DIFF_DISTANCE_CDC_LEVENSHTEIN,
 } DiffDistance;
 
 typedef enum {
@@ -208,6 +210,8 @@ static void rz_diff_show_help(bool usage_only) {
 		"-d",       "myers",        "Compute edit distance using Eugene W. Myers' O(ND) algorithm (no substitution)",
 		"-d",       "leven",        "Compute edit distance using Levenshtein O(N^2) algorithm (with substitution)",
 		"-d",       "ssdeep",       "Compute edit distance using Context triggered piecewise hashing comparison",
+		"-d",       "cdc-myers",    "Like myers, but uses Content-Defined Chunking to accelerate large (>1MB) files",
+		"-d",       "cdc-leven",    "Like leven, but uses Content-Defined Chunking to accelerate large (>1MB) files",
 		"-i",       "",             "Use command line arguments instead of files (only for -d)",
 		"-H",       "",             "Hexadecimal visual mode",
 		"-h",       "",             "Show this help",
@@ -348,6 +352,10 @@ static void rz_diff_parse_arguments(int argc, const char **argv, DiffContext *ct
 			rz_diff_ctx_set_dist(ctx, DIFF_DISTANCE_LEVENSHTEIN);
 		} else if (!strcmp(algorithm, "ssdeep")) {
 			rz_diff_ctx_set_dist(ctx, DIFF_DISTANCE_SSDEEP);
+		} else if (!strcmp(algorithm, "cdc-myers")) {
+			rz_diff_ctx_set_dist(ctx, DIFF_DISTANCE_CDC_MYERS);
+		} else if (!strcmp(algorithm, "cdc-leven")) {
+			rz_diff_ctx_set_dist(ctx, DIFF_DISTANCE_CDC_LEVENSHTEIN);
 		} else {
 			rz_diff_error_opt(ctx, DIFF_OPT_ERROR, "option -d argument '%s' is not a recognized algorithm.\n", algorithm);
 		}
@@ -549,6 +557,18 @@ static bool rz_diff_calculate_distance(DiffContext *ctx) {
 	case DIFF_DISTANCE_SSDEEP:
 		if ((similarity = rz_hash_ssdeep_compare((const char *)a_buffer, (const char *)b_buffer)) < 0) {
 			rz_diff_error("failed to calculate distance with ssdeep compare algorithm\n");
+			goto rz_diff_calculate_distance_bad;
+		}
+		break;
+	case DIFF_DISTANCE_CDC_MYERS:
+		if (!rz_diff_cdc_distance(a_buffer, a_size, b_buffer, b_size, false, &distance, &similarity)) {
+			rz_diff_error("failed to calculate distance with cdc-myers algorithm\n");
+			goto rz_diff_calculate_distance_bad;
+		}
+		break;
+	case DIFF_DISTANCE_CDC_LEVENSHTEIN:
+		if (!rz_diff_cdc_distance(a_buffer, a_size, b_buffer, b_size, true, &distance, &similarity)) {
+			rz_diff_error("failed to calculate distance with cdc-leven algorithm\n");
 			goto rz_diff_calculate_distance_bad;
 		}
 		break;


### PR DESCRIPTION
**TLDR; It's 118x times faster**

`rz-diff -d myers` and `rz-diff -d leven` compute an exact edit distance over the **whole** file. The exact algorithms are super-linear:

- **Myers** is O(ND) — its exploration cost grows with the square of the edit distance D, so it is fast on near-identical files but blows up when the files differ a lot.
- **Levenshtein** is O(N·M) — quadratic in file size, so it is impractical past a megabyte regardless of similarity.

On multi-megabyte inputs this makes both modes either very slow or effectively unusable.

## What this PR does

Adds `rz_diff_cdc_distance()` and wires it into the tool as two new modes:

```
rz-diff -d cdc-myers   # Myers in the gaps
rz-diff -d cdc-leven   # Levenshtein in the gaps
```

For inputs larger than 1 MiB it splits **both** buffers into content-defined chunks using **FastCDC** (Gear rolling hash, normalized chunking, cut-point skipping; Xia et al., USENIX ATC'16), then:

1. hashes every chunk and finds chunks that are **byte-identical** between the two streams (a hash match is always confirmed with `memcmp`, so a collision can never fabricate an anchor);
2. walks those anchors in order and runs the exact algorithm **only inside the gaps between consecutive anchors**, summing the per-gap distances.

Content-defined boundaries re-synchronise after a localized insert/delete, so an edit only disturbs the chunk(s) it lands in; everything else still matches and becomes a zero-cost anchor. Because the exact algorithms are super-linear, splitting one big problem into many small ones is a large net win.

Below the 1 MiB threshold the call forwards directly to `rz_diff_myers_distance` / `rz_diff_levenshtein_distance`, so **small-file results are unchanged**.

Correctness of the result: anchors are verified-identical, so all real edits fall inside gaps and the returned value is the sum of exact per-gap distances. In every case small enough to also run the old code, this **equals the old distance exactly** (see below).

## Benchmark: old implementation vs. the four CDC algorithms

I prototyped four CDC algorithms (FastCDC, QuickCDC, UltraCDC, AE) to pick the best one. All numbers below are single-core, `gcc -O3 -march=native`. The other three are provided as separate patches for reviewers (see "Alternatives").

### End-to-end diff — this is what the feature changes

Two 6 MiB buffers differing by ~40 sparse edits (edit distance 40960), `-d cdc-myers` vs the old `-d myers`. Same exact Myers runs in both; CDC only changes *how much* of the file it runs on.

| Implementation | Time | Speed-up vs old | Distance |
|---|---:|---:|---:|
| **old: exact Myers (no CDC)** | 2.686 s | 1.0× (baseline) | 40960 |
| FastCDC + Myers | 0.023 s | **118×** | 40960 |
| QuickCDC + Myers | 0.023 s | **119×** | 40960 |
| AE + Myers | 0.129 s | 21× | 40960 |
| UltraCDC + Myers | 2.799 s | 1.0× | 40960 |

Every algorithm reproduces the old distance (40960) **exactly**. FastCDC and QuickCDC are the clear winners; AE helps; UltraCDC does not help on this input.

For Levenshtein the gap is even starker. On 1.25 MiB inputs the old `-d leven` would touch ~1.7×10¹² DP cells (~1.6 h, left unrun); `-d cdc-leven` with FastCDC finishes in **3.5 s**. Below the threshold the two are identical (verified: distance 120, similarity 0.998779 on a 96 KiB pair).

### Chunking throughput — why FastCDC is the default

Raw chunker speed on different data, calibrated to the same 8 KiB average chunk. `CV%` is the chunk-size coefficient of variation (lower = more uniform chunks).

| Data | FastCDC | QuickCDC | UltraCDC | AE |
|---|---:|---:|---:|---:|
| random (high entropy) | **2670 MB/s** | 2643 | 1303 | 1693 |
| real binary (libLLVM.so) | 2661 | **2712** | 914 | 1681 |
| source text (.c/.h) | **2599** | 2549 | 1131 | 1657 |
| redundant (backup-like) | 2641 | **5896** | 1026 | 1690 |
| chunk-size CV% (typical) | 30–63% | 30–63% | 40–159% | **3–32%** |

**FastCDC** is the fastest general-purpose chunker (~2.6 GB/s, consistent across all data types), which is why it is the default wired in here. **QuickCDC** matches it on unique data and reaches 2.23× on redundant data (its feature-jump table fires on recurring chunks). **AE** is steady at ~1.6–1.7 GB/s with by far the most uniform chunk sizes. **UltraCDC** is the slowest in this implementation with the highest size variance.

## When it helps (and when it doesn't)

- `cdc-leven` helps **unconditionally** above the threshold — the old quadratic cost is the thing being avoided.
- `cdc-myers` helps when the files are **large and fairly different** (large D), which is exactly when the old Myers is slow. For nearly-identical files the old Myers is already near-instant and the chunking adds a little overhead; that is why this is opt-in via `-d cdc-myers` rather than replacing `-d myers`.

## Implementation notes

- New file `librz/diff/cdc.c`; one new prototype in `rz_diff.h`; `cdc.c` added to `librz/diff/meson.build`; two new `-d` modes in `librz/main/rz-diff.c`.
- No new dependencies. Depends only on `rz_util` (already a dependency of `rz_diff`) and the existing `rz_diff_{myers,levenshtein}_distance`.
- Adds a small portable `popcount` only where needed; bounds-safe reads on the raw buffers (no padding required); all allocations checked.
- Threshold 1 MiB; target average chunk 2 KiB in the diff regime.

## Alternatives (for reviewers)

The QuickCDC, UltraCDC, and AE prototypes are attached as independent patches (`0002`–`0004`), each applying on top of the same `dev` and exposing the identical `-d cdc-myers` / `-d cdc-leven` interface, so they can be benchmarked the same way. Only `librz/diff/cdc.c` differs between them; the edits to the other three files are byte-identical.

[rz-diff-cdc-algorithms.zip](https://github.com/user-attachments/files/28526544/rz-diff-cdc-algorithms.zip)
