### PR TITLE
Add bounded retries for command tests

### DIFF
--- a/binrz/rz-test/run.c
+++ b/binrz/rz-test/run.c
@@ -327,6 +327,19 @@ RZ_API RzSubprocessOutput *rz_test_run_cmd_test(RzTestRunConfig *config, RzCmdTe
 	return out;
 }
 
+static RzSubprocessOutput *run_cmd_test_with_retries(RzTestRunConfig *config, RzCmdTest *test, RzTestCmdRunner runner, void *user) {
+	RzSubprocessOutput *out = NULL;
+	ut64 retries = test->retries.value;
+	do {
+		out = rz_test_run_cmd_test(config, test, runner, user);
+		if (rz_test_check_cmd_test(out, test) || !retries) {
+			return out;
+		}
+		rz_subprocess_output_free(out);
+		retries--;
+	} while (true);
+}
+
 RZ_API RZ_OWN RzStrBuf *rz_test_regex_full_match_str(RZ_NONNULL const char *pattern, RZ_NONNULL const char *text) {
 	return rz_regex_full_match_str(pattern, text, RZ_REGEX_ZERO_TERMINATED, RZ_REGEX_EXTENDED, RZ_REGEX_DEFAULT,
 		"\n");
@@ -716,7 +729,7 @@ RZ_API RzTestResultInfo *rz_test_run_test(RzTestRunConfig *config, RzTest *test)
 	switch (test->type) {
 	case RZ_TEST_TYPE_CMD: {
 		RzCmdTest *cmd_test = test->cmd_test;
-		RzSubprocessOutput *out = rz_test_run_cmd_test(config, cmd_test, subprocess_runner, NULL);
+		RzSubprocessOutput *out = run_cmd_test_with_retries(config, cmd_test, subprocess_runner, NULL);
 		success = rz_test_check_cmd_test(out, cmd_test);
 		ret->proc_out = out;
 		ret->timeout = out && out->timeout;

--- a/binrz/rz-test/rz_test.h
+++ b/binrz/rz-test/rz_test.h
@@ -73,6 +73,7 @@ typedef struct rz_test_cmd_test_t {
 	RzCmdTestBoolRecord broken;
 	RzCmdTestBoolRecord color;
 	RzCmdTestBoolRecord utf8;
+	RzCmdTestNumRecord retries;
 	RzCmdTestNumRecord timeout;
 	RzCmdTestNumRecord exit_status;
 	ut64 run_line;
@@ -90,6 +91,7 @@ typedef struct rz_test_cmd_test_t {
 	macro_str ("ARGS", args) \
 	macro_str ("TOOL", tool) \
 	macro_str ("ENVS", envs) \
+	macro_int ("RETRIES", retries) \
 	macro_int ("TIMEOUT", timeout) \
 	macro_int ("EXIT_STATUS", exit_status) \
 	macro_str ("SOURCE", source) \

--- a/test/README.md
+++ b/test/README.md
@@ -220,6 +220,7 @@ Without the regex that filtered out the non-deterministic file path and addresse
 * **EXPECT** is the expected output of the test from stdout. If `REGEXP_FILTER_OUT` is used, `EXPECT` matches only the filtered output.
 * **EXPECT_ERR** (optional) is the expected output of the test from stderr. Can be specified in addition or instead of `EXPECT`
 * **BROKEN** (optional) is 1 if the tests is expected to be fail, 0 or unspecified otherwise
+* **RETRIES** (optional) is the number of additional attempts after a failed command test; total attempts are `RETRIES + 1`; stop after the first success.
 * **TIMEOUT** (optional) is the number of seconds to wait before considering the test timeout
 * **REGEXP_FILTER_OUT** (optional) apply given regex on stdout before comparing the output to `EXPECT` (e.g. `REGEXP_FILTER_OUT=([a-zA-Z]+)`). This is similar to piping stdout to `grep -E "<regex>"` and then comparing the matched text with `EXPECT`.
 * **REGEXP_FILTER_ERR** (optional) apply given regex on stderr before comparing the ouput to `EXPECT_ERR`

--- a/test/db/archos/not-windows-any/http
+++ b/test/db/archos/not-windows-any/http
@@ -1,5 +1,6 @@
 NAME=read from http
 FILE=--
+RETRIES=3
 CMDS=<<EOF
 !python3 scripts/http_server.py
 o http://127.0.0.1:9000/simple.html

--- a/test/unit/rz_test_cmd_test
+++ b/test/unit/rz_test_cmd_test
@@ -1,5 +1,6 @@
 NAME=multiline0
 FILE==
+RETRIES=3
 CMDS=<<EOF
 rm -rf /
 EOF

--- a/test/unit/test_rz_test.c
+++ b/test/unit/test_rz_test.c
@@ -11,6 +11,59 @@
 
 #define FILENAME "unit/rz_test_cmd_test"
 
+typedef struct retry_runner_context_t {
+	ut64 calls;
+	ut64 succeed_on;
+	const char *success_out;
+} RetryRunnerContext;
+
+static RzSubprocessOutput *retry_runner(RZ_UNUSED const char *file, RZ_UNUSED const char *args[], RZ_UNUSED size_t args_size,
+	RZ_UNUSED const char *envvars[], RZ_UNUSED const char *envvals[], RZ_UNUSED size_t env_size, RZ_UNUSED ut64 timeout_ms, void *user) {
+	RetryRunnerContext *ctx = user;
+	RzSubprocessOutput *out = RZ_NEW0(RzSubprocessOutput);
+	if (!out) {
+		return NULL;
+	}
+	ctx->calls++;
+	const char *output = ctx->calls >= ctx->succeed_on ? ctx->success_out : "unexpected\n";
+	out->out = (ut8 *)strdup(output);
+	out->out_len = strlen(output);
+	out->err = (ut8 *)strdup("");
+	out->err_len = 0;
+	out->ret = 0;
+	out->timeout = false;
+	return out;
+}
+
+bool test_rz_test_cmd_retries(void) {
+	RzTestDatabase *db = rz_test_test_database_new();
+	database_load(db, FILENAME, 1);
+	RzTestRunConfig config = { .timeout_ms = 1000 };
+	RzCmdTest *retry_test = ((RzTest *)rz_pvector_at(&db->tests, 0))->cmd_test;
+	RzCmdTest *single_shot_test = ((RzTest *)rz_pvector_at(&db->tests, 2))->cmd_test;
+
+	RetryRunnerContext ctx = { .succeed_on = 2, .success_out = retry_test->expect.value };
+	RzSubprocessOutput *out = run_cmd_test_with_retries(&config, retry_test, retry_runner, &ctx);
+	mu_assert_true(rz_test_check_cmd_test(out, retry_test), "retry succeeds");
+	mu_assert_eq(ctx.calls, 2, "retry stops after success");
+	rz_subprocess_output_free(out);
+
+	ctx = (RetryRunnerContext){ .succeed_on = 5, .success_out = retry_test->expect.value };
+	out = run_cmd_test_with_retries(&config, retry_test, retry_runner, &ctx);
+	mu_assert_false(rz_test_check_cmd_test(out, retry_test), "retry remains failed");
+	mu_assert_eq(ctx.calls, 4, "retry budget is bounded");
+	rz_subprocess_output_free(out);
+
+	ctx = (RetryRunnerContext){ .succeed_on = 2, .success_out = single_shot_test->expect.value };
+	out = run_cmd_test_with_retries(&config, single_shot_test, retry_runner, &ctx);
+	mu_assert_false(rz_test_check_cmd_test(out, single_shot_test), "default remains failed");
+	mu_assert_eq(ctx.calls, 1, "default is single shot");
+	rz_subprocess_output_free(out);
+
+	rz_test_test_database_free(db);
+	mu_end;
+}
+
 bool test_rz_test_database_load_cmd(void) {
 	RzTestDatabase *db = rz_test_test_database_new();
 	database_load(db, FILENAME, 1);
@@ -24,32 +77,36 @@ bool test_rz_test_database_load_cmd(void) {
 	mu_assert_streq(cmd_test->file.value, "=", "file");
 	mu_assert_streq(cmd_test->cmds.value, "rm -rf /\n", "cmds");
 	mu_assert_streq(cmd_test->expect.value, "expected\noutput\n", "expect");
-	mu_assert_eq(cmd_test->expect.line_begin, 6, "line begin");
-	mu_assert_eq(cmd_test->expect.line_end, 10, "line begin");
+	mu_assert_eq(cmd_test->retries.set, true, "retries set");
+	mu_assert_eq(cmd_test->retries.value, 3, "retries value");
+	mu_assert_eq(cmd_test->expect.line_begin, 7, "line begin");
+	mu_assert_eq(cmd_test->expect.line_end, 11, "line begin");
 
 	test = rz_pvector_at(&db->tests, 1);
 	mu_assert_eq(test->type, RZ_TEST_TYPE_CMD, "test type");
 	cmd_test = test->cmd_test;
 	mu_assert_streq(cmd_test->name.value, "singleline0", "name");
 	mu_assert_streq(cmd_test->expect.value, "", "expect");
-	mu_assert_eq(cmd_test->expect.line_begin, 17, "line begin");
-	mu_assert_eq(cmd_test->expect.line_end, 18, "line begin");
+	mu_assert_eq(cmd_test->expect.line_begin, 18, "line begin");
+	mu_assert_eq(cmd_test->expect.line_end, 19, "line begin");
 
 	test = rz_pvector_at(&db->tests, 2);
 	mu_assert_eq(test->type, RZ_TEST_TYPE_CMD, "test type");
 	cmd_test = test->cmd_test;
 	mu_assert_streq(cmd_test->name.value, "multiline1", "name");
 	mu_assert_streq(cmd_test->expect.value, "more\nexpected\noutput\n", "expect");
-	mu_assert_eq(cmd_test->expect.line_begin, 25, "line begin");
-	mu_assert_eq(cmd_test->expect.line_end, 30, "line begin");
+	mu_assert_eq(cmd_test->expect.line_begin, 26, "line begin");
+	mu_assert_eq(cmd_test->expect.line_end, 31, "line begin");
+	mu_assert_eq(cmd_test->retries.set, false, "retries unset");
+	mu_assert_eq(cmd_test->retries.value, 0, "retries value");
 
 	test = rz_pvector_at(&db->tests, 3);
 	mu_assert_eq(test->type, RZ_TEST_TYPE_CMD, "test type");
 	cmd_test = test->cmd_test;
 	mu_assert_streq(cmd_test->name.value, "singleline1", "name");
 	mu_assert_streq(cmd_test->expect.value, "", "expect");
-	mu_assert_eq(cmd_test->expect.line_begin, 37, "line begin");
-	mu_assert_eq(cmd_test->expect.line_end, 38, "line begin");
+	mu_assert_eq(cmd_test->expect.line_begin, 38, "line begin");
+	mu_assert_eq(cmd_test->expect.line_end, 39, "line begin");
 
 	rz_test_test_database_free(db);
 	mu_end;
@@ -131,6 +188,7 @@ bool test_rz_test_fix(void) {
 	mu_assert_streq(content,
 		"NAME=multiline0\n"
 		"FILE==\n"
+		"RETRIES=3\n"
 		"CMDS=<<EOF\n"
 		"rm -rf /\n"
 		"EOF\n"
@@ -189,6 +247,7 @@ bool test_rz_test_fix(void) {
 }
 
 int all_tests() {
+	mu_run_test(test_rz_test_cmd_retries);
 	mu_run_test(test_rz_test_database_load_cmd);
 	mu_run_test(test_rz_test_fix);
 	return tests_passed != tests_run;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes. No `RZ_API` function or struct was changed.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed). No book update is needed; the `rz-test` directive is documented
in `test/README.md`.
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

This PR adds an opt-in `RETRIES` directive for command tests.

`RETRIES=N` permits one initial execution plus up to `N` additional executions. Retries stop immediately after the first successful command test. An absent directive or
`RETRIES=0` preserves the existing single-execution behavior.

The HTTP regression test now opts into `RETRIES=3`.

AI disclosure: these changes were generated partially using oh-my-pi with model `gpt-5.6`
