### PR TITLE
librz/bin: check allocation results and release a buffer on an error path

### DIFF
--- a/librz/bin/format/dmp/dmp64.c
+++ b/librz/bin/format/dmp/dmp64.c
@@ -340,6 +340,10 @@ static int rz_bin_dmp64_init_bmp_header(struct rz_bin_dmp64_obj_t *obj) {
 
 	ut64 bitmapsize = obj->bmp_header->Pages / 8;
 	obj->bitmap = calloc(1, bitmapsize);
+	if (!obj->bitmap) {
+		RZ_LOG_ERROR("Cannot allocate bitmap\n");
+		return false;
+	}
 	if (rz_buf_read_at(obj->b, sizeof(dmp64_header) + rz_offsetof(dmp_bmp_header, Bitmap), obj->bitmap, bitmapsize) < 0) {
 		RZ_LOG_ERROR("Cannot read bitmap\n");
 		return false;

--- a/librz/bin/golang.c
+++ b/librz/bin/golang.c
@@ -184,9 +184,13 @@ static void parse_go_build_info(RzBinFile *bf, GoBuildInfo *go_info, ut64 bi_pad
 	ut32 setting_sz = 0;
 	if (tmp32[15] & 2) {
 		ut8 *buffer = malloc(GOLANG_MAX_STRING_BUF);
+		if (!buffer) {
+			return;
+		}
 		// Read build info
 		if (rz_buf_read_at(bf->buf, bi_paddr + 32, buffer, GOLANG_MAX_STRING_BUF) < 1) {
 			RZ_LOG_ERROR("goinfo: Cannot read build info header at 0x%08" PFMT64x " (phy)\n", bi_paddr);
+			free(buffer);
 			return;
 		}
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Two allocations in `librz/bin` are used without checking the result, and one of
them also leaks on an error path.

*1. `librz/bin/golang.c` — `parse_go_build_info()`*

```c
186		ut8 *buffer = malloc(GOLANG_MAX_STRING_BUF);   // not checked
187		// Read build info
188		if (rz_buf_read_at(bf->buf, bi_paddr + 32, buffer, GOLANG_MAX_STRING_BUF) < 1) {
189			RZ_LOG_ERROR("goinfo: Cannot read build info header at ...");
190			return;                                    // buffer leaked
191		}
```

`rz_buf_read_at()` writes through `buffer`, so the unchecked `malloc()` is a NULL
write. The sibling paths at lines 195 and 202 release `buffer` correctly, so the
missing `free()` on line 190 looks like an oversight. This is reachable from any
opened file: `rz_bin_object_process_plugin_data()` calls
`rz_bin_file_golang_compiler()` for every ELF, Mach-O and PE, and it dispatches on
the section name alone, so a `.go.buildinfo` section placed 32 bytes before EOF
makes the header read succeed and the follow-up read return zero. 4 KB per open.

*2. `librz/bin/format/dmp/dmp64.c` — `rz_bin_dmp64_init_bmp_header()`*

```c
341	ut64 bitmapsize = obj->bmp_header->Pages / 8;
342	obj->bitmap = calloc(1, bitmapsize);           // not checked
343	if (rz_buf_read_at(obj->b, ..., obj->bitmap, bitmapsize) < 0) {
```

`Pages` is read from the dump header, so `bitmapsize` is file-controlled and the
`calloc()` can fail on a crafted file; `obj->bitmap` then goes to
`rz_buf_read_at()` unchecked. Not a leak — the destructor frees it — only the
missing check.

Both changes bail out early when an allocation fails, and the `golang.c` one also
releases `buffer` on the read-failure path.

**Test plan**

* `meson setup build -Db_sanitize=address -Db_lundef=false && ninja -C build`
* Opening a crafted ELF whose `.go.buildinfo` section ends at EOF leaks 4096 bytes
  under LeakSanitizer (`parse_go_build_info` at `golang.c:186`); with the patch the
  leak is gone.
* `git diff --check`

The two unchecked allocations only fail under allocation pressure, so they are
covered by inspection rather than a runtime test.

**Closing issues**

None.

**AI disclosure**

Claude Opus (Anthropic) assisted with implementing the code patch. I reviewed the
resulting code and verified the behavior locally; no generated placeholder code is
included.
