### PR TITLE
librz/util/pj: Fix JSON depth limit handling

### DIFF
--- a/librz/include/rz_util/rz_pj.h
+++ b/librz/include/rz_util/rz_pj.h
@@ -14,7 +14,7 @@ typedef struct pj_t {
 	bool is_first;
 	bool is_key;
 	char braces[RZ_PRINT_JSON_DEPTH_LIMIT];
-	int level;
+	int level; ///< Current nesting depth. 0 = top-level, >0 = inside braces, <0 = error (depth limit exceeded).
 } PJ;
 
 /* lifecycle */

--- a/librz/include/rz_util/rz_pj.h
+++ b/librz/include/rz_util/rz_pj.h
@@ -14,7 +14,7 @@ typedef struct pj_t {
 	bool is_first;
 	bool is_key;
 	char braces[RZ_PRINT_JSON_DEPTH_LIMIT];
-	int level; ///< Current nesting depth. 0 = top-level, >0 = inside braces, <0 = error (depth limit exceeded).
+	st64 level; ///< Current nesting depth. 0 = top-level, >0 = inside braces, <0 = error (depth limit exceeded).
 } PJ;
 
 /* lifecycle */

--- a/librz/util/pj.c
+++ b/librz/util/pj.c
@@ -6,6 +6,9 @@
 
 RZ_API void pj_raw(PJ *j, const char *msg) {
 	rz_return_if_fail(j && msg);
+	if (j->level < 0) {
+		return;
+	}
 	if (*msg) {
 		rz_strbuf_append(&j->sb, msg);
 	}
@@ -13,6 +16,9 @@ RZ_API void pj_raw(PJ *j, const char *msg) {
 
 static void pj_comma(PJ *j) {
 	rz_return_if_fail(j);
+	if (j->level < 0) {
+		return;
+	}
 	if (!j->is_key) {
 		if (!j->is_first) {
 			pj_raw(j, ",");
@@ -48,19 +54,27 @@ RZ_API void pj_reset(PJ *j) {
 }
 
 RZ_API char *pj_drain(PJ *pj) {
-	rz_return_val_if_fail(pj && pj->level == 0, NULL);
+	if (!pj) {
+		return NULL;
+	}
+	if (pj->level != 0) {
+		pj_free(pj);
+		return NULL;
+	}
 	char *res = rz_strbuf_drain_nofree(&pj->sb);
 	free(pj);
 	return res;
 }
 
 RZ_API const char *pj_string(PJ *j) {
-	return j ? rz_strbuf_get(&j->sb) : NULL;
+	return (j && j->level >= 0) ? rz_strbuf_get(&j->sb) : NULL;
 }
 
 static PJ *pj_begin(PJ *j, char type) {
 	if (j) {
-		if (!j || j->level >= RZ_PRINT_JSON_DEPTH_LIMIT) {
+		if (j->level < 0 || j->level >= RZ_PRINT_JSON_DEPTH_LIMIT) {
+			j->level = -1;
+			RZ_LOG_ERROR("pj: JSON maximum depth of %d exceeded\n", RZ_PRINT_JSON_DEPTH_LIMIT);
 			return NULL;
 		}
 		char msg[2] = { type, 0 };

--- a/librz/util/pj.c
+++ b/librz/util/pj.c
@@ -58,6 +58,7 @@ RZ_API char *pj_drain(PJ *pj) {
 		return NULL;
 	}
 	if (pj->level != 0) {
+		// error case, invalid json, return NULL
 		pj_free(pj);
 		return NULL;
 	}

--- a/test/unit/test_pj.c
+++ b/test/unit/test_pj.c
@@ -22,8 +22,19 @@ bool test_pj_reset() {
 	mu_end;
 }
 
+bool test_depth_limit() {
+	PJ *j = pj_new();
+	for (int i = 0; i < RZ_PRINT_JSON_DEPTH_LIMIT + 1; i++) {
+		pj_o(j);
+	}
+	mu_assert_null(pj_string(j), "pj_string should be null after exceeding depth limit");
+	pj_free(j);
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test(test_pj_reset);
+	mu_run_test(test_depth_limit);
 	return tests_passed != tests_run;
 }
 

--- a/test/unit/test_pj.c
+++ b/test/unit/test_pj.c
@@ -28,13 +28,47 @@ bool test_depth_limit() {
 		pj_o(j);
 	}
 	mu_assert_null(pj_string(j), "pj_string should be null after exceeding depth limit");
+
+	// writing after overflow is suppressed (level<0 path)
+	pj_ks(j, "key", "val");
+	mu_assert_null(pj_string(j), "pj_string still null after writing in overflow state");
+
+	// pj_end is a nop after overflow (level<1 path)
+	pj_end(j);
+	mu_assert_null(pj_string(j), "pj_string still null after pj_end in overflow state");
 	pj_free(j);
+
+	mu_end;
+}
+
+bool test_pj_drain() {
+	// pj_drain returns NULL and frees when level != 0 (overflow)
+	PJ *j = pj_new();
+	for (int i = 0; i < RZ_PRINT_JSON_DEPTH_LIMIT + 1; i++) {
+		pj_o(j);
+	}
+	char *res = pj_drain(j); // j is consumed
+	mu_assert_null(res, "pj_drain should return NULL on overflow");
+
+	mu_assert_null(pj_drain(NULL), "pj_drain(NULL) should return NULL");
+
+	// pj_drain suceed when level=0
+	j = pj_new();
+	pj_o(j);
+	pj_ki(j, "a", 1);
+	pj_end(j);
+	res = pj_drain(j);
+	mu_assert_notnull(res, "pj_drain should succeed on valid json");
+	mu_assert_streq(res, "{\"a\":1}", "pj_drain result");
+	free(res);
+
 	mu_end;
 }
 
 int all_tests() {
 	mu_run_test(test_pj_reset);
 	mu_run_test(test_depth_limit);
+	mu_run_test(test_pj_drain);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

It was failing silently when hardcoded JSON depth limit was exceeded.

now if depth limit is exceeded, it logs error and returns NULL instead of invalid  json
also once this error happens , any subsequent addition will be rejected (to preserve error till end)  and finally return NULL

...

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
