### PR TITLE
Implement file download from the remote machine in GDB protocol

### DIFF
--- a/librz/include/rz_io.h
+++ b/librz/include/rz_io.h
@@ -384,6 +384,7 @@ RZ_API bool rz_io_desc_is_blockdevice(RzIODesc *desc);
 RZ_API bool rz_io_desc_is_chardevice(RzIODesc *desc);
 RZ_API bool rz_io_desc_exchange(RzIO *io, int fd, int fdx); // this should get 2 descs
 RZ_API bool rz_io_desc_is_dbg(RzIODesc *desc);
+RZ_API bool rz_io_gdb_download_file(RzIODesc *desc, const char *remote, const char *local);
 RZ_API int rz_io_desc_get_pid(RzIODesc *desc);
 RZ_API int rz_io_desc_get_tid(RzIODesc *desc);
 RZ_API bool rz_io_desc_get_base(RzIODesc *desc, ut64 *base);

--- a/librz/include/rz_io.h
+++ b/librz/include/rz_io.h
@@ -138,6 +138,7 @@ typedef struct rz_io_plugin_t {
 	int (*create)(RzIO *io, const char *file, int mode, int type);
 	bool (*check)(RzIO *io, const char *, bool many);
 	ut8 *(*get_buf)(RzIODesc *desc, ut64 *size);
+	bool (*download_file)(RzIO *io, RzIODesc *fd, const char *remote, const char *local);
 } RzIOPlugin;
 
 typedef struct rz_io_map_t {
@@ -384,7 +385,7 @@ RZ_API bool rz_io_desc_is_blockdevice(RzIODesc *desc);
 RZ_API bool rz_io_desc_is_chardevice(RzIODesc *desc);
 RZ_API bool rz_io_desc_exchange(RzIO *io, int fd, int fdx); // this should get 2 descs
 RZ_API bool rz_io_desc_is_dbg(RzIODesc *desc);
-RZ_API bool rz_io_gdb_download_file(RzIODesc *desc, const char *remote, const char *local);
+RZ_API bool rz_io_desc_download_file(RzIODesc *desc, const char *remote, const char *local);
 RZ_API int rz_io_desc_get_pid(RzIODesc *desc);
 RZ_API int rz_io_desc_get_tid(RzIODesc *desc);
 RZ_API bool rz_io_desc_get_base(RzIODesc *desc, ut64 *base);

--- a/librz/io/io_desc.c
+++ b/librz/io/io_desc.c
@@ -307,6 +307,13 @@ RZ_API bool rz_io_desc_is_dbg(RzIODesc *desc) {
 	return false;
 }
 
+RZ_API bool rz_io_desc_download_file(RzIODesc *desc, const char *remote, const char *local) {
+	if (!desc || !desc->plugin || !desc->plugin->download_file || RZ_STR_ISEMPTY(remote) || RZ_STR_ISEMPTY(local)) {
+		return false;
+	}
+	return desc->plugin->download_file(desc->io, desc, remote, local);
+}
+
 RZ_API int rz_io_desc_get_pid(RzIODesc *desc) {
 	//-1 and -2 are reserved
 	if (!desc) {

--- a/librz/io/p/io_gdb.c
+++ b/librz/io/p/io_gdb.c
@@ -15,6 +15,9 @@
 
 #define RZ_GDB_MAGIC rz_str_djb2_hash("gdb")
 
+#define MIN_DOWNLOAD_CHUNK 64
+#define MAX_DOWNLOAD_CHUNK 65536
+
 static int __close(RzIODesc *fd);
 
 static bool __plugin_open(RzIO *io, const char *file, bool many) {
@@ -209,19 +212,20 @@ extern int read_packet(libgdbr_t *instance, bool vcont);
 
 static bool gdbr_download_file(libgdbr_t *g, const char *remote, const char *local) {
 	rz_return_val_if_fail(g && remote && local, false);
-
+	// empty the destination file by writing nothing in non-append mode
 	if (!rz_file_dump(local, NULL, 0, false)) {
 		return false;
 	}
-
+	// open the remote file on the stub side
 	if (gdbr_open_file(g, remote, O_RDONLY, 0) < 0) {
 		return false;
 	}
 
 	uint32_t off = 0;
 	bool ok = true;
-	ut32 chunk = RZ_MAX(64, g->stub_features.pkt_sz / 2);
-	chunk = RZ_MIN(chunk, 65536);
+	// clamp the download size between a reasonable MIN floor and MAX ceiling
+	ut32 chunk = RZ_MAX(MIN_DOWNLOAD_CHUNK, g->stub_features.pkt_sz / 2);
+	chunk = RZ_MIN(chunk, MAX_DOWNLOAD_CHUNK);
 	ut8 *buf = malloc(chunk);
 	if (!buf) {
 		gdbr_close_file(g);
@@ -249,9 +253,8 @@ static bool gdbr_download_file(libgdbr_t *g, const char *remote, const char *loc
 	return ok;
 }
 
-RZ_API bool rz_io_gdb_download_file(RzIODesc *fd, const char *remote, const char *local) {
-	rz_return_val_if_fail(fd && remote && local, false);
-	if (!fd->plugin || strcmp(fd->plugin->name, "gdb")) {
+static bool io_gdb_download_file(RzIO *io, RzIODesc *fd, const char *remote, const char *local) {
+	if (!fd || !fd->data) {
 		return false;
 	}
 	return gdbr_download_file(fd->data, remote, local);
@@ -492,6 +495,7 @@ RzIOPlugin rz_io_plugin_gdb = {
 	.system = __system,
 	.getpid = __getpid,
 	.gettid = __gettid,
+	.download_file = io_gdb_download_file,
 	.isdbg = true
 };
 

--- a/librz/io/p/io_gdb.c
+++ b/librz/io/p/io_gdb.c
@@ -207,6 +207,56 @@ static int __gettid(RzIODesc *fd) {
 extern int send_msg(libgdbr_t *g, const char *command);
 extern int read_packet(libgdbr_t *instance, bool vcont);
 
+static bool gdbr_download_file(libgdbr_t *g, const char *remote, const char *local) {
+	rz_return_val_if_fail(g && remote && local, false);
+
+	if (!rz_file_dump(local, NULL, 0, false)) {
+		return false;
+	}
+
+	if (gdbr_open_file(g, remote, O_RDONLY, 0) < 0) {
+		return false;
+	}
+
+	uint32_t off = 0;
+	bool ok = true;
+	ut32 chunk = RZ_MAX(64, g->stub_features.pkt_sz / 2);
+	chunk = RZ_MIN(chunk, 65536);
+	ut8 *buf = malloc(chunk);
+	if (!buf) {
+		gdbr_close_file(g);
+		return false;
+	}
+
+	int ret;
+	do {
+		ret = gdbr_pread_file(g, buf, chunk, off);
+		if (ret < 0) {
+			ok = false;
+			break;
+		}
+		if (ret == 0) {
+			break;
+		}
+		if (!rz_file_dump(local, buf, ret, true)) {
+			ok = false;
+			break;
+		}
+		off += ret;
+	} while ((ut32)ret == chunk);
+	free(buf);
+	gdbr_close_file(g);
+	return ok;
+}
+
+RZ_API bool rz_io_gdb_download_file(RzIODesc *fd, const char *remote, const char *local) {
+	rz_return_val_if_fail(fd && remote && local, false);
+	if (!fd->plugin || strcmp(fd->plugin->name, "gdb")) {
+		return false;
+	}
+	return gdbr_download_file(fd->data, remote, local);
+}
+
 static char *__system(RzIO *io, RzIODesc *fd, const char *cmd) {
 	if (!fd || !fd->data) {
 		return NULL;
@@ -228,10 +278,22 @@ static char *__system(RzIO *io, RzIODesc *fd, const char *cmd) {
 			" R! pktsz           - get max packet size used\n"
 			" R! pktsz bytes     - set max. packet size as 'bytes' bytes\n"
 			" R! exec_file [pid] - get file which was executed for"
-			" current/specified pid\n");
+			" current/specified pid\n"
+			" R! download_file remote local - download remote file to local path\n");
 		return NULL;
 	}
 	libgdbr_t *desc = fd->data;
+	if (rz_str_startswith(cmd, "download_file")) {
+		int argc = 0;
+		char **argv = rz_str_argv(cmd, &argc);
+		if (!argv || argc != 3) {
+			rz_str_argv_free(argv);
+			return rz_str_dup("0");
+		}
+		bool ok = gdbr_download_file(desc, argv[1], argv[2]);
+		rz_str_argv_free(argv);
+		return rz_str_dup(ok ? "1" : "0");
+	}
 	if (rz_str_startswith(cmd, "pktsz")) {
 		const char *ptr = rz_str_trim_head_ro(cmd + 5);
 		if (!isdigit((ut8)*ptr)) {

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -20,6 +20,24 @@ static bool is_valid_dmp_file(RzCoreFile *fh) {
 	return d && strncmp(d->name, "dmp://", 6);
 }
 
+static char *download_gdb_remote_file(RzIODesc *iod, const char *remote_path) {
+	if (!iod || RZ_STR_ISEMPTY(remote_path)) {
+		return NULL;
+	}
+	char *local_path = NULL;
+	int fd = rz_file_mkstemp("gdbexe", &local_path);
+	if (fd == -1 || !local_path) {
+		free(local_path);
+		return NULL;
+	}
+	close(fd);
+	if (!rz_io_gdb_download_file(iod, remote_path, local_path)) {
+		rz_file_rm(local_path);
+		RZ_FREE(local_path);
+	}
+	return local_path;
+}
+
 static char *get_file_in_cur_dir(const char *filepath) {
 	filepath = rz_file_basename(filepath);
 	if (rz_file_exists(filepath) && !rz_file_is_directory(filepath)) {
@@ -428,6 +446,7 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 	bool do_list_io_plugins = false;
 	char *file = NULL;
 	char *pfile = NULL;
+	char *gdb_downloaded_exe = NULL;
 	const char *asmarch = NULL;
 	const char *asmos = NULL;
 	const char *forcebin = NULL;
@@ -1073,12 +1092,33 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 							}
 						} else if (is_valid_gdb_file(fh) || is_valid_dmp_file(fh)) {
 							filepath = iod->name;
-							if (RZ_STR_ISNOTEMPTY(filepath) && rz_file_exists(filepath) && !rz_file_is_directory(filepath)) {
+							bool is_gdb_remote = rz_str_startswith(pfile, "gdb://");
+							bool is_localhost_gdb_remote = rz_str_startswith(pfile, "gdb://localhost:");
+							bool local_file_exists = RZ_STR_ISNOTEMPTY(filepath) && rz_file_exists(filepath) && !rz_file_is_directory(filepath);
+							bool should_download = is_gdb_remote && RZ_STR_ISNOTEMPTY(filepath) && (!is_localhost_gdb_remote || !local_file_exists);
+							if (should_download) {
+								char *downloaded = NULL;
+								if (addr == UINT64_MAX) {
+									addr = rz_debug_get_baddr(r->dbg, filepath);
+								}
+								if (rz_cons_yesno('n', "Download remote executable '%s' to a temporary file? (y/N) ", filepath)) {
+									downloaded = download_gdb_remote_file(iod, filepath);
+									if (!downloaded) {
+										RZ_LOG_ERROR("Failed to download remote executable '%s'.\n", filepath);
+									}
+								}
+								if (downloaded) {
+									gdb_downloaded_exe = downloaded;
+									free(iod->name);
+									iod->name = rz_str_dup(downloaded);
+									rz_core_bin_load(r, NULL, addr);
+								}
+							} else if (local_file_exists) {
 								if (addr == UINT64_MAX) {
 									addr = rz_debug_get_baddr(r->dbg, filepath);
 								}
 								rz_core_bin_load(r, filepath, addr);
-							} else if ((filepath = get_file_in_cur_dir(filepath))) {
+							} else if (!is_gdb_remote && (filepath = get_file_in_cur_dir(filepath))) {
 								// Present in local directory
 								if (iod) {
 									free(iod->name);
@@ -1574,6 +1614,10 @@ beach:
 	// execution.
 	// rz_core_file_close (r, fh);
 	rz_core_free(r);
+	if (gdb_downloaded_exe) {
+		rz_file_rm(gdb_downloaded_exe);
+		free(gdb_downloaded_exe);
+	}
 	rz_cons_set_raw(0);
 	rz_cons_free();
 	LISTS_FREE();

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -31,7 +31,7 @@ static char *download_gdb_remote_file(RzIODesc *iod, const char *remote_path) {
 		return NULL;
 	}
 	close(fd);
-	if (!rz_io_gdb_download_file(iod, remote_path, local_path)) {
+	if (!rz_io_desc_download_file(iod, remote_path, local_path)) {
 		rz_file_rm(local_path);
 		RZ_FREE(local_path);
 	}

--- a/subprojects/rzgdb/include/gdbclient/commands.h
+++ b/subprojects/rzgdb/include/gdbclient/commands.h
@@ -126,6 +126,7 @@ int gdbr_remove_hwa(libgdbr_t *g, ut64 address, int sizebp);
  * File read from remote target (only one file open at a time for now)
  */
 int gdbr_open_file(libgdbr_t *g, const char *filename, int flags, int mode);
+int gdbr_pread_file(libgdbr_t *g, ut8 *buf, ut64 max_len, uint32_t start_offset);
 int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 max_len);
 int gdbr_close_file(libgdbr_t *g);
 

--- a/subprojects/rzgdb/src/gdbclient/core.c
+++ b/subprojects/rzgdb/src/gdbclient/core.c
@@ -1507,7 +1507,7 @@ end:
 	return ret;
 }
 
-int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 max_len) {
+int gdbr_pread_file(libgdbr_t *g, ut8 *buf, ut64 max_len, uint32_t start_offset) {
 	int ret, ret1;
 	char command[64];
 	ut64 data_sz;
@@ -1534,7 +1534,7 @@ int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 max_len) {
 		if (snprintf(command, sizeof(command) - 1,
 			    "vFile:pread:%x,%" PFMT64x ",%" PFMT64x,
 			    (int)g->remote_file_fd, (ut64)RZ_MIN(data_sz, max_len - ret),
-			    (ut64)ret) < 0) {
+			    (ut64)start_offset + ret) < 0) {
 			ret = -1;
 			goto end;
 		}
@@ -1559,6 +1559,10 @@ int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 max_len) {
 end:
 	gdbr_lock_leave(g);
 	return ret;
+}
+
+int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 max_len) {
+	return gdbr_pread_file(g, buf, max_len, 0);
 }
 
 int gdbr_close_file(libgdbr_t *g) {

--- a/test/db/archos/linux-x64/dbg_gdbserver
+++ b/test/db/archos/linux-x64/dbg_gdbserver
@@ -26,3 +26,19 @@ EXPECT=<<EOF
 s bins/elf/analysis/pie
 EOF
 RUN
+
+NAME=gdbserver download_file
+FILE=bins/elf/analysis/pie
+CMDS=<<EOF
+!rm -f gdbserver_download_file.tmp
+!scripts/gdbserver.py --port 12348 --binary bins/elf/analysis/pie
+oodf gdb://127.0.0.1:12348
+R! download_file bins/elf/analysis/pie gdbserver_download_file.tmp
+!rz-hash -qqa sha256 gdbserver_download_file.tmp
+!rm -f gdbserver_download_file.tmp
+EOF
+EXPECT=<<EOF
+1
+7f1c67175bc493d6008bec675f0a05ed281d3867c4f2320300f0b4ebecff3f27
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

There is an issue to download binary files from a remote machine during a GDB remote session https://github.com/rizinorg/rizin/issues/3975, this file is a simple implementation of that addresses the simplest case.

Implementation  as follows:

(1) An existing `gdbr_read_file` that implemented a bounded read of a remote file into a caller-provided buffer was refactored, it now takes an additional argument `start_offset`, and starts reading from the remote file at this offset. The more general logic is named `gdbr_pread_file`, and the behaviour of `gdbr_read_file`  is recovered by calling it with a `start_offset` of 0.

(2) Using `gdbr_pread_file` as a generic primitive, file downloading is then implemented as an outer loop repeatedly calling it with increasing offsets until a zero-length or shorter-than-expected read (indicating the remote file is complete).

(3) A sub-command `download_file` was added where the user controls both the remote source and the local destination

(4) A convenience was added to the main function so that if the user runs `rizin -D gdb gdb://...`, it offers to download the remote executable being deubugged if any of the following is true (a) the remote host is NOT localhost (b)  the file doesn't exist by its full path locally, even if the remote host is localhost. 

Note: the localhost check is intentionally conservative, it checks for a literal "gdb://localhost:" in the prefix of the URI, so (e.g.) it rejects `127.0.0.1` and considers it "not local". This is because parsing IP addresses doesn't have any well-established utilities in Rizin AFAICT, and I don't want to implement a half-baked buggy and slow implementation of half of an IP parser in the main function. Note that `127.0.0.1` is not unique as a loopback address anyway, and sometimes it can be behind container/namespace routing that make its filesystem not identical to the local filesystem Rizin is running on. 

So for now, `localhost` is treated as a magic escape when the user knows the file doesn't need to be downloaded, and any other remote address is treated as remote.

**Test plan**

There are no automated tests, sorry, it would be awkward to test network code like this.

Here's a concrete UX difference:

1- First, run a gdb server with a binary that is inaccessible to Rizin, this can be done with VMs or SSH, but a much simpler way to do it with bwrap is:

`sudo bwrap --ro-bind / / --dev-bind /dev /dev --proc /proc --tmpfs /tmp --bind "$tmp/remote-sleep" /tmp/remote-sleep gdbserver :2345 /tmp/remote-sleep 1000`

(bwrap is only a convience wrapper over namespaces here, so this is doable on any modern linux without bwrap as well.)

2- Run Rizin without this PR (or with this PR but select no when the prompt for downloading the remote file appears)

3- run `is`, the reasonable expectation is: symbols should appear. But the error `ERROR: No binary object currently selected.` appears instead. 

4- Even after running a full `aaaa` analysis pass, a simple debug command like `dcu main` doesn't actually stop at main. The error `WARNING: Breakpoint won't be placed since it's not in a valid map.
You can bypass this check by setting dbg.bpinmaps to false.` appears instead, and the sleep command appears to run to completion before control is handed back to Rizin.

With this PR, choosing `y` at the prompt will make (3) and (4) work as expected. 

**Closing issues**

Closes https://github.com/rizinorg/rizin/issues/3975 but might need extra features.

**Future/RFC**

The following concerns are reasonably too big/unknown to handle in this PR, but arguably should:

1- If the binary being debugged in the remote machine loads `.so` objects, does the current prompt in main naturally extend to download them as well ? should it ? what if loading is lazy and happens mid-execution? Do we need a new prompt for every one ?

2- If the file is not downloaded by the prompt or manually by the user, should other triggers (e.g. the `is` command) re-prompt the user or should we treat user refusal as final, given that the manual command is always available in case user changes their mind ?

3- Right now, for simplicity, the convenience prompt generates a new temp file on every download and deletes it on exit, should we make any attempt to build a hash-keyed persistent local database ?

4- Instead of downloading to the filesystem for simplicity, maybe it's better to download to memory instead.

Almost all of those problems/nitpicks are around the triggers and UX of downloading, downloading itself once the decision is made is straightforward enough and uses existing code for the most part.