### PR TITLE
librz/reg: handle 1 bit fields the same on BE and LE

### DIFF
--- a/librz/reg/rvalue.c
+++ b/librz/reg/rvalue.c
@@ -19,6 +19,17 @@ RZ_API RZ_OWN RzBitVector *rz_reg_get_bv(RZ_NONNULL RzReg *reg, RZ_NONNULL RzReg
 		return rz_bv_new_zero(item->size);
 	}
 	RzRegSet *regset = &reg->regset[item->arena];
+	if (item->size == 1 && (item->offset % 8)) {
+		// a single-bit, non-byte-aligned register (e.g. a status-word flag) is
+		// stored at a fixed physical bit position, independent of endianness.
+		RzBitVector *bv = rz_bv_new(1);
+		if (!bv) {
+			return NULL;
+		}
+		bool bit = (regset->arena->bytes[item->offset / 8] >> (item->offset % 8)) & 1;
+		rz_bv_set(bv, 0, bit);
+		return bv;
+	}
 	if (reg->big_endian) {
 		return rz_bv_new_from_bytes_be(regset->arena->bytes, item->offset, item->size);
 	} else {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Was found on Travis CI with recently merged MIL-STD-1750: https://github.com/rizinorg/rizin/commit/423576676b336c9a456cdd271c65c0c3b6f0d898

```
[XX] 00h00m00s136ms db/formats/milstd1750 milstd1750: register profile (count, SW flag bits cf/pf/zf/nf, ic=PC, r15=SP per spec 4.4.1.c)
RZ_COLOR=0 RZ_UTF8=0 RZ_NOPLUGINS=1 /home/travis/build/rizinorg/rizin/install/bin/rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -eflirt.sigdb.load.system=false -esearch.show_progress=false -eflirt.sigdb.load.home=false -N -a milstd1750 -b 8 -qc 'e scr.color=false
ar~?
ar cf=1
ar pf=1
ar zf=1
ar nf=1
ar cf
ar pf
ar zf
ar nf
ar ic=0x1234
ar ic
ar r15=0xabcd
ar r15
' malloc://32
-- stdout
--- expected
+++ actual
@@ -0,8 +0,8 @@
 21
 cf = 0x1
-pf = 0x1
-zf = 0x1
-nf = 0x1
+pf = 0x0
+zf = 0x0
+nf = 0x0
 ic = 0x1234
 r15 = 0xabcd

```

**Test plan**

CI is green