### PR TITLE
Fix rz-find -Z string handling

### DIFF
--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -77,40 +77,44 @@ typedef struct {
 	RzIO *io;
 } RzfindContext;
 
+static void str_iterate_wide(RzStrBuf *sb, char *buf, uint64_t len, uint64_t start) {
+	uint64_t i, j = 0;
+	for (i = start; i < len && buf[i]; i++) {
+		char ch = buf[i];
+		if (ch == '"' || ch == '\\') {
+			ch = '\'';
+		}
+		if (!IS_PRINTABLE(ch)) {
+			break;
+		}
+		rz_strbuf_append_n(sb, &ch, 1);
+		j++;
+		i++;
+		if (j > 80) {
+			rz_strbuf_append(sb, "...");
+			break;
+		}
+		if (i >= len || !buf[i]) {
+			break;
+		}
+	}
+}
+
 static void str_iterate(bool widestr, RzStrBuf *sb, char *buf, uint64_t len, uint64_t start) {
 	if (widestr) {
-		uint64_t i, j = 0;
-		for (i = start; i < len && buf[i]; i++) {
-			char ch = buf[i];
-			if (ch == '"' || ch == '\\') {
-				ch = '\'';
-			}
-			if (!IS_PRINTABLE(ch)) {
-				break;
-			}
-			rz_strbuf_append_n(sb, &ch, 1);
-			j++;
-			i++;
-			if (j > 80) {
-				rz_strbuf_append(sb, "...");
-				break;
-			}
-			if (i >= len || !buf[i]) {
-				break;
-			}
-		}
+		str_iterate_wide(sb, buf, len, start);
 		return;
-	} else {
-		for (uint64_t i = start; i < len; i++) {
-			char ch = buf[i];
-			if (ch == '"' || ch == '\\') {
-				ch = '\'';
-			}
-			if (!ch || !IS_PRINTABLE(ch)) {
-				break;
-			}
-			rz_strbuf_append_n(sb, &ch, 1);
+	}
+
+	for (uint64_t i = start; i < len; i++) {
+		char ch = buf[i];
+		if (ch == '"' || ch == '\\') {
+			ch = '\'';
 		}
+		if (!ch || !IS_PRINTABLE(ch)) {
+			break;
+		}
+		rz_strbuf_append_n(sb, &ch, 1);
 	}
 }
 

--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -38,6 +38,7 @@ typedef struct {
 	int align;
 	ut8 *buf;
 	ut64 bsize;
+	ut64 buflen; /* length of valid data in buf */
 	ut64 from;
 	ut64 to;
 	ut64 cur;
@@ -53,6 +54,7 @@ typedef struct {
 static void rzfind_options_fini(RzfindOptions *ro) {
 	free(ro->buf);
 	ro->cur = 0;
+	ro->buflen = 0;
 }
 
 static void rzfind_options_init(RzfindOptions *ro) {
@@ -72,78 +74,79 @@ typedef struct {
 	RzfindOptions *opt;
 	const char *filename;
 	RzCore *core;
+	RzIO *io;
 } RzfindContext;
 
-static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
-	RzfindContext *ctx = (RzfindContext *)user;
-	RzfindOptions *ro = ctx->opt;
-	int delta = addr - ro->cur;
-	if (ro->cur > addr && (ro->cur - addr == kw->keyword_length - 1)) {
-		// This case occurs when there is hit in search left over
-		delta = ro->cur - addr;
-	}
-	if (delta < 0 || delta >= ro->bsize) {
-		eprintf("Invalid delta\n");
-		return 0;
-	}
-	if (!ro->quiet && !ro->json) {
-		printf("File: %s\n", ctx->filename);
-	}
-	char _str[128];
-	char *str = _str;
-	*_str = 0;
-	if (ro->showstr) {
-		if (ro->widestr) {
-			str = _str;
-			int i, j = 0;
-			for (i = delta; ro->buf[i] && i < sizeof(_str); i++) {
-				char ch = ro->buf[i];
-				if (ch == '"' || ch == '\\') {
-					ch = '\'';
-				}
-				if (!IS_PRINTABLE(ch)) {
-					break;
-				}
-				str[j++] = ch;
-				i++;
-				if (j > 80) {
-					strcpy(str + j, "...");
-					j += 3;
-					break;
-				}
-				if (ro->buf[i]) {
-					break;
-				}
+static void str_iterate(bool widestr, RzStrBuf *sb, char *buf, uint64_t len, uint64_t start) {
+	if (widestr) {
+		uint64_t i, j = 0;
+		for (i = start; i < len && buf[i]; i++) {
+			char ch = buf[i];
+			if (ch == '"' || ch == '\\') {
+				ch = '\'';
 			}
-			str[j] = 0;
-		} else {
-			size_t i;
-			for (i = 0; i < sizeof(_str) - 1; i++) {
-				char ch = ro->buf[delta + i];
-				if (ch == '"' || ch == '\\') {
-					ch = '\'';
-				}
-				if (!ch || !IS_PRINTABLE(ch)) {
-					break;
-				}
-				str[i] = ch;
+			if (!IS_PRINTABLE(ch)) {
+				break;
 			}
-			str[i] = 0;
+			rz_strbuf_append_n(sb, &ch, 1);
+			j++;
+			i++;
+			if (j > 80) {
+				rz_strbuf_append(sb, "...");
+				break;
+			}
+			if (i >= len || !buf[i]) {
+				break;
+			}
 		}
+		return;
 	} else {
-		size_t i;
-		for (i = 0; i < sizeof(_str) - 1; i++) {
-			char ch = ro->buf[delta + i];
+		for (uint64_t i = start; i < len; i++) {
+			char ch = buf[i];
 			if (ch == '"' || ch == '\\') {
 				ch = '\'';
 			}
 			if (!ch || !IS_PRINTABLE(ch)) {
 				break;
 			}
-			str[i] = ch;
+			rz_strbuf_append_n(sb, &ch, 1);
 		}
-		str[i] = 0;
 	}
+}
+
+static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
+	RzfindContext *ctx = (RzfindContext *)user;
+	RzfindOptions *ro = ctx->opt;
+	int delta = addr - ro->cur;
+	bool search_leftover = false;
+	RzStrBuf sb;
+	rz_strbuf_init(&sb);
+	RzStrBuf leftover;
+	if (ro->cur > addr) {
+		// This case occurs when there is hit in search left over
+		delta = ro->widestr ? (ro->cur - addr) : 0;
+		search_leftover = true;
+		rz_strbuf_init(&leftover);
+	}
+	if (delta < 0 || delta >= ro->buflen) {
+		RZ_LOG_ERROR("Invalid delta\n");
+		return 0;
+	}
+	if (!ro->quiet && !ro->json) {
+		printf("File: %s\n", ctx->filename);
+	}
+
+	bool is_widestr = ro->widestr;
+	if (!is_widestr && ro->showstr && search_leftover && rz_strbuf_reserve(&leftover, ro->cur - addr)) {
+		int ret = rz_io_pread_at(ctx->io, addr, (uint8_t *)rz_strbuf_get(&leftover), ro->cur - addr);
+		if (ret > 0) {
+			str_iterate(is_widestr, &sb, rz_strbuf_get(&leftover), ret, 0);
+		}
+		rz_strbuf_fini(&leftover);
+	}
+	str_iterate(is_widestr, &sb, (char *)ro->buf, ro->buflen, delta);
+
+	char *str = rz_strbuf_get(&sb);
 	if (ro->json) {
 		const char *type = "string";
 		printf("%s{\"offset\":%" PFMT64d ",\"type\":\"%s\",\"data\":\"%s\"}",
@@ -172,6 +175,7 @@ static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 			RZ_LOG_ERROR("Failed to execute command: %s\n", command);
 		}
 		free(command);
+		rz_strbuf_fini(&sb);
 		return 1;
 	}
 	if (ro->rizin_command && ctx->core) {
@@ -181,8 +185,10 @@ static int hit(RzSearchKeyword *kw, void *user, ut64 addr) {
 			printf("%s", output);
 			free(output);
 		}
+		rz_strbuf_fini(&sb);
 		return 1;
 	}
+	rz_strbuf_fini(&sb);
 	return 1;
 }
 
@@ -532,7 +538,7 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 		}
 		rz_core_bin_load(core, NULL, UT64_MAX);
 	}
-	RzfindContext ctx = { .opt = ro, .filename = file, .core = core };
+	RzfindContext ctx = { .opt = ro, .filename = file, .core = core, .io = io };
 	rz_search_set_callback(rs, &hit, &ctx);
 	ut64 to = ro->to;
 	if (to == -1) {
@@ -727,8 +733,9 @@ static int rzfind_open_file(RzfindOptions *ro, const char *file, const ut8 *data
 			result = 1;
 			break;
 		}
-		if (ret != bsize && ret > 0) {
+		if (ret > 0) {
 			bsize = ret;
+			ro->buflen = ret;
 		}
 
 		if (rz_search_update(rs, ro->cur, ro->buf, ret) == -1) {

--- a/librz/main/rz-find.c
+++ b/librz/main/rz-find.c
@@ -94,7 +94,7 @@ static void str_iterate_wide(RzStrBuf *sb, char *buf, uint64_t len, uint64_t sta
 			rz_strbuf_append(sb, "...");
 			break;
 		}
-		if (i >= len || !buf[i]) {
+		if (i >= len || buf[i]) {
 			break;
 		}
 	}

--- a/test/db/tools/rz_find
+++ b/test/db/tools/rz_find
@@ -281,6 +281,14 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=rz-find -Z keyword across block boundary
+TOOL=rz-find
+ARGS=-Z -b 0x592 -s 250382 bins/elf/ioli/crackme0x00
+EXPECT=<<EOF
+0x58f 250382
+EOF
+RUN
+
 NAME=rz-find -F
 TOOL=rz-find
 ARGS=-F scripts/keyword bins/mach0/FileDP

--- a/test/db/tools/rz_find
+++ b/test/db/tools/rz_find
@@ -257,6 +257,14 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=rz-find -Z wide string
+TOOL=rz-find
+ARGS=-Z -w PATH=C: bins/heap/multithreadheap.exe.bin
+EXPECT=<<EOF
+0x15d8 PATH=C:'Users'vboxuser'rizin'rizin-install'bin;C:'Windows'system32;C:'Windows;C:'...
+EOF
+RUN
+
 NAME=rz-find -S ascii
 TOOL=rz-find
 ARGS=-S QueryPerformanceCounter bins/pe/testapp-msvc64.exe


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

Closes #6289. Using `RzStrBuf` the fixed buffer of 128 bytes was replaced. While trying different testcases, I found another bug where if a keyword is split on the boundary of two blocks then the printing logic was broken.  For example,
If block size is 5 and the file has content: `ABCDEFGHIJ` where the keyword is `CDEF`. Then with the previous logic:
```c
if (ro->cur > addr && (ro->cur - addr == kw->keyword_length - 1)) {
    // This case occurs when there is hit in search left over
    delta = ro->cur - addr;
}

// ro->cur = 5 and addr = 2
// delta = 3
{...}

for (i = 0; i < sizeof(_str) - 1; i++) {
    char ch = ro->buf[delta + i];
    {...}
}
```
Now according to this it would read buf[3], buf[4]. This means I, J whereas CDEFGHIJ should have been printed. To fix this issue of "leftover" strings, I made a change to the `RzfindContext` struct where a new member `RzIO *io`was added to use `rz_io_pread_at()`and read the leftover part of the string. To read leftover string **delta** is also set to 0. This leftover string handling has not been implemented for widestr. The string iterating logic has been moved to a separate static function `str_iterate()`as it's reused. Also to fix reading of stale values from buf[] when ret was smaller than bsize, a new variable called `buflen` has been added to the struct `RzfindOptions`. This keeps track of the size of valid bytes in buf. Its updated using:

```c  
if (ret > 0) {
    bsize = ret;
    ro->buflen = ret;
}
```
I could try to update existing ro->bsize but it might have complications for memory management and other hits. A new testcase has been added `test/db/tools/rz_find` to verify the keyword boundary splitting case