### PR TITLE
Improve detection and parsing of fmt string

### DIFF
--- a/librz/core/analysis_tp.c
+++ b/librz/core/analysis_tp.c
@@ -9,6 +9,9 @@
 #include <rz_core.h>
 #define LOOP_MAX 10
 
+// from canalysis.c (core_private.h isn't included: it clashes with the local bb_cmpaddr)
+RZ_IPI void rz_core_add_string_ref(RzCore *core, ut64 xref_from, ut64 xref_to);
+
 static bool analysis_emul_init(RzCore *core, RzConfigHold *hc, RzDebugTrace **dt, RzAnalysisEsilTrace **et, RzAnalysisILTrace **rt) {
 	RzReg *rreg = rz_analysis_get_reg(core->analysis);
 	RzAnalysisEsil *esil = rz_analysis_get_esil(core->analysis);
@@ -458,6 +461,16 @@ static void type_match(RzCore *core, char *fcn_name, ut64 addr, ut64 baddr, cons
 					cmt_set = true;
 					if ((op->ptr && op->ptr != UT64_MAX) && !strcmp(name, "format")) {
 						RzFlagItem *f = rz_flag_get_by_spaces(core->flags, op->ptr, RZ_FLAGS_FS_STRINGS, NULL);
+						if (!f) {
+							// A format argument (e.g. scanf's "%s") is a string even when
+							// shorter than the detection threshold; create the reference so
+							// it is shown as a string and parsed for variadic typing below.
+							size_t saved_min = core->bin->str_search_cfg.min_length;
+							core->bin->str_search_cfg.min_length = 1;
+							rz_core_add_string_ref(core, op->addr, op->ptr);
+							core->bin->str_search_cfg.min_length = saved_min;
+							f = rz_flag_get_by_spaces(core->flags, op->ptr, RZ_FLAGS_FS_STRINGS, NULL);
+						}
 						if (f) {
 							char formatstr[0x200];
 							int read = rz_io_nread_at(core->io, f->offset, (ut8 *)formatstr, RZ_MIN(sizeof(formatstr) - 1, f->size));

--- a/test/db/cmd/cmd_avD
+++ b/test/db/cmd/cmd_avD
@@ -869,14 +869,14 @@ EXPECT=<<EOF
 |      |:   0x100001a85      add   eax, 0x01
 |      |:   0x100001a88      mov   dword [var_34h], eax
 |      |`=< 0x100001a8b      jmp   0x100001a58
-|      `--> 0x100001a90      lea   rdi, qword data.100001e17           ; 0x100001e17 ; "\n" ; const char *format
+|      `--> 0x100001a90      lea   rdi, qword str.                     ; 0x100001e17 ; "\n" ; const char *format
 |           0x100001a97      mov   al, 0x00
 |           0x100001a99      call  sym.imp.printf                      ; int printf(const char *format)
 |           0x100001a9e      lea   rdi, qword reloc.__CFConstantStringClassReference.100002030 ; rsi
 |                                                                      ; 0x100002030
 |           0x100001aa5      mov   qword [var_40h], rdi
 |           0x100001aa9      mov   rsi, qword [var_40h]
-|           0x100001aad      lea   rdi, qword data.100001e28           ; 0x100001e28 ; "%p\n" ; const char *format
+|           0x100001aad      lea   rdi, qword str.p                    ; 0x100001e28 ; "%p\n" ; const char *format
 |           0x100001ab4      mov   dword [var_a8h], eax
 |           0x100001aba      mov   al, 0x00
 |           0x100001abc      call  sym.imp.printf                      ; int printf(const char *format)

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -2749,7 +2749,7 @@ EXPECT=<<EOF
 | 0x08048572      call  sym.imp.printf                                 ; int printf(const char *format)
 | 0x08048577      lea   eax, dword [var_7ch]
 | 0x0804857a      mov   dword [var_88h], eax
-| 0x0804857e      mov   dword [esp], data.080486b2                     ; [0x80486b2:4]=0x7325 ; "%s" ; const char *format
+| 0x0804857e      mov   dword [esp], str.s                             ; [0x80486b2:4]=0x7325 ; "%s" ; const char *format
 | 0x08048585      call  sym.imp.scanf                                  ; int scanf(const char *format)
 | 0x0804858a      lea   eax, dword [var_7ch]
 | 0x0804858d      mov   dword [esp], eax                               ; int32_t arg_4h
@@ -3075,7 +3075,7 @@ EXPECT=<<EOF
     "fcn_last": 134514069,
     "size": 7,
     "opcode": "mov dword [esp], 0x80486b2",
-    "disasm": "mov dword [esp], data.080486b2",
+    "disasm": "mov dword [esp], str.s",
     "bytes": "c70424b2860408",
     "family": "cpu",
     "type": "mov",

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1935,7 +1935,8 @@ s main
 afvl
 EOF
 EXPECT=<<EOF
-var void *va_args @ stack - 0x3c
+var int var_3ch @ stack - 0x3c
+var unsigned long var_38h @ stack - 0x38
 var unsigned long var_34h @ stack - 0x34
 var FILE *stream @ stack - 0x30
 var const char *s @ stack - 0x28

--- a/test/integration/test_analysis_graph.c
+++ b/test/integration/test_analysis_graph.c
@@ -131,7 +131,7 @@ bool test_analysis_graph_more() {
 		"{\"id\":2,\"title\":\"str.RPISEC___CrackMe_v2.0\",\"offset\":134516134,\"out_nodes\":[]},"
 		"{\"id\":3,\"title\":\"str.\",\"offset\":134516164,\"out_nodes\":[]},"
 		"{\"id\":4,\"title\":\"str.Password:\",\"offset\":134516194,\"out_nodes\":[]},"
-		"{\"id\":5,\"title\":\"data.08048dee\",\"offset\":134516206,\"out_nodes\":[]}"
+		"{\"id\":5,\"title\":\"str.d\",\"offset\":134516206,\"out_nodes\":[]}"
 		"]}\n",
 		"graph json");
 	rz_graph_free(g);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

- Short strings `%s` we dropped during the scan, force a string when it's fmt-style argument of printf-like function (including `scanf()`)
- Decode fmt after the detection

**Test plan**

CI is green

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/313
