### PR TITLE
librz/core/tui: fix panel mode and visual modes cmd format and redundant quotes

### DIFF
--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -1862,7 +1862,7 @@ RZ_IPI RzCmdStatus rz_cmd_search_assemble_handler(RzCore *core, int argc, const 
 	RzAsmCode *acode;
 	if (!(acode = rz_asm_massemble(core->rasm, argv[1]))) {
 		RZ_LOG_ERROR("Failed to assemble '%s'\n", argv[1]);
-		RZ_LOG_ERROR("Consider using \"/ar\" instead.\n");
+		RZ_LOG_ERROR("Consider using \"/ad\" instead.\n");
 		return RZ_CMD_STATUS_ERROR;
 	}
 	size_t len = acode->len;

--- a/librz/core/tui/panels.c
+++ b/librz/core/tui/panels.c
@@ -1636,7 +1636,7 @@ void __handleComment(RzCore *core) {
 	char buf[4095];
 	int i;
 	rz_line_set_prompt(core->cons->line, "[Comment]> ");
-	strcpy(buf, "\"CC ");
+	strcpy(buf, "CC \"");
 	i = strlen(buf);
 	if (rz_cons_fgets(buf + i, sizeof(buf) - i, 0, NULL) > 0) {
 		ut64 addr, orig;
@@ -1650,18 +1650,18 @@ void __handleComment(RzCore *core) {
 		} else {
 			switch (buf[i]) {
 			case '-':
-				memcpy(buf, "\"CC-", 5);
+				memcpy(buf, "CC-\"", 4);
 				break;
 			case '!':
-				memcpy(buf, "\"CC!", 5);
+				memcpy(buf, "CC!\"", 4);
 				break;
 			default:
-				memcpy(buf, "\"CC ", 4);
+				memcpy(buf, "CC \"", 4);
 				break;
 			}
 			strcat(buf, "\"");
 		}
-		if (buf[3] == ' ') {
+		if (buf[2] == ' ') {
 			int j, len = strlen(buf);
 			char *duped = rz_str_dup(buf);
 			for (i = 4, j = 4; i < len; i++, j++) {
@@ -3240,7 +3240,7 @@ int __clear_layout_cb(void *user) {
 
 int __copy_cb(void *user) {
 	RzCore *core = (RzCore *)user;
-	__add_cmdf_panel(core, "How many bytes? ", "\"y %s\"");
+	__add_cmdf_panel(core, "How many bytes? ", "y %s");
 	return 0;
 }
 
@@ -3252,13 +3252,13 @@ int __paste_cb(void *user) {
 
 int __write_str_cb(void *user) {
 	RzCore *core = (RzCore *)user;
-	__add_cmdf_panel(core, "insert string: ", "\"w %s\"");
+	__add_cmdf_panel(core, "insert string: ", "w %s");
 	return 0;
 }
 
 int __write_hex_cb(void *user) {
 	RzCore *core = (RzCore *)user;
-	__add_cmdf_panel(core, "insert hexpairs: ", "\"wx %s\"");
+	__add_cmdf_panel(core, "insert hexpairs: ", "wx %s");
 	return 0;
 }
 

--- a/librz/core/tui/panels.c
+++ b/librz/core/tui/panels.c
@@ -122,7 +122,7 @@ static const char *menus_Tools[] = {
 };
 
 static const char *menus_Search[] = {
-	"String (Whole Bin)", "String (Data Sections)", "ROP", "Code", "Hexpairs",
+	"String (Whole Bin)", "String (Data Sections)", "ROP", "COP", "JOP", "Code", "Hexpairs",
 	NULL
 };
 
@@ -489,6 +489,8 @@ static int __system_shell_cb(void *user);
 static int __string_whole_bin_cb(void *user);
 static int __string_data_sec_cb(void *user);
 static int __rop_cb(void *user);
+static int __cop_cb(void *user);
+static int __jop_cb(void *user);
 static int __code_cb(void *user);
 static int __hexpairs_cb(void *user);
 static int __continue_cb(void *user);
@@ -3386,19 +3388,31 @@ int __string_data_sec_cb(void *user) {
 
 int __rop_cb(void *user) {
 	RzCore *core = (RzCore *)user;
-	__add_cmdf_panel(core, "rop grep: ", "\"/R %s\"");
+	__add_cmdf_panel(core, "rop grep: ", "/R %s");
+	return 0;
+}
+
+int __cop_cb(void *user) {
+	RzCore *core = (RzCore *)user;
+	__add_cmdf_panel(core, "cop grep: ", "/C %s");
+	return 0;
+}
+
+int __jop_cb(void *user) {
+	RzCore *core = (RzCore *)user;
+	__add_cmdf_panel(core, "jop grep: ", "/J %s");
 	return 0;
 }
 
 int __code_cb(void *user) {
 	RzCore *core = (RzCore *)user;
-	__add_cmdf_panel(core, "search code: ", "\"/c %s\"");
+	__add_cmdf_panel(core, "search code: ", "/a %s");
 	return 0;
 }
 
 int __hexpairs_cb(void *user) {
 	RzCore *core = (RzCore *)user;
-	__add_cmdf_panel(core, "search hexpairs: ", "\"/x %s\"");
+	__add_cmdf_panel(core, "search hexpairs: ", "/x %s");
 	return 0;
 }
 
@@ -4588,6 +4602,10 @@ bool __init_panels_menu(RzCore *core) {
 			__add_menu(core, parent, menus_Search[i], __string_data_sec_cb);
 		} else if (!strcmp(menus_Search[i], "ROP")) {
 			__add_menu(core, parent, menus_Search[i], __rop_cb);
+		} else if (!strcmp(menus_Search[i], "COP")) {
+			__add_menu(core, parent, menus_Search[i], __cop_cb);
+		} else if (!strcmp(menus_Search[i], "JOP")) {
+			__add_menu(core, parent, menus_Search[i], __jop_cb);
 		} else if (!strcmp(menus_Search[i], "Code")) {
 			__add_menu(core, parent, menus_Search[i], __code_cb);
 		} else if (!strcmp(menus_Search[i], "Hexpairs")) {

--- a/librz/core/tui/visual.c
+++ b/librz/core/tui/visual.c
@@ -2236,13 +2236,12 @@ RZ_IPI int rz_core_visual_cmd(RzCore *core, const char *arg) {
 			rz_core_visual_showcursor(core, true);
 			rz_cons_flush();
 			rz_cons_set_raw(false);
-			strcpy(buf, "\"wa ");
+			strcpy(buf, "wa ");
 			rz_line_set_prompt(line, ":> ");
 			rz_cons_enable_mouse(false);
-			if (rz_cons_fgets(buf + 4, sizeof(buf) - 4, 0, NULL) < 0) {
+			if (rz_cons_fgets(buf + 3, sizeof(buf) - 3, 0, NULL) < 0) {
 				buf[0] = '\0';
 			}
-			strcat(buf, "\"");
 			bool wheel = rz_config_get_b(core->config, "scr.wheel");
 			if (wheel) {
 				rz_cons_enable_mouse(true);
@@ -2510,7 +2509,7 @@ RZ_IPI int rz_core_visual_cmd(RzCore *core, const char *arg) {
 				break;
 			}
 			if (core->print->col == 2) {
-				strcpy(buf, "\"w ");
+				strcpy(buf, "w \"");
 				rz_line_set_prompt(line, "insert string: ");
 				if (rz_cons_fgets(buf + 3, sizeof(buf) - 3, 0, NULL) < 0) {
 					buf[0] = '\0';

--- a/test/db/cmd/cmd_search_a
+++ b/test/db/cmd/cmd_search_a
@@ -9,7 +9,7 @@ EXPECT=
 EXPECT_ERR=<<EOF
 ERROR: Cannot assemble 'add esp, 8' at line 3
 ERROR: Failed to assemble 'add esp, 8'
-ERROR: Consider using "/ar" instead.
+ERROR: Consider using "/ad" instead.
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

- removed quotes from commands in panel mode and visual mode and also replaced with correct cmds as of now.
- added COP and JOP search cmds in panel mode.

**cmds fixed**

panel mode:
- search (ROP, COP, JOP, code search, hexpairs)
- copy (y)
- wrute string (w)
- write hex (wx)
- comments (CC)

visual mode:
- assemble (wa)
- write string (w) - selecting a range of bytes in ascii mode while under cursor mode. And then `i` for inserting string. This was failing earlier.


@Rot127 i think there was some typo in your older PR (#4931), the error message should suggest `/ad` , there's not cmd like `/ar`. Likely a typo as R and D are close on keyboard

---

**Before/After**

**Panel mode - Search Before** 

https://github.com/user-attachments/assets/a3024c15-5e1e-448d-a4bd-c07dab697b9b

**Panel mode - Search After**

https://github.com/user-attachments/assets/7e967e4d-2037-4b11-8a09-c4c5882c047a

**Panel mode - Edit before**

https://github.com/user-attachments/assets/5f01f605-cfc7-4ef1-b756-4ef8e1686155

**Panel mode - Edit AFter**

https://github.com/user-attachments/assets/3b373f89-06af-4caa-a114-1f9017e24c7d


**Visual mode Before**

https://github.com/user-attachments/assets/7fa4dd9c-24ef-4198-b9d7-644b9b49559b

**Visual mode After**

https://github.com/user-attachments/assets/b87262ba-827f-4df9-bfed-69809492d435




...

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tested all the commands in rizin session in visual and panel mode

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...



