### PR TITLE
rz-asm: show an error when `-m` arg is invalid

### DIFF
--- a/librz/core/casm.c
+++ b/librz/core/casm.c
@@ -284,8 +284,13 @@ RZ_API RzCmdStatus rz_core_cpu_descs_print(RZ_NONNULL RzCore *core, RZ_NONNULL c
 	rz_list_sort(plugin_list, (RzListComparator)rz_asm_plugin_cmp, NULL);
 	RzListIter *it;
 	RzAsmPlugin *ap;
+	bool found = false;
 	rz_list_foreach (plugin_list, it, ap) {
-		if (ap->cpus && ap->get_cpu_desc && RZ_STR_EQ(plugin, ap->name)) {
+		if (!RZ_STR_EQ(plugin, ap->name)) {
+			continue;
+		}
+		found = true;
+		if (ap->cpus && ap->get_cpu_desc) {
 			char **desc = ap->get_cpu_desc();
 			if (!desc) {
 				rz_iterator_free(iter);
@@ -296,11 +301,15 @@ RZ_API RzCmdStatus rz_core_cpu_descs_print(RZ_NONNULL RzCore *core, RZ_NONNULL c
 				rz_cons_printf("%-15s %s", desc[i], desc[i + 1]);
 				rz_cons_newline();
 			}
-			break;
 		}
+		break;
 	}
 	rz_iterator_free(iter);
 	rz_list_free(plugin_list);
+	if (!found) {
+		RZ_LOG_ERROR("Unknown asm plugin '%s'\n", plugin);
+		return RZ_CMD_STATUS_ERROR;
+	}
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/main/rz-asm.c
+++ b/librz/main/rz-asm.c
@@ -637,10 +637,11 @@ RZ_API int rz_main_rz_asm(int argc, const char *argv[]) {
 			RzCore *core = rz_core_new();
 			RzAsm *tmp_asm = core->rasm;
 			core->rasm = as->a;
-			rz_core_cpu_descs_print(core, opt.arg);
+			RzCmdStatus status = rz_core_cpu_descs_print(core, opt.arg);
 			rz_cons_flush();
 			core->rasm = tmp_asm;
 			rz_core_free(core);
+			ret = (status == RZ_CMD_STATUS_OK) ? 0 : 1;
 			goto beach;
 		}
 		case '@':

--- a/test/db/tools/rz_asm
+++ b/test/db/tools/rz_asm
@@ -675,3 +675,12 @@ EXPECT=<<EOF
 tricore         Generic TriCore CPU family by Infineon
 EOF
 RUN
+
+NAME=rz-asm -m unknown architecture shows an error
+TOOL=rz-asm
+ARGS=-m ic
+EXIT_STATUS=1
+EXPECT_ERR=<<EOF
+ERROR: Unknown asm plugin 'ic'
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Just show an error when asm plugin doesn't exist

**Test plan**

CI is green

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/6367
