### PR TITLE
Fix memory leaks in the dmi command's module lookup

### DIFF
--- a/librz/core/cmd/cmd_debug.c
+++ b/librz/core/cmd/cmd_debug.c
@@ -768,10 +768,16 @@ static ut64 addroflib(RzCore *core, const char *libname) {
 	rz_debug_map_sync(core->dbg);
 	// RzList *list = rz_debug_native_modules_get (core->dbg);
 	RzList *list = rz_debug_modules_list(core->dbg);
+	ut64 addr = UT64_MAX;
 	rz_list_foreach (list, iter, map) {
 		if (strstr(rz_file_basename(map->name), libname)) {
-			return map->addr;
+			addr = map->addr;
+			break;
 		}
+	}
+	rz_list_free(list);
+	if (addr != UT64_MAX) {
+		return addr;
 	}
 	rz_list_foreach (core->dbg->maps, iter, map) {
 		if (strstr(rz_file_basename(map->name), libname)) {
@@ -787,14 +793,20 @@ static RzDebugMap *get_closest_map(RzCore *core, ut64 addr) {
 
 	rz_debug_map_sync(core->dbg);
 	RzList *list = rz_debug_modules_list(core->dbg);
+	RzDebugMap *found = NULL;
 	rz_list_foreach (list, iter, map) {
 		if (addr != UT64_MAX && (addr >= map->addr && addr < map->addr_end)) {
-			return map;
+			found = rz_debug_map_clone(map);
+			break;
 		}
+	}
+	rz_list_free(list);
+	if (found) {
+		return found;
 	}
 	rz_list_foreach (core->dbg->maps, iter, map) {
 		if (addr != UT64_MAX && (addr >= map->addr && addr < map->addr_end)) {
-			return map;
+			return rz_debug_map_clone(map);
 		}
 	}
 	return NULL;
@@ -1076,11 +1088,12 @@ RZ_IPI RzCmdStatus rz_cmd_debug_dmi_handler(RzCore *core, int argc, const char *
 		return RZ_CMD_STATUS_ERROR;
 	}
 	const char *file = map->file ? map->file : map->name;
-	if (!get_bin_info(core, file, map->addr, state, action, &filter)) {
+	bool ok = get_bin_info(core, file, map->addr, state, action, &filter);
+	if (!ok) {
 		RZ_LOG_ERROR("Failed to get binary information for map: '%s' in file: '%s'\n", map->name, file);
-		return RZ_CMD_STATUS_ERROR;
 	}
-	return RZ_CMD_STATUS_OK;
+	rz_debug_map_free(map);
+	return ok ? RZ_CMD_STATUS_OK : RZ_CMD_STATUS_ERROR;
 }
 
 RZ_IPI RzCmdStatus rz_cmd_debug_dmi_all_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {
@@ -1126,11 +1139,12 @@ RZ_IPI RzCmdStatus rz_cmd_debug_dmi_all_handler(RzCore *core, int argc, const ch
 		return RZ_CMD_STATUS_ERROR;
 	}
 	const char *file = map->file ? map->file : map->name;
-	if (!get_bin_info(core, file, map->addr, state, action, &filter)) {
+	bool ok = get_bin_info(core, file, map->addr, state, action, &filter);
+	if (!ok) {
 		RZ_LOG_ERROR("Failed to get binary information for map: '%s' in file: '%s'\n", map->name, file);
-		return RZ_CMD_STATUS_ERROR;
 	}
-	return RZ_CMD_STATUS_OK;
+	rz_debug_map_free(map);
+	return ok ? RZ_CMD_STATUS_OK : RZ_CMD_STATUS_ERROR;
 }
 
 RZ_IPI RzCmdStatus rz_cmd_debug_dmi_closest_handler(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state) {

--- a/librz/debug/dmap.c
+++ b/librz/debug/dmap.c
@@ -80,6 +80,17 @@ RZ_API void rz_debug_map_free(RZ_NULLABLE RzDebugMap *map) {
 	free(map);
 }
 
+RZ_API RZ_OWN RzDebugMap *rz_debug_map_clone(RZ_NONNULL RzDebugMap *m) {
+	rz_return_val_if_fail(m, NULL);
+	RzDebugMap *c = rz_debug_map_new(m->name, m->addr, m->addr_end, m->perm, m->user);
+	if (c) {
+		c->offset = m->offset;
+		c->shared = m->shared;
+		c->file = rz_str_dup(m->file);
+	}
+	return c;
+}
+
 RZ_API RzList /*<RzDebugMap *>*/ *rz_debug_map_list_new(void) {
 	RzList *list = rz_list_new();
 	if (!list) {

--- a/librz/debug/p/native/xnu/xnu_debug.c
+++ b/librz/debug/p/native/xnu/xnu_debug.c
@@ -1213,18 +1213,6 @@ static int cmp(const void *_a, const void *_b, void *user) {
 	return 0;
 }
 
-static RzDebugMap *rz_debug_map_clone(RzDebugMap *m) {
-	RzDebugMap *map = RZ_NEWCOPY(RzDebugMap, m);
-	// memcpy (map, m, sizeof (RzDebugMap));
-	if (m->name) {
-		map->name = rz_str_dup(m->name);
-	}
-	if (m->file) {
-		map->file = rz_str_dup(m->file);
-	}
-	return map;
-}
-
 RzList *xnu_dbg_maps(RzDebug *dbg, int only_modules) {
 	rz_return_val_if_fail(dbg && dbg->plugin_data, NULL);
 	RzXnuDebug *ctx = dbg->plugin_data;

--- a/librz/include/rz_debug.h
+++ b/librz/include/rz_debug.h
@@ -520,6 +520,7 @@ RZ_API int rz_debug_map_dealloc(RzDebug *dbg, RzDebugMap *map);
 RZ_API RzList /*<RzDebugMap *>*/ *rz_debug_map_list_new(void);
 RZ_API RzDebugMap *rz_debug_map_get(RzDebug *dbg, ut64 addr);
 RZ_API RZ_OWN RzDebugMap *rz_debug_map_new(RZ_NULLABLE char *name, ut64 begin, ut64 end, int perm, int user);
+RZ_API RZ_OWN RzDebugMap *rz_debug_map_clone(RZ_NONNULL RzDebugMap *m);
 RZ_API void rz_debug_map_free(RZ_NULLABLE RzDebugMap *map);
 RZ_API void rz_debug_map_list_visual(RzDebug *dbg, ut64 addr, const char *input, int colors);
 RZ_API RZ_BORROW RzList /*<RzDebugMap *>*/ *rz_debug_map_list(RzDebug *dbg, bool user_map);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

More leaks found in https://github.com/rizinorg/rizin/pull/6578

**Test plan**

CI is green
