### PR TITLE
Fix sdb memory usage in RzBinFile/RzBinObject (Fix #6688)

### DIFF
--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -252,15 +252,6 @@ RZ_API RzBinFile *rz_bin_reload(RzBin *bin, RzBinFile *bf, ut64 baseaddr) {
 	opt.filename = bf->file;
 	rz_buf_seek(bf->buf, 0, RZ_BUF_SET);
 	RzBinFile *nbf = rz_bin_open_buf(bin, bf->buf, &opt);
-	// On reload the new file reuses the same fd, so opening it overwrites the
-	// old file's "cur" and "fd.<fd>" entries in bin->sdb. That releases fewer
-	// references to the old sdb than the regular teardown path does, leaving
-	// the extra reference rz_bin_object_new took on bf->sdb dangling, so the
-	// old sdb would leak once the old file is deleted below. Drop it here:
-	// sdb_free is reference-counted, so this only decrements the counter and
-	// the sdb is actually released when rz_bin_file_delete() drops the last
-	// reference.
-	sdb_free(bf->sdb);
 	rz_bin_file_delete(bin, bf);
 	return nbf;
 }

--- a/librz/bin/bobj.c
+++ b/librz/bin/bobj.c
@@ -213,6 +213,7 @@ RZ_IPI void rz_bin_object_free(RzBinObject *o) {
 	for (ut32 i = 0; i < RZ_BIN_SPECIAL_SYMBOL_LAST; i++) {
 		free(o->binsym[i]);
 	}
+	sdb_free(o->kv);
 	free(o);
 }
 
@@ -543,7 +544,6 @@ RZ_IPI RzBinObject *rz_bin_object_new(RzBinFile *bf, RzBinPlugin *plugin, RzBinO
 		sdb_ns_set(bf->rbin->sdb, fdns, bf->sdb);
 		free(fdns);
 	}
-	bf->sdb->refs++;
 
 	return o;
 }

--- a/librz/bin/bobj_process_file.c
+++ b/librz/bin/bobj_process_file.c
@@ -62,7 +62,10 @@ RZ_IPI void rz_bin_set_and_process_file(RzBinFile *bf, RzBinObject *o) {
 	}
 
 	sdb_free(o->kv);
