### PR TITLE
lbrz/core/cmd: fix config print for plugins and one mem leak

### DIFF
--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -444,8 +444,11 @@ static void print_all_plugin_configs(const RzCore *core) {
 	rz_cmd_state_output_fini(&state);
 }
 
-static RZ_BORROW RzConfig *eval_get_config_obj_by_key(const RzCore *core, const char *config_str) {
+static RZ_BORROW RzConfig *eval_get_config_obj_by_key(const RzCore *core, const char *config_str, bool *invalid_plugin) {
 	rz_return_val_if_fail(core && config_str, NULL);
+	if (invalid_plugin) {
+		*invalid_plugin = false;
+	}
 	RzConfig *cfg = NULL;
 	if (!rz_str_startswith(config_str, "plugins")) {
 		return core->config;
@@ -459,6 +462,9 @@ static RZ_BORROW RzConfig *eval_get_config_obj_by_key(const RzCore *core, const 
 	const char *second_dot = strchr(first_dot + 1, '.');
 	bool cfg_found = false;
 	if (!second_dot) {
+		if (RZ_STR_ISEMPTY(first_dot + 1)) {
+			return NULL;
+		}
 		cfg = ht_sp_find(core->plugin_configs, first_dot + 1, &cfg_found);
 	} else {
 		char *config_name = rz_sub_str_ptr(config_str, first_dot + 1, second_dot - 1);
@@ -467,6 +473,9 @@ static RZ_BORROW RzConfig *eval_get_config_obj_by_key(const RzCore *core, const 
 	}
 	if (!cfg_found) {
 		RZ_LOG_DEBUG("Did not find plugin config with name '%s'\n", config_str);
+		if (invalid_plugin) {
+			*invalid_plugin = true;
+		}
 		return NULL;
 	}
 	return cfg;
@@ -491,8 +500,15 @@ RZ_IPI RzCmdStatus rz_eval_getset_handler(RzCore *core, int argc, const char **a
 		}
 
 		RzConfig *cfg = NULL;
-		if (!(cfg = eval_get_config_obj_by_key(core, key))) {
+		bool invalid_plugin = false;
+		if (!(cfg = eval_get_config_obj_by_key(core, key, &invalid_plugin))) {
+			if (invalid_plugin) {
+				RZ_LOG_ERROR("core: Invalid config key '%s'\n", key);
+				rz_list_free(l);
+				return RZ_CMD_STATUS_ERROR;
+			}
 			print_all_plugin_configs(core);
+			rz_list_free(l);
 			return RZ_CMD_STATUS_OK;
 		}
 		if (llen == 1 && rz_str_endswith(key, ".")) {
@@ -524,7 +540,12 @@ RZ_IPI RzCmdStatus rz_eval_getset_handler(RzCore *core, int argc, const char **a
 RZ_IPI RzCmdStatus rz_eval_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
 	const char *arg = argc > 1 ? argv[1] : "";
 	RzConfig *cfg = NULL;
-	if (!(cfg = eval_get_config_obj_by_key(core, arg))) {
+	bool invalid_plugin = false;
+	if (!(cfg = eval_get_config_obj_by_key(core, arg, &invalid_plugin))) {
+		if (invalid_plugin) {
+			RZ_LOG_ERROR("core: Invalid config key '%s'\n", arg);
+			return RZ_CMD_STATUS_ERROR;
+		}
 		print_all_plugin_configs(core);
 		return RZ_CMD_STATUS_OK;
 	}
@@ -539,7 +560,12 @@ RZ_IPI RzCmdStatus rz_eval_reset_handler(RzCore *core, int argc, const char **ar
 
 RZ_IPI RzCmdStatus rz_eval_bool_invert_handler(RzCore *core, int argc, const char **argv) {
 	RzConfig *cfg = NULL;
-	if (!(cfg = eval_get_config_obj_by_key(core, argv[1]))) {
+	bool invalid_plugin = false;
+	if (!(cfg = eval_get_config_obj_by_key(core, argv[1], &invalid_plugin))) {
+		if (invalid_plugin) {
+			RZ_LOG_ERROR("core: Invalid config key '%s'\n", argv[1]);
+			return RZ_CMD_STATUS_ERROR;
+		}
 		print_all_plugin_configs(core);
 		return RZ_CMD_STATUS_OK;
 	}
@@ -552,7 +578,12 @@ RZ_IPI RzCmdStatus rz_eval_bool_invert_handler(RzCore *core, int argc, const cha
 
 RZ_IPI RzCmdStatus rz_eval_editor_handler(RzCore *core, int argc, const char **argv) {
 	RzConfig *cfg = NULL;
-	if (!(cfg = eval_get_config_obj_by_key(core, argv[1]))) {
+	bool invalid_plugin = false;
+	if (!(cfg = eval_get_config_obj_by_key(core, argv[1], &invalid_plugin))) {
+		if (invalid_plugin) {
+			RZ_LOG_ERROR("core: Invalid config key '%s'\n", argv[1]);
+			return RZ_CMD_STATUS_ERROR;
+		}
 		print_all_plugin_configs(core);
 		return RZ_CMD_STATUS_OK;
 	}
@@ -573,7 +604,12 @@ RZ_IPI RzCmdStatus rz_eval_editor_handler(RzCore *core, int argc, const char **a
 
 RZ_IPI RzCmdStatus rz_eval_readonly_handler(RzCore *core, int argc, const char **argv) {
 	RzConfig *cfg = NULL;
-	if (!(cfg = eval_get_config_obj_by_key(core, argv[1]))) {
+	bool invalid_plugin = false;
+	if (!(cfg = eval_get_config_obj_by_key(core, argv[1], &invalid_plugin))) {
+		if (invalid_plugin) {
+			RZ_LOG_ERROR("core: Invalid config key '%s'\n", argv[1]);
+			return RZ_CMD_STATUS_ERROR;
+		}
 		print_all_plugin_configs(core);
 		return RZ_CMD_STATUS_OK;
 	}
@@ -602,7 +638,12 @@ RZ_IPI RzCmdStatus rz_eval_spaces_handler(RzCore *core, int argc, const char **a
 
 RZ_IPI RzCmdStatus rz_eval_type_handler(RzCore *core, int argc, const char **argv) {
 	RzConfig *cfg = NULL;
-	if (!(cfg = eval_get_config_obj_by_key(core, argv[1]))) {
+	bool invalid_plugin = false;
+	if (!(cfg = eval_get_config_obj_by_key(core, argv[1], &invalid_plugin))) {
+		if (invalid_plugin) {
+			RZ_LOG_ERROR("core: Invalid config key '%s'\n", argv[1]);
+			return RZ_CMD_STATUS_ERROR;
+		}
 		print_all_plugin_configs(core);
 		return RZ_CMD_STATUS_OK;
 	}

--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -481,6 +481,21 @@ static RZ_BORROW RzConfig *eval_get_config_obj_by_key(const RzCore *core, const 
 	return cfg;
 }
 
+static RZ_BORROW RzConfig *eval_get_config_obj_by_key_or_error(RzCore *core, const char *config_str, RzCmdStatus *status) {
+	bool invalid_plugin = false;
+	RzConfig *cfg = eval_get_config_obj_by_key(core, config_str, &invalid_plugin);
+	if (!cfg) {
+		if (invalid_plugin) {
+			RZ_LOG_ERROR("core: Invalid config key '%s'\n", config_str);
+			*status = RZ_CMD_STATUS_ERROR;
+		} else {
+			print_all_plugin_configs(core);
+			*status = RZ_CMD_STATUS_OK;
+		}
+	}
+	return cfg;
+}
+
 RZ_IPI RzCmdStatus rz_eval_getset_handler(RzCore *core, int argc, const char **argv) {
 	int i;
 	for (i = 1; i < argc; i++) {
@@ -499,17 +514,11 @@ RZ_IPI RzCmdStatus rz_eval_getset_handler(RzCore *core, int argc, const char **a
 			continue;
 		}
 
-		RzConfig *cfg = NULL;
-		bool invalid_plugin = false;
-		if (!(cfg = eval_get_config_obj_by_key(core, key, &invalid_plugin))) {
-			if (invalid_plugin) {
-				RZ_LOG_ERROR("core: Invalid config key '%s'\n", key);
-				rz_list_free(l);
-				return RZ_CMD_STATUS_ERROR;
-			}
-			print_all_plugin_configs(core);
+		RzCmdStatus status;
+		RzConfig *cfg = eval_get_config_obj_by_key_or_error(core, key, &status);
+		if (!cfg) {
 			rz_list_free(l);
-			return RZ_CMD_STATUS_OK;
+			return status;
 		}
 		if (llen == 1 && rz_str_endswith(key, ".")) {
 			// no value was set, only key with ".". List possible sub-keys.
@@ -539,15 +548,10 @@ RZ_IPI RzCmdStatus rz_eval_getset_handler(RzCore *core, int argc, const char **a
 
 RZ_IPI RzCmdStatus rz_eval_list_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
 	const char *arg = argc > 1 ? argv[1] : "";
-	RzConfig *cfg = NULL;
-	bool invalid_plugin = false;
-	if (!(cfg = eval_get_config_obj_by_key(core, arg, &invalid_plugin))) {
-		if (invalid_plugin) {
-			RZ_LOG_ERROR("core: Invalid config key '%s'\n", arg);
-			return RZ_CMD_STATUS_ERROR;
-		}
-		print_all_plugin_configs(core);
-		return RZ_CMD_STATUS_OK;
+	RzCmdStatus status;
+	RzConfig *cfg = eval_get_config_obj_by_key_or_error(core, arg, &status);
+	if (!cfg) {
+		return status;
 	}
 	rz_core_config_print_all(cfg, arg, state);
 	return RZ_CMD_STATUS_OK;
@@ -559,15 +563,10 @@ RZ_IPI RzCmdStatus rz_eval_reset_handler(RzCore *core, int argc, const char **ar
 }
 
 RZ_IPI RzCmdStatus rz_eval_bool_invert_handler(RzCore *core, int argc, const char **argv) {
-	RzConfig *cfg = NULL;
-	bool invalid_plugin = false;
-	if (!(cfg = eval_get_config_obj_by_key(core, argv[1], &invalid_plugin))) {
-		if (invalid_plugin) {
-			RZ_LOG_ERROR("core: Invalid config key '%s'\n", argv[1]);
-			return RZ_CMD_STATUS_ERROR;
-		}
-		print_all_plugin_configs(core);
-		return RZ_CMD_STATUS_OK;
+	RzCmdStatus status;
+	RzConfig *cfg = eval_get_config_obj_by_key_or_error(core, argv[1], &status);
+	if (!cfg) {
+		return status;
 	}
 	if (!rz_config_toggle(cfg, argv[1])) {
 		RZ_LOG_ERROR("core: Cannot toggle config key '%s'\n", argv[1]);
@@ -577,15 +576,10 @@ RZ_IPI RzCmdStatus rz_eval_bool_invert_handler(RzCore *core, int argc, const cha
 }
 
 RZ_IPI RzCmdStatus rz_eval_editor_handler(RzCore *core, int argc, const char **argv) {
-	RzConfig *cfg = NULL;
-	bool invalid_plugin = false;
-	if (!(cfg = eval_get_config_obj_by_key(core, argv[1], &invalid_plugin))) {
-		if (invalid_plugin) {
-			RZ_LOG_ERROR("core: Invalid config key '%s'\n", argv[1]);
-			return RZ_CMD_STATUS_ERROR;
-		}
-		print_all_plugin_configs(core);
-		return RZ_CMD_STATUS_OK;
+	RzCmdStatus status;
+	RzConfig *cfg = eval_get_config_obj_by_key_or_error(core, argv[1], &status);
+	if (!cfg) {
+		return status;
 	}
 	char *val = rz_config_get_as_string(cfg, argv[1]);
 	if (!val) {
@@ -603,15 +597,10 @@ RZ_IPI RzCmdStatus rz_eval_editor_handler(RzCore *core, int argc, const char **a
 }
 
 RZ_IPI RzCmdStatus rz_eval_readonly_handler(RzCore *core, int argc, const char **argv) {
-	RzConfig *cfg = NULL;
-	bool invalid_plugin = false;
-	if (!(cfg = eval_get_config_obj_by_key(core, argv[1], &invalid_plugin))) {
-		if (invalid_plugin) {
-			RZ_LOG_ERROR("core: Invalid config key '%s'\n", argv[1]);
-			return RZ_CMD_STATUS_ERROR;
-		}
-		print_all_plugin_configs(core);
-		return RZ_CMD_STATUS_OK;
+	RzCmdStatus status;
+	RzConfig *cfg = eval_get_config_obj_by_key_or_error(core, argv[1], &status);
+	if (!cfg) {
+		return status;
 	}
 
 	if (!rz_config_set_readonly(cfg, argv[1], true)) {
@@ -637,15 +626,10 @@ RZ_IPI RzCmdStatus rz_eval_spaces_handler(RzCore *core, int argc, const char **a
 }
 
 RZ_IPI RzCmdStatus rz_eval_type_handler(RzCore *core, int argc, const char **argv) {
-	RzConfig *cfg = NULL;
-	bool invalid_plugin = false;
-	if (!(cfg = eval_get_config_obj_by_key(core, argv[1], &invalid_plugin))) {
-		if (invalid_plugin) {
-			RZ_LOG_ERROR("core: Invalid config key '%s'\n", argv[1]);
-			return RZ_CMD_STATUS_ERROR;
-		}
-		print_all_plugin_configs(core);
-		return RZ_CMD_STATUS_OK;
+	RzCmdStatus status;
+	RzConfig *cfg = eval_get_config_obj_by_key_or_error(core, argv[1], &status);
+	if (!cfg) {
+		return status;
 	}
 	RzConfigNode *node = rz_config_node_get(cfg, argv[1]);
 	if (!node) {

--- a/test/db/cmd/cmd_eval
+++ b/test/db/cmd/cmd_eval
@@ -193,15 +193,15 @@ zoom.to=0
 EOF
 RUN
 
-NAME=List and set plugin configurations
+NAME=List and set hexagon plugin configurations
 FILE==
 CMDS=<<EOF
-el plugins
+el plugins.hexagon
 # Should print nothing
-el plugins
+el plugins.hexagon
 e asm.arch=hexagon
 # Now it should print the hexagon options.
-el plugins.
+el plugins.hexagon
 # Check if it only prints a specific sub-category.
 el plugins.hexagon.imm
 # Check if a value change is performed properly.
@@ -215,13 +215,13 @@ pi 1
 # Disable plugin.
 e asm.arch=x86
 # Should print no hexagon options anymore
-el plugins.
+el plugins.hexagon
 EOF
 EXPECT=<<EOF
-plugins.hexagon.imm.hash=true
-plugins.hexagon.imm.sign=true
-plugins.hexagon.reg.alias=true
-plugins.hexagon.sdk=false
+plugins.hexagon.imm.hash: Display ## before 32bit immediates and # before immidiates with other width.
+plugins.hexagon.imm.sign: True: Print them with sign. False: Print signed immediates in unsigned representation.
+plugins.hexagon.reg.alias: Print the alias of registers (Alias from C0 = SA0).
+ plugins.hexagon.sdk: Print packet syntax in objdump style.
 plugins.hexagon.imm.hash: Display ## before 32bit immediates and # before immidiates with other width.
 plugins.hexagon.imm.sign: True: Print them with sign. False: Print signed immediates in unsigned representation.
 [   allocframe(SP,#0x8):raw

--- a/test/db/cmd/cmd_eval
+++ b/test/db/cmd/cmd_eval
@@ -228,3 +228,29 @@ plugins.hexagon.imm.sign: True: Print them with sign. False: Print signed immedi
 [   allocframe(SP,0x8):raw
 EOF
 RUN
+
+NAME=Invalid plugin config key errors
+FILE==
+CMDS=<<EOF
+e plugins.missing
+e plugins.missing=true
+e plugins.missing.
+el plugins.missing
+e! plugins.missing
+ee plugins.missing
+er plugins.missing
+et plugins.missing
+EOF
+EXPECT=
+EXPECT_ERR=<<EOF
+ERROR: core: Invalid config key 'plugins.missing'
+ERROR: core: Invalid config key 'plugins.missing'
+ERROR: core: Invalid config key 'plugins.missing.'
+ERROR: core: Invalid config key 'plugins.missing'
+ERROR: core: Invalid config key 'plugins.missing'
+ERROR: core: Invalid config key 'plugins.missing'
+ERROR: core: Invalid config key 'plugins.missing'
+ERROR: core: Invalid config key 'plugins.missing'
+EOF
+RUN
+


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [X] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

earlier if a plugin was not loaded / user typed invalid config key then `el plugins.hexagon` was printing all other plugin's config instead of printing nothing.

now if its `el plugins.` then it prints all plugin's configs but if its `el plugins.hexagon` and hexagon is not loaded (which means the config fetch will fail), and print nothing.

so two cases are seperated : `el plugins.` fails means user wants all configs list else its invalid config and so ERROR

Is this design fine?

also fixed a mem leak. The list was not freed in early return there.

The hexagon plugin's `cmd_eval` test is updated and works as test.

this will prevent this test from changing when new plugins like static core plugins are added like mine.

...

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

dev
```bash
❯ rizin
 -- Execute a command on the visual prompt with cmd.vprompt
[0x00000000]> e asm.arch=hexagon
[0x00000000]> el plugins.hexagon
plugins.hexagon.imm.hash: Display ## before 32bit immediates and # before immidiates with other width.
plugins.hexagon.imm.sign: True: Print them with sign. False: Print signed immediates in unsigned representation.
plugins.hexagon.reg.alias: Print the alias of registers (Alias from C0 = SA0).
 plugins.hexagon.sdk: Print packet syntax in objdump style.
[0x00000000]> el plugins.hexa
plugins.hexagon.imm.hash=true
plugins.hexagon.imm.sign=true
plugins.hexagon.reg.alias=true
plugins.hexagon.sdk=false
```

new
```bash
❯ rizin
 -- This code was intentionally left blank, try 'e asm.arch=ws'
[0x00000000]> e asm.arch=hexagon
[0x00000000]> el plugins.hexagon
plugins.hexagon.imm.hash: Display ## before 32bit immediates and # before immidiates with other width.
plugins.hexagon.imm.sign: True: Print them with sign. False: Print signed immediates in unsigned representation.
plugins.hexagon.reg.alias: Print the alias of registers (Alias from C0 = SA0).
 plugins.hexagon.sdk: Print packet syntax in objdump style.
[0x00000000]> el plugins.hexa
ERROR: core: Invalid config key 'plugins.hexa'
[0x00000000]> 
```

listing all plugin configs:
```bash
[0x00000000]> el plugins.
plugins.hexagon.imm.hash=true
plugins.hexagon.imm.sign=true
plugins.hexagon.reg.alias=true
plugins.hexagon.sdk=false
[0x00000000]> 
```
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
