### PR TITLE
[RISCV][CI] Fix the kernel URL to point to snapshot archives

### DIFF
--- a/.github/riscv-qemu-setup-all.sh
+++ b/.github/riscv-qemu-setup-all.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 set -eux
 
-LINUX_IMG=linux-image-6.12.73+deb13-riscv64_6.12.73-1_riscv64.deb
-DEBIAN_SERVER=https://ftp.debian.org/debian/pool/main/l/linux
+LINUX_IMG_URL=https://snapshot.debian.org/archive/debian/20260220T023858Z/pool/main/l/linux/linux-image-6.12.73%2Bdeb13-riscv64_6.12.73-1_riscv64.deb
 BUSYBOX_PATH=busybox-1.30.1-riscv64
 BUSYBOX_VERSION=9d220791e5917fc2190c5cf405a014a483c01d86
 LIB_PATH=/usr/riscv64-linux-gnu/lib
@@ -11,9 +10,10 @@ LIB_M=libm.so.6
 DYN_LD=ld-linux-riscv64-lp64d.so.1
 TEST_BIN_URL=https://raw.githubusercontent.com/rizinorg/rizin-testbins/master/elf/riscv_bitmanip
 # Fetch the kernel package
-wget "$DEBIAN_SERVER/$LINUX_IMG"
+wget "$LINUX_IMG_URL"
 # Extract
-dpkg-deb -x "$LINUX_IMG" linux-image
+# DO NOT try to derieve this from the URL via basename please, %x encodings will break this
+dpkg-deb -x 'linux-image-6.12.73+deb13-riscv64_6.12.73-1_riscv64.deb' linux-image
 
 # Fetch busybox
 git clone https://github.com/rcore-os/busybox-prebuilts.git busybox


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

The kernel fetch URL in rv64 VM workflow used to point to a URL like `https://ftp.debian.org/debian/pool/main/l/linux/<version>.deb`, this URL is essentially just a reference into a live pool of used images by current releases, when no relase references it it gets garbage collected out of existence.

The URL can be replaced by a snapshot URL which is more stable.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The CI is green again.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes https://github.com/rizinorg/rizin/issues/6624


**Long Term**

For elegance/de-duplication reason, we should perhaps use what riscv-32 uses, which is https://github.com/moste00/riscv-minstack, a self-hosted minimal build of linux, open SBI, and busybox. RV32 must do this because it has no choice, as almost no mainstream linux distro publishes pre-built images for rv32. RV64 should probably exploit this and also depend on the same build, possibly after transferring the repo to Rizinorg.