### PR TITLE
librz/bin/dyldcache, librz/debug/dmp: fix memory leaks

### DIFF
--- a/librz/bin/p/bin_dyldcache.c
+++ b/librz/bin/p/bin_dyldcache.c
@@ -378,7 +378,7 @@ static RzPVector /*<RzBinClass *>*/ *dyldcache_classes(RzBinFile *bf) {
 		return NULL;
 	}
 
-	RzPVector *ret = rz_pvector_new(free);
+	RzPVector *ret = rz_pvector_new((RzPVectorFree)rz_bin_class_free);
 	if (!ret) {
 		return NULL;
 	}
@@ -451,8 +451,8 @@ static RzPVector /*<RzBinClass *>*/ *dyldcache_classes(RzBinFile *bf) {
 
 				RzBinClass *klass;
 				if (!(klass = RZ_NEW0(RzBinClass)) ||
-					!(klass->methods = rz_list_new()) ||
-					!(klass->fields = rz_list_new())) {
+					!(klass->methods = rz_list_newf((RzListFree)rz_bin_symbol_free)) ||
+					!(klass->fields = rz_list_newf((RzListFree)rz_bin_class_field_free))) {
 					RZ_FREE(klass);
 					RZ_FREE(pointers);
 					RZ_FREE(sections);

--- a/librz/debug/p/debug_dmp.c
+++ b/librz/debug/p/debug_dmp.c
@@ -116,6 +116,7 @@ static bool rz_debug_dmp_init(RzDebug *dbg, void **user) {
 	// Find ntoskrnl.exe module
 	RzListIter *it;
 	WindModule mod = { 0 };
+	RzList *modules = NULL;
 	if (ctx->type == DMP_DUMPTYPE_TRIAGE) {
 		struct rz_bin_dmp64_obj_t *obj = core->bin->cur->o->bin_obj;
 		dmp_driver_desc *driver;
@@ -131,7 +132,7 @@ static bool rz_debug_dmp_init(RzDebug *dbg, void **user) {
 	} else {
 		WindProc kernel = { .dir_base_table = ctx->kernelDirectoryTable, .uniqueid = 4 };
 		ctx->windctx.target = kernel;
-		RzList *modules = winkd_list_modules(&ctx->windctx);
+		modules = winkd_list_modules(&ctx->windctx);
 		WindModule *m;
 		rz_list_foreach (modules, it, m) {
 			if (rz_str_endswith(m->name, "\\ntoskrnl.exe")) {
@@ -164,6 +165,7 @@ static bool rz_debug_dmp_init(RzDebug *dbg, void **user) {
 			RZ_LOG_WARN("Failed to download ntoskrnl.pdb, many things won't work.\n");
 		}
 	}
+	rz_list_free(modules);
 
 	if (!ctx->windctx.profile) {
 		RZ_LOG_ERROR("Could not find a profile for this Windows: %s %" PFMT32d "-bit %" PFMT32u " SP %" PFMT32u "\n",


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Fixes leaks detected by "New Leaks" in https://github.com/rizinorg/rizin/pull/6465:

bin/dyldcache: dyldcache_classes() built the classes vector with rz_pvector_new(free) and the per-class methods/fields lists with rz_list_new() (no element destructor). Each RzBinClass was therefore plain free()'d without releasing its name, methods and fields, leaking memory.

debug/dmp (winkd): rz_debug_dmp_init() obtained the module list from winkd_list_modules() in the non-triage branch, scanned it for ntoskrnl.exe and then never freed it, leaking the list and all of its WindModule entries.

**Test plan**

CI is green