### PR TITLE
Set rizin version to 0.10.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rizin', 'c',
-  version: 'v1.0.0',
+  version: 'v0.10.0',
   license: 'LGPL-3.0-only',
   meson_version: '>=0.58.0',
   default_options: [

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LGPL-3.0-only
 
 name: rizin
-version: '1.0.0'
+version: '0.10.0'
 base: core18
 summary: Rizin reverse engineering framework and tool
 description: |


### PR DESCRIPTION
1.0 does not automatically follow after 0.9.
Needed for https://github.com/rizinorg/cutter/pull/3653