### PR TITLE
cconfig.c: Fix Use After Free

### DIFF
--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -795,13 +795,14 @@ static bool cb_timezone(void *user, void *data) {
 static bool cb_cfgdebug(void *user, void *data) {
 	RzCore *core = (RzCore *)user;
 	RzConfigNode *node = (RzConfigNode *)data;
-	if (!core) {
+	if (!core || !node) {
 		return false;
 	}
+	bool is_debug = node->i_value;
 	if (core->io) {
-		rz_config_set_b(core->config, "io.va", !node->i_value);
+		rz_config_set_b(core->config, "io.va", !is_debug);
 	}
-	if (core->dbg && node->i_value) {
+	if (core->dbg && is_debug) {
 		const char *dbgbackend = rz_config_get(core->config, "dbg.backend");
 		core->bin->is_debugger = true;
 		rz_debug_use(core->dbg, dbgbackend);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request.
If you have used AI tools to generate these code changes, please disclose software used, model name. -->

There was a hidden use after free in the callback function of `cfg.debug` config.

It just accidentally got hit by luck in this PR: https://github.com/rizinorg/rizin/pull/6514#pullrequestreview-5006194689

Likely the removal of one `analysis.prelude` config resulted in a state where the vector capacity is full at the point when   `io.va` was config added in the callback, resulting in vector reallocation. Before this this condition was not hit, hence not caught.

Previously the `node->i_value` was accessed after a neew config was added before it. If there happened a vector reallocation, then previous addrresss where `RzConfigNode *node` pointed too was already freed. (use after free).

...

**Test plan**

<!-- THIS IS A HARD REQUIREMENT FOR NEW CONTRIBUTORS! -->
<!-- Please refer to CONTRIBUTING.md for more details. -->

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
