### PR TITLE
main: add persistent tracing CLI option

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -3459,6 +3459,7 @@ RZ_API int rz_core_config_init(RzCore *core) {
 	rz_config_add_bool_bind(cfg, "dbg.swstep", "Force use of software steps (code analysis+breakpoint)", core_dbg_swstep_get, core_dbg_swstep_set, NULL, core);
 	SETBPREF("dbg.trace.inrange", "false", "While tracing, avoid following calls outside specified range");
 	SETBPREF("dbg.trace.libs", "true", "Trace library code too");
+	SETBPREF("dbg.trace_persistent", "false", "Automatically enable tracing when a debugger session starts");
 	SETBPREF("dbg.exitkills", "true", "Kill process on exit");
 	SETPREF("dbg.exe.path", "", "Path to binary being debugged");
 	SETCB("dbg.execs", "false", &cb_dbg_execs, "Stop execution if new thread is created");

--- a/librz/core/cio.c
+++ b/librz/core/cio.c
@@ -50,7 +50,12 @@ RZ_API int rz_core_setup_debugger(RzCore *r, const char *debugbackend, bool atta
 			}
 		}
 	}
-	rz_core_seek_to_register(r, "PC", false);
+    rz_core_seek_to_register(r, "PC", false);
+
+	if (rz_config_get_b(r->config, "dbg.trace_persistent") && !r->dbg->session) {
+		r->dbg->session = rz_debug_session_new();
+		rz_debug_add_checkpoint(r->dbg);
+	}
 
 	return true;
 }

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -585,6 +585,9 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 		case 'C':
 			do_connect = true;
 			break;
+		case 't':
+			rz_config_set_b(r->config, "dbg.trace_persistent", true);
+			break;
 #if DEBUGGER
 		case 'd': debug = 1; break;
 #else


### PR DESCRIPTION

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

## Summary

This PR adds support for enabling persistent tracing from the command line using the `-t` option.

When `-t` is specified, the `dbg.trace_persistent` configuration option is enabled. If debugging is started immediately with `-d` or later through commands such as `ood`, a tracing session is created automatically, providing behavior equivalent to running `dts+` after the debugger starts.

## Changes

- Added the `dbg.trace_persistent` configuration option.
- Added support for the `-t` CLI option.
- Automatically creates a tracing session during debugger setup when persistent tracing is enabled.

## Test plan

### Manual testing

1. Build Rizin:

```sh
meson compile -C build
```

2. Verify that the configuration is disabled by default:

```sh
./build/binrz/rizin/rizin /bin/ls
```

Inside Rizin:

```sh
e dbg.trace_persistent
```

Expected output:

```text
false
```

3. Verify immediate debugger startup with `-d -t`:

```sh
./build/binrz/rizin/rizin -d -t /bin/ls
```

Inside Rizin:

```sh
dts+
```

Expected output:

```text
ERROR: Session already started
```

This confirms that the tracing session was automatically created when the debugger started.

4. Verify deferred debugger startup with `-t`:

```sh
./build/binrz/rizin/rizin -t /bin/ls
```

Inside Rizin:

```sh
ood
dts+
```

Expected output:

```text
ERROR: Session already started
```

This confirms that persistent tracing is also enabled when the debugger is started later using `ood`.

5. Verify that the configuration is enabled when using `-t`:

```sh
./build/binrz/rizin/rizin -t /bin/ls
```

Inside Rizin:

```sh
e dbg.trace_persistent
```

Expected output:

```text
true
```
## Closing issues
Closes #765 