### PR TITLE
Replace m680x configure time check with version check

### DIFF
--- a/librz/arch/p/analysis/analysis_m680x_cs.c
+++ b/librz/arch/p/analysis/analysis_m680x_cs.c
@@ -174,7 +174,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_SWI2:
 	case M680X_INS_SWI3:
 	case M680X_INS_BGND:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_TRAP:
 	case M680X_INS_SYS:
 #endif
@@ -209,7 +209,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_INS:
 	case M680X_INS_INX:
 	case M680X_INS_INY:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_ADDX:
 	case M680X_INS_ADDY:
 	case M680X_INS_ADED:
@@ -244,7 +244,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_DES:
 	case M680X_INS_DEX:
 	case M680X_INS_DEY:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_SBED:
 	case M680X_INS_SBEX:
 	case M680X_INS_SBEY:
@@ -281,7 +281,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_BAND:
 	case M680X_INS_BCLR:
 	case M680X_INS_BIAND:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_ANDX:
 	case M680X_INS_ANDY:
 #endif
@@ -298,7 +298,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_ORR:
 	case M680X_INS_OIM:
 	case M680X_INS_BSET:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_ORX:
 	case M680X_INS_ORY:
 	case M680X_INS_BTAS:
@@ -313,7 +313,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_EORB:
 	case M680X_INS_EORD:
 	case M680X_INS_EORR:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_EORX:
 	case M680X_INS_EORY:
 #endif
@@ -332,7 +332,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_NEGB:
 	case M680X_INS_NEGD:
 	case M680X_INS_NEGX:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_COMY:
 	case M680X_INS_NEGW:
 	case M680X_INS_NEGY:
@@ -348,7 +348,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_LSLB:
 	case M680X_INS_LSLD:
 	case M680X_INS_LSLX:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_ASLW:
 	case M680X_INS_ASLX:
 	case M680X_INS_ASLY:
@@ -361,7 +361,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_ASRB:
 	case M680X_INS_ASRD:
 	case M680X_INS_ASRX:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_ASRW:
 	case M680X_INS_ASRY:
 #endif
@@ -373,7 +373,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_LSRD:
 	case M680X_INS_LSRW:
 	case M680X_INS_LSRX:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_LSRY:
 	case M680X_INS_SHA:
 #endif
@@ -385,7 +385,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_ROLD:
 	case M680X_INS_ROLW:
 	case M680X_INS_ROLX:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_ROLY:
 #endif
 		op->type = RZ_ANALYSIS_OP_TYPE_ROL;
@@ -396,7 +396,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_RORD:
 	case M680X_INS_RORW:
 	case M680X_INS_RORX:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_RORY:
 #endif
 		op->type = RZ_ANALYSIS_OP_TYPE_ROR;
@@ -442,7 +442,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_BITD:
 	case M680X_INS_BITMD:
 	case M680X_INS_TIM:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_CPED:
 	case M680X_INS_CPES:
 	case M680X_INS_CPEX:
@@ -464,7 +464,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_PSHUW:
 	case M680X_INS_PSHX:
 	case M680X_INS_PSHY:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_PSHCW:
 #endif
 		op->type = RZ_ANALYSIS_OP_TYPE_PUSH;
@@ -480,7 +480,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_PULUW:
 	case M680X_INS_PULX:
 	case M680X_INS_PULY:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_PULCW:
 #endif
 		op->type = RZ_ANALYSIS_OP_TYPE_POP;
@@ -507,7 +507,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_LEAY:
 	case M680X_INS_ETBL:
 	case M680X_INS_TBL:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_GLDAA:
 	case M680X_INS_GLDAB:
 	case M680X_INS_GLDD:
@@ -532,7 +532,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_STW:
 	case M680X_INS_STX:
 	case M680X_INS_STY:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_GSTAA:
 	case M680X_INS_GSTAB:
 	case M680X_INS_GSTD:
@@ -567,7 +567,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_CLRH:
 	case M680X_INS_CLRW:
 	case M680X_INS_CLRX:
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	case M680X_INS_CLRY:
 #endif
 		op->type = RZ_ANALYSIS_OP_TYPE_MOV;

