### PR TITLE
Fix CID 912643: Overflowed constant (INTEGER_OVERFLOW)

### DIFF
--- a/librz/util/float/float.c
+++ b/librz/util/float/float.c
@@ -1125,10 +1125,14 @@ RZ_API bool rz_float_is_equal(RZ_NONNULL RzFloat *x, RZ_NONNULL RzFloat *y) {
 	return true;
 }
 
-static void set_inf(RzFloat *f, bool is_negative) {
+static bool set_inf(RzFloat *f, bool is_negative) {
+	rz_return_val_if_fail(f && f->s, false);
 	RzBitVector *bv = f->s;
 	ut32 exp_start = rz_float_get_format_info(f->r, RZ_FLOAT_INFO_MAN_LEN);
 	ut32 exp_end = exp_start + rz_float_get_format_info(f->r, RZ_FLOAT_INFO_EXP_LEN);
+	if (!exp_end) {
+		return false;
+	}
 
 	rz_bv_set_all(bv, false);
 	// set exponent part to all 1
@@ -1140,6 +1144,7 @@ static void set_inf(RzFloat *f, bool is_negative) {
 
 	// set sign bit (MSB), keep the fractional mantissa as zero-bv
 	rz_bv_set(bv, bv->len - 1, is_negative);
+	return true;
 }
 
 static void set_qnan(RzFloat *f) {
@@ -1190,8 +1195,7 @@ static void set_snan(RzFloat *f) {
  */
 RZ_API bool rz_float_set_from_inf(RZ_NONNULL RzFloat *f, bool is_negative) {
 	rz_return_val_if_fail(f, false);
-	set_inf(f, is_negative);
-	return true;
+	return set_inf(f, is_negative);
 }
 
 /**
@@ -1235,11 +1239,10 @@ RZ_API bool rz_float_set_from_snan(RZ_NONNULL RzFloat *f) {
 RZ_API RZ_OWN RzFloat *rz_float_new_inf(RzFloatFormat format, bool is_negative) {
 	// gen an Infinite num for return
 	RzFloat *ret = rz_float_new(format);
-	if (!ret || !ret->s) {
+	if (!ret || !set_inf(ret, is_negative)) {
 		rz_float_free(ret);
 		return NULL;
 	}
-	set_inf(ret, is_negative);
 	return ret;
 }
 

--- a/test/unit/test_float.c
+++ b/test/unit/test_float.c
@@ -176,6 +176,19 @@ bool rz_float_detect_spec_test(void) {
 	mu_end;
 }
 
+bool rz_float_set_from_inf_invalid_format_test(void) {
+	RzFloat *f = rz_float_new(RZ_FLOAT_IEEE754_BIN_32);
+	mu_assert_notnull(f, "create float for invalid infinity format test");
+	rz_bv_set(f->s, 0, true);
+	f->r = RZ_FLOAT_IEEE754_DEC_64;
+
+	mu_assert_false(rz_float_set_from_inf(f, false), "reject infinity for an unsupported float format");
+	mu_assert_true(rz_bv_get(f->s, 0), "failed infinity conversion leaves the bitvector unchanged");
+
+	rz_float_free(f);
+	mu_end;
+}
+
 bool f16_ieee_arithmetic_test(void) {
 	RzFloat *source = rz_float_new_from_f32(1.0f);
 	RzFloat *one = rz_float_convert(source, RZ_FLOAT_IEEE754_BIN_16, RZ_FLOAT_RMODE_RNE);
@@ -2143,6 +2156,7 @@ bool all_tests() {
 	mu_run_test(rz_float_new_from_hex_test);
 	mu_run_test(f32_ieee_format_test);
 	mu_run_test(rz_float_detect_spec_test);
+	mu_run_test(rz_float_set_from_inf_invalid_format_test);
 	mu_run_test(f16_ieee_arithmetic_test);
 	mu_run_test(f32_ieee_add_test);
 	mu_run_test(f32_ieee_sub_test);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

float: Guard infinity encoding against invalid formats

