### PR TITLE
Fix old LD linking issues

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -506,6 +506,32 @@ foreach it : ccs
     add_project_link_arguments('-Wl,--allow-shlib-undefined', language: 'c', native: it_native)
   endif
 
+  # Old GNU ld (binutils 2.22, shipped with Debian Wheezy) combined with the
+  # --as-needed flag that Meson passes by default drops shared libraries that
+  # are needed only indirectly -- through another shared library -- rather than
+  # directly by the linked object files. It then (defaulting to
+  # --no-copy-dt-needed-entries) also refuses to resolve the symbol through the
+  # dropped library's own DT_NEEDED entry. Linking the rizin tools against the
+  # rizin shared libraries therefore fails with:
+  #   librz_main.so.0.9.0: undefined reference to symbol 'rz_buf_size'
+  #   librz_util.so.0.9.0: could not read symbols: Invalid operation
+  # even though librz_util, which defines the symbol, is already on the link
+  # line. Disable --as-needed for these old linkers so the indirectly-needed
+  # libraries stay on the link line and resolve directly; newer linkers handle
+  # this correctly on their own and keep the optimisation.
+  if it_cc.get_linker_id() == 'ld.bfd'
+    ld_bin = find_program('ld', required: false, native: it_native)
+    if ld_bin.found()
+      ld_version_raw = run_command(ld_bin, '--version', check: false).stdout()
+      if ld_version_raw != ''
+        ld_version = ld_version_raw.split('\n')[0].split(' ')[-1].strip()
+        if ld_version.version_compare('<2.31')
+          add_project_link_arguments('-Wl,--no-as-needed', language: 'c', native: it_native)
+        endif
+      endif
+    endif
+  endif
+
   if it_machine.system() == 'darwin'
     # On older Mac OS X versions (at least Lion and older), environ is only available when compiling an executable,
     # but we will use is primarily in shared libs. Unfortunately, it_cc.links() only checks for executable compiling,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

An attempt to fix this issue:
```
[2417/2575] Linking target binrz/rz-ar/rz-ar
FAILED: binrz/rz-ar/rz-ar 
cc  -o binrz/rz-ar/rz-ar binrz/rz-ar/rz-ar.p/rz-ar.c.o -Wl,--as-needed -Wl,--no-undefined '-Wl,-rpath,$ORIGIN/../../librz/main:$ORIGIN/../../librz/util:$ORIGIN/../../librz/demangler:$ORIGIN/../../librz/magic:$ORIGIN/../../librz/socket:$ORIGIN/../../librz/flag:$ORIGIN/../../librz/cons:$ORIGIN/../../librz/hash:$ORIGIN/../../librz/crypto:$ORIGIN/../../librz/il:$ORIGIN/../../librz/reg:$ORIGIN/../../librz/io:$ORIGIN/../../librz/syscall:$ORIGIN/../../librz/arch:$ORIGIN/../../librz/search:$ORIGIN/../../librz/config:$ORIGIN/../../librz/diff:$ORIGIN/../../librz/bin:$ORIGIN/../../librz/type:$ORIGIN/../../librz/egg:$ORIGIN/../../librz/debug:$ORIGIN/../../librz/sign:$ORIGIN/../../librz/core:$ORIGIN/../../librz/lang:$ORIGIN/../../librz/mark' -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/main -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/util -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/demangler -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/magic -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/socket -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/flag -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/cons -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/hash -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/crypto -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/il -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/reg -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/io -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/syscall -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/arch -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/search -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/config -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/diff -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/bin -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/type -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/egg -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/debug -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/sign -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/core -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/lang -Wl,-rpath-link,/__w/rizin/rizin/rizin/build/librz/mark -Wl,--start-group librz/main/librz_main.so.0.9.0 librz/util/librz_util.so.0.9.0 librz/demangler/librz_demangler.so.0.9.0 librz/magic/librz_magic.so.0.9.0 librz/socket/librz_socket.so.0.9.0 librz/flag/librz_flag.so.0.9.0 librz/cons/librz_cons.so.0.9.0 librz/hash/librz_hash.so.0.9.0 librz/crypto/librz_crypto.so.0.9.0 librz/il/librz_il.so.0.9.0 librz/io/librz_io.so.0.9.0 librz/reg/librz_reg.so.0.9.0 librz/syscall/librz_syscall.so.0.9.0 librz/arch/librz_arch.so.0.9.0 librz/egg/librz_egg.so.0.9.0 librz/search/librz_search.so.0.9.0 librz/debug/librz_debug.so.0.9.0 librz/config/librz_config.so.0.9.0 librz/bin/librz_bin.so.0.9.0 librz/sign/librz_sign.so.0.9.0 librz/core/librz_core.so.0.9.0 librz/diff/librz_diff.so.0.9.0 subprojects/rzar/librzar.a -Wl,--end-group
/usr/bin/ld: librz/main/librz_main.so.0.9.0: undefined reference to symbol 'rz_buf_size'
/usr/bin/ld: note: 'rz_buf_size' is defined in DSO librz/util/librz_util.so.0.9.0 so try adding it to the linker command line
librz/util/librz_util.so.0.9.0: could not read symbols: Invalid operation
collect2: error: ld returned 1 exit status
```

https://github.com/rizinorg/rizin/actions/runs/27488313287/job/81248603633?pr=6487#step:13:3767

**Test plan**

CI is green