### PR TITLE
 Address truncation in interactive histogram X-axis ruler

### DIFF
--- a/librz/cons/histogram.c
+++ b/librz/cons/histogram.c
@@ -733,7 +733,7 @@ static void render_visual_xaxis_ruler(RzStrBuf *buf, const RzHistogramInteractiv
 		if (t + 1 < ticks) {
 			max_room = tick_cols[t + 1] - start_col - 1;
 		} else {
-			max_room = (int)data_cols - start_col;
+			max_room = sizeof(label);
 		}
 		if (max_room < 1) {
 			max_room = 1;

--- a/librz/cons/histogram.c
+++ b/librz/cons/histogram.c
@@ -712,14 +712,12 @@ static void render_visual_xaxis_ruler(RzStrBuf *buf, const RzHistogramInteractiv
 		int realj, max_room, wrote;
 		ut64 off;
 		char label[32] = { 0 };
-		if ((int)c < start_col) {
-			rz_strbuf_appendf(buf, "%*s", start_col - (int)c, "");
-			c = (ut32)start_col;
-		}
+
+		// Calculate label value early to know its length before padding
 		if (sizeofonebar > 1) {
-			realj = adder + (int)c / sizeofonebar;
+			realj = adder + start_col / sizeofonebar;
 		} else {
-			realj = adder + (int)((ut64)c * histogramwidth / ((ut64)zoom * width));
+			realj = adder + (int)((ut64)start_col * histogramwidth / ((ut64)zoom * width));
 		}
 		if (realj < 0) {
 			realj = 0;
@@ -729,6 +727,26 @@ static void render_visual_xaxis_ruler(RzStrBuf *buf, const RzHistogramInteractiv
 		off = opts->offpos + (ut64)realj * hist->blocksize;
 		rz_strf(label, "0x%" PFMT64x, off);
 		wrote = (int)strlen(label);
+
+		// If this is the last tick, shift start_col to the left so the whole label fits
+		if (t + 1 == ticks && wrote > 0) {
+			int new_start = (int)data_cols - wrote;
+			if (new_start < 0) {
+				new_start = 0;
+			}
+			if (t > 0 && new_start <= tick_cols[t - 1]) {
+				new_start = tick_cols[t - 1] + 1;
+			}
+			if (new_start < start_col && (int)c <= new_start) {
+				start_col = new_start;
+			}
+		}
+
+		if ((int)c < start_col) {
+			rz_strbuf_appendf(buf, "%*s", start_col - (int)c, "");
+			c = (ut32)start_col;
+		}
+
 		// Truncate if the label would overflow into the next tick.
 		if (t + 1 < ticks) {
 			max_room = tick_cols[t + 1] - start_col - 1;


### PR DESCRIPTION


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
The interactive horizontal histogram (`p==`) truncated the rightmost address offset on the X-axis ruler to a single character (e.g. `0` instead of `0x...`) because `max_room` for the last label tick was constrained to `data_cols - start_col`.

This commit replaces the `max_room` calculation for the last tick so that it does not aggressively truncate the label, allowing the full address to be displayed correctly.
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

...

**Test plan**
1. Build the project using `ninja -C build`.
2. Run `rizin` and view interactive histogram using `p== <size>`.
3. Notice that the last address on the x-axis ruler (bottom right) is no longer truncated and displays the full address representation (e.g. `0x1000` instead of `0`).
4. Ensure the regression tests for histogram pass via `ninja -C build test` or specifically `cd test && rz-test db/cmd/cmd_print`.
<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**
Closes:. #6550
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
