### PR TITLE
Make rz_analysis_op_is_call() treat op->type 's as enum values rather than bit flags

### DIFF
--- a/librz/arch/analysis.c
+++ b/librz/arch/analysis.c
@@ -979,11 +979,18 @@ RZ_API bool rz_analysis_op_is_eob(const RzAnalysisOp *op) {
  */
 RZ_API bool rz_analysis_op_is_call(RZ_NONNULL const RzAnalysisOp *op) {
 	rz_return_val_if_fail(op, false);
-	if ((op->type & RZ_ANALYSIS_OP_TYPE_CALL) == RZ_ANALYSIS_OP_TYPE_CALL ||
-		(op->type & RZ_ANALYSIS_OP_TYPE_UCALL) == RZ_ANALYSIS_OP_TYPE_UCALL) {
+	switch (op->type & RZ_ANALYSIS_OP_TYPE_MASK) {
+	case RZ_ANALYSIS_OP_TYPE_CALL:
+	case RZ_ANALYSIS_OP_TYPE_UCALL:
+	case RZ_ANALYSIS_OP_TYPE_RCALL:
+	case RZ_ANALYSIS_OP_TYPE_ICALL:
+	case RZ_ANALYSIS_OP_TYPE_IRCALL:
+	case RZ_ANALYSIS_OP_TYPE_CCALL:
+	case RZ_ANALYSIS_OP_TYPE_UCCALL:
 		return true;
+	default:
+		return false;
 	}
-	return false;
 }
 
 RZ_API void rz_analysis_purge(RzAnalysis *analysis) {


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
`rz_analysis_op_is_call()` treats `RZ_ANALYSIS_OP_TYPE_CALL` and `RZ_ANALYSIS_OP_TYPE_UCALL` as bit flags, but they are enum values

So, many other operation types maybe incorrectly classified as calls

**Test plan**
none

**Closing issues**
none
