### PR TITLE
Check input_callbacks allocation in windbg init_callbacks

### DIFF
--- a/librz/io/p/io_windbg.c
+++ b/librz/io/p/io_windbg.c
@@ -242,7 +242,7 @@ static bool init_callbacks(DbgEngContext *idbg) {
 	PDEBUG_INPUT_CALLBACKS input_callbacks = DEBUG_INPUT_CALLBACKS_impl_new(idbg);
 	PDEBUG_OUTPUT_CALLBACKS output_callbacks = DEBUG_OUTPUT_CALLBACKS_impl_new(idbg);
 
-	if (!event_callbacks || !output_callbacks || !event_callbacks) {
+	if (!event_callbacks || !input_callbacks || !output_callbacks) {
 		RELEASE(event_callbacks);
 		RELEASE(input_callbacks);
 		RELEASE(output_callbacks);


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md) to this repository.
- [x] I made sure to follow the project's [coding style](https://github.com/rizinorg/rizin/blob/dev/DEVELOPERS.md#code-style).
- [ ] I've documented every `RZ_API` function and struct this PR changes.
- [ ] I've added tests that prove my changes are effective (required for changes to `RZ_API`).
- [ ] I've updated the [Rizin book](https://github.com/rizinorg/book) with the relevant information (if needed).
- [x] I've used AI tools to generate fully or partially these code changes and I'm sure the changes are not copyrighted by somebody else.

**Detailed description**

The allocation check in init_callbacks() looks at event_callbacks twice and never at input_callbacks, so if DEBUG_INPUT_CALLBACKS_impl_new() returns NULL it goes straight into SetInputCallbacks. No RZ_API touched, it only changes which pointer the error path checks.

AI disclosure: Claude Code (claude-opus-5) flagged the repeated operand in a static scan of duplicated conditions and wrote the one-line change; I read the DECLARE_NEW macro to confirm the constructor can return NULL.

**Test plan**

This is the Windows-only dbgeng IO plugin and only the out-of-memory path changes, so there is nothing to exercise from a test on my side. I'm relying on the Windows CI build for compilation.

**Closing issues**

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLUWMiUYbYkPzoYwn1P8uE
