### PR TITLE
Fix *BSD failures related to RzNum

### DIFF
--- a/librz/debug/p/native/dragonfly.c
+++ b/librz/debug/p/native/dragonfly.c
@@ -325,6 +325,8 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 			continue;
 		}
 		strncpy(&region2[2], pos_c + 1, sizeof(region2) - 2 - 1);
+		// Terminate the start token at the '-'
+		*pos_c = 0;
 
 		if (!*name) {
 			snprintf(name, sizeof(name), "unk%d", unk++);

--- a/librz/debug/p/native/netbsd.c
+++ b/librz/debug/p/native/netbsd.c
@@ -345,6 +345,8 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 			continue;
 		}
 		strncpy(&region2[2], pos_c + 1, sizeof(region2) - 2 - 1);
+		// Terminate the start token at the '-'
+		*pos_c = 0;
 
 		if (!*name) {
 			snprintf(name, sizeof(name), "unk%d", unk++);

--- a/librz/debug/p/native/openbsd.c
+++ b/librz/debug/p/native/openbsd.c
@@ -348,6 +348,8 @@ static RzList /*<RzDebugMap *>*/ *rz_debug_native_map_get(RzDebug *dbg) {
 			continue;
 		}
 		strncpy(&region2[2], pos_c + 1, sizeof(region2) - 2 - 1);
+		// Terminate the start token at the '-'
+		*pos_c = 0;
 
 		if (!*name) {
 			snprintf(name, sizeof(name), "unk%d", unk++);

--- a/librz/include/meson.build
+++ b/librz/include/meson.build
@@ -96,6 +96,7 @@ rz_util_files = [
   'rz_util/rz_mem.h',
   'rz_util/rz_name.h',
   'rz_util/rz_num.h',
+  'rz_util/rz_num_expression.h',
   'rz_util/rz_panels.h',
   'rz_util/rz_path.h',
   'rz_util/rz_pj.h',

--- a/test/db/cmd/cmd_math
+++ b/test/db/cmd/cmd_math
@@ -273,10 +273,14 @@ RUN
 NAME="% 2**4.5"
 FILE=--
 CMDS=% 2**4.5
+# pow() is not correctly rounded on every libm. FreeBSD and NetBSD (msun)
+# return 22.627416997969519, one ULP below the correctly rounded
+# 22.627416997969522 that glibc and the UCRT give, so scifmt and hex cannot
+# be pinned here. Assert the rounded line, which any implementation within
+# one ULP agrees on.
+REGEXP_FILTER_OUT=float[[:space:]]+22\.6274
 EXPECT=<<EOF
 float   22.6274
-scifmt  22.627416997969522
-hex     0x4036a09e667f3bcd
 EOF
 RUN
 


### PR DESCRIPTION
# DO NOT SQUASH

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

A follow up to https://github.com/rizinorg/rizin/pull/4326
It reflects how lenient/imprecise old parser was and constructions like `0x2342-2345` from debug maps were parsed not as an expression but as a number

**Test plan**

CI is green
