### PR TITLE
librz/core/disasm: dedup symbol name when realname is used

### DIFF
--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -3600,6 +3600,15 @@ static void ds_print_fcn_name(RzDisasmState *ds) {
 	if (ds->analysis_op.type != RZ_ANALYSIS_OP_TYPE_JMP && ds->analysis_op.type != RZ_ANALYSIS_OP_TYPE_CJMP && ds->analysis_op.type != RZ_ANALYSIS_OP_TYPE_CALL) {
 		return;
 	}
+	if (ds->core->flags && ds->core->flags->realnames) {
+		// When realnames are enabled the jump/call target is shown by its real
+		// (demangled) name directly in the operand.
+		RzFlagItem *real_flag = rz_flag_get_by_spaces(ds->core->flags, ds->analysis_op.jump,
+			RZ_FLAGS_FS_FUNCTIONS, RZ_FLAGS_FS_IMPORTS, RZ_FLAGS_FS_SYMBOLS, RZ_FLAGS_FS_CLASSES, NULL);
+		if (real_flag && real_flag->realname && strstr_opstr(ds, real_flag->realname)) {
+			return;
+		}
+	}
 	RzAnalysisFunction *f = fcnIn(ds, ds->analysis_op.jump, RZ_ANALYSIS_FCN_TYPE_NULL);
 	if (!f && ds->core->flags && (!ds->core->vmode || (!ds->subjmp && !ds->subnames))) {
 		const char *arch;

--- a/test/db/cmd/cmd_flags
+++ b/test/db/cmd/cmd_flags
@@ -687,14 +687,14 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=pd shows real names and flag name in comments
+NAME=asm.flags.real shows the real name without duplicating the flag name as a comment
 FILE=bins/elf/demangle-test-cpp
 CMDS=<<EOF
 pd 1 @ 0x000011ef @e:asm.flags.real=true
 pd 1 @ 0x000011ef @e:asm.flags.real=false
 EOF
 EXPECT=<<EOF
-            0x000011ef      call  std::vector<int, std::allocator<int>>::vector() ; method.std::vector_int__std::allocator_int__.vector
+            0x000011ef      call  std::vector<int, std::allocator<int>>::vector()
             0x000011ef      call  method.std::vector_int__std::allocator_int__.vector
 EOF
 RUN

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -2267,10 +2267,10 @@ pd 1 @ 0x8048566
 EOF
 EXPECT=<<EOF
             0x08048566      e829feffff     call  sym.imp.printf
-            0x08048566      e829feffff     call  printf                ; sym.imp.printf
+            0x08048566      e829feffff     call  printf
 0x08048394    1 6            sym.imp.printf
 |           0x08048566      e829feffff     call  sym.imp.printf        ; int printf(const char *format)
-|           0x08048566      e829feffff     call  printf                ; sym.imp.printf ; int printf(const char *format)
+|           0x08048566      e829feffff     call  printf                ; int printf(const char *format)
 EOF
 RUN
 

--- a/test/db/cmd/cmd_pd2
+++ b/test/db/cmd/cmd_pd2
@@ -964,9 +964,9 @@ e scr.color=1
 EOF
 EXPECT=<<EOF
 \           0x0000103d      call  sym.imp._Exit                        ; void _Exit(int status)
-\           0x0000103d      call  _Exit                                ; sym.imp._Exit ; void _Exit(int status)
+\           0x0000103d      call  _Exit                                ; void _Exit(int status)
 
 [36m\[0m           [32m0x0000103d[0m      [1;92mcall[0m[37m  [0m[37msym[0m[37m.[0m[37mimp[0m[37m.[0m[37m_[0m[37mExit[0m[0m[0m[31m                        ; void _Exit(int status)[0m
-[36m\[0m           [32m0x0000103d[0m      [1;92mcall[0m[37m  [0m[37m_[0m[37mExit[0m[0m[31m                                ; sym.imp._Exit[0m[31m ; void _Exit(int status)[0m
+[36m\[0m           [32m0x0000103d[0m      [1;92mcall[0m[37m  [0m[37m_[0m[37mExit[0m[0m[0m[31m                                ; void _Exit(int status)[0m
 EOF
 RUN

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -8839,11 +8839,11 @@ var double c @ ...
 |           ; var struct Some *n @ r0
 |           0x0000813c      push  {r4, lr}                             ; test.c:27
 |           0x0000813e      movs  r0, 0x14                             ; test.c:28 ; size_t size
-|           0x00008140      bl    malloc                               ; sym.malloc ; void *malloc(size_t size)
+|           0x00008140      bl    malloc                               ; void *malloc(size_t size)
 |           0x00008144      mov   r4, r0
 |           0x00008146      movs  r2, 0x14                             ; test.c:29 ; size_t n
 |           0x00008148      movs  r1, 0                                ; int c
-|           0x0000814a      bl    memset                               ; sym.memset ; void *memset(void *s, int c, size_t n)
+|           0x0000814a      bl    memset                               ; void *memset(void *s, int c, size_t n)
 |           0x0000814e      mov   r0, r4                               ; test.c:30
 \           0x00008150      pop   {r4, pc}
 / __do_global_dtors_aux();

--- a/test/db/formats/demangling_bin
+++ b/test/db/formats/demangling_bin
@@ -248,20 +248,17 @@ e asm.flags.real=false
 pd 1
 EOF
 EXPECT=<<EOF
-            0x0804921a      call  __x86.get_pc_thunk.si                ; sym.__x86.get_pc_thunk.si
-            0x08049249      call  QFlags<Qt::WindowType>::QFlags(int QFlags<Qt::WindowType>::Private::*) ; method.QFlags_Qt::WindowType_.QFlags_int_QFlags_Qt::WindowType_::Private::
-            0x08049278      call  imp.QLabel::QLabel(QString const&, QWidget*, QFlags<Qt::WindowType>) ; method.QLabel.QLabel_QString_const___QWidget___QFlags_Qt::WindowType
+            0x0804921a      call  __x86.get_pc_thunk.si
+            0x08049249      call  QFlags<Qt::WindowType>::QFlags(int QFlags<Qt::WindowType>::Private::*)
+            0x08049278      call  imp.QLabel::QLabel(QString const&, QWidget*, QFlags<Qt::WindowType>)
 
-            ; sym.__x86.get_pc_thunk.si
             0x0804921a      call __x86.get_pc_thunk.si
-            ; method.QFlags_Qt::WindowType_.QFlags_int_QFlags_Qt::WindowType_::Private::
             0x08049249      call QFlags<Qt::WindowType>::QFlags(int QFlags<Qt::WindowType>::Private::*)
-            ; method.QLabel.QLabel_QString_const___QWidget___QFlags_Qt::WindowType
             0x08049278      call imp.QLabel::QLabel(QString const&, QWidget*, QFlags<Qt::WindowType>)
 
-|           0x0804921a      call  __x86.get_pc_thunk.si                ; sym.__x86.get_pc_thunk.si
-|           0x08049249      call  QFlags<Qt::WindowType>::QFlags(int QFlags<Qt::WindowType>::Private::*) ; method.QFlags_Qt::WindowType_.QFlags_int_QFlags_Qt::WindowType_::Private::
-|           0x08049278      call  imp.QLabel::QLabel(QString const&, QWidget*, QFlags<Qt::WindowType>) ; method.QLabel.QLabel_QString_const___QWidget___QFlags_Qt::WindowType
+|           0x0804921a      call  __x86.get_pc_thunk.si
+|           0x08049249      call  QFlags<Qt::WindowType>::QFlags(int QFlags<Qt::WindowType>::Private::*)
+|           0x08049278      call  imp.QLabel::QLabel(QString const&, QWidget*, QFlags<Qt::WindowType>)
 
 |           0x0804921a      call  sym.__x86.get_pc_thunk.si
 |           0x08049249      call  method.QFlags_Qt::WindowType_.QFlags_int_QFlags_Qt::WindowType_::Private::


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

A minor change reducing the amount of duplication/noise in the disasm

**Test plan**

- CI is green
- Change makes sense

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/60
