### PR TITLE
librz/bin: fix MTK image parsing on BE host

### DIFF
--- a/librz/bin/format/mtk/mtk.c
+++ b/librz/bin/format/mtk/mtk.c
@@ -30,11 +30,13 @@ static ut64 mtk_find_gfh(RzBuffer *b) {
 	for (ut64 off = 0; off + MTK_GFH_MIN_FILE_SIZE <= limit; off += 4) {
 		ut64 cursor = off;
 		MtkGfhCommonHdr hdr = { 0 };
+		ut16 type = 0;
 		if (!rz_buf_read_le32_offset(b, &cursor, &hdr.magic_version) ||
 			!rz_buf_read_le16_offset(b, &cursor, &hdr.size) ||
-			!rz_buf_read_le16_offset(b, &cursor, (ut16 *)&hdr.type)) {
+			!rz_buf_read_le16_offset(b, &cursor, &type)) {
 			continue;
 		}
+		hdr.type = type;
 		if (mtk_is_gfh_magic(hdr.magic_version) &&
 			hdr.type == MTK_GFH_TYPE_FILE_INFO &&
 			hdr.size >= MTK_GFH_MIN_FILE_SIZE) {
@@ -45,9 +47,14 @@ static ut64 mtk_find_gfh(RzBuffer *b) {
 }
 
 static bool mtk_read_common_hdr(RzBuffer *b, ut64 *offset, MtkGfhCommonHdr *hdr) {
-	return rz_buf_read_le32_offset(b, offset, &hdr->magic_version) &&
-		rz_buf_read_le16_offset(b, offset, &hdr->size) &&
-		rz_buf_read_le16_offset(b, offset, (ut16 *)&hdr->type);
+	ut16 type = 0;
+	if (!(rz_buf_read_le32_offset(b, offset, &hdr->magic_version) &&
+		    rz_buf_read_le16_offset(b, offset, &hdr->size) &&
+		    rz_buf_read_le16_offset(b, offset, &type))) {
+		return false;
+	}
+	hdr->type = type;
+	return true;
 }
 
 static bool mtk_read_file_info(RzBuffer *b, ut64 *offset, MtkGfhFileInfo *fi) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Fix 2 broken tests on Travis CI:
```
[XX] 00h00m00s115ms db/formats/mtk md1rom synthetic GFH firmware image
RZ_COLOR=0 RZ_UTF8=0 RZ_NOPLUGINS=1 /home/travis/build/rizinorg/rizin/install/bin/rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -eflirt.sigdb.load.system=false -esearch.show_progress=false -eflirt.sigdb.load.home=false -N -qc 'iI
echo ---
iH
echo ---
iS
echo ---
ie
echo ---
s 0x90000000
pi 4
' bins/mtk/md1rom
-- stdout
--- expected
+++ actual
@@ -50,12 +50,12 @@
   entry_point: 0x90000000
 gfh_headers:
   - file_offset: 0x38
-    type: "bl_info"
-    type_id: 0x1
+    type: "unknown"
+    type_id: 0x10000
     size: 20
   - file_offset: 0x4c
-    type: "brom_cfg"
-    type_id: 0x7
+    type: "unknown"
+    type_id: 0x70000
     size: 16
 code_offset: 0x60
 code_size: 0x100
[XX] 00h00m00s165ms db/formats/mtk md1img synthetic container with md1rom section
RZ_COLOR=0 RZ_UTF8=0 RZ_NOPLUGINS=1 /home/travis/build/rizinorg/rizin/install/bin/rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -eflirt.sigdb.load.system=false -esearch.show_progress=false -eflirt.sigdb.load.home=false -N -qc 'iI
echo ---
iH
echo ---
iS
echo ---
ie
echo ---
s 0x90000000
pi 4
' bins/mtk/md1img
-- stdout
--- expected
+++ actual
@@ -62,12 +62,12 @@
   entry_point: 0x90000000
 gfh_headers:
   - file_offset: 0x38
-    type: "bl_info"
-    type_id: 0x1
+    type: "unknown"
+    type_id: 0x10000
     size: 20
   - file_offset: 0x4c
-    type: "brom_cfg"
-    type_id: 0x7
+    type: "unknown"
+    type_id: 0x70000
     size: 16
 
 ```
https://app.travis-ci.com/github/rizinorg/rizin/jobs/639879266#L4827

**Test plan**

CI is green