### PR TITLE
util: return RzIterator over stack instead of heap-allocating

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,4 +1,4 @@
-# DEVELOPERS
+#DEVELOPERS
 
 This file is aimed at developers who want to work on the Rizin code base.
 
@@ -119,15 +119,13 @@ int check(RzCore *c, int a, int b) {
 
 ```c
 switch(something) {
-	case EXPECTED_CASE1:
-		...
-		break;
-	case EXPECTED_CASE2:
-		...
-		break;
-	case UNEXPECTED_CASE:
-		rz_warn_if_reached();
-		break;
+case EXPECTED_CASE1:
+	... break;
+case EXPECTED_CASE2:
+	... break;
+case UNEXPECTED_CASE:
+	rz_warn_if_reached();
+	break;
 	...
 }
 ```
@@ -136,24 +134,25 @@ switch(something) {
 
 ```diff
 +static inline bool inRange(RzBreakpointItem *b, ut64 addr) {
-+       return (addr >= b->addr && addr < (b->addr + b->size));
-+}
+	+return (addr >= b->addr && addr < (b->addr + b->size));
+	+}
 +
 +static inline bool matchProt(RzBreakpointItem *b, int rwx) {
-+       return (!rwx || (rwx && b->rwx));
-+}
+	+return (!rwx || (rwx && b->rwx));
+	+}
 +
  RZ_API RzBreakpointItem *rz_bp_get_in(RzBreakpoint *bp, ut64 addr, int rwx) {
-        RzBreakpointItem *b;
-        RzListIter *iter;
-        rz_list_foreach (bp->bps, iter, b) {
--               if (addr >= b->addr && addr < (b->addr+b->size) && \
--                       (!rwx || rwx&b->rwx))
-+               if (inRange(b, addr) && matchProt(b, rwx)) {
-                        return b;
-+               }
-        }
-        return NULL;
+	RzBreakpointItem *b;
+	RzListIter *iter;
+	rz_list_foreach (bp->bps, iter, b) {
+		-if (addr >= b->addr && addr < (b->addr + b->size) &&
+			-(!rwx || rwx & b->rwx)) +
+			if (inRange(b, addr) && matchProt(b, rwx)) {
+			return b;
+			+
+		}
+	}
+	return NULL;
  }
 ```
 
@@ -220,40 +219,40 @@ rz_core_wrap.cxx:32103:61: error: assigning to 'RzDebugReasonType' from incompat
 
   Examples:
   ```c
-  // OK: If the member `ops` is very often accessed in the code,
-  // it is fine to simplify the syntax with a macro.
-  #define GET_OP_N(n) insn->details->ops[n]
+// OK: If the member `ops` is very often accessed in the code,
+// it is fine to simplify the syntax with a macro.
+#define GET_OP_N(n) insn->details->ops[n]
   ```
 
   ```c
-  // OK: Repetitive but **simple** initialization patterns.
-  #define TOKEN(_type, _pat) \
-  	do { \
-  		RzAsmTokenPattern *pat = RZ_NEW0(RzAsmTokenPattern); \
-  		pat->type = RZ_ASM_TOKEN_##_type; \
-  		pat->pattern = rz_str_dup(_pat); \
-  		rz_pvector_push(pvec, pat); \
-  	} while (0)
+// OK: Repetitive but **simple** initialization patterns.
+#define TOKEN(_type, _pat) \
+	do { \
+		RzAsmTokenPattern *pat = RZ_NEW0(RzAsmTokenPattern); \
+		pat->type = RZ_ASM_TOKEN_##_type; \
+		pat->pattern = rz_str_dup(_pat); \
+		rz_pvector_push(pvec, pat); \
+	} while (0)
 
   // [...]
   void set_tokens() {
-    RzVector *pvec = rz_pvector_new();
-  	TOKEN(RZ_ASM_TOKEN_REGISTER, "(ptr)");
-  	TOKEN(RZ_ASM_TOKEN_OPERATOR, "(\\[)|(\\])");
-  	TOKEN(RZ_ASM_TOKEN_SEPARATOR, "(\\s+)");
+	RzVector *pvec = rz_pvector_new();
+	TOKEN(RZ_ASM_TOKEN_REGISTER, "(ptr)");
+	TOKEN(RZ_ASM_TOKEN_OPERATOR, "(\\[)|(\\])");
+	TOKEN(RZ_ASM_TOKEN_SEPARATOR, "(\\s+)");
   }
   ```
 
   ```c
-  // OK: Repetitive but **simple** function definitions implemented for each **type**.
-  // This case is rare!
-  //
-  // In C++ or other languages this would be done with templates or generics.
-  // C doesn't have this, so macros are fine in this case.
-  #define DEF_TEMPLATE_FCN(T) \
-  T template_like_function() { \
-    return (T) (sizeof(T) * sizeof(T)); \
-  }
+// OK: Repetitive but **simple** function definitions implemented for each **type**.
+// This case is rare!
+//
+// In C++ or other languages this would be done with templates or generics.
+// C doesn't have this, so macros are fine in this case.
+#define DEF_TEMPLATE_FCN(T) \
+	T template_like_function() { \
+		return (T)(sizeof(T) * sizeof(T)); \
+	}
   DEF_TEMPLATE_FCN(ut8);
   DEF_TEMPLATE_FCN(ut16);
   DEF_TEMPLATE_FCN(ut32);
@@ -261,23 +260,23 @@ rz_core_wrap.cxx:32103:61: error: assigning to 'RzDebugReasonType' from incompat
   ```
 
   ```c
-  // NOT OK: This hides semantics.
-  // Implement the case in a static function instead and call it.
-  #define REPETITIVE_CASE(n) \
-    int i = some_fcn(n); \
-    i <<= 8; \
-    i &= 0x80000; \
-    ret = i * other_fcn(n); \
-    break;
+// NOT OK: This hides semantics.
+// Implement the case in a static function instead and call it.
+#define REPETITIVE_CASE(n) \
+	int i = some_fcn(n); \
+	i <<= 8; \
+	i &= 0x80000; \
+	ret = i * other_fcn(n); \
+	break;
 
   // [...]
   switch(x) {
-  case 1:
-    REPETITIVE_CASE(1)
-  case 2:
-    REPETITIVE_CASE(2)
-  case 3:
-    REPETITIVE_CASE(3)
+case 1:
+	REPETITIVE_CASE(1)
+case 2:
+	REPETITIVE_CASE(2)
+case 3:
+	REPETITIVE_CASE(3)
   }
   ```
 
@@ -285,7 +284,7 @@ rz_core_wrap.cxx:32103:61: error: assigning to 'RzDebugReasonType' from incompat
 int sum = 0; // set sum to 0
 ```
 
-* If you want to iterate over values of your struct, implement `RzIterator *mystruct_as_iter()` and `RzIterator *mystruct_as_iter_mut()` for them.
+* If you want to iterate over values of your struct, implement `RzIterator mystruct_as_iter()` and `RzIterator mystruct_as_iter_mut()` for them.
   See `rz_iterator.h` for details about the iterator.
 
 * If you need bitmaps, do not shift and OR the bits manually on `ut32`. Use bit vectors from `rz_bitvector.h` instead.
@@ -302,7 +301,7 @@ int sum = 0; // set sum to 0
 
 * Code must run under Python 3.6 (for [Debian "wheezy" compatibility](https://github.com/rizinorg/rizin/pull/2870#issuecomment-1205338140)).
 
-# Manage Endianness
+#Manage Endianness
 
 As hackers, we need to be aware of endianness.
 
@@ -451,7 +450,7 @@ In particular, the SPDX header may look like:
 You can use the [REUSE Software](https://reuse.software/) to check the
 compliance of the project and get the licenses/copyright of each file.
 
-# Custom Pointer Modifiers
+#Custom Pointer Modifiers
 
 In Rizin code, there are some conventions to help developers use pointers more safely, which are defined in `librz/include/rz_types.h`:
 
@@ -497,41 +496,41 @@ You can use the two modifiers in two places, and their explanations are as follo
 
 ```c
 RZ_OWN MyString *capitalize_str(RZ_BORROW char *s) {
-  MyString *m = RZ_NEWS(MyString);
-  m->s = strdup(s);
-  capitalize(m->s);
-  return m;
+	MyString *m = RZ_NEWS(MyString);
+	m->s = strdup(s);
+	capitalize(m->s);
+	return m;
 }
 
 int main() {
-  char *s = rz_str_dup("Hello World");
-  MyString *m = capitalize_str(s);
-  // s was RZ_BORROW, so main MUST free it
-  free(s);
-  // ... use m ....
-  // m was RZ_OWN, so main now has to free it
-  my_string_free(m);
+	char *s = rz_str_dup("Hello World");
+	MyString *m = capitalize_str(s);
+	// s was RZ_BORROW, so main MUST free it
+	free(s);
+	// ... use m ....
+	// m was RZ_OWN, so main now has to free it
+	my_string_free(m);
 }
 ```
 
 ```c
 RZ_BORROW MyString *capitalize_str(RZ_BORROW MyFile *f, RZ_OWN char *s) {
-  MyString *m = RZ_NEWS(MyString);
-  m->s = s;
-  capitalize(m->s);
-  f->m = m;
-  return m;
+	MyString *m = RZ_NEWS(MyString);
+	m->s = s;
+	capitalize(m->s);
+	f->m = m;
+	return m;
 }
 
 int main() {
-  char *s = strdup("Hello World");
-  MyFile *f = create_my_file();
-  MyString *m = capitalize_str(f, s);
-  // s was RZ_OWN, so main does not need to free it. s is now owned by `m`
-  // ... use m ....
-  // m was RZ_BORROW, so main is just borrowing it from `f`, and it does not have to free it.
-  my_file_free(f);
-  // f was created by main and never transferred to anything else, so main needs to free it.
+	char *s = strdup("Hello World");
+	MyFile *f = create_my_file();
+	MyString *m = capitalize_str(f, s);
+	// s was RZ_OWN, so main does not need to free it. s is now owned by `m`
+	// ... use m ....
+	// m was RZ_BORROW, so main is just borrowing it from `f`, and it does not have to free it.
+	my_file_free(f);
+	// f was created by main and never transferred to anything else, so main needs to free it.
 }
 ```
 

--- a/librz/arch/analysis.c
+++ b/librz/arch/analysis.c
@@ -262,8 +262,8 @@ RZ_API const RzAnalysisPlugin *rz_analysis_plugin_current(RzAnalysis *analysis) 
 	return analysis->cur;
 }
 
-RZ_API RZ_OWN RzIterator *rz_analysis_plugin_iterator(RZ_NONNULL RzAnalysis *analysis) {
-	rz_return_val_if_fail(analysis, NULL);
+RZ_API RZ_OWN RzIterator rz_analysis_plugin_iterator(RZ_NONNULL RzAnalysis *analysis) {
+	rz_return_val_if_fail(analysis, (RzIterator){ 0 });
 	return ht_sp_as_iter(analysis->plugins);
 }
 
@@ -295,9 +295,9 @@ RZ_API bool rz_analysis_use(RzAnalysis *analysis, const char *name) {
 		return true;
 	}
 
-	RzIterator *it = ht_sp_as_iter(analysis->plugins);
+	RzIterator it = ht_sp_as_iter(analysis->plugins);
 	RzAnalysisPlugin **val;
-	rz_iterator_foreach(it, val) {
+	rz_iterator_foreach(&it, val) {
 		RzAnalysisPlugin *h = *val;
 		if (!h || !h->name || strcmp(h->name, name)) {
 			continue;
@@ -309,17 +309,17 @@ RZ_API bool rz_analysis_use(RzAnalysis *analysis, const char *name) {
 		rz_analysis_set_cpu(analysis, name);
 		if (h->init && !h->init(&analysis->plugin_data)) {
 			RZ_LOG_ERROR("analysis plugin '%s' failed to initialize.\n", h->name);
-			rz_iterator_free(it);
+			rz_iterator_fini(&it);
 			return false;
 		}
 		rz_analysis_set_reg_profile(analysis);
 		if (analysis->il_vm) {
 			rz_analysis_il_vm_setup(analysis);
 		}
-		rz_iterator_free(it);
+		rz_iterator_fini(&it);
 		return true;
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	return false;
 }
 

--- a/librz/arch/asm.c
+++ b/librz/arch/asm.c
@@ -385,8 +385,8 @@ RZ_API const RzAsmPlugin *rz_asm_plugin_current(RZ_NONNULL const RzAsm *a) {
 	return a->cur;
 }
 
-RZ_API RZ_OWN RzIterator *rz_asm_plugin_iterator(RZ_NONNULL const RzAsm *a) {
-	rz_return_val_if_fail(a, false);
+RZ_API RZ_OWN RzIterator rz_asm_plugin_iterator(RZ_NONNULL const RzAsm *a) {
+	rz_return_val_if_fail(a, (RzIterator){ 0 });
 	return ht_sp_as_iter(a->plugins);
 }
 
@@ -405,16 +405,16 @@ RZ_API bool rz_asm_is_valid(const RzAsm *a, const char *name) {
 		return false;
 	}
 
-	RzIterator *iter = ht_sp_as_iter(a->plugins);
+	RzIterator iter = ht_sp_as_iter(a->plugins);
 	RzAsmPlugin **val;
-	rz_iterator_foreach(iter, val) {
+	rz_iterator_foreach(&iter, val) {
 		RzAsmPlugin *h = *val;
 		if (!strcmp(h->name, name)) {
-			rz_iterator_free(iter);
+			rz_iterator_fini(&iter);
 			return true;
 		}
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	return false;
 }
 
@@ -425,17 +425,17 @@ RZ_API bool rz_asm_use_assembler(RzAsm *a, const char *name) {
 	if (RZ_STR_ISEMPTY(name)) {
 		a->acur = NULL;
 	}
-	RzIterator *iter = ht_sp_as_iter(a->plugins);
+	RzIterator iter = ht_sp_as_iter(a->plugins);
 	RzAsmPlugin **val;
-	rz_iterator_foreach(iter, val) {
+	rz_iterator_foreach(&iter, val) {
 		RzAsmPlugin *h = *val;
 		if (h->assemble && RZ_STR_EQ(h->name, name)) {
 			a->acur = h;
-			rz_iterator_free(iter);
+			rz_iterator_fini(&iter);
 			return true;
 		}
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	a->acur = NULL;
 	return false;
 }
@@ -503,16 +503,16 @@ RZ_API bool rz_asm_use(RzAsm *a, RZ_NULLABLE const char *name) {
 	if (a->cur && !strcmp(a->cur->arch, name)) {
 		return true;
 	}
-	RzIterator *iter = ht_sp_as_iter(a->plugins);
+	RzIterator iter = ht_sp_as_iter(a->plugins);
 	RzAsmPlugin **val;
-	rz_iterator_foreach(iter, val) {
+	rz_iterator_foreach(&iter, val) {
 		RzAsmPlugin *h = *val;
 		if (h->arch && h->name && !strcmp(h->name, name)) {
 			if (!a->cur || (a->cur && strcmp(a->cur->arch, h->arch))) {
 				plugin_fini(a);
 				char *opcodes_dir = rz_path_system(a->sdb_opcodes_path, RZ_SDB_OPCODES);
 				if (!opcodes_dir) {
-					rz_iterator_free(iter);
+					rz_iterator_fini(&iter);
 					return false;
 				}
 				char *file = rz_str_newf("%s/%s.sdb", opcodes_dir, h->arch);
@@ -528,18 +528,18 @@ RZ_API bool rz_asm_use(RzAsm *a, RZ_NULLABLE const char *name) {
 			rz_asm_set_cpu(a, NULL);
 			if (h->init && !h->init(&a->plugin_data)) {
 				RZ_LOG_ERROR("asm plugin '%s' failed to initialize.\n", h->name);
-				rz_iterator_free(iter);
+				rz_iterator_fini(&iter);
 				return false;
 			}
 			a->cur = h;
-			rz_iterator_free(iter);
+			rz_iterator_fini(&iter);
 			RZ_FREE(a->features);
 			RZ_FREE(a->platforms);
 			a->bits = asm_get_first_default_bits(h);
 			return true;
 		}
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	sdb_free(a->pair);
 	a->pair = NULL;
 	return false;
@@ -865,17 +865,17 @@ static bool assemblerMatches(const RzAsm *a, RzAsmPlugin *h) {
 
 static Ase findAssembler(const RzAsm *a, const char *kw) {
 	Ase ase = NULL;
-	RzIterator *iter = ht_sp_as_iter(a->plugins);
+	RzIterator iter = ht_sp_as_iter(a->plugins);
 	RzAsmPlugin **val;
 	if (a->acur && a->acur->assemble) {
 		return a->acur->assemble;
 	}
-	rz_iterator_foreach(iter, val) {
+	rz_iterator_foreach(&iter, val) {
 		RzAsmPlugin *h = *val;
 		if (assemblerMatches(a, h)) {
 			if (kw) {
 				if (strstr(h->name, kw)) {
-					rz_iterator_free(iter);
+					rz_iterator_fini(&iter);
 					return h->assemble;
 				}
 			} else {
@@ -883,7 +883,7 @@ static Ase findAssembler(const RzAsm *a, const char *kw) {
 			}
 		}
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	return ase;
 }
 

--- a/librz/arch/p/analysis/analysis_sparc_cs.c
+++ b/librz/arch/p/analysis/analysis_sparc_cs.c
@@ -767,15 +767,15 @@ static bool sparc_fini(void *user) {
 	if (!sparc) {
 		return true;
 	}
-	RzIterator *iter = ht_up_as_iter(sparc->delayed_branch);
+	RzIterator iter = ht_up_as_iter(sparc->delayed_branch);
 	RzSparcDelatedBranchOp **eff;
-	rz_iterator_foreach(iter, eff) {
+	rz_iterator_foreach(&iter, eff) {
 		rz_il_op_effect_free((*eff)->perform_jmp);
 		rz_il_op_effect_free((*eff)->set_ea);
 		free(*eff);
 	}
 	ht_up_free(sparc->delayed_branch);
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	if (sparc->handle != 0) {
 		cs_close(&sparc->handle);
 	}

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -259,7 +259,7 @@ RZ_API RzBinFile *rz_bin_reload(RzBin *bin, RzBinFile *bf, ut64 baseaddr) {
 RZ_API RzBinFile *rz_bin_open_buf(RzBin *bin, RzBuffer *buf, RzBinOptions *opt) {
 	rz_return_val_if_fail(bin && opt, NULL);
 
-	RzIterator *it = ht_sp_as_iter(bin->binxtrs);
+	RzIterator it = ht_sp_as_iter(bin->binxtrs);
 	RzBinXtrPlugin **val;
 
 	bin->file = opt->filename;
@@ -272,7 +272,7 @@ RZ_API RzBinFile *rz_bin_open_buf(RzBin *bin, RzBuffer *buf, RzBinOptions *opt) 
 		// XXX - for the time being this is fine, but we may want to
 		// change the name to something like
 		// <xtr_name>:<bin_type_name>
-		rz_iterator_foreach(it, val) {
+		rz_iterator_foreach(&it, val) {
 			RzBinXtrPlugin *xtr = *val;
 			if (!xtr->check_buffer) {
 				RZ_LOG_ERROR("Missing check_buffer callback for '%s'\n", xtr->name);
@@ -288,7 +288,7 @@ RZ_API RzBinFile *rz_bin_open_buf(RzBin *bin, RzBuffer *buf, RzBinOptions *opt) 
 			}
 		}
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	if (!bf) {
 		// Uncomment for this speedup: 20s vs 22s
 		// RzBuffer *buf = rz_buf_new_slurp (bin->file);
@@ -396,14 +396,14 @@ RZ_API RzBinPlugin *rz_bin_get_binplugin_by_buffer(RzBin *bin, RzBuffer *buf) {
 	if (!compatible_plugins) {
 		return NULL;
 	}
-	RzIterator *it = ht_sp_as_iter_keys(bin->plugins);
-	if (!it) {
+	RzIterator it = ht_sp_as_iter_keys(bin->plugins);
+	if (!it.next) {
 		rz_pvector_free(compatible_plugins);
 		return NULL;
 	}
 	// Iterate all plugins and save compatible plugins to `compatible_plugins`
 	char **key;
-	rz_iterator_foreach(it, key) {
+	rz_iterator_foreach(&it, key) {
 		bool found = false;
 		RzBinPlugin *plugin = (RzBinPlugin *)ht_sp_find(bin->plugins, *key, &found);
 		if (!found) {
@@ -414,7 +414,7 @@ RZ_API RzBinPlugin *rz_bin_get_binplugin_by_buffer(RzBin *bin, RzBuffer *buf) {
 			rz_pvector_push(compatible_plugins, rz_str_dup(*key));
 		}
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 
 	if (rz_pvector_empty(compatible_plugins)) {
 		rz_pvector_free(compatible_plugins);
@@ -434,23 +434,23 @@ RZ_API RzBinPlugin *rz_bin_get_binplugin_by_buffer(RzBin *bin, RzBuffer *buf) {
 }
 
 RZ_IPI RzBinPlugin *rz_bin_get_binplugin_by_filename(RzBin *bin) {
-	RzIterator *it = ht_sp_as_iter(bin->plugins);
+	RzIterator it = ht_sp_as_iter(bin->plugins);
 	RzBinPlugin **val;
 
 	rz_return_val_if_fail(bin, NULL);
 
 	const char *filename = strrchr(bin->file, RZ_SYS_DIR[0]);
 	filename = filename ? filename + 1 : bin->file;
-	rz_iterator_foreach(it, val) {
+	rz_iterator_foreach(&it, val) {
 		RzBinPlugin *plugin = *val;
 		if (plugin->check_filename) {
 			if (plugin->check_filename(filename)) {
-				rz_iterator_free(it);
+				rz_iterator_fini(&it);
 				return plugin;
 			}
 		}
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	return NULL;
 }
 
@@ -531,13 +531,13 @@ RZ_API void rz_bin_free(RZ_NULLABLE RzBin *bin) {
 	// rz_bin_free_bin_files (bin);
 	rz_list_free(bin->binfiles);
 
-	RzIterator *it = ht_sp_as_iter(bin->binxtrs);
+	RzIterator it = ht_sp_as_iter(bin->binxtrs);
 	RzBinXtrPlugin **val;
-	rz_iterator_foreach(it, val) {
+	rz_iterator_foreach(&it, val) {
 		RzBinXtrPlugin *p = *val;
 		plugin_fini(bin, p);
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	ht_sp_free(bin->binxtrs);
 	ht_sp_free(bin->plugins);
 	rz_list_free(bin->default_hashes);

--- a/librz/bin/bin.c
+++ b/librz/bin/bin.c
@@ -397,7 +397,7 @@ RZ_API RzBinPlugin *rz_bin_get_binplugin_by_buffer(RzBin *bin, RzBuffer *buf) {
 		return NULL;
 	}
 	RzIterator it = ht_sp_as_iter_keys(bin->plugins);
-	if (!it.next) {
+	if (rz_iterator_is_uninit(&it)) {
 		rz_pvector_free(compatible_plugins);
 		return NULL;
 	}

--- a/librz/config/config.c
+++ b/librz/config/config.c
@@ -79,12 +79,12 @@ RZ_IPI RZ_OWN RzSetS *rz_config_dup_set(RZ_NULLABLE const RzSetS *set) {
 		return safe_set;
 	}
 
-	RzIterator *it = rz_set_s_as_iter(set);
+	RzIterator it = rz_set_s_as_iter(set);
 	const char **elem;
-	rz_iterator_foreach(it, elem) {
+	rz_iterator_foreach(&it, elem) {
 		rz_set_s_add(safe_set, *elem);
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	return safe_set;
 }
 
@@ -525,12 +525,12 @@ RZ_API bool rz_config_var_as_json(RZ_NONNULL const RzConfigVar *var, RZ_NONNULL 
 	} else if (rz_config_var_has_type(var, RZ_CONFIG_VAR_TYPE_SET)) {
 		const char **value;
 		RzSetS *set = rz_config_var_get_set(var);
-		RzIterator *it = rz_set_s_as_iter(set);
+		RzIterator it = rz_set_s_as_iter(set);
 		pj_ka(pj, key);
-		rz_iterator_foreach(it, value) {
+		rz_iterator_foreach(&it, value) {
 			pj_s(pj, *value);
 		}
-		rz_iterator_free(it);
+		rz_iterator_fini(&it);
 		pj_end(pj);
 		rz_set_s_free(set);
 	} else if (rz_config_var_has_type(var, RZ_CONFIG_VAR_TYPE_ITV)) {
@@ -565,15 +565,15 @@ RZ_API RZ_OWN char *rz_config_var_as_string(RZ_NONNULL const RzConfigVar *var) {
 	} else if (rz_config_var_has_type(var, RZ_CONFIG_VAR_TYPE_SET)) {
 		RzSetS *set = rz_config_var_get_set(var);
 		RzStrBuf *sb = rz_strbuf_new("");
-		RzIterator *it = rz_set_s_as_iter(set);
+		RzIterator it = rz_set_s_as_iter(set);
 		const char **val;
-		rz_iterator_foreach(it, val) {
+		rz_iterator_foreach(&it, val) {
 			if (rz_strbuf_length(sb) > 0) {
 				rz_strbuf_append(sb, ",");
 			}
 			rz_strbuf_append(sb, *val);
 		}
-		rz_iterator_free(it);
+		rz_iterator_fini(&it);
 		char *value = rz_strbuf_drain(sb);
 		rz_set_s_free(set);
 		return value;
@@ -887,14 +887,14 @@ static bool config_var_has_option(RzConfigVar *var, const char *value) {
 	value = rz_str_get(value);
 
 	const char **opt;
-	RzIterator *it = rz_set_s_as_iter(var->options);
-	rz_iterator_foreach(it, opt) {
+	RzIterator it = rz_set_s_as_iter(var->options);
+	rz_iterator_foreach(&it, opt) {
 		if (RZ_STR_EQ(*opt, value)) {
-			rz_iterator_free(it);
+			rz_iterator_fini(&it);
 			return true;
 		}
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	return false;
 }
 

--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -136,30 +136,21 @@ static void pvec_owned_iter_free(void *u) {
 }
 
 /** Wrap an owned PVector as an RzIterator; frees vec on iterator_free. */
-static RzIterator *pvector_as_owned_iter(RzPVector /*<void *>*/ *vec) {
-	rz_return_val_if_fail(vec, NULL);
+static RzIterator pvector_as_owned_iter(RzPVector /*<void *>*/ *vec) {
+	rz_return_val_if_fail(vec, (RzIterator){ 0 });
 	PVecOwnedIter *s = RZ_NEW0(PVecOwnedIter);
 	if (!s) {
 		rz_pvector_free(vec);
-		return NULL;
+		return (RzIterator){ 0 };
 	}
 	s->vec = vec;
 
-	/**
-	 * RzIterator *it = rz_iterator_new(pvec_owned_iter_next, NULL, pvec_owned_iter_free, s);
-	 * Replaced with explicit allocation instead of rz_iterator_new because
-	 * this function must keep returning RzIterator* for graph interface compatibility.
-	 */
-	RzIterator *it = RZ_NEW0(RzIterator);
-	if (it) {
-		it->next = pvec_owned_iter_next;
-		it->free = NULL;
-		it->free_u = pvec_owned_iter_free;
-		it->u = s;
-	} else {
-		pvec_owned_iter_free(s);
-		return NULL;
-	}
+	RzIterator it = (RzIterator){
+		.next = pvec_owned_iter_next,
+		.free = NULL,
+		.free_u = pvec_owned_iter_free,
+		.u = s
+	};
 	return it;
 }
 
@@ -327,7 +318,7 @@ static int agraph_in_edge_order_cmp(const void *_a, const void *_b, void *user) 
 	return 0;
 }
 
-static RzIterator *agraph_out_neighbors(const RzAGraph *g, const RzGraphNode *node);
+static RzIterator agraph_out_neighbors(const RzAGraph *g, const RzGraphNode *node);
 static RzGraphNode *agraph_nth_neighbour(const RzAGraph *g, const RzGraphNode *node, ut64 nth, bool outgoing);
 static RzPVector /*<RzGraphEdge *>*/ *agraph_collect_edges(const RzAGraph *g, const RzGraphNode *node, bool outgoing, bool sorted);
 
@@ -429,19 +420,18 @@ static RzPVector /*<RzGraphNode *>*/ *agraph_collect_draw_neighbours(const RzAGr
 			rz_pvector_sort(neighbours, agraph_callgraph_draw_node_cmp, (void *)g);
 		}
 	} else {
-		RzIterator *it_neighbours = agraph_out_neighbors(g, node);
-		if (!it_neighbours) {
+		RzIterator it_neighbours = agraph_out_neighbors(g, node);
+		if (rz_iterator_is_uninit(&it_neighbours)) {
 			rz_pvector_free(neighbours);
 			return NULL;
 		}
 		RzGraphNode *neighbour = NULL;
-		rz_iterator_foreach(it_neighbours, neighbour) {
+		rz_iterator_foreach(&it_neighbours, neighbour) {
 			if (neighbour) {
 				rz_pvector_push(neighbours, neighbour);
 			}
 		}
-		rz_iterator_fini(it_neighbours);
-		free(it_neighbours);
+		rz_iterator_fini(&it_neighbours);
 	}
 	const size_t len = rz_pvector_len(neighbours);
 	if (!g->is_callgraph && len > 2) {
@@ -450,8 +440,8 @@ static RzPVector /*<RzGraphNode *>*/ *agraph_collect_draw_neighbours(const RzAGr
 	return neighbours;
 }
 
-static RzIterator *agraph_get_nodes(const RzAGraph *g) {
-	rz_return_val_if_fail(g, NULL);
+static RzIterator agraph_get_nodes(const RzAGraph *g) {
+	rz_return_val_if_fail(g, (RzIterator){ 0 });
 	return rz_graph_get_nodes(g->graph);
 }
 
@@ -462,39 +452,37 @@ static RzIterator *agraph_get_nodes(const RzAGraph *g) {
  */
 static RzPVector /*<RzGraphEdge *>*/ *agraph_collect_edges(const RzAGraph *g, const RzGraphNode *node, bool outgoing, bool sorted) {
 	rz_return_val_if_fail(g && node, NULL);
-	RzIterator *it_edges = outgoing
+	RzIterator it_edges = outgoing
 		? rz_graph_out_edges(g->graph, (RzGraphNode *)node)
 		: rz_graph_in_edges(g->graph, (RzGraphNode *)node);
-	if (!it_edges) {
+	if (rz_iterator_is_uninit(&it_edges)) {
 		return NULL;
 	}
 	RzPVector *edges = rz_pvector_new(NULL);
 	if (!edges) {
-		rz_iterator_fini(it_edges);
-		free(it_edges);
+		rz_iterator_fini(&it_edges);
 		return NULL;
 	}
 	RzGraphEdge *edge = NULL;
-	rz_iterator_foreach(it_edges, edge) {
+	rz_iterator_foreach(&it_edges, edge) {
 		if (edge) {
 			rz_pvector_push(edges, edge);
 		}
 	}
-	rz_iterator_fini(it_edges);
-	free(it_edges);
+	rz_iterator_fini(&it_edges);
 	if (sorted && rz_pvector_len(edges) > 1) {
 		rz_pvector_sort(edges, outgoing ? agraph_out_edge_order_cmp : agraph_in_edge_order_cmp, NULL);
 	}
 	return edges;
 }
 
-static RzIterator *agraph_neighbours(const RzAGraph *g, const RzGraphNode *node, bool outgoing) {
-	rz_return_val_if_fail(g && node, NULL);
+static RzIterator agraph_neighbours(const RzAGraph *g, const RzGraphNode *node, bool outgoing) {
+	rz_return_val_if_fail(g && node, (RzIterator){ 0 });
 	RzPVector *edges = agraph_collect_edges(g, node, outgoing, true);
 	if (!edges) {
 		edges = rz_pvector_new(NULL);
 		if (!edges) {
-			return NULL;
+			return (RzIterator){ 0 };
 		}
 	}
 	/* Extract the neighbour node pointer from each edge into a new PVector,
@@ -502,7 +490,7 @@ static RzIterator *agraph_neighbours(const RzAGraph *g, const RzGraphNode *node,
 	RzPVector *nodes = rz_pvector_new(NULL);
 	if (!nodes) {
 		rz_pvector_free(edges);
-		return NULL;
+		return (RzIterator){ 0 };
 	}
 	void **it;
 	rz_pvector_foreach (edges, it) {
@@ -515,11 +503,11 @@ static RzIterator *agraph_neighbours(const RzAGraph *g, const RzGraphNode *node,
 	return pvector_as_owned_iter(nodes);
 }
 
-static RzIterator *agraph_out_neighbors(const RzAGraph *g, const RzGraphNode *node) {
+static RzIterator agraph_out_neighbors(const RzAGraph *g, const RzGraphNode *node) {
 	return agraph_neighbours(g, node, true);
 }
 
-static RzIterator *agraph_in_neighbors(const RzAGraph *g, const RzGraphNode *node) {
+static RzIterator agraph_in_neighbors(const RzAGraph *g, const RzGraphNode *node) {
 	return agraph_neighbours(g, node, false);
 }
 
@@ -599,20 +587,19 @@ static RzGraphNode *agraph_get_title(const RzAGraph *g, RzANode *n, bool in) {
 		return n->gnode;
 	}
 
-	RzIterator *it_nodes = in ? agraph_in_neighbors(g, n->gnode) : agraph_out_neighbors(g, n->gnode);
-	if (!it_nodes) {
+	RzIterator it_nodes = in ? agraph_in_neighbors(g, n->gnode) : agraph_out_neighbors(g, n->gnode);
+	if (rz_iterator_is_uninit(&it_nodes)) {
 		return NULL;
 	}
 
 	RzGraphNode *gn;
 	RzGraphNode *res = NULL;
-	rz_iterator_foreach(it_nodes, gn) {
+	rz_iterator_foreach(&it_nodes, gn) {
 		RzANode *an = gn->data;
 		res = agraph_get_title(g, an, in);
 		break;
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 	return res;
 }
 
@@ -672,12 +659,12 @@ static int agraph_refresh(AGraphContext *grp_ctx);
 static void update_node_dimension(const RzAGraph *ag, int is_mini, int zoom, int edgemode, bool callgraph, int layout) {
 	RzGraphNode *gn;
 	RzANode *n;
-	RzIterator *it_nodes = agraph_get_nodes(ag);
-	if (!it_nodes) {
+	RzIterator it_nodes = agraph_get_nodes(ag);
+	if (rz_iterator_is_uninit(&it_nodes)) {
 		return;
 	}
 
-	rz_iterator_foreach(it_nodes, gn) {
+	rz_iterator_foreach(&it_nodes, gn) {
 		if (!(n = gn->data)) {
 			break;
 		}
@@ -714,8 +701,7 @@ static void update_node_dimension(const RzAGraph *ag, int is_mini, int zoom, int
 			}
 		}
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 }
 
 static void append_shortcut(const RzAGraph *g, char *title, char *nodetitle, int left) {
@@ -917,12 +903,12 @@ static int **get_crossing_matrix(const RzAGraph *g,
 			RzGraphNode *gj = layers[i - 1].nodes[j];
 			RzGraphNode *gk;
 
-			RzIterator *it_neighs = agraph_out_neighbors(g, gj);
-			if (!it_neighs) {
+			RzIterator it_neighs = agraph_out_neighbors(g, gj);
+			if (rz_iterator_is_uninit(&it_neighs)) {
 				goto err_row;
 			}
 
-			rz_iterator_foreach(it_neighs, gk) {
+			rz_iterator_foreach(&it_neighs, gk) {
 				int s;
 				// skip self-loop
 				if (gj == gk) {
@@ -931,14 +917,13 @@ static int **get_crossing_matrix(const RzAGraph *g,
 				for (s = 0; s < j; s++) {
 					RzGraphNode *gs = layers[i - 1].nodes[s];
 					RzGraphNode *gt;
-					RzIterator *it_neighs_s = agraph_out_neighbors(g, gs);
-					if (!it_neighs_s) {
-						rz_iterator_fini(it_neighs);
-						free(it_neighs);
+					RzIterator it_neighs_s = agraph_out_neighbors(g, gs);
+					if (rz_iterator_is_uninit(&it_neighs_s)) {
+						rz_iterator_fini(&it_neighs);
 						goto err_row;
 					}
 
-					rz_iterator_foreach(it_neighs_s, gt) {
+					rz_iterator_foreach(&it_neighs_s, gt) {
 						const RzANode *ak, *at; /* k and t should be "indexes" on layer i */
 						if (gt == gk || gt == gs) {
 							continue;
@@ -953,12 +938,10 @@ static int **get_crossing_matrix(const RzAGraph *g,
 						m[ak->pos_in_layer][at->pos_in_layer]++;
 					}
 
-					rz_iterator_fini(it_neighs_s);
-					free(it_neighs_s);
+					rz_iterator_fini(&it_neighs_s);
 				}
 			}
-			rz_iterator_fini(it_neighs);
-			free(it_neighs);
+			rz_iterator_fini(&it_neighs);
 		}
 	}
 
@@ -976,12 +959,12 @@ static int **get_crossing_matrix(const RzAGraph *g,
 				goto err_row;
 			}
 
-			RzIterator *neighbour_itk = agraph_out_neighbors(g, gj);
-			if (!neighbour_itk) {
+			RzIterator neighbour_itk = agraph_out_neighbors(g, gj);
+			if (rz_iterator_is_uninit(&neighbour_itk)) {
 				goto err_row;
 			}
 
-			rz_iterator_foreach(neighbour_itk, gk) {
+			rz_iterator_foreach(&neighbour_itk, gk) {
 				if (!(ak = gk->data)) {
 					break;
 				}
@@ -994,14 +977,13 @@ static int **get_crossing_matrix(const RzAGraph *g,
 						continue;
 					}
 
-					RzIterator *it_neighbour_s = agraph_out_neighbors(g, gs);
-					if (!it_neighbour_s) {
-						rz_iterator_fini(neighbour_itk);
-						free(neighbour_itk);
+					RzIterator it_neighbour_s = agraph_out_neighbors(g, gs);
+					if (rz_iterator_is_uninit(&it_neighbour_s)) {
+						rz_iterator_fini(&neighbour_itk);
 						goto err_row;
 					}
 
-					rz_iterator_foreach(it_neighbour_s, gt) {
+					rz_iterator_foreach(&it_neighbour_s, gt) {
 						if (!(at = gt->data)) {
 							break;
 						}
@@ -1010,12 +992,10 @@ static int **get_crossing_matrix(const RzAGraph *g,
 						}
 					}
 
-					rz_iterator_fini(it_neighbour_s);
-					free(it_neighbour_s);
+					rz_iterator_fini(&it_neighbour_s);
 				}
 			}
-			rz_iterator_fini(neighbour_itk);
-			free(neighbour_itk);
+			rz_iterator_fini(&neighbour_itk);
 		}
 	}
 
@@ -1157,19 +1137,18 @@ static void assign_layers(const RzAGraph *g) {
 	rz_return_if_fail(g);
 
 	/* initialise all layers to 0 */
-	RzIterator *it = agraph_get_nodes(g);
-	if (!it) {
+	RzIterator it = agraph_get_nodes(g);
+	if (rz_iterator_is_uninit(&it)) {
 		return;
 	}
 	RzGraphNode *gn;
-	rz_iterator_foreach(it, gn) {
+	rz_iterator_foreach(&it, gn) {
 		RzANode *n = get_anode(gn);
 		if (n) {
 			n->layer = 0;
 		}
 	}
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 
 	/* build remaining-in-degree table */
 	HtPUOptions opt = { 0 };
@@ -1185,20 +1164,19 @@ static void assign_layers(const RzAGraph *g) {
 	}
 
 	it = agraph_get_nodes(g);
-	if (!it) {
+	if (rz_iterator_is_uninit(&it)) {
 		ht_pu_free(indegree);
 		rz_list_free(queue);
 		return;
 	}
-	rz_iterator_foreach(it, gn) {
+	rz_iterator_foreach(&it, gn) {
 		ut64 deg = (ut64)agraph_in_degree(g, gn);
 		ht_pu_update(indegree, gn, deg);
 		if (deg == 0) {
 			rz_list_append(queue, gn);
 		}
 	}
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 
 	/* Kahn's BFS: process each node once all parents are done */
 	while (rz_list_length(queue) > 0) {
@@ -1208,12 +1186,12 @@ static void assign_layers(const RzAGraph *g) {
 			continue;
 		}
 
-		RzIterator *out_it = agraph_out_neighbors(g, u);
-		if (!out_it) {
+		RzIterator out_it = agraph_out_neighbors(g, u);
+		if (rz_iterator_is_uninit(&out_it)) {
 			continue;
 		}
 		RzGraphNode *v;
-		rz_iterator_foreach(out_it, v) {
+		rz_iterator_foreach(&out_it, v) {
 			RzANode *av = get_anode(v);
 			if (!av) {
 				continue;
@@ -1233,8 +1211,7 @@ static void assign_layers(const RzAGraph *g) {
 				}
 			}
 		}
-		rz_iterator_fini(out_it);
-		free(out_it);
+		rz_iterator_fini(&out_it);
 	}
 
 	rz_list_free(queue);
@@ -1265,10 +1242,10 @@ static void create_dummy_nodes(RzAGraph *g) {
 	}
 
 	/* Collect all out-edges that span more than one layer */
-	RzIterator *nodes_it = agraph_get_nodes(g);
-	if (nodes_it) {
+	RzIterator nodes_it = agraph_get_nodes(g);
+	if (!rz_iterator_is_uninit(&nodes_it)) {
 		RzGraphNode *gn;
-		rz_iterator_foreach(nodes_it, gn) {
+		rz_iterator_foreach(&nodes_it, gn) {
 			RzPVector *edges = agraph_collect_edges(g, gn, true, false);
 			if (!edges) {
 				continue;
@@ -1282,8 +1259,7 @@ static void create_dummy_nodes(RzAGraph *g) {
 			}
 			rz_pvector_free(edges);
 		}
-		rz_iterator_fini(nodes_it);
-		free(nodes_it);
+		rz_iterator_fini(&nodes_it);
 	}
 
 	const RzListIter *it;
@@ -1331,8 +1307,8 @@ static void create_layers(RzAGraph *g) {
 
 	/* identify max layer */
 	g->n_layers = 0;
-	RzIterator *nodes_it = agraph_get_nodes(g);
-	rz_iterator_foreach(nodes_it, gn) {
+	RzIterator nodes_it = agraph_get_nodes(g);
+	rz_iterator_foreach(&nodes_it, gn) {
 		if (!(n = gn->data)) {
 			break;
 		}
@@ -1340,8 +1316,7 @@ static void create_layers(RzAGraph *g) {
 			g->n_layers = n->layer;
 		}
 	}
-	rz_iterator_fini(nodes_it);
-	free(nodes_it);
+	rz_iterator_fini(&nodes_it);
 
 	/* create a starting ordering of nodes for each layer */
 	g->n_layers++;
@@ -1351,14 +1326,13 @@ static void create_layers(RzAGraph *g) {
 	g->layers = RZ_NEWS0(struct layer_t, g->n_layers);
 
 	nodes_it = agraph_get_nodes(g);
-	rz_iterator_foreach(nodes_it, gn) {
+	rz_iterator_foreach(&nodes_it, gn) {
 		if (!(n = gn->data)) {
 			break;
 		}
 		g->layers[n->layer].n_nodes++;
 	}
-	rz_iterator_fini(nodes_it);
-	free(nodes_it);
+	rz_iterator_fini(&nodes_it);
 
 	for (i = 0; i < g->n_layers; i++) {
 		if (sizeof(RzGraphNode *) * g->layers[i].n_nodes < g->layers[i].n_nodes) {
@@ -1369,15 +1343,14 @@ static void create_layers(RzAGraph *g) {
 		g->layers[i].position = 0;
 	}
 	nodes_it = agraph_get_nodes(g);
-	rz_iterator_foreach(nodes_it, gn) {
+	rz_iterator_foreach(&nodes_it, gn) {
 		if (!(n = gn->data)) {
 			break;
 		}
 		n->pos_in_layer = g->layers[n->layer].position;
 		g->layers[n->layer].nodes[g->layers[n->layer].position++] = gn;
 	}
-	rz_iterator_fini(nodes_it);
-	free(nodes_it);
+	rz_iterator_fini(&nodes_it);
 }
 
 /* layer-by-layer sweep */
@@ -1571,15 +1544,14 @@ static RzList /*<RzGraphNode *>*/ **compute_classes(const RzAGraph *g, HtPP /*<R
 	const RzListIter *it;
 	RzANode *n;
 
-	RzIterator *it_nodes = agraph_get_nodes(g);
-	rz_iterator_foreach(it_nodes, gn) {
+	RzIterator it_nodes = agraph_get_nodes(g);
+	rz_iterator_foreach(&it_nodes, gn) {
 		if (!(n = gn->data)) {
 			break;
 		}
 		n->klass = -1;
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 
 	for (i = 0; i < g->n_layers; i++) {
 		c = i;
@@ -1691,11 +1663,11 @@ static void adjust_class(const RzAGraph *g, int is_left, RzList /*<RzGraphNode *
 			const RzGraphNode *gk;
 			const RzANode *ak;
 
-			RzIterator *it_neigh_in = agraph_in_neighbors(g, gn);
-			if (!it_neigh_in) {
+			RzIterator it_neigh_in = agraph_in_neighbors(g, gn);
+			if (rz_iterator_is_uninit(&it_neigh_in)) {
 				continue;
 			}
-			rz_iterator_foreach(it_neigh_in, gk) {
+			rz_iterator_foreach(&it_neigh_in, gk) {
 				if (!(ak = gk->data)) {
 					break;
 				}
@@ -1706,14 +1678,13 @@ static void adjust_class(const RzAGraph *g, int is_left, RzList /*<RzGraphNode *
 					}
 				}
 			}
-			rz_iterator_fini(it_neigh_in);
-			free(it_neigh_in);
+			rz_iterator_fini(&it_neigh_in);
 
-			RzIterator *it_neigh_out = agraph_out_neighbors(g, gn);
-			if (!it_neigh_out) {
+			RzIterator it_neigh_out = agraph_out_neighbors(g, gn);
+			if (rz_iterator_is_uninit(&it_neigh_out)) {
 				continue;
 			}
-			rz_iterator_foreach(it_neigh_out, gk) {
+			rz_iterator_foreach(&it_neigh_out, gk) {
 				if (!(ak = gk->data)) {
 					break;
 				}
@@ -1724,8 +1695,7 @@ static void adjust_class(const RzAGraph *g, int is_left, RzList /*<RzGraphNode *
 					}
 				}
 			}
-			rz_iterator_fini(it_neigh_out);
-			free(it_neigh_out);
+			rz_iterator_fini(&it_neigh_out);
 		}
 
 		len = rz_list_length(heap);
@@ -1870,19 +1840,18 @@ static void place_dummies(const RzAGraph *g) {
 		goto xplus_err;
 	}
 
-	RzIterator *nodes = agraph_get_nodes(g);
-	if (!nodes) {
+	RzIterator nodes = agraph_get_nodes(g);
+	if (rz_iterator_is_uninit(&nodes)) {
 		goto general_err;
 	}
 
-	rz_iterator_foreach(nodes, gn) {
+	rz_iterator_foreach(&nodes, gn) {
 		if (!(n = gn->data)) {
 			break;
 		}
 		n->x = (hash_get_int(xminus, gn) + hash_get_int(xplus, gn)) / 2;
 	}
-	rz_iterator_fini(nodes);
-	free(nodes);
+	rz_iterator_fini(&nodes);
 
 general_err:
 	ht_pu_free(xplus);
@@ -1975,7 +1944,7 @@ static void place_single(const RzAGraph *g, int l, const RzGraphNode *bm, const 
 	if (!av) {
 		return;
 	}
-	RzIterator *it_neigh = from_up
+	RzIterator it_neigh = from_up
 		? agraph_in_neighbors(g, v)
 		: agraph_out_neighbors(g, v);
 
@@ -1984,16 +1953,15 @@ static void place_single(const RzAGraph *g, int l, const RzGraphNode *bm, const 
 		? rz_graph_in_degree(g->graph, v)
 		: rz_graph_out_degree(g->graph, v);
 	if (len == 0) {
-		rz_iterator_fini(it_neigh);
-		free(it_neigh);
+		rz_iterator_fini(&it_neigh);
 		return;
 	}
 
 	int sum_x = 0;
-	if (!it_neigh) {
+	if (rz_iterator_is_uninit(&it_neigh)) {
 		return;
 	}
-	rz_iterator_foreach(it_neigh, gk) {
+	rz_iterator_foreach(&it_neigh, gk) {
 		if (!(ak = gk->data)) {
 			break;
 		}
@@ -2003,8 +1971,7 @@ static void place_single(const RzAGraph *g, int l, const RzGraphNode *bm, const 
 		}
 		sum_x += ak->x;
 	}
-	rz_iterator_fini(it_neigh);
-	free(it_neigh);
+	rz_iterator_fini(&it_neigh);
 
 	if (len == 0) {
 		return;
@@ -2041,7 +2008,7 @@ static void collect_changes(const RzAGraph *g, int l, const RzGraphNode *b, int 
 	for (i = is_left ? s : e - 1; (is_left && i < e) || (!is_left && i >= s); i = is_left ? i + 1 : i - 1) {
 		const RzGraphNode *v, *vi = g->layers[l].nodes[i];
 		const RzANode *av, *avi = get_anode(vi);
-		RzIterator *it_neigh;
+		RzIterator it_neigh;
 		int c = 0;
 
 		if (!avi) {
@@ -2050,11 +2017,11 @@ static void collect_changes(const RzAGraph *g, int l, const RzGraphNode *b, int 
 		it_neigh = from_up
 			? agraph_in_neighbors(g, vi)
 			: agraph_out_neighbors(g, vi);
-		if (!it_neigh) {
+		if (rz_iterator_is_uninit(&it_neigh)) {
 			continue;
 		}
 
-		rz_iterator_foreach(it_neigh, v) {
+		rz_iterator_foreach(&it_neigh, v) {
 			if (!(av = v->data)) {
 				break;
 			}
@@ -2073,8 +2040,7 @@ static void collect_changes(const RzAGraph *g, int l, const RzGraphNode *b, int 
 				rz_list_add_sorted(list, cx, lcmp, NULL);
 			}
 		}
-		rz_iterator_fini(it_neigh);
-		free(it_neigh);
+		rz_iterator_fini(&it_neigh);
 
 		cx = RZ_NEW0(struct len_pos_t);
 		cx->len = c;
@@ -2261,8 +2227,8 @@ static void place_original(RzAGraph *g) {
 	const RzANode *an;
 	HtPUOptions opt = { 0 };
 
-	RzIterator *nodes = agraph_get_nodes(g);
-	if (!nodes) {
+	RzIterator nodes = agraph_get_nodes(g);
+	if (rz_iterator_is_uninit(&nodes)) {
 		return;
 	}
 
@@ -2282,7 +2248,7 @@ static void place_original(RzAGraph *g) {
 		return;
 	}
 
-	rz_iterator_foreach(nodes, gn) {
+	rz_iterator_foreach(&nodes, gn) {
 		if (!(an = gn->data)) {
 			break;
 		}
@@ -2297,8 +2263,7 @@ static void place_original(RzAGraph *g) {
 			ht_pu_update(P, gn, (ut64)(size_t)dt_eq);
 		}
 	}
-	rz_iterator_fini(nodes);
-	free(nodes);
+	rz_iterator_fini(&nodes);
 
 	original_traverse_l(g, D, P, true);
 	original_traverse_l(g, D, P, false);
@@ -2314,7 +2279,7 @@ static void set_layer_gap(RzAGraph *g) {
 	int i = 0, j = 0;
 	RzGraphNode *ga, *gb;
 	RzANode *a, *b;
-	RzIterator *out_nodes_it;
+	RzIterator out_nodes_it;
 
 	g->layers[0].gap = 0;
 	for (i = 0; i < g->n_layers; i++) {
@@ -2330,10 +2295,10 @@ static void set_layer_gap(RzAGraph *g) {
 			a = (RzANode *)ga->data;
 			out_nodes_it = agraph_out_neighbors(g, ga);
 
-			if (!out_nodes_it || !a) {
+			if (rz_iterator_is_uninit(&out_nodes_it) || !a) {
 				continue;
 			}
-			rz_iterator_foreach(out_nodes_it, gb) {
+			rz_iterator_foreach(&out_nodes_it, gb) {
 				if (!(b = gb->data)) {
 					break;
 				}
@@ -2357,8 +2322,7 @@ static void set_layer_gap(RzAGraph *g) {
 					}
 				}
 			}
-			rz_iterator_fini(out_nodes_it);
-			free(out_nodes_it);
+			rz_iterator_fini(&out_nodes_it);
 		}
 		if (i + 1 < g->n_layers) {
 			g->layers[i + 1].gap += gap;
@@ -2372,12 +2336,12 @@ static void fix_back_edge_dummy_nodes(RzAGraph *g, RzANode *from, RzANode *to) {
 	int i;
 	rz_return_if_fail(g && from && to);
 
-	RzIterator *it_neighbours = agraph_out_neighbors(g, to->gnode);
-	if (!it_neighbours) {
+	RzIterator it_neighbours = agraph_out_neighbors(g, to->gnode);
+	if (rz_iterator_is_uninit(&it_neighbours)) {
 		return;
 	}
 
-	rz_iterator_foreach(it_neighbours, gv) {
+	rz_iterator_foreach(&it_neighbours, gv) {
 		if (!(v = gv->data)) {
 			break;
 		}
@@ -2390,8 +2354,7 @@ static void fix_back_edge_dummy_nodes(RzAGraph *g, RzANode *from, RzANode *to) {
 		}
 		tmp = NULL;
 	}
-	rz_iterator_fini(it_neighbours);
-	free(it_neighbours);
+	rz_iterator_fini(&it_neighbours);
 
 	if (tmp) {
 		tmp = v;
@@ -2600,12 +2563,12 @@ static void backedge_info(RzAGraph *g) {
 				outedge += rz_graph_out_degree(g->graph, a->gnode);
 			}
 
-			RzIterator *it_neighbours = agraph_out_neighbors(g, a->gnode);
-			if (!it_neighbours) {
+			RzIterator it_neighbours = agraph_out_neighbors(g, a->gnode);
+			if (rz_iterator_is_uninit(&it_neighbours)) {
 				continue;
 			}
 
-			rz_iterator_foreach(it_neighbours, gb) {
+			rz_iterator_foreach(&it_neighbours, gb) {
 				if (!(b = gb->data)) {
 					break;
 				}
@@ -2666,8 +2629,7 @@ static void backedge_info(RzAGraph *g) {
 
 				rz_list_append(g->edges, e);
 			}
-			rz_iterator_fini(it_neighbours);
-			free(it_neighbours);
+			rz_iterator_fini(&it_neighbours);
 		}
 	}
 
@@ -3042,12 +3004,12 @@ static void fold_asm_trace(RzCore *core, RzAGraph *g) {
 
 	RzANode *curnode = get_anode(g->curnode);
 
-	RzIterator *nodes = agraph_get_nodes(g);
-	if (!nodes) {
+	RzIterator nodes = agraph_get_nodes(g);
+	if (rz_iterator_is_uninit(&nodes)) {
 		return;
 	}
 
-	rz_iterator_foreach(nodes, gn) {
+	rz_iterator_foreach(&nodes, gn) {
 		if (!(n = gn->data)) {
 			break;
 		}
@@ -3060,23 +3022,22 @@ static void fold_asm_trace(RzCore *core, RzAGraph *g) {
 		RzDebugTracepoint *tp = rz_debug_trace_get(core->dbg, addr);
 		n->is_mini = (tp == NULL);
 	}
-	rz_iterator_fini(nodes);
-	free(nodes);
+	rz_iterator_fini(&nodes);
 	g->need_update_dim = 1;
 	// agraph_refresh (rz_cons_singleton ()->event_data);
 }
 
 static void delete_dup_edges(RzAGraph *g) {
-	RzIterator *node_it = agraph_get_nodes(g);
+	RzIterator node_it = agraph_get_nodes(g);
 	RzGraphNode *n;
-	rz_iterator_foreach(node_it, n) {
+	rz_iterator_foreach(&node_it, n) {
 		RzPVector *seen = rz_pvector_new(NULL);
 		RzPVector *dups = rz_pvector_new(NULL);
 
-		RzIterator *out_it = agraph_out_neighbors(g, n);
+		RzIterator out_it = agraph_out_neighbors(g, n);
 		RzGraphNode *target;
-		if (out_it) {
-			rz_iterator_foreach(out_it, target) {
+		if (!rz_iterator_is_uninit(&out_it)) {
+			rz_iterator_foreach(&out_it, target) {
 				bool found = false;
 				void **pit;
 				rz_pvector_foreach (seen, pit) {
@@ -3091,8 +3052,7 @@ static void delete_dup_edges(RzAGraph *g) {
 					rz_pvector_push(seen, target);
 				}
 			}
-			rz_iterator_fini(out_it);
-			free(out_it);
+			rz_iterator_fini(&out_it);
 		}
 
 		void **pit;
@@ -3103,8 +3063,7 @@ static void delete_dup_edges(RzAGraph *g) {
 		rz_pvector_free(seen);
 		rz_pvector_free(dups);
 	}
-	rz_iterator_fini(node_it);
-	free(node_it);
+	rz_iterator_fini(&node_it);
 }
 
 static bool isbbfew(RzAnalysisBlock *curbb, RzAnalysisBlock *bb) {
@@ -3375,12 +3334,12 @@ static const RzGraphNode *find_near_of(const RzAGraph *g, const RzGraphNode *cur
 	const int start_x = acur ? acur->x : default_v;
 	const int start_y = acur ? acur->y : default_v;
 
-	RzIterator *nodes = agraph_get_nodes(g);
-	if (!nodes) {
+	RzIterator nodes = agraph_get_nodes(g);
+	if (rz_iterator_is_uninit(&nodes)) {
 		return NULL;
 	}
 
-	rz_iterator_foreach(nodes, gn) {
+	rz_iterator_foreach(&nodes, gn) {
 		if (!(n = gn->data)) {
 			break;
 		}
@@ -3405,8 +3364,7 @@ static const RzGraphNode *find_near_of(const RzAGraph *g, const RzGraphNode *cur
 			}
 		}
 	}
-	rz_iterator_fini(nodes);
-	free(nodes);
+	rz_iterator_fini(&nodes);
 
 	if (!resgn && cur) {
 		resgn = find_near_of(g, NULL, is_next);
@@ -3426,12 +3384,12 @@ static void update_graph_sizes(RzAGraph *g) {
 	max_x = max_y = INT_MIN;
 	min_gn = max_gn = NULL;
 
-	RzIterator *it_nodes = agraph_get_nodes(g);
-	if (!it_nodes) {
+	RzIterator it_nodes = agraph_get_nodes(g);
+	if (rz_iterator_is_uninit(&it_nodes)) {
 		return;
 	}
 
-	rz_iterator_foreach(it_nodes, gk) {
+	rz_iterator_foreach(&it_nodes, gk) {
 		if (!(ak = gk->data)) {
 			break;
 		}
@@ -3461,8 +3419,7 @@ static void update_graph_sizes(RzAGraph *g) {
 			max_gn = ak;
 		}
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 
 	/* while calculating the graph size, take into account long edges */
 	rz_list_foreach (g->edges, it, e) {
@@ -3566,12 +3523,12 @@ static void agraph_set_layout(RzAGraph *g) {
 
 	update_graph_sizes(g);
 
-	RzIterator *it_nodes = agraph_get_nodes(g);
-	if (!it_nodes) {
+	RzIterator it_nodes = agraph_get_nodes(g);
+	if (rz_iterator_is_uninit(&it_nodes)) {
 		return;
 	}
 
-	rz_iterator_foreach(it_nodes, n) {
+	rz_iterator_foreach(&it_nodes, n) {
 		if (!(a = n->data)) {
 			break;
 		}
@@ -3588,8 +3545,7 @@ static void agraph_set_layout(RzAGraph *g) {
 		rz_strf(buf, "agraph.nodes.%s.h", a->title);
 		sdb_num_set(g->db, buf, a->h);
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 }
 
 /* set the willing to center the screen on a particular node */
@@ -3615,12 +3571,12 @@ static void agraph_print_nodes(const RzAGraph *g, const AGraphContext *grp_ctx) 
 	RzGraphNode *gn;
 	RzANode *n;
 
-	RzIterator *it_nodes = agraph_get_nodes(g);
-	if (!it_nodes) {
+	RzIterator it_nodes = agraph_get_nodes(g);
+	if (rz_iterator_is_uninit(&it_nodes)) {
 		return;
 	}
 
-	rz_iterator_foreach(it_nodes, gn) {
+	rz_iterator_foreach(&it_nodes, gn) {
 		if (!(n = gn->data)) {
 			break;
 		}
@@ -3628,8 +3584,7 @@ static void agraph_print_nodes(const RzAGraph *g, const AGraphContext *grp_ctx) 
 			agraph_print_node(g, n, grp_ctx);
 		}
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 
 	/* draw current node now to make it appear on top */
 	if (g->curnode) {
@@ -3664,22 +3619,22 @@ static void agraph_print_edges_simple(RzAGraph *g) {
 	RzANode *n, *n2;
 	RzGraphNode *gn, *gn2;
 
-	RzIterator *it_nodes = agraph_get_nodes(g);
-	if (!it_nodes) {
+	RzIterator it_nodes = agraph_get_nodes(g);
+	if (rz_iterator_is_uninit(&it_nodes)) {
 		return;
 	}
 
-	rz_iterator_foreach(it_nodes, gn) {
+	rz_iterator_foreach(&it_nodes, gn) {
 		if (!(n = gn->data)) {
 			break;
 		}
 
-		RzIterator *it_outnodes = agraph_out_neighbors(g, gn);
-		if (!it_outnodes) {
+		RzIterator it_outnodes = agraph_out_neighbors(g, gn);
+		if (rz_iterator_is_uninit(&it_outnodes)) {
 			continue;
 		}
 
-		rz_iterator_foreach(it_outnodes, gn2) {
+		rz_iterator_foreach(&it_outnodes, gn2) {
 			if (!(n2 = gn2->data)) {
 				break;
 			}
@@ -3697,11 +3652,9 @@ static void agraph_print_edges_simple(RzAGraph *g) {
 					n2->x + sx2, n2->y + n2->h, &style);
 			}
 		}
-		rz_iterator_fini(it_outnodes);
-		free(it_outnodes);
+		rz_iterator_fini(&it_outnodes);
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 }
 
 static void agraph_print_edges(RzAGraph *g) {
@@ -3717,8 +3670,8 @@ static void agraph_print_edges(RzAGraph *g) {
 	RzCanvasLineStyle style = { 0 };
 	RzGraphNode *ga;
 	RzANode *a;
-	RzIterator *it_nodes = agraph_get_nodes(g);
-	if (!it_nodes) {
+	RzIterator it_nodes = agraph_get_nodes(g);
+	if (rz_iterator_is_uninit(&it_nodes)) {
 		return;
 	}
 
@@ -3726,7 +3679,7 @@ static void agraph_print_edges(RzAGraph *g) {
 	RzList *bckedges = rz_list_new();
 	struct tmplayer *tl, *tm;
 
-	rz_iterator_foreach(it_nodes, ga) {
+	rz_iterator_foreach(&it_nodes, ga) {
 		if (!(a = ga->data)) {
 			break;
 		}
@@ -3954,8 +3907,7 @@ static void agraph_print_edges(RzAGraph *g) {
 		}
 		rz_pvector_free(draw_neighbours);
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 
 	struct tmpbackedgeinfo *temp;
 	rz_list_foreach (bckedges, itm, temp) {
@@ -4103,13 +4055,13 @@ static void agraph_follow_innodes(RzAGraph *g, bool in) {
 	rz_cons_gotoxy(0, 2);
 	rz_cons_printf(in ? "Input nodes:\n" : "Output nodes:\n");
 	RzList *options = rz_list_newf(NULL);
-	RzIterator *it_gnodes = in ? agraph_in_neighbors(g, an->gnode) : agraph_out_neighbors(g, an->gnode);
-	if (!it_gnodes) {
+	RzIterator it_gnodes = in ? agraph_in_neighbors(g, an->gnode) : agraph_out_neighbors(g, an->gnode);
+	if (rz_iterator_is_uninit(&it_gnodes)) {
 		rz_list_free(options);
 		return;
 	}
 	RzGraphNode *gn;
-	rz_iterator_foreach(it_gnodes, gn) {
+	rz_iterator_foreach(&it_gnodes, gn) {
 		RzANode *an = get_anode(gn);
 		RzGraphNode *gnn = agraph_get_title(g, an, in);
 		if (gnn) {
@@ -4127,8 +4079,7 @@ static void agraph_follow_innodes(RzAGraph *g, bool in) {
 			count++;
 		}
 	}
-	rz_iterator_fini(it_gnodes);
-	free(it_gnodes);
+	rz_iterator_fini(&it_gnodes);
 
 	rz_cons_flush();
 	if (gdegree == 1) {
@@ -4578,12 +4529,12 @@ static char *agraph_build_sdb_neighbours(const RzAGraph *g, const RzGraphNode *n
 }
 
 static void agraph_sync_sdb_neighbours(const RzAGraph *g) {
-	RzIterator *it_nodes = agraph_get_nodes(g);
-	if (!it_nodes) {
+	RzIterator it_nodes = agraph_get_nodes(g);
+	if (rz_iterator_is_uninit(&it_nodes)) {
 		return;
 	}
 	RzGraphNode *node;
-	rz_iterator_foreach(it_nodes, node) {
+	rz_iterator_foreach(&it_nodes, node) {
 		RzANode *anode = get_anode(node);
 		if (!anode || RZ_STR_ISEMPTY(anode->title)) {
 			continue;
@@ -4594,8 +4545,7 @@ static void agraph_sync_sdb_neighbours(const RzAGraph *g) {
 		sdb_set(g->db, key, value);
 		free(value);
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 }
 
 RZ_API Sdb *rz_agraph_get_sdb(RzAGraph *g) {
@@ -4622,12 +4572,12 @@ RZ_API void rz_agraph_print_json(RzAGraph *g, PJ *pj) {
 		return;
 	}
 
-	RzIterator *it_nodes = agraph_get_nodes(g);
-	if (!it_nodes) {
+	RzIterator it_nodes = agraph_get_nodes(g);
+	if (rz_iterator_is_uninit(&it_nodes)) {
 		return;
 	}
 
-	rz_iterator_foreach(it_nodes, node) {
+	rz_iterator_foreach(&it_nodes, node) {
 		RzANode *anode = (RzANode *)node->data;
 		char *label = rz_str_dup(anode->body);
 		pj_o(pj);
@@ -4638,22 +4588,20 @@ RZ_API void rz_agraph_print_json(RzAGraph *g, PJ *pj) {
 		pj_k(pj, "out_nodes");
 		pj_a(pj);
 
-		RzIterator *neighbours = agraph_out_neighbors(g, anode->gnode);
-		if (neighbours) {
-			rz_iterator_foreach(neighbours, neighbour) {
+		RzIterator neighbours = agraph_out_neighbors(g, anode->gnode);
+		if (!rz_iterator_is_uninit(&neighbours)) {
+			rz_iterator_foreach(&neighbours, neighbour) {
 				// TODO: use accesser mode
 				pj_i(pj, rz_graph_node_get_vec_id(neighbour));
 			}
-			rz_iterator_fini(neighbours);
-			free(neighbours);
+			rz_iterator_fini(&neighbours);
 		}
 
 		pj_end(pj);
 		pj_end(pj);
 		free(label);
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 }
 
 RZ_API void rz_agraph_set_title(RzAGraph *g, const char *title) {
@@ -4784,9 +4732,9 @@ RZ_API bool rz_agraph_del_node(const RzAGraph *g, const char *title) {
 	rz_strf(buf, "agraph.nodes.%s.neighbours", res->title);
 	sdb_set(g->db, buf, NULL);
 
-	RzIterator *it_innodes = agraph_in_neighbors(g, res->gnode);
-	if (it_innodes) {
-		rz_iterator_foreach(it_innodes, gn) {
+	RzIterator it_innodes = agraph_in_neighbors(g, res->gnode);
+	if (!rz_iterator_is_uninit(&it_innodes)) {
+		rz_iterator_foreach(&it_innodes, gn) {
 			if (!(an = gn->data)) {
 				break;
 			}
@@ -4794,8 +4742,7 @@ RZ_API bool rz_agraph_del_node(const RzAGraph *g, const char *title) {
 			const char *key = buf;
 			sdb_array_remove(g->db, key, res->title);
 		}
-		rz_iterator_fini(it_innodes);
-		free(it_innodes);
+		rz_iterator_fini(&it_innodes);
 	}
 
 	rz_graph_del_node(g->graph, res->gnode);
@@ -4824,20 +4771,19 @@ static bool user_edge_cb(struct g_cb *user, RZ_UNUSED const char *k, const void 
 		return false;
 	}
 
-	RzIterator *it_neigh = agraph_out_neighbors(g, n->gnode);
+	RzIterator it_neigh = agraph_out_neighbors(g, n->gnode);
 	RzGraphNode *gn;
-	if (!it_neigh) {
+	if (rz_iterator_is_uninit(&it_neigh)) {
 		return true;
 	}
 
-	rz_iterator_foreach(it_neigh, gn) {
+	rz_iterator_foreach(&it_neigh, gn) {
 		if (!(an = gn->data)) {
 			break;
 		}
 		cb(n, an, user_data);
 	}
-	rz_iterator_fini(it_neigh);
-	free(it_neigh);
+	rz_iterator_fini(&it_neigh);
 	return true;
 }
 
@@ -4859,13 +4805,12 @@ RZ_API void rz_agraph_foreach_edge(RzAGraph *g, RAEdgeCallback cb, void *user) {
 }
 
 RZ_API RzANode *rz_agraph_get_first_node(const RzAGraph *g) {
-	RzIterator *it = agraph_get_nodes(g);
-	if (!it) {
+	RzIterator it = agraph_get_nodes(g);
+	if (rz_iterator_is_uninit(&it)) {
 		return NULL;
 	}
-	RzGraphNode *rgn = rz_iterator_next(it);
-	rz_iterator_fini(it);
-	free(it);
+	RzGraphNode *rgn = rz_iterator_next(&it);
+	rz_iterator_fini(&it);
 	return get_anode(rgn);
 }
 
@@ -5958,12 +5903,12 @@ RZ_API bool rz_core_create_agraph_from_graph_at(RZ_NONNULL RzAGraph *ag, RZ_NONN
 	// List of the new RzANodes
 	RzGraphNode *node;
 	// Traverse the list, create new ANode for each Node
-	RzIterator *it_nodes = rz_graph_get_nodes(g);
-	if (!it_nodes) {
+	RzIterator it_nodes = rz_graph_get_nodes(g);
+	if (rz_iterator_is_uninit(&it_nodes)) {
 		goto failure;
 	}
 
-	rz_iterator_foreach(it_nodes, node) {
+	rz_iterator_foreach(&it_nodes, node) {
 		RzGraphNodeInfo *info = node->data;
 		RzANode *a_node = rz_agraph_add_node_from_node_info(ag, info, utf8);
 		if (!a_node) {
@@ -5971,16 +5916,15 @@ RZ_API bool rz_core_create_agraph_from_graph_at(RZ_NONNULL RzAGraph *ag, RZ_NONN
 		}
 		ht_pp_insert(hashmap, node, a_node);
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 
 	// Traverse the nodes again, now build up the edges
 	it_nodes = rz_graph_get_nodes(g);
-	if (!it_nodes) {
+	if (rz_iterator_is_uninit(&it_nodes)) {
 		goto failure;
 	}
 
-	rz_iterator_foreach(it_nodes, node) {
+	rz_iterator_foreach(&it_nodes, node) {
 		RzANode *a_node = ht_pp_find(hashmap, node, NULL);
 		if (!a_node) {
 			goto failure; // shouldn't happen in correct graph state
@@ -5989,18 +5933,17 @@ RZ_API bool rz_core_create_agraph_from_graph_at(RZ_NONNULL RzAGraph *ag, RZ_NONN
 
 		if (info && info->type == RZ_GRAPH_NODE_TYPE_CFG) {
 			RzGraphEdge *out_edge;
-			RzIterator *out_edge_iter = rz_graph_out_edges((RzGraph *)g, node);
+			RzIterator out_edge_iter = rz_graph_out_edges((RzGraph *)g, node);
 			ut64 edge_idx = 0;
-			if (!out_edge_iter) {
+			if (rz_iterator_is_uninit(&out_edge_iter)) {
 				continue;
 			}
 
-			rz_iterator_foreach(out_edge_iter, out_edge) {
+			rz_iterator_foreach(&out_edge_iter, out_edge) {
 				RzGraphNode *to_node = out_edge ? out_edge->to : NULL;
 				RzANode *a_neighbour = ht_pp_find(hashmap, to_node, NULL);
 				if (!a_neighbour) {
-					rz_iterator_fini(out_edge_iter);
-					free(out_edge_iter);
+					rz_iterator_fini(&out_edge_iter);
 					goto failure;
 				}
 				if ((info->subtype & RZ_GRAPH_NODE_SUBTYPE_CFG_COND) && edge_idx < 2) {
@@ -6013,8 +5956,7 @@ RZ_API bool rz_core_create_agraph_from_graph_at(RZ_NONNULL RzAGraph *ag, RZ_NONN
 				}
 				edge_idx++;
 			}
-			rz_iterator_fini(out_edge_iter);
-			free(out_edge_iter);
+			rz_iterator_fini(&out_edge_iter);
 			continue;
 		}
 
@@ -6023,26 +5965,23 @@ RZ_API bool rz_core_create_agraph_from_graph_at(RZ_NONNULL RzAGraph *ag, RZ_NONN
 		 * order shaped both global creation_order and each source node's
 		 * out-edge order, which downstream layout/drawing still depends on. */
 		RzGraphEdge *in_edge;
-		RzIterator *in_edge_iter = rz_graph_in_edges((RzGraph *)g, node);
-		if (!in_edge_iter) {
+		RzIterator in_edge_iter = rz_graph_in_edges((RzGraph *)g, node);
+		if (rz_iterator_is_uninit(&in_edge_iter)) {
 			continue;
 		}
 
-		rz_iterator_foreach(in_edge_iter, in_edge) {
+		rz_iterator_foreach(&in_edge_iter, in_edge) {
 			RzGraphNode *from_node = in_edge ? in_edge->from : NULL;
 			RzANode *a_neighbour = ht_pp_find(hashmap, from_node, NULL);
 			if (!a_neighbour) {
-				rz_iterator_fini(in_edge_iter);
-				free(in_edge_iter);
+				rz_iterator_fini(&in_edge_iter);
 				goto failure;
 			}
 			rz_agraph_add_edge(ag, a_neighbour, a_node);
 		}
-		rz_iterator_fini(in_edge_iter);
-		free(in_edge_iter);
+		rz_iterator_fini(&in_edge_iter);
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 
 	ht_pp_free(hashmap);
 	return true;

--- a/librz/core/agraph.c
+++ b/librz/core/agraph.c
@@ -144,8 +144,19 @@ static RzIterator *pvector_as_owned_iter(RzPVector /*<void *>*/ *vec) {
 		return NULL;
 	}
 	s->vec = vec;
-	RzIterator *it = rz_iterator_new(pvec_owned_iter_next, NULL, pvec_owned_iter_free, s);
-	if (!it) {
+
+	/**
+	 * RzIterator *it = rz_iterator_new(pvec_owned_iter_next, NULL, pvec_owned_iter_free, s);
+	 * Replaced with explicit allocation instead of rz_iterator_new because
+	 * this function must keep returning RzIterator* for graph interface compatibility.
+	 */
+	RzIterator *it = RZ_NEW0(RzIterator);
+	if (it) {
+		it->next = pvec_owned_iter_next;
+		it->free = NULL;
+		it->free_u = pvec_owned_iter_free;
+		it->u = s;
+	} else {
 		pvec_owned_iter_free(s);
 		return NULL;
 	}
@@ -429,7 +440,8 @@ static RzPVector /*<RzGraphNode *>*/ *agraph_collect_draw_neighbours(const RzAGr
 				rz_pvector_push(neighbours, neighbour);
 			}
 		}
-		rz_iterator_free(it_neighbours);
+		rz_iterator_fini(it_neighbours);
+		free(it_neighbours);
 	}
 	const size_t len = rz_pvector_len(neighbours);
 	if (!g->is_callgraph && len > 2) {
@@ -458,7 +470,8 @@ static RzPVector /*<RzGraphEdge *>*/ *agraph_collect_edges(const RzAGraph *g, co
 	}
 	RzPVector *edges = rz_pvector_new(NULL);
 	if (!edges) {
-		rz_iterator_free(it_edges);
+		rz_iterator_fini(it_edges);
+		free(it_edges);
 		return NULL;
 	}
 	RzGraphEdge *edge = NULL;
@@ -467,7 +480,8 @@ static RzPVector /*<RzGraphEdge *>*/ *agraph_collect_edges(const RzAGraph *g, co
 			rz_pvector_push(edges, edge);
 		}
 	}
-	rz_iterator_free(it_edges);
+	rz_iterator_fini(it_edges);
+	free(it_edges);
 	if (sorted && rz_pvector_len(edges) > 1) {
 		rz_pvector_sort(edges, outgoing ? agraph_out_edge_order_cmp : agraph_in_edge_order_cmp, NULL);
 	}
@@ -597,7 +611,8 @@ static RzGraphNode *agraph_get_title(const RzAGraph *g, RzANode *n, bool in) {
 		res = agraph_get_title(g, an, in);
 		break;
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 	return res;
 }
 
@@ -699,7 +714,8 @@ static void update_node_dimension(const RzAGraph *ag, int is_mini, int zoom, int
 			}
 		}
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 }
 
 static void append_shortcut(const RzAGraph *g, char *title, char *nodetitle, int left) {
@@ -917,7 +933,8 @@ static int **get_crossing_matrix(const RzAGraph *g,
 					RzGraphNode *gt;
 					RzIterator *it_neighs_s = agraph_out_neighbors(g, gs);
 					if (!it_neighs_s) {
-						rz_iterator_free(it_neighs);
+						rz_iterator_fini(it_neighs);
+						free(it_neighs);
 						goto err_row;
 					}
 
@@ -936,10 +953,12 @@ static int **get_crossing_matrix(const RzAGraph *g,
 						m[ak->pos_in_layer][at->pos_in_layer]++;
 					}
 
-					rz_iterator_free(it_neighs_s);
+					rz_iterator_fini(it_neighs_s);
+					free(it_neighs_s);
 				}
 			}
-			rz_iterator_free(it_neighs);
+			rz_iterator_fini(it_neighs);
+			free(it_neighs);
 		}
 	}
 
@@ -977,7 +996,8 @@ static int **get_crossing_matrix(const RzAGraph *g,
 
 					RzIterator *it_neighbour_s = agraph_out_neighbors(g, gs);
 					if (!it_neighbour_s) {
-						rz_iterator_free(neighbour_itk);
+						rz_iterator_fini(neighbour_itk);
+						free(neighbour_itk);
 						goto err_row;
 					}
 
@@ -990,10 +1010,12 @@ static int **get_crossing_matrix(const RzAGraph *g,
 						}
 					}
 
-					rz_iterator_free(it_neighbour_s);
+					rz_iterator_fini(it_neighbour_s);
+					free(it_neighbour_s);
 				}
 			}
-			rz_iterator_free(neighbour_itk);
+			rz_iterator_fini(neighbour_itk);
+			free(neighbour_itk);
 		}
 	}
 
@@ -1146,7 +1168,8 @@ static void assign_layers(const RzAGraph *g) {
 			n->layer = 0;
 		}
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 
 	/* build remaining-in-degree table */
 	HtPUOptions opt = { 0 };
@@ -1174,7 +1197,8 @@ static void assign_layers(const RzAGraph *g) {
 			rz_list_append(queue, gn);
 		}
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 
 	/* Kahn's BFS: process each node once all parents are done */
 	while (rz_list_length(queue) > 0) {
@@ -1209,7 +1233,8 @@ static void assign_layers(const RzAGraph *g) {
 				}
 			}
 		}
-		rz_iterator_free(out_it);
+		rz_iterator_fini(out_it);
+		free(out_it);
 	}
 
 	rz_list_free(queue);
@@ -1257,7 +1282,8 @@ static void create_dummy_nodes(RzAGraph *g) {
 			}
 			rz_pvector_free(edges);
 		}
-		rz_iterator_free(nodes_it);
+		rz_iterator_fini(nodes_it);
+		free(nodes_it);
 	}
 
 	const RzListIter *it;
@@ -1314,7 +1340,8 @@ static void create_layers(RzAGraph *g) {
 			g->n_layers = n->layer;
 		}
 	}
-	rz_iterator_free(nodes_it);
+	rz_iterator_fini(nodes_it);
+	free(nodes_it);
 
 	/* create a starting ordering of nodes for each layer */
 	g->n_layers++;
@@ -1330,7 +1357,8 @@ static void create_layers(RzAGraph *g) {
 		}
 		g->layers[n->layer].n_nodes++;
 	}
-	rz_iterator_free(nodes_it);
+	rz_iterator_fini(nodes_it);
+	free(nodes_it);
 
 	for (i = 0; i < g->n_layers; i++) {
 		if (sizeof(RzGraphNode *) * g->layers[i].n_nodes < g->layers[i].n_nodes) {
@@ -1348,7 +1376,8 @@ static void create_layers(RzAGraph *g) {
 		n->pos_in_layer = g->layers[n->layer].position;
 		g->layers[n->layer].nodes[g->layers[n->layer].position++] = gn;
 	}
-	rz_iterator_free(nodes_it);
+	rz_iterator_fini(nodes_it);
+	free(nodes_it);
 }
 
 /* layer-by-layer sweep */
@@ -1549,7 +1578,8 @@ static RzList /*<RzGraphNode *>*/ **compute_classes(const RzAGraph *g, HtPP /*<R
 		}
 		n->klass = -1;
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 
 	for (i = 0; i < g->n_layers; i++) {
 		c = i;
@@ -1676,7 +1706,8 @@ static void adjust_class(const RzAGraph *g, int is_left, RzList /*<RzGraphNode *
 					}
 				}
 			}
-			rz_iterator_free(it_neigh_in);
+			rz_iterator_fini(it_neigh_in);
+			free(it_neigh_in);
 
 			RzIterator *it_neigh_out = agraph_out_neighbors(g, gn);
 			if (!it_neigh_out) {
@@ -1693,7 +1724,8 @@ static void adjust_class(const RzAGraph *g, int is_left, RzList /*<RzGraphNode *
 					}
 				}
 			}
-			rz_iterator_free(it_neigh_out);
+			rz_iterator_fini(it_neigh_out);
+			free(it_neigh_out);
 		}
 
 		len = rz_list_length(heap);
@@ -1849,7 +1881,8 @@ static void place_dummies(const RzAGraph *g) {
 		}
 		n->x = (hash_get_int(xminus, gn) + hash_get_int(xplus, gn)) / 2;
 	}
-	rz_iterator_free(nodes);
+	rz_iterator_fini(nodes);
+	free(nodes);
 
 general_err:
 	ht_pu_free(xplus);
@@ -1951,7 +1984,8 @@ static void place_single(const RzAGraph *g, int l, const RzGraphNode *bm, const 
 		? rz_graph_in_degree(g->graph, v)
 		: rz_graph_out_degree(g->graph, v);
 	if (len == 0) {
-		rz_iterator_free(it_neigh);
+		rz_iterator_fini(it_neigh);
+		free(it_neigh);
 		return;
 	}
 
@@ -1969,7 +2003,8 @@ static void place_single(const RzAGraph *g, int l, const RzGraphNode *bm, const 
 		}
 		sum_x += ak->x;
 	}
-	rz_iterator_free(it_neigh);
+	rz_iterator_fini(it_neigh);
+	free(it_neigh);
 
 	if (len == 0) {
 		return;
@@ -2038,7 +2073,8 @@ static void collect_changes(const RzAGraph *g, int l, const RzGraphNode *b, int 
 				rz_list_add_sorted(list, cx, lcmp, NULL);
 			}
 		}
-		rz_iterator_free(it_neigh);
+		rz_iterator_fini(it_neigh);
+		free(it_neigh);
 
 		cx = RZ_NEW0(struct len_pos_t);
 		cx->len = c;
@@ -2261,7 +2297,8 @@ static void place_original(RzAGraph *g) {
 			ht_pu_update(P, gn, (ut64)(size_t)dt_eq);
 		}
 	}
-	rz_iterator_free(nodes);
+	rz_iterator_fini(nodes);
+	free(nodes);
 
 	original_traverse_l(g, D, P, true);
 	original_traverse_l(g, D, P, false);
@@ -2320,7 +2357,8 @@ static void set_layer_gap(RzAGraph *g) {
 					}
 				}
 			}
-			rz_iterator_free(out_nodes_it);
+			rz_iterator_fini(out_nodes_it);
+			free(out_nodes_it);
 		}
 		if (i + 1 < g->n_layers) {
 			g->layers[i + 1].gap += gap;
@@ -2352,7 +2390,8 @@ static void fix_back_edge_dummy_nodes(RzAGraph *g, RzANode *from, RzANode *to) {
 		}
 		tmp = NULL;
 	}
-	rz_iterator_free(it_neighbours);
+	rz_iterator_fini(it_neighbours);
+	free(it_neighbours);
 
 	if (tmp) {
 		tmp = v;
@@ -2627,7 +2666,8 @@ static void backedge_info(RzAGraph *g) {
 
 				rz_list_append(g->edges, e);
 			}
-			rz_iterator_free(it_neighbours);
+			rz_iterator_fini(it_neighbours);
+			free(it_neighbours);
 		}
 	}
 
@@ -3020,7 +3060,8 @@ static void fold_asm_trace(RzCore *core, RzAGraph *g) {
 		RzDebugTracepoint *tp = rz_debug_trace_get(core->dbg, addr);
 		n->is_mini = (tp == NULL);
 	}
-	rz_iterator_free(nodes);
+	rz_iterator_fini(nodes);
+	free(nodes);
 	g->need_update_dim = 1;
 	// agraph_refresh (rz_cons_singleton ()->event_data);
 }
@@ -3050,7 +3091,8 @@ static void delete_dup_edges(RzAGraph *g) {
 					rz_pvector_push(seen, target);
 				}
 			}
-			rz_iterator_free(out_it);
+			rz_iterator_fini(out_it);
+			free(out_it);
 		}
 
 		void **pit;
@@ -3061,7 +3103,8 @@ static void delete_dup_edges(RzAGraph *g) {
 		rz_pvector_free(seen);
 		rz_pvector_free(dups);
 	}
-	rz_iterator_free(node_it);
+	rz_iterator_fini(node_it);
+	free(node_it);
 }
 
 static bool isbbfew(RzAnalysisBlock *curbb, RzAnalysisBlock *bb) {
@@ -3362,7 +3405,8 @@ static const RzGraphNode *find_near_of(const RzAGraph *g, const RzGraphNode *cur
 			}
 		}
 	}
-	rz_iterator_free(nodes);
+	rz_iterator_fini(nodes);
+	free(nodes);
 
 	if (!resgn && cur) {
 		resgn = find_near_of(g, NULL, is_next);
@@ -3417,7 +3461,8 @@ static void update_graph_sizes(RzAGraph *g) {
 			max_gn = ak;
 		}
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 
 	/* while calculating the graph size, take into account long edges */
 	rz_list_foreach (g->edges, it, e) {
@@ -3543,7 +3588,8 @@ static void agraph_set_layout(RzAGraph *g) {
 		rz_strf(buf, "agraph.nodes.%s.h", a->title);
 		sdb_num_set(g->db, buf, a->h);
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 }
 
 /* set the willing to center the screen on a particular node */
@@ -3582,7 +3628,8 @@ static void agraph_print_nodes(const RzAGraph *g, const AGraphContext *grp_ctx) 
 			agraph_print_node(g, n, grp_ctx);
 		}
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 
 	/* draw current node now to make it appear on top */
 	if (g->curnode) {
@@ -3650,9 +3697,11 @@ static void agraph_print_edges_simple(RzAGraph *g) {
 					n2->x + sx2, n2->y + n2->h, &style);
 			}
 		}
-		rz_iterator_free(it_outnodes);
+		rz_iterator_fini(it_outnodes);
+		free(it_outnodes);
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 }
 
 static void agraph_print_edges(RzAGraph *g) {
@@ -3905,7 +3954,8 @@ static void agraph_print_edges(RzAGraph *g) {
 		}
 		rz_pvector_free(draw_neighbours);
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 
 	struct tmpbackedgeinfo *temp;
 	rz_list_foreach (bckedges, itm, temp) {
@@ -4077,7 +4127,8 @@ static void agraph_follow_innodes(RzAGraph *g, bool in) {
 			count++;
 		}
 	}
-	rz_iterator_free(it_gnodes);
+	rz_iterator_fini(it_gnodes);
+	free(it_gnodes);
 
 	rz_cons_flush();
 	if (gdegree == 1) {
@@ -4543,7 +4594,8 @@ static void agraph_sync_sdb_neighbours(const RzAGraph *g) {
 		sdb_set(g->db, key, value);
 		free(value);
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 }
 
 RZ_API Sdb *rz_agraph_get_sdb(RzAGraph *g) {
@@ -4592,14 +4644,16 @@ RZ_API void rz_agraph_print_json(RzAGraph *g, PJ *pj) {
 				// TODO: use accesser mode
 				pj_i(pj, rz_graph_node_get_vec_id(neighbour));
 			}
-			rz_iterator_free(neighbours);
+			rz_iterator_fini(neighbours);
+			free(neighbours);
 		}
 
 		pj_end(pj);
 		pj_end(pj);
 		free(label);
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 }
 
 RZ_API void rz_agraph_set_title(RzAGraph *g, const char *title) {
@@ -4740,7 +4794,8 @@ RZ_API bool rz_agraph_del_node(const RzAGraph *g, const char *title) {
 			const char *key = buf;
 			sdb_array_remove(g->db, key, res->title);
 		}
-		rz_iterator_free(it_innodes);
+		rz_iterator_fini(it_innodes);
+		free(it_innodes);
 	}
 
 	rz_graph_del_node(g->graph, res->gnode);
@@ -4781,7 +4836,8 @@ static bool user_edge_cb(struct g_cb *user, RZ_UNUSED const char *k, const void 
 		}
 		cb(n, an, user_data);
 	}
-	rz_iterator_free(it_neigh);
+	rz_iterator_fini(it_neigh);
+	free(it_neigh);
 	return true;
 }
 
@@ -4808,7 +4864,8 @@ RZ_API RzANode *rz_agraph_get_first_node(const RzAGraph *g) {
 		return NULL;
 	}
 	RzGraphNode *rgn = rz_iterator_next(it);
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 	return get_anode(rgn);
 }
 
@@ -5914,7 +5971,8 @@ RZ_API bool rz_core_create_agraph_from_graph_at(RZ_NONNULL RzAGraph *ag, RZ_NONN
 		}
 		ht_pp_insert(hashmap, node, a_node);
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 
 	// Traverse the nodes again, now build up the edges
 	it_nodes = rz_graph_get_nodes(g);
@@ -5941,7 +5999,8 @@ RZ_API bool rz_core_create_agraph_from_graph_at(RZ_NONNULL RzAGraph *ag, RZ_NONN
 				RzGraphNode *to_node = out_edge ? out_edge->to : NULL;
 				RzANode *a_neighbour = ht_pp_find(hashmap, to_node, NULL);
 				if (!a_neighbour) {
-					rz_iterator_free(out_edge_iter);
+					rz_iterator_fini(out_edge_iter);
+					free(out_edge_iter);
 					goto failure;
 				}
 				if ((info->subtype & RZ_GRAPH_NODE_SUBTYPE_CFG_COND) && edge_idx < 2) {
@@ -5954,7 +6013,8 @@ RZ_API bool rz_core_create_agraph_from_graph_at(RZ_NONNULL RzAGraph *ag, RZ_NONN
 				}
 				edge_idx++;
 			}
-			rz_iterator_free(out_edge_iter);
+			rz_iterator_fini(out_edge_iter);
+			free(out_edge_iter);
 			continue;
 		}
 
@@ -5972,14 +6032,17 @@ RZ_API bool rz_core_create_agraph_from_graph_at(RZ_NONNULL RzAGraph *ag, RZ_NONN
 			RzGraphNode *from_node = in_edge ? in_edge->from : NULL;
 			RzANode *a_neighbour = ht_pp_find(hashmap, from_node, NULL);
 			if (!a_neighbour) {
-				rz_iterator_free(in_edge_iter);
+				rz_iterator_fini(in_edge_iter);
+				free(in_edge_iter);
 				goto failure;
 			}
 			rz_agraph_add_edge(ag, a_neighbour, a_node);
 		}
-		rz_iterator_free(in_edge_iter);
+		rz_iterator_fini(in_edge_iter);
+		free(in_edge_iter);
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 
 	ht_pp_free(hashmap);
 	return true;

--- a/librz/core/cagraph.c
+++ b/librz/core/cagraph.c
@@ -262,7 +262,8 @@ RZ_IPI bool rz_core_add_shortcuts(RzCore *core, RzAGraph *ag) {
 		RzANode *an = rz_graph_node_get_data_mut(gn);
 		rz_core_agraph_add_shortcut(core, ag, an, an->offset, an->title);
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 	return true;
 }
 

--- a/librz/core/cagraph.c
+++ b/librz/core/cagraph.c
@@ -253,17 +253,16 @@ RZ_IPI bool rz_core_agraph_add_shortcut(RzCore *core, RzAGraph *g, RzANode *an, 
 
 RZ_IPI bool rz_core_add_shortcuts(RzCore *core, RzAGraph *ag) {
 	rz_return_val_if_fail(core && ag, false);
-	RzIterator *it = rz_graph_get_nodes(ag->graph);
-	if (!it) {
+	RzIterator it = rz_graph_get_nodes(ag->graph);
+	if (rz_iterator_is_uninit(&it)) {
 		return false;
 	}
 	RzGraphNode *gn;
-	rz_iterator_foreach(it, gn) {
+	rz_iterator_foreach(&it, gn) {
 		RzANode *an = rz_graph_node_get_data_mut(gn);
 		rz_core_agraph_add_shortcut(core, ag, an, an->offset, an->title);
 	}
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 	return true;
 }
 

--- a/librz/core/canalysis.c
+++ b/librz/core/canalysis.c
@@ -3912,15 +3912,15 @@ static bool is_apple_target(RzCore *core) {
 }
 
 static void core_analysis_using_plugins(RzCore *core) {
-	RzIterator *it = ht_sp_as_iter(core->plugins);
+	RzIterator it = ht_sp_as_iter(core->plugins);
 	RzCorePlugin **val;
-	rz_iterator_foreach(it, val) {
+	rz_iterator_foreach(&it, val) {
 		RzCorePlugin *plugin = *val;
 		if (plugin->analysis) {
 			plugin->analysis(core, rz_core_plugin_context_get(core, plugin));
 		}
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 }
 
 static void core_analysis_analyze_local_var_and_arg(RzCore *core) {
@@ -5489,14 +5489,14 @@ static RzAnalysisOp *analysis_op_context_iter_next(RzIterator *it) {
  * \param mask The which analysis details should be disassembled.
  * \return RzIterator of RzAnalysisOp
  */
-RZ_API RZ_OWN RzIterator *rz_core_analysis_op_chunk_iter(
+RZ_API RZ_OWN RzIterator rz_core_analysis_op_chunk_iter(
 	RZ_NONNULL RzCore *core, ut64 start_addr, ut64 n_bytes, ut64 max_ops, RzAnalysisOpMask mask) {
-	rz_return_val_if_fail(core, NULL);
+	rz_return_val_if_fail(core, (RzIterator){ 0 });
 
 	AnalysisOpContext *ctx = RZ_NEW0(AnalysisOpContext);
 	if (!ctx || !analysis_op_context_init(ctx, core, start_addr, n_bytes, max_ops, mask)) {
 		free(ctx);
-		return NULL;
+		return (RzIterator){ 0 };
 	}
 
 	return rz_iterator_new((rz_iterator_next_cb)analysis_op_context_iter_next, (rz_iterator_free_cb)rz_analysis_op_fini, free, ctx);
@@ -5679,9 +5679,9 @@ static bool core_decoded_bytes_init(CoreDecodedBytes *ctx, RzCore *core, ut64 st
  * \param max_ops  analysis n ops
  * \return RzIterator of RzCoreDecodedBytes
  */
-RZ_API RZ_OWN RzIterator *rz_core_analysis_bytes(
+RZ_API RZ_OWN RzIterator rz_core_analysis_bytes(
 	RZ_NONNULL RzCore *core, ut64 start_addr, RZ_NONNULL const ut8 *buf, ut64 n_bytes, ut64 max_ops) {
-	rz_return_val_if_fail(core && buf, NULL);
+	rz_return_val_if_fail(core && buf, (RzIterator){ 0 });
 
 	// TODO: this should be removed once rz_config is refactored.
 	core->parser->subrel = rz_config_get_i(core->config, "asm.sub.rel");
@@ -5690,7 +5690,7 @@ RZ_API RZ_OWN RzIterator *rz_core_analysis_bytes(
 	CoreDecodedBytes *ctx = RZ_NEW0(CoreDecodedBytes);
 	if (!ctx || !core_decoded_bytes_init(ctx, core, start_addr, buf, n_bytes, max_ops)) {
 		free(ctx);
-		return NULL;
+		return (RzIterator){ 0 };
 	}
 
 	return rz_iterator_new((rz_iterator_next_cb)core_decoded_bytes_next, (rz_iterator_free_cb)analysis_bytes_iter_fini, free, ctx);
@@ -5704,10 +5704,10 @@ RZ_API RZ_OWN RzIterator *rz_core_analysis_bytes(
  * \param mask The which analysis details should be disassembled.
  * \return RzIterator of RzAnalysisOp
  */
-RZ_API RZ_OWN RzIterator *rz_core_analysis_op_function_iter(RZ_NONNULL RzCore *core, RZ_NONNULL RZ_BORROW RzAnalysisFunction *fcn, RzAnalysisOpMask mask) {
-	rz_return_val_if_fail(core && fcn, NULL);
+RZ_API RZ_OWN RzIterator rz_core_analysis_op_function_iter(RZ_NONNULL RzCore *core, RZ_NONNULL RZ_BORROW RzAnalysisFunction *fcn, RzAnalysisOpMask mask) {
+	rz_return_val_if_fail(core && fcn, (RzIterator){ 0 });
 
-	RzIterator *ops = NULL;
+	RzIterator ops = (RzIterator){ 0 };
 	ut64 start = fcn->addr;
 	ut64 end = rz_analysis_function_max_addr(fcn);
 	if (end <= start) {

--- a/librz/core/casm.c
+++ b/librz/core/casm.c
@@ -66,31 +66,31 @@ RZ_API char *rz_core_asm_search(RzCore *core, const char *input) {
 
 static const char *has_esil(RzCore *core, const char *name) {
 	rz_return_val_if_fail(core && core->analysis && name, NULL);
-	RzIterator *iter = rz_analysis_plugin_iterator(core->analysis);
+	RzIterator iter = rz_analysis_plugin_iterator(core->analysis);
 	RzAnalysisPlugin **val;
-	rz_iterator_foreach(iter, val) {
+	rz_iterator_foreach(&iter, val) {
 		RzAnalysisPlugin *h = *val;
 		if (!h->name || strcmp(name, h->name)) {
 			continue;
 		}
 		if (h->il_config && h->esil) {
 			// Analysis with RzIL and ESIL
-			rz_iterator_free(iter);
+			rz_iterator_fini(&iter);
 			return "AeI";
 		} else if (h->il_config) {
 			// Analysis with RzIL
-			rz_iterator_free(iter);
+			rz_iterator_fini(&iter);
 			return "A_I";
 		} else if (h->esil) {
 			// Analysis with ESIL
-			rz_iterator_free(iter);
+			rz_iterator_fini(&iter);
 			return "Ae_";
 		}
 		// Only the analysis plugin.
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 		return "A__";
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	return "___";
 }
 
@@ -244,10 +244,10 @@ RZ_API RzCmdStatus rz_core_asm_plugins_print(RZ_NONNULL RZ_BORROW RzCore *core, 
 	rz_return_val_if_fail(core && state, RZ_CMD_STATUS_ERROR);
 	RzAsm *a = core->rasm;
 
-	RzIterator *iter = rz_asm_plugin_iterator(a);
-	RzList *plugin_list = rz_list_new_from_iterator(iter);
+	RzIterator iter = rz_asm_plugin_iterator(a);
+	RzList *plugin_list = rz_list_new_from_iterator(&iter);
 	if (!plugin_list) {
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 		return RZ_CMD_STATUS_ERROR;
 	}
 	rz_list_sort(plugin_list, (RzListComparator)rz_asm_plugin_cmp, NULL);
@@ -260,7 +260,7 @@ RZ_API RzCmdStatus rz_core_asm_plugins_print(RZ_NONNULL RZ_BORROW RzCore *core, 
 	rz_list_foreach (plugin_list, it, ap) {
 		status = core_asm_plugin_print(core, ap, state, flags);
 		if (status != RZ_CMD_STATUS_OK) {
-			rz_iterator_free(iter);
+			rz_iterator_fini(&iter);
 			rz_list_free(plugin_list);
 			return status;
 		}
@@ -268,17 +268,17 @@ RZ_API RzCmdStatus rz_core_asm_plugins_print(RZ_NONNULL RZ_BORROW RzCore *core, 
 	rz_cmd_state_output_array_end(state);
 
 	rz_list_free(plugin_list);
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	return RZ_CMD_STATUS_OK;
 }
 
 RZ_API RzCmdStatus rz_core_cpu_descs_print(RZ_NONNULL RzCore *core, RZ_NONNULL const char *plugin) {
 	rz_return_val_if_fail(core && plugin && core->rasm, RZ_CMD_STATUS_ERROR);
 	RzAsm *a = core->rasm;
-	RzIterator *iter = rz_asm_plugin_iterator(a);
-	RzList *plugin_list = rz_list_new_from_iterator(iter);
+	RzIterator iter = rz_asm_plugin_iterator(a);
+	RzList *plugin_list = rz_list_new_from_iterator(&iter);
 	if (!plugin_list) {
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 		return RZ_CMD_STATUS_ERROR;
 	}
 	rz_list_sort(plugin_list, (RzListComparator)rz_asm_plugin_cmp, NULL);
@@ -293,7 +293,7 @@ RZ_API RzCmdStatus rz_core_cpu_descs_print(RZ_NONNULL RzCore *core, RZ_NONNULL c
 		if (ap->cpus && ap->get_cpu_desc) {
 			char **desc = ap->get_cpu_desc();
 			if (!desc) {
-				rz_iterator_free(iter);
+				rz_iterator_fini(&iter);
 				rz_list_free(plugin_list);
 				return RZ_CMD_STATUS_ERROR;
 			}
@@ -304,7 +304,7 @@ RZ_API RzCmdStatus rz_core_cpu_descs_print(RZ_NONNULL RzCore *core, RZ_NONNULL c
 		}
 		break;
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	rz_list_free(plugin_list);
 	if (!found) {
 		RZ_LOG_ERROR("Unknown asm plugin '%s'\n", plugin);

--- a/librz/core/cautocmpl.c
+++ b/librz/core/cautocmpl.c
@@ -195,7 +195,7 @@ static void autocmplt_bits_plugin(const RzAsmPlugin *plugin, RzLineNSCompletionR
 static void autocmplt_arch(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
 	rz_return_if_fail(core->rasm);
 
-	RzIterator *it = rz_asm_plugin_iterator(core->rasm);
+	RzIterator it = rz_asm_plugin_iterator(core->rasm);
 	RzAsmPlugin **val;
 
 	// @a: can either be used with @a:arch or @a:arch:bits
@@ -203,7 +203,7 @@ static void autocmplt_arch(RzCore *core, RzLineNSCompletionResult *res, const ch
 	const char *delim = rz_sub_str_rchr(s, 0, len, ':');
 	if (!delim) {
 		// We autocomplete just the architecture part
-		rz_iterator_foreach(it, val) {
+		rz_iterator_foreach(&it, val) {
 			RzAsmPlugin *plugin = *val;
 			if (!strncmp(plugin->name, s, len)) {
 				rz_line_ns_completion_result_add(res, plugin->name);
@@ -213,7 +213,7 @@ static void autocmplt_arch(RzCore *core, RzLineNSCompletionResult *res, const ch
 	} else {
 		// We autocomplete the bits part
 		res->start += delim + 1 - s;
-		rz_iterator_foreach(it, val) {
+		rz_iterator_foreach(&it, val) {
 			RzAsmPlugin *plugin = *val;
 			if (!strncmp(plugin->name, s, delim - s)) {
 				autocmplt_bits_plugin(plugin, res, delim + 1, len - (delim + 1 - s));
@@ -221,7 +221,7 @@ static void autocmplt_arch(RzCore *core, RzLineNSCompletionResult *res, const ch
 			}
 		}
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 }
 
 static void autocmplt_bits(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
@@ -860,11 +860,11 @@ static void autocmplt_cmd_arg_eval_key(RzCore *core, RzLineNSCompletionResult *r
 	rz_config_iterate_over(core->config, autocmplt_cmd_arg_eval_key_iterator, &ctx);
 
 	RzConfig **plugin_cfg;
-	RzIterator *it = ht_sp_as_iter(core->plugin_configs);
-	rz_iterator_foreach(it, plugin_cfg) {
+	RzIterator it = ht_sp_as_iter(core->plugin_configs);
+	rz_iterator_foreach(&it, plugin_cfg) {
 		rz_config_iterate_over((*plugin_cfg), autocmplt_cmd_arg_eval_key_iterator, &ctx);
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 }
 
 static void autocmplt_cmd_arg_eval_full(RzCore *core, RzLineNSCompletionResult *res, const char *s, size_t len) {
@@ -890,14 +890,14 @@ static void autocmplt_cmd_arg_eval_full(RzCore *core, RzLineNSCompletionResult *
 	res->start += strlen(k) + 1;
 
 	if (rz_set_s_size(options) > 0) {
-		RzIterator *iter = rz_set_s_as_iter(options);
+		RzIterator iter = rz_set_s_as_iter(options);
 		const char **opt;
-		rz_iterator_foreach(iter, opt) {
+		rz_iterator_foreach(&iter, opt) {
 			if (!strncmp(*opt, v, len)) {
 				rz_line_ns_completion_result_add(res, *opt);
 			}
 		}
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 	} else if (RZ_CONFIG_VAR_IS_TYPE(flags, RZ_CONFIG_VAR_TYPE_BOOL)) {
 		if (!strncmp("true", v, len)) {
 			rz_line_ns_completion_result_add(res, "true");

--- a/librz/core/cbin.c
+++ b/librz/core/cbin.c
@@ -5372,10 +5372,10 @@ RZ_API RzCmdStatus rz_core_bin_plugins_print(RzBin *bin, RzCmdStateOutput *state
 	RzCmdStatus status;
 	rz_cmd_state_output_array_start(state);
 
-	RzIterator *iter = ht_sp_as_iter(bin->plugins);
-	RzList *plugin_list = rz_list_new_from_iterator(iter);
+	RzIterator iter = ht_sp_as_iter(bin->plugins);
+	RzList *plugin_list = rz_list_new_from_iterator(&iter);
 	if (!plugin_list) {
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 		return RZ_CMD_STATUS_ERROR;
 	}
 	rz_list_sort(plugin_list, (RzListComparator)rz_bin_plugin_cmp, NULL);
@@ -5386,27 +5386,27 @@ RZ_API RzCmdStatus rz_core_bin_plugins_print(RzBin *bin, RzCmdStateOutput *state
 	rz_list_foreach (plugin_list, it, bp) {
 		status = rz_core_bin_plugin_print(bp, state);
 		if (status != RZ_CMD_STATUS_OK) {
-			rz_iterator_free(iter);
+			rz_iterator_fini(&iter);
 			rz_list_free(plugin_list);
 			return status;
 		}
 	}
 	rz_list_free(plugin_list);
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 
 	iter = ht_sp_as_iter(bin->binxtrs);
-	plugin_list = rz_list_new_from_iterator(iter);
+	plugin_list = rz_list_new_from_iterator(&iter);
 	rz_list_sort(plugin_list, (RzListComparator)rz_bin_xtr_plugin_cmp, NULL);
 	rz_list_foreach (plugin_list, it, bx) {
 		status = rz_core_binxtr_plugin_print(bx, state);
 		if (status != RZ_CMD_STATUS_OK) {
-			rz_iterator_free(iter);
+			rz_iterator_fini(&iter);
 			rz_list_free(plugin_list);
 			return status;
 		}
 	}
 	rz_list_free(plugin_list);
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	rz_cmd_state_output_array_end(state);
 	return RZ_CMD_STATUS_OK;
 }

--- a/librz/core/cconfig.c
+++ b/librz/core/cconfig.c
@@ -55,12 +55,12 @@ static bool isGdbPlugin(RzCore *core) {
 }
 
 static void print_node_options(RzConfigNode *node) {
-	RzIterator *iter = rz_set_s_as_iter(node->options);
+	RzIterator iter = rz_set_s_as_iter(node->options);
 	const char **option;
-	rz_iterator_foreach(iter, option) {
+	rz_iterator_foreach(&iter, option) {
 		rz_cons_printf("%s\n", *option);
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 }
 
 static int compareName(const RzAnalysisFunction *a, const RzAnalysisFunction *b, void *user) {
@@ -98,13 +98,13 @@ static void update_asmarch_options(RzCore *core, RzConfigNode *node) {
 	}
 
 	RzAsmPlugin **val;
-	RzIterator *it = rz_asm_plugin_iterator(core->rasm);
+	RzIterator it = rz_asm_plugin_iterator(core->rasm);
 	rz_set_s_clear(node->options);
-	rz_iterator_foreach(it, val) {
+	rz_iterator_foreach(&it, val) {
 		RzAsmPlugin *h = *val;
 		SETOPTIONS(node, h->name, NULL);
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 }
 
 static void update_asmbits_options(RzCore *core, RzConfigNode *node) {
@@ -458,16 +458,16 @@ static bool cb_analysis_hpskip(void *user, void *data) {
 }
 
 static void update_analysis_arch_options(RzCore *core, RzConfigNode *node) {
-	RzIterator *it = rz_analysis_plugin_iterator(core->analysis);
+	RzIterator it = rz_analysis_plugin_iterator(core->analysis);
 	RzAnalysisPlugin **val;
 	if (core && core->analysis && node) {
 		rz_set_s_clear(node->options);
-		rz_iterator_foreach(it, val) {
+		rz_iterator_foreach(&it, val) {
 			RzAnalysisPlugin *h = *val;
 			SETOPTIONS(node, h->name, NULL);
 		}
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 }
 
 static bool cb_analysis_recont(void *user, void *data) {
@@ -949,19 +949,19 @@ static bool cb_search_str_check_ascii_freq(void *user, void *data) {
 }
 
 static bool find_encoding(RzConfigNode *node, RzStrEnc *encoding) {
-	RzIterator *iter = rz_set_s_as_iter(node->options);
+	RzIterator iter = rz_set_s_as_iter(node->options);
 	const char **option;
-	rz_iterator_foreach(iter, option) {
+	rz_iterator_foreach(&iter, option) {
 		if (rz_str_casecmp(*option, node->value)) {
 			continue;
 		}
 		free(node->value);
 		node->value = rz_str_dup(*option);
 		*encoding = rz_str_enc_string_as_type(*option);
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 		return true;
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	if (rz_set_s_size(node->options) == 0) {
 		// Edge case when the node was just initialized but the options
 		// were not added yet.
@@ -1602,12 +1602,12 @@ static bool cb_iopcachewrite(void *user, void *data) {
 static void config_print_options_as_json(PJ *pj, const RzSetS *options) {
 	pj_ka(pj, "options");
 	if (options) {
-		RzIterator *iter = rz_set_s_as_iter(options);
+		RzIterator iter = rz_set_s_as_iter(options);
 		const char **option;
-		rz_iterator_foreach(iter, option) {
+		rz_iterator_foreach(&iter, option) {
 			pj_s(pj, *option);
 		}
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 	}
 	pj_end(pj);
 }
@@ -1667,10 +1667,10 @@ static void core_config_print_set_as_string(const RzSetS *set, bool allow_empty)
 		return;
 	}
 	rz_cons_print("[");
-	RzIterator *iter = rz_set_s_as_iter(set);
+	RzIterator iter = rz_set_s_as_iter(set);
 	const char **entry;
 	bool first = true;
-	rz_iterator_foreach(iter, entry) {
+	rz_iterator_foreach(&iter, entry) {
 		if (!first) {
 			rz_cons_printf(", %s", *entry);
 		} else {
@@ -1678,7 +1678,7 @@ static void core_config_print_set_as_string(const RzSetS *set, bool allow_empty)
 			first = false;
 		}
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	rz_cons_print("]");
 }
 

--- a/librz/core/ccrypto.c
+++ b/librz/core/ccrypto.c
@@ -42,10 +42,10 @@ RZ_API RzCmdStatus rz_core_crypto_plugins_print(RzCrypto *cry, RzCmdStateOutput 
 	rz_cmd_state_output_array_start(state);
 	rz_cmd_state_output_set_columnsf(state, "ssss", "algorithm", "license", "author", "description");
 
-	RzIterator *iter = ht_sp_as_iter(cry->plugins);
-	RzList *plugin_list = rz_list_new_from_iterator(iter);
+	RzIterator iter = ht_sp_as_iter(cry->plugins);
+	RzList *plugin_list = rz_list_new_from_iterator(&iter);
 	if (!plugin_list) {
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 		return RZ_CMD_STATUS_ERROR;
 	}
 	rz_list_sort(plugin_list, (RzListComparator)rz_crypto_plugin_cmp, NULL);
@@ -60,7 +60,7 @@ RZ_API RzCmdStatus rz_core_crypto_plugins_print(RzCrypto *cry, RzCmdStateOutput 
 		}
 	}
 	rz_list_free(plugin_list);
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	rz_cmd_state_output_array_end(state);
 	return status;
 }

--- a/librz/core/cdebug.c
+++ b/librz/core/cdebug.c
@@ -397,10 +397,10 @@ RZ_API RzCmdStatus rz_core_debug_plugins_print(RZ_NONNULL RZ_BORROW RzCore *core
 	}
 	rz_cmd_state_output_array_start(state);
 	rz_cmd_state_output_set_columnsf(state, "nsssss", "idx", "selected", "name", "license", "bits", "arch");
-	RzIterator *iter = ht_sp_as_iter(dbg->plugins);
-	RzList *plugin_list = rz_list_new_from_iterator(iter);
+	RzIterator iter = ht_sp_as_iter(dbg->plugins);
+	RzList *plugin_list = rz_list_new_from_iterator(&iter);
 	if (!plugin_list) {
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 		return RZ_CMD_STATUS_ERROR;
 	}
 	rz_list_sort(plugin_list, (RzListComparator)rz_debug_plugin_cmp, NULL);
@@ -411,14 +411,14 @@ RZ_API RzCmdStatus rz_core_debug_plugins_print(RZ_NONNULL RZ_BORROW RzCore *core
 		spaces[sp] = 0;
 		status = core_debug_plugin_print(dbg, plugin, state, count, spaces);
 		if (status != RZ_CMD_STATUS_OK) {
-			rz_iterator_free(iter);
+			rz_iterator_fini(&iter);
 			rz_list_free(plugin_list);
 			return status;
 		}
 		spaces[sp] = ' ';
 		count++;
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	rz_list_free(plugin_list);
 	rz_cmd_state_output_array_end(state);
 	return RZ_CMD_STATUS_OK;

--- a/librz/core/chash.c
+++ b/librz/core/chash.c
@@ -38,10 +38,10 @@ static RzCmdStatus core_hash_plugin_print(RzCmdStateOutput *state, const RzHashP
 RZ_API RzCmdStatus rz_core_hash_plugins_print(RZ_NONNULL RZ_BORROW RzHash *hash, RZ_OUT RzCmdStateOutput *state) {
 	rz_return_val_if_fail(hash && state, RZ_CMD_STATUS_ERROR);
 
-	RzIterator *iter = ht_sp_as_iter(hash->plugins);
-	RzList *plugin_list = rz_list_new_from_iterator(iter);
+	RzIterator iter = ht_sp_as_iter(hash->plugins);
+	RzList *plugin_list = rz_list_new_from_iterator(&iter);
 	if (!plugin_list) {
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 		return RZ_CMD_STATUS_ERROR;
 	}
 	rz_list_sort(plugin_list, (RzListComparator)rz_hash_plugin_cmp, NULL);
@@ -60,7 +60,7 @@ RZ_API RzCmdStatus rz_core_hash_plugins_print(RZ_NONNULL RZ_BORROW RzHash *hash,
 	}
 
 	rz_list_free(plugin_list);
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	rz_cmd_state_output_array_end(state);
 	return status;
 }

--- a/librz/core/cio.c
+++ b/librz/core/cio.c
@@ -495,10 +495,10 @@ RZ_API RzCmdStatus rz_core_io_plugins_print(RZ_NONNULL RZ_BORROW RzIO *io, RzCmd
 	rz_cmd_state_output_array_start(state);
 	rz_cmd_state_output_set_columnsf(state, "sssss", "perm", "license", "name", "uri", "description");
 
-	RzIterator *iter = ht_sp_as_iter(io->plugins);
-	RzList *plugin_list = rz_list_new_from_iterator(iter);
+	RzIterator iter = ht_sp_as_iter(io->plugins);
+	RzList *plugin_list = rz_list_new_from_iterator(&iter);
 	if (!plugin_list) {
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 		return RZ_CMD_STATUS_ERROR;
 	}
 	rz_list_sort(plugin_list, (RzListComparator)rz_io_plugin_cmp, NULL);
@@ -507,7 +507,7 @@ RZ_API RzCmdStatus rz_core_io_plugins_print(RZ_NONNULL RZ_BORROW RzIO *io, RzCmd
 	rz_list_foreach (plugin_list, it, plugin) {
 		rz_core_io_plugin_print(plugin, state);
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	rz_list_free(plugin_list);
 	rz_cmd_state_output_array_end(state);
 	return RZ_CMD_STATUS_OK;

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -396,14 +396,14 @@ static void core_analysis_bytes_esil(RzCore *core, const ut8 *buf, int len, int 
 }
 
 static void core_analysis_bytes_json(RzCore *core, const ut8 *buf, int len, int nops, PJ *pj) {
-	RzIterator *iter = rz_core_analysis_bytes(core, core->offset, buf, len, nops);
-	if (!iter) {
+	RzIterator iter = rz_core_analysis_bytes(core, core->offset, buf, len, nops);
+	if (!iter.next) {
 		return;
 	}
 	pj_a(pj);
 
 	RzCoreDecodedBytes *cdb;
-	rz_iterator_foreach(iter, cdb) {
+	rz_iterator_foreach(&iter, cdb) {
 		if (!cdb) {
 			break;
 		}
@@ -476,7 +476,7 @@ static void core_analysis_bytes_json(RzCore *core, const ut8 *buf, int len, int 
 	}
 
 	pj_end(pj);
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 }
 
 #define PRINTF_LN(k, fmt, arg) \
@@ -506,8 +506,8 @@ static void core_analysis_bytes_json(RzCore *core, const ut8 *buf, int len, int 
 	}
 
 static void core_analysis_bytes_standard(RzCore *core, const ut8 *buf, int len, int nops) {
-	RzIterator *iter = rz_core_analysis_bytes(core, core->offset, buf, len, nops);
-	if (!iter) {
+	RzIterator iter = rz_core_analysis_bytes(core, core->offset, buf, len, nops);
+	if (!iter.next) {
 		return;
 	}
 
@@ -515,7 +515,7 @@ static void core_analysis_bytes_standard(RzCore *core, const ut8 *buf, int len, 
 	const char *color = use_color ? core->cons->context->pal.label : "";
 
 	RzCoreDecodedBytes *cdb;
-	rz_iterator_foreach(iter, cdb) {
+	rz_iterator_foreach(&iter, cdb) {
 		RzAnalysisOp *op = &cdb->an_op;
 
 		const char *esilstr = RZ_STRBUF_SAFEGET(&op->esil);
@@ -588,7 +588,7 @@ static void core_analysis_bytes_standard(RzCore *core, const ut8 *buf, int len, 
 		PRINTF_LN_STR("stackop", op->stackop != RZ_ANALYSIS_STACK_NULL ? rz_analysis_stackop_tostring(op->stackop) : NULL);
 		PRINTF_LN_NOT("stackptr", "%" PFMT64d "\n", op->stackptr, 0);
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 }
 
 #undef PJ_KS
@@ -5456,13 +5456,13 @@ RZ_IPI RzCmdStatus rz_analyze_n_ins_esil_handler(RzCore *core, int argc, const c
  */
 RZ_API void rz_core_analysis_bytes_il(RZ_NONNULL RzCore *core, ut64 len, ut64 num_ops, bool pretty, bool unicode) {
 	rz_return_if_fail(core);
-	RzIterator *iter = rz_core_analysis_op_chunk_iter(core, core->offset, len, num_ops, RZ_ANALYSIS_OP_MASK_IL);
-	if (!iter) {
+	RzIterator iter = rz_core_analysis_op_chunk_iter(core, core->offset, len, num_ops, RZ_ANALYSIS_OP_MASK_IL);
+	if (!iter.next) {
 		return;
 	}
 
-	rz_core_il_cons_print(core, iter, pretty, unicode);
-	rz_iterator_free(iter);
+	rz_core_il_cons_print(core, &iter, pretty, unicode);
+	rz_iterator_fini(&iter);
 }
 
 RZ_IPI RzCmdStatus rz_analyze_n_ins_il_handler(RzCore *core, int argc, const char **argv) {

--- a/librz/core/cmd/cmd_analysis.c
+++ b/librz/core/cmd/cmd_analysis.c
@@ -397,7 +397,7 @@ static void core_analysis_bytes_esil(RzCore *core, const ut8 *buf, int len, int 
 
 static void core_analysis_bytes_json(RzCore *core, const ut8 *buf, int len, int nops, PJ *pj) {
 	RzIterator iter = rz_core_analysis_bytes(core, core->offset, buf, len, nops);
-	if (!iter.next) {
+	if (rz_iterator_is_uninit(&iter)) {
 		return;
 	}
 	pj_a(pj);
@@ -507,7 +507,7 @@ static void core_analysis_bytes_json(RzCore *core, const ut8 *buf, int len, int 
 
 static void core_analysis_bytes_standard(RzCore *core, const ut8 *buf, int len, int nops) {
 	RzIterator iter = rz_core_analysis_bytes(core, core->offset, buf, len, nops);
-	if (!iter.next) {
+	if (rz_iterator_is_uninit(&iter)) {
 		return;
 	}
 
@@ -5457,7 +5457,7 @@ RZ_IPI RzCmdStatus rz_analyze_n_ins_esil_handler(RzCore *core, int argc, const c
 RZ_API void rz_core_analysis_bytes_il(RZ_NONNULL RzCore *core, ut64 len, ut64 num_ops, bool pretty, bool unicode) {
 	rz_return_if_fail(core);
 	RzIterator iter = rz_core_analysis_op_chunk_iter(core, core->offset, len, num_ops, RZ_ANALYSIS_OP_MASK_IL);
-	if (!iter.next) {
+	if (rz_iterator_is_uninit(&iter)) {
 		return;
 	}
 

--- a/librz/core/cmd/cmd_debug.c
+++ b/librz/core/cmd/cmd_debug.c
@@ -194,9 +194,11 @@ static void dot_trace_traverse(RzCore *core, RTree *t, int fmt) {
 				}
 			}
 		}
-		rz_iterator_free(it_neighbours);
+		rz_iterator_fini(it_neighbours);
+		free(it_neighbours);
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 
 	if (!fmt) {
 		rz_cons_printf("}\n");
@@ -2359,10 +2361,10 @@ RZ_IPI RzCmdStatus rz_cmd_debug_toggle_bp_trace_index_handler(RzCore *core, int 
 // dbh
 RZ_IPI RzCmdStatus rz_cmd_debug_bp_plugin_handler(RzCore *core, int argc, const char **argv) {
 	rz_return_val_if_fail(core, RZ_CMD_STATUS_ERROR);
-	RzIterator *iter = rz_asm_plugin_iterator(core->rasm);
-	RzList *plugin_list = rz_list_new_from_iterator(iter);
+	RzIterator iter = rz_asm_plugin_iterator(core->rasm);
+	RzList *plugin_list = rz_list_new_from_iterator(&iter);
 	if (!plugin_list) {
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 		return RZ_CMD_STATUS_ERROR;
 	}
 
@@ -2378,7 +2380,7 @@ RZ_IPI RzCmdStatus rz_cmd_debug_bp_plugin_handler(RzCore *core, int argc, const 
 	}
 
 	rz_list_free(plugin_list);
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/core/cmd/cmd_debug.c
+++ b/librz/core/cmd/cmd_debug.c
@@ -147,8 +147,8 @@ static void dot_trace_traverse(RzCore *core, RTree *t, int fmt) {
 	rz_tree_bfs(t, &vis);
 
 	/* traverse the callgraph to print the dot file */
-	RzIterator *it_nodes = rz_graph_get_nodes(aux_data.graph);
-	if (!it_nodes) {
+	RzIterator it_nodes = rz_graph_get_nodes(aux_data.graph);
+	if (rz_iterator_is_uninit(&it_nodes)) {
 		RZ_LOG_ERROR("Failed to get graph nodes\n");
 		rz_graph_free(aux_data.graph);
 		sdb_free(aux_data.graphnodes);
@@ -162,7 +162,7 @@ static void dot_trace_traverse(RzCore *core, RTree *t, int fmt) {
 			       " shape=box fontname=\"%s\" fontsize=\"8\"];\n",
 			gfont);
 	}
-	rz_iterator_foreach(it_nodes, n) {
+	rz_iterator_foreach(&it_nodes, n) {
 		const struct trace_node *tn = rz_graph_node_get_data(n);
 		RzGraphNode *w;
 
@@ -173,12 +173,12 @@ static void dot_trace_traverse(RzCore *core, RTree *t, int fmt) {
 				tn->addr, tn->addr, tn->addr, tn->refs);
 		}
 
-		RzIterator *it_neighbours = rz_graph_out_neighbors(aux_data.graph, n);
-		if (!it_neighbours) {
+		RzIterator it_neighbours = rz_graph_out_neighbors(aux_data.graph, n);
+		if (rz_iterator_is_uninit(&it_neighbours)) {
 			continue;
 		}
 
-		rz_iterator_foreach(it_neighbours, w) {
+		rz_iterator_foreach(&it_neighbours, w) {
 			const struct trace_node *tv = rz_graph_node_get_data(w);
 
 			if (tv && tn) {
@@ -194,11 +194,9 @@ static void dot_trace_traverse(RzCore *core, RTree *t, int fmt) {
 				}
 			}
 		}
-		rz_iterator_fini(it_neighbours);
-		free(it_neighbours);
+		rz_iterator_fini(&it_neighbours);
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 
 	if (!fmt) {
 		rz_cons_printf("}\n");

--- a/librz/core/cmd/cmd_egg.c
+++ b/librz/core/cmd/cmd_egg.c
@@ -206,14 +206,14 @@ RZ_IPI RzCmdStatus rz_egg_list_plugins_handler(RzCore *core, int argc, const cha
 	if (!egg) {
 		return RZ_CMD_STATUS_ERROR;
 	}
-	RzIterator *iter = ht_sp_as_iter(egg->plugins);
+	RzIterator iter = ht_sp_as_iter(egg->plugins);
 	RzEggPlugin **val;
-	rz_iterator_foreach(iter, val) {
+	rz_iterator_foreach(&iter, val) {
 		RzEggPlugin *p = *val;
 		rz_cons_printf("%s  %6s : %s\n",
 			(p->type == RZ_EGG_PLUGIN_SHELLCODE) ? "shc" : "enc", p->name, p->desc);
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	return RZ_CMD_STATUS_OK;
 }
 

--- a/librz/core/cmd/cmd_eval.c
+++ b/librz/core/cmd/cmd_eval.c
@@ -435,11 +435,11 @@ static void print_all_plugin_configs(const RzCore *core) {
 	RzConfig **cfg;
 	RzCmdStateOutput state = { 0 };
 	rz_cmd_state_output_init(&state, RZ_OUTPUT_MODE_QUIET, core);
-	RzIterator *it = ht_sp_as_iter(core->plugin_configs);
-	rz_iterator_foreach(it, cfg) {
+	RzIterator it = ht_sp_as_iter(core->plugin_configs);
+	rz_iterator_foreach(&it, cfg) {
 		rz_core_config_print_all(*cfg, "", &state);
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	rz_cmd_state_output_print(&state);
 	rz_cmd_state_output_fini(&state);
 }

--- a/librz/core/cmd/cmd_help.c
+++ b/librz/core/cmd/cmd_help.c
@@ -190,11 +190,11 @@ RZ_IPI RzCmdStatus rz_cmd_help_search_interactive_settings_handler(RzCore *core,
 	rz_core_config_print_all(core->config, "", &state);
 
 	RzConfig **cfg;
-	RzIterator *it = ht_sp_as_iter(core->plugin_configs);
-	rz_iterator_foreach(it, cfg) {
+	RzIterator it = ht_sp_as_iter(core->plugin_configs);
+	rz_iterator_foreach(&it, cfg) {
 		rz_core_config_print_all(*cfg, "", &state);
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 
 	// Run it in the hub.
 	free(rz_cons_hud_string(rz_strbuf_get(state.d.sbuf)));

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -3024,13 +3024,13 @@ RZ_IPI RzCmdStatus rz_print_function_rzil_handler(RzCore *core, int argc, const 
 		goto exit;
 	}
 
-	RzIterator *ops = rz_core_analysis_op_function_iter(core, f, RZ_ANALYSIS_OP_MASK_IL);
-	if (!ops) {
+	RzIterator ops = rz_core_analysis_op_function_iter(core, f, RZ_ANALYSIS_OP_MASK_IL);
+	if (!ops.next) {
 		goto exit;
 	}
 
-	rz_core_il_cons_print(core, ops, false, false);
-	rz_iterator_free(ops);
+	rz_core_il_cons_print(core, &ops, false, false);
+	rz_iterator_fini(&ops);
 	return RZ_CMD_STATUS_OK;
 exit:
 	return RZ_CMD_STATUS_ERROR;
@@ -3046,13 +3046,13 @@ RZ_IPI RzCmdStatus rz_print_function_rzil_enriched_handler(RzCore *core, int arg
 		goto exit;
 	}
 
-	RzIterator *ops = rz_core_analysis_op_function_iter(core, f, RZ_ANALYSIS_OP_MASK_IL);
-	if (!ops) {
+	RzIterator ops = rz_core_analysis_op_function_iter(core, f, RZ_ANALYSIS_OP_MASK_IL);
+	if (!ops.next) {
 		goto exit;
 	}
 
-	rz_core_il_cons_print(core, ops, false, true);
-	rz_iterator_free(ops);
+	rz_core_il_cons_print(core, &ops, false, true);
+	rz_iterator_fini(&ops);
 	return RZ_CMD_STATUS_OK;
 exit:
 	return RZ_CMD_STATUS_ERROR;

--- a/librz/core/cmd/cmd_print.c
+++ b/librz/core/cmd/cmd_print.c
@@ -3025,7 +3025,7 @@ RZ_IPI RzCmdStatus rz_print_function_rzil_handler(RzCore *core, int argc, const 
 	}
 
 	RzIterator ops = rz_core_analysis_op_function_iter(core, f, RZ_ANALYSIS_OP_MASK_IL);
-	if (!ops.next) {
+	if (rz_iterator_is_uninit(&ops)) {
 		goto exit;
 	}
 
@@ -3047,7 +3047,7 @@ RZ_IPI RzCmdStatus rz_print_function_rzil_enriched_handler(RzCore *core, int arg
 	}
 
 	RzIterator ops = rz_core_analysis_op_function_iter(core, f, RZ_ANALYSIS_OP_MASK_IL);
-	if (!ops.next) {
+	if (rz_iterator_is_uninit(&ops)) {
 		goto exit;
 	}
 

--- a/librz/core/core.c
+++ b/librz/core/core.c
@@ -2341,7 +2341,7 @@ static RzCmdStatus core_core_plugin_print(RzCorePlugin *cp, RzCmdStateOutput *st
 }
 
 RZ_API RzCmdStatus rz_core_core_plugins_print(RzCore *core, RzCmdStateOutput *state) {
-	RzIterator *iter = ht_sp_as_iter(core->plugins);
+	RzIterator iter = ht_sp_as_iter(core->plugins);
 	RzCorePlugin **val;
 	RzCmdStatus status;
 	if (!core) {
@@ -2349,14 +2349,14 @@ RZ_API RzCmdStatus rz_core_core_plugins_print(RzCore *core, RzCmdStateOutput *st
 	}
 	rz_cmd_state_output_array_start(state);
 	rz_cmd_state_output_set_columnsf(state, "sssss", "name", "license", "author", "version", "description");
-	rz_iterator_foreach(iter, val) {
+	rz_iterator_foreach(&iter, val) {
 		RzCorePlugin *cp = *val;
 		status = core_core_plugin_print(cp, state);
 		if (status != RZ_CMD_STATUS_OK) {
 			return status;
 		}
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	rz_cmd_state_output_array_end(state);
 	return RZ_CMD_STATUS_OK;
 }

--- a/librz/core/cplugin.c
+++ b/librz/core/cplugin.c
@@ -30,13 +30,13 @@ static bool core_plugin_fini(RzCore *core, RzCorePlugin *plugin) {
 RZ_API bool rz_core_plugin_fini(RzCore *core) {
 	rz_return_val_if_fail(core->plugins, false);
 
-	RzIterator *iter = ht_sp_as_iter(core->plugins);
+	RzIterator iter = ht_sp_as_iter(core->plugins);
 	RzCorePlugin **val;
-	rz_iterator_foreach(iter, val) {
+	rz_iterator_foreach(&iter, val) {
 		RzCorePlugin *plugin = *val;
 		core_plugin_fini(core, plugin);
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	ht_sp_free(core->plugins);
 	RZ_FREE_CUSTOM(core->plugin_contexts, ht_sp_free);
 	ht_sp_free(core->plugin_configs);

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -6052,10 +6052,10 @@ RZ_API int rz_core_print_disasm_instructions(RzCore *core, int nb_bytes, int nb_
 
 RZ_API int rz_core_print_disasm_json(RzCore *core, ut64 addr, ut8 *buf, int nb_bytes, int nb_opcodes, PJ *pj) {
 	bool res = true;
-	RzIterator *iter = NULL;
+	RzIterator iter = (RzIterator){ 0 };
 	ut64 offset = rz_core_backward_offset(core, addr, &nb_opcodes, &nb_bytes);
 	iter = rz_core_analysis_bytes(core, offset, buf, nb_bytes, nb_opcodes);
-	if (!iter) {
+	if (!iter.next) {
 		res = false;
 		goto clean_return;
 	}
@@ -6063,7 +6063,7 @@ RZ_API int rz_core_print_disasm_json(RzCore *core, ut64 addr, ut8 *buf, int nb_b
 	bool asm_pseudo = rz_config_get_i(core->config, "asm.pseudo");
 
 	RzCoreDecodedBytes *cdb;
-	rz_iterator_foreach(iter, cdb) {
+	rz_iterator_foreach(&iter, cdb) {
 		RzAnalysisOp *op = &cdb->an_op;
 		pj_o(pj);
 		pj_kn(pj, "offset", op->addr);
@@ -6193,7 +6193,7 @@ RZ_API int rz_core_print_disasm_json(RzCore *core, ut64 addr, ut8 *buf, int nb_b
 		pj_end(pj);
 	}
 clean_return:
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	return res;
 }
 

--- a/librz/core/disasm.c
+++ b/librz/core/disasm.c
@@ -6055,7 +6055,7 @@ RZ_API int rz_core_print_disasm_json(RzCore *core, ut64 addr, ut8 *buf, int nb_b
 	RzIterator iter = (RzIterator){ 0 };
 	ut64 offset = rz_core_backward_offset(core, addr, &nb_opcodes, &nb_bytes);
 	iter = rz_core_analysis_bytes(core, offset, buf, nb_bytes, nb_opcodes);
-	if (!iter.next) {
+	if (rz_iterator_is_uninit(&iter)) {
 		res = false;
 		goto clean_return;
 	}

--- a/librz/core/gadget.c
+++ b/librz/core/gadget.c
@@ -402,7 +402,7 @@ RZ_API void rz_core_gadget_info_free(RZ_NULLABLE RzGadgetInfo *gadget_info) {
 	}
 	rz_pvector_free(gadget_info->modified_registers);
 	rz_list_free(gadget_info->dependencies);
-	rz_iterator_free(gadget_info->analysis_cache);
+	rz_iterator_fini(gadget_info->analysis_cache);
 	free(gadget_info);
 }
 

--- a/librz/core/tui/config.c
+++ b/librz/core/tui/config.c
@@ -82,9 +82,9 @@ static void show_config_options(RzCore *core, const char *name) {
 
 	int w = rz_cons_get_size(NULL);
 	const char **item;
-	RzIterator *iter = rz_set_s_as_iter(options);
+	RzIterator iter = rz_set_s_as_iter(options);
 	RzStrBuf *sb = rz_strbuf_new(" Options: ");
-	rz_iterator_foreach(iter, item) {
+	rz_iterator_foreach(&iter, item) {
 		rz_strbuf_appendf(sb, "%s%s", *item ? ", " : "", *item);
 		if (rz_strbuf_length(sb) + 5 >= w) {
 			char *s = rz_strbuf_drain(sb);
@@ -93,7 +93,7 @@ static void show_config_options(RzCore *core, const char *name) {
 			sb = rz_strbuf_new("");
 		}
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	char *s = rz_strbuf_drain(sb);
 	rz_cons_println(s);
 	free(s);

--- a/librz/crypto/crypto.c
+++ b/librz/crypto/crypto.c
@@ -70,19 +70,19 @@ RZ_API RZ_BORROW const char *rz_crypto_codec_name(const RzCryptoSelector bit) {
 RZ_API RZ_BORROW const RzCryptoPlugin *rz_crypto_plugin_by_index(RZ_NONNULL RzCrypto *cry, size_t index) {
 	rz_return_val_if_fail(cry, NULL);
 
-	RzIterator *it = ht_sp_as_iter(cry->plugins);
+	RzIterator it = ht_sp_as_iter(cry->plugins);
 	RzCryptoPlugin **val;
 	size_t i = 0;
 
-	rz_iterator_foreach(it, val) {
+	rz_iterator_foreach(&it, val) {
 		const RzCryptoPlugin *plugin = *val;
 		if (i == index) {
-			rz_iterator_free(it);
+			rz_iterator_fini(&it);
 			return plugin;
 		}
 		i++;
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	return NULL;
 }
 
@@ -169,27 +169,27 @@ RZ_API void rz_crypto_reset(RZ_NONNULL RzCrypto *cry) {
 
 RZ_API bool rz_crypto_use(RZ_NONNULL RzCrypto *cry, RZ_NONNULL const char *algo) {
 	rz_return_val_if_fail(cry && algo, false);
-	RzIterator *it = ht_sp_as_iter(cry->plugins);
+	RzIterator it = ht_sp_as_iter(cry->plugins);
 	RzCryptoPlugin **val;
 	if (cry->h && cry->h->fini && !cry->h->fini(cry)) {
 		RZ_LOG_ERROR("[!] crypto: error terminating '%s' plugin\n", cry->h->name);
 	}
-	rz_iterator_foreach(it, val) {
+	rz_iterator_foreach(&it, val) {
 		RzCryptoPlugin *h = *val;
 		rz_warn_if_fail(h && h->use);
 		if (h && h->use(algo)) {
 			if (h->init && !h->init(cry)) {
 				RZ_LOG_ERROR("[!] crypto: error initializing '%s' plugin\n", cry->h->name);
-				rz_iterator_free(it);
+				rz_iterator_fini(&it);
 				return false;
 			}
 
 			cry->h = h;
-			rz_iterator_free(it);
+			rz_iterator_fini(&it);
 			return true;
 		}
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	return false;
 }
 

--- a/librz/egg/egg.c
+++ b/librz/egg/egg.c
@@ -551,49 +551,49 @@ RZ_API char *rz_egg_option_get(RzEgg *egg, const char *key) {
 
 RZ_API int rz_egg_shellcode(RZ_NONNULL RZ_BORROW RzEgg *egg, const char *name) {
 	rz_return_val_if_fail(egg && name, false);
-	RzIterator *iter = ht_sp_as_iter(egg->plugins);
+	RzIterator iter = ht_sp_as_iter(egg->plugins);
 	RzEggPlugin **val;
 	RzBuffer *b;
-	rz_iterator_foreach(iter, val) {
+	rz_iterator_foreach(&iter, val) {
 		RzEggPlugin *p = *val;
 		if (p->type == RZ_EGG_PLUGIN_SHELLCODE && !strcmp(name, p->name)) {
 			b = p->build(egg);
 			if (!b) {
 				RZ_LOG_ERROR("egg: %s Shellcode has failed\n", p->name);
-				rz_iterator_free(iter);
+				rz_iterator_fini(&iter);
 				return false;
 			}
 			ut64 tmpsz;
 			const ut8 *tmp = rz_buf_data(b, &tmpsz);
 			rz_egg_raw(egg, tmp, tmpsz);
-			rz_iterator_free(iter);
+			rz_iterator_fini(&iter);
 			return true;
 		}
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	return false;
 }
 
 RZ_API int rz_egg_encode(RZ_NONNULL RZ_BORROW RzEgg *egg, const char *name) {
 	rz_return_val_if_fail(egg && name, false);
-	RzIterator *iter = ht_sp_as_iter(egg->plugins);
+	RzIterator iter = ht_sp_as_iter(egg->plugins);
 	RzEggPlugin **val;
 	RzBuffer *b;
-	rz_iterator_foreach(iter, val) {
+	rz_iterator_foreach(&iter, val) {
 		RzEggPlugin *p = *val;
 		if (p->type == RZ_EGG_PLUGIN_ENCODER && !strcmp(name, p->name)) {
 			b = p->build(egg);
 			if (!b) {
-				rz_iterator_free(iter);
+				rz_iterator_fini(&iter);
 				return false;
 			}
 			rz_buf_free(egg->bin);
 			egg->bin = b;
-			rz_iterator_free(iter);
+			rz_iterator_fini(&iter);
 			return true;
 		}
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	return false;
 }
 

--- a/librz/hash/hash.c
+++ b/librz/hash/hash.c
@@ -412,32 +412,32 @@ RZ_API bool rz_hash_cfg_configure(RZ_NONNULL RzHashCfg *md, RZ_NONNULL const cha
 	}
 
 	HashCfgConfig *mdc = NULL;
-	RzIterator *it = ht_sp_as_iter(md->hash->plugins);
+	RzIterator it = ht_sp_as_iter(md->hash->plugins);
 	const RzHashPlugin **val;
 
-	rz_iterator_foreach(it, val) {
+	rz_iterator_foreach(&it, val) {
 		const RzHashPlugin *plugin = *val;
 		if (is_all || !strcmp(plugin->name, name)) {
 			mdc = hash_cfg_config_new(plugin);
 			if (!mdc) {
-				rz_iterator_free(it);
+				rz_iterator_fini(&it);
 				return false;
 			}
 
 			if (!rz_list_append(md->configurations, mdc)) {
 				RZ_LOG_ERROR("msg digest: cannot allocate memory for list entry.\n");
 				hash_cfg_config_free(mdc);
-				rz_iterator_free(it);
+				rz_iterator_fini(&it);
 				return false;
 			}
 
 			if (!is_all) {
-				rz_iterator_free(it);
+				rz_iterator_fini(&it);
 				return true;
 			}
 		}
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 
 	if (is_all) {
 		return true;

--- a/librz/include/rz_analysis.h
+++ b/librz/include/rz_analysis.h
@@ -1398,7 +1398,7 @@ RZ_DEPRECATE RZ_API bool rz_analysis_plugin_is_arch(RZ_NONNULL RzAnalysis *analy
 RZ_API bool rz_analysis_plugin_add(RzAnalysis *analysis, RZ_NONNULL RzAnalysisPlugin *foo);
 RZ_API bool rz_analysis_plugin_del(RzAnalysis *analysis, RZ_NONNULL RzAnalysisPlugin *foo);
 RZ_API const RzAnalysisPlugin *rz_analysis_plugin_current(RzAnalysis *analysis);
-RZ_API RZ_OWN RzIterator *rz_analysis_plugin_iterator(RZ_NONNULL RzAnalysis *analysis);
+RZ_API RZ_OWN RzIterator rz_analysis_plugin_iterator(RZ_NONNULL RzAnalysis *analysis);
 RZ_API RZ_BORROW HtSP /*<RzAnalysisPlugin *>*/ *rz_analysis_get_plugins(RZ_NONNULL RzAnalysis *analysis);
 RZ_API int rz_analysis_archinfo(RzAnalysis *analysis, RzAnalysisInfoType query);
 RZ_API bool rz_analysis_use(RzAnalysis *analysis, const char *name);

--- a/librz/include/rz_asm.h
+++ b/librz/include/rz_asm.h
@@ -137,7 +137,7 @@ RZ_API char *rz_asm_mnemonics(const RzAsm *a, int id, bool json);
 RZ_API int rz_asm_mnemonics_byname(const RzAsm *a, const char *name);
 RZ_API bool rz_asm_plugin_add(RzAsm *a, RZ_NONNULL RzAsmPlugin *foo);
 RZ_API bool rz_asm_plugin_del(RzAsm *a, RZ_NONNULL RzAsmPlugin *foo);
-RZ_API RZ_OWN RzIterator *rz_asm_plugin_iterator(RZ_NONNULL const RzAsm *a);
+RZ_API RZ_OWN RzIterator rz_asm_plugin_iterator(RZ_NONNULL const RzAsm *a);
 RZ_API const RzAsmPlugin *rz_asm_plugin_current(RZ_NONNULL const RzAsm *a);
 RZ_API const RzAsmPlugin *rz_asm_plugin_find(RZ_NONNULL const RzAsm *a, RZ_NONNULL const char *name);
 RZ_API bool rz_asm_setup(RzAsm *a, const char *arch, int bits, int big_endian);

--- a/librz/include/rz_core.h
+++ b/librz/include/rz_core.h
@@ -882,9 +882,9 @@ typedef struct rz_core_decoded_bytes_t {
 	int oplen;
 } RzCoreDecodedBytes;
 
-RZ_API RZ_OWN RzIterator *rz_core_analysis_bytes(RZ_NONNULL RzCore *core, ut64 start_addr, RZ_NONNULL const ut8 *buf, ut64 n_bytes, ut64 max_ops);
-RZ_API RZ_OWN RzIterator *rz_core_analysis_op_chunk_iter(RZ_NONNULL RzCore *core, ut64 start_addr, ut64 n_bytes, ut64 max_ops, RzAnalysisOpMask mask);
-RZ_API RZ_OWN RzIterator *rz_core_analysis_op_function_iter(RZ_NONNULL RzCore *core, RZ_NONNULL RZ_BORROW RzAnalysisFunction *fcn, RzAnalysisOpMask mask);
+RZ_API RZ_OWN RzIterator rz_core_analysis_bytes(RZ_NONNULL RzCore *core, ut64 start_addr, RZ_NONNULL const ut8 *buf, ut64 n_bytes, ut64 max_ops);
+RZ_API RZ_OWN RzIterator rz_core_analysis_op_chunk_iter(RZ_NONNULL RzCore *core, ut64 start_addr, ut64 n_bytes, ut64 max_ops, RzAnalysisOpMask mask);
+RZ_API RZ_OWN RzIterator rz_core_analysis_op_function_iter(RZ_NONNULL RzCore *core, RZ_NONNULL RZ_BORROW RzAnalysisFunction *fcn, RzAnalysisOpMask mask);
 RZ_API ut64 rz_core_analysis_ops_size(RZ_NONNULL RzCore *core, ut64 start_addr, RZ_NONNULL const ut8 *buf, ut64 len, ut64 nops);
 
 /* cgraph.c */

--- a/librz/include/rz_util/ht_inc.h
+++ b/librz/include/rz_util/ht_inc.h
@@ -306,7 +306,7 @@ RZ_API const VALUE_TYPE *Ht_(iter_next)(RzIterator *it);
 RZ_API const KEY_TYPE *Ht_(iter_next_key)(RzIterator *it);
 RZ_API const HT_(Kv) *Ht_(iter_next_kv)(RzIterator *it);
 
-RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ *Ht_(as_iter_mut)(RZ_NONNULL HtName_(Ht) *ht);
-RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ *Ht_(as_iter)(const RZ_NONNULL HtName_(Ht) *ht);
-RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ *Ht_(as_iter_keys)(const RZ_NONNULL HtName_(Ht) *ht);
-RZ_API RZ_OWN RzIterator /* <const HtName_(Ht)> */ *Ht_(as_iter_kv)(const RZ_NONNULL HtName_(Ht) *ht);
+RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ Ht_(as_iter_mut)(RZ_NONNULL HtName_(Ht) *ht);
+RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ Ht_(as_iter)(const RZ_NONNULL HtName_(Ht) *ht);
+RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ Ht_(as_iter_keys)(const RZ_NONNULL HtName_(Ht) *ht);
+RZ_API RZ_OWN RzIterator /* <const HtName_(Ht)> */ Ht_(as_iter_kv)(const RZ_NONNULL HtName_(Ht) *ht);

--- a/librz/include/rz_util/rz_graph.h
+++ b/librz/include/rz_util/rz_graph.h
@@ -85,15 +85,15 @@ RZ_API RzGraphStatus rz_graph_del_edges(RZ_BORROW RzGraph *g, RZ_NULLABLE RzGrap
 RZ_API RzGraphStatus rz_graph_has_edge(RzGraph *g, RzGraphNode *from, RzGraphNode *to);
 RZ_API RZ_BORROW RzGraphEdge *rz_graph_find_edge(RzGraph *g, RzGraphNode *from, RzGraphNode *to);
 
-RZ_API RZ_OWN RzIterator *rz_graph_out_edges(RzGraph *g, RzGraphNode *node);
-RZ_API RZ_OWN RzIterator *rz_graph_in_edges(RzGraph *g, RzGraphNode *node);
-RZ_API RZ_OWN RzIterator *rz_graph_out_neighbors(RzGraph *g, RzGraphNode *n);
-RZ_API RZ_OWN RzIterator *rz_graph_in_neighbors(RzGraph *g, RzGraphNode *n);
+RZ_API RZ_OWN RzIterator rz_graph_out_edges(RzGraph *g, RzGraphNode *node);
+RZ_API RZ_OWN RzIterator rz_graph_in_edges(RzGraph *g, RzGraphNode *node);
+RZ_API RZ_OWN RzIterator rz_graph_out_neighbors(RzGraph *g, RzGraphNode *n);
+RZ_API RZ_OWN RzIterator rz_graph_in_neighbors(RzGraph *g, RzGraphNode *n);
 
 // utils
 RZ_API ut64 rz_graph_count_nodes(const RzGraph *g);
 RZ_API ut64 rz_graph_count_edges(const RzGraph *g);
-RZ_API RZ_OWN RzIterator *rz_graph_get_nodes(const RzGraph *g);
+RZ_API RZ_OWN RzIterator rz_graph_get_nodes(const RzGraph *g);
 RZ_API ut64 rz_graph_mem_usage(const RzGraph *g);
 
 /**
@@ -163,10 +163,10 @@ RZ_API RzGraphStatus rz_graph_add_edge_by_id(RzGraph *g, ut64 from_id, ut64 to_i
 RZ_API RzGraphStatus rz_graph_del_edge_by_id(RzGraph *g, ut64 from_id, ut64 to_id);
 RZ_API RzGraphStatus rz_graph_has_edge_by_id(RzGraph *g, ut64 from_id, ut64 to_id);
 RZ_API RZ_NULLABLE RZ_BORROW RzGraphEdge *rz_graph_find_edge_by_id(RzGraph *g, ut64 from_id, ut64 to_id);
-RZ_API RZ_OWN RzIterator *rz_graph_out_edges_by_id(RzGraph *g, ut64 id);
-RZ_API RZ_OWN RzIterator *rz_graph_in_edges_by_id(RzGraph *g, ut64 id);
-RZ_API RZ_OWN RzIterator *rz_graph_out_neighbors_by_id(RzGraph *g, ut64 id);
-RZ_API RZ_OWN RzIterator *rz_graph_in_neighbors_by_id(RzGraph *g, ut64 id);
+RZ_API RZ_OWN RzIterator rz_graph_out_edges_by_id(RzGraph *g, ut64 id);
+RZ_API RZ_OWN RzIterator rz_graph_in_edges_by_id(RzGraph *g, ut64 id);
+RZ_API RZ_OWN RzIterator rz_graph_out_neighbors_by_id(RzGraph *g, ut64 id);
+RZ_API RZ_OWN RzIterator rz_graph_in_neighbors_by_id(RzGraph *g, ut64 id);
 RZ_API ut64 rz_graph_out_degree_by_id(const RzGraph *g, ut64 id);
 RZ_API ut64 rz_graph_in_degree_by_id(const RzGraph *g, ut64 id);
 RZ_API RZ_NULLABLE RZ_BORROW RzGraphNode *rz_graph_nth_neighbour_by_id(const RzGraph *g, ut64 id, ut64 nth, bool out_neighbor);

--- a/librz/include/rz_util/rz_iterator.h
+++ b/librz/include/rz_util/rz_iterator.h
@@ -25,13 +25,13 @@ typedef struct rz_iterator_t {
 #define rz_iterator_foreach(iter, val) \
 	for ((val) = rz_iterator_next(iter); (val) != NULL; (val) = rz_iterator_next(iter))
 
-RZ_API RZ_OWN RzIterator *rz_iterator_new(
+RZ_API RZ_OWN RzIterator rz_iterator_new(
 	RZ_NONNULL rz_iterator_next_cb next,
 	RZ_NULLABLE rz_iterator_free_cb free,
 	RZ_NULLABLE rz_iterator_free_cb free_u,
 	RZ_NONNULL RZ_OWN void *u);
 RZ_API RZ_BORROW void *rz_iterator_next(RZ_NONNULL RZ_BORROW RzIterator *it);
-RZ_API void rz_iterator_free(RzIterator *it);
+RZ_API void rz_iterator_fini(RzIterator *it);
 
 #ifdef __cplusplus
 }

--- a/librz/include/rz_util/rz_iterator.h
+++ b/librz/include/rz_util/rz_iterator.h
@@ -17,7 +17,7 @@ typedef void (*rz_iterator_free_cb)(void *);
 typedef struct rz_iterator_t {
 	void *cur;
 	void *u;
-	rz_iterator_next_cb next;
+	rz_iterator_next_cb next; // NULL means this iterator is uninitialized/invalid
 	rz_iterator_free_cb free;
 	rz_iterator_free_cb free_u;
 } RzIterator;
@@ -32,6 +32,9 @@ RZ_API RZ_OWN RzIterator rz_iterator_new(
 	RZ_NONNULL RZ_OWN void *u);
 RZ_API RZ_BORROW void *rz_iterator_next(RZ_NONNULL RZ_BORROW RzIterator *it);
 RZ_API void rz_iterator_fini(RzIterator *it);
+static inline bool rz_iterator_is_uninit(RZ_NONNULL const RzIterator *it) {
+	return !it || !it->next;
+}
 
 #ifdef __cplusplus
 }

--- a/librz/include/rz_util/rz_set.h
+++ b/librz/include/rz_util/rz_set.h
@@ -24,7 +24,7 @@ RZ_API void rz_set_s_delete(RZ_NONNULL RzSetS *set, const char *str);
 RZ_API void rz_set_s_clear(RZ_NONNULL RzSetS *set);
 RZ_API ut32 rz_set_s_size(const RZ_NONNULL RzSetS *set);
 RZ_API RZ_OWN RzPVector /*<char *>*/ *rz_set_s_to_vector(RZ_NONNULL RzSetS *set);
-RZ_API RzIterator /* <RzSetS> */ *rz_set_s_as_iter(const RZ_NONNULL RzSetS *set);
+RZ_API RzIterator /* <RzSetS> */ rz_set_s_as_iter(const RZ_NONNULL RzSetS *set);
 
 typedef HtUP RzSetU;
 
@@ -36,7 +36,7 @@ RZ_API bool rz_set_u_contains(const RZ_NONNULL RzSetU *set, ut64 u);
 RZ_API void rz_set_u_delete(RZ_NONNULL RzSetU *set, ut64 u);
 RZ_API void rz_set_u_clear(RZ_NONNULL RzSetU *set);
 RZ_API ut32 rz_set_u_size(const RZ_NONNULL RzSetU *set);
-RZ_API RzIterator /* <RzSetU> */ *rz_set_u_as_iter(const RZ_NONNULL RzSetU *set);
+RZ_API RzIterator /* <RzSetU> */ rz_set_u_as_iter(const RZ_NONNULL RzSetU *set);
 
 #ifdef __cplusplus
 }

--- a/librz/io/io_plugin.c
+++ b/librz/io/io_plugin.c
@@ -60,34 +60,34 @@ RZ_API RzIOPlugin *rz_io_plugin_get_default(RzIO *io, const char *filename, bool
 
 RZ_API RzIOPlugin *rz_io_plugin_resolve(RzIO *io, const char *filename, bool many) {
 	rz_return_val_if_fail(io && filename, NULL);
-	RzIterator *iter = ht_sp_as_iter(io->plugins);
+	RzIterator iter = ht_sp_as_iter(io->plugins);
 	RzIOPlugin **val;
-	rz_iterator_foreach(iter, val) {
+	rz_iterator_foreach(&iter, val) {
 		RzIOPlugin *ret = *val;
 		if (!ret || !ret->check) {
 			continue;
 		}
 		if (ret->check(io, filename, many)) {
-			rz_iterator_free(iter);
+			rz_iterator_fini(&iter);
 			return ret;
 		}
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	return rz_io_plugin_get_default(io, filename, many);
 }
 
 RZ_API RzIOPlugin *rz_io_plugin_byname(RzIO *io, const char *name) {
 	rz_return_val_if_fail(io && name, NULL);
-	RzIterator *iter = ht_sp_as_iter(io->plugins);
+	RzIterator iter = ht_sp_as_iter(io->plugins);
 	RzIOPlugin **val;
-	rz_iterator_foreach(iter, val) {
+	rz_iterator_foreach(&iter, val) {
 		RzIOPlugin *iop = *val;
 		if (!strcmp(name, iop->name)) {
-			rz_iterator_free(iter);
+			rz_iterator_fini(&iter);
 			return iop;
 		}
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	return rz_io_plugin_get_default(io, name, false);
 }
 

--- a/librz/main/rz-gg.c
+++ b/librz/main/rz-gg.c
@@ -58,10 +58,10 @@ static int usage(int v) {
 
 static void list(RzEgg *egg) {
 	printf("shellcodes:\n");
-	RzIterator *iter = ht_sp_as_iter(egg->plugins);
-	RzList *plugin_list = rz_list_new_from_iterator(iter);
+	RzIterator iter = ht_sp_as_iter(egg->plugins);
+	RzList *plugin_list = rz_list_new_from_iterator(&iter);
 	if (!plugin_list) {
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 		return;
 	}
 	rz_list_sort(plugin_list, (RzListComparator)rz_egg_plugin_cmp, NULL);
@@ -80,7 +80,7 @@ static void list(RzEgg *egg) {
 		}
 	}
 	rz_list_free(plugin_list);
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 }
 
 static bool create(const char *format, const char *arch, int bits, const ut8 *code, int codelen) {

--- a/librz/main/rz-hash.c
+++ b/librz/main/rz-hash.c
@@ -117,10 +117,10 @@ static void rz_hash_show_algorithms(RzHashContext *ctx) {
 
 	printf("flags  algorithm      license    author\n");
 
-	RzIterator *iter = ht_sp_as_iter(ctx->rh->plugins);
-	RzList *plugin_list = rz_list_new_from_iterator(iter);
+	RzIterator iter = ht_sp_as_iter(ctx->rh->plugins);
+	RzList *plugin_list = rz_list_new_from_iterator(&iter);
 	if (!plugin_list) {
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 		return;
 	}
 	rz_list_sort(plugin_list, (RzListComparator)rz_hash_plugin_cmp, NULL);
@@ -131,7 +131,7 @@ static void rz_hash_show_algorithms(RzHashContext *ctx) {
 		printf("%6s %-14s %-10s %-30s %s\n", flags, rmdp->name, rmdp->license, rmdp->author, rmdp->description);
 	}
 	rz_list_free(plugin_list);
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 
 	const RzCryptoPlugin *rcp;
 	for (size_t i = 0; (rcp = rz_crypto_plugin_by_index(ctx->rc, i)); i++) {
@@ -810,10 +810,10 @@ static RzList /*<char *>*/ *parse_hash_algorithms(RzHashContext *ctx) {
 	if (!list) {
 		return NULL;
 	}
-	RzIterator *iter = ht_sp_as_iter(ctx->rh->plugins);
-	RzList *plugin_list = rz_list_new_from_iterator(iter);
+	RzIterator iter = ht_sp_as_iter(ctx->rh->plugins);
+	RzList *plugin_list = rz_list_new_from_iterator(&iter);
 	if (!plugin_list) {
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 		return NULL;
 	}
 	rz_list_sort(plugin_list, (RzListComparator)rz_hash_plugin_cmp, NULL);
@@ -823,7 +823,7 @@ static RzList /*<char *>*/ *parse_hash_algorithms(RzHashContext *ctx) {
 		rz_list_append(list, (void *)rmdp->name);
 	}
 	rz_list_free(plugin_list);
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	return list;
 }
 

--- a/librz/util/graph_algorithm.c
+++ b/librz/util/graph_algorithm.c
@@ -104,7 +104,8 @@ static void dfs_push_neighbours(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraph
 		}
 	}
 
-	rz_iterator_free(edge_iter);
+	rz_iterator_fini(edge_iter);
+	free(edge_iter);
 }
 
 /**
@@ -303,14 +304,16 @@ static void find_back_edges_push(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGrap
 	if (cmp) {
 		RzPVector /*<RzGraphEdge *>*/ *edges_vec = rz_pvector_new(NULL);
 		if (!edges_vec) {
-			rz_iterator_free(edge_iter);
+			rz_iterator_fini(edge_iter);
+			free(edge_iter);
 			return;
 		}
 		RzGraphEdge *e;
 		rz_iterator_foreach(edge_iter, e) {
 			rz_pvector_push(edges_vec, e);
 		}
-		rz_iterator_free(edge_iter);
+		rz_iterator_fini(edge_iter);
+		free(edge_iter);
 		if (rz_pvector_len(edges_vec) > 1) {
 			rz_pvector_sort(edges_vec, (RzPVectorComparator)cmp, user);
 		}
@@ -334,7 +337,8 @@ static void find_back_edges_push(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGrap
 				rz_stack_push(stack, entry);
 			}
 		}
-		rz_iterator_free(edge_iter);
+		rz_iterator_fini(edge_iter);
+		free(edge_iter);
 	}
 }
 
@@ -518,7 +522,8 @@ RZ_API RZ_OWN RzPVector /*<RzPVector<RzGraphNode *> *>*/ *rz_graph_find_sccs(RzG
 			rz_iterator_foreach(it, e) {
 				rz_pvector_push(root_nb, e->to);
 			}
-			rz_iterator_free(it);
+			rz_iterator_fini(it);
+			free(it);
 		}
 		TarjanFrame *rf = tarjan_frame_new(root, root_nb);
 		if (!rf) {
@@ -550,7 +555,8 @@ RZ_API RZ_OWN RzPVector /*<RzPVector<RzGraphNode *> *>*/ *rz_graph_find_sccs(RzG
 						rz_iterator_foreach(vit, e) {
 							rz_pvector_push(v_nb, e->to);
 						}
-						rz_iterator_free(vit);
+						rz_iterator_fini(vit);
+						free(vit);
 					}
 					TarjanFrame *vf = tarjan_frame_new(v, v_nb);
 					if (!vf) {

--- a/librz/util/graph_algorithm.c
+++ b/librz/util/graph_algorithm.c
@@ -89,14 +89,14 @@ static void dfs_edge_policy(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode
  */
 static void dfs_push_neighbours(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *node, RzStack *stack, bool forward, RzGraphVisitor *visitor) {
 	// assert g, node, stack, visitor NON NULL
-	RzIterator *edge_iter = forward ? g->impl_ops->get_out_edges(g, node) : g->impl_ops->get_in_edges(g, node);
-	if (!edge_iter) {
+	RzIterator edge_iter = forward ? g->impl_ops->get_out_edges(g, node) : g->impl_ops->get_in_edges(g, node);
+	if (rz_iterator_is_uninit(&edge_iter)) {
 		return;
 	}
 
 	RzGraphEdge *edge;
 	DfsEntry *entry;
-	rz_iterator_foreach(edge_iter, edge) {
+	rz_iterator_foreach(&edge_iter, edge) {
 		RzGraphNode *neighbour = forward ? edge->to : edge->from;
 		entry = dfs_entry_new(node, neighbour);
 		if (entry) {
@@ -104,8 +104,7 @@ static void dfs_push_neighbours(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraph
 		}
 	}
 
-	rz_iterator_fini(edge_iter);
-	free(edge_iter);
+	rz_iterator_fini(&edge_iter);
 }
 
 /**
@@ -296,24 +295,22 @@ RZ_API void rz_graph_dfs_reverse_from_node(RzGraph /*<NodeType *, EdgeType *>*/ 
  * the LIFO stack, matching the traversal order used for layout.
  */
 static void find_back_edges_push(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *node, RzStack *stack, RzGraphEdgeCmp cmp, void *user) {
-	RzIterator *edge_iter = g->impl_ops->get_out_edges(g, node);
-	if (!edge_iter) {
+	RzIterator edge_iter = g->impl_ops->get_out_edges(g, node);
+	if (rz_iterator_is_uninit(&edge_iter)) {
 		return;
 	}
 
 	if (cmp) {
 		RzPVector /*<RzGraphEdge *>*/ *edges_vec = rz_pvector_new(NULL);
 		if (!edges_vec) {
-			rz_iterator_fini(edge_iter);
-			free(edge_iter);
+			rz_iterator_fini(&edge_iter);
 			return;
 		}
 		RzGraphEdge *e;
-		rz_iterator_foreach(edge_iter, e) {
+		rz_iterator_foreach(&edge_iter, e) {
 			rz_pvector_push(edges_vec, e);
 		}
-		rz_iterator_fini(edge_iter);
-		free(edge_iter);
+		rz_iterator_fini(&edge_iter);
 		if (rz_pvector_len(edges_vec) > 1) {
 			rz_pvector_sort(edges_vec, (RzPVectorComparator)cmp, user);
 		}
@@ -331,14 +328,13 @@ static void find_back_edges_push(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGrap
 		rz_pvector_free(edges_vec);
 	} else {
 		RzGraphEdge *e;
-		rz_iterator_foreach(edge_iter, e) {
+		rz_iterator_foreach(&edge_iter, e) {
 			DfsEntry *entry = dfs_entry_new(node, e->to);
 			if (entry) {
 				rz_stack_push(stack, entry);
 			}
 		}
-		rz_iterator_fini(edge_iter);
-		free(edge_iter);
+		rz_iterator_fini(&edge_iter);
 	}
 }
 
@@ -516,14 +512,13 @@ RZ_API RZ_OWN RzPVector /*<RzPVector<RzGraphNode *> *>*/ *rz_graph_find_sccs(RzG
 		if (!root_nb) {
 			break;
 		}
-		RzIterator *it = g->impl_ops->get_out_edges(g, root);
-		if (it) {
+		RzIterator it = g->impl_ops->get_out_edges(g, root);
+		if (!rz_iterator_is_uninit(&it)) {
 			RzGraphEdge *e;
-			rz_iterator_foreach(it, e) {
+			rz_iterator_foreach(&it, e) {
 				rz_pvector_push(root_nb, e->to);
 			}
-			rz_iterator_fini(it);
-			free(it);
+			rz_iterator_fini(&it);
 		}
 		TarjanFrame *rf = tarjan_frame_new(root, root_nb);
 		if (!rf) {
@@ -549,14 +544,13 @@ RZ_API RZ_OWN RzPVector /*<RzPVector<RzGraphNode *> *>*/ *rz_graph_find_sccs(RzG
 					if (!v_nb) {
 						break;
 					}
-					RzIterator *vit = g->impl_ops->get_out_edges(g, v);
-					if (vit) {
+					RzIterator vit = g->impl_ops->get_out_edges(g, v);
+					if (!rz_iterator_is_uninit(&vit)) {
 						RzGraphEdge *e;
-						rz_iterator_foreach(vit, e) {
+						rz_iterator_foreach(&vit, e) {
 							rz_pvector_push(v_nb, e->to);
 						}
-						rz_iterator_fini(vit);
-						free(vit);
+						rz_iterator_fini(&vit);
 					}
 					TarjanFrame *vf = tarjan_frame_new(v, v_nb);
 					if (!vf) {

--- a/librz/util/graph_drawable.c
+++ b/librz/util/graph_drawable.c
@@ -195,22 +195,21 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_dot(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 		return NULL;
 	}
 	ut64 seq = 0;
-	RzIterator *it = rz_graph_get_nodes(graph);
-	rz_iterator_foreach(it, node) {
+	RzIterator it = rz_graph_get_nodes(graph);
+	rz_iterator_foreach(&it, node) {
 		ht_uu_insert(id_map, node->hash_id, seq++);
 	}
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 
 	// Pass 2: emit nodes and edges using sequential ids
-	RzIterator *it_nodes = rz_graph_get_nodes(graph);
-	if (!it_nodes) {
+	RzIterator it_nodes = rz_graph_get_nodes(graph);
+	if (rz_iterator_is_uninit(&it_nodes)) {
 		ht_uu_free(id_map);
 		rz_strbuf_fini(&buf);
 		return NULL;
 	}
 
-	rz_iterator_foreach(it_nodes, node) {
+	rz_iterator_foreach(&it_nodes, node) {
 		RzGraphNodeInfo *print_node = (RzGraphNodeInfo *)node->data;
 		char *url;
 		RzStrBuf *label = rz_strbuf_new("");
@@ -219,8 +218,7 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_dot(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 		default:
 			RZ_LOG_ERROR("Unhandled node type. Graph node either doesn't support dot graph printing or it isn't implemented.\n");
 			rz_strbuf_free(label);
-			rz_iterator_fini(it_nodes);
-			free(it_nodes);
+			rz_iterator_fini(&it_nodes);
 			ht_uu_free(id_map);
 			rz_strbuf_fini(&buf);
 			return NULL;
@@ -270,21 +268,19 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_dot(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 		url = NULL;
 
 		// get Iterator
-		RzIterator *it_out_nodes = rz_graph_out_neighbors(graph, node);
-		if (!it_out_nodes) {
+		RzIterator it_out_nodes = rz_graph_out_neighbors(graph, node);
+		if (rz_iterator_is_uninit(&it_out_nodes)) {
 			continue;
 		}
 
-		rz_iterator_foreach(it_out_nodes, target) {
+		rz_iterator_foreach(&it_out_nodes, target) {
 			bool found_t = false;
 			ut64 target_id = ht_uu_find(id_map, target->hash_id, &found_t);
 			rz_strbuf_appendf(&buf, "%" PFMT64d " -> %" PFMT64d "\n", node_id, target_id);
 		}
-		rz_iterator_fini(it_out_nodes);
-		free(it_out_nodes);
+		rz_iterator_fini(&it_out_nodes);
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 	ht_uu_free(id_map);
 
 	rz_strbuf_append(&buf, "}\n");
@@ -308,12 +304,11 @@ RZ_API void rz_graph_drawable_to_json(RZ_NONNULL RzGraph /*<RzGraphNodeInfo *, N
 		return;
 	}
 	ut64 seq = 0;
-	RzIterator *it = rz_graph_get_nodes(graph);
-	rz_iterator_foreach(it, node) {
+	RzIterator it = rz_graph_get_nodes(graph);
+	rz_iterator_foreach(&it, node) {
 		ht_uu_insert(id_map, node->hash_id, seq++);
 	}
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 
 	// Pass 2: serialize using sequential ids
 	pj_o(pj);
@@ -321,7 +316,7 @@ RZ_API void rz_graph_drawable_to_json(RZ_NONNULL RzGraph /*<RzGraphNodeInfo *, N
 	pj_a(pj);
 
 	it = rz_graph_get_nodes(graph);
-	rz_iterator_foreach(it, node) {
+	rz_iterator_foreach(&it, node) {
 		bool found;
 		RzGraphNodeInfo *print_node = (RzGraphNodeInfo *)node->data;
 		pj_o(pj);
@@ -352,19 +347,17 @@ RZ_API void rz_graph_drawable_to_json(RZ_NONNULL RzGraph /*<RzGraphNodeInfo *, N
 		pj_k(pj, "out_nodes");
 		pj_a(pj);
 
-		RzIterator *it_neighbours = rz_graph_out_neighbors(graph, node);
-		if (it_neighbours) {
-			rz_iterator_foreach(it_neighbours, neighbour) {
+		RzIterator it_neighbours = rz_graph_out_neighbors(graph, node);
+		if (!rz_iterator_is_uninit(&it_neighbours)) {
+			rz_iterator_foreach(&it_neighbours, neighbour) {
 				pj_n(pj, ht_uu_find(id_map, neighbour->hash_id, &found));
 			}
-			rz_iterator_fini(it_neighbours);
-			free(it_neighbours);
+			rz_iterator_fini(&it_neighbours);
 		}
 		pj_end(pj); // close out_nodes array
 		pj_end(pj); // close node object
 	}
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 	pj_end(pj); // close nodes array
 	pj_end(pj); // close root object
 	ht_uu_free(id_map);
@@ -406,8 +399,8 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_cmd(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 
 	RzGraphNode *node, *target;
 
-	RzIterator *it_nodes = rz_graph_get_nodes(graph);
-	rz_iterator_foreach(it_nodes, node) {
+	RzIterator it_nodes = rz_graph_get_nodes(graph);
+	rz_iterator_foreach(&it_nodes, node) {
 		RzGraphNodeInfo *print_node = node->data;
 		if (RZ_STR_ISNOTEMPTY(print_node->def.body)) {
 			ut32 len = strlen(print_node->def.body);
@@ -421,25 +414,22 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_cmd(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 			rz_strbuf_appendf(sb, "agn \"%s\"\n", print_node->def.title);
 		}
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 
 	it_nodes = rz_graph_get_nodes(graph);
-	rz_iterator_foreach(it_nodes, node) {
+	rz_iterator_foreach(&it_nodes, node) {
 		RzGraphNodeInfo *print_node = node->data;
-		RzIterator *it_out_neighbours = rz_graph_out_neighbors(graph, node);
-		if (!it_out_neighbours) {
+		RzIterator it_out_neighbours = rz_graph_out_neighbors(graph, node);
+		if (rz_iterator_is_uninit(&it_out_neighbours)) {
 			continue;
 		}
-		rz_iterator_foreach(it_out_neighbours, target) {
+		rz_iterator_foreach(&it_out_neighbours, target) {
 			RzGraphNodeInfo *to = target->data;
 			rz_strbuf_appendf(sb, "age \"%s\" \"%s\"\n", print_node->def.title, to->def.title);
 		}
-		rz_iterator_fini(it_out_neighbours);
-		free(it_out_neighbours);
+		rz_iterator_fini(&it_out_neighbours);
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 	return rz_strbuf_drain(sb);
 }
 
@@ -468,29 +458,27 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_gml(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 		return NULL;
 	}
 	ut64 seq = 0;
-	RzIterator *it = rz_graph_get_nodes(graph);
-	rz_iterator_foreach(it, graphNode) {
+	RzIterator it = rz_graph_get_nodes(graph);
+	rz_iterator_foreach(&it, graphNode) {
 		ht_uu_insert(id_map, graphNode->hash_id, seq++);
 	}
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 
 	// Pass 2: emit nodes using sequential ids
-	RzIterator *it_nodes = rz_graph_get_nodes(graph);
-	if (!it_nodes) {
+	RzIterator it_nodes = rz_graph_get_nodes(graph);
+	if (rz_iterator_is_uninit(&it_nodes)) {
 		ht_uu_free(id_map);
 		rz_strbuf_free(sb);
 		return NULL;
 	}
 
-	rz_iterator_foreach(it_nodes, graphNode) {
+	rz_iterator_foreach(&it_nodes, graphNode) {
 		RzGraphNodeInfo *print_node = graphNode->data;
 
 		switch (print_node->type) {
 		default:
 			RZ_LOG_ERROR("Unhandled node type. Graph node either doesn't support dot graph printing or it isn't implemented.\n");
-			rz_iterator_fini(it_nodes);
-			free(it_nodes);
+			rz_iterator_fini(&it_nodes);
 			ht_uu_free(id_map);
 			rz_strbuf_free(sb);
 			return NULL;
@@ -513,20 +501,19 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_gml(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 				      "  ]\n",
 			node_id, label);
 	}
-	rz_iterator_fini(it_nodes);
-	free(it_nodes);
+	rz_iterator_fini(&it_nodes);
 
-	RzIterator *it_out_nodes = rz_graph_get_nodes(graph);
-	RzIterator *it_neighbours = NULL;
-	rz_iterator_foreach(it_out_nodes, graphNode) {
+	RzIterator it_out_nodes = rz_graph_get_nodes(graph);
+	RzIterator it_neighbours = { 0 };
+	rz_iterator_foreach(&it_out_nodes, graphNode) {
 		it_neighbours = rz_graph_out_neighbors(graph, graphNode);
-		if (!it_neighbours) {
+		if (rz_iterator_is_uninit(&it_neighbours)) {
 			continue;
 		}
 
 		bool found_s = false;
 		ut64 src_id = ht_uu_find(id_map, graphNode->hash_id, &found_s);
-		rz_iterator_foreach(it_neighbours, target) {
+		rz_iterator_foreach(&it_neighbours, target) {
 			bool found_t = false;
 			ut64 target_id = ht_uu_find(id_map, target->hash_id, &found_t);
 			rz_strbuf_appendf(sb, "  edge [\n"
@@ -535,11 +522,9 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_gml(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 					      "  ]\n",
 				src_id, target_id);
 		}
-		rz_iterator_fini(it_neighbours);
-		free(it_neighbours);
+		rz_iterator_fini(&it_neighbours);
 	}
-	rz_iterator_fini(it_out_nodes);
-	free(it_out_nodes);
+	rz_iterator_fini(&it_out_nodes);
 	ht_uu_free(id_map);
 
 	rz_strbuf_appendf(sb, "]\n");

--- a/librz/util/graph_drawable.c
+++ b/librz/util/graph_drawable.c
@@ -199,7 +199,8 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_dot(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 	rz_iterator_foreach(it, node) {
 		ht_uu_insert(id_map, node->hash_id, seq++);
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 
 	// Pass 2: emit nodes and edges using sequential ids
 	RzIterator *it_nodes = rz_graph_get_nodes(graph);
@@ -218,7 +219,8 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_dot(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 		default:
 			RZ_LOG_ERROR("Unhandled node type. Graph node either doesn't support dot graph printing or it isn't implemented.\n");
 			rz_strbuf_free(label);
-			rz_iterator_free(it_nodes);
+			rz_iterator_fini(it_nodes);
+			free(it_nodes);
 			ht_uu_free(id_map);
 			rz_strbuf_fini(&buf);
 			return NULL;
@@ -278,9 +280,11 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_dot(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 			ut64 target_id = ht_uu_find(id_map, target->hash_id, &found_t);
 			rz_strbuf_appendf(&buf, "%" PFMT64d " -> %" PFMT64d "\n", node_id, target_id);
 		}
-		rz_iterator_free(it_out_nodes);
+		rz_iterator_fini(it_out_nodes);
+		free(it_out_nodes);
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 	ht_uu_free(id_map);
 
 	rz_strbuf_append(&buf, "}\n");
@@ -308,7 +312,8 @@ RZ_API void rz_graph_drawable_to_json(RZ_NONNULL RzGraph /*<RzGraphNodeInfo *, N
 	rz_iterator_foreach(it, node) {
 		ht_uu_insert(id_map, node->hash_id, seq++);
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 
 	// Pass 2: serialize using sequential ids
 	pj_o(pj);
@@ -352,12 +357,14 @@ RZ_API void rz_graph_drawable_to_json(RZ_NONNULL RzGraph /*<RzGraphNodeInfo *, N
 			rz_iterator_foreach(it_neighbours, neighbour) {
 				pj_n(pj, ht_uu_find(id_map, neighbour->hash_id, &found));
 			}
-			rz_iterator_free(it_neighbours);
+			rz_iterator_fini(it_neighbours);
+			free(it_neighbours);
 		}
 		pj_end(pj); // close out_nodes array
 		pj_end(pj); // close node object
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 	pj_end(pj); // close nodes array
 	pj_end(pj); // close root object
 	ht_uu_free(id_map);
@@ -414,7 +421,8 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_cmd(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 			rz_strbuf_appendf(sb, "agn \"%s\"\n", print_node->def.title);
 		}
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 
 	it_nodes = rz_graph_get_nodes(graph);
 	rz_iterator_foreach(it_nodes, node) {
@@ -427,9 +435,11 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_cmd(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 			RzGraphNodeInfo *to = target->data;
 			rz_strbuf_appendf(sb, "age \"%s\" \"%s\"\n", print_node->def.title, to->def.title);
 		}
-		rz_iterator_free(it_out_neighbours);
+		rz_iterator_fini(it_out_neighbours);
+		free(it_out_neighbours);
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 	return rz_strbuf_drain(sb);
 }
 
@@ -462,7 +472,8 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_gml(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 	rz_iterator_foreach(it, graphNode) {
 		ht_uu_insert(id_map, graphNode->hash_id, seq++);
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 
 	// Pass 2: emit nodes using sequential ids
 	RzIterator *it_nodes = rz_graph_get_nodes(graph);
@@ -478,7 +489,8 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_gml(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 		switch (print_node->type) {
 		default:
 			RZ_LOG_ERROR("Unhandled node type. Graph node either doesn't support dot graph printing or it isn't implemented.\n");
-			rz_iterator_free(it_nodes);
+			rz_iterator_fini(it_nodes);
+			free(it_nodes);
 			ht_uu_free(id_map);
 			rz_strbuf_free(sb);
 			return NULL;
@@ -501,7 +513,8 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_gml(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 				      "  ]\n",
 			node_id, label);
 	}
-	rz_iterator_free(it_nodes);
+	rz_iterator_fini(it_nodes);
+	free(it_nodes);
 
 	RzIterator *it_out_nodes = rz_graph_get_nodes(graph);
 	RzIterator *it_neighbours = NULL;
@@ -522,9 +535,11 @@ RZ_API RZ_OWN char *rz_graph_drawable_to_gml(RZ_NONNULL RzGraph /*<RzGraphNodeIn
 					      "  ]\n",
 				src_id, target_id);
 		}
-		rz_iterator_free(it_neighbours);
+		rz_iterator_fini(it_neighbours);
+		free(it_neighbours);
 	}
-	rz_iterator_free(it_out_nodes);
+	rz_iterator_fini(it_out_nodes);
+	free(it_out_nodes);
 	ht_uu_free(id_map);
 
 	rz_strbuf_appendf(sb, "]\n");

--- a/librz/util/graph_impl.c
+++ b/librz/util/graph_impl.c
@@ -358,11 +358,16 @@ static RZ_OWN RzIterator *pvector_as_iter(RzPVector /*<RzGraphEdge *>*/ *vec) {
 	state->cur_id = 0;
 	state->vec = vec;
 
-	RzIterator *iter = rz_iterator_new(
-		(rz_iterator_next_cb)pvecotr_iter_next,
-		NULL,
-		free,
-		state);
+	/**
+	 * RzIterator *iter = rz_iterator_new((rz_iterator_next_cb)pvecotr_iter_next, NULL, free, state);
+	 * Replaced with explicit allocation instead of rz_iterator_new
+	 * because this function must keep returning RzIterator* for graph interface compatibility.
+	 */
+	RzIterator *iter = RZ_NEW0(RzIterator);
+	iter->next = (rz_iterator_next_cb)pvecotr_iter_next;
+	iter->free = NULL;
+	iter->free_u = free;
+	iter->u = state;
 	return iter;
 }
 
@@ -811,11 +816,16 @@ static RzIterator *matrix_edge_as_iter(const RzGraph /*<NodeType *, EdgeType *>*
 	state->cur = 0;
 	state->scan_out = scan_out;
 
-	RzIterator *iter = rz_iterator_new(
-		(rz_iterator_next_cb)matrix_edge_iter_next,
-		NULL,
-		free,
-		state);
+	/**
+	 * RzIterator *iter = rz_iterator_new((rz_iterator_next_cb)matrix_edge_iter_next, NULL, free, state);
+	 * Replaced with explicit allocation instead of rz_iterator_new
+	 * because of the same reason as pvector_as_iter() above.
+	 */
+	RzIterator *iter = RZ_NEW0(RzIterator);
+	iter->next = (rz_iterator_next_cb)matrix_edge_iter_next;
+	iter->free = NULL;
+	iter->free_u = free;
+	iter->u = state;
 	return iter;
 }
 
@@ -1197,7 +1207,8 @@ RZ_API void rz_graph_free(RZ_NULLABLE RZ_OWN RzGraph /*<NodeType *, EdgeType *>*
 					e->data = NULL;
 				}
 			}
-			rz_iterator_free(edge_it);
+			rz_iterator_fini(edge_it);
+			free(edge_it);
 		}
 	}
 
@@ -1270,7 +1281,8 @@ RZ_API void rz_graph_reset(RzGraph /*<NodeType *, EdgeType *>*/ *g) {
 					e->data = NULL;
 				}
 			}
-			rz_iterator_free(edge_it);
+			rz_iterator_fini(edge_it);
+			free(edge_it);
 		}
 	}
 
@@ -1711,7 +1723,7 @@ static void neighbour_iter_free(void *user_data) {
 	if (!state) {
 		return;
 	}
-	rz_iterator_free(state->edge_iter);
+	rz_iterator_fini(state->edge_iter);
 	state->edge_iter = NULL;
 	free(state);
 }
@@ -1735,11 +1747,16 @@ static RZ_OWN RzIterator *as_neighbour_iter(RZ_OWN RzIterator *edge_iter, bool u
 	state->edge_iter = edge_iter;
 	state->use_from = use_from;
 
-	RzIterator *iter = rz_iterator_new(
-		neighbour_iter_next,
-		NULL,
-		neighbour_iter_free,
-		state);
+	/**
+	 * RzIterator *iter = rz_iterator_new(neighbour_iter_next, NULL, neighbour_iter_free, state);
+	 * Replaced with explicit allocation instead of rz_iterator_new
+	 * because of the same reason as pvector_as_iter() above.
+	 */
+	RzIterator *iter = RZ_NEW0(RzIterator);
+	iter->next = neighbour_iter_next;
+	iter->free = NULL;
+	iter->free_u = neighbour_iter_free;
+	iter->u = state;
 	return iter;
 }
 
@@ -1758,7 +1775,8 @@ RZ_API RZ_OWN RzIterator *rz_graph_out_neighbors(RzGraph /*<NodeType *, EdgeType
 	}
 	RzIterator *iter = as_neighbour_iter(edge_iter, false);
 	if (!iter) {
-		rz_iterator_free(edge_iter);
+		rz_iterator_fini(edge_iter);
+		free(edge_iter);
 		return NULL;
 	}
 	return iter;
@@ -1779,7 +1797,8 @@ RZ_API RZ_OWN RzIterator *rz_graph_in_neighbors(RzGraph /*<NodeType *, EdgeType 
 	}
 	RzIterator *iter = as_neighbour_iter(edge_iter, true);
 	if (!iter) {
-		rz_iterator_free(edge_iter);
+		rz_iterator_fini(edge_iter);
+		free(edge_iter);
 		return NULL;
 	}
 	return iter;
@@ -1808,12 +1827,14 @@ RZ_API RzGraphNode *rz_graph_nth_neighbour(const RzGraph /*<NodeType *, EdgeType
 	ut64 i = 0;
 	while ((edge = rz_iterator_next(edge_iter)) != NULL) {
 		if (i == nth) {
-			rz_iterator_free(edge_iter);
+			rz_iterator_fini(edge_iter);
+			free(edge_iter);
 			return out_neighbor ? edge->to : edge->from;
 		}
 		i += 1;
 	}
-	rz_iterator_free(edge_iter);
+	rz_iterator_fini(edge_iter);
+	free(edge_iter);
 	return NULL;
 }
 
@@ -1854,7 +1875,8 @@ RZ_API ut64 rz_graph_out_degree(const RzGraph /*<NodeType *, EdgeType *>*/ *g, c
 		rz_iterator_foreach(it, e) {
 			count += 1;
 		}
-		rz_iterator_free(it);
+		rz_iterator_fini(it);
+		free(it);
 	}
 	return count;
 }
@@ -1868,7 +1890,8 @@ RZ_API ut64 rz_graph_in_degree(const RzGraph /*<NodeType *, EdgeType *>*/ *g, co
 		rz_iterator_foreach(it, e) {
 			count += 1;
 		}
-		rz_iterator_free(it);
+		rz_iterator_fini(it);
+		free(it);
 	}
 	return count;
 }
@@ -2190,9 +2213,11 @@ RZ_API RZ_OWN char *rz_graph_as_dot_str(
 				rz_strbuf_append(sb, "\n");
 			}
 		}
-		rz_iterator_free(out_edges);
+		rz_iterator_fini(out_edges);
+		free(out_edges);
 	}
-	rz_iterator_free(nodes);
+	rz_iterator_fini(nodes);
+	free(nodes);
 	rz_strbuf_append(sb, "}\n");
 	return rz_strbuf_drain(sb);
 }

--- a/librz/util/graph_impl.c
+++ b/librz/util/graph_impl.c
@@ -345,29 +345,25 @@ static void *pvecotr_iter_next(RzIterator *iter) {
  * \param vec the pvector to iterate over (borrowed)
  * \return A new RzIterator, or NULL on failure
  */
-static RZ_OWN RzIterator *pvector_as_iter(RzPVector /*<RzGraphEdge *>*/ *vec) {
+static RZ_OWN RzIterator pvector_as_iter(RzPVector /*<RzGraphEdge *>*/ *vec) {
 	if (!vec) {
-		return NULL;
+		return (RzIterator){ 0 };
 	}
 
 	// free state only, dont broke pvector nodes of graph
 	RzGraphListIterState *state = RZ_NEW0(RzGraphListIterState);
 	if (!state) {
-		return NULL;
+		return (RzIterator){ 0 };
 	}
 	state->cur_id = 0;
 	state->vec = vec;
 
-	/**
-	 * RzIterator *iter = rz_iterator_new((rz_iterator_next_cb)pvecotr_iter_next, NULL, free, state);
-	 * Replaced with explicit allocation instead of rz_iterator_new
-	 * because this function must keep returning RzIterator* for graph interface compatibility.
-	 */
-	RzIterator *iter = RZ_NEW0(RzIterator);
-	iter->next = (rz_iterator_next_cb)pvecotr_iter_next;
-	iter->free = NULL;
-	iter->free_u = free;
-	iter->u = state;
+	RzIterator iter = (RzIterator){
+		.next = (rz_iterator_next_cb)pvecotr_iter_next,
+		.free = NULL,
+		.free_u = free,
+		.u = state
+	};
 	return iter;
 }
 
@@ -378,14 +374,14 @@ static RZ_OWN RzIterator *pvector_as_iter(RzPVector /*<RzGraphEdge *>*/ *vec) {
  * \param node the node whose out-edges to iterate
  * \return A new edge iterator owned by caller, or NULL if no out-edges
  */
-static RZ_OWN RzIterator *rz_graph_list_impl_get_out_edges(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *node) {
-	rz_return_val_if_fail(g, NULL);
+static RZ_OWN RzIterator rz_graph_list_impl_get_out_edges(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *node) {
+	rz_return_val_if_fail(g, (RzIterator){ 0 });
 	RzGraphListImpl *impl = (RzGraphListImpl *)g->impl;
 	RzPVector /*<RzGraphEdge *>*/ *out_vec = rz_pvector_at(impl->out_edges, node->_vec_id);
 	if (!out_vec || rz_pvector_empty(out_vec)) {
-		return NULL;
+		return (RzIterator){ 0 };
 	}
-	RzIterator *iter = pvector_as_iter(out_vec);
+	RzIterator iter = pvector_as_iter(out_vec);
 	return iter;
 }
 
@@ -396,14 +392,14 @@ static RZ_OWN RzIterator *rz_graph_list_impl_get_out_edges(RzGraph /*<NodeType *
  * \param node the node whose in-edges to iterate
  * \return A new edge iterator owned by caller, or NULL if no in-edges
  */
-static RZ_OWN RzIterator *rz_graph_list_impl_get_in_edges(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *node) {
-	rz_return_val_if_fail(g, NULL);
+static RZ_OWN RzIterator rz_graph_list_impl_get_in_edges(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *node) {
+	rz_return_val_if_fail(g, (RzIterator){ 0 });
 	RzGraphListImpl *impl = (RzGraphListImpl *)g->impl;
 	RzPVector /*<RzGraphEdge *>*/ *in_vec = rz_pvector_at(impl->in_edges, node->_vec_id);
 	if (!in_vec || rz_pvector_empty(in_vec)) {
-		return NULL;
+		return (RzIterator){ 0 };
 	}
-	RzIterator *iter = pvector_as_iter(in_vec);
+	RzIterator iter = pvector_as_iter(in_vec);
 	return iter;
 }
 
@@ -806,26 +802,22 @@ static void *matrix_edge_iter_next(RzIterator *it) {
  * \param scan_out true for outgoing edges, false for incoming edges
  * \return A new RzIterator, or NULL on failure
  */
-static RzIterator *matrix_edge_as_iter(const RzGraph /*<NodeType *, EdgeType *>*/ *g, ut64 node_vid, bool scan_out) {
+static RzIterator matrix_edge_as_iter(const RzGraph /*<NodeType *, EdgeType *>*/ *g, ut64 node_vid, bool scan_out) {
 	RzGraphMatrixIterState *state = RZ_NEW0(RzGraphMatrixIterState);
 	if (!state) {
-		return NULL;
+		return (RzIterator){ 0 };
 	}
 	state->g = g;
 	state->node_vid = node_vid;
 	state->cur = 0;
 	state->scan_out = scan_out;
 
-	/**
-	 * RzIterator *iter = rz_iterator_new((rz_iterator_next_cb)matrix_edge_iter_next, NULL, free, state);
-	 * Replaced with explicit allocation instead of rz_iterator_new
-	 * because of the same reason as pvector_as_iter() above.
-	 */
-	RzIterator *iter = RZ_NEW0(RzIterator);
-	iter->next = (rz_iterator_next_cb)matrix_edge_iter_next;
-	iter->free = NULL;
-	iter->free_u = free;
-	iter->u = state;
+	RzIterator iter = (RzIterator){
+		.next = (rz_iterator_next_cb)matrix_edge_iter_next,
+		.free = NULL,
+		.free_u = free,
+		.u = state
+	};
 	return iter;
 }
 
@@ -836,9 +828,9 @@ static RzIterator *matrix_edge_as_iter(const RzGraph /*<NodeType *, EdgeType *>*
  * \param node the node whose in-edges to iterate
  * \return A new edge iterator, or NULL if node is NULL
  */
-static RzIterator *rz_graph_matrix_impl_get_in_edges(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *node) {
+static RzIterator rz_graph_matrix_impl_get_in_edges(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *node) {
 	if (!node) {
-		return NULL;
+		return (RzIterator){ 0 };
 	}
 	return matrix_edge_as_iter(g, node->_vec_id, false);
 }
@@ -850,9 +842,9 @@ static RzIterator *rz_graph_matrix_impl_get_in_edges(RzGraph /*<NodeType *, Edge
  * \param node the node whose out-edges to iterate
  * \return A new edge iterator, or NULL if node is NULL
  */
-static RzIterator *rz_graph_matrix_impl_get_out_edges(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *node) {
+static RzIterator rz_graph_matrix_impl_get_out_edges(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *node) {
 	if (!node) {
-		return NULL;
+		return (RzIterator){ 0 };
 	}
 	return matrix_edge_as_iter(g, node->_vec_id, true);
 }
@@ -1196,19 +1188,18 @@ RZ_API void rz_graph_free(RZ_NULLABLE RZ_OWN RzGraph /*<NodeType *, EdgeType *>*
 			if (!node) {
 				continue;
 			}
-			RzIterator *edge_it = g->impl_ops->get_out_edges(g, node);
-			if (!edge_it) {
+			RzIterator edge_it = g->impl_ops->get_out_edges(g, node);
+			if (rz_iterator_is_uninit(&edge_it)) {
 				continue;
 			}
 			RzGraphEdge *e;
-			rz_iterator_foreach(edge_it, e) {
+			rz_iterator_foreach(&edge_it, e) {
 				if (e->data) {
 					g->edge_data_free(e->data);
 					e->data = NULL;
 				}
 			}
-			rz_iterator_fini(edge_it);
-			free(edge_it);
+			rz_iterator_fini(&edge_it);
 		}
 	}
 
@@ -1270,19 +1261,18 @@ RZ_API void rz_graph_reset(RzGraph /*<NodeType *, EdgeType *>*/ *g) {
 			if (!node) {
 				continue;
 			}
-			RzIterator *edge_it = g->impl_ops->get_out_edges(g, node);
-			if (!edge_it) {
+			RzIterator edge_it = g->impl_ops->get_out_edges(g, node);
+			if (rz_iterator_is_uninit(&edge_it)) {
 				continue;
 			}
 			RzGraphEdge *e;
-			rz_iterator_foreach(edge_it, e) {
+			rz_iterator_foreach(&edge_it, e) {
 				if (e->data) {
 					g->edge_data_free(e->data);
 					e->data = NULL;
 				}
 			}
-			rz_iterator_fini(edge_it);
-			free(edge_it);
+			rz_iterator_fini(&edge_it);
 		}
 	}
 
@@ -1638,9 +1628,9 @@ RZ_API RZ_BORROW RzGraphEdge *rz_graph_find_edge(RzGraph /*<NodeType *, EdgeType
  * \param g The graph.
  * \return A new node iterator, or NULL on failure
  */
-RZ_API RZ_OWN RzIterator *rz_graph_get_nodes(const RzGraph /*<NodeType *, EdgeType *>*/ *g) {
-	rz_return_val_if_fail(g, NULL);
-	RzIterator *iter = pvector_as_iter(g->node_vec);
+RZ_API RZ_OWN RzIterator rz_graph_get_nodes(const RzGraph /*<NodeType *, EdgeType *>*/ *g) {
+	rz_return_val_if_fail(g, (RzIterator){ 0 });
+	RzIterator iter = pvector_as_iter(g->node_vec);
 	return iter;
 }
 
@@ -1684,7 +1674,7 @@ RZ_API ut64 rz_graph_count_edges(const RzGraph /*<NodeType *, EdgeType *>*/ *g) 
 }
 
 typedef struct {
-	RzIterator *edge_iter;
+	RzIterator edge_iter;
 	bool use_from;
 } RzNeighbourIterState;
 
@@ -1699,7 +1689,7 @@ typedef struct {
  */
 static void *neighbour_iter_next(RzIterator *it) {
 	RzNeighbourIterState *state = (RzNeighbourIterState *)it->u;
-	RzGraphEdge *edge = rz_iterator_next(state->edge_iter);
+	RzGraphEdge *edge = rz_iterator_next(&state->edge_iter);
 	if (!edge) {
 		return NULL;
 	}
@@ -1723,8 +1713,8 @@ static void neighbour_iter_free(void *user_data) {
 	if (!state) {
 		return;
 	}
-	rz_iterator_fini(state->edge_iter);
-	state->edge_iter = NULL;
+	rz_iterator_fini(&state->edge_iter);
+	state->edge_iter = (RzIterator){ 0 };
 	free(state);
 }
 
@@ -1738,25 +1728,21 @@ static void neighbour_iter_free(void *user_data) {
  * \param use_from if true, yield edge->from; otherwise yield edge->to
  * \return A new neighbour iterator, or NULL on failure
  */
-static RZ_OWN RzIterator *as_neighbour_iter(RZ_OWN RzIterator *edge_iter, bool use_from) {
-	rz_return_val_if_fail(edge_iter, NULL);
+static RZ_OWN RzIterator as_neighbour_iter(RZ_OWN RzIterator *edge_iter, bool use_from) {
+	rz_return_val_if_fail(edge_iter, (RzIterator){ 0 });
 	RzNeighbourIterState *state = RZ_NEW0(RzNeighbourIterState);
 	if (!state) {
-		return NULL;
+		return (RzIterator){ 0 };
 	}
-	state->edge_iter = edge_iter;
+	state->edge_iter = *edge_iter;
 	state->use_from = use_from;
 
-	/**
-	 * RzIterator *iter = rz_iterator_new(neighbour_iter_next, NULL, neighbour_iter_free, state);
-	 * Replaced with explicit allocation instead of rz_iterator_new
-	 * because of the same reason as pvector_as_iter() above.
-	 */
-	RzIterator *iter = RZ_NEW0(RzIterator);
-	iter->next = neighbour_iter_next;
-	iter->free = NULL;
-	iter->free_u = neighbour_iter_free;
-	iter->u = state;
+	RzIterator iter = (RzIterator){
+		.next = neighbour_iter_next,
+		.free = NULL,
+		.free_u = neighbour_iter_free,
+		.u = state
+	};
 	return iter;
 }
 
@@ -1767,17 +1753,16 @@ static RZ_OWN RzIterator *as_neighbour_iter(RZ_OWN RzIterator *edge_iter, bool u
  * \param n the node
  * \return A new neighbour iterator owned by caller, or NULL
  */
-RZ_API RZ_OWN RzIterator *rz_graph_out_neighbors(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *n) {
-	rz_return_val_if_fail(g && n, NULL);
-	RzIterator *edge_iter = g->impl_ops->get_out_edges(g, n);
-	if (!edge_iter) {
-		return NULL;
+RZ_API RZ_OWN RzIterator rz_graph_out_neighbors(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *n) {
+	rz_return_val_if_fail(g && n, (RzIterator){ 0 });
+	RzIterator edge_iter = g->impl_ops->get_out_edges(g, n);
+	if (rz_iterator_is_uninit(&edge_iter)) {
+		return (RzIterator){ 0 };
 	}
-	RzIterator *iter = as_neighbour_iter(edge_iter, false);
-	if (!iter) {
-		rz_iterator_fini(edge_iter);
-		free(edge_iter);
-		return NULL;
+	RzIterator iter = as_neighbour_iter(&edge_iter, false);
+	if (rz_iterator_is_uninit(&iter)) {
+		rz_iterator_fini(&edge_iter);
+		return (RzIterator){ 0 };
 	}
 	return iter;
 }
@@ -1789,17 +1774,16 @@ RZ_API RZ_OWN RzIterator *rz_graph_out_neighbors(RzGraph /*<NodeType *, EdgeType
  * \param n the node
  * \return A new neighbour iterator owned by caller, or NULL
  */
-RZ_API RZ_OWN RzIterator *rz_graph_in_neighbors(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *n) {
-	rz_return_val_if_fail(g && n, NULL);
-	RzIterator *edge_iter = g->impl_ops->get_in_edges(g, n);
-	if (!edge_iter) {
-		return NULL;
+RZ_API RZ_OWN RzIterator rz_graph_in_neighbors(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *n) {
+	rz_return_val_if_fail(g && n, (RzIterator){ 0 });
+	RzIterator edge_iter = g->impl_ops->get_in_edges(g, n);
+	if (rz_iterator_is_uninit(&edge_iter)) {
+		return (RzIterator){ 0 };
 	}
-	RzIterator *iter = as_neighbour_iter(edge_iter, true);
-	if (!iter) {
-		rz_iterator_fini(edge_iter);
-		free(edge_iter);
-		return NULL;
+	RzIterator iter = as_neighbour_iter(&edge_iter, true);
+	if (rz_iterator_is_uninit(&iter)) {
+		rz_iterator_fini(&edge_iter);
+		return (RzIterator){ 0 };
 	}
 	return iter;
 }
@@ -1818,23 +1802,21 @@ RZ_API RZ_OWN RzIterator *rz_graph_in_neighbors(RzGraph /*<NodeType *, EdgeType 
  */
 RZ_API RzGraphNode *rz_graph_nth_neighbour(const RzGraph /*<NodeType *, EdgeType *>*/ *g, const RzGraphNode *n, ut64 nth, bool out_neighbor) {
 	rz_return_val_if_fail(g && n, NULL);
-	RzIterator *edge_iter = out_neighbor ? g->impl_ops->get_out_edges((RzGraph /*<NodeType *, EdgeType *>*/ *)g, (RzGraphNode *)n) : g->impl_ops->get_in_edges((RzGraph /*<NodeType *, EdgeType *>*/ *)g, (RzGraphNode *)n);
-	if (!edge_iter) {
+	RzIterator edge_iter = out_neighbor ? g->impl_ops->get_out_edges((RzGraph /*<NodeType *, EdgeType *>*/ *)g, (RzGraphNode *)n) : g->impl_ops->get_in_edges((RzGraph /*<NodeType *, EdgeType *>*/ *)g, (RzGraphNode *)n);
+	if (rz_iterator_is_uninit(&edge_iter)) {
 		return NULL;
 	}
 
 	RzGraphEdge *edge;
 	ut64 i = 0;
-	while ((edge = rz_iterator_next(edge_iter)) != NULL) {
+	while ((edge = rz_iterator_next(&edge_iter)) != NULL) {
 		if (i == nth) {
-			rz_iterator_fini(edge_iter);
-			free(edge_iter);
+			rz_iterator_fini(&edge_iter);
 			return out_neighbor ? edge->to : edge->from;
 		}
 		i += 1;
 	}
-	rz_iterator_fini(edge_iter);
-	free(edge_iter);
+	rz_iterator_fini(&edge_iter);
 	return NULL;
 }
 
@@ -1847,8 +1829,8 @@ RZ_API RzGraphNode *rz_graph_nth_neighbour(const RzGraph /*<NodeType *, EdgeType
  * \param node node to get edges
  * \return A new edge iterator, caller should free after use, or NULL if no edge or error
  */
-RZ_API RZ_OWN RzIterator *rz_graph_out_edges(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *node) {
-	rz_return_val_if_fail(g && node, NULL);
+RZ_API RZ_OWN RzIterator rz_graph_out_edges(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *node) {
+	rz_return_val_if_fail(g && node, (RzIterator){ 0 });
 	return g->impl_ops->get_out_edges(g, node);
 }
 
@@ -1861,22 +1843,21 @@ RZ_API RZ_OWN RzIterator *rz_graph_out_edges(RzGraph /*<NodeType *, EdgeType *>*
  * \param node node to get edges
  * \return A new edge iterator, caller should free after use, or NULL if no edge or error
  */
-RZ_API RZ_OWN RzIterator *rz_graph_in_edges(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *node) {
-	rz_return_val_if_fail(g && node, NULL);
+RZ_API RZ_OWN RzIterator rz_graph_in_edges(RzGraph /*<NodeType *, EdgeType *>*/ *g, RzGraphNode *node) {
+	rz_return_val_if_fail(g && node, (RzIterator){ 0 });
 	return g->impl_ops->get_in_edges(g, node);
 }
 
 RZ_API ut64 rz_graph_out_degree(const RzGraph /*<NodeType *, EdgeType *>*/ *g, const RzGraphNode *node) {
 	rz_return_val_if_fail(g && node, 0);
 	ut32 count = 0;
-	RzIterator *it = g->impl_ops->get_out_edges((RzGraph /*<NodeType *, EdgeType *>*/ *)g, (RzGraphNode *)node);
-	if (it) {
+	RzIterator it = g->impl_ops->get_out_edges((RzGraph /*<NodeType *, EdgeType *>*/ *)g, (RzGraphNode *)node);
+	if (!rz_iterator_is_uninit(&it)) {
 		RzGraphEdge *e;
-		rz_iterator_foreach(it, e) {
+		rz_iterator_foreach(&it, e) {
 			count += 1;
 		}
-		rz_iterator_fini(it);
-		free(it);
+		rz_iterator_fini(&it);
 	}
 	return count;
 }
@@ -1884,14 +1865,13 @@ RZ_API ut64 rz_graph_out_degree(const RzGraph /*<NodeType *, EdgeType *>*/ *g, c
 RZ_API ut64 rz_graph_in_degree(const RzGraph /*<NodeType *, EdgeType *>*/ *g, const RzGraphNode *node) {
 	rz_return_val_if_fail(g && node, 0);
 	ut32 count = 0;
-	RzIterator *it = g->impl_ops->get_in_edges((RzGraph /*<NodeType *, EdgeType *>*/ *)g, (RzGraphNode *)node);
-	if (it) {
+	RzIterator it = g->impl_ops->get_in_edges((RzGraph /*<NodeType *, EdgeType *>*/ *)g, (RzGraphNode *)node);
+	if (!rz_iterator_is_uninit(&it)) {
 		RzGraphEdge *e;
-		rz_iterator_foreach(it, e) {
+		rz_iterator_foreach(&it, e) {
 			count += 1;
 		}
-		rz_iterator_fini(it);
-		free(it);
+		rz_iterator_fini(&it);
 	}
 	return count;
 }
@@ -2069,11 +2049,11 @@ RZ_API RZ_NULLABLE RZ_BORROW RzGraphEdge *rz_graph_find_edge_by_id(RzGraph /*<No
  * \param hash_id The node identifier.
  * \return The iterator over <RZ_BORROW RzGraphEdge *> or NULL in case of failure.
  */
-RZ_API RZ_OWN RzIterator *rz_graph_out_edges_by_id(RzGraph /*<NodeType *, EdgeType *>*/ *g, ut64 hash_id) {
-	rz_return_val_if_fail(g, NULL);
+RZ_API RZ_OWN RzIterator rz_graph_out_edges_by_id(RzGraph /*<NodeType *, EdgeType *>*/ *g, ut64 hash_id) {
+	rz_return_val_if_fail(g, (RzIterator){ 0 });
 	RzGraphNode *node = rz_graph_find_node(g, hash_id);
 	if (!node) {
-		return NULL;
+		return (RzIterator){ 0 };
 	}
 	return rz_graph_out_edges(g, node);
 }
@@ -2085,11 +2065,11 @@ RZ_API RZ_OWN RzIterator *rz_graph_out_edges_by_id(RzGraph /*<NodeType *, EdgeTy
  * \param hash_id The node identifier.
  * \return The iterator over <RZ_BORROW RzGraphEdge *> or NULL in case of failure.
  */
-RZ_API RZ_OWN RzIterator *rz_graph_in_edges_by_id(RzGraph /*<NodeType *, EdgeType *>*/ *g, ut64 hash_id) {
-	rz_return_val_if_fail(g, NULL);
+RZ_API RZ_OWN RzIterator rz_graph_in_edges_by_id(RzGraph /*<NodeType *, EdgeType *>*/ *g, ut64 hash_id) {
+	rz_return_val_if_fail(g, (RzIterator){ 0 });
 	RzGraphNode *node = rz_graph_find_node(g, hash_id);
 	if (!node) {
-		return NULL;
+		return (RzIterator){ 0 };
 	}
 	return rz_graph_in_edges(g, node);
 }
@@ -2101,11 +2081,11 @@ RZ_API RZ_OWN RzIterator *rz_graph_in_edges_by_id(RzGraph /*<NodeType *, EdgeTyp
  * \param hash_id The node identifier.
  * \return The iterator over <RZ_BORROW RzGraphNode *> or NULL in case of failure.
  */
-RZ_API RZ_OWN RzIterator *rz_graph_out_neighbors_by_id(RzGraph /*<NodeType *, EdgeType *>*/ *g, ut64 hash_id) {
-	rz_return_val_if_fail(g, NULL);
+RZ_API RZ_OWN RzIterator rz_graph_out_neighbors_by_id(RzGraph /*<NodeType *, EdgeType *>*/ *g, ut64 hash_id) {
+	rz_return_val_if_fail(g, (RzIterator){ 0 });
 	RzGraphNode *node = rz_graph_find_node(g, hash_id);
 	if (!node) {
-		return NULL;
+		return (RzIterator){ 0 };
 	}
 	return rz_graph_out_neighbors(g, node);
 }
@@ -2117,11 +2097,11 @@ RZ_API RZ_OWN RzIterator *rz_graph_out_neighbors_by_id(RzGraph /*<NodeType *, Ed
  * \param hash_id The node identifier.
  * \return The iterator over <RZ_BORROW RzGraphNode *> or NULL in case of failure.
  */
-RZ_API RZ_OWN RzIterator *rz_graph_in_neighbors_by_id(RzGraph /*<NodeType *, EdgeType *>*/ *g, ut64 hash_id) {
-	rz_return_val_if_fail(g, NULL);
+RZ_API RZ_OWN RzIterator rz_graph_in_neighbors_by_id(RzGraph /*<NodeType *, EdgeType *>*/ *g, ut64 hash_id) {
+	rz_return_val_if_fail(g, (RzIterator){ 0 });
 	RzGraphNode *node = rz_graph_find_node(g, hash_id);
 	if (!node) {
-		return NULL;
+		return (RzIterator){ 0 };
 	}
 	return rz_graph_in_neighbors(g, node);
 }
@@ -2183,9 +2163,9 @@ RZ_API RZ_OWN char *rz_graph_as_dot_str(
 
 #define INDENT "   "
 
-	RzIterator *nodes = rz_graph_get_nodes(g);
+	RzIterator nodes = rz_graph_get_nodes(g);
 	RzGraphNode *n;
-	rz_iterator_foreach(nodes, n) {
+	rz_iterator_foreach(&nodes, n) {
 		char node_name[64] = { 0 };
 		rz_strf(node_name, "%" PFMT64d, rz_graph_node_get_id(n));
 
@@ -2195,12 +2175,12 @@ RZ_API RZ_OWN char *rz_graph_as_dot_str(
 			free(node_format);
 		}
 
-		RzIterator *out_edges = rz_graph_out_edges((RzGraph *)g, n);
-		if (!out_edges) {
+		RzIterator out_edges = rz_graph_out_edges((RzGraph *)g, n);
+		if (rz_iterator_is_uninit(&out_edges)) {
 			continue;
 		}
 		RzGraphEdge *e;
-		rz_iterator_foreach(out_edges, e) {
+		rz_iterator_foreach(&out_edges, e) {
 			rz_strbuf_appendf(sb, INDENT "%s -> %" PFMT64d,
 				node_name,
 				rz_graph_node_get_id(rz_graph_edge_get_to(e)));
@@ -2213,11 +2193,9 @@ RZ_API RZ_OWN char *rz_graph_as_dot_str(
 				rz_strbuf_append(sb, "\n");
 			}
 		}
-		rz_iterator_fini(out_edges);
-		free(out_edges);
+		rz_iterator_fini(&out_edges);
 	}
-	rz_iterator_fini(nodes);
-	free(nodes);
+	rz_iterator_fini(&nodes);
 	rz_strbuf_append(sb, "}\n");
 	return rz_strbuf_drain(sb);
 }

--- a/librz/util/graph_priv.h
+++ b/librz/util/graph_priv.h
@@ -46,8 +46,8 @@ struct rz_graph_impl_ops_t {
 	ut64 (*mem_usage)(const RzGraph *g);
 
 	// Return neighbors as iterator
-	RZ_OWN RzIterator *(*get_out_edges)(RzGraph *graph, RzGraphNode *node);
-	RZ_OWN RzIterator *(*get_in_edges)(RzGraph *graph, RzGraphNode *node);
+	RZ_OWN RzIterator (*get_out_edges)(RzGraph *graph, RzGraphNode *node);
+	RZ_OWN RzIterator (*get_in_edges)(RzGraph *graph, RzGraphNode *node);
 
 	bool (*add_node)(RzGraph *graph, RzGraphNode *node);
 	bool (*del_node)(RzGraph *graph, RzGraphNode *node);

--- a/librz/util/ht/ht_inc.c
+++ b/librz/util/ht/ht_inc.c
@@ -1083,16 +1083,16 @@ RZ_API void Ht_(free_iter_state)(RZ_NULLABLE HT_(IterState) *state) {
  *
  * \return The iterator over the hash table values or NULL in case of failure.
  */
-RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ *Ht_(as_iter_mut)(RZ_NONNULL HtName_(Ht) *ht) {
-	rz_return_val_if_fail(ht, NULL);
+RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ Ht_(as_iter_mut)(RZ_NONNULL HtName_(Ht) *ht) {
+	rz_return_val_if_fail(ht, (RzIterator){ 0 });
 	HT_(IterMutState) *state = Ht_(new_iter_mut_state)(ht);
 	if (!state) {
 		RZ_LOG_ERROR("Could not allocate a new ht_iter state.\n");
-		return NULL;
+		return (RzIterator){ 0 };
 	}
 
-	RzIterator *iter = rz_iterator_new((rz_iterator_next_cb)Ht_(iter_next_mut), NULL, (rz_iterator_free_cb)Ht_(free_iter_mut_state), state);
-	if (!iter) {
+	RzIterator iter = rz_iterator_new((rz_iterator_next_cb)Ht_(iter_next_mut), NULL, (rz_iterator_free_cb)Ht_(free_iter_mut_state), state);
+	if (!iter.next) {
 		Ht_(free_iter_mut_state)(state);
 	}
 	return iter;
@@ -1105,13 +1105,13 @@ RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ *Ht_(as_iter_mut)(RZ_NONNULL HtName
  *
  * \return The iterator over the hash table values or NULL in case of failure.
  */
-RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ *Ht_(as_iter)(const RZ_NONNULL HtName_(Ht) *ht) {
-	rz_return_val_if_fail(ht, NULL);
+RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ Ht_(as_iter)(const RZ_NONNULL HtName_(Ht) *ht) {
+	rz_return_val_if_fail(ht, (RzIterator){ 0 });
 	HT_(IterState) *state = Ht_(new_iter_state)(ht);
-	rz_return_val_if_fail(state, NULL);
+	rz_return_val_if_fail(state, (RzIterator){ 0 });
 
-	RzIterator *iter = rz_iterator_new((rz_iterator_next_cb)Ht_(iter_next), NULL, (rz_iterator_free_cb)Ht_(free_iter_state), state);
-	if (!iter) {
+	RzIterator iter = rz_iterator_new((rz_iterator_next_cb)Ht_(iter_next), NULL, (rz_iterator_free_cb)Ht_(free_iter_state), state);
+	if (!iter.next) {
 		Ht_(free_iter_state)(state);
 	}
 	return iter;
@@ -1124,13 +1124,13 @@ RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ *Ht_(as_iter)(const RZ_NONNULL HtNa
  *
  * \return The iterator over the hash table keys or NULL in case of failure.
  */
-RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ *Ht_(as_iter_keys)(const RZ_NONNULL HtName_(Ht) *ht) {
-	rz_return_val_if_fail(ht, NULL);
+RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ Ht_(as_iter_keys)(const RZ_NONNULL HtName_(Ht) *ht) {
+	rz_return_val_if_fail(ht, (RzIterator){ 0 });
 	HT_(IterState) *state = Ht_(new_iter_state)(ht);
-	rz_return_val_if_fail(state, NULL);
+	rz_return_val_if_fail(state, (RzIterator){ 0 });
 
-	RzIterator *iter = rz_iterator_new((rz_iterator_next_cb)Ht_(iter_next_key), NULL, (rz_iterator_free_cb)Ht_(free_iter_state), state);
-	if (!iter) {
+	RzIterator iter = rz_iterator_new((rz_iterator_next_cb)Ht_(iter_next_key), NULL, (rz_iterator_free_cb)Ht_(free_iter_state), state);
+	if (!iter.next) {
 		Ht_(free_iter_state)(state);
 	}
 	return iter;
@@ -1143,13 +1143,13 @@ RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ *Ht_(as_iter_keys)(const RZ_NONNULL
  *
  * \return The iterator over the hash table key-value pairs or NULL in case of failure.
  */
-RZ_API RZ_OWN RzIterator /* <const HtName_(Ht)> */ *Ht_(as_iter_kv)(const RZ_NONNULL HtName_(Ht) *ht) {
-	rz_return_val_if_fail(ht, NULL);
+RZ_API RZ_OWN RzIterator /* <const HtName_(Ht)> */ Ht_(as_iter_kv)(const RZ_NONNULL HtName_(Ht) *ht) {
+	rz_return_val_if_fail(ht, (RzIterator){ 0 });
 	HT_(IterState) *state = Ht_(new_iter_state)(ht);
-	rz_return_val_if_fail(state, NULL);
+	rz_return_val_if_fail(state, (RzIterator){ 0 });
 
-	RzIterator *iter = rz_iterator_new((rz_iterator_next_cb)Ht_(iter_next_kv), NULL, (rz_iterator_free_cb)Ht_(free_iter_state), state);
-	if (!iter) {
+	RzIterator iter = rz_iterator_new((rz_iterator_next_cb)Ht_(iter_next_kv), NULL, (rz_iterator_free_cb)Ht_(free_iter_state), state);
+	if (!iter.next) {
 		Ht_(free_iter_state)(state);
 	}
 	return iter;

--- a/librz/util/ht/ht_inc.c
+++ b/librz/util/ht/ht_inc.c
@@ -1092,7 +1092,7 @@ RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ Ht_(as_iter_mut)(RZ_NONNULL HtName_
 	}
 
 	RzIterator iter = rz_iterator_new((rz_iterator_next_cb)Ht_(iter_next_mut), NULL, (rz_iterator_free_cb)Ht_(free_iter_mut_state), state);
-	if (!iter.next) {
+	if (rz_iterator_is_uninit(&iter)) {
 		Ht_(free_iter_mut_state)(state);
 	}
 	return iter;
@@ -1111,7 +1111,7 @@ RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ Ht_(as_iter)(const RZ_NONNULL HtNam
 	rz_return_val_if_fail(state, (RzIterator){ 0 });
 
 	RzIterator iter = rz_iterator_new((rz_iterator_next_cb)Ht_(iter_next), NULL, (rz_iterator_free_cb)Ht_(free_iter_state), state);
-	if (!iter.next) {
+	if (rz_iterator_is_uninit(&iter)) {
 		Ht_(free_iter_state)(state);
 	}
 	return iter;
@@ -1130,7 +1130,7 @@ RZ_API RZ_OWN RzIterator /* <HtName_(Ht)> */ Ht_(as_iter_keys)(const RZ_NONNULL 
 	rz_return_val_if_fail(state, (RzIterator){ 0 });
 
 	RzIterator iter = rz_iterator_new((rz_iterator_next_cb)Ht_(iter_next_key), NULL, (rz_iterator_free_cb)Ht_(free_iter_state), state);
-	if (!iter.next) {
+	if (rz_iterator_is_uninit(&iter)) {
 		Ht_(free_iter_state)(state);
 	}
 	return iter;
@@ -1149,7 +1149,7 @@ RZ_API RZ_OWN RzIterator /* <const HtName_(Ht)> */ Ht_(as_iter_kv)(const RZ_NONN
 	rz_return_val_if_fail(state, (RzIterator){ 0 });
 
 	RzIterator iter = rz_iterator_new((rz_iterator_next_cb)Ht_(iter_next_kv), NULL, (rz_iterator_free_cb)Ht_(free_iter_state), state);
-	if (!iter.next) {
+	if (rz_iterator_is_uninit(&iter)) {
 		Ht_(free_iter_state)(state);
 	}
 	return iter;

--- a/librz/util/iterator.c
+++ b/librz/util/iterator.c
@@ -18,7 +18,7 @@
  *
  * \return RzIterator* A pointer to the newly created `RzIterator` or NULL if the operation failed.
  */
-RZ_API RZ_OWN RzIterator *rz_iterator_new(
+RZ_API RZ_OWN RzIterator rz_iterator_new(
 	RZ_NONNULL rz_iterator_next_cb next,
 	RZ_NULLABLE rz_iterator_free_cb free,
 	RZ_NULLABLE rz_iterator_free_cb free_u,
@@ -27,21 +27,18 @@ RZ_API RZ_OWN RzIterator *rz_iterator_new(
 		rz_warn_if_reached();
 		goto cleanup;
 	}
-	RzIterator *it = RZ_NEW0(RzIterator);
-	if (!it) {
-		goto cleanup;
-	}
+	RzIterator it = (RzIterator){ 0 };
 
-	it->next = next;
-	it->u = u;
-	it->free = free;
-	it->free_u = free_u;
+	it.next = next;
+	it.u = u;
+	it.free = free;
+	it.free_u = free_u;
 	return it;
 cleanup:
 	if (free_u) {
 		free_u(u);
 	}
-	return NULL;
+	return (RzIterator){ 0 };
 }
 
 /**
@@ -64,7 +61,7 @@ RZ_API RZ_BORROW void *rz_iterator_next(RZ_NONNULL RZ_BORROW RzIterator *it) {
 	return it->cur;
 }
 
-RZ_API void rz_iterator_free(RzIterator *it) {
+RZ_API void rz_iterator_fini(RzIterator *it) {
 	if (!it) {
 		return;
 	}
@@ -74,5 +71,9 @@ RZ_API void rz_iterator_free(RzIterator *it) {
 	if (it->free_u) {
 		it->free_u(it->u);
 	}
-	free(it);
+	/**
+	 * NOTE: Removed free(it).
+	 * RzIterator is now stack-allocated as part of the stack-refactor.
+	 * Freeing the handle causes heap corruption (debug assertion).
+	 */
 }

--- a/librz/util/iterator.c
+++ b/librz/util/iterator.c
@@ -71,9 +71,4 @@ RZ_API void rz_iterator_fini(RzIterator *it) {
 	if (it->free_u) {
 		it->free_u(it->u);
 	}
-	/**
-	 * NOTE: Removed free(it).
-	 * RzIterator is now stack-allocated as part of the stack-refactor.
-	 * Freeing the handle causes heap corruption (debug assertion).
-	 */
 }

--- a/librz/util/set.c
+++ b/librz/util/set.c
@@ -75,8 +75,8 @@ RZ_API void rz_set_s_delete(RZ_NONNULL RzSetS *set, const char *str) {
  *
  * \return Iterator yielding immutable elements.
  */
-RZ_API RzIterator /* <RzSetS> */ *rz_set_s_as_iter(const RZ_NONNULL RzSetS *set) {
-	rz_return_val_if_fail(set, NULL);
+RZ_API RzIterator /* <RzSetS> */ rz_set_s_as_iter(const RZ_NONNULL RzSetS *set) {
+	rz_return_val_if_fail(set, (RzIterator){ 0 });
 	return ht_sp_as_iter_keys((const HtSP *)set);
 }
 
@@ -206,7 +206,7 @@ RZ_API ut32 rz_set_u_size(const RZ_NONNULL RzSetU *set) {
  *
  * \return Iterator yielding immutable elements.
  */
-RZ_API RzIterator /* <RzSetU> */ *rz_set_u_as_iter(const RZ_NONNULL RzSetU *set) {
-	rz_return_val_if_fail(set, NULL);
+RZ_API RzIterator /* <RzSetU> */ rz_set_u_as_iter(const RZ_NONNULL RzSetU *set) {
+	rz_return_val_if_fail(set, (RzIterator){ 0 });
 	return ht_up_as_iter_keys((const HtUP *)set);
 }

--- a/test/integration/test_analysis_il.c
+++ b/test/integration/test_analysis_il.c
@@ -107,11 +107,11 @@ static bool test_analysis_il() {
 	rz_io_read_at_mapped(core->io, obj_seckrit, (ut8 *)buf, RZ_ARRAY_SIZE(buf));
 	mu_assert_streq(buf, "Hello from RzIL!", "eval rzil in function");
 
-	RzIterator *iter = rz_core_analysis_op_function_iter(core, f, RZ_ANALYSIS_OP_MASK_IL);
-	mu_assert_notnull(iter, "function rzil");
+	RzIterator iter = rz_core_analysis_op_function_iter(core, f, RZ_ANALYSIS_OP_MASK_IL);
+	mu_assert_notnull(&iter, "function rzil");
 	ut64 count = 0;
 	RzAnalysisOp *pop = NULL;
-	rz_iterator_foreach(iter, pop) {
+	rz_iterator_foreach(&iter, pop) {
 		if (op.addr == 0x804) {
 			rz_strbuf_fini(&sb);
 			rz_il_op_effect_stringify(pop->il_op, &sb, false);
@@ -126,13 +126,13 @@ static bool test_analysis_il() {
 		++count;
 	}
 	mu_assert_eq(count, 69, "il op count of function");
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 
 	// extract and evaluate a chunk of instructions
 	count = 0;
 	iter = rz_core_analysis_op_chunk_iter(core, 0x918, 0, 30, RZ_ANALYSIS_OP_MASK_IL);
-	mu_assert_notnull(iter, "chunk rzil");
-	rz_iterator_foreach(iter, pop) {
+	mu_assert_notnull(&iter, "chunk rzil");
+	rz_iterator_foreach(&iter, pop) {
 		if (op.addr == 0x918) {
 			rz_strbuf_fini(&sb);
 			rz_il_op_effect_stringify(pop->il_op, &sb, false);
@@ -147,7 +147,7 @@ static bool test_analysis_il() {
 		++count;
 	}
 	mu_assert_eq(count, 30, "il op count of function");
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 
 	rz_strbuf_fini(&sb);
 	rz_analysis_op_fini(&op);

--- a/test/unit/test_agraph.c
+++ b/test/unit/test_agraph.c
@@ -27,22 +27,22 @@ bool test_graph_to_agraph() {
 	mu_assert_notnull(agraph, "Couldn't create the agraph");
 	mu_assert_eq(rz_graph_count_nodes(agraph->graph), 4, "Wrong agraph node count");
 
-	RzIterator *iter = rz_graph_get_nodes(agraph->graph);
-	mu_assert_notnull(iter, "get_nodes iterator");
+	RzIterator iter = rz_graph_get_nodes(agraph->graph);
+	mu_assert_notnull(&iter, "get_nodes iterator");
 	RzGraphNode *node;
 	int i = 0;
-	rz_iterator_foreach(iter, node) {
+	rz_iterator_foreach(&iter, node) {
 		const RzANode *info = rz_graph_node_get_data(node);
 		switch (i++) {
 		case 0:
 			mu_assert_streq(info->title, "A", "Wrong node name");
 			mu_assert_eq(rz_graph_out_degree(agraph->graph, node), 2, "Wrong node out-nodes");
 			{
-				RzIterator *out_iter = rz_graph_out_neighbors(agraph->graph, node);
-				mu_assert_notnull(out_iter, "out_neighbors iter A");
+				RzIterator out_iter = rz_graph_out_neighbors(agraph->graph, node);
+				mu_assert_notnull(&out_iter, "out_neighbors iter A");
 				RzGraphNode *out_node;
 				int j = 0;
-				rz_iterator_foreach(out_iter, out_node) {
+				rz_iterator_foreach(&out_iter, out_node) {
 					const RzANode *out_info = rz_graph_node_get_data(out_node);
 					switch (j++) {
 					case 0:
@@ -53,8 +53,7 @@ bool test_graph_to_agraph() {
 						break;
 					}
 				}
-				rz_iterator_fini(out_iter);
-				free(out_iter);
+				rz_iterator_fini(&out_iter);
 			}
 			break;
 		case 1:
@@ -62,11 +61,11 @@ bool test_graph_to_agraph() {
 			mu_assert_eq(rz_graph_out_degree(agraph->graph, node), 1, "Wrong node out-nodes");
 			mu_assert_eq(rz_graph_in_degree(agraph->graph, node), 1, "Wrong node in-nodes");
 			{
-				RzIterator *out_iter = rz_graph_out_neighbors(agraph->graph, node);
-				mu_assert_notnull(out_iter, "out_neighbors iter B");
+				RzIterator out_iter = rz_graph_out_neighbors(agraph->graph, node);
+				mu_assert_notnull(&out_iter, "out_neighbors iter B");
 				RzGraphNode *out_node;
 				int j = 0;
-				rz_iterator_foreach(out_iter, out_node) {
+				rz_iterator_foreach(&out_iter, out_node) {
 					const RzANode *out_info = rz_graph_node_get_data(out_node);
 					switch (j++) {
 					case 0:
@@ -74,8 +73,7 @@ bool test_graph_to_agraph() {
 						break;
 					}
 				}
-				rz_iterator_fini(out_iter);
-				free(out_iter);
+				rz_iterator_fini(&out_iter);
 			}
 			break;
 		case 2:
@@ -83,11 +81,11 @@ bool test_graph_to_agraph() {
 			mu_assert_eq(rz_graph_out_degree(agraph->graph, node), 1, "Wrong node out-nodes");
 			mu_assert_eq(rz_graph_in_degree(agraph->graph, node), 1, "Wrong node in-nodes");
 			{
-				RzIterator *out_iter = rz_graph_out_neighbors(agraph->graph, node);
-				mu_assert_notnull(out_iter, "out_neighbors iter C");
+				RzIterator out_iter = rz_graph_out_neighbors(agraph->graph, node);
+				mu_assert_notnull(&out_iter, "out_neighbors iter C");
 				RzGraphNode *out_node;
 				int j = 0;
-				rz_iterator_foreach(out_iter, out_node) {
+				rz_iterator_foreach(&out_iter, out_node) {
 					const RzANode *out_info = rz_graph_node_get_data(out_node);
 					switch (j++) {
 					case 0:
@@ -95,8 +93,7 @@ bool test_graph_to_agraph() {
 						break;
 					}
 				}
-				rz_iterator_fini(out_iter);
-				free(out_iter);
+				rz_iterator_fini(&out_iter);
 			}
 			break;
 		case 3:
@@ -107,8 +104,7 @@ bool test_graph_to_agraph() {
 			break;
 		}
 	}
-	rz_iterator_fini(iter);
-	free(iter);
+	rz_iterator_fini(&iter);
 
 	rz_core_free(core);
 	rz_graph_free(graph);

--- a/test/unit/test_agraph.c
+++ b/test/unit/test_agraph.c
@@ -53,7 +53,8 @@ bool test_graph_to_agraph() {
 						break;
 					}
 				}
-				rz_iterator_free(out_iter);
+				rz_iterator_fini(out_iter);
+				free(out_iter);
 			}
 			break;
 		case 1:
@@ -73,7 +74,8 @@ bool test_graph_to_agraph() {
 						break;
 					}
 				}
-				rz_iterator_free(out_iter);
+				rz_iterator_fini(out_iter);
+				free(out_iter);
 			}
 			break;
 		case 2:
@@ -93,7 +95,8 @@ bool test_graph_to_agraph() {
 						break;
 					}
 				}
-				rz_iterator_free(out_iter);
+				rz_iterator_fini(out_iter);
+				free(out_iter);
 			}
 			break;
 		case 3:
@@ -104,7 +107,9 @@ bool test_graph_to_agraph() {
 			break;
 		}
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(iter);
+	free(iter);
+
 	rz_core_free(core);
 	rz_graph_free(graph);
 	rz_agraph_free(agraph);

--- a/test/unit/test_analysis_class_graph.c
+++ b/test/unit/test_analysis_class_graph.c
@@ -21,22 +21,22 @@ bool test_inherit_graph_creation() {
 	mu_assert_notnull(graph, "Couldn't create the graph");
 	mu_assert_eq(rz_graph_count_nodes(graph), 4, "Wrong node count");
 
-	RzIterator *iter = rz_graph_get_nodes(graph);
-	mu_assert_notnull(iter, "get_nodes iterator");
+	RzIterator iter = rz_graph_get_nodes(graph);
+	mu_assert_notnull(&iter, "get_nodes iterator");
 	RzGraphNode *node;
 	int i = 0;
-	rz_iterator_foreach(iter, node) {
+	rz_iterator_foreach(&iter, node) {
 		const RzGraphNodeInfo *info = rz_graph_node_get_data(node);
 		switch (i++) {
 		case 0:
 			mu_assert_streq(info->def.title, "A", "Wrong node name");
 			mu_assert_eq(rz_graph_out_degree(graph, node), 2, "Wrong node out-nodes");
 			{
-				RzIterator *out_iter = rz_graph_out_neighbors(graph, node);
-				mu_assert_notnull(out_iter, "out_neighbors iter A");
+				RzIterator out_iter = rz_graph_out_neighbors(graph, node);
+				mu_assert_notnull(&out_iter, "out_neighbors iter A");
 				RzGraphNode *out_node;
 				int j = 0;
-				rz_iterator_foreach(out_iter, out_node) {
+				rz_iterator_foreach(&out_iter, out_node) {
 					const RzGraphNodeInfo *out_info = rz_graph_node_get_data(out_node);
 					switch (j++) {
 					case 0:
@@ -47,8 +47,7 @@ bool test_inherit_graph_creation() {
 						break;
 					}
 				}
-				rz_iterator_fini(out_iter);
-				free(out_iter);
+				rz_iterator_fini(&out_iter);
 			}
 			break;
 		case 1:
@@ -56,11 +55,11 @@ bool test_inherit_graph_creation() {
 			mu_assert_eq(rz_graph_out_degree(graph, node), 1, "Wrong node out-nodes");
 			mu_assert_eq(rz_graph_in_degree(graph, node), 1, "Wrong node in-nodes");
 			{
-				RzIterator *out_iter = rz_graph_out_neighbors(graph, node);
-				mu_assert_notnull(out_iter, "out_neighbors iter B");
+				RzIterator out_iter = rz_graph_out_neighbors(graph, node);
+				mu_assert_notnull(&out_iter, "out_neighbors iter B");
 				RzGraphNode *out_node;
 				int j = 0;
-				rz_iterator_foreach(out_iter, out_node) {
+				rz_iterator_foreach(&out_iter, out_node) {
 					const RzGraphNodeInfo *out_info = rz_graph_node_get_data(out_node);
 					switch (j++) {
 					case 0:
@@ -68,8 +67,7 @@ bool test_inherit_graph_creation() {
 						break;
 					}
 				}
-				rz_iterator_fini(out_iter);
-				free(out_iter);
+				rz_iterator_fini(&out_iter);
 			}
 			break;
 		case 2:
@@ -77,11 +75,11 @@ bool test_inherit_graph_creation() {
 			mu_assert_eq(rz_graph_out_degree(graph, node), 1, "Wrong node out-nodes");
 			mu_assert_eq(rz_graph_in_degree(graph, node), 1, "Wrong node in-nodes");
 			{
-				RzIterator *out_iter = rz_graph_out_neighbors(graph, node);
-				mu_assert_notnull(out_iter, "out_neighbors iter C");
+				RzIterator out_iter = rz_graph_out_neighbors(graph, node);
+				mu_assert_notnull(&out_iter, "out_neighbors iter C");
 				RzGraphNode *out_node;
 				int j = 0;
-				rz_iterator_foreach(out_iter, out_node) {
+				rz_iterator_foreach(&out_iter, out_node) {
 					const RzGraphNodeInfo *out_info = rz_graph_node_get_data(out_node);
 					switch (j++) {
 					case 0:
@@ -89,8 +87,7 @@ bool test_inherit_graph_creation() {
 						break;
 					}
 				}
-				rz_iterator_fini(out_iter);
-				free(out_iter);
+				rz_iterator_fini(&out_iter);
 			}
 			break;
 		case 3:
@@ -101,8 +98,7 @@ bool test_inherit_graph_creation() {
 			break;
 		}
 	}
-	rz_iterator_fini(iter);
-	free(iter);
+	rz_iterator_fini(&iter);
 
 	rz_core_free(core);
 	rz_graph_free(graph);

--- a/test/unit/test_analysis_class_graph.c
+++ b/test/unit/test_analysis_class_graph.c
@@ -47,7 +47,8 @@ bool test_inherit_graph_creation() {
 						break;
 					}
 				}
-				rz_iterator_free(out_iter);
+				rz_iterator_fini(out_iter);
+				free(out_iter);
 			}
 			break;
 		case 1:
@@ -67,7 +68,8 @@ bool test_inherit_graph_creation() {
 						break;
 					}
 				}
-				rz_iterator_free(out_iter);
+				rz_iterator_fini(out_iter);
+				free(out_iter);
 			}
 			break;
 		case 2:
@@ -87,7 +89,8 @@ bool test_inherit_graph_creation() {
 						break;
 					}
 				}
-				rz_iterator_free(out_iter);
+				rz_iterator_fini(out_iter);
+				free(out_iter);
 			}
 			break;
 		case 3:
@@ -98,7 +101,9 @@ bool test_inherit_graph_creation() {
 			break;
 		}
 	}
-	rz_iterator_free(iter);
+	rz_iterator_fini(iter);
+	free(iter);
+
 	rz_core_free(core);
 	rz_graph_free(graph);
 	mu_end;

--- a/test/unit/test_analysis_op.c
+++ b/test/unit/test_analysis_op.c
@@ -111,21 +111,21 @@ bool test_rz_core_analysis_bytes() {
 
 	ut8 buf[128];
 	int len = rz_hex_str2bin("554889e5897dfc", buf);
-	RzIterator *iter = rz_core_analysis_bytes(core, core->offset, buf, len, 0);
-	mu_assert_notnull(iter, "rz_core_analysis_bytes");
+	RzIterator iter = rz_core_analysis_bytes(core, core->offset, buf, len, 0);
+	mu_assert_notnull(&iter, "rz_core_analysis_bytes");
 
-	RzCoreDecodedBytes *ab = rz_iterator_next(iter);
+	RzCoreDecodedBytes *ab = rz_iterator_next(&iter);
 	mu_assert_streq(ab->opcode, "push rbp", "rz_core_analysis_bytes opcode");
 
-	ab = rz_iterator_next(iter);
+	ab = rz_iterator_next(&iter);
 	mu_assert_streq(ab->opcode, "mov rbp, rsp", "rz_core_analysis_bytes opcode");
 	mu_assert_streq(ab->pseudo, "rbp = rsp", "rz_core_analysis_bytes pseudo");
 
-	ab = rz_iterator_next(iter);
+	ab = rz_iterator_next(&iter);
 	mu_assert_streq(ab->opcode, "mov dword [rbp-0x04], edi", "rz_core_analysis_bytes opcode");
 	mu_assert_streq(ab->pseudo, "dword [rbp-0x04] = edi", "rz_core_analysis_bytes pseudo");
 
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	rz_core_free(core);
 	mu_end;
 }

--- a/test/unit/test_config.c
+++ b/test/unit/test_config.c
@@ -393,12 +393,12 @@ static bool any_get(void *user, void *p) {
 	case RZ_CONFIG_VAR_TYPE_SET: {
 		RzSetS **value = p;
 		RzSetS *dup = rz_set_s_new(HT_STR_DUP);
-		RzIterator *iter = rz_set_s_as_iter(bt->set_val_set);
+		RzIterator iter = rz_set_s_as_iter(bt->set_val_set);
 		const char **elem;
-		rz_iterator_foreach(iter, elem) {
+		rz_iterator_foreach(&iter, elem) {
 			rz_set_s_add(dup, *elem);
 		}
-		rz_iterator_free(iter);
+		rz_iterator_fini(&iter);
 		*value = dup;
 		bt->get++;
 		return true;

--- a/test/unit/test_graph.c
+++ b/test/unit/test_graph.c
@@ -34,17 +34,16 @@ static bool test_legacy_graph(void) {
 
 	// Check out-neighbors of gn: should contain gn2
 	{
-		RzIterator *it = rz_graph_out_neighbors(g, gn);
-		mu_assert_notnull(it, "get_neighbours.1.iter");
+		RzIterator it = rz_graph_out_neighbors(g, gn);
+		mu_assert_notnull(&it, "get_neighbours.1.iter");
 		int count = 0;
 		RzGraphNode *nb;
-		rz_iterator_foreach(it, nb) {
+		rz_iterator_foreach(&it, nb) {
 			mu_assert_ptreq(nb, gn2, "get_neighbours.1");
 			count++;
 		}
 		mu_assert_eq(count, 1, "get_neighbours.1.count");
-		rz_iterator_fini(it);
-		free(it);
+		rz_iterator_fini(&it);
 	}
 
 	RzGraphNode *gn3 = NULL;
@@ -53,17 +52,16 @@ static bool test_legacy_graph(void) {
 
 	// Check out-neighbors of gn: gn2 and gn3
 	{
-		RzIterator *it = rz_graph_out_neighbors(g, gn);
-		mu_assert_notnull(it, "get_neighbours.2.iter");
+		RzIterator it = rz_graph_out_neighbors(g, gn);
+		mu_assert_notnull(&it, "get_neighbours.2.iter");
 		int count = 0;
 		RzGraphNode *nb;
-		rz_iterator_foreach(it, nb) {
+		rz_iterator_foreach(&it, nb) {
 			mu_assert_true(nb == gn2 || nb == gn3, "get_neighbours.2");
 			count++;
 		}
 		mu_assert_eq(count, 2, "get_neighbours.2.count");
-		rz_iterator_fini(it);
-		free(it);
+		rz_iterator_fini(&it);
 	}
 
 	RzGraphNode *gn4 = NULL;
@@ -84,16 +82,15 @@ static bool test_legacy_graph(void) {
 
 	// Check all nodes are present
 	{
-		RzIterator *it = rz_graph_get_nodes(g);
-		mu_assert_notnull(it, "get_all_nodes.iter");
+		RzIterator it = rz_graph_get_nodes(g);
+		mu_assert_notnull(&it, "get_all_nodes.iter");
 		int count = 0;
 		RzGraphNode *nd;
-		rz_iterator_foreach(it, nd) {
+		rz_iterator_foreach(&it, nd) {
 			count++;
 		}
 		mu_assert_eq(count, 10, "get_all_nodes.count");
-		rz_iterator_fini(it);
-		free(it);
+		rz_iterator_fini(&it);
 	}
 
 	rz_graph_add_edge(g, gn2, gn3, NULL);
@@ -133,37 +130,34 @@ static bool test_legacy_graph(void) {
 
 	// Check in-neighbors of gn3: gn and gn2
 	{
-		RzIterator *it = rz_graph_in_neighbors(g, gn3);
-		mu_assert_notnull(it, "in_nodes.iter");
+		RzIterator it = rz_graph_in_neighbors(g, gn3);
+		mu_assert_notnull(&it, "in_nodes.iter");
 		int count = 0;
 		RzGraphNode *nb;
-		rz_iterator_foreach(it, nb) {
+		rz_iterator_foreach(&it, nb) {
 			mu_assert_true(nb == gn || nb == gn2, "in_nodes");
 			count++;
 		}
 		mu_assert_eq(count, 2, "in_nodes.count");
-		rz_iterator_fini(it);
-		free(it);
+		rz_iterator_fini(&it);
 	}
 
 	// All neighbors of gn3: in={gn, gn2} + out={gn5}
 	{
 		int count = 0;
 		RzGraphNode *nb;
-		RzIterator *it = rz_graph_in_neighbors(g, gn3);
-		rz_iterator_foreach(it, nb) {
+		RzIterator it = rz_graph_in_neighbors(g, gn3);
+		rz_iterator_foreach(&it, nb) {
 			mu_assert_true(nb == gn || nb == gn2, "all_neighbours.in");
 			count++;
 		}
-		rz_iterator_fini(it);
-		free(it);
+		rz_iterator_fini(&it);
 		it = rz_graph_out_neighbors(g, gn3);
-		rz_iterator_foreach(it, nb) {
+		rz_iterator_foreach(&it, nb) {
 			mu_assert_ptreq(nb, gn5, "all_neighbours.out");
 			count++;
 		}
-		rz_iterator_fini(it);
-		free(it);
+		rz_iterator_fini(&it);
 		mu_assert_eq(count, 3, "all_neighbours.count");
 	}
 

--- a/test/unit/test_graph.c
+++ b/test/unit/test_graph.c
@@ -43,7 +43,8 @@ static bool test_legacy_graph(void) {
 			count++;
 		}
 		mu_assert_eq(count, 1, "get_neighbours.1.count");
-		rz_iterator_free(it);
+		rz_iterator_fini(it);
+		free(it);
 	}
 
 	RzGraphNode *gn3 = NULL;
@@ -61,7 +62,8 @@ static bool test_legacy_graph(void) {
 			count++;
 		}
 		mu_assert_eq(count, 2, "get_neighbours.2.count");
-		rz_iterator_free(it);
+		rz_iterator_fini(it);
+		free(it);
 	}
 
 	RzGraphNode *gn4 = NULL;
@@ -90,7 +92,8 @@ static bool test_legacy_graph(void) {
 			count++;
 		}
 		mu_assert_eq(count, 10, "get_all_nodes.count");
-		rz_iterator_free(it);
+		rz_iterator_fini(it);
+		free(it);
 	}
 
 	rz_graph_add_edge(g, gn2, gn3, NULL);
@@ -139,7 +142,8 @@ static bool test_legacy_graph(void) {
 			count++;
 		}
 		mu_assert_eq(count, 2, "in_nodes.count");
-		rz_iterator_free(it);
+		rz_iterator_fini(it);
+		free(it);
 	}
 
 	// All neighbors of gn3: in={gn, gn2} + out={gn5}
@@ -151,13 +155,15 @@ static bool test_legacy_graph(void) {
 			mu_assert_true(nb == gn || nb == gn2, "all_neighbours.in");
 			count++;
 		}
-		rz_iterator_free(it);
+		rz_iterator_fini(it);
+		free(it);
 		it = rz_graph_out_neighbors(g, gn3);
 		rz_iterator_foreach(it, nb) {
 			mu_assert_ptreq(nb, gn5, "all_neighbours.out");
 			count++;
 		}
-		rz_iterator_free(it);
+		rz_iterator_fini(it);
+		free(it);
 		mu_assert_eq(count, 3, "all_neighbours.count");
 	}
 

--- a/test/unit/test_graph_new.c
+++ b/test/unit/test_graph_new.c
@@ -285,7 +285,8 @@ static bool test_graph_in_out_edges(void) {
 		count++;
 	}
 	mu_assert_eq(count, 3, "out_edges.count");
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 
 	// in edges
 	rz_graph_add_edge(g, n2, n4, NULL);
@@ -300,7 +301,8 @@ static bool test_graph_in_out_edges(void) {
 		count++;
 	}
 	mu_assert_eq(count, 3, "in_edges.count");
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 
 	// clean
 	rz_graph_free(g);
@@ -333,7 +335,8 @@ static bool test_graph_in_out_neighbors(void) {
 	}
 	mu_assert_eq(count, 2, "out_neighbors.count");
 
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 
 	// Get in neighbours
 	rz_graph_add_edge(g, n2, n3, NULL);
@@ -347,7 +350,8 @@ static bool test_graph_in_out_neighbors(void) {
 		count++;
 	}
 	mu_assert_eq(count, 2, "in_neighbors.count");
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 
 	rz_graph_free(g);
 	mu_end;
@@ -510,7 +514,9 @@ static bool test_graph_get_nodes(void) {
 	}
 	mu_assert_eq(count, 3, "nodes.count");
 
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
+
 	rz_graph_free(g);
 	mu_end;
 }
@@ -838,7 +844,8 @@ static bool test_graph_in_out_edges_matrix(void) {
 		count++;
 	}
 	mu_assert_eq(count, 3, "out_edges.count");
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 
 	// in edges
 	rz_graph_add_edge(g, n2, n4, NULL);
@@ -853,7 +860,8 @@ static bool test_graph_in_out_edges_matrix(void) {
 		count++;
 	}
 	mu_assert_eq(count, 3, "in_edges.count");
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 
 	// clean
 	rz_graph_free(g);
@@ -886,7 +894,8 @@ static bool test_graph_in_out_neighbors_matrix(void) {
 	}
 	mu_assert_eq(count, 2, "out_neighbors.count");
 
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 
 	// Get in neighbours
 	rz_graph_add_edge(g, n2, n3, NULL);
@@ -899,7 +908,8 @@ static bool test_graph_in_out_neighbors_matrix(void) {
 		count++;
 	}
 	mu_assert_eq(count, 2, "in_neighbors.count");
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 
 	rz_graph_free(g);
 	mu_end;
@@ -1054,7 +1064,9 @@ static bool test_graph_get_nodes_matrix(void) {
 	}
 	mu_assert_eq(count, 3, "nodes.count");
 
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
+
 	rz_graph_free(g);
 	mu_end;
 }
@@ -1314,8 +1326,10 @@ static bool test_graph_impl_equivalence(void) {
 
 	mu_assert_eq(l_count, m_count, "same out-neighbor count");
 
-	rz_iterator_free(l_it);
-	rz_iterator_free(m_it);
+	rz_iterator_fini(l_it);
+	free(l_it);
+	rz_iterator_fini(m_it);
+	free(m_it);
 
 	rz_graph_free(g_list);
 	rz_graph_free(g_matrix);

--- a/test/unit/test_graph_new.c
+++ b/test/unit/test_graph_new.c
@@ -274,35 +274,33 @@ static bool test_graph_in_out_edges(void) {
 	rz_graph_add_edge(g, n1, n4, NULL);
 
 	// out edges
-	RzIterator *it = rz_graph_out_edges(g, n1);
-	mu_assert_notnull(it, "out_edges_iterator");
+	RzIterator it = rz_graph_out_edges(g, n1);
+	mu_assert_notnull(&it, "out_edges_iterator");
 
 	int count = 0;
 	RzGraphEdge *edge;
-	rz_iterator_foreach(it, edge) {
+	rz_iterator_foreach(&it, edge) {
 		mu_assert_ptreq(rz_graph_edge_get_from(edge), n1, "out_edge.from");
 		mu_assert_true(rz_graph_edge_get_to(edge) == n2 || rz_graph_edge_get_to(edge) == n3 || rz_graph_edge_get_to(edge) == n4, "out_edge.to");
 		count++;
 	}
 	mu_assert_eq(count, 3, "out_edges.count");
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 
 	// in edges
 	rz_graph_add_edge(g, n2, n4, NULL);
 	rz_graph_add_edge(g, n3, n4, NULL);
 	it = rz_graph_in_edges(g, n4);
-	mu_assert_notnull(it, "in_edges_iterator");
+	mu_assert_notnull(&it, "in_edges_iterator");
 
 	count = 0;
-	rz_iterator_foreach(it, edge) {
+	rz_iterator_foreach(&it, edge) {
 		mu_assert_ptreq(rz_graph_edge_get_to(edge), n4, "in_edge.to");
 		mu_assert_true(rz_graph_edge_get_from(edge) == n1 || rz_graph_edge_get_from(edge) == n2 || rz_graph_edge_get_from(edge) == n3, "in_edge.from");
 		count++;
 	}
 	mu_assert_eq(count, 3, "in_edges.count");
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 
 	// clean
 	rz_graph_free(g);
@@ -324,34 +322,32 @@ static bool test_graph_in_out_neighbors(void) {
 	rz_graph_add_edge(g, n1, n3, NULL);
 
 	// n1 out neighbours
-	RzIterator *it = rz_graph_out_neighbors(g, n1);
-	mu_assert_notnull(it, "out_neighbors_iterator");
+	RzIterator it = rz_graph_out_neighbors(g, n1);
+	mu_assert_notnull(&it, "out_neighbors_iterator");
 
 	int count = 0;
 	RzGraphNode *neighbor;
-	rz_iterator_foreach(it, neighbor) {
+	rz_iterator_foreach(&it, neighbor) {
 		mu_assert_true(neighbor == n2 || neighbor == n3, "out_neighbor");
 		count++;
 	}
 	mu_assert_eq(count, 2, "out_neighbors.count");
 
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 
 	// Get in neighbours
 	rz_graph_add_edge(g, n2, n3, NULL);
 
 	it = rz_graph_in_neighbors(g, n3);
-	mu_assert_notnull(it, "in_neighbors_iterator");
+	mu_assert_notnull(&it, "in_neighbors_iterator");
 
 	count = 0;
-	rz_iterator_foreach(it, neighbor) {
+	rz_iterator_foreach(&it, neighbor) {
 		mu_assert_true(neighbor == n1 || neighbor == n2, "in_neighbor");
 		count++;
 	}
 	mu_assert_eq(count, 2, "in_neighbors.count");
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 
 	rz_graph_free(g);
 	mu_end;
@@ -503,19 +499,18 @@ static bool test_graph_get_nodes(void) {
 	RzGraphNode *n3 = NULL;
 	mu_assert_eq(rz_graph_add_node(g, RZ_GRAPH_INT_AS_DATA(3), &n3), RZ_GRAPH_STATUS_OK, "Failed to add");
 
-	RzIterator *it = rz_graph_get_nodes(g);
-	mu_assert_notnull(it, "get_nodes_iterator");
+	RzIterator it = rz_graph_get_nodes(g);
+	mu_assert_notnull(&it, "get_nodes_iterator");
 
 	int count = 0;
 	RzGraphNode *node;
-	rz_iterator_foreach(it, node) {
+	rz_iterator_foreach(&it, node) {
 		mu_assert_true(node == n1 || node == n2 || node == n3, "node_in_graph");
 		count += 1;
 	}
 	mu_assert_eq(count, 3, "nodes.count");
 
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 
 	rz_graph_free(g);
 	mu_end;
@@ -833,35 +828,33 @@ static bool test_graph_in_out_edges_matrix(void) {
 	rz_graph_add_edge(g, n1, n4, NULL);
 
 	// out edges
-	RzIterator *it = rz_graph_out_edges(g, n1);
-	mu_assert_notnull(it, "out_edges_iterator");
+	RzIterator it = rz_graph_out_edges(g, n1);
+	mu_assert_notnull(&it, "out_edges_iterator");
 
 	int count = 0;
 	RzGraphEdge *edge;
-	rz_iterator_foreach(it, edge) {
+	rz_iterator_foreach(&it, edge) {
 		mu_assert_ptreq(rz_graph_edge_get_from(edge), n1, "out_edge.from");
 		mu_assert_true(rz_graph_edge_get_to(edge) == n2 || rz_graph_edge_get_to(edge) == n3 || rz_graph_edge_get_to(edge) == n4, "out_edge.to");
 		count++;
 	}
 	mu_assert_eq(count, 3, "out_edges.count");
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 
 	// in edges
 	rz_graph_add_edge(g, n2, n4, NULL);
 	rz_graph_add_edge(g, n3, n4, NULL);
 	it = rz_graph_in_edges(g, n4);
-	mu_assert_notnull(it, "in_edges_iterator");
+	mu_assert_notnull(&it, "in_edges_iterator");
 
 	count = 0;
-	rz_iterator_foreach(it, edge) {
+	rz_iterator_foreach(&it, edge) {
 		mu_assert_ptreq(rz_graph_edge_get_to(edge), n4, "in_edge.to");
 		mu_assert_true(rz_graph_edge_get_from(edge) == n1 || rz_graph_edge_get_from(edge) == n2 || rz_graph_edge_get_from(edge) == n3, "in_edge.from");
 		count++;
 	}
 	mu_assert_eq(count, 3, "in_edges.count");
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 
 	// clean
 	rz_graph_free(g);
@@ -883,33 +876,31 @@ static bool test_graph_in_out_neighbors_matrix(void) {
 	rz_graph_add_edge(g, n1, n3, NULL);
 
 	// n1 out neighbours
-	RzIterator *it = rz_graph_out_neighbors(g, n1);
-	mu_assert_notnull(it, "out_neighbors_iterator");
+	RzIterator it = rz_graph_out_neighbors(g, n1);
+	mu_assert_notnull(&it, "out_neighbors_iterator");
 
 	int count = 0;
 	RzGraphNode *neighbor;
-	rz_iterator_foreach(it, neighbor) {
+	rz_iterator_foreach(&it, neighbor) {
 		mu_assert_true(neighbor == n2 || neighbor == n3, "out_neighbor");
 		count++;
 	}
 	mu_assert_eq(count, 2, "out_neighbors.count");
 
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 
 	// Get in neighbours
 	rz_graph_add_edge(g, n2, n3, NULL);
 	it = rz_graph_in_neighbors(g, n3);
-	mu_assert_notnull(it, "in_neighbors_iterator");
+	mu_assert_notnull(&it, "in_neighbors_iterator");
 
 	count = 0;
-	rz_iterator_foreach(it, neighbor) {
+	rz_iterator_foreach(&it, neighbor) {
 		mu_assert_true(neighbor == n1 || neighbor == n2, "in_neighbor");
 		count++;
 	}
 	mu_assert_eq(count, 2, "in_neighbors.count");
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 
 	rz_graph_free(g);
 	mu_end;
@@ -1053,19 +1044,18 @@ static bool test_graph_get_nodes_matrix(void) {
 	RzGraphNode *n3 = NULL;
 	mu_assert_eq(rz_graph_add_node(g, RZ_GRAPH_INT_AS_DATA(3), &n3), RZ_GRAPH_STATUS_OK, "Failed to add");
 
-	RzIterator *it = rz_graph_get_nodes(g);
-	mu_assert_notnull(it, "get_nodes_iterator");
+	RzIterator it = rz_graph_get_nodes(g);
+	mu_assert_notnull(&it, "get_nodes_iterator");
 
 	int count = 0;
 	RzGraphNode *node;
-	rz_iterator_foreach(it, node) {
+	rz_iterator_foreach(&it, node) {
 		mu_assert_true(node == n1 || node == n2 || node == n3, "node_in_graph");
 		count += 1;
 	}
 	mu_assert_eq(count, 3, "nodes.count");
 
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 
 	rz_graph_free(g);
 	mu_end;
@@ -1312,24 +1302,22 @@ static bool test_graph_impl_equivalence(void) {
 		"same has_edge result for 1->0 (false)");
 
 	// Test out-neighbor count is same
-	RzIterator *l_it = rz_graph_out_neighbors(g_list, l_nodes[0]);
-	RzIterator *m_it = rz_graph_out_neighbors(g_matrix, m_nodes[0]);
+	RzIterator l_it = rz_graph_out_neighbors(g_list, l_nodes[0]);
+	RzIterator m_it = rz_graph_out_neighbors(g_matrix, m_nodes[0]);
 
 	int l_count = 0, m_count = 0;
 	RzGraphNode *node;
-	rz_iterator_foreach(l_it, node) {
+	rz_iterator_foreach(&l_it, node) {
 		l_count++;
 	}
-	rz_iterator_foreach(m_it, node) {
+	rz_iterator_foreach(&m_it, node) {
 		m_count++;
 	}
 
 	mu_assert_eq(l_count, m_count, "same out-neighbor count");
 
-	rz_iterator_fini(l_it);
-	free(l_it);
-	rz_iterator_fini(m_it);
-	free(m_it);
+	rz_iterator_fini(&l_it);
+	rz_iterator_fini(&m_it);
 
 	rz_graph_free(g_list);
 	rz_graph_free(g_matrix);

--- a/test/unit/test_graph_new_cfg.c
+++ b/test/unit/test_graph_new_cfg.c
@@ -301,7 +301,8 @@ static bool test_cfg_foo_function(void) {
 	rz_iterator_foreach(it, neighbor) {
 		count++;
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 	mu_assert_eq(count, 2, "bb_check_n out-neighbors");
 
 	// verify in-neighbors of bb_check_sum (should have 2: bb_even and bb_odd)
@@ -310,7 +311,8 @@ static bool test_cfg_foo_function(void) {
 	rz_iterator_foreach(it, neighbor) {
 		count++;
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 	mu_assert_eq(count, 2, "bb_check_sum in-neighbors");
 
 	// verify in-neighbors of bb_loop_cond (should have 2: bb_loop_init and bb_loop_inc)
@@ -319,7 +321,8 @@ static bool test_cfg_foo_function(void) {
 	rz_iterator_foreach(it, neighbor) {
 		count++;
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(it);
+	free(it);
 	mu_assert_eq(count, 2, "bb_loop_cond in-neighbors (includes back edge)");
 
 	rz_graph_free(cfg);

--- a/test/unit/test_graph_new_cfg.c
+++ b/test/unit/test_graph_new_cfg.c
@@ -295,34 +295,31 @@ static bool test_cfg_foo_function(void) {
 	mu_assert_eq(rz_graph_has_edge(cfg, n_check_sum, n_ret_sum), RZ_GRAPH_STATUS_OK, "edge: check_sum->ret_sum (break)");
 
 	// verify out-neighbors of bb_check_n (should have 2)
-	RzIterator *it = rz_graph_out_neighbors(cfg, n_check_n);
+	RzIterator it = rz_graph_out_neighbors(cfg, n_check_n);
 	int count = 0;
 	RzGraphNode *neighbor;
-	rz_iterator_foreach(it, neighbor) {
+	rz_iterator_foreach(&it, neighbor) {
 		count++;
 	}
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 	mu_assert_eq(count, 2, "bb_check_n out-neighbors");
 
 	// verify in-neighbors of bb_check_sum (should have 2: bb_even and bb_odd)
 	it = rz_graph_in_neighbors(cfg, n_check_sum);
 	count = 0;
-	rz_iterator_foreach(it, neighbor) {
+	rz_iterator_foreach(&it, neighbor) {
 		count++;
 	}
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 	mu_assert_eq(count, 2, "bb_check_sum in-neighbors");
 
 	// verify in-neighbors of bb_loop_cond (should have 2: bb_loop_init and bb_loop_inc)
 	it = rz_graph_in_neighbors(cfg, n_loop_cond);
 	count = 0;
-	rz_iterator_foreach(it, neighbor) {
+	rz_iterator_foreach(&it, neighbor) {
 		count++;
 	}
-	rz_iterator_fini(it);
-	free(it);
+	rz_iterator_fini(&it);
 	mu_assert_eq(count, 2, "bb_loop_cond in-neighbors (includes back edge)");
 
 	rz_graph_free(cfg);

--- a/test/unit/test_ht.c
+++ b/test/unit/test_ht.c
@@ -721,11 +721,11 @@ bool test_ht_uu_iter(void) {
 	ut32 icnt = 0;
 	const ut64 *im_elem;
 
-	RzIterator *it = ht_uu_as_iter(ht);
-	rz_iterator_foreach(it, im_elem) {
+	RzIterator it = ht_uu_as_iter(ht);
+	rz_iterator_foreach(&it, im_elem) {
 		icnt++;
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	mu_assert_eq(icnt, 0, "Wrong number of iterations");
 	ht_uu_insert(ht, 0x1010101, 0x1010101);
 	ht_uu_insert(ht, 0x2020202, 0x2020202);
@@ -734,7 +734,7 @@ bool test_ht_uu_iter(void) {
 	ht_uu_insert(ht, 0x5050505, 0x5050505);
 	icnt = 0;
 	it = ht_uu_as_iter(ht);
-	rz_iterator_foreach(it, im_elem) {
+	rz_iterator_foreach(&it, im_elem) {
 		icnt++;
 		mu_assert_true(
 			*im_elem == 0x1010101 ||
@@ -744,19 +744,19 @@ bool test_ht_uu_iter(void) {
 				*im_elem == 0x5050505,
 			"Value mismtach");
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	mu_assert_eq(icnt, 5, "Wrong number of iterations");
 	icnt = 0;
 	// Test write of value
 	ut64 *m_elem;
 	it = ht_uu_as_iter_mut(ht);
-	rz_iterator_foreach(it, m_elem) {
+	rz_iterator_foreach(&it, m_elem) {
 		icnt++;
 		if (*m_elem == 0x1010101) {
 			*m_elem = 0x0;
 		}
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	mu_assert_eq(icnt, 5, "Wrong number of iterations");
 	bool found = false;
 	ut64 v = ht_uu_find(ht, 0x1010101, &found);
@@ -771,11 +771,11 @@ bool test_ht_uu_iter_kv(void) {
 	ut32 icnt = 0;
 	const HtUUKv *kv;
 
-	RzIterator *it = ht_uu_as_iter_kv(ht);
-	rz_iterator_foreach(it, kv) {
+	RzIterator it = ht_uu_as_iter_kv(ht);
+	rz_iterator_foreach(&it, kv) {
 		icnt++;
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	mu_assert_eq(icnt, 0, "Wrong number of iterations");
 
 	ht_uu_insert(ht, 0x11, 0x1111);
@@ -788,7 +788,7 @@ bool test_ht_uu_iter_kv(void) {
 
 	icnt = 0;
 	it = ht_uu_as_iter_kv(ht);
-	rz_iterator_foreach(it, kv) {
+	rz_iterator_foreach(&it, kv) {
 		icnt++;
 		if (kv->key == 0x11 && kv->value == 0x1111) {
 			found_1 = true;
@@ -800,7 +800,7 @@ bool test_ht_uu_iter_kv(void) {
 			found_3 = true;
 		}
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 
 	mu_assert_eq(icnt, 3, "Wrong number of iterations");
 	mu_assert_true(found_1, "key not found");
@@ -816,11 +816,11 @@ bool test_ht_ss_iter(void) {
 	ut32 icnt = 0;
 	const char **im_elem;
 
-	RzIterator *it = ht_ss_as_iter(ht);
-	rz_iterator_foreach(it, im_elem) {
+	RzIterator it = ht_ss_as_iter(ht);
+	rz_iterator_foreach(&it, im_elem) {
 		icnt++;
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	mu_assert_eq(icnt, 0, "Wrong number of iterations");
 
 	ht_ss_insert(ht, "0x1010101", "0x1010101");
@@ -830,7 +830,7 @@ bool test_ht_ss_iter(void) {
 	ht_ss_insert(ht, "0x5050505", "0x5050505");
 	icnt = 0;
 	it = ht_ss_as_iter(ht);
-	rz_iterator_foreach(it, im_elem) {
+	rz_iterator_foreach(&it, im_elem) {
 		icnt++;
 		mu_assert_true(
 			RZ_STR_EQ(*im_elem, "0x1010101") ||
@@ -840,19 +840,19 @@ bool test_ht_ss_iter(void) {
 				RZ_STR_EQ(*im_elem, "0x5050505"),
 			"Value mismtach");
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	mu_assert_eq(icnt, 5, "Wrong number of iterations");
 	icnt = 0;
 	// Test write of value
 	char **m_elem;
 	it = ht_ss_as_iter_mut(ht);
-	rz_iterator_foreach(it, m_elem) {
+	rz_iterator_foreach(&it, m_elem) {
 		icnt++;
 		if (RZ_STR_EQ(*m_elem, "0x1010101")) {
 			*m_elem = "0x0";
 		}
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	mu_assert_eq(icnt, 5, "Wrong number of iterations");
 	bool found = false;
 	const char *v = ht_ss_find(ht, "0x1010101", &found);
@@ -884,13 +884,13 @@ bool test_set_u(void) {
 
 	size_t x = 0;
 	const ut64 *im_elem;
-	RzIterator *it = rz_set_u_as_iter(set_u);
-	rz_iterator_foreach(it, im_elem) {
+	RzIterator it = rz_set_u_as_iter(set_u);
+	rz_iterator_foreach(&it, im_elem) {
 		x++;
 		bool matches = *im_elem == 0x5050505 || *im_elem == 0x6060606;
 		mu_assert_true(matches, "Set contained ill-formed value.");
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	mu_assert_eq(x, 2, "Foreach hasn't iterated the correct number of times.");
 
 	rz_set_u_delete(set_u, 0x6060606);
@@ -899,10 +899,10 @@ bool test_set_u(void) {
 	mu_assert_eq(rz_set_u_size(set_u), 0, "Length wrong.");
 
 	it = rz_set_u_as_iter(set_u);
-	rz_iterator_foreach(it, im_elem) {
+	rz_iterator_foreach(&it, im_elem) {
 		mu_assert("Should not be reached.", false);
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	rz_set_u_add(set_u, 0x53e0);
 	rz_set_u_add(set_u, 0x53bc);
 
@@ -915,10 +915,10 @@ bool test_set_u(void) {
 
 	x = 0;
 	it = rz_set_u_as_iter(set_u);
-	rz_iterator_foreach(it, im_elem) {
+	rz_iterator_foreach(&it, im_elem) {
 		x++;
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	mu_assert_eq(x, 2, "Foreach hasn't iterated the correct number of times.");
 	rz_set_u_delete(set_u, 0x53e0);
 	rz_set_u_delete(set_u, 0x53bc);
@@ -936,10 +936,10 @@ bool test_set_u(void) {
 
 	x = 0;
 	it = rz_set_u_as_iter(set_u);
-	rz_iterator_foreach(it, im_elem) {
+	rz_iterator_foreach(&it, im_elem) {
 		x++;
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	mu_assert_eq(x, 5, "Foreach hasn't iterated the correct number of times.");
 
 	rz_set_u_clear(set_u);
@@ -976,13 +976,13 @@ bool test_set_s(void) {
 	size_t x = 0;
 	const char **im_elem;
 
-	RzIterator *it = rz_set_s_as_iter(set_s);
-	rz_iterator_foreach(it, im_elem) {
+	RzIterator it = rz_set_s_as_iter(set_s);
+	rz_iterator_foreach(&it, im_elem) {
 		x++;
 		bool matches = RZ_STR_EQ(*im_elem, "0x5050505") || RZ_STR_EQ(*im_elem, "0x6060606");
 		mu_assert_true(matches, "Set contained ill-formed value.");
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	mu_assert_eq(x, 2, "Foreach hasn't iterated the correct number of times.");
 
 	rz_set_s_delete(set_s, "0x6060606");
@@ -991,18 +991,18 @@ bool test_set_s(void) {
 	mu_assert_eq(rz_set_s_size(set_s), 0, "Length wrong.");
 
 	it = rz_set_s_as_iter(set_s);
-	rz_iterator_foreach(it, im_elem) {
+	rz_iterator_foreach(&it, im_elem) {
 		mu_assert("Should not be reached.", false);
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	rz_set_s_add(set_s, "0x53e0");
 	rz_set_s_add(set_s, "0x53bc");
 	x = 0;
 	it = rz_set_s_as_iter(set_s);
-	rz_iterator_foreach(it, im_elem) {
+	rz_iterator_foreach(&it, im_elem) {
 		x++;
 	}
-	rz_iterator_free(it);
+	rz_iterator_fini(&it);
 	mu_assert_eq(x, 2, "Foreach hasn't iterated the correct number of times.");
 	rz_set_s_delete(set_s, "0x53e0");
 	rz_set_s_delete(set_s, "0x53bc");

--- a/test/unit/test_list.c
+++ b/test/unit/test_list.c
@@ -227,8 +227,8 @@ bool test_rz_list_from_iter(void) {
 	for (size_t i = 0; i < 26; i++) {
 		ht_up_insert(alpha_ht, i, (void *)unordered_alphabeth[i]);
 	}
-	RzIterator *iter = ht_up_as_iter(alpha_ht);
-	RzList *list = rz_list_new_from_iterator(iter);
+	RzIterator iter = ht_up_as_iter(alpha_ht);
+	RzList *list = rz_list_new_from_iterator(&iter);
 	mu_assert_notnull(list, "List init failed.");
 	rz_list_sort(list, (RzListComparator)strcmp, NULL);
 	mu_assert_eq(rz_list_length(list), 26, "Number of elements are off");
@@ -239,7 +239,7 @@ bool test_rz_list_from_iter(void) {
 		mu_assert_streq(elem, lower[i], "Value mismatched.");
 	}
 	ht_up_free(alpha_ht);
-	rz_iterator_free(iter);
+	rz_iterator_fini(&iter);
 	rz_list_free(list);
 	mu_end;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

RzIterator was previously heap-allocated, even though the struct is small and doesn't need to outlive the function that consumes
it in these cases. This PR changes those functions to build the struct on the stack and return it by value, removing the allocation and the corresponding rz_iterator_free() call at every call site.

**Test plan**

Ran the full test suite before and after this change and diffed the
pass/fail results:

    meson test -C build > results_baseline.txt      (on unmodified dev)
    meson test -C build > results_with_changes.txt  (with this PR's changes)

Both runs show the same 17 pre-existing failures (unrelated to this
change, mostly Windows-specific test environment gaps like dwarf/pdb
symbol tests). No new failures introduced.

Also manually smoke-tested by running analysis on rizin's own binary
to exercise the iterator-heavy code paths:

    rizin -A -q -c "afl" rizin.exe

**Closing issues**

closes #6425 