### PR TITLE
Fix ARM stack address substitution

### DIFF
--- a/librz/arch/p/parse/parse_arm_pseudo.c
+++ b/librz/arch/p/parse/parse_arm_pseudo.c
@@ -208,29 +208,6 @@ static bool parse(RzParse *p, const char *assembly, RzStrBuf *sb) {
 	return rz_pseudo_convert(&arm_config, assembly, sb);
 }
 
-static bool op_is_stack_addr_addition(RzAnalysisOp *op) {
-	if (!op || (op->type != RZ_ANALYSIS_OP_TYPE_ADD && op->type != RZ_ANALYSIS_OP_TYPE_SUB)) {
-		return false;
-	} else if (op->dst && op->dst->reg &&
-		RZ_STR_ISNOTEMPTY(op->dst->reg->name) &&
-		(!rz_str_casecmp(op->dst->reg->name, "fp") ||
-			!rz_str_casecmp(op->dst->reg->name, "sp"))) {
-		// we do not want additions/subtractions which modifies the stack
-		return false;
-	}
-	for (size_t j = 0; j < 3; j++) {
-		if (!op->src[j] || !op->src[j]->reg ||
-			RZ_STR_ISEMPTY(op->src[j]->reg->name)) {
-			continue;
-		}
-		const char *reg_name = op->src[j]->reg->name;
-		if (!rz_str_casecmp(reg_name, "fp") || !rz_str_casecmp(reg_name, "sp")) {
-			return true;
-		}
-	}
-	return false;
-}
-
 static char *subvar_stack(RzParse *p, RzAnalysisOp *op, RZ_NULLABLE RzAnalysisFunction *f, char *tstr) {
 	const ut64 addr = op->addr;
 
@@ -241,25 +218,14 @@ static char *subvar_stack(RzParse *p, RzAnalysisOp *op, RZ_NULLABLE RzAnalysisFu
 	const char *re_str;
 	int group_idx_sign = -1;
 	int group_idx_addend = 2;
-	bool brackets = true;
+	// Stack variables can only replace bracketed memory operands. Keep
+	// unbracketed address calculations such as "add r4, sp, 8" unchanged.
 	if (p->pseudo) {
 		// match e.g. "fp - 0x42"
 		// capturing "fp", "-", "0x42"
 		re_str = "\\[([a-z][0-9a-z][0-9]?)\\s*(\\+|-)\\s*(-?(0x)?[0-9a-f]+)\\]";
 		group_idx_sign = 2;
 		group_idx_addend = 3;
-	} else if (op_is_stack_addr_addition(op)) {
-		// only in add instructions like "add r7, sp, 0x42" we want to match
-		// without brackets around the "sp, 0x42". That is because we want to
-		// avoid matching cases like the following:
-		//  * sub r7, sp, 0x42
-		//  * sub sp, 0x42
-		//  * add fp, sp, 4
-
-		// match e.g. "fp, -0x42"
-		// capturing "fp", "-0x42"
-		re_str = "([a-z][0-9a-z][0-9]?),\\s+(-?(0x)?[0-9a-f]+)";
-		brackets = false;
 	} else if (strchr(tstr, '[')) {
 		// match e.g. "[fp, -0x42]"
 		// capturing "fp", "-0x42"
@@ -316,16 +282,12 @@ static char *subvar_stack(RzParse *p, RzAnalysisOp *op, RZ_NULLABLE RzAnalysisFu
 	// reserve with a bit of padding for brackets, reg, whitespace, ...
 	rz_strbuf_reserve(&sb, match_full->start + strlen(varstr) + tail_len + 32);
 	rz_strbuf_append_n(&sb, tstr, match_full->start);
-	if (brackets) {
-		rz_strbuf_append(&sb, "[");
-	}
+	rz_strbuf_append(&sb, "[");
 	if (!p->localvar_only) {
 		rz_strbuf_appendf(&sb, "%s %c ", reg_str, reg_addend < 0 ? '-' : '+');
 	}
 	rz_strbuf_append(&sb, varstr);
-	if (brackets) {
-		rz_strbuf_append(&sb, "]");
-	}
+	rz_strbuf_append(&sb, "]");
 	rz_strbuf_append_n(&sb, tstr + match_full->start + match_full->len, tail_len);
 	free(reg_str);
 	free(varstr);

--- a/test/db/analysis/vars
+++ b/test/db/analysis/vars
@@ -469,7 +469,7 @@ afvW
 |           ; var int32_t var_4h @ stack - 0x4
 |           0x00000000      80b4           push  {r7}
 |           0x00000002      83b0           sub   sp, 0xc
-|           0x00000004      00af           add   r7, var_10h
+|           0x00000004      00af           add   r7, sp, 0
 |           0x00000006      7860           str   r0, [var_ch]
 |           0x00000008      0b46           mov   r3, r1
 |           0x0000000a      7b80           strh  r3, [var_eh]
@@ -696,7 +696,7 @@ EXPECT=<<EOF
 |           ; arg int a @ stack - 0xa
 |           0x000005e0      push  {r7, lr}
 |           0x000005e2      sub   sp, 0x18
-|           0x000005e4      add   r7, var_20h
+|           0x000005e4      add   r7, sp, 0
 |           0x000005e6      str   r0, [r7, 0x14]
 |           0x000005e8      str   r1, [r7, 0x10]
 |           0x000005ea      vstr  d0, [r7, 8]
@@ -763,7 +763,7 @@ EXPECT=<<EOF
 |           ; var int16_t var_20h @ stack - 0x20
 |           0x000005e0      push  {r7, lr}
 |           0x000005e2      sub   sp, 0x18
-|           0x000005e4      add   r7, var_20h
+|           0x000005e4      add   r7, sp, 0
 |           0x000005e6      str   r0, [r7, 0x14]
 |           0x000005e8      str   r1, [r7, 0x10]
 |           0x000005ea      vstr  d0, [r7, 8]
@@ -829,7 +829,7 @@ EXPECT=<<EOF
 |           ; var int16_t var_20h @ stack - 0x20
 |           0x000005e0      push  {r7, lr}
 |           0x000005e2      sub   sp, 0x18
-|           0x000005e4      add   r7, var_20h
+|           0x000005e4      add   r7, sp, 0
 |           0x000005e6      str   r0, [r7, 0x14]
 |           0x000005e8      str   r1, [r7, 0x10]
 |           0x000005ea      vstr  d0, [r7, 8]

--- a/test/db/cmd/cmd_avD
+++ b/test/db/cmd/cmd_avD
@@ -1037,7 +1037,7 @@ EXPECT=<<EOF
 |                                                                      ; x9
 |           0x1000078e8      mov   x0, x8
 |           0x1000078ec      bl    fcn.100007bf8
-|           0x1000078f0      add   x8, var_48h
+|           0x1000078f0      add   x8, sp, 0x38
 |           0x1000078f4      str   x0, [var_48h]
 |           0x1000078f8      ldr   x9, [var_48h]                       ; x1
 |                                                                      ; [0x38:4]=-1
@@ -1207,7 +1207,7 @@ EXPECT=<<EOF
 |           0x100007934      add   x8, x8, 0x70                        ; 0x100008070 ; "X\x80\U00000001"
 |           0x100007938      mov   x0, x8                              ; void *instance
 |           0x10000793c      bl    sym.imp.objc_retain                 ; void objc_retain(void *instance)
-|           0x100007940      add   x8, var_48h
+|           0x100007940      add   x8, sp, 0x38
 |           0x100007944      str   x0, [var_48h]
 |           0x100007948      ldr   x9, [var_48h]                       ; [0x38:4]=-1 ; 56
 |           0x10000794c      adrp  x0, data.100007000                  ; 0x100007000

--- a/test/db/cmd/cmd_pd_bugs
+++ b/test/db/cmd/cmd_pd_bugs
@@ -58,6 +58,31 @@ EOF
 EXPECT_ERR=
 RUN
 
+NAME=arm preserve stack address calculation and memory substitution (#4583)
+FILE=malloc://14
+ARGS=-a arm -b 16 -e asm.cpu=cortexA8
+CMDS=<<EOF
+e asm.bytes=false
+e asm.comments=false
+e asm.lines.bb=false
+e asm.lines.fcn=false
+e asm.offset=false
+wx b0b584b002ac0290029904b0b0bd
+af
+pd 3 @ 4
+e asm.pseudo=true
+pd 3 @ 4
+EOF
+EXPECT=<<EOF
+     add   r4, sp, 8
+     str   r0, [var_18h]
+     ldr   r1, [var_18h]
+     r4 = sp + 8
+     [var_18h] = r0
+     r1 = [var_18h]
+EOF
+RUN
+
 NAME=pd call sym bug
 FILE=bins/mach0/hello-objc-arm
 CMDS=<<EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

After function analysis, the ARM pseudo parser could incorrectly apply stack-variable substitution to unbracketed address-calculation instructions.

For example, this instruction:

add r4, sp, 8

was

add r4, var_18h

This PR removes the special handling for unbracketed stack address calculations and limits stack-variable substitution to bracketed memory operands.

The regression test covers both regular and pseudo disassembly. It verifies that address calculations remain unchanged while bracketed memory operands continue to be substituted:

add r4, sp, 8
str r0, [var_18h]
ldr r1, [var_18h]
r4 = sp + 8
[var_18h] = r0
r1 = [var_18h]

Existing ARM and ARM64 test expectations affected by the corrected behavior were also updated.

**Test plan**

Original:

build/binrz/rizin/rizin -N -a arm -b 16 -e asm.cpu=cortexA8 -e asm.bytes=false -e asm.comments=false -e asm.lines.bb=false -e asm.lines.fcn=false -e asm.offset=false -qc 'wx b0b584b002ac04b0b0bd; af; pd 1 @ 4' malloc://10

Output:

     add   r4, sp, 8

unit tests added

**Closing issues**

Closes #4583
