### PR TITLE
fix dbg for spaced filepaths

### DIFF
--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -1682,8 +1682,8 @@ RZ_API void rz_core_io_file_open(RZ_NONNULL RzCore *core, int fd) {
 		return;
 	}
 
-	// Escape spaces so that o's argv parse will detect the path properly
-	char *file = rz_str_path_escape(bf->file);
+	// keep path literal, dup as bf is freed
+	char *file = rz_str_dup(bf->file);
 	// Backup the baddr and sections that were already rebased to
 	// revert the rebase after the debug session is closed
 	ut64 orig_baddr = core->bin->cur->o->baddr_shift;

--- a/librz/io/p/io_debug.c
+++ b/librz/io/p/io_debug.c
@@ -190,7 +190,7 @@ static RzRunProfile *_get_run_profile(RzIO *io, int bits, char **argv) {
 		return NULL;
 	}
 	for (i = 0; argv[i]; i++) {
-		//exec needs literal path
+		// exec needs literal path
 		rz_str_arg_unescape(argv[i]);
 		rp->_args[i] = argv[i];
 	}

--- a/librz/io/p/io_debug.c
+++ b/librz/io/p/io_debug.c
@@ -190,6 +190,8 @@ static RzRunProfile *_get_run_profile(RzIO *io, int bits, char **argv) {
 		return NULL;
 	}
 	for (i = 0; argv[i]; i++) {
+		//exec needs literal path
+		rz_str_arg_unescape(argv[i]);
 		rp->_args[i] = argv[i];
 	}
 	rp->_args[i] = NULL;

--- a/test/db/archos/linux-x64/dbg_oo
+++ b/test/db/archos/linux-x64/dbg_oo
@@ -127,3 +127,22 @@ Process with PID
 helloworld-gcc reopened in read-write mode
 EOF
 RUN
+
+NAME=ood/doc with spaced path
+FILE=bins/elf/analysis/x86-helloworld-gcc
+CMDS=<<EOF
+cp `ol.t:uri:quiet` "space helloworld"
+!chmod +x "space helloworld" #as cp drops it
+o--
+o "space helloworld"
+ood > $_
+doc > $_
+ood > $_
+dc
+o--
+rm "space helloworld"
+EOF
+EXPECT=<<EOF
+Hello world!
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

after `rz_str_argv()` splits the cmd line, each arg still has its shell escaping (`a b` becomes `a\ b`), used by the run profile passed to `exec`, so dbg tried to launch path with \\, which will ofc error. i just called `rz_str_arg_unescape()` on each arg so the program and its args are passed as is, to `exec`.

also, the filepath went with `rz_str_path_escape()` before going to `rz_core_file_open()` / `rz_core_bin_load()`, which open it as is, (not through shell). that extra escaping causes `Cannot reopen file: 'dbg:///tmp/rz\ ax\ tmp'`. now kept the path literal w/ `rz_str_dup(bf->file)` (path is dupl as `bf`/`bf->file` is freed during reopen).

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

Before: refer to [issue comment](https://github.com/rizinorg/rizin/issues/4881#issuecomment-4642735101)

After:

rizin

<img width="716" height="632" alt="Screenshot_1" src="https://github.com/user-attachments/assets/53bb15df-368c-404d-9d68-41378dfbf281" />


and hence cutter as well:

https://github.com/user-attachments/assets/519c87e5-9f80-472c-b2ec-066caa33c6bc

- added test as well (probably unneeded?)

**Closing issues**

closes #4881
