### PR TITLE
Expose type constraints to the analysis and user

### DIFF
--- a/librz/arch/var.c
+++ b/librz/arch/var.c
@@ -1040,52 +1040,35 @@ RZ_API void rz_analysis_var_add_constraint(RzAnalysisVar *var, RZ_BORROW RzTypeC
 }
 
 /**
+ * \brief Removes all type constraints from a \p var variable
+ */
+RZ_API void rz_analysis_var_clear_constraints(RZ_NONNULL RzAnalysisVar *var) {
+	rz_return_if_fail(var);
+	rz_vector_clear(&var->constraints);
+}
+
+/**
  * \brief Get all type constraints of a \p var variable in the text form
  */
-RZ_API char *rz_analysis_var_get_constraints_readable(RzAnalysisVar *var) {
-	size_t n = var->constraints.len;
-	if (!n) {
-		return NULL;
-	}
-	bool low = false, high = false;
-	RzStrBuf sb;
-	rz_strbuf_init(&sb);
-	size_t i;
-	for (i = 0; i < n; i += 1) {
-		RzTypeConstraint *constr = rz_vector_index_ptr(&var->constraints, i);
-		switch (constr->cond) {
-		case RZ_TYPE_COND_LE:
-			if (high) {
-				rz_strbuf_append(&sb, " && ");
-			}
-			rz_strbuf_appendf(&sb, "<= 0x%" PFMT64x, constr->val);
-			low = true;
-			break;
-		case RZ_TYPE_COND_LT:
-			if (high) {
-				rz_strbuf_append(&sb, " && ");
-			}
-			rz_strbuf_appendf(&sb, "< 0x%" PFMT64x, constr->val);
-			low = true;
-			break;
-		case RZ_TYPE_COND_GE:
-			rz_strbuf_appendf(&sb, ">= 0x%" PFMT64x, constr->val);
-			high = true;
-			break;
-		case RZ_TYPE_COND_GT:
-			rz_strbuf_appendf(&sb, "> 0x%" PFMT64x, constr->val);
-			high = true;
-			break;
-		default:
-			break;
-		}
-		if (low && high && i != n - 1) {
-			rz_strbuf_append(&sb, " || ");
-			low = false;
-			high = false;
+RZ_API char *rz_analysis_var_get_constraints_readable(RZ_NONNULL RzAnalysisVar *var) {
+	rz_return_val_if_fail(var, NULL);
+	// The inline variable listing (afvl) only shows the interval/range hint.
+	// Equality and inequality constraints, such as the "== 0" produced by the
+	// ubiquitous null/zero checks, would clutter the listing; they are still
+	// recorded and can be inspected through the dedicated `afvc` command.
+	// Render only the interval bounds here.
+	RzVector /*<RzTypeConstraint>*/ intervals;
+	rz_vector_init(&intervals, sizeof(RzTypeConstraint), NULL, NULL);
+	RzTypeConstraint *c;
+	rz_vector_foreach (&var->constraints, c) {
+		if (c->cond == RZ_TYPE_COND_LE || c->cond == RZ_TYPE_COND_LT ||
+			c->cond == RZ_TYPE_COND_GE || c->cond == RZ_TYPE_COND_GT) {
+			rz_vector_push(&intervals, c);
 		}
 	}
-	return rz_strbuf_drain_nofree(&sb);
+	char *readable = rz_type_interval_constraints_as_string(&intervals);
+	rz_vector_fini(&intervals);
+	return readable;
 }
 
 static bool stack_offset_is_arg(RzAnalysisFunction *fcn, st64 stack_off) {

--- a/librz/arch/var_global.c
+++ b/librz/arch/var_global.c
@@ -22,6 +22,7 @@ RZ_API RZ_OWN RzAnalysisVarGlobal *rz_analysis_var_global_new(RZ_NONNULL const c
 	glob->coord.decl_file = NULL;
 	glob->coord.decl_line = UT32_MAX;
 	glob->coord.decl_col = UT32_MAX;
+	rz_vector_init(&glob->constraints, sizeof(RzTypeConstraint), NULL, NULL);
 
 	return glob;
 }
@@ -376,9 +377,19 @@ RZ_API void rz_analysis_var_global_set_type(RzAnalysisVarGlobal *glob, RZ_NONNUL
  * \param constraint RzTypeConstraint
  * \return void
  */
-RZ_API void rz_analysis_var_global_add_constraint(RzAnalysisVarGlobal *glob, RzTypeConstraint *constraint) {
+RZ_API void rz_analysis_var_global_add_constraint(RZ_NONNULL RzAnalysisVarGlobal *glob, RZ_NONNULL RzTypeConstraint *constraint) {
 	rz_return_if_fail(glob && constraint);
 	rz_vector_push(&glob->constraints, constraint);
+}
+
+/**
+ * \brief Removes all type constraints from a \p glob global variable
+ *
+ * \param glob Global variable instance
+ */
+RZ_API void rz_analysis_var_global_clear_constraints(RZ_NONNULL RzAnalysisVarGlobal *glob) {
+	rz_return_if_fail(glob);
+	rz_vector_clear(&glob->constraints);
 }
 
 /**
@@ -387,50 +398,9 @@ RZ_API void rz_analysis_var_global_add_constraint(RzAnalysisVarGlobal *glob, RzT
  * \param glob Global variable instance
  * \return char *
  */
-RZ_API RZ_OWN char *rz_analysis_var_global_get_constraints_readable(RzAnalysisVarGlobal *glob) {
-	size_t n = glob->constraints.len;
-	if (!n) {
-		return NULL;
-	}
-	bool low = false, high = false;
-	RzStrBuf sb;
-	rz_strbuf_init(&sb);
-	size_t i;
-	for (i = 0; i < n; i += 1) {
-		RzTypeConstraint *constr = rz_vector_index_ptr(&glob->constraints, i);
-		switch (constr->cond) {
-		case RZ_TYPE_COND_LE:
-			if (high) {
-				rz_strbuf_append(&sb, " && ");
-			}
-			rz_strbuf_appendf(&sb, "<= 0x%" PFMT64x, constr->val);
-			low = true;
-			break;
-		case RZ_TYPE_COND_LT:
-			if (high) {
-				rz_strbuf_append(&sb, " && ");
-			}
-			rz_strbuf_appendf(&sb, "< 0x%" PFMT64x, constr->val);
-			low = true;
-			break;
-		case RZ_TYPE_COND_GE:
-			rz_strbuf_appendf(&sb, ">= 0x%" PFMT64x, constr->val);
-			high = true;
-			break;
-		case RZ_TYPE_COND_GT:
-			rz_strbuf_appendf(&sb, "> 0x%" PFMT64x, constr->val);
-			high = true;
-			break;
-		default:
-			break;
-		}
-		if (low && high && i != n - 1) {
-			rz_strbuf_append(&sb, " || ");
-			low = false;
-			high = false;
-		}
-	}
-	return rz_strbuf_drain_nofree(&sb);
+RZ_API RZ_OWN char *rz_analysis_var_global_get_constraints_readable(RZ_NONNULL RzAnalysisVarGlobal *glob) {
+	rz_return_val_if_fail(glob, NULL);
+	return rz_type_interval_constraints_as_string(&glob->constraints);
 }
 
 /**

--- a/librz/core/analysis_tp.c
+++ b/librz/core/analysis_tp.c
@@ -771,7 +771,32 @@ void propagate_types_among_used_variables(RzCore *core, HtUP *op_cache, RzAnalys
 					.cond = jmp ? rz_type_cond_invert(next_op->cond) : next_op->cond,
 					.val = aop->val
 				};
-				rz_analysis_var_add_constraint(var, &constr);
+				// Only keep constraints that carry useful information: a known
+				// immediate value (UT64_MAX means the compared value was not a
+				// resolvable immediate) and a condition that the rest of the
+				// type engine knows how to represent. Besides the interval
+				// bounds (<, <=, >, >=) this includes the equality and
+				// inequality conditions produced by je/jne-style branches.
+				// This avoids recording degenerate constraints such as
+				// "> 0xffffffffffffffff".
+				bool useful_cond = constr.cond == RZ_TYPE_COND_LE || constr.cond == RZ_TYPE_COND_LT ||
+					constr.cond == RZ_TYPE_COND_GE || constr.cond == RZ_TYPE_COND_GT ||
+					constr.cond == RZ_TYPE_COND_EQ || constr.cond == RZ_TYPE_COND_NE;
+				if (constr.val != UT64_MAX && useful_cond) {
+					// Avoid recording the same constraint more than once (the
+					// emulation may revisit the same comparison).
+					bool dup = false;
+					RzTypeConstraint *existing;
+					rz_vector_foreach (&var->constraints, existing) {
+						if (existing->cond == constr.cond && existing->val == constr.val) {
+							dup = true;
+							break;
+						}
+					}
+					if (!dup) {
+						rz_analysis_var_add_constraint(var, &constr);
+					}
+				}
 			}
 		}
 		vars_resolve_overlaps(used_vars);

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3025,7 +3025,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	SETCB("analysis.strings", "false", &cb_analysis_strings, "Identify and register strings during analysis (aar only)");
 	SETPREF("analysis.types.spec", "gcc", "Set profile for specifying format chars used in type analysis");
 	SETBPREF("analysis.types.verbose", "false", "Verbose output from type analysis");
-	SETBPREF("analysis.types.constraint", "false", "Enable constraint types analysis for variables");
+	SETBPREF("analysis.types.constraint", "true", "Enable constraint types analysis for variables");
 	SETCB("analysis.vars", "true", &cb_analysis_vars, "Analyze local variables and arguments");
 	SETBPREF("analysis.vinfun", "true", "Search values in functions (aav) (false by default to only find on non-code)");
 	SETBPREF("analysis.vinfunrange", "false", "Search values outside function ranges (requires analysis.vinfun=false)\n");

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -2581,6 +2581,169 @@ RZ_IPI RzCmdStatus rz_analysis_function_vars_type_handler(RzCore *core, int argc
 	return RZ_CMD_STATUS_OK;
 }
 
+static void var_constraints_print(RzCmdStateOutput *state, RZ_NONNULL const char *name,
+	RZ_NONNULL const RzVector /*<RzTypeConstraint>*/ *constraints, bool with_name) {
+	char *readable = rz_type_interval_constraints_as_string(constraints);
+	switch (state->mode) {
+	case RZ_OUTPUT_MODE_JSON: {
+		PJ *pj = state->d.pj;
+		pj_o(pj);
+		pj_ks(pj, "name", name);
+		pj_ks(pj, "constraints", readable ? readable : "");
+		pj_ka(pj, "conditions");
+		void *it;
+		rz_vector_foreach (constraints, it) {
+			RzTypeConstraint *constr = (RzTypeConstraint *)it;
+			pj_o(pj);
+			pj_ks(pj, "cond", rz_type_cond_tostring(constr->cond));
+			pj_kn(pj, "value", constr->val);
+			pj_end(pj);
+		}
+		pj_end(pj);
+		pj_end(pj);
+		break;
+	}
+	default:
+		if (with_name) {
+			rz_cons_printf("%s: %s\n", name, readable ? readable : "");
+		} else if (readable) {
+			rz_cons_println(readable);
+		}
+		break;
+	}
+	free(readable);
+}
+
+RZ_IPI RzCmdStatus rz_analysis_function_vars_constraints_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
+	RzAnalysisFunction *fcn = analysis_get_function_in(core->analysis, core->offset);
+	if (!fcn) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_cmd_state_output_array_start(state);
+	if (argc > 1) {
+		RzAnalysisVar *var = rz_analysis_function_get_var_byname(fcn, argv[1]);
+		if (!var) {
+			RZ_LOG_ERROR("core: Cannot find variable \"%s\" in the current function\n", argv[1]);
+			rz_cmd_state_output_array_end(state);
+			return RZ_CMD_STATUS_ERROR;
+		}
+		var_constraints_print(state, var->name, &var->constraints, false);
+	} else {
+		void **it;
+		rz_pvector_foreach (&fcn->vars, it) {
+			RzAnalysisVar *var = *it;
+			char *readable = rz_type_interval_constraints_as_string(&var->constraints);
+			bool empty = RZ_STR_ISEMPTY(readable);
+			free(readable);
+			if (empty) {
+				continue;
+			}
+			var_constraints_print(state, var->name, &var->constraints, true);
+		}
+	}
+	rz_cmd_state_output_array_end(state);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_analysis_function_vars_constraints_set_handler(RzCore *core, int argc, const char **argv) {
+	RzAnalysisFunction *fcn = analysis_get_function_in(core->analysis, core->offset);
+	if (!fcn) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+	RzAnalysisVar *var = rz_analysis_function_get_var_byname(fcn, argv[1]);
+	if (!var) {
+		RZ_LOG_ERROR("core: Cannot find variable \"%s\" in the current function\n", argv[1]);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	RzVector /*<RzTypeConstraint>*/ parsed;
+	rz_vector_init(&parsed, sizeof(RzTypeConstraint), NULL, NULL);
+	if (!rz_type_interval_constraints_from_string(argv[2], &parsed)) {
+		rz_vector_fini(&parsed);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_analysis_var_clear_constraints(var);
+	RzTypeConstraint *c;
+	rz_vector_foreach (&parsed, c) {
+		rz_analysis_var_add_constraint(var, c);
+	}
+	rz_vector_fini(&parsed);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_analysis_function_vars_constraints_del_handler(RzCore *core, int argc, const char **argv) {
+	RzAnalysisFunction *fcn = analysis_get_function_in(core->analysis, core->offset);
+	if (!fcn) {
+		return RZ_CMD_STATUS_ERROR;
+	}
+	RzAnalysisVar *var = rz_analysis_function_get_var_byname(fcn, argv[1]);
+	if (!var) {
+		RZ_LOG_ERROR("core: Cannot find variable \"%s\" in the current function\n", argv[1]);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_analysis_var_clear_constraints(var);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_analysis_global_variable_constraints_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
+	rz_cmd_state_output_array_start(state);
+	if (argc > 1) {
+		RzAnalysisVarGlobal *glob = rz_analysis_var_global_get_byname(core->analysis, argv[1]);
+		if (!glob) {
+			RZ_LOG_ERROR("Global variable '%s' does not exist!\n", argv[1]);
+			rz_cmd_state_output_array_end(state);
+			return RZ_CMD_STATUS_ERROR;
+		}
+		var_constraints_print(state, glob->name, &glob->constraints, false);
+	} else {
+		RzList *globals = rz_analysis_var_global_get_all(core->analysis);
+		RzListIter *it;
+		RzAnalysisVarGlobal *glob;
+		rz_list_foreach (globals, it, glob) {
+			char *readable = rz_type_interval_constraints_as_string(&glob->constraints);
+			bool empty = RZ_STR_ISEMPTY(readable);
+			free(readable);
+			if (empty) {
+				continue;
+			}
+			var_constraints_print(state, glob->name, &glob->constraints, true);
+		}
+		rz_list_free(globals);
+	}
+	rz_cmd_state_output_array_end(state);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_analysis_global_variable_constraints_set_handler(RzCore *core, int argc, const char **argv) {
+	RzAnalysisVarGlobal *glob = rz_analysis_var_global_get_byname(core->analysis, argv[1]);
+	if (!glob) {
+		RZ_LOG_ERROR("Global variable '%s' does not exist!\n", argv[1]);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	RzVector /*<RzTypeConstraint>*/ parsed;
+	rz_vector_init(&parsed, sizeof(RzTypeConstraint), NULL, NULL);
+	if (!rz_type_interval_constraints_from_string(argv[2], &parsed)) {
+		rz_vector_fini(&parsed);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_analysis_var_global_clear_constraints(glob);
+	RzTypeConstraint *c;
+	rz_vector_foreach (&parsed, c) {
+		rz_analysis_var_global_add_constraint(glob, c);
+	}
+	rz_vector_fini(&parsed);
+	return RZ_CMD_STATUS_OK;
+}
+
+RZ_IPI RzCmdStatus rz_analysis_global_variable_constraints_del_handler(RzCore *core, int argc, const char **argv) {
+	RzAnalysisVarGlobal *glob = rz_analysis_var_global_get_byname(core->analysis, argv[1]);
+	if (!glob) {
+		RZ_LOG_ERROR("Global variable '%s' does not exist!\n", argv[1]);
+		return RZ_CMD_STATUS_ERROR;
+	}
+	rz_analysis_var_global_clear_constraints(glob);
+	return RZ_CMD_STATUS_OK;
+}
+
 RZ_IPI RzCmdStatus rz_analysis_function_args_and_vars_xrefs_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode, bool use_args, bool use_vars) {
 	RzAnalysisFunction *fcn = analysis_get_function_in(core->analysis, core->offset);
 	if (!fcn) {

--- a/librz/core/cmd_descs/cmd_analysis.yaml
+++ b/librz/core/cmd_descs/cmd_analysis.yaml
@@ -481,6 +481,34 @@ commands:
                 type: RZ_CMD_ARG_TYPE_FCN_VAR
               - name: type
                 type: RZ_CMD_ARG_TYPE_STRING
+          - name: afvc
+            summary: Read/change value constraints of arguments/locals
+            subcommands:
+              - name: afvc
+                cname: analysis_function_vars_constraints
+                summary: List value constraints of all variables / of the given one
+                type: RZ_CMD_DESC_TYPE_ARGV_STATE
+                modes:
+                  - RZ_OUTPUT_MODE_STANDARD
+                  - RZ_OUTPUT_MODE_JSON
+                args:
+                  - name: varname
+                    type: RZ_CMD_ARG_TYPE_FCN_VAR
+                    optional: true
+              - name: afvcs
+                cname: analysis_function_vars_constraints_set
+                summary: 'Set value constraints of a variable (e.g. afvcs var0 ">0,<=9")'
+                args:
+                  - name: varname
+                    type: RZ_CMD_ARG_TYPE_FCN_VAR
+                  - name: constraints
+                    type: RZ_CMD_ARG_TYPE_STRING
+              - name: afvc-
+                cname: analysis_function_vars_constraints_del
+                summary: Remove all value constraints of a variable
+                args:
+                  - name: varname
+                    type: RZ_CMD_ARG_TYPE_FCN_VAR
           - name: afvx
             summary: Show argument/variable xrefs in a function
             subcommands:
@@ -1610,6 +1638,34 @@ commands:
             args:
               - name: name
                 type: RZ_CMD_ARG_TYPE_GLOBAL_VAR
+          - name: avgc
+            summary: Read/change value constraints of global variables
+            subcommands:
+              - name: avgc
+                cname: analysis_global_variable_constraints
+                summary: List value constraints of all globals / of the given one
+                type: RZ_CMD_DESC_TYPE_ARGV_STATE
+                modes:
+                  - RZ_OUTPUT_MODE_STANDARD
+                  - RZ_OUTPUT_MODE_JSON
+                args:
+                  - name: var_name
+                    type: RZ_CMD_ARG_TYPE_GLOBAL_VAR
+                    optional: true
+              - name: avgcs
+                cname: analysis_global_variable_constraints_set
+                summary: 'Set value constraints of a global variable (e.g. avgcs g ">0,<=9")'
+                args:
+                  - name: var_name
+                    type: RZ_CMD_ARG_TYPE_GLOBAL_VAR
+                  - name: constraints
+                    type: RZ_CMD_ARG_TYPE_STRING
+              - name: avgc-
+                cname: analysis_global_variable_constraints_del
+                summary: Remove all value constraints of a global variable
+                args:
+                  - name: var_name
+                    type: RZ_CMD_ARG_TYPE_GLOBAL_VAR
       - name: avr
         summary: try to parse RTTI at vtable addr (see analysis.cpp.abi)
         type: RZ_CMD_DESC_TYPE_ARGV_MODES

--- a/librz/core/cmd_descs/cmd_descs.c
+++ b/librz/core/cmd_descs/cmd_descs.c
@@ -278,6 +278,9 @@ static const RzCmdDescArg analysis_function_vars_rename_args[3];
 static const RzCmdDescArg analysis_function_vars_reads_args[2];
 static const RzCmdDescArg analysis_function_vars_writes_args[2];
 static const RzCmdDescArg analysis_function_vars_type_args[3];
+static const RzCmdDescArg analysis_function_vars_constraints_args[2];
+static const RzCmdDescArg analysis_function_vars_constraints_set_args[3];
+static const RzCmdDescArg analysis_function_vars_constraints_del_args[2];
 static const RzCmdDescArg analysis_function_vars_xrefs_args[2];
 static const RzCmdDescArg analysis_function_vars_xrefs_args_args[2];
 static const RzCmdDescArg analysis_function_vars_xrefs_vars_args[2];
@@ -354,6 +357,9 @@ static const RzCmdDescArg analysis_global_variable_rename_args[3];
 static const RzCmdDescArg analysis_global_variable_print_args[2];
 static const RzCmdDescArg analysis_global_variable_retype_args[3];
 static const RzCmdDescArg analysis_global_variable_xrefs_args[2];
+static const RzCmdDescArg analysis_global_variable_constraints_args[2];
+static const RzCmdDescArg analysis_global_variable_constraints_set_args[3];
+static const RzCmdDescArg analysis_global_variable_constraints_del_args[2];
 static const RzCmdDescArg analysis_rtti_demangle_class_name_args[2];
 static const RzCmdDescArg analysis_virtual_xrefs_args[2];
 static const RzCmdDescArg analysis_xrefs_set_0_args[2];
@@ -4867,6 +4873,55 @@ static const RzCmdDescHelp analysis_function_vars_type_help = {
 	.args = analysis_function_vars_type_args,
 };
 
+static const RzCmdDescHelp afvc_help = {
+	.summary = "Read/change value constraints of arguments/locals",
+};
+static const RzCmdDescArg analysis_function_vars_constraints_args[] = {
+	{
+		.name = "varname",
+		.type = RZ_CMD_ARG_TYPE_FCN_VAR,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_function_vars_constraints_help = {
+	.summary = "List value constraints of all variables / of the given one",
+	.args = analysis_function_vars_constraints_args,
+};
+
+static const RzCmdDescArg analysis_function_vars_constraints_set_args[] = {
+	{
+		.name = "varname",
+		.type = RZ_CMD_ARG_TYPE_FCN_VAR,
+
+	},
+	{
+		.name = "constraints",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_function_vars_constraints_set_help = {
+	.summary = "Set value constraints of a variable (e.g. afvcs var0 \">0,<=9\")",
+	.args = analysis_function_vars_constraints_set_args,
+};
+
+static const RzCmdDescArg analysis_function_vars_constraints_del_args[] = {
+	{
+		.name = "varname",
+		.type = RZ_CMD_ARG_TYPE_FCN_VAR,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_function_vars_constraints_del_help = {
+	.summary = "Remove all value constraints of a variable",
+	.args = analysis_function_vars_constraints_del_args,
+};
+
 static const RzCmdDescHelp afvx_help = {
 	.summary = "Show argument/variable xrefs in a function",
 };
@@ -6696,6 +6751,55 @@ static const RzCmdDescArg analysis_global_variable_xrefs_args[] = {
 static const RzCmdDescHelp analysis_global_variable_xrefs_help = {
 	.summary = "print all xrefs to the global variable",
 	.args = analysis_global_variable_xrefs_args,
+};
+
+static const RzCmdDescHelp avgc_help = {
+	.summary = "Read/change value constraints of global variables",
+};
+static const RzCmdDescArg analysis_global_variable_constraints_args[] = {
+	{
+		.name = "var_name",
+		.type = RZ_CMD_ARG_TYPE_GLOBAL_VAR,
+		.optional = true,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_global_variable_constraints_help = {
+	.summary = "List value constraints of all globals / of the given one",
+	.args = analysis_global_variable_constraints_args,
+};
+
+static const RzCmdDescArg analysis_global_variable_constraints_set_args[] = {
+	{
+		.name = "var_name",
+		.type = RZ_CMD_ARG_TYPE_GLOBAL_VAR,
+
+	},
+	{
+		.name = "constraints",
+		.type = RZ_CMD_ARG_TYPE_STRING,
+		.flags = RZ_CMD_ARG_FLAG_LAST,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_global_variable_constraints_set_help = {
+	.summary = "Set value constraints of a global variable (e.g. avgcs g \">0,<=9\")",
+	.args = analysis_global_variable_constraints_set_args,
+};
+
+static const RzCmdDescArg analysis_global_variable_constraints_del_args[] = {
+	{
+		.name = "var_name",
+		.type = RZ_CMD_ARG_TYPE_GLOBAL_VAR,
+
+	},
+	{ 0 },
+};
+static const RzCmdDescHelp analysis_global_variable_constraints_del_help = {
+	.summary = "Remove all value constraints of a global variable",
+	.args = analysis_global_variable_constraints_del_args,
 };
 
 static const RzCmdDescArg analysis_print_rtti_args[] = {
@@ -23092,6 +23196,14 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 	RzCmdDesc *analysis_function_vars_type_cd = rz_cmd_desc_argv_new(core->rcmd, afv_cd, "afvt", rz_analysis_function_vars_type_handler, &analysis_function_vars_type_help);
 	rz_warn_if_fail(analysis_function_vars_type_cd);
 
+	RzCmdDesc *afvc_cd = rz_cmd_desc_group_state_new(core->rcmd, afv_cd, "afvc", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_function_vars_constraints_handler, &analysis_function_vars_constraints_help, &afvc_help);
+	rz_warn_if_fail(afvc_cd);
+	RzCmdDesc *analysis_function_vars_constraints_set_cd = rz_cmd_desc_argv_new(core->rcmd, afvc_cd, "afvcs", rz_analysis_function_vars_constraints_set_handler, &analysis_function_vars_constraints_set_help);
+	rz_warn_if_fail(analysis_function_vars_constraints_set_cd);
+
+	RzCmdDesc *analysis_function_vars_constraints_del_cd = rz_cmd_desc_argv_new(core->rcmd, afvc_cd, "afvc-", rz_analysis_function_vars_constraints_del_handler, &analysis_function_vars_constraints_del_help);
+	rz_warn_if_fail(analysis_function_vars_constraints_del_cd);
+
 	RzCmdDesc *afvx_cd = rz_cmd_desc_group_modes_new(core->rcmd, afv_cd, "afvx", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_function_vars_xrefs_handler, &analysis_function_vars_xrefs_help, &afvx_help);
 	rz_warn_if_fail(afvx_cd);
 	RzCmdDesc *analysis_function_vars_xrefs_args_cd = rz_cmd_desc_argv_modes_new(core->rcmd, afvx_cd, "afvxa", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_function_vars_xrefs_args_handler, &analysis_function_vars_xrefs_args_help);
@@ -23459,6 +23571,14 @@ RZ_IPI void rzshell_cmddescs_init(RzCore *core) {
 
 	RzCmdDesc *analysis_global_variable_xrefs_cd = rz_cmd_desc_argv_state_new(core->rcmd, avg_cd, "avgx", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON | RZ_OUTPUT_MODE_QUIET, rz_analysis_global_variable_xrefs_handler, &analysis_global_variable_xrefs_help);
 	rz_warn_if_fail(analysis_global_variable_xrefs_cd);
+
+	RzCmdDesc *avgc_cd = rz_cmd_desc_group_state_new(core->rcmd, avg_cd, "avgc", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_global_variable_constraints_handler, &analysis_global_variable_constraints_help, &avgc_help);
+	rz_warn_if_fail(avgc_cd);
+	RzCmdDesc *analysis_global_variable_constraints_set_cd = rz_cmd_desc_argv_new(core->rcmd, avgc_cd, "avgcs", rz_analysis_global_variable_constraints_set_handler, &analysis_global_variable_constraints_set_help);
+	rz_warn_if_fail(analysis_global_variable_constraints_set_cd);
+
+	RzCmdDesc *analysis_global_variable_constraints_del_cd = rz_cmd_desc_argv_new(core->rcmd, avgc_cd, "avgc-", rz_analysis_global_variable_constraints_del_handler, &analysis_global_variable_constraints_del_help);
+	rz_warn_if_fail(analysis_global_variable_constraints_del_cd);
 
 	RzCmdDesc *analysis_print_rtti_cd = rz_cmd_desc_argv_modes_new(core->rcmd, av_cd, "avr", RZ_OUTPUT_MODE_STANDARD | RZ_OUTPUT_MODE_JSON, rz_analysis_print_rtti_handler, &analysis_print_rtti_help);
 	rz_warn_if_fail(analysis_print_rtti_cd);

--- a/librz/core/cmd_descs/cmd_descs.h
+++ b/librz/core/cmd_descs/cmd_descs.h
@@ -472,6 +472,12 @@ RZ_IPI RzCmdStatus rz_analysis_function_vars_reads_handler(RzCore *core, int arg
 RZ_IPI RzCmdStatus rz_analysis_function_vars_writes_handler(RzCore *core, int argc, const char **argv);
 // "afvt"
 RZ_IPI RzCmdStatus rz_analysis_function_vars_type_handler(RzCore *core, int argc, const char **argv);
+// "afvc"
+RZ_IPI RzCmdStatus rz_analysis_function_vars_constraints_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+// "afvcs"
+RZ_IPI RzCmdStatus rz_analysis_function_vars_constraints_set_handler(RzCore *core, int argc, const char **argv);
+// "afvc-"
+RZ_IPI RzCmdStatus rz_analysis_function_vars_constraints_del_handler(RzCore *core, int argc, const char **argv);
 // "afvx"
 RZ_IPI RzCmdStatus rz_analysis_function_vars_xrefs_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 // "afvxa"
@@ -729,6 +735,12 @@ RZ_IPI RzCmdStatus rz_analysis_global_variable_print_handler(RzCore *core, int a
 RZ_IPI RzCmdStatus rz_analysis_global_variable_retype_handler(RzCore *core, int argc, const char **argv);
 // "avgx"
 RZ_IPI RzCmdStatus rz_analysis_global_variable_xrefs_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+// "avgc"
+RZ_IPI RzCmdStatus rz_analysis_global_variable_constraints_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state);
+// "avgcs"
+RZ_IPI RzCmdStatus rz_analysis_global_variable_constraints_set_handler(RzCore *core, int argc, const char **argv);
+// "avgc-"
+RZ_IPI RzCmdStatus rz_analysis_global_variable_constraints_del_handler(RzCore *core, int argc, const char **argv);
 // "avr"
 RZ_IPI RzCmdStatus rz_analysis_print_rtti_handler(RzCore *core, int argc, const char **argv, RzOutputMode mode);
 // "avra"

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1607,7 +1607,8 @@ RZ_API void rz_analysis_var_set_access(RzAnalysisVar *var, const char *reg, ut64
 RZ_API void rz_analysis_var_remove_access_at(RzAnalysisVar *var, ut64 address);
 RZ_API void rz_analysis_var_clear_accesses(RzAnalysisVar *var);
 RZ_API void rz_analysis_var_add_constraint(RzAnalysisVar *var, RZ_BORROW RzTypeConstraint *constraint);
-RZ_API char *rz_analysis_var_get_constraints_readable(RzAnalysisVar *var);
+RZ_API void rz_analysis_var_clear_constraints(RZ_NONNULL RzAnalysisVar *var);
+RZ_API char *rz_analysis_var_get_constraints_readable(RZ_NONNULL RzAnalysisVar *var);
 
 RZ_API int rz_analysis_var_storage_cmp(
 	RZ_NONNULL const RzAnalysisVarStorage *a,
@@ -1692,8 +1693,9 @@ RZ_API RZ_BORROW RzAnalysisVarGlobal *rz_analysis_var_global_get_byaddr_in(RzAna
 RZ_API RZ_OWN RzList /*<RzAnalysisVarGlobal *>*/ *rz_analysis_var_global_get_all(RzAnalysis *analysis);
 RZ_API bool rz_analysis_var_global_rename(RzAnalysis *analysis, RZ_NONNULL const char *old_name, RZ_NONNULL const char *newname);
 RZ_API void rz_analysis_var_global_set_type(RzAnalysisVarGlobal *glob, RZ_NONNULL RZ_BORROW RzType *type);
-RZ_API void rz_analysis_var_global_add_constraint(RzAnalysisVarGlobal *glob, RzTypeConstraint *constraint);
-RZ_API RZ_OWN char *rz_analysis_var_global_get_constraints_readable(RzAnalysisVarGlobal *glob);
+RZ_API void rz_analysis_var_global_add_constraint(RZ_NONNULL RzAnalysisVarGlobal *glob, RZ_NONNULL RzTypeConstraint *constraint);
+RZ_API void rz_analysis_var_global_clear_constraints(RZ_NONNULL RzAnalysisVarGlobal *glob);
+RZ_API RZ_OWN char *rz_analysis_var_global_get_constraints_readable(RZ_NONNULL RzAnalysisVarGlobal *glob);
 RZ_API RZ_OWN RzList /*<RzAnalysisXRef *>*/ *rz_analysis_var_global_xrefs(RzAnalysis *analysis, RZ_NONNULL const RzAnalysisVarGlobal *glob);
 RZ_API RZ_OWN RzList /*<RzTypePathTuple *>*/ *rz_analysis_type_paths_by_address(RzAnalysis *analysis, ut64 addr);
 

--- a/librz/include/rz_type.h
+++ b/librz/include/rz_type.h
@@ -478,6 +478,9 @@ RZ_API bool rz_serialize_callables_load(RZ_NONNULL Sdb *db, RZ_NONNULL RzTypeDB 
 
 // Constrained Type
 RZ_API RZ_BORROW const char *rz_type_cond_tostring(RzTypeCond cc);
+RZ_API RzTypeCond rz_type_cond_fromstring(RZ_NONNULL const char *s);
+RZ_API RZ_OWN char *rz_type_interval_constraints_as_string(RZ_NONNULL const RzVector /*<RzTypeConstraint>*/ *constraints);
+RZ_API bool rz_type_interval_constraints_from_string(RZ_NONNULL const char *str, RZ_NONNULL RzVector /*<RzTypeConstraint>*/ *constraints);
 RZ_API RzTypeCond rz_type_cond_invert(RzTypeCond cond);
 RZ_API bool rz_type_cond_eval(RzTypeCond cond, st64 arg0, st64 arg1);
 RZ_API bool rz_type_cond_eval_single(RzTypeCond cond, st64 arg0);

--- a/librz/type/helpers.c
+++ b/librz/type/helpers.c
@@ -510,6 +510,247 @@ RZ_API RZ_BORROW const char *rz_type_cond_tostring(RzTypeCond cc) {
 }
 
 /**
+ * \brief Parse a type condition from its string form
+ *
+ * Accepts both the short mnemonic form returned by \ref rz_type_cond_tostring
+ * (e.g. "eq", "ne", "ge", "gt", "le", "lt") and the usual comparison symbols
+ * ("==", "!=", ">=", ">", "<=", "<").
+ *
+ * \param s the string to parse
+ * \return the parsed RzTypeCond, or RZ_TYPE_COND_AL when \p s is not recognized
+ */
+RZ_API RzTypeCond rz_type_cond_fromstring(RZ_NONNULL const char *s) {
+	rz_return_val_if_fail(s, RZ_TYPE_COND_AL);
+	if (RZ_STR_EQ(s, "eq") || RZ_STR_EQ(s, "==") || RZ_STR_EQ(s, "=")) {
+		return RZ_TYPE_COND_EQ;
+	} else if (RZ_STR_EQ(s, "ne") || RZ_STR_EQ(s, "!=")) {
+		return RZ_TYPE_COND_NE;
+	} else if (RZ_STR_EQ(s, "ge") || RZ_STR_EQ(s, ">=")) {
+		return RZ_TYPE_COND_GE;
+	} else if (RZ_STR_EQ(s, "gt") || RZ_STR_EQ(s, ">")) {
+		return RZ_TYPE_COND_GT;
+	} else if (RZ_STR_EQ(s, "le") || RZ_STR_EQ(s, "<=")) {
+		return RZ_TYPE_COND_LE;
+	} else if (RZ_STR_EQ(s, "lt") || RZ_STR_EQ(s, "<")) {
+		return RZ_TYPE_COND_LT;
+	}
+	return RZ_TYPE_COND_AL;
+}
+
+/**
+ * \brief A single bounded interval being assembled from a list of constraints
+ *
+ * Each side is optional: an interval may have only a lower bound (e.g. "> 0"),
+ * only an upper bound (e.g. "<= 9") or both. The \p incl flags record whether
+ * the respective bound is inclusive (>=, <=) or exclusive (>, <).
+ */
+typedef struct {
+	bool has_low; ///< a lower bound (>, >=) was seen
+	bool low_incl; ///< the lower bound is inclusive (>=)
+	ut64 low; ///< the lower bound value
+	bool has_high; ///< an upper bound (<, <=) was seen
+	bool high_incl; ///< the upper bound is inclusive (<=)
+	ut64 high; ///< the upper bound value
+} TypeInterval;
+
+/**
+ * \brief Append the textual form of a single interval to \p sb
+ *
+ * An empty interval is one that no value can satisfy (the lower bound is above
+ * the upper bound, or equal to it while at least one side is exclusive). The
+ * degenerate interval [x, x] (both bounds inclusive and equal) is rendered as
+ * the equality "== x", matching \ref RZ_TYPE_COND_EQ.
+ *
+ * \param sb the string buffer to append to
+ * \param iv the interval to render
+ * \param first set to false once the first term has been written; used to
+ *        insert the " || " separator between alternative intervals
+ * \return false if the interval is empty and thus cannot be represented
+ */
+static bool type_interval_append(RzStrBuf *sb, RZ_NONNULL const TypeInterval *iv, bool *first) {
+	if (!iv->has_low && !iv->has_high) {
+		return true; // nothing pending
+	}
+	if (iv->has_low && iv->has_high) {
+		if (iv->low > iv->high) {
+			return false; // empty interval
+		}
+		if (iv->low == iv->high && !(iv->low_incl && iv->high_incl)) {
+			return false; // empty interval, e.g. (x, x] or [x, x)
+		}
+	}
+	if (!*first) {
+		rz_strbuf_append(sb, " || ");
+	}
+	*first = false;
+	if (iv->has_low && iv->has_high && iv->low == iv->high) {
+		// a single allowed value, [x, x] is the same as == x
+		rz_strbuf_appendf(sb, "== 0x%" PFMT64x, iv->low);
+		return true;
+	}
+	if (iv->has_low) {
+		rz_strbuf_appendf(sb, "%s 0x%" PFMT64x, iv->low_incl ? ">=" : ">", iv->low);
+	}
+	if (iv->has_high) {
+		if (iv->has_low) {
+			rz_strbuf_append(sb, " && ");
+		}
+		rz_strbuf_appendf(sb, "%s 0x%" PFMT64x, iv->high_incl ? "<=" : "<", iv->high);
+	}
+	return true;
+}
+
+/**
+ * \brief Render a list of interval constraints into a human-readable string
+ *
+ * The constraints are interpreted as a disjunction (joined by "||") of bounded
+ * intervals, where each interval is a conjunction (joined by "&&") of a lower
+ * bound (>, >=) and/or an upper bound (<, <=). This matches the shape produced
+ * by the variable type inference for range checks such as "x > 0 && x <= 9" or
+ * several alternative ranges. An exact \ref RZ_TYPE_COND_EQ constraint, or an
+ * interval that collapses to a single value [x, x], is rendered as "== x".
+ *
+ * Constraints that do not form consistent intervals (for example a variable
+ * that is compared against many unrelated constants, as in a switch table, or
+ * an interval whose lower bound is not below its upper bound) cannot be
+ * represented as a meaningful range. In that case, and when there is no
+ * interval-style constraint at all, NULL is returned so that callers do not
+ * display misleading information.
+ *
+ * \param constraints vector of \ref RzTypeConstraint
+ * \return an owned string, or NULL when there is nothing meaningful to show
+ */
+RZ_API RZ_OWN char *rz_type_interval_constraints_as_string(RZ_NONNULL const RzVector /*<RzTypeConstraint>*/ *constraints) {
+	rz_return_val_if_fail(constraints, NULL);
+	RzStrBuf sb = { 0 };
+	bool first = true; // whether the first term still has to be written
+	TypeInterval cur = { 0 }; // the interval currently being assembled
+	RzTypeConstraint *c;
+	rz_vector_foreach (constraints, c) {
+		bool is_lower, incl;
+		switch (c->cond) {
+		case RZ_TYPE_COND_GE: is_lower = true, incl = true; break;
+		case RZ_TYPE_COND_GT: is_lower = true, incl = false; break;
+		case RZ_TYPE_COND_LE: is_lower = false, incl = true; break;
+		case RZ_TYPE_COND_LT: is_lower = false, incl = false; break;
+		case RZ_TYPE_COND_EQ:
+			// an exact value is its own complete term: flush the pending
+			// interval and emit the equality as a degenerate interval [x, x]
+			if (!type_interval_append(&sb, &cur, &first)) {
+				goto invalid;
+			}
+			cur = (TypeInterval){ .has_low = true, .low_incl = true, .low = c->val, .has_high = true, .high_incl = true, .high = c->val };
+			if (!type_interval_append(&sb, &cur, &first)) {
+				goto invalid;
+			}
+			cur = (TypeInterval){ 0 };
+			continue;
+		default: continue; // not an interval bound, ignore
+		}
+		// A second bound on the same side cannot extend the current interval.
+		// If the interval is already complete it opens a new alternative,
+		// otherwise the constraints are inconsistent.
+		bool *have_side = is_lower ? &cur.has_low : &cur.has_high;
+		if (*have_side) {
+			if (cur.has_low && cur.has_high) {
+				if (!type_interval_append(&sb, &cur, &first)) {
+					goto invalid;
+				}
+				cur = (TypeInterval){ 0 };
+			} else {
+				goto invalid;
+			}
+		}
+		if (is_lower) {
+			cur.has_low = true;
+			cur.low_incl = incl;
+			cur.low = c->val;
+		} else {
+			cur.has_high = true;
+			cur.high_incl = incl;
+			cur.high = c->val;
+		}
+	}
+	if (!type_interval_append(&sb, &cur, &first)) {
+		goto invalid;
+	}
+	if (first) {
+		// no interval-style constraint produced any output
+		rz_strbuf_fini(&sb);
+		return NULL;
+	}
+	return rz_strbuf_drain_nofree(&sb);
+invalid:
+	rz_strbuf_fini(&sb);
+	return NULL;
+}
+
+/**
+ * \brief Parse a textual list of interval constraints into \p constraints
+ *
+ * This is the inverse of \ref rz_type_interval_constraints_as_string. The input
+ * is a comma-separated list of comparisons, each one of the operators ==, !=,
+ * <, <=, >, >= (in symbol form like ">=10" or mnemonic form like "ge 10", as
+ * accepted by \ref rz_type_cond_fromstring) followed by a value. Values are
+ * evaluated with \ref rz_num_math without a number environment, so they must be
+ * literals or constant expressions. Any other operator makes the whole parse
+ * fail. Note that while "== x" round-trips through
+ * \ref rz_type_interval_constraints_as_string as the degenerate interval
+ * [x, x], the inequality "!= x" is stored but is not part of the interval
+ * rendering, as it does not describe a range.
+ *
+ * \param str the textual constraints, e.g. ">0,<=9", "gt 0, le 9" or "== 5"
+ * \param constraints an initialized vector of \ref RzTypeConstraint to fill
+ * \return true on success, false on a parse error (vector may be partially filled)
+ */
+RZ_API bool rz_type_interval_constraints_from_string(RZ_NONNULL const char *str, RZ_NONNULL RzVector /*<RzTypeConstraint>*/ *constraints) {
+	rz_return_val_if_fail(str && constraints, false);
+	// Group 1 is the operator (a run of <>!= symbols or a mnemonic such as
+	// "ge"), group 2 is the value. rz_type_cond_fromstring() then maps the
+	// operator and rejects anything that is not a comparison condition.
+	RzRegex *re = rz_regex_new("^\\s*([<>!=]+|[a-z]+)\\s*(.+?)\\s*$", RZ_REGEX_DEFAULT, RZ_REGEX_DEFAULT, NULL);
+	if (!re) {
+		return false;
+	}
+	bool ok = true;
+	RzList /*<char *>*/ *tokens = rz_str_split_duplist(str, ",", true);
+	RzListIter *it;
+	char *tok;
+	rz_list_foreach (tokens, it, tok) {
+		if (RZ_STR_ISEMPTY(tok)) {
+			continue;
+		}
+		RzPVector /*<RzRegexMatch *>*/ *matches = rz_regex_match_first(re, tok, RZ_REGEX_ZERO_TERMINATED, 0, RZ_REGEX_DEFAULT);
+		RzRegexMatch *op_match = rz_pvector_at(matches, 1);
+		RzRegexMatch *val_match = rz_pvector_at(matches, 2);
+		char *op = op_match ? rz_str_ndup(tok + op_match->start, op_match->len) : NULL;
+		char *valstr = val_match ? rz_str_ndup(tok + val_match->start, val_match->len) : NULL;
+		RzTypeCond cond = op ? rz_type_cond_fromstring(op) : RZ_TYPE_COND_AL;
+		// Accept the interval bounds (<, <=, >, >=) together with the equality
+		// and inequality conditions (==, !=). Anything else maps to
+		// RZ_TYPE_COND_AL via rz_type_cond_fromstring() and is rejected.
+		if (cond != RZ_TYPE_COND_LE && cond != RZ_TYPE_COND_LT &&
+			cond != RZ_TYPE_COND_GE && cond != RZ_TYPE_COND_GT &&
+			cond != RZ_TYPE_COND_EQ && cond != RZ_TYPE_COND_NE) {
+			RZ_LOG_ERROR("Invalid constraint \"%s\" (expected ==, !=, <, <=, >, >= followed by a value)\n", tok);
+			ok = false;
+		} else {
+			RzTypeConstraint c = { .cond = cond, .val = rz_num_math(NULL, valstr) };
+			rz_vector_push(constraints, &c);
+		}
+		free(op);
+		free(valstr);
+		rz_pvector_free(matches);
+		if (!ok) {
+			break;
+		}
+	}
+	rz_list_free(tokens);
+	rz_regex_free(re);
+	return ok;
+}
+
+/**
  * \brief return the inverted condition
  *
  * \param cond RzTypeCond

--- a/test/db/cmd/cmd_afv
+++ b/test/db/cmd/cmd_afv
@@ -60,3 +60,44 @@ EXPECT=<<EOF
 | 0x0000115d      mov   rbp, rsp
 EOF
 RUN
+
+NAME=afvc read constraints and JSON (#315)
+FILE=bins/elf/constr_type
+CMDS=<<EOF
+e analysis.types.constraint=true
+aaa
+s sym.range_small
+afvc
+afvc var_1ch
+afvcj var_1ch
+s sym.single_cond
+afvc var_ch
+EOF
+EXPECT=<<EOF
+var_1ch: > 0x0 && <= 0x9
+> 0x0 && <= 0x9
+[{"name":"var_1ch","constraints":"> 0x0 && <= 0x9","conditions":[{"cond":"gt","value":0},{"cond":"le","value":9}]}]
+> 0xa
+EOF
+RUN
+
+NAME=afvcs set and afvc- clear constraints (#315)
+FILE=bins/elf/constr_type
+CMDS=<<EOF
+e analysis.types.constraint=true
+aaa
+s sym.range_small
+afvcs var_1ch ">5,<=20"
+afvc var_1ch
+afvcs var_1ch "gt 1,le 10"
+afvc var_1ch
+afvc- var_1ch
+afvc var_1ch
+echo done
+EOF
+EXPECT=<<EOF
+> 0x5 && <= 0x14
+> 0x1 && <= 0xa
+done
+EOF
+RUN

--- a/test/db/cmd/cmd_avg
+++ b/test/db/cmd/cmd_avg
@@ -167,3 +167,26 @@ EXPECT=<<EOF
 0x00000030 : char = [ 'd', 'g', 'h', 'd', 'f' ]
 EOF
 RUN
+
+NAME=avgc set, read and clear global variable constraints (#315)
+FILE==
+CMDS=<<EOF
+avga foo int @ 0x100
+avga bar char @ 0x1000
+avgcs foo ">0,<=9"
+avgc foo
+avgcs bar "ge 5,lt 100"
+avgcj bar
+avgc
+avgc- foo
+avgc foo
+echo cleared
+EOF
+EXPECT=<<EOF
+> 0x0 && <= 0x9
+[{"name":"bar","constraints":">= 0x5 && < 0x64","conditions":[{"cond":"ge","value":5},{"cond":"lt","value":100}]}]
+foo: > 0x0 && <= 0x9
+bar: >= 0x5 && < 0x64
+cleared
+EOF
+RUN

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -590,7 +590,7 @@ fn2
 arg void *q origin=DWARF @ rbp-8
 var float *arg1 @ rdi
 main
-var unsigned long long var_18h @ stack - 0x18
+var unsigned long long var_18h  { < 0x400} @ stack - 0x18
 var int64_t var_ch @ stack - 0xc
 EOF
 RUN

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1921,7 +1921,7 @@ afvl~var_30h
 EOF
 EXPECT=<<EOF
 var int var_3ch @ stack - 0x3c
-var int64_t var_38h @ stack - 0x38
+var int64_t var_38h  { > 0x0} @ stack - 0x38
 var unsigned long var_30h @ stack - 0x30
 EOF
 RUN
@@ -1973,7 +1973,7 @@ var char **var_14e8h @ stack - 0x14e8
 var int var_14dch @ stack - 0x14dc
 var int *wstatus @ stack - 0x14d4
 var int64_t var_14cch @ stack - 0x14cc
-var int64_t var_14c8h @ stack - 0x14c8
+var int64_t var_14c8h  { <= 0x1} @ stack - 0x14c8
 var int64_t var_14c4h @ stack - 0x14c4
 var unsigned long pid @ stack - 0x14c0
 var unsigned long var_14bch @ stack - 0x14bc
@@ -1994,7 +1994,7 @@ arg int argc @ rdi
 arg char **argv @ rsi
 var char *str @ stack - 0xb8
 var int_fast64_t var_ach @ stack - 0xac
-var int64_t var_a8h @ stack - 0xa8
+var int64_t var_a8h  { <= 0x0} @ stack - 0xa8
 var unsigned long var_a4h @ stack - 0xa4
 var int var_a0h @ stack - 0xa0
 var int var_9ch @ stack - 0x9c
@@ -2070,7 +2070,7 @@ afvl
 EOF
 EXPECT=<<EOF
 var int64_t var_2dh @ stack - 0x2d
-var int64_t var_2ch @ stack - 0x2c
+var int64_t var_2ch  { > 0x9} @ stack - 0x2c
 var unsigned int var_28h @ stack - 0x28
 var int64_t var_24h @ stack - 0x24
 var const char *var_20h @ stack - 0x20


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

We had type constraints in the code for years. But the ability to set and see them was limited and unimplemented. Consolidate the code and expose them for local `afv` and global `agv` variables - see new commands.
They also now picked up by the analysis.

**Test plan**

CI is green

**Closing issues**

Closes #315 
