### PR TITLE
Bump rz-libdemangle to get the dlang demangler

### DIFF
--- a/librz/bin/bin_demangle.c
+++ b/librz/bin/bin_demangle.c
@@ -106,6 +106,8 @@ RZ_API RZ_OWN char *rz_bin_demangle(RZ_NULLABLE RzBin *bin, RZ_NULLABLE const ch
 		return rz_demangler_rust(mangled, flags);
 	case RZ_BIN_LANGUAGE_CXX:
 		return rz_demangler_cxx(mangled, flags);
+	case RZ_BIN_LANGUAGE_DLANG:
+		return rz_demangler_dlang(mangled, flags);
 	default:
 		break;
 	}

--- a/librz/bin/bin_language.c
+++ b/librz/bin/bin_language.c
@@ -19,10 +19,7 @@ static inline bool check_objc(RzBinSymbol *sym) {
 }
 
 static inline bool check_dlang(RzBinSymbol *sym) {
-	if (!strncmp(sym->name, "_D2", 3)) {
-		return true;
-	}
-	return !strncmp(sym->name, "_D4", 3);
+	return !strncmp(sym->name, "_D", 2) && IS_DIGIT(sym->name[2]);
 }
 
 static inline bool check_swift(RzBinSymbol *sym) {

--- a/librz/demangler/demangler.c
+++ b/librz/demangler/demangler.c
@@ -26,6 +26,7 @@ DEFINE_DEMANGLER_PLUGIN(java, "java", "LGPL3", "deroad", libdemangle_handler_jav
 DEFINE_DEMANGLER_PLUGIN(msvc, "msvc", "LGPL3", "inisider", libdemangle_handler_msvc);
 DEFINE_DEMANGLER_PLUGIN(objc, "objc", "LGPL3", "pancake", libdemangle_handler_objc);
 DEFINE_DEMANGLER_PLUGIN(pascal, "pascal", "LGPL3", "deroad", libdemangle_handler_pascal);
+DEFINE_DEMANGLER_PLUGIN(dlang, "dlang", "LGPL3", "historicattle", libdemangle_handler_d);
 
 static RzDemanglerPlugin *demangler_static_plugins[] = { RZ_DEMANGLER_STATIC_PLUGINS };
 
@@ -71,6 +72,13 @@ RZ_API RZ_OWN char *rz_demangler_rust(RZ_NONNULL const char *symbol, RzDemangler
  */
 RZ_API RZ_OWN char *rz_demangler_msvc(RZ_NONNULL const char *symbol, RzDemanglerFlag flags) {
 	return libdemangle_handler_msvc(symbol, (RzDemangleOpts)flags);
+}
+
+/**
+ * \brief Demangles DLang symbols
+ */
+RZ_API RZ_OWN char *rz_demangler_dlang(RZ_NONNULL const char *symbol, RzDemanglerFlag flags) {
+	return libdemangle_handler_d(symbol, (RzDemangleOpts)flags);
 }
 
 /**

--- a/librz/demangler/meson.build
+++ b/librz/demangler/meson.build
@@ -4,7 +4,8 @@ demangler_plugins_list = [
   'objc',
   'pascal',
   'cpp',
-  'rust'
+  'rust',
+  'dlang',
 ]
 
 demangler_plugins = {

--- a/librz/include/rz_demangler.h
+++ b/librz/include/rz_demangler.h
@@ -43,6 +43,7 @@ RZ_API RZ_OWN char *rz_demangler_objc(RZ_NONNULL const char *symbol, RzDemangler
 RZ_API RZ_OWN char *rz_demangler_pascal(RZ_NONNULL const char *symbol, RzDemanglerFlag flags);
 RZ_API RZ_OWN char *rz_demangler_rust(RZ_NONNULL const char *symbol, RzDemanglerFlag flags);
 RZ_API RZ_OWN char *rz_demangler_msvc(RZ_NONNULL const char *symbol, RzDemanglerFlag flags);
+RZ_API RZ_OWN char *rz_demangler_dlang(RZ_NONNULL const char *symbol, RzDemanglerFlag flags);
 
 RZ_API RZ_OWN RzDemangler *rz_demangler_new(void);
 RZ_API void rz_demangler_free(RZ_NULLABLE RzDemangler *demangler);

--- a/subprojects/libdemangle.wrap
+++ b/subprojects/libdemangle.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 url = https://github.com/rizinorg/rz-libdemangle.git
-revision = e633061e901208a20ed90f8aaf0b64f25caf73eb
+revision = d86b1c1514a0ad19762feb596e99b691e49e7730
 depth = 1

--- a/test/db/formats/demangling_bin
+++ b/test/db/formats/demangling_bin
@@ -530,3 +530,12 @@ EXPECT=<<EOF
 0x004009e0 16 Swift.String.init (_builtinStringLiteral(Builtin.RawPointer byteSize__Builtin.Word isASCII__Builtin.Int1 _) -> String
 EOF
 RUN
+
+NAME=elf dlang demangling
+FILE=bins/elf/analysis/class_dlang
+CMDS=is~0x00089b24
+EXPECT=<<EOF
+ 233 0x00089b24 0x00089b24 WEAK   FUNC   4860     const pure nothrow @safe immutable(char)[] core.time.Duration.toString()
+4372 0x00089b24 0x00089b24 WEAK   FUNC   4860     const pure nothrow @safe immutable(char)[] core.time.Duration.toString()
+EOF
+RUN

--- a/test/db/tools/rz_bin
+++ b/test/db/tools/rz_bin
@@ -1138,6 +1138,7 @@ objc   LGPL3        pancake
 pascal LGPL3        deroad
 c++    LGPL3        billow
 rust   LGPL3        Dhruv Maroo/RizinOrg
+dlang  LGPL3        historicattle
 EOF
 RUN
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
Bump the commit hash of `rz-libdemangle` to get the dlang demangler.
Fix `check_dlang()` to check if the string starts with "_D" followed by _any_ digit.

**Test plan**
Add a test in `test/db/formats/demangling_bin`
Changes a test in `test/db/tools/rz_bin`

**Closing issues**
none