### PR TITLE
Fix #6607: Fix format autodetection for virtual URIs in rz-test

### DIFF
--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -252,6 +252,10 @@ RZ_API RzBinFile *rz_bin_reload(RzBin *bin, RzBinFile *bf, ut64 baseaddr) {
 	opt.filename = bf->file;
 	rz_buf_seek(bf->buf, 0, RZ_BUF_SET);
 	RzBinFile *nbf = rz_bin_open_buf(bin, bf->buf, &opt);
+	if (!nbf) {
+		rz_bin_set_cur_binfile(bin, bf);
+		return NULL;
+	}
 	// On reload the new file reuses the same fd, so opening it overwrites the
 	// old file's "cur" and "fd.<fd>" entries in bin->sdb. That releases fewer
 	// references to the old sdb than the regular teardown path does, leaving

--- a/librz/core/cfile.c
+++ b/librz/core/cfile.c
@@ -1343,14 +1343,14 @@ RZ_API bool rz_core_file_malloc_copy_chunk(RzCore *core, size_t len, ut64 offset
 		goto err;
 	}
 
+	RzIODesc *desc = rz_io_desc_get(core->io, cfile->fd);
+	rz_warn_if_fail(desc);
+	rz_io_desc_write_at(desc, 0, data, len);
+
 	if (!rz_core_bin_load(core, uri, 0)) {
 		RZ_LOG_ERROR("Cannot load binary info of '%s'.\n", uri);
 		goto err;
 	}
-
-	RzIODesc *desc = rz_io_desc_get(core->io, cfile->fd);
-	rz_warn_if_fail(desc);
-	rz_io_desc_write_at(desc, 0, data, len);
 	res = true;
 
 err:

--- a/librz/core/cmd/cmd_open.c
+++ b/librz/core/cmd/cmd_open.c
@@ -26,6 +26,9 @@ static bool core_bin_reload(RzCore *r, const char *file, ut64 baseaddr) {
 	if (!nbf) {
 		return false;
 	}
+	// rz_bin_reload deletes obf, which drops it from cf->binfiles via the
+	// BIN_FILE_DEL event. Keep the replacement owned by the core file.
+	rz_pvector_push(&cf->binfiles, nbf);
 	rz_core_bin_apply_all_info(r, nbf);
 	return true;
 }

--- a/librz/main/rizin.c
+++ b/librz/main/rizin.c
@@ -1018,6 +1018,11 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 				rz_io_fd_size(r->io, fh->fd));
 			rz_io_write_at(r->io, mapaddr, (const ut8 *)buf, sz);
 			rz_core_block_read(r);
