### PR TITLE
Fix PDB virtual functions recognition in analysis

### DIFF
--- a/librz/arch/fcn.c
+++ b/librz/arch/fcn.c
@@ -563,6 +563,12 @@ static inline bool jumps_to_prelude(RzAnalysis *analysis, ut64 jmp_addr) {
 static inline bool jump_leaves_mapped_mem(RzAnalysis *analysis, ut64 insn_addr, ut64 jump_target) {
 	rz_return_val_if_fail(analysis, false);
 	RzIOMap *map = analysis->iob.map_get(analysis->iob.io, insn_addr);
+	if (!map) {
+		// The instruction itself is not part of any mapped region (e.g. analysis
+		// walked into a hole of a sparse address space such as a crash dump).
+		// Treat the jump as leaving mapped memory so we stop following it.
+		return true;
+	}
 	return (jump_target < map->itv.addr || jump_target >= map->itv.addr + map->itv.size);
 }
 

--- a/librz/core/cpdb.c
+++ b/librz/core/cpdb.c
@@ -214,7 +214,7 @@ static void rz_core_bin_pdb_gvars_print(RzPdb *pdb, const ut64 baddr, RzCmdState
 }
 
 typedef struct {
-	const RzCore *core;
+	RzCore *core;
 	const ut64 baddr;
 	const char *file;
 } PDBLoadContext;
@@ -287,8 +287,53 @@ static bool symbol_load(RzPdb *pdb, const PDBSymbol *symbol, void *u) {
 	return true;
 }
 
+/**
+ * \brief Second-pass callback that turns PDB public function symbols into
+ * analyzed functions.
+ *
+ * The PDB explicitly marks public symbols that are functions (cvpsfFunction).
+ * Some of these (e.g. virtual methods only reached through a vtable) are never
+ * discovered by call-following code analysis, so without this they would be
+ * present only as a flag and never show up as a function. This mirrors how
+ * \ref rz_core_analysis_all turns FUNC bin symbols into functions: it triggers
+ * analysis at the address and lets the already-set PDB flag name the function.
+ *
+ * This must run after all symbol flags have been set (see \ref pdb_symbols_load)
+ * so that functions reached by direct calls from here are also named correctly.
+ */
+static bool symbol_make_function(RzPdb *pdb, const PDBSymbol *symbol, void *u) {
+	if (!symbol || symbol->kind != PDB_Public) {
+		return true;
+	}
+	const PDBSPublic *public = symbol->data;
+	if (!public || !public->function || RZ_STR_ISEMPTY(public->name)) {
+		return true;
+	}
+	PDBLoadContext *ctx = u;
+	RzCore *core = ctx->core;
+	ut64 addr = rz_bin_pdb_to_rva(pdb, &public->offset);
+	if (addr == UT64_MAX) {
+		return true;
+	}
+	if (ctx->baddr != UT64_MAX) {
+		addr += ctx->baddr;
+	}
+	// Only create functions where executable code is actually mapped. This also
+	// keeps the symbol info (flags, types, globals) usable when no backing
+	// binary is loaded, since in that case no function will be created.
+	if (!rz_io_is_valid_offset(core->io, addr, RZ_PERM_X)) {
+		return true;
+	}
+	if (rz_analysis_get_function_at(core->analysis, addr)) {
+		return true;
+	}
+	int depth = rz_config_get_i(core->config, "analysis.depth");
+	rz_core_analysis_fcn(core, addr, UT64_MAX, RZ_ANALYSIS_XREF_TYPE_NULL, depth);
+	return true;
+}
+
 static void pdb_symbols_load(
-	const RzCore *core, RzPdb *pdb, const char *pdbfile) {
+	RzCore *core, RzPdb *pdb, const char *pdbfile) {
 	rz_return_if_fail(core && pdb);
 	if (!(pdb->s_pe && pdb->s_gdata)) {
 		return;
@@ -309,6 +354,12 @@ static void pdb_symbols_load(
 	rz_pdb_all_symbols_foreach(pdb, symbol_load, &ctx);
 
 	rz_flag_space_pop(core->flags);
+
+	// Create functions for public function symbols in a separate pass, after
+	// every symbol flag has been set, so each function (and any function it
+	// directly calls) is named from its PDB flag.
+	rz_pdb_all_symbols_foreach(pdb, symbol_make_function, &ctx);
+
 	free(file);
 }
 

--- a/test/db/cmd/cmd_idp
+++ b/test/db/cmd/cmd_idp
@@ -7,8 +7,20 @@ fi 1 @ 0x00401010
 EOF
 EXPECT=<<EOF
 0x00401000 4096 section..text
-0x00401000 0 pdb.SimplePDB.void___cdecl_SomeCoolFunction_void
-0x00401010 0 pdb.SimplePDB._main
+0x00401000 13 pdb.SimplePDB.void___cdecl_SomeCoolFunction_void
+0x00401010 8 pdb.SimplePDB._main
+EOF
+RUN
+
+NAME=idp creates functions for public function symbols
+FILE=bins/pdb/vs2019_cpp_override.exe
+CMDS=<<EOF
+idp bins/pdb/vs2019_cpp_override.pdb
+aflq~Foo,Bar
+EOF
+EXPECT=<<EOF
+0x00401000 pdb.vs2019_cpp_override.public_virtual:_int___thiscall_CTest1::Foo_void_const
+0x00401040 pdb.vs2019_cpp_override.public_virtual:_int___thiscall_CTest2::Bar_void_const
 EOF
 RUN
 

--- a/test/db/formats/dmp/dmp
+++ b/test/db/formats/dmp/dmp
@@ -175,42 +175,42 @@ mov qword [rsp+0x08], rcx
 mov qword [rsp+0x10], rdx
 mov qword [rsp+0x18], r8
 mov qword [rsp+0x20], r9
-0  0xfffff8047bdf5a80 sp: 0xffff850429890ee8  0    [??]  pdb.ntkrnlmp.KeBugCheckEx
+0  0xfffff8047bdf5a80 sp: 0xffff850429890ee8  0    [pdb.ntkrnlmp.KeBugCheckEx]  pdb.ntkrnlmp.KeBugCheckEx
 1  0xfffff8047be0f4e1 sp: 0xffff850429890ef0  56   [??]  pdb.ntkrnlmp.string_::3655334267::_Kernel_MUI_Lang_::1575215452+5649
-2  0xfffff8047bdcc052 sp: 0xffff850429890f30  104  [??]  pdb.ntkrnlmp.__C_specific_handler+162
-3  0xfffff8047bdfe942 sp: 0xffff850429890fa0  40   [??]  pdb.ntkrnlmp.RtlpExecuteHandlerForException+18
+2  0xfffff8047bdcc052 sp: 0xffff850429890f30  104  [pdb.ntkrnlmp.__C_specific_handler]  pdb.ntkrnlmp.__C_specific_handler+162
+3  0xfffff8047bdfe942 sp: 0xffff850429890fa0  40   [pdb.ntkrnlmp.RtlpExecuteHandlerForException]  pdb.ntkrnlmp.RtlpExecuteHandlerForException+18
 4  0xfffff8047bd2bf97 sp: 0xffff850429890fd0  1816 [??]  pdb.ntkrnlmp.RtlDispatchException+663
-5  0xfffff8047bd2ab86 sp: 0xffff8504298916f0  1720 [??]  pdb.ntkrnlmp.KiDispatchException+390
-6  0xfffff8047be07bac sp: 0xffff850429891db0  472  [??]  pdb.ntkrnlmp.KiExceptionDispatch+300
-7  0xfffff8047be031f5 sp: 0xffff850429891f90  400  [??]  pdb.ntkrnlmp.KiSegmentNotPresentFault+821
-8  0xfffff8048b58334c sp: 0xffff850429892120  40   [??]  pdb.amdppm.WriteIoMemRawEx+112
-9  0xfffff8048b58313f sp: 0xffff850429892150  40   [??]  pdb.amdppm.WriteGenAddrEx+107
-10  0xfffff8048b583234 sp: 0xffff850429892180  40   [??]  pdb.amdppm.WriteGenAddrMaybeHiddenEx+24
-11  0xfffff8048b5a0e8f sp: 0xffff8504298921b0  88   [??]  pdb.amdppm.InitAcpiCpc+791
-12  0xfffff8048b5a83f6 sp: 0xffff850429892210  296  [??]  pdb.amdppm.ProcLibDeviceStart+2182
-13  0xfffff8048b59f852 sp: 0xffff850429892340  56   [??]  pdb.amdppm.EvtDevicePrepareHardware+210
-14  0xfffff804799cc027 sp: 0xffff850429892380  72   [??]  pdb.Wdf01000.protected_virtual:_long_int___cdecl_FxPnpDevicePrepareHardware::InvokeClient_void____ptr64+39
-15  0xfffff80479966f81 sp: 0xffff8504298923d0  56   [??]  pdb.Wdf01000.public:_long_int___cdecl_FxPrePostCallback::InvokeStateful_enum_FxCxCallbackProgress_____ptr64__enum_FxCxCallbackCleanupAction____ptr64+105
-16  0xfffff804799cb227 sp: 0xffff850429892410  72   [??]  pdb.Wdf01000.protected:_long_int___cdecl_FxPkgPnp::PnpPrepareHardware_unsigned_char_____ptr64__enum_FxCxCallbackProgress_____ptr64____ptr64+223
-17  0xfffff804799c9e21 sp: 0xffff850429892460  56   [??]  pdb.Wdf01000.protected:_static_enum__WDF_DEVICE_PNP_STATE___cdecl_FxPkgPnp::PnpEventHardwareAvailable_class_FxPkgPnp_____ptr64+81
-18  0xfffff804799c99da sp: 0xffff8504298924a0  136  [??]  pdb.Wdf01000.protected:_void___cdecl_FxPkgPnp::PnpEnterNewState_enum__WDF_DEVICE_PNP_STATE____ptr64+350
-19  0xfffff804799cb6b1 sp: 0xffff850429892530  104  [??]  pdb.Wdf01000.protected:_void___cdecl_FxPkgPnp::PnpProcessEventInner_struct_FxPostProcessInfo_____ptr64____ptr64+465
-20  0xfffff804799cb47a sp: 0xffff8504298925a0  136  [??]  pdb.Wdf01000.public:_void___cdecl_FxPkgPnp::PnpProcessEvent_enum_FxPnpEvent__unsigned_char____ptr64+386
-21  0xfffff804799d299e sp: 0xffff850429892630  40   [??]  pdb.Wdf01000.protected:_static_long_int___cdecl_FxPkgPnp::_PnpStartDevice_class_FxPkgPnp_____ptr64__class_FxIrp_____ptr64+30
-22  0xfffff8047995cc5f sp: 0xffff850429892660  104  [??]  pdb.Wdf01000.protected_virtual:_long_int___cdecl_FxPkgPnp::Dispatch_struct__IRP_____ptr64____ptr64+175
-23  0xfffff8047995a866 sp: 0xffff8504298926d0  88   [??]  pdb.Wdf01000.public:_static_long_int___cdecl_FxDevice::DispatchWithLock_struct__DEVICE_OBJECT_____ptr64__struct__IRP_____ptr64+342
-24  0xfffff8047bc52f55 sp: 0xffff850429892730  56   [??]  pdb.ntkrnlmp.IofCallDriver+85
-25  0xfffff8047c1548a6 sp: 0xffff850429892770  56   [??]  pdb.ntkrnlmp.PnpAsynchronousCall+234
-26  0xfffff8047bce0d1e sp: 0xffff8504298927b0  104  [??]  pdb.ntkrnlmp.PnpSendIrp+158
-27  0xfffff8047bd6ab7c sp: 0xffff850429892820  136  [??]  pdb.ntkrnlmp.PnpStartDevice+136
-28  0xfffff8047c123760 sp: 0xffff8504298928b0  136  [??]  pdb.ntkrnlmp.PnpStartDeviceNode+236
-29  0xfffff8047c12362f sp: 0xffff850429892940  72   [??]  pdb.ntkrnlmp.PipProcessStartPhase1+115
-30  0xfffff8047c126bdd sp: 0xffff850429892990  200  [??]  pdb.ntkrnlmp.PipProcessDevNodeTree+793
-31  0xfffff8047c1bdf0c sp: 0xffff850429892a60  72   [??]  pdb.ntkrnlmp.PiProcessStartSystemDevices+96
-32  0xfffff8047bd6c2ec sp: 0xffff850429892ab0  184  [??]  pdb.ntkrnlmp.PnpDeviceActionWorker+1228
-33  0xfffff8047bc25975 sp: 0xffff850429892b70  152  [??]  pdb.ntkrnlmp.ExpWorkerThread+261
-34  0xfffff8047bd17e25 sp: 0xffff850429892c10  72   [??]  pdb.ntkrnlmp.PspSystemThreadStartup+85
-35  0xfffff8047bdfd0d8 sp: 0xffff850429892c60  40   [??]  pdb.ntkrnlmp.KiStartSystemThread+40
+5  0xfffff8047bd2ab86 sp: 0xffff8504298916f0  1720 [pdb.ntkrnlmp.KiDispatchException]  pdb.ntkrnlmp.KiDispatchException+390
+6  0xfffff8047be07bac sp: 0xffff850429891db0  472  [pdb.ntkrnlmp.KiExceptionDispatch]  pdb.ntkrnlmp.KiExceptionDispatch+300
+7  0xfffff8047be031f5 sp: 0xffff850429891f90  400  [pdb.ntkrnlmp.KiSegmentNotPresentFault]  pdb.ntkrnlmp.KiSegmentNotPresentFault+821
+8  0xfffff8048b58334c sp: 0xffff850429892120  40   [pdb.amdppm.WriteIoMemRawEx]  pdb.amdppm.WriteIoMemRawEx+112
+9  0xfffff8048b58313f sp: 0xffff850429892150  40   [pdb.amdppm.WriteGenAddrEx]  pdb.amdppm.WriteGenAddrEx+107
+10  0xfffff8048b583234 sp: 0xffff850429892180  40   [pdb.amdppm.WriteGenAddrMaybeHiddenEx]  pdb.amdppm.WriteGenAddrMaybeHiddenEx+24
+11  0xfffff8048b5a0e8f sp: 0xffff8504298921b0  88   [pdb.amdppm.InitAcpiCpc]  pdb.amdppm.InitAcpiCpc+791
+12  0xfffff8048b5a83f6 sp: 0xffff850429892210  296  [pdb.amdppm.ProcLibDeviceStart]  pdb.amdppm.ProcLibDeviceStart+2182
+13  0xfffff8048b59f852 sp: 0xffff850429892340  56   [pdb.amdppm.EvtDevicePrepareHardware]  pdb.amdppm.EvtDevicePrepareHardware+210
+14  0xfffff804799cc027 sp: 0xffff850429892380  72   [pdb.Wdf01000.protected_virtual:_long_int___cdecl_FxPnpDevicePrepareHardware::InvokeClient_void____ptr64]  pdb.Wdf01000.protected_virtual:_long_int___cdecl_FxPnpDevicePrepareHardware::InvokeClient_void____ptr64+39
+15  0xfffff80479966f81 sp: 0xffff8504298923d0  56   [pdb.Wdf01000.public:_long_int___cdecl_FxPrePostCallback::InvokeStateful_enum_FxCxCallbackProgress_____ptr64__enum_FxCxCallbackCleanupAction____ptr64]  pdb.Wdf01000.public:_long_int___cdecl_FxPrePostCallback::InvokeStateful_enum_FxCxCallbackProgress_____ptr64__enum_FxCxCallbackCleanupAction____ptr64+105
+16  0xfffff804799cb227 sp: 0xffff850429892410  72   [pdb.Wdf01000.protected:_long_int___cdecl_FxPkgPnp::PnpPrepareHardware_unsigned_char_____ptr64__enum_FxCxCallbackProgress_____ptr64____ptr64]  pdb.Wdf01000.protected:_long_int___cdecl_FxPkgPnp::PnpPrepareHardware_unsigned_char_____ptr64__enum_FxCxCallbackProgress_____ptr64____ptr64+223
+17  0xfffff804799c9e21 sp: 0xffff850429892460  56   [pdb.Wdf01000.protected:_static_enum__WDF_DEVICE_PNP_STATE___cdecl_FxPkgPnp::PnpEventHardwareAvailable_class_FxPkgPnp_____ptr64]  pdb.Wdf01000.protected:_static_enum__WDF_DEVICE_PNP_STATE___cdecl_FxPkgPnp::PnpEventHardwareAvailable_class_FxPkgPnp_____ptr64+81
+18  0xfffff804799c99da sp: 0xffff8504298924a0  136  [pdb.Wdf01000.protected:_void___cdecl_FxPkgPnp::PnpEnterNewState_enum__WDF_DEVICE_PNP_STATE____ptr64]  pdb.Wdf01000.protected:_void___cdecl_FxPkgPnp::PnpEnterNewState_enum__WDF_DEVICE_PNP_STATE____ptr64+350
+19  0xfffff804799cb6b1 sp: 0xffff850429892530  104  [pdb.Wdf01000.protected:_void___cdecl_FxPkgPnp::PnpProcessEventInner_struct_FxPostProcessInfo_____ptr64____ptr64]  pdb.Wdf01000.protected:_void___cdecl_FxPkgPnp::PnpProcessEventInner_struct_FxPostProcessInfo_____ptr64____ptr64+465
+20  0xfffff804799cb47a sp: 0xffff8504298925a0  136  [pdb.Wdf01000.public:_void___cdecl_FxPkgPnp::PnpProcessEvent_enum_FxPnpEvent__unsigned_char____ptr64]  pdb.Wdf01000.public:_void___cdecl_FxPkgPnp::PnpProcessEvent_enum_FxPnpEvent__unsigned_char____ptr64+386
+21  0xfffff804799d299e sp: 0xffff850429892630  40   [pdb.Wdf01000.protected:_static_long_int___cdecl_FxPkgPnp::_PnpStartDevice_class_FxPkgPnp_____ptr64__class_FxIrp_____ptr64]  pdb.Wdf01000.protected:_static_long_int___cdecl_FxPkgPnp::_PnpStartDevice_class_FxPkgPnp_____ptr64__class_FxIrp_____ptr64+30
+22  0xfffff8047995cc5f sp: 0xffff850429892660  104  [pdb.Wdf01000.protected_virtual:_long_int___cdecl_FxPkgPnp::Dispatch_struct__IRP_____ptr64____ptr64]  pdb.Wdf01000.protected_virtual:_long_int___cdecl_FxPkgPnp::Dispatch_struct__IRP_____ptr64____ptr64+175
+23  0xfffff8047995a866 sp: 0xffff8504298926d0  88   [pdb.Wdf01000.public:_static_long_int___cdecl_FxDevice::DispatchWithLock_struct__DEVICE_OBJECT_____ptr64__struct__IRP_____ptr64]  pdb.Wdf01000.public:_static_long_int___cdecl_FxDevice::DispatchWithLock_struct__DEVICE_OBJECT_____ptr64__struct__IRP_____ptr64+342
+24  0xfffff8047bc52f55 sp: 0xffff850429892730  56   [pdb.ntkrnlmp.IofCallDriver]  pdb.ntkrnlmp.IofCallDriver+85
+25  0xfffff8047c1548a6 sp: 0xffff850429892770  56   [pdb.ntkrnlmp.PnpAsynchronousCall]  pdb.ntkrnlmp.PnpAsynchronousCall+234
+26  0xfffff8047bce0d1e sp: 0xffff8504298927b0  104  [pdb.ntkrnlmp.PnpSendIrp]  pdb.ntkrnlmp.PnpSendIrp+158
+27  0xfffff8047bd6ab7c sp: 0xffff850429892820  136  [pdb.ntkrnlmp.PnpStartDevice]  pdb.ntkrnlmp.PnpStartDevice+136
+28  0xfffff8047c123760 sp: 0xffff8504298928b0  136  [pdb.ntkrnlmp.PnpStartDeviceNode]  pdb.ntkrnlmp.PnpStartDeviceNode+236
+29  0xfffff8047c12362f sp: 0xffff850429892940  72   [pdb.ntkrnlmp.PipProcessStartPhase1]  pdb.ntkrnlmp.PipProcessStartPhase1+115
+30  0xfffff8047c126bdd sp: 0xffff850429892990  200  [pdb.ntkrnlmp.PipProcessDevNodeTree]  pdb.ntkrnlmp.PipProcessDevNodeTree+793
+31  0xfffff8047c1bdf0c sp: 0xffff850429892a60  72   [pdb.ntkrnlmp.PiProcessStartSystemDevices]  pdb.ntkrnlmp.PiProcessStartSystemDevices+96
+32  0xfffff8047bd6c2ec sp: 0xffff850429892ab0  184  [pdb.ntkrnlmp.PnpDeviceActionWorker]  pdb.ntkrnlmp.PnpDeviceActionWorker+1228
+33  0xfffff8047bc25975 sp: 0xffff850429892b70  152  [pdb.ntkrnlmp.ExpWorkerThread]  pdb.ntkrnlmp.ExpWorkerThread+261
+34  0xfffff8047bd17e25 sp: 0xffff850429892c10  72   [pdb.ntkrnlmp.PspSystemThreadStartup]  pdb.ntkrnlmp.PspSystemThreadStartup+85
+35  0xfffff8047bdfd0d8 sp: 0xffff850429892c60  40   [pdb.ntkrnlmp.KiStartSystemThread]  pdb.ntkrnlmp.KiStartSystemThread+40
 36  0x0                sp: 0xffff850429892c90  0    [??]
 EOF
 RUN
@@ -369,10 +369,10 @@ int3
 ret
 int3
 int3
-0  0xfffff805108776a0 sp: 0xfffff805135684f8  0    [??]  pdb.ntkrnlmp.RtlpBreakWithStatusInstruction
-1  0xfffff805110dd222 sp: 0xfffff80513568500  568  [??]  pdb.ntkrnlmp.string_::2500419057::__Device_Ramdisk_::253687359+25426
-2  0xfffff80510c50204 sp: 0xfffff80513568740  776  [??]  pdb.ntkrnlmp.KiInitializeKernel+1364
-3  0xfffff80510c45219 sp: 0xfffff80513568a50  1448 [??]  pdb.ntkrnlmp.KiSystemStartup+521
+0  0xfffff805108776a0 sp: 0xfffff805135684f8  0    [pdb.ntkrnlmp.RtlpBreakWithStatusInstruction]  pdb.ntkrnlmp.RtlpBreakWithStatusInstruction
+1  0xfffff805110dd222 sp: 0xfffff80513568500  568  [pdb.ntkrnlmp.InitBootProcessor]  loc.fffff805110dc832+2544
+2  0xfffff80510c50204 sp: 0xfffff80513568740  776  [pdb.ntkrnlmp.KiSetFeatureBits]  pdb.ntkrnlmp.KiInitializeKernel+1364
+3  0xfffff80510c45219 sp: 0xfffff80513568a50  1448 [pdb.ntkrnlmp.KiSystemStartup]  pdb.ntkrnlmp.KiSystemStartup+521
 4  0x0                sp: 0xfffff80513569000  0    [??]
  1 fd: 4 +0x0000a038 0x00001000 - 0x00014fff r-- fmap.page.0x1000
  2 fd: 4 +0x0001e038 0x00017000 - 0x00018fff r-- fmap.page.0x17000

--- a/test/db/formats/pdb
+++ b/test/db/formats/pdb
@@ -173,33 +173,21 @@ global void * __guard_dispatch_icall_fptr @ 0x140015020
 global void * __guard_xfg_dispatch_icall_fptr @ 0x140015030
 global void * __guard_xfg_table_dispatch_icall_fptr @ 0x140015040
 ---
-(nofunc) 0x140007344 [DATA] lea rcx, qword pdb.exceptions_test.__guard_check_icall_fptr
-            0x140007344      lea   rcx, qword pdb.exceptions_test.__guard_check_icall_fptr ; 0x140015000
-            0x14000734b      call  fcn.1400011db
-            0x140007350      lea   rcx, qword [0x14000101e]
-fcn.140001366 0x140006a64 [DATA] mov dword [pdb.exceptions_test.__scrt_debugger_hook_flag], 0x00
-  ; CALL XREFS from fcn.140001398 @ 0x140006aab, 0x140006c04
+pdb.exceptions_test._guard_icall_checks_enforced 0x140007344 [DATA] lea rcx, qword pdb.exceptions_test.__guard_check_icall_fptr
+|           0x140007344      lea   rcx, qword pdb.exceptions_test.__guard_check_icall_fptr ; 0x140015000 ; int64_t arg1
+|           0x14000734b      call  fcn.1400011db
+|           0x140007350      lea   rcx, qword data.14000101e           ; 0x14000101e
+pdb.exceptions_test.__crt_debugger_hook 0x140006a64 [DATA] mov dword [pdb.exceptions_test.__scrt_debugger_hook_flag], 0x00
+  ; CALL XREFS from pdb.exceptions_test.__scrt_fastfail @ 0x140006aab, 0x140006c04
 / fcn.140001366(int64_t arg1);
 | ; arg int64_t arg1 @ rcx
-| ; var int64_t var_8h @ stack + 0x8
-| 0x140001366      jmp   pdb.exceptions_test.__crt_debugger_hook
+\ 0x140001366      jmp   pdb.exceptions_test.__crt_debugger_hook
 | ----------- true: 0x140006a60
-| ; CODE XREF from fcn.140001366 @ 0x140001366
-| ;-- __crt_debugger_hook:
-| 0x140006a60      mov   dword [var_8h], ecx                           ; arg1
-| 0x140006a64      mov   dword [pdb.exceptions_test.__scrt_debugger_hook_flag], 0x00 ; [0x140011ba4:4]=0
-\ 0x140006a6e      ret
-
-fcn.140001316 0x140006a40 [DATA] lea rax, qword pdb.exceptions_test.__dyn_tls_init_callback
+pdb.exceptions_test.__scrt_get_dyn_tls_init_callback 0x140006a40 [DATA] lea rax, qword pdb.exceptions_test.__dyn_tls_init_callback
   ; CALL XREF from fcn.1400049a0 @ 0x140004a44
 / fcn.140001316();
-| 0x140001316      jmp   pdb.exceptions_test.__scrt_get_dyn_tls_init_callback
+\ 0x140001316      jmp   pdb.exceptions_test.__scrt_get_dyn_tls_init_callback
 | ----------- true: 0x140006a40
-| ; CODE XREF from fcn.140001316 @ 0x140001316
-| ;-- __scrt_get_dyn_tls_init_callback:
-| 0x140006a40      lea   rax, qword pdb.exceptions_test.__dyn_tls_init_callback ; 0x140011be0
-\ 0x140006a47      ret
-
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Previously PDB analysis integration missed virtual functions, now it doesn't.

Note, the removal of `const` for the `RzCore` in the context is required because `rz_core_analysis_fcn()` doesn't have `const RzCore` in its signature, and many callers - it would cause many unrelated changes and better to handle separately.

**Test plan**

CI is green

**Closing issues**

Closes #955
