### PR TITLE
rz-find: flush output to avoid undeterminism

### DIFF
--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -160,6 +160,8 @@ static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 	}
 	if (ro->exec_command) {
 		char *command = rz_str_newf("%s %s", ro->exec_command, ro->curfile);
+		// Flush buffered output before spawning the command
+		fflush(stdout);
 		int status = rz_sys_system(command);
 		if (status == -1) {
 			RZ_LOG_ERROR("Failed to execute command: %s\n", command);

--- a/test/db/tools/rz_find
+++ b/test/db/tools/rz_find
@@ -159,12 +159,12 @@ NAME=rz-find -E
 TOOL=rz-find
 ARGS=-E echo -s Password bins/elf/ioli/crackme0x00
 EXPECT=<<EOF
-bins/elf/ioli/crackme0x00
-bins/elf/ioli/crackme0x00
-bins/elf/ioli/crackme0x00
 0x581
+bins/elf/ioli/crackme0x00
 0x59e
+bins/elf/ioli/crackme0x00
 0x5a9
+bins/elf/ioli/crackme0x00
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Should fix the issue of undeterminism in `rz-find` test output:
```
[XX] 00h00m00s018ms db/tools/rz_find rz-find -E
RZ_COLOR=0 RZ_UTF8=0 RZ_NOPLUGINS=1 /github/home/rizin-static/bin/rz-find -E echo -s Password bins/elf/ioli/crackme0x00
-- stdout
--- expected
+++ actual
@@ -1,6 +1,6 @@
+0x581
 bins/elf/ioli/crackme0x00
 bins/elf/ioli/crackme0x00
 bins/elf/ioli/crackme0x00
-0x581
 0x59e
 0x5a9
 ```

**Test plan**

CI is green
