### PR TITLE
Fix aar ignoring vmap memory.

### DIFF
--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -2115,6 +2115,7 @@ RZ_API int rz_core_analysis_search_xrefs(RZ_NONNULL RzCore *core, ut64 from, ut6
 		}
 		int bytes_read = rz_io_nread_at(core->io, at, buf, bsz);
 		if (bytes_read <= 0) {
+			rz_cons_break_pop();
 			free(buf);
 			free(block);
 			return -1;

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -2115,6 +2115,8 @@ RZ_API int rz_core_analysis_search_xrefs(RZ_NONNULL RzCore *core, ut64 from, ut6
 		}
 		int bytes_read = rz_io_nread_at(core->io, at, buf, bsz);
 		if (bytes_read <= 0) {
+			free(buf);
+			free(block);
 			return -1;
 		}
 		memset(block, -1, bsz);

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -2109,12 +2109,12 @@ RZ_API int rz_core_analysis_search_xrefs(RZ_NONNULL RzCore *core, ut64 from, ut6
 	at = from;
 	st64 asm_sub_varmin = rz_config_get_i(core->config, "asm.sub.varmin");
 	while (at < to && !rz_cons_is_breaked()) {
-		int i = 0, ret = bsz;
+		int ret = bsz;
 		if (!rz_io_is_valid_offset(core->io, at, RZ_PERM_X)) {
 			break;
 		}
-		size_t bytes_read = rz_io_nread_at(core->io, at, buf, bsz);
-		if (!bytes_read) {
+		int bytes_read = rz_io_nread_at(core->io, at, buf, bsz);
+		if (bytes_read <= 0) {
 			return -1;
 		}
 		memset(block, -1, bsz);
@@ -2127,6 +2127,7 @@ RZ_API int rz_core_analysis_search_xrefs(RZ_NONNULL RzCore *core, ut64 from, ut6
 			at += ret;
 			continue;
 		}
+		size_t i = 0;
 		while (i < bytes_read && !rz_cons_is_breaked()) {
 			int count_before = count;
 			rz_analysis_op_init(&op);

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -1908,8 +1908,7 @@ RZ_API int rz_core_analysis_search(RzCore *core, ut64 from, ut64 to, ut64 ref, i
 
 static bool core_search_for_xrefs_in_boundaries(RzCore *core, ut64 from, ut64 to) {
 	if ((from == UT64_MAX && to == UT64_MAX) ||
-		(!from && !to) ||
-		(to - from > rz_io_size(core->io))) {
+		(!from && !to)) {
 		return false;
 	}
 	return rz_core_analysis_search_xrefs(core, from, to) > 0;
@@ -2114,7 +2113,10 @@ RZ_API int rz_core_analysis_search_xrefs(RZ_NONNULL RzCore *core, ut64 from, ut6
 		if (!rz_io_is_valid_offset(core->io, at, RZ_PERM_X)) {
 			break;
 		}
-		(void)rz_io_read_at_mapped(core->io, at, buf, bsz);
+		size_t bytes_read = rz_io_nread_at(core->io, at, buf, bsz);
+		if (!bytes_read) {
+			return -1;
+		}
 		memset(block, -1, bsz);
 		if (!memcmp(buf, block, bsz)) {
 			at += ret;
@@ -2125,13 +2127,13 @@ RZ_API int rz_core_analysis_search_xrefs(RZ_NONNULL RzCore *core, ut64 from, ut6
 			at += ret;
 			continue;
 		}
-		while (i < bsz && !rz_cons_is_breaked()) {
+		while (i < bytes_read && !rz_cons_is_breaked()) {
 			int count_before = count;
 			rz_analysis_op_init(&op);
-			ret = rz_analysis_op(core->analysis, &op, at + i, buf + i, bsz - i, RZ_ANALYSIS_OP_MASK_BASIC | RZ_ANALYSIS_OP_MASK_HINT);
+			ret = rz_analysis_op(core->analysis, &op, at + i, buf + i, bytes_read - i, RZ_ANALYSIS_OP_MASK_BASIC | RZ_ANALYSIS_OP_MASK_HINT);
 			ret = ret > 0 ? ret : 1;
 			i += ret;
-			if (ret <= 0 || i > bsz) {
+			if (ret <= 0 || i > bytes_read) {
 				break;
 			}
 			// find references
@@ -2216,7 +2218,7 @@ RZ_API int rz_core_analysis_search_xrefs(RZ_NONNULL RzCore *core, ut64 from, ut6
 			}
 			rz_analysis_op_fini(&op);
 		}
-		at += bsz;
+		at += bytes_read;
 		rz_analysis_op_fini(&op);
 	}
 	rz_cons_break_pop();

--- a/test/db/cmd/cmd_aar
+++ b/test/db/cmd/cmd_aar
@@ -1,0 +1,25 @@
+NAME=mdt analysis
+FILE=bins/mdt/bin-mdt/load-test.mdt
+CMDS=<<EOF
+oml~vmap
+aar
+echo "This xref lies within a vmap."
+axl~0xfe02c39c
+EOF
+EXPECT=<<EOF
+ 2 fd: 5 +0x00000000 0x89200000 - 0x89201c17 --- vmap.load-test.b01
+ 4 fd: 7 +0x00000000 0xfe000000 * 0xfe02ffff r-x vmap.load-test.b02
+ 5 fd: 8 +0x00001000 0x00550000 - 0x00553ebf r-x vmap.load-test.b03.LOAD0
+ 6 fd: 8 +0x00005000 0x00554000 - 0x0055b763 r-x vmap.load-test.b03.LOAD1
+ 8 fd: 8 +0x0000d000 0x0055c000 - 0x0055d0a7 r-- vmap.load-test.b03.LOAD2
+ 9 fd: 10 +0x00000000 0x000004f4 - 0x00000567 r-- vmap.load-test.b04.reloc-targets
+10 fd: 11 +0x00000388 0xc00c9388 - 0xc00c94e9 --- vmap.load-test.b04..strtab
+11 fd: 12 +0x00000034 0xc00c9034 - 0xc00c90bb r-x vmap.load-test.b04..text
+12 fd: 11 +0x0000022c 0xc00c922c - 0xc00c9387 --x vmap.load-test.b04..rela.text
+13 fd: 11 +0x000000bc 0xc00c90bc - 0xc00c922b --- vmap.load-test.b04..symtab
+14 fd: 11 +0x00000000 0xc00c9000 - 0xc00c9033 r-- vmap.load-test.b04.ehdr
+This xref lies within a vmap.
+                                       ? 0xfe02c39c ->      DATA -> 0xfe0266a4
+EOF
+RUN
+

--- a/test/db/cmd/cmd_coverage
+++ b/test/db/cmd/cmd_coverage
@@ -6,7 +6,7 @@ aai
 EOF
 EXPECT=<<EOF
 functions:   76
-xrefs:       179
+xrefs:       161
 calls:       130
 strings:     26
 symbols:     102


### PR DESCRIPTION


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [ ] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

That fixes a really annoying bug of `aar` ignoring any `vmap`. If `core_search_for_xrefs_in_boundaries()` gets an interval which lies within a `vmap`, `rz_io_size()` returns the size equivalent `mmap` (not `vmap`).
Which can be smaller and make the if case fail.

This seems to be a bug for all virtual files mapped in memory. If a virtual file of size `0x100` is mapped to a memory map of size `0x180`, it creates a `vmap` of `0x100` for the file content and a `0x80 mmap` for the empty bytes.
These maps are names `vmap.filename`, `mmap.filename`.

`rz_io_size()` now seems to only ever return the size of the `mmap`. I don't know why it does that.
And because it is one of the stone age functions I am not going down there to look.

This bug breaks `aar` for Qualcomm split firmware images (`.mdt`). Removing this check should not have an impact, because I added a check for the memory read.

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Added

I checked the failing test in `db/cmd/cmd_coverage`. The "missing xrefs" were false positives.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
