### PR TITLE
Add generic URI key=value parameter parser

### DIFF
--- a/librz/include/rz_util.h
+++ b/librz/include/rz_util.h
@@ -67,6 +67,7 @@
 #include <rz_util/rz_stack.h>
 #include <rz_util/rz_str.h>
 #include <rz_util/rz_str_constpool.h>
+#include <rz_util/rz_str_uri.h>
 #include <rz_util/rz_str_search.h>
 #include <rz_util/rz_strbuf.h>
 #include <rz_util/rz_strpool.h>

--- a/librz/include/rz_util/rz_str_uri.h
+++ b/librz/include/rz_util/rz_str_uri.h
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 kx7m2qd <kx7m2qd@users.noreply.github.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef RZ_STR_URI_H
+#define RZ_STR_URI_H
+
+#include <rz_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief Type of a single URI parameter value, as declared in its grammar entry.
+ */
+typedef enum {
+	RZ_STR_URI_PARAM_TYPE_STRING = 0, ///< Value is kept as-is (a copied string).
+	RZ_STR_URI_PARAM_TYPE_INT, ///< Value is parsed as a signed 64-bit integer.
+	RZ_STR_URI_PARAM_TYPE_BOOL, ///< Value is parsed with \p rz_str_is_true / \p rz_str_is_false rules.
+} RzStrUriParamType;
+
+/**
+ * \brief Describes a single parameter accepted by a plugin's URI, used to validate
+ * and type-check a parameter string before it is handed to the plugin.
+ */
+typedef struct rz_str_uri_param_spec_t {
+	RZ_NONNULL const char *name; ///< Parameter key, as it appears before '=' in the param string.
+	RzStrUriParamType type; ///< Expected type of the value.
+	bool required; ///< If true, parsing fails when this key is not present in the input.
+} RzStrUriParamSpec;
+
+/**
+ * \brief Opaque handle to a parsed, type-checked set of URI parameters.
+ *
+ * \note The \p grammar array passed to \p rz_str_uri_params_parse is borrowed, not
+ * copied: it must stay valid for the lifetime of the returned RzStrUriParams. In
+ * practice this means grammar tables should be declared `static const`.
+ */
+typedef struct rz_str_uri_params_t RzStrUriParams;
+
+RZ_API RZ_OWN RzStrUriParams *rz_str_uri_params_parse(
+	RZ_NONNULL const char *param_str,
+	RZ_NONNULL const RzStrUriParamSpec *grammar,
+	size_t grammar_count,
+	RZ_NULLABLE RZ_OUT char **error);
+RZ_API void rz_str_uri_params_free(RZ_NULLABLE RzStrUriParams *params);
+
+RZ_API bool rz_str_uri_params_has(RZ_NONNULL const RzStrUriParams *params, RZ_NONNULL const char *name);
+RZ_API bool rz_str_uri_params_get_string(RZ_NONNULL const RzStrUriParams *params, RZ_NONNULL const char *name, RZ_NONNULL RZ_OUT const char **value);
+RZ_API bool rz_str_uri_params_get_int(RZ_NONNULL const RzStrUriParams *params, RZ_NONNULL const char *name, RZ_NONNULL RZ_OUT st64 *value);
+RZ_API bool rz_str_uri_params_get_bool(RZ_NONNULL const RzStrUriParams *params, RZ_NONNULL const char *name, RZ_NONNULL RZ_OUT bool *value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RZ_STR_URI_H

--- a/librz/include/rz_util/rz_str_uri.h
+++ b/librz/include/rz_util/rz_str_uri.h
@@ -42,7 +42,7 @@ RZ_API RZ_OWN RzStrUriParams *rz_str_uri_params_parse(
 	RZ_NONNULL const char *param_str,
 	RZ_NONNULL const RzStrUriParamSpec *grammar,
 	size_t grammar_count,
-	RZ_NULLABLE RZ_OUT char **error);
+	RZ_NULLABLE RZ_OUT RZ_OWN char **error);
 RZ_API void rz_str_uri_params_free(RZ_NULLABLE RzStrUriParams *params);
 
 RZ_API bool rz_str_uri_params_has(RZ_NONNULL const RzStrUriParams *params, RZ_NONNULL const char *name);

