### PR TITLE
Rz cons html filter bright foreground background and resets.

### DIFF
--- a/librz/cons/html.c
+++ b/librz/cons/html.c
@@ -30,6 +30,20 @@ static const char *gethtmlcolor(const char ptrch) {
 	return "";
 }
 
+static const char *gethtmlbrightcolor(const char ptrch) {
+	switch (ptrch) {
+	case '0': return "#777"; // Bright Black (Gray)
+	case '1': return "#ff5555"; // Bright Red
+	case '2': return "#55ff55"; // Bright Green
+	case '3': return "#ffff55"; // Bright Yellow
+	case '4': return "#5555ff"; // Bright Blue
+	case '5': return "#ff55ff"; // Bright Magenta
+	case '6': return "#55ffff"; // Bright Cyan
+	case '7': return "#ffffff"; // Bright White
+	}
+	return "";
+}
+
 // TODO: move into rz_util/str
 RZ_API char *rz_cons_html_filter(const char *ptr, int *newlen) {
 	const char *str = ptr;
@@ -183,6 +197,14 @@ RZ_API char *rz_cons_html_filter(const char *ptr, int *newlen) {
 				esc = 0;
 				continue;
 				// invert color
+			} else if (!strncmp(ptr, "39m", 3)) {
+				// Reset foreground to default
+				text_color[0] = '\0';
+				need_to_set = true;
+				ptr += 2;
+				str = ptr + 1;
+				esc = 0;
+				continue;
 			} else if (ptr[0] == '3' && ptr[2] == 'm') {
 				const char *htmlColor = gethtmlcolor(ptr[1]);
 				if (htmlColor) {
@@ -193,6 +215,14 @@ RZ_API char *rz_cons_html_filter(const char *ptr, int *newlen) {
 				str = ptr + 1;
 				esc = 0;
 				continue;
+			} else if (!strncmp(ptr, "49m", 3)) {
+				// Reset background to default
+				background_color[0] = '\0';
+				need_to_set = true;
+				ptr += 2;
+				str = ptr + 1;
+				esc = 0;
+				continue;
 			} else if (ptr[0] == '4' && ptr[2] == 'm') {
 				const char *htmlColor = gethtmlcolor(ptr[1]);
 				if (htmlColor) {
@@ -200,6 +230,31 @@ RZ_API char *rz_cons_html_filter(const char *ptr, int *newlen) {
 				}
 				need_to_set = true;
 				ptr = ptr + 2;
+				str = ptr + 1;
+				esc = 0;
+				continue;
+			} else if (ptr[0] == '9' && ptr[2] == 'm') {
+				const char *htmlColor = gethtmlbrightcolor(ptr[1]);
+				if (htmlColor) {
+					rz_str_ncpy(text_color, htmlColor, sizeof(text_color));
+				}
+				need_to_set = true;
+				ptr = ptr + 2;
+				str = ptr + 1;
+				esc = 0;
+				continue;
+			} else if (ptr[0] == '1' &&
+				ptr[1] == '0' &&
+				ptr[3] == 'm' &&
+				ptr[2] >= '0' &&
+				ptr[2] <= '7') {
+				const char *htmlColor = gethtmlbrightcolor(ptr[2]);
+				if (htmlColor) {
+					rz_str_ncpy(background_color, htmlColor,
+						sizeof(background_color));
+				}
+				need_to_set = true;
+				ptr = ptr + 3;
 				str = ptr + 1;
 				esc = 0;
 				continue;

--- a/test/unit/test_cons_html.c
+++ b/test/unit/test_cons_html.c
@@ -76,6 +76,82 @@ bool test_cons_to_html() {
 	html = rz_cons_html_filter(Color_RED Color_BGGREEN "aaa" Color_RESET_BG Color_RESET "bbb", NULL);
 	mu_assert_streq_free(html, "<font color='#f00' style='background-color:#0f0'>aaa</font>bbb", "Two different resets opposite order");
 
+	/* Bright foreground colors (90-97) */
+
+	html = rz_cons_html_filter("\x1b[90mBright foreground\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font color='#777'>Bright&nbsp;foreground</font>", "Bright black");
+
+	html = rz_cons_html_filter("\x1b[91mBright foreground\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font color='#ff5555'>Bright&nbsp;foreground</font>", "Bright red");
+
+	html = rz_cons_html_filter("\x1b[92mBright foreground\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font color='#55ff55'>Bright&nbsp;foreground</font>", "Bright green");
+
+	html = rz_cons_html_filter("\x1b[93mBright foreground\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font color='#ffff55'>Bright&nbsp;foreground</font>", "Bright yellow");
+
+	html = rz_cons_html_filter("\x1b[94mBright foreground\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font color='#5555ff'>Bright&nbsp;foreground</font>", "Bright blue");
+
+	html = rz_cons_html_filter("\x1b[95mBright foreground\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font color='#ff55ff'>Bright&nbsp;foreground</font>", "Bright magenta");
+
+	html = rz_cons_html_filter("\x1b[96mBright foreground\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font color='#55ffff'>Bright&nbsp;foreground</font>", "Bright cyan");
+
+	html = rz_cons_html_filter("\x1b[97mBright foreground\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font color='#ffffff'>Bright&nbsp;foreground</font>", "Bright white");
+
+	/* Bright background colors (100-107) */
+
+	html = rz_cons_html_filter("\x1b[100mBright background\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font style='background-color:#777'>Bright&nbsp;background</font>", "Bright background black");
+
+	html = rz_cons_html_filter("\x1b[101mBright background\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font style='background-color:#ff5555'>Bright&nbsp;background</font>", "Bright background red");
+
+	html = rz_cons_html_filter("\x1b[102mBright background\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font style='background-color:#55ff55'>Bright&nbsp;background</font>", "Bright background green");
+
+	html = rz_cons_html_filter("\x1b[103mBright background\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font style='background-color:#ffff55'>Bright&nbsp;background</font>", "Bright background yellow");
+
+	html = rz_cons_html_filter("\x1b[104mBright background\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font style='background-color:#5555ff'>Bright&nbsp;background</font>", "Bright background blue");
+
+	html = rz_cons_html_filter("\x1b[105mBright background\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font style='background-color:#ff55ff'>Bright&nbsp;background</font>", "Bright background magenta");
+
+	html = rz_cons_html_filter("\x1b[106mBright background\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font style='background-color:#55ffff'>Bright&nbsp;background</font>", "Bright background cyan");
+
+	html = rz_cons_html_filter("\x1b[107mBright background\x1b[0m", NULL);
+	mu_assert_streq_free(html, "<font style='background-color:#ffffff'>Bright&nbsp;background</font>", "Bright background white");
+
+	/* Explicit foreground reset (39m) */
+
+	html = rz_cons_html_filter("\x1b[91mAA\x1b[39mBB", NULL);
+	mu_assert_streq_free(html,
+		"<font color='#ff5555'>AA</font>BB",
+		"Reset bright foreground");
+
+	html = rz_cons_html_filter("\x1b[91m\x1b[42mAA\x1b[39mBB", NULL);
+	mu_assert_streq_free(html,
+		"<font color='#ff5555' style='background-color:#0f0'>AA</font>"
+		"<font style='background-color:#0f0'>BB</font>",
+		"Reset foreground preserve background");
+
+	html = rz_cons_html_filter("\x1b[101mAA\x1b[49mBB", NULL);
+	mu_assert_streq_free(html,
+		"<font style='background-color:#ff5555'>AA</font>BB",
+		"Reset bright background");
+
+	html = rz_cons_html_filter("\x1b[91m\x1b[101mAA\x1b[49mBB", NULL);
+	mu_assert_streq_free(html,
+		"<font color='#ff5555' style='background-color:#ff5555'>AA</font>"
+		"<font color='#ff5555'>BB</font>",
+		"Reset background preserve foreground");
+
 	mu_end;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Added ansi bright foreground colors and forground and background reset support to rz_cons_html_filter for [rizinorg/cutter/#3625](https://github.com/rizinorg/cutter/pull/3625).


**Test plan**
Passes cons_html test