--- a/librz/arch/p/analysis/analysis_m680x_cs.c
+++ b/librz/arch/p/analysis/analysis_m680x_cs.c
@@ -7,12 +7,13 @@
 
 #include <capstone/m680x.h>
 
-#define OP(x)   insn->detail->m680x.operands[x]
-#define TYPE(x) OP(x).type
-#define IMM(x)  OP(x).imm
-#define REL(x)  OP(x).rel
-#define EXT(x)  OP(x).ext
-#define DIR(x)  OP(x).direct_addr
+#define OP(x)           insn->detail->m680x.operands[x]
+#define TYPE(x)         OP(x).type
+#define IMM(x)          OP(x).imm
+#define REL(x)          OP(x).rel
+#define EXT(x)          OP(x).ext
+#define DIR(x)          OP(x).direct_addr
+#define CAPSTONE6ALPHA9 (CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9)
 
 typedef struct {
 	csh handle;
@@ -174,7 +175,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_SWI2:
 	case M680X_INS_SWI3:
 	case M680X_INS_BGND:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_TRAP:
 	case M680X_INS_SYS:
 #endif
@@ -209,7 +210,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_INS:
 	case M680X_INS_INX:
 	case M680X_INS_INY:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_ADDX:
 	case M680X_INS_ADDY:
 	case M680X_INS_ADED:
@@ -244,7 +245,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_DES:
 	case M680X_INS_DEX:
 	case M680X_INS_DEY:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_SBED:
 	case M680X_INS_SBEX:
 	case M680X_INS_SBEY:
@@ -281,7 +282,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_BAND:
 	case M680X_INS_BCLR:
 	case M680X_INS_BIAND:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_ANDX:
 	case M680X_INS_ANDY:
 #endif
@@ -298,7 +299,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_ORR:
 	case M680X_INS_OIM:
 	case M680X_INS_BSET:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_ORX:
 	case M680X_INS_ORY:
 	case M680X_INS_BTAS:
@@ -313,7 +314,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_EORB:
 	case M680X_INS_EORD:
 	case M680X_INS_EORR:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_EORX:
 	case M680X_INS_EORY:
 #endif
@@ -332,7 +333,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_NEGB:
 	case M680X_INS_NEGD:
 	case M680X_INS_NEGX:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_COMY:
 	case M680X_INS_NEGW:
 	case M680X_INS_NEGY:
@@ -348,7 +349,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_LSLB:
 	case M680X_INS_LSLD:
 	case M680X_INS_LSLX:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_ASLW:
 	case M680X_INS_ASLX:
 	case M680X_INS_ASLY:
@@ -361,7 +362,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_ASRB:
 	case M680X_INS_ASRD:
 	case M680X_INS_ASRX:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_ASRW:
 	case M680X_INS_ASRY:
 #endif
@@ -373,7 +374,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_LSRD:
 	case M680X_INS_LSRW:
 	case M680X_INS_LSRX:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_LSRY:
 	case M680X_INS_SHA:
 #endif
@@ -385,7 +386,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_ROLD:
 	case M680X_INS_ROLW:
 	case M680X_INS_ROLX:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_ROLY:
 #endif
 		op->type = RZ_ANALYSIS_OP_TYPE_ROL;
@@ -396,7 +397,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_RORD:
 	case M680X_INS_RORW:
 	case M680X_INS_RORX:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_RORY:
 #endif
 		op->type = RZ_ANALYSIS_OP_TYPE_ROR;
@@ -442,7 +443,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_BITD:
 	case M680X_INS_BITMD:
 	case M680X_INS_TIM:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_CPED:
 	case M680X_INS_CPES:
 	case M680X_INS_CPEX:
@@ -464,7 +465,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_PSHUW:
 	case M680X_INS_PSHX:
 	case M680X_INS_PSHY:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_PSHCW:
 #endif
 		op->type = RZ_ANALYSIS_OP_TYPE_PUSH;
@@ -480,7 +481,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_PULUW:
 	case M680X_INS_PULX:
 	case M680X_INS_PULY:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_PULCW:
 #endif
 		op->type = RZ_ANALYSIS_OP_TYPE_POP;
@@ -507,7 +508,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_LEAY:
 	case M680X_INS_ETBL:
 	case M680X_INS_TBL:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_GLDAA:
 	case M680X_INS_GLDAB:
 	case M680X_INS_GLDD:
@@ -532,7 +533,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_STW:
 	case M680X_INS_STX:
 	case M680X_INS_STY:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_GSTAA:
 	case M680X_INS_GSTAB:
 	case M680X_INS_GSTD:
@@ -567,7 +568,7 @@ static int analyze_op(RzAnalysis *a, RzAnalysisOp *op, ut64 addr, const ut8 *buf
 	case M680X_INS_CLRH:
 	case M680X_INS_CLRW:
 	case M680X_INS_CLRX:
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	case M680X_INS_CLRY:
 #endif
 		op->type = RZ_ANALYSIS_OP_TYPE_MOV;

--- a/librz/arch/p/arch_m680x_cs.c
+++ b/librz/arch/p/arch_m680x_cs.c
@@ -5,6 +5,8 @@
 #include <deprecated_arch_helper.h>
 #include <capstone/capstone.h>
 
+#define CAPSTONE6ALPHA9 (CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9)
+
 static inline cs_mode m680x_mode(const char *str) {
 	if (!str) {
 		return CS_MODE_M680X_6800;
@@ -31,7 +33,7 @@ static inline cs_mode m680x_mode(const char *str) {
 	} else if (rz_str_casestr(str, "hcs08")) {
 		return CS_MODE_M680X_HCS08;
 	}
-#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
+#if CAPSTONE6ALPHA9
 	else if (rz_str_casestr(str, "rs08")) {
 		return CS_MODE_M680X_RS08;
 	} else if (rz_str_casestr(str, "hcs12x")) {

--- a/librz/arch/p/arch_m680x_cs.c
+++ b/librz/arch/p/arch_m680x_cs.c
@@ -31,7 +31,7 @@ static inline cs_mode m680x_mode(const char *str) {
 	} else if (rz_str_casestr(str, "hcs08")) {
 		return CS_MODE_M680X_HCS08;
 	}
-#ifdef RZ_CAPSTONE_HAS_M680X_HCS12X
+#if CS_API_MAJOR >= 6 && CS_VERSION_PRE_RELEASE >= CS_VERSION_ALPHA9
 	else if (rz_str_casestr(str, "rs08")) {
 		return CS_MODE_M680X_RS08;
 	} else if (rz_str_casestr(str, "hcs12x")) {

--- a/meson.build
+++ b/meson.build
@@ -245,21 +245,6 @@ if has_capstone_m68k_coldfire
   add_project_arguments(['-DRZ_CAPSTONE_HAS_M68K_COLDFIRE'], language: 'c')
 endif
 
-has_capstone_m680x_hcs12x = cc.compiles('''
-#include <capstone/capstone.h>
-int main(void) {
-        cs_mode mode = CS_MODE_M680X_HCS12X;
-        return mode == 0;
-}
-''',
-  dependencies: capstone_check_deps,
-  include_directories: capstone_check_includes,
-  name: 'Capstone has M680X HCS12X mode'
-)
-if has_capstone_m680x_hcs12x
-  add_project_arguments(['-DRZ_CAPSTONE_HAS_M680X_HCS12X'], language: 'c')
-endif
-
 # Handle PCRE2
 cpu_jit_supported = [ 'aarch64', 'arm', 'mips', 'mips64', 'ppc', 'ppc64', 'riscv32', 'riscv64', 's390x', 'x86', 'x86_64' ]
 pcre2_jit_supported = target_machine.cpu_family() in cpu_jit_supported and cc.get_id() != 'tcc' and target_machine.system() not in ['darwin', 'serenity']


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**
Replace the meson m680x configure time check with capstone version checks (using `CS_VERSION_PRE_RELEASE`) 

There are 2 more meson configure time checks, for m68k. Since they were added before alpha9, `CS_VERSION_PRE_RELEASE` is not available, so removing them this way is not possible

**Test plan**
none

**Closing issues**
none