--- a/librz/util/meson.build
+++ b/librz/util/meson.build
@@ -57,6 +57,7 @@ rz_util_common_sources = [
   'str_constpool.c',
   'str_search.c',
   'str_trim.c',
+  'str_uri.c',
   'strbuf.c',
   'strpool.c',
   'structured_data.c',

--- a/librz/util/str_uri.c
+++ b/librz/util/str_uri.c
@@ -49,7 +49,7 @@ RZ_API RZ_OWN RzStrUriParams *rz_str_uri_params_parse(
 	RZ_NONNULL const char *param_str,
 	RZ_NONNULL const RzStrUriParamSpec *grammar,
 	size_t grammar_count,
-	RZ_NULLABLE RZ_OUT char **error) {
+	RZ_NULLABLE RZ_OUT RZ_OWN char **error) {
 	rz_return_val_if_fail(param_str && grammar, NULL);
 
 	RzStrUriParams *params = RZ_NEW0(RzStrUriParams);

--- a/librz/util/str_uri.c
+++ b/librz/util/str_uri.c
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: 2026 kx7m2qd <kx7m2qd@users.noreply.github.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_util/rz_str_uri.h>
+#include <rz_util/rz_str.h>
+#include <rz_util/rz_assert.h>
+
+typedef struct {
+	bool is_set;
+	char *s;
+	st64 i;
+	bool b;
+} UriParamValue;
+
+struct rz_str_uri_params_t {
+	const RzStrUriParamSpec *grammar;
+	size_t grammar_count;
+	UriParamValue *values;
+};
+
+static const RzStrUriParamSpec *find_spec(const RzStrUriParamSpec *grammar, size_t grammar_count, const char *name) {
+	for (size_t i = 0; i < grammar_count; i++) {
+		if (!strcmp(grammar[i].name, name)) {
+			return &grammar[i];
+		}
+	}
+	return NULL;
+}
+
+static size_t spec_index(const RzStrUriParamSpec *grammar, size_t grammar_count, const RzStrUriParamSpec *spec) {
+	return (size_t)(spec - grammar);
+}
+
+static bool parse_int(const char *value, st64 *out) {
+	if (RZ_STR_ISEMPTY(value)) {
+		return false;
+	}
+	char *end = NULL;
+	errno = 0;
+	long long v = strtoll(value, &end, 0);
+	if (errno || !end || *end) {
+		return false;
+	}
+	*out = (st64)v;
+	return true;
+}
+
+RZ_API RZ_OWN RzStrUriParams *rz_str_uri_params_parse(
+	RZ_NONNULL const char *param_str,
+	RZ_NONNULL const RzStrUriParamSpec *grammar,
+	size_t grammar_count,
+	RZ_NULLABLE RZ_OUT char **error) {
+	rz_return_val_if_fail(param_str && grammar, NULL);
+
+	RzStrUriParams *params = RZ_NEW0(RzStrUriParams);
+	if (!params) {
+		return NULL;
+	}
+	params->grammar = grammar;
+	params->grammar_count = grammar_count;
+	params->values = RZ_NEWS0(UriParamValue, grammar_count ? grammar_count : 1);
+	if (!params->values) {
+		free(params);
+		return NULL;
+	}
+
+	char *dup = strdup(param_str);
+	if (!dup) {
+		rz_str_uri_params_free(params);
+		return NULL;
+	}
+
+	char *saveptr = NULL;
+	char *tok = strtok_r(dup, ",", &saveptr);
+	while (tok) {
+		rz_str_trim(tok);
+		if (RZ_STR_ISEMPTY(tok)) {
+			tok = strtok_r(NULL, ",", &saveptr);
+			continue;
+		}
+		char *eq = strchr(tok, '=');
+		if (!eq) {
+			if (error) {
+				*error = rz_str_newf("invalid parameter '%s': expected 'key=value'", tok);
+			}
+			free(dup);
+			rz_str_uri_params_free(params);
+			return NULL;
+		}
+		*eq = 0;
+		char *key = tok;
+		char *value = eq + 1;
+		rz_str_trim(key);
+		rz_str_trim(value);
+
+		const RzStrUriParamSpec *spec = find_spec(grammar, grammar_count, key);
+		if (!spec) {
+			if (error) {
+				*error = rz_str_newf("unknown parameter '%s'", key);
+			}
+			free(dup);
+			rz_str_uri_params_free(params);
+			return NULL;
+		}
+
+		size_t idx = spec_index(grammar, grammar_count, spec);
+		UriParamValue *slot = &params->values[idx];
+		switch (spec->type) {
+		case RZ_STR_URI_PARAM_TYPE_STRING:
+			free(slot->s);
+			slot->s = strdup(value);
+			break;
+		case RZ_STR_URI_PARAM_TYPE_INT:
+			if (!parse_int(value, &slot->i)) {
+				if (error) {
+					*error = rz_str_newf("parameter '%s' expects an integer, got '%s'", key, value);
+				}
+				free(dup);
+				rz_str_uri_params_free(params);
+				return NULL;
+			}
+			break;
+		case RZ_STR_URI_PARAM_TYPE_BOOL:
+			if (!rz_str_is_bool(value)) {
+				if (error) {
+					*error = rz_str_newf("parameter '%s' expects a boolean, got '%s'", key, value);
+				}
+				free(dup);
+				rz_str_uri_params_free(params);
+				return NULL;
+			}
+			slot->b = rz_str_is_true(value);
+			break;
+		}
+		slot->is_set = true;
+		tok = strtok_r(NULL, ",", &saveptr);
+	}
+	free(dup);
+
+	for (size_t i = 0; i < grammar_count; i++) {
+		if (grammar[i].required && !params->values[i].is_set) {
+			if (error) {
+				*error = rz_str_newf("missing required parameter '%s'", grammar[i].name);
+			}
+			rz_str_uri_params_free(params);
+			return NULL;
+		}
+	}
+
+	return params;
+}
+
+RZ_API void rz_str_uri_params_free(RZ_NULLABLE RzStrUriParams *params) {
+	if (!params) {
+		return;
+	}
+	if (params->values) {
+		for (size_t i = 0; i < params->grammar_count; i++) {
+			if (params->grammar[i].type == RZ_STR_URI_PARAM_TYPE_STRING) {
+				free(params->values[i].s);
+			}
+		}
+		free(params->values);
+	}
+	free(params);
+}
+
+RZ_API bool rz_str_uri_params_has(RZ_NONNULL const RzStrUriParams *params, RZ_NONNULL const char *name) {
+	rz_return_val_if_fail(params && name, false);
+	const RzStrUriParamSpec *spec = find_spec(params->grammar, params->grammar_count, name);
+	if (!spec) {
+		return false;
+	}
+	size_t idx = spec_index(params->grammar, params->grammar_count, spec);
+	return params->values[idx].is_set;
+}
+
+RZ_API bool rz_str_uri_params_get_string(RZ_NONNULL const RzStrUriParams *params, RZ_NONNULL const char *name, RZ_NONNULL RZ_OUT const char **value) {
+	rz_return_val_if_fail(params && name && value, false);
+	const RzStrUriParamSpec *spec = find_spec(params->grammar, params->grammar_count, name);
+	if (!spec || spec->type != RZ_STR_URI_PARAM_TYPE_STRING) {
+		return false;
+	}
+	size_t idx = spec_index(params->grammar, params->grammar_count, spec);
+	if (!params->values[idx].is_set) {
+		return false;
+	}
+	*value = params->values[idx].s;
+	return true;
+}
+
+RZ_API bool rz_str_uri_params_get_int(RZ_NONNULL const RzStrUriParams *params, RZ_NONNULL const char *name, RZ_NONNULL RZ_OUT st64 *value) {
+	rz_return_val_if_fail(params && name && value, false);
+	const RzStrUriParamSpec *spec = find_spec(params->grammar, params->grammar_count, name);
+	if (!spec || spec->type != RZ_STR_URI_PARAM_TYPE_INT) {
+		return false;
+	}
+	size_t idx = spec_index(params->grammar, params->grammar_count, spec);
+	if (!params->values[idx].is_set) {
+		return false;
+	}
+	*value = params->values[idx].i;
+	return true;
+}
+
+RZ_API bool rz_str_uri_params_get_bool(RZ_NONNULL const RzStrUriParams *params, RZ_NONNULL const char *name, RZ_NONNULL RZ_OUT bool *value) {
+	rz_return_val_if_fail(params && name && value, false);
+	const RzStrUriParamSpec *spec = find_spec(params->grammar, params->grammar_count, name);
+	if (!spec || spec->type != RZ_STR_URI_PARAM_TYPE_BOOL) {
+		return false;
+	}
+	size_t idx = spec_index(params->grammar, params->grammar_count, spec);
+	if (!params->values[idx].is_set) {
+		return false;
+	}
+	*value = params->values[idx].b;
+	return true;
+}

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -129,6 +129,7 @@ if get_option('enable_tests')
     'str',
     'strbuf',
     'str_search',
+    'str_uri',
     'subprocess',
     'syscall',
     'table',

--- a/test/unit/test_str_uri.c
+++ b/test/unit/test_str_uri.c
@@ -5,99 +5,99 @@
 #include "minunit.h"
 
 static const RzStrUriParamSpec test_grammar[] = {
-{ "d", RZ_STR_URI_PARAM_TYPE_INT, false },
-{ "verbose", RZ_STR_URI_PARAM_TYPE_BOOL, false },
-{ "name", RZ_STR_URI_PARAM_TYPE_STRING, true },
+	{ "d", RZ_STR_URI_PARAM_TYPE_INT, false },
+	{ "verbose", RZ_STR_URI_PARAM_TYPE_BOOL, false },
+	{ "name", RZ_STR_URI_PARAM_TYPE_STRING, true },
 };
 static const size_t test_grammar_count = sizeof(test_grammar) / sizeof(test_grammar[0]);
 
 bool test_rz_str_uri_params_happy_path(void) {
-char *error = NULL;
-RzStrUriParams *p = rz_str_uri_params_parse("d=32,verbose=true,name=shake", test_grammar, test_grammar_count, &error);
-mu_assert_notnull(p, "parse should succeed");
-mu_assert_null(error, "no error expected");
+	char *error = NULL;
+	RzStrUriParams *p = rz_str_uri_params_parse("d=32,verbose=true,name=shake", test_grammar, test_grammar_count, &error);
+	mu_assert_notnull(p, "parse should succeed");
+	mu_assert_null(error, "no error expected");
 
-st64 d = 0;
-bool verbose = false;
-const char *name = NULL;
-mu_assert_true(rz_str_uri_params_get_int(p, "d", &d), "get_int d should succeed");
-mu_assert_eq(d, 32, "d value");
-mu_assert_true(rz_str_uri_params_get_bool(p, "verbose", &verbose), "get_bool verbose should succeed");
-mu_assert_true(verbose, "verbose value");
-mu_assert_true(rz_str_uri_params_get_string(p, "name", &name), "get_string name should succeed");
-mu_assert_streq(name, "shake", "name value");
+	st64 d = 0;
+	bool verbose = false;
+	const char *name = NULL;
+	mu_assert_true(rz_str_uri_params_get_int(p, "d", &d), "get_int d should succeed");
+	mu_assert_eq(d, 32, "d value");
+	mu_assert_true(rz_str_uri_params_get_bool(p, "verbose", &verbose), "get_bool verbose should succeed");
+	mu_assert_true(verbose, "verbose value");
+	mu_assert_true(rz_str_uri_params_get_string(p, "name", &name), "get_string name should succeed");
+	mu_assert_streq(name, "shake", "name value");
 
-rz_str_uri_params_free(p);
-mu_end;
+	rz_str_uri_params_free(p);
+	mu_end;
 }
 
 bool test_rz_str_uri_params_missing_required(void) {
-char *error = NULL;
-RzStrUriParams *p = rz_str_uri_params_parse("d=32", test_grammar, test_grammar_count, &error);
-mu_assert_null(p, "parse should fail when required param is missing");
-mu_assert_notnull(error, "error should be set");
-free(error);
-mu_end;
+	char *error = NULL;
+	RzStrUriParams *p = rz_str_uri_params_parse("d=32", test_grammar, test_grammar_count, &error);
+	mu_assert_null(p, "parse should fail when required param is missing");
+	mu_assert_notnull(error, "error should be set");
+	free(error);
+	mu_end;
 }
 
 bool test_rz_str_uri_params_unknown_key(void) {
-char *error = NULL;
-RzStrUriParams *p = rz_str_uri_params_parse("name=x,bogus=1", test_grammar, test_grammar_count, &error);
-mu_assert_null(p, "parse should fail on unknown key");
-mu_assert_notnull(error, "error should be set");
-free(error);
-mu_end;
+	char *error = NULL;
+	RzStrUriParams *p = rz_str_uri_params_parse("name=x,bogus=1", test_grammar, test_grammar_count, &error);
+	mu_assert_null(p, "parse should fail on unknown key");
+	mu_assert_notnull(error, "error should be set");
+	free(error);
+	mu_end;
 }
 
 bool test_rz_str_uri_params_bad_int(void) {
-char *error = NULL;
-RzStrUriParams *p = rz_str_uri_params_parse("name=x,d=notanumber", test_grammar, test_grammar_count, &error);
-mu_assert_null(p, "parse should fail on non-numeric int value");
-mu_assert_notnull(error, "error should be set");
-free(error);
-mu_end;
+	char *error = NULL;
+	RzStrUriParams *p = rz_str_uri_params_parse("name=x,d=notanumber", test_grammar, test_grammar_count, &error);
+	mu_assert_null(p, "parse should fail on non-numeric int value");
+	mu_assert_notnull(error, "error should be set");
+	free(error);
+	mu_end;
 }
 
 bool test_rz_str_uri_params_optional_absent(void) {
-char *error = NULL;
-RzStrUriParams *p = rz_str_uri_params_parse("name=onlyname", test_grammar, test_grammar_count, &error);
-mu_assert_notnull(p, "parse should succeed with only required param given");
-mu_assert_null(error, "no error expected");
+	char *error = NULL;
+	RzStrUriParams *p = rz_str_uri_params_parse("name=onlyname", test_grammar, test_grammar_count, &error);
+	mu_assert_notnull(p, "parse should succeed with only required param given");
+	mu_assert_null(error, "no error expected");
 
-mu_assert_false(rz_str_uri_params_has(p, "d"), "d should not be set");
-st64 d = 0;
-mu_assert_false(rz_str_uri_params_get_int(p, "d", &d), "get_int should fail for unset param");
+	mu_assert_false(rz_str_uri_params_has(p, "d"), "d should not be set");
+	st64 d = 0;
+	mu_assert_false(rz_str_uri_params_get_int(p, "d", &d), "get_int should fail for unset param");
 
-rz_str_uri_params_free(p);
-mu_end;
+	rz_str_uri_params_free(p);
+	mu_end;
 }
 
 bool test_rz_str_uri_params_whitespace_tolerant(void) {
-char *error = NULL;
-RzStrUriParams *p = rz_str_uri_params_parse(" name = spaced , d = 7 ", test_grammar, test_grammar_count, &error);
-mu_assert_notnull(p, "parse should tolerate surrounding whitespace");
-mu_assert_null(error, "no error expected");
+	char *error = NULL;
+	RzStrUriParams *p = rz_str_uri_params_parse(" name = spaced , d = 7 ", test_grammar, test_grammar_count, &error);
+	mu_assert_notnull(p, "parse should tolerate surrounding whitespace");
+	mu_assert_null(error, "no error expected");
 
-st64 d = 0;
-const char *name = NULL;
-mu_assert_true(rz_str_uri_params_get_int(p, "d", &d), "get_int d should succeed");
-mu_assert_eq(d, 7, "d value");
-mu_assert_true(rz_str_uri_params_get_string(p, "name", &name), "get_string name should succeed");
-mu_assert_streq(name, "spaced", "name value trimmed");
+	st64 d = 0;
+	const char *name = NULL;
+	mu_assert_true(rz_str_uri_params_get_int(p, "d", &d), "get_int d should succeed");
+	mu_assert_eq(d, 7, "d value");
+	mu_assert_true(rz_str_uri_params_get_string(p, "name", &name), "get_string name should succeed");
+	mu_assert_streq(name, "spaced", "name value trimmed");
 
-rz_str_uri_params_free(p);
-mu_end;
+	rz_str_uri_params_free(p);
+	mu_end;
 }
 
 bool all_tests() {
-mu_run_test(test_rz_str_uri_params_happy_path);
-mu_run_test(test_rz_str_uri_params_missing_required);
-mu_run_test(test_rz_str_uri_params_unknown_key);
-mu_run_test(test_rz_str_uri_params_bad_int);
-mu_run_test(test_rz_str_uri_params_optional_absent);
-mu_run_test(test_rz_str_uri_params_whitespace_tolerant);
+	mu_run_test(test_rz_str_uri_params_happy_path);
+	mu_run_test(test_rz_str_uri_params_missing_required);
+	mu_run_test(test_rz_str_uri_params_unknown_key);
+	mu_run_test(test_rz_str_uri_params_bad_int);
+	mu_run_test(test_rz_str_uri_params_optional_absent);
+	mu_run_test(test_rz_str_uri_params_whitespace_tolerant);
 
-return tests_passed != tests_run;
+	return tests_passed != tests_run;
 }
 
 mu_main(all_tests)

--- a/test/unit/test_str_uri.c
+++ b/test/unit/test_str_uri.c
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 kx7m2qd <kx7m2qd@users.noreply.github.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_util.h>
+#include "minunit.h"
+
+static const RzStrUriParamSpec test_grammar[] = {
+{ "d", RZ_STR_URI_PARAM_TYPE_INT, false },
+{ "verbose", RZ_STR_URI_PARAM_TYPE_BOOL, false },
+{ "name", RZ_STR_URI_PARAM_TYPE_STRING, true },
+};
+static const size_t test_grammar_count = sizeof(test_grammar) / sizeof(test_grammar[0]);
+
+bool test_rz_str_uri_params_happy_path(void) {
+char *error = NULL;
+RzStrUriParams *p = rz_str_uri_params_parse("d=32,verbose=true,name=shake", test_grammar, test_grammar_count, &error);
+mu_assert_notnull(p, "parse should succeed");
+mu_assert_null(error, "no error expected");
+
+st64 d = 0;
+bool verbose = false;
+const char *name = NULL;
+mu_assert_true(rz_str_uri_params_get_int(p, "d", &d), "get_int d should succeed");
+mu_assert_eq(d, 32, "d value");
+mu_assert_true(rz_str_uri_params_get_bool(p, "verbose", &verbose), "get_bool verbose should succeed");
+mu_assert_true(verbose, "verbose value");
+mu_assert_true(rz_str_uri_params_get_string(p, "name", &name), "get_string name should succeed");
+mu_assert_streq(name, "shake", "name value");
+
+rz_str_uri_params_free(p);
+mu_end;
+}
+
+bool test_rz_str_uri_params_missing_required(void) {
+char *error = NULL;
+RzStrUriParams *p = rz_str_uri_params_parse("d=32", test_grammar, test_grammar_count, &error);
+mu_assert_null(p, "parse should fail when required param is missing");
+mu_assert_notnull(error, "error should be set");
+free(error);
+mu_end;
+}
+
+bool test_rz_str_uri_params_unknown_key(void) {
+char *error = NULL;
+RzStrUriParams *p = rz_str_uri_params_parse("name=x,bogus=1", test_grammar, test_grammar_count, &error);
+mu_assert_null(p, "parse should fail on unknown key");
+mu_assert_notnull(error, "error should be set");
+free(error);
+mu_end;
+}
+
+bool test_rz_str_uri_params_bad_int(void) {
+char *error = NULL;
+RzStrUriParams *p = rz_str_uri_params_parse("name=x,d=notanumber", test_grammar, test_grammar_count, &error);
+mu_assert_null(p, "parse should fail on non-numeric int value");
+mu_assert_notnull(error, "error should be set");
+free(error);
+mu_end;
+}
+
+bool test_rz_str_uri_params_optional_absent(void) {
+char *error = NULL;
+RzStrUriParams *p = rz_str_uri_params_parse("name=onlyname", test_grammar, test_grammar_count, &error);
+mu_assert_notnull(p, "parse should succeed with only required param given");
+mu_assert_null(error, "no error expected");
+
+mu_assert_false(rz_str_uri_params_has(p, "d"), "d should not be set");
+st64 d = 0;
+mu_assert_false(rz_str_uri_params_get_int(p, "d", &d), "get_int should fail for unset param");
+
+rz_str_uri_params_free(p);
+mu_end;
+}
+
+bool test_rz_str_uri_params_whitespace_tolerant(void) {
+char *error = NULL;
+RzStrUriParams *p = rz_str_uri_params_parse(" name = spaced , d = 7 ", test_grammar, test_grammar_count, &error);
+mu_assert_notnull(p, "parse should tolerate surrounding whitespace");
+mu_assert_null(error, "no error expected");
+
+st64 d = 0;
+const char *name = NULL;
+mu_assert_true(rz_str_uri_params_get_int(p, "d", &d), "get_int d should succeed");
+mu_assert_eq(d, 7, "d value");
+mu_assert_true(rz_str_uri_params_get_string(p, "name", &name), "get_string name should succeed");
+mu_assert_streq(name, "spaced", "name value trimmed");
+
+rz_str_uri_params_free(p);
+mu_end;
+}
+
+bool all_tests() {
+mu_run_test(test_rz_str_uri_params_happy_path);
+mu_run_test(test_rz_str_uri_params_missing_required);
+mu_run_test(test_rz_str_uri_params_unknown_key);
+mu_run_test(test_rz_str_uri_params_bad_int);
+mu_run_test(test_rz_str_uri_params_optional_absent);
+mu_run_test(test_rz_str_uri_params_whitespace_tolerant);
+
+return tests_passed != tests_run;
+}
+
+mu_main(all_tests)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Adds a generic, reusable parser for `key=value,key=value`-style URI parameters, discussed in #6317. wargio suggested this as the right fix for the duplicated ad-hoc option-parsing currently scattered across hash/sym/io plugins (e.g. SHAKE's `d` output-length parameter has no clean way to be passed in).

- New API in `rz_util`: `rz_str_uri_params_parse()` takes a caller-defined grammar (array of `{name, type, required}` specs) and a raw parameter string, and returns a type-checked `RzStrUriParams` handle.
- Supports `string`, `int`, and `bool` value types via `rz_str_uri_params_get_string/get_int/get_bool`.
- Rejects unknown keys, type mismatches, and missing required parameters with clear, specific error messages.
- Tolerates surrounding whitespace around keys/values/separators.

This is groundwork only — migrating individual plugins (SHAKE's `d` param, IO plugins' ad-hoc parsing) onto this is planned as separate follow-up PRs, to keep this PR reviewable and scoped to the core utility.

**AI tools disclosure:** Used Claude (Anthropic) to help design and implement this parser and its tests. All code was reviewed, compiled, and tested locally before submission.

**Test plan**

Unit tests added in `test/unit/test_str_uri.c`, covering:
- Happy path: multiple params of all three types parsed correctly
- Missing required parameter is rejected with an error
- Unknown parameter key is rejected with an error
- Non-numeric value for an int-typed parameter is rejected
- Optional parameter correctly reported as absent when omitted
- Surrounding whitespace around keys/values/commas is tolerated

Commands run locally:
\`\`\`
ninja -C build test/unit/test_str_uri
./build/test/unit/test_str_uri
\`\`\`
Output:
\`\`\`
test_rz_str_uri_params_happy_path OK
test_rz_str_uri_params_missing_required OK
test_rz_str_uri_params_unknown_key OK
test_rz_str_uri_params_bad_int OK
test_rz_str_uri_params_optional_absent OK
test_rz_str_uri_params_whitespace_tolerant OK
\`\`\`
Also verified:
\`\`\`
clang-format --dry-run -Werror librz/util/str_uri.c librz/include/rz_util/rz_str_uri.h
\`\`\`
(no output — clean)

**Closing issues**

Relates to #6317 (parser groundwork discussed with @wargio and @Rot127; plugin migration to follow in separate PRs).