### PR TITLE
Fix A32 branch assembly at high addresses

### DIFF
--- a/librz/arch/isa/arm/armass.c
+++ b/librz/arch/isa/arm/armass.c
@@ -5805,14 +5805,15 @@ static int arm_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				case TYPE_BRA:
 					if (getreg(ao->a[0]) == -1) {
 						// TODO: control if branch out of range
-						ret = (getnum(ao->a[0], &err) - (int)ao->off - 8) / 4;
-						if (ret >= 0x00800000 || ret < (int)0xff800000) {
+						st32 branch_offset = (st32)((ut32)getnum(ao->a[0], &err) - (ut32)ao->off - 8) / 4;
+						if (branch_offset >= 0x00800000 || branch_offset < -0x00800000) {
 							RZ_LOG_ERROR("assembler: arm: %s: invalid branch address (out of range).\n", ops[i].name);
 							return 0;
 						}
-						ao->o |= ((ret >> 16) & 0xff) << 8;
-						ao->o |= ((ret >> 8) & 0xff) << 16;
-						ao->o |= ((ret) & 0xff) << 24;
+						ut32 branch_bits = (ut32)branch_offset;
+						ao->o |= ((branch_bits >> 16) & 0xff) << 8;
+						ao->o |= ((branch_bits >> 8) & 0xff) << 16;
+						ao->o |= (branch_bits & 0xff) << 24;
 					} else {
 						RZ_LOG_ERROR("assembler: arm: %s: instruction does not accept a register as argument\n", ops[i].name);
 						return 0;

--- a/test/db/asm/arm_32
+++ b/test/db/asm/arm_32
@@ -256,6 +256,7 @@ aB "biceq r3, r3, 7" 0730c303
 a "blne 0x1900" 3E06001B
 a "bl 0x1900" 3e0600eb
 a "b 0x1900" 3e0600ea
+a "b 0x80000000" feffffea 0x80000000
 aB "bxeq lr" 1eff2f01
 aB "bxne lr" 1eff2f11
 a "clzne r5, sl" 1a5f6f11


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

A32 branch assembly incorrectly rejected valid branch targets when the address had bit 31 set, including 0x80000000.
The target returned by getnum() was combined with (int)ao->off, causing incorrect signed/unsigned arithmetic. This change calculates the displacement using 32-bit modular address arithmetic, interprets it as a signed offset, validates the A32 imm24 range, and encodes its low 24 bits.

**Test plan**

meson compile -C build

meson test -C build --suite unit

meson devenv -C build "$PWD/build/binrz/rz-test/rz-test" \"$PWD/test/db/asm/arm_32"

The ARM32 assembly tests completed with:
682 OK
99 BR
0 XX
0 FX

The original reproducer now produces the expected encoding:

build/binrz/rz-asm/rz-asm -a arm -b 32 -o 0x80000000 'b 0x80000000'
feffffea

**Closing issues**

Closes #6093