### PR TITLE
Fix egg context ownership as rz_egg_emit_t is static

### DIFF
--- a/librz/egg/egg.c
+++ b/librz/egg/egg.c
@@ -42,6 +42,18 @@ RZ_API const char *rz_egg_os_as_string(int os) {
 	}
 }
 
+static void egg_emit_init(RzEgg *egg) {
+	if (egg->remit && egg->remit->init) {
+		egg->remit->init(egg, &egg->emit_context);
+	}
+}
+
+static void egg_emit_fini(RzEgg *egg) {
+	if (egg->remit && egg->remit->fini) {
+		egg->remit->fini(egg, egg->emit_context);
+	}
+}
+
 RZ_API RzEgg *rz_egg_new(void) {
 	int i;
 	RzEgg *egg = RZ_NEW0(RzEgg);
@@ -61,9 +73,7 @@ RZ_API RzEgg *rz_egg_new(void) {
 		goto beach;
 	}
 	egg->remit = &emit_x86;
-	if (egg->remit->init) {
-		egg->remit->init(egg);
-	}
+	egg_emit_init(egg);
 	egg->syscall = rz_syscall_new();
 	if (!egg->syscall) {
 		goto beach;
@@ -116,9 +126,7 @@ RZ_API void rz_egg_free(RzEgg *egg) {
 		return;
 	}
 
-	if (egg->remit && egg->remit->fini) {
-		egg->remit->fini(egg->remit);
-	}
+	egg_emit_fini(egg);
 
 	rz_path_free(egg->sys_path);
 	rz_buf_free(egg->src);
@@ -146,9 +154,7 @@ RZ_API void rz_egg_reset(RzEgg *egg) {
 
 RZ_API bool rz_egg_setup(RzEgg *egg, const char *arch, int bits, int endian, const char *os) {
 	const char *asmcpu = NULL; // TODO
-	if (egg->remit && egg->remit->fini) {
-		egg->remit->fini(egg->remit);
-	}
+	egg_emit_fini(egg);
 	egg->remit = NULL;
 
 	egg->os = os ? rz_str_djb2_hash(os) : RZ_EGG_OS_DEFAULT;
@@ -197,9 +203,8 @@ RZ_API bool rz_egg_setup(RzEgg *egg, const char *arch, int bits, int endian, con
 	} else {
 		return false;
 	}
-	if (egg->remit && egg->remit->init) {
-		egg->remit->init(egg);
-	}
+
+	egg_emit_init(egg);
 	return true;
 }
 

--- a/librz/egg/emit/arm.c
+++ b/librz/egg/emit/arm.c
@@ -27,15 +27,15 @@ static void emit_begin(RzEgg *egg) {
 	/* TODO */
 }
 
-static void emit_init(RzEgg *egg) {
-	egg->remit->emit_context = RZ_NEW0(EmitArmArg);
+static void emit_init(RzEgg *egg, void **context) {
+	*context = RZ_NEW0(EmitArmArg);
 }
 
-static void emit_fini(RzEggEmit *egg_emit) {
-	if (!egg_emit) {
+static void emit_fini(RzEgg *egg, void *context) {
+	if (!context) {
 		return;
 	}
-	EmitArmArg *emit_arm_data = egg_emit->emit_context;
+	EmitArmArg *emit_arm_data = context;
 	free(emit_arm_data);
 }
 
@@ -92,9 +92,8 @@ static void emit_equ(RzEgg *egg, const char *key, const char *value) {
 }
 
 static void emit_syscall_args(RzEgg *egg, int nargs) {
-	int j, k;
-	for (j = 0; j < nargs; j++) {
-		k = j * RZ_SZ;
+	for (int j = 0; j < nargs; j++) {
+		int k = j * RZ_SZ;
 		rz_egg_printf(egg, "  ldr %s, [sp, %d]\n",
 			regs[j + 1], k ? k + 4 : k + 8);
 	}
@@ -136,10 +135,9 @@ static void emit_jmp(RzEgg *egg, const char *str, int atr) {
 }
 
 static void emit_call(RzEgg *egg, const char *str, int atr) {
-	int i;
-	EmitArmArg *emit_arm_data = egg->remit->emit_context;
-	// rz_egg_printf (egg, " ARGS=%d CALL(%s,%d)\n", lastarg, str, atr);
-	for (i = 0; i < emit_arm_data->lastarg; i++) {
+	EmitArmArg *emit_arm_data = egg->emit_context;
+
+	for (int i = 0; i < emit_arm_data->lastarg; i++) {
 		rz_egg_printf(egg, "  ldr r%d, [%s]\n", emit_arm_data->lastarg - 1 - i, emit_arm_data->lastargs[i]);
 		emit_arm_data->lastargs[i][0] = 0;
 	}
@@ -153,7 +151,7 @@ static void emit_call(RzEgg *egg, const char *str, int atr) {
 }
 
 static void emit_arg(RzEgg *egg, int xs, int num, const char *str) {
-	EmitArmArg *emit_arm_data = egg->remit->emit_context;
+	EmitArmArg *emit_arm_data = egg->emit_context;
 	int d = atoi(str);
 	if (!attsyntax && (*str == '$')) {
 		str++;

--- a/librz/include/rz_egg.h
+++ b/librz/include/rz_egg.h
@@ -103,6 +103,7 @@ typedef struct rz_egg_t {
 	RzList /*<struct egg_patch_t *>*/ *patches; // <RzBuffer>
 	RzPath *sys_path; ///< pointer to RzPath, contains path prefix of the system
 	struct rz_egg_emit_t *remit;
+	void *emit_context; ///< May holds the context data of the current emit type
 	int arch;
 	int endian;
 	int bits;
@@ -142,9 +143,9 @@ struct rz_egg_emit_t {
 	const char *retvar;
 	// const char *syscall_body;
 	const char *(*regs)(RzEgg *egg, int idx);
-	void (*init)(RzEgg *egg);
+	void (*init)(RzEgg *egg, void **context);
 	void (*begin)(RzEgg *egg);
-	void (*fini)(RzEggEmit *egg_emit);
+	void (*fini)(RzEgg *egg, void *context);
 	void (*call)(RzEgg *egg, const char *addr, int ptr);
 	void (*jmp)(RzEgg *egg, const char *addr, int ptr);
 	// void (*sc)(int num);
@@ -167,7 +168,6 @@ struct rz_egg_emit_t {
 	void (*branch)(RzEgg *egg, char *b, char *g, char *e, char *n, int sz, const char *dst);
 	void (*mathop)(RzEgg *egg, int ch, int sz, int type, const char *eq, const char *p);
 	void (*get_while_end)(RzEgg *egg, char *out, const char *ctxpush, const char *label);
-	void *emit_context; ///< May holds the context data of each emit type
 };
 
 /**


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

`rz_egg_emit_t` is static, so if we create 2 cores the `emit_context` field gets overwritten because is also static.

this moves the ownership to `RzEgg`