### PR TITLE
Update libdemangle to revision 4a0af689

### DIFF
--- a/subprojects/libdemangle.wrap
+++ b/subprojects/libdemangle.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 url = https://github.com/rizinorg/rz-libdemangle.git
-revision = 15d7d7cf4fcd7880d8e846ae22d1f5c2c9fe41b0
+revision = 4a0af6896daf4122cc9a02c3f58a7768f4e27b2d
 depth = 1


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes. No `RZ_API` functions or structs are changed.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`). The selected upstream revision includes regression cases for the fixed demangler behavior; this PR does not change `RZ_API`.
- [x] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed). No book update is needed for this dependency revision update.
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Update the `libdemangle` Meson wrap from revision
`15d7d7cf4fcd7880d8e846ae22d1f5c2c9fe41b0` to
`4a0af6896daf4122cc9a02c3f58a7768f4e27b2d`.

The new revision fixes an infinite-recursion path in the C++ v3 demangler's
`node_base_name()` implementation. It unwraps unnamed-type nodes through their
printable child and rejects unsupported node kinds instead of recursively
processing the same node. It also includes regression cases for affected
unnamed-type constructor and destructor symbols.

**Test plan**

Functional testing with the binary from #6687 was not performed because I could
not download the reported EdrawMax binary.

@linxiao828, could you please build this PR and test it with the binary from
#6687?

The expected result is that Rizin reaches the interactive prompt with the
default `bin.demangle=true` setting instead of hanging at 100% CPU. Please
confirm whether this resolves the issue.

**Closing issues**

Related to #6687.
