### PR TITLE
librz/core/canalysis.c: Fix data xref analysis

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4004,11 +4004,6 @@ static bool addr_in_exec_section(RzBinObject *bo, ut64 addr) {
 	return sec && (sec->perm & RZ_PERM_X);
 }
 
-static bool addr_in_exec_segment(RzBinObject *bo, ut64 addr) {
-	RzBinSection *seg = rz_bin_get_segment_at(bo, addr, true);
-	return seg && (seg->perm & RZ_PERM_X);
-}
-
 /** \brief How a DATA xref's instruction relates to its target address. */
 typedef enum {
 	XREF_REF_OTHER = 0, ///< address computation, control flow, etc. — handled as before
@@ -4106,11 +4101,9 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 		if (!bo) {
 			continue;
 		}
-		// Only executable-region targets need classifying: reject constants that merely
-		// equal a code address (e.g. `sub sp, sp, 0x810`), while skipping the decode for
-		// the common data-section case.
-		bool in_exec_segment = addr_in_exec_segment(bo, target);
-		XrefRefKind ref_kind = in_exec_segment ? xref_ref_kind(core, xref->from, target) : XREF_REF_OTHER;
+
+		// reject constants that merely equal a code address (e.g. `sub sp, sp, 0x810`)
+		XrefRefKind ref_kind = xref_ref_kind(core, xref->from, target);
 		if (ref_kind == XREF_REF_COINCIDENTAL_IMM) {
 			continue;
 		}

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -4045,6 +4045,12 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 		return;
 	}
 
+	RzBinObject *bo = rz_bin_cur_object(core->bin);
+	if (!bo) {
+		rz_list_free(all_xrefs);
+		return;
+	}
+
 	// collect every target address that has at least one CODE/CALL xref
 	RzSetU *code_call_targets = rz_set_u_new();
 	if (!code_call_targets) {
@@ -4097,10 +4103,6 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 		// ; DATA XREF from dbg.sched_run @ 0x490
 		// ;-- data.000004e0:
 		// 0x000004e0      .dword 0x1fff0274 ; runqueue_bitcache ; section..bss ; sym..bss ; obj.runqueue_bitcache ; loc._sbss ; loc._szero ; loc._erelocate ; sched.c:135
-		RzBinObject *bo = rz_bin_cur_object(core->bin);
-		if (!bo) {
-			continue;
-		}
 
 		// reject constants that merely equal a code address (e.g. `sub sp, sp, 0x810`)
 		XrefRefKind ref_kind = xref_ref_kind(core, xref->from, target);
@@ -4195,6 +4197,44 @@ static void analysis_mark_xrefs_as_data(RzCore *core) {
 			}
 		}
 		ut64 upper = RZ_MIN(next_data, next_fcn);
