### PR TITLE
librz/debug: fix follow child on Linux

### DIFF
--- a/librz/debug/debug.c
+++ b/librz/debug/debug.c
@@ -11,6 +11,15 @@
 
 RZ_LIB_VERSION(rz_debug);
 
+#if __linux__ && DEBUGGER
+// Defined by the native Linux debugger plugin, which is compiled into this same
+// library (librz_debug) under the same conditions as this file. Declared here so
+// that rz_debug_continue() can switch to a forked child without resorting to a
+// fragile runtime dlsym() lookup (the symbol has hidden visibility and cannot be
+// resolved that way).
+extern bool linux_attach_new_process(RzDebug *dbg, int pid);
+#endif
+
 // Size of the lookahead buffers used in rz_debug functions
 #define DBG_BUF_SIZE 512
 
@@ -398,8 +407,10 @@ RZ_API RZ_OWN RzDebug *rz_debug_new(RZ_BORROW RZ_NONNULL RzBreakpointContext *bp
 	dbg->num = rz_num_new(rz_debug_num_callback, rz_debug_str_callback, dbg);
 	dbg->cur = NULL;
 	dbg->plugin_data = NULL;
-	dbg->threads = NULL;
+	// dbg->threads = NULL;
 	dbg->hitinfo = 1;
+	dbg->processes = rz_list_new();
+	dbg->cur_proc = NULL;
 	/* TODO: needs a redesign? */
 	dbg->maps = rz_debug_map_list_new();
 	dbg->maps_user = rz_debug_map_list_new();
@@ -1154,6 +1165,12 @@ RZ_API int rz_debug_continue_kill(RzDebug *dbg, int sig) {
 	RzDebugReasonType reason = RZ_DEBUG_REASON_NONE;
 	int ret = 0;
 	RzBreakpointItem *bp = NULL;
+#if __linux__
+	// Tracks the iteration on which we just followed a forked child, so its
+	// pending post-fork SIGSTOP can be swallowed on the next wait (see below).
+	bool followed_child = false;
+	bool just_followed_child = false;
+#endif
 
 	if (!dbg) {
 		return 0;
@@ -1213,6 +1230,11 @@ repeat:
 		return 0;
 	}
 
+// #if __linux__
+// 	just_followed_child = followed_child;
+// 	followed_child = false;
+// #endif
+
 	if (dbg->corebind.core) {
 		RzCore *core = (RzCore *)dbg->corebind.core;
 		RzNum *num = core->num;
@@ -1231,18 +1253,35 @@ repeat:
 	}
 
 #if __linux__
-	if (reason == RZ_DEBUG_REASON_NEW_PID && dbg->follow_child) {
-#if DEBUGGER
-		/// if the plugin is not compiled link fails, so better do runtime linking
-		/// until this code gets fixed
-		static bool (*linux_attach_new_process)(RzDebug *dbg, int pid) = NULL;
-		if (!linux_attach_new_process) {
-			linux_attach_new_process = rz_sys_dlsym(NULL, "linux_attach_new_process");
-		}
-		if (linux_attach_new_process) {
-			linux_attach_new_process(dbg, dbg->forked_pid);
-		}
-#endif
+// 	// After following a fork, the child still has the SIGSTOP that the kernel
+// 	// raised on it at fork time pending. The first continue surfaces that as a
+// 	// signal-stop at the libc fork() return instead of running on to the user's
+// 	// breakpoint. Swallow that one SIGSTOP so following a child behaves like
+// 	// gdb's "set follow-fork-mode child", which lands directly on the breakpoint.
+// 	if (just_followed_child && reason == RZ_DEBUG_REASON_SIGNAL &&
+// 		dbg->reason.signum == SIGSTOP) {
+// 		goto repeat;
+// 	}
+// 	if (reason == RZ_DEBUG_REASON_NEW_PID && dbg->follow_child) {
+// #if DEBUGGER
+// 		// dbg->pid is still the parent here. linux_attach_new_process() detaches
+// 		// the parent (without restoring its original code bytes) and switches to
+// 		// the forked child. The parent shares the inherited software breakpoints
+// 		// (int3) with the child, so the now-untraced parent would take a fatal
+// 		// SIGTRAP the moment it executed one of them. Remove the breakpoints from
+// 		// the parent before it is detached; the child keeps its own int3 bytes
+// 		// via copy-on-write, so its breakpoints keep working without reinstalling.
+// 		rz_debug_bp_update(dbg);
+// 		rz_bp_restore(dbg->bp, false);
+// 		linux_attach_new_process(dbg, dbg->forked_pid);
+// 		followed_child = true;
+// #endif
+// 		goto repeat;
+// 	}
+
+	if(reason == RZ_DEBUG_REASON_NEW_PID && dbg->follow_child){
+		rz_bp_restore(dbg->bp, false);
+		rz_debug_select(dbg, dbg->forked_pid, dbg->forked_pid);
 		goto repeat;
 	}
 

--- a/librz/debug/p/native/linux/linux_debug.c
+++ b/librz/debug/p/native/linux/linux_debug.c
@@ -246,6 +246,9 @@ RzDebugReasonType linux_ptrace_event(RzDebug *dbg, int ptid, int status, bool do
 			return RZ_DEBUG_REASON_ERROR;
 		}
 		dbg->forked_pid = data;
+		RzDebugProcess *forked_child = RZ_NEW0(RzDebugProcess);
+		forked_child->pid=data;
+		rz_list_append(dbg->processes, (void *)data);
 		if (dowait) {
 			// The new child has a pending SIGSTOP. We can't affect it until it
 			// hits the SIGSTOP, but we're already attached.  */
@@ -254,13 +257,13 @@ RzDebugReasonType linux_ptrace_event(RzDebug *dbg, int ptid, int status, bool do
 			}
 		}
 		RZ_LOG_WARN("(%d) Created process %d\n", ptid, (int)data);
-		if (!dbg->trace_forks) {
+		if (!dbg->trace_forks && !dbg->follow_child) {
 			// We need to do this even if the new process will be detached since the
 			// breakpoints are inherited from the parent
 			linux_remove_fork_bps(dbg);
-			if (rz_debug_ptrace(dbg, PTRACE_DETACH, dbg->forked_pid, NULL, (rz_ptrace_data_t)(size_t)NULL) == -1) {
-				perror("PTRACE_DETACH");
-			}
+			// if (rz_debug_ptrace(dbg, PTRACE_DETACH, dbg->forked_pid, NULL, (rz_ptrace_data_t)(size_t)NULL) == -1) {
+			// 	perror("PTRACE_DETACH");
+			// }
 		}
 		return RZ_DEBUG_REASON_NEW_PID;
 	case PTRACE_EVENT_EXIT:
@@ -407,6 +410,9 @@ static void linux_remove_thread(RzDebug *dbg, int tid) {
 }
 
 bool linux_select(RzDebug *dbg, int pid, int tid) {
+	if(rz_list_contains(dbg->processes, (void *)pid)){
+		return true;
+	}
 	if (dbg->pid != -1 && dbg->pid != pid) {
 		return linux_attach_new_process(dbg, pid);
 	}

--- a/librz/include/rz_debug.h
+++ b/librz/include/rz_debug.h
@@ -235,6 +235,13 @@ typedef struct rz_debug_tracepoint_t {
 	ut64 stamp;
 } RzDebugTracepoint;
 
+typedef struct rz_debug_process_t{
+	int pid;
+	int n_threads;
+	RzList /*<void *>*/ *threads; /* NOTE: list contents are platform-specific */
+	RzReg reg;
+} RzDebugProcess;
+
 typedef struct rz_debug_t {
 	char *arch;
 	RZ_DEPRECATE int bits; ///< bad indicator for the bitness of the debuggee
@@ -245,7 +252,8 @@ typedef struct rz_debug_t {
 	int tid; /* selected thread id */
 	int forked_pid; /* last pid created by fork */
 	int n_threads;
-	RzList /*<void *>*/ *threads; /* NOTE: list contents are platform-specific */
+	RzList /*<RzDebugProcess>*/ *processes;
+	RzDebugProcess *cur_proc;
 
 	char *malloc; /*choose malloc parser: 0 = glibc, 1 = jemalloc*/
 

--- a/test/db/archos/linux-x64/dbg_follow_child
+++ b/test/db/archos/linux-x64/dbg_follow_child
@@ -1,0 +1,33 @@
+NAME=dbg.follow.child follows the forked child
+FILE=bins/elf/analysis/x64-fork-test
+ARGS=-d
+CMDS=<<EOF
+e scr.color=0
+e dbg.follow.child=true
+dc
+EOF
+EXPECT=<<EOF
+child in leaf!
+child process terminating!
+main exiting!
+EOF
+RUN
+
+NAME=dbg.follow.child stops at a breakpoint in the child
+FILE=bins/elf/analysis/x64-fork-test
+ARGS=-d
+CMDS=<<EOF
+e scr.color=0
+e dbg.follow.child=true
+db @ sym.break_on_me
+dc
+dr rip
+dc
+EOF
+EXPECT=<<EOF
+rip = 0x000000000040071d
+child in leaf!
+child process terminating!
+main exiting!
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Fix https://github.com/rizinorg/rizin/issues/2675

Separate out Threads from RzDebugPid, also better naming conventions wherever possible

This would result in refactor in all OS specific files:

- [ ] librz/debug/p/native/linux/linux_debug.c
- [ ] librz/debug/p/native/bsd/kfbsd_debug.c
- [ ] librz/debug/p/native/bsd/netbsd_debug.c
- [ ] librz/debug/p/native/bsd/openbsd_debug.c
- [ ] librz/debug/p/native/windows/windows_debug.c
- [ ] librz/debug/p/native/xnu/*
- [ ] other plugins other than natve

**Test plan**

- CI is green
- Try the debugger on Linux