### PR TITLE
Colorize RzIL in `ao` standard output like `plf`

### DIFF
--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -552,7 +552,16 @@ static void core_analysis_bytes_standard(RzCore *core, const ut8 *buf, int len, 
 		if (op->il_op) {
 			RzStrBuf *sbil = rz_strbuf_new("");
 			rz_il_op_effect_stringify(op->il_op, sbil, false);
-			PRINTF_LN_STR("rzil", rz_strbuf_get(sbil));
+			const char *ilstr = rz_strbuf_get(sbil);
+			if (RZ_STR_ISNOTEMPTY(ilstr)) {
+				if (use_color) {
+					rz_cons_printf("%srzil: " Color_RESET, color);
+					rz_core_il_colorize_body(core->cons->context, ilstr);
+					rz_cons_newline();
+				} else {
+					rz_cons_printf("rzil: %s\n", ilstr);
+				}
+			}
 			rz_strbuf_free(sbil);
 		}
 		if (op->opex) {


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Before:
<img width="1112" height="550" alt="Screenshot 2026-06-07 at 12 54 40 PM" src="https://github.com/user-attachments/assets/758ee8ba-26a6-4044-baa9-44f41ab2fc8c" />


After:
<img width="1108" height="556" alt="Screenshot 2026-06-07 at 12 53 41 PM" src="https://github.com/user-attachments/assets/52a3766b-6b91-4a79-952f-ddf8150535a9" />


**Test plan**

- CI is green
- Try `ao` command on architecture with RzIL support
