### PR TITLE
Fixes for debug timing out dbgtrace test and RzNum slow path

### DIFF
--- a/librz/debug/trace.c
+++ b/librz/debug/trace.c
@@ -142,7 +142,9 @@ RZ_API bool rz_debug_trace_ins_after(RZ_NONNULL RzDebug *dbg) {
 		switch (val->type) {
 		case RZ_ANALYSIS_VAL_REG: {
 			if (!val->reg) {
-				RZ_LOG_ERROR("invalid register, unable to trace register state\n");
+				RZ_LOG_DEBUG("no register profile entry for a write at 0x%" PFMT64x
+					     "; the change is not recorded\n",
+					dbg->cur_op->addr);
 				continue;
 			}
 			ut64 data = rz_reg_get_value(dbg->reg, val->reg);

--- a/librz/debug/trace.c
+++ b/librz/debug/trace.c
@@ -42,6 +42,11 @@ RZ_API int rz_debug_trace_tag(RzDebug *dbg, int tag) {
 	return (dbg->trace->tag = (tag > 0) ? tag : UT32_MAX);
 }
 
+// Largest single memory write recorded into a debug session. Sized to hold
+// an x86 XSAVE area (576 bytes for the legacy region plus header, more with
+// AVX-512 state), which the glibc PLT/IFUNC resolvers write on every call.
+#define RZ_DEBUG_TRACE_MEMREF_MAX 4096
+
 RZ_API bool rz_debug_trace_ins_before(RzDebug *dbg) {
 	RzListIter *it, *it_tmp;
 	RzAnalysisValue *val;
@@ -78,8 +83,10 @@ RZ_API bool rz_debug_trace_ins_before(RzDebug *dbg) {
 			}
 			break;
 		case RZ_ANALYSIS_VAL_MEM:
-			if (val->memref > 32) {
-				eprintf("Error: adding changes to %d bytes in memory.\n", val->memref);
+			if (val->memref < 1 || val->memref > RZ_DEBUG_TRACE_MEMREF_MAX) {
+				RZ_LOG_WARN("not recording a %d byte memory write at 0x%" PFMT64x
+					    "; stepping back over it will restore stale memory\n",
+					val->memref, dbg->cur_op->addr);
 				rz_list_delete(dbg->cur_op->access, it);
 				break;
 			}
@@ -145,17 +152,25 @@ RZ_API bool rz_debug_trace_ins_after(RZ_NONNULL RzDebug *dbg) {
 			break;
 		}
 		case RZ_ANALYSIS_VAL_MEM: {
-			ut8 buf[32] = { 0 };
+			if (val->memref < 1 || val->memref > RZ_DEBUG_TRACE_MEMREF_MAX) {
+				break;
+			}
+			ut8 *buf = RZ_NEWS0(ut8, val->memref);
+			if (!buf) {
+				break;
+			}
 			if (!dbg->iob.read_at(dbg->iob.io, val->base, buf, val->memref)) {
-				eprintf("Error reading memory at 0x%" PFMT64x "\n", val->base);
+				RZ_LOG_ERROR("cannot read %d byte(s) at 0x%" PFMT64x "\n",
+					val->memref, val->base);
+				free(buf);
 				break;
 			}
 
 			// add mem write
-			size_t i;
-			for (i = 0; i < val->memref; i++) {
+			for (int i = 0; i < val->memref; i++) {
 				rz_debug_session_add_mem_change(dbg->session, val->base + i, buf[i]);
 			}
+			free(buf);
 			break;
 		}
 		default:

--- a/librz/include/rz_util/rz_num.h
+++ b/librz/include/rz_util/rz_num.h
@@ -449,6 +449,8 @@ typedef enum {
 
 RZ_API RzNumBasePrefix rz_num_base_prefix(RZ_NONNULL const char *p, RZ_NULLABLE RZ_OUT ut32 *base,
 	RZ_NULLABLE RZ_OUT size_t *prefix_len);
+RZ_API bool rz_num_is_int_literal(RZ_NONNULL const char *str, RZ_NULLABLE RZ_OUT ut64 *value,
+	RZ_NULLABLE RZ_OUT bool *overflow);
 
 /**
  * \brief Absolute value of a 64-bit number. Store result in `ut64`

--- a/librz/util/num/evaluator.c
+++ b/librz/util/num/evaluator.c
@@ -216,45 +216,30 @@ static bool literal_is_float(const char *t) {
 
 // Parse an unsigned integer literal. Returns true on success. On
 // ERANGE, sets *overflow=true so the caller can promote to bignum.
+// Thin wrapper over rz_num_is_int_literal() adding the evaluator's own
+// diagnostics. The three outcomes the caller distinguishes are: nothing after
+// the base prefix, no valid digit at all, and a digit run followed by a digit
+// invalid for the base (the '8' in 08 / 0187, which the grammar's permissive
+// decimal digit class lets through to here). The last one leaves *err unset so
+// the caller categorises it as a plain parse error.
 static bool parse_int_literal(const char *t, ut64 *out, bool *overflow, char **err) {
-	const char *p = t;
+	if (rz_num_is_int_literal(t, out, overflow)) {
+		return true;
+	}
+	if (!err || *err || (overflow && *overflow)) {
+		return false;
+	}
 	ut32 base = 10;
 	size_t prefix_len = 0;
-	// A C style leading zero reports prefix_len 0: the zero is an octal
-	// digit, so strtoull() must still see it.
-	rz_num_base_prefix(p, &base, &prefix_len);
-	p += prefix_len;
-	if (!*p) {
-		if (err && !*err) {
-			*err = rz_str_newf("empty integer literal: %s", t);
-		}
-		return false;
+	rz_num_base_prefix(t, &base, &prefix_len);
+	const char *digits = t + prefix_len;
+	ut8 first = 0;
+	if (!*digits) {
+		*err = rz_str_newf("empty integer literal: %s", t);
+	} else if (rz_hex_to_byte(&first, (ut8)*digits) || first >= base) {
+		*err = rz_str_newf("not an integer: %s", t);
 	}
-	errno = 0;
-	char *endp = NULL;
-	unsigned long long v = strtoull(p, &endp, base);
-	if (errno == ERANGE) {
-		if (overflow) {
-			*overflow = true;
-		}
-		return false;
-	}
-	if (endp == p) {
-		if (err && !*err) {
-			*err = rz_str_newf("not an integer: %s", t);
-		}
-		return false;
-	}
-	if (*endp != '\0') {
-		// Trailing junk after the digit run: a digit not valid for the
-		// detected base. This catches C-style octal with an out-of-range
-		// digit (the '8' in 08 / 0187), which the permissive decimal
-		// digit class in the grammar lets through to here. Leave *err
-		// unset so the caller can categorise it as a parse error.
-		return false;
-	}
-	*out = (ut64)v;
-	return true;
+	return false;
 }
 
 static bool parse_float_literal(const char *t, double *out, char **err) {

--- a/librz/util/unum.c
+++ b/librz/util/unum.c
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2007-2020 pancake <pancake@nopcode.org>
 // SPDX-License-Identifier: LGPL-3.0-only
 
+#include <errno.h>
 #include <math.h> /* for ceill */
 #include <rz_util.h>
 
@@ -581,6 +582,59 @@ static bool num_is_flagname_token(const char *str) {
 }
 
 /**
+ * \brief Check whether \p str is a bare integer literal, and parse it.
+ *
+ * A bare integer literal is an optional base prefix (see \ref rz_num_base_prefix)
+ * followed only by digits valid in that base, and nothing else. Signs,
+ * whitespace, operators, radix points, exponents, bit-vector widths, unit
+ * suffixes and the deprecated trailing base suffixes all make \p str not a
+ * bare literal.
+ *
+ * This is the cheap path around rz_num_math(): it needs no expression parser.
+ *
+ * \param str Text to examine.
+ * \param value Set to the parsed value when the function returns true.
+ * \param overflow Set to true when \p str is a valid integer literal too large
+ *                 for a ut64. The function still returns false; a caller that
+ *                 supports arbitrary precision can use this to promote it.
+ *
+ * \return true if \p str is a bare integer literal that fits in a ut64.
+ */
+RZ_API bool rz_num_is_int_literal(RZ_NONNULL const char *str, RZ_NULLABLE RZ_OUT ut64 *value,
+	RZ_NULLABLE RZ_OUT bool *overflow) {
+	rz_return_val_if_fail(str, false);
+	ut32 base = 10;
+	size_t prefix_len = 0;
+	rz_num_base_prefix(str, &base, &prefix_len);
+	const char *digits = str + prefix_len;
+	if (!*digits) {
+		return false;
+	}
+	for (const char *p = digits; *p; p++) {
+		ut8 v = 0;
+		if (rz_hex_to_byte(&v, (ut8)*p) || v >= base) {
+			return false;
+		}
+	}
+	errno = 0;
+	char *endp = NULL;
+	unsigned long long v = strtoull(digits, &endp, base);
+	if (errno == ERANGE) {
+		if (overflow) {
+			*overflow = true;
+		}
+		return false;
+	}
+	if (*endp) {
+		return false;
+	}
+	if (value) {
+		*value = (ut64)v;
+	}
+	return true;
+}
+
+/**
  * \brief Compute a numerical expression yielding a ut64.
  *
  * \param num RzNum instance.
@@ -619,6 +673,16 @@ RZ_API ut64 rz_num_math_ut64(RzNum *num, const char *str) {
 		// failure (again, the seek command) names the actual input
 		// rather than a stale or null buffer.
 		num->nc.calc_buf = str;
+	}
+
+	ut64 plain = 0;
+	// Bare integer literals are the common input here and need no
+	// expression parser; see rz_num_is_int_literal().
+	if (rz_num_is_int_literal(str, &plain, NULL)) {
+		if (num) {
+			num->value = plain;
+		}
+		return plain;
 	}
 
 	// Legacy `[addr]` dereference. The bracket read predates the typed


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Fixing annoying:
```
[XX] TIMEOUT 00h16m00s061ms db/archos/linux-x64/dbg_cont_back dbg.manycontback
RZ_COLOR=0 RZ_UTF8=0 RZ_NOPLUGINS=1 /home/runner/bin/rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -eflirt.sigdb.load.system=false -esearch.show_progress=false -eflirt.sigdb.load.home=false -N -d -e dbg.bpsysign=true -qc 'db @ main
db @ 0x004028ca
db @ 0x004028d1
db @ 0x0040290d
db @ 0x0040294b
dc
dts+
dc
dc
dc
dc
dsb
dcb
dr rip
dsb
dcb
dr rip
dsb
dcb
dr rip
dsb
dcb
dr rip
' bins/elf/analysis/ls-linux-x86_64-zlul
-- stdout
--- expected
+++ actual
@@ -1,4 +1,0 @@
-rip = 0x000000000040290d
-rip = 0x00000000004028d1
-rip = 0x00000000004028ca
-rip = 0x00000000004028a0

-- stderr
Process with PID 52468 started...
hit breakpoint at: 0x4028a0
Reading 4096 byte(s) from 0x0061c000...
Reading 4096 byte(s) from 0x0061d000...
Reading 135168 byte(s) from 0x1f1dd000...
Reading 4096 byte(s) from 0x7f18103ff000...
Reading 8192 byte(s) from 0x7f1810603000...
Reading 53248 byte(s) from 0x7f1810605000...
Reading 8192 byte(s) from 0x7f1810624000...
Reading 4096 byte(s) from 0x7f181062f000...
Reading 4096 byte(s) from 0x7f181065a000...
Reading 8192 byte(s) from 0x7f181065b000...
Reading 8192 byte(s) from 0x7f1810667000...
Reading 8192 byte(s) from 0x7f18106a9000...
Reading 139264 byte(s) from 0x7ffd0dab6000...
hit breakpoint at: 0x4028ca
Error: adding changes to 576 bytes in memory.
Error: adding changes to 576 bytes in memory.
ERROR: invalid register, unable to trace register state
...
hit breakpoint at: 0x4028d1
Error: adding changes to 576 bytes in memory.
Error: adding changes to 576 bytes in memory.
ERROR: invalid register, unable to trace register state
...
```

And this one:
```
[XX] TIMEOUT 00h16m00s105ms db/cmd/cmd_af Issue 4842
RZ_COLOR=0 RZ_UTF8=0 RZ_NOPLUGINS=1 /home/runner/bin/rizin -escr.utf8=0 -escr.color=0 -escr.interactive=0 -eflirt.sigdb.load.system=false -esearch.show_progress=false -eflirt.sigdb.load.home=false -N -qc '# It only triggers if aaaa is run twice. Very obscure.
# Can't pinpoint it.
# But it is related to the `aft` code (type propagation).
aaaa
aaaa
' bins/fuzzed/issue-4842
-- stderr

ERROR: Cannot peek memory without specifying an address (esil address: 0x0011d57d)
ERROR: Cannot peek memory without specifying an address (esil address: 0x0011d584)
...
```

**Test plan**

CI is green
