### PR TITLE
Add DLang RTTI and devirtualization

### DIFF
--- a/librz/arch/meson.build
+++ b/librz/arch/meson.build
@@ -492,6 +492,7 @@ arch_common_sources = [
   'platform_target_index.c',
   'reflines.c',
   'rtti.c',
+  'rtti_dlang.c',
   'rtti_itanium.c',
   'rtti_msvc.c',
   'serialize_analysis.c',

--- a/librz/arch/rtti.c
+++ b/librz/arch/rtti.c
@@ -90,6 +90,9 @@ RZ_API void rz_analysis_rtti_recover_all(RzAnalysis *analysis) {
 		return;
 	}
 	switch (bin_obj->lang) {
+	case RZ_BIN_LANGUAGE_DLANG:
+		rz_analysis_rtti_dlang(analysis);
+		break;
 	case RZ_BIN_LANGUAGE_SWIFT:
 		rz_analysis_rtti_swift(analysis);
 		break;

--- a/librz/arch/rtti_dlang.c
+++ b/librz/arch/rtti_dlang.c
@@ -1,0 +1,521 @@
+// SPDX-FileCopyrightText: 2026 historicattle <sirigere.naren@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include "analysis_private.h"
+
+#define DLANG_CLASS_FLAG_COM 0x001 ///< Class uses the COM ABI
+#define DLANG_CLASS_FLAG_CPP 0x080 ///< Class uses the C++ ABI
+
+// https://github.com/dlang/dmd/blob/master/druntime/src/object.d#L2314-L2410
+#define DLANG_MODULE_FLAG_TLS_CTOR         0x008
+#define DLANG_MODULE_FLAG_UNITTEST         0x200
+#define DLANG_MODULE_FLAG_IMPORTED_MODULES 0x400
+#define DLANG_MODULE_FLAG_LOCAL_CLASSES    0x800
+
+typedef struct dlang_class_info_t {
+	ut64 addr;
+	ut64 init_size;
+	ut64 init_addr;
+	ut64 vtable_count;
+	ut64 vtable_addr;
+	ut64 interfaces_count;
+	ut64 interfaces_addr;
+	ut64 base_addr;
+	ut64 destructor;
+	ut64 flags;
+	ut64 constructor;
+	char *name;
+	bool is_interface;
+} DlangClassInfo;
+
+typedef struct dlang_interface_t {
+	ut64 class_info_addr;
+	ut64 vtable_count;
+	ut64 vtable_addr;
+	ut64 offset;
+} DlangInterface;
+
+static void class_info_free(void *ptr) {
+	DlangClassInfo *info = ptr;
+	RZ_FREE(info->name);
+	RZ_FREE(info);
+}
+
+static bool addr_has_perm(RzAnalysis *analysis, ut64 addr, int perm) {
+	RzBinSection *section = analysis->binb.get_vsect_at(analysis->binb.bin, addr);
+	return section && (section->perm & perm) == perm;
+}
+
+static bool range_is_readable(RzAnalysis *analysis, ut64 addr, ut64 count, ut64 element_size) {
+	if (!count || !element_size || count > UT64_MAX / element_size) {
+		return false;
+	}
+	ut64 size = count * element_size;
+	RzBinSection *section = analysis->binb.get_vsect_at(analysis->binb.bin, addr);
+	if (!section || !(section->perm & RZ_PERM_R)) {
+		return false;
+	}
+	ut64 start = rz_bin_object_addr_with_base(rz_bin_cur_object(analysis->binb.bin), section->vaddr);
+	if (start > addr) {
+		return false;
+	}
+	ut64 offset = addr - start;
+	return offset <= section->vsize && size <= section->vsize - offset;
+}
+
+static bool read_word(RVTableContext *context, ut64 base, ut64 index, RZ_OUT ut64 *value) {
+	return context->read_addr(context->analysis, base + index * context->word_size, value);
+}
+
+static char *read_name(RVTableContext *context, ut64 addr, ut64 length) {
+	if (!addr || !range_is_readable(context->analysis, addr, length, 1)) {
+		return NULL;
+	}
+	char *name = RZ_NEWS(char, (size_t)length + 1);
+	if (!name) {
+		return NULL;
+	}
+	if (!context->analysis->iob.read_at(context->analysis->iob.io, addr, (ut8 *)name, length)) {
+		RZ_FREE(name);
+		return NULL;
+	}
+	for (ut64 i = 0; i < length; i++) {
+		ut8 ch = name[i];
+		if (!ch || ch < 0x20 || ch == 0x7f) {
+			RZ_FREE(name);
+			return NULL;
+		}
+	}
+	name[length] = 0;
+	return name;
+}
+
+static bool vtable_is_valid(RVTableContext *context, ut64 class_info_addr, ut64 vtable_addr, ut64 count) {
+	if (!range_is_readable(context->analysis, vtable_addr, count, context->word_size)) {
+		return false;
+	}
+	ut64 value = 0;
+	if (!context->read_addr(context->analysis, vtable_addr, &value) || value != class_info_addr) {
+		return false;
+	}
+	for (ut64 i = 1; i < count; i++) {
+		if (!read_word(context, vtable_addr, i, &value)) {
+			return false;
+		}
+		if (value && !addr_has_perm(context->analysis, value, RZ_PERM_X)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool interface_read(RVTableContext *context, ut64 addr, RZ_OUT DlangInterface *interface) {
+	return read_word(context, addr, 0, &interface->class_info_addr) &&
+		read_word(context, addr, 1, &interface->vtable_count) &&
+		read_word(context, addr, 2, &interface->vtable_addr) &&
+		read_word(context, addr, 3, &interface->offset);
+}
+
+static bool interfaces_are_valid(RVTableContext *context, DlangClassInfo *info) {
+	if (!info->interfaces_count) {
+		return true;
+	}
+	ut64 descriptor_size = 4 * context->word_size;
+	if (!info->interfaces_addr || !range_is_readable(context->analysis, info->interfaces_addr, info->interfaces_count, descriptor_size)) {
+		return false;
+	}
+	for (ut64 i = 0; i < info->interfaces_count; i++) {
+		DlangInterface interface = { 0 };
+		ut64 addr = info->interfaces_addr + i * descriptor_size;
+		if (!interface_read(context, addr, &interface) || !interface.class_info_addr) {
+			return false;
+		}
+		if (info->is_interface) {
+			if (interface.vtable_addr || interface.vtable_count) {
+				return false;
+			}
+			continue;
+		}
+		if (!interface.vtable_addr || !interface.vtable_count ||
+			!range_is_readable(context->analysis, interface.vtable_addr,
+				interface.vtable_count, context->word_size) ||
+			interface.offset % context->word_size || interface.offset > info->init_size - context->word_size) {
+			return false;
+		}
+		ut64 actual_vtable = 0;
+		if (!context->read_addr(context->analysis, info->init_addr + interface.offset, &actual_vtable) ||
+			!vtable_is_valid(context, addr, actual_vtable, interface.vtable_count)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static DlangClassInfo *class_info_parse_layout(RVTableContext *context, ut64 addr, bool has_monitor) {
+	ut64 field = 1;
+	if (has_monitor) {
+		field++;
+	}
+	ut64 name_length = 0;
+	ut64 name_addr = 0;
+	DlangClassInfo *info = RZ_NEW0(DlangClassInfo);
+	if (!info) {
+		return NULL;
+	}
+	info->addr = addr;
+	bool ok = read_word(context, addr, field, &info->init_size) &&
+		read_word(context, addr, field + 1, &info->init_addr) &&
+		read_word(context, addr, field + 2, &name_length) &&
+		read_word(context, addr, field + 3, &name_addr) &&
+		read_word(context, addr, field + 4, &info->vtable_count) &&
+		read_word(context, addr, field + 5, &info->vtable_addr) &&
+		read_word(context, addr, field + 6, &info->interfaces_count) &&
+		read_word(context, addr, field + 7, &info->interfaces_addr) &&
+		read_word(context, addr, field + 8, &info->base_addr) &&
+		read_word(context, addr, field + 9, &info->destructor) &&
+		read_word(context, addr, field + 11, &info->flags) &&
+		read_word(context, addr, field + 15, &info->constructor);
+	if (!ok) {
+		class_info_free(info);
+		return NULL;
+	}
+
+	info->name = read_name(context, name_addr, name_length);
+	if (!info->name) {
+		class_info_free(info);
+		return NULL;
+	}
+
+	info->is_interface = !info->init_size && !info->vtable_count && !info->base_addr;
+	if (!info->is_interface) {
+		if (info->init_size < 2 * context->word_size || !info->init_addr ||
+			!vtable_is_valid(context, addr, info->vtable_addr, info->vtable_count)) {
+			class_info_free(info);
+			return NULL;
+		}
+		ut64 initial_vtable = 0;
+		if (!context->read_addr(context->analysis, info->init_addr, &initial_vtable) || initial_vtable != info->vtable_addr) {
+			class_info_free(info);
+			return NULL;
+		}
+	}
+	if ((info->destructor && !addr_has_perm(context->analysis, info->destructor, RZ_PERM_X)) ||
+		(info->constructor && !addr_has_perm(context->analysis, info->constructor, RZ_PERM_X)) ||
+		!interfaces_are_valid(context, info)) {
+		class_info_free(info);
+		return NULL;
+	}
+	return info;
+}
+
+static DlangClassInfo *class_info_parse(RVTableContext *context, ut64 addr) {
+	if (!addr || !addr_has_perm(context->analysis, addr, RZ_PERM_R)) {
+		return NULL;
+	}
+	ut64 own_vtable = 0;
+	if (!context->read_addr(context->analysis, addr, &own_vtable) || !own_vtable ||
+		!addr_has_perm(context->analysis, own_vtable, RZ_PERM_R)) {
+		return NULL;
+	}
+	DlangClassInfo *info = class_info_parse_layout(context, addr, true);
+	if (!info) {
+		info = class_info_parse_layout(context, addr, false);
+	}
+	return info;
+}
+
+static void info_add(RVTableContext *context, RzList /*<DlangClassInfo *>*/ *infos, HtUP *by_addr, ut64 addr) {
+	if (ht_up_find(by_addr, addr, NULL)) {
+		return;
+	}
+	DlangClassInfo *info = class_info_parse(context, addr);
+	if (!info) {
+		return;
+	}
+	if (info->flags & (DLANG_CLASS_FLAG_COM | DLANG_CLASS_FLAG_CPP)) {
+		class_info_free(info);
+		return;
+	}
+	if (!rz_list_append(infos, info)) {
+		class_info_free(info);
+		return;
+	}
+	if (!ht_up_insert(by_addr, addr, info)) {
+		rz_list_delete_val(infos, info);
+	}
+}
+
+static void discover_symbols(RVTableContext *context, RzBinObject *obj, RzList /*<DlangClassInfo *>*/ *infos, HtUP *by_addr) {
+	const RzPVector *symbols = rz_bin_object_get_symbols(obj);
+	void **iter;
+	rz_pvector_foreach (symbols, iter) {
+		RzBinSymbol *symbol = *iter;
+		if (!symbol || RZ_STR_ISEMPTY(symbol->name)) {
+			continue;
+		}
+		if (rz_str_endswith(symbol->name, "7__ClassZ") || rz_str_endswith(symbol->name, "11__InterfaceZ")) {
+			info_add(context, infos, by_addr, rz_bin_object_addr_with_base(obj, symbol->vaddr));
+		}
+	}
+}
+
+static bool read_u32(RzAnalysis *analysis, ut64 addr, RZ_OUT ut32 *value) {
+	ut8 bytes[4];
+	if (!analysis->iob.read_at(analysis->iob.io, addr, bytes, sizeof(bytes))) {
+		return false;
+	}
+	*value = rz_read_ble32(bytes, analysis->big_endian);
+	return true;
+}
+
+static void discover_module(RVTableContext *context, RzList /*<DlangClassInfo *>*/ *infos, HtUP *by_addr, ut64 addr) {
+	ut32 flags = 0;
+	if (!read_u32(context->analysis, addr, &flags) || !(flags & DLANG_MODULE_FLAG_LOCAL_CLASSES)) {
+		return;
+	}
+	ut64 cursor = addr + 8;
+	for (ut32 bit = DLANG_MODULE_FLAG_TLS_CTOR; bit <= DLANG_MODULE_FLAG_UNITTEST; bit <<= 1) {
+		if (flags & bit) {
+			cursor += context->word_size;
+		}
+	}
+	if (flags & DLANG_MODULE_FLAG_IMPORTED_MODULES) {
+		ut64 count = 0;
+		if (!context->read_addr(context->analysis, cursor, &count)) {
+			return;
+		}
+		cursor += context->word_size;
+		if (count && !range_is_readable(context->analysis, cursor, count, context->word_size)) {
+			return;
+		}
+		cursor += count * context->word_size;
+	}
+	ut64 count = 0;
+	if (!context->read_addr(context->analysis, cursor, &count)) {
+		return;
+	}
+	cursor += context->word_size;
+	if (count && !range_is_readable(context->analysis, cursor, count, context->word_size)) {
+		return;
+	}
+	for (ut64 i = 0; i < count; i++) {
+		ut64 class_info_addr = 0;
+		if (!read_word(context, cursor, i, &class_info_addr)) {
+			return;
+		}
+		info_add(context, infos, by_addr, class_info_addr);
+	}
+}
+
+static void discover_modules(RVTableContext *context, RzBinObject *obj, RzList /*<DlangClassInfo *>*/ *infos, HtUP *by_addr) {
+	const RzPVector *sections = context->analysis->binb.get_sections(obj);
+	void **iter;
+	rz_pvector_foreach (sections, iter) {
+		RzBinSection *section = *iter;
+		if (!section || section->is_segment || RZ_STR_ISEMPTY(section->name) ||
+			(strcmp(section->name, "minfo") && // https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/elfobj.d#L3420-L3431
+				strcmp(section->name, ".minfo") && // https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/mscoffobj.d#L2400-L2415
+				strcmp(section->name, "__minfodata"))) { // https://github.com/dlang/dmd/blob/master/compiler/src/dmd/backend/machobj.d#L3381-L3390
+			continue;
+		}
+		if (section->vsize < context->word_size) {
+			continue;
+		}
+		ut64 start = rz_bin_object_addr_with_base(obj, section->vaddr);
+		ut64 end = start + section->vsize;
+		for (ut64 cursor = start; cursor <= end - context->word_size; cursor += context->word_size) {
+			ut64 module_addr = 0;
+			if (context->read_addr(context->analysis, cursor, &module_addr) && module_addr) {
+				discover_module(context, infos, by_addr, module_addr);
+			}
+		}
+	}
+}
+
+static char *method_name(RzAnalysis *analysis, ut64 addr, const char *kind, st64 offset) {
+	RzAnalysisFunction *function = rz_analysis_get_function_at(analysis, addr);
+	if (function && RZ_STR_ISNOTEMPTY(function->name)) {
+		return rz_str_dup(function->name);
+	}
+	RzBinSymbol *symbol = rz_bin_object_get_symbol_at(rz_bin_cur_object(analysis->binb.bin), addr, true);
+	if (symbol && RZ_STR_ISNOTEMPTY(symbol->dname)) {
+		return rz_str_dup(symbol->dname);
+	}
+	if (symbol && RZ_STR_ISNOTEMPTY(symbol->name)) {
+		char *name = analysis->binb.demangle(analysis->binb.bin, "dlang", symbol->name);
+		if (name) {
+			return name;
+		}
+		return rz_str_dup(symbol->name);
+	}
+	if (offset < 0) {
+		return rz_str_dup(kind);
+	}
+	return rz_str_newf("%s_0x%" PFMT64x, kind, (ut64)offset);
+}
+
+static void add_method(RVTableContext *context, DlangClassInfo *info, ut64 addr, st64 offset, RzAnalysisMethodType type, const char *kind) {
+	if (!addr || rz_analysis_class_method_exists_by_addr(context->analysis, info->name, addr)) {
+		return;
+	}
+	char *real_name = method_name(context->analysis, addr, kind, offset);
+	if (!real_name) {
+		return;
+	}
+	char *name = rz_str_dup(real_name);
+	if (!name) {
+		RZ_FREE(real_name);
+		return;
+	}
+	real_name = rz_str_replace(real_name, ",", "#_#", 1);
+	if (!real_name) {
+		free(name);
+		return;
+	}
+	RzAnalysisMethod method = {
+		.name = name,
+		.real_name = real_name,
+		.addr = addr,
+		.vtable_offset = offset,
+		.method_type = type,
+	};
+	rz_analysis_class_method_set(context->analysis, info->name, &method);
+	rz_analysis_class_method_fini(&method);
+}
+
+static void add_vtable(RVTableContext *context, DlangClassInfo *info, ut64 addr, ut64 count, ut64 object_offset, const char *kind) {
+	RzAnalysisVTable vtable = {
+		.addr = addr,
+		.offset = object_offset,
+		.size = count * context->word_size,
+	};
+	rz_analysis_class_vtable_set(context->analysis, info->name, &vtable);
+	rz_analysis_class_vtable_fini(&vtable);
+	char *offset_kind = NULL;
+	const char *method_kind = kind;
+	if (object_offset) {
+		offset_kind = rz_str_newf("%s_0x%" PFMT64x, kind, object_offset);
+		if (offset_kind) {
+			method_kind = offset_kind;
+		}
+	}
+	for (ut64 slot = 1; slot < count; slot++) {
+		ut64 method_addr = 0;
+		if (!read_word(context, addr, slot, &method_addr)) {
+			break;
+		}
+		add_method(context, info, method_addr, slot * context->word_size,
+			RZ_ANALYSIS_CLASS_METHOD_VIRTUAL, method_kind);
+	}
+	free(offset_kind);
+}
+
+static void add_base(RzAnalysis *analysis, DlangClassInfo *info, DlangClassInfo *base_info, ut64 offset) {
+	if (!base_info || !strcmp(info->name, base_info->name)) {
+		return;
+	}
+	RzAnalysisBaseClass base = {
+		.class_name = rz_str_dup(base_info->name),
+		.offset = offset,
+	};
+	rz_analysis_class_base_set(analysis, info->name, &base);
+	rz_analysis_class_base_fini(&base);
+}
+
+static void apply_interfaces(RVTableContext *context, HtUP *by_addr, DlangClassInfo *info) {
+	DlangClassInfo *owner = info;
+	RzSetU *offsets = rz_set_u_new();
+	RzSetU *owners = rz_set_u_new();
+	if (!offsets || !owners) {
+		rz_set_u_free(offsets);
+		rz_set_u_free(owners);
+		return;
+	}
+	ut64 descriptor_size = 4 * context->word_size;
+	while (owner && !rz_set_u_contains(owners, owner->addr)) {
+		rz_set_u_add(owners, owner->addr);
+		for (ut64 i = 0; i < owner->interfaces_count; i++) {
+			DlangInterface interface = { 0 };
+			ut64 descriptor_addr = owner->interfaces_addr + i * descriptor_size;
+			if (!interface_read(context, descriptor_addr, &interface) ||
+				rz_set_u_contains(offsets, interface.offset)) {
+				continue;
+			}
+			ut64 actual_vtable = 0;
+			if (!context->read_addr(context->analysis, info->init_addr + interface.offset, &actual_vtable) ||
+				!vtable_is_valid(context, descriptor_addr, actual_vtable, interface.vtable_count)) {
+				continue;
+			}
+			rz_set_u_add(offsets, interface.offset);
+			DlangClassInfo *interface_info = ht_up_find(by_addr, interface.class_info_addr, NULL);
+			add_base(context->analysis, info, interface_info, interface.offset);
+			add_vtable(context, info, actual_vtable, interface.vtable_count, interface.offset, "interface");
+		}
+		owner = ht_up_find(by_addr, owner->base_addr, NULL);
+	}
+	rz_set_u_free(owners);
+	rz_set_u_free(offsets);
+}
+
+static void apply(RVTableContext *context, RzList /*<DlangClassInfo *>*/ *infos, HtUP *by_addr) {
+	RzListIter *iter;
+	DlangClassInfo *info;
+	rz_list_foreach (infos, iter, info) {
+		rz_analysis_class_create(context->analysis, info->name);
+	}
+	rz_list_foreach (infos, iter, info) {
+		add_base(context->analysis, info, ht_up_find(by_addr, info->base_addr, NULL), 0);
+		if (info->is_interface) {
+			for (ut64 i = 0; i < info->interfaces_count; i++) {
+				DlangInterface interface = { 0 };
+				if (interface_read(context, info->interfaces_addr + i * 4 * context->word_size, &interface)) {
+					add_base(context->analysis, info, ht_up_find(by_addr, interface.class_info_addr, NULL), interface.offset);
+				}
+			}
+			continue;
+		}
+		add_vtable(context, info, info->vtable_addr, info->vtable_count, 0, "virtual");
+		apply_interfaces(context, by_addr, info);
+		add_method(context, info, info->destructor, -1, RZ_ANALYSIS_CLASS_METHOD_DESTRUCTOR, "destructor");
+		add_method(context, info, info->constructor, -1, RZ_ANALYSIS_CLASS_METHOD_CONSTRUCTOR, "constructor");
+	}
+}
+
+/**
+ * \brief Recover classes from D runtime type information.
+ */
+RZ_API void rz_analysis_rtti_dlang(RZ_NONNULL RzAnalysis *analysis) {
+	RVTableContext context;
+	if (!rz_analysis_vtable_begin(analysis, &context)) {
+		return;
+	}
+	RzBinObject *obj = rz_bin_cur_object(analysis->binb.bin);
+	if (!obj) {
+		return;
+	}
+	RzList *infos = rz_list_newf(class_info_free);
+	HtUP *by_addr = ht_up_new(NULL, NULL);
+	if (!infos || !by_addr) {
+		rz_list_free(infos);
+		ht_up_free(by_addr);
+		return;
+	}
+
+	discover_symbols(&context, obj, infos, by_addr);
+	discover_modules(&context, obj, infos, by_addr);
+
+	for (ut64 i = 0; i < rz_list_length(infos); i++) {
+		DlangClassInfo *info = rz_list_get_n(infos, i);
+		info_add(&context, infos, by_addr, info->base_addr);
+		for (ut64 n = 0; n < info->interfaces_count; n++) {
+			ut64 class_info_addr = 0;
+			if (read_word(&context, info->interfaces_addr, n * 4, &class_info_addr)) {
+				info_add(&context, infos, by_addr, class_info_addr);
+			}
+		}
+	}
+	apply(&context, infos, by_addr);
+
+	ht_up_free(by_addr);
+	rz_list_free(infos);
+}

--- a/librz/bin/bin_demangle.c
+++ b/librz/bin/bin_demangle.c
@@ -26,6 +26,9 @@ static const char *get_mangled_name(const char *mangled) {
 	}
 
 	skip_prefix_n(mangled, "__OBJC_", 1);
+	if (!strncmp(mangled, "__D", 3) && IS_DIGIT(mangled[3])) {
+		mangled++;
+	}
 
 	return RZ_STR_ISEMPTY(mangled) ? NULL : mangled;
 }

--- a/librz/bin/bin_language.c
+++ b/librz/bin/bin_language.c
@@ -19,7 +19,7 @@ static inline bool check_objc(RzBinSymbol *sym) {
 }
 
 static inline bool check_dlang(RzBinSymbol *sym) {
-	return !strncmp(sym->name, "_D", 2) && IS_DIGIT(sym->name[2]);
+	return (!strncmp(sym->name, "_D", 2) && IS_DIGIT(sym->name[2])) || (!strncmp(sym->name, "__D", 3) && IS_DIGIT(sym->name[3]));
 }
 
 static inline bool check_swift(RzBinSymbol *sym) {

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -6272,12 +6272,15 @@ RZ_IPI RzCmdStatus rz_analysis_devirtualize_handler(RzCore *core, int argc, cons
 	case RZ_BIN_LANGUAGE_CXX:
 		rz_core_analysis_devirtualize_cxx_methods(core);
 		break;
+	case RZ_BIN_LANGUAGE_DLANG:
+		rz_core_analysis_devirtualize_dlang_methods(core);
+		break;
 	case RZ_BIN_LANGUAGE_OBJC:
 	case RZ_BIN_LANGUAGE_SWIFT:
 		rz_core_analysis_devirtualize_objc_methods(core);
 		break;
 	default:
-		RZ_LOG_ERROR("Devirtualization is only supported for C++ and Objective-C binaries.\n");
+		RZ_LOG_ERROR("Devirtualization is only supported for C++, D, and Objective-C binaries.\n");
 		break;
 	}
 	return RZ_CMD_STATUS_OK;

--- a/librz/core/core_private.h
+++ b/librz/core/core_private.h
@@ -46,6 +46,7 @@ RZ_IPI void rz_core_il_cons_print(RZ_NONNULL RzCore *core, RZ_NONNULL RZ_BORROW 
 RZ_IPI void rz_core_il_colorize_body(RZ_NONNULL RzConsContext *ctx, RZ_NULLABLE const char *il_stmt);
 
 RZ_IPI void rz_core_analysis_devirtualize_cxx_methods(RZ_NULLABLE RzCore *core);
+RZ_IPI void rz_core_analysis_devirtualize_dlang_methods(RZ_NULLABLE RzCore *core);
 RZ_IPI void rz_core_analysis_devirtualize_objc_methods(RZ_NULLABLE RzCore *core);
 RZ_IPI void rz_core_analysis_virtual_xrefs_print(RZ_NONNULL RzCore *core, RZ_NONNULL const char *vfunc);
 RZ_IPI void rz_core_analysis_virtual_xrefs_print_table(RZ_NONNULL RzCore *core, RZ_NONNULL const char *vfunc, RZ_NONNULL RzTable *table);

--- a/librz/core/devirtualize_dlang.c
+++ b/librz/core/devirtualize_dlang.c
@@ -1,0 +1,919 @@
+// SPDX-FileCopyrightText: 2026 historicattle <sirigere.naren@gmail.com>
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include <rz_analysis.h>
+#include <rz_core.h>
+#include "core_private.h"
+
+#define DLANG_MAX_CALL_ARGS  8
+#define DLANG_TRACK_MEM_ADDR 0x10000000
+#define DLANG_TRACK_MEM_SIZE 0x50000
+#define DLANG_STACK_PTR      (DLANG_TRACK_MEM_ADDR + (DLANG_TRACK_MEM_SIZE / 2))
+#define DLANG_OBJECT_ADDR    (DLANG_TRACK_MEM_ADDR + 0x30000)
+
+typedef struct dlang_call_seed_t {
+	const char *regs[DLANG_MAX_CALL_ARGS]; ///< Calling convention arg regs.
+	ut64 vtables[DLANG_MAX_CALL_ARGS]; ///< Vtable seeded for each argument.
+	bool has_vtable[DLANG_MAX_CALL_ARGS];
+	ut64 count; ///< Number of regs.
+} DlangCallSeed;
+
+typedef struct dlang_known_vtable_t {
+	ut64 addr;
+	RzVector /*<DlangKnownMethod>*/ *methods;
+} DlangKnownVTable;
+
+typedef struct dlang_known_method_t {
+	ut64 addr;
+	ut64 offset;
+	char *name;
+} DlangKnownMethod;
+
+typedef struct dlang_vtable_index_t {
+	RzVector /*<DlangKnownVTable>*/ *vtables; ///< All known vtables.
+	HtUP *by_addr;
+} DlangVTableIndex;
+
+typedef struct dlang_caller_replay_context_t {
+	DlangVTableIndex *vtable_index;
+	RzSetU *allocator_calls;
+	HtUP *known_classes;
+	const DlangCallSeed *argument_regs;
+} DlangCallerReplayContext;
+
+static ut64 ptr_size(RzCore *core) {
+	return rz_asm_get_bits(core->rasm) == 64 ? 8 : 4;
+}
+
+static bool addr_is_executable(RzCore *core, ut64 addr) {
+	RzBinSection *section = rz_bin_get_section_at(rz_bin_cur_object(core->bin), addr, true);
+	return section && (section->perm & RZ_PERM_X);
+}
+
+static bool range_is_readable(RzCore *core, ut64 addr, ut64 count, ut64 element_size) {
+	if (!count || !element_size || count > UT64_MAX / element_size) {
+		return false;
+	}
+	ut64 size = count * element_size;
+	RzBinSection *section = rz_bin_get_section_at(rz_bin_cur_object(core->bin), addr, true);
+	if (!section || !(section->perm & RZ_PERM_R)) {
+		return false;
+	}
+	ut64 start = rz_bin_object_addr_with_base(rz_bin_cur_object(core->bin), section->vaddr);
+	if (start > addr) {
+		return false;
+	}
+	ut64 offset = addr - start;
+	return offset <= section->vsize && size <= section->vsize - offset;
+}
+
+static RZ_OWN ut8 *read_mapped_range(RzCore *core, ut64 start, ut64 end) {
+	if (end <= start) {
+		return NULL;
+	}
+	size_t size = end - start;
+	ut8 *bytes = malloc(size);
+	if (!bytes) {
+		return NULL;
+	}
+	if (!rz_io_read_at_mapped(core->io, start, bytes, size)) {
+		RZ_FREE(bytes);
+	}
+	return bytes;
+}
+
+typedef struct dlang_class_info_t {
+	ut64 init_size;
+	ut64 init_addr;
+	ut64 vtable_count;
+	ut64 vtable_addr;
+} DlangClassInfo;
+
+static bool class_info(RzCore *core, ut64 addr, RZ_OUT DlangClassInfo *info) {
+	if (!addr) {
+		return false;
+	}
+	ut64 psize = ptr_size(core);
+	bool big_endian = rz_asm_is_big_endian_set(core->rasm);
+	ut64 back_pointer = 0;
+
+	return rz_io_read_i(core->io, addr + 2 * psize, &info->init_size, psize, big_endian) &&
+		rz_io_read_i(core->io, addr + 3 * psize, &info->init_addr, psize, big_endian) &&
+		rz_io_read_i(core->io, addr + 6 * psize, &info->vtable_count, psize, big_endian) &&
+		rz_io_read_i(core->io, addr + 7 * psize, &info->vtable_addr, psize, big_endian) &&
+		info->vtable_count && info->vtable_addr &&
+		range_is_readable(core, info->vtable_addr, info->vtable_count, psize) &&
+		rz_io_read_i(core->io, info->vtable_addr, &back_pointer, psize, big_endian) && back_pointer == addr;
+}
+
+static void known_method_fini(void *e, void *user) {
+	DlangKnownMethod *method = e;
+	RZ_FREE(method->name);
+}
+
+static void known_vtable_fini(void *e, void *user) {
+	DlangKnownVTable *vtable = e;
+	rz_vector_free(vtable->methods);
+}
+
+static RzAnalysisMethod *analysis_method_by_addr(RzVector /*<RzAnalysisMethod>*/ *methods, ut64 addr) {
+	RzAnalysisMethod *method;
+	rz_vector_foreach (methods, method) {
+		if (method->addr == addr) {
+			return method;
+		}
+	}
+	return NULL;
+}
+
+static RZ_OWN DlangVTableIndex *vtable_index_new(RzCore *core) {
+	RzPVector *classes = rz_analysis_class_get_all(core->analysis, false);
+	if (!classes) {
+		return NULL;
+	}
+	DlangVTableIndex *index = RZ_NEW(DlangVTableIndex);
+	if (!index) {
+		rz_pvector_free(classes);
+		return NULL;
+	}
+	index->vtables = rz_vector_new(sizeof(DlangKnownVTable), known_vtable_fini, NULL);
+	index->by_addr = ht_up_new(NULL, NULL);
+	if (!index->vtables || !index->by_addr) {
+		rz_vector_free(index->vtables);
+		ht_up_free(index->by_addr);
+		free(index);
+		rz_pvector_free(classes);
+		return NULL;
+	}
+
+	void **iter;
+	rz_pvector_foreach (classes, iter) {
+		SdbKv *kv = *iter;
+		const char *class_name = sdbkv_key(kv);
+		RzVector *class_methods = rz_analysis_class_method_get_all(core->analysis, class_name);
+		RzVector *class_vtables = rz_analysis_class_vtable_get_all(core->analysis, class_name);
+		RzAnalysisVTable *analysis_vtable;
+		rz_vector_foreach (class_vtables, analysis_vtable) {
+			DlangKnownVTable vtable = {
+				.addr = analysis_vtable->addr,
+				.methods = rz_vector_new(sizeof(DlangKnownMethod), known_method_fini, NULL),
+			};
+			if (!vtable.methods) {
+				continue;
+			}
+			ut64 psize = ptr_size(core);
+			bool big_endian = rz_asm_is_big_endian_set(core->rasm);
+
+			for (ut64 offset = psize; offset < analysis_vtable->size; offset += psize) {
+				ut64 method_addr = 0;
+				if (!rz_io_read_i(core->io, vtable.addr + offset, &method_addr, psize, big_endian) ||
+					!method_addr || !addr_is_executable(core, method_addr)) {
+					continue;
+				}
+				RzAnalysisMethod *analysis_method = analysis_method_by_addr(class_methods, method_addr);
+				if (!analysis_method) {
+					continue;
+				}
+				const char *name = analysis_method->name;
+				if (RZ_STR_ISNOTEMPTY(analysis_method->real_name)) {
+					name = analysis_method->real_name;
+				}
+				DlangKnownMethod method = {
+					.addr = method_addr,
+					.offset = offset,
+					.name = rz_str_dup(name),
+				};
+				if (!method.name || !rz_vector_push(vtable.methods, &method)) {
+					known_method_fini(&method, NULL);
+				}
+			}
+			if (!rz_vector_push(index->vtables, &vtable)) {
+				known_vtable_fini(&vtable, NULL);
+			}
+		}
+		rz_vector_free(class_vtables);
+		rz_vector_free(class_methods);
+	}
+	rz_pvector_free(classes);
+
+	DlangKnownVTable *vtable;
+	rz_vector_foreach (index->vtables, vtable) {
+		ht_up_insert(index->by_addr, vtable->addr, vtable);
+	}
+	return index;
+}
+
+static void vtable_index_free(DlangVTableIndex *index) {
+	ht_up_free(index->by_addr);
+	rz_vector_free(index->vtables);
+	free(index);
+}
+
+static DlangKnownVTable *vtable_by_addr(DlangVTableIndex *index, ut64 addr) {
+	return ht_up_find(index->by_addr, addr, NULL);
+}
+
+static DlangKnownMethod *method_at_offset(DlangKnownVTable *vtable, ut64 offset) {
+	DlangKnownMethod *method;
+	rz_vector_foreach (vtable->methods, method) {
+		if (method->offset == offset) {
+			return method;
+		}
+	}
+	return NULL;
+}
+
+static ut64 il_value_to_ut64(RZ_NULLABLE RzILVal *value) {
+	if (!value) {
+		return UT64_MAX;
+	}
+	RzBitVector *bv = rz_il_value_to_bv(value);
+	if (!bv) {
+		return UT64_MAX;
+	}
+	ut64 result = rz_bv_to_ut64(bv);
+	rz_bv_free(bv);
+	return result;
+}
+
+static ut64 get_reg_value(RzAnalysis *analysis, const char *reg_name) {
+	if (RZ_STR_ISEMPTY(reg_name)) {
+		return UT64_MAX;
+	}
+	RzAnalysisILVM *vm = rz_analysis_get_il_vm(analysis);
+	if (!vm) {
+		return UT64_MAX;
+	}
+	RzILVal *value = rz_il_vm_get_var_value(vm->vm, RZ_IL_VAR_KIND_GLOBAL, reg_name);
+	return il_value_to_ut64(value);
+}
+
+static bool is_valid_reg(RzCore *core, const char *reg_name) {
+	if (RZ_STR_ISEMPTY(reg_name)) {
+		return false;
+	}
+	RzReg *reg = rz_analysis_get_reg(core->analysis);
+	return reg && rz_reg_get(reg, reg_name, RZ_REG_TYPE_ANY);
+}
+
+static void advance_il_pc(RzCore *core, ut64 addr) {
+	RzReg *reg = rz_analysis_get_reg(core->analysis);
+	if (reg) {
+		rz_reg_set_value_by_role(reg, RZ_REG_NAME_PC, addr);
+	}
+}
+
+static bool analysis_value_addr(RzCore *core, RZ_NULLABLE const RzAnalysisOp *op, RzAnalysisValue *value, RZ_OUT ut64 *addr) {
+	ut64 result = value->base;
+	const char *base_reg = NULL;
+	if (value->reg) {
+		base_reg = value->reg->name;
+	}
+	if (base_reg) {
+		ut64 base = UT64_MAX;
+		RzReg *reg = rz_analysis_get_reg(core->analysis);
+		const char *pc = NULL;
+		if (reg) {
+			pc = rz_reg_get_name(reg, RZ_REG_NAME_PC);
+		}
+		if (op && pc && !strcmp(base_reg, pc)) {
+			base = op->addr + op->size;
+		} else {
+			base = get_reg_value(core->analysis, base_reg);
+		}
+		if (!base || base == UT64_MAX) {
+			return false;
+		}
+		result += base;
+	}
+	if (value->regdelta) {
+		ut64 index = get_reg_value(core->analysis, value->regdelta->name);
+		ut64 scale = value->mul;
+		if (!scale) {
+			scale = 1;
+		}
+		if (index == UT64_MAX) {
+			return false;
+		}
+		result += index * scale;
+	}
+	result += value->delta;
+	if (!result) {
+		return false;
+	}
+	*addr = result;
+	return true;
+}
+
+static bool value_mem_access_is_safe(RzCore *core, RzAnalysisOp *op, RzAnalysisValue *value, bool write) {
+	ut64 addr = UT64_MAX;
+	if (!analysis_value_addr(core, op, value, &addr)) {
+		return false;
+	}
+
+	ut64 access_size = value->memref;
+	if (addr >= DLANG_TRACK_MEM_ADDR) {
+		ut64 offset = addr - DLANG_TRACK_MEM_ADDR;
+		if (offset < DLANG_TRACK_MEM_SIZE && access_size <= DLANG_TRACK_MEM_SIZE - offset) {
+			return true;
+		}
+	}
+	return !write && rz_io_is_valid_offset(core->io, addr, RZ_PERM_R);
+}
+
+static bool op_memory_access_is_safe(RzCore *core, RzAnalysisOp *op) {
+	if ((op->type & RZ_ANALYSIS_OP_TYPE_MASK) == RZ_ANALYSIS_OP_TYPE_LEA) {
+		return true;
+	}
+	if (op->dst && op->dst->memref > 0 && !value_mem_access_is_safe(core, op, op->dst, true)) {
+		return false;
+	}
+	for (ut64 i = 0; i < RZ_ARRAY_SIZE(op->src); i++) {
+		if (op->src[i] && op->src[i]->memref > 0 &&
+			!value_mem_access_is_safe(core, op, op->src[i], false)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static const char *op_dst_reg_name(RzAnalysisOp *op) {
+	if (!op->dst || op->dst->type != RZ_ANALYSIS_VAL_REG || !op->dst->reg) {
+		return NULL;
+	}
+	return op->dst->reg->name;
+}
+
+static bool op_is_vtable_slot_dispatch(RzCore *core, RzAnalysisOp *op) {
+	return is_valid_reg(core, op->reg) && op->disp >= (st64)ptr_size(core) &&
+		!(op->disp % (st64)ptr_size(core)) &&
+		(op->type & (RZ_ANALYSIS_OP_TYPE_IND | RZ_ANALYSIS_OP_TYPE_MEM)) &&
+		(rz_analysis_op_is_call(op) || rz_analysis_op_is_eob(op));
+}
+
+static bool op_is_register_target_dispatch(RzCore *core, RzAnalysisOp *op) {
+	return is_valid_reg(core, op->reg) && (op->type & RZ_ANALYSIS_OP_TYPE_REG) &&
+		!(op->type & (RZ_ANALYSIS_OP_TYPE_IND | RZ_ANALYSIS_OP_TYPE_MEM)) &&
+		(rz_analysis_op_is_call(op) || rz_analysis_op_is_eob(op));
+}
+
+static void track_init(RzCore *core, RZ_NULLABLE const DlangCallSeed *seed) {
+	rz_core_analysis_esil_init_mem(core, NULL, DLANG_TRACK_MEM_ADDR, DLANG_TRACK_MEM_SIZE);
+	rz_core_analysis_il_reinit(core);
+	if (rz_asm_is_arch(core->rasm, "x86")) {
+		rz_analysis_il_vm_set_unsigned(core->analysis, "rbp", DLANG_STACK_PTR);
+		rz_analysis_il_vm_set_unsigned(core->analysis, "rsp", DLANG_STACK_PTR);
+	} else if (rz_asm_is_arch(core->rasm, "arm")) {
+		rz_analysis_il_vm_set_unsigned(core->analysis, "x29", DLANG_STACK_PTR);
+		rz_analysis_il_vm_set_unsigned(core->analysis, "sp", DLANG_STACK_PTR);
+	} else {
+		RZ_LOG_WARN("arch %s is not supported\n", rz_core_get_arch(core));
+	}
+	if (!seed) {
+		return;
+	}
+
+	ut64 psize = ptr_size(core);
+	bool big_endian = rz_asm_is_big_endian_set(core->rasm);
+	for (ut64 i = 0; i < seed->count; i++) {
+		if (!seed->has_vtable[i]) {
+			continue;
+		}
+		ut64 object_addr = DLANG_OBJECT_ADDR + i * 2 * psize;
+		rz_analysis_il_vm_set_unsigned(core->analysis, seed->regs[i], object_addr);
+		ut64 vtable_addr = seed->vtables[i];
+		rz_io_write_i(core->io, object_addr, &vtable_addr, psize, big_endian);
+	}
+}
+
+static void track_fini(RzCore *core) {
+	rz_core_analysis_il_reinit(core);
+	rz_core_analysis_esil_init_mem_del(core, NULL, DLANG_TRACK_MEM_ADDR, DLANG_TRACK_MEM_SIZE);
+}
+
+static ut64 allocate_object(RzCore *core, ut64 class_info_addr, ut64 object_addr) {
+	DlangClassInfo info = { 0 };
+	if (!class_info(core, class_info_addr, &info) || !info.init_size || !info.init_addr ||
+		!range_is_readable(core, info.init_addr, info.init_size, 1)) {
+		return 0;
+	}
+	ut64 mem_end = DLANG_TRACK_MEM_ADDR + DLANG_TRACK_MEM_SIZE;
+	if (object_addr >= mem_end || info.init_size > mem_end - object_addr) {
+		return 0;
+	}
+	ut8 *bytes = malloc(info.init_size);
+	if (!bytes) {
+		return 0;
+	}
+	bool ok = rz_io_read_at_mapped(core->io, info.init_addr, bytes, info.init_size) &&
+		rz_io_write_at(core->io, object_addr, bytes, info.init_size);
+	RZ_FREE(bytes);
+	if (!ok) {
+		return 0;
+	}
+	return info.init_size;
+}
+
+static void clear_dst_reg_for_skipped_op(RzCore *core, RzAnalysisOp *op) {
+	const char *dst = op_dst_reg_name(op);
+	if (is_valid_reg(core, dst)) {
+		rz_analysis_il_vm_set_unsigned(core->analysis, dst, 0);
+	}
+}
+
+static void track_step_or_skip(RzCore *core, RzAnalysisOp *op, ut64 next_addr) {
+	if (!op->il_op || !op_memory_access_is_safe(core, op)) {
+		clear_dst_reg_for_skipped_op(core, op);
+		advance_il_pc(core, next_addr);
+		return;
+	}
+	advance_il_pc(core, op->addr);
+	if (!rz_core_il_step(core, 1)) {
+		advance_il_pc(core, next_addr);
+	}
+}
+
+static void add_virtual_xref(RzAnalysis *analysis, const char *method_name, ut64 addr) {
+	HtSP *virtual_xrefs = rz_analysis_get_virtual_xrefs(analysis);
+	if (!virtual_xrefs || RZ_STR_ISEMPTY(method_name)) {
+		return;
+	}
+	bool found = false;
+	RzSetU *set = ht_sp_find(virtual_xrefs, method_name, &found);
+	if (!found) {
+		set = rz_set_u_new();
+		if (!set || !ht_sp_insert(virtual_xrefs, method_name, set)) {
+			rz_set_u_free(set);
+			return;
+		}
+	}
+	rz_set_u_add(set, addr);
+}
+
+static void add_virtual_xrefs_for_method(RzCore *core, const char *method_name, ut64 method_addr, ut64 xref_addr) {
+	add_virtual_xref(core->analysis, method_name, xref_addr);
+	const RzList *flags = rz_flag_get_list(core->flags, method_addr);
+	RzListIter *iter;
+	RzFlagItem *flag;
+	rz_list_foreach (flags, iter, flag) {
+		if (RZ_STR_ISNOTEMPTY(flag->name) && strcmp(flag->name, method_name)) {
+			add_virtual_xref(core->analysis, flag->name, xref_addr);
+		}
+	}
+}
+
+static void virtual_calls_add(RzCore *core, HtUP *calls, ut64 call_addr, DlangKnownMethod *method) {
+	if (!calls || !method || RZ_STR_ISEMPTY(method->name)) {
+		return;
+	}
+	bool found = false;
+	RzSetS *set = ht_up_find(calls, call_addr, &found);
+	if (!found) {
+		set = rz_set_s_new(HT_STR_DUP);
+		if (!set || !ht_up_insert(calls, call_addr, set)) {
+			rz_set_s_free(set);
+			return;
+		}
+	}
+	rz_set_s_add(set, method->name);
+	add_virtual_xrefs_for_method(core, method->name, method->addr, call_addr);
+}
+
+typedef struct dlang_comment_context_t {
+	RzStrBuf *text;
+	bool first;
+} DlangCommentContext;
+
+static bool virtual_comment_add_name(void *user, const char *name, RZ_UNUSED const void *value) {
+	DlangCommentContext *context = user;
+	if (context->first) {
+		rz_strbuf_setf(context->text, "Virtual call: %s", name);
+		context->first = false;
+	} else {
+		rz_strbuf_appendf(context->text, " / %s", name);
+	}
+	return true;
+}
+
+static bool virtual_comment_emit(void *user, ut64 addr, const void *value) {
+	RzCore *core = user;
+	RzStrBuf text;
+	rz_strbuf_init(&text);
+	DlangCommentContext context = { &text, true };
+	ht_sp_foreach((HtSP *)value, virtual_comment_add_name, &context);
+	const char *comment = rz_strbuf_get(&text);
+	if (RZ_STR_ISNOTEMPTY(comment)) {
+		rz_core_meta_comment_add(core, comment, addr);
+	}
+	rz_strbuf_fini(&text);
+	return true;
+}
+
+static void devirtualize_step(RzCore *core, RzAnalysisOp *op, DlangVTableIndex *index,
+	HtUP *calls, RZ_NULLABLE const DlangCallSeed *seed) {
+	if (op_is_vtable_slot_dispatch(core, op)) {
+		ut64 vtable_addr = get_reg_value(core->analysis, op->reg);
+		DlangKnownVTable *vtable = vtable_by_addr(index, vtable_addr);
+		if (!vtable) {
+			return;
+		}
+		ut64 offset = op->disp;
+		if (is_valid_reg(core, op->ireg)) {
+			ut64 array_index = get_reg_value(core->analysis, op->ireg);
+			ut64 scale = op->scale;
+			if (!scale) {
+				scale = 1;
+			}
+			if (array_index == UT64_MAX) {
+				return;
+			}
+			offset += array_index * scale;
+		}
+		DlangKnownMethod *method = method_at_offset(vtable, offset);
+		if (method) {
+			virtual_calls_add(core, calls, op->addr, method);
+		}
+		return;
+	}
+	if (!op_is_register_target_dispatch(core, op)) {
+		return;
+	}
+	ut64 target = get_reg_value(core->analysis, op->reg);
+	if (!target || !addr_is_executable(core, target)) {
+		return;
+	}
+	DlangKnownVTable *vtable;
+	rz_vector_foreach (index->vtables, vtable) {
+		if (seed) {
+			bool seeded = false;
+			for (ut64 i = 0; i < seed->count; i++) {
+				if (seed->has_vtable[i] && seed->vtables[i] == vtable->addr) {
+					seeded = true;
+					break;
+				}
+			}
+			if (!seeded) {
+				continue;
+			}
+		}
+		DlangKnownMethod *method;
+		rz_vector_foreach (vtable->methods, method) {
+			if (method->addr == target) {
+				virtual_calls_add(core, calls, op->addr, method);
+			}
+		}
+	}
+}
+
+static ut64 allocator_class_info(RzCore *core, RzAnalysisFunction *function) {
+	ut64 result = 0;
+	RzList *xrefs = rz_analysis_function_get_xrefs_from(function);
+	RzListIter *iter;
+	RzAnalysisXRef *xref;
+	rz_list_foreach (xrefs, iter, xref) {
+		DlangClassInfo info = { 0 };
+		if (!class_info(core, xref->to, &info)) {
+			continue;
+		}
+		if (result && result != xref->to) {
+			result = 0;
+			break;
+		}
+		result = xref->to;
+	}
+	rz_list_free(xrefs);
+	return result;
+}
+
+static bool function_is_thunk_to(RzCore *core, RzAnalysisFunction *function, ut64 target) {
+	if (!function || function->addr == target) {
+		return false;
+	}
+	RzAnalysisOp *op = rz_core_analysis_op(core, function->addr, RZ_ANALYSIS_OP_MASK_BASIC);
+	bool result = op && (op->type & RZ_ANALYSIS_OP_TYPE_MASK) == RZ_ANALYSIS_OP_TYPE_JMP &&
+		op->jump == target && rz_analysis_function_max_addr(function) == function->addr + op->size;
+	rz_analysis_op_free(op);
+	return result;
+}
+
+static RZ_OWN RzVector /*<ut64>*/ *call_sites_to(RzCore *core, ut64 target) {
+	RzVector *result = rz_vector_new(sizeof(ut64), NULL, NULL);
+	if (!result) {
+		return NULL;
+	}
+	RzList *xrefs = rz_analysis_xrefs_get_to(core->analysis, target);
+	RzListIter *iter;
+	RzAnalysisXRef *xref;
+	rz_list_foreach (xrefs, iter, xref) {
+		if (xref->type != RZ_ANALYSIS_XREF_TYPE_CALL && xref->type != RZ_ANALYSIS_XREF_TYPE_CODE) {
+			continue;
+		}
+		RzAnalysisFunction *function = rz_analysis_get_fcn_in(core->analysis, xref->from, RZ_ANALYSIS_FCN_TYPE_NULL);
+		if (!function_is_thunk_to(core, function, target)) {
+			rz_vector_push(result, &xref->from);
+			continue;
+		}
+		RzList *thunk_xrefs = rz_analysis_xrefs_get_to(core->analysis, function->addr);
+		RzListIter *thunk_iter;
+		RzAnalysisXRef *thunk_xref;
+		rz_list_foreach (thunk_xrefs, thunk_iter, thunk_xref) {
+			if (thunk_xref->type == RZ_ANALYSIS_XREF_TYPE_CALL || thunk_xref->type == RZ_ANALYSIS_XREF_TYPE_CODE) {
+				rz_vector_push(result, &thunk_xref->from);
+			}
+		}
+		rz_list_free(thunk_xrefs);
+	}
+	rz_list_free(xrefs);
+	return result;
+}
+
+static RZ_OWN RzSetU *allocator_xrefs(RzCore *core, HtUP *known_classes) {
+	RzSetU *result = rz_set_u_new();
+	if (!result) {
+		return NULL;
+	}
+	RzList *functions = rz_analysis_function_list(core->analysis);
+	RzListIter *iter;
+	RzAnalysisFunction *function;
+	rz_list_foreach (functions, iter, function) {
+		if (RZ_STR_ISEMPTY(function->name) || !strstr(function->name, "_d_newclass")) {
+			continue;
+		}
+		ut64 known_class = allocator_class_info(core, function);
+		RzVector *call_sites = call_sites_to(core, function->addr);
+		ut64 *call_site;
+		rz_vector_foreach (call_sites, call_site) {
+			rz_set_u_add(result, *call_site);
+			if (known_class) {
+				ut64 *value = RZ_NEW(ut64);
+				if (value) {
+					*value = known_class;
+					if (!ht_up_insert(known_classes, *call_site, value)) {
+						free(value);
+					}
+				}
+			}
+		}
+		rz_vector_free(call_sites);
+	}
+	return result;
+}
+
+static ut64 replay_allocator(RzCore *core, RzAnalysisOp *op, HtUP *known_classes, const char *arg0, const char *ret_reg, ut64 object_addr) {
+	bool found = false;
+	ut64 *known_class = ht_up_find(known_classes, op->addr, &found);
+	ut64 class_info_addr = get_reg_value(core->analysis, arg0);
+	if (found) {
+		class_info_addr = *known_class;
+	}
+	ut64 object_size = allocate_object(core, class_info_addr, object_addr);
+	if (is_valid_reg(core, ret_reg)) {
+		ut64 result = 0;
+		if (object_size) {
+			result = object_addr;
+		}
+		rz_analysis_il_vm_set_unsigned(core->analysis, ret_reg, result);
+	}
+	advance_il_pc(core, op->addr + op->size);
+	return object_size;
+}
+
+typedef struct dlang_function_replay_context_t {
+	RzCore *core;
+	RzAnalysisFunction *function;
+	ut64 end;
+	DlangVTableIndex *vtable_index;
+	RzSetU *allocator_calls;
+	HtUP *known_classes;
+	const DlangCallSeed *seed;
+	HtUP *calls;
+} DlangFunctionReplayContext;
+
+static bool replay_function(const DlangFunctionReplayContext *context) {
+	RzCore *core = context->core;
+	ut64 start = context->function->addr;
+	ut64 end = context->end;
+	if (!end) {
+		end = rz_analysis_function_max_addr(context->function);
+	}
+	if (!addr_is_executable(core, start)) {
+		return false;
+	}
+	ut8 *bytes = read_mapped_range(core, start, end);
+	RzAnalysisOp *op = rz_analysis_op_new();
+	if (!bytes || !op) {
+		RZ_FREE(bytes);
+		rz_analysis_op_free(op);
+		return false;
+	}
+	const char *cc = rz_analysis_cc_default(core->analysis);
+	const char *arg0 = rz_analysis_cc_arg(core->analysis, cc, 0);
+	const char *ret_reg = rz_analysis_cc_ret(core->analysis, cc);
+	ut64 old_offset = core->offset;
+	ut64 offset = 0;
+	core->offset = start;
+	ut64 next_object = DLANG_OBJECT_ADDR + DLANG_MAX_CALL_ARGS * 2 * ptr_size(core);
+	track_init(core, context->seed);
+	while (start < end) {
+		if (rz_analysis_op(core->analysis, op, start, bytes + offset, end - start, RZ_ANALYSIS_OP_MASK_ALL) <= 0 ||
+			op->size < 1) {
+			break;
+		}
+		devirtualize_step(core, op, context->vtable_index, context->calls, context->seed);
+		ut64 next = start + op->size;
+		if (rz_set_u_contains(context->allocator_calls, op->addr)) {
+			ut64 size = replay_allocator(core, op, context->known_classes, arg0, ret_reg, next_object);
+			next_object += RZ_ROUND(size, ptr_size(core));
+		} else if ((op->type & RZ_ANALYSIS_OP_TYPE_MASK) == RZ_ANALYSIS_OP_TYPE_JMP &&
+			op->jump > next && op->jump <= end) {
+			next = op->jump;
+			advance_il_pc(core, next);
+		} else if (rz_analysis_op_is_call(op) || rz_analysis_op_is_eob(op)) {
+			advance_il_pc(core, next);
+		} else {
+			track_step_or_skip(core, op, next);
+		}
+		start = next;
+		offset = start - context->function->addr;
+		core->offset = start;
+		rz_analysis_op_fini(op);
+	}
+	core->offset = old_offset;
+	rz_analysis_op_free(op);
+	free(bytes);
+	return true;
+}
+
+static void get_arg_regs(RzCore *core, RZ_OUT DlangCallSeed *args) {
+	const char *cc = rz_analysis_cc_default(core->analysis);
+	for (ut64 i = 0; i < DLANG_MAX_CALL_ARGS; i++) {
+		const char *reg = rz_analysis_cc_arg(core->analysis, cc, i);
+		if (!is_valid_reg(core, reg)) {
+			break;
+		}
+		args->regs[args->count++] = reg;
+	}
+}
+
+static bool seed_equal(const DlangCallSeed *a, const DlangCallSeed *b) {
+	if (a->count != b->count) {
+		return false;
+	}
+	for (ut64 i = 0; i < a->count; i++) {
+		if (a->has_vtable[i] != b->has_vtable[i] ||
+			(a->has_vtable[i] && a->vtables[i] != b->vtables[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static void push_unique_seed(RzVector /*<DlangCallSeed>*/ *seeds, const DlangCallSeed *seed) {
+	bool has_vtable = false;
+	for (ut64 i = 0; i < seed->count; i++) {
+		if (seed->has_vtable[i]) {
+			has_vtable = true;
+			break;
+		}
+	}
+	if (!has_vtable) {
+		return;
+	}
+	DlangCallSeed *existing;
+	rz_vector_foreach (seeds, existing) {
+		if (seed_equal(existing, seed)) {
+			return;
+		}
+	}
+	rz_vector_push(seeds, (DlangCallSeed *)seed);
+}
+
+static void collect_caller_args_from_site(RzCore *core, RzAnalysisFunction *caller, ut64 call_addr,
+	const DlangCallerReplayContext *context, RzVector /*<DlangCallSeed>*/ *seeds) {
+	if (call_addr <= caller->addr) {
+		return;
+	}
+	DlangFunctionReplayContext replay = {
+		.core = core,
+		.function = caller,
+		.end = RZ_MIN(call_addr, rz_analysis_function_max_addr(caller)),
+		.vtable_index = context->vtable_index,
+		.allocator_calls = context->allocator_calls,
+		.known_classes = context->known_classes,
+	};
+	if (!replay_function(&replay)) {
+		return;
+	}
+
+	DlangCallSeed seed = *context->argument_regs;
+	ut64 psize = ptr_size(core);
+	bool big_endian = rz_asm_is_big_endian_set(core->rasm);
+	for (ut64 i = 0; i < context->argument_regs->count; i++) {
+		ut64 object_addr = get_reg_value(core->analysis, context->argument_regs->regs[i]);
+		ut64 vtable_addr = 0;
+		if (object_addr && rz_io_read_i(core->io, object_addr, &vtable_addr, psize, big_endian) &&
+			vtable_by_addr(context->vtable_index, vtable_addr)) {
+			seed.vtables[i] = vtable_addr;
+			seed.has_vtable[i] = true;
+		}
+	}
+	push_unique_seed(seeds, &seed);
+	track_fini(core);
+}
+
+static RZ_OWN RzVector /*<DlangCallSeed>*/ *collect_caller_args(RzCore *core,
+	RzAnalysisFunction *function, const DlangCallerReplayContext *context) {
+	RzVector *seeds = rz_vector_new(sizeof(DlangCallSeed), NULL, NULL);
+	if (!seeds) {
+		return NULL;
+	}
+	RzVector *call_sites = call_sites_to(core, function->addr);
+	ut64 *call_site;
+	rz_vector_foreach (call_sites, call_site) {
+		RzAnalysisFunction *caller = rz_analysis_get_fcn_in(core->analysis, *call_site, RZ_ANALYSIS_FCN_TYPE_NULL);
+		if (caller) {
+			collect_caller_args_from_site(core, caller, *call_site, context, seeds);
+		}
+	}
+	rz_vector_free(call_sites);
+	return seeds;
+}
+
+/**
+ * \brief Resolve D virtual call targets in the current function.
+ *
+ * Replays the function with RzIL, propagating ClassInfo allocations and
+ * receiver types from callers, then adds comments and virtual xrefs for resolved
+ * class and interface methods
+ */
+RZ_IPI void rz_core_analysis_devirtualize_dlang_methods(RZ_NULLABLE RzCore *core) {
+	if (!core) {
+		return;
+	}
+	RzAnalysisFunction *function = rz_analysis_get_fcn_in(core->analysis, core->offset, RZ_ANALYSIS_FCN_TYPE_NULL);
+	if (!function) {
+		RZ_LOG_ERROR("Cannot find function at 0x%08" PFMT64x "\n", core->offset);
+		return;
+	}
+	DlangVTableIndex *index = vtable_index_new(core);
+	if (!index) {
+		return;
+	}
+	HtUP *known_classes = ht_up_new(NULL, free);
+	RzSetU *allocator_calls = NULL;
+	if (known_classes) {
+		allocator_calls = allocator_xrefs(core, known_classes);
+	}
+	if (!known_classes || !allocator_calls) {
+		ht_up_free(known_classes);
+		rz_set_u_free(allocator_calls);
+		vtable_index_free(index);
+		return;
+	}
+	DlangCallSeed args = { 0 };
+	get_arg_regs(core, &args);
+	RzVector *seeds = NULL;
+	if (args.count) {
+		DlangCallerReplayContext context = {
+			.vtable_index = index,
+			.allocator_calls = allocator_calls,
+			.known_classes = known_classes,
+			.argument_regs = &args,
+		};
+		seeds = collect_caller_args(core, function, &context);
+	}
+
+	HtUP *calls = ht_up_new(NULL, (HtUPFreeValue)rz_set_s_free);
+	if (!calls) {
+		rz_vector_free(seeds);
+		rz_set_u_free(allocator_calls);
+		ht_up_free(known_classes);
+		vtable_index_free(index);
+		return;
+	}
+	DlangFunctionReplayContext replay = {
+		.core = core,
+		.function = function,
+		.vtable_index = index,
+		.allocator_calls = allocator_calls,
+		.known_classes = known_classes,
+		.calls = calls,
+	};
+
+	if (replay_function(&replay)) {
+		track_fini(core);
+	}
+	DlangCallSeed *seed;
+	rz_vector_foreach (seeds, seed) {
+		replay.seed = seed;
+		if (replay_function(&replay)) {
+			track_fini(core);
+		}
+	}
+	ht_up_foreach(calls, virtual_comment_emit, core);
+	ht_up_free(calls);
+	rz_vector_free(seeds);
+	rz_set_u_free(allocator_calls);
+	ht_up_free(known_classes);
+	vtable_index_free(index);
+}

--- a/librz/core/meson.build
+++ b/librz/core/meson.build
@@ -53,6 +53,7 @@ rz_core_sources = [
   'ctypes.c',
   'cvfile.c',
   'devirtualize_cxx.c',
+  'devirtualize_dlang.c',
   'devirtualize_objc.c',
   'disasm.c',
   'fortune.c',

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -2091,6 +2091,7 @@ RZ_API void rz_analysis_rtti_msvc_print_class_hierarchy_descriptor(RVTableContex
 RZ_API void rz_analysis_rtti_msvc_print_base_class_descriptor(RVTableContext *context, ut64 addr, int mode);
 RZ_API bool rz_analysis_rtti_msvc_print_at_vtable(RVTableContext *context, ut64 addr, RzOutputMode mode, bool strict);
 RZ_API void rz_analysis_rtti_msvc_recover_all(RVTableContext *vt_context, RzList /*<RVTableInfo *>*/ *vtables);
+RZ_API void rz_analysis_rtti_dlang(RZ_NONNULL RzAnalysis *analysis);
 RZ_API void rz_analysis_rtti_swift(RzAnalysis *analysis);
 RZ_API void rz_analysis_rtti_objc(RZ_NONNULL RzAnalysis *analysis);
 

--- a/test/db/cmd/cmd_ac
+++ b/test/db/cmd/cmd_ac
@@ -639,3 +639,121 @@ attr.Flaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 attrtypes.Flaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaatline=vtable,method
 EOF
 RUN
+
+NAME=dlang class RTTI
+FILE=bins/elf/analysis/class_dlang
+CMDS=<<EOF
+aaa
+acvl class_dlang_Polygon
+acbl class_dlang_Rectangle
+acvl class_dlang_Triangle
+acil class_dlang_Rectangle
+EOF
+EXPECT=<<EOF
+class_dlang_Polygon:
+     0 vtable 0xa40e0 @ +0x0 size:+0x40
+class_dlang_Rectangle:
+     0 class_dlang_Polygon @ +0x0
+class_dlang_Triangle:
+     0 vtable 0xa4300 @ +0x0 size:+0x40
+[class_dlang_Rectangle: class_dlang_Polygon]
+  (vtable at 0xa41f0)
+nth       addr  vt_offset type        name                                                   
+---------------------------------------------------------------------------------------------
+  1 0x0004e9e0 0x00000008 VIRTUAL     sym.immutable_char____object.Object.toString
+  2 0x0004e9f0 0x00000010 VIRTUAL     sym.nothrow__trusted_ulong_object.Object.toHash
+  3 0x0004e9fc 0x00000018 VIRTUAL     sym.int_object.Object.opCmp_Object
+  4 0x0004ea88 0x00000020 VIRTUAL     sym.bool_object.Object.opEquals_Object
+  5 0x0004d864 0x00000028 VIRTUAL     sym.void_class_dlang.Polygon.set_values_int__int
+  6 0x0004d890 0x00000030 VIRTUAL     sym.int_class_dlang.Rectangle.area
+  7 0x0004d898 0x00000038 VIRTUAL     sym.int_class_dlang.Rectangle.sides
+  8 0x0004d88c ---------- DESTRUCTOR  sym.void_class_dlang.Rectangle.__dtor
+  9 0x0004d874 ---------- CONSTRUCTOR sym.class_dlang.Rectangle_class_dlang.Rectangle.__ctor
+
+EOF
+RUN
+
+NAME=dlang interfaces and vtables
+BROKEN=1
+FILE=bins/elf/dlang_pet
+CMDS=<<EOF
+aaa
+acbl pets_Pet
+acbl pets_Petoverr
+acvl pets_Petoverr
+acil pets_LoudPet
+EOF
+EXPECT=<<EOF
+pets_Pet:
+     0 pets_Speaker @ +0x0
+     1 pets_Runner @ +0x8
+pets_Petoverr:
+     0 pets_BasePet @ +0x0
+     1 pets_Speaker @ +0x28
+     2 pets_Pet @ +0x10
+     3 pets_Runner @ +0x18
+pets_Petoverr:
+     0 vtable 0x485a50 @ +0x0 size:+0x48
+     1 vtable 0x485a08 @ +0x28 size:+0x10
+     2 vtable 0x485a18 @ +0x10 size:+0x20
+     3 vtable 0x485738 @ +0x18 size:+0x10
+[pets_LoudPet: pets_BasePet, pets_Pet, pets_Runner]
+  (vtable at 0x4858c0)
+  (vtable at 0x485888 in class at +0x10)
+  (vtable at 0x485738 in class at +0x18)
+nth       addr  vt_offset type    name                                            
+----------------------------------------------------------------------------------
+  1 0x00400fd0 0x00000008 VIRTUAL sym.immutable_char____object.Object.toString
+  2 0x00400fe0 0x00000010 VIRTUAL sym.nothrow__trusted_ulong_object.Object.toHash
+  3 0x00400fec 0x00000018 VIRTUAL sym.int_object.Object.opCmp_Object
+  4 0x00401060 0x00000020 VIRTUAL sym.bool_object.Object.opEquals_Object
+  5 0x00400bc0 0x00000028 VIRTUAL sym.ulong_pets.LoudPet.speak
+  6 0x00400b64 0x00000030 VIRTUAL sym.ulong_pets.BasePet.runSpeed
+  7 0x00400bd0 0x00000038 VIRTUAL sym.ulong_pets.LoudPet.petValue
+  8 0x00400be0 0x00000040 VIRTUAL sym.ulong_pets.LoudPet.classValue
+  9 0x00400ad8 0x00000008 VIRTUAL sym._THUNK4
+ 10 0x00400ae8 0x00000010 VIRTUAL sym._THUNK5
+ 11 0x00400af8 0x00000018 VIRTUAL sym._THUNK6
+ 12 0x00400ac8 0x00000008 VIRTUAL sym._THUNK3
+
+EOF
+RUN
+
+NAME=dlang class RTTI (MachO)
+FILE=bins/mach0/dlang-hello
+CMDS=<<EOF
+aaa
+acbl TypeInfo_Const
+acvl TypeInfo_Const
+acil TypeInfo_Const
+EOF
+EXPECT=<<EOF
+TypeInfo_Const:
+     0 object_TypeInfo @ +0x0
+TypeInfo_Const:
+     0 vtable 0x100075100 @ +0x0 size:+0x98
+[TypeInfo_Const: object_TypeInfo]
+  (vtable at 0x100075100)
+nth        addr  vt_offset type    name                                                                                 
+------------------------------------------------------------------------------------------------------------------------
+  1 0x100038d40 0x00000008 VIRTUAL sym.const_pure_nothrow__safe_immutable_char____object.TypeInfo_Const.toString
+  2 0x100036e00 0x00000010 VIRTUAL sym.const_nothrow__trusted_ulong_object.TypeInfo.toHash
+  3 0x100036e30 0x00000018 VIRTUAL sym.int_object.TypeInfo.opCmp_Object
+  4 0x100038da0 0x00000020 VIRTUAL sym.bool_object.TypeInfo_Const.opEquals_Object
+  5 0x100036d20 0x00000028 VIRTUAL sym.const_nothrow__safe_ulong_object.TypeInfo_Const.getHash_const_void
+  6 0x100038e60 0x00000030 VIRTUAL sym.const_bool_object.TypeInfo_Const.equals_const_void____const_void
+  7 0x100038e70 0x00000038 VIRTUAL sym.const_int_object.TypeInfo_Const.compare_const_void____const_void
+  8 0x100038e80 0x00000040 VIRTUAL sym.const_pure_nothrow__property__nogc__safe_ulong_object.TypeInfo_Const.tsize
+  9 0x100038e90 0x00000048 VIRTUAL sym.const_void_object.TypeInfo_Const.swap_void___void
+ 10 0x100038ea0 0x00000050 VIRTUAL sym.inout_pure_nothrow__property__nogc_inout_TypeInfo__object.TypeInfo_Const.next
+ 11 0x100038ec0 0x00000058 VIRTUAL sym.const_pure_nothrow__nogc__safe_const_void____object.TypeInfo_Const.initializer
+ 12 0x100038eb0 0x00000060 VIRTUAL sym.const_pure_nothrow__property__nogc__safe_uint_object.TypeInfo_Const.flags
+ 13 0x1000371b0 0x00000068 VIRTUAL sym.const_const_object.OffsetTypeInfo____object.TypeInfo.offTi
+ 14 0x1000371c0 0x00000070 VIRTUAL sym.const_void_object.TypeInfo.destroy_void
+ 15 0x1000371d0 0x00000078 VIRTUAL sym.const_void_object.TypeInfo.postblit_void
+ 16 0x100038ed0 0x00000080 VIRTUAL sym.const_pure_nothrow__property__nogc__safe_ulong_object.TypeInfo_Const.talign
+ 17 0x100038ee0 0x00000088 VIRTUAL sym.nothrow__safe_int_object.TypeInfo_Const.argTypes_out_TypeInfo__out_TypeInfo
+ 18 0x100037200 0x00000090 VIRTUAL sym.const_pure_nothrow__property__nogc__safe_immutable_void___object.TypeInfo.rtInfo
+
+EOF
+RUN

--- a/test/db/cmd/cmd_avD
+++ b/test/db/cmd/cmd_avD
@@ -1259,3 +1259,270 @@ EXPECT=<<EOF
 \           0x100003e94      ret
 EOF
 RUN
+
+NAME=dlang class devirtualization
+FILE=bins/elf/analysis/class_dlang
+CMDS=<<EOF
+aaa
+avD @ 0x4d900
+pdf @ 0x4d900
+avD @ 0x4d8d8
+pdf @ 0x4d8d8
+avD @ 0x4d8f0
+pdf @ 0x4d8f0
+EOF
+EXPECT=<<EOF
+            ; DATA XREF from main @ 0x4d9bc
+            ;-- rip:
+/ sym._Dmain(int64_t arg2);
+|           ; arg int64_t arg2 @ rsi
+|           ; var int64_t var_20h @ stack - 0x20
+|           ; var int64_t var_18h @ stack - 0x18
+|           ; var int64_t var_10h @ stack - 0x10
+|           0x0004d900      push  rbp
+|           0x0004d901      mov   rbp, rsp
+|           0x0004d904      sub   rsp, 0x20
+|           0x0004d908      lea   rdi, qword obj.class_dlang.Polygon.__Class ; D11class_dlang7Polygon7__ClassZ
+|                                                                      ; 0xa4030 ; "pF\n" ; int64_t arg1
+|           0x0004d90f      call  sym._d_newclass
+|           0x0004d914      mov   rdi, rax                             ; int64_t arg1
+|           0x0004d917      call  sym.class_dlang.Polygon_class_dlang.Polygon.__ctor
+|           0x0004d91c      mov   qword [var_20h], rax
+|           0x0004d920      lea   rdi, qword obj.class_dlang.Rectangle.__Class ; D11class_dlang9Rectangle7__ClassZ
+|                                                                      ; 0xa4140 ; "pF\n" ; int64_t arg1
+|           0x0004d927      call  sym._d_newclass
+|           0x0004d92c      mov   rdi, rax                             ; int64_t arg1
+|           0x0004d92f      call  sym.class_dlang.Rectangle_class_dlang.Rectangle.__ctor
+|           0x0004d934      mov   qword [var_18h], rax
+|           0x0004d938      lea   rdi, qword obj.class_dlang.Triangle.__Class ; D11class_dlang8Triangle7__ClassZ
+|                                                                      ; 0xa4250 ; "pF\n" ; int64_t arg1
+|           0x0004d93f      call  sym._d_newclass
+|           0x0004d944      mov   rdi, rax                             ; int64_t arg1
+|           0x0004d947      call  sym.class_dlang.Triangle_class_dlang.Triangle.__ctor
+|           0x0004d94c      mov   qword [var_10h], rax
+|           0x0004d950      mov   edx, 0x04
+|           0x0004d955      mov   esi, 0x05
+|           0x0004d95a      mov   rdi, qword [var_20h]
+|           0x0004d95e      mov   rcx, qword [rdi]
+|           0x0004d961      call  qword [rcx+0x28]                     ; Virtual call: sym.void_class_dlang.Polygon.set_values_int__int
+|           0x0004d965      mov   edx, 0x04
+|           0x0004d96a      mov   esi, 0x05
+|           0x0004d96f      mov   rdi, qword [var_18h]
+|           0x0004d973      mov   rax, qword [rdi]
+|           0x0004d976      call  qword [rax+0x28]                     ; Virtual call: sym.void_class_dlang.Polygon.set_values_int__int
+|           0x0004d97a      mov   edx, 0x04
+|           0x0004d97f      mov   esi, 0x05
+|           0x0004d984      mov   rdi, qword [var_10h]
+|           0x0004d988      mov   rcx, qword [rdi]
+|           0x0004d98b      call  qword [rcx+0x28]                     ; Virtual call: sym.void_class_dlang.Polygon.set_values_int__int
+|           0x0004d98f      mov   rdi, qword [var_20h]                 ; int64_t arg1
+|           0x0004d993      call  sym.void_class_dlang.printArea_class_dlang.Polygon
+|           0x0004d998      mov   rdi, qword [var_20h]                 ; int64_t arg1
+|           0x0004d99c      call  sym.void_class_dlang.printSides_class_dlang.Polygon
+|           0x0004d9a1      mov   rdi, qword [var_18h]                 ; int64_t arg1
+|           0x0004d9a5      call  sym.void_class_dlang.printArea_class_dlang.Polygon
+|           0x0004d9aa      mov   rdi, qword [var_10h]                 ; int64_t arg1
+|           0x0004d9ae      call  sym.void_class_dlang.printArea_class_dlang.Polygon
+|           0x0004d9b3      xor   eax, eax
+|           0x0004d9b5      leave
+\           0x0004d9b6      ret
+            ; CALL XREFS from sym._Dmain @ 0x4d993, 0x4d9a5, 0x4d9ae
+            ;-- rip:
+/ sym.void_class_dlang.printArea_class_dlang.Polygon(int64_t arg1);
+|           ; arg int64_t arg1 @ rdi
+|           0x0004d8d8      push  rbp                                  ; void class_dlang.printArea(class_dlang.Polygon)
+|           0x0004d8d9      mov   rbp, rsp
+|           0x0004d8dc      mov   rax, qword [rdi]                     ; arg1
+|           0x0004d8df      call  qword [rax+0x30]                     ; Virtual call: sym.int_class_dlang.Polygon.area / sym.int_class_dlang.Rectangle.area / sym.int_class_dlang.Triangle.area
+|           0x0004d8e3      mov   edi, eax                             ; int64_t arg1
+|           0x0004d8e5      call  sym._safe_void_std.stdio.writeln__int_.writeln_int
+|           0x0004d8ea      pop   rbp
+\           0x0004d8eb      ret
+            ; CALL XREF from sym._Dmain @ 0x4d99c
+/ sym.void_class_dlang.printSides_class_dlang.Polygon(int64_t arg1);
+|           ; arg int64_t arg1 @ rdi
+|           0x0004d8ec      push  rbp                                  ; void class_dlang.printSides(class_dlang.Polygon)
+|           0x0004d8ed      mov   rbp, rsp
+|           ;-- rip:
+|           0x0004d8f0      mov   rax, qword [rdi]                     ; arg1
+|           0x0004d8f3      call  qword [rax+0x38]                     ; Virtual call: sym.int_class_dlang.Polygon.sides
+|           0x0004d8f7      mov   edi, eax                             ; int64_t arg1
+|           0x0004d8f9      call  sym._safe_void_std.stdio.writeln__int_.writeln_int
+|           0x0004d8fe      pop   rbp
+\           0x0004d8ff      ret
+EOF
+RUN
+
+NAME=dlang devirtualization elf (dlang_pet)
+BROKEN=1
+FILE=bins/elf/dlang_pet
+CMDS=<<EOF
+aaa
+avD @ 0x400c2c
+pdf @ 0x400c2c
+EOF
+EXPECT=<<EOF
+            ; CALL XREFS from dbg._Dmain @ 0x400d1b, 0x400d58, 0x400d93
+            ;-- ulong pets.dispatch(pets.Speaker, pets.Runner, pets.Pet, pets.BasePet):
+            ;-- dbg.ulong_pets.dispatch_pets.Speaker__pets.Runner__pets.Pet__pets.BasePet:
+            ;-- rip:
+/ ulong ulong pets.dispatch(pets.Speaker, pets.Runner, pets.Pet, pets.BasePet)(struct pets.BasePet *base, struct pets.Pet *pet, struct pets.Runner *runner, struct pets.Speaker *speaker)
+|           ; var int64_t arg1 @ rdi
+|           ; var int64_t arg2 @ rsi
+|           ; var int64_t arg3 @ rdx
+|           ; var int64_t arg4 @ rcx
+|           ; var int64_t var_30h @ stack - 0x30
+|           ; var int64_t var_28h @ stack - 0x28
+|           ; var int64_t var_20h @ stack - 0x20
+|           ; var int64_t var_18h @ stack - 0x18
+|           ; var int64_t var_10h @ stack - 0x10
+|           ; arg struct pets.BasePet *base @ stack + 0x344
+|           ; arg struct pets.Pet *pet @ stack + 0x344
+|           ; arg struct pets.Runner *runner @ stack + 0x344
+|           ; arg struct pets.Speaker *speaker @ stack + 0x344
+|           ; var ulong result @ rbx
+|           0x00400c2c      push  rbp                                  ; pets.d:67  ; ulong pets.dispatch(pets.Speaker, pets.Runner, pets.Pet, pets.BasePet)
+|           0x00400c2d      mov   rbp, rsp
+|           0x00400c30      sub   rsp, 0x30
+|           0x00400c34      mov   qword [var_30h], rbx
+|           0x00400c38      mov   qword [var_28h], rdi                 ; arg1
+|           0x00400c3c      mov   qword [var_20h], rsi                 ; arg2
+|           0x00400c40      mov   qword [var_18h], rdx                 ; arg3
+|           0x00400c44      mov   qword [var_10h], rcx                 ; arg4
+|           0x00400c48      mov   rdi, qword [var_10h]                 ; pets.d:68 export extern(D) size_t dispatch(Speaker speaker, Runner runner, Pet pet, BasePet base) {
+|           0x00400c4c      mov   rax, qword [rdi]
+|           0x00400c4f      call  qword [rax+0x08]                     ; 8 ; Virtual call: sym._THUNK4 / loc.unknown_12 / sym._THUNK7
+|           0x00400c53      mov   rbx, rax
+|           0x00400c56      mov   rdi, qword [var_18h]                 ; pets.d:69 size_t result = speaker.speak();
+|           0x00400c5a      mov   rcx, qword [rdi]
+|           0x00400c5d      call  qword [rcx+0x08]                     ; 8 ; Virtual call: sym._THUNK3
+|           0x00400c61      add   rbx, rax
+|           0x00400c64      mov   rdi, qword [var_20h]                 ; pets.d:70 result += runner.runSpeed();
+|           0x00400c68      mov   rdx, qword [rdi]
+|           0x00400c6b      call  qword [rdx+0x18]                     ; 24 ; Virtual call: sym._THUNK2 / sym._THUNK10 / sym._THUNK6
+|           0x00400c6f      add   rbx, rax
+|           0x00400c72      mov   rdi, qword [var_28h]                 ; pets.d:71 result += pet.petValue();
+|           0x00400c76      mov   rax, qword [rdi]
+|           0x00400c79      call  qword [rax+0x40]                     ; 64 ; Virtual call: sym.ulong_pets.LoudPet.classValue / sym.ulong_pets.BasePet.classValue
+|           0x00400c7d      add   rbx, rax
+|           0x00400c80      mov   rax, rbx
+|           0x00400c83      mov   rbx, qword [var_30h]                 ; pets.d:73 return result;
+|           0x00400c87      mov   rsp, rbp
+|           0x00400c8a      pop   rbp
+\           0x00400c8b      ret
+EOF
+RUN
+
+NAME=dlang devirtualization (PE)
+BROKEN=1
+FILE=bins/pe/dlang_pet/dlang_pet.exe
+CMDS=<<EOF
+idp bins/pe/dlang_pet/dlang_pet.pdb
+aaa
+avD @ pdb.dlang_pet._D4pets8dispatchFCQq7SpeakerCQBb6RunnerCQBm3PetCQBu7BasePetZm
+pdf @ pdb.dlang_pet._D4pets8dispatchFCQq7SpeakerCQBb6RunnerCQBm3PetCQBu7BasePetZm
+EOF
+EXPECT=<<EOF
+            ; CODE XREF from sym.dlang_pet_Og.exe_ulong_pets.dispatch_pets.Speaker__pets.Runner__pets.Pet__pets.BasePet @ 0x1400056f5
+            ;-- rip:
+/ pdb.dlang_pet._D4pets8dispatchFCQq7SpeakerCQBb6RunnerCQBm3PetCQBu7BasePetZm(int64_t arg1, int64_t arg2, int64_t arg3, int64_t arg4);
+|           ; arg int64_t arg1 @ rcx
+|           ; arg int64_t arg2 @ rdx
+|           ; arg int64_t arg3 @ r8
+|           ; arg int64_t arg4 @ r9
+|           ; var int64_t var_18h @ stack - 0x18
+|           ; var int64_t var_10h @ stack - 0x10
+|           ; var int64_t var_8h @ stack + 0x8
+|           ; var int64_t var_20h @ stack + 0x20
+|           0x14000cb50      push  rbp
+|           0x14000cb51      mov   rbp, rsp
+|           0x14000cb54      sub   rsp, 0x30
+|           0x14000cb58      mov   qword [var_18h], rbx
+|           0x14000cb5c      mov   qword [var_10h], rsi
+|           0x14000cb60      mov   qword [var_8h], rcx                 ; arg1
+|           0x14000cb64      mov   qword [var_8h + 0x8], rdx           ; arg2
+|           0x14000cb68      mov   qword [var_8h + 0x10], r8           ; arg3
+|           0x14000cb6c      mov   qword [var_20h], r9                 ; arg4
+|           0x14000cb70      mov   rcx, qword [var_20h]
+|           0x14000cb74      mov   rax, qword [rcx]
+|           0x14000cb77      call  qword [rax+0x08]                    ; 8 ; Virtual call: interface_0x10_0x8 / interface_0x28_0x8
+|           0x14000cb7b      mov   rsi, rax
+|           0x14000cb7e      mov   rcx, qword [var_8h + 0x10]
+|           0x14000cb82      mov   rdx, qword [rcx]
+|           0x14000cb85      call  qword [rdx+0x08]                    ; 8 ; Virtual call: interface_0x18_0x8
+|           0x14000cb89      add   rsi, rax
+|           0x14000cb8c      mov   rcx, qword [var_8h + 0x8]
+|           0x14000cb90      mov   rbx, qword [rcx]
+|           0x14000cb93      call  qword [rbx+0x18]                    ; 24 ; Virtual call: interface_0x10_0x18
+|           0x14000cb97      add   rsi, rax
+|           0x14000cb9a      mov   rcx, qword [var_8h]
+|           0x14000cb9e      mov   rax, qword [rcx]
+|           0x14000cba1      call  qword [rax+0x40]                    ; 64 ; Virtual call: virtual_0x40
+|           0x14000cba5      add   rsi, rax
+|           0x14000cba8      mov   rax, rsi
+|           0x14000cbab      mov   rbx, qword [var_18h]
+|           0x14000cbaf      mov   rsi, qword [var_10h]
+|           0x14000cbb3      mov   rsp, rbp
+|           0x14000cbb6      pop   rbp
+\           0x14000cbb7      ret
+EOF
+RUN
+
+NAME=dlang devirtualization (MachO)
+FILE=bins/mach0/dlang-hello
+CMDS=<<EOF
+aaa
+avD @ 0x100001eb0
+pdf @ 0x100001eb0
+EOF
+EXPECT=<<EOF
+            ;-- func.100001eb0:
+            ;-- rip:
+/ sym.nothrow__trusted_ulong_std.bitmanip.FloatRep.__xtoHash_ref_const_std.bitmanip.FloatRep(int64_t arg1);
+|           ; arg int64_t arg1 @ rdi
+|           0x100001eb0      push  r14                                 ; nothrow @trusted ulong std.bitmanip.FloatRep.__xtoHash(ref const(std.bitmanip.FloatRep))
+|           0x100001eb2      push  rbx
+|           0x100001eb3      push  rax
+|           0x100001eb4      mov   rbx, rdi                            ; arg1
+|           0x100001eb7      mov   rdi, qword [reloc.TypeInfo_xf.__init] ; [0x100072030:8]=0x100079f80 sym.TypeInfo_xf.__init
+|           0x100001ebe      mov   rax, qword [rdi]
+|           0x100001ec1      mov   rsi, rbx
+|           0x100001ec4      call  qword [rax+0x28]                    ; 40 ; Virtual call: sym.const_nothrow__safe_ulong_object.TypeInfo_Const.getHash_const_void
+|           0x100001ec7      mov   r14, rax
+|           0x100001eca      mov   rdi, qword [reloc.TypeInfo_xk.__init] ; [0x100072048:8]=0x1000779d0 rdi
+|           0x100001ed1      mov   rax, qword [rdi]
+|           0x100001ed4      mov   rsi, rbx
+|           0x100001ed7      call  qword [rax+0x28]                    ; 40 ; Virtual call: sym.const_nothrow__safe_ulong_object.TypeInfo_Const.getHash_const_void
+|           0x100001eda      add   rax, r14
+|           0x100001edd      add   rsp, 0x08
+|           0x100001ee1      pop   rbx
+|           0x100001ee2      pop   r14
+\           0x100001ee4      ret
+EOF
+RUN
+
+NAME=dlang devirtualization (elf)
+FILE=bins/elf/analysis/class_dlang
+CMDS=<<EOF
+aaa
+acvl class_dlang_Polygon
+avD @ 0x4d8d8
+pdf @ 0x4d8d8
+EOF
+EXPECT=<<EOF
+class_dlang_Polygon:
+     0 vtable 0xa40e0 @ +0x0 size:+0x40
+            ; CALL XREFS from sym._Dmain @ 0x4d993, 0x4d9a5, 0x4d9ae
+            ;-- rip:
+/ sym.void_class_dlang.printArea_class_dlang.Polygon(int64_t arg1);
+|           ; arg int64_t arg1 @ rdi
+|           0x0004d8d8      push  rbp                                  ; void class_dlang.printArea(class_dlang.Polygon)
+|           0x0004d8d9      mov   rbp, rsp
+|           0x0004d8dc      mov   rax, qword [rdi]                     ; arg1
+|           0x0004d8df      call  qword [rax+0x30]                     ; Virtual call: sym.int_class_dlang.Polygon.area / sym.int_class_dlang.Rectangle.area / sym.int_class_dlang.Triangle.area
+|           0x0004d8e3      mov   edi, eax                             ; int64_t arg1
+|           0x0004d8e5      call  sym._safe_void_std.stdio.writeln__int_.writeln_int
+|           0x0004d8ea      pop   rbp
+\           0x0004d8eb      ret
+EOF
+RUN

--- a/test/db/cmd/cmd_avx
+++ b/test/db/cmd/cmd_avx
@@ -83,3 +83,16 @@ C 0x1000077c0 bl sym.imp.objc_msgSend
 0x1000077c0
 EOF
 RUN
+
+NAME=dlang virtual xrefs
+FILE=bins/elf/analysis/class_dlang
+CMDS=<<EOF
+aaa
+avD @ 0x4d8d8
+avx sym.int_class_dlang.Rectangle.area
+EOF
+EXPECT=<<EOF
+Virtual xrefs to sym.int_class_dlang.Rectangle.area
+C 0x0004d8df call qword [rax+0x30]
+EOF
+RUN


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
This adds dlang RTTI recovery and devirtualization

dlang stores runtime type information in `ClassInfo` structures containing class names, inheritance, interfaces, initializers, constructors and vtables
This PR discovers these structures through symbols then recovers classes, base relations, interfaces, methods and vtables

Tracks RzIL state while replaying functions and callers, propagates types from dlang class allocators and ABI argument registers, and uses recovered class and interface vtables to resolve virtual calls

(dlang refers to only the dmd ABI spec here)

Reference:
https://dlang.org/spec/abi.html


**Test plan**
Adds tests in `cmd_avD` `cmd_ac` and `cmd_avx`

A few tests are marked BROKEN since it has not been merged in testbins

**Closing issues**
none