+		// cap upper to curr section boundary or map
+		RzBinSection *sec = rz_bin_get_section_at(bo, target, true);
+		if (sec) {
+			ut64 sec_end = sec->vaddr + sec->vsize;
+			if (upper > sec_end)
+				upper = sec_end;
+
+		} else {
+			// target is in a section gap or we are in a binary w/o metadata
+			ut64 next_sec_start = UT64_MAX;
+
+			RzBinSection *s;
+			void **iter;
+			rz_pvector_foreach (bo->sections, iter) {
+				s = *iter;
+				if (s->is_segment) {
+					continue;
+				}
+				ut64 vaddr = rz_bin_object_addr_with_base(bo, s->vaddr);
+				if (vaddr > target && vaddr < next_sec_start) {
+					next_sec_start = vaddr;
+				}
+			}
+
+			// cap upper to next section start if exists
+			if (next_sec_start != UT64_MAX && upper > next_sec_start) {
+				upper = next_sec_start;
+			}
+			// last fallback, cap upper to map_end
+			// also if target was in last section before unmapped region
+			RzIOMap *map = rz_io_map_get(core->io, target);
+			if (map) {
+				ut64 map_end = rz_io_map_get_to(map) + 1;
+				if (upper > map_end) {
+					upper = map_end;
+				}
+			}
+		}
 		ut64 size;
 		if (upper != UT64_MAX) {
 			size = rz_set_u_contains(exec_targets, target)

--- a/test/db/analysis/x86_64
+++ b/test/db/analysis/x86_64
@@ -4521,3 +4521,16 @@ EXPECT=<<EOF
 \           0x1400010ae      ret
 EOF
 RUN
+
+NAME=do not mark coincidental imm in non-exec segment as data
+FILE=bins/elf/hello-freebsd-x64
+CMDS=<<EOF
+e io.cache=true
+s 0x002015ae
+wa "and dword [rbp-8], 0x0020001f"
+aaa
+Cdl~0x0020001f
+EOF
+EXPECT=<<EOF
+EOF
+RUN

--- a/test/db/analysis/x86_64
+++ b/test/db/analysis/x86_64
@@ -4534,3 +4534,53 @@ EOF
 EXPECT=<<EOF
 EOF
 RUN
+
+NAME=data block should not bleed across section or map boundary
+FILE=bins/elf/hello-freebsd-x64
+CMDS=<<EOF
+aaa
+# map at 0x200000 ends at 0x0020059b = 1435 bytes
+oml~0x00200000
+# should not be 5536 bytes (upto next fxn at 0x002015a0), cap at next section
+Cdl~0x00200000
+echo "===not bleed across section==="
+e io.cache=true
+s 0x002015ae
+wa "add dword [0x00200546], 1"
+aaa
+# 0x00200546 is in section gap
+# should be caped at next section, 2 bytes ahead
+# should not be 4186 bytes (upto next fxn at 0x002015a0)
+Cdl~0x00200546
+echo "===handle section gap==="
+wa "add dword [0x00200544], 1"
+aaa
+# 0x00200544 is in .rodata
+s 0x00200544
+iS.
+# should be caped to curr section end, 2 bytes ahead
+# should not be 4188 bytes (upto next fxn at 0x002015a0)
+Cdl~0x00200544
+echo "===cap at map end==="
+s 0x002015ae
+wa "add dword [0x00200562], 1"
+aaa
+# 0x00200562 is last section before unmapped
+# so data block should cap at curr map end 0x0020059b = 57 bytes, 
+# should not be 4158 bytes (upto next fxn at 0x002015a0)
+Cdl~0x00200562
+EOF
+EXPECT=<<EOF
+ 2 fd: 3 +0x00000000 0x00200000 - 0x0020059b r-- fmap.LOAD0
+0x00200000 data Cd 680
+===not bleed across section===
+0x00200546 data Cd 2
+===handle section gap===
+     paddr size      vaddr vsize align perm name    type     flags               
+---------------------------------------------------------------------------------
+0x00000538  0xe 0x00200538   0xe   0x0 -r-- .rodata PROGBITS alloc,merge,strings
+0x00200544 data Cd 2
+===cap at map end===
+0x00200562 data Cd 58
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

while processing for marking xrefs as data
1. classify target using `xref_ref_kind` for data section too, previously it was only classified if target was in exec segment. Which caused false positive when the target was in non-exec section. Happens when the immediate value is small and it points in data section.

3. restrict data block from bleeding into other sections. Currently it correctly caps data block  at next "detected" function (or next data) but when the function is not detected yet (like in stripped bins) and the area onwards from data ref is empty, the data block bleeds into other sections specifically executable section. This should never happen. 

while experimenting on my fix i also noticed that this fails when the target is in a section gap (for any reason :D) and it fallback to caping on map_end.
so we need to iterate over sections if any , to cap upper at next section.

fallback to map end (when target is in last section before unmapped region)

Relevant PRs: 
1st bug : https://github.com/rizinorg/rizin/pull/6506
2nd bug : https://github.com/rizinorg/rizin/pull/6307

...

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

- **For 1st bug**
before:
```bash
❯ rizin test/bins/elf/hello-freebsd-x64
 -- Use the 'id' command to see the source line related to the current seek
[0x002015a0]> e io.cache=true
[0x002015a0]> s 0x2015ae
[0x002015ae]> wa "and dword [rbp-8], 0x0020001f"
[0x002015ae]> aaa
...
[0x002015ae]> Cdl~0x0020001f
0x0020001f data Cd 5505
[0x002015ae]> 
```

after:
```bash
❯ rizin test/bins/elf/hello-freebsd-x64
 -- Temporally drop the verbosity prefixing the commands with ':'
[0x002015a0]> e io.cache=true
[0x002015a0]> s 0x2015ae
[0x002015ae]> wa "and dword [rbp-8], 0x0020001f"
[0x002015ae]> aaa
...
[0x002015ae]> Cdl~0x0020001f
[0x002015ae]>
```

- **For 2nd bug i have already mentioned outputs on dev branch in test itself, checkout (those lines which says it should not be....). On dev that are the outputs and hence this test fails on dev**
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
