### PR TITLE
subprojects/gdb: add support for qGDBServerVersion query

### DIFF
--- a/subprojects/rzgdb/src/gdbclient/core.c
+++ b/subprojects/rzgdb/src/gdbclient/core.c
@@ -152,6 +152,27 @@ end:
 	return ret;
 }
 
+/**
+ * \brief Query the remote stub for its name and version via qGDBServerVersion
+ *
+ * qGDBServerVersion is an LLDB protocol extension. The reply is a list of
+ * `key:value;` pairs, e.g. `name:debugserver;version:902.0.0;`. Stubs that do
+ * not implement it (such as gdbserver) reply with an empty packet, in which
+ * case this does nothing beyond emitting a debug log line.
+ */
+static void gdbr_query_gdb_server_version(libgdbr_t *g) {
+	if (send_msg(g, "qGDBServerVersion") < 0 || read_packet(g, false) < 0) {
+		return;
+	}
+	send_ack(g);
+	if (g->data_len == 0 || !*g->data) {
+		RZ_LOG_DEBUG("gdb: remote does not implement qGDBServerVersion\n");
+		return;
+	}
+	g->data[g->data_len] = '\0';
+	RZ_LOG_DEBUG("gdb: remote server version: %s\n", g->data);
+}
+
 int gdbr_connect(libgdbr_t *g, const char *host, int port) {
 	const char *message = "qSupported:multiprocess+;qRelocInsn+;xmlRegisters=i386";
 	int i;
@@ -234,6 +255,8 @@ int gdbr_connect(libgdbr_t *g, const char *host, int port) {
 			g->no_ack = true;
 		}
 	}
+	// Query and log the remote server name/version (qGDBServerVersion)
+	gdbr_query_gdb_server_version(g);
 	if (g->remote_type == GDB_REMOTE_TYPE_LLDB) {
 		if ((ret = gdbr_connect_lldb(g)) < 0) {
 			goto end;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

This query returns the GDB remote server version. First introduced by LLDB, then picked up by QEMU and others. For now we just print the version in the debug log, which is helpful for, well, debugging the debugger.

- https://lists.gnu.org/archive/html/qemu-devel/2025-05/msg05129.html
- https://lldb.llvm.org/resources/lldbgdbremote.html#qgdbserverversion
- https://github.com/pwndbg/pwndbg/issues/2648
- https://github.com/pwndbg/pwndbg/issues/3501
- https://github.com/qemu/qemu/commit/b2654598b3330aaa58ab0cec2114843bfa96ddaa

**Test plan**

- CI is green
- Try with your favorite GDB server/stub