### PR TITLE
subprojects/gdb: fix RLE decoding

### DIFF
--- a/subprojects/rzgdb/src/packet.c
+++ b/subprojects/rzgdb/src/packet.c
@@ -73,9 +73,15 @@ static int unpack(libgdbr_t *g, struct parse_ctx *ctx, int len) {
 		}
 		ctx->sum += cur;
 		if (ctx->flags & ESC) {
+			first = false;
 			if (!append(g, cur ^ 0x20)) {
 				return -1;
 			}
+			// RLE in the GDB remote protocol operates on the raw
+			// (post-escape) byte stream, so a following '*' repeat must
+			// duplicate this raw byte rather than the previously appended
+			// literal byte. Record it as the last byte.
+			ctx->last = cur;
 			ctx->flags &= ~ESC;
 			continue;
 		}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Fix RLE decoding issue surfaced in https://github.com/rizinorg/rizin/issues/3975

**Test plan**

None (it's only part of the fix)

**Closing issues**

Partially addresses https://github.com/rizinorg/rizin/issues/3975
