### PR TITLE
Update capstone-next and support Alpha instruction ID variants

### DIFF
--- a/librz/arch/p/analysis/analysis_alpha_cs.c
+++ b/librz/arch/p/analysis/analysis_alpha_cs.c
@@ -11,6 +11,12 @@
 
 #include <alpha/alpha.inc>
 
+#ifdef RZ_CAPSTONE_ALPHA_INSNS_UPPERCASE
+#define RZ_ALPHA_INS(name) ALPHA_INS_##name
+#else
+#define RZ_ALPHA_INS(name) Alpha_INS_##name
+#endif
+
 static char *get_reg_profile(RzAnalysis *_) {
 	const char *p =
 		"=PC	r31\n"
@@ -197,198 +203,198 @@ static void alpha_op_set_type(RzAsmAlphaContext *ctx, RzAnalysisOp *op) {
 		op->type = RZ_ANALYSIS_OP_TYPE_UNK;
 		break;
 	}
-	case Alpha_INS_BEQ:
-	case Alpha_INS_BGE:
-	case Alpha_INS_BGT:
-	case Alpha_INS_BLBC:
-	case Alpha_INS_BLBS:
-	case Alpha_INS_BLE:
-	case Alpha_INS_BLT:
-	case Alpha_INS_BNE:
+	case RZ_ALPHA_INS(BEQ):
+	case RZ_ALPHA_INS(BGE):
+	case RZ_ALPHA_INS(BGT):
+	case RZ_ALPHA_INS(BLBC):
+	case RZ_ALPHA_INS(BLBS):
+	case RZ_ALPHA_INS(BLE):
+	case RZ_ALPHA_INS(BLT):
+	case RZ_ALPHA_INS(BNE):
 		op->type = RZ_ANALYSIS_OP_TYPE_CJMP;
 		op->jump = alpha_calc_64bit_jump(op->addr, ctx, 1);
 		op->fail = op->addr + op->size;
 		break;
-	case Alpha_INS_BR:
+	case RZ_ALPHA_INS(BR):
 		op->type = RZ_ANALYSIS_OP_TYPE_JMP;
 		op->jump = alpha_calc_64bit_jump(op->addr, ctx, 0);
 		break;
-	case Alpha_INS_BSR:
+	case RZ_ALPHA_INS(BSR):
 		op->type = RZ_ANALYSIS_OP_TYPE_CALL;
 		op->jump = alpha_calc_64bit_jump(op->addr, ctx, 0);
 		op->fail = op->addr + op->size;
 		break;
-	case Alpha_INS_RET:
+	case RZ_ALPHA_INS(RET):
 		op->type = RZ_ANALYSIS_OP_TYPE_RET;
 		op->stackop = RZ_ANALYSIS_STACK_GET;
 		op->stackptr = 8;
 		op->fail = op->addr + op->size;
 		break;
-	case Alpha_INS_JMP:
+	case RZ_ALPHA_INS(JMP):
 		op->type = RZ_ANALYSIS_OP_TYPE_JMP;
 		op->jump = op->addr + 4;
 		op->fail = op->addr + op->size;
 		break;
-	case Alpha_INS_JSR:
+	case RZ_ALPHA_INS(JSR):
 		op->type = RZ_ANALYSIS_OP_TYPE_CALL;
 		op->stackop = RZ_ANALYSIS_STACK_SET;
 		op->jump = op->addr + 4;
 		op->stackptr = 8;
 		op->fail = UT64_MAX;
 		break;
-	case Alpha_INS_JSR_COROUTINE:
+	case RZ_ALPHA_INS(JSR_COROUTINE):
 		op->type = RZ_ANALYSIS_OP_TYPE_JMP;
 		// This one is a weird one, pops from stack then pushes PC
 		op->stackop = RZ_ANALYSIS_STACK_GET;
 		op->fail = op->addr + op->size;
 		break;
-	case Alpha_INS_LDA:
-	case Alpha_INS_LDAH:
+	case RZ_ALPHA_INS(LDA):
+	case RZ_ALPHA_INS(LDAH):
 		op->type = RZ_ANALYSIS_OP_TYPE_LEA;
 		break;
-	case Alpha_INS_LDBU:
-	case Alpha_INS_LDL:
-	case Alpha_INS_LDL_L:
-	case Alpha_INS_LDQ:
-	case Alpha_INS_LDQ_L:
-	case Alpha_INS_LDQ_U:
-	case Alpha_INS_LDS:
-	case Alpha_INS_LDT:
-	case Alpha_INS_LDWU:
+	case RZ_ALPHA_INS(LDBU):
+	case RZ_ALPHA_INS(LDL):
+	case RZ_ALPHA_INS(LDL_L):
+	case RZ_ALPHA_INS(LDQ):
+	case RZ_ALPHA_INS(LDQ_L):
+	case RZ_ALPHA_INS(LDQ_U):
+	case RZ_ALPHA_INS(LDS):
+	case RZ_ALPHA_INS(LDT):
+	case RZ_ALPHA_INS(LDWU):
 		op->type = RZ_ANALYSIS_OP_TYPE_LOAD;
 		break;
 
-	case Alpha_INS_STB:
-	case Alpha_INS_STL:
-	case Alpha_INS_STL_C:
-	case Alpha_INS_STQ:
-	case Alpha_INS_STQ_C:
-	case Alpha_INS_STQ_U:
-	case Alpha_INS_STW:
+	case RZ_ALPHA_INS(STB):
+	case RZ_ALPHA_INS(STL):
+	case RZ_ALPHA_INS(STL_C):
+	case RZ_ALPHA_INS(STQ):
+	case RZ_ALPHA_INS(STQ_C):
+	case RZ_ALPHA_INS(STQ_U):
+	case RZ_ALPHA_INS(STW):
 		op->type = RZ_ANALYSIS_OP_TYPE_STORE;
 		break;
 
-	case Alpha_INS_XOR:
+	case RZ_ALPHA_INS(XOR):
 		op->type = RZ_ANALYSIS_OP_TYPE_XOR;
 		break;
 
-	case Alpha_INS_ADDL:
-	case Alpha_INS_ADDQ:
-	case Alpha_INS_ADDSsSU:
-	case Alpha_INS_ADDTsSU:
-	case Alpha_INS_AND:
-	case Alpha_INS_BIC:
-	case Alpha_INS_BIS:
-	case Alpha_INS_CMOVEQ:
-	case Alpha_INS_CMOVGE:
-	case Alpha_INS_CMOVGT:
-	case Alpha_INS_CMOVLBC:
-	case Alpha_INS_CMOVLBS:
-	case Alpha_INS_CMOVLE:
-	case Alpha_INS_CMOVLT:
-	case Alpha_INS_CMOVNE:
-	case Alpha_INS_CMPBGE:
-	case Alpha_INS_CMPEQ:
-	case Alpha_INS_CMPLE:
-	case Alpha_INS_CMPLT:
-	case Alpha_INS_CMPTEQsSU:
-	case Alpha_INS_CMPTLEsSU:
-	case Alpha_INS_CMPTLTsSU:
-	case Alpha_INS_CMPTUNsSU:
-	case Alpha_INS_CMPULE:
-	case Alpha_INS_CMPULT:
-	case Alpha_INS_COND_BRANCH:
-	case Alpha_INS_CPYSE:
-	case Alpha_INS_CPYSN:
-	case Alpha_INS_CPYS:
-	case Alpha_INS_CTLZ:
-	case Alpha_INS_CTPOP:
-	case Alpha_INS_CTTZ:
-	case Alpha_INS_CVTQSsSUI:
-	case Alpha_INS_CVTQTsSUI:
-	case Alpha_INS_CVTSTsS:
-	case Alpha_INS_CVTTQsSVC:
-	case Alpha_INS_CVTTSsSUI:
-	case Alpha_INS_DIVSsSU:
-	case Alpha_INS_DIVTsSU:
-	case Alpha_INS_ECB:
-	case Alpha_INS_EQV:
-	case Alpha_INS_EXCB:
-	case Alpha_INS_EXTBL:
-	case Alpha_INS_EXTLH:
-	case Alpha_INS_EXTLL:
-	case Alpha_INS_EXTQH:
-	case Alpha_INS_EXTQL:
-	case Alpha_INS_EXTWH:
-	case Alpha_INS_EXTWL:
-	case Alpha_INS_FBEQ:
-	case Alpha_INS_FBGE:
-	case Alpha_INS_FBGT:
-	case Alpha_INS_FBLE:
-	case Alpha_INS_FBLT:
-	case Alpha_INS_FBNE:
-	case Alpha_INS_FCMOVEQ:
-	case Alpha_INS_FCMOVGE:
-	case Alpha_INS_FCMOVGT:
-	case Alpha_INS_FCMOVLE:
-	case Alpha_INS_FCMOVLT:
-	case Alpha_INS_FCMOVNE:
-	case Alpha_INS_FETCH:
-	case Alpha_INS_FETCH_M:
-	case Alpha_INS_FTOIS:
-	case Alpha_INS_FTOIT:
-	case Alpha_INS_INSBL:
-	case Alpha_INS_INSLH:
-	case Alpha_INS_INSLL:
-	case Alpha_INS_INSQH:
-	case Alpha_INS_INSQL:
-	case Alpha_INS_INSWH:
-	case Alpha_INS_INSWL:
-	case Alpha_INS_ITOFS:
-	case Alpha_INS_ITOFT:
-	case Alpha_INS_MB:
-	case Alpha_INS_MSKBL:
-	case Alpha_INS_MSKLH:
-	case Alpha_INS_MSKLL:
-	case Alpha_INS_MSKQH:
-	case Alpha_INS_MSKQL:
-	case Alpha_INS_MSKWH:
-	case Alpha_INS_MSKWL:
-	case Alpha_INS_MULL:
-	case Alpha_INS_MULQ:
-	case Alpha_INS_MULSsSU:
-	case Alpha_INS_MULTsSU:
-	case Alpha_INS_ORNOT:
-	case Alpha_INS_RC:
-	case Alpha_INS_RPCC:
-	case Alpha_INS_RS:
-	case Alpha_INS_S4ADDL:
-	case Alpha_INS_S4ADDQ:
-	case Alpha_INS_S4SUBL:
-	case Alpha_INS_S4SUBQ:
-	case Alpha_INS_S8ADDL:
-	case Alpha_INS_S8ADDQ:
-	case Alpha_INS_S8SUBL:
-	case Alpha_INS_S8SUBQ:
-	case Alpha_INS_SEXTB:
-	case Alpha_INS_SEXTW:
-	case Alpha_INS_SLL:
-	case Alpha_INS_SQRTSsSU:
-	case Alpha_INS_SQRTTsSU:
-	case Alpha_INS_SRA:
-	case Alpha_INS_SRL:
-	case Alpha_INS_STS:
-	case Alpha_INS_STT:
-	case Alpha_INS_SUBL:
-	case Alpha_INS_SUBQ:
-	case Alpha_INS_SUBSsSU:
-	case Alpha_INS_SUBTsSU:
-	case Alpha_INS_TRAPB:
-	case Alpha_INS_UMULH:
-	case Alpha_INS_WH64:
-	case Alpha_INS_WH64EN:
-	case Alpha_INS_WMB:
-	case Alpha_INS_ZAPNOT:
+	case RZ_ALPHA_INS(ADDL):
+	case RZ_ALPHA_INS(ADDQ):
+	case RZ_ALPHA_INS(ADDSsSU):
+	case RZ_ALPHA_INS(ADDTsSU):
+	case RZ_ALPHA_INS(AND):
+	case RZ_ALPHA_INS(BIC):
+	case RZ_ALPHA_INS(BIS):
+	case RZ_ALPHA_INS(CMOVEQ):
+	case RZ_ALPHA_INS(CMOVGE):
+	case RZ_ALPHA_INS(CMOVGT):
+	case RZ_ALPHA_INS(CMOVLBC):
+	case RZ_ALPHA_INS(CMOVLBS):
+	case RZ_ALPHA_INS(CMOVLE):
+	case RZ_ALPHA_INS(CMOVLT):
+	case RZ_ALPHA_INS(CMOVNE):
+	case RZ_ALPHA_INS(CMPBGE):
+	case RZ_ALPHA_INS(CMPEQ):
+	case RZ_ALPHA_INS(CMPLE):
+	case RZ_ALPHA_INS(CMPLT):
+	case RZ_ALPHA_INS(CMPTEQsSU):
+	case RZ_ALPHA_INS(CMPTLEsSU):
+	case RZ_ALPHA_INS(CMPTLTsSU):
+	case RZ_ALPHA_INS(CMPTUNsSU):
+	case RZ_ALPHA_INS(CMPULE):
+	case RZ_ALPHA_INS(CMPULT):
+	case RZ_ALPHA_INS(COND_BRANCH):
+	case RZ_ALPHA_INS(CPYSE):
+	case RZ_ALPHA_INS(CPYSN):
+	case RZ_ALPHA_INS(CPYS):
+	case RZ_ALPHA_INS(CTLZ):
+	case RZ_ALPHA_INS(CTPOP):
+	case RZ_ALPHA_INS(CTTZ):
+	case RZ_ALPHA_INS(CVTQSsSUI):
+	case RZ_ALPHA_INS(CVTQTsSUI):
+	case RZ_ALPHA_INS(CVTSTsS):
+	case RZ_ALPHA_INS(CVTTQsSVC):
+	case RZ_ALPHA_INS(CVTTSsSUI):
+	case RZ_ALPHA_INS(DIVSsSU):
+	case RZ_ALPHA_INS(DIVTsSU):
+	case RZ_ALPHA_INS(ECB):
+	case RZ_ALPHA_INS(EQV):
+	case RZ_ALPHA_INS(EXCB):
+	case RZ_ALPHA_INS(EXTBL):
+	case RZ_ALPHA_INS(EXTLH):
+	case RZ_ALPHA_INS(EXTLL):
+	case RZ_ALPHA_INS(EXTQH):
+	case RZ_ALPHA_INS(EXTQL):
+	case RZ_ALPHA_INS(EXTWH):
+	case RZ_ALPHA_INS(EXTWL):
+	case RZ_ALPHA_INS(FBEQ):
+	case RZ_ALPHA_INS(FBGE):
+	case RZ_ALPHA_INS(FBGT):
+	case RZ_ALPHA_INS(FBLE):
+	case RZ_ALPHA_INS(FBLT):
+	case RZ_ALPHA_INS(FBNE):
+	case RZ_ALPHA_INS(FCMOVEQ):
+	case RZ_ALPHA_INS(FCMOVGE):
+	case RZ_ALPHA_INS(FCMOVGT):
+	case RZ_ALPHA_INS(FCMOVLE):
+	case RZ_ALPHA_INS(FCMOVLT):
+	case RZ_ALPHA_INS(FCMOVNE):
+	case RZ_ALPHA_INS(FETCH):
+	case RZ_ALPHA_INS(FETCH_M):
+	case RZ_ALPHA_INS(FTOIS):
+	case RZ_ALPHA_INS(FTOIT):
+	case RZ_ALPHA_INS(INSBL):
+	case RZ_ALPHA_INS(INSLH):
+	case RZ_ALPHA_INS(INSLL):
+	case RZ_ALPHA_INS(INSQH):
+	case RZ_ALPHA_INS(INSQL):
+	case RZ_ALPHA_INS(INSWH):
+	case RZ_ALPHA_INS(INSWL):
+	case RZ_ALPHA_INS(ITOFS):
+	case RZ_ALPHA_INS(ITOFT):
+	case RZ_ALPHA_INS(MB):
+	case RZ_ALPHA_INS(MSKBL):
+	case RZ_ALPHA_INS(MSKLH):
+	case RZ_ALPHA_INS(MSKLL):
+	case RZ_ALPHA_INS(MSKQH):
+	case RZ_ALPHA_INS(MSKQL):
+	case RZ_ALPHA_INS(MSKWH):
+	case RZ_ALPHA_INS(MSKWL):
+	case RZ_ALPHA_INS(MULL):
+	case RZ_ALPHA_INS(MULQ):
+	case RZ_ALPHA_INS(MULSsSU):
+	case RZ_ALPHA_INS(MULTsSU):
+	case RZ_ALPHA_INS(ORNOT):
+	case RZ_ALPHA_INS(RC):
+	case RZ_ALPHA_INS(RPCC):
+	case RZ_ALPHA_INS(RS):
+	case RZ_ALPHA_INS(S4ADDL):
+	case RZ_ALPHA_INS(S4ADDQ):
+	case RZ_ALPHA_INS(S4SUBL):
+	case RZ_ALPHA_INS(S4SUBQ):
+	case RZ_ALPHA_INS(S8ADDL):
+	case RZ_ALPHA_INS(S8ADDQ):
+	case RZ_ALPHA_INS(S8SUBL):
+	case RZ_ALPHA_INS(S8SUBQ):
+	case RZ_ALPHA_INS(SEXTB):
+	case RZ_ALPHA_INS(SEXTW):
+	case RZ_ALPHA_INS(SLL):
+	case RZ_ALPHA_INS(SQRTSsSU):
+	case RZ_ALPHA_INS(SQRTTsSU):
+	case RZ_ALPHA_INS(SRA):
+	case RZ_ALPHA_INS(SRL):
+	case RZ_ALPHA_INS(STS):
+	case RZ_ALPHA_INS(STT):
+	case RZ_ALPHA_INS(SUBL):
+	case RZ_ALPHA_INS(SUBQ):
+	case RZ_ALPHA_INS(SUBSsSU):
+	case RZ_ALPHA_INS(SUBTsSU):
+	case RZ_ALPHA_INS(TRAPB):
+	case RZ_ALPHA_INS(UMULH):
+	case RZ_ALPHA_INS(WH64):
+	case RZ_ALPHA_INS(WH64EN):
+	case RZ_ALPHA_INS(WMB):
+	case RZ_ALPHA_INS(ZAPNOT):
 		break;
 	}
 }