+			if (load_bin == LOAD_BIN_ALL) {
+				(void)rz_core_bin_load(r, path, baddr);
+			} else if (load_bin == LOAD_BIN_STRUCTURES_ONLY) {
+				rz_core_bin_load_structs(r, path);
+			}
 			free(buf);
 			free(path);
 			if (asmarch) {
@@ -1032,7 +1037,6 @@ RZ_API int rz_main_rizin(int argc, const char **argv) {
 			if (endianness != RZ_SYS_ENDIAN_NONE) {
 				rz_config_set_b(r->config, "cfg.bigendian", endianness == RZ_SYS_ENDIAN_BIG);
 			}
-			// TODO: load rbin thing
 		} else {
 			RZ_LOG_ERROR("Cannot slurp from stdin\n");
 			free(buf);

--- a/test/db/cmd/file_malloc
+++ b/test/db/cmd/file_malloc
@@ -12,3 +12,71 @@ EXPECT=<<EOF
 0x00000030  ffff ffff ffff ffff ffff ffff ffff ffff  ................
 EOF
 RUN
+
+NAME=malloc uri write does not autodetect
+FILE=malloc://128
+CMDS=<<EOF
+i~format
+wx 7f454c46010101000000000000000000020003000100000000000000000000000000000000000000340020000000000000000000
+i~format
+EOF
+EXPECT=<<EOF
+format  any
+format  any
+EOF
+RUN
+
+NAME=malloc uri obR reloads elf from buffer
+FILE=malloc://128
+CMDS=<<EOF
+wx 7f454c46010101000000000000000000020003000100000000000000000000000000000000000000340020000000000000000000
+obR
+i~format
+e io.va=0
+p8 4 @ 0
+EOF
+EXPECT=<<EOF
+format   elf
+7f454c46
+EOF
+RUN
+
+NAME=hex uri autodetect elf at open
+FILE=hex://7f454c46010101000000000000000000020003000100000000000000000000000000000000000000340020000000000000000000
+CMDS=<<EOF
+i~format
+EOF
+EXPECT=<<EOF
+format   elf
+EOF
+RUN
+
+NAME=malloc uri nops stay any after obR
+FILE=malloc://128
+CMDS=<<EOF
+wx 90909090
+obR
+i~format
+e io.va=0
+p8 4 @ 0
+EOF
+EXPECT=<<EOF
+format  any
+90909090
+EOF
+RUN
+
+NAME=malloc uri obR reloads mach0 from buffer
+FILE=malloc://128
+CMDS=<<EOF
+wx cefaedfe070000010300000002000000
+obR
+i~format
+e io.va=0
+p8 4 @ 0
+EOF
+EXPECT=<<EOF
+format   mach0
+cefaedfe
+EOF
+RUN

--- a/test/unit/test_core_bin.c
+++ b/test/unit/test_core_bin.c
@@ -631,6 +631,93 @@ bool test_bin_set_export_info(void) {
 	mu_end;
 }
 
+static const ut8 k_min_elf32[] = { 0x7f, 0x45, 0x4c, 0x46, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+bool test_malloc_uri_write_does_not_autodetect(void) {
+	RzCore *core = rz_core_new();
+	RzCoreFile *f = rz_core_file_open(core, "malloc://128", RZ_PERM_RW, 0);
+	mu_assert_notnull(f, "open malloc");
+	bool r = rz_core_bin_load(core, NULL, UT64_MAX);
+	mu_assert_true(r, "initial bin load");
+	RzBinFile *bf = rz_bin_file_find_by_fd(core->bin, f->fd);
+	mu_assert_notnull(bf, "binfile");
+	mu_assert_streq(rz_bin_file_cur_plugin(bf)->name, "any", "empty malloc is any");
+
+	r = rz_core_write_at(core, 0, k_min_elf32, sizeof(k_min_elf32));
+	mu_assert_true(r, "write elf header");
+	bf = rz_bin_file_find_by_fd(core->bin, f->fd);
+	mu_assert_notnull(bf, "binfile after write");
+	mu_assert_streq(rz_bin_file_cur_plugin(bf)->name, "any", "write does not reload bin info");
+
+	rz_core_free(core);
+	mu_end;
+}
+
+bool test_malloc_uri_obr_reloads_elf_keeps_buffer(void) {
+	RzCore *core = rz_core_new();
+	RzCoreFile *f = rz_core_file_open(core, "malloc://128", RZ_PERM_RW, 0);
+	mu_assert_notnull(f, "open malloc");
+	bool r = rz_core_bin_load(core, NULL, UT64_MAX);
+	mu_assert_true(r, "initial bin load");
+	r = rz_core_write_at(core, 0, k_min_elf32, sizeof(k_min_elf32));
+	mu_assert_true(r, "write elf header");
+	mu_assert_eq(rz_core_cmd0(core, "obR"), 0, "obR");
+
+	RzBinFile *bf = rz_bin_file_find_by_fd(core->bin, f->fd);
+	mu_assert_notnull(bf, "binfile after obR");
+	mu_assert_streq(rz_bin_file_cur_plugin(bf)->name, "elf", "obR reloads elf from the live buffer");
+	mu_assert_eq(rz_pvector_len(&f->binfiles), 1, "core file owns the reloaded binfile");
+	mu_assert_ptreq(rz_pvector_at(&f->binfiles, 0), bf, "reloaded binfile is registered on the core file");
+
+	ut8 got[4];
+	RzIODesc *desc = rz_io_desc_get(core->io, f->fd);
+	mu_assert_notnull(desc, "io desc after obR");
+	int n = rz_io_desc_read_at(desc, 0, got, sizeof(got));
+	mu_assert_eq(n, 4, "read desc after obR");
+	mu_assert_memeq(got, k_min_elf32, 4, "obR does not discard the io buffer");
+
+	rz_core_free(core);
+	mu_end;
+}
+
+bool test_hex_uri_autodetect_at_open(void) {
+	RzCore *core = rz_core_new();
+	RzCoreFile *f = rz_core_file_open(core,
+		"hex://7f454c46010101000000000000000000020003000100000000000000000000000000000000000000340020000000000000000000",
+		RZ_PERM_R, 0);
+	mu_assert_notnull(f, "open hex uri");
+	bool r = rz_core_bin_load(core, NULL, UT64_MAX);
+	mu_assert_true(r, "bin load");
+	RzBinFile *bf = rz_bin_file_find_by_fd(core->bin, f->fd);
+	mu_assert_notnull(bf, "binfile");
+	mu_assert_streq(rz_bin_file_cur_plugin(bf)->name, "elf", "hex uri autodetects elf at open");
+
+	rz_core_free(core);
+	mu_end;
+}
+
+bool test_malloc_uri_obr_reloads_mach0(void) {
+	RzCore *core = rz_core_new();
+	RzCoreFile *f = rz_core_file_open(core, "malloc://128", RZ_PERM_RW, 0);
+	mu_assert_notnull(f, "open malloc");
+	bool r = rz_core_bin_load(core, NULL, UT64_MAX);
+	mu_assert_true(r, "initial bin load");
+	const ut8 macho[] = { 0xce, 0xfa, 0xed, 0xfe, 0x07, 0x00, 0x00, 0x01,
+		0x03, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00 };
+	r = rz_core_write_at(core, 0, macho, sizeof(macho));
+	mu_assert_true(r, "write macho header");
+	RzBinFile *bf = rz_bin_file_find_by_fd(core->bin, f->fd);
+	mu_assert_notnull(bf, "binfile after write");
+	mu_assert_streq(rz_bin_file_cur_plugin(bf)->name, "any", "write does not reload bin info");
+	mu_assert_eq(rz_core_cmd0(core, "obR"), 0, "obR");
+	bf = rz_bin_file_find_by_fd(core->bin, f->fd);
+	mu_assert_notnull(bf, "binfile after obR");
+	mu_assert_streq(rz_bin_file_cur_plugin(bf)->name, "mach0", "obR reloads mach0 from the live buffer");
+
+	rz_core_free(core);
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_map);
 	mu_run_test(test_cfile_close);
@@ -641,6 +728,10 @@ bool all_tests() {
 	mu_run_test(test_cfile_close_manual_vfile_map);
 	mu_run_test(test_cfile_close_manual_cfile_map_multiple);
 	mu_run_test(test_bin_set_export_info);
+	mu_run_test(test_malloc_uri_write_does_not_autodetect);
+	mu_run_test(test_malloc_uri_obr_reloads_elf_keeps_buffer);
+	mu_run_test(test_hex_uri_autodetect_at_open);
+	mu_run_test(test_malloc_uri_obr_reloads_mach0);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
Closes #6607

This PR fixes the issue where `rz-test` fails to autodetect the format for virtual URIs (like `malloc://` or `mmap://`).

Previously, autodetection would be skipped when the target file wasn't a valid physical file path, forcing us to explicitly define the format/architecture even when we had enough pre-filled magic bytes or subsequent writes. 

This enables `rz-test` (and the core engine) to reload the bin info directly from the live buffer using `obR`, so format autodetection works correctly for these virtual URIs. 

This is essentially the same approach proposed in #6668. I've also added tests to ensure `obR` successfully detects formats (like ELF and Mach-O) from `malloc://` and `hex://` URIs after writes.
