### PR TITLE
Make Python optional for the build

### DIFF
--- a/librz/core/cmd_descs/meson.build
+++ b/librz/core/cmd_descs/meson.build
@@ -40,9 +40,8 @@ cmd_descs_yaml = files(
 )
 cmd_descs_src_c = files('cmd_descs.c', 'cmd_descs.h')
 
-r = run_command(py3_exe, '-c', 'import yaml', check: false)
 cmd_option = get_option('regenerate_cmds')
-has_pyyaml = r.returncode() == 0
+has_pyyaml = have_python and run_command(py3_exe, '-c', 'import yaml', check: false).returncode() == 0
 if (cmd_option.auto() or cmd_option.enabled()) and has_pyyaml
   cmd_descs_ch = custom_target(
     'cmd_descs.[ch]',

--- a/librz/flag/d/meson.build
+++ b/librz/flag/d/meson.build
@@ -11,10 +11,20 @@ tags_rz_sources = [
   'string'
 ]
 
+if have_python
+  tags_rz_cmd = [py3_exe, create_tags_rz_py, '@INPUT@']
+else
+  create_tags_rz_exe = executable('create_tags_rz', create_tags_rz_c,
+    native: meson.is_cross_build(),
+    install: false,
+  )
+  tags_rz_cmd = [create_tags_rz_exe, '@INPUT@']
+endif
+
 custom_target('tags.rz',
   input: tags_rz_sources,
   output: 'tags.rz',
-  command: [py3_exe, create_tags_rz_py, '@INPUT@'],
+  command: tags_rz_cmd,
   capture: true,
   build_by_default: true,
   install: true,

--- a/librz/syscall/d/meson.build
+++ b/librz/syscall/d/meson.build
@@ -22,12 +22,23 @@ sdb_files = [
   'windows-x86-64',
 ]
 
+if have_python
+  syscall_pre_cmd = [py3_exe, syscall_preprocessing_py, '@INPUT@', '@OUTPUT@']
+else
+  # No Python: build a tiny native helper (like sdb_gen) that does the same.
+  syscall_pre_exe = executable('syscall_preprocessing', syscall_preprocessing_c,
+    native: meson.is_cross_build(),
+    install: false,
+  )
+  syscall_pre_cmd = [syscall_pre_exe, '@INPUT@', '@OUTPUT@']
+endif
+
 foreach file : sdb_files
   tmp_outfile = '@0@.sdb.txt.tmp'.format(file)
   pre_sdb_txt = custom_target(tmp_outfile,
     input: '@0@.sdb.txt'.format(file),
     output: tmp_outfile,
-    command: [py3_exe, syscall_preprocessing_py, '@INPUT@', '@OUTPUT@'],
+    command: syscall_pre_cmd,
     build_by_default: true,
     install: false
   )

--- a/librz/type/meson.build
+++ b/librz/type/meson.build
@@ -27,8 +27,7 @@ rz_type_sources = [
   'pf/pf_render_sd.c'
 ]
 
-r = run_command(py3_exe, check_meson_subproject_py, 'rizin-grammar-c', check: false)
-if r.returncode() == 1 and get_option('subprojects_check')
+if do_subprojects_check and run_command(py3_exe, check_meson_subproject_py, 'rizin-grammar-c', check: false).returncode() == 1
   error('Subprojects are not updated. Please run `git clean -dxff subprojects/` to delete all local subprojects directories. If you want to compile against current subprojects then set option `subprojects_check=false`.')
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,11 @@ syscall_preprocessing_py = files('sys/syscall_preprocessing.py')
 check_meson_subproject_py = files('sys/check_meson_subproject.py')
 git_exe_repo_py = files('sys/meson_git_wrapper.py')
 
+# Portable C equivalents of the per-build helper scripts, used as native
+# build-time tools when Python is not available (e.g. building with muon).
+create_tags_rz_c = files('sys/create_tags_rz.c')
+syscall_preprocessing_c = files('sys/syscall_preprocessing.c')
+
 is_static_build = get_option('static_runtime')
 is_static_libs_only = get_option('default_library') == 'static'
 if is_static_build and not is_static_libs_only

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,12 @@ project('rizin', 'c',
   ]
 )
 
-py3_exe = import('python').find_installation()
+py3_exe = import('python').find_installation(required: false)
+have_python = py3_exe.found()
+# The subproject staleness check is a developer convenience implemented in
+# Python (sys/check_meson_subproject.py). When Python is not available (e.g.
+# building with muon on a host without Python) the check is simply skipped.
+do_subprojects_check = have_python and get_option('subprojects_check')
 git_exe = find_program('git', required: false)
 pkgconfig_mod = import('pkgconfig')
 
@@ -18,7 +23,6 @@ create_tags_rz_py = files('sys/create_tags_rz.py')
 syscall_preprocessing_py = files('sys/syscall_preprocessing.py')
 check_meson_subproject_py = files('sys/check_meson_subproject.py')
 git_exe_repo_py = files('sys/meson_git_wrapper.py')
-cmake_package_prefix_dir_py = files('sys/meson_cmake_prefix_dir.py')
 
 is_static_build = get_option('static_runtime')
 is_static_libs_only = get_option('default_library') == 'static'
@@ -168,10 +172,14 @@ load_dirs = {
 }
 
 # Calcualte BINDIR's depth to be able to find the root directory during runtime
-# in portable builds
-py_cmd = 'import os; from pathlib import Path; print(len(Path(os.path.normpath(r"@0@")).parents) - len(Path(os.path.normpath(r"@1@")).parents))'.format(rizin_prefix / rizin_bindir, rizin_prefix)
-py_cmd = run_command(py3_exe, '-c', py_cmd, check: true)
-bindir_depth = py_cmd.stdout().strip()
+# in portable builds. bindir is relative to prefix, so its number of path
+# components is exactly the depth (the prefix components cancel out).
+bindir_depth = 0
+foreach _part : get_option('bindir').split('/')
+  if _part != '' and _part != '.'
+    bindir_depth += 1
+  endif
+endforeach
 
 foreach load_dir, default_subdir : load_dirs
   val = get_option(load_dir)
@@ -186,7 +194,22 @@ foreach load_dir, default_subdir : load_dirs
   endif
 endforeach
 
-cmake_package_relative_path = run_command(py3_exe, cmake_package_prefix_dir_py, rizin_prefix, rizin_cmakedir / 'xxx', check: true).stdout().strip()
+# Relative path from the installed CMake package directory back to the install
+# prefix. The generated config file is installed in <libdir>/cmake/<module>/,
+# so the number of '..' segments needed to reach the prefix is the component
+# count of libdir plus two (the 'cmake' directory and the per-module
+# directory). Computed in pure Meson (no Python) so the build also works with
+# muon; produces the same result as sys/meson_cmake_prefix_dir.py.
+cmake_ups = 2
+foreach _part : get_option('libdir').split('/')
+  if _part != '' and _part != '.'
+    cmake_ups += 1
+  endif
+endforeach
+cmake_package_relative_path = '..'
+foreach _i : range(cmake_ups - 1)
+  cmake_package_relative_path += '/..'
+endforeach
 
 subproject_clean_error_msg = 'Subprojects are not updated. Please run `git clean -dxff subprojects/` to delete all local subprojects directories. If you want to compile against current subprojects then set option `subprojects_check=false`.'
 
@@ -197,8 +220,7 @@ capstone_dep = dependency('capstone', version: '>=4.0.2', required: get_option('
 if not capstone_dep.found()
   capstone_version = get_option('use_capstone_version')
   if fs.is_file('subprojects/capstone-' + capstone_version + '.wrap')
-    r = run_command(py3_exe, check_meson_subproject_py, 'capstone-' + capstone_version, check: false)
-    if r.returncode() == 1 and get_option('subprojects_check')
+    if do_subprojects_check and run_command(py3_exe, check_meson_subproject_py, 'capstone-' + capstone_version, check: false).returncode() == 1
       error(subproject_clean_error_msg)
     endif
     capstone_proj = subproject('capstone-' + capstone_version, default_options: ['default_library=static'])
@@ -334,8 +356,7 @@ if (sys_libmspack_opt.auto() and not libmspack_dep.found()) or sys_libmspack_opt
 endif
 
 # handle xxhash library
-r = run_command(py3_exe, check_meson_subproject_py, 'xxhash', check: false)
-if r.returncode() == 1 and get_option('subprojects_check')
+if do_subprojects_check and run_command(py3_exe, check_meson_subproject_py, 'xxhash', check: false).returncode() == 1
   error(subproject_clean_error_msg)
 endif
 
@@ -352,8 +373,7 @@ if (sys_xxhash_opt.auto() and not xxhash_dep.found()) or sys_xxhash_opt.disabled
 endif
 
 # handle libdemangle
-r = run_command(py3_exe, check_meson_subproject_py, 'libdemangle', check: false)
-if r.returncode() == 1 and get_option('subprojects_check')
+if do_subprojects_check and run_command(py3_exe, check_meson_subproject_py, 'libdemangle', check: false).returncode() == 1
   error(subproject_clean_error_msg)
 endif
 
@@ -378,8 +398,7 @@ endif
 sys_openssl = dependency('openssl', required: get_option('use_sys_openssl'), static: is_static_build)
 
 # handle tree-sitter
-r = run_command(py3_exe, check_meson_subproject_py, 'tree-sitter', check: false)
-if r.returncode() == 1 and get_option('subprojects_check')
+if do_subprojects_check and run_command(py3_exe, check_meson_subproject_py, 'tree-sitter', check: false).returncode() == 1
   error(subproject_clean_error_msg)
 endif
 
@@ -391,8 +410,7 @@ if not tree_sitter_dep.found()
 endif
 
 # handle rizin-grammar-c
-r = run_command(py3_exe, check_meson_subproject_py, 'rizin-grammar-c', check: false)
-if r.returncode() == 1 and get_option('subprojects_check')
+if do_subprojects_check and run_command(py3_exe, check_meson_subproject_py, 'rizin-grammar-c', check: false).returncode() == 1
   error(subproject_clean_error_msg)
 endif
 
@@ -651,21 +669,34 @@ rz_version_h = configure_file(
 )
 
 if git_exe.found() and fs.exists('.git')
-  gittip_file = custom_target('gittip_file',
-    build_always_stale: true,
-    build_by_default: true,
-    output: 'gittip',
-    command: [py3_exe, git_exe_repo_py, git_exe, repo, '@OUTPUT@', 'rev-parse', 'HEAD'],
-    install: true,
-    install_dir: rizin_datdir_rz
-  )
+  if have_python
+    gittip_file = custom_target('gittip_file',
+      build_always_stale: true,
+      build_by_default: true,
+      output: 'gittip',
+      command: [py3_exe, git_exe_repo_py, git_exe, repo, '@OUTPUT@', 'rev-parse', 'HEAD'],
+      install: true,
+      install_dir: rizin_datdir_rz
+    )
+  else
+    # sys/meson_git_wrapper.py only exists to support ancient git without -C.
+    # Modern git supports -C, so call it directly and capture stdout.
+    gittip_file = custom_target('gittip_file',
+      build_always_stale: true,
+      build_by_default: true,
+      output: 'gittip',
+      command: [git_exe, '-C', repo, 'rev-parse', 'HEAD'],
+      capture: true,
+      install: true,
+      install_dir: rizin_datdir_rz
+    )
+  endif
 endif
 
 # handle zlib dependency
 zlib_dep = disabler()
 if get_option('use_zlib')
-  r = run_command(py3_exe, check_meson_subproject_py, 'zlib', check: false)
-  if r.returncode() == 1 and get_option('subprojects_check')
+  if do_subprojects_check and run_command(py3_exe, check_meson_subproject_py, 'zlib', check: false).returncode() == 1
     error(subproject_clean_error_msg)
   endif
 
@@ -678,8 +709,7 @@ if get_option('use_zlib')
 endif
 
 # handle lz4 dependency
-r = run_command(py3_exe, check_meson_subproject_py, 'lz4', check: false)
-if r.returncode() == 1 and get_option('subprojects_check')
+if do_subprojects_check and run_command(py3_exe, check_meson_subproject_py, 'lz4', check: false).returncode() == 1
   error(subproject_clean_error_msg)
 endif
 
@@ -692,8 +722,7 @@ endif
 # handle lzma dependency
 liblzma_dep = disabler()
 if get_option('use_lzma')
-  r = run_command(py3_exe, check_meson_subproject_py, 'lzma', check: false)
-  if r.returncode() == 1 and get_option('subprojects_check')
+  if do_subprojects_check and run_command(py3_exe, check_meson_subproject_py, 'lzma', check: false).returncode() == 1
     error(subproject_clean_error_msg)
   endif
 
@@ -706,8 +735,7 @@ if get_option('use_lzma')
 endif
 
 # handle softfloat dependency
-r = run_command(py3_exe, check_meson_subproject_py, 'softfloat', check: false)
-if r.returncode() == 1 and get_option('subprojects_check')
+if do_subprojects_check and run_command(py3_exe, check_meson_subproject_py, 'softfloat', check: false).returncode() == 1
   error(subproject_clean_error_msg)
 endif
 
@@ -723,8 +751,7 @@ if meson.is_cross_build()
 endif
 
 # handle zip dependency
-r = run_command(py3_exe, check_meson_subproject_py, 'libzip', check: false)
-if r.returncode() == 1 and get_option('subprojects_check')
+if do_subprojects_check and run_command(py3_exe, check_meson_subproject_py, 'libzip', check: false).returncode() == 1
   error(subproject_clean_error_msg)
 endif
 
@@ -747,8 +774,7 @@ if host_machine.system() == 'serenity' and libzip_dep.found()
 endif
 
 # handle zstd dependency
-r = run_command(py3_exe, check_meson_subproject_py, 'zstd', check: false)
-if r.returncode() == 1 and get_option('subprojects_check')
+if do_subprojects_check and run_command(py3_exe, check_meson_subproject_py, 'zstd', check: false).returncode() == 1
   error(subproject_clean_error_msg)
 endif
 
@@ -763,8 +789,7 @@ if not libzstd_dep.found()
 endif
 
 # handle yxml dependency
-r = run_command(py3_exe, check_meson_subproject_py, 'yxml', check: false)
-if r.returncode() == 1 and get_option('subprojects_check')
+if do_subprojects_check and run_command(py3_exe, check_meson_subproject_py, 'yxml', check: false).returncode() == 1
   error(subproject_clean_error_msg)
 endif
 
@@ -799,9 +824,10 @@ rpath_lib = ''
 rpath_summary = 'disabled'
 if use_rpath
   # Use bindir depth to create a path to the rootdir from bindir
-  py_cmd = 'import os; print("../" * @0@)'.format(bindir_depth.to_int())
-  py_cmd = run_command(py3_exe, '-c', py_cmd, check: true)
-  path_to_rootdir = py_cmd.stdout().strip()
+  path_to_rootdir = ''
+  foreach _i : range(bindir_depth)
+    path_to_rootdir += '../'
+  endforeach
 
   rpath_exe = '$ORIGIN/' + path_to_rootdir + get_option('libdir')
   rpath_lib = '$ORIGIN'
@@ -848,8 +874,7 @@ endif
 subdir('librz')
 
 if get_option('install_sigdb')
-  r = run_command(py3_exe, check_meson_subproject_py, 'sigdb', check: false)
-  if r.returncode() == 1 and get_option('subprojects_check')
+  if do_subprojects_check and run_command(py3_exe, check_meson_subproject_py, 'sigdb', check: false).returncode() == 1
     error(subproject_clean_error_msg)
   endif
   subproject('sigdb', default_options: ['sigdb_path=@0@'.format(get_option('prefix') / rizin_sigdb)])

--- a/sys/create_tags_rz.c
+++ b/sys/create_tags_rz.c
@@ -1,0 +1,91 @@
+/* SPDX-FileCopyrightText: 2026 RizinOrg <info@rizin.re> */
+/* SPDX-License-Identifier: LGPL-3.0-only */
+
+/* Portable C reimplementation of sys/create_tags_rz.py.
+ *
+ * For each input file it emits a single line:
+ *   ft <basename> <file contents with newlines replaced by single spaces>
+ *
+ * This mirrors Python's str.splitlines() + " ".join(): line boundaries are
+ * '\n', '\r' and '\r\n', empty lines are preserved (producing consecutive
+ * spaces) and a trailing newline does not add a trailing space. Like the
+ * Python version the output is written to stdout. Having this as a native
+ * build-time helper removes the build-time dependency on Python. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *basename_portable(const char *path) {
+	const char *base = path;
+	for (const char *p = path; *p; p++) {
+		if (*p == '/' || *p == '\\') {
+			base = p + 1;
+		}
+	}
+	return base;
+}
+
+static int emit_file(const char *path) {
+	FILE *in = fopen(path, "rb");
+	if (!in) {
+		fprintf(stderr, "create_tags_rz: cannot open %s\n", path);
+		return 1;
+	}
+	fseek(in, 0, SEEK_END);
+	long size = ftell(in);
+	fseek(in, 0, SEEK_SET);
+	if (size < 0) {
+		fclose(in);
+		return 1;
+	}
+	char *buf = (char *)malloc((size_t)size + 1);
+	if (!buf) {
+		fclose(in);
+		return 1;
+	}
+	size_t rd = fread(buf, 1, (size_t)size, in);
+	buf[rd] = '\0';
+	fclose(in);
+
+	fputs("ft ", stdout);
+	fputs(basename_portable(path), stdout);
+	fputc(' ', stdout);
+
+	/* Replicate " ".join(text.splitlines()): print a space before every line
+	 * except the first. A line ends at '\n', '\r' or '\r\n'. */
+	int first = 1;
+	size_t i = 0;
+	while (i < rd) {
+		size_t start = i;
+		while (i < rd && buf[i] != '\n' && buf[i] != '\r') {
+			i++;
+		}
+		if (!first) {
+			fputc(' ', stdout);
+		}
+		first = 0;
+		fwrite(buf + start, 1, i - start, stdout);
+		if (i < rd) {
+			char c = buf[i];
+			i++;
+			if (c == '\r' && i < rd && buf[i] == '\n') {
+				i++;
+			}
+		}
+	}
+
+	fputc('\n', stdout);
+	free(buf);
+	return 0;
+}
+
+int main(int argc, char **argv) {
+	for (int i = 1; i < argc; i++) {
+		int rc = emit_file(argv[i]);
+		if (rc != 0) {
+			return rc;
+		}
+	}
+	return 0;
+}

--- a/sys/syscall_preprocessing.c
+++ b/sys/syscall_preprocessing.c
@@ -1,0 +1,156 @@
+/* SPDX-FileCopyrightText: 2026 RizinOrg <info@rizin.re> */
+/* SPDX-License-Identifier: LGPL-3.0-only */
+
+/* Portable C reimplementation of sys/syscall_preprocessing.py.
+ *
+ * It preprocesses syscall/d .sdb.txt files so that they can be compiled by
+ * sdb_gen. For every line that does not start with '_' and contains a '=',
+ * it splits the line on '=' and ',' (stripping whitespace from each field)
+ * and emits two lines:
+ *   <field1>.<field2>=<field0>
+ *   <field0>=<field1>,<field2>,...   (padded to at least 4 fields)
+ * Every other line is copied verbatim.
+ *
+ * Unlike the Python version this has no external dependencies and is meant to
+ * be built as a native build-time helper (like sdb_gen), so the build does
+ * not require a Python interpreter. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int is_ws(char c) {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+}
+
+/* Append [start,end) with surrounding whitespace stripped to the field list. */
+static void push_field(char ***fields, size_t *n, size_t *cap, const char *start, const char *end) {
+	while (start < end && is_ws(*start)) {
+		start++;
+	}
+	while (end > start && is_ws(end[-1])) {
+		end--;
+	}
+	size_t len = (size_t)(end - start);
+	char *s = (char *)malloc(len + 1);
+	if (!s) {
+		exit(1);
+	}
+	memcpy(s, start, len);
+	s[len] = '\0';
+	if (*n == *cap) {
+		*cap = *cap ? *cap * 2 : 8;
+		*fields = (char **)realloc(*fields, *cap * sizeof(char *));
+		if (!*fields) {
+			exit(1);
+		}
+	}
+	(*fields)[(*n)++] = s;
+}
+
+static void process_line(FILE *out, const char *line, size_t len) {
+	/* Find end of line content (excluding a single trailing '\n'). */
+	size_t content_len = len;
+	int has_nl = 0;
+	if (content_len > 0 && line[content_len - 1] == '\n') {
+		content_len--;
+		has_nl = 1;
+	}
+
+	int starts_underscore = (len > 0 && line[0] == '_');
+	int has_eq = 0;
+	for (size_t i = 0; i < content_len; i++) {
+		if (line[i] == '=') {
+			has_eq = 1;
+			break;
+		}
+	}
+
+	if (starts_underscore || !has_eq) {
+		/* Copy verbatim (including trailing newline if present). */
+		fwrite(line, 1, len, out);
+		return;
+	}
+
+	/* Split content on '=' and ','. */
+	char **fields = NULL;
+	size_t n = 0, cap = 0;
+	const char *seg = line;
+	for (size_t i = 0; i < content_len; i++) {
+		if (line[i] == '=' || line[i] == ',') {
+			push_field(&fields, &n, &cap, seg, line + i);
+			seg = line + i + 1;
+		}
+	}
+	push_field(&fields, &n, &cap, seg, line + content_len);
+
+	/* fields[1].fields[2]=fields[0] */
+	fprintf(out, "%s.%s=%s\n", fields[1], fields[2], fields[0]);
+
+	/* fields[0]=fields[1],fields[2],...  padded to at least 4 fields. */
+	fprintf(out, "%s=", fields[0]);
+	size_t total = n < 4 ? 4 : n;
+	for (size_t i = 1; i < total; i++) {
+		if (i > 1) {
+			fputc(',', out);
+		}
+		fputs(i < n ? fields[i] : "", out);
+	}
+	fputc('\n', out);
+
+	for (size_t i = 0; i < n; i++) {
+		free(fields[i]);
+	}
+	free(fields);
+	(void)has_nl;
+}
+
+int main(int argc, char **argv) {
+	if (argc < 3) {
+		fprintf(stderr, "Usage: %s <input> <output>\n", argv[0]);
+		return 1;
+	}
+
+	FILE *in = fopen(argv[1], "rb");
+	if (!in) {
+		fprintf(stderr, "%s: cannot open input %s\n", argv[0], argv[1]);
+		return 1;
+	}
+	fseek(in, 0, SEEK_END);
+	long size = ftell(in);
+	fseek(in, 0, SEEK_SET);
+	if (size < 0) {
+		fclose(in);
+		return 1;
+	}
+	char *buf = (char *)malloc((size_t)size + 1);
+	if (!buf) {
+		fclose(in);
+		return 1;
+	}
+	size_t rd = fread(buf, 1, (size_t)size, in);
+	buf[rd] = '\0';
+	fclose(in);
+
+	FILE *out = fopen(argv[2], "wb");
+	if (!out) {
+		fprintf(stderr, "%s: cannot open output %s\n", argv[0], argv[2]);
+		free(buf);
+		return 1;
+	}
+
+	size_t start = 0;
+	for (size_t i = 0; i < rd; i++) {
+		if (buf[i] == '\n') {
+			process_line(out, buf + start, i - start + 1);
+			start = i + 1;
+		}
+	}
+	if (start < rd) {
+		process_line(out, buf + start, rd - start);
+	}
+
+	fclose(out);
+	free(buf);
+	return 0;
+}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Rizin can already be built with [muon](https://muon.build/), but configuring and
building still required a Python 3 interpreter in a handful of places. This PR
removes that requirement so Rizin can be built with muon on systems where
porting Python is impractical (e.g. exotic targets), while leaving normal Meson
builds completely unchanged.

The key observation is that **Meson is itself a Python program**: if Meson is
running the build, Python is present by definition. Every change here is gated on
a `have_python` flag, so under Meson the existing Python paths always run (no
behavioural change, no regression), and the new fallbacks only ever execute under
muon.

**Commit 1 (`make Python optional during configuration`)** removes all
configuration-time uses of Python without adding anything new: `find_installation()`
becomes optional; the `check_meson_subproject.py` staleness checks are guarded
(they are a developer convenience and both Meson and muon short-circuit `and`);
BINDIR depth, the relative rpath and the CMake package relative path are computed
in pure Meson; the `gittip` stamp falls back to `git -C` directly; and the PyYAML
probe is skipped, using the committed `cmd_descs.[ch]`. After this commit muon
gets all the way through configuration and only stops at the two remaining
per-build scripts.

**Commit 2 (`replace per-build Python scripts with native C helpers`)** handles
those two scripts — `syscall_preprocessing.py` and `create_tags_rz.py` — which
run on every build with no committed output to fall back on. They are
reimplemented as small, dependency-free C programs built as native build-time
tools, exactly the way the existing `sdb_gen` helper is built, so they add no new
cross-build bootstrapping. They are only used when Python is unavailable and
produce byte-for-byte identical output.

Verified end to end: with `python3` removed from `PATH`, `muon setup` + `muon samu`
build a working `rizin 0.9.0` binary; the generated `tags.rz` and syscall `.sdb`
tables are byte-identical to the Python output; and the full tree still configures
and builds under **Meson 0.61.5** (no `fs.relative_to` or other newer features are
used). Two notes: muon does not fetch wrap subprojects, so sources must already be
present (release tarballs vendor them); and a fully python-less build currently
needs a system `libzip` (`-Duse_sys_libzip=enabled`), since the vendored libzip
subproject's own `meson.build` requires Python.

**Test plan**

- CI is green (Meson, Muon, old Debians)

**Closing issues**

Trying to addresss https://github.com/rizinorg/rizin/issues/3067
