### PR TITLE
librz/arch: fix signed integer overflow in rz_analysis_function_relocate

### DIFF
--- a/librz/arch/function.c
+++ b/librz/arch/function.c
@@ -213,7 +213,7 @@ RZ_API RzAnalysisFunction *rz_analysis_get_function_at(const RzAnalysis *analysi
 
 typedef struct {
 	HtUP *inst_vars_new;
-	st64 delta;
+	ut64 delta;
 } InstVarsRelocateCtx;
 
 static bool inst_vars_relocate_cb(void *user, const ut64 k, const void *v) {
@@ -231,14 +231,17 @@ RZ_API bool rz_analysis_function_relocate(RzAnalysisFunction *fcn, ut64 addr) {
 	}
 	ht_up_delete(fcn->analysis->ht_addr_fun, fcn->addr);
 
-	// relocate the var accesses (their addrs are relative to the function addr)
-	st64 delta = addr - fcn->addr;
+	// relocate the var accesses (their addrs are relative to the function addr).
+	// delta and the offset arithmetic are done in ut64: addresses and their
+	// differences wrap modulo 2^64 by design, and the offsets are only ever
+	// compared/looked up as exact values, so signed overflow must be avoided.
+	ut64 delta = addr - fcn->addr;
 	void **it;
 	rz_pvector_foreach (&fcn->vars, it) {
 		RzAnalysisVar *var = *it;
 		RzAnalysisVarAccess *acc;
 		rz_vector_foreach (&var->accesses, acc) {
-			acc->offset -= delta;
+			acc->offset = (st64)((ut64)acc->offset - delta);
 		}
 	}
 	InstVarsRelocateCtx ctx = {


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

When a function is relocated, each variable access offset (stored relative to the function's entry point) is rebased by the relocation delta so that the accesses keep pointing at the same absolute addresses. This was done as a signed st64 subtraction:
```
    st64 delta = addr - fcn->addr;
    ...
    acc->offset -= delta;
```
Relocating to an address near the int64 boundary makes delta close to INT64_MIN, and 'acc->offset - delta' then overflows st64. UBSAN aborts:
```
    librz/arch/function.c:241:16: runtime error: signed integer overflow:
    65568 - -9223372036854710512 cannot be represented in type 'long int'
```
(reproducible via test/unit/test_analysis_var, which relocates to 0x8000000000000010 and 0x7ffffffffffffe00).

Addresses and their differences are meant to wrap modulo 2^64, and the offsets are only ever looked up as exact values (get_vars_used_at computes op_addr - fcn->addr in ut64 as well), so perform the arithmetic in ut64. delta becomes ut64 and the rebase is '(st64)((ut64)acc->offset - delta)'; the result is bit-identical for every non-overflowing case and well-defined for the rest. The inst_vars rebase callback already subtracted in ut64.

**Test plan**

- CI is green
- No UBSAN complaining

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/4013
