### PR TITLE
util/regex: fix memory leak of ccontext on pattern compile failure in rz_regex_new_multi

### DIFF
--- a/librz/util/regex.c
+++ b/librz/util/regex.c
@@ -289,7 +289,7 @@ RZ_API RZ_OWN RzRegexMulti *rz_regex_new_multi(RZ_NONNULL const char *pattern, R
 	}
 	}
 	if (!re->re8 && !re->re16 && !re->re32) {
-		free(re);
+		rz_regex_free_multi(re);
 		return NULL;
 	}
 #ifdef SUPPORTS_PCRE2_JIT


### PR DESCRIPTION
- [x] I've read the guidelines for contributing to this repository.
- [x] I made sure to follow the project's coding style.
- [ ] I've documented every RZ_API function and struct this PR changes. (N/A - no new RZ_API functions, existing signature unchanged)
- [ ] I've added tests that prove my changes are effective (required for changes to RZ_API). (N/A - internal cleanup path, no test binaries required to trigger; verified manually with ASAN/LSAN, see below)
- [ ] I've updated the Rizin book with the relevant information (if needed). (N/A - no user-facing behavior change)
- [ ] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

## Detailed description

Fixes an 88-byte memory leak in `rz_regex_new_multi()`, found while working on #6673.

When the given pattern fails to compile (e.g. an invalid regex), `re->re8`/`re->re16`/`re->re32` all stay `NULL` and the function takes the early-return path at the end of the compilation switch, doing a bare `free(re)`. However `re->ccontext` — the PCRE2 compile context created earlier in the same function and stored on the struct — is never freed on this path, leaking it.

The function's other failure path a few lines below (JIT stack allocation failure) already calls `rz_regex_free_multi(re)` instead of a bare `free(re)`. This earlier path just missed the same fix.

`rz_regex_free_multi` is safe to call in this state:
- `re8`/`re16`/`re32` are `NULL` — their respective free functions (`rz_regex_free`, `pcre2_jit_stack_free_*`) accept `NULL` safely.
- `jit_stack` is zero-initialized by `RZ_NEW0` at the top of `rz_regex_new_multi` and is never touched before this early-return point, so it's also `NULL` and safe to free.
- `ccontext` is the only live object at this point, and is exactly what needs freeing.

## Test plan

Build with ASAN + LeakSanitizer:

```
meson setup build-asan -Db_sanitize=address
ninja -C build-asan
```

Reproduce with an invalid regex pattern via `/ao`, which is the first caller in the codebase to invoke `rz_regex_new_multi` repeatedly on user-controlled input. `/ao [` is rejected as an invalid pattern (confirmed via `RZ_LOG_ERROR`), then `exit`:

```
[0x00000000]> /ao [
[0x00000000]> exit
```


**Before this fix:**

```
==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 88 byte(s) in 1 object(s) allocated from:
#0 ... in malloc
#1 ... in _pcre2_memctl_malloc_8
#2 ... in pcre2_compile_context_create_8
#3 ... in rz_regex_new_multi ../librz/util/regex.c:258
SUMMARY: AddressSanitizer: 88 byte(s) leaked in 1 allocation(s).
```


**After this fix:** same sequence exits cleanly, no leak reported.

## Closing issues

No issues closed by this PR. This fix was found while working on #6673 (which itself addresses #6663).