--- a/librz/main/rz-asm.c
+++ b/librz/main/rz-asm.c
@@ -140,6 +140,7 @@ static int show_analisys_info(RzAsmState *as, const char *arg, ut64 offset) {
 		rz_analysis_op_init(&aop);
 		if (rz_analysis_op(as->analysis, &aop, offset, buf + ret, len - ret, RZ_ANALYSIS_OP_MASK_BASIC | RZ_ANALYSIS_OP_MASK_ESIL) < 1) {
 			eprintf("Error analyzing instruction at 0x%08" PFMT64x "\n", offset);
+			rz_analysis_op_fini(&aop);
 			break;
 		}
 		if (aop.size < 1) {
@@ -151,6 +152,7 @@ static int show_analisys_info(RzAsmState *as, const char *arg, ut64 offset) {
 			} else {
 				eprintf("Invalid\n");
 			}
+			rz_analysis_op_fini(&aop);
 			break;
 		}
 		print_analysis_info(as, &aop, offset, buf + ret, len - ret, pj);
@@ -312,6 +314,7 @@ static int print_disassembly_output(RzAsmState *as, ut64 addr, const char *buf, 
 			}
 			if (aop.size < 1) {
 				eprintf("Invalid\n");
+				rz_analysis_op_fini(&aop);
 				break;
 			}
 			ret += aop.size;
@@ -327,6 +330,7 @@ static int print_disassembly_output(RzAsmState *as, ut64 addr, const char *buf, 
 			rz_analysis_op_init(&aop);
 			if (rz_analysis_op(as->analysis, &aop, addr, data + ret, len - ret, RZ_ANALYSIS_OP_MASK_IL) <= 0) {
 				eprintf("Invalid\n");
+				rz_analysis_op_fini(&aop);
 				ret = 0;
 				break;
 			}

--- a/meson.build
+++ b/meson.build
@@ -215,6 +215,22 @@ else
   add_project_arguments(['-DUSE_SYS_CAPSTONE'], language: 'c')
 endif
 
+has_capstone_alpha_uppercase_insns = cc.compiles('''
+#include <capstone/capstone.h>
+#include <capstone/alpha.h>
+int main(void) {
+	alpha_insn insn = ALPHA_INS_INVALID;
+	return insn == ALPHA_INS_INVALID;
+}
+''',
+  dependencies: capstone_check_deps,
+  include_directories: capstone_check_includes,
+  name: 'Capstone has uppercase Alpha instruction IDs'
+)
+if has_capstone_alpha_uppercase_insns
+  add_project_arguments(['-DRZ_CAPSTONE_ALPHA_INSNS_UPPERCASE'], language: 'c')
+endif
+
 has_capstone_m68k_cpu32 = cc.compiles('''
 #include <capstone/capstone.h>
 int main(void) {

--- a/subprojects/capstone-next.wrap
+++ b/subprojects/capstone-next.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/capstone-engine/capstone.git
-revision = 3df6ff015fb6afd81307e325fdd9c82dbf184b28
+revision = ae11e4232cb1f0df4847bf2d66825b9f1cb119a2
 directory = capstone-next
 patch_directory = capstone-next
 depth = 1

--- a/test/db/analysis/alpha
+++ b/test/db/analysis/alpha
@@ -7,10 +7,10 @@ ao @ 0x12001b33c
 EOF
 EXPECT=<<EOF
 / size_t sym.strlen(const char *s);
-|           0x12001b320      ldq_u $1,0($23)
+|           0x12001b320      ldq_u $1,0($16)
 |           0x12001b324      lda   $2,0xffff($31)
-|           0x12001b328      insqh $2,$23,$2
-|           0x12001b32c      bic   $23,7,$0
+|           0x12001b328      insqh $2,$16,$2
+|           0x12001b32c      bic   $16,7,$0
 |           0x12001b330      bis   $2,$1,$1
 |           0x12001b334      bis   $31,$31,$31
 |           0x12001b338      cmpbge $31,$1,$2
@@ -31,7 +31,7 @@ EXPECT=<<EOF
 |           0x12001b374      addq  $0,$5,$0
 |           0x12001b378      addq  $0,$3,$0
 |           0x12001b37c      bis   $31,$31,$31
-|           0x12001b380      subq  $0,$23,$0
+|           0x12001b380      subq  $0,$16,$0
 \           0x12001b384      ret   $31,($26),1
 address: 0x12001b33c
 opcode: bne $2,0x12001b350

--- a/test/db/analysis/m68k
+++ b/test/db/analysis/m68k
@@ -1403,7 +1403,7 @@ e asm.arch=m68k
 e asm.bits=32
 e asm.cpu=cfv4e
 e asm.lines=false
-wx f2004000f2006000f23c44803f800000f23c5480400921fb54442d18f2105000f2106400f210c003f210e003f2800000f2800010f2c000000010f24800000010f2500000f27c0000f27a00001234f27b000012345678f200053af2000522f2000a28f2000523f2000520f2000521f2000525f2000538f2000518f200051af2000501f2000503f310f350f200051d
+wx f2004000f2006000f23c44803f800000f23c5480400921fb54442d18f2105000f2106400f210d003f210f003f2800000f2800010f2c000000010f24800000010f2500000f27c0000f27a00001234f27b000012345678f200053af2000522f2000a28f2000523f2000520f2000521f2000525f2000538f2000518f200051af2000501f2000503f310f350f200051d
 pdj 31~{}
 EOF
 EXPECT=<<EOF
@@ -1511,9 +1511,9 @@ EXPECT=<<EOF
     "fcn_addr": 0,
     "fcn_last": 0,
     "size": 4,
-    "opcode": "fmovem (a0), fp0-fp1",
-    "disasm": "fmovem (a0), fp0-fp1",
-    "bytes": "f210c003",
+    "opcode": "fmovem (a0), fp6-fp7",
+    "disasm": "fmovem (a0), fp6-fp7",
+    "bytes": "f210d003",
     "family": "fpu",
     "type": "load",
     "reloc": false,
@@ -1527,9 +1527,9 @@ EXPECT=<<EOF
     "fcn_addr": 0,
     "fcn_last": 0,
     "size": 4,
-    "opcode": "fmovem fp0-fp1, (a0)",
-    "disasm": "fmovem fp0-fp1, (a0)",
-    "bytes": "f210e003",
+    "opcode": "fmovem fp6-fp7, (a0)",
+    "disasm": "fmovem fp6-fp7, (a0)",
+    "bytes": "f210f003",
     "family": "fpu",
     "type": "store",
     "reloc": false,
@@ -1661,8 +1661,8 @@ EXPECT=<<EOF
     "fcn_addr": 0,
     "fcn_last": 0,
     "size": 8,
-    "opcode": "ftrapf.w 0x12345678",
-    "disasm": "ftrapf.w 0x12345678",
+    "opcode": "ftrapf.l 0x12345678",
+    "disasm": "ftrapf.l 0x12345678",
     "bytes": "f27b000012345678",
     "family": "fpu",
     "type": "trap",

--- a/test/db/asm/m68k_cfv4e_32
+++ b/test/db/asm/m68k_cfv4e_32
@@ -34,11 +34,8 @@ d "fmove.l d0, fpcr" f2009000
 d "fmove.l fpcr, d0" f200b000
 d "fmove.l d0, fpsr" f2008800
 d "fmove.l fpiar, d0" f200a400
-d "fmovem (a0), fp0-fp1" f210c003
-d "fmovem fp0-fp1, (a0)" f210e003
 d "fmovem (a0)+, fp6-fp7" f218d003
 d "fmovem fp0-fp1, -(a0)" f220e003
-d "fmovem (a0), d1" f210c810
 d "move.l d0, d0" 2000
 d "movea.l d0, a0" 2040
 d "moveq 0x1, d0" 7001
@@ -60,7 +57,7 @@ d "fdbf d0, 0x14" f24800000010
 d "fsf.b (a0)" f2500000
 d "ftrapf" f27c0000
 d "ftrapf.w 0x1234" f27a00001234
-d "ftrapf.w 0x12345678" f27b000012345678
+d "ftrapf.l 0x12345678" f27b000012345678
 d "ftst fp1, fp2" f200053a
 d "st.b d0" 50c0
 d "jmp (a0)" 4ed0

--- a/test/db/asm/m68k_coldfire_32
+++ b/test/db/asm/m68k_coldfire_32
@@ -34,11 +34,8 @@ d "fmove.l d0, fpcr" f2009000
 d "fmove.l fpcr, d0" f200b000
 d "fmove.l d0, fpsr" f2008800
 d "fmove.l fpiar, d0" f200a400
-d "fmovem (a0), fp0-fp1" f210c003
-d "fmovem fp0-fp1, (a0)" f210e003
 d "fmovem (a0)+, fp6-fp7" f218d003
 d "fmovem fp0-fp1, -(a0)" f220e003
-d "fmovem (a0), d1" f210c810
 d "move.l d0, d0" 2000
 d "movea.l d0, a0" 2040
 d "moveq 0x1, d0" 7001
@@ -60,7 +57,7 @@ d "fdbf d0, 0x14" f24800000010
 d "fsf.b (a0)" f2500000
 d "ftrapf" f27c0000
 d "ftrapf.w 0x1234" f27a00001234
-d "ftrapf.w 0x12345678" f27b000012345678
+d "ftrapf.l 0x12345678" f27b000012345678
 d "ftst fp1, fp2" f200053a
 d "st.b d0" 50c0
 d "jmp (a0)" 4ed0


### PR DESCRIPTION
**Your checklist for this pull request**
  - [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
  - [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
  - [x] I've documented every `RZ_API` function and struct this PR changes.
  - [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
  - [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
  - [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

This PR updates the bundled `capstone-next` revision from
`3df6ff015fb6afd81307e325fdd9c82dbf184b28` to
`ae11e4232cb1f0df4847bf2d66825b9f1cb119a2`.

The newer Capstone revision uses uppercase Alpha instruction identifiers such
as `ALPHA_INS_*`, while older revisions expose `Alpha_INS_*`. A Meson feature
probe now detects which variant is available, and the Alpha analysis plugin
uses the `RZ_ALPHA_INS()` compatibility macro to support both forms.

The affected test expectations are also updated:

- Use the source register emitted by the updated Alpha decoder.
- Remove invalid ColdFire `fmovem` encodings now rejected by Capstone.
- Expect the correct `.l` suffix for long `ftrap` instructions.

This PR does not change any `RZ_API` interfaces and does not require a Rizin
book update.

OpenAI Codex with the GPT-5 model was used to help implement, review, split,
and validate these changes. The resulting changes were manually reviewed and
tested.
