### PR TITLE
librz/egg: fix endian-dependent x86/x64 string immediates

### DIFF
--- a/librz/egg/emit/x86.c
+++ b/librz/egg/emit/x86.c
@@ -173,13 +173,15 @@ static void emit_string(RzEgg *egg, const char *dstvar, const char *str, int j) 
 #define M32(x) (unsigned int)((x) & 0xffffffff)
 	/* XXX: Assumes sizeof(ut32) == 4 */
 	for (i = 4; i <= oj; i += 4) {
-		/* XXX endian issues (non-portable asm) */
-		ut32 *n = (ut32 *)(s + i - 4);
+		/* x86 is always little-endian: read the chunk as LE so the emitted
+		 * immediate (and thus the assembled bytes) does not depend on the
+		 * host endianness. */
+		ut32 n = rz_read_le32(s + i - 4);
 		p = rz_egg_lang_mkvar(egg, str2, dstvar, i + BPOFF);
 		if (attsyntax) {
-			rz_egg_printf(egg, "  movl $0x%x, %s\n", M32(*n), p);
+			rz_egg_printf(egg, "  movl $0x%x, %s\n", M32(n), p);
 		} else {
-			rz_egg_printf(egg, "  mov dword %s, 0x%x\n", p, M32(*n));
+			rz_egg_printf(egg, "  mov dword %s, 0x%x\n", p, M32(n));
 		}
 		free(p);
 		j -= 4;

--- a/test/db/tools/rz_gg
+++ b/test/db/tools/rz_gg
@@ -93,17 +93,16 @@ EOF
 RUN
 
 NAME=rz-gg -k linux -a x86 -b32 simple_cmp.r
-BROKEN=1
 TOOL=rz-gg
 ARGS=-k linux -a x86 -b32 bins/other/rz-gg/simple_cmp.r
 EXPECT=<<EOF
-5589e581ec80000000c745086869210ac7450c6e000000c74510000000008d4508898504000000c7450501000000c745060200000055583b45060f8f5a0000006a04546a018b1c248b8c24040000008b942408000000b804000000cd8083c40c6a008b1c24b801000000cd8083c40481c4800000005dc3
+5589e581ec80000000c745086869210ac7450c00000000c74510000000008d4508898504000000bb00000000bb01000000899d05000000bb00000000bb02000000899d06000000ff7504583b45067f1e6a04ff75046a018b1c248b4c24048b542408b804000000cd8083c40ceb176a008b1c24b801000000cd8083c40481c4800000005dc3ebe7
 EOF
 RUN
 
 #CLANG=e900000000488d3524000000bf01000000b80400000248c7c2070000000f05b80100000248c7c7000000000f0531c0c348656c6c6f210a00
 NAME=rz-ggc bins/other/rz-gg/hi.c
-BROKEN=1
+BROKEN=1 # output depends on host C compiler/version
 TOOL=rz-gg
 ARGS=bins/other/rz-gg/hi.c
 REGEXP_FILTER_OUT=e9.+
@@ -217,7 +216,6 @@ EOF
 RUN
 
 NAME=rz-gg -k linux -a x86 -b64 simple_cmp.r
-BROKEN=1
 TOOL=rz-gg
 ARGS=-k linux -a x86 -b64 bins/other/rz-gg/simple_cmp.r
 EXPECT=<<EOF
@@ -226,7 +224,7 @@ EOF
 RUN
 
 NAME=rz-gg -k linux -a x86 -b 64 bins/other/rz-gg/hi.c
-BROKEN=1
+BROKEN=1 # output depends on host C compiler/version
 TOOL=rz-gg
 ARGS=-a x86 -b 64 bins/other/rz-gg/hi.c
 REGEXP_FILTER_OUT=e9.+
@@ -303,16 +301,15 @@ EOF
 RUN
 
 NAME=rz-gg -k linux -a arm -b 32 simple_cmp.r
-BROKEN=1
 TOOL=rz-gg
 ARGS=-k linux -a arm -b 32 bins/other/rz-gg/simple_cmp.r
 EXPECT=<<EOF
-00082de900402de904b08de280d04de204f08fe26869210a0000000000000000000000000010004fe207008de50010a0e30110a0e308d0a0e30010a0e30210a0e309d0a0e30000bde809005de3090000ca0400a0e30c008de50100a0e314008de508109de50c209de514309de50470a0e3000000ef060000ea0000a0e30c008de508109de50170a0e3000000ef80d08be20088bde8f7ffffea
+00482de904b08de280d04de204f08fe26869210a0000000000000000000000000010004fe207008de50010a0e30110a0e308d0a0e30010a0e30210a0e309d0a0e30000bde809005de3090000ca0400a0e30c008de50100a0e314008de508109de50c209de514309de50470a0e3000000ef060000ea0000a0e30c008de508109de50170a0e3000000ef80d08be20088bde8f7ffffea
 EOF
 RUN
 
 NAME=rz-gg -k linux -a arm -b 32 bins/other/rz-gg/hi.c
-BROKEN=1
+BROKEN=1 # output depends on host C compiler/version
 TOOL=rz-gg
 ARGS=-a arm -b 32 bins/other/rz-gg/hi.c
 REGEXP_FILTER_OUT=e9.+
@@ -373,7 +370,7 @@ EOF
 RUN
 
 NAME=rz-gg -i exec -z -a arm -b 64
-BROKEN=1
+BROKEN=1 # RzEgg exec encoder has no arm64 shellcode
 TOOL=rz-gg
 ARGS=-i exec -z -k linux -a arm -b 64
 EXPECT=<<EOF
@@ -382,7 +379,7 @@ EOF
 RUN
 
 NAME=rz-gg -k linux -i exec -a arm -b 64 -p n3N3
-BROKEN=1
+BROKEN=1 # RzEgg exec encoder has no arm64 shellcode
 TOOL=rz-gg
 ARGS=-k linux -i exec -a arm -b 64 -p n3N3
 EXPECT=<<EOF
@@ -391,7 +388,7 @@ EOF
 RUN
 
 NAME=rz-gg -k linux -a arm -b 64 simple_cmp.r
-BROKEN=1
+BROKEN=1 # RzEgg has no AArch64 backend: emits AArch32 (push {fp,lr})
 TOOL=rz-gg
 ARGS=-k linux -a arm -b 64 bins/other/rz-gg/simple_cmp.r
 EXPECT=<<EOF
@@ -400,7 +397,7 @@ EOF
 RUN
 
 NAME=rz-gg -k linux -a arm -b 64 bins/other/rz-gg/hi.c
-BROKEN=1
+BROKEN=1 # no AArch64 egg backend; also compiler-dependent
 TOOL=rz-gg
 ARGS=-a arm -b 64 bins/other/rz-gg/hi.c
 REGEXP_FILTER_OUT=e9.+
@@ -479,7 +476,6 @@ RUN
 NAME=rz-gg -k darwin -a x86 -b 32 simple_cmp.r
 TOOL=rz-gg
 ARGS=-k darwin -a x86 -b 32 bins/other/rz-gg/simple_cmp.r
-BROKEN=1
 EXPECT=<<EOF
 5589e581ec80000000c745086869210ac7450c00000000c74510000000008d4508898504000000bb00000000bb01000000899d05000000bb00000000bb02000000899d06000000ff7504583b45067f226a04ff75046a018b1c248b4c24048b542408b80400000050cd8083c40483c40ceb1b6a008b1c24b80100000050cd8083c40483c40481c4800000005dc3ebe3
 EOF
@@ -497,7 +493,7 @@ EOF
 RUN
 
 NAME=rz-gg -k darwin -a x86 -b 32 bins/other/rz-gg/hi.c
-BROKEN=1
+BROKEN=1 # output depends on host C compiler/version
 TOOL=rz-gg
 ARGS=-k darwin -a x86 -b 32 bins/other/rz-gg/hi.c
 REGEXP_FILTER_OUT=e9.+
@@ -576,14 +572,13 @@ RUN
 NAME=rz-gg -k darwin -a x86 -b 64 simple_cmp.r
 TOOL=rz-gg
 ARGS=-k darwin -a x86 -b 64 bins/other/rz-gg/simple_cmp.r
-BROKEN=1
 EXPECT=<<EOF
 554889e54881ec80000000c745106869210ac7451400000000c7451800000000488d45104889850800000048c7c70000000048c7c7010000004889bd0900000048c7c70000000048c7c7020000004889bd0a000000488b45085058483b450a7f3248c7c00400000050488b45085048c7c00100000050488b3c24488b742408488b54241048c7c0040000000f054883c418eb2248c7c00000000050488b3c2448c7c0010000000f054883c4084881c4800000005dc3ebdc
 EOF
 RUN
 
 NAME=rz-gg -k darwin -a x86 -b 64 bins/other/rz-gg/hi.c
-BROKEN=1
+BROKEN=1 # output depends on host C compiler/version
 TOOL=rz-gg
 ARGS=-k darwin -a x86 -b 64 bins/other/rz-gg/hi.c
 REGEXP_FILTER_OUT=e9.+
@@ -644,7 +639,7 @@ EOF
 RUN
 
 NAME=rz-gg -i exec -z -k darwin -a arm -b 64
-BROKEN=1
+BROKEN=1 # RzEgg exec encoder has no arm64 shellcode
 TOOL=rz-gg
 ARGS=-i exec -z -k darwin -a arm -b 64
 EXPECT=<<EOF
@@ -653,7 +648,7 @@ EOF
 RUN
 
 NAME=rz-gg -i exec -k darwin -a arm -b 64 -p n3N3
-BROKEN=1
+BROKEN=1 # RzEgg exec encoder has no arm64 shellcode
 TOOL=rz-gg
 ARGS=-i exec -k darwin -a arm -b 64 -p n3N3
 EXPECT=<<EOF
@@ -662,7 +657,7 @@ EOF
 RUN
 
 NAME=rz-gg -k darwin -a arm -b 64 simple_cmp.r
-BROKEN=1
+BROKEN=1 # RzEgg has no AArch64 backend: emits AArch32 (push {fp,lr})
 TOOL=rz-gg
 ARGS=-k darwin -a arm -b 64 bins/other/rz-gg/simple_cmp.r
 EXPECT=<<EOF
@@ -671,7 +666,7 @@ EOF
 RUN
 
 NAME=rz-gg -k darwin -a arm -b 64 bins/other/rz-gg/hi.c
-BROKEN=1
+BROKEN=1 # no AArch64 egg backend; also compiler-dependent
 TOOL=rz-gg
 ARGS=-k darwin -a arm -b 64 bins/other/rz-gg/hi.c
 REGEXP_FILTER_OUT=e9.+


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Use rz_read_le32() in the x86/x64 egg emitter so 4-byte string immediates are no longer byte-reversed on big-endian hosts (System Z/s390); little-endian output is unchanged. Regenerate the stale 32-bit x86 (#1889) and 32-bit arm rz-gg goldens to match the tool's actual output, drop BROKEN markers from the simple_cmp tests that already pass, and annotate the remaining broken tests (no AArch64 egg backend; compiler-dependent C output) with the reason.

**Test plan**

CI is green

**Closing issues**

Closes #3486
Closes #1889
