### PR TITLE
WIP: Refactor /ao for regex assembly search (#6663)

### DIFF
--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -45,6 +45,60 @@ struct search_parameters {
 	bool regex_search;
 };
 
+static void do_asm_regex_search(RzCore *core, const char *regex_pattern) {
+    if (!regex_pattern || !*regex_pattern) {
+        RZ_LOG_ERROR("Usage: /ao <extended-regex>\n");
+        return;
+    }
+
+    RzRegexMulti *re = rz_regex_new_multi(regex_pattern, RZ_REGEX_EXTENDED, RZ_REGEX_DEFAULT, RZ_REGEX_UTF8);
+    if (!re) {
+        RZ_LOG_ERROR("Failed to compile regex: %s\n", regex_pattern);
+        return;
+    }
+
+    ut64 from = core->offset;
+    ut64 to = from + core->blocksize;
+    ut64 buf_size = to - from;
+
+    if (buf_size == 0) {
+        rz_regex_free_multi(re);
+        return;
+    }
+
+    ut64 current_offset = 0;
+    while (current_offset < buf_size) {
+        if (rz_cons_is_breaked()) {
+            break;
+        }
+
+        RzAsmOp op;
+        rz_asm_op_init(&op);
+        rz_asm_set_pc(core->rasm, from + current_offset);
+
+        int instr_len = rz_asm_disassemble(core->rasm, &op, core->block + current_offset, (int)(buf_size - current_offset));
+
+        if (instr_len < 1) {
+            rz_asm_op_fini(&op);
+            current_offset += 1;
+            continue;
+        }
+
+        RzPVector *matches = rz_regex_match_all(re->re8, rz_strbuf_get(&op.buf_asm), RZ_REGEX_ZERO_TERMINATED, 0, RZ_REGEX_DEFAULT);
+        
+        if (matches && !rz_pvector_empty(matches)) {
+            rz_cons_printf("0x%08" PFMT64x "   %s\n", from + current_offset, rz_strbuf_get(&op.buf_asm));
+        }
+        
+        rz_pvector_free(matches);
+        rz_asm_op_fini(&op);
+        
+        current_offset += instr_len;
+    }
+
+    rz_regex_free_multi(re);
+}
+
 static RzCmdStatus gadget_info(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state, RzGadgetType gadget_type) {
 	const char *input = argc > 1 ? argv[1] : "";
 	if (!input) {
@@ -1498,7 +1552,7 @@ reread:
 			do_asm_search(core, &param, input + 2, 'c', search_itv);
 		} else if (input[1] == 'o') { // "/ao"
 			dosearch = 0;
-			do_asm_search(core, &param, input + 2, 'o', search_itv);
+            do_asm_regex_search(core, input + 2);
 		} else if (input[1] == 'a') { // "/aa"
 			dosearch = 0;
 			do_asm_search(core, &param, input + 2, 'a', search_itv);

--- a/librz/core/cmd/cmd_search.c
+++ b/librz/core/cmd/cmd_search.c
@@ -46,57 +46,57 @@ struct search_parameters {
 };
 
 static void do_asm_regex_search(RzCore *core, const char *regex_pattern) {
-    if (!regex_pattern || !*regex_pattern) {
-        RZ_LOG_ERROR("Usage: /ao <extended-regex>\n");
-        return;
-    }
+	if (!regex_pattern || !*regex_pattern) {
+		RZ_LOG_ERROR("Usage: /ao <extended-regex>\n");
+		return;
+	}
 
-    RzRegexMulti *re = rz_regex_new_multi(regex_pattern, RZ_REGEX_EXTENDED, RZ_REGEX_DEFAULT, RZ_REGEX_UTF8);
-    if (!re) {
-        RZ_LOG_ERROR("Failed to compile regex: %s\n", regex_pattern);
-        return;
-    }
+	RzRegexMulti *re = rz_regex_new_multi(regex_pattern, RZ_REGEX_EXTENDED, RZ_REGEX_DEFAULT, RZ_REGEX_UTF8);
+	if (!re) {
+		RZ_LOG_ERROR("Failed to compile regex: %s\n", regex_pattern);
+		return;
+	}
 
-    ut64 from = core->offset;
-    ut64 to = from + core->blocksize;
-    ut64 buf_size = to - from;
+	ut64 from = core->offset;
+	ut64 to = from + core->blocksize;
+	ut64 buf_size = to - from;
 
-    if (buf_size == 0) {
-        rz_regex_free_multi(re);
-        return;
-    }
+	if (buf_size == 0) {
+		rz_regex_free_multi(re);
+		return;
+	}
 
-    ut64 current_offset = 0;
-    while (current_offset < buf_size) {
-        if (rz_cons_is_breaked()) {
-            break;
-        }
+	ut64 current_offset = 0;
+	while (current_offset < buf_size) {
+		if (rz_cons_is_breaked()) {
+			break;
+		}
 
-        RzAsmOp op;
-        rz_asm_op_init(&op);
-        rz_asm_set_pc(core->rasm, from + current_offset);
+		RzAsmOp op;
+		rz_asm_op_init(&op);
+		rz_asm_set_pc(core->rasm, from + current_offset);
 
-        int instr_len = rz_asm_disassemble(core->rasm, &op, core->block + current_offset, (int)(buf_size - current_offset));
+		int instr_len = rz_asm_disassemble(core->rasm, &op, core->block + current_offset, (int)(buf_size - current_offset));
 
-        if (instr_len < 1) {
-            rz_asm_op_fini(&op);
-            current_offset += 1;
-            continue;
-        }
+		if (instr_len < 1) {
+			rz_asm_op_fini(&op);
+			current_offset += 1;
+			continue;
+		}
 
-        RzPVector *matches = rz_regex_match_all(re->re8, rz_strbuf_get(&op.buf_asm), RZ_REGEX_ZERO_TERMINATED, 0, RZ_REGEX_DEFAULT);
-        
-        if (matches && !rz_pvector_empty(matches)) {
-            rz_cons_printf("0x%08" PFMT64x "   %s\n", from + current_offset, rz_strbuf_get(&op.buf_asm));
-        }
-        
-        rz_pvector_free(matches);
-        rz_asm_op_fini(&op);
-        
-        current_offset += instr_len;
-    }
+		RzPVector *matches = rz_regex_match_all(re->re8, rz_strbuf_get(&op.buf_asm), RZ_REGEX_ZERO_TERMINATED, 0, RZ_REGEX_DEFAULT);
 
-    rz_regex_free_multi(re);
+		if (matches && !rz_pvector_empty(matches)) {
+			rz_cons_printf("0x%08" PFMT64x "   %s\n", from + current_offset, rz_strbuf_get(&op.buf_asm));
+		}
+
+		rz_pvector_free(matches);
+		rz_asm_op_fini(&op);
+
+		current_offset += instr_len;
+	}
+
+	rz_regex_free_multi(re);
 }
 
 static RzCmdStatus gadget_info(RzCore *core, int argc, const char **argv, RzCmdStateOutput *state, RzGadgetType gadget_type) {
@@ -1552,7 +1552,7 @@ reread:
 			do_asm_search(core, &param, input + 2, 'c', search_itv);
 		} else if (input[1] == 'o') { // "/ao"
 			dosearch = 0;
-            do_asm_regex_search(core, input + 2);
+			do_asm_regex_search(core, input + 2);
 		} else if (input[1] == 'a') { // "/aa"
 			dosearch = 0;
 			do_asm_search(core, &param, input + 2, 'a', search_itv);


### PR DESCRIPTION
[x] I've read the guidelines for contributing to this repository.

[x] I made sure to follow the project's coding style.

[ ] I've documented every RZ_API function and struct this PR changes. (N/A - no RZ_API changes)

[ ] I've added tests that prove my changes are effective (required for changes to RZ_API). (WIP)

[ ] I've updated the Rizin book with the relevant information (if needed).

[x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

### Detailed description

This PR implements the core functionality for issue #6663 (Refactor /ao for regex assembly search). I have built a functional /ao <extended-regex> command that correctly reads memory, disassembles instructions, and matches them against the user's regex.

(Note: The original issue requested multithreading, but per @wargio's feedback, RzArch is not yet thread-safe. Therefore, this has been refactored into a single-threaded static function inside cmd_search.c to respect the current architecture).

What is currently working:
-> Added a new static helper do_asm_regex_search directly in cmd_search.c.
-> Disassembles current memory blocks using rz_asm_disassemble.
-> Compiles and executes extended regex queries against op.buf_asm.
-> The command is abortable using rz_cons_is_breaked().
-> Seamlessly integrates into the existing /ao command switch using public Rizin APIs.

(Note: I used Google's Gemini AI assistant to help format my code, and I have reviewed the code to ensure architectural soundness).

**Test plan**

Build the project using Meson/Ninja and enter the developer environment.

Open an empty memory block: rizin -

Verify default bytes with pd 3 (e.g., 0x00000000      jnbe  0x63).

Run the new regex search to match instructions:

> [0x00000000]> /ao jnbe
> 0x00000000   jnbe 0x63

You can also write custom assembly as a single string and search for it:

> [0x00000000]> "wa mov eax, 1; mov ebx, 2; add eax, ebx"
> [0x00000000]> /ao mov

Closing issues

Addresses #6663