-	if (!plugin->get_sdb || !(o->kv = plugin->get_sdb(bf))) {
+	o->kv = plugin->get_sdb ? plugin->get_sdb(bf) : NULL;
+	if (o->kv) {
+		o->kv->refs++;
+	} else {
 		o->kv = sdb_new0();
 	}
 

--- a/librz/bin/format/elf/elf.c
+++ b/librz/bin/format/elf/elf.c
@@ -285,7 +285,9 @@ static bool init_symbols_info_aux(ELFOBJ *bin) {
 		return false;
 	}
 
-	return sdb_ns_set(bin->kv, "versioninfo", info);
+	bool r = sdb_ns_set(bin->kv, "versioninfo", info);
+	sdb_free(info);
+	return r;
 }
 
 static void init_symbols_info(ELFOBJ *bin) {

--- a/librz/bin/p/bin_nro.c
+++ b/librz/bin/p/bin_nro.c
@@ -96,6 +96,7 @@ static Sdb *get_sdb(RzBinFile *bf) {
 	sdb_num_set(kv, "nro_header.size", 0x70);
 	sdb_set(kv, "nro_header.format", "xxxxxxxxxxxx magic unk size unk2 text_offset text_size ro_offset ro_size data_offset data_size bss_size unk3");
 	sdb_ns_set(bf->sdb, "info", kv);
+	sdb_free(kv); // only decrefs, there is still a reference from bf->sdb above
 	return kv;
 }
 

--- a/librz/bin/p/bin_nso.c
+++ b/librz/bin/p/bin_nso.c
@@ -236,6 +236,7 @@ static Sdb *get_sdb(RzBinFile *bf) {
 	sdb_num_set(kv, "nso_header.size", 0x40);
 	sdb_set(kv, "nso_header.format", "xxxxxxxxxxxx magic unk size unk2 text_offset text_size ro_offset ro_size data_offset data_size bss_size unk3");
 	sdb_ns_set(bf->sdb, "info", kv);
+	sdb_free(kv); // only decrefs, there is still a reference from bf->sdb above
 	return kv;
 }
 

--- a/librz/core/cmd/cmd_debug.c
+++ b/librz/core/cmd/cmd_debug.c
@@ -876,14 +876,6 @@ static bool get_bin_info(RzCore *core, const char *file, ut64 baseaddr,
 		return false;
 	}
 	rz_core_bin_print(core, bf, action, filter, state, NULL);
-	// rz_bin_object_new() registers bf->sdb under core->bin->sdb ("cur" and
-	// "fd.<fd>") and takes an extra reference. Restoring the previous binfile
-	// below only updates bin->cur, so drop every reference to this temporary sdb
-	// here, otherwise it dangles in core->bin->sdb and is double-freed on teardown.
-	while (sdb_ns_unset(core->bin->sdb, NULL, bf->sdb)) {
-		;
-	}
-	sdb_free(bf->sdb);
 	rz_bin_file_delete(core->bin, bf);
 	rz_bin_file_set_obj(obf, obf->o);
 	rz_bin_set_cur_binfile(core->bin, obf);

--- a/librz/include/rz_bin.h
+++ b/librz/include/rz_bin.h
@@ -364,7 +364,7 @@ typedef struct rz_bin_object_t {
 	RzBinAddr *binsym[RZ_BIN_SPECIAL_SYMBOL_LAST];
 	struct rz_bin_plugin_t *plugin;
 	RzBinLanguage lang;
-	RZ_DEPRECATE RZ_BORROW Sdb *kv; ///< deprecated, put info in C structures instead of this (holds a copy of another pointer.)
+	RZ_DEPRECATE RZ_OWN Sdb *kv; ///< deprecated, put info in C structures instead of this
 	void *bin_obj; // internal pointer used by formats
 } RzBinObject;
 

--- a/librz/util/sdb/src/ns.c
+++ b/librz/util/sdb/src/ns.c
@@ -41,7 +41,6 @@ static void ns_free_exc_list(Sdb *s, RzList /*<void *>*/ *list) {
 			rz_list_append(list, ns);
 			rz_list_append(list, ns->sdb);
 			ns_free_exc_list(ns->sdb, list);
-			sdb_free(ns->sdb);
 		}
 		if (!deleted) {
 			sdb_free(ns->sdb);

--- a/test/integration/test_bin.c
+++ b/test/integration/test_bin.c
@@ -117,7 +117,7 @@ static RzBinReloc *add_reloc(RzPVector *l, ut64 paddr, ut64 vaddr, ut64 target_v
 }
 
 bool test_rz_bin_reloc_storage(void) {
-	RzPVector *l = rz_pvector_new(NULL);
+	RzPVector *l = rz_pvector_new(free);
 	RzBinReloc *r0 = add_reloc(l, 0x108, 0x1000, 0x2004);
 	mu_assert_notnull(r0, "reloc");
 	RzBinReloc *r1 = add_reloc(l, 0x2002, 0x1003, 0x2008);

--- a/test/unit/test_sdb_sdb.c
+++ b/test/unit/test_sdb_sdb.c
@@ -189,6 +189,23 @@ bool test_sdb_namespace(void) {
 	mu_end;
 }
 
+bool test_sdb_namespace_multiref(void) {
+	Sdb *root = sdb_new0();
+
+	Sdb *sub = sdb_new0(); // sub->refs = 1
+
+	Sdb *sub2 = sdb_new0(); // sub2->refs = 1
+	sdb_ns_set(sub, "sub2", sub2); // sub2->refs++
+	sdb_free(sub2); // sub2->refs--
+
+	sdb_ns_set(root, "ref0", sub); // sub->refs++
+	sdb_ns_set(root, "ref1", sub); // sub->refs++
+	sdb_free(sub); // sub->refs--
+
+	sdb_free(root); // only this should actually free anything, and it should free everything
+	mu_end;
+}
+
 static bool foreach_filter_user_cb(void *user, const SdbKv *kv) {
 	Sdb *db = (Sdb *)user;
 	const char *key = sdbkv_key(kv);
@@ -610,6 +627,7 @@ int all_tests() {
 	// XXX two bugs found with crash
 	mu_run_test(test_sdb_kv_list);
 	mu_run_test(test_sdb_namespace);
+	mu_run_test(test_sdb_namespace_multiref);
 	mu_run_test(test_sdb_foreach_delete);
 	mu_run_test(test_sdb_list_delete);
 	mu_run_test(test_sdb_delete_none);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

This fixes several interdependent issues, originally surfaced as leaked memory by xzy test cases:

- Fixed double-free of sub-namespaced sdbs in ns_free_exc_list and added a test for this case. Refcounting should correctly account for the amount of times an sdb is referenced as a sub-namespace.

This caused even more leaks, whose causes are now localized downstream:

- bf->sdb->refs++; in rz_bin_object_new() appears to have only been a workaround for the actual issue mentioned above.
- RzBinObject.kv also depended on it, but actually it is supposed to only be an additional reference to an sdb managed by the plugin, so we adjust the code accordingly.

Finally, test_rz_bin_reloc_storage also had an independent leak fixed here to make the entire test file leak-free.

**Test plan**

```
[root@ddc5e113efa8 test]# valgrind --leak-check=full ../build/test/integration/test_bin
```

**Closing issues**

Fix #6688 