### PR TITLE
Float Core: Fix positive zero comparing inequal with negative zero, against IEEE754

### DIFF
--- a/librz/util/float/float.c
+++ b/librz/util/float/float.c
@@ -1890,7 +1890,11 @@ RZ_API RZ_OWN st32 rz_float_cmp(RZ_NONNULL RzFloat *x, RZ_NONNULL RzFloat *y) {
 			cmp = -cmp;
 		}
 	} else {
-		cmp = rz_bv_ule(x_bv, y_bv) ? 1 : -1;
+		if (rz_float_is_zero(x) && rz_float_is_zero(y)) {
+			cmp = 0;
+		} else {
+			cmp = rz_bv_ule(x_bv, y_bv) ? 1 : -1;
+		}
 	}
 
 	rz_bv_free(x_bv);

--- a/test/unit/test_float.c
+++ b/test/unit/test_float.c
@@ -910,6 +910,11 @@ bool f32_ieee_cmp_test(void) {
 	mu_assert_true(rz_float_cmp(pinf, a) > 0, "test positive inf");
 	mu_assert_true(rz_float_cmp(ninf, b) < 0, "test negative inf");
 
+	RzFloat *pzero = rz_float_new_zero(RZ_FLOAT_IEEE754_BIN_32, false);
+	RzFloat *nzero = rz_float_new_zero(RZ_FLOAT_IEEE754_BIN_32, true);
+	mu_assert_true(rz_float_cmp(pzero, nzero) == 0, "test positive and negative zero equality");
+	mu_assert_true(rz_float_cmp(nzero, pzero) == 0, "test negative and positive zero equality");
+
 	rz_float_free(a);
 	rz_float_free(b);
 	rz_float_free(c);
@@ -917,6 +922,8 @@ bool f32_ieee_cmp_test(void) {
 	rz_float_free(e);
 	rz_float_free(pinf);
 	rz_float_free(ninf);
+	rz_float_free(pzero);
+	rz_float_free(nzero);
 
 	mu_end;
 }


### PR DESCRIPTION

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

IEEE754 says that +0 and -0 should compare equal in a direct equality test (not under maxNumber or minNumber though, only `==` direct equality), the float core used to consider any 2 numbers differing in the sign bit as necessarily unequal, this is wrong behaviour.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Added a unit test to ensure that negative zero and positive zero representation compare equal to each other, commenting my fix makes that unit test fail.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

No existing issue, bug encountered while probing the edge cases of float arithmetic for stress-testing RISC-V float instruction lifting.