### PR TITLE
Avoid 0-size realloc in RzVector

### DIFF
--- a/librz/util/vector.c
+++ b/librz/util/vector.c
@@ -23,9 +23,14 @@
 #define RESIZE_OR_RETURN_VAL(next_capacity, retval) \
 	do { \
 		size_t new_capacity = next_capacity; \
-		void **new_a = realloc(vec->a, vec->elem_size * new_capacity); \
-		if (!new_a && new_capacity) { \
-			return retval; \
+		void **new_a = NULL; \
+		if (new_capacity) { \
+			new_a = realloc(vec->a, vec->elem_size * new_capacity); \
+			if (!new_a) { \
+				return retval; \
+			} \
+		} else { \
+			free(vec->a); \
 		} \
 		vec->a = new_a; \
 		vec->capacity = new_capacity; \

--- a/test/unit/test_vector.c
+++ b/test/unit/test_vector.c
@@ -1011,6 +1011,17 @@ static bool test_vector_shrink(void) {
 
 	init_test_vector(&v, 0, 8, NULL, NULL);
 	rz_vector_shrink(&v);
+	mu_assert_eq(v.len, 0, "shrink to 0");
+	mu_assert_eq(rz_vector_capacity(&v), 0, "shrink to 0");
+	mu_assert_null(v.a, "shrink to 0 frees");
+	rz_vector_fini(&v);
+
+	init_test_vector(&v, 0, 8, NULL, NULL);
+	rz_vector_shrink(&v);
+	rz_vector_reserve(&v, 8);
+	mu_assert_eq(v.len, 0, "reserve after 0-shrink");
+	mu_assert_eq(rz_vector_capacity(&v), 8, "reserve after 0-shrink");
+	mu_assert_notnull(v.a, "sreserve after 0-shrink");
 	rz_vector_fini(&v);
 
 	mu_end;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

realloc with 0 size behavior is implementation-defined and not very useful to us, also valgrind is noisy about it.
When we shrink with len 0, it is best to just free the array.

Extracted from https://github.com/rizinorg/rizin/pull/5505

Fixes the following valgrind report (this is not critical at all, only informative):

```
==8243== realloc() with size 0
==8243==    at 0x488CCB4: realloc (vg_replace_malloc.c:1741)
==8243==    by 0x49A70D7: rz_vector_shrink (vector.c:542)
==8243==    by 0x41343B: test_vector_shrink (test_vector.c:1013)
==8243==    by 0x42287F: all_tests (test_vector.c:1875)
==8243==    by 0x423533: main (test_vector.c:1912)
==8243==  Address 0x5008ab0 is 0 bytes inside a block of size 32 alloc'd
==8243==    at 0x488CCB4: realloc (vg_replace_malloc.c:1741)
==8243==    by 0x49A6FE7: rz_vector_reserve (vector.c:534)
==8243==    by 0x4022A3: _init_test_vector (test_vector.c:12)
==8243==    by 0x413393: test_vector_shrink (test_vector.c:1012)
==8243==    by 0x42287F: all_tests (test_vector.c:1875)
==8243==    by 0x423533: main (test_vector.c:1912)
==8243==
```

**Test plan**

```
valgrind build/test/unit/test_vector
```