### PR TITLE
When sm3 on openssl is not available, compile algorithms/sm3/sm3.c

### DIFF
--- a/librz/hash/meson.build
+++ b/librz/hash/meson.build
@@ -184,6 +184,11 @@ else
     'algorithms/md5/md5.c',
     'algorithms/sha1/sha1.c',
     'algorithms/sha2/sha2.c',
+  ]
+endif
+
+if userconf.get('HAVE_OPENSSL_SM3', 0) == 0
+  rz_hash_sources += [
     'algorithms/sm3/sm3.c',
   ]
 endif

--- a/meson.build
+++ b/meson.build
@@ -945,6 +945,7 @@ summary({
   'System xxhash library': xxhash_dep.found() and xxhash_dep.type_name() != 'internal',
   'System libmspack library': libmspack_dep.found() and libmspack_dep.type_name() != 'internal',
   'System openssl library': sys_openssl.found() and sys_openssl.type_name() != 'internal',
+  'System openssl has SM3': userconf.get('HAVE_OPENSSL_SM3', 0) != 0,
   'System capstone library': capstone_dep.found() and capstone_dep.type_name() != 'internal',
   'System zydis library': zydis_dep.found() and zydis_dep.type_name() != 'internal',
   'System tree-sitter library': tree_sitter_dep.found() and tree_sitter_dep.type_name() != 'internal',


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

For whatever reason when i tested it, my built openssl had sm3 still enabled, so it never worked.

Now it will compile the missing file.

fix #6586