### PR TITLE
il: add bit-reversal, per-byte popcount and bit interleaving routines

### DIFF
--- a/librz/il/il_routines.c
+++ b/librz/il/il_routines.c
@@ -233,6 +233,90 @@ RZ_API RZ_OWN RzILOpBitVector *rz_il_bswap64(RZ_BORROW RzILOpBitVector *t) {
 	return op_OR_38;
 }
 
+#include <rz_il/rz_il_opbuilder_begin.h>
+
+/**
+ * \brief Reverse the bit order of a 32-bit value.
+ *
+ * \param x The value to reverse.
+ *
+ * \return A pure expression where bit i of the result is bit 31 - i of \p x.
+ */
+RZ_API RZ_OWN RzILOpBitVector *rz_il_bitrev32(RZ_OWN RzILOpBitVector *x) {
+#define REVSTAGE(vn, s, m) LOGOR(SHIFTL0(LOGAND(VARLP(vn), U32(m)), U32(s)), LOGAND(SHIFTR0(VARLP(vn), U32(s)), U32(m)))
+	return LET("_r0", x,
+		LET("_r1", REVSTAGE("_r0", 1, 0x55555555),
+			LET("_r2", REVSTAGE("_r1", 2, 0x33333333),
+				LET("_r3", REVSTAGE("_r2", 4, 0x0f0f0f0f),
+					LET("_r4", REVSTAGE("_r3", 8, 0x00ff00ff),
+						REVSTAGE("_r4", 16, 0x0000ffff))))));
+#undef REVSTAGE
+}
+
+/**
+ * \brief Population count of each byte of a 32-bit value.
+ *
+ * \param x The value whose bytes are counted.
+ *
+ * \return A pure expression where each result byte holds the number of set bits in the matching byte of \p x.
+ */
+RZ_API RZ_OWN RzILOpBitVector *rz_il_popcount_bytes32(RZ_OWN RzILOpBitVector *x) {
+	return LET("_b0", x,
+		LET("_b1", SUB(VARLP("_b0"), LOGAND(SHIFTR0(VARLP("_b0"), U32(1)), U32(0x55555555))),
+			LET("_b2", ADD(LOGAND(VARLP("_b1"), U32(0x33333333)), LOGAND(SHIFTR0(VARLP("_b1"), U32(2)), U32(0x33333333))),
+				LOGAND(ADD(VARLP("_b2"), SHIFTR0(VARLP("_b2"), U32(4))), U32(0x0f0f0f0f)))));
+}
+
+/**
+ * \brief Deinterleave the bits of a 32-bit value.
+ *
+ * \param x The value to deinterleave.
+ *
+ * \return A pure expression where the even bits of \p x are packed into the low halfword of the result and the odd bits into the high halfword.
+ */
+RZ_API RZ_OWN RzILOpBitVector *rz_il_deinterleave32(RZ_OWN RzILOpBitVector *x) {
+#define CMPR(vn, sh, m) LOGAND(LOGOR(VARLP(vn), SHIFTR0(VARLP(vn), U32(sh))), U32(m))
+	return LET("_dx", x,
+		LET("_e0", LOGAND(VARLP("_dx"), U32(0x55555555)),
+			LET("_e1", CMPR("_e0", 1, 0x33333333),
+				LET("_e2", CMPR("_e1", 2, 0x0f0f0f0f),
+					LET("_e3", CMPR("_e2", 4, 0x00ff00ff),
+						LET("_elo", CMPR("_e3", 8, 0x0000ffff),
+							LET("_o0", LOGAND(SHIFTR0(VARLP("_dx"), U32(1)), U32(0x55555555)),
+								LET("_o1", CMPR("_o0", 1, 0x33333333),
+									LET("_o2", CMPR("_o1", 2, 0x0f0f0f0f),
+										LET("_o3", CMPR("_o2", 4, 0x00ff00ff),
+											LET("_ohi", CMPR("_o3", 8, 0x0000ffff),
+												LOGOR(SHIFTL0(VARLP("_ohi"), U32(16)), VARLP("_elo")))))))))))));
+#undef CMPR
+}
+
+/**
+ * \brief Interleave the halfwords of a 32-bit value.
+ *
+ * \param x The value to interleave.
+ *
+ * \return A pure expression where the low halfword of \p x is spread into the even bit positions of the result and the high halfword into the odd ones.
+ */
+RZ_API RZ_OWN RzILOpBitVector *rz_il_interleave32(RZ_OWN RzILOpBitVector *x) {
+#define SPRD(vn, sh, m) LOGAND(LOGOR(VARLP(vn), SHIFTL0(VARLP(vn), U32(sh))), U32(m))
+	return LET("_sx", x,
+		LET("_l0", LOGAND(VARLP("_sx"), U32(0x0000ffff)),
+			LET("_l1", SPRD("_l0", 8, 0x00ff00ff),
+				LET("_l2", SPRD("_l1", 4, 0x0f0f0f0f),
+					LET("_l3", SPRD("_l2", 2, 0x33333333),
+						LET("_llo", SPRD("_l3", 1, 0x55555555),
+							LET("_h0", LOGAND(SHIFTR0(VARLP("_sx"), U32(16)), U32(0x0000ffff)),
+								LET("_h1", SPRD("_h0", 8, 0x00ff00ff),
+									LET("_h2", SPRD("_h1", 4, 0x0f0f0f0f),
+										LET("_h3", SPRD("_h2", 2, 0x33333333),
+											LET("_hhi", SPRD("_h3", 1, 0x55555555),
+												LOGOR(SHIFTL0(VARLP("_hhi"), U32(1)), VARLP("_llo")))))))))))));
+#undef SPRD
+}
+
+#include <rz_il/rz_il_opbuilder_end.h>
+
 /**
  *  \brief [NE] not eq x y binary predicate for bitwise equality
  */

