### PR TITLE
librz/debug: add native debugger for NetBSD on DEC VAX

### DIFF
--- a/librz/debug/meson.build
+++ b/librz/debug/meson.build
@@ -137,7 +137,7 @@ if has_debugger
 
   # NetBSD OS
   elif host_machine.system() == 'netbsd'
-    if host_machine.cpu_family() == 'x86' or host_machine.cpu_family() == 'x86_64'
+    if host_machine.cpu_family() == 'x86' or host_machine.cpu_family() == 'x86_64' or host_machine.cpu_family() == 'vax'
       rz_debug_sources += ['p/native/netbsd.c']
     else
       rz_debug_sources += ['p/native/unsupported.c']

--- a/librz/debug/p/native/netbsd.c
+++ b/librz/debug/p/native/netbsd.c
@@ -34,6 +34,8 @@ static char *rz_debug_native_reg_profile(RzDebug *dbg) {
 #include "reg/netbsd-x86.h"
 #elif __x86_64__ /* x86_64 */
 #include "reg/netbsd-x64.h"
+#elif __vax__ /* vax */
+#include "reg/netbsd-vax.h"
 #endif /* end */
 }
 
@@ -571,6 +573,10 @@ RzDebugPlugin rz_debug_plugin_native = {
 	.bits = RZ_SYS_BITS_32 | RZ_SYS_BITS_64,
 	.arch = "x86",
 	.canstep = 1, // XXX it's 1 on some platforms...
+#elif __vax__
+	.bits = RZ_SYS_BITS_32,
+	.arch = "vax",
+	.canstep = 1, // single-step via the PSL trace (T) bit
 #endif
 	.init = &rz_debug_native_init,
 	.fini = &rz_debug_native_fini,

--- a/librz/debug/p/native/reg/netbsd-vax.h
+++ b/librz/debug/p/native/reg/netbsd-vax.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 RizinOrg <info@rizin.re>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+/* Register layout of NetBSD/vax `struct reg`, kept in sync with the kernel:
+ *   sys/arch/vax/include/reg.h (reg.h,v 1.7) declares the struct, and
+ *   sys/arch/vax/vax/machdep.c:process_read_regs() (the PT_GETREGS handler)
+ *   fills all 17 ints in order: r0-r11, ap, fp, sp, pc, psl.
+ * With 4-byte ints these land at byte offsets 0,4,..,64 (68 bytes total).
+ * The PSL condition codes are bits 0-3 of psl (absolute bits 512-515),
+ * matching PSL_C/PSL_V/PSL_Z/PSL_N in sys/arch/vax/include/psl.h. */
+
+return rz_str_dup(
+	"=PC	pc\n"
+	"=SP	sp\n"
+	"=BP	fp\n"
+	"=A0	r0\n"
+	"=A1	r1\n"
+	"=A2	r2\n"
+	"=A3	r3\n"
+	"gpr	r0	.32	0	0\n"
+	"gpr	r1	.32	4	0\n"
+	"gpr	r2	.32	8	0\n"
+	"gpr	r3	.32	12	0\n"
+	"gpr	r4	.32	16	0\n"
+	"gpr	r5	.32	20	0\n"
+	"gpr	r6	.32	24	0\n"
+	"gpr	r7	.32	28	0\n"
+	"gpr	r8	.32	32	0\n"
+	"gpr	r9	.32	36	0\n"
+	"gpr	r10	.32	40	0\n"
+	"gpr	r11	.32	44	0\n"
+	"gpr	ap	.32	48	0\n"
+	"gpr	fp	.32	52	0\n"
+	"gpr	sp	.32	56	0\n"
+	"gpr	pc	.32	60	0\n"
+	"gpr	psl	.32	64	0\n"
+	"gpr	c	.1	.512	0	carry\n"
+	"gpr	v	.1	.513	0	overflow\n"
+	"gpr	z	.1	.514	0	zero\n"
+	"gpr	n	.1	.515	0	negative\n");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Adds a native debugger for DEC VAX with NetBSD (tested on ZIMH emulator)

Based on https://github.com/rizinorg/rizin/pull/6500

**Test plan**

- CI is green
- Test it on your home VAX computer

