### PR TITLE
Fix Objective-C RTTI superclass decoding on big-endian hosts

### DIFF
--- a/librz/arch/objc_rtti.c
+++ b/librz/arch/objc_rtti.c
@@ -5,16 +5,14 @@
 #include "analysis_private.h"
 
 static const RzBinSymbol *get_objc_superclass(RzAnalysis *analysis, const RzPVector /*<RzBinSymbol *>*/ *symbols, const RzBinSymbol *meta_info) {
-	ut64 addr;
-	if (!analysis->iob.read_at(analysis->iob.io, meta_info->vaddr + 8, (ut8 *)&addr, 8)) {
+	ut8 buf[8];
+	if (!analysis->iob.read_at(analysis->iob.io, meta_info->vaddr + 8, buf, sizeof(buf))) {
 		return NULL;
 	}
+	ut64 addr = rz_read_ble64(buf, analysis->big_endian);
 
 	void **it;
 	rz_pvector_foreach (symbols, it) {
-		if (!it) {
-			continue;
-		}
 		RzBinSymbol *super_meta = *it;
 		if (!super_meta) {
 			continue;
@@ -59,9 +57,6 @@ RZ_API void rz_analysis_rtti_objc(RZ_NONNULL RzAnalysis *analysis) {
 	const RzPVector *symbols = rz_bin_object_get_symbols(o);
 	void **it;
 	rz_pvector_foreach (symbols, it) {
-		if (!it) {
-			continue;
-		}
 		RzBinSymbol *sym = *it;
 		if (!sym) {
 			continue;

--- a/librz/core/devirtualize_objc.c
+++ b/librz/core/devirtualize_objc.c
@@ -226,7 +226,6 @@ static void devirtualize_msg_dispatch(RzCore *core, RzSetU *msg_dispatch_addr) {
 		rz_analysis_op(core->analysis, op, start, bytes + offset, end - start, RZ_ANALYSIS_OP_MASK_ALL);
 		if (refresh_vm) {
 			rz_core_analysis_il_reinit(core);
-			refresh_vm = false;
 		}
 		refresh_vm = is_branch_type_to_method(op);
 
@@ -302,7 +301,6 @@ static void devirtualize_msg_super_dispatch(RzCore *core, RzSetU *msg_super_disp
 		}
 		if (refresh_vm) {
 			rz_core_analysis_il_reinit(core);
-			refresh_vm = false;
 		}
 
 		refresh_vm = is_branch_type_to_method(op);


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
This fixes Objective-C RTTI superclass decoding on big endian (s390x), which caused test failures introduced by https://github.com/rizinorg/rizin/pull/6529

The superclass pointer was previously read directly into a `ut64`, which made decoding depend on the host endianness.

Also fixed Coverity issues: 910855, 910854

**Test plan**
No test regressions locally (little endian) (x86_64)
@notxvilka @wargio Could you open a branch in rizin to test on s390x?

**Closing issues**
none