--- a/librz/include/rz_il/rz_il_opbuilder_begin.h
+++ b/librz/include/rz_il/rz_il_opbuilder_begin.h
@@ -209,6 +209,10 @@
 #define DEPOSIT64(value, start, length, fieldval) rz_il_deposit64(value, start, length, fieldval)
 #define BSWAP16(t)                                rz_il_bswap16(t)
 #define BSWAP32(t)                                rz_il_bswap32(t)
+#define BITREV32(x)                               rz_il_bitrev32(x)
+#define POPCOUNT_BYTES32(x)                       rz_il_popcount_bytes32(x)
+#define DEINTERLEAVE32(x)                         rz_il_deinterleave32(x)
+#define INTERLEAVE32(x)                           rz_il_interleave32(x)
 #define BSWAP64(t)                                rz_il_bswap64(t)
 
 #endif

--- a/librz/include/rz_il/rz_il_opcodes.h
+++ b/librz/include/rz_il/rz_il_opcodes.h
@@ -870,6 +870,10 @@ RZ_API RZ_OWN RzILOpBitVector *rz_il_deposit64(RZ_BORROW RzILOpBitVector *value,
 RZ_API RZ_OWN RzILOpBitVector *rz_il_deposit32(RZ_BORROW RzILOpBitVector *value, RZ_BORROW RzILOpBitVector *start, RZ_BORROW RzILOpBitVector *length, RZ_BORROW RzILOpBitVector *fieldval);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_bswap16(RZ_BORROW RzILOpBitVector *t);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_bswap32(RZ_BORROW RzILOpBitVector *t);
+RZ_API RZ_OWN RzILOpBitVector *rz_il_bitrev32(RZ_OWN RzILOpBitVector *x);
+RZ_API RZ_OWN RzILOpBitVector *rz_il_popcount_bytes32(RZ_OWN RzILOpBitVector *x);
+RZ_API RZ_OWN RzILOpBitVector *rz_il_deinterleave32(RZ_OWN RzILOpBitVector *x);
+RZ_API RZ_OWN RzILOpBitVector *rz_il_interleave32(RZ_OWN RzILOpBitVector *x);
 RZ_API RZ_OWN RzILOpBitVector *rz_il_bswap64(RZ_BORROW RzILOpBitVector *t);
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_ne(RZ_NONNULL RzILOpPure *x, RZ_NONNULL RzILOpPure *y);
 RZ_API RZ_OWN RzILOpBool *rz_il_op_new_fneq(RZ_NONNULL RZ_OWN RzILOpFloat *x, RZ_NONNULL RZ_OWN RzILOpFloat *y);

--- a/test/unit/test_il_helpers.c
+++ b/test/unit/test_il_helpers.c
@@ -812,6 +812,138 @@ bool test_float_print_format(void) {
 	mu_end;
 }
 
+static bool test_il_bitrev32() {
+	RzILSortPure sort;
+	RzILValidateReport report;
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty(24);
+	bool valid = false;
+	RzILVM *vm = rz_il_vm_new(0, 32, false, RZ_IL_EVENT_EXC_NONE);
+	RzILVal *vm_result = NULL;
+	RzILOpBitVector *val = NULL;
+	RzILOpBitVector *result = NULL;
+
+	val = rz_il_op_new_bitv_from_ut64(32, 0x01234567);
+	result = rz_il_bitrev32(val);
+	valid = rz_il_validate_pure(result, ctx, &sort, &report);
+	mu_assert_true(valid, "invalid pure");
+	vm_result = rz_il_evaluate_val(vm, result);
+	mu_assert_eq(vm_result->data.bv->bits.small_u, 0xe6a2c480, "bitrev32(0x01234567) mismatch");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+	val = rz_il_op_new_bitv_from_ut64(32, 0x80000000);
+	result = rz_il_bitrev32(val);
+	valid = rz_il_validate_pure(result, ctx, &sort, &report);
+	mu_assert_true(valid, "invalid pure");
+	vm_result = rz_il_evaluate_val(vm, result);
+	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x00000001, "bitrev32(0x80000000) mismatch");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+	val = rz_il_op_new_bitv_from_ut64(32, 0xffffffff);
+	result = rz_il_bitrev32(val);
+	valid = rz_il_validate_pure(result, ctx, &sort, &report);
+	mu_assert_true(valid, "invalid pure");
+	vm_result = rz_il_evaluate_val(vm, result);
+	mu_assert_eq(vm_result->data.bv->bits.small_u, 0xffffffff, "bitrev32(0xffffffff) mismatch");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+	rz_il_vm_free(vm);
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_popcount_bytes32() {
+	RzILSortPure sort;
+	RzILValidateReport report;
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty(24);
+	bool valid = false;
+	RzILVM *vm = rz_il_vm_new(0, 32, false, RZ_IL_EVENT_EXC_NONE);
+	RzILVal *vm_result = NULL;
+	RzILOpBitVector *val = NULL;
+	RzILOpBitVector *result = NULL;
+
+	val = rz_il_op_new_bitv_from_ut64(32, 0xff0f0301);
+	result = rz_il_popcount_bytes32(val);
+	valid = rz_il_validate_pure(result, ctx, &sort, &report);
+	mu_assert_true(valid, "invalid pure");
+	vm_result = rz_il_evaluate_val(vm, result);
+	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x08040201, "popcount_bytes32(0xff0f0301) mismatch");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+	val = rz_il_op_new_bitv_from_ut64(32, 0x00000000);
+	result = rz_il_popcount_bytes32(val);
+	valid = rz_il_validate_pure(result, ctx, &sort, &report);
+	mu_assert_true(valid, "invalid pure");
+	vm_result = rz_il_evaluate_val(vm, result);
+	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x00000000, "popcount_bytes32(0x00000000) mismatch");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+	rz_il_vm_free(vm);
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_deinterleave32() {
+	RzILSortPure sort;
+	RzILValidateReport report;
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty(24);
+	bool valid = false;
+	RzILVM *vm = rz_il_vm_new(0, 32, false, RZ_IL_EVENT_EXC_NONE);
+	RzILVal *vm_result = NULL;
+	RzILOpBitVector *val = NULL;
+	RzILOpBitVector *result = NULL;
+
+	val = rz_il_op_new_bitv_from_ut64(32, 0xffff0000);
+	result = rz_il_deinterleave32(val);
+	valid = rz_il_validate_pure(result, ctx, &sort, &report);
+	mu_assert_true(valid, "invalid pure");
+	vm_result = rz_il_evaluate_val(vm, result);
+	mu_assert_eq(vm_result->data.bv->bits.small_u, 0xff00ff00, "deinterleave32(0xffff0000) mismatch");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+	val = rz_il_op_new_bitv_from_ut64(32, 0x00000000);
+	result = rz_il_deinterleave32(val);
+	valid = rz_il_validate_pure(result, ctx, &sort, &report);
+	mu_assert_true(valid, "invalid pure");
+	vm_result = rz_il_evaluate_val(vm, result);
+	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x00000000, "deinterleave32(0x00000000) mismatch");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+	rz_il_vm_free(vm);
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
+static bool test_il_interleave32() {
+	RzILSortPure sort;
+	RzILValidateReport report;
+	RzILValidateGlobalContext *ctx = rz_il_validate_global_context_new_empty(24);
+	bool valid = false;
+	RzILVM *vm = rz_il_vm_new(0, 32, false, RZ_IL_EVENT_EXC_NONE);
+	RzILVal *vm_result = NULL;
+	RzILOpBitVector *val = NULL;
+	RzILOpBitVector *result = NULL;
+
+	val = rz_il_op_new_bitv_from_ut64(32, 0xff00ff00);
+	result = rz_il_interleave32(val);
+	valid = rz_il_validate_pure(result, ctx, &sort, &report);
+	mu_assert_true(valid, "invalid pure");
+	vm_result = rz_il_evaluate_val(vm, result);
+	mu_assert_eq(vm_result->data.bv->bits.small_u, 0xffff0000, "interleave32(0xff00ff00) mismatch");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+	val = rz_il_op_new_bitv_from_ut64(32, 0x00000000);
+	result = rz_il_interleave32(val);
+	valid = rz_il_validate_pure(result, ctx, &sort, &report);
+	mu_assert_true(valid, "invalid pure");
+	vm_result = rz_il_evaluate_val(vm, result);
+	mu_assert_eq(vm_result->data.bv->bits.small_u, 0x00000000, "interleave32(0x00000000) mismatch");
+	rz_il_value_free(vm_result);
+	rz_il_op_pure_free(result);
+	rz_il_vm_free(vm);
+	rz_il_validate_global_context_free(ctx);
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test(test_il_extract32);
 	mu_run_test(test_il_extract64);
@@ -828,6 +960,10 @@ bool all_tests() {
 	mu_run_test(test_il_fgt);
 	mu_run_test(test_il_fge);
 	mu_run_test(test_float_print_format);
+	mu_run_test(test_il_bitrev32);
+	mu_run_test(test_il_popcount_bytes32);
+	mu_run_test(test_il_deinterleave32);
+	mu_run_test(test_il_interleave32);
 
 	return tests_passed != tests_run;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [x] I've documented every `RZ_API` function and struct this PR changes.
- [x] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

Extracted from https://github.com/rizinorg/rizin/pull/6603

**Test plan**

CI is green